### PR TITLE
fix/monit: print query details correctly in docs

### DIFF
--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -27,8 +27,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=100000`
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.99, sum by (le)(rate(src_search_streaming_latency_seconds_bucket{source="browser"}[5m])))`
+Query:
 
+```
+histogram_quantile(0.99, sum by (le)(rate(src_search_streaming_latency_seconds_bucket{source="browser"}[5m])))
+```
 </details>
 
 <br />
@@ -46,8 +49,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=100001`
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.90, sum by (le)(rate(src_search_streaming_latency_seconds_bucket{source="browser"}[5m])))`
+Query:
 
+```
+histogram_quantile(0.90, sum by (le)(rate(src_search_streaming_latency_seconds_bucket{source="browser"}[5m])))
+```
 </details>
 
 <br />
@@ -65,8 +71,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=100010`
 <details>
 <summary>Technical details</summary>
 
-Query: `(sum(increase(src_graphql_search_response{status="timeout",source="browser",request_name!="CodeIntelSearch"}[5m])) + sum(increase(src_graphql_search_response{status="alert",alert_type="timed_out",source="browser",request_name!="CodeIntelSearch"}[5m]))) / sum(increase(src_graphql_search_response{source="browser",request_name!="CodeIntelSearch"}[5m])) * 100`
+Query:
 
+```
+(sum(increase(src_graphql_search_response{status="timeout",source="browser",request_name!="CodeIntelSearch"}[5m])) + sum(increase(src_graphql_search_response{status="alert",alert_type="timed_out",source="browser",request_name!="CodeIntelSearch"}[5m]))) / sum(increase(src_graphql_search_response{source="browser",request_name!="CodeIntelSearch"}[5m])) * 100
+```
 </details>
 
 <br />
@@ -84,8 +93,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=100011`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (status)(increase(src_graphql_search_response{status=~"error",source="browser",request_name!="CodeIntelSearch"}[5m])) / ignoring(status) group_left sum(increase(src_graphql_search_response{source="browser",request_name!="CodeIntelSearch"}[5m])) * 100`
+Query:
 
+```
+sum by (status)(increase(src_graphql_search_response{status=~"error",source="browser",request_name!="CodeIntelSearch"}[5m])) / ignoring(status) group_left sum(increase(src_graphql_search_response{source="browser",request_name!="CodeIntelSearch"}[5m])) * 100
+```
 </details>
 
 <br />
@@ -103,8 +115,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=100012`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (status)(increase(src_graphql_search_response{status="partial_timeout",source="browser",request_name!="CodeIntelSearch"}[5m])) / ignoring(status) group_left sum(increase(src_graphql_search_response{source="browser",request_name!="CodeIntelSearch"}[5m])) * 100`
+Query:
 
+```
+sum by (status)(increase(src_graphql_search_response{status="partial_timeout",source="browser",request_name!="CodeIntelSearch"}[5m])) / ignoring(status) group_left sum(increase(src_graphql_search_response{source="browser",request_name!="CodeIntelSearch"}[5m])) * 100
+```
 </details>
 
 <br />
@@ -122,8 +137,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=100013`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (alert_type)(increase(src_graphql_search_response{status="alert",alert_type!~"timed_out|no_results__suggest_quotes",source="browser",request_name!="CodeIntelSearch"}[5m])) / ignoring(alert_type) group_left sum(increase(src_graphql_search_response{source="browser",request_name!="CodeIntelSearch"}[5m])) * 100`
+Query:
 
+```
+sum by (alert_type)(increase(src_graphql_search_response{status="alert",alert_type!~"timed_out|no_results__suggest_quotes",source="browser",request_name!="CodeIntelSearch"}[5m])) / ignoring(alert_type) group_left sum(increase(src_graphql_search_response{source="browser",request_name!="CodeIntelSearch"}[5m])) * 100
+```
 </details>
 
 <br />
@@ -141,8 +159,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=100020`
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.9, sum by(le) (rate(src_http_request_duration_seconds_bucket{route!="raw",route!="blob",route!~"graphql.*"}[10m])))`
+Query:
 
+```
+histogram_quantile(0.9, sum by(le) (rate(src_http_request_duration_seconds_bucket{route!="raw",route!="blob",route!~"graphql.*"}[10m])))
+```
 </details>
 
 <br />
@@ -162,8 +183,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=100100`
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.99, sum by (le)(rate(src_graphql_field_seconds_bucket{type="Search",field="results",error="false",source="browser",request_name="CodeIntelSearch"}[5m])))`
+Query:
 
+```
+histogram_quantile(0.99, sum by (le)(rate(src_graphql_field_seconds_bucket{type="Search",field="results",error="false",source="browser",request_name="CodeIntelSearch"}[5m])))
+```
 </details>
 
 <br />
@@ -181,8 +205,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=100101`
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.90, sum by (le)(rate(src_graphql_field_seconds_bucket{type="Search",field="results",error="false",source="browser",request_name="CodeIntelSearch"}[5m])))`
+Query:
 
+```
+histogram_quantile(0.90, sum by (le)(rate(src_graphql_field_seconds_bucket{type="Search",field="results",error="false",source="browser",request_name="CodeIntelSearch"}[5m])))
+```
 </details>
 
 <br />
@@ -200,8 +227,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=100110`
 <details>
 <summary>Technical details</summary>
 
-Query: `(sum(increase(src_graphql_search_response{status="timeout",source="browser",request_name="CodeIntelSearch"}[5m])) + sum(increase(src_graphql_search_response{status="alert",alert_type="timed_out",source="browser",request_name="CodeIntelSearch"}[5m]))) / sum(increase(src_graphql_search_response{source="browser",request_name="CodeIntelSearch"}[5m])) * 100`
+Query:
 
+```
+(sum(increase(src_graphql_search_response{status="timeout",source="browser",request_name="CodeIntelSearch"}[5m])) + sum(increase(src_graphql_search_response{status="alert",alert_type="timed_out",source="browser",request_name="CodeIntelSearch"}[5m]))) / sum(increase(src_graphql_search_response{source="browser",request_name="CodeIntelSearch"}[5m])) * 100
+```
 </details>
 
 <br />
@@ -219,8 +249,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=100111`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (status)(increase(src_graphql_search_response{status=~"error",source="browser",request_name="CodeIntelSearch"}[5m])) / ignoring(status) group_left sum(increase(src_graphql_search_response{source="browser",request_name="CodeIntelSearch"}[5m])) * 100`
+Query:
 
+```
+sum by (status)(increase(src_graphql_search_response{status=~"error",source="browser",request_name="CodeIntelSearch"}[5m])) / ignoring(status) group_left sum(increase(src_graphql_search_response{source="browser",request_name="CodeIntelSearch"}[5m])) * 100
+```
 </details>
 
 <br />
@@ -238,8 +271,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=100112`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (status)(increase(src_graphql_search_response{status="partial_timeout",source="browser",request_name="CodeIntelSearch"}[5m])) / ignoring(status) group_left sum(increase(src_graphql_search_response{status="partial_timeout",source="browser",request_name="CodeIntelSearch"}[5m])) * 100`
+Query:
 
+```
+sum by (status)(increase(src_graphql_search_response{status="partial_timeout",source="browser",request_name="CodeIntelSearch"}[5m])) / ignoring(status) group_left sum(increase(src_graphql_search_response{status="partial_timeout",source="browser",request_name="CodeIntelSearch"}[5m])) * 100
+```
 </details>
 
 <br />
@@ -257,8 +293,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=100113`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (alert_type)(increase(src_graphql_search_response{status="alert",alert_type!~"timed_out",source="browser",request_name="CodeIntelSearch"}[5m])) / ignoring(alert_type) group_left sum(increase(src_graphql_search_response{source="browser",request_name="CodeIntelSearch"}[5m])) * 100`
+Query:
 
+```
+sum by (alert_type)(increase(src_graphql_search_response{status="alert",alert_type!~"timed_out",source="browser",request_name="CodeIntelSearch"}[5m])) / ignoring(alert_type) group_left sum(increase(src_graphql_search_response{source="browser",request_name="CodeIntelSearch"}[5m])) * 100
+```
 </details>
 
 <br />
@@ -278,8 +317,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=100200`
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.99, sum by (le)(rate(src_graphql_field_seconds_bucket{type="Search",field="results",error="false",source="other"}[5m])))`
+Query:
 
+```
+histogram_quantile(0.99, sum by (le)(rate(src_graphql_field_seconds_bucket{type="Search",field="results",error="false",source="other"}[5m])))
+```
 </details>
 
 <br />
@@ -297,8 +339,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=100201`
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.90, sum by (le)(rate(src_graphql_field_seconds_bucket{type="Search",field="results",error="false",source="other"}[5m])))`
+Query:
 
+```
+histogram_quantile(0.90, sum by (le)(rate(src_graphql_field_seconds_bucket{type="Search",field="results",error="false",source="other"}[5m])))
+```
 </details>
 
 <br />
@@ -316,8 +361,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=100210`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (status)(increase(src_graphql_search_response{status=~"error",source="other"}[5m])) / ignoring(status) group_left sum(increase(src_graphql_search_response{source="other"}[5m]))`
+Query:
 
+```
+sum by (status)(increase(src_graphql_search_response{status=~"error",source="other"}[5m])) / ignoring(status) group_left sum(increase(src_graphql_search_response{source="other"}[5m]))
+```
 </details>
 
 <br />
@@ -335,8 +383,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=100211`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_graphql_search_response{status="partial_timeout",source="other"}[5m])) / sum(increase(src_graphql_search_response{source="other"}[5m]))`
+Query:
 
+```
+sum(increase(src_graphql_search_response{status="partial_timeout",source="other"}[5m])) / sum(increase(src_graphql_search_response{source="other"}[5m]))
+```
 </details>
 
 <br />
@@ -354,8 +405,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=100212`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (alert_type)(increase(src_graphql_search_response{status="alert",alert_type!~"timed_out|no_results__suggest_quotes",source="other"}[5m])) / ignoring(alert_type) group_left sum(increase(src_graphql_search_response{status="alert",source="other"}[5m]))`
+Query:
 
+```
+sum by (alert_type)(increase(src_graphql_search_response{status="alert",alert_type!~"timed_out|no_results__suggest_quotes",source="other"}[5m])) / ignoring(alert_type) group_left sum(increase(src_graphql_search_response{status="alert",source="other"}[5m]))
+```
 </details>
 
 <br />
@@ -377,8 +431,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=100300`
 <details>
 <summary>Technical details</summary>
 
-Query: `src_conf_client_time_since_last_successful_update_seconds{job=~`(sourcegraph-)?frontend`,instance=~`${internalInstance:regex}`}`
+Query:
 
+```
+src_conf_client_time_since_last_successful_update_seconds{job=~`(sourcegraph-)?frontend`,instance=~`${internalInstance:regex}`}
+```
 </details>
 
 <br />
@@ -396,8 +453,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=100301`
 <details>
 <summary>Technical details</summary>
 
-Query: `max(max_over_time(src_conf_client_time_since_last_successful_update_seconds{job=~`(sourcegraph-)?frontend`,instance=~`${internalInstance:regex}`}[1m]))`
+Query:
 
+```
+max(max_over_time(src_conf_client_time_since_last_successful_update_seconds{job=~`(sourcegraph-)?frontend`,instance=~`${internalInstance:regex}`}[1m]))
+```
 </details>
 
 <br />
@@ -417,8 +477,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=100400`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_resolvers_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_resolvers_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))
+```
 </details>
 
 <br />
@@ -436,8 +499,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=100401`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum  by (le)(rate(src_codeintel_resolvers_duration_seconds_bucket{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))`
+Query:
 
+```
+sum  by (le)(rate(src_codeintel_resolvers_duration_seconds_bucket{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))
+```
 </details>
 
 <br />
@@ -455,8 +521,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=100402`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_resolvers_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_resolvers_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))
+```
 </details>
 
 <br />
@@ -474,8 +543,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=100403`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_resolvers_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) / (sum(increase(src_codeintel_resolvers_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) + sum(increase(src_codeintel_resolvers_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))) * 100`
+Query:
 
+```
+sum(increase(src_codeintel_resolvers_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) / (sum(increase(src_codeintel_resolvers_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) + sum(increase(src_codeintel_resolvers_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -493,8 +565,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=100410`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_resolvers_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_resolvers_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))
+```
 </details>
 
 <br />
@@ -512,8 +587,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=100411`
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_resolvers_duration_seconds_bucket{job=~"^(frontend|sourcegraph-frontend).*"}[5m])))`
+Query:
 
+```
+histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_resolvers_duration_seconds_bucket{job=~"^(frontend|sourcegraph-frontend).*"}[5m])))
+```
 </details>
 
 <br />
@@ -531,8 +609,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=100412`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_resolvers_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_resolvers_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))
+```
 </details>
 
 <br />
@@ -550,8 +631,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=100413`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_resolvers_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) / (sum by (op)(increase(src_codeintel_resolvers_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) + sum by (op)(increase(src_codeintel_resolvers_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))) * 100`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_resolvers_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) / (sum by (op)(increase(src_codeintel_resolvers_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) + sum by (op)(increase(src_codeintel_resolvers_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -571,8 +655,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=100500`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_autoindex_enqueuer_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_autoindex_enqueuer_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))
+```
 </details>
 
 <br />
@@ -590,8 +677,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=100501`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum  by (le)(rate(src_codeintel_autoindex_enqueuer_duration_seconds_bucket{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))`
+Query:
 
+```
+sum  by (le)(rate(src_codeintel_autoindex_enqueuer_duration_seconds_bucket{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))
+```
 </details>
 
 <br />
@@ -609,8 +699,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=100502`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_autoindex_enqueuer_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_autoindex_enqueuer_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))
+```
 </details>
 
 <br />
@@ -628,8 +721,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=100503`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_autoindex_enqueuer_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) / (sum(increase(src_codeintel_autoindex_enqueuer_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) + sum(increase(src_codeintel_autoindex_enqueuer_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))) * 100`
+Query:
 
+```
+sum(increase(src_codeintel_autoindex_enqueuer_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) / (sum(increase(src_codeintel_autoindex_enqueuer_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) + sum(increase(src_codeintel_autoindex_enqueuer_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -647,8 +743,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=100510`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_autoindex_enqueuer_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_autoindex_enqueuer_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))
+```
 </details>
 
 <br />
@@ -666,8 +765,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=100511`
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_autoindex_enqueuer_duration_seconds_bucket{job=~"^(frontend|sourcegraph-frontend).*"}[5m])))`
+Query:
 
+```
+histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_autoindex_enqueuer_duration_seconds_bucket{job=~"^(frontend|sourcegraph-frontend).*"}[5m])))
+```
 </details>
 
 <br />
@@ -685,8 +787,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=100512`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_autoindex_enqueuer_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_autoindex_enqueuer_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))
+```
 </details>
 
 <br />
@@ -704,8 +809,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=100513`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_autoindex_enqueuer_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) / (sum by (op)(increase(src_codeintel_autoindex_enqueuer_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) + sum by (op)(increase(src_codeintel_autoindex_enqueuer_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))) * 100`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_autoindex_enqueuer_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) / (sum by (op)(increase(src_codeintel_autoindex_enqueuer_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) + sum by (op)(increase(src_codeintel_autoindex_enqueuer_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -725,8 +833,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=100600`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_uploads_store_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_uploads_store_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))
+```
 </details>
 
 <br />
@@ -744,8 +855,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=100601`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum  by (le)(rate(src_codeintel_uploads_store_duration_seconds_bucket{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))`
+Query:
 
+```
+sum  by (le)(rate(src_codeintel_uploads_store_duration_seconds_bucket{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))
+```
 </details>
 
 <br />
@@ -763,8 +877,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=100602`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_uploads_store_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_uploads_store_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))
+```
 </details>
 
 <br />
@@ -782,8 +899,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=100603`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_uploads_store_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) / (sum(increase(src_codeintel_uploads_store_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) + sum(increase(src_codeintel_uploads_store_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))) * 100`
+Query:
 
+```
+sum(increase(src_codeintel_uploads_store_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) / (sum(increase(src_codeintel_uploads_store_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) + sum(increase(src_codeintel_uploads_store_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -801,8 +921,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=100610`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_uploads_store_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_uploads_store_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))
+```
 </details>
 
 <br />
@@ -820,8 +943,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=100611`
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_uploads_store_duration_seconds_bucket{job=~"^(frontend|sourcegraph-frontend).*"}[5m])))`
+Query:
 
+```
+histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_uploads_store_duration_seconds_bucket{job=~"^(frontend|sourcegraph-frontend).*"}[5m])))
+```
 </details>
 
 <br />
@@ -839,8 +965,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=100612`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_uploads_store_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_uploads_store_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))
+```
 </details>
 
 <br />
@@ -858,8 +987,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=100613`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_uploads_store_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) / (sum by (op)(increase(src_codeintel_uploads_store_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) + sum by (op)(increase(src_codeintel_uploads_store_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))) * 100`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_uploads_store_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) / (sum by (op)(increase(src_codeintel_uploads_store_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) + sum by (op)(increase(src_codeintel_uploads_store_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -879,8 +1011,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=100700`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_workerutil_dbworker_store_codeintel_index_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))`
+Query:
 
+```
+sum(increase(src_workerutil_dbworker_store_codeintel_index_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))
+```
 </details>
 
 <br />
@@ -898,8 +1033,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=100701`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum  by (le)(rate(src_workerutil_dbworker_store_codeintel_index_duration_seconds_bucket{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))`
+Query:
 
+```
+sum  by (le)(rate(src_workerutil_dbworker_store_codeintel_index_duration_seconds_bucket{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))
+```
 </details>
 
 <br />
@@ -917,8 +1055,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=100702`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_workerutil_dbworker_store_codeintel_index_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))`
+Query:
 
+```
+sum(increase(src_workerutil_dbworker_store_codeintel_index_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))
+```
 </details>
 
 <br />
@@ -936,8 +1077,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=100703`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_workerutil_dbworker_store_codeintel_index_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) / (sum(increase(src_workerutil_dbworker_store_codeintel_index_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) + sum(increase(src_workerutil_dbworker_store_codeintel_index_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))) * 100`
+Query:
 
+```
+sum(increase(src_workerutil_dbworker_store_codeintel_index_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) / (sum(increase(src_workerutil_dbworker_store_codeintel_index_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) + sum(increase(src_workerutil_dbworker_store_codeintel_index_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -957,8 +1101,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=100800`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_uploads_lsifstore_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_uploads_lsifstore_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))
+```
 </details>
 
 <br />
@@ -976,8 +1123,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=100801`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum  by (le)(rate(src_codeintel_uploads_lsifstore_duration_seconds_bucket{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))`
+Query:
 
+```
+sum  by (le)(rate(src_codeintel_uploads_lsifstore_duration_seconds_bucket{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))
+```
 </details>
 
 <br />
@@ -995,8 +1145,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=100802`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_uploads_lsifstore_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_uploads_lsifstore_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))
+```
 </details>
 
 <br />
@@ -1014,8 +1167,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=100803`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_uploads_lsifstore_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) / (sum(increase(src_codeintel_uploads_lsifstore_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) + sum(increase(src_codeintel_uploads_lsifstore_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))) * 100`
+Query:
 
+```
+sum(increase(src_codeintel_uploads_lsifstore_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) / (sum(increase(src_codeintel_uploads_lsifstore_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) + sum(increase(src_codeintel_uploads_lsifstore_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -1033,8 +1189,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=100810`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_uploads_lsifstore_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_uploads_lsifstore_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))
+```
 </details>
 
 <br />
@@ -1052,8 +1211,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=100811`
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_uploads_lsifstore_duration_seconds_bucket{job=~"^(frontend|sourcegraph-frontend).*"}[5m])))`
+Query:
 
+```
+histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_uploads_lsifstore_duration_seconds_bucket{job=~"^(frontend|sourcegraph-frontend).*"}[5m])))
+```
 </details>
 
 <br />
@@ -1071,8 +1233,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=100812`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_uploads_lsifstore_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_uploads_lsifstore_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))
+```
 </details>
 
 <br />
@@ -1090,8 +1255,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=100813`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_uploads_lsifstore_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) / (sum by (op)(increase(src_codeintel_uploads_lsifstore_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) + sum by (op)(increase(src_codeintel_uploads_lsifstore_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))) * 100`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_uploads_lsifstore_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) / (sum by (op)(increase(src_codeintel_uploads_lsifstore_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) + sum by (op)(increase(src_codeintel_uploads_lsifstore_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -1111,8 +1279,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=100900`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_gitserver_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_gitserver_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))
+```
 </details>
 
 <br />
@@ -1130,8 +1301,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=100901`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum  by (le)(rate(src_codeintel_gitserver_duration_seconds_bucket{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))`
+Query:
 
+```
+sum  by (le)(rate(src_codeintel_gitserver_duration_seconds_bucket{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))
+```
 </details>
 
 <br />
@@ -1149,8 +1323,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=100902`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_gitserver_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_gitserver_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))
+```
 </details>
 
 <br />
@@ -1168,8 +1345,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=100903`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_gitserver_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) / (sum(increase(src_codeintel_gitserver_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) + sum(increase(src_codeintel_gitserver_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))) * 100`
+Query:
 
+```
+sum(increase(src_codeintel_gitserver_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) / (sum(increase(src_codeintel_gitserver_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) + sum(increase(src_codeintel_gitserver_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -1187,8 +1367,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=100910`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_gitserver_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_gitserver_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))
+```
 </details>
 
 <br />
@@ -1206,8 +1389,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=100911`
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_gitserver_duration_seconds_bucket{job=~"^(frontend|sourcegraph-frontend).*"}[5m])))`
+Query:
 
+```
+histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_gitserver_duration_seconds_bucket{job=~"^(frontend|sourcegraph-frontend).*"}[5m])))
+```
 </details>
 
 <br />
@@ -1225,8 +1411,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=100912`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_gitserver_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_gitserver_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))
+```
 </details>
 
 <br />
@@ -1244,8 +1433,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=100913`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_gitserver_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) / (sum by (op)(increase(src_codeintel_gitserver_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) + sum by (op)(increase(src_codeintel_gitserver_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))) * 100`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_gitserver_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) / (sum by (op)(increase(src_codeintel_gitserver_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) + sum by (op)(increase(src_codeintel_gitserver_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -1265,8 +1457,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=101000`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_uploadstore_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_uploadstore_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))
+```
 </details>
 
 <br />
@@ -1284,8 +1479,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=101001`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum  by (le)(rate(src_codeintel_uploadstore_duration_seconds_bucket{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))`
+Query:
 
+```
+sum  by (le)(rate(src_codeintel_uploadstore_duration_seconds_bucket{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))
+```
 </details>
 
 <br />
@@ -1303,8 +1501,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=101002`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_uploadstore_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_uploadstore_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))
+```
 </details>
 
 <br />
@@ -1322,8 +1523,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=101003`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_uploadstore_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) / (sum(increase(src_codeintel_uploadstore_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) + sum(increase(src_codeintel_uploadstore_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))) * 100`
+Query:
 
+```
+sum(increase(src_codeintel_uploadstore_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) / (sum(increase(src_codeintel_uploadstore_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) + sum(increase(src_codeintel_uploadstore_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -1341,8 +1545,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=101010`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_uploadstore_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_uploadstore_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))
+```
 </details>
 
 <br />
@@ -1360,8 +1567,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=101011`
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_uploadstore_duration_seconds_bucket{job=~"^(frontend|sourcegraph-frontend).*"}[5m])))`
+Query:
 
+```
+histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_uploadstore_duration_seconds_bucket{job=~"^(frontend|sourcegraph-frontend).*"}[5m])))
+```
 </details>
 
 <br />
@@ -1379,8 +1589,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=101012`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_uploadstore_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_uploadstore_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))
+```
 </details>
 
 <br />
@@ -1398,8 +1611,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=101013`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_uploadstore_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) / (sum by (op)(increase(src_codeintel_uploadstore_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) + sum by (op)(increase(src_codeintel_uploadstore_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))) * 100`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_uploadstore_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) / (sum by (op)(increase(src_codeintel_uploadstore_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) + sum by (op)(increase(src_codeintel_uploadstore_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -1419,8 +1635,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=101100`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_dependencies_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_dependencies_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))
+```
 </details>
 
 <br />
@@ -1438,8 +1657,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=101101`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum  by (le)(rate(src_codeintel_dependencies_duration_seconds_bucket{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))`
+Query:
 
+```
+sum  by (le)(rate(src_codeintel_dependencies_duration_seconds_bucket{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))
+```
 </details>
 
 <br />
@@ -1457,8 +1679,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=101102`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_dependencies_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_dependencies_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))
+```
 </details>
 
 <br />
@@ -1476,8 +1701,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=101103`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_dependencies_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) / (sum(increase(src_codeintel_dependencies_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) + sum(increase(src_codeintel_dependencies_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))) * 100`
+Query:
 
+```
+sum(increase(src_codeintel_dependencies_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) / (sum(increase(src_codeintel_dependencies_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) + sum(increase(src_codeintel_dependencies_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -1495,8 +1723,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=101110`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_dependencies_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_dependencies_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))
+```
 </details>
 
 <br />
@@ -1514,8 +1745,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=101111`
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_dependencies_duration_seconds_bucket{job=~"^(frontend|sourcegraph-frontend).*"}[5m])))`
+Query:
 
+```
+histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_dependencies_duration_seconds_bucket{job=~"^(frontend|sourcegraph-frontend).*"}[5m])))
+```
 </details>
 
 <br />
@@ -1533,8 +1767,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=101112`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_dependencies_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_dependencies_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))
+```
 </details>
 
 <br />
@@ -1552,8 +1789,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=101113`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_dependencies_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) / (sum by (op)(increase(src_codeintel_dependencies_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) + sum by (op)(increase(src_codeintel_dependencies_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))) * 100`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_dependencies_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) / (sum by (op)(increase(src_codeintel_dependencies_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) + sum by (op)(increase(src_codeintel_dependencies_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -1573,8 +1813,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=101200`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_dependencies_background_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_dependencies_background_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))
+```
 </details>
 
 <br />
@@ -1592,8 +1835,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=101201`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum  by (le)(rate(src_codeintel_dependencies_background_duration_seconds_bucket{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))`
+Query:
 
+```
+sum  by (le)(rate(src_codeintel_dependencies_background_duration_seconds_bucket{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))
+```
 </details>
 
 <br />
@@ -1611,8 +1857,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=101202`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_dependencies_background_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_dependencies_background_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))
+```
 </details>
 
 <br />
@@ -1630,8 +1879,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=101203`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_dependencies_background_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) / (sum(increase(src_codeintel_dependencies_background_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) + sum(increase(src_codeintel_dependencies_background_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))) * 100`
+Query:
 
+```
+sum(increase(src_codeintel_dependencies_background_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) / (sum(increase(src_codeintel_dependencies_background_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) + sum(increase(src_codeintel_dependencies_background_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -1649,8 +1901,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=101210`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_dependencies_background_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_dependencies_background_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))
+```
 </details>
 
 <br />
@@ -1668,8 +1923,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=101211`
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_dependencies_background_duration_seconds_bucket{job=~"^(frontend|sourcegraph-frontend).*"}[5m])))`
+Query:
 
+```
+histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_dependencies_background_duration_seconds_bucket{job=~"^(frontend|sourcegraph-frontend).*"}[5m])))
+```
 </details>
 
 <br />
@@ -1687,8 +1945,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=101212`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_dependencies_background_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_dependencies_background_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))
+```
 </details>
 
 <br />
@@ -1706,8 +1967,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=101213`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_dependencies_background_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) / (sum by (op)(increase(src_codeintel_dependencies_background_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) + sum by (op)(increase(src_codeintel_dependencies_background_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))) * 100`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_dependencies_background_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) / (sum by (op)(increase(src_codeintel_dependencies_background_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) + sum by (op)(increase(src_codeintel_dependencies_background_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -1727,8 +1991,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=101300`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_dependencies_background_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_dependencies_background_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))
+```
 </details>
 
 <br />
@@ -1746,8 +2013,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=101301`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum  by (le)(rate(src_codeintel_dependencies_background_duration_seconds_bucket{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))`
+Query:
 
+```
+sum  by (le)(rate(src_codeintel_dependencies_background_duration_seconds_bucket{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))
+```
 </details>
 
 <br />
@@ -1765,8 +2035,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=101302`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_dependencies_background_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_dependencies_background_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))
+```
 </details>
 
 <br />
@@ -1784,8 +2057,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=101303`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_dependencies_background_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) / (sum(increase(src_codeintel_dependencies_background_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) + sum(increase(src_codeintel_dependencies_background_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))) * 100`
+Query:
 
+```
+sum(increase(src_codeintel_dependencies_background_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) / (sum(increase(src_codeintel_dependencies_background_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) + sum(increase(src_codeintel_dependencies_background_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -1803,8 +2079,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=101310`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_dependencies_background_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_dependencies_background_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))
+```
 </details>
 
 <br />
@@ -1822,8 +2101,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=101311`
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_dependencies_background_duration_seconds_bucket{job=~"^(frontend|sourcegraph-frontend).*"}[5m])))`
+Query:
 
+```
+histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_dependencies_background_duration_seconds_bucket{job=~"^(frontend|sourcegraph-frontend).*"}[5m])))
+```
 </details>
 
 <br />
@@ -1841,8 +2123,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=101312`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_dependencies_background_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_dependencies_background_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))
+```
 </details>
 
 <br />
@@ -1860,8 +2145,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=101313`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_dependencies_background_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) / (sum by (op)(increase(src_codeintel_dependencies_background_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) + sum by (op)(increase(src_codeintel_dependencies_background_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))) * 100`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_dependencies_background_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) / (sum by (op)(increase(src_codeintel_dependencies_background_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) + sum by (op)(increase(src_codeintel_dependencies_background_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -1881,8 +2169,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=101400`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_lockfiles_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_lockfiles_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))
+```
 </details>
 
 <br />
@@ -1900,8 +2191,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=101401`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum  by (le)(rate(src_codeintel_lockfiles_duration_seconds_bucket{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))`
+Query:
 
+```
+sum  by (le)(rate(src_codeintel_lockfiles_duration_seconds_bucket{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))
+```
 </details>
 
 <br />
@@ -1919,8 +2213,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=101402`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_lockfiles_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_lockfiles_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))
+```
 </details>
 
 <br />
@@ -1938,8 +2235,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=101403`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_lockfiles_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) / (sum(increase(src_codeintel_lockfiles_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) + sum(increase(src_codeintel_lockfiles_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))) * 100`
+Query:
 
+```
+sum(increase(src_codeintel_lockfiles_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) / (sum(increase(src_codeintel_lockfiles_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) + sum(increase(src_codeintel_lockfiles_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -1957,8 +2257,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=101410`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_lockfiles_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_lockfiles_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))
+```
 </details>
 
 <br />
@@ -1976,8 +2279,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=101411`
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_lockfiles_duration_seconds_bucket{job=~"^(frontend|sourcegraph-frontend).*"}[5m])))`
+Query:
 
+```
+histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_lockfiles_duration_seconds_bucket{job=~"^(frontend|sourcegraph-frontend).*"}[5m])))
+```
 </details>
 
 <br />
@@ -1995,8 +2301,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=101412`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_lockfiles_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_lockfiles_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))
+```
 </details>
 
 <br />
@@ -2014,8 +2323,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=101413`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_lockfiles_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) / (sum by (op)(increase(src_codeintel_lockfiles_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) + sum by (op)(increase(src_codeintel_lockfiles_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))) * 100`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_lockfiles_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) / (sum by (op)(increase(src_codeintel_lockfiles_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) + sum by (op)(increase(src_codeintel_lockfiles_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -2035,8 +2347,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=101500`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_gitserver_client_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))`
+Query:
 
+```
+sum(increase(src_gitserver_client_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))
+```
 </details>
 
 <br />
@@ -2054,8 +2369,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=101501`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum  by (le)(rate(src_gitserver_client_duration_seconds_bucket{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))`
+Query:
 
+```
+sum  by (le)(rate(src_gitserver_client_duration_seconds_bucket{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))
+```
 </details>
 
 <br />
@@ -2073,8 +2391,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=101502`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_gitserver_client_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))`
+Query:
 
+```
+sum(increase(src_gitserver_client_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))
+```
 </details>
 
 <br />
@@ -2092,8 +2413,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=101503`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_gitserver_client_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) / (sum(increase(src_gitserver_client_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) + sum(increase(src_gitserver_client_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))) * 100`
+Query:
 
+```
+sum(increase(src_gitserver_client_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) / (sum(increase(src_gitserver_client_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) + sum(increase(src_gitserver_client_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -2111,8 +2435,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=101510`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op,scope)(increase(src_gitserver_client_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))`
+Query:
 
+```
+sum by (op,scope)(increase(src_gitserver_client_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))
+```
 </details>
 
 <br />
@@ -2130,8 +2457,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=101511`
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.99, sum  by (le,op,scope)(rate(src_gitserver_client_duration_seconds_bucket{job=~"^(frontend|sourcegraph-frontend).*"}[5m])))`
+Query:
 
+```
+histogram_quantile(0.99, sum  by (le,op,scope)(rate(src_gitserver_client_duration_seconds_bucket{job=~"^(frontend|sourcegraph-frontend).*"}[5m])))
+```
 </details>
 
 <br />
@@ -2149,8 +2479,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=101512`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op,scope)(increase(src_gitserver_client_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))`
+Query:
 
+```
+sum by (op,scope)(increase(src_gitserver_client_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))
+```
 </details>
 
 <br />
@@ -2168,8 +2501,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=101513`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op,scope)(increase(src_gitserver_client_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) / (sum by (op,scope)(increase(src_gitserver_client_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) + sum by (op,scope)(increase(src_gitserver_client_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))) * 100`
+Query:
 
+```
+sum by (op,scope)(increase(src_gitserver_client_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) / (sum by (op,scope)(increase(src_gitserver_client_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) + sum by (op,scope)(increase(src_gitserver_client_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -2189,8 +2525,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=101600`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_batches_dbstore_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))`
+Query:
 
+```
+sum(increase(src_batches_dbstore_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))
+```
 </details>
 
 <br />
@@ -2208,8 +2547,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=101601`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum  by (le)(rate(src_batches_dbstore_duration_seconds_bucket{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))`
+Query:
 
+```
+sum  by (le)(rate(src_batches_dbstore_duration_seconds_bucket{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))
+```
 </details>
 
 <br />
@@ -2227,8 +2569,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=101602`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_batches_dbstore_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))`
+Query:
 
+```
+sum(increase(src_batches_dbstore_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))
+```
 </details>
 
 <br />
@@ -2246,8 +2591,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=101603`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_batches_dbstore_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) / (sum(increase(src_batches_dbstore_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) + sum(increase(src_batches_dbstore_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))) * 100`
+Query:
 
+```
+sum(increase(src_batches_dbstore_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) / (sum(increase(src_batches_dbstore_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) + sum(increase(src_batches_dbstore_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -2265,8 +2613,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=101610`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_batches_dbstore_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_batches_dbstore_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))
+```
 </details>
 
 <br />
@@ -2284,8 +2635,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=101611`
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.99, sum  by (le,op)(rate(src_batches_dbstore_duration_seconds_bucket{job=~"^(frontend|sourcegraph-frontend).*"}[5m])))`
+Query:
 
+```
+histogram_quantile(0.99, sum  by (le,op)(rate(src_batches_dbstore_duration_seconds_bucket{job=~"^(frontend|sourcegraph-frontend).*"}[5m])))
+```
 </details>
 
 <br />
@@ -2303,8 +2657,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=101612`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_batches_dbstore_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_batches_dbstore_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))
+```
 </details>
 
 <br />
@@ -2322,8 +2679,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=101613`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_batches_dbstore_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) / (sum by (op)(increase(src_batches_dbstore_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) + sum by (op)(increase(src_batches_dbstore_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))) * 100`
+Query:
 
+```
+sum by (op)(increase(src_batches_dbstore_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) / (sum by (op)(increase(src_batches_dbstore_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) + sum by (op)(increase(src_batches_dbstore_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -2343,8 +2703,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=101700`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_batches_service_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))`
+Query:
 
+```
+sum(increase(src_batches_service_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))
+```
 </details>
 
 <br />
@@ -2362,8 +2725,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=101701`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum  by (le)(rate(src_batches_service_duration_seconds_bucket{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))`
+Query:
 
+```
+sum  by (le)(rate(src_batches_service_duration_seconds_bucket{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))
+```
 </details>
 
 <br />
@@ -2381,8 +2747,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=101702`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_batches_service_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))`
+Query:
 
+```
+sum(increase(src_batches_service_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))
+```
 </details>
 
 <br />
@@ -2400,8 +2769,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=101703`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_batches_service_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) / (sum(increase(src_batches_service_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) + sum(increase(src_batches_service_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))) * 100`
+Query:
 
+```
+sum(increase(src_batches_service_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) / (sum(increase(src_batches_service_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) + sum(increase(src_batches_service_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -2419,8 +2791,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=101710`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_batches_service_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_batches_service_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))
+```
 </details>
 
 <br />
@@ -2438,8 +2813,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=101711`
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.99, sum  by (le,op)(rate(src_batches_service_duration_seconds_bucket{job=~"^(frontend|sourcegraph-frontend).*"}[5m])))`
+Query:
 
+```
+histogram_quantile(0.99, sum  by (le,op)(rate(src_batches_service_duration_seconds_bucket{job=~"^(frontend|sourcegraph-frontend).*"}[5m])))
+```
 </details>
 
 <br />
@@ -2457,8 +2835,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=101712`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_batches_service_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_batches_service_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))
+```
 </details>
 
 <br />
@@ -2476,8 +2857,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=101713`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_batches_service_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) / (sum by (op)(increase(src_batches_service_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) + sum by (op)(increase(src_batches_service_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))) * 100`
+Query:
 
+```
+sum by (op)(increase(src_batches_service_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) / (sum by (op)(increase(src_batches_service_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) + sum by (op)(increase(src_batches_service_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -2497,8 +2881,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=101800`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_workerutil_dbworker_store_batch_spec_workspace_execution_worker_store_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_workerutil_dbworker_store_batch_spec_workspace_execution_worker_store_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))
+```
 </details>
 
 <br />
@@ -2516,8 +2903,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=101801`
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.99, sum  by (le,op)(rate(src_workerutil_dbworker_store_batch_spec_workspace_execution_worker_store_duration_seconds_bucket{job=~"^(frontend|sourcegraph-frontend).*"}[5m])))`
+Query:
 
+```
+histogram_quantile(0.99, sum  by (le,op)(rate(src_workerutil_dbworker_store_batch_spec_workspace_execution_worker_store_duration_seconds_bucket{job=~"^(frontend|sourcegraph-frontend).*"}[5m])))
+```
 </details>
 
 <br />
@@ -2535,8 +2925,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=101802`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_workerutil_dbworker_store_batch_spec_workspace_execution_worker_store_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_workerutil_dbworker_store_batch_spec_workspace_execution_worker_store_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))
+```
 </details>
 
 <br />
@@ -2554,8 +2947,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=101803`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_workerutil_dbworker_store_batch_spec_workspace_execution_worker_store_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) / (sum by (op)(increase(src_workerutil_dbworker_store_batch_spec_workspace_execution_worker_store_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) + sum by (op)(increase(src_workerutil_dbworker_store_batch_spec_workspace_execution_worker_store_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))) * 100`
+Query:
 
+```
+sum by (op)(increase(src_workerutil_dbworker_store_batch_spec_workspace_execution_worker_store_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) / (sum by (op)(increase(src_workerutil_dbworker_store_batch_spec_workspace_execution_worker_store_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) + sum by (op)(increase(src_workerutil_dbworker_store_batch_spec_workspace_execution_worker_store_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -2575,8 +2971,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=101900`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_batches_httpapi_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))`
+Query:
 
+```
+sum(increase(src_batches_httpapi_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))
+```
 </details>
 
 <br />
@@ -2594,8 +2993,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=101901`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum  by (le)(rate(src_batches_httpapi_duration_seconds_bucket{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))`
+Query:
 
+```
+sum  by (le)(rate(src_batches_httpapi_duration_seconds_bucket{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))
+```
 </details>
 
 <br />
@@ -2613,8 +3015,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=101902`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_batches_httpapi_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))`
+Query:
 
+```
+sum(increase(src_batches_httpapi_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))
+```
 </details>
 
 <br />
@@ -2632,8 +3037,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=101903`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_batches_httpapi_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) / (sum(increase(src_batches_httpapi_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) + sum(increase(src_batches_httpapi_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))) * 100`
+Query:
 
+```
+sum(increase(src_batches_httpapi_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) / (sum(increase(src_batches_httpapi_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) + sum(increase(src_batches_httpapi_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -2651,8 +3059,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=101910`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_batches_httpapi_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_batches_httpapi_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))
+```
 </details>
 
 <br />
@@ -2670,8 +3081,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=101911`
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.99, sum  by (le,op)(rate(src_batches_httpapi_duration_seconds_bucket{job=~"^(frontend|sourcegraph-frontend).*"}[5m])))`
+Query:
 
+```
+histogram_quantile(0.99, sum  by (le,op)(rate(src_batches_httpapi_duration_seconds_bucket{job=~"^(frontend|sourcegraph-frontend).*"}[5m])))
+```
 </details>
 
 <br />
@@ -2689,8 +3103,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=101912`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_batches_httpapi_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_batches_httpapi_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))
+```
 </details>
 
 <br />
@@ -2708,8 +3125,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=101913`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_batches_httpapi_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) / (sum by (op)(increase(src_batches_httpapi_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) + sum by (op)(increase(src_batches_httpapi_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))) * 100`
+Query:
 
+```
+sum by (op)(increase(src_batches_httpapi_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) / (sum by (op)(increase(src_batches_httpapi_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) + sum by (op)(increase(src_batches_httpapi_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -2729,8 +3149,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102000`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_oobmigration_total{op="up",job=~"^(frontend|sourcegraph-frontend).*"}[5m]))`
+Query:
 
+```
+sum(increase(src_oobmigration_total{op="up",job=~"^(frontend|sourcegraph-frontend).*"}[5m]))
+```
 </details>
 
 <br />
@@ -2748,8 +3171,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102001`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum  by (le)(rate(src_oobmigration_duration_seconds_bucket{op="up",job=~"^(frontend|sourcegraph-frontend).*"}[5m]))`
+Query:
 
+```
+sum  by (le)(rate(src_oobmigration_duration_seconds_bucket{op="up",job=~"^(frontend|sourcegraph-frontend).*"}[5m]))
+```
 </details>
 
 <br />
@@ -2767,8 +3193,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102002`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_oobmigration_errors_total{op="up",job=~"^(frontend|sourcegraph-frontend).*"}[5m]))`
+Query:
 
+```
+sum(increase(src_oobmigration_errors_total{op="up",job=~"^(frontend|sourcegraph-frontend).*"}[5m]))
+```
 </details>
 
 <br />
@@ -2786,8 +3215,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102003`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_oobmigration_errors_total{op="up",job=~"^(frontend|sourcegraph-frontend).*"}[5m])) / (sum(increase(src_oobmigration_total{op="up",job=~"^(frontend|sourcegraph-frontend).*"}[5m])) + sum(increase(src_oobmigration_errors_total{op="up",job=~"^(frontend|sourcegraph-frontend).*"}[5m]))) * 100`
+Query:
 
+```
+sum(increase(src_oobmigration_errors_total{op="up",job=~"^(frontend|sourcegraph-frontend).*"}[5m])) / (sum(increase(src_oobmigration_total{op="up",job=~"^(frontend|sourcegraph-frontend).*"}[5m])) + sum(increase(src_oobmigration_errors_total{op="up",job=~"^(frontend|sourcegraph-frontend).*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -2807,8 +3239,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102100`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_oobmigration_total{op="down",job=~"^(frontend|sourcegraph-frontend).*"}[5m]))`
+Query:
 
+```
+sum(increase(src_oobmigration_total{op="down",job=~"^(frontend|sourcegraph-frontend).*"}[5m]))
+```
 </details>
 
 <br />
@@ -2826,8 +3261,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102101`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum  by (le)(rate(src_oobmigration_duration_seconds_bucket{op="down",job=~"^(frontend|sourcegraph-frontend).*"}[5m]))`
+Query:
 
+```
+sum  by (le)(rate(src_oobmigration_duration_seconds_bucket{op="down",job=~"^(frontend|sourcegraph-frontend).*"}[5m]))
+```
 </details>
 
 <br />
@@ -2845,8 +3283,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102102`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_oobmigration_errors_total{op="down",job=~"^(frontend|sourcegraph-frontend).*"}[5m]))`
+Query:
 
+```
+sum(increase(src_oobmigration_errors_total{op="down",job=~"^(frontend|sourcegraph-frontend).*"}[5m]))
+```
 </details>
 
 <br />
@@ -2864,8 +3305,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102103`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_oobmigration_errors_total{op="down",job=~"^(frontend|sourcegraph-frontend).*"}[5m])) / (sum(increase(src_oobmigration_total{op="down",job=~"^(frontend|sourcegraph-frontend).*"}[5m])) + sum(increase(src_oobmigration_errors_total{op="down",job=~"^(frontend|sourcegraph-frontend).*"}[5m]))) * 100`
+Query:
 
+```
+sum(increase(src_oobmigration_errors_total{op="down",job=~"^(frontend|sourcegraph-frontend).*"}[5m])) / (sum(increase(src_oobmigration_total{op="down",job=~"^(frontend|sourcegraph-frontend).*"}[5m])) + sum(increase(src_oobmigration_errors_total{op="down",job=~"^(frontend|sourcegraph-frontend).*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -2887,8 +3331,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102200`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(rate(grpc_server_started_total{instance=~`${internalInstance:regex}`,grpc_service=~"sourcegraph.zoekt.configuration.v1.ZoektConfigurationService"}[2m]))`
+Query:
 
+```
+sum(rate(grpc_server_started_total{instance=~`${internalInstance:regex}`,grpc_service=~"sourcegraph.zoekt.configuration.v1.ZoektConfigurationService"}[2m]))
+```
 </details>
 
 <br />
@@ -2908,8 +3355,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102201`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(rate(grpc_server_started_total{grpc_method=~`${zoekt_configuration_method:regex}`,instance=~`${internalInstance:regex}`,grpc_service=~"sourcegraph.zoekt.configuration.v1.ZoektConfigurationService"}[2m])) by (grpc_method)`
+Query:
 
+```
+sum(rate(grpc_server_started_total{grpc_method=~`${zoekt_configuration_method:regex}`,instance=~`${internalInstance:regex}`,grpc_service=~"sourcegraph.zoekt.configuration.v1.ZoektConfigurationService"}[2m])) by (grpc_method)
+```
 </details>
 
 <br />
@@ -2929,8 +3379,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102210`
 <details>
 <summary>Technical details</summary>
 
-Query: `(100.0 * ( (sum(rate(grpc_server_handled_total{grpc_code!="OK",instance=~`${internalInstance:regex}`,grpc_service=~"sourcegraph.zoekt.configuration.v1.ZoektConfigurationService"}[2m]))) / (sum(rate(grpc_server_handled_total{instance=~`${internalInstance:regex}`,grpc_service=~"sourcegraph.zoekt.configuration.v1.ZoektConfigurationService"}[2m]))) ))`
+Query:
 
+```
+(100.0 * ( (sum(rate(grpc_server_handled_total{grpc_code!="OK",instance=~`${internalInstance:regex}`,grpc_service=~"sourcegraph.zoekt.configuration.v1.ZoektConfigurationService"}[2m]))) / (sum(rate(grpc_server_handled_total{instance=~`${internalInstance:regex}`,grpc_service=~"sourcegraph.zoekt.configuration.v1.ZoektConfigurationService"}[2m]))) ))
+```
 </details>
 
 <br />
@@ -2950,8 +3403,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102211`
 <details>
 <summary>Technical details</summary>
 
-Query: `(100.0 * ( (sum(rate(grpc_server_handled_total{grpc_method=~`${zoekt_configuration_method:regex}`,grpc_code!="OK",instance=~`${internalInstance:regex}`,grpc_service=~"sourcegraph.zoekt.configuration.v1.ZoektConfigurationService"}[2m])) by (grpc_method)) / (sum(rate(grpc_server_handled_total{grpc_method=~`${zoekt_configuration_method:regex}`,instance=~`${internalInstance:regex}`,grpc_service=~"sourcegraph.zoekt.configuration.v1.ZoektConfigurationService"}[2m])) by (grpc_method)) ))`
+Query:
 
+```
+(100.0 * ( (sum(rate(grpc_server_handled_total{grpc_method=~`${zoekt_configuration_method:regex}`,grpc_code!="OK",instance=~`${internalInstance:regex}`,grpc_service=~"sourcegraph.zoekt.configuration.v1.ZoektConfigurationService"}[2m])) by (grpc_method)) / (sum(rate(grpc_server_handled_total{grpc_method=~`${zoekt_configuration_method:regex}`,instance=~`${internalInstance:regex}`,grpc_service=~"sourcegraph.zoekt.configuration.v1.ZoektConfigurationService"}[2m])) by (grpc_method)) ))
+```
 </details>
 
 <br />
@@ -2971,8 +3427,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102220`
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.99, sum by (le, name, grpc_method)(rate(grpc_server_handling_seconds_bucket{grpc_method=~`${zoekt_configuration_method:regex}`,instance=~`${internalInstance:regex}`,grpc_service=~"sourcegraph.zoekt.configuration.v1.ZoektConfigurationService"}[2m])))`
+Query:
 
+```
+histogram_quantile(0.99, sum by (le, name, grpc_method)(rate(grpc_server_handling_seconds_bucket{grpc_method=~`${zoekt_configuration_method:regex}`,instance=~`${internalInstance:regex}`,grpc_service=~"sourcegraph.zoekt.configuration.v1.ZoektConfigurationService"}[2m])))
+```
 </details>
 
 <br />
@@ -2992,8 +3451,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102221`
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.90, sum by (le, name, grpc_method)(rate(grpc_server_handling_seconds_bucket{grpc_method=~`${zoekt_configuration_method:regex}`,instance=~`${internalInstance:regex}`,grpc_service=~"sourcegraph.zoekt.configuration.v1.ZoektConfigurationService"}[2m])))`
+Query:
 
+```
+histogram_quantile(0.90, sum by (le, name, grpc_method)(rate(grpc_server_handling_seconds_bucket{grpc_method=~`${zoekt_configuration_method:regex}`,instance=~`${internalInstance:regex}`,grpc_service=~"sourcegraph.zoekt.configuration.v1.ZoektConfigurationService"}[2m])))
+```
 </details>
 
 <br />
@@ -3013,8 +3475,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102222`
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.75, sum by (le, name, grpc_method)(rate(grpc_server_handling_seconds_bucket{grpc_method=~`${zoekt_configuration_method:regex}`,instance=~`${internalInstance:regex}`,grpc_service=~"sourcegraph.zoekt.configuration.v1.ZoektConfigurationService"}[2m])))`
+Query:
 
+```
+histogram_quantile(0.75, sum by (le, name, grpc_method)(rate(grpc_server_handling_seconds_bucket{grpc_method=~`${zoekt_configuration_method:regex}`,instance=~`${internalInstance:regex}`,grpc_service=~"sourcegraph.zoekt.configuration.v1.ZoektConfigurationService"}[2m])))
+```
 </details>
 
 <br />
@@ -3034,8 +3499,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102230`
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.999, sum by (le, name, grpc_method)(rate(src_grpc_server_sent_bytes_per_rpc_bucket{grpc_method=~`${zoekt_configuration_method:regex}`,instance=~`${internalInstance:regex}`,grpc_service=~"sourcegraph.zoekt.configuration.v1.ZoektConfigurationService"}[2m])))`
+Query:
 
+```
+histogram_quantile(0.999, sum by (le, name, grpc_method)(rate(src_grpc_server_sent_bytes_per_rpc_bucket{grpc_method=~`${zoekt_configuration_method:regex}`,instance=~`${internalInstance:regex}`,grpc_service=~"sourcegraph.zoekt.configuration.v1.ZoektConfigurationService"}[2m])))
+```
 </details>
 
 <br />
@@ -3055,8 +3523,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102231`
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.90, sum by (le, name, grpc_method)(rate(src_grpc_server_sent_bytes_per_rpc_bucket{grpc_method=~`${zoekt_configuration_method:regex}`,instance=~`${internalInstance:regex}`,grpc_service=~"sourcegraph.zoekt.configuration.v1.ZoektConfigurationService"}[2m])))`
+Query:
 
+```
+histogram_quantile(0.90, sum by (le, name, grpc_method)(rate(src_grpc_server_sent_bytes_per_rpc_bucket{grpc_method=~`${zoekt_configuration_method:regex}`,instance=~`${internalInstance:regex}`,grpc_service=~"sourcegraph.zoekt.configuration.v1.ZoektConfigurationService"}[2m])))
+```
 </details>
 
 <br />
@@ -3076,8 +3547,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102232`
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.75, sum by (le, name, grpc_method)(rate(src_grpc_server_sent_bytes_per_rpc_bucket{grpc_method=~`${zoekt_configuration_method:regex}`,instance=~`${internalInstance:regex}`,grpc_service=~"sourcegraph.zoekt.configuration.v1.ZoektConfigurationService"}[2m])))`
+Query:
 
+```
+histogram_quantile(0.75, sum by (le, name, grpc_method)(rate(src_grpc_server_sent_bytes_per_rpc_bucket{grpc_method=~`${zoekt_configuration_method:regex}`,instance=~`${internalInstance:regex}`,grpc_service=~"sourcegraph.zoekt.configuration.v1.ZoektConfigurationService"}[2m])))
+```
 </details>
 
 <br />
@@ -3097,8 +3571,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102240`
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.999, sum by (le, name, grpc_method)(rate(src_grpc_server_sent_individual_message_size_bytes_per_rpc_bucket{grpc_method=~`${zoekt_configuration_method:regex}`,instance=~`${internalInstance:regex}`,grpc_service=~"sourcegraph.zoekt.configuration.v1.ZoektConfigurationService"}[2m])))`
+Query:
 
+```
+histogram_quantile(0.999, sum by (le, name, grpc_method)(rate(src_grpc_server_sent_individual_message_size_bytes_per_rpc_bucket{grpc_method=~`${zoekt_configuration_method:regex}`,instance=~`${internalInstance:regex}`,grpc_service=~"sourcegraph.zoekt.configuration.v1.ZoektConfigurationService"}[2m])))
+```
 </details>
 
 <br />
@@ -3118,8 +3595,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102241`
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.90, sum by (le, name, grpc_method)(rate(src_grpc_server_sent_individual_message_size_bytes_per_rpc_bucket{grpc_method=~`${zoekt_configuration_method:regex}`,instance=~`${internalInstance:regex}`,grpc_service=~"sourcegraph.zoekt.configuration.v1.ZoektConfigurationService"}[2m])))`
+Query:
 
+```
+histogram_quantile(0.90, sum by (le, name, grpc_method)(rate(src_grpc_server_sent_individual_message_size_bytes_per_rpc_bucket{grpc_method=~`${zoekt_configuration_method:regex}`,instance=~`${internalInstance:regex}`,grpc_service=~"sourcegraph.zoekt.configuration.v1.ZoektConfigurationService"}[2m])))
+```
 </details>
 
 <br />
@@ -3139,8 +3619,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102242`
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.75, sum by (le, name, grpc_method)(rate(src_grpc_server_sent_individual_message_size_bytes_per_rpc_bucket{grpc_method=~`${zoekt_configuration_method:regex}`,instance=~`${internalInstance:regex}`,grpc_service=~"sourcegraph.zoekt.configuration.v1.ZoektConfigurationService"}[2m])))`
+Query:
 
+```
+histogram_quantile(0.75, sum by (le, name, grpc_method)(rate(src_grpc_server_sent_individual_message_size_bytes_per_rpc_bucket{grpc_method=~`${zoekt_configuration_method:regex}`,instance=~`${internalInstance:regex}`,grpc_service=~"sourcegraph.zoekt.configuration.v1.ZoektConfigurationService"}[2m])))
+```
 </details>
 
 <br />
@@ -3160,8 +3643,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102250`
 <details>
 <summary>Technical details</summary>
 
-Query: `((sum(rate(grpc_server_msg_sent_total{grpc_type="server_stream",instance=~`${internalInstance:regex}`,grpc_service=~"sourcegraph.zoekt.configuration.v1.ZoektConfigurationService"}[2m])) by (grpc_method))/(sum(rate(grpc_server_started_total{grpc_type="server_stream",instance=~`${internalInstance:regex}`,grpc_service=~"sourcegraph.zoekt.configuration.v1.ZoektConfigurationService"}[2m])) by (grpc_method)))`
+Query:
 
+```
+((sum(rate(grpc_server_msg_sent_total{grpc_type="server_stream",instance=~`${internalInstance:regex}`,grpc_service=~"sourcegraph.zoekt.configuration.v1.ZoektConfigurationService"}[2m])) by (grpc_method))/(sum(rate(grpc_server_started_total{grpc_type="server_stream",instance=~`${internalInstance:regex}`,grpc_service=~"sourcegraph.zoekt.configuration.v1.ZoektConfigurationService"}[2m])) by (grpc_method)))
+```
 </details>
 
 <br />
@@ -3181,8 +3667,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102260`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(rate(grpc_server_handled_total{grpc_method=~`${zoekt_configuration_method:regex}`,instance=~`${internalInstance:regex}`,grpc_service=~"sourcegraph.zoekt.configuration.v1.ZoektConfigurationService"}[2m])) by (grpc_method, grpc_code)`
+Query:
 
+```
+sum(rate(grpc_server_handled_total{grpc_method=~`${zoekt_configuration_method:regex}`,instance=~`${internalInstance:regex}`,grpc_service=~"sourcegraph.zoekt.configuration.v1.ZoektConfigurationService"}[2m])) by (grpc_method, grpc_code)
+```
 </details>
 
 <br />
@@ -3204,8 +3693,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102300`
 <details>
 <summary>Technical details</summary>
 
-Query: `(100.0 * ((((sum(rate(grpc_method_status{grpc_service=~"sourcegraph.zoekt.configuration.v1.ZoektConfigurationService",grpc_code!="OK"}[2m])))) / ((sum(rate(grpc_method_status{grpc_service=~"sourcegraph.zoekt.configuration.v1.ZoektConfigurationService"}[2m])))))))`
+Query:
 
+```
+(100.0 * ((((sum(rate(grpc_method_status{grpc_service=~"sourcegraph.zoekt.configuration.v1.ZoektConfigurationService",grpc_code!="OK"}[2m])))) / ((sum(rate(grpc_method_status{grpc_service=~"sourcegraph.zoekt.configuration.v1.ZoektConfigurationService"}[2m])))))))
+```
 </details>
 
 <br />
@@ -3225,8 +3717,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102301`
 <details>
 <summary>Technical details</summary>
 
-Query: `(100.0 * ((((sum(rate(grpc_method_status{grpc_service=~"sourcegraph.zoekt.configuration.v1.ZoektConfigurationService",grpc_method=~"${zoekt_configuration_method:regex}",grpc_code!="OK"}[2m])) by (grpc_method))) / ((sum(rate(grpc_method_status{grpc_service=~"sourcegraph.zoekt.configuration.v1.ZoektConfigurationService",grpc_method=~"${zoekt_configuration_method:regex}"}[2m])) by (grpc_method))))))`
+Query:
 
+```
+(100.0 * ((((sum(rate(grpc_method_status{grpc_service=~"sourcegraph.zoekt.configuration.v1.ZoektConfigurationService",grpc_method=~"${zoekt_configuration_method:regex}",grpc_code!="OK"}[2m])) by (grpc_method))) / ((sum(rate(grpc_method_status{grpc_service=~"sourcegraph.zoekt.configuration.v1.ZoektConfigurationService",grpc_method=~"${zoekt_configuration_method:regex}"}[2m])) by (grpc_method))))))
+```
 </details>
 
 <br />
@@ -3246,8 +3741,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102302`
 <details>
 <summary>Technical details</summary>
 
-Query: `(sum(rate(grpc_method_status{grpc_service=~"sourcegraph.zoekt.configuration.v1.ZoektConfigurationService",grpc_method=~"${zoekt_configuration_method:regex}"}[2m])) by (grpc_method, grpc_code))`
+Query:
 
+```
+(sum(rate(grpc_method_status{grpc_service=~"sourcegraph.zoekt.configuration.v1.ZoektConfigurationService",grpc_method=~"${zoekt_configuration_method:regex}"}[2m])) by (grpc_method, grpc_code))
+```
 </details>
 
 <br />
@@ -3273,8 +3771,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102310`
 <details>
 <summary>Technical details</summary>
 
-Query: `(100.0 * ((((sum(rate(grpc_method_status{grpc_service=~"sourcegraph.zoekt.configuration.v1.ZoektConfigurationService",grpc_code!="OK",is_internal_error="true"}[2m])))) / ((sum(rate(grpc_method_status{grpc_service=~"sourcegraph.zoekt.configuration.v1.ZoektConfigurationService"}[2m])))))))`
+Query:
 
+```
+(100.0 * ((((sum(rate(grpc_method_status{grpc_service=~"sourcegraph.zoekt.configuration.v1.ZoektConfigurationService",grpc_code!="OK",is_internal_error="true"}[2m])))) / ((sum(rate(grpc_method_status{grpc_service=~"sourcegraph.zoekt.configuration.v1.ZoektConfigurationService"}[2m])))))))
+```
 </details>
 
 <br />
@@ -3300,8 +3801,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102311`
 <details>
 <summary>Technical details</summary>
 
-Query: `(100.0 * ((((sum(rate(grpc_method_status{grpc_service=~"sourcegraph.zoekt.configuration.v1.ZoektConfigurationService",grpc_method=~"${zoekt_configuration_method:regex}",grpc_code!="OK",is_internal_error="true"}[2m])) by (grpc_method))) / ((sum(rate(grpc_method_status{grpc_service=~"sourcegraph.zoekt.configuration.v1.ZoektConfigurationService",grpc_method=~"${zoekt_configuration_method:regex}"}[2m])) by (grpc_method))))))`
+Query:
 
+```
+(100.0 * ((((sum(rate(grpc_method_status{grpc_service=~"sourcegraph.zoekt.configuration.v1.ZoektConfigurationService",grpc_method=~"${zoekt_configuration_method:regex}",grpc_code!="OK",is_internal_error="true"}[2m])) by (grpc_method))) / ((sum(rate(grpc_method_status{grpc_service=~"sourcegraph.zoekt.configuration.v1.ZoektConfigurationService",grpc_method=~"${zoekt_configuration_method:regex}"}[2m])) by (grpc_method))))))
+```
 </details>
 
 <br />
@@ -3327,8 +3831,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102312`
 <details>
 <summary>Technical details</summary>
 
-Query: `(sum(rate(grpc_method_status{grpc_service=~"sourcegraph.zoekt.configuration.v1.ZoektConfigurationService",is_internal_error="true",grpc_method=~"${zoekt_configuration_method:regex}"}[2m])) by (grpc_method, grpc_code))`
+Query:
 
+```
+(sum(rate(grpc_method_status{grpc_service=~"sourcegraph.zoekt.configuration.v1.ZoektConfigurationService",is_internal_error="true",grpc_method=~"${zoekt_configuration_method:regex}"}[2m])) by (grpc_method, grpc_code))
+```
 </details>
 
 <br />
@@ -3350,8 +3857,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102400`
 <details>
 <summary>Technical details</summary>
 
-Query: `(100.0 * ((((sum(rate(src_grpc_client_retry_attempts_total{grpc_service=~"sourcegraph.zoekt.configuration.v1.ZoektConfigurationService",is_retried="true"}[2m])))) / ((sum(rate(src_grpc_client_retry_attempts_total{grpc_service=~"sourcegraph.zoekt.configuration.v1.ZoektConfigurationService"}[2m])))))))`
+Query:
 
+```
+(100.0 * ((((sum(rate(src_grpc_client_retry_attempts_total{grpc_service=~"sourcegraph.zoekt.configuration.v1.ZoektConfigurationService",is_retried="true"}[2m])))) / ((sum(rate(src_grpc_client_retry_attempts_total{grpc_service=~"sourcegraph.zoekt.configuration.v1.ZoektConfigurationService"}[2m])))))))
+```
 </details>
 
 <br />
@@ -3371,8 +3881,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102401`
 <details>
 <summary>Technical details</summary>
 
-Query: `(100.0 * ((((sum(rate(src_grpc_client_retry_attempts_total{grpc_service=~"sourcegraph.zoekt.configuration.v1.ZoektConfigurationService",is_retried="true",grpc_method=~"${zoekt_configuration_method:regex}"}[2m])) by (grpc_method))) / ((sum(rate(src_grpc_client_retry_attempts_total{grpc_service=~"sourcegraph.zoekt.configuration.v1.ZoektConfigurationService",grpc_method=~"${zoekt_configuration_method:regex}"}[2m])) by (grpc_method))))))`
+Query:
 
+```
+(100.0 * ((((sum(rate(src_grpc_client_retry_attempts_total{grpc_service=~"sourcegraph.zoekt.configuration.v1.ZoektConfigurationService",is_retried="true",grpc_method=~"${zoekt_configuration_method:regex}"}[2m])) by (grpc_method))) / ((sum(rate(src_grpc_client_retry_attempts_total{grpc_service=~"sourcegraph.zoekt.configuration.v1.ZoektConfigurationService",grpc_method=~"${zoekt_configuration_method:regex}"}[2m])) by (grpc_method))))))
+```
 </details>
 
 <br />
@@ -3392,8 +3905,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102402`
 <details>
 <summary>Technical details</summary>
 
-Query: `(sum(rate(src_grpc_client_retry_attempts_total{grpc_service=~"sourcegraph.zoekt.configuration.v1.ZoektConfigurationService",grpc_method=~"${zoekt_configuration_method:regex}",is_retried="true"}[2m])) by (grpc_method))`
+Query:
 
+```
+(sum(rate(src_grpc_client_retry_attempts_total{grpc_service=~"sourcegraph.zoekt.configuration.v1.ZoektConfigurationService",grpc_method=~"${zoekt_configuration_method:regex}",is_retried="true"}[2m])) by (grpc_method))
+```
 </details>
 
 <br />
@@ -3415,8 +3931,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102500`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(rate(grpc_server_started_total{instance=~`${internalInstance:regex}`,grpc_service=~"api.internalapi.v1.ConfigService"}[2m]))`
+Query:
 
+```
+sum(rate(grpc_server_started_total{instance=~`${internalInstance:regex}`,grpc_service=~"api.internalapi.v1.ConfigService"}[2m]))
+```
 </details>
 
 <br />
@@ -3436,8 +3955,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102501`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(rate(grpc_server_started_total{grpc_method=~`${internal_api_method:regex}`,instance=~`${internalInstance:regex}`,grpc_service=~"api.internalapi.v1.ConfigService"}[2m])) by (grpc_method)`
+Query:
 
+```
+sum(rate(grpc_server_started_total{grpc_method=~`${internal_api_method:regex}`,instance=~`${internalInstance:regex}`,grpc_service=~"api.internalapi.v1.ConfigService"}[2m])) by (grpc_method)
+```
 </details>
 
 <br />
@@ -3457,8 +3979,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102510`
 <details>
 <summary>Technical details</summary>
 
-Query: `(100.0 * ( (sum(rate(grpc_server_handled_total{grpc_code!="OK",instance=~`${internalInstance:regex}`,grpc_service=~"api.internalapi.v1.ConfigService"}[2m]))) / (sum(rate(grpc_server_handled_total{instance=~`${internalInstance:regex}`,grpc_service=~"api.internalapi.v1.ConfigService"}[2m]))) ))`
+Query:
 
+```
+(100.0 * ( (sum(rate(grpc_server_handled_total{grpc_code!="OK",instance=~`${internalInstance:regex}`,grpc_service=~"api.internalapi.v1.ConfigService"}[2m]))) / (sum(rate(grpc_server_handled_total{instance=~`${internalInstance:regex}`,grpc_service=~"api.internalapi.v1.ConfigService"}[2m]))) ))
+```
 </details>
 
 <br />
@@ -3478,8 +4003,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102511`
 <details>
 <summary>Technical details</summary>
 
-Query: `(100.0 * ( (sum(rate(grpc_server_handled_total{grpc_method=~`${internal_api_method:regex}`,grpc_code!="OK",instance=~`${internalInstance:regex}`,grpc_service=~"api.internalapi.v1.ConfigService"}[2m])) by (grpc_method)) / (sum(rate(grpc_server_handled_total{grpc_method=~`${internal_api_method:regex}`,instance=~`${internalInstance:regex}`,grpc_service=~"api.internalapi.v1.ConfigService"}[2m])) by (grpc_method)) ))`
+Query:
 
+```
+(100.0 * ( (sum(rate(grpc_server_handled_total{grpc_method=~`${internal_api_method:regex}`,grpc_code!="OK",instance=~`${internalInstance:regex}`,grpc_service=~"api.internalapi.v1.ConfigService"}[2m])) by (grpc_method)) / (sum(rate(grpc_server_handled_total{grpc_method=~`${internal_api_method:regex}`,instance=~`${internalInstance:regex}`,grpc_service=~"api.internalapi.v1.ConfigService"}[2m])) by (grpc_method)) ))
+```
 </details>
 
 <br />
@@ -3499,8 +4027,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102520`
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.99, sum by (le, name, grpc_method)(rate(grpc_server_handling_seconds_bucket{grpc_method=~`${internal_api_method:regex}`,instance=~`${internalInstance:regex}`,grpc_service=~"api.internalapi.v1.ConfigService"}[2m])))`
+Query:
 
+```
+histogram_quantile(0.99, sum by (le, name, grpc_method)(rate(grpc_server_handling_seconds_bucket{grpc_method=~`${internal_api_method:regex}`,instance=~`${internalInstance:regex}`,grpc_service=~"api.internalapi.v1.ConfigService"}[2m])))
+```
 </details>
 
 <br />
@@ -3520,8 +4051,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102521`
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.90, sum by (le, name, grpc_method)(rate(grpc_server_handling_seconds_bucket{grpc_method=~`${internal_api_method:regex}`,instance=~`${internalInstance:regex}`,grpc_service=~"api.internalapi.v1.ConfigService"}[2m])))`
+Query:
 
+```
+histogram_quantile(0.90, sum by (le, name, grpc_method)(rate(grpc_server_handling_seconds_bucket{grpc_method=~`${internal_api_method:regex}`,instance=~`${internalInstance:regex}`,grpc_service=~"api.internalapi.v1.ConfigService"}[2m])))
+```
 </details>
 
 <br />
@@ -3541,8 +4075,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102522`
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.75, sum by (le, name, grpc_method)(rate(grpc_server_handling_seconds_bucket{grpc_method=~`${internal_api_method:regex}`,instance=~`${internalInstance:regex}`,grpc_service=~"api.internalapi.v1.ConfigService"}[2m])))`
+Query:
 
+```
+histogram_quantile(0.75, sum by (le, name, grpc_method)(rate(grpc_server_handling_seconds_bucket{grpc_method=~`${internal_api_method:regex}`,instance=~`${internalInstance:regex}`,grpc_service=~"api.internalapi.v1.ConfigService"}[2m])))
+```
 </details>
 
 <br />
@@ -3562,8 +4099,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102530`
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.999, sum by (le, name, grpc_method)(rate(src_grpc_server_sent_bytes_per_rpc_bucket{grpc_method=~`${internal_api_method:regex}`,instance=~`${internalInstance:regex}`,grpc_service=~"api.internalapi.v1.ConfigService"}[2m])))`
+Query:
 
+```
+histogram_quantile(0.999, sum by (le, name, grpc_method)(rate(src_grpc_server_sent_bytes_per_rpc_bucket{grpc_method=~`${internal_api_method:regex}`,instance=~`${internalInstance:regex}`,grpc_service=~"api.internalapi.v1.ConfigService"}[2m])))
+```
 </details>
 
 <br />
@@ -3583,8 +4123,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102531`
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.90, sum by (le, name, grpc_method)(rate(src_grpc_server_sent_bytes_per_rpc_bucket{grpc_method=~`${internal_api_method:regex}`,instance=~`${internalInstance:regex}`,grpc_service=~"api.internalapi.v1.ConfigService"}[2m])))`
+Query:
 
+```
+histogram_quantile(0.90, sum by (le, name, grpc_method)(rate(src_grpc_server_sent_bytes_per_rpc_bucket{grpc_method=~`${internal_api_method:regex}`,instance=~`${internalInstance:regex}`,grpc_service=~"api.internalapi.v1.ConfigService"}[2m])))
+```
 </details>
 
 <br />
@@ -3604,8 +4147,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102532`
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.75, sum by (le, name, grpc_method)(rate(src_grpc_server_sent_bytes_per_rpc_bucket{grpc_method=~`${internal_api_method:regex}`,instance=~`${internalInstance:regex}`,grpc_service=~"api.internalapi.v1.ConfigService"}[2m])))`
+Query:
 
+```
+histogram_quantile(0.75, sum by (le, name, grpc_method)(rate(src_grpc_server_sent_bytes_per_rpc_bucket{grpc_method=~`${internal_api_method:regex}`,instance=~`${internalInstance:regex}`,grpc_service=~"api.internalapi.v1.ConfigService"}[2m])))
+```
 </details>
 
 <br />
@@ -3625,8 +4171,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102540`
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.999, sum by (le, name, grpc_method)(rate(src_grpc_server_sent_individual_message_size_bytes_per_rpc_bucket{grpc_method=~`${internal_api_method:regex}`,instance=~`${internalInstance:regex}`,grpc_service=~"api.internalapi.v1.ConfigService"}[2m])))`
+Query:
 
+```
+histogram_quantile(0.999, sum by (le, name, grpc_method)(rate(src_grpc_server_sent_individual_message_size_bytes_per_rpc_bucket{grpc_method=~`${internal_api_method:regex}`,instance=~`${internalInstance:regex}`,grpc_service=~"api.internalapi.v1.ConfigService"}[2m])))
+```
 </details>
 
 <br />
@@ -3646,8 +4195,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102541`
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.90, sum by (le, name, grpc_method)(rate(src_grpc_server_sent_individual_message_size_bytes_per_rpc_bucket{grpc_method=~`${internal_api_method:regex}`,instance=~`${internalInstance:regex}`,grpc_service=~"api.internalapi.v1.ConfigService"}[2m])))`
+Query:
 
+```
+histogram_quantile(0.90, sum by (le, name, grpc_method)(rate(src_grpc_server_sent_individual_message_size_bytes_per_rpc_bucket{grpc_method=~`${internal_api_method:regex}`,instance=~`${internalInstance:regex}`,grpc_service=~"api.internalapi.v1.ConfigService"}[2m])))
+```
 </details>
 
 <br />
@@ -3667,8 +4219,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102542`
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.75, sum by (le, name, grpc_method)(rate(src_grpc_server_sent_individual_message_size_bytes_per_rpc_bucket{grpc_method=~`${internal_api_method:regex}`,instance=~`${internalInstance:regex}`,grpc_service=~"api.internalapi.v1.ConfigService"}[2m])))`
+Query:
 
+```
+histogram_quantile(0.75, sum by (le, name, grpc_method)(rate(src_grpc_server_sent_individual_message_size_bytes_per_rpc_bucket{grpc_method=~`${internal_api_method:regex}`,instance=~`${internalInstance:regex}`,grpc_service=~"api.internalapi.v1.ConfigService"}[2m])))
+```
 </details>
 
 <br />
@@ -3688,8 +4243,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102550`
 <details>
 <summary>Technical details</summary>
 
-Query: `((sum(rate(grpc_server_msg_sent_total{grpc_type="server_stream",instance=~`${internalInstance:regex}`,grpc_service=~"api.internalapi.v1.ConfigService"}[2m])) by (grpc_method))/(sum(rate(grpc_server_started_total{grpc_type="server_stream",instance=~`${internalInstance:regex}`,grpc_service=~"api.internalapi.v1.ConfigService"}[2m])) by (grpc_method)))`
+Query:
 
+```
+((sum(rate(grpc_server_msg_sent_total{grpc_type="server_stream",instance=~`${internalInstance:regex}`,grpc_service=~"api.internalapi.v1.ConfigService"}[2m])) by (grpc_method))/(sum(rate(grpc_server_started_total{grpc_type="server_stream",instance=~`${internalInstance:regex}`,grpc_service=~"api.internalapi.v1.ConfigService"}[2m])) by (grpc_method)))
+```
 </details>
 
 <br />
@@ -3709,8 +4267,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102560`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(rate(grpc_server_handled_total{grpc_method=~`${internal_api_method:regex}`,instance=~`${internalInstance:regex}`,grpc_service=~"api.internalapi.v1.ConfigService"}[2m])) by (grpc_method, grpc_code)`
+Query:
 
+```
+sum(rate(grpc_server_handled_total{grpc_method=~`${internal_api_method:regex}`,instance=~`${internalInstance:regex}`,grpc_service=~"api.internalapi.v1.ConfigService"}[2m])) by (grpc_method, grpc_code)
+```
 </details>
 
 <br />
@@ -3732,8 +4293,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102600`
 <details>
 <summary>Technical details</summary>
 
-Query: `(100.0 * ((((sum(rate(src_grpc_method_status{grpc_service=~"api.internalapi.v1.ConfigService",grpc_code!="OK"}[2m])))) / ((sum(rate(src_grpc_method_status{grpc_service=~"api.internalapi.v1.ConfigService"}[2m])))))))`
+Query:
 
+```
+(100.0 * ((((sum(rate(src_grpc_method_status{grpc_service=~"api.internalapi.v1.ConfigService",grpc_code!="OK"}[2m])))) / ((sum(rate(src_grpc_method_status{grpc_service=~"api.internalapi.v1.ConfigService"}[2m])))))))
+```
 </details>
 
 <br />
@@ -3753,8 +4317,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102601`
 <details>
 <summary>Technical details</summary>
 
-Query: `(100.0 * ((((sum(rate(src_grpc_method_status{grpc_service=~"api.internalapi.v1.ConfigService",grpc_method=~"${internal_api_method:regex}",grpc_code!="OK"}[2m])) by (grpc_method))) / ((sum(rate(src_grpc_method_status{grpc_service=~"api.internalapi.v1.ConfigService",grpc_method=~"${internal_api_method:regex}"}[2m])) by (grpc_method))))))`
+Query:
 
+```
+(100.0 * ((((sum(rate(src_grpc_method_status{grpc_service=~"api.internalapi.v1.ConfigService",grpc_method=~"${internal_api_method:regex}",grpc_code!="OK"}[2m])) by (grpc_method))) / ((sum(rate(src_grpc_method_status{grpc_service=~"api.internalapi.v1.ConfigService",grpc_method=~"${internal_api_method:regex}"}[2m])) by (grpc_method))))))
+```
 </details>
 
 <br />
@@ -3774,8 +4341,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102602`
 <details>
 <summary>Technical details</summary>
 
-Query: `(sum(rate(src_grpc_method_status{grpc_service=~"api.internalapi.v1.ConfigService",grpc_method=~"${internal_api_method:regex}"}[2m])) by (grpc_method, grpc_code))`
+Query:
 
+```
+(sum(rate(src_grpc_method_status{grpc_service=~"api.internalapi.v1.ConfigService",grpc_method=~"${internal_api_method:regex}"}[2m])) by (grpc_method, grpc_code))
+```
 </details>
 
 <br />
@@ -3801,8 +4371,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102610`
 <details>
 <summary>Technical details</summary>
 
-Query: `(100.0 * ((((sum(rate(src_grpc_method_status{grpc_service=~"api.internalapi.v1.ConfigService",grpc_code!="OK",is_internal_error="true"}[2m])))) / ((sum(rate(src_grpc_method_status{grpc_service=~"api.internalapi.v1.ConfigService"}[2m])))))))`
+Query:
 
+```
+(100.0 * ((((sum(rate(src_grpc_method_status{grpc_service=~"api.internalapi.v1.ConfigService",grpc_code!="OK",is_internal_error="true"}[2m])))) / ((sum(rate(src_grpc_method_status{grpc_service=~"api.internalapi.v1.ConfigService"}[2m])))))))
+```
 </details>
 
 <br />
@@ -3828,8 +4401,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102611`
 <details>
 <summary>Technical details</summary>
 
-Query: `(100.0 * ((((sum(rate(src_grpc_method_status{grpc_service=~"api.internalapi.v1.ConfigService",grpc_method=~"${internal_api_method:regex}",grpc_code!="OK",is_internal_error="true"}[2m])) by (grpc_method))) / ((sum(rate(src_grpc_method_status{grpc_service=~"api.internalapi.v1.ConfigService",grpc_method=~"${internal_api_method:regex}"}[2m])) by (grpc_method))))))`
+Query:
 
+```
+(100.0 * ((((sum(rate(src_grpc_method_status{grpc_service=~"api.internalapi.v1.ConfigService",grpc_method=~"${internal_api_method:regex}",grpc_code!="OK",is_internal_error="true"}[2m])) by (grpc_method))) / ((sum(rate(src_grpc_method_status{grpc_service=~"api.internalapi.v1.ConfigService",grpc_method=~"${internal_api_method:regex}"}[2m])) by (grpc_method))))))
+```
 </details>
 
 <br />
@@ -3855,8 +4431,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102612`
 <details>
 <summary>Technical details</summary>
 
-Query: `(sum(rate(src_grpc_method_status{grpc_service=~"api.internalapi.v1.ConfigService",is_internal_error="true",grpc_method=~"${internal_api_method:regex}"}[2m])) by (grpc_method, grpc_code))`
+Query:
 
+```
+(sum(rate(src_grpc_method_status{grpc_service=~"api.internalapi.v1.ConfigService",is_internal_error="true",grpc_method=~"${internal_api_method:regex}"}[2m])) by (grpc_method, grpc_code))
+```
 </details>
 
 <br />
@@ -3878,8 +4457,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102700`
 <details>
 <summary>Technical details</summary>
 
-Query: `(100.0 * ((((sum(rate(src_grpc_client_retry_attempts_total{grpc_service=~"api.internalapi.v1.ConfigService",is_retried="true"}[2m])))) / ((sum(rate(src_grpc_client_retry_attempts_total{grpc_service=~"api.internalapi.v1.ConfigService"}[2m])))))))`
+Query:
 
+```
+(100.0 * ((((sum(rate(src_grpc_client_retry_attempts_total{grpc_service=~"api.internalapi.v1.ConfigService",is_retried="true"}[2m])))) / ((sum(rate(src_grpc_client_retry_attempts_total{grpc_service=~"api.internalapi.v1.ConfigService"}[2m])))))))
+```
 </details>
 
 <br />
@@ -3899,8 +4481,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102701`
 <details>
 <summary>Technical details</summary>
 
-Query: `(100.0 * ((((sum(rate(src_grpc_client_retry_attempts_total{grpc_service=~"api.internalapi.v1.ConfigService",is_retried="true",grpc_method=~"${internal_api_method:regex}"}[2m])) by (grpc_method))) / ((sum(rate(src_grpc_client_retry_attempts_total{grpc_service=~"api.internalapi.v1.ConfigService",grpc_method=~"${internal_api_method:regex}"}[2m])) by (grpc_method))))))`
+Query:
 
+```
+(100.0 * ((((sum(rate(src_grpc_client_retry_attempts_total{grpc_service=~"api.internalapi.v1.ConfigService",is_retried="true",grpc_method=~"${internal_api_method:regex}"}[2m])) by (grpc_method))) / ((sum(rate(src_grpc_client_retry_attempts_total{grpc_service=~"api.internalapi.v1.ConfigService",grpc_method=~"${internal_api_method:regex}"}[2m])) by (grpc_method))))))
+```
 </details>
 
 <br />
@@ -3920,8 +4505,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102702`
 <details>
 <summary>Technical details</summary>
 
-Query: `(sum(rate(src_grpc_client_retry_attempts_total{grpc_service=~"api.internalapi.v1.ConfigService",grpc_method=~"${internal_api_method:regex}",is_retried="true"}[2m])) by (grpc_method))`
+Query:
 
+```
+(sum(rate(src_grpc_client_retry_attempts_total{grpc_service=~"api.internalapi.v1.ConfigService",grpc_method=~"${internal_api_method:regex}",is_retried="true"}[2m])) by (grpc_method))
+```
 </details>
 
 <br />
@@ -3941,8 +4529,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102800`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by(code) (increase(src_zoekt_request_duration_seconds_count{code!~"2.."}[5m])) / ignoring(code) group_left sum(increase(src_zoekt_request_duration_seconds_count[5m])) * 100`
+Query:
 
+```
+sum by(code) (increase(src_zoekt_request_duration_seconds_count{code!~"2.."}[5m])) / ignoring(code) group_left sum(increase(src_zoekt_request_duration_seconds_count[5m])) * 100
+```
 </details>
 
 <br />
@@ -3960,8 +4551,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102801`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by(code) (increase(searcher_service_request_total{code!~"2.."}[5m])) / ignoring(code) group_left sum(increase(searcher_service_request_total[5m])) * 100`
+Query:
 
+```
+sum by(code) (increase(searcher_service_request_total{code!~"2.."}[5m])) / ignoring(code) group_left sum(increase(searcher_service_request_total[5m])) * 100
+```
 </details>
 
 <br />
@@ -3979,8 +4573,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102810`
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.99, sum by (le,category)(rate(src_gitserver_request_duration_seconds_bucket{job=~"(sourcegraph-)?frontend"}[5m])))`
+Query:
 
+```
+histogram_quantile(0.99, sum by (le,category)(rate(src_gitserver_request_duration_seconds_bucket{job=~"(sourcegraph-)?frontend"}[5m])))
+```
 </details>
 
 <br />
@@ -3998,8 +4595,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102811`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (category)(increase(src_gitserver_request_duration_seconds_count{job=~"(sourcegraph-)?frontend",code!~"2.."}[5m])) / ignoring(code) group_left sum by (category)(increase(src_gitserver_request_duration_seconds_count{job=~"(sourcegraph-)?frontend"}[5m])) * 100`
+Query:
 
+```
+sum by (category)(increase(src_gitserver_request_duration_seconds_count{job=~"(sourcegraph-)?frontend",code!~"2.."}[5m])) / ignoring(code) group_left sum by (category)(increase(src_gitserver_request_duration_seconds_count{job=~"(sourcegraph-)?frontend"}[5m])) * 100
+```
 </details>
 
 <br />
@@ -4017,8 +4617,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102820`
 <details>
 <summary>Technical details</summary>
 
-Query: `max by(owner) (observability_test_metric_warning)`
+Query:
 
+```
+max by(owner) (observability_test_metric_warning)
+```
 </details>
 
 <br />
@@ -4036,8 +4639,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102821`
 <details>
 <summary>Technical details</summary>
 
-Query: `max by(owner) (observability_test_metric_critical)`
+Query:
 
+```
+max by(owner) (observability_test_metric_critical)
+```
 </details>
 
 <br />
@@ -4059,8 +4665,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102900`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(irate(src_http_request_duration_seconds_count{route="sign-in",method="post"}[5m]))`
+Query:
 
+```
+sum(irate(src_http_request_duration_seconds_count{route="sign-in",method="post"}[5m]))
+```
 </details>
 
 <br />
@@ -4080,8 +4689,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102901`
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.99, sum(rate(src_http_request_duration_seconds_bucket{route="sign-in",method="post"}[5m])) by (le))`
+Query:
 
+```
+histogram_quantile(0.99, sum(rate(src_http_request_duration_seconds_bucket{route="sign-in",method="post"}[5m])) by (le))
+```
 </details>
 
 <br />
@@ -4101,8 +4713,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102902`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (code)(irate(src_http_request_duration_seconds_count{route="sign-in",method="post"}[5m]))/ ignoring (code) group_left sum(irate(src_http_request_duration_seconds_count{route="sign-in",method="post"}[5m]))*100`
+Query:
 
+```
+sum by (code)(irate(src_http_request_duration_seconds_count{route="sign-in",method="post"}[5m]))/ ignoring (code) group_left sum(irate(src_http_request_duration_seconds_count{route="sign-in",method="post"}[5m]))*100
+```
 </details>
 
 <br />
@@ -4122,8 +4737,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102910`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(irate(src_http_request_duration_seconds_count{route="sign-up",method="post"}[5m]))`
+Query:
 
+```
+sum(irate(src_http_request_duration_seconds_count{route="sign-up",method="post"}[5m]))
+```
 </details>
 
 <br />
@@ -4143,8 +4761,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102911`
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.99, sum(rate(src_http_request_duration_seconds_bucket{route="sign-up",method="post"}[5m])) by (le))`
+Query:
 
+```
+histogram_quantile(0.99, sum(rate(src_http_request_duration_seconds_bucket{route="sign-up",method="post"}[5m])) by (le))
+```
 </details>
 
 <br />
@@ -4164,8 +4785,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102912`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (code)(irate(src_http_request_duration_seconds_count{route="sign-up",method="post"}[5m]))/ ignoring (code) group_left sum(irate(src_http_request_duration_seconds_count{route="sign-out"}[5m]))*100`
+Query:
 
+```
+sum by (code)(irate(src_http_request_duration_seconds_count{route="sign-up",method="post"}[5m]))/ ignoring (code) group_left sum(irate(src_http_request_duration_seconds_count{route="sign-out"}[5m]))*100
+```
 </details>
 
 <br />
@@ -4185,8 +4809,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102920`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(irate(src_http_request_duration_seconds_count{route="sign-out"}[5m]))`
+Query:
 
+```
+sum(irate(src_http_request_duration_seconds_count{route="sign-out"}[5m]))
+```
 </details>
 
 <br />
@@ -4206,8 +4833,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102921`
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.99, sum(rate(src_http_request_duration_seconds_bucket{route="sign-out"}[5m])) by (le))`
+Query:
 
+```
+histogram_quantile(0.99, sum(rate(src_http_request_duration_seconds_bucket{route="sign-out"}[5m])) by (le))
+```
 </details>
 
 <br />
@@ -4227,8 +4857,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102922`
 <details>
 <summary>Technical details</summary>
 
-Query: ` sum by (code)(irate(src_http_request_duration_seconds_count{route="sign-out"}[5m]))/ ignoring (code) group_left sum(irate(src_http_request_duration_seconds_count{route="sign-out"}[5m]))*100`
+Query:
 
+```
+ sum by (code)(irate(src_http_request_duration_seconds_count{route="sign-out"}[5m]))/ ignoring (code) group_left sum(irate(src_http_request_duration_seconds_count{route="sign-out"}[5m]))*100
+```
 </details>
 
 <br />
@@ -4248,8 +4881,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102930`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(rate(src_frontend_account_failed_sign_in_attempts_total[1m]))`
+Query:
 
+```
+sum(rate(src_frontend_account_failed_sign_in_attempts_total[1m]))
+```
 </details>
 
 <br />
@@ -4269,8 +4905,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102931`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(rate(src_frontend_account_lockouts_total[1m]))`
+Query:
 
+```
+sum(rate(src_frontend_account_lockouts_total[1m]))
+```
 </details>
 
 <br />
@@ -4291,8 +4930,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=103000`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (route, code)(irate(src_http_request_duration_seconds_count{route=~"^completions.*"}[5m]))`
+Query:
 
+```
+sum by (route, code)(irate(src_http_request_duration_seconds_count{route=~"^completions.*"}[5m]))
+```
 </details>
 
 <br />
@@ -4312,8 +4954,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=103100`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_cloudkms_cryptographic_total[1m]))`
+Query:
 
+```
+sum(increase(src_cloudkms_cryptographic_total[1m]))
+```
 </details>
 
 <br />
@@ -4333,8 +4978,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=103101`
 <details>
 <summary>Technical details</summary>
 
-Query: `min by (kubernetes_name) (src_encryption_cache_hit_total/(src_encryption_cache_hit_total+src_encryption_cache_miss_total))`
+Query:
 
+```
+min by (kubernetes_name) (src_encryption_cache_hit_total/(src_encryption_cache_hit_total+src_encryption_cache_miss_total))
+```
 </details>
 
 <br />
@@ -4354,8 +5002,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=103102`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (kubernetes_name) (irate(src_encryption_cache_eviction_total[5m]))`
+Query:
 
+```
+sum by (kubernetes_name) (irate(src_encryption_cache_eviction_total[5m]))
+```
 </details>
 
 <br />
@@ -4375,8 +5026,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=103200`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (app_name, db_name) (src_pgsql_conns_max_open{app_name="frontend"})`
+Query:
 
+```
+sum by (app_name, db_name) (src_pgsql_conns_max_open{app_name="frontend"})
+```
 </details>
 
 <br />
@@ -4394,8 +5048,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=103201`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (app_name, db_name) (src_pgsql_conns_open{app_name="frontend"})`
+Query:
 
+```
+sum by (app_name, db_name) (src_pgsql_conns_open{app_name="frontend"})
+```
 </details>
 
 <br />
@@ -4413,8 +5070,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=103210`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (app_name, db_name) (src_pgsql_conns_in_use{app_name="frontend"})`
+Query:
 
+```
+sum by (app_name, db_name) (src_pgsql_conns_in_use{app_name="frontend"})
+```
 </details>
 
 <br />
@@ -4432,8 +5092,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=103211`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (app_name, db_name) (src_pgsql_conns_idle{app_name="frontend"})`
+Query:
 
+```
+sum by (app_name, db_name) (src_pgsql_conns_idle{app_name="frontend"})
+```
 </details>
 
 <br />
@@ -4451,8 +5114,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=103220`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (app_name, db_name) (increase(src_pgsql_conns_blocked_seconds{app_name="frontend"}[5m])) / sum by (app_name, db_name) (increase(src_pgsql_conns_waited_for{app_name="frontend"}[5m]))`
+Query:
 
+```
+sum by (app_name, db_name) (increase(src_pgsql_conns_blocked_seconds{app_name="frontend"}[5m])) / sum by (app_name, db_name) (increase(src_pgsql_conns_waited_for{app_name="frontend"}[5m]))
+```
 </details>
 
 <br />
@@ -4470,8 +5136,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=103230`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (app_name, db_name) (increase(src_pgsql_conns_closed_max_idle{app_name="frontend"}[5m]))`
+Query:
 
+```
+sum by (app_name, db_name) (increase(src_pgsql_conns_closed_max_idle{app_name="frontend"}[5m]))
+```
 </details>
 
 <br />
@@ -4489,8 +5158,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=103231`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (app_name, db_name) (increase(src_pgsql_conns_closed_max_lifetime{app_name="frontend"}[5m]))`
+Query:
 
+```
+sum by (app_name, db_name) (increase(src_pgsql_conns_closed_max_lifetime{app_name="frontend"}[5m]))
+```
 </details>
 
 <br />
@@ -4508,8 +5180,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=103232`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (app_name, db_name) (increase(src_pgsql_conns_closed_max_idle_time{app_name="frontend"}[5m]))`
+Query:
 
+```
+sum by (app_name, db_name) (increase(src_pgsql_conns_closed_max_idle_time{app_name="frontend"}[5m]))
+```
 </details>
 
 <br />
@@ -4539,8 +5214,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=103300`
 <details>
 <summary>Technical details</summary>
 
-Query: `count by(name) ((time() - container_last_seen{name=~"^(frontend|sourcegraph-frontend).*"}) > 60)`
+Query:
 
+```
+count by(name) ((time() - container_last_seen{name=~"^(frontend|sourcegraph-frontend).*"}) > 60)
+```
 </details>
 
 <br />
@@ -4558,8 +5236,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=103301`
 <details>
 <summary>Technical details</summary>
 
-Query: `cadvisor_container_cpu_usage_percentage_total{name=~"^(frontend|sourcegraph-frontend).*"}`
+Query:
 
+```
+cadvisor_container_cpu_usage_percentage_total{name=~"^(frontend|sourcegraph-frontend).*"}
+```
 </details>
 
 <br />
@@ -4577,8 +5258,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=103302`
 <details>
 <summary>Technical details</summary>
 
-Query: `cadvisor_container_memory_usage_percentage_total{name=~"^(frontend|sourcegraph-frontend).*"}`
+Query:
 
+```
+cadvisor_container_memory_usage_percentage_total{name=~"^(frontend|sourcegraph-frontend).*"}
+```
 </details>
 
 <br />
@@ -4599,8 +5283,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=103303`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by(name) (rate(container_fs_reads_total{name=~"^(frontend|sourcegraph-frontend).*"}[1h]) + rate(container_fs_writes_total{name=~"^(frontend|sourcegraph-frontend).*"}[1h]))`
+Query:
 
+```
+sum by(name) (rate(container_fs_reads_total{name=~"^(frontend|sourcegraph-frontend).*"}[1h]) + rate(container_fs_writes_total{name=~"^(frontend|sourcegraph-frontend).*"}[1h]))
+```
 </details>
 
 <br />
@@ -4620,8 +5307,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=103400`
 <details>
 <summary>Technical details</summary>
 
-Query: `quantile_over_time(0.9, cadvisor_container_cpu_usage_percentage_total{name=~"^(frontend|sourcegraph-frontend).*"}[1d])`
+Query:
 
+```
+quantile_over_time(0.9, cadvisor_container_cpu_usage_percentage_total{name=~"^(frontend|sourcegraph-frontend).*"}[1d])
+```
 </details>
 
 <br />
@@ -4639,8 +5329,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=103401`
 <details>
 <summary>Technical details</summary>
 
-Query: `max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^(frontend|sourcegraph-frontend).*"}[1d])`
+Query:
 
+```
+max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^(frontend|sourcegraph-frontend).*"}[1d])
+```
 </details>
 
 <br />
@@ -4658,8 +5351,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=103410`
 <details>
 <summary>Technical details</summary>
 
-Query: `max_over_time(cadvisor_container_cpu_usage_percentage_total{name=~"^(frontend|sourcegraph-frontend).*"}[5m])`
+Query:
 
+```
+max_over_time(cadvisor_container_cpu_usage_percentage_total{name=~"^(frontend|sourcegraph-frontend).*"}[5m])
+```
 </details>
 
 <br />
@@ -4677,8 +5373,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=103411`
 <details>
 <summary>Technical details</summary>
 
-Query: `max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^(frontend|sourcegraph-frontend).*"}[5m])`
+Query:
 
+```
+max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^(frontend|sourcegraph-frontend).*"}[5m])
+```
 </details>
 
 <br />
@@ -4699,8 +5398,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=103412`
 <details>
 <summary>Technical details</summary>
 
-Query: `max by (name) (container_oom_events_total{name=~"^(frontend|sourcegraph-frontend).*"})`
+Query:
 
+```
+max by (name) (container_oom_events_total{name=~"^(frontend|sourcegraph-frontend).*"})
+```
 </details>
 
 <br />
@@ -4722,8 +5424,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=103500`
 <details>
 <summary>Technical details</summary>
 
-Query: `max by(instance) (go_goroutines{job=~".*(frontend|sourcegraph-frontend)"})`
+Query:
 
+```
+max by(instance) (go_goroutines{job=~".*(frontend|sourcegraph-frontend)"})
+```
 </details>
 
 <br />
@@ -4741,8 +5446,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=103501`
 <details>
 <summary>Technical details</summary>
 
-Query: `max by(instance) (go_gc_duration_seconds{job=~".*(frontend|sourcegraph-frontend)"})`
+Query:
 
+```
+max by(instance) (go_gc_duration_seconds{job=~".*(frontend|sourcegraph-frontend)"})
+```
 </details>
 
 <br />
@@ -4762,8 +5470,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=103600`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by(app) (up{app=~".*(frontend|sourcegraph-frontend)"}) / count by (app) (up{app=~".*(frontend|sourcegraph-frontend)"}) * 100`
+Query:
 
+```
+sum by(app) (up{app=~".*(frontend|sourcegraph-frontend)"}) / count by (app) (up{app=~".*(frontend|sourcegraph-frontend)"}) * 100
+```
 </details>
 
 <br />
@@ -4785,8 +5496,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=103700`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (ranked) (increase(src_search_ranking_result_clicked_count[6h]))`
+Query:
 
+```
+sum by (ranked) (increase(src_search_ranking_result_clicked_count[6h]))
+```
 </details>
 
 <br />
@@ -4806,8 +5520,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=103701`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (ranked) (increase(src_search_ranking_result_clicked_bucket{le="1",resultsLength=">3"}[6h])) / sum by (ranked) (increase(src_search_ranking_result_clicked_count[6h])) * 100`
+Query:
 
+```
+sum by (ranked) (increase(src_search_ranking_result_clicked_bucket{le="1",resultsLength=">3"}[6h])) / sum by (ranked) (increase(src_search_ranking_result_clicked_count[6h])) * 100
+```
 </details>
 
 <br />
@@ -4827,8 +5544,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=103702`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (ranked) (increase(src_search_ranking_result_clicked_bucket{le="3",resultsLength=">3"}[6h])) / sum by (ranked) (increase(src_search_ranking_result_clicked_count[6h])) * 100`
+Query:
 
+```
+sum by (ranked) (increase(src_search_ranking_result_clicked_bucket{le="3",resultsLength=">3"}[6h])) / sum by (ranked) (increase(src_search_ranking_result_clicked_count[6h])) * 100
+```
 </details>
 
 <br />
@@ -4848,8 +5568,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=103710`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_search_ranking_result_clicked_count{type="repo"}[6h])) / sum(increase(src_search_ranking_result_clicked_count[6h])) * 100`
+Query:
 
+```
+sum(increase(src_search_ranking_result_clicked_count{type="repo"}[6h])) / sum(increase(src_search_ranking_result_clicked_count[6h])) * 100
+```
 </details>
 
 <br />
@@ -4869,8 +5592,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=103711`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(zoekt_final_aggregate_size_count{reason="timer_expired"}[1d])) / sum(increase(zoekt_final_aggregate_size_count[1d])) * 100`
+Query:
 
+```
+sum(increase(zoekt_final_aggregate_size_count{reason="timer_expired"}[1d])) / sum(increase(zoekt_final_aggregate_size_count[1d])) * 100
+```
 </details>
 
 <br />
@@ -4890,8 +5616,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=103800`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_email_send{success="false"}[30m])) / sum(increase(src_email_send[30m])) * 100`
+Query:
 
+```
+sum(increase(src_email_send{success="false"}[30m])) / sum(increase(src_email_send[30m])) * 100
+```
 </details>
 
 <br />
@@ -4911,8 +5640,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=103810`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum (increase(src_email_send{success="true"}[30m]))`
+Query:
 
+```
+sum (increase(src_email_send{success="true"}[30m]))
+```
 </details>
 
 <br />
@@ -4932,8 +5664,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=103811`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (email_source) (increase(src_email_send{success="true"}[30m]))`
+Query:
 
+```
+sum by (email_source) (increase(src_email_send{success="true"}[30m]))
+```
 </details>
 
 <br />
@@ -4955,8 +5690,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=103900`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(rate(src_search_response_latency_seconds_sum{source=~`searchblitz.*`, status=`success`}[2h])) / sum(rate(src_search_response_latency_seconds_count{source=~`searchblitz.*`, status=`success`}[2h]))`
+Query:
 
+```
+sum(rate(src_search_response_latency_seconds_sum{source=~`searchblitz.*`, status=`success`}[2h])) / sum(rate(src_search_response_latency_seconds_count{source=~`searchblitz.*`, status=`success`}[2h]))
+```
 </details>
 
 <br />
@@ -4976,8 +5714,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=103901`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(rate(src_search_streaming_latency_seconds_sum{source=~"searchblitz.*"}[2h])) / sum(rate(src_search_streaming_latency_seconds_count{source=~"searchblitz.*"}[2h]))`
+Query:
 
+```
+sum(rate(src_search_streaming_latency_seconds_sum{source=~"searchblitz.*"}[2h])) / sum(rate(src_search_streaming_latency_seconds_count{source=~"searchblitz.*"}[2h]))
+```
 </details>
 
 <br />
@@ -4997,8 +5738,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=103910`
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.90, sum by (le)(label_replace(rate(src_search_response_latency_seconds_bucket{source=~"searchblitz.*", status="success"}[2h]), "source", "$1", "source", "searchblitz_(.*)")))`
+Query:
 
+```
+histogram_quantile(0.90, sum by (le)(label_replace(rate(src_search_response_latency_seconds_bucket{source=~"searchblitz.*", status="success"}[2h]), "source", "$1", "source", "searchblitz_(.*)")))
+```
 </details>
 
 <br />
@@ -5018,8 +5762,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=103911`
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.90, sum by (le)(label_replace(rate(src_search_streaming_latency_seconds_bucket{source=~"searchblitz.*"}[2h]), "source", "$1", "source", "searchblitz_(.*)")))`
+Query:
 
+```
+histogram_quantile(0.90, sum by (le)(label_replace(rate(src_search_streaming_latency_seconds_bucket{source=~"searchblitz.*"}[2h]), "source", "$1", "source", "searchblitz_(.*)")))
+```
 </details>
 
 <br />
@@ -5039,8 +5786,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=103920`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(rate(src_search_response_latency_seconds_sum{source=~"searchblitz.*", status="success"}[$sentinel_sampling_duration])) by (source) / sum(rate(src_search_response_latency_seconds_count{source=~"searchblitz.*", status="success"}[$sentinel_sampling_duration])) by (source)`
+Query:
 
+```
+sum(rate(src_search_response_latency_seconds_sum{source=~"searchblitz.*", status="success"}[$sentinel_sampling_duration])) by (source) / sum(rate(src_search_response_latency_seconds_count{source=~"searchblitz.*", status="success"}[$sentinel_sampling_duration])) by (source)
+```
 </details>
 
 <br />
@@ -5060,8 +5810,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=103921`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(rate(src_search_streaming_latency_seconds_sum{source=~"searchblitz.*"}[$sentinel_sampling_duration])) by (source) / sum(rate(src_search_streaming_latency_seconds_count{source=~"searchblitz.*"}[$sentinel_sampling_duration])) by (source)`
+Query:
 
+```
+sum(rate(src_search_streaming_latency_seconds_sum{source=~"searchblitz.*"}[$sentinel_sampling_duration])) by (source) / sum(rate(src_search_streaming_latency_seconds_count{source=~"searchblitz.*"}[$sentinel_sampling_duration])) by (source)
+```
 </details>
 
 <br />
@@ -5081,8 +5834,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=103930`
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.90, sum(rate(src_search_response_latency_seconds_bucket{source=~"searchblitz.*", status="success"}[$sentinel_sampling_duration])) by (le, source))`
+Query:
 
+```
+histogram_quantile(0.90, sum(rate(src_search_response_latency_seconds_bucket{source=~"searchblitz.*", status="success"}[$sentinel_sampling_duration])) by (le, source))
+```
 </details>
 
 <br />
@@ -5102,8 +5858,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=103931`
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.90, sum(rate(src_search_streaming_latency_seconds_bucket{source=~"searchblitz.*"}[$sentinel_sampling_duration])) by (le, source))`
+Query:
 
+```
+histogram_quantile(0.90, sum(rate(src_search_streaming_latency_seconds_bucket{source=~"searchblitz.*"}[$sentinel_sampling_duration])) by (le, source))
+```
 </details>
 
 <br />
@@ -5123,8 +5882,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=103940`
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.90, sum(rate(src_search_response_latency_seconds_bucket{source=~`searchblitz.*`, status!=`success`}[$sentinel_sampling_duration])) by (le, source))`
+Query:
 
+```
+histogram_quantile(0.90, sum(rate(src_search_response_latency_seconds_bucket{source=~`searchblitz.*`, status!=`success`}[$sentinel_sampling_duration])) by (le, source))
+```
 </details>
 
 <br />
@@ -5144,8 +5906,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=103950`
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.75, sum(rate(src_search_response_latency_seconds_bucket{source=~"searchblitz.*", status="success"}[$sentinel_sampling_duration])) by (le, source))`
+Query:
 
+```
+histogram_quantile(0.75, sum(rate(src_search_response_latency_seconds_bucket{source=~"searchblitz.*", status="success"}[$sentinel_sampling_duration])) by (le, source))
+```
 </details>
 
 <br />
@@ -5165,8 +5930,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=103951`
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.75, sum(rate(src_search_streaming_latency_seconds_bucket{source=~"searchblitz.*"}[$sentinel_sampling_duration])) by (le, source))`
+Query:
 
+```
+histogram_quantile(0.75, sum(rate(src_search_streaming_latency_seconds_bucket{source=~"searchblitz.*"}[$sentinel_sampling_duration])) by (le, source))
+```
 </details>
 
 <br />
@@ -5186,8 +5954,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=103960`
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.75, sum(rate(src_search_response_latency_seconds_bucket{source=~`searchblitz.*`, status!=`success`}[$sentinel_sampling_duration])) by (le, source))`
+Query:
 
+```
+histogram_quantile(0.75, sum(rate(src_search_response_latency_seconds_bucket{source=~`searchblitz.*`, status!=`success`}[$sentinel_sampling_duration])) by (le, source))
+```
 </details>
 
 <br />
@@ -5207,8 +5978,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=103970`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(rate(src_graphql_search_response{source=~"searchblitz.*", status!="success"}[$sentinel_sampling_duration])) by (status)`
+Query:
 
+```
+sum(rate(src_graphql_search_response{source=~"searchblitz.*", status!="success"}[$sentinel_sampling_duration])) by (status)
+```
 </details>
 
 <br />
@@ -5234,8 +6008,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=104000`
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.95, sum  (rate(src_http_request_duration_seconds_bucket{route=~"webhooks|github.webhooks|gitlab.webhooks|bitbucketServer.webhooks|bitbucketCloud.webhooks"}[5m])) by (le, route))`
+Query:
 
+```
+histogram_quantile(0.95, sum  (rate(src_http_request_duration_seconds_bucket{route=~"webhooks|github.webhooks|gitlab.webhooks|bitbucketServer.webhooks|bitbucketCloud.webhooks"}[5m])) by (le, route))
+```
 </details>
 
 <br />
@@ -5255,8 +6032,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=104100`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_insights_aggregations_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))`
+Query:
 
+```
+sum(increase(src_insights_aggregations_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))
+```
 </details>
 
 <br />
@@ -5274,8 +6054,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=104101`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum  by (le)(rate(src_insights_aggregations_duration_seconds_bucket{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))`
+Query:
 
+```
+sum  by (le)(rate(src_insights_aggregations_duration_seconds_bucket{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))
+```
 </details>
 
 <br />
@@ -5293,8 +6076,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=104102`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_insights_aggregations_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))`
+Query:
 
+```
+sum(increase(src_insights_aggregations_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))
+```
 </details>
 
 <br />
@@ -5312,8 +6098,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=104103`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_insights_aggregations_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) / (sum(increase(src_insights_aggregations_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) + sum(increase(src_insights_aggregations_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))) * 100`
+Query:
 
+```
+sum(increase(src_insights_aggregations_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) / (sum(increase(src_insights_aggregations_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) + sum(increase(src_insights_aggregations_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -5331,8 +6120,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=104110`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op,extended_mode)(increase(src_insights_aggregations_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))`
+Query:
 
+```
+sum by (op,extended_mode)(increase(src_insights_aggregations_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))
+```
 </details>
 
 <br />
@@ -5350,8 +6142,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=104111`
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.99, sum  by (le,op,extended_mode)(rate(src_insights_aggregations_duration_seconds_bucket{job=~"^(frontend|sourcegraph-frontend).*"}[5m])))`
+Query:
 
+```
+histogram_quantile(0.99, sum  by (le,op,extended_mode)(rate(src_insights_aggregations_duration_seconds_bucket{job=~"^(frontend|sourcegraph-frontend).*"}[5m])))
+```
 </details>
 
 <br />
@@ -5369,8 +6164,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=104112`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op,extended_mode)(increase(src_insights_aggregations_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))`
+Query:
 
+```
+sum by (op,extended_mode)(increase(src_insights_aggregations_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))
+```
 </details>
 
 <br />
@@ -5388,8 +6186,11 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=104113`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op,extended_mode)(increase(src_insights_aggregations_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) / (sum by (op,extended_mode)(increase(src_insights_aggregations_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) + sum by (op,extended_mode)(increase(src_insights_aggregations_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))) * 100`
+Query:
 
+```
+sum by (op,extended_mode)(increase(src_insights_aggregations_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) / (sum by (op,extended_mode)(increase(src_insights_aggregations_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m])) + sum by (op,extended_mode)(increase(src_insights_aggregations_errors_total{job=~"^(frontend|sourcegraph-frontend).*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -5415,8 +6216,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10000
 <details>
 <summary>Technical details</summary>
 
-Query: `go_goroutines{app="gitserver", instance=~`${shard:regex}`}`
+Query:
 
+```
+go_goroutines{app="gitserver", instance=~`${shard:regex}`}
+```
 </details>
 
 <br />
@@ -5436,8 +6240,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10001
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (container_label_io_kubernetes_pod_name) ((rate(container_cpu_cfs_throttled_periods_total{container_label_io_kubernetes_container_name="gitserver", container_label_io_kubernetes_pod_name=~`${shard:regex}`}[5m]) / rate(container_cpu_cfs_periods_total{container_label_io_kubernetes_container_name="gitserver", container_label_io_kubernetes_pod_name=~`${shard:regex}`}[5m])) * 100)`
+Query:
 
+```
+sum by (container_label_io_kubernetes_pod_name) ((rate(container_cpu_cfs_throttled_periods_total{container_label_io_kubernetes_container_name="gitserver", container_label_io_kubernetes_pod_name=~`${shard:regex}`}[5m]) / rate(container_cpu_cfs_periods_total{container_label_io_kubernetes_container_name="gitserver", container_label_io_kubernetes_pod_name=~`${shard:regex}`}[5m])) * 100)
+```
 </details>
 
 <br />
@@ -5460,8 +6267,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10001
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (container_label_io_kubernetes_pod_name) (rate(container_cpu_usage_seconds_total{container_label_io_kubernetes_container_name="gitserver", container_label_io_kubernetes_pod_name=~`${shard:regex}`}[5m]))`
+Query:
 
+```
+sum by (container_label_io_kubernetes_pod_name) (rate(container_cpu_usage_seconds_total{container_label_io_kubernetes_container_name="gitserver", container_label_io_kubernetes_pod_name=~`${shard:regex}`}[5m]))
+```
 </details>
 
 <br />
@@ -5481,8 +6291,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10002
 <details>
 <summary>Technical details</summary>
 
-Query: `(src_gitserver_disk_space_available{instance=~`${shard:regex}`} / src_gitserver_disk_space_total{instance=~`${shard:regex}`}) * 100`
+Query:
 
+```
+(src_gitserver_disk_space_available{instance=~`${shard:regex}`} / src_gitserver_disk_space_total{instance=~`${shard:regex}`}) * 100
+```
 </details>
 
 <br />
@@ -5502,8 +6315,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10003
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (instance, cmd) (src_gitserver_exec_running{instance=~`${shard:regex}`})`
+Query:
 
+```
+sum by (instance, cmd) (src_gitserver_exec_running{instance=~`${shard:regex}`})
+```
 </details>
 
 <br />
@@ -5523,8 +6339,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10003
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (cmd) (rate(src_gitserver_exec_duration_seconds_count{instance=~`${shard:regex}`}[5m]))`
+Query:
 
+```
+sum by (cmd) (rate(src_gitserver_exec_duration_seconds_count{instance=~`${shard:regex}`}[5m]))
+```
 </details>
 
 <br />
@@ -5544,8 +6363,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10004
 <details>
 <summary>Technical details</summary>
 
-Query: `max(src_gitserver_echo_duration_seconds)`
+Query:
 
+```
+max(src_gitserver_echo_duration_seconds)
+```
 </details>
 
 <br />
@@ -5567,8 +6389,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10004
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(rate(src_gitserver_repo_corrupted[5m]))`
+Query:
 
+```
+sum(rate(src_gitserver_repo_corrupted[5m]))
+```
 </details>
 
 <br />
@@ -5586,8 +6411,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10005
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(src_gitserver_clone_queue)`
+Query:
 
+```
+sum(src_gitserver_clone_queue)
+```
 </details>
 
 <br />
@@ -5609,8 +6437,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10005
 <details>
 <summary>Technical details</summary>
 
-Query: `src_gitserver_repo_count`
+Query:
 
+```
+src_gitserver_repo_count
+```
 </details>
 
 <br />
@@ -5632,8 +6463,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10010
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.95, sum(rate(src_gitserver_gitservice_duration_seconds_bucket{type=`gitserver`, error=`false`}[5m])) by (le))`
+Query:
 
+```
+histogram_quantile(0.95, sum(rate(src_gitserver_gitservice_duration_seconds_bucket{type=`gitserver`, error=`false`}[5m])) by (le))
+```
 </details>
 
 <br />
@@ -5653,8 +6487,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10010
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.95, sum(rate(src_gitserver_gitservice_duration_seconds_bucket{type=`gitserver`, error=`false`, instance=~`${shard:regex}`}[5m])) by (le, instance))`
+Query:
 
+```
+histogram_quantile(0.95, sum(rate(src_gitserver_gitservice_duration_seconds_bucket{type=`gitserver`, error=`false`, instance=~`${shard:regex}`}[5m])) by (le, instance))
+```
 </details>
 
 <br />
@@ -5674,8 +6511,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10011
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.95, sum(rate(src_gitserver_gitservice_duration_seconds_bucket{type=`gitserver`, error=`true`}[5m])) by (le))`
+Query:
 
+```
+histogram_quantile(0.95, sum(rate(src_gitserver_gitservice_duration_seconds_bucket{type=`gitserver`, error=`true`}[5m])) by (le))
+```
 </details>
 
 <br />
@@ -5695,8 +6535,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10011
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.95, sum(rate(src_gitserver_gitservice_duration_seconds_bucket{type=`gitserver`, error=`true`, instance=~`${shard:regex}`}[5m])) by (le, instance))`
+Query:
 
+```
+histogram_quantile(0.95, sum(rate(src_gitserver_gitservice_duration_seconds_bucket{type=`gitserver`, error=`true`, instance=~`${shard:regex}`}[5m])) by (le, instance))
+```
 </details>
 
 <br />
@@ -5716,8 +6559,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10012
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(rate(src_gitserver_gitservice_duration_seconds_count{type=`gitserver`, error=`false`}[5m]))`
+Query:
 
+```
+sum(rate(src_gitserver_gitservice_duration_seconds_count{type=`gitserver`, error=`false`}[5m]))
+```
 </details>
 
 <br />
@@ -5737,8 +6583,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10012
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(rate(src_gitserver_gitservice_duration_seconds_count{type=`gitserver`, error=`false`, instance=~`${shard:regex}`}[5m]))`
+Query:
 
+```
+sum(rate(src_gitserver_gitservice_duration_seconds_count{type=`gitserver`, error=`false`, instance=~`${shard:regex}`}[5m]))
+```
 </details>
 
 <br />
@@ -5758,8 +6607,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10013
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(rate(src_gitserver_gitservice_duration_seconds_count{type=`gitserver`, error=`true`}[5m]))`
+Query:
 
+```
+sum(rate(src_gitserver_gitservice_duration_seconds_count{type=`gitserver`, error=`true`}[5m]))
+```
 </details>
 
 <br />
@@ -5779,8 +6631,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10013
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(rate(src_gitserver_gitservice_duration_seconds_count{type=`gitserver`, error=`true`, instance=~`${shard:regex}`}[5m]))`
+Query:
 
+```
+sum(rate(src_gitserver_gitservice_duration_seconds_count{type=`gitserver`, error=`true`, instance=~`${shard:regex}`}[5m]))
+```
 </details>
 
 <br />
@@ -5800,8 +6655,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10014
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(src_gitserver_gitservice_running{type=`gitserver`})`
+Query:
 
+```
+sum(src_gitserver_gitservice_running{type=`gitserver`})
+```
 </details>
 
 <br />
@@ -5821,8 +6679,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10014
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(src_gitserver_gitservice_running{type=`gitserver`, instance=~`${shard:regex}`}) by (instance)`
+Query:
 
+```
+sum(src_gitserver_gitservice_running{type=`gitserver`, instance=~`${shard:regex}`}) by (instance)
+```
 </details>
 
 <br />
@@ -5844,8 +6705,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10020
 <details>
 <summary>Technical details</summary>
 
-Query: `max by (instance) (src_gitserver_janitor_running{instance=~`${shard:regex}`})`
+Query:
 
+```
+max by (instance) (src_gitserver_janitor_running{instance=~`${shard:regex}`})
+```
 </details>
 
 <br />
@@ -5865,8 +6729,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10021
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.95, sum(rate(src_gitserver_janitor_job_duration_seconds_bucket{instance=~`${shard:regex}`}[5m])) by (le, job_name))`
+Query:
 
+```
+histogram_quantile(0.95, sum(rate(src_gitserver_janitor_job_duration_seconds_bucket{instance=~`${shard:regex}`}[5m])) by (le, job_name))
+```
 </details>
 
 <br />
@@ -5886,8 +6753,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10022
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (job_name) (rate(src_gitserver_janitor_job_duration_seconds_count{instance=~`${shard:regex}`,success="false"}[5m]))`
+Query:
 
+```
+sum by (job_name) (rate(src_gitserver_janitor_job_duration_seconds_count{instance=~`${shard:regex}`,success="false"}[5m]))
+```
 </details>
 
 <br />
@@ -5907,8 +6777,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10023
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (instance) (rate(src_gitserver_repos_removed_disk_pressure{instance=~`${shard:regex}`}[5m]))`
+Query:
 
+```
+sum by (instance) (rate(src_gitserver_repos_removed_disk_pressure{instance=~`${shard:regex}`}[5m]))
+```
 </details>
 
 <br />
@@ -5928,8 +6801,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10024
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (instance) (increase(src_gitserver_non_existing_repos_removed[5m]))`
+Query:
 
+```
+sum by (instance) (increase(src_gitserver_non_existing_repos_removed[5m]))
+```
 </details>
 
 <br />
@@ -5949,8 +6825,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10025
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (reason) (rate(src_gitserver_maintenance_status{success="true"}[1h]))`
+Query:
 
+```
+sum by (reason) (rate(src_gitserver_maintenance_status{success="true"}[1h]))
+```
 </details>
 
 <br />
@@ -5970,8 +6849,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10026
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (skipped) (rate(src_gitserver_prune_status{success="true"}[1h]))`
+Query:
 
+```
+sum by (skipped) (rate(src_gitserver_prune_status{success="true"}[1h]))
+```
 </details>
 
 <br />
@@ -5993,8 +6875,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10030
 <details>
 <summary>Technical details</summary>
 
-Query: `rate(src_gitserver_search_latency_seconds_sum[5m]) / rate(src_gitserver_search_latency_seconds_count[5m])`
+Query:
 
+```
+rate(src_gitserver_search_latency_seconds_sum[5m]) / rate(src_gitserver_search_latency_seconds_count[5m])
+```
 </details>
 
 <br />
@@ -6014,8 +6899,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10030
 <details>
 <summary>Technical details</summary>
 
-Query: `rate(src_gitserver_search_duration_seconds_sum[5m]) / rate(src_gitserver_search_duration_seconds_count[5m])`
+Query:
 
+```
+rate(src_gitserver_search_duration_seconds_sum[5m]) / rate(src_gitserver_search_duration_seconds_count[5m])
+```
 </details>
 
 <br />
@@ -6035,8 +6923,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10031
 <details>
 <summary>Technical details</summary>
 
-Query: `rate(src_gitserver_search_latency_seconds_count{instance=~`${shard:regex}`}[5m])`
+Query:
 
+```
+rate(src_gitserver_search_latency_seconds_count{instance=~`${shard:regex}`}[5m])
+```
 </details>
 
 <br />
@@ -6056,8 +6947,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10031
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (instance) (src_gitserver_search_running{instance=~`${shard:regex}`})`
+Query:
 
+```
+sum by (instance) (src_gitserver_search_running{instance=~`${shard:regex}`})
+```
 </details>
 
 <br />
@@ -6079,8 +6973,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10040
 <details>
 <summary>Technical details</summary>
 
-Query: `src_gitserver_backend_concurrent_operations`
+Query:
 
+```
+src_gitserver_backend_concurrent_operations
+```
 </details>
 
 <br />
@@ -6098,8 +6995,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10041
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_gitserver_backend_total{job=~"^gitserver.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_gitserver_backend_total{job=~"^gitserver.*"}[5m]))
+```
 </details>
 
 <br />
@@ -6117,8 +7017,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10041
 <details>
 <summary>Technical details</summary>
 
-Query: `sum  by (le)(rate(src_gitserver_backend_duration_seconds_bucket{job=~"^gitserver.*"}[5m]))`
+Query:
 
+```
+sum  by (le)(rate(src_gitserver_backend_duration_seconds_bucket{job=~"^gitserver.*"}[5m]))
+```
 </details>
 
 <br />
@@ -6136,8 +7039,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10041
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_gitserver_backend_errors_total{job=~"^gitserver.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_gitserver_backend_errors_total{job=~"^gitserver.*"}[5m]))
+```
 </details>
 
 <br />
@@ -6155,8 +7061,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10041
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_gitserver_backend_errors_total{job=~"^gitserver.*"}[5m])) / (sum(increase(src_gitserver_backend_total{job=~"^gitserver.*"}[5m])) + sum(increase(src_gitserver_backend_errors_total{job=~"^gitserver.*"}[5m]))) * 100`
+Query:
 
+```
+sum(increase(src_gitserver_backend_errors_total{job=~"^gitserver.*"}[5m])) / (sum(increase(src_gitserver_backend_total{job=~"^gitserver.*"}[5m])) + sum(increase(src_gitserver_backend_errors_total{job=~"^gitserver.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -6174,8 +7083,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10042
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_gitserver_backend_total{job=~"^gitserver.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_gitserver_backend_total{job=~"^gitserver.*"}[5m]))
+```
 </details>
 
 <br />
@@ -6193,8 +7105,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10042
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.99, sum  by (le,op)(rate(src_gitserver_backend_duration_seconds_bucket{job=~"^gitserver.*"}[5m])))`
+Query:
 
+```
+histogram_quantile(0.99, sum  by (le,op)(rate(src_gitserver_backend_duration_seconds_bucket{job=~"^gitserver.*"}[5m])))
+```
 </details>
 
 <br />
@@ -6212,8 +7127,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10042
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_gitserver_backend_errors_total{job=~"^gitserver.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_gitserver_backend_errors_total{job=~"^gitserver.*"}[5m]))
+```
 </details>
 
 <br />
@@ -6231,8 +7149,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10042
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_gitserver_backend_errors_total{job=~"^gitserver.*"}[5m])) / (sum by (op)(increase(src_gitserver_backend_total{job=~"^gitserver.*"}[5m])) + sum by (op)(increase(src_gitserver_backend_errors_total{job=~"^gitserver.*"}[5m]))) * 100`
+Query:
 
+```
+sum by (op)(increase(src_gitserver_backend_errors_total{job=~"^gitserver.*"}[5m])) / (sum by (op)(increase(src_gitserver_backend_total{job=~"^gitserver.*"}[5m])) + sum by (op)(increase(src_gitserver_backend_errors_total{job=~"^gitserver.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -6252,8 +7173,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10050
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_gitserver_client_total{job=~"^*.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_gitserver_client_total{job=~"^*.*"}[5m]))
+```
 </details>
 
 <br />
@@ -6271,8 +7195,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10050
 <details>
 <summary>Technical details</summary>
 
-Query: `sum  by (le)(rate(src_gitserver_client_duration_seconds_bucket{job=~"^*.*"}[5m]))`
+Query:
 
+```
+sum  by (le)(rate(src_gitserver_client_duration_seconds_bucket{job=~"^*.*"}[5m]))
+```
 </details>
 
 <br />
@@ -6290,8 +7217,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10050
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_gitserver_client_errors_total{job=~"^*.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_gitserver_client_errors_total{job=~"^*.*"}[5m]))
+```
 </details>
 
 <br />
@@ -6309,8 +7239,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10050
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_gitserver_client_errors_total{job=~"^*.*"}[5m])) / (sum(increase(src_gitserver_client_total{job=~"^*.*"}[5m])) + sum(increase(src_gitserver_client_errors_total{job=~"^*.*"}[5m]))) * 100`
+Query:
 
+```
+sum(increase(src_gitserver_client_errors_total{job=~"^*.*"}[5m])) / (sum(increase(src_gitserver_client_total{job=~"^*.*"}[5m])) + sum(increase(src_gitserver_client_errors_total{job=~"^*.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -6328,8 +7261,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10051
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op,scope)(increase(src_gitserver_client_total{job=~"^*.*"}[5m]))`
+Query:
 
+```
+sum by (op,scope)(increase(src_gitserver_client_total{job=~"^*.*"}[5m]))
+```
 </details>
 
 <br />
@@ -6347,8 +7283,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10051
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.99, sum  by (le,op,scope)(rate(src_gitserver_client_duration_seconds_bucket{job=~"^*.*"}[5m])))`
+Query:
 
+```
+histogram_quantile(0.99, sum  by (le,op,scope)(rate(src_gitserver_client_duration_seconds_bucket{job=~"^*.*"}[5m])))
+```
 </details>
 
 <br />
@@ -6366,8 +7305,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10051
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op,scope)(increase(src_gitserver_client_errors_total{job=~"^*.*"}[5m]))`
+Query:
 
+```
+sum by (op,scope)(increase(src_gitserver_client_errors_total{job=~"^*.*"}[5m]))
+```
 </details>
 
 <br />
@@ -6385,8 +7327,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10051
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op,scope)(increase(src_gitserver_client_errors_total{job=~"^*.*"}[5m])) / (sum by (op,scope)(increase(src_gitserver_client_total{job=~"^*.*"}[5m])) + sum by (op,scope)(increase(src_gitserver_client_errors_total{job=~"^*.*"}[5m]))) * 100`
+Query:
 
+```
+sum by (op,scope)(increase(src_gitserver_client_errors_total{job=~"^*.*"}[5m])) / (sum by (op,scope)(increase(src_gitserver_client_total{job=~"^*.*"}[5m])) + sum by (op,scope)(increase(src_gitserver_client_errors_total{job=~"^*.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -6410,8 +7355,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10060
 <details>
 <summary>Technical details</summary>
 
-Query: `(max by (instance) (gitserver_mount_point_info{mount_name="reposDir",instance=~`${shard:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_reads_completed_total{instance=~`node-exporter.*`}[1m])))))`
+Query:
 
+```
+(max by (instance) (gitserver_mount_point_info{mount_name="reposDir",instance=~`${shard:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_reads_completed_total{instance=~`node-exporter.*`}[1m])))))
+```
 </details>
 
 <br />
@@ -6433,8 +7381,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10060
 <details>
 <summary>Technical details</summary>
 
-Query: `(max by (instance) (gitserver_mount_point_info{mount_name="reposDir",instance=~`${shard:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_writes_completed_total{instance=~`node-exporter.*`}[1m])))))`
+Query:
 
+```
+(max by (instance) (gitserver_mount_point_info{mount_name="reposDir",instance=~`${shard:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_writes_completed_total{instance=~`node-exporter.*`}[1m])))))
+```
 </details>
 
 <br />
@@ -6456,8 +7407,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10061
 <details>
 <summary>Technical details</summary>
 
-Query: `(max by (instance) (gitserver_mount_point_info{mount_name="reposDir",instance=~`${shard:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_read_bytes_total{instance=~`node-exporter.*`}[1m])))))`
+Query:
 
+```
+(max by (instance) (gitserver_mount_point_info{mount_name="reposDir",instance=~`${shard:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_read_bytes_total{instance=~`node-exporter.*`}[1m])))))
+```
 </details>
 
 <br />
@@ -6479,8 +7433,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10061
 <details>
 <summary>Technical details</summary>
 
-Query: `(max by (instance) (gitserver_mount_point_info{mount_name="reposDir",instance=~`${shard:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_written_bytes_total{instance=~`node-exporter.*`}[1m])))))`
+Query:
 
+```
+(max by (instance) (gitserver_mount_point_info{mount_name="reposDir",instance=~`${shard:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_written_bytes_total{instance=~`node-exporter.*`}[1m])))))
+```
 </details>
 
 <br />
@@ -6502,8 +7459,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10062
 <details>
 <summary>Technical details</summary>
 
-Query: `(((max by (instance) (gitserver_mount_point_info{mount_name="reposDir",instance=~`${shard:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_read_time_seconds_total{instance=~`node-exporter.*`}[1m])))))) / ((max by (instance) (gitserver_mount_point_info{mount_name="reposDir",instance=~`${shard:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_reads_completed_total{instance=~`node-exporter.*`}[1m])))))))`
+Query:
 
+```
+(((max by (instance) (gitserver_mount_point_info{mount_name="reposDir",instance=~`${shard:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_read_time_seconds_total{instance=~`node-exporter.*`}[1m])))))) / ((max by (instance) (gitserver_mount_point_info{mount_name="reposDir",instance=~`${shard:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_reads_completed_total{instance=~`node-exporter.*`}[1m])))))))
+```
 </details>
 
 <br />
@@ -6525,8 +7485,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10062
 <details>
 <summary>Technical details</summary>
 
-Query: `(((max by (instance) (gitserver_mount_point_info{mount_name="reposDir",instance=~`${shard:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_write_time_seconds_total{instance=~`node-exporter.*`}[1m])))))) / ((max by (instance) (gitserver_mount_point_info{mount_name="reposDir",instance=~`${shard:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_writes_completed_total{instance=~`node-exporter.*`}[1m])))))))`
+Query:
 
+```
+(((max by (instance) (gitserver_mount_point_info{mount_name="reposDir",instance=~`${shard:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_write_time_seconds_total{instance=~`node-exporter.*`}[1m])))))) / ((max by (instance) (gitserver_mount_point_info{mount_name="reposDir",instance=~`${shard:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_writes_completed_total{instance=~`node-exporter.*`}[1m])))))))
+```
 </details>
 
 <br />
@@ -6548,8 +7511,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10063
 <details>
 <summary>Technical details</summary>
 
-Query: `(((max by (instance) (gitserver_mount_point_info{mount_name="reposDir",instance=~`${shard:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_read_bytes_total{instance=~`node-exporter.*`}[1m])))))) / ((max by (instance) (gitserver_mount_point_info{mount_name="reposDir",instance=~`${shard:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_reads_completed_total{instance=~`node-exporter.*`}[1m])))))))`
+Query:
 
+```
+(((max by (instance) (gitserver_mount_point_info{mount_name="reposDir",instance=~`${shard:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_read_bytes_total{instance=~`node-exporter.*`}[1m])))))) / ((max by (instance) (gitserver_mount_point_info{mount_name="reposDir",instance=~`${shard:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_reads_completed_total{instance=~`node-exporter.*`}[1m])))))))
+```
 </details>
 
 <br />
@@ -6571,8 +7537,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10063
 <details>
 <summary>Technical details</summary>
 
-Query: `(((max by (instance) (gitserver_mount_point_info{mount_name="reposDir",instance=~`${shard:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_written_bytes_total{instance=~`node-exporter.*`}[1m])))))) / ((max by (instance) (gitserver_mount_point_info{mount_name="reposDir",instance=~`${shard:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_writes_completed_total{instance=~`node-exporter.*`}[1m])))))))`
+Query:
 
+```
+(((max by (instance) (gitserver_mount_point_info{mount_name="reposDir",instance=~`${shard:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_written_bytes_total{instance=~`node-exporter.*`}[1m])))))) / ((max by (instance) (gitserver_mount_point_info{mount_name="reposDir",instance=~`${shard:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_writes_completed_total{instance=~`node-exporter.*`}[1m])))))))
+```
 </details>
 
 <br />
@@ -6594,8 +7563,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10064
 <details>
 <summary>Technical details</summary>
 
-Query: `(max by (instance) (gitserver_mount_point_info{mount_name="reposDir",instance=~`${shard:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_reads_merged_total{instance=~`node-exporter.*`}[1m])))))`
+Query:
 
+```
+(max by (instance) (gitserver_mount_point_info{mount_name="reposDir",instance=~`${shard:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_reads_merged_total{instance=~`node-exporter.*`}[1m])))))
+```
 </details>
 
 <br />
@@ -6617,8 +7589,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10064
 <details>
 <summary>Technical details</summary>
 
-Query: `(max by (instance) (gitserver_mount_point_info{mount_name="reposDir",instance=~`${shard:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_writes_merged_total{instance=~`node-exporter.*`}[1m])))))`
+Query:
 
+```
+(max by (instance) (gitserver_mount_point_info{mount_name="reposDir",instance=~`${shard:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_writes_merged_total{instance=~`node-exporter.*`}[1m])))))
+```
 </details>
 
 <br />
@@ -6640,8 +7615,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10065
 <details>
 <summary>Technical details</summary>
 
-Query: `(max by (instance) (gitserver_mount_point_info{mount_name="reposDir",instance=~`${shard:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_io_time_weighted_seconds_total{instance=~`node-exporter.*`}[1m])))))`
+Query:
 
+```
+(max by (instance) (gitserver_mount_point_info{mount_name="reposDir",instance=~`${shard:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_io_time_weighted_seconds_total{instance=~`node-exporter.*`}[1m])))))
+```
 </details>
 
 <br />
@@ -6663,8 +7641,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10070
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(rate(grpc_server_started_total{instance=~`${shard:regex}`,grpc_service=~"gitserver.v1.GitserverService"}[2m]))`
+Query:
 
+```
+sum(rate(grpc_server_started_total{instance=~`${shard:regex}`,grpc_service=~"gitserver.v1.GitserverService"}[2m]))
+```
 </details>
 
 <br />
@@ -6684,8 +7665,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10070
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(rate(grpc_server_started_total{grpc_method=~`${gitserver_method:regex}`,instance=~`${shard:regex}`,grpc_service=~"gitserver.v1.GitserverService"}[2m])) by (grpc_method)`
+Query:
 
+```
+sum(rate(grpc_server_started_total{grpc_method=~`${gitserver_method:regex}`,instance=~`${shard:regex}`,grpc_service=~"gitserver.v1.GitserverService"}[2m])) by (grpc_method)
+```
 </details>
 
 <br />
@@ -6705,8 +7689,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10071
 <details>
 <summary>Technical details</summary>
 
-Query: `(100.0 * ( (sum(rate(grpc_server_handled_total{grpc_code!="OK",instance=~`${shard:regex}`,grpc_service=~"gitserver.v1.GitserverService"}[2m]))) / (sum(rate(grpc_server_handled_total{instance=~`${shard:regex}`,grpc_service=~"gitserver.v1.GitserverService"}[2m]))) ))`
+Query:
 
+```
+(100.0 * ( (sum(rate(grpc_server_handled_total{grpc_code!="OK",instance=~`${shard:regex}`,grpc_service=~"gitserver.v1.GitserverService"}[2m]))) / (sum(rate(grpc_server_handled_total{instance=~`${shard:regex}`,grpc_service=~"gitserver.v1.GitserverService"}[2m]))) ))
+```
 </details>
 
 <br />
@@ -6726,8 +7713,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10071
 <details>
 <summary>Technical details</summary>
 
-Query: `(100.0 * ( (sum(rate(grpc_server_handled_total{grpc_method=~`${gitserver_method:regex}`,grpc_code!="OK",instance=~`${shard:regex}`,grpc_service=~"gitserver.v1.GitserverService"}[2m])) by (grpc_method)) / (sum(rate(grpc_server_handled_total{grpc_method=~`${gitserver_method:regex}`,instance=~`${shard:regex}`,grpc_service=~"gitserver.v1.GitserverService"}[2m])) by (grpc_method)) ))`
+Query:
 
+```
+(100.0 * ( (sum(rate(grpc_server_handled_total{grpc_method=~`${gitserver_method:regex}`,grpc_code!="OK",instance=~`${shard:regex}`,grpc_service=~"gitserver.v1.GitserverService"}[2m])) by (grpc_method)) / (sum(rate(grpc_server_handled_total{grpc_method=~`${gitserver_method:regex}`,instance=~`${shard:regex}`,grpc_service=~"gitserver.v1.GitserverService"}[2m])) by (grpc_method)) ))
+```
 </details>
 
 <br />
@@ -6747,8 +7737,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10072
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.99, sum by (le, name, grpc_method)(rate(grpc_server_handling_seconds_bucket{grpc_method=~`${gitserver_method:regex}`,instance=~`${shard:regex}`,grpc_service=~"gitserver.v1.GitserverService"}[2m])))`
+Query:
 
+```
+histogram_quantile(0.99, sum by (le, name, grpc_method)(rate(grpc_server_handling_seconds_bucket{grpc_method=~`${gitserver_method:regex}`,instance=~`${shard:regex}`,grpc_service=~"gitserver.v1.GitserverService"}[2m])))
+```
 </details>
 
 <br />
@@ -6768,8 +7761,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10072
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.90, sum by (le, name, grpc_method)(rate(grpc_server_handling_seconds_bucket{grpc_method=~`${gitserver_method:regex}`,instance=~`${shard:regex}`,grpc_service=~"gitserver.v1.GitserverService"}[2m])))`
+Query:
 
+```
+histogram_quantile(0.90, sum by (le, name, grpc_method)(rate(grpc_server_handling_seconds_bucket{grpc_method=~`${gitserver_method:regex}`,instance=~`${shard:regex}`,grpc_service=~"gitserver.v1.GitserverService"}[2m])))
+```
 </details>
 
 <br />
@@ -6789,8 +7785,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10072
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.75, sum by (le, name, grpc_method)(rate(grpc_server_handling_seconds_bucket{grpc_method=~`${gitserver_method:regex}`,instance=~`${shard:regex}`,grpc_service=~"gitserver.v1.GitserverService"}[2m])))`
+Query:
 
+```
+histogram_quantile(0.75, sum by (le, name, grpc_method)(rate(grpc_server_handling_seconds_bucket{grpc_method=~`${gitserver_method:regex}`,instance=~`${shard:regex}`,grpc_service=~"gitserver.v1.GitserverService"}[2m])))
+```
 </details>
 
 <br />
@@ -6810,8 +7809,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10073
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.999, sum by (le, name, grpc_method)(rate(src_grpc_server_sent_bytes_per_rpc_bucket{grpc_method=~`${gitserver_method:regex}`,instance=~`${shard:regex}`,grpc_service=~"gitserver.v1.GitserverService"}[2m])))`
+Query:
 
+```
+histogram_quantile(0.999, sum by (le, name, grpc_method)(rate(src_grpc_server_sent_bytes_per_rpc_bucket{grpc_method=~`${gitserver_method:regex}`,instance=~`${shard:regex}`,grpc_service=~"gitserver.v1.GitserverService"}[2m])))
+```
 </details>
 
 <br />
@@ -6831,8 +7833,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10073
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.90, sum by (le, name, grpc_method)(rate(src_grpc_server_sent_bytes_per_rpc_bucket{grpc_method=~`${gitserver_method:regex}`,instance=~`${shard:regex}`,grpc_service=~"gitserver.v1.GitserverService"}[2m])))`
+Query:
 
+```
+histogram_quantile(0.90, sum by (le, name, grpc_method)(rate(src_grpc_server_sent_bytes_per_rpc_bucket{grpc_method=~`${gitserver_method:regex}`,instance=~`${shard:regex}`,grpc_service=~"gitserver.v1.GitserverService"}[2m])))
+```
 </details>
 
 <br />
@@ -6852,8 +7857,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10073
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.75, sum by (le, name, grpc_method)(rate(src_grpc_server_sent_bytes_per_rpc_bucket{grpc_method=~`${gitserver_method:regex}`,instance=~`${shard:regex}`,grpc_service=~"gitserver.v1.GitserverService"}[2m])))`
+Query:
 
+```
+histogram_quantile(0.75, sum by (le, name, grpc_method)(rate(src_grpc_server_sent_bytes_per_rpc_bucket{grpc_method=~`${gitserver_method:regex}`,instance=~`${shard:regex}`,grpc_service=~"gitserver.v1.GitserverService"}[2m])))
+```
 </details>
 
 <br />
@@ -6873,8 +7881,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10074
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.999, sum by (le, name, grpc_method)(rate(src_grpc_server_sent_individual_message_size_bytes_per_rpc_bucket{grpc_method=~`${gitserver_method:regex}`,instance=~`${shard:regex}`,grpc_service=~"gitserver.v1.GitserverService"}[2m])))`
+Query:
 
+```
+histogram_quantile(0.999, sum by (le, name, grpc_method)(rate(src_grpc_server_sent_individual_message_size_bytes_per_rpc_bucket{grpc_method=~`${gitserver_method:regex}`,instance=~`${shard:regex}`,grpc_service=~"gitserver.v1.GitserverService"}[2m])))
+```
 </details>
 
 <br />
@@ -6894,8 +7905,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10074
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.90, sum by (le, name, grpc_method)(rate(src_grpc_server_sent_individual_message_size_bytes_per_rpc_bucket{grpc_method=~`${gitserver_method:regex}`,instance=~`${shard:regex}`,grpc_service=~"gitserver.v1.GitserverService"}[2m])))`
+Query:
 
+```
+histogram_quantile(0.90, sum by (le, name, grpc_method)(rate(src_grpc_server_sent_individual_message_size_bytes_per_rpc_bucket{grpc_method=~`${gitserver_method:regex}`,instance=~`${shard:regex}`,grpc_service=~"gitserver.v1.GitserverService"}[2m])))
+```
 </details>
 
 <br />
@@ -6915,8 +7929,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10074
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.75, sum by (le, name, grpc_method)(rate(src_grpc_server_sent_individual_message_size_bytes_per_rpc_bucket{grpc_method=~`${gitserver_method:regex}`,instance=~`${shard:regex}`,grpc_service=~"gitserver.v1.GitserverService"}[2m])))`
+Query:
 
+```
+histogram_quantile(0.75, sum by (le, name, grpc_method)(rate(src_grpc_server_sent_individual_message_size_bytes_per_rpc_bucket{grpc_method=~`${gitserver_method:regex}`,instance=~`${shard:regex}`,grpc_service=~"gitserver.v1.GitserverService"}[2m])))
+```
 </details>
 
 <br />
@@ -6936,8 +7953,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10075
 <details>
 <summary>Technical details</summary>
 
-Query: `((sum(rate(grpc_server_msg_sent_total{grpc_type="server_stream",instance=~`${shard:regex}`,grpc_service=~"gitserver.v1.GitserverService"}[2m])) by (grpc_method))/(sum(rate(grpc_server_started_total{grpc_type="server_stream",instance=~`${shard:regex}`,grpc_service=~"gitserver.v1.GitserverService"}[2m])) by (grpc_method)))`
+Query:
 
+```
+((sum(rate(grpc_server_msg_sent_total{grpc_type="server_stream",instance=~`${shard:regex}`,grpc_service=~"gitserver.v1.GitserverService"}[2m])) by (grpc_method))/(sum(rate(grpc_server_started_total{grpc_type="server_stream",instance=~`${shard:regex}`,grpc_service=~"gitserver.v1.GitserverService"}[2m])) by (grpc_method)))
+```
 </details>
 
 <br />
@@ -6957,8 +7977,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10076
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(rate(grpc_server_handled_total{grpc_method=~`${gitserver_method:regex}`,instance=~`${shard:regex}`,grpc_service=~"gitserver.v1.GitserverService"}[2m])) by (grpc_method, grpc_code)`
+Query:
 
+```
+sum(rate(grpc_server_handled_total{grpc_method=~`${gitserver_method:regex}`,instance=~`${shard:regex}`,grpc_service=~"gitserver.v1.GitserverService"}[2m])) by (grpc_method, grpc_code)
+```
 </details>
 
 <br />
@@ -6980,8 +8003,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10080
 <details>
 <summary>Technical details</summary>
 
-Query: `(100.0 * ((((sum(rate(src_grpc_method_status{grpc_service=~"gitserver.v1.GitserverService",grpc_code!="OK"}[2m])))) / ((sum(rate(src_grpc_method_status{grpc_service=~"gitserver.v1.GitserverService"}[2m])))))))`
+Query:
 
+```
+(100.0 * ((((sum(rate(src_grpc_method_status{grpc_service=~"gitserver.v1.GitserverService",grpc_code!="OK"}[2m])))) / ((sum(rate(src_grpc_method_status{grpc_service=~"gitserver.v1.GitserverService"}[2m])))))))
+```
 </details>
 
 <br />
@@ -7001,8 +8027,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10080
 <details>
 <summary>Technical details</summary>
 
-Query: `(100.0 * ((((sum(rate(src_grpc_method_status{grpc_service=~"gitserver.v1.GitserverService",grpc_method=~"${gitserver_method:regex}",grpc_code!="OK"}[2m])) by (grpc_method))) / ((sum(rate(src_grpc_method_status{grpc_service=~"gitserver.v1.GitserverService",grpc_method=~"${gitserver_method:regex}"}[2m])) by (grpc_method))))))`
+Query:
 
+```
+(100.0 * ((((sum(rate(src_grpc_method_status{grpc_service=~"gitserver.v1.GitserverService",grpc_method=~"${gitserver_method:regex}",grpc_code!="OK"}[2m])) by (grpc_method))) / ((sum(rate(src_grpc_method_status{grpc_service=~"gitserver.v1.GitserverService",grpc_method=~"${gitserver_method:regex}"}[2m])) by (grpc_method))))))
+```
 </details>
 
 <br />
@@ -7022,8 +8051,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10080
 <details>
 <summary>Technical details</summary>
 
-Query: `(sum(rate(src_grpc_method_status{grpc_service=~"gitserver.v1.GitserverService",grpc_method=~"${gitserver_method:regex}"}[2m])) by (grpc_method, grpc_code))`
+Query:
 
+```
+(sum(rate(src_grpc_method_status{grpc_service=~"gitserver.v1.GitserverService",grpc_method=~"${gitserver_method:regex}"}[2m])) by (grpc_method, grpc_code))
+```
 </details>
 
 <br />
@@ -7049,8 +8081,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10081
 <details>
 <summary>Technical details</summary>
 
-Query: `(100.0 * ((((sum(rate(src_grpc_method_status{grpc_service=~"gitserver.v1.GitserverService",grpc_code!="OK",is_internal_error="true"}[2m])))) / ((sum(rate(src_grpc_method_status{grpc_service=~"gitserver.v1.GitserverService"}[2m])))))))`
+Query:
 
+```
+(100.0 * ((((sum(rate(src_grpc_method_status{grpc_service=~"gitserver.v1.GitserverService",grpc_code!="OK",is_internal_error="true"}[2m])))) / ((sum(rate(src_grpc_method_status{grpc_service=~"gitserver.v1.GitserverService"}[2m])))))))
+```
 </details>
 
 <br />
@@ -7076,8 +8111,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10081
 <details>
 <summary>Technical details</summary>
 
-Query: `(100.0 * ((((sum(rate(src_grpc_method_status{grpc_service=~"gitserver.v1.GitserverService",grpc_method=~"${gitserver_method:regex}",grpc_code!="OK",is_internal_error="true"}[2m])) by (grpc_method))) / ((sum(rate(src_grpc_method_status{grpc_service=~"gitserver.v1.GitserverService",grpc_method=~"${gitserver_method:regex}"}[2m])) by (grpc_method))))))`
+Query:
 
+```
+(100.0 * ((((sum(rate(src_grpc_method_status{grpc_service=~"gitserver.v1.GitserverService",grpc_method=~"${gitserver_method:regex}",grpc_code!="OK",is_internal_error="true"}[2m])) by (grpc_method))) / ((sum(rate(src_grpc_method_status{grpc_service=~"gitserver.v1.GitserverService",grpc_method=~"${gitserver_method:regex}"}[2m])) by (grpc_method))))))
+```
 </details>
 
 <br />
@@ -7103,8 +8141,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10081
 <details>
 <summary>Technical details</summary>
 
-Query: `(sum(rate(src_grpc_method_status{grpc_service=~"gitserver.v1.GitserverService",is_internal_error="true",grpc_method=~"${gitserver_method:regex}"}[2m])) by (grpc_method, grpc_code))`
+Query:
 
+```
+(sum(rate(src_grpc_method_status{grpc_service=~"gitserver.v1.GitserverService",is_internal_error="true",grpc_method=~"${gitserver_method:regex}"}[2m])) by (grpc_method, grpc_code))
+```
 </details>
 
 <br />
@@ -7126,8 +8167,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10090
 <details>
 <summary>Technical details</summary>
 
-Query: `(100.0 * ((((sum(rate(src_grpc_client_retry_attempts_total{grpc_service=~"gitserver.v1.GitserverService",is_retried="true"}[2m])))) / ((sum(rate(src_grpc_client_retry_attempts_total{grpc_service=~"gitserver.v1.GitserverService"}[2m])))))))`
+Query:
 
+```
+(100.0 * ((((sum(rate(src_grpc_client_retry_attempts_total{grpc_service=~"gitserver.v1.GitserverService",is_retried="true"}[2m])))) / ((sum(rate(src_grpc_client_retry_attempts_total{grpc_service=~"gitserver.v1.GitserverService"}[2m])))))))
+```
 </details>
 
 <br />
@@ -7147,8 +8191,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10090
 <details>
 <summary>Technical details</summary>
 
-Query: `(100.0 * ((((sum(rate(src_grpc_client_retry_attempts_total{grpc_service=~"gitserver.v1.GitserverService",is_retried="true",grpc_method=~"${gitserver_method:regex}"}[2m])) by (grpc_method))) / ((sum(rate(src_grpc_client_retry_attempts_total{grpc_service=~"gitserver.v1.GitserverService",grpc_method=~"${gitserver_method:regex}"}[2m])) by (grpc_method))))))`
+Query:
 
+```
+(100.0 * ((((sum(rate(src_grpc_client_retry_attempts_total{grpc_service=~"gitserver.v1.GitserverService",is_retried="true",grpc_method=~"${gitserver_method:regex}"}[2m])) by (grpc_method))) / ((sum(rate(src_grpc_client_retry_attempts_total{grpc_service=~"gitserver.v1.GitserverService",grpc_method=~"${gitserver_method:regex}"}[2m])) by (grpc_method))))))
+```
 </details>
 
 <br />
@@ -7168,8 +8215,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10090
 <details>
 <summary>Technical details</summary>
 
-Query: `(sum(rate(src_grpc_client_retry_attempts_total{grpc_service=~"gitserver.v1.GitserverService",grpc_method=~"${gitserver_method:regex}",is_retried="true"}[2m])) by (grpc_method))`
+Query:
 
+```
+(sum(rate(src_grpc_client_retry_attempts_total{grpc_service=~"gitserver.v1.GitserverService",grpc_method=~"${gitserver_method:regex}",is_retried="true"}[2m])) by (grpc_method))
+```
 </details>
 
 <br />
@@ -7191,8 +8241,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10100
 <details>
 <summary>Technical details</summary>
 
-Query: `src_conf_client_time_since_last_successful_update_seconds{job=~`.*gitserver`,instance=~`${shard:regex}`}`
+Query:
 
+```
+src_conf_client_time_since_last_successful_update_seconds{job=~`.*gitserver`,instance=~`${shard:regex}`}
+```
 </details>
 
 <br />
@@ -7210,8 +8263,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10100
 <details>
 <summary>Technical details</summary>
 
-Query: `max(max_over_time(src_conf_client_time_since_last_successful_update_seconds{job=~`.*gitserver`,instance=~`${shard:regex}`}[1m]))`
+Query:
 
+```
+max(max_over_time(src_conf_client_time_since_last_successful_update_seconds{job=~`.*gitserver`,instance=~`${shard:regex}`}[1m]))
+```
 </details>
 
 <br />
@@ -7231,8 +8287,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10110
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_coursier_total{op!="RunCommand",job=~"^gitserver.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_coursier_total{op!="RunCommand",job=~"^gitserver.*"}[5m]))
+```
 </details>
 
 <br />
@@ -7250,8 +8309,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10110
 <details>
 <summary>Technical details</summary>
 
-Query: `sum  by (le)(rate(src_codeintel_coursier_duration_seconds_bucket{op!="RunCommand",job=~"^gitserver.*"}[5m]))`
+Query:
 
+```
+sum  by (le)(rate(src_codeintel_coursier_duration_seconds_bucket{op!="RunCommand",job=~"^gitserver.*"}[5m]))
+```
 </details>
 
 <br />
@@ -7269,8 +8331,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10110
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_coursier_errors_total{op!="RunCommand",job=~"^gitserver.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_coursier_errors_total{op!="RunCommand",job=~"^gitserver.*"}[5m]))
+```
 </details>
 
 <br />
@@ -7288,8 +8353,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10110
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_coursier_errors_total{op!="RunCommand",job=~"^gitserver.*"}[5m])) / (sum(increase(src_codeintel_coursier_total{op!="RunCommand",job=~"^gitserver.*"}[5m])) + sum(increase(src_codeintel_coursier_errors_total{op!="RunCommand",job=~"^gitserver.*"}[5m]))) * 100`
+Query:
 
+```
+sum(increase(src_codeintel_coursier_errors_total{op!="RunCommand",job=~"^gitserver.*"}[5m])) / (sum(increase(src_codeintel_coursier_total{op!="RunCommand",job=~"^gitserver.*"}[5m])) + sum(increase(src_codeintel_coursier_errors_total{op!="RunCommand",job=~"^gitserver.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -7307,8 +8375,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10111
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_coursier_total{op!="RunCommand",job=~"^gitserver.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_coursier_total{op!="RunCommand",job=~"^gitserver.*"}[5m]))
+```
 </details>
 
 <br />
@@ -7326,8 +8397,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10111
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_coursier_duration_seconds_bucket{op!="RunCommand",job=~"^gitserver.*"}[5m])))`
+Query:
 
+```
+histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_coursier_duration_seconds_bucket{op!="RunCommand",job=~"^gitserver.*"}[5m])))
+```
 </details>
 
 <br />
@@ -7345,8 +8419,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10111
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_coursier_errors_total{op!="RunCommand",job=~"^gitserver.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_coursier_errors_total{op!="RunCommand",job=~"^gitserver.*"}[5m]))
+```
 </details>
 
 <br />
@@ -7364,8 +8441,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10111
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_coursier_errors_total{op!="RunCommand",job=~"^gitserver.*"}[5m])) / (sum by (op)(increase(src_codeintel_coursier_total{op!="RunCommand",job=~"^gitserver.*"}[5m])) + sum by (op)(increase(src_codeintel_coursier_errors_total{op!="RunCommand",job=~"^gitserver.*"}[5m]))) * 100`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_coursier_errors_total{op!="RunCommand",job=~"^gitserver.*"}[5m])) / (sum by (op)(increase(src_codeintel_coursier_total{op!="RunCommand",job=~"^gitserver.*"}[5m])) + sum by (op)(increase(src_codeintel_coursier_errors_total{op!="RunCommand",job=~"^gitserver.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -7385,8 +8465,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10120
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_npm_total{op!="RunCommand",job=~"^gitserver.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_npm_total{op!="RunCommand",job=~"^gitserver.*"}[5m]))
+```
 </details>
 
 <br />
@@ -7404,8 +8487,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10120
 <details>
 <summary>Technical details</summary>
 
-Query: `sum  by (le)(rate(src_codeintel_npm_duration_seconds_bucket{op!="RunCommand",job=~"^gitserver.*"}[5m]))`
+Query:
 
+```
+sum  by (le)(rate(src_codeintel_npm_duration_seconds_bucket{op!="RunCommand",job=~"^gitserver.*"}[5m]))
+```
 </details>
 
 <br />
@@ -7423,8 +8509,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10120
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_npm_errors_total{op!="RunCommand",job=~"^gitserver.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_npm_errors_total{op!="RunCommand",job=~"^gitserver.*"}[5m]))
+```
 </details>
 
 <br />
@@ -7442,8 +8531,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10120
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_npm_errors_total{op!="RunCommand",job=~"^gitserver.*"}[5m])) / (sum(increase(src_codeintel_npm_total{op!="RunCommand",job=~"^gitserver.*"}[5m])) + sum(increase(src_codeintel_npm_errors_total{op!="RunCommand",job=~"^gitserver.*"}[5m]))) * 100`
+Query:
 
+```
+sum(increase(src_codeintel_npm_errors_total{op!="RunCommand",job=~"^gitserver.*"}[5m])) / (sum(increase(src_codeintel_npm_total{op!="RunCommand",job=~"^gitserver.*"}[5m])) + sum(increase(src_codeintel_npm_errors_total{op!="RunCommand",job=~"^gitserver.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -7461,8 +8553,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10121
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_npm_total{op!="RunCommand",job=~"^gitserver.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_npm_total{op!="RunCommand",job=~"^gitserver.*"}[5m]))
+```
 </details>
 
 <br />
@@ -7480,8 +8575,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10121
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_npm_duration_seconds_bucket{op!="RunCommand",job=~"^gitserver.*"}[5m])))`
+Query:
 
+```
+histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_npm_duration_seconds_bucket{op!="RunCommand",job=~"^gitserver.*"}[5m])))
+```
 </details>
 
 <br />
@@ -7499,8 +8597,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10121
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_npm_errors_total{op!="RunCommand",job=~"^gitserver.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_npm_errors_total{op!="RunCommand",job=~"^gitserver.*"}[5m]))
+```
 </details>
 
 <br />
@@ -7518,8 +8619,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10121
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_npm_errors_total{op!="RunCommand",job=~"^gitserver.*"}[5m])) / (sum by (op)(increase(src_codeintel_npm_total{op!="RunCommand",job=~"^gitserver.*"}[5m])) + sum by (op)(increase(src_codeintel_npm_errors_total{op!="RunCommand",job=~"^gitserver.*"}[5m]))) * 100`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_npm_errors_total{op!="RunCommand",job=~"^gitserver.*"}[5m])) / (sum by (op)(increase(src_codeintel_npm_total{op!="RunCommand",job=~"^gitserver.*"}[5m])) + sum by (op)(increase(src_codeintel_npm_errors_total{op!="RunCommand",job=~"^gitserver.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -7541,8 +8645,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10130
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (route) (rate(src_http_request_duration_seconds_count{app="gitserver",code=~"2.."}[5m]))`
+Query:
 
+```
+sum by (route) (rate(src_http_request_duration_seconds_count{app="gitserver",code=~"2.."}[5m]))
+```
 </details>
 
 <br />
@@ -7562,8 +8669,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10130
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (route) (rate(src_http_request_duration_seconds_count{app="gitserver",code!~"2.."}[5m]))`
+Query:
 
+```
+sum by (route) (rate(src_http_request_duration_seconds_count{app="gitserver",code!~"2.."}[5m]))
+```
 </details>
 
 <br />
@@ -7583,8 +8693,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10130
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (code) (rate(src_http_request_duration_seconds_count{app="gitserver"}[5m]))`
+Query:
 
+```
+sum by (code) (rate(src_http_request_duration_seconds_count{app="gitserver"}[5m]))
+```
 </details>
 
 <br />
@@ -7604,8 +8717,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10131
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.95, sum(rate(src_http_request_duration_seconds_bucket{app="gitserver",code=~"2.."}[5m])) by (le, route))`
+Query:
 
+```
+histogram_quantile(0.95, sum(rate(src_http_request_duration_seconds_bucket{app="gitserver",code=~"2.."}[5m])) by (le, route))
+```
 </details>
 
 <br />
@@ -7625,8 +8741,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10131
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.95, sum(rate(src_http_request_duration_seconds_bucket{app="gitserver",code!~"2.."}[5m])) by (le, route))`
+Query:
 
+```
+histogram_quantile(0.95, sum(rate(src_http_request_duration_seconds_bucket{app="gitserver",code!~"2.."}[5m])) by (le, route))
+```
 </details>
 
 <br />
@@ -7646,8 +8765,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10140
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (app_name, db_name) (src_pgsql_conns_max_open{app_name="gitserver"})`
+Query:
 
+```
+sum by (app_name, db_name) (src_pgsql_conns_max_open{app_name="gitserver"})
+```
 </details>
 
 <br />
@@ -7665,8 +8787,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10140
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (app_name, db_name) (src_pgsql_conns_open{app_name="gitserver"})`
+Query:
 
+```
+sum by (app_name, db_name) (src_pgsql_conns_open{app_name="gitserver"})
+```
 </details>
 
 <br />
@@ -7684,8 +8809,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10141
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (app_name, db_name) (src_pgsql_conns_in_use{app_name="gitserver"})`
+Query:
 
+```
+sum by (app_name, db_name) (src_pgsql_conns_in_use{app_name="gitserver"})
+```
 </details>
 
 <br />
@@ -7703,8 +8831,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10141
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (app_name, db_name) (src_pgsql_conns_idle{app_name="gitserver"})`
+Query:
 
+```
+sum by (app_name, db_name) (src_pgsql_conns_idle{app_name="gitserver"})
+```
 </details>
 
 <br />
@@ -7722,8 +8853,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10142
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (app_name, db_name) (increase(src_pgsql_conns_blocked_seconds{app_name="gitserver"}[5m])) / sum by (app_name, db_name) (increase(src_pgsql_conns_waited_for{app_name="gitserver"}[5m]))`
+Query:
 
+```
+sum by (app_name, db_name) (increase(src_pgsql_conns_blocked_seconds{app_name="gitserver"}[5m])) / sum by (app_name, db_name) (increase(src_pgsql_conns_waited_for{app_name="gitserver"}[5m]))
+```
 </details>
 
 <br />
@@ -7741,8 +8875,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10143
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (app_name, db_name) (increase(src_pgsql_conns_closed_max_idle{app_name="gitserver"}[5m]))`
+Query:
 
+```
+sum by (app_name, db_name) (increase(src_pgsql_conns_closed_max_idle{app_name="gitserver"}[5m]))
+```
 </details>
 
 <br />
@@ -7760,8 +8897,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10143
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (app_name, db_name) (increase(src_pgsql_conns_closed_max_lifetime{app_name="gitserver"}[5m]))`
+Query:
 
+```
+sum by (app_name, db_name) (increase(src_pgsql_conns_closed_max_lifetime{app_name="gitserver"}[5m]))
+```
 </details>
 
 <br />
@@ -7779,8 +8919,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10143
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (app_name, db_name) (increase(src_pgsql_conns_closed_max_idle_time{app_name="gitserver"}[5m]))`
+Query:
 
+```
+sum by (app_name, db_name) (increase(src_pgsql_conns_closed_max_idle_time{app_name="gitserver"}[5m]))
+```
 </details>
 
 <br />
@@ -7810,8 +8953,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10150
 <details>
 <summary>Technical details</summary>
 
-Query: `count by(name) ((time() - container_last_seen{name=~"^gitserver.*"}) > 60)`
+Query:
 
+```
+count by(name) ((time() - container_last_seen{name=~"^gitserver.*"}) > 60)
+```
 </details>
 
 <br />
@@ -7829,8 +8975,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10150
 <details>
 <summary>Technical details</summary>
 
-Query: `cadvisor_container_cpu_usage_percentage_total{name=~"^gitserver.*"}`
+Query:
 
+```
+cadvisor_container_cpu_usage_percentage_total{name=~"^gitserver.*"}
+```
 </details>
 
 <br />
@@ -7848,8 +8997,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10150
 <details>
 <summary>Technical details</summary>
 
-Query: `cadvisor_container_memory_usage_percentage_total{name=~"^gitserver.*"}`
+Query:
 
+```
+cadvisor_container_memory_usage_percentage_total{name=~"^gitserver.*"}
+```
 </details>
 
 <br />
@@ -7870,8 +9022,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10150
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by(name) (rate(container_fs_reads_total{name=~"^gitserver.*"}[1h]) + rate(container_fs_writes_total{name=~"^gitserver.*"}[1h]))`
+Query:
 
+```
+sum by(name) (rate(container_fs_reads_total{name=~"^gitserver.*"}[1h]) + rate(container_fs_writes_total{name=~"^gitserver.*"}[1h]))
+```
 </details>
 
 <br />
@@ -7891,8 +9046,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10160
 <details>
 <summary>Technical details</summary>
 
-Query: `quantile_over_time(0.9, cadvisor_container_cpu_usage_percentage_total{name=~"^gitserver.*"}[1d])`
+Query:
 
+```
+quantile_over_time(0.9, cadvisor_container_cpu_usage_percentage_total{name=~"^gitserver.*"}[1d])
+```
 </details>
 
 <br />
@@ -7912,8 +9070,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10160
 <details>
 <summary>Technical details</summary>
 
-Query: `max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^gitserver.*"}[1d])`
+Query:
 
+```
+max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^gitserver.*"}[1d])
+```
 </details>
 
 <br />
@@ -7931,8 +9092,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10161
 <details>
 <summary>Technical details</summary>
 
-Query: `max_over_time(cadvisor_container_cpu_usage_percentage_total{name=~"^gitserver.*"}[5m])`
+Query:
 
+```
+max_over_time(cadvisor_container_cpu_usage_percentage_total{name=~"^gitserver.*"}[5m])
+```
 </details>
 
 <br />
@@ -7952,8 +9116,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10161
 <details>
 <summary>Technical details</summary>
 
-Query: `max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^gitserver.*"}[5m])`
+Query:
 
+```
+max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^gitserver.*"}[5m])
+```
 </details>
 
 <br />
@@ -7974,8 +9141,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10161
 <details>
 <summary>Technical details</summary>
 
-Query: `max by (name) (container_oom_events_total{name=~"^gitserver.*"})`
+Query:
 
+```
+max by (name) (container_oom_events_total{name=~"^gitserver.*"})
+```
 </details>
 
 <br />
@@ -7997,8 +9167,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10170
 <details>
 <summary>Technical details</summary>
 
-Query: `max by(instance) (go_goroutines{job=~".*gitserver"})`
+Query:
 
+```
+max by(instance) (go_goroutines{job=~".*gitserver"})
+```
 </details>
 
 <br />
@@ -8016,8 +9189,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10170
 <details>
 <summary>Technical details</summary>
 
-Query: `max by(instance) (go_gc_duration_seconds{job=~".*gitserver"})`
+Query:
 
+```
+max by(instance) (go_gc_duration_seconds{job=~".*gitserver"})
+```
 </details>
 
 <br />
@@ -8037,8 +9213,11 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10180
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by(app) (up{app=~".*gitserver"}) / count by (app) (up{app=~".*gitserver"}) * 100`
+Query:
 
+```
+sum by(app) (up{app=~".*gitserver"}) / count by (app) (up{app=~".*gitserver"}) * 100
+```
 </details>
 
 <br />
@@ -8062,8 +9241,11 @@ To see this panel, visit `/-/debug/grafana/d/postgres/postgres?viewPanel=100000`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (job) (pg_stat_activity_count{datname!~"template.*|postgres|cloudsqladmin"}) OR sum by (job) (pg_stat_activity_count{job="codeinsights-db", datname!~"template.*|cloudsqladmin"})`
+Query:
 
+```
+sum by (job) (pg_stat_activity_count{datname!~"template.*|postgres|cloudsqladmin"}) OR sum by (job) (pg_stat_activity_count{job="codeinsights-db", datname!~"template.*|cloudsqladmin"})
+```
 </details>
 
 <br />
@@ -8081,8 +9263,11 @@ To see this panel, visit `/-/debug/grafana/d/postgres/postgres?viewPanel=100001`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(pg_stat_activity_count) by (job) / (sum(pg_settings_max_connections) by (job) - sum(pg_settings_superuser_reserved_connections) by (job)) * 100`
+Query:
 
+```
+sum(pg_stat_activity_count) by (job) / (sum(pg_settings_max_connections) by (job) - sum(pg_settings_superuser_reserved_connections) by (job)) * 100
+```
 </details>
 
 <br />
@@ -8100,8 +9285,11 @@ To see this panel, visit `/-/debug/grafana/d/postgres/postgres?viewPanel=100002`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (job) (pg_stat_activity_max_tx_duration{datname!~"template.*|postgres|cloudsqladmin",job!="codeintel-db"}) OR sum by (job) (pg_stat_activity_max_tx_duration{job="codeinsights-db", datname!~"template.*|cloudsqladmin"})`
+Query:
 
+```
+sum by (job) (pg_stat_activity_max_tx_duration{datname!~"template.*|postgres|cloudsqladmin",job!="codeintel-db"}) OR sum by (job) (pg_stat_activity_max_tx_duration{job="codeinsights-db", datname!~"template.*|cloudsqladmin"})
+```
 </details>
 
 <br />
@@ -8123,8 +9311,11 @@ To see this panel, visit `/-/debug/grafana/d/postgres/postgres?viewPanel=100100`
 <details>
 <summary>Technical details</summary>
 
-Query: `pg_up`
+Query:
 
+```
+pg_up
+```
 </details>
 
 <br />
@@ -8144,8 +9335,11 @@ To see this panel, visit `/-/debug/grafana/d/postgres/postgres?viewPanel=100101`
 <details>
 <summary>Technical details</summary>
 
-Query: `max by (relname)(pg_invalid_index_count)`
+Query:
 
+```
+max by (relname)(pg_invalid_index_count)
+```
 </details>
 
 <br />
@@ -8165,8 +9359,11 @@ To see this panel, visit `/-/debug/grafana/d/postgres/postgres?viewPanel=100110`
 <details>
 <summary>Technical details</summary>
 
-Query: `pg_exporter_last_scrape_error`
+Query:
 
+```
+pg_exporter_last_scrape_error
+```
 </details>
 
 <br />
@@ -8186,8 +9383,11 @@ To see this panel, visit `/-/debug/grafana/d/postgres/postgres?viewPanel=100111`
 <details>
 <summary>Technical details</summary>
 
-Query: `pg_sg_migration_status`
+Query:
 
+```
+pg_sg_migration_status
+```
 </details>
 
 <br />
@@ -8209,8 +9409,11 @@ To see this panel, visit `/-/debug/grafana/d/postgres/postgres?viewPanel=100200`
 <details>
 <summary>Technical details</summary>
 
-Query: `max by (relname)(pg_table_bloat_size)`
+Query:
 
+```
+max by (relname)(pg_table_bloat_size)
+```
 </details>
 
 <br />
@@ -8230,8 +9433,11 @@ To see this panel, visit `/-/debug/grafana/d/postgres/postgres?viewPanel=100201`
 <details>
 <summary>Technical details</summary>
 
-Query: `max by (relname)(pg_table_bloat_ratio) * 100`
+Query:
 
+```
+max by (relname)(pg_table_bloat_ratio) * 100
+```
 </details>
 
 <br />
@@ -8251,8 +9457,11 @@ To see this panel, visit `/-/debug/grafana/d/postgres/postgres?viewPanel=100210`
 <details>
 <summary>Technical details</summary>
 
-Query: `max by (relname)(pg_index_bloat_size)`
+Query:
 
+```
+max by (relname)(pg_index_bloat_size)
+```
 </details>
 
 <br />
@@ -8272,8 +9481,11 @@ To see this panel, visit `/-/debug/grafana/d/postgres/postgres?viewPanel=100211`
 <details>
 <summary>Technical details</summary>
 
-Query: `max by (relname)(pg_index_bloat_ratio) * 100`
+Query:
 
+```
+max by (relname)(pg_index_bloat_ratio) * 100
+```
 </details>
 
 <br />
@@ -8293,8 +9505,11 @@ To see this panel, visit `/-/debug/grafana/d/postgres/postgres?viewPanel=100300`
 <details>
 <summary>Technical details</summary>
 
-Query: `quantile_over_time(0.9, cadvisor_container_cpu_usage_percentage_total{name=~"^(pgsql|codeintel-db|codeinsights).*"}[1d])`
+Query:
 
+```
+quantile_over_time(0.9, cadvisor_container_cpu_usage_percentage_total{name=~"^(pgsql|codeintel-db|codeinsights).*"}[1d])
+```
 </details>
 
 <br />
@@ -8312,8 +9527,11 @@ To see this panel, visit `/-/debug/grafana/d/postgres/postgres?viewPanel=100301`
 <details>
 <summary>Technical details</summary>
 
-Query: `max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^(pgsql|codeintel-db|codeinsights).*"}[1d])`
+Query:
 
+```
+max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^(pgsql|codeintel-db|codeinsights).*"}[1d])
+```
 </details>
 
 <br />
@@ -8331,8 +9549,11 @@ To see this panel, visit `/-/debug/grafana/d/postgres/postgres?viewPanel=100310`
 <details>
 <summary>Technical details</summary>
 
-Query: `max_over_time(cadvisor_container_cpu_usage_percentage_total{name=~"^(pgsql|codeintel-db|codeinsights).*"}[5m])`
+Query:
 
+```
+max_over_time(cadvisor_container_cpu_usage_percentage_total{name=~"^(pgsql|codeintel-db|codeinsights).*"}[5m])
+```
 </details>
 
 <br />
@@ -8350,8 +9571,11 @@ To see this panel, visit `/-/debug/grafana/d/postgres/postgres?viewPanel=100311`
 <details>
 <summary>Technical details</summary>
 
-Query: `max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^(pgsql|codeintel-db|codeinsights).*"}[5m])`
+Query:
 
+```
+max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^(pgsql|codeintel-db|codeinsights).*"}[5m])
+```
 </details>
 
 <br />
@@ -8372,8 +9596,11 @@ To see this panel, visit `/-/debug/grafana/d/postgres/postgres?viewPanel=100312`
 <details>
 <summary>Technical details</summary>
 
-Query: `max by (name) (container_oom_events_total{name=~"^(pgsql|codeintel-db|codeinsights).*"})`
+Query:
 
+```
+max by (name) (container_oom_events_total{name=~"^(pgsql|codeintel-db|codeinsights).*"})
+```
 </details>
 
 <br />
@@ -8393,8 +9620,11 @@ To see this panel, visit `/-/debug/grafana/d/postgres/postgres?viewPanel=100400`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by(app) (up{app=~".*(pgsql|codeintel-db|codeinsights)"}) / count by (app) (up{app=~".*(pgsql|codeintel-db|codeinsights)"}) * 100`
+Query:
 
+```
+sum by(app) (up{app=~".*(pgsql|codeintel-db|codeinsights)"}) / count by (app) (up{app=~".*(pgsql|codeintel-db|codeinsights)"}) * 100
+```
 </details>
 
 <br />
@@ -8420,8 +9650,11 @@ To see this panel, visit `/-/debug/grafana/d/precise-code-intel-worker/precise-c
 <details>
 <summary>Technical details</summary>
 
-Query: `max(src_codeintel_upload_total{job=~"^precise-code-intel-worker.*"})`
+Query:
 
+```
+max(src_codeintel_upload_total{job=~"^precise-code-intel-worker.*"})
+```
 </details>
 
 <br />
@@ -8445,8 +9678,11 @@ To see this panel, visit `/-/debug/grafana/d/precise-code-intel-worker/precise-c
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_upload_total{job=~"^precise-code-intel-worker.*"}[30m])) / sum(increase(src_codeintel_upload_processor_total{job=~"^precise-code-intel-worker.*"}[30m]))`
+Query:
 
+```
+sum(increase(src_codeintel_upload_total{job=~"^precise-code-intel-worker.*"}[30m])) / sum(increase(src_codeintel_upload_processor_total{job=~"^precise-code-intel-worker.*"}[30m]))
+```
 </details>
 
 <br />
@@ -8464,8 +9700,11 @@ To see this panel, visit `/-/debug/grafana/d/precise-code-intel-worker/precise-c
 <details>
 <summary>Technical details</summary>
 
-Query: `max(src_codeintel_upload_queued_duration_seconds_total{job=~"^precise-code-intel-worker.*"})`
+Query:
 
+```
+max(src_codeintel_upload_queued_duration_seconds_total{job=~"^precise-code-intel-worker.*"})
+```
 </details>
 
 <br />
@@ -8485,8 +9724,11 @@ To see this panel, visit `/-/debug/grafana/d/precise-code-intel-worker/precise-c
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(src_codeintel_upload_processor_handlers{job=~"^precise-code-intel-worker.*"})`
+Query:
 
+```
+sum(src_codeintel_upload_processor_handlers{job=~"^precise-code-intel-worker.*"})
+```
 </details>
 
 <br />
@@ -8504,8 +9746,11 @@ To see this panel, visit `/-/debug/grafana/d/precise-code-intel-worker/precise-c
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by(instance) (src_codeintel_upload_processor_upload_size{job="precise-code-intel-worker"})`
+Query:
 
+```
+sum by(instance) (src_codeintel_upload_processor_upload_size{job="precise-code-intel-worker"})
+```
 </details>
 
 <br />
@@ -8523,8 +9768,11 @@ To see this panel, visit `/-/debug/grafana/d/precise-code-intel-worker/precise-c
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_upload_processor_total{job=~"^precise-code-intel-worker.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_upload_processor_total{job=~"^precise-code-intel-worker.*"}[5m]))
+```
 </details>
 
 <br />
@@ -8542,8 +9790,11 @@ To see this panel, visit `/-/debug/grafana/d/precise-code-intel-worker/precise-c
 <details>
 <summary>Technical details</summary>
 
-Query: `sum  by (le)(rate(src_codeintel_upload_processor_duration_seconds_bucket{job=~"^precise-code-intel-worker.*"}[5m]))`
+Query:
 
+```
+sum  by (le)(rate(src_codeintel_upload_processor_duration_seconds_bucket{job=~"^precise-code-intel-worker.*"}[5m]))
+```
 </details>
 
 <br />
@@ -8561,8 +9812,11 @@ To see this panel, visit `/-/debug/grafana/d/precise-code-intel-worker/precise-c
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_upload_processor_errors_total{job=~"^precise-code-intel-worker.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_upload_processor_errors_total{job=~"^precise-code-intel-worker.*"}[5m]))
+```
 </details>
 
 <br />
@@ -8580,8 +9834,11 @@ To see this panel, visit `/-/debug/grafana/d/precise-code-intel-worker/precise-c
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_upload_processor_errors_total{job=~"^precise-code-intel-worker.*"}[5m])) / (sum(increase(src_codeintel_upload_processor_total{job=~"^precise-code-intel-worker.*"}[5m])) + sum(increase(src_codeintel_upload_processor_errors_total{job=~"^precise-code-intel-worker.*"}[5m]))) * 100`
+Query:
 
+```
+sum(increase(src_codeintel_upload_processor_errors_total{job=~"^precise-code-intel-worker.*"}[5m])) / (sum(increase(src_codeintel_upload_processor_total{job=~"^precise-code-intel-worker.*"}[5m])) + sum(increase(src_codeintel_upload_processor_errors_total{job=~"^precise-code-intel-worker.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -8601,8 +9858,11 @@ To see this panel, visit `/-/debug/grafana/d/precise-code-intel-worker/precise-c
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_uploads_store_total{job=~"^precise-code-intel-worker.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_uploads_store_total{job=~"^precise-code-intel-worker.*"}[5m]))
+```
 </details>
 
 <br />
@@ -8620,8 +9880,11 @@ To see this panel, visit `/-/debug/grafana/d/precise-code-intel-worker/precise-c
 <details>
 <summary>Technical details</summary>
 
-Query: `sum  by (le)(rate(src_codeintel_uploads_store_duration_seconds_bucket{job=~"^precise-code-intel-worker.*"}[5m]))`
+Query:
 
+```
+sum  by (le)(rate(src_codeintel_uploads_store_duration_seconds_bucket{job=~"^precise-code-intel-worker.*"}[5m]))
+```
 </details>
 
 <br />
@@ -8639,8 +9902,11 @@ To see this panel, visit `/-/debug/grafana/d/precise-code-intel-worker/precise-c
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_uploads_store_errors_total{job=~"^precise-code-intel-worker.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_uploads_store_errors_total{job=~"^precise-code-intel-worker.*"}[5m]))
+```
 </details>
 
 <br />
@@ -8658,8 +9924,11 @@ To see this panel, visit `/-/debug/grafana/d/precise-code-intel-worker/precise-c
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_uploads_store_errors_total{job=~"^precise-code-intel-worker.*"}[5m])) / (sum(increase(src_codeintel_uploads_store_total{job=~"^precise-code-intel-worker.*"}[5m])) + sum(increase(src_codeintel_uploads_store_errors_total{job=~"^precise-code-intel-worker.*"}[5m]))) * 100`
+Query:
 
+```
+sum(increase(src_codeintel_uploads_store_errors_total{job=~"^precise-code-intel-worker.*"}[5m])) / (sum(increase(src_codeintel_uploads_store_total{job=~"^precise-code-intel-worker.*"}[5m])) + sum(increase(src_codeintel_uploads_store_errors_total{job=~"^precise-code-intel-worker.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -8677,8 +9946,11 @@ To see this panel, visit `/-/debug/grafana/d/precise-code-intel-worker/precise-c
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_uploads_store_total{job=~"^precise-code-intel-worker.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_uploads_store_total{job=~"^precise-code-intel-worker.*"}[5m]))
+```
 </details>
 
 <br />
@@ -8696,8 +9968,11 @@ To see this panel, visit `/-/debug/grafana/d/precise-code-intel-worker/precise-c
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_uploads_store_duration_seconds_bucket{job=~"^precise-code-intel-worker.*"}[5m])))`
+Query:
 
+```
+histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_uploads_store_duration_seconds_bucket{job=~"^precise-code-intel-worker.*"}[5m])))
+```
 </details>
 
 <br />
@@ -8715,8 +9990,11 @@ To see this panel, visit `/-/debug/grafana/d/precise-code-intel-worker/precise-c
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_uploads_store_errors_total{job=~"^precise-code-intel-worker.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_uploads_store_errors_total{job=~"^precise-code-intel-worker.*"}[5m]))
+```
 </details>
 
 <br />
@@ -8734,8 +10012,11 @@ To see this panel, visit `/-/debug/grafana/d/precise-code-intel-worker/precise-c
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_uploads_store_errors_total{job=~"^precise-code-intel-worker.*"}[5m])) / (sum by (op)(increase(src_codeintel_uploads_store_total{job=~"^precise-code-intel-worker.*"}[5m])) + sum by (op)(increase(src_codeintel_uploads_store_errors_total{job=~"^precise-code-intel-worker.*"}[5m]))) * 100`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_uploads_store_errors_total{job=~"^precise-code-intel-worker.*"}[5m])) / (sum by (op)(increase(src_codeintel_uploads_store_total{job=~"^precise-code-intel-worker.*"}[5m])) + sum by (op)(increase(src_codeintel_uploads_store_errors_total{job=~"^precise-code-intel-worker.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -8755,8 +10036,11 @@ To see this panel, visit `/-/debug/grafana/d/precise-code-intel-worker/precise-c
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_uploads_lsifstore_total{job=~"^precise-code-intel-worker.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_uploads_lsifstore_total{job=~"^precise-code-intel-worker.*"}[5m]))
+```
 </details>
 
 <br />
@@ -8774,8 +10058,11 @@ To see this panel, visit `/-/debug/grafana/d/precise-code-intel-worker/precise-c
 <details>
 <summary>Technical details</summary>
 
-Query: `sum  by (le)(rate(src_codeintel_uploads_lsifstore_duration_seconds_bucket{job=~"^precise-code-intel-worker.*"}[5m]))`
+Query:
 
+```
+sum  by (le)(rate(src_codeintel_uploads_lsifstore_duration_seconds_bucket{job=~"^precise-code-intel-worker.*"}[5m]))
+```
 </details>
 
 <br />
@@ -8793,8 +10080,11 @@ To see this panel, visit `/-/debug/grafana/d/precise-code-intel-worker/precise-c
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_uploads_lsifstore_errors_total{job=~"^precise-code-intel-worker.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_uploads_lsifstore_errors_total{job=~"^precise-code-intel-worker.*"}[5m]))
+```
 </details>
 
 <br />
@@ -8812,8 +10102,11 @@ To see this panel, visit `/-/debug/grafana/d/precise-code-intel-worker/precise-c
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_uploads_lsifstore_errors_total{job=~"^precise-code-intel-worker.*"}[5m])) / (sum(increase(src_codeintel_uploads_lsifstore_total{job=~"^precise-code-intel-worker.*"}[5m])) + sum(increase(src_codeintel_uploads_lsifstore_errors_total{job=~"^precise-code-intel-worker.*"}[5m]))) * 100`
+Query:
 
+```
+sum(increase(src_codeintel_uploads_lsifstore_errors_total{job=~"^precise-code-intel-worker.*"}[5m])) / (sum(increase(src_codeintel_uploads_lsifstore_total{job=~"^precise-code-intel-worker.*"}[5m])) + sum(increase(src_codeintel_uploads_lsifstore_errors_total{job=~"^precise-code-intel-worker.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -8831,8 +10124,11 @@ To see this panel, visit `/-/debug/grafana/d/precise-code-intel-worker/precise-c
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_uploads_lsifstore_total{job=~"^precise-code-intel-worker.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_uploads_lsifstore_total{job=~"^precise-code-intel-worker.*"}[5m]))
+```
 </details>
 
 <br />
@@ -8850,8 +10146,11 @@ To see this panel, visit `/-/debug/grafana/d/precise-code-intel-worker/precise-c
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_uploads_lsifstore_duration_seconds_bucket{job=~"^precise-code-intel-worker.*"}[5m])))`
+Query:
 
+```
+histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_uploads_lsifstore_duration_seconds_bucket{job=~"^precise-code-intel-worker.*"}[5m])))
+```
 </details>
 
 <br />
@@ -8869,8 +10168,11 @@ To see this panel, visit `/-/debug/grafana/d/precise-code-intel-worker/precise-c
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_uploads_lsifstore_errors_total{job=~"^precise-code-intel-worker.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_uploads_lsifstore_errors_total{job=~"^precise-code-intel-worker.*"}[5m]))
+```
 </details>
 
 <br />
@@ -8888,8 +10190,11 @@ To see this panel, visit `/-/debug/grafana/d/precise-code-intel-worker/precise-c
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_uploads_lsifstore_errors_total{job=~"^precise-code-intel-worker.*"}[5m])) / (sum by (op)(increase(src_codeintel_uploads_lsifstore_total{job=~"^precise-code-intel-worker.*"}[5m])) + sum by (op)(increase(src_codeintel_uploads_lsifstore_errors_total{job=~"^precise-code-intel-worker.*"}[5m]))) * 100`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_uploads_lsifstore_errors_total{job=~"^precise-code-intel-worker.*"}[5m])) / (sum by (op)(increase(src_codeintel_uploads_lsifstore_total{job=~"^precise-code-intel-worker.*"}[5m])) + sum by (op)(increase(src_codeintel_uploads_lsifstore_errors_total{job=~"^precise-code-intel-worker.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -8909,8 +10214,11 @@ To see this panel, visit `/-/debug/grafana/d/precise-code-intel-worker/precise-c
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_workerutil_dbworker_store_codeintel_upload_total{job=~"^precise-code-intel-worker.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_workerutil_dbworker_store_codeintel_upload_total{job=~"^precise-code-intel-worker.*"}[5m]))
+```
 </details>
 
 <br />
@@ -8928,8 +10236,11 @@ To see this panel, visit `/-/debug/grafana/d/precise-code-intel-worker/precise-c
 <details>
 <summary>Technical details</summary>
 
-Query: `sum  by (le)(rate(src_workerutil_dbworker_store_codeintel_upload_duration_seconds_bucket{job=~"^precise-code-intel-worker.*"}[5m]))`
+Query:
 
+```
+sum  by (le)(rate(src_workerutil_dbworker_store_codeintel_upload_duration_seconds_bucket{job=~"^precise-code-intel-worker.*"}[5m]))
+```
 </details>
 
 <br />
@@ -8947,8 +10258,11 @@ To see this panel, visit `/-/debug/grafana/d/precise-code-intel-worker/precise-c
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_workerutil_dbworker_store_codeintel_upload_errors_total{job=~"^precise-code-intel-worker.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_workerutil_dbworker_store_codeintel_upload_errors_total{job=~"^precise-code-intel-worker.*"}[5m]))
+```
 </details>
 
 <br />
@@ -8966,8 +10280,11 @@ To see this panel, visit `/-/debug/grafana/d/precise-code-intel-worker/precise-c
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_workerutil_dbworker_store_codeintel_upload_errors_total{job=~"^precise-code-intel-worker.*"}[5m])) / (sum(increase(src_workerutil_dbworker_store_codeintel_upload_total{job=~"^precise-code-intel-worker.*"}[5m])) + sum(increase(src_workerutil_dbworker_store_codeintel_upload_errors_total{job=~"^precise-code-intel-worker.*"}[5m]))) * 100`
+Query:
 
+```
+sum(increase(src_workerutil_dbworker_store_codeintel_upload_errors_total{job=~"^precise-code-intel-worker.*"}[5m])) / (sum(increase(src_workerutil_dbworker_store_codeintel_upload_total{job=~"^precise-code-intel-worker.*"}[5m])) + sum(increase(src_workerutil_dbworker_store_codeintel_upload_errors_total{job=~"^precise-code-intel-worker.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -8987,8 +10304,11 @@ To see this panel, visit `/-/debug/grafana/d/precise-code-intel-worker/precise-c
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_gitserver_total{job=~"^precise-code-intel-worker.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_gitserver_total{job=~"^precise-code-intel-worker.*"}[5m]))
+```
 </details>
 
 <br />
@@ -9006,8 +10326,11 @@ To see this panel, visit `/-/debug/grafana/d/precise-code-intel-worker/precise-c
 <details>
 <summary>Technical details</summary>
 
-Query: `sum  by (le)(rate(src_codeintel_gitserver_duration_seconds_bucket{job=~"^precise-code-intel-worker.*"}[5m]))`
+Query:
 
+```
+sum  by (le)(rate(src_codeintel_gitserver_duration_seconds_bucket{job=~"^precise-code-intel-worker.*"}[5m]))
+```
 </details>
 
 <br />
@@ -9025,8 +10348,11 @@ To see this panel, visit `/-/debug/grafana/d/precise-code-intel-worker/precise-c
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_gitserver_errors_total{job=~"^precise-code-intel-worker.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_gitserver_errors_total{job=~"^precise-code-intel-worker.*"}[5m]))
+```
 </details>
 
 <br />
@@ -9044,8 +10370,11 @@ To see this panel, visit `/-/debug/grafana/d/precise-code-intel-worker/precise-c
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_gitserver_errors_total{job=~"^precise-code-intel-worker.*"}[5m])) / (sum(increase(src_codeintel_gitserver_total{job=~"^precise-code-intel-worker.*"}[5m])) + sum(increase(src_codeintel_gitserver_errors_total{job=~"^precise-code-intel-worker.*"}[5m]))) * 100`
+Query:
 
+```
+sum(increase(src_codeintel_gitserver_errors_total{job=~"^precise-code-intel-worker.*"}[5m])) / (sum(increase(src_codeintel_gitserver_total{job=~"^precise-code-intel-worker.*"}[5m])) + sum(increase(src_codeintel_gitserver_errors_total{job=~"^precise-code-intel-worker.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -9063,8 +10392,11 @@ To see this panel, visit `/-/debug/grafana/d/precise-code-intel-worker/precise-c
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_gitserver_total{job=~"^precise-code-intel-worker.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_gitserver_total{job=~"^precise-code-intel-worker.*"}[5m]))
+```
 </details>
 
 <br />
@@ -9082,8 +10414,11 @@ To see this panel, visit `/-/debug/grafana/d/precise-code-intel-worker/precise-c
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_gitserver_duration_seconds_bucket{job=~"^precise-code-intel-worker.*"}[5m])))`
+Query:
 
+```
+histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_gitserver_duration_seconds_bucket{job=~"^precise-code-intel-worker.*"}[5m])))
+```
 </details>
 
 <br />
@@ -9101,8 +10436,11 @@ To see this panel, visit `/-/debug/grafana/d/precise-code-intel-worker/precise-c
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_gitserver_errors_total{job=~"^precise-code-intel-worker.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_gitserver_errors_total{job=~"^precise-code-intel-worker.*"}[5m]))
+```
 </details>
 
 <br />
@@ -9120,8 +10458,11 @@ To see this panel, visit `/-/debug/grafana/d/precise-code-intel-worker/precise-c
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_gitserver_errors_total{job=~"^precise-code-intel-worker.*"}[5m])) / (sum by (op)(increase(src_codeintel_gitserver_total{job=~"^precise-code-intel-worker.*"}[5m])) + sum by (op)(increase(src_codeintel_gitserver_errors_total{job=~"^precise-code-intel-worker.*"}[5m]))) * 100`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_gitserver_errors_total{job=~"^precise-code-intel-worker.*"}[5m])) / (sum by (op)(increase(src_codeintel_gitserver_total{job=~"^precise-code-intel-worker.*"}[5m])) + sum by (op)(increase(src_codeintel_gitserver_errors_total{job=~"^precise-code-intel-worker.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -9141,8 +10482,11 @@ To see this panel, visit `/-/debug/grafana/d/precise-code-intel-worker/precise-c
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_uploadstore_total{job=~"^precise-code-intel-worker.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_uploadstore_total{job=~"^precise-code-intel-worker.*"}[5m]))
+```
 </details>
 
 <br />
@@ -9160,8 +10504,11 @@ To see this panel, visit `/-/debug/grafana/d/precise-code-intel-worker/precise-c
 <details>
 <summary>Technical details</summary>
 
-Query: `sum  by (le)(rate(src_codeintel_uploadstore_duration_seconds_bucket{job=~"^precise-code-intel-worker.*"}[5m]))`
+Query:
 
+```
+sum  by (le)(rate(src_codeintel_uploadstore_duration_seconds_bucket{job=~"^precise-code-intel-worker.*"}[5m]))
+```
 </details>
 
 <br />
@@ -9179,8 +10526,11 @@ To see this panel, visit `/-/debug/grafana/d/precise-code-intel-worker/precise-c
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_uploadstore_errors_total{job=~"^precise-code-intel-worker.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_uploadstore_errors_total{job=~"^precise-code-intel-worker.*"}[5m]))
+```
 </details>
 
 <br />
@@ -9198,8 +10548,11 @@ To see this panel, visit `/-/debug/grafana/d/precise-code-intel-worker/precise-c
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_uploadstore_errors_total{job=~"^precise-code-intel-worker.*"}[5m])) / (sum(increase(src_codeintel_uploadstore_total{job=~"^precise-code-intel-worker.*"}[5m])) + sum(increase(src_codeintel_uploadstore_errors_total{job=~"^precise-code-intel-worker.*"}[5m]))) * 100`
+Query:
 
+```
+sum(increase(src_codeintel_uploadstore_errors_total{job=~"^precise-code-intel-worker.*"}[5m])) / (sum(increase(src_codeintel_uploadstore_total{job=~"^precise-code-intel-worker.*"}[5m])) + sum(increase(src_codeintel_uploadstore_errors_total{job=~"^precise-code-intel-worker.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -9217,8 +10570,11 @@ To see this panel, visit `/-/debug/grafana/d/precise-code-intel-worker/precise-c
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_uploadstore_total{job=~"^precise-code-intel-worker.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_uploadstore_total{job=~"^precise-code-intel-worker.*"}[5m]))
+```
 </details>
 
 <br />
@@ -9236,8 +10592,11 @@ To see this panel, visit `/-/debug/grafana/d/precise-code-intel-worker/precise-c
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_uploadstore_duration_seconds_bucket{job=~"^precise-code-intel-worker.*"}[5m])))`
+Query:
 
+```
+histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_uploadstore_duration_seconds_bucket{job=~"^precise-code-intel-worker.*"}[5m])))
+```
 </details>
 
 <br />
@@ -9255,8 +10614,11 @@ To see this panel, visit `/-/debug/grafana/d/precise-code-intel-worker/precise-c
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_uploadstore_errors_total{job=~"^precise-code-intel-worker.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_uploadstore_errors_total{job=~"^precise-code-intel-worker.*"}[5m]))
+```
 </details>
 
 <br />
@@ -9274,8 +10636,11 @@ To see this panel, visit `/-/debug/grafana/d/precise-code-intel-worker/precise-c
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_uploadstore_errors_total{job=~"^precise-code-intel-worker.*"}[5m])) / (sum by (op)(increase(src_codeintel_uploadstore_total{job=~"^precise-code-intel-worker.*"}[5m])) + sum by (op)(increase(src_codeintel_uploadstore_errors_total{job=~"^precise-code-intel-worker.*"}[5m]))) * 100`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_uploadstore_errors_total{job=~"^precise-code-intel-worker.*"}[5m])) / (sum by (op)(increase(src_codeintel_uploadstore_total{job=~"^precise-code-intel-worker.*"}[5m])) + sum by (op)(increase(src_codeintel_uploadstore_errors_total{job=~"^precise-code-intel-worker.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -9295,8 +10660,11 @@ To see this panel, visit `/-/debug/grafana/d/precise-code-intel-worker/precise-c
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (app_name, db_name) (src_pgsql_conns_max_open{app_name="precise-code-intel-worker"})`
+Query:
 
+```
+sum by (app_name, db_name) (src_pgsql_conns_max_open{app_name="precise-code-intel-worker"})
+```
 </details>
 
 <br />
@@ -9314,8 +10682,11 @@ To see this panel, visit `/-/debug/grafana/d/precise-code-intel-worker/precise-c
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (app_name, db_name) (src_pgsql_conns_open{app_name="precise-code-intel-worker"})`
+Query:
 
+```
+sum by (app_name, db_name) (src_pgsql_conns_open{app_name="precise-code-intel-worker"})
+```
 </details>
 
 <br />
@@ -9333,8 +10704,11 @@ To see this panel, visit `/-/debug/grafana/d/precise-code-intel-worker/precise-c
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (app_name, db_name) (src_pgsql_conns_in_use{app_name="precise-code-intel-worker"})`
+Query:
 
+```
+sum by (app_name, db_name) (src_pgsql_conns_in_use{app_name="precise-code-intel-worker"})
+```
 </details>
 
 <br />
@@ -9352,8 +10726,11 @@ To see this panel, visit `/-/debug/grafana/d/precise-code-intel-worker/precise-c
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (app_name, db_name) (src_pgsql_conns_idle{app_name="precise-code-intel-worker"})`
+Query:
 
+```
+sum by (app_name, db_name) (src_pgsql_conns_idle{app_name="precise-code-intel-worker"})
+```
 </details>
 
 <br />
@@ -9371,8 +10748,11 @@ To see this panel, visit `/-/debug/grafana/d/precise-code-intel-worker/precise-c
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (app_name, db_name) (increase(src_pgsql_conns_blocked_seconds{app_name="precise-code-intel-worker"}[5m])) / sum by (app_name, db_name) (increase(src_pgsql_conns_waited_for{app_name="precise-code-intel-worker"}[5m]))`
+Query:
 
+```
+sum by (app_name, db_name) (increase(src_pgsql_conns_blocked_seconds{app_name="precise-code-intel-worker"}[5m])) / sum by (app_name, db_name) (increase(src_pgsql_conns_waited_for{app_name="precise-code-intel-worker"}[5m]))
+```
 </details>
 
 <br />
@@ -9390,8 +10770,11 @@ To see this panel, visit `/-/debug/grafana/d/precise-code-intel-worker/precise-c
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (app_name, db_name) (increase(src_pgsql_conns_closed_max_idle{app_name="precise-code-intel-worker"}[5m]))`
+Query:
 
+```
+sum by (app_name, db_name) (increase(src_pgsql_conns_closed_max_idle{app_name="precise-code-intel-worker"}[5m]))
+```
 </details>
 
 <br />
@@ -9409,8 +10792,11 @@ To see this panel, visit `/-/debug/grafana/d/precise-code-intel-worker/precise-c
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (app_name, db_name) (increase(src_pgsql_conns_closed_max_lifetime{app_name="precise-code-intel-worker"}[5m]))`
+Query:
 
+```
+sum by (app_name, db_name) (increase(src_pgsql_conns_closed_max_lifetime{app_name="precise-code-intel-worker"}[5m]))
+```
 </details>
 
 <br />
@@ -9428,8 +10814,11 @@ To see this panel, visit `/-/debug/grafana/d/precise-code-intel-worker/precise-c
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (app_name, db_name) (increase(src_pgsql_conns_closed_max_idle_time{app_name="precise-code-intel-worker"}[5m]))`
+Query:
 
+```
+sum by (app_name, db_name) (increase(src_pgsql_conns_closed_max_idle_time{app_name="precise-code-intel-worker"}[5m]))
+```
 </details>
 
 <br />
@@ -9459,8 +10848,11 @@ To see this panel, visit `/-/debug/grafana/d/precise-code-intel-worker/precise-c
 <details>
 <summary>Technical details</summary>
 
-Query: `count by(name) ((time() - container_last_seen{name=~"^precise-code-intel-worker.*"}) > 60)`
+Query:
 
+```
+count by(name) ((time() - container_last_seen{name=~"^precise-code-intel-worker.*"}) > 60)
+```
 </details>
 
 <br />
@@ -9478,8 +10870,11 @@ To see this panel, visit `/-/debug/grafana/d/precise-code-intel-worker/precise-c
 <details>
 <summary>Technical details</summary>
 
-Query: `cadvisor_container_cpu_usage_percentage_total{name=~"^precise-code-intel-worker.*"}`
+Query:
 
+```
+cadvisor_container_cpu_usage_percentage_total{name=~"^precise-code-intel-worker.*"}
+```
 </details>
 
 <br />
@@ -9497,8 +10892,11 @@ To see this panel, visit `/-/debug/grafana/d/precise-code-intel-worker/precise-c
 <details>
 <summary>Technical details</summary>
 
-Query: `cadvisor_container_memory_usage_percentage_total{name=~"^precise-code-intel-worker.*"}`
+Query:
 
+```
+cadvisor_container_memory_usage_percentage_total{name=~"^precise-code-intel-worker.*"}
+```
 </details>
 
 <br />
@@ -9519,8 +10917,11 @@ To see this panel, visit `/-/debug/grafana/d/precise-code-intel-worker/precise-c
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by(name) (rate(container_fs_reads_total{name=~"^precise-code-intel-worker.*"}[1h]) + rate(container_fs_writes_total{name=~"^precise-code-intel-worker.*"}[1h]))`
+Query:
 
+```
+sum by(name) (rate(container_fs_reads_total{name=~"^precise-code-intel-worker.*"}[1h]) + rate(container_fs_writes_total{name=~"^precise-code-intel-worker.*"}[1h]))
+```
 </details>
 
 <br />
@@ -9540,8 +10941,11 @@ To see this panel, visit `/-/debug/grafana/d/precise-code-intel-worker/precise-c
 <details>
 <summary>Technical details</summary>
 
-Query: `quantile_over_time(0.9, cadvisor_container_cpu_usage_percentage_total{name=~"^precise-code-intel-worker.*"}[1d])`
+Query:
 
+```
+quantile_over_time(0.9, cadvisor_container_cpu_usage_percentage_total{name=~"^precise-code-intel-worker.*"}[1d])
+```
 </details>
 
 <br />
@@ -9559,8 +10963,11 @@ To see this panel, visit `/-/debug/grafana/d/precise-code-intel-worker/precise-c
 <details>
 <summary>Technical details</summary>
 
-Query: `max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^precise-code-intel-worker.*"}[1d])`
+Query:
 
+```
+max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^precise-code-intel-worker.*"}[1d])
+```
 </details>
 
 <br />
@@ -9578,8 +10985,11 @@ To see this panel, visit `/-/debug/grafana/d/precise-code-intel-worker/precise-c
 <details>
 <summary>Technical details</summary>
 
-Query: `max_over_time(cadvisor_container_cpu_usage_percentage_total{name=~"^precise-code-intel-worker.*"}[5m])`
+Query:
 
+```
+max_over_time(cadvisor_container_cpu_usage_percentage_total{name=~"^precise-code-intel-worker.*"}[5m])
+```
 </details>
 
 <br />
@@ -9597,8 +11007,11 @@ To see this panel, visit `/-/debug/grafana/d/precise-code-intel-worker/precise-c
 <details>
 <summary>Technical details</summary>
 
-Query: `max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^precise-code-intel-worker.*"}[5m])`
+Query:
 
+```
+max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^precise-code-intel-worker.*"}[5m])
+```
 </details>
 
 <br />
@@ -9619,8 +11032,11 @@ To see this panel, visit `/-/debug/grafana/d/precise-code-intel-worker/precise-c
 <details>
 <summary>Technical details</summary>
 
-Query: `max by (name) (container_oom_events_total{name=~"^precise-code-intel-worker.*"})`
+Query:
 
+```
+max by (name) (container_oom_events_total{name=~"^precise-code-intel-worker.*"})
+```
 </details>
 
 <br />
@@ -9642,8 +11058,11 @@ To see this panel, visit `/-/debug/grafana/d/precise-code-intel-worker/precise-c
 <details>
 <summary>Technical details</summary>
 
-Query: `max by(instance) (go_goroutines{job=~".*precise-code-intel-worker"})`
+Query:
 
+```
+max by(instance) (go_goroutines{job=~".*precise-code-intel-worker"})
+```
 </details>
 
 <br />
@@ -9661,8 +11080,11 @@ To see this panel, visit `/-/debug/grafana/d/precise-code-intel-worker/precise-c
 <details>
 <summary>Technical details</summary>
 
-Query: `max by(instance) (go_gc_duration_seconds{job=~".*precise-code-intel-worker"})`
+Query:
 
+```
+max by(instance) (go_gc_duration_seconds{job=~".*precise-code-intel-worker"})
+```
 </details>
 
 <br />
@@ -9682,8 +11104,11 @@ To see this panel, visit `/-/debug/grafana/d/precise-code-intel-worker/precise-c
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by(app) (up{app=~".*precise-code-intel-worker"}) / count by (app) (up{app=~".*precise-code-intel-worker"}) * 100`
+Query:
 
+```
+sum by(app) (up{app=~".*precise-code-intel-worker"}) / count by (app) (up{app=~".*precise-code-intel-worker"}) * 100
+```
 </details>
 
 <br />
@@ -9711,8 +11136,11 @@ To see this panel, visit `/-/debug/grafana/d/redis/redis?viewPanel=100000` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `redis_up{app="redis-store"}`
+Query:
 
+```
+redis_up{app="redis-store"}
+```
 </details>
 
 <br />
@@ -9734,8 +11162,11 @@ To see this panel, visit `/-/debug/grafana/d/redis/redis?viewPanel=100100` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `redis_up{app="redis-cache"}`
+Query:
 
+```
+redis_up{app="redis-cache"}
+```
 </details>
 
 <br />
@@ -9755,8 +11186,11 @@ To see this panel, visit `/-/debug/grafana/d/redis/redis?viewPanel=100200` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `quantile_over_time(0.9, cadvisor_container_cpu_usage_percentage_total{name=~"^redis-cache.*"}[1d])`
+Query:
 
+```
+quantile_over_time(0.9, cadvisor_container_cpu_usage_percentage_total{name=~"^redis-cache.*"}[1d])
+```
 </details>
 
 <br />
@@ -9774,8 +11208,11 @@ To see this panel, visit `/-/debug/grafana/d/redis/redis?viewPanel=100201` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^redis-cache.*"}[1d])`
+Query:
 
+```
+max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^redis-cache.*"}[1d])
+```
 </details>
 
 <br />
@@ -9793,8 +11230,11 @@ To see this panel, visit `/-/debug/grafana/d/redis/redis?viewPanel=100210` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `max_over_time(cadvisor_container_cpu_usage_percentage_total{name=~"^redis-cache.*"}[5m])`
+Query:
 
+```
+max_over_time(cadvisor_container_cpu_usage_percentage_total{name=~"^redis-cache.*"}[5m])
+```
 </details>
 
 <br />
@@ -9812,8 +11252,11 @@ To see this panel, visit `/-/debug/grafana/d/redis/redis?viewPanel=100211` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^redis-cache.*"}[5m])`
+Query:
 
+```
+max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^redis-cache.*"}[5m])
+```
 </details>
 
 <br />
@@ -9834,8 +11277,11 @@ To see this panel, visit `/-/debug/grafana/d/redis/redis?viewPanel=100212` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `max by (name) (container_oom_events_total{name=~"^redis-cache.*"})`
+Query:
 
+```
+max by (name) (container_oom_events_total{name=~"^redis-cache.*"})
+```
 </details>
 
 <br />
@@ -9855,8 +11301,11 @@ To see this panel, visit `/-/debug/grafana/d/redis/redis?viewPanel=100300` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `quantile_over_time(0.9, cadvisor_container_cpu_usage_percentage_total{name=~"^redis-store.*"}[1d])`
+Query:
 
+```
+quantile_over_time(0.9, cadvisor_container_cpu_usage_percentage_total{name=~"^redis-store.*"}[1d])
+```
 </details>
 
 <br />
@@ -9874,8 +11323,11 @@ To see this panel, visit `/-/debug/grafana/d/redis/redis?viewPanel=100301` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^redis-store.*"}[1d])`
+Query:
 
+```
+max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^redis-store.*"}[1d])
+```
 </details>
 
 <br />
@@ -9893,8 +11345,11 @@ To see this panel, visit `/-/debug/grafana/d/redis/redis?viewPanel=100310` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `max_over_time(cadvisor_container_cpu_usage_percentage_total{name=~"^redis-store.*"}[5m])`
+Query:
 
+```
+max_over_time(cadvisor_container_cpu_usage_percentage_total{name=~"^redis-store.*"}[5m])
+```
 </details>
 
 <br />
@@ -9912,8 +11367,11 @@ To see this panel, visit `/-/debug/grafana/d/redis/redis?viewPanel=100311` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^redis-store.*"}[5m])`
+Query:
 
+```
+max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^redis-store.*"}[5m])
+```
 </details>
 
 <br />
@@ -9934,8 +11392,11 @@ To see this panel, visit `/-/debug/grafana/d/redis/redis?viewPanel=100312` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `max by (name) (container_oom_events_total{name=~"^redis-store.*"})`
+Query:
 
+```
+max by (name) (container_oom_events_total{name=~"^redis-store.*"})
+```
 </details>
 
 <br />
@@ -9955,8 +11416,11 @@ To see this panel, visit `/-/debug/grafana/d/redis/redis?viewPanel=100400` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by(app) (up{app=~".*redis-cache"}) / count by (app) (up{app=~".*redis-cache"}) * 100`
+Query:
 
+```
+sum by(app) (up{app=~".*redis-cache"}) / count by (app) (up{app=~".*redis-cache"}) * 100
+```
 </details>
 
 <br />
@@ -9976,8 +11440,11 @@ To see this panel, visit `/-/debug/grafana/d/redis/redis?viewPanel=100500` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by(app) (up{app=~".*redis-store"}) / count by (app) (up{app=~".*redis-store"}) * 100`
+Query:
 
+```
+sum by(app) (up{app=~".*redis-store"}) / count by (app) (up{app=~".*redis-store"}) * 100
+```
 </details>
 
 <br />
@@ -10005,8 +11472,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=100000` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (job_name) (src_worker_jobs{job=~"^worker.*"})`
+Query:
 
+```
+sum by (job_name) (src_worker_jobs{job=~"^worker.*"})
+```
 </details>
 
 <br />
@@ -10024,8 +11494,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=100010` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum (src_worker_jobs{job=~"^worker.*", job_name="codeintel-upload-janitor"})`
+Query:
 
+```
+sum (src_worker_jobs{job=~"^worker.*", job_name="codeintel-upload-janitor"})
+```
 </details>
 
 <br />
@@ -10043,8 +11516,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=100011` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum (src_worker_jobs{job=~"^worker.*", job_name="codeintel-commitgraph-updater"})`
+Query:
 
+```
+sum (src_worker_jobs{job=~"^worker.*", job_name="codeintel-commitgraph-updater"})
+```
 </details>
 
 <br />
@@ -10062,8 +11538,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=100012` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum (src_worker_jobs{job=~"^worker.*", job_name="codeintel-autoindexing-scheduler"})`
+Query:
 
+```
+sum (src_worker_jobs{job=~"^worker.*", job_name="codeintel-autoindexing-scheduler"})
+```
 </details>
 
 <br />
@@ -10085,8 +11564,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=100100` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `(max(src_records_encrypted_at_rest_total) by (tableName)) / ((max(src_records_encrypted_at_rest_total) by (tableName)) + (max(src_records_unencrypted_at_rest_total) by (tableName))) * 100`
+Query:
 
+```
+(max(src_records_encrypted_at_rest_total) by (tableName)) / ((max(src_records_encrypted_at_rest_total) by (tableName)) + (max(src_records_unencrypted_at_rest_total) by (tableName))) * 100
+```
 </details>
 
 <br />
@@ -10106,8 +11588,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=100101` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (tableName)(increase(src_records_encrypted_total{job=~"^worker.*"}[5m]))`
+Query:
 
+```
+sum by (tableName)(increase(src_records_encrypted_total{job=~"^worker.*"}[5m]))
+```
 </details>
 
 <br />
@@ -10127,8 +11612,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=100102` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (tableName)(increase(src_records_decrypted_total{job=~"^worker.*"}[5m]))`
+Query:
 
+```
+sum by (tableName)(increase(src_records_decrypted_total{job=~"^worker.*"}[5m]))
+```
 </details>
 
 <br />
@@ -10148,8 +11636,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=100103` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_record_encryption_errors_total{job=~"^worker.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_record_encryption_errors_total{job=~"^worker.*"}[5m]))
+```
 </details>
 
 <br />
@@ -10169,8 +11660,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=100200` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `max(src_codeintel_commit_graph_total{job=~"^worker.*"})`
+Query:
 
+```
+max(src_codeintel_commit_graph_total{job=~"^worker.*"})
+```
 </details>
 
 <br />
@@ -10194,8 +11688,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=100201` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_commit_graph_total{job=~"^worker.*"}[30m])) / sum(increase(src_codeintel_commit_graph_processor_total{job=~"^worker.*"}[30m]))`
+Query:
 
+```
+sum(increase(src_codeintel_commit_graph_total{job=~"^worker.*"}[30m])) / sum(increase(src_codeintel_commit_graph_processor_total{job=~"^worker.*"}[30m]))
+```
 </details>
 
 <br />
@@ -10213,8 +11710,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=100202` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `max(src_codeintel_commit_graph_queued_duration_seconds_total{job=~"^worker.*"})`
+Query:
 
+```
+max(src_codeintel_commit_graph_queued_duration_seconds_total{job=~"^worker.*"})
+```
 </details>
 
 <br />
@@ -10234,8 +11734,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=100300` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_commit_graph_processor_total{job=~"^worker.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_commit_graph_processor_total{job=~"^worker.*"}[5m]))
+```
 </details>
 
 <br />
@@ -10253,8 +11756,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=100301` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum  by (le)(rate(src_codeintel_commit_graph_processor_duration_seconds_bucket{job=~"^worker.*"}[5m]))`
+Query:
 
+```
+sum  by (le)(rate(src_codeintel_commit_graph_processor_duration_seconds_bucket{job=~"^worker.*"}[5m]))
+```
 </details>
 
 <br />
@@ -10272,8 +11778,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=100302` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_commit_graph_processor_errors_total{job=~"^worker.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_commit_graph_processor_errors_total{job=~"^worker.*"}[5m]))
+```
 </details>
 
 <br />
@@ -10291,8 +11800,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=100303` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_commit_graph_processor_errors_total{job=~"^worker.*"}[5m])) / (sum(increase(src_codeintel_commit_graph_processor_total{job=~"^worker.*"}[5m])) + sum(increase(src_codeintel_commit_graph_processor_errors_total{job=~"^worker.*"}[5m]))) * 100`
+Query:
 
+```
+sum(increase(src_codeintel_commit_graph_processor_errors_total{job=~"^worker.*"}[5m])) / (sum(increase(src_codeintel_commit_graph_processor_total{job=~"^worker.*"}[5m])) + sum(increase(src_codeintel_commit_graph_processor_errors_total{job=~"^worker.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -10312,8 +11824,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=100400` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `max(src_codeintel_dependency_index_total{job=~"^worker.*"})`
+Query:
 
+```
+max(src_codeintel_dependency_index_total{job=~"^worker.*"})
+```
 </details>
 
 <br />
@@ -10337,8 +11852,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=100401` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_dependency_index_total{job=~"^worker.*"}[30m])) / sum(increase(src_codeintel_dependency_index_processor_total{job=~"^worker.*"}[30m]))`
+Query:
 
+```
+sum(increase(src_codeintel_dependency_index_total{job=~"^worker.*"}[30m])) / sum(increase(src_codeintel_dependency_index_processor_total{job=~"^worker.*"}[30m]))
+```
 </details>
 
 <br />
@@ -10356,8 +11874,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=100402` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `max(src_codeintel_dependency_index_queued_duration_seconds_total{job=~"^worker.*"})`
+Query:
 
+```
+max(src_codeintel_dependency_index_queued_duration_seconds_total{job=~"^worker.*"})
+```
 </details>
 
 <br />
@@ -10377,8 +11898,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=100500` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(src_codeintel_dependency_index_processor_handlers{job=~"^worker.*"})`
+Query:
 
+```
+sum(src_codeintel_dependency_index_processor_handlers{job=~"^worker.*"})
+```
 </details>
 
 <br />
@@ -10396,8 +11920,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=100510` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_dependency_index_processor_total{job=~"^worker.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_dependency_index_processor_total{job=~"^worker.*"}[5m]))
+```
 </details>
 
 <br />
@@ -10415,8 +11942,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=100511` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum  by (le)(rate(src_codeintel_dependency_index_processor_duration_seconds_bucket{job=~"^worker.*"}[5m]))`
+Query:
 
+```
+sum  by (le)(rate(src_codeintel_dependency_index_processor_duration_seconds_bucket{job=~"^worker.*"}[5m]))
+```
 </details>
 
 <br />
@@ -10434,8 +11964,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=100512` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_dependency_index_processor_errors_total{job=~"^worker.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_dependency_index_processor_errors_total{job=~"^worker.*"}[5m]))
+```
 </details>
 
 <br />
@@ -10453,8 +11986,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=100513` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_dependency_index_processor_errors_total{job=~"^worker.*"}[5m])) / (sum(increase(src_codeintel_dependency_index_processor_total{job=~"^worker.*"}[5m])) + sum(increase(src_codeintel_dependency_index_processor_errors_total{job=~"^worker.*"}[5m]))) * 100`
+Query:
 
+```
+sum(increase(src_codeintel_dependency_index_processor_errors_total{job=~"^worker.*"}[5m])) / (sum(increase(src_codeintel_dependency_index_processor_total{job=~"^worker.*"}[5m])) + sum(increase(src_codeintel_dependency_index_processor_errors_total{job=~"^worker.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -10474,8 +12010,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=100600` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_autoindexing_total{op='HandleIndexSchedule',job=~"^worker.*"}[10m]))`
+Query:
 
+```
+sum(increase(src_codeintel_autoindexing_total{op='HandleIndexSchedule',job=~"^worker.*"}[10m]))
+```
 </details>
 
 <br />
@@ -10493,8 +12032,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=100601` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum  by (le)(rate(src_codeintel_autoindexing_duration_seconds_bucket{op='HandleIndexSchedule',job=~"^worker.*"}[10m]))`
+Query:
 
+```
+sum  by (le)(rate(src_codeintel_autoindexing_duration_seconds_bucket{op='HandleIndexSchedule',job=~"^worker.*"}[10m]))
+```
 </details>
 
 <br />
@@ -10512,8 +12054,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=100602` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_autoindexing_errors_total{op='HandleIndexSchedule',job=~"^worker.*"}[10m]))`
+Query:
 
+```
+sum(increase(src_codeintel_autoindexing_errors_total{op='HandleIndexSchedule',job=~"^worker.*"}[10m]))
+```
 </details>
 
 <br />
@@ -10531,8 +12076,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=100603` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_autoindexing_errors_total{op='HandleIndexSchedule',job=~"^worker.*"}[10m])) / (sum(increase(src_codeintel_autoindexing_total{op='HandleIndexSchedule',job=~"^worker.*"}[10m])) + sum(increase(src_codeintel_autoindexing_errors_total{op='HandleIndexSchedule',job=~"^worker.*"}[10m]))) * 100`
+Query:
 
+```
+sum(increase(src_codeintel_autoindexing_errors_total{op='HandleIndexSchedule',job=~"^worker.*"}[10m])) / (sum(increase(src_codeintel_autoindexing_total{op='HandleIndexSchedule',job=~"^worker.*"}[10m])) + sum(increase(src_codeintel_autoindexing_errors_total{op='HandleIndexSchedule',job=~"^worker.*"}[10m]))) * 100
+```
 </details>
 
 <br />
@@ -10552,8 +12100,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=100700` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_uploads_store_total{job=~"^worker.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_uploads_store_total{job=~"^worker.*"}[5m]))
+```
 </details>
 
 <br />
@@ -10571,8 +12122,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=100701` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum  by (le)(rate(src_codeintel_uploads_store_duration_seconds_bucket{job=~"^worker.*"}[5m]))`
+Query:
 
+```
+sum  by (le)(rate(src_codeintel_uploads_store_duration_seconds_bucket{job=~"^worker.*"}[5m]))
+```
 </details>
 
 <br />
@@ -10590,8 +12144,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=100702` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_uploads_store_errors_total{job=~"^worker.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_uploads_store_errors_total{job=~"^worker.*"}[5m]))
+```
 </details>
 
 <br />
@@ -10609,8 +12166,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=100703` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_uploads_store_errors_total{job=~"^worker.*"}[5m])) / (sum(increase(src_codeintel_uploads_store_total{job=~"^worker.*"}[5m])) + sum(increase(src_codeintel_uploads_store_errors_total{job=~"^worker.*"}[5m]))) * 100`
+Query:
 
+```
+sum(increase(src_codeintel_uploads_store_errors_total{job=~"^worker.*"}[5m])) / (sum(increase(src_codeintel_uploads_store_total{job=~"^worker.*"}[5m])) + sum(increase(src_codeintel_uploads_store_errors_total{job=~"^worker.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -10628,8 +12188,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=100710` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_uploads_store_total{job=~"^worker.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_uploads_store_total{job=~"^worker.*"}[5m]))
+```
 </details>
 
 <br />
@@ -10647,8 +12210,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=100711` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_uploads_store_duration_seconds_bucket{job=~"^worker.*"}[5m])))`
+Query:
 
+```
+histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_uploads_store_duration_seconds_bucket{job=~"^worker.*"}[5m])))
+```
 </details>
 
 <br />
@@ -10666,8 +12232,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=100712` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_uploads_store_errors_total{job=~"^worker.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_uploads_store_errors_total{job=~"^worker.*"}[5m]))
+```
 </details>
 
 <br />
@@ -10685,8 +12254,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=100713` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_uploads_store_errors_total{job=~"^worker.*"}[5m])) / (sum by (op)(increase(src_codeintel_uploads_store_total{job=~"^worker.*"}[5m])) + sum by (op)(increase(src_codeintel_uploads_store_errors_total{job=~"^worker.*"}[5m]))) * 100`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_uploads_store_errors_total{job=~"^worker.*"}[5m])) / (sum by (op)(increase(src_codeintel_uploads_store_total{job=~"^worker.*"}[5m])) + sum by (op)(increase(src_codeintel_uploads_store_errors_total{job=~"^worker.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -10706,8 +12278,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=100800` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_uploads_lsifstore_total{job=~"^worker.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_uploads_lsifstore_total{job=~"^worker.*"}[5m]))
+```
 </details>
 
 <br />
@@ -10725,8 +12300,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=100801` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum  by (le)(rate(src_codeintel_uploads_lsifstore_duration_seconds_bucket{job=~"^worker.*"}[5m]))`
+Query:
 
+```
+sum  by (le)(rate(src_codeintel_uploads_lsifstore_duration_seconds_bucket{job=~"^worker.*"}[5m]))
+```
 </details>
 
 <br />
@@ -10744,8 +12322,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=100802` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_uploads_lsifstore_errors_total{job=~"^worker.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_uploads_lsifstore_errors_total{job=~"^worker.*"}[5m]))
+```
 </details>
 
 <br />
@@ -10763,8 +12344,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=100803` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_uploads_lsifstore_errors_total{job=~"^worker.*"}[5m])) / (sum(increase(src_codeintel_uploads_lsifstore_total{job=~"^worker.*"}[5m])) + sum(increase(src_codeintel_uploads_lsifstore_errors_total{job=~"^worker.*"}[5m]))) * 100`
+Query:
 
+```
+sum(increase(src_codeintel_uploads_lsifstore_errors_total{job=~"^worker.*"}[5m])) / (sum(increase(src_codeintel_uploads_lsifstore_total{job=~"^worker.*"}[5m])) + sum(increase(src_codeintel_uploads_lsifstore_errors_total{job=~"^worker.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -10782,8 +12366,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=100810` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_uploads_lsifstore_total{job=~"^worker.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_uploads_lsifstore_total{job=~"^worker.*"}[5m]))
+```
 </details>
 
 <br />
@@ -10801,8 +12388,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=100811` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_uploads_lsifstore_duration_seconds_bucket{job=~"^worker.*"}[5m])))`
+Query:
 
+```
+histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_uploads_lsifstore_duration_seconds_bucket{job=~"^worker.*"}[5m])))
+```
 </details>
 
 <br />
@@ -10820,8 +12410,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=100812` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_uploads_lsifstore_errors_total{job=~"^worker.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_uploads_lsifstore_errors_total{job=~"^worker.*"}[5m]))
+```
 </details>
 
 <br />
@@ -10839,8 +12432,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=100813` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_uploads_lsifstore_errors_total{job=~"^worker.*"}[5m])) / (sum by (op)(increase(src_codeintel_uploads_lsifstore_total{job=~"^worker.*"}[5m])) + sum by (op)(increase(src_codeintel_uploads_lsifstore_errors_total{job=~"^worker.*"}[5m]))) * 100`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_uploads_lsifstore_errors_total{job=~"^worker.*"}[5m])) / (sum by (op)(increase(src_codeintel_uploads_lsifstore_total{job=~"^worker.*"}[5m])) + sum by (op)(increase(src_codeintel_uploads_lsifstore_errors_total{job=~"^worker.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -10860,8 +12456,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=100900` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_workerutil_dbworker_store_codeintel_dependency_index_total{job=~"^worker.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_workerutil_dbworker_store_codeintel_dependency_index_total{job=~"^worker.*"}[5m]))
+```
 </details>
 
 <br />
@@ -10879,8 +12478,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=100901` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum  by (le)(rate(src_workerutil_dbworker_store_codeintel_dependency_index_duration_seconds_bucket{job=~"^worker.*"}[5m]))`
+Query:
 
+```
+sum  by (le)(rate(src_workerutil_dbworker_store_codeintel_dependency_index_duration_seconds_bucket{job=~"^worker.*"}[5m]))
+```
 </details>
 
 <br />
@@ -10898,8 +12500,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=100902` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_workerutil_dbworker_store_codeintel_dependency_index_errors_total{job=~"^worker.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_workerutil_dbworker_store_codeintel_dependency_index_errors_total{job=~"^worker.*"}[5m]))
+```
 </details>
 
 <br />
@@ -10917,8 +12522,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=100903` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_workerutil_dbworker_store_codeintel_dependency_index_errors_total{job=~"^worker.*"}[5m])) / (sum(increase(src_workerutil_dbworker_store_codeintel_dependency_index_total{job=~"^worker.*"}[5m])) + sum(increase(src_workerutil_dbworker_store_codeintel_dependency_index_errors_total{job=~"^worker.*"}[5m]))) * 100`
+Query:
 
+```
+sum(increase(src_workerutil_dbworker_store_codeintel_dependency_index_errors_total{job=~"^worker.*"}[5m])) / (sum(increase(src_workerutil_dbworker_store_codeintel_dependency_index_total{job=~"^worker.*"}[5m])) + sum(increase(src_workerutil_dbworker_store_codeintel_dependency_index_errors_total{job=~"^worker.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -10938,8 +12546,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=101000` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_gitserver_total{job=~"^worker.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_gitserver_total{job=~"^worker.*"}[5m]))
+```
 </details>
 
 <br />
@@ -10957,8 +12568,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=101001` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum  by (le)(rate(src_codeintel_gitserver_duration_seconds_bucket{job=~"^worker.*"}[5m]))`
+Query:
 
+```
+sum  by (le)(rate(src_codeintel_gitserver_duration_seconds_bucket{job=~"^worker.*"}[5m]))
+```
 </details>
 
 <br />
@@ -10976,8 +12590,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=101002` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_gitserver_errors_total{job=~"^worker.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_gitserver_errors_total{job=~"^worker.*"}[5m]))
+```
 </details>
 
 <br />
@@ -10995,8 +12612,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=101003` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_gitserver_errors_total{job=~"^worker.*"}[5m])) / (sum(increase(src_codeintel_gitserver_total{job=~"^worker.*"}[5m])) + sum(increase(src_codeintel_gitserver_errors_total{job=~"^worker.*"}[5m]))) * 100`
+Query:
 
+```
+sum(increase(src_codeintel_gitserver_errors_total{job=~"^worker.*"}[5m])) / (sum(increase(src_codeintel_gitserver_total{job=~"^worker.*"}[5m])) + sum(increase(src_codeintel_gitserver_errors_total{job=~"^worker.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -11014,8 +12634,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=101010` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_gitserver_total{job=~"^worker.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_gitserver_total{job=~"^worker.*"}[5m]))
+```
 </details>
 
 <br />
@@ -11033,8 +12656,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=101011` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_gitserver_duration_seconds_bucket{job=~"^worker.*"}[5m])))`
+Query:
 
+```
+histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_gitserver_duration_seconds_bucket{job=~"^worker.*"}[5m])))
+```
 </details>
 
 <br />
@@ -11052,8 +12678,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=101012` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_gitserver_errors_total{job=~"^worker.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_gitserver_errors_total{job=~"^worker.*"}[5m]))
+```
 </details>
 
 <br />
@@ -11071,8 +12700,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=101013` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_gitserver_errors_total{job=~"^worker.*"}[5m])) / (sum by (op)(increase(src_codeintel_gitserver_total{job=~"^worker.*"}[5m])) + sum by (op)(increase(src_codeintel_gitserver_errors_total{job=~"^worker.*"}[5m]))) * 100`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_gitserver_errors_total{job=~"^worker.*"}[5m])) / (sum by (op)(increase(src_codeintel_gitserver_total{job=~"^worker.*"}[5m])) + sum by (op)(increase(src_codeintel_gitserver_errors_total{job=~"^worker.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -11092,8 +12724,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=101100` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_dependency_repos_total{job=~"^worker.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_dependency_repos_total{job=~"^worker.*"}[5m]))
+```
 </details>
 
 <br />
@@ -11111,8 +12746,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=101101` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum  by (le)(rate(src_codeintel_dependency_repos_duration_seconds_bucket{job=~"^worker.*"}[5m]))`
+Query:
 
+```
+sum  by (le)(rate(src_codeintel_dependency_repos_duration_seconds_bucket{job=~"^worker.*"}[5m]))
+```
 </details>
 
 <br />
@@ -11130,8 +12768,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=101102` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_dependency_repos_errors_total{job=~"^worker.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_dependency_repos_errors_total{job=~"^worker.*"}[5m]))
+```
 </details>
 
 <br />
@@ -11149,8 +12790,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=101103` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_dependency_repos_errors_total{job=~"^worker.*"}[5m])) / (sum(increase(src_codeintel_dependency_repos_total{job=~"^worker.*"}[5m])) + sum(increase(src_codeintel_dependency_repos_errors_total{job=~"^worker.*"}[5m]))) * 100`
+Query:
 
+```
+sum(increase(src_codeintel_dependency_repos_errors_total{job=~"^worker.*"}[5m])) / (sum(increase(src_codeintel_dependency_repos_total{job=~"^worker.*"}[5m])) + sum(increase(src_codeintel_dependency_repos_errors_total{job=~"^worker.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -11168,8 +12812,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=101110` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (scheme,new)(increase(src_codeintel_dependency_repos_total{job=~"^worker.*"}[5m]))`
+Query:
 
+```
+sum by (scheme,new)(increase(src_codeintel_dependency_repos_total{job=~"^worker.*"}[5m]))
+```
 </details>
 
 <br />
@@ -11187,8 +12834,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=101111` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.99, sum  by (le,scheme,new)(rate(src_codeintel_dependency_repos_duration_seconds_bucket{job=~"^worker.*"}[5m])))`
+Query:
 
+```
+histogram_quantile(0.99, sum  by (le,scheme,new)(rate(src_codeintel_dependency_repos_duration_seconds_bucket{job=~"^worker.*"}[5m])))
+```
 </details>
 
 <br />
@@ -11206,8 +12856,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=101112` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (scheme,new)(increase(src_codeintel_dependency_repos_errors_total{job=~"^worker.*"}[5m]))`
+Query:
 
+```
+sum by (scheme,new)(increase(src_codeintel_dependency_repos_errors_total{job=~"^worker.*"}[5m]))
+```
 </details>
 
 <br />
@@ -11225,8 +12878,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=101113` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (scheme,new)(increase(src_codeintel_dependency_repos_errors_total{job=~"^worker.*"}[5m])) / (sum by (scheme,new)(increase(src_codeintel_dependency_repos_total{job=~"^worker.*"}[5m])) + sum by (scheme,new)(increase(src_codeintel_dependency_repos_errors_total{job=~"^worker.*"}[5m]))) * 100`
+Query:
 
+```
+sum by (scheme,new)(increase(src_codeintel_dependency_repos_errors_total{job=~"^worker.*"}[5m])) / (sum by (scheme,new)(increase(src_codeintel_dependency_repos_total{job=~"^worker.*"}[5m])) + sum by (scheme,new)(increase(src_codeintel_dependency_repos_errors_total{job=~"^worker.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -11248,8 +12904,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=101200` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(src_repo_perms_syncer_success_syncs{type="user"})`
+Query:
 
+```
+sum(src_repo_perms_syncer_success_syncs{type="user"})
+```
 </details>
 
 <br />
@@ -11269,8 +12928,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=101201` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_repo_perms_syncer_success_syncs{type="user"}[5m]))`
+Query:
 
+```
+sum(increase(src_repo_perms_syncer_success_syncs{type="user"}[5m]))
+```
 </details>
 
 <br />
@@ -11290,8 +12952,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=101202` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_repo_perms_syncer_initial_syncs{type="user"}[5m]))`
+Query:
 
+```
+sum(increase(src_repo_perms_syncer_initial_syncs{type="user"}[5m]))
+```
 </details>
 
 <br />
@@ -11311,8 +12976,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=101210` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(src_repo_perms_syncer_success_syncs{type="repo"})`
+Query:
 
+```
+sum(src_repo_perms_syncer_success_syncs{type="repo"})
+```
 </details>
 
 <br />
@@ -11332,8 +13000,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=101211` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_repo_perms_syncer_success_syncs{type="repo"}[5m]))`
+Query:
 
+```
+sum(increase(src_repo_perms_syncer_success_syncs{type="repo"}[5m]))
+```
 </details>
 
 <br />
@@ -11353,8 +13024,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=101212` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_repo_perms_syncer_initial_syncs{type="repo"}[5m]))`
+Query:
 
+```
+sum(increase(src_repo_perms_syncer_initial_syncs{type="repo"}[5m]))
+```
 </details>
 
 <br />
@@ -11374,8 +13048,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=101220` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `max(max_over_time (src_repo_perms_syncer_perms_consecutive_sync_delay{type="user"} [1m]))`
+Query:
 
+```
+max(max_over_time (src_repo_perms_syncer_perms_consecutive_sync_delay{type="user"} [1m]))
+```
 </details>
 
 <br />
@@ -11395,8 +13072,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=101221` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `max(max_over_time (src_repo_perms_syncer_perms_consecutive_sync_delay{type="repo"} [1m]))`
+Query:
 
+```
+max(max_over_time (src_repo_perms_syncer_perms_consecutive_sync_delay{type="repo"} [1m]))
+```
 </details>
 
 <br />
@@ -11416,8 +13096,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=101230` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `max(max_over_time(src_repo_perms_syncer_perms_first_sync_delay{type="user"}[1m]))`
+Query:
 
+```
+max(max_over_time(src_repo_perms_syncer_perms_first_sync_delay{type="user"}[1m]))
+```
 </details>
 
 <br />
@@ -11437,8 +13120,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=101231` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `max(max_over_time(src_repo_perms_syncer_perms_first_sync_delay{type="repo"}[1m]))`
+Query:
 
+```
+max(max_over_time(src_repo_perms_syncer_perms_first_sync_delay{type="repo"}[1m]))
+```
 </details>
 
 <br />
@@ -11458,8 +13144,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=101240` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (type) (src_repo_perms_syncer_perms_found)`
+Query:
 
+```
+sum by (type) (src_repo_perms_syncer_perms_found)
+```
 </details>
 
 <br />
@@ -11479,8 +13168,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=101241` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `avg by (type) (src_repo_perms_syncer_perms_found)`
+Query:
 
+```
+avg by (type) (src_repo_perms_syncer_perms_found)
+```
 </details>
 
 <br />
@@ -11498,8 +13190,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=101250` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `max by (type) (src_repo_perms_syncer_outdated_perms)`
+Query:
 
+```
+max by (type) (src_repo_perms_syncer_outdated_perms)
+```
 </details>
 
 <br />
@@ -11517,8 +13212,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=101260` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.95, max by (le, type) (rate(src_repo_perms_syncer_sync_duration_seconds_bucket[1m])))`
+Query:
 
+```
+histogram_quantile(0.95, max by (le, type) (rate(src_repo_perms_syncer_sync_duration_seconds_bucket[1m])))
+```
 </details>
 
 <br />
@@ -11536,8 +13234,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=101270` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `max by (type) (ceil(rate(src_repo_perms_syncer_sync_errors_total[1m])))`
+Query:
 
+```
+max by (type) (ceil(rate(src_repo_perms_syncer_sync_errors_total[1m])))
+```
 </details>
 
 <br />
@@ -11558,8 +13259,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=101271` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `max(rate(src_repo_perms_syncer_schedule_repos_total[1m]))`
+Query:
 
+```
+max(rate(src_repo_perms_syncer_schedule_repos_total[1m]))
+```
 </details>
 
 <br />
@@ -11579,8 +13283,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=101300` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_gitserver_client_total{job=~"^worker.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_gitserver_client_total{job=~"^worker.*"}[5m]))
+```
 </details>
 
 <br />
@@ -11598,8 +13305,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=101301` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum  by (le)(rate(src_gitserver_client_duration_seconds_bucket{job=~"^worker.*"}[5m]))`
+Query:
 
+```
+sum  by (le)(rate(src_gitserver_client_duration_seconds_bucket{job=~"^worker.*"}[5m]))
+```
 </details>
 
 <br />
@@ -11617,8 +13327,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=101302` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_gitserver_client_errors_total{job=~"^worker.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_gitserver_client_errors_total{job=~"^worker.*"}[5m]))
+```
 </details>
 
 <br />
@@ -11636,8 +13349,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=101303` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_gitserver_client_errors_total{job=~"^worker.*"}[5m])) / (sum(increase(src_gitserver_client_total{job=~"^worker.*"}[5m])) + sum(increase(src_gitserver_client_errors_total{job=~"^worker.*"}[5m]))) * 100`
+Query:
 
+```
+sum(increase(src_gitserver_client_errors_total{job=~"^worker.*"}[5m])) / (sum(increase(src_gitserver_client_total{job=~"^worker.*"}[5m])) + sum(increase(src_gitserver_client_errors_total{job=~"^worker.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -11655,8 +13371,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=101310` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op,scope)(increase(src_gitserver_client_total{job=~"^worker.*"}[5m]))`
+Query:
 
+```
+sum by (op,scope)(increase(src_gitserver_client_total{job=~"^worker.*"}[5m]))
+```
 </details>
 
 <br />
@@ -11674,8 +13393,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=101311` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.99, sum  by (le,op,scope)(rate(src_gitserver_client_duration_seconds_bucket{job=~"^worker.*"}[5m])))`
+Query:
 
+```
+histogram_quantile(0.99, sum  by (le,op,scope)(rate(src_gitserver_client_duration_seconds_bucket{job=~"^worker.*"}[5m])))
+```
 </details>
 
 <br />
@@ -11693,8 +13415,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=101312` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op,scope)(increase(src_gitserver_client_errors_total{job=~"^worker.*"}[5m]))`
+Query:
 
+```
+sum by (op,scope)(increase(src_gitserver_client_errors_total{job=~"^worker.*"}[5m]))
+```
 </details>
 
 <br />
@@ -11712,8 +13437,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=101313` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op,scope)(increase(src_gitserver_client_errors_total{job=~"^worker.*"}[5m])) / (sum by (op,scope)(increase(src_gitserver_client_total{job=~"^worker.*"}[5m])) + sum by (op,scope)(increase(src_gitserver_client_errors_total{job=~"^worker.*"}[5m]))) * 100`
+Query:
 
+```
+sum by (op,scope)(increase(src_gitserver_client_errors_total{job=~"^worker.*"}[5m])) / (sum by (op,scope)(increase(src_gitserver_client_total{job=~"^worker.*"}[5m])) + sum by (op,scope)(increase(src_gitserver_client_errors_total{job=~"^worker.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -11733,8 +13461,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=101400` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_batches_dbstore_total{job=~"^worker.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_batches_dbstore_total{job=~"^worker.*"}[5m]))
+```
 </details>
 
 <br />
@@ -11752,8 +13483,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=101401` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum  by (le)(rate(src_batches_dbstore_duration_seconds_bucket{job=~"^worker.*"}[5m]))`
+Query:
 
+```
+sum  by (le)(rate(src_batches_dbstore_duration_seconds_bucket{job=~"^worker.*"}[5m]))
+```
 </details>
 
 <br />
@@ -11771,8 +13505,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=101402` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_batches_dbstore_errors_total{job=~"^worker.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_batches_dbstore_errors_total{job=~"^worker.*"}[5m]))
+```
 </details>
 
 <br />
@@ -11790,8 +13527,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=101403` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_batches_dbstore_errors_total{job=~"^worker.*"}[5m])) / (sum(increase(src_batches_dbstore_total{job=~"^worker.*"}[5m])) + sum(increase(src_batches_dbstore_errors_total{job=~"^worker.*"}[5m]))) * 100`
+Query:
 
+```
+sum(increase(src_batches_dbstore_errors_total{job=~"^worker.*"}[5m])) / (sum(increase(src_batches_dbstore_total{job=~"^worker.*"}[5m])) + sum(increase(src_batches_dbstore_errors_total{job=~"^worker.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -11809,8 +13549,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=101410` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_batches_dbstore_total{job=~"^worker.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_batches_dbstore_total{job=~"^worker.*"}[5m]))
+```
 </details>
 
 <br />
@@ -11828,8 +13571,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=101411` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.99, sum  by (le,op)(rate(src_batches_dbstore_duration_seconds_bucket{job=~"^worker.*"}[5m])))`
+Query:
 
+```
+histogram_quantile(0.99, sum  by (le,op)(rate(src_batches_dbstore_duration_seconds_bucket{job=~"^worker.*"}[5m])))
+```
 </details>
 
 <br />
@@ -11847,8 +13593,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=101412` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_batches_dbstore_errors_total{job=~"^worker.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_batches_dbstore_errors_total{job=~"^worker.*"}[5m]))
+```
 </details>
 
 <br />
@@ -11866,8 +13615,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=101413` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_batches_dbstore_errors_total{job=~"^worker.*"}[5m])) / (sum by (op)(increase(src_batches_dbstore_total{job=~"^worker.*"}[5m])) + sum by (op)(increase(src_batches_dbstore_errors_total{job=~"^worker.*"}[5m]))) * 100`
+Query:
 
+```
+sum by (op)(increase(src_batches_dbstore_errors_total{job=~"^worker.*"}[5m])) / (sum by (op)(increase(src_batches_dbstore_total{job=~"^worker.*"}[5m])) + sum by (op)(increase(src_batches_dbstore_errors_total{job=~"^worker.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -11887,8 +13639,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=101500` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_batches_service_total{job=~"^worker.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_batches_service_total{job=~"^worker.*"}[5m]))
+```
 </details>
 
 <br />
@@ -11906,8 +13661,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=101501` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum  by (le)(rate(src_batches_service_duration_seconds_bucket{job=~"^worker.*"}[5m]))`
+Query:
 
+```
+sum  by (le)(rate(src_batches_service_duration_seconds_bucket{job=~"^worker.*"}[5m]))
+```
 </details>
 
 <br />
@@ -11925,8 +13683,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=101502` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_batches_service_errors_total{job=~"^worker.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_batches_service_errors_total{job=~"^worker.*"}[5m]))
+```
 </details>
 
 <br />
@@ -11944,8 +13705,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=101503` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_batches_service_errors_total{job=~"^worker.*"}[5m])) / (sum(increase(src_batches_service_total{job=~"^worker.*"}[5m])) + sum(increase(src_batches_service_errors_total{job=~"^worker.*"}[5m]))) * 100`
+Query:
 
+```
+sum(increase(src_batches_service_errors_total{job=~"^worker.*"}[5m])) / (sum(increase(src_batches_service_total{job=~"^worker.*"}[5m])) + sum(increase(src_batches_service_errors_total{job=~"^worker.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -11963,8 +13727,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=101510` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_batches_service_total{job=~"^worker.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_batches_service_total{job=~"^worker.*"}[5m]))
+```
 </details>
 
 <br />
@@ -11982,8 +13749,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=101511` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.99, sum  by (le,op)(rate(src_batches_service_duration_seconds_bucket{job=~"^worker.*"}[5m])))`
+Query:
 
+```
+histogram_quantile(0.99, sum  by (le,op)(rate(src_batches_service_duration_seconds_bucket{job=~"^worker.*"}[5m])))
+```
 </details>
 
 <br />
@@ -12001,8 +13771,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=101512` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_batches_service_errors_total{job=~"^worker.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_batches_service_errors_total{job=~"^worker.*"}[5m]))
+```
 </details>
 
 <br />
@@ -12020,8 +13793,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=101513` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_batches_service_errors_total{job=~"^worker.*"}[5m])) / (sum by (op)(increase(src_batches_service_total{job=~"^worker.*"}[5m])) + sum by (op)(increase(src_batches_service_errors_total{job=~"^worker.*"}[5m]))) * 100`
+Query:
 
+```
+sum by (op)(increase(src_batches_service_errors_total{job=~"^worker.*"}[5m])) / (sum by (op)(increase(src_batches_service_total{job=~"^worker.*"}[5m])) + sum by (op)(increase(src_batches_service_errors_total{job=~"^worker.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -12041,8 +13817,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=101600` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_workerutil_dbworker_store_batch_changes_batch_spec_resolution_worker_store_total{job=~"^worker.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_workerutil_dbworker_store_batch_changes_batch_spec_resolution_worker_store_total{job=~"^worker.*"}[5m]))
+```
 </details>
 
 <br />
@@ -12060,8 +13839,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=101601` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.99, sum  by (le,op)(rate(src_workerutil_dbworker_store_batch_changes_batch_spec_resolution_worker_store_duration_seconds_bucket{job=~"^worker.*"}[5m])))`
+Query:
 
+```
+histogram_quantile(0.99, sum  by (le,op)(rate(src_workerutil_dbworker_store_batch_changes_batch_spec_resolution_worker_store_duration_seconds_bucket{job=~"^worker.*"}[5m])))
+```
 </details>
 
 <br />
@@ -12079,8 +13861,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=101602` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_workerutil_dbworker_store_batch_changes_batch_spec_resolution_worker_store_errors_total{job=~"^worker.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_workerutil_dbworker_store_batch_changes_batch_spec_resolution_worker_store_errors_total{job=~"^worker.*"}[5m]))
+```
 </details>
 
 <br />
@@ -12098,8 +13883,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=101603` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_workerutil_dbworker_store_batch_changes_batch_spec_resolution_worker_store_errors_total{job=~"^worker.*"}[5m])) / (sum by (op)(increase(src_workerutil_dbworker_store_batch_changes_batch_spec_resolution_worker_store_total{job=~"^worker.*"}[5m])) + sum by (op)(increase(src_workerutil_dbworker_store_batch_changes_batch_spec_resolution_worker_store_errors_total{job=~"^worker.*"}[5m]))) * 100`
+Query:
 
+```
+sum by (op)(increase(src_workerutil_dbworker_store_batch_changes_batch_spec_resolution_worker_store_errors_total{job=~"^worker.*"}[5m])) / (sum by (op)(increase(src_workerutil_dbworker_store_batch_changes_batch_spec_resolution_worker_store_total{job=~"^worker.*"}[5m])) + sum by (op)(increase(src_workerutil_dbworker_store_batch_changes_batch_spec_resolution_worker_store_errors_total{job=~"^worker.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -12119,8 +13907,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=101700` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_workerutil_dbworker_store_batches_bulk_worker_store_total{job=~"^worker.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_workerutil_dbworker_store_batches_bulk_worker_store_total{job=~"^worker.*"}[5m]))
+```
 </details>
 
 <br />
@@ -12138,8 +13929,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=101701` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.99, sum  by (le,op)(rate(src_workerutil_dbworker_store_batches_bulk_worker_store_duration_seconds_bucket{job=~"^worker.*"}[5m])))`
+Query:
 
+```
+histogram_quantile(0.99, sum  by (le,op)(rate(src_workerutil_dbworker_store_batches_bulk_worker_store_duration_seconds_bucket{job=~"^worker.*"}[5m])))
+```
 </details>
 
 <br />
@@ -12157,8 +13951,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=101702` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_workerutil_dbworker_store_batches_bulk_worker_store_errors_total{job=~"^worker.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_workerutil_dbworker_store_batches_bulk_worker_store_errors_total{job=~"^worker.*"}[5m]))
+```
 </details>
 
 <br />
@@ -12176,8 +13973,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=101703` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_workerutil_dbworker_store_batches_bulk_worker_store_errors_total{job=~"^worker.*"}[5m])) / (sum by (op)(increase(src_workerutil_dbworker_store_batches_bulk_worker_store_total{job=~"^worker.*"}[5m])) + sum by (op)(increase(src_workerutil_dbworker_store_batches_bulk_worker_store_errors_total{job=~"^worker.*"}[5m]))) * 100`
+Query:
 
+```
+sum by (op)(increase(src_workerutil_dbworker_store_batches_bulk_worker_store_errors_total{job=~"^worker.*"}[5m])) / (sum by (op)(increase(src_workerutil_dbworker_store_batches_bulk_worker_store_total{job=~"^worker.*"}[5m])) + sum by (op)(increase(src_workerutil_dbworker_store_batches_bulk_worker_store_errors_total{job=~"^worker.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -12197,8 +13997,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=101800` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_workerutil_dbworker_store_batches_reconciler_worker_store_total{job=~"^worker.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_workerutil_dbworker_store_batches_reconciler_worker_store_total{job=~"^worker.*"}[5m]))
+```
 </details>
 
 <br />
@@ -12216,8 +14019,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=101801` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.99, sum  by (le,op)(rate(src_workerutil_dbworker_store_batches_reconciler_worker_store_duration_seconds_bucket{job=~"^worker.*"}[5m])))`
+Query:
 
+```
+histogram_quantile(0.99, sum  by (le,op)(rate(src_workerutil_dbworker_store_batches_reconciler_worker_store_duration_seconds_bucket{job=~"^worker.*"}[5m])))
+```
 </details>
 
 <br />
@@ -12235,8 +14041,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=101802` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_workerutil_dbworker_store_batches_reconciler_worker_store_errors_total{job=~"^worker.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_workerutil_dbworker_store_batches_reconciler_worker_store_errors_total{job=~"^worker.*"}[5m]))
+```
 </details>
 
 <br />
@@ -12254,8 +14063,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=101803` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_workerutil_dbworker_store_batches_reconciler_worker_store_errors_total{job=~"^worker.*"}[5m])) / (sum by (op)(increase(src_workerutil_dbworker_store_batches_reconciler_worker_store_total{job=~"^worker.*"}[5m])) + sum by (op)(increase(src_workerutil_dbworker_store_batches_reconciler_worker_store_errors_total{job=~"^worker.*"}[5m]))) * 100`
+Query:
 
+```
+sum by (op)(increase(src_workerutil_dbworker_store_batches_reconciler_worker_store_errors_total{job=~"^worker.*"}[5m])) / (sum by (op)(increase(src_workerutil_dbworker_store_batches_reconciler_worker_store_total{job=~"^worker.*"}[5m])) + sum by (op)(increase(src_workerutil_dbworker_store_batches_reconciler_worker_store_errors_total{job=~"^worker.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -12275,8 +14087,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=101900` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_workerutil_dbworker_store_batch_spec_workspace_execution_worker_store_total{job=~"^worker.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_workerutil_dbworker_store_batch_spec_workspace_execution_worker_store_total{job=~"^worker.*"}[5m]))
+```
 </details>
 
 <br />
@@ -12294,8 +14109,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=101901` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.99, sum  by (le,op)(rate(src_workerutil_dbworker_store_batch_spec_workspace_execution_worker_store_duration_seconds_bucket{job=~"^worker.*"}[5m])))`
+Query:
 
+```
+histogram_quantile(0.99, sum  by (le,op)(rate(src_workerutil_dbworker_store_batch_spec_workspace_execution_worker_store_duration_seconds_bucket{job=~"^worker.*"}[5m])))
+```
 </details>
 
 <br />
@@ -12313,8 +14131,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=101902` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_workerutil_dbworker_store_batch_spec_workspace_execution_worker_store_errors_total{job=~"^worker.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_workerutil_dbworker_store_batch_spec_workspace_execution_worker_store_errors_total{job=~"^worker.*"}[5m]))
+```
 </details>
 
 <br />
@@ -12332,8 +14153,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=101903` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_workerutil_dbworker_store_batch_spec_workspace_execution_worker_store_errors_total{job=~"^worker.*"}[5m])) / (sum by (op)(increase(src_workerutil_dbworker_store_batch_spec_workspace_execution_worker_store_total{job=~"^worker.*"}[5m])) + sum by (op)(increase(src_workerutil_dbworker_store_batch_spec_workspace_execution_worker_store_errors_total{job=~"^worker.*"}[5m]))) * 100`
+Query:
 
+```
+sum by (op)(increase(src_workerutil_dbworker_store_batch_spec_workspace_execution_worker_store_errors_total{job=~"^worker.*"}[5m])) / (sum by (op)(increase(src_workerutil_dbworker_store_batch_spec_workspace_execution_worker_store_total{job=~"^worker.*"}[5m])) + sum by (op)(increase(src_workerutil_dbworker_store_batch_spec_workspace_execution_worker_store_errors_total{job=~"^worker.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -12353,8 +14177,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=102000` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `max by (queue)(src_executor_total{queue=~"batches",job=~"^(executor|sourcegraph-code-intel-indexers|executor-batches|frontend|sourcegraph-frontend|worker|sourcegraph-executors).*"})`
+Query:
 
+```
+max by (queue)(src_executor_total{queue=~"batches",job=~"^(executor|sourcegraph-code-intel-indexers|executor-batches|frontend|sourcegraph-frontend|worker|sourcegraph-executors).*"})
+```
 </details>
 
 <br />
@@ -12378,8 +14205,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=102001` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (queue)(increase(src_executor_total{queue=~"batches",job=~"^(executor|sourcegraph-code-intel-indexers|executor-batches|frontend|sourcegraph-frontend|worker|sourcegraph-executors).*"}[30m])) / sum by (queue)(increase(src_executor_processor_total{queue=~"batches",job=~"^(executor|sourcegraph-code-intel-indexers|executor-batches|frontend|sourcegraph-frontend|worker|sourcegraph-executors).*"}[30m]))`
+Query:
 
+```
+sum by (queue)(increase(src_executor_total{queue=~"batches",job=~"^(executor|sourcegraph-code-intel-indexers|executor-batches|frontend|sourcegraph-frontend|worker|sourcegraph-executors).*"}[30m])) / sum by (queue)(increase(src_executor_processor_total{queue=~"batches",job=~"^(executor|sourcegraph-code-intel-indexers|executor-batches|frontend|sourcegraph-frontend|worker|sourcegraph-executors).*"}[30m]))
+```
 </details>
 
 <br />
@@ -12397,8 +14227,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=102002` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `max by (queue)(src_executor_queued_duration_seconds_total{queue=~"batches",job=~"^(executor|sourcegraph-code-intel-indexers|executor-batches|frontend|sourcegraph-frontend|worker|sourcegraph-executors).*"})`
+Query:
 
+```
+max by (queue)(src_executor_queued_duration_seconds_total{queue=~"batches",job=~"^(executor|sourcegraph-code-intel-indexers|executor-batches|frontend|sourcegraph-frontend|worker|sourcegraph-executors).*"})
+```
 </details>
 
 <br />
@@ -12418,8 +14251,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=102100` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_background_upload_record_resets_total{job=~"^worker.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_background_upload_record_resets_total{job=~"^worker.*"}[5m]))
+```
 </details>
 
 <br />
@@ -12437,8 +14273,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=102101` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_background_upload_record_reset_failures_total{job=~"^worker.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_background_upload_record_reset_failures_total{job=~"^worker.*"}[5m]))
+```
 </details>
 
 <br />
@@ -12456,8 +14295,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=102102` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_background_upload_record_reset_errors_total{job=~"^worker.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_background_upload_record_reset_errors_total{job=~"^worker.*"}[5m]))
+```
 </details>
 
 <br />
@@ -12477,8 +14319,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=102200` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_background_index_record_resets_total{job=~"^worker.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_background_index_record_resets_total{job=~"^worker.*"}[5m]))
+```
 </details>
 
 <br />
@@ -12496,8 +14341,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=102201` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_background_index_record_reset_failures_total{job=~"^worker.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_background_index_record_reset_failures_total{job=~"^worker.*"}[5m]))
+```
 </details>
 
 <br />
@@ -12515,8 +14363,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=102202` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_background_index_record_reset_errors_total{job=~"^worker.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_background_index_record_reset_errors_total{job=~"^worker.*"}[5m]))
+```
 </details>
 
 <br />
@@ -12536,8 +14387,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=102300` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_background_dependency_index_record_resets_total{job=~"^worker.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_background_dependency_index_record_resets_total{job=~"^worker.*"}[5m]))
+```
 </details>
 
 <br />
@@ -12555,8 +14409,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=102301` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_background_dependency_index_record_reset_failures_total{job=~"^worker.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_background_dependency_index_record_reset_failures_total{job=~"^worker.*"}[5m]))
+```
 </details>
 
 <br />
@@ -12574,8 +14431,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=102302` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_background_dependency_index_record_reset_errors_total{job=~"^worker.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_background_dependency_index_record_reset_errors_total{job=~"^worker.*"}[5m]))
+```
 </details>
 
 <br />
@@ -12595,8 +14455,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=102400` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `max(src_query_runner_worker_total{job=~"^worker.*"})`
+Query:
 
+```
+max(src_query_runner_worker_total{job=~"^worker.*"})
+```
 </details>
 
 <br />
@@ -12620,8 +14483,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=102401` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_query_runner_worker_total{job=~"^worker.*"}[30m])) / sum(increase(src_query_runner_worker_processor_total{job=~"^worker.*"}[30m]))`
+Query:
 
+```
+sum(increase(src_query_runner_worker_total{job=~"^worker.*"}[30m])) / sum(increase(src_query_runner_worker_processor_total{job=~"^worker.*"}[30m]))
+```
 </details>
 
 <br />
@@ -12641,8 +14507,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=102500` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(src_query_runner_worker_processor_handlers{job=~"^worker.*"})`
+Query:
 
+```
+sum(src_query_runner_worker_processor_handlers{job=~"^worker.*"})
+```
 </details>
 
 <br />
@@ -12660,8 +14529,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=102510` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_query_runner_worker_processor_total{job=~"^worker.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_query_runner_worker_processor_total{job=~"^worker.*"}[5m]))
+```
 </details>
 
 <br />
@@ -12679,8 +14551,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=102511` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum  by (le)(rate(src_query_runner_worker_processor_duration_seconds_bucket{job=~"^worker.*"}[5m]))`
+Query:
 
+```
+sum  by (le)(rate(src_query_runner_worker_processor_duration_seconds_bucket{job=~"^worker.*"}[5m]))
+```
 </details>
 
 <br />
@@ -12698,8 +14573,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=102512` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_query_runner_worker_processor_errors_total{job=~"^worker.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_query_runner_worker_processor_errors_total{job=~"^worker.*"}[5m]))
+```
 </details>
 
 <br />
@@ -12717,8 +14595,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=102513` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_query_runner_worker_processor_errors_total{job=~"^worker.*"}[5m])) / (sum(increase(src_query_runner_worker_processor_total{job=~"^worker.*"}[5m])) + sum(increase(src_query_runner_worker_processor_errors_total{job=~"^worker.*"}[5m]))) * 100`
+Query:
 
+```
+sum(increase(src_query_runner_worker_processor_errors_total{job=~"^worker.*"}[5m])) / (sum(increase(src_query_runner_worker_processor_total{job=~"^worker.*"}[5m])) + sum(increase(src_query_runner_worker_processor_errors_total{job=~"^worker.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -12738,8 +14619,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=102600` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_query_runner_worker_record_resets_total{job=~"^worker.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_query_runner_worker_record_resets_total{job=~"^worker.*"}[5m]))
+```
 </details>
 
 <br />
@@ -12757,8 +14641,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=102601` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_query_runner_worker_record_reset_failures_total{job=~"^worker.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_query_runner_worker_record_reset_failures_total{job=~"^worker.*"}[5m]))
+```
 </details>
 
 <br />
@@ -12776,8 +14663,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=102602` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_query_runner_worker_record_reset_errors_total{job=~"^worker.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_query_runner_worker_record_reset_errors_total{job=~"^worker.*"}[5m]))
+```
 </details>
 
 <br />
@@ -12797,8 +14687,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=102700` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_workerutil_dbworker_store_insights_query_runner_jobs_store_total{job=~"^worker.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_workerutil_dbworker_store_insights_query_runner_jobs_store_total{job=~"^worker.*"}[5m]))
+```
 </details>
 
 <br />
@@ -12816,8 +14709,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=102701` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum  by (le)(rate(src_workerutil_dbworker_store_insights_query_runner_jobs_store_duration_seconds_bucket{job=~"^worker.*"}[5m]))`
+Query:
 
+```
+sum  by (le)(rate(src_workerutil_dbworker_store_insights_query_runner_jobs_store_duration_seconds_bucket{job=~"^worker.*"}[5m]))
+```
 </details>
 
 <br />
@@ -12835,8 +14731,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=102702` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_workerutil_dbworker_store_insights_query_runner_jobs_store_errors_total{job=~"^worker.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_workerutil_dbworker_store_insights_query_runner_jobs_store_errors_total{job=~"^worker.*"}[5m]))
+```
 </details>
 
 <br />
@@ -12854,8 +14753,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=102703` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_workerutil_dbworker_store_insights_query_runner_jobs_store_errors_total{job=~"^worker.*"}[5m])) / (sum(increase(src_workerutil_dbworker_store_insights_query_runner_jobs_store_total{job=~"^worker.*"}[5m])) + sum(increase(src_workerutil_dbworker_store_insights_query_runner_jobs_store_errors_total{job=~"^worker.*"}[5m]))) * 100`
+Query:
 
+```
+sum(increase(src_workerutil_dbworker_store_insights_query_runner_jobs_store_errors_total{job=~"^worker.*"}[5m])) / (sum(increase(src_workerutil_dbworker_store_insights_query_runner_jobs_store_total{job=~"^worker.*"}[5m])) + sum(increase(src_workerutil_dbworker_store_insights_query_runner_jobs_store_errors_total{job=~"^worker.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -12873,8 +14775,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=102710` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_workerutil_dbworker_store_insights_query_runner_jobs_store_total{job=~"^worker.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_workerutil_dbworker_store_insights_query_runner_jobs_store_total{job=~"^worker.*"}[5m]))
+```
 </details>
 
 <br />
@@ -12892,8 +14797,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=102711` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.99, sum  by (le,op)(rate(src_workerutil_dbworker_store_insights_query_runner_jobs_store_duration_seconds_bucket{job=~"^worker.*"}[5m])))`
+Query:
 
+```
+histogram_quantile(0.99, sum  by (le,op)(rate(src_workerutil_dbworker_store_insights_query_runner_jobs_store_duration_seconds_bucket{job=~"^worker.*"}[5m])))
+```
 </details>
 
 <br />
@@ -12911,8 +14819,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=102712` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_workerutil_dbworker_store_insights_query_runner_jobs_store_errors_total{job=~"^worker.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_workerutil_dbworker_store_insights_query_runner_jobs_store_errors_total{job=~"^worker.*"}[5m]))
+```
 </details>
 
 <br />
@@ -12930,8 +14841,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=102713` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_workerutil_dbworker_store_insights_query_runner_jobs_store_errors_total{job=~"^worker.*"}[5m])) / (sum by (op)(increase(src_workerutil_dbworker_store_insights_query_runner_jobs_store_total{job=~"^worker.*"}[5m])) + sum by (op)(increase(src_workerutil_dbworker_store_insights_query_runner_jobs_store_errors_total{job=~"^worker.*"}[5m]))) * 100`
+Query:
 
+```
+sum by (op)(increase(src_workerutil_dbworker_store_insights_query_runner_jobs_store_errors_total{job=~"^worker.*"}[5m])) / (sum by (op)(increase(src_workerutil_dbworker_store_insights_query_runner_jobs_store_total{job=~"^worker.*"}[5m])) + sum by (op)(increase(src_workerutil_dbworker_store_insights_query_runner_jobs_store_errors_total{job=~"^worker.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -12953,8 +14867,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=102800` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `max(src_query_runner_worker_total{job=~"^worker.*"}) > 0 and on(job) sum by (op)(increase(src_workerutil_dbworker_store_insights_query_runner_jobs_store_total{job=~"^worker.*",op="Dequeue"}[5m])) < 1`
+Query:
 
+```
+max(src_query_runner_worker_total{job=~"^worker.*"}) > 0 and on(job) sum by (op)(increase(src_workerutil_dbworker_store_insights_query_runner_jobs_store_total{job=~"^worker.*",op="Dequeue"}[5m])) < 1
+```
 </details>
 
 <br />
@@ -12974,8 +14891,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=102900` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (app_name, db_name) (src_pgsql_conns_max_open{app_name="worker"})`
+Query:
 
+```
+sum by (app_name, db_name) (src_pgsql_conns_max_open{app_name="worker"})
+```
 </details>
 
 <br />
@@ -12993,8 +14913,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=102901` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (app_name, db_name) (src_pgsql_conns_open{app_name="worker"})`
+Query:
 
+```
+sum by (app_name, db_name) (src_pgsql_conns_open{app_name="worker"})
+```
 </details>
 
 <br />
@@ -13012,8 +14935,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=102910` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (app_name, db_name) (src_pgsql_conns_in_use{app_name="worker"})`
+Query:
 
+```
+sum by (app_name, db_name) (src_pgsql_conns_in_use{app_name="worker"})
+```
 </details>
 
 <br />
@@ -13031,8 +14957,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=102911` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (app_name, db_name) (src_pgsql_conns_idle{app_name="worker"})`
+Query:
 
+```
+sum by (app_name, db_name) (src_pgsql_conns_idle{app_name="worker"})
+```
 </details>
 
 <br />
@@ -13050,8 +14979,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=102920` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (app_name, db_name) (increase(src_pgsql_conns_blocked_seconds{app_name="worker"}[5m])) / sum by (app_name, db_name) (increase(src_pgsql_conns_waited_for{app_name="worker"}[5m]))`
+Query:
 
+```
+sum by (app_name, db_name) (increase(src_pgsql_conns_blocked_seconds{app_name="worker"}[5m])) / sum by (app_name, db_name) (increase(src_pgsql_conns_waited_for{app_name="worker"}[5m]))
+```
 </details>
 
 <br />
@@ -13069,8 +15001,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=102930` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (app_name, db_name) (increase(src_pgsql_conns_closed_max_idle{app_name="worker"}[5m]))`
+Query:
 
+```
+sum by (app_name, db_name) (increase(src_pgsql_conns_closed_max_idle{app_name="worker"}[5m]))
+```
 </details>
 
 <br />
@@ -13088,8 +15023,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=102931` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (app_name, db_name) (increase(src_pgsql_conns_closed_max_lifetime{app_name="worker"}[5m]))`
+Query:
 
+```
+sum by (app_name, db_name) (increase(src_pgsql_conns_closed_max_lifetime{app_name="worker"}[5m]))
+```
 </details>
 
 <br />
@@ -13107,8 +15045,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=102932` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (app_name, db_name) (increase(src_pgsql_conns_closed_max_idle_time{app_name="worker"}[5m]))`
+Query:
 
+```
+sum by (app_name, db_name) (increase(src_pgsql_conns_closed_max_idle_time{app_name="worker"}[5m]))
+```
 </details>
 
 <br />
@@ -13138,8 +15079,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=103000` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `count by(name) ((time() - container_last_seen{name=~"^worker.*"}) > 60)`
+Query:
 
+```
+count by(name) ((time() - container_last_seen{name=~"^worker.*"}) > 60)
+```
 </details>
 
 <br />
@@ -13157,8 +15101,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=103001` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `cadvisor_container_cpu_usage_percentage_total{name=~"^worker.*"}`
+Query:
 
+```
+cadvisor_container_cpu_usage_percentage_total{name=~"^worker.*"}
+```
 </details>
 
 <br />
@@ -13176,8 +15123,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=103002` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `cadvisor_container_memory_usage_percentage_total{name=~"^worker.*"}`
+Query:
 
+```
+cadvisor_container_memory_usage_percentage_total{name=~"^worker.*"}
+```
 </details>
 
 <br />
@@ -13198,8 +15148,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=103003` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by(name) (rate(container_fs_reads_total{name=~"^worker.*"}[1h]) + rate(container_fs_writes_total{name=~"^worker.*"}[1h]))`
+Query:
 
+```
+sum by(name) (rate(container_fs_reads_total{name=~"^worker.*"}[1h]) + rate(container_fs_writes_total{name=~"^worker.*"}[1h]))
+```
 </details>
 
 <br />
@@ -13219,8 +15172,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=103100` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `quantile_over_time(0.9, cadvisor_container_cpu_usage_percentage_total{name=~"^worker.*"}[1d])`
+Query:
 
+```
+quantile_over_time(0.9, cadvisor_container_cpu_usage_percentage_total{name=~"^worker.*"}[1d])
+```
 </details>
 
 <br />
@@ -13238,8 +15194,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=103101` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^worker.*"}[1d])`
+Query:
 
+```
+max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^worker.*"}[1d])
+```
 </details>
 
 <br />
@@ -13257,8 +15216,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=103110` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `max_over_time(cadvisor_container_cpu_usage_percentage_total{name=~"^worker.*"}[5m])`
+Query:
 
+```
+max_over_time(cadvisor_container_cpu_usage_percentage_total{name=~"^worker.*"}[5m])
+```
 </details>
 
 <br />
@@ -13276,8 +15238,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=103111` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^worker.*"}[5m])`
+Query:
 
+```
+max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^worker.*"}[5m])
+```
 </details>
 
 <br />
@@ -13298,8 +15263,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=103112` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `max by (name) (container_oom_events_total{name=~"^worker.*"})`
+Query:
 
+```
+max by (name) (container_oom_events_total{name=~"^worker.*"})
+```
 </details>
 
 <br />
@@ -13321,8 +15289,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=103200` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `max by(instance) (go_goroutines{job=~".*worker"})`
+Query:
 
+```
+max by(instance) (go_goroutines{job=~".*worker"})
+```
 </details>
 
 <br />
@@ -13340,8 +15311,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=103201` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `max by(instance) (go_gc_duration_seconds{job=~".*worker"})`
+Query:
 
+```
+max by(instance) (go_gc_duration_seconds{job=~".*worker"})
+```
 </details>
 
 <br />
@@ -13361,8 +15335,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=103300` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by(app) (up{app=~".*worker"}) / count by (app) (up{app=~".*worker"}) * 100`
+Query:
 
+```
+sum by(app) (up{app=~".*worker"}) / count by (app) (up{app=~".*worker"}) * 100
+```
 </details>
 
 <br />
@@ -13382,8 +15359,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=103400` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_workerutil_dbworker_store_own_background_worker_store_total{job=~"^worker.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_workerutil_dbworker_store_own_background_worker_store_total{job=~"^worker.*"}[5m]))
+```
 </details>
 
 <br />
@@ -13401,8 +15381,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=103401` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum  by (le)(rate(src_workerutil_dbworker_store_own_background_worker_store_duration_seconds_bucket{job=~"^worker.*"}[5m]))`
+Query:
 
+```
+sum  by (le)(rate(src_workerutil_dbworker_store_own_background_worker_store_duration_seconds_bucket{job=~"^worker.*"}[5m]))
+```
 </details>
 
 <br />
@@ -13420,8 +15403,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=103402` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_workerutil_dbworker_store_own_background_worker_store_errors_total{job=~"^worker.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_workerutil_dbworker_store_own_background_worker_store_errors_total{job=~"^worker.*"}[5m]))
+```
 </details>
 
 <br />
@@ -13439,8 +15425,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=103403` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_workerutil_dbworker_store_own_background_worker_store_errors_total{job=~"^worker.*"}[5m])) / (sum(increase(src_workerutil_dbworker_store_own_background_worker_store_total{job=~"^worker.*"}[5m])) + sum(increase(src_workerutil_dbworker_store_own_background_worker_store_errors_total{job=~"^worker.*"}[5m]))) * 100`
+Query:
 
+```
+sum(increase(src_workerutil_dbworker_store_own_background_worker_store_errors_total{job=~"^worker.*"}[5m])) / (sum(increase(src_workerutil_dbworker_store_own_background_worker_store_total{job=~"^worker.*"}[5m])) + sum(increase(src_workerutil_dbworker_store_own_background_worker_store_errors_total{job=~"^worker.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -13458,8 +15447,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=103410` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_workerutil_dbworker_store_own_background_worker_store_total{job=~"^worker.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_workerutil_dbworker_store_own_background_worker_store_total{job=~"^worker.*"}[5m]))
+```
 </details>
 
 <br />
@@ -13477,8 +15469,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=103411` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.99, sum  by (le,op)(rate(src_workerutil_dbworker_store_own_background_worker_store_duration_seconds_bucket{job=~"^worker.*"}[5m])))`
+Query:
 
+```
+histogram_quantile(0.99, sum  by (le,op)(rate(src_workerutil_dbworker_store_own_background_worker_store_duration_seconds_bucket{job=~"^worker.*"}[5m])))
+```
 </details>
 
 <br />
@@ -13496,8 +15491,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=103412` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_workerutil_dbworker_store_own_background_worker_store_errors_total{job=~"^worker.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_workerutil_dbworker_store_own_background_worker_store_errors_total{job=~"^worker.*"}[5m]))
+```
 </details>
 
 <br />
@@ -13515,8 +15513,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=103413` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_workerutil_dbworker_store_own_background_worker_store_errors_total{job=~"^worker.*"}[5m])) / (sum by (op)(increase(src_workerutil_dbworker_store_own_background_worker_store_total{job=~"^worker.*"}[5m])) + sum by (op)(increase(src_workerutil_dbworker_store_own_background_worker_store_errors_total{job=~"^worker.*"}[5m]))) * 100`
+Query:
 
+```
+sum by (op)(increase(src_workerutil_dbworker_store_own_background_worker_store_errors_total{job=~"^worker.*"}[5m])) / (sum by (op)(increase(src_workerutil_dbworker_store_own_background_worker_store_total{job=~"^worker.*"}[5m])) + sum by (op)(increase(src_workerutil_dbworker_store_own_background_worker_store_errors_total{job=~"^worker.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -13536,8 +15537,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=103500` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(src_own_background_worker_processor_handlers{job=~"^worker.*"})`
+Query:
 
+```
+sum(src_own_background_worker_processor_handlers{job=~"^worker.*"})
+```
 </details>
 
 <br />
@@ -13555,8 +15559,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=103510` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_own_background_worker_processor_total{job=~"^worker.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_own_background_worker_processor_total{job=~"^worker.*"}[5m]))
+```
 </details>
 
 <br />
@@ -13574,8 +15581,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=103511` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum  by (le)(rate(src_own_background_worker_processor_duration_seconds_bucket{job=~"^worker.*"}[5m]))`
+Query:
 
+```
+sum  by (le)(rate(src_own_background_worker_processor_duration_seconds_bucket{job=~"^worker.*"}[5m]))
+```
 </details>
 
 <br />
@@ -13593,8 +15603,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=103512` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_own_background_worker_processor_errors_total{job=~"^worker.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_own_background_worker_processor_errors_total{job=~"^worker.*"}[5m]))
+```
 </details>
 
 <br />
@@ -13612,8 +15625,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=103513` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_own_background_worker_processor_errors_total{job=~"^worker.*"}[5m])) / (sum(increase(src_own_background_worker_processor_total{job=~"^worker.*"}[5m])) + sum(increase(src_own_background_worker_processor_errors_total{job=~"^worker.*"}[5m]))) * 100`
+Query:
 
+```
+sum(increase(src_own_background_worker_processor_errors_total{job=~"^worker.*"}[5m])) / (sum(increase(src_own_background_worker_processor_total{job=~"^worker.*"}[5m])) + sum(increase(src_own_background_worker_processor_errors_total{job=~"^worker.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -13633,8 +15649,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=103600` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_own_background_worker_record_resets_total{job=~"^worker.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_own_background_worker_record_resets_total{job=~"^worker.*"}[5m]))
+```
 </details>
 
 <br />
@@ -13652,8 +15671,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=103601` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_own_background_worker_record_reset_failures_total{job=~"^worker.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_own_background_worker_record_reset_failures_total{job=~"^worker.*"}[5m]))
+```
 </details>
 
 <br />
@@ -13671,8 +15693,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=103602` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_own_background_worker_record_reset_errors_total{job=~"^worker.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_own_background_worker_record_reset_errors_total{job=~"^worker.*"}[5m]))
+```
 </details>
 
 <br />
@@ -13692,8 +15717,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=103700` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_own_background_index_scheduler_total{job=~"^worker.*"}[10m]))`
+Query:
 
+```
+sum by (op)(increase(src_own_background_index_scheduler_total{job=~"^worker.*"}[10m]))
+```
 </details>
 
 <br />
@@ -13711,8 +15739,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=103701` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.99, sum  by (le,op)(rate(src_own_background_index_scheduler_duration_seconds_bucket{job=~"^worker.*"}[10m])))`
+Query:
 
+```
+histogram_quantile(0.99, sum  by (le,op)(rate(src_own_background_index_scheduler_duration_seconds_bucket{job=~"^worker.*"}[10m])))
+```
 </details>
 
 <br />
@@ -13730,8 +15761,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=103702` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_own_background_index_scheduler_errors_total{job=~"^worker.*"}[10m]))`
+Query:
 
+```
+sum by (op)(increase(src_own_background_index_scheduler_errors_total{job=~"^worker.*"}[10m]))
+```
 </details>
 
 <br />
@@ -13749,8 +15783,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=103703` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_own_background_index_scheduler_errors_total{job=~"^worker.*"}[10m])) / (sum by (op)(increase(src_own_background_index_scheduler_total{job=~"^worker.*"}[10m])) + sum by (op)(increase(src_own_background_index_scheduler_errors_total{job=~"^worker.*"}[10m]))) * 100`
+Query:
 
+```
+sum by (op)(increase(src_own_background_index_scheduler_errors_total{job=~"^worker.*"}[10m])) / (sum by (op)(increase(src_own_background_index_scheduler_total{job=~"^worker.*"}[10m])) + sum by (op)(increase(src_own_background_index_scheduler_errors_total{job=~"^worker.*"}[10m]))) * 100
+```
 </details>
 
 <br />
@@ -13772,8 +15809,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=103800` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `src_conf_client_time_since_last_successful_update_seconds{job=~`^worker.*`,instance=~`${instance:regex}`}`
+Query:
 
+```
+src_conf_client_time_since_last_successful_update_seconds{job=~`^worker.*`,instance=~`${instance:regex}`}
+```
 </details>
 
 <br />
@@ -13791,8 +15831,11 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=103801` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `max(max_over_time(src_conf_client_time_since_last_successful_update_seconds{job=~`^worker.*`,instance=~`${instance:regex}`}[1m]))`
+Query:
 
+```
+max(max_over_time(src_conf_client_time_since_last_successful_update_seconds{job=~`^worker.*`,instance=~`${instance:regex}`}[1m]))
+```
 </details>
 
 <br />
@@ -13821,8 +15864,11 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `max(timestamp(vector(time()))) - max(src_repoupdater_syncer_sync_last_time)`
+Query:
 
+```
+max(timestamp(vector(time()))) - max(src_repoupdater_syncer_sync_last_time)
+```
 </details>
 
 <br />
@@ -13840,8 +15886,11 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `max(src_repoupdater_max_sync_backoff)`
+Query:
 
+```
+max(src_repoupdater_max_sync_backoff)
+```
 </details>
 
 <br />
@@ -13859,8 +15908,11 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `max by (family) (rate(src_repoupdater_syncer_sync_errors_total{owner!="user",reason!="invalid_npm_path",reason!="internal_rate_limit"}[5m]))`
+Query:
 
+```
+max by (family) (rate(src_repoupdater_syncer_sync_errors_total{owner!="user",reason!="invalid_npm_path",reason!="internal_rate_limit"}[5m]))
+```
 </details>
 
 <br />
@@ -13878,8 +15930,11 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `max by (family) (rate(src_repoupdater_syncer_start_sync{family="Syncer.SyncExternalService"}[9h0m0s]))`
+Query:
 
+```
+max by (family) (rate(src_repoupdater_syncer_start_sync{family="Syncer.SyncExternalService"}[9h0m0s]))
+```
 </details>
 
 <br />
@@ -13897,8 +15952,11 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.95, max by (le, family, success) (rate(src_repoupdater_syncer_sync_duration_seconds_bucket[1m])))`
+Query:
 
+```
+histogram_quantile(0.95, max by (le, family, success) (rate(src_repoupdater_syncer_sync_duration_seconds_bucket[1m])))
+```
 </details>
 
 <br />
@@ -13916,8 +15974,11 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.95, max by (le) (rate(src_repoupdater_source_duration_seconds_bucket[1m])))`
+Query:
 
+```
+histogram_quantile(0.95, max by (le) (rate(src_repoupdater_source_duration_seconds_bucket[1m])))
+```
 </details>
 
 <br />
@@ -13935,8 +15996,11 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `max(rate(src_repoupdater_syncer_synced_repos_total[1m]))`
+Query:
 
+```
+max(rate(src_repoupdater_syncer_synced_repos_total[1m]))
+```
 </details>
 
 <br />
@@ -13954,8 +16018,11 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `max(rate(src_repoupdater_source_repos_total[1m]))`
+Query:
 
+```
+max(rate(src_repoupdater_source_repos_total[1m]))
+```
 </details>
 
 <br />
@@ -13973,8 +16040,11 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `max(rate(src_repoupdater_purge_failed[1m]))`
+Query:
 
+```
+max(rate(src_repoupdater_purge_failed[1m]))
+```
 </details>
 
 <br />
@@ -13992,8 +16062,11 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `max(rate(src_repoupdater_sched_auto_fetch[1m]))`
+Query:
 
+```
+max(rate(src_repoupdater_sched_auto_fetch[1m]))
+```
 </details>
 
 <br />
@@ -14014,8 +16087,11 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `max(rate(src_repoupdater_sched_manual_fetch[1m]))`
+Query:
 
+```
+max(rate(src_repoupdater_sched_manual_fetch[1m]))
+```
 </details>
 
 <br />
@@ -14033,8 +16109,11 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `max(src_repoupdater_sched_known_repos)`
+Query:
 
+```
+max(src_repoupdater_sched_known_repos)
+```
 </details>
 
 <br />
@@ -14052,8 +16131,11 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `max(deriv(src_repoupdater_sched_update_queue_length[5m]))`
+Query:
 
+```
+max(deriv(src_repoupdater_sched_update_queue_length[5m]))
+```
 </details>
 
 <br />
@@ -14071,8 +16153,11 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `max(rate(src_repoupdater_sched_loops[1m]))`
+Query:
 
+```
+max(rate(src_repoupdater_sched_loops[1m]))
+```
 </details>
 
 <br />
@@ -14090,8 +16175,11 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `max(src_repoupdater_stale_repos)`
+Query:
 
+```
+max(src_repoupdater_stale_repos)
+```
 </details>
 
 <br />
@@ -14109,8 +16197,11 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `max(rate(src_repoupdater_sched_error[1m]))`
+Query:
 
+```
+max(rate(src_repoupdater_sched_error[1m]))
+```
 </details>
 
 <br />
@@ -14130,8 +16221,11 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `max(src_repoupdater_external_services_total)`
+Query:
 
+```
+max(src_repoupdater_external_services_total)
+```
 </details>
 
 <br />
@@ -14149,8 +16243,11 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `max(src_repoupdater_queued_sync_jobs_total)`
+Query:
 
+```
+max(src_repoupdater_queued_sync_jobs_total)
+```
 </details>
 
 <br />
@@ -14168,8 +16265,11 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `max(src_repoupdater_completed_sync_jobs_total)`
+Query:
 
+```
+max(src_repoupdater_completed_sync_jobs_total)
+```
 </details>
 
 <br />
@@ -14187,8 +16287,11 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `max(src_repoupdater_errored_sync_jobs_percentage)`
+Query:
 
+```
+max(src_repoupdater_errored_sync_jobs_percentage)
+```
 </details>
 
 <br />
@@ -14206,8 +16309,11 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `max by (name) (src_github_rate_limit_remaining_v2{resource="graphql"})`
+Query:
 
+```
+max by (name) (src_github_rate_limit_remaining_v2{resource="graphql"})
+```
 </details>
 
 <br />
@@ -14225,8 +16331,11 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `max by (name) (src_github_rate_limit_remaining_v2{resource="rest"})`
+Query:
 
+```
+max by (name) (src_github_rate_limit_remaining_v2{resource="rest"})
+```
 </details>
 
 <br />
@@ -14244,8 +16353,11 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `max by (name) (src_github_rate_limit_remaining_v2{resource="search"})`
+Query:
 
+```
+max by (name) (src_github_rate_limit_remaining_v2{resource="search"})
+```
 </details>
 
 <br />
@@ -14265,8 +16377,11 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `max by(name) (rate(src_github_rate_limit_wait_duration_seconds{resource="graphql"}[5m]))`
+Query:
 
+```
+max by(name) (rate(src_github_rate_limit_wait_duration_seconds{resource="graphql"}[5m]))
+```
 </details>
 
 <br />
@@ -14286,8 +16401,11 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `max by(name) (rate(src_github_rate_limit_wait_duration_seconds{resource="rest"}[5m]))`
+Query:
 
+```
+max by(name) (rate(src_github_rate_limit_wait_duration_seconds{resource="rest"}[5m]))
+```
 </details>
 
 <br />
@@ -14307,8 +16425,11 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `max by(name) (rate(src_github_rate_limit_wait_duration_seconds{resource="search"}[5m]))`
+Query:
 
+```
+max by(name) (rate(src_github_rate_limit_wait_duration_seconds{resource="search"}[5m]))
+```
 </details>
 
 <br />
@@ -14326,8 +16447,11 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `max by (name) (src_gitlab_rate_limit_remaining{resource="rest"})`
+Query:
 
+```
+max by (name) (src_gitlab_rate_limit_remaining{resource="rest"})
+```
 </details>
 
 <br />
@@ -14347,8 +16471,11 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `max by (name) (rate(src_gitlab_rate_limit_wait_duration_seconds{resource="rest"}[5m]))`
+Query:
 
+```
+max by (name) (rate(src_gitlab_rate_limit_wait_duration_seconds{resource="rest"}[5m]))
+```
 </details>
 
 <br />
@@ -14368,8 +16495,11 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.95, sum(rate(src_internal_rate_limit_wait_duration_bucket{failed="false"}[5m])) by (le, urn))`
+Query:
 
+```
+histogram_quantile(0.95, sum(rate(src_internal_rate_limit_wait_duration_bucket{failed="false"}[5m])) by (le, urn))
+```
 </details>
 
 <br />
@@ -14389,8 +16519,11 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (urn) (rate(src_internal_rate_limit_wait_duration_count{failed="true"}[5m]))`
+Query:
 
+```
+sum by (urn) (rate(src_internal_rate_limit_wait_duration_count{failed="true"}[5m]))
+```
 </details>
 
 <br />
@@ -14410,8 +16543,11 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_gitserver_client_total{job=~"^repo-updater.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_gitserver_client_total{job=~"^repo-updater.*"}[5m]))
+```
 </details>
 
 <br />
@@ -14429,8 +16565,11 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `sum  by (le)(rate(src_gitserver_client_duration_seconds_bucket{job=~"^repo-updater.*"}[5m]))`
+Query:
 
+```
+sum  by (le)(rate(src_gitserver_client_duration_seconds_bucket{job=~"^repo-updater.*"}[5m]))
+```
 </details>
 
 <br />
@@ -14448,8 +16587,11 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_gitserver_client_errors_total{job=~"^repo-updater.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_gitserver_client_errors_total{job=~"^repo-updater.*"}[5m]))
+```
 </details>
 
 <br />
@@ -14467,8 +16609,11 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_gitserver_client_errors_total{job=~"^repo-updater.*"}[5m])) / (sum(increase(src_gitserver_client_total{job=~"^repo-updater.*"}[5m])) + sum(increase(src_gitserver_client_errors_total{job=~"^repo-updater.*"}[5m]))) * 100`
+Query:
 
+```
+sum(increase(src_gitserver_client_errors_total{job=~"^repo-updater.*"}[5m])) / (sum(increase(src_gitserver_client_total{job=~"^repo-updater.*"}[5m])) + sum(increase(src_gitserver_client_errors_total{job=~"^repo-updater.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -14486,8 +16631,11 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op,scope)(increase(src_gitserver_client_total{job=~"^repo-updater.*"}[5m]))`
+Query:
 
+```
+sum by (op,scope)(increase(src_gitserver_client_total{job=~"^repo-updater.*"}[5m]))
+```
 </details>
 
 <br />
@@ -14505,8 +16653,11 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.99, sum  by (le,op,scope)(rate(src_gitserver_client_duration_seconds_bucket{job=~"^repo-updater.*"}[5m])))`
+Query:
 
+```
+histogram_quantile(0.99, sum  by (le,op,scope)(rate(src_gitserver_client_duration_seconds_bucket{job=~"^repo-updater.*"}[5m])))
+```
 </details>
 
 <br />
@@ -14524,8 +16675,11 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op,scope)(increase(src_gitserver_client_errors_total{job=~"^repo-updater.*"}[5m]))`
+Query:
 
+```
+sum by (op,scope)(increase(src_gitserver_client_errors_total{job=~"^repo-updater.*"}[5m]))
+```
 </details>
 
 <br />
@@ -14543,8 +16697,11 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op,scope)(increase(src_gitserver_client_errors_total{job=~"^repo-updater.*"}[5m])) / (sum by (op,scope)(increase(src_gitserver_client_total{job=~"^repo-updater.*"}[5m])) + sum by (op,scope)(increase(src_gitserver_client_errors_total{job=~"^repo-updater.*"}[5m]))) * 100`
+Query:
 
+```
+sum by (op,scope)(increase(src_gitserver_client_errors_total{job=~"^repo-updater.*"}[5m])) / (sum by (op,scope)(increase(src_gitserver_client_total{job=~"^repo-updater.*"}[5m])) + sum by (op,scope)(increase(src_gitserver_client_errors_total{job=~"^repo-updater.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -14564,8 +16721,11 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_batches_dbstore_total{job=~"^repo-updater.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_batches_dbstore_total{job=~"^repo-updater.*"}[5m]))
+```
 </details>
 
 <br />
@@ -14583,8 +16743,11 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `sum  by (le)(rate(src_batches_dbstore_duration_seconds_bucket{job=~"^repo-updater.*"}[5m]))`
+Query:
 
+```
+sum  by (le)(rate(src_batches_dbstore_duration_seconds_bucket{job=~"^repo-updater.*"}[5m]))
+```
 </details>
 
 <br />
@@ -14602,8 +16765,11 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_batches_dbstore_errors_total{job=~"^repo-updater.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_batches_dbstore_errors_total{job=~"^repo-updater.*"}[5m]))
+```
 </details>
 
 <br />
@@ -14621,8 +16787,11 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_batches_dbstore_errors_total{job=~"^repo-updater.*"}[5m])) / (sum(increase(src_batches_dbstore_total{job=~"^repo-updater.*"}[5m])) + sum(increase(src_batches_dbstore_errors_total{job=~"^repo-updater.*"}[5m]))) * 100`
+Query:
 
+```
+sum(increase(src_batches_dbstore_errors_total{job=~"^repo-updater.*"}[5m])) / (sum(increase(src_batches_dbstore_total{job=~"^repo-updater.*"}[5m])) + sum(increase(src_batches_dbstore_errors_total{job=~"^repo-updater.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -14640,8 +16809,11 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_batches_dbstore_total{job=~"^repo-updater.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_batches_dbstore_total{job=~"^repo-updater.*"}[5m]))
+```
 </details>
 
 <br />
@@ -14659,8 +16831,11 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.99, sum  by (le,op)(rate(src_batches_dbstore_duration_seconds_bucket{job=~"^repo-updater.*"}[5m])))`
+Query:
 
+```
+histogram_quantile(0.99, sum  by (le,op)(rate(src_batches_dbstore_duration_seconds_bucket{job=~"^repo-updater.*"}[5m])))
+```
 </details>
 
 <br />
@@ -14678,8 +16853,11 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_batches_dbstore_errors_total{job=~"^repo-updater.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_batches_dbstore_errors_total{job=~"^repo-updater.*"}[5m]))
+```
 </details>
 
 <br />
@@ -14697,8 +16875,11 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_batches_dbstore_errors_total{job=~"^repo-updater.*"}[5m])) / (sum by (op)(increase(src_batches_dbstore_total{job=~"^repo-updater.*"}[5m])) + sum by (op)(increase(src_batches_dbstore_errors_total{job=~"^repo-updater.*"}[5m]))) * 100`
+Query:
 
+```
+sum by (op)(increase(src_batches_dbstore_errors_total{job=~"^repo-updater.*"}[5m])) / (sum by (op)(increase(src_batches_dbstore_total{job=~"^repo-updater.*"}[5m])) + sum by (op)(increase(src_batches_dbstore_errors_total{job=~"^repo-updater.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -14718,8 +16899,11 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_batches_service_total{job=~"^repo-updater.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_batches_service_total{job=~"^repo-updater.*"}[5m]))
+```
 </details>
 
 <br />
@@ -14737,8 +16921,11 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `sum  by (le)(rate(src_batches_service_duration_seconds_bucket{job=~"^repo-updater.*"}[5m]))`
+Query:
 
+```
+sum  by (le)(rate(src_batches_service_duration_seconds_bucket{job=~"^repo-updater.*"}[5m]))
+```
 </details>
 
 <br />
@@ -14756,8 +16943,11 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_batches_service_errors_total{job=~"^repo-updater.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_batches_service_errors_total{job=~"^repo-updater.*"}[5m]))
+```
 </details>
 
 <br />
@@ -14775,8 +16965,11 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_batches_service_errors_total{job=~"^repo-updater.*"}[5m])) / (sum(increase(src_batches_service_total{job=~"^repo-updater.*"}[5m])) + sum(increase(src_batches_service_errors_total{job=~"^repo-updater.*"}[5m]))) * 100`
+Query:
 
+```
+sum(increase(src_batches_service_errors_total{job=~"^repo-updater.*"}[5m])) / (sum(increase(src_batches_service_total{job=~"^repo-updater.*"}[5m])) + sum(increase(src_batches_service_errors_total{job=~"^repo-updater.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -14794,8 +16987,11 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_batches_service_total{job=~"^repo-updater.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_batches_service_total{job=~"^repo-updater.*"}[5m]))
+```
 </details>
 
 <br />
@@ -14813,8 +17009,11 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.99, sum  by (le,op)(rate(src_batches_service_duration_seconds_bucket{job=~"^repo-updater.*"}[5m])))`
+Query:
 
+```
+histogram_quantile(0.99, sum  by (le,op)(rate(src_batches_service_duration_seconds_bucket{job=~"^repo-updater.*"}[5m])))
+```
 </details>
 
 <br />
@@ -14832,8 +17031,11 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_batches_service_errors_total{job=~"^repo-updater.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_batches_service_errors_total{job=~"^repo-updater.*"}[5m]))
+```
 </details>
 
 <br />
@@ -14851,8 +17053,11 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_batches_service_errors_total{job=~"^repo-updater.*"}[5m])) / (sum by (op)(increase(src_batches_service_total{job=~"^repo-updater.*"}[5m])) + sum by (op)(increase(src_batches_service_errors_total{job=~"^repo-updater.*"}[5m]))) * 100`
+Query:
 
+```
+sum by (op)(increase(src_batches_service_errors_total{job=~"^repo-updater.*"}[5m])) / (sum by (op)(increase(src_batches_service_total{job=~"^repo-updater.*"}[5m])) + sum by (op)(increase(src_batches_service_errors_total{job=~"^repo-updater.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -14872,8 +17077,11 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_coursier_total{op!="RunCommand",job=~"^repo-updater.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_coursier_total{op!="RunCommand",job=~"^repo-updater.*"}[5m]))
+```
 </details>
 
 <br />
@@ -14891,8 +17099,11 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `sum  by (le)(rate(src_codeintel_coursier_duration_seconds_bucket{op!="RunCommand",job=~"^repo-updater.*"}[5m]))`
+Query:
 
+```
+sum  by (le)(rate(src_codeintel_coursier_duration_seconds_bucket{op!="RunCommand",job=~"^repo-updater.*"}[5m]))
+```
 </details>
 
 <br />
@@ -14910,8 +17121,11 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_coursier_errors_total{op!="RunCommand",job=~"^repo-updater.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_coursier_errors_total{op!="RunCommand",job=~"^repo-updater.*"}[5m]))
+```
 </details>
 
 <br />
@@ -14929,8 +17143,11 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_coursier_errors_total{op!="RunCommand",job=~"^repo-updater.*"}[5m])) / (sum(increase(src_codeintel_coursier_total{op!="RunCommand",job=~"^repo-updater.*"}[5m])) + sum(increase(src_codeintel_coursier_errors_total{op!="RunCommand",job=~"^repo-updater.*"}[5m]))) * 100`
+Query:
 
+```
+sum(increase(src_codeintel_coursier_errors_total{op!="RunCommand",job=~"^repo-updater.*"}[5m])) / (sum(increase(src_codeintel_coursier_total{op!="RunCommand",job=~"^repo-updater.*"}[5m])) + sum(increase(src_codeintel_coursier_errors_total{op!="RunCommand",job=~"^repo-updater.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -14948,8 +17165,11 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_coursier_total{op!="RunCommand",job=~"^repo-updater.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_coursier_total{op!="RunCommand",job=~"^repo-updater.*"}[5m]))
+```
 </details>
 
 <br />
@@ -14967,8 +17187,11 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_coursier_duration_seconds_bucket{op!="RunCommand",job=~"^repo-updater.*"}[5m])))`
+Query:
 
+```
+histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_coursier_duration_seconds_bucket{op!="RunCommand",job=~"^repo-updater.*"}[5m])))
+```
 </details>
 
 <br />
@@ -14986,8 +17209,11 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_coursier_errors_total{op!="RunCommand",job=~"^repo-updater.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_coursier_errors_total{op!="RunCommand",job=~"^repo-updater.*"}[5m]))
+```
 </details>
 
 <br />
@@ -15005,8 +17231,11 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_coursier_errors_total{op!="RunCommand",job=~"^repo-updater.*"}[5m])) / (sum by (op)(increase(src_codeintel_coursier_total{op!="RunCommand",job=~"^repo-updater.*"}[5m])) + sum by (op)(increase(src_codeintel_coursier_errors_total{op!="RunCommand",job=~"^repo-updater.*"}[5m]))) * 100`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_coursier_errors_total{op!="RunCommand",job=~"^repo-updater.*"}[5m])) / (sum by (op)(increase(src_codeintel_coursier_total{op!="RunCommand",job=~"^repo-updater.*"}[5m])) + sum by (op)(increase(src_codeintel_coursier_errors_total{op!="RunCommand",job=~"^repo-updater.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -15026,8 +17255,11 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_npm_total{op!="RunCommand",job=~"^repo-updater.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_npm_total{op!="RunCommand",job=~"^repo-updater.*"}[5m]))
+```
 </details>
 
 <br />
@@ -15045,8 +17277,11 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `sum  by (le)(rate(src_codeintel_npm_duration_seconds_bucket{op!="RunCommand",job=~"^repo-updater.*"}[5m]))`
+Query:
 
+```
+sum  by (le)(rate(src_codeintel_npm_duration_seconds_bucket{op!="RunCommand",job=~"^repo-updater.*"}[5m]))
+```
 </details>
 
 <br />
@@ -15064,8 +17299,11 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_npm_errors_total{op!="RunCommand",job=~"^repo-updater.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_npm_errors_total{op!="RunCommand",job=~"^repo-updater.*"}[5m]))
+```
 </details>
 
 <br />
@@ -15083,8 +17321,11 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_npm_errors_total{op!="RunCommand",job=~"^repo-updater.*"}[5m])) / (sum(increase(src_codeintel_npm_total{op!="RunCommand",job=~"^repo-updater.*"}[5m])) + sum(increase(src_codeintel_npm_errors_total{op!="RunCommand",job=~"^repo-updater.*"}[5m]))) * 100`
+Query:
 
+```
+sum(increase(src_codeintel_npm_errors_total{op!="RunCommand",job=~"^repo-updater.*"}[5m])) / (sum(increase(src_codeintel_npm_total{op!="RunCommand",job=~"^repo-updater.*"}[5m])) + sum(increase(src_codeintel_npm_errors_total{op!="RunCommand",job=~"^repo-updater.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -15102,8 +17343,11 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_npm_total{op!="RunCommand",job=~"^repo-updater.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_npm_total{op!="RunCommand",job=~"^repo-updater.*"}[5m]))
+```
 </details>
 
 <br />
@@ -15121,8 +17365,11 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_npm_duration_seconds_bucket{op!="RunCommand",job=~"^repo-updater.*"}[5m])))`
+Query:
 
+```
+histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_npm_duration_seconds_bucket{op!="RunCommand",job=~"^repo-updater.*"}[5m])))
+```
 </details>
 
 <br />
@@ -15140,8 +17387,11 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_npm_errors_total{op!="RunCommand",job=~"^repo-updater.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_npm_errors_total{op!="RunCommand",job=~"^repo-updater.*"}[5m]))
+```
 </details>
 
 <br />
@@ -15159,8 +17409,11 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_npm_errors_total{op!="RunCommand",job=~"^repo-updater.*"}[5m])) / (sum by (op)(increase(src_codeintel_npm_total{op!="RunCommand",job=~"^repo-updater.*"}[5m])) + sum by (op)(increase(src_codeintel_npm_errors_total{op!="RunCommand",job=~"^repo-updater.*"}[5m]))) * 100`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_npm_errors_total{op!="RunCommand",job=~"^repo-updater.*"}[5m])) / (sum by (op)(increase(src_codeintel_npm_total{op!="RunCommand",job=~"^repo-updater.*"}[5m])) + sum by (op)(increase(src_codeintel_npm_errors_total{op!="RunCommand",job=~"^repo-updater.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -15182,8 +17435,11 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(rate(grpc_server_started_total{instance=~`${instance:regex}`,grpc_service=~"repoupdater.v1.RepoUpdaterService"}[2m]))`
+Query:
 
+```
+sum(rate(grpc_server_started_total{instance=~`${instance:regex}`,grpc_service=~"repoupdater.v1.RepoUpdaterService"}[2m]))
+```
 </details>
 
 <br />
@@ -15203,8 +17459,11 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(rate(grpc_server_started_total{grpc_method=~`${repo_updater_method:regex}`,instance=~`${instance:regex}`,grpc_service=~"repoupdater.v1.RepoUpdaterService"}[2m])) by (grpc_method)`
+Query:
 
+```
+sum(rate(grpc_server_started_total{grpc_method=~`${repo_updater_method:regex}`,instance=~`${instance:regex}`,grpc_service=~"repoupdater.v1.RepoUpdaterService"}[2m])) by (grpc_method)
+```
 </details>
 
 <br />
@@ -15224,8 +17483,11 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `(100.0 * ( (sum(rate(grpc_server_handled_total{grpc_code!="OK",instance=~`${instance:regex}`,grpc_service=~"repoupdater.v1.RepoUpdaterService"}[2m]))) / (sum(rate(grpc_server_handled_total{instance=~`${instance:regex}`,grpc_service=~"repoupdater.v1.RepoUpdaterService"}[2m]))) ))`
+Query:
 
+```
+(100.0 * ( (sum(rate(grpc_server_handled_total{grpc_code!="OK",instance=~`${instance:regex}`,grpc_service=~"repoupdater.v1.RepoUpdaterService"}[2m]))) / (sum(rate(grpc_server_handled_total{instance=~`${instance:regex}`,grpc_service=~"repoupdater.v1.RepoUpdaterService"}[2m]))) ))
+```
 </details>
 
 <br />
@@ -15245,8 +17507,11 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `(100.0 * ( (sum(rate(grpc_server_handled_total{grpc_method=~`${repo_updater_method:regex}`,grpc_code!="OK",instance=~`${instance:regex}`,grpc_service=~"repoupdater.v1.RepoUpdaterService"}[2m])) by (grpc_method)) / (sum(rate(grpc_server_handled_total{grpc_method=~`${repo_updater_method:regex}`,instance=~`${instance:regex}`,grpc_service=~"repoupdater.v1.RepoUpdaterService"}[2m])) by (grpc_method)) ))`
+Query:
 
+```
+(100.0 * ( (sum(rate(grpc_server_handled_total{grpc_method=~`${repo_updater_method:regex}`,grpc_code!="OK",instance=~`${instance:regex}`,grpc_service=~"repoupdater.v1.RepoUpdaterService"}[2m])) by (grpc_method)) / (sum(rate(grpc_server_handled_total{grpc_method=~`${repo_updater_method:regex}`,instance=~`${instance:regex}`,grpc_service=~"repoupdater.v1.RepoUpdaterService"}[2m])) by (grpc_method)) ))
+```
 </details>
 
 <br />
@@ -15266,8 +17531,11 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.99, sum by (le, name, grpc_method)(rate(grpc_server_handling_seconds_bucket{grpc_method=~`${repo_updater_method:regex}`,instance=~`${instance:regex}`,grpc_service=~"repoupdater.v1.RepoUpdaterService"}[2m])))`
+Query:
 
+```
+histogram_quantile(0.99, sum by (le, name, grpc_method)(rate(grpc_server_handling_seconds_bucket{grpc_method=~`${repo_updater_method:regex}`,instance=~`${instance:regex}`,grpc_service=~"repoupdater.v1.RepoUpdaterService"}[2m])))
+```
 </details>
 
 <br />
@@ -15287,8 +17555,11 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.90, sum by (le, name, grpc_method)(rate(grpc_server_handling_seconds_bucket{grpc_method=~`${repo_updater_method:regex}`,instance=~`${instance:regex}`,grpc_service=~"repoupdater.v1.RepoUpdaterService"}[2m])))`
+Query:
 
+```
+histogram_quantile(0.90, sum by (le, name, grpc_method)(rate(grpc_server_handling_seconds_bucket{grpc_method=~`${repo_updater_method:regex}`,instance=~`${instance:regex}`,grpc_service=~"repoupdater.v1.RepoUpdaterService"}[2m])))
+```
 </details>
 
 <br />
@@ -15308,8 +17579,11 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.75, sum by (le, name, grpc_method)(rate(grpc_server_handling_seconds_bucket{grpc_method=~`${repo_updater_method:regex}`,instance=~`${instance:regex}`,grpc_service=~"repoupdater.v1.RepoUpdaterService"}[2m])))`
+Query:
 
+```
+histogram_quantile(0.75, sum by (le, name, grpc_method)(rate(grpc_server_handling_seconds_bucket{grpc_method=~`${repo_updater_method:regex}`,instance=~`${instance:regex}`,grpc_service=~"repoupdater.v1.RepoUpdaterService"}[2m])))
+```
 </details>
 
 <br />
@@ -15329,8 +17603,11 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.999, sum by (le, name, grpc_method)(rate(src_grpc_server_sent_bytes_per_rpc_bucket{grpc_method=~`${repo_updater_method:regex}`,instance=~`${instance:regex}`,grpc_service=~"repoupdater.v1.RepoUpdaterService"}[2m])))`
+Query:
 
+```
+histogram_quantile(0.999, sum by (le, name, grpc_method)(rate(src_grpc_server_sent_bytes_per_rpc_bucket{grpc_method=~`${repo_updater_method:regex}`,instance=~`${instance:regex}`,grpc_service=~"repoupdater.v1.RepoUpdaterService"}[2m])))
+```
 </details>
 
 <br />
@@ -15350,8 +17627,11 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.90, sum by (le, name, grpc_method)(rate(src_grpc_server_sent_bytes_per_rpc_bucket{grpc_method=~`${repo_updater_method:regex}`,instance=~`${instance:regex}`,grpc_service=~"repoupdater.v1.RepoUpdaterService"}[2m])))`
+Query:
 
+```
+histogram_quantile(0.90, sum by (le, name, grpc_method)(rate(src_grpc_server_sent_bytes_per_rpc_bucket{grpc_method=~`${repo_updater_method:regex}`,instance=~`${instance:regex}`,grpc_service=~"repoupdater.v1.RepoUpdaterService"}[2m])))
+```
 </details>
 
 <br />
@@ -15371,8 +17651,11 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.75, sum by (le, name, grpc_method)(rate(src_grpc_server_sent_bytes_per_rpc_bucket{grpc_method=~`${repo_updater_method:regex}`,instance=~`${instance:regex}`,grpc_service=~"repoupdater.v1.RepoUpdaterService"}[2m])))`
+Query:
 
+```
+histogram_quantile(0.75, sum by (le, name, grpc_method)(rate(src_grpc_server_sent_bytes_per_rpc_bucket{grpc_method=~`${repo_updater_method:regex}`,instance=~`${instance:regex}`,grpc_service=~"repoupdater.v1.RepoUpdaterService"}[2m])))
+```
 </details>
 
 <br />
@@ -15392,8 +17675,11 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.999, sum by (le, name, grpc_method)(rate(src_grpc_server_sent_individual_message_size_bytes_per_rpc_bucket{grpc_method=~`${repo_updater_method:regex}`,instance=~`${instance:regex}`,grpc_service=~"repoupdater.v1.RepoUpdaterService"}[2m])))`
+Query:
 
+```
+histogram_quantile(0.999, sum by (le, name, grpc_method)(rate(src_grpc_server_sent_individual_message_size_bytes_per_rpc_bucket{grpc_method=~`${repo_updater_method:regex}`,instance=~`${instance:regex}`,grpc_service=~"repoupdater.v1.RepoUpdaterService"}[2m])))
+```
 </details>
 
 <br />
@@ -15413,8 +17699,11 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.90, sum by (le, name, grpc_method)(rate(src_grpc_server_sent_individual_message_size_bytes_per_rpc_bucket{grpc_method=~`${repo_updater_method:regex}`,instance=~`${instance:regex}`,grpc_service=~"repoupdater.v1.RepoUpdaterService"}[2m])))`
+Query:
 
+```
+histogram_quantile(0.90, sum by (le, name, grpc_method)(rate(src_grpc_server_sent_individual_message_size_bytes_per_rpc_bucket{grpc_method=~`${repo_updater_method:regex}`,instance=~`${instance:regex}`,grpc_service=~"repoupdater.v1.RepoUpdaterService"}[2m])))
+```
 </details>
 
 <br />
@@ -15434,8 +17723,11 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.75, sum by (le, name, grpc_method)(rate(src_grpc_server_sent_individual_message_size_bytes_per_rpc_bucket{grpc_method=~`${repo_updater_method:regex}`,instance=~`${instance:regex}`,grpc_service=~"repoupdater.v1.RepoUpdaterService"}[2m])))`
+Query:
 
+```
+histogram_quantile(0.75, sum by (le, name, grpc_method)(rate(src_grpc_server_sent_individual_message_size_bytes_per_rpc_bucket{grpc_method=~`${repo_updater_method:regex}`,instance=~`${instance:regex}`,grpc_service=~"repoupdater.v1.RepoUpdaterService"}[2m])))
+```
 </details>
 
 <br />
@@ -15455,8 +17747,11 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `((sum(rate(grpc_server_msg_sent_total{grpc_type="server_stream",instance=~`${instance:regex}`,grpc_service=~"repoupdater.v1.RepoUpdaterService"}[2m])) by (grpc_method))/(sum(rate(grpc_server_started_total{grpc_type="server_stream",instance=~`${instance:regex}`,grpc_service=~"repoupdater.v1.RepoUpdaterService"}[2m])) by (grpc_method)))`
+Query:
 
+```
+((sum(rate(grpc_server_msg_sent_total{grpc_type="server_stream",instance=~`${instance:regex}`,grpc_service=~"repoupdater.v1.RepoUpdaterService"}[2m])) by (grpc_method))/(sum(rate(grpc_server_started_total{grpc_type="server_stream",instance=~`${instance:regex}`,grpc_service=~"repoupdater.v1.RepoUpdaterService"}[2m])) by (grpc_method)))
+```
 </details>
 
 <br />
@@ -15476,8 +17771,11 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(rate(grpc_server_handled_total{grpc_method=~`${repo_updater_method:regex}`,instance=~`${instance:regex}`,grpc_service=~"repoupdater.v1.RepoUpdaterService"}[2m])) by (grpc_method, grpc_code)`
+Query:
 
+```
+sum(rate(grpc_server_handled_total{grpc_method=~`${repo_updater_method:regex}`,instance=~`${instance:regex}`,grpc_service=~"repoupdater.v1.RepoUpdaterService"}[2m])) by (grpc_method, grpc_code)
+```
 </details>
 
 <br />
@@ -15499,8 +17797,11 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `(100.0 * ((((sum(rate(src_grpc_method_status{grpc_service=~"repoupdater.v1.RepoUpdaterService",grpc_code!="OK"}[2m])))) / ((sum(rate(src_grpc_method_status{grpc_service=~"repoupdater.v1.RepoUpdaterService"}[2m])))))))`
+Query:
 
+```
+(100.0 * ((((sum(rate(src_grpc_method_status{grpc_service=~"repoupdater.v1.RepoUpdaterService",grpc_code!="OK"}[2m])))) / ((sum(rate(src_grpc_method_status{grpc_service=~"repoupdater.v1.RepoUpdaterService"}[2m])))))))
+```
 </details>
 
 <br />
@@ -15520,8 +17821,11 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `(100.0 * ((((sum(rate(src_grpc_method_status{grpc_service=~"repoupdater.v1.RepoUpdaterService",grpc_method=~"${repo_updater_method:regex}",grpc_code!="OK"}[2m])) by (grpc_method))) / ((sum(rate(src_grpc_method_status{grpc_service=~"repoupdater.v1.RepoUpdaterService",grpc_method=~"${repo_updater_method:regex}"}[2m])) by (grpc_method))))))`
+Query:
 
+```
+(100.0 * ((((sum(rate(src_grpc_method_status{grpc_service=~"repoupdater.v1.RepoUpdaterService",grpc_method=~"${repo_updater_method:regex}",grpc_code!="OK"}[2m])) by (grpc_method))) / ((sum(rate(src_grpc_method_status{grpc_service=~"repoupdater.v1.RepoUpdaterService",grpc_method=~"${repo_updater_method:regex}"}[2m])) by (grpc_method))))))
+```
 </details>
 
 <br />
@@ -15541,8 +17845,11 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `(sum(rate(src_grpc_method_status{grpc_service=~"repoupdater.v1.RepoUpdaterService",grpc_method=~"${repo_updater_method:regex}"}[2m])) by (grpc_method, grpc_code))`
+Query:
 
+```
+(sum(rate(src_grpc_method_status{grpc_service=~"repoupdater.v1.RepoUpdaterService",grpc_method=~"${repo_updater_method:regex}"}[2m])) by (grpc_method, grpc_code))
+```
 </details>
 
 <br />
@@ -15568,8 +17875,11 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `(100.0 * ((((sum(rate(src_grpc_method_status{grpc_service=~"repoupdater.v1.RepoUpdaterService",grpc_code!="OK",is_internal_error="true"}[2m])))) / ((sum(rate(src_grpc_method_status{grpc_service=~"repoupdater.v1.RepoUpdaterService"}[2m])))))))`
+Query:
 
+```
+(100.0 * ((((sum(rate(src_grpc_method_status{grpc_service=~"repoupdater.v1.RepoUpdaterService",grpc_code!="OK",is_internal_error="true"}[2m])))) / ((sum(rate(src_grpc_method_status{grpc_service=~"repoupdater.v1.RepoUpdaterService"}[2m])))))))
+```
 </details>
 
 <br />
@@ -15595,8 +17905,11 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `(100.0 * ((((sum(rate(src_grpc_method_status{grpc_service=~"repoupdater.v1.RepoUpdaterService",grpc_method=~"${repo_updater_method:regex}",grpc_code!="OK",is_internal_error="true"}[2m])) by (grpc_method))) / ((sum(rate(src_grpc_method_status{grpc_service=~"repoupdater.v1.RepoUpdaterService",grpc_method=~"${repo_updater_method:regex}"}[2m])) by (grpc_method))))))`
+Query:
 
+```
+(100.0 * ((((sum(rate(src_grpc_method_status{grpc_service=~"repoupdater.v1.RepoUpdaterService",grpc_method=~"${repo_updater_method:regex}",grpc_code!="OK",is_internal_error="true"}[2m])) by (grpc_method))) / ((sum(rate(src_grpc_method_status{grpc_service=~"repoupdater.v1.RepoUpdaterService",grpc_method=~"${repo_updater_method:regex}"}[2m])) by (grpc_method))))))
+```
 </details>
 
 <br />
@@ -15622,8 +17935,11 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `(sum(rate(src_grpc_method_status{grpc_service=~"repoupdater.v1.RepoUpdaterService",is_internal_error="true",grpc_method=~"${repo_updater_method:regex}"}[2m])) by (grpc_method, grpc_code))`
+Query:
 
+```
+(sum(rate(src_grpc_method_status{grpc_service=~"repoupdater.v1.RepoUpdaterService",is_internal_error="true",grpc_method=~"${repo_updater_method:regex}"}[2m])) by (grpc_method, grpc_code))
+```
 </details>
 
 <br />
@@ -15645,8 +17961,11 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `(100.0 * ((((sum(rate(src_grpc_client_retry_attempts_total{grpc_service=~"repoupdater.v1.RepoUpdaterService",is_retried="true"}[2m])))) / ((sum(rate(src_grpc_client_retry_attempts_total{grpc_service=~"repoupdater.v1.RepoUpdaterService"}[2m])))))))`
+Query:
 
+```
+(100.0 * ((((sum(rate(src_grpc_client_retry_attempts_total{grpc_service=~"repoupdater.v1.RepoUpdaterService",is_retried="true"}[2m])))) / ((sum(rate(src_grpc_client_retry_attempts_total{grpc_service=~"repoupdater.v1.RepoUpdaterService"}[2m])))))))
+```
 </details>
 
 <br />
@@ -15666,8 +17985,11 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `(100.0 * ((((sum(rate(src_grpc_client_retry_attempts_total{grpc_service=~"repoupdater.v1.RepoUpdaterService",is_retried="true",grpc_method=~"${repo_updater_method:regex}"}[2m])) by (grpc_method))) / ((sum(rate(src_grpc_client_retry_attempts_total{grpc_service=~"repoupdater.v1.RepoUpdaterService",grpc_method=~"${repo_updater_method:regex}"}[2m])) by (grpc_method))))))`
+Query:
 
+```
+(100.0 * ((((sum(rate(src_grpc_client_retry_attempts_total{grpc_service=~"repoupdater.v1.RepoUpdaterService",is_retried="true",grpc_method=~"${repo_updater_method:regex}"}[2m])) by (grpc_method))) / ((sum(rate(src_grpc_client_retry_attempts_total{grpc_service=~"repoupdater.v1.RepoUpdaterService",grpc_method=~"${repo_updater_method:regex}"}[2m])) by (grpc_method))))))
+```
 </details>
 
 <br />
@@ -15687,8 +18009,11 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `(sum(rate(src_grpc_client_retry_attempts_total{grpc_service=~"repoupdater.v1.RepoUpdaterService",grpc_method=~"${repo_updater_method:regex}",is_retried="true"}[2m])) by (grpc_method))`
+Query:
 
+```
+(sum(rate(src_grpc_client_retry_attempts_total{grpc_service=~"repoupdater.v1.RepoUpdaterService",grpc_method=~"${repo_updater_method:regex}",is_retried="true"}[2m])) by (grpc_method))
+```
 </details>
 
 <br />
@@ -15710,8 +18035,11 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `src_conf_client_time_since_last_successful_update_seconds{job=~`.*repo-updater`,instance=~`${instance:regex}`}`
+Query:
 
+```
+src_conf_client_time_since_last_successful_update_seconds{job=~`.*repo-updater`,instance=~`${instance:regex}`}
+```
 </details>
 
 <br />
@@ -15729,8 +18057,11 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `max(max_over_time(src_conf_client_time_since_last_successful_update_seconds{job=~`.*repo-updater`,instance=~`${instance:regex}`}[1m]))`
+Query:
 
+```
+max(max_over_time(src_conf_client_time_since_last_successful_update_seconds{job=~`.*repo-updater`,instance=~`${instance:regex}`}[1m]))
+```
 </details>
 
 <br />
@@ -15752,8 +18083,11 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (route) (rate(src_http_request_duration_seconds_count{app="repo-updater",code=~"2.."}[5m]))`
+Query:
 
+```
+sum by (route) (rate(src_http_request_duration_seconds_count{app="repo-updater",code=~"2.."}[5m]))
+```
 </details>
 
 <br />
@@ -15773,8 +18107,11 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (route) (rate(src_http_request_duration_seconds_count{app="repo-updater",code!~"2.."}[5m]))`
+Query:
 
+```
+sum by (route) (rate(src_http_request_duration_seconds_count{app="repo-updater",code!~"2.."}[5m]))
+```
 </details>
 
 <br />
@@ -15794,8 +18131,11 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (code) (rate(src_http_request_duration_seconds_count{app="repo-updater"}[5m]))`
+Query:
 
+```
+sum by (code) (rate(src_http_request_duration_seconds_count{app="repo-updater"}[5m]))
+```
 </details>
 
 <br />
@@ -15815,8 +18155,11 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.95, sum(rate(src_http_request_duration_seconds_bucket{app="repo-updater",code=~"2.."}[5m])) by (le, route))`
+Query:
 
+```
+histogram_quantile(0.95, sum(rate(src_http_request_duration_seconds_bucket{app="repo-updater",code=~"2.."}[5m])) by (le, route))
+```
 </details>
 
 <br />
@@ -15836,8 +18179,11 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.95, sum(rate(src_http_request_duration_seconds_bucket{app="repo-updater",code!~"2.."}[5m])) by (le, route))`
+Query:
 
+```
+histogram_quantile(0.95, sum(rate(src_http_request_duration_seconds_bucket{app="repo-updater",code!~"2.."}[5m])) by (le, route))
+```
 </details>
 
 <br />
@@ -15857,8 +18203,11 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (app_name, db_name) (src_pgsql_conns_max_open{app_name="repo-updater"})`
+Query:
 
+```
+sum by (app_name, db_name) (src_pgsql_conns_max_open{app_name="repo-updater"})
+```
 </details>
 
 <br />
@@ -15876,8 +18225,11 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (app_name, db_name) (src_pgsql_conns_open{app_name="repo-updater"})`
+Query:
 
+```
+sum by (app_name, db_name) (src_pgsql_conns_open{app_name="repo-updater"})
+```
 </details>
 
 <br />
@@ -15895,8 +18247,11 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (app_name, db_name) (src_pgsql_conns_in_use{app_name="repo-updater"})`
+Query:
 
+```
+sum by (app_name, db_name) (src_pgsql_conns_in_use{app_name="repo-updater"})
+```
 </details>
 
 <br />
@@ -15914,8 +18269,11 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (app_name, db_name) (src_pgsql_conns_idle{app_name="repo-updater"})`
+Query:
 
+```
+sum by (app_name, db_name) (src_pgsql_conns_idle{app_name="repo-updater"})
+```
 </details>
 
 <br />
@@ -15933,8 +18291,11 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (app_name, db_name) (increase(src_pgsql_conns_blocked_seconds{app_name="repo-updater"}[5m])) / sum by (app_name, db_name) (increase(src_pgsql_conns_waited_for{app_name="repo-updater"}[5m]))`
+Query:
 
+```
+sum by (app_name, db_name) (increase(src_pgsql_conns_blocked_seconds{app_name="repo-updater"}[5m])) / sum by (app_name, db_name) (increase(src_pgsql_conns_waited_for{app_name="repo-updater"}[5m]))
+```
 </details>
 
 <br />
@@ -15952,8 +18313,11 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (app_name, db_name) (increase(src_pgsql_conns_closed_max_idle{app_name="repo-updater"}[5m]))`
+Query:
 
+```
+sum by (app_name, db_name) (increase(src_pgsql_conns_closed_max_idle{app_name="repo-updater"}[5m]))
+```
 </details>
 
 <br />
@@ -15971,8 +18335,11 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (app_name, db_name) (increase(src_pgsql_conns_closed_max_lifetime{app_name="repo-updater"}[5m]))`
+Query:
 
+```
+sum by (app_name, db_name) (increase(src_pgsql_conns_closed_max_lifetime{app_name="repo-updater"}[5m]))
+```
 </details>
 
 <br />
@@ -15990,8 +18357,11 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (app_name, db_name) (increase(src_pgsql_conns_closed_max_idle_time{app_name="repo-updater"}[5m]))`
+Query:
 
+```
+sum by (app_name, db_name) (increase(src_pgsql_conns_closed_max_idle_time{app_name="repo-updater"}[5m]))
+```
 </details>
 
 <br />
@@ -16021,8 +18391,11 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `count by(name) ((time() - container_last_seen{name=~"^repo-updater.*"}) > 60)`
+Query:
 
+```
+count by(name) ((time() - container_last_seen{name=~"^repo-updater.*"}) > 60)
+```
 </details>
 
 <br />
@@ -16040,8 +18413,11 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `cadvisor_container_cpu_usage_percentage_total{name=~"^repo-updater.*"}`
+Query:
 
+```
+cadvisor_container_cpu_usage_percentage_total{name=~"^repo-updater.*"}
+```
 </details>
 
 <br />
@@ -16059,8 +18435,11 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `cadvisor_container_memory_usage_percentage_total{name=~"^repo-updater.*"}`
+Query:
 
+```
+cadvisor_container_memory_usage_percentage_total{name=~"^repo-updater.*"}
+```
 </details>
 
 <br />
@@ -16081,8 +18460,11 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by(name) (rate(container_fs_reads_total{name=~"^repo-updater.*"}[1h]) + rate(container_fs_writes_total{name=~"^repo-updater.*"}[1h]))`
+Query:
 
+```
+sum by(name) (rate(container_fs_reads_total{name=~"^repo-updater.*"}[1h]) + rate(container_fs_writes_total{name=~"^repo-updater.*"}[1h]))
+```
 </details>
 
 <br />
@@ -16102,8 +18484,11 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `quantile_over_time(0.9, cadvisor_container_cpu_usage_percentage_total{name=~"^repo-updater.*"}[1d])`
+Query:
 
+```
+quantile_over_time(0.9, cadvisor_container_cpu_usage_percentage_total{name=~"^repo-updater.*"}[1d])
+```
 </details>
 
 <br />
@@ -16121,8 +18506,11 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^repo-updater.*"}[1d])`
+Query:
 
+```
+max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^repo-updater.*"}[1d])
+```
 </details>
 
 <br />
@@ -16140,8 +18528,11 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `max_over_time(cadvisor_container_cpu_usage_percentage_total{name=~"^repo-updater.*"}[5m])`
+Query:
 
+```
+max_over_time(cadvisor_container_cpu_usage_percentage_total{name=~"^repo-updater.*"}[5m])
+```
 </details>
 
 <br />
@@ -16159,8 +18550,11 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^repo-updater.*"}[5m])`
+Query:
 
+```
+max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^repo-updater.*"}[5m])
+```
 </details>
 
 <br />
@@ -16181,8 +18575,11 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `max by (name) (container_oom_events_total{name=~"^repo-updater.*"})`
+Query:
 
+```
+max by (name) (container_oom_events_total{name=~"^repo-updater.*"})
+```
 </details>
 
 <br />
@@ -16204,8 +18601,11 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `max by(instance) (go_goroutines{job=~".*repo-updater"})`
+Query:
 
+```
+max by(instance) (go_goroutines{job=~".*repo-updater"})
+```
 </details>
 
 <br />
@@ -16223,8 +18623,11 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `max by(instance) (go_gc_duration_seconds{job=~".*repo-updater"})`
+Query:
 
+```
+max by(instance) (go_gc_duration_seconds{job=~".*repo-updater"})
+```
 </details>
 
 <br />
@@ -16244,8 +18647,11 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by(app) (up{app=~".*repo-updater"}) / count by (app) (up{app=~".*repo-updater"}) * 100`
+Query:
 
+```
+sum by(app) (up{app=~".*repo-updater"}) / count by (app) (up{app=~".*repo-updater"}) * 100
+```
 </details>
 
 <br />
@@ -16280,8 +18686,11 @@ To see this panel, visit `/-/debug/grafana/d/searcher/searcher?viewPanel=100000`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (code) (rate(searcher_service_request_total{instance=~`${instance:regex}`}[10m]))`
+Query:
 
+```
+sum by (code) (rate(searcher_service_request_total{instance=~`${instance:regex}`}[10m]))
+```
 </details>
 
 <br />
@@ -16310,8 +18719,11 @@ To see this panel, visit `/-/debug/grafana/d/searcher/searcher?viewPanel=100001`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (instance) (rate(searcher_service_request_total{instance=~`${instance:regex}`}[10m]))`
+Query:
 
+```
+sum by (instance) (rate(searcher_service_request_total{instance=~`${instance:regex}`}[10m]))
+```
 </details>
 
 <br />
@@ -16332,8 +18744,11 @@ To see this panel, visit `/-/debug/grafana/d/searcher/searcher?viewPanel=100010`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (instance) (searcher_service_running{instance=~`${instance:regex}`})`
+Query:
 
+```
+sum by (instance) (searcher_service_running{instance=~`${instance:regex}`})
+```
 </details>
 
 <br />
@@ -16351,8 +18766,11 @@ To see this panel, visit `/-/debug/grafana/d/searcher/searcher?viewPanel=100011`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (code)(increase(searcher_service_request_total{code!="200",code!="canceled",instance=~`${instance:regex}`}[5m])) / ignoring(code) group_left sum(increase(searcher_service_request_total{instance=~`${instance:regex}`}[5m])) * 100`
+Query:
 
+```
+sum by (code)(increase(searcher_service_request_total{code!="200",code!="canceled",instance=~`${instance:regex}`}[5m])) / ignoring(code) group_left sum(increase(searcher_service_request_total{instance=~`${instance:regex}`}[5m])) * 100
+```
 </details>
 
 <br />
@@ -16381,8 +18799,11 @@ To see this panel, visit `/-/debug/grafana/d/searcher/searcher?viewPanel=100100`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (instance) (searcher_store_fetching{instance=~`${instance:regex}`})`
+Query:
 
+```
+sum by (instance) (searcher_store_fetching{instance=~`${instance:regex}`})
+```
 </details>
 
 <br />
@@ -16404,8 +18825,11 @@ To see this panel, visit `/-/debug/grafana/d/searcher/searcher?viewPanel=100101`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (instance) (searcher_store_fetch_queue_size{instance=~`${instance:regex}`})`
+Query:
 
+```
+sum by (instance) (searcher_store_fetch_queue_size{instance=~`${instance:regex}`})
+```
 </details>
 
 <br />
@@ -16428,8 +18852,11 @@ To see this panel, visit `/-/debug/grafana/d/searcher/searcher?viewPanel=100102`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (instance) (rate(searcher_store_fetch_failed{instance=~`${instance:regex}`}[10m]))`
+Query:
 
+```
+sum by (instance) (rate(searcher_store_fetch_failed{instance=~`${instance:regex}`}[10m]))
+```
 </details>
 
 <br />
@@ -16466,8 +18893,11 @@ To see this panel, visit `/-/debug/grafana/d/searcher/searcher?viewPanel=100200`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (state)(increase(searcher_hybrid_final_state_total{instance=~`${instance:regex}`}[10m]))`
+Query:
 
+```
+sum by (state)(increase(searcher_hybrid_final_state_total{instance=~`${instance:regex}`}[10m]))
+```
 </details>
 
 <br />
@@ -16490,8 +18920,11 @@ To see this panel, visit `/-/debug/grafana/d/searcher/searcher?viewPanel=100201`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (reason)(increase(searcher_hybrid_retry_total{instance=~`${instance:regex}`}[10m]))`
+Query:
 
+```
+sum by (reason)(increase(searcher_hybrid_retry_total{instance=~`${instance:regex}`}[10m]))
+```
 </details>
 
 <br />
@@ -16515,8 +18948,11 @@ To see this panel, visit `/-/debug/grafana/d/searcher/searcher?viewPanel=100300`
 <details>
 <summary>Technical details</summary>
 
-Query: `(max by (instance) (searcher_mount_point_info{mount_name="cacheDir",instance=~`${instance:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_reads_completed_total{instance=~`node-exporter.*`}[1m])))))`
+Query:
 
+```
+(max by (instance) (searcher_mount_point_info{mount_name="cacheDir",instance=~`${instance:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_reads_completed_total{instance=~`node-exporter.*`}[1m])))))
+```
 </details>
 
 <br />
@@ -16538,8 +18974,11 @@ To see this panel, visit `/-/debug/grafana/d/searcher/searcher?viewPanel=100301`
 <details>
 <summary>Technical details</summary>
 
-Query: `(max by (instance) (searcher_mount_point_info{mount_name="cacheDir",instance=~`${instance:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_writes_completed_total{instance=~`node-exporter.*`}[1m])))))`
+Query:
 
+```
+(max by (instance) (searcher_mount_point_info{mount_name="cacheDir",instance=~`${instance:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_writes_completed_total{instance=~`node-exporter.*`}[1m])))))
+```
 </details>
 
 <br />
@@ -16561,8 +19000,11 @@ To see this panel, visit `/-/debug/grafana/d/searcher/searcher?viewPanel=100310`
 <details>
 <summary>Technical details</summary>
 
-Query: `(max by (instance) (searcher_mount_point_info{mount_name="cacheDir",instance=~`${instance:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_read_bytes_total{instance=~`node-exporter.*`}[1m])))))`
+Query:
 
+```
+(max by (instance) (searcher_mount_point_info{mount_name="cacheDir",instance=~`${instance:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_read_bytes_total{instance=~`node-exporter.*`}[1m])))))
+```
 </details>
 
 <br />
@@ -16584,8 +19026,11 @@ To see this panel, visit `/-/debug/grafana/d/searcher/searcher?viewPanel=100311`
 <details>
 <summary>Technical details</summary>
 
-Query: `(max by (instance) (searcher_mount_point_info{mount_name="cacheDir",instance=~`${instance:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_written_bytes_total{instance=~`node-exporter.*`}[1m])))))`
+Query:
 
+```
+(max by (instance) (searcher_mount_point_info{mount_name="cacheDir",instance=~`${instance:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_written_bytes_total{instance=~`node-exporter.*`}[1m])))))
+```
 </details>
 
 <br />
@@ -16607,8 +19052,11 @@ To see this panel, visit `/-/debug/grafana/d/searcher/searcher?viewPanel=100320`
 <details>
 <summary>Technical details</summary>
 
-Query: `(((max by (instance) (searcher_mount_point_info{mount_name="cacheDir",instance=~`${instance:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_read_time_seconds_total{instance=~`node-exporter.*`}[1m])))))) / ((max by (instance) (searcher_mount_point_info{mount_name="cacheDir",instance=~`${instance:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_reads_completed_total{instance=~`node-exporter.*`}[1m])))))))`
+Query:
 
+```
+(((max by (instance) (searcher_mount_point_info{mount_name="cacheDir",instance=~`${instance:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_read_time_seconds_total{instance=~`node-exporter.*`}[1m])))))) / ((max by (instance) (searcher_mount_point_info{mount_name="cacheDir",instance=~`${instance:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_reads_completed_total{instance=~`node-exporter.*`}[1m])))))))
+```
 </details>
 
 <br />
@@ -16630,8 +19078,11 @@ To see this panel, visit `/-/debug/grafana/d/searcher/searcher?viewPanel=100321`
 <details>
 <summary>Technical details</summary>
 
-Query: `(((max by (instance) (searcher_mount_point_info{mount_name="cacheDir",instance=~`${instance:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_write_time_seconds_total{instance=~`node-exporter.*`}[1m])))))) / ((max by (instance) (searcher_mount_point_info{mount_name="cacheDir",instance=~`${instance:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_writes_completed_total{instance=~`node-exporter.*`}[1m])))))))`
+Query:
 
+```
+(((max by (instance) (searcher_mount_point_info{mount_name="cacheDir",instance=~`${instance:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_write_time_seconds_total{instance=~`node-exporter.*`}[1m])))))) / ((max by (instance) (searcher_mount_point_info{mount_name="cacheDir",instance=~`${instance:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_writes_completed_total{instance=~`node-exporter.*`}[1m])))))))
+```
 </details>
 
 <br />
@@ -16653,8 +19104,11 @@ To see this panel, visit `/-/debug/grafana/d/searcher/searcher?viewPanel=100330`
 <details>
 <summary>Technical details</summary>
 
-Query: `(((max by (instance) (searcher_mount_point_info{mount_name="cacheDir",instance=~`${instance:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_read_bytes_total{instance=~`node-exporter.*`}[1m])))))) / ((max by (instance) (searcher_mount_point_info{mount_name="cacheDir",instance=~`${instance:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_reads_completed_total{instance=~`node-exporter.*`}[1m])))))))`
+Query:
 
+```
+(((max by (instance) (searcher_mount_point_info{mount_name="cacheDir",instance=~`${instance:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_read_bytes_total{instance=~`node-exporter.*`}[1m])))))) / ((max by (instance) (searcher_mount_point_info{mount_name="cacheDir",instance=~`${instance:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_reads_completed_total{instance=~`node-exporter.*`}[1m])))))))
+```
 </details>
 
 <br />
@@ -16676,8 +19130,11 @@ To see this panel, visit `/-/debug/grafana/d/searcher/searcher?viewPanel=100331`
 <details>
 <summary>Technical details</summary>
 
-Query: `(((max by (instance) (searcher_mount_point_info{mount_name="cacheDir",instance=~`${instance:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_written_bytes_total{instance=~`node-exporter.*`}[1m])))))) / ((max by (instance) (searcher_mount_point_info{mount_name="cacheDir",instance=~`${instance:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_writes_completed_total{instance=~`node-exporter.*`}[1m])))))))`
+Query:
 
+```
+(((max by (instance) (searcher_mount_point_info{mount_name="cacheDir",instance=~`${instance:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_written_bytes_total{instance=~`node-exporter.*`}[1m])))))) / ((max by (instance) (searcher_mount_point_info{mount_name="cacheDir",instance=~`${instance:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_writes_completed_total{instance=~`node-exporter.*`}[1m])))))))
+```
 </details>
 
 <br />
@@ -16699,8 +19156,11 @@ To see this panel, visit `/-/debug/grafana/d/searcher/searcher?viewPanel=100340`
 <details>
 <summary>Technical details</summary>
 
-Query: `(max by (instance) (searcher_mount_point_info{mount_name="cacheDir",instance=~`${instance:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_reads_merged_total{instance=~`node-exporter.*`}[1m])))))`
+Query:
 
+```
+(max by (instance) (searcher_mount_point_info{mount_name="cacheDir",instance=~`${instance:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_reads_merged_total{instance=~`node-exporter.*`}[1m])))))
+```
 </details>
 
 <br />
@@ -16722,8 +19182,11 @@ To see this panel, visit `/-/debug/grafana/d/searcher/searcher?viewPanel=100341`
 <details>
 <summary>Technical details</summary>
 
-Query: `(max by (instance) (searcher_mount_point_info{mount_name="cacheDir",instance=~`${instance:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_writes_merged_total{instance=~`node-exporter.*`}[1m])))))`
+Query:
 
+```
+(max by (instance) (searcher_mount_point_info{mount_name="cacheDir",instance=~`${instance:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_writes_merged_total{instance=~`node-exporter.*`}[1m])))))
+```
 </details>
 
 <br />
@@ -16745,8 +19208,11 @@ To see this panel, visit `/-/debug/grafana/d/searcher/searcher?viewPanel=100350`
 <details>
 <summary>Technical details</summary>
 
-Query: `(max by (instance) (searcher_mount_point_info{mount_name="cacheDir",instance=~`${instance:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_io_time_weighted_seconds_total{instance=~`node-exporter.*`}[1m])))))`
+Query:
 
+```
+(max by (instance) (searcher_mount_point_info{mount_name="cacheDir",instance=~`${instance:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_io_time_weighted_seconds_total{instance=~`node-exporter.*`}[1m])))))
+```
 </details>
 
 <br />
@@ -16768,8 +19234,11 @@ To see this panel, visit `/-/debug/grafana/d/searcher/searcher?viewPanel=100400`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(rate(grpc_server_started_total{instance=~`${instance:regex}`,grpc_service=~"searcher.v1.SearcherService"}[2m]))`
+Query:
 
+```
+sum(rate(grpc_server_started_total{instance=~`${instance:regex}`,grpc_service=~"searcher.v1.SearcherService"}[2m]))
+```
 </details>
 
 <br />
@@ -16789,8 +19258,11 @@ To see this panel, visit `/-/debug/grafana/d/searcher/searcher?viewPanel=100401`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(rate(grpc_server_started_total{grpc_method=~`${searcher_method:regex}`,instance=~`${instance:regex}`,grpc_service=~"searcher.v1.SearcherService"}[2m])) by (grpc_method)`
+Query:
 
+```
+sum(rate(grpc_server_started_total{grpc_method=~`${searcher_method:regex}`,instance=~`${instance:regex}`,grpc_service=~"searcher.v1.SearcherService"}[2m])) by (grpc_method)
+```
 </details>
 
 <br />
@@ -16810,8 +19282,11 @@ To see this panel, visit `/-/debug/grafana/d/searcher/searcher?viewPanel=100410`
 <details>
 <summary>Technical details</summary>
 
-Query: `(100.0 * ( (sum(rate(grpc_server_handled_total{grpc_code!="OK",instance=~`${instance:regex}`,grpc_service=~"searcher.v1.SearcherService"}[2m]))) / (sum(rate(grpc_server_handled_total{instance=~`${instance:regex}`,grpc_service=~"searcher.v1.SearcherService"}[2m]))) ))`
+Query:
 
+```
+(100.0 * ( (sum(rate(grpc_server_handled_total{grpc_code!="OK",instance=~`${instance:regex}`,grpc_service=~"searcher.v1.SearcherService"}[2m]))) / (sum(rate(grpc_server_handled_total{instance=~`${instance:regex}`,grpc_service=~"searcher.v1.SearcherService"}[2m]))) ))
+```
 </details>
 
 <br />
@@ -16831,8 +19306,11 @@ To see this panel, visit `/-/debug/grafana/d/searcher/searcher?viewPanel=100411`
 <details>
 <summary>Technical details</summary>
 
-Query: `(100.0 * ( (sum(rate(grpc_server_handled_total{grpc_method=~`${searcher_method:regex}`,grpc_code!="OK",instance=~`${instance:regex}`,grpc_service=~"searcher.v1.SearcherService"}[2m])) by (grpc_method)) / (sum(rate(grpc_server_handled_total{grpc_method=~`${searcher_method:regex}`,instance=~`${instance:regex}`,grpc_service=~"searcher.v1.SearcherService"}[2m])) by (grpc_method)) ))`
+Query:
 
+```
+(100.0 * ( (sum(rate(grpc_server_handled_total{grpc_method=~`${searcher_method:regex}`,grpc_code!="OK",instance=~`${instance:regex}`,grpc_service=~"searcher.v1.SearcherService"}[2m])) by (grpc_method)) / (sum(rate(grpc_server_handled_total{grpc_method=~`${searcher_method:regex}`,instance=~`${instance:regex}`,grpc_service=~"searcher.v1.SearcherService"}[2m])) by (grpc_method)) ))
+```
 </details>
 
 <br />
@@ -16852,8 +19330,11 @@ To see this panel, visit `/-/debug/grafana/d/searcher/searcher?viewPanel=100420`
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.99, sum by (le, name, grpc_method)(rate(grpc_server_handling_seconds_bucket{grpc_method=~`${searcher_method:regex}`,instance=~`${instance:regex}`,grpc_service=~"searcher.v1.SearcherService"}[2m])))`
+Query:
 
+```
+histogram_quantile(0.99, sum by (le, name, grpc_method)(rate(grpc_server_handling_seconds_bucket{grpc_method=~`${searcher_method:regex}`,instance=~`${instance:regex}`,grpc_service=~"searcher.v1.SearcherService"}[2m])))
+```
 </details>
 
 <br />
@@ -16873,8 +19354,11 @@ To see this panel, visit `/-/debug/grafana/d/searcher/searcher?viewPanel=100421`
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.90, sum by (le, name, grpc_method)(rate(grpc_server_handling_seconds_bucket{grpc_method=~`${searcher_method:regex}`,instance=~`${instance:regex}`,grpc_service=~"searcher.v1.SearcherService"}[2m])))`
+Query:
 
+```
+histogram_quantile(0.90, sum by (le, name, grpc_method)(rate(grpc_server_handling_seconds_bucket{grpc_method=~`${searcher_method:regex}`,instance=~`${instance:regex}`,grpc_service=~"searcher.v1.SearcherService"}[2m])))
+```
 </details>
 
 <br />
@@ -16894,8 +19378,11 @@ To see this panel, visit `/-/debug/grafana/d/searcher/searcher?viewPanel=100422`
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.75, sum by (le, name, grpc_method)(rate(grpc_server_handling_seconds_bucket{grpc_method=~`${searcher_method:regex}`,instance=~`${instance:regex}`,grpc_service=~"searcher.v1.SearcherService"}[2m])))`
+Query:
 
+```
+histogram_quantile(0.75, sum by (le, name, grpc_method)(rate(grpc_server_handling_seconds_bucket{grpc_method=~`${searcher_method:regex}`,instance=~`${instance:regex}`,grpc_service=~"searcher.v1.SearcherService"}[2m])))
+```
 </details>
 
 <br />
@@ -16915,8 +19402,11 @@ To see this panel, visit `/-/debug/grafana/d/searcher/searcher?viewPanel=100430`
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.999, sum by (le, name, grpc_method)(rate(src_grpc_server_sent_bytes_per_rpc_bucket{grpc_method=~`${searcher_method:regex}`,instance=~`${instance:regex}`,grpc_service=~"searcher.v1.SearcherService"}[2m])))`
+Query:
 
+```
+histogram_quantile(0.999, sum by (le, name, grpc_method)(rate(src_grpc_server_sent_bytes_per_rpc_bucket{grpc_method=~`${searcher_method:regex}`,instance=~`${instance:regex}`,grpc_service=~"searcher.v1.SearcherService"}[2m])))
+```
 </details>
 
 <br />
@@ -16936,8 +19426,11 @@ To see this panel, visit `/-/debug/grafana/d/searcher/searcher?viewPanel=100431`
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.90, sum by (le, name, grpc_method)(rate(src_grpc_server_sent_bytes_per_rpc_bucket{grpc_method=~`${searcher_method:regex}`,instance=~`${instance:regex}`,grpc_service=~"searcher.v1.SearcherService"}[2m])))`
+Query:
 
+```
+histogram_quantile(0.90, sum by (le, name, grpc_method)(rate(src_grpc_server_sent_bytes_per_rpc_bucket{grpc_method=~`${searcher_method:regex}`,instance=~`${instance:regex}`,grpc_service=~"searcher.v1.SearcherService"}[2m])))
+```
 </details>
 
 <br />
@@ -16957,8 +19450,11 @@ To see this panel, visit `/-/debug/grafana/d/searcher/searcher?viewPanel=100432`
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.75, sum by (le, name, grpc_method)(rate(src_grpc_server_sent_bytes_per_rpc_bucket{grpc_method=~`${searcher_method:regex}`,instance=~`${instance:regex}`,grpc_service=~"searcher.v1.SearcherService"}[2m])))`
+Query:
 
+```
+histogram_quantile(0.75, sum by (le, name, grpc_method)(rate(src_grpc_server_sent_bytes_per_rpc_bucket{grpc_method=~`${searcher_method:regex}`,instance=~`${instance:regex}`,grpc_service=~"searcher.v1.SearcherService"}[2m])))
+```
 </details>
 
 <br />
@@ -16978,8 +19474,11 @@ To see this panel, visit `/-/debug/grafana/d/searcher/searcher?viewPanel=100440`
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.999, sum by (le, name, grpc_method)(rate(src_grpc_server_sent_individual_message_size_bytes_per_rpc_bucket{grpc_method=~`${searcher_method:regex}`,instance=~`${instance:regex}`,grpc_service=~"searcher.v1.SearcherService"}[2m])))`
+Query:
 
+```
+histogram_quantile(0.999, sum by (le, name, grpc_method)(rate(src_grpc_server_sent_individual_message_size_bytes_per_rpc_bucket{grpc_method=~`${searcher_method:regex}`,instance=~`${instance:regex}`,grpc_service=~"searcher.v1.SearcherService"}[2m])))
+```
 </details>
 
 <br />
@@ -16999,8 +19498,11 @@ To see this panel, visit `/-/debug/grafana/d/searcher/searcher?viewPanel=100441`
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.90, sum by (le, name, grpc_method)(rate(src_grpc_server_sent_individual_message_size_bytes_per_rpc_bucket{grpc_method=~`${searcher_method:regex}`,instance=~`${instance:regex}`,grpc_service=~"searcher.v1.SearcherService"}[2m])))`
+Query:
 
+```
+histogram_quantile(0.90, sum by (le, name, grpc_method)(rate(src_grpc_server_sent_individual_message_size_bytes_per_rpc_bucket{grpc_method=~`${searcher_method:regex}`,instance=~`${instance:regex}`,grpc_service=~"searcher.v1.SearcherService"}[2m])))
+```
 </details>
 
 <br />
@@ -17020,8 +19522,11 @@ To see this panel, visit `/-/debug/grafana/d/searcher/searcher?viewPanel=100442`
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.75, sum by (le, name, grpc_method)(rate(src_grpc_server_sent_individual_message_size_bytes_per_rpc_bucket{grpc_method=~`${searcher_method:regex}`,instance=~`${instance:regex}`,grpc_service=~"searcher.v1.SearcherService"}[2m])))`
+Query:
 
+```
+histogram_quantile(0.75, sum by (le, name, grpc_method)(rate(src_grpc_server_sent_individual_message_size_bytes_per_rpc_bucket{grpc_method=~`${searcher_method:regex}`,instance=~`${instance:regex}`,grpc_service=~"searcher.v1.SearcherService"}[2m])))
+```
 </details>
 
 <br />
@@ -17041,8 +19546,11 @@ To see this panel, visit `/-/debug/grafana/d/searcher/searcher?viewPanel=100450`
 <details>
 <summary>Technical details</summary>
 
-Query: `((sum(rate(grpc_server_msg_sent_total{grpc_type="server_stream",instance=~`${instance:regex}`,grpc_service=~"searcher.v1.SearcherService"}[2m])) by (grpc_method))/(sum(rate(grpc_server_started_total{grpc_type="server_stream",instance=~`${instance:regex}`,grpc_service=~"searcher.v1.SearcherService"}[2m])) by (grpc_method)))`
+Query:
 
+```
+((sum(rate(grpc_server_msg_sent_total{grpc_type="server_stream",instance=~`${instance:regex}`,grpc_service=~"searcher.v1.SearcherService"}[2m])) by (grpc_method))/(sum(rate(grpc_server_started_total{grpc_type="server_stream",instance=~`${instance:regex}`,grpc_service=~"searcher.v1.SearcherService"}[2m])) by (grpc_method)))
+```
 </details>
 
 <br />
@@ -17062,8 +19570,11 @@ To see this panel, visit `/-/debug/grafana/d/searcher/searcher?viewPanel=100460`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(rate(grpc_server_handled_total{grpc_method=~`${searcher_method:regex}`,instance=~`${instance:regex}`,grpc_service=~"searcher.v1.SearcherService"}[2m])) by (grpc_method, grpc_code)`
+Query:
 
+```
+sum(rate(grpc_server_handled_total{grpc_method=~`${searcher_method:regex}`,instance=~`${instance:regex}`,grpc_service=~"searcher.v1.SearcherService"}[2m])) by (grpc_method, grpc_code)
+```
 </details>
 
 <br />
@@ -17085,8 +19596,11 @@ To see this panel, visit `/-/debug/grafana/d/searcher/searcher?viewPanel=100500`
 <details>
 <summary>Technical details</summary>
 
-Query: `(100.0 * ((((sum(rate(src_grpc_method_status{grpc_service=~"searcher.v1.SearcherService",grpc_code!="OK"}[2m])))) / ((sum(rate(src_grpc_method_status{grpc_service=~"searcher.v1.SearcherService"}[2m])))))))`
+Query:
 
+```
+(100.0 * ((((sum(rate(src_grpc_method_status{grpc_service=~"searcher.v1.SearcherService",grpc_code!="OK"}[2m])))) / ((sum(rate(src_grpc_method_status{grpc_service=~"searcher.v1.SearcherService"}[2m])))))))
+```
 </details>
 
 <br />
@@ -17106,8 +19620,11 @@ To see this panel, visit `/-/debug/grafana/d/searcher/searcher?viewPanel=100501`
 <details>
 <summary>Technical details</summary>
 
-Query: `(100.0 * ((((sum(rate(src_grpc_method_status{grpc_service=~"searcher.v1.SearcherService",grpc_method=~"${searcher_method:regex}",grpc_code!="OK"}[2m])) by (grpc_method))) / ((sum(rate(src_grpc_method_status{grpc_service=~"searcher.v1.SearcherService",grpc_method=~"${searcher_method:regex}"}[2m])) by (grpc_method))))))`
+Query:
 
+```
+(100.0 * ((((sum(rate(src_grpc_method_status{grpc_service=~"searcher.v1.SearcherService",grpc_method=~"${searcher_method:regex}",grpc_code!="OK"}[2m])) by (grpc_method))) / ((sum(rate(src_grpc_method_status{grpc_service=~"searcher.v1.SearcherService",grpc_method=~"${searcher_method:regex}"}[2m])) by (grpc_method))))))
+```
 </details>
 
 <br />
@@ -17127,8 +19644,11 @@ To see this panel, visit `/-/debug/grafana/d/searcher/searcher?viewPanel=100502`
 <details>
 <summary>Technical details</summary>
 
-Query: `(sum(rate(src_grpc_method_status{grpc_service=~"searcher.v1.SearcherService",grpc_method=~"${searcher_method:regex}"}[2m])) by (grpc_method, grpc_code))`
+Query:
 
+```
+(sum(rate(src_grpc_method_status{grpc_service=~"searcher.v1.SearcherService",grpc_method=~"${searcher_method:regex}"}[2m])) by (grpc_method, grpc_code))
+```
 </details>
 
 <br />
@@ -17154,8 +19674,11 @@ To see this panel, visit `/-/debug/grafana/d/searcher/searcher?viewPanel=100510`
 <details>
 <summary>Technical details</summary>
 
-Query: `(100.0 * ((((sum(rate(src_grpc_method_status{grpc_service=~"searcher.v1.SearcherService",grpc_code!="OK",is_internal_error="true"}[2m])))) / ((sum(rate(src_grpc_method_status{grpc_service=~"searcher.v1.SearcherService"}[2m])))))))`
+Query:
 
+```
+(100.0 * ((((sum(rate(src_grpc_method_status{grpc_service=~"searcher.v1.SearcherService",grpc_code!="OK",is_internal_error="true"}[2m])))) / ((sum(rate(src_grpc_method_status{grpc_service=~"searcher.v1.SearcherService"}[2m])))))))
+```
 </details>
 
 <br />
@@ -17181,8 +19704,11 @@ To see this panel, visit `/-/debug/grafana/d/searcher/searcher?viewPanel=100511`
 <details>
 <summary>Technical details</summary>
 
-Query: `(100.0 * ((((sum(rate(src_grpc_method_status{grpc_service=~"searcher.v1.SearcherService",grpc_method=~"${searcher_method:regex}",grpc_code!="OK",is_internal_error="true"}[2m])) by (grpc_method))) / ((sum(rate(src_grpc_method_status{grpc_service=~"searcher.v1.SearcherService",grpc_method=~"${searcher_method:regex}"}[2m])) by (grpc_method))))))`
+Query:
 
+```
+(100.0 * ((((sum(rate(src_grpc_method_status{grpc_service=~"searcher.v1.SearcherService",grpc_method=~"${searcher_method:regex}",grpc_code!="OK",is_internal_error="true"}[2m])) by (grpc_method))) / ((sum(rate(src_grpc_method_status{grpc_service=~"searcher.v1.SearcherService",grpc_method=~"${searcher_method:regex}"}[2m])) by (grpc_method))))))
+```
 </details>
 
 <br />
@@ -17208,8 +19734,11 @@ To see this panel, visit `/-/debug/grafana/d/searcher/searcher?viewPanel=100512`
 <details>
 <summary>Technical details</summary>
 
-Query: `(sum(rate(src_grpc_method_status{grpc_service=~"searcher.v1.SearcherService",is_internal_error="true",grpc_method=~"${searcher_method:regex}"}[2m])) by (grpc_method, grpc_code))`
+Query:
 
+```
+(sum(rate(src_grpc_method_status{grpc_service=~"searcher.v1.SearcherService",is_internal_error="true",grpc_method=~"${searcher_method:regex}"}[2m])) by (grpc_method, grpc_code))
+```
 </details>
 
 <br />
@@ -17231,8 +19760,11 @@ To see this panel, visit `/-/debug/grafana/d/searcher/searcher?viewPanel=100600`
 <details>
 <summary>Technical details</summary>
 
-Query: `(100.0 * ((((sum(rate(src_grpc_client_retry_attempts_total{grpc_service=~"searcher.v1.SearcherService",is_retried="true"}[2m])))) / ((sum(rate(src_grpc_client_retry_attempts_total{grpc_service=~"searcher.v1.SearcherService"}[2m])))))))`
+Query:
 
+```
+(100.0 * ((((sum(rate(src_grpc_client_retry_attempts_total{grpc_service=~"searcher.v1.SearcherService",is_retried="true"}[2m])))) / ((sum(rate(src_grpc_client_retry_attempts_total{grpc_service=~"searcher.v1.SearcherService"}[2m])))))))
+```
 </details>
 
 <br />
@@ -17252,8 +19784,11 @@ To see this panel, visit `/-/debug/grafana/d/searcher/searcher?viewPanel=100601`
 <details>
 <summary>Technical details</summary>
 
-Query: `(100.0 * ((((sum(rate(src_grpc_client_retry_attempts_total{grpc_service=~"searcher.v1.SearcherService",is_retried="true",grpc_method=~"${searcher_method:regex}"}[2m])) by (grpc_method))) / ((sum(rate(src_grpc_client_retry_attempts_total{grpc_service=~"searcher.v1.SearcherService",grpc_method=~"${searcher_method:regex}"}[2m])) by (grpc_method))))))`
+Query:
 
+```
+(100.0 * ((((sum(rate(src_grpc_client_retry_attempts_total{grpc_service=~"searcher.v1.SearcherService",is_retried="true",grpc_method=~"${searcher_method:regex}"}[2m])) by (grpc_method))) / ((sum(rate(src_grpc_client_retry_attempts_total{grpc_service=~"searcher.v1.SearcherService",grpc_method=~"${searcher_method:regex}"}[2m])) by (grpc_method))))))
+```
 </details>
 
 <br />
@@ -17273,8 +19808,11 @@ To see this panel, visit `/-/debug/grafana/d/searcher/searcher?viewPanel=100602`
 <details>
 <summary>Technical details</summary>
 
-Query: `(sum(rate(src_grpc_client_retry_attempts_total{grpc_service=~"searcher.v1.SearcherService",grpc_method=~"${searcher_method:regex}",is_retried="true"}[2m])) by (grpc_method))`
+Query:
 
+```
+(sum(rate(src_grpc_client_retry_attempts_total{grpc_service=~"searcher.v1.SearcherService",grpc_method=~"${searcher_method:regex}",is_retried="true"}[2m])) by (grpc_method))
+```
 </details>
 
 <br />
@@ -17296,8 +19834,11 @@ To see this panel, visit `/-/debug/grafana/d/searcher/searcher?viewPanel=100700`
 <details>
 <summary>Technical details</summary>
 
-Query: `src_conf_client_time_since_last_successful_update_seconds{job=~`.*searcher`,instance=~`${instance:regex}`}`
+Query:
 
+```
+src_conf_client_time_since_last_successful_update_seconds{job=~`.*searcher`,instance=~`${instance:regex}`}
+```
 </details>
 
 <br />
@@ -17315,8 +19856,11 @@ To see this panel, visit `/-/debug/grafana/d/searcher/searcher?viewPanel=100701`
 <details>
 <summary>Technical details</summary>
 
-Query: `max(max_over_time(src_conf_client_time_since_last_successful_update_seconds{job=~`.*searcher`,instance=~`${instance:regex}`}[1m]))`
+Query:
 
+```
+max(max_over_time(src_conf_client_time_since_last_successful_update_seconds{job=~`.*searcher`,instance=~`${instance:regex}`}[1m]))
+```
 </details>
 
 <br />
@@ -17336,8 +19880,11 @@ To see this panel, visit `/-/debug/grafana/d/searcher/searcher?viewPanel=100800`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (app_name, db_name) (src_pgsql_conns_max_open{app_name="searcher"})`
+Query:
 
+```
+sum by (app_name, db_name) (src_pgsql_conns_max_open{app_name="searcher"})
+```
 </details>
 
 <br />
@@ -17355,8 +19902,11 @@ To see this panel, visit `/-/debug/grafana/d/searcher/searcher?viewPanel=100801`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (app_name, db_name) (src_pgsql_conns_open{app_name="searcher"})`
+Query:
 
+```
+sum by (app_name, db_name) (src_pgsql_conns_open{app_name="searcher"})
+```
 </details>
 
 <br />
@@ -17374,8 +19924,11 @@ To see this panel, visit `/-/debug/grafana/d/searcher/searcher?viewPanel=100810`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (app_name, db_name) (src_pgsql_conns_in_use{app_name="searcher"})`
+Query:
 
+```
+sum by (app_name, db_name) (src_pgsql_conns_in_use{app_name="searcher"})
+```
 </details>
 
 <br />
@@ -17393,8 +19946,11 @@ To see this panel, visit `/-/debug/grafana/d/searcher/searcher?viewPanel=100811`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (app_name, db_name) (src_pgsql_conns_idle{app_name="searcher"})`
+Query:
 
+```
+sum by (app_name, db_name) (src_pgsql_conns_idle{app_name="searcher"})
+```
 </details>
 
 <br />
@@ -17412,8 +19968,11 @@ To see this panel, visit `/-/debug/grafana/d/searcher/searcher?viewPanel=100820`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (app_name, db_name) (increase(src_pgsql_conns_blocked_seconds{app_name="searcher"}[5m])) / sum by (app_name, db_name) (increase(src_pgsql_conns_waited_for{app_name="searcher"}[5m]))`
+Query:
 
+```
+sum by (app_name, db_name) (increase(src_pgsql_conns_blocked_seconds{app_name="searcher"}[5m])) / sum by (app_name, db_name) (increase(src_pgsql_conns_waited_for{app_name="searcher"}[5m]))
+```
 </details>
 
 <br />
@@ -17431,8 +19990,11 @@ To see this panel, visit `/-/debug/grafana/d/searcher/searcher?viewPanel=100830`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (app_name, db_name) (increase(src_pgsql_conns_closed_max_idle{app_name="searcher"}[5m]))`
+Query:
 
+```
+sum by (app_name, db_name) (increase(src_pgsql_conns_closed_max_idle{app_name="searcher"}[5m]))
+```
 </details>
 
 <br />
@@ -17450,8 +20012,11 @@ To see this panel, visit `/-/debug/grafana/d/searcher/searcher?viewPanel=100831`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (app_name, db_name) (increase(src_pgsql_conns_closed_max_lifetime{app_name="searcher"}[5m]))`
+Query:
 
+```
+sum by (app_name, db_name) (increase(src_pgsql_conns_closed_max_lifetime{app_name="searcher"}[5m]))
+```
 </details>
 
 <br />
@@ -17469,8 +20034,11 @@ To see this panel, visit `/-/debug/grafana/d/searcher/searcher?viewPanel=100832`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (app_name, db_name) (increase(src_pgsql_conns_closed_max_idle_time{app_name="searcher"}[5m]))`
+Query:
 
+```
+sum by (app_name, db_name) (increase(src_pgsql_conns_closed_max_idle_time{app_name="searcher"}[5m]))
+```
 </details>
 
 <br />
@@ -17500,8 +20068,11 @@ To see this panel, visit `/-/debug/grafana/d/searcher/searcher?viewPanel=100900`
 <details>
 <summary>Technical details</summary>
 
-Query: `count by(name) ((time() - container_last_seen{name=~"^searcher.*"}) > 60)`
+Query:
 
+```
+count by(name) ((time() - container_last_seen{name=~"^searcher.*"}) > 60)
+```
 </details>
 
 <br />
@@ -17519,8 +20090,11 @@ To see this panel, visit `/-/debug/grafana/d/searcher/searcher?viewPanel=100901`
 <details>
 <summary>Technical details</summary>
 
-Query: `cadvisor_container_cpu_usage_percentage_total{name=~"^searcher.*"}`
+Query:
 
+```
+cadvisor_container_cpu_usage_percentage_total{name=~"^searcher.*"}
+```
 </details>
 
 <br />
@@ -17538,8 +20112,11 @@ To see this panel, visit `/-/debug/grafana/d/searcher/searcher?viewPanel=100902`
 <details>
 <summary>Technical details</summary>
 
-Query: `cadvisor_container_memory_usage_percentage_total{name=~"^searcher.*"}`
+Query:
 
+```
+cadvisor_container_memory_usage_percentage_total{name=~"^searcher.*"}
+```
 </details>
 
 <br />
@@ -17560,8 +20137,11 @@ To see this panel, visit `/-/debug/grafana/d/searcher/searcher?viewPanel=100903`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by(name) (rate(container_fs_reads_total{name=~"^searcher.*"}[1h]) + rate(container_fs_writes_total{name=~"^searcher.*"}[1h]))`
+Query:
 
+```
+sum by(name) (rate(container_fs_reads_total{name=~"^searcher.*"}[1h]) + rate(container_fs_writes_total{name=~"^searcher.*"}[1h]))
+```
 </details>
 
 <br />
@@ -17581,8 +20161,11 @@ To see this panel, visit `/-/debug/grafana/d/searcher/searcher?viewPanel=101000`
 <details>
 <summary>Technical details</summary>
 
-Query: `quantile_over_time(0.9, cadvisor_container_cpu_usage_percentage_total{name=~"^searcher.*"}[1d])`
+Query:
 
+```
+quantile_over_time(0.9, cadvisor_container_cpu_usage_percentage_total{name=~"^searcher.*"}[1d])
+```
 </details>
 
 <br />
@@ -17600,8 +20183,11 @@ To see this panel, visit `/-/debug/grafana/d/searcher/searcher?viewPanel=101001`
 <details>
 <summary>Technical details</summary>
 
-Query: `max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^searcher.*"}[1d])`
+Query:
 
+```
+max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^searcher.*"}[1d])
+```
 </details>
 
 <br />
@@ -17619,8 +20205,11 @@ To see this panel, visit `/-/debug/grafana/d/searcher/searcher?viewPanel=101010`
 <details>
 <summary>Technical details</summary>
 
-Query: `max_over_time(cadvisor_container_cpu_usage_percentage_total{name=~"^searcher.*"}[5m])`
+Query:
 
+```
+max_over_time(cadvisor_container_cpu_usage_percentage_total{name=~"^searcher.*"}[5m])
+```
 </details>
 
 <br />
@@ -17638,8 +20227,11 @@ To see this panel, visit `/-/debug/grafana/d/searcher/searcher?viewPanel=101011`
 <details>
 <summary>Technical details</summary>
 
-Query: `max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^searcher.*"}[5m])`
+Query:
 
+```
+max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^searcher.*"}[5m])
+```
 </details>
 
 <br />
@@ -17660,8 +20252,11 @@ To see this panel, visit `/-/debug/grafana/d/searcher/searcher?viewPanel=101012`
 <details>
 <summary>Technical details</summary>
 
-Query: `max by (name) (container_oom_events_total{name=~"^searcher.*"})`
+Query:
 
+```
+max by (name) (container_oom_events_total{name=~"^searcher.*"})
+```
 </details>
 
 <br />
@@ -17683,8 +20278,11 @@ To see this panel, visit `/-/debug/grafana/d/searcher/searcher?viewPanel=101100`
 <details>
 <summary>Technical details</summary>
 
-Query: `max by(instance) (go_goroutines{job=~".*searcher"})`
+Query:
 
+```
+max by(instance) (go_goroutines{job=~".*searcher"})
+```
 </details>
 
 <br />
@@ -17702,8 +20300,11 @@ To see this panel, visit `/-/debug/grafana/d/searcher/searcher?viewPanel=101101`
 <details>
 <summary>Technical details</summary>
 
-Query: `max by(instance) (go_gc_duration_seconds{job=~".*searcher"})`
+Query:
 
+```
+max by(instance) (go_gc_duration_seconds{job=~".*searcher"})
+```
 </details>
 
 <br />
@@ -17723,8 +20324,11 @@ To see this panel, visit `/-/debug/grafana/d/searcher/searcher?viewPanel=101200`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by(app) (up{app=~".*searcher"}) / count by (app) (up{app=~".*searcher"}) * 100`
+Query:
 
+```
+sum by(app) (up{app=~".*searcher"}) / count by (app) (up{app=~".*searcher"}) * 100
+```
 </details>
 
 <br />
@@ -17750,8 +20354,11 @@ To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100000` o
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_symbols_api_total{job=~"^symbols.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_symbols_api_total{job=~"^symbols.*"}[5m]))
+```
 </details>
 
 <br />
@@ -17769,8 +20376,11 @@ To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100001` o
 <details>
 <summary>Technical details</summary>
 
-Query: `sum  by (le)(rate(src_codeintel_symbols_api_duration_seconds_bucket{job=~"^symbols.*"}[5m]))`
+Query:
 
+```
+sum  by (le)(rate(src_codeintel_symbols_api_duration_seconds_bucket{job=~"^symbols.*"}[5m]))
+```
 </details>
 
 <br />
@@ -17788,8 +20398,11 @@ To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100002` o
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_symbols_api_errors_total{job=~"^symbols.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_symbols_api_errors_total{job=~"^symbols.*"}[5m]))
+```
 </details>
 
 <br />
@@ -17807,8 +20420,11 @@ To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100003` o
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_symbols_api_errors_total{job=~"^symbols.*"}[5m])) / (sum(increase(src_codeintel_symbols_api_total{job=~"^symbols.*"}[5m])) + sum(increase(src_codeintel_symbols_api_errors_total{job=~"^symbols.*"}[5m]))) * 100`
+Query:
 
+```
+sum(increase(src_codeintel_symbols_api_errors_total{job=~"^symbols.*"}[5m])) / (sum(increase(src_codeintel_symbols_api_total{job=~"^symbols.*"}[5m])) + sum(increase(src_codeintel_symbols_api_errors_total{job=~"^symbols.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -17826,8 +20442,11 @@ To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100010` o
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op,parseAmount)(increase(src_codeintel_symbols_api_total{job=~"^symbols.*"}[5m]))`
+Query:
 
+```
+sum by (op,parseAmount)(increase(src_codeintel_symbols_api_total{job=~"^symbols.*"}[5m]))
+```
 </details>
 
 <br />
@@ -17845,8 +20464,11 @@ To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100011` o
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.99, sum  by (le,op,parseAmount)(rate(src_codeintel_symbols_api_duration_seconds_bucket{job=~"^symbols.*"}[5m])))`
+Query:
 
+```
+histogram_quantile(0.99, sum  by (le,op,parseAmount)(rate(src_codeintel_symbols_api_duration_seconds_bucket{job=~"^symbols.*"}[5m])))
+```
 </details>
 
 <br />
@@ -17864,8 +20486,11 @@ To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100012` o
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op,parseAmount)(increase(src_codeintel_symbols_api_errors_total{job=~"^symbols.*"}[5m]))`
+Query:
 
+```
+sum by (op,parseAmount)(increase(src_codeintel_symbols_api_errors_total{job=~"^symbols.*"}[5m]))
+```
 </details>
 
 <br />
@@ -17883,8 +20508,11 @@ To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100013` o
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op,parseAmount)(increase(src_codeintel_symbols_api_errors_total{job=~"^symbols.*"}[5m])) / (sum by (op,parseAmount)(increase(src_codeintel_symbols_api_total{job=~"^symbols.*"}[5m])) + sum by (op,parseAmount)(increase(src_codeintel_symbols_api_errors_total{job=~"^symbols.*"}[5m]))) * 100`
+Query:
 
+```
+sum by (op,parseAmount)(increase(src_codeintel_symbols_api_errors_total{job=~"^symbols.*"}[5m])) / (sum by (op,parseAmount)(increase(src_codeintel_symbols_api_total{job=~"^symbols.*"}[5m])) + sum by (op,parseAmount)(increase(src_codeintel_symbols_api_errors_total{job=~"^symbols.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -17904,8 +20532,11 @@ To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100100` o
 <details>
 <summary>Technical details</summary>
 
-Query: `max(src_codeintel_symbols_parsing{job=~"^symbols.*"})`
+Query:
 
+```
+max(src_codeintel_symbols_parsing{job=~"^symbols.*"})
+```
 </details>
 
 <br />
@@ -17923,8 +20554,11 @@ To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100101` o
 <details>
 <summary>Technical details</summary>
 
-Query: `max(src_codeintel_symbols_parse_queue_size{job=~"^symbols.*"})`
+Query:
 
+```
+max(src_codeintel_symbols_parse_queue_size{job=~"^symbols.*"})
+```
 </details>
 
 <br />
@@ -17942,8 +20576,11 @@ To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100102` o
 <details>
 <summary>Technical details</summary>
 
-Query: `max(src_codeintel_symbols_parse_queue_timeouts_total{job=~"^symbols.*"})`
+Query:
 
+```
+max(src_codeintel_symbols_parse_queue_timeouts_total{job=~"^symbols.*"})
+```
 </details>
 
 <br />
@@ -17961,8 +20598,11 @@ To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100103` o
 <details>
 <summary>Technical details</summary>
 
-Query: `rate(src_codeintel_symbols_parse_failed_total{job=~"^symbols.*"}[5m])`
+Query:
 
+```
+rate(src_codeintel_symbols_parse_failed_total{job=~"^symbols.*"}[5m])
+```
 </details>
 
 <br />
@@ -17980,8 +20620,11 @@ To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100110` o
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_symbols_parser_total{job=~"^symbols.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_symbols_parser_total{job=~"^symbols.*"}[5m]))
+```
 </details>
 
 <br />
@@ -17999,8 +20642,11 @@ To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100111` o
 <details>
 <summary>Technical details</summary>
 
-Query: `sum  by (le)(rate(src_codeintel_symbols_parser_duration_seconds_bucket{job=~"^symbols.*"}[5m]))`
+Query:
 
+```
+sum  by (le)(rate(src_codeintel_symbols_parser_duration_seconds_bucket{job=~"^symbols.*"}[5m]))
+```
 </details>
 
 <br />
@@ -18018,8 +20664,11 @@ To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100112` o
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_symbols_parser_errors_total{job=~"^symbols.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_symbols_parser_errors_total{job=~"^symbols.*"}[5m]))
+```
 </details>
 
 <br />
@@ -18037,8 +20686,11 @@ To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100113` o
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_symbols_parser_errors_total{job=~"^symbols.*"}[5m])) / (sum(increase(src_codeintel_symbols_parser_total{job=~"^symbols.*"}[5m])) + sum(increase(src_codeintel_symbols_parser_errors_total{job=~"^symbols.*"}[5m]))) * 100`
+Query:
 
+```
+sum(increase(src_codeintel_symbols_parser_errors_total{job=~"^symbols.*"}[5m])) / (sum(increase(src_codeintel_symbols_parser_total{job=~"^symbols.*"}[5m])) + sum(increase(src_codeintel_symbols_parser_errors_total{job=~"^symbols.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -18056,8 +20708,11 @@ To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100120` o
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_symbols_parser_total{job=~"^symbols.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_symbols_parser_total{job=~"^symbols.*"}[5m]))
+```
 </details>
 
 <br />
@@ -18075,8 +20730,11 @@ To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100121` o
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_symbols_parser_duration_seconds_bucket{job=~"^symbols.*"}[5m])))`
+Query:
 
+```
+histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_symbols_parser_duration_seconds_bucket{job=~"^symbols.*"}[5m])))
+```
 </details>
 
 <br />
@@ -18094,8 +20752,11 @@ To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100122` o
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_symbols_parser_errors_total{job=~"^symbols.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_symbols_parser_errors_total{job=~"^symbols.*"}[5m]))
+```
 </details>
 
 <br />
@@ -18113,8 +20774,11 @@ To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100123` o
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_symbols_parser_errors_total{job=~"^symbols.*"}[5m])) / (sum by (op)(increase(src_codeintel_symbols_parser_total{job=~"^symbols.*"}[5m])) + sum by (op)(increase(src_codeintel_symbols_parser_errors_total{job=~"^symbols.*"}[5m]))) * 100`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_symbols_parser_errors_total{job=~"^symbols.*"}[5m])) / (sum by (op)(increase(src_codeintel_symbols_parser_total{job=~"^symbols.*"}[5m])) + sum by (op)(increase(src_codeintel_symbols_parser_errors_total{job=~"^symbols.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -18136,8 +20800,11 @@ To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100200` o
 <details>
 <summary>Technical details</summary>
 
-Query: `src_codeintel_symbols_store_cache_size_bytes`
+Query:
 
+```
+src_codeintel_symbols_store_cache_size_bytes
+```
 </details>
 
 <br />
@@ -18157,8 +20824,11 @@ To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100201` o
 <details>
 <summary>Technical details</summary>
 
-Query: `rate(src_codeintel_symbols_store_evictions_total[5m])`
+Query:
 
+```
+rate(src_codeintel_symbols_store_evictions_total[5m])
+```
 </details>
 
 <br />
@@ -18178,8 +20848,11 @@ To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100202` o
 <details>
 <summary>Technical details</summary>
 
-Query: `rate(src_codeintel_symbols_store_errors_total[5m])`
+Query:
 
+```
+rate(src_codeintel_symbols_store_errors_total[5m])
+```
 </details>
 
 <br />
@@ -18199,8 +20872,11 @@ To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100300` o
 <details>
 <summary>Technical details</summary>
 
-Query: `src_codeintel_symbols_fetching`
+Query:
 
+```
+src_codeintel_symbols_fetching
+```
 </details>
 
 <br />
@@ -18218,8 +20894,11 @@ To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100301` o
 <details>
 <summary>Technical details</summary>
 
-Query: `max(src_codeintel_symbols_fetch_queue_size{job=~"^symbols.*"})`
+Query:
 
+```
+max(src_codeintel_symbols_fetch_queue_size{job=~"^symbols.*"})
+```
 </details>
 
 <br />
@@ -18237,8 +20916,11 @@ To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100310` o
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_symbols_repository_fetcher_total{job=~"^symbols.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_symbols_repository_fetcher_total{job=~"^symbols.*"}[5m]))
+```
 </details>
 
 <br />
@@ -18256,8 +20938,11 @@ To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100311` o
 <details>
 <summary>Technical details</summary>
 
-Query: `sum  by (le)(rate(src_codeintel_symbols_repository_fetcher_duration_seconds_bucket{job=~"^symbols.*"}[5m]))`
+Query:
 
+```
+sum  by (le)(rate(src_codeintel_symbols_repository_fetcher_duration_seconds_bucket{job=~"^symbols.*"}[5m]))
+```
 </details>
 
 <br />
@@ -18275,8 +20960,11 @@ To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100312` o
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_symbols_repository_fetcher_errors_total{job=~"^symbols.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_symbols_repository_fetcher_errors_total{job=~"^symbols.*"}[5m]))
+```
 </details>
 
 <br />
@@ -18294,8 +20982,11 @@ To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100313` o
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_symbols_repository_fetcher_errors_total{job=~"^symbols.*"}[5m])) / (sum(increase(src_codeintel_symbols_repository_fetcher_total{job=~"^symbols.*"}[5m])) + sum(increase(src_codeintel_symbols_repository_fetcher_errors_total{job=~"^symbols.*"}[5m]))) * 100`
+Query:
 
+```
+sum(increase(src_codeintel_symbols_repository_fetcher_errors_total{job=~"^symbols.*"}[5m])) / (sum(increase(src_codeintel_symbols_repository_fetcher_total{job=~"^symbols.*"}[5m])) + sum(increase(src_codeintel_symbols_repository_fetcher_errors_total{job=~"^symbols.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -18313,8 +21004,11 @@ To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100320` o
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_symbols_repository_fetcher_total{job=~"^symbols.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_symbols_repository_fetcher_total{job=~"^symbols.*"}[5m]))
+```
 </details>
 
 <br />
@@ -18332,8 +21026,11 @@ To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100321` o
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_symbols_repository_fetcher_duration_seconds_bucket{job=~"^symbols.*"}[5m])))`
+Query:
 
+```
+histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_symbols_repository_fetcher_duration_seconds_bucket{job=~"^symbols.*"}[5m])))
+```
 </details>
 
 <br />
@@ -18351,8 +21048,11 @@ To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100322` o
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_symbols_repository_fetcher_errors_total{job=~"^symbols.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_symbols_repository_fetcher_errors_total{job=~"^symbols.*"}[5m]))
+```
 </details>
 
 <br />
@@ -18370,8 +21070,11 @@ To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100323` o
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_symbols_repository_fetcher_errors_total{job=~"^symbols.*"}[5m])) / (sum by (op)(increase(src_codeintel_symbols_repository_fetcher_total{job=~"^symbols.*"}[5m])) + sum by (op)(increase(src_codeintel_symbols_repository_fetcher_errors_total{job=~"^symbols.*"}[5m]))) * 100`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_symbols_repository_fetcher_errors_total{job=~"^symbols.*"}[5m])) / (sum by (op)(increase(src_codeintel_symbols_repository_fetcher_total{job=~"^symbols.*"}[5m])) + sum by (op)(increase(src_codeintel_symbols_repository_fetcher_errors_total{job=~"^symbols.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -18391,8 +21094,11 @@ To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100400` o
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_symbols_gitserver_total{job=~"^symbols.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_symbols_gitserver_total{job=~"^symbols.*"}[5m]))
+```
 </details>
 
 <br />
@@ -18410,8 +21116,11 @@ To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100401` o
 <details>
 <summary>Technical details</summary>
 
-Query: `sum  by (le)(rate(src_codeintel_symbols_gitserver_duration_seconds_bucket{job=~"^symbols.*"}[5m]))`
+Query:
 
+```
+sum  by (le)(rate(src_codeintel_symbols_gitserver_duration_seconds_bucket{job=~"^symbols.*"}[5m]))
+```
 </details>
 
 <br />
@@ -18429,8 +21138,11 @@ To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100402` o
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_symbols_gitserver_errors_total{job=~"^symbols.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_symbols_gitserver_errors_total{job=~"^symbols.*"}[5m]))
+```
 </details>
 
 <br />
@@ -18448,8 +21160,11 @@ To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100403` o
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_symbols_gitserver_errors_total{job=~"^symbols.*"}[5m])) / (sum(increase(src_codeintel_symbols_gitserver_total{job=~"^symbols.*"}[5m])) + sum(increase(src_codeintel_symbols_gitserver_errors_total{job=~"^symbols.*"}[5m]))) * 100`
+Query:
 
+```
+sum(increase(src_codeintel_symbols_gitserver_errors_total{job=~"^symbols.*"}[5m])) / (sum(increase(src_codeintel_symbols_gitserver_total{job=~"^symbols.*"}[5m])) + sum(increase(src_codeintel_symbols_gitserver_errors_total{job=~"^symbols.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -18467,8 +21182,11 @@ To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100410` o
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_symbols_gitserver_total{job=~"^symbols.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_symbols_gitserver_total{job=~"^symbols.*"}[5m]))
+```
 </details>
 
 <br />
@@ -18486,8 +21204,11 @@ To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100411` o
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_symbols_gitserver_duration_seconds_bucket{job=~"^symbols.*"}[5m])))`
+Query:
 
+```
+histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_symbols_gitserver_duration_seconds_bucket{job=~"^symbols.*"}[5m])))
+```
 </details>
 
 <br />
@@ -18505,8 +21226,11 @@ To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100412` o
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_symbols_gitserver_errors_total{job=~"^symbols.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_symbols_gitserver_errors_total{job=~"^symbols.*"}[5m]))
+```
 </details>
 
 <br />
@@ -18524,8 +21248,11 @@ To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100413` o
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_symbols_gitserver_errors_total{job=~"^symbols.*"}[5m])) / (sum by (op)(increase(src_codeintel_symbols_gitserver_total{job=~"^symbols.*"}[5m])) + sum by (op)(increase(src_codeintel_symbols_gitserver_errors_total{job=~"^symbols.*"}[5m]))) * 100`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_symbols_gitserver_errors_total{job=~"^symbols.*"}[5m])) / (sum by (op)(increase(src_codeintel_symbols_gitserver_total{job=~"^symbols.*"}[5m])) + sum by (op)(increase(src_codeintel_symbols_gitserver_errors_total{job=~"^symbols.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -18547,8 +21274,11 @@ To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100500` o
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(rate(grpc_server_started_total{instance=~`${instance:regex}`,grpc_service=~"symbols.v1.SymbolsService"}[2m]))`
+Query:
 
+```
+sum(rate(grpc_server_started_total{instance=~`${instance:regex}`,grpc_service=~"symbols.v1.SymbolsService"}[2m]))
+```
 </details>
 
 <br />
@@ -18568,8 +21298,11 @@ To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100501` o
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(rate(grpc_server_started_total{grpc_method=~`${symbols_method:regex}`,instance=~`${instance:regex}`,grpc_service=~"symbols.v1.SymbolsService"}[2m])) by (grpc_method)`
+Query:
 
+```
+sum(rate(grpc_server_started_total{grpc_method=~`${symbols_method:regex}`,instance=~`${instance:regex}`,grpc_service=~"symbols.v1.SymbolsService"}[2m])) by (grpc_method)
+```
 </details>
 
 <br />
@@ -18589,8 +21322,11 @@ To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100510` o
 <details>
 <summary>Technical details</summary>
 
-Query: `(100.0 * ( (sum(rate(grpc_server_handled_total{grpc_code!="OK",instance=~`${instance:regex}`,grpc_service=~"symbols.v1.SymbolsService"}[2m]))) / (sum(rate(grpc_server_handled_total{instance=~`${instance:regex}`,grpc_service=~"symbols.v1.SymbolsService"}[2m]))) ))`
+Query:
 
+```
+(100.0 * ( (sum(rate(grpc_server_handled_total{grpc_code!="OK",instance=~`${instance:regex}`,grpc_service=~"symbols.v1.SymbolsService"}[2m]))) / (sum(rate(grpc_server_handled_total{instance=~`${instance:regex}`,grpc_service=~"symbols.v1.SymbolsService"}[2m]))) ))
+```
 </details>
 
 <br />
@@ -18610,8 +21346,11 @@ To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100511` o
 <details>
 <summary>Technical details</summary>
 
-Query: `(100.0 * ( (sum(rate(grpc_server_handled_total{grpc_method=~`${symbols_method:regex}`,grpc_code!="OK",instance=~`${instance:regex}`,grpc_service=~"symbols.v1.SymbolsService"}[2m])) by (grpc_method)) / (sum(rate(grpc_server_handled_total{grpc_method=~`${symbols_method:regex}`,instance=~`${instance:regex}`,grpc_service=~"symbols.v1.SymbolsService"}[2m])) by (grpc_method)) ))`
+Query:
 
+```
+(100.0 * ( (sum(rate(grpc_server_handled_total{grpc_method=~`${symbols_method:regex}`,grpc_code!="OK",instance=~`${instance:regex}`,grpc_service=~"symbols.v1.SymbolsService"}[2m])) by (grpc_method)) / (sum(rate(grpc_server_handled_total{grpc_method=~`${symbols_method:regex}`,instance=~`${instance:regex}`,grpc_service=~"symbols.v1.SymbolsService"}[2m])) by (grpc_method)) ))
+```
 </details>
 
 <br />
@@ -18631,8 +21370,11 @@ To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100520` o
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.99, sum by (le, name, grpc_method)(rate(grpc_server_handling_seconds_bucket{grpc_method=~`${symbols_method:regex}`,instance=~`${instance:regex}`,grpc_service=~"symbols.v1.SymbolsService"}[2m])))`
+Query:
 
+```
+histogram_quantile(0.99, sum by (le, name, grpc_method)(rate(grpc_server_handling_seconds_bucket{grpc_method=~`${symbols_method:regex}`,instance=~`${instance:regex}`,grpc_service=~"symbols.v1.SymbolsService"}[2m])))
+```
 </details>
 
 <br />
@@ -18652,8 +21394,11 @@ To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100521` o
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.90, sum by (le, name, grpc_method)(rate(grpc_server_handling_seconds_bucket{grpc_method=~`${symbols_method:regex}`,instance=~`${instance:regex}`,grpc_service=~"symbols.v1.SymbolsService"}[2m])))`
+Query:
 
+```
+histogram_quantile(0.90, sum by (le, name, grpc_method)(rate(grpc_server_handling_seconds_bucket{grpc_method=~`${symbols_method:regex}`,instance=~`${instance:regex}`,grpc_service=~"symbols.v1.SymbolsService"}[2m])))
+```
 </details>
 
 <br />
@@ -18673,8 +21418,11 @@ To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100522` o
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.75, sum by (le, name, grpc_method)(rate(grpc_server_handling_seconds_bucket{grpc_method=~`${symbols_method:regex}`,instance=~`${instance:regex}`,grpc_service=~"symbols.v1.SymbolsService"}[2m])))`
+Query:
 
+```
+histogram_quantile(0.75, sum by (le, name, grpc_method)(rate(grpc_server_handling_seconds_bucket{grpc_method=~`${symbols_method:regex}`,instance=~`${instance:regex}`,grpc_service=~"symbols.v1.SymbolsService"}[2m])))
+```
 </details>
 
 <br />
@@ -18694,8 +21442,11 @@ To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100530` o
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.999, sum by (le, name, grpc_method)(rate(src_grpc_server_sent_bytes_per_rpc_bucket{grpc_method=~`${symbols_method:regex}`,instance=~`${instance:regex}`,grpc_service=~"symbols.v1.SymbolsService"}[2m])))`
+Query:
 
+```
+histogram_quantile(0.999, sum by (le, name, grpc_method)(rate(src_grpc_server_sent_bytes_per_rpc_bucket{grpc_method=~`${symbols_method:regex}`,instance=~`${instance:regex}`,grpc_service=~"symbols.v1.SymbolsService"}[2m])))
+```
 </details>
 
 <br />
@@ -18715,8 +21466,11 @@ To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100531` o
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.90, sum by (le, name, grpc_method)(rate(src_grpc_server_sent_bytes_per_rpc_bucket{grpc_method=~`${symbols_method:regex}`,instance=~`${instance:regex}`,grpc_service=~"symbols.v1.SymbolsService"}[2m])))`
+Query:
 
+```
+histogram_quantile(0.90, sum by (le, name, grpc_method)(rate(src_grpc_server_sent_bytes_per_rpc_bucket{grpc_method=~`${symbols_method:regex}`,instance=~`${instance:regex}`,grpc_service=~"symbols.v1.SymbolsService"}[2m])))
+```
 </details>
 
 <br />
@@ -18736,8 +21490,11 @@ To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100532` o
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.75, sum by (le, name, grpc_method)(rate(src_grpc_server_sent_bytes_per_rpc_bucket{grpc_method=~`${symbols_method:regex}`,instance=~`${instance:regex}`,grpc_service=~"symbols.v1.SymbolsService"}[2m])))`
+Query:
 
+```
+histogram_quantile(0.75, sum by (le, name, grpc_method)(rate(src_grpc_server_sent_bytes_per_rpc_bucket{grpc_method=~`${symbols_method:regex}`,instance=~`${instance:regex}`,grpc_service=~"symbols.v1.SymbolsService"}[2m])))
+```
 </details>
 
 <br />
@@ -18757,8 +21514,11 @@ To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100540` o
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.999, sum by (le, name, grpc_method)(rate(src_grpc_server_sent_individual_message_size_bytes_per_rpc_bucket{grpc_method=~`${symbols_method:regex}`,instance=~`${instance:regex}`,grpc_service=~"symbols.v1.SymbolsService"}[2m])))`
+Query:
 
+```
+histogram_quantile(0.999, sum by (le, name, grpc_method)(rate(src_grpc_server_sent_individual_message_size_bytes_per_rpc_bucket{grpc_method=~`${symbols_method:regex}`,instance=~`${instance:regex}`,grpc_service=~"symbols.v1.SymbolsService"}[2m])))
+```
 </details>
 
 <br />
@@ -18778,8 +21538,11 @@ To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100541` o
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.90, sum by (le, name, grpc_method)(rate(src_grpc_server_sent_individual_message_size_bytes_per_rpc_bucket{grpc_method=~`${symbols_method:regex}`,instance=~`${instance:regex}`,grpc_service=~"symbols.v1.SymbolsService"}[2m])))`
+Query:
 
+```
+histogram_quantile(0.90, sum by (le, name, grpc_method)(rate(src_grpc_server_sent_individual_message_size_bytes_per_rpc_bucket{grpc_method=~`${symbols_method:regex}`,instance=~`${instance:regex}`,grpc_service=~"symbols.v1.SymbolsService"}[2m])))
+```
 </details>
 
 <br />
@@ -18799,8 +21562,11 @@ To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100542` o
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.75, sum by (le, name, grpc_method)(rate(src_grpc_server_sent_individual_message_size_bytes_per_rpc_bucket{grpc_method=~`${symbols_method:regex}`,instance=~`${instance:regex}`,grpc_service=~"symbols.v1.SymbolsService"}[2m])))`
+Query:
 
+```
+histogram_quantile(0.75, sum by (le, name, grpc_method)(rate(src_grpc_server_sent_individual_message_size_bytes_per_rpc_bucket{grpc_method=~`${symbols_method:regex}`,instance=~`${instance:regex}`,grpc_service=~"symbols.v1.SymbolsService"}[2m])))
+```
 </details>
 
 <br />
@@ -18820,8 +21586,11 @@ To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100550` o
 <details>
 <summary>Technical details</summary>
 
-Query: `((sum(rate(grpc_server_msg_sent_total{grpc_type="server_stream",instance=~`${instance:regex}`,grpc_service=~"symbols.v1.SymbolsService"}[2m])) by (grpc_method))/(sum(rate(grpc_server_started_total{grpc_type="server_stream",instance=~`${instance:regex}`,grpc_service=~"symbols.v1.SymbolsService"}[2m])) by (grpc_method)))`
+Query:
 
+```
+((sum(rate(grpc_server_msg_sent_total{grpc_type="server_stream",instance=~`${instance:regex}`,grpc_service=~"symbols.v1.SymbolsService"}[2m])) by (grpc_method))/(sum(rate(grpc_server_started_total{grpc_type="server_stream",instance=~`${instance:regex}`,grpc_service=~"symbols.v1.SymbolsService"}[2m])) by (grpc_method)))
+```
 </details>
 
 <br />
@@ -18841,8 +21610,11 @@ To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100560` o
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(rate(grpc_server_handled_total{grpc_method=~`${symbols_method:regex}`,instance=~`${instance:regex}`,grpc_service=~"symbols.v1.SymbolsService"}[2m])) by (grpc_method, grpc_code)`
+Query:
 
+```
+sum(rate(grpc_server_handled_total{grpc_method=~`${symbols_method:regex}`,instance=~`${instance:regex}`,grpc_service=~"symbols.v1.SymbolsService"}[2m])) by (grpc_method, grpc_code)
+```
 </details>
 
 <br />
@@ -18864,8 +21636,11 @@ To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100600` o
 <details>
 <summary>Technical details</summary>
 
-Query: `(100.0 * ((((sum(rate(src_grpc_method_status{grpc_service=~"symbols.v1.SymbolsService",grpc_code!="OK"}[2m])))) / ((sum(rate(src_grpc_method_status{grpc_service=~"symbols.v1.SymbolsService"}[2m])))))))`
+Query:
 
+```
+(100.0 * ((((sum(rate(src_grpc_method_status{grpc_service=~"symbols.v1.SymbolsService",grpc_code!="OK"}[2m])))) / ((sum(rate(src_grpc_method_status{grpc_service=~"symbols.v1.SymbolsService"}[2m])))))))
+```
 </details>
 
 <br />
@@ -18885,8 +21660,11 @@ To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100601` o
 <details>
 <summary>Technical details</summary>
 
-Query: `(100.0 * ((((sum(rate(src_grpc_method_status{grpc_service=~"symbols.v1.SymbolsService",grpc_method=~"${symbols_method:regex}",grpc_code!="OK"}[2m])) by (grpc_method))) / ((sum(rate(src_grpc_method_status{grpc_service=~"symbols.v1.SymbolsService",grpc_method=~"${symbols_method:regex}"}[2m])) by (grpc_method))))))`
+Query:
 
+```
+(100.0 * ((((sum(rate(src_grpc_method_status{grpc_service=~"symbols.v1.SymbolsService",grpc_method=~"${symbols_method:regex}",grpc_code!="OK"}[2m])) by (grpc_method))) / ((sum(rate(src_grpc_method_status{grpc_service=~"symbols.v1.SymbolsService",grpc_method=~"${symbols_method:regex}"}[2m])) by (grpc_method))))))
+```
 </details>
 
 <br />
@@ -18906,8 +21684,11 @@ To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100602` o
 <details>
 <summary>Technical details</summary>
 
-Query: `(sum(rate(src_grpc_method_status{grpc_service=~"symbols.v1.SymbolsService",grpc_method=~"${symbols_method:regex}"}[2m])) by (grpc_method, grpc_code))`
+Query:
 
+```
+(sum(rate(src_grpc_method_status{grpc_service=~"symbols.v1.SymbolsService",grpc_method=~"${symbols_method:regex}"}[2m])) by (grpc_method, grpc_code))
+```
 </details>
 
 <br />
@@ -18933,8 +21714,11 @@ To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100610` o
 <details>
 <summary>Technical details</summary>
 
-Query: `(100.0 * ((((sum(rate(src_grpc_method_status{grpc_service=~"symbols.v1.SymbolsService",grpc_code!="OK",is_internal_error="true"}[2m])))) / ((sum(rate(src_grpc_method_status{grpc_service=~"symbols.v1.SymbolsService"}[2m])))))))`
+Query:
 
+```
+(100.0 * ((((sum(rate(src_grpc_method_status{grpc_service=~"symbols.v1.SymbolsService",grpc_code!="OK",is_internal_error="true"}[2m])))) / ((sum(rate(src_grpc_method_status{grpc_service=~"symbols.v1.SymbolsService"}[2m])))))))
+```
 </details>
 
 <br />
@@ -18960,8 +21744,11 @@ To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100611` o
 <details>
 <summary>Technical details</summary>
 
-Query: `(100.0 * ((((sum(rate(src_grpc_method_status{grpc_service=~"symbols.v1.SymbolsService",grpc_method=~"${symbols_method:regex}",grpc_code!="OK",is_internal_error="true"}[2m])) by (grpc_method))) / ((sum(rate(src_grpc_method_status{grpc_service=~"symbols.v1.SymbolsService",grpc_method=~"${symbols_method:regex}"}[2m])) by (grpc_method))))))`
+Query:
 
+```
+(100.0 * ((((sum(rate(src_grpc_method_status{grpc_service=~"symbols.v1.SymbolsService",grpc_method=~"${symbols_method:regex}",grpc_code!="OK",is_internal_error="true"}[2m])) by (grpc_method))) / ((sum(rate(src_grpc_method_status{grpc_service=~"symbols.v1.SymbolsService",grpc_method=~"${symbols_method:regex}"}[2m])) by (grpc_method))))))
+```
 </details>
 
 <br />
@@ -18987,8 +21774,11 @@ To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100612` o
 <details>
 <summary>Technical details</summary>
 
-Query: `(sum(rate(src_grpc_method_status{grpc_service=~"symbols.v1.SymbolsService",is_internal_error="true",grpc_method=~"${symbols_method:regex}"}[2m])) by (grpc_method, grpc_code))`
+Query:
 
+```
+(sum(rate(src_grpc_method_status{grpc_service=~"symbols.v1.SymbolsService",is_internal_error="true",grpc_method=~"${symbols_method:regex}"}[2m])) by (grpc_method, grpc_code))
+```
 </details>
 
 <br />
@@ -19010,8 +21800,11 @@ To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100700` o
 <details>
 <summary>Technical details</summary>
 
-Query: `(100.0 * ((((sum(rate(src_grpc_client_retry_attempts_total{grpc_service=~"symbols.v1.SymbolsService",is_retried="true"}[2m])))) / ((sum(rate(src_grpc_client_retry_attempts_total{grpc_service=~"symbols.v1.SymbolsService"}[2m])))))))`
+Query:
 
+```
+(100.0 * ((((sum(rate(src_grpc_client_retry_attempts_total{grpc_service=~"symbols.v1.SymbolsService",is_retried="true"}[2m])))) / ((sum(rate(src_grpc_client_retry_attempts_total{grpc_service=~"symbols.v1.SymbolsService"}[2m])))))))
+```
 </details>
 
 <br />
@@ -19031,8 +21824,11 @@ To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100701` o
 <details>
 <summary>Technical details</summary>
 
-Query: `(100.0 * ((((sum(rate(src_grpc_client_retry_attempts_total{grpc_service=~"symbols.v1.SymbolsService",is_retried="true",grpc_method=~"${symbols_method:regex}"}[2m])) by (grpc_method))) / ((sum(rate(src_grpc_client_retry_attempts_total{grpc_service=~"symbols.v1.SymbolsService",grpc_method=~"${symbols_method:regex}"}[2m])) by (grpc_method))))))`
+Query:
 
+```
+(100.0 * ((((sum(rate(src_grpc_client_retry_attempts_total{grpc_service=~"symbols.v1.SymbolsService",is_retried="true",grpc_method=~"${symbols_method:regex}"}[2m])) by (grpc_method))) / ((sum(rate(src_grpc_client_retry_attempts_total{grpc_service=~"symbols.v1.SymbolsService",grpc_method=~"${symbols_method:regex}"}[2m])) by (grpc_method))))))
+```
 </details>
 
 <br />
@@ -19052,8 +21848,11 @@ To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100702` o
 <details>
 <summary>Technical details</summary>
 
-Query: `(sum(rate(src_grpc_client_retry_attempts_total{grpc_service=~"symbols.v1.SymbolsService",grpc_method=~"${symbols_method:regex}",is_retried="true"}[2m])) by (grpc_method))`
+Query:
 
+```
+(sum(rate(src_grpc_client_retry_attempts_total{grpc_service=~"symbols.v1.SymbolsService",grpc_method=~"${symbols_method:regex}",is_retried="true"}[2m])) by (grpc_method))
+```
 </details>
 
 <br />
@@ -19075,8 +21874,11 @@ To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100800` o
 <details>
 <summary>Technical details</summary>
 
-Query: `src_conf_client_time_since_last_successful_update_seconds{job=~`.*symbols`,instance=~`${instance:regex}`}`
+Query:
 
+```
+src_conf_client_time_since_last_successful_update_seconds{job=~`.*symbols`,instance=~`${instance:regex}`}
+```
 </details>
 
 <br />
@@ -19094,8 +21896,11 @@ To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100801` o
 <details>
 <summary>Technical details</summary>
 
-Query: `max(max_over_time(src_conf_client_time_since_last_successful_update_seconds{job=~`.*symbols`,instance=~`${instance:regex}`}[1m]))`
+Query:
 
+```
+max(max_over_time(src_conf_client_time_since_last_successful_update_seconds{job=~`.*symbols`,instance=~`${instance:regex}`}[1m]))
+```
 </details>
 
 <br />
@@ -19115,8 +21920,11 @@ To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100900` o
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (app_name, db_name) (src_pgsql_conns_max_open{app_name="symbols"})`
+Query:
 
+```
+sum by (app_name, db_name) (src_pgsql_conns_max_open{app_name="symbols"})
+```
 </details>
 
 <br />
@@ -19134,8 +21942,11 @@ To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100901` o
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (app_name, db_name) (src_pgsql_conns_open{app_name="symbols"})`
+Query:
 
+```
+sum by (app_name, db_name) (src_pgsql_conns_open{app_name="symbols"})
+```
 </details>
 
 <br />
@@ -19153,8 +21964,11 @@ To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100910` o
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (app_name, db_name) (src_pgsql_conns_in_use{app_name="symbols"})`
+Query:
 
+```
+sum by (app_name, db_name) (src_pgsql_conns_in_use{app_name="symbols"})
+```
 </details>
 
 <br />
@@ -19172,8 +21986,11 @@ To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100911` o
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (app_name, db_name) (src_pgsql_conns_idle{app_name="symbols"})`
+Query:
 
+```
+sum by (app_name, db_name) (src_pgsql_conns_idle{app_name="symbols"})
+```
 </details>
 
 <br />
@@ -19191,8 +22008,11 @@ To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100920` o
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (app_name, db_name) (increase(src_pgsql_conns_blocked_seconds{app_name="symbols"}[5m])) / sum by (app_name, db_name) (increase(src_pgsql_conns_waited_for{app_name="symbols"}[5m]))`
+Query:
 
+```
+sum by (app_name, db_name) (increase(src_pgsql_conns_blocked_seconds{app_name="symbols"}[5m])) / sum by (app_name, db_name) (increase(src_pgsql_conns_waited_for{app_name="symbols"}[5m]))
+```
 </details>
 
 <br />
@@ -19210,8 +22030,11 @@ To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100930` o
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (app_name, db_name) (increase(src_pgsql_conns_closed_max_idle{app_name="symbols"}[5m]))`
+Query:
 
+```
+sum by (app_name, db_name) (increase(src_pgsql_conns_closed_max_idle{app_name="symbols"}[5m]))
+```
 </details>
 
 <br />
@@ -19229,8 +22052,11 @@ To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100931` o
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (app_name, db_name) (increase(src_pgsql_conns_closed_max_lifetime{app_name="symbols"}[5m]))`
+Query:
 
+```
+sum by (app_name, db_name) (increase(src_pgsql_conns_closed_max_lifetime{app_name="symbols"}[5m]))
+```
 </details>
 
 <br />
@@ -19248,8 +22074,11 @@ To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100932` o
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (app_name, db_name) (increase(src_pgsql_conns_closed_max_idle_time{app_name="symbols"}[5m]))`
+Query:
 
+```
+sum by (app_name, db_name) (increase(src_pgsql_conns_closed_max_idle_time{app_name="symbols"}[5m]))
+```
 </details>
 
 <br />
@@ -19279,8 +22108,11 @@ To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=101000` o
 <details>
 <summary>Technical details</summary>
 
-Query: `count by(name) ((time() - container_last_seen{name=~"^symbols.*"}) > 60)`
+Query:
 
+```
+count by(name) ((time() - container_last_seen{name=~"^symbols.*"}) > 60)
+```
 </details>
 
 <br />
@@ -19298,8 +22130,11 @@ To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=101001` o
 <details>
 <summary>Technical details</summary>
 
-Query: `cadvisor_container_cpu_usage_percentage_total{name=~"^symbols.*"}`
+Query:
 
+```
+cadvisor_container_cpu_usage_percentage_total{name=~"^symbols.*"}
+```
 </details>
 
 <br />
@@ -19317,8 +22152,11 @@ To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=101002` o
 <details>
 <summary>Technical details</summary>
 
-Query: `cadvisor_container_memory_usage_percentage_total{name=~"^symbols.*"}`
+Query:
 
+```
+cadvisor_container_memory_usage_percentage_total{name=~"^symbols.*"}
+```
 </details>
 
 <br />
@@ -19339,8 +22177,11 @@ To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=101003` o
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by(name) (rate(container_fs_reads_total{name=~"^symbols.*"}[1h]) + rate(container_fs_writes_total{name=~"^symbols.*"}[1h]))`
+Query:
 
+```
+sum by(name) (rate(container_fs_reads_total{name=~"^symbols.*"}[1h]) + rate(container_fs_writes_total{name=~"^symbols.*"}[1h]))
+```
 </details>
 
 <br />
@@ -19360,8 +22201,11 @@ To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=101100` o
 <details>
 <summary>Technical details</summary>
 
-Query: `quantile_over_time(0.9, cadvisor_container_cpu_usage_percentage_total{name=~"^symbols.*"}[1d])`
+Query:
 
+```
+quantile_over_time(0.9, cadvisor_container_cpu_usage_percentage_total{name=~"^symbols.*"}[1d])
+```
 </details>
 
 <br />
@@ -19379,8 +22223,11 @@ To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=101101` o
 <details>
 <summary>Technical details</summary>
 
-Query: `max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^symbols.*"}[1d])`
+Query:
 
+```
+max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^symbols.*"}[1d])
+```
 </details>
 
 <br />
@@ -19398,8 +22245,11 @@ To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=101110` o
 <details>
 <summary>Technical details</summary>
 
-Query: `max_over_time(cadvisor_container_cpu_usage_percentage_total{name=~"^symbols.*"}[5m])`
+Query:
 
+```
+max_over_time(cadvisor_container_cpu_usage_percentage_total{name=~"^symbols.*"}[5m])
+```
 </details>
 
 <br />
@@ -19417,8 +22267,11 @@ To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=101111` o
 <details>
 <summary>Technical details</summary>
 
-Query: `max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^symbols.*"}[5m])`
+Query:
 
+```
+max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^symbols.*"}[5m])
+```
 </details>
 
 <br />
@@ -19439,8 +22292,11 @@ To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=101112` o
 <details>
 <summary>Technical details</summary>
 
-Query: `max by (name) (container_oom_events_total{name=~"^symbols.*"})`
+Query:
 
+```
+max by (name) (container_oom_events_total{name=~"^symbols.*"})
+```
 </details>
 
 <br />
@@ -19462,8 +22318,11 @@ To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=101200` o
 <details>
 <summary>Technical details</summary>
 
-Query: `max by(instance) (go_goroutines{job=~".*symbols"})`
+Query:
 
+```
+max by(instance) (go_goroutines{job=~".*symbols"})
+```
 </details>
 
 <br />
@@ -19481,8 +22340,11 @@ To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=101201` o
 <details>
 <summary>Technical details</summary>
 
-Query: `max by(instance) (go_gc_duration_seconds{job=~".*symbols"})`
+Query:
 
+```
+max by(instance) (go_gc_duration_seconds{job=~".*symbols"})
+```
 </details>
 
 <br />
@@ -19502,8 +22364,11 @@ To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=101300` o
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by(app) (up{app=~".*symbols"}) / count by (app) (up{app=~".*symbols"}) * 100`
+Query:
 
+```
+sum by(app) (up{app=~".*symbols"}) / count by (app) (up{app=~".*symbols"}) * 100
+```
 </details>
 
 <br />
@@ -19527,8 +22392,11 @@ To see this panel, visit `/-/debug/grafana/d/syntect-server/syntect-server?viewP
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_syntax_highlighting_requests{status="error"}[5m])) / sum(increase(src_syntax_highlighting_requests[5m])) * 100`
+Query:
 
+```
+sum(increase(src_syntax_highlighting_requests{status="error"}[5m])) / sum(increase(src_syntax_highlighting_requests[5m])) * 100
+```
 </details>
 
 <br />
@@ -19546,8 +22414,11 @@ To see this panel, visit `/-/debug/grafana/d/syntect-server/syntect-server?viewP
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_syntax_highlighting_requests{status="timeout"}[5m])) / sum(increase(src_syntax_highlighting_requests[5m])) * 100`
+Query:
 
+```
+sum(increase(src_syntax_highlighting_requests{status="timeout"}[5m])) / sum(increase(src_syntax_highlighting_requests[5m])) * 100
+```
 </details>
 
 <br />
@@ -19565,8 +22436,11 @@ To see this panel, visit `/-/debug/grafana/d/syntect-server/syntect-server?viewP
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_syntax_highlighting_requests{status="panic"}[5m]))`
+Query:
 
+```
+sum(increase(src_syntax_highlighting_requests{status="panic"}[5m]))
+```
 </details>
 
 <br />
@@ -19584,8 +22458,11 @@ To see this panel, visit `/-/debug/grafana/d/syntect-server/syntect-server?viewP
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_syntax_highlighting_requests{status="hss_worker_timeout"}[5m]))`
+Query:
 
+```
+sum(increase(src_syntax_highlighting_requests{status="hss_worker_timeout"}[5m]))
+```
 </details>
 
 <br />
@@ -19615,8 +22492,11 @@ To see this panel, visit `/-/debug/grafana/d/syntect-server/syntect-server?viewP
 <details>
 <summary>Technical details</summary>
 
-Query: `count by(name) ((time() - container_last_seen{name=~"^syntect-server.*"}) > 60)`
+Query:
 
+```
+count by(name) ((time() - container_last_seen{name=~"^syntect-server.*"}) > 60)
+```
 </details>
 
 <br />
@@ -19634,8 +22514,11 @@ To see this panel, visit `/-/debug/grafana/d/syntect-server/syntect-server?viewP
 <details>
 <summary>Technical details</summary>
 
-Query: `cadvisor_container_cpu_usage_percentage_total{name=~"^syntect-server.*"}`
+Query:
 
+```
+cadvisor_container_cpu_usage_percentage_total{name=~"^syntect-server.*"}
+```
 </details>
 
 <br />
@@ -19653,8 +22536,11 @@ To see this panel, visit `/-/debug/grafana/d/syntect-server/syntect-server?viewP
 <details>
 <summary>Technical details</summary>
 
-Query: `cadvisor_container_memory_usage_percentage_total{name=~"^syntect-server.*"}`
+Query:
 
+```
+cadvisor_container_memory_usage_percentage_total{name=~"^syntect-server.*"}
+```
 </details>
 
 <br />
@@ -19675,8 +22561,11 @@ To see this panel, visit `/-/debug/grafana/d/syntect-server/syntect-server?viewP
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by(name) (rate(container_fs_reads_total{name=~"^syntect-server.*"}[1h]) + rate(container_fs_writes_total{name=~"^syntect-server.*"}[1h]))`
+Query:
 
+```
+sum by(name) (rate(container_fs_reads_total{name=~"^syntect-server.*"}[1h]) + rate(container_fs_writes_total{name=~"^syntect-server.*"}[1h]))
+```
 </details>
 
 <br />
@@ -19696,8 +22585,11 @@ To see this panel, visit `/-/debug/grafana/d/syntect-server/syntect-server?viewP
 <details>
 <summary>Technical details</summary>
 
-Query: `quantile_over_time(0.9, cadvisor_container_cpu_usage_percentage_total{name=~"^syntect-server.*"}[1d])`
+Query:
 
+```
+quantile_over_time(0.9, cadvisor_container_cpu_usage_percentage_total{name=~"^syntect-server.*"}[1d])
+```
 </details>
 
 <br />
@@ -19715,8 +22607,11 @@ To see this panel, visit `/-/debug/grafana/d/syntect-server/syntect-server?viewP
 <details>
 <summary>Technical details</summary>
 
-Query: `max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^syntect-server.*"}[1d])`
+Query:
 
+```
+max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^syntect-server.*"}[1d])
+```
 </details>
 
 <br />
@@ -19734,8 +22629,11 @@ To see this panel, visit `/-/debug/grafana/d/syntect-server/syntect-server?viewP
 <details>
 <summary>Technical details</summary>
 
-Query: `max_over_time(cadvisor_container_cpu_usage_percentage_total{name=~"^syntect-server.*"}[5m])`
+Query:
 
+```
+max_over_time(cadvisor_container_cpu_usage_percentage_total{name=~"^syntect-server.*"}[5m])
+```
 </details>
 
 <br />
@@ -19753,8 +22651,11 @@ To see this panel, visit `/-/debug/grafana/d/syntect-server/syntect-server?viewP
 <details>
 <summary>Technical details</summary>
 
-Query: `max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^syntect-server.*"}[5m])`
+Query:
 
+```
+max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^syntect-server.*"}[5m])
+```
 </details>
 
 <br />
@@ -19775,8 +22676,11 @@ To see this panel, visit `/-/debug/grafana/d/syntect-server/syntect-server?viewP
 <details>
 <summary>Technical details</summary>
 
-Query: `max by (name) (container_oom_events_total{name=~"^syntect-server.*"})`
+Query:
 
+```
+max by (name) (container_oom_events_total{name=~"^syntect-server.*"})
+```
 </details>
 
 <br />
@@ -19796,8 +22700,11 @@ To see this panel, visit `/-/debug/grafana/d/syntect-server/syntect-server?viewP
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by(app) (up{app=~".*syntect-server"}) / count by (app) (up{app=~".*syntect-server"}) * 100`
+Query:
 
+```
+sum by(app) (up{app=~".*syntect-server"}) / count by (app) (up{app=~".*syntect-server"}) * 100
+```
 </details>
 
 <br />
@@ -19830,8 +22737,11 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100000` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (__name__) ({__name__=~"index_num_assigned|index_num_indexed|index_queue_cap"})`
+Query:
 
+```
+sum by (__name__) ({__name__=~"index_num_assigned|index_num_indexed|index_queue_cap"})
+```
 </details>
 
 <br />
@@ -19858,8 +22768,11 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100001` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (__name__, instance) ({__name__=~"index_num_assigned|index_num_indexed|index_queue_cap",instance=~"${instance:regex}"})`
+Query:
 
+```
+sum by (__name__, instance) ({__name__=~"index_num_assigned|index_num_indexed|index_queue_cap",instance=~"${instance:regex}"})
+```
 </details>
 
 <br />
@@ -19879,8 +22792,11 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100010` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(index_num_stopped_tracking_total[5m]))`
+Query:
 
+```
+sum(increase(index_num_stopped_tracking_total[5m]))
+```
 </details>
 
 <br />
@@ -19900,8 +22816,11 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100011` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (instance) (increase(index_num_stopped_tracking_total{instance=~`${instance:regex}`}[5m]))`
+Query:
 
+```
+sum by (instance) (increase(index_num_stopped_tracking_total{instance=~`${instance:regex}`}[5m]))
+```
 </details>
 
 <br />
@@ -19919,8 +22838,11 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100020` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(rate(resolve_revision_seconds_sum[5m])) / sum(rate(resolve_revision_seconds_count[5m]))`
+Query:
 
+```
+sum(rate(resolve_revision_seconds_sum[5m])) / sum(rate(resolve_revision_seconds_count[5m]))
+```
 </details>
 
 <br />
@@ -19946,8 +22868,11 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100021` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(get_index_options_error_total[5m]))`
+Query:
 
+```
+sum(increase(get_index_options_error_total[5m]))
+```
 </details>
 
 <br />
@@ -19971,8 +22896,11 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100100` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.99, sum by (le, name)(rate(zoekt_search_duration_seconds_bucket[1m])))`
+Query:
 
+```
+histogram_quantile(0.99, sum by (le, name)(rate(zoekt_search_duration_seconds_bucket[1m])))
+```
 </details>
 
 <br />
@@ -19994,8 +22922,11 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100101` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.90, sum by (le, name)(rate(zoekt_search_duration_seconds_bucket[1m])))`
+Query:
 
+```
+histogram_quantile(0.90, sum by (le, name)(rate(zoekt_search_duration_seconds_bucket[1m])))
+```
 </details>
 
 <br />
@@ -20017,8 +22948,11 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100102` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.75, sum by (le, name)(rate(zoekt_search_duration_seconds_bucket[1m])))`
+Query:
 
+```
+histogram_quantile(0.75, sum by (le, name)(rate(zoekt_search_duration_seconds_bucket[1m])))
+```
 </details>
 
 <br />
@@ -20040,8 +22974,11 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100110` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.99, sum by (le, instance)(rate(zoekt_search_duration_seconds_bucket{instance=~`${instance:regex}`}[1m])))`
+Query:
 
+```
+histogram_quantile(0.99, sum by (le, instance)(rate(zoekt_search_duration_seconds_bucket{instance=~`${instance:regex}`}[1m])))
+```
 </details>
 
 <br />
@@ -20063,8 +23000,11 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100111` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.90, sum by (le, instance)(rate(zoekt_search_duration_seconds_bucket{instance=~`${instance:regex}`}[1m])))`
+Query:
 
+```
+histogram_quantile(0.90, sum by (le, instance)(rate(zoekt_search_duration_seconds_bucket{instance=~`${instance:regex}`}[1m])))
+```
 </details>
 
 <br />
@@ -20086,8 +23026,11 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100112` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.75, sum by (le, instance)(rate(zoekt_search_duration_seconds_bucket{instance=~`${instance:regex}`}[1m])))`
+Query:
 
+```
+histogram_quantile(0.75, sum by (le, instance)(rate(zoekt_search_duration_seconds_bucket{instance=~`${instance:regex}`}[1m])))
+```
 </details>
 
 <br />
@@ -20111,8 +23054,11 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100120` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (name) (zoekt_search_running)`
+Query:
 
+```
+sum by (name) (zoekt_search_running)
+```
 </details>
 
 <br />
@@ -20136,8 +23082,11 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100121` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (instance, name) (zoekt_search_running{instance=~`${instance:regex}`})`
+Query:
 
+```
+sum by (instance, name) (zoekt_search_running{instance=~`${instance:regex}`})
+```
 </details>
 
 <br />
@@ -20163,8 +23112,11 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100130` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (name) (deriv(zoekt_search_running[1m]))`
+Query:
 
+```
+sum by (name) (deriv(zoekt_search_running[1m]))
+```
 </details>
 
 <br />
@@ -20190,8 +23142,11 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100131` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (instance) (deriv(zoekt_search_running[1m]))`
+Query:
 
+```
+sum by (instance) (deriv(zoekt_search_running[1m]))
+```
 </details>
 
 <br />
@@ -20209,8 +23164,11 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100140` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (code)(increase(src_zoekt_request_duration_seconds_count{code!~"2.."}[5m])) / ignoring(code) group_left sum(increase(src_zoekt_request_duration_seconds_count[5m])) * 100`
+Query:
 
+```
+sum by (code)(increase(src_zoekt_request_duration_seconds_count{code!~"2.."}[5m])) / ignoring(code) group_left sum(increase(src_zoekt_request_duration_seconds_count[5m])) * 100
+```
 </details>
 
 <br />
@@ -20237,8 +23195,11 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100150` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (type, state) (zoekt_shards_sched)`
+Query:
 
+```
+sum by (type, state) (zoekt_shards_sched)
+```
 </details>
 
 <br />
@@ -20265,8 +23226,11 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100151` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (type, state) (rate(zoekt_shards_sched[5m]))`
+Query:
 
+```
+sum by (type, state) (rate(zoekt_shards_sched[5m]))
+```
 </details>
 
 <br />
@@ -20288,8 +23252,11 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100200` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.90, sum by (le, name)(rate(index_fetch_seconds_bucket{success="true"}[5m])))`
+Query:
 
+```
+histogram_quantile(0.90, sum by (le, name)(rate(index_fetch_seconds_bucket{success="true"}[5m])))
+```
 </details>
 
 <br />
@@ -20309,8 +23276,11 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100201` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.90, sum by (le, name)(rate(index_fetch_seconds_bucket{success="false"}[5m])))`
+Query:
 
+```
+histogram_quantile(0.90, sum by (le, name)(rate(index_fetch_seconds_bucket{success="false"}[5m])))
+```
 </details>
 
 <br />
@@ -20341,8 +23311,11 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100300` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (state) (increase(index_repo_seconds_count[5m]))`
+Query:
 
+```
+sum by (state) (increase(index_repo_seconds_count[5m]))
+```
 </details>
 
 <br />
@@ -20373,8 +23346,11 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100301` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (instance, state) (increase(index_repo_seconds_count{instance=~`${instance:regex}`}[5m]))`
+Query:
 
+```
+sum by (instance, state) (increase(index_repo_seconds_count{instance=~`${instance:regex}`}[5m]))
+```
 </details>
 
 <br />
@@ -20394,8 +23370,11 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100310` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (le, state) (increase(index_repo_seconds_bucket{state="success"}[$__rate_interval]))`
+Query:
 
+```
+sum by (le, state) (increase(index_repo_seconds_bucket{state="success"}[$__rate_interval]))
+```
 </details>
 
 <br />
@@ -20415,8 +23394,11 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100311` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (le, state) (increase(index_repo_seconds_bucket{state="fail"}[$__rate_interval]))`
+Query:
 
+```
+sum by (le, state) (increase(index_repo_seconds_bucket{state="fail"}[$__rate_interval]))
+```
 </details>
 
 <br />
@@ -20438,8 +23420,11 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100320` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.99, sum by (le, name)(rate(index_repo_seconds_bucket{state="success"}[5m])))`
+Query:
 
+```
+histogram_quantile(0.99, sum by (le, name)(rate(index_repo_seconds_bucket{state="success"}[5m])))
+```
 </details>
 
 <br />
@@ -20461,8 +23446,11 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100321` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.90, sum by (le, name)(rate(index_repo_seconds_bucket{state="success"}[5m])))`
+Query:
 
+```
+histogram_quantile(0.90, sum by (le, name)(rate(index_repo_seconds_bucket{state="success"}[5m])))
+```
 </details>
 
 <br />
@@ -20484,8 +23472,11 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100322` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.75, sum by (le, name)(rate(index_repo_seconds_bucket{state="success"}[5m])))`
+Query:
 
+```
+histogram_quantile(0.75, sum by (le, name)(rate(index_repo_seconds_bucket{state="success"}[5m])))
+```
 </details>
 
 <br />
@@ -20507,8 +23498,11 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100330` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.99, sum by (le, instance)(rate(index_repo_seconds_bucket{state="success",instance=~`${instance:regex}`}[5m])))`
+Query:
 
+```
+histogram_quantile(0.99, sum by (le, instance)(rate(index_repo_seconds_bucket{state="success",instance=~`${instance:regex}`}[5m])))
+```
 </details>
 
 <br />
@@ -20530,8 +23524,11 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100331` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.90, sum by (le, instance)(rate(index_repo_seconds_bucket{state="success",instance=~`${instance:regex}`}[5m])))`
+Query:
 
+```
+histogram_quantile(0.90, sum by (le, instance)(rate(index_repo_seconds_bucket{state="success",instance=~`${instance:regex}`}[5m])))
+```
 </details>
 
 <br />
@@ -20553,8 +23550,11 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100332` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.75, sum by (le, instance)(rate(index_repo_seconds_bucket{state="success",instance=~`${instance:regex}`}[5m])))`
+Query:
 
+```
+histogram_quantile(0.75, sum by (le, instance)(rate(index_repo_seconds_bucket{state="success",instance=~`${instance:regex}`}[5m])))
+```
 </details>
 
 <br />
@@ -20576,8 +23576,11 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100340` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.99, sum by (le, name)(rate(index_repo_seconds_bucket{state="fail"}[5m])))`
+Query:
 
+```
+histogram_quantile(0.99, sum by (le, name)(rate(index_repo_seconds_bucket{state="fail"}[5m])))
+```
 </details>
 
 <br />
@@ -20599,8 +23602,11 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100341` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.90, sum by (le, name)(rate(index_repo_seconds_bucket{state="fail"}[5m])))`
+Query:
 
+```
+histogram_quantile(0.90, sum by (le, name)(rate(index_repo_seconds_bucket{state="fail"}[5m])))
+```
 </details>
 
 <br />
@@ -20622,8 +23628,11 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100342` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.75, sum by (le, name)(rate(index_repo_seconds_bucket{state="fail"}[5m])))`
+Query:
 
+```
+histogram_quantile(0.75, sum by (le, name)(rate(index_repo_seconds_bucket{state="fail"}[5m])))
+```
 </details>
 
 <br />
@@ -20645,8 +23654,11 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100350` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.99, sum by (le, instance)(rate(index_repo_seconds_bucket{state="fail",instance=~`${instance:regex}`}[5m])))`
+Query:
 
+```
+histogram_quantile(0.99, sum by (le, instance)(rate(index_repo_seconds_bucket{state="fail",instance=~`${instance:regex}`}[5m])))
+```
 </details>
 
 <br />
@@ -20668,8 +23680,11 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100351` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.90, sum by (le, instance)(rate(index_repo_seconds_bucket{state="fail",instance=~`${instance:regex}`}[5m])))`
+Query:
 
+```
+histogram_quantile(0.90, sum by (le, instance)(rate(index_repo_seconds_bucket{state="fail",instance=~`${instance:regex}`}[5m])))
+```
 </details>
 
 <br />
@@ -20691,8 +23706,11 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100352` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.75, sum by (le, instance)(rate(index_repo_seconds_bucket{state="fail",instance=~`${instance:regex}`}[5m])))`
+Query:
 
+```
+histogram_quantile(0.75, sum by (le, instance)(rate(index_repo_seconds_bucket{state="fail",instance=~`${instance:regex}`}[5m])))
+```
 </details>
 
 <br />
@@ -20714,8 +23732,11 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100400` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(index_queue_len)`
+Query:
 
+```
+sum(index_queue_len)
+```
 </details>
 
 <br />
@@ -20735,8 +23756,11 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100401` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `index_queue_len{instance=~`${instance:regex}`}`
+Query:
 
+```
+index_queue_len{instance=~`${instance:regex}`}
+```
 </details>
 
 <br />
@@ -20760,8 +23784,11 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100410` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (le) (increase(index_queue_age_seconds_bucket[$__rate_interval]))`
+Query:
 
+```
+sum by (le) (increase(index_queue_age_seconds_bucket[$__rate_interval]))
+```
 </details>
 
 <br />
@@ -20789,8 +23816,11 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100420` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.999, sum by (le, name)(rate(index_queue_age_seconds_bucket[5m])))`
+Query:
 
+```
+histogram_quantile(0.999, sum by (le, name)(rate(index_queue_age_seconds_bucket[5m])))
+```
 </details>
 
 <br />
@@ -20816,8 +23846,11 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100421` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.90, sum by (le, name)(rate(index_queue_age_seconds_bucket[5m])))`
+Query:
 
+```
+histogram_quantile(0.90, sum by (le, name)(rate(index_queue_age_seconds_bucket[5m])))
+```
 </details>
 
 <br />
@@ -20843,8 +23876,11 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100422` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.75, sum by (le, name)(rate(index_queue_age_seconds_bucket[5m])))`
+Query:
 
+```
+histogram_quantile(0.75, sum by (le, name)(rate(index_queue_age_seconds_bucket[5m])))
+```
 </details>
 
 <br />
@@ -20872,8 +23908,11 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100430` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.999, sum by (le, instance)(rate(index_queue_age_seconds_bucket{instance=~`${instance:regex}`}[5m])))`
+Query:
 
+```
+histogram_quantile(0.999, sum by (le, instance)(rate(index_queue_age_seconds_bucket{instance=~`${instance:regex}`}[5m])))
+```
 </details>
 
 <br />
@@ -20899,8 +23938,11 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100431` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.90, sum by (le, instance)(rate(index_queue_age_seconds_bucket{instance=~`${instance:regex}`}[5m])))`
+Query:
 
+```
+histogram_quantile(0.90, sum by (le, instance)(rate(index_queue_age_seconds_bucket{instance=~`${instance:regex}`}[5m])))
+```
 </details>
 
 <br />
@@ -20926,8 +23968,11 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100432` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.75, sum by (le, instance)(rate(index_queue_age_seconds_bucket{instance=~`${instance:regex}`}[5m])))`
+Query:
 
+```
+histogram_quantile(0.75, sum by (le, instance)(rate(index_queue_age_seconds_bucket{instance=~`${instance:regex}`}[5m])))
+```
 </details>
 
 <br />
@@ -20956,8 +24001,11 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100500` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `(proc_metrics_memory_map_current_count{instance=~`${instance:regex}`} / proc_metrics_memory_map_max_limit{instance=~`${instance:regex}`}) * 100`
+Query:
 
+```
+(proc_metrics_memory_map_current_count{instance=~`${instance:regex}`} / proc_metrics_memory_map_max_limit{instance=~`${instance:regex}`}) * 100
+```
 </details>
 
 <br />
@@ -20981,8 +24029,11 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100600` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(index_number_compound_shards) by (app)`
+Query:
 
+```
+sum(index_number_compound_shards) by (app)
+```
 </details>
 
 <br />
@@ -21004,8 +24055,11 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100601` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(index_number_compound_shards{instance=~`${instance:regex}`}) by (instance)`
+Query:
 
+```
+sum(index_number_compound_shards{instance=~`${instance:regex}`}) by (instance)
+```
 </details>
 
 <br />
@@ -21028,8 +24082,11 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100610` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(rate(index_shard_merging_duration_seconds_sum{error="false"}[1h])) / sum(rate(index_shard_merging_duration_seconds_count{error="false"}[1h]))`
+Query:
 
+```
+sum(rate(index_shard_merging_duration_seconds_sum{error="false"}[1h])) / sum(rate(index_shard_merging_duration_seconds_count{error="false"}[1h]))
+```
 </details>
 
 <br />
@@ -21051,8 +24108,11 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100611` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(rate(index_shard_merging_duration_seconds_sum{error="true"}[1h])) / sum(rate(index_shard_merging_duration_seconds_count{error="true"}[1h]))`
+Query:
 
+```
+sum(rate(index_shard_merging_duration_seconds_sum{error="true"}[1h])) / sum(rate(index_shard_merging_duration_seconds_count{error="true"}[1h]))
+```
 </details>
 
 <br />
@@ -21072,8 +24132,11 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100620` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(index_shard_merging_duration_seconds_count{error="true"}) by (app)`
+Query:
 
+```
+sum(index_shard_merging_duration_seconds_count{error="true"}) by (app)
+```
 </details>
 
 <br />
@@ -21093,8 +24156,11 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100621` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(index_shard_merging_duration_seconds_count{instance=~`${instance:regex}`, error="true"}) by (instance)`
+Query:
 
+```
+sum(index_shard_merging_duration_seconds_count{instance=~`${instance:regex}`, error="true"}) by (instance)
+```
 </details>
 
 <br />
@@ -21114,8 +24180,11 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100630` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `max by (instance) (index_shard_merging_running{instance=~`${instance:regex}`})`
+Query:
 
+```
+max by (instance) (index_shard_merging_running{instance=~`${instance:regex}`})
+```
 </details>
 
 <br />
@@ -21135,8 +24204,11 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100631` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `max by (instance) (index_vacuum_running{instance=~`${instance:regex}`})`
+Query:
 
+```
+max by (instance) (index_vacuum_running{instance=~`${instance:regex}`})
+```
 </details>
 
 <br />
@@ -21158,8 +24230,11 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100700` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(rate(container_network_transmit_bytes_total{container_label_io_kubernetes_pod_name=~`.*indexed-search.*`}[5m]))`
+Query:
 
+```
+sum(rate(container_network_transmit_bytes_total{container_label_io_kubernetes_pod_name=~`.*indexed-search.*`}[5m]))
+```
 </details>
 
 <br />
@@ -21179,8 +24254,11 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100701` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (container_label_io_kubernetes_pod_name) (rate(container_network_transmit_bytes_total{container_label_io_kubernetes_pod_name=~`${instance:regex}`}[5m]))`
+Query:
 
+```
+sum by (container_label_io_kubernetes_pod_name) (rate(container_network_transmit_bytes_total{container_label_io_kubernetes_pod_name=~`${instance:regex}`}[5m]))
+```
 </details>
 
 <br />
@@ -21200,8 +24278,11 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100710` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(rate(container_network_receive_bytes_total{container_label_io_kubernetes_pod_name=~`.*indexed-search.*`}[5m]))`
+Query:
 
+```
+sum(rate(container_network_receive_bytes_total{container_label_io_kubernetes_pod_name=~`.*indexed-search.*`}[5m]))
+```
 </details>
 
 <br />
@@ -21221,8 +24302,11 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100711` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (container_label_io_kubernetes_pod_name) (rate(container_network_receive_bytes_total{container_label_io_kubernetes_pod_name=~`${instance:regex}`}[5m]))`
+Query:
 
+```
+sum by (container_label_io_kubernetes_pod_name) (rate(container_network_receive_bytes_total{container_label_io_kubernetes_pod_name=~`${instance:regex}`}[5m]))
+```
 </details>
 
 <br />
@@ -21242,8 +24326,11 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100720` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (container_label_io_kubernetes_pod_name) (rate(container_network_transmit_packets_dropped_total{container_label_io_kubernetes_pod_name=~`${instance:regex}`}[5m]))`
+Query:
 
+```
+sum by (container_label_io_kubernetes_pod_name) (rate(container_network_transmit_packets_dropped_total{container_label_io_kubernetes_pod_name=~`${instance:regex}`}[5m]))
+```
 </details>
 
 <br />
@@ -21263,8 +24350,11 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100721` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (container_label_io_kubernetes_pod_name) (rate(container_network_transmit_errors_total{container_label_io_kubernetes_pod_name=~`${instance:regex}`}[5m]))`
+Query:
 
+```
+sum by (container_label_io_kubernetes_pod_name) (rate(container_network_transmit_errors_total{container_label_io_kubernetes_pod_name=~`${instance:regex}`}[5m]))
+```
 </details>
 
 <br />
@@ -21284,8 +24374,11 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100722` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (container_label_io_kubernetes_pod_name) (rate(container_network_receive_packets_dropped_total{container_label_io_kubernetes_pod_name=~`${instance:regex}`}[5m]))`
+Query:
 
+```
+sum by (container_label_io_kubernetes_pod_name) (rate(container_network_receive_packets_dropped_total{container_label_io_kubernetes_pod_name=~`${instance:regex}`}[5m]))
+```
 </details>
 
 <br />
@@ -21305,8 +24398,11 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100723` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (container_label_io_kubernetes_pod_name) (rate(container_network_receive_errors_total{container_label_io_kubernetes_pod_name=~`${instance:regex}`}[5m]))`
+Query:
 
+```
+sum by (container_label_io_kubernetes_pod_name) (rate(container_network_receive_errors_total{container_label_io_kubernetes_pod_name=~`${instance:regex}`}[5m]))
+```
 </details>
 
 <br />
@@ -21328,8 +24424,11 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100800` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(rate(grpc_server_started_total{instance=~`${webserver_instance:regex}`,grpc_service=~"zoekt.webserver.v1.WebserverService"}[2m]))`
+Query:
 
+```
+sum(rate(grpc_server_started_total{instance=~`${webserver_instance:regex}`,grpc_service=~"zoekt.webserver.v1.WebserverService"}[2m]))
+```
 </details>
 
 <br />
@@ -21349,8 +24448,11 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100801` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(rate(grpc_server_started_total{grpc_method=~`${zoekt_webserver_method:regex}`,instance=~`${webserver_instance:regex}`,grpc_service=~"zoekt.webserver.v1.WebserverService"}[2m])) by (grpc_method)`
+Query:
 
+```
+sum(rate(grpc_server_started_total{grpc_method=~`${zoekt_webserver_method:regex}`,instance=~`${webserver_instance:regex}`,grpc_service=~"zoekt.webserver.v1.WebserverService"}[2m])) by (grpc_method)
+```
 </details>
 
 <br />
@@ -21370,8 +24472,11 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100810` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `(100.0 * ( (sum(rate(grpc_server_handled_total{grpc_code!="OK",instance=~`${webserver_instance:regex}`,grpc_service=~"zoekt.webserver.v1.WebserverService"}[2m]))) / (sum(rate(grpc_server_handled_total{instance=~`${webserver_instance:regex}`,grpc_service=~"zoekt.webserver.v1.WebserverService"}[2m]))) ))`
+Query:
 
+```
+(100.0 * ( (sum(rate(grpc_server_handled_total{grpc_code!="OK",instance=~`${webserver_instance:regex}`,grpc_service=~"zoekt.webserver.v1.WebserverService"}[2m]))) / (sum(rate(grpc_server_handled_total{instance=~`${webserver_instance:regex}`,grpc_service=~"zoekt.webserver.v1.WebserverService"}[2m]))) ))
+```
 </details>
 
 <br />
@@ -21391,8 +24496,11 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100811` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `(100.0 * ( (sum(rate(grpc_server_handled_total{grpc_method=~`${zoekt_webserver_method:regex}`,grpc_code!="OK",instance=~`${webserver_instance:regex}`,grpc_service=~"zoekt.webserver.v1.WebserverService"}[2m])) by (grpc_method)) / (sum(rate(grpc_server_handled_total{grpc_method=~`${zoekt_webserver_method:regex}`,instance=~`${webserver_instance:regex}`,grpc_service=~"zoekt.webserver.v1.WebserverService"}[2m])) by (grpc_method)) ))`
+Query:
 
+```
+(100.0 * ( (sum(rate(grpc_server_handled_total{grpc_method=~`${zoekt_webserver_method:regex}`,grpc_code!="OK",instance=~`${webserver_instance:regex}`,grpc_service=~"zoekt.webserver.v1.WebserverService"}[2m])) by (grpc_method)) / (sum(rate(grpc_server_handled_total{grpc_method=~`${zoekt_webserver_method:regex}`,instance=~`${webserver_instance:regex}`,grpc_service=~"zoekt.webserver.v1.WebserverService"}[2m])) by (grpc_method)) ))
+```
 </details>
 
 <br />
@@ -21412,8 +24520,11 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100820` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.99, sum by (le, name, grpc_method)(rate(grpc_server_handling_seconds_bucket{grpc_method=~`${zoekt_webserver_method:regex}`,instance=~`${webserver_instance:regex}`,grpc_service=~"zoekt.webserver.v1.WebserverService"}[2m])))`
+Query:
 
+```
+histogram_quantile(0.99, sum by (le, name, grpc_method)(rate(grpc_server_handling_seconds_bucket{grpc_method=~`${zoekt_webserver_method:regex}`,instance=~`${webserver_instance:regex}`,grpc_service=~"zoekt.webserver.v1.WebserverService"}[2m])))
+```
 </details>
 
 <br />
@@ -21433,8 +24544,11 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100821` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.90, sum by (le, name, grpc_method)(rate(grpc_server_handling_seconds_bucket{grpc_method=~`${zoekt_webserver_method:regex}`,instance=~`${webserver_instance:regex}`,grpc_service=~"zoekt.webserver.v1.WebserverService"}[2m])))`
+Query:
 
+```
+histogram_quantile(0.90, sum by (le, name, grpc_method)(rate(grpc_server_handling_seconds_bucket{grpc_method=~`${zoekt_webserver_method:regex}`,instance=~`${webserver_instance:regex}`,grpc_service=~"zoekt.webserver.v1.WebserverService"}[2m])))
+```
 </details>
 
 <br />
@@ -21454,8 +24568,11 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100822` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.75, sum by (le, name, grpc_method)(rate(grpc_server_handling_seconds_bucket{grpc_method=~`${zoekt_webserver_method:regex}`,instance=~`${webserver_instance:regex}`,grpc_service=~"zoekt.webserver.v1.WebserverService"}[2m])))`
+Query:
 
+```
+histogram_quantile(0.75, sum by (le, name, grpc_method)(rate(grpc_server_handling_seconds_bucket{grpc_method=~`${zoekt_webserver_method:regex}`,instance=~`${webserver_instance:regex}`,grpc_service=~"zoekt.webserver.v1.WebserverService"}[2m])))
+```
 </details>
 
 <br />
@@ -21475,8 +24592,11 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100830` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.999, sum by (le, name, grpc_method)(rate(grpc_server_sent_bytes_per_rpc_bucket{grpc_method=~`${zoekt_webserver_method:regex}`,instance=~`${webserver_instance:regex}`,grpc_service=~"zoekt.webserver.v1.WebserverService"}[2m])))`
+Query:
 
+```
+histogram_quantile(0.999, sum by (le, name, grpc_method)(rate(grpc_server_sent_bytes_per_rpc_bucket{grpc_method=~`${zoekt_webserver_method:regex}`,instance=~`${webserver_instance:regex}`,grpc_service=~"zoekt.webserver.v1.WebserverService"}[2m])))
+```
 </details>
 
 <br />
@@ -21496,8 +24616,11 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100831` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.90, sum by (le, name, grpc_method)(rate(grpc_server_sent_bytes_per_rpc_bucket{grpc_method=~`${zoekt_webserver_method:regex}`,instance=~`${webserver_instance:regex}`,grpc_service=~"zoekt.webserver.v1.WebserverService"}[2m])))`
+Query:
 
+```
+histogram_quantile(0.90, sum by (le, name, grpc_method)(rate(grpc_server_sent_bytes_per_rpc_bucket{grpc_method=~`${zoekt_webserver_method:regex}`,instance=~`${webserver_instance:regex}`,grpc_service=~"zoekt.webserver.v1.WebserverService"}[2m])))
+```
 </details>
 
 <br />
@@ -21517,8 +24640,11 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100832` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.75, sum by (le, name, grpc_method)(rate(grpc_server_sent_bytes_per_rpc_bucket{grpc_method=~`${zoekt_webserver_method:regex}`,instance=~`${webserver_instance:regex}`,grpc_service=~"zoekt.webserver.v1.WebserverService"}[2m])))`
+Query:
 
+```
+histogram_quantile(0.75, sum by (le, name, grpc_method)(rate(grpc_server_sent_bytes_per_rpc_bucket{grpc_method=~`${zoekt_webserver_method:regex}`,instance=~`${webserver_instance:regex}`,grpc_service=~"zoekt.webserver.v1.WebserverService"}[2m])))
+```
 </details>
 
 <br />
@@ -21538,8 +24664,11 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100840` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.999, sum by (le, name, grpc_method)(rate(grpc_server_sent_individual_message_size_bytes_per_rpc_bucket{grpc_method=~`${zoekt_webserver_method:regex}`,instance=~`${webserver_instance:regex}`,grpc_service=~"zoekt.webserver.v1.WebserverService"}[2m])))`
+Query:
 
+```
+histogram_quantile(0.999, sum by (le, name, grpc_method)(rate(grpc_server_sent_individual_message_size_bytes_per_rpc_bucket{grpc_method=~`${zoekt_webserver_method:regex}`,instance=~`${webserver_instance:regex}`,grpc_service=~"zoekt.webserver.v1.WebserverService"}[2m])))
+```
 </details>
 
 <br />
@@ -21559,8 +24688,11 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100841` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.90, sum by (le, name, grpc_method)(rate(grpc_server_sent_individual_message_size_bytes_per_rpc_bucket{grpc_method=~`${zoekt_webserver_method:regex}`,instance=~`${webserver_instance:regex}`,grpc_service=~"zoekt.webserver.v1.WebserverService"}[2m])))`
+Query:
 
+```
+histogram_quantile(0.90, sum by (le, name, grpc_method)(rate(grpc_server_sent_individual_message_size_bytes_per_rpc_bucket{grpc_method=~`${zoekt_webserver_method:regex}`,instance=~`${webserver_instance:regex}`,grpc_service=~"zoekt.webserver.v1.WebserverService"}[2m])))
+```
 </details>
 
 <br />
@@ -21580,8 +24712,11 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100842` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.75, sum by (le, name, grpc_method)(rate(grpc_server_sent_individual_message_size_bytes_per_rpc_bucket{grpc_method=~`${zoekt_webserver_method:regex}`,instance=~`${webserver_instance:regex}`,grpc_service=~"zoekt.webserver.v1.WebserverService"}[2m])))`
+Query:
 
+```
+histogram_quantile(0.75, sum by (le, name, grpc_method)(rate(grpc_server_sent_individual_message_size_bytes_per_rpc_bucket{grpc_method=~`${zoekt_webserver_method:regex}`,instance=~`${webserver_instance:regex}`,grpc_service=~"zoekt.webserver.v1.WebserverService"}[2m])))
+```
 </details>
 
 <br />
@@ -21601,8 +24736,11 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100850` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `((sum(rate(grpc_server_msg_sent_total{grpc_type="server_stream",instance=~`${webserver_instance:regex}`,grpc_service=~"zoekt.webserver.v1.WebserverService"}[2m])) by (grpc_method))/(sum(rate(grpc_server_started_total{grpc_type="server_stream",instance=~`${webserver_instance:regex}`,grpc_service=~"zoekt.webserver.v1.WebserverService"}[2m])) by (grpc_method)))`
+Query:
 
+```
+((sum(rate(grpc_server_msg_sent_total{grpc_type="server_stream",instance=~`${webserver_instance:regex}`,grpc_service=~"zoekt.webserver.v1.WebserverService"}[2m])) by (grpc_method))/(sum(rate(grpc_server_started_total{grpc_type="server_stream",instance=~`${webserver_instance:regex}`,grpc_service=~"zoekt.webserver.v1.WebserverService"}[2m])) by (grpc_method)))
+```
 </details>
 
 <br />
@@ -21622,8 +24760,11 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100860` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(rate(grpc_server_handled_total{grpc_method=~`${zoekt_webserver_method:regex}`,instance=~`${webserver_instance:regex}`,grpc_service=~"zoekt.webserver.v1.WebserverService"}[2m])) by (grpc_method, grpc_code)`
+Query:
 
+```
+sum(rate(grpc_server_handled_total{grpc_method=~`${zoekt_webserver_method:regex}`,instance=~`${webserver_instance:regex}`,grpc_service=~"zoekt.webserver.v1.WebserverService"}[2m])) by (grpc_method, grpc_code)
+```
 </details>
 
 <br />
@@ -21645,8 +24786,11 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100900` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `(100.0 * ((((sum(rate(src_grpc_method_status{grpc_service=~"zoekt.webserver.v1.WebserverService",grpc_code!="OK"}[2m])))) / ((sum(rate(src_grpc_method_status{grpc_service=~"zoekt.webserver.v1.WebserverService"}[2m])))))))`
+Query:
 
+```
+(100.0 * ((((sum(rate(src_grpc_method_status{grpc_service=~"zoekt.webserver.v1.WebserverService",grpc_code!="OK"}[2m])))) / ((sum(rate(src_grpc_method_status{grpc_service=~"zoekt.webserver.v1.WebserverService"}[2m])))))))
+```
 </details>
 
 <br />
@@ -21666,8 +24810,11 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100901` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `(100.0 * ((((sum(rate(src_grpc_method_status{grpc_service=~"zoekt.webserver.v1.WebserverService",grpc_method=~"${zoekt_webserver_method:regex}",grpc_code!="OK"}[2m])) by (grpc_method))) / ((sum(rate(src_grpc_method_status{grpc_service=~"zoekt.webserver.v1.WebserverService",grpc_method=~"${zoekt_webserver_method:regex}"}[2m])) by (grpc_method))))))`
+Query:
 
+```
+(100.0 * ((((sum(rate(src_grpc_method_status{grpc_service=~"zoekt.webserver.v1.WebserverService",grpc_method=~"${zoekt_webserver_method:regex}",grpc_code!="OK"}[2m])) by (grpc_method))) / ((sum(rate(src_grpc_method_status{grpc_service=~"zoekt.webserver.v1.WebserverService",grpc_method=~"${zoekt_webserver_method:regex}"}[2m])) by (grpc_method))))))
+```
 </details>
 
 <br />
@@ -21687,8 +24834,11 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100902` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `(sum(rate(src_grpc_method_status{grpc_service=~"zoekt.webserver.v1.WebserverService",grpc_method=~"${zoekt_webserver_method:regex}"}[2m])) by (grpc_method, grpc_code))`
+Query:
 
+```
+(sum(rate(src_grpc_method_status{grpc_service=~"zoekt.webserver.v1.WebserverService",grpc_method=~"${zoekt_webserver_method:regex}"}[2m])) by (grpc_method, grpc_code))
+```
 </details>
 
 <br />
@@ -21714,8 +24864,11 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100910` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `(100.0 * ((((sum(rate(src_grpc_method_status{grpc_service=~"zoekt.webserver.v1.WebserverService",grpc_code!="OK",is_internal_error="true"}[2m])))) / ((sum(rate(src_grpc_method_status{grpc_service=~"zoekt.webserver.v1.WebserverService"}[2m])))))))`
+Query:
 
+```
+(100.0 * ((((sum(rate(src_grpc_method_status{grpc_service=~"zoekt.webserver.v1.WebserverService",grpc_code!="OK",is_internal_error="true"}[2m])))) / ((sum(rate(src_grpc_method_status{grpc_service=~"zoekt.webserver.v1.WebserverService"}[2m])))))))
+```
 </details>
 
 <br />
@@ -21741,8 +24894,11 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100911` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `(100.0 * ((((sum(rate(src_grpc_method_status{grpc_service=~"zoekt.webserver.v1.WebserverService",grpc_method=~"${zoekt_webserver_method:regex}",grpc_code!="OK",is_internal_error="true"}[2m])) by (grpc_method))) / ((sum(rate(src_grpc_method_status{grpc_service=~"zoekt.webserver.v1.WebserverService",grpc_method=~"${zoekt_webserver_method:regex}"}[2m])) by (grpc_method))))))`
+Query:
 
+```
+(100.0 * ((((sum(rate(src_grpc_method_status{grpc_service=~"zoekt.webserver.v1.WebserverService",grpc_method=~"${zoekt_webserver_method:regex}",grpc_code!="OK",is_internal_error="true"}[2m])) by (grpc_method))) / ((sum(rate(src_grpc_method_status{grpc_service=~"zoekt.webserver.v1.WebserverService",grpc_method=~"${zoekt_webserver_method:regex}"}[2m])) by (grpc_method))))))
+```
 </details>
 
 <br />
@@ -21768,8 +24924,11 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100912` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `(sum(rate(src_grpc_method_status{grpc_service=~"zoekt.webserver.v1.WebserverService",is_internal_error="true",grpc_method=~"${zoekt_webserver_method:regex}"}[2m])) by (grpc_method, grpc_code))`
+Query:
 
+```
+(sum(rate(src_grpc_method_status{grpc_service=~"zoekt.webserver.v1.WebserverService",is_internal_error="true",grpc_method=~"${zoekt_webserver_method:regex}"}[2m])) by (grpc_method, grpc_code))
+```
 </details>
 
 <br />
@@ -21791,8 +24950,11 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=101000` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `(100.0 * ((((sum(rate(src_grpc_client_retry_attempts_total{grpc_service=~"zoekt.webserver.v1.WebserverService",is_retried="true"}[2m])))) / ((sum(rate(src_grpc_client_retry_attempts_total{grpc_service=~"zoekt.webserver.v1.WebserverService"}[2m])))))))`
+Query:
 
+```
+(100.0 * ((((sum(rate(src_grpc_client_retry_attempts_total{grpc_service=~"zoekt.webserver.v1.WebserverService",is_retried="true"}[2m])))) / ((sum(rate(src_grpc_client_retry_attempts_total{grpc_service=~"zoekt.webserver.v1.WebserverService"}[2m])))))))
+```
 </details>
 
 <br />
@@ -21812,8 +24974,11 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=101001` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `(100.0 * ((((sum(rate(src_grpc_client_retry_attempts_total{grpc_service=~"zoekt.webserver.v1.WebserverService",is_retried="true",grpc_method=~"${zoekt_webserver_method:regex}"}[2m])) by (grpc_method))) / ((sum(rate(src_grpc_client_retry_attempts_total{grpc_service=~"zoekt.webserver.v1.WebserverService",grpc_method=~"${zoekt_webserver_method:regex}"}[2m])) by (grpc_method))))))`
+Query:
 
+```
+(100.0 * ((((sum(rate(src_grpc_client_retry_attempts_total{grpc_service=~"zoekt.webserver.v1.WebserverService",is_retried="true",grpc_method=~"${zoekt_webserver_method:regex}"}[2m])) by (grpc_method))) / ((sum(rate(src_grpc_client_retry_attempts_total{grpc_service=~"zoekt.webserver.v1.WebserverService",grpc_method=~"${zoekt_webserver_method:regex}"}[2m])) by (grpc_method))))))
+```
 </details>
 
 <br />
@@ -21833,8 +24998,11 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=101002` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `(sum(rate(src_grpc_client_retry_attempts_total{grpc_service=~"zoekt.webserver.v1.WebserverService",grpc_method=~"${zoekt_webserver_method:regex}",is_retried="true"}[2m])) by (grpc_method))`
+Query:
 
+```
+(sum(rate(src_grpc_client_retry_attempts_total{grpc_service=~"zoekt.webserver.v1.WebserverService",grpc_method=~"${zoekt_webserver_method:regex}",is_retried="true"}[2m])) by (grpc_method))
+```
 </details>
 
 <br />
@@ -21858,8 +25026,11 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=101100` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `(max by (instance) (zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_reads_completed_total{instance=~`node-exporter.*`}[1m])))))`
+Query:
 
+```
+(max by (instance) (zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_reads_completed_total{instance=~`node-exporter.*`}[1m])))))
+```
 </details>
 
 <br />
@@ -21881,8 +25052,11 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=101101` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `(max by (instance) (zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_writes_completed_total{instance=~`node-exporter.*`}[1m])))))`
+Query:
 
+```
+(max by (instance) (zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_writes_completed_total{instance=~`node-exporter.*`}[1m])))))
+```
 </details>
 
 <br />
@@ -21904,8 +25078,11 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=101110` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `(max by (instance) (zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_read_bytes_total{instance=~`node-exporter.*`}[1m])))))`
+Query:
 
+```
+(max by (instance) (zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_read_bytes_total{instance=~`node-exporter.*`}[1m])))))
+```
 </details>
 
 <br />
@@ -21927,8 +25104,11 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=101111` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `(max by (instance) (zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_written_bytes_total{instance=~`node-exporter.*`}[1m])))))`
+Query:
 
+```
+(max by (instance) (zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_written_bytes_total{instance=~`node-exporter.*`}[1m])))))
+```
 </details>
 
 <br />
@@ -21950,8 +25130,11 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=101120` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `(((max by (instance) (zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_read_time_seconds_total{instance=~`node-exporter.*`}[1m])))))) / ((max by (instance) (zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_reads_completed_total{instance=~`node-exporter.*`}[1m])))))))`
+Query:
 
+```
+(((max by (instance) (zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_read_time_seconds_total{instance=~`node-exporter.*`}[1m])))))) / ((max by (instance) (zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_reads_completed_total{instance=~`node-exporter.*`}[1m])))))))
+```
 </details>
 
 <br />
@@ -21973,8 +25156,11 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=101121` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `(((max by (instance) (zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_write_time_seconds_total{instance=~`node-exporter.*`}[1m])))))) / ((max by (instance) (zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_writes_completed_total{instance=~`node-exporter.*`}[1m])))))))`
+Query:
 
+```
+(((max by (instance) (zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_write_time_seconds_total{instance=~`node-exporter.*`}[1m])))))) / ((max by (instance) (zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_writes_completed_total{instance=~`node-exporter.*`}[1m])))))))
+```
 </details>
 
 <br />
@@ -21996,8 +25182,11 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=101130` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `(((max by (instance) (zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_read_bytes_total{instance=~`node-exporter.*`}[1m])))))) / ((max by (instance) (zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_reads_completed_total{instance=~`node-exporter.*`}[1m])))))))`
+Query:
 
+```
+(((max by (instance) (zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_read_bytes_total{instance=~`node-exporter.*`}[1m])))))) / ((max by (instance) (zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_reads_completed_total{instance=~`node-exporter.*`}[1m])))))))
+```
 </details>
 
 <br />
@@ -22019,8 +25208,11 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=101131` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `(((max by (instance) (zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_written_bytes_total{instance=~`node-exporter.*`}[1m])))))) / ((max by (instance) (zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_writes_completed_total{instance=~`node-exporter.*`}[1m])))))))`
+Query:
 
+```
+(((max by (instance) (zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_written_bytes_total{instance=~`node-exporter.*`}[1m])))))) / ((max by (instance) (zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_writes_completed_total{instance=~`node-exporter.*`}[1m])))))))
+```
 </details>
 
 <br />
@@ -22042,8 +25234,11 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=101140` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `(max by (instance) (zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_reads_merged_total{instance=~`node-exporter.*`}[1m])))))`
+Query:
 
+```
+(max by (instance) (zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_reads_merged_total{instance=~`node-exporter.*`}[1m])))))
+```
 </details>
 
 <br />
@@ -22065,8 +25260,11 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=101141` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `(max by (instance) (zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_writes_merged_total{instance=~`node-exporter.*`}[1m])))))`
+Query:
 
+```
+(max by (instance) (zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_writes_merged_total{instance=~`node-exporter.*`}[1m])))))
+```
 </details>
 
 <br />
@@ -22088,8 +25286,11 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=101150` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `(max by (instance) (zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_io_time_weighted_seconds_total{instance=~`node-exporter.*`}[1m])))))`
+Query:
 
+```
+(max by (instance) (zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_io_time_weighted_seconds_total{instance=~`node-exporter.*`}[1m])))))
+```
 </details>
 
 <br />
@@ -22119,8 +25320,11 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=101200` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `count by(name) ((time() - container_last_seen{name=~"^zoekt-indexserver.*"}) > 60)`
+Query:
 
+```
+count by(name) ((time() - container_last_seen{name=~"^zoekt-indexserver.*"}) > 60)
+```
 </details>
 
 <br />
@@ -22138,8 +25342,11 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=101201` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `cadvisor_container_cpu_usage_percentage_total{name=~"^zoekt-indexserver.*"}`
+Query:
 
+```
+cadvisor_container_cpu_usage_percentage_total{name=~"^zoekt-indexserver.*"}
+```
 </details>
 
 <br />
@@ -22157,8 +25364,11 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=101202` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `cadvisor_container_memory_usage_percentage_total{name=~"^zoekt-indexserver.*"}`
+Query:
 
+```
+cadvisor_container_memory_usage_percentage_total{name=~"^zoekt-indexserver.*"}
+```
 </details>
 
 <br />
@@ -22179,8 +25389,11 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=101203` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by(name) (rate(container_fs_reads_total{name=~"^zoekt-indexserver.*"}[1h]) + rate(container_fs_writes_total{name=~"^zoekt-indexserver.*"}[1h]))`
+Query:
 
+```
+sum by(name) (rate(container_fs_reads_total{name=~"^zoekt-indexserver.*"}[1h]) + rate(container_fs_writes_total{name=~"^zoekt-indexserver.*"}[1h]))
+```
 </details>
 
 <br />
@@ -22210,8 +25423,11 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=101300` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `count by(name) ((time() - container_last_seen{name=~"^zoekt-webserver.*"}) > 60)`
+Query:
 
+```
+count by(name) ((time() - container_last_seen{name=~"^zoekt-webserver.*"}) > 60)
+```
 </details>
 
 <br />
@@ -22229,8 +25445,11 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=101301` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `cadvisor_container_cpu_usage_percentage_total{name=~"^zoekt-webserver.*"}`
+Query:
 
+```
+cadvisor_container_cpu_usage_percentage_total{name=~"^zoekt-webserver.*"}
+```
 </details>
 
 <br />
@@ -22248,8 +25467,11 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=101302` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `cadvisor_container_memory_usage_percentage_total{name=~"^zoekt-webserver.*"}`
+Query:
 
+```
+cadvisor_container_memory_usage_percentage_total{name=~"^zoekt-webserver.*"}
+```
 </details>
 
 <br />
@@ -22270,8 +25492,11 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=101303` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by(name) (rate(container_fs_reads_total{name=~"^zoekt-webserver.*"}[1h]) + rate(container_fs_writes_total{name=~"^zoekt-webserver.*"}[1h]))`
+Query:
 
+```
+sum by(name) (rate(container_fs_reads_total{name=~"^zoekt-webserver.*"}[1h]) + rate(container_fs_writes_total{name=~"^zoekt-webserver.*"}[1h]))
+```
 </details>
 
 <br />
@@ -22291,8 +25516,11 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=101400` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `quantile_over_time(0.9, cadvisor_container_cpu_usage_percentage_total{name=~"^zoekt-indexserver.*"}[1d])`
+Query:
 
+```
+quantile_over_time(0.9, cadvisor_container_cpu_usage_percentage_total{name=~"^zoekt-indexserver.*"}[1d])
+```
 </details>
 
 <br />
@@ -22310,8 +25538,11 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=101401` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^zoekt-indexserver.*"}[1d])`
+Query:
 
+```
+max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^zoekt-indexserver.*"}[1d])
+```
 </details>
 
 <br />
@@ -22329,8 +25560,11 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=101410` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `max_over_time(cadvisor_container_cpu_usage_percentage_total{name=~"^zoekt-indexserver.*"}[5m])`
+Query:
 
+```
+max_over_time(cadvisor_container_cpu_usage_percentage_total{name=~"^zoekt-indexserver.*"}[5m])
+```
 </details>
 
 <br />
@@ -22348,8 +25582,11 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=101411` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^zoekt-indexserver.*"}[5m])`
+Query:
 
+```
+max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^zoekt-indexserver.*"}[5m])
+```
 </details>
 
 <br />
@@ -22370,8 +25607,11 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=101412` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `max by (name) (container_oom_events_total{name=~"^zoekt-indexserver.*"})`
+Query:
 
+```
+max by (name) (container_oom_events_total{name=~"^zoekt-indexserver.*"})
+```
 </details>
 
 <br />
@@ -22391,8 +25631,11 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=101500` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `quantile_over_time(0.9, cadvisor_container_cpu_usage_percentage_total{name=~"^zoekt-webserver.*"}[1d])`
+Query:
 
+```
+quantile_over_time(0.9, cadvisor_container_cpu_usage_percentage_total{name=~"^zoekt-webserver.*"}[1d])
+```
 </details>
 
 <br />
@@ -22410,8 +25653,11 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=101501` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^zoekt-webserver.*"}[1d])`
+Query:
 
+```
+max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^zoekt-webserver.*"}[1d])
+```
 </details>
 
 <br />
@@ -22429,8 +25675,11 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=101510` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `max_over_time(cadvisor_container_cpu_usage_percentage_total{name=~"^zoekt-webserver.*"}[5m])`
+Query:
 
+```
+max_over_time(cadvisor_container_cpu_usage_percentage_total{name=~"^zoekt-webserver.*"}[5m])
+```
 </details>
 
 <br />
@@ -22448,8 +25697,11 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=101511` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^zoekt-webserver.*"}[5m])`
+Query:
 
+```
+max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^zoekt-webserver.*"}[5m])
+```
 </details>
 
 <br />
@@ -22470,8 +25722,11 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=101512` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `max by (name) (container_oom_events_total{name=~"^zoekt-webserver.*"})`
+Query:
 
+```
+max by (name) (container_oom_events_total{name=~"^zoekt-webserver.*"})
+```
 </details>
 
 <br />
@@ -22491,8 +25746,11 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=101600` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by(app) (up{app=~".*indexed-search"}) / count by (app) (up{app=~".*indexed-search"}) * 100`
+Query:
 
+```
+sum by(app) (up{app=~".*indexed-search"}) / count by (app) (up{app=~".*indexed-search"}) * 100
+```
 </details>
 
 <br />
@@ -22520,8 +25778,11 @@ To see this panel, visit `/-/debug/grafana/d/prometheus/prometheus?viewPanel=100
 <details>
 <summary>Technical details</summary>
 
-Query: `topk(10, count by (__name__, job)({__name__!=""}))`
+Query:
 
+```
+topk(10, count by (__name__, job)({__name__!=""}))
+```
 </details>
 
 <br />
@@ -22541,8 +25802,11 @@ To see this panel, visit `/-/debug/grafana/d/prometheus/prometheus?viewPanel=100
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by(job) (scrape_samples_post_metric_relabeling{job!=""})`
+Query:
 
+```
+sum by(job) (scrape_samples_post_metric_relabeling{job!=""})
+```
 </details>
 
 <br />
@@ -22565,8 +25829,11 @@ To see this panel, visit `/-/debug/grafana/d/prometheus/prometheus?viewPanel=100
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by(rule_group) (avg_over_time(prometheus_rule_group_last_duration_seconds[10m]))`
+Query:
 
+```
+sum by(rule_group) (avg_over_time(prometheus_rule_group_last_duration_seconds[10m]))
+```
 </details>
 
 <br />
@@ -22586,8 +25853,11 @@ To see this panel, visit `/-/debug/grafana/d/prometheus/prometheus?viewPanel=100
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by(rule_group) (rate(prometheus_rule_evaluation_failures_total[5m]))`
+Query:
 
+```
+sum by(rule_group) (rate(prometheus_rule_evaluation_failures_total[5m]))
+```
 </details>
 
 <br />
@@ -22607,8 +25877,11 @@ To see this panel, visit `/-/debug/grafana/d/prometheus/prometheus?viewPanel=100
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by(integration) (rate(alertmanager_notification_latency_seconds_sum[1m]))`
+Query:
 
+```
+sum by(integration) (rate(alertmanager_notification_latency_seconds_sum[1m]))
+```
 </details>
 
 <br />
@@ -22626,8 +25899,11 @@ To see this panel, visit `/-/debug/grafana/d/prometheus/prometheus?viewPanel=100
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by(integration) (rate(alertmanager_notifications_failed_total[1m]))`
+Query:
 
+```
+sum by(integration) (rate(alertmanager_notifications_failed_total[1m]))
+```
 </details>
 
 <br />
@@ -22649,8 +25925,11 @@ To see this panel, visit `/-/debug/grafana/d/prometheus/prometheus?viewPanel=100
 <details>
 <summary>Technical details</summary>
 
-Query: `prometheus_config_last_reload_successful`
+Query:
 
+```
+prometheus_config_last_reload_successful
+```
 </details>
 
 <br />
@@ -22670,8 +25949,11 @@ To see this panel, visit `/-/debug/grafana/d/prometheus/prometheus?viewPanel=100
 <details>
 <summary>Technical details</summary>
 
-Query: `alertmanager_config_last_reload_successful`
+Query:
 
+```
+alertmanager_config_last_reload_successful
+```
 </details>
 
 <br />
@@ -22689,8 +25971,11 @@ To see this panel, visit `/-/debug/grafana/d/prometheus/prometheus?viewPanel=100
 <details>
 <summary>Technical details</summary>
 
-Query: `increase(label_replace({__name__=~"prometheus_tsdb_(.*)_failed_total"}, "operation", "$1", "__name__", "(.+)s_failed_total")[5m:1m])`
+Query:
 
+```
+increase(label_replace({__name__=~"prometheus_tsdb_(.*)_failed_total"}, "operation", "$1", "__name__", "(.+)s_failed_total")[5m:1m])
+```
 </details>
 
 <br />
@@ -22708,8 +25993,11 @@ To see this panel, visit `/-/debug/grafana/d/prometheus/prometheus?viewPanel=100
 <details>
 <summary>Technical details</summary>
 
-Query: `increase(prometheus_target_scrapes_exceeded_sample_limit_total[10m])`
+Query:
 
+```
+increase(prometheus_target_scrapes_exceeded_sample_limit_total[10m])
+```
 </details>
 
 <br />
@@ -22727,8 +26015,11 @@ To see this panel, visit `/-/debug/grafana/d/prometheus/prometheus?viewPanel=100
 <details>
 <summary>Technical details</summary>
 
-Query: `increase(prometheus_target_scrapes_sample_duplicate_timestamp_total[10m])`
+Query:
 
+```
+increase(prometheus_target_scrapes_sample_duplicate_timestamp_total[10m])
+```
 </details>
 
 <br />
@@ -22758,8 +26049,11 @@ To see this panel, visit `/-/debug/grafana/d/prometheus/prometheus?viewPanel=100
 <details>
 <summary>Technical details</summary>
 
-Query: `count by(name) ((time() - container_last_seen{name=~"^prometheus.*"}) > 60)`
+Query:
 
+```
+count by(name) ((time() - container_last_seen{name=~"^prometheus.*"}) > 60)
+```
 </details>
 
 <br />
@@ -22777,8 +26071,11 @@ To see this panel, visit `/-/debug/grafana/d/prometheus/prometheus?viewPanel=100
 <details>
 <summary>Technical details</summary>
 
-Query: `cadvisor_container_cpu_usage_percentage_total{name=~"^prometheus.*"}`
+Query:
 
+```
+cadvisor_container_cpu_usage_percentage_total{name=~"^prometheus.*"}
+```
 </details>
 
 <br />
@@ -22796,8 +26093,11 @@ To see this panel, visit `/-/debug/grafana/d/prometheus/prometheus?viewPanel=100
 <details>
 <summary>Technical details</summary>
 
-Query: `cadvisor_container_memory_usage_percentage_total{name=~"^prometheus.*"}`
+Query:
 
+```
+cadvisor_container_memory_usage_percentage_total{name=~"^prometheus.*"}
+```
 </details>
 
 <br />
@@ -22818,8 +26118,11 @@ To see this panel, visit `/-/debug/grafana/d/prometheus/prometheus?viewPanel=100
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by(name) (rate(container_fs_reads_total{name=~"^prometheus.*"}[1h]) + rate(container_fs_writes_total{name=~"^prometheus.*"}[1h]))`
+Query:
 
+```
+sum by(name) (rate(container_fs_reads_total{name=~"^prometheus.*"}[1h]) + rate(container_fs_writes_total{name=~"^prometheus.*"}[1h]))
+```
 </details>
 
 <br />
@@ -22839,8 +26142,11 @@ To see this panel, visit `/-/debug/grafana/d/prometheus/prometheus?viewPanel=100
 <details>
 <summary>Technical details</summary>
 
-Query: `quantile_over_time(0.9, cadvisor_container_cpu_usage_percentage_total{name=~"^prometheus.*"}[1d])`
+Query:
 
+```
+quantile_over_time(0.9, cadvisor_container_cpu_usage_percentage_total{name=~"^prometheus.*"}[1d])
+```
 </details>
 
 <br />
@@ -22858,8 +26164,11 @@ To see this panel, visit `/-/debug/grafana/d/prometheus/prometheus?viewPanel=100
 <details>
 <summary>Technical details</summary>
 
-Query: `max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^prometheus.*"}[1d])`
+Query:
 
+```
+max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^prometheus.*"}[1d])
+```
 </details>
 
 <br />
@@ -22877,8 +26186,11 @@ To see this panel, visit `/-/debug/grafana/d/prometheus/prometheus?viewPanel=100
 <details>
 <summary>Technical details</summary>
 
-Query: `max_over_time(cadvisor_container_cpu_usage_percentage_total{name=~"^prometheus.*"}[5m])`
+Query:
 
+```
+max_over_time(cadvisor_container_cpu_usage_percentage_total{name=~"^prometheus.*"}[5m])
+```
 </details>
 
 <br />
@@ -22896,8 +26208,11 @@ To see this panel, visit `/-/debug/grafana/d/prometheus/prometheus?viewPanel=100
 <details>
 <summary>Technical details</summary>
 
-Query: `max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^prometheus.*"}[5m])`
+Query:
 
+```
+max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^prometheus.*"}[5m])
+```
 </details>
 
 <br />
@@ -22918,8 +26233,11 @@ To see this panel, visit `/-/debug/grafana/d/prometheus/prometheus?viewPanel=100
 <details>
 <summary>Technical details</summary>
 
-Query: `max by (name) (container_oom_events_total{name=~"^prometheus.*"})`
+Query:
 
+```
+max by (name) (container_oom_events_total{name=~"^prometheus.*"})
+```
 </details>
 
 <br />
@@ -22939,8 +26257,11 @@ To see this panel, visit `/-/debug/grafana/d/prometheus/prometheus?viewPanel=100
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by(app) (up{app=~".*prometheus"}) / count by (app) (up{app=~".*prometheus"}) * 100`
+Query:
 
+```
+sum by(app) (up{app=~".*prometheus"}) / count by (app) (up{app=~".*prometheus"}) * 100
+```
 </details>
 
 <br />
@@ -22966,8 +26287,11 @@ To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100000`
 <details>
 <summary>Technical details</summary>
 
-Query: `max by (queue)(src_executor_total{queue=~"$queue",job=~"^(executor|sourcegraph-code-intel-indexers|executor-batches|frontend|sourcegraph-frontend|worker|sourcegraph-executors).*"})`
+Query:
 
+```
+max by (queue)(src_executor_total{queue=~"$queue",job=~"^(executor|sourcegraph-code-intel-indexers|executor-batches|frontend|sourcegraph-frontend|worker|sourcegraph-executors).*"})
+```
 </details>
 
 <br />
@@ -22991,8 +26315,11 @@ To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100001`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (queue)(increase(src_executor_total{queue=~"$queue",job=~"^(executor|sourcegraph-code-intel-indexers|executor-batches|frontend|sourcegraph-frontend|worker|sourcegraph-executors).*"}[30m])) / sum by (queue)(increase(src_executor_processor_total{queue=~"$queue",job=~"^(executor|sourcegraph-code-intel-indexers|executor-batches|frontend|sourcegraph-frontend|worker|sourcegraph-executors).*"}[30m]))`
+Query:
 
+```
+sum by (queue)(increase(src_executor_total{queue=~"$queue",job=~"^(executor|sourcegraph-code-intel-indexers|executor-batches|frontend|sourcegraph-frontend|worker|sourcegraph-executors).*"}[30m])) / sum by (queue)(increase(src_executor_processor_total{queue=~"$queue",job=~"^(executor|sourcegraph-code-intel-indexers|executor-batches|frontend|sourcegraph-frontend|worker|sourcegraph-executors).*"}[30m]))
+```
 </details>
 
 <br />
@@ -23010,8 +26337,11 @@ To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100002`
 <details>
 <summary>Technical details</summary>
 
-Query: `max by (queue)(src_executor_queued_duration_seconds_total{queue=~"$queue",job=~"^(executor|sourcegraph-code-intel-indexers|executor-batches|frontend|sourcegraph-frontend|worker|sourcegraph-executors).*"})`
+Query:
 
+```
+max by (queue)(src_executor_queued_duration_seconds_total{queue=~"$queue",job=~"^(executor|sourcegraph-code-intel-indexers|executor-batches|frontend|sourcegraph-frontend|worker|sourcegraph-executors).*"})
+```
 </details>
 
 <br />
@@ -23031,8 +26361,11 @@ To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100100`
 <details>
 <summary>Technical details</summary>
 
-Query: `multiqueue_executor_dequeue_cache_size{queue=~"$queue",job=~"^(executor|sourcegraph-code-intel-indexers|executor-batches|frontend|sourcegraph-frontend|worker|sourcegraph-executors).*"}`
+Query:
 
+```
+multiqueue_executor_dequeue_cache_size{queue=~"$queue",job=~"^(executor|sourcegraph-code-intel-indexers|executor-batches|frontend|sourcegraph-frontend|worker|sourcegraph-executors).*"}
+```
 </details>
 
 <br />
@@ -23052,8 +26385,11 @@ To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100200`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(src_executor_processor_handlers{queue=~"${queue:regex}",sg_job=~"^sourcegraph-executors.*"})`
+Query:
 
+```
+sum(src_executor_processor_handlers{queue=~"${queue:regex}",sg_job=~"^sourcegraph-executors.*"})
+```
 </details>
 
 <br />
@@ -23071,8 +26407,11 @@ To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100210`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_executor_processor_total{queue=~"${queue:regex}",sg_job=~"^sourcegraph-executors.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_executor_processor_total{queue=~"${queue:regex}",sg_job=~"^sourcegraph-executors.*"}[5m]))
+```
 </details>
 
 <br />
@@ -23090,8 +26429,11 @@ To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100211`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum  by (le)(rate(src_executor_processor_duration_seconds_bucket{queue=~"${queue:regex}",sg_job=~"^sourcegraph-executors.*"}[5m]))`
+Query:
 
+```
+sum  by (le)(rate(src_executor_processor_duration_seconds_bucket{queue=~"${queue:regex}",sg_job=~"^sourcegraph-executors.*"}[5m]))
+```
 </details>
 
 <br />
@@ -23109,8 +26451,11 @@ To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100212`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_executor_processor_errors_total{queue=~"${queue:regex}",sg_job=~"^sourcegraph-executors.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_executor_processor_errors_total{queue=~"${queue:regex}",sg_job=~"^sourcegraph-executors.*"}[5m]))
+```
 </details>
 
 <br />
@@ -23128,8 +26473,11 @@ To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100213`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_executor_processor_errors_total{queue=~"${queue:regex}",sg_job=~"^sourcegraph-executors.*"}[5m])) / (sum(increase(src_executor_processor_total{queue=~"${queue:regex}",sg_job=~"^sourcegraph-executors.*"}[5m])) + sum(increase(src_executor_processor_errors_total{queue=~"${queue:regex}",sg_job=~"^sourcegraph-executors.*"}[5m]))) * 100`
+Query:
 
+```
+sum(increase(src_executor_processor_errors_total{queue=~"${queue:regex}",sg_job=~"^sourcegraph-executors.*"}[5m])) / (sum(increase(src_executor_processor_total{queue=~"${queue:regex}",sg_job=~"^sourcegraph-executors.*"}[5m])) + sum(increase(src_executor_processor_errors_total{queue=~"${queue:regex}",sg_job=~"^sourcegraph-executors.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -23149,8 +26497,11 @@ To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100300`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_apiworker_apiclient_queue_total{sg_job=~"^sourcegraph-executors.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_apiworker_apiclient_queue_total{sg_job=~"^sourcegraph-executors.*"}[5m]))
+```
 </details>
 
 <br />
@@ -23168,8 +26519,11 @@ To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100301`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum  by (le)(rate(src_apiworker_apiclient_queue_duration_seconds_bucket{sg_job=~"^sourcegraph-executors.*"}[5m]))`
+Query:
 
+```
+sum  by (le)(rate(src_apiworker_apiclient_queue_duration_seconds_bucket{sg_job=~"^sourcegraph-executors.*"}[5m]))
+```
 </details>
 
 <br />
@@ -23187,8 +26541,11 @@ To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100302`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_apiworker_apiclient_queue_errors_total{sg_job=~"^sourcegraph-executors.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_apiworker_apiclient_queue_errors_total{sg_job=~"^sourcegraph-executors.*"}[5m]))
+```
 </details>
 
 <br />
@@ -23206,8 +26563,11 @@ To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100303`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_apiworker_apiclient_queue_errors_total{sg_job=~"^sourcegraph-executors.*"}[5m])) / (sum(increase(src_apiworker_apiclient_queue_total{sg_job=~"^sourcegraph-executors.*"}[5m])) + sum(increase(src_apiworker_apiclient_queue_errors_total{sg_job=~"^sourcegraph-executors.*"}[5m]))) * 100`
+Query:
 
+```
+sum(increase(src_apiworker_apiclient_queue_errors_total{sg_job=~"^sourcegraph-executors.*"}[5m])) / (sum(increase(src_apiworker_apiclient_queue_total{sg_job=~"^sourcegraph-executors.*"}[5m])) + sum(increase(src_apiworker_apiclient_queue_errors_total{sg_job=~"^sourcegraph-executors.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -23225,8 +26585,11 @@ To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100310`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_apiworker_apiclient_queue_total{sg_job=~"^sourcegraph-executors.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_apiworker_apiclient_queue_total{sg_job=~"^sourcegraph-executors.*"}[5m]))
+```
 </details>
 
 <br />
@@ -23244,8 +26607,11 @@ To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100311`
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.99, sum  by (le,op)(rate(src_apiworker_apiclient_queue_duration_seconds_bucket{sg_job=~"^sourcegraph-executors.*"}[5m])))`
+Query:
 
+```
+histogram_quantile(0.99, sum  by (le,op)(rate(src_apiworker_apiclient_queue_duration_seconds_bucket{sg_job=~"^sourcegraph-executors.*"}[5m])))
+```
 </details>
 
 <br />
@@ -23263,8 +26629,11 @@ To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100312`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_apiworker_apiclient_queue_errors_total{sg_job=~"^sourcegraph-executors.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_apiworker_apiclient_queue_errors_total{sg_job=~"^sourcegraph-executors.*"}[5m]))
+```
 </details>
 
 <br />
@@ -23282,8 +26651,11 @@ To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100313`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_apiworker_apiclient_queue_errors_total{sg_job=~"^sourcegraph-executors.*"}[5m])) / (sum by (op)(increase(src_apiworker_apiclient_queue_total{sg_job=~"^sourcegraph-executors.*"}[5m])) + sum by (op)(increase(src_apiworker_apiclient_queue_errors_total{sg_job=~"^sourcegraph-executors.*"}[5m]))) * 100`
+Query:
 
+```
+sum by (op)(increase(src_apiworker_apiclient_queue_errors_total{sg_job=~"^sourcegraph-executors.*"}[5m])) / (sum by (op)(increase(src_apiworker_apiclient_queue_total{sg_job=~"^sourcegraph-executors.*"}[5m])) + sum by (op)(increase(src_apiworker_apiclient_queue_errors_total{sg_job=~"^sourcegraph-executors.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -23303,8 +26675,11 @@ To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100400`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_apiworker_apiclient_files_total{sg_job=~"^sourcegraph-executors.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_apiworker_apiclient_files_total{sg_job=~"^sourcegraph-executors.*"}[5m]))
+```
 </details>
 
 <br />
@@ -23322,8 +26697,11 @@ To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100401`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum  by (le)(rate(src_apiworker_apiclient_files_duration_seconds_bucket{sg_job=~"^sourcegraph-executors.*"}[5m]))`
+Query:
 
+```
+sum  by (le)(rate(src_apiworker_apiclient_files_duration_seconds_bucket{sg_job=~"^sourcegraph-executors.*"}[5m]))
+```
 </details>
 
 <br />
@@ -23341,8 +26719,11 @@ To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100402`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_apiworker_apiclient_files_errors_total{sg_job=~"^sourcegraph-executors.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_apiworker_apiclient_files_errors_total{sg_job=~"^sourcegraph-executors.*"}[5m]))
+```
 </details>
 
 <br />
@@ -23360,8 +26741,11 @@ To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100403`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_apiworker_apiclient_files_errors_total{sg_job=~"^sourcegraph-executors.*"}[5m])) / (sum(increase(src_apiworker_apiclient_files_total{sg_job=~"^sourcegraph-executors.*"}[5m])) + sum(increase(src_apiworker_apiclient_files_errors_total{sg_job=~"^sourcegraph-executors.*"}[5m]))) * 100`
+Query:
 
+```
+sum(increase(src_apiworker_apiclient_files_errors_total{sg_job=~"^sourcegraph-executors.*"}[5m])) / (sum(increase(src_apiworker_apiclient_files_total{sg_job=~"^sourcegraph-executors.*"}[5m])) + sum(increase(src_apiworker_apiclient_files_errors_total{sg_job=~"^sourcegraph-executors.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -23379,8 +26763,11 @@ To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100410`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_apiworker_apiclient_files_total{sg_job=~"^sourcegraph-executors.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_apiworker_apiclient_files_total{sg_job=~"^sourcegraph-executors.*"}[5m]))
+```
 </details>
 
 <br />
@@ -23398,8 +26785,11 @@ To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100411`
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.99, sum  by (le,op)(rate(src_apiworker_apiclient_files_duration_seconds_bucket{sg_job=~"^sourcegraph-executors.*"}[5m])))`
+Query:
 
+```
+histogram_quantile(0.99, sum  by (le,op)(rate(src_apiworker_apiclient_files_duration_seconds_bucket{sg_job=~"^sourcegraph-executors.*"}[5m])))
+```
 </details>
 
 <br />
@@ -23417,8 +26807,11 @@ To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100412`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_apiworker_apiclient_files_errors_total{sg_job=~"^sourcegraph-executors.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_apiworker_apiclient_files_errors_total{sg_job=~"^sourcegraph-executors.*"}[5m]))
+```
 </details>
 
 <br />
@@ -23436,8 +26829,11 @@ To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100413`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_apiworker_apiclient_files_errors_total{sg_job=~"^sourcegraph-executors.*"}[5m])) / (sum by (op)(increase(src_apiworker_apiclient_files_total{sg_job=~"^sourcegraph-executors.*"}[5m])) + sum by (op)(increase(src_apiworker_apiclient_files_errors_total{sg_job=~"^sourcegraph-executors.*"}[5m]))) * 100`
+Query:
 
+```
+sum by (op)(increase(src_apiworker_apiclient_files_errors_total{sg_job=~"^sourcegraph-executors.*"}[5m])) / (sum by (op)(increase(src_apiworker_apiclient_files_total{sg_job=~"^sourcegraph-executors.*"}[5m])) + sum by (op)(increase(src_apiworker_apiclient_files_errors_total{sg_job=~"^sourcegraph-executors.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -23457,8 +26853,11 @@ To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100500`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_apiworker_command_total{op=~"setup.*",sg_job=~"^sourcegraph-executors.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_apiworker_command_total{op=~"setup.*",sg_job=~"^sourcegraph-executors.*"}[5m]))
+```
 </details>
 
 <br />
@@ -23476,8 +26875,11 @@ To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100501`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum  by (le)(rate(src_apiworker_command_duration_seconds_bucket{op=~"setup.*",sg_job=~"^sourcegraph-executors.*"}[5m]))`
+Query:
 
+```
+sum  by (le)(rate(src_apiworker_command_duration_seconds_bucket{op=~"setup.*",sg_job=~"^sourcegraph-executors.*"}[5m]))
+```
 </details>
 
 <br />
@@ -23495,8 +26897,11 @@ To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100502`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_apiworker_command_errors_total{op=~"setup.*",sg_job=~"^sourcegraph-executors.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_apiworker_command_errors_total{op=~"setup.*",sg_job=~"^sourcegraph-executors.*"}[5m]))
+```
 </details>
 
 <br />
@@ -23514,8 +26919,11 @@ To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100503`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_apiworker_command_errors_total{op=~"setup.*",sg_job=~"^sourcegraph-executors.*"}[5m])) / (sum(increase(src_apiworker_command_total{op=~"setup.*",sg_job=~"^sourcegraph-executors.*"}[5m])) + sum(increase(src_apiworker_command_errors_total{op=~"setup.*",sg_job=~"^sourcegraph-executors.*"}[5m]))) * 100`
+Query:
 
+```
+sum(increase(src_apiworker_command_errors_total{op=~"setup.*",sg_job=~"^sourcegraph-executors.*"}[5m])) / (sum(increase(src_apiworker_command_total{op=~"setup.*",sg_job=~"^sourcegraph-executors.*"}[5m])) + sum(increase(src_apiworker_command_errors_total{op=~"setup.*",sg_job=~"^sourcegraph-executors.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -23533,8 +26941,11 @@ To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100510`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_apiworker_command_total{op=~"setup.*",sg_job=~"^sourcegraph-executors.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_apiworker_command_total{op=~"setup.*",sg_job=~"^sourcegraph-executors.*"}[5m]))
+```
 </details>
 
 <br />
@@ -23552,8 +26963,11 @@ To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100511`
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.99, sum  by (le,op)(rate(src_apiworker_command_duration_seconds_bucket{op=~"setup.*",sg_job=~"^sourcegraph-executors.*"}[5m])))`
+Query:
 
+```
+histogram_quantile(0.99, sum  by (le,op)(rate(src_apiworker_command_duration_seconds_bucket{op=~"setup.*",sg_job=~"^sourcegraph-executors.*"}[5m])))
+```
 </details>
 
 <br />
@@ -23571,8 +26985,11 @@ To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100512`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_apiworker_command_errors_total{op=~"setup.*",sg_job=~"^sourcegraph-executors.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_apiworker_command_errors_total{op=~"setup.*",sg_job=~"^sourcegraph-executors.*"}[5m]))
+```
 </details>
 
 <br />
@@ -23590,8 +27007,11 @@ To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100513`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_apiworker_command_errors_total{op=~"setup.*",sg_job=~"^sourcegraph-executors.*"}[5m])) / (sum by (op)(increase(src_apiworker_command_total{op=~"setup.*",sg_job=~"^sourcegraph-executors.*"}[5m])) + sum by (op)(increase(src_apiworker_command_errors_total{op=~"setup.*",sg_job=~"^sourcegraph-executors.*"}[5m]))) * 100`
+Query:
 
+```
+sum by (op)(increase(src_apiworker_command_errors_total{op=~"setup.*",sg_job=~"^sourcegraph-executors.*"}[5m])) / (sum by (op)(increase(src_apiworker_command_total{op=~"setup.*",sg_job=~"^sourcegraph-executors.*"}[5m])) + sum by (op)(increase(src_apiworker_command_errors_total{op=~"setup.*",sg_job=~"^sourcegraph-executors.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -23611,8 +27031,11 @@ To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100600`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_apiworker_command_total{op=~"exec.*",sg_job=~"^sourcegraph-executors.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_apiworker_command_total{op=~"exec.*",sg_job=~"^sourcegraph-executors.*"}[5m]))
+```
 </details>
 
 <br />
@@ -23630,8 +27053,11 @@ To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100601`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum  by (le)(rate(src_apiworker_command_duration_seconds_bucket{op=~"exec.*",sg_job=~"^sourcegraph-executors.*"}[5m]))`
+Query:
 
+```
+sum  by (le)(rate(src_apiworker_command_duration_seconds_bucket{op=~"exec.*",sg_job=~"^sourcegraph-executors.*"}[5m]))
+```
 </details>
 
 <br />
@@ -23649,8 +27075,11 @@ To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100602`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_apiworker_command_errors_total{op=~"exec.*",sg_job=~"^sourcegraph-executors.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_apiworker_command_errors_total{op=~"exec.*",sg_job=~"^sourcegraph-executors.*"}[5m]))
+```
 </details>
 
 <br />
@@ -23668,8 +27097,11 @@ To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100603`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_apiworker_command_errors_total{op=~"exec.*",sg_job=~"^sourcegraph-executors.*"}[5m])) / (sum(increase(src_apiworker_command_total{op=~"exec.*",sg_job=~"^sourcegraph-executors.*"}[5m])) + sum(increase(src_apiworker_command_errors_total{op=~"exec.*",sg_job=~"^sourcegraph-executors.*"}[5m]))) * 100`
+Query:
 
+```
+sum(increase(src_apiworker_command_errors_total{op=~"exec.*",sg_job=~"^sourcegraph-executors.*"}[5m])) / (sum(increase(src_apiworker_command_total{op=~"exec.*",sg_job=~"^sourcegraph-executors.*"}[5m])) + sum(increase(src_apiworker_command_errors_total{op=~"exec.*",sg_job=~"^sourcegraph-executors.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -23687,8 +27119,11 @@ To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100610`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_apiworker_command_total{op=~"exec.*",sg_job=~"^sourcegraph-executors.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_apiworker_command_total{op=~"exec.*",sg_job=~"^sourcegraph-executors.*"}[5m]))
+```
 </details>
 
 <br />
@@ -23706,8 +27141,11 @@ To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100611`
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.99, sum  by (le,op)(rate(src_apiworker_command_duration_seconds_bucket{op=~"exec.*",sg_job=~"^sourcegraph-executors.*"}[5m])))`
+Query:
 
+```
+histogram_quantile(0.99, sum  by (le,op)(rate(src_apiworker_command_duration_seconds_bucket{op=~"exec.*",sg_job=~"^sourcegraph-executors.*"}[5m])))
+```
 </details>
 
 <br />
@@ -23725,8 +27163,11 @@ To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100612`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_apiworker_command_errors_total{op=~"exec.*",sg_job=~"^sourcegraph-executors.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_apiworker_command_errors_total{op=~"exec.*",sg_job=~"^sourcegraph-executors.*"}[5m]))
+```
 </details>
 
 <br />
@@ -23744,8 +27185,11 @@ To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100613`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_apiworker_command_errors_total{op=~"exec.*",sg_job=~"^sourcegraph-executors.*"}[5m])) / (sum by (op)(increase(src_apiworker_command_total{op=~"exec.*",sg_job=~"^sourcegraph-executors.*"}[5m])) + sum by (op)(increase(src_apiworker_command_errors_total{op=~"exec.*",sg_job=~"^sourcegraph-executors.*"}[5m]))) * 100`
+Query:
 
+```
+sum by (op)(increase(src_apiworker_command_errors_total{op=~"exec.*",sg_job=~"^sourcegraph-executors.*"}[5m])) / (sum by (op)(increase(src_apiworker_command_total{op=~"exec.*",sg_job=~"^sourcegraph-executors.*"}[5m])) + sum by (op)(increase(src_apiworker_command_errors_total{op=~"exec.*",sg_job=~"^sourcegraph-executors.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -23765,8 +27209,11 @@ To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100700`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_apiworker_command_total{op=~"teardown.*",sg_job=~"^sourcegraph-executors.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_apiworker_command_total{op=~"teardown.*",sg_job=~"^sourcegraph-executors.*"}[5m]))
+```
 </details>
 
 <br />
@@ -23784,8 +27231,11 @@ To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100701`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum  by (le)(rate(src_apiworker_command_duration_seconds_bucket{op=~"teardown.*",sg_job=~"^sourcegraph-executors.*"}[5m]))`
+Query:
 
+```
+sum  by (le)(rate(src_apiworker_command_duration_seconds_bucket{op=~"teardown.*",sg_job=~"^sourcegraph-executors.*"}[5m]))
+```
 </details>
 
 <br />
@@ -23803,8 +27253,11 @@ To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100702`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_apiworker_command_errors_total{op=~"teardown.*",sg_job=~"^sourcegraph-executors.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_apiworker_command_errors_total{op=~"teardown.*",sg_job=~"^sourcegraph-executors.*"}[5m]))
+```
 </details>
 
 <br />
@@ -23822,8 +27275,11 @@ To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100703`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_apiworker_command_errors_total{op=~"teardown.*",sg_job=~"^sourcegraph-executors.*"}[5m])) / (sum(increase(src_apiworker_command_total{op=~"teardown.*",sg_job=~"^sourcegraph-executors.*"}[5m])) + sum(increase(src_apiworker_command_errors_total{op=~"teardown.*",sg_job=~"^sourcegraph-executors.*"}[5m]))) * 100`
+Query:
 
+```
+sum(increase(src_apiworker_command_errors_total{op=~"teardown.*",sg_job=~"^sourcegraph-executors.*"}[5m])) / (sum(increase(src_apiworker_command_total{op=~"teardown.*",sg_job=~"^sourcegraph-executors.*"}[5m])) + sum(increase(src_apiworker_command_errors_total{op=~"teardown.*",sg_job=~"^sourcegraph-executors.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -23841,8 +27297,11 @@ To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100710`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_apiworker_command_total{op=~"teardown.*",sg_job=~"^sourcegraph-executors.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_apiworker_command_total{op=~"teardown.*",sg_job=~"^sourcegraph-executors.*"}[5m]))
+```
 </details>
 
 <br />
@@ -23860,8 +27319,11 @@ To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100711`
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.99, sum  by (le,op)(rate(src_apiworker_command_duration_seconds_bucket{op=~"teardown.*",sg_job=~"^sourcegraph-executors.*"}[5m])))`
+Query:
 
+```
+histogram_quantile(0.99, sum  by (le,op)(rate(src_apiworker_command_duration_seconds_bucket{op=~"teardown.*",sg_job=~"^sourcegraph-executors.*"}[5m])))
+```
 </details>
 
 <br />
@@ -23879,8 +27341,11 @@ To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100712`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_apiworker_command_errors_total{op=~"teardown.*",sg_job=~"^sourcegraph-executors.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_apiworker_command_errors_total{op=~"teardown.*",sg_job=~"^sourcegraph-executors.*"}[5m]))
+```
 </details>
 
 <br />
@@ -23898,8 +27363,11 @@ To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100713`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_apiworker_command_errors_total{op=~"teardown.*",sg_job=~"^sourcegraph-executors.*"}[5m])) / (sum by (op)(increase(src_apiworker_command_total{op=~"teardown.*",sg_job=~"^sourcegraph-executors.*"}[5m])) + sum by (op)(increase(src_apiworker_command_errors_total{op=~"teardown.*",sg_job=~"^sourcegraph-executors.*"}[5m]))) * 100`
+Query:
 
+```
+sum by (op)(increase(src_apiworker_command_errors_total{op=~"teardown.*",sg_job=~"^sourcegraph-executors.*"}[5m])) / (sum by (op)(increase(src_apiworker_command_total{op=~"teardown.*",sg_job=~"^sourcegraph-executors.*"}[5m])) + sum by (op)(increase(src_apiworker_command_errors_total{op=~"teardown.*",sg_job=~"^sourcegraph-executors.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -23920,8 +27388,11 @@ To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100800`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(rate(node_cpu_seconds_total{sg_job=~"sourcegraph-executors",mode!~"(idle|iowait)",sg_instance=~"$instance"}[$__rate_interval])) by(sg_instance) / count(node_cpu_seconds_total{sg_job=~"sourcegraph-executors",mode="system",sg_instance=~"$instance"}) by (sg_instance) * 100`
+Query:
 
+```
+sum(rate(node_cpu_seconds_total{sg_job=~"sourcegraph-executors",mode!~"(idle|iowait)",sg_instance=~"$instance"}[$__rate_interval])) by(sg_instance) / count(node_cpu_seconds_total{sg_job=~"sourcegraph-executors",mode="system",sg_instance=~"$instance"}) by (sg_instance) * 100
+```
 </details>
 
 <br />
@@ -23940,8 +27411,11 @@ To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100801`
 <details>
 <summary>Technical details</summary>
 
-Query: `rate(node_pressure_cpu_waiting_seconds_total{sg_job=~"sourcegraph-executors",sg_instance=~"$instance"}[$__rate_interval])`
+Query:
 
+```
+rate(node_pressure_cpu_waiting_seconds_total{sg_job=~"sourcegraph-executors",sg_instance=~"$instance"}[$__rate_interval])
+```
 </details>
 
 <br />
@@ -23960,8 +27434,11 @@ To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100810`
 <details>
 <summary>Technical details</summary>
 
-Query: `(1 - sum(node_memory_MemAvailable_bytes{sg_job=~"sourcegraph-executors",sg_instance=~"$instance"}) by (sg_instance) / sum(node_memory_MemTotal_bytes{sg_job=~"sourcegraph-executors",sg_instance=~"$instance"}) by (sg_instance)) * 100`
+Query:
 
+```
+(1 - sum(node_memory_MemAvailable_bytes{sg_job=~"sourcegraph-executors",sg_instance=~"$instance"}) by (sg_instance) / sum(node_memory_MemTotal_bytes{sg_job=~"sourcegraph-executors",sg_instance=~"$instance"}) by (sg_instance)) * 100
+```
 </details>
 
 <br />
@@ -23980,8 +27457,11 @@ To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100811`
 <details>
 <summary>Technical details</summary>
 
-Query: `(rate(node_vmstat_pgsteal_anon{sg_job=~"sourcegraph-executors",sg_instance=~"$instance"}[$__rate_interval]) + rate(node_vmstat_pgsteal_direct{sg_job=~"sourcegraph-executors",sg_instance=~"$instance"}[$__rate_interval]) + rate(node_vmstat_pgsteal_file{sg_job=~"sourcegraph-executors",sg_instance=~"$instance"}[$__rate_interval]) + rate(node_vmstat_pgsteal_kswapd{sg_job=~"sourcegraph-executors",sg_instance=~"$instance"}[$__rate_interval])) / (rate(node_vmstat_pgscan_anon{sg_job=~"sourcegraph-executors",sg_instance=~"$instance"}[$__rate_interval]) + rate(node_vmstat_pgscan_direct{sg_job=~"sourcegraph-executors",sg_instance=~"$instance"}[$__rate_interval]) + rate(node_vmstat_pgscan_file{sg_job=~"sourcegraph-executors",sg_instance=~"$instance"}[$__rate_interval]) + rate(node_vmstat_pgscan_kswapd{sg_job=~"sourcegraph-executors",sg_instance=~"$instance"}[$__rate_interval])) * 100`
+Query:
 
+```
+(rate(node_vmstat_pgsteal_anon{sg_job=~"sourcegraph-executors",sg_instance=~"$instance"}[$__rate_interval]) + rate(node_vmstat_pgsteal_direct{sg_job=~"sourcegraph-executors",sg_instance=~"$instance"}[$__rate_interval]) + rate(node_vmstat_pgsteal_file{sg_job=~"sourcegraph-executors",sg_instance=~"$instance"}[$__rate_interval]) + rate(node_vmstat_pgsteal_kswapd{sg_job=~"sourcegraph-executors",sg_instance=~"$instance"}[$__rate_interval])) / (rate(node_vmstat_pgscan_anon{sg_job=~"sourcegraph-executors",sg_instance=~"$instance"}[$__rate_interval]) + rate(node_vmstat_pgscan_direct{sg_job=~"sourcegraph-executors",sg_instance=~"$instance"}[$__rate_interval]) + rate(node_vmstat_pgscan_file{sg_job=~"sourcegraph-executors",sg_instance=~"$instance"}[$__rate_interval]) + rate(node_vmstat_pgscan_kswapd{sg_job=~"sourcegraph-executors",sg_instance=~"$instance"}[$__rate_interval])) * 100
+```
 </details>
 
 <br />
@@ -24000,8 +27480,11 @@ To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100812`
 <details>
 <summary>Technical details</summary>
 
-Query: `rate(node_pressure_memory_stalled_seconds_total{sg_job=~"sourcegraph-executors",sg_instance=~"$instance"}[$__rate_interval])`
+Query:
 
+```
+rate(node_pressure_memory_stalled_seconds_total{sg_job=~"sourcegraph-executors",sg_instance=~"$instance"}[$__rate_interval])
+```
 </details>
 
 <br />
@@ -24020,8 +27503,11 @@ To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100820`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(label_replace(label_replace(rate(node_disk_io_time_seconds_total{sg_job=~"sourcegraph-executors",sg_instance=~"$instance"}[$__rate_interval]), "disk", "$1", "device", "^([^d].+)"), "disk", "ignite", "device", "dm-.*")) by(sg_instance,disk) * 100`
+Query:
 
+```
+sum(label_replace(label_replace(rate(node_disk_io_time_seconds_total{sg_job=~"sourcegraph-executors",sg_instance=~"$instance"}[$__rate_interval]), "disk", "$1", "device", "^([^d].+)"), "disk", "ignite", "device", "dm-.*")) by(sg_instance,disk) * 100
+```
 </details>
 
 <br />
@@ -24040,8 +27526,11 @@ To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100821`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(label_replace(label_replace(rate(node_disk_io_time_weighted_seconds_total{sg_job=~"sourcegraph-executors",sg_instance=~"$instance"}[$__rate_interval]), "disk", "$1", "device", "^([^d].+)"), "disk", "ignite", "device", "dm-.*")) by(sg_instance,disk)`
+Query:
 
+```
+sum(label_replace(label_replace(rate(node_disk_io_time_weighted_seconds_total{sg_job=~"sourcegraph-executors",sg_instance=~"$instance"}[$__rate_interval]), "disk", "$1", "device", "^([^d].+)"), "disk", "ignite", "device", "dm-.*")) by(sg_instance,disk)
+```
 </details>
 
 <br />
@@ -24060,8 +27549,11 @@ To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100822`
 <details>
 <summary>Technical details</summary>
 
-Query: `rate(node_pressure_io_stalled_seconds_total{sg_job=~"sourcegraph-executors",sg_instance=~"$instance"}[$__rate_interval])`
+Query:
 
+```
+rate(node_pressure_io_stalled_seconds_total{sg_job=~"sourcegraph-executors",sg_instance=~"$instance"}[$__rate_interval])
+```
 </details>
 
 <br />
@@ -24080,8 +27572,11 @@ To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100830`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(rate(node_network_receive_bytes_total{sg_job=~"sourcegraph-executors",sg_instance=~"$instance"}[$__rate_interval])) by(sg_instance) * 8`
+Query:
 
+```
+sum(rate(node_network_receive_bytes_total{sg_job=~"sourcegraph-executors",sg_instance=~"$instance"}[$__rate_interval])) by(sg_instance) * 8
+```
 </details>
 
 <br />
@@ -24100,8 +27595,11 @@ To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100831`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(rate(node_network_receive_drop_total{sg_job=~"sourcegraph-executors",sg_instance=~"$instance"}[$__rate_interval])) by(sg_instance)`
+Query:
 
+```
+sum(rate(node_network_receive_drop_total{sg_job=~"sourcegraph-executors",sg_instance=~"$instance"}[$__rate_interval])) by(sg_instance)
+```
 </details>
 
 <br />
@@ -24120,8 +27618,11 @@ To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100832`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(rate(node_network_receive_errs_total{sg_job=~"sourcegraph-executors",sg_instance=~"$instance"}[$__rate_interval])) by(sg_instance)`
+Query:
 
+```
+sum(rate(node_network_receive_errs_total{sg_job=~"sourcegraph-executors",sg_instance=~"$instance"}[$__rate_interval])) by(sg_instance)
+```
 </details>
 
 <br />
@@ -24140,8 +27641,11 @@ To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100840`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(rate(node_network_transmit_bytes_total{sg_job=~"sourcegraph-executors",sg_instance=~"$instance"}[$__rate_interval])) by(sg_instance) * 8`
+Query:
 
+```
+sum(rate(node_network_transmit_bytes_total{sg_job=~"sourcegraph-executors",sg_instance=~"$instance"}[$__rate_interval])) by(sg_instance) * 8
+```
 </details>
 
 <br />
@@ -24160,8 +27664,11 @@ To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100841`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(rate(node_network_transmit_drop_total{sg_job=~"sourcegraph-executors",sg_instance=~"$instance"}[$__rate_interval])) by(sg_instance)`
+Query:
 
+```
+sum(rate(node_network_transmit_drop_total{sg_job=~"sourcegraph-executors",sg_instance=~"$instance"}[$__rate_interval])) by(sg_instance)
+```
 </details>
 
 <br />
@@ -24180,8 +27687,11 @@ To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100842`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(rate(node_network_transmit_errs_total{sg_job=~"sourcegraph-executors",sg_instance=~"$instance"}[$__rate_interval])) by(sg_instance)`
+Query:
 
+```
+sum(rate(node_network_transmit_errs_total{sg_job=~"sourcegraph-executors",sg_instance=~"$instance"}[$__rate_interval])) by(sg_instance)
+```
 </details>
 
 <br />
@@ -24202,8 +27712,11 @@ To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100900`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(rate(node_cpu_seconds_total{sg_job=~"sourcegraph-executors-registry",mode!~"(idle|iowait)",sg_instance=~"docker-registry"}[$__rate_interval])) by(sg_instance) / count(node_cpu_seconds_total{sg_job=~"sourcegraph-executors-registry",mode="system",sg_instance=~"docker-registry"}) by (sg_instance) * 100`
+Query:
 
+```
+sum(rate(node_cpu_seconds_total{sg_job=~"sourcegraph-executors-registry",mode!~"(idle|iowait)",sg_instance=~"docker-registry"}[$__rate_interval])) by(sg_instance) / count(node_cpu_seconds_total{sg_job=~"sourcegraph-executors-registry",mode="system",sg_instance=~"docker-registry"}) by (sg_instance) * 100
+```
 </details>
 
 <br />
@@ -24222,8 +27735,11 @@ To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100901`
 <details>
 <summary>Technical details</summary>
 
-Query: `rate(node_pressure_cpu_waiting_seconds_total{sg_job=~"sourcegraph-executors-registry",sg_instance=~"docker-registry"}[$__rate_interval])`
+Query:
 
+```
+rate(node_pressure_cpu_waiting_seconds_total{sg_job=~"sourcegraph-executors-registry",sg_instance=~"docker-registry"}[$__rate_interval])
+```
 </details>
 
 <br />
@@ -24242,8 +27758,11 @@ To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100910`
 <details>
 <summary>Technical details</summary>
 
-Query: `(1 - sum(node_memory_MemAvailable_bytes{sg_job=~"sourcegraph-executors-registry",sg_instance=~"docker-registry"}) by (sg_instance) / sum(node_memory_MemTotal_bytes{sg_job=~"sourcegraph-executors-registry",sg_instance=~"docker-registry"}) by (sg_instance)) * 100`
+Query:
 
+```
+(1 - sum(node_memory_MemAvailable_bytes{sg_job=~"sourcegraph-executors-registry",sg_instance=~"docker-registry"}) by (sg_instance) / sum(node_memory_MemTotal_bytes{sg_job=~"sourcegraph-executors-registry",sg_instance=~"docker-registry"}) by (sg_instance)) * 100
+```
 </details>
 
 <br />
@@ -24262,8 +27781,11 @@ To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100911`
 <details>
 <summary>Technical details</summary>
 
-Query: `(rate(node_vmstat_pgsteal_anon{sg_job=~"sourcegraph-executors-registry",sg_instance=~"docker-registry"}[$__rate_interval]) + rate(node_vmstat_pgsteal_direct{sg_job=~"sourcegraph-executors-registry",sg_instance=~"docker-registry"}[$__rate_interval]) + rate(node_vmstat_pgsteal_file{sg_job=~"sourcegraph-executors-registry",sg_instance=~"docker-registry"}[$__rate_interval]) + rate(node_vmstat_pgsteal_kswapd{sg_job=~"sourcegraph-executors-registry",sg_instance=~"docker-registry"}[$__rate_interval])) / (rate(node_vmstat_pgscan_anon{sg_job=~"sourcegraph-executors-registry",sg_instance=~"docker-registry"}[$__rate_interval]) + rate(node_vmstat_pgscan_direct{sg_job=~"sourcegraph-executors-registry",sg_instance=~"docker-registry"}[$__rate_interval]) + rate(node_vmstat_pgscan_file{sg_job=~"sourcegraph-executors-registry",sg_instance=~"docker-registry"}[$__rate_interval]) + rate(node_vmstat_pgscan_kswapd{sg_job=~"sourcegraph-executors-registry",sg_instance=~"docker-registry"}[$__rate_interval])) * 100`
+Query:
 
+```
+(rate(node_vmstat_pgsteal_anon{sg_job=~"sourcegraph-executors-registry",sg_instance=~"docker-registry"}[$__rate_interval]) + rate(node_vmstat_pgsteal_direct{sg_job=~"sourcegraph-executors-registry",sg_instance=~"docker-registry"}[$__rate_interval]) + rate(node_vmstat_pgsteal_file{sg_job=~"sourcegraph-executors-registry",sg_instance=~"docker-registry"}[$__rate_interval]) + rate(node_vmstat_pgsteal_kswapd{sg_job=~"sourcegraph-executors-registry",sg_instance=~"docker-registry"}[$__rate_interval])) / (rate(node_vmstat_pgscan_anon{sg_job=~"sourcegraph-executors-registry",sg_instance=~"docker-registry"}[$__rate_interval]) + rate(node_vmstat_pgscan_direct{sg_job=~"sourcegraph-executors-registry",sg_instance=~"docker-registry"}[$__rate_interval]) + rate(node_vmstat_pgscan_file{sg_job=~"sourcegraph-executors-registry",sg_instance=~"docker-registry"}[$__rate_interval]) + rate(node_vmstat_pgscan_kswapd{sg_job=~"sourcegraph-executors-registry",sg_instance=~"docker-registry"}[$__rate_interval])) * 100
+```
 </details>
 
 <br />
@@ -24282,8 +27804,11 @@ To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100912`
 <details>
 <summary>Technical details</summary>
 
-Query: `rate(node_pressure_memory_stalled_seconds_total{sg_job=~"sourcegraph-executors-registry",sg_instance=~"docker-registry"}[$__rate_interval])`
+Query:
 
+```
+rate(node_pressure_memory_stalled_seconds_total{sg_job=~"sourcegraph-executors-registry",sg_instance=~"docker-registry"}[$__rate_interval])
+```
 </details>
 
 <br />
@@ -24302,8 +27827,11 @@ To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100920`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(label_replace(label_replace(rate(node_disk_io_time_seconds_total{sg_job=~"sourcegraph-executors-registry",sg_instance=~"docker-registry"}[$__rate_interval]), "disk", "$1", "device", "^([^d].+)"), "disk", "ignite", "device", "dm-.*")) by(sg_instance,disk) * 100`
+Query:
 
+```
+sum(label_replace(label_replace(rate(node_disk_io_time_seconds_total{sg_job=~"sourcegraph-executors-registry",sg_instance=~"docker-registry"}[$__rate_interval]), "disk", "$1", "device", "^([^d].+)"), "disk", "ignite", "device", "dm-.*")) by(sg_instance,disk) * 100
+```
 </details>
 
 <br />
@@ -24322,8 +27850,11 @@ To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100921`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(label_replace(label_replace(rate(node_disk_io_time_weighted_seconds_total{sg_job=~"sourcegraph-executors-registry",sg_instance=~"docker-registry"}[$__rate_interval]), "disk", "$1", "device", "^([^d].+)"), "disk", "ignite", "device", "dm-.*")) by(sg_instance,disk)`
+Query:
 
+```
+sum(label_replace(label_replace(rate(node_disk_io_time_weighted_seconds_total{sg_job=~"sourcegraph-executors-registry",sg_instance=~"docker-registry"}[$__rate_interval]), "disk", "$1", "device", "^([^d].+)"), "disk", "ignite", "device", "dm-.*")) by(sg_instance,disk)
+```
 </details>
 
 <br />
@@ -24342,8 +27873,11 @@ To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100922`
 <details>
 <summary>Technical details</summary>
 
-Query: `rate(node_pressure_io_stalled_seconds_total{sg_job=~"sourcegraph-executors-registry",sg_instance=~"docker-registry"}[$__rate_interval])`
+Query:
 
+```
+rate(node_pressure_io_stalled_seconds_total{sg_job=~"sourcegraph-executors-registry",sg_instance=~"docker-registry"}[$__rate_interval])
+```
 </details>
 
 <br />
@@ -24362,8 +27896,11 @@ To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100930`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(rate(node_network_receive_bytes_total{sg_job=~"sourcegraph-executors-registry",sg_instance=~"docker-registry"}[$__rate_interval])) by(sg_instance) * 8`
+Query:
 
+```
+sum(rate(node_network_receive_bytes_total{sg_job=~"sourcegraph-executors-registry",sg_instance=~"docker-registry"}[$__rate_interval])) by(sg_instance) * 8
+```
 </details>
 
 <br />
@@ -24382,8 +27919,11 @@ To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100931`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(rate(node_network_receive_drop_total{sg_job=~"sourcegraph-executors-registry",sg_instance=~"docker-registry"}[$__rate_interval])) by(sg_instance)`
+Query:
 
+```
+sum(rate(node_network_receive_drop_total{sg_job=~"sourcegraph-executors-registry",sg_instance=~"docker-registry"}[$__rate_interval])) by(sg_instance)
+```
 </details>
 
 <br />
@@ -24402,8 +27942,11 @@ To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100932`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(rate(node_network_receive_errs_total{sg_job=~"sourcegraph-executors-registry",sg_instance=~"docker-registry"}[$__rate_interval])) by(sg_instance)`
+Query:
 
+```
+sum(rate(node_network_receive_errs_total{sg_job=~"sourcegraph-executors-registry",sg_instance=~"docker-registry"}[$__rate_interval])) by(sg_instance)
+```
 </details>
 
 <br />
@@ -24422,8 +27965,11 @@ To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100940`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(rate(node_network_transmit_bytes_total{sg_job=~"sourcegraph-executors-registry",sg_instance=~"docker-registry"}[$__rate_interval])) by(sg_instance) * 8`
+Query:
 
+```
+sum(rate(node_network_transmit_bytes_total{sg_job=~"sourcegraph-executors-registry",sg_instance=~"docker-registry"}[$__rate_interval])) by(sg_instance) * 8
+```
 </details>
 
 <br />
@@ -24442,8 +27988,11 @@ To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100941`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(rate(node_network_transmit_drop_total{sg_job=~"sourcegraph-executors-registry",sg_instance=~"docker-registry"}[$__rate_interval])) by(sg_instance)`
+Query:
 
+```
+sum(rate(node_network_transmit_drop_total{sg_job=~"sourcegraph-executors-registry",sg_instance=~"docker-registry"}[$__rate_interval])) by(sg_instance)
+```
 </details>
 
 <br />
@@ -24462,8 +28011,11 @@ To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=100942`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(rate(node_network_transmit_errs_total{sg_job=~"sourcegraph-executors-registry",sg_instance=~"docker-registry"}[$__rate_interval])) by(sg_instance)`
+Query:
 
+```
+sum(rate(node_network_transmit_errs_total{sg_job=~"sourcegraph-executors-registry",sg_instance=~"docker-registry"}[$__rate_interval])) by(sg_instance)
+```
 </details>
 
 <br />
@@ -24485,8 +28037,11 @@ To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=101000`
 <details>
 <summary>Technical details</summary>
 
-Query: `max by(sg_instance) (go_goroutines{sg_job=~".*sourcegraph-executors"})`
+Query:
 
+```
+max by(sg_instance) (go_goroutines{sg_job=~".*sourcegraph-executors"})
+```
 </details>
 
 <br />
@@ -24504,8 +28059,11 @@ To see this panel, visit `/-/debug/grafana/d/executor/executor?viewPanel=101001`
 <details>
 <summary>Technical details</summary>
 
-Query: `max by(sg_instance) (go_gc_duration_seconds{sg_job=~".*sourcegraph-executors"})`
+Query:
 
+```
+max by(sg_instance) (go_gc_duration_seconds{sg_job=~".*sourcegraph-executors"})
+```
 </details>
 
 <br />
@@ -24533,8 +28091,11 @@ To see this panel, visit `/-/debug/grafana/d/containers/containers?viewPanel=100
 <details>
 <summary>Technical details</summary>
 
-Query: `cadvisor_container_memory_usage_percentage_total{name=~"^(frontend|sourcegraph-frontend|gitserver|pgsql|codeintel-db|codeinsights|precise-code-intel-worker|prometheus|redis-cache|redis-store|redis-exporter|repo-updater|searcher|symbols|syntect-server|worker|zoekt-indexserver|zoekt-webserver|indexed-search|grafana|blobstore|jaeger).*"}`
+Query:
 
+```
+cadvisor_container_memory_usage_percentage_total{name=~"^(frontend|sourcegraph-frontend|gitserver|pgsql|codeintel-db|codeinsights|precise-code-intel-worker|prometheus|redis-cache|redis-store|redis-exporter|repo-updater|searcher|symbols|syntect-server|worker|zoekt-indexserver|zoekt-webserver|indexed-search|grafana|blobstore|jaeger).*"}
+```
 </details>
 
 <br />
@@ -24554,8 +28115,11 @@ To see this panel, visit `/-/debug/grafana/d/containers/containers?viewPanel=100
 <details>
 <summary>Technical details</summary>
 
-Query: `cadvisor_container_cpu_usage_percentage_total{name=~"^(frontend|sourcegraph-frontend|gitserver|pgsql|codeintel-db|codeinsights|precise-code-intel-worker|prometheus|redis-cache|redis-store|redis-exporter|repo-updater|searcher|symbols|syntect-server|worker|zoekt-indexserver|zoekt-webserver|indexed-search|grafana|blobstore|jaeger).*"}`
+Query:
 
+```
+cadvisor_container_cpu_usage_percentage_total{name=~"^(frontend|sourcegraph-frontend|gitserver|pgsql|codeintel-db|codeinsights|precise-code-intel-worker|prometheus|redis-cache|redis-store|redis-exporter|repo-updater|searcher|symbols|syntect-server|worker|zoekt-indexserver|zoekt-webserver|indexed-search|grafana|blobstore|jaeger).*"}
+```
 </details>
 
 <br />
@@ -24577,8 +28141,11 @@ To see this panel, visit `/-/debug/grafana/d/containers/containers?viewPanel=100
 <details>
 <summary>Technical details</summary>
 
-Query: `max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^(frontend|sourcegraph-frontend|gitserver|pgsql|codeintel-db|codeinsights|precise-code-intel-worker|prometheus|redis-cache|redis-store|redis-exporter|repo-updater|searcher|symbols|syntect-server|worker|zoekt-indexserver|zoekt-webserver|indexed-search|grafana|blobstore|jaeger).*"}[5m]) >= 80`
+Query:
 
+```
+max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^(frontend|sourcegraph-frontend|gitserver|pgsql|codeintel-db|codeinsights|precise-code-intel-worker|prometheus|redis-cache|redis-store|redis-exporter|repo-updater|searcher|symbols|syntect-server|worker|zoekt-indexserver|zoekt-webserver|indexed-search|grafana|blobstore|jaeger).*"}[5m]) >= 80
+```
 </details>
 
 <br />
@@ -24598,8 +28165,11 @@ To see this panel, visit `/-/debug/grafana/d/containers/containers?viewPanel=100
 <details>
 <summary>Technical details</summary>
 
-Query: `max_over_time(cadvisor_container_cpu_usage_percentage_total{name=~"^(frontend|sourcegraph-frontend|gitserver|pgsql|codeintel-db|codeinsights|precise-code-intel-worker|prometheus|redis-cache|redis-store|redis-exporter|repo-updater|searcher|symbols|syntect-server|worker|zoekt-indexserver|zoekt-webserver|indexed-search|grafana|blobstore|jaeger).*"}[5m]) >= 80`
+Query:
 
+```
+max_over_time(cadvisor_container_cpu_usage_percentage_total{name=~"^(frontend|sourcegraph-frontend|gitserver|pgsql|codeintel-db|codeinsights|precise-code-intel-worker|prometheus|redis-cache|redis-store|redis-exporter|repo-updater|searcher|symbols|syntect-server|worker|zoekt-indexserver|zoekt-webserver|indexed-search|grafana|blobstore|jaeger).*"}[5m]) >= 80
+```
 </details>
 
 <br />
@@ -24620,8 +28190,11 @@ To see this panel, visit `/-/debug/grafana/d/containers/containers?viewPanel=100
 <details>
 <summary>Technical details</summary>
 
-Query: `max by (name) (container_oom_events_total{name=~"^(frontend|sourcegraph-frontend|gitserver|pgsql|codeintel-db|codeinsights|precise-code-intel-worker|prometheus|redis-cache|redis-store|redis-exporter|repo-updater|searcher|symbols|syntect-server|worker|zoekt-indexserver|zoekt-webserver|indexed-search|grafana|blobstore|jaeger).*"}) >= 1`
+Query:
 
+```
+max by (name) (container_oom_events_total{name=~"^(frontend|sourcegraph-frontend|gitserver|pgsql|codeintel-db|codeinsights|precise-code-intel-worker|prometheus|redis-cache|redis-store|redis-exporter|repo-updater|searcher|symbols|syntect-server|worker|zoekt-indexserver|zoekt-webserver|indexed-search|grafana|blobstore|jaeger).*"}) >= 1
+```
 </details>
 
 <br />
@@ -24642,8 +28215,11 @@ To see this panel, visit `/-/debug/grafana/d/containers/containers?viewPanel=100
 <details>
 <summary>Technical details</summary>
 
-Query: `count by(name) ((time() - container_last_seen{name=~"^(frontend|sourcegraph-frontend|gitserver|pgsql|codeintel-db|codeinsights|precise-code-intel-worker|prometheus|redis-cache|redis-store|redis-exporter|repo-updater|searcher|symbols|syntect-server|worker|zoekt-indexserver|zoekt-webserver|indexed-search|grafana|blobstore|jaeger).*"}) > 60)`
+Query:
 
+```
+count by(name) ((time() - container_last_seen{name=~"^(frontend|sourcegraph-frontend|gitserver|pgsql|codeintel-db|codeinsights|precise-code-intel-worker|prometheus|redis-cache|redis-store|redis-exporter|repo-updater|searcher|symbols|syntect-server|worker|zoekt-indexserver|zoekt-webserver|indexed-search|grafana|blobstore|jaeger).*"}) > 60)
+```
 </details>
 
 <br />
@@ -24669,8 +28245,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-autoindexing/codeintel-au
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_dbstore_indexes_inserted[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_dbstore_indexes_inserted[5m]))
+```
 </details>
 
 <br />
@@ -24688,8 +28267,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-autoindexing/codeintel-au
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_autoindexing_errors_total{op='HandleIndexSchedule',job=~"^${source:regex}.*"}[10m])) / (sum(increase(src_codeintel_autoindexing_total{op='HandleIndexSchedule',job=~"^${source:regex}.*"}[10m])) + sum(increase(src_codeintel_autoindexing_errors_total{op='HandleIndexSchedule',job=~"^${source:regex}.*"}[10m]))) * 100`
+Query:
 
+```
+sum(increase(src_codeintel_autoindexing_errors_total{op='HandleIndexSchedule',job=~"^${source:regex}.*"}[10m])) / (sum(increase(src_codeintel_autoindexing_total{op='HandleIndexSchedule',job=~"^${source:regex}.*"}[10m])) + sum(increase(src_codeintel_autoindexing_errors_total{op='HandleIndexSchedule',job=~"^${source:regex}.*"}[10m]))) * 100
+```
 </details>
 
 <br />
@@ -24707,8 +28289,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-autoindexing/codeintel-au
 <details>
 <summary>Technical details</summary>
 
-Query: `max by (queue)(src_executor_total{queue=~"codeintel",job=~"^(executor|sourcegraph-code-intel-indexers|executor-batches|frontend|sourcegraph-frontend|worker|sourcegraph-executors).*"})`
+Query:
 
+```
+max by (queue)(src_executor_total{queue=~"codeintel",job=~"^(executor|sourcegraph-code-intel-indexers|executor-batches|frontend|sourcegraph-frontend|worker|sourcegraph-executors).*"})
+```
 </details>
 
 <br />
@@ -24732,8 +28317,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-autoindexing/codeintel-au
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (queue)(increase(src_executor_total{queue=~"codeintel",job=~"^(executor|sourcegraph-code-intel-indexers|executor-batches|frontend|sourcegraph-frontend|worker|sourcegraph-executors).*"}[30m])) / sum by (queue)(increase(src_executor_processor_total{queue=~"codeintel",job=~"^(executor|sourcegraph-code-intel-indexers|executor-batches|frontend|sourcegraph-frontend|worker|sourcegraph-executors).*"}[30m]))`
+Query:
 
+```
+sum by (queue)(increase(src_executor_total{queue=~"codeintel",job=~"^(executor|sourcegraph-code-intel-indexers|executor-batches|frontend|sourcegraph-frontend|worker|sourcegraph-executors).*"}[30m])) / sum by (queue)(increase(src_executor_processor_total{queue=~"codeintel",job=~"^(executor|sourcegraph-code-intel-indexers|executor-batches|frontend|sourcegraph-frontend|worker|sourcegraph-executors).*"}[30m]))
+```
 </details>
 
 <br />
@@ -24751,8 +28339,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-autoindexing/codeintel-au
 <details>
 <summary>Technical details</summary>
 
-Query: `max by (queue)(src_executor_queued_duration_seconds_total{queue=~"codeintel",job=~"^(executor|sourcegraph-code-intel-indexers|executor-batches|frontend|sourcegraph-frontend|worker|sourcegraph-executors).*"})`
+Query:
 
+```
+max by (queue)(src_executor_queued_duration_seconds_total{queue=~"codeintel",job=~"^(executor|sourcegraph-code-intel-indexers|executor-batches|frontend|sourcegraph-frontend|worker|sourcegraph-executors).*"})
+```
 </details>
 
 <br />
@@ -24772,8 +28363,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-autoindexing/codeintel-au
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_autoindexing_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_autoindexing_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -24791,8 +28385,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-autoindexing/codeintel-au
 <details>
 <summary>Technical details</summary>
 
-Query: `sum  by (le)(rate(src_codeintel_autoindexing_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum  by (le)(rate(src_codeintel_autoindexing_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -24810,8 +28407,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-autoindexing/codeintel-au
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_autoindexing_errors_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_autoindexing_errors_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -24829,8 +28429,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-autoindexing/codeintel-au
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_autoindexing_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum(increase(src_codeintel_autoindexing_total{job=~"^${source:regex}.*"}[5m])) + sum(increase(src_codeintel_autoindexing_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100`
+Query:
 
+```
+sum(increase(src_codeintel_autoindexing_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum(increase(src_codeintel_autoindexing_total{job=~"^${source:regex}.*"}[5m])) + sum(increase(src_codeintel_autoindexing_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -24848,8 +28451,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-autoindexing/codeintel-au
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_autoindexing_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_autoindexing_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -24867,8 +28473,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-autoindexing/codeintel-au
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_autoindexing_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m])))`
+Query:
 
+```
+histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_autoindexing_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m])))
+```
 </details>
 
 <br />
@@ -24886,8 +28495,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-autoindexing/codeintel-au
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_autoindexing_errors_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_autoindexing_errors_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -24905,8 +28517,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-autoindexing/codeintel-au
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_autoindexing_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum by (op)(increase(src_codeintel_autoindexing_total{job=~"^${source:regex}.*"}[5m])) + sum by (op)(increase(src_codeintel_autoindexing_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_autoindexing_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum by (op)(increase(src_codeintel_autoindexing_total{job=~"^${source:regex}.*"}[5m])) + sum by (op)(increase(src_codeintel_autoindexing_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -24926,8 +28541,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-autoindexing/codeintel-au
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_autoindexing_transport_graphql_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_autoindexing_transport_graphql_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -24945,8 +28563,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-autoindexing/codeintel-au
 <details>
 <summary>Technical details</summary>
 
-Query: `sum  by (le)(rate(src_codeintel_autoindexing_transport_graphql_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum  by (le)(rate(src_codeintel_autoindexing_transport_graphql_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -24964,8 +28585,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-autoindexing/codeintel-au
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_autoindexing_transport_graphql_errors_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_autoindexing_transport_graphql_errors_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -24983,8 +28607,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-autoindexing/codeintel-au
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_autoindexing_transport_graphql_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum(increase(src_codeintel_autoindexing_transport_graphql_total{job=~"^${source:regex}.*"}[5m])) + sum(increase(src_codeintel_autoindexing_transport_graphql_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100`
+Query:
 
+```
+sum(increase(src_codeintel_autoindexing_transport_graphql_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum(increase(src_codeintel_autoindexing_transport_graphql_total{job=~"^${source:regex}.*"}[5m])) + sum(increase(src_codeintel_autoindexing_transport_graphql_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -25002,8 +28629,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-autoindexing/codeintel-au
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_autoindexing_transport_graphql_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_autoindexing_transport_graphql_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -25021,8 +28651,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-autoindexing/codeintel-au
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_autoindexing_transport_graphql_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m])))`
+Query:
 
+```
+histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_autoindexing_transport_graphql_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m])))
+```
 </details>
 
 <br />
@@ -25040,8 +28673,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-autoindexing/codeintel-au
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_autoindexing_transport_graphql_errors_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_autoindexing_transport_graphql_errors_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -25059,8 +28695,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-autoindexing/codeintel-au
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_autoindexing_transport_graphql_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum by (op)(increase(src_codeintel_autoindexing_transport_graphql_total{job=~"^${source:regex}.*"}[5m])) + sum by (op)(increase(src_codeintel_autoindexing_transport_graphql_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_autoindexing_transport_graphql_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum by (op)(increase(src_codeintel_autoindexing_transport_graphql_total{job=~"^${source:regex}.*"}[5m])) + sum by (op)(increase(src_codeintel_autoindexing_transport_graphql_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -25080,8 +28719,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-autoindexing/codeintel-au
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_autoindexing_store_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_autoindexing_store_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -25099,8 +28741,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-autoindexing/codeintel-au
 <details>
 <summary>Technical details</summary>
 
-Query: `sum  by (le)(rate(src_codeintel_autoindexing_store_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum  by (le)(rate(src_codeintel_autoindexing_store_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -25118,8 +28763,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-autoindexing/codeintel-au
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_autoindexing_store_errors_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_autoindexing_store_errors_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -25137,8 +28785,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-autoindexing/codeintel-au
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_autoindexing_store_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum(increase(src_codeintel_autoindexing_store_total{job=~"^${source:regex}.*"}[5m])) + sum(increase(src_codeintel_autoindexing_store_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100`
+Query:
 
+```
+sum(increase(src_codeintel_autoindexing_store_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum(increase(src_codeintel_autoindexing_store_total{job=~"^${source:regex}.*"}[5m])) + sum(increase(src_codeintel_autoindexing_store_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -25156,8 +28807,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-autoindexing/codeintel-au
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_autoindexing_store_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_autoindexing_store_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -25175,8 +28829,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-autoindexing/codeintel-au
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_autoindexing_store_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m])))`
+Query:
 
+```
+histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_autoindexing_store_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m])))
+```
 </details>
 
 <br />
@@ -25194,8 +28851,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-autoindexing/codeintel-au
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_autoindexing_store_errors_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_autoindexing_store_errors_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -25213,8 +28873,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-autoindexing/codeintel-au
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_autoindexing_store_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum by (op)(increase(src_codeintel_autoindexing_store_total{job=~"^${source:regex}.*"}[5m])) + sum by (op)(increase(src_codeintel_autoindexing_store_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_autoindexing_store_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum by (op)(increase(src_codeintel_autoindexing_store_total{job=~"^${source:regex}.*"}[5m])) + sum by (op)(increase(src_codeintel_autoindexing_store_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -25234,8 +28897,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-autoindexing/codeintel-au
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_autoindexing_background_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_autoindexing_background_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -25253,8 +28919,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-autoindexing/codeintel-au
 <details>
 <summary>Technical details</summary>
 
-Query: `sum  by (le)(rate(src_codeintel_autoindexing_background_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum  by (le)(rate(src_codeintel_autoindexing_background_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -25272,8 +28941,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-autoindexing/codeintel-au
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_autoindexing_background_errors_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_autoindexing_background_errors_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -25291,8 +28963,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-autoindexing/codeintel-au
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_autoindexing_background_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum(increase(src_codeintel_autoindexing_background_total{job=~"^${source:regex}.*"}[5m])) + sum(increase(src_codeintel_autoindexing_background_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100`
+Query:
 
+```
+sum(increase(src_codeintel_autoindexing_background_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum(increase(src_codeintel_autoindexing_background_total{job=~"^${source:regex}.*"}[5m])) + sum(increase(src_codeintel_autoindexing_background_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -25310,8 +28985,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-autoindexing/codeintel-au
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_autoindexing_background_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_autoindexing_background_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -25329,8 +29007,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-autoindexing/codeintel-au
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_autoindexing_background_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m])))`
+Query:
 
+```
+histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_autoindexing_background_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m])))
+```
 </details>
 
 <br />
@@ -25348,8 +29029,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-autoindexing/codeintel-au
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_autoindexing_background_errors_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_autoindexing_background_errors_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -25367,8 +29051,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-autoindexing/codeintel-au
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_autoindexing_background_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum by (op)(increase(src_codeintel_autoindexing_background_total{job=~"^${source:regex}.*"}[5m])) + sum by (op)(increase(src_codeintel_autoindexing_background_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_autoindexing_background_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum by (op)(increase(src_codeintel_autoindexing_background_total{job=~"^${source:regex}.*"}[5m])) + sum by (op)(increase(src_codeintel_autoindexing_background_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -25388,8 +29075,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-autoindexing/codeintel-au
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_autoindexing_inference_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_autoindexing_inference_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -25407,8 +29097,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-autoindexing/codeintel-au
 <details>
 <summary>Technical details</summary>
 
-Query: `sum  by (le)(rate(src_codeintel_autoindexing_inference_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum  by (le)(rate(src_codeintel_autoindexing_inference_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -25426,8 +29119,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-autoindexing/codeintel-au
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_autoindexing_inference_errors_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_autoindexing_inference_errors_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -25445,8 +29141,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-autoindexing/codeintel-au
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_autoindexing_inference_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum(increase(src_codeintel_autoindexing_inference_total{job=~"^${source:regex}.*"}[5m])) + sum(increase(src_codeintel_autoindexing_inference_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100`
+Query:
 
+```
+sum(increase(src_codeintel_autoindexing_inference_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum(increase(src_codeintel_autoindexing_inference_total{job=~"^${source:regex}.*"}[5m])) + sum(increase(src_codeintel_autoindexing_inference_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -25464,8 +29163,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-autoindexing/codeintel-au
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_autoindexing_inference_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_autoindexing_inference_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -25483,8 +29185,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-autoindexing/codeintel-au
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_autoindexing_inference_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m])))`
+Query:
 
+```
+histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_autoindexing_inference_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m])))
+```
 </details>
 
 <br />
@@ -25502,8 +29207,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-autoindexing/codeintel-au
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_autoindexing_inference_errors_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_autoindexing_inference_errors_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -25521,8 +29229,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-autoindexing/codeintel-au
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_autoindexing_inference_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum by (op)(increase(src_codeintel_autoindexing_inference_total{job=~"^${source:regex}.*"}[5m])) + sum by (op)(increase(src_codeintel_autoindexing_inference_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_autoindexing_inference_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum by (op)(increase(src_codeintel_autoindexing_inference_total{job=~"^${source:regex}.*"}[5m])) + sum by (op)(increase(src_codeintel_autoindexing_inference_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -25542,8 +29253,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-autoindexing/codeintel-au
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_luasandbox_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_luasandbox_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -25561,8 +29275,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-autoindexing/codeintel-au
 <details>
 <summary>Technical details</summary>
 
-Query: `sum  by (le)(rate(src_luasandbox_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum  by (le)(rate(src_luasandbox_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -25580,8 +29297,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-autoindexing/codeintel-au
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_luasandbox_errors_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_luasandbox_errors_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -25599,8 +29319,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-autoindexing/codeintel-au
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_luasandbox_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum(increase(src_luasandbox_total{job=~"^${source:regex}.*"}[5m])) + sum(increase(src_luasandbox_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100`
+Query:
 
+```
+sum(increase(src_luasandbox_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum(increase(src_luasandbox_total{job=~"^${source:regex}.*"}[5m])) + sum(increase(src_luasandbox_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -25618,8 +29341,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-autoindexing/codeintel-au
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_luasandbox_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_luasandbox_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -25637,8 +29363,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-autoindexing/codeintel-au
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.99, sum  by (le,op)(rate(src_luasandbox_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m])))`
+Query:
 
+```
+histogram_quantile(0.99, sum  by (le,op)(rate(src_luasandbox_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m])))
+```
 </details>
 
 <br />
@@ -25656,8 +29385,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-autoindexing/codeintel-au
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_luasandbox_errors_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_luasandbox_errors_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -25675,8 +29407,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-autoindexing/codeintel-au
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_luasandbox_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum by (op)(increase(src_luasandbox_total{job=~"^${source:regex}.*"}[5m])) + sum by (op)(increase(src_luasandbox_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100`
+Query:
 
+```
+sum by (op)(increase(src_luasandbox_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum by (op)(increase(src_luasandbox_total{job=~"^${source:regex}.*"}[5m])) + sum by (op)(increase(src_luasandbox_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -25698,8 +29433,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-autoindexing/codeintel-au
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_autoindexing_janitor_unknown_repository_records_scanned_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_autoindexing_janitor_unknown_repository_records_scanned_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -25719,8 +29457,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-autoindexing/codeintel-au
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_autoindexing_janitor_unknown_repository_records_altered_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_autoindexing_janitor_unknown_repository_records_altered_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -25738,8 +29479,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-autoindexing/codeintel-au
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_autoindexing_janitor_unknown_repository_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_autoindexing_janitor_unknown_repository_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -25757,8 +29501,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-autoindexing/codeintel-au
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_autoindexing_janitor_unknown_repository_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m])))`
+Query:
 
+```
+histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_autoindexing_janitor_unknown_repository_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m])))
+```
 </details>
 
 <br />
@@ -25776,8 +29523,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-autoindexing/codeintel-au
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_autoindexing_janitor_unknown_repository_errors_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_autoindexing_janitor_unknown_repository_errors_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -25795,8 +29545,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-autoindexing/codeintel-au
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_autoindexing_janitor_unknown_repository_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum by (op)(increase(src_codeintel_autoindexing_janitor_unknown_repository_total{job=~"^${source:regex}.*"}[5m])) + sum by (op)(increase(src_codeintel_autoindexing_janitor_unknown_repository_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_autoindexing_janitor_unknown_repository_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum by (op)(increase(src_codeintel_autoindexing_janitor_unknown_repository_total{job=~"^${source:regex}.*"}[5m])) + sum by (op)(increase(src_codeintel_autoindexing_janitor_unknown_repository_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -25818,8 +29571,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-autoindexing/codeintel-au
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_autoindexing_janitor_unknown_commit_records_scanned_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_autoindexing_janitor_unknown_commit_records_scanned_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -25839,8 +29595,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-autoindexing/codeintel-au
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_autoindexing_janitor_unknown_commit_records_altered_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_autoindexing_janitor_unknown_commit_records_altered_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -25858,8 +29617,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-autoindexing/codeintel-au
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_autoindexing_janitor_unknown_commit_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_autoindexing_janitor_unknown_commit_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -25877,8 +29639,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-autoindexing/codeintel-au
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_autoindexing_janitor_unknown_commit_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m])))`
+Query:
 
+```
+histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_autoindexing_janitor_unknown_commit_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m])))
+```
 </details>
 
 <br />
@@ -25896,8 +29661,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-autoindexing/codeintel-au
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_autoindexing_janitor_unknown_commit_errors_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_autoindexing_janitor_unknown_commit_errors_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -25915,8 +29683,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-autoindexing/codeintel-au
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_autoindexing_janitor_unknown_commit_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum by (op)(increase(src_codeintel_autoindexing_janitor_unknown_commit_total{job=~"^${source:regex}.*"}[5m])) + sum by (op)(increase(src_codeintel_autoindexing_janitor_unknown_commit_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_autoindexing_janitor_unknown_commit_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum by (op)(increase(src_codeintel_autoindexing_janitor_unknown_commit_total{job=~"^${source:regex}.*"}[5m])) + sum by (op)(increase(src_codeintel_autoindexing_janitor_unknown_commit_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -25938,8 +29709,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-autoindexing/codeintel-au
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_autoindexing_janitor_expired_records_scanned_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_autoindexing_janitor_expired_records_scanned_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -25959,8 +29733,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-autoindexing/codeintel-au
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_autoindexing_janitor_expired_records_altered_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_autoindexing_janitor_expired_records_altered_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -25978,8 +29755,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-autoindexing/codeintel-au
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_autoindexing_janitor_expired_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_autoindexing_janitor_expired_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -25997,8 +29777,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-autoindexing/codeintel-au
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_autoindexing_janitor_expired_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m])))`
+Query:
 
+```
+histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_autoindexing_janitor_expired_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m])))
+```
 </details>
 
 <br />
@@ -26016,8 +29799,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-autoindexing/codeintel-au
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_autoindexing_janitor_expired_errors_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_autoindexing_janitor_expired_errors_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -26035,8 +29821,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-autoindexing/codeintel-au
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_autoindexing_janitor_expired_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum by (op)(increase(src_codeintel_autoindexing_janitor_expired_total{job=~"^${source:regex}.*"}[5m])) + sum by (op)(increase(src_codeintel_autoindexing_janitor_expired_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_autoindexing_janitor_expired_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum by (op)(increase(src_codeintel_autoindexing_janitor_expired_total{job=~"^${source:regex}.*"}[5m])) + sum by (op)(increase(src_codeintel_autoindexing_janitor_expired_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -26062,8 +29851,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-codenav/codeintel-codenav
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_codenav_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_codenav_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -26081,8 +29873,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-codenav/codeintel-codenav
 <details>
 <summary>Technical details</summary>
 
-Query: `sum  by (le)(rate(src_codeintel_codenav_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum  by (le)(rate(src_codeintel_codenav_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -26100,8 +29895,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-codenav/codeintel-codenav
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_codenav_errors_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_codenav_errors_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -26119,8 +29917,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-codenav/codeintel-codenav
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_codenav_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum(increase(src_codeintel_codenav_total{job=~"^${source:regex}.*"}[5m])) + sum(increase(src_codeintel_codenav_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100`
+Query:
 
+```
+sum(increase(src_codeintel_codenav_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum(increase(src_codeintel_codenav_total{job=~"^${source:regex}.*"}[5m])) + sum(increase(src_codeintel_codenav_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -26138,8 +29939,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-codenav/codeintel-codenav
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_codenav_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_codenav_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -26157,8 +29961,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-codenav/codeintel-codenav
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_codenav_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m])))`
+Query:
 
+```
+histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_codenav_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m])))
+```
 </details>
 
 <br />
@@ -26176,8 +29983,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-codenav/codeintel-codenav
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_codenav_errors_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_codenav_errors_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -26195,8 +30005,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-codenav/codeintel-codenav
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_codenav_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum by (op)(increase(src_codeintel_codenav_total{job=~"^${source:regex}.*"}[5m])) + sum by (op)(increase(src_codeintel_codenav_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_codenav_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum by (op)(increase(src_codeintel_codenav_total{job=~"^${source:regex}.*"}[5m])) + sum by (op)(increase(src_codeintel_codenav_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -26216,8 +30029,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-codenav/codeintel-codenav
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_codenav_lsifstore_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_codenav_lsifstore_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -26235,8 +30051,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-codenav/codeintel-codenav
 <details>
 <summary>Technical details</summary>
 
-Query: `sum  by (le)(rate(src_codeintel_codenav_lsifstore_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum  by (le)(rate(src_codeintel_codenav_lsifstore_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -26254,8 +30073,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-codenav/codeintel-codenav
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_codenav_lsifstore_errors_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_codenav_lsifstore_errors_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -26273,8 +30095,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-codenav/codeintel-codenav
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_codenav_lsifstore_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum(increase(src_codeintel_codenav_lsifstore_total{job=~"^${source:regex}.*"}[5m])) + sum(increase(src_codeintel_codenav_lsifstore_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100`
+Query:
 
+```
+sum(increase(src_codeintel_codenav_lsifstore_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum(increase(src_codeintel_codenav_lsifstore_total{job=~"^${source:regex}.*"}[5m])) + sum(increase(src_codeintel_codenav_lsifstore_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -26292,8 +30117,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-codenav/codeintel-codenav
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_codenav_lsifstore_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_codenav_lsifstore_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -26311,8 +30139,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-codenav/codeintel-codenav
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_codenav_lsifstore_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m])))`
+Query:
 
+```
+histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_codenav_lsifstore_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m])))
+```
 </details>
 
 <br />
@@ -26330,8 +30161,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-codenav/codeintel-codenav
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_codenav_lsifstore_errors_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_codenav_lsifstore_errors_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -26349,8 +30183,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-codenav/codeintel-codenav
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_codenav_lsifstore_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum by (op)(increase(src_codeintel_codenav_lsifstore_total{job=~"^${source:regex}.*"}[5m])) + sum by (op)(increase(src_codeintel_codenav_lsifstore_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_codenav_lsifstore_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum by (op)(increase(src_codeintel_codenav_lsifstore_total{job=~"^${source:regex}.*"}[5m])) + sum by (op)(increase(src_codeintel_codenav_lsifstore_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -26370,8 +30207,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-codenav/codeintel-codenav
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_codenav_transport_graphql_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_codenav_transport_graphql_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -26389,8 +30229,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-codenav/codeintel-codenav
 <details>
 <summary>Technical details</summary>
 
-Query: `sum  by (le)(rate(src_codeintel_codenav_transport_graphql_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum  by (le)(rate(src_codeintel_codenav_transport_graphql_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -26408,8 +30251,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-codenav/codeintel-codenav
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_codenav_transport_graphql_errors_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_codenav_transport_graphql_errors_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -26427,8 +30273,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-codenav/codeintel-codenav
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_codenav_transport_graphql_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum(increase(src_codeintel_codenav_transport_graphql_total{job=~"^${source:regex}.*"}[5m])) + sum(increase(src_codeintel_codenav_transport_graphql_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100`
+Query:
 
+```
+sum(increase(src_codeintel_codenav_transport_graphql_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum(increase(src_codeintel_codenav_transport_graphql_total{job=~"^${source:regex}.*"}[5m])) + sum(increase(src_codeintel_codenav_transport_graphql_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -26446,8 +30295,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-codenav/codeintel-codenav
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_codenav_transport_graphql_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_codenav_transport_graphql_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -26465,8 +30317,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-codenav/codeintel-codenav
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_codenav_transport_graphql_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m])))`
+Query:
 
+```
+histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_codenav_transport_graphql_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m])))
+```
 </details>
 
 <br />
@@ -26484,8 +30339,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-codenav/codeintel-codenav
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_codenav_transport_graphql_errors_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_codenav_transport_graphql_errors_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -26503,8 +30361,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-codenav/codeintel-codenav
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_codenav_transport_graphql_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum by (op)(increase(src_codeintel_codenav_transport_graphql_total{job=~"^${source:regex}.*"}[5m])) + sum by (op)(increase(src_codeintel_codenav_transport_graphql_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_codenav_transport_graphql_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum by (op)(increase(src_codeintel_codenav_transport_graphql_total{job=~"^${source:regex}.*"}[5m])) + sum by (op)(increase(src_codeintel_codenav_transport_graphql_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -26524,8 +30385,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-codenav/codeintel-codenav
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_codenav_store_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_codenav_store_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -26543,8 +30407,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-codenav/codeintel-codenav
 <details>
 <summary>Technical details</summary>
 
-Query: `sum  by (le)(rate(src_codeintel_codenav_store_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum  by (le)(rate(src_codeintel_codenav_store_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -26562,8 +30429,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-codenav/codeintel-codenav
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_codenav_store_errors_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_codenav_store_errors_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -26581,8 +30451,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-codenav/codeintel-codenav
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_codenav_store_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum(increase(src_codeintel_codenav_store_total{job=~"^${source:regex}.*"}[5m])) + sum(increase(src_codeintel_codenav_store_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100`
+Query:
 
+```
+sum(increase(src_codeintel_codenav_store_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum(increase(src_codeintel_codenav_store_total{job=~"^${source:regex}.*"}[5m])) + sum(increase(src_codeintel_codenav_store_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -26600,8 +30473,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-codenav/codeintel-codenav
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_codenav_store_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_codenav_store_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -26619,8 +30495,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-codenav/codeintel-codenav
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_codenav_store_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m])))`
+Query:
 
+```
+histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_codenav_store_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m])))
+```
 </details>
 
 <br />
@@ -26638,8 +30517,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-codenav/codeintel-codenav
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_codenav_store_errors_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_codenav_store_errors_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -26657,8 +30539,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-codenav/codeintel-codenav
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_codenav_store_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum by (op)(increase(src_codeintel_codenav_store_total{job=~"^${source:regex}.*"}[5m])) + sum by (op)(increase(src_codeintel_codenav_store_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_codenav_store_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum by (op)(increase(src_codeintel_codenav_store_total{job=~"^${source:regex}.*"}[5m])) + sum by (op)(increase(src_codeintel_codenav_store_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -26684,8 +30569,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-policies/codeintel-polici
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_policies_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_policies_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -26703,8 +30591,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-policies/codeintel-polici
 <details>
 <summary>Technical details</summary>
 
-Query: `sum  by (le)(rate(src_codeintel_policies_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum  by (le)(rate(src_codeintel_policies_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -26722,8 +30613,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-policies/codeintel-polici
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_policies_errors_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_policies_errors_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -26741,8 +30635,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-policies/codeintel-polici
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_policies_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum(increase(src_codeintel_policies_total{job=~"^${source:regex}.*"}[5m])) + sum(increase(src_codeintel_policies_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100`
+Query:
 
+```
+sum(increase(src_codeintel_policies_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum(increase(src_codeintel_policies_total{job=~"^${source:regex}.*"}[5m])) + sum(increase(src_codeintel_policies_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -26760,8 +30657,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-policies/codeintel-polici
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_policies_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_policies_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -26779,8 +30679,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-policies/codeintel-polici
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_policies_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m])))`
+Query:
 
+```
+histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_policies_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m])))
+```
 </details>
 
 <br />
@@ -26798,8 +30701,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-policies/codeintel-polici
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_policies_errors_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_policies_errors_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -26817,8 +30723,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-policies/codeintel-polici
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_policies_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum by (op)(increase(src_codeintel_policies_total{job=~"^${source:regex}.*"}[5m])) + sum by (op)(increase(src_codeintel_policies_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_policies_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum by (op)(increase(src_codeintel_policies_total{job=~"^${source:regex}.*"}[5m])) + sum by (op)(increase(src_codeintel_policies_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -26838,8 +30747,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-policies/codeintel-polici
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_policies_store_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_policies_store_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -26857,8 +30769,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-policies/codeintel-polici
 <details>
 <summary>Technical details</summary>
 
-Query: `sum  by (le)(rate(src_codeintel_policies_store_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum  by (le)(rate(src_codeintel_policies_store_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -26876,8 +30791,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-policies/codeintel-polici
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_policies_store_errors_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_policies_store_errors_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -26895,8 +30813,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-policies/codeintel-polici
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_policies_store_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum(increase(src_codeintel_policies_store_total{job=~"^${source:regex}.*"}[5m])) + sum(increase(src_codeintel_policies_store_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100`
+Query:
 
+```
+sum(increase(src_codeintel_policies_store_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum(increase(src_codeintel_policies_store_total{job=~"^${source:regex}.*"}[5m])) + sum(increase(src_codeintel_policies_store_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -26914,8 +30835,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-policies/codeintel-polici
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_policies_store_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_policies_store_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -26933,8 +30857,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-policies/codeintel-polici
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_policies_store_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m])))`
+Query:
 
+```
+histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_policies_store_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m])))
+```
 </details>
 
 <br />
@@ -26952,8 +30879,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-policies/codeintel-polici
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_policies_store_errors_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_policies_store_errors_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -26971,8 +30901,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-policies/codeintel-polici
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_policies_store_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum by (op)(increase(src_codeintel_policies_store_total{job=~"^${source:regex}.*"}[5m])) + sum by (op)(increase(src_codeintel_policies_store_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_policies_store_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum by (op)(increase(src_codeintel_policies_store_total{job=~"^${source:regex}.*"}[5m])) + sum by (op)(increase(src_codeintel_policies_store_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -26992,8 +30925,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-policies/codeintel-polici
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_policies_transport_graphql_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_policies_transport_graphql_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -27011,8 +30947,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-policies/codeintel-polici
 <details>
 <summary>Technical details</summary>
 
-Query: `sum  by (le)(rate(src_codeintel_policies_transport_graphql_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum  by (le)(rate(src_codeintel_policies_transport_graphql_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -27030,8 +30969,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-policies/codeintel-polici
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_policies_transport_graphql_errors_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_policies_transport_graphql_errors_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -27049,8 +30991,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-policies/codeintel-polici
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_policies_transport_graphql_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum(increase(src_codeintel_policies_transport_graphql_total{job=~"^${source:regex}.*"}[5m])) + sum(increase(src_codeintel_policies_transport_graphql_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100`
+Query:
 
+```
+sum(increase(src_codeintel_policies_transport_graphql_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum(increase(src_codeintel_policies_transport_graphql_total{job=~"^${source:regex}.*"}[5m])) + sum(increase(src_codeintel_policies_transport_graphql_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -27068,8 +31013,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-policies/codeintel-polici
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_policies_transport_graphql_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_policies_transport_graphql_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -27087,8 +31035,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-policies/codeintel-polici
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_policies_transport_graphql_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m])))`
+Query:
 
+```
+histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_policies_transport_graphql_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m])))
+```
 </details>
 
 <br />
@@ -27106,8 +31057,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-policies/codeintel-polici
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_policies_transport_graphql_errors_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_policies_transport_graphql_errors_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -27125,8 +31079,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-policies/codeintel-polici
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_policies_transport_graphql_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum by (op)(increase(src_codeintel_policies_transport_graphql_total{job=~"^${source:regex}.*"}[5m])) + sum by (op)(increase(src_codeintel_policies_transport_graphql_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_policies_transport_graphql_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum by (op)(increase(src_codeintel_policies_transport_graphql_total{job=~"^${source:regex}.*"}[5m])) + sum by (op)(increase(src_codeintel_policies_transport_graphql_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -27148,8 +31105,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-policies/codeintel-polici
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_background_policies_updated_total_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_background_policies_updated_total_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -27175,8 +31135,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-ranking/codeintel-ranking
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_ranking_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_ranking_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -27194,8 +31157,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-ranking/codeintel-ranking
 <details>
 <summary>Technical details</summary>
 
-Query: `sum  by (le)(rate(src_codeintel_ranking_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum  by (le)(rate(src_codeintel_ranking_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -27213,8 +31179,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-ranking/codeintel-ranking
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_ranking_errors_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_ranking_errors_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -27232,8 +31201,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-ranking/codeintel-ranking
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_ranking_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum(increase(src_codeintel_ranking_total{job=~"^${source:regex}.*"}[5m])) + sum(increase(src_codeintel_ranking_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100`
+Query:
 
+```
+sum(increase(src_codeintel_ranking_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum(increase(src_codeintel_ranking_total{job=~"^${source:regex}.*"}[5m])) + sum(increase(src_codeintel_ranking_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -27251,8 +31223,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-ranking/codeintel-ranking
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_ranking_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_ranking_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -27270,8 +31245,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-ranking/codeintel-ranking
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_ranking_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m])))`
+Query:
 
+```
+histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_ranking_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m])))
+```
 </details>
 
 <br />
@@ -27289,8 +31267,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-ranking/codeintel-ranking
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_ranking_errors_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_ranking_errors_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -27308,8 +31289,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-ranking/codeintel-ranking
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_ranking_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum by (op)(increase(src_codeintel_ranking_total{job=~"^${source:regex}.*"}[5m])) + sum by (op)(increase(src_codeintel_ranking_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_ranking_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum by (op)(increase(src_codeintel_ranking_total{job=~"^${source:regex}.*"}[5m])) + sum by (op)(increase(src_codeintel_ranking_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -27329,8 +31313,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-ranking/codeintel-ranking
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_ranking_store_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_ranking_store_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -27348,8 +31335,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-ranking/codeintel-ranking
 <details>
 <summary>Technical details</summary>
 
-Query: `sum  by (le)(rate(src_codeintel_ranking_store_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum  by (le)(rate(src_codeintel_ranking_store_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -27367,8 +31357,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-ranking/codeintel-ranking
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_ranking_store_errors_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_ranking_store_errors_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -27386,8 +31379,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-ranking/codeintel-ranking
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_ranking_store_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum(increase(src_codeintel_ranking_store_total{job=~"^${source:regex}.*"}[5m])) + sum(increase(src_codeintel_ranking_store_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100`
+Query:
 
+```
+sum(increase(src_codeintel_ranking_store_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum(increase(src_codeintel_ranking_store_total{job=~"^${source:regex}.*"}[5m])) + sum(increase(src_codeintel_ranking_store_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -27405,8 +31401,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-ranking/codeintel-ranking
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_ranking_store_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_ranking_store_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -27424,8 +31423,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-ranking/codeintel-ranking
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_ranking_store_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m])))`
+Query:
 
+```
+histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_ranking_store_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m])))
+```
 </details>
 
 <br />
@@ -27443,8 +31445,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-ranking/codeintel-ranking
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_ranking_store_errors_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_ranking_store_errors_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -27462,8 +31467,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-ranking/codeintel-ranking
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_ranking_store_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum by (op)(increase(src_codeintel_ranking_store_total{job=~"^${source:regex}.*"}[5m])) + sum by (op)(increase(src_codeintel_ranking_store_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_ranking_store_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum by (op)(increase(src_codeintel_ranking_store_total{job=~"^${source:regex}.*"}[5m])) + sum by (op)(increase(src_codeintel_ranking_store_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -27483,8 +31491,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-ranking/codeintel-ranking
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_ranking_lsifstore_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_ranking_lsifstore_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -27502,8 +31513,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-ranking/codeintel-ranking
 <details>
 <summary>Technical details</summary>
 
-Query: `sum  by (le)(rate(src_codeintel_ranking_lsifstore_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum  by (le)(rate(src_codeintel_ranking_lsifstore_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -27521,8 +31535,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-ranking/codeintel-ranking
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_ranking_lsifstore_errors_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_ranking_lsifstore_errors_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -27540,8 +31557,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-ranking/codeintel-ranking
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_ranking_lsifstore_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum(increase(src_codeintel_ranking_lsifstore_total{job=~"^${source:regex}.*"}[5m])) + sum(increase(src_codeintel_ranking_lsifstore_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100`
+Query:
 
+```
+sum(increase(src_codeintel_ranking_lsifstore_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum(increase(src_codeintel_ranking_lsifstore_total{job=~"^${source:regex}.*"}[5m])) + sum(increase(src_codeintel_ranking_lsifstore_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -27559,8 +31579,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-ranking/codeintel-ranking
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_ranking_lsifstore_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_ranking_lsifstore_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -27578,8 +31601,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-ranking/codeintel-ranking
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_ranking_lsifstore_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m])))`
+Query:
 
+```
+histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_ranking_lsifstore_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m])))
+```
 </details>
 
 <br />
@@ -27597,8 +31623,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-ranking/codeintel-ranking
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_ranking_lsifstore_errors_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_ranking_lsifstore_errors_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -27616,8 +31645,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-ranking/codeintel-ranking
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_ranking_lsifstore_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum by (op)(increase(src_codeintel_ranking_lsifstore_total{job=~"^${source:regex}.*"}[5m])) + sum by (op)(increase(src_codeintel_ranking_lsifstore_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_ranking_lsifstore_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum by (op)(increase(src_codeintel_ranking_lsifstore_total{job=~"^${source:regex}.*"}[5m])) + sum by (op)(increase(src_codeintel_ranking_lsifstore_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -27639,8 +31671,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-ranking/codeintel-ranking
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_ranking_symbol_exporter_records_processed_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_ranking_symbol_exporter_records_processed_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -27660,8 +31695,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-ranking/codeintel-ranking
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_ranking_symbol_exporter_records_altered_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_ranking_symbol_exporter_records_altered_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -27679,8 +31717,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-ranking/codeintel-ranking
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_ranking_symbol_exporter_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_ranking_symbol_exporter_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -27698,8 +31739,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-ranking/codeintel-ranking
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_ranking_symbol_exporter_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m])))`
+Query:
 
+```
+histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_ranking_symbol_exporter_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m])))
+```
 </details>
 
 <br />
@@ -27717,8 +31761,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-ranking/codeintel-ranking
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_ranking_symbol_exporter_errors_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_ranking_symbol_exporter_errors_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -27736,8 +31783,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-ranking/codeintel-ranking
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_ranking_symbol_exporter_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum by (op)(increase(src_codeintel_ranking_symbol_exporter_total{job=~"^${source:regex}.*"}[5m])) + sum by (op)(increase(src_codeintel_ranking_symbol_exporter_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_ranking_symbol_exporter_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum by (op)(increase(src_codeintel_ranking_symbol_exporter_total{job=~"^${source:regex}.*"}[5m])) + sum by (op)(increase(src_codeintel_ranking_symbol_exporter_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -27759,8 +31809,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-ranking/codeintel-ranking
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_ranking_file_reference_count_seed_mapper_records_processed_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_ranking_file_reference_count_seed_mapper_records_processed_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -27780,8 +31833,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-ranking/codeintel-ranking
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_ranking_file_reference_count_seed_mapper_records_altered_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_ranking_file_reference_count_seed_mapper_records_altered_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -27799,8 +31855,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-ranking/codeintel-ranking
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_ranking_file_reference_count_seed_mapper_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_ranking_file_reference_count_seed_mapper_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -27818,8 +31877,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-ranking/codeintel-ranking
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_ranking_file_reference_count_seed_mapper_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m])))`
+Query:
 
+```
+histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_ranking_file_reference_count_seed_mapper_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m])))
+```
 </details>
 
 <br />
@@ -27837,8 +31899,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-ranking/codeintel-ranking
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_ranking_file_reference_count_seed_mapper_errors_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_ranking_file_reference_count_seed_mapper_errors_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -27856,8 +31921,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-ranking/codeintel-ranking
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_ranking_file_reference_count_seed_mapper_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum by (op)(increase(src_codeintel_ranking_file_reference_count_seed_mapper_total{job=~"^${source:regex}.*"}[5m])) + sum by (op)(increase(src_codeintel_ranking_file_reference_count_seed_mapper_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_ranking_file_reference_count_seed_mapper_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum by (op)(increase(src_codeintel_ranking_file_reference_count_seed_mapper_total{job=~"^${source:regex}.*"}[5m])) + sum by (op)(increase(src_codeintel_ranking_file_reference_count_seed_mapper_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -27879,8 +31947,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-ranking/codeintel-ranking
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_ranking_file_reference_count_mapper_records_processed_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_ranking_file_reference_count_mapper_records_processed_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -27900,8 +31971,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-ranking/codeintel-ranking
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_ranking_file_reference_count_mapper_records_altered_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_ranking_file_reference_count_mapper_records_altered_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -27919,8 +31993,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-ranking/codeintel-ranking
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_ranking_file_reference_count_mapper_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_ranking_file_reference_count_mapper_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -27938,8 +32015,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-ranking/codeintel-ranking
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_ranking_file_reference_count_mapper_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m])))`
+Query:
 
+```
+histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_ranking_file_reference_count_mapper_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m])))
+```
 </details>
 
 <br />
@@ -27957,8 +32037,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-ranking/codeintel-ranking
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_ranking_file_reference_count_mapper_errors_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_ranking_file_reference_count_mapper_errors_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -27976,8 +32059,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-ranking/codeintel-ranking
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_ranking_file_reference_count_mapper_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum by (op)(increase(src_codeintel_ranking_file_reference_count_mapper_total{job=~"^${source:regex}.*"}[5m])) + sum by (op)(increase(src_codeintel_ranking_file_reference_count_mapper_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_ranking_file_reference_count_mapper_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum by (op)(increase(src_codeintel_ranking_file_reference_count_mapper_total{job=~"^${source:regex}.*"}[5m])) + sum by (op)(increase(src_codeintel_ranking_file_reference_count_mapper_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -27999,8 +32085,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-ranking/codeintel-ranking
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_ranking_file_reference_count_reducer_records_processed_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_ranking_file_reference_count_reducer_records_processed_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -28020,8 +32109,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-ranking/codeintel-ranking
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_ranking_file_reference_count_reducer_records_altered_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_ranking_file_reference_count_reducer_records_altered_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -28039,8 +32131,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-ranking/codeintel-ranking
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_ranking_file_reference_count_reducer_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_ranking_file_reference_count_reducer_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -28058,8 +32153,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-ranking/codeintel-ranking
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_ranking_file_reference_count_reducer_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m])))`
+Query:
 
+```
+histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_ranking_file_reference_count_reducer_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m])))
+```
 </details>
 
 <br />
@@ -28077,8 +32175,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-ranking/codeintel-ranking
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_ranking_file_reference_count_reducer_errors_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_ranking_file_reference_count_reducer_errors_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -28096,8 +32197,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-ranking/codeintel-ranking
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_ranking_file_reference_count_reducer_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum by (op)(increase(src_codeintel_ranking_file_reference_count_reducer_total{job=~"^${source:regex}.*"}[5m])) + sum by (op)(increase(src_codeintel_ranking_file_reference_count_reducer_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_ranking_file_reference_count_reducer_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum by (op)(increase(src_codeintel_ranking_file_reference_count_reducer_total{job=~"^${source:regex}.*"}[5m])) + sum by (op)(increase(src_codeintel_ranking_file_reference_count_reducer_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -28119,8 +32223,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-ranking/codeintel-ranking
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_ranking_processed_references_janitor_records_scanned_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_ranking_processed_references_janitor_records_scanned_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -28140,8 +32247,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-ranking/codeintel-ranking
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_ranking_processed_references_janitor_records_altered_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_ranking_processed_references_janitor_records_altered_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -28159,8 +32269,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-ranking/codeintel-ranking
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_ranking_processed_references_janitor_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_ranking_processed_references_janitor_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -28178,8 +32291,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-ranking/codeintel-ranking
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_ranking_processed_references_janitor_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m])))`
+Query:
 
+```
+histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_ranking_processed_references_janitor_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m])))
+```
 </details>
 
 <br />
@@ -28197,8 +32313,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-ranking/codeintel-ranking
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_ranking_processed_references_janitor_errors_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_ranking_processed_references_janitor_errors_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -28216,8 +32335,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-ranking/codeintel-ranking
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_ranking_processed_references_janitor_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum by (op)(increase(src_codeintel_ranking_processed_references_janitor_total{job=~"^${source:regex}.*"}[5m])) + sum by (op)(increase(src_codeintel_ranking_processed_references_janitor_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_ranking_processed_references_janitor_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum by (op)(increase(src_codeintel_ranking_processed_references_janitor_total{job=~"^${source:regex}.*"}[5m])) + sum by (op)(increase(src_codeintel_ranking_processed_references_janitor_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -28239,8 +32361,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-ranking/codeintel-ranking
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_ranking_processed_paths_janitor_records_scanned_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_ranking_processed_paths_janitor_records_scanned_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -28260,8 +32385,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-ranking/codeintel-ranking
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_ranking_processed_paths_janitor_records_altered_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_ranking_processed_paths_janitor_records_altered_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -28279,8 +32407,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-ranking/codeintel-ranking
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_ranking_processed_paths_janitor_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_ranking_processed_paths_janitor_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -28298,8 +32429,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-ranking/codeintel-ranking
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_ranking_processed_paths_janitor_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m])))`
+Query:
 
+```
+histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_ranking_processed_paths_janitor_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m])))
+```
 </details>
 
 <br />
@@ -28317,8 +32451,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-ranking/codeintel-ranking
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_ranking_processed_paths_janitor_errors_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_ranking_processed_paths_janitor_errors_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -28336,8 +32473,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-ranking/codeintel-ranking
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_ranking_processed_paths_janitor_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum by (op)(increase(src_codeintel_ranking_processed_paths_janitor_total{job=~"^${source:regex}.*"}[5m])) + sum by (op)(increase(src_codeintel_ranking_processed_paths_janitor_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_ranking_processed_paths_janitor_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum by (op)(increase(src_codeintel_ranking_processed_paths_janitor_total{job=~"^${source:regex}.*"}[5m])) + sum by (op)(increase(src_codeintel_ranking_processed_paths_janitor_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -28359,8 +32499,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-ranking/codeintel-ranking
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_ranking_exported_uploads_janitor_records_scanned_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_ranking_exported_uploads_janitor_records_scanned_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -28380,8 +32523,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-ranking/codeintel-ranking
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_ranking_exported_uploads_janitor_records_altered_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_ranking_exported_uploads_janitor_records_altered_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -28399,8 +32545,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-ranking/codeintel-ranking
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_ranking_exported_uploads_janitor_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_ranking_exported_uploads_janitor_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -28418,8 +32567,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-ranking/codeintel-ranking
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_ranking_exported_uploads_janitor_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m])))`
+Query:
 
+```
+histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_ranking_exported_uploads_janitor_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m])))
+```
 </details>
 
 <br />
@@ -28437,8 +32589,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-ranking/codeintel-ranking
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_ranking_exported_uploads_janitor_errors_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_ranking_exported_uploads_janitor_errors_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -28456,8 +32611,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-ranking/codeintel-ranking
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_ranking_exported_uploads_janitor_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum by (op)(increase(src_codeintel_ranking_exported_uploads_janitor_total{job=~"^${source:regex}.*"}[5m])) + sum by (op)(increase(src_codeintel_ranking_exported_uploads_janitor_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_ranking_exported_uploads_janitor_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum by (op)(increase(src_codeintel_ranking_exported_uploads_janitor_total{job=~"^${source:regex}.*"}[5m])) + sum by (op)(increase(src_codeintel_ranking_exported_uploads_janitor_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -28479,8 +32637,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-ranking/codeintel-ranking
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_ranking_deleted_exported_uploads_janitor_records_scanned_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_ranking_deleted_exported_uploads_janitor_records_scanned_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -28500,8 +32661,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-ranking/codeintel-ranking
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_ranking_deleted_exported_uploads_janitor_records_altered_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_ranking_deleted_exported_uploads_janitor_records_altered_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -28519,8 +32683,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-ranking/codeintel-ranking
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_ranking_deleted_exported_uploads_janitor_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_ranking_deleted_exported_uploads_janitor_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -28538,8 +32705,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-ranking/codeintel-ranking
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_ranking_deleted_exported_uploads_janitor_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m])))`
+Query:
 
+```
+histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_ranking_deleted_exported_uploads_janitor_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m])))
+```
 </details>
 
 <br />
@@ -28557,8 +32727,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-ranking/codeintel-ranking
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_ranking_deleted_exported_uploads_janitor_errors_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_ranking_deleted_exported_uploads_janitor_errors_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -28576,8 +32749,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-ranking/codeintel-ranking
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_ranking_deleted_exported_uploads_janitor_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum by (op)(increase(src_codeintel_ranking_deleted_exported_uploads_janitor_total{job=~"^${source:regex}.*"}[5m])) + sum by (op)(increase(src_codeintel_ranking_deleted_exported_uploads_janitor_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_ranking_deleted_exported_uploads_janitor_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum by (op)(increase(src_codeintel_ranking_deleted_exported_uploads_janitor_total{job=~"^${source:regex}.*"}[5m])) + sum by (op)(increase(src_codeintel_ranking_deleted_exported_uploads_janitor_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -28599,8 +32775,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-ranking/codeintel-ranking
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_ranking_abandoned_exported_uploads_janitor_records_scanned_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_ranking_abandoned_exported_uploads_janitor_records_scanned_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -28620,8 +32799,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-ranking/codeintel-ranking
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_ranking_abandoned_exported_uploads_janitor_records_altered_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_ranking_abandoned_exported_uploads_janitor_records_altered_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -28639,8 +32821,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-ranking/codeintel-ranking
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_ranking_abandoned_exported_uploads_janitor_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_ranking_abandoned_exported_uploads_janitor_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -28658,8 +32843,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-ranking/codeintel-ranking
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_ranking_abandoned_exported_uploads_janitor_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m])))`
+Query:
 
+```
+histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_ranking_abandoned_exported_uploads_janitor_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m])))
+```
 </details>
 
 <br />
@@ -28677,8 +32865,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-ranking/codeintel-ranking
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_ranking_abandoned_exported_uploads_janitor_errors_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_ranking_abandoned_exported_uploads_janitor_errors_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -28696,8 +32887,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-ranking/codeintel-ranking
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_ranking_abandoned_exported_uploads_janitor_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum by (op)(increase(src_codeintel_ranking_abandoned_exported_uploads_janitor_total{job=~"^${source:regex}.*"}[5m])) + sum by (op)(increase(src_codeintel_ranking_abandoned_exported_uploads_janitor_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_ranking_abandoned_exported_uploads_janitor_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum by (op)(increase(src_codeintel_ranking_abandoned_exported_uploads_janitor_total{job=~"^${source:regex}.*"}[5m])) + sum by (op)(increase(src_codeintel_ranking_abandoned_exported_uploads_janitor_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -28719,8 +32913,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-ranking/codeintel-ranking
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_ranking_rank_counts_janitor_records_scanned_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_ranking_rank_counts_janitor_records_scanned_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -28740,8 +32937,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-ranking/codeintel-ranking
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_ranking_rank_counts_janitor_records_altered_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_ranking_rank_counts_janitor_records_altered_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -28759,8 +32959,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-ranking/codeintel-ranking
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_ranking_rank_counts_janitor_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_ranking_rank_counts_janitor_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -28778,8 +32981,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-ranking/codeintel-ranking
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_ranking_rank_counts_janitor_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m])))`
+Query:
 
+```
+histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_ranking_rank_counts_janitor_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m])))
+```
 </details>
 
 <br />
@@ -28797,8 +33003,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-ranking/codeintel-ranking
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_ranking_rank_counts_janitor_errors_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_ranking_rank_counts_janitor_errors_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -28816,8 +33025,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-ranking/codeintel-ranking
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_ranking_rank_counts_janitor_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum by (op)(increase(src_codeintel_ranking_rank_counts_janitor_total{job=~"^${source:regex}.*"}[5m])) + sum by (op)(increase(src_codeintel_ranking_rank_counts_janitor_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_ranking_rank_counts_janitor_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum by (op)(increase(src_codeintel_ranking_rank_counts_janitor_total{job=~"^${source:regex}.*"}[5m])) + sum by (op)(increase(src_codeintel_ranking_rank_counts_janitor_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -28839,8 +33051,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-ranking/codeintel-ranking
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_ranking_rank_janitor_records_scanned_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_ranking_rank_janitor_records_scanned_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -28860,8 +33075,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-ranking/codeintel-ranking
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_ranking_rank_janitor_records_altered_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_ranking_rank_janitor_records_altered_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -28879,8 +33097,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-ranking/codeintel-ranking
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_ranking_rank_janitor_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_ranking_rank_janitor_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -28898,8 +33119,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-ranking/codeintel-ranking
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_ranking_rank_janitor_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m])))`
+Query:
 
+```
+histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_ranking_rank_janitor_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m])))
+```
 </details>
 
 <br />
@@ -28917,8 +33141,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-ranking/codeintel-ranking
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_ranking_rank_janitor_errors_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_ranking_rank_janitor_errors_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -28936,8 +33163,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-ranking/codeintel-ranking
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_ranking_rank_janitor_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum by (op)(increase(src_codeintel_ranking_rank_janitor_total{job=~"^${source:regex}.*"}[5m])) + sum by (op)(increase(src_codeintel_ranking_rank_janitor_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_ranking_rank_janitor_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum by (op)(increase(src_codeintel_ranking_rank_janitor_total{job=~"^${source:regex}.*"}[5m])) + sum by (op)(increase(src_codeintel_ranking_rank_janitor_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -28963,8 +33193,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-uploads/codeintel-uploads
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_uploads_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_uploads_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -28982,8 +33215,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-uploads/codeintel-uploads
 <details>
 <summary>Technical details</summary>
 
-Query: `sum  by (le)(rate(src_codeintel_uploads_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum  by (le)(rate(src_codeintel_uploads_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -29001,8 +33237,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-uploads/codeintel-uploads
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_uploads_errors_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_uploads_errors_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -29020,8 +33259,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-uploads/codeintel-uploads
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_uploads_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum(increase(src_codeintel_uploads_total{job=~"^${source:regex}.*"}[5m])) + sum(increase(src_codeintel_uploads_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100`
+Query:
 
+```
+sum(increase(src_codeintel_uploads_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum(increase(src_codeintel_uploads_total{job=~"^${source:regex}.*"}[5m])) + sum(increase(src_codeintel_uploads_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -29039,8 +33281,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-uploads/codeintel-uploads
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_uploads_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_uploads_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -29058,8 +33303,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-uploads/codeintel-uploads
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_uploads_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m])))`
+Query:
 
+```
+histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_uploads_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m])))
+```
 </details>
 
 <br />
@@ -29077,8 +33325,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-uploads/codeintel-uploads
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_uploads_errors_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_uploads_errors_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -29096,8 +33347,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-uploads/codeintel-uploads
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_uploads_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum by (op)(increase(src_codeintel_uploads_total{job=~"^${source:regex}.*"}[5m])) + sum by (op)(increase(src_codeintel_uploads_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_uploads_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum by (op)(increase(src_codeintel_uploads_total{job=~"^${source:regex}.*"}[5m])) + sum by (op)(increase(src_codeintel_uploads_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -29117,8 +33371,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-uploads/codeintel-uploads
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_uploads_store_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_uploads_store_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -29136,8 +33393,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-uploads/codeintel-uploads
 <details>
 <summary>Technical details</summary>
 
-Query: `sum  by (le)(rate(src_codeintel_uploads_store_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum  by (le)(rate(src_codeintel_uploads_store_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -29155,8 +33415,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-uploads/codeintel-uploads
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_uploads_store_errors_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_uploads_store_errors_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -29174,8 +33437,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-uploads/codeintel-uploads
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_uploads_store_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum(increase(src_codeintel_uploads_store_total{job=~"^${source:regex}.*"}[5m])) + sum(increase(src_codeintel_uploads_store_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100`
+Query:
 
+```
+sum(increase(src_codeintel_uploads_store_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum(increase(src_codeintel_uploads_store_total{job=~"^${source:regex}.*"}[5m])) + sum(increase(src_codeintel_uploads_store_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -29193,8 +33459,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-uploads/codeintel-uploads
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_uploads_store_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_uploads_store_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -29212,8 +33481,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-uploads/codeintel-uploads
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_uploads_store_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m])))`
+Query:
 
+```
+histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_uploads_store_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m])))
+```
 </details>
 
 <br />
@@ -29231,8 +33503,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-uploads/codeintel-uploads
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_uploads_store_errors_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_uploads_store_errors_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -29250,8 +33525,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-uploads/codeintel-uploads
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_uploads_store_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum by (op)(increase(src_codeintel_uploads_store_total{job=~"^${source:regex}.*"}[5m])) + sum by (op)(increase(src_codeintel_uploads_store_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_uploads_store_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum by (op)(increase(src_codeintel_uploads_store_total{job=~"^${source:regex}.*"}[5m])) + sum by (op)(increase(src_codeintel_uploads_store_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -29271,8 +33549,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-uploads/codeintel-uploads
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_uploads_transport_graphql_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_uploads_transport_graphql_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -29290,8 +33571,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-uploads/codeintel-uploads
 <details>
 <summary>Technical details</summary>
 
-Query: `sum  by (le)(rate(src_codeintel_uploads_transport_graphql_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum  by (le)(rate(src_codeintel_uploads_transport_graphql_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -29309,8 +33593,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-uploads/codeintel-uploads
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_uploads_transport_graphql_errors_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_uploads_transport_graphql_errors_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -29328,8 +33615,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-uploads/codeintel-uploads
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_uploads_transport_graphql_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum(increase(src_codeintel_uploads_transport_graphql_total{job=~"^${source:regex}.*"}[5m])) + sum(increase(src_codeintel_uploads_transport_graphql_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100`
+Query:
 
+```
+sum(increase(src_codeintel_uploads_transport_graphql_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum(increase(src_codeintel_uploads_transport_graphql_total{job=~"^${source:regex}.*"}[5m])) + sum(increase(src_codeintel_uploads_transport_graphql_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -29347,8 +33637,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-uploads/codeintel-uploads
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_uploads_transport_graphql_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_uploads_transport_graphql_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -29366,8 +33659,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-uploads/codeintel-uploads
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_uploads_transport_graphql_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m])))`
+Query:
 
+```
+histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_uploads_transport_graphql_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m])))
+```
 </details>
 
 <br />
@@ -29385,8 +33681,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-uploads/codeintel-uploads
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_uploads_transport_graphql_errors_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_uploads_transport_graphql_errors_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -29404,8 +33703,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-uploads/codeintel-uploads
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_uploads_transport_graphql_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum by (op)(increase(src_codeintel_uploads_transport_graphql_total{job=~"^${source:regex}.*"}[5m])) + sum by (op)(increase(src_codeintel_uploads_transport_graphql_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_uploads_transport_graphql_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum by (op)(increase(src_codeintel_uploads_transport_graphql_total{job=~"^${source:regex}.*"}[5m])) + sum by (op)(increase(src_codeintel_uploads_transport_graphql_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -29425,8 +33727,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-uploads/codeintel-uploads
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_uploads_transport_http_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_uploads_transport_http_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -29444,8 +33749,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-uploads/codeintel-uploads
 <details>
 <summary>Technical details</summary>
 
-Query: `sum  by (le)(rate(src_codeintel_uploads_transport_http_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum  by (le)(rate(src_codeintel_uploads_transport_http_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -29463,8 +33771,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-uploads/codeintel-uploads
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_uploads_transport_http_errors_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_uploads_transport_http_errors_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -29482,8 +33793,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-uploads/codeintel-uploads
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_uploads_transport_http_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum(increase(src_codeintel_uploads_transport_http_total{job=~"^${source:regex}.*"}[5m])) + sum(increase(src_codeintel_uploads_transport_http_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100`
+Query:
 
+```
+sum(increase(src_codeintel_uploads_transport_http_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum(increase(src_codeintel_uploads_transport_http_total{job=~"^${source:regex}.*"}[5m])) + sum(increase(src_codeintel_uploads_transport_http_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -29501,8 +33815,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-uploads/codeintel-uploads
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_uploads_transport_http_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_uploads_transport_http_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -29520,8 +33837,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-uploads/codeintel-uploads
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_uploads_transport_http_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m])))`
+Query:
 
+```
+histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_uploads_transport_http_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m])))
+```
 </details>
 
 <br />
@@ -29539,8 +33859,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-uploads/codeintel-uploads
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_uploads_transport_http_errors_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_uploads_transport_http_errors_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -29558,8 +33881,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-uploads/codeintel-uploads
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_uploads_transport_http_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum by (op)(increase(src_codeintel_uploads_transport_http_total{job=~"^${source:regex}.*"}[5m])) + sum by (op)(increase(src_codeintel_uploads_transport_http_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_uploads_transport_http_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum by (op)(increase(src_codeintel_uploads_transport_http_total{job=~"^${source:regex}.*"}[5m])) + sum by (op)(increase(src_codeintel_uploads_transport_http_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -29579,8 +33905,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-uploads/codeintel-uploads
 <details>
 <summary>Technical details</summary>
 
-Query: `max(src_codeintel_commit_graph_total{job=~"^${source:regex}.*"})`
+Query:
 
+```
+max(src_codeintel_commit_graph_total{job=~"^${source:regex}.*"})
+```
 </details>
 
 <br />
@@ -29604,8 +33933,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-uploads/codeintel-uploads
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_commit_graph_total{job=~"^${source:regex}.*"}[30m])) / sum(increase(src_codeintel_commit_graph_processor_total{job=~"^${source:regex}.*"}[30m]))`
+Query:
 
+```
+sum(increase(src_codeintel_commit_graph_total{job=~"^${source:regex}.*"}[30m])) / sum(increase(src_codeintel_commit_graph_processor_total{job=~"^${source:regex}.*"}[30m]))
+```
 </details>
 
 <br />
@@ -29623,8 +33955,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-uploads/codeintel-uploads
 <details>
 <summary>Technical details</summary>
 
-Query: `max(src_codeintel_commit_graph_queued_duration_seconds_total{job=~"^${source:regex}.*"})`
+Query:
 
+```
+max(src_codeintel_commit_graph_queued_duration_seconds_total{job=~"^${source:regex}.*"})
+```
 </details>
 
 <br />
@@ -29646,8 +33981,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-uploads/codeintel-uploads
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_background_repositories_scanned_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_background_repositories_scanned_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -29667,8 +34005,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-uploads/codeintel-uploads
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_background_upload_records_scanned_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_background_upload_records_scanned_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -29688,8 +34029,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-uploads/codeintel-uploads
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_background_commits_scanned_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_background_commits_scanned_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -29709,8 +34053,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-uploads/codeintel-uploads
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_background_upload_records_expired_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_background_upload_records_expired_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -29732,8 +34079,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-uploads/codeintel-uploads
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_uploads_janitor_unknown_repository_records_scanned_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_uploads_janitor_unknown_repository_records_scanned_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -29753,8 +34103,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-uploads/codeintel-uploads
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_uploads_janitor_unknown_repository_records_altered_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_uploads_janitor_unknown_repository_records_altered_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -29772,8 +34125,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-uploads/codeintel-uploads
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_uploads_janitor_unknown_repository_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_uploads_janitor_unknown_repository_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -29791,8 +34147,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-uploads/codeintel-uploads
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_uploads_janitor_unknown_repository_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m])))`
+Query:
 
+```
+histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_uploads_janitor_unknown_repository_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m])))
+```
 </details>
 
 <br />
@@ -29810,8 +34169,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-uploads/codeintel-uploads
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_uploads_janitor_unknown_repository_errors_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_uploads_janitor_unknown_repository_errors_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -29829,8 +34191,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-uploads/codeintel-uploads
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_uploads_janitor_unknown_repository_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum by (op)(increase(src_codeintel_uploads_janitor_unknown_repository_total{job=~"^${source:regex}.*"}[5m])) + sum by (op)(increase(src_codeintel_uploads_janitor_unknown_repository_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_uploads_janitor_unknown_repository_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum by (op)(increase(src_codeintel_uploads_janitor_unknown_repository_total{job=~"^${source:regex}.*"}[5m])) + sum by (op)(increase(src_codeintel_uploads_janitor_unknown_repository_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -29852,8 +34217,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-uploads/codeintel-uploads
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_uploads_janitor_unknown_commit_records_scanned_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_uploads_janitor_unknown_commit_records_scanned_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -29873,8 +34241,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-uploads/codeintel-uploads
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_uploads_janitor_unknown_commit_records_altered_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_uploads_janitor_unknown_commit_records_altered_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -29892,8 +34263,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-uploads/codeintel-uploads
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_uploads_janitor_unknown_commit_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_uploads_janitor_unknown_commit_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -29911,8 +34285,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-uploads/codeintel-uploads
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_uploads_janitor_unknown_commit_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m])))`
+Query:
 
+```
+histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_uploads_janitor_unknown_commit_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m])))
+```
 </details>
 
 <br />
@@ -29930,8 +34307,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-uploads/codeintel-uploads
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_uploads_janitor_unknown_commit_errors_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_uploads_janitor_unknown_commit_errors_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -29949,8 +34329,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-uploads/codeintel-uploads
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_uploads_janitor_unknown_commit_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum by (op)(increase(src_codeintel_uploads_janitor_unknown_commit_total{job=~"^${source:regex}.*"}[5m])) + sum by (op)(increase(src_codeintel_uploads_janitor_unknown_commit_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_uploads_janitor_unknown_commit_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum by (op)(increase(src_codeintel_uploads_janitor_unknown_commit_total{job=~"^${source:regex}.*"}[5m])) + sum by (op)(increase(src_codeintel_uploads_janitor_unknown_commit_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -29972,8 +34355,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-uploads/codeintel-uploads
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_uploads_janitor_abandoned_records_scanned_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_uploads_janitor_abandoned_records_scanned_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -29993,8 +34379,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-uploads/codeintel-uploads
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_uploads_janitor_abandoned_records_altered_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_uploads_janitor_abandoned_records_altered_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -30012,8 +34401,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-uploads/codeintel-uploads
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_uploads_janitor_abandoned_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_uploads_janitor_abandoned_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -30031,8 +34423,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-uploads/codeintel-uploads
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_uploads_janitor_abandoned_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m])))`
+Query:
 
+```
+histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_uploads_janitor_abandoned_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m])))
+```
 </details>
 
 <br />
@@ -30050,8 +34445,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-uploads/codeintel-uploads
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_uploads_janitor_abandoned_errors_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_uploads_janitor_abandoned_errors_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -30069,8 +34467,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-uploads/codeintel-uploads
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_uploads_janitor_abandoned_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum by (op)(increase(src_codeintel_uploads_janitor_abandoned_total{job=~"^${source:regex}.*"}[5m])) + sum by (op)(increase(src_codeintel_uploads_janitor_abandoned_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_uploads_janitor_abandoned_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum by (op)(increase(src_codeintel_uploads_janitor_abandoned_total{job=~"^${source:regex}.*"}[5m])) + sum by (op)(increase(src_codeintel_uploads_janitor_abandoned_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -30092,8 +34493,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-uploads/codeintel-uploads
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_uploads_expirer_unreferenced_records_scanned_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_uploads_expirer_unreferenced_records_scanned_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -30113,8 +34517,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-uploads/codeintel-uploads
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_uploads_expirer_unreferenced_records_altered_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_uploads_expirer_unreferenced_records_altered_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -30132,8 +34539,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-uploads/codeintel-uploads
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_uploads_expirer_unreferenced_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_uploads_expirer_unreferenced_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -30151,8 +34561,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-uploads/codeintel-uploads
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_uploads_expirer_unreferenced_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m])))`
+Query:
 
+```
+histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_uploads_expirer_unreferenced_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m])))
+```
 </details>
 
 <br />
@@ -30170,8 +34583,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-uploads/codeintel-uploads
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_uploads_expirer_unreferenced_errors_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_uploads_expirer_unreferenced_errors_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -30189,8 +34605,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-uploads/codeintel-uploads
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_uploads_expirer_unreferenced_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum by (op)(increase(src_codeintel_uploads_expirer_unreferenced_total{job=~"^${source:regex}.*"}[5m])) + sum by (op)(increase(src_codeintel_uploads_expirer_unreferenced_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_uploads_expirer_unreferenced_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum by (op)(increase(src_codeintel_uploads_expirer_unreferenced_total{job=~"^${source:regex}.*"}[5m])) + sum by (op)(increase(src_codeintel_uploads_expirer_unreferenced_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -30212,8 +34631,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-uploads/codeintel-uploads
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_uploads_expirer_unreferenced_graph_records_scanned_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_uploads_expirer_unreferenced_graph_records_scanned_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -30233,8 +34655,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-uploads/codeintel-uploads
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_uploads_expirer_unreferenced_graph_records_altered_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_uploads_expirer_unreferenced_graph_records_altered_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -30252,8 +34677,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-uploads/codeintel-uploads
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_uploads_expirer_unreferenced_graph_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_uploads_expirer_unreferenced_graph_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -30271,8 +34699,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-uploads/codeintel-uploads
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_uploads_expirer_unreferenced_graph_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m])))`
+Query:
 
+```
+histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_uploads_expirer_unreferenced_graph_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m])))
+```
 </details>
 
 <br />
@@ -30290,8 +34721,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-uploads/codeintel-uploads
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_uploads_expirer_unreferenced_graph_errors_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_uploads_expirer_unreferenced_graph_errors_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -30309,8 +34743,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-uploads/codeintel-uploads
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_uploads_expirer_unreferenced_graph_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum by (op)(increase(src_codeintel_uploads_expirer_unreferenced_graph_total{job=~"^${source:regex}.*"}[5m])) + sum by (op)(increase(src_codeintel_uploads_expirer_unreferenced_graph_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_uploads_expirer_unreferenced_graph_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum by (op)(increase(src_codeintel_uploads_expirer_unreferenced_graph_total{job=~"^${source:regex}.*"}[5m])) + sum by (op)(increase(src_codeintel_uploads_expirer_unreferenced_graph_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -30332,8 +34769,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-uploads/codeintel-uploads
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_uploads_hard_deleter_records_scanned_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_uploads_hard_deleter_records_scanned_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -30353,8 +34793,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-uploads/codeintel-uploads
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_uploads_hard_deleter_records_altered_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_uploads_hard_deleter_records_altered_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -30372,8 +34815,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-uploads/codeintel-uploads
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_uploads_hard_deleter_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_uploads_hard_deleter_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -30391,8 +34837,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-uploads/codeintel-uploads
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_uploads_hard_deleter_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m])))`
+Query:
 
+```
+histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_uploads_hard_deleter_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m])))
+```
 </details>
 
 <br />
@@ -30410,8 +34859,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-uploads/codeintel-uploads
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_uploads_hard_deleter_errors_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_uploads_hard_deleter_errors_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -30429,8 +34881,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-uploads/codeintel-uploads
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_uploads_hard_deleter_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum by (op)(increase(src_codeintel_uploads_hard_deleter_total{job=~"^${source:regex}.*"}[5m])) + sum by (op)(increase(src_codeintel_uploads_hard_deleter_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_uploads_hard_deleter_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum by (op)(increase(src_codeintel_uploads_hard_deleter_total{job=~"^${source:regex}.*"}[5m])) + sum by (op)(increase(src_codeintel_uploads_hard_deleter_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -30452,8 +34907,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-uploads/codeintel-uploads
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_uploads_janitor_audit_logs_records_scanned_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_uploads_janitor_audit_logs_records_scanned_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -30473,8 +34931,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-uploads/codeintel-uploads
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_uploads_janitor_audit_logs_records_altered_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_uploads_janitor_audit_logs_records_altered_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -30492,8 +34953,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-uploads/codeintel-uploads
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_uploads_janitor_audit_logs_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_uploads_janitor_audit_logs_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -30511,8 +34975,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-uploads/codeintel-uploads
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_uploads_janitor_audit_logs_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m])))`
+Query:
 
+```
+histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_uploads_janitor_audit_logs_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m])))
+```
 </details>
 
 <br />
@@ -30530,8 +34997,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-uploads/codeintel-uploads
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_uploads_janitor_audit_logs_errors_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_uploads_janitor_audit_logs_errors_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -30549,8 +35019,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-uploads/codeintel-uploads
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_uploads_janitor_audit_logs_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum by (op)(increase(src_codeintel_uploads_janitor_audit_logs_total{job=~"^${source:regex}.*"}[5m])) + sum by (op)(increase(src_codeintel_uploads_janitor_audit_logs_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_uploads_janitor_audit_logs_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum by (op)(increase(src_codeintel_uploads_janitor_audit_logs_total{job=~"^${source:regex}.*"}[5m])) + sum by (op)(increase(src_codeintel_uploads_janitor_audit_logs_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -30572,8 +35045,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-uploads/codeintel-uploads
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_uploads_janitor_scip_documents_records_scanned_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_uploads_janitor_scip_documents_records_scanned_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -30593,8 +35069,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-uploads/codeintel-uploads
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_uploads_janitor_scip_documents_records_altered_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_uploads_janitor_scip_documents_records_altered_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -30612,8 +35091,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-uploads/codeintel-uploads
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_uploads_janitor_scip_documents_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_uploads_janitor_scip_documents_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -30631,8 +35113,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-uploads/codeintel-uploads
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_uploads_janitor_scip_documents_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m])))`
+Query:
 
+```
+histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_uploads_janitor_scip_documents_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m])))
+```
 </details>
 
 <br />
@@ -30650,8 +35135,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-uploads/codeintel-uploads
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_uploads_janitor_scip_documents_errors_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_uploads_janitor_scip_documents_errors_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -30669,8 +35157,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-uploads/codeintel-uploads
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_uploads_janitor_scip_documents_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum by (op)(increase(src_codeintel_uploads_janitor_scip_documents_total{job=~"^${source:regex}.*"}[5m])) + sum by (op)(increase(src_codeintel_uploads_janitor_scip_documents_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_uploads_janitor_scip_documents_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum by (op)(increase(src_codeintel_uploads_janitor_scip_documents_total{job=~"^${source:regex}.*"}[5m])) + sum by (op)(increase(src_codeintel_uploads_janitor_scip_documents_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -30692,8 +35183,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-uploads/codeintel-uploads
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_uploads_reconciler_scip_metadata_records_scanned_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_uploads_reconciler_scip_metadata_records_scanned_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -30713,8 +35207,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-uploads/codeintel-uploads
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_uploads_reconciler_scip_metadata_records_altered_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_uploads_reconciler_scip_metadata_records_altered_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -30732,8 +35229,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-uploads/codeintel-uploads
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_uploads_reconciler_scip_metadata_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_uploads_reconciler_scip_metadata_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -30751,8 +35251,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-uploads/codeintel-uploads
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_uploads_reconciler_scip_metadata_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m])))`
+Query:
 
+```
+histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_uploads_reconciler_scip_metadata_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m])))
+```
 </details>
 
 <br />
@@ -30770,8 +35273,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-uploads/codeintel-uploads
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_uploads_reconciler_scip_metadata_errors_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_uploads_reconciler_scip_metadata_errors_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -30789,8 +35295,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-uploads/codeintel-uploads
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_uploads_reconciler_scip_metadata_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum by (op)(increase(src_codeintel_uploads_reconciler_scip_metadata_total{job=~"^${source:regex}.*"}[5m])) + sum by (op)(increase(src_codeintel_uploads_reconciler_scip_metadata_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_uploads_reconciler_scip_metadata_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum by (op)(increase(src_codeintel_uploads_reconciler_scip_metadata_total{job=~"^${source:regex}.*"}[5m])) + sum by (op)(increase(src_codeintel_uploads_reconciler_scip_metadata_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -30812,8 +35321,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-uploads/codeintel-uploads
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_uploads_reconciler_scip_data_records_scanned_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_uploads_reconciler_scip_data_records_scanned_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -30833,8 +35345,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-uploads/codeintel-uploads
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_uploads_reconciler_scip_data_records_altered_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_codeintel_uploads_reconciler_scip_data_records_altered_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -30852,8 +35367,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-uploads/codeintel-uploads
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_uploads_reconciler_scip_data_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_uploads_reconciler_scip_data_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -30871,8 +35389,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-uploads/codeintel-uploads
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_uploads_reconciler_scip_data_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m])))`
+Query:
 
+```
+histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_uploads_reconciler_scip_data_duration_seconds_bucket{job=~"^${source:regex}.*"}[5m])))
+```
 </details>
 
 <br />
@@ -30890,8 +35411,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-uploads/codeintel-uploads
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_uploads_reconciler_scip_data_errors_total{job=~"^${source:regex}.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_uploads_reconciler_scip_data_errors_total{job=~"^${source:regex}.*"}[5m]))
+```
 </details>
 
 <br />
@@ -30909,8 +35433,11 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-uploads/codeintel-uploads
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_uploads_reconciler_scip_data_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum by (op)(increase(src_codeintel_uploads_reconciler_scip_data_total{job=~"^${source:regex}.*"}[5m])) + sum by (op)(increase(src_codeintel_uploads_reconciler_scip_data_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100`
+Query:
 
+```
+sum by (op)(increase(src_codeintel_uploads_reconciler_scip_data_errors_total{job=~"^${source:regex}.*"}[5m])) / (sum by (op)(increase(src_codeintel_uploads_reconciler_scip_data_total{job=~"^${source:regex}.*"}[5m])) + sum by (op)(increase(src_codeintel_uploads_reconciler_scip_data_errors_total{job=~"^${source:regex}.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -30938,8 +35465,11 @@ To see this panel, visit `/-/debug/grafana/d/telemetry/telemetry?viewPanel=10000
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(src_telemetrygatewayexporter_queue_size)`
+Query:
 
+```
+sum(src_telemetrygatewayexporter_queue_size)
+```
 </details>
 
 <br />
@@ -30959,8 +35489,11 @@ To see this panel, visit `/-/debug/grafana/d/telemetry/telemetry?viewPanel=10000
 <details>
 <summary>Technical details</summary>
 
-Query: `max(deriv(src_telemetrygatewayexporter_queue_size[30m]))`
+Query:
 
+```
+max(deriv(src_telemetrygatewayexporter_queue_size[30m]))
+```
 </details>
 
 <br />
@@ -30980,8 +35513,11 @@ To see this panel, visit `/-/debug/grafana/d/telemetry/telemetry?viewPanel=10001
 <details>
 <summary>Technical details</summary>
 
-Query: `max(increase(src_telemetrygatewayexporter_exported_events[1h]))`
+Query:
 
+```
+max(increase(src_telemetrygatewayexporter_exported_events[1h]))
+```
 </details>
 
 <br />
@@ -31002,8 +35538,11 @@ To see this panel, visit `/-/debug/grafana/d/telemetry/telemetry?viewPanel=10001
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (le) (rate(src_telemetrygatewayexporter_batch_size_bucket[30m]))`
+Query:
 
+```
+sum by (le) (rate(src_telemetrygatewayexporter_batch_size_bucket[30m]))
+```
 </details>
 
 <br />
@@ -31023,8 +35562,11 @@ To see this panel, visit `/-/debug/grafana/d/telemetry/telemetry?viewPanel=10010
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_telemetrygatewayexporter_exporter_total{job=~"^worker.*"}[30m]))`
+Query:
 
+```
+sum(increase(src_telemetrygatewayexporter_exporter_total{job=~"^worker.*"}[30m]))
+```
 </details>
 
 <br />
@@ -31042,8 +35584,11 @@ To see this panel, visit `/-/debug/grafana/d/telemetry/telemetry?viewPanel=10010
 <details>
 <summary>Technical details</summary>
 
-Query: `sum  by (le)(rate(src_telemetrygatewayexporter_exporter_duration_seconds_bucket{job=~"^worker.*"}[30m]))`
+Query:
 
+```
+sum  by (le)(rate(src_telemetrygatewayexporter_exporter_duration_seconds_bucket{job=~"^worker.*"}[30m]))
+```
 </details>
 
 <br />
@@ -31061,8 +35606,11 @@ To see this panel, visit `/-/debug/grafana/d/telemetry/telemetry?viewPanel=10010
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_telemetrygatewayexporter_exporter_errors_total{job=~"^worker.*"}[30m]))`
+Query:
 
+```
+sum(increase(src_telemetrygatewayexporter_exporter_errors_total{job=~"^worker.*"}[30m]))
+```
 </details>
 
 <br />
@@ -31080,8 +35628,11 @@ To see this panel, visit `/-/debug/grafana/d/telemetry/telemetry?viewPanel=10010
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_telemetrygatewayexporter_exporter_errors_total{job=~"^worker.*"}[30m])) / (sum(increase(src_telemetrygatewayexporter_exporter_total{job=~"^worker.*"}[30m])) + sum(increase(src_telemetrygatewayexporter_exporter_errors_total{job=~"^worker.*"}[30m]))) * 100`
+Query:
 
+```
+sum(increase(src_telemetrygatewayexporter_exporter_errors_total{job=~"^worker.*"}[30m])) / (sum(increase(src_telemetrygatewayexporter_exporter_total{job=~"^worker.*"}[30m])) + sum(increase(src_telemetrygatewayexporter_exporter_errors_total{job=~"^worker.*"}[30m]))) * 100
+```
 </details>
 
 <br />
@@ -31101,8 +35652,11 @@ To see this panel, visit `/-/debug/grafana/d/telemetry/telemetry?viewPanel=10020
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_telemetrygatewayexporter_queue_cleanup_total{job=~"^worker.*"}[30m]))`
+Query:
 
+```
+sum(increase(src_telemetrygatewayexporter_queue_cleanup_total{job=~"^worker.*"}[30m]))
+```
 </details>
 
 <br />
@@ -31120,8 +35674,11 @@ To see this panel, visit `/-/debug/grafana/d/telemetry/telemetry?viewPanel=10020
 <details>
 <summary>Technical details</summary>
 
-Query: `sum  by (le)(rate(src_telemetrygatewayexporter_queue_cleanup_duration_seconds_bucket{job=~"^worker.*"}[30m]))`
+Query:
 
+```
+sum  by (le)(rate(src_telemetrygatewayexporter_queue_cleanup_duration_seconds_bucket{job=~"^worker.*"}[30m]))
+```
 </details>
 
 <br />
@@ -31139,8 +35696,11 @@ To see this panel, visit `/-/debug/grafana/d/telemetry/telemetry?viewPanel=10020
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_telemetrygatewayexporter_queue_cleanup_errors_total{job=~"^worker.*"}[30m]))`
+Query:
 
+```
+sum(increase(src_telemetrygatewayexporter_queue_cleanup_errors_total{job=~"^worker.*"}[30m]))
+```
 </details>
 
 <br />
@@ -31158,8 +35718,11 @@ To see this panel, visit `/-/debug/grafana/d/telemetry/telemetry?viewPanel=10020
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_telemetrygatewayexporter_queue_cleanup_errors_total{job=~"^worker.*"}[30m])) / (sum(increase(src_telemetrygatewayexporter_queue_cleanup_total{job=~"^worker.*"}[30m])) + sum(increase(src_telemetrygatewayexporter_queue_cleanup_errors_total{job=~"^worker.*"}[30m]))) * 100`
+Query:
 
+```
+sum(increase(src_telemetrygatewayexporter_queue_cleanup_errors_total{job=~"^worker.*"}[30m])) / (sum(increase(src_telemetrygatewayexporter_queue_cleanup_total{job=~"^worker.*"}[30m])) + sum(increase(src_telemetrygatewayexporter_queue_cleanup_errors_total{job=~"^worker.*"}[30m]))) * 100
+```
 </details>
 
 <br />
@@ -31179,8 +35742,11 @@ To see this panel, visit `/-/debug/grafana/d/telemetry/telemetry?viewPanel=10030
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_telemetrygatewayexporter_queue_metrics_reporter_total{job=~"^worker.*"}[30m]))`
+Query:
 
+```
+sum(increase(src_telemetrygatewayexporter_queue_metrics_reporter_total{job=~"^worker.*"}[30m]))
+```
 </details>
 
 <br />
@@ -31198,8 +35764,11 @@ To see this panel, visit `/-/debug/grafana/d/telemetry/telemetry?viewPanel=10030
 <details>
 <summary>Technical details</summary>
 
-Query: `sum  by (le)(rate(src_telemetrygatewayexporter_queue_metrics_reporter_duration_seconds_bucket{job=~"^worker.*"}[30m]))`
+Query:
 
+```
+sum  by (le)(rate(src_telemetrygatewayexporter_queue_metrics_reporter_duration_seconds_bucket{job=~"^worker.*"}[30m]))
+```
 </details>
 
 <br />
@@ -31217,8 +35786,11 @@ To see this panel, visit `/-/debug/grafana/d/telemetry/telemetry?viewPanel=10030
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_telemetrygatewayexporter_queue_metrics_reporter_errors_total{job=~"^worker.*"}[30m]))`
+Query:
 
+```
+sum(increase(src_telemetrygatewayexporter_queue_metrics_reporter_errors_total{job=~"^worker.*"}[30m]))
+```
 </details>
 
 <br />
@@ -31236,8 +35808,11 @@ To see this panel, visit `/-/debug/grafana/d/telemetry/telemetry?viewPanel=10030
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_telemetrygatewayexporter_queue_metrics_reporter_errors_total{job=~"^worker.*"}[30m])) / (sum(increase(src_telemetrygatewayexporter_queue_metrics_reporter_total{job=~"^worker.*"}[30m])) + sum(increase(src_telemetrygatewayexporter_queue_metrics_reporter_errors_total{job=~"^worker.*"}[30m]))) * 100`
+Query:
 
+```
+sum(increase(src_telemetrygatewayexporter_queue_metrics_reporter_errors_total{job=~"^worker.*"}[30m])) / (sum(increase(src_telemetrygatewayexporter_queue_metrics_reporter_total{job=~"^worker.*"}[30m])) + sum(increase(src_telemetrygatewayexporter_queue_metrics_reporter_errors_total{job=~"^worker.*"}[30m]))) * 100
+```
 </details>
 
 <br />
@@ -31257,8 +35832,11 @@ To see this panel, visit `/-/debug/grafana/d/telemetry/telemetry?viewPanel=10040
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_telemetry_job_total{job=~"^worker.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_telemetry_job_total{job=~"^worker.*"}[5m]))
+```
 </details>
 
 <br />
@@ -31276,8 +35854,11 @@ To see this panel, visit `/-/debug/grafana/d/telemetry/telemetry?viewPanel=10040
 <details>
 <summary>Technical details</summary>
 
-Query: `sum  by (le)(rate(src_telemetry_job_duration_seconds_bucket{job=~"^worker.*"}[5m]))`
+Query:
 
+```
+sum  by (le)(rate(src_telemetry_job_duration_seconds_bucket{job=~"^worker.*"}[5m]))
+```
 </details>
 
 <br />
@@ -31295,8 +35876,11 @@ To see this panel, visit `/-/debug/grafana/d/telemetry/telemetry?viewPanel=10040
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_telemetry_job_errors_total{job=~"^worker.*"}[5m]))`
+Query:
 
+```
+sum(increase(src_telemetry_job_errors_total{job=~"^worker.*"}[5m]))
+```
 </details>
 
 <br />
@@ -31314,8 +35898,11 @@ To see this panel, visit `/-/debug/grafana/d/telemetry/telemetry?viewPanel=10040
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_telemetry_job_errors_total{job=~"^worker.*"}[5m])) / (sum(increase(src_telemetry_job_total{job=~"^worker.*"}[5m])) + sum(increase(src_telemetry_job_errors_total{job=~"^worker.*"}[5m]))) * 100`
+Query:
 
+```
+sum(increase(src_telemetry_job_errors_total{job=~"^worker.*"}[5m])) / (sum(increase(src_telemetry_job_total{job=~"^worker.*"}[5m])) + sum(increase(src_telemetry_job_errors_total{job=~"^worker.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -31333,8 +35920,11 @@ To see this panel, visit `/-/debug/grafana/d/telemetry/telemetry?viewPanel=10041
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_telemetry_job_total{job=~"^worker.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_telemetry_job_total{job=~"^worker.*"}[5m]))
+```
 </details>
 
 <br />
@@ -31352,8 +35942,11 @@ To see this panel, visit `/-/debug/grafana/d/telemetry/telemetry?viewPanel=10041
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.99, sum  by (le,op)(rate(src_telemetry_job_duration_seconds_bucket{job=~"^worker.*"}[5m])))`
+Query:
 
+```
+histogram_quantile(0.99, sum  by (le,op)(rate(src_telemetry_job_duration_seconds_bucket{job=~"^worker.*"}[5m])))
+```
 </details>
 
 <br />
@@ -31371,8 +35964,11 @@ To see this panel, visit `/-/debug/grafana/d/telemetry/telemetry?viewPanel=10041
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_telemetry_job_errors_total{job=~"^worker.*"}[5m]))`
+Query:
 
+```
+sum by (op)(increase(src_telemetry_job_errors_total{job=~"^worker.*"}[5m]))
+```
 </details>
 
 <br />
@@ -31390,8 +35986,11 @@ To see this panel, visit `/-/debug/grafana/d/telemetry/telemetry?viewPanel=10041
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_telemetry_job_errors_total{job=~"^worker.*"}[5m])) / (sum by (op)(increase(src_telemetry_job_total{job=~"^worker.*"}[5m])) + sum by (op)(increase(src_telemetry_job_errors_total{job=~"^worker.*"}[5m]))) * 100`
+Query:
 
+```
+sum by (op)(increase(src_telemetry_job_errors_total{job=~"^worker.*"}[5m])) / (sum by (op)(increase(src_telemetry_job_total{job=~"^worker.*"}[5m])) + sum by (op)(increase(src_telemetry_job_errors_total{job=~"^worker.*"}[5m]))) * 100
+```
 </details>
 
 <br />
@@ -31411,8 +36010,11 @@ To see this panel, visit `/-/debug/grafana/d/telemetry/telemetry?viewPanel=10050
 <details>
 <summary>Technical details</summary>
 
-Query: `max(src_telemetry_job_queue_size_total{job=~"^worker.*"})`
+Query:
 
+```
+max(src_telemetry_job_queue_size_total{job=~"^worker.*"})
+```
 </details>
 
 <br />
@@ -31436,8 +36038,11 @@ To see this panel, visit `/-/debug/grafana/d/telemetry/telemetry?viewPanel=10050
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_telemetry_job_queue_size_total{job=~"^worker.*"}[30m])) / sum(increase(src_telemetry_job_queue_size_processor_total{job=~"^worker.*"}[30m]))`
+Query:
 
+```
+sum(increase(src_telemetry_job_queue_size_total{job=~"^worker.*"}[30m])) / sum(increase(src_telemetry_job_queue_size_processor_total{job=~"^worker.*"}[30m]))
+```
 </details>
 
 <br />
@@ -31457,8 +36062,11 @@ To see this panel, visit `/-/debug/grafana/d/telemetry/telemetry?viewPanel=10060
 <details>
 <summary>Technical details</summary>
 
-Query: `rate(src_telemetry_job_total{op="SendEvents"}[1h]) / on() group_right() src_telemetry_job_max_throughput * 100`
+Query:
 
+```
+rate(src_telemetry_job_total{op="SendEvents"}[1h]) / on() group_right() src_telemetry_job_max_throughput * 100
+```
 </details>
 
 <br />
@@ -31495,8 +36103,11 @@ To see this panel, visit `/-/debug/grafana/d/otel-collector/otel-collector?viewP
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (receiver) (rate(otelcol_receiver_accepted_spans[1m]))`
+Query:
 
+```
+sum by (receiver) (rate(otelcol_receiver_accepted_spans[1m]))
+```
 </details>
 
 <br />
@@ -31516,8 +36127,11 @@ To see this panel, visit `/-/debug/grafana/d/otel-collector/otel-collector?viewP
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (receiver) (rate(otelcol_receiver_refused_spans[1m]))`
+Query:
 
+```
+sum by (receiver) (rate(otelcol_receiver_refused_spans[1m]))
+```
 </details>
 
 <br />
@@ -31544,8 +36158,11 @@ To see this panel, visit `/-/debug/grafana/d/otel-collector/otel-collector?viewP
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (exporter) (rate(otelcol_exporter_sent_spans[1m]))`
+Query:
 
+```
+sum by (exporter) (rate(otelcol_exporter_sent_spans[1m]))
+```
 </details>
 
 <br />
@@ -31567,8 +36184,11 @@ To see this panel, visit `/-/debug/grafana/d/otel-collector/otel-collector?viewP
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (exporter) (rate(otelcol_exporter_send_failed_spans[1m]))`
+Query:
 
+```
+sum by (exporter) (rate(otelcol_exporter_send_failed_spans[1m]))
+```
 </details>
 
 <br />
@@ -31590,8 +36210,11 @@ To see this panel, visit `/-/debug/grafana/d/otel-collector/otel-collector?viewP
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (exporter) (rate(otelcol_exporter_queue_capacity{job=~"^.*"}[1m]))`
+Query:
 
+```
+sum by (exporter) (rate(otelcol_exporter_queue_capacity{job=~"^.*"}[1m]))
+```
 </details>
 
 <br />
@@ -31611,8 +36234,11 @@ To see this panel, visit `/-/debug/grafana/d/otel-collector/otel-collector?viewP
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (exporter) (rate(otelcol_exporter_queue_size{job=~"^.*"}[1m]))`
+Query:
 
+```
+sum by (exporter) (rate(otelcol_exporter_queue_size{job=~"^.*"}[1m]))
+```
 </details>
 
 <br />
@@ -31632,8 +36258,11 @@ To see this panel, visit `/-/debug/grafana/d/otel-collector/otel-collector?viewP
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (exporter) (rate(otelcol_exporter_enqueue_failed_spans{job=~"^.*"}[1m]))`
+Query:
 
+```
+sum by (exporter) (rate(otelcol_exporter_enqueue_failed_spans{job=~"^.*"}[1m]))
+```
 </details>
 
 <br />
@@ -31655,8 +36284,11 @@ To see this panel, visit `/-/debug/grafana/d/otel-collector/otel-collector?viewP
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (processor) (rate(otelcol_processor_dropped_spans[1m]))`
+Query:
 
+```
+sum by (processor) (rate(otelcol_processor_dropped_spans[1m]))
+```
 </details>
 
 <br />
@@ -31678,8 +36310,11 @@ To see this panel, visit `/-/debug/grafana/d/otel-collector/otel-collector?viewP
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (job) (rate(otelcol_process_cpu_seconds{job=~"^.*"}[1m]))`
+Query:
 
+```
+sum by (job) (rate(otelcol_process_cpu_seconds{job=~"^.*"}[1m]))
+```
 </details>
 
 <br />
@@ -31699,8 +36334,11 @@ To see this panel, visit `/-/debug/grafana/d/otel-collector/otel-collector?viewP
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (job) (rate(otelcol_process_memory_rss{job=~"^.*"}[1m]))`
+Query:
 
+```
+sum by (job) (rate(otelcol_process_memory_rss{job=~"^.*"}[1m]))
+```
 </details>
 
 <br />
@@ -31726,8 +36364,11 @@ To see this panel, visit `/-/debug/grafana/d/otel-collector/otel-collector?viewP
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (job) (rate(otelcol_process_runtime_total_alloc_bytes{job=~"^.*"}[1m]))`
+Query:
 
+```
+sum by (job) (rate(otelcol_process_runtime_total_alloc_bytes{job=~"^.*"}[1m]))
+```
 </details>
 
 <br />
@@ -31757,8 +36398,11 @@ To see this panel, visit `/-/debug/grafana/d/otel-collector/otel-collector?viewP
 <details>
 <summary>Technical details</summary>
 
-Query: `count by(name) ((time() - container_last_seen{name=~"^otel-collector.*"}) > 60)`
+Query:
 
+```
+count by(name) ((time() - container_last_seen{name=~"^otel-collector.*"}) > 60)
+```
 </details>
 
 <br />
@@ -31776,8 +36420,11 @@ To see this panel, visit `/-/debug/grafana/d/otel-collector/otel-collector?viewP
 <details>
 <summary>Technical details</summary>
 
-Query: `cadvisor_container_cpu_usage_percentage_total{name=~"^otel-collector.*"}`
+Query:
 
+```
+cadvisor_container_cpu_usage_percentage_total{name=~"^otel-collector.*"}
+```
 </details>
 
 <br />
@@ -31795,8 +36442,11 @@ To see this panel, visit `/-/debug/grafana/d/otel-collector/otel-collector?viewP
 <details>
 <summary>Technical details</summary>
 
-Query: `cadvisor_container_memory_usage_percentage_total{name=~"^otel-collector.*"}`
+Query:
 
+```
+cadvisor_container_memory_usage_percentage_total{name=~"^otel-collector.*"}
+```
 </details>
 
 <br />
@@ -31817,8 +36467,11 @@ To see this panel, visit `/-/debug/grafana/d/otel-collector/otel-collector?viewP
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by(name) (rate(container_fs_reads_total{name=~"^otel-collector.*"}[1h]) + rate(container_fs_writes_total{name=~"^otel-collector.*"}[1h]))`
+Query:
 
+```
+sum by(name) (rate(container_fs_reads_total{name=~"^otel-collector.*"}[1h]) + rate(container_fs_writes_total{name=~"^otel-collector.*"}[1h]))
+```
 </details>
 
 <br />
@@ -31838,8 +36491,11 @@ To see this panel, visit `/-/debug/grafana/d/otel-collector/otel-collector?viewP
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by(app) (up{app=~".*otel-collector"}) / count by (app) (up{app=~".*otel-collector"}) * 100`
+Query:
 
+```
+sum by(app) (up{app=~".*otel-collector"}) / count by (app) (up{app=~".*otel-collector"}) * 100
+```
 </details>
 
 <br />
@@ -31867,8 +36523,11 @@ To see this panel, visit `/-/debug/grafana/d/embeddings/embeddings?viewPanel=100
 <details>
 <summary>Technical details</summary>
 
-Query: `src_conf_client_time_since_last_successful_update_seconds{job=~`.*embeddings`,instance=~`${instance:regex}`}`
+Query:
 
+```
+src_conf_client_time_since_last_successful_update_seconds{job=~`.*embeddings`,instance=~`${instance:regex}`}
+```
 </details>
 
 <br />
@@ -31886,8 +36545,11 @@ To see this panel, visit `/-/debug/grafana/d/embeddings/embeddings?viewPanel=100
 <details>
 <summary>Technical details</summary>
 
-Query: `max(max_over_time(src_conf_client_time_since_last_successful_update_seconds{job=~`.*embeddings`,instance=~`${instance:regex}`}[1m]))`
+Query:
 
+```
+max(max_over_time(src_conf_client_time_since_last_successful_update_seconds{job=~`.*embeddings`,instance=~`${instance:regex}`}[1m]))
+```
 </details>
 
 <br />
@@ -31907,8 +36569,11 @@ To see this panel, visit `/-/debug/grafana/d/embeddings/embeddings?viewPanel=100
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (app_name, db_name) (src_pgsql_conns_max_open{app_name="embeddings"})`
+Query:
 
+```
+sum by (app_name, db_name) (src_pgsql_conns_max_open{app_name="embeddings"})
+```
 </details>
 
 <br />
@@ -31926,8 +36591,11 @@ To see this panel, visit `/-/debug/grafana/d/embeddings/embeddings?viewPanel=100
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (app_name, db_name) (src_pgsql_conns_open{app_name="embeddings"})`
+Query:
 
+```
+sum by (app_name, db_name) (src_pgsql_conns_open{app_name="embeddings"})
+```
 </details>
 
 <br />
@@ -31945,8 +36613,11 @@ To see this panel, visit `/-/debug/grafana/d/embeddings/embeddings?viewPanel=100
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (app_name, db_name) (src_pgsql_conns_in_use{app_name="embeddings"})`
+Query:
 
+```
+sum by (app_name, db_name) (src_pgsql_conns_in_use{app_name="embeddings"})
+```
 </details>
 
 <br />
@@ -31964,8 +36635,11 @@ To see this panel, visit `/-/debug/grafana/d/embeddings/embeddings?viewPanel=100
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (app_name, db_name) (src_pgsql_conns_idle{app_name="embeddings"})`
+Query:
 
+```
+sum by (app_name, db_name) (src_pgsql_conns_idle{app_name="embeddings"})
+```
 </details>
 
 <br />
@@ -31983,8 +36657,11 @@ To see this panel, visit `/-/debug/grafana/d/embeddings/embeddings?viewPanel=100
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (app_name, db_name) (increase(src_pgsql_conns_blocked_seconds{app_name="embeddings"}[5m])) / sum by (app_name, db_name) (increase(src_pgsql_conns_waited_for{app_name="embeddings"}[5m]))`
+Query:
 
+```
+sum by (app_name, db_name) (increase(src_pgsql_conns_blocked_seconds{app_name="embeddings"}[5m])) / sum by (app_name, db_name) (increase(src_pgsql_conns_waited_for{app_name="embeddings"}[5m]))
+```
 </details>
 
 <br />
@@ -32002,8 +36679,11 @@ To see this panel, visit `/-/debug/grafana/d/embeddings/embeddings?viewPanel=100
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (app_name, db_name) (increase(src_pgsql_conns_closed_max_idle{app_name="embeddings"}[5m]))`
+Query:
 
+```
+sum by (app_name, db_name) (increase(src_pgsql_conns_closed_max_idle{app_name="embeddings"}[5m]))
+```
 </details>
 
 <br />
@@ -32021,8 +36701,11 @@ To see this panel, visit `/-/debug/grafana/d/embeddings/embeddings?viewPanel=100
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (app_name, db_name) (increase(src_pgsql_conns_closed_max_lifetime{app_name="embeddings"}[5m]))`
+Query:
 
+```
+sum by (app_name, db_name) (increase(src_pgsql_conns_closed_max_lifetime{app_name="embeddings"}[5m]))
+```
 </details>
 
 <br />
@@ -32040,8 +36723,11 @@ To see this panel, visit `/-/debug/grafana/d/embeddings/embeddings?viewPanel=100
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (app_name, db_name) (increase(src_pgsql_conns_closed_max_idle_time{app_name="embeddings"}[5m]))`
+Query:
 
+```
+sum by (app_name, db_name) (increase(src_pgsql_conns_closed_max_idle_time{app_name="embeddings"}[5m]))
+```
 </details>
 
 <br />
@@ -32071,8 +36757,11 @@ To see this panel, visit `/-/debug/grafana/d/embeddings/embeddings?viewPanel=100
 <details>
 <summary>Technical details</summary>
 
-Query: `count by(name) ((time() - container_last_seen{name=~"^embeddings.*"}) > 60)`
+Query:
 
+```
+count by(name) ((time() - container_last_seen{name=~"^embeddings.*"}) > 60)
+```
 </details>
 
 <br />
@@ -32090,8 +36779,11 @@ To see this panel, visit `/-/debug/grafana/d/embeddings/embeddings?viewPanel=100
 <details>
 <summary>Technical details</summary>
 
-Query: `cadvisor_container_cpu_usage_percentage_total{name=~"^embeddings.*"}`
+Query:
 
+```
+cadvisor_container_cpu_usage_percentage_total{name=~"^embeddings.*"}
+```
 </details>
 
 <br />
@@ -32109,8 +36801,11 @@ To see this panel, visit `/-/debug/grafana/d/embeddings/embeddings?viewPanel=100
 <details>
 <summary>Technical details</summary>
 
-Query: `cadvisor_container_memory_usage_percentage_total{name=~"^embeddings.*"}`
+Query:
 
+```
+cadvisor_container_memory_usage_percentage_total{name=~"^embeddings.*"}
+```
 </details>
 
 <br />
@@ -32131,8 +36826,11 @@ To see this panel, visit `/-/debug/grafana/d/embeddings/embeddings?viewPanel=100
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by(name) (rate(container_fs_reads_total{name=~"^embeddings.*"}[1h]) + rate(container_fs_writes_total{name=~"^embeddings.*"}[1h]))`
+Query:
 
+```
+sum by(name) (rate(container_fs_reads_total{name=~"^embeddings.*"}[1h]) + rate(container_fs_writes_total{name=~"^embeddings.*"}[1h]))
+```
 </details>
 
 <br />
@@ -32152,8 +36850,11 @@ To see this panel, visit `/-/debug/grafana/d/embeddings/embeddings?viewPanel=100
 <details>
 <summary>Technical details</summary>
 
-Query: `quantile_over_time(0.9, cadvisor_container_cpu_usage_percentage_total{name=~"^embeddings.*"}[1d])`
+Query:
 
+```
+quantile_over_time(0.9, cadvisor_container_cpu_usage_percentage_total{name=~"^embeddings.*"}[1d])
+```
 </details>
 
 <br />
@@ -32171,8 +36872,11 @@ To see this panel, visit `/-/debug/grafana/d/embeddings/embeddings?viewPanel=100
 <details>
 <summary>Technical details</summary>
 
-Query: `max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^embeddings.*"}[1d])`
+Query:
 
+```
+max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^embeddings.*"}[1d])
+```
 </details>
 
 <br />
@@ -32190,8 +36894,11 @@ To see this panel, visit `/-/debug/grafana/d/embeddings/embeddings?viewPanel=100
 <details>
 <summary>Technical details</summary>
 
-Query: `max_over_time(cadvisor_container_cpu_usage_percentage_total{name=~"^embeddings.*"}[5m])`
+Query:
 
+```
+max_over_time(cadvisor_container_cpu_usage_percentage_total{name=~"^embeddings.*"}[5m])
+```
 </details>
 
 <br />
@@ -32209,8 +36916,11 @@ To see this panel, visit `/-/debug/grafana/d/embeddings/embeddings?viewPanel=100
 <details>
 <summary>Technical details</summary>
 
-Query: `max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^embeddings.*"}[5m])`
+Query:
 
+```
+max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^embeddings.*"}[5m])
+```
 </details>
 
 <br />
@@ -32231,8 +36941,11 @@ To see this panel, visit `/-/debug/grafana/d/embeddings/embeddings?viewPanel=100
 <details>
 <summary>Technical details</summary>
 
-Query: `max by (name) (container_oom_events_total{name=~"^embeddings.*"})`
+Query:
 
+```
+max by (name) (container_oom_events_total{name=~"^embeddings.*"})
+```
 </details>
 
 <br />
@@ -32254,8 +36967,11 @@ To see this panel, visit `/-/debug/grafana/d/embeddings/embeddings?viewPanel=100
 <details>
 <summary>Technical details</summary>
 
-Query: `max by(instance) (go_goroutines{job=~".*embeddings"})`
+Query:
 
+```
+max by(instance) (go_goroutines{job=~".*embeddings"})
+```
 </details>
 
 <br />
@@ -32273,8 +36989,11 @@ To see this panel, visit `/-/debug/grafana/d/embeddings/embeddings?viewPanel=100
 <details>
 <summary>Technical details</summary>
 
-Query: `max by(instance) (go_gc_duration_seconds{job=~".*embeddings"})`
+Query:
 
+```
+max by(instance) (go_gc_duration_seconds{job=~".*embeddings"})
+```
 </details>
 
 <br />
@@ -32294,8 +37013,11 @@ To see this panel, visit `/-/debug/grafana/d/embeddings/embeddings?viewPanel=100
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by(app) (up{app=~".*embeddings"}) / count by (app) (up{app=~".*embeddings"}) * 100`
+Query:
 
+```
+sum by(app) (up{app=~".*embeddings"}) / count by (app) (up{app=~".*embeddings"}) * 100
+```
 </details>
 
 <br />
@@ -32316,8 +37038,11 @@ To see this panel, visit `/-/debug/grafana/d/embeddings/embeddings?viewPanel=100
 <details>
 <summary>Technical details</summary>
 
-Query: `rate(src_embeddings_cache_hit_count[30m]) / (rate(src_embeddings_cache_hit_count[30m]) + rate(src_embeddings_cache_miss_count[30m]))`
+Query:
 
+```
+rate(src_embeddings_cache_hit_count[30m]) / (rate(src_embeddings_cache_hit_count[30m]) + rate(src_embeddings_cache_miss_count[30m]))
+```
 </details>
 
 <br />
@@ -32336,8 +37061,11 @@ To see this panel, visit `/-/debug/grafana/d/embeddings/embeddings?viewPanel=100
 <details>
 <summary>Technical details</summary>
 
-Query: `rate(src_embeddings_cache_miss_bytes[10m])`
+Query:
 
+```
+rate(src_embeddings_cache_miss_bytes[10m])
+```
 </details>
 
 <br />

--- a/monitoring/monitoring/documentation.go
+++ b/monitoring/monitoring/documentation.go
@@ -227,10 +227,11 @@ func (d *documentation) renderDashboardPanelEntry(c *Dashboard, o Observable, pa
 <details>
 <summary>Technical details</summary>
 
-Query: %s
+Query:
 
+`+"```\n%s\n```"+`
 </details>
-`, fmt.Sprintf("`%s`", o.Query))
+`, o.Query)
 
 	// render break for readability
 	fmt.Fprint(&d.dashboards, "\n<br />\n\n")


### PR DESCRIPTION
While taking on the sync job to automatically port generated doc changes to github.com/sourcegraph/docs, I stumbled across a rendering issue, when the prom queries are involving backticks. 

I initially went for using \` but it's a bit of as reliable as using a code block, as not all markdown parsers handles it the same. Other options are to use double backticks, but, well, same thing. In the end code blocks are dumb and do exactly what we want. 

## Test plan

Before: 

![CleanShot 2024-03-20 at 10 50 53@2x](https://github.com/sourcegraph/sourcegraph/assets/10151/d09fb095-9edc-4c19-9de5-e412d5ab59d8)

After

![CleanShot 2024-03-20 at 10 51 10@2x](https://github.com/sourcegraph/sourcegraph/assets/10151/d6170940-e4b1-4978-9ced-b346d39e59cf)


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->


## Preview 🤩
[Preview Link](https://docs.sourcegraph.com/@jh/fix-monitoring-docs)