### PR TITLE
release: add permission type for BUILDKITE_ACCESS_TOKEN

### DIFF
--- a/release.yaml
+++ b/release.yaml
@@ -8,7 +8,7 @@ requirements:
   - name: "curl"
     cmd: "curl --help"
   - name: "Buidkite access token"
-    env: BUILDKITE_ACCESS_TOKEN
+    env: BUILDKITE_ACCESS_TOKEN # `write_builds` permission is needed here
 
   # #announce-engineering slack webhook url:
   # https://start.1password.com/open/i?a=HEDEDSLHPBFGRBTKAKJWE23XX4&v=dnrhbauihkhjs5ag6vszsme45a&i=pldpna5vivapxe4phewnqd42ji&h=team-sourcegraph.1password.com


### PR DESCRIPTION
Add `BUILDKITE_ACCESS_TOKEN` permission needed for release.

## Test plan

Added a comment for future use.
