### PR TITLE
release: update PKR_VAR_name when building executor AMIs

### DIFF
--- a/cmd/executor/vm-image/_ami.build.sh
+++ b/cmd/executor/vm-image/_ami.build.sh
@@ -34,7 +34,10 @@ GCP_PROJECT="aspect-dev"
 "$gcloud" secrets versions access latest --secret=e2e-builder-sa-key --quiet --project="$GCP_PROJECT" >"workdir/builder-sa-key.json"
 
 export PKR_VAR_name
-PKR_VAR_name="${IMAGE_FAMILY}-${BUILDKITE_BUILD_NUMBER}"
+PKR_VAR_name="${IMAGE_FAMILY}"
+if [ "${RELEASE_INTERNAL:-}" != "true" ]; then
+  PKR_VAR_name="${PKR_VAR_name}-${BUILDKITE_BUILD_NUMBER}"
+fi
 export PKR_VAR_image_family="${IMAGE_FAMILY}"
 export PKR_VAR_tagged_release="${EXECUTOR_IS_TAGGED_RELEASE}"
 export PKR_VAR_version="${VERSION}"


### PR DESCRIPTION
#61263 catered for how we push the executor AMIs, however we didn't handle building these AMIs. This was an oversight that should be fixed by this PR.

I noticed this after creating [an internal release](https://buildkite.com/sourcegraph/sourcegraph/builds/265831#018e5bb1-9e40-400c-ae3c-a441b332b7f0/168) and watching Buildkite fail.
![CleanShot 2024-03-20 at 14 42 38@2x](https://github.com/sourcegraph/sourcegraph/assets/25608335/de4eab4a-67af-46d4-a07c-273085dc8570)

I noticed the image number was appended with the BUILDKITE_BUILD_NUMBER, however when publishing said images we look for images without the build number.

![CleanShot 2024-03-20 at 14 43 44@2x](https://github.com/sourcegraph/sourcegraph/assets/25608335/77c9da78-0e3a-45f8-b0b5-14be33c22b70)

## Test plan

Creating another internal release and hopefully CI should pass now.