### PR TITLE
bazel: rework schema migrations reporule without gsutil

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -156,6 +156,10 @@ http_archive(
     url = "https://github.com/aspect-build/aspect-cli/archive/5.8.20.tar.gz",
 )
 
+load("@aspect_bazel_lib//lib:repositories.bzl", "register_jq_toolchains")
+
+register_jq_toolchains()
+
 # hermetic_cc_toolchain setup ================================
 HERMETIC_CC_TOOLCHAIN_VERSION = "v2.2.1"
 

--- a/dev/schema_migrations.bzl
+++ b/dev/schema_migrations.bzl
@@ -1,16 +1,13 @@
 def _schema_migrations(rctx):
-    gsutil_path = rctx.path(
-        Label("@gcloud-{}-{}//:gsutil".format({
-            "mac os x": "darwin",
-            "linux": "linux",
-        }[rctx.os.name], {
-            "aarch64": "arm64",
-            "arm64": "arm64",
-            "amd64": "amd64",
-            "x86_64": "amd64",
-            "x86": "amd64",
-        }[rctx.os.arch])),
-    )
+    """
+    This repository is used to download the schema migrations from GCS.
+
+    We use the GCS JSON API directly instead of gsutil or gcloud because:
+        - gsutil may spend up to a ~1m20s trying to contact metadata.google.internal
+            without a discovered way to disable that
+        - gcloud disallows unauthed access to an even public bucket
+    """
+    jq_path = rctx.path(Label("@jq//:jq"))
 
     rctx.file("BUILD.bazel", content = """
 package(default_visibility = ["//visibility:public"])
@@ -23,19 +20,37 @@ filegroup(
 )
 """)
 
-    rctx.execute(["mkdir", "archives"])
-    rctx.report_progress("Downloading schema migrations from GCS")
+    rctx.report_progress("Listing GCS bucket contents")
+
+    rctx.download("https://storage.googleapis.com/storage/v1/b/schemas-migrations/o?prefix=migrations/migrations-", "bucket_contents.json")
+
     result = rctx.execute([
-        gsutil_path,
-        "-m",
-        "cp",
-        "gs://schemas-migrations/migrations/*",
-        "archives",
-    ], timeout = 60, environment = {
-        "CLOUDSDK_CORE_PROJECT": "sourcegraph-ci",
-    })
+        jq_path,
+        ".items | map({name, mediaLink, generation})",
+        "bucket_contents.json",
+    ])
     if result.return_code != 0:
-        fail("Failed to download schema migrations from GCS: {}".format(result.stderr))
+        fail("Failed to extract bucket data from GCS API: {}".format(result.stderr))
+
+    rctx.delete("bucket_contents.json")
+
+    output = json.decode(result.stdout)
+
+    rctx.execute(["mkdir", "archives"])
+
+    rctx.report_progress("Downloading schema migrations from GCS")
+
+    download_tokens = []
+    for file in output:
+        download_tokens.append(rctx.download(
+            file["mediaLink"],
+            "archives/" + file["name"].split("/")[-1],
+            canonical_id = file["generation"],
+            block = False,
+        ))
+
+    for token in download_tokens:
+        token.wait()
 
 schema_migrations = repository_rule(
     implementation = _schema_migrations,


### PR DESCRIPTION
We use the GCS JSON API directly instead of gsutil or gcloud because:
        - gsutil may spend up to a ~1m20s trying to contact metadata.google.internal
            without a discovered way to disable that
        - gcloud disallows unauthed access to an even public bucket

TODO: in future iterations we can explore how to properly invalidate this. For now we can force a refresh with `bazel sync`

## Test plan

`bazel run //internal/database/migration/shared:write_stitched_migration_graph` runs successfully and without a change to the file
