### PR TITLE
Svelte: make markdown blob rendering consistent with react app

### DIFF
--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/+page.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/+page.svelte
@@ -17,6 +17,7 @@
     import Permalink from '$lib/repo/Permalink.svelte'
     import { createCodeIntelAPI, parseQueryAndHash } from '$lib/shared'
     import { Alert } from '$lib/wildcard'
+    import markdownStyles from '$lib/wildcard/Markdown.module.scss'
 
     import type { PageData } from './$types'
     import FormatAction from './FormatAction.svelte'
@@ -92,7 +93,7 @@
         {/await}
     {:else if blob}
         {#if blob.richHTML && !showRaw}
-            <div class="rich">
+            <div class={`rich ${markdownStyles.markdown}`}>
                 {@html blob.richHTML}
             </div>
         {:else}
@@ -152,6 +153,7 @@
     .rich {
         padding: 1rem;
         overflow: auto;
+        max-width: 50rem;
     }
 
     .circle {


### PR DESCRIPTION
Just a small change to make the markdown rendering look nicer in the blob view. We already have the markdown styles, we just weren't applying them and were just rendering the raw HTML. Additionally, this adds a max width of `50rem` to the markdown column to match the behavior of the react app.

## Test plan

Before: 

![CleanShot 2024-03-20 at 10 46 14@2x](https://github.com/sourcegraph/sourcegraph/assets/12631702/6b05a846-6a34-49e1-a072-074336b55db6)

After:
![CleanShot 2024-03-20 at 10 46 29@2x](https://github.com/sourcegraph/sourcegraph/assets/12631702/b1d5c78d-06cf-4c46-a6b7-76f3a938b591)





<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
