### PR TITLE
release: specify version when running release test

### DIFF
--- a/dev/ci/internal/ci/release_operations.go
+++ b/dev/ci/internal/ci/release_operations.go
@@ -41,7 +41,7 @@ func releaseTestOperation(c Config) operations.Operation {
 			bk.Agent("queue", AspectWorkflows.QueueDefault),
 			bk.Env("VERSION", c.Version),
 			bk.AnnotatedCmd(
-				bazelCmd(`run --run_under="cd $$PWD &&" //dev/sg -- release run test --branch $$BUILDKITE_BRANCH`),
+				bazelCmd(`run --run_under="cd $$PWD &&" //dev/sg -- release run test --branch $$BUILDKITE_BRANCH --version $$VERSION`),
 				bk.AnnotatedCmdOpts{
 					Annotations: &bk.AnnotationOpts{
 						Type:         bk.AnnotationTypeInfo,


### PR DESCRIPTION
The `sg release` tool expects the version to be specified when running a release test.

![CleanShot 2024-03-21 at 11 35 22@2x](https://github.com/sourcegraph/sourcegraph/assets/25608335/883d0525-1789-474e-a66e-bc374e84c307)

THe version exists in the environment so I'm guessing `$$` should be sufficient enough to reference the version lol.

## Test plan

Try another internal release.
