### PR TITLE
release: specify version when finalizing release

### DIFF
--- a/dev/ci/internal/ci/release_operations.go
+++ b/dev/ci/internal/ci/release_operations.go
@@ -70,7 +70,7 @@ func releaseFinalizeOperation(c Config) operations.Operation {
 			bk.Agent("queue", AspectWorkflows.QueueDefault),
 			bk.Env("VERSION", c.Version),
 			bk.AnnotatedCmd(
-				bazelCmd(fmt.Sprintf(`run --run_under="cd $$PWD &&" //dev/sg -- release run %s finalize --branch $$BUILDKITE_BRANCH`, command)),
+				bazelCmd(fmt.Sprintf(`run --run_under="cd $$PWD &&" //dev/sg -- release run %s finalize --branch $$BUILDKITE_BRANCH --version $$VERSION`, command)),
 				bk.AnnotatedCmdOpts{
 					Annotations: &bk.AnnotationOpts{
 						Type:         bk.AnnotationTypeInfo,


### PR DESCRIPTION
similar to #61317, we need to specify version when running `sg release finalize`.

![CleanShot 2024-03-21 at 13 59 56@2x](https://github.com/sourcegraph/sourcegraph/assets/25608335/59c9f2df-d49d-41be-979d-42e8d230d856)

## Test plan

Successful internal release.
