### PR TITLE
svelte: Persist theme choice

### DIFF
--- a/client/web-sveltekit/src/app.html
+++ b/client/web-sveltekit/src/app.html
@@ -11,6 +11,15 @@
         <meta name="color-scheme" content="light dark" />
 
         %sveltekit.head%
+        <script>
+            const userPreference = localStorage.getItem('sourcegraph-theme') || 'System'
+            const theme =
+                (userPreference === 'System' && window.matchMedia('(prefers-color-scheme: dark)').matches) ||
+                userPreference === 'Dark'
+                    ? 'theme-dark'
+                    : 'theme-light'
+            document.documentElement.classList.add(theme)
+        </script>
     </head>
     <body data-sveltekit-preload-data data-sveltekit-preload-code="hover">
         <div style="display: contents">%sveltekit.body%</div>

--- a/client/web-sveltekit/src/app.prod.html
+++ b/client/web-sveltekit/src/app.prod.html
@@ -17,6 +17,16 @@
         </script>
 
         %sveltekit.head%
+
+        <script>
+            const userPreference = localStorage.getItem('sourcegraph-theme') || 'System'
+            const theme =
+                (userPreference === 'System' && window.matchMedia('(prefers-color-scheme: dark)').matches) ||
+                userPreference === 'Dark'
+                    ? 'theme-dark'
+                    : 'theme-light'
+            document.documentElement.classList.add(theme)
+        </script>
     </head>
     <body data-sveltekit-preload-data data-sveltekit-preload-code="hover">
         <div style="display: contents">%sveltekit.body%</div>

--- a/client/web-sveltekit/src/lib/stores.ts
+++ b/client/web-sveltekit/src/lib/stores.ts
@@ -1,26 +1,32 @@
-import { getContext } from 'svelte'
+import { getContext, setContext } from 'svelte'
 import { readable, writable, type Readable, type Writable } from 'svelte/store'
 
 import type { Settings, TemporarySettingsStorage } from '$lib/shared'
 
 import type { AuthenticatedUser, FeatureFlag } from '../routes/layout.gql'
 
-export { isLightTheme } from './theme'
+export { theme, isLightTheme } from './theme'
 
-export interface SourcegraphContext {
+const KEY = '__sourcegraph__'
+
+interface SourcegraphContext {
     settings: Readable<Settings | null>
     user: Readable<AuthenticatedUser | null>
     temporarySettingsStorage: Readable<TemporarySettingsStorage>
     featureFlags: Readable<FeatureFlag[]>
 }
 
-export const KEY = '__sourcegraph__'
-
-export function getStores(): SourcegraphContext {
-    const { settings, user, temporarySettingsStorage, featureFlags } = getContext<SourcegraphContext>(KEY)
-    return { settings, user, temporarySettingsStorage, featureFlags }
+export function setAppContext(context: SourcegraphContext): void {
+    setContext<SourcegraphContext>(KEY, context)
 }
 
+export function getStores(): SourcegraphContext {
+    return getContext<SourcegraphContext>(KEY)
+}
+
+/**
+ * This store returns the currently logged in user.
+ */
 export const user = {
     subscribe(subscriber: (user: AuthenticatedUser | null) => void) {
         const { user } = getStores()
@@ -28,6 +34,9 @@ export const user = {
     },
 }
 
+/**
+ * This store returns the user's settings.
+ */
 export const settings = {
     subscribe(subscriber: (settings: Settings | null) => void) {
         const { settings } = getStores()

--- a/client/web-sveltekit/src/lib/stores.ts
+++ b/client/web-sveltekit/src/lib/stores.ts
@@ -7,9 +7,11 @@ import type { AuthenticatedUser, FeatureFlag } from '../routes/layout.gql'
 
 export { theme, isLightTheme } from './theme'
 
-const KEY = '__sourcegraph__'
+// Only exported to be used for mocking tests
+// TODO (fkling): Find a better way to initialize mocked contexts and stores
+export const KEY = '__sourcegraph__'
 
-interface SourcegraphContext {
+export interface SourcegraphContext {
     settings: Readable<Settings | null>
     user: Readable<AuthenticatedUser | null>
     temporarySettingsStorage: Readable<TemporarySettingsStorage>

--- a/client/web-sveltekit/src/lib/temporarySettings.ts
+++ b/client/web-sveltekit/src/lib/temporarySettings.ts
@@ -5,9 +5,7 @@ import { type TemporarySettings, TemporarySettingsStorage, migrateLocalStorageTo
 
 import { getStores } from './stores'
 
-const loggedOutUserStore = new TemporarySettingsStorage(null, false)
-
-export function createTemporarySettingsStorage(storage = loggedOutUserStore): Writable<TemporarySettingsStorage> {
+export function createTemporarySettingsStorage(storage: TemporarySettingsStorage): Writable<TemporarySettingsStorage> {
     const { subscribe, set } = writable(storage)
 
     function disposeAndSet(newStorage: TemporarySettingsStorage): void {

--- a/client/web-sveltekit/src/lib/temporarySettings.ts
+++ b/client/web-sveltekit/src/lib/temporarySettings.ts
@@ -34,7 +34,7 @@ type LoadingData<D, E> =
 type TemporarySettingsKey = keyof TemporarySettings
 type TemporarySettingStatus<K extends TemporarySettingsKey> = LoadingData<TemporarySettings[K], unknown>
 
-interface TemporarySettingStore<K extends TemporarySettingsKey> extends Readable<TemporarySettingStatus<K>> {
+export interface TemporarySettingStore<K extends TemporarySettingsKey> extends Readable<TemporarySettingStatus<K>> {
     setValue(value: TemporarySettings[K]): void
 }
 

--- a/client/web-sveltekit/src/lib/theme.ts
+++ b/client/web-sveltekit/src/lib/theme.ts
@@ -1,17 +1,73 @@
-import { derived, writable, type Readable } from 'svelte/store'
+import { type Writable, writable, type Updater, derived, type Readable } from 'svelte/store'
+import { temporarySetting, type TemporarySettingStore } from './temporarySettings'
 
-import { createMappingStore } from './utils'
+const LOCAL_STORAGE_THEME_KEY = 'sourcegraph-theme'
 
 export enum Theme {
-    Light,
-    Dark,
-    System,
+    Light = 'Light',
+    Dark = 'Dark',
+    System = 'System',
 }
 
 /**
- * The currently selected Theme.
+ * The currently selected theme. Writing to this store will persist the theme
+ * to temporary settings.
  */
-export const theme = writable(Theme.System)
+export const theme: Writable<Theme> = (function () {
+    let theme: Theme = (localStorage.getItem(LOCAL_STORAGE_THEME_KEY) ?? Theme.System) as Theme
+    let themeSettingStore: TemporarySettingStore<'user.themePreference'> | undefined
+
+    const { subscribe } = writable(theme, set => {
+        if (!themeSettingStore) {
+            themeSettingStore = temporarySetting('user.themePreference')
+        }
+
+        return themeSettingStore.subscribe($themeSetting => {
+            if (!$themeSetting.loading && $themeSetting.data) {
+                switch ($themeSetting.data.toLowerCase()) {
+                    case 'light': {
+                        theme = Theme.Light
+                        break
+                    }
+                    case 'dark': {
+                        theme = Theme.Dark
+                        break
+                    }
+                    case 'system': {
+                        theme = Theme.System
+                        break
+                    }
+                }
+            }
+            localStorage.setItem(LOCAL_STORAGE_THEME_KEY, theme)
+            set(theme)
+        })
+    })
+
+    function getThemeStringValue(theme: Theme): string {
+        switch (theme) {
+            case Theme.Light: {
+                return 'light'
+            }
+            case Theme.Dark: {
+                return 'dark'
+            }
+            case Theme.System: {
+                return 'system'
+            }
+        }
+    }
+
+    return {
+        subscribe,
+        set: (value: Theme) => {
+            themeSettingStore?.setValue(getThemeStringValue(value))
+        },
+        update: (updater: Updater<Theme>) => {
+            themeSettingStore?.setValue(updater(theme))
+        },
+    }
+})()
 
 /**
  * This store returns true if the theme is set to light or if the user's system
@@ -31,57 +87,3 @@ export const isLightTheme = derived(theme, ($theme, set) => {
     set($theme === Theme.Light)
     return
 }) satisfies Readable<boolean>
-
-/**
- * A store that maps user friendly theme names to Theme.* values and vice versa.
- */
-export const humanTheme = createMappingStore(
-    theme,
-    theme => {
-        switch (theme) {
-            case Theme.Light: {
-                return 'Light'
-            }
-            case Theme.Dark: {
-                return 'Dark'
-            }
-            case Theme.System: {
-                return 'System'
-            }
-        }
-    },
-    value => {
-        switch (value) {
-            case 'Light': {
-                return Theme.Light
-            }
-            case 'Dark': {
-                return Theme.Dark
-            }
-            case 'System': {
-                return Theme.System
-            }
-        }
-    }
-)
-
-/**
- * Interprets a string as a theme and sets the theme accordingly.
- */
-export function setThemeFromString(value: string): void {
-    value = value.toLowerCase()
-    switch (value) {
-        case 'light': {
-            theme.set(Theme.Light)
-            break
-        }
-        case 'dark': {
-            theme.set(Theme.Dark)
-            break
-        }
-        case 'system': {
-            theme.set(Theme.System)
-            break
-        }
-    }
-}

--- a/client/web-sveltekit/src/lib/theme.ts
+++ b/client/web-sveltekit/src/lib/theme.ts
@@ -1,6 +1,8 @@
 import { type Writable, writable, type Updater, derived, type Readable } from 'svelte/store'
-import { temporarySetting, type TemporarySettingStore } from './temporarySettings'
+
 import { browser } from '$app/environment'
+
+import { temporarySetting, type TemporarySettingStore } from './temporarySettings'
 
 const LOCAL_STORAGE_THEME_KEY = 'sourcegraph-theme'
 

--- a/client/web-sveltekit/src/lib/theme.ts
+++ b/client/web-sveltekit/src/lib/theme.ts
@@ -1,5 +1,6 @@
 import { type Writable, writable, type Updater, derived, type Readable } from 'svelte/store'
 import { temporarySetting, type TemporarySettingStore } from './temporarySettings'
+import { browser } from '$app/environment'
 
 const LOCAL_STORAGE_THEME_KEY = 'sourcegraph-theme'
 
@@ -14,7 +15,7 @@ export enum Theme {
  * to temporary settings.
  */
 export const theme: Writable<Theme> = (function () {
-    let theme: Theme = (localStorage.getItem(LOCAL_STORAGE_THEME_KEY) ?? Theme.System) as Theme
+    let theme: Theme = ((browser && localStorage.getItem(LOCAL_STORAGE_THEME_KEY)) || Theme.System) as Theme
     let themeSettingStore: TemporarySettingStore<'user.themePreference'> | undefined
 
     const { subscribe } = writable(theme, set => {

--- a/client/web-sveltekit/src/routes/+layout.svelte
+++ b/client/web-sveltekit/src/routes/+layout.svelte
@@ -27,7 +27,10 @@
     // It's OK to set the temporary storage during initialization time because
     // sign-in/out currently performs a full page refresh
     const temporarySettingsStorage = createTemporarySettingsStorage(
-        data.user ? new TemporarySettingsStorage(getGraphQLClient(), true) : undefined
+        data.user
+            ? new TemporarySettingsStorage(getGraphQLClient(), true)
+            : // Logged out storage
+              new TemporarySettingsStorage(null, false)
     )
 
     setAppContext({

--- a/client/web-sveltekit/src/routes/+layout.svelte
+++ b/client/web-sveltekit/src/routes/+layout.svelte
@@ -1,13 +1,11 @@
 <script lang="ts">
-    import { setContext } from 'svelte'
     import { writable } from 'svelte/store'
 
     import { browser, dev } from '$app/environment'
     import { isErrorLike } from '$lib/common'
     import { TemporarySettingsStorage } from '$lib/shared'
-    import { isLightTheme, KEY, scrollAll, type SourcegraphContext } from '$lib/stores'
-    import { createTemporarySettingsStorage, temporarySetting } from '$lib/temporarySettings'
-    import { setThemeFromString } from '$lib/theme'
+    import { isLightTheme, setAppContext, scrollAll } from '$lib/stores'
+    import { createTemporarySettingsStorage } from '$lib/temporarySettings'
     import { classNames } from '$lib/dom'
 
     import Header from './Header.svelte'
@@ -20,6 +18,7 @@
     import { getGraphQLClient } from '$lib/graphql/apollo'
     import { isRouteRolledOut } from '$lib/navigation'
     import { beforeNavigate } from '$app/navigation'
+    import { onDestroy } from 'svelte'
 
     export let data: LayoutData
 
@@ -31,28 +30,26 @@
         data.user ? new TemporarySettingsStorage(getGraphQLClient(), true) : undefined
     )
 
-    setContext<SourcegraphContext>(KEY, {
+    setAppContext({
         user,
         settings,
         temporarySettingsStorage,
         featureFlags: createFeatureFlagStore(data.featureFlags, data.fetchEvaluatedFeatureFlags),
     })
 
+    // We need to manually subscribe instead of using $isLightTheme because
+    // at the moment Svelte tries to automatically subscribe to the store
+    // the app context is not yet set.
+    let lightTheme = false
+    onDestroy(isLightTheme.subscribe(value => (lightTheme = value)))
+
     // Update stores when data changes
     $: $user = data.user ?? null
     $: $settings = isErrorLike(data.settings) ? null : data.settings
 
-    // Set initial, user configured theme
-    // TODO: This should be send be server in the HTML so that we don't flash the wrong theme
-    // on initial page load.
-    $: userTheme = temporarySetting('user.themePreference', 'System')
-    $: if (!$userTheme.loading && $userTheme.data) {
-        setThemeFromString($userTheme.data)
-    }
-
     $: if (browser) {
-        document.documentElement.classList.toggle('theme-light', $isLightTheme)
-        document.documentElement.classList.toggle('theme-dark', !$isLightTheme)
+        document.documentElement.classList.toggle('theme-light', lightTheme)
+        document.documentElement.classList.toggle('theme-dark', !lightTheme)
     }
 
     $: allRoutesEnabled = featureFlag('web-next')

--- a/client/web-sveltekit/src/routes/UserMenu.svelte
+++ b/client/web-sveltekit/src/routes/UserMenu.svelte
@@ -2,11 +2,12 @@
     import Icon from '$lib/Icon.svelte'
     import Avatar from '$lib/Avatar.svelte'
     import type { UserMenu_User } from './UserMenu.gql'
-    import { humanTheme } from '$lib/theme'
+    import { Theme } from '$lib/theme'
     import { DropdownMenu, MenuLink, MenuRadioGroup, MenuSeparator, Submenu } from '$lib/wildcard'
     import { getButtonClassName } from '$lib/wildcard/Button'
     import { mdiChevronDown, mdiChevronUp, mdiOpenInNew } from '@mdi/js'
     import { writable } from 'svelte/store'
+    import { theme } from '$lib/stores'
 
     const MAX_VISIBLE_ORGS = 5
 
@@ -33,7 +34,7 @@
     <MenuSeparator />
     <Submenu>
         <svelte:fragment slot="trigger">Theme</svelte:fragment>
-        <MenuRadioGroup values={['Light', 'Dark', 'System']} value={humanTheme} />
+        <MenuRadioGroup values={[Theme.Light, Theme.Dark, Theme.System]} value={theme} />
     </Submenu>
     {#if organizations.length > 0}
         <MenuSeparator />


### PR DESCRIPTION
Until now selecting a different theme didn't persist it in temporary settings. This commit fixes it. I first tried an approach via context (hence the changes to setting the context) but that didn't work as expected (but the changes are still an improvement).

I also added a small piece of JavaScript to the HTML pages to set the selected theme as soon as possible. This does not have any visible effect yet because the style sheets are loaded lazily but in the future we could add a set of minimal styles to set the background color.

## Test plan

Manual testing.
