### PR TITLE
nix: bump to bazel 7.1

### DIFF
--- a/dev/nix/bazel.nix
+++ b/dev/nix/bazel.nix
@@ -1,5 +1,4 @@
-{ nixpkgs
-, pkgs
+{ pkgs
 , bazel_7
 , lib
 , substituteAll
@@ -18,35 +17,34 @@
 , unzip
 , which
 , zip
-}: {
-  bazel_7 = bazel_7.overrideAttrs (oldAttrs:
-    let
-      # yoinked from https://sourcegraph.com/github.com/NixOS/nixpkgs/-/blob/pkgs/development/tools/build-managers/bazel/bazel_7/default.nix?L77-120
-      defaultShellUtils = [
-        bash
-        coreutils
-        diffutils
-        file
-        findutils
-        gawk
-        gnugrep
-        gnupatch
-        gnused
-        gnutar
-        gzip
-        python3
-        unzip
-        which
-        zip
-      ];
-    in
-    {
-      # https://github.com/NixOS/nixpkgs/pull/262152#issuecomment-1879053113
-      patches = (oldAttrs.patches or [ ]) ++ [
-        (substituteAll {
-          src = "${nixpkgs}/pkgs/development/tools/build-managers/bazel/bazel_6/actions_path.patch";
-          actionsPathPatch = lib.makeBinPath defaultShellUtils;
-        })
-      ];
-    });
-}
+}:
+let
+  # yoinked from https://sourcegraph.com/github.com/NixOS/nixpkgs/-/blob/pkgs/development/tools/build-managers/bazel/bazel_7/default.nix?L77-120
+  defaultShellUtils = [
+    bash
+    coreutils
+    diffutils
+    file
+    findutils
+    gawk
+    gnugrep
+    gnupatch
+    gnused
+    gnutar
+    gzip
+    python3
+    unzip
+    which
+    zip
+  ];
+in
+bazel_7.overrideAttrs (oldAttrs:
+{
+  # https://github.com/NixOS/nixpkgs/pull/262152#issuecomment-1879053113
+  patches = (oldAttrs.patches or [ ]) ++ [
+    (substituteAll {
+      src = "${pkgs.path}/pkgs/development/tools/build-managers/bazel/bazel_6/actions_path.patch";
+      actionsPathPatch = lib.makeBinPath defaultShellUtils;
+    })
+  ];
+})

--- a/flake.lock
+++ b/flake.lock
@@ -33,6 +33,22 @@
         "type": "indirect"
       }
     },
+    "nixpkgs-bazel": {
+      "locked": {
+        "lastModified": 1710347736,
+        "narHash": "sha256-AqT4QwGkZuSWlNOn+xiM7oLwKQc3okwur/gnYuUYXQ0=",
+        "owner": "Strum355",
+        "repo": "nixpkgs",
+        "rev": "1e01835f072e832806d4e5097856ca21faf9811c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Strum355",
+        "ref": "bazel-7.1.0",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs-stable": {
       "locked": {
         "lastModified": 1682268651,
@@ -53,6 +69,7 @@
       "inputs": {
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",
+        "nixpkgs-bazel": "nixpkgs-bazel",
         "nixpkgs-stable": "nixpkgs-stable"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -1,14 +1,20 @@
 {
   description = "The Sourcegraph developer environment & packages Nix Flake";
 
+  nixConfig = {
+    extra-substituters = [ "https://sourcegraph-noah.cachix.org" ];
+    extra-trusted-public-keys = [ "sourcegraph-noah.cachix.org-1:rTTKnyuUmJuGt/UAXUpdOCOXDAfaO1AYy+/jSre3XgA=" ];
+  };
+
   inputs = {
     nixpkgs.url = "nixpkgs/nixpkgs-unstable";
+    nixpkgs-bazel.url = "github:Strum355/nixpkgs/bazel-7.1.0";
     # separate nixpkgs pin for more stable changes to binaries we build
     nixpkgs-stable.url = "github:NixOS/nixpkgs/e78d25df6f1036b3fa76750ed4603dd9d5fe90fc";
     flake-utils.url = "github:numtide/flake-utils";
   };
 
-  outputs = { self, nixpkgs, nixpkgs-stable, flake-utils }:
+  outputs = { self, nixpkgs, nixpkgs-stable, flake-utils, nixpkgs-bazel }:
     let
       xcompileTargets = with nixpkgs-stable.lib.systems.examples; {
         "aarch64-darwin" = nixpkgs-stable.legacyPackages.aarch64-darwin.pkgsx86_64Darwin;
@@ -36,7 +42,7 @@
             }) // {
             # doesnt need the same stability as those above
             nodejs-20_x = pkgs.callPackage ./dev/nix/nodejs.nix { };
-            inherit (pkgs.callPackage ./dev/nix/bazel.nix { inherit nixpkgs; }) bazel_7;
+            bazel_7 = nixpkgs-bazel.legacyPackages.${system}.callPackage ./dev/nix/bazel.nix { };
           };
 
           # We use pkgsShell (not pkgsAll) intentionally to avoid doing extra work of


### PR DESCRIPTION
Using my fork with open PR: https://github.com/NixOS/nixpkgs/pull/295615

Im needing 7.1 sooner than later, given its new features and this repo also using 7.1 (so all new features are fair game for it!)

Cached version is pushed to sourcegraph-noah.cachix.org, which I've added at the top here so you too can avoid building it locally :slightly_smiling_face: 

## Test plan

Tested locally :sunglasses: 