### PR TITLE
k8s/resource: Add pkg for creating k8s container resources

### DIFF
--- a/internal/k8s/resource/BUILD.bazel
+++ b/internal/k8s/resource/BUILD.bazel
@@ -1,0 +1,8 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "resource",
+    srcs = ["doc.go"],
+    importpath = "github.com/sourcegraph/sourcegraph/internal/k8s/resource",
+    visibility = ["//:__subpackages__"],
+)

--- a/internal/k8s/resource/container/BUILD.bazel
+++ b/internal/k8s/resource/container/BUILD.bazel
@@ -7,10 +7,10 @@ go_library(
     importpath = "github.com/sourcegraph/sourcegraph/internal/k8s/resource/container",
     visibility = ["//:__subpackages__"],
     deps = [
+        "//lib/pointers",
         "@io_k8s_api//core/v1:core",
         "@io_k8s_apimachinery//pkg/api/resource",
         "@io_k8s_apimachinery//pkg/util/intstr",
-        "@io_k8s_utils//pointer",
     ],
 )
 
@@ -22,6 +22,7 @@ go_test(
     ],
     embed = [":container"],
     deps = [
+        "//lib/pointers",
         "@com_github_google_go_cmp//cmp",
         "@io_k8s_api//core/v1:core",
         "@io_k8s_apimachinery//pkg/api/resource",

--- a/internal/k8s/resource/container/BUILD.bazel
+++ b/internal/k8s/resource/container/BUILD.bazel
@@ -1,0 +1,32 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("//dev:go_defs.bzl", "go_test")
+
+go_library(
+    name = "container",
+    srcs = ["container.go"],
+    importpath = "github.com/sourcegraph/sourcegraph/internal/k8s/resource/container",
+    visibility = ["//:__subpackages__"],
+    deps = [
+        "@io_k8s_api//core/v1:core",
+        "@io_k8s_apimachinery//pkg/api/resource",
+        "@io_k8s_apimachinery//pkg/util/intstr",
+        "@io_k8s_utils//pointer",
+    ],
+)
+
+go_test(
+    name = "container_test",
+    srcs = [
+        "container_test.go",
+        "example_test.go",
+    ],
+    embed = [":container"],
+    deps = [
+        "@com_github_google_go_cmp//cmp",
+        "@io_k8s_api//core/v1:core",
+        "@io_k8s_apimachinery//pkg/api/resource",
+        "@io_k8s_apimachinery//pkg/util/intstr",
+        "@io_k8s_sigs_yaml//:yaml",
+        "@io_k8s_utils//pointer",
+    ],
+)

--- a/internal/k8s/resource/container/container.go
+++ b/internal/k8s/resource/container/container.go
@@ -1,0 +1,263 @@
+package container
+
+import (
+	"sort"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/pointer"
+)
+
+// NewContainer creates a new k8s Container with default values.
+//
+// Default values include:
+//
+//   - ImagePullPolicy: PullIfNotPresent
+//   - TerminationMessagePolicy: TerminationMessageFallbackToLogsOnError
+//   - CPU/memory resource limits and requests.
+//   - SecurityContext with defaults.
+//
+// Additional options can be passed to modify the default values.
+func NewContainer(name string, options ...Option) (corev1.Container, error) {
+	container := corev1.Container{
+		Name:                     name,
+		ImagePullPolicy:          corev1.PullIfNotPresent,
+		TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
+		Resources: corev1.ResourceRequirements{
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("1"),
+				corev1.ResourceMemory: resource.MustParse("500Mi"),
+			},
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("500m"),
+				corev1.ResourceMemory: resource.MustParse("100Mi"),
+			},
+		},
+		SecurityContext: &corev1.SecurityContext{
+			RunAsUser:                pointer.Int64(100),
+			RunAsGroup:               pointer.Int64(101),
+			AllowPrivilegeEscalation: pointer.Bool(false),
+			ReadOnlyRootFilesystem:   pointer.Bool(true),
+		},
+	}
+
+	// apply any given options
+	for _, opt := range options {
+		err := opt(&container)
+		if err != nil {
+			return corev1.Container{}, err
+		}
+	}
+
+	return container, nil
+}
+
+// Option sets an option for a Container.
+type Option func(container *corev1.Container) error
+
+// WithImage sets the image field on the Container.
+func WithImage(image string) Option {
+	return func(container *corev1.Container) error {
+		container.Image = image
+		return nil
+	}
+}
+
+// WithCommand sets the command field on the Container to the provided
+// command and arguments.
+func WithCommand(command ...string) Option {
+	return func(container *corev1.Container) error {
+		container.Command = command
+		return nil
+	}
+}
+
+// WithArgs sets the args field on the Container to the provided arguments.
+func WithArgs(args ...string) Option {
+	return func(container *corev1.Container) error {
+		container.Args = args
+		return nil
+	}
+}
+
+// WithWorkingDir sets the working directory on the Container.
+func WithWorkingDir(dir string) Option {
+	return func(container *corev1.Container) error {
+		container.WorkingDir = dir
+		return nil
+	}
+}
+
+// WithPorts adds the provided ContainerPorts to the Container if they do not already exist.
+// It also sorts the ports by name for accurate comparison of resources.
+func WithPorts(ports ...corev1.ContainerPort) Option {
+	return func(container *corev1.Container) error {
+		for _, p := range ports {
+			if !portExists(p.Name, container) {
+				container.Ports = append(container.Ports, p)
+			}
+		}
+
+		// sort ports by names
+		sort.SliceStable(container.Ports, func(i, j int) bool {
+			return container.Ports[i].Name < container.Ports[j].Name
+		})
+		return nil
+	}
+}
+
+func portExists(name string, container *corev1.Container) bool {
+	for _, p := range container.Ports {
+		if p.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+// WithEnv adds the provided EnvVars to the Container if they do not already exist.
+func WithEnv(vars ...corev1.EnvVar) Option {
+	return func(container *corev1.Container) error {
+		for _, v := range vars {
+			if envExists(v.Name, container) {
+				continue
+			}
+			container.Env = append(container.Env, v)
+		}
+		return nil
+	}
+}
+
+func envExists(name string, container *corev1.Container) bool {
+	for _, env := range container.Env {
+		if env.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+// WithResources sets the given ResourceRequirements on the Container.
+func WithResources(resources corev1.ResourceRequirements) Option {
+	return func(container *corev1.Container) error {
+		container.Resources = resources
+		return nil
+	}
+}
+
+// WithVolumeMounts adds the provided VolumeMounts to the Container if they do not already exist.
+// It also sorts the VolumeMounts by name for accurate comparison of resources.
+func WithVolumeMounts(volumeMounts []corev1.VolumeMount) Option {
+	return func(container *corev1.Container) error {
+		for _, v := range volumeMounts {
+			if !volumeMountExists(v, container) {
+				container.VolumeMounts = append(container.VolumeMounts, v)
+			}
+		}
+
+		sort.SliceStable(container.VolumeMounts, func(i, j int) bool {
+			return container.VolumeMounts[i].Name < container.VolumeMounts[j].Name
+		})
+		return nil
+	}
+}
+
+func volumeMountExists(volumeMount corev1.VolumeMount, container *corev1.Container) bool {
+	for _, volMount := range container.VolumeMounts {
+		if volMount.Name == volumeMount.Name || volMount.MountPath == volumeMount.MountPath {
+			return true
+		}
+	}
+	return false
+}
+
+// WithLivenessProbe sets the given *corev1.Probe as the LivenessProbe on the Container.
+func WithLivenessProbe(livenessProbe *corev1.Probe) Option {
+	return func(container *corev1.Container) error {
+		container.LivenessProbe = livenessProbe
+		return nil
+	}
+}
+
+// WithDefaultLivenessProbe sets a default LivenessProbe on the Container
+// that is commonly used for Sourcegraph services.
+//
+// The default probe is:
+//
+//	&corev1.Probe{
+//		ProbeHandler: corev1.ProbeHandler{
+//			HTTPGet: &corev1.HTTPGetAction{
+//				Path:   "/",
+//				Port:   intstr.FromString(container.Name),
+//				Scheme: corev1.URISchemeHTTP,
+//			},
+//		},
+//		InitialDelaySeconds: 60,
+//		TimeoutSeconds:      5,
+//	}
+func WithDefaultLivenessProbe() Option {
+	return func(container *corev1.Container) error {
+		container.LivenessProbe = &corev1.Probe{
+			ProbeHandler: corev1.ProbeHandler{
+				HTTPGet: &corev1.HTTPGetAction{
+					Path:   "/",
+					Port:   intstr.FromString(container.Name),
+					Scheme: corev1.URISchemeHTTP,
+				},
+			},
+			InitialDelaySeconds: 60,
+			TimeoutSeconds:      5,
+		}
+		return nil
+	}
+}
+
+// WithReadinessProbe sets the given *corev1.Probe as the ReadinessProbe on the Container.
+func WithReadinessProbe(readinessProbe *corev1.Probe) Option {
+	return func(container *corev1.Container) error {
+		container.ReadinessProbe = readinessProbe
+		return nil
+	}
+}
+
+// WithDefaultReadinessProbe sets a default ReadinessProbe on the Container
+// that is commonly used for Sourcegraph services.
+//
+// The default probe is:
+//
+//	&corev1.Probe{
+//		ProbeHandler: corev1.ProbeHandler{
+//			HTTPGet: &corev1.HTTPGetAction{
+//				Path:   "/",
+//				Port:   intstr.FromString(container.Name),
+//				Scheme: corev1.URISchemeHTTP,
+//			},
+//		},
+//		PeriodSeconds:  5,
+//		TimeoutSeconds: 5,
+//	}
+func WithDefaultReadinessProbe() Option {
+	return func(container *corev1.Container) error {
+		container.ReadinessProbe = &corev1.Probe{
+			ProbeHandler: corev1.ProbeHandler{
+				HTTPGet: &corev1.HTTPGetAction{
+					Path:   "/",
+					Port:   intstr.FromString(container.Name),
+					Scheme: corev1.URISchemeHTTP,
+				},
+			},
+			PeriodSeconds:  5,
+			TimeoutSeconds: 5,
+		}
+		return nil
+	}
+}
+
+// WithSecurityContext sets the given corev1.SecurityContext on the Container.
+func WithSecurityContext(securityContext corev1.SecurityContext) Option {
+	return func(container *corev1.Container) error {
+		container.SecurityContext = &securityContext
+		return nil
+	}
+}

--- a/internal/k8s/resource/container/container.go
+++ b/internal/k8s/resource/container/container.go
@@ -6,7 +6,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/utils/pointer"
+
+	"github.com/sourcegraph/sourcegraph/lib/pointers"
 )
 
 // NewContainer creates a new k8s Container with default values.
@@ -35,10 +36,10 @@ func NewContainer(name string, options ...Option) (corev1.Container, error) {
 			},
 		},
 		SecurityContext: &corev1.SecurityContext{
-			RunAsUser:                pointer.Int64(100),
-			RunAsGroup:               pointer.Int64(101),
-			AllowPrivilegeEscalation: pointer.Bool(false),
-			ReadOnlyRootFilesystem:   pointer.Bool(true),
+			RunAsUser:                pointers.Ptr[int64](100),
+			RunAsGroup:               pointers.Ptr[int64](101),
+			AllowPrivilegeEscalation: pointers.Ptr(false),
+			ReadOnlyRootFilesystem:   pointers.Ptr(true),
 		},
 	}
 

--- a/internal/k8s/resource/container/container_test.go
+++ b/internal/k8s/resource/container/container_test.go
@@ -8,6 +8,8 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/pointer"
+
+	"github.com/sourcegraph/sourcegraph/lib/pointers"
 )
 
 func TestNewContainer(t *testing.T) {
@@ -43,10 +45,10 @@ func TestNewContainer(t *testing.T) {
 					},
 				},
 				SecurityContext: &corev1.SecurityContext{
-					RunAsUser:                pointer.Int64(100),
-					RunAsGroup:               pointer.Int64(101),
-					AllowPrivilegeEscalation: pointer.Bool(false),
-					ReadOnlyRootFilesystem:   pointer.Bool(true),
+					RunAsUser:                pointers.Ptr[int64](100),
+					RunAsGroup:               pointers.Ptr[int64](101),
+					AllowPrivilegeEscalation: pointers.Ptr(false),
+					ReadOnlyRootFilesystem:   pointers.Ptr(true),
 				},
 			},
 		},
@@ -74,10 +76,10 @@ func TestNewContainer(t *testing.T) {
 					},
 				},
 				SecurityContext: &corev1.SecurityContext{
-					RunAsUser:                pointer.Int64(100),
-					RunAsGroup:               pointer.Int64(101),
-					AllowPrivilegeEscalation: pointer.Bool(false),
-					ReadOnlyRootFilesystem:   pointer.Bool(true),
+					RunAsUser:                pointers.Ptr[int64](100),
+					RunAsGroup:               pointers.Ptr[int64](101),
+					AllowPrivilegeEscalation: pointers.Ptr(false),
+					ReadOnlyRootFilesystem:   pointers.Ptr(true),
 				},
 			},
 		},
@@ -108,10 +110,10 @@ func TestNewContainer(t *testing.T) {
 					},
 				},
 				SecurityContext: &corev1.SecurityContext{
-					RunAsUser:                pointer.Int64(100),
-					RunAsGroup:               pointer.Int64(101),
-					AllowPrivilegeEscalation: pointer.Bool(false),
-					ReadOnlyRootFilesystem:   pointer.Bool(true),
+					RunAsUser:                pointers.Ptr[int64](100),
+					RunAsGroup:               pointers.Ptr[int64](101),
+					AllowPrivilegeEscalation: pointers.Ptr(false),
+					ReadOnlyRootFilesystem:   pointers.Ptr(true),
 				},
 			},
 		},
@@ -142,10 +144,10 @@ func TestNewContainer(t *testing.T) {
 					},
 				},
 				SecurityContext: &corev1.SecurityContext{
-					RunAsUser:                pointer.Int64(100),
-					RunAsGroup:               pointer.Int64(101),
-					AllowPrivilegeEscalation: pointer.Bool(false),
-					ReadOnlyRootFilesystem:   pointer.Bool(true),
+					RunAsUser:                pointers.Ptr[int64](100),
+					RunAsGroup:               pointers.Ptr[int64](101),
+					AllowPrivilegeEscalation: pointers.Ptr(false),
+					ReadOnlyRootFilesystem:   pointers.Ptr(true),
 				},
 			},
 		},
@@ -173,10 +175,10 @@ func TestNewContainer(t *testing.T) {
 					},
 				},
 				SecurityContext: &corev1.SecurityContext{
-					RunAsUser:                pointer.Int64(100),
-					RunAsGroup:               pointer.Int64(101),
-					AllowPrivilegeEscalation: pointer.Bool(false),
-					ReadOnlyRootFilesystem:   pointer.Bool(true),
+					RunAsUser:                pointers.Ptr[int64](100),
+					RunAsGroup:               pointers.Ptr[int64](101),
+					AllowPrivilegeEscalation: pointers.Ptr(false),
+					ReadOnlyRootFilesystem:   pointers.Ptr(true),
 				},
 			},
 		},
@@ -238,10 +240,10 @@ func TestNewContainer(t *testing.T) {
 					},
 				},
 				SecurityContext: &corev1.SecurityContext{
-					RunAsUser:                pointer.Int64(100),
-					RunAsGroup:               pointer.Int64(101),
-					AllowPrivilegeEscalation: pointer.Bool(false),
-					ReadOnlyRootFilesystem:   pointer.Bool(true),
+					RunAsUser:                pointers.Ptr[int64](100),
+					RunAsGroup:               pointers.Ptr[int64](101),
+					AllowPrivilegeEscalation: pointers.Ptr(false),
+					ReadOnlyRootFilesystem:   pointers.Ptr(true),
 				},
 			},
 		},
@@ -277,10 +279,10 @@ func TestNewContainer(t *testing.T) {
 					},
 				},
 				SecurityContext: &corev1.SecurityContext{
-					RunAsUser:                pointer.Int64(100),
-					RunAsGroup:               pointer.Int64(101),
-					AllowPrivilegeEscalation: pointer.Bool(false),
-					ReadOnlyRootFilesystem:   pointer.Bool(true),
+					RunAsUser:                pointers.Ptr[int64](100),
+					RunAsGroup:               pointers.Ptr[int64](101),
+					AllowPrivilegeEscalation: pointers.Ptr(false),
+					ReadOnlyRootFilesystem:   pointers.Ptr(true),
 				},
 				Env: []corev1.EnvVar{
 					{
@@ -323,10 +325,10 @@ func TestNewContainer(t *testing.T) {
 					},
 				},
 				SecurityContext: &corev1.SecurityContext{
-					RunAsUser:                pointer.Int64(100),
-					RunAsGroup:               pointer.Int64(101),
-					AllowPrivilegeEscalation: pointer.Bool(false),
-					ReadOnlyRootFilesystem:   pointer.Bool(true),
+					RunAsUser:                pointers.Ptr[int64](100),
+					RunAsGroup:               pointers.Ptr[int64](101),
+					AllowPrivilegeEscalation: pointers.Ptr(false),
+					ReadOnlyRootFilesystem:   pointers.Ptr(true),
 				},
 			},
 		},
@@ -369,10 +371,10 @@ func TestNewContainer(t *testing.T) {
 					},
 				},
 				SecurityContext: &corev1.SecurityContext{
-					RunAsUser:                pointer.Int64(100),
-					RunAsGroup:               pointer.Int64(101),
-					AllowPrivilegeEscalation: pointer.Bool(false),
-					ReadOnlyRootFilesystem:   pointer.Bool(true),
+					RunAsUser:                pointers.Ptr[int64](100),
+					RunAsGroup:               pointers.Ptr[int64](101),
+					AllowPrivilegeEscalation: pointers.Ptr(false),
+					ReadOnlyRootFilesystem:   pointers.Ptr(true),
 				},
 				VolumeMounts: []corev1.VolumeMount{
 					// Notice the order here, volumes should be sorted
@@ -404,7 +406,7 @@ func TestNewContainer(t *testing.T) {
 							},
 						},
 						PeriodSeconds:                 5,
-						TerminationGracePeriodSeconds: pointer.Int64(10),
+						TerminationGracePeriodSeconds: pointers.Ptr[int64](10),
 					}),
 				},
 			},
@@ -423,10 +425,10 @@ func TestNewContainer(t *testing.T) {
 					},
 				},
 				SecurityContext: &corev1.SecurityContext{
-					RunAsUser:                pointer.Int64(100),
-					RunAsGroup:               pointer.Int64(101),
-					AllowPrivilegeEscalation: pointer.Bool(false),
-					ReadOnlyRootFilesystem:   pointer.Bool(true),
+					RunAsUser:                pointers.Ptr[int64](100),
+					RunAsGroup:               pointers.Ptr[int64](101),
+					AllowPrivilegeEscalation: pointers.Ptr(false),
+					ReadOnlyRootFilesystem:   pointers.Ptr(true),
 				},
 				LivenessProbe: &corev1.Probe{
 					ProbeHandler: corev1.ProbeHandler{
@@ -464,10 +466,10 @@ func TestNewContainer(t *testing.T) {
 					},
 				},
 				SecurityContext: &corev1.SecurityContext{
-					RunAsUser:                pointer.Int64(100),
-					RunAsGroup:               pointer.Int64(101),
-					AllowPrivilegeEscalation: pointer.Bool(false),
-					ReadOnlyRootFilesystem:   pointer.Bool(true),
+					RunAsUser:                pointers.Ptr[int64](100),
+					RunAsGroup:               pointers.Ptr[int64](101),
+					AllowPrivilegeEscalation: pointers.Ptr(false),
+					ReadOnlyRootFilesystem:   pointers.Ptr(true),
 				},
 				LivenessProbe: &corev1.Probe{
 					ProbeHandler: corev1.ProbeHandler{
@@ -519,10 +521,10 @@ func TestNewContainer(t *testing.T) {
 					},
 				},
 				SecurityContext: &corev1.SecurityContext{
-					RunAsUser:                pointer.Int64(100),
-					RunAsGroup:               pointer.Int64(101),
-					AllowPrivilegeEscalation: pointer.Bool(false),
-					ReadOnlyRootFilesystem:   pointer.Bool(true),
+					RunAsUser:                pointers.Ptr[int64](100),
+					RunAsGroup:               pointers.Ptr[int64](101),
+					AllowPrivilegeEscalation: pointers.Ptr(false),
+					ReadOnlyRootFilesystem:   pointers.Ptr(true),
 				},
 				ReadinessProbe: &corev1.Probe{
 					ProbeHandler: corev1.ProbeHandler{
@@ -564,10 +566,10 @@ func TestNewContainer(t *testing.T) {
 					},
 				},
 				SecurityContext: &corev1.SecurityContext{
-					RunAsUser:                pointer.Int64(100),
-					RunAsGroup:               pointer.Int64(101),
-					AllowPrivilegeEscalation: pointer.Bool(false),
-					ReadOnlyRootFilesystem:   pointer.Bool(true),
+					RunAsUser:                pointers.Ptr[int64](100),
+					RunAsGroup:               pointers.Ptr[int64](101),
+					AllowPrivilegeEscalation: pointers.Ptr(false),
+					ReadOnlyRootFilesystem:   pointers.Ptr(true),
 				},
 				ReadinessProbe: &corev1.Probe{
 					ProbeHandler: corev1.ProbeHandler{
@@ -588,11 +590,11 @@ func TestNewContainer(t *testing.T) {
 				name: "foo",
 				options: []Option{
 					WithSecurityContext(corev1.SecurityContext{
-						Privileged:               pointer.Bool(true),
-						RunAsUser:                pointer.Int64(5000),
-						RunAsGroup:               pointer.Int64(9000),
-						ReadOnlyRootFilesystem:   pointer.Bool(true),
-						AllowPrivilegeEscalation: pointer.Bool(false),
+						Privileged:               pointers.Ptr(true),
+						RunAsUser:                pointers.Ptr[int64](5000),
+						RunAsGroup:               pointers.Ptr[int64](9000),
+						ReadOnlyRootFilesystem:   pointers.Ptr(true),
+						AllowPrivilegeEscalation: pointers.Ptr(false),
 					}),
 				},
 			},
@@ -611,11 +613,11 @@ func TestNewContainer(t *testing.T) {
 					},
 				},
 				SecurityContext: &corev1.SecurityContext{
-					Privileged:               pointer.Bool(true),
-					RunAsUser:                pointer.Int64(5000),
-					RunAsGroup:               pointer.Int64(9000),
-					ReadOnlyRootFilesystem:   pointer.Bool(true),
-					AllowPrivilegeEscalation: pointer.Bool(false),
+					Privileged:               pointers.Ptr(true),
+					RunAsUser:                pointers.Ptr[int64](5000),
+					RunAsGroup:               pointers.Ptr[int64](9000),
+					ReadOnlyRootFilesystem:   pointers.Ptr(true),
+					AllowPrivilegeEscalation: pointers.Ptr(false),
 				},
 			},
 		},

--- a/internal/k8s/resource/container/container_test.go
+++ b/internal/k8s/resource/container/container_test.go
@@ -1,0 +1,637 @@
+package container
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/pointer"
+)
+
+func TestNewContainer(t *testing.T) {
+	t.Parallel()
+
+	type args struct {
+		name    string
+		options []Option
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want corev1.Container
+	}{
+		{
+			name: "default container",
+			args: args{
+				name: "foo",
+			},
+			want: corev1.Container{
+				Name:                     "foo",
+				ImagePullPolicy:          corev1.PullIfNotPresent,
+				TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("1"),
+						corev1.ResourceMemory: resource.MustParse("500Mi"),
+					},
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("500m"),
+						corev1.ResourceMemory: resource.MustParse("100Mi"),
+					},
+				},
+				SecurityContext: &corev1.SecurityContext{
+					RunAsUser:                pointer.Int64(100),
+					RunAsGroup:               pointer.Int64(101),
+					AllowPrivilegeEscalation: pointer.Bool(false),
+					ReadOnlyRootFilesystem:   pointer.Bool(true),
+				},
+			},
+		},
+		{
+			name: "with image",
+			args: args{
+				name: "foo",
+				options: []Option{
+					WithImage("ghcr.io/sourcegraph/service"),
+				},
+			},
+			want: corev1.Container{
+				Name:                     "foo",
+				ImagePullPolicy:          corev1.PullIfNotPresent,
+				Image:                    "ghcr.io/sourcegraph/service",
+				TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("1"),
+						corev1.ResourceMemory: resource.MustParse("500Mi"),
+					},
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("500m"),
+						corev1.ResourceMemory: resource.MustParse("100Mi"),
+					},
+				},
+				SecurityContext: &corev1.SecurityContext{
+					RunAsUser:                pointer.Int64(100),
+					RunAsGroup:               pointer.Int64(101),
+					AllowPrivilegeEscalation: pointer.Bool(false),
+					ReadOnlyRootFilesystem:   pointer.Bool(true),
+				},
+			},
+		},
+		{
+			name: "with command",
+			args: args{
+				name: "foo",
+				options: []Option{
+					WithCommand("ls", "-a"),
+				},
+			},
+			want: corev1.Container{
+				Name:                     "foo",
+				ImagePullPolicy:          corev1.PullIfNotPresent,
+				TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
+				Command: []string{
+					"ls",
+					"-a",
+				},
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("1"),
+						corev1.ResourceMemory: resource.MustParse("500Mi"),
+					},
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("500m"),
+						corev1.ResourceMemory: resource.MustParse("100Mi"),
+					},
+				},
+				SecurityContext: &corev1.SecurityContext{
+					RunAsUser:                pointer.Int64(100),
+					RunAsGroup:               pointer.Int64(101),
+					AllowPrivilegeEscalation: pointer.Bool(false),
+					ReadOnlyRootFilesystem:   pointer.Bool(true),
+				},
+			},
+		},
+		{
+			name: "with args",
+			args: args{
+				name: "foo",
+				options: []Option{
+					WithArgs("foo", "bar"),
+				},
+			},
+			want: corev1.Container{
+				Name:                     "foo",
+				ImagePullPolicy:          corev1.PullIfNotPresent,
+				TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
+				Args: []string{
+					"foo",
+					"bar",
+				},
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("1"),
+						corev1.ResourceMemory: resource.MustParse("500Mi"),
+					},
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("500m"),
+						corev1.ResourceMemory: resource.MustParse("100Mi"),
+					},
+				},
+				SecurityContext: &corev1.SecurityContext{
+					RunAsUser:                pointer.Int64(100),
+					RunAsGroup:               pointer.Int64(101),
+					AllowPrivilegeEscalation: pointer.Bool(false),
+					ReadOnlyRootFilesystem:   pointer.Bool(true),
+				},
+			},
+		},
+		{
+			name: "with working dir",
+			args: args{
+				name: "foo",
+				options: []Option{
+					WithWorkingDir("/home/foo"),
+				},
+			},
+			want: corev1.Container{
+				Name:                     "foo",
+				ImagePullPolicy:          corev1.PullIfNotPresent,
+				TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
+				WorkingDir:               "/home/foo",
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("1"),
+						corev1.ResourceMemory: resource.MustParse("500Mi"),
+					},
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("500m"),
+						corev1.ResourceMemory: resource.MustParse("100Mi"),
+					},
+				},
+				SecurityContext: &corev1.SecurityContext{
+					RunAsUser:                pointer.Int64(100),
+					RunAsGroup:               pointer.Int64(101),
+					AllowPrivilegeEscalation: pointer.Bool(false),
+					ReadOnlyRootFilesystem:   pointer.Bool(true),
+				},
+			},
+		},
+		{
+			name: "with ports",
+			args: args{
+				name: "foo",
+				options: []Option{
+					WithPorts([]corev1.ContainerPort{
+						{
+							Name:          "prometheus",
+							HostPort:      9000,
+							ContainerPort: 9000,
+							Protocol:      "TCP",
+						},
+						{
+							// try to add duplicate port
+							Name:          "prometheus",
+							HostPort:      9000,
+							ContainerPort: 9000,
+							Protocol:      "TCP",
+						},
+						{
+							// ports should be sorted by function
+							Name:          "http",
+							HostPort:      80,
+							ContainerPort: 80,
+							Protocol:      "TCP",
+						},
+					}...),
+				},
+			},
+			want: corev1.Container{
+				Name:                     "foo",
+				ImagePullPolicy:          corev1.PullIfNotPresent,
+				TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
+				Ports: []corev1.ContainerPort{
+					{
+						Name:          "http",
+						HostPort:      80,
+						ContainerPort: 80,
+						Protocol:      "TCP",
+					},
+					{
+						Name:          "prometheus",
+						HostPort:      9000,
+						ContainerPort: 9000,
+						Protocol:      "TCP",
+					},
+				},
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("1"),
+						corev1.ResourceMemory: resource.MustParse("500Mi"),
+					},
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("500m"),
+						corev1.ResourceMemory: resource.MustParse("100Mi"),
+					},
+				},
+				SecurityContext: &corev1.SecurityContext{
+					RunAsUser:                pointer.Int64(100),
+					RunAsGroup:               pointer.Int64(101),
+					AllowPrivilegeEscalation: pointer.Bool(false),
+					ReadOnlyRootFilesystem:   pointer.Bool(true),
+				},
+			},
+		},
+		{
+			name: "with env",
+			args: args{
+				name: "foo",
+				options: []Option{
+					WithEnv(corev1.EnvVar{
+						Name:      "DEBUG",
+						Value:     "TRUE",
+						ValueFrom: nil,
+					}),
+					WithEnv(corev1.EnvVar{
+						Name:      "DEBUG",
+						Value:     "FALSE",
+						ValueFrom: nil,
+					}),
+				},
+			},
+			want: corev1.Container{
+				Name:                     "foo",
+				ImagePullPolicy:          corev1.PullIfNotPresent,
+				TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("1"),
+						corev1.ResourceMemory: resource.MustParse("500Mi"),
+					},
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("500m"),
+						corev1.ResourceMemory: resource.MustParse("100Mi"),
+					},
+				},
+				SecurityContext: &corev1.SecurityContext{
+					RunAsUser:                pointer.Int64(100),
+					RunAsGroup:               pointer.Int64(101),
+					AllowPrivilegeEscalation: pointer.Bool(false),
+					ReadOnlyRootFilesystem:   pointer.Bool(true),
+				},
+				Env: []corev1.EnvVar{
+					{
+						Name:      "DEBUG",
+						Value:     "TRUE",
+						ValueFrom: nil,
+					},
+				},
+			},
+		},
+		{
+			name: "with resources",
+			args: args{
+				name: "foo",
+				options: []Option{
+					WithResources(corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("10"),
+							corev1.ResourceMemory: resource.MustParse("5G"),
+						},
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("10"),
+							corev1.ResourceMemory: resource.MustParse("5G"),
+						},
+					}),
+				},
+			},
+			want: corev1.Container{
+				Name:                     "foo",
+				ImagePullPolicy:          corev1.PullIfNotPresent,
+				TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("10"),
+						corev1.ResourceMemory: resource.MustParse("5G"),
+					},
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("10"),
+						corev1.ResourceMemory: resource.MustParse("5G"),
+					},
+				},
+				SecurityContext: &corev1.SecurityContext{
+					RunAsUser:                pointer.Int64(100),
+					RunAsGroup:               pointer.Int64(101),
+					AllowPrivilegeEscalation: pointer.Bool(false),
+					ReadOnlyRootFilesystem:   pointer.Bool(true),
+				},
+			},
+		},
+		{
+			name: "with volume mounts",
+			args: args{
+				name: "foo",
+				options: []Option{
+					WithVolumeMounts([]corev1.VolumeMount{
+						{
+							Name:      "stuff",
+							ReadOnly:  true,
+							MountPath: "/data",
+						},
+						{
+							Name:      "other stuff",
+							ReadOnly:  false,
+							MountPath: "/tmp",
+						},
+						{
+							Name:      "other stuff",
+							ReadOnly:  false,
+							MountPath: "/var/log",
+						},
+					}),
+				},
+			},
+			want: corev1.Container{
+				Name:                     "foo",
+				ImagePullPolicy:          corev1.PullIfNotPresent,
+				TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("1"),
+						corev1.ResourceMemory: resource.MustParse("500Mi"),
+					},
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("500m"),
+						corev1.ResourceMemory: resource.MustParse("100Mi"),
+					},
+				},
+				SecurityContext: &corev1.SecurityContext{
+					RunAsUser:                pointer.Int64(100),
+					RunAsGroup:               pointer.Int64(101),
+					AllowPrivilegeEscalation: pointer.Bool(false),
+					ReadOnlyRootFilesystem:   pointer.Bool(true),
+				},
+				VolumeMounts: []corev1.VolumeMount{
+					// Notice the order here, volumes should be sorted
+					// and won't overwrite an existing volume
+					{
+						Name:      "other stuff",
+						ReadOnly:  false,
+						MountPath: "/tmp",
+					},
+					{
+						Name:      "stuff",
+						ReadOnly:  true,
+						MountPath: "/data",
+					},
+				},
+			},
+		},
+		{
+			name: "with liveness probe",
+			args: args{
+				name: "foo",
+				options: []Option{
+					WithLivenessProbe(&corev1.Probe{
+						ProbeHandler: corev1.ProbeHandler{
+							HTTPGet: &corev1.HTTPGetAction{
+								Path:   "/ready",
+								Port:   intstr.FromString("foo"),
+								Scheme: corev1.URISchemeHTTP,
+							},
+						},
+						PeriodSeconds:                 5,
+						TerminationGracePeriodSeconds: pointer.Int64(10),
+					}),
+				},
+			},
+			want: corev1.Container{
+				Name:                     "foo",
+				ImagePullPolicy:          corev1.PullIfNotPresent,
+				TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("1"),
+						corev1.ResourceMemory: resource.MustParse("500Mi"),
+					},
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("500m"),
+						corev1.ResourceMemory: resource.MustParse("100Mi"),
+					},
+				},
+				SecurityContext: &corev1.SecurityContext{
+					RunAsUser:                pointer.Int64(100),
+					RunAsGroup:               pointer.Int64(101),
+					AllowPrivilegeEscalation: pointer.Bool(false),
+					ReadOnlyRootFilesystem:   pointer.Bool(true),
+				},
+				LivenessProbe: &corev1.Probe{
+					ProbeHandler: corev1.ProbeHandler{
+						HTTPGet: &corev1.HTTPGetAction{
+							Path:   "/ready",
+							Port:   intstr.FromString("foo"),
+							Scheme: corev1.URISchemeHTTP,
+						},
+					},
+					PeriodSeconds:                 5,
+					TerminationGracePeriodSeconds: pointer.Int64(10),
+				},
+			},
+		},
+		{
+			name: "with default liveness probe",
+			args: args{
+				name: "foo",
+				options: []Option{
+					WithDefaultLivenessProbe(),
+				},
+			},
+			want: corev1.Container{
+				Name:                     "foo",
+				ImagePullPolicy:          corev1.PullIfNotPresent,
+				TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("1"),
+						corev1.ResourceMemory: resource.MustParse("500Mi"),
+					},
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("500m"),
+						corev1.ResourceMemory: resource.MustParse("100Mi"),
+					},
+				},
+				SecurityContext: &corev1.SecurityContext{
+					RunAsUser:                pointer.Int64(100),
+					RunAsGroup:               pointer.Int64(101),
+					AllowPrivilegeEscalation: pointer.Bool(false),
+					ReadOnlyRootFilesystem:   pointer.Bool(true),
+				},
+				LivenessProbe: &corev1.Probe{
+					ProbeHandler: corev1.ProbeHandler{
+						HTTPGet: &corev1.HTTPGetAction{
+							Path:   "/",
+							Port:   intstr.FromString("foo"),
+							Scheme: corev1.URISchemeHTTP,
+						},
+					},
+					InitialDelaySeconds: 60,
+					TimeoutSeconds:      5,
+				},
+			},
+		},
+		{
+			name: "with readiness probe",
+			args: args{
+				name: "foo",
+				options: []Option{
+					WithReadinessProbe(&corev1.Probe{
+						ProbeHandler: corev1.ProbeHandler{
+							HTTPGet: &corev1.HTTPGetAction{
+								Path:   "/ready",
+								Port:   intstr.FromString("foo"),
+								Scheme: corev1.URISchemeHTTP,
+							},
+						},
+						InitialDelaySeconds:           6,
+						TimeoutSeconds:                10,
+						PeriodSeconds:                 10,
+						SuccessThreshold:              3,
+						FailureThreshold:              10,
+						TerminationGracePeriodSeconds: pointer.Int64(10),
+					}),
+				},
+			},
+			want: corev1.Container{
+				Name:                     "foo",
+				ImagePullPolicy:          corev1.PullIfNotPresent,
+				TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("1"),
+						corev1.ResourceMemory: resource.MustParse("500Mi"),
+					},
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("500m"),
+						corev1.ResourceMemory: resource.MustParse("100Mi"),
+					},
+				},
+				SecurityContext: &corev1.SecurityContext{
+					RunAsUser:                pointer.Int64(100),
+					RunAsGroup:               pointer.Int64(101),
+					AllowPrivilegeEscalation: pointer.Bool(false),
+					ReadOnlyRootFilesystem:   pointer.Bool(true),
+				},
+				ReadinessProbe: &corev1.Probe{
+					ProbeHandler: corev1.ProbeHandler{
+						HTTPGet: &corev1.HTTPGetAction{
+							Path:   "/ready",
+							Port:   intstr.FromString("foo"),
+							Scheme: corev1.URISchemeHTTP,
+						},
+					},
+					InitialDelaySeconds:           6,
+					TimeoutSeconds:                10,
+					PeriodSeconds:                 10,
+					SuccessThreshold:              3,
+					FailureThreshold:              10,
+					TerminationGracePeriodSeconds: pointer.Int64(10),
+				},
+			},
+		},
+		{
+			name: "with default readiness probe",
+			args: args{
+				name: "foo",
+				options: []Option{
+					WithDefaultReadinessProbe(),
+				},
+			},
+			want: corev1.Container{
+				Name:                     "foo",
+				ImagePullPolicy:          corev1.PullIfNotPresent,
+				TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("1"),
+						corev1.ResourceMemory: resource.MustParse("500Mi"),
+					},
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("500m"),
+						corev1.ResourceMemory: resource.MustParse("100Mi"),
+					},
+				},
+				SecurityContext: &corev1.SecurityContext{
+					RunAsUser:                pointer.Int64(100),
+					RunAsGroup:               pointer.Int64(101),
+					AllowPrivilegeEscalation: pointer.Bool(false),
+					ReadOnlyRootFilesystem:   pointer.Bool(true),
+				},
+				ReadinessProbe: &corev1.Probe{
+					ProbeHandler: corev1.ProbeHandler{
+						HTTPGet: &corev1.HTTPGetAction{
+							Path:   "/",
+							Port:   intstr.FromString("foo"),
+							Scheme: corev1.URISchemeHTTP,
+						},
+					},
+					TimeoutSeconds: 5,
+					PeriodSeconds:  5,
+				},
+			},
+		},
+		{
+			name: "with security context",
+			args: args{
+				name: "foo",
+				options: []Option{
+					WithSecurityContext(corev1.SecurityContext{
+						Privileged:               pointer.Bool(true),
+						RunAsUser:                pointer.Int64(5000),
+						RunAsGroup:               pointer.Int64(9000),
+						ReadOnlyRootFilesystem:   pointer.Bool(true),
+						AllowPrivilegeEscalation: pointer.Bool(false),
+					}),
+				},
+			},
+			want: corev1.Container{
+				Name:                     "foo",
+				ImagePullPolicy:          corev1.PullIfNotPresent,
+				TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("1"),
+						corev1.ResourceMemory: resource.MustParse("500Mi"),
+					},
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("500m"),
+						corev1.ResourceMemory: resource.MustParse("100Mi"),
+					},
+				},
+				SecurityContext: &corev1.SecurityContext{
+					Privileged:               pointer.Bool(true),
+					RunAsUser:                pointer.Int64(5000),
+					RunAsGroup:               pointer.Int64(9000),
+					ReadOnlyRootFilesystem:   pointer.Bool(true),
+					AllowPrivilegeEscalation: pointer.Bool(false),
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := NewContainer(tt.args.name, tt.args.options...)
+			if err != nil {
+				t.Errorf("NewContainer() error: %v", err)
+			}
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("NewContainer() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/internal/k8s/resource/container/example_test.go
+++ b/internal/k8s/resource/container/example_test.go
@@ -1,0 +1,106 @@
+package container
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"sigs.k8s.io/yaml"
+)
+
+func ExampleContainer() {
+	c, _ := NewContainer("test")
+
+	jc, _ := json.Marshal(c)
+	fmt.Println(string(jc))
+
+	yc, _ := yaml.Marshal(c)
+	fmt.Println(string(yc))
+
+	// Output:
+	// {"name":"test","resources":{"limits":{"cpu":"1","memory":"500Mi"},"requests":{"cpu":"500m","memory":"100Mi"}},"terminationMessagePolicy":"FallbackToLogsOnError","imagePullPolicy":"IfNotPresent","securityContext":{"runAsUser":100,"runAsGroup":101,"readOnlyRootFilesystem":true,"allowPrivilegeEscalation":false}}
+	// imagePullPolicy: IfNotPresent
+	// name: test
+	// resources:
+	//   limits:
+	//     cpu: "1"
+	//     memory: 500Mi
+	//   requests:
+	//     cpu: 500m
+	//     memory: 100Mi
+	// securityContext:
+	//   allowPrivilegeEscalation: false
+	//   readOnlyRootFilesystem: true
+	//   runAsGroup: 101
+	//   runAsUser: 100
+	// terminationMessagePolicy: FallbackToLogsOnError
+}
+
+func ExampleWithDefaultLivenessProbe() {
+	c, _ := NewContainer("test", WithDefaultLivenessProbe())
+
+	jc, _ := json.Marshal(c)
+	fmt.Println(string(jc))
+
+	yc, _ := yaml.Marshal(c)
+	fmt.Println(string(yc))
+
+	// Output:
+	// {"name":"test","resources":{"limits":{"cpu":"1","memory":"500Mi"},"requests":{"cpu":"500m","memory":"100Mi"}},"livenessProbe":{"httpGet":{"path":"/","port":"test","scheme":"HTTP"},"initialDelaySeconds":60,"timeoutSeconds":5},"terminationMessagePolicy":"FallbackToLogsOnError","imagePullPolicy":"IfNotPresent","securityContext":{"runAsUser":100,"runAsGroup":101,"readOnlyRootFilesystem":true,"allowPrivilegeEscalation":false}}
+	// imagePullPolicy: IfNotPresent
+	// livenessProbe:
+	//   httpGet:
+	//     path: /
+	//     port: test
+	//     scheme: HTTP
+	//   initialDelaySeconds: 60
+	//   timeoutSeconds: 5
+	// name: test
+	// resources:
+	//   limits:
+	//     cpu: "1"
+	//     memory: 500Mi
+	//   requests:
+	//     cpu: 500m
+	//     memory: 100Mi
+	// securityContext:
+	//   allowPrivilegeEscalation: false
+	//   readOnlyRootFilesystem: true
+	//   runAsGroup: 101
+	//   runAsUser: 100
+	// terminationMessagePolicy: FallbackToLogsOnError
+}
+
+func ExampleWithDefaultReadinessProbe() {
+	c, _ := NewContainer("test", WithDefaultReadinessProbe())
+
+	jc, _ := json.Marshal(c)
+	fmt.Println(string(jc))
+
+	yc, _ := yaml.Marshal(c)
+	fmt.Println(string(yc))
+
+	// Output:
+	// {"name":"test","resources":{"limits":{"cpu":"1","memory":"500Mi"},"requests":{"cpu":"500m","memory":"100Mi"}},"readinessProbe":{"httpGet":{"path":"/","port":"test","scheme":"HTTP"},"timeoutSeconds":5,"periodSeconds":5},"terminationMessagePolicy":"FallbackToLogsOnError","imagePullPolicy":"IfNotPresent","securityContext":{"runAsUser":100,"runAsGroup":101,"readOnlyRootFilesystem":true,"allowPrivilegeEscalation":false}}
+	// imagePullPolicy: IfNotPresent
+	// name: test
+	// readinessProbe:
+	//   httpGet:
+	//     path: /
+	//     port: test
+	//     scheme: HTTP
+	//   periodSeconds: 5
+	//   timeoutSeconds: 5
+	// resources:
+	//   limits:
+	//     cpu: "1"
+	//     memory: 500Mi
+	//   requests:
+	//     cpu: 500m
+	//     memory: 100Mi
+	// securityContext:
+	//   allowPrivilegeEscalation: false
+	//   readOnlyRootFilesystem: true
+	//   runAsGroup: 101
+	//   runAsUser: 100
+	// terminationMessagePolicy: FallbackToLogsOnError
+}

--- a/internal/k8s/resource/doc.go
+++ b/internal/k8s/resource/doc.go
@@ -1,0 +1,2 @@
+// Package resource contains functions to build Kubernetes resources using patterns and defaults common to Sourcegraph.
+package resource


### PR DESCRIPTION
This is the start of a series of packages to help create k8s resources with patterns and defaults common to Sourcegraph.

Throughout many of our K8s deployments, we have common settings such as security contexts, readiness probes, liveness probes, etc... 

We can abstract some if not most of these to make deploying on k8s easier in the future. While this is not the final layer of abstraction, it will be used by it.

Specifically, this pkg helps create k8s containers, with a few defaults baked in, while still allow a user to override if necessary. 

## Test plan

Full unit test coverage as well as testable examples.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
