### PR TITLE
web: Make Logo work with SvelteKit integration

### DIFF
--- a/client/web/src/nav/NavBar/NavBar.tsx
+++ b/client/web/src/nav/NavBar/NavBar.tsx
@@ -58,9 +58,9 @@ export const NavBar = forwardRef(function NavBar({ children, logo }, reference):
             {logo && (
                 <>
                     <H1 className={navBarStyles.logo}>
-                        <RouterNavLink className="d-flex align-items-center" to={logoUrl}>
+                        <Link className="d-flex align-items-center" to={logoUrl}>
                             {logo}
-                        </RouterNavLink>
+                        </Link>
                     </H1>
                     <hr className={navBarStyles.divider} aria-hidden={true} />
                 </>


### PR DESCRIPTION
The logo link isn't rendered via <Link /> (not sure why) and therefore the special "reload if SvelteKit is enabled" logic didn't work.

This fixes it.



## Test plan

Manual testing