### PR TITLE
Enable flagging for OpenAI-routed LLM requests

### DIFF
--- a/cmd/cody-gateway/internal/httpapi/completions/BUILD.bazel
+++ b/cmd/cody-gateway/internal/httpapi/completions/BUILD.bazel
@@ -46,6 +46,7 @@ go_test(
         "anthropic_test.go",
         "anthropicmessages_test.go",
         "fireworks_test.go",
+        "flagging_test.go",
         "openai_test.go",
     ],
     embed = [":completions"],

--- a/cmd/cody-gateway/internal/httpapi/completions/anthropic.go
+++ b/cmd/cody-gateway/internal/httpapi/completions/anthropic.go
@@ -132,27 +132,20 @@ func (a *AnthropicHandlerMethods) getAPIURLByFeature(feature codygateway.Feature
 }
 
 func (a *AnthropicHandlerMethods) validateRequest(ctx context.Context, logger log.Logger, _ codygateway.Feature, ar anthropicRequest) error {
-	if ar.MaxTokensToSample > int32(a.config.MaxTokensToSample) {
-		return errors.Errorf("max_tokens_to_sample exceeds maximum allowed value of %d: %d", a.config.MaxTokensToSample, ar.MaxTokensToSample)
+	maxTokensToSample := a.config.FlaggingConfig.MaxTokensToSample
+	if ar.MaxTokensToSample > int32(maxTokensToSample) {
+		return errors.Errorf("max_tokens_to_sample exceeds maximum allowed value of %d: %d", maxTokensToSample, ar.MaxTokensToSample)
 	}
 	return nil
 }
 
 func (a *AnthropicHandlerMethods) shouldFlagRequest(ctx context.Context, logger log.Logger, ar anthropicRequest) (*flaggingResult, error) {
-	cfg := a.config
 	result, err := isFlaggedRequest(a.anthropicTokenizer,
 		flaggingRequest{
 			FlattenedPrompt: ar.Prompt,
 			MaxTokens:       int(ar.MaxTokensToSample),
 		},
-		flaggingConfig{
-			AllowedPromptPatterns:          cfg.AllowedPromptPatterns,
-			BlockedPromptPatterns:          cfg.BlockedPromptPatterns,
-			PromptTokenFlaggingLimit:       cfg.PromptTokenFlaggingLimit,
-			PromptTokenBlockingLimit:       cfg.PromptTokenBlockingLimit,
-			MaxTokensToSampleFlaggingLimit: cfg.MaxTokensToSampleFlaggingLimit,
-			ResponseTokenBlockingLimit:     cfg.ResponseTokenBlockingLimit,
-		},
+		makeFlaggingConfig(a.config.FlaggingConfig),
 	)
 	if err != nil {
 		return nil, err
@@ -166,7 +159,6 @@ func (a *AnthropicHandlerMethods) shouldFlagRequest(ctx context.Context, logger 
 		if err := a.promptRecorder.Record(ctx, ar.BuildPrompt()); err != nil {
 			logger.Warn("failed to record flagged prompt", log.Error(err))
 		}
-		result.shouldBlock = result.shouldBlock && a.config.RequestBlockingEnabled
 	}
 	return result, nil
 }

--- a/cmd/cody-gateway/internal/httpapi/completions/anthropic_test.go
+++ b/cmd/cody-gateway/internal/httpapi/completions/anthropic_test.go
@@ -26,14 +26,14 @@ func (*mockPromptRecorder) Record(ctx context.Context, prompt string) error {
 func TestIsFlaggedAnthropicRequest(t *testing.T) {
 	validPreamble := "You are cody-gateway."
 
-	cfg := config.AnthropicConfig{
+	cfg := config.FlaggingConfig{
 		PromptTokenFlaggingLimit:       18000,
 		PromptTokenBlockingLimit:       20000,
 		MaxTokensToSampleFlaggingLimit: 1000,
 		ResponseTokenBlockingLimit:     1000,
 		RequestBlockingEnabled:         true,
 	}
-	cfgWithPreamble := config.AnthropicConfig{
+	cfgWithPreamble := config.FlaggingConfig{
 		PromptTokenFlaggingLimit:       18000,
 		PromptTokenBlockingLimit:       20000,
 		MaxTokensToSampleFlaggingLimit: 1000,
@@ -46,12 +46,14 @@ func TestIsFlaggedAnthropicRequest(t *testing.T) {
 
 	// Helper function for calling the AnthropicHandlerMethod's shouldFlagRequest, using the supplied
 	// request and configuration.
-	callShouldFlagRequest := func(t *testing.T, ar anthropicRequest, cfg config.AnthropicConfig) (*flaggingResult, error) {
+	callShouldFlagRequest := func(t *testing.T, ar anthropicRequest, flaggingConfig config.FlaggingConfig) (*flaggingResult, error) {
 		t.Helper()
 		anthropicUpstream := &AnthropicHandlerMethods{
 			anthropicTokenizer: tk,
 			promptRecorder:     &mockPromptRecorder{},
-			config:             cfg,
+			config: config.AnthropicConfig{
+				FlaggingConfig: flaggingConfig,
+			},
 		}
 		ctx := context.Background()
 		logger := logtest.NoOp(t)

--- a/cmd/cody-gateway/internal/httpapi/completions/anthropic_test.go
+++ b/cmd/cody-gateway/internal/httpapi/completions/anthropic_test.go
@@ -29,6 +29,7 @@ func TestIsFlaggedAnthropicRequest(t *testing.T) {
 	cfg := config.FlaggingConfig{
 		PromptTokenFlaggingLimit:       18000,
 		PromptTokenBlockingLimit:       20000,
+		MaxTokensToSample:              0, // Not used within isFlaggedRequest.
 		MaxTokensToSampleFlaggingLimit: 1000,
 		ResponseTokenBlockingLimit:     1000,
 		RequestBlockingEnabled:         true,
@@ -36,6 +37,7 @@ func TestIsFlaggedAnthropicRequest(t *testing.T) {
 	cfgWithPreamble := config.FlaggingConfig{
 		PromptTokenFlaggingLimit:       18000,
 		PromptTokenBlockingLimit:       20000,
+		MaxTokensToSample:              0, // Not used within isFlaggedRequest.
 		MaxTokensToSampleFlaggingLimit: 1000,
 		ResponseTokenBlockingLimit:     1000,
 		RequestBlockingEnabled:         true,

--- a/cmd/cody-gateway/internal/httpapi/completions/anthropicmessages_test.go
+++ b/cmd/cody-gateway/internal/httpapi/completions/anthropicmessages_test.go
@@ -19,14 +19,14 @@ import (
 func TestIsFlaggedAnthropicMessagesRequest(t *testing.T) {
 	validPreamble := "You are cody-gateway."
 
-	cfg := config.AnthropicConfig{
+	cfg := config.FlaggingConfig{
 		PromptTokenFlaggingLimit:       18000,
 		PromptTokenBlockingLimit:       20000,
 		MaxTokensToSampleFlaggingLimit: 1000,
 		ResponseTokenBlockingLimit:     1000,
 		RequestBlockingEnabled:         true,
 	}
-	cfgWithPreamble := config.AnthropicConfig{
+	cfgWithPreamble := config.FlaggingConfig{
 		PromptTokenFlaggingLimit:       18000,
 		PromptTokenBlockingLimit:       20000,
 		MaxTokensToSampleFlaggingLimit: 1000,
@@ -39,12 +39,14 @@ func TestIsFlaggedAnthropicMessagesRequest(t *testing.T) {
 
 	// Helper function for calling the AnthropicMessageHandlerMethod's shouldFlagRequest, using the supplied
 	// request and configuration.
-	callShouldFlagRequest := func(t *testing.T, ar anthropicMessagesRequest, cfg config.AnthropicConfig) (*flaggingResult, error) {
+	callShouldFlagRequest := func(t *testing.T, ar anthropicMessagesRequest, flaggingConfig config.FlaggingConfig) (*flaggingResult, error) {
 		t.Helper()
 		anthropicUpstream := &AnthropicMessagesHandlerMethods{
 			tokenizer:      tk,
 			promptRecorder: &mockPromptRecorder{},
-			config:         cfg,
+			config: config.AnthropicConfig{
+				FlaggingConfig: flaggingConfig,
+			},
 		}
 		ctx := context.Background()
 		logger := logtest.NoOp(t)

--- a/cmd/cody-gateway/internal/httpapi/completions/anthropicmessages_test.go
+++ b/cmd/cody-gateway/internal/httpapi/completions/anthropicmessages_test.go
@@ -22,6 +22,7 @@ func TestIsFlaggedAnthropicMessagesRequest(t *testing.T) {
 	cfg := config.FlaggingConfig{
 		PromptTokenFlaggingLimit:       18000,
 		PromptTokenBlockingLimit:       20000,
+		MaxTokensToSample:              0, // Not used within isFlaggedRequest.
 		MaxTokensToSampleFlaggingLimit: 1000,
 		ResponseTokenBlockingLimit:     1000,
 		RequestBlockingEnabled:         true,
@@ -29,6 +30,7 @@ func TestIsFlaggedAnthropicMessagesRequest(t *testing.T) {
 	cfgWithPreamble := config.FlaggingConfig{
 		PromptTokenFlaggingLimit:       18000,
 		PromptTokenBlockingLimit:       20000,
+		MaxTokensToSample:              0, // Not used within isFlaggedRequest.
 		MaxTokensToSampleFlaggingLimit: 1000,
 		ResponseTokenBlockingLimit:     1000,
 		RequestBlockingEnabled:         true,

--- a/cmd/cody-gateway/internal/httpapi/completions/flagging.go
+++ b/cmd/cody-gateway/internal/httpapi/completions/flagging.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/sourcegraph/sourcegraph/cmd/cody-gateway/internal/tokenizer"
+	"github.com/sourcegraph/sourcegraph/cmd/cody-gateway/shared/config"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
@@ -22,7 +23,25 @@ type flaggingConfig struct {
 	PromptTokenBlockingLimit       int
 	MaxTokensToSampleFlaggingLimit int
 	ResponseTokenBlockingLimit     int
+
+	// If false, the flaggingResult returned from isFlaggedRequest will never have shouldBlock set to true.
+	RequestBlockingEnabled bool
 }
+
+// makeFlaggingConfig converts the config.FlaggingConfig into the type used in this package.
+// (This just avoids taking a hard dependency, allowing the config package to change independently, etc.)
+func makeFlaggingConfig(cfg config.FlaggingConfig) flaggingConfig {
+	return flaggingConfig{
+		AllowedPromptPatterns:          cfg.AllowedPromptPatterns,
+		BlockedPromptPatterns:          cfg.BlockedPromptPatterns,
+		PromptTokenFlaggingLimit:       cfg.PromptTokenFlaggingLimit,
+		PromptTokenBlockingLimit:       cfg.PromptTokenBlockingLimit,
+		MaxTokensToSampleFlaggingLimit: cfg.MaxTokensToSampleFlaggingLimit,
+		ResponseTokenBlockingLimit:     cfg.ResponseTokenBlockingLimit,
+		RequestBlockingEnabled:         cfg.RequestBlockingEnabled,
+	}
+}
+
 type flaggingRequest struct {
 	FlattenedPrompt string
 	MaxTokens       int
@@ -53,15 +72,19 @@ func isFlaggedRequest(tk *tokenizer.Tokenizer, r flaggingRequest, cfg flaggingCo
 		reasons = append(reasons, "high_max_tokens_to_sample")
 	}
 
-	// If this prompt consists of a very large number of tokens, then flag it.
-	tokens, err := tk.Tokenize(r.FlattenedPrompt)
-	if err != nil {
-		return &flaggingResult{}, errors.Wrap(err, "tokenize prompt")
-	}
-	tokenCount := len(tokens)
+	// For more accurate flagging, we need to take the actual tokenization of the prompt
+	// into account. However, not every LLM integration has that available.
+	tokenCount := -1
+	if tk != nil {
+		tokens, err := tk.Tokenize(r.FlattenedPrompt)
+		if err != nil {
+			return &flaggingResult{}, errors.Wrap(err, "tokenizing prompt")
+		}
 
-	if tokenCount > cfg.PromptTokenFlaggingLimit {
-		reasons = append(reasons, "high_prompt_token_count")
+		tokenCount = len(tokens)
+		if tokenCount > cfg.PromptTokenFlaggingLimit {
+			reasons = append(reasons, "high_prompt_token_count")
+		}
 	}
 
 	if len(reasons) == 0 {
@@ -92,6 +115,10 @@ func isFlaggedRequest(tk *tokenizer.Tokenizer, r flaggingRequest, cfg flaggingCo
 	if hasBlockedPhrase {
 		res.blockedPhrase = &phrase
 	}
+
+	// Honor the configuration setting for disabling request blocking.
+	res.shouldBlock = res.shouldBlock && cfg.RequestBlockingEnabled
+
 	return res, nil
 }
 

--- a/cmd/cody-gateway/internal/httpapi/completions/flagging.go
+++ b/cmd/cody-gateway/internal/httpapi/completions/flagging.go
@@ -24,7 +24,7 @@ type flaggingConfig struct {
 	MaxTokensToSampleFlaggingLimit int
 	ResponseTokenBlockingLimit     int
 
-	// If false, the flaggingResult returned from isFlaggedRequest will never have shouldBlock set to true.
+	// If false, flaggingResult.shouldBlock will always be false when returned by isFlaggedRequest.
 	RequestBlockingEnabled bool
 }
 

--- a/cmd/cody-gateway/internal/httpapi/completions/flagging_test.go
+++ b/cmd/cody-gateway/internal/httpapi/completions/flagging_test.go
@@ -1,0 +1,207 @@
+package completions
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sourcegraph/sourcegraph/cmd/cody-gateway/internal/tokenizer"
+	"github.com/sourcegraph/sourcegraph/cmd/cody-gateway/shared/config"
+)
+
+func TestMakeFlaggingConfig(t *testing.T) {
+	configConfig := config.FlaggingConfig{
+		AllowedPromptPatterns:  []string{"allowed", "prompt", "patterns"},
+		BlockedPromptPatterns:  []string{"blocked", "prompt", "patterns"},
+		RequestBlockingEnabled: true,
+
+		// NOTE: This field is NOT part of flagging.go's flaggingConfig struct, it
+		// only uses MaxTokensToSampleFlaggingLimit. Instead, this is the hard-cap
+		// for the LLM provider.
+		MaxTokensToSample: 111,
+
+		PromptTokenFlaggingLimit:       222,
+		PromptTokenBlockingLimit:       333,
+		MaxTokensToSampleFlaggingLimit: 444,
+		ResponseTokenBlockingLimit:     555,
+	}
+
+	// Confirm that everything is copied over as expected.
+	convertedConfig := makeFlaggingConfig(configConfig)
+	assert.Equal(t, configConfig.AllowedPromptPatterns, convertedConfig.AllowedPromptPatterns)
+	assert.Equal(t, configConfig.BlockedPromptPatterns, convertedConfig.BlockedPromptPatterns)
+	assert.Equal(t, configConfig.RequestBlockingEnabled, convertedConfig.RequestBlockingEnabled)
+	assert.Equal(t, configConfig.MaxTokensToSampleFlaggingLimit, convertedConfig.MaxTokensToSampleFlaggingLimit)
+	assert.Equal(t, configConfig.PromptTokenFlaggingLimit, convertedConfig.PromptTokenFlaggingLimit)
+	assert.Equal(t, configConfig.PromptTokenFlaggingLimit, convertedConfig.PromptTokenFlaggingLimit)
+}
+
+func TestIsFlaggedRequest(t *testing.T) {
+	validPreamble := "You are cody-gateway."
+
+	basicCfg := flaggingConfig{
+		PromptTokenFlaggingLimit:       18000,
+		PromptTokenBlockingLimit:       20000,
+		MaxTokensToSampleFlaggingLimit: 1000,
+		ResponseTokenBlockingLimit:     1000,
+		RequestBlockingEnabled:         true,
+	}
+	cfgWithPreamble := flaggingConfig{
+		PromptTokenFlaggingLimit:       18000,
+		PromptTokenBlockingLimit:       20000,
+		MaxTokensToSampleFlaggingLimit: 1000,
+		ResponseTokenBlockingLimit:     1000,
+		RequestBlockingEnabled:         true,
+		AllowedPromptPatterns:          []string{strings.ToLower(validPreamble)},
+	}
+
+	// Create a generic tokenizer. If provided to isFlaggedRequest, it will enable
+	// a few more checks.
+	tokenizer, err := tokenizer.NewAnthropicClaudeTokenizer()
+	require.NoError(t, err)
+
+	// callIsFlaggedRequest just wraps the call to isFlaggedResult.
+	callIsFlaggedRequest := func(t *testing.T, prompt string, cfg flaggingConfig) (*flaggingResult, error) {
+		return isFlaggedRequest(
+			tokenizer,
+			flaggingRequest{
+				FlattenedPrompt: prompt,
+				MaxTokens:       200,
+			},
+			cfg)
+	}
+
+	// Request is missing the preamble.
+	t.Run("MissingPreamble", func(t *testing.T) {
+		result, err := callIsFlaggedRequest(t, "prompt without known preamble", cfgWithPreamble)
+		require.NoError(t, err)
+
+		require.True(t, result.IsFlagged())
+		require.False(t, result.shouldBlock)
+		require.Contains(t, result.reasons, "unknown_prompt")
+	})
+
+	// If the configuration doesn't include a preamble, the same request won't get flagged.
+	t.Run("PremableNotConfigured", func(t *testing.T) {
+		result, err := callIsFlaggedRequest(t, "some prompt without known premable", basicCfg)
+		require.NoError(t, err)
+		require.False(t, result.IsFlagged())
+	})
+
+	t.Run("WithPreamble", func(t *testing.T) {
+		result, err := callIsFlaggedRequest(t, "yadda yadda"+validPreamble+"yadda yadda", cfgWithPreamble)
+		require.NoError(t, err)
+		require.False(t, result.IsFlagged())
+	})
+
+	t.Run("high max tokens to sample", func(t *testing.T) {
+		result, err := isFlaggedRequest(
+			tokenizer,
+			flaggingRequest{
+				FlattenedPrompt: validPreamble,
+				MaxTokens:       basicCfg.MaxTokensToSampleFlaggingLimit + 1,
+			},
+			basicCfg)
+		require.NoError(t, err)
+		assert.True(t, result.IsFlagged())
+		assert.True(t, result.shouldBlock)
+		assert.Contains(t, result.reasons, "high_max_tokens_to_sample")
+
+		// NB. In practice, this is essentially us returning to the client what the configured
+		// MaxTokensToSampleFlaggingLimit is. e.g. "flagged, because maxTokensToSample was set to xxx".
+		assert.Equal(t, result.maxTokensToSample, basicCfg.MaxTokensToSampleFlaggingLimit+1)
+	})
+
+	t.Run("missing preamble and bad phrase", func(t *testing.T) {
+		cfgWithBadPhrase := cfgWithPreamble
+		cfgWithBadPhrase.BlockedPromptPatterns = []string{"bad phrase"}
+		result, err := callIsFlaggedRequest(
+			t,
+			"never going to give you up... bad phrase never going to... ",
+			cfgWithBadPhrase)
+		require.NoError(t, err)
+		assert.True(t, result.IsFlagged())
+		assert.True(t, result.shouldBlock)
+		assert.Contains(t, result.reasons, "unknown_prompt")
+	})
+
+	// If the prompt is NOT flagged, then we do not perform the "blocking due to bad phrase" check.
+	// In other words, a valid prompt with a bad phrase is allowed through.
+	t.Run("bad phrase only", func(t *testing.T) {
+		cfgWithBadPhrase := cfgWithPreamble
+		cfgWithBadPhrase.BlockedPromptPatterns = []string{"bad phrase"}
+		result, err := callIsFlaggedRequest(
+			t,
+			validPreamble+" ... bad phrase ...",
+			cfgWithBadPhrase)
+		require.NoError(t, err)
+		assert.False(t, result.IsFlagged())
+	})
+
+	t.Run("TokenCountChecks", func(t *testing.T) {
+		// Set up a prompt with a well-enough known prompt count based on tokenizer.
+		repeatedWords := strings.Repeat("never going to give you up ", 10)
+		prompt := validPreamble + repeatedWords
+
+		promptTokens, err := tokenizer.Tokenize(prompt)
+		require.NoError(t, err)
+		promptTokenCount := len(promptTokens)
+
+		// Flagging config's with the flagging limit equal to the token count of the prompt.
+		tokenCountConfig := cfgWithPreamble
+		tokenCountConfig.PromptTokenFlaggingLimit = promptTokenCount
+		tokenCountConfig.PromptTokenBlockingLimit = promptTokenCount + 10
+
+		// If no tokenizer is available when checking if the request should be flagged,
+		// we simply skip those checks. (And do not panic, etc.)
+		t.Run("NilTokenizer", func(t *testing.T) {
+			reallyLongPrompt := strings.Repeat(prompt, 10)
+			result, err := isFlaggedRequest(
+				nil,
+				flaggingRequest{
+					FlattenedPrompt: reallyLongPrompt,
+					MaxTokens:       200,
+				},
+				tokenCountConfig)
+			require.NoError(t, err)
+
+			// Other than the long-prompt check (which requires the tokenizer),
+			// the request is legit.
+			assert.False(t, result.IsFlagged())
+		})
+
+		t.Run("BelowFlaggingLimit", func(t *testing.T) {
+			shoterPrompt := string(prompt[:len(prompt)-8])
+			result, err := callIsFlaggedRequest(t, shoterPrompt, tokenCountConfig)
+			require.NoError(t, err)
+			assert.False(t, result.IsFlagged())
+			assert.Nil(t, result)
+		})
+
+		t.Run("AboveFlaggingLimitBelowBlockLimit", func(t *testing.T) {
+			longerPrompt := prompt + " qed" // NB. Must be fewer than XX tokens, as to not be blocked.
+			result, err := callIsFlaggedRequest(t, longerPrompt, tokenCountConfig)
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			assert.True(t, result.IsFlagged())
+			assert.False(t, result.shouldBlock)
+			assert.Contains(t, result.reasons, "high_prompt_token_count")
+			assert.Greater(t, result.promptTokenCount, promptTokenCount)
+		})
+
+		t.Run("AboveFlaggingLimitAboveBlockLimit", func(t *testing.T) {
+			// Create an even longer prompt, more than XX tokens in length to
+			// exceed the blocking limit.
+			longerPrompt := prompt + " qed. Along with additional information, which I intend to use in order to..."
+			result, err := callIsFlaggedRequest(t, longerPrompt, tokenCountConfig)
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			assert.True(t, result.IsFlagged())
+			assert.True(t, result.shouldBlock)
+			assert.Contains(t, result.reasons, "high_prompt_token_count")
+			assert.Greater(t, result.promptTokenCount, tokenCountConfig.PromptTokenBlockingLimit)
+		})
+	})
+}

--- a/cmd/cody-gateway/internal/httpapi/completions/openai.go
+++ b/cmd/cody-gateway/internal/httpapi/completions/openai.go
@@ -126,14 +126,14 @@ func (*OpenAIHandlerMethods) validateRequest(_ context.Context, _ log.Logger, fe
 	return nil
 }
 
-func (oaih *OpenAIHandlerMethods) shouldFlagRequest(ctx context.Context, logger log.Logger, req openaiRequest) (*flaggingResult, error) {
+func (o *OpenAIHandlerMethods) shouldFlagRequest(ctx context.Context, logger log.Logger, req openaiRequest) (*flaggingResult, error) {
 	result, err := isFlaggedRequest(
 		nil, /* tokenzier, meaning token counts aren't considered when for flagging consideration. */
 		flaggingRequest{
 			FlattenedPrompt: req.BuildPrompt(),
 			MaxTokens:       int(req.MaxTokens),
 		},
-		makeFlaggingConfig(oaih.config.FlaggingConfig))
+		makeFlaggingConfig(o.config.FlaggingConfig))
 	return result, err
 }
 

--- a/cmd/cody-gateway/internal/httpapi/completions/openai.go
+++ b/cmd/cody-gateway/internal/httpapi/completions/openai.go
@@ -126,9 +126,15 @@ func (*OpenAIHandlerMethods) validateRequest(_ context.Context, _ log.Logger, fe
 	return nil
 }
 
-func (*OpenAIHandlerMethods) shouldFlagRequest(_ context.Context, _ log.Logger, _ openaiRequest) (*flaggingResult, error) {
-	// TODO[#61278]: Add missing request validation for all LLM providers in Cody Gateway.
-	return nil, nil
+func (oaih *OpenAIHandlerMethods) shouldFlagRequest(ctx context.Context, logger log.Logger, req openaiRequest) (*flaggingResult, error) {
+	result, err := isFlaggedRequest(
+		nil, /* tokenzier, meaning token counts aren't considered when for flagging consideration. */
+		flaggingRequest{
+			FlattenedPrompt: req.BuildPrompt(),
+			MaxTokens:       int(req.MaxTokens),
+		},
+		makeFlaggingConfig(oaih.config.FlaggingConfig))
+	return result, err
 }
 
 func (*OpenAIHandlerMethods) transformBody(body *openaiRequest, identifier string) {

--- a/cmd/cody-gateway/shared/config/config.go
+++ b/cmd/cody-gateway/shared/config/config.go
@@ -71,20 +71,9 @@ type OpenTelemetryConfig struct {
 }
 
 type AnthropicConfig struct {
-	AllowedModels     []string
-	AccessToken       string
-	MaxTokensToSample int
-	// Phrases we look for in the prompt to consider it valid.
-	// Each phrase is lower case.
-	AllowedPromptPatterns []string
-	// Phrases we look for in a flagged request to consider blocking the response.
-	// Each phrase is lower case. Can be empty (to disable blocking).
-	BlockedPromptPatterns          []string
-	RequestBlockingEnabled         bool
-	PromptTokenFlaggingLimit       int
-	PromptTokenBlockingLimit       int
-	MaxTokensToSampleFlaggingLimit int
-	ResponseTokenBlockingLimit     int
+	AllowedModels  []string
+	AccessToken    string
+	FlaggingConfig FlaggingConfig
 }
 
 type FireworksConfig struct {
@@ -95,14 +84,37 @@ type FireworksConfig struct {
 }
 
 type OpenAIConfig struct {
-	AllowedModels []string
-	AccessToken   string
-	OrgID         string
+	AllowedModels  []string
+	AccessToken    string
+	OrgID          string
+	FlaggingConfig FlaggingConfig
 }
 
 type SourcegraphConfig struct {
 	TritonURL           string
 	UnlimitedEmbeddings bool
+}
+
+// FlaggingConfig defines common parameters for filtering and flagging requests,
+// in an LLM-provider agnostic manner.
+type FlaggingConfig struct {
+	// Phrases we look for in the prompt to consider it valid.
+	// Each phrase is lower case.
+	AllowedPromptPatterns []string
+
+	// Phrases we look for in a flagged request to consider blocking the response.
+	// Each phrase is lower case. Can be empty (to disable blocking).
+	BlockedPromptPatterns []string
+
+	// RequestBlockingEnabled controls whether or not requests can be blocked.
+	// A possible escape hatch if there is a sudden spike in false-positives.
+	RequestBlockingEnabled bool
+
+	MaxTokensToSample              int
+	PromptTokenFlaggingLimit       int
+	PromptTokenBlockingLimit       int
+	MaxTokensToSampleFlaggingLimit int
+	ResponseTokenBlockingLimit     int
 }
 
 func (c *Config) Load() {
@@ -153,15 +165,9 @@ func (c *Config) Load() {
 	if c.Anthropic.AccessToken != "" && len(c.Anthropic.AllowedModels) == 0 {
 		c.AddError(errors.New("must provide allowed models for Anthropic"))
 	}
-	c.Anthropic.MaxTokensToSample = c.GetInt("CODY_GATEWAY_ANTHROPIC_MAX_TOKENS_TO_SAMPLE", "10000", "Maximum permitted value of maxTokensToSample")
-	c.Anthropic.AllowedPromptPatterns = toLower(splitMaybe(c.GetOptional("CODY_GATEWAY_ANTHROPIC_ALLOWED_PROMPT_PATTERNS", "Prompt patterns to allow.")))
-	c.Anthropic.BlockedPromptPatterns = toLower(splitMaybe(c.GetOptional("CODY_GATEWAY_ANTHROPIC_BLOCKED_PROMPT_PATTERNS", "Patterns to block in prompt.")))
-	c.Anthropic.RequestBlockingEnabled = c.GetBool("CODY_GATEWAY_ANTHROPIC_REQUEST_BLOCKING_ENABLED", "false", "Whether we should block requests that match our blocking criteria.")
 
-	c.Anthropic.PromptTokenBlockingLimit = c.GetInt("CODY_GATEWAY_ANTHROPIC_PROMPT_TOKEN_BLOCKING_LIMIT", "20000", "Maximum number of prompt tokens to allow without blocking.")
-	c.Anthropic.PromptTokenFlaggingLimit = c.GetInt("CODY_GATEWAY_ANTHROPIC_PROMPT_TOKEN_FLAGGING_LIMIT", "18000", "Maximum number of prompt tokens to allow without flagging.")
-	c.Anthropic.MaxTokensToSampleFlaggingLimit = c.GetInt("CODY_GATEWAY_ANTHROPIC_MAX_TOKENS_TO_SAMPLE_FLAGGING_LIMIT", "1000", "Maximum value of max_tokens_to_sample to allow without flagging.")
-	c.Anthropic.ResponseTokenBlockingLimit = c.GetInt("CODY_GATEWAY_ANTHROPIC_RESPONSE_TOKEN_BLOCKING_LIMIT", "1000", "Maximum number of completion tokens to allow without blocking.")
+	// Load configuration settings specific to how we flag Anthropic requests.
+	c.loadFlaggingConfig(&c.Anthropic.FlaggingConfig, "CODY_GATEWAY_ANTHROPIC")
 
 	c.OpenAI.AccessToken = c.GetOptional("CODY_GATEWAY_OPENAI_ACCESS_TOKEN", "The OpenAI access token to be used.")
 	c.OpenAI.OrgID = c.GetOptional("CODY_GATEWAY_OPENAI_ORG_ID", "The OpenAI organization to count billing towards. Setting this ensures we always use the correct negotiated terms.")
@@ -172,6 +178,14 @@ func (c *Config) Load() {
 	if c.OpenAI.AccessToken != "" && len(c.OpenAI.AllowedModels) == 0 {
 		c.AddError(errors.New("must provide allowed models for OpenAI"))
 	}
+
+	// Load configuration settings specific to how we flag OpenAI requests.
+	//
+	// HACK: Rather than duplicate all of the env vars to independently control how we flag
+	// Anthropic and OpenAI models, we are just reusing the same settings for Anthropic.
+	// If we follow this better, we should just rename the env vars to something general, e.g.
+	// "CODY_GATEWAY_FLAGGING_" and just load a single, shared flagging config.
+	c.loadFlaggingConfig(&c.OpenAI.FlaggingConfig, "CODY_GATEWAY_ANTHROPIC")
 
 	c.Fireworks.AccessToken = c.GetOptional("CODY_GATEWAY_FIREWORKS_ACCESS_TOKEN", "The Fireworks access token to be used.")
 	c.Fireworks.AllowedModels = splitMaybe(c.Get("CODY_GATEWAY_FIREWORKS_ALLOWED_MODELS",
@@ -243,8 +257,38 @@ func (c *Config) Load() {
 
 }
 
-// splitMaybe splits on commas, but only returns at least one element if the input
-// is non-empty.
+// loadFlaggingConfig loads the common set of flagging-related environment variables for
+// an LLM provider. The expectation is that the env vars all share the provider-specific
+// prefix, and a flagging config-specific suffix.
+//
+// IMPORTANT: Some of the env vars loaded are _required_. So be sure that they are all
+// set before calling loadFlaggingConfig for a new LLM provider.
+func (c *Config) loadFlaggingConfig(cfg *FlaggingConfig, envVarPrefix string) {
+	// Ensure the prefix ends with a _, so we require
+	// "ACME_CORP_MAX_TOKENS" and not "ACME_CORPMAX_TOKENS".
+	if !strings.HasSuffix(envVarPrefix, "_") {
+		envVarPrefix += "_"
+	}
+
+	// Loads a comma-separated env var, and converts it to lower-case.
+	maybeLoadLowercaseSlice := func(envVar, description string) []string {
+		value := c.GetOptional(envVarPrefix+envVar, description)
+		values := splitMaybe(value)
+		return toLower(values)
+	}
+
+	cfg.MaxTokensToSample = c.GetInt(envVarPrefix+"MAX_TOKENS_TO_SAMPLE", "10000", "Maximum permitted value of maxTokensToSample")
+	cfg.AllowedPromptPatterns = maybeLoadLowercaseSlice("ALLOWED_PROMPT_PATTERNS", "Allowed prompt patterns")
+	cfg.BlockedPromptPatterns = maybeLoadLowercaseSlice(envVarPrefix+"BLOCKED_PROMPT_PATTERNS", "Patterns to block in prompt.")
+	cfg.RequestBlockingEnabled = c.GetBool(envVarPrefix+"REQUEST_BLOCKING_ENABLED", "false", "Whether we should block requests that match our blocking criteria.")
+
+	cfg.PromptTokenBlockingLimit = c.GetInt(envVarPrefix+"PROMPT_TOKEN_BLOCKING_LIMIT", "20000", "Maximum number of prompt tokens to allow without blocking.")
+	cfg.PromptTokenFlaggingLimit = c.GetInt(envVarPrefix+"PROMPT_TOKEN_FLAGGING_LIMIT", "18000", "Maximum number of prompt tokens to allow without flagging.")
+	cfg.MaxTokensToSampleFlaggingLimit = c.GetInt(envVarPrefix+"MAX_TOKENS_TO_SAMPLE_FLAGGING_LIMIT", "1000", "Maximum value of max_tokens_to_sample to allow without flagging.")
+	cfg.ResponseTokenBlockingLimit = c.GetInt(envVarPrefix+"RESPONSE_TOKEN_BLOCKING_LIMIT", "1000", "Maximum number of completion tokens to allow without blocking.")
+}
+
+// splitMaybe splits the provided string on commas, but returns nil if given the empty string.
 func splitMaybe(input string) []string {
 	if input == "" {
 		return nil

--- a/cmd/cody-gateway/shared/config/config.go
+++ b/cmd/cody-gateway/shared/config/config.go
@@ -110,11 +110,19 @@ type FlaggingConfig struct {
 	// A possible escape hatch if there is a sudden spike in false-positives.
 	RequestBlockingEnabled bool
 
-	MaxTokensToSample              int
-	PromptTokenFlaggingLimit       int
-	PromptTokenBlockingLimit       int
+	PromptTokenFlaggingLimit int
+	PromptTokenBlockingLimit int
+
+	// MaxTokensToSample is the hard-cap, used to block requests that are too long.
+	MaxTokensToSample int
+	// MaxTokensToSampleFlaggingLimit is a soft-cap, used to flag requests. (But not necessarily block.)
+	// So MaxTokensToSampleFlaggingLimit should be <= MaxTokensToSample.
 	MaxTokensToSampleFlaggingLimit int
-	ResponseTokenBlockingLimit     int
+
+	// ResponseTokenBlockingLimit is the maximum number of tokens we allow before outright blocking
+	// a response. e.g. the client sends a request desiring a response with 100 max tokens, we will
+	// block it IFF the ResponseTokenBlockingLimit is less than 100.
+	ResponseTokenBlockingLimit int
 }
 
 func (c *Config) Load() {
@@ -278,13 +286,14 @@ func (c *Config) loadFlaggingConfig(cfg *FlaggingConfig, envVarPrefix string) {
 	}
 
 	cfg.MaxTokensToSample = c.GetInt(envVarPrefix+"MAX_TOKENS_TO_SAMPLE", "10000", "Maximum permitted value of maxTokensToSample")
+	cfg.MaxTokensToSampleFlaggingLimit = c.GetInt(envVarPrefix+"MAX_TOKENS_TO_SAMPLE_FLAGGING_LIMIT", "1000", "Maximum value of max_tokens_to_sample to allow without flagging.")
+
 	cfg.AllowedPromptPatterns = maybeLoadLowercaseSlice("ALLOWED_PROMPT_PATTERNS", "Allowed prompt patterns")
 	cfg.BlockedPromptPatterns = maybeLoadLowercaseSlice(envVarPrefix+"BLOCKED_PROMPT_PATTERNS", "Patterns to block in prompt.")
 	cfg.RequestBlockingEnabled = c.GetBool(envVarPrefix+"REQUEST_BLOCKING_ENABLED", "false", "Whether we should block requests that match our blocking criteria.")
 
 	cfg.PromptTokenBlockingLimit = c.GetInt(envVarPrefix+"PROMPT_TOKEN_BLOCKING_LIMIT", "20000", "Maximum number of prompt tokens to allow without blocking.")
 	cfg.PromptTokenFlaggingLimit = c.GetInt(envVarPrefix+"PROMPT_TOKEN_FLAGGING_LIMIT", "18000", "Maximum number of prompt tokens to allow without flagging.")
-	cfg.MaxTokensToSampleFlaggingLimit = c.GetInt(envVarPrefix+"MAX_TOKENS_TO_SAMPLE_FLAGGING_LIMIT", "1000", "Maximum value of max_tokens_to_sample to allow without flagging.")
 	cfg.ResponseTokenBlockingLimit = c.GetInt(envVarPrefix+"RESPONSE_TOKEN_BLOCKING_LIMIT", "1000", "Maximum number of completion tokens to allow without blocking.")
 }
 


### PR DESCRIPTION
This PR enables our flagging/abuse-detection logic for requests sent to OpenAI.

To do this, it was only a matter of updating the `OpenAIHandlerMethods`'s `shouldFlagRequest(...)` function. And having it call `isFlaggedRequest(...)`. However, the bulk of this PR is to do the wiring in such a way that making the necessary configuration data available makes sense.

## Changes

1. Introduce `config.FlaggingConfig`

All of our anti-abuse parameters are part of `AnthropicConfig`. Rather than add the same fields to `OpenAIConfig` (and later, other LLM configuration objects), I moved them to a stand-alone `FlaggingConfig` struct.

These flagging configuration values can then be loaded in-bulk by calling this function:

```go
// loadFlaggingConfig loads the common set of flagging-related environment variables for
// an LLM provider. The expectation is that the env vars all share the provider-specific
// prefix, and a flagging config-specific suffix.
//
// IMPORTANT: Some of the env vars loaded are _required_. So be sure that they are all
// set before calling loadFlaggingConfig for a new LLM provider.
func (c *Config) loadFlaggingConfig(cfg *FlaggingConfig, envVarPrefix string) {
```

So all of the configuration loading for Anthropic is just a matter of calling:

```go
// Load configuration settings specific to how we flag Anthropic requests.
c.loadFlaggingConfig(&c.Anthropic.FlaggingConfig, "CODY_GATEWAY_ANTHROPIC")
```

2. Add `FlaggingConfig` to `OpenAIConfig`

Next, we just add the same `FlaggingConfig` bag of settings to `OpenAIConfig`. So the same configuration settings are available there, too.

However, the question becomes how do we _load_ these values? Do we want to add `CODY_GATEWAY_OPENAI_BLOCKED_PROMPT_PATTERNS`, and friends? That would be super-annoying to maintain. So to start with, I just load the same Anthropic settings for OpenAI.

Chiefly:

```go
// Load configuration settings specific to how we flag OpenAI requests.
//
// HACK: Rather than duplicate all of the env vars to independently control how we flag
// Anthropic and OpenAI models, we are just reusing the same settings for Anthropic.
// If we follow this better, we should just rename the env vars to something general, e.g.
// "CODY_GATEWAY_FLAGGING_" and just load a single, shared flagging config.
c.loadFlaggingConfig(&c.OpenAI.FlaggingConfig, "CODY_GATEWAY_ANTHROPIC")
```

I believe the long-term solution is to tease out all of these abuse-related env vars, into their own specific configuration bag. (e.g. `CODY_GATEWAY_FLAGGING`.) And only wire through LLM-specific env vars on an as-needed basis.

⚠️ Some ramifications of this:

- It assumes that the "tuning" for the two LLMs is more or less the same. e.g. if we set a custom `RESPONSE_TOKEN_BLOCKING_LIMIT` for Anthropic, that the same limit would apply to OpenAI too. However, that cannot be true because they would use different tokenizers.

In fact, isn't it possible that different LLM _models_ from the same provider could use different tokenizers?) I'm not sure if there is a great, one-size-fits-all type solution here.

- More importantly, this also means that we will -- unless we add some more logic, or update our `.tf` configuration -- have `REQUEST_BLOCKING_ENABLED=true` for OpenAI. (Since it is the case for Anthropic at the moment.) That may be risky, and a more conservative approach would be to set `REQUEST_BLOCKING_ENABLED=false` for OpenAI, manually inspect flagged requests from that model, and then enable it.

Since there's an ongoing REDACTED involving REDACTED, I'm inclined to just enable this. I am guessing that our existing abuse flagging isn't aggressive enough to disrupt legitimate OpenAI traffic. Even if things like token counts have different meanings. (e.g. the wiggle room between legitimate traffic and abusive traffic is X%, and X% of tokens is larger than any disparity between Anthropic and OpenAI tokenizers. But I could be totally wrong here.)

3. Update callers of `isFlaggedRequest` and the function itself

Rather than having `isFlaggedRequest` take a `config.FlaggingConfig` object directly (which wouldn't be too unreasonable), I instead kept the package's `flaggingConfig` struct.

That is nearly identical as `config.FlaggingConfig`, but is missing `MaxTokensToSample`. I added some comments here and there to clarify that surprising fact. (e.g. pointing out the difference between and `MaxTokensToSample` and `MaxTokensToSampleFlaggingLimit`, since auto-completion might trick you into using the wrong one.)

4. Add some tests specifically for `isFlaggedRequest`

Finally, just add some specific tests for `isFlaggedRequest`. Since the tests we have today (which are still valuable!) add a lot of ceremony to go through the `AnthropicHandlers` interface, and then call the `upstreamMethods.shouldFlagRequest`, etc.

And now that things are a bit more decoupled, it's far easier to just test the logic within `isFlaggedRequest` directly.

## Test plan

Added `flagging_test.go`, and generally cleaned things up. But we still do not have more robust end-to-end or integration type tests, for how the `http.Handler` that processes these requests work.

But we're getting closer. And hopefully soon we can do that without it being a major slog.