### PR TITLE
svelte: Fix theme persistence

### DIFF
--- a/client/shared/BUILD.bazel
+++ b/client/shared/BUILD.bazel
@@ -300,6 +300,7 @@ ts_project(
         "src/telemetry/index.ts",
         "src/telemetry/telemetryService.ts",
         "src/theme.ts",
+        "src/theme-types.ts",
         "src/tracking/event-log-creators.ts",
         "src/tracking/utm.ts",
         "src/types/core-js/configurator.d.ts",

--- a/client/shared/src/theme-types.ts
+++ b/client/shared/src/theme-types.ts
@@ -1,0 +1,22 @@
+// These enums are defined in a separate file to avoid pulling in unnecessary dependencies
+// into the SvelteKit app.
+
+/**
+ * Enum with possible users theme settings, it might be dark or light
+ * or user can pick system and in this case we fall back on system preference
+ * with match media
+ */
+export enum ThemeSetting {
+    Light = 'light',
+    Dark = 'dark',
+    System = 'system',
+}
+
+/**
+ * List of possibles theme values, there is only two themes at the moment,
+ * but in the future it could be more than just two
+ */
+export enum Theme {
+    Light = 'light',
+    Dark = 'dark',
+}

--- a/client/shared/src/theme.ts
+++ b/client/shared/src/theme.ts
@@ -1,26 +1,9 @@
 import { createContext, useCallback, useContext, useSyncExternalStore } from 'react'
 
 import { useTemporarySetting } from './settings/temporary'
+import { Theme, ThemeSetting } from './theme-types'
 
-/**
- * Enum with possible users theme settings, it might be dark or light
- * or user can pick system and in this case we fall back on system preference
- * with match media
- */
-export enum ThemeSetting {
-    Light = 'light',
-    Dark = 'dark',
-    System = 'system',
-}
-
-/**
- * List of possibles theme values, there is only two themes at the moment,
- * but in the future it could be more than just two
- */
-export enum Theme {
-    Light = 'light',
-    Dark = 'dark',
-}
+export { Theme, ThemeSetting }
 
 interface ThemeContextData {
     themeSetting: ThemeSetting | null
@@ -121,7 +104,7 @@ function useUserThemeSetting(): [ThemeSetting, (setting: ThemeSetting) => void] 
 
 function readStoredThemePreference(value?: string): ThemeSetting {
     // Handle both old and new preference values
-    switch (value) {
+    switch (value?.toLowerCase()) {
         case 'true':
         case 'light': {
             return ThemeSetting.Light

--- a/client/web-sveltekit/src/lib/shared.ts
+++ b/client/web-sveltekit/src/lib/shared.ts
@@ -75,6 +75,7 @@ export { createCodeIntelAPI, type CodeIntelAPI } from '@sourcegraph/shared/src/c
 export { getModeFromPath } from '@sourcegraph/shared/src/languages'
 export type { ActionItemAction } from '@sourcegraph/shared/src/actions/ActionItem'
 export { repositoryInsertText } from '@sourcegraph/shared/src/search/query/completion-utils'
+export { ThemeSetting, Theme } from '@sourcegraph/shared/src/theme-types'
 
 // Copies of non-reusable code
 

--- a/client/web-sveltekit/src/lib/stores.ts
+++ b/client/web-sveltekit/src/lib/stores.ts
@@ -5,7 +5,7 @@ import type { Settings, TemporarySettingsStorage } from '$lib/shared'
 
 import type { AuthenticatedUser, FeatureFlag } from '../routes/layout.gql'
 
-export { theme, isLightTheme } from './theme'
+export { themeSetting, theme, isLightTheme } from './theme'
 
 // Only exported to be used for mocking tests
 // TODO (fkling): Find a better way to initialize mocked contexts and stores

--- a/client/web-sveltekit/src/routes/UserMenu.svelte
+++ b/client/web-sveltekit/src/routes/UserMenu.svelte
@@ -2,12 +2,11 @@
     import Icon from '$lib/Icon.svelte'
     import Avatar from '$lib/Avatar.svelte'
     import type { UserMenu_User } from './UserMenu.gql'
-    import { Theme } from '$lib/theme'
+    import { ThemeSetting, themeSetting } from '$lib/theme'
     import { DropdownMenu, MenuLink, MenuRadioGroup, MenuSeparator, Submenu } from '$lib/wildcard'
     import { getButtonClassName } from '$lib/wildcard/Button'
     import { mdiChevronDown, mdiChevronUp, mdiOpenInNew } from '@mdi/js'
     import { writable } from 'svelte/store'
-    import { theme } from '$lib/stores'
 
     const MAX_VISIBLE_ORGS = 5
 
@@ -34,7 +33,7 @@
     <MenuSeparator />
     <Submenu>
         <svelte:fragment slot="trigger">Theme</svelte:fragment>
-        <MenuRadioGroup values={[Theme.Light, Theme.Dark, Theme.System]} value={theme} />
+        <MenuRadioGroup values={[ThemeSetting.Light, ThemeSetting.Dark, ThemeSetting.System]} value={themeSetting} />
     </Submenu>
     {#if organizations.length > 0}
         <MenuSeparator />


### PR DESCRIPTION
PR #61322 didn't quite work. The Svelte app was setting the capitalized theme name, but the React app expected a lower case name. Setting the theme in React would properly work in Svelte but not vice versa.

This commit makes two changes:

- The shares the Theme and ThemeSettings constants between Svelte and React so that we ensure using the same values.
- It updates the React version to normalize the theme settings value received from the server.



## Test plan

Set the theme in the Svelte app and verified in the dev tools that the lowercase theme name was sent.
