### PR TITLE
svelte: Update sg start enterprise-sveltekit command set

### DIFF
--- a/client/web/dev/esbuild/server.ts
+++ b/client/web/dev/esbuild/server.ts
@@ -37,6 +37,22 @@ export const esbuildDevelopmentServer = async (
     // Start a proxy at :3080. Asset requests (underneath /.assets/) go to esbuild; all other
     // requests go to the upstream.
     const proxyApp = express()
+
+    if (process.env.SVELTEKIT) {
+        // Proxy requests for SvelteKit's assets to the server, not the esbuild server.
+        proxyApp.use(
+            `${assetPathPrefix}/_sk`,
+            createProxyMiddleware({
+                target: {
+                    protocol: 'http:',
+                    host: DEV_SERVER_PROXY_TARGET_ADDR.host,
+                    port: DEV_SERVER_PROXY_TARGET_ADDR.port,
+                },
+                logLevel: 'error',
+            })
+        )
+    }
+
     proxyApp.use(
         assetPathPrefix,
         createProxyMiddleware({

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -417,6 +417,12 @@ commands:
       # Needed so that node can ping the caddy server
       NODE_TLS_REJECT_UNAUTHORIZED: 0
 
+  web-sveltekit:
+    description: Enterprise version of the web sveltekit app
+    cmd: pnpm --filter @sourcegraph/web-sveltekit dev:enterprise
+    install: |
+      pnpm install
+
   web-standalone-http:
     description: Standalone web frontend (dev) with API proxy to a configurable URL
     cmd: pnpm --filter @sourcegraph/web serve:dev --color
@@ -1793,6 +1799,28 @@ commandsets:
 
   enterprise-sveltekit:
     <<: *enterprise_set
+    # Keep in sync with &enterprise_set.commands
+    commands:
+      - frontend
+      - worker
+      - repo-updater
+      - web
+      - web-sveltekit
+      - gitserver-0
+      - gitserver-1
+      - searcher
+      - caddy
+      - symbols
+      # TODO https://github.com/sourcegraph/devx-support/issues/537
+      # - docsite
+      - syntax-highlighter
+      - zoekt-index-0
+      - zoekt-index-1
+      - zoekt-web-0
+      - zoekt-web-1
+      - blobstore
+      - embeddings
+      - telemetry-gateway
     env:
       SVELTEKIT: true
 


### PR DESCRIPTION
This commit updates the enterprise-sveltekit command set to work with the current esbuild setup. It adds a new command to start the vite build process. The build process is quite slow so this is not a good way to develop the SvelteKit application but it's as close to the real setup as possible.



## Test plan

```
sg start enterprise-sveltekit
```
