### PR TITLE
k8s/resource: Add pkg for creating k8s pod resources

### DIFF
--- a/internal/k8s/resource/pod/BUILD.bazel
+++ b/internal/k8s/resource/pod/BUILD.bazel
@@ -1,0 +1,33 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("//dev:go_defs.bzl", "go_test")
+
+go_library(
+    name = "pod",
+    srcs = ["pod.go"],
+    importpath = "github.com/sourcegraph/sourcegraph/internal/k8s/resource/pod",
+    visibility = ["//:__subpackages__"],
+    deps = [
+        "//internal/maps",
+        "//lib/pointers",
+        "@io_k8s_api//core/v1:core",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:meta",
+    ],
+)
+
+go_test(
+    name = "pod_test",
+    srcs = [
+        "example_test.go",
+        "pod_test.go",
+    ],
+    embed = [":pod"],
+    deps = [
+        "//internal/k8s/resource/container",
+        "//lib/pointers",
+        "@com_github_google_go_cmp//cmp",
+        "@io_k8s_api//core/v1:core",
+        "@io_k8s_apimachinery//pkg/api/resource",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:meta",
+        "@io_k8s_sigs_yaml//:yaml",
+    ],
+)

--- a/internal/k8s/resource/pod/example_test.go
+++ b/internal/k8s/resource/pod/example_test.go
@@ -1,0 +1,40 @@
+package pod
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"sigs.k8s.io/yaml"
+)
+
+func ExamplePodTemplate() {
+	pt, _ := NewPodTemplate("test", "sourcegraph")
+
+	jpt, _ := json.Marshal(pt)
+	fmt.Println(string(jpt))
+
+	ypt, _ := yaml.Marshal(pt)
+	fmt.Println(string(ypt))
+
+	// Output:
+	// {"metadata":{"creationTimestamp":null},"template":{"metadata":{"name":"test","namespace":"sourcegraph","creationTimestamp":null,"labels":{"app":"test","deploy":"sourcegraph"},"annotations":{"kubectl.kubernetes.io/default-container":"test"}},"spec":{"containers":null,"securityContext":{"runAsUser":100,"runAsGroup":101,"fsGroup":101,"fsGroupChangePolicy":"OnRootMismatch"}}}}
+	// metadata:
+	//   creationTimestamp: null
+	// template:
+	//   metadata:
+	//     annotations:
+	//       kubectl.kubernetes.io/default-container: test
+	//     creationTimestamp: null
+	//     labels:
+	//       app: test
+	//       deploy: sourcegraph
+	//     name: test
+	//     namespace: sourcegraph
+	//   spec:
+	//     containers: null
+	//     securityContext:
+	//       fsGroup: 101
+	//       fsGroupChangePolicy: OnRootMismatch
+	//       runAsGroup: 101
+	//       runAsUser: 100
+}

--- a/internal/k8s/resource/pod/pod.go
+++ b/internal/k8s/resource/pod/pod.go
@@ -1,0 +1,174 @@
+package pod
+
+import (
+	"sort"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/sourcegraph/sourcegraph/internal/maps"
+	"github.com/sourcegraph/sourcegraph/lib/pointers"
+)
+
+// NewPodTemplate creates a new k8s PodTemplate with default values.
+//
+// Default values include:
+//
+//   - Default container annotations
+//   - Default Sourcegraph `app` and `deploy` labels
+//   - SecurityContext with defaults.
+//
+// Additional options can be passed to modify the default values.
+func NewPodTemplate(name, namespace string, options ...Option) (corev1.PodTemplate, error) {
+	podTemplate := corev1.PodTemplate{
+		Template: corev1.PodTemplateSpec{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+				Annotations: map[string]string{
+					"kubectl.kubernetes.io/default-container": name,
+				},
+				Labels: map[string]string{
+					"app":    name,
+					"deploy": "sourcegraph",
+				},
+			},
+			Spec: corev1.PodSpec{
+				SecurityContext: &corev1.PodSecurityContext{
+					RunAsUser:           pointers.Ptr[int64](100),
+					RunAsGroup:          pointers.Ptr[int64](101),
+					FSGroup:             pointers.Ptr[int64](101),
+					FSGroupChangePolicy: pointers.Ptr(corev1.FSGroupChangeOnRootMismatch),
+				},
+			},
+		},
+	}
+
+	// apply any given options
+	for _, opt := range options {
+		err := opt(&podTemplate)
+		if err != nil {
+			return corev1.PodTemplate{}, err
+		}
+	}
+
+	return podTemplate, nil
+}
+
+// Option sets an option for a PodTemplate.
+type Option func(podTemplate *corev1.PodTemplate) error
+
+// WithLabels sets PodTemplate labels without overriding existing labels.
+func WithLabels(labels map[string]string) Option {
+	return func(podTemplate *corev1.PodTemplate) error {
+		podTemplate.Template.Labels = maps.MergePreservingExistingKeys(podTemplate.Template.Labels, labels)
+		return nil
+	}
+}
+
+// WithAnnotations sets PodTemplate annotations without overriding existing annotations.
+func WithAnnotations(annotations map[string]string) Option {
+	return func(podTemplate *corev1.PodTemplate) error {
+		podTemplate.Template.Annotations = maps.MergePreservingExistingKeys(podTemplate.Template.Annotations, annotations)
+		return nil
+	}
+}
+
+// WithAffinity sets a default affinity on the PodTemplate.
+func WithAffinity(affinity corev1.Affinity) Option {
+	return func(podTemplate *corev1.PodTemplate) error {
+		podTemplate.Template.Spec.Affinity = &affinity
+		return nil
+	}
+}
+
+// WithVolumes appends the given volumes to the PodSpec without overriding existing volumes.
+func WithVolumes(volumes []corev1.Volume) Option {
+	return func(podTemplate *corev1.PodTemplate) error {
+		for _, v := range volumes {
+			if !volumeExists(v.Name, podTemplate) {
+				podTemplate.Template.Spec.Volumes = append(podTemplate.Template.Spec.Volumes, v)
+			}
+		}
+
+		sort.SliceStable(podTemplate.Template.Spec.Volumes, func(i, j int) bool {
+			return podTemplate.Template.Spec.Volumes[i].Name < podTemplate.Template.Spec.Volumes[j].Name
+		})
+		return nil
+	}
+}
+
+func volumeExists(name string, podTemplate *corev1.PodTemplate) bool {
+	for _, v := range podTemplate.Template.Spec.Volumes {
+		if v.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+// WithTerminationGracePeriod sets the given termination grace period.
+func WithTerminationGracePeriod(period int64) Option {
+	return func(podTemplate *corev1.PodTemplate) error {
+		podTemplate.Template.Spec.TerminationGracePeriodSeconds = &period
+		return nil
+	}
+}
+
+// WithInitContainers appends the given InitContainers to the Pod without overriding existing containers.
+func WithInitContainers(initContainers ...corev1.Container) Option {
+	return func(podTemplate *corev1.PodTemplate) error {
+		for _, c := range initContainers {
+			if !initContainerExists(c.Name, podTemplate) {
+				podTemplate.Template.Spec.InitContainers = append(podTemplate.Template.Spec.InitContainers, c)
+			}
+		}
+		return nil
+	}
+}
+
+func initContainerExists(name string, podTemplate *corev1.PodTemplate) bool {
+	for _, c := range podTemplate.Template.Spec.InitContainers {
+		if c.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+// WithContainers appends the given containers to the Pod without overriding existing containers.
+func WithContainers(containers ...corev1.Container) Option {
+	return func(podTemplate *corev1.PodTemplate) error {
+		for _, c := range containers {
+			if !containerExists(c.Name, podTemplate) {
+				podTemplate.Template.Spec.Containers = append(podTemplate.Template.Spec.Containers, c)
+			}
+		}
+		return nil
+	}
+}
+
+func containerExists(name string, podTemplate *corev1.PodTemplate) bool {
+	for _, c := range podTemplate.Template.Spec.Containers {
+		if c.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+// WithServiceAccount sets the given Service Account on the pod.
+func WithServiceAccount(serviceAccount string) Option {
+	return func(podTemplate *corev1.PodTemplate) error {
+		podTemplate.Template.Spec.ServiceAccountName = serviceAccount
+		return nil
+	}
+}
+
+// WithSecurityContext sets the given Pod Security Context on the pod.
+func WithSecurityContext(securityContext corev1.PodSecurityContext) Option {
+	return func(podTemplate *corev1.PodTemplate) error {
+		podTemplate.Template.Spec.SecurityContext = &securityContext
+		return nil
+	}
+}

--- a/internal/k8s/resource/pod/pod_test.go
+++ b/internal/k8s/resource/pod/pod_test.go
@@ -1,0 +1,486 @@
+package pod
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/sourcegraph/sourcegraph/internal/k8s/resource/container"
+	"github.com/sourcegraph/sourcegraph/lib/pointers"
+)
+
+func TestNewPodTemplate(t *testing.T) {
+	t.Parallel()
+
+	type args struct {
+		name      string
+		namespace string
+		options   []Option
+	}
+
+	tests := []struct {
+		name    string
+		args    args
+		want    corev1.PodTemplate
+		wantErr bool
+	}{
+		{
+			name: "default container",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+			},
+			want: corev1.PodTemplate{
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "foo",
+						Namespace: "sourcegraph",
+						Annotations: map[string]string{
+							"kubectl.kubernetes.io/default-container": "foo",
+						},
+						Labels: map[string]string{
+							"app":    "foo",
+							"deploy": "sourcegraph",
+						},
+					},
+					Spec: corev1.PodSpec{
+						SecurityContext: &corev1.PodSecurityContext{
+							RunAsUser:           pointers.Ptr[int64](100),
+							RunAsGroup:          pointers.Ptr[int64](101),
+							FSGroup:             pointers.Ptr[int64](101),
+							FSGroupChangePolicy: pointers.Ptr(corev1.FSGroupChangeOnRootMismatch),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "with labels",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithLabels(map[string]string{
+						"app":         "bar",
+						"environment": "prod",
+					}),
+				},
+			},
+			want: corev1.PodTemplate{
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "foo",
+						Namespace: "sourcegraph",
+						Annotations: map[string]string{
+							"kubectl.kubernetes.io/default-container": "foo",
+						},
+						Labels: map[string]string{
+							"app":         "foo",
+							"deploy":      "sourcegraph",
+							"environment": "prod",
+						},
+					},
+					Spec: corev1.PodSpec{
+						SecurityContext: &corev1.PodSecurityContext{
+							RunAsUser:           pointers.Ptr[int64](100),
+							RunAsGroup:          pointers.Ptr[int64](101),
+							FSGroup:             pointers.Ptr[int64](101),
+							FSGroupChangePolicy: pointers.Ptr(corev1.FSGroupChangeOnRootMismatch),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "with annotations",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithAnnotations(map[string]string{
+						"kubectl.kubernetes.io/default-container": "bar",
+						"environment": "prod",
+					}),
+				},
+			},
+			want: corev1.PodTemplate{
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "foo",
+						Namespace: "sourcegraph",
+						Annotations: map[string]string{
+							"kubectl.kubernetes.io/default-container": "foo",
+							"environment": "prod",
+						},
+						Labels: map[string]string{
+							"app":    "foo",
+							"deploy": "sourcegraph",
+						},
+					},
+					Spec: corev1.PodSpec{
+						SecurityContext: &corev1.PodSecurityContext{
+							RunAsUser:           pointers.Ptr[int64](100),
+							RunAsGroup:          pointers.Ptr[int64](101),
+							FSGroup:             pointers.Ptr[int64](101),
+							FSGroupChangePolicy: pointers.Ptr(corev1.FSGroupChangeOnRootMismatch),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "with affinity",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithAffinity(corev1.Affinity{
+						NodeAffinity: &corev1.NodeAffinity{
+							RequiredDuringSchedulingIgnoredDuringExecution:  nil,
+							PreferredDuringSchedulingIgnoredDuringExecution: nil,
+						},
+						PodAffinity:     nil,
+						PodAntiAffinity: nil,
+					}),
+				},
+			},
+			want: corev1.PodTemplate{
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "foo",
+						Namespace: "sourcegraph",
+						Annotations: map[string]string{
+							"kubectl.kubernetes.io/default-container": "foo",
+						},
+						Labels: map[string]string{
+							"app":    "foo",
+							"deploy": "sourcegraph",
+						},
+					},
+					Spec: corev1.PodSpec{
+						SecurityContext: &corev1.PodSecurityContext{
+							RunAsUser:           pointers.Ptr[int64](100),
+							RunAsGroup:          pointers.Ptr[int64](101),
+							FSGroup:             pointers.Ptr[int64](101),
+							FSGroupChangePolicy: pointers.Ptr(corev1.FSGroupChangeOnRootMismatch),
+						},
+						Affinity: &corev1.Affinity{
+							NodeAffinity: &corev1.NodeAffinity{
+								RequiredDuringSchedulingIgnoredDuringExecution:  nil,
+								PreferredDuringSchedulingIgnoredDuringExecution: nil,
+							},
+							PodAffinity:     nil,
+							PodAntiAffinity: nil,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "with volumes",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithVolumes([]corev1.Volume{
+						{
+							Name: "stuff",
+						},
+						{
+							Name: "data",
+						},
+					}),
+				},
+			},
+			want: corev1.PodTemplate{
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "foo",
+						Namespace: "sourcegraph",
+						Annotations: map[string]string{
+							"kubectl.kubernetes.io/default-container": "foo",
+						},
+						Labels: map[string]string{
+							"app":    "foo",
+							"deploy": "sourcegraph",
+						},
+					},
+					Spec: corev1.PodSpec{
+						SecurityContext: &corev1.PodSecurityContext{
+							RunAsUser:           pointers.Ptr[int64](100),
+							RunAsGroup:          pointers.Ptr[int64](101),
+							FSGroup:             pointers.Ptr[int64](101),
+							FSGroupChangePolicy: pointers.Ptr(corev1.FSGroupChangeOnRootMismatch),
+						},
+						Volumes: []corev1.Volume{
+							{
+								Name: "data",
+							},
+							{
+								Name: "stuff",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "with termination grace period",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithTerminationGracePeriod(int64(10)),
+				},
+			},
+			want: corev1.PodTemplate{
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "foo",
+						Namespace: "sourcegraph",
+						Annotations: map[string]string{
+							"kubectl.kubernetes.io/default-container": "foo",
+						},
+						Labels: map[string]string{
+							"app":    "foo",
+							"deploy": "sourcegraph",
+						},
+					},
+					Spec: corev1.PodSpec{
+						SecurityContext: &corev1.PodSecurityContext{
+							RunAsUser:           pointers.Ptr[int64](100),
+							RunAsGroup:          pointers.Ptr[int64](101),
+							FSGroup:             pointers.Ptr[int64](101),
+							FSGroupChangePolicy: pointers.Ptr(corev1.FSGroupChangeOnRootMismatch),
+						},
+						TerminationGracePeriodSeconds: pointers.Ptr[int64](10),
+					},
+				},
+			},
+		},
+		{
+			name: "with init containers",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithInitContainers(func() corev1.Container {
+						c, _ := container.NewContainer("foo")
+						return c
+					}()),
+				},
+			},
+			want: corev1.PodTemplate{
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "foo",
+						Namespace: "sourcegraph",
+						Annotations: map[string]string{
+							"kubectl.kubernetes.io/default-container": "foo",
+						},
+						Labels: map[string]string{
+							"app":    "foo",
+							"deploy": "sourcegraph",
+						},
+					},
+					Spec: corev1.PodSpec{
+						SecurityContext: &corev1.PodSecurityContext{
+							RunAsUser:           pointers.Ptr[int64](100),
+							RunAsGroup:          pointers.Ptr[int64](101),
+							FSGroup:             pointers.Ptr[int64](101),
+							FSGroupChangePolicy: pointers.Ptr(corev1.FSGroupChangeOnRootMismatch),
+						},
+						InitContainers: []corev1.Container{
+							{
+								Name:                     "foo",
+								ImagePullPolicy:          corev1.PullIfNotPresent,
+								TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
+								Resources: corev1.ResourceRequirements{
+									Limits: corev1.ResourceList{
+										corev1.ResourceCPU:    resource.MustParse("1"),
+										corev1.ResourceMemory: resource.MustParse("500Mi"),
+									},
+									Requests: corev1.ResourceList{
+										corev1.ResourceCPU:    resource.MustParse("500m"),
+										corev1.ResourceMemory: resource.MustParse("100Mi"),
+									},
+								},
+								SecurityContext: &corev1.SecurityContext{
+									RunAsUser:                pointers.Ptr[int64](100),
+									RunAsGroup:               pointers.Ptr[int64](101),
+									AllowPrivilegeEscalation: pointers.Ptr(false),
+									ReadOnlyRootFilesystem:   pointers.Ptr(true),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "with containers",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithContainers(func() corev1.Container {
+						c, _ := container.NewContainer("foo")
+						return c
+					}()),
+				},
+			},
+			want: corev1.PodTemplate{
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "foo",
+						Namespace: "sourcegraph",
+						Annotations: map[string]string{
+							"kubectl.kubernetes.io/default-container": "foo",
+						},
+						Labels: map[string]string{
+							"app":    "foo",
+							"deploy": "sourcegraph",
+						},
+					},
+					Spec: corev1.PodSpec{
+						SecurityContext: &corev1.PodSecurityContext{
+							RunAsUser:           pointers.Ptr[int64](100),
+							RunAsGroup:          pointers.Ptr[int64](101),
+							FSGroup:             pointers.Ptr[int64](101),
+							FSGroupChangePolicy: pointers.Ptr(corev1.FSGroupChangeOnRootMismatch),
+						},
+						Containers: []corev1.Container{
+							{
+								Name:                     "foo",
+								ImagePullPolicy:          corev1.PullIfNotPresent,
+								TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
+								Resources: corev1.ResourceRequirements{
+									Limits: corev1.ResourceList{
+										corev1.ResourceCPU:    resource.MustParse("1"),
+										corev1.ResourceMemory: resource.MustParse("500Mi"),
+									},
+									Requests: corev1.ResourceList{
+										corev1.ResourceCPU:    resource.MustParse("500m"),
+										corev1.ResourceMemory: resource.MustParse("100Mi"),
+									},
+								},
+								SecurityContext: &corev1.SecurityContext{
+									RunAsUser:                pointers.Ptr[int64](100),
+									RunAsGroup:               pointers.Ptr[int64](101),
+									AllowPrivilegeEscalation: pointers.Ptr(false),
+									ReadOnlyRootFilesystem:   pointers.Ptr(true),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "with service account",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithServiceAccount("foobar"),
+				},
+			},
+			want: corev1.PodTemplate{
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "foo",
+						Namespace: "sourcegraph",
+						Annotations: map[string]string{
+							"kubectl.kubernetes.io/default-container": "foo",
+						},
+						Labels: map[string]string{
+							"app":    "foo",
+							"deploy": "sourcegraph",
+						},
+					},
+					Spec: corev1.PodSpec{
+						SecurityContext: &corev1.PodSecurityContext{
+							RunAsUser:           pointers.Ptr[int64](100),
+							RunAsGroup:          pointers.Ptr[int64](101),
+							FSGroup:             pointers.Ptr[int64](101),
+							FSGroupChangePolicy: pointers.Ptr(corev1.FSGroupChangeOnRootMismatch),
+						},
+						ServiceAccountName: "foobar",
+					},
+				},
+			},
+		},
+		{
+			name: "with security context",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithSecurityContext(corev1.PodSecurityContext{
+						RunAsUser:           pointers.Ptr[int64](999),
+						RunAsGroup:          pointers.Ptr[int64](101),
+						FSGroup:             pointers.Ptr[int64](101),
+						FSGroupChangePolicy: pointers.Ptr(corev1.FSGroupChangeAlways),
+					}),
+				},
+			},
+			want: corev1.PodTemplate{
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "foo",
+						Namespace: "sourcegraph",
+						Annotations: map[string]string{
+							"kubectl.kubernetes.io/default-container": "foo",
+						},
+						Labels: map[string]string{
+							"app":    "foo",
+							"deploy": "sourcegraph",
+						},
+					},
+					Spec: corev1.PodSpec{
+						SecurityContext: &corev1.PodSecurityContext{
+							RunAsUser:           pointers.Ptr[int64](999),
+							RunAsGroup:          pointers.Ptr[int64](101),
+							FSGroup:             pointers.Ptr[int64](101),
+							FSGroupChangePolicy: pointers.Ptr(corev1.FSGroupChangeAlways),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "with error",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					func(podTemplate *corev1.PodTemplate) error {
+						return errors.New("test error")
+					},
+				},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := NewPodTemplate(tt.args.name, tt.args.namespace, tt.args.options...)
+			if err != nil && tt.wantErr == false {
+				t.Errorf("NewContainer() error: %v", err)
+			}
+			if err != nil && tt.wantErr == true {
+				return
+			}
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("NewContainer() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/internal/maps/BUILD.bazel
+++ b/internal/maps/BUILD.bazel
@@ -1,0 +1,19 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("//dev:go_defs.bzl", "go_test")
+
+go_library(
+    name = "maps",
+    srcs = ["maps.go"],
+    importpath = "github.com/sourcegraph/sourcegraph/internal/maps",
+    visibility = ["//:__subpackages__"],
+)
+
+go_test(
+    name = "maps_test",
+    srcs = [
+        "example_test.go",
+        "maps_test.go",
+    ],
+    embed = [":maps"],
+    deps = ["@com_github_google_go_cmp//cmp"],
+)

--- a/internal/maps/example_test.go
+++ b/internal/maps/example_test.go
@@ -1,0 +1,19 @@
+package maps
+
+import "fmt"
+
+func ExampleMerge() {
+	m := Merge(map[string]int{"a": 1, "b": 2}, map[string]int{"b": 3, "c": 4})
+	fmt.Printf("%#v\n", m)
+
+	// Output:
+	// map[string]int{"a":1, "b":3, "c":4}
+}
+
+func ExampleMergePreservingExistingKeys() {
+	m := MergePreservingExistingKeys(map[string]int{"a": 1, "b": 2}, map[string]int{"b": 3, "c": 4})
+	fmt.Printf("%#v\n", m)
+
+	// Output:
+	// map[string]int{"a":1, "b":2, "c":4}
+}

--- a/internal/maps/maps.go
+++ b/internal/maps/maps.go
@@ -1,0 +1,36 @@
+package maps
+
+// Merge merges the source map into the destination map, overwriting existing values if necessary.
+func Merge[K comparable, V any](dest, src map[K]V) map[K]V {
+	if dest == nil {
+		if src == nil {
+			return make(map[K]V)
+		}
+		dest = make(map[K]V, len(src))
+	}
+
+	for k, v := range src {
+		dest[k] = v
+	}
+
+	return dest
+}
+
+// MergePreservingExistingKeys merges the source map into the destination map,
+// without overwriting any existing keys in the destination.
+func MergePreservingExistingKeys[K comparable, V any](dest, src map[K]V) map[K]V {
+	if dest == nil {
+		if src == nil {
+			return make(map[K]V)
+		}
+		dest = make(map[K]V, len(src))
+	}
+
+	for k, v := range src {
+		if _, exists := dest[k]; !exists {
+			dest[k] = v
+		}
+	}
+
+	return dest
+}

--- a/internal/maps/maps_test.go
+++ b/internal/maps/maps_test.go
@@ -1,0 +1,174 @@
+package maps
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+type testCase[K comparable, V any] struct {
+	name string
+	src  map[K]V
+	dest map[K]V
+	want map[K]V
+}
+
+func runMergeTest[K comparable, V any](t *testing.T, tt testCase[K, V]) {
+	t.Helper()
+
+	t.Run(tt.name, func(t *testing.T) {
+		t.Parallel()
+		got := Merge(tt.dest, tt.src)
+		if diff := cmp.Diff(tt.want, got); diff != "" {
+			t.Errorf("Merge() mismatch (-want +got):\n%s", diff)
+		}
+	})
+}
+
+func TestMerge(t *testing.T) {
+	t.Parallel()
+
+	strIntTests := []testCase[string, int]{
+		{
+			name: "merge with overlapping keys",
+			dest: map[string]int{"a": 1, "b": 2},
+			src:  map[string]int{"b": 3, "c": 4},
+			want: map[string]int{"a": 1, "b": 3, "c": 4},
+		},
+		{
+			name: "src is nil",
+			dest: map[string]int{"a": 1},
+			src:  nil,
+			want: map[string]int{"a": 1},
+		},
+		{
+			name: "dest is nil",
+			dest: nil,
+			src:  map[string]int{"a": 1},
+			want: map[string]int{"a": 1},
+		},
+		{
+			name: "both are nil",
+			dest: nil,
+			src:  nil,
+			want: map[string]int{},
+		},
+	}
+
+	strStrTests := []testCase[string, string]{
+		{
+			name: "merge with overlapping keys",
+			dest: map[string]string{"a": "1", "b": "2"},
+			src:  map[string]string{"b": "3", "c": "4"},
+			want: map[string]string{"a": "1", "b": "3", "c": "4"},
+		},
+		{
+			name: "rc is nil",
+			dest: map[string]string{"a": "1"},
+			src:  nil,
+			want: map[string]string{"a": "1"},
+		},
+		{
+			name: "dest is nil",
+			dest: nil,
+			src:  map[string]string{"a": "1"},
+			want: map[string]string{"a": "1"},
+		},
+		{
+			name: "both are nil",
+			dest: nil,
+			src:  nil,
+			want: map[string]string{},
+		},
+	}
+
+	for _, tt := range strIntTests {
+		tt := tt
+		runMergeTest(t, tt)
+	}
+
+	for _, tt := range strStrTests {
+		tt := tt
+		runMergeTest(t, tt)
+	}
+}
+
+func runMergePreservingExistingKeysTest[K comparable, V any](t *testing.T, tt testCase[K, V]) {
+	t.Helper()
+
+	t.Run(tt.name, func(t *testing.T) {
+		t.Parallel()
+		got := MergePreservingExistingKeys(tt.dest, tt.src)
+		if diff := cmp.Diff(tt.want, got); diff != "" {
+			t.Errorf("MergePreservingExistingKeys() mismatch (-want +got):\n%s", diff)
+		}
+	})
+}
+
+func TestMergePreservingExistingKeys(t *testing.T) {
+	t.Parallel()
+
+	strIntTests := []testCase[string, int]{
+		{
+			name: "merge with overlapping keys",
+			dest: map[string]int{"a": 1, "b": 2},
+			src:  map[string]int{"b": 3, "c": 4},
+			want: map[string]int{"a": 1, "b": 2, "c": 4},
+		},
+		{
+			name: "src is nil",
+			dest: map[string]int{"a": 1},
+			src:  nil,
+			want: map[string]int{"a": 1},
+		},
+		{
+			name: "dest is nil",
+			dest: nil,
+			src:  map[string]int{"a": 1},
+			want: map[string]int{"a": 1},
+		},
+		{
+			name: "both are nil",
+			dest: nil,
+			src:  nil,
+			want: map[string]int{},
+		},
+	}
+
+	strStrTests := []testCase[string, string]{
+		{
+			name: "merge with overlapping keys",
+			dest: map[string]string{"a": "1", "b": "2"},
+			src:  map[string]string{"b": "3", "c": "4"},
+			want: map[string]string{"a": "1", "b": "2", "c": "4"},
+		},
+		{
+			name: "src is nil",
+			dest: map[string]string{"a": "1"},
+			src:  nil,
+			want: map[string]string{"a": "1"},
+		},
+		{
+			name: "dest is nil",
+			dest: nil,
+			src:  map[string]string{"a": "1"},
+			want: map[string]string{"a": "1"},
+		},
+		{
+			name: "both are nil",
+			dest: nil,
+			src:  nil,
+			want: map[string]string{},
+		},
+	}
+
+	for _, tt := range strIntTests {
+		tt := tt
+		runMergePreservingExistingKeysTest(t, tt)
+	}
+
+	for _, tt := range strStrTests {
+		tt := tt
+		runMergePreservingExistingKeysTest(t, tt)
+	}
+}


### PR DESCRIPTION
- Add the `pod` pkg that creates k8s pod resources with patterns and defaults common to Sourcegraph. 
- Add `maps` pkg with some helper functions to help manage merging maps inside of k8s resources.

## Test plan

Full unit test coverage as well as testable examples.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
