### PR TITLE
svelte: Remove transitive dependency on all of @sourcegraph/wildcard (via eventLogger)

### DIFF
--- a/client/web-sveltekit/src/lib/logger.ts
+++ b/client/web-sveltekit/src/lib/logger.ts
@@ -4,11 +4,9 @@
 import { onMount } from 'svelte'
 
 // Dev build breaks if this import is moved to `$lib/web` ¯\_(ツ)_/¯
-import { eventLogger, type EventLogger } from '@sourcegraph/web/src/tracking/eventLogger'
+import type { EventLogger } from '@sourcegraph/web/src/tracking/eventLogger'
 
 import { PUBLIC_ENABLE_EVENT_LOGGER } from '$env/static/public'
-
-export { eventLogger }
 
 /**
  * Can only be called during component initialization. It logs a view event when
@@ -17,7 +15,8 @@ export { eventLogger }
 export function logViewEvent(...args: Parameters<EventLogger['logViewEvent']>): void {
     if (PUBLIC_ENABLE_EVENT_LOGGER) {
         onMount(() => {
-            eventLogger.logViewEvent(...args)
+            // TODO: Implement event logging
+            console.log('logViewEvent', args)
         })
     }
 }


### PR DESCRIPTION
One reason why the development server is relatively slow is that we are pulling in a lot of (transitive) dependencies that are not used. Specifically the whole wildcard package is included.

I used [dependency-cruiser](https://github.com/sverweij/dependency-cruiser) to find out why all of wildcard is included and eventually discovered that it was because of importing `eventLogger`.

`eventLogger` imports `observerQuerySelector` from `dom.ts` which in turn imports `useObservable` from `@sourcegraph/wildcard`, which of course imports all of wildcard:

![wildcard-index-deps](https://github.com/sourcegraph/sourcegraph/assets/179026/af5a0532-6308-4175-a44d-8fbd2d4e6d77)


Since `eventLogger` is deprecated and we'll have to implement proper support for event logging anyway I've removed the dependency for now. This avoids pulling in all of wildcard and reduces the number of request made for the homepage by almost half:

Before: 
![2024-03-24_14-54](https://github.com/sourcegraph/sourcegraph/assets/179026/a54fcf33-7fed-4273-9902-a24ae79addaa)

After: 
![2024-03-24_15-00](https://github.com/sourcegraph/sourcegraph/assets/179026/62608084-4393-4326-831d-e650141f987b)

**Additional notes**

In future PR we could add dependency-cruiser to help us keep our dependencies "clean". E.g. it can help us detect transitive dependencies to React. We can then refactor our code so that non-React modules don't depend on React modules.

I don't see why `useObservable` is part of `client/wildcard`. Maybe it should be moved to `client/shared`.

## Test plan

`pnpm dev` and `pnpm build`