### PR TITLE
rfc-795: use docker hub for public releases

### DIFF
--- a/dev/ci/internal/ci/release_operations.go
+++ b/dev/ci/internal/ci/release_operations.go
@@ -20,7 +20,7 @@ func releasePromoteImages(c Config) operations.Operation {
 			bk.Agent("queue", AspectWorkflows.QueueDefault),
 			bk.Env("VERSION", c.Version),
 			bk.Env("INTERNAL_REGISTRY", images.SourcegraphInternalReleaseRegistry),
-			bk.Env("PUBLIC_REGISTRY", images.SourcegraphPublicReleaseRegistry),
+			bk.Env("PUBLIC_REGISTRY", images.SourcegraphDockerPublishRegistry),
 			bk.AnnotatedCmd(
 				fmt.Sprintf("./tools/release/promote_images.sh %s", image_args),
 				bk.AnnotatedCmdOpts{


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/61063

Should be merged after `sourcergaph/sourcegraph` has been clearred in https://github.com/sourcegraph/sourcegraph/issues/61062
## Test plan
CI
https://github.com/sourcegraph/sourcegraph/issues/61062