### PR TITLE
telemetry-gateway: fixup cancel cause recording

### DIFF
--- a/cmd/telemetry-gateway/internal/events/events.go
+++ b/cmd/telemetry-gateway/internal/events/events.go
@@ -162,11 +162,10 @@ func (p *Publisher) Publish(ctx context.Context, events []*telemetrygatewayv1.Ev
 			// ourselves, and attach attributes for ease of routing the pub/sub
 			// message.
 			if err := p.topic.PublishMessage(ctx, payload, extractPubSubAttributes(p.source, event)); err != nil {
-				// Try to record the cancel cause as the primary error in case
-				// one is recorded.
+				// Explicitly record the cancel cause if one is provided.
 				if cancelCause := context.Cause(ctx); cancelCause != nil {
-					return errors.Wrapf(cancelCause, "%s: interrupted event publish",
-						err.Error())
+					return errors.Wrapf(err, "interrupted event publish, cause: %s",
+						errors.Safe(cancelCause.Error()))
 				}
 				return errors.Wrap(err, "publishing event")
 			}


### PR DESCRIPTION
In https://sourcegraph.slack.com/archives/C06CCJR4K9R/p1711370770336949 the format string got redacted :)

## Test plan

n/a