### PR TITLE
k8s/resource: Add pkg for creating k8s service resources

### DIFF
--- a/internal/k8s/resource/service/BUILD.bazel
+++ b/internal/k8s/resource/service/BUILD.bazel
@@ -1,0 +1,30 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("//dev:go_defs.bzl", "go_test")
+
+go_library(
+    name = "service",
+    srcs = ["service.go"],
+    importpath = "github.com/sourcegraph/sourcegraph/internal/k8s/resource/service",
+    visibility = ["//:__subpackages__"],
+    deps = [
+        "//internal/maps",
+        "@io_k8s_api//core/v1:core",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:meta",
+    ],
+)
+
+go_test(
+    name = "service_test",
+    srcs = [
+        "example_test.go",
+        "service_test.go",
+    ],
+    embed = [":service"],
+    deps = [
+        "@com_github_google_go_cmp//cmp",
+        "@io_k8s_api//core/v1:core",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:meta",
+        "@io_k8s_apimachinery//pkg/util/intstr",
+        "@io_k8s_sigs_yaml//:yaml",
+    ],
+)

--- a/internal/k8s/resource/service/example_test.go
+++ b/internal/k8s/resource/service/example_test.go
@@ -1,0 +1,34 @@
+package service
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"sigs.k8s.io/yaml"
+)
+
+func ExampleService() {
+	s, _ := NewService("test", "sourcegraph")
+
+	js, _ := json.Marshal(s)
+	fmt.Println(string(js))
+
+	ys, _ := yaml.Marshal(s)
+	fmt.Println(string(ys))
+
+	// Output:
+	// {"metadata":{"name":"test","namespace":"sourcegraph","creationTimestamp":null,"labels":{"app":"test","deploy":"sourcegraph"}},"spec":{"selector":{"app":"test"},"type":"ClusterIP"},"status":{"loadBalancer":{}}}
+	// metadata:
+	//   creationTimestamp: null
+	//   labels:
+	//     app: test
+	//     deploy: sourcegraph
+	//   name: test
+	//   namespace: sourcegraph
+	// spec:
+	//   selector:
+	//     app: test
+	//   type: ClusterIP
+	// status:
+	//   loadBalancer: {}
+}

--- a/internal/k8s/resource/service/service.go
+++ b/internal/k8s/resource/service/service.go
@@ -1,0 +1,116 @@
+package service
+
+import (
+	"sort"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/sourcegraph/sourcegraph/internal/maps"
+)
+
+// NewService creates a new k8s Service with default values.
+//
+// Default values include:
+//   - Selector based on the provided service name.
+//   - Service type of Cluster IP.
+//
+// Additional options can be passed to modify the default values.
+func NewService(name, namespace string, options ...Option) (corev1.Service, error) {
+	service := corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				"app":    name,
+				"deploy": "sourcegraph",
+			},
+		},
+		Spec: corev1.ServiceSpec{
+			Selector: map[string]string{
+				"app": name,
+			},
+			Type: corev1.ServiceTypeClusterIP,
+		},
+	}
+
+	// apply any given options
+	for _, opt := range options {
+		err := opt(&service)
+		if err != nil {
+			return corev1.Service{}, err
+		}
+	}
+
+	return service, nil
+}
+
+// Option sets an option for a Service.
+type Option func(service *corev1.Service) error
+
+// WithLabels sets Service labels without overriding existing labels.
+func WithLabels(labels map[string]string) Option {
+	return func(service *corev1.Service) error {
+		service.Labels = maps.MergePreservingExistingKeys(service.Labels, labels)
+		return nil
+	}
+}
+
+// WithAnnotations sets Service annotations without overriding existing annotations.
+func WithAnnotations(annotations map[string]string) Option {
+	return func(service *corev1.Service) error {
+		service.Annotations = maps.MergePreservingExistingKeys(service.Annotations, annotations)
+		return nil
+	}
+}
+
+// WithPorts adds the provided ServicePorts to the Service if they do not already exist.
+// It also sorts the Ports by name for accurate comparison of resources.
+func WithPorts(ports ...corev1.ServicePort) Option {
+	return func(service *corev1.Service) error {
+		for _, p := range ports {
+			if !portExists(p.Name, service) {
+				service.Spec.Ports = append(service.Spec.Ports, p)
+			}
+		}
+
+		// sort ports by name
+		sort.SliceStable(service.Spec.Ports, func(i, j int) bool {
+			return service.Spec.Ports[i].Name < service.Spec.Ports[j].Name
+		})
+		return nil
+	}
+}
+
+func portExists(name string, service *corev1.Service) bool {
+	for _, p := range service.Spec.Ports {
+		if p.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+// WithSelector sets the given selector as the Selector on the Service.
+func WithSelector(selector map[string]string) Option {
+	return func(service *corev1.Service) error {
+		service.Spec.Selector = selector
+		return nil
+	}
+}
+
+// WithServiceType sets the given serviceType on the Service.
+func WithServiceType(serviceType corev1.ServiceType) Option {
+	return func(service *corev1.Service) error {
+		service.Spec.Type = serviceType
+		return nil
+	}
+}
+
+// WithClusterIP sets the Service cluster IP manually.
+func WithClusterIP(clusterIP string) Option {
+	return func(service *corev1.Service) error {
+		service.Spec.ClusterIP = clusterIP
+		return nil
+	}
+}

--- a/internal/k8s/resource/service/service_test.go
+++ b/internal/k8s/resource/service/service_test.go
@@ -1,0 +1,251 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+func TestNewService(t *testing.T) {
+	t.Parallel()
+
+	type args struct {
+		name      string
+		namespace string
+		options   []Option
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want corev1.Service
+	}{
+		{
+			name: "default service",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+			},
+			want: corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"app":    "foo",
+						"deploy": "sourcegraph",
+					},
+				},
+				Spec: corev1.ServiceSpec{
+					Selector: map[string]string{
+						"app": "foo",
+					},
+					Type: corev1.ServiceTypeClusterIP,
+				},
+			},
+		},
+		{
+			name: "with labels",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithLabels(map[string]string{
+						"app":         "bar",
+						"deploy":      "horsegraph",
+						"environment": "testing",
+					}),
+				},
+			},
+			want: corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"app":         "foo",
+						"deploy":      "sourcegraph",
+						"environment": "testing",
+					},
+				},
+				Spec: corev1.ServiceSpec{
+					Selector: map[string]string{
+						"app": "foo",
+					},
+					Type: corev1.ServiceTypeClusterIP,
+				},
+			},
+		},
+		{
+			name: "with annotations",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithAnnotations(map[string]string{
+						"foo":  "bar",
+						"type": "test",
+					}),
+				},
+			},
+			want: corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"app":    "foo",
+						"deploy": "sourcegraph",
+					},
+					Annotations: map[string]string{
+						"foo":  "bar",
+						"type": "test",
+					},
+				},
+				Spec: corev1.ServiceSpec{
+					Selector: map[string]string{
+						"app": "foo",
+					},
+					Type: corev1.ServiceTypeClusterIP,
+				},
+			},
+		},
+		{
+			name: "with ports",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithPorts([]corev1.ServicePort{
+						{
+							Name:     "http",
+							Protocol: "TCP",
+							Port:     8080,
+							TargetPort: intstr.IntOrString{
+								Type:   0,
+								IntVal: 8080,
+							},
+							NodePort: 8080,
+						},
+						{
+							Name:     "app",
+							Protocol: "TCP",
+							Port:     400,
+							TargetPort: intstr.IntOrString{
+								Type:   0,
+								IntVal: 400,
+							},
+							NodePort: 400,
+						},
+					}...),
+				},
+			},
+			want: corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"app":    "foo",
+						"deploy": "sourcegraph",
+					},
+				},
+				Spec: corev1.ServiceSpec{
+					Selector: map[string]string{
+						"app": "foo",
+					},
+					Type: corev1.ServiceTypeClusterIP,
+					Ports: []corev1.ServicePort{
+						{
+							Name:     "app",
+							Protocol: "TCP",
+							Port:     400,
+							TargetPort: intstr.IntOrString{
+								Type:   0,
+								IntVal: 400,
+							},
+							NodePort: 400,
+						},
+						{
+							Name:     "http",
+							Protocol: "TCP",
+							Port:     8080,
+							TargetPort: intstr.IntOrString{
+								Type:   0,
+								IntVal: 8080,
+							},
+							NodePort: 8080,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "with selector",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithSelector(map[string]string{
+						"app": "horsegraph",
+					}),
+				},
+			},
+			want: corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"app":    "foo",
+						"deploy": "sourcegraph",
+					},
+				},
+				Spec: corev1.ServiceSpec{
+					Selector: map[string]string{
+						"app": "horsegraph",
+					},
+					Type: corev1.ServiceTypeClusterIP,
+				},
+			},
+		},
+		{
+			name: "with service type",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithServiceType(corev1.ServiceTypeLoadBalancer),
+				},
+			},
+			want: corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"app":    "foo",
+						"deploy": "sourcegraph",
+					},
+				},
+				Spec: corev1.ServiceSpec{
+					Selector: map[string]string{
+						"app": "foo",
+					},
+					Type: corev1.ServiceTypeLoadBalancer,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := NewService(tt.args.name, tt.args.namespace, tt.args.options...)
+			if err != nil {
+				t.Errorf("NewContainer() error: %v", err)
+			}
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("NewService() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add `service` pkg to define k8s services with patterns and defaults common to Sourcegraph.



## Test plan

Full unit test coverage as well as testable examples.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
