### PR TITLE
soap: Don't count SOAP users as licensed

### DIFF
--- a/cmd/frontend/internal/licensing/enforcement/users.go
+++ b/cmd/frontend/internal/licensing/enforcement/users.go
@@ -50,7 +50,9 @@ func NewBeforeCreateUserHook() func(context.Context, database.DB, *extsvc.Accoun
 		}
 
 		// Block creation of a new user beyond the licensed user count (unless true-up is allowed).
-		userCount, err := db.Users().Count(ctx, nil)
+		userCount, err := db.Users().Count(ctx, &database.UsersListOptions{
+			ExcludeSourcegraphOperators: true,
+		})
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
When creating a new user, this hook is run to ensure only up to the licensed amount of users is created. We do that by counting the number of users that are currently non-deleted on the instance.

However, unlike most other places around licensing and enforcement, this one was missing the flag to exclude SOAP users.

So the initial `managed-XX` user with ID 1 on our cloud instances which is a SOAP user will occupy a seat in this check.

This should fix an issue where a customer is only able to create 9 instead of 10 licensed users.

## Test plan

Code review and explanation from the PR description.
