### PR TITLE
Change "contact support" link to email address

### DIFF
--- a/client/web/src/user/settings/profile/UserSettingsProfilePage.tsx
+++ b/client/web/src/user/settings/profile/UserSettingsProfilePage.tsx
@@ -60,8 +60,10 @@ export const UserSettingsProfilePage: React.FunctionComponent<React.PropsWithChi
                     after={
                         window.context.sourcegraphDotComMode && (
                             <Text className="mt-4">
-                                <Link to="https://sourcegraph.com/contact">Contact support</Link> to delete your
-                                account.
+                                <Link to="mailto:support@sourcegraph.com" target="_blank" rel="noopener noreferrer">
+                                    Contact support
+                                </Link>{' '}
+                                to delete your account.
                             </Text>
                         )
                     }


### PR DESCRIPTION
Changed "contact support" link from `https://sourcegraph.com/contact` to `support@sourcegraph.com` email address.

## Test plan

Ran it locally, it looks good to me:
![CleanShot 2024-03-26 at 13 09 31@2x](https://github.com/sourcegraph/sourcegraph/assets/2552265/71dbf4c8-12cd-4191-b48c-e085476247c4)

It doesn't affect enterprise because this is behind an "If dotcom" flag.