### PR TITLE
telemetry-gateway: add MSP rollouts delivery

### DIFF
--- a/cmd/telemetry-gateway/BUILD.bazel
+++ b/cmd/telemetry-gateway/BUILD.bazel
@@ -2,6 +2,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 load("//dev:oci_defs.bzl", "image_repository", "oci_image", "oci_push", "oci_tarball")
 load("@rules_pkg//:pkg.bzl", "pkg_tar")
 load("@container_structure_test//:defs.bzl", "container_structure_test")
+load("//dev:msp_delivery.bzl", "msp_delivery")
 
 go_binary(
     name = "telemetry-gateway",
@@ -63,4 +64,11 @@ go_library(
         "//cmd/telemetry-gateway/service",
         "//lib/managedservicesplatform/runtime",
     ],
+)
+
+msp_delivery(
+    name = "msp_deploy",
+    gcp_delivery_pipeline = "telemetry-gateway-us-central1-rollout",
+    gcp_project = "telemetry-gateway-prod-acae",
+    repository = "index.docker.io/sourcegraph/telemetry-gateway",
 )


### PR DESCRIPTION
Enables rollouts-based delivery (#59956) for Telemetry Gateway, which is being enabled in https://github.com/sourcegraph/managed-services/pull/958#pullrequestreview-1960184875

Closes https://github.com/sourcegraph/managed-services/issues/933

## Test plan

