### PR TITLE
search: add ENV to disable hybrid search

### DIFF
--- a/cmd/searcher/internal/search/search.go
+++ b/cmd/searcher/internal/search/search.go
@@ -53,6 +53,8 @@ type Service struct {
 	// single call to git archive. This mainly needs to be less than ARG_MAX
 	// for the exec.Command on gitserver.
 	MaxTotalPathsLength int
+
+	UseHybridSearch bool
 }
 
 func (s *Service) search(ctx context.Context, p *protocol.Request, sender matchSender) (err error) {
@@ -142,27 +144,29 @@ func (s *Service) search(ctx context.Context, p *protocol.Request, sender matchS
 		return badRequestError{err.Error()}
 	}
 
-	logger := logWithTrace(ctx, s.Log).Scoped("hybrid").With(
-		log.String("repo", string(p.Repo)),
-		log.String("commit", string(p.Commit)),
-	)
-
 	var paths []string
-	unsearched, ok, err := s.hybrid(ctx, logger, p, sender)
-	if err != nil {
-		// error logging is done inside of s.hybrid so we just return
-		// error here.
-		return errors.Wrap(err, "hybrid search failed")
-	}
-	if !ok {
-		logger.Debug("hybrid search is falling back to normal unindexed search")
-	} else {
-		// now we only need to search unsearched
-		if len(unsearched) == 0 {
-			// indexed search did it all
-			return nil
+	if s.UseHybridSearch {
+		logger := logWithTrace(ctx, s.Log).Scoped("hybrid").With(
+			log.String("repo", string(p.Repo)),
+			log.String("commit", string(p.Commit)),
+		)
+
+		unsearched, ok, err := s.hybrid(ctx, logger, p, sender)
+		if err != nil {
+			// error logging is done inside of s.hybrid so we just return
+			// error here.
+			return errors.Wrap(err, "hybrid search failed")
 		}
-		paths = unsearched
+		if !ok {
+			logger.Debug("hybrid search is falling back to normal unindexed search")
+		} else {
+			// now we only need to search unsearched
+			if len(unsearched) == 0 {
+				// indexed search did it all
+				return nil
+			}
+			paths = unsearched
+		}
 	}
 
 	_, zf, err := s.getZipFile(ctx, tr, p, paths)

--- a/cmd/searcher/shared/shared.go
+++ b/cmd/searcher/shared/shared.go
@@ -43,6 +43,8 @@ var (
 	backgroundTimeout = env.MustGetDuration("PROCESSING_TIMEOUT", 2*time.Hour, "maximum time to spend processing a repository")
 
 	maxTotalPathsLengthRaw = env.Get("MAX_TOTAL_PATHS_LENGTH", "100000", "maximum sum of lengths of all paths in a single call to git archive")
+
+	useHybridSearch = env.MustGetBool("USE_HYBRID_SEARCH", true, "set to false to disable hybrid search")
 )
 
 const port = "3181"
@@ -164,6 +166,8 @@ func Start(ctx context.Context, observationCtx *observation.Context, ready servi
 		MaxTotalPathsLength: maxTotalPathsLength,
 
 		Log: logger,
+
+		UseHybridSearch: useHybridSearch,
 	}
 	sService.Store.Start()
 


### PR DESCRIPTION
This gives us flexibility during troubleshooting issues if we suspect hybrid search might be the issue.

Test plan:
CI
