### PR TITLE
add event type to HubSpot error logs

### DIFF
--- a/cmd/frontend/hubspot/hubspotutil/hubspotutil.go
+++ b/cmd/frontend/hubspot/hubspotutil/hubspotutil.go
@@ -106,7 +106,7 @@ func SyncUserWithV3Event(email, eventName string, contactParams *hubspot.Contact
 	// contact independent of the request lifecycle.
 	err := syncHubSpotContact(context.Background(), email, "", contactParams)
 	if err != nil {
-		log15.Warn("syncHubSpotContact: failed to create or update HubSpot contact", "source", "HubSpot", "eventID", eventID, "error", err)
+		log15.Warn("syncHubSpotContact: failed to create or update HubSpot contact", "source", "HubSpot", "eventName", eventName, "error", err)
 	}
 
 	// Log the V3 event

--- a/cmd/frontend/hubspot/hubspotutil/hubspotutil.go
+++ b/cmd/frontend/hubspot/hubspotutil/hubspotutil.go
@@ -84,7 +84,7 @@ func SyncUser(email, eventID string, contactParams *hubspot.ContactProperties) {
 	// contact independent of the request lifecycle.
 	err := syncHubSpotContact(context.Background(), email, eventID, contactParams)
 	if err != nil {
-		log15.Warn("syncHubSpotContact: failed to create or update HubSpot contact", "source", "HubSpot", "error", err)
+		log15.Warn("syncHubSpotContact: failed to create or update HubSpot contact", "source", "HubSpot", "eventID", eventID, "error", err)
 	}
 }
 
@@ -106,7 +106,7 @@ func SyncUserWithV3Event(email, eventName string, contactParams *hubspot.Contact
 	// contact independent of the request lifecycle.
 	err := syncHubSpotContact(context.Background(), email, "", contactParams)
 	if err != nil {
-		log15.Warn("syncHubSpotContact: failed to create or update HubSpot contact", "source", "HubSpot", "error", err)
+		log15.Warn("syncHubSpotContact: failed to create or update HubSpot contact", "source", "HubSpot", "eventID", eventID, "error", err)
 	}
 
 	// Log the V3 event


### PR DESCRIPTION
Add event type to HubSpot error logs. Help debug issues like [this one](https://sourcegraph.slack.com/archives/C05GJPTSZCZ/p1711488395693409).

## Test plan

CI