### PR TITLE
Commits buttons: handle selected revision and support Perforce terminology

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Added the GraphQL query `User.evaluateFeatureFlag` to show if a feature flag is enabled or disabled for a user. [#60828](https://github.com/sourcegraph/sourcegraph/pull/60828)
 - Search Jobs now supports diff, commit and path searches. Before, only file searches were supported. [#60883](https://github.com/sourcegraph/sourcegraph/pull/60883)
 - Auth providers now support a `noSignIn` option that, when set to true, will hide the auth provider from the sign in page, but still allow users to connect the external account from their Account Security page for permissions syncing. [#60722](https://github.com/sourcegraph/sourcegraph/pull/60722)
+- Added a "Commits" button to the folders in repos that shows commits for the items in that folder. [#60909](https://github.com/sourcegraph/sourcegraph/pull/60909)
 
 ### Changed
 
@@ -34,6 +35,8 @@ All notable changes to Sourcegraph are documented in this file.
 - Code Monitors now properly ignores monitors associated with soft-deleted users, which previously would have led to an error on the overview page. [#60405](https://github.com/sourcegraph/sourcegraph/pull/60405)
 - Fixed a bug where clicking "Exclude Repo" on Azure DevOps or Gerrit repositories would not work. [#60509](https://github.com/sourcegraph/sourcegraph/pull/60509)
 - Links in codeintel popovers respect the revision from the URL. [#60545](https://github.com/sourcegraph/sourcegraph/pull/60545)
+- The "Commits" button in repository and folder pages links to commits in the current revision instead of in the default branch. [#61408](https://github.com/sourcegraph/sourcegraph/pull/61408)
+- The "Commits" button in repository and folder pages uses Perforce language and links to `/-/changelists` for Perforce depots when the experimental feature `perforceChangelistMapping` is enabled. [#61408](https://github.com/sourcegraph/sourcegraph/pull/61408)
 
 ## 5.3.3
 
@@ -4210,7 +4213,7 @@ See the changelog entries for 3.0.0 beta releases and our [3.0](https://docs.sou
 ### Added
 
 - More detailed progress information is displayed on pages that are waiting for repositories to clone.
-- Admins can now see charts with daily, weekly, and monthly unique user counts by visiting the site-admin Analytics page.
+- Admins can now see charts with daily, weekly, and monthly unique user counts by visiting the site-admin Analytics page.
 - Admins can now host and see results from Sourcegraph user satisfaction surveys locally by setting the `"experimentalFeatures": { "hostSurveysLocally": "enabled"}` site config option. This feature will be enabled for all instances once stable.
 - Access tokens are now supported for all authentication providers (including OpenID Connect and SAML, which were previously not supported).
 - The new `motd` setting (in global, organization, and user settings) displays specified messages at the top of all pages.

--- a/client/web/src/repo/tree/TreePage.test.tsx
+++ b/client/web/src/repo/tree/TreePage.test.tsx
@@ -93,7 +93,7 @@ describe('TreePage', () => {
             expect(screen.getByText('Commits')).toBeEnabled()
         })
 
-        it('displays a Perforce repository with Perforce language (at least in the Commits button)', () => {
+        it('displays a Perforce repository with Perforce language in the Commits button', () => {
             // enable the feature that affects how the Commits button renders
             window.context.experimentalFeatures = { perforceChangelistMapping: 'enabled' }
             const repo = repoDefaults()
@@ -106,12 +106,11 @@ describe('TreePage', () => {
             )
             // when `perforceChangelistMapping` is enabled,
             // Perforce depots should display the Commits button using Perforce-centric language.
-            expect(render.queryByText('Changelists')).toBeEnabled()
-            expect(render.queryByText('Changelists')).toBeVisible()
-            expect(render.queryByText('Commits')).toBeNull()
+            expect(render.queryByText('Changelists')).toBeInTheDocument()
+            expect(render.queryByText('Commits')).not.toBeInTheDocument()
         })
 
-        it('displays a Perforce repository with Perforce language (at least in the Commits button)', () => {
+        it('displays a Perforce repository with Git language in the Commits button', () => {
             // enable the feature that affects how the Commits button renders
             window.context.experimentalFeatures = { perforceChangelistMapping: 'disabled' }
             const repo = repoDefaults()
@@ -124,9 +123,8 @@ describe('TreePage', () => {
             )
             // when `perforceChangelistMapping` is disabled,
             // Perforce depots should display the Commits button using the same langauge as Git repos.
-            expect(render.queryByText('Commits')).toBeEnabled()
-            expect(render.queryByText('Commits')).toBeVisible()
-            expect(render.queryByText('Changelists')).toBeNull()
+            expect(render.queryByText('Commits')).toBeInTheDocument()
+            expect(render.queryByText('Changelists')).not.toBeInTheDocument()
         })
 
         it('displays a page that is a fork', () => {

--- a/client/web/src/repo/tree/TreePage.test.tsx
+++ b/client/web/src/repo/tree/TreePage.test.tsx
@@ -24,7 +24,7 @@ describe('TreePage', () => {
 
     const repoDefaults = (): RepositoryFields => ({
         id: 'repo-id',
-        name: 'repo name',
+        name: 'repo-name',
         sourceType: RepositoryType.GIT_REPOSITORY,
         url: 'http://repo.url.example.com',
         description: 'Awesome for testing',
@@ -45,7 +45,7 @@ describe('TreePage', () => {
 
     const treePagePropsDefaults = (repositoryFields: RepositoryFields): Props => ({
         repo: repositoryFields,
-        repoName: 'test repo',
+        repoName: 'test-repo',
         filePath: '',
         commitID: 'asdf1234',
         revision: 'asdf1234',
@@ -90,7 +90,14 @@ describe('TreePage', () => {
             expect(result.queryByTestId('repo-fork-badge')).not.toBeInTheDocument()
             // check for validity that repo header renders
             expect(result.queryByTestId('repo-header')).toBeInTheDocument()
-            expect(screen.getByText('Commits')).toBeEnabled()
+
+            // confirm that the Commits button exists
+            expect(screen.queryByText('Commits')).toBeInTheDocument()
+            // and links to commits in the correct revision
+            expect(result.queryByRole('link', { name: 'Commits' })).toHaveAttribute(
+                'href',
+                '/repo-name@asdf1234/-/commits'
+            )
         })
 
         it('displays a Perforce repository with Perforce language in the Commits button', () => {
@@ -108,6 +115,11 @@ describe('TreePage', () => {
             // Perforce depots should display the Commits button using Perforce-centric language.
             expect(render.queryByText('Changelists')).toBeInTheDocument()
             expect(render.queryByText('Commits')).not.toBeInTheDocument()
+            // and link to "changelists" instead of to "commits"
+            expect(render.queryByRole('link', { name: 'Changelists' })).toHaveAttribute(
+                'href',
+                '/repo-name@asdf1234/-/changelists'
+            )
         })
 
         it('displays a Perforce repository with Git language in the Commits button', () => {
@@ -125,6 +137,11 @@ describe('TreePage', () => {
             // Perforce depots should display the Commits button using the same langauge as Git repos.
             expect(render.queryByText('Commits')).toBeInTheDocument()
             expect(render.queryByText('Changelists')).not.toBeInTheDocument()
+            // and link to "commits" like any other Git repo
+            expect(render.queryByRole('link', { name: 'Commits' })).toHaveAttribute(
+                'href',
+                '/repo-name@asdf1234/-/commits'
+            )
         })
 
         it('displays a page that is a fork', () => {

--- a/client/web/src/repo/tree/TreePage.tsx
+++ b/client/web/src/repo/tree/TreePage.tsx
@@ -56,6 +56,7 @@ import type { OwnConfigProps } from '../../own/OwnConfigProps'
 import { TryCodyWidget } from '../components/TryCodyWidget/TryCodyWidget'
 import { FilePathBreadcrumbs } from '../FilePathBreadcrumbs'
 import { isPackageServiceType } from '../packages/isPackageServiceType'
+import { RepoCommitsButton } from '../utils'
 
 import { TreePageContent } from './TreePageContent'
 import { treeHistoryFragment } from './TreePagePanels'
@@ -215,6 +216,15 @@ export const TreePage: FC<Props> = ({
         return mdiSourceRepository
     }
 
+    const commitsButton = RepoCommitsButton({
+        repoName: repo?.name || '',
+        repoType: repo?.sourceType || '',
+        revision: revision,
+        filePath: filePath,
+        svgPath: mdiSourceCommit,
+        className: styles.text,
+    })
+
     const RootHeaderSection = (): React.ReactElement => (
         <div className="d-flex flex-wrap justify-content-between px-0">
             <div className={styles.header}>
@@ -232,20 +242,7 @@ export const TreePage: FC<Props> = ({
             </div>
             <div className={styles.menu}>
                 <ButtonGroup>
-                    <Tooltip content="Git commits">
-                        <Button
-                            className="flex-shrink-0"
-                            to={`/${encodeURIPathComponent(repoName)}${
-                                revision && `@${encodeURIPathComponent(revision)}`
-                            }/-/commits`}
-                            variant="secondary"
-                            outline={true}
-                            as={Link}
-                        >
-                            <Icon aria-hidden={true} svgPath={mdiSourceCommit} />{' '}
-                            <span className={styles.text}>Commits</span>
-                        </Button>
-                    </Tooltip>
+                    {commitsButton}
                     {!isPackage && (
                         <Tooltip content="Git branches">
                             <Button

--- a/client/web/src/repo/tree/TreePage.tsx
+++ b/client/web/src/repo/tree/TreePage.tsx
@@ -216,15 +216,6 @@ export const TreePage: FC<Props> = ({
         return mdiSourceRepository
     }
 
-    const commitsButton = RepoCommitsButton({
-        repoName: repo?.name || '',
-        repoType: repo?.sourceType || '',
-        revision: revision,
-        filePath: filePath,
-        svgPath: mdiSourceCommit,
-        className: styles.text,
-    })
-
     const RootHeaderSection = (): React.ReactElement => (
         <div className="d-flex flex-wrap justify-content-between px-0">
             <div className={styles.header}>
@@ -242,7 +233,14 @@ export const TreePage: FC<Props> = ({
             </div>
             <div className={styles.menu}>
                 <ButtonGroup>
-                    {commitsButton}
+                    <RepoCommitsButton
+                        repoName={repo?.name || ''}
+                        repoType={repo?.sourceType || ''}
+                        revision={revision}
+                        filePath={filePath}
+                        svgPath={mdiSourceCommit}
+                        className={styles.text}
+                    />
                     {!isPackage && (
                         <Tooltip content="Git branches">
                             <Button

--- a/client/web/src/repo/tree/TreePage.tsx
+++ b/client/web/src/repo/tree/TreePage.tsx
@@ -235,7 +235,9 @@ export const TreePage: FC<Props> = ({
                     <Tooltip content="Git commits">
                         <Button
                             className="flex-shrink-0"
-                            to={`/${encodeURIPathComponent(repoName)}/-/commits`}
+                            to={`/${encodeURIPathComponent(repoName)}${
+                                revision && `@${encodeURIPathComponent(revision)}`
+                            }/-/commits`}
                             variant="secondary"
                             outline={true}
                             as={Link}

--- a/client/web/src/repo/tree/TreePageContent.tsx
+++ b/client/web/src/repo/tree/TreePageContent.tsx
@@ -175,18 +175,20 @@ export const TreePageContent: React.FunctionComponent<React.PropsWithChildren<Tr
     const [enableOwnershipPanels] = useFeatureFlag('enable-ownership-panels', true)
     const hasRepoMetaWritePermissions = canWriteRepoMetadata(props.authenticatedUser)
 
-    const commitsButton = RepoCommitsButton({
-        repoName: repo?.name,
-        repoType: repo?.sourceType,
-        revision: revision,
-        filePath: filePath,
-        svgPath: mdiSourceCommit,
-        className: menuStyles.text,
-    })
-
     return (
         <>
-            {!isRoot && <div className={menuStyles.menu}>{commitsButton}</div>}
+            {!isRoot && (
+                <div className={menuStyles.menu}>
+                    <RepoCommitsButton
+                        repoName={repo.name}
+                        repoType={repo.sourceType}
+                        revision={revision}
+                        filePath={filePath}
+                        svgPath={mdiSourceCommit}
+                        className={menuStyles.text}
+                    />
+                </div>
+            )}
 
             {(readmeEntry || isRoot) && (
                 <section className={classNames('container mb-3 px-0', styles.section)}>

--- a/client/web/src/repo/tree/TreePageContent.tsx
+++ b/client/web/src/repo/tree/TreePageContent.tsx
@@ -13,7 +13,7 @@ import { SearchPatternType, type TreeFields } from '@sourcegraph/shared/src/grap
 import type { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { buildSearchURLQuery } from '@sourcegraph/shared/src/util/url'
-import { Badge, Button, ButtonLink, Card, CardHeader, Icon, Link, Text, Tooltip } from '@sourcegraph/wildcard'
+import { Badge, ButtonLink, Card, CardHeader, Icon, Link, Text, Tooltip } from '@sourcegraph/wildcard'
 
 import type { AuthenticatedUser } from '../../auth'
 import {
@@ -40,7 +40,7 @@ import { quoteIfNeeded, searchQueryForRepoRevision } from '../../search'
 import { buildSearchURLQueryFromQueryState, useNavbarQueryState } from '../../stores'
 import { canWriteRepoMetadata } from '../../util/rbac'
 import { OWNER_FIELDS, RECENT_CONTRIBUTOR_FIELDS, RECENT_VIEW_FIELDS } from '../blob/own/grapqlQueries'
-import { getRefType } from '../utils'
+import { getRefType, RepoCommitsButton } from '../utils'
 
 import { FilesCard, ReadmePreviewCard } from './TreePagePanels'
 
@@ -175,26 +175,18 @@ export const TreePageContent: React.FunctionComponent<React.PropsWithChildren<Tr
     const [enableOwnershipPanels] = useFeatureFlag('enable-ownership-panels', true)
     const hasRepoMetaWritePermissions = canWriteRepoMetadata(props.authenticatedUser)
 
+    const commitsButton = RepoCommitsButton({
+        repoName: repo?.name,
+        repoType: repo?.sourceType,
+        revision: revision,
+        filePath: filePath,
+        svgPath: mdiSourceCommit,
+        className: menuStyles.text,
+    })
+
     return (
         <>
-            {!isRoot && (
-                <div className={menuStyles.menu}>
-                    <Tooltip content="Git commits">
-                        <Button
-                            className="flex-shrink-0"
-                            to={`/${encodeURIPathComponent(repo.name)}${
-                                revision && `@${encodeURIPathComponent(revision)}`
-                            }/-/commits/${encodeURIPathComponent(filePath)}`}
-                            variant="secondary"
-                            outline={true}
-                            as={Link}
-                        >
-                            <Icon aria-hidden={true} svgPath={mdiSourceCommit} />{' '}
-                            <span className={menuStyles.text}>Commits</span>
-                        </Button>
-                    </Tooltip>
-                </div>
-            )}
+            {!isRoot && <div className={menuStyles.menu}>{commitsButton}</div>}
 
             {(readmeEntry || isRoot) && (
                 <section className={classNames('container mb-3 px-0', styles.section)}>

--- a/client/web/src/repo/utils.tsx
+++ b/client/web/src/repo/utils.tsx
@@ -67,13 +67,14 @@ export const RepoCommitsButton: React.FunctionComponent<React.PropsWithChildren<
     return (
         <Tooltip content={tooltip}>
             <Button
+                as={Link}
+                name={title}
                 className="flex-shrink-0"
                 to={`/${encodeURIPathComponent(repoName)}${
                     revision && `@${encodeURIPathComponent(revision)}`
                 }/-/${revisionPath}${filePath && `/${encodeURIPathComponent(filePath)}`}`}
                 variant="secondary"
                 outline={true}
-                as={Link}
             >
                 <Icon aria-hidden={true} svgPath={svgPath} /> <span className={className}>{title}</span>
             </Button>

--- a/client/web/src/repo/utils.tsx
+++ b/client/web/src/repo/utils.tsx
@@ -65,20 +65,18 @@ export const RepoCommitsButton: React.FunctionComponent<React.PropsWithChildren<
     const title = isRepoPerforce ? 'Changelists' : 'Commits'
     const revisionPath = isRepoPerforce ? 'changelists' : 'commits'
     return (
-        <>
-            <Tooltip content={tooltip}>
-                <Button
-                    className="flex-shrink-0"
-                    to={`/${encodeURIPathComponent(repoName)}${
-                        revision && `@${encodeURIPathComponent(revision)}`
-                    }/-/${revisionPath}${filePath && `/${encodeURIPathComponent(filePath)}`}`}
-                    variant="secondary"
-                    outline={true}
-                    as={Link}
-                >
-                    <Icon aria-hidden={true} svgPath={svgPath} /> <span className={className}>{title}</span>
-                </Button>
-            </Tooltip>
-        </>
+        <Tooltip content={tooltip}>
+            <Button
+                className="flex-shrink-0"
+                to={`/${encodeURIPathComponent(repoName)}${
+                    revision && `@${encodeURIPathComponent(revision)}`
+                }/-/${revisionPath}${filePath && `/${encodeURIPathComponent(filePath)}`}`}
+                variant="secondary"
+                outline={true}
+                as={Link}
+            >
+                <Icon aria-hidden={true} svgPath={svgPath} /> <span className={className}>{title}</span>
+            </Button>
+        </Tooltip>
     )
 }

--- a/client/web/src/repo/utils.tsx
+++ b/client/web/src/repo/utils.tsx
@@ -1,3 +1,6 @@
+import { encodeURIPathComponent } from '@sourcegraph/common'
+import { Button, Icon, Link, Tooltip } from '@sourcegraph/wildcard'
+
 import { type GitCommitFields, RepositoryType } from '../graphql-operations'
 
 import { CodeHostType } from './constants'
@@ -44,4 +47,38 @@ export const stringToCodeHostType = (codeHostType: string): CodeHostType => {
             return CodeHostType.OTHER
         }
     }
+}
+
+interface RepoCommitsButtonProps {
+    repoName: string
+    repoType: string
+    revision: string
+    filePath: string
+    svgPath: string
+    className: string
+}
+
+export const RepoCommitsButton: React.FunctionComponent<React.PropsWithChildren<RepoCommitsButtonProps>> = props => {
+    const { repoName, repoType, revision, filePath, svgPath, className } = props
+    const isRepoPerforce = isPerforceChangelistMappingEnabled() && repoType === RepositoryType.PERFORCE_DEPOT
+    const tooltip = isRepoPerforce ? 'Perforce changelists' : 'Git commits'
+    const title = isRepoPerforce ? 'Changelists' : 'Commits'
+    const revisionPath = isRepoPerforce ? 'changelists' : 'commits'
+    return (
+        <>
+            <Tooltip content={tooltip}>
+                <Button
+                    className="flex-shrink-0"
+                    to={`/${encodeURIPathComponent(repoName)}${
+                        revision && `@${encodeURIPathComponent(revision)}`
+                    }/-/${revisionPath}${filePath && `/${encodeURIPathComponent(filePath)}`}`}
+                    variant="secondary"
+                    outline={true}
+                    as={Link}
+                >
+                    <Icon aria-hidden={true} svgPath={svgPath} /> <span className={className}>{title}</span>
+                </Button>
+            </Tooltip>
+        </>
+    )
 }


### PR DESCRIPTION
Followup to PR #60909, which added a Commits button to the folders, and included the revision in it, exposing the shortcoming of the Commits button in the repo root page, which didn't include the revision.

Closes #60487

## Test plan

When viewing a repository root page, click the Commits button and ensure that the URL includes the current revision (branch, tag or commit).