### PR TITLE
msp: support README.md in managed-services repo as mixins for generated docs

### DIFF
--- a/dev/managedservicesplatform/operationdocs/index.go
+++ b/dev/managedservicesplatform/operationdocs/index.go
@@ -46,10 +46,12 @@ func RenderIndexPage(services []*spec.Spec, opts Options) string {
 	opts.AddDocumentComment(md)
 
 	generalGuidanceLink, generalGuidance := markdown.HeadingLinkf("General guidance")
-	md.Paragraphf(`These pages contain generated operational guidance for the infrastructure of %s services.
-This includes information about each service, configured environments, Entitle requests, common tasks, monitoring, etc.
+	md.Paragraphf(`These pages contain generated operational guidance for the infrastructure of the %d %s services (across %d environments) currently in operation at Sourcegraph.
+This includes information about each service, configured environments, Entitle requests, common tasks, monitoring, custom documentation provided by service operators, and so on.
 In addition to service-specific guidance, %s is also available.`,
+		len(services),
 		markdown.Link("Managed Services Platform (MSP)", relativePathToMSPPage),
+		specSet(services).countEnvironments(),
 		generalGuidanceLink)
 
 	md.Paragraphf(`MSP is owned by %s, but individual teams are responsible for the services they operate on the platform.`,
@@ -139,3 +141,11 @@ func (s specSet) Less(i, j int) bool {
 	return s[i].Service.ID < s[j].Service.ID
 }
 func (s specSet) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
+
+func (s specSet) countEnvironments() int {
+	var environments int
+	for _, sp := range s {
+		environments += len(sp.Environments)
+	}
+	return environments
+}

--- a/dev/managedservicesplatform/operationdocs/index_test.go
+++ b/dev/managedservicesplatform/operationdocs/index_test.go
@@ -18,6 +18,9 @@ func TestRenderIndexPage(t *testing.T) {
 				Name:        pointers.Ptr("Service 1"),
 				Owners:      []string{"team-a"},
 			},
+			Environments: []spec.EnvironmentSpec{{
+				ID: "dev",
+			}},
 		},
 		{
 			Service: spec.ServiceSpec{
@@ -26,6 +29,11 @@ func TestRenderIndexPage(t *testing.T) {
 				Name:        pointers.Ptr("Service 2"),
 				Owners:      []string{"team-a"},
 			},
+			Environments: []spec.EnvironmentSpec{{
+				ID: "dev",
+			}, {
+				ID: "prod",
+			}},
 		},
 		{
 			Service: spec.ServiceSpec{
@@ -34,6 +42,9 @@ func TestRenderIndexPage(t *testing.T) {
 				Name:        pointers.Ptr("Service 3"),
 				Owners:      []string{"team-b"},
 			},
+			Environments: []spec.EnvironmentSpec{{
+				ID: "dev",
+			}},
 		},
 		{
 			Service: spec.ServiceSpec{
@@ -42,6 +53,11 @@ func TestRenderIndexPage(t *testing.T) {
 				Name:        pointers.Ptr("Service 4"),
 				Owners:      []string{"team-a", "team-b"},
 			},
+			Environments: []spec.EnvironmentSpec{{
+				ID: "dev",
+			}, {
+				ID: "prod",
+			}},
 		},
 	}
 

--- a/dev/managedservicesplatform/operationdocs/operationdocs.go
+++ b/dev/managedservicesplatform/operationdocs/operationdocs.go
@@ -81,12 +81,13 @@ This service is operated on the %s.`,
 
 	md.Headingf(2, "Service overview")
 	serviceKind := pointers.Deref(s.Service.Kind, spec.ServiceKindService)
-	serviceConfigURL := fmt.Sprintf("https://github.com/sourcegraph/managed-services/blob/main/services/%s/service.yaml",
-		s.Service.ID)
+	serviceDirURL := fmt.Sprintf("https://github.com/sourcegraph/managed-services/blob/main/services/%s", s.Service.ID)
+	serviceConfigURL := fmt.Sprintf("%s/service.yaml", serviceDirURL)
 	md.Table(
 		[]string{"Property", "Details"},
 		[][]string{
-			{"Service ID", markdown.Link(markdown.Code(s.Service.ID), serviceConfigURL)},
+			{"Service ID", fmt.Sprintf("%s (%s)",
+				markdown.Code(s.Service.ID), markdown.Link("specification", serviceConfigURL))},
 			// TODO: See service.Description docstring
 			// {"Description", s.Service.Description},
 			{"Owners", strings.Join(mapTo(s.Service.Owners, markdown.Bold), ", ")},
@@ -105,6 +106,21 @@ This service is operated on the %s.`,
 				fmt.Sprintf("%s - %s", markdown.Code(s.Build.Source.Repo), markdown.Code(s.Build.Source.Dir)),
 				"https://%s/tree/HEAD/%s", s.Build.Source.Repo, path.Clean(s.Build.Source.Dir))},
 		})
+
+	if len(s.README) > 0 {
+		md.Commentf("Automatically generated from the service README: %s", fmt.Sprintf("%s/README.md", serviceDirURL))
+
+		readme := string(s.README)
+		lines := strings.Split(readme, "\n")
+		for i, line := range lines {
+			// Increase all headers by 1 so that they fit nicely into the
+			// generated page.
+			if strings.HasPrefix(line, "##") {
+				lines[i] = "#" + line
+			}
+		}
+		md.Paragraphf(strings.Join(lines, "\n"))
+	}
 
 	md.Headingf(2, "Environments")
 	for _, section := range environmentHeaders {

--- a/dev/managedservicesplatform/operationdocs/operationdocs_test.go
+++ b/dev/managedservicesplatform/operationdocs/operationdocs_test.go
@@ -72,6 +72,31 @@ func TestRender(t *testing.T) {
 				},
 			}},
 		},
+	}, {
+		name: "with README",
+		spec: spec.Spec{
+			Service: spec.ServiceSpec{
+				ID:          testServiceID,
+				Description: "Test service for MSP",
+			},
+			Build: spec.BuildSpec{
+				Image: "us.gcr.io/sourcegraph-dev/msp-example",
+				Source: spec.BuildSourceSpec{
+					Repo: "github.com/sourcegraph/sourcegraph",
+					Dir:  "cmd/msp-example",
+				},
+			},
+			Environments: []spec.EnvironmentSpec{{
+				ID:        testServiceEnvironment,
+				ProjectID: testProjectID,
+				Category:  spec.EnvironmentCategoryTest,
+			}},
+			README: []byte(`This service does X, Y, Z. Refer to [here](sourcegraph.com) for more information.
+
+## Additional operations
+
+Some additional operations!`),
+		},
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
 			doc, err := Render(tc.spec, tc.opts)

--- a/dev/managedservicesplatform/operationdocs/testdata/TestRender/basic.golden
+++ b/dev/managedservicesplatform/operationdocs/testdata/TestRender/basic.golden
@@ -16,7 +16,7 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 |   PROPERTY   |                                                             DETAILS                                                              |
 |--------------|----------------------------------------------------------------------------------------------------------------------------------|
-| Service ID   | [`msp-testbed`](https://github.com/sourcegraph/managed-services/blob/main/services/msp-testbed/service.yaml)                     |
+| Service ID   | `msp-testbed` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/msp-testbed/service.yaml))     |
 | Owners       |                                                                                                                                  |
 | Service kind | Cloud Run service                                                                                                                |
 | Environments | [test](#test)                                                                                                                    |

--- a/dev/managedservicesplatform/operationdocs/testdata/TestRender/with_README.golden
+++ b/dev/managedservicesplatform/operationdocs/testdata/TestRender/with_README.golden
@@ -23,18 +23,28 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 | Docker image | `us.gcr.io/sourcegraph-dev/msp-example`                                                                                          |
 | Source code  | [`github.com/sourcegraph/sourcegraph` - `cmd/msp-example`](https://github.com/sourcegraph/sourcegraph/tree/HEAD/cmd/msp-example) |
 
+<!--
+Automatically generated from the service README: https://github.com/sourcegraph/managed-services/blob/main/services/msp-testbed/README.md
+-->
+
+This service does X, Y, Z. Refer to [here](sourcegraph.com) for more information.
+
+### Additional operations
+
+Some additional operations!
+
 ## Environments
 
 ### test
 
-|      PROPERTY       |                                                              DETAILS                                                              |
-|---------------------|-----------------------------------------------------------------------------------------------------------------------------------|
-| Project ID          | [`msp-testbed-test-77589aae45d0`](https://console.cloud.google.com/run?project=msp-testbed-test-77589aae45d0)                     |
-| Category            | **test**                                                                                                                          |
-| Resources           | [test Redis](#test-redis), [test PostgreSQL instance](#test-postgresql-instance), [test BigQuery dataset](#test-bigquery-dataset) |
-| Slack notifications | [#alerts-msp-testbed-test](https://sourcegraph.slack.com/archives/alerts-msp-testbed-test)                                        |
-| Alerts              | [GCP monitoring](https://console.cloud.google.com/monitoring/alerting?project=msp-testbed-test-77589aae45d0)                      |
-| Errors              | [Sentry `msp-testbed-test`](https://sourcegraph.sentry.io/projects/msp-testbed-test/)                                             |
+|      PROPERTY       |                                                    DETAILS                                                    |
+|---------------------|---------------------------------------------------------------------------------------------------------------|
+| Project ID          | [`msp-testbed-test-77589aae45d0`](https://console.cloud.google.com/run?project=msp-testbed-test-77589aae45d0) |
+| Category            | **test**                                                                                                      |
+| Resources           |                                                                                                               |
+| Slack notifications | [#alerts-msp-testbed-test](https://sourcegraph.slack.com/archives/alerts-msp-testbed-test)                    |
+| Alerts              | [GCP monitoring](https://console.cloud.google.com/monitoring/alerting?project=msp-testbed-test-77589aae45d0)  |
+| Errors              | [Sentry `msp-testbed-test`](https://sourcegraph.sentry.io/projects/msp-testbed-test/)                         |
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges. Test environments may have less stringent requirements.
 
@@ -61,40 +71,6 @@ You can also use `sg msp` to quickly open a link to your service logs:
 ```bash
 sg msp logs msp-testbed test
 ```
-
-#### test Redis
-
-| PROPERTY |                                                              DETAILS                                                              |
-|----------|-----------------------------------------------------------------------------------------------------------------------------------|
-| Console  | [Memorystore Redis instances](https://console.cloud.google.com/memorystore/redis/instances?project=msp-testbed-test-77589aae45d0) |
-
-#### test PostgreSQL instance
-
-| PROPERTY  |                                                   DETAILS                                                   |
-|-----------|-------------------------------------------------------------------------------------------------------------|
-| Console   | [Cloud SQL instances](https://console.cloud.google.com/sql/instances?project=msp-testbed-test-77589aae45d0) |
-| Databases | `foo`, `bar`                                                                                                |
-
-> [!NOTE]
-> The [Write access Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYzJkMTUwOGEtMGQ0ZS00MjA1LWFiZWUtOGY1ODg1ZGY3ZDE4IiwidGhyb3VnaCI6ImMyZDE1MDhhLTBkNGUtNDIwNS1hYmVlLThmNTg4NWRmN2QxOCIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) is required for BOTH read-only and write access to the database.
-
-To connect to the PostgreSQL instance in this environment, use `sg msp` in the [`sourcegraph/managed-services`](https://github.com/sourcegraph/managed-services) repository:
-
-```bash
-# For read-only access
-sg msp pg connect msp-testbed test
-
-# For write access - use with caution!
-sg msp pg connect -write-access msp-testbed test
-```
-
-#### test BigQuery dataset
-
-|    PROPERTY     |                                                                                                            DETAILS                                                                                                             |
-|-----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Dataset Project | `msp-testbed-test-77589aae45d0`                                                                                                                                                                                                |
-| Dataset ID      | `msp_testbed`                                                                                                                                                                                                                  |
-| Tables          | [`bar`](https://github.com/sourcegraph/managed-services/blob/main/services/msp-testbed/bar.bigquerytable.json), [`baz`](https://github.com/sourcegraph/managed-services/blob/main/services/msp-testbed/baz.bigquerytable.json) |
 
 #### test Terraform Cloud
 

--- a/dev/managedservicesplatform/operationdocs/testdata/TestRenderIndexPage.golden
+++ b/dev/managedservicesplatform/operationdocs/testdata/TestRenderIndexPage.golden
@@ -4,8 +4,8 @@
 Generated from: unknown revision of https://github.com/sourcegraph/managed-services
 -->
 
-These pages contain generated operational guidance for the infrastructure of [Managed Services Platform (MSP)](../teams/core-services/managed-services/platform.md) services.
-This includes information about each service, configured environments, Entitle requests, common tasks, monitoring, etc.
+These pages contain generated operational guidance for the infrastructure of the 4 [Managed Services Platform (MSP)](../teams/core-services/managed-services/platform.md) services (across 6 environments) currently in operation at Sourcegraph.
+This includes information about each service, configured environments, Entitle requests, common tasks, monitoring, custom documentation provided by service operators, and so on.
 In addition to service-specific guidance, [General guidance](#general-guidance) is also available.
 
 MSP is owned by [Core Services](../teams/core-services/index.md), but individual teams are responsible for the services they operate on the platform.

--- a/dev/managedservicesplatform/spec/spec.go
+++ b/dev/managedservicesplatform/spec/spec.go
@@ -31,6 +31,11 @@ type Spec struct {
 	// Rollout can be configured to indicate how releases should roll out
 	// through a set of environments.
 	Rollout *RolloutSpec `yaml:"rollout,omitempty"`
+
+	// README is the contents of the README.md file adjacent to the service
+	// specification. May be a zero-length byte slice if a README file is not
+	// present, or nil if this spec was not opened with 'spec.Open(...)'.
+	README []byte
 }
 
 // Open a specification file, validate it, unmarshal the data as a MSP spec,
@@ -59,10 +64,13 @@ func Open(specPath string) (*Spec, error) {
 
 	// Load extraneous resources
 	configDir := filepath.Dir(specPath)
+	if err := spec.loadREADME(configDir); err != nil {
+		return spec, errors.Wrap(err, "spec.loadREADME")
+	}
 	for _, e := range spec.Environments {
 		if e.Resources != nil && e.Resources.BigQueryDataset != nil {
 			if err := e.Resources.BigQueryDataset.LoadSchemas(configDir); err != nil {
-				return spec, errors.Wrap(err, "BigQueryTable.LoadSchema")
+				return spec, errors.Wrapf(err, "spec.environments.[%s].Resources.BigQueryDataset.LoadSchema", e.ID)
 			}
 		}
 	}
@@ -240,4 +248,30 @@ func (s Spec) ListEnvironmentIDs() []string {
 // MarshalYAML marshals the spec to YAML using our YAML library of choice.
 func (s Spec) MarshalYAML() ([]byte, error) {
 	return yaml.Marshal(s)
+}
+
+// loadREADME populates s.readme by convention, looking for the `README.md` file
+// in dir. It expects a specific header format, and populates s.readme with the
+// specific header removed.
+//
+// It is called by spec.Open(...).
+func (s *Spec) loadREADME(dir string) error {
+	// Open by convention
+	readme, err := os.ReadFile(filepath.Join(dir, "README.md"))
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return errors.Wrapf(err, "open README")
+	}
+
+	// Must have header as prefix
+	mustStartWith := "# " + s.Service.GetName()
+	if !bytes.HasPrefix(readme, []byte(mustStartWith)) {
+		return errors.Newf("README must start with an H1 header that matches the service name, i.e. %q", mustStartWith)
+	}
+
+	// Trim the prefix
+	s.README = bytes.TrimSpace(bytes.TrimPrefix(readme, append([]byte(mustStartWith), '\n')))
+	return nil
 }


### PR DESCRIPTION
This allows MSP operators to define a custom introduction to their service by writing a `README.md` file adjacent to their service specification in https://github.com/sourcegraph/managed-services. The README is parsed, stripped of the first header (which must be an H1 with the service name), all H2+ gets indented (to fit in nicely into the generated docs), and included under the `Service overview` section.

This closes https://github.com/sourcegraph/managed-services/issues/382 for now - while @chrsmith's idea to have a `/.msp/...` convention in source code repos, it's a bit finicky to reach upstream for the required files.

The custom README can be a large, detailed all-in-one page such that `go/msp-ops/<my-service>` can be used as a go-to reference for everything about that service, or just be a few links to other relevant documentation, pages, and/or places to get help.

Examples, from https://github.com/sourcegraph/handbook/pull/8781 and https://github.com/sourcegraph/managed-services/pull/984:

- Minimal details: ![image](https://github.com/sourcegraph/sourcegraph/assets/23356519/4f36e8fc-001d-440c-b4aa-facb8f8fee65)

- Lots of details: ![image](https://github.com/sourcegraph/sourcegraph/assets/23356519/8e669963-abbe-442d-9cd1-e59b0f4719b6)

## Test plan

Above examples + simple golden testing