### PR TITLE
gomod: update zoekt to fix List optimization

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -5294,8 +5294,8 @@ def go_dependencies():
         name = "com_github_sourcegraph_zoekt",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/sourcegraph/zoekt",
-        sum = "h1:dNBOcv+bNGniU5iB3SDMQPu3PjqN1QVpJDMw+JJjRic=",
-        version = "v0.0.0-20240326152727-931974dd953e",
+        sum = "h1:QnS7KZETcE9g2CvBCF423BMhIXIwtxuvck3N7SKBJC0=",
+        version = "v0.0.0-20240327102325-8cf8887a903a",
     )
     go_repository(
         name = "com_github_spaolacci_murmur3",

--- a/go.mod
+++ b/go.mod
@@ -585,7 +585,7 @@ require (
 	github.com/scim2/filter-parser/v2 v2.2.0
 	github.com/sourcegraph/conc v0.3.1-0.20240108182409-4afefce20f9b
 	github.com/sourcegraph/mountinfo v0.0.0-20240201124957-b314c0befab1
-	github.com/sourcegraph/zoekt v0.0.0-20240326152727-931974dd953e
+	github.com/sourcegraph/zoekt v0.0.0-20240327102325-8cf8887a903a
 	github.com/spf13/cobra v1.8.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stretchr/objx v0.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1690,8 +1690,8 @@ github.com/sourcegraph/scip v0.3.3 h1:3EOkChYOntwHl0pPSAju7rj0oRuujh8owC4vjGDEr0
 github.com/sourcegraph/scip v0.3.3/go.mod h1:Q67VaoTpftINIy/CLrkYQOMwlsx67h8ys+ligmdUcqM=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152 h1:z/MpntplPaW6QW95pzcAR/72Z5TWDyDnSo0EOcyij9o=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152/go.mod h1:GIjDIg/heH5DOkXY3YJ/wNhfHsQHoXGjl8G8amsYQ1I=
-github.com/sourcegraph/zoekt v0.0.0-20240326152727-931974dd953e h1:dNBOcv+bNGniU5iB3SDMQPu3PjqN1QVpJDMw+JJjRic=
-github.com/sourcegraph/zoekt v0.0.0-20240326152727-931974dd953e/go.mod h1:+j+huwz4ZnffJmDHeLJyI9AY4a8DKQnfNV0J//upnyo=
+github.com/sourcegraph/zoekt v0.0.0-20240327102325-8cf8887a903a h1:QnS7KZETcE9g2CvBCF423BMhIXIwtxuvck3N7SKBJC0=
+github.com/sourcegraph/zoekt v0.0.0-20240327102325-8cf8887a903a/go.mod h1:+j+huwz4ZnffJmDHeLJyI9AY4a8DKQnfNV0J//upnyo=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v0.0.0-20170901052352-ee1bd8ee15a1/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=


### PR DESCRIPTION
After investigating the performance impact of the List optimization, we noticed we did not in practice use the performance improvement. Additionally, in a large number of cases the more advanced synchronization was leading to worse performance. So this update includes two commits which fix the optimization and revert the concurrency changes.

https://github.com/sourcegraph/zoekt/compare/931974dd953e...8cf8887a903a

- https://github.com/sourcegraph/zoekt/commit/7621acc2c5 shards: selectRepoSet supports queries which are not wrapped in and
- https://github.com/sourcegraph/zoekt/commit/8cf8887a90 Revert "shards: respect scheduler and use smarter synchronization for List"

Test Plan: tested in zoekt and this CI
