### PR TITLE
gomod: update zoekt to include List performance improvement

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -5216,8 +5216,8 @@ def go_dependencies():
         name = "com_github_sourcegraph_zoekt",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/sourcegraph/zoekt",
-        sum = "h1://9ddP+HGyVf9Zr5SslDDt2l8VdCW89LA4M0VcZ9jE4=",
-        version = "v0.0.0-20240202144453-245e0cebf761",
+        sum = "h1:PwDo9wDS9X7KduNQE1dELKVOONpmv2Zfdl+VQDc/Ir4=",
+        version = "v0.0.0-20240327103433-6364497e6146",
     )
     go_repository(
         name = "com_github_spaolacci_murmur3",

--- a/go.mod
+++ b/go.mod
@@ -570,7 +570,7 @@ require (
 	github.com/sourcegraph/conc v0.3.1-0.20240108182409-4afefce20f9b
 	github.com/sourcegraph/mountinfo v0.0.0-20240201124957-b314c0befab1
 	github.com/sourcegraph/sourcegraph/monitoring v0.0.0-20230124144931-b2d81b1accb6
-	github.com/sourcegraph/zoekt v0.0.0-20240202144453-245e0cebf761
+	github.com/sourcegraph/zoekt v0.0.0-20240327103433-6364497e6146
 	github.com/spf13/cobra v1.8.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stretchr/objx v0.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1662,8 +1662,8 @@ github.com/sourcegraph/scip v0.3.1-0.20230627154934-45df7f6d33fc h1:o+eq0cjVV3B5
 github.com/sourcegraph/scip v0.3.1-0.20230627154934-45df7f6d33fc/go.mod h1:7ZKAtLIUmiMvOIgG5LMcBxdtBXVa0v2GWC4Hm1ASYQ0=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152 h1:z/MpntplPaW6QW95pzcAR/72Z5TWDyDnSo0EOcyij9o=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152/go.mod h1:GIjDIg/heH5DOkXY3YJ/wNhfHsQHoXGjl8G8amsYQ1I=
-github.com/sourcegraph/zoekt v0.0.0-20240202144453-245e0cebf761 h1://9ddP+HGyVf9Zr5SslDDt2l8VdCW89LA4M0VcZ9jE4=
-github.com/sourcegraph/zoekt v0.0.0-20240202144453-245e0cebf761/go.mod h1:pNXYPYPwN+woZJwc50TwwvyqSx4EOqO/SorzmVhROrI=
+github.com/sourcegraph/zoekt v0.0.0-20240327103433-6364497e6146 h1:PwDo9wDS9X7KduNQE1dELKVOONpmv2Zfdl+VQDc/Ir4=
+github.com/sourcegraph/zoekt v0.0.0-20240327103433-6364497e6146/go.mod h1:pNXYPYPwN+woZJwc50TwwvyqSx4EOqO/SorzmVhROrI=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v0.0.0-20170901052352-ee1bd8ee15a1/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=


### PR DESCRIPTION
NOTE: This is not a backport from sourcegraph's main branch, but rather updating backports that have occurred on the zoekt sourcegraph-5.3 branch.

This includes an improvement performance improvement for List. This change was generated with "./dev/zoekt/update sourcegraph-5.3". The sourcegraph-5.3 branch tracks the version of zoekt used by the 5.3 release branch in sourcegraph.

https://github.com/sourcegraph/zoekt/compare/245e0cebf761...6364497e6146

- https://github.com/sourcegraph/zoekt/commit/8f6d308e8e shards: use selectRepoSet in List
- https://github.com/sourcegraph/zoekt/commit/2da0b9825a shards: respect scheduler and use smarter synchronization for List
- https://github.com/sourcegraph/zoekt/commit/31adf4c3db shards: selectRepoSet supports queries which are not wrapped in and
- https://github.com/sourcegraph/zoekt/commit/6364497e61 Revert "shards: respect scheduler and use smarter synchronization for List"

Test Plan: tested in zoekt repo and in this CI
