### PR TITLE
k8s/resource: Add pkg for creating k8s persistent volume claim resources

### DIFF
--- a/internal/k8s/resource/pod/pod_test.go
+++ b/internal/k8s/resource/pod/pod_test.go
@@ -473,13 +473,13 @@ func TestNewPodTemplate(t *testing.T) {
 			t.Parallel()
 			got, err := NewPodTemplate(tt.args.name, tt.args.namespace, tt.args.options...)
 			if err != nil && tt.wantErr == false {
-				t.Errorf("NewContainer() error: %v", err)
+				t.Errorf("NewPodTemplate() error: %v", err)
 			}
 			if err != nil && tt.wantErr == true {
 				return
 			}
 			if diff := cmp.Diff(tt.want, got); diff != "" {
-				t.Errorf("NewContainer() mismatch (-want +got):\n%s", diff)
+				t.Errorf("NewPodTemplate() mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/internal/k8s/resource/pvc/BUILD.bazel
+++ b/internal/k8s/resource/pvc/BUILD.bazel
@@ -1,0 +1,33 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("//dev:go_defs.bzl", "go_test")
+
+go_library(
+    name = "pvc",
+    srcs = ["pvc.go"],
+    importpath = "github.com/sourcegraph/sourcegraph/internal/k8s/resource/pvc",
+    visibility = ["//:__subpackages__"],
+    deps = [
+        "//internal/maps",
+        "//lib/pointers",
+        "@io_k8s_api//core/v1:core",
+        "@io_k8s_apimachinery//pkg/api/resource",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:meta",
+    ],
+)
+
+go_test(
+    name = "pvc_test",
+    srcs = [
+        "example_test.go",
+        "pvc_test.go",
+    ],
+    embed = [":pvc"],
+    deps = [
+        "//lib/pointers",
+        "@com_github_google_go_cmp//cmp",
+        "@io_k8s_api//core/v1:core",
+        "@io_k8s_apimachinery//pkg/api/resource",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:meta",
+        "@io_k8s_sigs_yaml//:yaml",
+    ],
+)

--- a/internal/k8s/resource/pvc/example_test.go
+++ b/internal/k8s/resource/pvc/example_test.go
@@ -1,0 +1,34 @@
+package pvc
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"sigs.k8s.io/yaml"
+)
+
+func ExamplePersistentVolumeClaim() {
+	p, _ := NewPersistentVolumeClaim("test", "sourcegraph")
+
+	jp, _ := json.Marshal(p)
+	fmt.Println(string(jp))
+
+	yp, _ := yaml.Marshal(p)
+	fmt.Println(string(yp))
+
+	// Output:
+	// {"metadata":{"name":"test","namespace":"sourcegraph","creationTimestamp":null,"labels":{"deploy":"sourcegraph"}},"spec":{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"10Gi"}}},"status":{}}
+	// metadata:
+	//   creationTimestamp: null
+	//   labels:
+	//     deploy: sourcegraph
+	//   name: test
+	//   namespace: sourcegraph
+	// spec:
+	//   accessModes:
+	//   - ReadWriteOnce
+	//   resources:
+	//     requests:
+	//       storage: 10Gi
+	// status: {}
+}

--- a/internal/k8s/resource/pvc/pvc.go
+++ b/internal/k8s/resource/pvc/pvc.go
@@ -1,0 +1,100 @@
+package pvc
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/sourcegraph/sourcegraph/internal/maps"
+	"github.com/sourcegraph/sourcegraph/lib/pointers"
+)
+
+// NewPersistentVolumeClaim creates a new k8s PVC with default values.
+//
+// Default values include:
+//
+//   - Access mode of `ReadWriteOnce`.
+//   - Storage request of 10Gi.
+//
+// Additional options can be passed to modify the default values.
+func NewPersistentVolumeClaim(name, namespace string, options ...Option) (corev1.PersistentVolumeClaim, error) {
+	pvc := corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				"deploy": "sourcegraph",
+			},
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			AccessModes: []corev1.PersistentVolumeAccessMode{
+				corev1.ReadWriteOnce,
+			},
+			Resources: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceStorage: resource.MustParse("10Gi"),
+				},
+			},
+		},
+	}
+
+	for _, opt := range options {
+		err := opt(&pvc)
+		if err != nil {
+			return corev1.PersistentVolumeClaim{}, err
+		}
+	}
+
+	return pvc, nil
+}
+
+// Option sets an option for a PVC.
+type Option func(pvc *corev1.PersistentVolumeClaim) error
+
+// WithLabels sets the PVC labels without overriding existing labels.
+func WithLabels(labels map[string]string) Option {
+	return func(pvc *corev1.PersistentVolumeClaim) error {
+		pvc.Labels = maps.MergePreservingExistingKeys(pvc.Labels, labels)
+		return nil
+	}
+}
+
+// WithAnnotations sets the PVC annotations without overriding existing annotations.
+func WithAnnotations(annotations map[string]string) Option {
+	return func(pvc *corev1.PersistentVolumeClaim) error {
+		pvc.Annotations = maps.MergePreservingExistingKeys(pvc.Annotations, annotations)
+		return nil
+	}
+}
+
+// WithAccessMode sets the Access Mode for the PVC.
+func WithAccessMode(accessModes []corev1.PersistentVolumeAccessMode) Option {
+	return func(pvc *corev1.PersistentVolumeClaim) error {
+		pvc.Spec.AccessModes = accessModes
+		return nil
+	}
+}
+
+// WithResources sets the given Resource Requirements for the PVC.
+func WithResources(resources corev1.ResourceRequirements) Option {
+	return func(pvc *corev1.PersistentVolumeClaim) error {
+		pvc.Spec.Resources = resources
+		return nil
+	}
+}
+
+// WithStorageClassName sets the storage class name for the PVC.
+func WithStorageClassName(storageClassName string) Option {
+	return func(pvc *corev1.PersistentVolumeClaim) error {
+		pvc.Spec.StorageClassName = pointers.Ptr(storageClassName)
+		return nil
+	}
+}
+
+// WithVolumeName sets the given volume name for the PVC.
+func WithVolumeName(volumeName string) Option {
+	return func(pvc *corev1.PersistentVolumeClaim) error {
+		pvc.Spec.VolumeName = volumeName
+		return nil
+	}
+}

--- a/internal/k8s/resource/pvc/pvc_test.go
+++ b/internal/k8s/resource/pvc/pvc_test.go
@@ -1,0 +1,260 @@
+package pvc
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/sourcegraph/sourcegraph/lib/pointers"
+)
+
+func TestNewPersistentVolumeClaim(t *testing.T) {
+	t.Parallel()
+
+	type args struct {
+		name      string
+		namespace string
+		options   []Option
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want corev1.PersistentVolumeClaim
+	}{
+		{
+			name: "default pvc",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+			},
+			want: corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph",
+					},
+				},
+				Spec: corev1.PersistentVolumeClaimSpec{
+					AccessModes: []corev1.PersistentVolumeAccessMode{
+						corev1.ReadWriteOnce,
+					},
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceStorage: resource.MustParse("10Gi"),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "with labels",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithLabels(map[string]string{
+						"app":    "foobar",
+						"deploy": "horsegraph",
+					}),
+				},
+			},
+			want: corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"app":    "foobar",
+						"deploy": "sourcegraph",
+					},
+				},
+				Spec: corev1.PersistentVolumeClaimSpec{
+					AccessModes: []corev1.PersistentVolumeAccessMode{
+						corev1.ReadWriteOnce,
+					},
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceStorage: resource.MustParse("10Gi"),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "with annotations",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithAnnotations(map[string]string{
+						"app": "horsegraph",
+					}),
+				},
+			},
+			want: corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph",
+					},
+					Annotations: map[string]string{
+						"app": "horsegraph",
+					},
+				},
+				Spec: corev1.PersistentVolumeClaimSpec{
+					AccessModes: []corev1.PersistentVolumeAccessMode{
+						corev1.ReadWriteOnce,
+					},
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceStorage: resource.MustParse("10Gi"),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "with access mode",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithAccessMode([]corev1.PersistentVolumeAccessMode{
+						corev1.ReadWriteMany,
+					}),
+				},
+			},
+			want: corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph",
+					},
+				},
+				Spec: corev1.PersistentVolumeClaimSpec{
+					AccessModes: []corev1.PersistentVolumeAccessMode{
+						corev1.ReadWriteMany,
+					},
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceStorage: resource.MustParse("10Gi"),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "with resources",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithResources(corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceStorage: resource.MustParse("100Gi"),
+						},
+					}),
+				},
+			},
+			want: corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph",
+					},
+				},
+				Spec: corev1.PersistentVolumeClaimSpec{
+					AccessModes: []corev1.PersistentVolumeAccessMode{
+						corev1.ReadWriteOnce,
+					},
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceStorage: resource.MustParse("100Gi"),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "with storage class name",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithStorageClassName("sourcegraph"),
+				},
+			},
+			want: corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph",
+					},
+				},
+				Spec: corev1.PersistentVolumeClaimSpec{
+					AccessModes: []corev1.PersistentVolumeAccessMode{
+						corev1.ReadWriteOnce,
+					},
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceStorage: resource.MustParse("10Gi"),
+						},
+					},
+					StorageClassName: pointers.Ptr("sourcegraph"),
+				},
+			},
+		},
+		{
+			name: "with volume name",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithVolumeName("testing"),
+				},
+			},
+			want: corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph",
+					},
+				},
+				Spec: corev1.PersistentVolumeClaimSpec{
+					AccessModes: []corev1.PersistentVolumeAccessMode{
+						corev1.ReadWriteOnce,
+					},
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceStorage: resource.MustParse("10Gi"),
+						},
+					},
+					VolumeName: "testing",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := NewPersistentVolumeClaim(tt.args.name, tt.args.namespace, tt.args.options...)
+			if err != nil {
+				t.Errorf("NewPersistentVolumeClaim() error: %v", err)
+			}
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("NewPersistentVolumeClaim() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add `pvc` pkg to define k8s persistent volume claims with patterns and defaults common to Sourcegraph.



## Test plan

Full unit test coverage as well as testable examples.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
