### PR TITLE
chore: remove unused darwin-arm64 cross binaries for codeintel-qa

### DIFF
--- a/dev/codeintel-qa/cmd/clear/BUILD.bazel
+++ b/dev/codeintel-qa/cmd/clear/BUILD.bazel
@@ -19,11 +19,3 @@ go_binary(
     embed = [":clear_lib"],
     visibility = ["//visibility:public"],
 )
-
-go_cross_binary(
-    name = "clear-darwin-arm64",
-    platform = "@io_bazel_rules_go//go/toolchain:darwin_arm64",
-    tags = ["manual"],
-    target = ":clear",
-    visibility = ["//testing:__pkg__"],
-)

--- a/dev/codeintel-qa/cmd/clone-and-index/BUILD.bazel
+++ b/dev/codeintel-qa/cmd/clone-and-index/BUILD.bazel
@@ -19,11 +19,3 @@ go_binary(
     embed = [":clone-and-index_lib"],
     visibility = ["//visibility:public"],
 )
-
-go_cross_binary(
-    name = "clone-and-index-darwin-arm64",
-    platform = "@io_bazel_rules_go//go/toolchain:darwin_arm64",
-    tags = ["manual"],
-    target = ":clone-and-index",
-    visibility = ["//testing:__pkg__"],
-)

--- a/dev/codeintel-qa/cmd/download/BUILD.bazel
+++ b/dev/codeintel-qa/cmd/download/BUILD.bazel
@@ -20,11 +20,3 @@ go_binary(
     embed = [":download_lib"],
     visibility = ["//visibility:public"],
 )
-
-go_cross_binary(
-    name = "download-darwin-arm64",
-    platform = "@io_bazel_rules_go//go/toolchain:darwin_arm64",
-    tags = ["manual"],
-    target = ":download",
-    visibility = ["//testing:__pkg__"],
-)

--- a/dev/codeintel-qa/cmd/query/BUILD.bazel
+++ b/dev/codeintel-qa/cmd/query/BUILD.bazel
@@ -26,11 +26,3 @@ go_binary(
     embed = [":query_lib"],
     visibility = ["//visibility:public"],
 )
-
-go_cross_binary(
-    name = "query-darwin-arm64",
-    platform = "@io_bazel_rules_go//go/toolchain:darwin_arm64",
-    tags = ["manual"],
-    target = ":query",
-    visibility = ["//testing:__pkg__"],
-)

--- a/dev/codeintel-qa/cmd/upload-gcs/BUILD.bazel
+++ b/dev/codeintel-qa/cmd/upload-gcs/BUILD.bazel
@@ -19,11 +19,3 @@ go_binary(
     embed = [":upload-gcs_lib"],
     visibility = ["//visibility:public"],
 )
-
-go_cross_binary(
-    name = "upload-gcs-darwin-arm64",
-    platform = "@io_bazel_rules_go//go/toolchain:darwin_arm64",
-    tags = ["manual"],
-    target = ":upload-gcs",
-    visibility = ["//testing:__pkg__"],
-)

--- a/dev/codeintel-qa/cmd/upload/BUILD.bazel
+++ b/dev/codeintel-qa/cmd/upload/BUILD.bazel
@@ -20,11 +20,3 @@ go_binary(
     embed = [":upload_lib"],
     visibility = ["//visibility:public"],
 )
-
-go_cross_binary(
-    name = "upload-darwin-arm64",
-    platform = "@io_bazel_rules_go//go/toolchain:darwin_arm64",
-    tags = ["manual"],
-    target = ":upload",
-    visibility = ["//testing:__pkg__"],
-)


### PR DESCRIPTION
No longer needed since https://github.com/sourcegraph/sourcegraph/pull/60569

## Test plan

ctrl+f + bazel query to find any references
