### PR TITLE
ci: create dir if does not exist

### DIFF
--- a/cmd/executor/docker-mirror/_ami.build.sh
+++ b/cmd/executor/docker-mirror/_ami.build.sh
@@ -8,7 +8,7 @@ packer="$(pwd)/$2"
 base="cmd/executor/docker-mirror/"
 
 ## Setting up the folder we're going to use with packer
-mkdir workdir
+mkdir -p workdir
 trap "rm -Rf workdir" EXIT
 
 cp "${base}/docker-mirror.pkr.hcl" workdir/


### PR DESCRIPTION
There is a bug in the 5.3 CI pipeline with `docker mirror build`  where it fails because the `workdir` already exists.

This also makes it consistent with `vm-image/_ami.build.sh`

```
Target //cmd/executor/docker-mirror:ami.build up-to-date:
  bazel-bin/cmd/executor/docker-mirror/ami.build
Aspect @@rules_rust//rust/private:clippy.bzl%rust_clippy_aspect of //cmd/executor/docker-mirror:ami.build up-to-date (nothing to build)
(13:48:00) INFO: Elapsed time: 30.101s, Critical Path: 0.02s
(13:48:00) INFO: 1 process: 1 internal.
(13:48:00) INFO: Build completed successfully, 1 total action
(13:48:00) INFO: Running command line: bazel-bin/cmd/executor/docker-mirror/ami.build dev/tools/gcloud dev/tools/packer
mkdir: cannot create directory 'workdir': File exists
Error: bazel exited with exit code: 1
```

## Test plan
CI and [main-dry-run](https://buildkite.com/sourcegraph/sourcegraph/builds/266586)
