### PR TITLE
GraphQL: add ability to query by user ID for debugging

### DIFF
--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1717,6 +1717,10 @@ type Query {
         Query the user by verified email address.
         """
         email: String
+        """
+        Query the user by ID. Clients should prefer using GraphQL IDs. This is primarily intended for debugging.
+        """
+        intID: Int
     ): User
     """
     List all users.

--- a/cmd/frontend/graphqlbackend/user.go
+++ b/cmd/frontend/graphqlbackend/user.go
@@ -36,6 +36,7 @@ func (r *schemaResolver) User(
 	args struct {
 		Username *string
 		Email    *string
+		IntID    *int32
 	},
 ) (*UserResolver, error) {
 	var err error
@@ -43,6 +44,9 @@ func (r *schemaResolver) User(
 	switch {
 	case args.Username != nil:
 		user, err = r.db.Users().GetByUsername(ctx, *args.Username)
+
+	case args.IntID != nil:
+		user, err = r.db.Users().GetByID(ctx, *args.IntID)
 
 	case args.Email != nil:
 		// 🚨 SECURITY: Only site admins are allowed to look up by email address on
@@ -53,7 +57,6 @@ func (r *schemaResolver) User(
 			}
 		}
 		user, err = r.db.Users().GetByVerifiedEmail(ctx, *args.Email)
-
 	default:
 		return nil, errors.New("must specify either username or email to look up a user")
 	}

--- a/cmd/frontend/graphqlbackend/users_test.go
+++ b/cmd/frontend/graphqlbackend/users_test.go
@@ -26,7 +26,7 @@ func TestUsers(t *testing.T) {
 	users.CountFunc.SetDefaultReturn(2, nil)
 	users.GetByIDFunc.SetDefaultHook(func(ctx context.Context, id int32) (*types.User, error) {
 		if id == 1 {
-			return &types.User{ID: 1, SiteAdmin: true}, nil
+			return &types.User{ID: 1, SiteAdmin: true, Username: "user1"}, nil
 		}
 		return nil, database.NewUserNotFoundError(id)
 	})
@@ -63,6 +63,26 @@ func TestUsers(t *testing.T) {
 							}
 						],
 						"totalCount": 2
+					}
+				}
+			`,
+		},
+		{
+			Context: actor.WithActor(context.Background(), actor.FromMockUser(1)),
+			Schema:  mustParseGraphQLSchema(t, db),
+			Query: `
+				{
+					user(intID:1) {
+						username
+						siteAdmin
+					}
+				}
+			`,
+			ExpectedResult: `
+				{
+					"user": {
+						"username": "user1",
+						"siteAdmin": true
 					}
 				}
 			`,


### PR DESCRIPTION
When debugging, I fairly regularly need to look up a user by an ID from a log message or a trace or something. In order to do that, I currently resort to a hack like writing a test like the following:

```go
func TestMarshalUserID(t *testing.T) {
	t.Fatal(gql.MarshalUserID(38428))
}
```

then using the generated ID to query with GraphQL:

```graphql
query {
    node(id:"VXHalsdgh=") {
        ...on User { ... }
    }
}
```

This is not an obvious solution for what should be a simple operation, especially because when we're trying to look up a user by ID, we're frequently in a hurry, which then makes the most obvious solution just hitting the database directly.

This PR just adds `intID` as a queryable field on the `user()` GraphQL query. It's documented as for debugging to hopefully discourage people from preferring this to GraphQL IDs in clients.

## Test plan

Added a test. Manually tested. 

![CleanShot 2024-03-27 at 10 11 17@2x](https://github.com/sourcegraph/sourcegraph/assets/12631702/8d4bba94-1beb-4457-930e-723f7086bddb)
