### PR TITLE
embeddings: don't schedule jobs if disabled

### DIFF
--- a/internal/embeddings/schedule.go
+++ b/internal/embeddings/schedule.go
@@ -59,6 +59,9 @@ func ScheduleRepositoriesForPolicy(
 	repoEmbeddingJobsStore repo.RepoEmbeddingJobsStore,
 	gitserverClient gitserver.Client,
 ) (err error) {
+	if len(repoIDs) == 0 {
+		return nil
+	}
 	tx, err := repoEmbeddingJobsStore.Transact(ctx)
 	if err != nil {
 		return err


### PR DESCRIPTION
We return early, either if embeddings are disabled or if there are no repos matching any policy.

Before, we scheduled embeddings for all repos returned by `ListMinimalRepos(ctx, database.ReposListOptions{IDs: nil})` in `ScheduleRepositoriesForPolicy`. Reading the documentation of `RepoListOptions.IDs`  "When zero-valued, this is omitted from the predicate set", this might cause repos to get embedded even if embeddings are disabled and no policies are defined. This causes 1 call to gitserver per repo.

Test plan:
CI
