### PR TITLE
GraphQL: rename intID to databaseID

### DIFF
--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1720,7 +1720,7 @@ type Query {
         """
         Query the user by ID. Clients should prefer using GraphQL IDs. This is primarily intended for debugging.
         """
-        intID: Int
+        databaseID: Int
     ): User
     """
     List all users.

--- a/cmd/frontend/graphqlbackend/user.go
+++ b/cmd/frontend/graphqlbackend/user.go
@@ -34,9 +34,9 @@ import (
 func (r *schemaResolver) User(
 	ctx context.Context,
 	args struct {
-		Username *string
-		Email    *string
-		IntID    *int32
+		Username   *string
+		Email      *string
+		DatabaseID *int32
 	},
 ) (*UserResolver, error) {
 	var err error
@@ -45,8 +45,8 @@ func (r *schemaResolver) User(
 	case args.Username != nil:
 		user, err = r.db.Users().GetByUsername(ctx, *args.Username)
 
-	case args.IntID != nil:
-		user, err = r.db.Users().GetByID(ctx, *args.IntID)
+	case args.DatabaseID != nil:
+		user, err = r.db.Users().GetByID(ctx, *args.DatabaseID)
 
 	case args.Email != nil:
 		// 🚨 SECURITY: Only site admins are allowed to look up by email address on

--- a/cmd/frontend/graphqlbackend/users_test.go
+++ b/cmd/frontend/graphqlbackend/users_test.go
@@ -26,7 +26,7 @@ func TestUsers(t *testing.T) {
 	users.CountFunc.SetDefaultReturn(2, nil)
 	users.GetByIDFunc.SetDefaultHook(func(ctx context.Context, id int32) (*types.User, error) {
 		if id == 1 {
-			return &types.User{ID: 1, SiteAdmin: true, Username: "user1"}, nil
+			return &types.User{ID: 1, SiteAdmin: true}, nil
 		}
 		return nil, database.NewUserNotFoundError(id)
 	})
@@ -63,26 +63,6 @@ func TestUsers(t *testing.T) {
 							}
 						],
 						"totalCount": 2
-					}
-				}
-			`,
-		},
-		{
-			Context: actor.WithActor(context.Background(), actor.FromMockUser(1)),
-			Schema:  mustParseGraphQLSchema(t, db),
-			Query: `
-				{
-					user(intID:1) {
-						username
-						siteAdmin
-					}
-				}
-			`,
-			ExpectedResult: `
-				{
-					"user": {
-						"username": "user1",
-						"siteAdmin": true
 					}
 				}
 			`,


### PR DESCRIPTION
Followup from https://github.com/sourcegraph/sourcegraph/pull/61424#discussion_r1541447702

Also moves the test from `users_test.go` to `user_test.go` , which is a more appropriate place for it.

## Test plan

Updated test, manually tested. 