### PR TITLE
msp: add yaml langserver magic comment for schema

### DIFF
--- a/dev/sg/msp/example/job.template.yaml
+++ b/dev/sg/msp/example/job.template.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schema/service.schema.json
 service:
   kind: job
   id: {{ .ID }}

--- a/dev/sg/msp/example/service.template.yaml
+++ b/dev/sg/msp/example/service.template.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schema/service.schema.json
 service:
   id: {{ .ID }}
   name: {{ .Name }}

--- a/dev/sg/msp/example/testdata/TestNewJob/dev/insert_environment.golden
+++ b/dev/sg/msp/example/testdata/TestNewJob/dev/insert_environment.golden
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schema/service.schema.json
 service:
   kind: job
   id: msp-example

--- a/dev/sg/msp/example/testdata/TestNewJob/dev/spec.golden
+++ b/dev/sg/msp/example/testdata/TestNewJob/dev/spec.golden
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schema/service.schema.json
 service:
   kind: job
   id: msp-example

--- a/dev/sg/msp/example/testdata/TestNewJob/prod/insert_environment.golden
+++ b/dev/sg/msp/example/testdata/TestNewJob/prod/insert_environment.golden
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schema/service.schema.json
 service:
   kind: job
   id: msp-example

--- a/dev/sg/msp/example/testdata/TestNewJob/prod/spec.golden
+++ b/dev/sg/msp/example/testdata/TestNewJob/prod/spec.golden
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schema/service.schema.json
 service:
   kind: job
   id: msp-example

--- a/dev/sg/msp/example/testdata/TestNewService/dev.golden
+++ b/dev/sg/msp/example/testdata/TestNewService/dev.golden
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schema/service.schema.json
 service:
   id: msp-example
   name: Msp Example

--- a/dev/sg/msp/example/testdata/TestNewService/dev/insert_environment.golden
+++ b/dev/sg/msp/example/testdata/TestNewService/dev/insert_environment.golden
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schema/service.schema.json
 service:
   id: msp-example
   name: Msp Example

--- a/dev/sg/msp/example/testdata/TestNewService/dev/spec.golden
+++ b/dev/sg/msp/example/testdata/TestNewService/dev/spec.golden
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schema/service.schema.json
 service:
   id: msp-example
   name: Msp Example

--- a/dev/sg/msp/example/testdata/TestNewService/prod.golden
+++ b/dev/sg/msp/example/testdata/TestNewService/prod.golden
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schema/service.schema.json
 service:
   id: msp-example
   name: Msp Example

--- a/dev/sg/msp/example/testdata/TestNewService/prod/insert_environment.golden
+++ b/dev/sg/msp/example/testdata/TestNewService/prod/insert_environment.golden
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schema/service.schema.json
 service:
   id: msp-example
   name: Msp Example

--- a/dev/sg/msp/example/testdata/TestNewService/prod/spec.golden
+++ b/dev/sg/msp/example/testdata/TestNewService/prod/spec.golden
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schema/service.schema.json
 service:
   id: msp-example
   name: Msp Example


### PR DESCRIPTION
If opening a generated MSP service file in your editor, but as part of a different workspace/repo, then vscode doesnt pick up what schema file to use for it, resulting in no intellisense. The yaml langserver supports a magic comment to point to a relative file, that works in this case :slightly_smiling_face: 

## Test plan

Validated locally with local sg build and `sg msp init ...`
