### PR TITLE
k8s/resouce: Add pkg for creating k8s role resources

### DIFF
--- a/internal/k8s/resource/role/BUILD.bazel
+++ b/internal/k8s/resource/role/BUILD.bazel
@@ -1,0 +1,29 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("//dev:go_defs.bzl", "go_test")
+
+go_library(
+    name = "role",
+    srcs = ["role.go"],
+    importpath = "github.com/sourcegraph/sourcegraph/internal/k8s/resource/role",
+    visibility = ["//:__subpackages__"],
+    deps = [
+        "//internal/maps",
+        "@io_k8s_api//rbac/v1:rbac",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:meta",
+    ],
+)
+
+go_test(
+    name = "role_test",
+    srcs = [
+        "example_test.go",
+        "role_test.go",
+    ],
+    embed = [":role"],
+    deps = [
+        "@com_github_google_go_cmp//cmp",
+        "@io_k8s_api//rbac/v1:rbac",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:meta",
+        "@io_k8s_sigs_yaml//:yaml",
+    ],
+)

--- a/internal/k8s/resource/role/example_test.go
+++ b/internal/k8s/resource/role/example_test.go
@@ -1,0 +1,28 @@
+package role
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"sigs.k8s.io/yaml"
+)
+
+func ExampleRole() {
+	r, _ := NewRole("test", "sourcegraph")
+
+	jr, _ := json.Marshal(r)
+	fmt.Println(string(jr))
+
+	yr, _ := yaml.Marshal(r)
+	fmt.Println(string(yr))
+
+	// Output:
+	// {"metadata":{"name":"test","namespace":"sourcegraph","creationTimestamp":null,"labels":{"deploy":"sourcegraph"}},"rules":null}
+	// metadata:
+	//   creationTimestamp: null
+	//   labels:
+	//     deploy: sourcegraph
+	//   name: test
+	//   namespace: sourcegraph
+	// rules: null
+}

--- a/internal/k8s/resource/role/role.go
+++ b/internal/k8s/resource/role/role.go
@@ -1,0 +1,71 @@
+package role
+
+import (
+	"sort"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/sourcegraph/sourcegraph/internal/maps"
+)
+
+// NewRole creates a new k8s RBAC role with default values.
+//
+// Default values include:
+//
+//   - Labels common for Sourcegraph deployments.
+//
+// Additional options can be passed to modify the default values.
+func NewRole(name, namespace string, options ...Option) (rbacv1.Role, error) {
+	role := rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				"deploy": "sourcegraph",
+			},
+		},
+	}
+
+	// apply any options
+	for _, opt := range options {
+		err := opt(&role)
+		if err != nil {
+			return rbacv1.Role{}, err
+		}
+	}
+
+	return role, nil
+}
+
+// Option sets an option for a Role.
+type Option func(role *rbacv1.Role) error
+
+// WithLabels sets Role labels without overriding existing labels.
+func WithLabels(labels map[string]string) Option {
+	return func(role *rbacv1.Role) error {
+		role.Labels = maps.MergePreservingExistingKeys(role.Labels, labels)
+		return nil
+	}
+}
+
+// WithAnnotations sets Role annotations without overriding existing annotations.
+func WithAnnotations(annotations map[string]string) Option {
+	return func(role *rbacv1.Role) error {
+		role.Annotations = maps.MergePreservingExistingKeys(role.Annotations, annotations)
+		return nil
+	}
+}
+
+// WithRules sets Role Policy Rules, sorting by name for accurate comparison of resources.
+func WithRules(rules []rbacv1.PolicyRule) Option {
+	return func(role *rbacv1.Role) error {
+		role.Rules = rules
+
+		sort.SliceStable(role.Rules, func(i, j int) bool {
+			return role.Rules[i].Verbs[0] < role.Rules[j].Verbs[0]
+		})
+
+		return nil
+	}
+}

--- a/internal/k8s/resource/role/role_test.go
+++ b/internal/k8s/resource/role/role_test.go
@@ -1,0 +1,134 @@
+package role
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestNewRole(t *testing.T) {
+	t.Parallel()
+
+	type args struct {
+		name      string
+		namespace string
+		options   []Option
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want rbacv1.Role
+	}{
+		{
+			name: "default role",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+			},
+			want: rbacv1.Role{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph",
+					},
+				},
+			},
+		},
+		{
+			name: "with labels",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithLabels(map[string]string{
+						"foo": "bar",
+					}),
+				},
+			},
+			want: rbacv1.Role{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph",
+						"foo":    "bar",
+					},
+				},
+			},
+		},
+		{
+			name: "with annotations",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithAnnotations(map[string]string{
+						"foo": "bar",
+					}),
+				},
+			},
+			want: rbacv1.Role{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph",
+					},
+					Annotations: map[string]string{
+						"foo": "bar",
+					},
+				},
+			},
+		},
+		{
+			name: "with rules",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithRules([]rbacv1.PolicyRule{
+						{
+							Verbs:     []string{"get", "list", "watch"},
+							APIGroups: []string{"core"},
+							Resources: []string{"pods"},
+						},
+					}),
+				},
+			},
+			want: rbacv1.Role{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph",
+					},
+				},
+				Rules: []rbacv1.PolicyRule{
+					{
+						Verbs:     []string{"get", "list", "watch"},
+						APIGroups: []string{"core"},
+						Resources: []string{"pods"},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := NewRole(tt.args.name, tt.args.namespace, tt.args.options...)
+			if err != nil {
+				t.Errorf("NewRole() error: %v", err)
+			}
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("NewRole() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add `role` pkg to define k8s roles with patterns and defaults common to Sourcegraph.



## Test plan

Full unit test coverage as well as testable examples.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
