### PR TITLE
Code Insights: Log code insights alerts instead failing while gathering repo list

### DIFF
--- a/internal/insights/query/streaming_query_executor.go
+++ b/internal/insights/query/streaming_query_executor.go
@@ -153,11 +153,11 @@ func (c *StreamingRepoQueryExecutor) ExecuteRepoList(ctx context.Context, query 
 	if len(repoResult.SkippedReasons) > 0 {
 		c.logger.Error("repo search encountered skipped events", log.String("reasons", fmt.Sprintf("%v", repoResult.SkippedReasons)), log.String("query", query))
 	}
+	if len(repoResult.Alerts) > 0 {
+		c.logger.Error("repo search encountered alert events", log.String("alerts", fmt.Sprintf("%v", repoResult.Alerts)), log.String("query", query))
+	}
 	if len(repoResult.Errors) > 0 {
 		return nil, errors.Errorf("streaming repo search: errors: %v", repoResult.Errors)
-	}
-	if len(repoResult.Alerts) > 0 {
-		return nil, errors.Errorf("streaming repo search: alerts: %v", repoResult.Alerts)
 	}
 	return repoResult.Repos, nil
 }


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/61370

Simple fix to avoid failing if search API got results with alerts, log them instead and return list of repo

## Test plan
- Check that you can resolve repositories in the creation UI with query which produce search with alerts 
- To setup these alerts you can add an empty repo to you local instance 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
