### PR TITLE
k8s/resource: Add pkg for creating k8s rolebinding resources

### DIFF
--- a/internal/k8s/resource/rolebinding/BUILD.bazel
+++ b/internal/k8s/resource/rolebinding/BUILD.bazel
@@ -1,0 +1,29 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("//dev:go_defs.bzl", "go_test")
+
+go_library(
+    name = "rolebinding",
+    srcs = ["rolebinding.go"],
+    importpath = "github.com/sourcegraph/sourcegraph/internal/k8s/resource/rolebinding",
+    visibility = ["//:__subpackages__"],
+    deps = [
+        "//internal/maps",
+        "@io_k8s_api//rbac/v1:rbac",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:meta",
+    ],
+)
+
+go_test(
+    name = "rolebinding_test",
+    srcs = [
+        "example_test.go",
+        "rolebinding_test.go",
+    ],
+    embed = [":rolebinding"],
+    deps = [
+        "@com_github_google_go_cmp//cmp",
+        "@io_k8s_api//rbac/v1:rbac",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:meta",
+        "@io_k8s_sigs_yaml//:yaml",
+    ],
+)

--- a/internal/k8s/resource/rolebinding/example_test.go
+++ b/internal/k8s/resource/rolebinding/example_test.go
@@ -1,0 +1,30 @@
+package rolebinding
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"sigs.k8s.io/yaml"
+)
+
+func ExampleRoleBinding() {
+	rb, _ := NewRoleBinding("test", "sourcegraph")
+
+	jrb, _ := json.Marshal(rb)
+	fmt.Print(string(jrb))
+
+	yrb, _ := yaml.Marshal(rb)
+	fmt.Print(string(yrb))
+
+	// Output:
+	// {"metadata":{"name":"test","namespace":"sourcegraph","creationTimestamp":null,"labels":{"deploy":"sourcegraph"}},"roleRef":{"apiGroup":"","kind":"","name":""}}metadata:
+	//   creationTimestamp: null
+	//   labels:
+	//     deploy: sourcegraph
+	//   name: test
+	//   namespace: sourcegraph
+	// roleRef:
+	//   apiGroup: ""
+	//   kind: ""
+	//   name: ""
+}

--- a/internal/k8s/resource/rolebinding/example_test.go
+++ b/internal/k8s/resource/rolebinding/example_test.go
@@ -11,13 +11,14 @@ func ExampleRoleBinding() {
 	rb, _ := NewRoleBinding("test", "sourcegraph")
 
 	jrb, _ := json.Marshal(rb)
-	fmt.Print(string(jrb))
+	fmt.Println(string(jrb))
 
 	yrb, _ := yaml.Marshal(rb)
-	fmt.Print(string(yrb))
+	fmt.Println(string(yrb))
 
 	// Output:
-	// {"metadata":{"name":"test","namespace":"sourcegraph","creationTimestamp":null,"labels":{"deploy":"sourcegraph"}},"roleRef":{"apiGroup":"","kind":"","name":""}}metadata:
+	// {"metadata":{"name":"test","namespace":"sourcegraph","creationTimestamp":null,"labels":{"deploy":"sourcegraph"}},"roleRef":{"apiGroup":"","kind":"","name":""}}
+	// metadata:
 	//   creationTimestamp: null
 	//   labels:
 	//     deploy: sourcegraph

--- a/internal/k8s/resource/rolebinding/rolebinding.go
+++ b/internal/k8s/resource/rolebinding/rolebinding.go
@@ -1,0 +1,72 @@
+package rolebinding
+
+import (
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/sourcegraph/sourcegraph/internal/maps"
+)
+
+// NewRoleBinding creates a new k8s RoleBinding with default values.
+//
+// Default values include:
+//
+//   - Labels common for Sourcegraph deployments.
+//
+// Additional options can be passed to modify the default values.
+func NewRoleBinding(name, namespace string, options ...Option) (rbacv1.RoleBinding, error) {
+	roleBinding := rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				"deploy": "sourcegraph",
+			},
+		},
+	}
+
+	// apply any given options
+	for _, opt := range options {
+		err := opt(&roleBinding)
+		if err != nil {
+			return rbacv1.RoleBinding{}, err
+		}
+	}
+
+	return roleBinding, nil
+}
+
+// Option sets an option for a RoleBinding.
+type Option func(rolebinding *rbacv1.RoleBinding) error
+
+// WithLabels sets RoleBinding labels without overriding existing labels.
+func WithLabels(labels map[string]string) Option {
+	return func(rolebinding *rbacv1.RoleBinding) error {
+		rolebinding.Labels = maps.MergePreservingExistingKeys(rolebinding.Labels, labels)
+		return nil
+	}
+}
+
+// WithAnnotations sets RoleBinding annotations without overriding existing labels.
+func WithAnnotations(annotations map[string]string) Option {
+	return func(rolebinding *rbacv1.RoleBinding) error {
+		rolebinding.Annotations = maps.MergePreservingExistingKeys(rolebinding.Annotations, annotations)
+		return nil
+	}
+}
+
+// WithRoleRef sets the given RoleRef for the RoleBinding.
+func WithRoleRef(roleRef rbacv1.RoleRef) Option {
+	return func(rolebinding *rbacv1.RoleBinding) error {
+		rolebinding.RoleRef = roleRef
+		return nil
+	}
+}
+
+// WithSubjects sets the given Subjects for the RoleBinding.
+func WithSubjects(subjects []rbacv1.Subject) Option {
+	return func(rolebinding *rbacv1.RoleBinding) error {
+		rolebinding.Subjects = subjects
+		return nil
+	}
+}

--- a/internal/k8s/resource/rolebinding/rolebinding_test.go
+++ b/internal/k8s/resource/rolebinding/rolebinding_test.go
@@ -1,0 +1,162 @@
+package rolebinding
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestNewRoleBinding(t *testing.T) {
+	t.Parallel()
+
+	type args struct {
+		name      string
+		namespace string
+		options   []Option
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want rbacv1.RoleBinding
+	}{
+		{
+			name: "sourcegraph",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+			},
+			want: rbacv1.RoleBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph",
+					},
+				},
+			},
+		},
+		{
+			name: "with labels",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithLabels(map[string]string{
+						"foo": "bar",
+					}),
+				},
+			},
+			want: rbacv1.RoleBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph",
+						"foo":    "bar",
+					},
+				},
+			},
+		},
+		{
+			name: "with annotations",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithAnnotations(map[string]string{
+						"foo": "bar",
+					}),
+				},
+			},
+			want: rbacv1.RoleBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph",
+					},
+					Annotations: map[string]string{
+						"foo": "bar",
+					},
+				},
+			},
+		},
+		{
+			name: "with role ref",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithRoleRef(rbacv1.RoleRef{
+						APIGroup: "rbac.authorization.k8s.io",
+						Kind:     "Role",
+						Name:     "foorole",
+					}),
+				},
+			},
+			want: rbacv1.RoleBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph",
+					},
+				},
+				RoleRef: rbacv1.RoleRef{
+					APIGroup: "rbac.authorization.k8s.io",
+					Kind:     "Role",
+					Name:     "foorole",
+				},
+			},
+		},
+		{
+			name: "with subjects",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithSubjects([]rbacv1.Subject{
+						{
+							Kind:     "User",
+							Name:     "foouser",
+							APIGroup: "rbac.authorization.k8s.io",
+						},
+					}),
+				},
+			},
+			want: rbacv1.RoleBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph",
+					},
+				},
+				Subjects: []rbacv1.Subject{
+					{
+						Kind:     "User",
+						Name:     "foouser",
+						APIGroup: "rbac.authorization.k8s.io",
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := NewRoleBinding(tt.args.name, tt.args.namespace, tt.args.options...)
+			if err != nil {
+				t.Errorf("NewRoleBinding() error: %v", err)
+			}
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("NewRoleBinding() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add `rolebinding` pkg to define k8s relebindings with patterns and defaults common to Sourcegraph.



## Test plan

Full unit testing coverage as well as testable examples

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
