### PR TITLE
Fix and optimize repo exclusions

### DIFF
--- a/internal/repos/awscodecommit.go
+++ b/internal/repos/awscodecommit.go
@@ -87,9 +87,10 @@ func newAWSCodeCommitSource(svc *types.ExternalService, c *schema.AWSCodeCommitC
 
 	var ex repoExcluder
 	for _, r := range c.Exclude {
-		ex.AddRule().
+		// Either Name OR ID must match.
+		ex.AddRule(NewRule().
 			Exact(r.Name).
-			Exact(r.Id)
+			Exact(r.Id))
 	}
 	if err := ex.RuleErrors(); err != nil {
 		return nil, err

--- a/internal/repos/azuredevops.go
+++ b/internal/repos/azuredevops.go
@@ -57,9 +57,10 @@ func NewAzureDevOpsSource(ctx context.Context, logger log.Logger, svc *types.Ext
 
 	var ex repoExcluder
 	for _, r := range c.Exclude {
-		ex.AddRule().
+		// Either Name must match, or the pattern must match.
+		ex.AddRule(NewRule().
 			Exact(r.Name).
-			Pattern(r.Pattern)
+			Pattern(r.Pattern))
 	}
 	if err := ex.RuleErrors(); err != nil {
 		return nil, err

--- a/internal/repos/bitbucketcloud.go
+++ b/internal/repos/bitbucketcloud.go
@@ -57,10 +57,11 @@ func newBitbucketCloudSource(logger log.Logger, svc *types.ExternalService, c *s
 
 	var ex repoExcluder
 	for _, r := range c.Exclude {
-		ex.AddRule().
+		// Either Name OR UUID must match, or the pattern.
+		ex.AddRule(NewRule().
 			Exact(r.Name).
 			Exact(r.Uuid).
-			Pattern(r.Pattern)
+			Pattern(r.Pattern))
 	}
 	if err := ex.RuleErrors(); err != nil {
 		return nil, err

--- a/internal/repos/bitbucketserver.go
+++ b/internal/repos/bitbucketserver.go
@@ -66,14 +66,15 @@ func newBitbucketServerSource(logger log.Logger, svc *types.ExternalService, c *
 
 	var ex repoExcluder
 	for _, r := range c.Exclude {
-		rule := ex.AddRule()
-		rule.
+		rule := NewRule().
 			Exact(r.Name).
 			Pattern(r.Pattern)
 
 		if r.Id != 0 {
 			rule.Exact(strconv.Itoa(r.Id))
 		}
+
+		ex.AddRule(rule)
 	}
 	if err := ex.RuleErrors(); err != nil {
 		return nil, err

--- a/internal/repos/github.go
+++ b/internal/repos/github.go
@@ -136,7 +136,8 @@ func newGitHubSource(
 	}
 
 	for _, r := range c.Exclude {
-		rule := ex.AddRule().
+		// Either Name OR ID must match, or pattern if set.
+		rule := NewRule().
 			Exact(r.Name).
 			Exact(r.Id).
 			Pattern(r.Pattern)
@@ -162,6 +163,8 @@ func newGitHubSource(
 		if r.Forks {
 			rule.Generic(excludeFork)
 		}
+
+		ex.AddRule(rule)
 	}
 	if err := ex.RuleErrors(); err != nil {
 		return nil, err

--- a/internal/repos/gitlab.go
+++ b/internal/repos/gitlab.go
@@ -92,7 +92,7 @@ func newGitLabSource(logger log.Logger, svc *types.ExternalService, c *schema.Gi
 
 	var ex repoExcluder
 	for _, r := range c.Exclude {
-		rule := ex.AddRule().
+		rule := NewRule().
 			Exact(r.Name).
 			Pattern(r.Pattern)
 
@@ -108,6 +108,8 @@ func newGitLabSource(logger log.Logger, svc *types.ExternalService, c *schema.Gi
 				return false
 			})
 		}
+
+		ex.AddRule(rule)
 	}
 	if err := ex.RuleErrors(); err != nil {
 		return nil, err

--- a/internal/repos/gitolite.go
+++ b/internal/repos/gitolite.go
@@ -36,9 +36,9 @@ func NewGitoliteSource(ctx context.Context, svc *types.ExternalService, gc gitse
 
 	var ex repoExcluder
 	for _, r := range c.Exclude {
-		ex.AddRule().
+		ex.AddRule(NewRule().
 			Exact(r.Name).
-			Pattern(r.Pattern)
+			Pattern(r.Pattern))
 	}
 	if err := ex.RuleErrors(); err != nil {
 		return nil, err

--- a/internal/repos/other.go
+++ b/internal/repos/other.go
@@ -63,9 +63,9 @@ func NewOtherSource(ctx context.Context, svc *types.ExternalService, cf *httpcli
 
 	var ex repoExcluder
 	for _, r := range c.Exclude {
-		ex.AddRule().
+		ex.AddRule(NewRule().
 			Exact(r.Name).
-			Pattern(r.Pattern)
+			Pattern(r.Pattern))
 	}
 	if err := ex.RuleErrors(); err != nil {
 		return nil, err


### PR DESCRIPTION
There was a bug in this logic: For some code host types, we would overwrite the value of exact if both Name and ID were specified in an exclusion rule, for example. Instead, we should OR match on _any_ given exact match. 

This is just a side-effect though, the actual improvement here is that we no longer need to iterate over thousands of rules for simple exact matches. We have a customer who wants to use potentially up to 20000 statements, and during code host syncing, this would need to run 20000 times, for a total of 400,000,000 exact comparisons. 

I added a benchmark for this. Before:

```
goos: darwin
goarch: arm64
pkg: github.com/sourcegraph/sourcegraph/internal/repos
BenchmarkExcludeExact-10            8205            144040 ns/op               0 B/op          0 allocs/op
PASS
```

After:

```
goos: darwin
goarch: arm64
pkg: github.com/sourcegraph/sourcegraph/internal/repos
BenchmarkExcludeExact-10        57618390                20.75 ns/op            0 B/op          0 allocs/op
PASS
```

## Test plan

Adjusted existing tests, other existing tests are still passing, and added a benchmark to verify the improvement.