### PR TITLE
k8s/resouce: Add pkg for creating k8s secret resources

### DIFF
--- a/internal/k8s/resource/secret/BUILD.bazel
+++ b/internal/k8s/resource/secret/BUILD.bazel
@@ -1,0 +1,31 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("//dev:go_defs.bzl", "go_test")
+
+go_library(
+    name = "secret",
+    srcs = ["secret.go"],
+    importpath = "github.com/sourcegraph/sourcegraph/internal/k8s/resource/secret",
+    visibility = ["//:__subpackages__"],
+    deps = [
+        "//internal/maps",
+        "//lib/pointers",
+        "@io_k8s_api//core/v1:core",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:meta",
+    ],
+)
+
+go_test(
+    name = "secret_test",
+    srcs = [
+        "example_test.go",
+        "secret_test.go",
+    ],
+    embed = [":secret"],
+    deps = [
+        "//lib/pointers",
+        "@com_github_google_go_cmp//cmp",
+        "@io_k8s_api//core/v1:core",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:meta",
+        "@io_k8s_sigs_yaml//:yaml",
+    ],
+)

--- a/internal/k8s/resource/secret/example_test.go
+++ b/internal/k8s/resource/secret/example_test.go
@@ -1,0 +1,29 @@
+package secret
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"sigs.k8s.io/yaml"
+)
+
+func ExampleSecret() {
+	s, _ := NewSecret("test", "sourcegraph")
+
+	js, _ := json.Marshal(s)
+	fmt.Println(string(js))
+
+	ys, _ := yaml.Marshal(s)
+	fmt.Println(string(ys))
+
+	// Output:
+	// {"metadata":{"name":"test","namespace":"sourcegraph","creationTimestamp":null,"labels":{"deploy":"sourcegraph"}},"immutable":false,"type":"Opaque"}
+	// immutable: false
+	// metadata:
+	//   creationTimestamp: null
+	//   labels:
+	//     deploy: sourcegraph
+	//   name: test
+	//   namespace: sourcegraph
+	// type: Opaque
+}

--- a/internal/k8s/resource/secret/secret.go
+++ b/internal/k8s/resource/secret/secret.go
@@ -1,0 +1,91 @@
+package secret
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/sourcegraph/sourcegraph/internal/maps"
+	"github.com/sourcegraph/sourcegraph/lib/pointers"
+)
+
+// NewSecret creates a new k8s Secret with default values.
+//
+// Default values include:
+//
+//   - Immutable set to false.
+//   - Default type of `SecretTypeOpaque`
+//
+// Additional options can be passed to modify the default values.
+func NewSecret(name, namespace string, options ...Option) (corev1.Secret, error) {
+	secret := corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				"deploy": "sourcegraph",
+			},
+		},
+		Immutable: pointers.Ptr(false),
+		Type:      corev1.SecretTypeOpaque,
+	}
+
+	// apply any options
+	for _, opt := range options {
+		err := opt(&secret)
+		if err != nil {
+			return corev1.Secret{}, err
+		}
+	}
+	return secret, nil
+}
+
+// Option sets an option for a Secret.
+type Option func(secret *corev1.Secret) error
+
+// WithLabels sets Secret labels without overriding existing labels.
+func WithLabels(labels map[string]string) Option {
+	return func(secret *corev1.Secret) error {
+		secret.Labels = maps.MergePreservingExistingKeys(secret.Labels, labels)
+		return nil
+	}
+}
+
+// WithAnnotations sets Secret annotations without overriding existing annotations.
+func WithAnnotations(annotations map[string]string) Option {
+	return func(secret *corev1.Secret) error {
+		secret.Annotations = maps.MergePreservingExistingKeys(secret.Annotations, annotations)
+		return nil
+	}
+}
+
+// Immutable sets a secret to be immutable.
+func Immutable() Option {
+	return func(secret *corev1.Secret) error {
+		secret.Immutable = pointers.Ptr(true)
+		return nil
+	}
+}
+
+// WithData sets the given binary data to a Secret.
+func WithData(data map[string][]byte) Option {
+	return func(secret *corev1.Secret) error {
+		secret.Data = data
+		return nil
+	}
+}
+
+// WithStringData sets the given string data to a Secret.
+func WithStringData(data map[string]string) Option {
+	return func(secret *corev1.Secret) error {
+		secret.StringData = data
+		return nil
+	}
+}
+
+// OfType sets the given SecretType to the Secret.
+func OfType(secretType corev1.SecretType) Option {
+	return func(secret *corev1.Secret) error {
+		secret.Type = secretType
+		return nil
+	}
+}

--- a/internal/k8s/resource/secret/secret_test.go
+++ b/internal/k8s/resource/secret/secret_test.go
@@ -1,0 +1,206 @@
+package secret
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/sourcegraph/sourcegraph/lib/pointers"
+)
+
+func TestNewSecret(t *testing.T) {
+	t.Parallel()
+
+	type args struct {
+		name      string
+		namespace string
+		options   []Option
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want corev1.Secret
+	}{
+		{
+			name: "default secret",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+			},
+			want: corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph",
+					},
+				},
+				Immutable: pointers.Ptr(false),
+				Type:      corev1.SecretTypeOpaque,
+			},
+		},
+		{
+			name: "with labels",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithLabels(map[string]string{
+						"foo": "bar",
+					}),
+				},
+			},
+			want: corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph",
+						"foo":    "bar",
+					},
+				},
+				Immutable: pointers.Ptr(false),
+				Type:      corev1.SecretTypeOpaque,
+			},
+		},
+		{
+			name: "with annotations",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithAnnotations(map[string]string{
+						"foo": "bar",
+					}),
+				},
+			},
+			want: corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph",
+					},
+					Annotations: map[string]string{
+						"foo": "bar",
+					},
+				},
+				Immutable: pointers.Ptr(false),
+				Type:      corev1.SecretTypeOpaque,
+			},
+		},
+		{
+			name: "immutable",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					Immutable(),
+				},
+			},
+			want: corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph",
+					},
+				},
+				Immutable: pointers.Ptr(true),
+				Type:      corev1.SecretTypeOpaque,
+			},
+		},
+		{
+			name: "with data",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithData(map[string][]byte{
+						"username": []byte("myuser"),
+						"password": []byte("mypass"),
+					}),
+				},
+			},
+			want: corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph",
+					},
+				},
+				Immutable: pointers.Ptr(false),
+				Data: map[string][]byte{
+					"username": []byte("myuser"),
+					"password": []byte("mypass"),
+				},
+				Type: corev1.SecretTypeOpaque,
+			},
+		},
+		{
+			name: "with string data",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithStringData(map[string]string{
+						"foo": "bar",
+					}),
+				},
+			},
+			want: corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph",
+					},
+				},
+				Immutable: pointers.Ptr(false),
+				StringData: map[string]string{
+					"foo": "bar",
+				},
+				Type: corev1.SecretTypeOpaque,
+			},
+		},
+		{
+			name: "of type",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					OfType(corev1.SecretTypeBasicAuth),
+				},
+			},
+			want: corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph",
+					},
+				},
+				Immutable: pointers.Ptr(false),
+				Type:      corev1.SecretTypeBasicAuth,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := NewSecret(tt.args.name, tt.args.namespace, tt.args.options...)
+			if err != nil {
+				t.Errorf("NewPodTemplate() error: %v", err)
+			}
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("NewSecret() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add `secret` pkgs to define k8s secrets with patterns and defaults common to Sourcegraph.



## Test plan

Full unit test coverage as well as testable examples.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
