### PR TITLE
Svelte: persist opt in/out

### DIFF
--- a/client/web-sveltekit/src/routes/+layout.ts
+++ b/client/web-sveltekit/src/routes/+layout.ts
@@ -62,10 +62,10 @@ export const load: LayoutLoad = async ({ fetch }) => {
             }
             return result.data.evaluatedFeatureFlags
         },
-        disableSvelteFeatureFlags: async () => {
+        disableSvelteFeatureFlags: async (userID: string) => {
             const mutationResult = await client.mutation(
                 DisableSveltePrototype,
-                { userID: result?.data?.currentUser?.id },
+                { userID },
                 { requestPolicy: 'network-only', fetch }
             )
             if (!mutationResult.data || mutationResult.error) {

--- a/client/web-sveltekit/src/routes/+layout.ts
+++ b/client/web-sveltekit/src/routes/+layout.ts
@@ -6,7 +6,7 @@ import { getGraphQLClient } from '$lib/graphql'
 import type { Settings } from '$lib/shared'
 
 import type { LayoutLoad } from './$types'
-import { Init, EvaluatedFeatureFlagsQuery, GlobalAlertsSiteFlags } from './layout.gql'
+import { Init, EvaluatedFeatureFlagsQuery, GlobalAlertsSiteFlags, DisableSveltePrototype } from './layout.gql'
 
 // Disable server side rendering for the whole app
 export const ssr = false
@@ -61,6 +61,16 @@ export const load: LayoutLoad = async ({ fetch }) => {
                 throw new Error(`Failed to fetch evaluated feature flags: ${result.error}`)
             }
             return result.data.evaluatedFeatureFlags
+        },
+        disableSvelteFeatureFlags: async () => {
+            const mutationResult = await client.mutation(
+                DisableSveltePrototype,
+                { userID: result?.data?.currentUser?.id },
+                { requestPolicy: 'network-only', fetch }
+            )
+            if (!mutationResult.data || mutationResult.error) {
+                throw new Error(`Failed to disable svelte feature flags: ${result.error}`)
+            }
         },
     }
 }

--- a/client/web-sveltekit/src/routes/Header.svelte
+++ b/client/web-sveltekit/src/routes/Header.svelte
@@ -1,14 +1,14 @@
 <script lang="ts">
+    import { browser } from '$app/environment'
+    import { page } from '$app/stores'
     import { mark } from '$lib/images'
-
+    import Popover from '$lib/Popover.svelte'
     import { Badge, Button } from '$lib/wildcard'
-    import UserMenu from './UserMenu.svelte'
+
     import type { Header_User } from './Header.gql'
     import { mainNavigation } from './mainNavigation'
     import MainNavigationEntry from './MainNavigationEntry.svelte'
-    import Popover from '$lib/Popover.svelte'
-    import { browser } from '$app/environment'
-    import { page } from '$app/stores'
+    import UserMenu from './UserMenu.svelte'
 
     export let authenticatedUser: Header_User | null | undefined
 
@@ -16,18 +16,10 @@
         (browser && window.location.hostname === 'localhost') ||
         window.location.hostname === 'sourcegraph.sourcegraph.com'
 
-    $: reactURL = (function (url) {
-        const urlCopy = new URL(url)
-        urlCopy.searchParams.delete('feat')
-        for (let feature of urlCopy.searchParams.getAll('feat')) {
-            if (feature !== 'web-next' && feature !== 'web-next-rollout') {
-                urlCopy.searchParams.append('feat', feature)
-            }
-        }
-        urlCopy.searchParams.append('feat', '-web-next')
-        urlCopy.searchParams.append('feat', '-web-next-rollout')
-        return urlCopy.toString()
-    })($page.url)
+    async function handleOptOut() {
+        await $page.data.disableSvelteFeatureFlags()
+        window.location.reload()
+    }
 </script>
 
 <header>
@@ -58,12 +50,7 @@
                     >.
                 </p>
             {/if}
-            <p>
-                You can temporarily switch back to the stable version of the web app by clicking <a
-                    href={reactURL}
-                    data-sveltekit-reload>here</a
-                >.
-            </p>
+            Or you can <button role="link" class="opt-out" on:click={handleOptOut}>opt out</button> of the Sveltekit experiment.
         </div>
     </Popover>
     <div>
@@ -89,6 +76,16 @@
         padding: 0 0.5rem;
         border-bottom: 1px solid var(--border-color-2);
         background-color: var(--color-bg-1);
+    }
+
+    .opt-out {
+        background: none;
+        border: none;
+        padding: 0;
+        font: inherit;
+        cursor: pointer;
+        color: var(--link-color);
+        text-decoration: underline;
     }
 
     .logo img {

--- a/client/web-sveltekit/src/routes/Header.svelte
+++ b/client/web-sveltekit/src/routes/Header.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
     import { browser } from '$app/environment'
-    import { page } from '$app/stores'
     import { mark } from '$lib/images'
     import Popover from '$lib/Popover.svelte'
     import { Badge, Button } from '$lib/wildcard'
@@ -11,15 +10,11 @@
     import UserMenu from './UserMenu.svelte'
 
     export let authenticatedUser: Header_User | null | undefined
+    export let handleOptOut: (() => Promise<void>) | undefined
 
     const isDevOrS2 =
         (browser && window.location.hostname === 'localhost') ||
         window.location.hostname === 'sourcegraph.sourcegraph.com'
-
-    async function handleOptOut() {
-        await $page.data.disableSvelteFeatureFlags()
-        window.location.reload()
-    }
 </script>
 
 <header>
@@ -50,7 +45,10 @@
                     >.
                 </p>
             {/if}
-            Or you can <button role="link" class="opt-out" on:click={handleOptOut}>opt out</button> of the Sveltekit experiment.
+            {#if handleOptOut}
+                Or you can <button role="link" class="opt-out" on:click={handleOptOut}>opt out</button> of the Sveltekit
+                experiment.
+            {/if}
         </div>
     </Popover>
     <div>
@@ -79,10 +77,7 @@
     }
 
     .opt-out {
-        background: none;
-        border: none;
-        padding: 0;
-        font: inherit;
+        all: unset;
         cursor: pointer;
         color: var(--link-color);
         text-decoration: underline;

--- a/client/web-sveltekit/src/routes/layout.gql
+++ b/client/web-sveltekit/src/routes/layout.gql
@@ -24,6 +24,15 @@ query GlobalAlertsSiteFlags {
     }
 }
 
+mutation DisableSveltePrototype($userID: ID!) {
+    overrideWebNext: createFeatureFlagOverride(namespace:$userID, flagName:"web-next", value:false) {
+        __typename
+    }
+    overrideRollout: createFeatureFlagOverride(namespace:$userID, flagName:"web-next-rollout", value:false) {
+        __typename
+    }
+}
+
 fragment FeatureFlag on EvaluatedFeatureFlag {
     name
     value

--- a/client/web/src/nav/GlobalNavbar.tsx
+++ b/client/web/src/nav/GlobalNavbar.tsx
@@ -205,7 +205,7 @@ export const GlobalNavbar: React.FunctionComponent<React.PropsWithChildren<Globa
                             <DeveloperSettingsGlobalNavItem />
                         </NavAction>
                     )}
-                    <SvelteKitNavItem />
+                    <SvelteKitNavItem userID={props.authenticatedUser?.id} />
                     {props.authenticatedUser?.siteAdmin && (
                         <AccessRequestsGlobalNavItem className="d-flex align-items-center py-1" />
                     )}

--- a/client/web/src/sveltekit/SvelteKitNavItem.tsx
+++ b/client/web/src/sveltekit/SvelteKitNavItem.tsx
@@ -1,5 +1,6 @@
 import type { FC } from 'react'
 
+import { useApolloClient } from '@apollo/client'
 import { mdiFlaskEmptyOutline } from '@mdi/js'
 import { useLocation } from 'react-router-dom'
 
@@ -7,19 +8,20 @@ import { Button, Icon, Tooltip } from '@sourcegraph/wildcard'
 
 import { useFeatureFlag } from '../featureFlags/useFeatureFlag'
 
-import { reload, isSupportedRoute } from './util'
+import { enableSvelteAndReload, isSupportedRoute } from './util'
 
-export const SvelteKitNavItem: FC = () => {
+export const SvelteKitNavItem: FC<{ userID?: string }> = ({ userID }) => {
     const location = useLocation()
+    const client = useApolloClient()
     const [isEnabled] = useFeatureFlag('web-next-toggle')
 
-    if (!isEnabled || !isSupportedRoute(location.pathname)) {
+    if (!isEnabled || !isSupportedRoute(location.pathname) || !userID) {
         return null
     }
 
     return (
         <Tooltip content="Go to experimental web app">
-            <Button variant="icon" onClick={reload}>
+            <Button variant="icon" onClick={() => enableSvelteAndReload(client, userID)}>
                 <span className="text-muted">
                     <Icon svgPath={mdiFlaskEmptyOutline} aria-hidden={true} inline={false} />
                 </span>

--- a/client/web/src/sveltekit/util.ts
+++ b/client/web/src/sveltekit/util.ts
@@ -1,3 +1,4 @@
+import { ApolloClient, gql } from '@apollo/client'
 import { memoize } from 'lodash'
 import { matchPath } from 'react-router-dom'
 
@@ -69,8 +70,23 @@ export function isRolledOutRoute(pathname: string): boolean {
     return false
 }
 
-export function reload(): void {
-    const url = new URL(window.location.href)
-    url.searchParams.append('feat', 'web-next')
-    window.location.href = url.toString()
+export async function enableSvelteAndReload(client: ApolloClient<{}>, userID: string) {
+    await client.mutate({
+        mutation: gql`
+            mutation EnableSveltePrototype($userID: ID!) {
+                overrideWebNext: createFeatureFlagOverride(namespace: $userID, flagName: "web-next", value: true) {
+                    __typename
+                }
+                overrideRollout: createFeatureFlagOverride(
+                    namespace: $userID
+                    flagName: "web-next-rollout"
+                    value: true
+                ) {
+                    __typename
+                }
+            }
+        `,
+        variables: { userID },
+    })
+    window.location.reload()
 }

--- a/client/web/src/sveltekit/util.ts
+++ b/client/web/src/sveltekit/util.ts
@@ -70,7 +70,7 @@ export function isRolledOutRoute(pathname: string): boolean {
     return false
 }
 
-export async function enableSvelteAndReload(client: ApolloClient<{}>, userID: string) {
+export async function enableSvelteAndReload(client: ApolloClient<{}>, userID: string): Promise<void> {
     await client.mutate({
         mutation: gql`
             mutation EnableSveltePrototype($userID: ID!) {


### PR DESCRIPTION
Basically, when you opt into or out of the svelte experiment, it persists that choice. The rollout flag is now only effectively used if you have not done either of these actions. Once you opt in or out, that choice is remembered by saving a feature flag override.

Previously, enabling the feature was done with URL-level feature flag overrides, which is problematic because they don't stay enabled/disabled.

This should be the last thing needed before enabling by default on S2. Closes https://github.com/sourcegraph/sourcegraph/issues/61298

## Test plan

https://github.com/sourcegraph/sourcegraph/assets/12631702/038cfb5b-2d30-46a6-8299-7fde46562e77



