### PR TITLE
v2t: add v2t to NPS surveys

### DIFF
--- a/client/web/src/LegacyLayout.tsx
+++ b/client/web/src/LegacyLayout.tsx
@@ -220,7 +220,10 @@ export const LegacyLayout: FC<LegacyLayoutProps> = props => {
 
             <GlobalAlerts authenticatedUser={props.authenticatedUser} />
             {!isSiteInit && !isSignInOrUp && !props.isSourcegraphDotCom && !disableFeedbackSurvey && (
-                <SurveyToast authenticatedUser={props.authenticatedUser} />
+                <SurveyToast
+                    authenticatedUser={props.authenticatedUser}
+                    telemetryRecorder={props.platformContext.telemetryRecorder}
+                />
             )}
             {!isSiteInit && !isSignInOrUp && !isGetCodyPage && !isPostSignUpPage && (
                 <>

--- a/client/web/src/integration/jscontext.ts
+++ b/client/web/src/integration/jscontext.ts
@@ -78,5 +78,6 @@ export const createJsContext = ({ sourcegraphBaseUrl }: { sourcegraphBaseUrl: st
     embeddingsEnabled: false,
     runningOnMacOS: true,
     primaryLoginProvidersCount: 5,
+    // use noOpTelemetryRecorder since this jsContext is only used for integration tests.
     telemetryRecorder: noOpTelemetryRecorder,
 })

--- a/client/web/src/marketing/components/SurveyRatingRadio.tsx
+++ b/client/web/src/marketing/components/SurveyRatingRadio.tsx
@@ -3,13 +3,14 @@ import React, { useState } from 'react'
 import classNames from 'classnames'
 import { range } from 'lodash'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import { Button } from '@sourcegraph/wildcard'
 
 import { eventLogger } from '../../tracking/eventLogger'
 
 import radioStyles from './SurveyRatingRadio.module.scss'
 
-interface SurveyRatingRadio {
+interface SurveyRatingRadio extends TelemetryV2Props {
     ariaLabelledby?: string
     score?: number
     onChange: (score: number) => void
@@ -29,6 +30,7 @@ export const SurveyRatingRadio: React.FunctionComponent<React.PropsWithChildren<
 
     const handleChange = (score: number): void => {
         eventLogger.log('SurveyButtonClicked', { score }, { score })
+        props.telemetryRecorder.recordEvent('surveyNPS.button', 'click', { metadata: { score } })
 
         if (props.onChange) {
             props.onChange(score)

--- a/client/web/src/marketing/page/SurveyForm.tsx
+++ b/client/web/src/marketing/page/SurveyForm.tsx
@@ -3,6 +3,7 @@ import React, { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 
 import { useMutation, gql } from '@sourcegraph/http-client'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import { Button, LoadingSpinner, Label, Text, Form } from '@sourcegraph/wildcard'
 
 import type { AuthenticatedUser } from '../../auth'
@@ -13,7 +14,7 @@ import { SurveyUseCaseForm } from '../components/SurveyUseCaseForm'
 
 import styles from './SurveyPage.module.scss'
 
-interface SurveyFormProps {
+interface SurveyFormProps extends TelemetryV2Props {
     authenticatedUser: AuthenticatedUser | null
     score?: number
 }
@@ -37,6 +38,7 @@ export interface SurveyFormLocationState {
 export const SurveyForm: React.FunctionComponent<React.PropsWithChildren<SurveyFormProps>> = ({
     authenticatedUser,
     score,
+    telemetryRecorder,
 }) => {
     const navigate = useNavigate()
     const [email, setEmail] = useState('')
@@ -78,6 +80,7 @@ export const SurveyForm: React.FunctionComponent<React.PropsWithChildren<SurveyF
         }
 
         eventLogger.log('SurveySubmitted')
+        telemetryRecorder.recordEvent('surveyNPS', 'submit')
 
         await submitSurvey({
             variables: {
@@ -101,7 +104,12 @@ export const SurveyForm: React.FunctionComponent<React.PropsWithChildren<SurveyF
             <Label id="survey-form-scores" className={styles.label}>
                 How likely is it that you would recommend Sourcegraph to a friend?
             </Label>
-            <SurveyRatingRadio ariaLabelledby="survey-form-scores" onChange={handleScoreChange} score={score} />
+            <SurveyRatingRadio
+                ariaLabelledby="survey-form-scores"
+                onChange={handleScoreChange}
+                score={score}
+                telemetryRecorder={telemetryRecorder}
+            />
             <SurveyUseCaseForm
                 className="my-2"
                 authenticatedUser={authenticatedUser}

--- a/client/web/src/marketing/page/SurveyPage.story.tsx
+++ b/client/web/src/marketing/page/SurveyPage.story.tsx
@@ -1,5 +1,7 @@
 import type { Decorator, Meta, StoryFn } from '@storybook/react'
 
+import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
+
 import { WebStory } from '../../components/WebStory'
 
 import { SurveyPage } from './SurveyPage'
@@ -16,4 +18,6 @@ const config: Meta = {
 
 export default config
 
-export const Page: StoryFn = () => <SurveyPage authenticatedUser={null} forceScore="10" />
+export const Page: StoryFn = () => (
+    <SurveyPage authenticatedUser={null} forceScore="10" telemetryRecorder={noOpTelemetryRecorder} />
+)

--- a/client/web/src/marketing/page/SurveyPage.test.tsx
+++ b/client/web/src/marketing/page/SurveyPage.test.tsx
@@ -2,6 +2,7 @@ import type { MockedProviderProps } from '@apollo/client/testing'
 import { cleanup, fireEvent, within, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
+import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
 import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
 import { type RenderWithBrandedContextResult, renderWithBrandedContext } from '@sourcegraph/wildcard/src/testing'
 
@@ -27,7 +28,7 @@ describe('SurveyPage', () => {
     const renderSurveyPage = ({ mocks, routerProps }: RenderSurveyPageParameters) =>
         renderWithBrandedContext(
             <MockedTestProvider mocks={mocks}>
-                <SurveyPage authenticatedUser={null} />
+                <SurveyPage authenticatedUser={null} telemetryRecorder={noOpTelemetryRecorder} />
             </MockedTestProvider>,
             {
                 path: '/survey/:score?',

--- a/client/web/src/marketing/page/SurveyPage.tsx
+++ b/client/web/src/marketing/page/SurveyPage.tsx
@@ -2,6 +2,7 @@ import React, { useEffect } from 'react'
 
 import { useParams, useLocation } from 'react-router-dom'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import { FeedbackText } from '@sourcegraph/wildcard'
 
 import type { AuthenticatedUser } from '../../auth'
@@ -14,7 +15,7 @@ import { SurveyForm } from './SurveyForm'
 
 import styles from './SurveyPage.module.scss'
 
-interface SurveyPageProps {
+interface SurveyPageProps extends TelemetryV2Props {
     authenticatedUser: AuthenticatedUser | null
     /**
      * For Storybook only
@@ -32,7 +33,8 @@ export const SurveyPage: React.FunctionComponent<React.PropsWithChildren<SurveyP
 
     useEffect(() => {
         eventLogger.logViewEvent('Survey')
-    }, [])
+        props.telemetryRecorder.recordEvent('surveyNPS.page', 'view')
+    }, [props.telemetryRecorder])
 
     if (score === 'thanks') {
         return (
@@ -52,7 +54,13 @@ export const SurveyPage: React.FunctionComponent<React.PropsWithChildren<SurveyP
             <PageTitle title="Almost there..." />
             <HeroPage
                 title="Almost there..."
-                cta={<SurveyForm score={getScoreFromString(score)} authenticatedUser={props.authenticatedUser} />}
+                cta={
+                    <SurveyForm
+                        score={getScoreFromString(score)}
+                        authenticatedUser={props.authenticatedUser}
+                        telemetryRecorder={props.telemetryRecorder}
+                    />
+                }
             />
         </div>
     )

--- a/client/web/src/marketing/toast/SurveyToast.story.tsx
+++ b/client/web/src/marketing/toast/SurveyToast.story.tsx
@@ -1,5 +1,7 @@
 import type { Decorator, Meta, StoryFn } from '@storybook/react'
 
+import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
+
 import { WebStory } from '../../components/WebStory'
 
 import { SurveyToast } from '.'
@@ -13,4 +15,6 @@ const config: Meta = {
 
 export default config
 
-export const Toast: StoryFn = () => <SurveyToast forceVisible={true} authenticatedUser={null} />
+export const Toast: StoryFn = () => (
+    <SurveyToast forceVisible={true} authenticatedUser={null} telemetryRecorder={noOpTelemetryRecorder} />
+)

--- a/client/web/src/marketing/toast/SurveyToast.test.tsx
+++ b/client/web/src/marketing/toast/SurveyToast.test.tsx
@@ -10,6 +10,7 @@ import {
     InMemoryMockSettingsBackend,
     TemporarySettingsStorage,
 } from '@sourcegraph/shared/src/settings/temporary/TemporarySettingsStorage'
+import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
 import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
 import { type RenderWithBrandedContextResult, renderWithBrandedContext } from '@sourcegraph/wildcard/src/testing'
 
@@ -51,7 +52,7 @@ describe('SurveyToast', () => {
         return renderWithBrandedContext(
             <MockedTestProvider mocks={[submitSurveyMock]}>
                 <TemporarySettingsContext.Provider value={settingsStorage}>
-                    <SurveyToast authenticatedUser={mockAuthenticatedUser} />
+                    <SurveyToast authenticatedUser={mockAuthenticatedUser} telemetryRecorder={noOpTelemetryRecorder} />
                 </TemporarySettingsContext.Provider>
             </MockedTestProvider>
         )

--- a/client/web/src/marketing/toast/SurveyToastContent.tsx
+++ b/client/web/src/marketing/toast/SurveyToastContent.tsx
@@ -2,6 +2,8 @@ import React, { useEffect, useState } from 'react'
 
 import { gql, useMutation } from '@apollo/client'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
+
 import type { AuthenticatedUser } from '../../auth'
 import type { SubmitSurveyResult, SubmitSurveyVariables } from '../../graphql-operations'
 import { eventLogger } from '../../tracking/eventLogger'
@@ -31,7 +33,7 @@ enum ToastSteps {
     thankYou = 3,
 }
 
-interface SurveyToastContentProps {
+interface SurveyToastContentProps extends TelemetryV2Props {
     authenticatedUser: AuthenticatedUser | null
     shouldTemporarilyDismiss: () => void
     shouldPermanentlyDismiss: () => void
@@ -43,6 +45,7 @@ export const SurveyToastContent: React.FunctionComponent<React.PropsWithChildren
     shouldTemporarilyDismiss,
     shouldPermanentlyDismiss,
     hideToast,
+    telemetryRecorder,
 }) => {
     const [togglePermanentlyDismiss, setTogglePermanentlyDismiss] = useState(false)
     const [toggleErrorMessage, setToggleErrorMessage] = useState<boolean>(false)
@@ -56,7 +59,8 @@ export const SurveyToastContent: React.FunctionComponent<React.PropsWithChildren
 
     useEffect(() => {
         eventLogger.log('SurveyReminderViewed')
-    }, [])
+        telemetryRecorder.recordEvent('surveyNPS.toast', 'view')
+    }, [telemetryRecorder])
 
     /**
      * We set dismissal state when either:
@@ -100,12 +104,14 @@ export const SurveyToastContent: React.FunctionComponent<React.PropsWithChildren
             // No need to submit, but we want to ensure user isn't bothered by the toast again before exiting
             setFutureVisibility()
         }
+        telemetryRecorder.recordEvent('surveyNPS', 'dismiss')
 
         hideToast()
     }
 
     const handleUseCaseDone = async (): Promise<void> => {
         await submitSurvey({ variables: { input: userFeedback } })
+        telemetryRecorder.recordEvent('surveyNPS', 'submit')
         handleContinue()
     }
 
@@ -119,6 +125,7 @@ export const SurveyToastContent: React.FunctionComponent<React.PropsWithChildren
                     onContinue={handleContinue}
                     setToggledPermanentlyDismiss={setTogglePermanentlyDismiss}
                     toggleErrorMessage={toggleErrorMessage}
+                    telemetryRecorder={telemetryRecorder}
                 />
             )
         }

--- a/client/web/src/marketing/toast/SurveyToastTrigger.tsx
+++ b/client/web/src/marketing/toast/SurveyToastTrigger.tsx
@@ -35,14 +35,14 @@ export const SurveyToastTrigger: React.FunctionComponent<React.PropsWithChildren
     const [shouldShow, setShouldShow] = useState(false)
 
     useEffect(() => {
-        if (!loadingTemporarySettings || true) {
+        if (!loadingTemporarySettings) {
             /**
              * We show a toast notification if:
              * 1. User has not recently dismissed the notification
              * 2. User has not permanently dismissed the notification
              * 3. User has been active for exactly 3 days OR it has been 30 days since they were last shown the notification
              */
-            setShouldShow((!temporarilyDismissed && !permanentlyDismissed && daysActiveCount % 30 === 3) || true)
+            setShouldShow(!temporarilyDismissed && !permanentlyDismissed && daysActiveCount % 30 === 3)
         }
 
         /**

--- a/client/web/src/marketing/toast/SurveyToastTrigger.tsx
+++ b/client/web/src/marketing/toast/SurveyToastTrigger.tsx
@@ -1,12 +1,13 @@
 import React, { useEffect, useState } from 'react'
 
 import { useTemporarySetting } from '@sourcegraph/shared/src/settings/temporary/useTemporarySetting'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 
 import type { AuthenticatedUser } from '../../auth'
 
 import { SurveyToastContent } from './SurveyToastContent'
 
-interface SurveyToastTriggerProps {
+interface SurveyToastTriggerProps extends TelemetryV2Props {
     /**
      * For Storybook only
      */
@@ -17,6 +18,7 @@ interface SurveyToastTriggerProps {
 export const SurveyToastTrigger: React.FunctionComponent<React.PropsWithChildren<SurveyToastTriggerProps>> = ({
     forceVisible,
     authenticatedUser,
+    telemetryRecorder,
 }) => {
     const [temporarilyDismissed, setTemporarilyDismissed] = useTemporarySetting(
         'npsSurvey.hasTemporarilyDismissed',
@@ -33,14 +35,14 @@ export const SurveyToastTrigger: React.FunctionComponent<React.PropsWithChildren
     const [shouldShow, setShouldShow] = useState(false)
 
     useEffect(() => {
-        if (!loadingTemporarySettings) {
+        if (!loadingTemporarySettings || true) {
             /**
              * We show a toast notification if:
              * 1. User has not recently dismissed the notification
              * 2. User has not permanently dismissed the notification
              * 3. User has been active for exactly 3 days OR it has been 30 days since they were last shown the notification
              */
-            setShouldShow(!temporarilyDismissed && !permanentlyDismissed && daysActiveCount % 30 === 3)
+            setShouldShow((!temporarilyDismissed && !permanentlyDismissed && daysActiveCount % 30 === 3) || true)
         }
 
         /**
@@ -69,6 +71,7 @@ export const SurveyToastTrigger: React.FunctionComponent<React.PropsWithChildren
             shouldTemporarilyDismiss={() => setTemporarilyDismissed(true)}
             shouldPermanentlyDismiss={() => setPermanentlyDismissed(true)}
             hideToast={() => setShouldShow(false)}
+            telemetryRecorder={telemetryRecorder}
         />
     )
 }

--- a/client/web/src/marketing/toast/SurveyUserRatingToast.tsx
+++ b/client/web/src/marketing/toast/SurveyUserRatingToast.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import { Button, Checkbox, Link, Text } from '@sourcegraph/wildcard'
 
 import { SurveyRatingRadio } from '../components/SurveyRatingRadio'
@@ -8,7 +9,7 @@ import { Toast } from './Toast'
 
 import styles from './SurveyUserRatingToast.module.scss'
 
-export interface SurveyUserRatingToastProps {
+export interface SurveyUserRatingToastProps extends TelemetryV2Props {
     score: number
     onChange: (score: number) => void
     toggleErrorMessage: boolean
@@ -24,6 +25,7 @@ export const SurveyUserRatingToast: React.FunctionComponent<SurveyUserRatingToas
     onDismiss,
     onContinue,
     setToggledPermanentlyDismiss,
+    telemetryRecorder,
 }) => (
     <Toast
         title="Tell us what you think"
@@ -32,7 +34,12 @@ export const SurveyUserRatingToast: React.FunctionComponent<SurveyUserRatingToas
         }
         cta={
             <>
-                <SurveyRatingRadio ariaLabelledby="survey-toast-scores" score={score} onChange={onChange} />
+                <SurveyRatingRadio
+                    ariaLabelledby="survey-toast-scores"
+                    score={score}
+                    onChange={onChange}
+                    telemetryRecorder={telemetryRecorder}
+                />
                 {toggleErrorMessage && (
                     <div className={styles.alertDanger} role="alert">
                         Please select a score between 0 to 10

--- a/client/web/src/routes.tsx
+++ b/client/web/src/routes.tsx
@@ -322,7 +322,11 @@ export const routes: RouteObject[] = [
     },
     {
         path: PageRoutes.Survey,
-        element: <LegacyRoute render={props => <SurveyPage {...props} />} />,
+        element: (
+            <LegacyRoute
+                render={props => <SurveyPage {...props} telemetryRecorder={props.platformContext.telemetryRecorder} />}
+            />
+        ),
     },
     {
         path: PageRoutes.Help,

--- a/client/web/src/storm/pages/LayoutPage/LayoutPage.tsx
+++ b/client/web/src/storm/pages/LayoutPage/LayoutPage.tsx
@@ -191,7 +191,10 @@ export const Layout: React.FC<LegacyLayoutProps> = props => {
 
             <GlobalAlerts authenticatedUser={props.authenticatedUser} />
             {!isSiteInit && !isSignInOrUp && !props.isSourcegraphDotCom && !disableFeedbackSurvey && (
-                <SurveyToast authenticatedUser={props.authenticatedUser} />
+                <SurveyToast
+                    authenticatedUser={props.authenticatedUser}
+                    telemetryRecorder={props.platformContext.telemetryRecorder}
+                />
             )}
             {!isSiteInit && props.isSourcegraphDotCom && props.authenticatedUser && (
                 <CodySurveyToast


### PR DESCRIPTION
Context:

* https://github.com/sourcegraph/sourcegraph/pull/60127
* https://github.com/sourcegraph/sourcegraph/pull/60192
* https://github.com/sourcegraph/sourcegraph/pull/60219
* https://github.com/sourcegraph/sourcegraph/pull/60343
* https://github.com/sourcegraph/sourcegraph/pull/60377
* https://github.com/sourcegraph/sourcegraph/pull/60382
* https://github.com/sourcegraph/sourcegraph/pull/60764
* https://github.com/sourcegraph/sourcegraph/pull/60765
* https://github.com/sourcegraph/sourcegraph/pull/60767
* https://github.com/sourcegraph/sourcegraph/pull/60768
* https://github.com/sourcegraph/sourcegraph/pull/60788
* https://github.com/sourcegraph/sourcegraph/pull/60789
* https://github.com/sourcegraph/sourcegraph/pull/60803
* https://github.com/sourcegraph/sourcegraph/pull/60812
* https://github.com/sourcegraph/sourcegraph/pull/60850
* https://github.com/sourcegraph/sourcegraph/pull/60851
* https://github.com/sourcegraph/sourcegraph/pull/60939
* https://github.com/sourcegraph/sourcegraph/pull/60971
* https://github.com/sourcegraph/sourcegraph/pull/61205

## Test plan

`sg start`
visit page
check if events appear in `event_logs` table locally