### PR TITLE
Add syntactic indexing experimental feature (disabled)

### DIFF
--- a/schema/schema.go
+++ b/schema/schema.go
@@ -2576,8 +2576,10 @@ type SettingsExperimentalFeatures struct {
 	// ShowMultilineSearchConsole description: Enables the multiline search console at search/console
 	ShowMultilineSearchConsole *bool `json:"showMultilineSearchConsole,omitempty"`
 	// SymbolKindTags description: Show the initial letter of the symbol kind instead of icons.
-	SymbolKindTags bool           `json:"symbolKindTags,omitempty"`
-	Additional     map[string]any `json:"-"` // additionalProperties not explicitly defined in the schema
+	SymbolKindTags bool `json:"symbolKindTags,omitempty"`
+	// SyntacticIndexing description: Whether syntactic indexing is enabled
+	SyntacticIndexing bool           `json:"syntacticIndexing,omitempty"`
+	Additional        map[string]any `json:"-"` // additionalProperties not explicitly defined in the schema
 }
 
 func (v SettingsExperimentalFeatures) MarshalJSON() ([]byte, error) {
@@ -2638,6 +2640,7 @@ func (v *SettingsExperimentalFeatures) UnmarshalJSON(data []byte) error {
 	delete(m, "showCodeMonitoringLogs")
 	delete(m, "showMultilineSearchConsole")
 	delete(m, "symbolKindTags")
+	delete(m, "syntacticIndexing")
 	if len(m) > 0 {
 		v.Additional = make(map[string]any, len(m))
 	}

--- a/schema/settings.schema.json
+++ b/schema/settings.schema.json
@@ -227,6 +227,11 @@
           "description": "Whether to enable the 'keyword search' language improvement",
           "type": "boolean",
           "default": true
+        },
+        "syntacticIndexing": {
+          "description": "Whether syntactic indexing is enabled",
+          "type": "boolean",
+          "default": false
         }
       },
       "group": "Experimental"


### PR DESCRIPTION
We seem to have

- Feature flags: https://sourcegraph.com/docs/dev/how-to/use_feature_flags#when-to-use-feature-flags - **I don't think they fit here**
- Site config: https://sourcegraph.com/docs/admin/config/site_config - designed to be enabled/disabled by site admins. **At this point, I don't think this should be an admin-facing setting**
- Settings? https://sourcegraph.com/docs/admin/config/settings. Which seem to contain `experimentalFeatures` object that contains features similar to what we're building: https://sourcegraph.com/docs/admin/how-to/enable-experimental-feature. **Let's put it there**

The `schema.go` file is generated automatically.

## Test plan

N/A

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
