### PR TITLE
PLG: Add "no subscription" alert

### DIFF
--- a/client/web/src/cody/subscription/CodySubscriptionPage.module.scss
+++ b/client/web/src/cody/subscription/CodySubscriptionPage.module.scss
@@ -17,6 +17,10 @@
     font-size: 1.25rem;
 }
 
+.overflow-visible {
+    overflow: visible;
+}
+
 .ide-name {
     font-size: 1rem;
 }

--- a/client/web/src/cody/subscription/CodySubscriptionPage.tsx
+++ b/client/web/src/cody/subscription/CodySubscriptionPage.tsx
@@ -59,7 +59,9 @@ export const CodySubscriptionPage: React.FunctionComponent<CodySubscriptionPageP
     const parameters = useSearchParameters()
 
     const utm_source = parameters.get('utm_source')
-    const redirectedForNoSubscription = useMemo(() => parameters.get('noSubscription') === '1', [parameters])
+
+    // Used when redirected from the SSC site for not having a subscription.
+    const showNoSubscriptionMessage = useMemo(() => parameters.get('noSubscription') === '1', [parameters])
 
     const codyPaymentsUrl = useCodyPaymentsUrl()
     const manageSubscriptionRedirectURL = `${codyPaymentsUrl}/cody/subscription`
@@ -93,7 +95,7 @@ export const CodySubscriptionPage: React.FunctionComponent<CodySubscriptionPageP
         <>
             <Page className={classNames('d-flex flex-column')}>
                 <PageTitle title="Cody Subscription" />
-                {redirectedForNoSubscription && (
+                {showNoSubscriptionMessage && (
                     <Alert variant="primary" className={styles.overflowVisible}>
                         No subscription exists.
                     </Alert>

--- a/client/web/src/cody/subscription/CodySubscriptionPage.tsx
+++ b/client/web/src/cody/subscription/CodySubscriptionPage.tsx
@@ -1,5 +1,4 @@
-import type { ReactElement } from 'react'
-import React, { useEffect } from 'react'
+import React, { type ReactElement, useMemo, useEffect } from 'react'
 
 import { mdiArrowLeft, mdiInformationOutline, mdiTrendingUp, mdiCreditCardOutline } from '@mdi/js'
 import classNames from 'classnames'
@@ -115,12 +114,10 @@ export const CodySubscriptionPage: React.FunctionComponent<CodySubscriptionPageP
                         </div>
                     </PageHeader.Heading>
                 </PageHeader>
-
                 <Link to="/cody/manage" className="my-4">
                     <Icon className="mr-1 text-link" svgPath={mdiArrowLeft} aria-hidden={true} />
                     Back to Cody Dashboard
                 </Link>
-
                 <div className={classNames('d-flex mt-4', styles.responsiveContainer)}>
                     <div className="border d-flex flex-column flex-1 bg-1 rounded">
                         <div className="p-4">
@@ -173,7 +170,7 @@ export const CodySubscriptionPage: React.FunctionComponent<CodySubscriptionPageP
                                         <Icon
                                             className="ml-1 text-muted"
                                             svgPath={mdiInformationOutline}
-                                            aria-hidden={true}
+                                            aria-label="More info"
                                         />
                                     </Tooltip>
                                 </Text>
@@ -183,7 +180,7 @@ export const CodySubscriptionPage: React.FunctionComponent<CodySubscriptionPageP
                                         <Icon
                                             className="ml-1 text-muted"
                                             svgPath={mdiInformationOutline}
-                                            aria-hidden={true}
+                                            aria-label="More info"
                                         />
                                     </Tooltip>
                                 </Text>
@@ -193,7 +190,7 @@ export const CodySubscriptionPage: React.FunctionComponent<CodySubscriptionPageP
                                         <Icon
                                             className="ml-1 text-muted"
                                             svgPath={mdiInformationOutline}
-                                            aria-hidden={true}
+                                            aria-label="More info"
                                         />
                                     </Tooltip>
                                 </Text>
@@ -286,7 +283,7 @@ export const CodySubscriptionPage: React.FunctionComponent<CodySubscriptionPageP
                                         <Icon
                                             className="ml-1 text-muted"
                                             svgPath={mdiInformationOutline}
-                                            aria-hidden={true}
+                                            aria-label="More info"
                                         />
                                     </Tooltip>
                                 </Text>
@@ -303,7 +300,7 @@ export const CodySubscriptionPage: React.FunctionComponent<CodySubscriptionPageP
                                         <Icon
                                             className="ml-1 text-muted"
                                             svgPath={mdiInformationOutline}
-                                            aria-hidden={true}
+                                            aria-label="More info"
                                         />
                                     </Tooltip>
                                 </Text>
@@ -313,7 +310,7 @@ export const CodySubscriptionPage: React.FunctionComponent<CodySubscriptionPageP
                                         <Icon
                                             className="ml-1 text-muted"
                                             svgPath={mdiInformationOutline}
-                                            aria-hidden={true}
+                                            aria-label="More info"
                                         />
                                     </Tooltip>
                                 </Text>
@@ -323,7 +320,7 @@ export const CodySubscriptionPage: React.FunctionComponent<CodySubscriptionPageP
                                         <Icon
                                             className="ml-1 text-muted"
                                             svgPath={mdiInformationOutline}
-                                            aria-hidden={true}
+                                            aria-label="More info"
                                         />
                                     </Tooltip>
                                 </Text>
@@ -336,7 +333,7 @@ export const CodySubscriptionPage: React.FunctionComponent<CodySubscriptionPageP
                             </div>
                         </div>
                     </div>
-                    <div className="border d-flex flex-column flex-1 bg-1 border p-3 rounded">
+                    <div className="border d-flex flex-column flex-1 bg-1 p-3 rounded">
                         <div className="border-bottom pb-4">
                             <H1 className="mb-1 d-flex align-items-center">Enterprise</H1>
                             <Text className="mb-0" size="small">
@@ -399,7 +396,7 @@ export const CodySubscriptionPage: React.FunctionComponent<CodySubscriptionPageP
                                     <Icon
                                         className="ml-1 text-muted"
                                         svgPath={mdiInformationOutline}
-                                        aria-hidden={true}
+                                        aria-label="More info"
                                     />
                                 </Tooltip>
                             </Text>
@@ -409,7 +406,7 @@ export const CodySubscriptionPage: React.FunctionComponent<CodySubscriptionPageP
                                     <Icon
                                         className="ml-1 text-muted"
                                         svgPath={mdiInformationOutline}
-                                        aria-hidden={true}
+                                        aria-label="More info"
                                     />
                                 </Tooltip>
                             </Text>
@@ -433,7 +430,7 @@ export const CodySubscriptionPage: React.FunctionComponent<CodySubscriptionPageP
                                     <Icon
                                         className="ml-1 text-muted"
                                         svgPath={mdiInformationOutline}
-                                        aria-hidden={true}
+                                        aria-label="More info"
                                     />
                                 </Tooltip>
                             </Text>

--- a/client/web/src/cody/subscription/CodySubscriptionPage.tsx
+++ b/client/web/src/cody/subscription/CodySubscriptionPage.tsx
@@ -18,6 +18,7 @@ import {
     Text,
     Tooltip,
     useSearchParameters,
+    Alert,
 } from '@sourcegraph/wildcard'
 
 import type { AuthenticatedUser } from '../../auth'
@@ -58,6 +59,7 @@ export const CodySubscriptionPage: React.FunctionComponent<CodySubscriptionPageP
     const parameters = useSearchParameters()
 
     const utm_source = parameters.get('utm_source')
+    const redirectedForNoSubscription = useMemo(() => parameters.get('noSubscription') === '1', [parameters])
 
     const codyPaymentsUrl = useCodyPaymentsUrl()
     const manageSubscriptionRedirectURL = `${codyPaymentsUrl}/cody/subscription`
@@ -91,6 +93,11 @@ export const CodySubscriptionPage: React.FunctionComponent<CodySubscriptionPageP
         <>
             <Page className={classNames('d-flex flex-column')}>
                 <PageTitle title="Cody Subscription" />
+                {redirectedForNoSubscription && (
+                    <Alert variant="primary" className={styles.overflowVisible}>
+                        No subscription exists.
+                    </Alert>
+                )}
                 <PageHeader
                     className="mb-4"
                     actions={


### PR DESCRIPTION
- Part of https://github.com/sourcegraph/self-serve-cody/issues/506

I had to add an unexpected CSS rule to get the alert to display correctly because of its parent having `display: flex`.

Unrelated: fixed a few warnings around aria labels to improve accessibility.

## Test plan

Ran locally. This is how it looks: 
![CleanShot 2024-03-28 at 15 03 36@2x](https://github.com/sourcegraph/sourcegraph/assets/2552265/d73bfe58-74a1-4917-b125-c4f5de146589)
