### PR TITLE
PLG: Redirect user from /get-cody if unauthed

### DIFF
--- a/client/web/src/get-cody/GetCodyPage.tsx
+++ b/client/web/src/get-cody/GetCodyPage.tsx
@@ -53,6 +53,8 @@ export const GetCodyPage: React.FunctionComponent<GetCodyPageProps> = ({ authent
     useEffect(() => {
         if (authenticatedUser) {
             navigate(`/cody/manage${search || ''}`)
+        } else {
+            navigate('/cody')
         }
     }, [authenticatedUser, navigate, search])
 


### PR DESCRIPTION
- Closes https://github.com/sourcegraph/sourcegraph/issues/60679

Just a very simple two-line change.

## Test plan

Tested authed and un-authed with and without the change: I could repro the old behavior and saw that this change fixes it. See it work in this 1-min Loom: https://www.loom.com/share/056ebfe326244c18966e1500e735fa49