### PR TITLE
bazel: add prometheus-gcp image

### DIFF
--- a/dev/ci/push_all.sh
+++ b/dev/ci/push_all.sh
@@ -65,6 +65,10 @@ function create_push_command() {
     repository="scip-ctags"
   fi
 
+  if [[ "$target" == "//docker-images/prometheus:gcp_candidate_push" ]]; then
+    repository="prometheus-gcp"
+  fi
+
   repositories_args=""
   for registry in "${registries[@]}"; do
     repositories_args="$repositories_args --repository ${registry}/${repository}"

--- a/docker-images/prometheus/BUILD.bazel
+++ b/docker-images/prometheus/BUILD.bazel
@@ -60,3 +60,35 @@ oci_push(
     image = ":image",
     repository = image_repository("prometheus"),
 )
+
+oci_image(
+    name = "image_gcp",
+    base = "@wolfi_prometheus_gcp_base",
+    entrypoint = ["/bin/prom-wrapper"],
+    tars = [":config_tar"],
+    user = "sourcegraph",
+)
+
+oci_tarball(
+    name = "image_gcp_tarball",
+    image = ":image_gcp",
+    repo_tags = ["prometheus-gcp:candidate"],
+)
+
+container_structure_test(
+    name = "image_gcp_test",
+    timeout = "short",
+    configs = ["image_test.yaml"],
+    driver = "docker",
+    image = ":image_gcp",
+    tags = [
+        "exclusive",
+        "requires-network",
+    ],
+)
+
+oci_push(
+    name = "gcp_candidate_push",
+    image = ":image_gcp",
+    repository = image_repository("prometheus-gcp"),
+)


### PR DESCRIPTION
EDIT

In light of https://github.com/sourcegraph/sourcegraph/pull/58484 seems this was purposely removed

## Test plan
https://buildkite.com/sourcegraph/sourcegraph/builds/266763