### PR TITLE
k8s/resource: Add pkg for creating k8s configmap resources

### DIFF
--- a/internal/k8s/resource/configmap/BUILD.bazel
+++ b/internal/k8s/resource/configmap/BUILD.bazel
@@ -1,0 +1,31 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("//dev:go_defs.bzl", "go_test")
+
+go_library(
+    name = "configmap",
+    srcs = ["configmap.go"],
+    importpath = "github.com/sourcegraph/sourcegraph/internal/k8s/resource/configmap",
+    visibility = ["//:__subpackages__"],
+    deps = [
+        "//internal/maps",
+        "//lib/pointers",
+        "@io_k8s_api//core/v1:core",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:meta",
+    ],
+)
+
+go_test(
+    name = "configmap_test",
+    srcs = [
+        "configmap_test.go",
+        "example_test.go",
+    ],
+    embed = [":configmap"],
+    deps = [
+        "//lib/pointers",
+        "@com_github_google_go_cmp//cmp",
+        "@io_k8s_api//core/v1:core",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:meta",
+        "@io_k8s_sigs_yaml//:yaml",
+    ],
+)

--- a/internal/k8s/resource/configmap/configmap.go
+++ b/internal/k8s/resource/configmap/configmap.go
@@ -1,0 +1,81 @@
+package configmap
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/sourcegraph/sourcegraph/internal/maps"
+	"github.com/sourcegraph/sourcegraph/lib/pointers"
+)
+
+// NewConfigMap creates a new k8s ConfigMap with default values.
+//
+// Default values include:
+//
+//   - Immutable set to false.
+//
+// Additional options can be passed to modify the default values.
+func NewConfigMap(name, namespace string, options ...Option) (corev1.ConfigMap, error) {
+	configMap := corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				"deploy": "sourcegraph",
+			},
+		},
+		Immutable: pointers.Ptr(false),
+	}
+
+	// apply any given options
+	for _, opt := range options {
+		err := opt(&configMap)
+		if err != nil {
+			return corev1.ConfigMap{}, err
+		}
+	}
+	return configMap, nil
+}
+
+// Option sets an option for a ConfigMap.
+type Option func(configMap *corev1.ConfigMap) error
+
+// WithLabels set ConfigMap labels without overriding existing labels.
+func WithLabels(labels map[string]string) Option {
+	return func(configMap *corev1.ConfigMap) error {
+		configMap.Labels = maps.MergePreservingExistingKeys(configMap.Labels, labels)
+		return nil
+	}
+}
+
+// WithAnnotations set ConfigMap annotations without overriding existing annotations.
+func WithAnnotations(annotations map[string]string) Option {
+	return func(configMap *corev1.ConfigMap) error {
+		configMap.Annotations = maps.MergePreservingExistingKeys(configMap.Annotations, annotations)
+		return nil
+	}
+}
+
+// Immutable sets a ConfigMap to be immutable.
+func Immutable() Option {
+	return func(configMap *corev1.ConfigMap) error {
+		configMap.Immutable = pointers.Ptr(true)
+		return nil
+	}
+}
+
+// WithData sets the given string data to a ConfigMap.
+func WithData(data map[string]string) Option {
+	return func(configMap *corev1.ConfigMap) error {
+		configMap.Data = data
+		return nil
+	}
+}
+
+// WithBinaryData sets the given binary data to a ConfigMap.
+func WithBinaryData(data map[string][]byte) Option {
+	return func(configMap *corev1.ConfigMap) error {
+		configMap.BinaryData = data
+		return nil
+	}
+}

--- a/internal/k8s/resource/configmap/configmap_test.go
+++ b/internal/k8s/resource/configmap/configmap_test.go
@@ -1,0 +1,177 @@
+package configmap
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/sourcegraph/sourcegraph/lib/pointers"
+)
+
+func TestNewConfigMap(t *testing.T) {
+	t.Parallel()
+
+	type args struct {
+		name      string
+		namespace string
+		options   []Option
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want corev1.ConfigMap
+	}{
+		{
+			name: "default configmap",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+			},
+			want: corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph",
+					},
+				},
+				Immutable: pointers.Ptr(false),
+			},
+		},
+		{
+			name: "with labels",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithLabels(map[string]string{
+						"foo": "bar",
+					}),
+				},
+			},
+			want: corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph",
+						"foo":    "bar",
+					},
+				},
+				Immutable: pointers.Ptr(false),
+			},
+		},
+		{
+			name: "with annotations",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithAnnotations(map[string]string{
+						"foo": "bar",
+					}),
+				},
+			},
+			want: corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph",
+					},
+					Annotations: map[string]string{
+						"foo": "bar",
+					},
+				},
+				Immutable: pointers.Ptr(false),
+			},
+		},
+		{
+			name: "immutable",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					Immutable(),
+				},
+			},
+			want: corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph",
+					},
+				},
+				Immutable: pointers.Ptr(true),
+			},
+		},
+		{
+			name: "with data",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithData(map[string]string{
+						"data": "foo",
+					}),
+				},
+			},
+			want: corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph",
+					},
+				},
+				Immutable: pointers.Ptr(false),
+				Data: map[string]string{
+					"data": "foo",
+				},
+			},
+		},
+		{
+			name: "with binary data",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithBinaryData(map[string][]byte{
+						"data": []byte("foo"),
+					}),
+				},
+			},
+			want: corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph",
+					},
+				},
+				Immutable: pointers.Ptr(false),
+				Data:      nil,
+				BinaryData: map[string][]byte{
+					"data": []byte("foo"),
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := NewConfigMap(tt.args.name, tt.args.namespace, tt.args.options...)
+			if err != nil {
+				t.Errorf("NewConfigMap() error: %v", err)
+			}
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("NewConfigMap() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/internal/k8s/resource/configmap/example_test.go
+++ b/internal/k8s/resource/configmap/example_test.go
@@ -1,0 +1,28 @@
+package configmap
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"sigs.k8s.io/yaml"
+)
+
+func ExampleConfigMap() {
+	cm, _ := NewConfigMap("test", "sourcegraph")
+
+	jcm, _ := json.Marshal(cm)
+	fmt.Println(string(jcm))
+
+	ycm, _ := yaml.Marshal(cm)
+	fmt.Println(string(ycm))
+
+	// Output:
+	// {"metadata":{"name":"test","namespace":"sourcegraph","creationTimestamp":null,"labels":{"deploy":"sourcegraph"}},"immutable":false}
+	// immutable: false
+	// metadata:
+	//   creationTimestamp: null
+	//   labels:
+	//     deploy: sourcegraph
+	//   name: test
+	//   namespace: sourcegraph
+}


### PR DESCRIPTION
Add `configmap` pkg to create k8s configmaps with patterns and defaults common to Sourcegraph.



## Test plan

Full unit test coverage as well as testable examples

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
