### PR TITLE
release: add sg command for sending calendar invites

### DIFF
--- a/dev/release/calendar.jsonc
+++ b/dev/release/calendar.jsonc
@@ -1,5 +1,7 @@
 {
     "teamEmail": "team@sourcegraph.com",
+    // these dates should always be in sync with the Sourcegraph Handbook release schedule
+    // https://handbook.sourcegraph.com/departments/engineering/dev/process/releases/#release-schedule
     "events": [
         {
             "name": "March 2024 Release",

--- a/dev/release/calendar.jsonc
+++ b/dev/release/calendar.jsonc
@@ -1,0 +1,23 @@
+{
+    "teamEmail": "team@sourcegraph.com",
+    "events": [
+        {
+            "name": "March 2024 Release",
+            "codeFreezeDate": "2024-03-06T09:00:00-07:00",
+            "monthlyReleaseDate": "2024-03-08T09:00:00-07:00",
+            "patchReleaseDate": "2024-03-20T09:00:00-07:00"
+        },
+        {
+            "name": "April 2024 Release",
+            "codeFreezeDate": "2024-04-03T09:00:00-07:00",
+            "monthlyReleaseDate": "2024-04-05T09:00:00-07:00",
+            "patchReleaseDate": "2024-04-22T09:00:00-07:00"
+        },
+        {
+            "name": "May 2024 Release",
+            "codeFreezeDate": "2024-05-02T09:00:00-07:00",
+            "monthlyReleaseDate": "2024-05-06T09:00:00-07:00",
+            "patchReleaseDate": "2024-05-20T09:00:00-07:00"
+        }
+    ]
+}

--- a/dev/sg/internal/release/BUILD.bazel
+++ b/dev/sg/internal/release/BUILD.bazel
@@ -4,6 +4,7 @@ load("//dev:go_defs.bzl", "go_test")
 go_library(
     name = "release",
     srcs = [
+        "calendar.go",
         "config.go",
         "cve.go",
         "release.go",
@@ -14,12 +15,18 @@ go_library(
         "//dev/sg/internal/bk",
         "//dev/sg/internal/category",
         "//dev/sg/internal/std",
+        "//internal/jsonc",
         "//lib/errors",
         "//lib/output",
         "@com_github_grafana_regexp//:regexp",
+        "@com_github_pkg_browser//:browser",
         "@com_github_sourcegraph_run//:run",
         "@com_github_urfave_cli_v2//:cli",
         "@in_gopkg_yaml_v3//:yaml_v3",
+        "@org_golang_google_api//calendar/v3:calendar",
+        "@org_golang_google_api//option",
+        "@org_golang_x_oauth2//:oauth2",
+        "@org_golang_x_oauth2//google",
     ],
 )
 

--- a/dev/sg/internal/release/calendar.go
+++ b/dev/sg/internal/release/calendar.go
@@ -1,0 +1,231 @@
+package release
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/pkg/browser"
+	"github.com/urfave/cli/v2"
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/google"
+	"google.golang.org/api/calendar/v3"
+	"google.golang.org/api/option"
+
+	"github.com/sourcegraph/sourcegraph/dev/sg/internal/std"
+	"github.com/sourcegraph/sourcegraph/internal/jsonc"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"github.com/sourcegraph/sourcegraph/lib/output"
+)
+
+type Event struct {
+	Name               string    `json:"name"`
+	CodeFreezeDate     time.Time `json:"codeFreezeDate"`
+	MonthlyReleaseDate time.Time `json:"monthlyReleaseDate"`
+	PatchReleaseDate   time.Time `json:"patchReleaseDate"`
+}
+
+type CalendarConfig struct {
+	TeamEmail string  `json:"teamEmail"`
+	Events    []Event `json:"events"`
+}
+
+func generateCalendarEvents(cctx *cli.Context) error {
+	configPath := cctx.String("config")
+	if configPath == "" {
+		return errors.New("config path is required")
+	}
+
+	f, err := os.ReadFile(configPath)
+	if err != nil {
+		return err
+	}
+
+	var cc CalendarConfig
+	if err := jsonc.Unmarshal(string(f), &cc); err != nil {
+		return err
+	}
+
+	client, err := getGoogleCalClient(cctx.Context)
+	if err != nil {
+		return err
+	}
+
+	now := time.Now()
+	for _, e := range cc.Events {
+		p := std.Out.Pending(output.Styledf(output.StylePending, "Processing Calendar event: %q", e.Name))
+		if e.MonthlyReleaseDate.Before(now) || e.PatchReleaseDate.Before(now) {
+			p.Complete(output.Linef(output.EmojiWarning, output.StyleWarning, "Skipping event: %q because the date is in the past.", e.Name))
+			continue
+		}
+
+		// p.Updatef("Creating Code Freeze event for %q", e.Name)
+		codeFreezeEvt := createReleaseEvent(cc.TeamEmail, fmt.Sprintf("Code Freeze: (%s)", e.Name), e.CodeFreezeDate)
+		_, err := client.Events.Insert("primary", codeFreezeEvt).Context(cctx.Context).Do()
+		if err != nil {
+			p.Destroy()
+			fmt.Println(err.Error(), "<===")
+			return errors.Wrapf(err, "Failed to create Code Freeze event for %q", e.Name)
+		}
+
+		p.Updatef("Creating Monthly Release event for %q", e.Name)
+		monthlyReleaseEvt := createReleaseEvent(cc.TeamEmail, fmt.Sprintf("Monthly Release: (%s)", e.Name), e.MonthlyReleaseDate)
+		_, err = client.Events.Insert("primary", monthlyReleaseEvt).Context(cctx.Context).Do()
+		if err != nil {
+			p.Destroy()
+			return errors.Wrapf(err, "Failed to create monthly release event for %q", e.Name)
+		}
+
+		p.Updatef("Creating Patch Release event for %q", e.Name)
+		patchReleaseEvt := createReleaseEvent(cc.TeamEmail, fmt.Sprintf("Patch Release: (%s)", e.Name), e.PatchReleaseDate)
+		_, err = client.Events.Insert("primary", patchReleaseEvt).Context(cctx.Context).Do()
+		if err != nil {
+			p.Destroy()
+			return errors.Wrapf(err, "Failed to create patch release event for %q", e.Name)
+		}
+
+		p.Complete(output.Linef(output.EmojiSuccess, output.StyleSuccess, "Sent and created event: %q", e.Name))
+	}
+
+	return nil
+}
+
+func createReleaseEvent(email, title string, eventTime time.Time) *calendar.Event {
+	startTime := eventTime.Format("2006-01-02T15:04:05.000-07:00")
+	endTime := eventTime.Add(time.Minute).Format("2006-01-02T15:04:05.000-07:00")
+	return &calendar.Event{
+		AnyoneCanAddSelf: true,
+		Summary:          title,
+		Description:      "(This is not an actual event to attend, just a calendar marker.)",
+		Location:         "Sourcegraph (Remote)",
+		Start: &calendar.EventDateTime{
+			DateTime: startTime,
+			TimeZone: "America/Los_Angeles",
+		},
+		End: &calendar.EventDateTime{
+			DateTime: endTime,
+			TimeZone: "America/Los_Angeles",
+		},
+		Attendees: []*calendar.EventAttendee{
+			{Email: email, Optional: true},
+		},
+	}
+}
+
+type GoogleCalendarCred struct {
+	Installed struct {
+		ClientID     string   `json:"client_id"`
+		ProjectID    string   `json:"project_id"`
+		AuthURI      string   `json:"auth_uri"`
+		TokenURI     string   `json:"token_uri"`
+		AuthProvider string   `json:"auth_provider_x509_cert_url"`
+		ClientSecret string   `json:"client_secret"`
+		RedirectURIs []string `json:"redirect_uris"`
+	}
+}
+
+func getGoogleCalClient(ctx context.Context) (*calendar.Service, error) {
+	credentialsJSON, err := std.Out.
+		PromptPasswordf(
+			os.Stdin,
+			`Paste Google Calendar credentials (1Password "Release automation Google Calendar API App credentials"): `,
+		)
+	if err != nil {
+		return nil, err
+	}
+
+	var creds GoogleCalendarCred
+	if err := json.Unmarshal([]byte(credentialsJSON), &creds); err != nil {
+		return nil, err
+	}
+
+	srv, err := createServer()
+	if err != nil {
+		return nil, err
+	}
+	defer srv.Close()
+
+	cfg := oauth2.Config{
+		ClientID:     creds.Installed.ClientID,
+		ClientSecret: creds.Installed.ClientSecret,
+		RedirectURL:  fmt.Sprintf("http://localhost%s", srv.Addr),
+		Endpoint:     google.Endpoint,
+		Scopes:       []string{"https://www.googleapis.com/auth/calendar.events"},
+	}
+	authUrl := cfg.AuthCodeURL("state", oauth2.AccessTypeOffline)
+
+	if err := browser.OpenURL(authUrl); err != nil {
+		return nil, err
+	}
+
+	// Wait for the authCode from the redirect
+	authCode, err := waitForAuthCode()
+	if err != nil {
+		return nil, err
+	}
+
+	token, err := cfg.Exchange(ctx, authCode)
+	if err != nil {
+		return nil, err
+	}
+
+	oauth2Client := cfg.Client(ctx, token)
+	return calendar.NewService(ctx, option.WithHTTPClient(oauth2Client))
+}
+
+// authCodeChan is used to communicate the auth code from the server handler to the waitForAuthCode function
+var authCodeChan = make(chan string)
+
+func createServer() (*http.Server, error) {
+	// Listen on a random port
+	listener, err := net.Listen("tcp", "")
+	if err != nil {
+		return nil, err
+	}
+
+	port := listener.Addr().(*net.TCPAddr).Port
+	server := &http.Server{
+		Addr: fmt.Sprintf(":%d", port),
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "text/plain")
+
+			q := r.URL.Query()
+			code := q.Get("code")
+			err := q.Get("error")
+
+			if err != "" {
+				fmt.Fprintf(w, "Authentication failed: %s", err)
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+
+			// fmt.Fprint(w, "Authentication successful! Please return to the console")
+			authCodeChan <- code
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte("Authentication successful! Please return to the console"))
+		}),
+	}
+
+	go func() {
+		defer listener.Close()
+		if err := server.Serve(listener); err != http.ErrServerClosed {
+			log.Fatalf("Failed to start server: %v", err)
+		}
+	}()
+
+	return server, nil
+}
+
+func waitForAuthCode() (string, error) {
+	select {
+	case authCode := <-authCodeChan:
+		return authCode, nil
+	case <-time.After(5 * time.Minute):
+		return "", errors.Newf("timeout waiting for auth code")
+	}
+}

--- a/dev/sg/internal/release/calendar.go
+++ b/dev/sg/internal/release/calendar.go
@@ -36,6 +36,7 @@ type CalendarConfig struct {
 }
 
 func generateCalendarEvents(cctx *cli.Context) error {
+	// config path: dev/release/calendar.jsonc
 	configPath := cctx.String("config")
 	if configPath == "" {
 		return errors.New("config path is required")

--- a/dev/sg/internal/release/calendar.go
+++ b/dev/sg/internal/release/calendar.go
@@ -64,7 +64,7 @@ func generateCalendarEvents(cctx *cli.Context) error {
 			continue
 		}
 
-		// p.Updatef("Creating Code Freeze event for %q", e.Name)
+		p.Updatef("Creating Code Freeze event for %q", e.Name)
 		codeFreezeEvt := createReleaseEvent(cc.TeamEmail, fmt.Sprintf("Code Freeze: (%s)", e.Name), e.CodeFreezeDate)
 		_, err := client.Events.Insert("primary", codeFreezeEvt).Context(cctx.Context).Do()
 		if err != nil {
@@ -204,10 +204,9 @@ func createServer() (*http.Server, error) {
 				return
 			}
 
-			// fmt.Fprint(w, "Authentication successful! Please return to the console")
 			authCodeChan <- code
 			w.WriteHeader(http.StatusOK)
-			w.Write([]byte("Authentication successful! Please return to the console"))
+			fmt.Fprint(w, "Authentication successful! Please return to the console")
 		}),
 	}
 

--- a/dev/sg/internal/release/calendar.go
+++ b/dev/sg/internal/release/calendar.go
@@ -153,7 +153,7 @@ func getGoogleCalClient(ctx context.Context) (*calendar.Service, error) {
 	cfg := oauth2.Config{
 		ClientID:     creds.Installed.ClientID,
 		ClientSecret: creds.Installed.ClientSecret,
-		RedirectURL:  fmt.Sprintf("http://localhost%s", srv.Addr),
+		RedirectURL:  fmt.Sprintf("http://localhost%s", srv.Addr), // CI:LOCALHOST_OK
 		Endpoint:     google.Endpoint,
 		Scopes:       []string{"https://www.googleapis.com/auth/calendar.events"},
 	}

--- a/dev/sg/internal/release/release.go
+++ b/dev/sg/internal/release/release.go
@@ -2,12 +2,14 @@ package release
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/sourcegraph/run"
+	"github.com/urfave/cli/v2"
+
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/category"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
-	"github.com/urfave/cli/v2"
 )
 
 // releaseBaseFlags are the flags that are common to all subcommands of the release command.
@@ -160,6 +162,27 @@ var Command = &cli.Command{
 					return err
 				}
 				return r.Promote(cctx.Context)
+			},
+		},
+		{
+			Name:      "calendar",
+			Usage:     "Generate a calendar events for releases",
+			Aliases:   []string{"cal"},
+			Category:  category.Util,
+			UsageText: "sg release calendar --config /path/to/calendar/config",
+			Action:    generateCalendarEvents,
+			Flags: []cli.Flag{
+				&cli.StringFlag{
+					Name:     "config",
+					Required: true,
+					Usage:    "Path to the calendar config file",
+					Action: func(ctx *cli.Context, s string) error {
+						if _, err := os.Stat(s); err != nil {
+							return errors.Newf("config file %q does not exist", s)
+						}
+						return nil
+					},
+				},
 			},
 		},
 	},

--- a/go.mod
+++ b/go.mod
@@ -566,7 +566,7 @@ require (
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/opsgenie/opsgenie-go-sdk-v2 v1.2.22
 	github.com/pandatix/go-cvss v0.5.2
-	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8 // indirect
+	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pkg/profile v1.7.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect


### PR DESCRIPTION
This PR adds a new subcommand to the `sg release` command. This command `cal` is used to send out calendar invites for upcoming releases. It also includes a new configuration file for defining the calendar dates and should always be in sync with the [Sourcegraph handbook release schedule](https://handbook.sourcegraph.com/departments/engineering/dev/process/releases/#release-schedule)

## Test plan

Sent out calendar invites for the monthly releases happening in April, 2024 and May, 2024


![CleanShot 2024-03-28 at 18 21 58@2x](https://github.com/sourcegraph/sourcegraph/assets/25608335/fb90a85e-43e8-44ca-913f-dc5643969d9d)
![CleanShot 2024-03-28 at 18 22 14@2x](https://github.com/sourcegraph/sourcegraph/assets/25608335/672520a0-39d0-4730-b7f1-3125e2dae97f)
