### PR TITLE
k8s/resource: Add pkg for creating k8s storageclass resources

### DIFF
--- a/internal/k8s/resource/storage/BUILD.bazel
+++ b/internal/k8s/resource/storage/BUILD.bazel
@@ -1,0 +1,33 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("//dev:go_defs.bzl", "go_test")
+
+go_library(
+    name = "storage",
+    srcs = ["storageclass.go"],
+    importpath = "github.com/sourcegraph/sourcegraph/internal/k8s/resource/storage",
+    visibility = ["//:__subpackages__"],
+    deps = [
+        "//internal/maps",
+        "//lib/pointers",
+        "@io_k8s_api//core/v1:core",
+        "@io_k8s_api//storage/v1:storage",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:meta",
+    ],
+)
+
+go_test(
+    name = "storage_test",
+    srcs = [
+        "example_test.go",
+        "storageclass_test.go",
+    ],
+    embed = [":storage"],
+    deps = [
+        "//lib/pointers",
+        "@com_github_google_go_cmp//cmp",
+        "@io_k8s_api//core/v1:core",
+        "@io_k8s_api//storage/v1:storage",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:meta",
+        "@io_k8s_sigs_yaml//:yaml",
+    ],
+)

--- a/internal/k8s/resource/storage/example_test.go
+++ b/internal/k8s/resource/storage/example_test.go
@@ -1,0 +1,31 @@
+package storage
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"sigs.k8s.io/yaml"
+)
+
+func ExampleStorageClass() {
+	sc, _ := NewStorageClass("test", "sourcegraph")
+
+	jsc, _ := json.Marshal(sc)
+	fmt.Println(string(jsc))
+
+	ysc, _ := yaml.Marshal(sc)
+	fmt.Println(string(ysc))
+
+	// Output:
+	// {"metadata":{"name":"test","namespace":"sourcegraph","creationTimestamp":null,"labels":{"deploy":"sourcegraph-storage"}},"provisioner":"","reclaimPolicy":"Retain","allowVolumeExpansion":true,"volumeBindingMode":"WaitForFirstConsumer"}
+	// allowVolumeExpansion: true
+	// metadata:
+	//   creationTimestamp: null
+	//   labels:
+	//     deploy: sourcegraph-storage
+	//   name: test
+	//   namespace: sourcegraph
+	// provisioner: ""
+	// reclaimPolicy: Retain
+	// volumeBindingMode: WaitForFirstConsumer
+}

--- a/internal/k8s/resource/storage/storageclass.go
+++ b/internal/k8s/resource/storage/storageclass.go
@@ -1,0 +1,121 @@
+package storage
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/sourcegraph/sourcegraph/internal/maps"
+	"github.com/sourcegraph/sourcegraph/lib/pointers"
+)
+
+// NewStorageClass creates a new k8s StorageClass with default values.
+//
+// Default values include:
+//
+//   - AllowVolumeExpansion: true
+//   - ReclaimPolicy: PersistentVolumeReclaimRetain
+//   - VolumeBindingMode: VolumeBindingWaitForFirstConsumer
+//
+// Additional options can be passed to modify the default values.
+func NewStorageClass(name, namespace string, options ...Option) (storagev1.StorageClass, error) {
+	storageClass := storagev1.StorageClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				"deploy": "sourcegraph-storage",
+			},
+		},
+		AllowVolumeExpansion: pointers.Ptr(true),
+		ReclaimPolicy:        pointers.Ptr(corev1.PersistentVolumeReclaimRetain),
+		VolumeBindingMode:    pointers.Ptr(storagev1.VolumeBindingWaitForFirstConsumer),
+	}
+
+	// apply any given options
+	for _, opt := range options {
+		err := opt(&storageClass)
+		if err != nil {
+			return storagev1.StorageClass{}, err
+		}
+	}
+
+	return storageClass, nil
+}
+
+// Option sets an option for a StorageClass.
+type Option func(storageClass *storagev1.StorageClass) error
+
+// WithLabels sets StorageClass labels without overriding existing labels.
+func WithLabels(labels map[string]string) Option {
+	return func(storageClass *storagev1.StorageClass) error {
+		storageClass.Labels = maps.MergePreservingExistingKeys(storageClass.Labels, labels)
+		return nil
+	}
+}
+
+// WithAnnotations sets StorageClass annotations without overriding existing annotations.
+func WithAnnotations(annotations map[string]string) Option {
+	return func(storageClass *storagev1.StorageClass) error {
+		storageClass.Annotations = maps.MergePreservingExistingKeys(storageClass.Annotations, annotations)
+		return nil
+	}
+}
+
+// WithType sets the given type on the StorageClass.
+func WithType(typeParam string) Option {
+	return func(storageClass *storagev1.StorageClass) error {
+		storageClass.Parameters = maps.Merge(storageClass.Parameters, map[string]string{
+			"type": typeParam,
+		})
+		return nil
+	}
+}
+
+// WithParameters sets the given parameters on the StorageClass.
+func WithParameters(params map[string]string) Option {
+	return func(storageClass *storagev1.StorageClass) error {
+		storageClass.Parameters = maps.MergePreservingExistingKeys(storageClass.Parameters, params)
+		return nil
+	}
+}
+
+// WithProvisioner sets the given provisioner on the StorageClass.
+func WithProvisioner(provisioner string) Option {
+	return func(storageClass *storagev1.StorageClass) error {
+		storageClass.Provisioner = provisioner
+		return nil
+	}
+}
+
+// WithReclaimPolicy sets the given PersistentVolumeReclaimPolicy on the StorageClass.
+func WithReclaimPolicy(reclaimPolicy corev1.PersistentVolumeReclaimPolicy) Option {
+	return func(storageClass *storagev1.StorageClass) error {
+		storageClass.ReclaimPolicy = &reclaimPolicy
+		return nil
+	}
+}
+
+// AllowVolumeExpansion allows volume expansion on the StorageClass.
+func AllowVolumeExpansion() Option {
+	return func(storageClass *storagev1.StorageClass) error {
+		storageClass.AllowVolumeExpansion = pointers.Ptr(true)
+		return nil
+	}
+}
+
+// DisallowVolumeExpansion disallows volume expansion on the StorageClass.
+func DisallowVolumeExpansion() Option {
+	return func(storageClass *storagev1.StorageClass) error {
+		storageClass.AllowVolumeExpansion = pointers.Ptr(false)
+		return nil
+	}
+}
+
+// WithVolumeBindingMode sets the given VolumeBindingMode on the StorageClasss.
+func WithVolumeBindingMode(volumeBindingMode storagev1.VolumeBindingMode) Option {
+	return func(storageClass *storagev1.StorageClass) error {
+		storageClass.VolumeBindingMode = &volumeBindingMode
+		return nil
+	}
+}

--- a/internal/k8s/resource/storage/storageclass_test.go
+++ b/internal/k8s/resource/storage/storageclass_test.go
@@ -1,0 +1,257 @@
+package storage
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/sourcegraph/sourcegraph/lib/pointers"
+)
+
+func TestNewStorageClass(t *testing.T) {
+	t.Parallel()
+
+	type args struct {
+		name      string
+		namespace string
+		options   []Option
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want storagev1.StorageClass
+	}{
+		{
+			name: "default storageclass",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+			},
+			want: storagev1.StorageClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph-storage",
+					},
+				},
+				ReclaimPolicy:        pointers.Ptr(corev1.PersistentVolumeReclaimRetain),
+				AllowVolumeExpansion: pointers.Ptr(true),
+				VolumeBindingMode:    pointers.Ptr(storagev1.VolumeBindingWaitForFirstConsumer),
+			},
+		},
+		{
+			name: "with labels",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithLabels(map[string]string{
+						"app": "bar",
+					}),
+				},
+			},
+			want: storagev1.StorageClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"app":    "bar",
+						"deploy": "sourcegraph-storage",
+					},
+				},
+				ReclaimPolicy:        pointers.Ptr(corev1.PersistentVolumeReclaimRetain),
+				AllowVolumeExpansion: pointers.Ptr(true),
+				VolumeBindingMode:    pointers.Ptr(storagev1.VolumeBindingWaitForFirstConsumer),
+			},
+		},
+		{
+			name: "with annotations",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithAnnotations(map[string]string{
+						"foo": "bar",
+					}),
+				},
+			},
+			want: storagev1.StorageClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph-storage",
+					},
+					Annotations: map[string]string{
+						"foo": "bar",
+					},
+				},
+				ReclaimPolicy:        pointers.Ptr(corev1.PersistentVolumeReclaimRetain),
+				AllowVolumeExpansion: pointers.Ptr(true),
+				VolumeBindingMode:    pointers.Ptr(storagev1.VolumeBindingWaitForFirstConsumer),
+			},
+		},
+		{
+			name: "with type",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithType("ssd"),
+				},
+			},
+			want: storagev1.StorageClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph-storage",
+					},
+				},
+				Parameters: map[string]string{
+					"type": "ssd",
+				},
+				ReclaimPolicy:        pointers.Ptr(corev1.PersistentVolumeReclaimRetain),
+				AllowVolumeExpansion: pointers.Ptr(true),
+				VolumeBindingMode:    pointers.Ptr(storagev1.VolumeBindingWaitForFirstConsumer),
+			},
+		},
+		{
+			name: "with parameters",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithParameters(map[string]string{
+						"type":  "ssd",
+						"stuff": "here",
+					}),
+				},
+			},
+			want: storagev1.StorageClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph-storage",
+					},
+				},
+				Parameters: map[string]string{
+					"stuff": "here",
+					"type":  "ssd",
+				},
+				ReclaimPolicy:        pointers.Ptr(corev1.PersistentVolumeReclaimRetain),
+				AllowVolumeExpansion: pointers.Ptr(true),
+				VolumeBindingMode:    pointers.Ptr(storagev1.VolumeBindingWaitForFirstConsumer),
+			},
+		},
+		{
+			name: "with provisioner",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithProvisioner("test"),
+				},
+			},
+			want: storagev1.StorageClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph-storage",
+					},
+				},
+				Provisioner:          "test",
+				ReclaimPolicy:        pointers.Ptr(corev1.PersistentVolumeReclaimRetain),
+				AllowVolumeExpansion: pointers.Ptr(true),
+				VolumeBindingMode:    pointers.Ptr(storagev1.VolumeBindingWaitForFirstConsumer),
+			},
+		},
+		{
+			name: "with reclaim policy",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithReclaimPolicy(corev1.PersistentVolumeReclaimDelete),
+				},
+			},
+			want: storagev1.StorageClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph-storage",
+					},
+				},
+				ReclaimPolicy:        pointers.Ptr(corev1.PersistentVolumeReclaimDelete),
+				AllowVolumeExpansion: pointers.Ptr(true),
+				VolumeBindingMode:    pointers.Ptr(storagev1.VolumeBindingWaitForFirstConsumer),
+			},
+		},
+		{
+			name: "disallow volume expansion",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					DisallowVolumeExpansion(),
+				},
+			},
+			want: storagev1.StorageClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph-storage",
+					},
+				},
+				ReclaimPolicy:        pointers.Ptr(corev1.PersistentVolumeReclaimRetain),
+				AllowVolumeExpansion: pointers.Ptr(false),
+				VolumeBindingMode:    pointers.Ptr(storagev1.VolumeBindingWaitForFirstConsumer),
+			},
+		},
+		{
+			name: "with volume binding mode",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithVolumeBindingMode(storagev1.VolumeBindingImmediate),
+				},
+			},
+			want: storagev1.StorageClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph-storage",
+					},
+				},
+				ReclaimPolicy:        pointers.Ptr(corev1.PersistentVolumeReclaimRetain),
+				AllowVolumeExpansion: pointers.Ptr(true),
+				VolumeBindingMode:    pointers.Ptr(storagev1.VolumeBindingImmediate),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := NewStorageClass(tt.args.name, tt.args.namespace, tt.args.options...)
+			if err != nil {
+				t.Errorf("NewStorageClass() error: %v", err)
+			}
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("NewStorageClass() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add `storage` pkg to create k8s storageclass with patterns and defaults common to Sourcegraph.



## Test plan

Full unit test coverage as well as testable examples

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
