### PR TITLE
k8s/resource: Add pkg for creating k8s serviceaccount resources

### DIFF
--- a/internal/k8s/resource/serviceaccount/BUILD.bazel
+++ b/internal/k8s/resource/serviceaccount/BUILD.bazel
@@ -1,0 +1,29 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("//dev:go_defs.bzl", "go_test")
+
+go_library(
+    name = "serviceaccount",
+    srcs = ["serviceaccount.go"],
+    importpath = "github.com/sourcegraph/sourcegraph/internal/k8s/resource/serviceaccount",
+    visibility = ["//:__subpackages__"],
+    deps = [
+        "//internal/maps",
+        "@io_k8s_api//core/v1:core",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:meta",
+    ],
+)
+
+go_test(
+    name = "serviceaccount_test",
+    srcs = [
+        "example_test.go",
+        "serviceaccount_test.go",
+    ],
+    embed = [":serviceaccount"],
+    deps = [
+        "@com_github_google_go_cmp//cmp",
+        "@io_k8s_api//core/v1:core",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:meta",
+        "@io_k8s_sigs_yaml//:yaml",
+    ],
+)

--- a/internal/k8s/resource/serviceaccount/example_test.go
+++ b/internal/k8s/resource/serviceaccount/example_test.go
@@ -1,0 +1,27 @@
+package serviceaccount
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"sigs.k8s.io/yaml"
+)
+
+func ExampleServiceAccount() {
+	sa, _ := NewServiceAccount("test", "sourcegraph")
+
+	sat, _ := json.Marshal(sa)
+	fmt.Println(string(sat))
+
+	yat, _ := yaml.Marshal(sa)
+	fmt.Println(string(yat))
+
+	// Output:
+	// {"metadata":{"name":"test","namespace":"sourcegraph","creationTimestamp":null,"labels":{"deploy":"sourcegraph"}}}
+	// metadata:
+	//   creationTimestamp: null
+	//   labels:
+	//     deploy: sourcegraph
+	//   name: test
+	//   namespace: sourcegraph
+}

--- a/internal/k8s/resource/serviceaccount/serviceaccount.go
+++ b/internal/k8s/resource/serviceaccount/serviceaccount.go
@@ -1,0 +1,56 @@
+package serviceaccount
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/sourcegraph/sourcegraph/internal/maps"
+)
+
+// NewServiceAccount creates a new k8s ServiceAccount with default values.
+//
+// Default values include:
+//
+//   - Labels common for Sourcegraph deployments.
+//
+// Additional options can be passed to modify the default values.
+func NewServiceAccount(name, namespace string, options ...Option) (corev1.ServiceAccount, error) {
+	serviceAccount := corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				"deploy": "sourcegraph",
+			},
+		},
+	}
+
+	// apply any given options
+	for _, opt := range options {
+		err := opt(&serviceAccount)
+		if err != nil {
+			return corev1.ServiceAccount{}, err
+		}
+	}
+
+	return serviceAccount, nil
+}
+
+// Option sets an option for a ServiceAccount.
+type Option func(serviceAccount *corev1.ServiceAccount) error
+
+// WithLabels sets ServiceAccount labes without overriding existing labels.
+func WithLabels(labels map[string]string) Option {
+	return func(serviceAccount *corev1.ServiceAccount) error {
+		serviceAccount.Labels = maps.MergePreservingExistingKeys(serviceAccount.Labels, labels)
+		return nil
+	}
+}
+
+// WithAnnotations sets ServiceAccount annotations without overriding existing annotations.
+func WithAnnotations(annotations map[string]string) Option {
+	return func(serviceAccount *corev1.ServiceAccount) error {
+		serviceAccount.Annotations = maps.MergePreservingExistingKeys(serviceAccount.Annotations, annotations)
+		return nil
+	}
+}

--- a/internal/k8s/resource/serviceaccount/serviceaccount_test.go
+++ b/internal/k8s/resource/serviceaccount/serviceaccount_test.go
@@ -1,0 +1,102 @@
+package serviceaccount
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestNewServiceAccount(t *testing.T) {
+	t.Parallel()
+
+	type args struct {
+		name      string
+		namespace string
+		options   []Option
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want corev1.ServiceAccount
+	}{
+		{
+			name: "default service account",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+			},
+			want: corev1.ServiceAccount{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph",
+					},
+				},
+			},
+		},
+		{
+			name: "with labels",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithLabels(map[string]string{
+						"foo": "bar",
+					}),
+				},
+			},
+			want: corev1.ServiceAccount{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph",
+						"foo":    "bar",
+					},
+				},
+			},
+		},
+		{
+			name: "with annotations",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithAnnotations(map[string]string{
+						"foo": "bar",
+					}),
+				},
+			},
+			want: corev1.ServiceAccount{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph",
+					},
+					Annotations: map[string]string{
+						"foo": "bar",
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := NewServiceAccount(tt.args.name, tt.args.namespace, tt.args.options...)
+			if err != nil {
+				t.Errorf("NewServiceAccount() error: %v", err)
+			}
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("NewServiceAccount() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add `serviceaccount` pkg to create k8s service accounts with patterns and defaults common to Sourcegraph.



## Test plan

Full unit test coverage as well as testable examples

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
