### PR TITLE
aspect workflows: stamp delivery targets

### DIFF
--- a/.aspect/workflows/config.yaml
+++ b/.aspect/workflows/config.yaml
@@ -33,6 +33,7 @@ tasks:
   - delivery:
       auto_deliver: true
       icon: 'ship'
+      stamp_flags: ['--stamp', '--workspace_status_command=./dev/bazel_stamp_vars.sh']
       rules:
         - deliverable: 'attr(tags, "docs-deliverable", //doc/...)'
           condition:

--- a/cmd/msp-example/BUILD.bazel
+++ b/cmd/msp-example/BUILD.bazel
@@ -19,10 +19,6 @@ go_binary(
     name = "msp-example",
     embed = [":msp-example_lib"],
     visibility = ["//visibility:public"],
-    x_defs = {
-        "github.com/sourcegraph/sourcegraph/internal/version.version": "{STABLE_VERSION}",
-        "github.com/sourcegraph/sourcegraph/internal/version.timestamp": "{VERSION_TIMESTAMP}",
-    },
 )
 
 pkg_tar(

--- a/cmd/msp-example/BUILD.bazel
+++ b/cmd/msp-example/BUILD.bazel
@@ -19,6 +19,10 @@ go_binary(
     name = "msp-example",
     embed = [":msp-example_lib"],
     visibility = ["//visibility:public"],
+    x_defs = {
+        "github.com/sourcegraph/sourcegraph/internal/version.version": "{STABLE_VERSION}",
+        "github.com/sourcegraph/sourcegraph/internal/version.timestamp": "{VERSION_TIMESTAMP}",
+    },
 )
 
 pkg_tar(


### PR DESCRIPTION
Stamps targets delivered by aspect workflows.

Adds x_defs to `msp-example` for version stamping
## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
CI, tested in [266843](https://buildkite.com/sourcegraph/sourcegraph/builds/266843)
```sh
$ docker run --rm -it us.gcr.io/sourcegraph-dev/msp-example:ff102caaa6c0_266843 --help  
SERVICE: example
VERSION: jac-stamp_266843_2024-03-28_5.3-ff102caaa6c0
CONFIGURATION OPTIONS:
- 'STATELESS_MODE': if true, disable dependencies (default: "false")
- 'VARIABLE': variable value (default: "13")
- 'MSP': indicates if we are running in a MSP environment (default: "false")
- 'ENVIRONMENT_ID': MSP Service Environment ID (default: "unknown")
- 'PORT': service port (required)
- 'OTEL_SDK_DISABLED': disable OpenTelemetry SDK (default: "false")
```
> VERSION: jac-stamp_266843_2024-03-28_5.3-ff102caaa6c0