### PR TITLE
Add note for supplying context when changing per-user overrides

### DIFF
--- a/client/web/src/user/settings/quota/backend.ts
+++ b/client/web/src/user/settings/quota/backend.ts
@@ -11,6 +11,7 @@ export const USER_REQUEST_QUOTAS = gql`
             ... on User {
                 completionsQuotaOverride
                 codeCompletionsQuotaOverride
+                completionsQuotaOverrideNote
             }
         }
     }
@@ -30,6 +31,15 @@ export const SET_USER_CODE_COMPLETIONS_QUOTA = gql`
         setUserCodeCompletionsQuota(user: $userID, quota: $quota) {
             id
             codeCompletionsQuotaOverride
+        }
+    }
+`
+
+export const SET_USER_COMPLETIONS_QUOTA_NOTE = gql`
+    mutation SetUserCompletionsQuotaNote($userID: ID!, $note: String!) {
+        setUserCompletionsQuotaNote(user: $userID, note: $note) {
+            id
+            completionsQuotaOverrideNote
         }
     }
 `

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -932,6 +932,11 @@ type Mutation {
     """
     setUserCodeCompletionsQuota(user: ID!, quota: Int): User!
     """
+    Sets the completions override note, an optional string used to provide context
+    for understanding why any changes were made.
+    """
+    setUserCompletionsQuotaNote(user: ID!, note: String!): User!
+    """
     Submits a post-signup user survey about intended Cody usage.
     """
     submitCodySurvey(isForWork: Boolean!, isForPersonal: Boolean!): EmptyResponse!
@@ -6637,6 +6642,10 @@ type User implements Node & SettingsSubject & Namespace {
     Null, if not overwritten.
     """
     codeCompletionsQuotaOverride: Int
+    """
+    Optional note to describe why any overrides were set.
+    """
+    completionsQuotaOverrideNote: String
     """
     The Cody subscription details for the user.
     """

--- a/cmd/frontend/graphqlbackend/user.go
+++ b/cmd/frontend/graphqlbackend/user.go
@@ -792,18 +792,18 @@ func (r *UserResolver) CodeCompletionsQuotaOverride(ctx context.Context) (*int32
 	return &iv, nil
 }
 
-func (r *UserResolver) CompletionsQuotaOverrideNote(ctx context.Context) (string, error) {
+func (r *UserResolver) CompletionsQuotaOverrideNote(ctx context.Context) (*string, error) {
 	// 🚨 SECURITY: Only the user and admins are allowed to see quotas.
 	if err := auth.CheckSiteAdminOrSameUser(ctx, r.db, r.user.ID); err != nil {
-		return "", err
+		return nil, err
 	}
 
 	s, err := r.db.Users().GetCompletionsQuotaNote(ctx, r.user.ID)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
-	return s, nil
+	return &s, nil
 }
 
 func (r *UserResolver) BatchChanges(ctx context.Context, args *ListBatchChangesArgs) (BatchChangesConnectionResolver, error) {

--- a/internal/database/dbmocks/mocks_temp.go
+++ b/internal/database/dbmocks/mocks_temp.go
@@ -84722,6 +84722,9 @@ type MockUserStore struct {
 	// GetCodeCompletionsQuotaFunc is an instance of a mock function object
 	// controlling the behavior of the method GetCodeCompletionsQuota.
 	GetCodeCompletionsQuotaFunc *UserStoreGetCodeCompletionsQuotaFunc
+	// GetCompletionsQuotaNoteFunc is an instance of a mock function object
+	// controlling the behavior of the method GetCompletionsQuotaNote.
+	GetCompletionsQuotaNoteFunc *UserStoreGetCompletionsQuotaNoteFunc
 	// HandleFunc is an instance of a mock function object controlling the
 	// behavior of the method Handle.
 	HandleFunc *UserStoreHandleFunc
@@ -84768,6 +84771,9 @@ type MockUserStore struct {
 	// SetCodeCompletionsQuotaFunc is an instance of a mock function object
 	// controlling the behavior of the method SetCodeCompletionsQuota.
 	SetCodeCompletionsQuotaFunc *UserStoreSetCodeCompletionsQuotaFunc
+	// SetCompletionsQuotaNoteFunc is an instance of a mock function object
+	// controlling the behavior of the method SetCompletionsQuotaNote.
+	SetCompletionsQuotaNoteFunc *UserStoreSetCompletionsQuotaNoteFunc
 	// SetIsSiteAdminFunc is an instance of a mock function object
 	// controlling the behavior of the method SetIsSiteAdmin.
 	SetIsSiteAdminFunc *UserStoreSetIsSiteAdminFunc
@@ -84897,6 +84903,11 @@ func NewMockUserStore() *MockUserStore {
 				return
 			},
 		},
+		GetCompletionsQuotaNoteFunc: &UserStoreGetCompletionsQuotaNoteFunc{
+			defaultHook: func(context.Context, int32) (r0 string, r1 error) {
+				return
+			},
+		},
 		HandleFunc: &UserStoreHandleFunc{
 			defaultHook: func() (r0 basestore.TransactableHandle) {
 				return
@@ -84969,6 +84980,11 @@ func NewMockUserStore() *MockUserStore {
 		},
 		SetCodeCompletionsQuotaFunc: &UserStoreSetCodeCompletionsQuotaFunc{
 			defaultHook: func(context.Context, int32, *int) (r0 error) {
+				return
+			},
+		},
+		SetCompletionsQuotaNoteFunc: &UserStoreSetCompletionsQuotaNoteFunc{
+			defaultHook: func(context.Context, int32, string) (r0 error) {
 				return
 			},
 		},
@@ -85114,6 +85130,11 @@ func NewStrictMockUserStore() *MockUserStore {
 				panic("unexpected invocation of MockUserStore.GetCodeCompletionsQuota")
 			},
 		},
+		GetCompletionsQuotaNoteFunc: &UserStoreGetCompletionsQuotaNoteFunc{
+			defaultHook: func(context.Context, int32) (string, error) {
+				panic("unexpected invocation of MockUserStore.GetCompletionsQuotaNote")
+			},
+		},
 		HandleFunc: &UserStoreHandleFunc{
 			defaultHook: func() basestore.TransactableHandle {
 				panic("unexpected invocation of MockUserStore.Handle")
@@ -85187,6 +85208,11 @@ func NewStrictMockUserStore() *MockUserStore {
 		SetCodeCompletionsQuotaFunc: &UserStoreSetCodeCompletionsQuotaFunc{
 			defaultHook: func(context.Context, int32, *int) error {
 				panic("unexpected invocation of MockUserStore.SetCodeCompletionsQuota")
+			},
+		},
+		SetCompletionsQuotaNoteFunc: &UserStoreSetCompletionsQuotaNoteFunc{
+			defaultHook: func(context.Context, int32, string) error {
+				panic("unexpected invocation of MockUserStore.SetCompletionsQuotaNote")
 			},
 		},
 		SetIsSiteAdminFunc: &UserStoreSetIsSiteAdminFunc{
@@ -85289,6 +85315,9 @@ func NewMockUserStoreFrom(i database.UserStore) *MockUserStore {
 		GetCodeCompletionsQuotaFunc: &UserStoreGetCodeCompletionsQuotaFunc{
 			defaultHook: i.GetCodeCompletionsQuota,
 		},
+		GetCompletionsQuotaNoteFunc: &UserStoreGetCompletionsQuotaNoteFunc{
+			defaultHook: i.GetCompletionsQuotaNote,
+		},
 		HandleFunc: &UserStoreHandleFunc{
 			defaultHook: i.Handle,
 		},
@@ -85333,6 +85362,9 @@ func NewMockUserStoreFrom(i database.UserStore) *MockUserStore {
 		},
 		SetCodeCompletionsQuotaFunc: &UserStoreSetCodeCompletionsQuotaFunc{
 			defaultHook: i.SetCodeCompletionsQuota,
+		},
+		SetCompletionsQuotaNoteFunc: &UserStoreSetCompletionsQuotaNoteFunc{
+			defaultHook: i.SetCompletionsQuotaNote,
 		},
 		SetIsSiteAdminFunc: &UserStoreSetIsSiteAdminFunc{
 			defaultHook: i.SetIsSiteAdmin,
@@ -87627,6 +87659,117 @@ func (c UserStoreGetCodeCompletionsQuotaFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 
+// UserStoreGetCompletionsQuotaNoteFunc describes the behavior when the
+// GetCompletionsQuotaNote method of the parent MockUserStore instance is
+// invoked.
+type UserStoreGetCompletionsQuotaNoteFunc struct {
+	defaultHook func(context.Context, int32) (string, error)
+	hooks       []func(context.Context, int32) (string, error)
+	history     []UserStoreGetCompletionsQuotaNoteFuncCall
+	mutex       sync.Mutex
+}
+
+// GetCompletionsQuotaNote delegates to the next hook function in the queue
+// and stores the parameter and result values of this invocation.
+func (m *MockUserStore) GetCompletionsQuotaNote(v0 context.Context, v1 int32) (string, error) {
+	r0, r1 := m.GetCompletionsQuotaNoteFunc.nextHook()(v0, v1)
+	m.GetCompletionsQuotaNoteFunc.appendCall(UserStoreGetCompletionsQuotaNoteFuncCall{v0, v1, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the
+// GetCompletionsQuotaNote method of the parent MockUserStore instance is
+// invoked and the hook queue is empty.
+func (f *UserStoreGetCompletionsQuotaNoteFunc) SetDefaultHook(hook func(context.Context, int32) (string, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// GetCompletionsQuotaNote method of the parent MockUserStore instance
+// invokes the hook at the front of the queue and discards it. After the
+// queue is empty, the default hook function is invoked for any future
+// action.
+func (f *UserStoreGetCompletionsQuotaNoteFunc) PushHook(hook func(context.Context, int32) (string, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *UserStoreGetCompletionsQuotaNoteFunc) SetDefaultReturn(r0 string, r1 error) {
+	f.SetDefaultHook(func(context.Context, int32) (string, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *UserStoreGetCompletionsQuotaNoteFunc) PushReturn(r0 string, r1 error) {
+	f.PushHook(func(context.Context, int32) (string, error) {
+		return r0, r1
+	})
+}
+
+func (f *UserStoreGetCompletionsQuotaNoteFunc) nextHook() func(context.Context, int32) (string, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *UserStoreGetCompletionsQuotaNoteFunc) appendCall(r0 UserStoreGetCompletionsQuotaNoteFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of UserStoreGetCompletionsQuotaNoteFuncCall
+// objects describing the invocations of this function.
+func (f *UserStoreGetCompletionsQuotaNoteFunc) History() []UserStoreGetCompletionsQuotaNoteFuncCall {
+	f.mutex.Lock()
+	history := make([]UserStoreGetCompletionsQuotaNoteFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// UserStoreGetCompletionsQuotaNoteFuncCall is an object that describes an
+// invocation of method GetCompletionsQuotaNote on an instance of
+// MockUserStore.
+type UserStoreGetCompletionsQuotaNoteFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 int32
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 string
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c UserStoreGetCompletionsQuotaNoteFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c UserStoreGetCompletionsQuotaNoteFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
+}
+
 // UserStoreHandleFunc describes the behavior when the Handle method of the
 // parent MockUserStore instance is invoked.
 type UserStoreHandleFunc struct {
@@ -89241,6 +89384,117 @@ func (c UserStoreSetCodeCompletionsQuotaFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c UserStoreSetCodeCompletionsQuotaFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0}
+}
+
+// UserStoreSetCompletionsQuotaNoteFunc describes the behavior when the
+// SetCompletionsQuotaNote method of the parent MockUserStore instance is
+// invoked.
+type UserStoreSetCompletionsQuotaNoteFunc struct {
+	defaultHook func(context.Context, int32, string) error
+	hooks       []func(context.Context, int32, string) error
+	history     []UserStoreSetCompletionsQuotaNoteFuncCall
+	mutex       sync.Mutex
+}
+
+// SetCompletionsQuotaNote delegates to the next hook function in the queue
+// and stores the parameter and result values of this invocation.
+func (m *MockUserStore) SetCompletionsQuotaNote(v0 context.Context, v1 int32, v2 string) error {
+	r0 := m.SetCompletionsQuotaNoteFunc.nextHook()(v0, v1, v2)
+	m.SetCompletionsQuotaNoteFunc.appendCall(UserStoreSetCompletionsQuotaNoteFuncCall{v0, v1, v2, r0})
+	return r0
+}
+
+// SetDefaultHook sets function that is called when the
+// SetCompletionsQuotaNote method of the parent MockUserStore instance is
+// invoked and the hook queue is empty.
+func (f *UserStoreSetCompletionsQuotaNoteFunc) SetDefaultHook(hook func(context.Context, int32, string) error) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// SetCompletionsQuotaNote method of the parent MockUserStore instance
+// invokes the hook at the front of the queue and discards it. After the
+// queue is empty, the default hook function is invoked for any future
+// action.
+func (f *UserStoreSetCompletionsQuotaNoteFunc) PushHook(hook func(context.Context, int32, string) error) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *UserStoreSetCompletionsQuotaNoteFunc) SetDefaultReturn(r0 error) {
+	f.SetDefaultHook(func(context.Context, int32, string) error {
+		return r0
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *UserStoreSetCompletionsQuotaNoteFunc) PushReturn(r0 error) {
+	f.PushHook(func(context.Context, int32, string) error {
+		return r0
+	})
+}
+
+func (f *UserStoreSetCompletionsQuotaNoteFunc) nextHook() func(context.Context, int32, string) error {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *UserStoreSetCompletionsQuotaNoteFunc) appendCall(r0 UserStoreSetCompletionsQuotaNoteFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of UserStoreSetCompletionsQuotaNoteFuncCall
+// objects describing the invocations of this function.
+func (f *UserStoreSetCompletionsQuotaNoteFunc) History() []UserStoreSetCompletionsQuotaNoteFuncCall {
+	f.mutex.Lock()
+	history := make([]UserStoreSetCompletionsQuotaNoteFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// UserStoreSetCompletionsQuotaNoteFuncCall is an object that describes an
+// invocation of method SetCompletionsQuotaNote on an instance of
+// MockUserStore.
+type UserStoreSetCompletionsQuotaNoteFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 int32
+	// Arg2 is the value of the 3rd argument passed to this method
+	// invocation.
+	Arg2 string
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c UserStoreSetCompletionsQuotaNoteFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c UserStoreSetCompletionsQuotaNoteFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
 }
 

--- a/internal/database/users.go
+++ b/internal/database/users.go
@@ -101,6 +101,8 @@ type UserStore interface {
 	GetChatCompletionsQuota(ctx context.Context, id int32) (*int, error)
 	SetCodeCompletionsQuota(ctx context.Context, id int32, quota *int) error
 	GetCodeCompletionsQuota(ctx context.Context, id int32) (*int, error)
+	SetCompletionsQuotaNote(ctx context.Context, id int32, note string) error
+	GetCompletionsQuotaNote(ctx context.Context, id int32) (string, error)
 	With(basestore.ShareableStore) UserStore
 }
 
@@ -1570,6 +1572,17 @@ func (u *userStore) GetCodeCompletionsQuota(ctx context.Context, id int32) (*int
 		return &quota, nil
 	}
 	return nil, nil
+}
+
+// SetCompletionsQuotaNote sets a generic note to provide context whenever setting a per-user quota override.
+func (u *userStore) SetCompletionsQuotaNote(ctx context.Context, id int32, note string) error {
+	return u.Exec(ctx, sqlf.Sprintf("UPDATE users SET completions_quota_note = %s WHERE id = %s", note, id))
+}
+
+// GetCompletionsQuotaNote retrieves whatever note has been associated with the given user.
+func (u *userStore) GetCompletionsQuotaNote(ctx context.Context, id int32) (string, error) {
+	s, _, err := basestore.ScanFirstString(u.Query(ctx, sqlf.Sprintf("SELECT completions_quota_note FROM users WHERE id = %s", id)))
+	return s, err
 }
 
 // CreatePassword creates a user's password if they don't have a password.

--- a/internal/database/users_test.go
+++ b/internal/database/users_test.go
@@ -1210,6 +1210,32 @@ func TestUsers_GetSetChatCompletionsQuota(t *testing.T) {
 		}
 		require.Nil(t, quota, "expected unconfigured quota to be nil")
 	}
+
+	t.Run("CompletionsQuotaNote", func(t *testing.T) {
+		var (
+			str  string
+			err  error
+			note = time.Now().String()
+		)
+
+		// The column has "" as a default value.
+		str, err = db.Users().GetCompletionsQuotaNote(ctx, user.ID)
+		require.NoError(t, err)
+		assert.Equal(t, "", str)
+
+		// Set the note.
+		err = db.Users().SetCompletionsQuotaNote(ctx, user.ID, note)
+		require.NoError(t, err)
+
+		// Get the note, confirming it was persisted.
+		str, err = db.Users().GetCompletionsQuotaNote(ctx, user.ID)
+		require.NoError(t, err)
+		assert.Equal(t, note, str)
+
+		// Confirm the note can be set to the empty string.
+		err = db.Users().SetCompletionsQuotaNote(ctx, user.ID, "")
+		require.NoError(t, err)
+	})
 }
 
 func TestUsers_GetSetCodeCompletionsQuota(t *testing.T) {

--- a/migrations/frontend/1711656466_add_quota_overrides_note/down.sql
+++ b/migrations/frontend/1711656466_add_quota_overrides_note/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE users DROP COLUMN IF EXISTS completions_quota_note;

--- a/migrations/frontend/1711656466_add_quota_overrides_note/metadata.yaml
+++ b/migrations/frontend/1711656466_add_quota_overrides_note/metadata.yaml
@@ -1,0 +1,2 @@
+name: add_quota_overrides_note
+parents: [1711003437]

--- a/migrations/frontend/1711656466_add_quota_overrides_note/up.sql
+++ b/migrations/frontend/1711656466_add_quota_overrides_note/up.sql
@@ -1,0 +1,3 @@
+-- Add a note field to allow for context when modifying
+-- the completions_quota and code_completions_quota columns.
+ALTER TABLE users ADD COLUMN IF NOT EXISTS completions_quota_note text DEFAULT '';


### PR DESCRIPTION
Sourcegraph instances have the ability to set a per-user "quota override" which is used for Cody PLG, as a knob for governing access to the system.

However, this has been kinda painful to work with in-practice, because there isn't any context about when or why a change was made. (e.g. Why was this user's quota set higher or lower? Who made the change? How long should it be in effect?)

This PR does (I think) all of the wiring to just add a new `users.completions_quota_note` column to the `users` table. And the associated read/write actions to expose it from our GraphQL schema. And finally adding the new field to the User Quota page... all so that 🤞  we can just see a note displayed like `"User quota set by <tool> for <reason>. (<date>)"`.

⚠️ I have no idea what I'm doing, and wasn't able to successfully run Sg locally. So I kinda sorta need some help 👉👈😢.

> I'll bug people on Slack, but things like `sg generate` fail before updating `schema.md`. And when running locally, the default configuration for GitHub OAuth doesn't seem to work. (So maybe it's a client-side configuration issue? Or I just need to fetch the secrets?)
>
> Anyways, in the interest of time, if you could just patch this locally and sanity check the User Quota page can read/write the quota note I would greatly appreciate it.

## Long-term Plan

This is essentially a stop-gap solution to make it easier to understand and diagnose quota-related issues. But this definitely isn't where we want to land long-term.

My thinking is that this quarter we'd make the following changes to Sourcegraph.com / Cody PLG:

- Move the source of truth for user subscription information to the SSC backend. Today, Cody Gateway fetches the allowed models and/or user limits from dotcom. And dotcom in-turn fetches the user's subscription information from the SSC backend. But we'll just cut dotcom out of that equation. And have Cody Gateway read subscription information (and the models/quotas that are allowed as a result) directly from the SSC backend.
- As part of that, we'll also migrate the "quota overrides" component of dotcom into the SSC backend. So at that point we'll be able to drop the `users.code_completions_quota` and GraphQL methods like `SetCodeCompletionsQuota(...)` from the codebase entirely. (And instead, this information will be managed by the SSC backend. Which is the right long-term solution, since this functionality is specific to Cody PLG. And doesn't really apply to a prototypical Sourcegraph instance.

Both of those things are planned for the current quarter by the PLG team. So hopefully just having a simple text field will buy us enough time to have a better story from the SSC backend.

e.g. a more robust support for recording quota changes. Or being able to more easily set quota overrides per-Cody Gateway feature. Rather than having mostly duplicate GraphQL endpoints for both "completions" (chats?) and "code-completions".

## Test plan

Added some tests. But I was not able to try it out locally. (See note above.)