### PR TITLE
switch hubspot response type to uint64

### DIFF
--- a/cmd/frontend/hubspot/contacts.go
+++ b/cmd/frontend/hubspot/contacts.go
@@ -94,8 +94,8 @@ type ContactProperties struct {
 // ContactResponse represents HubSpot user properties returned
 // after a CreateOrUpdate API call
 type ContactResponse struct {
-	VID   int32 `json:"vid"`
-	IsNew bool  `json:"isNew"`
+	VID   uint64 `json:"vid"`
+	IsNew bool   `json:"isNew"`
 }
 
 // newAPIValues converts a ContactProperties struct to a HubSpot API-compliant


### PR DESCRIPTION
Full discussion thread: https://sourcegraph.slack.com/archives/C01PQEVJ5A9/p1711377521550879

Context:

> Hi team - we're having a data discrepancy in Hubspot. The database is showing 0 contacts created via signup between 3/20 and 3/24 - can someone point me to the correct Looker table to get a good sense of how many contacts we should be seeing?

Solution:

>AHA, with [the new error logging](https://github.com/sourcegraph/sourcegraph/pull/61405/files) that I added yesterday deployed, I am finally able to find the errors associated with signups.
>
>...
>
>The new errors for signups are:
```error="json: cannot unmarshal number 7XXXXXXXXX into Go struct field ContactResponse.vid of type int32"```
>
>Basically—VIDs (or visitor IDs) are now numbers like 7,XXX,XXX,XXX. Int32s have a maximum value of 2^31 - 1 , or 2,147,483,647.
>Something changed on March 19th on HubSpot's side where these numbers grew in length. I suspect they went from shorter numbers (9 digits or less?) to 10 digit numbers.

## Test plan

CI