### PR TITLE
[Search results][Svelte]: Add resizable panels to search results

### DIFF
--- a/client/web-sveltekit/src/lib/wildcard/resizable-panel/Panel.svelte
+++ b/client/web-sveltekit/src/lib/wildcard/resizable-panel/Panel.svelte
@@ -17,6 +17,7 @@
     onDestroy(
         registerPanel({
             id: panelId,
+            idFromProps: id,
             order,
             constraints: { defaultSize, minSize, maxSize },
             getPanelElement: () => panelElement,

--- a/client/web-sveltekit/src/lib/wildcard/resizable-panel/PanelResizeHandle.svelte
+++ b/client/web-sveltekit/src/lib/wildcard/resizable-panel/PanelResizeHandle.svelte
@@ -75,14 +75,27 @@
     data-resize-handle-state={$state}
     data-resize-handle-active={$state === 'drag' ? 'pointer' : undefined}
     data-panel-resize-handle-id={resizeHandleId}
->
-    <slot />
-</div>
+/>
 
 <style lang="scss">
     .separator {
+        // Since drag handler is always rendered within flex
+        // PanelGroup component is safe to assume that flex rules
+        // can applied here.
+        flex: 0 0 3px;
         display: flex;
         touch-action: none;
         user-select: none;
+        width: 100%;
+        height: 100%;
+        background: transparent;
+
+        &[data-resize-handle-state='hover'] {
+            background: var(--border-color);
+        }
+
+        &[data-resize-handle-state='drag'] {
+            background: var(--oc-blue-3);
+        }
     }
 </style>

--- a/client/web-sveltekit/src/lib/wildcard/resizable-panel/ResizablePanels.stories.svelte
+++ b/client/web-sveltekit/src/lib/wildcard/resizable-panel/ResizablePanels.stories.svelte
@@ -10,22 +10,36 @@
     }
 </script>
 
+<script lang="ts">
+    let showLeftPanel = true
+    let showRightPanel = true
+
+    function handleClick(side: 'left' | 'right') {
+        switch (side) {
+            case 'left': {
+                showLeftPanel = !showLeftPanel
+                break
+            }
+            case 'right': {
+                showRightPanel = !showRightPanel
+                break
+            }
+        }
+    }
+</script>
+
 <Story name="Horizontal panels">
     <section class="root">
-        <PanelGroup direction="horizontal">
-            <Panel defaultSize={30} minSize={20}>
+        <PanelGroup id="main-group" direction="horizontal">
+            <Panel defaultSize={30} minSize={20} id="first" order={1}>
                 <div class="item">left</div>
             </Panel>
-            <PanelResizeHandle>
-                <div class="handle" />
-            </PanelResizeHandle>
-            <Panel minSize={30}>
+            <PanelResizeHandle />
+            <Panel minSize={30} id="second" order={2}>
                 <div class="item">middle</div>
             </Panel>
-            <PanelResizeHandle>
-                <div class="handle" />
-            </PanelResizeHandle>
-            <Panel defaultSize={30} minSize={20}>
+            <PanelResizeHandle />
+            <Panel defaultSize={30} minSize={20} id="third" order={3}>
                 <div class="item">right</div>
             </Panel>
         </PanelGroup>
@@ -34,13 +48,11 @@
 
 <Story name="Vertical panels">
     <section class="root">
-        <PanelGroup direction="vertical">
+        <PanelGroup id="main-vertical" direction="vertical">
             <Panel maxSize={75}>
                 <div class="item">Top</div>
             </Panel>
-            <PanelResizeHandle>
-                <div class="handle" />
-            </PanelResizeHandle>
+            <PanelResizeHandle />
             <Panel maxSize={75}>
                 <div class="item">Bottom</div>
             </Panel>
@@ -48,31 +60,56 @@
     </section>
 </Story>
 
+<Story name="Conditional panels">
+    <section>
+        <header>
+            <button on:click={() => handleClick('left')}>Toggle left panel</button>
+            <button on:click={() => handleClick('right')}>Toggle right panel</button>
+        </header>
+
+        <div class="root">
+            <PanelGroup id="main-conditional-group" direction="horizontal">
+                {#if showLeftPanel}
+                    <Panel minSize={20} id="first" order={1}>
+                        <div class="item">left</div>
+                    </Panel>
+                    <PanelResizeHandle />
+                {/if}
+
+                <Panel minSize={30} id="second" order={2}>
+                    <div class="item">middle</div>
+                </Panel>
+
+                {#if showRightPanel}
+                    <PanelResizeHandle />
+                    <Panel minSize={20} id="third" order={3}>
+                        <div class="item">right</div>
+                    </Panel>
+                {/if}
+            </PanelGroup>
+        </div>
+    </section>
+</Story>
+
 <Story name="Nested panels">
     <section class="root">
-        <PanelGroup direction="horizontal">
+        <PanelGroup id="main-horizontal" direction="horizontal">
             <Panel defaultSize={20} minSize={10}>
                 <div class="item">left</div>
             </Panel>
-            <PanelResizeHandle>
-                <div class="handle" />
-            </PanelResizeHandle>
+            <PanelResizeHandle />
             <Panel minSize={35}>
-                <PanelGroup direction="vertical">
+                <PanelGroup id="main-nested-vertical" direction="vertical">
                     <Panel defaultSize={35} minSize={10}>
                         <div class="item">Top</div>
                     </Panel>
-                    <PanelResizeHandle>
-                        <div class="handle" />
-                    </PanelResizeHandle>
+                    <PanelResizeHandle />
                     <Panel minSize={10}>
-                        <PanelGroup direction="horizontal">
+                        <PanelGroup id="main-nested-horizontal" direction="horizontal">
                             <Panel minSize={10}>
                                 <div class="item">left</div>
                             </Panel>
-                            <PanelResizeHandle>
-                                <div class="handle" />
-                            </PanelResizeHandle>
+                            <PanelResizeHandle />
                             <Panel minSize={10}>
                                 <div class="item">right</div>
                             </Panel>
@@ -80,9 +117,7 @@
                     </Panel>
                 </PanelGroup>
             </Panel>
-            <PanelResizeHandle>
-                <div class="handle" />
-            </PanelResizeHandle>
+            <PanelResizeHandle />
             <Panel defaultSize={20} minSize={10}>
                 <div class="item">right</div>
             </Panel>
@@ -108,23 +143,5 @@
         display: flex;
         overflow: hidden;
         height: 100%;
-    }
-
-    :global([data-resize-handle]) {
-        flex: 0 0 3px;
-    }
-
-    .handle {
-        width: 100%;
-        height: 100%;
-        background: transparent;
-    }
-
-    :global([data-resize-handle-state='drag']) .handle {
-        background: #4c6490;
-    }
-
-    :global([data-resize-handle-state='hover']) .handle {
-        background: transparent;
     }
 </style>

--- a/client/web-sveltekit/src/lib/wildcard/resizable-panel/types.ts
+++ b/client/web-sveltekit/src/lib/wildcard/resizable-panel/types.ts
@@ -16,6 +16,7 @@ export type ResizeEvent = KeyboardEvent | MouseEvent | TouchEvent
 
 export interface PanelInfo {
     id: PanelId
+    idFromProps: PanelId | null
     order: number | undefined
     constraints: PanelConstraints
     getPanelElement: () => HTMLElement

--- a/client/web-sveltekit/src/lib/wildcard/resizable-panel/utils/computePanelFlexBoxStyle.ts
+++ b/client/web-sveltekit/src/lib/wildcard/resizable-panel/utils/computePanelFlexBoxStyle.ts
@@ -29,6 +29,6 @@ export function computePanelFlexBoxStyle(input: Input): string {
         flex-basis: 0;
         flex-shrink: 0;
         overflow: hidden;
-        pointer-events: ${dragState !== undefined ? 'none' : 'unset'}
+        pointer-events: ${dragState !== null ? 'none' : 'unset'}
     `
 }

--- a/client/web-sveltekit/src/lib/wildcard/resizable-panel/utils/debounce.ts
+++ b/client/web-sveltekit/src/lib/wildcard/resizable-panel/utils/debounce.ts
@@ -1,0 +1,20 @@
+type Func<Args extends unknown[]> = (...args: Args) => void
+
+export function debounce<Args extends unknown[]>(
+    callback: (...args: Args) => void,
+    durationMs: number = 10
+): Func<Args> {
+    let timeoutId: NodeJS.Timeout | null = null
+
+    const callable = (...args: Args): void => {
+        if (timeoutId !== null) {
+            clearTimeout(timeoutId)
+        }
+
+        timeoutId = setTimeout(() => {
+            callback(...args)
+        }, durationMs)
+    }
+
+    return callable as unknown as Func<Args>
+}

--- a/client/web-sveltekit/src/lib/wildcard/resizable-panel/utils/storage.ts
+++ b/client/web-sveltekit/src/lib/wildcard/resizable-panel/utils/storage.ts
@@ -1,0 +1,59 @@
+import type { PanelInfo, PanelsLayout } from '../types'
+
+interface SerializedPanelGroupState {
+    [panelIds: string]: PanelsLayout
+}
+
+export function savePanelGroupLayout(panelId: string, panels: PanelInfo[], layout: PanelsLayout): void {
+    const panelsKey = getPanelsKey(panels)
+    const state = loadSerializedPanelGroupState(panelId) ?? {}
+
+    state[panelsKey] = layout
+
+    try {
+        localStorage.setItem(panelId, JSON.stringify(state))
+    } catch (error) {
+        console.error(error)
+    }
+}
+
+export function loadPanelGroupLayout(groupId: string, panels: PanelInfo[]): PanelsLayout | null {
+    const state = loadSerializedPanelGroupState(groupId) ?? {}
+    const panelKey = getPanelsKey(panels)
+
+    return state[panelKey] ?? null
+}
+
+function loadSerializedPanelGroupState(panelGroupKey: string): SerializedPanelGroupState | null {
+    try {
+        const serialized = localStorage.getItem(panelGroupKey)
+        if (serialized) {
+            const parsed = JSON.parse(serialized)
+            if (typeof parsed === 'object' && parsed !== undefined) {
+                return parsed as SerializedPanelGroupState
+            }
+        }
+    } catch {
+        // Noop
+    }
+
+    return null
+}
+
+// Note that Panel ids might be user-provided (stable) or useId generated (non-deterministic)
+// so they should not be used as part of the serialization key.
+// Using the min/max size attributes should work well enough as a backup.
+// Pre-sorting by minSize allows remembering layouts even if panels are re-ordered/dragged.
+function getPanelsKey(panels: PanelInfo[]): string {
+    return panels
+        .map(panel => {
+            const { constraints, idFromProps, order } = panel
+            if (idFromProps) {
+                return idFromProps
+            }
+
+            return order ? `${order}:${JSON.stringify(constraints)}` : JSON.stringify(constraints)
+        })
+        .sort((a, b) => a.localeCompare(b))
+        .join(',')
+}


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/61369

This PR migrates search results page (svelte prototype page) to the new resizable components
I picked some default/min/max sizes for these panels, open for suggestions if their sizes look 
weird in some states. 

## Test plan
- Check that search result panel layout looks good
- Check resizable panel works (try to resize filter or file preview panels)

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
