### PR TITLE
ci: remove blobstore2 from SourcegraphDockerImagesMisc

### DIFF
--- a/dev/ci/images/images.go
+++ b/dev/ci/images/images.go
@@ -78,7 +78,6 @@ var SourcegraphDockerImages = append(append(SourcegraphDockerImagesTestDeps, Dep
 // base deployment, nor do they require a special bazel toolchain ie: musl
 var SourcegraphDockerImagesMisc = []string{
 	"batcheshelper",
-	"blobstore2",
 	"bundled-executor",
 	"dind",
 	"embeddings",

--- a/dev/ci/internal/ci/legacy_operations.go
+++ b/dev/ci/internal/ci/legacy_operations.go
@@ -13,6 +13,7 @@ import (
 )
 
 // Keep: allows building an array of images on one agent. Useful for streamlining and rules_oci in the future.
+// TODO(burmudar): I think we can remove this
 func legacyBuildCandidateDockerImages(apps []string, version string, tag string, rt runtype.RunType) operations.Operation {
 	return func(pipeline *bk.Pipeline) {
 		cmds := []bk.StepOpt{}


### PR DESCRIPTION
`blobstore2` isn't used anymore

![Screenshot 2024-03-29 at 12 05 38](https://github.com/sourcegraph/sourcegraph/assets/1001709/104921d2-faa4-4447-a613-1735f99b1b96)


## Test plan
CI
