### PR TITLE
ci: set tag refspec for semgrep when working with tags

### DIFF
--- a/dev/ci/semgrep-scan.sh
+++ b/dev/ci/semgrep-scan.sh
@@ -26,15 +26,21 @@ echo -e "--- :rocket: reporting scan results to GitHub\n"
 # upload SARIF results to code scanning API
 encoded_sarif=$(gzip -c results.sarif | base64 -w0)
 
+
 # upload SARIF results to code scanning API
 if [ "$BUILDKITE_PULL_REQUEST" = "false" ]; then
+  ref="refs/heads/${BUILDKIATE_BRANCH}"
+  if [[ -n "${BUILDKITE_TAG}" ]]; then
+    ref="refs/tags/${BUILDKITE_TAG}"
+  fi
+
   gh api \
     --method POST \
     -H "Accept: application/vnd.github+json" \
     -H "X-GitHub-Api-Version: 2022-11-28" \
     /repos/sourcegraph/sourcegraph/code-scanning/sarifs \
     -f commit_sha="$BUILDKITE_COMMIT" \
-    -f ref="refs/heads/$BUILDKITE_BRANCH" \
+    -f ref="${ref}" \
     -f sarif="$encoded_sarif" \
     -f tool_name="ci semgrep"
 else

--- a/dev/ci/semgrep-scan.sh
+++ b/dev/ci/semgrep-scan.sh
@@ -29,7 +29,7 @@ encoded_sarif=$(gzip -c results.sarif | base64 -w0)
 
 # upload SARIF results to code scanning API
 if [ "$BUILDKITE_PULL_REQUEST" = "false" ]; then
-  ref="refs/heads/${BUILDKIATE_BRANCH}"
+  ref="refs/heads/${BUILDKITE_BRANCH}"
   if [[ -n "${BUILDKITE_TAG}" ]]; then
     ref="refs/tags/${BUILDKITE_TAG}"
   fi


### PR DESCRIPTION
The semgrep check fails on tags since it uses the branch refspec but on a tag those do not exist see https://buildkite.com/sourcegraph/sourcegraph/builds/266947#018e8a09-c8ad-4a3e-bf74-92cdb048f8da
## Test plan
CI and https://buildkite.com/sourcegraph/sourcegraph/builds/266955#018e8a2f-a110-409e-83c0-5d196b193857
