### PR TITLE
bazel: move internal/version stamping to internal/version's go_library decl

### DIFF
--- a/cmd/batcheshelper/BUILD.bazel
+++ b/cmd/batcheshelper/BUILD.bazel
@@ -24,10 +24,6 @@ go_binary(
     name = "batcheshelper",
     embed = [":batcheshelper_lib"],
     visibility = ["//visibility:public"],
-    x_defs = {
-        "github.com/sourcegraph/sourcegraph/internal/version.version": "{STABLE_VERSION}",
-        "github.com/sourcegraph/sourcegraph/internal/version.timestamp": "{VERSION_TIMESTAMP}",
-    },
 )
 
 go_test(

--- a/cmd/blobstore/BUILD.bazel
+++ b/cmd/blobstore/BUILD.bazel
@@ -19,10 +19,6 @@ go_binary(
     name = "blobstore",
     embed = [":blobstore_lib"],
     visibility = ["//visibility:public"],
-    x_defs = {
-        "github.com/sourcegraph/sourcegraph/internal/version.version": "{STABLE_VERSION}",
-        "github.com/sourcegraph/sourcegraph/internal/version.timestamp": "{VERSION_TIMESTAMP}",
-    },
 )
 
 pkg_tar(

--- a/cmd/cody-gateway/BUILD.bazel
+++ b/cmd/cody-gateway/BUILD.bazel
@@ -23,10 +23,6 @@ go_binary(
     name = "cody-gateway",
     embed = [":cody-gateway_lib"],
     visibility = ["//visibility:public"],
-    x_defs = {
-        "github.com/sourcegraph/sourcegraph/internal/version.version": "{STABLE_VERSION}",
-        "github.com/sourcegraph/sourcegraph/internal/version.timestamp": "{VERSION_TIMESTAMP}",
-    },
 )
 
 pkg_tar(

--- a/cmd/embeddings/BUILD.bazel
+++ b/cmd/embeddings/BUILD.bazel
@@ -19,10 +19,6 @@ go_binary(
     name = "embeddings",
     embed = [":embeddings_lib"],
     visibility = ["//visibility:public"],
-    x_defs = {
-        "github.com/sourcegraph/sourcegraph/internal/version.version": "{STABLE_VERSION}",
-        "github.com/sourcegraph/sourcegraph/internal/version.timestamp": "{VERSION_TIMESTAMP}",
-    },
 )
 
 pkg_tar(

--- a/cmd/executor/BUILD.bazel
+++ b/cmd/executor/BUILD.bazel
@@ -27,10 +27,6 @@ go_binary(
     name = "executor",
     embed = [":executor_lib"],
     visibility = ["//visibility:public"],
-    x_defs = {
-        "github.com/sourcegraph/sourcegraph/internal/version.version": "{STABLE_VERSION}",
-        "github.com/sourcegraph/sourcegraph/internal/version.timestamp": "{VERSION_TIMESTAMP}",
-    },
 )
 
 # Ensure this builds, so we don't fail at publish time later on in the pipeline.
@@ -47,10 +43,6 @@ go_binary(
         "shell",
     ],
     visibility = ["//visibility:public"],
-    x_defs = {
-        "github.com/sourcegraph/sourcegraph/internal/version.version": "{STABLE_VERSION}",
-        "github.com/sourcegraph/sourcegraph/internal/version.timestamp": "{VERSION_TIMESTAMP}",
-    },
 )
 
 pkg_tar(

--- a/cmd/frontend/BUILD.bazel
+++ b/cmd/frontend/BUILD.bazel
@@ -23,10 +23,6 @@ go_binary(
     name = "frontend",
     embed = [":frontend_lib"],
     visibility = ["//visibility:public"],
-    x_defs = {
-        "github.com/sourcegraph/sourcegraph/internal/version.version": "{STABLE_VERSION}",
-        "github.com/sourcegraph/sourcegraph/internal/version.timestamp": "{VERSION_TIMESTAMP}",
-    },
 )
 
 pkg_tar(

--- a/cmd/gitserver/BUILD.bazel
+++ b/cmd/gitserver/BUILD.bazel
@@ -19,10 +19,6 @@ go_binary(
     name = "gitserver",
     embed = [":gitserver_lib"],
     visibility = ["//visibility:public"],
-    x_defs = {
-        "github.com/sourcegraph/sourcegraph/internal/version.version": "{STABLE_VERSION}",
-        "github.com/sourcegraph/sourcegraph/internal/version.timestamp": "{VERSION_TIMESTAMP}",
-    },
 )
 
 pkg_tar(

--- a/cmd/loadtest/BUILD.bazel
+++ b/cmd/loadtest/BUILD.bazel
@@ -20,10 +20,6 @@ go_binary(
     name = "loadtest",
     embed = [":loadtest_lib"],
     visibility = ["//visibility:public"],
-    x_defs = {
-        "github.com/sourcegraph/sourcegraph/internal/version.version": "{STABLE_VERSION}",
-        "github.com/sourcegraph/sourcegraph/internal/version.timestamp": "{VERSION_TIMESTAMP}",
-    },
 )
 
 pkg_tar(

--- a/cmd/migrator/BUILD.bazel
+++ b/cmd/migrator/BUILD.bazel
@@ -22,10 +22,6 @@ go_binary(
     name = "migrator",
     embed = [":migrator_lib"],
     visibility = ["//visibility:public"],
-    x_defs = {
-        "github.com/sourcegraph/sourcegraph/internal/version.version": "{STABLE_VERSION}",
-        "github.com/sourcegraph/sourcegraph/internal/version.timestamp": "{VERSION_TIMESTAMP}",
-    },
 )
 
 # This rule builds a tarball of the database schema descriptions that only contains the current database schema

--- a/cmd/pings/BUILD.bazel
+++ b/cmd/pings/BUILD.bazel
@@ -18,10 +18,6 @@ go_binary(
     name = "pings",
     embed = [":pings_lib"],
     visibility = ["//visibility:public"],
-    x_defs = {
-        "github.com/sourcegraph/sourcegraph/internal/version.version": "{STABLE_VERSION}",
-        "github.com/sourcegraph/sourcegraph/internal/version.timestamp": "{VERSION_TIMESTAMP}",
-    },
 )
 
 pkg_tar(

--- a/cmd/precise-code-intel-worker/BUILD.bazel
+++ b/cmd/precise-code-intel-worker/BUILD.bazel
@@ -19,10 +19,6 @@ go_binary(
     name = "precise-code-intel-worker",
     embed = [":precise-code-intel-worker_lib"],
     visibility = ["//visibility:public"],
-    x_defs = {
-        "github.com/sourcegraph/sourcegraph/internal/version.version": "{STABLE_VERSION}",
-        "github.com/sourcegraph/sourcegraph/internal/version.timestamp": "{VERSION_TIMESTAMP}",
-    },
 )
 
 pkg_tar(

--- a/cmd/repo-updater/BUILD.bazel
+++ b/cmd/repo-updater/BUILD.bazel
@@ -19,10 +19,6 @@ go_binary(
     name = "repo-updater",
     embed = [":repo-updater_lib"],
     visibility = ["//visibility:public"],
-    x_defs = {
-        "github.com/sourcegraph/sourcegraph/internal/version.version": "{STABLE_VERSION}",
-        "github.com/sourcegraph/sourcegraph/internal/version.timestamp": "{VERSION_TIMESTAMP}",
-    },
 )
 
 pkg_tar(

--- a/cmd/searcher/BUILD.bazel
+++ b/cmd/searcher/BUILD.bazel
@@ -19,10 +19,6 @@ go_binary(
     name = "searcher",
     embed = [":searcher_lib"],
     visibility = ["//visibility:public"],
-    x_defs = {
-        "github.com/sourcegraph/sourcegraph/internal/version.version": "{STABLE_VERSION}",
-        "github.com/sourcegraph/sourcegraph/internal/version.timestamp": "{VERSION_TIMESTAMP}",
-    },
 )
 
 pkg_tar(

--- a/cmd/server/BUILD.bazel
+++ b/cmd/server/BUILD.bazel
@@ -25,10 +25,6 @@ go_binary(
     ],
     pure = "on",
     visibility = ["//visibility:public"],
-    x_defs = {
-        "github.com/sourcegraph/sourcegraph/internal/version.version": "{STABLE_VERSION}",
-        "github.com/sourcegraph/sourcegraph/internal/version.timestamp": "{VERSION_TIMESTAMP}",
-    },
 )
 
 pkg_tar(

--- a/cmd/symbols/BUILD.bazel
+++ b/cmd/symbols/BUILD.bazel
@@ -19,10 +19,6 @@ go_binary(
     name = "symbols",
     embed = [":symbols_lib"],
     visibility = ["//visibility:public"],
-    x_defs = {
-        "github.com/sourcegraph/sourcegraph/internal/version.version": "{STABLE_VERSION}",
-        "github.com/sourcegraph/sourcegraph/internal/version.timestamp": "{VERSION_TIMESTAMP}",
-    },
 )
 
 pkg_tar(

--- a/cmd/syntactic-code-intel-worker/BUILD.bazel
+++ b/cmd/syntactic-code-intel-worker/BUILD.bazel
@@ -19,10 +19,6 @@ go_binary(
     name = "syntactic-code-intel-worker",
     embed = [":syntactic-code-intel-worker_lib"],
     visibility = ["//visibility:public"],
-    x_defs = {
-        "github.com/sourcegraph/sourcegraph/internal/version.version": "{STABLE_VERSION}",
-        "github.com/sourcegraph/sourcegraph/internal/version.timestamp": "{VERSION_TIMESTAMP}",
-    },
 )
 
 pkg_tar(

--- a/cmd/telemetry-gateway/BUILD.bazel
+++ b/cmd/telemetry-gateway/BUILD.bazel
@@ -8,10 +8,6 @@ go_binary(
     name = "telemetry-gateway",
     embed = [":telemetry-gateway_lib"],
     visibility = ["//visibility:public"],
-    x_defs = {
-        "github.com/sourcegraph/sourcegraph/internal/version.version": "{STABLE_VERSION}",
-        "github.com/sourcegraph/sourcegraph/internal/version.timestamp": "{VERSION_TIMESTAMP}",
-    },
 )
 
 pkg_tar(

--- a/cmd/worker/BUILD.bazel
+++ b/cmd/worker/BUILD.bazel
@@ -19,10 +19,6 @@ go_binary(
     name = "worker",
     embed = [":worker_lib"],
     visibility = ["//visibility:public"],
-    x_defs = {
-        "github.com/sourcegraph/sourcegraph/internal/version.version": "{STABLE_VERSION}",
-        "github.com/sourcegraph/sourcegraph/internal/version.timestamp": "{VERSION_TIMESTAMP}",
-    },
 )
 
 pkg_tar(

--- a/dev/sg/BUILD.bazel
+++ b/dev/sg/BUILD.bazel
@@ -134,10 +134,6 @@ go_binary(
         "//conditions:default": [],
     }),
     visibility = ["//visibility:public"],
-    x_defs = {
-        "github.com/sourcegraph/sourcegraph/internal/version.version": "{STABLE_VERSION}",
-        "github.com/sourcegraph/sourcegraph/internal/version.timestamp": "{VERSION_TIMESTAMP}",
-    },
 )
 
 go_test(

--- a/docker-images/prometheus/cmd/prom-wrapper/BUILD.bazel
+++ b/docker-images/prometheus/cmd/prom-wrapper/BUILD.bazel
@@ -49,10 +49,6 @@ go_binary(
     pure = "on",
     static = "on",
     visibility = ["//visibility:public"],
-    x_defs = {
-        "github.com/sourcegraph/sourcegraph/internal/version.version": "{STABLE_VERSION}",
-        "github.com/sourcegraph/sourcegraph/internal/version.timestamp": "{VERSION_TIMESTAMP}",
-    },
 )
 
 go_test(

--- a/internal/cmd/ghe-feeder/BUILD.bazel
+++ b/internal/cmd/ghe-feeder/BUILD.bazel
@@ -31,8 +31,4 @@ go_binary(
     name = "ghe-feeder",
     embed = [":ghe-feeder_lib"],
     visibility = ["//:__subpackages__"],
-    x_defs = {
-        "github.com/sourcegraph/sourcegraph/internal/version.version": "{STABLE_VERSION}",
-        "github.com/sourcegraph/sourcegraph/internal/version.timestamp": "{VERSION_TIMESTAMP}",
-    },
 )

--- a/internal/cmd/search-blitz/BUILD.bazel
+++ b/internal/cmd/search-blitz/BUILD.bazel
@@ -39,10 +39,6 @@ go_binary(
     name = "search-blitz",
     embed = [":search-blitz_lib"],
     visibility = ["//:__subpackages__"],
-    x_defs = {
-        "github.com/sourcegraph/sourcegraph/internal/version.version": "{STABLE_VERSION}",
-        "github.com/sourcegraph/sourcegraph/internal/version.timestamp": "{VERSION_TIMESTAMP}",
-    },
 )
 
 go_test(

--- a/internal/cmd/src-cli-version/BUILD.bazel
+++ b/internal/cmd/src-cli-version/BUILD.bazel
@@ -12,8 +12,4 @@ go_binary(
     name = "src-cli-version",
     embed = [":src-cli-version_lib"],
     visibility = ["//:__subpackages__"],
-    x_defs = {
-        "github.com/sourcegraph/sourcegraph/internal/version.version": "{STABLE_VERSION}",
-        "github.com/sourcegraph/sourcegraph/internal/version.timestamp": "{VERSION_TIMESTAMP}",
-    },
 )

--- a/internal/database/migration/shared/data/cmd/generator/BUILD.bazel
+++ b/internal/database/migration/shared/data/cmd/generator/BUILD.bazel
@@ -23,8 +23,6 @@ go_binary(
     embed = [":generator_lib"],
     visibility = ["//:__subpackages__"],
     x_defs = {
-        "github.com/sourcegraph/sourcegraph/internal/version.version": "{STABLE_VERSION}",
-        "github.com/sourcegraph/sourcegraph/internal/version.timestamp": "{VERSION_TIMESTAMP}",
         "github.com/sourcegraph/sourcegraph/internal/database/migration/shared/data/cmd/generator/version.FinalVersionString": "{STABLE_VERSION}",
     },
 )

--- a/internal/version/BUILD.bazel
+++ b/internal/version/BUILD.bazel
@@ -6,6 +6,10 @@ go_library(
     srcs = ["version.go"],
     importpath = "github.com/sourcegraph/sourcegraph/internal/version",
     visibility = ["//:__subpackages__"],
+    x_defs = {
+        "github.com/sourcegraph/sourcegraph/internal/version.version": "{STABLE_VERSION}",
+        "github.com/sourcegraph/sourcegraph/internal/version.timestamp": "{VERSION_TIMESTAMP}",
+    },
     deps = ["//lib/errors"],
 )
 


### PR DESCRIPTION
Instead of having to declare the stamp vars on every go_binary (and risk forgetting one, like in https://github.com/sourcegraph/sourcegraph/pull/61480/files#r1543982602), we can stamp at the go_library declaration point instead.

## Test plan

Locally tested with `strings`
