### PR TITLE
k8s/resource: Add pkg for creating k8s ingress resources

### DIFF
--- a/internal/k8s/resource/ingress/BUILD.bazel
+++ b/internal/k8s/resource/ingress/BUILD.bazel
@@ -1,0 +1,30 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("//dev:go_defs.bzl", "go_test")
+
+go_library(
+    name = "ingress",
+    srcs = ["ingress.go"],
+    importpath = "github.com/sourcegraph/sourcegraph/internal/k8s/resource/ingress",
+    visibility = ["//:__subpackages__"],
+    deps = [
+        "//internal/maps",
+        "@io_k8s_api//networking/v1:networking",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:meta",
+    ],
+)
+
+go_test(
+    name = "ingress_test",
+    srcs = [
+        "example_test.go",
+        "ingress_test.go",
+    ],
+    embed = [":ingress"],
+    deps = [
+        "//lib/pointers",
+        "@com_github_google_go_cmp//cmp",
+        "@io_k8s_api//networking/v1:networking",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:meta",
+        "@io_k8s_sigs_yaml//:yaml",
+    ],
+)

--- a/internal/k8s/resource/ingress/example_test.go
+++ b/internal/k8s/resource/ingress/example_test.go
@@ -1,0 +1,30 @@
+package ingress
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"sigs.k8s.io/yaml"
+)
+
+func ExampleIngress() {
+	i, _ := NewIngress("test", "sourcegraph")
+
+	ji, _ := json.Marshal(i)
+	fmt.Println(string(ji))
+
+	yc, _ := yaml.Marshal(i)
+	fmt.Println(string(yc))
+
+	// Output:
+	// {"metadata":{"name":"test","namespace":"sourcegraph","creationTimestamp":null,"labels":{"deploy":"sourcegraph"}},"spec":{},"status":{"loadBalancer":{}}}
+	// metadata:
+	//   creationTimestamp: null
+	//   labels:
+	//     deploy: sourcegraph
+	//   name: test
+	//   namespace: sourcegraph
+	// spec: {}
+	// status:
+	//   loadBalancer: {}
+}

--- a/internal/k8s/resource/ingress/ingress.go
+++ b/internal/k8s/resource/ingress/ingress.go
@@ -1,0 +1,81 @@
+package ingress
+
+import (
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/sourcegraph/sourcegraph/internal/maps"
+)
+
+func NewIngress(name, namespace string, options ...Option) (networkingv1.Ingress, error) {
+	ingress := networkingv1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				"deploy": "sourcegraph",
+			},
+		},
+		Spec: networkingv1.IngressSpec{},
+	}
+
+	// apply any given options
+	for _, opt := range options {
+		err := opt(&ingress)
+		if err != nil {
+			return networkingv1.Ingress{}, err
+		}
+	}
+	return ingress, nil
+}
+
+// Option sets an option for an Ingress.
+type Option func(ingress *networkingv1.Ingress) error
+
+// WithLabels sets ingress labels without overriding existing labels.
+func WithLabels(labels map[string]string) Option {
+	return func(ingress *networkingv1.Ingress) error {
+		ingress.Labels = maps.MergePreservingExistingKeys(ingress.Labels, labels)
+		return nil
+	}
+}
+
+// WithAnnotations sets ingress annotations without overriding existing labels.
+func WithAnnotations(annotations map[string]string) Option {
+	return func(ingress *networkingv1.Ingress) error {
+		ingress.Annotations = maps.MergePreservingExistingKeys(ingress.Annotations, annotations)
+		return nil
+	}
+}
+
+// WithIngressClassName sets the name of the IngressClass cluster resource.
+func WithIngressClassName(ingressClassName string) Option {
+	return func(ingress *networkingv1.Ingress) error {
+		ingress.Spec.IngressClassName = &ingressClassName
+		return nil
+	}
+}
+
+// WithDefaultIngressBackend sets the default ingress backend.
+func WithDefaultIngressBackend(defaultBackend networkingv1.IngressBackend) Option {
+	return func(ingress *networkingv1.Ingress) error {
+		ingress.Spec.DefaultBackend = &defaultBackend
+		return nil
+	}
+}
+
+// WithIngressTLS sets the ingress TLS settings.
+func WithIngressTLS(tls []networkingv1.IngressTLS) Option {
+	return func(ingress *networkingv1.Ingress) error {
+		ingress.Spec.TLS = tls
+		return nil
+	}
+}
+
+// WithIngressRules sets the ingress rules.
+func WithIngressRules(rules []networkingv1.IngressRule) Option {
+	return func(ingress *networkingv1.Ingress) error {
+		ingress.Spec.Rules = rules
+		return nil
+	}
+}

--- a/internal/k8s/resource/ingress/ingress_test.go
+++ b/internal/k8s/resource/ingress/ingress_test.go
@@ -1,0 +1,226 @@
+package ingress
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/sourcegraph/sourcegraph/lib/pointers"
+)
+
+func TestNewIngress(t *testing.T) {
+	t.Parallel()
+
+	type args struct {
+		name      string
+		namespace string
+		options   []Option
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want networkingv1.Ingress
+	}{
+		{
+			name: "default ingress",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+			},
+			want: networkingv1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph",
+					},
+				},
+			},
+		},
+		{
+			name: "with labels",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithLabels(map[string]string{
+						"foo": "bar",
+					}),
+				},
+			},
+			want: networkingv1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph",
+						"foo":    "bar",
+					},
+				},
+			},
+		},
+		{
+			name: "with annotations",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithAnnotations(map[string]string{
+						"foo": "bar",
+					}),
+				},
+			},
+			want: networkingv1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph",
+					},
+					Annotations: map[string]string{
+						"foo": "bar",
+					},
+				},
+			},
+		},
+		{
+			name: "with ingress class name",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithIngressClassName("foo"),
+				},
+			},
+			want: networkingv1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph",
+					},
+				},
+				Spec: networkingv1.IngressSpec{
+					IngressClassName: pointers.Ptr("foo"),
+				},
+			},
+		},
+		{
+			name: "with ingress TLS",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithIngressTLS([]networkingv1.IngressTLS{
+						{
+							Hosts:      []string{"foo"},
+							SecretName: "bar",
+						},
+					}),
+				},
+			},
+			want: networkingv1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph",
+					},
+				},
+				Spec: networkingv1.IngressSpec{
+					TLS: []networkingv1.IngressTLS{
+						{
+							Hosts:      []string{"foo"},
+							SecretName: "bar",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "with default ingress backend",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithDefaultIngressBackend(networkingv1.IngressBackend{
+						Service: &networkingv1.IngressServiceBackend{
+							Name: "foo",
+							Port: networkingv1.ServiceBackendPort{
+								Name:   "http",
+								Number: 80,
+							},
+						},
+					}),
+				},
+			},
+			want: networkingv1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph",
+					},
+				},
+				Spec: networkingv1.IngressSpec{
+					DefaultBackend: &networkingv1.IngressBackend{
+						Service: &networkingv1.IngressServiceBackend{
+							Name: "foo",
+							Port: networkingv1.ServiceBackendPort{
+								Name:   "http",
+								Number: 80,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "with ingress rules",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithIngressRules([]networkingv1.IngressRule{
+						{
+							Host: "foo",
+						},
+					}),
+				},
+			},
+			want: networkingv1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph",
+					},
+				},
+				Spec: networkingv1.IngressSpec{
+					Rules: []networkingv1.IngressRule{
+						{
+							Host: "foo",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := NewIngress(tt.args.name, tt.args.namespace, tt.args.options...)
+			if err != nil {
+				t.Errorf("NewIngress() error: %v", err)
+			}
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("NewIngress() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add `ingress` pkg to create k8s ingress with patterns and defaults common to Sourcegraph.



## Test plan

Full unit test coverage as well as testable examples

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
