### PR TITLE
/get-cody: Replace soft redirect with hard one

### DIFF
--- a/client/web/src/get-cody/GetCodyPage.tsx
+++ b/client/web/src/get-cody/GetCodyPage.tsx
@@ -54,7 +54,7 @@ export const GetCodyPage: React.FunctionComponent<GetCodyPageProps> = ({ authent
         if (authenticatedUser) {
             navigate(`/cody/manage${search || ''}`)
         } else {
-            navigate('/cody')
+            window.location.href = '/cody'
         }
     }, [authenticatedUser, navigate, search])
 


### PR DESCRIPTION
This is a follow-up to https://github.com/sourcegraph/sourcegraph/pull/61470/. Raman reported [here](https://sourcegraph.slack.com/archives/C01KPE23H4M/p1711699203555329) that the redirect showed the wrong page.

It's a URL collision between the marketing site and the Sourcegraph webapp. The problem is that my solution used the `useNavigate` hook which does a soft redirect inside the React app, and the `/cody` page happens to exist there.
But the correct solution is to do a _hard_ redirect so that the load balancer has a chance to catch the request and serve the marketing page.

This PR replaces the soft redirect with a hard one.

## Test plan

Tested it locally; the redirect still works, and it reloads the whole page.