### PR TITLE
k8s/resource: Add pkg for creating k8s deployment resources

### DIFF
--- a/internal/k8s/resource/deployment/BUILD.bazel
+++ b/internal/k8s/resource/deployment/BUILD.bazel
@@ -1,0 +1,34 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("//dev:go_defs.bzl", "go_test")
+
+go_library(
+    name = "deployment",
+    srcs = ["deployment.go"],
+    importpath = "github.com/sourcegraph/sourcegraph/internal/k8s/resource/deployment",
+    visibility = ["//:__subpackages__"],
+    deps = [
+        "//internal/maps",
+        "//lib/pointers",
+        "@io_k8s_api//apps/v1:apps",
+        "@io_k8s_api//core/v1:core",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:meta",
+    ],
+)
+
+go_test(
+    name = "deployment_test",
+    srcs = [
+        "deployment_test.go",
+        "example_test.go",
+    ],
+    embed = [":deployment"],
+    deps = [
+        "//internal/k8s/resource/pod",
+        "//lib/pointers",
+        "@com_github_google_go_cmp//cmp",
+        "@io_k8s_api//apps/v1:apps",
+        "@io_k8s_api//core/v1:core",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:meta",
+        "@io_k8s_sigs_yaml//:yaml",
+    ],
+)

--- a/internal/k8s/resource/deployment/deployment.go
+++ b/internal/k8s/resource/deployment/deployment.go
@@ -1,0 +1,127 @@
+package deployment
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/sourcegraph/sourcegraph/internal/maps"
+	"github.com/sourcegraph/sourcegraph/lib/pointers"
+)
+
+// NewDeployment creates a new k8s Deployment with default values.
+//
+// Default values include:
+//
+//   - MinReadySeconds: 10
+//   - Replicas: 1
+//   - RevisionHistoryLimit: 10
+//   - Selector: "app": <name>
+//   - DeploymentStrategy: RecreateDeploymentStrategy
+//
+// Additional options can be passed to modify the default values.
+func NewDeployment(name, namespace string, options ...Option) (appsv1.Deployment, error) {
+	deployment := appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				"deploy": "sourcegraph",
+			},
+		},
+		Spec: appsv1.DeploymentSpec{
+			MinReadySeconds:      int32(10),
+			Replicas:             pointers.Ptr[int32](1),
+			RevisionHistoryLimit: pointers.Ptr[int32](10),
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app": name,
+				},
+			},
+			Strategy: appsv1.DeploymentStrategy{
+				Type: appsv1.RecreateDeploymentStrategyType,
+			},
+		},
+	}
+
+	// apply any given options
+	for _, opt := range options {
+		err := opt(&deployment)
+		if err != nil {
+			return appsv1.Deployment{}, err
+		}
+	}
+
+	return deployment, nil
+}
+
+// Option sets an option for a Deployment.
+type Option func(deployment *appsv1.Deployment) error
+
+// WithLabels sets Deployment labels without overriding existing labels.
+func WithLabels(labels map[string]string) Option {
+	return func(deployment *appsv1.Deployment) error {
+		deployment.Labels = maps.MergePreservingExistingKeys(deployment.Labels, labels)
+		return nil
+	}
+}
+
+// WithAnnotations sets Deployment annotations without overriding existing annotations.
+func WithAnnotations(annotations map[string]string) Option {
+	return func(deployment *appsv1.Deployment) error {
+		deployment.Annotations = maps.MergePreservingExistingKeys(deployment.Annotations, annotations)
+		return nil
+	}
+}
+
+// WithMinReadySeconds sets the minimum number of seconds for which a newly
+// created Pod should be ready without any of its containers crashing, for it to
+// be considered available.
+func WithMinReadySeconds(seconds int32) Option {
+	return func(deployment *appsv1.Deployment) error {
+		deployment.Spec.MinReadySeconds = seconds
+		return nil
+	}
+}
+
+// WithReplicas sets the number of replicas for the Deployment.
+func WithReplicas(replicas int32) Option {
+	return func(deployment *appsv1.Deployment) error {
+		deployment.Spec.Replicas = pointers.Ptr[int32](replicas)
+		return nil
+	}
+}
+
+// WithRevisionHistoryLimit sets the revision history limit for the Deployment.
+func WithRevisionHistoryLimit(revisionHistoryLimit int32) Option {
+	return func(deployment *appsv1.Deployment) error {
+		deployment.Spec.RevisionHistoryLimit = pointers.Ptr[int32](revisionHistoryLimit)
+		return nil
+	}
+}
+
+// WithSelector sets the selector for the Deployment. The selector determines which Pods are managed by the Deployment.
+func WithSelector(selector metav1.LabelSelector) Option {
+	return func(deployment *appsv1.Deployment) error {
+		deployment.Spec.Selector = &selector
+		return nil
+	}
+}
+
+// WithDeploymentStrategy sets the deployment strategy for the Deployment.
+// The deployment strategy determines how Pods are created/updated/deleted when the Deployment is updated.
+func WithDeploymentStrategy(deploymentStrategy appsv1.DeploymentStrategy) Option {
+	return func(deployment *appsv1.Deployment) error {
+		deployment.Spec.Strategy = deploymentStrategy
+		return nil
+	}
+}
+
+// WithPodTemplateSpec sets the pod template spec for the Deployment. The pod template spec
+// defines the pods that will be created by the Deployment.
+func WithPodTemplateSpec(podTemplate corev1.PodTemplateSpec) Option {
+	return func(deployment *appsv1.Deployment) error {
+		deployment.Spec.Template = podTemplate
+		return nil
+	}
+}

--- a/internal/k8s/resource/deployment/deployment_test.go
+++ b/internal/k8s/resource/deployment/deployment_test.go
@@ -1,0 +1,378 @@
+package deployment
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/sourcegraph/sourcegraph/internal/k8s/resource/pod"
+	"github.com/sourcegraph/sourcegraph/lib/pointers"
+)
+
+func TestNewDeployment(t *testing.T) {
+	t.Parallel()
+
+	type args struct {
+		name      string
+		namespace string
+		options   []Option
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want appsv1.Deployment
+	}{
+		{
+			name: "default deployment",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+			},
+			want: appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph",
+					},
+				},
+				Spec: appsv1.DeploymentSpec{
+					MinReadySeconds:      int32(10),
+					Replicas:             pointers.Ptr[int32](1),
+					RevisionHistoryLimit: pointers.Ptr[int32](10),
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"app": "foo",
+						},
+					},
+					Strategy: appsv1.DeploymentStrategy{
+						Type: appsv1.RecreateDeploymentStrategyType,
+					},
+					Template: corev1.PodTemplateSpec{},
+				},
+			},
+		},
+		{
+			name: "with labels",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithLabels(map[string]string{
+						"deploy": "horsegraph",
+						"app":    "horsegraph",
+					}),
+				},
+			},
+			want: appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"app":    "horsegraph",
+						"deploy": "sourcegraph",
+					},
+				},
+				Spec: appsv1.DeploymentSpec{
+					MinReadySeconds:      int32(10),
+					Replicas:             pointers.Ptr[int32](1),
+					RevisionHistoryLimit: pointers.Ptr[int32](10),
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"app": "foo",
+						},
+					},
+					Strategy: appsv1.DeploymentStrategy{
+						Type: appsv1.RecreateDeploymentStrategyType,
+					},
+					Template: corev1.PodTemplateSpec{},
+				},
+			},
+		},
+		{
+			name: "with annotations",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithAnnotations(map[string]string{
+						"app": "horsegraph",
+						"foo": "bar",
+					}),
+				},
+			},
+			want: appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph",
+					},
+					Annotations: map[string]string{
+						"app": "horsegraph",
+						"foo": "bar",
+					},
+				},
+				Spec: appsv1.DeploymentSpec{
+					MinReadySeconds:      int32(10),
+					Replicas:             pointers.Ptr[int32](1),
+					RevisionHistoryLimit: pointers.Ptr[int32](10),
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"app": "foo",
+						},
+					},
+					Strategy: appsv1.DeploymentStrategy{
+						Type: appsv1.RecreateDeploymentStrategyType,
+					},
+					Template: corev1.PodTemplateSpec{},
+				},
+			},
+		},
+		{
+			name: "with minreadyseconds",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithMinReadySeconds(int32(20)),
+				},
+			},
+			want: appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph",
+					},
+				},
+				Spec: appsv1.DeploymentSpec{
+					MinReadySeconds:      int32(20),
+					Replicas:             pointers.Ptr[int32](1),
+					RevisionHistoryLimit: pointers.Ptr[int32](10),
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"app": "foo",
+						},
+					},
+					Strategy: appsv1.DeploymentStrategy{
+						Type: appsv1.RecreateDeploymentStrategyType,
+					},
+					Template: corev1.PodTemplateSpec{},
+				},
+			},
+		},
+		{
+			name: "with replicas",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithReplicas(int32(10)),
+				},
+			},
+			want: appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph",
+					},
+				},
+				Spec: appsv1.DeploymentSpec{
+					MinReadySeconds:      int32(10),
+					Replicas:             pointers.Ptr[int32](10),
+					RevisionHistoryLimit: pointers.Ptr[int32](10),
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"app": "foo",
+						},
+					},
+					Strategy: appsv1.DeploymentStrategy{
+						Type: appsv1.RecreateDeploymentStrategyType,
+					},
+					Template: corev1.PodTemplateSpec{},
+				},
+			},
+		},
+		{
+			name: "with revision history limit",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithRevisionHistoryLimit(int32(100)),
+				},
+			},
+			want: appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph",
+					},
+				},
+				Spec: appsv1.DeploymentSpec{
+					MinReadySeconds:      int32(10),
+					Replicas:             pointers.Ptr[int32](1),
+					RevisionHistoryLimit: pointers.Ptr[int32](100),
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"app": "foo",
+						},
+					},
+					Strategy: appsv1.DeploymentStrategy{
+						Type: appsv1.RecreateDeploymentStrategyType,
+					},
+					Template: corev1.PodTemplateSpec{},
+				},
+			},
+		},
+		{
+			name: "with selector",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithSelector(metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"app": "bar",
+						},
+					}),
+				},
+			},
+			want: appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph",
+					},
+				},
+				Spec: appsv1.DeploymentSpec{
+					MinReadySeconds:      int32(10),
+					Replicas:             pointers.Ptr[int32](1),
+					RevisionHistoryLimit: pointers.Ptr[int32](10),
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"app": "bar",
+						},
+					},
+					Strategy: appsv1.DeploymentStrategy{
+						Type: appsv1.RecreateDeploymentStrategyType,
+					},
+					Template: corev1.PodTemplateSpec{},
+				},
+			},
+		},
+		{
+			name: "with deployment strategy",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithDeploymentStrategy(appsv1.DeploymentStrategy{
+						Type: appsv1.RollingUpdateDeploymentStrategyType,
+					}),
+				},
+			},
+			want: appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph",
+					},
+				},
+				Spec: appsv1.DeploymentSpec{
+					MinReadySeconds:      int32(10),
+					Replicas:             pointers.Ptr[int32](1),
+					RevisionHistoryLimit: pointers.Ptr[int32](10),
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"app": "foo",
+						},
+					},
+					Strategy: appsv1.DeploymentStrategy{
+						Type: appsv1.RollingUpdateDeploymentStrategyType,
+					},
+					Template: corev1.PodTemplateSpec{},
+				},
+			},
+		},
+		{
+			name: "with pod template spec",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithPodTemplateSpec(func() corev1.PodTemplateSpec {
+						ts, _ := pod.NewPodTemplate("foo", "sourcegraph")
+						return ts.Template
+					}()),
+				},
+			},
+			want: appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph",
+					},
+				},
+				Spec: appsv1.DeploymentSpec{
+					MinReadySeconds:      int32(10),
+					Replicas:             pointers.Ptr[int32](1),
+					RevisionHistoryLimit: pointers.Ptr[int32](10),
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"app": "foo",
+						},
+					},
+					Strategy: appsv1.DeploymentStrategy{
+						Type: appsv1.RecreateDeploymentStrategyType,
+					},
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "foo",
+							Namespace: "sourcegraph",
+							Annotations: map[string]string{
+								"kubectl.kubernetes.io/default-container": "foo",
+							},
+							Labels: map[string]string{
+								"app":    "foo",
+								"deploy": "sourcegraph",
+							},
+						},
+						Spec: corev1.PodSpec{
+							SecurityContext: &corev1.PodSecurityContext{
+								RunAsUser:           pointers.Ptr[int64](100),
+								RunAsGroup:          pointers.Ptr[int64](101),
+								FSGroup:             pointers.Ptr[int64](101),
+								FSGroupChangePolicy: pointers.Ptr(corev1.FSGroupChangeOnRootMismatch),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := NewDeployment(tt.args.name, tt.args.namespace, tt.args.options...)
+			if err != nil {
+				t.Errorf("NewDeployment() error: %v", err)
+			}
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("NewDeployment() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/internal/k8s/resource/deployment/example_test.go
+++ b/internal/k8s/resource/deployment/example_test.go
@@ -1,0 +1,42 @@
+package deployment
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"sigs.k8s.io/yaml"
+)
+
+func ExampleDeployment() {
+	d, _ := NewDeployment("test", "sourcegraph")
+
+	jd, _ := json.Marshal(d)
+	fmt.Println(string(jd))
+
+	yd, _ := yaml.Marshal(d)
+	fmt.Println(string(yd))
+
+	// Output:
+	// {"metadata":{"name":"test","namespace":"sourcegraph","creationTimestamp":null,"labels":{"deploy":"sourcegraph"}},"spec":{"replicas":1,"selector":{"matchLabels":{"app":"test"}},"template":{"metadata":{"creationTimestamp":null},"spec":{"containers":null}},"strategy":{"type":"Recreate"},"minReadySeconds":10,"revisionHistoryLimit":10},"status":{}}
+	// metadata:
+	//   creationTimestamp: null
+	//   labels:
+	//     deploy: sourcegraph
+	//   name: test
+	//   namespace: sourcegraph
+	// spec:
+	//   minReadySeconds: 10
+	//   replicas: 1
+	//   revisionHistoryLimit: 10
+	//   selector:
+	//     matchLabels:
+	//       app: test
+	//   strategy:
+	//     type: Recreate
+	//   template:
+	//     metadata:
+	//       creationTimestamp: null
+	//     spec:
+	//       containers: null
+	// status: {}
+}

--- a/internal/k8s/resource/serviceaccount/serviceaccount.go
+++ b/internal/k8s/resource/serviceaccount/serviceaccount.go
@@ -39,7 +39,7 @@ func NewServiceAccount(name, namespace string, options ...Option) (corev1.Servic
 // Option sets an option for a ServiceAccount.
 type Option func(serviceAccount *corev1.ServiceAccount) error
 
-// WithLabels sets ServiceAccount labes without overriding existing labels.
+// WithLabels sets ServiceAccount labels without overriding existing labels.
 func WithLabels(labels map[string]string) Option {
 	return func(serviceAccount *corev1.ServiceAccount) error {
 		serviceAccount.Labels = maps.MergePreservingExistingKeys(serviceAccount.Labels, labels)

--- a/internal/k8s/resource/storage/storageclass.go
+++ b/internal/k8s/resource/storage/storageclass.go
@@ -112,7 +112,7 @@ func DisallowVolumeExpansion() Option {
 	}
 }
 
-// WithVolumeBindingMode sets the given VolumeBindingMode on the StorageClasss.
+// WithVolumeBindingMode sets the given VolumeBindingMode on the StorageClass.
 func WithVolumeBindingMode(volumeBindingMode storagev1.VolumeBindingMode) Option {
 	return func(storageClass *storagev1.StorageClass) error {
 		storageClass.VolumeBindingMode = &volumeBindingMode


### PR DESCRIPTION
Add `deployment` pgk to create k8s deployment with patterns and defaults common to Sourcegraph.

## Test plan

Full unit test coverage as well as testable examples

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
