### PR TITLE
v2t: add v2t to notebooks

### DIFF
--- a/client/web/src/LegacySourcegraphWebApp.tsx
+++ b/client/web/src/LegacySourcegraphWebApp.tsx
@@ -124,6 +124,7 @@ export class LegacySourcegraphWebApp extends React.Component<StaticAppConfig, Le
                 // Override the no-op telemetryRecorder from initialization
                 const { platformContext } = this.state
                 platformContext.telemetryRecorder = telemetryRecorderProvider.getRecorder()
+
                 this.setState({
                     graphqlClient,
                     temporarySettingsStorage: new TemporarySettingsStorage(

--- a/client/web/src/LegacySourcegraphWebApp.tsx
+++ b/client/web/src/LegacySourcegraphWebApp.tsx
@@ -124,7 +124,6 @@ export class LegacySourcegraphWebApp extends React.Component<StaticAppConfig, Le
                 // Override the no-op telemetryRecorder from initialization
                 const { platformContext } = this.state
                 platformContext.telemetryRecorder = telemetryRecorderProvider.getRecorder()
-
                 this.setState({
                     graphqlClient,
                     temporarySettingsStorage: new TemporarySettingsStorage(

--- a/client/web/src/notebooks/GlobalNotebooksArea.tsx
+++ b/client/web/src/notebooks/GlobalNotebooksArea.tsx
@@ -41,21 +41,19 @@ export interface GlobalNotebooksAreaProps
 export const GlobalNotebooksArea: FC<React.PropsWithChildren<GlobalNotebooksAreaProps>> = ({
     authenticatedUser,
     ...outerProps
-}) => {
-    return (
-        <Routes>
-            <Route index={true} element={<NotebooksListPage authenticatedUser={authenticatedUser} {...outerProps} />} />
-            <Route
-                path="new"
-                element={
-                    authenticatedUser ? (
-                        <CreateNotebookPage authenticatedUser={authenticatedUser} {...outerProps} />
-                    ) : (
-                        <Navigate to={PageRoutes.Notebooks} replace={true} />
-                    )
-                }
-            />
-            <Route path=":id" element={<NotebookPage authenticatedUser={authenticatedUser} {...outerProps} />} />
-        </Routes>
-    )
-}
+}) => (
+    <Routes>
+        <Route index={true} element={<NotebooksListPage authenticatedUser={authenticatedUser} {...outerProps} />} />
+        <Route
+            path="new"
+            element={
+                authenticatedUser ? (
+                    <CreateNotebookPage authenticatedUser={authenticatedUser} {...outerProps} />
+                ) : (
+                    <Navigate to={PageRoutes.Notebooks} replace={true} />
+                )
+            }
+        />
+        <Route path=":id" element={<NotebookPage authenticatedUser={authenticatedUser} {...outerProps} />} />
+    </Routes>
+)

--- a/client/web/src/notebooks/GlobalNotebooksArea.tsx
+++ b/client/web/src/notebooks/GlobalNotebooksArea.tsx
@@ -7,6 +7,7 @@ import type { FetchFileParameters } from '@sourcegraph/shared/src/backend/file'
 import type { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
 import type { SearchContextProps } from '@sourcegraph/shared/src/search'
 import type { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { lazyComponent } from '@sourcegraph/shared/src/util/lazyComponent'
 
@@ -23,6 +24,7 @@ const NotebooksListPage = lazyComponent(() => import('./listPage/NotebooksListPa
 
 export interface GlobalNotebooksAreaProps
     extends TelemetryProps,
+        TelemetryV2Props,
         PlatformContextProps,
         SettingsCascadeProps,
         NotebookProps,
@@ -39,19 +41,22 @@ export interface GlobalNotebooksAreaProps
 export const GlobalNotebooksArea: FC<React.PropsWithChildren<GlobalNotebooksAreaProps>> = ({
     authenticatedUser,
     ...outerProps
-}) => (
-    <Routes>
-        <Route index={true} element={<NotebooksListPage authenticatedUser={authenticatedUser} {...outerProps} />} />
-        <Route
-            path="new"
-            element={
-                authenticatedUser ? (
-                    <CreateNotebookPage authenticatedUser={authenticatedUser} {...outerProps} />
-                ) : (
-                    <Navigate to={PageRoutes.Notebooks} replace={true} />
-                )
-            }
-        />
-        <Route path=":id" element={<NotebookPage authenticatedUser={authenticatedUser} {...outerProps} />} />
-    </Routes>
-)
+}) => {
+    console.log('outerProps.telemetryRecorder', outerProps.telemetryRecorder)
+    return (
+        <Routes>
+            <Route index={true} element={<NotebooksListPage authenticatedUser={authenticatedUser} {...outerProps} />} />
+            <Route
+                path="new"
+                element={
+                    authenticatedUser ? (
+                        <CreateNotebookPage authenticatedUser={authenticatedUser} {...outerProps} />
+                    ) : (
+                        <Navigate to={PageRoutes.Notebooks} replace={true} />
+                    )
+                }
+            />
+            <Route path=":id" element={<NotebookPage authenticatedUser={authenticatedUser} {...outerProps} />} />
+        </Routes>
+    )
+}

--- a/client/web/src/notebooks/GlobalNotebooksArea.tsx
+++ b/client/web/src/notebooks/GlobalNotebooksArea.tsx
@@ -42,7 +42,6 @@ export const GlobalNotebooksArea: FC<React.PropsWithChildren<GlobalNotebooksArea
     authenticatedUser,
     ...outerProps
 }) => {
-    console.log('outerProps.telemetryRecorder', outerProps.telemetryRecorder)
     return (
         <Routes>
             <Route index={true} element={<NotebooksListPage authenticatedUser={authenticatedUser} {...outerProps} />} />

--- a/client/web/src/notebooks/blocks/file/NotebookFileBlock.tsx
+++ b/client/web/src/notebooks/blocks/file/NotebookFileBlock.tsx
@@ -9,6 +9,7 @@ import { startWith } from 'rxjs/operators'
 import { CodeExcerpt } from '@sourcegraph/branded'
 import { isErrorLike } from '@sourcegraph/common'
 import { getRepositoryUrl } from '@sourcegraph/shared/src/search/stream'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { codeCopiedEvent } from '@sourcegraph/shared/src/tracking/event-log-creators'
 import { toPrettyBlobURL } from '@sourcegraph/shared/src/util/url'
@@ -28,7 +29,7 @@ import { NotebookFileBlockInputs } from './NotebookFileBlockInputs'
 
 import styles from './NotebookFileBlock.module.scss'
 
-interface NotebookFileBlockProps extends BlockProps<FileBlock>, TelemetryProps {
+interface NotebookFileBlockProps extends BlockProps<FileBlock>, TelemetryProps, TelemetryV2Props {
     isSourcegraphDotCom: boolean
 }
 
@@ -40,6 +41,7 @@ export const NotebookFileBlock: React.FunctionComponent<React.PropsWithChildren<
         input,
         output,
         telemetryService,
+        telemetryRecorder,
         isSelected,
         showMenu,
         isReadOnly,
@@ -156,7 +158,8 @@ export const NotebookFileBlock: React.FunctionComponent<React.PropsWithChildren<
 
         const logEventOnCopy = useCallback(() => {
             telemetryService.log(...codeCopiedEvent('notebook-file-block'))
-        }, [telemetryService])
+            telemetryRecorder.recordEvent('notebook.code', 'copy', { metadata: { page: 2 } })
+        }, [telemetryService, telemetryRecorder])
 
         return (
             <NotebookBlock

--- a/client/web/src/notebooks/blocks/query/NotebookQueryBlock.story.tsx
+++ b/client/web/src/notebooks/blocks/query/NotebookQueryBlock.story.tsx
@@ -4,6 +4,7 @@ import { of } from 'rxjs'
 
 import type { AggregateStreamingSearchResults } from '@sourcegraph/shared/src/search/stream'
 import { EMPTY_SETTINGS_CASCADE } from '@sourcegraph/shared/src/settings/settings'
+import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import {
     HIGHLIGHTED_FILE_LINES_LONG,
@@ -63,6 +64,7 @@ export const Default: StoryFn = () => (
                 searchContextsEnabled={true}
                 ownEnabled={true}
                 telemetryService={NOOP_TELEMETRY_SERVICE}
+                telemetryRecorder={noOpTelemetryRecorder}
                 fetchHighlightedFileLineRanges={() => of([HIGHLIGHTED_FILE_LINES_LONG])}
                 settingsCascade={EMPTY_SETTINGS_CASCADE}
                 platformContext={NOOP_PLATFORM_CONTEXT}
@@ -87,6 +89,7 @@ export const Selected: StoryFn = () => (
                 searchContextsEnabled={true}
                 ownEnabled={true}
                 telemetryService={NOOP_TELEMETRY_SERVICE}
+                telemetryRecorder={noOpTelemetryRecorder}
                 fetchHighlightedFileLineRanges={() => of([HIGHLIGHTED_FILE_LINES_LONG])}
                 settingsCascade={EMPTY_SETTINGS_CASCADE}
                 authenticatedUser={null}
@@ -112,6 +115,7 @@ export const ReadOnlySelected: StoryFn = () => (
                 searchContextsEnabled={true}
                 ownEnabled={true}
                 telemetryService={NOOP_TELEMETRY_SERVICE}
+                telemetryRecorder={noOpTelemetryRecorder}
                 fetchHighlightedFileLineRanges={() => of([HIGHLIGHTED_FILE_LINES_LONG])}
                 settingsCascade={EMPTY_SETTINGS_CASCADE}
                 authenticatedUser={null}

--- a/client/web/src/notebooks/blocks/query/NotebookQueryBlock.tsx
+++ b/client/web/src/notebooks/blocks/query/NotebookQueryBlock.tsx
@@ -191,7 +191,6 @@ export const NotebookQueryBlock: React.FunctionComponent<React.PropsWithChildren
                                 results={searchResults}
                                 fetchHighlightedFileLineRanges={fetchHighlightedFileLineRanges}
                                 telemetryService={telemetryService}
-                                telemetryRecorder={telemetryRecorder}
                                 settingsCascade={settingsCascade}
                                 platformContext={props.platformContext}
                                 openMatchesInNewTab={true}

--- a/client/web/src/notebooks/blocks/query/NotebookQueryBlock.tsx
+++ b/client/web/src/notebooks/blocks/query/NotebookQueryBlock.tsx
@@ -12,6 +12,7 @@ import type { PlatformContextProps } from '@sourcegraph/shared/src/platform/cont
 import type { SearchContextProps } from '@sourcegraph/shared/src/search'
 import { fetchStreamSuggestions } from '@sourcegraph/shared/src/search/suggestions'
 import type { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { buildSearchURLQuery } from '@sourcegraph/shared/src/util/url'
 import { LoadingSpinner, useObservable, Icon } from '@sourcegraph/wildcard'
@@ -33,6 +34,7 @@ interface NotebookQueryBlockProps
         Pick<SearchContextProps, 'searchContextsEnabled'>,
         SettingsCascadeProps,
         TelemetryProps,
+        TelemetryV2Props,
         PlatformContextProps<'requestGraphQL' | 'urlToFile' | 'settings'>,
         OwnConfigProps {
     isSourcegraphDotCom: boolean
@@ -57,6 +59,7 @@ export const NotebookQueryBlock: React.FunctionComponent<React.PropsWithChildren
         input,
         output,
         telemetryService,
+        telemetryRecorder,
         settingsCascade,
         isSelected,
         onBlockInputChange,
@@ -188,6 +191,7 @@ export const NotebookQueryBlock: React.FunctionComponent<React.PropsWithChildren
                                 results={searchResults}
                                 fetchHighlightedFileLineRanges={fetchHighlightedFileLineRanges}
                                 telemetryService={telemetryService}
+                                telemetryRecorder={telemetryRecorder}
                                 settingsCascade={settingsCascade}
                                 platformContext={props.platformContext}
                                 openMatchesInNewTab={true}

--- a/client/web/src/notebooks/blocks/symbol/NotebookSymbolBlock.tsx
+++ b/client/web/src/notebooks/blocks/symbol/NotebookSymbolBlock.tsx
@@ -12,6 +12,7 @@ import type { PlatformContextProps } from '@sourcegraph/shared/src/platform/cont
 import { getRepositoryUrl } from '@sourcegraph/shared/src/search/stream'
 import { useExperimentalFeatures } from '@sourcegraph/shared/src/settings/settings'
 import { SymbolKind } from '@sourcegraph/shared/src/symbols/SymbolKind'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { codeCopiedEvent } from '@sourcegraph/shared/src/tracking/event-log-creators'
 import { toPrettyBlobURL } from '@sourcegraph/shared/src/util/url'
@@ -32,6 +33,7 @@ import styles from './NotebookSymbolBlock.module.scss'
 interface NotebookSymbolBlockProps
     extends BlockProps<SymbolBlock>,
         TelemetryProps,
+        TelemetryV2Props,
         PlatformContextProps<'requestGraphQL' | 'urlToFile' | 'settings'> {
     isSourcegraphDotCom: boolean
 }
@@ -51,6 +53,7 @@ export const NotebookSymbolBlock: React.FunctionComponent<React.PropsWithChildre
             input,
             output,
             telemetryService,
+            telemetryRecorder,
             isSelected,
             showMenu,
             isReadOnly,
@@ -139,7 +142,8 @@ export const NotebookSymbolBlock: React.FunctionComponent<React.PropsWithChildre
 
             const logEventOnCopy = useCallback(() => {
                 telemetryService.log(...codeCopiedEvent('notebook-symbols'))
-            }, [telemetryService])
+                telemetryRecorder.recordEvent('notebook.code', 'copy', { metadata: { page: 1 } })
+            }, [telemetryService, telemetryRecorder])
 
             return (
                 <NotebookBlock

--- a/client/web/src/notebooks/createPage/CreateNotebookPage.tsx
+++ b/client/web/src/notebooks/createPage/CreateNotebookPage.tsx
@@ -4,6 +4,7 @@ import { Navigate } from 'react-router-dom'
 import { catchError, startWith } from 'rxjs/operators'
 
 import { asError, isErrorLike } from '@sourcegraph/common'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { LoadingSpinner, useObservable, Alert } from '@sourcegraph/wildcard'
 
@@ -15,8 +16,8 @@ import { createNotebook } from '../backend'
 const LOADING = 'loading' as const
 
 export const CreateNotebookPage: React.FunctionComponent<
-    React.PropsWithChildren<TelemetryProps & { authenticatedUser: AuthenticatedUser }>
-> = ({ telemetryService, authenticatedUser }) => {
+    React.PropsWithChildren<TelemetryProps & TelemetryV2Props & { authenticatedUser: AuthenticatedUser }>
+> = ({ telemetryService, authenticatedUser, telemetryRecorder }) => {
     const notebookOrError = useObservable(
         useMemo(
             () =>
@@ -32,6 +33,7 @@ export const CreateNotebookPage: React.FunctionComponent<
 
     if (notebookOrError && !isErrorLike(notebookOrError) && notebookOrError !== LOADING) {
         telemetryService.log('SearchNotebookCreated')
+        telemetryRecorder.recordEvent('notebook', 'create')
         return <Navigate to={PageRoutes.Notebook.replace(':id', notebookOrError.id)} replace={true} />
     }
 

--- a/client/web/src/notebooks/index.ts
+++ b/client/web/src/notebooks/index.ts
@@ -10,6 +10,14 @@ import type { HighlightLineRange, SymbolKind } from '../graphql-operations'
 // When adding a new block type, make sure to track its usage in internal/usagestats/notebooks.go.
 export type BlockType = 'md' | 'query' | 'file' | 'compute' | 'symbol'
 
+export const V2BlockTypes: { [key in BlockType]: number } = {
+    md: 1,
+    query: 2,
+    file: 3,
+    compute: 4,
+    symbol: 5,
+}
+
 interface BaseBlock<I, O> {
     id: string
     type: BlockType

--- a/client/web/src/notebooks/listPage/NotebooksGettingStartedTab.tsx
+++ b/client/web/src/notebooks/listPage/NotebooksGettingStartedTab.tsx
@@ -55,7 +55,10 @@ const functionalityPanels = [
 export const NotebooksGettingStartedTab: React.FunctionComponent<
     React.PropsWithChildren<NotebooksGettingStartedTabProps>
 > = ({ telemetryService, authenticatedUser }) => {
-    useEffect(() => telemetryService.log('NotebooksGettingStartedTabViewed'), [telemetryService])
+    useEffect(() => {
+        // No V2 telemetry required, as this is duplicative with the view event logged in NotebooksListPage.tsx.
+        telemetryService.log('NotebooksGettingStartedTabViewed')
+    }, [telemetryService])
 
     const [, setHasSeenGettingStartedTab] = useTemporarySetting('search.notebooks.gettingStartedTabSeen', false)
     const isSourcegraphDotCom: boolean = window.context?.sourcegraphDotComMode || false

--- a/client/web/src/notebooks/listPage/NotebooksList.tsx
+++ b/client/web/src/notebooks/listPage/NotebooksList.tsx
@@ -13,12 +13,13 @@ import type {
 import type { fetchNotebooks as _fetchNotebooks } from '../backend'
 
 import { NotebookNode, type NotebookNodeProps } from './NotebookNode'
+import { type NotebooksFilterEvents } from './NotebooksListPage'
 
 import styles from './NotebooksList.module.scss'
 
 export interface NotebooksListProps extends TelemetryProps {
     title: string
-    logEventName: string
+    logEventName: NotebooksFilterEvents
     orderOptions: FilteredConnectionFilter[]
     creatorUserID?: string
     starredByUserID?: string
@@ -36,10 +37,10 @@ export const NotebooksList: FC<NotebooksListProps> = ({
     fetchNotebooks,
     telemetryService,
 }) => {
-    useEffect(
-        () => telemetryService.logViewEvent(`SearchNotebooksList${logEventName}`),
-        [logEventName, telemetryService]
-    )
+    useEffect(() => {
+        // No V2 telemetry required, as this is duplicative with the view event logged in NotebooksListPage.tsx.
+        telemetryService.logViewEvent(`SearchNotebooksList${logEventName}`)
+    }, [logEventName, telemetryService])
 
     const queryConnection = useCallback(
         (args: Partial<ListNotebooksVariables>) => {

--- a/client/web/src/notebooks/listPage/NotebooksListPage.story.tsx
+++ b/client/web/src/notebooks/listPage/NotebooksListPage.story.tsx
@@ -2,6 +2,7 @@ import type { Decorator, StoryFn, Meta } from '@storybook/react'
 import { subDays } from 'date-fns'
 import { type Observable, of } from 'rxjs'
 
+import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
 
 import { WebStory } from '../../components/WebStory'
@@ -70,6 +71,7 @@ export const Default: StoryFn = () => (
             <NotebooksListPage
                 {...props}
                 telemetryService={NOOP_TELEMETRY_SERVICE}
+                telemetryRecorder={noOpTelemetryRecorder}
                 authenticatedUser={null}
                 fetchNotebooks={fetchNotebooks}
             />

--- a/client/web/src/notebooks/listPage/NotebooksListPage.tsx
+++ b/client/web/src/notebooks/listPage/NotebooksListPage.tsx
@@ -82,7 +82,7 @@ export const NotebooksListPage: React.FunctionComponent<React.PropsWithChildren<
     useEffect(() => {
         telemetryService.logPageView('SearchNotebooksListPage')
         telemetryRecorder.recordEvent('notebooks.list', 'view', {
-            metadata: { tab: selectedTab == 'notebooks' ? 0 : 1 },
+            metadata: { tab: selectedTab === 'notebooks' ? 0 : 1 },
         })
     }, [telemetryService, telemetryRecorder, selectedTab])
 

--- a/client/web/src/notebooks/listPage/NotebooksListPage.tsx
+++ b/client/web/src/notebooks/listPage/NotebooksListPage.tsx
@@ -8,6 +8,7 @@ import { catchError, startWith, switchMap } from 'rxjs/operators'
 
 import { asError, type ErrorLike, isErrorLike } from '@sourcegraph/common'
 import { useTemporarySetting } from '@sourcegraph/shared/src/settings/temporary/useTemporarySetting'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { PageHeader, Button, useEventObservable, Alert, ButtonLink } from '@sourcegraph/wildcard'
 
@@ -22,7 +23,7 @@ import { NotebooksGettingStartedTab } from './NotebooksGettingStartedTab'
 import { NotebooksList, type NotebooksListProps } from './NotebooksList'
 import { NotebooksListPageHeader } from './NotebooksListPageHeader'
 
-export interface NotebooksListPageProps extends TelemetryProps {
+export interface NotebooksListPageProps extends TelemetryProps, TelemetryV2Props {
     authenticatedUser: AuthenticatedUser | null
     fetchNotebooks?: typeof _fetchNotebooks
     createNotebook?: typeof _createNotebook
@@ -55,22 +56,21 @@ function setSelectedLocationTab(location: Location, navigate: NavigateFunction, 
 
 const LOADING = 'loading' as const
 
+export type NotebooksFilterEvents = 'myNotebooks' | 'starredNotebooks' | 'allNotebooks' | 'orgNotebooks'
+
 interface NotebooksFilter extends Pick<NotebooksListProps, 'creatorUserID' | 'starredByUserID' | 'namespace'> {
     id: string
     label: string
-    logEventName: string
+    logEventName: NotebooksFilterEvents
 }
 
 export const NotebooksListPage: React.FunctionComponent<React.PropsWithChildren<NotebooksListPageProps>> = ({
     authenticatedUser,
     telemetryService,
+    telemetryRecorder,
     fetchNotebooks = _fetchNotebooks,
     createNotebook = _createNotebook,
 }) => {
-    useEffect(() => {
-        telemetryService.logPageView('SearchNotebooksListPage')
-    }, [telemetryService])
-
     const [importState, setImportState] = useState<typeof LOADING | ErrorLike | undefined>()
     const navigate = useNavigate()
     const location = useLocation()
@@ -78,6 +78,14 @@ export const NotebooksListPage: React.FunctionComponent<React.PropsWithChildren<
     const [selectedTab, setSelectedTab] = useState<NotebooksTab>(
         getSelectedTabFromLocation(location.search, authenticatedUser)
     )
+
+    useEffect(() => {
+        telemetryService.logPageView('SearchNotebooksListPage')
+        telemetryRecorder.recordEvent('notebooks.list', 'view', {
+            metadata: { tab: selectedTab == 'notebooks' ? 0 : 1 },
+        })
+    }, [telemetryService, telemetryRecorder, selectedTab])
+
     const [selectedFilter, setSelectedFilter] = useState<NotebooksFilter>()
 
     const [hasSeenGettingStartedTab] = useTemporarySetting('search.notebooks.gettingStartedTabSeen', false)
@@ -93,8 +101,9 @@ export const NotebooksListPage: React.FunctionComponent<React.PropsWithChildren<
             setSelectedTab(tab)
             setSelectedLocationTab(location, navigate, tab)
             telemetryService.log(logName)
+            telemetryRecorder.recordEvent(`notebooks.list.tab.${tab}`, 'click')
         },
-        [navigate, location, setSelectedTab, telemetryService]
+        [navigate, location, setSelectedTab, telemetryService, telemetryRecorder]
     )
 
     const orderOptions: FilteredConnectionFilter[] = [
@@ -161,7 +170,7 @@ export const NotebooksListPage: React.FunctionComponent<React.PropsWithChildren<
             authenticatedUser?.organizations.nodes.map(org => ({
                 id: `org-${org.id}-notebooks`,
                 label: `${org.displayName} notebooks`,
-                logEventName: 'OrgNotebooks',
+                logEventName: 'orgNotebooks',
                 namespace: org.id,
             })),
         [authenticatedUser]
@@ -192,18 +201,18 @@ export const NotebooksListPage: React.FunctionComponent<React.PropsWithChildren<
                     id: 'my-notebooks',
                     label: 'Created by me',
                     creatorUserID: authenticatedUser.id,
-                    logEventName: 'MyNotebooks',
+                    logEventName: 'myNotebooks',
                 },
                 authenticatedUser && {
                     id: 'starred-notebooks',
                     label: 'Starred',
                     starredByUserID: authenticatedUser.id,
-                    logEventName: 'StarredNotebooks',
+                    logEventName: 'starredNotebooks',
                 },
                 {
                     id: 'all-notebooks',
                     label: 'All notebooks',
-                    logEventName: 'ExploreNotebooks',
+                    logEventName: 'exploreNotebooks',
                 },
                 ...(orgFilters || []),
             ].filter((filter): filter is NotebooksFilter => !!filter),
@@ -236,6 +245,7 @@ export const NotebooksListPage: React.FunctionComponent<React.PropsWithChildren<
 
     if (importedNotebookOrError && importedNotebookOrError !== LOADING) {
         telemetryService.log('SearchNotebookImportedFromMarkdown')
+        telemetryRecorder.recordEvent('notebook', 'importedFromMarkdown')
         return <Navigate to={PageRoutes.Notebook.replace(':id', importedNotebookOrError.id)} replace={true} />
     }
 
@@ -250,6 +260,7 @@ export const NotebooksListPage: React.FunctionComponent<React.PropsWithChildren<
                                 importNotebook={importNotebook}
                                 setImportState={setImportState}
                                 telemetryService={telemetryService}
+                                telemetryRecorder={telemetryRecorder}
                             />
                         )
                     }

--- a/client/web/src/notebooks/listPage/NotebooksListPageHeader.tsx
+++ b/client/web/src/notebooks/listPage/NotebooksListPageHeader.tsx
@@ -5,6 +5,7 @@ import { VisuallyHidden } from '@reach/visually-hidden'
 import * as uuid from 'uuid'
 
 import type { ErrorLike } from '@sourcegraph/common'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import {
     Link,
@@ -35,7 +36,7 @@ const INVALID_IMPORT_FILE_ERROR = new Error(
 
 const MAX_FILE_SIZE_IN_BYTES = 1000 * 1000 // 1MB
 
-interface NotebooksListPageHeaderProps extends TelemetryProps {
+interface NotebooksListPageHeaderProps extends TelemetryProps, TelemetryV2Props {
     authenticatedUser: AuthenticatedUser
     importNotebook: (notebook: CreateNotebookVariables['notebook']) => void
     setImportState: (state: typeof LOADING | ErrorLike | undefined) => void
@@ -43,14 +44,15 @@ interface NotebooksListPageHeaderProps extends TelemetryProps {
 
 export const NotebooksListPageHeader: React.FunctionComponent<
     React.PropsWithChildren<NotebooksListPageHeaderProps>
-> = ({ authenticatedUser, telemetryService, setImportState, importNotebook }) => {
+> = ({ authenticatedUser, telemetryService, telemetryRecorder, setImportState, importNotebook }) => {
     const fileInputReference = useRef<HTMLInputElement>(null)
 
     const onImportMenuItemSelect = useCallback(() => {
         telemetryService.log('SearchNotebookImportMarkdownNotebookButtonClick')
+        telemetryRecorder.recordEvent('notebook.importFromMarkdown', 'click')
         // Open the system file picker.
         fileInputReference.current?.click()
-    }, [fileInputReference, telemetryService])
+    }, [fileInputReference, telemetryService, telemetryRecorder])
 
     const onFileLoad = useCallback(
         (event: ProgressEvent<FileReader>, fileName: string): void => {

--- a/client/web/src/notebooks/notebook/NotebookComponent.story.tsx
+++ b/client/web/src/notebooks/notebook/NotebookComponent.story.tsx
@@ -2,6 +2,7 @@ import type { Decorator, Meta, StoryFn } from '@storybook/react'
 import { NEVER, of } from 'rxjs'
 
 import { EMPTY_SETTINGS_CASCADE } from '@sourcegraph/shared/src/settings/settings'
+import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { HIGHLIGHTED_FILE_LINES_LONG, NOOP_PLATFORM_CONTEXT } from '@sourcegraph/shared/src/testing/searchTestHelpers'
 
@@ -47,6 +48,7 @@ export const Default: StoryFn = () => (
                 searchContextsEnabled={true}
                 ownEnabled={true}
                 telemetryService={NOOP_TELEMETRY_SERVICE}
+                telemetryRecorder={noOpTelemetryRecorder}
                 streamSearch={() => NEVER}
                 fetchHighlightedFileLineRanges={() => of([HIGHLIGHTED_FILE_LINES_LONG])}
                 onSerializeBlocks={() => {}}
@@ -71,6 +73,7 @@ export const DefaultReadOnly: StoryFn = () => (
                 searchContextsEnabled={true}
                 ownEnabled={true}
                 telemetryService={NOOP_TELEMETRY_SERVICE}
+                telemetryRecorder={noOpTelemetryRecorder}
                 streamSearch={() => NEVER}
                 fetchHighlightedFileLineRanges={() => of([HIGHLIGHTED_FILE_LINES_LONG])}
                 onSerializeBlocks={() => {}}

--- a/client/web/src/notebooks/notebook/NotebookComponent.tsx
+++ b/client/web/src/notebooks/notebook/NotebookComponent.tsx
@@ -10,10 +10,11 @@ import { catchError, delay, startWith, switchMap, tap } from 'rxjs/operators'
 import type { StreamingSearchResultsListProps } from '@sourcegraph/branded'
 import { asError, isErrorLike } from '@sourcegraph/common'
 import type { PlatformContext } from '@sourcegraph/shared/src/platform/context'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Button, useEventObservable, Icon } from '@sourcegraph/wildcard'
 
-import type { Block, BlockDirection, BlockInit, BlockInput, BlockType } from '..'
+import { V2BlockTypes, type Block, type BlockDirection, type BlockInit, type BlockInput, type BlockType } from '..'
 import type { AuthenticatedUser } from '../../auth'
 import type { NotebookFields } from '../../graphql-operations'
 import type { OwnConfigProps } from '../../own/OwnConfigProps'
@@ -34,6 +35,7 @@ import styles from './NotebookComponent.module.scss'
 export interface NotebookComponentProps
     extends SearchStreamingProps,
         TelemetryProps,
+        TelemetryV2Props,
         Omit<StreamingSearchResultsListProps, 'location' | 'allExpanded' | 'executedQuery'>,
         OwnConfigProps {
     isReadOnly?: boolean
@@ -83,6 +85,7 @@ export const NotebookComponent: React.FunctionComponent<React.PropsWithChildren<
         isEmbedded,
         authenticatedUser,
         telemetryService,
+        telemetryRecorder,
         isSourcegraphDotCom,
         platformContext,
         blocks: initialBlocks,
@@ -122,8 +125,10 @@ export const NotebookComponent: React.FunctionComponent<React.PropsWithChildren<
                     { blocksCount: blocks.length, blockCountsPerType },
                     { blocksCount: blocks.length, blockCountsPerType }
                 )
+                // No V2 telemetry needed, as this is not a direct user action, and is duplicative with
+                // other telemetry below (since updateBlocks() is called by the other user actions).
             },
-            [notebook, setBlocks, debouncedOnSerializeBlocks, telemetryService]
+            [notebook, setBlocks, debouncedOnSerializeBlocks, telemetryService, telemetryRecorder]
         )
 
         const selectBlock = useCallback(
@@ -150,26 +155,31 @@ export const NotebookComponent: React.FunctionComponent<React.PropsWithChildren<
                 notebook.runBlockById(id)
                 updateBlocks(false)
 
-                telemetryService.log(
-                    'SearchNotebookRunBlock',
-                    { type: notebook.getBlockById(id)?.type },
-                    { type: notebook.getBlockById(id)?.type }
-                )
+                const blockType = notebook.getBlockById(id)
+                telemetryService.log('SearchNotebookRunBlock', { type: blockType?.type }, { type: blockType?.type })
+                telemetryRecorder.recordEvent('notebook.block', 'run', {
+                    metadata: {
+                        type: blockType && blockType.type ? V2BlockTypes[blockType.type] : 0,
+                    },
+                })
             },
-            [notebook, telemetryService, updateBlocks]
+            [notebook, telemetryService, telemetryRecorder, updateBlocks]
         )
 
         const [runAllBlocks, runningAllBlocks] = useEventObservable(
             useCallback(
                 (click: Observable<React.MouseEvent>) =>
                     click.pipe(
+                        tap(() => {
+                            telemetryService.log('SearchNotebookRunAllBlocks')
+                            telemetryRecorder.recordEvent('notebook.blocks', 'runAll')
+                        }),
                         switchMap(() => notebook.runAllBlocks().pipe(startWith(LOADING))),
                         tap(() => {
                             updateBlocks(false)
-                            telemetryService.log('SearchNotebookRunAllBlocks')
                         })
                     ),
-                [notebook, telemetryService, updateBlocks]
+                [notebook, telemetryService, telemetryRecorder, updateBlocks]
             )
         )
 
@@ -181,9 +191,10 @@ export const NotebookComponent: React.FunctionComponent<React.PropsWithChildren<
                         tap(exportedMarkdown => {
                             downloadTextAsFile(exportedMarkdown, exportedFileName)
                             telemetryService.log('SearchNotebookExportNotebook')
+                            telemetryRecorder.recordEvent('notebook', 'export')
                         })
                     ),
-                [notebook, exportedFileName, telemetryService]
+                [notebook, exportedFileName, telemetryService, telemetryRecorder]
             )
         )
 
@@ -205,12 +216,14 @@ export const NotebookComponent: React.FunctionComponent<React.PropsWithChildren<
                 return
             }
             telemetryService.log('SearchNotebookCopyNotebookButtonClick')
+            telemetryRecorder.recordEvent('notebook', 'copy')
             copyNotebook({ namespace: authenticatedUser.id, blocks: notebook.getBlocks() })
         }, [authenticatedUser, copyNotebook, notebook, telemetryService])
 
         const onBlockInputChange = useCallback(
             (id: string, blockInput: BlockInput) => {
                 notebook.setBlockInputById(id, blockInput)
+                telemetryRecorder.recordEvent('notebook', 'changeInput')
                 updateBlocks()
             },
             [notebook, updateBlocks]
@@ -258,8 +271,11 @@ export const NotebookComponent: React.FunctionComponent<React.PropsWithChildren<
                 updateBlocks()
 
                 telemetryService.log('SearchNotebookAddBlock', { type: addedBlock.type }, { type: addedBlock.type })
+                telemetryRecorder.recordEvent('notebook.blocks', 'add', {
+                    metadata: { type: V2BlockTypes[addedBlock.type] },
+                })
             },
-            [isReadOnly, notebook, selectBlock, focusBlock, updateBlocks, telemetryService]
+            [isReadOnly, notebook, selectBlock, focusBlock, updateBlocks, telemetryService, telemetryRecorder]
         )
 
         const onDeleteBlock = useCallback(
@@ -278,8 +294,11 @@ export const NotebookComponent: React.FunctionComponent<React.PropsWithChildren<
                 updateBlocks()
 
                 telemetryService.log('SearchNotebookDeleteBlock', { type: block?.type }, { type: block?.type })
+                telemetryRecorder.recordEvent('notebook.block', 'delete', {
+                    metadata: { type: block ? V2BlockTypes[block.type] : 0 },
+                })
             },
-            [notebook, isReadOnly, telemetryService, selectBlock, updateBlocks, focusBlock]
+            [notebook, isReadOnly, telemetryService, telemetryRecorder, selectBlock, updateBlocks, focusBlock]
         )
 
         const onMoveBlock = useCallback(
@@ -292,13 +311,20 @@ export const NotebookComponent: React.FunctionComponent<React.PropsWithChildren<
                 focusBlock(id)
                 updateBlocks()
 
+                const blockType = notebook.getBlockById(id)
                 telemetryService.log(
                     'SearchNotebookMoveBlock',
-                    { type: notebook.getBlockById(id)?.type, direction },
-                    { type: notebook.getBlockById(id)?.type, direction }
+                    { type: blockType?.type, direction },
+                    { type: blockType?.type, direction }
                 )
+                telemetryRecorder.recordEvent('notebook.block', 'move', {
+                    metadata: {
+                        type: blockType ? V2BlockTypes[blockType.type] : 0,
+                        direction: direction == 'up' ? 1 : 2,
+                    },
+                })
             },
-            [notebook, isReadOnly, telemetryService, updateBlocks, focusBlock]
+            [notebook, isReadOnly, telemetryService, telemetryRecorder, updateBlocks, focusBlock]
         )
 
         const onDuplicateBlock = useCallback(
@@ -322,6 +348,9 @@ export const NotebookComponent: React.FunctionComponent<React.PropsWithChildren<
                     { type: duplicateBlock?.type },
                     { type: duplicateBlock?.type }
                 )
+                telemetryRecorder.recordEvent('notebook.block', 'duplicate', {
+                    metadata: { type: duplicateBlock ? V2BlockTypes[duplicateBlock.type] : 0 },
+                })
             },
             [notebook, isReadOnly, telemetryService, selectBlock, updateBlocks, focusBlock]
         )
@@ -390,6 +419,7 @@ export const NotebookComponent: React.FunctionComponent<React.PropsWithChildren<
                                 {...block}
                                 {...blockProps}
                                 telemetryService={telemetryService}
+                                telemetryRecorder={telemetryRecorder}
                                 isSourcegraphDotCom={isSourcegraphDotCom}
                             />
                         )
@@ -405,6 +435,7 @@ export const NotebookComponent: React.FunctionComponent<React.PropsWithChildren<
                                 ownEnabled={ownEnabled}
                                 settingsCascade={settingsCascade}
                                 telemetryService={telemetryService}
+                                telemetryRecorder={telemetryRecorder}
                                 platformContext={platformContext}
                                 authenticatedUser={authenticatedUser}
                             />
@@ -417,6 +448,7 @@ export const NotebookComponent: React.FunctionComponent<React.PropsWithChildren<
                                 {...blockProps}
                                 isSourcegraphDotCom={isSourcegraphDotCom}
                                 telemetryService={telemetryService}
+                                telemetryRecorder={telemetryRecorder}
                                 platformContext={platformContext}
                             />
                         )
@@ -436,6 +468,7 @@ export const NotebookComponent: React.FunctionComponent<React.PropsWithChildren<
                 isReadOnly,
                 isEmbedded,
                 telemetryService,
+                telemetryRecorder,
                 isSourcegraphDotCom,
                 fetchHighlightedFileLineRanges,
                 searchContextsEnabled,

--- a/client/web/src/notebooks/notebook/NotebookComponent.tsx
+++ b/client/web/src/notebooks/notebook/NotebookComponent.tsx
@@ -128,7 +128,7 @@ export const NotebookComponent: React.FunctionComponent<React.PropsWithChildren<
                 // No V2 telemetry needed, as this is not a direct user action, and is duplicative with
                 // other telemetry below (since updateBlocks() is called by the other user actions).
             },
-            [notebook, setBlocks, debouncedOnSerializeBlocks, telemetryService, telemetryRecorder]
+            [notebook, setBlocks, debouncedOnSerializeBlocks, telemetryService]
         )
 
         const selectBlock = useCallback(

--- a/client/web/src/notebooks/notebook/NotebookComponent.tsx
+++ b/client/web/src/notebooks/notebook/NotebookComponent.tsx
@@ -218,7 +218,7 @@ export const NotebookComponent: React.FunctionComponent<React.PropsWithChildren<
             telemetryService.log('SearchNotebookCopyNotebookButtonClick')
             telemetryRecorder.recordEvent('notebook', 'copy')
             copyNotebook({ namespace: authenticatedUser.id, blocks: notebook.getBlocks() })
-        }, [authenticatedUser, copyNotebook, notebook, telemetryService])
+        }, [authenticatedUser, copyNotebook, notebook, telemetryService, telemetryRecorder])
 
         const onBlockInputChange = useCallback(
             (id: string, blockInput: BlockInput) => {
@@ -226,7 +226,7 @@ export const NotebookComponent: React.FunctionComponent<React.PropsWithChildren<
                 telemetryRecorder.recordEvent('notebook', 'changeInput')
                 updateBlocks()
             },
-            [notebook, updateBlocks]
+            [notebook, updateBlocks, telemetryRecorder]
         )
 
         const onNewBlock = useCallback(
@@ -320,7 +320,7 @@ export const NotebookComponent: React.FunctionComponent<React.PropsWithChildren<
                 telemetryRecorder.recordEvent('notebook.block', 'move', {
                     metadata: {
                         type: blockType ? V2BlockTypes[blockType.type] : 0,
-                        direction: direction == 'up' ? 1 : 2,
+                        direction: direction === 'up' ? 1 : 2,
                     },
                 })
             },
@@ -352,7 +352,7 @@ export const NotebookComponent: React.FunctionComponent<React.PropsWithChildren<
                     metadata: { type: duplicateBlock ? V2BlockTypes[duplicateBlock.type] : 0 },
                 })
             },
-            [notebook, isReadOnly, telemetryService, selectBlock, updateBlocks, focusBlock]
+            [notebook, isReadOnly, telemetryService, telemetryRecorder, selectBlock, updateBlocks, focusBlock]
         )
 
         const onFocusLastBlock = useCallback(() => {

--- a/client/web/src/notebooks/notebookPage/DeleteNotebookModal.tsx
+++ b/client/web/src/notebooks/notebookPage/DeleteNotebookModal.tsx
@@ -5,12 +5,13 @@ import type { Observable } from 'rxjs'
 import { mergeMap, startWith, tap, catchError } from 'rxjs/operators'
 
 import { asError, isErrorLike } from '@sourcegraph/common'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { LoadingSpinner, useEventObservable, Modal, Button, Alert, H3, Text } from '@sourcegraph/wildcard'
 
 import type { deleteNotebook as _deleteNotebook } from '../backend'
 
-interface DeleteNotebookModalProps extends TelemetryProps {
+interface DeleteNotebookModalProps extends TelemetryProps, TelemetryV2Props {
     notebookId: string
     isOpen: boolean
     toggleDeleteModal: () => void
@@ -26,20 +27,25 @@ export const DeleteNotebookModal: FC<DeleteNotebookModalProps> = ({
     isOpen,
     toggleDeleteModal,
     telemetryService,
+    telemetryRecorder,
 }) => {
     const navigate = useNavigate()
 
     useEffect(() => {
         if (isOpen) {
             telemetryService.log('SearchNotebookDeleteModalOpened')
+            telemetryRecorder.recordEvent('notebook.deleteModal', 'open')
         }
-    }, [isOpen, telemetryService])
+    }, [isOpen, telemetryService, telemetryRecorder])
 
     const [onDelete, deleteCompletedOrError] = useEventObservable(
         useCallback(
             (click: Observable<React.MouseEvent<HTMLButtonElement>>) =>
                 click.pipe(
-                    tap(() => telemetryService.log('SearchNotebookDeleteButtonClicked')),
+                    tap(() => {
+                        telemetryService.log('SearchNotebookDeleteButtonClicked')
+                        telemetryRecorder.recordEvent('notebook', 'delete')
+                    }),
                     mergeMap(() =>
                         deleteNotebook(notebookId).pipe(
                             tap(() => {
@@ -50,7 +56,7 @@ export const DeleteNotebookModal: FC<DeleteNotebookModalProps> = ({
                         )
                     )
                 ),
-            [deleteNotebook, navigate, notebookId, telemetryService]
+            [deleteNotebook, navigate, notebookId, telemetryService, telemetryRecorder]
         )
     )
 

--- a/client/web/src/notebooks/notebookPage/EmbeddedNotebookPage.tsx
+++ b/client/web/src/notebooks/notebookPage/EmbeddedNotebookPage.tsx
@@ -25,7 +25,7 @@ interface EmbeddedNotebookPageProps
             NotebookContentProps,
             'searchContextsEnabled' | 'isSourcegraphDotCom' | 'authenticatedUser' | 'settingsCascade' | 'ownEnabled'
         >,
-        PlatformContextProps<'sourcegraphURL' | 'requestGraphQL' | 'urlToFile' | 'settings'> {}
+        PlatformContextProps<'sourcegraphURL' | 'requestGraphQL' | 'urlToFile' | 'settings' | 'telemetryRecorder'> {}
 
 const LOADING = 'loading' as const
 
@@ -33,6 +33,7 @@ export const EmbeddedNotebookPage: FC<EmbeddedNotebookPageProps> = ({ platformCo
     const { notebookId } = useParams()
 
     useEffect(() => eventLogger.logPageView('EmbeddedNotebookPage'), [])
+    platformContext.telemetryRecorder.recordEvent('embeddedNotebook', 'view')
 
     const notebookOrError = useObservable(
         useMemo(
@@ -78,6 +79,7 @@ export const EmbeddedNotebookPage: FC<EmbeddedNotebookPageProps> = ({ platformCo
                     fetchHighlightedFileLineRanges={fetchHighlightedFileLineRanges}
                     streamSearch={aggregateStreamingSearch}
                     telemetryService={eventLogger}
+                    telemetryRecorder={platformContext.telemetryRecorder}
                     platformContext={platformContext}
                     exportedFileName={convertNotebookTitleToFileName(notebookOrError.title)}
                     // Copying is not supported in embedded notebooks

--- a/client/web/src/notebooks/notebookPage/NotebookContent.tsx
+++ b/client/web/src/notebooks/notebookPage/NotebookContent.tsx
@@ -6,6 +6,7 @@ import type { Observable } from 'rxjs'
 import type { StreamingSearchResultsListProps } from '@sourcegraph/branded'
 import type { AuthenticatedUser } from '@sourcegraph/shared/src/auth'
 import type { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 
 import type { Block, BlockInit } from '..'
@@ -18,6 +19,7 @@ import { NotebookComponent } from '../notebook/NotebookComponent'
 export interface NotebookContentProps
     extends SearchStreamingProps,
         TelemetryProps,
+        TelemetryV2Props,
         Omit<StreamingSearchResultsListProps, 'allExpanded' | 'platformContext' | 'executedQuery'>,
         PlatformContextProps<'sourcegraphURL' | 'requestGraphQL' | 'urlToFile' | 'settings'>,
         OwnConfigProps {
@@ -40,6 +42,7 @@ export const NotebookContent: React.FunctionComponent<React.PropsWithChildren<No
         onUpdateBlocks,
         streamSearch,
         telemetryService,
+        telemetryRecorder,
         searchContextsEnabled,
         ownEnabled,
         isSourcegraphDotCom,
@@ -83,6 +86,7 @@ export const NotebookContent: React.FunctionComponent<React.PropsWithChildren<No
             <NotebookComponent
                 streamSearch={streamSearch}
                 telemetryService={telemetryService}
+                telemetryRecorder={telemetryRecorder}
                 searchContextsEnabled={searchContextsEnabled}
                 ownEnabled={ownEnabled}
                 isSourcegraphDotCom={isSourcegraphDotCom}

--- a/client/web/src/notebooks/notebookPage/NotebookPage.tsx
+++ b/client/web/src/notebooks/notebookPage/NotebookPage.tsx
@@ -11,6 +11,7 @@ import type { StreamingSearchResultsListProps } from '@sourcegraph/branded'
 import { Timestamp } from '@sourcegraph/branded/src/components/Timestamp'
 import { asError, isErrorLike } from '@sourcegraph/common'
 import type { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { LoadingSpinner, PageHeader, useEventObservable, useObservable, Alert, Icon } from '@sourcegraph/wildcard'
 
@@ -39,6 +40,7 @@ import styles from './NotebookPage.module.scss'
 interface NotebookPageProps
     extends SearchStreamingProps,
         TelemetryProps,
+        TelemetryV2Props,
         Omit<StreamingSearchResultsListProps, 'allExpanded' | 'platformContext' | 'executedQuery'>,
         PlatformContextProps<'sourcegraphURL' | 'requestGraphQL' | 'urlToFile' | 'settings'>,
         OwnConfigProps {
@@ -66,6 +68,7 @@ export const NotebookPage: React.FunctionComponent<React.PropsWithChildren<Noteb
     copyNotebook = _copyNotebook,
     streamSearch,
     telemetryService,
+    telemetryRecorder,
     searchContextsEnabled,
     ownEnabled,
     isSourcegraphDotCom,
@@ -76,7 +79,10 @@ export const NotebookPage: React.FunctionComponent<React.PropsWithChildren<Noteb
 }) => {
     const { id: notebookId } = useParams()
 
-    useEffect(() => telemetryService.logPageView('SearchNotebookPage'), [telemetryService])
+    useEffect(() => {
+        telemetryService.logPageView('SearchNotebookPage')
+        telemetryRecorder.recordEvent('notebook', 'view')
+    }, [telemetryService, telemetryRecorder])
 
     const [notebookTitle, setNotebookTitle] = useState('')
     const [updateQueue, setUpdateQueue] = useState<Partial<NotebookInput>[]>([])
@@ -212,6 +218,7 @@ export const NotebookPage: React.FunctionComponent<React.PropsWithChildren<Noteb
                                         createNotebookStar={createNotebookStar}
                                         deleteNotebookStar={deleteNotebookStar}
                                         telemetryService={telemetryService}
+                                        telemetryRecorder={telemetryRecorder}
                                     />
                                 }
                             >
@@ -227,6 +234,7 @@ export const NotebookPage: React.FunctionComponent<React.PropsWithChildren<Noteb
                                             viewerCanManage={notebookOrError.viewerCanManage}
                                             onUpdateTitle={onUpdateTitle}
                                             telemetryService={telemetryService}
+                                            telemetryRecorder={telemetryRecorder}
                                         />
                                     </PageHeader.Breadcrumb>
                                 </PageHeader.Heading>
@@ -282,6 +290,7 @@ export const NotebookPage: React.FunctionComponent<React.PropsWithChildren<Noteb
                                 exportedFileName={exportedFileName}
                                 streamSearch={streamSearch}
                                 telemetryService={telemetryService}
+                                telemetryRecorder={telemetryRecorder}
                                 searchContextsEnabled={searchContextsEnabled}
                                 ownEnabled={ownEnabled}
                                 isSourcegraphDotCom={isSourcegraphDotCom}

--- a/client/web/src/notebooks/notebookPage/NotebookPageHeaderActions.tsx
+++ b/client/web/src/notebooks/notebookPage/NotebookPageHeaderActions.tsx
@@ -5,6 +5,7 @@ import classNames from 'classnames'
 import type { Observable } from 'rxjs'
 import { catchError, switchMap, tap } from 'rxjs/operators'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import {
     Menu,
@@ -34,7 +35,7 @@ import { ShareNotebookModal } from './ShareNotebookModal'
 
 import styles from './NotebookPageHeaderActions.module.scss'
 
-export interface NotebookPageHeaderActionsProps extends TelemetryProps {
+export interface NotebookPageHeaderActionsProps extends TelemetryProps, TelemetryV2Props {
     isSourcegraphDotCom: boolean
     authenticatedUser: AuthenticatedUser | null
     namespace: NotebookFields['namespace']
@@ -65,6 +66,7 @@ export const NotebookPageHeaderActions: React.FunctionComponent<
     createNotebookStar,
     deleteNotebookStar,
     telemetryService,
+    telemetryRecorder,
 }) => {
     const [showShareModal, setShowShareModal] = useState(false)
     const toggleShareModal = useCallback(() => setShowShareModal(show => !show), [setShowShareModal])
@@ -119,6 +121,7 @@ export const NotebookPageHeaderActions: React.FunctionComponent<
                 createNotebookStar={createNotebookStar}
                 deleteNotebookStar={deleteNotebookStar}
                 telemetryService={telemetryService}
+                telemetryRecorder={telemetryRecorder}
             />
             {authenticatedUser && viewerCanManage && namespace && selectedShareOption && (
                 <>
@@ -135,6 +138,7 @@ export const NotebookPageHeaderActions: React.FunctionComponent<
                         isSourcegraphDotCom={isSourcegraphDotCom}
                         toggleModal={toggleShareModal}
                         telemetryService={telemetryService}
+                        telemetryRecorder={telemetryRecorder}
                         authenticatedUser={authenticatedUser}
                         selectedShareOption={selectedShareOption}
                         setSelectedShareOption={setSelectedShareOption}
@@ -147,13 +151,14 @@ export const NotebookPageHeaderActions: React.FunctionComponent<
                     notebookId={notebookId}
                     deleteNotebook={deleteNotebook}
                     telemetryService={telemetryService}
+                    telemetryRecorder={telemetryRecorder}
                 />
             )}
         </div>
     )
 }
 
-interface NotebookSettingsDropdownProps extends TelemetryProps {
+interface NotebookSettingsDropdownProps extends TelemetryProps, TelemetryV2Props {
     notebookId: string
     deleteNotebook: typeof _deleteNotebook
 }
@@ -162,6 +167,7 @@ const NotebookSettingsDropdown: React.FunctionComponent<React.PropsWithChildren<
     notebookId,
     deleteNotebook,
     telemetryService,
+    telemetryRecorder,
 }) => {
     const [showDeleteModal, setShowDeleteModal] = useState(false)
     const toggleDeleteModal = useCallback(() => setShowDeleteModal(show => !show), [setShowDeleteModal])
@@ -191,12 +197,13 @@ const NotebookSettingsDropdown: React.FunctionComponent<React.PropsWithChildren<
                 toggleDeleteModal={toggleDeleteModal}
                 deleteNotebook={deleteNotebook}
                 telemetryService={telemetryService}
+                telemetryRecorder={telemetryRecorder}
             />
         </>
     )
 }
 
-interface NotebookStarsButtonProps extends TelemetryProps {
+interface NotebookStarsButtonProps extends TelemetryProps, TelemetryV2Props {
     notebookId: string
     disabled: boolean
     starsCount: number
@@ -213,6 +220,7 @@ const NotebookStarsButton: React.FunctionComponent<React.PropsWithChildren<Noteb
     createNotebookStar,
     deleteNotebookStar,
     telemetryService,
+    telemetryRecorder,
 }) => {
     const [starsCount, setStarsCount] = useState(initialStarsCount)
     const [viewerHasStarred, setViewerHasStarred] = useState(initialViewerHasStarred)
@@ -224,6 +232,7 @@ const NotebookStarsButton: React.FunctionComponent<React.PropsWithChildren<Noteb
                     // Immediately update the UI.
                     tap(viewerHasStarred => {
                         telemetryService.log(`SearchNotebook${viewerHasStarred ? 'Remove' : 'Add'}Star`)
+                        telemetryRecorder.recordEvent('notebook.stars', viewerHasStarred ? 'remove' : 'add')
                         if (viewerHasStarred) {
                             setStarsCount(starsCount => starsCount - 1)
                             setViewerHasStarred(() => false)
@@ -248,6 +257,7 @@ const NotebookStarsButton: React.FunctionComponent<React.PropsWithChildren<Noteb
                 initialStarsCount,
                 initialViewerHasStarred,
                 telemetryService,
+                telemetryRecorder,
             ]
         )
     )

--- a/client/web/src/notebooks/notebookPage/NotebookShareOptionsDropdown.tsx
+++ b/client/web/src/notebooks/notebookPage/NotebookShareOptionsDropdown.tsx
@@ -2,6 +2,7 @@ import React, { type FC, useMemo } from 'react'
 
 import { mdiChevronDown, mdiChevronUp, mdiDomain, mdiLock, mdiWeb } from '@mdi/js'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Icon, Menu, MenuButton, MenuItem, MenuList } from '@sourcegraph/wildcard'
 
@@ -17,7 +18,7 @@ export interface ShareOption {
     isPublic: boolean
 }
 
-interface NotebookShareOptionsDropdownProps extends TelemetryProps {
+interface NotebookShareOptionsDropdownProps extends TelemetryProps, TelemetryV2Props {
     isSourcegraphDotCom: boolean
     authenticatedUser: AuthenticatedUser
     selectedShareOption: ShareOption
@@ -66,10 +67,18 @@ const ShareOptionComponent: React.FunctionComponent<
 }
 
 export const NotebookShareOptionsDropdown: FC<NotebookShareOptionsDropdownProps> = props => {
-    const { isSourcegraphDotCom, telemetryService, authenticatedUser, selectedShareOption, onSelectShareOption } = props
+    const {
+        isSourcegraphDotCom,
+        telemetryService,
+        telemetryRecorder,
+        authenticatedUser,
+        selectedShareOption,
+        onSelectShareOption,
+    } = props
 
     const handleTriggerClick = (): void => {
         telemetryService.log('NotebookVisibilitySettingsDropdownToggled')
+        telemetryRecorder.recordEvent('notebook.visibilitySettingsDropdown', 'toggle')
     }
 
     const shareOptions: ShareOption[] = useMemo(

--- a/client/web/src/notebooks/notebookPage/NotebookTitle.tsx
+++ b/client/web/src/notebooks/notebookPage/NotebookTitle.tsx
@@ -2,12 +2,13 @@ import React, { useEffect, useRef, useState } from 'react'
 
 import { mdiPencilOutline } from '@mdi/js'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { useOnClickOutside, Icon, Input } from '@sourcegraph/wildcard'
 
 import styles from './NotebookTitle.module.scss'
 
-export interface NotebookTitleProps extends TelemetryProps {
+export interface NotebookTitleProps extends TelemetryProps, TelemetryV2Props {
     title: string
     viewerCanManage: boolean
     onUpdateTitle: (title: string) => void
@@ -18,6 +19,7 @@ export const NotebookTitle: React.FunctionComponent<React.PropsWithChildren<Note
     viewerCanManage,
     onUpdateTitle,
     telemetryService,
+    telemetryRecorder,
 }) => {
     const [isEditing, setIsEditing] = useState(false)
     const [title, setTitle] = useState(initialTitle)
@@ -31,6 +33,7 @@ export const NotebookTitle: React.FunctionComponent<React.PropsWithChildren<Note
 
     const updateTitle = (): void => {
         telemetryService.log('SearchNotebookTitleUpdated')
+        telemetryRecorder.recordEvent('notebook.title', 'update')
         setIsEditing(false)
         onUpdateTitle(title)
     }

--- a/client/web/src/notebooks/notebookPage/ShareNotebookModal.tsx
+++ b/client/web/src/notebooks/notebookPage/ShareNotebookModal.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useMemo, useEffect } from 'react'
 
 import classNames from 'classnames'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Modal, Button, Checkbox, H3 } from '@sourcegraph/wildcard'
 
@@ -11,7 +12,7 @@ import { NotebookShareOptionsDropdown, type ShareOption } from './NotebookShareO
 
 import styles from './ShareNotebookModal.module.scss'
 
-interface ShareNotebookModalProps extends TelemetryProps {
+interface ShareNotebookModalProps extends TelemetryProps, TelemetryV2Props {
     isSourcegraphDotCom: boolean
     selectedShareOption: ShareOption
     setSelectedShareOption: (option: ShareOption) => void
@@ -40,12 +41,14 @@ export const ShareNotebookModal: React.FunctionComponent<React.PropsWithChildren
     authenticatedUser,
     telemetryService,
     onUpdateVisibility,
+    telemetryRecorder,
 }) => {
     useEffect(() => {
         if (isOpen) {
             telemetryService.log('SearchNotebookShareModalOpened')
+            telemetryRecorder.recordEvent('notebook.shareModal', 'open')
         }
-    }, [isOpen, telemetryService])
+    }, [isOpen, telemetryService, telemetryRecorder])
 
     const shareLabelId = 'shareNotebookId'
 
@@ -66,6 +69,7 @@ export const ShareNotebookModal: React.FunctionComponent<React.PropsWithChildren
                 <NotebookShareOptionsDropdown
                     isSourcegraphDotCom={isSourcegraphDotCom}
                     telemetryService={telemetryService}
+                    telemetryRecorder={telemetryRecorder}
                     authenticatedUser={authenticatedUser}
                     selectedShareOption={selectedShareOption}
                     onSelectShareOption={setSelectedShareOption}

--- a/client/web/src/routes.tsx
+++ b/client/web/src/routes.tsx
@@ -236,7 +236,9 @@ export const routes: RouteObject[] = [
         path: PageRoutes.Notebooks + '/*',
         element: (
             <LegacyRoute
-                render={props => <GlobalNotebooksArea {...props} />}
+                render={props => (
+                    <GlobalNotebooksArea {...props} telemetryRecorder={props.platformContext.telemetryRecorder} />
+                )}
                 condition={({ licenseFeatures }) => licenseFeatures.isCodeSearchEnabled}
             />
         ),


### PR DESCRIPTION
Context:

* https://github.com/sourcegraph/sourcegraph/pull/60127
* https://github.com/sourcegraph/sourcegraph/pull/60192
* https://github.com/sourcegraph/sourcegraph/pull/60219
* https://github.com/sourcegraph/sourcegraph/pull/60343
* https://github.com/sourcegraph/sourcegraph/pull/60377
* https://github.com/sourcegraph/sourcegraph/pull/60382
* https://github.com/sourcegraph/sourcegraph/pull/60764
* https://github.com/sourcegraph/sourcegraph/pull/60765
* https://github.com/sourcegraph/sourcegraph/pull/60767
* https://github.com/sourcegraph/sourcegraph/pull/60768
* https://github.com/sourcegraph/sourcegraph/pull/60788
* https://github.com/sourcegraph/sourcegraph/pull/60789
* https://github.com/sourcegraph/sourcegraph/pull/60803
* https://github.com/sourcegraph/sourcegraph/pull/60812
* https://github.com/sourcegraph/sourcegraph/pull/60850
* https://github.com/sourcegraph/sourcegraph/pull/60851
* https://github.com/sourcegraph/sourcegraph/pull/60939
* https://github.com/sourcegraph/sourcegraph/pull/60971
* https://github.com/sourcegraph/sourcegraph/pull/61205
* https://github.com/sourcegraph/sourcegraph/pull/61457

## Test plan

`sg start`
visit page
check if events appear in `event_logs` table locally