### PR TITLE
v2t: add v2t to src/open-in-editor

### DIFF
--- a/client/web/src/open-in-editor/OpenInEditorActionItem.tsx
+++ b/client/web/src/open-in-editor/OpenInEditorActionItem.tsx
@@ -8,6 +8,7 @@ import { logger } from '@sourcegraph/common'
 import { SimpleActionItem } from '@sourcegraph/shared/src/actions/SimpleActionItem'
 import type { PlatformContext } from '@sourcegraph/shared/src/platform/context'
 import { isSettingsValid, type Settings } from '@sourcegraph/shared/src/settings/settings'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import {
     Button,
     Icon,
@@ -32,7 +33,7 @@ import { useOpenCurrentUrlInEditor } from './useOpenCurrentUrlInEditor'
 
 import styles from './OpenInEditorActionItem.module.scss'
 
-export interface OpenInEditorActionItemProps {
+export interface OpenInEditorActionItemProps extends TelemetryV2Props {
     platformContext: PlatformContext
     externalServiceType?: string
     assetsRoot?: string
@@ -110,6 +111,9 @@ export const OpenInEditorActionItem: React.FunctionComponent<OpenInEditorActionI
                             }
                             onClick={() => {
                                 eventLogger.log('OpenInEditorClicked', { editor: editor.id }, { editor: editor.id })
+                                props.telemetryRecorder.recordEvent('blob.openInEditor', 'click', {
+                                    metadata: { editor: editor.telemetryID },
+                                })
                                 openCurrentUrlInEditor(
                                     settings?.openInEditor,
                                     props.externalServiceType,

--- a/client/web/src/open-in-editor/editors.ts
+++ b/client/web/src/open-in-editor/editors.ts
@@ -1,5 +1,6 @@
 export interface Editor {
     id: string
+    telemetryID: number
     name: string
     urlPattern?: string
     isJetBrainsProduct: boolean
@@ -10,65 +11,77 @@ export const supportedEditors: Editor[] = [
         id: 'appcode',
         name: 'AppCode',
         isJetBrainsProduct: true,
+        telemetryID: 1,
     },
     {
         id: 'atom',
         name: 'Atom',
         urlPattern: 'atom://core/open/file?filename=%file:%line:%col',
         isJetBrainsProduct: false,
+        telemetryID: 2,
     },
     {
         id: 'clion',
         name: 'CLion',
         isJetBrainsProduct: true,
+        telemetryID: 3,
     },
     {
         id: 'goland',
         name: 'GoLand',
         isJetBrainsProduct: true,
+        telemetryID: 4,
     },
     {
         id: 'idea',
         name: 'IntelliJ IDEA',
         isJetBrainsProduct: true,
+        telemetryID: 5,
     },
     {
         id: 'phpstorm',
         name: 'PhpStorm',
         isJetBrainsProduct: true,
+        telemetryID: 6,
     },
     {
         id: 'pycharm',
         name: 'PyCharm',
         isJetBrainsProduct: true,
+        telemetryID: 7,
     },
     {
         id: 'rider',
         name: 'Rider',
         isJetBrainsProduct: true,
+        telemetryID: 8,
     },
     {
         id: 'rubymine',
         name: 'RubyMine',
         isJetBrainsProduct: true,
+        telemetryID: 9,
     },
     {
         id: 'sublime',
         name: 'Sublime Text',
         urlPattern: 'subl://open?url=%file&line=%line&column=%col',
         isJetBrainsProduct: false,
+        telemetryID: 10,
     },
     {
         id: 'vscode',
         name: 'Visual Studio Code',
         isJetBrainsProduct: false,
+        telemetryID: 11,
     },
     {
         id: 'webstorm',
         name: 'WebStorm',
         isJetBrainsProduct: true,
+        telemetryID: 12,
     },
-    { id: 'custom', name: 'Custom', urlPattern: '', isJetBrainsProduct: false },
+    { id: 'custom', name: 'Custom', urlPattern: '', isJetBrainsProduct: false, telemetryID: 13 },
 ]
 
 export type EditorId = typeof supportedEditors[number]['id']

--- a/client/web/src/repo/blob/BlobPage.tsx
+++ b/client/web/src/repo/blob/BlobPage.tsx
@@ -379,6 +379,7 @@ export const BlobPage: React.FunctionComponent<BlobPageProps> = ({ className, co
                             externalServiceType={props.repoServiceType}
                             actionType={actionType}
                             source="repoHeader"
+                            telemetryRecorder={props.telemetryRecorder}
                         />
                     )}
                 </RepoHeaderContributionPortal>


### PR DESCRIPTION
Context:

* https://github.com/sourcegraph/sourcegraph/pull/60127
* https://github.com/sourcegraph/sourcegraph/pull/60192
* https://github.com/sourcegraph/sourcegraph/pull/60219
* https://github.com/sourcegraph/sourcegraph/pull/60343
* https://github.com/sourcegraph/sourcegraph/pull/60377
* https://github.com/sourcegraph/sourcegraph/pull/60382
* https://github.com/sourcegraph/sourcegraph/pull/60764
* https://github.com/sourcegraph/sourcegraph/pull/60765
* https://github.com/sourcegraph/sourcegraph/pull/60767
* https://github.com/sourcegraph/sourcegraph/pull/60768
* https://github.com/sourcegraph/sourcegraph/pull/60788
* https://github.com/sourcegraph/sourcegraph/pull/60789
* https://github.com/sourcegraph/sourcegraph/pull/60803
* https://github.com/sourcegraph/sourcegraph/pull/60812
* https://github.com/sourcegraph/sourcegraph/pull/60850
* https://github.com/sourcegraph/sourcegraph/pull/60851
* https://github.com/sourcegraph/sourcegraph/pull/60939
* https://github.com/sourcegraph/sourcegraph/pull/60971
* https://github.com/sourcegraph/sourcegraph/pull/61205
* https://github.com/sourcegraph/sourcegraph/pull/61457
* https://github.com/sourcegraph/sourcegraph/pull/61503

## Test plan

`sg start`
visit page
check if events appear in `event_logs` table locally