### PR TITLE
k8s/resource: Add pkg for creating k8s stateful set resources

### DIFF
--- a/internal/k8s/resource/rolebinding/rolebinding_test.go
+++ b/internal/k8s/resource/rolebinding/rolebinding_test.go
@@ -23,7 +23,7 @@ func TestNewRoleBinding(t *testing.T) {
 		want rbacv1.RoleBinding
 	}{
 		{
-			name: "sourcegraph",
+			name: "default rolebindings",
 			args: args{
 				name:      "foo",
 				namespace: "sourcegraph",

--- a/internal/k8s/resource/statefulset/BUILD.bazel
+++ b/internal/k8s/resource/statefulset/BUILD.bazel
@@ -1,0 +1,35 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("//dev:go_defs.bzl", "go_test")
+
+go_library(
+    name = "statefulset",
+    srcs = ["statefulset.go"],
+    importpath = "github.com/sourcegraph/sourcegraph/internal/k8s/resource/statefulset",
+    visibility = ["//:__subpackages__"],
+    deps = [
+        "//internal/maps",
+        "//lib/pointers",
+        "@io_k8s_api//apps/v1:apps",
+        "@io_k8s_api//core/v1:core",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:meta",
+    ],
+)
+
+go_test(
+    name = "statefulset_test",
+    srcs = [
+        "example_test.go",
+        "statefulset_test.go",
+    ],
+    embed = [":statefulset"],
+    deps = [
+        "//internal/k8s/resource/pod",
+        "//lib/pointers",
+        "@com_github_google_go_cmp//cmp",
+        "@io_k8s_api//apps/v1:apps",
+        "@io_k8s_api//core/v1:core",
+        "@io_k8s_apimachinery//pkg/api/resource",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:meta",
+        "@io_k8s_sigs_yaml//:yaml",
+    ],
+)

--- a/internal/k8s/resource/statefulset/example_test.go
+++ b/internal/k8s/resource/statefulset/example_test.go
@@ -1,0 +1,46 @@
+package statefulset
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"sigs.k8s.io/yaml"
+)
+
+func ExampleStatefulSet() {
+	ss, _ := NewStatefulSet("test", "sourcegraph")
+
+	jss, _ := json.Marshal(ss)
+	fmt.Println(string(jss))
+
+	yss, _ := yaml.Marshal(ss)
+	fmt.Println(string(yss))
+
+	// Output:
+	// {"metadata":{"name":"test","namespace":"sourcegraph","creationTimestamp":null,"labels":{"deploy":"sourcegraph"}},"spec":{"replicas":1,"selector":{"matchLabels":{"app":"test"}},"template":{"metadata":{"creationTimestamp":null},"spec":{"containers":null}},"serviceName":"test","podManagementPolicy":"OrderedReady","updateStrategy":{"type":"RollingUpdate"},"revisionHistoryLimit":10,"minReadySeconds":10},"status":{"replicas":0,"availableReplicas":0}}
+	// metadata:
+	//   creationTimestamp: null
+	//   labels:
+	//     deploy: sourcegraph
+	//   name: test
+	//   namespace: sourcegraph
+	// spec:
+	//   minReadySeconds: 10
+	//   podManagementPolicy: OrderedReady
+	//   replicas: 1
+	//   revisionHistoryLimit: 10
+	//   selector:
+	//     matchLabels:
+	//       app: test
+	//   serviceName: test
+	//   template:
+	//     metadata:
+	//       creationTimestamp: null
+	//     spec:
+	//       containers: null
+	//   updateStrategy:
+	//     type: RollingUpdate
+	// status:
+	//   availableReplicas: 0
+	//   replicas: 0
+}

--- a/internal/k8s/resource/statefulset/statefulset.go
+++ b/internal/k8s/resource/statefulset/statefulset.go
@@ -1,0 +1,152 @@
+package statefulset
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/sourcegraph/sourcegraph/internal/maps"
+	"github.com/sourcegraph/sourcegraph/lib/pointers"
+)
+
+// NewStatefulSet creates a new k8s StatefulSet with default values.
+//
+// Default values include:
+//
+//   - MinReadySeconds: 10
+//   - RevisionHistoryLimit: 10
+//   - UpdateStrategy: RollingUpdateStrategy
+//   - PodManagementPolicy: OrderedReadyPodManagement
+//   - ServiceName: <name>
+//   - Selector: "app": <name>
+//   - Replicas: 1
+//
+// Additional options can be passed to modify the default values.
+func NewStatefulSet(name, namespace string, options ...Option) (appsv1.StatefulSet, error) {
+	statefulSet := appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				"deploy": "sourcegraph",
+			},
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: pointers.Ptr[int32](1),
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app": name,
+				},
+			},
+			ServiceName:         name,
+			PodManagementPolicy: appsv1.OrderedReadyPodManagement,
+			UpdateStrategy: appsv1.StatefulSetUpdateStrategy{
+				Type: appsv1.RollingUpdateStatefulSetStrategyType,
+			},
+			RevisionHistoryLimit: pointers.Ptr[int32](10),
+			MinReadySeconds:      int32(10),
+		},
+	}
+
+	// apply any given options
+	for _, opt := range options {
+		err := opt(&statefulSet)
+		if err != nil {
+			return appsv1.StatefulSet{}, err
+		}
+	}
+
+	return statefulSet, nil
+}
+
+// Option sets an option for a StatefulSet.
+type Option func(statefulSet *appsv1.StatefulSet) error
+
+// WithLabels sets StatefulSet labels without overriding existing labels.
+func WithLabels(labels map[string]string) Option {
+	return func(statefulSet *appsv1.StatefulSet) error {
+		statefulSet.Labels = maps.MergePreservingExistingKeys(statefulSet.Labels, labels)
+		return nil
+	}
+}
+
+// WithAnnotations sets StatefulSet annotations without overriding existing annotations.
+func WithAnnotations(annotations map[string]string) Option {
+	return func(statefulSet *appsv1.StatefulSet) error {
+		statefulSet.Annotations = maps.MergePreservingExistingKeys(statefulSet.Annotations, annotations)
+		return nil
+	}
+}
+
+// WithReplicas sets the given number of Replicas for the StatefulSet.
+func WithReplicas(replicas int32) Option {
+	return func(statefulSet *appsv1.StatefulSet) error {
+		statefulSet.Spec.Replicas = pointers.Ptr[int32](replicas)
+		return nil
+	}
+}
+
+// WithSelector sets the given Selector for the StatefulSet.
+func WithSelector(selector metav1.LabelSelector) Option {
+	return func(statefulSet *appsv1.StatefulSet) error {
+		statefulSet.Spec.Selector = &selector
+		return nil
+	}
+}
+
+// WithPodTemplateSpec sets the given PodTemplateSpec for the StatefulSet.
+func WithPodTemplateSpec(template corev1.PodTemplateSpec) Option {
+	return func(statefulSet *appsv1.StatefulSet) error {
+		statefulSet.Spec.Template = template
+		return nil
+	}
+}
+
+// WithVolumeClaimTemplate sets the given PersistentVolumeClaim templates for the StatefulSet.
+func WithVolumeClaimTemplate(template ...corev1.PersistentVolumeClaim) Option {
+	return func(statefulSet *appsv1.StatefulSet) error {
+		statefulSet.Spec.VolumeClaimTemplates = template
+		return nil
+	}
+}
+
+// WithServiceName sets the given Service name for the StatefulSet.
+func WithServiceName(serviceName string) Option {
+	return func(statefulSet *appsv1.StatefulSet) error {
+		statefulSet.Spec.ServiceName = serviceName
+		return nil
+	}
+}
+
+// WithPodManagementPolicy sets the given PodManagementPolicy for the StatefulSet.
+func WithPodManagementPolicy(podManagementPolicy appsv1.PodManagementPolicyType) Option {
+	return func(statefulSet *appsv1.StatefulSet) error {
+		statefulSet.Spec.PodManagementPolicy = podManagementPolicy
+		return nil
+	}
+}
+
+// WithUpdateStrategy sets the given StatefulSetUpdateStrategy for the StatefulSet.
+func WithUpdateStrategy(updateStrategy appsv1.StatefulSetUpdateStrategy) Option {
+	return func(statefulSet *appsv1.StatefulSet) error {
+		statefulSet.Spec.UpdateStrategy = updateStrategy
+		return nil
+	}
+}
+
+// WithRevisionHistoryLimit sets the given RevisionHistoryLimit for the StatefulSet.
+func WithRevisionHistoryLimit(limit int32) Option {
+	return func(statefulSet *appsv1.StatefulSet) error {
+		statefulSet.Spec.RevisionHistoryLimit = pointers.Ptr[int32](limit)
+		return nil
+	}
+}
+
+// WithMinReadySeconds sets the minimum number of seconds for which a newly created
+// Pod should be ready without any of its containers crashing, for it to be considered available.
+func WithMinReadySeconds(minReadySeconds int32) Option {
+	return func(statefulSet *appsv1.StatefulSet) error {
+		statefulSet.Spec.MinReadySeconds = minReadySeconds
+		return nil
+	}
+}

--- a/internal/k8s/resource/statefulset/statefulset_test.go
+++ b/internal/k8s/resource/statefulset/statefulset_test.go
@@ -1,0 +1,520 @@
+package statefulset
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/sourcegraph/sourcegraph/internal/k8s/resource/pod"
+	"github.com/sourcegraph/sourcegraph/lib/pointers"
+)
+
+func TestNewStatefulSet(t *testing.T) {
+	t.Parallel()
+
+	type args struct {
+		name      string
+		namespace string
+		options   []Option
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want appsv1.StatefulSet
+	}{
+		{
+			name: "default statefulset",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+			},
+			want: appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph",
+					},
+				},
+				Spec: appsv1.StatefulSetSpec{
+					MinReadySeconds:      int32(10),
+					PodManagementPolicy:  appsv1.OrderedReadyPodManagement,
+					Replicas:             pointers.Ptr[int32](1),
+					RevisionHistoryLimit: pointers.Ptr[int32](10),
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"app": "foo",
+						},
+					},
+					ServiceName: "foo",
+					UpdateStrategy: appsv1.StatefulSetUpdateStrategy{
+						Type: appsv1.RollingUpdateStatefulSetStrategyType,
+					},
+				},
+			},
+		},
+		{
+			name: "with labels",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithLabels(map[string]string{
+						"deploy": "horsegraph",
+						"app":    "bar",
+					}),
+				},
+			},
+			want: appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"app":    "bar",
+						"deploy": "sourcegraph",
+					},
+				},
+				Spec: appsv1.StatefulSetSpec{
+					MinReadySeconds:      int32(10),
+					PodManagementPolicy:  appsv1.OrderedReadyPodManagement,
+					Replicas:             pointers.Ptr[int32](1),
+					RevisionHistoryLimit: pointers.Ptr[int32](10),
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"app": "foo",
+						},
+					},
+					ServiceName: "foo",
+					UpdateStrategy: appsv1.StatefulSetUpdateStrategy{
+						Type: appsv1.RollingUpdateStatefulSetStrategyType,
+					},
+				},
+			},
+		},
+		{
+			name: "with annotations",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithAnnotations(map[string]string{
+						"foo": "bar",
+					}),
+				},
+			},
+			want: appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph",
+					},
+					Annotations: map[string]string{
+						"foo": "bar",
+					},
+				},
+				Spec: appsv1.StatefulSetSpec{
+					MinReadySeconds:      int32(10),
+					PodManagementPolicy:  appsv1.OrderedReadyPodManagement,
+					Replicas:             pointers.Ptr[int32](1),
+					RevisionHistoryLimit: pointers.Ptr[int32](10),
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"app": "foo",
+						},
+					},
+					ServiceName: "foo",
+					UpdateStrategy: appsv1.StatefulSetUpdateStrategy{
+						Type: appsv1.RollingUpdateStatefulSetStrategyType,
+					},
+				},
+			},
+		},
+		{
+			name: "with replicas",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithReplicas(int32(5)),
+				},
+			},
+			want: appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph",
+					},
+				},
+				Spec: appsv1.StatefulSetSpec{
+					MinReadySeconds:      int32(10),
+					PodManagementPolicy:  appsv1.OrderedReadyPodManagement,
+					Replicas:             pointers.Ptr[int32](5),
+					RevisionHistoryLimit: pointers.Ptr[int32](10),
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"app": "foo",
+						},
+					},
+					ServiceName: "foo",
+					UpdateStrategy: appsv1.StatefulSetUpdateStrategy{
+						Type: appsv1.RollingUpdateStatefulSetStrategyType,
+					},
+				},
+			},
+		},
+		{
+			name: "with selector",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithSelector(metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"app": "horsegraph",
+						},
+					}),
+				},
+			},
+			want: appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph",
+					},
+				},
+				Spec: appsv1.StatefulSetSpec{
+					MinReadySeconds:      int32(10),
+					PodManagementPolicy:  appsv1.OrderedReadyPodManagement,
+					Replicas:             pointers.Ptr[int32](1),
+					RevisionHistoryLimit: pointers.Ptr[int32](10),
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"app": "horsegraph",
+						},
+					},
+					ServiceName: "foo",
+					UpdateStrategy: appsv1.StatefulSetUpdateStrategy{
+						Type: appsv1.RollingUpdateStatefulSetStrategyType,
+					},
+				},
+			},
+		},
+		{
+			name: "with pod template spec",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithPodTemplateSpec(func() corev1.PodTemplateSpec {
+						ts, _ := pod.NewPodTemplate("foo", "sourcegraph")
+						return ts.Template
+					}()),
+				},
+			},
+			want: appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph",
+					},
+				},
+				Spec: appsv1.StatefulSetSpec{
+					MinReadySeconds:      int32(10),
+					PodManagementPolicy:  appsv1.OrderedReadyPodManagement,
+					Replicas:             pointers.Ptr[int32](1),
+					RevisionHistoryLimit: pointers.Ptr[int32](10),
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"app": "foo",
+						},
+					},
+					ServiceName: "foo",
+					UpdateStrategy: appsv1.StatefulSetUpdateStrategy{
+						Type: appsv1.RollingUpdateStatefulSetStrategyType,
+					},
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "foo",
+							Namespace: "sourcegraph",
+							Labels: map[string]string{
+								"app":    "foo",
+								"deploy": "sourcegraph",
+							},
+							Annotations: map[string]string{
+								"kubectl.kubernetes.io/default-container": "foo",
+							},
+						},
+						Spec: corev1.PodSpec{
+							SecurityContext: &corev1.PodSecurityContext{
+								RunAsUser:           pointers.Ptr[int64](100),
+								RunAsGroup:          pointers.Ptr[int64](101),
+								FSGroup:             pointers.Ptr[int64](101),
+								FSGroupChangePolicy: pointers.Ptr(corev1.FSGroupChangeOnRootMismatch),
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "with volume claim template",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithVolumeClaimTemplate(corev1.PersistentVolumeClaim{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "repos",
+						},
+						Spec: corev1.PersistentVolumeClaimSpec{
+							AccessModes: []corev1.PersistentVolumeAccessMode{
+								corev1.ReadWriteOnce,
+							},
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceStorage: resource.MustParse("200Gi"),
+								},
+							},
+						},
+					}),
+				},
+			},
+			want: appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph",
+					},
+				},
+				Spec: appsv1.StatefulSetSpec{
+					MinReadySeconds:      int32(10),
+					PodManagementPolicy:  appsv1.OrderedReadyPodManagement,
+					Replicas:             pointers.Ptr[int32](1),
+					RevisionHistoryLimit: pointers.Ptr[int32](10),
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"app": "foo",
+						},
+					},
+					ServiceName: "foo",
+					UpdateStrategy: appsv1.StatefulSetUpdateStrategy{
+						Type: appsv1.RollingUpdateStatefulSetStrategyType,
+					},
+					VolumeClaimTemplates: []corev1.PersistentVolumeClaim{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "repos",
+							},
+							Spec: corev1.PersistentVolumeClaimSpec{
+								AccessModes: []corev1.PersistentVolumeAccessMode{
+									corev1.ReadWriteOnce,
+								},
+								Resources: corev1.ResourceRequirements{
+									Requests: corev1.ResourceList{
+										corev1.ResourceStorage: resource.MustParse("200Gi"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "with service name",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithServiceName("test"),
+				},
+			},
+			want: appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph",
+					},
+				},
+				Spec: appsv1.StatefulSetSpec{
+					MinReadySeconds:      int32(10),
+					PodManagementPolicy:  appsv1.OrderedReadyPodManagement,
+					Replicas:             pointers.Ptr[int32](1),
+					RevisionHistoryLimit: pointers.Ptr[int32](10),
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"app": "foo",
+						},
+					},
+					ServiceName: "test",
+					UpdateStrategy: appsv1.StatefulSetUpdateStrategy{
+						Type: appsv1.RollingUpdateStatefulSetStrategyType,
+					},
+				},
+			},
+		},
+		{
+			name: "with pod management policy",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithPodManagementPolicy(appsv1.ParallelPodManagement),
+				},
+			},
+			want: appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph",
+					},
+				},
+				Spec: appsv1.StatefulSetSpec{
+					MinReadySeconds:      int32(10),
+					PodManagementPolicy:  appsv1.ParallelPodManagement,
+					Replicas:             pointers.Ptr[int32](1),
+					RevisionHistoryLimit: pointers.Ptr[int32](10),
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"app": "foo",
+						},
+					},
+					ServiceName: "foo",
+					UpdateStrategy: appsv1.StatefulSetUpdateStrategy{
+						Type: appsv1.RollingUpdateStatefulSetStrategyType,
+					},
+				},
+			},
+		},
+		{
+			name: "with update strategy",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithUpdateStrategy(appsv1.StatefulSetUpdateStrategy{
+						Type: appsv1.OnDeleteStatefulSetStrategyType,
+					}),
+				},
+			},
+			want: appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph",
+					},
+				},
+				Spec: appsv1.StatefulSetSpec{
+					MinReadySeconds:      int32(10),
+					PodManagementPolicy:  appsv1.OrderedReadyPodManagement,
+					Replicas:             pointers.Ptr[int32](1),
+					RevisionHistoryLimit: pointers.Ptr[int32](10),
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"app": "foo",
+						},
+					},
+					ServiceName: "foo",
+					UpdateStrategy: appsv1.StatefulSetUpdateStrategy{
+						Type: appsv1.OnDeleteStatefulSetStrategyType,
+					},
+				},
+			},
+		},
+		{
+			name: "with revision history",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithRevisionHistoryLimit(int32(5)),
+				},
+			},
+			want: appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph",
+					},
+				},
+				Spec: appsv1.StatefulSetSpec{
+					MinReadySeconds:      int32(10),
+					PodManagementPolicy:  appsv1.OrderedReadyPodManagement,
+					Replicas:             pointers.Ptr[int32](1),
+					RevisionHistoryLimit: pointers.Ptr[int32](5),
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"app": "foo",
+						},
+					},
+					ServiceName: "foo",
+					UpdateStrategy: appsv1.StatefulSetUpdateStrategy{
+						Type: appsv1.RollingUpdateStatefulSetStrategyType,
+					},
+				},
+			},
+		},
+		{
+			name: "with minready seconds",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithMinReadySeconds(int32(12)),
+				},
+			},
+			want: appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph",
+					},
+				},
+				Spec: appsv1.StatefulSetSpec{
+					MinReadySeconds:      int32(12),
+					PodManagementPolicy:  appsv1.OrderedReadyPodManagement,
+					Replicas:             pointers.Ptr[int32](1),
+					RevisionHistoryLimit: pointers.Ptr[int32](10),
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"app": "foo",
+						},
+					},
+					ServiceName: "foo",
+					UpdateStrategy: appsv1.StatefulSetUpdateStrategy{
+						Type: appsv1.RollingUpdateStatefulSetStrategyType,
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := NewStatefulSet(tt.args.name, tt.args.namespace, tt.args.options...)
+			if err != nil {
+				t.Errorf("NewStatefulSets() error: %v", err)
+			}
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("NewStatefulSets() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add `statefulset` pkg to create k8s statefulsets with patterns and defaults common to Sourcegraph.

## Test plan

Full unit test coverage as well as testable examples

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
