### PR TITLE
v2t: add v2t to src/openCodeGraph

### DIFF
--- a/client/web/src/opencodegraph/global/ToggleOpenCodeGraphVisibility.tsx
+++ b/client/web/src/opencodegraph/global/ToggleOpenCodeGraphVisibility.tsx
@@ -3,6 +3,7 @@ import { useCallback } from 'react'
 import { mdiWeb, mdiWebOff } from '@mdi/js'
 
 import { SimpleActionItem } from '@sourcegraph/shared/src/actions/SimpleActionItem'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { RenderMode } from '@sourcegraph/shared/src/util/url'
 import { Button, Icon, Tooltip } from '@sourcegraph/wildcard'
 
@@ -12,7 +13,7 @@ import { useOpenCodeGraphVisibility } from './useOpenCodeGraphVisibility'
 
 import styles from './ToggleOpenCodeGraphVisibility.module.scss'
 
-interface Props {
+interface Props extends TelemetryV2Props {
     source?: 'repoHeader' | 'actionItemsBar'
     actionType?: 'nav' | 'dropdown'
     renderMode?: RenderMode
@@ -27,9 +28,9 @@ export const ToggleOpenCodeGraphVisibilityAction: React.FC<Props> = props => {
         : `${visible ? 'Hide' : 'Show'} OpenCodeGraph metadata`
 
     const onCycle = useCallback(() => {
+        props.telemetryRecorder.recordEvent('blob.openCodeGraph.metadata', visible ? 'hide' : 'show')
         setVisible(prevVisible => !prevVisible)
-        // TODO(sqs): telemetry
-    }, [setVisible])
+    }, [setVisible, visible, props.telemetryRecorder])
 
     const icon = disabled || !visible ? mdiWebOff : mdiWeb
 

--- a/client/web/src/repo/blob/BlobPage.tsx
+++ b/client/web/src/repo/blob/BlobPage.tsx
@@ -410,6 +410,7 @@ export const BlobPage: React.FunctionComponent<BlobPageProps> = ({ className, co
                             actionType={actionType}
                             source="repoHeader"
                             renderMode={renderMode}
+                            telemetryRecorder={props.telemetryRecorder}
                         />
                     )}
                 </RepoHeaderContributionPortal>


### PR DESCRIPTION
Context:

* https://github.com/sourcegraph/sourcegraph/pull/60127
* https://github.com/sourcegraph/sourcegraph/pull/60192
* https://github.com/sourcegraph/sourcegraph/pull/60219
* https://github.com/sourcegraph/sourcegraph/pull/60343
* https://github.com/sourcegraph/sourcegraph/pull/60377
* https://github.com/sourcegraph/sourcegraph/pull/60382
* https://github.com/sourcegraph/sourcegraph/pull/60764
* https://github.com/sourcegraph/sourcegraph/pull/60765
* https://github.com/sourcegraph/sourcegraph/pull/60767
* https://github.com/sourcegraph/sourcegraph/pull/60768
* https://github.com/sourcegraph/sourcegraph/pull/60788
* https://github.com/sourcegraph/sourcegraph/pull/60789
* https://github.com/sourcegraph/sourcegraph/pull/60803
* https://github.com/sourcegraph/sourcegraph/pull/60812
* https://github.com/sourcegraph/sourcegraph/pull/60850
* https://github.com/sourcegraph/sourcegraph/pull/60851
* https://github.com/sourcegraph/sourcegraph/pull/60939
* https://github.com/sourcegraph/sourcegraph/pull/60971
* https://github.com/sourcegraph/sourcegraph/pull/61205
* https://github.com/sourcegraph/sourcegraph/pull/61457
* https://github.com/sourcegraph/sourcegraph/pull/61503
* https://github.com/sourcegraph/sourcegraph/pull/61504

## Test plan

`sg start`
visit page
check if events appear in `event_logs` table locally