### PR TITLE
build-tracker: trigger build-metrics pipeline on build.finished

### DIFF
--- a/dev/build-tracker/BUILD.bazel
+++ b/dev/build-tracker/BUILD.bazel
@@ -22,6 +22,8 @@ go_library(
         "//lib/background",
         "//lib/errors",
         "//lib/managedservicesplatform/runtime",
+        "//lib/pointers",
+        "@com_github_buildkite_go_buildkite_v3//buildkite",
         "@com_github_gorilla_mux//:mux",
         "@com_github_sourcegraph_log//:log",
     ],
@@ -41,6 +43,7 @@ go_test(
         "main_test.go",
         "server_test.go",
     ],
+    data = glob(["testdata/**"]),
     embed = [":build-tracker_lib"],
     deps = [
         "//dev/build-tracker/build",

--- a/dev/build-tracker/BUILD.bazel
+++ b/dev/build-tracker/BUILD.bazel
@@ -43,7 +43,6 @@ go_test(
         "main_test.go",
         "server_test.go",
     ],
-    data = glob(["testdata/**"]),
     embed = [":build-tracker_lib"],
     deps = [
         "//dev/build-tracker/build",

--- a/dev/build-tracker/build/build.go
+++ b/dev/build-tracker/build/build.go
@@ -324,7 +324,6 @@ func (s *Store) Add(event *Event) {
 			),
 			log.Int("totalSteps", len(build.Steps)),
 		)
-
 	}
 }
 

--- a/dev/build-tracker/config/config.go
+++ b/dev/build-tracker/config/config.go
@@ -5,15 +5,17 @@ import "github.com/sourcegraph/sourcegraph/lib/managedservicesplatform/runtime"
 const DefaultChannel = "#william-buildchecker-webhook-test"
 
 type Config struct {
-	BuildkiteToken string
-	SlackToken     string
-	SlackChannel   string
-	Production     bool
-	DebugPassword  string
+	BuildkiteWebhookToken string
+	BuildkiteToken        string
+	SlackToken            string
+	SlackChannel          string
+	Production            bool
+	DebugPassword         string
 }
 
 func (c *Config) Load(env *runtime.Env) {
-	c.BuildkiteToken = env.Get("BUILDKITE_WEBHOOK_TOKEN", "", "")
+	c.BuildkiteWebhookToken = env.Get("BUILDKITE_WEBHOOK_TOKEN", "", "")
+	c.BuildkiteToken = env.Get("BUILDKITE_TOKEN", "", "")
 	c.SlackToken = env.Get("SLACK_TOKEN", "", "")
 	c.SlackChannel = env.Get("SLACK_CHANNEL", DefaultChannel, "")
 	c.Production = env.GetBool("BUILDTRACKER_PRODUCTION", "false", "")

--- a/dev/build-tracker/integration_test.go
+++ b/dev/build-tracker/integration_test.go
@@ -431,9 +431,9 @@ func TestServerNotify(t *testing.T) {
 	logger := logtest.NoOp(t)
 
 	conf := config.Config{
-		BuildkiteToken: os.Getenv("BUILDKITE_WEBHOOK_TOKEN"),
-		SlackToken:     os.Getenv("SLACK_TOKEN"),
-		SlackChannel:   os.Getenv("SLACK_CHANNEL"),
+		BuildkiteWebhookToken: os.Getenv("BUILDKITE_WEBHOOK_TOKEN"),
+		SlackToken:            os.Getenv("SLACK_TOKEN"),
+		SlackChannel:          os.Getenv("SLACK_CHANNEL"),
 	}
 
 	server := NewServer(":8080", logger, conf)

--- a/dev/build-tracker/main.go
+++ b/dev/build-tracker/main.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/buildkite/go-buildkite/v3/buildkite"
 	"github.com/gorilla/mux"
 
 	"github.com/sourcegraph/log"
@@ -20,15 +21,8 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/background"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 	"github.com/sourcegraph/sourcegraph/lib/managedservicesplatform/runtime"
+	"github.com/sourcegraph/sourcegraph/lib/pointers"
 )
-
-var (
-	ErrInvalidToken  = errors.New("buildkite token is invalid")
-	ErrInvalidHeader = errors.New("Header of request is invalid")
-	ErrUnwantedEvent = errors.New("Unwanted event received")
-)
-
-var nowFunc = time.Now
 
 // CleanUpInterval determines how often the old build cleaner should run
 var CleanUpInterval = 5 * time.Minute
@@ -215,6 +209,52 @@ func (s *Server) notifyIfFailed(b *build.Build) error {
 	return nil
 }
 
+func (s *Server) triggerMetricsPipeline(b *build.Build) error {
+	if *b.State == "cancelled" {
+		return nil
+	}
+
+	bk, err := buildkite.NewTokenConfig(s.config.BuildkiteToken, false)
+	if err != nil {
+		return err
+	}
+
+	client := buildkite.NewClient(bk.Client())
+
+	var prNumber int
+	var prBase string
+	var repo string
+	if b.PullRequest != nil {
+		prNumber, _ = strconv.Atoi(*b.Pipeline.ID)
+		prBase = *b.PullRequest.Base
+		repo = *b.PullRequest.Repository
+	}
+
+	triggered, response, err := client.Builds.Create("sourcegraph", "devx-build-metrics", &buildkite.CreateBuild{
+		Commit:  *b.Commit,
+		Branch:  *b.Branch,
+		Message: *b.Message,
+		Author:  *b.Author,
+		// TODO: do we need to clone b.Env?
+		Env: map[string]string{
+			"BUILDKITE_TRIGGERED_FROM_BUILD_ID":      pointers.DerefZero(b.ID),
+			"BUILDKITE_TRIGGERED_FROM_BUILD_NUMBER":  strconv.Itoa(pointers.DerefZero(b.Number)),
+			"BUILDKITE_TRIGGERED_FROM_PIPELINE_SLUG": pointers.DerefZero(b.Pipeline.Slug),
+		},
+		MetaData:              map[string]string{},
+		PullRequestID:         int64(prNumber),
+		PullRequestBaseBranch: prBase,
+		PullRequestRepository: repo,
+	})
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("%s %+v\n", response.Status, triggered)
+
+	return nil
+}
+
 // processEvent processes a BuildEvent received from Buildkite. If the event is for a `build.finished` event we get the
 // full build which includes all recorded jobs for the build and send a notification.
 // processEvent delegates the decision to actually send a notifcation
@@ -223,8 +263,14 @@ func (s *Server) processEvent(event *build.Event) {
 	s.store.Add(event)
 	b := s.store.GetByBuildNumber(event.GetBuildNumber())
 	if event.IsBuildFinished() {
-		if err := s.notifyIfFailed(b); err != nil {
-			s.logger.Error("failed to send notification for build", log.Int("buildNumber", event.GetBuildNumber()), log.Error(err))
+		if *event.Build.Branch == "main" {
+			if err := s.notifyIfFailed(b); err != nil {
+				s.logger.Error("failed to send notification for build", log.Int("buildNumber", event.GetBuildNumber()), log.Error(err))
+			}
+		}
+
+		if err := s.triggerMetricsPipeline(b); err != nil {
+			s.logger.Error("failed to trigger metrics pipeline for build", log.Int("buildNumber", event.GetBuildNumber()), log.Error(err))
 		}
 	}
 }


### PR DESCRIPTION
Triggers a buildkite pipeline when a build.finished event is received from buildkite in order to collect metrics & information about the build (coming in a later PR).

The details we attach as part of the build can be iterated upon as needed. For the most part, we can get all the details of the build that ultimately is triggering this by using the buildkite cli to query the build by its ID from the `DEVX_TRIGGERED_FROM_BUILD_ID` env var

A drawback appears to be that it will always show the owner of the token as the author/creator of the build (although the committer is preserved in `BUILDKITE_BUILD_AUTHOR` env var of the jobs)

Depends on https://github.com/sourcegraph/managed-services/pull/1096

## Test plan

Tested with payloads fetched from the webhook log, and with a personal token (see builds here: https://buildkite.com/sourcegraph/devx-build-metrics/)