### PR TITLE
gomod: update zoekt to remove perf regression in go 1.22

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -5294,8 +5294,8 @@ def go_dependencies():
         name = "com_github_sourcegraph_zoekt",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/sourcegraph/zoekt",
-        sum = "h1:QnS7KZETcE9g2CvBCF423BMhIXIwtxuvck3N7SKBJC0=",
-        version = "v0.0.0-20240327102325-8cf8887a903a",
+        sum = "h1:tMqptvT8zd2xD1Yl11zDd42fBHxlT40zJoPU+Vl8REI=",
+        version = "v0.0.0-20240402071238-c39011a14191",
     )
     go_repository(
         name = "com_github_spaolacci_murmur3",

--- a/go.mod
+++ b/go.mod
@@ -585,7 +585,7 @@ require (
 	github.com/scim2/filter-parser/v2 v2.2.0
 	github.com/sourcegraph/conc v0.3.1-0.20240108182409-4afefce20f9b
 	github.com/sourcegraph/mountinfo v0.0.0-20240201124957-b314c0befab1
-	github.com/sourcegraph/zoekt v0.0.0-20240327102325-8cf8887a903a
+	github.com/sourcegraph/zoekt v0.0.0-20240402071238-c39011a14191
 	github.com/spf13/cobra v1.8.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stretchr/objx v0.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1690,8 +1690,8 @@ github.com/sourcegraph/scip v0.3.3 h1:3EOkChYOntwHl0pPSAju7rj0oRuujh8owC4vjGDEr0
 github.com/sourcegraph/scip v0.3.3/go.mod h1:Q67VaoTpftINIy/CLrkYQOMwlsx67h8ys+ligmdUcqM=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152 h1:z/MpntplPaW6QW95pzcAR/72Z5TWDyDnSo0EOcyij9o=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152/go.mod h1:GIjDIg/heH5DOkXY3YJ/wNhfHsQHoXGjl8G8amsYQ1I=
-github.com/sourcegraph/zoekt v0.0.0-20240327102325-8cf8887a903a h1:QnS7KZETcE9g2CvBCF423BMhIXIwtxuvck3N7SKBJC0=
-github.com/sourcegraph/zoekt v0.0.0-20240327102325-8cf8887a903a/go.mod h1:+j+huwz4ZnffJmDHeLJyI9AY4a8DKQnfNV0J//upnyo=
+github.com/sourcegraph/zoekt v0.0.0-20240402071238-c39011a14191 h1:tMqptvT8zd2xD1Yl11zDd42fBHxlT40zJoPU+Vl8REI=
+github.com/sourcegraph/zoekt v0.0.0-20240402071238-c39011a14191/go.mod h1:+j+huwz4ZnffJmDHeLJyI9AY4a8DKQnfNV0J//upnyo=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v0.0.0-20170901052352-ee1bd8ee15a1/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=

--- a/internal/search/job/jobutil/job_test.go
+++ b/internal/search/job/jobutil/job_test.go
@@ -241,7 +241,7 @@ func TestNewPlanJob(t *testing.T) {
               (repoScope . [(and branch="HEAD" rawConfig:RcOnlyPublic|RcNoForks|RcNoArchived)])
               (includePrivate . true)
               (globalZoektQueryRegexps . [(?i)(?-s:ok.*?ok)])
-              (query . regex:"(?-s:ok.*?ok)")
+              (query . regex:"ok(?-s:.)*?ok")
               (type . text))
             (REPOSEARCH
               (repoOpts.repoFilters . [(?:ok).*?(?:ok)])
@@ -386,7 +386,7 @@ func TestNewPlanJob(t *testing.T) {
             (repoScope . [(and branch="HEAD" rawConfig:RcOnlyPublic|RcNoForks|RcNoArchived)])
             (includePrivate . true)
             (globalZoektQueryRegexps . [(?i)(?-s:foo.*?@bar)])
-            (query . regex:"(?-s:foo.*?@bar)")
+            (query . regex:"foo(?-s:.)*?@bar")
             (type . text))
           REPOSCOMPUTEEXCLUDED
           NOOP)))))
@@ -880,7 +880,7 @@ func TestNewPlanJob(t *testing.T) {
               (repoScope . [(and branch="HEAD" rawConfig:RcOnlyPublic|RcNoForks|RcNoArchived)])
               (includePrivate . true)
               (globalZoektQueryRegexps . [(?i)(?-s:a.*b)])
-              (query . regex:"(?-s:a.*b)")
+              (query . regex:"a(?-s:.)*b")
               (type . text))
             REPOSCOMPUTEEXCLUDED
             NOOP))))))
@@ -915,7 +915,7 @@ func TestNewPlanJob(t *testing.T) {
                   (fileMatchLimit . 10000)
                   (select . )
                   (zoektQueryRegexps . [(?i)(?-s:a.*b)])
-                  (query . regex:"(?-s:a.*b)")
+                  (query . regex:"a(?-s:.)*b")
                   (type . text))))
             (REPOPAGER
               (containsRefGlobs . false)


### PR DESCRIPTION
This updates zoekt to have one more commit. See details of commit for more information.

https://github.com/sourcegraph/zoekt/compare/8cf8887a903a...c39011a14191

- https://github.com/sourcegraph/zoekt/commit/c39011a141 all: use a faster vendored regexp/syntax/Regexp.String

Test Plan: CI

Part of https://github.com/sourcegraph/sourcegraph/issues/61462
