### PR TITLE
V2t: add v2t to src/repo

### DIFF
--- a/client/web/src/enterprise/batches/repo/BatchChangeRepoPage.tsx
+++ b/client/web/src/enterprise/batches/repo/BatchChangeRepoPage.tsx
@@ -1,4 +1,4 @@
-import { type FC, useMemo } from 'react'
+import { type FC, useMemo, useEffect } from 'react'
 
 import VisuallyHidden from '@reach/visually-hidden'
 
@@ -65,6 +65,8 @@ export const BatchChangeRepoPage: FC<BatchChangeRepoPageProps> = ({
         }
         return true
     }, [isSourcegraphDotCom, authenticatedUser])
+
+    useEffect(() => props.telemetryRecorder.recordEvent('repo.batchChanges', 'view'), [props.telemetryRecorder])
 
     return (
         <Page>

--- a/client/web/src/enterprise/own/RepositoryOwnPage.tsx
+++ b/client/web/src/enterprise/own/RepositoryOwnPage.tsx
@@ -104,7 +104,12 @@ export const RepositoryOwnPage: React.FunctionComponent<RepositoryOwnAreaPagePro
                     </H1>
                 </PageHeader>
 
-                <TreeOwnershipPanel repoID={repo.id} filePath={filePath} telemetryService={telemetryService} />
+                <TreeOwnershipPanel
+                    repoID={repo.id}
+                    filePath={filePath}
+                    telemetryService={telemetryService}
+                    telemetryRecorder={telemetryRecorder}
+                />
             </Page>
             {openAddOwnerModal && <AddOwnerModal repoID={repo.id} path={filePath} onCancel={closeModal} />}
         </>

--- a/client/web/src/repo/RepoContainer.tsx
+++ b/client/web/src/repo/RepoContainer.tsx
@@ -395,6 +395,7 @@ const RepoUserContainer: FC<RepoUserContainerProps> = ({
                 repoName={repoName}
                 viewerCanAdminister={viewerCanAdminister}
                 repoFetchError={repoOrError as ErrorLike}
+                telemetryRecorder={props.platformContext.telemetryRecorder}
             />
         )
     }

--- a/client/web/src/repo/RepoContainer.tsx
+++ b/client/web/src/repo/RepoContainer.tsx
@@ -491,6 +491,7 @@ const RepoUserContainer: FC<RepoUserContainerProps> = ({
                         source="repoHeader"
                         key="go-to-code-host"
                         externalLinks={externalLinks}
+                        telemetryRecorder={props.platformContext.telemetryRecorder}
                     />
                 )}
             </RepoHeaderContributionPortal>

--- a/client/web/src/repo/RepoContainerError.tsx
+++ b/client/web/src/repo/RepoContainerError.tsx
@@ -1,3 +1,6 @@
+import { useEffect } from 'react'
+
+import { R } from 'linguist-languages'
 import AlertCircleIcon from 'mdi-react/AlertCircleIcon'
 import AlertIcon from 'mdi-react/AlertIcon'
 import SourceRepositoryIcon from 'mdi-react/SourceRepositoryIcon'
@@ -9,6 +12,7 @@ import {
     isRevisionNotFoundErrorLike,
     isRepoNotFoundErrorLike,
     isRepoDeniedErrorLike,
+    RepoDeniedError,
 } from '@sourcegraph/shared/src/backend/errors'
 import { RepoQuestionIcon } from '@sourcegraph/shared/src/components/icons'
 import { displayRepoName } from '@sourcegraph/shared/src/components/RepoLink'
@@ -45,58 +49,108 @@ export const RepoContainerError: React.FunctionComponent<React.PropsWithChildren
     }
 
     if (isRepoDeniedErrorLike(repoFetchError)) {
-        telemetryRecorder.recordEvent('repo.error.repoDenied', 'view')
         return (
-            <HeroPage
-                icon={AlertIcon}
-                title={displayRepoName(repoName)}
-                body={<Text className="mt-4">Repository cannot be added on-demand: {repoFetchError.reason}.</Text>}
+            <RepoDeniedPage
+                repoFetchError={repoFetchError}
+                repoName={repoName}
+                telemetryRecorder={telemetryRecorder}
             />
         )
     }
 
     if (isCloneInProgressErrorLike(repoFetchError)) {
-        telemetryRecorder.recordEvent('repo.error.cloneInProgress', 'view')
         return (
-            <HeroPage
-                icon={SourceRepositoryIcon}
-                title={displayRepoName(repoName)}
-                className="repository-cloning-in-progress-page"
-                subtitle={<Text>Cloning in progress</Text>}
-                detail={
-                    <>
-                        <Code>{(repoFetchError as CloneInProgressError).progress}</Code>
-                        {viewerCanAdminister && (
-                            <Text className="mt-4">
-                                <Link to={`${repoName}/-/settings`}>Go to settings</Link> to view details
-                            </Text>
-                        )}
-                    </>
-                }
-                body={<DirectImportRepoAlert className="mt-3" />}
+            <CloneInProgressPage
+                repoName={repoName}
+                viewerCanAdminister={viewerCanAdminister}
+                repoFetchError={repoFetchError}
+                telemetryRecorder={telemetryRecorder}
             />
         )
     }
 
     if (isRevisionNotFoundErrorLike(repoFetchError)) {
-        telemetryRecorder.recordEvent('repo.error.revisionNotFound', 'view')
         return (
-            <HeroPage
-                icon={RepoQuestionIcon}
-                title="Empty repository"
-                detail={
-                    <>
-                        {viewerCanAdminister && (
-                            <Text>
-                                <Link to={`${repoName}/-/settings`}>Go to settings</Link>
-                            </Text>
-                        )}
-                    </>
-                }
+            <RevisionNotFoundErrorPage
+                repoName={repoName}
+                viewerCanAdminister={viewerCanAdminister}
+                telemetryRecorder={telemetryRecorder}
             />
         )
     }
 
-    telemetryRecorder.recordEvent('repo.error.other', 'view')
+    return (<OtherRepoErrorPage repoFetchError={repoFetchError} telemetryRecorder={telemetryRecorder} />)
+}
+
+interface RepoDeniedPageProps extends TelemetryV2Props {
+    repoFetchError: RepoDeniedError
+    repoName: string
+}
+
+export const RepoDeniedPage: React.FunctionComponent<React.PropsWithChildren<RepoDeniedPageProps> = props => {
+    const { repoName, repoFetchError, telemetryRecorder } = props
+
+    useEffect(() => telemetryRecorder.recordEvent('repo.error.repoDenied', 'view'), [telemetryRecorder])
+    return (
+        <HeroPage
+            icon={AlertIcon}
+            title={displayRepoName(repoName)}
+            body={<Text className="mt-4">Repository cannot be added on-demand: {repoFetchError.reason}.</Text>}
+        />
+    )
+}
+
+export const CloneInProgressPage: React.FunctionComponent<React.PropsWithChildren<RepoContainerErrorProps>> = props => {
+    const { repoName, viewerCanAdminister, repoFetchError, telemetryRecorder } = props
+
+    useEffect(() => telemetryRecorder.recordEvent('repo.error.cloneInProgress', 'view'), [telemetryRecorder])
+    return (
+        <HeroPage
+            icon={SourceRepositoryIcon}
+            title={displayRepoName(repoName)}
+            className="repository-cloning-in-progress-page"
+            subtitle={<Text>Cloning in progress</Text>}
+            detail={
+                <>
+                    <Code>{(repoFetchError as CloneInProgressError).progress}</Code>
+                    {viewerCanAdminister && (
+                        <Text className="mt-4">
+                            <Link to={`${repoName}/-/settings`}>Go to settings</Link> to view details
+                        </Text>
+                    )}
+                </>
+            }
+            body={<DirectImportRepoAlert className="mt-3" />}
+        />
+    )
+}
+
+export const RevisionNotFoundErrorPage: React.FunctionComponent<
+    React.PropsWithChildren<Pick<RepoContainerErrorProps, 'repoName' | 'viewerCanAdminister' | 'telemetryRecorder'>>
+> = props => {
+    const { repoName, viewerCanAdminister, telemetryRecorder } = props
+
+    useEffect(() => telemetryRecorder.recordEvent('repo.error.revisionNotFound', 'view'), [telemetryRecorder])
+    return (
+        <HeroPage
+            icon={RepoQuestionIcon}
+            title="Empty repository"
+            detail={
+                <>
+                    {viewerCanAdminister && (
+                        <Text>
+                            <Link to={`${repoName}/-/settings`}>Go to settings</Link>
+                        </Text>
+                    )}
+                </>
+            }
+        />
+    )
+}
+
+export const OtherRepoErrorPage: React.FunctionComponent<React.PropsWithChildren<Pick<RepoContainerErrorProps, 'repoFetchError' | 'telemetryRecorder'>>> = props => {
+    const { repoFetchError, telemetryRecorder } = props
+
+    useEffect(() => telemetryRecorder.recordEvent('repo.error.other', 'view'), [telemetryRecorder])
     return <HeroPage icon={AlertCircleIcon} title="Error" subtitle={<ErrorMessage error={repoFetchError} />} />
 }

--- a/client/web/src/repo/RepoContainerError.tsx
+++ b/client/web/src/repo/RepoContainerError.tsx
@@ -1,6 +1,5 @@
 import { useEffect } from 'react'
 
-import { R } from 'linguist-languages'
 import AlertCircleIcon from 'mdi-react/AlertCircleIcon'
 import AlertIcon from 'mdi-react/AlertIcon'
 import SourceRepositoryIcon from 'mdi-react/SourceRepositoryIcon'

--- a/client/web/src/repo/RepoContainerError.tsx
+++ b/client/web/src/repo/RepoContainerError.tsx
@@ -50,11 +50,7 @@ export const RepoContainerError: React.FunctionComponent<React.PropsWithChildren
 
     if (isRepoDeniedErrorLike(repoFetchError)) {
         return (
-            <RepoDeniedPage
-                repoFetchError={repoFetchError}
-                repoName={repoName}
-                telemetryRecorder={telemetryRecorder}
-            />
+            <RepoDeniedPage repoFetchError={repoFetchError} repoName={repoName} telemetryRecorder={telemetryRecorder} />
         )
     }
 
@@ -79,7 +75,7 @@ export const RepoContainerError: React.FunctionComponent<React.PropsWithChildren
         )
     }
 
-    return (<OtherRepoErrorPage repoFetchError={repoFetchError} telemetryRecorder={telemetryRecorder} />)
+    return <OtherRepoErrorPage repoFetchError={repoFetchError} telemetryRecorder={telemetryRecorder} />
 }
 
 interface RepoDeniedPageProps extends TelemetryV2Props {
@@ -87,7 +83,7 @@ interface RepoDeniedPageProps extends TelemetryV2Props {
     repoName: string
 }
 
-export const RepoDeniedPage: React.FunctionComponent<React.PropsWithChildren<RepoDeniedPageProps> = props => {
+export const RepoDeniedPage: React.FunctionComponent<React.PropsWithChildren<RepoDeniedPageProps>> = props => {
     const { repoName, repoFetchError, telemetryRecorder } = props
 
     useEffect(() => telemetryRecorder.recordEvent('repo.error.repoDenied', 'view'), [telemetryRecorder])
@@ -148,7 +144,9 @@ export const RevisionNotFoundErrorPage: React.FunctionComponent<
     )
 }
 
-export const OtherRepoErrorPage: React.FunctionComponent<React.PropsWithChildren<Pick<RepoContainerErrorProps, 'repoFetchError' | 'telemetryRecorder'>>> = props => {
+export const OtherRepoErrorPage: React.FunctionComponent<
+    React.PropsWithChildren<Pick<RepoContainerErrorProps, 'repoFetchError' | 'telemetryRecorder'>>
+> = props => {
     const { repoFetchError, telemetryRecorder } = props
 
     useEffect(() => telemetryRecorder.recordEvent('repo.error.other', 'view'), [telemetryRecorder])

--- a/client/web/src/repo/RepoHeader.story.tsx
+++ b/client/web/src/repo/RepoHeader.story.tsx
@@ -123,6 +123,7 @@ const createBreadcrumbs = (path: string) => [
                     revision="main"
                     repoName="sourcegraph/sourcegraph"
                     repo={undefined}
+                    telemetryRecorder={noOpTelemetryRecorder}
                 />
             ),
         },

--- a/client/web/src/repo/RepoMetadataPage/index.tsx
+++ b/client/web/src/repo/RepoMetadataPage/index.tsx
@@ -4,6 +4,7 @@ import { Navigate } from 'react-router-dom'
 
 import { RepoMetadata, type RepoMetadataItem } from '@sourcegraph/branded'
 import { useMutation, useQuery } from '@sourcegraph/http-client'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Container, PageHeader, ErrorAlert, Input, Text, LoadingSpinner, Link } from '@sourcegraph/wildcard'
 
@@ -24,22 +25,29 @@ import { DELETE_REPO_METADATA_GQL, GET_REPO_METADATA_GQL } from './query'
 
 const BREADCRUMB = { key: 'metadata', element: 'Metadata' }
 
-interface RepoMetadataPageProps extends Pick<BreadcrumbSetters, 'useBreadcrumb'>, TelemetryProps {
+interface RepoMetadataPageProps extends Pick<BreadcrumbSetters, 'useBreadcrumb'>, TelemetryProps, TelemetryV2Props {
     repo: Pick<RepositoryFields, 'name' | 'url' | 'metadata' | 'id'>
 }
 
 /**
  * The repository metadata page.
  */
-export const RepoMetadataPage: FC<RepoMetadataPageProps> = ({ telemetryService, useBreadcrumb, repo, ...props }) => {
+export const RepoMetadataPage: FC<RepoMetadataPageProps> = ({
+    telemetryService,
+    telemetryRecorder,
+    useBreadcrumb,
+    repo,
+    ...props
+}) => {
     useBreadcrumb(BREADCRUMB)
     const [repoMetadataEnabled, status] = useFeatureFlag('repository-metadata', true)
 
     useEffect(() => {
         if (repoMetadataEnabled) {
-            telemetryService.log('repoPage:ownershipPage:viewed')
+            telemetryService.log('repoPage:metadataPage:viewed')
+            telemetryRecorder.recordEvent('repo.metadata', 'view')
         }
-    }, [repoMetadataEnabled, telemetryService])
+    }, [repoMetadataEnabled, telemetryService, telemetryRecorder])
 
     const {
         data,

--- a/client/web/src/repo/RepoRevisionContainer.tsx
+++ b/client/web/src/repo/RepoRevisionContainer.tsx
@@ -7,6 +7,7 @@ import { isErrorLike } from '@sourcegraph/common'
 import type { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
 import type { SearchContextProps } from '@sourcegraph/shared/src/search'
 import type { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import type { RevisionSpec } from '@sourcegraph/shared/src/util/url'
 import {
@@ -110,12 +111,14 @@ interface RepoRevisionContainerProps
     isSourcegraphDotCom: boolean
 }
 
-interface RepoRevisionBreadcrumbProps extends Pick<RepoRevisionContainerProps, 'repo' | 'revision' | 'repoName'> {
+interface RepoRevisionBreadcrumbProps
+    extends Pick<RepoRevisionContainerProps, 'repo' | 'revision' | 'repoName'>,
+        TelemetryV2Props {
     resolvedRevision: ResolvedRevision | undefined
 }
 
 export const RepoRevisionContainerBreadcrumb: FC<RepoRevisionBreadcrumbProps> = props => {
-    const { revision, resolvedRevision, repoName, repo } = props
+    const { revision, resolvedRevision, repoName, repo, telemetryRecorder } = props
 
     const [revisionLabelElement, setRevisionLabelElement] = useState<HTMLElement | null>(null)
     const [showRevisionTooltip, setShowRevisionTooltip] = useState(false)
@@ -177,6 +180,7 @@ export const RepoRevisionContainerBreadcrumb: FC<RepoRevisionBreadcrumbProps> = 
                         currentCommitID={resolvedRevision?.commitID}
                         togglePopover={togglePopover}
                         onSelect={togglePopover}
+                        telemetryRecorder={telemetryRecorder}
                     />
                 )}
             </PopoverContent>
@@ -206,6 +210,7 @@ export const RepoRevisionContainer: FC<RepoRevisionContainerProps> = props => {
                         revision={revision}
                         repoName={repoName}
                         repo={repo}
+                        telemetryRecorder={props.platformContext.telemetryRecorder}
                     />
                 ),
             }

--- a/client/web/src/repo/RepoRevisionContainer.tsx
+++ b/client/web/src/repo/RepoRevisionContainer.tsx
@@ -214,7 +214,7 @@ export const RepoRevisionContainer: FC<RepoRevisionContainerProps> = props => {
                     />
                 ),
             }
-        }, [resolvedRevision, revision, repo, repoName])
+        }, [resolvedRevision, revision, repo, repoName, props.platformContext.telemetryRecorder])
     )
 
     const isPackage = useMemo(

--- a/client/web/src/repo/RepoRevisionSidebar.tsx
+++ b/client/web/src/repo/RepoRevisionSidebar.tsx
@@ -78,7 +78,7 @@ export const RepoRevisionSidebar: FC<RepoRevisionSidebarProps> = props => {
                 action: 'click',
                 label: 'expand / collapse file tree view',
             })
-            props.telemetryRecorder.recordEvent('blobSidebar.fileTreeView', 'click')
+            props.telemetryRecorder.recordEvent('repoSidebar.fileTreeView', 'click')
             setPersistedIsVisible(value)
             setIsVisible(value)
         },
@@ -86,7 +86,7 @@ export const RepoRevisionSidebar: FC<RepoRevisionSidebarProps> = props => {
     )
     const handleSymbolClick = useCallback(() => {
         props.telemetryService.log('SymbolTreeViewClicked')
-        props.telemetryRecorder.recordEvent('blobSidebar.symbolTreeView', 'click')
+        props.telemetryRecorder.recordEvent('repoSidebar.symbolTreeView', 'click')
     }, [props.telemetryService, props.telemetryRecorder])
 
     const [enableBlobPageSwitchAreasShortcuts] = useFeatureFlag('blob-page-switch-areas-shortcuts')

--- a/client/web/src/repo/RepoRevisionSidebarCommits.tsx
+++ b/client/web/src/repo/RepoRevisionSidebarCommits.tsx
@@ -5,6 +5,7 @@ import classNames from 'classnames'
 import { useLocation } from 'react-router-dom'
 
 import { dataOrThrowErrors, gql } from '@sourcegraph/http-client'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { FileSpec, RevisionSpec } from '@sourcegraph/shared/src/util/url'
 import { Icon, Link, ErrorAlert } from '@sourcegraph/wildcard'
 
@@ -23,11 +24,11 @@ import { gitCommitFragment } from './commits/RepositoryCommitsPage'
 
 import styles from './RepoRevisionSidebarCommits.module.scss'
 
-interface CommitNodeProps {
+interface CommitNodeProps extends TelemetryV2Props {
     node: GitCommitFields
 }
 
-const CommitNode: FC<CommitNodeProps> = ({ node }) => {
+const CommitNode: FC<CommitNodeProps> = ({ node, telemetryRecorder }) => {
     const location = useLocation()
 
     return (
@@ -46,12 +47,13 @@ const CommitNode: FC<CommitNodeProps> = ({ node }) => {
                         <Icon aria-hidden={true} svgPath={mdiFile} />
                     </Link>
                 }
+                telemetryRecorder={telemetryRecorder}
             />
         </li>
     )
 }
 
-interface Props extends Partial<RevisionSpec>, FileSpec {
+interface Props extends Partial<RevisionSpec>, FileSpec, TelemetryV2Props {
     repoID: Scalars['ID']
     defaultPageSize?: number
 }
@@ -100,7 +102,7 @@ export const RepoRevisionSidebarCommits: FC<Props> = props => {
         <ConnectionContainer>
             {error && <ErrorAlert error={error} />}
             {connection?.nodes.map(node => (
-                <CommitNode key={node.id} node={node} />
+                <CommitNode key={node.id} node={node} telemetryRecorder={props.telemetryRecorder} />
             ))}
             {loading && <ConnectionLoading />}
             {!loading && connection && (

--- a/client/web/src/repo/RepoRevisionSidebarFileTree.tsx
+++ b/client/web/src/repo/RepoRevisionSidebarFileTree.tsx
@@ -194,7 +194,7 @@ export const RepoRevisionSidebarFileTree: React.FunctionComponent<Props> = props
             }
 
             telemetryService.log('FileTreeLoadDirectory')
-            telemetryRecorder.recordEvent('blobSidebar.fileTreeDirectory', 'load')
+            telemetryRecorder.recordEvent('repoSidebar.fileTreeDirectory', 'load')
             await fetchEntries({
                 ...defaultVariables,
                 filePath: fullPath,
@@ -227,7 +227,7 @@ export const RepoRevisionSidebarFileTree: React.FunctionComponent<Props> = props
 
             if (element.dotdot) {
                 telemetryService.log('FileTreeLoadParent')
-                telemetryRecorder.recordEvent('blobSidebar.fileTreeParentLink', 'click')
+                telemetryRecorder.recordEvent('repoSidebar.fileTreeParentLink', 'click')
                 navigate(element.dotdot)
 
                 let parent = props.initialFilePathIsDirectory
@@ -242,7 +242,7 @@ export const RepoRevisionSidebarFileTree: React.FunctionComponent<Props> = props
 
             if (element.entry) {
                 telemetryService.log('FileTreeClick')
-                telemetryRecorder.recordEvent('blobSidebar.fileTreeLink', 'click')
+                telemetryRecorder.recordEvent('repoSidebar.fileTreeLink', 'click')
                 navigate(element.entry.url)
             }
             setSelectedIds([element.id])

--- a/client/web/src/repo/RepositoriesPopover/RepositoriesPopover.story.tsx
+++ b/client/web/src/repo/RepositoriesPopover/RepositoriesPopover.story.tsx
@@ -1,5 +1,6 @@
 import type { Meta } from '@storybook/react'
 
+import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
 
 import { WebStory } from '../../components/WebStory'
@@ -22,5 +23,9 @@ const Story: Meta = {
 export default Story
 
 export const RepositoriesPopoverExample = () => (
-    <RepositoriesPopover currentRepo="some-repo-id" telemetryService={NOOP_TELEMETRY_SERVICE} />
+    <RepositoriesPopover
+        currentRepo="some-repo-id"
+        telemetryService={NOOP_TELEMETRY_SERVICE}
+        telemetryRecorder={noOpTelemetryRecorder}
+    />
 )

--- a/client/web/src/repo/RepositoriesPopover/RepositoriesPopover.test.tsx
+++ b/client/web/src/repo/RepositoriesPopover/RepositoriesPopover.test.tsx
@@ -1,6 +1,7 @@
 import { cleanup, fireEvent, act } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
+import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { MockedTestProvider, waitForNextApolloResponse } from '@sourcegraph/shared/src/testing/apollo'
 import { type RenderWithBrandedContextResult, renderWithBrandedContext } from '@sourcegraph/wildcard/src/testing'
@@ -26,7 +27,11 @@ describe('RevisionsPopover', () => {
     beforeEach(async () => {
         renderResult = renderWithBrandedContext(
             <MockedTestProvider mocks={MOCK_REQUESTS}>
-                <RepositoriesPopover currentRepo={repo.id} telemetryService={NOOP_TELEMETRY_SERVICE} />
+                <RepositoriesPopover
+                    currentRepo={repo.id}
+                    telemetryService={NOOP_TELEMETRY_SERVICE}
+                    telemetryRecorder={noOpTelemetryRecorder}
+                />
             </MockedTestProvider>,
             { route: repo.name }
         )

--- a/client/web/src/repo/RepositoriesPopover/RepositoriesPopover.tsx
+++ b/client/web/src/repo/RepositoriesPopover/RepositoriesPopover.tsx
@@ -3,6 +3,7 @@ import React, { useEffect, useState } from 'react'
 import { createAggregateError } from '@sourcegraph/common'
 import { gql } from '@sourcegraph/http-client'
 import type { Scalars } from '@sourcegraph/shared/src/graphql-operations'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { EVENT_LOGGER } from '@sourcegraph/shared/src/telemetry/web/eventLogger'
 import { useDebounce } from '@sourcegraph/wildcard'
@@ -49,7 +50,7 @@ export const REPOSITORIES_FOR_POPOVER = gql`
     }
 `
 
-export interface RepositoriesPopoverProps extends TelemetryProps {
+export interface RepositoriesPopoverProps extends TelemetryProps, TelemetryV2Props {
     /**
      * The current repository (shown as selected in the list), if any.
      */
@@ -64,6 +65,7 @@ export const BATCH_COUNT = 10
 export const RepositoriesPopover: React.FunctionComponent<React.PropsWithChildren<RepositoriesPopoverProps>> = ({
     currentRepo,
     telemetryService,
+    telemetryRecorder,
 }) => {
     const [searchValue, setSearchValue] = useState('')
     const query = useDebounce(searchValue, 200)
@@ -71,7 +73,8 @@ export const RepositoriesPopover: React.FunctionComponent<React.PropsWithChildre
     useEffect(() => {
         EVENT_LOGGER.logViewEvent('RepositoriesPopover')
         telemetryService.log('RepositoriesPopover')
-    }, [telemetryService])
+        telemetryRecorder.recordEvent('reposPopover', 'view')
+    }, [telemetryService, telemetryRecorder])
 
     const { connection, loading, error, hasNextPage, fetchMore } = useShowMorePagination<
         RepositoriesForPopoverResult,

--- a/client/web/src/repo/RepositoryFileTreePage.tsx
+++ b/client/web/src/repo/RepositoryFileTreePage.tsx
@@ -145,6 +145,7 @@ export const RepositoryFileTreePage: FC<RepositoryFileTreePageProps> = props => 
                                 className={styles.pageContent}
                                 authenticatedUser={context.authenticatedUser}
                                 context={globalContext}
+                                telemetryRecorder={platformContext.telemetryRecorder}
                             />
                         ) : (
                             <LoadingSpinner />

--- a/client/web/src/repo/RepositoryNotFoundPage.tsx
+++ b/client/web/src/repo/RepositoryNotFoundPage.tsx
@@ -2,8 +2,8 @@ import * as React from 'react'
 
 import MapSearchIcon from 'mdi-react/MapSearchIcon'
 
-import { EVENT_LOGGER } from '@sourcegraph/shared/src/telemetry/web/eventLogger'
 import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
+import { EVENT_LOGGER } from '@sourcegraph/shared/src/telemetry/web/eventLogger'
 import { Code, Link, Text } from '@sourcegraph/wildcard'
 
 import { HeroPage } from '../components/HeroPage'
@@ -22,8 +22,6 @@ interface Props extends TelemetryV2Props {
  * A page informing the user that an error occurred while trying to display the repository. It
  * attempts to present the user with actions to solve the problem.
  */
-export const RepositoryNotFoundPage: React.FunctionComponent<Props> = ({ repo, viewerCanAdminister }) => {
-    React.useEffect(() => EVENT_LOGGER.logViewEvent('RepositoryError'), [])
 export const RepositoryNotFoundPage: React.FunctionComponent<Props> = ({
     repo,
     viewerCanAdminister,

--- a/client/web/src/repo/RepositoryNotFoundPage.tsx
+++ b/client/web/src/repo/RepositoryNotFoundPage.tsx
@@ -3,13 +3,14 @@ import * as React from 'react'
 import MapSearchIcon from 'mdi-react/MapSearchIcon'
 
 import { EVENT_LOGGER } from '@sourcegraph/shared/src/telemetry/web/eventLogger'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import { Code, Link, Text } from '@sourcegraph/wildcard'
 
 import { HeroPage } from '../components/HeroPage'
 
 import styles from './RepositoryNotFoundPage.module.scss'
 
-interface Props {
+interface Props extends TelemetryV2Props {
     /** The name of the repository. */
     repo: string
 
@@ -23,6 +24,15 @@ interface Props {
  */
 export const RepositoryNotFoundPage: React.FunctionComponent<Props> = ({ repo, viewerCanAdminister }) => {
     React.useEffect(() => EVENT_LOGGER.logViewEvent('RepositoryError'), [])
+export const RepositoryNotFoundPage: React.FunctionComponent<Props> = ({
+    repo,
+    viewerCanAdminister,
+    telemetryRecorder,
+}) => {
+    React.useEffect(() => {
+        EVENT_LOGGER.logViewEvent('RepositoryError')
+        telemetryRecorder.recordEvent('repo.error.notFound', 'view')
+    }, [telemetryRecorder])
 
     return (
         <HeroPage

--- a/client/web/src/repo/RevisionsPopover/RevisionsPopover.mocks.ts
+++ b/client/web/src/repo/RevisionsPopover/RevisionsPopover.mocks.ts
@@ -3,6 +3,7 @@ import { subDays } from 'date-fns'
 
 import { getDocumentNode } from '@sourcegraph/http-client'
 import { GitRefType } from '@sourcegraph/shared/src/graphql-operations'
+import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
 
 import type {
     GitCommitAncestorsConnectionFields,
@@ -23,6 +24,7 @@ export const MOCK_PROPS: RevisionsPopoverProps = {
     currentRev: 'main',
     togglePopover: () => null,
     showSpeculativeResults: false,
+    telemetryRecorder: noOpTelemetryRecorder,
 }
 
 const yesterday = subDays(new Date(), 1).toISOString()

--- a/client/web/src/repo/RevisionsPopover/RevisionsPopover.tsx
+++ b/client/web/src/repo/RevisionsPopover/RevisionsPopover.tsx
@@ -4,6 +4,7 @@ import { mdiClose } from '@mdi/js'
 import classNames from 'classnames'
 
 import { GitRefType, type Scalars } from '@sourcegraph/shared/src/graphql-operations'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import { EVENT_LOGGER } from '@sourcegraph/shared/src/telemetry/web/eventLogger'
 import { Button, useLocalStorage, Tab, TabList, TabPanel, TabPanels, Icon } from '@sourcegraph/wildcard'
 
@@ -17,7 +18,7 @@ import { RevisionsPopoverReferences } from './RevisionsPopoverReferences'
 
 import styles from './RevisionsPopover.module.scss'
 
-export interface RevisionsPopoverProps {
+export interface RevisionsPopoverProps extends TelemetryV2Props {
     repoId: Scalars['ID']
     repoName: string
     repoServiceType: string
@@ -98,11 +99,12 @@ const VERSIONS_TAB: RevisionsPopoverTab = {
  * the current repository.
  */
 export const RevisionsPopover: React.FunctionComponent<React.PropsWithChildren<RevisionsPopoverProps>> = props => {
-    const { getPathFromRevision = replaceRevisionInURL, repoServiceType } = props
+    const { getPathFromRevision = replaceRevisionInURL, repoServiceType, telemetryRecorder } = props
 
     useEffect(() => {
         EVENT_LOGGER.logViewEvent('RevisionsPopover')
-    }, [])
+        telemetryRecorder.recordEvent('repo.revisionsPopover', 'view')
+    }, [telemetryRecorder])
 
     const [tabIndex, setTabIndex] = useLocalStorage(LAST_TAB_STORAGE_KEY, 0)
     const handleTabsChange = useCallback((index: number) => setTabIndex(index), [setTabIndex])

--- a/client/web/src/repo/actions/CopyPermalinkAction.tsx
+++ b/client/web/src/repo/actions/CopyPermalinkAction.tsx
@@ -81,7 +81,7 @@ export const CopyPermalinkAction: React.FunctionComponent<CopyPermalinkActionPro
 
     const onClick = (): void => {
         telemetryService.log('PermalinkClicked', { repoName, commitID })
-        telemetryRecorder.recordEvent('search.header.permalink', 'click')
+        telemetryRecorder.recordEvent('repo.header.permalink', 'click')
     }
 
     if (actionType === 'dropdown') {
@@ -95,7 +95,7 @@ export const CopyPermalinkAction: React.FunctionComponent<CopyPermalinkActionPro
 
     const copyPermalink = (): void => {
         telemetryService.log('CopyPermalink')
-        telemetryRecorder.recordEvent('search.header.permalink', 'copy')
+        telemetryRecorder.recordEvent('repo.header.permalink', 'copy')
         copy(createUrl(rootUrl, permalinkURL))
         setCopiedPermalink(true)
         screenReaderAnnounce('Permalink copied to clipboard')
@@ -105,7 +105,7 @@ export const CopyPermalinkAction: React.FunctionComponent<CopyPermalinkActionPro
 
     const copyLink = (): void => {
         telemetryService.log('CopyLink')
-        telemetryRecorder.recordEvent('search.header.link', 'click')
+        telemetryRecorder.recordEvent('repo.header.link', 'copy')
         copy(createUrl(rootUrl, linkURL))
         setCopiedLink(true)
         screenReaderAnnounce('Link copied to clipboard')

--- a/client/web/src/repo/actions/GoToCodeHostAction.tsx
+++ b/client/web/src/repo/actions/GoToCodeHostAction.tsx
@@ -14,6 +14,7 @@ import type { Position, Range } from '@sourcegraph/extension-api-types'
 import { SimpleActionItem } from '@sourcegraph/shared/src/actions/SimpleActionItem'
 // TODO: Switch mdi icon
 import { HelixSwarmIcon, PhabricatorIcon } from '@sourcegraph/shared/src/components/icons'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import { EVENT_LOGGER } from '@sourcegraph/shared/src/telemetry/web/eventLogger'
 import type { FileSpec, RevisionSpec } from '@sourcegraph/shared/src/util/url'
 import { type ButtonLinkProps, Icon, Link, Tooltip, useObservable } from '@sourcegraph/wildcard'
@@ -26,7 +27,7 @@ import type { RepoHeaderContext } from '../RepoHeader'
 
 import styles from './actions.module.scss'
 
-interface Props extends RevisionSpec, Partial<FileSpec> {
+interface Props extends RevisionSpec, Partial<FileSpec>, TelemetryV2Props {
     repo?: Pick<RepositoryFields, 'name' | 'defaultBranch' | 'externalURLs' | 'externalRepository'> | null
     filePath?: string
     commitRange?: string
@@ -50,7 +51,7 @@ interface Props extends RevisionSpec, Partial<FileSpec> {
 export const GoToCodeHostAction: React.FunctionComponent<
     React.PropsWithChildren<Props & RepoHeaderContext>
 > = props => {
-    const { repo, revision, filePath } = props
+    const { repo, revision, filePath, telemetryRecorder } = props
 
     const serviceType = props.repo?.externalRepository?.serviceType
 
@@ -92,7 +93,10 @@ export const GoToCodeHostAction: React.FunctionComponent<
         }, [serviceType, props.perforceCodeHostUrlToSwarmUrlMap, props.repo, props.repoName, props.revision])
     )
 
-    const onClick = useCallback(() => EVENT_LOGGER.log('GoToCodeHostClicked'), [])
+    const onClick = useCallback(() => {
+        EVENT_LOGGER.log('GoToCodeHostClicked')
+        telemetryRecorder.recordEvent('repo.goToCodeHost', 'click')
+    }, [telemetryRecorder])
 
     // If the default branch is undefined, set to HEAD
     const defaultBranch = (!isErrorLike(props.repo) && props.repo?.defaultBranch?.displayName) || 'HEAD'

--- a/client/web/src/repo/actions/ToggleBlameAction.tsx
+++ b/client/web/src/repo/actions/ToggleBlameAction.tsx
@@ -3,6 +3,7 @@ import { useCallback } from 'react'
 import { mdiGit } from '@mdi/js'
 
 import { SimpleActionItem } from '@sourcegraph/shared/src/actions/SimpleActionItem'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import { EVENT_LOGGER } from '@sourcegraph/shared/src/telemetry/web/eventLogger'
 import type { RenderMode } from '@sourcegraph/shared/src/util/url'
 import { Button, Icon, Tooltip } from '@sourcegraph/wildcard'
@@ -13,7 +14,7 @@ import { RepoActionInfo } from '../RepoActionInfo'
 
 import styles from './actions.module.scss'
 
-interface Props {
+interface Props extends TelemetryV2Props {
     source?: 'repoHeader' | 'actionItemsBar'
     actionType?: 'nav' | 'dropdown'
     renderMode?: RenderMode
@@ -35,11 +36,13 @@ export const ToggleBlameAction: React.FC<Props> = props => {
         if (isBlameVisible) {
             setIsBlameVisible(false)
             EVENT_LOGGER.log('GitBlameDisabled')
+            props.telemetryRecorder.recordEvent('repo.gitBlame', 'disable')
         } else {
             setIsBlameVisible(true)
             EVENT_LOGGER.log('GitBlameEnabled')
+            props.telemetryRecorder.recordEvent('repo.gitBlame', 'enable')
         }
-    }, [isBlameVisible, setIsBlameVisible])
+    }, [isBlameVisible, setIsBlameVisible, props.telemetryRecorder])
 
     const icon = <Icon aria-hidden={true} svgPath={mdiGit} />
 

--- a/client/web/src/repo/blob/BlobPage.tsx
+++ b/client/web/src/repo/blob/BlobPage.tsx
@@ -392,6 +392,7 @@ export const BlobPage: React.FunctionComponent<BlobPageProps> = ({ className, co
                         source="repoHeader"
                         renderMode={renderMode}
                         isPackage={isPackage}
+                        telemetryRecorder={props.telemetryRecorder}
                     />
                 )}
             </RepoHeaderContributionPortal>
@@ -465,6 +466,7 @@ export const BlobPage: React.FunctionComponent<BlobPageProps> = ({ className, co
                     revision={revision}
                     filePath={filePath}
                     enableOwnershipPanel={enableOwnershipPanel}
+                    telemetryRecorder={props.telemetryRecorder}
                 />
             )}
             {isErrorLike(blameHunks) && <ErrorAlert error={blameHunks} />}

--- a/client/web/src/repo/blob/BlobPage.tsx
+++ b/client/web/src/repo/blob/BlobPage.tsx
@@ -147,7 +147,7 @@ export const BlobPage: React.FunctionComponent<BlobPageProps> = ({ className, co
     // Log view event whenever a new Blob, or a Blob with a different render mode, is visited.
     useEffect(() => {
         props.telemetryService.logViewEvent('Blob', { repoName, filePath })
-        props.telemetryRecorder.recordEvent('blob', 'view')
+        props.telemetryRecorder.recordEvent('repo.blob', 'view')
     }, [repoName, commitID, filePath, renderMode, props.telemetryService, props.telemetryRecorder])
 
     useBreadcrumb(

--- a/client/web/src/repo/blob/CodeMirrorBlob.tsx
+++ b/client/web/src/repo/blob/CodeMirrorBlob.tsx
@@ -215,6 +215,7 @@ export const CodeMirrorBlob: React.FunctionComponent<BlobProps> = props => {
         staticHighlightRanges,
         'data-testid': dataTestId,
         telemetryService,
+        telemetryRecorder,
     } = props
 
     const apolloClient = useApolloClient()
@@ -499,7 +500,8 @@ export const CodeMirrorBlob: React.FunctionComponent<BlobProps> = props => {
 
     const logEventOnCopy = useCallback(() => {
         telemetryService.log(...codeCopiedEvent('blob-view'))
-    }, [telemetryService])
+        telemetryRecorder.recordEvent('repo.blob.code', 'copy')
+    }, [telemetryService, telemetryRecorder])
 
     return (
         <>

--- a/client/web/src/repo/blob/own/FileOwnershipPanel.tsx
+++ b/client/web/src/repo/blob/own/FileOwnershipPanel.tsx
@@ -28,7 +28,7 @@ export const FileOwnershipPanel: React.FunctionComponent<OwnershipPanelProps & T
 }) => {
     React.useEffect(() => {
         telemetryService.log('OwnershipPanelOpened')
-        telemetryRecorder.recordEvent('blob.ownershipPanel', 'open')
+        telemetryRecorder.recordEvent('repo.blob.ownershipPanel', 'open')
     }, [telemetryService, telemetryRecorder])
 
     const { data, loading, error, refetch } = useQuery<FetchOwnershipResult, FetchOwnershipVariables>(FETCH_OWNERS, {

--- a/client/web/src/repo/blob/own/HistoryAndOwnBar.story.tsx
+++ b/client/web/src/repo/blob/own/HistoryAndOwnBar.story.tsx
@@ -2,6 +2,7 @@ import type { MockedResponse } from '@apollo/client/testing'
 import type { Meta, StoryFn } from '@storybook/react'
 
 import { getDocumentNode } from '@sourcegraph/http-client'
+import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
 
 import { WebStory } from '../../../components/WebStory'
 import { ExternalServiceKind, type FetchOwnersAndHistoryResult, RepositoryType } from '../../../graphql-operations'
@@ -136,7 +137,7 @@ const barData: FetchOwnersAndHistoryResult = {
     },
 }
 
-const variables = { repoID: 'VXNlcjox', filePath: 'test.tsx' }
+const variables = { repoID: 'VXNlcjox', filePath: 'test.tsx', telemetryRecorder: noOpTelemetryRecorder }
 
 const mockLoaded: MockedResponse = {
     request: {

--- a/client/web/src/repo/blob/own/HistoryAndOwnBar.tsx
+++ b/client/web/src/repo/blob/own/HistoryAndOwnBar.tsx
@@ -8,6 +8,7 @@ import { logger, pluralize } from '@sourcegraph/common'
 import { useQuery } from '@sourcegraph/http-client'
 import { TeamAvatar } from '@sourcegraph/shared/src/components/TeamAvatar'
 import { UserAvatar } from '@sourcegraph/shared/src/components/UserAvatar'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import { Alert, Button, Icon, LoadingSpinner, Tooltip } from '@sourcegraph/wildcard'
 
 import type { FetchOwnersAndHistoryResult, FetchOwnersAndHistoryVariables } from '../../../graphql-operations'
@@ -18,12 +19,20 @@ import { FETCH_OWNERS_AND_HISTORY } from './grapqlQueries'
 
 import styles from './HistoryAndOwnBar.module.scss'
 
-export const HistoryAndOwnBar: React.FunctionComponent<{
+interface Props extends TelemetryV2Props {
     repoID: string
     revision?: string
     filePath: string
     enableOwnershipPanel: boolean
-}> = ({ repoID, revision, filePath, enableOwnershipPanel }) => {
+}
+
+export const HistoryAndOwnBar: React.FunctionComponent<Props> = ({
+    repoID,
+    revision,
+    filePath,
+    enableOwnershipPanel,
+    telemetryRecorder,
+}) => {
     const navigate = useNavigate()
 
     const openOwnershipPanel = useCallback(() => {
@@ -87,6 +96,7 @@ export const HistoryAndOwnBar: React.FunctionComponent<{
                         extraCompact={true}
                         hideExpandCommitMessageBody={true}
                         className={styles.history}
+                        telemetryRecorder={telemetryRecorder}
                     />
                 </div>
             )}

--- a/client/web/src/repo/blob/own/TreeOwnershipPanel.tsx
+++ b/client/web/src/repo/blob/own/TreeOwnershipPanel.tsx
@@ -5,6 +5,7 @@ import classNames from 'classnames'
 
 import { logger } from '@sourcegraph/common'
 import { useQuery } from '@sourcegraph/http-client'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { ErrorAlert, LoadingSpinner } from '@sourcegraph/wildcard'
 
@@ -17,7 +18,7 @@ import { OwnerList } from './OwnerList'
 
 import styles from './FileOwnershipPanel.module.scss'
 
-export interface OwnershipPanelProps {
+export interface OwnershipPanelProps extends TelemetryV2Props {
     repoID: string
     revision?: string
     filePath: string
@@ -30,10 +31,12 @@ export const TreeOwnershipPanel: React.FunctionComponent<OwnershipPanelProps & T
     filePath,
     telemetryService,
     showAddOwnerButton,
+    telemetryRecorder,
 }) => {
     useEffect(() => {
         telemetryService.log('OwnershipPanelOpened')
-    }, [telemetryService])
+        telemetryRecorder.recordEvent('repo.blob.ownershipPanel', 'open')
+    }, [telemetryService, telemetryRecorder])
 
     const { data, loading, error, refetch } = useQuery<FetchTreeOwnershipResult, FetchTreeOwnershipVariables>(
         FETCH_TREE_OWNERS,

--- a/client/web/src/repo/blob/panel/BlobPanel.tsx
+++ b/client/web/src/repo/blob/panel/BlobPanel.tsx
@@ -117,6 +117,7 @@ function useBlobPanelViews({
                                       revision={revision}
                                       filePath={filePath}
                                       defaultPageSize={defaultPageSize}
+                                      telemetryRecorder={telemetryRecorder}
                                   />
                               </PanelContent>
                           ),

--- a/client/web/src/repo/branches/RepositoryBranchesAllPage.tsx
+++ b/client/web/src/repo/branches/RepositoryBranchesAllPage.tsx
@@ -15,11 +15,12 @@ interface Props extends RepositoryBranchesAreaPageProps {}
 
 /** A page that shows all of a repository's branches. */
 export const RepositoryBranchesAllPage: FC<Props> = props => {
-    const { repo } = props
+    const { repo, telemetryRecorder } = props
 
     useEffect(() => {
         EVENT_LOGGER.logViewEvent('RepositoryBranchesAll')
-    }, [])
+        telemetryRecorder.recordEvent('repo.branches.all', 'view')
+    }, [telemetryRecorder])
 
     const queryBranches = useCallback(
         (args: FilteredConnectionQueryArguments): Observable<GitRefConnectionFields> =>

--- a/client/web/src/repo/branches/RepositoryBranchesArea.tsx
+++ b/client/web/src/repo/branches/RepositoryBranchesArea.tsx
@@ -2,6 +2,8 @@ import type { FC } from 'react'
 
 import { Routes, Route } from 'react-router-dom'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
+
 import type { BreadcrumbSetters } from '../../components/Breadcrumbs'
 import { NotFoundPage } from '../../components/HeroPage'
 import type { RepositoryFields } from '../../graphql-operations'
@@ -10,14 +12,14 @@ import { RepositoryBranchesAllPage } from './RepositoryBranchesAllPage'
 import { RepositoryBranchesNavbar } from './RepositoryBranchesNavbar'
 import { RepositoryBranchesOverviewPage } from './RepositoryBranchesOverviewPage'
 
-interface Props extends BreadcrumbSetters {
+interface Props extends BreadcrumbSetters, TelemetryV2Props {
     repo: RepositoryFields
 }
 
 /**
  * Properties passed to all page components in the repository branches area.
  */
-export interface RepositoryBranchesAreaPageProps {
+export interface RepositoryBranchesAreaPageProps extends TelemetryV2Props {
     /**
      * The active repository.
      */
@@ -30,7 +32,7 @@ const BREADCRUMB = { key: 'branches', element: 'Branches' }
  * Renders pages related to repository branches.
  */
 export const RepositoryBranchesArea: FC<Props> = props => {
-    const { useBreadcrumb, repo } = props
+    const { useBreadcrumb, repo, telemetryRecorder } = props
 
     useBreadcrumb(BREADCRUMB)
 
@@ -38,8 +40,14 @@ export const RepositoryBranchesArea: FC<Props> = props => {
         <div className="repository-branches-area container px-3">
             <RepositoryBranchesNavbar className="my-3" repo={repo.name} />
             <Routes>
-                <Route path="all" element={<RepositoryBranchesAllPage repo={repo} />} />
-                <Route path="" element={<RepositoryBranchesOverviewPage repo={repo} />} />
+                <Route
+                    path="all"
+                    element={<RepositoryBranchesAllPage repo={repo} telemetryRecorder={telemetryRecorder} />}
+                />
+                <Route
+                    path=""
+                    element={<RepositoryBranchesOverviewPage repo={repo} telemetryRecorder={telemetryRecorder} />}
+                />
                 <Route path="*" element={<NotFoundPage pageType="repository branches" />} />
             </Routes>
         </div>

--- a/client/web/src/repo/branches/RepositoryBranchesOverviewPage.tsx
+++ b/client/web/src/repo/branches/RepositoryBranchesOverviewPage.tsx
@@ -2,6 +2,7 @@ import React, { useMemo } from 'react'
 
 import { mdiChevronRight } from '@mdi/js'
 
+import type { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import { EVENT_LOGGER } from '@sourcegraph/shared/src/telemetry/web/eventLogger'
 import { Link, LoadingSpinner, CardHeader, Card, Icon, ErrorAlert } from '@sourcegraph/wildcard'
 
@@ -14,13 +15,14 @@ import type { RepositoryBranchesAreaPageProps } from './RepositoryBranchesArea'
 
 import styles from './RepositoryBranchesOverviewPage.module.scss'
 
-interface Props extends RepositoryBranchesAreaPageProps {}
+interface Props extends RepositoryBranchesAreaPageProps, TelemetryV2Props {}
 
 /** A page with an overview of the repository's branches. */
-export const RepositoryBranchesOverviewPage: React.FunctionComponent<Props> = ({ repo }) => {
+export const RepositoryBranchesOverviewPage: React.FunctionComponent<Props> = ({ repo, telemetryRecorder }) => {
     useMemo(() => {
         EVENT_LOGGER.logViewEvent('RepositoryBranchesOverview')
-    }, [])
+        telemetryRecorder.recordEvent('repo.branches', 'view')
+    }, [telemetryRecorder])
 
     const { loading, error, activeBranches, defaultBranch, hasMoreActiveBranches } = useBranches(repo.id, 10)
 

--- a/client/web/src/repo/commit/RepositoryCommitPage.tsx
+++ b/client/web/src/repo/commit/RepositoryCommitPage.tsx
@@ -128,7 +128,8 @@ const RepositoryRevisionNodes: React.FunctionComponent<RepositoryRevisionNodesPr
 
     useEffect(() => {
         props.telemetryService.logViewEvent('RepositoryCommit')
-    }, [props.telemetryService])
+        props.platformContext.telemetryRecorder.recordEvent('repo.commit', 'view')
+    }, [props.telemetryService, props.platformContext.telemetryRecorder])
 
     useEffect(() => {
         if (commit) {
@@ -180,6 +181,7 @@ const RepositoryRevisionNodes: React.FunctionComponent<RepositoryRevisionNodesPr
                                     diffMode={diffMode}
                                     onHandleDiffMode={setDiffMode}
                                     className={styles.gitCommitNode}
+                                    telemetryRecorder={props.platformContext.telemetryRecorder}
                                 />
                             </div>
                         </div>

--- a/client/web/src/repo/commits/GitCommitNode.story.tsx
+++ b/client/web/src/repo/commits/GitCommitNode.story.tsx
@@ -1,6 +1,7 @@
 import type { Decorator, Meta, StoryFn } from '@storybook/react'
 import { subDays } from 'date-fns'
 
+import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
 import { Card } from '@sourcegraph/wildcard'
 
 import { WebStory } from '../../components/WebStory'
@@ -86,6 +87,7 @@ export const FullCustomizable: StoryFn = args => (
                     showSHAAndParentsRow={args.showSHAAndParentsRow}
                     hideExpandCommitMessageBody={args.hideExpandCommitMessageBody}
                     preferAbsoluteTimestamps={args.preferAbsoluteTimestamps}
+                    telemetryRecorder={noOpTelemetryRecorder}
                 />
             </Card>
         )}
@@ -128,6 +130,7 @@ export const Compact: StoryFn = () => (
                     expandCommitMessageBody={false}
                     showSHAAndParentsRow={false}
                     hideExpandCommitMessageBody={false}
+                    telemetryRecorder={noOpTelemetryRecorder}
                 />
             </Card>
         )}
@@ -144,6 +147,7 @@ export const CommitMessageExpand: StoryFn = () => (
                     expandCommitMessageBody={true}
                     showSHAAndParentsRow={false}
                     hideExpandCommitMessageBody={false}
+                    telemetryRecorder={noOpTelemetryRecorder}
                 />
             </Card>
         )}
@@ -162,6 +166,7 @@ export const SHAAndParentShown: StoryFn = () => (
                     expandCommitMessageBody={false}
                     showSHAAndParentsRow={true}
                     hideExpandCommitMessageBody={false}
+                    telemetryRecorder={noOpTelemetryRecorder}
                 />
             </Card>
         )}
@@ -180,6 +185,7 @@ export const ExpandCommitMessageButtonHidden: StoryFn = () => (
                     expandCommitMessageBody={false}
                     showSHAAndParentsRow={false}
                     hideExpandCommitMessageBody={true}
+                    telemetryRecorder={noOpTelemetryRecorder}
                 />
             </Card>
         )}
@@ -259,6 +265,7 @@ export const PerforceChangelist: StoryFn = () => (
                     expandCommitMessageBody={false}
                     showSHAAndParentsRow={false}
                     hideExpandCommitMessageBody={true}
+                    telemetryRecorder={noOpTelemetryRecorder}
                 />
             </Card>
         )}

--- a/client/web/src/repo/commits/GitCommitNodeTableRow.tsx
+++ b/client/web/src/repo/commits/GitCommitNodeTableRow.tsx
@@ -26,13 +26,21 @@ export const GitCommitNodeTableRow: React.FC<
         | 'onHandleDiffMode'
         | 'diffMode'
     >
-> = ({ node, className, expandCommitMessageBody, hideExpandCommitMessageBody, messageSubjectClassName }) => {
+> = ({
+    node,
+    className,
+    expandCommitMessageBody,
+    hideExpandCommitMessageBody,
+    messageSubjectClassName,
+    telemetryRecorder,
+}) => {
     const [showCommitMessageBody, setShowCommitMessageBody] = useState<boolean>(false)
 
     const toggleShowCommitMessageBody = useCallback((): void => {
         EVENT_LOGGER.log('CommitBodyToggled')
+        telemetryRecorder.recordEvent('repo.commit.body', 'toggle')
         setShowCommitMessageBody(!showCommitMessageBody)
-    }, [showCommitMessageBody])
+    }, [showCommitMessageBody, telemetryRecorder])
 
     const canonicalURL =
         isPerforceChangelistMappingEnabled() && node.perforceChangelist?.canonicalURL

--- a/client/web/src/repo/commits/RepositoryCommitsPage.tsx
+++ b/client/web/src/repo/commits/RepositoryCommitsPage.tsx
@@ -6,7 +6,7 @@ import { useLocation } from 'react-router-dom'
 import { basename, pluralize } from '@sourcegraph/common'
 import { dataOrThrowErrors, gql } from '@sourcegraph/http-client'
 import { displayRepoName } from '@sourcegraph/shared/src/components/RepoLink'
-import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { EVENT_LOGGER } from '@sourcegraph/shared/src/telemetry/web/eventLogger'
 import type { RevisionSpec } from '@sourcegraph/shared/src/util/url'
@@ -125,7 +125,7 @@ export const REPOSITORY_GIT_COMMITS_QUERY = gql`
     ${gitCommitFragment}
 `
 
-export interface RepositoryCommitsPageProps extends RevisionSpec, BreadcrumbSetters, TelemetryProps {
+export interface RepositoryCommitsPageProps extends RevisionSpec, BreadcrumbSetters, TelemetryProps, TelemetryV2Props {
     repo: RepositoryFields
 }
 
@@ -184,7 +184,8 @@ export const RepositoryCommitsPage: FC<RepositoryCommitsPageProps> = props => {
 
     useEffect(() => {
         EVENT_LOGGER.logPageView('RepositoryCommits')
-    }, [])
+        props.telemetryRecorder.recordEvent('repo.commits', 'view')
+    }, [props.telemetryRecorder])
 
     useBreadcrumb(
         useMemo(() => {
@@ -202,12 +203,11 @@ export const RepositoryCommitsPage: FC<RepositoryCommitsPageProps> = props => {
                         filePath={filePath}
                         isDir={true}
                         telemetryService={props.telemetryService}
-                        // TODO (dadlerj): update to use a real telemetry recorder
-                        telemetryRecorder={noOpTelemetryRecorder}
+                        telemetryRecorder={props.telemetryRecorder}
                     />
                 ),
             }
-        }, [filePath, repo, props.revision, props.telemetryService])
+        }, [filePath, repo, props.revision, props.telemetryService, props.telemetryRecorder])
     )
     // We need to resolve the Commits breadcrumb at the same time as the
     // filePath, so that the order is correct (otherwise Commits will show
@@ -253,7 +253,13 @@ export const RepositoryCommitsPage: FC<RepositoryCommitsPageProps> = props => {
                     {error && <ErrorAlert error={error} className="w-100 mb-0" />}
                     <ConnectionList className="list-group list-group-flush w-100">
                         {connection?.nodes.map(node => (
-                            <GitCommitNode key={node.id} className="list-group-item" wrapperElement="li" node={node} />
+                            <GitCommitNode
+                                key={node.id}
+                                className="list-group-item"
+                                wrapperElement="li"
+                                node={node}
+                                telemetryRecorder={props.telemetryRecorder}
+                            />
                         ))}
                     </ConnectionList>
                     {loading && <ConnectionLoading />}

--- a/client/web/src/repo/compare/RepositoryCompareArea.tsx
+++ b/client/web/src/repo/compare/RepositoryCompareArea.tsx
@@ -3,6 +3,7 @@ import type { FC } from 'react'
 import classNames from 'classnames'
 import { useLocation, useNavigate, useParams } from 'react-router-dom'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import { Alert, LoadingSpinner } from '@sourcegraph/wildcard'
 
 import type { BreadcrumbSetters } from '../../components/Breadcrumbs'
@@ -13,14 +14,14 @@ import { RepositoryCompareOverviewPage } from './RepositoryCompareOverviewPage'
 
 import styles from './RepositoryCompareArea.module.scss'
 
-interface RepositoryCompareAreaProps extends BreadcrumbSetters {
+interface RepositoryCompareAreaProps extends BreadcrumbSetters, TelemetryV2Props {
     repo?: RepositoryFields
 }
 
 /**
  * Properties passed to all page components in the repository compare area.
  */
-export interface RepositoryCompareAreaPageProps {
+export interface RepositoryCompareAreaPageProps extends TelemetryV2Props {
     /** The repository being compared. */
     repo: RepositoryFields
 
@@ -37,7 +38,7 @@ const BREADCRUMB = { key: 'compare', element: <>Compare</> }
  * Renders pages related to a repository comparison.
  */
 export const RepositoryCompareArea: FC<RepositoryCompareAreaProps> = props => {
-    const { repo, useBreadcrumb } = props
+    const { repo, useBreadcrumb, telemetryRecorder } = props
 
     const { '*': splat } = useParams<{ '*': string }>()
     const location = useLocation()
@@ -62,6 +63,7 @@ export const RepositoryCompareArea: FC<RepositoryCompareAreaProps> = props => {
         repo,
         base: { repoID: repo.id, repoName: repo.name, revision: spec?.base },
         head: { repoID: repo.id, repoName: repo.name, revision: spec?.head },
+        telemetryRecorder,
     }
 
     return (

--- a/client/web/src/repo/compare/RepositoryCompareCommitsPage.tsx
+++ b/client/web/src/repo/compare/RepositoryCompareCommitsPage.tsx
@@ -105,7 +105,7 @@ export class RepositoryCompareCommitsPage extends React.PureComponent<Props> {
                     <CardHeader>Commits</CardHeader>
                     <FilteredConnection<
                         GitCommitFields,
-                        Pick<GitCommitNodeProps, 'className' | 'compact' | 'wrapperElement'>
+                        Pick<GitCommitNodeProps, 'className' | 'compact' | 'wrapperElement' | 'telemetryRecorder'>
                     >
                         listClassName="list-group list-group-flush"
                         noun="commit"
@@ -117,6 +117,7 @@ export class RepositoryCompareCommitsPage extends React.PureComponent<Props> {
                             className: 'list-group-item',
                             compact: true,
                             wrapperElement: 'li',
+                            telemetryRecorder: this.props.telemetryRecorder,
                         }}
                         defaultFirst={50}
                         hideSearch={true}

--- a/client/web/src/repo/compare/RepositoryCompareHeader.tsx
+++ b/client/web/src/repo/compare/RepositoryCompareHeader.tsx
@@ -16,7 +16,7 @@ interface RepositoryCompareHeaderProps extends RepositoryCompareAreaPageProps {
 
 export const RepositoryCompareHeader: React.FunctionComponent<
     React.PropsWithChildren<RepositoryCompareHeaderProps>
-> = ({ base, head, className, repo }) => (
+> = ({ base, head, className, repo, telemetryRecorder }) => (
     <div className={classNames(styles.repositoryCompareHeader, className)}>
         <PageHeader
             description={
@@ -38,9 +38,21 @@ export const RepositoryCompareHeader: React.FunctionComponent<
             </PageHeader.Heading>
         </PageHeader>
         <div className="d-flex align-items-center">
-            <RepositoryComparePopover id="base-popover" type="base" comparison={{ base, head }} repo={repo} />
+            <RepositoryComparePopover
+                id="base-popover"
+                type="base"
+                comparison={{ base, head }}
+                repo={repo}
+                telemetryRecorder={telemetryRecorder}
+            />
             <Icon className="mx-2" aria-hidden={true} svgPath={mdiDotsHorizontal} />
-            <RepositoryComparePopover id="head-popover" type="head" comparison={{ base, head }} repo={repo} />
+            <RepositoryComparePopover
+                id="head-popover"
+                type="head"
+                comparison={{ base, head }}
+                repo={repo}
+                telemetryRecorder={telemetryRecorder}
+            />
         </div>
     </div>
 )

--- a/client/web/src/repo/compare/RepositoryComparePopover.tsx
+++ b/client/web/src/repo/compare/RepositoryComparePopover.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react'
 
 import { escapeRevspecForURL } from '@sourcegraph/common'
+import type { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import { EVENT_LOGGER } from '@sourcegraph/shared/src/telemetry/web/eventLogger'
 import { Button, Popover, PopoverContent, PopoverTrigger, Position } from '@sourcegraph/wildcard'
 
@@ -18,7 +19,7 @@ interface RevisionComparison {
     head: RepositoryCompareHeaderProps['head']
 }
 
-interface RepositoryComparePopoverProps {
+interface RepositoryComparePopoverProps extends TelemetryV2Props {
     /**
      * Uniquely identify this specific popover. Used to link the trigger button with the popover to display
      */
@@ -36,12 +37,13 @@ interface RepositoryComparePopoverProps {
 
 export const RepositoryComparePopover: React.FunctionComponent<
     React.PropsWithChildren<RepositoryComparePopoverProps>
-> = ({ id, comparison, repo, type }) => {
+> = ({ id, comparison, repo, type, telemetryRecorder }) => {
     const [popoverOpen, setPopoverOpen] = useState(false)
     const togglePopover = (): void => setPopoverOpen(previous => !previous)
 
     const handleSelect = (): void => {
         EVENT_LOGGER.log('RepositoryComparisonSubmitted')
+        telemetryRecorder.recordEvent('repo.compare', 'submit')
         togglePopover()
     }
 
@@ -89,6 +91,7 @@ export const RepositoryComparePopover: React.FunctionComponent<
                     getPathFromRevision={getPathFromRevision}
                     showSpeculativeResults={true}
                     onSelect={handleSelect}
+                    telemetryRecorder={telemetryRecorder}
                 />
             </PopoverContent>
         </Popover>

--- a/client/web/src/repo/releases/RepositoryReleasesArea.tsx
+++ b/client/web/src/repo/releases/RepositoryReleasesArea.tsx
@@ -7,7 +7,7 @@ import type { RepoContainerContext } from '../RepoContainer'
 
 import { RepositoryReleasesTagsPage } from './RepositoryReleasesTagsPage'
 
-interface Props extends Pick<RepoContainerContext, 'repo'>, BreadcrumbSetters {
+interface Props extends Pick<RepoContainerContext, 'repo' | 'platformContext'>, BreadcrumbSetters {
     repo: RepositoryFields
 }
 
@@ -41,7 +41,11 @@ export const RepositoryReleasesArea: FC<Props> = props => {
         <div className="repository-graph-area">
             <div className="container">
                 <div className="container-inner">
-                    <RepositoryReleasesTagsPage repo={repo} isPackage={isPackage} />
+                    <RepositoryReleasesTagsPage
+                        repo={repo}
+                        isPackage={isPackage}
+                        telemetryRecorder={props.platformContext.telemetryRecorder}
+                    />
                 </div>
             </div>
         </div>

--- a/client/web/src/repo/releases/RepositoryReleasesTagsPage.test.tsx
+++ b/client/web/src/repo/releases/RepositoryReleasesTagsPage.test.tsx
@@ -3,6 +3,8 @@ import { MemoryRouter } from 'react-router-dom'
 import { of } from 'rxjs'
 import { describe, expect, test } from 'vitest'
 
+import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
+
 import type { RepositoryFields } from '../../graphql-operations'
 
 import { RepositoryReleasesTagsPage } from './RepositoryReleasesTagsPage'
@@ -23,6 +25,7 @@ describe('RepositoryReleasesTagsPage', () => {
                                 pageInfo: { __typename: 'PageInfo', endCursor: '', hasNextPage: false },
                             })
                         }
+                        telemetryRecorder={noOpTelemetryRecorder}
                     />
                 </MemoryRouter>
             ).asFragment()
@@ -43,6 +46,7 @@ describe('RepositoryReleasesTagsPage', () => {
                                 pageInfo: { __typename: 'PageInfo', endCursor: '', hasNextPage: false },
                             })
                         }
+                        telemetryRecorder={noOpTelemetryRecorder}
                     />
                 </MemoryRouter>
             ).asFragment()

--- a/client/web/src/repo/releases/RepositoryReleasesTagsPage.tsx
+++ b/client/web/src/repo/releases/RepositoryReleasesTagsPage.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect } from 'react'
 
 import { type Observable, of } from 'rxjs'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import { EVENT_LOGGER } from '@sourcegraph/shared/src/telemetry/web/eventLogger'
 import { LoadingSpinner } from '@sourcegraph/wildcard'
 
@@ -20,7 +21,7 @@ import {
     queryGitReferences as queryGitReferencesFromBackend,
 } from '../GitReference'
 
-interface Props {
+interface Props extends TelemetryV2Props {
     repo: RepositoryFields | undefined
     isPackage?: boolean
     queryGitReferences?: (args: {
@@ -37,10 +38,12 @@ export const RepositoryReleasesTagsPage: React.FunctionComponent<React.PropsWith
     repo,
     isPackage,
     queryGitReferences: queryGitReferences = queryGitReferencesFromBackend,
+    telemetryRecorder,
 }) => {
     useEffect(() => {
         EVENT_LOGGER.logViewEvent('RepositoryReleasesTags')
-    }, [])
+        telemetryRecorder.recordEvent('repo.releasesTags', 'view')
+    }, [telemetryRecorder])
 
     const queryTags = useCallback(
         (args: FilteredConnectionQueryArguments): Observable<GitRefConnectionFields> => {

--- a/client/web/src/repo/repoContainerRoutes.tsx
+++ b/client/web/src/repo/repoContainerRoutes.tsx
@@ -42,7 +42,9 @@ export const repoContainerRoutes: readonly RepoContainerRoute[] = [
     },
     {
         path: '/-/branches/*',
-        render: context => <RepositoryBranchesArea {...context} />,
+        render: context => (
+            <RepositoryBranchesArea {...context} telemetryRecorder={context.platformContext.telemetryRecorder} />
+        ),
     },
     {
         path: '/-/tags',
@@ -56,7 +58,7 @@ export const repoContainerRoutes: readonly RepoContainerRoute[] = [
         path: compareSpecPath,
         render: context => (
             <RepoRevisionWrapper>
-                <RepositoryCompareArea {...context} />
+                <RepositoryCompareArea {...context} telemetryRecorder={context.platformContext.telemetryRecorder} />
             </RepoRevisionWrapper>
         ),
     },

--- a/client/web/src/repo/repoContainerRoutes.tsx
+++ b/client/web/src/repo/repoContainerRoutes.tsx
@@ -62,11 +62,15 @@ export const repoContainerRoutes: readonly RepoContainerRoute[] = [
     },
     {
         path: '/-/stats/contributors',
-        render: context => <RepositoryStatsArea {...context} />,
+        render: context => (
+            <RepositoryStatsArea {...context} telemetryRecorder={context.platformContext.telemetryRecorder} />
+        ),
     },
     {
         path: '/-/metadata',
         condition: ({ authenticatedUser }) => canWriteRepoMetadata(authenticatedUser),
-        render: context => <RepositoryMetadataPage {...context} />,
+        render: context => (
+            <RepositoryMetadataPage {...context} telemetryRecorder={context.platformContext.telemetryRecorder} />
+        ),
     },
 ]

--- a/client/web/src/repo/repoRevisionContainerRoutes.tsx
+++ b/client/web/src/repo/repoRevisionContainerRoutes.tsx
@@ -28,12 +28,30 @@ export function createRepoRevisionContainerRoutes(
         {
             path: '/-/commits/*',
             render: ({ revision, repo, ...context }) =>
-                repo ? <RepositoryCommitsPage {...context} repo={repo} revision={revision} /> : <LoadingSpinner />,
+                repo ? (
+                    <RepositoryCommitsPage
+                        {...context}
+                        repo={repo}
+                        revision={revision}
+                        telemetryRecorder={context.platformContext.telemetryRecorder}
+                    />
+                ) : (
+                    <LoadingSpinner />
+                ),
         },
         {
             path: '/-/changelists/*',
             render: ({ revision, repo, ...context }) =>
-                repo ? <RepositoryCommitsPage {...context} repo={repo} revision={revision} /> : <LoadingSpinner />,
+                repo ? (
+                    <RepositoryCommitsPage
+                        {...context}
+                        repo={repo}
+                        revision={revision}
+                        telemetryRecorder={context.platformContext.telemetryRecorder}
+                    />
+                ) : (
+                    <LoadingSpinner />
+                ),
         },
     ]
 }

--- a/client/web/src/repo/settings/RepoSettingsIndexPage.tsx
+++ b/client/web/src/repo/settings/RepoSettingsIndexPage.tsx
@@ -9,6 +9,7 @@ import { map, switchMap, tap } from 'rxjs/operators'
 import { Timestamp } from '@sourcegraph/branded/src/components/Timestamp'
 import { createAggregateError, pluralize } from '@sourcegraph/common'
 import { gql, useMutation } from '@sourcegraph/http-client'
+import type { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import { EVENT_LOGGER } from '@sourcegraph/shared/src/telemetry/web/eventLogger'
 import {
     Button,
@@ -238,7 +239,7 @@ const TextSearchIndexedReference: React.FunctionComponent<
     )
 }
 
-interface Props {
+interface Props extends TelemetryV2Props {
     repo: SettingsAreaRepositoryFields
 }
 
@@ -259,6 +260,7 @@ export class RepoSettingsIndexPage extends React.PureComponent<Props, State> {
 
     public componentDidMount(): void {
         EVENT_LOGGER.logViewEvent('RepoSettingsIndex')
+        this.props.telemetryRecorder.recordEvent('repo.settings.index', 'view')
 
         this.subscriptions.add(
             this.updates

--- a/client/web/src/repo/settings/RepoSettingsMirrorPage.story.tsx
+++ b/client/web/src/repo/settings/RepoSettingsMirrorPage.story.tsx
@@ -2,6 +2,7 @@ import type { MockedResponse } from '@apollo/client/testing'
 import type { Decorator, StoryFn, Meta } from '@storybook/react'
 
 import { getDocumentNode } from '@sourcegraph/http-client'
+import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
 import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
 
 import { WebStory } from '../../components/WebStory'
@@ -106,7 +107,7 @@ export const CloneInProgress: StoryFn = args => (
     <WebStory>
         {() => (
             <MockedTestProvider mocks={[FETCH_SETTINGS_AREA_REPOSITORY_MOCK, CHECK_MIRROR_REPOSITORY_CONNECTION_MOCK]}>
-                <RepoSettingsMirrorPage disablePolling={true} repo={repo} />
+                <RepoSettingsMirrorPage disablePolling={true} repo={repo} telemetryRecorder={noOpTelemetryRecorder} />
             </MockedTestProvider>
         )}
     </WebStory>

--- a/client/web/src/repo/settings/RepoSettingsMirrorPage.tsx
+++ b/client/web/src/repo/settings/RepoSettingsMirrorPage.tsx
@@ -325,7 +325,7 @@ export const RepoSettingsMirrorPage: FC<RepoSettingsMirrorPageProps> = ({
         <>
             <PageTitle title="Mirror settings" />
             <PageHeader path={[{ text: 'Mirroring and cloning' }]} headingElement="h2" className="mb-3" />
-            <RepoSettingsOptions repo={repo} telemetryRecorder={telemetryRecorder} />
+            <RepoSettingsOptions repo={repo} />
             <Container className="repo-settings-mirror-page">
                 {error && <ErrorAlert error={error} />}
 

--- a/client/web/src/repo/settings/RepoSettingsMirrorPage.tsx
+++ b/client/web/src/repo/settings/RepoSettingsMirrorPage.tsx
@@ -5,6 +5,7 @@ import classNames from 'classnames'
 
 import { Timestamp } from '@sourcegraph/branded/src/components/Timestamp'
 import { useMutation, useQuery } from '@sourcegraph/http-client'
+import type { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import { EVENT_LOGGER } from '@sourcegraph/shared/src/telemetry/web/eventLogger'
 import {
     Container,
@@ -282,7 +283,7 @@ const CorruptionLogsContainer: FC<CorruptionLogProps> = props => {
     )
 }
 
-interface RepoSettingsMirrorPageProps {
+interface RepoSettingsMirrorPageProps extends TelemetryV2Props {
     repo: SettingsAreaRepositoryFields
     disablePolling?: boolean
 }
@@ -293,8 +294,13 @@ interface RepoSettingsMirrorPageProps {
 export const RepoSettingsMirrorPage: FC<RepoSettingsMirrorPageProps> = ({
     repo: initialRepo,
     disablePolling = false,
+    telemetryRecorder,
 }) => {
-    EVENT_LOGGER.logPageView('RepoSettingsMirror')
+    useEffect(() => {
+        EVENT_LOGGER.logPageView('RepoSettingsMirror')
+        telemetryRecorder.recordEvent('repo.settings.mirror', 'view')
+    }, [telemetryRecorder])
+
     const [reachable, setReachable] = useState<boolean>()
     const [recloneRepository] = useMutation<RecloneRepositoryResult, RecloneRepositoryVariables>(
         RECLONE_REPOSITORY_MUTATION,
@@ -319,7 +325,7 @@ export const RepoSettingsMirrorPage: FC<RepoSettingsMirrorPageProps> = ({
         <>
             <PageTitle title="Mirror settings" />
             <PageHeader path={[{ text: 'Mirroring and cloning' }]} headingElement="h2" className="mb-3" />
-            <RepoSettingsOptions repo={repo} />
+            <RepoSettingsOptions repo={repo} telemetryRecorder={telemetryRecorder} />
             <Container className="repo-settings-mirror-page">
                 {error && <ErrorAlert error={error} />}
 

--- a/client/web/src/repo/settings/RepoSettingsOptions.tsx
+++ b/client/web/src/repo/settings/RepoSettingsOptions.tsx
@@ -3,7 +3,6 @@ import { type FC, useCallback, useEffect, useState } from 'react'
 import { noop } from 'lodash'
 
 import { useMutation, useQuery } from '@sourcegraph/http-client'
-import type { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import { EVENT_LOGGER } from '@sourcegraph/shared/src/telemetry/web/eventLogger'
 import { Button, Container, ErrorAlert, H3, LoadingSpinner, renderError, Text } from '@sourcegraph/wildcard'
 

--- a/client/web/src/repo/settings/RepoSettingsOptions.tsx
+++ b/client/web/src/repo/settings/RepoSettingsOptions.tsx
@@ -25,15 +25,15 @@ import { RedirectionAlert } from './components/RedirectionAlert'
 
 import styles from './RepoSettingsOptions.module.scss'
 
-interface Props extends TelemetryV2Props {
+interface Props {
     repo: SettingsAreaRepositoryFields
 }
 
-export const RepoSettingsOptions: FC<Props> = ({ repo, telemetryRecorder }) => {
+export const RepoSettingsOptions: FC<Props> = ({ repo }) => {
     useEffect(() => {
         EVENT_LOGGER.logViewEvent('RepoSettings')
-        telemetryRecorder.recordEvent('repo.settings', 'view')
-    }, [telemetryRecorder])
+        // No need to use v2 telemetry here. This event is duplicative with 'repo.settings.mirror', 'view'
+    }, [])
 
     const { data, error, loading } = useQuery<SettingsAreaRepositoryResult, SettingsAreaRepositoryVariables>(
         FETCH_SETTINGS_AREA_REPOSITORY_GQL,

--- a/client/web/src/repo/settings/RepoSettingsOptions.tsx
+++ b/client/web/src/repo/settings/RepoSettingsOptions.tsx
@@ -3,6 +3,7 @@ import { type FC, useCallback, useEffect, useState } from 'react'
 import { noop } from 'lodash'
 
 import { useMutation, useQuery } from '@sourcegraph/http-client'
+import type { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import { EVENT_LOGGER } from '@sourcegraph/shared/src/telemetry/web/eventLogger'
 import { Button, Container, ErrorAlert, H3, LoadingSpinner, renderError, Text } from '@sourcegraph/wildcard'
 
@@ -24,14 +25,15 @@ import { RedirectionAlert } from './components/RedirectionAlert'
 
 import styles from './RepoSettingsOptions.module.scss'
 
-interface Props {
+interface Props extends TelemetryV2Props {
     repo: SettingsAreaRepositoryFields
 }
 
-export const RepoSettingsOptions: FC<Props> = ({ repo }) => {
+export const RepoSettingsOptions: FC<Props> = ({ repo, telemetryRecorder }) => {
     useEffect(() => {
         EVENT_LOGGER.logViewEvent('RepoSettings')
-    })
+        telemetryRecorder.recordEvent('repo.settings', 'view')
+    }, [telemetryRecorder])
 
     const { data, error, loading } = useQuery<SettingsAreaRepositoryResult, SettingsAreaRepositoryVariables>(
         FETCH_SETTINGS_AREA_REPOSITORY_GQL,

--- a/client/web/src/repo/stats/RepositoryStatsArea.tsx
+++ b/client/web/src/repo/stats/RepositoryStatsArea.tsx
@@ -2,7 +2,7 @@ import { type FC, useMemo } from 'react'
 
 import { useSearchParams } from 'react-router-dom'
 
-import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { LoadingSpinner } from '@sourcegraph/wildcard'
 
@@ -12,7 +12,7 @@ import { FilePathBreadcrumbs } from '../FilePathBreadcrumbs'
 
 import { RepositoryStatsContributorsPage } from './RepositoryStatsContributorsPage'
 
-interface Props extends BreadcrumbSetters, TelemetryProps {
+interface Props extends BreadcrumbSetters, TelemetryProps, TelemetryV2Props {
     repo: RepositoryFields | undefined
 }
 
@@ -32,7 +32,7 @@ const BREADCRUMB = { key: 'contributors', element: 'Contributors' }
  * Renders pages related to repository stats.
  */
 export const RepositoryStatsArea: FC<Props> = props => {
-    const { useBreadcrumb, repo, telemetryService } = props
+    const { useBreadcrumb, repo, telemetryService, telemetryRecorder } = props
     const [searchParams] = useSearchParams()
     const filePath = searchParams.get('path') ?? ''
 
@@ -52,18 +52,21 @@ export const RepositoryStatsArea: FC<Props> = props => {
                         filePath={filePath}
                         isDir={true}
                         telemetryService={telemetryService}
-                        // TODO (dadlerj): update to use a real telemetry recorder
-                        telemetryRecorder={noOpTelemetryRecorder}
+                        telemetryRecorder={telemetryRecorder}
                     />
                 ),
             }
-        }, [filePath, repo, telemetryService])
+        }, [filePath, repo, telemetryService, telemetryRecorder])
     )
     setter.useBreadcrumb(BREADCRUMB)
 
     return (
         <div className="repository-stats-area container mt-3">
-            {repo ? <RepositoryStatsContributorsPage repo={repo} /> : <LoadingSpinner />}
+            {repo ? (
+                <RepositoryStatsContributorsPage repo={repo} telemetryRecorder={telemetryRecorder} />
+            ) : (
+                <LoadingSpinner />
+            )}
         </div>
     )
 }

--- a/client/web/src/repo/stats/RepositoryStatsContributorsPage.tsx
+++ b/client/web/src/repo/stats/RepositoryStatsContributorsPage.tsx
@@ -10,6 +10,7 @@ import { numberWithCommas, pluralize } from '@sourcegraph/common'
 import { gql, dataOrThrowErrors } from '@sourcegraph/http-client'
 import { UserAvatar } from '@sourcegraph/shared/src/components/UserAvatar'
 import { SearchPatternType } from '@sourcegraph/shared/src/graphql-operations'
+import type { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import { EVENT_LOGGER } from '@sourcegraph/shared/src/telemetry/web/eventLogger'
 import { buildSearchURLQuery } from '@sourcegraph/shared/src/util/url'
 import {
@@ -191,7 +192,7 @@ const BATCH_COUNT = 20
 
 const equalOrEmpty = (a: string | undefined, b: string | undefined): boolean => a === b || (!a && !b)
 
-interface Props extends RepositoryStatsAreaPageProps {}
+interface Props extends RepositoryStatsAreaPageProps, TelemetryV2Props {}
 
 const contributorsPageInputIds: Record<string, string> = {
     REVISION_RANGE: 'repository-stats-contributors-page__revision-range',
@@ -211,7 +212,7 @@ const getUrlQuery = (spec: Partial<QuerySpec>): string => {
 }
 
 /** A page that shows a repository's contributors. */
-export const RepositoryStatsContributorsPage: React.FunctionComponent<Props> = ({ repo }) => {
+export const RepositoryStatsContributorsPage: React.FunctionComponent<Props> = ({ repo, telemetryRecorder }) => {
     const location = useLocation()
     const navigate = useNavigate()
     const queryParameters = new URLSearchParams(location.search)
@@ -256,7 +257,8 @@ export const RepositoryStatsContributorsPage: React.FunctionComponent<Props> = (
     // Log page view when initially rendered
     useEffect(() => {
         EVENT_LOGGER.logPageView('RepositoryStatsContributors')
-    }, [])
+        telemetryRecorder.recordEvent('repo.stats.contributors', 'view')
+    }, [telemetryRecorder])
 
     // Update spec when search params change
     useEffect(() => {

--- a/client/web/src/repo/tree/TreePage.test.tsx
+++ b/client/web/src/repo/tree/TreePage.test.tsx
@@ -66,6 +66,7 @@ describe('TreePage', () => {
             telemetryRecorder: noOpTelemetryRecorder,
         },
         telemetryService: NOOP_TELEMETRY_SERVICE,
+        telemetryRecorder: noOpTelemetryRecorder,
         codeIntelligenceEnabled: false,
         batchChangesExecutionEnabled: false,
         batchChangesEnabled: false,


### PR DESCRIPTION
Context:

* https://github.com/sourcegraph/sourcegraph/pull/60127
* https://github.com/sourcegraph/sourcegraph/pull/60192
* https://github.com/sourcegraph/sourcegraph/pull/60219
* https://github.com/sourcegraph/sourcegraph/pull/60343
* https://github.com/sourcegraph/sourcegraph/pull/60377
* https://github.com/sourcegraph/sourcegraph/pull/60382
* https://github.com/sourcegraph/sourcegraph/pull/60764
* https://github.com/sourcegraph/sourcegraph/pull/60765
* https://github.com/sourcegraph/sourcegraph/pull/60767
* https://github.com/sourcegraph/sourcegraph/pull/60768
* https://github.com/sourcegraph/sourcegraph/pull/60788
* https://github.com/sourcegraph/sourcegraph/pull/60789
* https://github.com/sourcegraph/sourcegraph/pull/60803
* https://github.com/sourcegraph/sourcegraph/pull/60812
* https://github.com/sourcegraph/sourcegraph/pull/60850
* https://github.com/sourcegraph/sourcegraph/pull/60851
* https://github.com/sourcegraph/sourcegraph/pull/60939
* https://github.com/sourcegraph/sourcegraph/pull/60971
* https://github.com/sourcegraph/sourcegraph/pull/61205
* https://github.com/sourcegraph/sourcegraph/pull/61457
* https://github.com/sourcegraph/sourcegraph/pull/61503
* https://github.com/sourcegraph/sourcegraph/pull/61504
* https://github.com/sourcegraph/sourcegraph/pull/61506
* https://github.com/sourcegraph/sourcegraph/pull/61507

## Test plan

`sg start`
visit page
check if events appear in `event_logs` table locally