### PR TITLE
release: Add release test to check schema descriptions

### DIFF
--- a/release.yaml
+++ b/release.yaml
@@ -87,19 +87,17 @@ test:
 
         IMAGE="${REGISTRY}/migrator:{{tag}}"
 
-        echo "pulling migrator image ${IMAGE}"
-
         # Pull the image so that we can inspect it
+        echo "pulling migrator image ${IMAGE}"
         docker pull "${IMAGE}"
 
         echo "checking migrator image for {{version}} schema description files"
-
-        # now we check that the schem description files exist
+        # now we check that the schema description files exist
         # we need to trim the result from docker since it has '\r' hence the use of tr
         count=$(docker run -t --rm --entrypoint /bin/sh "${IMAGE}" -c "ls -al /schema-descriptions/{{version}}-*.json | wc -l" | tr -d '[:space:]')
 
         if [[ "$count" -ne 3 ]]; then
-          echo "migrator:{{tag}} does not contain the correct amount of schema description files for this release- expected 3 got ${count}"
+          echo "migrator:{{tag}} does not contain the correct amount of schema description files for this release - expected 3 got ${count}"
           exit 1
         fi
 

--- a/release.yaml
+++ b/release.yaml
@@ -72,6 +72,36 @@ test:
           echo "❌ Tag '{{version}}' already exists"
           exit 1
         fi
+    - name: "check:migrator-schemas"
+      cmd: |
+        set -eu
+
+        REGISTRY="${PROD_REGISTRY:-''}"
+
+        # the reason this is not in the requirements check of the release yaml is because those checks also
+        # apply when running the release tooling locally, and the testing steps are supposed to run in CI
+        if [ ${REGISTRY} == "" ]; then
+          echo "PROD_REGISTRY is not set - unable to check migrator image"
+          exit 1
+        fi
+
+        IMAGE="${REGISTRY}/migrator:{{tag}}"
+
+        echo "pulling migrator image ${IMAGE}"
+
+        # Pull the image so that we can inspect it
+        docker pull "${IMAGE}"
+
+        echo "checking migrator image for {{version}} schema description files"
+
+        # now we check that the schem description files exist
+        # we need to trim the result from docker since it has '\r' hence the use of tr
+        count=$(docker run -t --rm --entrypoint /bin/sh "${IMAGE}" -c "ls -al /schema-descriptions/{{version}}-*.json | wc -l" | tr -d '[:space:]')
+
+        if [[ "$count" -ne 3 ]]; then
+          echo "migrator:{{tag}} does not contain the correct amount of schema description files for this release- expected 3 got ${count}"
+          exit 1
+        fi
 
 promoteToPublic:
   create:

--- a/release.yaml
+++ b/release.yaml
@@ -80,7 +80,7 @@ test:
 
         # the reason this is not in the requirements check of the release yaml is because those checks also
         # apply when running the release tooling locally, and the testing steps are supposed to run in CI
-        if [ ${REGISTRY} == "" ]; then
+        if [ -z ${REGISTRY} ]; then
           echo "PROD_REGISTRY is not set - unable to check migrator image"
           exit 1
         fi
@@ -95,9 +95,17 @@ test:
         # now we check that the schema description files exist
         # we need to trim the result from docker since it has '\r' hence the use of tr
         count=$(docker run -t --rm --entrypoint /bin/sh "${IMAGE}" -c "ls -al /schema-descriptions/{{version}}-*.json | wc -l" | tr -d '[:space:]')
-
         if [[ "$count" -ne 3 ]]; then
           echo "migrator:{{tag}} does not contain the correct amount of schema description files for this release - expected 3 got ${count}"
+          exit 1
+        fi
+
+        echo "checking migrator image for older schema description files"
+        count=$(docker run -t --rm --entrypoint /bin/sh "${IMAGE}" -c "ls -al /schema-descriptions/*-internal_database_schema*json | wc -l" | tr -d '[:space:]')
+
+        # in our newer releases we have upwards of 300 schema descriptions, so we check that we have at least 300
+        if [[ "$count" -lt 300 ]]; then
+          echo "migrator:{{tag}} does not contain the correct amount of schema description files for this release - expected more than 300 got ${count}"
           exit 1
         fi
 


### PR DESCRIPTION
release test will pull the migrator image for this release and then check whether the folder /schema-descriptions contains the json files for the current release version.

Closes https://github.com/sourcegraph/sourcegraph/issues/61068

## Test plan
Test locally
```
sg release run test --inputs=server=v5.3.666 --version=v5.3.666
👉 [     setup] Finding release manifest in "."
   [     setup] No explicit branch name was provided, assuming current branch is the target: wb/release/schema-descriptions-test
   [     setup] Found manifest for "sourcegraph" (github.com/sourcegraph/sourcegraph)
   [      meta] Owners: @sourcegraph/release
   [      meta] Repository: github.com/sourcegraph/sourcegraph
👉 [      vars] Variables
   [      vars] version="v5.3.666"
   [      vars] tag="5.3.666"
   [      vars] config="{\"version\":\"v5.3.666\",\"inputs\":\"server=v5.3.666\",\"type\":\"patch\"}"
   [      vars] git.branch="wb/release/schema-descriptions-test"
   [      vars] inputs.server.version="v5.3.666"
   [      vars] inputs.server.tag="5.3.666"
👉 [      test] Running testing steps for v5.3.666
👉 [      step] Running step "placeholder"
   [placeholder] -- pretending to test release ...
   [      step] Step "placeholder" succeeded
👉 [      step] Running step "check:migrator-schemas"
   [check:migrator-schemas] pulling migrator image us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal/migrator:5.3.666
   [check:migrator-schemas] 5.3.666: Pulling from sourcegraph-ci/rfc795-internal/migrator
   [check:migrator-schemas] Digest: sha256:abe9dc4bc3c9b8146aa2a89ec128715de3b178769720da42b792834ed0de1eb1
   [check:migrator-schemas] Status: Image is up to date for us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal/migrator:5.3.666
   [check:migrator-schemas] us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal/migrator:5.3.666
   [check:migrator-schemas]
   [check:migrator-schemas] What's Next?
   [check:migrator-schemas]   View a summary of image vulnerabilities and recommendations → docker scout quickview us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal/migrator:5.3.666
   [check:migrator-schemas] checking migrator image for v5.3.666 schema description files
   [check:migrator-schemas] WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
   [      step] Step "check:migrator-schemas" succeeded
   ```