### PR TITLE
Revert adding "no subscription" message

### DIFF
--- a/client/web/src/cody/subscription/CodySubscriptionPage.module.scss
+++ b/client/web/src/cody/subscription/CodySubscriptionPage.module.scss
@@ -17,10 +17,6 @@
     font-size: 1.25rem;
 }
 
-.overflow-visible {
-    overflow: visible;
-}
-
 .ide-name {
     font-size: 1rem;
 }

--- a/client/web/src/cody/subscription/CodySubscriptionPage.tsx
+++ b/client/web/src/cody/subscription/CodySubscriptionPage.tsx
@@ -1,4 +1,4 @@
-import React, { type ReactElement, useMemo, useEffect } from 'react'
+import React, { type ReactElement, useEffect } from 'react'
 
 import { mdiArrowLeft, mdiInformationOutline, mdiTrendingUp, mdiCreditCardOutline } from '@mdi/js'
 import classNames from 'classnames'
@@ -18,7 +18,6 @@ import {
     Text,
     Tooltip,
     useSearchParameters,
-    Alert,
 } from '@sourcegraph/wildcard'
 
 import type { AuthenticatedUser } from '../../auth'
@@ -60,9 +59,6 @@ export const CodySubscriptionPage: React.FunctionComponent<CodySubscriptionPageP
 
     const utm_source = parameters.get('utm_source')
 
-    // Used when redirected from the SSC site for not having a subscription.
-    const showNoSubscriptionMessage = useMemo(() => parameters.get('noSubscription') === '1', [parameters])
-
     const codyPaymentsUrl = useCodyPaymentsUrl()
     const manageSubscriptionRedirectURL = `${codyPaymentsUrl}/cody/subscription`
 
@@ -95,11 +91,6 @@ export const CodySubscriptionPage: React.FunctionComponent<CodySubscriptionPageP
         <>
             <Page className={classNames('d-flex flex-column')}>
                 <PageTitle title="Cody Subscription" />
-                {showNoSubscriptionMessage && (
-                    <Alert variant="primary" className={styles.overflowVisible}>
-                        No subscription exists.
-                    </Alert>
-                )}
                 <PageHeader
                     className="mb-4"
                     actions={


### PR DESCRIPTION
- Reverts #61469 because we decided to not merge https://github.com/sourcegraph/self-serve-cody/pull/696 and close https://github.com/sourcegraph/self-serve-cody/issues/506 as a wontfix.

(I kept the other improvements that were in my PR.)

Note: enabled auto-merge.

## Test plan

Just a revert of a commit. No linter errors reassure me that it's good.