### PR TITLE
[gitserver] ArchiveReader correctly handles paths with spaces

### DIFF
--- a/cmd/gitserver/internal/git/gitcli/BUILD.bazel
+++ b/cmd/gitserver/internal/git/gitcli/BUILD.bazel
@@ -25,6 +25,7 @@ go_library(
         "//cmd/gitserver/internal/git",
         "//internal/actor",
         "//internal/api",
+        "//internal/byteutils",
         "//internal/collections",
         "//internal/conf",
         "//internal/gitserver/gitdomain",

--- a/cmd/gitserver/internal/git/gitcli/archivereader.go
+++ b/cmd/gitserver/internal/git/gitcli/archivereader.go
@@ -78,7 +78,13 @@ func (g *gitCLIBackend) verifyPaths(ctx context.Context, treeish string, paths [
 		if len(p) == 0 {
 			continue
 		}
-		pathSegments := bytes.Fields(p)
+
+		// Split into path segments by skipping only tab characters, since
+		// files/dirs can start with/contain spaces.
+		pathSegments := bytes.FieldsFunc(p, func(r rune) bool {
+			return r == rune('\t')
+		})
+
 		fileSet.Add(string(pathSegments[len(pathSegments)-1]))
 	}
 

--- a/cmd/gitserver/internal/git/gitcli/archivereader.go
+++ b/cmd/gitserver/internal/git/gitcli/archivereader.go
@@ -44,7 +44,7 @@ func buildArchiveArgs(format git.ArchiveFormat, treeish string, paths []string) 
 func pathspecLiteral(s string) string { return ":(literal)" + s }
 
 func (g *gitCLIBackend) verifyPaths(ctx context.Context, treeish string, paths []string) error {
-	args := []string{"ls-tree", treeish, "--"}
+	args := []string{"ls-tree", "--name-only", treeish, "--"}
 	args = append(args, paths...)
 	r, err := g.NewCommand(ctx, WithArguments(args...))
 	if err != nil {
@@ -75,17 +75,7 @@ func (g *gitCLIBackend) verifyPaths(ctx context.Context, treeish string, paths [
 	gotPaths := bytes.Split(bytes.TrimSpace(stdout), []byte("\n"))
 	fileSet := collections.NewSet[string]()
 	for _, p := range gotPaths {
-		if len(p) == 0 {
-			continue
-		}
-
-		// Split into path segments by skipping only tab characters, since
-		// files/dirs can start with/contain spaces.
-		pathSegments := bytes.FieldsFunc(p, func(r rune) bool {
-			return r == rune('\t')
-		})
-
-		fileSet.Add(string(pathSegments[len(pathSegments)-1]))
+		fileSet.Add(string(p))
 	}
 
 	pathsSet := collections.NewSet[string]()

--- a/cmd/gitserver/internal/git/gitcli/archivereader.go
+++ b/cmd/gitserver/internal/git/gitcli/archivereader.go
@@ -44,8 +44,29 @@ func buildArchiveArgs(format git.ArchiveFormat, treeish string, paths []string) 
 // See: https://git-scm.com/docs/gitglossary#Documentation/gitglossary.txt-literal
 func pathspecLiteral(s string) string { return ":(literal)" + s }
 
+// scanNullLines is a split function for a [Scanner] that returns each null-terminated
+// line of text, stripped of any trailing end-of-line marker. The returned line may
+// be empty. The end-of-line marker is a null character.
+// The last non-empty line of input will be returned even if it has no
+// null character.
+func scanNullLines(data []byte, atEOF bool) (advance int, token []byte, err error) {
+	if atEOF && len(data) == 0 {
+		return 0, nil, nil
+	}
+	if i := bytes.IndexByte(data, '\000'); i >= 0 {
+		// We have a full null-terminated line.
+		return i + 1, data[0:i], nil
+	}
+	// If we're at EOF, we have a final, non-terminated line. Return it.
+	if atEOF {
+		return len(data), data, nil
+	}
+	// Request more data.
+	return 0, nil, nil
+}
+
 func (g *gitCLIBackend) verifyPaths(ctx context.Context, treeish string, paths []string) error {
-	args := []string{"ls-tree", "--name-only", treeish, "--"}
+	args := []string{"ls-tree", "-z", "--name-only", treeish, "--"}
 	args = append(args, paths...)
 	r, err := g.NewCommand(ctx, WithArguments(args...))
 	if err != nil {
@@ -54,6 +75,7 @@ func (g *gitCLIBackend) verifyPaths(ctx context.Context, treeish string, paths [
 	defer r.Close()
 
 	scanner := bufio.NewScanner(r)
+	scanner.Split(scanNullLines)
 	fileSet := make(collections.Set[string], len(paths))
 	for scanner.Scan() {
 		fileSet.Add(scanner.Text())

--- a/cmd/gitserver/internal/git/gitcli/archivereader_test.go
+++ b/cmd/gitserver/internal/git/gitcli/archivereader_test.go
@@ -70,9 +70,10 @@ func TestGitCLIBackend_ArchiveReader(t *testing.T) {
 		"echo abcd > file1",
 		"mkdir dir1",
 		"echo efgh > dir1/file2",
-		`echo ijkl > "dir1/ file3"`,
+		`echo ijkl > " file3"`,
 		`echo mnop > "dir1/file with spaces"`,
 		"git add file1",
+		`git add " file3"`,
 		"git add dir1",
 		"git commit -m commit --author='Foo Author <foo@sourcegraph.com>'",
 	)
@@ -126,14 +127,14 @@ func TestGitCLIBackend_ArchiveReader(t *testing.T) {
 	})
 
 	t.Run("read file with space in name", func(t *testing.T) {
-		r, err := backend.ArchiveReader(ctx, "tar", string(commitID), []string{"dir1/ file3", "dir1/file with spaces"})
+		r, err := backend.ArchiveReader(ctx, "tar", string(commitID), []string{" file3", "dir1/file with spaces"})
 		require.NoError(t, err)
 		t.Cleanup(func() { r.Close() })
 		tr := tar.NewReader(r)
-		contents := readFileContentsFromTar(t, tr, "dir1/ file3")
+		contents := readFileContentsFromTar(t, tr, " file3")
 		require.Equal(t, "ijkl\n", contents)
 
-		r, err = backend.ArchiveReader(ctx, "tar", string(commitID), []string{"dir1/ file3", "dir1/file with spaces"})
+		r, err = backend.ArchiveReader(ctx, "tar", string(commitID), []string{" file3", "dir1/file with spaces"})
 		require.NoError(t, err)
 		t.Cleanup(func() { r.Close() })
 		tr = tar.NewReader(r)

--- a/cmd/gitserver/internal/git/gitcli/archivereader_test.go
+++ b/cmd/gitserver/internal/git/gitcli/archivereader_test.go
@@ -70,6 +70,8 @@ func TestGitCLIBackend_ArchiveReader(t *testing.T) {
 		"echo abcd > file1",
 		"mkdir dir1",
 		"echo efgh > dir1/file2",
+		`echo ijkl > "dir1/ file3"`,
+		`echo mnop > "dir1/file with spaces"`,
 		"git add file1",
 		"git add dir1",
 		"git commit -m commit --author='Foo Author <foo@sourcegraph.com>'",
@@ -121,6 +123,22 @@ func TestGitCLIBackend_ArchiveReader(t *testing.T) {
 		tr := tar.NewReader(r)
 		contents := readFileContentsFromTar(t, tr, "dir1/file2")
 		require.Equal(t, "efgh\n", contents)
+	})
+
+	t.Run("read file with space in name", func(t *testing.T) {
+		r, err := backend.ArchiveReader(ctx, "tar", string(commitID), []string{"dir1/ file3", "dir1/file with spaces"})
+		require.NoError(t, err)
+		t.Cleanup(func() { r.Close() })
+		tr := tar.NewReader(r)
+		contents := readFileContentsFromTar(t, tr, "dir1/ file3")
+		require.Equal(t, "ijkl\n", contents)
+
+		r, err = backend.ArchiveReader(ctx, "tar", string(commitID), []string{"dir1/ file3", "dir1/file with spaces"})
+		require.NoError(t, err)
+		t.Cleanup(func() { r.Close() })
+		tr = tar.NewReader(r)
+		contents = readFileContentsFromTar(t, tr, "dir1/file with spaces")
+		require.Equal(t, "mnop\n", contents)
 	})
 
 	t.Run("non existent commit", func(t *testing.T) {

--- a/cmd/gitserver/internal/git/gitcli/archivereader_test.go
+++ b/cmd/gitserver/internal/git/gitcli/archivereader_test.go
@@ -72,6 +72,8 @@ func TestGitCLIBackend_ArchiveReader(t *testing.T) {
 		"echo efgh > dir1/file2",
 		`echo ijkl > " file3"`,
 		`echo mnop > "dir1/file with spaces"`,
+		"echo qrst > 我的工作",
+		"git add 我的工作",
 		"git add file1",
 		`git add " file3"`,
 		"git add dir1",
@@ -140,6 +142,15 @@ func TestGitCLIBackend_ArchiveReader(t *testing.T) {
 		tr = tar.NewReader(r)
 		contents = readFileContentsFromTar(t, tr, "dir1/file with spaces")
 		require.Equal(t, "mnop\n", contents)
+	})
+
+	t.Run("read non-ascii filename", func(t *testing.T) {
+		r, err := backend.ArchiveReader(ctx, "tar", string(commitID), []string{" file3", "我的工作"})
+		require.NoError(t, err)
+		t.Cleanup(func() { r.Close() })
+		tr := tar.NewReader(r)
+		contents := readFileContentsFromTar(t, tr, "我的工作")
+		require.Equal(t, "qrst\n", contents)
 	})
 
 	t.Run("non existent commit", func(t *testing.T) {

--- a/internal/byteutils/BUILD.bazel
+++ b/internal/byteutils/BUILD.bazel
@@ -3,7 +3,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "byteutils",
-    srcs = ["linereader.go"],
+    srcs = [
+        "linereader.go",
+        "nullscanner.go",
+    ],
     importpath = "github.com/sourcegraph/sourcegraph/internal/byteutils",
     visibility = ["//:__subpackages__"],
 )

--- a/internal/byteutils/nullscanner.go
+++ b/internal/byteutils/nullscanner.go
@@ -1,0 +1,24 @@
+package byteutils
+
+import "bytes"
+
+// ScanNullLines is a split function for a [Scanner] that returns each null-terminated
+// line of text, stripped of any trailing end-of-line marker. The returned line may
+// be empty. The end-of-line marker is a null character.
+// The last non-empty line of input will be returned even if it has no
+// null character.
+func ScanNullLines(data []byte, atEOF bool) (advance int, token []byte, err error) {
+	if atEOF && len(data) == 0 {
+		return 0, nil, nil
+	}
+	if i := bytes.IndexByte(data, '\x00'); i >= 0 {
+		// We have a full null-terminated line.
+		return i + 1, data[0:i], nil
+	}
+	// If we're at EOF, we have a final, non-terminated line. Return it.
+	if atEOF {
+		return len(data), data, nil
+	}
+	// Request more data.
+	return 0, nil, nil
+}


### PR DESCRIPTION
Closes #61518 

We used `bytes.Fields` to parse the output from the `git` command, but `bytes.Fields` splits on all whitespace. This leads to erroneous file paths when the file paths have spaces in them, since we'll only be using the final path segment.

This PR passes the `--name-only` flag to the `git ls-tree` command so that we don't have to do any parsing to get the path.

## Test plan

Unit test added.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
