### PR TITLE
[perf] Do less string allocations when performing git blame

### DIFF
--- a/cmd/gitserver/internal/git/gitcli/blame.go
+++ b/cmd/gitserver/internal/git/gitcli/blame.go
@@ -2,6 +2,7 @@ package gitcli
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -96,7 +97,7 @@ func (br *blameHunkReader) Read() (_ *gitdomain.Hunk, err error) {
 		}
 
 		// Read line from git blame, in porcelain format
-		line := br.sc.Text()
+		line := br.sc.Bytes()
 		annotation, fields := splitLine(line)
 
 		// On the first read, we have no hunk and the first thing we read is an entry.
@@ -142,17 +143,17 @@ func (br *blameHunkReader) Close() error {
 
 // parseEntry turns a `67b7b725a7ff913da520b997d71c840230351e30 10 20 1` line from
 // git blame into a hunk.
-func parseEntry(rev string, content string) (*gitdomain.Hunk, error) {
-	fields := strings.Split(content, " ")
+func parseEntry(rev []byte, content []byte) (*gitdomain.Hunk, error) {
+	fields := bytes.Split(content, []byte(" "))
 	if len(fields) != 3 {
 		return nil, errors.Errorf("Expected at least 4 parts to hunkHeader, but got: '%s %s'", rev, content)
 	}
 
-	resultLine, err := strconv.Atoi(fields[1])
+	resultLine, err := strconv.Atoi(string(fields[1]))
 	if err != nil {
 		return nil, err
 	}
-	numLines, _ := strconv.Atoi(fields[2])
+	numLines, err := strconv.Atoi(string(fields[2]))
 	if err != nil {
 		return nil, err
 	}
@@ -166,32 +167,32 @@ func parseEntry(rev string, content string) (*gitdomain.Hunk, error) {
 
 // parseExtra updates a hunk with data parsed from the other annotations such as `author ...`,
 // `summary ...`.
-func parseExtra(hunk *gitdomain.Hunk, annotation string, content string) (ok bool, err error) {
+func parseExtra(hunk *gitdomain.Hunk, annotation []byte, content []byte) (ok bool, err error) {
 	ok = true
-	switch annotation {
+	switch string(annotation) {
 	case "author":
-		hunk.Author.Name = content
+		hunk.Author.Name = string(content)
 	case "author-mail":
 		if len(content) >= 2 && content[0] == '<' && content[len(content)-1] == '>' {
-			hunk.Author.Email = content[1 : len(content)-1]
+			hunk.Author.Email = string(content[1 : len(content)-1])
 		}
 	case "author-time":
 		var t int64
-		t, err = strconv.ParseInt(content, 10, 64)
+		t, err = strconv.ParseInt(string(content), 10, 64)
 		hunk.Author.Date = time.Unix(t, 0).UTC()
 	case "author-tz":
 		// do nothing
 	case "committer", "committer-mail", "committer-tz", "committer-time":
 	case "summary":
-		hunk.Message = content
+		hunk.Message = string(content)
 	case "filename":
-		hunk.Filename = content
+		hunk.Filename = string(content)
 	case "previous":
 	case "boundary":
 	default:
 		// If it doesn't look like an entry, it's probably an unhandled git blame
 		// annotation.
-		if len(annotation) != 40 && len(strings.Split(content, " ")) != 3 {
+		if len(annotation) != 40 && len(bytes.Split(content, []byte(" "))) != 3 {
 			err = errors.Newf("unhandled git blame annotation: %s")
 		}
 		ok = false
@@ -201,10 +202,11 @@ func parseExtra(hunk *gitdomain.Hunk, annotation string, content string) (ok boo
 
 // splitLine splits a scanned line and returns the annotation along
 // with the content, if any.
-func splitLine(line string) (annotation string, content string) {
-	annotation, content, found := strings.Cut(line, " ")
+func splitLine(line []byte) (annotation []byte, content []byte) {
+	annotation, content, found := bytes.Cut(line, []byte(" "))
 	if found {
 		return annotation, content
 	}
-	return line, ""
+
+	return line, nil
 }

--- a/cmd/gitserver/internal/git/gitcli/blame.go
+++ b/cmd/gitserver/internal/git/gitcli/blame.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"path/filepath"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/sourcegraph/sourcegraph/cmd/gitserver/internal/git"

--- a/cmd/gitserver/internal/git/gitcli/blame_test.go
+++ b/cmd/gitserver/internal/git/gitcli/blame_test.go
@@ -430,6 +430,24 @@ func TestBlameHunkReader(t *testing.T) {
 	})
 }
 
+func BenchmarkBlameBytes(b *testing.B) {
+	for range b.N {
+		rc := io.NopCloser(strings.NewReader(testGitBlameOutputIncremental2))
+		reader := newBlameHunkReader(rc)
+		defer reader.Close()
+
+		for {
+			_, err := reader.Read()
+			if errors.Is(err, io.EOF) {
+				break
+			} else if err != nil {
+				b.Fatalf("blameHunkReader.Read failed: %s", err)
+			}
+		}
+	}
+	b.ReportAllocs()
+}
+
 func mustParseTime(layout, value string) time.Time {
 	tm, err := time.Parse(layout, value)
 	if err != nil {


### PR DESCRIPTION
Improves our git blame performance by using `[]byte` operations instead of allocating strings.

Some numbers:

Using the `string` functions:
```
BenchmarkBlameBytes-10                                                    291399              4192 ns/op            7487 B/op         68 allocs/op
```

Using the `[]byte` functions:
```
BenchmarkBlameBytes-10                                                    344814              3397 ns/op            6783 B/op         45 allocs/op
```

And then anecdotal spot testing on `schema/schema.go`:

Using the `string` functions:
![image](https://github.com/sourcegraph/sourcegraph/assets/6427795/da06fb01-a853-4d68-b54d-604ee07c1030)

Using the `[]byte` functions:
![image](https://github.com/sourcegraph/sourcegraph/assets/6427795/f8c3e382-75d2-4986-9fbf-324f107f01ae)

## Test plan

Manual tests and benchmark

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
