### PR TITLE
svelte/ci: Run `svelte-check` in CI

### DIFF
--- a/client/web-sveltekit/BUILD.bazel
+++ b/client/web-sveltekit/BUILD.bazel
@@ -96,6 +96,7 @@ BUILD_DEPS = [
     ":node_modules/hotkeys-js",
     ":node_modules/prismjs",
     ":node_modules/sass",
+    ":node_modules/signale",
     ":node_modules/svelte",
     ":node_modules/ts-key-enum",
     ":node_modules/vite",
@@ -147,11 +148,19 @@ TESTS = glob([
 ])
 
 TEST_BUILD_DEPS = [
+    ":generate-graphql-types",
     ":node_modules/vitest",
-    ":node_modules/signale",
     ":node_modules/@testing-library/svelte",
     ":node_modules/@testing-library/user-event",
-]
+] + glob(
+    [
+        "src/testing/*",
+    ],
+    [
+        # Already inluded in TESTS
+        "src/testing/graphql-mocking.test.ts",
+    ],
+)
 
 vitest_test(
     name = "unit_tests",

--- a/client/web-sveltekit/BUILD.bazel
+++ b/client/web-sveltekit/BUILD.bazel
@@ -170,22 +170,6 @@ vitest_test(
     with_vitest_config = False,
 )
 
-# Input for graphql-codegen
-filegroup(
-    name = "graphql_sources",
-    srcs = glob(
-        [
-            "src/**/*.gql",
-            "src/**/*.ts",
-        ],
-        [
-            "src/lib/graphql-*.ts",
-            "src/testing/graphql-type-mocks.ts",
-            "src/**/*.gql.ts",
-        ],
-    ),
-)
-
 # Create binary that executes graphql-codegen
 ts_binary(
     name = "graphql_codegen_bin",
@@ -205,14 +189,32 @@ ts_binary(
     entry_point = "dev/generate-graphql.ts",
 )
 
+# Generate types from graphql files
+GRAPHQL_FILES = glob(
+    [
+        "src/**/*.gql",
+    ],
+)
+
+# Files that possibly contain gql`...` tags
+OTHER_GRAPHQL_INPUT_FILES = glob(
+    [
+        "src/**/*.ts",
+    ],
+    [
+        "src/lib/graphql-*.ts",
+        "src/testing/graphql-type-mocks.ts",
+        "src/**/*.gql.ts",
+    ],
+)
+
 # Run graphql-codegen
 js_run_binary(
     name = "generate-graphql-types",
-    srcs = [
-        ":graphql_sources",
+    srcs = GRAPHQL_FILES + OTHER_GRAPHQL_INPUT_FILES + [
         "//cmd/frontend/graphqlbackend:graphql_schema",
     ],
-    outs = glob(["src/**/*.gql.ts"]) + [
+    outs = [src + ".ts" for src in GRAPHQL_FILES] + [
         "src/lib/graphql-operations.ts",
         "src/lib/graphql-types.ts",
         "src/testing/graphql-type-mocks.ts",

--- a/client/web-sveltekit/BUILD.bazel
+++ b/client/web-sveltekit/BUILD.bazel
@@ -5,10 +5,10 @@ load("@npm//client/web-sveltekit:vite/package_json.bzl", vite_bin = "bin")
 load("@npm//client/web-sveltekit:vitest/package_json.bzl", vitest_bin = "bin")
 load("@npm//client/web-sveltekit:svelte-check/package_json.bzl", svelte_check = "bin")
 load("@npm//client/web-sveltekit:@sveltejs/kit/package_json.bzl", sveltekit = "bin")
-load("@aspect_rules_ts//ts:defs.bzl", "ts_project", "ts_config")
-load("@aspect_rules_js//js:defs.bzl", "js_run_binary", "js_binary")
+load("@aspect_rules_ts//ts:defs.bzl", "ts_config", "ts_project")
+load("@aspect_rules_js//js:defs.bzl", "js_binary", "js_run_binary")
 load("@aspect_rules_swc//swc:defs.bzl", "swc")
-load("//dev:defs.bzl", "vitest_test", "ts_binary")
+load("//dev:defs.bzl", "ts_binary", "vitest_test")
 
 # gazelle:ignore
 
@@ -164,26 +164,25 @@ vitest_test(
 # Input for graphql-codegen
 filegroup(
     name = "graphql_sources",
-    srcs = glob([
-        "src/**/*.gql",
-        "src/**/*.ts",
-    ],
-    [
-        "src/lib/graphql-*.ts",
-        "src/testing/graphql-type-mocks.ts",
-        "src/**/*.gql.ts",
-    ]),
+    srcs = glob(
+        [
+            "src/**/*.gql",
+            "src/**/*.ts",
+        ],
+        [
+            "src/lib/graphql-*.ts",
+            "src/testing/graphql-type-mocks.ts",
+            "src/**/*.gql.ts",
+        ],
+    ),
 )
 
 # Create binary that executes graphql-codegen
 ts_binary(
     name = "graphql_codegen_bin",
-    entry_point = "dev/generate-graphql.ts",
     data = [
-        "dev/vite-graphql-codegen.ts",
         "dev/graphql-type-mocks.cjs",
-        ":node_modules/graphql",
-        ":node_modules/signale",
+        "dev/vite-graphql-codegen.ts",
         ":node_modules/@graphql-codegen/cli",
         ":node_modules/@graphql-codegen/near-operation-file-preset",
         ":node_modules/@graphql-codegen/typed-document-node",
@@ -191,13 +190,15 @@ ts_binary(
         ":node_modules/@graphql-codegen/typescript-operations",
         ":node_modules/@graphql-tools/utils",
         ":node_modules/@graphql-typed-document-node/core",
+        ":node_modules/graphql",
+        ":node_modules/signale",
     ],
+    entry_point = "dev/generate-graphql.ts",
 )
 
 # Run graphql-codegen
 js_run_binary(
     name = "generate-graphql-types",
-    tool = ":graphql_codegen_bin",
     srcs = [
         ":graphql_sources",
         "//cmd/frontend/graphqlbackend:graphql_schema",
@@ -208,12 +209,12 @@ js_run_binary(
         "src/testing/graphql-type-mocks.ts",
     ],
     chdir = package_name(),
+    tool = ":graphql_codegen_bin",
 )
 
 # Generate SvelteKit specific types
 sveltekit.svelte_kit(
     name = "sveltekit-sync",
-    chdir = package_name(),
     srcs = SRCS + [
         ":node_modules/@sveltejs/adapter-static",
         ":node_modules/@sveltejs/vite-plugin-svelte",
@@ -224,14 +225,20 @@ sveltekit.svelte_kit(
     args = [
         "sync",
     ],
+    chdir = package_name(),
     out_dirs = [
         ".svelte-kit",
-    ]
+    ],
 )
 
 # Runs svelte-check on production source files
 svelte_check.svelte_check_test(
     name = "svelte-check",
+    timeout = "short",
+    args = [
+        "--tsconfig",
+        "tsconfig.json",
+    ],
     chdir = package_name(),
     data = SRCS + BUILD_DEPS + CONFIGS + [
         ":sveltekit-sync",
@@ -239,11 +246,6 @@ svelte_check.svelte_check_test(
         ":node_modules/@graphql-typed-document-node/core",
         "//:node_modules/@types/uuid",
         # Needed to properly extend vite's UserConfig type
-        ":node_modules/vitest"
+        ":node_modules/vitest",
     ],
-    args = [
-        "--tsconfig",
-        "tsconfig.json",
-    ],
-    timeout = "short",
 )

--- a/client/web-sveltekit/BUILD.bazel
+++ b/client/web-sveltekit/BUILD.bazel
@@ -1,8 +1,14 @@
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
+load("@bazel_skylib//lib:partial.bzl", "partial")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@npm//client/web-sveltekit:vite/package_json.bzl", vite_bin = "bin")
 load("@npm//client/web-sveltekit:vitest/package_json.bzl", vitest_bin = "bin")
-load("//dev:defs.bzl", "vitest_test")
+load("@npm//client/web-sveltekit:svelte-check/package_json.bzl", svelte_check = "bin")
+load("@npm//client/web-sveltekit:@sveltejs/kit/package_json.bzl", sveltekit = "bin")
+load("@aspect_rules_ts//ts:defs.bzl", "ts_project", "ts_config")
+load("@aspect_rules_js//js:defs.bzl", "js_run_binary", "js_binary")
+load("@aspect_rules_swc//swc:defs.bzl", "swc")
+load("//dev:defs.bzl", "vitest_test", "ts_binary")
 
 # gazelle:ignore
 
@@ -32,18 +38,18 @@ SRCS = [
     [
         "src/lib/graphql-operations.ts",
         "src/lib/graphql-types.ts",
-        "src/lib/graphql-type-mocks.ts",
+        "src/testing/graphql-type-mocks.ts",
         "src/**/*.gql.ts",
         "src/**/*.gql.d.ts",
         "src/**/*.test.ts",
         "src/**/*.spec.ts",
+        "src/testing/*",
+        "src/**/*.stories.svelte",
     ],
-) + glob([
-    "dev/**/*.cjs",
-    "dev/**/*.ts",
-])
+)
 
 BUILD_DEPS = [
+    "//cmd/frontend/graphqlbackend:graphql_schema",
     "//:node_modules/@apollo/client",
     "//:node_modules/@codemirror/autocomplete",
     "//:node_modules/@codemirror/commands",
@@ -64,8 +70,6 @@ BUILD_DEPS = [
     "//:node_modules/react-resizable",
     "//:node_modules/rxjs",
     "//:node_modules/uuid",
-    "//cmd/frontend/graphqlbackend:graphql_schema",
-    ":node_modules/hotkeys-js",
     ":node_modules/@faker-js/faker",
     ":node_modules/@floating-ui/dom",
     ":node_modules/@graphql-codegen/cli",
@@ -76,6 +80,7 @@ BUILD_DEPS = [
     ":node_modules/@graphql-tools/utils",
     ":node_modules/@melt-ui/svelte",
     ":node_modules/@sourcegraph/branded",
+    ":node_modules/@sourcegraph/client-api",
     ":node_modules/@sourcegraph/common",
     ":node_modules/@sourcegraph/http-client",
     ":node_modules/@sourcegraph/shared",
@@ -88,6 +93,7 @@ BUILD_DEPS = [
     ":node_modules/@types/prismjs",
     ":node_modules/@urql/core",
     ":node_modules/graphql",
+    ":node_modules/hotkeys-js",
     ":node_modules/prismjs",
     ":node_modules/sass",
     ":node_modules/svelte",
@@ -95,7 +101,10 @@ BUILD_DEPS = [
     ":node_modules/vite",
     ":node_modules/vite-plugin-inspect",
     ":node_modules/wonka",
-]
+] + glob([
+    "dev/**/*.cjs",
+    "dev/**/*.ts",
+])
 
 CONFIGS = [
     "//client/branded:tsconfig",
@@ -150,4 +159,91 @@ vitest_test(
     chdir = package_name(),
     data = SRCS + BUILD_DEPS + CONFIGS + TESTS + TEST_BUILD_DEPS,
     with_vitest_config = False,
+)
+
+# Input for graphql-codegen
+filegroup(
+    name = "graphql_sources",
+    srcs = glob([
+        "src/**/*.gql",
+        "src/**/*.ts",
+    ],
+    [
+        "src/lib/graphql-*.ts",
+        "src/testing/graphql-type-mocks.ts",
+        "src/**/*.gql.ts",
+    ]),
+)
+
+# Create binary that executes graphql-codegen
+ts_binary(
+    name = "graphql_codegen_bin",
+    entry_point = "dev/generate-graphql.ts",
+    data = [
+        "dev/vite-graphql-codegen.ts",
+        "dev/graphql-type-mocks.cjs",
+        ":node_modules/graphql",
+        ":node_modules/signale",
+        ":node_modules/@graphql-codegen/cli",
+        ":node_modules/@graphql-codegen/near-operation-file-preset",
+        ":node_modules/@graphql-codegen/typed-document-node",
+        ":node_modules/@graphql-codegen/typescript",
+        ":node_modules/@graphql-codegen/typescript-operations",
+        ":node_modules/@graphql-tools/utils",
+        ":node_modules/@graphql-typed-document-node/core",
+    ],
+)
+
+# Run graphql-codegen
+js_run_binary(
+    name = "generate-graphql-types",
+    tool = ":graphql_codegen_bin",
+    srcs = [
+        ":graphql_sources",
+        "//cmd/frontend/graphqlbackend:graphql_schema",
+    ],
+    outs = glob(["src/**/*.gql.ts"]) + [
+        "src/lib/graphql-operations.ts",
+        "src/lib/graphql-types.ts",
+        "src/testing/graphql-type-mocks.ts",
+    ],
+    chdir = package_name(),
+)
+
+# Generate SvelteKit specific types
+sveltekit.svelte_kit(
+    name = "sveltekit-sync",
+    chdir = package_name(),
+    srcs = SRCS + [
+        ":node_modules/@sveltejs/adapter-static",
+        ":node_modules/@sveltejs/vite-plugin-svelte",
+        # This is needed to sveltekit sync to generate the types
+        # It explicitly looks for the existince of this package
+        "//:node_modules/typescript",
+    ],
+    args = [
+        "sync",
+    ],
+    out_dirs = [
+        ".svelte-kit",
+    ]
+)
+
+# Runs svelte-check on production source files
+svelte_check.svelte_check_test(
+    name = "svelte-check",
+    chdir = package_name(),
+    data = SRCS + BUILD_DEPS + CONFIGS + [
+        ":sveltekit-sync",
+        ":generate-graphql-types",
+        ":node_modules/@graphql-typed-document-node/core",
+        "//:node_modules/@types/uuid",
+        # Needed to properly extend vite's UserConfig type
+        ":node_modules/vitest"
+    ],
+    args = [
+        "--tsconfig",
+        "tsconfig.json",
+    ],
+    timeout = "short",
 )

--- a/client/web-sveltekit/dev/generate-graphql.ts
+++ b/client/web-sveltekit/dev/generate-graphql.ts
@@ -1,0 +1,7 @@
+// Standalone script to generate graphql types, used by bazel
+import { codegen } from './vite-graphql-codegen'
+
+codegen().catch(error => {
+    console.error(error)
+    process.exit(1)
+})

--- a/client/web-sveltekit/src/lib/graphql/urql.ts
+++ b/client/web-sveltekit/src/lib/graphql/urql.ts
@@ -122,7 +122,8 @@ interface OperationResultState<TData = any, TVariables extends AnyVariables = An
     restoring: boolean
 }
 
-interface InfinityQueryStore<TData = any, TVariables extends AnyVariables = AnyVariables>
+// This needs to be exported so that TS type inference can work in SvelteKit generated files.
+export interface InfinityQueryStore<TData = any, TVariables extends AnyVariables = AnyVariables>
     extends Readable<OperationResultState<TData, TVariables>> {
     /**
      * Reruns the query with the next set of variables returned by {@link InfinityQueryArgs.nextVariables}.

--- a/client/web-sveltekit/src/lib/wildcard/Button.svelte
+++ b/client/web-sveltekit/src/lib/wildcard/Button.svelte
@@ -6,12 +6,16 @@
 
     import { type BUTTON_DISPLAY, type BUTTON_SIZES, type BUTTON_VARIANTS, getButtonClassName } from './Button'
 
-    interface $$Props extends HTMLButtonAttributes {
+    type $$Props = {
         variant?: typeof BUTTON_VARIANTS[number]
         size?: typeof BUTTON_SIZES[number]
         display?: typeof BUTTON_DISPLAY[number]
         outline?: boolean
-    }
+        // This is already allowed by HTMLButtonAttributes ([key: `data-${string}`]: any)
+        // but for some reason it's not recognized when using `svelte-check` and an error
+        // is thrown instead.
+        'data-testid'?: string
+    } & HTMLButtonAttributes
 
     export let variant: $$Props['variant'] = 'primary'
     export let size: $$Props['size'] = undefined

--- a/client/web-sveltekit/src/lib/wildcard/menu/Menu.svelte
+++ b/client/web-sveltekit/src/lib/wildcard/menu/Menu.svelte
@@ -4,9 +4,7 @@
 
     interface DropdownMenuContext {
         item: DropdownMenu['elements']['item']
-        trigger: DropdownMenu['elements']['trigger']
         separator: DropdownMenu['elements']['separator']
-        open: DropdownMenu['states']['open']
         builders: DropdownMenu['builders']
     }
 
@@ -34,7 +32,7 @@
     } = createDropdownMenu({
         open,
     })
-    setContext({ item, trigger, separator, builders, $open })
+    setContext({ item, separator, builders })
 </script>
 
 <button {...$trigger} use:trigger class={triggerButtonClass} {...$$restProps}>

--- a/client/web-sveltekit/src/routes/layout.gql
+++ b/client/web-sveltekit/src/routes/layout.gql
@@ -25,10 +25,10 @@ query GlobalAlertsSiteFlags {
 }
 
 mutation DisableSveltePrototype($userID: ID!) {
-    overrideWebNext: createFeatureFlagOverride(namespace:$userID, flagName:"web-next", value:false) {
+    overrideWebNext: createFeatureFlagOverride(namespace: $userID, flagName: "web-next", value: false) {
         __typename
     }
-    overrideRollout: createFeatureFlagOverride(namespace:$userID, flagName:"web-next-rollout", value:false) {
+    overrideRollout: createFeatureFlagOverride(namespace: $userID, flagName: "web-next-rollout", value: false) {
         __typename
     }
 }

--- a/client/web-sveltekit/vite.config.ts
+++ b/client/web-sveltekit/vite.config.ts
@@ -3,11 +3,15 @@ import { join } from 'path'
 import { sveltekit } from '@sveltejs/kit/vite'
 import { defineConfig, mergeConfig, type UserConfig } from 'vite'
 import inspect from 'vite-plugin-inspect'
+import type { UserConfig as VitestUserConfig } from 'vitest'
 
 import graphqlCodegen from './dev/vite-graphql-codegen'
 
 export default defineConfig(({ mode }) => {
-    let config: UserConfig = {
+    // Using & VitestUserConfig shouldn't be necessary but without it `svelte-check` complains when run
+    // in bazel. It's not clear what needs to be done to make it work without it, just like it does
+    // locally.
+    let config: UserConfig & VitestUserConfig = {
         plugins: [
             sveltekit(),
             // Generates typescript types for gql-tags and .gql files


### PR DESCRIPTION
This commit updates the bazel build file to execute `svelte-check` in CI.

To make this work correctly we need to run additional commands to generate all the files that are needed by the code. Specifically that's `svelte-kit sync` and the graphql code/type generation. The code was refactored to make that work.

This commit also fixes issues detected by `svelte-check`.

IMPORTANT
Running `svelte-check` in CI differs in two ways from running it locally:

1. Locally `svelte-check` will also check all local `@sourcegraph/*`, because they symlink the orginal source code. In CI/Bazel those dependencies are already built and therefore are not checked by Bazel. However, this is what we want because the dependencies do not always conform to the rules set by `svelte-check`.
2. Source files that are not required for the production build have been excluded and are therefore not checked. That includes Storybook story files, playwright and vitest files and `src/testing/*`.

FWIW I'm happy to add story and tests files as well if others would prefer that.


## Test plan

```
bazel test //client/web-sveltekit:svelte-check
```

```
pnpm build
```

CI