### PR TITLE
chore(sg): rfc flags are now position independent

### DIFF
--- a/dev/sg/sg_rfc.go
+++ b/dev/sg/sg_rfc.go
@@ -12,6 +12,17 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
+// rfcFlags are the flags that are common to all subcommands of the rfc command. This allows to not have to remember which position the flags are
+// to be inputted on the CLI.
+var rfcFlags = []cli.Flag{
+	&cli.BoolFlag{
+		Name:     "private",
+		Usage:    "perform the RFC action on the private RFC drive",
+		Required: false,
+		Value:    false,
+	},
+}
+
 var rfcCommand = &cli.Command{
 	Name:  "rfc",
 	Usage: `List, search, and open Sourcegraph RFCs`,
@@ -26,40 +37,33 @@ var rfcCommand = &cli.Command{
 sg rfc list
 
 # List all Private RFCs
-sg rfc --private list
+sg rfc list --private
 
 # Search for a Public RFC
 sg rfc search "search terms"
 
 # Search for a Private RFC
-sg rfc --private search "search terms"
+sg rfc search --private "search terms"
 
 # Open a specific Public RFC
 sg rfc open 420
 
 # Open a specific private RFC
-sg rfc --private open 420
+sg rfc open --private 420
 
 # Create a new public RFC
 sg rfc create "title"
 
 # Create a new private RFC. Possible types: [solution]
-sg rfc --private create --type <type> "title"
+sg rfc create --private --type <type> "title"
 `,
 	Category: category.Company,
-	Flags: []cli.Flag{
-		&cli.BoolFlag{
-			Name:     "private",
-			Usage:    "perform the RFC action on the private RFC drive",
-			Required: false,
-			Value:    false,
-		},
-	},
+	Flags:    rfcFlags,
 	Subcommands: []*cli.Command{
 		{
-			Name:      "list",
-			ArgsUsage: " ",
-			Usage:     "List Sourcegraph RFCs",
+			Name:  "list",
+			Usage: "List Sourcegraph RFCs",
+			Flags: rfcFlags,
 			Action: func(c *cli.Context) error {
 				driveSpec := rfc.PublicDrive
 				if c.Bool("private") {
@@ -71,6 +75,7 @@ sg rfc --private create --type <type> "title"
 		{
 			Name:      "search",
 			ArgsUsage: "[query]",
+			Flags:     rfcFlags,
 			Usage:     "Search Sourcegraph RFCs",
 			Action: func(c *cli.Context) error {
 				driveSpec := rfc.PublicDrive
@@ -86,6 +91,7 @@ sg rfc --private create --type <type> "title"
 		{
 			Name:      "open",
 			ArgsUsage: "[number]",
+			Flags:     rfcFlags,
 			Usage:     "Open a Sourcegraph RFC - find and list RFC numbers with 'sg rfc list' or 'sg rfc search'",
 			Action: func(c *cli.Context) error {
 				driveSpec := rfc.PublicDrive
@@ -100,14 +106,12 @@ sg rfc --private create --type <type> "title"
 		},
 		{
 			Name:      "create",
-			ArgsUsage: "--type <type> [title...]",
-			Flags: []cli.Flag{
-				&cli.StringFlag{
-					Name:  "type",
-					Usage: "the type of the RFC to create (valid: solution)",
-					Value: rfc.ProblemSolutionDriveTemplate.Name,
-				},
-			},
+			ArgsUsage: "[title...]",
+			Flags: append(rfcFlags, &cli.StringFlag{
+				Name:  "type",
+				Usage: "the type of the RFC to create (valid: solution)",
+				Value: rfc.ProblemSolutionDriveTemplate.Name,
+			}),
 			Usage: "Create Sourcegraph RFCs",
 			Action: func(c *cli.Context) error {
 				driveSpec := rfc.PublicDrive


### PR DESCRIPTION
In between things, noticed that `sg rfc` is annoying with positional flags, so made it sane. We somehow got used to this, and it stayed like this. Until now. 

## Test plan

before: 
```
$ sg rfc create "glorious changes" --private
Incorrect Usage: flag provided but not defined: -private
# 😵
$ sg rfc create --help
NAME:
   sg rfc create - Create Sourcegraph RFCs

USAGE:
   sg rfc create [command options] --type <type> [title...]

OPTIONS:
   --type value  the type of the RFC to create (valid: solution) (default: solution)
$ say "where the hell are you, damn private flag" 
$ sg rfc --help 
# ...
```
![](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExcXQ5eHFjOXA1NGtvaW1qZHZ1bXJ6NHdjOTk4dDNkbDUxOHB6YTNjbCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/WFhWSpXfEqLLSDaScz/giphy-downsized.gif)
```
# ... 
$ sg rfc --private create "glorious changes"
$ sg rfc create "glorious changes" --private
# 😤
```

after: 
```
$ sg rfc create --private "glorious changes"
# 🧘‍♂️ 
$ say "sanity restored"
``` 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
