### PR TITLE
wolfi: add debugging and use switch for new branch

### DIFF
--- a/dev/ci/scripts/wolfi/update-base-image-hashes.sh
+++ b/dev/ci/scripts/wolfi/update-base-image-hashes.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -eu -o pipefail
+set -exu -o pipefail
 
 cd "$(dirname "${BASH_SOURCE[0]}")/../../../.."
 
@@ -29,8 +29,8 @@ Built from Buildkite run [#${BUILDKITE_BUILD_NUMBER}](https://buildkite.com/sour
 
 # Commit changes to dev/oci-deps.bzl
 # Delete branch if it exists; catch status code if not
-git branch -D "${BRANCH_NAME}" || :
-git checkout -b "${BRANCH_NAME}"
+git branch -D "${BRANCH_NAME}" || true
+git switch -c "${BRANCH_NAME}"
 git add dev/oci_deps.bzl
 git commit -m "Auto-update Wolfi base image hashes at ${TIMESTAMP}"
 git push --force -u origin "${BRANCH_NAME}"


### PR DESCRIPTION
Wofli is currently timing out see [here](https://buildkite.com/sourcegraph/sourcegraph/builds/267161#018e9f87-33ff-457f-aac8-38fb8b41bc51) so we add some things to see WHY it is doing that
* Print out the commands
* Use switch instead of checkout since checkout can possibly hang when the repo is in a detached state
* swap out `:` for `true` since it is slightly more readable
## Test plan
CI

