### PR TITLE
Fix SAMS client configuration; make more flexible

### DIFF
--- a/cmd/cody-gateway/internal/httpapi/maintenance.go
+++ b/cmd/cody-gateway/internal/httpapi/maintenance.go
@@ -2,6 +2,7 @@ package httpapi
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"strings"
 
@@ -43,7 +44,8 @@ func NewMaintenanceHandler(
 			ClientSecret: config.SAMSClientConfig.ClientSecret,
 			// Since we are only using our SAMS client to verify supplied token,
 			// we just issue tokens with a minimal set of scopes.
-			Scopes: []string{"openid", "profile", "email"},
+			Scopes:   []string{"openid", "profile", "email"},
+			TokenURL: fmt.Sprintf("%s/oauth/token", config.SAMSClientConfig.URL),
 		})
 
 	return newMaintenanceHandler(logger, next, redisKV, samsClient)

--- a/internal/sams/client.go
+++ b/internal/sams/client.go
@@ -98,6 +98,11 @@ func (c *samsClient) IntrospectToken(ctx context.Context, token string) (*TokenI
 }
 
 func NewClient(samsServer string, clientCredentialsConfig clientcredentials.Config) Client {
+	// Provide a default value for the required TokenURL field, in case the caller forgot to set it.
+	if clientCredentialsConfig.TokenURL == "" {
+		clientCredentialsConfig.TokenURL = fmt.Sprintf("%s/oauth/token", samsServer)
+	}
+
 	return &samsClient{
 		server:                  samsServer,
 		clientCredentialsConfig: clientCredentialsConfig,


### PR DESCRIPTION
In https://github.com/sourcegraph/sourcegraph/pull/61514 I added a new codepath where we instantiate a SAMS client. However, when trying to use the new APIs it was failing with an odd error message.

After taking a closer look, apparently the `TokenURL` is a really important configuration setting when supplying OAuth client credentials 🤦 ...

This PR fixes that for the new callsite, but also updates `sams.NewClient` to supply a default value in case it is missed in the future. (Since it's the same URL for all callers of `sams.NewClient` throughout the repo.)

## Test plan

NA