### PR TITLE
Add OpenAI models to supported chat models for enterprise customers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Auth providers now support a `noSignIn` option that, when set to true, will hide the auth provider from the sign in page, but still allow users to connect the external account from their Account Security page for permissions syncing. [#60722](https://github.com/sourcegraph/sourcegraph/pull/60722)
 - Added a "Commits" button to the folders in repos that shows commits for the items in that folder. [#60909](https://github.com/sourcegraph/sourcegraph/pull/60909)
 - The frontend Grafana dashboard has a new Prometheus metric that tracks the rate of requests that Sourcegraph issues to external services. [#61348](https://github.com/sourcegraph/sourcegraph/pull/61348)
+- Support for OpenAI chat models for enterprise customers. [#61539](https://github.com/sourcegraph/sourcegraph/pull/61539)
 
 ### Changed
 

--- a/cmd/frontend/internal/dotcom/productsubscription/codygateway_graphql.go
+++ b/cmd/frontend/internal/dotcom/productsubscription/codygateway_graphql.go
@@ -35,7 +35,7 @@ func (r codyGatewayAccessResolver) ChatCompletionsRateLimit(ctx context.Context)
 	var source graphqlbackend.CodyGatewayRateLimitSource
 	if activeLicense != nil {
 		source = graphqlbackend.CodyGatewayRateLimitSourcePlan
-		rateLimit = licensing.NewCodyGatewayChatRateLimit(licensing.PlanFromTags(activeLicense.LicenseTags), activeLicense.LicenseUserCount, activeLicense.LicenseTags)
+		rateLimit = licensing.NewCodyGatewayChatRateLimit(licensing.PlanFromTags(activeLicense.LicenseTags), activeLicense.LicenseUserCount)
 	}
 
 	// Apply overrides

--- a/cmd/frontend/internal/dotcom/productsubscription/codygateway_graphql_test.go
+++ b/cmd/frontend/internal/dotcom/productsubscription/codygateway_graphql_test.go
@@ -49,7 +49,7 @@ func TestCodeGatewayAccessResolverRateLimit(t *testing.T) {
 		rateLimit, err := r.ChatCompletionsRateLimit(ctx)
 		require.NoError(t, err)
 
-		wantRateLimit := licensing.NewCodyGatewayChatRateLimit(licensing.PlanEnterprise1, pointify(int(info.UserCount)), []string{})
+		wantRateLimit := licensing.NewCodyGatewayChatRateLimit(licensing.PlanEnterprise1, pointify(int(info.UserCount)))
 		assert.Equal(t, graphqlbackend.BigInt(wantRateLimit.Limit), rateLimit.Limit())
 		assert.Equal(t, wantRateLimit.IntervalSeconds, rateLimit.IntervalSeconds())
 	})
@@ -69,7 +69,7 @@ func TestCodeGatewayAccessResolverRateLimit(t *testing.T) {
 		rateLimit, err := r.ChatCompletionsRateLimit(ctx)
 		require.NoError(t, err)
 
-		defaultRateLimit := licensing.NewCodyGatewayChatRateLimit(licensing.PlanEnterprise1, pointify(10), []string{})
+		defaultRateLimit := licensing.NewCodyGatewayChatRateLimit(licensing.PlanEnterprise1, pointify(10))
 		assert.Equal(t, graphqlbackend.BigInt(10), rateLimit.Limit())
 		assert.Equal(t, defaultRateLimit.IntervalSeconds, rateLimit.IntervalSeconds())
 	})

--- a/internal/licensing/codygateway.go
+++ b/internal/licensing/codygateway.go
@@ -33,10 +33,10 @@ func NewCodyGatewayChatRateLimit(plan Plan, userCount *int, licenseTags []string
 		"anthropic/claude-instant-v1",
 		"anthropic/claude-instant-1",
 		"anthropic/claude-instant-1.2",
-	}
-	// Switch on GPT models by default if the customer license has the GPT tag.
-	if slices.Contains(licenseTags, GPTLLMAccessTag) {
-		models = append(models, "openai/gpt-4", "openai/gpt-3.5-turbo")
+
+		"openai/gpt-3.5-turbo",
+		"openai/gpt-4",
+		"openai/gpt-4-turbo-preview",
 	}
 	switch plan {
 	// TODO: This is just an example for now.

--- a/internal/licensing/codygateway.go
+++ b/internal/licensing/codygateway.go
@@ -17,7 +17,7 @@ type CodyGatewayRateLimit struct {
 }
 
 // NewCodyGatewayChatRateLimit applies default Cody Gateway access based on the plan.
-func NewCodyGatewayChatRateLimit(plan Plan, userCount *int, licenseTags []string) CodyGatewayRateLimit {
+func NewCodyGatewayChatRateLimit(plan Plan, userCount *int) CodyGatewayRateLimit {
 	uc := 0
 	if userCount != nil {
 		uc = *userCount

--- a/internal/licensing/codygateway_test.go
+++ b/internal/licensing/codygateway_test.go
@@ -10,29 +10,17 @@ import (
 
 func TestNewCodyGatewayChatRateLimit(t *testing.T) {
 	tests := []struct {
-		name        string
-		plan        Plan
-		userCount   *int
-		licenseTags []string
-		want        CodyGatewayRateLimit
+		name      string
+		plan      Plan
+		userCount *int
+		want      CodyGatewayRateLimit
 	}{
 		{
-			name:        "Enterprise plan with GPT tag and user count",
-			plan:        PlanEnterprise1,
-			userCount:   pointers.Ptr(50),
-			licenseTags: []string{GPTLLMAccessTag},
-			want: CodyGatewayRateLimit{
-				AllowedModels:   []string{"anthropic/claude-v1", "anthropic/claude-2", "anthropic/claude-2.0", "anthropic/claude-2.1", "anthropic/claude-instant-v1", "anthropic/claude-instant-1", "anthropic/claude-instant-1.2", "openai/gpt-4", "openai/gpt-3.5-turbo"},
-				Limit:           2500,
-				IntervalSeconds: 60 * 60 * 24,
-			},
-		},
-		{
-			name:      "Enterprise plan with no GPT tag",
+			name:      "Enterprise plan with user count",
 			plan:      PlanEnterprise1,
 			userCount: pointers.Ptr(50),
 			want: CodyGatewayRateLimit{
-				AllowedModels:   []string{"anthropic/claude-v1", "anthropic/claude-2", "anthropic/claude-2.0", "anthropic/claude-2.1", "anthropic/claude-instant-v1", "anthropic/claude-instant-1", "anthropic/claude-instant-1.2"},
+				AllowedModels:   []string{"anthropic/claude-v1", "anthropic/claude-2", "anthropic/claude-2.0", "anthropic/claude-2.1", "anthropic/claude-instant-v1", "anthropic/claude-instant-1", "anthropic/claude-instant-1.2", "openai/gpt-3.5-turbo", "openai/gpt-4", "openai/gpt-4-turbo-preview"},
 				Limit:           2500,
 				IntervalSeconds: 60 * 60 * 24,
 			},
@@ -41,16 +29,16 @@ func TestNewCodyGatewayChatRateLimit(t *testing.T) {
 			name: "Enterprise plan with no user count",
 			plan: PlanEnterprise1,
 			want: CodyGatewayRateLimit{
-				AllowedModels:   []string{"anthropic/claude-v1", "anthropic/claude-2", "anthropic/claude-2.0", "anthropic/claude-2.1", "anthropic/claude-instant-v1", "anthropic/claude-instant-1", "anthropic/claude-instant-1.2"},
+				AllowedModels:   []string{"anthropic/claude-v1", "anthropic/claude-2", "anthropic/claude-2.0", "anthropic/claude-2.1", "anthropic/claude-instant-v1", "anthropic/claude-instant-1", "anthropic/claude-instant-1.2", "openai/gpt-3.5-turbo", "openai/gpt-4", "openai/gpt-4-turbo-preview"},
 				Limit:           50,
 				IntervalSeconds: 60 * 60 * 24,
 			},
 		},
 		{
-			name: "Non-enterprise plan with no GPT tag and no user count",
+			name: "Non-enterprise plan with no user count",
 			plan: "unknown",
 			want: CodyGatewayRateLimit{
-				AllowedModels:   []string{"anthropic/claude-v1", "anthropic/claude-2", "anthropic/claude-2.0", "anthropic/claude-2.1", "anthropic/claude-instant-v1", "anthropic/claude-instant-1", "anthropic/claude-instant-1.2"},
+				AllowedModels:   []string{"anthropic/claude-v1", "anthropic/claude-2", "anthropic/claude-2.0", "anthropic/claude-2.1", "anthropic/claude-instant-v1", "anthropic/claude-instant-1", "anthropic/claude-instant-1.2", "openai/gpt-3.5-turbo", "openai/gpt-4", "openai/gpt-4-turbo-preview"},
 				Limit:           10,
 				IntervalSeconds: 60 * 60 * 24,
 			},
@@ -58,7 +46,7 @@ func TestNewCodyGatewayChatRateLimit(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := NewCodyGatewayChatRateLimit(tt.plan, tt.userCount, tt.licenseTags)
+			got := NewCodyGatewayChatRateLimit(tt.plan, tt.userCount)
 			if diff := cmp.Diff(got, tt.want); diff != "" {
 				t.Fatalf("incorrect rate limit computed: %s", diff)
 			}


### PR DESCRIPTION
Adds GPT3.5, GPT4 Turbo, GPT 4 to the list of supported chat models for enterprise ([thread](https://sourcegraph.slack.com/archives/C012NU3PXA9/p1712103525033819?thread_ts=1712094412.441679&cid=C012NU3PXA9)).

## Test plan
- CI
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
