### PR TITLE
Add postgresql-12-client to server

### DIFF
--- a/wolfi-images/server.yaml
+++ b/wolfi-images/server.yaml
@@ -21,6 +21,7 @@ contents:
     - pcre
     - posix-libc-utils # Adds locale, used by server postgres init scripts
     - postgresql-12
+    - postgresql-12-client
     - postgresql-12-contrib
     - prometheus-postgres-exporter
     - prometheus-alertmanager


### PR DESCRIPTION
This binary has been removed form the postgresql-12 package, and is required for CI integration tests

## Test plan

- CI

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
