### PR TITLE
monitoring: Make gitserver alert less trigger-friendly

### DIFF
--- a/doc/admin/observability/alerts.md
+++ b/doc/admin/observability/alerts.md
@@ -1484,7 +1484,7 @@ Generated query for critical alert: `max((sum by (instance, cmd) (src_gitserver_
 **Descriptions**
 
 - <span class="badge badge-warning">warning</span> gitserver: 0.02s+ echo test command duration for 30s
-- <span class="badge badge-critical">critical</span> gitserver: 1s+ echo test command duration
+- <span class="badge badge-critical">critical</span> gitserver: 1s+ echo test command duration for 1m0s
 
 **Next steps**
 

--- a/monitoring/definitions/git_server.go
+++ b/monitoring/definitions/git_server.go
@@ -158,7 +158,7 @@ func GitServer() *monitoring.Dashboard {
 							Description: "echo test command duration",
 							Query:       "max(src_gitserver_echo_duration_seconds)",
 							Warning:     monitoring.Alert().GreaterOrEqual(0.020).For(30 * time.Second),
-							Critical:    monitoring.Alert().GreaterOrEqual(1),
+							Critical:    monitoring.Alert().GreaterOrEqual(1).For(1 * time.Minute),
 							Panel:       monitoring.Panel().LegendFormat("running commands").Unit(monitoring.Seconds),
 							Owner:       monitoring.ObservableOwnerSource,
 							Interpretation: `


### PR DESCRIPTION
Making sure this doesn't randomly trigger all the time.

Ideally, I would want this to read "more than 3 times in 30 minutes above threshold" or so, but not sure if that's expressable.

## Test plan

Code review.