### PR TITLE
symbols: add metrics and panels for Rockskip

### DIFF
--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -21353,7 +21353,7 @@ To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100501` o
 Query:
 
 ```
-src_rockskip_service_in_flight_search_requests
+sum(src_rockskip_service_in_flight_search_requests)
 ```
 </details>
 
@@ -21379,7 +21379,7 @@ To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100502` o
 Query:
 
 ```
-increase(src_rockskip_service_search_request_errors[5m])
+sum(increase(src_rockskip_service_search_request_errors[5m]))
 ```
 </details>
 
@@ -21430,7 +21430,7 @@ To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100511` o
 Query:
 
 ```
-src_rockskip_service_in_flight_index_jobs
+sum(src_rockskip_service_in_flight_index_jobs)
 ```
 </details>
 
@@ -21457,7 +21457,7 @@ To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100512` o
 Query:
 
 ```
-increase(src_rockskip_service_index_job_errors[5m])
+sum(increase(src_rockskip_service_index_job_errors[5m]))
 ```
 </details>
 
@@ -21484,7 +21484,7 @@ To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100520` o
 Query:
 
 ```
-src_rockskip_service_repos_indexed
+max(src_rockskip_service_repos_indexed)
 ```
 </details>
 

--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -21307,6 +21307,189 @@ sum by (op)(increase(src_codeintel_symbols_gitserver_errors_total{job=~"^symbols
 
 <br />
 
+### Symbols: Rockskip
+
+#### symbols: p95_rockskip_search_request_duration
+
+<p class="subtitle">95th percentile search request duration over 5m</p>
+
+The 95th percentile duration of search requests to Rockskip in seconds. Lower is better.
+
+This panel has no related alerts.
+
+To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100500` on your Sourcegraph instance.
+
+<sub>*Managed by the [Sourcegraph Search Platform team](https://handbook.sourcegraph.com/departments/engineering/teams/search/core).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Query:
+
+```
+histogram_quantile(0.95, sum(rate(src_rockskip_service_search_request_duration_seconds_bucket[5m])) by (le))
+```
+</details>
+
+<br />
+
+#### symbols: rockskip_in_flight_search_requests
+
+<p class="subtitle">Number of in-flight search requests</p>
+
+The number of search requests currently being processed by Rockskip.
+								If there is not much traffic and the requests are served very fast relative to the polling window of Prometheus,
+								it possible that that this number is 0 even if there are search requests being processed.
+
+This panel has no related alerts.
+
+To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100501` on your Sourcegraph instance.
+
+<sub>*Managed by the [Sourcegraph Search Platform team](https://handbook.sourcegraph.com/departments/engineering/teams/search/core).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Query:
+
+```
+src_rockskip_service_in_flight_search_requests
+```
+</details>
+
+<br />
+
+#### symbols: rockskip_search_request_errors
+
+<p class="subtitle">Search request errors every 5m</p>
+
+The number of search requests that returned an error in the last 5 minutes.
+								The errors tracked here are all application errors, grpc errors are not included.
+								We generally want this to be 0.
+
+This panel has no related alerts.
+
+To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100502` on your Sourcegraph instance.
+
+<sub>*Managed by the [Sourcegraph Search Platform team](https://handbook.sourcegraph.com/departments/engineering/teams/search/core).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Query:
+
+```
+increase(src_rockskip_service_search_request_errors[5m])
+```
+</details>
+
+<br />
+
+#### symbols: p95_rockskip_index_job_duration
+
+<p class="subtitle">95th percentile index job duration over 5m</p>
+
+The 95th percentile duration of index jobs in seconds.
+								The range of values is very large, because the metric measure quick delta updates as well as full index jobs.
+								Lower is better.
+
+This panel has no related alerts.
+
+To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100510` on your Sourcegraph instance.
+
+<sub>*Managed by the [Sourcegraph Search Platform team](https://handbook.sourcegraph.com/departments/engineering/teams/search/core).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Query:
+
+```
+histogram_quantile(0.95, sum(rate(src_rockskip_service_index_job_duration_seconds_bucket[5m])) by (le))
+```
+</details>
+
+<br />
+
+#### symbols: rockskip_in_flight_index_jobs
+
+<p class="subtitle">Number of in-flight index jobs</p>
+
+The number of index jobs currently being processed by Rockskip.
+								This includes delta updates as well as full index jobs.
+
+This panel has no related alerts.
+
+To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100511` on your Sourcegraph instance.
+
+<sub>*Managed by the [Sourcegraph Search Platform team](https://handbook.sourcegraph.com/departments/engineering/teams/search/core).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Query:
+
+```
+src_rockskip_service_in_flight_index_jobs
+```
+</details>
+
+<br />
+
+#### symbols: rockskip_index_job_errors
+
+<p class="subtitle">Index job errors every 5m</p>
+
+The number of index jobs that returned an error in the last 5 minutes.
+								If the errors are persistent, users will see alerts in the UI.
+								The service logs will contain more detailed information about the kind of errors.
+								We generally want this to be 0.
+
+This panel has no related alerts.
+
+To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100512` on your Sourcegraph instance.
+
+<sub>*Managed by the [Sourcegraph Search Platform team](https://handbook.sourcegraph.com/departments/engineering/teams/search/core).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Query:
+
+```
+increase(src_rockskip_service_index_job_errors[5m])
+```
+</details>
+
+<br />
+
+#### symbols: rockskip_number_of_repos_indexed
+
+<p class="subtitle">Number of repositories indexed by Rockskip</p>
+
+The number of repositories indexed by Rockskip.
+								Apart from an initial transient phase in which many repos are being indexed,
+								this number should be low and relatively stable and only increase by small increments.
+								To verify if this number makes sense, compare ROCKSKIP_MIN_REPO_SIZE_MB with the repository sizes reported by gitserver_repos table.
+
+This panel has no related alerts.
+
+To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100520` on your Sourcegraph instance.
+
+<sub>*Managed by the [Sourcegraph Search Platform team](https://handbook.sourcegraph.com/departments/engineering/teams/search/core).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Query:
+
+```
+src_rockskip_service_repos_indexed
+```
+</details>
+
+<br />
+
 ### Symbols: Symbols GRPC server metrics
 
 #### symbols: symbols_grpc_request_rate_all_methods
@@ -21317,7 +21500,7 @@ The number of gRPC requests received per second across all methods, aggregated a
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100500` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100600` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Code intelligence team](https://handbook.sourcegraph.com/departments/engineering/teams/code-intelligence).*</sub>
 
@@ -21341,7 +21524,7 @@ The number of gRPC requests received per second broken out per method, aggregate
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100501` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100601` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Code intelligence team](https://handbook.sourcegraph.com/departments/engineering/teams/code-intelligence).*</sub>
 
@@ -21365,7 +21548,7 @@ The percentage of gRPC requests that fail across all methods, aggregated across 
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100510` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100610` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Code intelligence team](https://handbook.sourcegraph.com/departments/engineering/teams/code-intelligence).*</sub>
 
@@ -21389,7 +21572,7 @@ The percentage of gRPC requests that fail per method, aggregated across all inst
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100511` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100611` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Code intelligence team](https://handbook.sourcegraph.com/departments/engineering/teams/code-intelligence).*</sub>
 
@@ -21413,7 +21596,7 @@ The 99th percentile response time per method, aggregated across all instances.
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100520` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100620` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Code intelligence team](https://handbook.sourcegraph.com/departments/engineering/teams/code-intelligence).*</sub>
 
@@ -21437,7 +21620,7 @@ The 90th percentile response time per method, aggregated across all instances.
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100521` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100621` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Code intelligence team](https://handbook.sourcegraph.com/departments/engineering/teams/code-intelligence).*</sub>
 
@@ -21461,7 +21644,7 @@ The 75th percentile response time per method, aggregated across all instances.
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100522` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100622` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Code intelligence team](https://handbook.sourcegraph.com/departments/engineering/teams/code-intelligence).*</sub>
 
@@ -21485,7 +21668,7 @@ The 99.9th percentile total per-RPC response size per method, aggregated across 
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100530` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100630` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Code intelligence team](https://handbook.sourcegraph.com/departments/engineering/teams/code-intelligence).*</sub>
 
@@ -21509,7 +21692,7 @@ The 90th percentile total per-RPC response size per method, aggregated across al
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100531` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100631` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Code intelligence team](https://handbook.sourcegraph.com/departments/engineering/teams/code-intelligence).*</sub>
 
@@ -21533,7 +21716,7 @@ The 75th percentile total per-RPC response size per method, aggregated across al
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100532` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100632` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Code intelligence team](https://handbook.sourcegraph.com/departments/engineering/teams/code-intelligence).*</sub>
 
@@ -21557,7 +21740,7 @@ The 99.9th percentile size of every individual protocol buffer size sent by the 
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100540` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100640` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Code intelligence team](https://handbook.sourcegraph.com/departments/engineering/teams/code-intelligence).*</sub>
 
@@ -21581,7 +21764,7 @@ The 90th percentile size of every individual protocol buffer size sent by the se
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100541` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100641` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Code intelligence team](https://handbook.sourcegraph.com/departments/engineering/teams/code-intelligence).*</sub>
 
@@ -21605,7 +21788,7 @@ The 75th percentile size of every individual protocol buffer size sent by the se
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100542` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100642` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Code intelligence team](https://handbook.sourcegraph.com/departments/engineering/teams/code-intelligence).*</sub>
 
@@ -21629,7 +21812,7 @@ The average number of response messages sent during a streaming RPC method, brok
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100550` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100650` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Code intelligence team](https://handbook.sourcegraph.com/departments/engineering/teams/code-intelligence).*</sub>
 
@@ -21653,7 +21836,7 @@ The rate of all generated gRPC response codes per method, aggregated across all 
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100560` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100660` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Code intelligence team](https://handbook.sourcegraph.com/departments/engineering/teams/code-intelligence).*</sub>
 
@@ -21679,7 +21862,7 @@ The percentage of gRPC requests that fail across all methods (regardless of whet
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100600` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100700` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Code intelligence team](https://handbook.sourcegraph.com/departments/engineering/teams/code-intelligence).*</sub>
 
@@ -21703,7 +21886,7 @@ The percentage of gRPC requests that fail per method (regardless of whether or n
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100601` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100701` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Code intelligence team](https://handbook.sourcegraph.com/departments/engineering/teams/code-intelligence).*</sub>
 
@@ -21727,7 +21910,7 @@ The rate of all generated gRPC response codes per method (regardless of whether 
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100602` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100702` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Code intelligence team](https://handbook.sourcegraph.com/departments/engineering/teams/code-intelligence).*</sub>
 
@@ -21757,7 +21940,7 @@ When debugging, knowing that a particular error comes from the grpc-go library i
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100610` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100710` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Code intelligence team](https://handbook.sourcegraph.com/departments/engineering/teams/code-intelligence).*</sub>
 
@@ -21787,7 +21970,7 @@ When debugging, knowing that a particular error comes from the grpc-go library i
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100611` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100711` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Code intelligence team](https://handbook.sourcegraph.com/departments/engineering/teams/code-intelligence).*</sub>
 
@@ -21817,7 +22000,7 @@ When debugging, knowing that a particular error comes from the grpc-go library i
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100612` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100712` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Code intelligence team](https://handbook.sourcegraph.com/departments/engineering/teams/code-intelligence).*</sub>
 
@@ -21843,7 +22026,7 @@ The percentage of gRPC requests that were retried across all methods, aggregated
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100700` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100800` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Code intelligence team](https://handbook.sourcegraph.com/departments/engineering/teams/code-intelligence).*</sub>
 
@@ -21867,7 +22050,7 @@ The percentage of gRPC requests that were retried aggregated across all "symbols
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100701` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100801` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Code intelligence team](https://handbook.sourcegraph.com/departments/engineering/teams/code-intelligence).*</sub>
 
@@ -21891,7 +22074,7 @@ The count of gRPC requests that were retried aggregated across all "symbols" cli
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100702` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100802` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Code intelligence team](https://handbook.sourcegraph.com/departments/engineering/teams/code-intelligence).*</sub>
 
@@ -21917,7 +22100,7 @@ The duration since the configuration client used by the "symbols" service last s
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100800` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100900` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Infrastructure Org team](https://handbook.sourcegraph.com/departments/engineering/infrastructure).*</sub>
 
@@ -21939,7 +22122,7 @@ src_conf_client_time_since_last_successful_update_seconds{job=~`.*symbols`,insta
 
 Refer to the [alerts reference](./alerts.md#symbols-symbols-site-configuration-duration-since-last-successful-update-by-instance) for 1 alert related to this panel.
 
-To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100801` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100901` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Infrastructure Org team](https://handbook.sourcegraph.com/departments/engineering/infrastructure).*</sub>
 
@@ -21963,7 +22146,7 @@ max(max_over_time(src_conf_client_time_since_last_successful_update_seconds{job=
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100900` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=101000` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Infrastructure Org team](https://handbook.sourcegraph.com/departments/engineering/infrastructure).*</sub>
 
@@ -21985,7 +22168,7 @@ sum by (app_name, db_name) (src_pgsql_conns_max_open{app_name="symbols"})
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100901` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=101001` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Infrastructure Org team](https://handbook.sourcegraph.com/departments/engineering/infrastructure).*</sub>
 
@@ -22007,7 +22190,7 @@ sum by (app_name, db_name) (src_pgsql_conns_open{app_name="symbols"})
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100910` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=101010` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Infrastructure Org team](https://handbook.sourcegraph.com/departments/engineering/infrastructure).*</sub>
 
@@ -22029,7 +22212,7 @@ sum by (app_name, db_name) (src_pgsql_conns_in_use{app_name="symbols"})
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100911` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=101011` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Infrastructure Org team](https://handbook.sourcegraph.com/departments/engineering/infrastructure).*</sub>
 
@@ -22051,7 +22234,7 @@ sum by (app_name, db_name) (src_pgsql_conns_idle{app_name="symbols"})
 
 Refer to the [alerts reference](./alerts.md#symbols-mean-blocked-seconds-per-conn-request) for 2 alerts related to this panel.
 
-To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100920` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=101020` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Infrastructure Org team](https://handbook.sourcegraph.com/departments/engineering/infrastructure).*</sub>
 
@@ -22073,7 +22256,7 @@ sum by (app_name, db_name) (increase(src_pgsql_conns_blocked_seconds{app_name="s
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100930` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=101030` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Infrastructure Org team](https://handbook.sourcegraph.com/departments/engineering/infrastructure).*</sub>
 
@@ -22095,7 +22278,7 @@ sum by (app_name, db_name) (increase(src_pgsql_conns_closed_max_idle{app_name="s
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100931` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=101031` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Infrastructure Org team](https://handbook.sourcegraph.com/departments/engineering/infrastructure).*</sub>
 
@@ -22117,7 +22300,7 @@ sum by (app_name, db_name) (increase(src_pgsql_conns_closed_max_lifetime{app_nam
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100932` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=101032` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Infrastructure Org team](https://handbook.sourcegraph.com/departments/engineering/infrastructure).*</sub>
 
@@ -22151,7 +22334,7 @@ value change independent of deployment events (such as an upgrade), it could ind
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=101000` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=101100` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Code intelligence team](https://handbook.sourcegraph.com/departments/engineering/teams/code-intelligence).*</sub>
 
@@ -22173,7 +22356,7 @@ count by(name) ((time() - container_last_seen{name=~"^symbols.*"}) > 60)
 
 Refer to the [alerts reference](./alerts.md#symbols-container-cpu-usage) for 1 alert related to this panel.
 
-To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=101001` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=101101` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Code intelligence team](https://handbook.sourcegraph.com/departments/engineering/teams/code-intelligence).*</sub>
 
@@ -22195,7 +22378,7 @@ cadvisor_container_cpu_usage_percentage_total{name=~"^symbols.*"}
 
 Refer to the [alerts reference](./alerts.md#symbols-container-memory-usage) for 1 alert related to this panel.
 
-To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=101002` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=101102` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Code intelligence team](https://handbook.sourcegraph.com/departments/engineering/teams/code-intelligence).*</sub>
 
@@ -22220,7 +22403,7 @@ When extremely high, this can indicate a resource usage problem, or can cause pr
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=101003` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=101103` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Code intelligence team](https://handbook.sourcegraph.com/departments/engineering/teams/code-intelligence).*</sub>
 
@@ -22244,7 +22427,7 @@ sum by(name) (rate(container_fs_reads_total{name=~"^symbols.*"}[1h]) + rate(cont
 
 Refer to the [alerts reference](./alerts.md#symbols-provisioning-container-cpu-usage-long-term) for 1 alert related to this panel.
 
-To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=101100` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=101200` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Code intelligence team](https://handbook.sourcegraph.com/departments/engineering/teams/code-intelligence).*</sub>
 
@@ -22266,7 +22449,7 @@ quantile_over_time(0.9, cadvisor_container_cpu_usage_percentage_total{name=~"^sy
 
 Refer to the [alerts reference](./alerts.md#symbols-provisioning-container-memory-usage-long-term) for 1 alert related to this panel.
 
-To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=101101` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=101201` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Code intelligence team](https://handbook.sourcegraph.com/departments/engineering/teams/code-intelligence).*</sub>
 
@@ -22288,7 +22471,7 @@ max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^symbols.*
 
 Refer to the [alerts reference](./alerts.md#symbols-provisioning-container-cpu-usage-short-term) for 1 alert related to this panel.
 
-To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=101110` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=101210` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Code intelligence team](https://handbook.sourcegraph.com/departments/engineering/teams/code-intelligence).*</sub>
 
@@ -22310,7 +22493,7 @@ max_over_time(cadvisor_container_cpu_usage_percentage_total{name=~"^symbols.*"}[
 
 Refer to the [alerts reference](./alerts.md#symbols-provisioning-container-memory-usage-short-term) for 1 alert related to this panel.
 
-To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=101111` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=101211` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Code intelligence team](https://handbook.sourcegraph.com/departments/engineering/teams/code-intelligence).*</sub>
 
@@ -22335,7 +22518,7 @@ When it occurs frequently, it is an indicator of underprovisioning.
 
 Refer to the [alerts reference](./alerts.md#symbols-container-oomkill-events-total) for 1 alert related to this panel.
 
-To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=101112` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=101212` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Code intelligence team](https://handbook.sourcegraph.com/departments/engineering/teams/code-intelligence).*</sub>
 
@@ -22361,7 +22544,7 @@ A high value here indicates a possible goroutine leak.
 
 Refer to the [alerts reference](./alerts.md#symbols-go-goroutines) for 1 alert related to this panel.
 
-To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=101200` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=101300` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Code intelligence team](https://handbook.sourcegraph.com/departments/engineering/teams/code-intelligence).*</sub>
 
@@ -22383,7 +22566,7 @@ max by(instance) (go_goroutines{job=~".*symbols"})
 
 Refer to the [alerts reference](./alerts.md#symbols-go-gc-duration-seconds) for 1 alert related to this panel.
 
-To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=101201` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=101301` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Code intelligence team](https://handbook.sourcegraph.com/departments/engineering/teams/code-intelligence).*</sub>
 
@@ -22407,7 +22590,7 @@ max by(instance) (go_gc_duration_seconds{job=~".*symbols"})
 
 Refer to the [alerts reference](./alerts.md#symbols-pods-available-percentage) for 1 alert related to this panel.
 
-To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=101300` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=101400` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Code intelligence team](https://handbook.sourcegraph.com/departments/engineering/teams/code-intelligence).*</sub>
 

--- a/internal/rockskip/BUILD.bazel
+++ b/internal/rockskip/BUILD.bazel
@@ -32,6 +32,8 @@ go_library(
         "@com_github_grafana_regexp//syntax",
         "@com_github_keegancsmith_sqlf//:sqlf",
         "@com_github_lib_pq//:pq",
+        "@com_github_prometheus_client_golang//prometheus",
+        "@com_github_prometheus_client_golang//prometheus/promauto",
         "@com_github_segmentio_fasthash//fnv1",
         "@com_github_sourcegraph_go_ctags//:go-ctags",
         "@com_github_sourcegraph_log//:log",

--- a/internal/rockskip/search.go
+++ b/internal/rockskip/search.go
@@ -26,6 +26,15 @@ import (
 )
 
 func (s *Service) Search(ctx context.Context, args search.SymbolsParameters) (_ result.Symbols, err error) {
+	s.metrics.searchRunning.Inc()
+	defer func(start time.Time) {
+		s.metrics.searchRunning.Dec()
+		if err != nil {
+			s.metrics.searchFailed.Inc()
+		}
+		s.metrics.searchDuration.Observe(time.Since(start).Seconds())
+	}(time.Now())
+
 	repo := string(args.Repo)
 	commitHash := string(args.CommitID)
 

--- a/monitoring/definitions/symbols.go
+++ b/monitoring/definitions/symbols.go
@@ -61,7 +61,7 @@ func Symbols() *monitoring.Dashboard {
 						{
 							Name:        "rockskip_in_flight_search_requests",
 							Description: "number of in-flight search requests",
-							Query:       `src_rockskip_service_in_flight_search_requests`,
+							Query:       `sum(src_rockskip_service_in_flight_search_requests)`,
 							Panel:       monitoring.Panel().Min(0).With(monitoring.PanelOptions.NoLegend()),
 							Owner:       monitoring.ObservableOwnerSearchCore,
 							NoAlert:     true,
@@ -73,7 +73,7 @@ func Symbols() *monitoring.Dashboard {
 						{
 							Name:        "rockskip_search_request_errors",
 							Description: "search request errors every 5m",
-							Query:       `increase(src_rockskip_service_search_request_errors[5m])`,
+							Query:       `sum(increase(src_rockskip_service_search_request_errors[5m]))`,
 							Panel:       monitoring.Panel().Min(0).With(monitoring.PanelOptions.NoLegend()),
 							Owner:       monitoring.ObservableOwnerSearchCore,
 							NoAlert:     true,
@@ -103,7 +103,7 @@ func Symbols() *monitoring.Dashboard {
 						{
 							Name:        "rockskip_in_flight_index_jobs",
 							Description: "number of in-flight index jobs",
-							Query:       `src_rockskip_service_in_flight_index_jobs`,
+							Query:       `sum(src_rockskip_service_in_flight_index_jobs)`,
 							Panel:       monitoring.Panel().Min(0).With(monitoring.PanelOptions.NoLegend()),
 							Owner:       monitoring.ObservableOwnerSearchCore,
 							NoAlert:     true,
@@ -114,7 +114,7 @@ func Symbols() *monitoring.Dashboard {
 						{
 							Name:        "rockskip_index_job_errors",
 							Description: "index job errors every 5m",
-							Query:       `increase(src_rockskip_service_index_job_errors[5m])`,
+							Query:       `sum(increase(src_rockskip_service_index_job_errors[5m]))`,
 							Panel:       monitoring.Panel().Min(0).With(monitoring.PanelOptions.NoLegend()),
 							Owner:       monitoring.ObservableOwnerSearchCore,
 							NoAlert:     true,
@@ -129,8 +129,8 @@ func Symbols() *monitoring.Dashboard {
 						{
 							Name:        "rockskip_number_of_repos_indexed",
 							Description: "number of repositories indexed by Rockskip",
-							Query:       `src_rockskip_service_repos_indexed`,
-							Panel:       monitoring.Panel().Min(0).With(monitoring.PanelOptions.NoLegend()),
+							Query:       `max(src_rockskip_service_repos_indexed)`, // "max" is used as hack to show only one value instead one per instance
+							Panel:       monitoring.Panel().With(monitoring.PanelOptions.NoLegend()),
 							Owner:       monitoring.ObservableOwnerSearchCore,
 							NoAlert:     true,
 							Interpretation: `

--- a/monitoring/definitions/symbols.go
+++ b/monitoring/definitions/symbols.go
@@ -3,6 +3,8 @@ package definitions
 import (
 	"fmt"
 
+	"github.com/grafana-tools/sdk"
+
 	"github.com/sourcegraph/sourcegraph/monitoring/definitions/shared"
 	"github.com/sourcegraph/sourcegraph/monitoring/monitoring"
 )
@@ -40,6 +42,106 @@ func Symbols() *monitoring.Dashboard {
 			shared.CodeIntelligence.NewSymbolsCacheJanitorGroup(containerName),
 			shared.CodeIntelligence.NewSymbolsRepositoryFetcherGroup(containerName),
 			shared.CodeIntelligence.NewSymbolsGitserverClientGroup(containerName),
+
+			{
+				Title:  "Rockskip",
+				Hidden: true,
+				Rows: []monitoring.Row{
+					{
+						{
+							Name:        "p95_rockskip_search_request_duration",
+							Description: "95th percentile search request duration over 5m",
+							Query:       "histogram_quantile(0.95, sum(rate(src_rockskip_service_search_request_duration_seconds_bucket[5m])) by (le))",
+							Panel:       monitoring.Panel().LegendFormat("duration").Unit(monitoring.Seconds).With(monitoring.PanelOptions.NoLegend()),
+							Owner:       monitoring.ObservableOwnerSearchCore,
+							NoAlert:     true,
+							Interpretation: `
+								The 95th percentile duration of search requests to Rockskip in seconds. Lower is better.`,
+						},
+						{
+							Name:        "rockskip_in_flight_search_requests",
+							Description: "number of in-flight search requests",
+							Query:       `src_rockskip_service_in_flight_search_requests`,
+							Panel:       monitoring.Panel().Min(0).With(monitoring.PanelOptions.NoLegend()),
+							Owner:       monitoring.ObservableOwnerSearchCore,
+							NoAlert:     true,
+							Interpretation: `
+								The number of search requests currently being processed by Rockskip.
+								If there is not much traffic and the requests are served very fast relative to the polling window of Prometheus,
+								it possible that that this number is 0 even if there are search requests being processed.`,
+						},
+						{
+							Name:        "rockskip_search_request_errors",
+							Description: "search request errors every 5m",
+							Query:       `increase(src_rockskip_service_search_request_errors[5m])`,
+							Panel:       monitoring.Panel().Min(0).With(monitoring.PanelOptions.NoLegend()),
+							Owner:       monitoring.ObservableOwnerSearchCore,
+							NoAlert:     true,
+							Interpretation: `
+								The number of search requests that returned an error in the last 5 minutes.
+								The errors tracked here are all application errors, grpc errors are not included.
+								We generally want this to be 0.`,
+						},
+					},
+					{
+						{
+							Name:        "p95_rockskip_index_job_duration",
+							Description: "95th percentile index job duration over 5m",
+							Query:       "histogram_quantile(0.95, sum(rate(src_rockskip_service_index_job_duration_seconds_bucket[5m])) by (le))",
+							Panel: monitoring.Panel().LegendFormat("duration").Unit(monitoring.Seconds).With(
+								monitoring.PanelOptions.NoLegend(),
+								func(o monitoring.Observable, p *sdk.Panel) {
+									p.GraphPanel.Yaxes[0].LogBase = 2 // log to account for huge range of "new" vs "delta" index.
+								}),
+							Owner:   monitoring.ObservableOwnerSearchCore,
+							NoAlert: true,
+							Interpretation: `
+								The 95th percentile duration of index jobs in seconds.
+								The range of values is very large, because the metric measure quick delta updates as well as full index jobs.
+								Lower is better.`,
+						},
+						{
+							Name:        "rockskip_in_flight_index_jobs",
+							Description: "number of in-flight index jobs",
+							Query:       `src_rockskip_service_in_flight_index_jobs`,
+							Panel:       monitoring.Panel().Min(0).With(monitoring.PanelOptions.NoLegend()),
+							Owner:       monitoring.ObservableOwnerSearchCore,
+							NoAlert:     true,
+							Interpretation: `
+								The number of index jobs currently being processed by Rockskip.
+								This includes delta updates as well as full index jobs.`,
+						},
+						{
+							Name:        "rockskip_index_job_errors",
+							Description: "index job errors every 5m",
+							Query:       `increase(src_rockskip_service_index_job_errors[5m])`,
+							Panel:       monitoring.Panel().Min(0).With(monitoring.PanelOptions.NoLegend()),
+							Owner:       monitoring.ObservableOwnerSearchCore,
+							NoAlert:     true,
+							Interpretation: `
+								The number of index jobs that returned an error in the last 5 minutes.
+								If the errors are persistent, users will see alerts in the UI.
+								The service logs will contain more detailed information about the kind of errors.
+								We generally want this to be 0.`,
+						},
+					},
+					{
+						{
+							Name:        "rockskip_number_of_repos_indexed",
+							Description: "number of repositories indexed by Rockskip",
+							Query:       `src_rockskip_service_repos_indexed`,
+							Panel:       monitoring.Panel().Min(0).With(monitoring.PanelOptions.NoLegend()),
+							Owner:       monitoring.ObservableOwnerSearchCore,
+							NoAlert:     true,
+							Interpretation: `
+								The number of repositories indexed by Rockskip.
+								Apart from an initial transient phase in which many repos are being indexed,
+								this number should be low and relatively stable and only increase by small increments.
+								To verify if this number makes sense, compare ROCKSKIP_MIN_REPO_SIZE_MB with the repository sizes reported by gitserver_repos table.`,
+						},
+					},
+				},
+			},
 
 			shared.NewGRPCServerMetricsGroup(
 				shared.GRPCServerMetricsOptions{


### PR DESCRIPTION
This adds basic metrics to Rockskip and exposes them in a new panel group "Rockskip" on the dashboard of the Symbol service.

Test plan:
- manual testing: I enabled Rockskip locally, browsed unindexed commits and verified that the dashboards make sense. For example: I navigated to unindexed repos which caused search request errors and triggered index jobs.

<img width="1396" alt="Screenshot 2024-04-03 at 17 37 05" src="https://github.com/sourcegraph/sourcegraph/assets/26413131/86d179b0-e594-403f-9ba2-6a930295771e">

