### PR TITLE
build-tracker: fix nil pointer in old build purger & enabling auto-rollout with MSP

### DIFF
--- a/dev/build-tracker/BUILD.bazel
+++ b/dev/build-tracker/BUILD.bazel
@@ -96,10 +96,9 @@ oci_push(
     repository = image_repository("build-tracker"),
 )
 
-# automatic deployment not enabled for initial testing
-# msp_delivery(
-#     name = "msp_deploy",
-#     gcp_project = "build-tracker-prod-59bf",
-#     msp_service_id = "build-tracker",
-#     repository = "us.gcr.io/sourcegraph-dev/build-tracker",
-# )
+msp_delivery(
+    name = "msp_deploy",
+    gcp_project = "build-tracker-prod-59bf",
+    msp_service_id = "build-tracker",
+    repository = "us.gcr.io/sourcegraph-dev/build-tracker",
+)

--- a/dev/build-tracker/background.go
+++ b/dev/build-tracker/background.go
@@ -25,5 +25,5 @@ func deleteOldBuilds(logger log.Logger, store *build.Store, every, window time.D
 		logger.Info("deleting old builds", log.Int("oldBuildCount", len(oldBuilds)))
 		store.DelByBuildNumber(oldBuilds...)
 		return nil
-	}), goroutine.WithInterval(every))
+	}), goroutine.WithInterval(every), goroutine.WithName("old-build-purger"))
 }

--- a/dev/build-tracker/main.go
+++ b/dev/build-tracker/main.go
@@ -284,9 +284,11 @@ type Service struct{}
 func (s Service) Initialize(ctx context.Context, logger log.Logger, contract runtime.Contract, config config.Config) (background.Routine, error) {
 	logger.Info("config loaded from environment", log.Object("config", log.String("SlackChannel", config.SlackChannel), log.Bool("Production", config.Production)))
 
+	server := NewServer(fmt.Sprintf(":%d", contract.Port), logger, config)
+
 	return background.CombinedRoutine{
-		NewServer(fmt.Sprintf(":%d", contract.Port), logger, config),
-		deleteOldBuilds(logger, nil, CleanUpInterval, BuildExpiryWindow),
+		server,
+		deleteOldBuilds(logger, server.store, CleanUpInterval, BuildExpiryWindow),
 	}, nil
 }
 


### PR DESCRIPTION
James said I can enable this now :clueless:

## Test plan

Ran locally, no more panic 
