### PR TITLE
msp: look in //... for msp-deliverables, not only //cmd/...

### DIFF
--- a/.aspect/workflows/config.yaml
+++ b/.aspect/workflows/config.yaml
@@ -40,7 +40,7 @@ tasks:
             only_on_change: true
             branches:
               - '^main$'
-        - deliverable: 'attr(tags, "msp-deliverable", //cmd/...)'
+        - deliverable: 'attr(tags, "msp-deliverable", //...)'
           condition:
             branches:
               - '^main$'


### PR DESCRIPTION
Got joshed, feelsbad

## Test plan

```
$ bazel query 'attr(tags, "msp-deliverable", //...)'
//cmd/msp-example:msp_deploy
//dev/build-tracker:msp_deploy
```
