### PR TITLE
build-tracker: update healthz endpoint for MSP deployment expectations

### DIFF
--- a/dev/build-tracker/main.go
+++ b/dev/build-tracker/main.go
@@ -60,7 +60,7 @@ func NewServer(addr string, logger log.Logger, c config.Config) *Server {
 	// Register routes the the server will be responding too
 	r := mux.NewRouter()
 	r.Path("/buildkite").HandlerFunc(server.handleEvent).Methods(http.MethodPost)
-	r.Path("/healthz").HandlerFunc(server.handleHealthz).Methods(http.MethodGet)
+	r.Path("/-/healthz").HandlerFunc(server.handleHealthz).Methods(http.MethodGet)
 
 	debug := r.PathPrefix("/-/debug").Subrouter()
 	debug.Path("/{buildNumber}").HandlerFunc(server.handleGetBuild).Methods(http.MethodGet)


### PR DESCRIPTION
We can use `contract.RegisterDiagnosticsHandlers` later, requires more work due to gorilla/mux incompatibilities 

## Test plan

curl'd locally
