### PR TITLE
Svelte: Avatar size bug fix

### DIFF
--- a/client/web-sveltekit/src/lib/Avatar.stories.svelte
+++ b/client/web-sveltekit/src/lib/Avatar.stories.svelte
@@ -1,7 +1,9 @@
 <script lang="ts" context="module">
-    import { Story } from '@storybook/addon-svelte-csf'
-    import Avatar from './Avatar.svelte'
     import { faker } from '@faker-js/faker'
+    import { Story } from '@storybook/addon-svelte-csf'
+
+    import type { Avatar_Person } from './Avatar.gql'
+    import Avatar from './Avatar.svelte'
 
     export const meta = {
         component: Avatar,
@@ -10,16 +12,26 @@
 
 <script lang="ts">
     faker.seed(1)
-    const avatarURL = faker.internet.avatar()
-    const username = faker.internet.userName()
-    const displayName = `${faker.person.firstName()} ${faker.person.lastName()}`
+
+    const avatar: Avatar_Person = {
+        // Having __typename is relevant here because getName() uses it
+        // to determine the initials of a person to display in the Avatar.
+        __typename: 'Person',
+        avatarURL: faker.internet.avatar(),
+        displayName: `${faker.person.firstName()} ${faker.person.lastName()}`,
+        name: faker.internet.userName(),
+    }
 </script>
 
 <Story name="Default">
-    <h2>With <code>avatarURL</code></h2>
-    <Avatar avatar={{ avatarURL, displayName: null }} />
-    <h2>With <code>username</code> "{username}"</h2>
-    <Avatar avatar={{ username, avatarURL: null, displayName: null }} />
-    <h2>With <code>displayName</code> "{displayName}"</h2>
-    <Avatar avatar={{ displayName, avatarURL: null, username }} />
+    <h2>With <code>avatarURL</code>and default size</h2>
+    <Avatar {avatar} />
+    <h2>With <code>avatarURL</code>and custom size</h2>
+    <Avatar {avatar} --avatar-size="3rem" />
+    <h2>Without <code>avatarURL</code>and default size</h2>
+    <Avatar avatar={{ ...avatar, avatarURL: null }} />
+    <h2>Without <code>avatarURL</code>and custom size</h2>
+    <Avatar avatar={{ ...avatar, avatarURL: null }} --avatar-size="6rem" />
+    <h2>Without <code>avatarURL</code>and huge size</h2>
+    <Avatar avatar={{ ...avatar, avatarURL: null }} --avatar-size="15rem" />
 </Story>

--- a/client/web-sveltekit/src/lib/Avatar.svelte
+++ b/client/web-sveltekit/src/lib/Avatar.svelte
@@ -35,11 +35,20 @@
     <img src={avatarURL} role="presentation" aria-hidden="true" alt="Avatar of {name}" />
 {:else}
     <div>
-        <span>{getInitials(name)}</span>
+        <span>
+            {getInitials(name)}
+        </span>
     </div>
 {/if}
 
 <style lang="scss">
+    span {
+        z-index: 1;
+        color: var(--white);
+        // defaults to var(--icon-inline-size) if --avatar-size is not set
+        font-size: calc(var(--avatar-size, var(--icon-inline-size)) * 0.5);
+    }
+
     img,
     div {
         isolation: isolate;
@@ -67,11 +76,5 @@
         border-radius: 50%;
         background: linear-gradient(to right, var(--logo-purple), var(--logo-blue));
         mask-image: linear-gradient(to bottom, #000000, transparent);
-    }
-
-    span {
-        z-index: 1;
-        color: var(--white);
-        font-size: calc(var(--avatar-size) * 0.5);
     }
 </style>

--- a/client/web-sveltekit/src/lib/Avatar.svelte
+++ b/client/web-sveltekit/src/lib/Avatar.svelte
@@ -35,9 +35,7 @@
     <img src={avatarURL} role="presentation" aria-hidden="true" alt="Avatar of {name}" />
 {:else}
     <div>
-        <span>
-            {getInitials(name)}
-        </span>
+        <span>{getInitials(name)}</span>
     </div>
 {/if}
 
@@ -45,12 +43,18 @@
     span {
         z-index: 1;
         color: var(--white);
-        // defaults to var(--icon-inline-size) if --avatar-size is not set
-        font-size: calc(var(--avatar-size, var(--icon-inline-size)) * 0.5);
+        font-size: calc(var(--size) * 0.5);
     }
 
     img,
     div {
+        --min-size: 1rem;
+        --size: var(--avatar-size, var(--icon-inline-size, var(--min-size)));
+
+        min-width: var(--min-size);
+        min-height: var(--min-size);
+        width: var(--size);
+        height: var(--size);
         isolation: isolate;
         display: inline-flex;
         border-radius: 50%;
@@ -58,12 +62,8 @@
         color: var(--color-bg-1);
         align-items: center;
         justify-content: center;
-        min-width: 1rem;
-        min-height: 1rem;
         position: relative;
         background: linear-gradient(to bottom, var(--logo-purple), var(--logo-orange));
-        width: var(--avatar-size, var(--icon-inline-size));
-        height: var(--avatar-size, var(--icon-inline-size));
     }
 
     div::after {

--- a/client/web-sveltekit/src/lib/Avatar.svelte
+++ b/client/web-sveltekit/src/lib/Avatar.svelte
@@ -72,6 +72,6 @@
     span {
         z-index: 1;
         color: var(--white);
-        font-size: 0.5rem;
+        font-size: calc(var(--avatar-size) * 0.5);
     }
 </style>

--- a/client/web-sveltekit/src/lib/Commit.svelte
+++ b/client/web-sveltekit/src/lib/Commit.svelte
@@ -3,11 +3,12 @@
 <script lang="ts">
     import { mdiDotsHorizontal } from '@mdi/js'
 
-    import type { Commit } from './Commit.gql'
-    import Icon from '$lib/Icon.svelte'
     import Avatar from '$lib/Avatar.svelte'
+    import Icon from '$lib/Icon.svelte'
     import Timestamp from '$lib/Timestamp.svelte'
     import Tooltip from '$lib/Tooltip.svelte'
+
+    import type { Commit } from './Commit.gql'
 
     export let commit: Commit
     export let alwaysExpanded: boolean = false
@@ -33,7 +34,7 @@
 <div class="root">
     <div class="avatar">
         <Tooltip tooltip={authorAvatarTooltip}>
-            <Avatar avatar={author} />
+            <Avatar avatar={author} --avatar-size="1.5rem" />
         </Tooltip>
     </div>
     {#if committer && committer.name !== author.name}

--- a/client/web-sveltekit/src/lib/repo/HistoryPanel.svelte
+++ b/client/web-sveltekit/src/lib/repo/HistoryPanel.svelte
@@ -75,7 +75,7 @@
                 {@const selected = commit.abbreviatedOID === selectedRev}
                 <tr class:selected use:scrollIntoView={selected}>
                     <td>
-                        <Avatar avatar={commit.author.person} --avatar-size="1rem" />&nbsp;
+                        <Avatar avatar={commit.author.person} />&nbsp;
                         {commit.author.person.displayName}
                     </td>
                     <td class="subject">

--- a/client/web-sveltekit/src/lib/repo/HistoryPanel.svelte
+++ b/client/web-sveltekit/src/lib/repo/HistoryPanel.svelte
@@ -75,7 +75,7 @@
                 {@const selected = commit.abbreviatedOID === selectedRev}
                 <tr class:selected use:scrollIntoView={selected}>
                     <td>
-                        <Avatar avatar={commit.author.person} />&nbsp;
+                        <Avatar avatar={commit.author.person} --avatar-size="1rem" />&nbsp;
                         {commit.author.person.displayName}
                     </td>
                     <td class="subject">

--- a/client/web-sveltekit/src/lib/repo/LastCommit.stories.svelte
+++ b/client/web-sveltekit/src/lib/repo/LastCommit.stories.svelte
@@ -1,0 +1,55 @@
+<script lang="ts" context="module">
+    import { faker } from '@faker-js/faker'
+    import { Story } from '@storybook/addon-svelte-csf'
+
+    import type { LastCommitFragment } from './LastCommit.gql'
+    import LastCommit from './LastCommit.svelte'
+
+    export const meta = {
+        component: LastCommit,
+    }
+</script>
+
+<script lang="ts">
+    faker.seed(1)
+
+    const withAvatar: LastCommitFragment = {
+        id: faker.datatype.number.toString(),
+        abbreviatedOID: faker.datatype.number.toString(),
+        subject: faker.lorem.sentence(),
+        canonicalURL: faker.internet.url(),
+        author: {
+            date: new Date().toISOString(),
+            person: {
+                __typename: 'Person',
+                displayName: `${faker.person.firstName()} ${faker.person.lastName()}`,
+                name: faker.internet.userName(),
+                avatarURL: faker.internet.avatar(),
+            },
+        },
+    }
+
+    const withoutAvatar: LastCommitFragment = {
+        id: faker.datatype.number.toString(),
+        abbreviatedOID: faker.datatype.number.toString(),
+        subject: faker.lorem.sentence(),
+        canonicalURL: faker.internet.url(),
+        author: {
+            date: new Date().toISOString(),
+            person: {
+                __typename: 'Person',
+                displayName: `${faker.person.firstName()} ${faker.person.lastName()}`,
+                name: faker.internet.userName(),
+                avatarURL: null,
+            },
+        },
+    }
+</script>
+
+<Story name="Default">
+    <h2>With <code>avatarURL</code></h2>
+    <LastCommit lastCommit={withAvatar} />
+    <br />
+    <h2>Without <code>avatarURL</code></h2>
+    <LastCommit lastCommit={withoutAvatar} />
+</Story>

--- a/client/web-sveltekit/src/lib/repo/LastCommit.svelte
+++ b/client/web-sveltekit/src/lib/repo/LastCommit.svelte
@@ -15,7 +15,7 @@
 
 <div class="last-commit">
     <div class="avatar">
-        <Avatar avatar={user} --avatar-size="1rem" />
+        <Avatar avatar={user} />
     </div>
 
     <div class="display-name">
@@ -40,6 +40,13 @@
 </div>
 
 <style lang="scss">
+    .avatar {
+        align-items: center;
+        display: flex;
+        flex-flow: row nowrap;
+        margin-right: 0.25rem;
+    }
+
     .commit-date {
         color: var(--text-muted);
     }
@@ -65,12 +72,5 @@
         justify-content: space-between;
         margin-right: 0.5rem;
         white-space: nowrap;
-    }
-
-    .avatar {
-        align-items: center;
-        display: flex;
-        flex-flow: row nowrap;
-        margin-right: 0.25rem;
     }
 </style>

--- a/client/web-sveltekit/src/lib/repo/LastCommit.svelte
+++ b/client/web-sveltekit/src/lib/repo/LastCommit.svelte
@@ -15,7 +15,7 @@
 
 <div class="last-commit">
     <div class="avatar">
-        <Avatar avatar={user} />
+        <Avatar avatar={user} --avatar-size="1rem" />
     </div>
 
     <div class="display-name">

--- a/client/web-sveltekit/src/lib/repo/LastCommit.svelte
+++ b/client/web-sveltekit/src/lib/repo/LastCommit.svelte
@@ -19,23 +19,17 @@
     </div>
 
     <div class="display-name">
-        <small>
-            {user.name}
-        </small>
+        <small>{user.name}</small>
     </div>
 
     <div class="commit-message">
         <a href={canonicalURL}>
-            <small>
-                {commitMessage}
-            </small>
+            <small>{commitMessage}</small>
         </a>
     </div>
 
     <div class="commit-date">
-        <small>
-            {commitDate}
-        </small>
+        <small>{commitDate}</small>
     </div>
 </div>
 
@@ -72,5 +66,6 @@
         justify-content: space-between;
         margin-right: 0.5rem;
         white-space: nowrap;
+        max-width: 400px;
     }
 </style>

--- a/client/web-sveltekit/src/routes/UserMenu.svelte
+++ b/client/web-sveltekit/src/routes/UserMenu.svelte
@@ -1,12 +1,14 @@
 <script lang="ts">
-    import Icon from '$lib/Icon.svelte'
+    import { mdiChevronDown, mdiChevronUp, mdiOpenInNew } from '@mdi/js'
+    import { writable } from 'svelte/store'
+
     import Avatar from '$lib/Avatar.svelte'
-    import type { UserMenu_User } from './UserMenu.gql'
+    import Icon from '$lib/Icon.svelte'
     import { ThemeSetting, themeSetting } from '$lib/theme'
     import { DropdownMenu, MenuLink, MenuRadioGroup, MenuSeparator, Submenu } from '$lib/wildcard'
     import { getButtonClassName } from '$lib/wildcard/Button'
-    import { mdiChevronDown, mdiChevronUp, mdiOpenInNew } from '@mdi/js'
-    import { writable } from 'svelte/store'
+
+    import type { UserMenu_User } from './UserMenu.gql'
 
     const MAX_VISIBLE_ORGS = 5
 
@@ -22,7 +24,7 @@
     aria-label="{$open ? 'Close' : 'Open'} user menu"
 >
     <svelte:fragment slot="trigger">
-        <Avatar avatar={user} />
+        <Avatar avatar={user} --avatar-size="1.5rem" />
         <Icon svgPath={$open ? mdiChevronUp : mdiChevronDown} aria-hidden={true} inline />
     </svelte:fragment>
     <h6>Signed in as <strong>@{user.username}</strong></h6>

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/-/stats/contributors/+page.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/-/stats/contributors/+page.svelte
@@ -1,15 +1,15 @@
 <script lang="ts">
     import { goto } from '$app/navigation'
     import { page } from '$app/stores'
+    import Avatar from '$lib/Avatar.svelte'
     import LoadingSpinner from '$lib/LoadingSpinner.svelte'
     import Paginator from '$lib/Paginator.svelte'
     import Timestamp from '$lib/Timestamp.svelte'
-    import Avatar from '$lib/Avatar.svelte'
     import { createPromiseStore } from '$lib/utils'
     import { Alert, Button, ButtonGroup } from '$lib/wildcard'
-    import type { ContributorConnection } from './page.gql'
 
     import type { PageData } from './$types'
+    import type { ContributorConnection } from './page.gql'
 
     export let data: PageData
 
@@ -80,10 +80,13 @@
                         {@const commit = contributor.commits.nodes[0]}
                         <tr>
                             <td
-                                ><span><Avatar avatar={contributor.person} /></span>&nbsp;<span
-                                    >{contributor.person.displayName}</span
-                                ></td
-                            >
+                                ><span>
+                                    <Avatar avatar={contributor.person} --avatar-size="1.5rem" />
+                                </span>&nbsp;
+                                <span>
+                                    {contributor.person.displayName}
+                                </span>
+                            </td>
                             <td
                                 ><Timestamp date={new Date(commit.author.date)} strict />:
                                 <a href={commit.canonicalURL}>{commit.subject}</a></td

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/-/stats/contributors/+page.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/-/stats/contributors/+page.svelte
@@ -80,12 +80,8 @@
                         {@const commit = contributor.commits.nodes[0]}
                         <tr>
                             <td
-                                ><span>
-                                    <Avatar avatar={contributor.person} --avatar-size="1.5rem" />
-                                </span>&nbsp;
-                                <span>
-                                    {contributor.person.displayName}
-                                </span>
+                                ><span><Avatar avatar={contributor.person} --avatar-size="1.5rem" /></span>&nbsp;
+                                <span>{contributor.person.displayName}</span>
                             </td>
                             <td
                                 ><Timestamp date={new Date(commit.author.date)} strict />:

--- a/client/web-sveltekit/src/routes/search/PersonSearchResult.svelte
+++ b/client/web-sveltekit/src/routes/search/PersonSearchResult.svelte
@@ -1,14 +1,15 @@
 <svelte:options immutable />
 
 <script lang="ts">
-    import Icon from '$lib/Icon.svelte'
     import { mdiAccount } from '@mdi/js'
+
+    import Avatar from '$lib/Avatar.svelte'
+    import Icon from '$lib/Icon.svelte'
+    import { getOwnerDisplayName, getOwnerMatchURL, buildSearchURLQueryForOwner } from '$lib/search/results'
+    import type { PersonMatch } from '$lib/shared'
 
     import SearchResult from './SearchResult.svelte'
     import { getSearchResultsContext } from './searchResultsContext'
-    import { getOwnerDisplayName, getOwnerMatchURL, buildSearchURLQueryForOwner } from '$lib/search/results'
-    import Avatar from '$lib/Avatar.svelte'
-    import type { PersonMatch } from '$lib/shared'
 
     export let result: PersonMatch
 
@@ -23,6 +24,7 @@
     <Avatar
         slot="icon"
         avatar={{ displayName, username: result.user?.username ?? '', avatarURL: result.user?.avatarURL ?? null }}
+        --avatar-size="1.5rem"
     />
     <div slot="title">
         &nbsp;


### PR DESCRIPTION
This (small) PR adds the `--avatar-size` property to any instance of the `Avatar` svelte component where needed. 
<img width="772" alt="Screenshot 2024-04-03 at 11 09 37 AM" src="https://github.com/sourcegraph/sourcegraph/assets/62355966/217f6252-985f-4960-bb60-26a954c76fbb">
## Test plan
Manual testing
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
