### PR TITLE
feat(rel): plug upgradetest into release tests

### DIFF
--- a/dev/ci/internal/ci/pipeline.go
+++ b/dev/ci/internal/ci/pipeline.go
@@ -278,7 +278,7 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 		)
 	default:
 		// Executor VM image
-		alwaysRebuild := c.MessageFlags.SkipHashCompare || c.RunType.Is(runtype.ReleaseBranch, runtype.TaggedRelease, runtype.InternalRelease) || c.Diff.Has(changed.ExecutorVMImage)
+		// alwaysRebuild := c.MessageFlags.SkipHashCompare || c.RunType.Is(runtype.ReleaseBranch, runtype.TaggedRelease, runtype.InternalRelease) || c.Diff.Has(changed.ExecutorVMImage)
 		// Slow image builds
 		imageBuildOps := operations.NewNamedSet("Image builds")
 
@@ -290,10 +290,10 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 			runtype.InternalRelease,
 			runtype.CloudEphemeral,
 		) {
-			imageBuildOps.Append(bazelBuildExecutorVM(c, alwaysRebuild))
-			if c.RunType.Is(runtype.ReleaseBranch, runtype.TaggedRelease) || c.Diff.Has(changed.ExecutorDockerRegistryMirror) {
-				imageBuildOps.Append(bazelBuildExecutorDockerMirror(c))
-			}
+			// imageBuildOps.Append(bazelBuildExecutorVM(c, alwaysRebuild))
+			// if c.RunType.Is(runtype.ReleaseBranch, runtype.TaggedRelease) || c.Diff.Has(changed.ExecutorDockerRegistryMirror) {
+			// 	imageBuildOps.Append(bazelBuildExecutorDockerMirror(c))
+			// }
 		}
 		ops.Merge(imageBuildOps)
 

--- a/dev/ci/internal/ci/pipeline.go
+++ b/dev/ci/internal/ci/pipeline.go
@@ -316,11 +316,12 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 		publishOpsDev.Append(bazelPushImagesCandidates(c))
 		ops.Merge(publishOpsDev)
 
+		// TODO faster QA
 		// End-to-end tests
-		ops.Merge(operations.NewNamedSet("End-to-end tests",
-			executorsE2E(c),
-			// testUpgrade(c.candidateImageTag(), minimumUpgradeableVersion),
-		))
+		// ops.Merge(operations.NewNamedSet("End-to-end tests",
+		// 	executorsE2E(c),
+		// 	// testUpgrade(c.candidateImageTag(), minimumUpgradeableVersion),
+		// ))
 
 		// Wolfi package and base images
 		packageOps, apkoOps := addWolfiOps(c)
@@ -337,13 +338,14 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 		// Add final artifacts
 		publishOps := operations.NewNamedSet("Publish images")
 		// Executor VM image
-		if c.RunType.Is(runtype.MainBranch, runtype.TaggedRelease, runtype.InternalRelease) {
-			publishOps.Append(bazelPublishExecutorVM(c, alwaysRebuild))
-			publishOps.Append(bazelPublishExecutorBinary(c))
-			if c.RunType.Is(runtype.TaggedRelease) || c.Diff.Has(changed.ExecutorDockerRegistryMirror) {
-				publishOps.Append(bazelPublishExecutorDockerMirror(c))
-			}
-		}
+		// TODO Faster QA
+		// if c.RunType.Is(runtype.MainBranch, runtype.TaggedRelease, runtype.InternalRelease) {
+		// 	publishOps.Append(bazelPublishExecutorVM(c, alwaysRebuild))
+		// 	publishOps.Append(bazelPublishExecutorBinary(c))
+		// 	if c.RunType.Is(runtype.TaggedRelease) || c.Diff.Has(changed.ExecutorDockerRegistryMirror) {
+		// 		publishOps.Append(bazelPublishExecutorDockerMirror(c))
+		// 	}
+		// }
 
 		// Final Bazel images
 		publishOps.Append(bazelPushImagesFinal(c))

--- a/dev/ci/internal/ci/pipeline.go
+++ b/dev/ci/internal/ci/pipeline.go
@@ -282,19 +282,19 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 		// Slow image builds
 		imageBuildOps := operations.NewNamedSet("Image builds")
 
-		if c.RunType.Is(
-			runtype.MainDryRun,
-			runtype.MainBranch,
-			runtype.ReleaseBranch,
-			runtype.TaggedRelease,
-			runtype.InternalRelease,
-			runtype.CloudEphemeral,
-		) {
-			// imageBuildOps.Append(bazelBuildExecutorVM(c, alwaysRebuild))
-			// if c.RunType.Is(runtype.ReleaseBranch, runtype.TaggedRelease) || c.Diff.Has(changed.ExecutorDockerRegistryMirror) {
-			// 	imageBuildOps.Append(bazelBuildExecutorDockerMirror(c))
-			// }
-		}
+		// if c.RunType.Is(
+		// 	runtype.MainDryRun,
+		// 	runtype.MainBranch,
+		// 	runtype.ReleaseBranch,
+		// 	runtype.TaggedRelease,
+		// 	runtype.InternalRelease,
+		// 	runtype.CloudEphemeral,
+		// ) {
+		// 	// imageBuildOps.Append(bazelBuildExecutorVM(c, alwaysRebuild))
+		// 	// if c.RunType.Is(runtype.ReleaseBranch, runtype.TaggedRelease) || c.Diff.Has(changed.ExecutorDockerRegistryMirror) {
+		// 	// 	imageBuildOps.Append(bazelBuildExecutorDockerMirror(c))
+		// 	// }
+		// }
 		ops.Merge(imageBuildOps)
 
 		// Core tests

--- a/dev/ci/internal/ci/pipeline.go
+++ b/dev/ci/internal/ci/pipeline.go
@@ -290,10 +290,10 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 			runtype.InternalRelease,
 			runtype.CloudEphemeral,
 		) {
-			// imageBuildOps.Append(bazelBuildExecutorVM(c, alwaysRebuild))
-			// if c.RunType.Is(runtype.ReleaseBranch, runtype.TaggedRelease) || c.Diff.Has(changed.ExecutorDockerRegistryMirror) {
-			// 	imageBuildOps.Append(bazelBuildExecutorDockerMirror(c))
-			// }
+			imageBuildOps.Append(bazelBuildExecutorVM(c, alwaysRebuild))
+			if c.RunType.Is(runtype.ReleaseBranch, runtype.TaggedRelease) || c.Diff.Has(changed.ExecutorDockerRegistryMirror) {
+				imageBuildOps.Append(bazelBuildExecutorDockerMirror(c))
+			}
 		}
 		ops.Merge(imageBuildOps)
 

--- a/release.yaml
+++ b/release.yaml
@@ -109,8 +109,12 @@ test:
     #     fi
     - name: 'db:migration:coherence_test'
       cmd: |
+        aspectRC="/tmp/aspect-generated.bazelrc"
+        rosetta bazelrc > "$aspectRC"
+        bazelrc=(--bazelrc="$aspectRC" --bazelrc=.aspect/bazelrc/ci.sourcegraph.bazelrc)
+
         # Hardcoding version, as for now I just want to make sure this works in CI.
-        bazel run //testing/tools/upgradetest:sh_upgradetest -- auto --post-release-version=5.3.9071 --avs 5.3.1,5.3.2, 5.3.0 --target-registry us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal/
+        bazel ${bazelrc[*]} run //testing/tools/upgradetest:sh_upgradetest -- auto --post-release-version=5.3.9071 --avs 5.3.1,5.3.2, 5.3.0 --target-registry us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal/
 
 promoteToPublic:
   create:

--- a/release.yaml
+++ b/release.yaml
@@ -119,9 +119,6 @@ test:
         _VERSION=$VERSION
         unset VERSION
 
-        # TODO should be on the test runner side
-        git fetch --tags
-
         # Hardcoding version, as for now I just want to make sure this works in CI.
         bazel ${bazelrc[*]} run //testing/tools/upgradetest:release_test_run -- all \
           --post-release-version=5.3.9104 \

--- a/release.yaml
+++ b/release.yaml
@@ -123,7 +123,7 @@ test:
         bazel ${bazelrc[*]} run //testing/tools/upgradetest:release_test_run -- all \
           --post-release-version=5.3.9104 \
           --target-registry us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal/ \
-          --max-routines 5
+          --max-routines 6
 
         # Restoring it to avoid creating a footgun if we add more test steps later on.
         VERSION=$_VERSION

--- a/release.yaml
+++ b/release.yaml
@@ -119,11 +119,15 @@ test:
         _VERSION=$VERSION
         unset VERSION
 
+        # We purposely limit the concurrency to 6, because if we use the default, there are
+        # scenarios where we can exhaust available ports to the docker daemon and end up
+        # with an infrastructure flake.
+        max_routines=6
         # Hardcoding version, as for now I just want to make sure this works in CI.
         bazel ${bazelrc[*]} run //testing/tools/upgradetest:release_test_run -- all \
           --post-release-version={{tag}} \
           --target-registry us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal/ \
-          --max-routines 6
+          --max-routines $max_routines
 
         # Restoring it to avoid creating a footgun if we add more test steps later on.
         VERSION=$_VERSION

--- a/release.yaml
+++ b/release.yaml
@@ -1,8 +1,8 @@
 meta:
   productName: sourcegraph
-  repository: "github.com/sourcegraph/sourcegraph"
+  repository: 'github.com/sourcegraph/sourcegraph'
   owners:
-    - "@sourcegraph/release"
+    - '@sourcegraph/release'
 
 requirements:
   - name: "curl"
@@ -17,14 +17,14 @@ requirements:
 
   # #bolaji-release-testing
   # https://start.1password.com/open/i?a=HEDEDSLHPBFGRBTKAKJWE23XX4&v=isv4abynddpox72wwbhaamo76e&i=7zjax5rm5hlilbgrzeb257i62i&h=team-sourcegraph.1password.com
-  - name: "Slack Webhook URL"
+  - name: 'Slack Webhook URL'
     env: SLACK_WEBHOOK_URL
 
 internal:
   create:
     steps:
       patch:
-        - name: "buildkite"
+        - name: 'buildkite'
           cmd: |
             echo "Triggering build on sourcegraph/sourcegraph with VERSION={{version}} on branch {{git.branch}}"
             body=$(curl -s --fail-with-body -X POST "https://api.buildkite.com/v2/organizations/sourcegraph/pipelines/sourcegraph/builds" -H "Content-Type: application/json" -H "Authorization: Bearer $BUILDKITE_ACCESS_TOKEN" -d '{
@@ -50,10 +50,10 @@ internal:
             fi
   finalize:
     steps:
-      - name: "Register on release registry"
+      - name: 'Register on release registry'
         cmd: |
           echo "pretending to call release registry api"
-      - name: "notifications"
+      - name: 'notifications'
         cmd: |
           set -eu
 
@@ -64,54 +64,57 @@ internal:
 
 test:
   steps:
-    - name: "check:git tag does not exist"
+    # - name: 'check:git tag does not exist'
+    #   cmd: |
+    #     tags=$(git ls-remote --tags origin | sort -t '/' -k 3 | cut -f 2 | awk -F '/' '{gsub(/\^\{\}$/, "", $3); print $3}' | uniq)
+    #     if echo "${tags}" | grep -q "^{{version}}$"; then
+    #       echo "❌ Tag '{{version}}' already exists"
+    #       exit 1
+    #     fi
+    # - name: 'check:migrator-schemas'
+    #   cmd: |
+    #     set -eu
+
+    #     REGISTRY="${PROD_REGISTRY:-''}"
+
+    #     # the reason this is not in the requirements check of the release yaml is because those checks also
+    #     # apply when running the release tooling locally, and the testing steps are supposed to run in CI
+    #     if [ -z ${REGISTRY} ]; then
+    #       echo "PROD_REGISTRY is not set - unable to check migrator image"
+    #       exit 1
+    #     fi
+
+    #     IMAGE="${REGISTRY}/migrator:{{tag}}"
+
+    #     # Pull the image so that we can inspect it
+    #     echo "pulling migrator image ${IMAGE}"
+    #     docker pull "${IMAGE}"
+
+    #     echo "checking migrator image for {{version}} schema description files"
+    #     # now we check that the schema description files exist
+    #     # we need to trim the result from docker since it has '\r' hence the use of tr
+    #     count=$(docker run -t --rm --entrypoint /bin/sh "${IMAGE}" -c "ls -al /schema-descriptions/{{version}}-*.json | wc -l" | tr -d '[:space:]')
+    #     if [[ "$count" -ne 3 ]]; then
+    #       echo "migrator:{{tag}} does not contain the correct amount of schema description files for this release - expected 3 got ${count}"
+    #       exit 1
+    #     fi
+
+    #     echo "checking migrator image for older schema description files"
+    #     count=$(docker run -t --rm --entrypoint /bin/sh "${IMAGE}" -c "ls -al /schema-descriptions/*-internal_database_schema*json | wc -l" | tr -d '[:space:]')
+
+    #     # in our newer releases we have upwards of 300 schema descriptions, so we check that we have at least 300
+    #     if [[ "$count" -lt 300 ]]; then
+    #       echo "migrator:{{tag}} does not contain the correct amount of schema description files for this release - expected more than 300 got ${count}"
+    #       exit 1
+    #     fi
+    - name: 'db:migration:coherence_test'
       cmd: |
-        tags=$(git ls-remote --tags origin | sort -t '/' -k 3 | cut -f 2 | awk -F '/' '{gsub(/\^\{\}$/, "", $3); print $3}' | uniq)
-        if echo "${tags}" | grep -q "^{{version}}$"; then
-          echo "❌ Tag '{{version}}' already exists"
-          exit 1
-        fi
-    - name: "check:migrator-schemas"
-      cmd: |
-        set -eu
-
-        REGISTRY="${PROD_REGISTRY:-''}"
-
-        # the reason this is not in the requirements check of the release yaml is because those checks also
-        # apply when running the release tooling locally, and the testing steps are supposed to run in CI
-        if [ -z ${REGISTRY} ]; then
-          echo "PROD_REGISTRY is not set - unable to check migrator image"
-          exit 1
-        fi
-
-        IMAGE="${REGISTRY}/migrator:{{tag}}"
-
-        # Pull the image so that we can inspect it
-        echo "pulling migrator image ${IMAGE}"
-        docker pull "${IMAGE}"
-
-        echo "checking migrator image for {{version}} schema description files"
-        # now we check that the schema description files exist
-        # we need to trim the result from docker since it has '\r' hence the use of tr
-        count=$(docker run -t --rm --entrypoint /bin/sh "${IMAGE}" -c "ls -al /schema-descriptions/{{version}}-*.json | wc -l" | tr -d '[:space:]')
-        if [[ "$count" -ne 3 ]]; then
-          echo "migrator:{{tag}} does not contain the correct amount of schema description files for this release - expected 3 got ${count}"
-          exit 1
-        fi
-
-        echo "checking migrator image for older schema description files"
-        count=$(docker run -t --rm --entrypoint /bin/sh "${IMAGE}" -c "ls -al /schema-descriptions/*-internal_database_schema*json | wc -l" | tr -d '[:space:]')
-
-        # in our newer releases we have upwards of 300 schema descriptions, so we check that we have at least 300
-        if [[ "$count" -lt 300 ]]; then
-          echo "migrator:{{tag}} does not contain the correct amount of schema description files for this release - expected more than 300 got ${count}"
-          exit 1
-        fi
+        bazel run //testing/tools/upgradetest:sh_upgrade_test -- std
 
 promoteToPublic:
   create:
     steps:
-      - name: "buildkite"
+      - name: 'buildkite'
         cmd: |
           # We set DISABLE_ASPECT_WORKFLOWS to true, because the promotion is purely about retagging images
           # and we don't rely on AW at all.
@@ -140,10 +143,10 @@ promoteToPublic:
           fi
   finalize:
     steps:
-      - name: "Promote on release registry"
+      - name: 'Promote on release registry'
         cmd: |
           echo "pretending to call release registry api"
-      - name: "git:tag"
+      - name: 'git:tag'
         cmd: |
           set -eu
 
@@ -159,7 +162,7 @@ promoteToPublic:
           EOF
       # tag is usually in the format `5.3.2`
       # while version is usually the tag prepended with a v, `v5.3.2`
-      - name: "Slack notification (#announce-engineering)"
+      - name: 'Slack notification (#announce-engineering)'
         cmd: |
           echo "Posting slack notification for release"
           tag="{{tag}}"

--- a/release.yaml
+++ b/release.yaml
@@ -110,7 +110,7 @@ test:
     - name: 'db:migration:coherence_test'
       cmd: |
         # Hardcoding version, as for now I just want to make sure this works in CI.
-        bazel run //testing/tools/upgradetest:sh_upgrade_test -- auto --post-release-version=5.3.9071 --avs 5.3.1,5.3.2, 5.3.0 --target-registry us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal/
+        bazel run //testing/tools/upgradetest:sh_upgradetest -- auto --post-release-version=5.3.9071 --avs 5.3.1,5.3.2, 5.3.0 --target-registry us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal/
 
 promoteToPublic:
   create:

--- a/release.yaml
+++ b/release.yaml
@@ -17,8 +17,8 @@ requirements:
 
   # #bolaji-release-testing
   # https://start.1password.com/open/i?a=HEDEDSLHPBFGRBTKAKJWE23XX4&v=isv4abynddpox72wwbhaamo76e&i=7zjax5rm5hlilbgrzeb257i62i&h=team-sourcegraph.1password.com
-  # - name: 'Slack Webhook URL'
-  #   env: SLACK_WEBHOOK_URL
+  - name: 'Slack Webhook URL'
+    env: SLACK_WEBHOOK_URL
 
 internal:
   create:
@@ -64,49 +64,49 @@ internal:
 
 test:
   steps:
-    # - name: 'check:git tag does not exist'
-    #   cmd: |
-    #     tags=$(git ls-remote --tags origin | sort -t '/' -k 3 | cut -f 2 | awk -F '/' '{gsub(/\^\{\}$/, "", $3); print $3}' | uniq)
-    #     if echo "${tags}" | grep -q "^{{version}}$"; then
-    #       echo "❌ Tag '{{version}}' already exists"
-    #       exit 1
-    #     fi
-    # - name: 'check:migrator-schemas'
-    #   cmd: |
-    #     set -eu
+    - name: 'check:git tag does not exist'
+      cmd: |
+        tags=$(git ls-remote --tags origin | sort -t '/' -k 3 | cut -f 2 | awk -F '/' '{gsub(/\^\{\}$/, "", $3); print $3}' | uniq)
+        if echo "${tags}" | grep -q "^{{version}}$"; then
+          echo "❌ Tag '{{version}}' already exists"
+          exit 1
+        fi
+    - name: 'check:migrator-schemas'
+      cmd: |
+        set -eu
 
-    #     REGISTRY="${PROD_REGISTRY:-''}"
+        REGISTRY="${PROD_REGISTRY:-''}"
 
-    #     # the reason this is not in the requirements check of the release yaml is because those checks also
-    #     # apply when running the release tooling locally, and the testing steps are supposed to run in CI
-    #     if [ -z ${REGISTRY} ]; then
-    #       echo "PROD_REGISTRY is not set - unable to check migrator image"
-    #       exit 1
-    #     fi
+        # the reason this is not in the requirements check of the release yaml is because those checks also
+        # apply when running the release tooling locally, and the testing steps are supposed to run in CI
+        if [ -z ${REGISTRY} ]; then
+          echo "PROD_REGISTRY is not set - unable to check migrator image"
+          exit 1
+        fi
 
-    #     IMAGE="${REGISTRY}/migrator:{{tag}}"
+        IMAGE="${REGISTRY}/migrator:{{tag}}"
 
-    #     # Pull the image so that we can inspect it
-    #     echo "pulling migrator image ${IMAGE}"
-    #     docker pull "${IMAGE}"
+        # Pull the image so that we can inspect it
+        echo "pulling migrator image ${IMAGE}"
+        docker pull "${IMAGE}"
 
-    #     echo "checking migrator image for {{version}} schema description files"
-    #     # now we check that the schema description files exist
-    #     # we need to trim the result from docker since it has '\r' hence the use of tr
-    #     count=$(docker run -t --rm --entrypoint /bin/sh "${IMAGE}" -c "ls -al /schema-descriptions/{{version}}-*.json | wc -l" | tr -d '[:space:]')
-    #     if [[ "$count" -ne 3 ]]; then
-    #       echo "migrator:{{tag}} does not contain the correct amount of schema description files for this release - expected 3 got ${count}"
-    #       exit 1
-    #     fi
+        echo "checking migrator image for {{version}} schema description files"
+        # now we check that the schema description files exist
+        # we need to trim the result from docker since it has '\r' hence the use of tr
+        count=$(docker run -t --rm --entrypoint /bin/sh "${IMAGE}" -c "ls -al /schema-descriptions/{{version}}-*.json | wc -l" | tr -d '[:space:]')
+        if [[ "$count" -ne 3 ]]; then
+          echo "migrator:{{tag}} does not contain the correct amount of schema description files for this release - expected 3 got ${count}"
+          exit 1
+        fi
 
-    #     echo "checking migrator image for older schema description files"
-    #     count=$(docker run -t --rm --entrypoint /bin/sh "${IMAGE}" -c "ls -al /schema-descriptions/*-internal_database_schema*json | wc -l" | tr -d '[:space:]')
+        echo "checking migrator image for older schema description files"
+        count=$(docker run -t --rm --entrypoint /bin/sh "${IMAGE}" -c "ls -al /schema-descriptions/*-internal_database_schema*json | wc -l" | tr -d '[:space:]')
 
-    #     # in our newer releases we have upwards of 300 schema descriptions, so we check that we have at least 300
-    #     if [[ "$count" -lt 300 ]]; then
-    #       echo "migrator:{{tag}} does not contain the correct amount of schema description files for this release - expected more than 300 got ${count}"
-    #       exit 1
-    #     fi
+        # in our newer releases we have upwards of 300 schema descriptions, so we check that we have at least 300
+        if [[ "$count" -lt 300 ]]; then
+          echo "migrator:{{tag}} does not contain the correct amount of schema description files for this release - expected more than 300 got ${count}"
+          exit 1
+        fi
     - name: 'db:migration:coherence_test'
       cmd: |
         set -eu

--- a/release.yaml
+++ b/release.yaml
@@ -120,7 +120,7 @@ test:
         unset VERSION
 
         # Hardcoding version, as for now I just want to make sure this works in CI.
-        bazel ${bazelrc[*]} run //testing/tools/upgradetest:sh_upgradetest_run -- auto --post-release-version=5.3.9071 --avs 5.3.1,5.3.2,5.3.0 --target-registry us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal/
+        bazel ${bazelrc[*]} run //testing/tools/upgradetest:sh_upgradetest_run -- std --post-release-version=5.3.9071 --svs 5.3.1 --target-registry us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal/
 
         # Restoring it to avoid creating a footgun if we add more test steps later on.
         VERSION=$_VERSION

--- a/release.yaml
+++ b/release.yaml
@@ -113,8 +113,15 @@ test:
         rosetta bazelrc > "$aspectRC"
         bazelrc=(--bazelrc="$aspectRC" --bazelrc=.aspect/bazelrc/ci.sourcegraph.bazelrc)
 
+        # The upgradetest are inferring the stamp-version flag based on the version, so we need to unset it here.
+        _VERSION=$VERSION
+        unset VERSION
+
         # Hardcoding version, as for now I just want to make sure this works in CI.
         bazel ${bazelrc[*]} run //testing/tools/upgradetest:sh_upgradetest -- auto --post-release-version=5.3.9071 --avs 5.3.1,5.3.2, 5.3.0 --target-registry us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal/
+
+        # Restoring it to avoid creating a footgun if we add more test steps later on.
+        VERSION=$_VERSION
 
 promoteToPublic:
   create:

--- a/release.yaml
+++ b/release.yaml
@@ -119,9 +119,12 @@ test:
         _VERSION=$VERSION
         unset VERSION
 
+        # TODO should be on the test runner side
+        git fetch --tags
+
         # Hardcoding version, as for now I just want to make sure this works in CI.
         bazel ${bazelrc[*]} run //testing/tools/upgradetest:release_test_run -- all \
-          --post-release-version=5.3.9071 \
+          --post-release-version=5.3.9104 \
           --target-registry us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal/
 
         # Restoring it to avoid creating a footgun if we add more test steps later on.

--- a/release.yaml
+++ b/release.yaml
@@ -109,6 +109,8 @@ test:
     #     fi
     - name: 'db:migration:coherence_test'
       cmd: |
+        set -eu
+
         aspectRC="/tmp/aspect-generated.bazelrc"
         rosetta bazelrc > "$aspectRC"
         bazelrc=(--bazelrc="$aspectRC" --bazelrc=.aspect/bazelrc/ci.sourcegraph.bazelrc)
@@ -118,7 +120,7 @@ test:
         unset VERSION
 
         # Hardcoding version, as for now I just want to make sure this works in CI.
-        bazel ${bazelrc[*]} run //testing/tools/upgradetest:sh_upgradetest -- auto --post-release-version=5.3.9071 --avs 5.3.1,5.3.2, 5.3.0 --target-registry us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal/
+        bazel ${bazelrc[*]} run //testing/tools/upgradetest:sh_upgradetest -- auto --post-release-version=5.3.9071 --avs 5.3.1,5.3.2,5.3.0 --target-registry us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal/
 
         # Restoring it to avoid creating a footgun if we add more test steps later on.
         VERSION=$_VERSION

--- a/release.yaml
+++ b/release.yaml
@@ -17,8 +17,8 @@ requirements:
 
   # #bolaji-release-testing
   # https://start.1password.com/open/i?a=HEDEDSLHPBFGRBTKAKJWE23XX4&v=isv4abynddpox72wwbhaamo76e&i=7zjax5rm5hlilbgrzeb257i62i&h=team-sourcegraph.1password.com
-  - name: 'Slack Webhook URL'
-    env: SLACK_WEBHOOK_URL
+  # - name: 'Slack Webhook URL'
+  #   env: SLACK_WEBHOOK_URL
 
 internal:
   create:

--- a/release.yaml
+++ b/release.yaml
@@ -109,7 +109,8 @@ test:
     #     fi
     - name: 'db:migration:coherence_test'
       cmd: |
-        bazel run //testing/tools/upgradetest:sh_upgrade_test -- std
+        # Hardcoding version, as for now I just want to make sure this works in CI.
+        bazel run //testing/tools/upgradetest:sh_upgrade_test -- auto --post-release-version=5.3.9071 --avs 5.3.1,5.3.2, 5.3.0 --target-registry us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal/
 
 promoteToPublic:
   create:

--- a/release.yaml
+++ b/release.yaml
@@ -122,7 +122,8 @@ test:
         # Hardcoding version, as for now I just want to make sure this works in CI.
         bazel ${bazelrc[*]} run //testing/tools/upgradetest:release_test_run -- all \
           --post-release-version=5.3.9104 \
-          --target-registry us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal/
+          --target-registry us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal/ \
+          --max-routines 5
 
         # Restoring it to avoid creating a footgun if we add more test steps later on.
         VERSION=$_VERSION

--- a/release.yaml
+++ b/release.yaml
@@ -120,7 +120,9 @@ test:
         unset VERSION
 
         # Hardcoding version, as for now I just want to make sure this works in CI.
-        bazel ${bazelrc[*]} run //testing/tools/upgradetest:sh_upgradetest_run -- std --post-release-version=5.3.9071 --svs 5.3.1 --target-registry us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal/
+        bazel ${bazelrc[*]} run //testing/tools/upgradetest:release_test_run -- all \
+          --post-release-version=5.3.9071 \
+          --target-registry us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal/
 
         # Restoring it to avoid creating a footgun if we add more test steps later on.
         VERSION=$_VERSION

--- a/release.yaml
+++ b/release.yaml
@@ -121,7 +121,7 @@ test:
 
         # Hardcoding version, as for now I just want to make sure this works in CI.
         bazel ${bazelrc[*]} run //testing/tools/upgradetest:release_test_run -- all \
-          --post-release-version=5.3.9104 \
+          --post-release-version={{tag}} \
           --target-registry us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal/ \
           --max-routines 6
 

--- a/release.yaml
+++ b/release.yaml
@@ -120,7 +120,7 @@ test:
         unset VERSION
 
         # Hardcoding version, as for now I just want to make sure this works in CI.
-        bazel ${bazelrc[*]} run //testing/tools/upgradetest:sh_upgradetest -- auto --post-release-version=5.3.9071 --avs 5.3.1,5.3.2,5.3.0 --target-registry us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal/
+        bazel ${bazelrc[*]} run //testing/tools/upgradetest:sh_upgradetest_run -- auto --post-release-version=5.3.9071 --avs 5.3.1,5.3.2,5.3.0 --target-registry us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal/
 
         # Restoring it to avoid creating a footgun if we add more test steps later on.
         VERSION=$_VERSION

--- a/testing/tools/upgradetest/BUILD.bazel
+++ b/testing/tools/upgradetest/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_cross_binary", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 
 go_library(
     name = "upgradetest_lib",
@@ -66,5 +66,16 @@ sh_binary(
         "//cmd/frontend:image_tarball",
         "//cmd/migrator:image_tarball",
         "//internal/database:generate_schemas",
+    ],
+)
+
+sh_binary(
+    name = "release_test_run",
+    srcs = ["release_test.sh"],
+    args = [
+        "$(location :go_upgradetest)",
+    ],
+    data = [
+        ":go_upgradetest",
     ],
 )

--- a/testing/tools/upgradetest/main.go
+++ b/testing/tools/upgradetest/main.go
@@ -291,6 +291,12 @@ func main() {
 					}
 					if err := stdTestPool.Wait(); err != nil {
 						fmt.Println("🚨 Error: failed to run tests in pool: ", err)
+						for _, t := range results.StandardUpgradeTests {
+							fmt.Println("LOGS")
+							t.DisplayLog()
+							fmt.Println("ERROR")
+							t.DisplayErrors()
+						}
 						return err
 					}
 

--- a/testing/tools/upgradetest/main.go
+++ b/testing/tools/upgradetest/main.go
@@ -223,7 +223,7 @@ func main() {
 					&cli.IntFlag{
 						Name:    "max-routines",
 						Aliases: []string{"mr"}, Usage: "Maximum number of tests to run concurrently. Sets goroutine pool limit.\n Defaults to 10.",
-						Value: 10,
+						Value: runtime.NumCPU() - 2,
 					},
 					&cli.StringSliceFlag{
 						Name:    "standard-versions",
@@ -338,7 +338,7 @@ func main() {
 						Name:    "max-routines",
 						Aliases: []string{"mr"},
 						Usage:   "Maximum number of tests to run concurrently. Sets goroutine pool limit.\n Defaults to 10.",
-						Value:   10,
+						Value:   runtime.NumCPU() - 2,
 					},
 					&cli.StringSliceFlag{
 						Name:    "mvu-versions",
@@ -445,7 +445,7 @@ func main() {
 						Name:    "max-routines",
 						Aliases: []string{"mr"},
 						Usage:   "Maximum number of tests to run concurrently. Sets goroutine pool limit.\n Defaults to 10.",
-						Value:   10,
+						Value:   runtime.NumCPU() - 2,
 					},
 					&cli.StringSliceFlag{
 						Name:    "auto-versions",

--- a/testing/tools/upgradetest/main.go
+++ b/testing/tools/upgradetest/main.go
@@ -50,10 +50,9 @@ func main() {
 						Value:       "",
 					},
 					&cli.StringFlag{
-						Name:        "from-registry",
-						DefaultText: "sourcegraph/",
-						Usage:       "Registry host and path to pull versions we're upgrading from, i.e. index.docker.io/sourcegraph will pull index.docker.io/sourcegraph/migrator:<tag>",
-						Value:       "",
+						Name:  "from-registry",
+						Usage: "Registry host and path to pull versions we're upgrading from, i.e. index.docker.io/sourcegraph will pull index.docker.io/sourcegraph/migrator:<tag>",
+						Value: "sourcegraph/",
 					},
 					&cli.IntFlag{
 						Name:    "max-routines",
@@ -327,16 +326,14 @@ func main() {
 						Usage:   "Select an already released version as the target version for the test suite.",
 					},
 					&cli.StringFlag{
-						Name:        "target-registry",
-						DefaultText: "sourcegraph/",
-						Usage:       "Registry host and path to pull the targeted version from, i.e. index.docker.io/sourcegraph will pull index.docker.io/sourcegraph/migrator:<tag>",
-						Value:       "",
+						Name:  "target-registry",
+						Usage: "Registry host and path to pull the targeted version from, i.e. index.docker.io/sourcegraph will pull index.docker.io/sourcegraph/migrator:<tag>",
+						Value: "sourcegraph/",
 					},
 					&cli.StringFlag{
-						Name:        "from-registry",
-						DefaultText: "sourcegraph/",
-						Usage:       "Registry host and path to pull versions we're upgrading from, i.e. index.docker.io/sourcegraph will pull index.docker.io/sourcegraph/migrator:<tag>",
-						Value:       "sourcegraph",
+						Name:  "from-registry",
+						Usage: "Registry host and path to pull versions we're upgrading from, i.e. index.docker.io/sourcegraph will pull index.docker.io/sourcegraph/migrator:<tag>",
+						Value: "sourcegraph/",
 					},
 					&cli.IntFlag{
 						Name:    "max-routines",
@@ -436,16 +433,14 @@ func main() {
 					},
 
 					&cli.StringFlag{
-						Name:        "target-registry",
-						DefaultText: "sourcegraph/",
-						Usage:       "Registry host and path to pull the targeted version from, i.e. index.docker.io/sourcegraph will pull index.docker.io/sourcegraph/migrator:<tag>",
-						Value:       "",
+						Name:  "target-registry",
+						Usage: "Registry host and path to pull the targeted version from, i.e. index.docker.io/sourcegraph will pull index.docker.io/sourcegraph/migrator:<tag>",
+						Value: "sourcegraph/",
 					},
 					&cli.StringFlag{
-						Name:        "from-registry",
-						DefaultText: "sourcegraph/",
-						Usage:       "Registry host and path to pull versions we're upgrading from, i.e. index.docker.io/sourcegraph will pull index.docker.io/sourcegraph/migrator:<tag>",
-						Value:       "sourcegraph/",
+						Name:  "from-registry",
+						Usage: "Registry host and path to pull versions we're upgrading from, i.e. index.docker.io/sourcegraph will pull index.docker.io/sourcegraph/migrator:<tag>",
+						Value: "sourcegraph/",
 					},
 					&cli.IntFlag{
 						Name:    "max-routines",

--- a/testing/tools/upgradetest/main.go
+++ b/testing/tools/upgradetest/main.go
@@ -324,7 +324,7 @@ func main() {
 						Name:        "from-registry",
 						DefaultText: "sourcegraph/",
 						Usage:       "Registry host and path to pull versions we're upgrading from, i.e. index.docker.io/sourcegraph will pull index.docker.io/sourcegraph/migrator:<tag>",
-						Value:       "",
+						Value:       "sourcegraph",
 					},
 					&cli.IntFlag{
 						Name:    "max-routines",
@@ -430,7 +430,7 @@ func main() {
 						Name:        "from-registry",
 						DefaultText: "sourcegraph/",
 						Usage:       "Registry host and path to pull versions we're upgrading from, i.e. index.docker.io/sourcegraph will pull index.docker.io/sourcegraph/migrator:<tag>",
-						Value:       "",
+						Value:       "sourcegraph/",
 					},
 					&cli.IntFlag{
 						Name:    "max-routines",

--- a/testing/tools/upgradetest/main.go
+++ b/testing/tools/upgradetest/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"runtime"
 	"strings"
 	"time"
 
@@ -57,8 +58,8 @@ func main() {
 					&cli.IntFlag{
 						Name:    "max-routines",
 						Aliases: []string{"mr"},
-						Usage:   "Maximum number of tests to run concurrently. Sets goroutine pool limit.\n Defaults to 10.",
-						Value:   10,
+						Usage:   "Maximum number of tests to run concurrently. Sets goroutine pool limit.\n Defaults to CPU cores count minus two.",
+						Value:   runtime.NumCPU() - 2,
 					},
 					&cli.StringSliceFlag{
 						Name:    "standard-versions",

--- a/testing/tools/upgradetest/main.go
+++ b/testing/tools/upgradetest/main.go
@@ -18,6 +18,7 @@ import (
 // This type is used to assign the stamp version from VERSION
 type stampVersionKey struct{}
 type postReleaseKey struct{}
+type registryKey struct{}
 
 // Register upgrade commands -- see README.md for more details.
 func main() {
@@ -40,6 +41,12 @@ func main() {
 						Name:    "post-release-version",
 						Aliases: []string{"pv"},
 						Usage:   "Select an already released version as the target version for the test suite.",
+					},
+					&cli.StringFlag{
+						Name:        "registry",
+						DefaultText: "sourcegraph/",
+						Usage:       "Registry host and path, i.e. index.docker.io/sourcegraph will pull index.docker.io/sourcegraph/migrator:<tag>",
+						Value:       "",
 					},
 					&cli.IntFlag{
 						Name:    "max-routines",
@@ -66,6 +73,7 @@ func main() {
 				Action: func(cCtx *cli.Context) error {
 					ctx := context.WithValue(cCtx.Context, stampVersionKey{}, cCtx.String("stamp-version"))
 					ctx = context.WithValue(ctx, postReleaseKey{}, cCtx.String("post-release-version"))
+					ctx = context.WithValue(ctx, registryKey{}, cCtx.String("registry"))
 
 					// check docker is running
 					if err := run.Cmd(ctx, "docker", "ps").Run().Wait(); err != nil {
@@ -83,7 +91,7 @@ func main() {
 					var targetMigratorImage string
 					switch {
 					case ctx.Value(postReleaseKey{}) != "":
-						targetMigratorImage = fmt.Sprintf("sourcegraph/migrator:%s", ctx.Value(postReleaseKey{}))
+						targetMigratorImage = fmt.Sprintf("%smigrator:%s", ctx.Value(registryKey{}), ctx.Value(postReleaseKey{}))
 					case ctx.Value(stampVersionKey{}) != "":
 						targetMigratorImage = fmt.Sprintf("migrator:candidate stamped as %s", ctx.Value(stampVersionKey{}))
 					default:
@@ -188,6 +196,12 @@ func main() {
 						Aliases: []string{"pv"},
 						Usage:   "Select an already released version as the target version for the test suite.",
 					},
+					&cli.StringFlag{
+						Name:        "registry",
+						DefaultText: "sourcegraph/",
+						Usage:       "Registry host and path, i.e. index.docker.io/sourcegraph will pull index.docker.io/sourcegraph/migrator:<tag>",
+						Value:       "",
+					},
 					&cli.IntFlag{
 						Name:    "max-routines",
 						Aliases: []string{"mr"}, Usage: "Maximum number of tests to run concurrently. Sets goroutine pool limit.\n Defaults to 10.",
@@ -219,7 +233,7 @@ func main() {
 					var targetMigratorImage string
 					switch {
 					case ctx.Value(postReleaseKey{}) != "":
-						targetMigratorImage = fmt.Sprintf("sourcegraph/migrator:%s", ctx.Value(postReleaseKey{}))
+						targetMigratorImage = fmt.Sprintf("%smigrator:%s", ctx.Value(registryKey{}), ctx.Value(postReleaseKey{}))
 					case ctx.Value(stampVersionKey{}) != "":
 						targetMigratorImage = fmt.Sprintf("migrator:candidate stamped as %s", ctx.Value(stampVersionKey{}))
 					default:
@@ -280,6 +294,12 @@ func main() {
 						Name:    "post-release-version",
 						Aliases: []string{"pv"},
 						Usage:   "Select an already released version as the target version for the test suite.",
+					},
+					&cli.StringFlag{
+						Name:        "registry",
+						DefaultText: "sourcegraph/",
+						Usage:       "Registry host and path, i.e. index.docker.io/sourcegraph will pull index.docker.io/sourcegraph/migrator:<tag>",
+						Value:       "",
 					},
 					&cli.IntFlag{
 						Name:    "max-routines",
@@ -371,6 +391,12 @@ func main() {
 						Name:    "post-release-version",
 						Aliases: []string{"pv"},
 						Usage:   "Select an already released version as the target version for the test suite.",
+					},
+					&cli.StringFlag{
+						Name:        "registry",
+						DefaultText: "sourcegraph/",
+						Usage:       "Registry host and path, i.e. index.docker.io/sourcegraph will pull index.docker.io/sourcegraph/migrator:<tag>",
+						Value:       "",
 					},
 					&cli.IntFlag{
 						Name:    "max-routines",

--- a/testing/tools/upgradetest/main.go
+++ b/testing/tools/upgradetest/main.go
@@ -189,7 +189,10 @@ func main() {
 					// This is where we do the majority of our printing to stdout.
 					results.OrderByVersion()
 					results.PrintSimpleResults()
-					results.DisplayErrors()
+					if results.Failed() {
+						results.DisplayErrors()
+						os.Exit(1)
+					}
 
 					return nil
 				},
@@ -304,6 +307,10 @@ func main() {
 					// This is where we do the majority of our printing to stdout.
 					results.OrderByVersion()
 					results.PrintSimpleResults()
+					if results.Failed() {
+						results.DisplayErrors()
+						os.Exit(1)
+					}
 
 					return nil
 				},
@@ -410,6 +417,10 @@ func main() {
 
 					results.OrderByVersion()
 					results.PrintSimpleResults()
+					if results.Failed() {
+						results.DisplayErrors()
+						os.Exit(1)
+					}
 
 					return nil
 				},
@@ -518,6 +529,10 @@ func main() {
 
 					results.OrderByVersion()
 					results.PrintSimpleResults()
+					if results.Failed() {
+						results.DisplayErrors()
+						os.Exit(1)
+					}
 
 					return nil
 				},

--- a/testing/tools/upgradetest/main.go
+++ b/testing/tools/upgradetest/main.go
@@ -341,7 +341,8 @@ func main() {
 				Action: func(cCtx *cli.Context) error {
 					ctx := context.WithValue(cCtx.Context, stampVersionKey{}, cCtx.String("stamp-version"))
 					ctx = context.WithValue(ctx, postReleaseKey{}, cCtx.String("post-release-version"))
-					ctx = context.WithValue(ctx, targetRegistryKey{}, cCtx.String("registry"))
+					ctx = context.WithValue(ctx, targetRegistryKey{}, cCtx.String("target-registry"))
+					ctx = context.WithValue(ctx, fromRegistryKey{}, cCtx.String("from-registry"))
 
 					// check docker is running
 					if err := run.Cmd(ctx, "docker", "ps").Run().Wait(); err != nil {
@@ -418,10 +419,17 @@ func main() {
 						Aliases: []string{"pv"},
 						Usage:   "Select an already released version as the target version for the test suite.",
 					},
+
 					&cli.StringFlag{
-						Name:        "registry",
+						Name:        "target-registry",
 						DefaultText: "sourcegraph/",
-						Usage:       "Registry host and path, i.e. index.docker.io/sourcegraph will pull index.docker.io/sourcegraph/migrator:<tag>",
+						Usage:       "Registry host and path to pull the targeted version from, i.e. index.docker.io/sourcegraph will pull index.docker.io/sourcegraph/migrator:<tag>",
+						Value:       "",
+					},
+					&cli.StringFlag{
+						Name:        "from-registry",
+						DefaultText: "sourcegraph/",
+						Usage:       "Registry host and path to pull versions we're upgrading from, i.e. index.docker.io/sourcegraph will pull index.docker.io/sourcegraph/migrator:<tag>",
 						Value:       "",
 					},
 					&cli.IntFlag{
@@ -439,7 +447,8 @@ func main() {
 				Action: func(cCtx *cli.Context) error {
 					ctx := context.WithValue(cCtx.Context, stampVersionKey{}, cCtx.String("stamp-version"))
 					ctx = context.WithValue(ctx, postReleaseKey{}, cCtx.String("post-release-version"))
-					ctx = context.WithValue(ctx, targetRegistryKey{}, cCtx.String("registry"))
+					ctx = context.WithValue(ctx, targetRegistryKey{}, cCtx.String("target-registry"))
+					ctx = context.WithValue(ctx, fromRegistryKey{}, cCtx.String("from-registry"))
 
 					// check docker is running
 					if err := run.Cmd(ctx, "docker", "ps").Run().Wait(); err != nil {

--- a/testing/tools/upgradetest/main.go
+++ b/testing/tools/upgradetest/main.go
@@ -188,6 +188,7 @@ func main() {
 					// This is where we do the majority of our printing to stdout.
 					results.OrderByVersion()
 					results.PrintSimpleResults()
+					results.DisplayErrors()
 
 					return nil
 				},

--- a/testing/tools/upgradetest/main.go
+++ b/testing/tools/upgradetest/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	_ "github.com/lib/pq"
@@ -44,10 +45,9 @@ func main() {
 						Usage:   "Select an already released version as the target version for the test suite.",
 					},
 					&cli.StringFlag{
-						Name:        "target-registry",
-						DefaultText: "sourcegraph/",
-						Usage:       "Registry host and path to pull the targeted version from, i.e. index.docker.io/sourcegraph will pull index.docker.io/sourcegraph/migrator:<tag>",
-						Value:       "",
+						Name:  "target-registry",
+						Usage: "Registry host and path to pull the targeted version from, i.e. index.docker.io/sourcegraph will pull index.docker.io/sourcegraph/migrator:<tag>",
+						Value: "sourcegraph/",
 					},
 					&cli.StringFlag{
 						Name:  "from-registry",
@@ -103,7 +103,7 @@ func main() {
 					var targetMigratorImage string
 					switch {
 					case ctx.Value(postReleaseKey{}) != "":
-						targetMigratorImage = fmt.Sprintf("%smigrator:%s", ctx.Value(targetRegistryKey{}), ctx.Value(postReleaseKey{}))
+						targetMigratorImage = fmt.Sprintf("%smigrator:%s", ctx.Value(targetRegistryKey{}), strings.TrimPrefix(ctx.Value(postReleaseKey{}).(string), "v"))
 					case ctx.Value(stampVersionKey{}) != "":
 						targetMigratorImage = fmt.Sprintf("migrator:candidate stamped as %s", ctx.Value(stampVersionKey{}))
 					default:
@@ -158,9 +158,6 @@ func main() {
 								result := standardUpgradeTest(ctx, version.Version, targetVersion, latestStableVersion)
 								result.Runtime = time.Since(start)
 								results.AddStdTest(result)
-								if len(result.Errors) > 0 {
-									return result.Errors[0]
-								}
 								return nil
 							})
 						case "mvu":
@@ -170,9 +167,6 @@ func main() {
 								result := multiversionUpgradeTest(ctx, version.Version, targetVersion, latestStableVersion)
 								result.Runtime = time.Since(start)
 								results.AddMVUTest(result)
-								if len(result.Errors) > 0 {
-									return result.Errors[0]
-								}
 								return nil
 							})
 						case "auto":
@@ -182,9 +176,6 @@ func main() {
 								result := autoUpgradeTest(ctx, version.Version, targetVersion, latestStableVersion)
 								result.Runtime = time.Since(start)
 								results.AddAutoTest(result)
-								if len(result.Errors) > 0 {
-									return result.Errors[0]
-								}
 								return nil
 							})
 						}
@@ -260,7 +251,7 @@ func main() {
 					var targetMigratorImage string
 					switch {
 					case ctx.Value(postReleaseKey{}) != "":
-						targetMigratorImage = fmt.Sprintf("%smigrator:%s", ctx.Value(targetRegistryKey{}), ctx.Value(postReleaseKey{}))
+						targetMigratorImage = fmt.Sprintf("%smigrator:%s", ctx.Value(targetRegistryKey{}), strings.TrimPrefix(ctx.Value(postReleaseKey{}).(string), "v"))
 					case ctx.Value(stampVersionKey{}) != "":
 						targetMigratorImage = fmt.Sprintf("migrator:candidate stamped as %s", ctx.Value(stampVersionKey{}))
 					default:
@@ -369,7 +360,7 @@ func main() {
 					var targetMigratorImage string
 					switch {
 					case ctx.Value(postReleaseKey{}) != "":
-						targetMigratorImage = fmt.Sprintf("%smigrator:%s", ctx.Value(targetRegistryKey{}), ctx.Value(postReleaseKey{}))
+						targetMigratorImage = fmt.Sprintf("%smigrator:%s", ctx.Value(targetRegistryKey{}), strings.TrimPrefix(ctx.Value(postReleaseKey{}).(string), "v"))
 					case ctx.Value(stampVersionKey{}) != "":
 						targetMigratorImage = fmt.Sprintf("migrator:candidate stamped as %s", ctx.Value(stampVersionKey{}))
 					default:
@@ -476,7 +467,7 @@ func main() {
 					var targetMigratorImage string
 					switch {
 					case ctx.Value(postReleaseKey{}) != "":
-						targetMigratorImage = fmt.Sprintf("%smigrator:%s", ctx.Value(targetRegistryKey{}), ctx.Value(postReleaseKey{}))
+						targetMigratorImage = fmt.Sprintf("%smigrator:%s", ctx.Value(targetRegistryKey{}), strings.TrimPrefix(ctx.Value(postReleaseKey{}).(string), "v"))
 					case ctx.Value(stampVersionKey{}) != "":
 						targetMigratorImage = fmt.Sprintf("migrator:candidate stamped as %s", ctx.Value(stampVersionKey{}))
 					default:

--- a/testing/tools/upgradetest/main.go
+++ b/testing/tools/upgradetest/main.go
@@ -159,6 +159,9 @@ func main() {
 								result := standardUpgradeTest(ctx, version.Version, targetVersion, latestStableVersion)
 								result.Runtime = time.Since(start)
 								results.AddStdTest(result)
+								if len(result.Errors) > 0 {
+									return result.Errors[0]
+								}
 								return nil
 							})
 						case "mvu":
@@ -168,6 +171,9 @@ func main() {
 								result := multiversionUpgradeTest(ctx, version.Version, targetVersion, latestStableVersion)
 								result.Runtime = time.Since(start)
 								results.AddMVUTest(result)
+								if len(result.Errors) > 0 {
+									return result.Errors[0]
+								}
 								return nil
 							})
 						case "auto":
@@ -177,6 +183,9 @@ func main() {
 								result := autoUpgradeTest(ctx, version.Version, targetVersion, latestStableVersion)
 								result.Runtime = time.Since(start)
 								results.AddAutoTest(result)
+								if len(result.Errors) > 0 {
+									return result.Errors[0]
+								}
 								return nil
 							})
 						}
@@ -283,6 +292,9 @@ func main() {
 							result := standardUpgradeTest(ctx, version, targetVersion, latestStableVersion)
 							result.Runtime = time.Since(start)
 							results.AddStdTest(result)
+							if len(result.Errors) > 0 {
+								return result.Errors[0]
+							}
 							return nil
 						})
 					}
@@ -389,6 +401,9 @@ func main() {
 							result := multiversionUpgradeTest(ctx, version, targetVersion, latestStableVersion)
 							result.Runtime = time.Since(start)
 							results.AddMVUTest(result)
+							if len(result.Errors) > 0 {
+								return result.Errors[0]
+							}
 							return nil
 						})
 					}
@@ -495,6 +510,10 @@ func main() {
 							result := autoUpgradeTest(ctx, version, targetVersion, latestStableVersion)
 							result.Runtime = time.Since(start)
 							results.AddAutoTest(result)
+							if len(result.Errors) > 0 {
+								return result.Errors[0]
+							}
+
 							return nil
 						})
 					}
@@ -514,6 +533,7 @@ func main() {
 
 	if err := app.Run(os.Args); err != nil {
 		fmt.Println("🚨 Error: failed to run tests: ", err)
+		os.Exit(1)
 	}
 
 }

--- a/testing/tools/upgradetest/release_test.sh
+++ b/testing/tools/upgradetest/release_test.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+set -e
+
+RUNNER="$1"
+
+# internal/database/. artifacts are being loaded as arguments, 13 is the beginning of passed arguments to the cli tool
+# Args:
+# bazel-bin/testing/tools/upgradetest/sh_upgradetest_run
+# testing/tools/upgradetest/upgradetest-darwin-arm64
+# cmd/migrator/image_tarball.sh
+# cmd/frontend/image_tarball.sh
+# internal/database/_codeinsights_squashed.sql
+# internal/database/_codeintel_squashed.sql
+# internal/database/_frontend_squashed.sql
+# internal/database/_schema.codeinsights.json
+# internal/database/_schema.codeinsights.md
+# internal/database/_schema.codeintel.json
+# internal/database/_schema.codeintel.md
+# internal/database/_schema.json
+# internal/database/_schema.md
+"$RUNNER" "${@:2}"

--- a/testing/tools/upgradetest/test.sh
+++ b/testing/tools/upgradetest/test.sh
@@ -27,5 +27,3 @@ FRONTEND_TARBALL="$3"
 # internal/database/_schema.json
 # internal/database/_schema.md
 "$RUNNER" "${@:13}"
-
-exit

--- a/testing/tools/upgradetest/tests-util.go
+++ b/testing/tools/upgradetest/tests-util.go
@@ -518,8 +518,7 @@ func startFrontend(ctx context.Context, test Test, image, version, networkName s
 	if auto {
 		envString = append(envString, "-e", "SRC_AUTOUPGRADE=true")
 	}
-	// ERROR
-	// {"SeverityText":"FATAL","Timestamp":1706224238009644720,"InstrumentationScope":"sourcegraph","Caller":"svcmain/svcmain.go:167","Function":"github.com/sourcegraph/sourcegraph/internal/service/svcmain.run.func1","Body":"failed to start service","Resource":{"service.name":"frontend","service.version":"0.0.0+dev","service.instance.id":"79a3e3ca0bfc"},"Attributes":{"service":"frontend","error":"failed to connect to frontend database: database schema out of date"}}
+
 	cmdString := []string{
 		"--network", networkName,
 		fmt.Sprintf("%s:%s", image, version),
@@ -531,7 +530,6 @@ func startFrontend(ctx context.Context, test Test, image, version, networkName s
 	errChan := make(chan error)
 	go func() {
 		if _, err := run.Cmd(ctx, cmdString...).Run().String(); err != nil {
-			fmt.Println("🚨 failed to start frontend: ", err)
 			errChan <- err
 		}
 	}()

--- a/testing/tools/upgradetest/tests-util.go
+++ b/testing/tools/upgradetest/tests-util.go
@@ -257,11 +257,12 @@ func setupTestEnv(ctx context.Context, testType string, initVersion *semver.Vers
 			"--name", db.ContainerName,
 			"--network", networkName,
 			"-p", "5432",
-			fmt.Sprintf("%s%s:%s", ctx.Value(registryKey{}), db.Image, initVersion),
+			fmt.Sprintf("%s%s:%s", ctx.Value(fromRegistryKey{}), db.Image, initVersion),
 		).Run().Wait()
 		if err != nil {
 			test.AddError(errors.Newf("🚨 failed to create test databases: %s", err))
 		}
+
 		// get the dynamically allocated port and register it to the test
 		port, err := run.Cmd(ctx, "docker", "port", db.ContainerName, "5432").Run().String()
 		if err != nil {
@@ -313,7 +314,7 @@ func setupTestEnv(ctx context.Context, testType string, initVersion *semver.Vers
 
 	// Initialize the databases by running migrator with the `up` command.
 	test.LogLines = append(test.LogLines, "-- 🏗️  initializing database schemas with migrator")
-	out, err = run.Cmd(ctx, dockerMigratorBaseString(test, "up", fmt.Sprintf("%smigrator:%s", ctx.Value(registryKey{}), initVersion), networkName, dbs)...).Run().String()
+	out, err = run.Cmd(ctx, dockerMigratorBaseString(test, "up", fmt.Sprintf("%smigrator:%s", ctx.Value(fromRegistryKey{}), initVersion), networkName, dbs)...).Run().String()
 	if err != nil {
 		test.AddError(errors.Newf("🚨 failed to initialize database: %w", err))
 	}
@@ -346,7 +347,7 @@ func setupTestEnv(ctx context.Context, testType string, initVersion *semver.Vers
 
 	//start frontend and poll db until initial version is set by frontend
 	var cleanFrontend func()
-	cleanFrontend, err = startFrontend(ctx, test, fmt.Sprintf("%sfrontend", ctx.Value(registryKey{})), initVersion.String(), networkName, false, dbs)
+	cleanFrontend, err = startFrontend(ctx, test, fmt.Sprintf("%sfrontend", ctx.Value(fromRegistryKey{})), initVersion.String(), networkName, false, dbs)
 	if err != nil {
 		test.AddError(errors.Newf("🚨 failed to start frontend: %w", err))
 	}

--- a/testing/tools/upgradetest/tests-util.go
+++ b/testing/tools/upgradetest/tests-util.go
@@ -221,6 +221,39 @@ func setupTestEnv(ctx context.Context, testType string, initVersion *semver.Vers
 	test.AddLog(fmt.Sprintf("Upgrading from version (%s) to release candidate.", initVersion))
 	test.AddLog("-- 🏗️  setting up test environment")
 
+	// Pull images from registry if -from-registry is set
+	if ctx.Value(fromRegistryKey{}).(string) != "sourcegraph/" {
+		test.AddLog(fmt.Sprintf("🐋 pulling -from-registry images from %s", ctx.Value(fromRegistryKey{}).(string)))
+		out, err := run.Cmd(ctx, "docker", "image", "pull", fmt.Sprintf("%sfrontend:%s", ctx.Value(fromRegistryKey{}).(string), initVersion.String())).Run().String()
+		test.AddLog(out)
+		if err != nil {
+			test.AddError(errors.Newf("🚨 failed to pull images from -from-registry: %s", err))
+		}
+		fmt.Println(out)
+		out, err = run.Cmd(ctx, "docker", "image", "pull", fmt.Sprintf("%smigrator:%s", ctx.Value(fromRegistryKey{}).(string), initVersion.String())).Run().String()
+		test.AddLog(out)
+		if err != nil {
+			test.AddError(errors.Newf("🚨 failed to pull images from -from-registry: %s", err))
+		}
+		fmt.Println(out)
+	}
+
+	// Pull images from registry if -target-registry is set
+	if ctx.Value(targetRegistryKey{}).(string) != "sourcegraph/" {
+		test.AddLog(fmt.Sprintf("🐋 pulling -target-registry images from %s", ctx.Value(targetRegistryKey{}).(string)))
+		out, err := run.Cmd(ctx, "docker", "image", "pull", fmt.Sprintf("%sfrontend:%s", ctx.Value(targetRegistryKey{}).(string), initVersion.String())).Run().String()
+		test.AddLog(out)
+		if err != nil {
+			test.AddError(errors.Newf("🚨 failed to pull images from -target-registry: %s", err))
+		}
+		out, err = run.Cmd(ctx, "docker", "image", "pull", fmt.Sprintf("%smigrator:%s", ctx.Value(targetRegistryKey{}).(string), initVersion.String())).Run().String()
+		test.AddLog(out)
+		if err != nil {
+			test.AddError(errors.Newf("🚨 failed to pull images from -target-registry: %s", err))
+		}
+		fmt.Println(out)
+	}
+
 	// Create a docker network for testing
 	//
 	// Docker bridge networks take up a lot of the docker daemons available port allocation. We run only a limited amount of test parallelization to get around this.
@@ -526,6 +559,7 @@ func startFrontend(ctx context.Context, test Test, image, version, networkName s
 	baseString = append(baseString, envString...)
 	cmdString = append(baseString, cmdString...)
 
+	// TODO: Improve log aggregation of frontend container runs
 	// Start the frontend container in goroutine to get logs
 	errChan := make(chan error)
 	go func() {

--- a/testing/tools/upgradetest/tests-util.go
+++ b/testing/tools/upgradetest/tests-util.go
@@ -731,6 +731,12 @@ func handleVersions(cCtx *cli.Context, overrideStd, overrideMVU, overrideAuto []
 		targetVersion = semver.MustParse("0.0.0+dev") // If no stamp version is set, we assume version is in dev
 	}
 
+	// Ensure latest tags
+	err = run.Cmd(ctx, "git", "fetch", "--tags").Run().Wait()
+	if err != nil {
+		return nil, nil, nil, nil, nil, nil, err
+	}
+
 	// Sort latest stable release tags
 	tags, err := run.Cmd(ctx, "git",
 		"for-each-ref",

--- a/testing/tools/upgradetest/tests-util.go
+++ b/testing/tools/upgradetest/tests-util.go
@@ -281,7 +281,17 @@ func setupTestEnv(ctx context.Context, testType string, initVersion *semver.Vers
 		}
 
 		// get the dynamically allocated port and register it to the test
-		port, err := run.Cmd(ctx, "docker", "port", db.ContainerName, "5432").Run().String()
+		out, err := run.Cmd(ctx, "docker", "port", db.ContainerName, "5432").Run().String()
+
+		// docker port can return multiple ports, ipv4 and ipv6, so we need to keep the former only.
+		ports := strings.Split(out, "\n")
+		var port string
+		if len(ports) < 1 {
+			test.AddError(errors.Newf("incorrect port output for %s", db.ContainerName))
+		} else {
+			port = ports[0]
+		}
+
 		if err != nil {
 			test.AddError(errors.Newf("🚨 failed to get port for %s: %s", db.ContainerName, err))
 		}

--- a/testing/tools/upgradetest/tests-util.go
+++ b/testing/tools/upgradetest/tests-util.go
@@ -43,7 +43,7 @@ func (t *Test) AddError(err error) {
 // DisplayErrors prints errors to stdout
 func (t *Test) DisplayErrors() {
 	for _, err := range t.Errors {
-		fmt.Println(err)
+		fmt.Println(err.Error())
 	}
 }
 

--- a/testing/tools/upgradetest/tests-util.go
+++ b/testing/tools/upgradetest/tests-util.go
@@ -257,7 +257,7 @@ func setupTestEnv(ctx context.Context, testType string, initVersion *semver.Vers
 			"--name", db.ContainerName,
 			"--network", networkName,
 			"-p", "5432",
-			fmt.Sprintf("sourcegraph/%s:%s", db.Image, initVersion),
+			fmt.Sprintf("%s%s:%s", ctx.Value(registryKey{}), db.Image, initVersion),
 		).Run().Wait()
 		if err != nil {
 			test.AddError(errors.Newf("🚨 failed to create test databases: %s", err))
@@ -313,7 +313,7 @@ func setupTestEnv(ctx context.Context, testType string, initVersion *semver.Vers
 
 	// Initialize the databases by running migrator with the `up` command.
 	test.LogLines = append(test.LogLines, "-- 🏗️  initializing database schemas with migrator")
-	out, err = run.Cmd(ctx, dockerMigratorBaseString(test, "up", fmt.Sprintf("sourcegraph/migrator:%s", initVersion), networkName, dbs)...).Run().String()
+	out, err = run.Cmd(ctx, dockerMigratorBaseString(test, "up", fmt.Sprintf("%smigrator:%s", ctx.Value(registryKey{}), initVersion), networkName, dbs)...).Run().String()
 	if err != nil {
 		test.AddError(errors.Newf("🚨 failed to initialize database: %w", err))
 	}
@@ -346,7 +346,7 @@ func setupTestEnv(ctx context.Context, testType string, initVersion *semver.Vers
 
 	//start frontend and poll db until initial version is set by frontend
 	var cleanFrontend func()
-	cleanFrontend, err = startFrontend(ctx, test, "sourcegraph/frontend", initVersion.String(), networkName, false, dbs)
+	cleanFrontend, err = startFrontend(ctx, test, fmt.Sprintf("%sfrontend", ctx.Value(registryKey{})), initVersion.String(), networkName, false, dbs)
 	if err != nil {
 		test.AddError(errors.Newf("🚨 failed to start frontend: %w", err))
 	}

--- a/testing/tools/upgradetest/tests-util.go
+++ b/testing/tools/upgradetest/tests-util.go
@@ -531,6 +531,7 @@ func startFrontend(ctx context.Context, test Test, image, version, networkName s
 	errChan := make(chan error)
 	go func() {
 		if _, err := run.Cmd(ctx, cmdString...).Run().String(); err != nil {
+			fmt.Println("🚨 failed to start frontend: ", err)
 			errChan <- err
 		}
 	}()

--- a/testing/tools/upgradetest/tests-util.go
+++ b/testing/tools/upgradetest/tests-util.go
@@ -238,22 +238,6 @@ func setupTestEnv(ctx context.Context, testType string, initVersion *semver.Vers
 		fmt.Println(out)
 	}
 
-	// Pull images from registry if -target-registry is set
-	if ctx.Value(targetRegistryKey{}).(string) != "sourcegraph/" {
-		test.AddLog(fmt.Sprintf("🐋 pulling -target-registry images from %s", ctx.Value(targetRegistryKey{}).(string)))
-		out, err := run.Cmd(ctx, "docker", "image", "pull", fmt.Sprintf("%sfrontend:%s", ctx.Value(targetRegistryKey{}).(string), initVersion.String())).Run().String()
-		test.AddLog(out)
-		if err != nil {
-			test.AddError(errors.Newf("🚨 failed to pull images from -target-registry: %s", err))
-		}
-		out, err = run.Cmd(ctx, "docker", "image", "pull", fmt.Sprintf("%smigrator:%s", ctx.Value(targetRegistryKey{}).(string), initVersion.String())).Run().String()
-		test.AddLog(out)
-		if err != nil {
-			test.AddError(errors.Newf("🚨 failed to pull images from -target-registry: %s", err))
-		}
-		fmt.Println(out)
-	}
-
 	// Create a docker network for testing
 	//
 	// Docker bridge networks take up a lot of the docker daemons available port allocation. We run only a limited amount of test parallelization to get around this.

--- a/testing/tools/upgradetest/tests-util.go
+++ b/testing/tools/upgradetest/tests-util.go
@@ -252,19 +252,19 @@ func setupTestEnv(ctx context.Context, testType string, initVersion *semver.Vers
 	test.AddLog(fmt.Sprintf("Upgrading from version (%s) to release candidate.", initVersion))
 	test.AddLog("-- 🏗️  setting up test environment")
 
-	// Pull images from registry if -from-registry is set
+	// Pull images from registry if -target-registry is set
 	if ctx.Value(fromRegistryKey{}).(string) != "sourcegraph/" {
-		test.AddLog(fmt.Sprintf("🐋 pulling -from-registry images from %s", ctx.Value(fromRegistryKey{}).(string)))
+		test.AddLog(fmt.Sprintf("🐋 pulling -target-registry images from %s", ctx.Value(fromRegistryKey{}).(string)))
 		out, err := run.Cmd(ctx, "docker", "image", "pull", fmt.Sprintf("%sfrontend:%s", ctx.Value(fromRegistryKey{}).(string), initVersion.String())).Run().String()
 		test.AddLog(out)
 		if err != nil {
-			test.AddError(errors.Newf("🚨 failed to pull images from -from-registry: %s", err))
+			test.AddError(errors.Newf("🚨 failed to pull images from -target-registry: %s", err))
 		}
 		fmt.Println(out)
 		out, err = run.Cmd(ctx, "docker", "image", "pull", fmt.Sprintf("%smigrator:%s", ctx.Value(fromRegistryKey{}).(string), initVersion.String())).Run().String()
 		test.AddLog(out)
 		if err != nil {
-			test.AddError(errors.Newf("🚨 failed to pull images from -from-registry: %s", err))
+			test.AddError(errors.Newf("🚨 failed to pull images from -target-registry: %s", err))
 		}
 		fmt.Println(out)
 	}

--- a/testing/tools/upgradetest/tests-util.go
+++ b/testing/tools/upgradetest/tests-util.go
@@ -290,7 +290,7 @@ func setupTestEnv(ctx context.Context, testType string, initVersion *semver.Vers
 
 	// Create a timeout to validate the databases have initialized, this is to prevent a hung test
 	// When many goroutines are running this test this is a point of failure.
-	dbPingTimeout, cancel := context.WithTimeout(ctx, time.Second*120)
+	dbPingTimeout, cancel := context.WithTimeout(ctx, time.Second*220)
 	wgDbPing := pool.New().WithErrors().WithContext(dbPingTimeout)
 	defer cancel()
 

--- a/testing/tools/upgradetest/tests.go
+++ b/testing/tools/upgradetest/tests.go
@@ -28,9 +28,9 @@ func standardUpgradeTest(ctx context.Context, initVersion, targetVersion, latest
 	// Use the latest stable migrator for a pre release test, and the target version migrator if testing a released version
 	var migratorImage string
 	if postRelease != "" {
-		migratorImage = fmt.Sprintf("sourcegraph/migrator:%s", postRelease)
+		migratorImage = fmt.Sprintf("%smigrator:%s", ctx.Value(registryKey{}), postRelease)
 	} else {
-		migratorImage = fmt.Sprintf("sourcegraph/migrator:%s", latestStableVersion.String())
+		migratorImage = fmt.Sprintf("%smigrator:%s", ctx.Value(registryKey{}), latestStableVersion.String())
 	}
 
 	// ensure env correctly initialized
@@ -42,7 +42,7 @@ func standardUpgradeTest(ctx context.Context, initVersion, targetVersion, latest
 	test.AddLog("-- ⚙️  performing standard upgrade")
 
 	if postRelease != "" {
-		migratorImage = fmt.Sprintf("sourcegraph/migrator:%s", postRelease)
+		migratorImage = fmt.Sprintf("%smigrator:%s", ctx.Value(registryKey{}), postRelease)
 	} else {
 		migratorImage = "migrator:candidate"
 	}
@@ -58,7 +58,7 @@ func standardUpgradeTest(ctx context.Context, initVersion, targetVersion, latest
 	// Start frontend with candidate
 	var cleanFrontend func()
 	if postRelease != "" {
-		cleanFrontend, err = startFrontend(ctx, test, "sourcegraph/frontend", postRelease, networkName, false, dbs)
+		cleanFrontend, err = startFrontend(ctx, test, fmt.Sprintf("%sfrontend", ctx.Value(registryKey{})), postRelease, networkName, false, dbs)
 	} else {
 		cleanFrontend, err = startFrontend(ctx, test, "frontend", "candidate", networkName, false, dbs)
 	}
@@ -72,7 +72,7 @@ func standardUpgradeTest(ctx context.Context, initVersion, targetVersion, latest
 	test.AddLog("-- ⚙️  post upgrade validation")
 	// Validate the upgrade
 	if postRelease != "" {
-		migratorImage = fmt.Sprintf("sourcegraph/migrator:%s", postRelease)
+		migratorImage = fmt.Sprintf("%smigrator:%s", ctx.Value(registryKey{}), postRelease)
 	} else {
 		migratorImage = "migrator:candidate"
 	}
@@ -101,9 +101,9 @@ func multiversionUpgradeTest(ctx context.Context, initVersion, targetVersion, la
 	// Use the latest stable migrator for a pre release test, and the target version migrator if testing a released version
 	var migratorImage string
 	if postRelease != "" {
-		migratorImage = fmt.Sprintf("sourcegraph/migrator:%s", postRelease)
+		migratorImage = fmt.Sprintf("%smigrator:%s", ctx.Value(registryKey{}), postRelease)
 	} else {
-		migratorImage = fmt.Sprintf("sourcegraph/migrator:%s", latestStableVersion.String())
+		migratorImage = fmt.Sprintf("%smigrator:%s", ctx.Value(registryKey{}), latestStableVersion.String())
 	}
 
 	// ensure env correctly initialized
@@ -124,7 +124,7 @@ func multiversionUpgradeTest(ctx context.Context, initVersion, targetVersion, la
 	}
 	test.AddLog(fmt.Sprintf("-- ⚙️  performing multiversion upgrade (--from %s --to %s)", initVersion.String(), toVersion))
 	if postRelease != "" {
-		migratorImage = fmt.Sprintf("sourcegraph/migrator:%s", postRelease)
+		migratorImage = fmt.Sprintf("%smigrator:%s", ctx.Value(registryKey{}), postRelease)
 	} else {
 		migratorImage = "migrator:candidate"
 	}
@@ -192,9 +192,9 @@ func autoUpgradeTest(ctx context.Context, initVersion, targetVersion, latestStab
 	// Use the latest stable migrator for a pre release test, and the target version migrator if testing a released version
 	var migratorImage string
 	if postRelease != "" {
-		migratorImage = fmt.Sprintf("sourcegraph/migrator:%s", postRelease)
+		migratorImage = fmt.Sprintf("%smigrator:%s", ctx.Value(registryKey{}), postRelease)
 	} else {
-		migratorImage = fmt.Sprintf("sourcegraph/migrator:%s", latestStableVersion.String())
+		migratorImage = fmt.Sprintf("%smigrator:%s", ctx.Value(registryKey{}), latestStableVersion.String())
 	}
 
 	// ensure env correctly initialized
@@ -224,7 +224,7 @@ func autoUpgradeTest(ctx context.Context, initVersion, targetVersion, latestStab
 	test.AddLog("-- ⚙️  post upgrade validation")
 	// Validate the upgrade
 	if postRelease != "" {
-		migratorImage = fmt.Sprintf("sourcegraph/migrator:%s", postRelease)
+		migratorImage = fmt.Sprintf("%smigrator:%s", ctx.Value(registryKey{}), postRelease)
 	} else {
 		migratorImage = "migrator:candidate"
 	}

--- a/testing/tools/upgradetest/tests.go
+++ b/testing/tools/upgradetest/tests.go
@@ -152,7 +152,7 @@ func multiversionUpgradeTest(ctx context.Context, initVersion, targetVersion, la
 	// Start frontend with candidate unless a post release version is specified
 	var cleanFrontend func()
 	if postRelease != "" {
-		cleanFrontend, err = startFrontend(ctx, test, "sourcegraph/frontend", postRelease, networkName, false, dbs)
+		cleanFrontend, err = startFrontend(ctx, test, fmt.Sprintf("%sfrontend", ctx.Value(targetRegistryKey{})), postRelease, networkName, false, dbs)
 	} else {
 		cleanFrontend, err = startFrontend(ctx, test, "frontend", "candidate", networkName, false, dbs)
 	}
@@ -210,7 +210,7 @@ func autoUpgradeTest(ctx context.Context, initVersion, targetVersion, latestStab
 	// Start frontend with candidate
 	var cleanFrontend func()
 	if postRelease != "" {
-		cleanFrontend, err = startFrontend(ctx, test, "sourcegraph/frontend", postRelease, networkName, true, dbs)
+		cleanFrontend, err = startFrontend(ctx, test, fmt.Sprintf("%sfrontend", ctx.Value(targetRegistryKey{})), postRelease, networkName, true, dbs)
 	} else {
 		cleanFrontend, err = startFrontend(ctx, test, "frontend", "candidate", networkName, true, dbs)
 	}

--- a/testing/tools/upgradetest/tests.go
+++ b/testing/tools/upgradetest/tests.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/Masterminds/semver"
 
@@ -14,7 +15,7 @@ import (
 // standardUpgradeTest initializes Sourcegraph's dbs and runs a standard upgrade
 // i.e. an upgrade test between some last minor version and the current release candidate
 func standardUpgradeTest(ctx context.Context, initVersion, targetVersion, latestStableVersion *semver.Version) Test {
-	postRelease := ctx.Value(postReleaseKey{}).(string)
+	postRelease := strings.TrimPrefix(ctx.Value(postReleaseKey{}).(string), "v") // Post release version string
 
 	//start test env
 	test, networkName, dbs, cleanup, err := setupTestEnv(ctx, "standard", initVersion)
@@ -87,7 +88,7 @@ func standardUpgradeTest(ctx context.Context, initVersion, targetVersion, latest
 // multiversionUpgradeTest tests the migrator upgrade command,
 // initializing the three main dbs and conducting an upgrade to the release candidate version
 func multiversionUpgradeTest(ctx context.Context, initVersion, targetVersion, latestStableVersion *semver.Version) Test {
-	postRelease := ctx.Value(postReleaseKey{}).(string) // Post release version string
+	postRelease := strings.TrimPrefix(ctx.Value(postReleaseKey{}).(string), "v") // Post release version string
 
 	//start test env
 	test, networkName, dbs, cleanup, err := setupTestEnv(ctx, "multiversion", initVersion)
@@ -178,7 +179,7 @@ func multiversionUpgradeTest(ctx context.Context, initVersion, targetVersion, la
 // Without this in place autoupgrade fails and exits while trying to make an oobmigration comparison here: https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/cmd/frontend/internal/cli/autoupgrade.go?L67-76
 // {"SeverityText":"WARN","Timestamp":1706721478276103721,"InstrumentationScope":"frontend","Caller":"cli/autoupgrade.go:73","Function":"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/cli.tryAutoUpgrade","Body":"unexpected string for desired instance schema version, skipping auto-upgrade","Resource":{"service.name":"frontend","service.version":"devVersion","service.instance.id":"487754e1c54a"},"Attributes":{"version":"devVersion"}}
 func autoUpgradeTest(ctx context.Context, initVersion, targetVersion, latestStableVersion *semver.Version) Test {
-	postRelease := ctx.Value(postReleaseKey{}).(string) // Post release version string
+	postRelease := strings.TrimPrefix(ctx.Value(postReleaseKey{}).(string), "v") // Post release version string
 
 	//start test env
 	test, networkName, dbs, cleanup, err := setupTestEnv(ctx, "auto", initVersion)

--- a/testing/tools/upgradetest/tests.go
+++ b/testing/tools/upgradetest/tests.go
@@ -28,9 +28,9 @@ func standardUpgradeTest(ctx context.Context, initVersion, targetVersion, latest
 	// Use the latest stable migrator for a pre release test, and the target version migrator if testing a released version
 	var migratorImage string
 	if postRelease != "" {
-		migratorImage = fmt.Sprintf("%smigrator:%s", ctx.Value(registryKey{}), postRelease)
+		migratorImage = fmt.Sprintf("%smigrator:%s", ctx.Value(targetRegistryKey{}), postRelease)
 	} else {
-		migratorImage = fmt.Sprintf("%smigrator:%s", ctx.Value(registryKey{}), latestStableVersion.String())
+		migratorImage = fmt.Sprintf("%smigrator:%s", ctx.Value(fromRegistryKey{}), latestStableVersion.String())
 	}
 
 	// ensure env correctly initialized
@@ -42,7 +42,7 @@ func standardUpgradeTest(ctx context.Context, initVersion, targetVersion, latest
 	test.AddLog("-- ⚙️  performing standard upgrade")
 
 	if postRelease != "" {
-		migratorImage = fmt.Sprintf("%smigrator:%s", ctx.Value(registryKey{}), postRelease)
+		migratorImage = fmt.Sprintf("%smigrator:%s", ctx.Value(targetRegistryKey{}), postRelease)
 	} else {
 		migratorImage = "migrator:candidate"
 	}
@@ -58,7 +58,7 @@ func standardUpgradeTest(ctx context.Context, initVersion, targetVersion, latest
 	// Start frontend with candidate
 	var cleanFrontend func()
 	if postRelease != "" {
-		cleanFrontend, err = startFrontend(ctx, test, fmt.Sprintf("%sfrontend", ctx.Value(registryKey{})), postRelease, networkName, false, dbs)
+		cleanFrontend, err = startFrontend(ctx, test, fmt.Sprintf("%sfrontend", ctx.Value(targetRegistryKey{})), postRelease, networkName, false, dbs)
 	} else {
 		cleanFrontend, err = startFrontend(ctx, test, "frontend", "candidate", networkName, false, dbs)
 	}
@@ -72,7 +72,7 @@ func standardUpgradeTest(ctx context.Context, initVersion, targetVersion, latest
 	test.AddLog("-- ⚙️  post upgrade validation")
 	// Validate the upgrade
 	if postRelease != "" {
-		migratorImage = fmt.Sprintf("%smigrator:%s", ctx.Value(registryKey{}), postRelease)
+		migratorImage = fmt.Sprintf("%smigrator:%s", ctx.Value(targetRegistryKey{}), postRelease)
 	} else {
 		migratorImage = "migrator:candidate"
 	}
@@ -101,9 +101,9 @@ func multiversionUpgradeTest(ctx context.Context, initVersion, targetVersion, la
 	// Use the latest stable migrator for a pre release test, and the target version migrator if testing a released version
 	var migratorImage string
 	if postRelease != "" {
-		migratorImage = fmt.Sprintf("%smigrator:%s", ctx.Value(registryKey{}), postRelease)
+		migratorImage = fmt.Sprintf("%smigrator:%s", ctx.Value(targetRegistryKey{}), postRelease)
 	} else {
-		migratorImage = fmt.Sprintf("%smigrator:%s", ctx.Value(registryKey{}), latestStableVersion.String())
+		migratorImage = fmt.Sprintf("%smigrator:%s", ctx.Value(fromRegistryKey{}), latestStableVersion.String())
 	}
 
 	// ensure env correctly initialized
@@ -124,7 +124,7 @@ func multiversionUpgradeTest(ctx context.Context, initVersion, targetVersion, la
 	}
 	test.AddLog(fmt.Sprintf("-- ⚙️  performing multiversion upgrade (--from %s --to %s)", initVersion.String(), toVersion))
 	if postRelease != "" {
-		migratorImage = fmt.Sprintf("%smigrator:%s", ctx.Value(registryKey{}), postRelease)
+		migratorImage = fmt.Sprintf("%smigrator:%s", ctx.Value(targetRegistryKey{}), postRelease)
 	} else {
 		migratorImage = "migrator:candidate"
 	}
@@ -192,9 +192,9 @@ func autoUpgradeTest(ctx context.Context, initVersion, targetVersion, latestStab
 	// Use the latest stable migrator for a pre release test, and the target version migrator if testing a released version
 	var migratorImage string
 	if postRelease != "" {
-		migratorImage = fmt.Sprintf("%smigrator:%s", ctx.Value(registryKey{}), postRelease)
+		migratorImage = fmt.Sprintf("%smigrator:%s", ctx.Value(targetRegistryKey{}), postRelease)
 	} else {
-		migratorImage = fmt.Sprintf("%smigrator:%s", ctx.Value(registryKey{}), latestStableVersion.String())
+		migratorImage = fmt.Sprintf("%smigrator:%s", ctx.Value(fromRegistryKey{}), latestStableVersion.String())
 	}
 
 	// ensure env correctly initialized
@@ -224,7 +224,7 @@ func autoUpgradeTest(ctx context.Context, initVersion, targetVersion, latestStab
 	test.AddLog("-- ⚙️  post upgrade validation")
 	// Validate the upgrade
 	if postRelease != "" {
-		migratorImage = fmt.Sprintf("%smigrator:%s", ctx.Value(registryKey{}), postRelease)
+		migratorImage = fmt.Sprintf("%smigrator:%s", ctx.Value(targetRegistryKey{}), postRelease)
 	} else {
 		migratorImage = "migrator:candidate"
 	}


### PR DESCRIPTION
This PR introduces the `target-registry` and `from-registry` flags. These flags allow the specification of the image registry to pull from when running the upgrade test. `target-registry` sets the `migrator` image image registry as well as the `frontend` during the upgrade steps of the various upgrade test types. `from-registry` sets the image registry used to pull images on test env init -- initializing `pgsql`, `codeintel-db`, `codeinsights-db`, migrator`, and `frontend`. 

## Test plan
The following command works on main --
`bazel run //testing/tools/upgradetest:sh_upgradetest -- all -pv 5.3.9104 -svs 5.2.2 -mvs 5.1.0 -avs 5.1.0`

The command should work with new flag `bazel run //testing/tools/upgradetest:sh_upgradetest -- all -pv 5.3.9104 -svs 5.2.2 -mvs 5.1.0 -avs 5.1.0 -target-registry us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal/`

<details>

```
➜  sourcegraph git:(main) bazel run //testing/tools/upgradetest:sh_upgradetest -- all -pv 5.3.9104 -svs 5.2.2 -mvs 5.1.0 -avs 5.1.0
INFO: Analyzed target //testing/tools/upgradetest:sh_upgradetest (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //testing/tools/upgradetest:sh_upgradetest up-to-date:
  bazel-bin/testing/tools/upgradetest/sh_upgradetest
Aspect @@rules_rust//rust/private:clippy.bzl%rust_clippy_aspect of //testing/tools/upgradetest:sh_upgradetest up-to-date (nothing to build)
INFO: Elapsed time: 2.065s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
INFO: Running command line: external/bazel_tools/tools/test/test-setup.sh testing/tools/upgradetest/sh_upgradetest testing/tools/upgradetest/go_upgradetest_/go_upgradetest cmd/migrator/image_tarball.sh cmd/frontend/image_tarball.sh internal/database/_codeinsights_squashed.sql internal/database/_codeintel_squashed.sql internal/database/_frontend_squashed.sql internal/database/_schema.codeinsights.json internal/database/_schema.codeinsights.md internal/database/_schema.codeintel.json internal/database/_schema.codeintel.md internal/database/_schema.json internal/database/_schema.md all -pv 5.3.9104 -svs 5.2.2 -mvs 5.1.0 -avs 5.1.0
exec ${PAGER:-/usr/bin/less} "$0" || exit 1
Executing tests from //testing/tools/upgradetest:sh_upgradetest
-----------------------------------------------------------------------------
Loaded image: migrator:candidate
Loaded image: frontend:candidate
Latest stable release version:  5.3.9104
Latest minor version:  5.3.0
Target version:  5.3.9104
Migrator image used to upgrade:  sourcegraph/migrator:5.3.9104
Standard Versions: [5.2.2]
Multiversion Versions: [5.1.0]
Autoupgrade Versions: [5.1.0]
auto:  5.1.0
std:  5.2.2
mvu:  5.1.0
--- 🕵️  Standard Upgrade Tests:
✅ 5.2.2 Passed -- 44.370164625s
--- 🕵️  Multiversion Upgrade Tests:
✅ 5.1.0 Passed -- 47.75924125s
--- 🕵️  Auto Upgrade Tests:
✅ 5.1.0 Passed -- 45.660516292s
```

</details>

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
