### PR TITLE
ci: make pushed images annotation collapsible

### DIFF
--- a/dev/ci/push_all.sh
+++ b/dev/ci/push_all.sh
@@ -35,22 +35,22 @@ function echo_append_annotation() {
     if [ "$arg" != "--tag" ]; then
       if [ "$formatted_tags" == "" ]; then
         # Do not insert a comma for the first element
-        formatted_tags="\`$arg\`"
+        formatted_tags="<code>$arg</code>"
       else
-        formatted_tags="${formatted_tags}, \`$arg\`"
+        formatted_tags="${formatted_tags}, <code>$arg</code>"
       fi
     fi
   done
 
   for reg in "${registries[@]}"; do
     if [ "$formatted_registries" == "" ]; then
-      formatted_registries="\`$reg\`"
+      formatted_registries="<code>$reg</code>"
     else
-      formatted_registries="${formatted_registries}, \`$reg\`"
+      formatted_registries="${formatted_registries}, <code>$reg</code>"
     fi
   done
 
-  raw="| ${repository} | ${formatted_registries} | ${formatted_tags} |"
+  raw="<tr><td>${repository}</td><td>${formatted_registries}</td><td>${formatted_tags}</td></tr>"
   echo "echo -e '${raw}' >>./annotations/pushed_images.md"
 }
 
@@ -146,14 +146,13 @@ fi
 
 # Posting the preamble for image pushes.
 echo -e "### ${BUILDKITE_LABEL}" > ./annotations/pushed_images.md
-echo -e "\n| Name | Registries | Tags |\n|---|---|---|" >> ./annotations/pushed_images.md
+echo -e "<details><summary>Click to expand table</summary><table>\n" >>./annotations/pushed_images.md
+echo -e "<tr><th>Name</th><th>Registries</th><th>Tags</th></tr>\n" >> ./annotations/pushed_images.md
 
 preview_tags "${dev_registries[*]}" "${dev_tags[*]}"
 if $push_prod; then
   preview_tags "${prod_registries[*]}" "${prod_tags[*]}"
 fi
-
-echo "--- done"
 
 dev_tags_args=""
 for t in "${dev_tags[@]}"; do
@@ -184,9 +183,8 @@ for target in ${images[@]}; do
   fi
 done
 
-echo "-- jobfile"
+echo "--- :bash: Generated jobfile"
 cat "$job_file"
-echo "--- done"
 
 echo "--- :bazel::docker: Pushing images..."
 log_file=$(mktemp)
@@ -211,6 +209,7 @@ while read -r line; do
   fi
 done <"$log_file"
 
+echo -e "</table></details>" >>./annotations/pushed_images.md
+
 echo "--- :bazel::docker: detailed summary"
 cat "$log_file"
-echo "--- done"


### PR DESCRIPTION
Shrinks down the output from the "Push xyz images" buildkite annotation!

![image](https://github.com/sourcegraph/sourcegraph/assets/18282288/7f4d17bb-b295-4b09-91aa-cc16e5f68fb6)

![image](https://github.com/sourcegraph/sourcegraph/assets/18282288/46c64c6a-2114-4dd0-8128-2af28c758132)


## Test plan

See screenshots above for tested results
