### PR TITLE
Cody: increase size of context snippet

### DIFF
--- a/internal/codycontext/context.go
+++ b/internal/codycontext/context.go
@@ -350,10 +350,10 @@ func fileMatchToContextMatches(fm *result.FileMatch) []FileChunkContext {
 	// To provide some context variety, we just use the top-ranked
 	// chunk (the first chunk) from each file
 
-	// 4 lines of leading context, clamped to zero
-	startLine := max(0, fm.ChunkMatches[0].ContentStart.Line-4)
+	// 5 lines of leading context, clamped to zero
+	startLine := max(0, fm.ChunkMatches[0].ContentStart.Line-5)
 	// depend on content fetching to trim to the end of the file
-	endLine := startLine + 8
+	endLine := startLine + 20
 
 	return []FileChunkContext{{
 		RepoName:  fm.Repo.Name,


### PR DESCRIPTION
While comparing context retrieval strategies, I noticed that keyword context
was returning much smaller result snippets than we did from embeddings. In
general, providing more surrounding context to the LLM can only help the
response quality.

This PR increases the number of context lines we return to 20. The reasoning:
* We didn't have problems with embeddings exceeding the context window size
(7000 tokens by default!). So we can use at least as much context as we did for
embeddings.
* Each embedding chunk is roughly 1024 chars (see [Cody context napkin
numbers](https://docs.google.com/spreadsheets/d/1xt-vEbvuQ8OoHXjaP28_YRn83ao377QKxrLsZ4J_62Q/edit#gid=0)).
I tested a variety of file types (Go, Typescript, Markdown), and this roughly
corresponded to 20 lines. It's also a conservative estimate.

## Test plan

Covered by existing unit tests. Also tested a bunch of our "golden queries"
manually in Cody Web and the LLM responses looked good.