### PR TITLE
Svelte: simplify blob scrolling and fixup component composability

### DIFF
--- a/client/web-sveltekit/src/lib/CodeMirrorBlob.svelte
+++ b/client/web-sveltekit/src/lib/CodeMirrorBlob.svelte
@@ -28,6 +28,11 @@
         languages: string[]
     }
 
+    export interface Capture {
+        scrollTop: number
+        scrollLeft: number
+    }
+
     const extensionsCompartment = new Compartment()
 
     const defaultTheme = EditorView.theme({
@@ -153,6 +158,19 @@
 
     let editor: EditorView
     let container: HTMLDivElement | null = null
+
+    export function capture(): Capture {
+        return {
+            scrollTop: editor.scrollDOM.scrollTop,
+            scrollLeft: editor.scrollDOM.scrollLeft,
+        }
+    }
+
+    export function restore(data: Capture) {
+        console.log({ data, scrollDOM: editor.scrollDOM })
+        editor.scrollDOM.scrollTop = data.scrollTop
+        editor.scrollDOM.scrollLeft = data.scrollLeft
+    }
 
     const lineNumbers = selectableLineNumbers({
         onSelection(range) {

--- a/client/web-sveltekit/src/lib/dom.ts
+++ b/client/web-sveltekit/src/lib/dom.ts
@@ -210,33 +210,6 @@ export const computeFit: Action<HTMLElement, void, ComputeFitAttributes> = node 
 }
 
 /**
- * Helper action to manage CSS classes on an element. This is used on svelte:body because
- * it doesn't support the class directive.
- * See https://github.com/sveltejs/svelte/issues/3105
- */
-export const classNames: Action<HTMLElement, string | string[]> = (node, classes) => {
-    // Converts the input to an array of non-empty strings.
-    // Empty strings are not valid inputs for classList and would throw an error.
-    function clean(classes: string | string[]): string[] {
-        return (Array.isArray(classes) ? classes : [classes]).filter(cls => cls.trim().length > 0)
-    }
-
-    classes = clean(classes)
-    node.classList.add(...classes)
-
-    return {
-        update(newClasses) {
-            node.classList.remove(...classes)
-            classes = clean(newClasses)
-            node.classList.add(...classes)
-        },
-        destroy() {
-            node.classList.remove(...classes)
-        },
-    }
-}
-
-/**
  * An action to move the attached element to the end of the document body.
  */
 export const portal: Action<HTMLElement> = target => {

--- a/client/web-sveltekit/src/lib/global-notifications/GlobalNotifications.svelte
+++ b/client/web-sveltekit/src/lib/global-notifications/GlobalNotifications.svelte
@@ -1,6 +1,7 @@
 <script lang="ts" context="module">
-    import { AlertType } from '$lib/graphql-types'
     import { formatDistanceStrict, isAfter } from 'date-fns'
+
+    import { AlertType } from '$lib/graphql-types'
 
     type PossibleAlertVariation = 'info' | 'warning' | 'danger'
 
@@ -33,13 +34,13 @@
 </script>
 
 <script lang="ts">
-    import { settings } from '$lib/stores'
-
-    import { Markdown } from '$lib/wildcard'
-    import DismissibleAlert from './DismissibleAlert.svelte'
-
-    import type { GlobalNotifications } from './GlobalNotifications.gql'
     import { differenceInDays, parseISO } from 'date-fns'
+
+    import { settings } from '$lib/stores'
+    import { Markdown } from '$lib/wildcard'
+
+    import DismissibleAlert from './DismissibleAlert.svelte'
+    import type { GlobalNotifications } from './GlobalNotifications.gql'
 
     export let globalAlerts: GlobalNotifications
 
@@ -116,11 +117,6 @@
 <style lang="scss">
     .root {
         width: 100%;
-        border-top: 1px solid var(--border-color-2);
-
-        &:empty {
-            display: none;
-        }
     }
 
     .proxy-link {

--- a/client/web-sveltekit/src/lib/stores.ts
+++ b/client/web-sveltekit/src/lib/stores.ts
@@ -81,5 +81,3 @@ export function createLocalWritable<T>(localStorageKey: string, defaultValue: T)
         },
     }
 }
-
-export const scrollAll = writable(false)

--- a/client/web-sveltekit/src/routes/+layout.svelte
+++ b/client/web-sveltekit/src/routes/+layout.svelte
@@ -109,6 +109,12 @@
 </div>
 
 <style lang="scss">
+    .inner-body {
+        display: flex;
+        flex-direction: column;
+        height: 100%;
+    }
+
     main {
         isolation: isolate;
         flex: 1;
@@ -116,11 +122,5 @@
         flex-direction: column;
         box-sizing: border-box;
         min-height: 0;
-    }
-
-    .inner-body {
-        display: flex;
-        flex-direction: column;
-        height: 100%;
     }
 </style>

--- a/client/web-sveltekit/src/routes/+layout.svelte
+++ b/client/web-sveltekit/src/routes/+layout.svelte
@@ -3,9 +3,8 @@
 
     import { browser, dev } from '$app/environment'
     import { isErrorLike } from '$lib/common'
-    import { classNames } from '$lib/dom'
     import { TemporarySettingsStorage } from '$lib/shared'
-    import { isLightTheme, setAppContext, scrollAll } from '$lib/stores'
+    import { isLightTheme, setAppContext } from '$lib/stores'
     import { createTemporarySettingsStorage } from '$lib/temporarySettings'
 
     import Header from './Header.svelte'

--- a/client/web-sveltekit/src/routes/+layout.svelte
+++ b/client/web-sveltekit/src/routes/+layout.svelte
@@ -94,13 +94,13 @@
     <meta name="description" content="Code search" />
 </svelte:head>
 
-{#await data.globalSiteAlerts then globalSiteAlerts}
-    {#if globalSiteAlerts}
-        <GlobalNotification globalAlerts={globalSiteAlerts} />
-    {/if}
-{/await}
-
 <div class="inner-body">
+    {#await data.globalSiteAlerts then globalSiteAlerts}
+        {#if globalSiteAlerts}
+            <GlobalNotification globalAlerts={globalSiteAlerts} />
+        {/if}
+    {/await}
+
     <Header authenticatedUser={$user} {handleOptOut} />
 
     <main>

--- a/client/web-sveltekit/src/routes/+layout.svelte
+++ b/client/web-sveltekit/src/routes/+layout.svelte
@@ -94,37 +94,33 @@
     <meta name="description" content="Code search" />
 </svelte:head>
 
-<svelte:body use:classNames={$scrollAll ? '' : 'overflowHidden'} />
-
 {#await data.globalSiteAlerts then globalSiteAlerts}
     {#if globalSiteAlerts}
         <GlobalNotification globalAlerts={globalSiteAlerts} />
     {/if}
 {/await}
 
-<Header authenticatedUser={$user} {handleOptOut} />
+<div class="inner-body">
+    <Header authenticatedUser={$user} {handleOptOut} />
 
-<main>
-    <slot />
-</main>
+    <main>
+        <slot />
+    </main>
+</div>
 
 <style lang="scss">
-    :global(body.overflowHidden) {
-        display: flex;
-        flex-direction: column;
-        height: 100vh;
-        overflow: hidden;
-
-        main {
-            overflow-y: auto;
-        }
-    }
-
     main {
         isolation: isolate;
         flex: 1;
         display: flex;
         flex-direction: column;
         box-sizing: border-box;
+        min-height: 0;
+    }
+
+    .inner-body {
+        display: flex;
+        flex-direction: column;
+        height: 100%;
     }
 </style>

--- a/client/web-sveltekit/src/routes/+layout.svelte
+++ b/client/web-sveltekit/src/routes/+layout.svelte
@@ -118,9 +118,6 @@
     main {
         isolation: isolate;
         flex: 1;
-        display: flex;
-        flex-direction: column;
-        box-sizing: border-box;
         min-height: 0;
     }
 </style>

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/+layout.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/+layout.svelte
@@ -172,10 +172,8 @@
 <style lang="scss">
     section {
         display: flex;
-        flex: 1;
-        flex-shrink: 0;
         background-color: var(--code-bg);
-        min-height: 100vh;
+        height: 100%;
     }
 
     .sidebar {
@@ -190,7 +188,6 @@
         padding-bottom: 0;
         position: sticky;
         top: 0px;
-        max-height: 100vh;
     }
 
     .main {

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/+layout.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/+layout.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { onMount, tick } from 'svelte'
+    import { tick } from 'svelte'
 
     import { afterNavigate, disableScrollHandling, goto } from '$app/navigation'
     import { page } from '$app/stores'
@@ -11,7 +11,6 @@
     import SidebarToggleButton from '$lib/repo/SidebarToggleButton.svelte'
     import { sidebarOpen } from '$lib/repo/stores'
     import Separator, { getSeparatorPosition } from '$lib/Separator.svelte'
-    import { scrollAll } from '$lib/stores'
     import TabPanel from '$lib/TabPanel.svelte'
     import Tabs from '$lib/Tabs.svelte'
     import { Alert } from '$lib/wildcard'
@@ -93,12 +92,6 @@
 
     const sidebarSize = getSeparatorPosition('repo-sidebar', 0.2)
     $: sidebarWidth = `max(200px, ${$sidebarSize * 100}%)`
-
-    onMount(() => {
-        // We want the whole page to be scrollable and hide page and repo navigation
-        scrollAll.set(true)
-        return () => scrollAll.set(false)
-    })
 
     afterNavigate(() => {
         // When navigating to a new page we want to ensure two things:

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/+page.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/+page.svelte
@@ -93,8 +93,10 @@
         {/await}
     {:else if blob}
         {#if blob.richHTML && !showRaw}
-            <div class={`rich ${markdownStyles.markdown}`}>
-                {@html blob.richHTML}
+            <div class="rich-scroller">
+                <div class={`rich-content ${markdownStyles.markdown}`}>
+                    {@html blob.richHTML}
+                </div>
             </div>
         {:else}
             <CodeMirrorBlob
@@ -155,9 +157,13 @@
     }
 
     .rich {
-        padding: 1rem;
-        overflow: auto;
-        max-width: 50rem;
+        &-scroller {
+            padding: 2rem;
+            overflow: auto;
+        }
+        &-content {
+            max-width: 50rem;
+        }
     }
 
     .circle {

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/-/branches/+layout.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/-/branches/+layout.svelte
@@ -36,7 +36,8 @@
 
     section {
         overflow: auto;
-        margin-top: 2rem;
+        height: 100%;
+        padding-top: 2rem;
     }
 
     div {

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/-/commit/[...revspec]/+page.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/-/commit/[...revspec]/+page.svelte
@@ -1,14 +1,15 @@
 <script lang="ts">
+    import { get } from 'svelte/store'
+
+    import { navigating } from '$app/stores'
     import Commit from '$lib/Commit.svelte'
     import LoadingSpinner from '$lib/LoadingSpinner.svelte'
-
-    import type { PageData, Snapshot } from './$types'
     import FileDiff from '$lib/repo/FileDiff.svelte'
     import Scroller, { type Capture as ScrollerCapture } from '$lib/Scroller.svelte'
-    import { get } from 'svelte/store'
-    import { navigating } from '$app/stores'
-    import type { CommitPage_DiffConnection } from './page.gql'
     import { Alert } from '$lib/wildcard'
+
+    import type { PageData, Snapshot } from './$types'
+    import type { CommitPage_DiffConnection } from './page.gql'
 
     interface Capture {
         scroll: ScrollerCapture
@@ -96,6 +97,7 @@
 <style lang="scss">
     section {
         overflow: auto;
+        height: 100%;
     }
 
     .header {

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/-/commits/+page.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/-/commits/+page.svelte
@@ -1,12 +1,13 @@
 <script lang="ts">
-    import Commit from '$lib/Commit.svelte'
+    import { get } from 'svelte/store'
 
-    import type { PageData, Snapshot } from './$types'
+    import { navigating } from '$app/stores'
+    import Commit from '$lib/Commit.svelte'
     import LoadingSpinner from '$lib/LoadingSpinner.svelte'
     import Scroller, { type Capture as ScrollerCapture } from '$lib/Scroller.svelte'
-    import { get } from 'svelte/store'
-    import { navigating } from '$app/stores'
     import { Alert } from '$lib/wildcard'
+
+    import type { PageData, Snapshot } from './$types'
     import type { CommitsPage_GitCommitConnection } from './page.gql'
 
     export let data: PageData
@@ -80,9 +81,8 @@
 
 <style lang="scss">
     section {
-        flex: 1;
-        min-height: 0;
         overflow: hidden;
+        height: 100%;
     }
 
     ul,

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/-/stats/contributors/+page.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/-/stats/contributors/+page.svelte
@@ -1,15 +1,15 @@
 <script lang="ts">
     import { goto } from '$app/navigation'
     import { page } from '$app/stores'
+    import Avatar from '$lib/Avatar.svelte'
     import LoadingSpinner from '$lib/LoadingSpinner.svelte'
     import Paginator from '$lib/Paginator.svelte'
     import Timestamp from '$lib/Timestamp.svelte'
-    import Avatar from '$lib/Avatar.svelte'
     import { createPromiseStore } from '$lib/utils'
     import { Alert, Button, ButtonGroup } from '$lib/wildcard'
-    import type { ContributorConnection } from './page.gql'
 
     import type { PageData } from './$types'
+    import type { ContributorConnection } from './page.gql'
 
     export let data: PageData
 
@@ -122,8 +122,9 @@
 
 <style lang="scss">
     section {
+        height: 100%;
         overflow: auto;
-        margin-top: 2rem;
+        padding-top: 2rem;
     }
 
     div.root {

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/-/tags/+page.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/-/tags/+page.svelte
@@ -40,14 +40,15 @@
 </section>
 
 <style lang="scss">
+    section {
+        height: 100%;
+        overflow: auto;
+        padding-top: 2rem;
+    }
+
     table {
         width: 100%;
         border-spacing: 0;
-    }
-
-    section {
-        overflow: auto;
-        margin-top: 2rem;
     }
 
     div {

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/+layout.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/+layout.svelte
@@ -9,15 +9,16 @@
         mdiSourceRepository,
         mdiTag,
     } from '@mdi/js'
+    import { writable } from 'svelte/store'
+
+    import { getButtonClassName } from '@sourcegraph/wildcard'
 
     import { page } from '$app/stores'
+    import { computeFit } from '$lib/dom'
     import Icon from '$lib/Icon.svelte'
+    import { DropdownMenu, MenuLink } from '$lib/wildcard'
 
     import type { LayoutData } from './$types'
-    import { DropdownMenu, MenuLink } from '$lib/wildcard'
-    import { computeFit } from '$lib/dom'
-    import { writable } from 'svelte/store'
-    import { getButtonClassName } from '@sourcegraph/wildcard'
     import RepoSearchInput from './RepoSearchInput.svelte'
 
     export let data: LayoutData
@@ -101,7 +102,10 @@
     </DropdownMenu>
     <RepoSearchInput repoName={data.repoName} />
 </nav>
-<slot />
+
+<div class="content">
+    <slot />
+</div>
 
 <style lang="scss">
     nav {
@@ -165,5 +169,10 @@
 
     nav {
         color: var(--body-color);
+    }
+
+    .content {
+        flex: 1;
+        min-height: 0;
     }
 </style>

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/+layout.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/+layout.svelte
@@ -61,53 +61,61 @@
     <title>{data.displayRepoName} - Sourcegraph</title>
 </svelte:head>
 
-<nav aria-label="repository">
-    <h1><a href="/{repoName}"><Icon svgPath={mdiSourceRepository} inline /> {displayRepoName}</a></h1>
-    <!--
+<div class="root">
+    <nav aria-label="repository">
+        <h1><a href="/{repoName}"><Icon svgPath={mdiSourceRepository} inline /> {displayRepoName}</a></h1>
+        <!--
         TODO: Add back revision
         {#if revisionLabel}
             @ <span class="button">{revisionLabel}</span>
         {/if}
         -->
-    <ul use:computeFit on:fit={event => (visibleNavEntries = event.detail.itemCount)}>
-        {#each navEntriesToShow as entry}
-            {@const href = data.repoURL + entry.path}
-            <li>
-                <a {href} aria-current={isActive(href, $page.url) ? 'page' : undefined}>
-                    {#if entry.icon}
-                        <Icon svgPath={entry.icon} inline />
-                    {/if}
-                    <span class="ml-1">{entry.title}</span>
-                </a>
-            </li>
-        {/each}
-    </ul>
-    <DropdownMenu
-        open={menuOpen}
-        triggerButtonClass={getButtonClassName({ variant: 'secondary', outline: true, size: 'sm' })}
-        aria-label="{$menuOpen ? 'Close' : 'Open'} repo navigation"
-    >
-        <svelte:fragment slot="trigger">&hellip;</svelte:fragment>
-        {#each allMenuEntries as entry}
-            {@const href = data.repoURL + entry.path}
-            <MenuLink {href}>
-                <span class="overflow-entry" class:active={isActive(href, $page.url)}>
-                    {#if entry.icon}
-                        <Icon svgPath={entry.icon} inline />
-                    {/if}
-                    <span class="ml-1">{entry.title}</span>
-                </span>
-            </MenuLink>
-        {/each}
-    </DropdownMenu>
-    <RepoSearchInput repoName={data.repoName} />
-</nav>
+        <ul use:computeFit on:fit={event => (visibleNavEntries = event.detail.itemCount)}>
+            {#each navEntriesToShow as entry}
+                {@const href = data.repoURL + entry.path}
+                <li>
+                    <a {href} aria-current={isActive(href, $page.url) ? 'page' : undefined}>
+                        {#if entry.icon}
+                            <Icon svgPath={entry.icon} inline />
+                        {/if}
+                        <span class="ml-1">{entry.title}</span>
+                    </a>
+                </li>
+            {/each}
+        </ul>
+        <DropdownMenu
+            open={menuOpen}
+            triggerButtonClass={getButtonClassName({ variant: 'secondary', outline: true, size: 'sm' })}
+            aria-label="{$menuOpen ? 'Close' : 'Open'} repo navigation"
+        >
+            <svelte:fragment slot="trigger">&hellip;</svelte:fragment>
+            {#each allMenuEntries as entry}
+                {@const href = data.repoURL + entry.path}
+                <MenuLink {href}>
+                    <span class="overflow-entry" class:active={isActive(href, $page.url)}>
+                        {#if entry.icon}
+                            <Icon svgPath={entry.icon} inline />
+                        {/if}
+                        <span class="ml-1">{entry.title}</span>
+                    </span>
+                </MenuLink>
+            {/each}
+        </DropdownMenu>
+        <RepoSearchInput repoName={data.repoName} />
+    </nav>
 
-<div class="content">
-    <slot />
+    <div class="content">
+        <slot />
+    </div>
 </div>
 
 <style lang="scss">
+    .root {
+        height: 100%;
+        display: flex;
+        flex-direction: column;
+    }
+
     nav {
         display: flex;
         align-items: center;

--- a/client/web-sveltekit/src/routes/search/SearchHome.svelte
+++ b/client/web-sveltekit/src/routes/search/SearchHome.svelte
@@ -30,11 +30,11 @@
 
 <style lang="scss">
     section {
+        height: 100%;
         overflow-y: auto;
         padding: 0 1rem;
         display: flex;
         flex-direction: column;
-        flex: 1;
         align-items: center;
     }
 

--- a/client/web-sveltekit/src/routes/search/SearchResults.svelte
+++ b/client/web-sveltekit/src/routes/search/SearchResults.svelte
@@ -126,49 +126,62 @@
     <title>{queryFromURL} - Sourcegraph</title>
 </svelte:head>
 
-<div class="search">
-    <SearchInput {queryState} />
-</div>
+<div class="root">
+    <div class="search">
+        <SearchInput {queryState} />
+    </div>
 
-<div class="search-results">
-    <div style:width={`clamp(14rem, ${$filtersSidebarPosition * 100}%, 35%)`}>
-        <DynamicFiltersSidebar {selectedFilters} streamFilters={$stream.filters} searchQuery={queryFromURL} {state} />
-    </div>
-    <Separator currentPosition={filtersSidebarPosition} />
-    <div class="results">
-        <aside class="actions">
-            <StreamingProgress {state} progress={$stream.progress} on:submit={onResubmitQuery} />
-        </aside>
-        <div class="result-list" bind:this={resultContainer}>
-            <ol>
-                {#each resultsToShow as result, i}
-                    {@const component = getSearchResultComponent(result)}
-                    {#if i === resultsToShow.length - 1}
-                        <li use:observeIntersection on:intersecting={loadMore}>
-                            <svelte:component this={component} {result} />
-                        </li>
-                    {:else}
-                        <li><svelte:component this={component} {result} /></li>
-                    {/if}
-                {/each}
-            </ol>
-            {#if resultsToShow.length === 0 && state !== 'loading'}
-                <div class="no-result">
-                    <Icon svgPath={mdiCloseOctagonOutline} />
-                    <p>No results found</p>
-                </div>
-            {/if}
+    <div class="search-results">
+        <div style:width={`clamp(14rem, ${$filtersSidebarPosition * 100}%, 35%)`}>
+            <DynamicFiltersSidebar
+                {selectedFilters}
+                streamFilters={$stream.filters}
+                searchQuery={queryFromURL}
+                {state}
+            />
         </div>
-    </div>
-    {#if $previewResult}
-        <Separator currentPosition={previewSidebarPosition} />
-        <div style:width={`clamp(10rem, ${100 - $previewSidebarPosition * 100}%, 50%)`}>
-            <PreviewPanel result={$previewResult} />
+        <Separator currentPosition={filtersSidebarPosition} />
+        <div class="results">
+            <aside class="actions">
+                <StreamingProgress {state} progress={$stream.progress} on:submit={onResubmitQuery} />
+            </aside>
+            <div class="result-list" bind:this={resultContainer}>
+                <ol>
+                    {#each resultsToShow as result, i}
+                        {@const component = getSearchResultComponent(result)}
+                        {#if i === resultsToShow.length - 1}
+                            <li use:observeIntersection on:intersecting={loadMore}>
+                                <svelte:component this={component} {result} />
+                            </li>
+                        {:else}
+                            <li><svelte:component this={component} {result} /></li>
+                        {/if}
+                    {/each}
+                </ol>
+                {#if resultsToShow.length === 0 && state !== 'loading'}
+                    <div class="no-result">
+                        <Icon svgPath={mdiCloseOctagonOutline} />
+                        <p>No results found</p>
+                    </div>
+                {/if}
+            </div>
         </div>
-    {/if}
+        {#if $previewResult}
+            <Separator currentPosition={previewSidebarPosition} />
+            <div style:width={`clamp(10rem, ${100 - $previewSidebarPosition * 100}%, 50%)`}>
+                <PreviewPanel result={$previewResult} />
+            </div>
+        {/if}
+    </div>
 </div>
 
 <style lang="scss">
+    .root {
+        height: 100%;
+        display: flex;
+        flex-direction: column;
+    }
+
     .search {
         border-bottom: 1px solid var(--border-color);
         align-self: stretch;


### PR DESCRIPTION
This makes various changes to scrolling behavior in the Svelte prototype.

The biggest change is removing the "scroll file contents to full page size" behavior so that we can bring the page closer to the designs. 

There are a few other changes to make components/pages/layouts more independent and not assume things about the parent they are rendered into. In particular, I made a few changes to our layouts assuming they are being rendered into a flex box.

Comments inline. I recommend reviewing by hiding whitespace-only changes.

## Test plan

See [Loom video](https://www.loom.com/looms/videos)