### PR TITLE
fix(docs): no delivery if triggered without changes

### DIFF
--- a/doc/_generated.push.sh
+++ b/doc/_generated.push.sh
@@ -49,7 +49,16 @@ find docs/admin/observability -name "*.md" -print0 | xargs --null --no-run-if-em
 find docs/cli -name "*.md" -print0 | xargs --null --no-run-if-empty rm
 
 git add .
-git diff
+
+# git diff --exit-code returns non-zero if there is an actual diff. So if there is none, it means that there is
+# nothing to deliver and we can safely stop here.
+if git diff --exit-code; then
+    echo "No changes detected on the generated docs, exiting gracefully without delivering a PR on the docs."
+    echo "This most likely happened because an input changed, such as the tools but the actual output, i.e."
+    echo "the generated docs, didn't change."
+    exit 0
+fi
+
 git commit -m "🤖 sync'ing generated docs"
 
 git push origin "$_branch"


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/devx-support/issues/769

## Test plan

Tested locally, to make sure we get the right if predicate, it's always confusing when dealing with exit code. 

CI 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
