### PR TITLE
chore(rel): exit if no steps are defined

### DIFF
--- a/dev/sg/internal/release/config.go
+++ b/dev/sg/internal/release/config.go
@@ -303,7 +303,7 @@ func (r *releaseRunner) CreateRelease(ctx context.Context) error {
 	// We don't want to accidentally think the release creation worked if there are no steps defined.
 	if len(steps) == 0 {
 		sayFail("create", "No steps defined for %s release", r.typ)
-		return fmt.Errorf("no steps defined for %s release", r.typ)
+		return errors.Newf("no steps defined for %s release", r.typ)
 	}
 
 	announce2("create", "Will create a %s release %q", r.typ, r.version)

--- a/dev/sg/internal/release/config.go
+++ b/dev/sg/internal/release/config.go
@@ -300,6 +300,12 @@ func (r *releaseRunner) CreateRelease(ctx context.Context) error {
 		steps = r.m.Internal.Create.Steps.Major
 	}
 
+	// We don't want to accidentally think the release creation worked if there are no steps defined.
+	if len(steps) == 0 {
+		sayFail("create", "No steps defined for %s release", r.typ)
+		return fmt.Errorf("no steps defined for %s release", r.typ)
+	}
+
 	announce2("create", "Will create a %s release %q", r.typ, r.version)
 	return r.runSteps(ctx, steps)
 }


### PR DESCRIPTION
@burmudar rightfully mentioned that if we don't have steps, the tooling would still appear to be working, which might be confusing, as well, nothing would happen, just green text and exit 0. 

## Test plan

CI

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
