### PR TITLE
Don't use bazel for Cody Gateway

### DIFF
--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -1384,7 +1384,6 @@ commandsets:
       - blobstore
       - embeddings
       - telemetry-gateway
-    bazelCommands:
       - cody-gateway
     env:
       SOURCEGRAPHDOTCOM_MODE: true


### PR DESCRIPTION
Running Cody Gateway as a Bazel command doesn't [play nicely ](https://sourcegraph.slack.com/archives/C05497E9MDW/p1710488108310269)with multiple levels of config overrides required to set it up locally - this PR reverts `sg.config.yaml` to make `cody-gateway` a "regular" command (like the other 18 commands in dotcom command set).

## Test plan
- `sg start dotcom` runs correctly
- the old "recompilation bug" is not longer present
