### PR TITLE
Cody Gateway: Antropic messages handler returns error out if request doesn't have required "messages" field

### DIFF
--- a/cmd/cody-gateway/internal/httpapi/completions/anthropicmessages.go
+++ b/cmd/cody-gateway/internal/httpapi/completions/anthropicmessages.go
@@ -166,6 +166,11 @@ func (a *AnthropicMessagesHandlerMethods) getAPIURLByFeature(feature codygateway
 }
 
 func (a *AnthropicMessagesHandlerMethods) validateRequest(ctx context.Context, logger log.Logger, _ codygateway.Feature, ar anthropicMessagesRequest) error {
+	if ar.Messages == nil {
+		// https://docs.anthropic.com/claude/reference/messages_post#:~:text=details%20and%20options.-,messages,-array%20of%20objects
+		return errors.New("request body must contain \"messages\" field")
+	}
+
 	maxTokensToSample := a.config.FlaggingConfig.MaxTokensToSample
 	if ar.MaxTokens > int32(maxTokensToSample) {
 		return errors.Errorf("max_tokens exceeds maximum allowed value of %d: %d", maxTokensToSample, ar.MaxTokens)


### PR DESCRIPTION
Requesting Antropic Messages API with no `"messages"` field (e.g., with deprecated `"prompt"` field instead) caused the request to fail ([thread](https://sourcegraph.slack.com/archives/C05497E9MDW/p1712067925436309)). Check for the required field and return the error before making a request to LLM.

## Test plan
- CI
- Tested manually with cURL command mentioned in the thread against locally running instance and Cody Gateway

|Before|After|
|--|--|
|Sourcegraph Cody Gateway: unexpected status code 400: {"type":"error","error":{"type":"invalid_request_error","message":"messages: Field required"}}%`|Sourcegraph Cody Gateway: unexpected status code 400: {"error":"\"messages\" field is required"}|

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
