### PR TITLE
rockskip: monitor indexing queue

### DIFF
--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -21490,6 +21490,57 @@ max(src_rockskip_service_repos_indexed)
 
 <br />
 
+#### symbols: p99.9_rockskip_index_queue_age
+
+<p class="subtitle">99.9th percentile index queue delay over 5m</p>
+
+The 99.9th percentile age of index jobs in seconds
+								This 99.9th percentile is useful to catch the long tail of queueing delays.
+
+This panel has no related alerts.
+
+To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100521` on your Sourcegraph instance.
+
+<sub>*Managed by the [Sourcegraph Search Platform team](https://handbook.sourcegraph.com/departments/engineering/teams/search/core).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Query:
+
+```
+histogram_quantile(0.999, sum(rate(src_rockskip_service_index_queue_age_seconds_bucket[5m])) by (le))
+```
+</details>
+
+<br />
+
+#### symbols: p95_rockskip_index_queue_age
+
+<p class="subtitle">95th percentile index queue delay over 5m</p>
+
+The 95th percentile age of index jobs in seconds.
+								A high delay might indicate a resource issue.
+								Consider increasing indexing bandwidth by either increasing the number of queues or the number of symbol services.
+
+This panel has no related alerts.
+
+To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100522` on your Sourcegraph instance.
+
+<sub>*Managed by the [Sourcegraph Search Platform team](https://handbook.sourcegraph.com/departments/engineering/teams/search/core).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Query:
+
+```
+histogram_quantile(0.95, sum(rate(src_rockskip_service_index_queue_age_seconds_bucket[5m])) by (le))
+```
+</details>
+
+<br />
+
 ### Symbols: Symbols GRPC server metrics
 
 #### symbols: symbols_grpc_request_rate_all_methods

--- a/internal/rockskip/index.go
+++ b/internal/rockskip/index.go
@@ -340,7 +340,8 @@ type repoCommit struct {
 
 type indexRequest struct {
 	repoCommit
-	done chan struct{}
+	dateAddedToQueue time.Time
+	done             chan struct{}
 }
 
 type pathSymbol struct {

--- a/internal/rockskip/search.go
+++ b/internal/rockskip/search.go
@@ -204,7 +204,8 @@ func (s *Service) emitIndexRequest(rc repoCommit) (chan struct{}, error) {
 			repo:   rc.repo,
 			commit: rc.commit,
 		},
-		done: done}
+		dateAddedToQueue: time.Now(),
+		done:             done}
 
 	// Route the index request to the indexer associated with the repo.
 	ix := int(fnv1.HashString32(rc.repo)) % len(s.indexRequestQueues)

--- a/monitoring/definitions/symbols.go
+++ b/monitoring/definitions/symbols.go
@@ -52,7 +52,7 @@ func Symbols() *monitoring.Dashboard {
 							Name:        "p95_rockskip_search_request_duration",
 							Description: "95th percentile search request duration over 5m",
 							Query:       "histogram_quantile(0.95, sum(rate(src_rockskip_service_search_request_duration_seconds_bucket[5m])) by (le))",
-							Panel:       monitoring.Panel().LegendFormat("duration").Unit(monitoring.Seconds).With(monitoring.PanelOptions.NoLegend()),
+							Panel:       monitoring.Panel().LegendFormat("duration").Unit(monitoring.Seconds),
 							Owner:       monitoring.ObservableOwnerSearchCore,
 							NoAlert:     true,
 							Interpretation: `
@@ -62,7 +62,7 @@ func Symbols() *monitoring.Dashboard {
 							Name:        "rockskip_in_flight_search_requests",
 							Description: "number of in-flight search requests",
 							Query:       `sum(src_rockskip_service_in_flight_search_requests)`,
-							Panel:       monitoring.Panel().Min(0).With(monitoring.PanelOptions.NoLegend()),
+							Panel:       monitoring.Panel().LegendFormat("requests"),
 							Owner:       monitoring.ObservableOwnerSearchCore,
 							NoAlert:     true,
 							Interpretation: `
@@ -74,7 +74,7 @@ func Symbols() *monitoring.Dashboard {
 							Name:        "rockskip_search_request_errors",
 							Description: "search request errors every 5m",
 							Query:       `sum(increase(src_rockskip_service_search_request_errors[5m]))`,
-							Panel:       monitoring.Panel().Min(0).With(monitoring.PanelOptions.NoLegend()),
+							Panel:       monitoring.Panel().LegendFormat("errors"),
 							Owner:       monitoring.ObservableOwnerSearchCore,
 							NoAlert:     true,
 							Interpretation: `
@@ -89,7 +89,6 @@ func Symbols() *monitoring.Dashboard {
 							Description: "95th percentile index job duration over 5m",
 							Query:       "histogram_quantile(0.95, sum(rate(src_rockskip_service_index_job_duration_seconds_bucket[5m])) by (le))",
 							Panel: monitoring.Panel().LegendFormat("duration").Unit(monitoring.Seconds).With(
-								monitoring.PanelOptions.NoLegend(),
 								func(o monitoring.Observable, p *sdk.Panel) {
 									p.GraphPanel.Yaxes[0].LogBase = 2 // log to account for huge range of "new" vs "delta" index.
 								}),
@@ -104,7 +103,7 @@ func Symbols() *monitoring.Dashboard {
 							Name:        "rockskip_in_flight_index_jobs",
 							Description: "number of in-flight index jobs",
 							Query:       `sum(src_rockskip_service_in_flight_index_jobs)`,
-							Panel:       monitoring.Panel().Min(0).With(monitoring.PanelOptions.NoLegend()),
+							Panel:       monitoring.Panel().LegendFormat("jobs"),
 							Owner:       monitoring.ObservableOwnerSearchCore,
 							NoAlert:     true,
 							Interpretation: `
@@ -115,7 +114,7 @@ func Symbols() *monitoring.Dashboard {
 							Name:        "rockskip_index_job_errors",
 							Description: "index job errors every 5m",
 							Query:       `sum(increase(src_rockskip_service_index_job_errors[5m]))`,
-							Panel:       monitoring.Panel().Min(0).With(monitoring.PanelOptions.NoLegend()),
+							Panel:       monitoring.Panel().LegendFormat("errors"),
 							Owner:       monitoring.ObservableOwnerSearchCore,
 							NoAlert:     true,
 							Interpretation: `
@@ -130,7 +129,7 @@ func Symbols() *monitoring.Dashboard {
 							Name:        "rockskip_number_of_repos_indexed",
 							Description: "number of repositories indexed by Rockskip",
 							Query:       `max(src_rockskip_service_repos_indexed)`, // "max" is used as hack to show only one value instead one per instance
-							Panel:       monitoring.Panel().With(monitoring.PanelOptions.NoLegend()),
+							Panel:       monitoring.Panel().LegendFormat("num_indexed"),
 							Owner:       monitoring.ObservableOwnerSearchCore,
 							NoAlert:     true,
 							Interpretation: `
@@ -138,6 +137,29 @@ func Symbols() *monitoring.Dashboard {
 								Apart from an initial transient phase in which many repos are being indexed,
 								this number should be low and relatively stable and only increase by small increments.
 								To verify if this number makes sense, compare ROCKSKIP_MIN_REPO_SIZE_MB with the repository sizes reported by gitserver_repos table.`,
+						},
+						{
+							Name:        "p99.9_rockskip_index_queue_age",
+							Description: "99.9th percentile index queue delay over 5m",
+							Query:       "histogram_quantile(0.999, sum(rate(src_rockskip_service_index_queue_age_seconds_bucket[5m])) by (le))",
+							Panel:       monitoring.Panel().LegendFormat("age").Unit(monitoring.Seconds),
+							Owner:       monitoring.ObservableOwnerSearchCore,
+							NoAlert:     true,
+							Interpretation: `
+								The 99.9th percentile age of index jobs in seconds
+								This 99.9th percentile is useful to catch the long tail of queueing delays.`,
+						},
+						{
+							Name:        "p95_rockskip_index_queue_age",
+							Description: "95th percentile index queue delay over 5m",
+							Query:       "histogram_quantile(0.95, sum(rate(src_rockskip_service_index_queue_age_seconds_bucket[5m])) by (le))",
+							Panel:       monitoring.Panel().LegendFormat("age").Unit(monitoring.Seconds),
+							Owner:       monitoring.ObservableOwnerSearchCore,
+							NoAlert:     true,
+							Interpretation: `
+								The 95th percentile age of index jobs in seconds.
+								A high delay might indicate a resource issue.
+								Consider increasing indexing bandwidth by either increasing the number of queues or the number of symbol services.`,
 						},
 					},
 				},


### PR DESCRIPTION
Follow up from [this comment](https://github.com/sourcegraph/sourcegraph/pull/61547#pullrequestreview-1977509426)

This adds a p99.9 and p95 panel to monitor how long index requests have been waiting on the queue.

Test plan:
- manual testing

<img width="1392" alt="Screenshot 2024-04-04 at 15 24 50" src="https://github.com/sourcegraph/sourcegraph/assets/26413131/1295712d-9eb8-4fb5-a065-5b4be2206de3">


