### PR TITLE
Read PLG embeddings limits directly from site config 

### DIFF
--- a/cmd/frontend/internal/dotcom/productsubscription/codygateway_dotcom_user.go
+++ b/cmd/frontend/internal/dotcom/productsubscription/codygateway_dotcom_user.go
@@ -199,7 +199,7 @@ func getEmbeddingsRateLimit(ctx context.Context, db database.DB, userID int32) (
 	intervalSeconds := int32(math.MaxInt32)
 
 	// Apply self-serve limits if available
-	cfg := conf.GetEmbeddingsConfig(conf.Get().SiteConfig())
+	cfg := conf.Get().SiteConfig().Embeddings
 	if cfg != nil {
 		user, err := db.Users().GetByID(ctx, userID)
 		if err != nil {


### PR DESCRIPTION
During the decommissioning of enterprise embeddings it was necessary to contiue generating community embeddings on sourcegraph.com in support of JetBrains users. Since all PLG users now rely on symf for context it is possible to disable embeddings from being generated on sourcegraph.com, however when disabling embeddings in the config the PLG rate limits are not read from the site config.  This directly access the site config to read the embeddings limits bypassing the fact that embeddings are disabled. 

Because there is still a internal usage of embeddings for benchmarking purposes I will not be removing the related embeddings code.  

## Test plan
```graphql
{
  dotcom{
    codyGatewayDotcomUserByToken(token:"REDACTED"){
      username
      id
      codyGatewayAccess{
        embeddingsRateLimit{
          source
          limit
          intervalSeconds
          allowedModels
        }
      }
    }
  }
}
```

```json
{
  "data": {
    "dotcom": {
      "codyGatewayDotcomUserByToken": {
        "username": "chris",
        "id": "VXNlcjox",
        "codyGatewayAccess": {
          "embeddingsRateLimit": {
            "source": "PLAN",
            "limit": "1234",
            "intervalSeconds": 2592000,
            "allowedModels": [
              "openai/text-embedding-ada-002",
              "sourcegraph/triton"
            ]
          }
        }
      }
    }
  }
}
```
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
