### PR TITLE
sg: detect and use dockerhub registry

### DIFF
--- a/dev/sg/sg_ops.go
+++ b/dev/sg/sg_ops.go
@@ -202,6 +202,13 @@ func opsUpdateImages(
 				return errors.Errorf("invalid custom registry %q", registryType)
 			}
 
+			// might have specified the public registry url without knowing, so we check and create dockrhub!
+			if strings.Contains(registryType, "index.docker.io") {
+				registry = images.NewDockerHub("sourcegraph", dockerUsername, dockerPassword)
+				std.Out.WriteNoticef("using Docker Hub registry %s/%s", registry.Host(), registry.Org())
+				break
+			}
+
 			// custom regisry is in the format <host>/<org>, so host = parts[0], org = parts[1]
 			gcr := images.NewGCR(parts[0], parts[1])
 			if err := gcr.LoadToken(); err != nil {


### PR DESCRIPTION
Do the right thing if someone specifies the public docker hub registry.

## Test plan
```
👉 using Docker Hub registry index.docker.io/sourcegraph
👉 updating images to latest
⚠️ Registry credentials are not provided and could not be retrieved from docker config.
⚠️ You will be using anonymous requests and may be subject to rate limiting by Docker Hub.
❌ cannot load docker creds from store: failed to find store provider or credential helper for https://registry.hub.docker.com/v2
Error: bazel exited with exit code: 1
```