### PR TITLE
Adding new anthropic claude 3 models family to supported chat models for enterprise customers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ All notable changes to Sourcegraph are documented in this file.
 - The frontend Grafana dashboard has a new Prometheus metric that tracks the rate of requests that Sourcegraph issues to external services. [#61348](https://github.com/sourcegraph/sourcegraph/pull/61348)
 - Added support for the `gitURLType` setting for Gerrit, Sourcegraph now supports cloning from Gerrit via SSH. Note: Not on Cloud yet, like for all code hosts. [#61537](https://github.com/sourcegraph/sourcegraph/pull/61537)
 - Support for OpenAI chat models for enterprise customers. [#61539](https://github.com/sourcegraph/sourcegraph/pull/61539)
+- Support for Anthropics new chat models for enterprise customers. [#60953](https://github.com/sourcegraph/sourcegraph/pull/60953)
+
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,8 +26,6 @@ All notable changes to Sourcegraph are documented in this file.
 - The frontend Grafana dashboard has a new Prometheus metric that tracks the rate of requests that Sourcegraph issues to external services. [#61348](https://github.com/sourcegraph/sourcegraph/pull/61348)
 - Added support for the `gitURLType` setting for Gerrit, Sourcegraph now supports cloning from Gerrit via SSH. Note: Not on Cloud yet, like for all code hosts. [#61537](https://github.com/sourcegraph/sourcegraph/pull/61537)
 - Support for OpenAI chat models for enterprise customers. [#61539](https://github.com/sourcegraph/sourcegraph/pull/61539)
-- Support for Anthropics new chat models for enterprise customers. [#60953](https://github.com/sourcegraph/sourcegraph/pull/60953)
-
 
 ### Changed
 

--- a/internal/licensing/codygateway.go
+++ b/internal/licensing/codygateway.go
@@ -33,6 +33,9 @@ func NewCodyGatewayChatRateLimit(plan Plan, userCount *int) CodyGatewayRateLimit
 		"anthropic/claude-instant-v1",
 		"anthropic/claude-instant-1",
 		"anthropic/claude-instant-1.2",
+		"anthropic/claude-3-sonnet-20240229",
+		"anthropic/claude-3-opus-20240229",
+		"anthropic/claude-3-haiku-20240307",
 
 		"openai/gpt-3.5-turbo",
 		"openai/gpt-4",

--- a/internal/licensing/codygateway_test.go
+++ b/internal/licensing/codygateway_test.go
@@ -20,7 +20,7 @@ func TestNewCodyGatewayChatRateLimit(t *testing.T) {
 			plan:      PlanEnterprise1,
 			userCount: pointers.Ptr(50),
 			want: CodyGatewayRateLimit{
-				AllowedModels:   []string{"anthropic/claude-v1", "anthropic/claude-2", "anthropic/claude-2.0", "anthropic/claude-2.1", "anthropic/claude-instant-v1", "anthropic/claude-instant-1", "anthropic/claude-instant-1.2", "openai/gpt-3.5-turbo", "openai/gpt-4", "openai/gpt-4-turbo-preview"},
+				AllowedModels:   []string{"anthropic/claude-v1", "anthropic/claude-2", "anthropic/claude-2.0", "anthropic/claude-2.1", "anthropic/claude-instant-v1", "anthropic/claude-instant-1", "anthropic/claude-instant-1.2", "anthropic/claude-3-sonnet-20240229", "anthropic/claude-3-opus-20240229", "anthropic/claude-3-haiku-20240307", "openai/gpt-3.5-turbo", "openai/gpt-4", "openai/gpt-4-turbo-preview"},
 				Limit:           2500,
 				IntervalSeconds: 60 * 60 * 24,
 			},
@@ -29,7 +29,7 @@ func TestNewCodyGatewayChatRateLimit(t *testing.T) {
 			name: "Enterprise plan with no user count",
 			plan: PlanEnterprise1,
 			want: CodyGatewayRateLimit{
-				AllowedModels:   []string{"anthropic/claude-v1", "anthropic/claude-2", "anthropic/claude-2.0", "anthropic/claude-2.1", "anthropic/claude-instant-v1", "anthropic/claude-instant-1", "anthropic/claude-instant-1.2", "openai/gpt-3.5-turbo", "openai/gpt-4", "openai/gpt-4-turbo-preview"},
+				AllowedModels:   []string{"anthropic/claude-v1", "anthropic/claude-2", "anthropic/claude-2.0", "anthropic/claude-2.1", "anthropic/claude-instant-v1", "anthropic/claude-instant-1", "anthropic/claude-instant-1.2", "anthropic/claude-3-sonnet-20240229", "anthropic/claude-3-opus-20240229", "anthropic/claude-3-haiku-20240307", "openai/gpt-3.5-turbo", "openai/gpt-4", "openai/gpt-4-turbo-preview"},
 				Limit:           50,
 				IntervalSeconds: 60 * 60 * 24,
 			},
@@ -38,7 +38,7 @@ func TestNewCodyGatewayChatRateLimit(t *testing.T) {
 			name: "Non-enterprise plan with no user count",
 			plan: "unknown",
 			want: CodyGatewayRateLimit{
-				AllowedModels:   []string{"anthropic/claude-v1", "anthropic/claude-2", "anthropic/claude-2.0", "anthropic/claude-2.1", "anthropic/claude-instant-v1", "anthropic/claude-instant-1", "anthropic/claude-instant-1.2", "openai/gpt-3.5-turbo", "openai/gpt-4", "openai/gpt-4-turbo-preview"},
+				AllowedModels:   []string{"anthropic/claude-v1", "anthropic/claude-2", "anthropic/claude-2.0", "anthropic/claude-2.1", "anthropic/claude-instant-v1", "anthropic/claude-instant-1", "anthropic/claude-instant-1.2", "anthropic/claude-3-sonnet-20240229", "anthropic/claude-3-opus-20240229", "anthropic/claude-3-haiku-20240307", "openai/gpt-3.5-turbo", "openai/gpt-4", "openai/gpt-4-turbo-preview"},
 				Limit:           10,
 				IntervalSeconds: 60 * 60 * 24,
 			},


### PR DESCRIPTION
Issue https://github.com/sourcegraph/sourcegraph/issues/61291
Adds Claude 3 family of anthropic models to the list of supported chat models for enterprise ([thread](https://sourcegraph.slack.com/archives/C04MSD3DP5L/p1712251852944669?thread_ts=1711632452.407259&cid=C04MSD3DP5L)).


## Test plan

- CI 
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
