### PR TITLE
msp: update ops with deployment info

### DIFF
--- a/dev/managedservicesplatform/operationdocs/operationdocs.go
+++ b/dev/managedservicesplatform/operationdocs/operationdocs.go
@@ -125,7 +125,7 @@ This service is operated on the %s.`,
 	}
 
 	if s.Rollout != nil {
-		md.Headingf(2, "Rollout")
+		md.Headingf(2, "Rollouts")
 		region := "us-central1"
 		var rolloutDetails [][]string
 		// Get final stage to generate pipeline url

--- a/dev/managedservicesplatform/operationdocs/operationdocs.go
+++ b/dev/managedservicesplatform/operationdocs/operationdocs.go
@@ -117,7 +117,7 @@ This service is operated on the %s.`,
 			}
 		}
 		serviceDetails = append(serviceDetails,
-			[]string{"Rollout Pipeline", markdown.Linkf(fmt.Sprintf("`%s-%s-rollout`", s.Service.ID, region),
+			[]string{"Rollout pipeline", markdown.Linkf(fmt.Sprintf("`%s-%s-rollout`", s.Service.ID, region),
 				"https://console.cloud.google.com/deploy/delivery-pipelines/%[1]s/%[2]s-%[1]s-rollout?project=%[3]s", region, s.Service.ID, finalStageProject)})
 	}
 

--- a/dev/managedservicesplatform/operationdocs/operationdocs.go
+++ b/dev/managedservicesplatform/operationdocs/operationdocs.go
@@ -175,7 +175,7 @@ This service is operated on the %s.`,
 		overview := [][]string{
 			{"Project ID", markdown.Linkf(markdown.Code(env.ProjectID), cloudRunURL)},
 			{"Category", markdown.Bold(string(env.Category))},
-			{"Deployment Type", fmt.Sprintf("`%s`", env.Deploy.Type)},
+			{"Deployment type", fmt.Sprintf("`%s`", env.Deploy.Type)},
 			{"Resources", strings.Join(mapTo(env.Resources.List(), func(k string) string {
 				l, h := markdown.HeadingLinkf("%s %s", env.ID, k)
 				resourceHeadings[k] = h

--- a/dev/managedservicesplatform/operationdocs/operationdocs_test.go
+++ b/dev/managedservicesplatform/operationdocs/operationdocs_test.go
@@ -7,15 +7,18 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/sourcegraph/sourcegraph/dev/managedservicesplatform/spec"
+	"github.com/sourcegraph/sourcegraph/lib/pointers"
 )
 
 const (
 	// Use a real service and environment to help validate links actually work
 	// in our golden tests (TestRender).
 	// https://handbook.sourcegraph.com/departments/engineering/managed-services/msp-testbed#test
-	testServiceID          = "msp-testbed"
-	testServiceEnvironment = "test"
-	testProjectID          = "msp-testbed-test-77589aae45d0"
+	testServiceID            = "msp-testbed"
+	testServiceEnvironment   = "test"
+	testProjectID            = "msp-testbed-test-77589aae45d0"
+	robertServiceEnvironment = "robert"
+	robertProjectID          = "msp-testbed-robert-7be9"
 )
 
 func TestRender(t *testing.T) {
@@ -29,6 +32,7 @@ func TestRender(t *testing.T) {
 			Service: spec.ServiceSpec{
 				ID:          testServiceID,
 				Description: "Test service for MSP",
+				Name:        pointers.Ptr("MSP Testbed"),
 			},
 			Build: spec.BuildSpec{
 				Image: "us.gcr.io/sourcegraph-dev/msp-example",
@@ -53,7 +57,8 @@ func TestRender(t *testing.T) {
 		name: "resources",
 		spec: spec.Spec{
 			Service: spec.ServiceSpec{
-				ID:          "msp-testbed",
+				ID: "msp-testbed",
+
 				Description: "Test service for MSP",
 			},
 			Build: spec.BuildSpec{
@@ -87,6 +92,7 @@ func TestRender(t *testing.T) {
 			Service: spec.ServiceSpec{
 				ID:          testServiceID,
 				Description: "Test service for MSP",
+				Name:        pointers.Ptr("MSP Testbed"),
 			},
 			Build: spec.BuildSpec{
 				Image: "us.gcr.io/sourcegraph-dev/msp-example",
@@ -108,6 +114,40 @@ func TestRender(t *testing.T) {
 ## Additional operations
 
 Some additional operations!`),
+		},
+	}, {
+		name: "multi env rollout",
+		spec: spec.Spec{
+			Service: spec.ServiceSpec{
+				ID:          testServiceID,
+				Description: "Test service for MSP",
+				Name:        pointers.Ptr("MSP Testbed"),
+			},
+			Build: spec.BuildSpec{
+				Image: "us.gcr.io/sourcegraph-dev/msp-example",
+				Source: spec.BuildSourceSpec{
+					Repo: "github.com/sourcegraph/sourcegraph",
+					Dir:  "cmd/msp-example",
+				},
+			},
+			Environments: []spec.EnvironmentSpec{{
+				ID:        testServiceEnvironment,
+				ProjectID: testProjectID,
+				Category:  spec.EnvironmentCategoryTest,
+				Deploy: spec.EnvironmentDeploySpec{
+					Type: "rollout",
+				},
+			}, {
+				ID:        robertServiceEnvironment,
+				ProjectID: robertProjectID,
+				Category:  spec.EnvironmentCategoryTest,
+				Deploy: spec.EnvironmentDeploySpec{
+					Type: "rollout",
+				},
+			}},
+			Rollout: &spec.RolloutSpec{
+				Stages: []spec.RolloutStageSpec{{EnvironmentID: testServiceEnvironment}, {EnvironmentID: robertServiceEnvironment}},
+			},
 		},
 	}} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/dev/managedservicesplatform/operationdocs/operationdocs_test.go
+++ b/dev/managedservicesplatform/operationdocs/operationdocs_test.go
@@ -41,7 +41,13 @@ func TestRender(t *testing.T) {
 				ID:        testServiceEnvironment,
 				ProjectID: testProjectID,
 				Category:  spec.EnvironmentCategoryTest,
+				Deploy: spec.EnvironmentDeploySpec{
+					Type: "rollout",
+				},
 			}},
+			Rollout: &spec.RolloutSpec{
+				Stages: []spec.RolloutStageSpec{{EnvironmentID: testServiceEnvironment}},
+			},
 		},
 	}, {
 		name: "resources",
@@ -70,6 +76,9 @@ func TestRender(t *testing.T) {
 						Tables: []string{"bar", "baz"},
 					},
 				},
+				Deploy: spec.EnvironmentDeploySpec{
+					Type: "subscription",
+				},
 			}},
 		},
 	}, {
@@ -90,6 +99,9 @@ func TestRender(t *testing.T) {
 				ID:        testServiceEnvironment,
 				ProjectID: testProjectID,
 				Category:  spec.EnvironmentCategoryTest,
+				Deploy: spec.EnvironmentDeploySpec{
+					Type: "manual",
+				},
 			}},
 			README: []byte(`This service does X, Y, Z. Refer to [here](sourcegraph.com) for more information.
 

--- a/dev/managedservicesplatform/operationdocs/testdata/TestRender/basic.golden
+++ b/dev/managedservicesplatform/operationdocs/testdata/TestRender/basic.golden
@@ -14,14 +14,15 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ## Service overview
 
-|   PROPERTY   |                                                             DETAILS                                                              |
-|--------------|----------------------------------------------------------------------------------------------------------------------------------|
-| Service ID   | `msp-testbed` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/msp-testbed/service.yaml))     |
-| Owners       |                                                                                                                                  |
-| Service kind | Cloud Run service                                                                                                                |
-| Environments | [test](#test)                                                                                                                    |
-| Docker image | `us.gcr.io/sourcegraph-dev/msp-example`                                                                                          |
-| Source code  | [`github.com/sourcegraph/sourcegraph` - `cmd/msp-example`](https://github.com/sourcegraph/sourcegraph/tree/HEAD/cmd/msp-example) |
+|     PROPERTY     |                                                                                      DETAILS                                                                                      |
+|------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Service ID       | `msp-testbed` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/msp-testbed/service.yaml))                                                      |
+| Owners           |                                                                                                                                                                                   |
+| Service kind     | Cloud Run service                                                                                                                                                                 |
+| Environments     | [test](#test)                                                                                                                                                                     |
+| Docker image     | `us.gcr.io/sourcegraph-dev/msp-example`                                                                                                                                           |
+| Source code      | [`github.com/sourcegraph/sourcegraph` - `cmd/msp-example`](https://github.com/sourcegraph/sourcegraph/tree/HEAD/cmd/msp-example)                                                  |
+| Rollout Pipeline | [`msp-testbed-us-central1-rollout`](https://console.cloud.google.com/deploy/delivery-pipelines/us-central1/msp-testbed-us-central1-rollout?project=msp-testbed-test-77589aae45d0) |
 
 ## Environments
 
@@ -31,6 +32,7 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 |---------------------|---------------------------------------------------------------------------------------------------------------|
 | Project ID          | [`msp-testbed-test-77589aae45d0`](https://console.cloud.google.com/run?project=msp-testbed-test-77589aae45d0) |
 | Category            | **test**                                                                                                      |
+| Deployment Type     | `rollout`                                                                                                     |
 | Resources           |                                                                                                               |
 | Slack notifications | [#alerts-msp-testbed-test](https://sourcegraph.slack.com/archives/alerts-msp-testbed-test)                    |
 | Alerts              | [GCP monitoring](https://console.cloud.google.com/monitoring/alerting?project=msp-testbed-test-77589aae45d0)  |

--- a/dev/managedservicesplatform/operationdocs/testdata/TestRender/basic.golden
+++ b/dev/managedservicesplatform/operationdocs/testdata/TestRender/basic.golden
@@ -1,10 +1,10 @@
-# msp-testbed infrastructure operations
+# MSP Testbed infrastructure operations
 
 <!--
 Generated from: unknown revision of https://github.com/sourcegraph/managed-services
 -->
 
-This document describes operational guidance for msp-testbed infrastructure.
+This document describes operational guidance for MSP Testbed infrastructure.
 This service is operated on the [Managed Services Platform (MSP)](https://handbook.sourcegraph.com/departments/engineering/teams/core-services/managed-services/platform/).
 
 > [!IMPORTANT]
@@ -14,15 +14,23 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ## Service overview
 
-|     PROPERTY     |                                                                                      DETAILS                                                                                      |
-|------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Service ID       | `msp-testbed` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/msp-testbed/service.yaml))                                                      |
-| Owners           |                                                                                                                                                                                   |
-| Service kind     | Cloud Run service                                                                                                                                                                 |
-| Environments     | [test](#test)                                                                                                                                                                     |
-| Docker image     | `us.gcr.io/sourcegraph-dev/msp-example`                                                                                                                                           |
-| Source code      | [`github.com/sourcegraph/sourcegraph` - `cmd/msp-example`](https://github.com/sourcegraph/sourcegraph/tree/HEAD/cmd/msp-example)                                                  |
-| Rollout Pipeline | [`msp-testbed-us-central1-rollout`](https://console.cloud.google.com/deploy/delivery-pipelines/us-central1/msp-testbed-us-central1-rollout?project=msp-testbed-test-77589aae45d0) |
+|   PROPERTY   |                                                             DETAILS                                                              |
+|--------------|----------------------------------------------------------------------------------------------------------------------------------|
+| Service ID   | `msp-testbed` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/msp-testbed/service.yaml))     |
+| Owners       |                                                                                                                                  |
+| Service kind | Cloud Run service                                                                                                                |
+| Environments | [test](#test)                                                                                                                    |
+| Docker image | `us.gcr.io/sourcegraph-dev/msp-example`                                                                                          |
+| Source code  | [`github.com/sourcegraph/sourcegraph` - `cmd/msp-example`](https://github.com/sourcegraph/sourcegraph/tree/HEAD/cmd/msp-example) |
+
+## Rollout
+
+|     PROPERTY      |                                                                                      DETAILS                                                                                      |
+|-------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Delivery pipeline | [`msp-testbed-us-central1-rollout`](https://console.cloud.google.com/deploy/delivery-pipelines/us-central1/msp-testbed-us-central1-rollout?project=msp-testbed-test-77589aae45d0) |
+| Stages            | [test](#test)                                                                                                                                                                     |
+
+Changes to MSP Testbed are continuously delivered to the first stage ([test](#test)) of the delivery pipeline.
 
 ## Environments
 
@@ -49,7 +57,7 @@ For Terraform Cloud access, see [test Terraform Cloud](#test-terraform-cloud).
 
 #### test Cloud Run
 
-The msp-testbed test service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
+The MSP Testbed test service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
 |    PROPERTY    |                                                                                                                                                                  DETAILS                                                                                                                                                                   |
 |----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|

--- a/dev/managedservicesplatform/operationdocs/testdata/TestRender/basic.golden
+++ b/dev/managedservicesplatform/operationdocs/testdata/TestRender/basic.golden
@@ -23,7 +23,7 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 | Docker image | `us.gcr.io/sourcegraph-dev/msp-example`                                                                                          |
 | Source code  | [`github.com/sourcegraph/sourcegraph` - `cmd/msp-example`](https://github.com/sourcegraph/sourcegraph/tree/HEAD/cmd/msp-example) |
 
-## Rollout
+## Rollouts
 
 |     PROPERTY      |                                                                                      DETAILS                                                                                      |
 |-------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -40,7 +40,7 @@ Changes to MSP Testbed are continuously delivered to the first stage ([test](#te
 |---------------------|---------------------------------------------------------------------------------------------------------------|
 | Project ID          | [`msp-testbed-test-77589aae45d0`](https://console.cloud.google.com/run?project=msp-testbed-test-77589aae45d0) |
 | Category            | **test**                                                                                                      |
-| Deployment Type     | `rollout`                                                                                                     |
+| Deployment type     | `rollout`                                                                                                     |
 | Resources           |                                                                                                               |
 | Slack notifications | [#alerts-msp-testbed-test](https://sourcegraph.slack.com/archives/alerts-msp-testbed-test)                    |
 | Alerts              | [GCP monitoring](https://console.cloud.google.com/monitoring/alerting?project=msp-testbed-test-77589aae45d0)  |

--- a/dev/managedservicesplatform/operationdocs/testdata/TestRender/multi_env_rollout.golden
+++ b/dev/managedservicesplatform/operationdocs/testdata/TestRender/multi_env_rollout.golden
@@ -19,19 +19,20 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 | Service ID   | `msp-testbed` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/msp-testbed/service.yaml))     |
 | Owners       |                                                                                                                                  |
 | Service kind | Cloud Run service                                                                                                                |
-| Environments | [test](#test)                                                                                                                    |
+| Environments | [test](#test), [robert](#robert)                                                                                                 |
 | Docker image | `us.gcr.io/sourcegraph-dev/msp-example`                                                                                          |
 | Source code  | [`github.com/sourcegraph/sourcegraph` - `cmd/msp-example`](https://github.com/sourcegraph/sourcegraph/tree/HEAD/cmd/msp-example) |
 
-<!--
-Automatically generated from the service README: https://github.com/sourcegraph/managed-services/blob/main/services/msp-testbed/README.md
--->
+## Rollout
 
-This service does X, Y, Z. Refer to [here](sourcegraph.com) for more information.
+|     PROPERTY      |                                                                                   DETAILS                                                                                   |
+|-------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Delivery pipeline | [`msp-testbed-us-central1-rollout`](https://console.cloud.google.com/deploy/delivery-pipelines/us-central1/msp-testbed-us-central1-rollout?project=msp-testbed-robert-7be9) |
+| Stages            | [test](#test) -> [robert](#robert)                                                                                                                                          |
 
-### Additional operations
+Changes to MSP Testbed are continuously delivered to the first stage ([test](#test)) of the delivery pipeline.
 
-Some additional operations!
+Promotion of a release to the next stage in the pipeline must be done manually using the GCP Delivery pipeline UI.
 
 ## Environments
 
@@ -41,7 +42,7 @@ Some additional operations!
 |---------------------|---------------------------------------------------------------------------------------------------------------|
 | Project ID          | [`msp-testbed-test-77589aae45d0`](https://console.cloud.google.com/run?project=msp-testbed-test-77589aae45d0) |
 | Category            | **test**                                                                                                      |
-| Deployment Type     | `manual`                                                                                                      |
+| Deployment Type     | `rollout`                                                                                                     |
 | Resources           |                                                                                                               |
 | Slack notifications | [#alerts-msp-testbed-test](https://sourcegraph.slack.com/archives/alerts-msp-testbed-test)                    |
 | Alerts              | [GCP monitoring](https://console.cloud.google.com/monitoring/alerting?project=msp-testbed-test-77589aae45d0)  |
@@ -96,4 +97,67 @@ The Terraform Cloud workspaces for this service environment are [grouped under t
 
 ```bash
 sg msp tfc view msp-testbed test
+```
+
+### robert
+
+|      PROPERTY       |                                                DETAILS                                                 |
+|---------------------|--------------------------------------------------------------------------------------------------------|
+| Project ID          | [`msp-testbed-robert-7be9`](https://console.cloud.google.com/run?project=msp-testbed-robert-7be9)      |
+| Category            | **test**                                                                                               |
+| Deployment Type     | `rollout`                                                                                              |
+| Resources           |                                                                                                        |
+| Slack notifications | [#alerts-msp-testbed-robert](https://sourcegraph.slack.com/archives/alerts-msp-testbed-robert)         |
+| Alerts              | [GCP monitoring](https://console.cloud.google.com/monitoring/alerting?project=msp-testbed-robert-7be9) |
+| Errors              | [Sentry `msp-testbed-robert`](https://sourcegraph.sentry.io/projects/msp-testbed-robert/)              |
+
+MSP infrastructure access needs to be requested using Entitle for time-bound privileges. Test environments may have less stringent requirements.
+
+|          ACCESS          |                                                                                                                                                                        ENTITLE REQUEST TEMPLATE                                                                                                                                                                        |
+|--------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| GCP project read access  | [Read-only Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZGY3NWJkNWMtYmUxOC00MjhmLWEzNjYtYzlhYTU1MGIwODIzIiwidGhyb3VnaCI6ImRmNzViZDVjLWJlMTgtNDI4Zi1hMzY2LWM5YWE1NTBiMDgyMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
+| GCP project write access | [Write access Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYzJkMTUwOGEtMGQ0ZS00MjA1LWFiZWUtOGY1ODg1ZGY3ZDE4IiwidGhyb3VnaCI6ImMyZDE1MDhhLTBkNGUtNDIwNS1hYmVlLThmNTg4NWRmN2QxOCIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
+
+For Terraform Cloud access, see [robert Terraform Cloud](#robert-terraform-cloud).
+
+#### robert Cloud Run
+
+The MSP Testbed robert service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
+
+|    PROPERTY    |                                                                                                                                                               DETAILS                                                                                                                                                                |
+|----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Console        | [Cloud Run service](https://console.cloud.google.com/run?project=msp-testbed-robert-7be9)                                                                                                                                                                                                                                            |
+| Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=msp-testbed-robert-7be9) |
+| Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=msp-testbed-robert-7be9)                                                                                                                                                                                                                                          |
+| Service errors | [Sentry `msp-testbed-robert`](https://sourcegraph.sentry.io/projects/msp-testbed-robert/)                                                                                                                                                                                                                                            |
+
+You can also use `sg msp` to quickly open a link to your service logs:
+
+```bash
+sg msp logs msp-testbed robert
+```
+
+#### robert Terraform Cloud
+
+This service's configuration is defined in [`sourcegraph/managed-services/services/msp-testbed/service.yaml`](https://github.com/sourcegraph/managed-services/blob/main/services/msp-testbed/service.yaml), and `sg msp generate msp-testbed robert` generates the required infrastructure configuration for this environment in Terraform.
+Terraform Cloud (TFC) workspaces specific to each service then provisions the required infrastructure from this configuration.
+You may want to check your service environment's TFC workspaces if a Terraform apply fails (reported via GitHub commit status checks in the [`sourcegraph/managed-services`](https://github.com/sourcegraph/managed-services) repository, or in #alerts-msp-tfc).
+
+> [!NOTE]
+> If you are looking for service logs, see the [robert Cloud Run](#robert-cloud-run) section instead. In general:
+>
+> - check service logs ([robert Cloud Run](#robert-cloud-run)) if your service has gone down or is misbehaving
+> - check TFC workspaces for infrastructure provisioning or configuration issues
+
+To access this environment's Terraform Cloud workspaces, you will need to [log in to Terraform Cloud](https://app.terraform.io/app/sourcegraph) and then [request Entitle access to membership in the "Managed Services Platform Operator" TFC team](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjM2MDAiLCJqdXN0aWZpY2F0aW9uIjoiSlVTVElGSUNBVElPTiBIRVJFIiwicm9sZUlkcyI6W3siaWQiOiJiMzg3MzJjYy04OTUyLTQ2Y2QtYmIxZS1lZjI2ODUwNzIyNmIiLCJ0aHJvdWdoIjoiYjM4NzMyY2MtODk1Mi00NmNkLWJiMWUtZWYyNjg1MDcyMjZiIiwidHlwZSI6InJvbGUifV19).
+The "Managed Services Platform Operator" team has access to all MSP TFC workspaces.
+
+> [!WARNING]
+> You **must [log in to Terraform Cloud](https://app.terraform.io/app/sourcegraph) before making your Entitle request**.
+> If you make your Entitle request, then log in, you will be removed from any team memberships granted through Entitle by Terraform Cloud's SSO implementation.
+
+The Terraform Cloud workspaces for this service environment are [grouped under the `msp-msp-testbed-robert` tag](https://app.terraform.io/app/sourcegraph/workspaces?tag=msp-msp-testbed-robert), or you can use:
+
+```bash
+sg msp tfc view msp-testbed robert
 ```

--- a/dev/managedservicesplatform/operationdocs/testdata/TestRender/multi_env_rollout.golden
+++ b/dev/managedservicesplatform/operationdocs/testdata/TestRender/multi_env_rollout.golden
@@ -23,7 +23,7 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 | Docker image | `us.gcr.io/sourcegraph-dev/msp-example`                                                                                          |
 | Source code  | [`github.com/sourcegraph/sourcegraph` - `cmd/msp-example`](https://github.com/sourcegraph/sourcegraph/tree/HEAD/cmd/msp-example) |
 
-## Rollout
+## Rollouts
 
 |     PROPERTY      |                                                                                   DETAILS                                                                                   |
 |-------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -42,7 +42,7 @@ Promotion of a release to the next stage in the pipeline must be done manually u
 |---------------------|---------------------------------------------------------------------------------------------------------------|
 | Project ID          | [`msp-testbed-test-77589aae45d0`](https://console.cloud.google.com/run?project=msp-testbed-test-77589aae45d0) |
 | Category            | **test**                                                                                                      |
-| Deployment Type     | `rollout`                                                                                                     |
+| Deployment type     | `rollout`                                                                                                     |
 | Resources           |                                                                                                               |
 | Slack notifications | [#alerts-msp-testbed-test](https://sourcegraph.slack.com/archives/alerts-msp-testbed-test)                    |
 | Alerts              | [GCP monitoring](https://console.cloud.google.com/monitoring/alerting?project=msp-testbed-test-77589aae45d0)  |
@@ -105,7 +105,7 @@ sg msp tfc view msp-testbed test
 |---------------------|--------------------------------------------------------------------------------------------------------|
 | Project ID          | [`msp-testbed-robert-7be9`](https://console.cloud.google.com/run?project=msp-testbed-robert-7be9)      |
 | Category            | **test**                                                                                               |
-| Deployment Type     | `rollout`                                                                                              |
+| Deployment type     | `rollout`                                                                                              |
 | Resources           |                                                                                                        |
 | Slack notifications | [#alerts-msp-testbed-robert](https://sourcegraph.slack.com/archives/alerts-msp-testbed-robert)         |
 | Alerts              | [GCP monitoring](https://console.cloud.google.com/monitoring/alerting?project=msp-testbed-robert-7be9) |

--- a/dev/managedservicesplatform/operationdocs/testdata/TestRender/resources.golden
+++ b/dev/managedservicesplatform/operationdocs/testdata/TestRender/resources.golden
@@ -31,6 +31,7 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 |---------------------|-----------------------------------------------------------------------------------------------------------------------------------|
 | Project ID          | [`msp-testbed-test-77589aae45d0`](https://console.cloud.google.com/run?project=msp-testbed-test-77589aae45d0)                     |
 | Category            | **test**                                                                                                                          |
+| Deployment Type     | `subscription`                                                                                                                    |
 | Resources           | [test Redis](#test-redis), [test PostgreSQL instance](#test-postgresql-instance), [test BigQuery dataset](#test-bigquery-dataset) |
 | Slack notifications | [#alerts-msp-testbed-test](https://sourcegraph.slack.com/archives/alerts-msp-testbed-test)                                        |
 | Alerts              | [GCP monitoring](https://console.cloud.google.com/monitoring/alerting?project=msp-testbed-test-77589aae45d0)                      |

--- a/dev/managedservicesplatform/operationdocs/testdata/TestRender/resources.golden
+++ b/dev/managedservicesplatform/operationdocs/testdata/TestRender/resources.golden
@@ -31,7 +31,7 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 |---------------------|-----------------------------------------------------------------------------------------------------------------------------------|
 | Project ID          | [`msp-testbed-test-77589aae45d0`](https://console.cloud.google.com/run?project=msp-testbed-test-77589aae45d0)                     |
 | Category            | **test**                                                                                                                          |
-| Deployment Type     | `subscription`                                                                                                                    |
+| Deployment type     | `subscription`                                                                                                                    |
 | Resources           | [test Redis](#test-redis), [test PostgreSQL instance](#test-postgresql-instance), [test BigQuery dataset](#test-bigquery-dataset) |
 | Slack notifications | [#alerts-msp-testbed-test](https://sourcegraph.slack.com/archives/alerts-msp-testbed-test)                                        |
 | Alerts              | [GCP monitoring](https://console.cloud.google.com/monitoring/alerting?project=msp-testbed-test-77589aae45d0)                      |

--- a/dev/managedservicesplatform/operationdocs/testdata/TestRender/with_README.golden
+++ b/dev/managedservicesplatform/operationdocs/testdata/TestRender/with_README.golden
@@ -41,6 +41,7 @@ Some additional operations!
 |---------------------|---------------------------------------------------------------------------------------------------------------|
 | Project ID          | [`msp-testbed-test-77589aae45d0`](https://console.cloud.google.com/run?project=msp-testbed-test-77589aae45d0) |
 | Category            | **test**                                                                                                      |
+| Deployment Type     | `manual`                                                                                                      |
 | Resources           |                                                                                                               |
 | Slack notifications | [#alerts-msp-testbed-test](https://sourcegraph.slack.com/archives/alerts-msp-testbed-test)                    |
 | Alerts              | [GCP monitoring](https://console.cloud.google.com/monitoring/alerting?project=msp-testbed-test-77589aae45d0)  |

--- a/dev/managedservicesplatform/operationdocs/testdata/TestRender/with_README.golden
+++ b/dev/managedservicesplatform/operationdocs/testdata/TestRender/with_README.golden
@@ -41,7 +41,7 @@ Some additional operations!
 |---------------------|---------------------------------------------------------------------------------------------------------------|
 | Project ID          | [`msp-testbed-test-77589aae45d0`](https://console.cloud.google.com/run?project=msp-testbed-test-77589aae45d0) |
 | Category            | **test**                                                                                                      |
-| Deployment Type     | `manual`                                                                                                      |
+| Deployment type     | `manual`                                                                                                      |
 | Resources           |                                                                                                               |
 | Slack notifications | [#alerts-msp-testbed-test](https://sourcegraph.slack.com/archives/alerts-msp-testbed-test)                    |
 | Alerts              | [GCP monitoring](https://console.cloud.google.com/monitoring/alerting?project=msp-testbed-test-77589aae45d0)  |


### PR DESCRIPTION
Updates MSP ops pages to include deployment info and links to delivery pipelines if applicable

Deployed in this handbook pr: https://github.com/sourcegraph/handbook/pull/8845
## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
docs changes