### PR TITLE
auth: bitbucket: fix slice indexing error when constructing oauth error messages

### DIFF
--- a/cmd/frontend/internal/auth/bitbucketcloudoauth/BUILD.bazel
+++ b/cmd/frontend/internal/auth/bitbucketcloudoauth/BUILD.bazel
@@ -72,6 +72,7 @@ go_test(
         "@com_github_google_go_cmp//cmp",
         "@com_github_google_go_cmp//cmp/cmpopts",
         "@com_github_sourcegraph_log//logtest",
+        "@com_github_stretchr_testify//assert",
         "@org_golang_x_oauth2//:oauth2",
     ],
 )

--- a/cmd/frontend/internal/auth/bitbucketcloudoauth/session.go
+++ b/cmd/frontend/internal/auth/bitbucketcloudoauth/session.go
@@ -118,8 +118,8 @@ func (s *sessionIssuerHelper) GetOrCreateUser(ctx context.Context, token *oauth2
 
 	// On failure, return the first error
 	verifiedEmails := make([]string, 0, len(attempts))
-	for i, attempt := range attempts {
-		verifiedEmails[i] = attempt.email
+	for _, attempt := range attempts {
+		verifiedEmails = append(verifiedEmails, attempt.email)
 	}
 	return false, nil, fmt.Sprintf("No Sourcegraph user exists matching any of the verified emails: %s.\n\nFirst error was: %s", strings.Join(verifiedEmails, ", "), firstSafeErrMsg), firstErr
 }

--- a/cmd/frontend/internal/auth/bitbucketcloudoauth/session_test.go
+++ b/cmd/frontend/internal/auth/bitbucketcloudoauth/session_test.go
@@ -3,6 +3,7 @@ package bitbucketcloudoauth
 import (
 	"context"
 	"encoding/json"
+	"github.com/stretchr/testify/assert"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -305,4 +306,75 @@ func acct(serviceType, serviceID, clientID, accountID string) extsvc.AccountSpec
 		ClientID:    clientID,
 		AccountID:   accountID,
 	}
+}
+
+func TestGetOrCreateUser_NoPanicOnEmailSlice(t *testing.T) {
+	fakeVerifiedEmails := []bitbucketcloud.UserEmail{
+		{
+			Email:       "foo@test.com",
+			IsConfirmed: true,
+		},
+		{
+			Email:       "bar@test.com",
+			IsConfirmed: true,
+		},
+	}
+
+	oldReturnEmails := returnEmails
+	returnEmails.Values = fakeVerifiedEmails
+	t.Cleanup(func() {
+		returnEmails = oldReturnEmails
+	})
+
+	server := createTestServer()
+	t.Cleanup(server.Close)
+
+	expectedError := errors.New("GetAndSaveUser failed for an arbitrary reason")
+
+	// Mock GetAndSaveUser to return an error
+	auth.MockGetAndSaveUser = func(ctx context.Context, op auth.GetAndSaveUserOp) (bool, int32, string, error) {
+		return false, 0, "", expectedError
+	}
+
+	t.Cleanup(func() {
+		auth.MockGetAndSaveUser = nil
+	})
+
+	ctx := bitbucketlogin.WithUser(context.Background(), nil)
+	conf := &schema.BitbucketCloudConnection{
+		Url:    server.URL,
+		ApiURL: server.URL,
+	}
+	bbClient, err := bitbucketcloud.NewClient(server.URL, conf, httpcli.TestExternalDoer)
+	if err != nil {
+		t.Fatalf("Failed to create Bitbucket Cloud client: %v", err)
+	}
+
+	u, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("Failed to parse URL: %v", err)
+	}
+
+	// Create issuer helper
+	issuer := &sessionIssuerHelper{
+		baseURL: u,
+		client:  bbClient,
+	}
+
+	// Assert no panic and that the returned error is the expected one
+	assert.NotPanics(t, func() {
+		tok := &oauth2.Token{AccessToken: "fake-token"}
+
+		_, _, safeErrString, err := issuer.GetOrCreateUser(ctx, tok, nil)
+
+		// Assert that the error is the expected one
+		assert.EqualError(t, err, expectedError.Error())
+
+		// Assert that the error message contains all the verified emails
+		// e.x. "...foo@test.com,...,bar@test.com,..."
+		for _, email := range fakeVerifiedEmails {
+			assert.Contains(t, safeErrString, email.Email)
+		}
+	})
+
 }


### PR DESCRIPTION
https://sourcegraph.slack.com/archives/C03JR7S7KRP/p1712180759513679?thread_ts=1712168903.358759&cid=C03JR7S7KRP

When a user signs in to Sourcegraph using a bitbucket oauth provider, there must be a corresponding Sourcegraph user with a verified email as their bitbucket account. (See https://sourcegraph.com/docs/admin/auth#linking-accounts-from-multiple-auth-providers). 

In the case where there isn't a matching Sourcegraph user with a verified email, we attempt to return an error message that looks like:

`No Sourcegraph user exists matching any of the verified emails: $VERIFIED_EMAILS.\n\nFirst error was: $ERROR` .

This was the original logic to construct the list of verified emails for the error message

```go
verifiedEmails := make([]string, 0, len(attempts))
	for i, attempt := range attempts {
		verifiedEmails[i] = attempt.email
	}
```

However, this logic has a fatal bug. The `make([]string, 0, len(attempts)`) constructs a slice with `0` len. Indexing into a slice with 0 length immediately throws an out-of-bounds panic. The correct thing to do here is to _append_ to the slice since it's initially empty.

This PR fixes this issue. 

## Test plan

New unit test