### PR TITLE
Remove clone progress DB experiment

### DIFF
--- a/client/web/src/featureFlags/featureFlags.ts
+++ b/client/web/src/featureFlags/featureFlags.ts
@@ -8,7 +8,6 @@ export const FEATURE_FLAGS = [
     'admin-onboarding',
     'auditlog-expansion',
     'blob-page-switch-areas-shortcuts',
-    'clone-progress-logging',
     'cody-chat-mock-test',
     'cody-web-search',
     'contrast-compliant-syntax-highlighting',

--- a/client/web/src/site-admin/SiteAdminRepositoriesContainer.tsx
+++ b/client/web/src/site-admin/SiteAdminRepositoriesContainer.tsx
@@ -15,7 +15,6 @@ import {
 } from '../components/FilteredConnection'
 import { usePageSwitcherPagination } from '../components/FilteredConnection/hooks/usePageSwitcherPagination'
 import { getFilterFromURL, getUrlQuery } from '../components/FilteredConnection/utils'
-import { useFeatureFlag } from '../featureFlags/useFeatureFlag'
 import {
     type ExternalServiceIDsAndNamesResult,
     type ExternalServiceIDsAndNamesVariables,
@@ -154,7 +153,6 @@ export const SiteAdminRepositoriesContainer: React.FunctionComponent<{ alwaysPol
     } = useQuery<StatusAndRepoStatsResult>(STATUS_AND_REPO_STATS, {})
     const location = useLocation()
     const navigate = useNavigate()
-    const [displayCloneProgress] = useFeatureFlag('clone-progress-logging')
 
     useEffect(() => {
         if (alwaysPoll || data?.repositoryStats?.total === 0 || data?.repositoryStats?.cloning !== 0) {
@@ -261,9 +259,8 @@ export const SiteAdminRepositoriesContainer: React.FunctionComponent<{ alwaysPol
             corrupted: args.corrupted ?? false,
             cloneStatus: args.cloneStatus ?? null,
             externalService: args.externalService ?? null,
-            displayCloneProgress,
         } as RepositoriesVariables
-    }, [searchQuery, filterValues, displayCloneProgress])
+    }, [searchQuery, filterValues])
 
     const debouncedVariables = useDebounce(variables, 300)
 

--- a/client/web/src/site-admin/backend.ts
+++ b/client/web/src/site-admin/backend.ts
@@ -112,7 +112,6 @@ const mirrorRepositoryInfoFieldsFragment = gql`
     fragment MirrorRepositoryInfoFields on MirrorRepositoryInfo {
         cloned
         cloneInProgress
-        cloneProgress @include(if: $displayCloneProgress)
         updatedAt
         nextSyncAt
         isCorrupted
@@ -170,7 +169,6 @@ export const REPOSITORIES_QUERY = gql`
         $orderBy: RepositoryOrderBy
         $descending: Boolean
         $externalService: ID
-        $displayCloneProgress: Boolean = false
     ) {
         repositories(
             first: $first
@@ -1005,13 +1003,7 @@ const siteAdminPackageFieldsFragment = gql`
 `
 
 export const PACKAGES_QUERY = gql`
-    query Packages(
-        $kind: PackageRepoReferenceKind
-        $name: String
-        $first: Int!
-        $after: String
-        $displayCloneProgress: Boolean = false
-    ) {
+    query Packages($kind: PackageRepoReferenceKind, $name: String, $first: Int!, $after: String) {
         packageRepoReferences(kind: $kind, name: $name, first: $first, after: $after) {
             nodes {
                 ...SiteAdminPackageFields

--- a/client/web/src/site-admin/components/RepoMirrorInfo.tsx
+++ b/client/web/src/site-admin/components/RepoMirrorInfo.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 
 import { Timestamp } from '@sourcegraph/branded/src/components/Timestamp'
-import { Code, Text, Tooltip } from '@sourcegraph/wildcard'
+import { Text, Tooltip } from '@sourcegraph/wildcard'
 
 import type { MirrorRepositoryInfoFields } from '../../graphql-operations'
 import { prettyBytesBigint } from '../../util/prettyBytesBigint'
@@ -34,14 +34,6 @@ export const RepoMirrorInfo: React.FunctionComponent<
                                     <span>not assigned</span>
                                 </Tooltip>
                             </>
-                        )}
-                        {mirrorInfo.cloneInProgress && (mirrorInfo.cloneProgress ?? '').trim() !== '' ? (
-                            <>
-                                <br />
-                                <Code>{mirrorInfo.cloneProgress}</Code>
-                            </>
-                        ) : (
-                            ''
                         )}
                     </>
                 )}

--- a/cmd/frontend/graphqlbackend/repository_mirror.go
+++ b/cmd/frontend/graphqlbackend/repository_mirror.go
@@ -11,7 +11,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/internal/auth"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/featureflag"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/gqlutil"
 	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
@@ -126,17 +125,6 @@ func (r *repositoryMirrorInfoResolver) CloneInProgress(ctx context.Context) (boo
 }
 
 func (r *repositoryMirrorInfoResolver) CloneProgress(ctx context.Context) (*string, error) {
-	if featureflag.FromContext(ctx).GetBoolOr("clone-progress-logging", false) {
-		info, err := r.computeGitserverRepo(ctx)
-		if err != nil {
-			return nil, err
-		}
-		if info.CloneStatus != types.CloneStatusCloning {
-			return nil, nil
-		}
-		return strptr(info.CloningProgress), nil
-	}
-
 	progress, err := r.gitServerClient.RepoCloneProgress(ctx, r.repository.RepoName())
 	if err != nil {
 		return nil, err

--- a/cmd/gitserver/internal/BUILD.bazel
+++ b/cmd/gitserver/internal/BUILD.bazel
@@ -47,7 +47,6 @@ go_library(
         "//internal/env",
         "//internal/errcode",
         "//internal/extsvc/gitolite",
-        "//internal/featureflag",
         "//internal/fileutil",
         "//internal/gitserver",
         "//internal/gitserver/gitdomain",

--- a/cmd/gitserver/internal/server_test.go
+++ b/cmd/gitserver/internal/server_test.go
@@ -350,9 +350,6 @@ func TestCloneRepo(t *testing.T) {
 
 	repoName := api.RepoName("example.com/foo/bar")
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	if _, err := db.FeatureFlags().CreateBool(ctx, "clone-progress-logging", true); err != nil {
-		t.Fatal(err)
-	}
 	dbRepo := &types.Repo{
 		Name:        repoName,
 		Description: "Test",
@@ -444,13 +441,6 @@ func TestCloneRepo(t *testing.T) {
 	if wantCommit != gotCommit {
 		t.Fatal("failed to clone:", gotCommit)
 	}
-	gitserverRepo, err := db.GitserverRepos().GetByName(ctx, repoName)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if gitserverRepo.CloningProgress == "" {
-		t.Error("want non-empty CloningProgress")
-	}
 }
 
 func TestCloneRepoRecordsFailures(t *testing.T) {
@@ -535,7 +525,6 @@ var ignoreVolatileGitserverRepoFields = cmpopts.IgnoreFields(
 	"RepoSizeBytes",
 	"UpdatedAt",
 	"CorruptionLogs",
-	"CloningProgress",
 )
 
 func TestHandleRepoUpdate(t *testing.T) {

--- a/internal/database/dbmocks/mocks_temp.go
+++ b/internal/database/dbmocks/mocks_temp.go
@@ -37624,9 +37624,6 @@ type MockGitserverRepoStore struct {
 	// SetCloneStatusFunc is an instance of a mock function object
 	// controlling the behavior of the method SetCloneStatus.
 	SetCloneStatusFunc *GitserverRepoStoreSetCloneStatusFunc
-	// SetCloningProgressFunc is an instance of a mock function object
-	// controlling the behavior of the method SetCloningProgress.
-	SetCloningProgressFunc *GitserverRepoStoreSetCloningProgressFunc
 	// SetLastErrorFunc is an instance of a mock function object controlling
 	// the behavior of the method SetLastError.
 	SetLastErrorFunc *GitserverRepoStoreSetLastErrorFunc
@@ -37711,11 +37708,6 @@ func NewMockGitserverRepoStore() *MockGitserverRepoStore {
 		},
 		SetCloneStatusFunc: &GitserverRepoStoreSetCloneStatusFunc{
 			defaultHook: func(context.Context, api.RepoName, types.CloneStatus, string) (r0 error) {
-				return
-			},
-		},
-		SetCloningProgressFunc: &GitserverRepoStoreSetCloningProgressFunc{
-			defaultHook: func(context.Context, api.RepoName, string) (r0 error) {
 				return
 			},
 		},
@@ -37822,11 +37814,6 @@ func NewStrictMockGitserverRepoStore() *MockGitserverRepoStore {
 				panic("unexpected invocation of MockGitserverRepoStore.SetCloneStatus")
 			},
 		},
-		SetCloningProgressFunc: &GitserverRepoStoreSetCloningProgressFunc{
-			defaultHook: func(context.Context, api.RepoName, string) error {
-				panic("unexpected invocation of MockGitserverRepoStore.SetCloningProgress")
-			},
-		},
 		SetLastErrorFunc: &GitserverRepoStoreSetLastErrorFunc{
 			defaultHook: func(context.Context, api.RepoName, string, string) error {
 				panic("unexpected invocation of MockGitserverRepoStore.SetLastError")
@@ -37907,9 +37894,6 @@ func NewMockGitserverRepoStoreFrom(i database.GitserverRepoStore) *MockGitserver
 		},
 		SetCloneStatusFunc: &GitserverRepoStoreSetCloneStatusFunc{
 			defaultHook: i.SetCloneStatus,
-		},
-		SetCloningProgressFunc: &GitserverRepoStoreSetCloningProgressFunc{
-			defaultHook: i.SetCloningProgress,
 		},
 		SetLastErrorFunc: &GitserverRepoStoreSetLastErrorFunc{
 			defaultHook: i.SetLastError,
@@ -39153,118 +39137,6 @@ func (c GitserverRepoStoreSetCloneStatusFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c GitserverRepoStoreSetCloneStatusFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0}
-}
-
-// GitserverRepoStoreSetCloningProgressFunc describes the behavior when the
-// SetCloningProgress method of the parent MockGitserverRepoStore instance
-// is invoked.
-type GitserverRepoStoreSetCloningProgressFunc struct {
-	defaultHook func(context.Context, api.RepoName, string) error
-	hooks       []func(context.Context, api.RepoName, string) error
-	history     []GitserverRepoStoreSetCloningProgressFuncCall
-	mutex       sync.Mutex
-}
-
-// SetCloningProgress delegates to the next hook function in the queue and
-// stores the parameter and result values of this invocation.
-func (m *MockGitserverRepoStore) SetCloningProgress(v0 context.Context, v1 api.RepoName, v2 string) error {
-	r0 := m.SetCloningProgressFunc.nextHook()(v0, v1, v2)
-	m.SetCloningProgressFunc.appendCall(GitserverRepoStoreSetCloningProgressFuncCall{v0, v1, v2, r0})
-	return r0
-}
-
-// SetDefaultHook sets function that is called when the SetCloningProgress
-// method of the parent MockGitserverRepoStore instance is invoked and the
-// hook queue is empty.
-func (f *GitserverRepoStoreSetCloningProgressFunc) SetDefaultHook(hook func(context.Context, api.RepoName, string) error) {
-	f.defaultHook = hook
-}
-
-// PushHook adds a function to the end of hook queue. Each invocation of the
-// SetCloningProgress method of the parent MockGitserverRepoStore instance
-// invokes the hook at the front of the queue and discards it. After the
-// queue is empty, the default hook function is invoked for any future
-// action.
-func (f *GitserverRepoStoreSetCloningProgressFunc) PushHook(hook func(context.Context, api.RepoName, string) error) {
-	f.mutex.Lock()
-	f.hooks = append(f.hooks, hook)
-	f.mutex.Unlock()
-}
-
-// SetDefaultReturn calls SetDefaultHook with a function that returns the
-// given values.
-func (f *GitserverRepoStoreSetCloningProgressFunc) SetDefaultReturn(r0 error) {
-	f.SetDefaultHook(func(context.Context, api.RepoName, string) error {
-		return r0
-	})
-}
-
-// PushReturn calls PushHook with a function that returns the given values.
-func (f *GitserverRepoStoreSetCloningProgressFunc) PushReturn(r0 error) {
-	f.PushHook(func(context.Context, api.RepoName, string) error {
-		return r0
-	})
-}
-
-func (f *GitserverRepoStoreSetCloningProgressFunc) nextHook() func(context.Context, api.RepoName, string) error {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-
-	if len(f.hooks) == 0 {
-		return f.defaultHook
-	}
-
-	hook := f.hooks[0]
-	f.hooks = f.hooks[1:]
-	return hook
-}
-
-func (f *GitserverRepoStoreSetCloningProgressFunc) appendCall(r0 GitserverRepoStoreSetCloningProgressFuncCall) {
-	f.mutex.Lock()
-	f.history = append(f.history, r0)
-	f.mutex.Unlock()
-}
-
-// History returns a sequence of
-// GitserverRepoStoreSetCloningProgressFuncCall objects describing the
-// invocations of this function.
-func (f *GitserverRepoStoreSetCloningProgressFunc) History() []GitserverRepoStoreSetCloningProgressFuncCall {
-	f.mutex.Lock()
-	history := make([]GitserverRepoStoreSetCloningProgressFuncCall, len(f.history))
-	copy(history, f.history)
-	f.mutex.Unlock()
-
-	return history
-}
-
-// GitserverRepoStoreSetCloningProgressFuncCall is an object that describes
-// an invocation of method SetCloningProgress on an instance of
-// MockGitserverRepoStore.
-type GitserverRepoStoreSetCloningProgressFuncCall struct {
-	// Arg0 is the value of the 1st argument passed to this method
-	// invocation.
-	Arg0 context.Context
-	// Arg1 is the value of the 2nd argument passed to this method
-	// invocation.
-	Arg1 api.RepoName
-	// Arg2 is the value of the 3rd argument passed to this method
-	// invocation.
-	Arg2 string
-	// Result0 is the value of the 1st result returned from this method
-	// invocation.
-	Result0 error
-}
-
-// Args returns an interface slice containing the arguments of this
-// invocation.
-func (c GitserverRepoStoreSetCloningProgressFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
-}
-
-// Results returns an interface slice containing the results of this
-// invocation.
-func (c GitserverRepoStoreSetCloningProgressFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
 }
 

--- a/internal/database/gitserver_repos_test.go
+++ b/internal/database/gitserver_repos_test.go
@@ -587,43 +587,6 @@ func TestSetCloneStatus(t *testing.T) {
 	}
 }
 
-func TestCloningProgress(t *testing.T) {
-	if testing.Short() {
-		t.Skip()
-	}
-
-	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(t))
-	ctx := context.Background()
-
-	t.Run("Default", func(t *testing.T) {
-		repo, _ := createTestRepo(ctx, t, db, "github.com/sourcegraph/defaultcloningprogress")
-		gotRepo, err := db.GitserverRepos().GetByName(ctx, repo.Name)
-		if err != nil {
-			t.Fatalf("GetByName: %s", err)
-		}
-		if got := gotRepo.CloningProgress; got != "" {
-			t.Errorf("GetByName.CloningProgress, got %q, want empty string", got)
-		}
-	})
-
-	t.Run("Set", func(t *testing.T) {
-		repo, gitserverRepo := createTestRepo(ctx, t, db, "github.com/sourcegraph/updatedcloningprogress")
-
-		gitserverRepo.CloningProgress = "Receiving objects: 97% (97/100)"
-		if err := db.GitserverRepos().SetCloningProgress(ctx, repo.Name, gitserverRepo.CloningProgress); err != nil {
-			t.Fatalf("SetCloningProgress: %s", err)
-		}
-		gotRepo, err := db.GitserverRepos().GetByName(ctx, repo.Name)
-		if err != nil {
-			t.Fatalf("GetByName: %s", err)
-		}
-		if diff := cmp.Diff(gitserverRepo, gotRepo, cmpopts.IgnoreFields(types.GitserverRepo{}, "UpdatedAt")); diff != "" {
-			t.Errorf("SetCloningProgress->GetByName -want+got: %s", diff)
-		}
-	})
-}
-
 func TestLogCorruption(t *testing.T) {
 	if testing.Short() {
 		t.Skip()

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -583,9 +583,8 @@ func ParseCloneStatusFromGraphQL(s string) CloneStatus {
 type GitserverRepo struct {
 	RepoID api.RepoID
 	// Usually represented by a gitserver hostname
-	ShardID         string
-	CloneStatus     CloneStatus
-	CloningProgress string
+	ShardID     string
+	CloneStatus CloneStatus
 	// The last error that occurred or empty if the last action was successful
 	LastError string
 	// The last time fetch was called.


### PR DESCRIPTION
This was an experiment from a while ago about storing the clone progress in the DB instead of making a request to gitserver to retrieve it. This has never been activated and is thus dead code, so removing it. With the switch to a dbworker we get better logging for free anyways.

## Test plan

Removed dead code, tests should cover any regressions.

