### PR TITLE
sg/msp: retrieve service/env more consistently, provide possible values in errors

### DIFF
--- a/dev/managedservicesplatform/spec/spec.go
+++ b/dev/managedservicesplatform/spec/spec.go
@@ -38,6 +38,8 @@ type Spec struct {
 	README []byte
 }
 
+var ErrServiceDoesNotExist = errors.New("service does not exist")
+
 // Open a specification file, validate it, unmarshal the data as a MSP spec,
 // and load any extraneous configuration. Callsites that return an error to the
 // user should wrap the error with the name of the service to avoid any confusion,
@@ -53,7 +55,7 @@ func Open(specPath string) (*Spec, error) {
 	specData, err := os.ReadFile(specPath)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			return nil, errors.Wrap(err, "service does not exist")
+			return nil, ErrServiceDoesNotExist
 		}
 		return nil, errors.Wrap(err, "read service specification")
 	}


### PR DESCRIPTION
This change migrates `generate` and `tfc sync` to use our service/env argument getters so that we return more consistent error messages. Errors around non-existent or missing service/env arguments now also provide relevant lists of possible values, such as all available services or all available environments for a valid service argument (see test plan examples).

Hopefully this makes errors easier to understand, as the possible values should give a better hint as to what arguments the command expects.

## Test plan

<img width="887" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/23356519/9e641c92-aec8-4bb4-9450-0a6865d21d62">

<img width="887" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/23356519/35d56943-f21a-4071-b5c5-582ef6aaa37a">
