### PR TITLE
Syntactic indexing support in policy matcher

### DIFF
--- a/internal/codeintel/autoindexing/internal/background/scheduler/job_scheduler.go
+++ b/internal/codeintel/autoindexing/internal/background/scheduler/job_scheduler.go
@@ -168,10 +168,10 @@ func (b indexSchedulerJob) handleRepository(ctx context.Context, repositoryID, p
 	for {
 		// Retrieve the set of configuration policies that affect indexing for this repository.
 		policies, totalCount, err := b.policiesSvc.GetConfigurationPolicies(ctx, policiesshared.GetConfigurationPoliciesOptions{
-			RepositoryID: repositoryID,
-			ForIndexing:  &t,
-			Limit:        policyBatchSize,
-			Offset:       offset,
+			RepositoryID:       repositoryID,
+			ForPreciseIndexing: &t,
+			Limit:              policyBatchSize,
+			Offset:             offset,
 		})
 		if err != nil {
 			return errors.Wrap(err, "policySvc.GetConfigurationPolicies")

--- a/internal/codeintel/policies/internal/store/configurations.go
+++ b/internal/codeintel/policies/internal/store/configurations.go
@@ -28,8 +28,8 @@ func (s *store) GetConfigurationPolicies(ctx context.Context, opts shared.GetCon
 	if opts.ForDataRetention != nil {
 		attrs = append(attrs, attribute.Bool("forDataRetention", *opts.ForDataRetention))
 	}
-	if opts.ForIndexing != nil {
-		attrs = append(attrs, attribute.Bool("forIndexing", *opts.ForIndexing))
+	if opts.ForPreciseIndexing != nil {
+		attrs = append(attrs, attribute.Bool("forPreciseIndexing", *opts.ForPreciseIndexing))
 	}
 	if opts.ForSyntacticIndexing != nil {
 		attrs = append(attrs, attribute.Bool("forSyntacticIndexing", *opts.ForSyntacticIndexing))
@@ -82,8 +82,8 @@ func (s *store) GetConfigurationPolicies(ctx context.Context, opts shared.GetCon
 			conds = append(conds, sqlf.Sprintf("NOT p.retention_enabled"))
 		}
 	}
-	if opts.ForIndexing != nil {
-		if *opts.ForIndexing {
+	if opts.ForPreciseIndexing != nil {
+		if *opts.ForPreciseIndexing {
 			conds = append(conds, sqlf.Sprintf("p.indexing_enabled"))
 		} else {
 			conds = append(conds, sqlf.Sprintf("NOT p.indexing_enabled"))

--- a/internal/codeintel/policies/internal/store/configurations.go
+++ b/internal/codeintel/policies/internal/store/configurations.go
@@ -31,6 +31,9 @@ func (s *store) GetConfigurationPolicies(ctx context.Context, opts shared.GetCon
 	if opts.ForIndexing != nil {
 		attrs = append(attrs, attribute.Bool("forIndexing", *opts.ForIndexing))
 	}
+	if opts.ForSyntacticIndexing != nil {
+		attrs = append(attrs, attribute.Bool("forSyntacticIndexing", *opts.ForSyntacticIndexing))
+	}
 	if opts.ForEmbeddings != nil {
 		attrs = append(attrs, attribute.Bool("forEmbeddings", *opts.ForEmbeddings))
 	}
@@ -84,6 +87,13 @@ func (s *store) GetConfigurationPolicies(ctx context.Context, opts shared.GetCon
 			conds = append(conds, sqlf.Sprintf("p.indexing_enabled"))
 		} else {
 			conds = append(conds, sqlf.Sprintf("NOT p.indexing_enabled"))
+		}
+	}
+	if opts.ForSyntacticIndexing != nil {
+		if *opts.ForSyntacticIndexing {
+			conds = append(conds, sqlf.Sprintf("p.syntactic_indexing_enabled"))
+		} else {
+			conds = append(conds, sqlf.Sprintf("NOT p.syntactic_indexing_enabled"))
 		}
 	}
 	if opts.ForEmbeddings != nil {

--- a/internal/codeintel/policies/internal/store/configurations_test.go
+++ b/internal/codeintel/policies/internal/store/configurations_test.go
@@ -33,21 +33,31 @@ func TestGetConfigurationPolicies(t *testing.T) {
 			retention_duration_hours,
 			retain_intermediate_commits,
 			indexing_enabled,
+			syntactic_indexing_enabled,
 			index_commit_max_age_hours,
 			index_intermediate_commits,
 			embeddings_enabled,
 			protected
 		) VALUES
-			(101, 42,   'policy  1 abc', 'GIT_TREE', '', null,              false, 0, false, true,  0, false, false, true),
-			(102, 42,   'policy  2 def', 'GIT_TREE', '', null,              true , 0, false, false, 0, false, false, true),
-			(103, 43,   'policy  3 bcd', 'GIT_TREE', '', null,              false, 0, false, true,  0, false, false, true),
-			(104, NULL, 'policy  4 abc', 'GIT_TREE', '', null,              true , 0, false, false, 0, false, false, false),
-			(105, NULL, 'policy  5 bcd', 'GIT_TREE', '', null,              false, 0, false, true,  0, false, false, false),
-			(106, NULL, 'policy  6 bcd', 'GIT_TREE', '', '{gitlab.com/*}',  true , 0, false, false, 0, false, false, false),
-			(107, NULL, 'policy  7 def', 'GIT_TREE', '', '{gitlab.com/*1}', false, 0, false, true,  0, false, false, false),
-			(108, NULL, 'policy  8 abc', 'GIT_TREE', '', '{gitlab.com/*2}', true , 0, false, false, 0, false, false, false),
-			(109, NULL, 'policy  9 def', 'GIT_TREE', '', '{github.com/*}',  false, 0, false, true,  0, false, false, false),
-			(110, NULL, 'policy 10 def', 'GIT_TREE', '', '{github.com/*}',  false, 0, false, false, 0, false, true,  false)
+			--                        							              ↙ retention_enabled
+			--                        							              |    ↙ retention_duration_hours
+			--                        							              |    |    ↙ retain_intermediate_commits
+			--                        							              |    |    |      ↙ indexing_enabled
+			--                        							              |    |    |      |      ↙ syntactic_indexing_enabled
+			--                        							              |    |    |      |      |    ↙ index_commit_max_age_hours
+			--                        							              |    |    |      |      |    |     ↙ index_intermediate_commits
+			--                        							              |    |    |      |      |    |     |     ↙ embeddings_enabled
+			--                        							              |    |    |      |      |    |     |     |     ↙ protected
+			(101, 42,   'policy  1 abc', 'GIT_TREE', '', null,              false, 0, false, true,  false, 0, false, false, true),
+			(102, 42,   'policy  2 def', 'GIT_TREE', '', null,              true , 0, false, false, true,  0, false, false, true),
+			(103, 43,   'policy  3 bcd', 'GIT_TREE', '', null,              false, 0, false, true,  false, 0, false, false, true),
+			(104, NULL, 'policy  4 abc', 'GIT_TREE', '', null,              true , 0, false, false, true,  0, false, false, false),
+			(105, NULL, 'policy  5 bcd', 'GIT_TREE', '', null,              false, 0, false, true,  true,  0, false, false, false),
+			(106, NULL, 'policy  6 bcd', 'GIT_TREE', '', '{gitlab.com/*}',  true , 0, false, false, true,  0, false, false, false),
+			(107, NULL, 'policy  7 def', 'GIT_TREE', '', '{gitlab.com/*1}', false, 0, false, true,  false, 0, false, false, false),
+			(108, NULL, 'policy  8 abc', 'GIT_TREE', '', '{gitlab.com/*2}', true , 0, false, false, true,  0, false, false, false),
+			(109, NULL, 'policy  9 def', 'GIT_TREE', '', '{github.com/*}',  false, 0, false, true,  false, 0, false, false, false),
+			(110, NULL, 'policy 10 def', 'GIT_TREE', '', '{github.com/*}',  false, 0, false, false, true,  0, false, true,  false)
 	`
 	if _, err := db.ExecContext(ctx, query); err != nil {
 		t.Fatalf("unexpected error while inserting configuration policies: %s", err)
@@ -71,39 +81,45 @@ func TestGetConfigurationPolicies(t *testing.T) {
 	}
 
 	var (
-		vt = true
-		vf = false
+		True  = true
+		False = false
 	)
 
 	type testCase struct {
-		repositoryID     int
-		term             string
-		forDataRetention *bool
-		forIndexing      *bool
-		forEmbeddings    *bool
-		protected        *bool
-		expectedIDs      []int
+		repositoryID         int
+		term                 string
+		forDataRetention     *bool
+		forIndexing          *bool
+		forSyntacticIndexing *bool
+		forEmbeddings        *bool
+		protected            *bool
+		expectedIDs          []int
 	}
 	testCases := []testCase{
-		{forEmbeddings: &vf, expectedIDs: []int{101, 102, 103, 104, 105, 106, 107, 108, 109}},  // Any flags; all policies
-		{forEmbeddings: &vf, protected: &vt, expectedIDs: []int{101, 102, 103}},                // Only protected
-		{forEmbeddings: &vf, protected: &vf, expectedIDs: []int{104, 105, 106, 107, 108, 109}}, // Only un-protected
+		{forEmbeddings: &False, expectedIDs: []int{101, 102, 103, 104, 105, 106, 107, 108, 109}},     // Any flags; all policies
+		{forEmbeddings: &False, protected: &True, expectedIDs: []int{101, 102, 103}},                 // Only protected
+		{forEmbeddings: &False, protected: &False, expectedIDs: []int{104, 105, 106, 107, 108, 109}}, // Only un-protected
 
-		{forEmbeddings: &vf, repositoryID: 41, expectedIDs: []int{104, 105, 106, 107}},              // Any flags; matches repo by patterns
-		{forEmbeddings: &vf, repositoryID: 42, expectedIDs: []int{101, 102, 104, 105, 109}},         // Any flags; matches repo by assignment and pattern
-		{forEmbeddings: &vf, repositoryID: 43, expectedIDs: []int{103, 104, 105}},                   // Any flags; matches repo by assignment
-		{forEmbeddings: &vf, repositoryID: 44, expectedIDs: []int{104, 105}},                        // Any flags; no matches by repo
-		{forEmbeddings: &vf, forDataRetention: &vt, expectedIDs: []int{102, 104, 106, 108}},         // For data retention; all policies
-		{forEmbeddings: &vf, forDataRetention: &vt, repositoryID: 41, expectedIDs: []int{104, 106}}, // For data retention; matches repo by patterns
-		{forEmbeddings: &vf, forDataRetention: &vt, repositoryID: 42, expectedIDs: []int{102, 104}}, // For data retention; matches repo by assignment and pattern
-		{forEmbeddings: &vf, forDataRetention: &vt, repositoryID: 43, expectedIDs: []int{104}},      // For data retention; matches repo by assignment
-		{forEmbeddings: &vf, forDataRetention: &vt, repositoryID: 44, expectedIDs: []int{104}},      // For data retention; no matches by repo
-		{forEmbeddings: &vf, forIndexing: &vt, expectedIDs: []int{101, 103, 105, 107, 109}},         // For indexing; all policies
-		{forEmbeddings: &vf, forIndexing: &vt, repositoryID: 41, expectedIDs: []int{105, 107}},      // For indexing; matches repo by patterns
-		{forEmbeddings: &vf, forIndexing: &vt, repositoryID: 42, expectedIDs: []int{101, 105, 109}}, // For indexing; matches repo by assignment and pattern
-		{forEmbeddings: &vf, forIndexing: &vt, repositoryID: 43, expectedIDs: []int{103, 105}},      // For indexing; matches repo by assignment
-		{forEmbeddings: &vf, forIndexing: &vt, repositoryID: 44, expectedIDs: []int{105}},           // For indexing; no matches by repo
-		{forDataRetention: &vf, forIndexing: &vf, forEmbeddings: &vt, expectedIDs: []int{110}},      // For embeddings
+		{forEmbeddings: &False, repositoryID: 41, expectedIDs: []int{104, 105, 106, 107}},                                              // Any flags; matches repo by patterns
+		{forEmbeddings: &False, repositoryID: 42, expectedIDs: []int{101, 102, 104, 105, 109}},                                         // Any flags; matches repo by assignment and pattern
+		{forEmbeddings: &False, repositoryID: 43, expectedIDs: []int{103, 104, 105}},                                                   // Any flags; matches repo by assignment
+		{forEmbeddings: &False, repositoryID: 44, expectedIDs: []int{104, 105}},                                                        // Any flags; no matches by repo
+		{forEmbeddings: &False, forDataRetention: &True, expectedIDs: []int{102, 104, 106, 108}},                                       // For data retention; all policies
+		{forEmbeddings: &False, forDataRetention: &True, repositoryID: 41, expectedIDs: []int{104, 106}},                               // For data retention; matches repo by patterns
+		{forEmbeddings: &False, forDataRetention: &True, repositoryID: 42, expectedIDs: []int{102, 104}},                               // For data retention; matches repo by assignment and pattern
+		{forEmbeddings: &False, forDataRetention: &True, repositoryID: 43, expectedIDs: []int{104}},                                    // For data retention; matches repo by assignment
+		{forEmbeddings: &False, forDataRetention: &True, repositoryID: 44, expectedIDs: []int{104}},                                    // For data retention; no matches by repo
+		{forEmbeddings: &False, forIndexing: &True, expectedIDs: []int{101, 103, 105, 107, 109}},                                       // For indexing; all policies
+		{forEmbeddings: &False, forIndexing: &True, repositoryID: 41, expectedIDs: []int{105, 107}},                                    // For indexing; matches repo by patterns
+		{forEmbeddings: &False, forIndexing: &True, repositoryID: 42, expectedIDs: []int{101, 105, 109}},                               // For indexing; matches repo by assignment and pattern
+		{forEmbeddings: &False, forIndexing: &True, repositoryID: 43, expectedIDs: []int{103, 105}},                                    // For indexing; matches repo by assignment
+		{forEmbeddings: &False, forIndexing: &True, repositoryID: 44, expectedIDs: []int{105}},                                         // For indexing; no matches by repo
+		{forSyntacticIndexing: &True, expectedIDs: []int{102, 104, 105, 106, 108, 110}},    // For syntactic indexing; all policies
+		{forSyntacticIndexing: &True, repositoryID: 41, expectedIDs: []int{104, 105, 106}},      // For syntactic indexing; matches repo by patterns
+		{forSyntacticIndexing: &True, repositoryID: 42, expectedIDs: []int{102, 104, 105}}, // For syntactic indexing; matches repo by assignment and pattern
+		{forSyntacticIndexing: &True, repositoryID: 43, expectedIDs: []int{103, 105}},      // For syntactic indexing; matches repo by assignment
+		{forSyntacticIndexing: &True, repositoryID: 44, expectedIDs: []int{105}},           // For syntactic indexing; no matches by repo
+		{forDataRetention: &False, forIndexing: &False, forEmbeddings: &True, expectedIDs: []int{110}},                                 // For embeddings
 
 		{term: "bc", expectedIDs: []int{101, 103, 104, 105, 106, 108}}, // Searches by name (multiple substring matches)
 		{term: "abcd", expectedIDs: []int{}},                           // Searches by name (no matches)
@@ -111,25 +127,27 @@ func TestGetConfigurationPolicies(t *testing.T) {
 
 	runTest := func(testCase testCase, lo, hi int) (errors int) {
 		name := fmt.Sprintf(
-			"repositoryID=%d term=%q forDataRetention=%v forIndexing=%v forEmbeddings=%v offset=%d",
+			"repositoryID=%d term=%q forDataRetention=%v forIndexing=%v forSyntacticIndexing=%v forEmbeddings=%v offset=%d",
 			testCase.repositoryID,
 			testCase.term,
 			testCase.forDataRetention,
 			testCase.forIndexing,
+			testCase.forSyntacticIndexing,
 			testCase.forEmbeddings,
 			lo,
 		)
 
 		t.Run(name, func(t *testing.T) {
 			policies, totalCount, err := store.GetConfigurationPolicies(ctx, policiesshared.GetConfigurationPoliciesOptions{
-				RepositoryID:     testCase.repositoryID,
-				Term:             testCase.term,
-				ForDataRetention: testCase.forDataRetention,
-				ForIndexing:      testCase.forIndexing,
-				ForEmbeddings:    testCase.forEmbeddings,
-				Protected:        testCase.protected,
-				Limit:            3,
-				Offset:           lo,
+				RepositoryID:         testCase.repositoryID,
+				Term:                 testCase.term,
+				ForDataRetention:     testCase.forDataRetention,
+				ForIndexing:          testCase.forIndexing,
+				ForSyntacticIndexing: testCase.forSyntacticIndexing,
+				ForEmbeddings:        testCase.forEmbeddings,
+				Protected:            testCase.protected,
+				Limit:                3,
+				Offset:               lo,
 			})
 			if err != nil {
 				t.Fatalf("unexpected error fetching configuration policies: %s", err)

--- a/internal/codeintel/policies/internal/store/configurations_test.go
+++ b/internal/codeintel/policies/internal/store/configurations_test.go
@@ -82,49 +82,49 @@ func TestGetConfigurationPolicies(t *testing.T) {
 	}
 
 	var (
-		True  = true
-		False = false
+		trueValue  = true
+		falseValue = false
 	)
 
 	type testCase struct {
 		repositoryID         int
 		term                 string
 		forDataRetention     *bool
-		forIndexing          *bool
+		forPreciseIndexing   *bool
 		forSyntacticIndexing *bool
 		forEmbeddings        *bool
 		protected            *bool
 		expectedIDs          []int
 	}
 	testCases := []testCase{
-		{forEmbeddings: &False, expectedIDs: []int{101, 102, 103, 104, 105, 106, 107, 108, 109, 111}}, // Any flags; all policies
-		{forEmbeddings: &False, protected: &True, expectedIDs: []int{101, 102, 103, 111}},             // Only protected
-		{forEmbeddings: &False, protected: &False, expectedIDs: []int{104, 105, 106, 107, 108, 109}},  // Only un-protected
+		{forEmbeddings: &falseValue, expectedIDs: []int{101, 102, 103, 104, 105, 106, 107, 108, 109, 111}},     // Any flags; all policies
+		{forEmbeddings: &falseValue, protected: &trueValue, expectedIDs: []int{101, 102, 103, 111}},            // Only protected
+		{forEmbeddings: &falseValue, protected: &falseValue, expectedIDs: []int{104, 105, 106, 107, 108, 109}}, // Only un-protected
 
-		{forEmbeddings: &False, repositoryID: 41, expectedIDs: []int{104, 105, 106, 107}},      // Any flags; matches repo by patterns
-		{forEmbeddings: &False, repositoryID: 42, expectedIDs: []int{101, 102, 104, 105, 109}}, // Any flags; matches repo by assignment and pattern
-		{forEmbeddings: &False, repositoryID: 43, expectedIDs: []int{103, 104, 105, 111}},      // Any flags; matches repo by assignment
-		{forEmbeddings: &False, repositoryID: 44, expectedIDs: []int{104, 105}},                // Any flags; no matches by repo
+		{forEmbeddings: &falseValue, repositoryID: 41, expectedIDs: []int{104, 105, 106, 107}},      // Any flags; matches repo by patterns
+		{forEmbeddings: &falseValue, repositoryID: 42, expectedIDs: []int{101, 102, 104, 105, 109}}, // Any flags; matches repo by assignment and pattern
+		{forEmbeddings: &falseValue, repositoryID: 43, expectedIDs: []int{103, 104, 105, 111}},      // Any flags; matches repo by assignment
+		{forEmbeddings: &falseValue, repositoryID: 44, expectedIDs: []int{104, 105}},                // Any flags; no matches by repo
 
-		{forEmbeddings: &False, forDataRetention: &True, expectedIDs: []int{102, 104, 106, 108}},         // For data retention; all policies
-		{forEmbeddings: &False, forDataRetention: &True, repositoryID: 41, expectedIDs: []int{104, 106}}, // For data retention; matches repo by patterns
-		{forEmbeddings: &False, forDataRetention: &True, repositoryID: 42, expectedIDs: []int{102, 104}}, // For data retention; matches repo by assignment and pattern
-		{forEmbeddings: &False, forDataRetention: &True, repositoryID: 43, expectedIDs: []int{104}},      // For data retention; matches repo by assignment
-		{forEmbeddings: &False, forDataRetention: &True, repositoryID: 44, expectedIDs: []int{104}},      // For data retention; no matches by repo
+		{forEmbeddings: &falseValue, forDataRetention: &trueValue, expectedIDs: []int{102, 104, 106, 108}},         // For data retention; all policies
+		{forEmbeddings: &falseValue, forDataRetention: &trueValue, repositoryID: 41, expectedIDs: []int{104, 106}}, // For data retention; matches repo by patterns
+		{forEmbeddings: &falseValue, forDataRetention: &trueValue, repositoryID: 42, expectedIDs: []int{102, 104}}, // For data retention; matches repo by assignment and pattern
+		{forEmbeddings: &falseValue, forDataRetention: &trueValue, repositoryID: 43, expectedIDs: []int{104}},      // For data retention; matches repo by assignment
+		{forEmbeddings: &falseValue, forDataRetention: &trueValue, repositoryID: 44, expectedIDs: []int{104}},      // For data retention; no matches by repo
 
-		{forEmbeddings: &False, forIndexing: &True, expectedIDs: []int{101, 103, 105, 107, 109}},         // For indexing; all policies
-		{forEmbeddings: &False, forIndexing: &True, repositoryID: 41, expectedIDs: []int{105, 107}},      // For indexing; matches repo by patterns
-		{forEmbeddings: &False, forIndexing: &True, repositoryID: 42, expectedIDs: []int{101, 105, 109}}, // For indexing; matches repo by assignment and pattern
-		{forEmbeddings: &False, forIndexing: &True, repositoryID: 43, expectedIDs: []int{103, 105}},      // For indexing; matches repo by assignment
-		{forEmbeddings: &False, forIndexing: &True, repositoryID: 44, expectedIDs: []int{105}},           // For indexing; no matches by repo
+		{forEmbeddings: &falseValue, forPreciseIndexing: &trueValue, expectedIDs: []int{101, 103, 105, 107, 109}},         // For indexing; all policies
+		{forEmbeddings: &falseValue, forPreciseIndexing: &trueValue, repositoryID: 41, expectedIDs: []int{105, 107}},      // For indexing; matches repo by patterns
+		{forEmbeddings: &falseValue, forPreciseIndexing: &trueValue, repositoryID: 42, expectedIDs: []int{101, 105, 109}}, // For indexing; matches repo by assignment and pattern
+		{forEmbeddings: &falseValue, forPreciseIndexing: &trueValue, repositoryID: 43, expectedIDs: []int{103, 105}},      // For indexing; matches repo by assignment
+		{forEmbeddings: &falseValue, forPreciseIndexing: &trueValue, repositoryID: 44, expectedIDs: []int{105}},           // For indexing; no matches by repo
 
-		{forSyntacticIndexing: &True, expectedIDs: []int{102, 104, 105, 106, 108, 111}},    // For syntactic indexing; all policies
-		{forSyntacticIndexing: &True, repositoryID: 41, expectedIDs: []int{104, 105, 106}}, // For syntactic indexing; matches repo by patterns
-		{forSyntacticIndexing: &True, repositoryID: 42, expectedIDs: []int{102, 104, 105}}, // For syntactic indexing; matches repo by assignment and pattern
-		{forSyntacticIndexing: &True, repositoryID: 43, expectedIDs: []int{104, 105, 111}}, // For syntactic indexing; matches repo by assignment
-		{forSyntacticIndexing: &True, repositoryID: 44, expectedIDs: []int{104, 105}},      // For syntactic indexing; no matches by repo
+		{forSyntacticIndexing: &trueValue, expectedIDs: []int{102, 104, 105, 106, 108, 111}},    // For syntactic indexing; all policies
+		{forSyntacticIndexing: &trueValue, repositoryID: 41, expectedIDs: []int{104, 105, 106}}, // For syntactic indexing; matches repo by patterns
+		{forSyntacticIndexing: &trueValue, repositoryID: 42, expectedIDs: []int{102, 104, 105}}, // For syntactic indexing; matches repo by assignment and pattern
+		{forSyntacticIndexing: &trueValue, repositoryID: 43, expectedIDs: []int{104, 105, 111}}, // For syntactic indexing; matches repo by assignment
+		{forSyntacticIndexing: &trueValue, repositoryID: 44, expectedIDs: []int{104, 105}},      // For syntactic indexing; no matches by repo
 
-		{forDataRetention: &False, forIndexing: &False, forEmbeddings: &True, expectedIDs: []int{110}}, // For embeddings
+		{forDataRetention: &falseValue, forPreciseIndexing: &falseValue, forEmbeddings: &trueValue, expectedIDs: []int{110}}, // For embeddings
 
 		{term: "bc", expectedIDs: []int{101, 103, 104, 105, 106, 108, 111}}, // Searches by name (multiple substring matches)
 		{term: "abcd", expectedIDs: []int{}},                                // Searches by name (no matches)
@@ -138,7 +138,7 @@ func TestGetConfigurationPolicies(t *testing.T) {
 			// without formatBoolOption the strings for those bool pointers end up looking like `0xc000010b4f`
 			// which only helps differentiate between empty value and non-empty
 			formatBoolOption(testCase.forDataRetention),
-			formatBoolOption(testCase.forIndexing),
+			formatBoolOption(testCase.forPreciseIndexing),
 			formatBoolOption(testCase.forSyntacticIndexing),
 			formatBoolOption(testCase.forEmbeddings),
 			formatBoolOption(testCase.protected),
@@ -150,7 +150,7 @@ func TestGetConfigurationPolicies(t *testing.T) {
 				RepositoryID:         testCase.repositoryID,
 				Term:                 testCase.term,
 				ForDataRetention:     testCase.forDataRetention,
-				ForIndexing:          testCase.forIndexing,
+				ForPreciseIndexing:   testCase.forPreciseIndexing,
 				ForSyntacticIndexing: testCase.forSyntacticIndexing,
 				ForEmbeddings:        testCase.forEmbeddings,
 				Protected:            testCase.protected,
@@ -294,5 +294,4 @@ func formatBoolOption(opt *bool) string {
 	} else {
 		return "false"
 	}
-
 }

--- a/internal/codeintel/policies/shared/types.go
+++ b/internal/codeintel/policies/shared/types.go
@@ -53,6 +53,10 @@ type GetConfigurationPoliciesOptions struct {
 	// be returned (or filtered).
 	ForIndexing *bool
 
+	// ForIndexing indicates that configuration policies with indexing enabled should
+	// be returned (or filtered).
+	ForSyntacticIndexing *bool
+
 	// ForEmbeddings indicates that configuration policies with embeddings enabled
 	// should be returned (or filtered).
 	ForEmbeddings *bool

--- a/internal/codeintel/policies/shared/types.go
+++ b/internal/codeintel/policies/shared/types.go
@@ -49,11 +49,11 @@ type GetConfigurationPoliciesOptions struct {
 	// should be returned (or filtered).
 	ForDataRetention *bool
 
-	// ForIndexing indicates that configuration policies with indexing enabled should
+	// ForPreciseIndexing indicates that configuration policies with precise indexing enabled should
 	// be returned (or filtered).
-	ForIndexing *bool
+	ForPreciseIndexing *bool
 
-	// ForIndexing indicates that configuration policies with indexing enabled should
+	// ForSyntacticIndexing indicates that configuration policies with syntactic indexing enabled should
 	// be returned (or filtered).
 	ForSyntacticIndexing *bool
 

--- a/internal/codeintel/policies/transport/graphql/root_resolver_policy_queries.go
+++ b/internal/codeintel/policies/transport/graphql/root_resolver_policy_queries.go
@@ -48,7 +48,7 @@ func (r *rootResolver) CodeIntelligenceConfigurationPolicies(ctx context.Context
 	}
 	opts.Protected = args.Protected
 	opts.ForDataRetention = args.ForDataRetention
-	opts.ForIndexing = args.ForIndexing
+	opts.ForPreciseIndexing = args.ForIndexing
 	opts.ForEmbeddings = args.ForEmbeddings
 
 	configPolicies, totalCount, err := r.policySvc.GetConfigurationPolicies(ctx, opts)


### PR DESCRIPTION
Add support for retrieving policies which enable syntactic indexing.

The meat of the PR is in the tests, which I improved a little, but they require much more work to be considered "easy to read".

## Test plan

New tests
Existing tests

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
