### PR TITLE
search jobs: fix feature flag eval in backend

### DIFF
--- a/internal/search/exhaustive/service/BUILD.bazel
+++ b/internal/search/exhaustive/service/BUILD.bazel
@@ -52,6 +52,7 @@ go_test(
     deps = [
         "//internal/actor",
         "//internal/api",
+        "//internal/conf",
         "//internal/database",
         "//internal/database/dbmocks",
         "//internal/endpoint",
@@ -70,6 +71,7 @@ go_test(
         "//internal/uploadstore/mocks",
         "//lib/errors",
         "//lib/iterator",
+        "//schema",
         "@com_github_hexops_autogold_v2//:autogold",
         "@com_github_sourcegraph_log//logtest",
         "@com_github_sourcegraph_zoekt//:zoekt",

--- a/internal/search/exhaustive/service/service.go
+++ b/internal/search/exhaustive/service/service.go
@@ -477,8 +477,9 @@ func (c *writeCounter) Write(p []byte) (n int, err error) {
 }
 
 func isEnabled() bool {
-	if experimentalFeatures := conf.SiteConfig().ExperimentalFeatures; experimentalFeatures != nil {
-		return experimentalFeatures.SearchJobs != nil && *experimentalFeatures.SearchJobs
+	experimentalFeatures := conf.SiteConfig().ExperimentalFeatures
+	if experimentalFeatures != nil && experimentalFeatures.SearchJobs != nil {
+		return *experimentalFeatures.SearchJobs
 	}
 	return true
 }

--- a/internal/search/exhaustive/service/service_test.go
+++ b/internal/search/exhaustive/service/service_test.go
@@ -8,8 +8,10 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/uploadstore/mocks"
 	"github.com/sourcegraph/sourcegraph/lib/iterator"
+	"github.com/sourcegraph/sourcegraph/schema"
 )
 
 // Test_copyBlobs tests that we concatenate objects from the object store
@@ -36,4 +38,45 @@ func Test_copyBlobs(t *testing.T) {
 
 	want := "{\"Key\":\"a\"}\n{\"Key\":\"b\"}\n{\"Key\":\"c\"}\n{\"Key\":\"d\"}\n{\"Key\":\"e\"}\n{\"Key\":\"f\"}\n"
 	require.Equal(t, want, w.String())
+}
+
+func TestIsEnabled(t *testing.T) {
+	defer conf.Mock(nil)
+
+	enabled := true
+	disabled := false
+
+	cases := []struct {
+		name                 string
+		experimentalFeatures *schema.ExperimentalFeatures
+		want                 bool
+	}{
+		{
+			name:                 "explicitly enabled",
+			experimentalFeatures: &schema.ExperimentalFeatures{SearchJobs: &enabled},
+			want:                 true,
+		},
+		{
+			name:                 "ExperimentalFeatures=nil",
+			experimentalFeatures: nil,
+			want:                 true,
+		},
+		{
+			name:                 "SearchJobs=nil",
+			experimentalFeatures: &schema.ExperimentalFeatures{},
+			want:                 true,
+		},
+		{
+			name:                 "explicitly disabled",
+			experimentalFeatures: &schema.ExperimentalFeatures{SearchJobs: &disabled},
+			want:                 false,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run("", func(t *testing.T) {
+			conf.Mock(&conf.Unified{SiteConfiguration: schema.SiteConfiguration{ExperimentalFeatures: c.experimentalFeatures}})
+			require.Equal(t, c.want, isEnabled())
+		})
+	}
 }


### PR DESCRIPTION
This fixes a bug in the evaluation of the feature flag for Search Jobs in the backend, where we would evaluate to "false" if other experimental features were set but "SearchJobs" was unset.

As a consequence, it could happen that the UI elements for Search Jobs were visible, but the backend returned a warning nevertheless. 

Test plan:
- new unit test