### PR TITLE
Bug: fixes UI bug causing the history panel not to fill the full space

### DIFF
--- a/client/web-sveltekit/src/lib/repo/LastCommit.svelte
+++ b/client/web-sveltekit/src/lib/repo/LastCommit.svelte
@@ -17,17 +17,14 @@
     <div class="avatar">
         <Avatar avatar={user} />
     </div>
-
     <div class="display-name">
         <small>{user.name}</small>
     </div>
-
     <div class="commit-message">
         <a href={canonicalURL}>
             <small>{commitMessage}</small>
         </a>
     </div>
-
     <div class="commit-date">
         <small>{commitDate}</small>
     </div>

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/+layout.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/+layout.svelte
@@ -160,10 +160,8 @@
                     {/key}
                 </TabPanel>
             </Tabs>
-            {#if lastCommit}
+            {#if lastCommit && selectedTab === null}
                 <LastCommit {lastCommit} />
-            {:else}
-                <LoadingSpinner inline />
             {/if}
         </div>
     </div>
@@ -218,8 +216,10 @@
         flex-flow: row nowrap;
         justify-content: space-between;
         padding-right: 0.5rem;
+        max-width: 100%;
 
         :global(.tabs) {
+            flex-grow: 1;
             height: 100%;
             max-height: 100%;
         }


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/61612 where the last commit information was causing the History panel to render incorrectly and not fill the available space.

**Before:**
![Screenshot 2024-04-05 at 9 26 46 AM](https://github.com/sourcegraph/sourcegraph/assets/62355966/e970756e-e0c4-43f6-9731-d0844c06176f)

**After:**
![Screenshot 2024-04-05 at 9 27 13 AM](https://github.com/sourcegraph/sourcegraph/assets/62355966/b3f69533-cee1-4966-af92-6cd23beeb217)

## Test plan
manual testing
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
