### PR TITLE
Svelte [ResultsIndicator]: Add 'Search Jobs' message to popover

### DIFF
--- a/client/web-sveltekit/src/lib/search/resultsIndicator/SuggestedAction.svelte
+++ b/client/web-sveltekit/src/lib/search/resultsIndicator/SuggestedAction.svelte
@@ -49,6 +49,12 @@
                 </small>
             </div>
         {/if}
+        <!--
+        TODO: @jasonhawkharris - When we implement search jobs,
+        we can change the link so that it points to where a user
+        can actually create a search job. We should also change
+        the text of the link when we do so, "Create a search job"
+        -->
         {#if severity === 'error' && !Object.hasOwn(mostSevere, 'suggested')}
             <div class="separator">{CENTER_DOT}</div>
             <div class="search-job-link">

--- a/client/web-sveltekit/src/lib/search/resultsIndicator/SuggestedAction.svelte
+++ b/client/web-sveltekit/src/lib/search/resultsIndicator/SuggestedAction.svelte
@@ -49,6 +49,14 @@
                 </small>
             </div>
         {/if}
+        {#if severity === 'error' && !Object.hasOwn(mostSevere, 'suggested')}
+            <div class="separator">{CENTER_DOT}</div>
+            <div class="search-job-link">
+                <small>
+                    Use <a href="/help/code-search/types/search-jobs">Search Job</a> for background search.
+                </small>
+            </div>
+        {/if}
     </div>
 </div>
 
@@ -84,5 +92,10 @@
     .suggested-action {
         display: flex;
         flex-flow: row nowrap;
+    }
+    .search-job-link {
+        // we don't want the text of this message to change color
+        // on hover when in an error state, so we set the text color explicitly
+        color: var(--text-body);
     }
 </style>

--- a/client/web-sveltekit/src/lib/search/resultsIndicator/SuggestedAction.test.ts
+++ b/client/web-sveltekit/src/lib/search/resultsIndicator/SuggestedAction.test.ts
@@ -25,7 +25,6 @@ describe('SuggestedAction.svelte', () => {
                         severity: 'error',
                         suggested: {
                             title: "here's a title",
-                            message: "here's a message",
                         },
                     },
                 ],
@@ -55,16 +54,16 @@ describe('SuggestedAction.svelte', () => {
                         reason: 'error',
                         title: 'this is an error',
                         message: 'vv much an error',
-                        severity: 'error',
+                        severity: 'info',
                     },
                 ],
             },
-            severity: 'error',
-            state: 'error',
+            severity: 'info',
+            state: 'complete',
         })
 
         const infoBadge = document.getElementsByClassName('info-badge error-text')
-        expect(infoBadge).toHaveLength(1)
+        expect(infoBadge).toHaveLength(0)
 
         const interpunct = document.getElementsByClassName('separator')
         expect(interpunct).toHaveLength(0)

--- a/client/web-sveltekit/src/routes/search/StreamingProgress.svelte
+++ b/client/web-sveltekit/src/routes/search/StreamingProgress.svelte
@@ -119,12 +119,30 @@
                 </Button>
             </form>
         {/if}
+        {#if severity === 'error' || state === 'loading'}
+            <div class="search-job-link">
+                <small>
+                    Search taking too long or timing out? Use <a
+                        href="/help/code-search/types/search-jobs"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                    >
+                        Search Job</a
+                    > for background search.
+                </small>
+            </div>
+        {/if}
     </div>
 </Popover>
 
 <style lang="scss">
     .chevron > :global(svg) {
         fill: currentColor !important;
+    }
+
+    .search-job-link {
+        margin: 0rem 1rem 1rem 1rem;
+        font-style: italic;
     }
 
     label {

--- a/client/web-sveltekit/src/routes/search/StreamingProgress.svelte
+++ b/client/web-sveltekit/src/routes/search/StreamingProgress.svelte
@@ -119,6 +119,11 @@
                 </Button>
             </form>
         {/if}
+        <!--
+        TODO: @jasonhawkharris - When we implement search jobs,
+        we can change the link so that it points to where a user
+        can actually create a search job
+        -->
         {#if severity === 'error' || state === 'loading'}
             <div class="search-job-link">
                 <small>


### PR DESCRIPTION
This PR introduces a "Search Jobs" suggestion in the popover when necessary. Additionally, it includes the suggestion in the results indicator.

The message displayed in the results indicator: 
![Screenshot 2024-04-05 at 1 04 22 PM](https://github.com/sourcegraph/sourcegraph/assets/62355966/891807c3-f4cf-429a-b712-ffc0c5deff69)

The message displayed in the popover:
![Screenshot 2024-04-05 at 1 05 50 PM](https://github.com/sourcegraph/sourcegraph/assets/62355966/8c07ec74-4e0c-4c1f-9bbc-96d4c8034414)

Both of these messages will appear simultaneously when the popover is active. Although this simultaneous display shouldn't pose an issue, I'd appreciate thoughts on this approach.

The message will display under the following conditions:

The search is completed with error.
The search is in a loading state.

For reference, here's how it looks when the message does not display: 
![Screenshot 2024-04-05 at 1 07 58 PM](https://github.com/sourcegraph/sourcegraph/assets/62355966/541e6540-6cd8-458a-ba4f-8edd40f0e271)

## Test plan
Adjust existing unit tests.
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
