### PR TITLE
nix: build pg-utils with nix & upload to GCS

### DIFF
--- a/.github/workflows/pg-utils.yml
+++ b/.github/workflows/pg-utils.yml
@@ -1,0 +1,121 @@
+name: pg-utils
+
+on:
+  push:
+    paths:
+      - 'dev/nix/pg-utils.nix'
+    branches:
+        - 'main'
+  pull_request:
+    paths:
+      - 'dev/nix/pg-utils.nix'
+  workflow_dispatch:
+permissions:
+  contents: 'read'
+  id-token: 'write'
+
+jobs:
+  x86_64-darwin:
+    name: Build pg-utils x86_64-darwin
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: DeterminateSystems/nix-installer-action@07b8bcba1b22d847db7ee507180c33e115499665 # SECURITY: pin third-party action hashes
+      - uses: DeterminateSystems/magic-nix-cache-action@a08d2ea91155518e6677c96e3111ac63813b9349
+      - name: '🔓 Authenticate to Google Cloud'
+        uses: google-github-actions/auth@3a3c4c57d294ef65efaaee4ff17b22fa88dd3c69
+        with:
+          credentials_json: ${{ secrets.CTAGS_GCP_SERVICE_ACCOUNT }}
+      - name: Run `nix build`
+        run: |
+          nix build .#pg-utils
+      - name: Sign the binaries
+        # signing in ./result/bin will cause a cache miss on next invocation
+        run: |
+          mkdir -p dist
+          cp -L ./result/bin/{createdb,dropdb,pg_dump} ./dist/
+          sudo codesign --force -s - ./dist/{createdb,dropdb,pg_dump}
+      - name: Rename and prepare for upload
+        run: |
+          cd dist/ && ls | xargs -I{} mv {} "{}.$(git rev-parse --short HEAD)"
+      - name: Show hash of pg-utils
+        run: |
+          shasum -a 256 ./dist/{createdb,dropdb,pg_dump}.*
+      - uses: google-github-actions/upload-cloud-storage@e95a15f226403ed658d3e65f40205649f342ba2c
+        # github.head_ref is only available for pull requests
+        # if the event type is not pull_requet we have to use github.ref_name
+        if: ${{ github.ref_name == 'main' }}
+        with:
+          path: './dist/'
+          destination: 'pg-utils/x86_64-darwin/'
+          glob: '{createdb,dropdb,pg_dump}*'
+  aarch64-darwin:
+    name: Build pg-utils aarch64-darwin
+    runs-on: macos-latest-xlarge
+    steps:
+      - uses: actions/checkout@v3
+      - uses: DeterminateSystems/nix-installer-action@07b8bcba1b22d847db7ee507180c33e115499665 # SECURITY: pin third-party action hashes
+      - uses: DeterminateSystems/magic-nix-cache-action@a08d2ea91155518e6677c96e3111ac63813b9349
+      - name: '🔓 Authenticate to Google Cloud'
+        uses: google-github-actions/auth@3a3c4c57d294ef65efaaee4ff17b22fa88dd3c69
+        with:
+          credentials_json: ${{ secrets.CTAGS_GCP_SERVICE_ACCOUNT }}
+      - name: Run `nix build`
+        run: |
+          nix build .#pg-utils
+      - name: Sign the binary
+        # signing in ./result/bin will cause a cache miss on next invocation
+        run: |
+          mkdir -p dist
+          cp -L ./result/bin/{createdb,dropdb,pg_dump}* ./dist/
+          sudo codesign --force -s - ./dist/{createdb,dropdb,pg_dump}*
+      - name: Rename and prepare for upload
+        run: |
+          cd dist/ && ls | xargs -I{} mv {} "{}.$(git rev-parse --short HEAD)"
+      - name: Show hash of pg-utils
+        run: |
+          shasum -a 256 ./dist/{createdb,dropdb,pg_dump}*
+      - uses: google-github-actions/upload-cloud-storage@e95a15f226403ed658d3e65f40205649f342ba2c
+        # github.head_ref is only available for pull requests
+        # if the event type is not pull_requet we have to use github.ref_name
+        if: ${{ github.ref_name == 'main' }}
+        with:
+          path: './dist/'
+          destination: 'pg-utils/aarch64-darwin'
+          glob: '{createdb,dropdb,pg_dump}*'
+  x86_64-linux:
+    name: Build pg-utils x86_64-linux
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: DeterminateSystems/nix-installer-action@07b8bcba1b22d847db7ee507180c33e115499665 # SECURITY: pin third-party action hashes
+      - uses: DeterminateSystems/magic-nix-cache-action@a08d2ea91155518e6677c96e3111ac63813b9349
+      - name: '🔓 Authenticate to Google Cloud'
+        uses: google-github-actions/auth@3a3c4c57d294ef65efaaee4ff17b22fa88dd3c69
+        with:
+          credentials_json: ${{ secrets.CTAGS_GCP_SERVICE_ACCOUNT }}
+      - name: Run `nix build`
+        run: |
+          nix build .#pg-utils
+      - name: Rename and prepare for upload
+        run: |
+          mkdir -p dist
+          cp -R -L ./result/bin/{createdb,dropdb,pg_dump}* dist/
+          cd dist/ && ls | xargs -I{} mv {} "{}.$(git rev-parse --short HEAD)"
+      - name: Show hash of pg-utils
+        run: |
+          shasum -a 256 ./dist/{createdb,dropdb,pg_dump}*
+      - uses: google-github-actions/upload-cloud-storage@e95a15f226403ed658d3e65f40205649f342ba2c
+        # github.head_ref is only available for pull requests
+        # if the event type is not pull_requet we have to use github.ref_name
+        if: ${{ github.ref_name == 'main' }}
+        with:
+          path: './dist/'
+          destination: 'pg-utils/x86_64-linux'
+          glob: '{createdb,dropdb,pg_dump}*'
+
+  report_failure:
+    needs: [aarch64-darwin, x86_64-darwin, x86_64-linux]
+    if: ${{ failure() }}
+    uses: sourcegraph/sourcegraph/.github/workflows/report-job-failure.yml@main
+    secrets: inherit

--- a/dev/nix/pg-utils.nix
+++ b/dev/nix/pg-utils.nix
@@ -1,0 +1,86 @@
+{ stdenv
+, fetchurl
+, pkg-config
+, tzdata
+, lib
+, path
+, substituteAll
+, darwin
+, patchelf
+}:
+stdenv.mkDerivation rec {
+  name = "postgresql";
+  version = "12.18";
+
+  src = fetchurl {
+    url = "mirror://postgresql/source/v${version}/postgresql-${version}.tar.bz2";
+    hash = "sha256-T5kZcl2UHOmGjgf+HtHTqGdIWZtIM4ZUdYOSi3TDkYo=";
+  };
+
+  hardeningEnable = [ ];
+
+  outputs = [ "out" ];
+
+  LC_ALL = "C";
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  # needed in order for libpq to be statically linked
+  postPatch = ''
+    sed -r 's/^(.*all-lib.*[ \t:])[a-z0-9-]+shared\S*/\1/' -i src/Makefile.shlib
+  '';
+
+  # for some reason, `make -C src/bin` wasnt being stable for me, but the install variant was,
+  # so we essentially do that building in the installing phase instead.
+  dontBuild = true;
+  doCheck = false;
+
+  installPhase = ''
+    make -C src/bin install
+  '';
+
+  # update linker to not point to the nix one, but to one that will work on
+  # most other distros such as Ubuntu
+  postFixup = lib.optionalString stdenv.isLinux ''
+    for bin in $out/bin/*; do
+      ${patchelf}/bin/patchelf --set-interpreter /lib64/ld-linux-x86-64.so.2 "$bin"
+    done
+  '';
+
+  # Want the minimal amount of things involved, so we don't have to deal with
+  # statically linking them all. We'll discover which we need as time goes on : )
+  configureFlags = [
+    "USE_DEV_URANDOM=1"
+    "--without-openssl"
+    "--without-libxml"
+    "--without-icu"
+    "--sysconfdir=/etc"
+    "--prefix=$(out)/"
+    "--with-system-tzdata=${tzdata}/share/zoneinfo"
+    "--disable-strong-random"
+    "--without-readline"
+    "--without-zlib"
+  ];
+
+  # some patches taken from https://sourcegraph.com/github.com/NixOS/nixpkgs/-/blob/pkgs/servers/sql/postgresql/generic.nix,
+  # only removed those obviously not needed, but haven't vetted the rest.
+  patches = [
+    "${path}/pkgs/servers/sql/postgresql/patches/disable-resolve_symlinks.patch"
+    "${path}/pkgs/servers/sql/postgresql/patches/less-is-more.patch"
+    "${path}/pkgs/servers/sql/postgresql/patches/hardcode-pgxs-path.patch"
+    "${path}/pkgs/servers/sql/postgresql/patches/specify_pkglibdir_at_runtime.patch"
+    "${path}/pkgs/servers/sql/postgresql/patches/findstring.patch"
+
+    (substituteAll {
+      src = "${path}/pkgs/servers/sql/postgresql/locale-binary-path.patch";
+      locale = "${if stdenv.isDarwin then darwin.adv_cmds else lib.getBin stdenv.cc.libc}/bin/locale";
+    })
+
+  ] ++ lib.optionals stdenv.isLinux [
+    "${path}/pkgs/servers/sql/postgresql/patches/socketdir-in-run.patch"
+  ];
+
+  disallowedReferences = [ stdenv.cc ];
+}

--- a/flake.nix
+++ b/flake.nix
@@ -43,6 +43,7 @@
             # doesnt need the same stability as those above
             nodejs-20_x = pkgs.callPackage ./dev/nix/nodejs.nix { };
             bazel_7 = nixpkgs-bazel.legacyPackages.${system}.callPackage ./dev/nix/bazel.nix { };
+            pg-utils = pkgs.callPackage ./dev/nix/pg-utils.nix { };
           };
 
           # We use pkgsShell (not pkgsAll) intentionally to avoid doing extra work of
@@ -58,6 +59,7 @@
         nodejs-20_x = final: prev: { nodejs-20_x = self.packages.${prev.system}.nodejs-20_x; };
         p4-fusion = final: prev: { p4-fusion = self.packages.${prev.system}.p4-fusion; };
         bazel_7 = final: prev: { bazel_7 = self.packages.${prev.system}.bazel_7; };
+        pg-utils = final: prev: { pg-utils = self.packages.${prev.system}.pg-utils; };
       };
     };
 }


### PR DESCRIPTION
Lets get rid of PG_UTILS_PATH! :allthethings: :tada: 

## Test plan

CI and a _lot_ of  `nix build .#pg-utils && ldd ./result/bin/pg_dump`
also tested e2e with the following diff: https://github.com/sourcegraph/sourcegraph/commit/61e0eb0d556dbfbcdae7a0c2cac1f5dd5cb85553