### PR TITLE
Svelte [bug]: adjust conditional to stay consistent with types

### DIFF
--- a/client/web-sveltekit/src/lib/search/resultsIndicator/SuggestedAction.svelte
+++ b/client/web-sveltekit/src/lib/search/resultsIndicator/SuggestedAction.svelte
@@ -38,7 +38,7 @@
         {/if}
 
         <!-- completed with suggested items -->
-        {#if done && mostSevere && Object.hasOwn(mostSevere, 'suggested')}
+        {#if done && mostSevere && mostSevere.suggested}
             <div class="separator">{CENTER_DOT}</div>
             <div class="action-badge">
                 <small>
@@ -55,7 +55,7 @@
         can actually create a search job. We should also change
         the text of the link when we do so, "Create a search job"
         -->
-        {#if severity === 'error' && !Object.hasOwn(mostSevere, 'suggested')}
+        {#if severity === 'error' && !mostSevere.suggested}
             <div class="separator">{CENTER_DOT}</div>
             <div class="search-job-link">
                 <small>


### PR DESCRIPTION
Using `Object.hasOwn()` circumvents the type system, so we shouldn't use this in conditional statements, in general.

The change is self-explanatory in the diff view.

## Test plan
Manual testing
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
