### PR TITLE
Context: remove key words from stopwords

### DIFF
--- a/internal/search/codycontext/query_transformer_test.go
+++ b/internal/search/codycontext/query_transformer_test.go
@@ -25,7 +25,8 @@ func TestTransformPattern(t *testing.T) {
 		"a",
 		"timer",
 		"computing",
-		"!?", // punctuation-only token should be removed
+		"own", // key terms should not be removed, even if they are common
+		"!?",  // punctuation-only token should be removed
 	}
 	wantPatterns := []string{
 		"comput",
@@ -34,6 +35,7 @@ func TestTransformPattern(t *testing.T) {
 		"string",
 		"elaps",
 		"timer",
+		"own",
 	}
 
 	gotPatterns := transformPatterns(patterns)

--- a/internal/search/codycontext/stop_words.go
+++ b/internal/search/codycontext/stop_words.go
@@ -1,6 +1,9 @@
 package codycontext
 
 // A large set of stopwords, taken from the ATIRE list here: https://github.com/igorbrigadir/stopwords/tree/master.
+// Custom modifications:
+// - Remove "changes" to improve changelog queries
+// - Remove "own" to improve ownership queries
 var stopWords = stringSet{
 	"'ll":             {},
 	"'ve":             {},
@@ -148,7 +151,6 @@ var stopWords = stringSet{
 	"causes":          {},
 	"certain":         {},
 	"certainly":       {},
-	"changes":         {},
 	"clear":           {},
 	"clearly":         {},
 	"co":              {},
@@ -588,7 +590,6 @@ var stopWords = stringSet{
 	"over":            {},
 	"overall":         {},
 	"owing":           {},
-	"own":             {},
 	"p":               {},
 	"page":            {},
 	"pages":           {},


### PR DESCRIPTION
While digging into why we perform poorly on "Ownership" and "Changelog"
searches, I noticed we were removing key terms in these queries. This PR adapts
the stopwords list to avoid removing them.

This doesn't immediately fix the problem, as we still don't match on filenames
(like CODEOWNERS or CHANGELOG.md). But it's a step towards the solution.

## Test plan

Adapted unit test.