### PR TITLE
Improving tokenization for OpenAI models and stop claude 3 tokenization

### DIFF
--- a/internal/completions/client/azureopenai/openai.go
+++ b/internal/completions/client/azureopenai/openai.go
@@ -230,7 +230,7 @@ func streamAutocomplete(
 		// stream is done
 		if errors.Is(err, io.EOF) {
 			tokenManager := tokenusage.NewManager()
-			err = tokenManager.TokenizeAndCalculateUsage(inputText(requestParams.Messages), content, tokenizer.AzureModel+"/"+requestParams.Model, "code_completions")
+			err = tokenManager.TokenizeAndCalculateUsage(requestParams.Messages, content, tokenizer.AzureModel+"/"+requestParams.Model, "code_completions")
 			if err != nil {
 				logger.Warn("Failed to count tokens with the token manager %w ", log.Error(err))
 			}
@@ -282,7 +282,7 @@ func streamChat(
 		// stream is done
 		if errors.Is(err, io.EOF) {
 			tokenManager := tokenusage.NewManager()
-			err = tokenManager.TokenizeAndCalculateUsage(inputText(requestParams.Messages), content, tokenizer.AzureModel+"/"+requestParams.Model, "chat_completions")
+			err = tokenManager.TokenizeAndCalculateUsage(requestParams.Messages, content, tokenizer.AzureModel+"/"+requestParams.Model, "chat_completions")
 			if err != nil {
 				logger.Warn("Failed to count tokens with the token manager %w ", log.Error(err))
 			}

--- a/internal/completions/client/openai/openai.go
+++ b/internal/completions/client/openai/openai.go
@@ -67,7 +67,7 @@ func (c *openAIChatCompletionStreamClient) Complete(
 		// Empty response.
 		return &types.CompletionResponse{}, nil
 	}
-	err = c.tokenManager.TokenizeAndCalculateUsage(inputText(requestParams.Messages), response.Choices[0].Text, tokenizer.OpenAIModel+"/"+requestParams.Model, string(feature))
+	err = c.tokenManager.TokenizeAndCalculateUsage(requestParams.Messages, response.Choices[0].Text, tokenizer.OpenAIModel+"/"+requestParams.Model, string(feature))
 	if err != nil {
 		logger.Warn("Failed to count tokens with the token manager %w ", log.Error(err))
 	}
@@ -139,19 +139,11 @@ func (c *openAIChatCompletionStreamClient) Stream(
 	if dec.Err() != nil {
 		return dec.Err()
 	}
-	err = c.tokenManager.TokenizeAndCalculateUsage(inputText(requestParams.Messages), content, tokenizer.OpenAIModel+"/"+requestParams.Model, string(feature))
+	err = c.tokenManager.TokenizeAndCalculateUsage(requestParams.Messages, content, tokenizer.OpenAIModel+"/"+requestParams.Model, string(feature))
 	if err != nil {
 		logger.Warn("Failed to count tokens with the token manager %w", log.Error(err))
 	}
 	return nil
-}
-
-func inputText(messages []types.Message) string {
-	allText := ""
-	for _, message := range messages {
-		allText += message.Text
-	}
-	return allText
 }
 
 // makeRequest formats the request and calls the chat/completions endpoint for code_completion requests

--- a/internal/completions/tokenizer/BUILD.bazel
+++ b/internal/completions/tokenizer/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "//internal/completions/tokenusage:__pkg__",
     ],
     deps = [
+        "//internal/completions/types",
         "//lib/errors",
         "@com_github_pkoukk_tiktoken_go//:tiktoken-go",
     ],

--- a/internal/completions/tokenizer/claude.go
+++ b/internal/completions/tokenizer/claude.go
@@ -26,7 +26,7 @@ type claudeEncodingFile struct {
 
 // NewAnthropicClaudeTokenizer is a tokenizer that emulates Anthropic's
 // tokenization for Claude.
-func newAnthropicClaudeTokenizer(model string, modelType ModelFamily) (Tokenizer, error) {
+func newAnthropicClaudeTokenizer(model string, modelFamily ModelFamily) (Tokenizer, error) {
 	var claudeEncodingFile claudeEncodingFile
 	err := json.Unmarshal([]byte(claudeJSON), &claudeEncodingFile)
 	if err != nil {
@@ -61,8 +61,8 @@ func newAnthropicClaudeTokenizer(model string, modelType ModelFamily) (Tokenizer
 	}
 
 	return &tiktokenTokenizer{
-		tk:        tiktoken.NewTiktoken(bpe, claudeEncoding, specialTokensSet),
-		model:     model,
-		modelType: modelType,
+		tk:          tiktoken.NewTiktoken(bpe, claudeEncoding, specialTokensSet),
+		model:       model,
+		modelFamily: modelFamily,
 	}, nil
 }

--- a/internal/completions/tokenizer/claude.go
+++ b/internal/completions/tokenizer/claude.go
@@ -26,7 +26,7 @@ type claudeEncodingFile struct {
 
 // NewAnthropicClaudeTokenizer is a tokenizer that emulates Anthropic's
 // tokenization for Claude.
-func newAnthropicClaudeTokenizer(model string) (Tokenizer, error) {
+func newAnthropicClaudeTokenizer(model string, modelType ModelFamily) (Tokenizer, error) {
 	var claudeEncodingFile claudeEncodingFile
 	err := json.Unmarshal([]byte(claudeJSON), &claudeEncodingFile)
 	if err != nil {
@@ -61,7 +61,8 @@ func newAnthropicClaudeTokenizer(model string) (Tokenizer, error) {
 	}
 
 	return &tiktokenTokenizer{
-		tk:    tiktoken.NewTiktoken(bpe, claudeEncoding, specialTokensSet),
-		model: model,
+		tk:        tiktoken.NewTiktoken(bpe, claudeEncoding, specialTokensSet),
+		model:     model,
+		modelType: modelType,
 	}, nil
 }

--- a/internal/completions/tokenizer/tokenizer.go
+++ b/internal/completions/tokenizer/tokenizer.go
@@ -4,6 +4,9 @@ import (
 	_ "embed"
 	"strings"
 
+	_ "embed"
+
+	"github.com/sourcegraph/sourcegraph/internal/completions/types"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 
 	"github.com/pkoukk/tiktoken-go"
@@ -16,34 +19,88 @@ const (
 	OpenAIModel    = "openai"
 )
 
+type ModelFamily int
+
+const (
+	UnknownModel ModelFamily = iota
+	Claude2
+	Claude3
+	GPT
+)
+
 // Tokenizer is an interface that all tokenizer implementations must satisfy.
 type Tokenizer interface {
 	Tokenize(text string) ([]int, error)
+	NumTokenizeFromMessages(messages []types.Message) (int, error)
 }
 
 type tiktokenTokenizer struct {
-	tk    *tiktoken.Tiktoken
-	model string
+	tk        *tiktoken.Tiktoken
+	model     string
+	modelType ModelFamily
 }
 
 func (t *tiktokenTokenizer) Tokenize(text string) ([]int, error) {
+	if t.modelType != Claude2 && t.modelType != GPT {
+		// tiktoken Tokenize is only support for Anthropic Claude 2 and OpenAI GPT family of models
+		// so we return nil for all other models so that zero tokens are  counted and token counting is disabled
+		return nil, nil
+	}
 	return t.tk.Encode(text, []string{"all"}, nil), nil
+}
+
+func (t *tiktokenTokenizer) NumTokenizeFromMessages(messages []types.Message) (int, error) {
+	if t.modelType != GPT {
+		return 0, errors.Newf("tiktoken NumTokenizeFromMessages is only support for OpenAI GPT family of models")
+	}
+	numTokens := 0
+	tokensPerMessage := 3
+	for _, message := range messages {
+		numTokens += tokensPerMessage
+		numTokens += len(t.tk.Encode(message.Speaker, nil, nil))
+		numTokens += len(t.tk.Encode(message.Text, nil, nil))
+	}
+	numTokens += 3 // every reply is primed with <|start|>assistant<|message|>
+	return numTokens, nil
+}
+
+// modelTypeFromString converts a model string to a ModelType.
+func modelTypeFromString(model string) ModelFamily {
+	switch {
+	case strings.Contains(model, AnthropicModel):
+		switch {
+		// Selects for claude 2, claude 2.1 and claude instant models
+		case strings.Contains(model, "claude-3"):
+			return Claude3
+		default:
+			// Selects for claude 3 models by exclusion
+			return Claude2
+		}
+	case strings.Contains(model, OpenAIModel), strings.Contains(model, AzureModel):
+		// Both Azure and OpenAI models use the same tokenizer
+		return GPT
+	default:
+		return UnknownModel
+	}
 }
 
 // NewTokenizer returns a Tokenizer instance based on the provided model.
 func NewTokenizer(model string) (Tokenizer, error) {
-	switch {
-	case strings.Contains(model, AnthropicModel):
-		return newAnthropicClaudeTokenizer(model)
-	case strings.Contains(model, AzureModel), strings.Contains(model, OpenAIModel):
-		// Returning a tiktokenTokenizer for models related to "azure" or "openai"
-		return newOpenAITokenizer(model)
+	modelType := modelTypeFromString(model)
+	switch modelType {
+	case Claude2:
+		return newAnthropicClaudeTokenizer(model, Claude2)
+	case Claude3:
+		// Claude 3 models are not supported yet so tokenization will eventually need to be implemented
+		return newAnthropicClaudeTokenizer(model, Claude3)
+	case GPT:
+		return newOpenAITokenizer(model, GPT)
 	default:
 		return nil, errors.New("tokenizer not found for this model")
 	}
 }
 
-func newOpenAITokenizer(model string) (*tiktokenTokenizer, error) {
+func newOpenAITokenizer(model string, modelType ModelFamily) (*tiktokenTokenizer, error) {
 	// Remove "azure" or "openai" prefix from the model string
 	model = strings.NewReplacer(AzureModel+"/", "", OpenAIModel+"/", "").Replace(model)
 
@@ -53,7 +110,8 @@ func newOpenAITokenizer(model string) (*tiktokenTokenizer, error) {
 	}
 
 	return &tiktokenTokenizer{
-		tk:    tkm,
-		model: model,
+		tk:        tkm,
+		model:     model,
+		modelType: modelType,
 	}, nil
 }

--- a/internal/completions/tokenizer/tokenizer.go
+++ b/internal/completions/tokenizer/tokenizer.go
@@ -35,13 +35,13 @@ type Tokenizer interface {
 }
 
 type tiktokenTokenizer struct {
-	tk        *tiktoken.Tiktoken
-	model     string
-	modelType ModelFamily
+	tk          *tiktoken.Tiktoken
+	model       string
+	modelFamily ModelFamily
 }
 
 func (t *tiktokenTokenizer) Tokenize(text string) ([]int, error) {
-	if t.modelType != Claude2 && t.modelType != GPT {
+	if t.modelFamily != Claude2 && t.modelFamily != GPT {
 		// tiktoken Tokenize is only support for Anthropic Claude 2 and OpenAI GPT family of models
 		// so we return nil for all other models so that zero tokens are  counted and token counting is disabled
 		return nil, nil
@@ -50,7 +50,7 @@ func (t *tiktokenTokenizer) Tokenize(text string) ([]int, error) {
 }
 
 func (t *tiktokenTokenizer) NumTokenizeFromMessages(messages []types.Message) (int, error) {
-	if t.modelType != GPT {
+	if t.modelFamily != GPT {
 		return 0, errors.Newf("tiktoken NumTokenizeFromMessages is only support for OpenAI GPT family of models")
 	}
 	numTokens := 0
@@ -64,8 +64,8 @@ func (t *tiktokenTokenizer) NumTokenizeFromMessages(messages []types.Message) (i
 	return numTokens, nil
 }
 
-// modelTypeFromString converts a model string to a ModelType.
-func modelTypeFromString(model string) ModelFamily {
+// modelFamilyFromString converts a model string to a ModelType.
+func modelFamilyFromString(model string) ModelFamily {
 	switch {
 	case strings.Contains(model, AnthropicModel):
 		switch {
@@ -86,8 +86,8 @@ func modelTypeFromString(model string) ModelFamily {
 
 // NewTokenizer returns a Tokenizer instance based on the provided model.
 func NewTokenizer(model string) (Tokenizer, error) {
-	modelType := modelTypeFromString(model)
-	switch modelType {
+	modelFamily := modelFamilyFromString(model)
+	switch modelFamily {
 	case Claude2:
 		return newAnthropicClaudeTokenizer(model, Claude2)
 	case Claude3:
@@ -100,7 +100,7 @@ func NewTokenizer(model string) (Tokenizer, error) {
 	}
 }
 
-func newOpenAITokenizer(model string, modelType ModelFamily) (*tiktokenTokenizer, error) {
+func newOpenAITokenizer(model string, modelFamily ModelFamily) (*tiktokenTokenizer, error) {
 	// Remove "azure" or "openai" prefix from the model string
 	model = strings.NewReplacer(AzureModel+"/", "", OpenAIModel+"/", "").Replace(model)
 
@@ -110,8 +110,8 @@ func newOpenAITokenizer(model string, modelType ModelFamily) (*tiktokenTokenizer
 	}
 
 	return &tiktokenTokenizer{
-		tk:        tkm,
-		model:     model,
-		modelType: modelType,
+		tk:          tkm,
+		model:       model,
+		modelFamily: modelFamily,
 	}, nil
 }

--- a/internal/completions/tokenusage/BUILD.bazel
+++ b/internal/completions/tokenusage/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
     ],
     deps = [
         "//internal/completions/tokenizer",
+        "//internal/completions/types",
         "//internal/rcache",
         "//lib/errors",
     ],
@@ -33,6 +34,7 @@ go_test(
     deps = [
         ":tokenusage",
         "//internal/completions/tokenizer",
+        "//internal/completions/types",
         "//internal/rcache",
     ],
 )


### PR DESCRIPTION
As I was testing the tokenization of different models and figuring out what to keep/remove in the current tokenization logic for Anthropic and OpenAI models I found out a couple of things

1. We can't remove the current anthropic token counting logic because the abuse detection logic depends on it([Slack Thread](https://sourcegraph.slack.com/archives/C05AGQYD528/p1712071741350299))
<img width="1151" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/11155207/560da65b-1d32-4515-8f17-9b9ce4cab954">
2. The current tokenization for abuse detection doesn't support anthropic claude 3 family of models because of the results of my token testing examples 

```
 tikatest python tokentest.py         
File: activate.csh, Model: claude-instant-1.2, Usage: Usage(input_tokens=331, output_tokens=255)
File: activate.csh, Model: claude-3-haiku-20240307, Usage: Usage(input_tokens=364, output_tokens=406)
Usage difference for activate.csh: 33 in percentage is 9.496402877697841 

File: another.tx, Model: claude-instant-1.2, Usage: Usage(input_tokens=940, output_tokens=323)
File: another.tx, Model: claude-3-haiku-20240307, Usage: Usage(input_tokens=1009, output_tokens=504)
Usage difference for another.tx: 69 in percentage is 7.080554130323243 

File: blod.py, Model: claude-instant-1.2, Usage: Usage(input_tokens=404, output_tokens=279)
File: blod.py, Model: claude-3-haiku-20240307, Usage: Usage(input_tokens=451, output_tokens=410)
Usage difference for blod.py: 47 in percentage is 10.994152046783626 

File: copyapp.py, Model: claude-instant-1.2, Usage: Usage(input_tokens=60, output_tokens=310)
File: copyapp.py, Model: claude-3-haiku-20240307, Usage: Usage(input_tokens=66, output_tokens=439)
Usage difference for copyapp.py: 6 in percentage is 9.523809523809524 

File: pyvenv.cfg, Model: claude-instant-1.2, Usage: Usage(input_tokens=124, output_tokens=285)
File: pyvenv.cfg, Model: claude-3-haiku-20240307, Usage: Usage(input_tokens=125, output_tokens=388)
Usage difference for pyvenv.cfg: 1 in percentage is 0.8032128514056225 

File: testFuzzysort.js, Model: claude-instant-1.2, Usage: Usage(input_tokens=574, output_tokens=298)
File: testFuzzysort.js, Model: claude-3-haiku-20240307, Usage: Usage(input_tokens=697, output_tokens=375)
Usage difference for testFuzzysort.js: 123 in percentage is 19.35483870967742 

File: textfile.txt, Model: claude-instant-1.2, Usage: Usage(input_tokens=1305, output_tokens=198)
File: textfile.txt, Model: claude-3-haiku-20240307, Usage: Usage(input_tokens=1508, output_tokens=349)
Usage difference for textfile.txt: 203 in percentage is 14.43298969072165 
```

## Purpose of this PR
- Add token counting specialized and more accurate logic for OpenAI models the counting is inspired by [this](https://github.com/pkoukk/tiktoken-go?tab=readme-ov-file#counting-tokens-for-chat-api-calls). NOTE the edge cases carefully and see that because we don't support the gpt-3.5-turbo-0301 model our token counting is much simpler but the underslying logic is exactly the same. I have tested this in my scripting too and compared the results with the OpenAI token counting usage results(sent as a result of the API calls). 
- Add new anthropic families claude 2 and claude 3(More info in slack)


## Test plan
- CI
- Run the debugger and check token counting for the case of OpenAI, anthropic with different models

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
