### PR TITLE
gitserver: Simplify clone

### DIFF
--- a/cmd/gitserver/internal/server_test.go
+++ b/cmd/gitserver/internal/server_test.go
@@ -181,7 +181,7 @@ func TestExecRequest(t *testing.T) {
 		if repo == "github.com/gorilla/mux" || repo == "my-mux" {
 			return true, nil
 		}
-		_, err := s.CloneRepo(context.Background(), repo, CloneOptions{})
+		err := s.cloneRepo(context.Background(), repo)
 		require.NoError(t, err)
 		return false, nil
 	})
@@ -293,7 +293,6 @@ func makeTestServer(ctx context.Context, t *testing.T, repoDir, remote string, d
 		return remote, nil
 	}
 
-	cloneQueue := NewCloneQueue(obctx, list.New())
 	fs := gitserverfs.New(obctx, repoDir)
 	require.NoError(t, fs.Initialize())
 	s := NewServer(&ServerOpts{
@@ -324,7 +323,6 @@ func makeTestServer(ctx context.Context, t *testing.T, repoDir, remote string, d
 				NewNoOpRecordingCommandFactory(), getRemoteURLSource), nil
 		},
 		DB:                      db,
-		CloneQueue:              cloneQueue,
 		Locker:                  NewRepositoryLocker(),
 		RPSLimiter:              ratelimit.NewInstrumentedLimiter("GitserverTest", rate.NewLimiter(rate.Inf, 10)),
 		RecordingCommandFactory: wrexec.NewRecordingCommandFactory(nil, 0),
@@ -334,9 +332,6 @@ func makeTestServer(ctx context.Context, t *testing.T, repoDir, remote string, d
 	s.ctx = ctx
 	s.cloneLimiter = limiter.NewMutable(1)
 
-	p := s.NewClonePipeline(logtest.Scoped(t), cloneQueue)
-	p.Start()
-	t.Cleanup(p.Stop)
 	return s
 }
 
@@ -393,7 +388,7 @@ func TestCloneRepo(t *testing.T) {
 	cmd("git", "tag", "HEAD")
 
 	// Enqueue repo clone.
-	_, err := s.CloneRepo(ctx, repoName, CloneOptions{})
+	err := s.cloneRepo(ctx, repoName)
 	require.NoError(t, err)
 
 	// Wait until the clone is done. Please do not use this code snippet
@@ -417,24 +412,11 @@ func TestCloneRepo(t *testing.T) {
 	}
 
 	// Test blocking with a failure (already exists since we didn't specify overwrite)
-	_, err = s.CloneRepo(context.Background(), repoName, CloneOptions{Block: true})
+	err = s.cloneRepo(context.Background(), repoName)
 	if !errors.Is(err, os.ErrExist) {
 		t.Fatalf("expected clone repo to fail with already exists: %s", err)
 	}
 	assertRepoState(types.CloneStatusCloned, wantRepoSize, err)
-
-	// Test blocking with overwrite. First add random file to GIT_DIR. If the
-	// file is missing after cloning we know the directory was replaced
-	mkFiles(t, repoDir.Path("."), "HELLO")
-	_, err = s.CloneRepo(context.Background(), repoName, CloneOptions{Block: true, Overwrite: true})
-	if err != nil {
-		t.Fatal(err)
-	}
-	assertRepoState(types.CloneStatusCloned, wantRepoSize, err)
-
-	if _, err := os.Stat(repoDir.Path("HELLO")); !os.IsNotExist(err) {
-		t.Fatalf("expected clone to be overwritten: %s", err)
-	}
 
 	gotCommit = cmd("git", "rev-parse", "HEAD")
 	if wantCommit != gotCommit {
@@ -509,9 +491,7 @@ func TestCloneRepoRecordsFailures(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			s.getVCSSyncer = tc.getVCSSyncer
-			_, _ = s.CloneRepo(ctx, repoName, CloneOptions{
-				Block: true,
-			})
+			_ = s.cloneRepo(ctx, repoName)
 			assertRepoState(types.CloneStatusNotCloned, 0, tc.wantErr)
 		})
 	}
@@ -709,7 +689,7 @@ func TestCloneRepo_EnsureValidity(t *testing.T) {
 		cmd("rm", ".git/HEAD")
 
 		s := makeTestServer(ctx, t, reposDir, remote, nil)
-		if _, err := s.CloneRepo(ctx, "example.com/foo/bar", CloneOptions{}); err == nil {
+		if err := s.cloneRepo(ctx, "example.com/foo/bar"); err == nil {
 			t.Fatal("expected an error, got none")
 		}
 	})
@@ -727,7 +707,7 @@ func TestCloneRepo_EnsureValidity(t *testing.T) {
 		cmd("sh", "-c", ": > .git/HEAD")
 
 		s := makeTestServer(ctx, t, reposDir, remote, nil)
-		if _, err := s.CloneRepo(ctx, "example.com/foo/bar", CloneOptions{}); err == nil {
+		if err := s.cloneRepo(ctx, "example.com/foo/bar"); err == nil {
 			t.Fatal("expected an error, got none")
 		}
 	})
@@ -757,7 +737,7 @@ func TestCloneRepo_EnsureValidity(t *testing.T) {
 		t.Cleanup(func() { vcssyncer.TestRepositoryPostFetchCorruptionFunc = nil })
 		// Use block so we get clone errors right here and don't have to rely on the
 		// clone queue. There's no other reason for blocking here, just convenience/simplicity.
-		_, err := s.CloneRepo(ctx, repoName, CloneOptions{Block: true})
+		err := s.cloneRepo(ctx, repoName)
 		require.NoError(t, err)
 
 		dst := s.fs.RepoDir(repoName)
@@ -786,7 +766,7 @@ func TestCloneRepo_EnsureValidity(t *testing.T) {
 			cmd("sh", "-c", fmt.Sprintf(": > %s/HEAD", tmpDir))
 		}
 		t.Cleanup(func() { vcssyncer.TestRepositoryPostFetchCorruptionFunc = nil })
-		if _, err := s.CloneRepo(ctx, "example.com/foo/bar", CloneOptions{Block: true}); err != nil {
+		if err := s.cloneRepo(ctx, "example.com/foo/bar"); err != nil {
 			t.Fatalf("expected no error, got %v", err)
 		}
 
@@ -898,7 +878,7 @@ func TestSyncRepoState(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = s.CloneRepo(ctx, repoName, CloneOptions{Block: true})
+	err = s.cloneRepo(ctx, repoName)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/gitserver/shared/shared.go
+++ b/cmd/gitserver/shared/shared.go
@@ -90,7 +90,6 @@ func Main(ctx context.Context, observationCtx *observation.Context, ready servic
 
 	// Setup our server megastruct.
 	recordingCommandFactory := wrexec.NewRecordingCommandFactory(nil, 0)
-	cloneQueue := server.NewCloneQueue(observationCtx, list.New())
 	locker := server.NewRepositoryLocker()
 	hostname := config.ExternalAddress
 	gitserver := server.NewServer(&server.ServerOpts{
@@ -135,7 +134,6 @@ func Main(ctx context.Context, observationCtx *observation.Context, ready servic
 		FS:                      fs,
 		Hostname:                hostname,
 		DB:                      db,
-		CloneQueue:              cloneQueue,
 		Perforce:                perforce.NewService(ctx, observationCtx, logger, db, list.New()),
 		RecordingCommandFactory: recordingCommandFactory,
 		Locker:                  locker,
@@ -174,7 +172,6 @@ func Main(ctx context.Context, observationCtx *observation.Context, ready servic
 		httpserver.NewFromAddr(config.ListenAddress, &http.Server{
 			Handler: handler,
 		}),
-		gitserver.NewClonePipeline(logger, cloneQueue),
 		server.NewRepoStateSyncer(
 			ctx,
 			logger,


### PR DESCRIPTION
After the PRs this is stacked on top of, the only option we passed to CloneRepo was Block: true. 
This means that the in-memory queue was no longer used and could be removed.
This makes for a single code path to clone a repo, and a single caller on the gRPC side as well, so nice and simple.

This'll help make improvements to the scheduler simpler without having to think about 10 different call paths.

## Test plan

Just removed dead code, E2E tests still pass.