### PR TITLE
gitserver: Move gitservice off of server struct

### DIFF
--- a/cmd/gitserver/internal/gitservice.go
+++ b/cmd/gitserver/internal/gitservice.go
@@ -3,6 +3,7 @@ package internal
 import (
 	"context"
 	"io"
+	"net/http"
 	"os/exec"
 	"strconv"
 	"sync"
@@ -15,8 +16,11 @@ import (
 	"github.com/sourcegraph/log"
 
 	"github.com/sourcegraph/sourcegraph/cmd/gitserver/internal/accesslog"
+	"github.com/sourcegraph/sourcegraph/cmd/gitserver/internal/gitserverfs"
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/env"
+	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/lib/gitservice"
 )
 
@@ -32,6 +36,33 @@ var (
 	gitServiceMaxEgressBytesPerSecond        int64
 	getGitServiceMaxEgressBytesPerSecondOnce sync.Once
 )
+
+// NewHTTPHandler returns a HTTP handler that serves a git upload pack server,
+// plus a few other endpoints.
+func NewHTTPHandler(logger log.Logger, fs gitserverfs.FS) http.Handler {
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/ping", trace.WithRouteName("ping", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	// This endpoint allows us to expose gitserver itself as a "git service"
+	// (ETOOMANYGITS!) that allows other services to run commands like "git fetch"
+	// directly against a gitserver replica and treat it as a git remote.
+	//
+	// Example use case for this is a repo migration from one replica to another during
+	// scaling events and the new destination gitserver replica can directly clone from
+	// the gitserver replica which hosts the repository currently.
+	mux.HandleFunc("/git/", trace.WithRouteName("git", accesslog.HTTPMiddleware(
+		logger.Scoped("git.accesslog"),
+		conf.DefaultClient(),
+		func(rw http.ResponseWriter, r *http.Request) {
+			http.StripPrefix("/git", gitServiceHandler(logger.Scoped("gitServiceHandler"), fs)).ServeHTTP(rw, r)
+		},
+	)))
+
+	return mux
+}
 
 // getGitServiceMaxEgressBytesPerSecond parses envGitServiceMaxEgressBytesPerSecond once
 // and returns the same value on subsequent calls.
@@ -70,12 +101,10 @@ func flowrateWriter(logger log.Logger, w io.Writer) io.Writer {
 	return w
 }
 
-func (s *Server) gitServiceHandler() *gitservice.Handler {
-	logger := s.logger.Scoped("gitServiceHandler")
-
+func gitServiceHandler(logger log.Logger, fs gitserverfs.FS) *gitservice.Handler {
 	return &gitservice.Handler{
 		Dir: func(d string) string {
-			return string(s.fs.RepoDir(api.RepoName(d)))
+			return string(fs.RepoDir(api.RepoName(d)))
 		},
 
 		ErrorHook: func(err error, stderr string) {

--- a/cmd/gitserver/internal/integration_tests/clone_test.go
+++ b/cmd/gitserver/internal/integration_tests/clone_test.go
@@ -3,6 +3,7 @@ package inttests
 import (
 	"container/list"
 	"context"
+	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"os"
@@ -98,7 +99,7 @@ func TestClone(t *testing.T) {
 	grpcServer := defaults.NewServer(logtest.Scoped(t))
 	proto.RegisterGitserverServiceServer(grpcServer, server.NewGRPCServer(s))
 
-	handler := internalgrpc.MultiplexHandlers(grpcServer, s.Handler())
+	handler := internalgrpc.MultiplexHandlers(grpcServer, http.NotFoundHandler())
 	srv := httptest.NewServer(handler)
 	t.Cleanup(srv.Close)
 
@@ -213,7 +214,7 @@ func TestClone_Fail(t *testing.T) {
 	grpcServer := defaults.NewServer(logtest.Scoped(t))
 	proto.RegisterGitserverServiceServer(grpcServer, server.NewGRPCServer(s))
 
-	handler := internalgrpc.MultiplexHandlers(grpcServer, s.Handler())
+	handler := internalgrpc.MultiplexHandlers(grpcServer, http.NotFoundHandler())
 	srv := httptest.NewServer(handler)
 	t.Cleanup(srv.Close)
 

--- a/cmd/gitserver/internal/integration_tests/resolverevisions_test.go
+++ b/cmd/gitserver/internal/integration_tests/resolverevisions_test.go
@@ -3,6 +3,7 @@ package inttests
 import (
 	"container/list"
 	"context"
+	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"path/filepath"
@@ -112,7 +113,7 @@ func TestClient_ResolveRevision(t *testing.T) {
 	grpcServer := defaults.NewServer(logtest.Scoped(t))
 	proto.RegisterGitserverServiceServer(grpcServer, server.NewGRPCServer(s))
 
-	handler := internalgrpc.MultiplexHandlers(grpcServer, s.Handler())
+	handler := internalgrpc.MultiplexHandlers(grpcServer, http.NotFoundHandler())
 	srv := httptest.NewServer(handler)
 
 	defer srv.Close()

--- a/cmd/gitserver/internal/integration_tests/test_utils.go
+++ b/cmd/gitserver/internal/integration_tests/test_utils.go
@@ -120,7 +120,7 @@ func InitGitserver() {
 
 	grpcServer := defaults.NewServer(logger)
 	proto.RegisterGitserverServiceServer(grpcServer, server.NewGRPCServer(s))
-	handler := internalgrpc.MultiplexHandlers(grpcServer, s.Handler())
+	handler := internalgrpc.MultiplexHandlers(grpcServer, http.NotFoundHandler())
 
 	srv := &http.Server{
 		Handler: handler,

--- a/cmd/gitserver/shared/shared.go
+++ b/cmd/gitserver/shared/shared.go
@@ -17,6 +17,7 @@ import (
 	"github.com/sourcegraph/log"
 	"google.golang.org/grpc"
 
+	"github.com/sourcegraph/sourcegraph/cmd/gitserver/internal"
 	server "github.com/sourcegraph/sourcegraph/cmd/gitserver/internal"
 	"github.com/sourcegraph/sourcegraph/cmd/gitserver/internal/accesslog"
 	"github.com/sourcegraph/sourcegraph/cmd/gitserver/internal/cloneurl"
@@ -157,7 +158,7 @@ func Main(ctx context.Context, observationCtx *observation.Context, ready servic
 
 	gitserver.RegisterMetrics(observationCtx, db)
 
-	handler := gitserver.Handler()
+	handler := internal.NewHTTPHandler(logger, fs)
 	handler = actor.HTTPMiddleware(logger, handler)
 	handler = requestclient.InternalHTTPMiddleware(handler)
 	handler = requestinteraction.HTTPMiddleware(handler)


### PR DESCRIPTION
gitserver: Move gitservice off of server struct

To simplify the server struct, the gitservice HTTP handler for upload pack requests is now standalone.

## Test plan

CI still passes after moving around the code.