### PR TITLE
gitserver: Remove double negation for ensure revision

### DIFF
--- a/cmd/frontend/backend/repos.go
+++ b/cmd/frontend/backend/repos.go
@@ -336,7 +336,7 @@ func (s *repos) ResolveRev(ctx context.Context, repo api.RepoName, rev string) (
 	ctx, done := startTrace(ctx, "ResolveRev", map[string]any{"repo": repo, "rev": rev}, &err)
 	defer done()
 
-	return s.gitserverClient.ResolveRevision(ctx, repo, rev, gitserver.ResolveRevisionOptions{})
+	return s.gitserverClient.ResolveRevision(ctx, repo, rev, gitserver.ResolveRevisionOptions{EnsureRevision: true})
 }
 
 // ErrRepoSeeOther indicates that the repo does not exist on this server but might exist on an external Sourcegraph

--- a/cmd/frontend/graphqlbackend/git_commit.go
+++ b/cmd/frontend/graphqlbackend/git_commit.go
@@ -94,7 +94,7 @@ func (r *GitCommitResolver) resolveCommit(ctx context.Context) (*gitdomain.Commi
 		r.commit, r.commitErr = r.gitserverClient.GetCommit(ctx, r.gitRepo, api.CommitID(r.oid))
 		if r.commitErr != nil && errors.HasType(r.commitErr, &gitdomain.RevisionNotFoundError{}) {
 			// If the commit is not found, attempt to do a ensure revision call.
-			_, err := r.gitserverClient.ResolveRevision(ctx, r.gitRepo, string(r.oid), gitserver.ResolveRevisionOptions{})
+			_, err := r.gitserverClient.ResolveRevision(ctx, r.gitRepo, string(r.oid), gitserver.ResolveRevisionOptions{EnsureRevision: true})
 			if err != nil {
 				r.logger.Error("failed to resolve commit", log.Error(err), log.String("oid", string(r.oid)))
 			} else {

--- a/cmd/frontend/graphqlbackend/git_commits.go
+++ b/cmd/frontend/graphqlbackend/git_commits.go
@@ -82,7 +82,7 @@ func (r *gitCommitConnectionResolver) compute(ctx context.Context) ([]*gitdomain
 			ctx,
 			r.repo.RepoName(),
 			r.revisionRange,
-			gitserver.ResolveRevisionOptions{NoEnsureRevision: false},
+			gitserver.ResolveRevisionOptions{EnsureRevision: true},
 		)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to resolve revision range")

--- a/cmd/frontend/graphqlbackend/git_revision.go
+++ b/cmd/frontend/graphqlbackend/git_revision.go
@@ -16,7 +16,7 @@ type gitRevSpecExpr struct {
 func (r *gitRevSpecExpr) Expr() string { return r.expr }
 
 func (r *gitRevSpecExpr) Object(ctx context.Context) (*gitObject, error) {
-	oid, err := r.repo.gitserverClient.ResolveRevision(ctx, r.repo.RepoName(), r.expr, gitserver.ResolveRevisionOptions{})
+	oid, err := r.repo.gitserverClient.ResolveRevision(ctx, r.repo.RepoName(), r.expr, gitserver.ResolveRevisionOptions{EnsureRevision: true})
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/graphqlbackend/repository.go
+++ b/cmd/frontend/graphqlbackend/repository.go
@@ -608,7 +608,7 @@ func (r *schemaResolver) ResolvePhabricatorDiff(ctx context.Context, args *struc
 		// will try and fetch it from the remote host. However, this is not on
 		// the remote host since we created it.
 		_, err = r.gitserverClient.ResolveRevision(ctx, repo.Name, targetRef, gitserver.ResolveRevisionOptions{
-			NoEnsureRevision: true,
+			EnsureRevision: false,
 		})
 		if err != nil {
 			return nil, err

--- a/cmd/frontend/graphqlbackend/repository_comparison.go
+++ b/cmd/frontend/graphqlbackend/repository_comparison.go
@@ -74,7 +74,7 @@ func NewRepositoryComparison(ctx context.Context, db database.DB, client gitserv
 		}
 
 		opt := gitserver.ResolveRevisionOptions{
-			NoEnsureRevision: !args.FetchMissing,
+			EnsureRevision: args.FetchMissing,
 		}
 
 		// Call ResolveRevision to trigger fetches from remote (in case base/head commits don't

--- a/cmd/frontend/graphqlbackend/repository_text_search_index.go
+++ b/cmd/frontend/graphqlbackend/repository_text_search_index.go
@@ -147,7 +147,7 @@ func (r *repositoryTextSearchIndexResolver) Refs(ctx context.Context) ([]*reposi
 	refByName := func(name string) *repositoryTextSearchIndexedRef {
 		possibleRefNames := []string{"refs/heads/" + name, "refs/tags/" + name}
 		for _, ref := range possibleRefNames {
-			if _, err := repoResolver.gitserverClient.ResolveRevision(ctx, repoResolver.RepoName(), ref, gitserver.ResolveRevisionOptions{NoEnsureRevision: true}); err == nil {
+			if _, err := repoResolver.gitserverClient.ResolveRevision(ctx, repoResolver.RepoName(), ref, gitserver.ResolveRevisionOptions{EnsureRevision: false}); err == nil {
 				name = ref
 				break
 			}

--- a/cmd/frontend/internal/httpapi/search.go
+++ b/cmd/frontend/internal/httpapi/search.go
@@ -249,7 +249,7 @@ func (h *searchIndexerServer) doSearchConfiguration(ctx context.Context, paramet
 			metricGetVersion.Inc()
 			// Do not to trigger a repo-updater lookup since this is a batch job.
 			commitID, err := h.gitserverClient.ResolveRevision(ctx, repo.Name, branch, gitserver.ResolveRevisionOptions{
-				NoEnsureRevision: true,
+				EnsureRevision: false,
 			})
 			if err != nil && errcode.HTTP(err) == http.StatusNotFound {
 				// GetIndexOptions wants an empty rev for a missing rev or empty

--- a/cmd/gitserver/internal/integration_tests/resolverevisions_test.go
+++ b/cmd/gitserver/internal/integration_tests/resolverevisions_test.go
@@ -129,7 +129,7 @@ func TestClient_ResolveRevision(t *testing.T) {
 			_, err := cli.RequestRepoUpdate(ctx, api.RepoName(remote))
 			require.NoError(t, err)
 
-			got, err := cli.ResolveRevision(ctx, api.RepoName(remote), test.input, gitserver.ResolveRevisionOptions{NoEnsureRevision: true})
+			got, err := cli.ResolveRevision(ctx, api.RepoName(remote), test.input, gitserver.ResolveRevisionOptions{EnsureRevision: false})
 			if test.err != nil {
 				require.Equal(t, test.err, err)
 				return

--- a/internal/batches/service/workspace_resolver.go
+++ b/internal/batches/service/workspace_resolver.go
@@ -297,7 +297,7 @@ func (wr *workspaceResolver) resolveRepositoryNameAndBranch(ctx context.Context,
 	}
 
 	commit, err := wr.gitserverClient.ResolveRevision(ctx, repo.Name, branch, gitserver.ResolveRevisionOptions{
-		NoEnsureRevision: true,
+		EnsureRevision: false,
 	})
 	if err != nil && errors.HasType(err, &gitdomain.RevisionNotFoundError{}) {
 		return nil, errors.Newf("no branch matching %q found for repository %s", branch, name)

--- a/internal/batches/state/state.go
+++ b/internal/batches/state/state.go
@@ -861,7 +861,7 @@ func computeRev(ctx context.Context, client gitserver.Client, repo api.RepoName,
 
 	// Resolve the revision to make sure it's on gitserver and, in case we did
 	// the fallback to ref, to get the specific revision.
-	gitRev, err := client.ResolveRevision(ctx, repo, rev, gitserver.ResolveRevisionOptions{})
+	gitRev, err := client.ResolveRevision(ctx, repo, rev, gitserver.ResolveRevisionOptions{EnsureRevision: true})
 	return string(gitRev), err
 }
 

--- a/internal/codeintel/autoindexing/internal/enqueuer/enqueuer.go
+++ b/internal/codeintel/autoindexing/internal/enqueuer/enqueuer.go
@@ -64,7 +64,7 @@ func (s *IndexEnqueuer) QueueIndexes(ctx context.Context, repositoryID int, rev,
 		return nil, err
 	}
 
-	commitID, err := s.gitserverClient.ResolveRevision(ctx, repo.Name, rev, gitserver.ResolveRevisionOptions{})
+	commitID, err := s.gitserverClient.ResolveRevision(ctx, repo.Name, rev, gitserver.ResolveRevisionOptions{EnsureRevision: true})
 	if err != nil {
 		return nil, errors.Wrap(err, "gitserver.ResolveRevision")
 	}
@@ -98,7 +98,7 @@ func (s *IndexEnqueuer) QueueIndexesForPackage(ctx context.Context, pkg dependen
 	}
 	repoID := int(repo.ID)
 
-	commit, err := s.gitserverClient.ResolveRevision(ctx, repoName, revision, gitserver.ResolveRevisionOptions{})
+	commit, err := s.gitserverClient.ResolveRevision(ctx, repoName, revision, gitserver.ResolveRevisionOptions{EnsureRevision: true})
 	if err != nil {
 		if errcode.IsNotFound(err) {
 			return nil

--- a/internal/codeintel/shared/resolvers/gitresolvers/cached_resolvers.go
+++ b/internal/codeintel/shared/resolvers/gitresolvers/cached_resolvers.go
@@ -58,7 +58,7 @@ func newCachedLocationResolver(
 	}
 
 	resolveCommit := func(ctx context.Context, repositoryResolver resolverstubs.RepositoryResolver, commit string) (resolverstubs.GitCommitResolver, error) {
-		commitID, err := gitserverClient.ResolveRevision(ctx, api.RepoName(repositoryResolver.Name()), commit, gitserver.ResolveRevisionOptions{NoEnsureRevision: true})
+		commitID, err := gitserverClient.ResolveRevision(ctx, api.RepoName(repositoryResolver.Name()), commit, gitserver.ResolveRevisionOptions{EnsureRevision: false})
 		if err != nil {
 			if errors.HasType(err, &gitdomain.RevisionNotFoundError{}) {
 				return nil, nil

--- a/internal/codeintel/uploads/internal/background/janitor/job_cleanup.go
+++ b/internal/codeintel/uploads/internal/background/janitor/job_cleanup.go
@@ -67,7 +67,7 @@ func NewUnknownCommitJanitor(
 }
 
 func shouldDeleteRecordsForCommit(ctx context.Context, gitserverClient gitserver.Client, repositoryName, commit string) (bool, error) {
-	if _, err := gitserverClient.ResolveRevision(ctx, api.RepoName(repositoryName), commit, gitserver.ResolveRevisionOptions{}); err != nil {
+	if _, err := gitserverClient.ResolveRevision(ctx, api.RepoName(repositoryName), commit, gitserver.ResolveRevisionOptions{EnsureRevision: true}); err != nil {
 		if gitdomain.IsRepoNotExist(err) {
 			// Repository not found; we'll delete these in a separate process
 			return false, nil

--- a/internal/codeintel/uploads/internal/background/processor/job_worker_handler.go
+++ b/internal/codeintel/uploads/internal/background/processor/job_worker_handler.go
@@ -340,7 +340,7 @@ const requeueDelay = time.Minute
 // valued flag. Otherwise, the repo does not exist or there is an unexpected infrastructure error, which we'll
 // fail on.
 func requeueIfCloningOrCommitUnknown(ctx context.Context, logger log.Logger, gitserverClient gitserver.Client, workerStore dbworkerstore.Store[uploadsshared.Upload], upload uploadsshared.Upload, repo *types.Repo) (requeued bool, _ error) {
-	_, err := gitserverClient.ResolveRevision(ctx, repo.Name, upload.Commit, gitserver.ResolveRevisionOptions{})
+	_, err := gitserverClient.ResolveRevision(ctx, repo.Name, upload.Commit, gitserver.ResolveRevisionOptions{EnsureRevision: true})
 	if err == nil {
 		// commit is resolvable
 		return false, nil

--- a/internal/codemonitors/search.go
+++ b/internal/codemonitors/search.go
@@ -114,7 +114,7 @@ func Snapshot(ctx context.Context, logger log.Logger, db database.DB, query stri
 				return ctx.Err()
 			}
 
-			res, err := gs.ResolveRevision(ctx, args.Repo, rev, gitserver.ResolveRevisionOptions{NoEnsureRevision: true})
+			res, err := gs.ResolveRevision(ctx, args.Repo, rev, gitserver.ResolveRevisionOptions{EnsureRevision: false})
 			// We don't want to fail the snapshot if a revision is not found. We log missing
 			// revisions when the job executes.
 			var revErr *gitdomain.RevisionNotFoundError
@@ -195,7 +195,7 @@ func hookWithID(
 			return ctx.Err()
 		}
 
-		res, err := gs.ResolveRevision(ctx, args.Repo, rev, gitserver.ResolveRevisionOptions{NoEnsureRevision: true})
+		res, err := gs.ResolveRevision(ctx, args.Repo, rev, gitserver.ResolveRevisionOptions{EnsureRevision: false})
 		// If the revision is not found, update the trigger job with the error message
 		// and continue. This can happen for empty repos.
 		var revErr *gitdomain.RevisionNotFoundError

--- a/internal/gitserver/commands.go
+++ b/internal/gitserver/commands.go
@@ -893,7 +893,8 @@ func (r *grpcBlameHunkReader) Close() error {
 // ResolveRevisionOptions configure how we resolve revisions.
 // The zero value should contain appropriate default values.
 type ResolveRevisionOptions struct {
-	NoEnsureRevision bool // do not try to fetch from remote if revision doesn't exist locally
+	// If set, try to fetch from remote if revision doesn't exist locally.
+	EnsureRevision bool
 }
 
 // ResolveRevision will return the absolute commit for a commit-ish spec. If spec is empty, HEAD is
@@ -910,7 +911,7 @@ func (c *clientImplementor) ResolveRevision(ctx context.Context, repo api.RepoNa
 		Attrs: []attribute.KeyValue{
 			repo.Attr(),
 			attribute.String("spec", spec),
-			attribute.Bool("noEnsureRevision", opt.NoEnsureRevision),
+			attribute.Bool("ensureRevision", opt.EnsureRevision),
 		},
 	})
 	defer endObservation(1, observation.Args{})
@@ -924,7 +925,7 @@ func (c *clientImplementor) ResolveRevision(ctx context.Context, repo api.RepoNa
 		RepoName: string(repo),
 		RevSpec:  []byte(spec),
 	}
-	if !opt.NoEnsureRevision {
+	if opt.EnsureRevision {
 		req.EnsureRevision = pointers.Ptr(true)
 	}
 	res, err := client.ResolveRevision(ctx, req)
@@ -1607,7 +1608,7 @@ func (c *clientImplementor) HasCommitAfter(ctx context.Context, repo api.RepoNam
 		revspec = "HEAD"
 	}
 
-	commitid, err := c.ResolveRevision(ctx, repo, revspec, ResolveRevisionOptions{NoEnsureRevision: true})
+	commitid, err := c.ResolveRevision(ctx, repo, revspec, ResolveRevisionOptions{EnsureRevision: false})
 	if err != nil {
 		return false, err
 	}

--- a/internal/own/background/analytics.go
+++ b/internal/own/background/analytics.go
@@ -66,7 +66,7 @@ func (r *analyticsIndexer) indexRepo(ctx context.Context, repoId api.RepoID, che
 		return errors.Wrap(err, "ls-files")
 	}
 	// Try to compute ownership stats
-	commitID, err := r.client.ResolveRevision(ctx, repo.Name, "HEAD", gitserver.ResolveRevisionOptions{NoEnsureRevision: true})
+	commitID, err := r.client.ResolveRevision(ctx, repo.Name, "HEAD", gitserver.ResolveRevisionOptions{EnsureRevision: false})
 	if err != nil {
 		return errcode.MakeNonRetryable(errors.Wrapf(err, "cannot resolve HEAD"))
 	}

--- a/internal/search/repos/repos.go
+++ b/internal/search/repos/repos.go
@@ -536,7 +536,7 @@ func (r *Resolver) normalizeRepoRefs(
 			revs = append(revs, rev.RevSpec)
 		case rev.RevSpec != "":
 			trimmedRev := strings.TrimPrefix(rev.RevSpec, "^")
-			_, err := r.gitserver.ResolveRevision(ctx, repo.Name, trimmedRev, gitserver.ResolveRevisionOptions{NoEnsureRevision: true})
+			_, err := r.gitserver.ResolveRevision(ctx, repo.Name, trimmedRev, gitserver.ResolveRevisionOptions{EnsureRevision: false})
 			if err != nil {
 				if errors.Is(err, context.DeadlineExceeded) || errors.HasType(err, &gitdomain.BadCommitError{}) {
 					return nil, err
@@ -777,7 +777,7 @@ func (r *Resolver) filterRepoHasFileContent(
 	{ // Use searcher for unindexed revs
 
 		checkHasMatches := func(ctx context.Context, arg query.RepoHasFileContentArgs, repo types.MinimalRepo, rev string) (bool, error) {
-			commitID, err := r.gitserver.ResolveRevision(ctx, repo.Name, rev, gitserver.ResolveRevisionOptions{NoEnsureRevision: true})
+			commitID, err := r.gitserver.ResolveRevision(ctx, repo.Name, rev, gitserver.ResolveRevisionOptions{EnsureRevision: false})
 			if err != nil {
 				if errors.Is(err, context.DeadlineExceeded) || errors.HasType(err, &gitdomain.BadCommitError{}) {
 					return false, err

--- a/internal/search/searcher/search.go
+++ b/internal/search/searcher/search.go
@@ -195,7 +195,7 @@ func (s *TextSearchJob) searchFilesInRepo(
 	// backend.{GitRepo,Repos.ResolveRev}) because that would slow this operation
 	// down by a lot (if we're looping over many repos). This means that it'll fail if a
 	// repo is not on gitserver.
-	commit, err := client.ResolveRevision(ctx, gitserverRepo, rev, gitserver.ResolveRevisionOptions{NoEnsureRevision: true})
+	commit, err := client.ResolveRevision(ctx, gitserverRepo, rev, gitserver.ResolveRevisionOptions{EnsureRevision: false})
 	if err != nil {
 		return false, err
 	}

--- a/internal/search/searcher/symbol_search_job.go
+++ b/internal/search/searcher/symbol_search_job.go
@@ -98,7 +98,7 @@ func searchInRepo(ctx context.Context, gitserverClient gitserver.Client, repoRev
 	// backend.{GitRepo,Repos.ResolveRev}) because that would slow this operation
 	// down by a lot (if we're looping over many repos). This means that it'll fail if a
 	// repo is not on gitserver.
-	commitID, err := gitserverClient.ResolveRevision(ctx, repoRevs.GitserverRepo(), inputRev, gitserver.ResolveRevisionOptions{NoEnsureRevision: true})
+	commitID, err := gitserverClient.ResolveRevision(ctx, repoRevs.GitserverRepo(), inputRev, gitserver.ResolveRevisionOptions{EnsureRevision: false})
 	if err != nil {
 		return nil, false, err
 	}


### PR DESCRIPTION
gitserver: Remove double negation for ensure revision

I _ALWAYS_ stumble over this double negation. "If not noensurerevision". huh?

Also, we should not encourage people to accidentally make the server do a resolve revision call which is generally costly, so the cheap option as the default seems more desirable.

For now, I haven't changed any of the values, but we should also do another review of the cases where we explicitly set it to true.

## Test plan

Just converted a bool, CI and E2E tests should catch any issues.