### PR TITLE
search: wrap structural search with repoPagerRob 

### DIFF
--- a/internal/search/job/jobutil/job.go
+++ b/internal/search/job/jobutil/job.go
@@ -408,12 +408,16 @@ func NewFlatJob(searchInputs *search.Inputs, f query.Flat) (job.Job, error) {
 				Features:        *searchInputs.Features,
 			}
 
-			addJob(&structural.SearchJob{
+			structuralSearchJob := &structural.SearchJob{
 				SearcherArgs:     searcherArgs,
 				UseIndex:         f.Index(),
 				ContainsRefGlobs: query.ContainsRefGlobs(f.ToBasic().ToParseTree()),
-				RepoOpts:         repoOptions,
 				BatchRetry:       searchInputs.Protocol == search.Batch,
+			}
+
+			addJob(&repoPagerJob{
+				child:    &reposPartialJob{structuralSearchJob},
+				repoOpts: repoOptions,
 			})
 		}
 

--- a/internal/search/job/jobutil/job.go
+++ b/internal/search/job/jobutil/job.go
@@ -409,15 +409,15 @@ func NewFlatJob(searchInputs *search.Inputs, f query.Flat) (job.Job, error) {
 			}
 
 			structuralSearchJob := &structural.SearchJob{
-				SearcherArgs:     searcherArgs,
-				UseIndex:         f.Index(),
-				ContainsRefGlobs: query.ContainsRefGlobs(f.ToBasic().ToParseTree()),
-				BatchRetry:       searchInputs.Protocol == search.Batch,
+				SearcherArgs: searcherArgs,
+				UseIndex:     f.Index(),
+				BatchRetry:   searchInputs.Protocol == search.Batch,
 			}
 
 			addJob(&repoPagerJob{
-				child:    &reposPartialJob{structuralSearchJob},
-				repoOpts: repoOptions,
+				child:            &reposPartialJob{structuralSearchJob},
+				repoOpts:         repoOptions,
+				containsRefGlobs: query.ContainsRefGlobs(f.ToBasic().ToParseTree()),
 			})
 		}
 

--- a/internal/search/job/jobutil/job_test.go
+++ b/internal/search/job/jobutil/job_test.go
@@ -1101,13 +1101,16 @@ func TestNewPlanJob(t *testing.T) {
         (limit . 10000)
         (PARALLEL
           REPOSCOMPUTEEXCLUDED
-          (STRUCTURALSEARCH
-            (useFullDeadline . true)
+          (REPOPAGER
             (containsRefGlobs . false)
-            (useIndex . yes)
-            (patternInfo.query . "(:[_])")
-            (patternInfo.isStructural . true)
-            (patternInfo.fileMatchLimit . 10000)))))))
+            (PARTIALREPOS
+              (STRUCTURALSEARCH
+                (useFullDeadline . true)
+                (containsRefGlobs . false)
+                (useIndex . yes)
+                (patternInfo.query . "(:[_])")
+                (patternInfo.isStructural . true)
+                (patternInfo.fileMatchLimit . 10000)))))))))
 `),
 		},
 		// The next query shows an unexpected way that a query is

--- a/internal/search/job/jobutil/job_test.go
+++ b/internal/search/job/jobutil/job_test.go
@@ -1106,7 +1106,6 @@ func TestNewPlanJob(t *testing.T) {
             (PARTIALREPOS
               (STRUCTURALSEARCH
                 (useFullDeadline . true)
-                (containsRefGlobs . false)
                 (useIndex . yes)
                 (patternInfo.query . "(:[_])")
                 (patternInfo.isStructural . true)

--- a/internal/search/job/jobutil/repo_pager_job.go
+++ b/internal/search/job/jobutil/repo_pager_job.go
@@ -11,6 +11,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/search/repos"
 	"github.com/sourcegraph/sourcegraph/internal/search/searcher"
 	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
+	"github.com/sourcegraph/sourcegraph/internal/search/structural"
 	"github.com/sourcegraph/sourcegraph/internal/search/zoekt"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 )
@@ -79,6 +80,11 @@ func setRepos(j job.Job, indexed *zoekt.IndexedRepoRevs, unindexed []*search.Rep
 		case *commit.SearchJob:
 			cp := *v
 			cp.Repos = unindexed
+			return &cp
+		case *structural.SearchJob:
+			cp := *v
+			cp.Unindexed = unindexed
+			cp.Indexed = indexed
 			return &cp
 		default:
 			return j

--- a/internal/search/structural/BUILD.bazel
+++ b/internal/search/structural/BUILD.bazel
@@ -10,7 +10,6 @@ go_library(
         "//internal/search",
         "//internal/search/job",
         "//internal/search/query",
-        "//internal/search/repos",
         "//internal/search/result",
         "//internal/search/searcher",
         "//internal/search/streaming",

--- a/internal/search/structural/structural.go
+++ b/internal/search/structural/structural.go
@@ -10,7 +10,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/search/job"
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
-	searchrepos "github.com/sourcegraph/sourcegraph/internal/search/repos"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
 	"github.com/sourcegraph/sourcegraph/internal/search/searcher"
 	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
@@ -163,45 +162,20 @@ type SearchJob struct {
 	ContainsRefGlobs bool
 	BatchRetry       bool
 
-	RepoOpts search.RepoOptions
+	Indexed   *zoektutil.IndexedRepoRevs
+	Unindexed []*search.RepositoryRevisions
 }
 
 func (s *SearchJob) Run(ctx context.Context, clients job.RuntimeClients, stream streaming.Sender) (alert *search.Alert, err error) {
 	_, ctx, stream, finish := job.StartSpan(ctx, stream, s)
 	defer func() { finish(alert, err) }()
 
-	repos := searchrepos.NewResolver(clients.Logger, clients.DB, clients.Gitserver, clients.SearcherURLs, clients.SearcherGRPCConnectionCache, clients.Zoekt)
-	it := repos.Iterator(ctx, s.RepoOpts)
-
-	for it.Next() {
-		page := it.Current()
-		page.MaybeSendStats(stream)
-
-		indexed, unindexed, err := zoektutil.PartitionRepos(
-			ctx,
-			clients.Logger,
-			page.RepoRevs,
-			clients.Zoekt,
-			search.TextRequest,
-			s.UseIndex,
-			s.ContainsRefGlobs,
-		)
-		if err != nil {
-			return nil, err
-		}
-
-		repoSet := []repoData{UnindexedList(unindexed)}
-		if indexed != nil {
-			repoRevsFromBranchRepos := indexed.GetRepoRevsFromBranchRepos()
-			repoSet = append(repoSet, IndexedMap(repoRevsFromBranchRepos))
-		}
-		err = runStructuralSearch(ctx, clients, s.SearcherArgs, s.BatchRetry, repoSet, stream)
-		if err != nil {
-			return nil, err
-		}
+	repoSet := []repoData{UnindexedList(s.Unindexed)}
+	if s.Indexed != nil {
+		repoRevsFromBranchRepos := s.Indexed.GetRepoRevsFromBranchRepos()
+		repoSet = append(repoSet, IndexedMap(repoRevsFromBranchRepos))
 	}
-
-	return nil, it.Err()
+	return nil, runStructuralSearch(ctx, clients, s.SearcherArgs, s.BatchRetry, repoSet, stream)
 }
 
 func (*SearchJob) Name() string {
@@ -219,7 +193,6 @@ func (s *SearchJob) Attributes(v job.Verbosity) (res []attribute.KeyValue) {
 		fallthrough
 	case job.VerbosityBasic:
 		res = append(res, trace.Scoped("patternInfo", s.SearcherArgs.PatternInfo.Fields()...)...)
-		res = append(res, trace.Scoped("repoOpts", s.RepoOpts.Attributes()...)...)
 	}
 	return res
 }

--- a/internal/search/structural/structural.go
+++ b/internal/search/structural/structural.go
@@ -157,10 +157,9 @@ func runStructuralSearch(ctx context.Context, clients job.RuntimeClients, args *
 }
 
 type SearchJob struct {
-	SearcherArgs     *search.SearcherParameters
-	UseIndex         query.YesNoOnly
-	ContainsRefGlobs bool
-	BatchRetry       bool
+	SearcherArgs *search.SearcherParameters
+	UseIndex     query.YesNoOnly
+	BatchRetry   bool
 
 	Indexed   *zoektutil.IndexedRepoRevs
 	Unindexed []*search.RepositoryRevisions
@@ -187,7 +186,6 @@ func (s *SearchJob) Attributes(v job.Verbosity) (res []attribute.KeyValue) {
 	case job.VerbosityMax:
 		res = append(res,
 			attribute.Bool("useFullDeadline", s.SearcherArgs.UseFullDeadline),
-			attribute.Bool("containsRefGlobs", s.ContainsRefGlobs),
 			attribute.String("useIndex", string(s.UseIndex)),
 		)
 		fallthrough


### PR DESCRIPTION
This is a refactor to use the repo pager for structural search. This will be useful to support
structural search in Search Jobs.

Test plan:
- updated unit test
- manual testing: I compared result counts for a cross-repo structural search query of this PR vs main