### PR TITLE
backport: remove patch version check

### DIFF
--- a/dev/sg/sg_backport.go
+++ b/dev/sg/sg_backport.go
@@ -7,7 +7,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/backport"
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/category"
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/std"
-	"github.com/sourcegraph/sourcegraph/lib/errors"
 	"github.com/sourcegraph/sourcegraph/lib/output"
 )
 
@@ -33,15 +32,11 @@ var backportCommand = &cli.Command{
 		prNumber := pullRequestIDFlag.Get(cmd)
 		releaseBranch := releaseBranchFlag.Get(cmd)
 
-		rb, err := semver.NewVersion(releaseBranch)
+		_, err := semver.NewVersion(releaseBranch)
 		if err != nil {
 			return err
 		}
 
-		// release branch is usually in the format <MAJOR>.<MINOR>
-		if rb.Patch() != 0 {
-			return errors.New("invalid release branch name")
-		}
 		std.Out.WriteLine(output.Styledf(output.StylePending, "Backporting commits from main to release branch %q for PR %d...", releaseBranch, prNumber))
 		return backport.Run(cmd, prNumber, releaseBranch)
 	},


### PR DESCRIPTION
Before the start of monthly releases, release branches were named in the semver format `<MAJOR>.<MINOR>`, however part of the changes that monthly releases bring, the release branch naming is now in the format `<MAJOR>.<MINOR>.<PATCH>`. 
This PR ensures the `sg backport` command works with this new logic.

## Test plan

Manual testing. Led to the creation of [this PR](https://github.com/sourcegraph/sourcegraph/pull/61682)