### PR TITLE
sg msp: add interactive version of 'sg msp init' and 'sg msp init-env'

### DIFF
--- a/dev/sg/internal/std/BUILD.bazel
+++ b/dev/sg/internal/std/BUILD.bazel
@@ -2,7 +2,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "std",
-    srcs = ["output.go"],
+    srcs = [
+        "output.go",
+        "prompt.go",
+    ],
     importpath = "github.com/sourcegraph/sourcegraph/dev/sg/internal/std",
     visibility = ["//dev/sg:__subpackages__"],
     deps = [

--- a/dev/sg/internal/std/prompt.go
+++ b/dev/sg/internal/std/prompt.go
@@ -1,0 +1,34 @@
+package std
+
+import (
+	"fmt"
+	"strings"
+)
+
+// PromptAndScan is a helper that renders the prompt into out and scans for
+// subsequent input up to a newline. The return value indicates if a value was
+// provided at all.
+//
+//	ok, err := std.PromptAndScan(std.Out, "Prompt:", &value)
+//	if err != nil {
+//		return err
+//	} else if !ok {
+//		return errors.New("response is required")
+//	}
+func PromptAndScan(out *Output, prompt string, result *string) (valueProvided bool, err error) {
+	out.Promptf(prompt)
+	n, err := fmt.Scanln(result)
+	if err != nil {
+		// Ignore newline error and treat it as "no input provided, no error".
+		// There is no exported error type for us to assert, so we have to check
+		// the error string.
+		if err.Error() == "unexpected newline" {
+			return false, nil
+		}
+		return false, err
+	}
+	if n == 0 || strings.TrimSpace(*result) == "" {
+		return false, nil
+	}
+	return true, nil
+}

--- a/dev/sg/msp/sg_msp.go
+++ b/dev/sg/msp/sg_msp.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strings"
 
@@ -87,10 +88,15 @@ sg msp init -owner core-services -name "MSP Example Service" msp-example
 			},
 			Before: msprepo.UseManagedServicesRepo,
 			Action: func(c *cli.Context) error {
-				if c.Args().Len() != 1 {
-					return errors.New("exactly 1 argument required: service ID")
+				if c.Args().Len() > 1 {
+					return errors.New("exactly 1 argument allowed: the desired service ID, or no arguments to use interactive setup")
 				}
 
+				// Track if no args were provided at all to guide interactive
+				// setup features
+				fullyInteractive := c.Args().Len() == 0
+
+				// Collect required inputs
 				template := example.Template{
 					ID:    c.Args().First(),
 					Name:  c.String("name"),
@@ -99,9 +105,62 @@ sg msp init -owner core-services -name "MSP Example Service" msp-example
 
 					ProjectIDSuffixLength: c.Int("project-id-suffix-length"),
 				}
+				if template.ID == "" {
+					std.Out.Write("Please provide an all-lowercase, dash-delimited, machine-friendly identifier for your new service, e.g. 'my-service'.")
+					ok, err := std.PromptAndScan(std.Out, "Service ID:", &template.ID)
+					if err != nil {
+						return err
+					} else if !ok {
+						return errors.New("response is required")
+					}
+				}
+				if allServices, err := msprepo.ListServices(); err != nil {
+					return errors.Wrap(err, "checking existing services")
+				} else if slices.Contains(allServices, template.ID) {
+					return errors.Newf("service with ID %q already exists", template.ID)
+				}
+				if template.Name == "" {
+					std.Out.Write("Please provide a human-readable name for your new service, e.g. 'My Service'.")
+					// optional, we can automatically generate one
+					if _, err := std.PromptAndScan(std.Out, "Service name (optional):", &template.Name); err != nil {
+						return err
+					}
+				}
+				if template.Owner == "" {
+					std.Out.Write("Please provide the name of the Opsgenie team that owns this new service - this MUST be an existing team listed in https://sourcegraph.app.opsgenie.com/teams/list")
+					ok, err := std.PromptAndScan(std.Out, "Service owner:", &template.Owner)
+					if err != nil {
+						return err
+					} else if !ok {
+						return errors.New("response is required")
+					}
+				}
+				if fullyInteractive && !c.IsSet("dev") { // ask only in interactive setup
+					std.Out.Write("We are going to scaffold an initial environment for your service - do you want to start with a 'dev' environment?")
+					std.Out.WriteSuggestionf("You can scaffold additional environments later using 'sg msp init-env %s'.", template.ID)
+					var dev string
+					ok, err := std.PromptAndScan(std.Out, "Start with a 'dev' environment (y/N):", &dev)
+					if err != nil {
+						return err
+					} else if !ok {
+						return errors.New("response is required")
+					}
+					template.Dev = strings.EqualFold(dev, "y")
+				}
+
+				var kind = c.String("kind")
+				if fullyInteractive && !c.IsSet("kind") { // ask only in interactive setup
+					std.Out.Write("MSP supports long-running services, or cron jobs.")
+					ok, err := std.PromptAndScan(std.Out, "Service kind (one of: 'service', 'job'):", &kind)
+					if err != nil {
+						return err
+					} else if !ok {
+						return errors.New("response is required")
+					}
+				}
 
 				var exampleSpec []byte
-				switch c.String("kind") {
+				switch kind {
 				case "service":
 					var err error
 					exampleSpec, err = example.NewService(template)
@@ -115,10 +174,10 @@ sg msp init -owner core-services -name "MSP Example Service" msp-example
 						return errors.Wrap(err, "example.NewJob")
 					}
 				default:
-					return errors.Newf("unsupported service kind: %q", c.String("kind"))
+					return errors.Newf("unsupported service kind: %q", kind)
 				}
 
-				outputPath := msprepo.ServiceYAMLPath(c.Args().First())
+				outputPath := msprepo.ServiceYAMLPath(template.ID)
 
 				_ = os.MkdirAll(filepath.Dir(outputPath), 0o755)
 				if err := os.WriteFile(outputPath, exampleSpec, 0o644); err != nil {
@@ -127,6 +186,10 @@ sg msp init -owner core-services -name "MSP Example Service" msp-example
 
 				std.Out.WriteSuccessf("Rendered %s template spec in %s",
 					c.String("kind"), outputPath)
+
+				std.Out.WriteSuggestionf("Take a look at the spec to see what you can change! "+
+					"When you are done, run 'sg msp generate -all %s' to render the required manifests and assets, and open a pull request for Core Services review.",
+					template.ID)
 				return nil
 			},
 		},
@@ -147,17 +210,26 @@ sg msp init -owner core-services -name "MSP Example Service" msp-example
 				return ss
 			}),
 			Action: func(c *cli.Context) error {
-				if c.Args().Len() != 2 {
-					return errors.Newf("exactly 2 arguments required, '<service ID>' and '<env ID>' - " +
-						" this command is for adding an environment to an existing service, did you mean to use 'sg msp init' instead?")
-				}
-				svc, err := useServiceArgument(c, false) // we're expecting a second argument
+				svc, err := useServiceArgument(c, false) // we're expecting a potential second argument
 				if err != nil {
-					return err
+					// A bad argument suggests a user misunderstanding of this
+					// command, so provide a hint with the error
+					return errors.Wrap(err,
+						"this command is for adding an environment to an existing service, did you mean to use 'sg msp init' instead?")
 				}
-				envID := c.Args().Get(1) // we already validate 2 arguments
+
+				envID := c.Args().Get(1)
+				if envID == "" {
+					std.Out.Write("Please provide an all-lowercase, dash-delimited, machine-friendly identifier for your new environment, e.g. 'dev' or 'prod'.")
+					ok, err := std.PromptAndScan(std.Out, "Environment ID:", &envID)
+					if err != nil {
+						return err
+					} else if !ok {
+						return errors.New("response is required")
+					}
+				}
 				if existing := svc.GetEnvironment(envID); existing != nil {
-					return errors.Newf("environment %q already exists", envID)
+					return errors.Newf("environment %q already exists for service %q", envID, svc.Service.ID)
 				}
 
 				envNode, err := example.NewEnvironment(example.EnvironmentTemplate{


### PR DESCRIPTION
As titled - we can now prompt you through service setup. This is a small QOL improvement that makes providing the required parameters a bit easier, as the setup flags experience has been a point of feedback from several MSP adopters.

As a follow-up, we can probably remove the flag-based setup entirely, as it should generally be a human-operator-only setup. Then we can expand the setup to include e.g. resource setup (postgres), and maybe an initial generate step as well.

## Test plan

![image](https://github.com/sourcegraph/sourcegraph/assets/23356519/62810f24-bcce-4c8d-8bed-2f6c762ab45a)
