### PR TITLE
Symbols: Remove unused ctags config

### DIFF
--- a/cmd/symbols/internal/api/handler.go
+++ b/cmd/symbols/internal/api/handler.go
@@ -19,7 +19,6 @@ import (
 type grpcService struct {
 	searchFunc   types.SearchFunc
 	readFileFunc func(context.Context, internaltypes.RepoCommitPath) ([]byte, error)
-	ctagsBinary  string
 	proto.UnimplementedSymbolsServiceServer
 	logger logger.Logger
 }
@@ -62,7 +61,6 @@ func NewHandler(
 	searchFunc types.SearchFunc,
 	readFileFunc func(context.Context, internaltypes.RepoCommitPath) ([]byte, error),
 	handleStatus func(http.ResponseWriter, *http.Request),
-	ctagsBinary string,
 ) http.Handler {
 	rootLogger := logger.Scoped("symbolsServer")
 
@@ -71,7 +69,6 @@ func NewHandler(
 	proto.RegisterSymbolsServiceServer(grpcServer, &grpcService{
 		searchFunc:   searchFunc,
 		readFileFunc: readFileFunc,
-		ctagsBinary:  ctagsBinary,
 		logger:       rootLogger.Scoped("grpc"),
 	})
 

--- a/cmd/symbols/internal/api/handler_test.go
+++ b/cmd/symbols/internal/api/handler_test.go
@@ -81,7 +81,7 @@ func TestHandler(t *testing.T) {
 	symbolParser := parser.NewParser(&observation.TestContext, parserPool, fetcher.NewRepositoryFetcher(&observation.TestContext, gitserverClient, 1000, 1_000_000), 0, 10)
 	databaseWriter := writer.NewDatabaseWriter(observation.TestContextTB(t), tmpDir, gitserverClient, symbolParser, semaphore.NewWeighted(1))
 	cachedDatabaseWriter := writer.NewCachedDatabaseWriter(databaseWriter, cache)
-	handler := NewHandler(MakeSqliteSearchFunc(observation.TestContextTB(t), cachedDatabaseWriter, dbmocks.NewMockDB()), func(ctx context.Context, rcp types.RepoCommitPath) ([]byte, error) { return nil, nil }, nil, "")
+	handler := NewHandler(MakeSqliteSearchFunc(observation.TestContextTB(t), cachedDatabaseWriter, dbmocks.NewMockDB()), func(ctx context.Context, rcp types.RepoCommitPath) ([]byte, error) { return nil, nil }, nil)
 
 	server := httptest.NewServer(handler)
 	defer server.Close()

--- a/cmd/symbols/shared/main.go
+++ b/cmd/symbols/shared/main.go
@@ -44,7 +44,7 @@ var (
 
 const addr = ":3184"
 
-type SetupFunc func(observationCtx *observation.Context, db database.DB, gitserverClient gitserver.GitserverClient, repositoryFetcher fetcher.RepositoryFetcher) (types.SearchFunc, func(http.ResponseWriter, *http.Request), []goroutine.BackgroundRoutine, string, error)
+type SetupFunc func(observationCtx *observation.Context, db database.DB, gitserverClient gitserver.GitserverClient, repositoryFetcher fetcher.RepositoryFetcher) (types.SearchFunc, func(http.ResponseWriter, *http.Request), []goroutine.BackgroundRoutine, error)
 
 func Main(ctx context.Context, observationCtx *observation.Context, ready service.ReadyFunc, setup SetupFunc) error {
 	logger := observationCtx.Logger
@@ -80,7 +80,7 @@ func Main(ctx context.Context, observationCtx *observation.Context, ready servic
 	// Run setup
 	gitserverClient := gitserver.NewClient(observationCtx, db)
 	repositoryFetcher := fetcher.NewRepositoryFetcher(observationCtx, gitserverClient, RepositoryFetcherConfig.MaxTotalPathsLength, int64(RepositoryFetcherConfig.MaxFileSizeKb)*1000)
-	searchFunc, handleStatus, newRoutines, ctagsBinary, err := setup(observationCtx, db, gitserverClient, repositoryFetcher)
+	searchFunc, handleStatus, newRoutines, err := setup(observationCtx, db, gitserverClient, repositoryFetcher)
 	if err != nil {
 		return errors.Wrap(err, "failed to set up")
 	}
@@ -94,7 +94,7 @@ func Main(ctx context.Context, observationCtx *observation.Context, ready servic
 		}
 		defer r.Close()
 		return io.ReadAll(r)
-	}, handleStatus, ctagsBinary)
+	}, handleStatus)
 
 	handler = handlePanic(logger, handler)
 	handler = trace.HTTPMiddleware(logger, handler, conf.DefaultClient())

--- a/cmd/symbols/shared/setup.go
+++ b/cmd/symbols/shared/setup.go
@@ -39,17 +39,17 @@ func CreateSetup(config rockskipConfig) SetupFunc {
 	repoToSize := map[string]int64{}
 
 	if useRockskip {
-		return func(observationCtx *observation.Context, db database.DB, gitserverClient symbolsGitserver.GitserverClient, repositoryFetcher fetcher.RepositoryFetcher) (types.SearchFunc, func(http.ResponseWriter, *http.Request), []goroutine.BackgroundRoutine, string, error) {
-			rockskipSearchFunc, rockskipHandleStatus, rockskipCtagsCommand, err := setupRockskip(observationCtx, config, gitserverClient, repositoryFetcher)
+		return func(observationCtx *observation.Context, db database.DB, gitserverClient symbolsGitserver.GitserverClient, repositoryFetcher fetcher.RepositoryFetcher) (types.SearchFunc, func(http.ResponseWriter, *http.Request), []goroutine.BackgroundRoutine, error) {
+			rockskipSearchFunc, rockskipHandleStatus, err := setupRockskip(observationCtx, config, gitserverClient, repositoryFetcher)
 			if err != nil {
-				return nil, nil, nil, "", err
+				return nil, nil, nil, err
 			}
 
 			// The blanks are the SQLite status endpoint (it's always nil) and the ctags command (same as
 			// Rockskip's).
-			sqliteSearchFunc, _, sqliteBackgroundRoutines, _, err := SetupSqlite(observationCtx, db, gitserverClient, repositoryFetcher)
+			sqliteSearchFunc, _, sqliteBackgroundRoutines, err := SetupSqlite(observationCtx, db, gitserverClient, repositoryFetcher)
 			if err != nil {
-				return nil, nil, nil, "", err
+				return nil, nil, nil, err
 			}
 
 			searchFunc := func(ctx context.Context, args search.SymbolsParameters) (results result.Symbols, err error) {
@@ -84,7 +84,7 @@ func CreateSetup(config rockskipConfig) SetupFunc {
 				return sqliteSearchFunc(ctx, args)
 			}
 
-			return searchFunc, rockskipHandleStatus, sqliteBackgroundRoutines, rockskipCtagsCommand, nil
+			return searchFunc, rockskipHandleStatus, sqliteBackgroundRoutines, nil
 		}
 	} else {
 		return SetupSqlite
@@ -122,7 +122,7 @@ func loadRockskipConfig(baseConfig env.BaseConfig, ctags types.CtagsConfig, repo
 	}
 }
 
-func setupRockskip(observationCtx *observation.Context, config rockskipConfig, gitserverClient symbolsGitserver.GitserverClient, repositoryFetcher fetcher.RepositoryFetcher) (types.SearchFunc, func(http.ResponseWriter, *http.Request), string, error) {
+func setupRockskip(observationCtx *observation.Context, config rockskipConfig, gitserverClient symbolsGitserver.GitserverClient, repositoryFetcher fetcher.RepositoryFetcher) (types.SearchFunc, func(http.ResponseWriter, *http.Request), error) {
 	observationCtx = observation.ContextWithLogger(observationCtx.Logger.Scoped("rockskip"), observationCtx)
 
 	codeintelDB := mustInitializeCodeIntelDB(observationCtx)
@@ -131,10 +131,10 @@ func setupRockskip(observationCtx *observation.Context, config rockskipConfig, g
 	}
 	server, err := rockskip.NewService(codeintelDB, gitserverClient, repositoryFetcher, createParser, config.MaxConcurrentlyIndexing, config.MaxRepos, config.LogQueries, config.IndexRequestsQueueSize, config.SymbolsCacheSize, config.PathSymbolsCacheSize, config.SearchLastIndexedCommit)
 	if err != nil {
-		return nil, nil, config.Ctags.UniversalCommand, err
+		return nil, nil, err
 	}
 
-	return server.Search, server.HandleStatus, config.Ctags.UniversalCommand, nil
+	return server.Search, server.HandleStatus, nil
 }
 
 func mustInitializeCodeIntelDB(observationCtx *observation.Context) *sql.DB {

--- a/cmd/symbols/shared/sqlite.go
+++ b/cmd/symbols/shared/sqlite.go
@@ -32,7 +32,7 @@ func LoadConfig() {
 
 var config types.SqliteConfig
 
-func SetupSqlite(observationCtx *observation.Context, db database.DB, gitserverClient gitserver.GitserverClient, repositoryFetcher fetcher.RepositoryFetcher) (types.SearchFunc, func(http.ResponseWriter, *http.Request), []goroutine.BackgroundRoutine, string, error) {
+func SetupSqlite(observationCtx *observation.Context, db database.DB, gitserverClient gitserver.GitserverClient, repositoryFetcher fetcher.RepositoryFetcher) (types.SearchFunc, func(http.ResponseWriter, *http.Request), []goroutine.BackgroundRoutine, error) {
 	logger := observationCtx.Logger.Scoped("sqlite.setup")
 
 	if err := baseConfig.Validate(); err != nil {
@@ -66,7 +66,7 @@ func SetupSqlite(observationCtx *observation.Context, db database.DB, gitserverC
 	cacheSizeBytes := int64(config.CacheSizeMB) * 1000 * 1000
 	cacheEvicter := janitor.NewCacheEvicter(evictionInterval, cache, cacheSizeBytes, janitor.NewMetrics(observationCtx))
 
-	return searchFunc, nil, []goroutine.BackgroundRoutine{cacheEvicter}, config.Ctags.UniversalCommand, nil
+	return searchFunc, nil, []goroutine.BackgroundRoutine{cacheEvicter}, nil
 }
 
 func parserTypesForDeployment() []ctags_config.ParserType {


### PR DESCRIPTION
This PR removes the unused `ctagsBinary` field from symbols server and its
set-up commands. The binary that's actually used is loaded through a separate
codepath.

## Test plan

Covered by current tests. Tested manually with both symbols and rockskip.