### PR TITLE
V2t src/search

### DIFF
--- a/client/branded/src/search-ui/results/sidebar/FilterLink.tsx
+++ b/client/branded/src/search-ui/results/sidebar/FilterLink.tsx
@@ -22,9 +22,9 @@ export interface FilterLinkProps {
     value: string
     count?: number
     limitHit?: boolean
-    kind?: string
+    kind?: Filter['kind']
     labelConverter?: (label: string) => JSX.Element
-    onFilterChosen: (value: string, kind?: string) => void
+    onFilterChosen: (value: string, kind?: Filter['kind']) => void
 }
 
 export const FilterLink: React.FunctionComponent<React.PropsWithChildren<FilterLinkProps>> = ({
@@ -67,7 +67,7 @@ export const FilterLink: React.FunctionComponent<React.PropsWithChildren<FilterL
 
 export const getRepoFilterLinks = (
     filters: Filter[] | undefined,
-    onFilterChosen: (value: string, kind?: string) => void
+    onFilterChosen: (value: string, kind?: Filter['kind']) => void
 ): React.ReactElement[] => {
     function repoLabelConverter(label: string): JSX.Element {
         const Icon = CodeHostIcon({
@@ -103,7 +103,7 @@ export const getRepoFilterLinks = (
 export const getDynamicFilterLinks = (
     filters: Filter[] | undefined,
     kinds: Filter['kind'][],
-    onFilterChosen: (value: string, kind?: string) => void,
+    onFilterChosen: (value: string, kind?: Filter['kind']) => void,
     ariaLabelTransform: (label: string, value: string) => string = label => `${label}`,
     labelTransform: (label: string, value: string) => string = label => `${label}`
 ): React.ReactElement[] =>

--- a/client/shared/src/search/searchQueryState.tsx
+++ b/client/shared/src/search/searchQueryState.tsx
@@ -3,6 +3,7 @@ import React, { createContext } from 'react'
 import type { StoreApi, UseBoundStore } from 'zustand'
 
 import type { SearchPatternType } from '../graphql-operations'
+import { TelemetryV2Props } from '../telemetry'
 
 import { type QueryState, type SubmitSearchParameters, toggleSubquery } from './helpers'
 import type { FilterType } from './query/filters'
@@ -84,7 +85,9 @@ export interface SearchQueryState {
      * Note that this won't update `queryState` directly.
      */
     submitSearch: (
-        parameters: Omit<SubmitSearchParameters, 'query' | 'caseSensitive' | 'patternType'> & { query?: string },
+        parameters: Omit<SubmitSearchParameters, 'query' | 'caseSensitive' | 'patternType'> & {
+            query?: string
+        } & TelemetryV2Props,
         updates?: QueryUpdate[]
     ) => void
 }

--- a/client/vscode/src/webview/sidebars/search/SearchSidebarView.tsx
+++ b/client/vscode/src/webview/sidebars/search/SearchSidebarView.tsx
@@ -148,7 +148,7 @@ export const SearchSidebarView: FC<SearchSidebarViewProps> = React.memo(function
     )
 
     const onDynamicFilterClicked = useCallback(
-        (value: string, kind?: string) => {
+        (value: string, kind?: Filter['kind']) => {
             platformContext.telemetryService.log('DynamicFilterClicked', { search_filter: { kind } })
             handleSidebarSearchSubmit([{ type: 'toggleSubquery', value }])
         },

--- a/client/vscode/src/webview/sidebars/search/SearchSidebarView.tsx
+++ b/client/vscode/src/webview/sidebars/search/SearchSidebarView.tsx
@@ -28,6 +28,7 @@ import { FilterType } from '@sourcegraph/shared/src/search/query/filters'
 import { type Filter, LATEST_VERSION } from '@sourcegraph/shared/src/search/stream'
 import { SectionID } from '@sourcegraph/shared/src/settings/temporary/searchSidebar'
 import { useTemporarySetting } from '@sourcegraph/shared/src/settings/temporary/useTemporarySetting'
+import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
 import { Code, useObservable } from '@sourcegraph/wildcard'
 
 import { SearchPatternType } from '../../../graphql-operations'
@@ -141,6 +142,7 @@ export const SearchSidebarView: FC<SearchSidebarViewProps> = React.memo(function
                     historyOrNavigate: navigate,
                     location,
                     source: 'filter',
+                    telemetryRecorder: noOpTelemetryRecorder,
                 },
                 updates
             ),

--- a/client/web/src/LegacyLayout.tsx
+++ b/client/web/src/LegacyLayout.tsx
@@ -244,6 +244,7 @@ export const LegacyLayout: FC<LegacyLayoutProps> = props => {
                             showFeedbackModal={showFeedbackModal}
                             selectedSearchContextSpec={props.selectedSearchContextSpec}
                             telemetryService={props.telemetryService}
+                            telemetryRecorder={props.platformContext.telemetryRecorder}
                         />
                     ) : (
                         <GlobalNavbar

--- a/client/web/src/communitySearchContexts/CommunitySearchContextPage.tsx
+++ b/client/web/src/communitySearchContexts/CommunitySearchContextPage.tsx
@@ -97,6 +97,7 @@ export const CommunitySearchContextPage: React.FunctionComponent<
                     patternType,
                     selectedSearchContextSpec,
                     source: 'communitySearchContextPage',
+                    telemetryRecorder,
                 })
             },
         [telemetryRecorder, caseSensitive, location, navigate, selectedSearchContextSpec]

--- a/client/web/src/nav/GlobalNavbar.tsx
+++ b/client/web/src/nav/GlobalNavbar.tsx
@@ -267,6 +267,7 @@ export const GlobalNavbar: React.FunctionComponent<React.PropsWithChildren<Globa
                         searchContextsEnabled={searchContextsEnabled}
                         isRepositoryRelatedPage={isRepositoryRelatedPage}
                         showKeywordSearchToggle={showKeywordSearchToggle}
+                        telemetryRecorder={props.platformContext.telemetryRecorder}
                     />
                 </div>
             )}

--- a/client/web/src/nav/new-global-navigation/NewGlobalNavigationBar.story.tsx
+++ b/client/web/src/nav/new-global-navigation/NewGlobalNavigationBar.story.tsx
@@ -1,5 +1,6 @@
 import type { Decorator, Meta, StoryFn } from '@storybook/react'
 
+import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { updateJSContextBatchChangesLicense } from '@sourcegraph/shared/src/testing/batches'
 
@@ -52,6 +53,7 @@ export const NewGlobalNavigationBarDemo: StoryFn = () => (
         }
         selectedSearchContextSpec=""
         telemetryService={NOOP_TELEMETRY_SERVICE}
+        telemetryRecorder={noOpTelemetryRecorder}
         showFeedbackModal={() => {}}
     />
 )

--- a/client/web/src/nav/new-global-navigation/NewGlobalNavigationBar.tsx
+++ b/client/web/src/nav/new-global-navigation/NewGlobalNavigationBar.tsx
@@ -10,6 +10,7 @@ import shallow from 'zustand/shallow'
 import { LegacyToggles } from '@sourcegraph/branded'
 import { Toggles } from '@sourcegraph/branded/src/search-ui/input/toggles/Toggles'
 import type { SearchQueryState, SubmitSearchParameters } from '@sourcegraph/shared/src/search'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { useIsLightTheme } from '@sourcegraph/shared/src/theme'
 import { Text, Icon, Button, Modal, Link, ProductStatusBadge, ButtonLink } from '@sourcegraph/wildcard'
@@ -30,7 +31,7 @@ import { UserNavItem } from '../UserNavItem'
 
 import styles from './NewGlobalNavigationBar.module.scss'
 
-interface NewGlobalNavigationBar extends TelemetryProps {
+interface NewGlobalNavigationBar extends TelemetryProps, TelemetryV2Props {
     authenticatedUser: AuthenticatedUser | null
     isSourcegraphDotCom: boolean
     notebooksEnabled: boolean
@@ -61,6 +62,7 @@ export const NewGlobalNavigationBar: FC<NewGlobalNavigationBar> = props => {
         showSearchBox,
         showFeedbackModal,
         telemetryService,
+        telemetryRecorder,
     } = props
 
     const isLightTheme = useIsLightTheme()
@@ -105,6 +107,7 @@ export const NewGlobalNavigationBar: FC<NewGlobalNavigationBar> = props => {
                         authenticatedUser={authenticatedUser}
                         selectedSearchContextSpec={selectedSearchContextSpec}
                         telemetryService={telemetryService}
+                        telemetryRecorder={telemetryRecorder}
                     />
                 ) : (
                     <InlineNavigationPanel
@@ -173,7 +176,7 @@ const selectQueryState = (state: SearchQueryState): NavigationSearchBoxState => 
     searchMode: state.searchMode,
 })
 
-interface NavigationSearchBoxProps extends TelemetryProps {
+interface NavigationSearchBoxProps extends TelemetryProps, TelemetryV2Props {
     authenticatedUser: AuthenticatedUser | null
     isSourcegraphDotCom: boolean
     selectedSearchContextSpec?: string
@@ -184,7 +187,8 @@ interface NavigationSearchBoxProps extends TelemetryProps {
  * search box gets focus.
  */
 const NavigationSearchBox: FC<NavigationSearchBoxProps> = props => {
-    const { authenticatedUser, isSourcegraphDotCom, selectedSearchContextSpec, telemetryService } = props
+    const { authenticatedUser, isSourcegraphDotCom, selectedSearchContextSpec, telemetryService, telemetryRecorder } =
+        props
 
     const navigate = useNavigate()
     const location = useLocation()
@@ -200,10 +204,11 @@ const NavigationSearchBox: FC<NavigationSearchBoxProps> = props => {
                 source: 'nav',
                 historyOrNavigate: navigate,
                 selectedSearchContextSpec,
+                telemetryRecorder: telemetryRecorder,
                 ...parameters,
             })
         },
-        [submitSearch, navigate, location, selectedSearchContextSpec]
+        [submitSearch, navigate, location, selectedSearchContextSpec, telemetryRecorder]
     )
 
     // TODO: Move this check outside of navigation component and share it via context
@@ -220,6 +225,7 @@ const NavigationSearchBox: FC<NavigationSearchBoxProps> = props => {
             authenticatedUser={authenticatedUser}
             selectedSearchContextSpec={selectedSearchContextSpec}
             telemetryService={telemetryService}
+            telemetryRecorder={telemetryRecorder}
             className={styles.searchBar}
             onChange={setQueryState}
             onSubmit={submitSearchOnChange}

--- a/client/web/src/nav/new-global-navigation/NewGlobalNavigationBar.tsx
+++ b/client/web/src/nav/new-global-navigation/NewGlobalNavigationBar.tsx
@@ -204,7 +204,7 @@ const NavigationSearchBox: FC<NavigationSearchBoxProps> = props => {
                 source: 'nav',
                 historyOrNavigate: navigate,
                 selectedSearchContextSpec,
-                telemetryRecorder: telemetryRecorder,
+                telemetryRecorder,
                 ...parameters,
             })
         },

--- a/client/web/src/routes.tsx
+++ b/client/web/src/routes.tsx
@@ -465,7 +465,7 @@ function SearchConsolePageOrRedirect(props: LegacyLayoutRouteContext): JSX.Eleme
 function SearchPageOrUpsellPage(props: LegacyLayoutRouteContext): JSX.Element {
     const { isCodeSearchEnabled } = props.licenseFeatures
     if (!isCodeSearchEnabled) {
-        return <SearchUpsellPage />
+        return <SearchUpsellPage telemetryRecorder={props.platformContext.telemetryRecorder} />
     }
     return <SearchPageWrapper {...props} />
 }

--- a/client/web/src/routes.tsx
+++ b/client/web/src/routes.tsx
@@ -251,7 +251,12 @@ export const routes: RouteObject[] = [
         path: PageRoutes.SearchConsole,
         element: (
             <LegacyRoute
-                render={props => <SearchConsolePageOrRedirect {...props} />}
+                render={props => (
+                    <SearchConsolePageOrRedirect
+                        {...props}
+                        telemetryRecorder={props.platformContext.telemetryRecorder}
+                    />
+                )}
                 condition={({ licenseFeatures }) => licenseFeatures.isCodeSearchEnabled}
             />
         ),

--- a/client/web/src/savedSearches/SavedSearchModal.tsx
+++ b/client/web/src/savedSearches/SavedSearchModal.tsx
@@ -4,13 +4,14 @@ import classNames from 'classnames'
 import type { NavigateFunction } from 'react-router-dom'
 
 import type { SearchPatternTypeProps } from '@sourcegraph/shared/src/search'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import { Button, Modal, Select, H3, Form } from '@sourcegraph/wildcard'
 
 import type { AuthenticatedUser } from '../auth'
 
 import styles from './SavedSearchModal.module.scss'
 
-interface Props extends SearchPatternTypeProps {
+interface Props extends SearchPatternTypeProps, TelemetryV2Props {
     authenticatedUser: Pick<AuthenticatedUser, 'organizations' | 'username'> | null
     query?: string
     onDidCancel: () => void
@@ -35,6 +36,7 @@ export class SavedSearchModal extends React.Component<Props, State> {
         this.state = {
             saveLocation: UserOrOrg.User,
         }
+        props.telemetryRecorder.recordEvent('search.resultsInfoBar.savedQueriesModal', 'view')
     }
 
     private onLocationChange = (event: React.ChangeEvent<HTMLSelectElement>): void => {

--- a/client/web/src/search/SearchConsolePage.tsx
+++ b/client/web/src/search/SearchConsolePage.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo } from 'react'
+import React, { useCallback, useEffect, useMemo } from 'react'
 
 import classNames from 'classnames'
 import { useLocation, useNavigate } from 'react-router-dom'
@@ -13,6 +13,7 @@ import {
 } from '@sourcegraph/branded'
 import { LATEST_VERSION } from '@sourcegraph/shared/src/search/stream'
 import { fetchStreamSuggestions } from '@sourcegraph/shared/src/search/suggestions'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import { LoadingSpinner, Button, useObservable } from '@sourcegraph/wildcard'
 
 import { PageTitle } from '../components/PageTitle'
@@ -26,7 +27,8 @@ import styles from './SearchConsolePage.module.scss'
 interface SearchConsolePageProps
     extends SearchStreamingProps,
         Omit<StreamingSearchResultsListProps, 'allExpanded' | 'executedQuery' | 'showSearchContext'>,
-        OwnConfigProps {
+        OwnConfigProps,
+        TelemetryV2Props {
     isMacPlatform: boolean
 }
 
@@ -89,6 +91,8 @@ export const SearchConsolePage: React.FunctionComponent<React.PropsWithChildren<
             [patternType, transformedQuery, streamSearch]
         )
     )
+
+    useEffect(() => props.telemetryRecorder.recordEvent('search.console', 'view'), [props.telemetryRecorder])
 
     return (
         <div className="w-100 p-2">

--- a/client/web/src/search/helpers.test.tsx
+++ b/client/web/src/search/helpers.test.tsx
@@ -1,6 +1,8 @@
 import * as H from 'history'
 import { describe, expect, test } from 'vitest'
 
+import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
+
 import { SearchPatternType } from '../graphql-operations'
 
 import { submitSearch } from './helpers'
@@ -17,6 +19,7 @@ describe('search/helpers', () => {
                 caseSensitive: false,
                 selectedSearchContextSpec: 'global',
                 source: 'home',
+                telemetryRecorder: noOpTelemetryRecorder,
             })
             expect(history.location.search).toMatchInlineSnapshot(
                 '"?q=context:global+querystring&patternType=standard&sm=0"'
@@ -32,6 +35,7 @@ describe('search/helpers', () => {
                 caseSensitive: false,
                 selectedSearchContextSpec: 'global',
                 source: 'home',
+                telemetryRecorder: noOpTelemetryRecorder,
             })
             expect(history.location.search).toMatchInlineSnapshot(
                 '"?q=context:global+querystring&patternType=standard&sm=0&trace=1"'

--- a/client/web/src/search/helpers.tsx
+++ b/client/web/src/search/helpers.tsx
@@ -2,10 +2,24 @@ import { FILTERS_URL_KEY } from '@sourcegraph/branded/src/search-ui/results/filt
 import { compatNavigate } from '@sourcegraph/common'
 import type { SubmitSearchParameters } from '@sourcegraph/shared/src/search'
 import { appendContextFilter } from '@sourcegraph/shared/src/search/query/transformer'
+import type { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import { EVENT_LOGGER } from '@sourcegraph/shared/src/telemetry/web/eventLogger'
 import { buildSearchURLQuery } from '@sourcegraph/shared/src/util/url'
 
 import { AGGREGATION_MODE_URL_KEY, AGGREGATION_UI_MODE_URL_KEY } from './results/components/aggregation/constants'
+
+const v2SearchSourceType: { [key in SubmitSearchParameters['source']]: number } = {
+    home: 1,
+    nav: 2,
+    repo: 3,
+    tree: 4,
+    filter: 5,
+    type: 6,
+    scopePage: 7,
+    communitySearchContextPage: 8,
+    excludedResults: 9,
+    smartSearchDisabled: 10,
+}
 
 /**
  * By default {@link submitSearch} overrides all existing query parameters.
@@ -47,7 +61,8 @@ export function submitSearch({
     selectedSearchContextSpec,
     searchMode,
     source,
-}: SubmitSearchParameters): void {
+    telemetryRecorder,
+}: SubmitSearchParameters & TelemetryV2Props): void {
     let searchQueryParameter = buildSearchURLQuery(
         query,
         patternType,
@@ -70,6 +85,7 @@ export function submitSearch({
         },
         { source, patternType }
     )
+    telemetryRecorder.recordEvent('search', 'submit', { metadata: { source: v2SearchSourceType[source] } })
 
     const state = {
         ...(typeof location.state === 'object' ? location.state : null),

--- a/client/web/src/search/input/SearchNavbarItem.tsx
+++ b/client/web/src/search/input/SearchNavbarItem.tsx
@@ -8,6 +8,7 @@ import { Toggles } from '@sourcegraph/branded/src/search-ui/input/toggles/Toggle
 import type { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
 import type { SearchContextInputProps, SubmitSearchParameters } from '@sourcegraph/shared/src/search'
 import type { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Form } from '@sourcegraph/wildcard'
 
@@ -23,6 +24,7 @@ interface Props
     extends SettingsCascadeProps,
         SearchContextInputProps,
         TelemetryProps,
+        TelemetryV2Props,
         PlatformContextProps<'requestGraphQL'> {
     authenticatedUser: AuthenticatedUser | null
     isSourcegraphDotCom: boolean
@@ -64,10 +66,11 @@ export const SearchNavbarItem: React.FunctionComponent<React.PropsWithChildren<P
                 location,
                 source: 'nav',
                 selectedSearchContextSpec: props.selectedSearchContextSpec,
+                telemetryRecorder: props.telemetryRecorder,
                 ...parameters,
             })
         },
-        [submitSearch, navigate, location, props.selectedSearchContextSpec]
+        [submitSearch, navigate, location, props.selectedSearchContextSpec, props.telemetryRecorder]
     )
     const submitSearchOnChangeRef = useRef(submitSearchOnChange)
     useEffect(() => {
@@ -89,6 +92,7 @@ export const SearchNavbarItem: React.FunctionComponent<React.PropsWithChildren<P
                 <LazyV2SearchInput
                     visualMode="compact"
                     telemetryService={props.telemetryService}
+                    telemetryRecorder={props.telemetryRecorder}
                     patternType={searchPatternType}
                     interpretComments={false}
                     queryState={queryState}

--- a/client/web/src/search/input/V2SearchInput.tsx
+++ b/client/web/src/search/input/V2SearchInput.tsx
@@ -23,6 +23,7 @@ import type { SearchContextProps, SubmitSearchParameters } from '@sourcegraph/sh
 import { FILTERS, FilterType } from '@sourcegraph/shared/src/search/query/filters'
 import { resolveFilterMemoized } from '@sourcegraph/shared/src/search/query/utils'
 import { useTemporarySetting } from '@sourcegraph/shared/src/settings/temporary'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 
 import { createSuggestionsSource, type SuggestionsSourceConfig } from './suggestions'
@@ -94,6 +95,7 @@ export interface V2SearchInputProps
     extends Omit<CodeMirrorQueryInputWrapperProps, 'suggestionSource' | 'extensions' | 'placeholder'>,
         Pick<SearchContextProps, 'selectedSearchContextSpec'>,
         TelemetryProps,
+        TelemetryV2Props,
         Pick<SuggestionsSourceConfig, 'authenticatedUser' | 'isSourcegraphDotCom'> {
     submitSearch(parameters: Partial<SubmitSearchParameters>): void
 }
@@ -111,6 +113,7 @@ export const V2SearchInput: FC<PropsWithChildren<V2SearchInputProps>> = ({
     visualMode,
     onFocus,
     onBlur,
+    telemetryRecorder,
     ...inputProps
 }) => {
     const { recentSearches } = useRecentSearches()
@@ -171,6 +174,17 @@ export const V2SearchInput: FC<PropsWithChildren<V2SearchInputProps>> = ({
                     type: option.kind,
                     source,
                 })
+                switch (action.type) {
+                    case 'command':
+                        telemetryRecorder.recordEvent('search.input.command', 'select')
+                        break
+                    case 'completion':
+                        telemetryRecorder.recordEvent('search.input.completion', 'select')
+                        break
+                    case 'goto':
+                        telemetryRecorder.recordEvent('search.input.goto', 'select')
+                        break
+                }
             }),
             Prec.low(
                 exampleSuggestions({
@@ -180,7 +194,7 @@ export const V2SearchInput: FC<PropsWithChildren<V2SearchInputProps>> = ({
                 })
             ),
         ],
-        [telemetryService, addExample]
+        [telemetryService, telemetryRecorder, addExample]
     )
 
     return (

--- a/client/web/src/search/input/V2SearchInput.tsx
+++ b/client/web/src/search/input/V2SearchInput.tsx
@@ -175,15 +175,18 @@ export const V2SearchInput: FC<PropsWithChildren<V2SearchInputProps>> = ({
                     source,
                 })
                 switch (action.type) {
-                    case 'command':
+                    case 'command': {
                         telemetryRecorder.recordEvent('search.input.command', 'select')
                         break
-                    case 'completion':
+                    }
+                    case 'completion': {
                         telemetryRecorder.recordEvent('search.input.completion', 'select')
                         break
-                    case 'goto':
+                    }
+                    case 'goto': {
                         telemetryRecorder.recordEvent('search.input.goto', 'select')
                         break
+                    }
                 }
             }),
             Prec.low(

--- a/client/web/src/search/results/SearchResultsCacheProvider.tsx
+++ b/client/web/src/search/results/SearchResultsCacheProvider.tsx
@@ -16,6 +16,7 @@ import { last, share, tap, throttleTime } from 'rxjs/operators'
 
 import { type URLQueryFilter, serializeURLQueryFilters, mergeQueryAndFilters } from '@sourcegraph/branded'
 import type { AggregateStreamingSearchResults, StreamSearchOptions } from '@sourcegraph/shared/src/search/stream'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryService } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { useObservable } from '@sourcegraph/wildcard'
 
@@ -34,7 +35,7 @@ interface CachedResults {
 
 const SearchResultsCacheContext = createContext<MutableRefObject<CachedResults | null>>(createRef())
 
-interface CachedSearchResultsInput {
+interface CachedSearchResultsInput extends TelemetryV2Props {
     /** Search query */
     query: string
 
@@ -64,7 +65,7 @@ interface CachedSearchResultsInput {
  * (updated as new streaming results come in).
  */
 export function useCachedSearchResults(props: CachedSearchResultsInput): AggregateStreamingSearchResults | undefined {
-    const { query, urlFilters: selectedFilters, options, streamSearch, telemetryService } = props
+    const { query, urlFilters: selectedFilters, options, streamSearch, telemetryService, telemetryRecorder } = props
     const cachedResults = useContext(SearchResultsCacheContext)
 
     const location = useLocation()
@@ -125,6 +126,9 @@ export function useCachedSearchResults(props: CachedSearchResultsInput): Aggrega
 
         if (navigationType === 'POP') {
             telemetryService.log('SearchResultsCacheRetrieved', { cacheHit: cacheExists }, { cacheHit: cacheExists })
+            telemetryRecorder.recordEvent('search.results.cache', 'retrieve', {
+                metadata: { cacheHit: cacheExists ? 1 : 0 },
+            })
         }
         // Only log on first render
         // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/client/web/src/search/results/StreamingSearchResults.story.tsx
+++ b/client/web/src/search/results/StreamingSearchResults.story.tsx
@@ -4,6 +4,7 @@ import { EMPTY, NEVER, of } from 'rxjs'
 
 import { SearchQueryStateStoreProvider } from '@sourcegraph/shared/src/search'
 import type { AggregateStreamingSearchResults } from '@sourcegraph/shared/src/search/stream'
+import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import {
     HIGHLIGHTED_FILE_LINES_LONG_REQUEST,
@@ -45,7 +46,12 @@ const defaultProps: StreamingSearchResultsProps = {
         subjects: null,
         final: null,
     },
-    platformContext: { settings: NEVER, requestGraphQL: () => EMPTY, sourcegraphURL: 'https://sourcegraph.com' } as any,
+    platformContext: {
+        settings: NEVER,
+        requestGraphQL: () => EMPTY,
+        sourcegraphURL: 'https://sourcegraph.com',
+        telemetryRecorder: noOpTelemetryRecorder,
+    } as any,
 
     streamSearch: () => of(streamingSearchResult),
 

--- a/client/web/src/search/results/StreamingSearchResults.test.tsx
+++ b/client/web/src/search/results/StreamingSearchResults.test.tsx
@@ -12,6 +12,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { GitRefType, SearchPatternType } from '@sourcegraph/shared/src/graphql-operations'
 import { SearchMode, SearchQueryStateStoreProvider } from '@sourcegraph/shared/src/search'
 import type { AggregateStreamingSearchResults, Skipped } from '@sourcegraph/shared/src/search/stream'
+import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
 import {
@@ -48,6 +49,7 @@ describe('StreamingSearchResults', () => {
             settings: NEVER,
             requestGraphQL: () => EMPTY,
             sourcegraphURL: 'https://sourcegraph.com',
+            telemetryRecorder: noOpTelemetryRecorder,
         } as any,
 
         streamSearch: () => of(MULTIPLE_SEARCH_RESULT),

--- a/client/web/src/search/results/StreamingSearchResults.tsx
+++ b/client/web/src/search/results/StreamingSearchResults.tsx
@@ -129,8 +129,11 @@ export const StreamingSearchResults: FC<StreamingSearchResultsProps> = props => 
 
     const onExpandAllResultsToggle = useCallback(() => {
         setAllExpanded(oldValue => !oldValue)
-        telemetryService.log(allExpanded ? 'allResultsExpanded' : 'allResultsCollapsed')
-        platformContext.telemetryRecorder.recordEvent('search.allResults', allExpanded ? 'expand' : 'collapse')
+        platformContext.telemetryRecorder.recordEvent(
+            'search.resultsInfoBar.allResults',
+            !allExpanded ? 'expand' : 'collapse'
+        )
+        telemetryService.log(!allExpanded ? 'allResultsExpanded' : 'allResultsCollapsed')
     }, [allExpanded, telemetryService, platformContext.telemetryRecorder])
 
     useEffect(() => {
@@ -168,7 +171,7 @@ export const StreamingSearchResults: FC<StreamingSearchResultsProps> = props => 
     const onSearchAgain = useCallback(
         (additionalFilters: string[]) => {
             telemetryService.log('SearchSkippedResultsAgainClicked')
-            platformContext.telemetryRecorder.recordEvent('search.skippedResultsSearchAgain', 'click')
+            platformContext.telemetryRecorder.recordEvent('search.resultsInfoBar.skippedResultsSearchAgain', 'click')
 
             const { selectedSearchContextSpec } = props
             submitSearch({

--- a/client/web/src/search/results/StreamingSearchResults.tsx
+++ b/client/web/src/search/results/StreamingSearchResults.tsx
@@ -232,7 +232,7 @@ export const StreamingSearchResults: FC<StreamingSearchResultsProps> = props => 
             source: 'smartSearchDisabled',
             telemetryRecorder: platformContext.telemetryRecorder,
         })
-    }, [caseSensitive, location, navigate, props, submittedURLQuery])
+    }, [caseSensitive, location, navigate, props, submittedURLQuery, platformContext.telemetryRecorder])
 
     const onTogglePatternType = useCallback(
         (patternType: SearchPatternType) => {

--- a/client/web/src/search/results/StreamingSearchResults.tsx
+++ b/client/web/src/search/results/StreamingSearchResults.tsx
@@ -103,6 +103,7 @@ export const StreamingSearchResults: FC<StreamingSearchResultsProps> = props => 
         options,
         streamSearch,
         telemetryService,
+        telemetryRecorder: platformContext.telemetryRecorder,
     })
 
     const { logSearchResultClicked } = useStreamingSearchPings({
@@ -110,6 +111,7 @@ export const StreamingSearchResults: FC<StreamingSearchResultsProps> = props => 
         isSourcegraphDotCom,
         results,
         isAuauthenticated: !!authenticatedUser,
+        telemetryRecorder: platformContext.telemetryRecorder,
     })
 
     useEffect(() => {
@@ -128,7 +130,8 @@ export const StreamingSearchResults: FC<StreamingSearchResultsProps> = props => 
     const onExpandAllResultsToggle = useCallback(() => {
         setAllExpanded(oldValue => !oldValue)
         telemetryService.log(allExpanded ? 'allResultsExpanded' : 'allResultsCollapsed')
-    }, [allExpanded, telemetryService])
+        platformContext.telemetryRecorder.recordEvent('search.allResults', allExpanded ? 'expand' : 'collapse')
+    }, [allExpanded, telemetryService, platformContext.telemetryRecorder])
 
     useEffect(() => {
         setAllExpanded(false) // Reset expanded state when new search is started
@@ -154,16 +157,18 @@ export const StreamingSearchResults: FC<StreamingSearchResultsProps> = props => 
                         ...location,
                         search: updatedSearchQuery || location.search,
                     },
+                    telemetryRecorder: platformContext.telemetryRecorder,
                 },
                 updates
             )
         },
-        [submitQuerySearch, props.selectedSearchContextSpec, navigate, location]
+        [submitQuerySearch, props.selectedSearchContextSpec, navigate, location, platformContext.telemetryRecorder]
     )
 
     const onSearchAgain = useCallback(
         (additionalFilters: string[]) => {
             telemetryService.log('SearchSkippedResultsAgainClicked')
+            platformContext.telemetryRecorder.recordEvent('search.skippedResultsSearchAgain', 'click')
 
             const { selectedSearchContextSpec } = props
             submitSearch({
@@ -174,9 +179,19 @@ export const StreamingSearchResults: FC<StreamingSearchResultsProps> = props => 
                 patternType,
                 query: applyAdditionalFilters(submittedURLQuery, additionalFilters),
                 source: 'excludedResults',
+                telemetryRecorder: platformContext.telemetryRecorder,
             })
         },
-        [telemetryService, props, navigate, location, caseSensitive, patternType, submittedURLQuery]
+        [
+            telemetryService,
+            props,
+            navigate,
+            location,
+            caseSensitive,
+            patternType,
+            submittedURLQuery,
+            platformContext.telemetryRecorder,
+        ]
     )
 
     /**
@@ -198,6 +213,7 @@ export const StreamingSearchResults: FC<StreamingSearchResultsProps> = props => 
             patternType,
             query,
             source: 'nav',
+            telemetryRecorder: platformContext.telemetryRecorder,
         })
     }
 
@@ -211,6 +227,7 @@ export const StreamingSearchResults: FC<StreamingSearchResultsProps> = props => 
             patternType: SearchPatternType.standard,
             query: submittedURLQuery,
             source: 'smartSearchDisabled',
+            telemetryRecorder: platformContext.telemetryRecorder,
         })
     }, [caseSensitive, location, navigate, props, submittedURLQuery])
 
@@ -229,6 +246,7 @@ export const StreamingSearchResults: FC<StreamingSearchResultsProps> = props => 
                 patternType: newPatternType,
                 query: submittedURLQuery,
                 source: 'nav',
+                telemetryRecorder: platformContext.telemetryRecorder,
             })
         },
         [caseSensitive, location, navigate, props, submittedURLQuery]

--- a/client/web/src/search/results/StreamingSearchResults.tsx
+++ b/client/web/src/search/results/StreamingSearchResults.tsx
@@ -252,7 +252,7 @@ export const StreamingSearchResults: FC<StreamingSearchResultsProps> = props => 
                 telemetryRecorder: platformContext.telemetryRecorder,
             })
         },
-        [caseSensitive, location, navigate, props, submittedURLQuery]
+        [caseSensitive, location, navigate, props, submittedURLQuery, platformContext.telemetryRecorder]
     )
 
     const hasResultsToAggregate = results?.state === 'complete' ? (results?.results.length ?? 0) > 0 : true

--- a/client/web/src/search/results/components/aggregation/SearchAggregationResult.story.tsx
+++ b/client/web/src/search/results/components/aggregation/SearchAggregationResult.story.tsx
@@ -3,6 +3,7 @@ import type { Meta, StoryFn } from '@storybook/react'
 import { noop } from 'lodash'
 
 import { getDocumentNode } from '@sourcegraph/http-client'
+import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
 import { BrandedStory } from '@sourcegraph/wildcard/src/stories'
@@ -147,6 +148,7 @@ export const SearchAggregationResultDemo: StoryFn = () => (
                     patternType={SearchPatternType.literal}
                     caseSensitive={false}
                     telemetryService={NOOP_TELEMETRY_SERVICE}
+                    telemetryRecorder={noOpTelemetryRecorder}
                     onQuerySubmit={noop}
                 />
             </MockedTestProvider>

--- a/client/web/src/search/results/components/aggregation/hooks.ts
+++ b/client/web/src/search/results/components/aggregation/hooks.ts
@@ -2,6 +2,7 @@ import { useLayoutEffect, useState } from 'react'
 
 import { gql, useQuery } from '@apollo/client'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryService } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { useSyncedWithURLState, type SetStateResult } from '@sourcegraph/wildcard'
 
@@ -15,6 +16,7 @@ import {
 
 import { AGGREGATION_MODE_URL_KEY, AGGREGATION_UI_MODE_URL_KEY } from './constants'
 import { GroupResultsPing } from './pings'
+import { V2SearchAggregationModeTypes } from './SearchAggregationResult'
 import { AggregationUIMode } from './types'
 
 type SerializedAggregationMode = 'repo' | 'path' | 'author' | 'group' | 'repo-metadata' | ''
@@ -176,7 +178,7 @@ export const AGGREGATION_SEARCH_QUERY = gql`
     }
 `
 
-interface SearchAggregationDataInput {
+interface SearchAggregationDataInput extends TelemetryV2Props {
     query: string
     patternType: SearchPatternType
     aggregationMode: SearchAggregationMode | null
@@ -207,6 +209,7 @@ export const useSearchAggregationData = (input: SearchAggregationDataInput): Sea
         extendedTimeout,
         proactive = false,
         telemetryService,
+        telemetryRecorder,
     } = input
 
     const [, setURLAggregationMode] = useAggregationSearchMode()
@@ -258,7 +261,7 @@ export const useSearchAggregationData = (input: SearchAggregationDataInput): Sea
                 // skip: true resets data field in the useQuery hook, in order to use previously
                 // saved data we use useState to store data outside useQuery hook
                 setState({ data, calculatedMode: calculatedAggregationMode })
-                sendAggregationPing({ data, extendedTimeout, proactive, telemetryService })
+                sendAggregationPing({ data, extendedTimeout, proactive, telemetryService, telemetryRecorder })
             },
         }
     )
@@ -302,7 +305,7 @@ export const isNonExhaustiveAggregationResults = (response?: GetSearchAggregatio
     return response.searchQueryAggregate?.aggregations?.__typename === 'NonExhaustiveSearchAggregationResult'
 }
 
-interface UseAggregationPingsArgs {
+interface UseAggregationPingsArgs extends TelemetryV2Props {
     data: GetSearchAggregationResult | undefined
     proactive: boolean
     extendedTimeout: boolean
@@ -310,7 +313,7 @@ interface UseAggregationPingsArgs {
 }
 
 function sendAggregationPing(props: UseAggregationPingsArgs): void {
-    const { data, proactive, extendedTimeout, telemetryService } = props
+    const { data, proactive, extendedTimeout, telemetryService, telemetryRecorder } = props
 
     const aggregation = data?.searchQueryAggregate.aggregations
 
@@ -332,6 +335,9 @@ function sendAggregationPing(props: UseAggregationPingsArgs): void {
                 { aggregationMode: mode },
                 { aggregationMode: mode }
             )
+            telemetryRecorder.recordEvent('search.group.results.proactiveLimit', 'hit', {
+                metadata: { aggregationMode: mode ? V2SearchAggregationModeTypes[mode] : 0 },
+            })
         }
 
         if (noExtensionAvailable) {
@@ -340,6 +346,9 @@ function sendAggregationPing(props: UseAggregationPingsArgs): void {
                 { aggregationMode: mode },
                 { aggregationMode: mode }
             )
+            telemetryRecorder.recordEvent('search.group.results.explicitLimit', 'hit', {
+                metadata: { aggregationMode: mode ? V2SearchAggregationModeTypes[mode] : 0 },
+            })
         }
     } else {
         const { mode } = aggregation
@@ -350,12 +359,18 @@ function sendAggregationPing(props: UseAggregationPingsArgs): void {
                 { aggregationMode: mode },
                 { aggregationMode: mode }
             )
+            telemetryRecorder.recordEvent('search.group.results.explicitLimit', 'success', {
+                metadata: { aggregationMode: mode ? V2SearchAggregationModeTypes[mode] : 0 },
+            })
         } else {
             telemetryService.log(
                 GroupResultsPing.ProactiveLimitSuccess,
                 { aggregationMode: mode },
                 { aggregationMode: mode }
             )
+            telemetryRecorder.recordEvent('search.group.results.proactiveLimit', 'success', {
+                metadata: { aggregationMode: mode ? V2SearchAggregationModeTypes[mode] : 0 },
+            })
         }
     }
 }

--- a/client/web/src/search/results/components/filters-panel/SearchFiltersPanel.tsx
+++ b/client/web/src/search/results/components/filters-panel/SearchFiltersPanel.tsx
@@ -39,16 +39,8 @@ export interface SearchFiltersPanelProps extends TelemetryProps, TelemetryV2Prop
  * as it is, use consumer agnostic NewSearchFilters component instead.
  */
 export const SearchFiltersPanel: FC<SearchFiltersPanelProps> = props => {
-    const {
-        query,
-        filters,
-        withCountAllFilter,
-        isFilterLoadingComplete,
-        className,
-        onQueryChange,
-        telemetryService,
-        telemetryRecorder,
-    } = props
+    const { query, filters, withCountAllFilter, isFilterLoadingComplete, className, onQueryChange, telemetryService } =
+        props
 
     const { isOpen, setFiltersPanel } = useSearchFiltersStore()
     const uiMode = useSearchFiltersPanelUIMode()

--- a/client/web/src/search/results/components/filters-panel/SearchFiltersPanel.tsx
+++ b/client/web/src/search/results/components/filters-panel/SearchFiltersPanel.tsx
@@ -5,6 +5,7 @@ import create from 'zustand'
 import { NewSearchFilters, useUrlFilters } from '@sourcegraph/branded'
 import { DeleteIcon } from '@sourcegraph/branded/src/search-ui/results/filters/components/Icons'
 import type { Filter } from '@sourcegraph/shared/src/search/stream'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Badge, Button, Icon, Modal, Panel, useWindowSize } from '@sourcegraph/wildcard'
 
@@ -20,7 +21,7 @@ export const useSearchFiltersStore = create<SearchFiltersStore>(set => ({
     setFiltersPanel: (open: boolean) => set({ isOpen: open }),
 }))
 
-export interface SearchFiltersPanelProps extends TelemetryProps {
+export interface SearchFiltersPanelProps extends TelemetryProps, TelemetryV2Props {
     query: string
     filters: Filter[] | undefined
     withCountAllFilter: boolean
@@ -38,8 +39,16 @@ export interface SearchFiltersPanelProps extends TelemetryProps {
  * as it is, use consumer agnostic NewSearchFilters component instead.
  */
 export const SearchFiltersPanel: FC<SearchFiltersPanelProps> = props => {
-    const { query, filters, withCountAllFilter, isFilterLoadingComplete, className, onQueryChange, telemetryService } =
-        props
+    const {
+        query,
+        filters,
+        withCountAllFilter,
+        isFilterLoadingComplete,
+        className,
+        onQueryChange,
+        telemetryService,
+        telemetryRecorder,
+    } = props
 
     const { isOpen, setFiltersPanel } = useSearchFiltersStore()
     const uiMode = useSearchFiltersPanelUIMode()

--- a/client/web/src/search/results/components/new-search-content/NewSearchContent.tsx
+++ b/client/web/src/search/results/components/new-search-content/NewSearchContent.tsx
@@ -401,7 +401,7 @@ const FilePreviewPanel: FC<FilePreviewPanelProps> = props => {
 
     useEffect(() => {
         telemetryService.logViewEvent('SearchFilePreview')
-        telemetryRecorder.recordEvent('search.filePreviePanel', 'view')
+        telemetryRecorder.recordEvent('search.filePreview', 'view')
     }, [telemetryService, telemetryRecorder])
 
     return (

--- a/client/web/src/search/results/components/new-search-content/NewSearchContent.tsx
+++ b/client/web/src/search/results/components/new-search-content/NewSearchContent.tsx
@@ -35,7 +35,7 @@ import {
     type StreamSearchOptions,
 } from '@sourcegraph/shared/src/search/stream'
 import type { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
-import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import { NOOP_TELEMETRY_SERVICE, type TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { lazyComponent } from '@sourcegraph/shared/src/util/lazyComponent'
 import { Button, H2, H4, Icon, Link, Panel, useLocalStorage, useScrollManager } from '@sourcegraph/wildcard'
@@ -135,6 +135,8 @@ export const NewSearchContent: FC<NewSearchContentProps> = props => {
         onLogSearchResultClick,
     } = props
 
+    const telemetryRecorder = platformContext.telemetryRecorder
+
     const submittedURLQueryRef = useRef(submittedURLQuery)
     const containerRef = useRef<HTMLDivElement>(null)
     const { previewBlob, clearPreview } = useSearchResultState()
@@ -177,7 +179,8 @@ export const NewSearchContent: FC<NewSearchContentProps> = props => {
     const handleFilterPanelClose = useCallback(() => {
         clearPreview()
         telemetryService.log('SearchFilePreviewClose', {}, {})
-    }, [telemetryService, clearPreview])
+        telemetryRecorder.recordEvent('search.filePreview', 'close')
+    }, [telemetryService, clearPreview, telemetryRecorder])
 
     return (
         <div className={classNames(styles.root, { [styles.rootWithNewFilters]: newFiltersEnabled })}>
@@ -190,6 +193,7 @@ export const NewSearchContent: FC<NewSearchContentProps> = props => {
                     className={styles.newFilters}
                     onQueryChange={handleFilterPanelQueryChange}
                     telemetryService={telemetryService}
+                    telemetryRecorder={telemetryRecorder}
                 />
             )}
 
@@ -205,6 +209,7 @@ export const NewSearchContent: FC<NewSearchContentProps> = props => {
                     aggregationUIMode={aggregationUIMode}
                     settingsCascade={settingsCascade}
                     telemetryService={telemetryService}
+                    telemetryRecorder={telemetryRecorder}
                     caseSensitive={caseSensitive}
                     className={classNames(styles.filters)}
                     setSidebarCollapsed={setSidebarCollapsed}
@@ -227,6 +232,7 @@ export const NewSearchContent: FC<NewSearchContentProps> = props => {
                 sourcegraphURL={platformContext.sourcegraphURL}
                 isSourcegraphDotCom={isSourcegraphDotCom}
                 telemetryService={telemetryService}
+                telemetryRecorder={telemetryRecorder}
                 className={styles.infobar}
                 onExpandAllResultsToggle={onExpandAllResultsToggle}
                 onShowMobileFiltersChanged={setSidebarCollapsed}
@@ -257,6 +263,7 @@ export const NewSearchContent: FC<NewSearchContentProps> = props => {
                         aria-label="Aggregation results panel"
                         onQuerySubmit={onQuerySubmit}
                         telemetryService={telemetryService}
+                        telemetryRecorder={telemetryRecorder}
                         className="m-3"
                     />
                 )}
@@ -265,6 +272,7 @@ export const NewSearchContent: FC<NewSearchContentProps> = props => {
                     <div className={styles.contentMetaInfo}>
                         <DidYouMean
                             telemetryService={props.telemetryService}
+                            telemetryRecorder={telemetryRecorder}
                             query={submittedURLQuery}
                             patternType={patternType}
                             caseSensitive={caseSensitive}
@@ -334,6 +342,7 @@ export const NewSearchContent: FC<NewSearchContentProps> = props => {
                 <FilePreviewPanel
                     blobInfo={previewBlob}
                     telemetryService={telemetryService}
+                    telemetryRecorder={telemetryRecorder}
                     onClose={handleFilterPanelClose}
                 />
             )}
@@ -375,13 +384,13 @@ const NewSearchSidebarWrapper: FC<PropsWithChildren<NewSearchSidebarWrapper>> = 
     )
 }
 
-interface FilePreviewPanelProps extends TelemetryProps {
+interface FilePreviewPanelProps extends TelemetryProps, TelemetryV2Props {
     blobInfo: SearchResultPreview
     onClose: () => void
 }
 
 const FilePreviewPanel: FC<FilePreviewPanelProps> = props => {
-    const { blobInfo, onClose, telemetryService } = props
+    const { blobInfo, onClose, telemetryService, telemetryRecorder } = props
 
     const staticHighlights = useMemo(() => {
         if (blobInfo.type === 'path') {
@@ -392,7 +401,8 @@ const FilePreviewPanel: FC<FilePreviewPanelProps> = props => {
 
     useEffect(() => {
         telemetryService.logViewEvent('SearchFilePreview')
-    }, [telemetryService])
+        telemetryRecorder.recordEvent('search.filePreviePanel', 'view')
+    }, [telemetryService, telemetryRecorder])
 
     return (
         <Panel
@@ -426,8 +436,7 @@ const FilePreviewPanel: FC<FilePreviewPanelProps> = props => {
                     navigateToLineOnAnyClick={false}
                     className={styles.previewContent}
                     telemetryService={NOOP_TELEMETRY_SERVICE}
-                    // TODO (dadlerj): update to use a real telemetry recorder
-                    telemetryRecorder={noOpTelemetryRecorder}
+                    telemetryRecorder={telemetryRecorder}
                     staticHighlightRanges={staticHighlights}
                 />
             </Suspense>

--- a/client/web/src/search/results/components/search-results-info-bar/SearchResultsInfoBar.test.tsx
+++ b/client/web/src/search/results/components/search-results-info-bar/SearchResultsInfoBar.test.tsx
@@ -1,6 +1,7 @@
 import { noop } from 'lodash'
 import { describe, expect, test } from 'vitest'
 
+import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
 import { renderWithBrandedContext } from '@sourcegraph/wildcard/src/testing'
@@ -23,6 +24,7 @@ const COMMON_PROPS: Omit<SearchResultsInfoBarProps, 'enableCodeMonitoring'> = {
     onExpandAllResultsToggle: noop,
     stats: <div />,
     telemetryService: NOOP_TELEMETRY_SERVICE,
+    telemetryRecorder: noOpTelemetryRecorder,
     patternType: SearchPatternType.standard,
     showKeywordSearchToggle: false,
     onTogglePatternType: noop,

--- a/client/web/src/search/results/components/search-results-info-bar/SearchResultsInfoBar.tsx
+++ b/client/web/src/search/results/components/search-results-info-bar/SearchResultsInfoBar.tsx
@@ -10,6 +10,7 @@ import type { CaseSensitivityProps, SearchPatternTypeProps } from '@sourcegraph/
 import { FilterKind, findFilter } from '@sourcegraph/shared/src/search/query/query'
 import type { AggregateStreamingSearchResults, StreamSearchOptions } from '@sourcegraph/shared/src/search/stream'
 import { useExperimentalFeatures } from '@sourcegraph/shared/src/settings/settings'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { EVENT_LOGGER } from '@sourcegraph/shared/src/telemetry/web/eventLogger'
 import {
@@ -59,6 +60,7 @@ const KEYWORD_SEARCH_POPOVER_PADDING = createRectangle(0, 0, 0, 2)
 
 export interface SearchResultsInfoBarProps
     extends TelemetryProps,
+        TelemetryV2Props,
         SearchPatternTypeProps,
         Pick<CaseSensitivityProps, 'caseSensitive'> {
     /** The currently authenticated user or null */
@@ -114,6 +116,7 @@ export const SearchResultsInfoBar: FC<SearchResultsInfoBarProps> = props => {
         sourcegraphURL,
         onTogglePatternType,
         telemetryService,
+        telemetryRecorder,
     } = props
 
     const popoverRef = useRef<HTMLDivElement>(null)
@@ -206,12 +209,14 @@ export const SearchResultsInfoBar: FC<SearchResultsInfoBarProps> = props => {
     const onSaveQueryModalClose = useCallback(() => {
         setShowSavedSearchModal(false)
         telemetryService.log('SavedQueriesToggleCreating', { queries: { creating: false } })
-    }, [telemetryService])
+        telemetryRecorder.recordEvent('search.resultsInfoBar.savedQueriesModal', 'close')
+    }, [telemetryService, telemetryRecorder])
 
     const handleKeywordSearchToggle = useCallback(() => {
         telemetryService.log('ToggleKeywordPatternType', { currentStatus: patternType === SearchPatternType.keyword })
+        telemetryRecorder.recordEvent('search.resultsInfoBar.toggleKeywordSearch', 'toggle')
         onTogglePatternType(patternType)
-    }, [onTogglePatternType, patternType, telemetryService])
+    }, [onTogglePatternType, patternType, telemetryService, telemetryRecorder])
 
     const [feedbackModalOpen, setFeedbackModalOpen] = useState(false)
 
@@ -440,6 +445,7 @@ export const SearchResultsInfoBar: FC<SearchResultsInfoBarProps> = props => {
                     results={results}
                     sourcegraphURL={sourcegraphURL}
                     telemetryService={telemetryService}
+                    telemetryRecorder={telemetryRecorder}
                     onClose={() => setShowCsvExportModal(false)}
                 />
             )}

--- a/client/web/src/search/results/components/search-results-info-bar/SearchResultsInfoBar.tsx
+++ b/client/web/src/search/results/components/search-results-info-bar/SearchResultsInfoBar.tsx
@@ -436,6 +436,7 @@ export const SearchResultsInfoBar: FC<SearchResultsInfoBarProps> = props => {
                     query={query}
                     authenticatedUser={authenticatedUser}
                     onDidCancel={onSaveQueryModalClose}
+                    telemetryRecorder={telemetryRecorder}
                 />
             )}
             {showCsvExportModal && (

--- a/client/web/src/search/results/export/SearchResultsCsvExportModal.tsx
+++ b/client/web/src/search/results/export/SearchResultsCsvExportModal.tsx
@@ -4,6 +4,7 @@ import { type ErrorLike, isErrorLike, logger } from '@sourcegraph/common'
 import type { PlatformContext } from '@sourcegraph/shared/src/platform/context'
 import { FilterKind, findFilter } from '@sourcegraph/shared/src/search/query/query'
 import type { AggregateStreamingSearchResults, StreamSearchOptions } from '@sourcegraph/shared/src/search/stream'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Alert, Button, Code, H3, Modal, Text } from '@sourcegraph/wildcard'
 
@@ -12,7 +13,10 @@ import { useFeatureFlag } from '../../../featureFlags/useFeatureFlag'
 
 import { downloadSearchResults, EXPORT_RESULT_DISPLAY_LIMIT } from './searchResultsExport'
 
-interface SearchResultsCsvExportModalProps extends Pick<PlatformContext, 'sourcegraphURL'>, TelemetryProps {
+interface SearchResultsCsvExportModalProps
+    extends Pick<PlatformContext, 'sourcegraphURL'>,
+        TelemetryProps,
+        TelemetryV2Props {
     query?: string
     options: StreamSearchOptions
     results?: AggregateStreamingSearchResults
@@ -28,6 +32,7 @@ export const SearchResultsCsvExportModal: React.FunctionComponent<SearchResultsC
     options,
     results,
     onClose,
+    telemetryRecorder,
 }) => {
     const searchCompleted = results?.state === 'complete' || results?.state === 'error' // Allow exporting results even if there was an error
 
@@ -53,6 +58,7 @@ export const SearchResultsCsvExportModal: React.FunctionComponent<SearchResultsC
 
         if (query.includes('select:file.owners')) {
             telemetryService.log('searchResults:ownershipCsv:exported')
+            telemetryRecorder.recordEvent('search.results.ownershipCSV', 'export')
         }
 
         setLoading(true)
@@ -63,7 +69,8 @@ export const SearchResultsCsvExportModal: React.FunctionComponent<SearchResultsC
             query,
             { ...options, enableRepositoryMetadata },
             results,
-            shouldRerunSearch
+            shouldRerunSearch,
+            telemetryRecorder
         )
             .then(() => {
                 onClose()

--- a/client/web/src/search/results/export/SearchResultsCsvExportModal.tsx
+++ b/client/web/src/search/results/export/SearchResultsCsvExportModal.tsx
@@ -95,6 +95,7 @@ export const SearchResultsCsvExportModal: React.FunctionComponent<SearchResultsC
         results,
         shouldRerunSearch,
         telemetryService,
+        telemetryRecorder,
         onClose,
     ])
 

--- a/client/web/src/search/results/export/searchResultsExport.ts
+++ b/client/web/src/search/results/export/searchResultsExport.ts
@@ -17,6 +17,7 @@ import {
     aggregateStreamingSearch,
     type AggregateStreamingSearchResults,
 } from '@sourcegraph/shared/src/search/stream'
+import { TelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
 import { EVENT_LOGGER } from '@sourcegraph/shared/src/telemetry/web/eventLogger'
 
 export const searchResultsToFileContent = (
@@ -238,7 +239,8 @@ export const downloadSearchResults = (
     query: string,
     options: StreamSearchOptions,
     results: AggregateStreamingSearchResults | undefined,
-    shouldRerunSearch: boolean
+    shouldRerunSearch: boolean,
+    telemetryRecorder: TelemetryRecorder
 ): Promise<void> => {
     const resultsObservable = shouldRerunSearch
         ? aggregateStreamingSearch(of(query), {
@@ -271,7 +273,9 @@ export const downloadSearchResults = (
         a.style.display = 'none'
         a.download = buildFileName(query)
         a.click()
+
         EVENT_LOGGER.log('SearchExportPerformed', { count: results.results.length }, { count: results.results.length })
+        telemetryRecorder.recordEvent('search.results', 'export', { metadata: { count: results.results.length } })
 
         // cleanup
         a.remove()

--- a/client/web/src/search/results/sidebar/SearchAggregations.tsx
+++ b/client/web/src/search/results/sidebar/SearchAggregations.tsx
@@ -2,6 +2,7 @@ import { type FC, useEffect, useState, memo } from 'react'
 
 import { mdiArrowExpand } from '@mdi/js'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Button, Icon } from '@sourcegraph/wildcard'
 
@@ -20,7 +21,7 @@ import {
 
 import styles from './SearchAggregations.module.scss'
 
-interface SearchAggregationsProps extends TelemetryProps {
+interface SearchAggregationsProps extends TelemetryProps, TelemetryV2Props {
     /**
      * Current submitted query, note that this query isn't a live query
      * that is synced with typed query in the search box, this query is submitted
@@ -45,7 +46,7 @@ interface SearchAggregationsProps extends TelemetryProps {
 }
 
 export const SearchAggregations: FC<SearchAggregationsProps> = memo(props => {
-    const { query, patternType, proactive, caseSensitive, telemetryService, onQuerySubmit } = props
+    const { query, patternType, proactive, caseSensitive, telemetryService, telemetryRecorder, onQuerySubmit } = props
 
     const [extendedTimeout, setExtendedTimeoutLocal] = useState(false)
 
@@ -59,6 +60,7 @@ export const SearchAggregations: FC<SearchAggregationsProps> = memo(props => {
         caseSensitive,
         extendedTimeout,
         telemetryService,
+        telemetryRecorder,
     })
 
     // When query is updated reset extendedTimeout as per business rules
@@ -78,6 +80,7 @@ export const SearchAggregations: FC<SearchAggregationsProps> = memo(props => {
             { aggregationMode, index, uiMode: 'sidebar' },
             { aggregationMode, index, uiMode: 'sidebar' }
         )
+        telemetryRecorder.recordEvent('search.group.results.chartBar', 'click')
     }
 
     const handleBarHover = (): void => {
@@ -86,11 +89,13 @@ export const SearchAggregations: FC<SearchAggregationsProps> = memo(props => {
             { aggregationMode, uiMode: 'sidebar' },
             { aggregationMode, uiMode: 'sidebar' }
         )
+        telemetryRecorder.recordEvent('search.group.results.chartBar', 'hover')
     }
 
     const handleExpandClick = (): void => {
         setAggregationUIMode(AggregationUIMode.SearchPage)
         telemetryService.log(GroupResultsPing.ExpandFullViewPanel, { aggregationMode }, { aggregationMode })
+        telemetryRecorder.recordEvent('search.group.results', 'openExpandedView')
     }
 
     const handleAggregationModeChange = (mode: SearchAggregationMode): void => {
@@ -100,6 +105,7 @@ export const SearchAggregations: FC<SearchAggregationsProps> = memo(props => {
             { aggregationMode: mode, uiMode: 'sidebar' },
             { aggregationMode: mode, uiMode: 'sidebar' }
         )
+        telemetryRecorder.recordEvent('search.group.aggregationMode', 'click')
     }
 
     const handleAggregationModeHover = (aggregationMode: SearchAggregationMode, available: boolean): void => {
@@ -109,6 +115,7 @@ export const SearchAggregations: FC<SearchAggregationsProps> = memo(props => {
                 { aggregationMode, uiMode: 'sidebar' },
                 { aggregationMode, uiMode: 'sidebar' }
             )
+            telemetryRecorder.recordEvent('search.group.aggregationMode', 'hover')
         }
     }
 

--- a/client/web/src/search/results/sidebar/SearchFiltersSidebar.story.tsx
+++ b/client/web/src/search/results/sidebar/SearchFiltersSidebar.story.tsx
@@ -3,6 +3,7 @@ import type { Meta, StoryFn } from '@storybook/react'
 import type { QuickLink, SearchScope } from '@sourcegraph/shared/src/schema/settings.schema'
 import type { Filter } from '@sourcegraph/shared/src/search/stream'
 import { EMPTY_SETTINGS_CASCADE } from '@sourcegraph/shared/src/settings/settings'
+import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
 
 import { WebStory } from '../../../components/WebStory'
@@ -33,6 +34,7 @@ const defaultProps: SearchFiltersSidebarProps = {
     selectedSearchContextSpec: 'global',
     settingsCascade: EMPTY_SETTINGS_CASCADE,
     telemetryService: NOOP_TELEMETRY_SERVICE,
+    telemetryRecorder: noOpTelemetryRecorder,
     setSidebarCollapsed: () => {},
 }
 

--- a/client/web/src/search/results/sidebar/SearchFiltersSidebar.tsx
+++ b/client/web/src/search/results/sidebar/SearchFiltersSidebar.tsx
@@ -29,6 +29,7 @@ import { FilterType } from '@sourcegraph/shared/src/search/query/filters'
 import type { Filter } from '@sourcegraph/shared/src/search/stream'
 import { type SettingsCascadeProps, useExperimentalFeatures } from '@sourcegraph/shared/src/settings/settings'
 import { SectionID } from '@sourcegraph/shared/src/settings/temporary/searchSidebar'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Code, Tooltip, Icon } from '@sourcegraph/wildcard'
 
@@ -43,7 +44,11 @@ interface GenericSidebarProps extends HTMLAttributes<HTMLElement> {
     onClose: () => void
 }
 
-export interface SearchFiltersSidebarProps extends TelemetryProps, SettingsCascadeProps, HTMLAttributes<HTMLElement> {
+export interface SearchFiltersSidebarProps
+    extends TelemetryProps,
+        SettingsCascadeProps,
+        HTMLAttributes<HTMLElement>,
+        TelemetryV2Props {
     as?: ComponentType<PropsWithChildren<GenericSidebarProps>>
     liveQuery: string
     submittedURLQuery: string
@@ -56,6 +61,17 @@ export interface SearchFiltersSidebarProps extends TelemetryProps, SettingsCasca
     onNavbarQueryChange: (queryState: QueryStateUpdate) => void
     onSearchSubmit: (updates: QueryUpdate[], updatedSearchQuery?: string) => void
     setSidebarCollapsed: (collapsed: boolean) => void
+}
+
+const V2KindTypes: { [key in Filter['kind']]: number } = {
+    file: 1,
+    repo: 2,
+    lang: 3,
+    utility: 4,
+    author: 5,
+    'commit date': 6,
+    'symbol type': 7,
+    type: 8,
 }
 
 export const SearchFiltersSidebar = forwardRef<HTMLElement, PropsWithChildren<SearchFiltersSidebarProps>>(props => {
@@ -73,6 +89,7 @@ export const SearchFiltersSidebar = forwardRef<HTMLElement, PropsWithChildren<Se
         onSearchSubmit,
         setSidebarCollapsed,
         telemetryService,
+        telemetryRecorder,
         settingsCascade,
         children,
         ...attributes
@@ -89,19 +106,23 @@ export const SearchFiltersSidebar = forwardRef<HTMLElement, PropsWithChildren<Se
     const repoName = useLastRepoName(liveQuery, repoFilters)
 
     const onDynamicFilterClicked = useCallback(
-        (value: string, kind?: string) => {
+        (value: string, kind?: Filter['kind']) => {
             telemetryService.log('DynamicFilterClicked', { search_filter: { kind } })
+            telemetryRecorder.recordEvent('search.dynamicFilter', 'click', {
+                metadata: { kind: kind ? V2KindTypes[kind] : 0 },
+            })
             onSearchSubmit([{ type: 'toggleSubquery', value }])
         },
-        [telemetryService, onSearchSubmit]
+        [telemetryService, onSearchSubmit, telemetryRecorder]
     )
 
     const onSnippetClicked = useCallback(
         (value: string) => {
             telemetryService.log('SearchSnippetClicked')
+            telemetryRecorder.recordEvent('search.snippet', 'click')
             onSearchSubmit([{ type: 'toggleSubquery', value }])
         },
-        [telemetryService, onSearchSubmit]
+        [telemetryService, onSearchSubmit, telemetryRecorder]
     )
 
     const handleAggregationBarLinkClick = useCallback(
@@ -114,8 +135,9 @@ export const SearchFiltersSidebar = forwardRef<HTMLElement, PropsWithChildren<Se
     const handleGroupedByToggle = useCallback(
         (open: boolean): void => {
             telemetryService.log(open ? GroupResultsPing.ExpandSidebarSection : GroupResultsPing.CollapseSidebarSection)
+            telemetryRecorder.recordEvent('search.group.results', open ? 'expand' : 'collapse')
         },
-        [telemetryService]
+        [telemetryService, telemetryRecorder]
     )
 
     return (
@@ -129,7 +151,12 @@ export const SearchFiltersSidebar = forwardRef<HTMLElement, PropsWithChildren<Se
                         <SearchSidebarSection
                             sectionId={SectionID.GROUPED_BY}
                             header="Group results by"
-                            postHeader={<CustomAggregationHeading telemetryService={props.telemetryService} />}
+                            postHeader={
+                                <CustomAggregationHeading
+                                    telemetryService={props.telemetryService}
+                                    telemetryRecorder={telemetryRecorder}
+                                />
+                            }
                             // SearchAggregations content contains component that makes a few API network requests
                             // in order to prevent these calls if this section is collapsed we turn off force render
                             // for collapse section component
@@ -142,6 +169,7 @@ export const SearchFiltersSidebar = forwardRef<HTMLElement, PropsWithChildren<Se
                                 proactive={proactiveSearchAggregations}
                                 caseSensitive={caseSensitive}
                                 telemetryService={telemetryService}
+                                telemetryRecorder={telemetryRecorder}
                                 onQuerySubmit={handleAggregationBarLinkClick}
                             />
                         </SearchSidebarSection>
@@ -218,13 +246,16 @@ const getRepoFilterNoResultText = (repoFilterLinks: ReactElement[]): ReactNode =
     </span>
 )
 
-const CustomAggregationHeading: FC<TelemetryProps> = ({ telemetryService }) => (
+const CustomAggregationHeading: FC<TelemetryProps & TelemetryV2Props> = ({ telemetryService, telemetryRecorder }) => (
     <Tooltip content="Aggregation is based on results with no count limitation (count:all).">
         <Icon
             aria-label="(Aggregation is based on results with no count limitation (count:all).)"
             size="md"
             svgPath={mdiInformationOutline}
-            onMouseEnter={() => telemetryService.log(GroupResultsPing.InfoIconHover)}
+            onMouseEnter={() => {
+                telemetryService.log(GroupResultsPing.InfoIconHover)
+                telemetryRecorder.recordEvent('search.group.results.infoIcon', 'hover')
+            }}
         />
     </Tooltip>
 )

--- a/client/web/src/search/results/useStreamingSearchPings.ts
+++ b/client/web/src/search/results/useStreamingSearchPings.ts
@@ -5,12 +5,13 @@ import { asError } from '@sourcegraph/common'
 import { collectMetrics } from '@sourcegraph/shared/src/search/query/metrics'
 import { sanitizeQueryForTelemetry } from '@sourcegraph/shared/src/search/query/transformer'
 import type { AggregateStreamingSearchResults } from '@sourcegraph/shared/src/search/stream'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 
 import { useNavbarQueryState } from '../../stores'
 import { smartSearchEvent } from '../suggestion/SmartSearch'
 
-interface useStreamingSearchPingsProps extends TelemetryProps {
+interface useStreamingSearchPingsProps extends TelemetryProps, TelemetryV2Props {
     isAuauthenticated: boolean
     isSourcegraphDotCom: boolean
     results: AggregateStreamingSearchResults | undefined
@@ -21,7 +22,7 @@ interface StreamingSearchPingsAPI {
 }
 
 export function useStreamingSearchPings(props: useStreamingSearchPingsProps): StreamingSearchPingsAPI {
-    const { isAuauthenticated, isSourcegraphDotCom, results, telemetryService } = props
+    const { isAuauthenticated, isSourcegraphDotCom, results, telemetryService, telemetryRecorder } = props
 
     const submittedURLQuery = useNavbarQueryState(state => state.searchQueryFromURL)
 
@@ -29,6 +30,7 @@ export function useStreamingSearchPings(props: useStreamingSearchPingsProps): St
     useEffect(
         () => {
             telemetryService.logViewEvent('SearchResults')
+            telemetryRecorder.recordEvent('search.results', 'view')
         },
         // Only log view on initial load
         // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -69,6 +71,7 @@ export function useStreamingSearchPings(props: useStreamingSearchPingsProps): St
                 },
             }
         )
+        telemetryRecorder.recordEvent('search.results', 'query')
         // Only log when the query changes
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [submittedURLQuery])
@@ -90,6 +93,15 @@ export function useStreamingSearchPings(props: useStreamingSearchPingsProps): St
                     },
                 },
             })
+            telemetryRecorder.recordEvent('search.results', 'fetch', {
+                metadata: {
+                    resultsCount: results.progress.matchCount,
+                    limitHit: limitHit(results.progress) ? 1 : 0,
+                    anyCloning: results.progress.skipped.some(skipped => skipped.reason === 'repository-cloning')
+                        ? 1
+                        : 0,
+                },
+            })
             if (results.results.length > 0) {
                 telemetryService.log('SearchResultsNonEmpty')
             }
@@ -97,8 +109,9 @@ export function useStreamingSearchPings(props: useStreamingSearchPingsProps): St
             telemetryService.log('SearchResultsFetchFailed', {
                 code_search: { error_message: asError(results.error).message },
             })
+            telemetryRecorder.recordEvent('search.results', 'fetchFailed')
         }
-    }, [results, submittedURLQuery, telemetryService])
+    }, [results, submittedURLQuery, telemetryService, telemetryRecorder])
 
     useEffect(() => {
         if (
@@ -127,8 +140,14 @@ export function useStreamingSearchPings(props: useStreamingSearchPingsProps): St
                 type,
                 resultsLength,
             })
+            telemetryRecorder.recordEvent('search.result', 'click', {
+                metadata: {
+                    index,
+                    resultsLength,
+                },
+            })
         },
-        [telemetryService]
+        [telemetryService, telemetryRecorder]
     )
 
     return { logSearchResultClicked }

--- a/client/web/src/search/results/useStreamingSearchPings.ts
+++ b/client/web/src/search/results/useStreamingSearchPings.ts
@@ -140,7 +140,7 @@ export function useStreamingSearchPings(props: useStreamingSearchPingsProps): St
                 type,
                 resultsLength,
             })
-            telemetryRecorder.recordEvent('search.result', 'click', {
+            telemetryRecorder.recordEvent('search.result.area', 'click', {
                 metadata: {
                     index,
                     resultsLength,

--- a/client/web/src/search/upsell/SearchUpsellPage.tsx
+++ b/client/web/src/search/upsell/SearchUpsellPage.tsx
@@ -1,7 +1,8 @@
-import type { FC } from 'react'
+import { useEffect, type FC } from 'react'
 
 import { mdiOpenInNew } from '@mdi/js'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import { useIsLightTheme } from '@sourcegraph/shared/src/theme'
 import { H2, Text, ButtonLink, Link, Icon } from '@sourcegraph/wildcard'
 
@@ -13,6 +14,8 @@ import { IntegrationsIcon } from './IntegrationsIcon'
 import { SearchExample } from './SearchExample'
 
 import styles from './SearchUpsellPage.module.scss'
+
+interface Props extends TelemetryV2Props {}
 
 interface SearchFeature {
     title: string
@@ -35,7 +38,9 @@ const searchFeatures: SearchFeature[] = [
     },
 ]
 
-export const SearchUpsellPage: FC = () => {
+export const SearchUpsellPage: FC<Props> = ({ telemetryRecorder }) => {
+    useEffect(() => telemetryRecorder.recordEvent('searchUpsell', 'view'), [telemetryRecorder])
+
     const isLightTheme = useIsLightTheme()
     const contactSalesLink = 'https://sourcegraph.com/contact/request-info'
     const findOutMoreLink = 'https://sourcegraph.com/code-search'

--- a/client/web/src/search/upsell/SearchUpsellPage.tsx
+++ b/client/web/src/search/upsell/SearchUpsellPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, type FC } from 'react'
+import { useEffect, type FC, useCallback } from 'react'
 
 import { mdiOpenInNew } from '@mdi/js'
 
@@ -40,6 +40,14 @@ const searchFeatures: SearchFeature[] = [
 
 export const SearchUpsellPage: FC<Props> = ({ telemetryRecorder }) => {
     useEffect(() => telemetryRecorder.recordEvent('searchUpsell', 'view'), [telemetryRecorder])
+    const onClickExpertCTA = useCallback(
+        () => telemetryRecorder.recordEvent('searchUpsell.talkToAnExpertCTA', 'click'),
+        [telemetryRecorder]
+    )
+    const onClickFindOutMoreCTA = useCallback(
+        () => telemetryRecorder.recordEvent('searchUpsell.findOutMoreCTA', 'click'),
+        [telemetryRecorder]
+    )
 
     const isLightTheme = useIsLightTheme()
     const contactSalesLink = 'https://sourcegraph.com/contact/request-info'
@@ -64,6 +72,7 @@ export const SearchUpsellPage: FC<Props> = ({ telemetryRecorder }) => {
                         className="py-2 px-3 rounded mr-4"
                         target="_blank"
                         rel="noreferrer"
+                        onClick={onClickExpertCTA}
                     >
                         Talk to a product expert
                     </ButtonLink>
@@ -74,6 +83,7 @@ export const SearchUpsellPage: FC<Props> = ({ telemetryRecorder }) => {
                         className="py-2 px-3 rounded"
                         target="_blank"
                         rel="noreferrer"
+                        onClick={onClickFindOutMoreCTA}
                     >
                         Find out more
                     </ButtonLink>

--- a/client/web/src/stores/navbarSearchQueryState.ts
+++ b/client/web/src/stores/navbarSearchQueryState.ts
@@ -61,6 +61,7 @@ export const useNavbarQueryState = create<NavbarQueryState>((set, get) => ({
                 caseSensitive,
                 patternType,
                 searchMode,
+                telemetryRecorder: parameters.telemetryRecorder,
             })
         }
     },

--- a/client/web/src/storm/pages/SearchPage/SearchPageInput.tsx
+++ b/client/web/src/storm/pages/SearchPage/SearchPageInput.tsx
@@ -94,6 +94,7 @@ export const SearchPageInput: FC<SearchPageInputProps> = props => {
                     // In the new query input, context is either omitted (-> global)
                     // or explicitly specified.
                     selectedSearchContextSpec: v2QueryInput ? undefined : selectedSearchContextSpec,
+                    telemetryRecorder: noOpTelemetryRecorder,
                     ...parameters,
                 })
             }
@@ -134,6 +135,7 @@ export const SearchPageInput: FC<SearchPageInputProps> = props => {
         <LazyV2SearchInput
             autoFocus={!isTouchOnlyDevice}
             telemetryService={telemetryService}
+            telemetryRecorder={noOpTelemetryRecorder}
             patternType={patternType}
             interpretComments={false}
             queryState={queryState}

--- a/client/web/src/storm/pages/SearchPage/SearchPageInput.tsx
+++ b/client/web/src/storm/pages/SearchPage/SearchPageInput.tsx
@@ -94,7 +94,7 @@ export const SearchPageInput: FC<SearchPageInputProps> = props => {
                     // In the new query input, context is either omitted (-> global)
                     // or explicitly specified.
                     selectedSearchContextSpec: v2QueryInput ? undefined : selectedSearchContextSpec,
-                    telemetryRecorder: noOpTelemetryRecorder,
+                    telemetryRecorder,
                     ...parameters,
                 })
             }
@@ -108,6 +108,7 @@ export const SearchPageInput: FC<SearchPageInputProps> = props => {
             caseSensitive,
             searchMode,
             v2QueryInput,
+            telemetryRecorder,
         ]
     )
     const submitSearchOnChangeRef = useRef(submitSearchOnChange)
@@ -135,7 +136,7 @@ export const SearchPageInput: FC<SearchPageInputProps> = props => {
         <LazyV2SearchInput
             autoFocus={!isTouchOnlyDevice}
             telemetryService={telemetryService}
-            telemetryRecorder={noOpTelemetryRecorder}
+            telemetryRecorder={telemetryRecorder}
             patternType={patternType}
             interpretComments={false}
             queryState={queryState}


### PR DESCRIPTION
Since this is a larger and more impactful one, I've tested it pretty thoroughly. I'm a bit confused about the dynamic filters (it seems like we have both new and old versions of these, some of which live in this directory, and some in /client/branded, making it hard to test everything) and search aggregations (which are also spread across multiple files). But overall I feel good.

Context:

* https://github.com/sourcegraph/sourcegraph/pull/60127
* https://github.com/sourcegraph/sourcegraph/pull/60192
* https://github.com/sourcegraph/sourcegraph/pull/60219
* https://github.com/sourcegraph/sourcegraph/pull/60343
* https://github.com/sourcegraph/sourcegraph/pull/60377
* https://github.com/sourcegraph/sourcegraph/pull/60382
* https://github.com/sourcegraph/sourcegraph/pull/60764
* https://github.com/sourcegraph/sourcegraph/pull/60765
* https://github.com/sourcegraph/sourcegraph/pull/60767
* https://github.com/sourcegraph/sourcegraph/pull/60768
* https://github.com/sourcegraph/sourcegraph/pull/60788
* https://github.com/sourcegraph/sourcegraph/pull/60789
* https://github.com/sourcegraph/sourcegraph/pull/60803
* https://github.com/sourcegraph/sourcegraph/pull/60812
* https://github.com/sourcegraph/sourcegraph/pull/60850
* https://github.com/sourcegraph/sourcegraph/pull/60851
* https://github.com/sourcegraph/sourcegraph/pull/60939
* https://github.com/sourcegraph/sourcegraph/pull/60971
* https://github.com/sourcegraph/sourcegraph/pull/61205
* https://github.com/sourcegraph/sourcegraph/pull/61457
* https://github.com/sourcegraph/sourcegraph/pull/61503
* https://github.com/sourcegraph/sourcegraph/pull/61504
* https://github.com/sourcegraph/sourcegraph/pull/61506
* https://github.com/sourcegraph/sourcegraph/pull/61507
* https://github.com/sourcegraph/sourcegraph/pull/61516

## Test plan

`sg start`
visit page
check if events appear in `event_logs` table locally