### PR TITLE
Allow start attribute on ordered lists in Markdown

### DIFF
--- a/internal/markdown/markdown.go
+++ b/internal/markdown/markdown.go
@@ -41,6 +41,7 @@ func Render(content string) (string, error) {
 		policy.AllowAttrs("srcset", "src", "type", "media", "width", "height", "sizes").OnElements("source")
 		policy.AllowAttrs("playsinline", "muted", "autoplay", "loop", "controls", "width", "height", "poster", "src").OnElements("video")
 		policy.AllowAttrs("src", "kind", "srclang", "default", "label").OnElements("track")
+		policy.AllowAttrs("start").OnElements("ol")
 		policy.AddTargetBlankToFullyQualifiedLinks(true)
 
 		html.LinkAttributeFilter.Add([]byte("aria-hidden"))


### PR DESCRIPTION
Closes: https://github.com/sourcegraph/sourcegraph/issues/61313

Allows the `start` attribute on `ol` elements. This will enable specifying a starting value for ordered lists in rendered markdown. e.g. `<ol start="2">`
## Test plan

Tested locally

Before:
![314762633-b77e4d96-b0bc-4700-bff3-e0757eee58f0](https://github.com/sourcegraph/sourcegraph/assets/69164745/7c6faf16-c4a4-4a8b-8239-6ee2aeca7c6e)

After:
![Screenshot 2024-04-08 at 4 16 29 PM](https://github.com/sourcegraph/sourcegraph/assets/69164745/f76ad54c-c4e2-48e5-801f-0495a1632e19)

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
