### PR TITLE
Adding an extra field for the tokenizer computed tokens for Anthropic API 

### DIFF
--- a/cmd/cody-gateway/internal/httpapi/completions/anthropic.go
+++ b/cmd/cody-gateway/internal/httpapi/completions/anthropic.go
@@ -176,13 +176,18 @@ func (a *AnthropicHandlerMethods) transformRequest(r *http.Request) {
 
 func (a *AnthropicHandlerMethods) parseResponseAndUsage(logger log.Logger, reqBody anthropicRequest, r io.Reader) (promptUsage, completionUsage usageStats) {
 	var err error
+
+	// Setting a default -1 value so that in case of errors the tokenizer computed tokens don't impact the data
+	completionUsage.tokenizerTokens = -1
+	promptUsage.tokenizerTokens = -1
+
 	// First, extract prompt usage details from the request.
 	promptUsage.characters = len(reqBody.Prompt)
 	promptUsage.tokens, err = reqBody.GetPromptTokenCount(a.anthropicTokenizer)
-	promptUsage.tokenizerTokens = promptUsage.tokens
 	if err != nil {
 		logger.Error("failed to count tokens in Anthropic response", log.Error(err))
 	}
+	promptUsage.tokenizerTokens = promptUsage.tokens
 
 	// Try to parse the request we saw, if it was non-streaming, we can simply parse
 	// it as JSON.

--- a/cmd/cody-gateway/internal/httpapi/completions/anthropic.go
+++ b/cmd/cody-gateway/internal/httpapi/completions/anthropic.go
@@ -179,6 +179,7 @@ func (a *AnthropicHandlerMethods) parseResponseAndUsage(logger log.Logger, reqBo
 	// First, extract prompt usage details from the request.
 	promptUsage.characters = len(reqBody.Prompt)
 	promptUsage.tokens, err = reqBody.GetPromptTokenCount(a.anthropicTokenizer)
+	promptUsage.tokenizerTokens = promptUsage.tokens
 	if err != nil {
 		logger.Error("failed to count tokens in Anthropic response", log.Error(err))
 	}
@@ -198,6 +199,7 @@ func (a *AnthropicHandlerMethods) parseResponseAndUsage(logger log.Logger, reqBo
 			logger.Error("failed to count tokens in Anthropic response", log.Error(err))
 		} else {
 			completionUsage.tokens = len(tokens)
+			completionUsage.tokenizerTokens = completionUsage.tokens
 		}
 		return promptUsage, completionUsage
 	}
@@ -234,5 +236,6 @@ func (a *AnthropicHandlerMethods) parseResponseAndUsage(logger log.Logger, reqBo
 	} else {
 		completionUsage.tokens = len(tokens)
 	}
+	completionUsage.tokenizerTokens = completionUsage.tokens
 	return promptUsage, completionUsage
 }

--- a/cmd/cody-gateway/internal/httpapi/completions/anthropicmessages.go
+++ b/cmd/cody-gateway/internal/httpapi/completions/anthropicmessages.go
@@ -255,7 +255,6 @@ func (a *AnthropicMessagesHandlerMethods) parseResponseAndUsage(logger log.Logge
 		if err == nil {
 			completionUsage.tokenizerTokens = len(completionUsageTokens)
 		}
-		completionUsage.tokenizerTokens = len(completionUsageTokens)
 		// Extract prompt usage data from the response
 		completionUsage.tokens = res.Usage.OutputTokens
 		promptUsage.tokens = res.Usage.InputTokens

--- a/cmd/cody-gateway/internal/httpapi/completions/anthropicmessages.go
+++ b/cmd/cody-gateway/internal/httpapi/completions/anthropicmessages.go
@@ -298,7 +298,6 @@ func (a *AnthropicMessagesHandlerMethods) parseResponseAndUsage(logger log.Logge
 		if err == nil {
 			completionUsage.tokenizerTokens = len(completionUsageTokens)
 		}
-		completionUsage.tokenizerTokens = len(completionUsageTokens)
 	}
 	if err := dec.Err(); err != nil {
 		logger.Error("failed to decode Anthropic streaming response", log.Error(err))

--- a/cmd/cody-gateway/internal/httpapi/completions/anthropicmessages.go
+++ b/cmd/cody-gateway/internal/httpapi/completions/anthropicmessages.go
@@ -227,7 +227,15 @@ func (a *AnthropicMessagesHandlerMethods) parseResponseAndUsage(logger log.Logge
 	for _, m := range body.Messages {
 		promptUsage.characters += len(m.Content)
 	}
-	promptUsage.characters = len(body.System)
+	// Setting a default -1 value so that in case of errors the tokenizer computed tokens don't impact the data
+	completionUsage.tokenizerTokens = -1
+	promptUsage.tokenizerTokens = -1
+
+	promptUsageTokens, err := a.tokenizer.Tokenize(body.BuildPrompt())
+	if err == nil {
+		promptUsage.tokenizerTokens = len(promptUsageTokens)
+	}
+	promptUsage.characters += len(body.System)
 
 	// Try to parse the request we saw, if it was non-streaming, we can simply parse
 	// it as JSON.
@@ -237,11 +245,17 @@ func (a *AnthropicMessagesHandlerMethods) parseResponseAndUsage(logger log.Logge
 			logger.Error("failed to parse Anthropic response as JSON", log.Error(err))
 			return promptUsage, completionUsage
 		}
-
+		var completionString string
 		// Extract character data from response by summing up all text
 		for _, c := range res.Content {
-			completionUsage.characters += len(c.Text)
+			completionString += c.Text
 		}
+		completionUsage.characters = len(completionString)
+		completionUsageTokens, err := a.tokenizer.Tokenize(completionString)
+		if err == nil {
+			completionUsage.tokenizerTokens = len(completionUsageTokens)
+		}
+		completionUsage.tokenizerTokens = len(completionUsageTokens)
 		// Extract prompt usage data from the response
 		completionUsage.tokens = res.Usage.OutputTokens
 		promptUsage.tokens = res.Usage.InputTokens
@@ -265,7 +279,7 @@ func (a *AnthropicMessagesHandlerMethods) parseResponseAndUsage(logger log.Logge
 			logger.Error("failed to decode event payload", log.Error(err), log.String("body", string(data)))
 			continue
 		}
-
+		var completionString string
 		switch event.Type {
 		case "message_start":
 			if event.Message != nil && event.Message.Usage != nil {
@@ -273,13 +287,19 @@ func (a *AnthropicMessagesHandlerMethods) parseResponseAndUsage(logger log.Logge
 			}
 		case "content_block_delta":
 			if event.Delta != nil {
-				completionUsage.characters += len(event.Delta.Text)
+				completionString += event.Delta.Text
 			}
 		case "message_delta":
 			if event.Usage != nil {
 				completionUsage.tokens = event.Usage.OutputTokens
 			}
 		}
+		completionUsage.characters += len(completionString)
+		completionUsageTokens, err := a.tokenizer.Tokenize(completionString)
+		if err == nil {
+			completionUsage.tokenizerTokens = len(completionUsageTokens)
+		}
+		completionUsage.tokenizerTokens = len(completionUsageTokens)
 	}
 	if err := dec.Err(); err != nil {
 		logger.Error("failed to decode Anthropic streaming response", log.Error(err))

--- a/cmd/cody-gateway/internal/httpapi/completions/fireworks.go
+++ b/cmd/cody-gateway/internal/httpapi/completions/fireworks.go
@@ -178,7 +178,9 @@ func (f *FireworksHandlerMethods) parseResponseAndUsage(logger log.Logger, reqBo
 	// For now, just count character usage, and set token counts to
 	// -1 as sentinel values.
 	promptUsage.tokens = -1
+	promptUsage.tokenizerTokens = -1
 	completionUsage.tokens = -1
+	completionUsage.tokenizerTokens = -1
 
 	dec := fireworks.NewDecoder(r)
 	// Consume all the messages, but we only care about the last completion data.

--- a/cmd/cody-gateway/internal/httpapi/completions/openai.go
+++ b/cmd/cody-gateway/internal/httpapi/completions/openai.go
@@ -167,6 +167,9 @@ func (*OpenAIHandlerMethods) parseResponseAndUsage(logger log.Logger, body opena
 		promptUsage.characters += len(m.Content)
 	}
 
+	// Setting a default -1 value so that in case of errors the tokenizer computed tokens don't impact the data
+	promptUsage.tokenizerTokens = -1
+	completionUsage.tokenizerTokens = -1
 	// Try to parse the request we saw, if it was non-streaming, we can simply parse
 	// it as JSON.
 	if !body.Stream {

--- a/cmd/cody-gateway/internal/httpapi/completions/upstream.go
+++ b/cmd/cody-gateway/internal/httpapi/completions/upstream.go
@@ -37,6 +37,8 @@ type usageStats struct {
 	characters int
 	// tokens is the number of tokens consumed in the input or response.
 	tokens int
+	// tokenizerTokens is the number of tokens computed by the tokenizer.
+	tokenizerTokens int
 }
 
 // Hop-by-Hop headers that should not be copied when proxying upstream requests
@@ -326,10 +328,12 @@ func makeUpstreamHandler[ReqT UpstreamRequest](
 				requestMetadata = events.MergeMaps(requestMetadata, getFlaggingMetadata(flaggingResult, act))
 			}
 			usageData := map[string]any{
-				"prompt_character_count":     promptUsage.characters,
-				"prompt_token_count":         promptUsage.tokens,
-				"completion_character_count": completionUsage.characters,
-				"completion_token_count":     completionUsage.tokens,
+				"prompt_character_count":           promptUsage.characters,
+				"prompt_token_count":               promptUsage.tokens,
+				"prompt_tokenizer_token_count":     promptUsage.tokenizerTokens,
+				"completion_character_count":       completionUsage.characters,
+				"completion_token_count":           completionUsage.tokens,
+				"completion_tokenizer_token_count": completionUsage.tokenizerTokens,
 			}
 			for k, v := range usageData {
 				// Drop usage fields that are invalid/unimplemented. All


### PR DESCRIPTION
[Slack Thread
](https://sourcegraph.slack.com/archives/C05AGQYD528/p1712071741350299)

I am doing this so as to compute the average offset in the computed tokens with the usage report from messages api for how many tokens were used. 

The Bigquery query we can use to interpret this 

```
SELECT 
    name,
    JSON_EXTRACT(metadata, '$.model') AS model_name,
    JSON_EXTRACT(metadata, '$.completion_token_count') AS token_count,
    JSON_EXTRACT(metadata, '$.completion_character_count') AS character_count,
    -- Add more JSON_EXTRACT lines here for other fields you're interested in
FROM 
    telligentsourcegraph.cody_gateway.events
LIMIT 50;

```

Interpretting and computing this data for a few days can tell use the average offset which can help us understand if we can use the old tokenizer for abuse detection or do I need to implement a new one. 

<img width="1207" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/11155207/ffc7c477-609e-4cca-b1d3-1eee4ca56725">



## Test plan
Checking the Bigquery outputs

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
