### PR TITLE
symbols: remove unused channel parseRequests

### DIFF
--- a/cmd/symbols/parser/parser.go
+++ b/cmd/symbols/parser/parser.go
@@ -84,15 +84,12 @@ func (p *parser) Parse(ctx context.Context, args search.SymbolsParameters, paths
 	}()
 
 	var (
-		wg                          sync.WaitGroup                                         // concurrency control
-		parseRequests               = make(chan fetcher.ParseRequest, p.requestBufferSize) // buffered requests
-		symbolOrErrors              = make(chan SymbolOrError)                             // parsed responses
-		totalRequests, totalSymbols uint32                                                 // stats
+		wg                          sync.WaitGroup             // concurrency control
+		symbolOrErrors              = make(chan SymbolOrError) // parsed responses
+		totalRequests, totalSymbols uint32                     // stats
 	)
 
 	defer func() {
-		close(parseRequests)
-
 		go func() {
 			defer func() {
 				endObservation(1, observation.Args{Attrs: []attribute.KeyValue{


### PR DESCRIPTION
We can remove it since it is only ever created and then closed, never read or written to. It seems like at some point we moved to using parseRequestOrErrors and didn't remove parseRequests.

Test Plan: go test
