### PR TITLE
symbols: canceling ParseRequest does not spam logs

### DIFF
--- a/cmd/symbols/parser/BUILD.bazel
+++ b/cmd/symbols/parser/BUILD.bazel
@@ -1,3 +1,4 @@
+load("//dev:go_defs.bzl", "go_test")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
@@ -30,4 +31,11 @@ go_library(
         "@com_github_sourcegraph_log//std",
         "@io_opentelemetry_go_otel//attribute",
     ],
+)
+
+go_test(
+    name = "parser_test",
+    srcs = ["observability_test.go"],
+    embed = [":parser"],
+    deps = ["//internal/observation"],
 )

--- a/cmd/symbols/parser/observability.go
+++ b/cmd/symbols/parser/observability.go
@@ -1,12 +1,14 @@
 package parser
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/sourcegraph/sourcegraph/internal/metrics"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 type operations struct {
@@ -14,6 +16,7 @@ type operations struct {
 	parseQueueSize     prometheus.Gauge
 	parseQueueTimeouts prometheus.Counter
 	parseFailed        prometheus.Counter
+	parseCanceled      prometheus.Counter
 	parse              *observation.Operation
 	handleParseRequest *observation.Operation
 }
@@ -47,6 +50,13 @@ func newOperations(observationCtx *observation.Context) *operations {
 	})
 	observationCtx.Registerer.MustRegister(parseFailed)
 
+	parseCanceled := prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: "src",
+		Name:      "codeintel_symbols_parse_canceled_total",
+		Help:      "The total number of parse jobs that are canceled. Seperate to failed since we don't treat these as failed parses.",
+	})
+	observationCtx.Registerer.MustRegister(parseCanceled)
+
 	operationMetrics := metrics.NewREDMetrics(
 		observationCtx.Registerer,
 		"codeintel_symbols_parser",
@@ -55,12 +65,24 @@ func newOperations(observationCtx *observation.Context) *operations {
 		metrics.WithDurationBuckets([]float64{1, 5, 10, 60, 300, 1200}),
 	)
 
-	op := func(name string) *observation.Operation {
-		return observationCtx.Operation(observation.Op{
+	op := func(name string) observation.Op {
+		return observation.Op{
 			Name:              fmt.Sprintf("codeintel.symbols.parser.%s", name),
 			MetricLabelValues: []string{name},
 			Metrics:           operationMetrics,
-		})
+		}
+	}
+
+	// HandleParseRequest we run concurrently and when we cancel the request
+	// they all logspam the error. But in the case of cancelation this is not
+	// useful signal, but rather higher level operations should log the
+	// cancelation.
+	handleParseRequestOp := op("HandleParseRequest")
+	handleParseRequestOp.ErrorFilter = func(err error) observation.ErrorFilterBehaviour {
+		if errors.Is(err, context.Canceled) {
+			return observation.EmitForAllExceptLogs
+		}
+		return observation.EmitForDefault
 	}
 
 	return &operations{
@@ -68,7 +90,8 @@ func newOperations(observationCtx *observation.Context) *operations {
 		parseQueueSize:     parseQueueSize,
 		parseQueueTimeouts: parseQueueTimeouts,
 		parseFailed:        parseFailed,
-		parse:              op("Parse"),
-		handleParseRequest: op("HandleParseRequest"),
+		parseCanceled:      parseCanceled,
+		parse:              observationCtx.Operation(op("Parse")),
+		handleParseRequest: observationCtx.Operation(handleParseRequestOp),
 	}
 }

--- a/cmd/symbols/parser/observability_test.go
+++ b/cmd/symbols/parser/observability_test.go
@@ -1,0 +1,13 @@
+package parser
+
+import (
+	"testing"
+
+	"github.com/sourcegraph/sourcegraph/internal/observation"
+)
+
+func TestNewOperation(t *testing.T) {
+	// tiny test that check for the side-effects of registering. EG if we have
+	// duplicate prometheus metrics.
+	_ = newOperations(observation.TestContextTB(t))
+}


### PR DESCRIPTION
We are seeing lots of log spam related to cancelation of parse requests. We haven't fully tracked this down yet, but the behaviour of spamming logs in this case hides the real issue.

This adjusts the implementation in two places:
- We introduce a parseCanceled metric so we can still track this. This is used instead of parseFailed in case of cancelation. In this case we also do not emit the "Closing failed parser" even though we are. This is due to log spam.
- We introduce an ErrorFilter just for handleParseRequest that will elide Canceled from the logs. This is called per file. Note: we keep the error logging for canceled in the high level Parse handler which runs across all files.

Test Plan: go test. Unfortunetly that is as good as it gets for now, as I investigate the root cause further I will test this code path (and only merge once I have manually triggered and tested this code path).