### PR TITLE
code-search: fix vertical alignment in search results list

### DIFF
--- a/client/web-sveltekit/src/routes/search/RepoRev.svelte
+++ b/client/web-sveltekit/src/routes/search/RepoRev.svelte
@@ -17,22 +17,31 @@
     }
 </script>
 
-<CodeHostIcon repository={repoName} />
-<!-- #key is needed here to recreate the link because use:highlightRanges changes the DOM -->
-{#key highlights}
-    <a class="repo-link" {href} use:highlightRanges={{ ranges: highlights }}>
-        {displayRepoName(repoName)}
-        {#if rev}
-            <small class="rev"> @ {rev}</small>
-        {/if}
-    </a>
-{/key}
+<div class="root">
+    <CodeHostIcon repository={repoName} />
+    <!-- #key is needed here to recreate the link because use:highlightRanges changes the DOM -->
+    {#key highlights}
+        <a class="repo-link" {href} use:highlightRanges={{ ranges: highlights }}>
+            {displayRepoName(repoName)}
+            {#if rev}
+                <small class="rev"> @ {rev}</small>
+            {/if}
+        </a>
+    {/key}
+</div>
 
 <style lang="scss">
-    .repo-link {
-        color: var(--text-body);
-        .rev {
-            color: var(--text-muted);
+    .root {
+        display: flex;
+        align-items: center;
+        gap: 0.375rem;
+
+        .repo-link {
+            align-self: baseline;
+            color: var(--text-body);
+            .rev {
+                color: var(--text-muted);
+            }
         }
     }
 </style>

--- a/client/web-sveltekit/src/routes/search/SearchResult.svelte
+++ b/client/web-sveltekit/src/routes/search/SearchResult.svelte
@@ -45,7 +45,7 @@
         overflow: hidden;
         display: flex;
         flex-wrap: wrap;
-        align-items: baseline;
+        align-items: center;
 
         // .title-inner
         overflow-wrap: anywhere;

--- a/client/web-sveltekit/src/routes/search/SearchResult.svelte
+++ b/client/web-sveltekit/src/routes/search/SearchResult.svelte
@@ -45,7 +45,7 @@
         overflow: hidden;
         display: flex;
         flex-wrap: wrap;
-        align-items: center;
+        align-items: baseline;
 
         // .title-inner
         overflow-wrap: anywhere;


### PR DESCRIPTION
[Context](https://sourcegraph.slack.com/archives/C05MHAP318B/p1712667167930699)

When viewing the search result page for files, the icon and path aren't properly aligned. This fixes that.

| Before  |
|---|
| ![CleanShot 2024-04-09 at 14 08 26@2x](https://github.com/sourcegraph/sourcegraph/assets/25608335/b37f45b3-88bb-4880-b825-6f3ebc74ab60)  |
| After  |
| ![CleanShot 2024-04-09 at 14 08 16@2x](https://github.com/sourcegraph/sourcegraph/assets/25608335/97caf7a6-de0d-4bc3-b6a0-adcc072f4c61)  |

## Test plan

Manual testing
