### PR TITLE
search jobs: add support for structural search

### DIFF
--- a/internal/search/exhaustive/service/searcher.go
+++ b/internal/search/exhaustive/service/searcher.go
@@ -2,7 +2,6 @@ package service
 
 import (
 	"context"
-	"strings"
 	"sync"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
@@ -31,10 +30,6 @@ func FromSearchClient(client client.SearchClient) NewSearcher {
 		// We run queries on searcher only which makes it easier to control limits. Low
 		// latency is not a priority of Search Jobs.
 		q = "index:no " + q
-
-		if strings.Contains(strings.ToLower(q), "patterntype:structural") {
-			return nil, errors.New("Structural search is not supported in Search Jobs")
-		}
 
 		inputs, err := client.Plan(
 			ctx,

--- a/internal/search/job/jobutil/exhaustive_job_test.go
+++ b/internal/search/job/jobutil/exhaustive_job_test.go
@@ -30,14 +30,16 @@ func TestNewExhaustive(t *testing.T) {
 	}
 
 	cases := []struct {
-		Name      string
-		Query     string
-		WantPager autogold.Value
-		WantJob   autogold.Value
+		Name       string
+		Query      string
+		WantPager  autogold.Value
+		WantJob    autogold.Value
+		SearchType query.SearchType
 	}{
 		{
-			Name:  "case sensitive lang match",
-			Query: `type:file index:no lang:cpp content case:yes`,
+			Name:       "case sensitive lang match",
+			Query:      `type:file index:no lang:cpp content case:yes`,
+			SearchType: query.SearchTypeLiteral,
 			WantPager: autogold.Expect(`
 (REPOPAGER
   (containsRefGlobs . false)
@@ -60,8 +62,9 @@ func TestNewExhaustive(t *testing.T) {
 `),
 		},
 		{
-			Name:  "glob",
-			Query: `type:file index:no repo:foo rev:*refs/heads/dev* content`,
+			Name:       "glob",
+			Query:      `type:file index:no repo:foo rev:*refs/heads/dev* content`,
+			SearchType: query.SearchTypeLiteral,
 			WantPager: autogold.Expect(`
 (REPOPAGER
   (containsRefGlobs . true)
@@ -85,8 +88,9 @@ func TestNewExhaustive(t *testing.T) {
 `),
 		},
 		{
-			Name:  "only pattern",
-			Query: "type:file index:no content",
+			Name:       "only pattern",
+			Query:      "type:file index:no content",
+			SearchType: query.SearchTypeLiteral,
 			WantPager: autogold.Expect(`
 (REPOPAGER
   (containsRefGlobs . false)
@@ -109,8 +113,9 @@ func TestNewExhaustive(t *testing.T) {
 `),
 		},
 		{
-			Name:  "keyword search",
-			Query: "type:file index:no foo bar baz patterntype:keyword",
+			Name:       "keyword search",
+			Query:      "type:file index:no foo bar baz patterntype:keyword",
+			SearchType: query.SearchTypeLiteral,
 			WantPager: autogold.Expect(`
 (REPOPAGER
   (containsRefGlobs . false)
@@ -133,8 +138,9 @@ func TestNewExhaustive(t *testing.T) {
 `),
 		},
 		{
-			Name:  "boolean query",
-			Query: "type:file index:no (foo OR bar) AND baz patterntype:keyword",
+			Name:       "boolean query",
+			Query:      "type:file index:no (foo OR bar) AND baz patterntype:keyword",
+			SearchType: query.SearchTypeLiteral,
 			WantPager: autogold.Expect(`
 (REPOPAGER
   (containsRefGlobs . false)
@@ -157,8 +163,9 @@ func TestNewExhaustive(t *testing.T) {
 `),
 		},
 		{
-			Name:  "regexp",
-			Query: "type:file index:no foo.*bar patterntype:regexp",
+			Name:       "regexp",
+			Query:      "type:file index:no foo.*bar patterntype:regexp",
+			SearchType: query.SearchTypeRegex,
 			WantPager: autogold.Expect(`
 (REPOPAGER
   (containsRefGlobs . false)
@@ -166,7 +173,7 @@ func TestNewExhaustive(t *testing.T) {
   (PARTIALREPOS
     (SEARCHERTEXTSEARCH
       (useFullDeadline . true)
-      (patternInfo . TextPatternInfo{"foo.*bar",nopath,filematchlimit:1000000})
+      (patternInfo . TextPatternInfo{/foo.*bar/,nopath,filematchlimit:1000000})
       (numRepos . 0)
       (pathRegexps . [])
       (indexed . false))))
@@ -174,15 +181,16 @@ func TestNewExhaustive(t *testing.T) {
 			WantJob: autogold.Expect(`
 (SEARCHERTEXTSEARCH
   (useFullDeadline . true)
-  (patternInfo . TextPatternInfo{"foo.*bar",nopath,filematchlimit:1000000})
+  (patternInfo . TextPatternInfo{/foo.*bar/,nopath,filematchlimit:1000000})
   (numRepos . 1)
   (pathRegexps . [])
   (indexed . false))
 `),
 		},
 		{
-			Name:  "repo:has.file predicate",
-			Query: "type:file index:no foo repo:has.file(go.mod)",
+			Name:       "repo:has.file predicate",
+			Query:      "type:file index:no foo repo:has.file(go.mod)",
+			SearchType: query.SearchTypeLiteral,
 			WantPager: autogold.Expect(`
 (REPOPAGER
   (containsRefGlobs . false)
@@ -206,8 +214,9 @@ func TestNewExhaustive(t *testing.T) {
 `),
 		},
 		{
-			Name:  "repo:has.meta predicate",
-			Query: "type:file index:no foo repo:has.meta(cognition)",
+			Name:       "repo:has.meta predicate",
+			Query:      "type:file index:no foo repo:has.meta(cognition)",
+			SearchType: query.SearchTypeLiteral,
 			WantPager: autogold.Expect(`
 (REPOPAGER
   (containsRefGlobs . false)
@@ -231,8 +240,9 @@ func TestNewExhaustive(t *testing.T) {
 `),
 		},
 		{
-			Name:  "type:diff author:alice",
-			Query: "index:no type:diff author:alice",
+			Name:       "type:diff author:alice",
+			Query:      "index:no type:diff author:alice",
+			SearchType: query.SearchTypeLiteral,
 			WantPager: autogold.Expect(`
 (REPOPAGER
   (containsRefGlobs . false)
@@ -254,8 +264,9 @@ func TestNewExhaustive(t *testing.T) {
 `),
 		},
 		{
-			Name:  "type:commit author:alice",
-			Query: "index:no type:commit author:alice",
+			Name:       "type:commit author:alice",
+			Query:      "index:no type:commit author:alice",
+			SearchType: query.SearchTypeLiteral,
 			WantPager: autogold.Expect(`
 (REPOPAGER
   (containsRefGlobs . false)
@@ -277,8 +288,9 @@ func TestNewExhaustive(t *testing.T) {
 `),
 		},
 		{
-			Name:  "type:path f:search.go",
-			Query: "index:no type:path f:search.go",
+			Name:       "type:path f:search.go",
+			Query:      "index:no type:path f:search.go",
+			SearchType: query.SearchTypeLiteral,
 			WantPager: autogold.Expect(`
 (REPOPAGER
   (containsRefGlobs . false)
@@ -300,19 +312,45 @@ func TestNewExhaustive(t *testing.T) {
   (indexed . false))
 `),
 		},
+		{
+			Name:       "patternType:structural if ... else ...",
+			Query:      "index:no patterntype:structural if ... else ...",
+			SearchType: query.SearchTypeStructural,
+			WantPager: autogold.Expect(`
+(REPOPAGER
+  (containsRefGlobs . false)
+  (repoOpts.useIndex . no)
+  (PARTIALREPOS
+    (STRUCTURALSEARCH
+      (useFullDeadline . true)
+      (useIndex . no)
+      (patternInfo.query . "if :[_] else :[_]")
+      (patternInfo.isStructural . true)
+      (patternInfo.fileMatchLimit . 1000000)
+      (patternInfo.index . no))))
+`),
+			WantJob: autogold.Expect(`
+(STRUCTURALSEARCH
+  (useFullDeadline . true)
+  (useIndex . no)
+  (patternInfo.query . "if :[_] else :[_]")
+  (patternInfo.isStructural . true)
+  (patternInfo.fileMatchLimit . 1000000)
+  (patternInfo.index . no))
+`),
+		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.Name, func(t *testing.T) {
-			searchType := query.SearchTypeLiteral
-			plan, err := query.Pipeline(query.Init(tc.Query, searchType))
+			plan, err := query.Pipeline(query.Init(tc.Query, tc.SearchType))
 			require.NoError(t, err)
 
 			inputs := &search.Inputs{
 				Plan:         plan,
 				Query:        plan.ToQ(),
 				UserSettings: &schema.Settings{},
-				PatternType:  searchType,
+				PatternType:  tc.SearchType,
 				Protocol:     search.Exhaustive,
 				Features:     &search.Features{},
 			}
@@ -335,40 +373,38 @@ func sPrintSexpMax(j job.Describer) string {
 // have to worry about valid queries we don't want to process for now.
 func TestNewExhaustive_negative(t *testing.T) {
 	tc := []struct {
-		query              string
-		isPatterntypeRegex bool
+		query      string
+		searchType query.SearchType
 	}{
 		// multiple jobs needed
-		{query: `type:file index:no (repo:repo1 or repo:repo2) content`},
+		{query: `type:file index:no (repo:repo1 or repo:repo2) content`, searchType: query.SearchTypeLiteral},
 		// catch-all regex
-		{query: `type:file index:no r:.* .*`, isPatterntypeRegex: true},
-		{query: `type:file index:no r:repo .*`, isPatterntypeRegex: true},
+		{query: `type:file index:no r:.* .*`, searchType: query.SearchTypeRegex},
+		{query: `type:file index:no r:repo .*`, searchType: query.SearchTypeRegex},
 		// file predicates
-		{query: `type:file index:no file:has.content(content)`},
-		{query: `type:file index:no file:has.owner(owner)`},
-		{query: `type:file index:no file:contains.content(content)`},
-		{query: `type:file index:no file:has.contributor(contributor)`},
+		{query: `type:file index:no file:has.content(content)`, searchType: query.SearchTypeLiteral},
+		{query: `type:file index:no file:has.owner(owner)`, searchType: query.SearchTypeLiteral},
+		{query: `type:file index:no file:contains.content(content)`, searchType: query.SearchTypeLiteral},
+		{query: `type:file index:no file:has.contributor(contributor)`, searchType: query.SearchTypeLiteral},
 		// unsupported types
-		{query: `index:no type:repo`},
-		{query: `index:no type:symbol`},
-		{query: `index:no foo select:file.owners`},
+		{query: `index:no type:repo`, searchType: query.SearchTypeLiteral},
+		{query: `index:no type:symbol`, searchType: query.SearchTypeLiteral},
+		{query: `index:no foo select:file.owners`, searchType: query.SearchTypeLiteral},
+		// structural search with AND/OR
+		{query: `index:no patterntype:structural if ... OR switch ... `, searchType: query.SearchTypeStructural},
+		{query: `index:no patterntype:structural if ... AND switch ... `, searchType: query.SearchTypeStructural},
 	}
 
 	for _, c := range tc {
 		t.Run("", func(t *testing.T) {
-			patternType := query.SearchTypeStandard
-			if c.isPatterntypeRegex {
-				patternType = query.SearchTypeRegex
-			}
-
-			plan, err := query.Pipeline(query.Init(c.query, patternType))
+			plan, err := query.Pipeline(query.Init(c.query, c.searchType))
 			require.NoError(t, err)
 
 			inputs := &search.Inputs{
 				Plan:         plan,
 				Query:        plan.ToQ(),
 				UserSettings: &schema.Settings{},
-				PatternType:  patternType,
+				PatternType:  c.searchType,
 				Protocol:     search.Exhaustive,
 				Features:     &search.Features{},
 			}

--- a/internal/search/job/jobutil/job.go
+++ b/internal/search/job/jobutil/job.go
@@ -408,12 +408,16 @@ func NewFlatJob(searchInputs *search.Inputs, f query.Flat) (job.Job, error) {
 				Features:        *searchInputs.Features,
 			}
 
-			addJob(&structural.SearchJob{
+			structuralSearchJob := &structural.SearchJob{
 				SearcherArgs:     searcherArgs,
 				UseIndex:         f.Index(),
 				ContainsRefGlobs: query.ContainsRefGlobs(f.ToBasic().ToParseTree()),
-				RepoOpts:         repoOptions,
 				BatchRetry:       searchInputs.Protocol == search.Batch,
+			}
+
+			addJob(&repoPagerJob{
+				child:    &reposPartialJob{structuralSearchJob},
+				repoOpts: repoOptions,
 			})
 		}
 

--- a/internal/search/job/jobutil/job.go
+++ b/internal/search/job/jobutil/job.go
@@ -409,15 +409,15 @@ func NewFlatJob(searchInputs *search.Inputs, f query.Flat) (job.Job, error) {
 			}
 
 			structuralSearchJob := &structural.SearchJob{
-				SearcherArgs:     searcherArgs,
-				UseIndex:         f.Index(),
-				ContainsRefGlobs: query.ContainsRefGlobs(f.ToBasic().ToParseTree()),
-				BatchRetry:       searchInputs.Protocol == search.Batch,
+				SearcherArgs: searcherArgs,
+				UseIndex:     f.Index(),
+				BatchRetry:   searchInputs.Protocol == search.Batch,
 			}
 
 			addJob(&repoPagerJob{
-				child:    &reposPartialJob{structuralSearchJob},
-				repoOpts: repoOptions,
+				child:            &reposPartialJob{structuralSearchJob},
+				repoOpts:         repoOptions,
+				containsRefGlobs: query.ContainsRefGlobs(f.ToBasic().ToParseTree()),
 			})
 		}
 

--- a/internal/search/job/jobutil/job_test.go
+++ b/internal/search/job/jobutil/job_test.go
@@ -1101,13 +1101,16 @@ func TestNewPlanJob(t *testing.T) {
         (limit . 10000)
         (PARALLEL
           REPOSCOMPUTEEXCLUDED
-          (STRUCTURALSEARCH
-            (useFullDeadline . true)
+          (REPOPAGER
             (containsRefGlobs . false)
-            (useIndex . yes)
-            (patternInfo.query . "(:[_])")
-            (patternInfo.isStructural . true)
-            (patternInfo.fileMatchLimit . 10000)))))))
+            (PARTIALREPOS
+              (STRUCTURALSEARCH
+                (useFullDeadline . true)
+                (containsRefGlobs . false)
+                (useIndex . yes)
+                (patternInfo.query . "(:[_])")
+                (patternInfo.isStructural . true)
+                (patternInfo.fileMatchLimit . 10000)))))))))
 `),
 		},
 		// The next query shows an unexpected way that a query is

--- a/internal/search/job/jobutil/job_test.go
+++ b/internal/search/job/jobutil/job_test.go
@@ -1106,7 +1106,6 @@ func TestNewPlanJob(t *testing.T) {
             (PARTIALREPOS
               (STRUCTURALSEARCH
                 (useFullDeadline . true)
-                (containsRefGlobs . false)
                 (useIndex . yes)
                 (patternInfo.query . "(:[_])")
                 (patternInfo.isStructural . true)

--- a/internal/search/job/jobutil/repo_pager_job.go
+++ b/internal/search/job/jobutil/repo_pager_job.go
@@ -11,6 +11,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/search/repos"
 	"github.com/sourcegraph/sourcegraph/internal/search/searcher"
 	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
+	"github.com/sourcegraph/sourcegraph/internal/search/structural"
 	"github.com/sourcegraph/sourcegraph/internal/search/zoekt"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 )
@@ -79,6 +80,11 @@ func setRepos(j job.Job, indexed *zoekt.IndexedRepoRevs, unindexed []*search.Rep
 		case *commit.SearchJob:
 			cp := *v
 			cp.Repos = unindexed
+			return &cp
+		case *structural.SearchJob:
+			cp := *v
+			cp.Unindexed = unindexed
+			cp.Indexed = indexed
 			return &cp
 		default:
 			return j

--- a/internal/search/structural/BUILD.bazel
+++ b/internal/search/structural/BUILD.bazel
@@ -10,7 +10,6 @@ go_library(
         "//internal/search",
         "//internal/search/job",
         "//internal/search/query",
-        "//internal/search/repos",
         "//internal/search/result",
         "//internal/search/searcher",
         "//internal/search/streaming",

--- a/internal/search/structural/structural.go
+++ b/internal/search/structural/structural.go
@@ -10,7 +10,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/search/job"
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
-	searchrepos "github.com/sourcegraph/sourcegraph/internal/search/repos"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
 	"github.com/sourcegraph/sourcegraph/internal/search/searcher"
 	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
@@ -163,45 +162,20 @@ type SearchJob struct {
 	ContainsRefGlobs bool
 	BatchRetry       bool
 
-	RepoOpts search.RepoOptions
+	Indexed   *zoektutil.IndexedRepoRevs
+	Unindexed []*search.RepositoryRevisions
 }
 
 func (s *SearchJob) Run(ctx context.Context, clients job.RuntimeClients, stream streaming.Sender) (alert *search.Alert, err error) {
 	_, ctx, stream, finish := job.StartSpan(ctx, stream, s)
 	defer func() { finish(alert, err) }()
 
-	repos := searchrepos.NewResolver(clients.Logger, clients.DB, clients.Gitserver, clients.SearcherURLs, clients.SearcherGRPCConnectionCache, clients.Zoekt)
-	it := repos.Iterator(ctx, s.RepoOpts)
-
-	for it.Next() {
-		page := it.Current()
-		page.MaybeSendStats(stream)
-
-		indexed, unindexed, err := zoektutil.PartitionRepos(
-			ctx,
-			clients.Logger,
-			page.RepoRevs,
-			clients.Zoekt,
-			search.TextRequest,
-			s.UseIndex,
-			s.ContainsRefGlobs,
-		)
-		if err != nil {
-			return nil, err
-		}
-
-		repoSet := []repoData{UnindexedList(unindexed)}
-		if indexed != nil {
-			repoRevsFromBranchRepos := indexed.GetRepoRevsFromBranchRepos()
-			repoSet = append(repoSet, IndexedMap(repoRevsFromBranchRepos))
-		}
-		err = runStructuralSearch(ctx, clients, s.SearcherArgs, s.BatchRetry, repoSet, stream)
-		if err != nil {
-			return nil, err
-		}
+	repoSet := []repoData{UnindexedList(s.Unindexed)}
+	if s.Indexed != nil {
+		repoRevsFromBranchRepos := s.Indexed.GetRepoRevsFromBranchRepos()
+		repoSet = append(repoSet, IndexedMap(repoRevsFromBranchRepos))
 	}
-
-	return nil, it.Err()
+	return nil, runStructuralSearch(ctx, clients, s.SearcherArgs, s.BatchRetry, repoSet, stream)
 }
 
 func (*SearchJob) Name() string {
@@ -219,7 +193,6 @@ func (s *SearchJob) Attributes(v job.Verbosity) (res []attribute.KeyValue) {
 		fallthrough
 	case job.VerbosityBasic:
 		res = append(res, trace.Scoped("patternInfo", s.SearcherArgs.PatternInfo.Fields()...)...)
-		res = append(res, trace.Scoped("repoOpts", s.RepoOpts.Attributes()...)...)
 	}
 	return res
 }

--- a/internal/search/structural/structural.go
+++ b/internal/search/structural/structural.go
@@ -157,10 +157,9 @@ func runStructuralSearch(ctx context.Context, clients job.RuntimeClients, args *
 }
 
 type SearchJob struct {
-	SearcherArgs     *search.SearcherParameters
-	UseIndex         query.YesNoOnly
-	ContainsRefGlobs bool
-	BatchRetry       bool
+	SearcherArgs *search.SearcherParameters
+	UseIndex     query.YesNoOnly
+	BatchRetry   bool
 
 	Indexed   *zoektutil.IndexedRepoRevs
 	Unindexed []*search.RepositoryRevisions
@@ -187,7 +186,6 @@ func (s *SearchJob) Attributes(v job.Verbosity) (res []attribute.KeyValue) {
 	case job.VerbosityMax:
 		res = append(res,
 			attribute.Bool("useFullDeadline", s.SearcherArgs.UseFullDeadline),
-			attribute.Bool("containsRefGlobs", s.ContainsRefGlobs),
 			attribute.String("useIndex", string(s.UseIndex)),
 		)
 		fallthrough


### PR DESCRIPTION
This adds support for structural search queries to Search Jobs. The changes are isolated to the Search Jobs framework.

Limitations:

- No AND/OR queries, because structural search doesn't support `Basic` queries.

This means

supported:
```
if ... patternType:structural
```

not supported
```
if ... OR switch ... patternType:structural
```

Notes:
- [Structural search relies on `bufio.Scanner` to read stdout](https://sourcegraph.sourcegraph.com/github.com/sourcegraph/sourcegraph@2ab15741c105937beba202785002ff31d0e8f5d0/-/blob/cmd/searcher/internal/search/search_structural.go?L411). Potentially long lines in the output of comby might cause a search job to fail. This limitation is not isolated to Search Jobs, but Search Jobs amplifies the issue because we fail the job if one (sub) search fails. In my tests it was very easy to hit that limit. If we merge this PR we should make the buffer size configurable as a follow-up.

Test plan:
- Updated unit test
