### PR TITLE
svelte: Show correct last commit information

### DIFF
--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/+layout.ts
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/+layout.ts
@@ -37,7 +37,7 @@ export const load: LayoutLoad = ({ parent, params }) => {
         lastCommit: client.query(LastCommitQuery, {
             repoName: repoName,
             revspec: revision,
-            filePath: parentPath,
+            filePath: params.path ?? '',
         }),
         // Fetches the most recent commits for current blob, tree or repo root
         commitHistory: infinityQuery({


### PR DESCRIPTION
Currently the "last commit" display in the bottom right shows the last commit of the parent folder, not of the file/folder itself.

This became apparent when opening the history. The top entry didn't match what was shown in the bottom right.

## Test plan

Manual testing.

- Repo home page -> last commit
- Directory/file page -> last commit that changes the file