### PR TITLE
gitserver: Match paths in ArchiveReader validation literally

### DIFF
--- a/cmd/gitserver/internal/git/gitcli/archivereader.go
+++ b/cmd/gitserver/internal/git/gitcli/archivereader.go
@@ -47,7 +47,9 @@ func pathspecLiteral(s string) string { return ":(literal)" + s }
 
 func (g *gitCLIBackend) verifyPaths(ctx context.Context, treeish string, paths []string) error {
 	args := []string{"ls-tree", "-z", "--name-only", treeish, "--"}
-	args = append(args, paths...)
+	for _, p := range paths {
+		args = append(args, pathspecLiteral(p))
+	}
 	r, err := g.NewCommand(ctx, WithArguments(args...))
 	if err != nil {
 		return err


### PR DESCRIPTION
We already do that for the actual archive operation, but not here. To avoid accidentally generating more output than expected, wrapping the paths here with `:(literal)` as well.

## Test plan

Existing tests still pass.

