### PR TITLE
observation: use pedantic prometheus registry for TestContextTB

### DIFF
--- a/internal/observation/context.go
+++ b/internal/observation/context.go
@@ -50,11 +50,11 @@ var TestContext = Context{
 }
 
 // TestContextTB creates a Context similar to `TestContext` but with a logger scoped
-// to the `testing.TB`.
+// to the `testing.TB` and a pedantic Registerer.
 func TestContextTB(t testing.TB) *Context {
 	return &Context{
 		Logger:     logtest.Scoped(t),
-		Registerer: metrics.NoOpRegisterer,
+		Registerer: prometheus.NewPedanticRegistry(),
 		Tracer:     noop.NewTracerProvider().Tracer("noop"),
 	}
 }


### PR DESCRIPTION
We currently use a NoOpRegisterer which means we don't do any validation on the metrics passed in, leading to us not catching things like duplicate registration of metrics/etc. So we update the registerer to be one which does a few more tests on metrics designed to be used in test contexts.

Note we do not update TestContext since that may be used multiple times in the same process to test the same metrics registration paths. To be honest, we should remove TestContext and update all call sites to use TestContextTB.

Test Plan: CI. Only affects tests this change.
