### PR TITLE
monitoring: add golang monitoring for zoekt

### DIFF
--- a/doc/admin/observability/alerts.md
+++ b/doc/admin/observability/alerts.md
@@ -6570,6 +6570,126 @@ Generated query for warning alert: `max((max by (name) (container_oom_events_tot
 
 <br />
 
+## zoekt: go_goroutines
+
+<p class="subtitle">maximum active goroutines</p>
+
+**Descriptions**
+
+- <span class="badge badge-warning">warning</span> zoekt: 10000+ maximum active goroutines for 10m0s
+
+**Next steps**
+
+- More help interpreting this metric is available in the [dashboards reference](./dashboards.md#zoekt-go-goroutines).
+- **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
+
+```json
+"observability.silenceAlerts": [
+  "warning_zoekt_go_goroutines"
+]
+```
+
+<sub>*Managed by the [Sourcegraph Search Platform team](https://handbook.sourcegraph.com/departments/engineering/teams/search/core).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((max by (instance) (go_goroutines{job=~".*indexed-search-indexer"})) >= 10000)`
+
+</details>
+
+<br />
+
+## zoekt: go_gc_duration_seconds
+
+<p class="subtitle">maximum go garbage collection duration</p>
+
+**Descriptions**
+
+- <span class="badge badge-warning">warning</span> zoekt: 2s+ maximum go garbage collection duration
+
+**Next steps**
+
+- Learn more about the related dashboard panel in the [dashboards reference](./dashboards.md#zoekt-go-gc-duration-seconds).
+- **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
+
+```json
+"observability.silenceAlerts": [
+  "warning_zoekt_go_gc_duration_seconds"
+]
+```
+
+<sub>*Managed by the [Sourcegraph Search Platform team](https://handbook.sourcegraph.com/departments/engineering/teams/search/core).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((max by (instance) (go_gc_duration_seconds{job=~".*indexed-search-indexer"})) >= 2)`
+
+</details>
+
+<br />
+
+## zoekt: go_goroutines
+
+<p class="subtitle">maximum active goroutines</p>
+
+**Descriptions**
+
+- <span class="badge badge-warning">warning</span> zoekt: 10000+ maximum active goroutines for 10m0s
+
+**Next steps**
+
+- More help interpreting this metric is available in the [dashboards reference](./dashboards.md#zoekt-go-goroutines).
+- **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
+
+```json
+"observability.silenceAlerts": [
+  "warning_zoekt_go_goroutines"
+]
+```
+
+<sub>*Managed by the [Sourcegraph Search Platform team](https://handbook.sourcegraph.com/departments/engineering/teams/search/core).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((max by (instance) (go_goroutines{job=~".*indexed-search"})) >= 10000)`
+
+</details>
+
+<br />
+
+## zoekt: go_gc_duration_seconds
+
+<p class="subtitle">maximum go garbage collection duration</p>
+
+**Descriptions**
+
+- <span class="badge badge-warning">warning</span> zoekt: 2s+ maximum go garbage collection duration
+
+**Next steps**
+
+- Learn more about the related dashboard panel in the [dashboards reference](./dashboards.md#zoekt-go-gc-duration-seconds).
+- **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
+
+```json
+"observability.silenceAlerts": [
+  "warning_zoekt_go_gc_duration_seconds"
+]
+```
+
+<sub>*Managed by the [Sourcegraph Search Platform team](https://handbook.sourcegraph.com/departments/engineering/teams/search/core).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((max by (instance) (go_gc_duration_seconds{job=~".*indexed-search"})) >= 2)`
+
+</details>
+
+<br />
+
 ## zoekt: pods_available_percentage
 
 <p class="subtitle">percentage pods available</p>

--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -26597,6 +26597,102 @@ max by (name) (container_oom_events_total{name=~"^zoekt-webserver.*"})
 
 <br />
 
+### Zoekt: [indexed-search-indexer] Golang runtime monitoring
+
+#### zoekt: go_goroutines
+
+<p class="subtitle">Maximum active goroutines</p>
+
+A high value here indicates a possible goroutine leak.
+
+Refer to the [alerts reference](./alerts.md#zoekt-go-goroutines) for 1 alert related to this panel.
+
+To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=101600` on your Sourcegraph instance.
+
+<sub>*Managed by the [Sourcegraph Search Platform team](https://handbook.sourcegraph.com/departments/engineering/teams/search/core).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Query:
+
+```
+max by(instance) (go_goroutines{job=~".*indexed-search-indexer"})
+```
+</details>
+
+<br />
+
+#### zoekt: go_gc_duration_seconds
+
+<p class="subtitle">Maximum go garbage collection duration</p>
+
+Refer to the [alerts reference](./alerts.md#zoekt-go-gc-duration-seconds) for 1 alert related to this panel.
+
+To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=101601` on your Sourcegraph instance.
+
+<sub>*Managed by the [Sourcegraph Search Platform team](https://handbook.sourcegraph.com/departments/engineering/teams/search/core).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Query:
+
+```
+max by(instance) (go_gc_duration_seconds{job=~".*indexed-search-indexer"})
+```
+</details>
+
+<br />
+
+### Zoekt: [indexed-search] Golang runtime monitoring
+
+#### zoekt: go_goroutines
+
+<p class="subtitle">Maximum active goroutines</p>
+
+A high value here indicates a possible goroutine leak.
+
+Refer to the [alerts reference](./alerts.md#zoekt-go-goroutines) for 1 alert related to this panel.
+
+To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=101700` on your Sourcegraph instance.
+
+<sub>*Managed by the [Sourcegraph Search Platform team](https://handbook.sourcegraph.com/departments/engineering/teams/search/core).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Query:
+
+```
+max by(instance) (go_goroutines{job=~".*indexed-search"})
+```
+</details>
+
+<br />
+
+#### zoekt: go_gc_duration_seconds
+
+<p class="subtitle">Maximum go garbage collection duration</p>
+
+Refer to the [alerts reference](./alerts.md#zoekt-go-gc-duration-seconds) for 1 alert related to this panel.
+
+To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=101701` on your Sourcegraph instance.
+
+<sub>*Managed by the [Sourcegraph Search Platform team](https://handbook.sourcegraph.com/departments/engineering/teams/search/core).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Query:
+
+```
+max by(instance) (go_gc_duration_seconds{job=~".*indexed-search"})
+```
+</details>
+
+<br />
+
 ### Zoekt: Kubernetes monitoring (only available on Kubernetes)
 
 #### zoekt: pods_available_percentage
@@ -26605,7 +26701,7 @@ max by (name) (container_oom_events_total{name=~"^zoekt-webserver.*"})
 
 Refer to the [alerts reference](./alerts.md#zoekt-pods-available-percentage) for 1 alert related to this panel.
 
-To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=101600` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=101800` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Search Platform team](https://handbook.sourcegraph.com/departments/engineering/teams/search/core).*</sub>
 

--- a/monitoring/definitions/shared/go.go
+++ b/monitoring/definitions/shared/go.go
@@ -54,6 +54,11 @@ type GolangMonitoringOptions struct {
 	JobLabelName string
 
 	InstanceLabelName string
+
+	// ContainerNameInTitle if true will prefix the groups title with the
+	// container that is being monitored. This is useful to set if your
+	// dashboard has monitoring for multiple containers.
+	ContainerNameInTitle bool
 }
 
 // NewGolangMonitoringGroup creates a group containing panels displaying Go monitoring
@@ -70,8 +75,13 @@ func NewGolangMonitoringGroup(containerName string, owner monitoring.ObservableO
 		options.JobLabelName = "job"
 	}
 
+	title := TitleGolangMonitoring
+	if options.ContainerNameInTitle {
+		title = fmt.Sprintf("[%s] %s", containerName, TitleGolangMonitoring)
+	}
+
 	return monitoring.Group{
-		Title:  TitleGolangMonitoring,
+		Title:  title,
 		Hidden: true,
 		Rows: []monitoring.Row{
 			{

--- a/monitoring/definitions/zoekt.go
+++ b/monitoring/definitions/zoekt.go
@@ -16,6 +16,9 @@ func Zoekt() *monitoring.Dashboard {
 		webserverContainerName   = "zoekt-webserver"
 		bundledContainerName     = "indexed-search"
 		grpcServiceName          = "zoekt.webserver.v1.WebserverService"
+
+		indexServerJob = "indexed-search-indexer"
+		webserverJob   = "indexed-search"
 	)
 
 	grpcMethodVariable := shared.GRPCMethodVariable("zoekt_webserver", grpcServiceName)
@@ -1127,6 +1130,9 @@ func Zoekt() *monitoring.Dashboard {
 			shared.NewProvisioningIndicatorsGroup(webserverContainerName, monitoring.ObservableOwnerSearchCore, &shared.ContainerProvisioningIndicatorsGroupOptions{
 				CustomTitle: fmt.Sprintf("[%s] %s", webserverContainerName, shared.TitleProvisioningIndicators),
 			}),
+
+			shared.NewGolangMonitoringGroup(indexServerJob, monitoring.ObservableOwnerSearchCore, &shared.GolangMonitoringOptions{ContainerNameInTitle: true}),
+			shared.NewGolangMonitoringGroup(webserverJob, monitoring.ObservableOwnerSearchCore, &shared.GolangMonitoringOptions{ContainerNameInTitle: true}),
 
 			// Note:
 			// We show pod availability here for both the webserver and indexserver as they are bundled together.


### PR DESCRIPTION
Noticed this omission when I was wondering if we had goroutine leaks. Our other services define this.

I added a simple way to indicate the container name in title since this is the first service we added which needs this.

Test Plan: go test. Copy paste generated query into grafana explore on dotcom.