### PR TITLE
symbols: avoid spamming handleParseRequest on context cancelation

### DIFF
--- a/cmd/symbols/parser/parser.go
+++ b/cmd/symbols/parser/parser.go
@@ -115,6 +115,12 @@ func (p *parser) Parse(ctx context.Context, args search.SymbolsParameters, paths
 					break
 				}
 
+				// Drain channel if our context has been canceled. Otherwise
+				// we just logspam on handleParseRequest.
+				if ctx.Err() != nil {
+					continue
+				}
+
 				atomic.AddUint32(&totalRequests, 1)
 				if err := p.handleParseRequest(ctx, symbolOrErrors, parseRequestOrError.ParseRequest, &totalSymbols); err != nil {
 					log15.Error("error handling parse request", "error", err, "path", parseRequestOrError.ParseRequest.Path)


### PR DESCRIPTION
Understanding how Parse works (and its callers) with respect to goroutines and channels is a sure path to the asylum. This is a short term fix around how it behaves when the context is canceled.

From what I can tell we can have a large number of parse requests go through handleParseRequest even once the context has been canceled, leading to large amounts of logging of errors which all amount to context canceled. This is a short term fix which drains the channel if we know we are just gonna fail our call to handleParseRequest.

Test Plan: go test. Didn't manual test, but the code change is minor enough that I trust it (famous last words).
