### PR TITLE
svelte: Fix file view text selection issue

### DIFF
--- a/client/web-sveltekit/src/lib/CodeMirrorBlob.svelte
+++ b/client/web-sveltekit/src/lib/CodeMirrorBlob.svelte
@@ -44,7 +44,6 @@
             fontSize: 'var(--code-font-size)',
         },
         '.cm-content': {
-            backgroundColor: 'var(--code-bg)',
             '&:focus-visible': {
                 outline: 'none',
                 boxShadow: 'none',

--- a/client/web-sveltekit/src/routes/search/PreviewPanel.svelte
+++ b/client/web-sveltekit/src/routes/search/PreviewPanel.svelte
@@ -152,5 +152,6 @@
     .content {
         flex: 1;
         min-height: 0;
+        background-color: var(--code-bg);
     }
 </style>


### PR DESCRIPTION
Fixes #61611 

In the file view it looked like text selection doesn't work. However, I did work but the decoration wasn't visible. That's because the text selection decoration is rendered "underneath" the content, but the content element has been given a background color, so the text selection decoration wasn't visible.

The fix is to set the background color on the container that renders the editor instead.

## Test plan

Manual testing.
