### PR TITLE
nix: build pg-utils with nix [static edition]

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -43,7 +43,10 @@
             # doesnt need the same stability as those above
             nodejs-20_x = pkgs.callPackage ./dev/nix/nodejs.nix { };
             bazel_7 = nixpkgs-bazel.legacyPackages.${system}.callPackage ./dev/nix/bazel.nix { };
-            pg-utils = pkgs.callPackage ./dev/nix/pg-utils.nix { };
+            pg-utils = pkgs.pkgsStatic.callPackage ./dev/nix/pg-utils.nix {
+              # tzdata fails to build on pkgsStatic, and pkgsMusl isnt supported on macos
+              tzdata = if pkgs.hostPlatform.isMacOS then pkgs.tzdata else pkgs.pkgsMusl.tzdata;
+            };
           };
 
           # We use pkgsShell (not pkgsAll) intentionally to avoid doing extra work of

--- a/flake.nix
+++ b/flake.nix
@@ -43,7 +43,7 @@
             # doesnt need the same stability as those above
             nodejs-20_x = pkgs.callPackage ./dev/nix/nodejs.nix { };
             bazel_7 = nixpkgs-bazel.legacyPackages.${system}.callPackage ./dev/nix/bazel.nix { };
-            pg-utils = pkgs.pkgsStatic.callPackage ./dev/nix/pg-utils.nix {
+            pg-utils = (if pkgs.hostPlatform.isMacOS then pkgs.callPackage else pkgs.pkgsStatic.callPackage) ./dev/nix/pg-utils.nix {
               # tzdata fails to build on pkgsStatic, and pkgsMusl isnt supported on macos
               tzdata = if pkgs.hostPlatform.isMacOS then pkgs.tzdata else pkgs.pkgsMusl.tzdata;
             };


### PR DESCRIPTION
Turns out we can do this after all! And thankfully so, because our buildkite runners have an older glibc version than what Nix was building our bins against which was resulting in `dropdb: /lib/x86_64-linux-gnu/libc.so.6: version GLIBC_2.32' not found (required by dropdb)` when bazel was running in buildkite

## Test plan

Much local `nix build`'ing, `ldd` and `patchelf`'ing
