### PR TITLE
web: Fix blame recency color "direction"

### DIFF
--- a/client/web/src/repo/blob/codemirror/blame-decorations.tsx
+++ b/client/web/src/repo/blob/codemirror/blame-decorations.tsx
@@ -270,7 +270,7 @@ class RecencyMarker extends GutterMarker {
             if (this.hunk.startLine === this.line) {
                 dom.classList.add('border-top')
             }
-            dom.style.backgroundColor = getBlameRecencyColor(new Date(this.hunk.author.date), !this.darkTheme)
+            dom.style.backgroundColor = getBlameRecencyColor(new Date(this.hunk.author.date), !!this.darkTheme)
         }
         return dom
     }


### PR DESCRIPTION
#61661 changed how "blame recency" is calculated in the client. In a last minute change I flipped the meaning of the boolean parameter but forgot to update the callsite. That's why the colors are currently the opposite (most recent = gray, least recent = purpel).

## Test plan

Trivial change.