### PR TITLE
rbac: check for undefined permissions in PermissionsList

### DIFF
--- a/client/web/src/enterprise/rbac/components/Permissions.story.tsx
+++ b/client/web/src/enterprise/rbac/components/Permissions.story.tsx
@@ -1,9 +1,11 @@
 import type { Decorator, Meta, StoryFn } from '@storybook/react'
 import { noop } from 'lodash'
 
+import { PermissionNamespace } from '@sourcegraph/shared/src/graphql-operations'
 import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
 
 import { WebStory } from '../../../components/WebStory'
+import { PermissionsMap } from '../backend'
 import { mockPermissionsMap, mockRoles } from '../mock'
 
 import { PermissionsList } from './Permissions'
@@ -82,3 +84,33 @@ export const AllPermissionsAssigned: StoryFn = () => (
 )
 
 AllPermissionsAssigned.storyName = 'All permissions assigned'
+
+export const DotComPermissionIncluded: StoryFn = () => (
+    <WebStory>
+        {() => {
+            const allPermissions: PermissionsMap = {
+                ...mockPermissionsMap,
+                [PermissionNamespace.PRODUCT_SUBSCRIPTIONS]: [
+                    {
+                        __typename: 'Permission',
+                        id: 'test-03-01',
+                        namespace: PermissionNamespace.PRODUCT_SUBSCRIPTIONS,
+                        action: 'TEST',
+                        displayName: 'PRODUCT_SUBSCRIPTIONS#TEST',
+                    },
+                ],
+            }
+            return (
+                <MockedTestProvider>
+                    <PermissionsList
+                        allPermissions={allPermissions}
+                        onChange={noop}
+                        onBlur={noop}
+                        isChecked={isChecked(roleWithAllPermissions)}
+                        roleName={roleName}
+                    />
+                </MockedTestProvider>
+            )
+        }}
+    </WebStory>
+)

--- a/client/web/src/enterprise/rbac/components/Permissions.tsx
+++ b/client/web/src/enterprise/rbac/components/Permissions.tsx
@@ -28,6 +28,9 @@ export const PermissionsList: React.FunctionComponent<React.PropsWithChildren<Pe
     <>
         {allNamespaces.map(namespace => {
             const namespacePermissions = allPermissions[namespace]
+            if (!namespacePermissions || namespacePermissions.length === 0) {
+                return null
+            }
             return (
                 <div key={namespace}>
                     <Text className="font-weight-bold">{prettifyNamespace(namespace)}</Text>


### PR DESCRIPTION
#60795 introduced the concept of permissions that only exists on `Dotcom`, however one thing we didn't take into consideration is how the frontend displays the role.

Turns out we get `allPermissions` from the generated `graphql-operations.ts` file which is statically generated at build time and doesn't know about permissions that only exist on `dotcom`. 

## Test plan

Manual testing?

Added a storybook also.