### PR TITLE
bazel: transition oci_image to opt/release mode for Rust

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -2,12 +2,16 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "platforms",
-    sha256 = "8150406605389ececb6da07cbcb509d5637a3ab9a24bc69b1101531367d89d74",
+    sha256 = "5eda539c841265031c2f82d8ae7a3a6490bd62176e0c038fc469eabf91f6149b",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/platforms/releases/download/0.0.8/platforms-0.0.8.tar.gz",
-        "https://github.com/bazelbuild/platforms/releases/download/0.0.8/platforms-0.0.8.tar.gz",
+        "https://mirror.bazel.build/github.com/bazelbuild/platforms/releases/download/0.0.9/platforms-0.0.9.tar.gz",
+        "https://github.com/bazelbuild/platforms/releases/download/0.0.9/platforms-0.0.9.tar.gz",
     ],
 )
+
+load("@platforms//host:extension.bzl", "host_platform_repo")
+
+host_platform_repo(name = "host_platform")
 
 http_archive(
     name = "bazel_skylib",

--- a/dev/oci_defs.bzl
+++ b/dev/oci_defs.bzl
@@ -32,9 +32,9 @@ def oci_image(name, **kwargs):
     oci_image_cross(
         name = name,
         image = ":" + name + "_underlying",
-        platforms = select({
-            "@platforms//os:macos": [Label("@zig_sdk//platform:linux_amd64")],
-            "//conditions:default": [],
+        platform = select({
+            "@platforms//os:macos": Label("@zig_sdk//platform:linux_amd64"),
+            "//conditions:default": Label("@platforms//host"),
         }),
         visibility = kwargs.pop("visibility", ["//visibility:public"]),
     )
@@ -45,13 +45,12 @@ oci_image_cross = rule(
     attrs = {
         "image": attr.label(cfg = transition(
             implementation = lambda settings, attr: [
-                {"//command_line_option:platforms": str(platform)}
-                for platform in attr.platforms
+                {"//command_line_option:platforms": str(attr.platform), "//command_line_option:compilation_mode": "opt"},
             ],
             inputs = [],
-            outputs = ["//command_line_option:platforms"],
+            outputs = ["//command_line_option:platforms", "//command_line_option:compilation_mode"],
         )),
-        "platforms": attr.label_list(),
+        "platform": attr.label(),
         "_allowlist_function_transition": attr.label(
             default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
         ),


### PR DESCRIPTION
Our rust binaries (e.g. scip-ctags/syntect_server) were being built in some mix of opt & fastbuild mode[1]. Unlike with Go where there is no release/debug mode flag, Rust requires opting into optimized release builds. We can do that automagically when building any oci_image target with the power of :sparkles: transitions :sparkles: 

This has the side-effect of our Go binaries no longer being stripped & containing debug symbols, see https://github.com/bazelbuild/rules_go/issues/3917

Also to note, [in Cargo.toml we opt into debug symbols in release mode](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@nsc/bazel-release-mode-rust/-/blob/docker-images/syntax-highlighter/Cargo.toml?L67%3A11-70%3A9). Is this preserved by this PR for bazel[2]? 

[1] `strings` on the binaries showed the 3rd-party crates having `k8-opt` filepath names e.g.
```
$ / # strings syntect_server | grep k8-
/tmp/bazel-working-directory/__main__/bazel-out/k8-opt-exec-ST-13d3ddad9198/bin/external/crate_index__onig_sys-69.8.1/onig_sys_build_script_.runfiles/crate_index__onig_sys-69.8.1
```
but the final binaries (and the 1st-party crates) themselves were being built in fastbuild mode. See https://github.com/sourcegraph/devx-support/issues/790 for original point of contact

[2] It seems like it may be preserved, but I dont know how reliable this is for Rust binaries
```
$ file bazel-bin/docker-images/syntax-highlighter/scip-ctags
bazel-bin/docker-images/syntax-highlighter/scip-ctags: ELF 64-bit LSB pie executable, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2, for GNU/Linux 2.0.0, with debug_info, not stripped
```

## Test plan

Tested for sourcegraph/scip-ctags image:
```
/ $ strings scip-ctags | grep "Could not parse file" 
/ $ echo $?
1
```