### PR TITLE
v2t: add v2t to src/site-admin

### DIFF
--- a/client/web/src/components/externalServices/AddExternalServicePage.tsx
+++ b/client/web/src/components/externalServices/AddExternalServicePage.tsx
@@ -8,7 +8,7 @@ import type { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Alert, Container, H3, H4, Markdown, PageHeader } from '@sourcegraph/wildcard'
 
-import type { AddExternalServiceInput, AddExternalServiceResult } from '../../graphql-operations'
+import type { AddExternalServiceInput, AddExternalServiceResult, ExternalServiceKind } from '../../graphql-operations'
 import { refreshSiteFlags } from '../../site/backend'
 import { PageTitle } from '../PageTitle'
 
@@ -24,6 +24,27 @@ interface Props extends TelemetryProps, TelemetryV2Props {
 
     /** For testing only. */
     autoFocusForm?: boolean
+}
+
+const v2ExternalServiceKinds: { [key in ExternalServiceKind]: number } = {
+    AWSCODECOMMIT: 1,
+    AZUREDEVOPS: 2,
+    BITBUCKETCLOUD: 3,
+    BITBUCKETSERVER: 4,
+    GERRIT: 5,
+    GITHUB: 6,
+    GITLAB: 7,
+    GITOLITE: 8,
+    GOMODULES: 9,
+    JVMPACKAGES: 10,
+    NPMPACKAGES: 11,
+    OTHER: 12,
+    PAGURE: 13,
+    PERFORCE: 14,
+    PHABRICATOR: 15,
+    PYTHONPACKAGES: 16,
+    RUBYPACKAGES: 17,
+    RUSTPACKAGES: 18,
 }
 
 /**
@@ -44,7 +65,9 @@ export const AddExternalServicePage: FC<Props> = ({
 
     useEffect(() => {
         telemetryService.logPageView('AddExternalService')
-        telemetryRecorder.recordEvent('admin.externalServices.add', 'view')
+        telemetryRecorder.recordEvent('admin.codeHostConnections.add', 'view', {
+            metadata: { kind: v2ExternalServiceKinds[externalService.kind] },
+        })
     }, [telemetryService, telemetryRecorder])
 
     useEffect(() => {
@@ -82,13 +105,13 @@ export const AddExternalServicePage: FC<Props> = ({
                 },
                 onCompleted: data => {
                     telemetryService.log('AddExternalServiceSucceeded')
-                    telemetryRecorder.recordEvent('admin.externalServices.add', 'success')
+                    telemetryRecorder.recordEvent('admin.codeHostConnections.add', 'success')
                     refreshSiteFlags(client).catch((error: Error) => logger.error(error))
                     navigate(`/site-admin/external-services/${data.addExternalService.id}`)
                 },
                 onError: () => {
                     telemetryService.log('AddExternalServiceFailed')
-                    telemetryRecorder.recordEvent('admin.externalServices.add', 'fail')
+                    telemetryRecorder.recordEvent('admin.codeHostConnections.add', 'fail')
                 },
             })
         },

--- a/client/web/src/components/externalServices/AddExternalServicePage.tsx
+++ b/client/web/src/components/externalServices/AddExternalServicePage.tsx
@@ -68,7 +68,7 @@ export const AddExternalServicePage: FC<Props> = ({
         telemetryRecorder.recordEvent('admin.codeHostConnections.add', 'view', {
             metadata: { kind: v2ExternalServiceKinds[externalService.kind] },
         })
-    }, [telemetryService, telemetryRecorder])
+    }, [telemetryService, telemetryRecorder, externalService.kind])
 
     useEffect(() => {
         setConfig(externalService.defaultConfig)

--- a/client/web/src/components/externalServices/AddExternalServicesPage.tsx
+++ b/client/web/src/components/externalServices/AddExternalServicesPage.tsx
@@ -1,4 +1,4 @@
-import { type FC, useMemo } from 'react'
+import { type FC, useMemo, useEffect } from 'react'
 
 import BitbucketIcon from 'mdi-react/BitbucketIcon'
 import GithubIcon from 'mdi-react/GithubIcon'
@@ -80,6 +80,12 @@ export const AddExternalServicesPage: FC<AddExternalServicesPageProps> = ({
         () => computeExternalServicesGroup(codeHostExternalServices),
         [codeHostExternalServices]
     )
+
+    useEffect(() => {
+        if (!externalService) {
+            telemetryRecorder.recordEvent('admin.allCodeHostConnections.add', 'view')
+        }
+    }, [telemetryRecorder, externalService])
 
     if (externalService) {
         return (

--- a/client/web/src/components/externalServices/ExternalServiceEditPage.tsx
+++ b/client/web/src/components/externalServices/ExternalServiceEditPage.tsx
@@ -42,7 +42,7 @@ export const ExternalServiceEditPage: FC<Props> = ({
 
     useEffect(() => {
         telemetryService.logViewEvent('SiteAdminExternalService')
-        telemetryRecorder.recordEvent('admin.externalService.edit', 'view')
+        telemetryRecorder.recordEvent('admin.codeHostConnection.edit', 'view')
     }, [telemetryService, telemetryRecorder])
 
     const [externalService, setExternalService] = useState<ExternalServiceFieldsWithConfig>()

--- a/client/web/src/components/externalServices/ExternalServicePage.tsx
+++ b/client/web/src/components/externalServices/ExternalServicePage.tsx
@@ -66,7 +66,7 @@ export const ExternalServicePage: FC<Props> = props => {
 
     useEffect(() => {
         telemetryService.logViewEvent('SiteAdminExternalService')
-        telemetryRecorder.recordEvent('admin.externalService', 'view')
+        telemetryRecorder.recordEvent('admin.codeHostConnection', 'view')
     }, [telemetryService, telemetryRecorder])
 
     const [syncInProgress, setSyncInProgress] = useState<boolean>(false)

--- a/client/web/src/components/externalServices/ExternalServicesPage.tsx
+++ b/client/web/src/components/externalServices/ExternalServicesPage.tsx
@@ -39,7 +39,7 @@ export const ExternalServicesPage: FC<Props> = ({
 }) => {
     useEffect(() => {
         telemetryService.logViewEvent('SiteAdminExternalServices')
-        telemetryRecorder.recordEvent('admin.externalServices', 'view')
+        telemetryRecorder.recordEvent('admin.codeHostConnections', 'view')
     }, [telemetryService, telemetryRecorder])
 
     const location = useLocation()

--- a/client/web/src/enterprise/batches/BatchSpecsPage.tsx
+++ b/client/web/src/enterprise/batches/BatchSpecsPage.tsx
@@ -1,4 +1,4 @@
-import React, { type FC, useCallback, useMemo } from 'react'
+import React, { type FC, useCallback, useMemo, useEffect } from 'react'
 
 import { mdiMapSearch } from '@mdi/js'
 import classNames from 'classnames'
@@ -25,24 +25,27 @@ export interface BatchSpecsPageProps extends TelemetryV2Props {
     now?: () => Date
 }
 
-export const BatchSpecsPage: FC<BatchSpecsPageProps> = props => (
-    <>
-        <PageTitle title="Batch specs" />
-        <PageHeader
-            headingElement="h2"
-            path={[{ text: 'Batch specs' }]}
-            description="All batch specs that currently exist."
-            className="mb-3"
-        />
-        <Container>
-            <BatchSpecList
-                queryBatchSpecs={props.queryBatchSpecs}
-                now={props.now}
-                telemetryRecorder={props.telemetryRecorder}
+export const BatchSpecsPage: FC<BatchSpecsPageProps> = props => {
+    useEffect(() => props.telemetryRecorder.recordEvent('admin.batchSpecs', 'view'), [props.telemetryRecorder])
+    return (
+        <>
+            <PageTitle title="Batch specs" />
+            <PageHeader
+                headingElement="h2"
+                path={[{ text: 'Batch specs' }]}
+                description="All batch specs that currently exist."
+                className="mb-3"
             />
-        </Container>
-    </>
-)
+            <Container>
+                <BatchSpecList
+                    queryBatchSpecs={props.queryBatchSpecs}
+                    now={props.now}
+                    telemetryRecorder={props.telemetryRecorder}
+                />
+            </Container>
+        </>
+    )
+}
 
 export interface BatchChangeBatchSpecListProps extends Omit<BatchSpecListProps, 'queryBatchSpecs'> {
     batchChangeID: Scalars['ID']

--- a/client/web/src/enterprise/batches/settings/BatchChangesSiteConfigSettingsPage.story.tsx
+++ b/client/web/src/enterprise/batches/settings/BatchChangesSiteConfigSettingsPage.story.tsx
@@ -2,6 +2,7 @@ import type { Decorator, Meta, StoryFn } from '@storybook/react'
 import { MATCH_ANY_PARAMETERS, type WildcardMockedResponse, WildcardMockLink } from 'wildcard-mock-link'
 
 import { getDocumentNode } from '@sourcegraph/http-client'
+import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
 import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
 
 import { WebStory } from '../../../components/WebStory'
@@ -124,7 +125,7 @@ export const Overview: StoryFn = () => (
                     )
                 }
             >
-                <BatchChangesSiteConfigSettingsPage />
+                <BatchChangesSiteConfigSettingsPage telemetryRecorder={noOpTelemetryRecorder} />
             </MockedTestProvider>
         )}
     </WebStory>
@@ -134,7 +135,7 @@ export const NoItems: StoryFn = () => (
     <WebStory>
         {() => (
             <MockedTestProvider link={new WildcardMockLink([ROLLOUT_WINDOWS_CONFIGURATION_MOCK, createMock()])}>
-                <BatchChangesSiteConfigSettingsPage />
+                <BatchChangesSiteConfigSettingsPage telemetryRecorder={noOpTelemetryRecorder} />
             </MockedTestProvider>
         )}
     </WebStory>
@@ -220,7 +221,7 @@ export const ConfigAdded: StoryFn = () => (
                     ])
                 }
             >
-                <BatchChangesSiteConfigSettingsPage />
+                <BatchChangesSiteConfigSettingsPage telemetryRecorder={noOpTelemetryRecorder} />
             </MockedTestProvider>
         )}
     </WebStory>

--- a/client/web/src/enterprise/batches/settings/BatchChangesSiteConfigSettingsPage.tsx
+++ b/client/web/src/enterprise/batches/settings/BatchChangesSiteConfigSettingsPage.tsx
@@ -1,5 +1,6 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import { PageHeader, Alert, Text } from '@sourcegraph/wildcard'
 
 import { PageTitle } from '../../../components/PageTitle'
@@ -8,27 +9,31 @@ import { GlobalCodeHostConnections } from './CodeHostConnections'
 import { GlobalCommitSigningIntegrations } from './CommitSigningIntegrations'
 import { RolloutWindowsConfiguration } from './RolloutWindowsConfiguration'
 
-interface BatchChangesSiteConfigSettingsPageProps {}
+interface BatchChangesSiteConfigSettingsPageProps extends TelemetryV2Props {}
 
 /** The page area for all batch changes settings. It's shown in the site admin settings sidebar. */
-export const BatchChangesSiteConfigSettingsPage: React.FunctionComponent<
-    BatchChangesSiteConfigSettingsPageProps
-> = () => (
-    <>
-        <PageTitle title="Batch changes settings" />
-        <PageHeader headingElement="h2" path={[{ text: 'Batch Changes settings' }]} className="mb-3" />
-        <RolloutWindowsConfiguration />
-        <GlobalCodeHostConnections
-            headerLine={
-                <>
-                    <Text>Add access tokens to enable Batch Changes changeset creation for all users.</Text>
-                    <Alert variant="info">
-                        You are configuring <strong>global credentials</strong> for Batch Changes. The credentials on
-                        this page can be used by all users of this Sourcegraph instance to create and sync changesets.
-                    </Alert>
-                </>
-            }
-        />
-        <GlobalCommitSigningIntegrations />
-    </>
-)
+export const BatchChangesSiteConfigSettingsPage: React.FunctionComponent<BatchChangesSiteConfigSettingsPageProps> = ({
+    telemetryRecorder,
+}) => {
+    useEffect(() => telemetryRecorder.recordEvent('admin.batchChangesSettings', 'view'), [telemetryRecorder])
+    return (
+        <>
+            <PageTitle title="Batch changes settings" />
+            <PageHeader headingElement="h2" path={[{ text: 'Batch Changes settings' }]} className="mb-3" />
+            <RolloutWindowsConfiguration />
+            <GlobalCodeHostConnections
+                headerLine={
+                    <>
+                        <Text>Add access tokens to enable Batch Changes changeset creation for all users.</Text>
+                        <Alert variant="info">
+                            You are configuring <strong>global credentials</strong> for Batch Changes. The credentials
+                            on this page can be used by all users of this Sourcegraph instance to create and sync
+                            changesets.
+                        </Alert>
+                    </>
+                }
+            />
+            <GlobalCommitSigningIntegrations />
+        </>
+    )
+}

--- a/client/web/src/enterprise/executors/instances/ExecutorsListPage.tsx
+++ b/client/web/src/enterprise/executors/instances/ExecutorsListPage.tsx
@@ -50,7 +50,7 @@ export const ExecutorsListPage: React.FC<ExecutorsListPageProps> = ({
 }) => {
     useEffect(() => {
         EVENT_LOGGER.logViewEvent('ExecutorsList')
-        telemetryRecorder.recordEvent('executors.list', 'view')
+        telemetryRecorder.recordEvent('admin.executors.list', 'view')
     }, [telemetryRecorder])
 
     const apolloClient = useApolloClient()

--- a/client/web/src/enterprise/executors/secrets/ExecutorSecretsListPage.tsx
+++ b/client/web/src/enterprise/executors/secrets/ExecutorSecretsListPage.tsx
@@ -146,18 +146,18 @@ const ExecutorSecretsListPage: FC<ExecutorSecretsListPageProps> = ({
             telemetryRecorder.recordEvent(`${areaType}.executors.addSecret`, 'click')
             setShowAddModal(true)
         },
-        [telemetryRecorder]
+        [areaType, telemetryRecorder]
     )
 
     const closeModal = useCallback(() => {
         telemetryRecorder.recordEvent(`${areaType}.executors.addSecret`, 'cancel')
         setShowAddModal(false)
-    }, [telemetryRecorder])
+    }, [areaType, telemetryRecorder])
     const afterAction = useCallback(() => {
         telemetryRecorder.recordEvent(`${areaType}.executors.addSecret`, 'submit')
         setShowAddModal(false)
         refetchAll()
-    }, [refetchAll, telemetryRecorder])
+    }, [areaType, refetchAll, telemetryRecorder])
 
     return (
         <>

--- a/client/web/src/enterprise/executors/secrets/ExecutorSecretsListPage.tsx
+++ b/client/web/src/enterprise/executors/secrets/ExecutorSecretsListPage.tsx
@@ -35,7 +35,7 @@ export interface GlobalExecutorSecretsListPageProps extends TelemetryV2Props {}
 
 export const GlobalExecutorSecretsListPage: FC<GlobalExecutorSecretsListPageProps> = props => {
     useEffect(
-        () => props.telemetryRecorder.recordEvent('executors.globalSecretsList', 'view'),
+        () => props.telemetryRecorder.recordEvent('admin.executors.secretsList', 'view'),
         [props.telemetryRecorder]
     )
     const connectionLoader = useCallback(
@@ -44,6 +44,7 @@ export const GlobalExecutorSecretsListPage: FC<GlobalExecutorSecretsListPageProp
     )
     return (
         <ExecutorSecretsListPage
+            areaType="admin"
             namespaceID={null}
             headerLine={<>Configure executor secrets that will be available to everyone on the Sourcegraph instance.</>}
             connectionLoader={connectionLoader}
@@ -57,13 +58,17 @@ export interface UserExecutorSecretsListPageProps extends GlobalExecutorSecretsL
 }
 
 export const UserExecutorSecretsListPage: FC<UserExecutorSecretsListPageProps> = props => {
-    useEffect(() => props.telemetryRecorder.recordEvent('executors.userSecretsList', 'view'), [props.telemetryRecorder])
+    useEffect(
+        () => props.telemetryRecorder.recordEvent('settings.executors.secretsList', 'view'),
+        [props.telemetryRecorder]
+    )
     const connectionLoader = useCallback(
         (scope: ExecutorSecretScope) => userExecutorSecretsConnectionFactory(props.userID, scope),
         [props.userID]
     )
     return (
         <ExecutorSecretsListPage
+            areaType="settings"
             namespaceID={props.userID}
             headerLine={
                 <>
@@ -85,13 +90,14 @@ export interface OrgExecutorSecretsListPageProps extends GlobalExecutorSecretsLi
 }
 
 export const OrgExecutorSecretsListPage: FC<OrgExecutorSecretsListPageProps> = props => {
-    useEffect(() => props.telemetryRecorder.recordEvent('executors.orgSecretsList', 'view'), [props.telemetryRecorder])
+    useEffect(() => props.telemetryRecorder.recordEvent('org.executors.secretsList', 'view'), [props.telemetryRecorder])
     const connectionLoader = useCallback(
         (scope: ExecutorSecretScope) => orgExecutorSecretsConnectionFactory(props.orgID, scope),
         [props.orgID]
     )
     return (
         <ExecutorSecretsListPage
+            areaType="org"
             namespaceID={props.orgID}
             headerLine={
                 <>
@@ -108,7 +114,11 @@ export const OrgExecutorSecretsListPage: FC<OrgExecutorSecretsListPageProps> = p
     )
 }
 
+type executorSecretsAreaType = 'admin' | 'org' | 'settings'
+
 export interface ExecutorSecretsListPageProps extends GlobalExecutorSecretsListPageProps {
+    // Used as a prefix for telemetry event naming
+    areaType: executorSecretsAreaType
     namespaceID: Scalars['ID'] | null
     headerLine: JSX.Element
     connectionLoader: (
@@ -120,6 +130,7 @@ export interface ExecutorSecretsListPageProps extends GlobalExecutorSecretsListP
 }
 
 const ExecutorSecretsListPage: FC<ExecutorSecretsListPageProps> = ({
+    areaType,
     namespaceID,
     headerLine,
     connectionLoader,
@@ -132,18 +143,18 @@ const ExecutorSecretsListPage: FC<ExecutorSecretsListPageProps> = ({
     const onClickAdd = useCallback<React.MouseEventHandler>(
         event => {
             event.preventDefault()
-            telemetryRecorder.recordEvent('executors.addSecret', 'click')
+            telemetryRecorder.recordEvent(`${areaType}.executors.addSecret`, 'click')
             setShowAddModal(true)
         },
         [telemetryRecorder]
     )
 
     const closeModal = useCallback(() => {
-        telemetryRecorder.recordEvent('executors.addSecret', 'cancel')
+        telemetryRecorder.recordEvent(`${areaType}.executors.addSecret`, 'cancel')
         setShowAddModal(false)
     }, [telemetryRecorder])
     const afterAction = useCallback(() => {
-        telemetryRecorder.recordEvent('executors.addSecret', 'submit')
+        telemetryRecorder.recordEvent(`${areaType}.executors.addSecret`, 'submit')
         setShowAddModal(false)
         refetchAll()
     }, [refetchAll, telemetryRecorder])

--- a/client/web/src/enterprise/insights/admin-ui/CodeInsightsJobs.tsx
+++ b/client/web/src/enterprise/insights/admin-ui/CodeInsightsJobs.tsx
@@ -1,8 +1,9 @@
-import { type ChangeEvent, type FC, useState } from 'react'
+import { type ChangeEvent, type FC, useState, useEffect } from 'react'
 
 import { mdiMapSearch } from '@mdi/js'
 
 import { BackfillQueueOrderBy, InsightQueueItemState } from '@sourcegraph/shared/src/graphql-operations'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import {
     Container,
     ErrorAlert,
@@ -25,7 +26,9 @@ import { GET_CODE_INSIGHTS_JOBS } from './query'
 
 import styles from './CodeInsightsJobs.module.scss'
 
-export const CodeInsightsJobs: FC = () => {
+interface Props extends TelemetryV2Props {}
+
+export const CodeInsightsJobs: FC<Props> = ({ telemetryRecorder }) => {
     const [search, setSearch] = useState<string>('')
     const [orderBy, setOrderBy] = useState<BackfillQueueOrderBy>(BackfillQueueOrderBy.QUEUE_POSITION)
     const [selectedJobs, setSelectedJobs] = useState<string[]>([])
@@ -33,6 +36,8 @@ export const CodeInsightsJobs: FC = () => {
         InsightQueueItemState.PROCESSING,
         InsightQueueItemState.QUEUED,
     ])
+
+    useEffect(() => telemetryRecorder.recordEvent('admin.codeInsightsJobs', 'view'), [telemetryRecorder])
 
     const { connection, loading, error, ...paginationProps } = usePageSwitcherPagination<
         GetCodeInsightsJobsResult,

--- a/client/web/src/enterprise/site-admin/SiteAdminPreciseIndexPage.tsx
+++ b/client/web/src/enterprise/site-admin/SiteAdminPreciseIndexPage.tsx
@@ -4,6 +4,7 @@ import { Navigate, useParams } from 'react-router-dom'
 import { catchError } from 'rxjs/operators'
 
 import { asError, type ErrorLike, isErrorLike } from '@sourcegraph/common'
+import type { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import { EVENT_LOGGER } from '@sourcegraph/shared/src/telemetry/web/eventLogger'
 import { LoadingSpinner, useObservable, ErrorAlert } from '@sourcegraph/wildcard'
 
@@ -11,12 +12,17 @@ import { PageTitle } from '../../components/PageTitle'
 
 import { fetchPreciseIndex } from './backend'
 
+interface Props extends TelemetryV2Props {}
+
 /**
  * A page displaying metadata about a precise index.
  */
-export const SiteAdminPreciseIndexPage: React.FC<{}> = () => {
+export const SiteAdminPreciseIndexPage: React.FC<Props> = ({ telemetryRecorder }) => {
     const { id = '' } = useParams<{ id: string }>()
-    useEffect(() => EVENT_LOGGER.logViewEvent('SiteAdminPreciseIndex'))
+    useEffect(() => {
+        EVENT_LOGGER.logViewEvent('SiteAdminPreciseIndex')
+        telemetryRecorder.recordEvent('admin.preciseIndex', 'view')
+    }, [telemetryRecorder])
 
     const indexOrError = useObservable(
         useMemo(() => fetchPreciseIndex({ id }).pipe(catchError((error): [ErrorLike] => [asError(error)])), [id])

--- a/client/web/src/site-admin/SiteAdminBackgroundJobsPage.tsx
+++ b/client/web/src/site-admin/SiteAdminBackgroundJobsPage.tsx
@@ -16,6 +16,7 @@ import { format } from 'date-fns'
 import { Timestamp } from '@sourcegraph/branded/src/components/Timestamp'
 import { pluralize } from '@sourcegraph/common'
 import { useQuery } from '@sourcegraph/http-client'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import {
     Button,
@@ -40,7 +41,7 @@ import { BACKGROUND_JOBS, BACKGROUND_JOBS_PAGE_POLL_INTERVAL_MS } from './backen
 
 import styles from './SiteAdminBackgroundJobsPage.module.scss'
 
-export interface SiteAdminBackgroundJobsPageProps extends TelemetryProps {}
+export interface SiteAdminBackgroundJobsPageProps extends TelemetryProps, TelemetryV2Props {}
 
 export type BackgroundJob = BackgroundJobsResult['backgroundJobs']['nodes'][0]
 export type BackgroundRoutine = BackgroundJob['routines'][0]
@@ -63,11 +64,12 @@ const routineTypeToIcon: Record<BackgroundRoutineType, string> = {
 
 export const SiteAdminBackgroundJobsPage: React.FunctionComponent<
     React.PropsWithChildren<SiteAdminBackgroundJobsPageProps>
-> = ({ telemetryService }) => {
+> = ({ telemetryService, telemetryRecorder }) => {
     // Log page view
     useEffect(() => {
         telemetryService.logPageView('SiteAdminBackgroundJobs')
-    }, [telemetryService])
+        telemetryRecorder.recordEvent('admin.backgroundJobs', 'view')
+    }, [telemetryService, telemetryRecorder])
 
     // Data query and polling setting
     const { data, loading, error, stopPolling, startPolling } = useQuery<BackgroundJobsResult, BackgroundJobsVariables>(

--- a/client/web/src/site-admin/SiteAdminConfigurationPage.tsx
+++ b/client/web/src/site-admin/SiteAdminConfigurationPage.tsx
@@ -531,7 +531,7 @@ class SiteAdminConfigurationContent extends React.Component<Props, State> {
 
     private reloadSite = (): void => {
         EVENT_LOGGER.log('SiteReloaded')
-        this.props.telemetryRecorder.recordEvent('admin.configuration.site', 'reload')
+        this.props.telemetryRecorder.recordEvent('admin.configuration', 'reloadInstance')
         this.siteReloads.next()
     }
 }

--- a/client/web/src/site-admin/SiteAdminCreateUserPage.tsx
+++ b/client/web/src/site-admin/SiteAdminCreateUserPage.tsx
@@ -5,6 +5,7 @@ import { Subject, Subscription } from 'rxjs'
 import { catchError, mergeMap, tap } from 'rxjs/operators'
 
 import { asError, logger } from '@sourcegraph/common'
+import type { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import { EVENT_LOGGER } from '@sourcegraph/shared/src/telemetry/web/eventLogger'
 import { Button, Link, Label, H2, Text, ErrorAlert, Form } from '@sourcegraph/wildcard'
 
@@ -31,10 +32,12 @@ interface State {
     email: string
 }
 
+interface Props extends TelemetryV2Props {}
+
 /**
  * A page with a form to create a user account.
  */
-export class SiteAdminCreateUserPage extends React.Component<{}, State> {
+export class SiteAdminCreateUserPage extends React.Component<Props, State> {
     public state: State = {
         loading: false,
         username: '',
@@ -46,6 +49,7 @@ export class SiteAdminCreateUserPage extends React.Component<{}, State> {
 
     public componentDidMount(): void {
         EVENT_LOGGER.logViewEvent('SiteAdminCreateUser')
+        this.props.telemetryRecorder.recordEvent('admin.users.create', 'view')
 
         this.subscriptions.add(
             this.submits

--- a/client/web/src/site-admin/SiteAdminFeatureFlagConfigurationPage.tsx
+++ b/client/web/src/site-admin/SiteAdminFeatureFlagConfigurationPage.tsx
@@ -9,6 +9,7 @@ import { catchError, map } from 'rxjs/operators'
 
 import { Toggle } from '@sourcegraph/branded/src/components/Toggle'
 import { asError, type ErrorLike, isErrorLike, pluralize } from '@sourcegraph/common'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import {
     Button,
@@ -41,18 +42,20 @@ import { UserSelect } from './user-select/UserSelect'
 
 import styles from './SiteAdminFeatureFlagConfigurationPage.module.scss'
 
-export interface SiteAdminFeatureFlagConfigurationProps extends TelemetryProps {
+export interface SiteAdminFeatureFlagConfigurationProps extends TelemetryProps, TelemetryV2Props {
     fetchFeatureFlags?: typeof defaultFetchFeatureFlags
     productVersion?: string
 }
 
 export const SiteAdminFeatureFlagConfigurationPage: FunctionComponent<
     React.PropsWithChildren<SiteAdminFeatureFlagConfigurationProps>
-> = ({ fetchFeatureFlags = defaultFetchFeatureFlags, productVersion = window.context.version }) => {
+> = ({ fetchFeatureFlags = defaultFetchFeatureFlags, productVersion = window.context.version, telemetryRecorder }) => {
     const { name = '' } = useParams<{ name: string }>()
     const navigate = useNavigate()
     const productGitVersion = parseProductReference(productVersion)
     const isCreateFeatureFlag = name === 'new'
+
+    useEffect(() => telemetryRecorder.recordEvent('admin.featureFlagConfiguration', 'view'), [telemetryRecorder])
 
     // Load the initial feature flag, unless we are creating a new feature flag.
     const featureFlagOrError = useObservable(

--- a/client/web/src/site-admin/SiteAdminFeatureFlagsPage.tsx
+++ b/client/web/src/site-admin/SiteAdminFeatureFlagsPage.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo } from 'react'
+import React, { useCallback, useEffect, useMemo } from 'react'
 
 import { mdiChevronRight } from '@mdi/js'
 import classNames from 'classnames'
@@ -7,6 +7,7 @@ import { catchError, map, mergeMap } from 'rxjs/operators'
 
 import { asError, type ErrorLike, isErrorLike, pluralize } from '@sourcegraph/common'
 import { aggregateStreamingSearch, type ContentMatch, LATEST_VERSION } from '@sourcegraph/shared/src/search/stream'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Link, PageHeader, Container, Code, H3, Text, Icon, Tooltip, ButtonLink } from '@sourcegraph/wildcard'
 
@@ -18,7 +19,7 @@ import { fetchFeatureFlags as defaultFetchFeatureFlags } from './backend'
 
 import styles from './SiteAdminFeatureFlagsPage.module.scss'
 
-interface SiteAdminFeatureFlagsPageProps extends TelemetryProps {
+interface SiteAdminFeatureFlagsPageProps extends TelemetryProps, TelemetryV2Props {
     fetchFeatureFlags?: typeof defaultFetchFeatureFlags
     productVersion?: string
 }
@@ -132,7 +133,7 @@ const filters: FilteredConnectionFilter[] = [
 
 export const SiteAdminFeatureFlagsPage: React.FunctionComponent<
     React.PropsWithChildren<SiteAdminFeatureFlagsPageProps>
-> = ({ fetchFeatureFlags = defaultFetchFeatureFlags, productVersion = window.context.version }) => {
+> = ({ fetchFeatureFlags = defaultFetchFeatureFlags, productVersion = window.context.version, telemetryRecorder }) => {
     // Try to parse out a git rev based on the product version, otherwise just fall back
     // to main.
     const productGitVersion = parseProductReference(productVersion)
@@ -187,6 +188,8 @@ export const SiteAdminFeatureFlagsPage: React.FunctionComponent<
             ),
         [featureFlagsOrErrorsObservable]
     )
+
+    useEffect(() => telemetryRecorder.recordEvent('admin.featureFlags', 'view'), [telemetryRecorder])
 
     return (
         <>

--- a/client/web/src/site-admin/SiteAdminGitservers.story.tsx
+++ b/client/web/src/site-admin/SiteAdminGitservers.story.tsx
@@ -2,6 +2,7 @@ import type { Decorator, Meta, StoryFn } from '@storybook/react'
 import { MATCH_ANY_PARAMETERS, WildcardMockLink } from 'wildcard-mock-link'
 
 import { getDocumentNode } from '@sourcegraph/http-client'
+import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
 
@@ -59,7 +60,10 @@ export const GitserversPage: StoryFn = () => (
     <WebStory>
         {() => (
             <MockedTestProvider link={mocks}>
-                <SiteAdminGitserversPage telemetryService={NOOP_TELEMETRY_SERVICE} />
+                <SiteAdminGitserversPage
+                    telemetryService={NOOP_TELEMETRY_SERVICE}
+                    telemetryRecorder={noOpTelemetryRecorder}
+                />
             </MockedTestProvider>
         )}
     </WebStory>

--- a/client/web/src/site-admin/SiteAdminGitserversPage.tsx
+++ b/client/web/src/site-admin/SiteAdminGitserversPage.tsx
@@ -3,6 +3,7 @@ import { type FC, useEffect } from 'react'
 import { mdiServer } from '@mdi/js'
 import classNames from 'classnames'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { H3, PageHeader, Text, ErrorAlert, LoadingSpinner } from '@sourcegraph/wildcard'
 
@@ -13,12 +14,13 @@ import { useGitserversConnection } from './backend'
 
 import styles from './SiteAdminGitserversPage.module.scss'
 
-export interface GitserversPageProps extends TelemetryProps {}
+export interface GitserversPageProps extends TelemetryProps, TelemetryV2Props {}
 
-export const SiteAdminGitserversPage: FC<GitserversPageProps> = ({ telemetryService }) => {
+export const SiteAdminGitserversPage: FC<GitserversPageProps> = ({ telemetryService, telemetryRecorder }) => {
     useEffect(() => {
         telemetryService.logPageView('SiteAdminGitserversPage')
-    }, [telemetryService])
+        telemetryRecorder.recordEvent('admin.gitServers', 'view')
+    }, [telemetryService, telemetryRecorder])
 
     const { data, loading, error } = useGitserversConnection()
 

--- a/client/web/src/site-admin/SiteAdminMigrationsPage.tsx
+++ b/client/web/src/site-admin/SiteAdminMigrationsPage.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo } from 'react'
+import React, { useCallback, useEffect, useMemo } from 'react'
 
 import { mdiAlertCircle, mdiAlert, mdiArrowLeftBold, mdiArrowRightBold } from '@mdi/js'
 import classNames from 'classnames'
@@ -8,6 +8,7 @@ import { parse as _parseVersion, type SemVer } from 'semver'
 
 import { Timestamp } from '@sourcegraph/branded/src/components/Timestamp'
 import { asError, type ErrorLike, isErrorLike } from '@sourcegraph/common'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import {
     LoadingSpinner,
@@ -35,7 +36,7 @@ import {
 
 import styles from './SiteAdminMigrationsPage.module.scss'
 
-export interface SiteAdminMigrationsPageProps extends TelemetryProps {
+export interface SiteAdminMigrationsPageProps extends TelemetryProps, TelemetryV2Props {
     fetchAllMigrations?: typeof defaultFetchAllMigrations
     fetchSiteUpdateCheck?: () => Observable<{ productVersion: string }>
     now?: () => Date
@@ -84,8 +85,12 @@ export const SiteAdminMigrationsPage: React.FunctionComponent<
     fetchAllMigrations = defaultFetchAllMigrations,
     fetchSiteUpdateCheck = defaultFetchSiteUpdateCheck,
     now,
-    telemetryService,
+    telemetryRecorder,
 }) => {
+    useEffect(() => {
+        telemetryRecorder.recordEvent('admin.migrations', 'view')
+    }, [telemetryRecorder])
+
     const migrationsOrError = useObservable(
         useMemo(
             () =>

--- a/client/web/src/site-admin/SiteAdminOnboardingTourPage.tsx
+++ b/client/web/src/site-admin/SiteAdminOnboardingTourPage.tsx
@@ -1,9 +1,10 @@
-import { type FC, type PropsWithChildren, useState, useMemo } from 'react'
+import { type FC, type PropsWithChildren, useState, useMemo, useEffect } from 'react'
 
 import AJV from 'ajv'
 import addFormats from 'ajv-formats'
 
 import { useMutation, useQuery } from '@sourcegraph/http-client'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { useIsLightTheme } from '@sourcegraph/shared/src/theme'
 import {
@@ -49,9 +50,9 @@ const DEFAULT_VALUE = JSON.stringify(
 const ajv = new AJV({ strict: false })
 addFormats(ajv)
 
-interface Props extends TelemetryProps {}
+interface Props extends TelemetryProps, TelemetryV2Props {}
 
-export const SiteAdminOnboardingTourPage: FC<PropsWithChildren<Props>> = () => {
+export const SiteAdminOnboardingTourPage: FC<PropsWithChildren<Props>> = ({ telemetryRecorder }) => {
     const isLightTheme = useIsLightTheme()
     const [value, setValue] = useState<string | null>(null)
     const { data, loading, error, previousData } = useQuery<OnboardingTourConfigResult, OnboardingTourConfigVariables>(
@@ -62,6 +63,10 @@ export const SiteAdminOnboardingTourPage: FC<PropsWithChildren<Props>> = () => {
     const initialLoad = loading && !previousData
     const config = loading ? value ?? '' : value ?? existingConfiguration ?? DEFAULT_VALUE
     const dirty = !loading && config !== existingConfiguration
+
+    useEffect(() => {
+        telemetryRecorder.recordEvent('admin.endUserOnboarding', 'view')
+    }, [telemetryRecorder])
 
     const discard = (): void => {
         if (dirty && window.confirm('Discard onboarding tour changes?')) {

--- a/client/web/src/site-admin/SiteAdminOrgsPage.tsx
+++ b/client/web/src/site-admin/SiteAdminOrgsPage.tsx
@@ -4,6 +4,7 @@ import { mdiCog, mdiAccount, mdiDelete, mdiPlus } from '@mdi/js'
 import { Subject } from 'rxjs'
 
 import { asError, isErrorLike, pluralize } from '@sourcegraph/common'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Button, Link, Icon, H2, Text, Tooltip, ErrorAlert } from '@sourcegraph/wildcard'
 
@@ -91,18 +92,22 @@ const OrgNode: React.FunctionComponent<React.PropsWithChildren<OrgNodeProps>> = 
     )
 }
 
-interface Props extends TelemetryProps {}
+interface Props extends TelemetryProps, TelemetryV2Props {}
 
 /**
  * A page displaying the orgs on this site.
  */
-export const SiteAdminOrgsPage: React.FunctionComponent<React.PropsWithChildren<Props>> = ({ telemetryService }) => {
+export const SiteAdminOrgsPage: React.FunctionComponent<React.PropsWithChildren<Props>> = ({
+    telemetryService,
+    telemetryRecorder,
+}) => {
     const orgUpdates = useMemo(() => new Subject<void>(), [])
     const onDidUpdateOrg = useCallback((): void => orgUpdates.next(), [orgUpdates])
 
     useEffect(() => {
         telemetryService.logViewEvent('SiteAdminOrgs')
-    }, [telemetryService])
+        telemetryRecorder.recordEvent('admin.orgs', 'view')
+    }, [telemetryService, telemetryRecorder])
 
     return (
         <div className="site-admin-orgs-page">

--- a/client/web/src/site-admin/SiteAdminOutboundRequestsPage.tsx
+++ b/client/web/src/site-admin/SiteAdminOutboundRequestsPage.tsx
@@ -9,6 +9,7 @@ import { delay, map } from 'rxjs/operators'
 
 import { Timestamp } from '@sourcegraph/branded/src/components/Timestamp'
 import { useQuery } from '@sourcegraph/http-client/src'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import {
     Button,
@@ -40,7 +41,7 @@ import { parseProductReference } from './SiteAdminFeatureFlagsPage'
 
 import styles from './SiteAdminOutboundRequestsPage.module.scss'
 
-export interface SiteAdminOutboundRequestsPageProps extends TelemetryProps {}
+export interface SiteAdminOutboundRequestsPageProps extends TelemetryProps, TelemetryV2Props {}
 
 export type OutboundRequest = OutboundRequestsResult['outboundRequests']['nodes'][0]
 
@@ -74,12 +75,13 @@ const filters: FilteredConnectionFilter[] = [
 
 export const SiteAdminOutboundRequestsPage: React.FunctionComponent<
     React.PropsWithChildren<SiteAdminOutboundRequestsPageProps>
-> = ({ telemetryService }) => {
+> = ({ telemetryService, telemetryRecorder }) => {
     const [items, setItems] = useState<OutboundRequest[]>([])
 
     useEffect(() => {
         telemetryService.logPageView('SiteAdminOutboundRequests')
-    }, [telemetryService])
+        telemetryRecorder.recordEvent('admin.outboundRequests', 'view')
+    }, [telemetryService, telemetryRecorder])
 
     const lastId = items.at(-1)?.id ?? null
     const { data, loading, error, stopPolling, refetch, startPolling } = useQuery<

--- a/client/web/src/site-admin/SiteAdminPackagesPage.tsx
+++ b/client/web/src/site-admin/SiteAdminPackagesPage.tsx
@@ -6,6 +6,7 @@ import { useLocation, useNavigate } from 'react-router-dom'
 
 import { dataOrThrowErrors, useQuery } from '@sourcegraph/http-client'
 import { RepoLink } from '@sourcegraph/shared/src/components/RepoLink'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import {
     Container,
@@ -147,7 +148,7 @@ const PackageNode: React.FunctionComponent<React.PropsWithChildren<PackageNodePr
     )
 }
 
-interface SiteAdminPackagesPageProps extends TelemetryProps {}
+interface SiteAdminPackagesPageProps extends TelemetryProps, TelemetryV2Props {}
 
 const DEFAULT_FIRST = 15
 
@@ -161,6 +162,7 @@ interface PackagesModalState {
  */
 export const SiteAdminPackagesPage: React.FunctionComponent<React.PropsWithChildren<SiteAdminPackagesPageProps>> = ({
     telemetryService,
+    telemetryRecorder,
 }) => {
     const location = useLocation()
     const navigate = useNavigate()
@@ -168,7 +170,8 @@ export const SiteAdminPackagesPage: React.FunctionComponent<React.PropsWithChild
 
     useEffect(() => {
         telemetryService.logPageView('SiteAdminPackages')
-    }, [telemetryService])
+        telemetryRecorder.recordEvent('admin.packages', 'view')
+    }, [telemetryService, telemetryRecorder])
 
     const {
         loading: extSvcLoading,

--- a/client/web/src/site-admin/SiteAdminPingsPage.tsx
+++ b/client/web/src/site-admin/SiteAdminPingsPage.tsx
@@ -15,6 +15,7 @@ import {
     jsonHighlighting,
     useCodeMirror,
 } from '@sourcegraph/shared/src/components/CodeMirrorEditor'
+import type { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import { EVENT_LOGGER } from '@sourcegraph/shared/src/telemetry/web/eventLogger'
 import { useIsLightTheme } from '@sourcegraph/shared/src/theme'
 import { Container, H3, Link, LoadingSpinner, PageHeader, Text, useObservable } from '@sourcegraph/wildcard'
@@ -30,19 +31,20 @@ const theme = EditorView.theme({
     },
 })
 
-interface Props {}
+interface Props extends TelemetryV2Props {}
 
 /**
  * A page displaying information about telemetry pings for the site.
  */
-export const SiteAdminPingsPage: React.FunctionComponent<React.PropsWithChildren<Props>> = () => {
+export const SiteAdminPingsPage: React.FunctionComponent<React.PropsWithChildren<Props>> = ({ telemetryRecorder }) => {
     const isLightTheme = useIsLightTheme()
     const latestPing = useObservable(
         useMemo(() => fromFetch<{}>('/site-admin/pings/latest', { selector: response => checkOk(response).json() }), [])
     )
     useEffect(() => {
         EVENT_LOGGER.logViewEvent('SiteAdminPings')
-    }, [])
+        telemetryRecorder.recordEvent('admin.pings', 'view')
+    }, [telemetryRecorder])
 
     const updatesDisabled = window.context.site['update.channel'] !== 'release'
     const jsonEditorContainerRef = useRef<HTMLDivElement | null>(null)

--- a/client/web/src/site-admin/SiteAdminReportBugPage.tsx
+++ b/client/web/src/site-admin/SiteAdminReportBugPage.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react'
+import React, { useEffect, useMemo } from 'react'
 
 import { mapValues, values } from 'lodash'
 
@@ -116,6 +116,8 @@ export const SiteAdminReportBugPage: React.FunctionComponent<React.PropsWithChil
     telemetryService,
     telemetryRecorder,
 }) => {
+    useEffect(() => telemetryRecorder.recordEvent('admin.reportBug', 'view'), [telemetryRecorder])
+
     const isLightTheme = useIsLightTheme()
     const allConfig = useObservable(useMemo(fetchAllConfigAndSettings, []))
     return (

--- a/client/web/src/site-admin/SiteAdminRepositoriesPage.tsx
+++ b/client/web/src/site-admin/SiteAdminRepositoriesPage.tsx
@@ -4,6 +4,7 @@ import { useApolloClient } from '@apollo/client'
 import { useLocation } from 'react-router-dom'
 
 import { logger } from '@sourcegraph/common'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Alert, Link, PageHeader } from '@sourcegraph/wildcard'
 
@@ -12,17 +13,19 @@ import { refreshSiteFlags } from '../site/backend'
 
 import { SiteAdminRepositoriesContainer } from './SiteAdminRepositoriesContainer'
 
-interface Props extends TelemetryProps {}
+interface Props extends TelemetryProps, TelemetryV2Props {}
 
 /** A page displaying the repositories on this site */
 export const SiteAdminRepositoriesPage: React.FunctionComponent<React.PropsWithChildren<Props>> = ({
     telemetryService,
+    telemetryRecorder,
 }) => {
     const location = useLocation()
 
     useEffect(() => {
         telemetryService.logPageView('SiteAdminRepos')
-    }, [telemetryService])
+        telemetryRecorder.recordEvent('admin.repos', 'view')
+    }, [telemetryService, telemetryRecorder])
 
     // Refresh global alert about enabling repositories when the user visits & navigates away from this page.
     const client = useApolloClient()

--- a/client/web/src/site-admin/SiteAdminSettingsPage.tsx
+++ b/client/web/src/site-admin/SiteAdminSettingsPage.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 
 import type { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
 import type { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { useIsLightTheme } from '@sourcegraph/shared/src/theme'
 import { Text } from '@sourcegraph/wildcard'
@@ -11,7 +12,7 @@ import { PageTitle } from '../components/PageTitle'
 import type { SiteResult } from '../graphql-operations'
 import { SettingsArea } from '../settings/SettingsArea'
 
-interface Props extends PlatformContextProps, SettingsCascadeProps, TelemetryProps {
+interface Props extends PlatformContextProps, SettingsCascadeProps, TelemetryProps, TelemetryV2Props {
     authenticatedUser: AuthenticatedUser
     site: Pick<SiteResult['site'], '__typename' | 'id'>
 }

--- a/client/web/src/site-admin/SiteAdminSlowRequestsPage.tsx
+++ b/client/web/src/site-admin/SiteAdminSlowRequestsPage.tsx
@@ -7,6 +7,7 @@ import { map } from 'rxjs/operators'
 
 import { Timestamp } from '@sourcegraph/branded/src/components/Timestamp'
 import { dataOrThrowErrors } from '@sourcegraph/http-client'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import {
     Button,
@@ -36,7 +37,7 @@ import { SLOW_REQUESTS } from './backend'
 
 import styles from './SiteAdminSlowRequestsPage.module.scss'
 
-export interface SiteAdminSlowRequestsPageProps extends TelemetryProps {}
+export interface SiteAdminSlowRequestsPageProps extends TelemetryProps, TelemetryV2Props {}
 
 type SlowRequest = SlowRequestsResult['slowRequests']['nodes'][0]
 
@@ -70,10 +71,11 @@ const filters: FilteredConnectionFilter[] = [
 
 export const SiteAdminSlowRequestsPage: React.FunctionComponent<
     React.PropsWithChildren<SiteAdminSlowRequestsPageProps>
-> = ({ telemetryService }) => {
+> = ({ telemetryService, telemetryRecorder }) => {
     useEffect(() => {
         telemetryService.logPageView('SiteAdminSlowRequests')
-    }, [telemetryService])
+        telemetryRecorder.recordEvent('admin.slowRequests', 'view')
+    }, [telemetryService, telemetryRecorder])
 
     const querySlowRequests = useCallback(
         (args: FilteredConnectionQueryArguments & { failed?: boolean }) =>

--- a/client/web/src/site-admin/SiteAdminSurveyResponsesPage.tsx
+++ b/client/web/src/site-admin/SiteAdminSurveyResponsesPage.tsx
@@ -4,6 +4,7 @@ import classNames from 'classnames'
 import { Subscription } from 'rxjs'
 
 import { Timestamp } from '@sourcegraph/branded/src/components/Timestamp'
+import type { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import { EVENT_LOGGER } from '@sourcegraph/shared/src/telemetry/web/eventLogger'
 import {
     Badge,
@@ -311,19 +312,22 @@ class SiteAdminSurveyResponsesSummary extends React.PureComponent<{}, SiteAdminS
     }
 }
 
-interface Props {}
+interface Props extends TelemetryV2Props {}
 
 const LAST_TAB_STORAGE_KEY = 'site-admin-survey-responses-last-tab'
 /**
  * A page displaying the survey responses on this site.
  */
 
-export const SiteAdminSurveyResponsesPage: React.FunctionComponent<React.PropsWithChildren<Props>> = () => {
+export const SiteAdminSurveyResponsesPage: React.FunctionComponent<React.PropsWithChildren<Props>> = ({
+    telemetryRecorder,
+}) => {
     const [persistedTabIndex, setPersistedTabIndex] = useLocalStorage(LAST_TAB_STORAGE_KEY, 0)
 
     useEffect(() => {
         EVENT_LOGGER.logViewEvent('SiteAdminSurveyResponses')
-    }, [])
+        telemetryRecorder.recordEvent('admin.surveyResponses', 'view')
+    }, [telemetryRecorder])
 
     return (
         <div className="site-admin-survey-responses-page">

--- a/client/web/src/site-admin/SiteAdminTokensPage.tsx
+++ b/client/web/src/site-admin/SiteAdminTokensPage.tsx
@@ -3,6 +3,7 @@ import React, { useCallback, useMemo } from 'react'
 import { mdiPlus } from '@mdi/js'
 import { Subject } from 'rxjs'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Button, ButtonLink, Container, Icon, PageHeader, Tooltip } from '@sourcegraph/wildcard'
 
@@ -14,7 +15,7 @@ import { AccessTokenNode, type AccessTokenNodeProps } from '../settings/tokens/A
 
 import { queryAccessTokens } from './backend'
 
-interface Props extends TelemetryProps {
+interface Props extends TelemetryProps, TelemetryV2Props {
     authenticatedUser: AuthenticatedUser
 }
 
@@ -24,10 +25,12 @@ interface Props extends TelemetryProps {
 export const SiteAdminTokensPage: React.FunctionComponent<React.PropsWithChildren<Props>> = ({
     authenticatedUser,
     telemetryService,
+    telemetryRecorder,
 }) => {
     useMemo(() => {
         telemetryService.logViewEvent('SiteAdminTokens')
-    }, [telemetryService])
+        telemetryRecorder.recordEvent('admin.tokens', 'view')
+    }, [telemetryService, telemetryRecorder])
     const accessTokenUpdates = useMemo(() => new Subject<void>(), [])
     const onDidUpdateAccessToken = useCallback(() => accessTokenUpdates.next(), [accessTokenUpdates])
     const accessTokensEnabled = window.context.accessTokensAllow !== 'none'

--- a/client/web/src/site-admin/SiteAdminUpdatesPage.tsx
+++ b/client/web/src/site-admin/SiteAdminUpdatesPage.tsx
@@ -6,6 +6,7 @@ import { parseISO, formatDistance } from 'date-fns'
 
 import { Toggle } from '@sourcegraph/branded/src/components/Toggle'
 import { useQuery, useMutation } from '@sourcegraph/http-client'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import {
     LoadingSpinner,
@@ -42,7 +43,7 @@ import { SITE_UPDATE_CHECK, SITE_UPGRADE_READINESS, SET_AUTO_UPGRADE } from './b
 
 import styles from './SiteAdminUpdatesPage.module.scss'
 
-interface Props extends TelemetryProps {}
+interface Props extends TelemetryProps, TelemetryV2Props {}
 const capitalize = (text: string): string => (text && text[0].toUpperCase() + text.slice(1)) || ''
 
 const SiteUpdateCheck: React.FC = () => {
@@ -390,10 +391,11 @@ const SiteUpgradeReadiness: FunctionComponent = () => {
 /**
  * A page displaying information about available updates for the Sourcegraph instance. As well as the readiness status of the instance for upgrade.
  */
-export const SiteAdminUpdatesPage: React.FC<Props> = ({ telemetryService }) => {
+export const SiteAdminUpdatesPage: React.FC<Props> = ({ telemetryService, telemetryRecorder }) => {
     useMemo(() => {
         telemetryService.logViewEvent('SiteAdminUpdates')
-    }, [telemetryService])
+        telemetryRecorder.recordEvent('admin.updates', 'view')
+    }, [telemetryService, telemetryRecorder])
 
     return (
         <div>

--- a/client/web/src/site-admin/SiteAdminWebhookCreatePage.story.tsx
+++ b/client/web/src/site-admin/SiteAdminWebhookCreatePage.story.tsx
@@ -4,6 +4,7 @@ import { WildcardMockLink } from 'wildcard-mock-link'
 
 import { getDocumentNode } from '@sourcegraph/http-client'
 import { ExternalServiceKind } from '@sourcegraph/shared/src/graphql-operations'
+import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
 
@@ -56,7 +57,10 @@ export const WebhookCreatePage: StoryFn = () => {
         <WebStory>
             {() => (
                 <MockedTestProvider link={mocks}>
-                    <SiteAdminWebhookCreatePage telemetryService={NOOP_TELEMETRY_SERVICE} />
+                    <SiteAdminWebhookCreatePage
+                        telemetryService={NOOP_TELEMETRY_SERVICE}
+                        telemetryRecorder={noOpTelemetryRecorder}
+                    />
                 </MockedTestProvider>
             )}
         </WebStory>
@@ -79,7 +83,10 @@ export const WebhookCreatePageWithError: StoryFn = () => {
         <WebStory>
             {() => (
                 <MockedTestProvider mocks={mockedResponse}>
-                    <SiteAdminWebhookCreatePage telemetryService={NOOP_TELEMETRY_SERVICE} />
+                    <SiteAdminWebhookCreatePage
+                        telemetryService={NOOP_TELEMETRY_SERVICE}
+                        telemetryRecorder={noOpTelemetryRecorder}
+                    />
                 </MockedTestProvider>
             )}
         </WebStory>

--- a/client/web/src/site-admin/SiteAdminWebhookCreatePage.tsx
+++ b/client/web/src/site-admin/SiteAdminWebhookCreatePage.tsx
@@ -2,6 +2,7 @@ import { type FC, useEffect } from 'react'
 
 import { mdiWebhook } from '@mdi/js'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Container, PageHeader } from '@sourcegraph/wildcard'
 
@@ -9,12 +10,16 @@ import { PageTitle } from '../components/PageTitle'
 
 import { WebhookCreateUpdatePage } from './WebhookCreateUpdatePage'
 
-export interface SiteAdminWebhookCreatePageProps extends TelemetryProps {}
+export interface SiteAdminWebhookCreatePageProps extends TelemetryProps, TelemetryV2Props {}
 
-export const SiteAdminWebhookCreatePage: FC<SiteAdminWebhookCreatePageProps> = ({ telemetryService }) => {
+export const SiteAdminWebhookCreatePage: FC<SiteAdminWebhookCreatePageProps> = ({
+    telemetryService,
+    telemetryRecorder,
+}) => {
     useEffect(() => {
         telemetryService.logPageView('SiteAdminWebhookCreatePage')
-    }, [telemetryService])
+        telemetryRecorder.recordEvent('admin.webhook.create', 'view')
+    }, [telemetryService, telemetryRecorder])
 
     return (
         <Container>

--- a/client/web/src/site-admin/SiteAdminWebhookPage.story.tsx
+++ b/client/web/src/site-admin/SiteAdminWebhookPage.story.tsx
@@ -5,6 +5,7 @@ import { MATCH_ANY_PARAMETERS, WildcardMockLink } from 'wildcard-mock-link'
 
 import { getDocumentNode } from '@sourcegraph/http-client'
 import { ExternalServiceKind } from '@sourcegraph/shared/src/graphql-operations'
+import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
 
@@ -114,7 +115,12 @@ export const SiteAdminWebhookPageStory: StoryFn = args => {
                     <Routes>
                         <Route
                             path="/site-admin/webhooks/incoming/:id"
-                            element={<SiteAdminWebhookPage telemetryService={NOOP_TELEMETRY_SERVICE} />}
+                            element={
+                                <SiteAdminWebhookPage
+                                    telemetryService={NOOP_TELEMETRY_SERVICE}
+                                    telemetryRecorder={noOpTelemetryRecorder}
+                                />
+                            }
                         />
                     </Routes>
                 </MockedTestProvider>
@@ -179,7 +185,10 @@ export const SiteAdminWebhookPageWithoutLogsStory: StoryFn = args => {
         <WebStory>
             {() => (
                 <MockedTestProvider link={buildWebhookLogsMock}>
-                    <SiteAdminWebhookPage telemetryService={NOOP_TELEMETRY_SERVICE} />
+                    <SiteAdminWebhookPage
+                        telemetryService={NOOP_TELEMETRY_SERVICE}
+                        telemetryRecorder={noOpTelemetryRecorder}
+                    />
                 </MockedTestProvider>
             )}
         </WebStory>

--- a/client/web/src/site-admin/SiteAdminWebhookPage.tsx
+++ b/client/web/src/site-admin/SiteAdminWebhookPage.tsx
@@ -5,6 +5,7 @@ import { noop } from 'lodash'
 import { useNavigate, useParams } from 'react-router-dom'
 
 import { useMutation } from '@sourcegraph/http-client'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import {
     Button,
@@ -39,10 +40,10 @@ import { WebhookLogNode } from './webhooks/WebhookLogNode'
 
 import styles from './SiteAdminWebhookPage.module.scss'
 
-export interface WebhookPageProps extends TelemetryProps {}
+export interface WebhookPageProps extends TelemetryProps, TelemetryV2Props {}
 
 export const SiteAdminWebhookPage: FC<WebhookPageProps> = props => {
-    const { telemetryService } = props
+    const { telemetryService, telemetryRecorder } = props
 
     const { id = '' } = useParams<{ id: string }>()
     const navigate = useNavigate()
@@ -53,7 +54,8 @@ export const SiteAdminWebhookPage: FC<WebhookPageProps> = props => {
 
     useEffect(() => {
         telemetryService.logPageView('SiteAdminWebhook')
-    }, [telemetryService])
+        telemetryRecorder.recordEvent('admin.webhook', 'view')
+    }, [telemetryService, telemetryRecorder])
 
     const [deleteWebhook, { error: deleteError, loading: isDeleting }] = useMutation<
         DeleteWebhookResult,

--- a/client/web/src/site-admin/SiteAdminWebhookUpdatePage.story.tsx
+++ b/client/web/src/site-admin/SiteAdminWebhookUpdatePage.story.tsx
@@ -4,6 +4,7 @@ import { WildcardMockLink } from 'wildcard-mock-link'
 
 import { getDocumentNode } from '@sourcegraph/http-client'
 import { ExternalServiceKind } from '@sourcegraph/shared/src/graphql-operations'
+import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
 
@@ -88,7 +89,12 @@ export const WebhookUpdatePage: StoryFn = () => (
                 <Routes>
                     <Route
                         path="/site-admin/webhooks/incoming/:id"
-                        element={<SiteAdminWebhookUpdatePage telemetryService={NOOP_TELEMETRY_SERVICE} />}
+                        element={
+                            <SiteAdminWebhookUpdatePage
+                                telemetryService={NOOP_TELEMETRY_SERVICE}
+                                telemetryRecorder={noOpTelemetryRecorder}
+                            />
+                        }
                     />
                 </Routes>
             </MockedTestProvider>

--- a/client/web/src/site-admin/SiteAdminWebhookUpdatePage.tsx
+++ b/client/web/src/site-admin/SiteAdminWebhookUpdatePage.tsx
@@ -3,6 +3,7 @@ import { type FC, useEffect } from 'react'
 import { mdiWebhook } from '@mdi/js'
 import { useParams } from 'react-router-dom'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Container, PageHeader } from '@sourcegraph/wildcard'
 
@@ -13,12 +14,16 @@ import { PageTitle } from '../components/PageTitle'
 import { useWebhookQuery } from './backend'
 import { WebhookCreateUpdatePage } from './WebhookCreateUpdatePage'
 
-export interface SiteAdminWebhookUpdatePageProps extends TelemetryProps {}
+export interface SiteAdminWebhookUpdatePageProps extends TelemetryProps, TelemetryV2Props {}
 
-export const SiteAdminWebhookUpdatePage: FC<SiteAdminWebhookUpdatePageProps> = ({ telemetryService }) => {
+export const SiteAdminWebhookUpdatePage: FC<SiteAdminWebhookUpdatePageProps> = ({
+    telemetryService,
+    telemetryRecorder,
+}) => {
     useEffect(() => {
         telemetryService.logPageView('SiteAdminWebhookUpdatePage')
-    }, [telemetryService])
+        telemetryRecorder.recordEvent('admin.webhook.update', 'view')
+    }, [telemetryService, telemetryRecorder])
 
     const { id = '' } = useParams<{ id: string }>()
 

--- a/client/web/src/site-admin/SiteAdminWebhooksPage.story.tsx
+++ b/client/web/src/site-admin/SiteAdminWebhooksPage.story.tsx
@@ -3,6 +3,7 @@ import { MATCH_ANY_PARAMETERS, WildcardMockLink } from 'wildcard-mock-link'
 
 import { getDocumentNode } from '@sourcegraph/http-client'
 import { ExternalServiceKind } from '@sourcegraph/shared/src/graphql-operations'
+import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
 
@@ -65,7 +66,10 @@ export const NoWebhooksFound: StoryFn = () => (
                     ])
                 }
             >
-                <SiteAdminWebhooksPage telemetryService={NOOP_TELEMETRY_SERVICE} />
+                <SiteAdminWebhooksPage
+                    telemetryService={NOOP_TELEMETRY_SERVICE}
+                    telemetryRecorder={noOpTelemetryRecorder}
+                />
             </MockedTestProvider>
         )}
     </WebStory>
@@ -169,7 +173,10 @@ export const FiveWebhooksFound: StoryFn = () => (
                     ])
                 }
             >
-                <SiteAdminWebhooksPage telemetryService={NOOP_TELEMETRY_SERVICE} />
+                <SiteAdminWebhooksPage
+                    telemetryService={NOOP_TELEMETRY_SERVICE}
+                    telemetryRecorder={noOpTelemetryRecorder}
+                />
             </MockedTestProvider>
         )}
     </WebStory>

--- a/client/web/src/site-admin/SiteAdminWebhooksPage.tsx
+++ b/client/web/src/site-admin/SiteAdminWebhooksPage.tsx
@@ -2,6 +2,7 @@ import React, { useEffect } from 'react'
 
 import { mdiWebhook, mdiMapSearch, mdiPlus } from '@mdi/js'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { ButtonLink, Container, Icon, PageHeader } from '@sourcegraph/wildcard'
 
@@ -22,14 +23,16 @@ import { PerformanceGauge } from './webhooks/PerformanceGauge'
 
 import styles from './SiteAdminWebhooksPage.module.scss'
 
-interface Props extends TelemetryProps {}
+interface Props extends TelemetryProps, TelemetryV2Props {}
 
 export const SiteAdminWebhooksPage: React.FunctionComponent<React.PropsWithChildren<Props>> = ({
     telemetryService,
+    telemetryRecorder,
 }) => {
     useEffect(() => {
         telemetryService.logPageView('SiteAdminWebhooks')
-    }, [telemetryService])
+        telemetryRecorder.recordEvent('admin.webhooks', 'view')
+    }, [telemetryService, telemetryRecorder])
 
     const { loading, hasNextPage, fetchMore, connection, error } = useWebhooksConnection()
     const headerTotals = useWebhookPageHeader()

--- a/client/web/src/site-admin/UserManagement/index.tsx
+++ b/client/web/src/site-admin/UserManagement/index.tsx
@@ -3,6 +3,7 @@ import React, { useEffect, useMemo } from 'react'
 import { mdiAccount, mdiPlus, mdiDownload } from '@mdi/js'
 
 import { useQuery } from '@sourcegraph/http-client'
+import type { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import { EVENT_LOGGER } from '@sourcegraph/shared/src/telemetry/web/eventLogger'
 import { H1, Card, Text, Icon, Button, Link, Alert, LoadingSpinner, AnchorLink } from '@sourcegraph/wildcard'
 
@@ -15,7 +16,7 @@ import { USERS_MANAGEMENT_SUMMARY } from './queries'
 
 import styles from './index.module.scss'
 
-export interface UsersManagementProps {
+export interface UsersManagementProps extends TelemetryV2Props {
     renderAssignmentModal: (
         onCancel: () => void,
         onSuccess: (user: { username: string }) => void,
@@ -23,10 +24,14 @@ export interface UsersManagementProps {
     ) => React.ReactNode
 }
 
-export const UsersManagement: React.FunctionComponent<UsersManagementProps> = ({ renderAssignmentModal }) => {
+export const UsersManagement: React.FunctionComponent<UsersManagementProps> = ({
+    renderAssignmentModal,
+    telemetryRecorder,
+}) => {
     useEffect(() => {
         EVENT_LOGGER.logPageView('UsersManagement')
-    }, [])
+        telemetryRecorder.recordEvent('admin.users', 'view')
+    }, [telemetryRecorder])
 
     const { data, error, loading, refetch } = useQuery<UsersManagementSummaryResult, UsersManagementSummaryVariables>(
         USERS_MANAGEMENT_SUMMARY,

--- a/client/web/src/site-admin/analytics/AnalyticsBatchChangesPage/index.tsx
+++ b/client/web/src/site-admin/analytics/AnalyticsBatchChangesPage/index.tsx
@@ -3,6 +3,7 @@ import React, { useMemo, useEffect } from 'react'
 import { startCase } from 'lodash'
 
 import { useQuery } from '@sourcegraph/http-client'
+import type { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import { EVENT_LOGGER } from '@sourcegraph/shared/src/telemetry/web/eventLogger'
 import { Card, LoadingSpinner, H2, Text, LineChart, type Series } from '@sourcegraph/wildcard'
 
@@ -19,8 +20,10 @@ import { BATCHCHANGES_STATISTICS } from './queries'
 
 export const DEFAULT_MINS_SAVED_PER_CHANGESET = 15
 
-export const AnalyticsBatchChangesPage: React.FunctionComponent = () => {
-    const { dateRange, grouping } = useChartFilters({ name: 'BatchChanges' })
+interface Props extends TelemetryV2Props {}
+
+export const AnalyticsBatchChangesPage: React.FunctionComponent<Props> = ({ telemetryRecorder }) => {
+    const { dateRange, grouping } = useChartFilters({ name: 'BatchChanges', telemetryRecorder })
     const { data, error, loading } = useQuery<BatchChangesStatisticsResult, BatchChangesStatisticsVariables>(
         BATCHCHANGES_STATISTICS,
         {
@@ -32,7 +35,8 @@ export const AnalyticsBatchChangesPage: React.FunctionComponent = () => {
     )
     useEffect(() => {
         EVENT_LOGGER.logPageView('AdminAnalyticsBatchChanges')
-    }, [])
+        telemetryRecorder.recordEvent('admin.analytics.batchChanges', 'view')
+    }, [telemetryRecorder])
     const [stats, legends, calculatorProps] = useMemo(() => {
         if (!data) {
             return []
@@ -94,10 +98,11 @@ export const AnalyticsBatchChangesPage: React.FunctionComponent = () => {
             description:
                 'Batch Changes automates opening changesets across many repositories and codehosts. It also significantly reduces the time required to manage cross-repository changes via tracking and management functions that are superior to custom solutions, spreadsheets and manually reaching out to developers.',
             temporarySettingsKey: 'batches.minSavedPerChangeset',
+            telemetryRecorder,
         }
 
         return [stats, legends, calculatorProps]
-    }, [data, dateRange.value])
+    }, [data, dateRange.value, telemetryRecorder])
 
     if (error) {
         throw error

--- a/client/web/src/site-admin/analytics/AnalyticsCodeInsightsPage/index.tsx
+++ b/client/web/src/site-admin/analytics/AnalyticsCodeInsightsPage/index.tsx
@@ -3,6 +3,7 @@ import React, { useMemo, useEffect } from 'react'
 import { startCase } from 'lodash'
 
 import { useQuery } from '@sourcegraph/http-client'
+import type { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import { EVENT_LOGGER } from '@sourcegraph/shared/src/telemetry/web/eventLogger'
 import { Card, LoadingSpinner, Text, LineChart, type Series, H2 } from '@sourcegraph/wildcard'
 
@@ -36,8 +37,14 @@ export const calculateMinutesSaved = (data: typeof MinutesSaved): number =>
     data.LanguageSeries * MinutesSaved.LanguageSeries +
     data.ComputeSeries * MinutesSaved.ComputeSeries
 
-export const AnalyticsCodeInsightsPage: React.FunctionComponent = () => {
-    const { dateRange, aggregation, grouping } = useChartFilters({ name: 'Insights', aggregation: 'count' })
+interface Props extends TelemetryV2Props {}
+
+export const AnalyticsCodeInsightsPage: React.FunctionComponent<Props> = ({ telemetryRecorder }) => {
+    const { dateRange, aggregation, grouping } = useChartFilters({
+        name: 'Insights',
+        aggregation: 'count',
+        telemetryRecorder,
+    })
     const { data, error, loading } = useQuery<InsightsStatisticsResult, InsightsStatisticsVariables>(
         INSIGHTS_STATISTICS,
         {
@@ -49,7 +56,8 @@ export const AnalyticsCodeInsightsPage: React.FunctionComponent = () => {
     )
     useEffect(() => {
         EVENT_LOGGER.logPageView('AdminAnalyticsCodeInsights')
-    }, [])
+        telemetryRecorder.recordEvent('admin.analytics.codeInsights', 'view')
+    }, [telemetryRecorder])
 
     const legends = useMemo(() => {
         if (!data) {

--- a/client/web/src/site-admin/analytics/AnalyticsCodeIntelPage/index.tsx
+++ b/client/web/src/site-admin/analytics/AnalyticsCodeIntelPage/index.tsx
@@ -4,6 +4,7 @@ import classNames from 'classnames'
 import { groupBy, sortBy, startCase, sumBy } from 'lodash'
 
 import { useQuery } from '@sourcegraph/http-client'
+import type { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import { EVENT_LOGGER } from '@sourcegraph/shared/src/telemetry/web/eventLogger'
 import {
     Card,
@@ -34,8 +35,9 @@ import { CODEINTEL_STATISTICS } from './queries'
 
 import styles from './index.module.scss'
 
-export const AnalyticsCodeIntelPage: React.FC = () => {
-    const { dateRange, aggregation, grouping } = useChartFilters({ name: 'CodeIntel' })
+interface Props extends TelemetryV2Props {}
+export const AnalyticsCodeIntelPage: React.FC<Props> = ({ telemetryRecorder }) => {
+    const { dateRange, aggregation, grouping } = useChartFilters({ name: 'CodeIntel', telemetryRecorder })
     const { data, error, loading } = useQuery<CodeIntelStatisticsResult, CodeIntelStatisticsVariables>(
         CODEINTEL_STATISTICS,
         {
@@ -47,7 +49,8 @@ export const AnalyticsCodeIntelPage: React.FC = () => {
     )
     useEffect(() => {
         EVENT_LOGGER.logPageView('AdminAnalyticsCodeIntel')
-    }, [])
+        telemetryRecorder.recordEvent('admin.analytics.codeIntel', 'view')
+    }, [telemetryRecorder])
 
     type Kind = 'inApp' | 'codeHost' | 'crossRepo' | 'precise'
 
@@ -182,9 +185,10 @@ export const AnalyticsCodeIntelPage: React.FC = () => {
                         'Compiler-accurate code navigation takes users to the correct result as defined by SCIP, and does so cross repository. The reduction in false positives produced by other search engines represents significant additional time savings.',
                 },
             ],
+            telemetryRecorder,
         }
 
-        return [stats, legends, calculatorProps]
+        return [stats, legends, calculatorProps, telemetryRecorder]
     }, [
         data,
         dateRange.value,

--- a/client/web/src/site-admin/analytics/AnalyticsCodeIntelPage/index.tsx
+++ b/client/web/src/site-admin/analytics/AnalyticsCodeIntelPage/index.tsx
@@ -188,7 +188,7 @@ export const AnalyticsCodeIntelPage: React.FC<Props> = ({ telemetryRecorder }) =
             telemetryRecorder,
         }
 
-        return [stats, legends, calculatorProps, telemetryRecorder]
+        return [stats, legends, calculatorProps]
     }, [
         data,
         dateRange.value,
@@ -197,6 +197,7 @@ export const AnalyticsCodeIntelPage: React.FC<Props> = ({ telemetryRecorder }) =
         kindToMinPerItem.crossRepo,
         kindToMinPerItem.inApp,
         kindToMinPerItem.precise,
+        telemetryRecorder,
     ])
 
     if (error) {

--- a/client/web/src/site-admin/analytics/AnalyticsCodyPage/index.tsx
+++ b/client/web/src/site-admin/analytics/AnalyticsCodyPage/index.tsx
@@ -1,22 +1,29 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import { Card, Link, Text } from '@sourcegraph/wildcard'
 
 import { AnalyticsPageTitle } from '../components/AnalyticsPageTitle'
 
-export const AnalyticsCodyPage: React.FC = () => (
-    <>
-        <AnalyticsPageTitle>Cody</AnalyticsPageTitle>
+interface Props extends TelemetryV2Props {}
 
-        <Card className="p-3">
-            <Text>
-                Cody analytics, including active users, completions, chat, and commands can be found at{' '}
-                <Link to="https://cody-analytics.sourcegraph.com" target="_blank" rel="noopener">
-                    cody-analytics.sourcegraph.com
-                </Link>
-                .
-            </Text>
-            <Text>To request access, please contact your account team.</Text>
-        </Card>
-    </>
-)
+export const AnalyticsCodyPage: React.FC<Props> = ({ telemetryRecorder }) => {
+    useEffect(() => telemetryRecorder.recordEvent('admin.analytics.cody', 'view'), [telemetryRecorder])
+
+    return (
+        <>
+            <AnalyticsPageTitle>Cody</AnalyticsPageTitle>
+
+            <Card className="p-3">
+                <Text>
+                    Cody analytics, including active users, completions, chat, and commands can be found at{' '}
+                    <Link to="https://cody-analytics.sourcegraph.com" target="_blank" rel="noopener">
+                        cody-analytics.sourcegraph.com
+                    </Link>
+                    .
+                </Text>
+                <Text>To request access, please contact your account team.</Text>
+            </Card>
+        </>
+    )
+}

--- a/client/web/src/site-admin/analytics/AnalyticsExtensionsPage/index.tsx
+++ b/client/web/src/site-admin/analytics/AnalyticsExtensionsPage/index.tsx
@@ -4,6 +4,7 @@ import classNames from 'classnames'
 import { startCase } from 'lodash'
 
 import { useQuery } from '@sourcegraph/http-client'
+import type { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import { EVENT_LOGGER } from '@sourcegraph/shared/src/telemetry/web/eventLogger'
 import { Card, H2, Text, LoadingSpinner, AnchorLink, H4, LineChart, type Series } from '@sourcegraph/wildcard'
 
@@ -11,7 +12,7 @@ import type { ExtensionsStatisticsResult, ExtensionsStatisticsVariables } from '
 import { AnalyticsPageTitle } from '../components/AnalyticsPageTitle'
 import { ChartContainer } from '../components/ChartContainer'
 import { HorizontalSelect } from '../components/HorizontalSelect'
-import { TimeSavedCalculatorGroup } from '../components/TimeSavedCalculatorGroup'
+import { TimeSavedCalculatorGroup, TimeSavedCalculatorGroupProps } from '../components/TimeSavedCalculatorGroup'
 import { ToggleSelect } from '../components/ToggleSelect'
 import { ValueLegendList, type ValueLegendListProps } from '../components/ValueLegendList'
 import { useChartFilters } from '../useChartFilters'
@@ -21,8 +22,10 @@ import { EXTENSIONS_STATISTICS } from './queries'
 
 import styles from './index.module.scss'
 
-export const AnalyticsExtensionsPage: React.FunctionComponent = () => {
-    const { dateRange, aggregation, grouping } = useChartFilters({ name: 'Extensions' })
+interface Props extends TelemetryV2Props {}
+
+export const AnalyticsExtensionsPage: React.FunctionComponent<Props> = ({ telemetryRecorder }) => {
+    const { dateRange, aggregation, grouping } = useChartFilters({ name: 'Extensions', telemetryRecorder })
     const { data, error, loading } = useQuery<ExtensionsStatisticsResult, ExtensionsStatisticsVariables>(
         EXTENSIONS_STATISTICS,
         {
@@ -34,7 +37,8 @@ export const AnalyticsExtensionsPage: React.FunctionComponent = () => {
     )
     useEffect(() => {
         EVENT_LOGGER.logPageView('AdminAnalyticsExtensions')
-    }, [])
+        telemetryRecorder.recordEvent('admin.analytics.extensions', 'view')
+    }, [telemetryRecorder])
     const [stats, legends, calculatorProps, installationStats] = useMemo(() => {
         if (!data) {
             return []
@@ -119,7 +123,7 @@ export const AnalyticsExtensionsPage: React.FunctionComponent = () => {
             },
         ]
 
-        const calculatorProps = {
+        const calculatorProps: TimeSavedCalculatorGroupProps = {
             page: 'Extensions',
             label: 'Total events',
             dateRange: dateRange.value,
@@ -150,6 +154,7 @@ export const AnalyticsExtensionsPage: React.FunctionComponent = () => {
                         "Searches from VS Code across all of your company's code without locally cloning repositories or complex scripting.",
                 },
             ],
+            telemetryRecorder,
         }
         const totalUsersCount = data?.site.users.totalCount
         const installationStats =
@@ -162,7 +167,7 @@ export const AnalyticsExtensionsPage: React.FunctionComponent = () => {
                 : undefined
 
         return [stats, legends, calculatorProps, installationStats]
-    }, [data, dateRange.value, aggregation.selected])
+    }, [data, dateRange.value, aggregation.selected, telemetryRecorder])
 
     if (error) {
         throw error

--- a/client/web/src/site-admin/analytics/AnalyticsNotebooksPage/index.tsx
+++ b/client/web/src/site-admin/analytics/AnalyticsNotebooksPage/index.tsx
@@ -4,6 +4,7 @@ import classNames from 'classnames'
 import { startCase } from 'lodash'
 
 import { useQuery } from '@sourcegraph/http-client'
+import type { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import { EVENT_LOGGER } from '@sourcegraph/shared/src/telemetry/web/eventLogger'
 import { Card, LoadingSpinner, H2, Text, H4, AnchorLink, LineChart, type Series } from '@sourcegraph/wildcard'
 
@@ -21,8 +22,10 @@ import { NOTEBOOKS_STATISTICS } from './queries'
 
 import styles from './index.module.scss'
 
-export const AnalyticsNotebooksPage: React.FunctionComponent = () => {
-    const { dateRange, aggregation, grouping } = useChartFilters({ name: 'Notebooks' })
+interface Props extends TelemetryV2Props {}
+
+export const AnalyticsNotebooksPage: React.FunctionComponent<Props> = ({ telemetryRecorder }) => {
+    const { dateRange, aggregation, grouping } = useChartFilters({ name: 'Notebooks', telemetryRecorder })
     const { data, error, loading } = useQuery<NotebooksStatisticsResult, NotebooksStatisticsVariables>(
         NOTEBOOKS_STATISTICS,
         {
@@ -34,7 +37,8 @@ export const AnalyticsNotebooksPage: React.FunctionComponent = () => {
     )
     useEffect(() => {
         EVENT_LOGGER.logPageView('AdminAnalyticsNotebooks')
-    }, [])
+        telemetryRecorder.recordEvent('admin.analytics.notebooks', 'view')
+    }, [telemetryRecorder])
     const [stats, legends, calculatorProps] = useMemo(() => {
         if (!data) {
             return []
@@ -111,10 +115,11 @@ export const AnalyticsNotebooksPage: React.FunctionComponent = () => {
             description:
                 'Notebooks reduce the time it takes to create living documentation and share it. Each notebook view accounts for time saved by both creators and consumers of notebooks.',
             temporarySettingsKey: 'search.notebooks.minSavedPerView',
+            telemetryRecorder,
         }
 
         return [stats, legends, calculatorProps]
-    }, [data, dateRange.value, aggregation.selected])
+    }, [data, dateRange.value, aggregation.selected, telemetryRecorder])
 
     if (error) {
         throw error

--- a/client/web/src/site-admin/analytics/AnalyticsOverviewPage/index.tsx
+++ b/client/web/src/site-admin/analytics/AnalyticsOverviewPage/index.tsx
@@ -5,6 +5,7 @@ import classNames from 'classnames'
 import { format } from 'date-fns'
 
 import { useQuery } from '@sourcegraph/http-client'
+import type { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import { EVENT_LOGGER } from '@sourcegraph/shared/src/telemetry/web/eventLogger'
 import { AnchorLink, Card, H2, Link, LoadingSpinner, Text } from '@sourcegraph/wildcard'
 
@@ -23,17 +24,18 @@ import { Sidebar } from './Sidebar'
 
 import styles from './index.module.scss'
 
-interface Props {}
+interface Props extends TelemetryV2Props {}
 
-export const AnalyticsOverviewPage: React.FunctionComponent<Props> = () => {
-    const { dateRange } = useChartFilters({ name: 'Overview' })
+export const AnalyticsOverviewPage: React.FunctionComponent<Props> = ({ telemetryRecorder }) => {
+    const { dateRange } = useChartFilters({ name: 'Overview', telemetryRecorder })
     const { data, error, loading } = useQuery<OverviewStatisticsResult, OverviewStatisticsVariables>(
         OVERVIEW_STATISTICS,
         {}
     )
     useEffect(() => {
         EVENT_LOGGER.logPageView('AdminAnalyticsOverview')
-    }, [])
+        telemetryRecorder.recordEvent('admin.analytics.overview', 'view')
+    }, [telemetryRecorder])
 
     const userStatisticsItems = useMemo(() => {
         if (!data) {

--- a/client/web/src/site-admin/analytics/AnalyticsSearchPage/index.tsx
+++ b/client/web/src/site-admin/analytics/AnalyticsSearchPage/index.tsx
@@ -4,6 +4,7 @@ import classNames from 'classnames'
 import { startCase } from 'lodash'
 
 import { useQuery } from '@sourcegraph/http-client'
+import type { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import { EVENT_LOGGER } from '@sourcegraph/shared/src/telemetry/web/eventLogger'
 import { Card, H2, Text, LoadingSpinner, AnchorLink, H4, LineChart, type Series } from '@sourcegraph/wildcard'
 
@@ -11,7 +12,7 @@ import type { SearchStatisticsResult, SearchStatisticsVariables } from '../../..
 import { AnalyticsPageTitle } from '../components/AnalyticsPageTitle'
 import { ChartContainer } from '../components/ChartContainer'
 import { HorizontalSelect } from '../components/HorizontalSelect'
-import { TimeSavedCalculatorGroup } from '../components/TimeSavedCalculatorGroup'
+import { TimeSavedCalculatorGroup, TimeSavedCalculatorGroupProps } from '../components/TimeSavedCalculatorGroup'
 import { ToggleSelect } from '../components/ToggleSelect'
 import { ValueLegendList, type ValueLegendListProps } from '../components/ValueLegendList'
 import { useChartFilters } from '../useChartFilters'
@@ -21,8 +22,10 @@ import { SEARCH_STATISTICS } from './queries'
 
 import styles from './index.module.scss'
 
-export const AnalyticsSearchPage: React.FC = () => {
-    const { dateRange, aggregation, grouping } = useChartFilters({ name: 'Search' })
+interface Props extends TelemetryV2Props {}
+
+export const AnalyticsSearchPage: React.FC<Props> = ({ telemetryRecorder }) => {
+    const { dateRange, aggregation, grouping } = useChartFilters({ name: 'Search', telemetryRecorder })
     const { data, error, loading } = useQuery<SearchStatisticsResult, SearchStatisticsVariables>(SEARCH_STATISTICS, {
         variables: {
             dateRange: dateRange.value,
@@ -31,7 +34,8 @@ export const AnalyticsSearchPage: React.FC = () => {
     })
     useEffect(() => {
         EVENT_LOGGER.logPageView('AdminAnalyticsSearch')
-    }, [])
+        telemetryRecorder.recordEvent('admin.analytics.search', 'view')
+    }, [telemetryRecorder])
     const [stats, legends] = useMemo(() => {
         if (!data) {
             return []
@@ -126,7 +130,7 @@ export const AnalyticsSearchPage: React.FC = () => {
         return [stats, legends]
     }, [data, aggregation.selected, dateRange.value])
 
-    const calculatorProps = useMemo(() => {
+    const calculatorProps: TimeSavedCalculatorGroupProps | undefined = useMemo(() => {
         if (!data) {
             return
         }
@@ -167,8 +171,9 @@ export const AnalyticsSearchPage: React.FC = () => {
                     value: totalCount,
                 },
             ],
+            telemetryRecorder,
         }
-    }, [data, dateRange.value])
+    }, [data, dateRange.value, telemetryRecorder])
 
     if (error) {
         throw error

--- a/client/web/src/site-admin/analytics/AnalyticsUsersPage/AnalyticsUsersPage.story.tsx
+++ b/client/web/src/site-admin/analytics/AnalyticsUsersPage/AnalyticsUsersPage.story.tsx
@@ -2,6 +2,7 @@ import type { MockedResponse } from '@apollo/client/testing'
 import type { Decorator, Meta, StoryFn } from '@storybook/react'
 
 import { getDocumentNode } from '@sourcegraph/http-client'
+import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
 import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
 
 import { WebStory } from '../../../components/WebStory'
@@ -695,6 +696,6 @@ const USER_ANALYTICS_QUERY_MOCK: MockedResponse<UsersStatisticsResult> = {
 
 export const AnalyticsUsersPageExample: StoryFn = () => (
     <MockedTestProvider mocks={[USER_ANALYTICS_QUERY_MOCK]}>
-        <AnalyticsUsersPage />
+        <AnalyticsUsersPage telemetryRecorder={noOpTelemetryRecorder} />
     </MockedTestProvider>
 )

--- a/client/web/src/site-admin/analytics/AnalyticsUsersPage/index.tsx
+++ b/client/web/src/site-admin/analytics/AnalyticsUsersPage/index.tsx
@@ -4,6 +4,7 @@ import classNames from 'classnames'
 import { startCase } from 'lodash'
 
 import { useQuery } from '@sourcegraph/http-client'
+import type { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import { EVENT_LOGGER } from '@sourcegraph/shared/src/telemetry/web/eventLogger'
 import { Card, LoadingSpinner, useMatchMedia, Text, LineChart, BarChart, type Series } from '@sourcegraph/wildcard'
 
@@ -21,8 +22,14 @@ import { USERS_STATISTICS } from './queries'
 
 import styles from './AnalyticsUsersPage.module.scss'
 
-export const AnalyticsUsersPage: FC = () => {
-    const { dateRange, aggregation, grouping } = useChartFilters({ name: 'Users', aggregation: 'uniqueUsers' })
+interface Props extends TelemetryV2Props {}
+
+export const AnalyticsUsersPage: FC<Props> = ({ telemetryRecorder }) => {
+    const { dateRange, aggregation, grouping } = useChartFilters({
+        name: 'Users',
+        aggregation: 'uniqueUsers',
+        telemetryRecorder,
+    })
     const { data, error, loading } = useQuery<UsersStatisticsResult, UsersStatisticsVariables>(USERS_STATISTICS, {
         variables: {
             dateRange: dateRange.value,
@@ -31,7 +38,8 @@ export const AnalyticsUsersPage: FC = () => {
     })
     useEffect(() => {
         EVENT_LOGGER.logPageView('AdminAnalyticsUsers')
-    }, [])
+        telemetryRecorder.recordEvent('admin.analytics.users', 'view')
+    }, [telemetryRecorder])
     const [uniqueOrPercentage, setUniqueOrPercentage] = useState<'unique' | 'percentage'>('unique')
 
     const [frequencies, legends] = useMemo(() => {

--- a/client/web/src/site-admin/analytics/useChartFilters.ts
+++ b/client/web/src/site-admin/analytics/useChartFilters.ts
@@ -1,3 +1,4 @@
+import type { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import { EVENT_LOGGER } from '@sourcegraph/shared/src/telemetry/web/eventLogger'
 
 import { AnalyticsDateRange, AnalyticsGrouping } from '../../graphql-operations'
@@ -5,8 +6,43 @@ import { useURLSyncedState } from '../../hooks'
 
 type IAggregation = 'count' | 'uniqueUsers'
 
-interface IProps {
-    name: string
+type ChartName =
+    | 'BatchChanges'
+    | 'Insights'
+    | 'CodeIntel'
+    | 'Extensions'
+    | 'Notebooks'
+    | 'Overview'
+    | 'Search'
+    | 'Users'
+
+const v2ChartTypes: { [key in ChartName]: number } = {
+    BatchChanges: 1,
+    Insights: 2,
+    CodeIntel: 3,
+    Extensions: 4,
+    Notebooks: 5,
+    Overview: 6,
+    Search: 7,
+    Users: 8,
+}
+const v2DateRangeTypes: { [key in AnalyticsDateRange]: number } = {
+    CUSTOM: 1,
+    LAST_MONTH: 2,
+    LAST_THREE_MONTHS: 3,
+    LAST_WEEK: 4,
+}
+const v2AggregationTypes: { [key in IAggregation]: number } = {
+    count: 1,
+    uniqueUsers: 2,
+}
+const v2GroupingTypes: { [key in AnalyticsGrouping]: number } = {
+    DAILY: 1,
+    WEEKLY: 2,
+}
+
+interface IProps extends TelemetryV2Props {
+    name: ChartName
     aggregation?: IAggregation
     dateRange?: AnalyticsDateRange
     grouping?: AnalyticsGrouping
@@ -50,6 +86,9 @@ export function useChartFilters(props: IProps): IResult {
                         value === AnalyticsDateRange.LAST_WEEK ? AnalyticsGrouping.DAILY : AnalyticsGrouping.WEEKLY,
                 })
                 EVENT_LOGGER.log(`AdminAnalytics${props.name}DateRange${value}`)
+                props.telemetryRecorder.recordEvent('admin.analytics.dateRange', 'change', {
+                    metadata: { kind: v2ChartTypes[props.name], value: v2DateRangeTypes[value] },
+                })
             },
             items: [
                 { value: AnalyticsDateRange.LAST_WEEK, label: 'Last week' },
@@ -62,6 +101,9 @@ export function useChartFilters(props: IProps): IResult {
             onChange: value => {
                 setData({ aggregation: value })
                 EVENT_LOGGER.log(`AdminAnalytics${props.name}Aggregate${value === 'count' ? 'Totals' : 'Uniques'}`)
+                props.telemetryRecorder.recordEvent('admin.analytics.aggregation', 'change', {
+                    metadata: { kind: v2ChartTypes[props.name], value: v2AggregationTypes[value] },
+                })
             },
             items: [
                 {
@@ -82,6 +124,9 @@ export function useChartFilters(props: IProps): IResult {
             onChange: value => {
                 setData({ grouping: value })
                 EVENT_LOGGER.log(`AdminAnalytics${props.name}DisplayAs${value}`)
+                props.telemetryRecorder.recordEvent('admin.analytics.grouping', 'change', {
+                    metadata: { kind: v2ChartTypes[props.name], value: v2GroupingTypes[value] },
+                })
             },
             items: [
                 { value: AnalyticsGrouping.DAILY, label: 'Daily' },

--- a/client/web/src/site-admin/init/SiteInitPage.story.tsx
+++ b/client/web/src/site-admin/init/SiteInitPage.story.tsx
@@ -1,5 +1,7 @@
 import type { Meta, StoryFn } from '@storybook/react'
 
+import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
+
 import { WebStory } from '../../components/WebStory'
 
 import { SiteInitPage } from './SiteInitPage'
@@ -23,6 +25,7 @@ export const Default: StoryFn = () => (
                 }}
                 authenticatedUser={null}
                 needsSiteInit={true}
+                telemetryRecorder={noOpTelemetryRecorder}
             />
         )}
     </WebStory>
@@ -38,6 +41,7 @@ export const Authenticated: StoryFn = () => (
                 }}
                 authenticatedUser={{ username: 'johndoe' }}
                 needsSiteInit={true}
+                telemetryRecorder={noOpTelemetryRecorder}
             />
         )}
     </WebStory>

--- a/client/web/src/site-admin/init/SiteInitPage.test.tsx
+++ b/client/web/src/site-admin/init/SiteInitPage.test.tsx
@@ -1,5 +1,6 @@
 import { afterAll, beforeAll, describe, expect, test } from 'vitest'
 
+import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
 import { renderWithBrandedContext } from '@sourcegraph/wildcard/src/testing'
 
 import { SiteInitPage } from './SiteInitPage'
@@ -24,6 +25,7 @@ describe('SiteInitPage', () => {
                     authPasswordPolicy: {},
                     authMinPasswordLength: 12,
                 }}
+                telemetryRecorder={noOpTelemetryRecorder}
             />,
             { route: '/init', path: '/init', extraRoutes: [{ path: '/search', element: null }] }
         )
@@ -41,6 +43,7 @@ describe('SiteInitPage', () => {
                         authPasswordPolicy: {},
                         authMinPasswordLength: 12,
                     }}
+                    telemetryRecorder={noOpTelemetryRecorder}
                 />
             ).asFragment()
         ).toMatchSnapshot())
@@ -55,6 +58,7 @@ describe('SiteInitPage', () => {
                         authPasswordPolicy: {},
                         authMinPasswordLength: 12,
                     }}
+                    telemetryRecorder={noOpTelemetryRecorder}
                 />
             ).asFragment()
         ).toMatchSnapshot())

--- a/client/web/src/site-admin/outbound-webhooks/CreatePage.story.tsx
+++ b/client/web/src/site-admin/outbound-webhooks/CreatePage.story.tsx
@@ -1,5 +1,6 @@
 import type { Decorator, Meta, StoryFn } from '@storybook/react'
 
+import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
 
@@ -21,7 +22,7 @@ export const Page: StoryFn = () => (
     <WebStory>
         {() => (
             <MockedTestProvider mocks={[eventTypesMock]}>
-                <CreatePage telemetryService={NOOP_TELEMETRY_SERVICE} />
+                <CreatePage telemetryService={NOOP_TELEMETRY_SERVICE} telemetryRecorder={noOpTelemetryRecorder} />
             </MockedTestProvider>
         )}
     </WebStory>

--- a/client/web/src/site-admin/outbound-webhooks/CreatePage.tsx
+++ b/client/web/src/site-admin/outbound-webhooks/CreatePage.tsx
@@ -5,6 +5,7 @@ import { noop } from 'lodash'
 import { useNavigate } from 'react-router-dom'
 
 import { useMutation } from '@sourcegraph/http-client'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Container, ErrorAlert, Form, Input, PageHeader } from '@sourcegraph/wildcard'
 
@@ -16,13 +17,14 @@ import { CREATE_OUTBOUND_WEBHOOK } from './backend'
 import { EventTypes } from './create-edit/EventTypes'
 import { SubmitButton } from './create-edit/SubmitButton'
 
-export interface CreatePageProps extends TelemetryProps {}
+export interface CreatePageProps extends TelemetryProps, TelemetryV2Props {}
 
-export const CreatePage: FC<CreatePageProps> = ({ telemetryService }) => {
+export const CreatePage: FC<CreatePageProps> = ({ telemetryService, telemetryRecorder }) => {
     const navigate = useNavigate()
     useEffect(() => {
         telemetryService.logPageView('OutboundWebhooksCreatePage')
-    }, [telemetryService])
+        telemetryRecorder.recordEvent('admin.outboundWebhooks.create', 'view')
+    }, [telemetryService, telemetryRecorder])
 
     const [url, setURL] = useState('')
     const [secret, setSecret] = useState(generateSecret())

--- a/client/web/src/site-admin/outbound-webhooks/EditPage.story.tsx
+++ b/client/web/src/site-admin/outbound-webhooks/EditPage.story.tsx
@@ -1,6 +1,7 @@
 import type { Decorator, Meta, StoryFn } from '@storybook/react'
 import { WildcardMockLink } from 'wildcard-mock-link'
 
+import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
 
@@ -24,7 +25,7 @@ export const Page: StoryFn = () => (
             <MockedTestProvider
                 link={new WildcardMockLink([logConnectionLink, buildOutboundWebhookMock(''), eventTypesMock])}
             >
-                <EditPage telemetryService={NOOP_TELEMETRY_SERVICE} />
+                <EditPage telemetryService={NOOP_TELEMETRY_SERVICE} telemetryRecorder={noOpTelemetryRecorder} />
             </MockedTestProvider>
         )}
     </WebStory>

--- a/client/web/src/site-admin/outbound-webhooks/EditPage.tsx
+++ b/client/web/src/site-admin/outbound-webhooks/EditPage.tsx
@@ -5,6 +5,7 @@ import { noop } from 'lodash'
 import { useNavigate, useParams } from 'react-router-dom'
 
 import { useMutation, useQuery } from '@sourcegraph/http-client'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Container, ErrorAlert, Form, Input, LoadingSpinner, PageHeader } from '@sourcegraph/wildcard'
 
@@ -23,15 +24,16 @@ import { SubmitButton } from './create-edit/SubmitButton'
 import { DeleteButton } from './delete/DeleteButton'
 import { Logs } from './logs/Logs'
 
-export interface EditPageProps extends TelemetryProps {}
+export interface EditPageProps extends TelemetryProps, TelemetryV2Props {}
 
-export const EditPage: FC<EditPageProps> = ({ telemetryService }) => {
+export const EditPage: FC<EditPageProps> = ({ telemetryService, telemetryRecorder }) => {
     const navigate = useNavigate()
     const { id = '' } = useParams<{ id: string }>()
 
     useEffect(() => {
         telemetryService.logPageView('OutboundWebhooksEditPage')
-    }, [telemetryService])
+        telemetryRecorder.recordEvent('admin.outboundWebhooks.edit', 'view')
+    }, [telemetryService, telemetryRecorder])
 
     const { data, loading, error, refetch } = useQuery<OutboundWebhookByIDResult, OutboundWebhookByIDVariables>(
         OUTBOUND_WEBHOOK_BY_ID,

--- a/client/web/src/site-admin/outbound-webhooks/OutboundWebhooksPage.story.tsx
+++ b/client/web/src/site-admin/outbound-webhooks/OutboundWebhooksPage.story.tsx
@@ -1,6 +1,7 @@
 import type { Decorator, Meta, StoryFn } from '@storybook/react'
 import { WildcardMockLink } from 'wildcard-mock-link'
 
+import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
 
@@ -22,7 +23,10 @@ export const Empty: StoryFn = () => (
     <WebStory>
         {() => (
             <MockedTestProvider link={new WildcardMockLink([buildOutboundWebhooksConnectionLink(0)])}>
-                <OutboundWebhooksPage telemetryService={NOOP_TELEMETRY_SERVICE} />
+                <OutboundWebhooksPage
+                    telemetryService={NOOP_TELEMETRY_SERVICE}
+                    telemetryRecorder={noOpTelemetryRecorder}
+                />
             </MockedTestProvider>
         )}
     </WebStory>
@@ -34,7 +38,10 @@ export const NotEmpty: StoryFn = () => (
     <WebStory>
         {() => (
             <MockedTestProvider link={new WildcardMockLink([buildOutboundWebhooksConnectionLink(20)])}>
-                <OutboundWebhooksPage telemetryService={NOOP_TELEMETRY_SERVICE} />
+                <OutboundWebhooksPage
+                    telemetryService={NOOP_TELEMETRY_SERVICE}
+                    telemetryRecorder={noOpTelemetryRecorder}
+                />
             </MockedTestProvider>
         )}
     </WebStory>

--- a/client/web/src/site-admin/outbound-webhooks/OutboundWebhooksPage.tsx
+++ b/client/web/src/site-admin/outbound-webhooks/OutboundWebhooksPage.tsx
@@ -3,6 +3,7 @@ import { type FC, useEffect } from 'react'
 import { mdiAlertCircle, mdiWebhook, mdiMapSearch, mdiPencil, mdiPlus } from '@mdi/js'
 
 import { pluralize } from '@sourcegraph/common'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { ButtonLink, Container, H3, Icon, Link, PageHeader, Tooltip } from '@sourcegraph/wildcard'
 
@@ -23,12 +24,13 @@ import { DeleteButton } from './delete/DeleteButton'
 
 import styles from './OutboundWebhooksPage.module.scss'
 
-export interface OutboundWebhooksPageProps extends TelemetryProps {}
+export interface OutboundWebhooksPageProps extends TelemetryProps, TelemetryV2Props {}
 
-export const OutboundWebhooksPage: FC<OutboundWebhooksPageProps> = ({ telemetryService }) => {
+export const OutboundWebhooksPage: FC<OutboundWebhooksPageProps> = ({ telemetryService, telemetryRecorder }) => {
     useEffect(() => {
         telemetryService.logPageView('OutboundWebhooksPage')
-    }, [telemetryService])
+        telemetryRecorder.recordEvent('admin.outboundWebhooks', 'view')
+    }, [telemetryService, telemetryRecorder])
 
     const { loading, hasNextPage, fetchMore, refetchAll, connection, error } = useOutboundWebhooksConnection()
 

--- a/client/web/src/site-admin/permissions-center/PermissionsSyncJobsTable.story.tsx
+++ b/client/web/src/site-admin/permissions-center/PermissionsSyncJobsTable.story.tsx
@@ -92,7 +92,6 @@ export const SixSyncJobsFound: StoryFn = () => (
             >
                 <PermissionsSyncJobsTable
                     telemetryService={NOOP_TELEMETRY_SERVICE}
-                    // TODO (dadlerj): update to use a real telemetry recorder
                     telemetryRecorder={noOpTelemetryRecorder}
                 />
             </MockedTestProvider>

--- a/client/web/src/site-admin/permissions-center/PermissionsSyncJobsTable.tsx
+++ b/client/web/src/site-admin/permissions-center/PermissionsSyncJobsTable.tsx
@@ -110,7 +110,14 @@ export const PermissionsSyncJobsTable: React.FunctionComponent<React.PropsWithCh
 }) => {
     useEffect(() => {
         telemetryService.logPageView('PermissionsSyncJobsTable')
-    }, [telemetryService])
+        if (userID) {
+            telemetryRecorder.recordEvent('user.permissionsCenter', 'view')
+        } else if (repoID) {
+            telemetryRecorder.recordEvent('repo.permissionsCenter', 'view')
+        } else {
+            telemetryRecorder.recordEvent('admin.permissionsCenter', 'view')
+        }
+    }, [telemetryService, telemetryRecorder, userID, repoID])
 
     const [filters, setFilters] = useURLSyncedState(DEFAULT_FILTERS)
     const debouncedQuery = useDebounce(filters.query, 300)
@@ -190,7 +197,7 @@ export const PermissionsSyncJobsTable: React.FunctionComponent<React.PropsWithCh
     const handleTriggerPermsSync = useCallback(
         ([job]: PermissionsSyncJob[]) => {
             if (job.subject.__typename === 'Repository') {
-                telemetryRecorder.recordEvent('permissions-center.repository.sync', 'trigger', {
+                telemetryRecorder.recordEvent('admin.permissionsCenter.repository.sync', 'trigger', {
                     privateMetadata: { repo: job.subject.id },
                 })
                 triggerRepoSync({
@@ -203,7 +210,7 @@ export const PermissionsSyncJobsTable: React.FunctionComponent<React.PropsWithCh
                     noop
                 )
             } else {
-                telemetryRecorder.recordEvent('permissions-center.user.sync', 'trigger', {
+                telemetryRecorder.recordEvent('admin.permissionsCenter.user.sync', 'trigger', {
                     privateMetadata: { user: job.subject.id },
                 })
                 triggerUserSync({
@@ -232,11 +239,11 @@ export const PermissionsSyncJobsTable: React.FunctionComponent<React.PropsWithCh
             )
 
             if (syncJob.subject.__typename === 'Repository') {
-                telemetryRecorder.recordEvent('permissions-center.repository.sync', 'cancel', {
+                telemetryRecorder.recordEvent('admin.permissionsCenter.repository.sync', 'cancel', {
                     privateMetadata: { repo: syncJob.subject.id },
                 })
             } else {
-                telemetryRecorder.recordEvent('permissions-center.user.sync', 'cancel', {
+                telemetryRecorder.recordEvent('admin.permissionsCenter.user.sync', 'cancel', {
                     privateMetadata: { user: syncJob.subject.id },
                 })
             }
@@ -250,11 +257,11 @@ export const PermissionsSyncJobsTable: React.FunctionComponent<React.PropsWithCh
             setSelectedJob(syncJob)
 
             if (syncJob.subject.__typename === 'Repository') {
-                telemetryRecorder.recordEvent('permissions-center.repository.sync', 'view', {
+                telemetryRecorder.recordEvent('admin.permissionsCenter.repository.sync', 'view', {
                     privateMetadata: { repo: syncJob.subject.id },
                 })
             } else {
-                telemetryRecorder.recordEvent('permissions-center.user.sync', 'view', {
+                telemetryRecorder.recordEvent('admin.permissionsCenter.user.sync', 'view', {
                     privateMetadata: { user: syncJob.subject.id },
                 })
             }

--- a/client/web/src/site-admin/routes.tsx
+++ b/client/web/src/site-admin/routes.tsx
@@ -198,44 +198,44 @@ const codyIsEnabled = (): boolean => Boolean(window.context?.codyEnabled && wind
 export const otherSiteAdminRoutes: readonly SiteAdminAreaRoute[] = [
     {
         path: '/',
-        render: () => <AnalyticsOverviewPage />,
+        render: props => <AnalyticsOverviewPage {...props} />,
     },
     {
         path: '/analytics/search',
-        render: () => <AnalyticsSearchPage />,
+        render: props => <AnalyticsSearchPage {...props} />,
         condition: ({ license }) => license.isCodeSearchEnabled,
     },
     {
         path: '/analytics/code-intel',
-        render: () => <AnalyticsCodeIntelPage />,
+        render: props => <AnalyticsCodeIntelPage {...props} />,
         condition: ({ license }) => license.isCodeSearchEnabled,
     },
     {
         path: '/analytics/extensions',
-        render: () => <AnalyticsExtensionsPage />,
+        render: props => <AnalyticsExtensionsPage {...props} />,
     },
     {
         path: '/analytics/users',
-        render: () => <AnalyticsUsersPage />,
+        render: props => <AnalyticsUsersPage {...props} />,
     },
     {
         path: '/analytics/cody',
-        render: () => <AnalyticsCodyPage />,
+        render: props => <AnalyticsCodyPage {...props} />,
         condition: ({ license }) => license.isCodyEnabled,
     },
     {
         path: '/analytics/code-insights',
-        render: () => <AnalyticsCodeInsightsPage />,
+        render: props => <AnalyticsCodeInsightsPage {...props} />,
         condition: ({ codeInsightsEnabled }) => codeInsightsEnabled,
     },
     {
         path: '/analytics/batch-changes',
-        render: () => <AnalyticsBatchChangesPage />,
+        render: props => <AnalyticsBatchChangesPage {...props} />,
         condition: ({ batchChangesEnabled }) => batchChangesEnabled,
     },
     {
         path: '/analytics/notebooks',
-        render: () => <AnalyticsNotebooksPage />,
+        render: props => <AnalyticsNotebooksPage {...props} />,
         condition: ({ license }) => license.isCodeSearchEnabled,
     },
     {
@@ -269,12 +269,12 @@ export const otherSiteAdminRoutes: readonly SiteAdminAreaRoute[] = [
     },
     {
         path: '/account-requests',
-        render: () => <AccessRequestsPage />,
+        render: props => <AccessRequestsPage {...props} />,
         condition: () => checkRequestAccessAllowed(window.context),
     },
     {
         path: '/users/new',
-        render: () => <SiteAdminCreateUserPage />,
+        render: props => <SiteAdminCreateUserPage {...props} />,
     },
     {
         path: '/tokens',
@@ -355,9 +355,7 @@ export const otherSiteAdminRoutes: readonly SiteAdminAreaRoute[] = [
     },
     {
         path: '/permissions-syncs',
-        render: props => (
-            <PermissionsSyncJobsTable {...props} telemetryRecorder={props.platformContext.telemetryRecorder} />
-        ),
+        render: props => <PermissionsSyncJobsTable {...props} />,
     },
     {
         path: '/gitservers',
@@ -365,11 +363,12 @@ export const otherSiteAdminRoutes: readonly SiteAdminAreaRoute[] = [
     },
     {
         path: '/users',
-        render: () => (
+        render: props => (
             <UsersManagement
                 renderAssignmentModal={(onCancel, onSuccess, user) => (
                     <RoleAssignmentModal onCancel={onCancel} onSuccess={onSuccess} user={user} />
                 )}
+                {...props}
             />
         ),
     },
@@ -416,7 +415,7 @@ export const otherSiteAdminRoutes: readonly SiteAdminAreaRoute[] = [
     },
     {
         path: '/batch-changes',
-        render: () => <BatchChangesSiteConfigSettingsPage />,
+        render: props => <BatchChangesSiteConfigSettingsPage {...props} />,
         condition: ({ batchChangesEnabled }) => batchChangesEnabled,
     },
     {
@@ -438,7 +437,7 @@ export const otherSiteAdminRoutes: readonly SiteAdminAreaRoute[] = [
     },
     {
         path: '/batch-changes/specs',
-        render: props => <BatchSpecsPage telemetryRecorder={props.platformContext.telemetryRecorder} />,
+        render: props => <BatchSpecsPage {...props} />,
         condition: ({ batchChangesEnabled, batchChangesExecutionEnabled }) =>
             batchChangesEnabled && batchChangesExecutionEnabled,
     },
@@ -457,7 +456,7 @@ export const otherSiteAdminRoutes: readonly SiteAdminAreaRoute[] = [
     {
         exact: true,
         path: '/code-insights-jobs',
-        render: () => <CodeInsightsJobsPage />,
+        render: props => <CodeInsightsJobsPage {...props} />,
         condition: ({ codeInsightsEnabled }) => codeInsightsEnabled,
     },
     {
@@ -480,7 +479,7 @@ export const otherSiteAdminRoutes: readonly SiteAdminAreaRoute[] = [
     },
     {
         path: '/lsif-uploads/:id',
-        render: () => <SiteAdminPreciseIndexPage />,
+        render: props => <SiteAdminPreciseIndexPage {...props} />,
     },
 
     // Executor routes
@@ -537,7 +536,7 @@ function NavigateToCodeGraph(): JSX.Element {
 
 const siteAdminUserManagementRoute: SiteAdminAreaRoute = {
     path: '/users',
-    render: () => <UsersManagement renderAssignmentModal={() => null} />,
+    render: props => <UsersManagement renderAssignmentModal={() => null} {...props} />,
 }
 
 export const siteAdminAreaRoutes: readonly SiteAdminAreaRoute[] = [


### PR DESCRIPTION
Context:

* https://github.com/sourcegraph/sourcegraph/pull/60127
* https://github.com/sourcegraph/sourcegraph/pull/60192
* https://github.com/sourcegraph/sourcegraph/pull/60219
* https://github.com/sourcegraph/sourcegraph/pull/60343
* https://github.com/sourcegraph/sourcegraph/pull/60377
* https://github.com/sourcegraph/sourcegraph/pull/60382
* https://github.com/sourcegraph/sourcegraph/pull/60764
* https://github.com/sourcegraph/sourcegraph/pull/60765
* https://github.com/sourcegraph/sourcegraph/pull/60767
* https://github.com/sourcegraph/sourcegraph/pull/60768
* https://github.com/sourcegraph/sourcegraph/pull/60788
* https://github.com/sourcegraph/sourcegraph/pull/60789
* https://github.com/sourcegraph/sourcegraph/pull/60803
* https://github.com/sourcegraph/sourcegraph/pull/60812
* https://github.com/sourcegraph/sourcegraph/pull/60850
* https://github.com/sourcegraph/sourcegraph/pull/60851
* https://github.com/sourcegraph/sourcegraph/pull/60939
* https://github.com/sourcegraph/sourcegraph/pull/60971
* https://github.com/sourcegraph/sourcegraph/pull/61205
* https://github.com/sourcegraph/sourcegraph/pull/61457
* https://github.com/sourcegraph/sourcegraph/pull/61503
* https://github.com/sourcegraph/sourcegraph/pull/61504
* https://github.com/sourcegraph/sourcegraph/pull/61506
* https://github.com/sourcegraph/sourcegraph/pull/61507
* https://github.com/sourcegraph/sourcegraph/pull/61516
* https://github.com/sourcegraph/sourcegraph/pull/61707

## Test plan

`sg start`
visit page
check if events appear in `event_logs` table locally