### PR TITLE
all: use observation.TestContextTB instead of TestContext

### DIFF
--- a/cmd/executor/internal/apiclient/files/client_test.go
+++ b/cmd/executor/internal/apiclient/files/client_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 func TestNew(t *testing.T) {
-	observationContext := &observation.TestContext
+	observationContext := observation.TestContextTB(t)
 
 	tests := []struct {
 		name    string
@@ -56,7 +56,7 @@ func TestNew(t *testing.T) {
 }
 
 func TestClient_Exists(t *testing.T) {
-	observationContext := &observation.TestContext
+	observationContext := observation.TestContextTB(t)
 
 	tests := []struct {
 		name string
@@ -150,7 +150,7 @@ func TestClient_Exists(t *testing.T) {
 }
 
 func TestClient_Get(t *testing.T) {
-	observationContext := &observation.TestContext
+	observationContext := observation.TestContextTB(t)
 
 	tests := []struct {
 		name string

--- a/cmd/executor/internal/worker/command/command_test.go
+++ b/cmd/executor/internal/worker/command/command_test.go
@@ -23,7 +23,7 @@ import (
 
 func TestCommand_Run(t *testing.T) {
 	internalLogger := logtest.Scoped(t)
-	operations := command.NewOperations(&observation.TestContext)
+	operations := command.NewOperations(observation.TestContextTB(t))
 
 	tests := []struct {
 		name         string

--- a/cmd/executor/internal/worker/command/kubernetes_test.go
+++ b/cmd/executor/internal/worker/command/kubernetes_test.go
@@ -30,7 +30,7 @@ func TestKubernetesCommand_CreateJob(t *testing.T) {
 	cmd := &command.KubernetesCommand{
 		Logger:     logtest.Scoped(t),
 		Clientset:  clientset,
-		Operations: command.NewOperations(&observation.TestContext),
+		Operations: command.NewOperations(observation.TestContextTB(t)),
 	}
 
 	job := &batchv1.Job{}
@@ -50,7 +50,7 @@ func TestKubernetesCommand_DeleteJob(t *testing.T) {
 	cmd := &command.KubernetesCommand{
 		Logger:     logtest.Scoped(t),
 		Clientset:  clientset,
-		Operations: command.NewOperations(&observation.TestContext),
+		Operations: command.NewOperations(observation.TestContextTB(t)),
 	}
 
 	job := &batchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: "my-job"}}
@@ -73,7 +73,7 @@ func TestKubernetesCommand_CreateSecrets(t *testing.T) {
 	cmd := &command.KubernetesCommand{
 		Logger:     logtest.Scoped(t),
 		Clientset:  clientset,
-		Operations: command.NewOperations(&observation.TestContext),
+		Operations: command.NewOperations(observation.TestContextTB(t)),
 	}
 
 	secrets := map[string]string{
@@ -99,7 +99,7 @@ func TestKubernetesCommand_DeleteSecret(t *testing.T) {
 	cmd := &command.KubernetesCommand{
 		Logger:     logtest.Scoped(t),
 		Clientset:  clientset,
-		Operations: command.NewOperations(&observation.TestContext),
+		Operations: command.NewOperations(observation.TestContextTB(t)),
 	}
 
 	secrets := map[string]string{
@@ -124,7 +124,7 @@ func TestKubernetesCommand_CreateJobPVC(t *testing.T) {
 	cmd := &command.KubernetesCommand{
 		Logger:     logtest.Scoped(t),
 		Clientset:  clientset,
-		Operations: command.NewOperations(&observation.TestContext),
+		Operations: command.NewOperations(observation.TestContextTB(t)),
 	}
 
 	err := cmd.CreateJobPVC(context.Background(), "my-namespace", "my-pvc", resource.MustParse("1Gi"))
@@ -142,7 +142,7 @@ func TestKubernetesCommand_DeleteJobPVC(t *testing.T) {
 	cmd := &command.KubernetesCommand{
 		Logger:     logtest.Scoped(t),
 		Clientset:  clientset,
-		Operations: command.NewOperations(&observation.TestContext),
+		Operations: command.NewOperations(observation.TestContextTB(t)),
 	}
 
 	err := cmd.CreateJobPVC(context.Background(), "my-namespace", "my-pvc", resource.MustParse("1Gi"))
@@ -509,7 +509,7 @@ func TestKubernetesCommand_WaitForPodToSucceed(t *testing.T) {
 			cmd := &command.KubernetesCommand{
 				Logger:     logtest.Scoped(t),
 				Clientset:  clientset,
-				Operations: command.NewOperations(&observation.TestContext),
+				Operations: command.NewOperations(observation.TestContextTB(t)),
 			}
 
 			pod, err := cmd.WaitForPodToSucceed(

--- a/cmd/executor/internal/worker/handler_test.go
+++ b/cmd/executor/internal/worker/handler_test.go
@@ -145,7 +145,7 @@ func TestHandler_Handle_Legacy(t *testing.T) {
 	// No runtime is configured.
 	// Will go away once firecracker is implemented.
 	internalLogger := logtest.Scoped(t)
-	operations := command.NewOperations(&observation.TestContext)
+	operations := command.NewOperations(observation.TestContextTB(t))
 
 	tests := []struct {
 		name           string
@@ -418,7 +418,7 @@ func TestHandler_Handle_Legacy(t *testing.T) {
 
 func TestHandler_Handle(t *testing.T) {
 	internalLogger := logtest.Scoped(t)
-	operations := command.NewOperations(&observation.TestContext)
+	operations := command.NewOperations(observation.TestContextTB(t))
 
 	tests := []struct {
 		name           string

--- a/cmd/executor/internal/worker/runner/firecracker_test.go
+++ b/cmd/executor/internal/worker/runner/firecracker_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 func TestFirecrackerRunner_Setup(t *testing.T) {
-	operations := command.NewOperations(&observation.TestContext)
+	operations := command.NewOperations(observation.TestContextTB(t))
 
 	tests := []struct {
 		name             string
@@ -331,7 +331,7 @@ const defaultCNIConfig = `
 func TestFirecrackerRunner_Teardown(t *testing.T) {
 	cmd := runner.NewMockCommand()
 	logger := runner.NewMockLogger()
-	operations := command.NewOperations(&observation.TestContext)
+	operations := command.NewOperations(observation.TestContextTB(t))
 	firecrackerRunner := runner.NewFirecrackerRunner(cmd, logger, "/dev", "test", runner.FirecrackerOptions{}, types.DockerAuthConfig{}, operations)
 
 	cmd.RunFunc.PushReturn(nil)
@@ -369,7 +369,7 @@ func matchCmd(key string) func(spec command.Spec) bool {
 func TestFirecrackerRunner_Run(t *testing.T) {
 	cmd := runner.NewMockCommand()
 	logger := runner.NewMockLogger()
-	operations := command.NewOperations(&observation.TestContext)
+	operations := command.NewOperations(observation.TestContextTB(t))
 	options := runner.FirecrackerOptions{
 		DockerOptions: command.DockerOptions{
 			ConfigPath:     "/docker/config",

--- a/cmd/executor/internal/worker/runner/kubernetes_test.go
+++ b/cmd/executor/internal/worker/runner/kubernetes_test.go
@@ -116,7 +116,7 @@ func TestKubernetesRunner_Run(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			clientset := fake.NewSimpleClientset()
-			cmd := &command.KubernetesCommand{Logger: logtest.Scoped(t), Clientset: clientset, Operations: command.NewOperations(&observation.TestContext)}
+			cmd := &command.KubernetesCommand{Logger: logtest.Scoped(t), Clientset: clientset, Operations: command.NewOperations(observation.TestContextTB(t))}
 			logger := runner.NewMockLogger()
 			logEntry := runner.NewMockLogEntry()
 			teardownLogEntry := runner.NewMockLogEntry()
@@ -181,7 +181,7 @@ func TestKubernetesRunner_Run(t *testing.T) {
 
 func TestKubernetesRunner_Teardown(t *testing.T) {
 	clientset := fake.NewSimpleClientset()
-	cmd := &command.KubernetesCommand{Logger: logtest.Scoped(t), Clientset: clientset, Operations: command.NewOperations(&observation.TestContext)}
+	cmd := &command.KubernetesCommand{Logger: logtest.Scoped(t), Clientset: clientset, Operations: command.NewOperations(observation.TestContextTB(t))}
 	logger := runner.NewMockLogger()
 	logEntry := runner.NewMockLogEntry()
 	logger.LogEntryFunc.PushReturn(logEntry)

--- a/cmd/executor/internal/worker/runtime/docker_test.go
+++ b/cmd/executor/internal/worker/runtime/docker_test.go
@@ -18,7 +18,7 @@ func TestDockerRuntime_Name(t *testing.T) {
 }
 
 func TestDockerRuntime_NewRunnerSpecs(t *testing.T) {
-	operations := command.NewOperations(&observation.TestContext)
+	operations := command.NewOperations(observation.TestContextTB(t))
 
 	tests := []struct {
 		name           string

--- a/cmd/executor/internal/worker/runtime/firecracker_test.go
+++ b/cmd/executor/internal/worker/runtime/firecracker_test.go
@@ -18,7 +18,7 @@ func TestFirecrackerRuntime_Name(t *testing.T) {
 }
 
 func TestFirecrackerRuntime_NewRunnerSpecs(t *testing.T) {
-	operations := command.NewOperations(&observation.TestContext)
+	operations := command.NewOperations(observation.TestContextTB(t))
 
 	tests := []struct {
 		name           string

--- a/cmd/executor/internal/worker/runtime/kubernetes_test.go
+++ b/cmd/executor/internal/worker/runtime/kubernetes_test.go
@@ -18,7 +18,7 @@ func TestKubernetesRuntime_Name(t *testing.T) {
 }
 
 func TestKubernetesRuntime_NewRunnerSpecs(t *testing.T) {
-	operations := command.NewOperations(&observation.TestContext)
+	operations := command.NewOperations(observation.TestContextTB(t))
 
 	tests := []struct {
 		name           string

--- a/cmd/executor/internal/worker/runtime/shell_test.go
+++ b/cmd/executor/internal/worker/runtime/shell_test.go
@@ -18,7 +18,7 @@ func TestShellRuntime_Name(t *testing.T) {
 }
 
 func TestShellRuntime_NewRunnerSpecs(t *testing.T) {
-	operations := command.NewOperations(&observation.TestContext)
+	operations := command.NewOperations(observation.TestContextTB(t))
 
 	tests := []struct {
 		name           string

--- a/cmd/executor/internal/worker/workspace/docker_test.go
+++ b/cmd/executor/internal/worker/workspace/docker_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 func TestNewDockerWorkspace(t *testing.T) {
-	operations := command.NewOperations(&observation.TestContext)
+	operations := command.NewOperations(observation.TestContextTB(t))
 
 	tests := []struct {
 		name                   string

--- a/cmd/executor/internal/worker/workspace/firecracker_test.go
+++ b/cmd/executor/internal/worker/workspace/firecracker_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 func TestNewFirecrackerWorkspace(t *testing.T) {
-	operations := command.NewOperations(&observation.TestContext)
+	operations := command.NewOperations(observation.TestContextTB(t))
 
 	tests := []struct {
 		name                   string

--- a/cmd/executor/internal/worker/workspace/kubernetes_test.go
+++ b/cmd/executor/internal/worker/workspace/kubernetes_test.go
@@ -26,7 +26,7 @@ func TestNewKubernetesWorkspace(t *testing.T) {
 		os.Unsetenv("KUBERNETES_SERVICE_HOST")
 	})
 
-	operations := command.NewOperations(&observation.TestContext)
+	operations := command.NewOperations(observation.TestContextTB(t))
 
 	tests := []struct {
 		name                   string
@@ -520,7 +520,7 @@ func TestNewKubernetesWorkspace_SingleJob(t *testing.T) {
 	cmd := workspace.NewMockCommand()
 	logger := workspace.NewMockLogger()
 
-	operations := command.NewOperations(&observation.TestContext)
+	operations := command.NewOperations(observation.TestContextTB(t))
 
 	ws, err := workspace.NewKubernetesWorkspace(
 		context.Background(),

--- a/cmd/frontend/graphqlbackend/guardrails_test.go
+++ b/cmd/frontend/graphqlbackend/guardrails_test.go
@@ -209,7 +209,7 @@ func TestSnippetAttributionReactsToSiteConfigChanges(t *testing.T) {
 	ctx := context.Background()
 	g := gitserver.NewClient("graphql.test")
 	var enterpriseServices enterprise.Services
-	require.NoError(t, guardrails.Init(ctx, &observation.TestContext, db, codeintel.Services{}, confMock, &enterpriseServices))
+	require.NoError(t, guardrails.Init(ctx, observation.TestContextTB(t), db, codeintel.Services{}, confMock, &enterpriseServices))
 	s, err := graphqlbackend.NewSchema(db, g, []graphqlbackend.OptionalResolver{{GuardrailsResolver: enterpriseServices.OptionalResolver.GuardrailsResolver}})
 	require.NoError(t, err)
 	// Same query runs in every test:

--- a/cmd/frontend/internal/batches/httpapi/file_handler_test.go
+++ b/cmd/frontend/internal/batches/httpapi/file_handler_test.go
@@ -36,7 +36,7 @@ func TestFileHandler_ServeHTTP(t *testing.T) {
 	modifiedTime, err := time.Parse("2006-01-02 15:04:05.999999999 -0700 MST", modifiedTimeString)
 	require.NoError(t, err)
 
-	operations := httpapi.NewOperations(&observation.TestContext)
+	operations := httpapi.NewOperations(observation.TestContextTB(t))
 
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))

--- a/cmd/frontend/internal/batches/resolvers/batch_change_connection_test.go
+++ b/cmd/frontend/internal/batches/resolvers/batch_change_connection_test.go
@@ -33,7 +33,7 @@ func TestBatchChangeConnectionResolver(t *testing.T) {
 
 	userID := bt.CreateTestUser(t, db, true).ID
 
-	bstore := bstore.New(db, &observation.TestContext, nil)
+	bstore := bstore.New(db, observation.TestContextTB(t), nil)
 	repoStore := database.ReposWith(logger, bstore)
 	esStore := database.ExternalServicesWith(logger, bstore)
 
@@ -189,7 +189,7 @@ func TestBatchChangesListing(t *testing.T) {
 
 	orgID := bt.CreateTestOrg(t, db, "org").ID
 
-	store := bstore.New(db, &observation.TestContext, nil)
+	store := bstore.New(db, observation.TestContextTB(t), nil)
 
 	r := &Resolver{store: store}
 	s, err := newSchema(db, r)

--- a/cmd/frontend/internal/batches/resolvers/batch_change_test.go
+++ b/cmd/frontend/internal/batches/resolvers/batch_change_test.go
@@ -39,7 +39,7 @@ func TestBatchChangeResolver(t *testing.T) {
 
 	now := timeutil.Now()
 	clock := func() time.Time { return now }
-	bstore := store.NewWithClock(db, &observation.TestContext, nil, clock)
+	bstore := store.NewWithClock(db, observation.TestContextTB(t), nil, clock)
 
 	batchSpec := &btypes.BatchSpec{
 		RawSpec:        bt.TestRawBatchSpec,
@@ -155,7 +155,7 @@ func TestBatchChangeResolver_BatchSpecs(t *testing.T) {
 
 	now := timeutil.Now()
 	clock := func() time.Time { return now }
-	bstore := store.NewWithClock(db, &observation.TestContext, nil, clock)
+	bstore := store.NewWithClock(db, observation.TestContextTB(t), nil, clock)
 
 	s, err := newSchema(db, &Resolver{store: bstore})
 	if err != nil {

--- a/cmd/frontend/internal/batches/resolvers/batch_spec_test.go
+++ b/cmd/frontend/internal/batches/resolvers/batch_spec_test.go
@@ -42,7 +42,7 @@ func TestBatchSpecResolver(t *testing.T) {
 	ctx := actor.WithInternalActor(context.Background())
 	db := database.NewDB(logger, dbtest.NewDB(t))
 
-	bstore := store.New(db, &observation.TestContext, nil)
+	bstore := store.New(db, observation.TestContextTB(t), nil)
 	repoStore := database.ReposWith(logger, bstore)
 	esStore := database.ExternalServicesWith(logger, bstore)
 
@@ -276,7 +276,7 @@ func TestBatchSpecResolver_BatchSpecCreatedFromRaw(t *testing.T) {
 
 	rs, extSvc := bt.CreateTestRepos(t, ctx, db, 3)
 
-	bstore := store.New(db, &observation.TestContext, nil)
+	bstore := store.New(db, observation.TestContextTB(t), nil)
 
 	svc := service.New(bstore)
 	spec, err := svc.CreateBatchSpecFromRaw(userCtx, service.CreateBatchSpecFromRawOpts{
@@ -507,7 +507,7 @@ func TestBatchSpecResolver_Files(t *testing.T) {
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	bstore := store.New(db, &observation.TestContext, nil)
+	bstore := store.New(db, observation.TestContextTB(t), nil)
 
 	resolver := batchSpecResolver{
 		store:     bstore,

--- a/cmd/frontend/internal/batches/resolvers/batch_spec_workspace_file_connection_test.go
+++ b/cmd/frontend/internal/batches/resolvers/batch_spec_workspace_file_connection_test.go
@@ -29,7 +29,7 @@ func TestBatchSpecWorkspaceFileConnectionResolver(t *testing.T) {
 	ctx := actor.WithInternalActor(context.Background())
 	db := database.NewDB(logger, dbtest.NewDB(t))
 
-	bstore := store.New(db, &observation.TestContext, nil)
+	bstore := store.New(db, observation.TestContextTB(t), nil)
 	specID, err := createBatchSpec(t, db, ctx, bstore)
 	require.NoError(t, err)
 

--- a/cmd/frontend/internal/batches/resolvers/batch_spec_workspace_test.go
+++ b/cmd/frontend/internal/batches/resolvers/batch_spec_workspace_test.go
@@ -32,7 +32,7 @@ func TestBatchSpecWorkspaceResolver(t *testing.T) {
 	ctx := actor.WithInternalActor(context.Background())
 	db := database.NewDB(logger, dbtest.NewDB(t))
 
-	bstore := store.New(db, &observation.TestContext, nil)
+	bstore := store.New(db, observation.TestContextTB(t), nil)
 	repo, _ := bt.CreateTestRepo(t, ctx, db)
 
 	repoID := graphqlbackend.MarshalRepositoryID(repo.ID)

--- a/cmd/frontend/internal/batches/resolvers/bulk_operation_connection_test.go
+++ b/cmd/frontend/internal/batches/resolvers/bulk_operation_connection_test.go
@@ -33,7 +33,7 @@ func TestBulkOperationConnectionResolver(t *testing.T) {
 	userID := bt.CreateTestUser(t, db, true).ID
 	now := timeutil.Now()
 	clock := func() time.Time { return now }
-	bstore := store.NewWithClock(db, &observation.TestContext, nil, clock)
+	bstore := store.NewWithClock(db, observation.TestContextTB(t), nil, clock)
 
 	batchSpec := bt.CreateBatchSpec(t, ctx, bstore, "test", userID, 0)
 	batchChange := bt.CreateBatchChange(t, ctx, bstore, "test", userID, batchSpec.ID)

--- a/cmd/frontend/internal/batches/resolvers/bulk_operation_test.go
+++ b/cmd/frontend/internal/batches/resolvers/bulk_operation_test.go
@@ -35,7 +35,7 @@ func TestBulkOperationResolver(t *testing.T) {
 
 	now := timeutil.Now()
 	clock := func() time.Time { return now }
-	bstore := store.NewWithClock(db, &observation.TestContext, nil, clock)
+	bstore := store.NewWithClock(db, observation.TestContextTB(t), nil, clock)
 
 	batchSpec := bt.CreateBatchSpec(t, ctx, bstore, "test", userID, 0)
 	batchChange := bt.CreateBatchChange(t, ctx, bstore, "test", userID, batchSpec.ID)

--- a/cmd/frontend/internal/batches/resolvers/changeset_apply_preview_connection_test.go
+++ b/cmd/frontend/internal/batches/resolvers/changeset_apply_preview_connection_test.go
@@ -39,7 +39,7 @@ func TestChangesetApplyPreviewConnectionResolver(t *testing.T) {
 
 	userID := bt.CreateTestUser(t, db, false).ID
 
-	bstore := store.New(db, &observation.TestContext, nil)
+	bstore := store.New(db, observation.TestContextTB(t), nil)
 
 	batchSpec := &btypes.BatchSpec{
 		UserID:          userID,

--- a/cmd/frontend/internal/batches/resolvers/changeset_apply_preview_test.go
+++ b/cmd/frontend/internal/batches/resolvers/changeset_apply_preview_test.go
@@ -39,7 +39,7 @@ func TestChangesetApplyPreviewResolver(t *testing.T) {
 
 	userID := bt.CreateTestUser(t, db, false).ID
 
-	bstore := store.New(db, &observation.TestContext, nil)
+	bstore := store.New(db, observation.TestContextTB(t), nil)
 
 	// Create a batch spec for the target batch change.
 	oldBatchSpec := &btypes.BatchSpec{
@@ -270,7 +270,7 @@ func TestChangesetApplyPreviewResolverWithPublicationStates(t *testing.T) {
 
 	userID := bt.CreateTestUser(t, db, false).ID
 
-	bstore := store.New(db, &observation.TestContext, nil)
+	bstore := store.New(db, observation.TestContextTB(t), nil)
 	esStore := database.ExternalServicesWith(logger, bstore)
 	repoStore := database.ReposWith(logger, bstore)
 

--- a/cmd/frontend/internal/batches/resolvers/changeset_connection_test.go
+++ b/cmd/frontend/internal/batches/resolvers/changeset_connection_test.go
@@ -32,7 +32,7 @@ func TestChangesetConnectionResolver(t *testing.T) {
 
 	userID := bt.CreateTestUser(t, db, false).ID
 
-	bstore := store.New(db, &observation.TestContext, nil)
+	bstore := store.New(db, observation.TestContextTB(t), nil)
 	repoStore := database.ReposWith(logger, bstore)
 	esStore := database.ExternalServicesWith(logger, bstore)
 

--- a/cmd/frontend/internal/batches/resolvers/changeset_counts_test.go
+++ b/cmd/frontend/internal/batches/resolvers/changeset_counts_test.go
@@ -129,7 +129,7 @@ func TestChangesetCountsOverTimeIntegration(t *testing.T) {
 	})
 	defer mockState.Unmock()
 
-	bstore := store.New(db, &observation.TestContext, nil)
+	bstore := store.New(db, observation.TestContextTB(t), nil)
 
 	if err := bstore.CreateSiteCredential(ctx,
 		&btypes.SiteCredential{

--- a/cmd/frontend/internal/batches/resolvers/changeset_event_connection_test.go
+++ b/cmd/frontend/internal/batches/resolvers/changeset_event_connection_test.go
@@ -36,7 +36,7 @@ func TestChangesetEventConnectionResolver(t *testing.T) {
 
 	now := timeutil.Now()
 	clock := func() time.Time { return now }
-	bstore := store.NewWithClock(db, &observation.TestContext, nil, clock)
+	bstore := store.NewWithClock(db, observation.TestContextTB(t), nil, clock)
 	repoStore := database.ReposWith(logger, bstore)
 	esStore := database.ExternalServicesWith(logger, bstore)
 

--- a/cmd/frontend/internal/batches/resolvers/changeset_spec_connection_test.go
+++ b/cmd/frontend/internal/batches/resolvers/changeset_spec_connection_test.go
@@ -32,7 +32,7 @@ func TestChangesetSpecConnectionResolver(t *testing.T) {
 
 	userID := bt.CreateTestUser(t, db, false).ID
 
-	bstore := store.New(db, &observation.TestContext, nil)
+	bstore := store.New(db, observation.TestContextTB(t), nil)
 
 	batchSpec := &btypes.BatchSpec{
 		UserID:          userID,

--- a/cmd/frontend/internal/batches/resolvers/changeset_spec_test.go
+++ b/cmd/frontend/internal/batches/resolvers/changeset_spec_test.go
@@ -35,7 +35,7 @@ func TestChangesetSpecResolver(t *testing.T) {
 
 	userID := bt.CreateTestUser(t, db, false).ID
 
-	bstore := store.New(db, &observation.TestContext, nil)
+	bstore := store.New(db, observation.TestContextTB(t), nil)
 	esStore := database.ExternalServicesWith(logger, bstore)
 
 	// Creating user with matching email to the changeset spec author.

--- a/cmd/frontend/internal/batches/resolvers/changeset_test.go
+++ b/cmd/frontend/internal/batches/resolvers/changeset_test.go
@@ -40,7 +40,7 @@ func TestChangesetResolver(t *testing.T) {
 
 	now := timeutil.Now()
 	clock := func() time.Time { return now }
-	bstore := store.NewWithClock(db, &observation.TestContext, nil, clock)
+	bstore := store.NewWithClock(db, observation.TestContextTB(t), nil, clock)
 	esStore := database.ExternalServicesWith(logger, bstore)
 	repoStore := database.ReposWith(logger, bstore)
 

--- a/cmd/frontend/internal/batches/resolvers/code_host_connection_test.go
+++ b/cmd/frontend/internal/batches/resolvers/code_host_connection_test.go
@@ -36,7 +36,7 @@ func TestCodeHostConnectionResolver(t *testing.T) {
 	userID := bt.CreateTestUser(t, db, true).ID
 	userAPIID := string(graphqlbackend.MarshalUserID(userID))
 
-	bstore := store.New(db, &observation.TestContext, nil)
+	bstore := store.New(db, observation.TestContextTB(t), nil)
 
 	ghRepo, _ := bt.CreateTestRepo(t, ctx, db)
 	glRepos, _ := bt.CreateGitlabTestRepos(t, ctx, db, 1)

--- a/cmd/frontend/internal/batches/resolvers/permissions_test.go
+++ b/cmd/frontend/internal/batches/resolvers/permissions_test.go
@@ -49,7 +49,7 @@ func TestPermissionLevels(t *testing.T) {
 	db := database.NewDB(logger, dbtest.NewDB(t))
 	key := et.TestKey{}
 
-	bstore := store.New(db, &observation.TestContext, key)
+	bstore := store.New(db, observation.TestContextTB(t), key)
 	sr := New(db, bstore, gitserver.NewMockClient(), logger)
 	s, err := newSchema(db, sr)
 	if err != nil {
@@ -1361,7 +1361,7 @@ func TestRepositoryPermissions(t *testing.T) {
 
 	db := database.NewDB(logger, dbtest.NewDB(t))
 
-	bstore := store.New(db, &observation.TestContext, nil)
+	bstore := store.New(db, observation.TestContextTB(t), nil)
 	gitserverClient := gitserver.NewMockClient()
 	sr := &Resolver{store: bstore}
 	s, err := newSchema(db, sr)

--- a/cmd/frontend/internal/batches/resolvers/resolver_test.go
+++ b/cmd/frontend/internal/batches/resolvers/resolver_test.go
@@ -52,7 +52,7 @@ func TestNullIDResilience(t *testing.T) {
 	logger := logtest.Scoped(t)
 
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	sr := New(db, store.New(db, &observation.TestContext, nil), gitserver.NewMockClient(), logger)
+	sr := New(db, store.New(db, observation.TestContextTB(t), nil), gitserver.NewMockClient(), logger)
 
 	s, err := newSchema(db, sr)
 	if err != nil {
@@ -149,7 +149,7 @@ func TestCreateBatchSpec(t *testing.T) {
 
 	unauthorizedUser := bt.CreateTestUser(t, db, false)
 
-	bstore := store.New(db, &observation.TestContext, nil)
+	bstore := store.New(db, observation.TestContextTB(t), nil)
 	repoStore := database.ReposWith(logger, bstore)
 	esStore := database.ExternalServicesWith(logger, bstore)
 
@@ -348,7 +348,7 @@ func TestCreateBatchSpecFromRaw(t *testing.T) {
 
 	unauthorizedUser := bt.CreateTestUser(t, db, false)
 
-	bstore := store.New(db, &observation.TestContext, nil)
+	bstore := store.New(db, observation.TestContextTB(t), nil)
 
 	r := &Resolver{store: bstore}
 	s, err := newSchema(db, r)
@@ -482,7 +482,7 @@ func TestCreateChangesetSpec(t *testing.T) {
 
 	unauthorizedUser := bt.CreateTestUser(t, db, false)
 
-	bstore := store.New(db, &observation.TestContext, nil)
+	bstore := store.New(db, observation.TestContextTB(t), nil)
 	repoStore := database.ReposWith(logger, bstore)
 	esStore := database.ExternalServicesWith(logger, bstore)
 
@@ -576,7 +576,7 @@ func TestCreateChangesetSpecs(t *testing.T) {
 
 	unauthorizedUser := bt.CreateTestUser(t, db, false)
 
-	bstore := store.New(db, &observation.TestContext, nil)
+	bstore := store.New(db, observation.TestContextTB(t), nil)
 	repoStore := database.ReposWith(logger, bstore)
 	esStore := database.ExternalServicesWith(logger, bstore)
 
@@ -688,7 +688,7 @@ func TestApplyBatchChange(t *testing.T) {
 
 	now := timeutil.Now()
 	clock := func() time.Time { return now }
-	bstore := store.NewWithClock(db, &observation.TestContext, nil, clock)
+	bstore := store.NewWithClock(db, observation.TestContextTB(t), nil, clock)
 	repoStore := database.ReposWith(logger, bstore)
 	esStore := database.ExternalServicesWith(logger, bstore)
 
@@ -860,7 +860,7 @@ func TestCreateEmptyBatchChange(t *testing.T) {
 	ctx := context.Background()
 	db := database.NewDB(logger, dbtest.NewDB(t))
 
-	bstore := store.New(db, &observation.TestContext, nil)
+	bstore := store.New(db, observation.TestContextTB(t), nil)
 
 	r := &Resolver{store: bstore}
 	s, err := newSchema(db, r)
@@ -968,7 +968,7 @@ func TestUpsertEmptyBatchChange(t *testing.T) {
 	ctx := context.Background()
 	db := database.NewDB(logger, dbtest.NewDB(t))
 
-	bstore := store.New(db, &observation.TestContext, nil)
+	bstore := store.New(db, observation.TestContextTB(t), nil)
 
 	r := &Resolver{store: bstore}
 	s, err := newSchema(db, r)
@@ -1064,7 +1064,7 @@ func TestCreateBatchChange(t *testing.T) {
 
 	unauthorizedUser := bt.CreateTestUser(t, db, false)
 
-	bstore := store.New(db, &observation.TestContext, nil)
+	bstore := store.New(db, observation.TestContextTB(t), nil)
 
 	batchSpec := &btypes.BatchSpec{
 		RawSpec: bt.TestRawBatchSpec,
@@ -1176,7 +1176,7 @@ func TestApplyOrCreateBatchSpecWithPublicationStates(t *testing.T) {
 
 	now := timeutil.Now()
 	clock := func() time.Time { return now }
-	bstore := store.NewWithClock(db, &observation.TestContext, nil, clock)
+	bstore := store.NewWithClock(db, observation.TestContextTB(t), nil, clock)
 	repoStore := database.ReposWith(logger, bstore)
 	esStore := database.ExternalServicesWith(logger, bstore)
 
@@ -1372,7 +1372,7 @@ func TestApplyBatchChangeWithLicenseFail(t *testing.T) {
 	now := timeutil.Now()
 	clock := func() time.Time { return now }
 
-	bstore := store.NewWithClock(db, &observation.TestContext, nil, clock)
+	bstore := store.NewWithClock(db, observation.TestContextTB(t), nil, clock)
 	repoStore := database.ReposWith(logger, bstore)
 	esStore := database.ExternalServicesWith(logger, bstore)
 
@@ -1525,7 +1525,7 @@ func TestMoveBatchChange(t *testing.T) {
 	orgName := "move-batch-change-test"
 	orgID := bt.CreateTestOrg(t, db, orgName).ID
 
-	bstore := store.New(db, &observation.TestContext, nil)
+	bstore := store.New(db, observation.TestContextTB(t), nil)
 
 	batchSpec := &btypes.BatchSpec{
 		RawSpec:         bt.TestRawBatchSpec,
@@ -1828,7 +1828,7 @@ func TestCreateBatchChangesCredential(t *testing.T) {
 
 	userID := bt.CreateTestUser(t, db, true).ID
 
-	bstore := store.New(db, &observation.TestContext, nil)
+	bstore := store.New(db, observation.TestContextTB(t), nil)
 
 	r := &Resolver{store: bstore}
 	s, err := newSchema(db, r)
@@ -1959,7 +1959,7 @@ func TestDeleteBatchChangesCredential(t *testing.T) {
 	userID := bt.CreateTestUser(t, db, true).ID
 	ctx = actor.WithActor(ctx, actor.FromUser(userID))
 
-	bstore := store.New(db, &observation.TestContext, nil)
+	bstore := store.New(db, observation.TestContextTB(t), nil)
 
 	authenticator := &auth.OAuthBearerToken{Token: "SOSECRET"}
 	userCred, err := bstore.UserCredentials().Create(ctx, database.UserCredentialScope{
@@ -2044,7 +2044,7 @@ func TestCreateChangesetComments(t *testing.T) {
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	bstore := store.New(db, &observation.TestContext, nil)
+	bstore := store.New(db, observation.TestContextTB(t), nil)
 
 	userID := bt.CreateTestUser(t, db, true).ID
 	// We give this user the `BATCH_CHANGES#WRITE` permission so they're authorized
@@ -2164,7 +2164,7 @@ func TestReenqueueChangesets(t *testing.T) {
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	bstore := store.New(db, &observation.TestContext, nil)
+	bstore := store.New(db, observation.TestContextTB(t), nil)
 
 	userID := bt.CreateTestUser(t, db, true).ID
 	// We give this user the `BATCH_CHANGES#WRITE` permission so they're authorized
@@ -2293,7 +2293,7 @@ func TestMergeChangesets(t *testing.T) {
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	bstore := store.New(db, &observation.TestContext, nil)
+	bstore := store.New(db, observation.TestContextTB(t), nil)
 
 	userID := bt.CreateTestUser(t, db, true).ID
 	// We give this user the `BATCH_CHANGES#WRITE` permission so they're authorized
@@ -2423,7 +2423,7 @@ func TestCloseChangesets(t *testing.T) {
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	bstore := store.New(db, &observation.TestContext, nil)
+	bstore := store.New(db, observation.TestContextTB(t), nil)
 
 	userID := bt.CreateTestUser(t, db, true).ID
 	// We give this user the `BATCH_CHANGES#WRITE` permission so they're authorized
@@ -2553,7 +2553,7 @@ func TestPublishChangesets(t *testing.T) {
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	bstore := store.New(db, &observation.TestContext, nil)
+	bstore := store.New(db, observation.TestContextTB(t), nil)
 
 	userID := bt.CreateTestUser(t, db, true).ID
 	// We give this user the `BATCH_CHANGES#WRITE` permission so they're authorized
@@ -2704,7 +2704,7 @@ func TestCheckBatchChangesCredential(t *testing.T) {
 	userID := bt.CreateTestUser(t, db, true).ID
 	ctx = actor.WithActor(ctx, actor.FromUser(userID))
 
-	bstore := store.New(db, &observation.TestContext, nil)
+	bstore := store.New(db, observation.TestContextTB(t), nil)
 
 	authenticator := &auth.OAuthBearerToken{Token: "SOSECRET"}
 	userCred, err := bstore.UserCredentials().Create(ctx, database.UserCredentialScope{
@@ -2800,7 +2800,7 @@ func TestMaxUnlicensedChangesets(t *testing.T) {
 	var response struct{ MaxUnlicensedChangesets int32 }
 	actorCtx := actor.WithActor(context.Background(), actor.FromUser(userID))
 
-	bstore := store.New(db, &observation.TestContext, nil)
+	bstore := store.New(db, observation.TestContextTB(t), nil)
 	r := &Resolver{store: bstore}
 	s, err := newSchema(db, r)
 	require.NoError(t, err)
@@ -2824,7 +2824,7 @@ func TestListBatchSpecs(t *testing.T) {
 	user := bt.CreateTestUser(t, db, true)
 	userID := user.ID
 
-	bstore := store.New(db, &observation.TestContext, nil)
+	bstore := store.New(db, observation.TestContextTB(t), nil)
 
 	batchSpecs := make([]*btypes.BatchSpec, 0, 10)
 
@@ -2891,7 +2891,7 @@ func TestGetChangesetsByIDs(t *testing.T) {
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	bstore := store.New(db, &observation.TestContext, nil)
+	bstore := store.New(db, observation.TestContextTB(t), nil)
 
 	userID := bt.CreateTestUser(t, db, true).ID
 	// We give this user the `BATCH_CHANGES#WRITE` permission so they're authorized

--- a/cmd/frontend/internal/batches/webhooks/bitbucketcloud_test.go
+++ b/cmd/frontend/internal/batches/webhooks/bitbucketcloud_test.go
@@ -400,7 +400,7 @@ func bitbucketCloudTestSetup(t *testing.T, sqlDB *sql.DB) *bstore.Store {
 	// transactions within the test.
 	db := database.NewDBWith(logger, basestore.NewWithHandle(&nestedTx{basestore.NewHandleWithTx(tx, sql.TxOptions{})}))
 
-	return bstore.NewWithClock(db, &observation.TestContext, nil, clock.Now)
+	return bstore.NewWithClock(db, observation.TestContextTB(t), nil, clock.Now)
 }
 
 // createBitbucketCloudExternalService creates a mock Bitbucket Cloud service

--- a/cmd/frontend/internal/batches/webhooks/bitbucketserver_test.go
+++ b/cmd/frontend/internal/batches/webhooks/bitbucketserver_test.go
@@ -100,7 +100,7 @@ func testBitbucketServerWebhook(db database.DB, userID int32) func(*testing.T) {
 			t.Fatal(err)
 		}
 
-		s := store.NewWithClock(db, &observation.TestContext, nil, clock)
+		s := store.NewWithClock(db, observation.TestContextTB(t), nil, clock)
 
 		if err := s.CreateSiteCredential(ctx, &btypes.SiteCredential{
 			ExternalServiceType: bitbucketRepo.ExternalRepo.ServiceType,

--- a/cmd/frontend/internal/batches/webhooks/github_test.go
+++ b/cmd/frontend/internal/batches/webhooks/github_test.go
@@ -98,7 +98,7 @@ func testGitHubWebhook(db database.DB, userID int32) func(*testing.T) {
 			t.Fatal(err)
 		}
 
-		s := store.NewWithClock(db, &observation.TestContext, nil, clock)
+		s := store.NewWithClock(db, observation.TestContextTB(t), nil, clock)
 		if err := s.CreateSiteCredential(ctx, &btypes.SiteCredential{
 			ExternalServiceType: githubRepo.ExternalRepo.ServiceType,
 			ExternalServiceID:   githubRepo.ExternalRepo.ServiceID,

--- a/cmd/frontend/internal/batches/webhooks/gitlab_test.go
+++ b/cmd/frontend/internal/batches/webhooks/gitlab_test.go
@@ -503,7 +503,7 @@ func testGitLabWebhook(db *sql.DB) func(*testing.T) {
 			s := gitLabTestSetup(t, db)
 			h := NewGitLabWebhook(s, gsClient, logger)
 			db := database.NewDBWith(logger, basestore.NewWithHandle(&brokenDB{errors.New("foo")}))
-			h.Store = bstore.NewWithClock(db, &observation.TestContext, nil, s.Clock())
+			h.Store = bstore.NewWithClock(db, observation.TestContextTB(t), nil, s.Clock())
 
 			es, err := h.getExternalServiceFromRawID(ctx, "12345")
 			if es != nil {
@@ -560,7 +560,7 @@ func testGitLabWebhook(db *sql.DB) func(*testing.T) {
 
 				// We can induce an error with a broken database connection.
 				db := database.NewDBWith(logger, basestore.NewWithHandle(&brokenDB{errors.New("foo")}))
-				h.Store = bstore.NewWithClock(db, &observation.TestContext, nil, s.Clock())
+				h.Store = bstore.NewWithClock(db, observation.TestContextTB(t), nil, s.Clock())
 
 				err := h.handleEvent(ctx, db, gitLabURL, event)
 				require.Error(t, err)
@@ -577,7 +577,7 @@ func testGitLabWebhook(db *sql.DB) func(*testing.T) {
 
 				// We can induce an error with a broken database connection.
 				db := database.NewDBWith(logger, basestore.NewWithHandle(&brokenDB{errors.New("foo")}))
-				h.Store = bstore.NewWithClock(db, &observation.TestContext, nil, s.Clock())
+				h.Store = bstore.NewWithClock(db, observation.TestContextTB(t), nil, s.Clock())
 
 				err := h.handleEvent(ctx, db, gitLabURL, event)
 				require.Error(t, err)
@@ -683,7 +683,7 @@ func testGitLabWebhook(db *sql.DB) func(*testing.T) {
 			// Again, we're going to set up a poisoned store database that will
 			// error if a transaction is started.
 			s := gitLabTestSetup(t, db)
-			store := bstore.NewWithClock(database.NewDBWith(logger, basestore.NewWithHandle(&noNestingTx{s.Handle()})), &observation.TestContext, nil, s.Clock())
+			store := bstore.NewWithClock(database.NewDBWith(logger, basestore.NewWithHandle(&noNestingTx{s.Handle()})), observation.TestContextTB(t), nil, s.Clock())
 			h := NewGitLabWebhook(store, gsClient, logger)
 
 			t.Run("missing merge request", func(t *testing.T) {
@@ -870,7 +870,7 @@ func gitLabTestSetup(t *testing.T, sqlDB *sql.DB) *bstore.Store {
 
 	// Note that tx is wrapped in nestedTx to effectively neuter further use of
 	// transactions within the test.
-	return bstore.NewWithClock(db, &observation.TestContext, nil, c.Now)
+	return bstore.NewWithClock(db, observation.TestContextTB(t), nil, c.Now)
 }
 
 // assertBodyIncludes checks for a specific substring within the given response

--- a/cmd/gitserver/internal/cleanup_test.go
+++ b/cmd/gitserver/internal/cleanup_test.go
@@ -72,7 +72,7 @@ UPDATE gitserver_repos SET repo_size_bytes = 5 where repo_id = 3;
 		t.Fatalf("unexpected error while inserting test data: %s", err)
 	}
 
-	fs := gitserverfs.New(&observation.TestContext, root)
+	fs := gitserverfs.New(observation.TestContextTB(t), root)
 	require.NoError(t, fs.Initialize())
 	cleanupRepos(
 		actor.WithInternalActor(context.Background()),
@@ -136,7 +136,7 @@ func TestCleanupInactive(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	fs := gitserverfs.New(&observation.TestContext, root)
+	fs := gitserverfs.New(observation.TestContextTB(t), root)
 	require.NoError(t, fs.Initialize())
 
 	cleanupRepos(
@@ -178,7 +178,7 @@ func TestCleanupWrongShard(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		fs := gitserverfs.New(&observation.TestContext, root)
+		fs := gitserverfs.New(observation.TestContextTB(t), root)
 		require.NoError(t, fs.Initialize())
 
 		cleanupRepos(
@@ -218,7 +218,7 @@ func TestCleanupWrongShard(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		fs := gitserverfs.New(&observation.TestContext, root)
+		fs := gitserverfs.New(observation.TestContextTB(t), root)
 		require.NoError(t, fs.Initialize())
 
 		cleanupRepos(
@@ -258,7 +258,7 @@ func TestCleanupWrongShard(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		fs := gitserverfs.New(&observation.TestContext, root)
+		fs := gitserverfs.New(observation.TestContextTB(t), root)
 		require.NoError(t, fs.Initialize())
 
 		cleanupRepos(
@@ -334,7 +334,7 @@ func TestGitGCAuto(t *testing.T) {
 		t.Fatalf("expected git to report objects but none found")
 	}
 
-	fs := gitserverfs.New(&observation.TestContext, root)
+	fs := gitserverfs.New(observation.TestContextTB(t), root)
 	require.NoError(t, fs.Initialize())
 
 	cleanupRepos(
@@ -464,7 +464,7 @@ func TestCleanupExpired(t *testing.T) {
 		return "done", nil
 	}
 
-	fs := gitserverfs.New(&observation.TestContext, root)
+	fs := gitserverfs.New(observation.TestContextTB(t), root)
 	require.NoError(t, fs.Initialize())
 
 	cleanupRepos(
@@ -531,7 +531,7 @@ func TestCleanup_RemoveNonExistentRepos(t *testing.T) {
 		root := t.TempDir()
 		repoExists, repoNotExists := initRepos(root)
 
-		fs := gitserverfs.New(&observation.TestContext, root)
+		fs := gitserverfs.New(observation.TestContextTB(t), root)
 		require.NoError(t, fs.Initialize())
 
 		cleanupRepos(
@@ -563,7 +563,7 @@ func TestCleanup_RemoveNonExistentRepos(t *testing.T) {
 		root := t.TempDir()
 		repoExists, repoNotExists := initRepos(root)
 
-		fs := gitserverfs.New(&observation.TestContext, root)
+		fs := gitserverfs.New(observation.TestContextTB(t), root)
 		require.NoError(t, fs.Initialize())
 
 		cleanupRepos(
@@ -718,7 +718,7 @@ func TestCleanupOldLocks(t *testing.T) {
 		}
 	}
 
-	fs := gitserverfs.New(&observation.TestContext, root)
+	fs := gitserverfs.New(observation.TestContextTB(t), root)
 	require.NoError(t, fs.Initialize())
 
 	cleanupRepos(
@@ -885,7 +885,7 @@ func isEmptyDir(path string) (bool, error) {
 func TestFreeUpSpace(t *testing.T) {
 	logger := logtest.Scoped(t)
 	root := t.TempDir()
-	fs := gitserverfs.New(&observation.TestContext, root)
+	fs := gitserverfs.New(observation.TestContextTB(t), root)
 	require.NoError(t, fs.Initialize())
 	t.Run("no error if no space requested and no repos", func(t *testing.T) {
 		if err := freeUpSpace(context.Background(), logger, newMockedGitserverDB(), fs, "test-gitserver", &fakeDiskUsage{}, 10, 0); err != nil {

--- a/cmd/gitserver/internal/integration_tests/clone_test.go
+++ b/cmd/gitserver/internal/integration_tests/clone_test.go
@@ -53,7 +53,7 @@ func TestClone(t *testing.T) {
 	lock := NewMockRepositoryLock()
 	locker.TryAcquireFunc.SetDefaultReturn(lock, true)
 
-	fs := gitserverfs.New(&observation.TestContext, reposDir)
+	fs := gitserverfs.New(observation.TestContextTB(t), reposDir)
 	require.NoError(t, fs.Initialize())
 	getRemoteURLFunc := func(_ context.Context, name api.RepoName) (string, error) { //nolint:unparam
 		require.Equal(t, repo, name)
@@ -169,7 +169,7 @@ func TestClone_Fail(t *testing.T) {
 	lock := NewMockRepositoryLock()
 	locker.TryAcquireFunc.SetDefaultReturn(lock, true)
 
-	fs := gitserverfs.New(&observation.TestContext, reposDir)
+	fs := gitserverfs.New(observation.TestContextTB(t), reposDir)
 	require.NoError(t, fs.Initialize())
 	getRemoteURLFunc := func(_ context.Context, name api.RepoName) (string, error) { //nolint:unparam
 		require.Equal(t, repo, name)

--- a/cmd/gitserver/internal/integration_tests/resolverevisions_test.go
+++ b/cmd/gitserver/internal/integration_tests/resolverevisions_test.go
@@ -72,7 +72,7 @@ func TestClient_ResolveRevision(t *testing.T) {
 	db := newMockDB()
 	ctx := context.Background()
 
-	fs := gitserverfs.New(&observation.TestContext, filepath.Join(root, "repos"))
+	fs := gitserverfs.New(observation.TestContextTB(t), filepath.Join(root, "repos"))
 	require.NoError(t, fs.Initialize())
 	getRemoteURLFunc := func(_ context.Context, name api.RepoName) (string, error) { //nolint:unparam
 		return remote, nil

--- a/cmd/gitserver/internal/integration_tests/test_utils.go
+++ b/cmd/gitserver/internal/integration_tests/test_utils.go
@@ -80,7 +80,7 @@ func InitGitserver() {
 	})
 	db.ReposFunc.SetDefaultReturn(r)
 
-	fs := gitserverfs.New(&observation.TestContext, filepath.Join(root, "repos"))
+	fs := gitserverfs.New(observation.TestContextTB(&t), filepath.Join(root, "repos"))
 	require.NoError(&t, fs.Initialize())
 	getRemoteURLFunc := func(_ context.Context, name api.RepoName) (string, error) { //nolint:unparam // context is unused but required by the interface, error is not used in this test
 		return filepath.Join(root, "remotes", string(name)), nil

--- a/cmd/gitserver/internal/server_test.go
+++ b/cmd/gitserver/internal/server_test.go
@@ -115,7 +115,7 @@ func TestExecRequest(t *testing.T) {
 	db := dbmocks.NewMockDB()
 	gr := dbmocks.NewMockGitserverRepoStore()
 	db.GitserverReposFunc.SetDefaultReturn(gr)
-	fs := gitserverfs.New(&observation.TestContext, t.TempDir())
+	fs := gitserverfs.New(observation.TestContextTB(t), t.TempDir())
 	require.NoError(t, fs.Initialize())
 	s := NewServer(&ServerOpts{
 		Logger: logtest.Scoped(t),
@@ -1148,7 +1148,7 @@ func TestServer_IsRepoCloneable_InternalActor(t *testing.T) {
 
 	isCloneableCalled := false
 
-	fs := gitserverfs.New(&observation.TestContext, t.TempDir())
+	fs := gitserverfs.New(observation.TestContextTB(t), t.TempDir())
 	require.NoError(t, fs.Initialize())
 
 	s := NewServer(&ServerOpts{

--- a/cmd/gitserver/internal/vcssyncer/jvm_packages_test.go
+++ b/cmd/gitserver/internal/vcssyncer/jvm_packages_test.go
@@ -136,7 +136,7 @@ func TestNoMaliciousFiles(t *testing.T) {
 
 	cacheDir := filepath.Join(dir, "cache")
 	s := jvmPackagesSyncer{
-		coursier: coursier.NewCoursierHandle(&observation.TestContext, cacheDir),
+		coursier: coursier.NewCoursierHandle(observation.TestContextTB(t), cacheDir),
 		config:   &schema.JVMPackagesConnection{Maven: schema.Maven{Dependencies: []string{}}},
 		fetch: func(ctx context.Context, config *schema.JVMPackagesConnection, dependency *reposource.MavenVersionedPackage) (sourceCodeJarPath string, err error) {
 			jarPath := path.Join(dir, "sampletext.zip")
@@ -219,7 +219,7 @@ func TestJVMCloneCommand(t *testing.T) {
 
 	depsSvc := dependencies.TestService(database.NewDB(logger, dbtest.NewDB(t)))
 	cacheDir := filepath.Join(dir, "cache")
-	fs := gitserverfs.New(&observation.TestContext, dir)
+	fs := gitserverfs.New(observation.TestContextTB(t), dir)
 	require.NoError(t, fs.Initialize())
 	s := NewJVMPackagesSyncer(&schema.JVMPackagesConnection{Maven: schema.Maven{Dependencies: []string{}}}, depsSvc, testGetRemoteURLSource, cacheDir, fs).(*vcsPackagesSyncer)
 	bareGitDirectory := path.Join(dir, "git")

--- a/cmd/gitserver/internal/vcssyncer/npm_packages_test.go
+++ b/cmd/gitserver/internal/vcssyncer/npm_packages_test.go
@@ -121,7 +121,7 @@ func TestNpmCloneCommand(t *testing.T) {
 
 	depsSvc := dependencies.TestService(database.NewDB(logger, dbtest.NewDB(t)))
 
-	fs := gitserverfs.New(&observation.TestContext, dir)
+	fs := gitserverfs.New(observation.TestContextTB(t), dir)
 	require.NoError(t, fs.Initialize())
 
 	s := NewNpmPackagesSyncer(

--- a/cmd/gitserver/internal/vcssyncer/packages_syncer_test.go
+++ b/cmd/gitserver/internal/vcssyncer/packages_syncer_test.go
@@ -39,7 +39,7 @@ func TestVcsDependenciesSyncer_Fetch(t *testing.T) {
 	depsService := &fakeDepsService{deps: map[reposource.PackageName]dependencies.PackageRepoReference{}}
 
 	root := t.TempDir()
-	fs := gitserverfs.New(&observation.TestContext, root)
+	fs := gitserverfs.New(observation.TestContextTB(t), root)
 	require.NoError(t, fs.Initialize())
 	remoteURL := &vcs.URL{URL: url.URL{Path: "fake/foo"}}
 

--- a/cmd/gitserver/internal/vcssyncer/syncer_test.go
+++ b/cmd/gitserver/internal/vcssyncer/syncer_test.go
@@ -27,7 +27,7 @@ func TestGetVCSSyncer(t *testing.T) {
 	}
 	tempCoursierCacheDir := filepath.Join(tempReposDir, "coursier")
 
-	fs := gitserverfs.New(&observation.TestContext, tempReposDir)
+	fs := gitserverfs.New(observation.TestContextTB(t), tempReposDir)
 	require.NoError(t, fs.Initialize())
 
 	repo := api.RepoName("foo/bar")

--- a/cmd/symbols/internal/api/handler_test.go
+++ b/cmd/symbols/internal/api/handler_test.go
@@ -78,7 +78,7 @@ func TestHandler(t *testing.T) {
 	gitserverClient := NewMockGitserverClient()
 	gitserverClient.FetchTarFunc.SetDefaultHook(gitserver.CreateTestFetchTarFunc(files))
 
-	symbolParser := parser.NewParser(&observation.TestContext, parserPool, fetcher.NewRepositoryFetcher(&observation.TestContext, gitserverClient, 1000, 1_000_000), 0, 10)
+	symbolParser := parser.NewParser(observation.TestContextTB(t), parserPool, fetcher.NewRepositoryFetcher(observation.TestContextTB(t), gitserverClient, 1000, 1_000_000), 0, 10)
 	databaseWriter := writer.NewDatabaseWriter(observation.TestContextTB(t), tmpDir, gitserverClient, symbolParser, semaphore.NewWeighted(1))
 	cachedDatabaseWriter := writer.NewCachedDatabaseWriter(databaseWriter, cache)
 	handler := NewHandler(MakeSqliteSearchFunc(observation.TestContextTB(t), cachedDatabaseWriter, dbmocks.NewMockDB()), func(ctx context.Context, rcp types.RepoCommitPath) ([]byte, error) { return nil, nil }, nil)

--- a/cmd/worker/internal/authz/perms_syncer_worker_test.go
+++ b/cmd/worker/internal/authz/perms_syncer_worker_test.go
@@ -33,7 +33,7 @@ func TestPermsSyncerWorker_Handle(t *testing.T) {
 	syncJobsStore := db.PermissionSyncJobs()
 
 	t.Run("user sync request", func(t *testing.T) {
-		worker := makePermsSyncerWorker(&observation.TestContext, dummySyncer, syncTypeUser, syncJobsStore)
+		worker := makePermsSyncerWorker(observation.TestContextTB(t), dummySyncer, syncTypeUser, syncJobsStore)
 		_ = worker.Handle(ctx, logtest.Scoped(t), &database.PermissionSyncJob{
 			ID:               99,
 			UserID:           1234,
@@ -55,7 +55,7 @@ func TestPermsSyncerWorker_Handle(t *testing.T) {
 	})
 
 	t.Run("repo sync request", func(t *testing.T) {
-		worker := makePermsSyncerWorker(&observation.TestContext, dummySyncer, syncTypeRepo, syncJobsStore)
+		worker := makePermsSyncerWorker(observation.TestContextTB(t), dummySyncer, syncTypeRepo, syncJobsStore)
 		_ = worker.Handle(ctx, logtest.Scoped(t), &database.PermissionSyncJob{
 			ID:               777,
 			RepositoryID:     4567,
@@ -96,7 +96,7 @@ func TestPermsSyncerWorker_RepoSyncJobs(t *testing.T) {
 	require.NoError(t, err)
 
 	// Creating a worker.
-	observationCtx := &observation.TestContext
+	observationCtx := observation.TestContextTB(t)
 	dummySyncer := &dummySyncerWithErrors{
 		repoIDErrors: map[api.RepoID]errorType{2: allProvidersFailed, 3: realError},
 	}
@@ -238,7 +238,7 @@ func TestPermsSyncerWorker_UserSyncJobs(t *testing.T) {
 	require.NoError(t, err)
 
 	// Creating a worker.
-	observationCtx := &observation.TestContext
+	observationCtx := observation.TestContextTB(t)
 	dummySyncer := &dummySyncerWithErrors{
 		userIDErrors:      map[int32]errorType{2: allProvidersFailed, 3: realError},
 		userIDNoProviders: map[int32]struct{}{4: {}},
@@ -423,7 +423,7 @@ func TestPermsSyncerWorker_Store_Dequeue_Order(t *testing.T) {
 		t.Fatalf("unexpected error inserting records: %s", err)
 	}
 
-	store := makeStore(&observation.TestContext, db.Handle(), syncTypeRepo)
+	store := makeStore(observation.TestContextTB(t), db.Handle(), syncTypeRepo)
 	jobIDs := make([]int, 0)
 	wantJobIDs := []int{5, 6, 8, 7, 3, 4, 10, 9, 1, 2, 12, 11, 0, 0, 0, 0}
 	var dequeueErr error

--- a/cmd/worker/internal/batches/workers/batch_spec_workspace_creator_test.go
+++ b/cmd/worker/internal/batches/workers/batch_spec_workspace_creator_test.go
@@ -38,7 +38,7 @@ func TestBatchSpecWorkspaceCreatorProcess(t *testing.T) {
 
 	user := bt.CreateTestUser(t, db, true)
 
-	s := store.New(db, &observation.TestContext, nil)
+	s := store.New(db, observation.TestContextTB(t), nil)
 
 	batchSpec, err := btypes.NewBatchSpecFromRaw(bt.TestRawBatchSpecYAML)
 	if err != nil {
@@ -196,7 +196,7 @@ func TestBatchSpecWorkspaceCreatorProcess_Caching(t *testing.T) {
 
 	now := timeutil.Now()
 	clock := func() time.Time { return now }
-	s := store.NewWithClock(db, &observation.TestContext, nil, clock)
+	s := store.NewWithClock(db, observation.TestContextTB(t), nil, clock)
 
 	creator := &batchSpecWorkspaceCreator{store: s, logger: logtest.Scoped(t)}
 
@@ -809,7 +809,7 @@ func TestBatchSpecWorkspaceCreatorProcess_Importing(t *testing.T) {
 
 	now := timeutil.Now()
 	clock := func() time.Time { return now }
-	s := store.NewWithClock(db, &observation.TestContext, nil, clock)
+	s := store.NewWithClock(db, observation.TestContextTB(t), nil, clock)
 
 	testSpecYAML := `
 name: my-unique-name
@@ -867,7 +867,7 @@ func TestBatchSpecWorkspaceCreatorProcess_NoDiff(t *testing.T) {
 
 	now := timeutil.Now()
 	clock := func() time.Time { return now }
-	s := store.NewWithClock(db, &observation.TestContext, nil, clock)
+	s := store.NewWithClock(db, observation.TestContextTB(t), nil, clock)
 
 	testSpecYAML := `
 name: my-unique-name
@@ -925,7 +925,7 @@ func TestBatchSpecWorkspaceCreatorProcess_Secrets(t *testing.T) {
 
 	repos, _ := bt.CreateTestRepos(t, ctx, db, 4)
 
-	s := store.New(db, &observation.TestContext, nil)
+	s := store.New(db, observation.TestContextTB(t), nil)
 
 	secret := &database.ExecutorSecret{
 		Key:       "FOO",

--- a/cmd/worker/internal/batches/workers/reconciler_worker_test.go
+++ b/cmd/worker/internal/batches/workers/reconciler_worker_test.go
@@ -32,7 +32,7 @@ func TestReconcilerWorkerView(t *testing.T) {
 
 	now := timeutil.Now()
 	clock := func() time.Time { return now }
-	bstore := store.NewWithClock(db, &observation.TestContext, nil, clock)
+	bstore := store.NewWithClock(db, observation.TestContextTB(t), nil, clock)
 
 	user := bt.CreateTestUser(t, db, true)
 	spec := bt.CreateBatchSpec(t, ctx, bstore, "test-batch-change", user.ID, 0)

--- a/internal/batches/processor/bulk_processor_test.go
+++ b/internal/batches/processor/bulk_processor_test.go
@@ -64,7 +64,7 @@ func TestBulkProcessor(t *testing.T) {
 	sqlDB := dbtest.NewDB(t)
 	tx := dbtest.NewTx(t, sqlDB)
 	db := database.NewDB(logger, sqlDB)
-	bstore := store.New(database.NewDBWith(logger, basestore.NewWithHandle(basestore.NewHandleWithTx(tx, sql.TxOptions{}))), &observation.TestContext, nil)
+	bstore := store.New(database.NewDBWith(logger, basestore.NewWithHandle(basestore.NewHandleWithTx(tx, sql.TxOptions{}))), observation.TestContextTB(t), nil)
 	wstore := database.OutboundWebhookJobsWith(bstore, nil)
 
 	user := bt.CreateTestUser(t, db, true)

--- a/internal/batches/reconciler/executor_test.go
+++ b/internal/batches/reconciler/executor_test.go
@@ -81,7 +81,7 @@ func TestExecutor_ExecutePlan(t *testing.T) {
 
 	now := timeutil.Now()
 	clock := func() time.Time { return now }
-	bstore := store.NewWithClock(db, &observation.TestContext, et.TestKey{}, clock)
+	bstore := store.NewWithClock(db, observation.TestContextTB(t), et.TestKey{}, clock)
 	wstore := database.OutboundWebhookJobsWith(bstore, nil)
 
 	admin := bt.CreateTestUser(t, db, true)
@@ -878,7 +878,7 @@ func TestExecutor_ExecutePlan_PublishedChangesetDuplicateBranch(t *testing.T) {
 	ctx := context.Background()
 	db := database.NewDB(logger, dbtest.NewDB(t))
 
-	bstore := store.New(db, &observation.TestContext, et.TestKey{})
+	bstore := store.New(db, observation.TestContextTB(t), et.TestKey{})
 
 	repo, _ := bt.CreateTestRepo(t, ctx, db)
 
@@ -920,7 +920,7 @@ func TestExecutor_ExecutePlan_AvoidLoadingChangesetSource(t *testing.T) {
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	bstore := store.New(db, &observation.TestContext, et.TestKey{})
+	bstore := store.New(db, observation.TestContextTB(t), et.TestKey{})
 	repo, _ := bt.CreateTestRepo(t, ctx, db)
 
 	changesetSpec := bt.BuildChangesetSpec(t, bt.TestSpecOpts{
@@ -999,7 +999,7 @@ func TestExecutor_UserCredentialsForGitserver(t *testing.T) {
 	ctx := actor.WithInternalActor(context.Background())
 	db := database.NewDB(logger, dbtest.NewDB(t))
 
-	bstore := store.New(db, &observation.TestContext, et.TestKey{})
+	bstore := store.New(db, observation.TestContextTB(t), et.TestKey{})
 
 	admin := bt.CreateTestUser(t, db, true)
 	user := bt.CreateTestUser(t, db, false)

--- a/internal/batches/reconciler/reconciler_test.go
+++ b/internal/batches/reconciler/reconciler_test.go
@@ -31,7 +31,7 @@ func TestReconcilerProcess_IntegrationTest(t *testing.T) {
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
 
-	store := bstore.New(db, &observation.TestContext, nil)
+	store := bstore.New(db, observation.TestContextTB(t), nil)
 
 	admin := bt.CreateTestUser(t, db, true)
 

--- a/internal/batches/service/service_apply_batch_change_test.go
+++ b/internal/batches/service/service_apply_batch_change_test.go
@@ -41,7 +41,7 @@ func TestServiceApplyBatchChange(t *testing.T) {
 
 	now := timeutil.Now()
 	clock := func() time.Time { return now }
-	store := bstore.NewWithClock(db, &observation.TestContext, nil, clock)
+	store := bstore.NewWithClock(db, observation.TestContextTB(t), nil, clock)
 	svc := New(store)
 
 	t.Run("BatchSpec without changesetSpecs", func(t *testing.T) {

--- a/internal/batches/service/service_test.go
+++ b/internal/batches/service/service_test.go
@@ -46,7 +46,7 @@ func TestServicePermissionLevels(t *testing.T) {
 	ctx := actor.WithInternalActor(context.Background())
 	db := database.NewDB(logger, dbtest.NewDB(t))
 
-	s := store.New(db, &observation.TestContext, nil)
+	s := store.New(db, observation.TestContextTB(t), nil)
 	svc := New(s)
 
 	admin := bt.CreateTestUser(t, db, true)
@@ -306,7 +306,7 @@ func TestService(t *testing.T) {
 	now := timeutil.Now()
 	clock := func() time.Time { return now }
 
-	s := store.NewWithClock(db, &observation.TestContext, nil, clock)
+	s := store.NewWithClock(db, observation.TestContextTB(t), nil, clock)
 	rs, _ := bt.CreateTestRepos(t, ctx, db, 4)
 
 	fakeSource := &stesting.FakeChangesetSource{}

--- a/internal/batches/service/workspace_resolver_test.go
+++ b/internal/batches/service/workspace_resolver_test.go
@@ -59,7 +59,7 @@ func TestService_ResolveWorkspacesForBatchSpec(t *testing.T) {
 	logger := logtest.Scoped(t)
 
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	s := store.New(db, &observation.TestContext, nil)
+	s := store.New(db, observation.TestContextTB(t), nil)
 
 	u := bt.CreateTestUser(t, db, false)
 

--- a/internal/batches/store/batch_spec_execution_cache_entry_test.go
+++ b/internal/batches/store/batch_spec_execution_cache_entry_test.go
@@ -151,7 +151,7 @@ func TestStore_CleanBatchSpecExecutionCacheEntries(t *testing.T) {
 	ctx := context.Background()
 	db := database.NewDB(logger, dbtest.NewDB(t))
 	c := &bt.TestClock{Time: timeutil.Now()}
-	s := NewWithClock(db, &observation.TestContext, nil, c.Now)
+	s := NewWithClock(db, observation.TestContextTB(t), nil, c.Now)
 	user := bt.CreateTestUser(t, db, true)
 
 	maxSize := 10 * 1024 // 10kb

--- a/internal/batches/store/batch_spec_resolution_jobs_test.go
+++ b/internal/batches/store/batch_spec_resolution_jobs_test.go
@@ -159,7 +159,7 @@ func TestBatchSpecResolutionJobs_BatchSpecIDUnique(t *testing.T) {
 	logger := logtest.Scoped(t)
 
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	s := NewWithClock(db, &observation.TestContext, nil, c.Now)
+	s := NewWithClock(db, observation.TestContextTB(t), nil, c.Now)
 
 	user := bt.CreateTestUser(t, db, true)
 

--- a/internal/batches/store/batch_specs_test.go
+++ b/internal/batches/store/batch_specs_test.go
@@ -710,7 +710,7 @@ func TestStoreGetBatchSpecStats(t *testing.T) {
 	minAgo := func(m int) time.Time { return c.Now().Add(-time.Duration(m) * time.Minute) }
 
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	s := NewWithClock(db, &observation.TestContext, nil, c.Now)
+	s := NewWithClock(db, observation.TestContextTB(t), nil, c.Now)
 
 	repo, _ := bt.CreateTestRepo(t, ctx, db)
 
@@ -885,7 +885,7 @@ func TestStore_ListBatchSpecRepoIDs(t *testing.T) {
 
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	s := New(db, &observation.TestContext, nil)
+	s := New(db, observation.TestContextTB(t), nil)
 
 	// Create two repos, one of which will be visible to everyone, and one which
 	// won't be.

--- a/internal/batches/store/changesets_test.go
+++ b/internal/batches/store/changesets_test.go
@@ -2373,7 +2373,7 @@ func TestCancelQueuedBatchChangeChangesets(t *testing.T) {
 	ctx := context.Background()
 	db := database.NewDB(logger, dbtest.NewDB(t))
 
-	s := New(db, &observation.TestContext, nil)
+	s := New(db, observation.TestContextTB(t), nil)
 
 	user := bt.CreateTestUser(t, db, true)
 	spec := bt.CreateBatchSpec(t, ctx, s, "test-batch-change", user.ID, 0)
@@ -2516,7 +2516,7 @@ func TestEnqueueChangesetsToClose(t *testing.T) {
 	ctx := context.Background()
 	db := database.NewDB(logger, dbtest.NewDB(t))
 
-	s := New(db, &observation.TestContext, nil)
+	s := New(db, observation.TestContextTB(t), nil)
 
 	user := bt.CreateTestUser(t, db, true)
 	spec := bt.CreateBatchSpec(t, ctx, s, "test-batch-change", user.ID, 0)
@@ -2647,7 +2647,7 @@ func TestCleanDetachedChangesets(t *testing.T) {
 	ctx := context.Background()
 	db := database.NewDB(logger, dbtest.NewDB(t))
 
-	s := New(db, &observation.TestContext, nil)
+	s := New(db, observation.TestContextTB(t), nil)
 	rs := database.ReposWith(logger, s)
 	es := database.ExternalServicesWith(logger, s)
 

--- a/internal/batches/store/store_test.go
+++ b/internal/batches/store/store_test.go
@@ -30,7 +30,7 @@ func storeTest(db *sql.DB, key encryption.Key, f storeTestFunc) func(*testing.T)
 		// don't need to insert a lot of dependencies into the DB (users,
 		// repos, ...) to setup the tests.
 		tx := database.NewDBWith(logger, basestore.NewWithHandle(basestore.NewHandleWithTx(dbtest.NewTx(t, db), sql.TxOptions{})))
-		s := NewWithClock(tx, &observation.TestContext, key, c.Now)
+		s := NewWithClock(tx, observation.TestContextTB(t), key, c.Now)
 
 		f(t, context.Background(), s, c)
 	}

--- a/internal/batches/store/worker_workspace_execution_test.go
+++ b/internal/batches/store/worker_workspace_execution_test.go
@@ -31,8 +31,8 @@ func TestBatchSpecWorkspaceExecutionWorkerStore_MarkComplete(t *testing.T) {
 	user := bt.CreateTestUser(t, db, true)
 
 	repo, _ := bt.CreateTestRepo(t, ctx, db)
-	s := New(db, &observation.TestContext, nil)
-	workStore := dbworkerstore.New(&observation.TestContext, s.Handle(), batchSpecWorkspaceExecutionWorkerStoreOptions)
+	s := New(db, observation.TestContextTB(t), nil)
+	workStore := dbworkerstore.New(observation.TestContextTB(t), s.Handle(), batchSpecWorkspaceExecutionWorkerStoreOptions)
 
 	// Setup all the associations
 	batchSpec := &btypes.BatchSpec{UserID: user.ID, NamespaceUserID: user.ID, RawSpec: "horse", Spec: &batcheslib.BatchSpec{
@@ -69,7 +69,7 @@ stdout: {"operation":"CACHE_AFTER_STEP_RESULT","timestamp":"2021-11-04T12:43:19.
 
 	executionStore := &batchSpecWorkspaceExecutionWorkerStore{
 		Store:          workStore,
-		observationCtx: &observation.TestContext,
+		observationCtx: observation.TestContextTB(t),
 		logger:         logtest.Scoped(t),
 	}
 	opts := dbworkerstore.MarkFinalOptions{WorkerHostname: "worker-1"}
@@ -225,8 +225,8 @@ func TestBatchSpecWorkspaceExecutionWorkerStore_MarkFailed(t *testing.T) {
 	user := bt.CreateTestUser(t, db, true)
 
 	repo, _ := bt.CreateTestRepo(t, ctx, db)
-	s := New(db, &observation.TestContext, nil)
-	workStore := dbworkerstore.New(&observation.TestContext, s.Handle(), batchSpecWorkspaceExecutionWorkerStoreOptions)
+	s := New(db, observation.TestContextTB(t), nil)
+	workStore := dbworkerstore.New(observation.TestContextTB(t), s.Handle(), batchSpecWorkspaceExecutionWorkerStoreOptions)
 
 	// Setup all the associations
 	batchSpec := &btypes.BatchSpec{UserID: user.ID, NamespaceUserID: user.ID, RawSpec: "horse", Spec: &batcheslib.BatchSpec{
@@ -278,7 +278,7 @@ stdout: {"operation":"CACHE_AFTER_STEP_RESULT","timestamp":"2021-11-04T12:43:19.
 
 	executionStore := &batchSpecWorkspaceExecutionWorkerStore{
 		Store:          workStore,
-		observationCtx: &observation.TestContext,
+		observationCtx: observation.TestContextTB(t),
 		logger:         logtest.Scoped(t),
 	}
 	opts := dbworkerstore.MarkFinalOptions{WorkerHostname: "worker-1"}
@@ -381,8 +381,8 @@ func TestBatchSpecWorkspaceExecutionWorkerStore_MarkComplete_EmptyDiff(t *testin
 
 	repo, _ := bt.CreateTestRepo(t, ctx, db)
 
-	s := New(db, &observation.TestContext, nil)
-	workStore := dbworkerstore.New(&observation.TestContext, s.Handle(), batchSpecWorkspaceExecutionWorkerStoreOptions)
+	s := New(db, observation.TestContextTB(t), nil)
+	workStore := dbworkerstore.New(observation.TestContextTB(t), s.Handle(), batchSpecWorkspaceExecutionWorkerStoreOptions)
 
 	// Setup all the associations
 	batchSpec := &btypes.BatchSpec{UserID: user.ID, NamespaceUserID: user.ID, RawSpec: "horse", Spec: &batcheslib.BatchSpec{
@@ -423,7 +423,7 @@ stdout: {"operation":"CACHE_AFTER_STEP_RESULT","timestamp":"2021-11-04T12:43:19.
 
 	executionStore := &batchSpecWorkspaceExecutionWorkerStore{
 		Store:          workStore,
-		observationCtx: &observation.TestContext,
+		observationCtx: observation.TestContextTB(t),
 	}
 	opts := dbworkerstore.MarkFinalOptions{WorkerHostname: "worker-1"}
 
@@ -465,8 +465,8 @@ func TestBatchSpecWorkspaceExecutionWorkerStore_Dequeue_RoundRobin(t *testing.T)
 
 	repo, _ := bt.CreateTestRepo(t, ctx, db)
 
-	s := New(db, &observation.TestContext, nil)
-	workerStore := dbworkerstore.New(&observation.TestContext, s.Handle(), batchSpecWorkspaceExecutionWorkerStoreOptions)
+	s := New(db, observation.TestContextTB(t), nil)
+	workerStore := dbworkerstore.New(observation.TestContextTB(t), s.Handle(), batchSpecWorkspaceExecutionWorkerStoreOptions)
 
 	user1 := bt.CreateTestUser(t, db, true)
 	user2 := bt.CreateTestUser(t, db, true)
@@ -514,8 +514,8 @@ func TestBatchSpecWorkspaceExecutionWorkerStore_Dequeue_RoundRobin_NoDoubleDeque
 
 	repo, _ := bt.CreateTestRepo(t, ctx, db)
 
-	s := New(db, &observation.TestContext, nil)
-	workerStore := dbworkerstore.New(&observation.TestContext, s.Handle(), batchSpecWorkspaceExecutionWorkerStoreOptions)
+	s := New(db, observation.TestContextTB(t), nil)
+	workerStore := dbworkerstore.New(observation.TestContextTB(t), s.Handle(), batchSpecWorkspaceExecutionWorkerStoreOptions)
 
 	user1 := bt.CreateTestUser(t, db, true)
 	user2 := bt.CreateTestUser(t, db, true)

--- a/internal/batches/syncer/syncer_test.go
+++ b/internal/batches/syncer/syncer_test.go
@@ -60,7 +60,7 @@ func TestSyncerRun(t *testing.T) {
 			syncStore:        syncStore,
 			scheduleInterval: 10 * time.Minute,
 			syncFunc:         syncFunc,
-			metrics:          makeMetrics(&observation.TestContext),
+			metrics:          makeMetrics(observation.TestContextTB(t)),
 		}
 		go syncer.Run(ctx)
 		select {
@@ -100,7 +100,7 @@ func TestSyncerRun(t *testing.T) {
 			logger:           logtest.Scoped(t),
 			syncStore:        syncStore,
 			scheduleInterval: 10 * time.Minute,
-			metrics:          makeMetrics(&observation.TestContext),
+			metrics:          makeMetrics(observation.TestContextTB(t)),
 		}
 		syncer.Run(ctx)
 		if updateCalled {
@@ -132,7 +132,7 @@ func TestSyncerRun(t *testing.T) {
 			syncStore:        syncStore,
 			scheduleInterval: 10 * time.Minute,
 			syncFunc:         syncFunc,
-			metrics:          makeMetrics(&observation.TestContext),
+			metrics:          makeMetrics(observation.TestContextTB(t)),
 		}
 		syncer.Run(ctx)
 		if syncCalled {
@@ -154,7 +154,7 @@ func TestSyncerRun(t *testing.T) {
 			scheduleInterval: 10 * time.Minute,
 			syncFunc:         syncFunc,
 			priorityNotify:   make(chan []int64, 1),
-			metrics:          makeMetrics(&observation.TestContext),
+			metrics:          makeMetrics(observation.TestContextTB(t)),
 		}
 		syncer.priorityNotify <- []int64{1}
 		go syncer.Run(ctx)
@@ -211,7 +211,7 @@ func TestSyncerRun(t *testing.T) {
 			logger:           capturingLogger,
 			syncStore:        syncStore,
 			scheduleInterval: 10 * time.Minute,
-			metrics:          makeMetrics(&observation.TestContext),
+			metrics:          makeMetrics(observation.TestContextTB(t)),
 		}
 		syncer.Run(ctx)
 		assert.False(t, updateCalled)
@@ -251,7 +251,7 @@ func TestSyncRegistry_SyncCodeHosts(t *testing.T) {
 		return codeHosts, nil
 	})
 
-	reg := NewSyncRegistry(ctx, &observation.TestContext, syncStore, nil)
+	reg := NewSyncRegistry(ctx, observation.TestContextTB(t), syncStore, nil)
 
 	assertSyncerCount := func(t *testing.T, want int) {
 		t.Helper()
@@ -309,12 +309,12 @@ func TestSyncRegistry_EnqueueChangesetSyncs(t *testing.T) {
 			return nil
 		},
 		priorityNotify: make(chan []int64, 1),
-		metrics:        makeMetrics(&observation.TestContext),
+		metrics:        makeMetrics(observation.TestContextTB(t)),
 		cancel:         syncerCancel,
 	}
 	go syncer.Run(syncerCtx)
 
-	reg := NewSyncRegistry(ctx, &observation.TestContext, syncStore, nil)
+	reg := NewSyncRegistry(ctx, observation.TestContextTB(t), syncStore, nil)
 	reg.syncers[codeHostURL] = syncer
 
 	// Start handler in background, will be canceled when ctx is canceled

--- a/internal/batches/webhooks/batch_change_test.go
+++ b/internal/batches/webhooks/batch_change_test.go
@@ -33,7 +33,7 @@ func TestMarshalBatchChange(t *testing.T) {
 	marshalledUserID := gql.MarshalUserID(userID)
 	now := timeutil.Now()
 	clock := func() time.Time { return now }
-	bstore := store.NewWithClock(db, &observation.TestContext, nil, clock)
+	bstore := store.NewWithClock(db, observation.TestContextTB(t), nil, clock)
 
 	batchSpec := bt.CreateBatchSpec(t, ctx, bstore, "test", userID, 0)
 

--- a/internal/batches/webhooks/changeset_test.go
+++ b/internal/batches/webhooks/changeset_test.go
@@ -37,7 +37,7 @@ func TestMarshalChangeset(t *testing.T) {
 	userID := bt.CreateTestUser(t, db, true).ID
 	now := timeutil.Now()
 	clock := func() time.Time { return now }
-	bstore := store.NewWithClock(db, &observation.TestContext, nil, clock)
+	bstore := store.NewWithClock(db, observation.TestContextTB(t), nil, clock)
 
 	batchSpec := bt.CreateBatchSpec(t, ctx, bstore, "test", userID, 0)
 

--- a/internal/codeintel/autoindexing/internal/background/dependencies/index_worker_store_test.go
+++ b/internal/codeintel/autoindexing/internal/background/dependencies/index_worker_store_test.go
@@ -30,7 +30,7 @@ func Test_AutoIndexingManualEnqueuedDequeueOrder(t *testing.T) {
 	db := database.NewDB(logtest.Scoped(t), raw)
 
 	opts := IndexWorkerStoreOptions
-	workerstore := store.New(&observation.TestContext, db.Handle(), opts)
+	workerstore := store.New(observation.TestContextTB(t), db.Handle(), opts)
 
 	for i, test := range []struct {
 		indexes []shared.Index

--- a/internal/codeintel/autoindexing/internal/inference/service_test.go
+++ b/internal/codeintel/autoindexing/internal/inference/service_test.go
@@ -54,5 +54,5 @@ func testService(t *testing.T, repositoryContents map[string]string) *Service {
 		return unpacktest.CreateTarArchive(t, files), nil
 	})
 
-	return newService(&observation.TestContext, sandboxService, gitService, ratelimit.NewInstrumentedLimiter("TestInference", rate.NewLimiter(rate.Limit(100), 1)), 100, 1024*1024)
+	return newService(observation.TestContextTB(t), sandboxService, gitService, ratelimit.NewInstrumentedLimiter("TestInference", rate.NewLimiter(rate.Limit(100), 1)), 100, 1024*1024)
 }

--- a/internal/codeintel/autoindexing/internal/store/config_inference_test.go
+++ b/internal/codeintel/autoindexing/internal/store/config_inference_test.go
@@ -13,7 +13,7 @@ import (
 func TestSetInferenceScript(t *testing.T) {
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	for _, testCase := range []struct {
 		script     string

--- a/internal/codeintel/autoindexing/internal/store/config_repo_test.go
+++ b/internal/codeintel/autoindexing/internal/store/config_repo_test.go
@@ -16,7 +16,7 @@ import (
 func TestRepositoryExceptions(t *testing.T) {
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	query := sqlf.Sprintf(
 		`INSERT INTO repo (id, name) VALUES (%s, %s)`,
@@ -56,7 +56,7 @@ func TestRepositoryExceptions(t *testing.T) {
 func TestGetIndexConfigurationByRepositoryID(t *testing.T) {
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	expectedConfigurationData := []byte(`{
 		"foo": "bar",
@@ -98,7 +98,7 @@ func TestGetIndexConfigurationByRepositoryID(t *testing.T) {
 func TestUpdateIndexConfigurationByRepositoryID(t *testing.T) {
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	query := sqlf.Sprintf(
 		`INSERT INTO repo (id, name) VALUES (%s, %s)`,

--- a/internal/codeintel/autoindexing/internal/store/coverage_test.go
+++ b/internal/codeintel/autoindexing/internal/store/coverage_test.go
@@ -22,7 +22,7 @@ func TestTopRepositoriesToConfigure(t *testing.T) {
 	logger := logtest.Scoped(t)
 	sqlDB := dbtest.NewDB(t)
 	db := database.NewDB(logger, sqlDB)
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	insertEvent := func(name string, repositoryID int, maxAge time.Duration) {
 		query := `
@@ -73,7 +73,7 @@ func TestRepositoryIDsWithConfiguration(t *testing.T) {
 	logger := logtest.Scoped(t)
 	sqlDB := dbtest.NewDB(t)
 	db := database.NewDB(logger, sqlDB)
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	testIndexerList := map[string]uploadsshared.AvailableIndexer{
 		"test-indexer": {
@@ -119,7 +119,7 @@ func TestGetLastIndexScanForRepository(t *testing.T) {
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	ts, err := store.GetLastIndexScanForRepository(ctx, 50)
 	if err != nil {

--- a/internal/codeintel/autoindexing/internal/store/dependencies_test.go
+++ b/internal/codeintel/autoindexing/internal/store/dependencies_test.go
@@ -16,7 +16,7 @@ import (
 func TestInsertDependencyIndexingJob(t *testing.T) {
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	insertRepo(t, db, 50, "")
 
@@ -46,7 +46,7 @@ func TestGetQueuedRepoRev(t *testing.T) {
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	expected := []RepoRev{
 		{1, 50, "HEAD"},

--- a/internal/codeintel/autoindexing/internal/store/enqueuer_test.go
+++ b/internal/codeintel/autoindexing/internal/store/enqueuer_test.go
@@ -20,7 +20,7 @@ import (
 func TestIsQueued(t *testing.T) {
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	insertIndexes(t, db, uploadsshared.Index{ID: 1, RepositoryID: 1, Commit: makeCommit(1)})
 	insertIndexes(t, db, uploadsshared.Index{ID: 2, RepositoryID: 1, Commit: makeCommit(1), ShouldReindex: true})
@@ -64,7 +64,7 @@ func TestIsQueued(t *testing.T) {
 func TestIsQueuedRootIndexer(t *testing.T) {
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	now := time.Now()
 	insertIndexes(t, db, uploadsshared.Index{ID: 1, RepositoryID: 1, Commit: makeCommit(1), Root: "/foo", Indexer: "i1", QueuedAt: now.Add(-time.Hour * 1)})
@@ -106,7 +106,7 @@ func TestInsertIndexes(t *testing.T) {
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	insertRepo(t, db, 50, "")
 
@@ -231,7 +231,7 @@ func TestInsertIndexes(t *testing.T) {
 func TestInsertIndexWithActor(t *testing.T) {
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	insertRepo(t, db, 50, "")
 

--- a/internal/codeintel/autoindexing/internal/store/store_test.go
+++ b/internal/codeintel/autoindexing/internal/store/store_test.go
@@ -18,7 +18,7 @@ func TestMarkRepoRevsAsProcessed(t *testing.T) {
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	expected := []RepoRev{
 		{1, 50, "HEAD"},
@@ -65,7 +65,7 @@ func testStoreWithoutConfigurationPolicies(t *testing.T, db database.DB) Store {
 		t.Fatalf("unexpected error while inserting configuration policies: %s", err)
 	}
 
-	return New(&observation.TestContext, db)
+	return New(observation.TestContextTB(t), db)
 }
 
 func updateGitserverUpdatedAt(t *testing.T, db database.DB, now time.Time) {

--- a/internal/codeintel/autoindexing/service_test.go
+++ b/internal/codeintel/autoindexing/service_test.go
@@ -64,7 +64,7 @@ func TestQueueIndexesExplicit(t *testing.T) {
 	inferenceService := NewMockInferenceService()
 
 	service := newService(
-		&observation.TestContext,
+		observation.TestContextTB(t),
 		mockDBStore,
 		inferenceService,
 		defaultMockRepoStore(), // repoStore
@@ -162,7 +162,7 @@ func TestQueueIndexesInDatabase(t *testing.T) {
 	inferenceService := NewMockInferenceService()
 
 	service := newService(
-		&observation.TestContext,
+		observation.TestContextTB(t),
 		mockDBStore,
 		inferenceService,
 		defaultMockRepoStore(), // repoStore
@@ -265,7 +265,7 @@ func TestQueueIndexesInRepository(t *testing.T) {
 	inferenceService := NewMockInferenceService()
 
 	service := newService(
-		&observation.TestContext,
+		observation.TestContextTB(t),
 		mockDBStore,
 		inferenceService,
 		defaultMockRepoStore(), // repoStore
@@ -351,7 +351,7 @@ func TestQueueIndexesInferred(t *testing.T) {
 	})
 
 	service := newService(
-		&observation.TestContext,
+		observation.TestContextTB(t),
 		mockDBStore,
 		inferenceService,
 		defaultMockRepoStore(), // repoStore
@@ -439,7 +439,7 @@ func TestQueueIndexesForPackage(t *testing.T) {
 	})
 
 	service := newService(
-		&observation.TestContext,
+		observation.TestContextTB(t),
 		mockDBStore,
 		inferenceService,
 		mockRepoStore, // repoStore

--- a/internal/codeintel/codenav/internal/lsifstore/locations_by_position_test.go
+++ b/internal/codeintel/codenav/internal/lsifstore/locations_by_position_test.go
@@ -316,7 +316,7 @@ func TestDatabaseReferences(t *testing.T) {
 func populateTestStore(t testing.TB) LsifStore {
 	logger := logtest.Scoped(t)
 	codeIntelDB := codeintelshared.NewCodeIntelDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, codeIntelDB)
+	store := New(observation.TestContextTB(t), codeIntelDB)
 
 	loadTestFile(t, codeIntelDB, "./testdata/code-intel-extensions@7802976b.sql")
 	return store

--- a/internal/codeintel/codenav/service_diagnostics_test.go
+++ b/internal/codeintel/codenav/service_diagnostics_test.go
@@ -25,7 +25,7 @@ func TestDiagnostics(t *testing.T) {
 	hunkCache, _ := NewHunkCache(50)
 
 	// Init service
-	svc := newService(&observation.TestContext, mockRepoStore, mockLsifStore, mockUploadSvc, mockGitserverClient)
+	svc := newService(observation.TestContextTB(t), mockRepoStore, mockLsifStore, mockUploadSvc, mockGitserverClient)
 
 	// Set up request state
 	mockRequestState := RequestState{}
@@ -98,7 +98,7 @@ func TestDiagnosticsWithSubRepoPermissions(t *testing.T) {
 	hunkCache, _ := NewHunkCache(50)
 
 	// Init service
-	svc := newService(&observation.TestContext, mockRepoStore, mockLsifStore, mockUploadSvc, mockGitserverClient)
+	svc := newService(observation.TestContextTB(t), mockRepoStore, mockLsifStore, mockUploadSvc, mockGitserverClient)
 
 	// Set up request state
 	mockRequestState := RequestState{}

--- a/internal/codeintel/codenav/service_hover_test.go
+++ b/internal/codeintel/codenav/service_hover_test.go
@@ -25,7 +25,7 @@ func TestHover(t *testing.T) {
 	hunkCache, _ := NewHunkCache(50)
 
 	// Init service
-	svc := newService(&observation.TestContext, mockRepoStore, mockLsifStore, mockUploadSvc, mockGitserverClient)
+	svc := newService(observation.TestContextTB(t), mockRepoStore, mockLsifStore, mockUploadSvc, mockGitserverClient)
 
 	// Set up request state
 	mockRequestState := RequestState{}
@@ -81,7 +81,7 @@ func TestHoverRemote(t *testing.T) {
 	hunkCache, _ := NewHunkCache(50)
 
 	// Init service
-	svc := newService(&observation.TestContext, mockRepoStore, mockLsifStore, mockUploadSvc, mockGitserverClient)
+	svc := newService(observation.TestContextTB(t), mockRepoStore, mockLsifStore, mockUploadSvc, mockGitserverClient)
 
 	// Set up request state
 	mockRequestState := RequestState{}

--- a/internal/codeintel/codenav/service_new_test.go
+++ b/internal/codeintel/codenav/service_new_test.go
@@ -26,7 +26,7 @@ func TestGetDefinitions(t *testing.T) {
 		hunkCache, _ := NewHunkCache(50)
 
 		// Init service
-		svc := newService(&observation.TestContext, mockRepoStore, mockLsifStore, mockUploadSvc, mockGitserverClient)
+		svc := newService(observation.TestContextTB(t), mockRepoStore, mockLsifStore, mockUploadSvc, mockGitserverClient)
 
 		// Set up request state
 		mockRequestState := RequestState{}
@@ -86,7 +86,7 @@ func TestGetDefinitions(t *testing.T) {
 		hunkCache, _ := NewHunkCache(50)
 
 		// Init service
-		svc := newService(&observation.TestContext, mockRepoStore, mockLsifStore, mockUploadSvc, mockGitserverClient)
+		svc := newService(observation.TestContextTB(t), mockRepoStore, mockLsifStore, mockUploadSvc, mockGitserverClient)
 
 		// Set up request state
 		mockRequestState := RequestState{}
@@ -208,7 +208,7 @@ func TestGetReferences(t *testing.T) {
 		hunkCache, _ := NewHunkCache(50)
 
 		// Init service
-		svc := newService(&observation.TestContext, mockRepoStore, mockLsifStore, mockUploadSvc, mockGitserverClient)
+		svc := newService(observation.TestContextTB(t), mockRepoStore, mockLsifStore, mockUploadSvc, mockGitserverClient)
 
 		// Set up request state
 		mockRequestState := RequestState{}
@@ -273,7 +273,7 @@ func TestGetReferences(t *testing.T) {
 		hunkCache, _ := NewHunkCache(50)
 
 		// Init service
-		svc := newService(&observation.TestContext, mockRepoStore, mockLsifStore, mockUploadSvc, mockGitserverClient)
+		svc := newService(observation.TestContextTB(t), mockRepoStore, mockLsifStore, mockUploadSvc, mockGitserverClient)
 
 		// Set up request state
 		mockRequestState := RequestState{}
@@ -454,7 +454,7 @@ func TestGetImplementations(t *testing.T) {
 		hunkCache, _ := NewHunkCache(50)
 
 		// Init service
-		svc := newService(&observation.TestContext, mockRepoStore, mockLsifStore, mockUploadSvc, mockGitserverClient)
+		svc := newService(observation.TestContextTB(t), mockRepoStore, mockLsifStore, mockUploadSvc, mockGitserverClient)
 
 		// Set up request state
 		mockRequestState := RequestState{}

--- a/internal/codeintel/codenav/service_ranges_test.go
+++ b/internal/codeintel/codenav/service_ranges_test.go
@@ -51,7 +51,7 @@ func TestRanges(t *testing.T) {
 	hunkCache, _ := NewHunkCache(50)
 
 	// Init service
-	svc := newService(&observation.TestContext, mockRepoStore, mockLsifStore, mockUploadSvc, mockGitserverClient)
+	svc := newService(observation.TestContextTB(t), mockRepoStore, mockLsifStore, mockUploadSvc, mockGitserverClient)
 
 	// Set up request state
 	mockRequestState := RequestState{}

--- a/internal/codeintel/codenav/service_snapshot_test.go
+++ b/internal/codeintel/codenav/service_snapshot_test.go
@@ -26,7 +26,7 @@ func TestSnapshotForDocument(t *testing.T) {
 	mockGitserverClient := gitserver.NewMockClient()
 
 	// Init service
-	svc := newService(&observation.TestContext, mockRepoStore, mockLsifStore, mockUploadSvc, mockGitserverClient)
+	svc := newService(observation.TestContextTB(t), mockRepoStore, mockLsifStore, mockUploadSvc, mockGitserverClient)
 
 	mockUploadSvc.GetCompletedUploadsByIDsFunc.SetDefaultReturn([]shared.CompletedUpload{{}}, nil)
 	mockRepoStore.GetFunc.SetDefaultReturn(&types.Repo{}, nil)

--- a/internal/codeintel/codenav/service_stencil_test.go
+++ b/internal/codeintel/codenav/service_stencil_test.go
@@ -22,7 +22,7 @@ func TestStencil(t *testing.T) {
 	hunkCache, _ := NewHunkCache(50)
 
 	// Init service
-	svc := newService(&observation.TestContext, mockRepoStore, mockLsifStore, mockUploadSvc, mockGitserverClient)
+	svc := newService(observation.TestContextTB(t), mockRepoStore, mockLsifStore, mockUploadSvc, mockGitserverClient)
 
 	// Set up request state
 	mockRequestState := RequestState{}
@@ -80,7 +80,7 @@ func TestStencilWithDuplicateRanges(t *testing.T) {
 	hunkCache, _ := NewHunkCache(50)
 
 	// Init service
-	svc := newService(&observation.TestContext, mockRepoStore, mockLsifStore, mockUploadSvc, mockGitserverClient)
+	svc := newService(observation.TestContextTB(t), mockRepoStore, mockLsifStore, mockUploadSvc, mockGitserverClient)
 
 	// Set up request state
 	mockRequestState := RequestState{}

--- a/internal/codeintel/codenav/transport/graphql/root_resolver_test.go
+++ b/internal/codeintel/codenav/transport/graphql/root_resolver_test.go
@@ -29,7 +29,7 @@ func TestRanges(t *testing.T) {
 		Commit:       "deadbeef1",
 		Path:         "/src/main",
 	}
-	mockOperations := newOperations(&observation.TestContext)
+	mockOperations := newOperations(observation.TestContextTB(t))
 
 	resolver := newGitBlobLSIFDataResolver(
 		mockCodeNavService,
@@ -64,7 +64,7 @@ func TestDefinitions(t *testing.T) {
 		Commit:       "deadbeef1",
 		Path:         "/src/main",
 	}
-	mockOperations := newOperations(&observation.TestContext)
+	mockOperations := newOperations(observation.TestContextTB(t))
 
 	resolver := newGitBlobLSIFDataResolver(
 		mockCodeNavService,
@@ -99,7 +99,7 @@ func TestReferences(t *testing.T) {
 		Commit:       "deadbeef1",
 		Path:         "/src/main",
 	}
-	mockOperations := newOperations(&observation.TestContext)
+	mockOperations := newOperations(observation.TestContextTB(t))
 
 	resolver := newGitBlobLSIFDataResolver(
 		mockCodeNavService,
@@ -152,7 +152,7 @@ func TestReferencesDefaultLimit(t *testing.T) {
 		Commit:       "deadbeef1",
 		Path:         "/src/main",
 	}
-	mockOperations := newOperations(&observation.TestContext)
+	mockOperations := newOperations(observation.TestContextTB(t))
 
 	resolver := newGitBlobLSIFDataResolver(
 		mockCodeNavService,
@@ -191,7 +191,7 @@ func TestReferencesDefaultIllegalLimit(t *testing.T) {
 		Commit:       "deadbeef1",
 		Path:         "/src/main",
 	}
-	mockOperations := newOperations(&observation.TestContext)
+	mockOperations := newOperations(observation.TestContextTB(t))
 
 	resolver := newGitBlobLSIFDataResolver(
 		mockCodeNavService,
@@ -224,7 +224,7 @@ func TestHover(t *testing.T) {
 		Commit:       "deadbeef1",
 		Path:         "/src/main",
 	}
-	mockOperations := newOperations(&observation.TestContext)
+	mockOperations := newOperations(observation.TestContextTB(t))
 
 	resolver := newGitBlobLSIFDataResolver(
 		mockCodeNavService,
@@ -260,7 +260,7 @@ func TestDiagnostics(t *testing.T) {
 		Commit:       "deadbeef1",
 		Path:         "/src/main",
 	}
-	mockOperations := newOperations(&observation.TestContext)
+	mockOperations := newOperations(observation.TestContextTB(t))
 
 	resolver := newGitBlobLSIFDataResolver(
 		mockCodeNavService,
@@ -296,7 +296,7 @@ func TestDiagnosticsDefaultLimit(t *testing.T) {
 		Commit:       "deadbeef1",
 		Path:         "/src/main",
 	}
-	mockOperations := newOperations(&observation.TestContext)
+	mockOperations := newOperations(observation.TestContextTB(t))
 
 	resolver := newGitBlobLSIFDataResolver(
 		mockCodeNavService,
@@ -329,7 +329,7 @@ func TestDiagnosticsDefaultIllegalLimit(t *testing.T) {
 		Commit:       "deadbeef1",
 		Path:         "/src/main",
 	}
-	mockOperations := newOperations(&observation.TestContext)
+	mockOperations := newOperations(observation.TestContextTB(t))
 
 	resolver := newGitBlobLSIFDataResolver(
 		mockCodeNavService,

--- a/internal/codeintel/dependencies/internal/background/job_packages_filter_test.go
+++ b/internal/codeintel/dependencies/internal/background/job_packages_filter_test.go
@@ -22,7 +22,7 @@ func TestPackageRepoFiltersBlockOnly(t *testing.T) {
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	s := store.New(&observation.TestContext, db)
+	s := store.New(observation.TestContextTB(t), db)
 
 	deps := []shared.MinimalPackageRepoRef{
 		{Scheme: "npm", Name: "bar", Versions: []shared.MinimalPackageRepoRefVersion{{Version: "2.0.0"}, {Version: "2.0.1"}, {Version: "3.0.0"}}},
@@ -63,7 +63,7 @@ func TestPackageRepoFiltersBlockOnly(t *testing.T) {
 	job := packagesFilterApplicatorJob{
 		store:       s,
 		extsvcStore: db.ExternalServices(),
-		operations:  newOperations(&observation.TestContext),
+		operations:  newOperations(observation.TestContextTB(t)),
 	}
 
 	if err := job.handle(ctx); err != nil {
@@ -114,7 +114,7 @@ func TestPackageRepoFiltersBlockAllow(t *testing.T) {
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	s := store.New(&observation.TestContext, db)
+	s := store.New(observation.TestContextTB(t), db)
 
 	deps := []shared.MinimalPackageRepoRef{
 		{Scheme: "npm", Name: "bar", Versions: []shared.MinimalPackageRepoRefVersion{{Version: "2.0.0"}, {Version: "2.0.1"}, {Version: "3.0.0"}}},
@@ -168,7 +168,7 @@ func TestPackageRepoFiltersBlockAllow(t *testing.T) {
 	job := packagesFilterApplicatorJob{
 		store:       s,
 		extsvcStore: db.ExternalServices(),
-		operations:  newOperations(&observation.TestContext),
+		operations:  newOperations(observation.TestContextTB(t)),
 	}
 
 	if err := job.handle(ctx); err != nil {

--- a/internal/codeintel/dependencies/internal/store/store_test.go
+++ b/internal/codeintel/dependencies/internal/store/store_test.go
@@ -22,7 +22,7 @@ func TestInsertDependencyRepo(t *testing.T) {
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	batches := [][]shared.MinimalPackageRepoRef{
 		{
@@ -103,7 +103,7 @@ func TestListPackageRepoRefs(t *testing.T) {
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	batches := [][]shared.MinimalPackageRepoRef{
 		{
@@ -193,7 +193,7 @@ func TestListPackageRepoRefsFuzzy(t *testing.T) {
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	pkgs := []shared.MinimalPackageRepoRef{
 		{Scheme: "npm", Name: "bar", Versions: []shared.MinimalPackageRepoRefVersion{{Version: "2.0.0"}}},
@@ -317,7 +317,7 @@ func TestDeletePackageRepoRefsByID(t *testing.T) {
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	repos := []shared.MinimalPackageRepoRef{
 		// Test same-set flushes

--- a/internal/codeintel/policies/internal/store/repository_matches_test.go
+++ b/internal/codeintel/policies/internal/store/repository_matches_test.go
@@ -21,7 +21,7 @@ func TestRepoIDsByGlobPatterns(t *testing.T) {
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	insertRepo(t, db, 50, "Darth Vader", true)
 	insertRepo(t, db, 51, "Darth Venamis", true)
@@ -99,7 +99,7 @@ func TestUpdateReposMatchingPatterns(t *testing.T) {
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	insertRepo(t, db, 50, "r1", false)
 	insertRepo(t, db, 51, "r2", false)
@@ -166,7 +166,7 @@ func TestUpdateReposMatchingPatternsOverLimit(t *testing.T) {
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	limit := 50
 	ids := make([]int, 0, limit*3)

--- a/internal/codeintel/policies/internal/store/store_test.go
+++ b/internal/codeintel/policies/internal/store/store_test.go
@@ -21,7 +21,7 @@ func testStoreWithoutConfigurationPolicies(t *testing.T, db database.DB) Store {
 		t.Fatalf("unexpected error while inserting configuration policies: %s", err)
 	}
 
-	return New(&observation.TestContext, db)
+	return New(observation.TestContextTB(t), db)
 }
 
 // insertRepo creates a repository record with the given id and name. If there is already a repository

--- a/internal/codeintel/policies/service_test.go
+++ b/internal/codeintel/policies/service_test.go
@@ -26,7 +26,7 @@ func TestGetRetentionPolicyOverview(t *testing.T) {
 	mockUploadSvc := NewMockUploadService()
 	mockGitserverClient := gitserver.NewMockClient()
 
-	svc := newService(&observation.TestContext, mockStore, mockRepoStore, mockUploadSvc, mockGitserverClient)
+	svc := newService(observation.TestContextTB(t), mockStore, mockRepoStore, mockUploadSvc, mockGitserverClient)
 
 	mockClock := glock.NewMockClock()
 
@@ -226,7 +226,7 @@ func TestRetentionPolicyOverview_ByVisibility(t *testing.T) {
 	mockUploadSvc := NewMockUploadService()
 	mockGitserverClient := gitserver.NewMockClient()
 
-	svc := newService(&observation.TestContext, mockStore, mockRepoStore, mockUploadSvc, mockGitserverClient)
+	svc := newService(observation.TestContextTB(t), mockStore, mockRepoStore, mockUploadSvc, mockGitserverClient)
 
 	mockClock := glock.NewMockClock()
 

--- a/internal/codeintel/ranking/internal/store/coordinator_test.go
+++ b/internal/codeintel/ranking/internal/store/coordinator_test.go
@@ -24,7 +24,7 @@ func TestCoordinateAndSummaries(t *testing.T) {
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
 	db := dbtest.NewDB(t)
-	store := New(&observation.TestContext, database.NewDB(logger, db))
+	store := New(observation.TestContextTB(t), database.NewDB(logger, db))
 
 	now1 := timeutil.Now().UTC()
 	now2 := now1.Add(time.Hour * 2)

--- a/internal/codeintel/ranking/internal/store/definitions_test.go
+++ b/internal/codeintel/ranking/internal/store/definitions_test.go
@@ -20,7 +20,7 @@ func TestInsertDefinition(t *testing.T) {
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	// Insert uploads
 	insertUploads(t, db, uploadsshared.Upload{ID: 4})

--- a/internal/codeintel/ranking/internal/store/graph_keys_test.go
+++ b/internal/codeintel/ranking/internal/store/graph_keys_test.go
@@ -15,7 +15,7 @@ func TestDerivativeGraphKey(t *testing.T) {
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	if _, _, err := DerivativeGraphKey(ctx, store); err != nil {
 		t.Fatalf("unexpected error: %s", err)

--- a/internal/codeintel/ranking/internal/store/mapper_test.go
+++ b/internal/codeintel/ranking/internal/store/mapper_test.go
@@ -25,7 +25,7 @@ func TestInsertPathCountInputs(t *testing.T) {
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	key := rankingshared.NewDerivativeGraphKey(mockRankingGraphKey, "123")
 
@@ -198,7 +198,7 @@ func TestInsertInitialPathCounts(t *testing.T) {
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	key := rankingshared.NewDerivativeGraphKey(mockRankingGraphKey, "123")
 
@@ -256,7 +256,7 @@ func TestVacuumStaleProcessedReferences(t *testing.T) {
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	key := rankingshared.NewDerivativeGraphKey(mockRankingGraphKey, "123")
 
@@ -320,7 +320,7 @@ func TestVacuumStaleProcessedPaths(t *testing.T) {
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	key := rankingshared.NewDerivativeGraphKey(mockRankingGraphKey, "123")
 
@@ -384,7 +384,7 @@ func TestVacuumStaleGraphs(t *testing.T) {
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	key := rankingshared.NewDerivativeGraphKey(mockRankingGraphKey, "123")
 

--- a/internal/codeintel/ranking/internal/store/paths_test.go
+++ b/internal/codeintel/ranking/internal/store/paths_test.go
@@ -23,7 +23,7 @@ func TestInsertInitialPathRanks(t *testing.T) {
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	// Insert uploads
 	insertUploads(t, db, uploadsshared.Upload{ID: 4})

--- a/internal/codeintel/ranking/internal/store/reducer_test.go
+++ b/internal/codeintel/ranking/internal/store/reducer_test.go
@@ -27,7 +27,7 @@ func TestInsertPathRanks(t *testing.T) {
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	key := rankingshared.NewDerivativeGraphKey(mockRankingGraphKey, "123")
 
@@ -137,7 +137,7 @@ func TestVacuumStaleRanks(t *testing.T) {
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	if _, err := db.ExecContext(ctx, `
 		INSERT INTO repo (name) VALUES ('bar'), ('baz'), ('bonk'), ('foo1'), ('foo2'), ('foo3'), ('foo4'), ('foo5')`); err != nil {

--- a/internal/codeintel/ranking/internal/store/references_test.go
+++ b/internal/codeintel/ranking/internal/store/references_test.go
@@ -21,7 +21,7 @@ func TestInsertReferences(t *testing.T) {
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	// Insert uploads
 	insertUploads(t, db, uploadsshared.Upload{ID: 4})

--- a/internal/codeintel/ranking/internal/store/retrieval_test.go
+++ b/internal/codeintel/ranking/internal/store/retrieval_test.go
@@ -26,7 +26,7 @@ func TestGetStarRank(t *testing.T) {
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	if _, err := db.ExecContext(ctx, `
 		INSERT INTO repo (name, stars)
@@ -73,7 +73,7 @@ func TestDocumentRanks(t *testing.T) {
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 	repoName := api.RepoName("foo")
 
 	key := rankingshared.NewDerivativeGraphKey(mockRankingGraphKey, "123")
@@ -130,7 +130,7 @@ func TestGetReferenceCountStatistics(t *testing.T) {
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	key := rankingshared.NewDerivativeGraphKey(mockRankingGraphKey, "123")
 
@@ -175,7 +175,7 @@ func TestCoverageCounts(t *testing.T) {
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	// Create three visible uploads and export a pair
 	if _, err := db.ExecContext(ctx, `
@@ -239,7 +239,7 @@ func TestLastUpdatedAt(t *testing.T) {
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	now := time.Unix(1686695462, 0)
 	key := rankingshared.NewDerivativeGraphKey(mockRankingGraphKey, "123")

--- a/internal/codeintel/ranking/internal/store/uploads_test.go
+++ b/internal/codeintel/ranking/internal/store/uploads_test.go
@@ -24,7 +24,7 @@ func TestGetUploadsForRanking(t *testing.T) {
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	if _, err := db.ExecContext(ctx, `
 		INSERT INTO repo (id, name, deleted_at) VALUES (50, 'foo', NULL);
@@ -74,7 +74,7 @@ func TestVacuumAbandonedExportedUploads(t *testing.T) {
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	// Insert uploads
 	for i := 1; i <= 9; i++ {
@@ -127,7 +127,7 @@ func TestSoftDeleteStaleExportedUploads(t *testing.T) {
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	// Insert uploads
 	for i := 1; i <= 9; i++ {
@@ -186,7 +186,7 @@ func TestVacuumDeletedExportedUploads(t *testing.T) {
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	// Insert uploads
 	for i := 1; i <= 9; i++ {

--- a/internal/codeintel/ranking/service_test.go
+++ b/internal/codeintel/ranking/service_test.go
@@ -13,7 +13,7 @@ import (
 func TestGetRepoRank(t *testing.T) {
 	ctx := context.Background()
 	mockStore := NewMockStore()
-	svc := newService(&observation.TestContext, mockStore, nil, conf.DefaultClient())
+	svc := newService(observation.TestContextTB(t), mockStore, nil, conf.DefaultClient())
 
 	mockStore.GetStarRankFunc.SetDefaultReturn(0.6, nil)
 
@@ -34,7 +34,7 @@ func TestGetRepoRankWithUserBoostedScores(t *testing.T) {
 	ctx := context.Background()
 	mockStore := NewMockStore()
 	mockConfigQuerier := NewMockSiteConfigQuerier()
-	svc := newService(&observation.TestContext, mockStore, nil, mockConfigQuerier)
+	svc := newService(observation.TestContextTB(t), mockStore, nil, mockConfigQuerier)
 
 	mockStore.GetStarRankFunc.SetDefaultReturn(0.6, nil)
 	mockConfigQuerier.SiteConfigFunc.SetDefaultReturn(schema.SiteConfiguration{

--- a/internal/codeintel/reposcheduler/store_test.go
+++ b/internal/codeintel/reposcheduler/store_test.go
@@ -237,7 +237,7 @@ func testPreciseStoreWithoutConfigurationPolicies(t *testing.T, db database.DB) 
 		t.Fatalf("unexpected error while inserting configuration policies: %s", err)
 	}
 
-	return NewPreciseStore(&observation.TestContext, db)
+	return NewPreciseStore(observation.TestContextTB(t), db)
 }
 
 func testSyntacticStoreWithoutConfigurationPolicies(t *testing.T, db database.DB) RepositorySchedulingStore {
@@ -245,7 +245,7 @@ func testSyntacticStoreWithoutConfigurationPolicies(t *testing.T, db database.DB
 		t.Fatalf("unexpected error while inserting configuration policies: %s", err)
 	}
 
-	return NewSyntacticStore(&observation.TestContext, db)
+	return NewSyntacticStore(observation.TestContextTB(t), db)
 }
 
 func assertRepoList(t *testing.T, store RepositorySchedulingStore, batchOptions RepositoryBatchOptions, now time.Time, want []int) {

--- a/internal/codeintel/sentinel/internal/store/matches_test.go
+++ b/internal/codeintel/sentinel/internal/store/matches_test.go
@@ -24,7 +24,7 @@ func TestVulnerabilityMatchByID(t *testing.T) {
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	setupReferences(t, db)
 
@@ -59,7 +59,7 @@ func TestGetVulnerabilityMatches(t *testing.T) {
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	/*
 	 * Setup references is inserting seven (7) total references.
@@ -200,7 +200,7 @@ func TestGetVulberabilityMatchesCountByRepository(t *testing.T) {
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	/*
 	 * Setup references is inserting seven (7) total references.
@@ -272,7 +272,7 @@ func TestGetVulnerabilityMatchesSummaryCount(t *testing.T) {
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 	handle := basestore.NewWithHandle(db.Handle())
 
 	/* Insert uploads for four (4) repositories */

--- a/internal/codeintel/sentinel/internal/store/vulnerabilities_test.go
+++ b/internal/codeintel/sentinel/internal/store/vulnerabilities_test.go
@@ -37,7 +37,7 @@ func TestVulnerabilityByID(t *testing.T) {
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	if _, err := store.InsertVulnerabilities(ctx, testVulnerabilities); err != nil {
 		t.Fatalf("unexpected error inserting vulnerabilities: %s", err)
@@ -59,7 +59,7 @@ func TestGetVulnerabilitiesByIDs(t *testing.T) {
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	if _, err := store.InsertVulnerabilities(ctx, testVulnerabilities); err != nil {
 		t.Fatalf("unexpected error inserting vulnerabilities: %s", err)
@@ -78,7 +78,7 @@ func TestGetVulnerabilities(t *testing.T) {
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	if _, err := store.InsertVulnerabilities(ctx, testVulnerabilities); err != nil {
 		t.Fatalf("unexpected error inserting vulnerabilities: %s", err)

--- a/internal/codeintel/syntactic_indexing/jobstore/store_test.go
+++ b/internal/codeintel/syntactic_indexing/jobstore/store_test.go
@@ -24,7 +24,7 @@ func TestIndexingWorkerStore(t *testing.T) {
 		so it's important that we use the real Postgres in this test to prevent
 		schema/implementation drift.
 	*/
-	observationContext := &observation.TestContext
+	observationContext := observation.TestContextTB(t)
 	sqlDB := dbtest.NewDB(t)
 	db := database.NewDB(observationContext.Logger, sqlDB)
 

--- a/internal/codeintel/uploads/internal/background/expirer/job_expirer_test.go
+++ b/internal/codeintel/uploads/internal/background/expirer/job_expirer_test.go
@@ -27,7 +27,7 @@ func TestUploadExpirer(t *testing.T) {
 	policySvc := setupMockPolicyService()
 	policyMatcher := testUploadExpirerMockPolicyMatcher()
 	repoStore := defaultMockRepoStore()
-	expirationMetrics := NewExpirationMetrics(&observation.TestContext)
+	expirationMetrics := NewExpirationMetrics(observation.TestContextTB(t))
 
 	uploadExpirer := &expirer{
 		store:         uploadSvc,

--- a/internal/codeintel/uploads/internal/lsifstore/cleanup_test.go
+++ b/internal/codeintel/uploads/internal/lsifstore/cleanup_test.go
@@ -23,7 +23,7 @@ func TestDeleteLsifDataByUploadIds(t *testing.T) {
 		Level: log.LevelError,
 	})
 	codeIntelDB := codeintelshared.NewCodeIntelDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, codeIntelDB)
+	store := New(observation.TestContextTB(t), codeIntelDB)
 
 	t.Run("scip", func(t *testing.T) {
 		for i := range 5 {
@@ -54,7 +54,7 @@ func TestDeleteAbandonedSchemaVersionsRecords(t *testing.T) {
 		Level: log.LevelError,
 	})
 	codeIntelDB := codeintelshared.NewCodeIntelDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, codeIntelDB)
+	store := New(observation.TestContextTB(t), codeIntelDB)
 	ctx := context.Background()
 
 	assertCounts := func(expectedNumSymbols, expectedNumDocuments int) {
@@ -126,7 +126,7 @@ func TestDeleteUnreferencedDocuments(t *testing.T) {
 	logger := logtest.Scoped(t)
 	codeIntelDB := codeintelshared.NewCodeIntelDB(logger, dbtest.NewDB(t))
 	internalStore := basestore.NewWithHandle(codeIntelDB.Handle())
-	store := New(&observation.TestContext, codeIntelDB)
+	store := New(observation.TestContextTB(t), codeIntelDB)
 
 	for i := range 200 {
 		insertDocumentQuery := sqlf.Sprintf(
@@ -222,7 +222,7 @@ func TestDeleteUnreferencedDocuments(t *testing.T) {
 func TestIDsWithMeta(t *testing.T) {
 	logger := logtest.Scoped(t)
 	codeIntelDB := codeintelshared.NewCodeIntelDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, codeIntelDB)
+	store := New(observation.TestContextTB(t), codeIntelDB)
 	ctx := context.Background()
 
 	if _, err := codeIntelDB.ExecContext(ctx, `
@@ -257,7 +257,7 @@ func TestIDsWithMeta(t *testing.T) {
 func TestReconcileCandidates(t *testing.T) {
 	logger := logtest.Scoped(t)
 	codeIntelDB := codeintelshared.NewCodeIntelDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, codeIntelDB)
+	store := New(observation.TestContextTB(t), codeIntelDB)
 
 	ctx := context.Background()
 	now := time.Unix(1587396557, 0).UTC()

--- a/internal/codeintel/uploads/internal/lsifstore/insert_test.go
+++ b/internal/codeintel/uploads/internal/lsifstore/insert_test.go
@@ -16,7 +16,7 @@ import (
 func TestInsertMetadata(t *testing.T) {
 	logger := logtest.Scoped(t)
 	codeIntelDB := codeintelshared.NewCodeIntelDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, codeIntelDB)
+	store := New(observation.TestContextTB(t), codeIntelDB)
 	ctx := context.Background()
 
 	if err := store.InsertMetadata(ctx, 42, ProcessedMetadata{
@@ -33,7 +33,7 @@ func TestInsertMetadata(t *testing.T) {
 func TestInsertSharedDocumentsConcurrently(t *testing.T) {
 	logger := logtest.Scoped(t)
 	codeIntelDB := codeintelshared.NewCodeIntelDB(logger, dbtest.NewDB(t))
-	store := newInternal(&observation.TestContext, codeIntelDB)
+	store := newInternal(observation.TestContextTB(t), codeIntelDB)
 	ctx := context.Background()
 
 	tx1, err := store.Transact(ctx)
@@ -110,7 +110,7 @@ func TestInsertSharedDocumentsConcurrently(t *testing.T) {
 func TestInsertDocumentWithSymbols(t *testing.T) {
 	logger := logtest.Scoped(t)
 	codeIntelDB := codeintelshared.NewCodeIntelDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, codeIntelDB)
+	store := New(observation.TestContextTB(t), codeIntelDB)
 	ctx := context.Background()
 
 	var n uint32

--- a/internal/codeintel/uploads/internal/store/cleanup_test.go
+++ b/internal/codeintel/uploads/internal/store/cleanup_test.go
@@ -23,7 +23,7 @@ import (
 func TestHardDeleteUploadsByIDs(t *testing.T) {
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	insertUploads(t, db,
 		shared.Upload{ID: 51, State: "deleting"},
@@ -51,7 +51,7 @@ func TestHardDeleteUploadsByIDs(t *testing.T) {
 func TestDeleteUploadsStuckUploading(t *testing.T) {
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	t1 := time.Unix(1587396557, 0).UTC()
 	t2 := t1.Add(time.Minute * 1)
@@ -99,7 +99,7 @@ func TestDeleteUploadsStuckUploading(t *testing.T) {
 func TestDeleteUploadsWithoutRepository(t *testing.T) {
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	var uploads []shared.Upload
 	for i := range 25 {
@@ -160,7 +160,7 @@ func TestDeleteOldAuditLogs(t *testing.T) {
 	logger := logtest.Scoped(t)
 	sqlDB := dbtest.NewDB(t)
 	db := database.NewDB(logger, sqlDB)
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	// Sanity check for syntax only
 	if _, _, err := store.DeleteOldAuditLogs(context.Background(), time.Second, time.Now()); err != nil {
@@ -171,7 +171,7 @@ func TestDeleteOldAuditLogs(t *testing.T) {
 func TestReconcileCandidates(t *testing.T) {
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 	ctx := context.Background()
 
 	if _, err := db.ExecContext(ctx, `
@@ -225,7 +225,7 @@ func TestProcessStaleSourcedCommits(t *testing.T) {
 	store := &store{
 		db:         basestore.NewWithHandle(db.Handle()),
 		logger:     logger.Scoped("autoindexing.store"),
-		operations: newOperations(&observation.TestContext),
+		operations: newOperations(observation.TestContextTB(t)),
 	}
 
 	ctx := context.Background()
@@ -337,7 +337,7 @@ func TestGetStaleSourcedCommits(t *testing.T) {
 	logger := logtest.Scoped(t)
 	sqlDB := dbtest.NewDB(t)
 	db := database.NewDB(logger, sqlDB)
-	store := New(&observation.TestContext, db).(s2)
+	store := New(observation.TestContextTB(t), db).(s2)
 
 	now := time.Unix(1587396557, 0).UTC()
 
@@ -391,7 +391,7 @@ func TestUpdateSourcedCommits(t *testing.T) {
 	logger := logtest.Scoped(t)
 	sqlDB := dbtest.NewDB(t)
 	db := database.NewDB(logger, sqlDB)
-	store := New(&observation.TestContext, db).(s2)
+	store := New(observation.TestContextTB(t), db).(s2)
 
 	now := time.Unix(1587396557, 0).UTC()
 
@@ -432,7 +432,7 @@ func TestUpdateSourcedCommits(t *testing.T) {
 func TestGetQueuedUploadRank(t *testing.T) {
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	t1 := time.Unix(1587396557, 0).UTC()
 	t2 := t1.Add(+time.Minute * 6)
@@ -483,7 +483,7 @@ func TestDeleteSourcedCommits(t *testing.T) {
 	logger := logtest.Scoped(t)
 	sqlDB := dbtest.NewDB(t)
 	db := database.NewDB(logger, sqlDB)
-	store := New(&observation.TestContext, db).(s2)
+	store := New(observation.TestContextTB(t), db).(s2)
 
 	now := time.Unix(1587396557, 0).UTC()
 
@@ -529,7 +529,7 @@ func TestDeleteSourcedCommits(t *testing.T) {
 func TestDeleteIndexesWithoutRepository(t *testing.T) {
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	var indexes []uploadsshared.Index
 	for i := range 25 {
@@ -568,7 +568,7 @@ func TestDeleteIndexesWithoutRepository(t *testing.T) {
 func TestExpireFailedRecords(t *testing.T) {
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	ctx := context.Background()
 	now := time.Unix(1587396557, 0).UTC()

--- a/internal/codeintel/uploads/internal/store/commitdate_test.go
+++ b/internal/codeintel/uploads/internal/store/commitdate_test.go
@@ -18,7 +18,7 @@ import (
 func TestGetOldestCommitDate(t *testing.T) {
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	t1 := time.Unix(1587396557, 0).UTC()
 	t2 := t1.Add(time.Minute)
@@ -102,7 +102,7 @@ func TestGetOldestCommitDate(t *testing.T) {
 func TestSourcedCommitsWithoutCommittedAt(t *testing.T) {
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	now := time.Unix(1587396557, 0).UTC()
 

--- a/internal/codeintel/uploads/internal/store/commitgraph_test.go
+++ b/internal/codeintel/uploads/internal/store/commitgraph_test.go
@@ -31,7 +31,7 @@ import (
 func TestSetRepositoryAsDirty(t *testing.T) {
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	for _, id := range []int{50, 51, 52} {
 		insertRepo(t, db, id, "", false)
@@ -62,7 +62,7 @@ func TestSetRepositoryAsDirty(t *testing.T) {
 func TestSkipsDeletedRepositories(t *testing.T) {
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	insertRepo(t, db, 50, "should not be dirty", false)
 	deleteRepo(t, db, 50, time.Now())
@@ -95,7 +95,7 @@ func TestSkipsDeletedRepositories(t *testing.T) {
 func TestCalculateVisibleUploadsResetsDirtyFlagTransactionTimestamp(t *testing.T) {
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	uploads := []shared.Upload{
 		{ID: 1, Commit: makeCommit(1)},
@@ -130,7 +130,7 @@ func TestCalculateVisibleUploadsResetsDirtyFlagTransactionTimestamp(t *testing.T
 func TestCalculateVisibleUploadsNonDefaultBranches(t *testing.T) {
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	// This database has the following commit graph:
 	//
@@ -223,7 +223,7 @@ func TestCalculateVisibleUploadsNonDefaultBranches(t *testing.T) {
 func TestCalculateVisibleUploadsNonDefaultBranchesWithCustomRetentionConfiguration(t *testing.T) {
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	// This database has the following commit graph:
 	//
@@ -333,7 +333,7 @@ func TestCalculateVisibleUploadsNonDefaultBranchesWithCustomRetentionConfigurati
 func TestUpdateUploadsVisibleToCommits(t *testing.T) {
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	// This database has the following commit graph:
 	//
@@ -392,7 +392,7 @@ func TestUpdateUploadsVisibleToCommits(t *testing.T) {
 func TestUpdateUploadsVisibleToCommitsAlternateCommitGraph(t *testing.T) {
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	// This database has the following commit graph:
 	//
@@ -445,7 +445,7 @@ func TestUpdateUploadsVisibleToCommitsAlternateCommitGraph(t *testing.T) {
 func TestUpdateUploadsVisibleToCommitsDistinctRoots(t *testing.T) {
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	// This database has the following commit graph:
 	//
@@ -488,7 +488,7 @@ func TestUpdateUploadsVisibleToCommitsDistinctRoots(t *testing.T) {
 func TestUpdateUploadsVisibleToCommitsOverlappingRoots(t *testing.T) {
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	// This database has the following commit graph:
 	//
@@ -563,7 +563,7 @@ func TestUpdateUploadsVisibleToCommitsOverlappingRoots(t *testing.T) {
 func TestUpdateUploadsVisibleToCommitsIndexerName(t *testing.T) {
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	// This database has the following commit graph:
 	//
@@ -619,7 +619,7 @@ func TestUpdateUploadsVisibleToCommitsIndexerName(t *testing.T) {
 func TestUpdateUploadsVisibleToCommitsResetsDirtyFlag(t *testing.T) {
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	uploads := []shared.Upload{
 		{ID: 1, Commit: makeCommit(1)},
@@ -686,7 +686,7 @@ func TestUpdateUploadsVisibleToCommitsResetsDirtyFlag(t *testing.T) {
 func TestFindClosestCompletedUploads(t *testing.T) {
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	// This database has the following commit graph:
 	//
@@ -752,7 +752,7 @@ func TestFindClosestCompletedUploads(t *testing.T) {
 func TestFindClosestCompletedUploadsAlternateCommitGraph(t *testing.T) {
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	// This database has the following commit graph:
 	//
@@ -812,7 +812,7 @@ func TestFindClosestCompletedUploadsAlternateCommitGraph(t *testing.T) {
 func TestFindClosestCompletedUploadsAlternateCommitGraphWithOverwrittenVisibleUploads(t *testing.T) {
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	// This database has the following commit graph:
 	//
@@ -865,7 +865,7 @@ func TestFindClosestCompletedUploadsAlternateCommitGraphWithOverwrittenVisibleUp
 func TestFindClosestCompletedUploadsDistinctRoots(t *testing.T) {
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	// This database has the following commit graph:
 	//
@@ -915,7 +915,7 @@ func TestFindClosestCompletedUploadsDistinctRoots(t *testing.T) {
 func TestFindClosestCompletedUploadsOverlappingRoots(t *testing.T) {
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	// This database has the following commit graph:
 	//
@@ -995,7 +995,7 @@ func TestFindClosestCompletedUploadsOverlappingRoots(t *testing.T) {
 func TestFindClosestCompletedUploadsIndexerName(t *testing.T) {
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	// This database has the following commit graph:
 	//
@@ -1084,7 +1084,7 @@ func TestFindClosestCompletedUploadsIndexerName(t *testing.T) {
 func TestFindClosestCompletedUploadsIntersectingPath(t *testing.T) {
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	// This database has the following commit graph:
 	//
@@ -1128,7 +1128,7 @@ func TestFindClosestCompletedUploadsIntersectingPath(t *testing.T) {
 func TestFindClosestCompletedUploadsFromGraphFragment(t *testing.T) {
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	// This database has the following commit graph:
 	//
@@ -1194,7 +1194,7 @@ func TestFindClosestCompletedUploadsFromGraphFragment(t *testing.T) {
 func TestGetRepositoriesMaxStaleAge(t *testing.T) {
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	for _, id := range []int{50, 51, 52} {
 		insertRepo(t, db, id, "", false)
@@ -1228,7 +1228,7 @@ func TestGetRepositoriesMaxStaleAge(t *testing.T) {
 func TestCommitGraphMetadata(t *testing.T) {
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	if err := store.SetRepositoryAsDirty(context.Background(), 50); err != nil {
 		t.Errorf("unexpected error marking repository as dirty: %s", err)
@@ -1535,7 +1535,7 @@ func keysOf(m map[string][]int) (keys []string) {
 func BenchmarkCalculateVisibleUploads(b *testing.B) {
 	logger := logtest.Scoped(b)
 	db := database.NewDB(logger, dbtest.NewDB(b))
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(b), db)
 
 	graph, err := readBenchmarkCommitGraph()
 	if err != nil {

--- a/internal/codeintel/uploads/internal/store/dependencies_test.go
+++ b/internal/codeintel/uploads/internal/store/dependencies_test.go
@@ -18,7 +18,7 @@ import (
 func TestReferencesForUpload(t *testing.T) {
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	insertUploads(t, db,
 		shared.Upload{ID: 1, Commit: makeCommit(2), Root: "sub1/"},
@@ -59,7 +59,7 @@ func TestReferencesForUpload(t *testing.T) {
 func TestUpdatePackages(t *testing.T) {
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	// for foreign key relation
 	insertUploads(t, db, shared.Upload{ID: 42})
@@ -91,7 +91,7 @@ func TestUpdatePackages(t *testing.T) {
 func TestUpdatePackagesEmpty(t *testing.T) {
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	if err := store.UpdatePackages(context.Background(), 0, nil); err != nil {
 		t.Fatalf("unexpected error updating packages: %s", err)
@@ -109,7 +109,7 @@ func TestUpdatePackagesEmpty(t *testing.T) {
 func TestUpdatePackageReferences(t *testing.T) {
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	// for foreign key relation
 	insertUploads(t, db, shared.Upload{ID: 42})

--- a/internal/codeintel/uploads/internal/store/expiration_test.go
+++ b/internal/codeintel/uploads/internal/store/expiration_test.go
@@ -17,7 +17,7 @@ import (
 func TestSoftDeleteExpiredUploads(t *testing.T) {
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	insertUploads(t, db,
 		shared.Upload{ID: 50, RepositoryID: 100, State: "completed"},
@@ -97,7 +97,7 @@ func TestSoftDeleteExpiredUploads(t *testing.T) {
 func TestSoftDeleteExpiredUploadsViaTraversal(t *testing.T) {
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	// The packages in this test reference each other in the following way:
 	//

--- a/internal/codeintel/uploads/internal/store/indexes_test.go
+++ b/internal/codeintel/uploads/internal/store/indexes_test.go
@@ -25,7 +25,7 @@ func TestGetIndexes(t *testing.T) {
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	t1 := time.Unix(1587396557, 0).UTC()
 	t2 := t1.Add(-time.Minute * 1)
@@ -163,7 +163,7 @@ func TestGetIndexByID(t *testing.T) {
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	// Index does not exist initially
 	if _, exists, err := store.GetIndexByID(ctx, 1); err != nil {
@@ -242,7 +242,7 @@ func TestGetIndexByID(t *testing.T) {
 func TestGetQueuedIndexRank(t *testing.T) {
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	t1 := time.Unix(1587396557, 0).UTC()
 	t2 := t1.Add(+time.Minute * 6)
@@ -293,7 +293,7 @@ func TestGetIndexesByIDs(t *testing.T) {
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	indexID1, indexID2, indexID3, indexID4 := 1, 3, 5, 5 // note the duplication
 	uploadID1, uploadID2, uploadID3, uploadID4 := 10, 11, 12, 13
@@ -361,7 +361,7 @@ func TestGetIndexesByIDs(t *testing.T) {
 func TestDeleteIndexByID(t *testing.T) {
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	insertIndexes(t, db, uploadsshared.Index{ID: 1})
 
@@ -382,7 +382,7 @@ func TestDeleteIndexByID(t *testing.T) {
 func TestDeleteIndexes(t *testing.T) {
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	insertIndexes(t, db, uploadsshared.Index{ID: 1, State: "completed"})
 	insertIndexes(t, db, uploadsshared.Index{ID: 2, State: "errored"})
@@ -406,7 +406,7 @@ func TestDeleteIndexes(t *testing.T) {
 func TestDeleteIndexesWithIndexerKey(t *testing.T) {
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	insertIndexes(t, db, uploadsshared.Index{ID: 1, Indexer: "sourcegraph/scip-go@sha256:123456"})
 	insertIndexes(t, db, uploadsshared.Index{ID: 2, Indexer: "sourcegraph/scip-go"})
@@ -441,7 +441,7 @@ func TestDeleteIndexesWithIndexerKey(t *testing.T) {
 func TestReindexIndexByID(t *testing.T) {
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	insertIndexes(t, db, uploadsshared.Index{ID: 1, State: "completed"})
 	insertIndexes(t, db, uploadsshared.Index{ID: 2, State: "errored"})
@@ -463,7 +463,7 @@ func TestReindexIndexByID(t *testing.T) {
 func TestReindexIndexes(t *testing.T) {
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	insertIndexes(t, db, uploadsshared.Index{ID: 1, State: "completed"})
 	insertIndexes(t, db, uploadsshared.Index{ID: 2, State: "errored"})
@@ -489,7 +489,7 @@ func TestReindexIndexes(t *testing.T) {
 func TestReindexIndexesWithIndexerKey(t *testing.T) {
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	insertIndexes(t, db, uploadsshared.Index{ID: 1, Indexer: "sourcegraph/scip-go@sha256:123456"})
 	insertIndexes(t, db, uploadsshared.Index{ID: 2, Indexer: "sourcegraph/scip-go"})
@@ -522,7 +522,7 @@ func TestReindexIndexesWithIndexerKey(t *testing.T) {
 func TestDeleteIndexByIDMissingRow(t *testing.T) {
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	if found, err := store.DeleteIndexByID(context.Background(), 1); err != nil {
 		t.Fatalf("unexpected error deleting index: %s", err)

--- a/internal/codeintel/uploads/internal/store/misc_test.go
+++ b/internal/codeintel/uploads/internal/store/misc_test.go
@@ -17,7 +17,7 @@ import (
 func TestHasRepository(t *testing.T) {
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	testCases := []struct {
 		repositoryID int
@@ -50,7 +50,7 @@ func TestHasCommit(t *testing.T) {
 	logger := logtest.Scoped(t)
 	sqlDB := dbtest.NewDB(t)
 	db := database.NewDB(logger, sqlDB)
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	testCases := []struct {
 		repositoryID int
@@ -83,7 +83,7 @@ func TestHasCommit(t *testing.T) {
 func TestInsertDependencySyncingJob(t *testing.T) {
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	uploadID := 42
 	insertRepo(t, db, 50, "", false)

--- a/internal/codeintel/uploads/internal/store/processing_test.go
+++ b/internal/codeintel/uploads/internal/store/processing_test.go
@@ -18,7 +18,7 @@ import (
 func TestInsertUploadUploading(t *testing.T) {
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	insertRepo(t, db, 50, "", false)
 
@@ -68,7 +68,7 @@ func TestInsertUploadUploading(t *testing.T) {
 func TestInsertUploadQueued(t *testing.T) {
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	insertRepo(t, db, 50, "", false)
 
@@ -121,7 +121,7 @@ func TestInsertUploadQueued(t *testing.T) {
 func TestInsertUploadWithAssociatedIndexID(t *testing.T) {
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	insertRepo(t, db, 50, "", false)
 
@@ -178,7 +178,7 @@ func TestInsertUploadWithAssociatedIndexID(t *testing.T) {
 func TestAddUploadPart(t *testing.T) {
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	insertUploads(t, db, shared.Upload{ID: 1, State: "uploading"})
 
@@ -202,7 +202,7 @@ func TestAddUploadPart(t *testing.T) {
 func TestMarkQueued(t *testing.T) {
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	insertUploads(t, db, shared.Upload{ID: 1, State: "uploading"})
 
@@ -229,7 +229,7 @@ func TestMarkQueued(t *testing.T) {
 func TestMarkQueuedNoSize(t *testing.T) {
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	insertUploads(t, db, shared.Upload{ID: 1, State: "uploading"})
 
@@ -251,7 +251,7 @@ func TestMarkQueuedNoSize(t *testing.T) {
 func TestMarkFailed(t *testing.T) {
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	insertUploads(t, db, shared.Upload{ID: 1, State: "uploading"})
 
@@ -281,7 +281,7 @@ func TestDeleteOverlappingCompletedUploads(t *testing.T) {
 	logger := logtest.Scoped(t)
 	sqlDB := dbtest.NewDB(t)
 	db := database.NewDB(logger, sqlDB)
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	insertUploads(t, db, shared.Upload{
 		ID:      1,
@@ -307,7 +307,7 @@ func TestDeleteOverlappingCompletedUploadsNoMatches(t *testing.T) {
 	logger := logtest.Scoped(t)
 	sqlDB := dbtest.NewDB(t)
 	db := database.NewDB(logger, sqlDB)
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	insertUploads(t, db, shared.Upload{
 		ID:      1,
@@ -345,7 +345,7 @@ func TestDeleteOverlappingCompletedUploadsIgnoresIncompleteUploads(t *testing.T)
 	logger := logtest.Scoped(t)
 	sqlDB := dbtest.NewDB(t)
 	db := database.NewDB(logger, sqlDB)
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	insertUploads(t, db, shared.Upload{
 		ID:      1,

--- a/internal/codeintel/uploads/internal/store/summary_test.go
+++ b/internal/codeintel/uploads/internal/store/summary_test.go
@@ -18,7 +18,7 @@ import (
 func TestGetIndexers(t *testing.T) {
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 	ctx := context.Background()
 
 	insertUploads(t, db,
@@ -64,7 +64,7 @@ func TestRecentUploadsSummary(t *testing.T) {
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	t0 := time.Unix(1587396557, 0).UTC()
 	t1 := t0.Add(-time.Minute * 1)
@@ -123,7 +123,7 @@ func TestRecentIndexesSummary(t *testing.T) {
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	t0 := time.Unix(1587396557, 0).UTC()
 	t1 := t0.Add(-time.Minute * 1)
@@ -184,7 +184,7 @@ func TestRepositoryIDsWithErrors(t *testing.T) {
 	logger := logtest.Scoped(t)
 	sqlDB := dbtest.NewDB(t)
 	db := database.NewDB(logger, sqlDB)
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	now := time.Now()
 	t1 := now.Add(-time.Minute * 1)
@@ -264,7 +264,7 @@ func TestNumRepositoriesWithCodeIntelligence(t *testing.T) {
 	logger := logtest.Scoped(t)
 	sqlDB := dbtest.NewDB(t)
 	db := database.NewDB(logger, sqlDB)
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	insertUploads(t, db,
 		shared.Upload{ID: 100, RepositoryID: 50},

--- a/internal/codeintel/uploads/internal/store/uploads_test.go
+++ b/internal/codeintel/uploads/internal/store/uploads_test.go
@@ -27,7 +27,7 @@ import (
 func TestGetUploads(t *testing.T) {
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 	ctx := context.Background()
 
 	t1 := time.Unix(1587396557, 0).UTC()
@@ -246,7 +246,7 @@ func TestGetUploadByID(t *testing.T) {
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	// Upload does not exist initially
 	if _, exists, err := store.GetUploadByID(ctx, 1); err != nil {
@@ -314,7 +314,7 @@ func TestGetUploadByID(t *testing.T) {
 func TestGetUploadByIDDeleted(t *testing.T) {
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	// Upload does not exist initially
 	if _, exists, err := store.GetUploadByID(context.Background(), 1); err != nil {
@@ -356,7 +356,7 @@ func TestGetUploadByIDDeleted(t *testing.T) {
 func TestGetCompletedUploadsByIDs(t *testing.T) {
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	// Dumps do not exist initially
 	if uploads, err := store.GetCompletedUploadsByIDs(context.Background(), []int{1, 2}); err != nil {
@@ -428,7 +428,7 @@ func TestGetUploadsByIDs(t *testing.T) {
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	insertUploads(t, db,
 		shared.Upload{ID: 1},
@@ -487,7 +487,7 @@ func TestGetUploadsByIDs(t *testing.T) {
 func TestGetVisibleUploadsMatchingMonikers(t *testing.T) {
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	insertUploads(t, db,
 		shared.Upload{ID: 1, Commit: makeCommit(2), Root: "sub1/"},
@@ -614,7 +614,7 @@ func TestGetVisibleUploadsMatchingMonikers(t *testing.T) {
 func TestDefinitionDumps(t *testing.T) {
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	moniker1 := precise.QualifiedMonikerData{
 		MonikerData: precise.MonikerData{
@@ -760,7 +760,7 @@ func TestUploadAuditLogs(t *testing.T) {
 	logger := logtest.Scoped(t)
 	sqlDB := dbtest.NewDB(t)
 	db := database.NewDB(logger, sqlDB)
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	insertUploads(t, db, shared.Upload{ID: 1})
 	updateUploads(t, db, shared.Upload{ID: 1, State: "deleting"})
@@ -793,7 +793,7 @@ func transitionForColumn(t *testing.T, key string, transitions []map[string]*str
 func TestDeleteUploads(t *testing.T) {
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	t1 := time.Unix(1587396557, 0).UTC()
 	t2 := t1.Add(time.Minute * 1)
@@ -842,7 +842,7 @@ func TestDeleteUploads(t *testing.T) {
 func TestDeleteUploadsWithIndexerKey(t *testing.T) {
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	// note: queued so we delete, not go to deleting state first (makes assertion simpler)
 	insertUploads(t, db, shared.Upload{ID: 1, State: "queued", Indexer: "sourcegraph/scip-go@sha256:123456"})
@@ -883,7 +883,7 @@ func TestDeleteUploadsWithIndexerKey(t *testing.T) {
 func TestDeleteUploadByID(t *testing.T) {
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	insertUploads(t, db,
 		shared.Upload{ID: 1, RepositoryID: 50},
@@ -921,7 +921,7 @@ func TestDeleteUploadByID(t *testing.T) {
 func TestDeleteUploadByIDMissingRow(t *testing.T) {
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	if found, err := store.DeleteUploadByID(context.Background(), 1); err != nil {
 		t.Fatalf("unexpected error deleting upload: %s", err)
@@ -933,7 +933,7 @@ func TestDeleteUploadByIDMissingRow(t *testing.T) {
 func TestDeleteUploadByIDNotCompleted(t *testing.T) {
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	insertUploads(t, db,
 		shared.Upload{ID: 1, RepositoryID: 50, State: "uploading"},
@@ -971,7 +971,7 @@ func TestDeleteUploadByIDNotCompleted(t *testing.T) {
 func TestReindexUploads(t *testing.T) {
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	insertUploads(t, db, shared.Upload{ID: 1, State: "completed"})
 	insertUploads(t, db, shared.Upload{ID: 2, State: "errored"})
@@ -997,7 +997,7 @@ func TestReindexUploads(t *testing.T) {
 func TestReindexUploadsWithIndexerKey(t *testing.T) {
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	insertUploads(t, db, shared.Upload{ID: 1, Indexer: "sourcegraph/scip-go@sha256:123456"})
 	insertUploads(t, db, shared.Upload{ID: 2, Indexer: "sourcegraph/scip-go"})
@@ -1030,7 +1030,7 @@ func TestReindexUploadsWithIndexerKey(t *testing.T) {
 func TestReindexUploadByID(t *testing.T) {
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	store := New(&observation.TestContext, db)
+	store := New(observation.TestContextTB(t), db)
 
 	insertUploads(t, db, shared.Upload{ID: 1, State: "completed"})
 	insertUploads(t, db, shared.Upload{ID: 2, State: "errored"})

--- a/internal/codeintel/uploads/transport/http/handler_test.go
+++ b/internal/codeintel/uploads/transport/http/handler_test.go
@@ -120,12 +120,12 @@ func TestHandleEnqueueAuth(t *testing.T) {
 				repoStore,
 				mockUploadStore,
 				mockDBStore,
-				uploadhandler.NewOperations(&observation.TestContext, "test"),
+				uploadhandler.NewOperations(observation.TestContextTB(t), "test"),
 			),
 			db.Users(),
 			repoStore,
 			authValidators,
-			newOperations(&observation.TestContext).authMiddleware,
+			newOperations(observation.TestContextTB(t)).authMiddleware,
 		).ServeHTTP(w, r)
 
 		if w.Code != user.statusCode {

--- a/internal/database/connections/live/migration_test.go
+++ b/internal/database/connections/live/migration_test.go
@@ -57,7 +57,7 @@ func testMigrations(t *testing.T, name string, schema *schemas.Schema) {
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
 	db := dbtest.NewRawDB(logger, t)
-	storeFactory := newStoreFactory(&observation.TestContext)
+	storeFactory := newStoreFactory(observation.TestContextTB(t))
 	migrationRunner := runnerFromDB(logger, storeFactory, db, schema)
 	all := schema.Definitions.All()
 

--- a/internal/database/migration/stitch/stitch_test.go
+++ b/internal/database/migration/stitch/stitch_test.go
@@ -257,7 +257,7 @@ func testStitchApplication(t *testing.T, schemaName string, from, to int) {
 		db := dbtest.NewRawDB(logger, t)
 		migrationsTableName := "testing"
 
-		storeShim := connections.NewStoreShim(store.NewWithDB(&observation.TestContext, db, migrationsTableName))
+		storeShim := connections.NewStoreShim(store.NewWithDB(observation.TestContextTB(t), db, migrationsTableName))
 		if err := storeShim.EnsureSchemaTable(ctx); err != nil {
 			t.Fatalf("failed to prepare store: %s", err)
 		}

--- a/internal/diskcache/cache_test.go
+++ b/internal/diskcache/cache_test.go
@@ -18,7 +18,7 @@ func TestOpen(t *testing.T) {
 	store := &store{
 		dir:       dir,
 		component: "test",
-		observe:   newOperations(&observation.TestContext, "test"),
+		observe:   newOperations(observation.TestContextTB(t), "test"),
 	}
 
 	do := func() (*File, bool) {
@@ -68,7 +68,7 @@ func TestMultiKeyEviction(t *testing.T) {
 	store := &store{
 		dir:       dir,
 		component: "test",
-		observe:   newOperations(&observation.TestContext, "test"),
+		observe:   newOperations(observation.TestContextTB(t), "test"),
 	}
 
 	f, err := store.Open(context.Background(), []string{"key1", "key2"}, func(ctx context.Context) (io.ReadCloser, error) {
@@ -94,7 +94,7 @@ func TestEvict(t *testing.T) {
 	store := &store{
 		dir:       dir,
 		component: "test",
-		observe:   newOperations(&observation.TestContext, "test"),
+		observe:   newOperations(observation.TestContextTB(t), "test"),
 	}
 
 	for _, name := range []string{

--- a/internal/executor/store/store_test.go
+++ b/internal/executor/store/store_test.go
@@ -20,7 +20,7 @@ import (
 func TestJobTokenStore_Create(t *testing.T) {
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	tokenStore := store.NewJobTokenStore(&observation.TestContext, db)
+	tokenStore := store.NewJobTokenStore(observation.TestContextTB(t), db)
 
 	repoStore := database.ReposWith(logger, db)
 	esStore := database.ExternalServicesWith(logger, db)
@@ -81,7 +81,7 @@ func TestJobTokenStore_Create(t *testing.T) {
 func TestJobTokenStore_Create_Duplicate(t *testing.T) {
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	tokenStore := store.NewJobTokenStore(&observation.TestContext, db)
+	tokenStore := store.NewJobTokenStore(observation.TestContextTB(t), db)
 
 	repoStore := database.ReposWith(logger, db)
 	esStore := database.ExternalServicesWith(logger, db)
@@ -103,7 +103,7 @@ func TestJobTokenStore_Create_Duplicate(t *testing.T) {
 func TestJobTokenStore_Regenerate(t *testing.T) {
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	tokenStore := store.NewJobTokenStore(&observation.TestContext, db)
+	tokenStore := store.NewJobTokenStore(observation.TestContextTB(t), db)
 
 	repoStore := database.ReposWith(logger, db)
 	esStore := database.ExternalServicesWith(logger, db)
@@ -148,7 +148,7 @@ func TestJobTokenStore_Regenerate(t *testing.T) {
 func TestJobTokenStore_Exists(t *testing.T) {
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	tokenStore := store.NewJobTokenStore(&observation.TestContext, db)
+	tokenStore := store.NewJobTokenStore(observation.TestContextTB(t), db)
 
 	repoStore := database.ReposWith(logger, db)
 	esStore := database.ExternalServicesWith(logger, db)
@@ -201,7 +201,7 @@ func TestJobTokenStore_Exists(t *testing.T) {
 func TestJobTokenStore_Get(t *testing.T) {
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	tokenStore := store.NewJobTokenStore(&observation.TestContext, db)
+	tokenStore := store.NewJobTokenStore(observation.TestContextTB(t), db)
 
 	repoStore := database.ReposWith(logger, db)
 	esStore := database.ExternalServicesWith(logger, db)
@@ -268,7 +268,7 @@ func TestJobTokenStore_Get(t *testing.T) {
 func TestJobTokenStore_GetByToken(t *testing.T) {
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	tokenStore := store.NewJobTokenStore(&observation.TestContext, db)
+	tokenStore := store.NewJobTokenStore(observation.TestContextTB(t), db)
 
 	repoStore := database.ReposWith(logger, db)
 	esStore := database.ExternalServicesWith(logger, db)
@@ -333,7 +333,7 @@ func TestJobTokenStore_GetByToken(t *testing.T) {
 func TestJobTokenStore_Delete(t *testing.T) {
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	tokenStore := store.NewJobTokenStore(&observation.TestContext, db)
+	tokenStore := store.NewJobTokenStore(observation.TestContextTB(t), db)
 
 	repoStore := database.ReposWith(logger, db)
 	esStore := database.ExternalServicesWith(logger, db)

--- a/internal/gitserver/client.go
+++ b/internal/gitserver/client.go
@@ -84,7 +84,7 @@ func NewTestClient(t testing.TB) TestClient {
 	return &clientImplementor{
 		logger:              logger,
 		scope:               fmt.Sprintf("gitserver.test.%s", t.Name()),
-		operations:          newOperations(observation.ContextWithLogger(logger, &observation.TestContext)),
+		operations:          newOperations(observation.ContextWithLogger(logger, observation.TestContextTB(t))),
 		clientSource:        NewTestClientSource(t, nil),
 		subRepoPermsChecker: authz.DefaultSubRepoPermsChecker,
 	}

--- a/internal/insights/scheduler/backfill_state_inprogress_handler_test.go
+++ b/internal/insights/scheduler/backfill_state_inprogress_handler_test.go
@@ -63,7 +63,7 @@ func Test_MovesBackfillFromProcessingToComplete(t *testing.T) {
 		InsightsDB:     insightsDB,
 		RepoStore:      repos,
 		InsightStore:   seriesStore,
-		ObservationCtx: &observation.TestContext,
+		ObservationCtx: observation.TestContextTB(t),
 		BackfillRunner: &noopBackfillRunner{},
 		CostAnalyzer:   priority.NewQueryAnalyzer(),
 	}
@@ -140,7 +140,7 @@ func Test_PullsByEstimatedCostAge(t *testing.T) {
 		InsightsDB:     insightsDB,
 		RepoStore:      repos,
 		InsightStore:   seriesStore,
-		ObservationCtx: &observation.TestContext,
+		ObservationCtx: observation.TestContextTB(t),
 		BackfillRunner: &noopBackfillRunner{},
 		CostAnalyzer:   priority.NewQueryAnalyzer(),
 	}
@@ -203,7 +203,7 @@ func Test_BackfillWithRetry(t *testing.T) {
 		InsightsDB:     insightsDB,
 		RepoStore:      repos,
 		InsightStore:   seriesStore,
-		ObservationCtx: &observation.TestContext,
+		ObservationCtx: observation.TestContextTB(t),
 		BackfillRunner: &noopBackfillRunner{},
 		CostAnalyzer:   priority.NewQueryAnalyzer(),
 	}
@@ -282,7 +282,7 @@ func Test_BackfillWithRetryAndComplete(t *testing.T) {
 		InsightsDB:     insightsDB,
 		RepoStore:      repos,
 		InsightStore:   seriesStore,
-		ObservationCtx: &observation.TestContext,
+		ObservationCtx: observation.TestContextTB(t),
 		BackfillRunner: &noopBackfillRunner{},
 		CostAnalyzer:   priority.NewQueryAnalyzer(),
 	}
@@ -370,7 +370,7 @@ func Test_BackfillWithRepoNotFound(t *testing.T) {
 		InsightsDB:     insightsDB,
 		RepoStore:      repos,
 		InsightStore:   seriesStore,
-		ObservationCtx: &observation.TestContext,
+		ObservationCtx: observation.TestContextTB(t),
 		BackfillRunner: &noopBackfillRunner{},
 		CostAnalyzer:   priority.NewQueryAnalyzer(),
 	}
@@ -453,7 +453,7 @@ func Test_BackfillWithARepoError(t *testing.T) {
 		InsightsDB:     insightsDB,
 		RepoStore:      repos,
 		InsightStore:   seriesStore,
-		ObservationCtx: &observation.TestContext,
+		ObservationCtx: observation.TestContextTB(t),
 		BackfillRunner: &noopBackfillRunner{},
 		CostAnalyzer:   priority.NewQueryAnalyzer(),
 	}
@@ -530,7 +530,7 @@ func Test_BackfillWithInterrupt(t *testing.T) {
 		InsightsDB:     insightsDB,
 		RepoStore:      repos,
 		InsightStore:   seriesStore,
-		ObservationCtx: &observation.TestContext,
+		ObservationCtx: observation.TestContextTB(t),
 		BackfillRunner: &noopBackfillRunner{},
 		CostAnalyzer:   priority.NewQueryAnalyzer(),
 	}
@@ -617,7 +617,7 @@ func Test_BackfillCrossingErrorThreshold(t *testing.T) {
 		InsightsDB:     insightsDB,
 		RepoStore:      repos,
 		InsightStore:   seriesStore,
-		ObservationCtx: &observation.TestContext,
+		ObservationCtx: observation.TestContextTB(t),
 		BackfillRunner: &noopBackfillRunner{},
 		CostAnalyzer:   priority.NewQueryAnalyzer(),
 	}

--- a/internal/insights/scheduler/backfill_state_new_handler_test.go
+++ b/internal/insights/scheduler/backfill_state_new_handler_test.go
@@ -40,7 +40,7 @@ func Test_MovesBackfillFromNewToProcessing(t *testing.T) {
 	config := JobMonitorConfig{
 		InsightsDB:        insightsDB,
 		RepoStore:         repos,
-		ObservationCtx:    &observation.TestContext,
+		ObservationCtx:    observation.TestContextTB(t),
 		CostAnalyzer:      priority.NewQueryAnalyzer(),
 		InsightStore:      seriesStore,
 		RepoQueryExecutor: repoQueryExecutor,
@@ -116,7 +116,7 @@ func Test_MovesBackfillFromNewToProcessing_ScopedInsight(t *testing.T) {
 	config := JobMonitorConfig{
 		InsightsDB:        insightsDB,
 		RepoStore:         repos,
-		ObservationCtx:    &observation.TestContext,
+		ObservationCtx:    observation.TestContextTB(t),
 		CostAnalyzer:      priority.NewQueryAnalyzer(),
 		InsightStore:      seriesStore,
 		RepoQueryExecutor: repoQueryExecutor,

--- a/internal/insights/scheduler/scheduler_test.go
+++ b/internal/insights/scheduler/scheduler_test.go
@@ -29,7 +29,7 @@ func Test_MonitorStartsAndStops(t *testing.T) {
 	config := JobMonitorConfig{
 		InsightsDB:     insightsDB,
 		RepoStore:      repos,
-		ObservationCtx: &observation.TestContext,
+		ObservationCtx: observation.TestContextTB(t),
 		CostAnalyzer:   priority.NewQueryAnalyzer(),
 	}
 	routines := NewBackgroundJobMonitor(ctx, config).Routines()
@@ -45,7 +45,7 @@ func TestScheduler_InitialBackfill(t *testing.T) {
 	config := JobMonitorConfig{
 		InsightsDB:     insightsDB,
 		RepoStore:      repos,
-		ObservationCtx: &observation.TestContext,
+		ObservationCtx: observation.TestContextTB(t),
 		CostAnalyzer:   priority.NewQueryAnalyzer(),
 	}
 	monitor := NewBackgroundJobMonitor(ctx, config)

--- a/internal/luasandbox/sandbox_test.go
+++ b/internal/luasandbox/sandbox_test.go
@@ -16,7 +16,7 @@ import (
 func TestSandboxHasNoIO(t *testing.T) {
 	ctx := context.Background()
 
-	sandbox, err := newService(&observation.TestContext).CreateSandbox(ctx, CreateOptions{})
+	sandbox, err := newService(observation.TestContextTB(t)).CreateSandbox(ctx, CreateOptions{})
 	if err != nil {
 		t.Fatalf("unexpected error creating sandbox: %s", err)
 	}
@@ -49,7 +49,7 @@ func TestSandboxHasNoIO(t *testing.T) {
 func TestSandboxHasFun(t *testing.T) {
 	ctx := context.Background()
 
-	sandbox, err := newService(&observation.TestContext).CreateSandbox(ctx, CreateOptions{})
+	sandbox, err := newService(observation.TestContextTB(t)).CreateSandbox(ctx, CreateOptions{})
 	if err != nil {
 		t.Fatalf("unexpected error creating sandbox: %s", err)
 	}
@@ -71,7 +71,7 @@ func TestSandboxHasFun(t *testing.T) {
 func TestSandboxMaxTimeout(t *testing.T) {
 	ctx := context.Background()
 
-	sandbox, err := newService(&observation.TestContext).CreateSandbox(ctx, CreateOptions{})
+	sandbox, err := newService(observation.TestContextTB(t)).CreateSandbox(ctx, CreateOptions{})
 	if err != nil {
 		t.Fatalf("unexpected error creating sandbox: %s", err)
 	}
@@ -90,7 +90,7 @@ func TestSandboxMaxTimeout(t *testing.T) {
 func TestRunScript(t *testing.T) {
 	ctx := context.Background()
 
-	sandbox, err := newService(&observation.TestContext).CreateSandbox(ctx, CreateOptions{})
+	sandbox, err := newService(observation.TestContextTB(t)).CreateSandbox(ctx, CreateOptions{})
 	if err != nil {
 		t.Fatalf("unexpected error creating sandbox: %s", err)
 	}
@@ -124,7 +124,7 @@ func TestModule(t *testing.T) {
 
 	ctx := context.Background()
 
-	sandbox, err := newService(&observation.TestContext).CreateSandbox(ctx, CreateOptions{
+	sandbox, err := newService(observation.TestContextTB(t)).CreateSandbox(ctx, CreateOptions{
 		GoModules: map[string]lua.LGFunction{
 			"testmod": util.CreateModule(api),
 		},
@@ -154,7 +154,7 @@ func TestModule(t *testing.T) {
 func TestCall(t *testing.T) {
 	ctx := context.Background()
 
-	sandbox, err := newService(&observation.TestContext).CreateSandbox(ctx, CreateOptions{})
+	sandbox, err := newService(observation.TestContextTB(t)).CreateSandbox(ctx, CreateOptions{})
 	if err != nil {
 		t.Fatalf("unexpected error creating sandbox: %s", err)
 	}
@@ -192,7 +192,7 @@ func TestCall(t *testing.T) {
 func TestCallGenerator(t *testing.T) {
 	ctx := context.Background()
 
-	sandbox, err := newService(&observation.TestContext).CreateSandbox(ctx, CreateOptions{})
+	sandbox, err := newService(observation.TestContextTB(t)).CreateSandbox(ctx, CreateOptions{})
 	if err != nil {
 		t.Fatalf("unexpected error creating sandbox: %s", err)
 	}
@@ -250,7 +250,7 @@ func TestDefaultLuaModulesFilesLoad(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error loading modules: %s", err)
 	}
-	sandbox, err := newService(&observation.TestContext).CreateSandbox(ctx, CreateOptions{
+	sandbox, err := newService(observation.TestContextTB(t)).CreateSandbox(ctx, CreateOptions{
 		GoModules: modules,
 	})
 	if err != nil {

--- a/internal/oobmigration/migrations/batches/empty_spec_id_migrator_test.go
+++ b/internal/oobmigration/migrations/batches/empty_spec_id_migrator_test.go
@@ -22,7 +22,7 @@ func TestEmptySpecIDMigrator(t *testing.T) {
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	s := bstore.New(db, &observation.TestContext, nil)
+	s := bstore.New(db, observation.TestContextTB(t), nil)
 
 	migrator := NewEmptySpecIDMigrator(s.Store)
 	progress, err := migrator.Progress(ctx, false)

--- a/internal/oobmigration/migrations/batches/external_fork_name_migrator_test.go
+++ b/internal/oobmigration/migrations/batches/external_fork_name_migrator_test.go
@@ -26,7 +26,7 @@ func TestExternalForkNameMigrator(t *testing.T) {
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
-	s := bstore.New(db, &observation.TestContext, nil)
+	s := bstore.New(db, observation.TestContextTB(t), nil)
 
 	migrator := NewExternalForkNameMigrator(s.Store, 100)
 	progress, err := migrator.Progress(ctx, false)

--- a/internal/oobmigration/runner_test.go
+++ b/internal/oobmigration/runner_test.go
@@ -25,7 +25,7 @@ func TestRunner(t *testing.T) {
 		{ID: 1, Progress: 0.5},
 	}, nil)
 
-	runner := newRunner(&observation.TestContext, store, refreshTicker)
+	runner := newRunner(observation.TestContextTB(t), store, refreshTicker)
 
 	migrator := NewMockMigrator()
 	migrator.ProgressFunc.SetDefaultReturn(0.5, nil)
@@ -55,7 +55,7 @@ func TestRunnerError(t *testing.T) {
 		{ID: 1, Progress: 0.5},
 	}, nil)
 
-	runner := newRunner(&observation.TestContext, store, refreshTicker)
+	runner := newRunner(observation.TestContextTB(t), store, refreshTicker)
 
 	migrator := NewMockMigrator()
 	migrator.ProgressFunc.SetDefaultReturn(0.5, nil)
@@ -94,7 +94,7 @@ func TestRunnerRemovesCompleted(t *testing.T) {
 		{ID: 3, Progress: 0.9},
 	}, nil)
 
-	runner := newRunner(&observation.TestContext, store, refreshTicker)
+	runner := newRunner(observation.TestContextTB(t), store, refreshTicker)
 
 	// Makes no progress
 	migrator1 := NewMockMigrator()
@@ -345,7 +345,7 @@ func TestRunnerValidate(t *testing.T) {
 		{ID: 1, Introduced: NewVersion(3, 13), Progress: 0},
 	}, nil)
 
-	runner := newRunner(&observation.TestContext, store, nil)
+	runner := newRunner(observation.TestContextTB(t), store, nil)
 	statusErr := runner.Validate(context.Background(), NewVersion(3, 12), NewVersion(0, 0))
 	if statusErr != nil {
 		t.Errorf("unexpected status error: %s ", statusErr)
@@ -358,7 +358,7 @@ func TestRunnerValidateUnfinishedUp(t *testing.T) {
 		{ID: 1, Introduced: NewVersion(3, 11), Progress: 0.65, Deprecated: newVersionPtr(3, 12)},
 	}, nil)
 
-	runner := newRunner(&observation.TestContext, store, nil)
+	runner := newRunner(observation.TestContextTB(t), store, nil)
 	statusErr := runner.Validate(context.Background(), NewVersion(3, 12), NewVersion(0, 0))
 
 	if diff := cmp.Diff(wrapMigrationErrors(newMigrationStatusError(1, 1, 0.65)).Error(), statusErr.Error()); diff != "" {
@@ -372,7 +372,7 @@ func TestRunnerValidateUnfinishedDown(t *testing.T) {
 		{ID: 1, Introduced: NewVersion(3, 13), Progress: 0.15, Deprecated: newVersionPtr(3, 15), ApplyReverse: true},
 	}, nil)
 
-	runner := newRunner(&observation.TestContext, store, nil)
+	runner := newRunner(observation.TestContextTB(t), store, nil)
 	statusErr := runner.Validate(context.Background(), NewVersion(3, 12), NewVersion(0, 0))
 
 	if diff := cmp.Diff(wrapMigrationErrors(newMigrationStatusError(1, 0, 0.15)).Error(), statusErr.Error()); diff != "" {
@@ -394,7 +394,7 @@ func TestRunnerBoundsFilter(t *testing.T) {
 		{ID: 3, Progress: 0.5, Introduced: NewVersion(3, 6), Deprecated: &d3},
 	}, nil)
 
-	runner := newRunner(&observation.TestContext, store, refreshTicker)
+	runner := newRunner(observation.TestContextTB(t), store, refreshTicker)
 
 	migrator1 := NewMockMigrator()
 	migrator1.ProgressFunc.SetDefaultReturn(0.5, nil)

--- a/internal/scim/init_test.go
+++ b/internal/scim/init_test.go
@@ -127,7 +127,7 @@ func TestLicenseMiddleware(t *testing.T) {
 
 func TestHandler(t *testing.T) {
 	db := getMockDB([]*types.UserForSCIM{}, map[int32][]*database.UserEmail{})
-	testHandler := NewHandler(context.Background(), db, &observation.TestContext)
+	testHandler := NewHandler(context.Background(), db, observation.TestContextTB(t))
 
 	licensingInfo := func(tags ...string) *license.Info {
 		return &license.Info{Tags: tags, ExpiresAt: time.Now().Add(1 * time.Hour)}

--- a/internal/scim/user_create_test.go
+++ b/internal/scim/user_create_test.go
@@ -42,7 +42,7 @@ func TestUserResourceHandler_Create(t *testing.T) {
 			5: {makeEmail(5, "e@example.com", true, true)},
 			6: {makeEmail(6, "f@example.com", true, true), makeEmail(6, "ff@example.com", false, true)},
 		})
-	userResourceHandler := NewUserResourceHandler(context.Background(), &observation.TestContext, db)
+	userResourceHandler := NewUserResourceHandler(context.Background(), observation.TestContextTB(t), db)
 	testCases := []struct {
 		name       string
 		username   string

--- a/internal/scim/user_get_test.go
+++ b/internal/scim/user_get_test.go
@@ -21,7 +21,7 @@ func TestUserResourceHandler_Get(t *testing.T) {
 		{User: types.User{ID: 2, Username: "user2", DisplayName: "First Middle Last"}, Emails: []string{"b@example.com"}},
 	},
 		map[int32][]*database.UserEmail{})
-	userResourceHandler := NewUserResourceHandler(context.Background(), &observation.TestContext, db)
+	userResourceHandler := NewUserResourceHandler(context.Background(), observation.TestContextTB(t), db)
 	user1, err := userResourceHandler.Get(&http.Request{}, "1")
 	if err != nil {
 		t.Fatal(err)
@@ -77,7 +77,7 @@ func TestUserResourceHandler_GetAll(t *testing.T) {
 		{name: "filter: AND", count: 999, startIndex: 1, filter: "(userName eq \"user3\") AND (displayName eq \"First Last\")", wantTotalResults: 1, wantResults: 1, wantFirstID: 3},
 	}
 
-	userResourceHandler := NewUserResourceHandler(context.Background(), &observation.TestContext, db)
+	userResourceHandler := NewUserResourceHandler(context.Background(), observation.TestContextTB(t), db)
 	for _, c := range cases {
 		t.Run("TestUserResourceHandler_GetAll "+c.name, func(t *testing.T) {
 			var params scim.ListRequestParams

--- a/internal/scim/user_patch_test.go
+++ b/internal/scim/user_patch_test.go
@@ -52,7 +52,7 @@ func Test_UserResourceHandler_PatchUsername(t *testing.T) {
 		t.Run(tc.op, func(t *testing.T) {
 			user := types.UserForSCIM{User: types.User{ID: 1, Username: "test-user1", DisplayName: "First Last"}, Emails: []string{"a@example.com"}, SCIMExternalID: "id1"}
 			db := getMockDB([]*types.UserForSCIM{&user}, map[int32][]*database.UserEmail{1: {makeEmail(1, "a@example.com", true, true)}})
-			userResourceHandler := NewUserResourceHandler(context.Background(), &observation.TestContext, db)
+			userResourceHandler := NewUserResourceHandler(context.Background(), observation.TestContextTB(t), db)
 			operations := []scim.PatchOperation{{Op: tc.op, Path: createPath(AttrUserName, nil), Value: "test-user1-patched"}}
 
 			userRes, err := userResourceHandler.Patch(createDummyRequest(), "1", operations)
@@ -69,7 +69,7 @@ func Test_UserResourceHandler_PatchUsername(t *testing.T) {
 
 func Test_UserResourceHandler_PatchReplaceWithFilter(t *testing.T) {
 	db := createMockDB()
-	userResourceHandler := NewUserResourceHandler(context.Background(), &observation.TestContext, db)
+	userResourceHandler := NewUserResourceHandler(context.Background(), observation.TestContextTB(t), db)
 	operations := []scim.PatchOperation{
 		{Op: "replace", Path: parseStringPath("emails[type eq \"work\" and primary eq true].value"), Value: "nicolas@breitenbergbartell.uk"},
 		{Op: "replace", Path: parseStringPath("emails[type eq \"work\" and primary eq false].type"), Value: "home"},
@@ -121,7 +121,7 @@ func Test_UserResourceHandler_PatchReplaceWithFilter(t *testing.T) {
 
 func Test_UserResourceHandler_PatchRemoveWithFilter(t *testing.T) {
 	db := createMockDB()
-	userResourceHandler := NewUserResourceHandler(context.Background(), &observation.TestContext, db)
+	userResourceHandler := NewUserResourceHandler(context.Background(), observation.TestContextTB(t), db)
 	operations := []scim.PatchOperation{
 		{Op: "remove", Path: parseStringPath("emails[type eq \"work\" and primary eq false]")},
 		{Op: "remove", Path: createPath(AttrName, pointers.Ptr(AttrNameMiddle))},
@@ -152,7 +152,7 @@ func Test_UserResourceHandler_PatchRemoveWithFilter(t *testing.T) {
 
 func Test_UserResourceHandler_PatchReplaceWholeArrayField(t *testing.T) {
 	db := createMockDB()
-	userResourceHandler := NewUserResourceHandler(context.Background(), &observation.TestContext, db)
+	userResourceHandler := NewUserResourceHandler(context.Background(), observation.TestContextTB(t), db)
 	operations := []scim.PatchOperation{
 		{Op: "replace", Path: parseStringPath("emails"), Value: toInterfaceSlice(map[string]interface{}{"value": "replaced@work.com", "type": "home", "primary": true})},
 	}
@@ -178,7 +178,7 @@ func Test_UserResourceHandler_PatchReplaceWholeArrayField(t *testing.T) {
 
 func Test_UserResourceHandler_PatchRemoveNonExistingField(t *testing.T) {
 	db := createMockDB()
-	userResourceHandler := NewUserResourceHandler(context.Background(), &observation.TestContext, db)
+	userResourceHandler := NewUserResourceHandler(context.Background(), observation.TestContextTB(t), db)
 	operations := []scim.PatchOperation{
 		{Op: "remove", Path: createPath(AttrNickName, nil)},
 	}
@@ -191,7 +191,7 @@ func Test_UserResourceHandler_PatchRemoveNonExistingField(t *testing.T) {
 
 func Test_UserResourceHandler_PatchAddPrimaryEmail(t *testing.T) {
 	db := createMockDB()
-	userResourceHandler := NewUserResourceHandler(context.Background(), &observation.TestContext, db)
+	userResourceHandler := NewUserResourceHandler(context.Background(), observation.TestContextTB(t), db)
 	operations := []scim.PatchOperation{
 		{Op: "add", Path: createPath(AttrEmails, nil), Value: toInterfaceSlice(map[string]interface{}{"value": "new@work.com", "type": "home", "primary": true})},
 	}
@@ -208,7 +208,7 @@ func Test_UserResourceHandler_PatchAddPrimaryEmail(t *testing.T) {
 
 func Test_UserResourceHandler_PatchReplacePrimaryEmailWithFilter(t *testing.T) {
 	db := createMockDB()
-	userResourceHandler := NewUserResourceHandler(context.Background(), &observation.TestContext, db)
+	userResourceHandler := NewUserResourceHandler(context.Background(), observation.TestContextTB(t), db)
 	operations := []scim.PatchOperation{
 		{Op: "replace", Path: parseStringPath("emails[value eq \"secondary@work.com\"].primary"), Value: true},
 	}
@@ -224,7 +224,7 @@ func Test_UserResourceHandler_PatchReplacePrimaryEmailWithFilter(t *testing.T) {
 
 func Test_UserResourceHandler_PatchAddNonExistingField(t *testing.T) {
 	db := createMockDB()
-	userResourceHandler := NewUserResourceHandler(context.Background(), &observation.TestContext, db)
+	userResourceHandler := NewUserResourceHandler(context.Background(), observation.TestContextTB(t), db)
 	operations := []scim.PatchOperation{
 		{Op: "add", Path: createPath(AttrNickName, nil), Value: "sampleNickName"},
 	}
@@ -237,7 +237,7 @@ func Test_UserResourceHandler_PatchAddNonExistingField(t *testing.T) {
 
 func Test_UserResourceHandler_PatchNoChange(t *testing.T) {
 	db := createMockDB()
-	userResourceHandler := NewUserResourceHandler(context.Background(), &observation.TestContext, db)
+	userResourceHandler := NewUserResourceHandler(context.Background(), observation.TestContextTB(t), db)
 	operations := []scim.PatchOperation{
 		{Op: "replace", Path: createPath(AttrName, pointers.Ptr(AttrNameGiven)), Value: "Nannie"},
 	}
@@ -253,7 +253,7 @@ func Test_UserResourceHandler_PatchMoveUnverifiedEmailToPrimaryWithFilter(t *tes
 	user1 := types.UserForSCIM{User: types.User{ID: 1, Username: "test-user1"}, Emails: []string{"primary@work.com", "secondary@work.com"}, SCIMExternalID: "id1", SCIMAccountData: sampleAccountData}
 	usersEmails := map[int32][]*database.UserEmail{1: {makeEmail(1, "primary@work.com", true, true), makeEmail(1, "secondary@work.com", false, false)}}
 	db := getMockDB([]*types.UserForSCIM{&user1}, usersEmails)
-	userResourceHandler := NewUserResourceHandler(context.Background(), &observation.TestContext, db)
+	userResourceHandler := NewUserResourceHandler(context.Background(), observation.TestContextTB(t), db)
 	operations := []scim.PatchOperation{
 		{Op: "replace", Path: parseStringPath("emails[value eq \"primary@work.com\"].primary"), Value: false},
 		{Op: "replace", Path: parseStringPath("emails[value eq \"secondary@work.com\"].primary"), Value: true},
@@ -281,7 +281,7 @@ func Test_UserResourceHandler_PatchMoveUnverifiedEmailToPrimaryWithFilter(t *tes
 
 func Test_UserResourceHandler_PatchSoftDelete(t *testing.T) {
 	db := createMockDB()
-	userResourceHandler := NewUserResourceHandler(context.Background(), &observation.TestContext, db)
+	userResourceHandler := NewUserResourceHandler(context.Background(), observation.TestContextTB(t), db)
 	operations := []scim.PatchOperation{
 		{Op: "replace", Path: parseStringPath(AttrActive), Value: false},
 	}
@@ -329,7 +329,7 @@ func Test_UserResourceHandler_PatchReactiveUser(t *testing.T) {
 	}}
 	db := getMockDB([]*types.UserForSCIM{user}, emails)
 
-	userResourceHandler := NewUserResourceHandler(context.Background(), &observation.TestContext, db)
+	userResourceHandler := NewUserResourceHandler(context.Background(), observation.TestContextTB(t), db)
 	operations := []scim.PatchOperation{
 		{Op: "replace", Path: parseStringPath(AttrActive), Value: true},
 	}
@@ -347,7 +347,7 @@ func Test_UserResourceHandler_PatchReactiveUser(t *testing.T) {
 
 func Test_UserResourceHandler_Patch_ReplaceStrategies_Azure(t *testing.T) {
 	db := createMockDB()
-	userResourceHandler := NewUserResourceHandler(context.Background(), &observation.TestContext, db)
+	userResourceHandler := NewUserResourceHandler(context.Background(), observation.TestContextTB(t), db)
 	config := &conf.Unified{SiteConfiguration: schema.SiteConfiguration{ScimIdentityProvider: string(IDPAzureAd)}}
 	operations := []scim.PatchOperation{
 		{Op: "replace", Path: parseStringPath("emails[type eq \"work\" and primary eq true].value"), Value: "work@work.com"},
@@ -383,7 +383,7 @@ func Test_UserResourceHandler_Patch_ReplaceStrategies_Azure(t *testing.T) {
 
 func Test_UserResourceHandler_Patch_ReplaceStrategies_Standard(t *testing.T) {
 	db := createMockDB()
-	userResourceHandler := NewUserResourceHandler(context.Background(), &observation.TestContext, db)
+	userResourceHandler := NewUserResourceHandler(context.Background(), observation.TestContextTB(t), db)
 	operations := []scim.PatchOperation{
 		{Op: "replace", Path: parseStringPath("emails[type eq \"work\" and primary eq true].value"), Value: "work@work.com"},
 		{Op: "replace", Path: parseStringPath("emails[type eq \"home\"].value"), Value: "home@work.com"},

--- a/internal/scim/user_replace_test.go
+++ b/internal/scim/user_replace_test.go
@@ -30,7 +30,7 @@ func Test_UserResourceHandler_Replace(t *testing.T) {
 			5: {makeEmail(5, "e@example.com", true, true)},
 			6: {makeEmail(6, "f@example.com", true, true)},
 		})
-	userResourceHandler := NewUserResourceHandler(context.Background(), &observation.TestContext, db)
+	userResourceHandler := NewUserResourceHandler(context.Background(), observation.TestContextTB(t), db)
 
 	testCases := []struct {
 		name     string

--- a/internal/search/exhaustive/store/exhaustive_search_jobs_test.go
+++ b/internal/search/exhaustive/store/exhaustive_search_jobs_test.go
@@ -39,7 +39,7 @@ func TestStore_CreateExhaustiveSearchJob(t *testing.T) {
 	adminID, err := createUser(bs, "admin")
 	require.NoError(t, err)
 
-	s := store.New(db, &observation.TestContext)
+	s := store.New(db, observation.TestContextTB(t))
 
 	tests := []struct {
 		name        string
@@ -149,7 +149,7 @@ func TestStore_GetAndListSearchJobs(t *testing.T) {
 	ctx := actor.WithActor(context.Background(), actor.FromUser(userID))
 	adminCtx := actor.WithActor(context.Background(), actor.FromUser(adminID))
 
-	s := store.New(db, &observation.TestContext)
+	s := store.New(db, observation.TestContextTB(t))
 
 	jobs := []types.ExhaustiveSearchJob{
 		{InitiatorID: userID, Query: "repo:job1"},
@@ -294,7 +294,7 @@ func TestStore_AggregateStatus(t *testing.T) {
 	_, err := createRepo(db, "repo1")
 	require.NoError(t, err)
 
-	s := store.New(db, &observation.TestContext)
+	s := store.New(db, observation.TestContextTB(t))
 
 	tc := []struct {
 		name string

--- a/internal/search/exhaustive/store/exhaustive_search_repo_jobs_test.go
+++ b/internal/search/exhaustive/store/exhaustive_search_repo_jobs_test.go
@@ -37,7 +37,7 @@ func TestStore_CreateExhaustiveSearchRepoJob(t *testing.T) {
 		UID: userID,
 	})
 
-	s := store.New(db, &observation.TestContext)
+	s := store.New(db, observation.TestContextTB(t))
 
 	searchJobID, err := s.CreateExhaustiveSearchJob(
 		ctx,

--- a/internal/search/exhaustive/store/exhaustive_search_repo_revision_jobs_test.go
+++ b/internal/search/exhaustive/store/exhaustive_search_repo_revision_jobs_test.go
@@ -37,7 +37,7 @@ func TestStore_CreateExhaustiveSearchRepoRevisionJob(t *testing.T) {
 		UID: userID,
 	})
 
-	s := store.New(db, &observation.TestContext)
+	s := store.New(db, observation.TestContextTB(t))
 
 	searchJobID, err := s.CreateExhaustiveSearchJob(
 		ctx,

--- a/internal/uploadhandler/upload_handler_test.go
+++ b/internal/uploadhandler/upload_handler_test.go
@@ -404,7 +404,7 @@ func TestHandleEnqueueMultipartFinalizeIncompleteUpload(t *testing.T) {
 	h := &UploadHandler[testUploadMetadata]{
 		dbStore:     mockDBStore,
 		uploadStore: mockUploadStore,
-		operations:  NewOperations(&observation.TestContext, "test"),
+		operations:  NewOperations(observation.TestContextTB(t), "test"),
 		logger:      logtest.Scoped(t),
 	}
 	h.handleEnqueue(w, r)
@@ -439,7 +439,7 @@ func newTestUploadHandler(t *testing.T, dbStore DBStore[testUploadMetadata], upl
 		logtest.Scoped(t),
 		dbStore,
 		uploadStore,
-		NewOperations(&observation.TestContext, "test"),
+		NewOperations(observation.TestContextTB(t), "test"),
 		metadataFromRequest,
 	)
 }

--- a/internal/uploadstore/s3_client_test.go
+++ b/internal/uploadstore/s3_client_test.go
@@ -53,7 +53,7 @@ func TestS3InitBucketExists(t *testing.T) {
 
 func TestS3UnmanagedInit(t *testing.T) {
 	s3Client := NewMockS3API()
-	client := newS3WithClients(s3Client, nil, "test-bucket", false, NewOperations(&observation.TestContext, "test", "brittleStore"))
+	client := newS3WithClients(s3Client, nil, "test-bucket", false, NewOperations(observation.TestContextTB(t), "test", "brittleStore"))
 	if err := client.Init(context.Background()); err != nil {
 		t.Fatalf("unexpected error initializing client: %s", err)
 	}
@@ -69,7 +69,7 @@ func TestS3Get(t *testing.T) {
 		Body: io.NopCloser(bytes.NewReader([]byte("TEST PAYLOAD"))),
 	}, nil)
 
-	client := newS3WithClients(s3Client, nil, "test-bucket", false, NewOperations(&observation.TestContext, "test", "brittleStore"))
+	client := newS3WithClients(s3Client, nil, "test-bucket", false, NewOperations(observation.TestContextTB(t), "test", "brittleStore"))
 	rc, err := client.Get(context.Background(), "test-key")
 	if err != nil {
 		t.Fatalf("unexpected error getting key: %s", err)
@@ -121,7 +121,7 @@ func TestS3GetTransientErrors(t *testing.T) {
 	}
 
 	s3Client := fullContentsS3API()
-	client := newS3WithClients(s3Client, nil, "test-bucket", false, NewOperations(&observation.TestContext, "test", "brittleStore"))
+	client := newS3WithClients(s3Client, nil, "test-bucket", false, NewOperations(observation.TestContextTB(t), "test", "brittleStore"))
 	rc, err := client.Get(context.Background(), "test-key")
 	if err != nil {
 		t.Fatalf("unexpected error getting key: %s", err)
@@ -150,7 +150,7 @@ func TestS3GetReadNothingLoop(t *testing.T) {
 	}
 
 	s3Client := fullContentsS3API()
-	client := newS3WithClients(s3Client, nil, "test-bucket", false, NewOperations(&observation.TestContext, "test", "brittleStore"))
+	client := newS3WithClients(s3Client, nil, "test-bucket", false, NewOperations(observation.TestContextTB(t), "test", "brittleStore"))
 	rc, err := client.Get(context.Background(), "test-key")
 	if err != nil {
 		t.Fatalf("unexpected error getting key: %s", err)

--- a/internal/workerutil/worker_test.go
+++ b/internal/workerutil/worker_test.go
@@ -41,7 +41,7 @@ func TestWorkerHandlerSuccess(t *testing.T) {
 		WorkerHostname: "test",
 		NumHandlers:    1,
 		Interval:       time.Second,
-		Metrics:        NewMetrics(&observation.TestContext, ""),
+		Metrics:        NewMetrics(observation.TestContextTB(t), ""),
 	}
 
 	store.DequeueFunc.PushReturn(&TestRecord{ID: 42}, true, nil)
@@ -77,7 +77,7 @@ func TestWorkerHandlerFailure(t *testing.T) {
 		WorkerHostname: "test",
 		NumHandlers:    1,
 		Interval:       time.Second,
-		Metrics:        NewMetrics(&observation.TestContext, ""),
+		Metrics:        NewMetrics(observation.TestContextTB(t), ""),
 	}
 
 	store.DequeueFunc.PushReturn(&TestRecord{ID: 42}, true, nil)
@@ -121,7 +121,7 @@ func TestWorkerHandlerNonRetryableFailure(t *testing.T) {
 		WorkerHostname: "test",
 		NumHandlers:    1,
 		Interval:       time.Second,
-		Metrics:        NewMetrics(&observation.TestContext, ""),
+		Metrics:        NewMetrics(observation.TestContextTB(t), ""),
 	}
 
 	store.DequeueFunc.PushReturn(&TestRecord{ID: 42}, true, nil)
@@ -168,7 +168,7 @@ func TestWorkerConcurrent(t *testing.T) {
 				WorkerHostname: "test",
 				NumHandlers:    numHandlers,
 				Interval:       time.Second,
-				Metrics:        NewMetrics(&observation.TestContext, ""),
+				Metrics:        NewMetrics(observation.TestContextTB(t), ""),
 			}
 
 			for i := range NumTestRecords {
@@ -235,7 +235,7 @@ func TestWorkerBlockingPreDequeueHook(t *testing.T) {
 		WorkerHostname: "test",
 		NumHandlers:    1,
 		Interval:       time.Second,
-		Metrics:        NewMetrics(&observation.TestContext, ""),
+		Metrics:        NewMetrics(observation.TestContextTB(t), ""),
 	}
 
 	store.DequeueFunc.PushReturn(&TestRecord{ID: 42}, true, nil)
@@ -265,7 +265,7 @@ func TestWorkerConditionalPreDequeueHook(t *testing.T) {
 		WorkerHostname: "test",
 		NumHandlers:    1,
 		Interval:       time.Second,
-		Metrics:        NewMetrics(&observation.TestContext, ""),
+		Metrics:        NewMetrics(observation.TestContextTB(t), ""),
 	}
 
 	store.DequeueFunc.PushReturn(&TestRecord{ID: 42}, true, nil)
@@ -341,7 +341,7 @@ func TestWorkerDequeueHeartbeat(t *testing.T) {
 		NumHandlers:       1,
 		HeartbeatInterval: heartbeatInterval,
 		Interval:          time.Second,
-		Metrics:           NewMetrics(&observation.TestContext, ""),
+		Metrics:           NewMetrics(observation.TestContextTB(t), ""),
 	}
 
 	dequeued := make(chan struct{})
@@ -388,7 +388,7 @@ func TestWorkerNumTotalJobs(t *testing.T) {
 		NumHandlers:    1,
 		NumTotalJobs:   5,
 		Interval:       time.Second,
-		Metrics:        NewMetrics(&observation.TestContext, ""),
+		Metrics:        NewMetrics(observation.TestContextTB(t), ""),
 	}
 
 	store.DequeueFunc.SetDefaultReturn(&TestRecord{ID: 42}, true, nil)
@@ -416,7 +416,7 @@ func TestWorkerMaxActiveTime(t *testing.T) {
 		NumTotalJobs:   50,
 		MaxActiveTime:  time.Second * 5,
 		Interval:       time.Second,
-		Metrics:        NewMetrics(&observation.TestContext, ""),
+		Metrics:        NewMetrics(observation.TestContextTB(t), ""),
 	}
 
 	called := make(chan struct{})
@@ -489,7 +489,7 @@ func TestWorkerCancelJobs(t *testing.T) {
 		NumHandlers:       1,
 		HeartbeatInterval: time.Second,
 		Interval:          time.Second,
-		Metrics:           NewMetrics(&observation.TestContext, ""),
+		Metrics:           NewMetrics(observation.TestContextTB(t), ""),
 	}
 
 	dequeued := make(chan struct{})
@@ -567,7 +567,7 @@ func TestWorkerDeadline(t *testing.T) {
 		NumHandlers:       1,
 		HeartbeatInterval: time.Second,
 		Interval:          time.Second,
-		Metrics:           NewMetrics(&observation.TestContext, ""),
+		Metrics:           NewMetrics(observation.TestContextTB(t), ""),
 		// The handler runs forever but should be canceled after 10ms.
 		MaximumRuntimePerJob: 10 * time.Millisecond,
 	}
@@ -623,7 +623,7 @@ func TestWorkerStopDrainsDequeueLoopOnly(t *testing.T) {
 		NumHandlers:       1,
 		HeartbeatInterval: time.Second,
 		Interval:          time.Second,
-		Metrics:           NewMetrics(&observation.TestContext, ""),
+		Metrics:           NewMetrics(observation.TestContextTB(t), ""),
 	}
 
 	dequeued := make(chan struct{})


### PR DESCRIPTION
observation.TestContextTB is better to use since your logs will be scoped to your test and it will use a more pedantic prometheus registry. To be honest TestContext should be removed but this is the first step.

This is a mechanical change. I replaced "&observation.TestContext" with "observation.TestContextTB(t)". I then undid the change each time it caused a compilation error (was only a handful of times).

Test Plan: go test