### PR TITLE
streaming: only call flush if writes succeeded

### DIFF
--- a/internal/search/streaming/http/writer.go
+++ b/internal/search/streaming/http/writer.go
@@ -106,7 +106,10 @@ func (e *Writer) EventBytes(event string, dataLine []byte) (err error) {
 	write(dataLine)
 	write([]byte("\n\n"))
 
-	e.flush()
+	// only need to call flush if writes succeeded.
+	if err == nil {
+		e.flush()
+	}
 
 	return err
 }


### PR DESCRIPTION
This is a speculative change to reduce the chances of misuse of the streaming http event writer (SSE). We are seeing panics in attribution search since it is trying to write events once the request has finished.

From the stack traces it seems the http package safely handles calls to Write without panicing but does not do the same for Flush. This change also seems more correct.

Note: this does not address the root cause of the panics, but should make it far less likely to occur.

Test Plan: go test

Part of #60439 