### PR TITLE
ci: set timeouts - gazelle 5 min and buildifier to 2 min

### DIFF
--- a/.aspect/workflows/config.yaml
+++ b/.aspect/workflows/config.yaml
@@ -11,11 +11,13 @@ tasks:
   # Checks that BUILD files are formatted
   - buildifier:
       queue: aspect-small
+      timeout_in_minutes: 2
   # Checks that BUILD file content is up-to-date with sources
   - gazelle:
       queue: aspect-small
       target: //:configure
       fix_target: //:configure
+      timeout_in_minutes: 5
   # Checks that all tests are passing
   - test:
       targets:


### PR DESCRIPTION
Gazelle and buildifier have been timing out lately where the bazel invocation is just hanging. 

We change the timeout of the gazelle and buildifier jobs so that the jobs get killed MUCH sooner than just waiting for hours on end.
## Test plan
CI