### PR TITLE
v2t: add v2t to src/settings

### DIFF
--- a/client/web/src/settings/SettingsArea.tsx
+++ b/client/web/src/settings/SettingsArea.tsx
@@ -10,6 +10,7 @@ import { gql } from '@sourcegraph/http-client'
 import type { Scalars } from '@sourcegraph/shared/src/graphql-operations'
 import type { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
 import type { SettingsCascadeProps, SettingsSubject } from '@sourcegraph/shared/src/settings/settings'
+import type { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { LoadingSpinner, PageHeader, ErrorMessage } from '@sourcegraph/wildcard'
 
@@ -40,7 +41,7 @@ interface SettingsData {
 }
 
 /** Properties passed to all pages in the settings area. */
-export interface SettingsAreaPageProps extends SettingsAreaPageCommonProps {
+export interface SettingsAreaPageProps extends SettingsAreaPageCommonProps, TelemetryV2Props {
     /** The settings data, or null if the subject has no settings yet. */
     data: SettingsData
 
@@ -78,6 +79,32 @@ export class SettingsArea extends React.Component<Props, State> {
 
     public componentDidMount(): void {
         eventLogger.logViewEvent(`Settings${this.props.subject.__typename}`)
+        switch (this.props.subject.__typename) {
+            case 'User': {
+                this.props.platformContext.telemetryRecorder.recordEvent('user.settings', 'view')
+                break
+            }
+            case 'Org': {
+                this.props.platformContext.telemetryRecorder.recordEvent('org.settings', 'view')
+                break
+            }
+            case 'Site': {
+                this.props.platformContext.telemetryRecorder.recordEvent('admin.settings', 'view')
+                break
+            }
+            case 'DefaultSettings': {
+                this.props.platformContext.telemetryRecorder.recordEvent('defaultSettings', 'view')
+                break
+            }
+            case 'Client': {
+                this.props.platformContext.telemetryRecorder.recordEvent('client.settings', 'view')
+            }
+            default: {
+                this.props.platformContext.telemetryRecorder.recordEvent('otherSettings', 'view')
+                break
+            }
+        }
+
         // Load settings.
         this.subscriptions.add(
             combineLatest([
@@ -160,6 +187,7 @@ export class SettingsArea extends React.Component<Props, State> {
             platformContext: this.props.platformContext,
             settingsCascade: this.props.settingsCascade,
             telemetryService: this.props.telemetryService,
+            telemetryRecorder: this.props.platformContext.telemetryRecorder,
         }
 
         return (

--- a/client/web/src/settings/SettingsFile.tsx
+++ b/client/web/src/settings/SettingsFile.tsx
@@ -4,6 +4,7 @@ import classNames from 'classnames'
 import { Subject, Subscription } from 'rxjs'
 import { distinctUntilChanged, filter, map, startWith } from 'rxjs/operators'
 
+import type { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { LoadingSpinner, BeforeUnloadPrompt } from '@sourcegraph/wildcard'
 
@@ -14,7 +15,7 @@ import { eventLogger } from '../tracking/eventLogger'
 
 import styles from './SettingsFile.module.scss'
 
-interface Props extends TelemetryProps {
+interface Props extends TelemetryProps, TelemetryV2Props {
     settings: SiteAdminSettingsCascadeFields['subjects'][number]['latestSettings'] | null
 
     /**
@@ -181,6 +182,7 @@ export class SettingsFile extends React.PureComponent<Props, State> {
             window.confirm('Discard settings edits?')
         ) {
             eventLogger.log('SettingsFileDiscard')
+            this.props.telemetryRecorder.recordEvent('settings.file', 'discard')
             this.setState({
                 contents: undefined,
                 editingLastID: undefined,
@@ -188,6 +190,7 @@ export class SettingsFile extends React.PureComponent<Props, State> {
             this.props.onDidDiscard()
         } else {
             eventLogger.log('SettingsFileDiscardCanceled')
+            this.props.telemetryRecorder.recordEvent('settings.file', 'discardCancel')
         }
     }
 
@@ -200,6 +203,7 @@ export class SettingsFile extends React.PureComponent<Props, State> {
 
     private save = (): void => {
         eventLogger.log('SettingsFileSaved')
+        this.props.telemetryRecorder.recordEvent('settings.file', 'save')
         this.setState({ saving: true }, () => {
             this.props.onDidCommit(this.getPropsSettingsID(), this.state.contents!)
         })

--- a/client/web/src/settings/SettingsPage.tsx
+++ b/client/web/src/settings/SettingsPage.tsx
@@ -2,13 +2,14 @@ import * as React from 'react'
 
 import { logger } from '@sourcegraph/common'
 import { overwriteSettings } from '@sourcegraph/shared/src/settings/edit'
+import type { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Container } from '@sourcegraph/wildcard'
 
 import type { SettingsAreaPageProps } from './SettingsArea'
 import { SettingsFile } from './SettingsFile'
 
-interface Props extends SettingsAreaPageProps, TelemetryProps {
+interface Props extends SettingsAreaPageProps, TelemetryProps, TelemetryV2Props {
     /** Optional description to render above the editor. */
     description?: JSX.Element
     isLightTheme: boolean
@@ -34,6 +35,7 @@ export class SettingsPage extends React.PureComponent<Props, State> {
                     onDidDiscard={this.onDidDiscard}
                     isLightTheme={this.props.isLightTheme}
                     telemetryService={this.props.telemetryService}
+                    telemetryRecorder={this.props.telemetryRecorder}
                 />
             </Container>
         )


### PR DESCRIPTION
Context:

* https://github.com/sourcegraph/sourcegraph/pull/60127
* https://github.com/sourcegraph/sourcegraph/pull/60192
* https://github.com/sourcegraph/sourcegraph/pull/60219
* https://github.com/sourcegraph/sourcegraph/pull/60343
* https://github.com/sourcegraph/sourcegraph/pull/60377
* https://github.com/sourcegraph/sourcegraph/pull/60382
* https://github.com/sourcegraph/sourcegraph/pull/60764
* https://github.com/sourcegraph/sourcegraph/pull/60765
* https://github.com/sourcegraph/sourcegraph/pull/60767
* https://github.com/sourcegraph/sourcegraph/pull/60768
* https://github.com/sourcegraph/sourcegraph/pull/60788
* https://github.com/sourcegraph/sourcegraph/pull/60789
* https://github.com/sourcegraph/sourcegraph/pull/60803
* https://github.com/sourcegraph/sourcegraph/pull/60812
* https://github.com/sourcegraph/sourcegraph/pull/60850
* https://github.com/sourcegraph/sourcegraph/pull/60851
* https://github.com/sourcegraph/sourcegraph/pull/60939
* https://github.com/sourcegraph/sourcegraph/pull/60971
* https://github.com/sourcegraph/sourcegraph/pull/61205
* https://github.com/sourcegraph/sourcegraph/pull/61457
* https://github.com/sourcegraph/sourcegraph/pull/61503
* https://github.com/sourcegraph/sourcegraph/pull/61504
* https://github.com/sourcegraph/sourcegraph/pull/61506
* https://github.com/sourcegraph/sourcegraph/pull/61507
* https://github.com/sourcegraph/sourcegraph/pull/61516
* https://github.com/sourcegraph/sourcegraph/pull/61707
* https://github.com/sourcegraph/sourcegraph/pull/61748

## Test plan

`sg start`
visit page
check if events appear in `event_logs` table locally