### PR TITLE
svelte: Show favicon in production

### DIFF
--- a/client/web-sveltekit/src/app.prod.html
+++ b/client/web-sveltekit/src/app.prod.html
@@ -2,7 +2,6 @@
 <html lang="en">
     <head>
         <meta charset="utf-8" />
-        <link rel="icon" href="%sveltekit.assets%/favicon.png" />
         <meta http-equiv="x-ua-compatible" content="ie=edge" />
         <meta http-equiv="Content-Language" content="en" />
         <meta name="google" content="notranslate" />


### PR DESCRIPTION
Closes #61637 

It appears that we are relying on the browser's default behavior for loading the favicon. Removing this (broken in production) link makes the favicon work.

## Test plan

Loading the SvelteKit app locally from the full devserver (`sg start enterprise-sveltekit`) shows the dev favicon (it didn't before).