### PR TITLE
test execution log artifact

### DIFF
--- a/.aspect/bazelrc/ci.sourcegraph.bazelrc
+++ b/.aspect/bazelrc/ci.sourcegraph.bazelrc
@@ -58,3 +58,5 @@ test --flaky_test_attempts=2
 # See https://github.com/aspect-build/rules_js/issues/1412
 # Sometimes the build fails due to some flakiness where a npm package fails to be copied
 common --noexperimental_merged_skyframe_analysis_execution
+
+build --experimental_execution_log_compact_file=/workflows/artifacts/executionlog.zstd


### PR DESCRIPTION
Likely needed as part of https://github.com/sourcegraph/sourcegraph/issues/61246, but if not, it can always be used to determine why something was a cache miss 

## Test plan

Saw new artifact in CI