### PR TITLE
Revert "bazel: bump rules_{oci,pkg}"

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -62,7 +62,6 @@ http_archive(
     name = "io_bazel_rules_go",
     patch_args = ["-p1"],
     patches = [
-        # Remove when bumping, is upstreamed and should be in 0.46.1
         "//third_party/rules_go:package_main.patch",
     ],
     sha256 = "80a98277ad1311dacd837f9b16db62887702e9f1d1c4c9f796d0121a46c8e184",
@@ -119,17 +118,17 @@ http_archive(
     patches = [
         "//third_party/rules_oci:no_xattr.patch",
     ],
-    sha256 = "cf6b8be82cde30daef18a09519d75269650317e40d917c8633cf8e3ab5645ea5",
-    strip_prefix = "rules_oci-1.7.2",
-    url = "https://github.com/bazel-contrib/rules_oci/releases/download/v1.7.2/rules_oci-v1.7.2.tar.gz",
+    sha256 = "d41d0ba7855f029ad0e5ee35025f882cbe45b0d5d570842c52704f7a47ba8668",
+    strip_prefix = "rules_oci-1.4.3",
+    url = "https://github.com/bazel-contrib/rules_oci/releases/download/v1.4.3/rules_oci-v1.4.3.tar.gz",
 )
 
 http_archive(
     name = "rules_pkg",
-    sha256 = "d250924a2ecc5176808fc4c25d5cf5e9e79e6346d79d5ab1c493e289e722d1d0",
+    sha256 = "8c20f74bca25d2d442b327ae26768c02cf3c99e93fad0381f32be9aab1967675",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_pkg/releases/download/0.10.1/rules_pkg-0.10.1.tar.gz",
-        "https://github.com/bazelbuild/rules_pkg/releases/download/0.10.1/rules_pkg-0.10.1.tar.gz",
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_pkg/releases/download/0.8.1/rules_pkg-0.8.1.tar.gz",
+        "https://github.com/bazelbuild/rules_pkg/releases/download/0.8.1/rules_pkg-0.8.1.tar.gz",
     ],
 )
 

--- a/cmd/server/macro.bzl
+++ b/cmd/server/macro.bzl
@@ -1,5 +1,4 @@
 load("@rules_pkg//:pkg.bzl", "pkg_tar")
-load("@rules_pkg//pkg:mappings.bzl", "pkg_attributes", "pkg_filegroup", "pkg_files", "pkg_mkdirs")
 
 def get_last_segment(path):
     segments = path.split("/")
@@ -15,20 +14,10 @@ def container_dependencies(targets):
     for target in targets:
         name = get_last_segment(target)
 
-        pkg_files(
-            name = "files_{}".format(name),
-            srcs = [target],
-            attributes = pkg_attributes(
-                mode = "0555",
-            ),
-            prefix = "/usr/local/bin",
-        )
-
         pkg_tar(
             name = "tar_{}".format(name),
-            srcs = [":files_{}".format(name)],
-            # remap_paths = {"/{}".format(name): "/usr/local/bin/{}".format(name)},
-            # modes = {"/usr/local/bin/{}".format(name): "0555"},
+            srcs = [target],
+            remap_paths = {"/{}".format(name): "/usr/local/bin/{}".format(name)},
         )
 
 def dependencies_tars(targets):


### PR DESCRIPTION
Potentially causing excessive remote cache issues 

# Test plan 

:clueless: