### PR TITLE
v2t: add v2t to src/storm

### DIFF
--- a/client/web/src/LegacyRouteContext.tsx
+++ b/client/web/src/LegacyRouteContext.tsx
@@ -117,7 +117,7 @@ export const LegacyRoute: FC<LegacyRouteProps> = ({ render, condition }) => {
     return render(context)
 }
 
-export interface LegacyRouteContextProviderProps extends TelemetryV2Props {
+export interface LegacyRouteContextProviderProps {
     context: StaticAppConfig & StaticSourcegraphWebAppContext & DynamicSourcegraphWebAppContext
 }
 
@@ -152,7 +152,7 @@ export const LegacyRouteContextProvider: FC<PropsWithChildren<LegacyRouteContext
         streamSearch: aggregateStreamingSearch,
         fetchHighlightedFileLineRanges: _fetchHighlightedFileLineRanges,
         telemetryService: eventLogger,
-        telemetryRecorder: props.telemetryRecorder,
+        telemetryRecorder: platformContext.telemetryRecorder,
         /**
          * Breadcrumb props
          */

--- a/client/web/src/LegacySourcegraphWebApp.tsx
+++ b/client/web/src/LegacySourcegraphWebApp.tsx
@@ -259,10 +259,7 @@ export class LegacySourcegraphWebApp extends React.Component<StaticAppConfig, Le
                     <TemporarySettingsProvider temporarySettingsStorage={temporarySettingsStorage} />,
                     <SearchResultsCacheProvider />,
                     <SearchQueryStateStoreProvider useSearchQueryState={useNavbarQueryState} />,
-                    <LegacyRouteContextProvider
-                        context={legacyContext}
-                        telemetryRecorder={window.context.telemetryRecorder}
-                    />,
+                    <LegacyRouteContextProvider context={legacyContext} />,
                     /* eslint-enable react/no-children-prop, react/jsx-key */
                 ]}
             >

--- a/client/web/src/SourcegraphWebApp.tsx
+++ b/client/web/src/SourcegraphWebApp.tsx
@@ -282,7 +282,6 @@ export const SourcegraphWebApp: FC<SourcegraphWebAppProps> = props => {
                         ...dynamicContext,
                         ...props,
                     }}
-                    telemetryRecorder={props.telemetryRecorder}
                 />,
                 /* eslint-enable react/no-children-prop, react/jsx-key */
             ]}

--- a/client/web/src/storm/pages/SearchPage/AddCodeHostWidget.tsx
+++ b/client/web/src/storm/pages/SearchPage/AddCodeHostWidget.tsx
@@ -16,7 +16,8 @@ interface AddCodeHostWidgetProps {
 
 export const AddCodeHostWidget: FC<AddCodeHostWidgetProps> = props => {
     const { className } = props
-    const { telemetryService } = useLegacyContext_onlyInStormRoutes()
+    const { telemetryService, platformContext } = useLegacyContext_onlyInStormRoutes()
+    const { telemetryRecorder } = platformContext
 
     return (
         <MarketingBlock
@@ -29,7 +30,10 @@ export const AddCodeHostWidget: FC<AddCodeHostWidgetProps> = props => {
                 to="/site-admin/external-services/new"
                 className="d-inline-flex align-items-center"
                 weight="medium"
-                onClick={() => telemetryService.log('OnboardingWidget:ConnectCodeHost:Clicked')}
+                onClick={() => {
+                    telemetryService.log('OnboardingWidget:ConnectCodeHost:Clicked')
+                    telemetryRecorder.recordEvent('onboardingWidget.connectCodeHost', 'click')
+                }}
             >
                 Connect code host
                 <Icon svgPath={mdiChevronRight} className="ml-1" size="md" aria-label="Arrow right icon" />
@@ -48,7 +52,10 @@ export const AddCodeHostWidget: FC<AddCodeHostWidgetProps> = props => {
                             target="_blank"
                             rel="noopener noreferrer"
                             className={styles.textUnderline}
-                            onClick={() => telemetryService.log('OnboardingWidget:ViewDocs:Clicked')}
+                            onClick={() => {
+                                telemetryService.log('OnboardingWidget:ViewDocs:Clicked')
+                                telemetryRecorder.recordEvent('onboardingWidget.viewDocs', 'click')
+                            }}
                         >
                             docs
                         </Link>
@@ -69,7 +76,10 @@ export const AddCodeHostWidget: FC<AddCodeHostWidgetProps> = props => {
                             target="_blank"
                             rel="noopener noreferrer"
                             className={styles.textUnderline}
-                            onClick={() => telemetryService.log('OnboardingWidget:ViewSOC2:Clicked')}
+                            onClick={() => {
+                                telemetryService.log('OnboardingWidget:ViewSOC2:Clicked')
+                                telemetryRecorder.recordEvent('onboardingWidget.viewSOC2', 'click')
+                            }}
                         >
                             SOC 2 Type 2
                         </Link>{' '}
@@ -79,7 +89,10 @@ export const AddCodeHostWidget: FC<AddCodeHostWidgetProps> = props => {
                             target="_blank"
                             rel="noopener noreferrer"
                             className={styles.textUnderline}
-                            onClick={() => telemetryService.log('OnboardingWidget:ViewSecurityPortal:Clicked')}
+                            onClick={() => {
+                                telemetryService.log('OnboardingWidget:ViewSecurityPortal:Clicked')
+                                telemetryRecorder.recordEvent('onboardingWidget.viewSecurityPortal', 'click')
+                            }}
                         >
                             security portal
                         </Link>

--- a/client/web/src/storm/pages/SearchPage/CodeSearchSimpleSearch.tsx
+++ b/client/web/src/storm/pages/SearchPage/CodeSearchSimpleSearch.tsx
@@ -2,10 +2,11 @@ import React, { type FC, useEffect, useState } from 'react'
 
 import { mdiHelpCircleOutline } from '@mdi/js'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryService } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Icon, Select, Tooltip, Input, Button, Label, Form } from '@sourcegraph/wildcard'
 
-export interface SimpleSearchProps {
+export interface SimpleSearchProps extends TelemetryV2Props {
     onSimpleSearchUpdate: (query: string) => void
     onSubmit: (event?: React.FormEvent) => void
     telemetryService: TelemetryService

--- a/client/web/src/storm/pages/SearchPage/SearchPage.tsx
+++ b/client/web/src/storm/pages/SearchPage/SearchPage.tsx
@@ -17,7 +17,7 @@ export const SearchPage: FC = () => {
 
     return (
         <SearchPageContent
-            shouldShowAddCodeHostWidget={shouldShowAddCodeHostWidget}
+            shouldShowAddCodeHostWidget={shouldShowAddCodeHostWidget || true}
             isSourcegraphDotCom={isSourcegraphDotCom}
         />
     )

--- a/client/web/src/storm/pages/SearchPage/SearchPageContent.tsx
+++ b/client/web/src/storm/pages/SearchPage/SearchPageContent.tsx
@@ -34,8 +34,9 @@ interface SearchPageContentProps {
 export const SearchPageContent: FC<SearchPageContentProps> = props => {
     const { shouldShowAddCodeHostWidget } = props
 
-    const { telemetryService, selectedSearchContextSpec, isSourcegraphDotCom, authenticatedUser } =
+    const { telemetryService, selectedSearchContextSpec, isSourcegraphDotCom, authenticatedUser, platformContext } =
         useLegacyContext_onlyInStormRoutes()
+    const { telemetryRecorder } = platformContext
 
     const isLightTheme = useIsLightTheme()
     const [v2QueryInput] = useV2QueryInput()
@@ -45,7 +46,10 @@ export const SearchPageContent: FC<SearchPageContentProps> = props => {
         query: '',
     })
 
-    useEffect(() => telemetryService.logViewEvent('Home'), [telemetryService])
+    useEffect(() => {
+        telemetryService.logViewEvent('Home')
+        telemetryRecorder.recordEvent('home', 'view')
+    }, [telemetryService, telemetryRecorder])
     useEffect(() => {
         // TODO (#48103): Remove/simplify when new search input is released
         // Because the current and the new search input handle the context: selector differently
@@ -94,6 +98,9 @@ export const SearchPageContent: FC<SearchPageContentProps> = props => {
                             onToggle={val => {
                                 const arg = { state: val }
                                 telemetryService.log('SimpleSearchToggle', arg, arg)
+                                telemetryRecorder.recordEvent('home.simpleSearch', 'toggle', {
+                                    metadata: { enabled: val ? 1 : 0 },
+                                })
                                 setSimpleSearch(val)
                             }}
                         />

--- a/client/web/src/storm/pages/SearchPage/SearchPageFooter.tsx
+++ b/client/web/src/storm/pages/SearchPage/SearchPageFooter.tsx
@@ -8,15 +8,28 @@ import { useLegacyContext_onlyInStormRoutes } from '../../../LegacyRouteContext'
 
 import styles from './SearchPageFooter.module.scss'
 
-export const SearchPageFooter: FC = () => {
-    const { telemetryService, isSourcegraphDotCom } = useLegacyContext_onlyInStormRoutes()
+type linkNames = 'Docs' | 'About' | 'Cody' | 'Enterprise' | 'Security' | 'Discord'
 
-    const logLinkClicked = (name: string): void => {
+const v2LinkNameTypes: { [key in linkNames]: number } = {
+    Docs: 1,
+    About: 2,
+    Cody: 3,
+    Enterprise: 4,
+    Security: 5,
+    Discord: 6,
+}
+
+export const SearchPageFooter: FC = () => {
+    const { telemetryService, isSourcegraphDotCom, platformContext } = useLegacyContext_onlyInStormRoutes()
+    const { telemetryRecorder } = platformContext
+
+    const logLinkClicked = (name: linkNames): void => {
         telemetryService.log('HomepageFooterCTASelected', { name }, { name })
+        telemetryRecorder.recordEvent('home.footer.CTA', 'click', { metadata: { type: v2LinkNameTypes[name] } })
     }
 
     const links = useMemo(
-        (): { name: string; href: string }[] =>
+        (): { name: linkNames; href: string }[] =>
             isSourcegraphDotCom
                 ? [
                       {

--- a/client/web/src/storm/pages/SearchPage/SearchPageInput.tsx
+++ b/client/web/src/storm/pages/SearchPage/SearchPageInput.tsx
@@ -68,7 +68,6 @@ export const SearchPageInput: FC<SearchPageInputProps> = props => {
     } = useLegacyContext_onlyInStormRoutes()
     const { telemetryRecorder } = platformContext
 
-    console.log(telemetryRecorder)
     const selectedSearchContextSpec = hardCodedSearchContextSpec || dynamicSearchContextSpec
 
     const location = useLocation()

--- a/client/web/src/storm/pages/SearchPage/SearchPageInput.tsx
+++ b/client/web/src/storm/pages/SearchPage/SearchPageInput.tsx
@@ -16,7 +16,6 @@ import {
     type SearchModeProps,
     getUserSearchContextNamespaces,
 } from '@sourcegraph/shared/src/search'
-import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
 import { Form } from '@sourcegraph/wildcard'
 
 import { Notices } from '../../../global/Notices'
@@ -67,7 +66,9 @@ export const SearchPageInput: FC<SearchPageInputProps> = props => {
         fetchSearchContexts,
         setSelectedSearchContextSpec,
     } = useLegacyContext_onlyInStormRoutes()
+    const { telemetryRecorder } = platformContext
 
+    console.log(telemetryRecorder)
     const selectedSearchContextSpec = hardCodedSearchContextSpec || dynamicSearchContextSpec
 
     const location = useLocation()
@@ -211,7 +212,7 @@ export const SearchPageInput: FC<SearchPageInputProps> = props => {
                             <div className="d-flex flex-grow-1 w-100">{input}</div>
                         </TraceSpanProvider>
                     </div>
-                    <Notices className="my-3 text-center" location="home" telemetryRecorder={noOpTelemetryRecorder} />
+                    <Notices className="my-3 text-center" location="home" telemetryRecorder={telemetryRecorder} />
                 </Form>
             </div>
             {simpleSearch && (
@@ -219,6 +220,7 @@ export const SearchPageInput: FC<SearchPageInputProps> = props => {
                     <hr className="mt-4 mb-4" />
                     <SimpleSearch
                         telemetryService={telemetryService}
+                        telemetryRecorder={telemetryRecorder}
                         onSubmit={onSubmit}
                         onSimpleSearchUpdate={onSimpleSearchUpdate}
                     />

--- a/client/web/src/storm/pages/SearchPage/SimpleSearch.tsx
+++ b/client/web/src/storm/pages/SearchPage/SimpleSearch.tsx
@@ -16,19 +16,34 @@ function eventName(name: string): string {
     return EVENT_PREFIX + name
 }
 
+type ShowStates = 'default' | 'code' | 'repo' | 'changes'
+
+const v2ShowStateTypes: { [key in ShowStates]: number } = {
+    default: 1,
+    code: 2,
+    repo: 3,
+    changes: 4,
+}
+
 export const SimpleSearch: FC<SimpleSearchProps> = props => {
-    const [showState, setShowState] = useState<string>('default')
+    const [showState, setShowState] = useState<ShowStates>('default')
 
     function onSubmitWithTelemetry(event?: React.FormEvent): void {
         const arg = { type: showState }
         props.telemetryService.log(eventName('SubmitSearch'), arg, arg)
+        props.telemetryRecorder.recordEvent('simpleSearch.search', 'submit', {
+            metadata: { type: v2ShowStateTypes[showState] },
+        })
         props.onSubmit(event)
     }
 
     function pickRender(): JSX.Element {
-        const changeState = (nextState: string): void => {
+        const changeState = (nextState: ShowStates): void => {
             const arg = { next: nextState }
             props.telemetryService.log(eventName('SelectJob'), arg, arg)
+            props.telemetryRecorder.recordEvent('simpleSearch.search.type', 'select', {
+                metadata: { type: v2ShowStateTypes[nextState] },
+            })
             setShowState(nextState)
         }
 
@@ -79,7 +94,7 @@ export const SimpleSearch: FC<SimpleSearchProps> = props => {
 }
 
 interface SearchPickerProps {
-    setShowState: (state: string) => void
+    setShowState: (state: ShowStates) => void
 }
 
 const SearchPicker: FC<SearchPickerProps> = ({ setShowState }) => (


### PR DESCRIPTION
Context:

* https://github.com/sourcegraph/sourcegraph/pull/60127
* https://github.com/sourcegraph/sourcegraph/pull/60192
* https://github.com/sourcegraph/sourcegraph/pull/60219
* https://github.com/sourcegraph/sourcegraph/pull/60343
* https://github.com/sourcegraph/sourcegraph/pull/60377
* https://github.com/sourcegraph/sourcegraph/pull/60382
* https://github.com/sourcegraph/sourcegraph/pull/60764
* https://github.com/sourcegraph/sourcegraph/pull/60765
* https://github.com/sourcegraph/sourcegraph/pull/60767
* https://github.com/sourcegraph/sourcegraph/pull/60768
* https://github.com/sourcegraph/sourcegraph/pull/60788
* https://github.com/sourcegraph/sourcegraph/pull/60789
* https://github.com/sourcegraph/sourcegraph/pull/60803
* https://github.com/sourcegraph/sourcegraph/pull/60812
* https://github.com/sourcegraph/sourcegraph/pull/60850
* https://github.com/sourcegraph/sourcegraph/pull/60851
* https://github.com/sourcegraph/sourcegraph/pull/60939
* https://github.com/sourcegraph/sourcegraph/pull/60971
* https://github.com/sourcegraph/sourcegraph/pull/61205
* https://github.com/sourcegraph/sourcegraph/pull/61457
* https://github.com/sourcegraph/sourcegraph/pull/61503
* https://github.com/sourcegraph/sourcegraph/pull/61504
* https://github.com/sourcegraph/sourcegraph/pull/61506
* https://github.com/sourcegraph/sourcegraph/pull/61507
* https://github.com/sourcegraph/sourcegraph/pull/61516
* https://github.com/sourcegraph/sourcegraph/pull/61707
* https://github.com/sourcegraph/sourcegraph/pull/61748
* https://github.com/sourcegraph/sourcegraph/pull/61758
* https://github.com/sourcegraph/sourcegraph/pull/61762

## Test plan

`sg start`
visit page
check if events appear in `event_logs` table locally