### PR TITLE
chore: Bump autoindexing image SHAs

### DIFF
--- a/internal/codeintel/autoindexing/internal/inference/libs/indexes.go
+++ b/internal/codeintel/autoindexing/internal/inference/libs/indexes.go
@@ -26,9 +26,9 @@ var defaultIndexers = map[string]string{
 
 // To update, run `DOCKER_USER=... DOCKER_PASS=... ./update-shas.sh`
 var defaultIndexerSHAs = map[string]string{
-	"sourcegraph/scip-go":         "sha256:39c1495d4c7381c553f44d979c3f301f9bedbd6f25fbab0f92d6e90a555391cc",
+	"sourcegraph/scip-go":         "sha256:e6ca2d4b55bd1379631d45faab169fc32dc6da2c1939ed11a700261ac4c4d26f",
 	"sourcegraph/scip-rust":       "sha256:adf0047fc3050ba4f7be71302b42c74b49901f38fb40916d94ac5fc9181ac078",
-	"sourcegraph/scip-java":       "sha256:808b063b7376cfc0a4937d89ddc3d4dd9652d10609865fae3f3b34302132737a",
+	"sourcegraph/scip-java":       "sha256:a2b3828145cd38758a43363f06d786f9e620c97979a9291463c6544f7f17c68f",
 	"sourcegraph/scip-python":     "sha256:e3c13f0cadca78098439c541d19a72c21672a3263e22aa706760d941581e068d",
 	"sourcegraph/scip-typescript": "sha256:3df8b36a2ad4e073415bfbeaedf38b3cfff3e697614c8f578299f470d140c2c8",
 	"sourcegraph/scip-ruby":       "sha256:ef53e5f1450330ddb4a3edce963b7e10d900d44ff1e7de4960680289ac25f319",

--- a/internal/codeintel/autoindexing/internal/inference/testdata/JVM_project_with_Gradle.yaml
+++ b/internal/codeintel/autoindexing/internal/inference/testdata/JVM_project_with_Gradle.yaml
@@ -1,7 +1,7 @@
 - steps: []
   local_steps: []
   root: ""
-  indexer: sourcegraph/scip-java@sha256:808b063b7376cfc0a4937d89ddc3d4dd9652d10609865fae3f3b34302132737a
+  indexer: sourcegraph/scip-java@sha256:a2b3828145cd38758a43363f06d786f9e620c97979a9291463c6544f7f17c68f
   indexer_args:
     - scip-java
     - index

--- a/internal/codeintel/autoindexing/internal/inference/testdata/JVM_project_with_Maven.yaml
+++ b/internal/codeintel/autoindexing/internal/inference/testdata/JVM_project_with_Maven.yaml
@@ -1,7 +1,7 @@
 - steps: []
   local_steps: []
   root: ""
-  indexer: sourcegraph/scip-java@sha256:808b063b7376cfc0a4937d89ddc3d4dd9652d10609865fae3f3b34302132737a
+  indexer: sourcegraph/scip-java@sha256:a2b3828145cd38758a43363f06d786f9e620c97979a9291463c6544f7f17c68f
   indexer_args:
     - scip-java
     - index

--- a/internal/codeintel/autoindexing/internal/inference/testdata/JVM_project_with_SBT.yaml
+++ b/internal/codeintel/autoindexing/internal/inference/testdata/JVM_project_with_SBT.yaml
@@ -1,7 +1,7 @@
 - steps: []
   local_steps: []
   root: ""
-  indexer: sourcegraph/scip-java@sha256:808b063b7376cfc0a4937d89ddc3d4dd9652d10609865fae3f3b34302132737a
+  indexer: sourcegraph/scip-java@sha256:a2b3828145cd38758a43363f06d786f9e620c97979a9291463c6544f7f17c68f
   indexer_args:
     - scip-java
     - index

--- a/internal/codeintel/autoindexing/internal/inference/testdata/JVM_project_with_lsif-java.json.yaml
+++ b/internal/codeintel/autoindexing/internal/inference/testdata/JVM_project_with_lsif-java.json.yaml
@@ -1,7 +1,7 @@
 - steps: []
   local_steps: []
   root: ""
-  indexer: sourcegraph/scip-java@sha256:808b063b7376cfc0a4937d89ddc3d4dd9652d10609865fae3f3b34302132737a
+  indexer: sourcegraph/scip-java@sha256:a2b3828145cd38758a43363f06d786f9e620c97979a9291463c6544f7f17c68f
   indexer_args:
     - scip-java
     - index

--- a/internal/codeintel/autoindexing/internal/inference/testdata/Nested_JVM_project_WITHOUT_top-level_build_file.yaml
+++ b/internal/codeintel/autoindexing/internal/inference/testdata/Nested_JVM_project_WITHOUT_top-level_build_file.yaml
@@ -1,7 +1,7 @@
 - steps: []
   local_steps: []
   root: my-module
-  indexer: sourcegraph/scip-java@sha256:808b063b7376cfc0a4937d89ddc3d4dd9652d10609865fae3f3b34302132737a
+  indexer: sourcegraph/scip-java@sha256:a2b3828145cd38758a43363f06d786f9e620c97979a9291463c6544f7f17c68f
   indexer_args:
     - scip-java
     - index
@@ -11,7 +11,7 @@
 - steps: []
   local_steps: []
   root: our-module
-  indexer: sourcegraph/scip-java@sha256:808b063b7376cfc0a4937d89ddc3d4dd9652d10609865fae3f3b34302132737a
+  indexer: sourcegraph/scip-java@sha256:a2b3828145cd38758a43363f06d786f9e620c97979a9291463c6544f7f17c68f
   indexer_args:
     - scip-java
     - index

--- a/internal/codeintel/autoindexing/internal/inference/testdata/Nested_JVM_project_with_top-level_build_file.yaml
+++ b/internal/codeintel/autoindexing/internal/inference/testdata/Nested_JVM_project_with_top-level_build_file.yaml
@@ -1,7 +1,7 @@
 - steps: []
   local_steps: []
   root: ""
-  indexer: sourcegraph/scip-java@sha256:808b063b7376cfc0a4937d89ddc3d4dd9652d10609865fae3f3b34302132737a
+  indexer: sourcegraph/scip-java@sha256:a2b3828145cd38758a43363f06d786f9e620c97979a9291463c6544f7f17c68f
   indexer_args:
     - scip-java
     - index

--- a/internal/codeintel/autoindexing/internal/inference/testdata/go_files_in_root.yaml
+++ b/internal/codeintel/autoindexing/internal/inference/testdata/go_files_in_root.yaml
@@ -8,7 +8,7 @@
         echo "No netrc config set, continuing"
       fi
   root: ""
-  indexer: sourcegraph/scip-go@sha256:39c1495d4c7381c553f44d979c3f301f9bedbd6f25fbab0f92d6e90a555391cc
+  indexer: sourcegraph/scip-go@sha256:e6ca2d4b55bd1379631d45faab169fc32dc6da2c1939ed11a700261ac4c4d26f
   indexer_args:
     - GO111MODULE=off
     - scip-go

--- a/internal/codeintel/autoindexing/internal/inference/testdata/go_modules.yaml
+++ b/internal/codeintel/autoindexing/internal/inference/testdata/go_modules.yaml
@@ -1,6 +1,6 @@
 - steps:
     - root: foo/bar
-      image: sourcegraph/scip-go@sha256:39c1495d4c7381c553f44d979c3f301f9bedbd6f25fbab0f92d6e90a555391cc
+      image: sourcegraph/scip-go@sha256:e6ca2d4b55bd1379631d45faab169fc32dc6da2c1939ed11a700261ac4c4d26f
       commands:
         - |
           if [ "$NETRC_DATA" ]; then
@@ -19,7 +19,7 @@
         echo "No netrc config set, continuing"
       fi
   root: foo/bar
-  indexer: sourcegraph/scip-go@sha256:39c1495d4c7381c553f44d979c3f301f9bedbd6f25fbab0f92d6e90a555391cc
+  indexer: sourcegraph/scip-go@sha256:e6ca2d4b55bd1379631d45faab169fc32dc6da2c1939ed11a700261ac4c4d26f
   indexer_args:
     - scip-go
     - --no-animation
@@ -33,7 +33,7 @@
     - NETRC_DATA
 - steps:
     - root: foo/baz
-      image: sourcegraph/scip-go@sha256:39c1495d4c7381c553f44d979c3f301f9bedbd6f25fbab0f92d6e90a555391cc
+      image: sourcegraph/scip-go@sha256:e6ca2d4b55bd1379631d45faab169fc32dc6da2c1939ed11a700261ac4c4d26f
       commands:
         - |
           if [ "$NETRC_DATA" ]; then
@@ -52,7 +52,7 @@
         echo "No netrc config set, continuing"
       fi
   root: foo/baz
-  indexer: sourcegraph/scip-go@sha256:39c1495d4c7381c553f44d979c3f301f9bedbd6f25fbab0f92d6e90a555391cc
+  indexer: sourcegraph/scip-go@sha256:e6ca2d4b55bd1379631d45faab169fc32dc6da2c1939ed11a700261ac4c4d26f
   indexer_args:
     - scip-go
     - --no-animation


### PR DESCRIPTION
To make sure we can index code using newer Go versions out of the box.

## Test plan

n/a