### PR TITLE
backport: fix gen pipeline

### DIFF
--- a/.buildkite/pipeline.backcompat.yml
+++ b/.buildkite/pipeline.backcompat.yml
@@ -4,3 +4,5 @@ steps:
     agents: { queue: aspect-default }
     commands:
     - ./dev/backcompat/bazel-backcompat.sh
+    soft_fail:
+    - exit_status: 1

--- a/dev/ci/internal/ci/config.go
+++ b/dev/ci/internal/ci/config.go
@@ -92,13 +92,26 @@ func NewConfig(now time.Time) Config {
 			// We run builds on every commit in main, so on main, just look at the diff of the current commit.
 			diffCommand = append(diffCommand, "@^")
 		} else {
-			diffCommand = append(diffCommand, "origin/main..."+commit)
+			// Determine the base branch
+			baseBranch := os.Getenv("BUILDKITE_PULL_REQUEST_BASE_BRANCH")
+			if baseBranch == "" {
+				baseBranch = "main"
+			}
+			// fetch the branch to make sure it exists
+			refspec := fmt.Sprintf("+refs/heads/%s:refs/remotes/origin/%s", baseBranch, baseBranch)
+			if output, err := exec.Command("git", "fetch", "origin", refspec).Output(); err != nil {
+				panic(fmt.Sprintf("failed to fetch %s: %s", baseBranch, err))
+			} else {
+				println("🧨", output)
+			}
+			diffCommand = append(diffCommand, fmt.Sprintf("origin/%s...%s", baseBranch, commit))
 		}
 	} else {
 		diffCommand = append(diffCommand, "origin/main...")
 		// for testing
 		commit = "1234567890123456789012345678901234567890"
 	}
+	fmt.Printf("🚔 git %v", diffCommand)
 	if output, err := exec.Command("git", diffCommand...).Output(); err != nil {
 		panic(err)
 	} else {


### PR DESCRIPTION
There are  two problems here

### Problem 1
Due to the 100 commit depth we have on aspect agents the `origin/main` branch or commit it points to might not exist. This is important because of the proximity of the 5.3.9104 branch and where a commit is that is being built. The repo is in a detached state so we might not have information locally on the commit that `origin/main` is at.

### Problem 2
This is a backport. Why are we diffing against `origin/main` ? We should diff against the base branch which is 5.3.9104

### Game plan
1. Determine the base branch
2. Fetch the that boi
3. Diff
4. PROFIT

>[!NOTE]
> I will cherry-pick this onto main as well


## Test plan
CI