### PR TITLE
svelte: Refactor search cache URL parameter processing

### DIFF
--- a/client/web-sveltekit/src/lib/search/constants.ts
+++ b/client/web-sveltekit/src/lib/search/constants.ts
@@ -1,1 +1,0 @@
-export const USE_CLIENT_CACHE_QUERY_PARAMETER = '__cc'

--- a/client/web-sveltekit/src/lib/search/dynamicFilters/index.ts
+++ b/client/web-sveltekit/src/lib/search/dynamicFilters/index.ts
@@ -3,7 +3,7 @@ import { mdiCodeBraces, mdiFileOutline, mdiFunction, mdiPlusMinus, mdiSourceComm
 import type { Filter } from '@sourcegraph/shared/src/search/stream'
 
 import { parseExtendedSearchURL } from '..'
-import { USE_CLIENT_CACHE_QUERY_PARAMETER } from '../constants'
+import { SearchCachePolicy, setCachePolicyInURL } from '../state'
 
 export type SectionItem = Omit<Filter, 'count'> & {
     count?: Filter['count']
@@ -47,7 +47,7 @@ export function updateFilterInURL(url: URL, filter: URLQueryFilter, remove: bool
     selectedFilters
         .map(serializeURLFilter)
         .forEach(selectedFilter => newURL.searchParams.append(DYNAMIC_FILTER_URL_QUERY_KEY, selectedFilter))
-    newURL.searchParams.set(USE_CLIENT_CACHE_QUERY_PARAMETER, '')
+    setCachePolicyInURL(newURL, SearchCachePolicy.CacheFirst)
 
     return newURL
 }

--- a/client/web-sveltekit/src/routes/search/+page.ts
+++ b/client/web-sveltekit/src/routes/search/+page.ts
@@ -5,7 +5,7 @@ import { browser } from '$app/environment'
 import { navigating } from '$app/stores'
 import { SearchPatternType } from '$lib/graphql-operations'
 import { parseExtendedSearchURL, type ExtendedParsedSearchURL } from '$lib/search'
-import { USE_CLIENT_CACHE_QUERY_PARAMETER } from '$lib/search/constants'
+import { SearchCachePolicy, getCachePolicyFromURL } from '$lib/search/state'
 import {
     aggregateStreamingSearch,
     LATEST_VERSION,
@@ -32,13 +32,13 @@ class CachingStreamManager {
     search(
         parsedQuery: ExtendedParsedSearchURL,
         searchOptions: StreamSearchOptions,
-        bypassCache: boolean
+        useCache: boolean
     ): Observable<AggregateStreamingSearchResults> {
-        const key = createCacheKey(parsedQuery, searchOptions)
+        const key = this.createCacheKey(parsedQuery, searchOptions)
 
         const searchStream = this.cache.get(key)
 
-        if (bypassCache || !searchStream) {
+        if (!useCache || !searchStream) {
             const stream = this.streamManager.search(parsedQuery, searchOptions)
             const searchStream = new BehaviorSubject<AggregateStreamingSearchResults>(emptyAggregateResults)
             this.cache.set(key, searchStream)
@@ -51,6 +51,20 @@ class CachingStreamManager {
         }
 
         return searchStream
+    }
+
+    private createCacheKey(parsedQuery: ExtendedParsedSearchURL, options: StreamSearchOptions): string {
+        return [
+            options.version,
+            options.patternType,
+            options.caseSensitive,
+            options.searchMode,
+            options.chunkMatches,
+            parsedQuery.filteredQuery,
+            parsedQuery.searchMode,
+            parsedQuery.patternType,
+            parsedQuery.caseSensitive,
+        ].join('--')
     }
 }
 
@@ -71,7 +85,7 @@ const streamManager = browser ? new CachingStreamManager() : new NonCachingStrea
 export const load: PageLoad = ({ url, depends }) => {
     const hasQuery = url.searchParams.has('q')
     const caseSensitiveURL = url.searchParams.get('case') === 'yes'
-    const forceCache = url.searchParams.has(USE_CLIENT_CACHE_QUERY_PARAMETER)
+    const cachePolicy = getCachePolicyFromURL(url)
     const trace = url.searchParams.get('trace') ?? undefined
 
     if (hasQuery) {
@@ -111,15 +125,21 @@ export const load: PageLoad = ({ url, depends }) => {
             maxLineLen: 5 * 1024,
         }
 
+        let useClientCache = false
+        switch (cachePolicy) {
+            case SearchCachePolicy.CacheFirst:
+                useClientCache = true
+                break
+            case SearchCachePolicy.Default:
+                useClientCache = get(navigating)?.type === 'popstate'
+                break
+        }
+
         // We create a new stream only if
         // - we do not have a cached stream (in the browser)
         // - the search result page was expliclty navigated to (not via back/forward buttons)
         // - cache is not enforced (which is used in the filters sidebar)
-        const searchStream = streamManager.search(
-            parsedQuery,
-            options,
-            !forceCache && get(navigating)?.type !== 'popstate'
-        )
+        const searchStream = streamManager.search(parsedQuery, options, useClientCache)
 
         return {
             searchStream,
@@ -148,18 +168,4 @@ function withoutGlobalContext(query: string): string {
         return omitFilter(query, globalSearchContext.filter)
     }
     return query
-}
-
-function createCacheKey(parsedQuery: ExtendedParsedSearchURL, options: StreamSearchOptions): string {
-    return [
-        options.version,
-        options.patternType,
-        options.caseSensitive,
-        options.searchMode,
-        options.chunkMatches,
-        parsedQuery.filteredQuery,
-        parsedQuery.searchMode,
-        parsedQuery.patternType,
-        parsedQuery.caseSensitive,
-    ].join('--')
 }


### PR DESCRIPTION
While looking into https://github.com/sourcegraph/sourcegraph/issues/61636 I thought we might need to support more than two caching policies, which let me to rewrite how handle this URL parameter.

It turned out that the root cause for the linked issue is something different but I still think that the changed code introduces a nice layer of abstraction.



## Test plan

Manual testing. Selecting a search filter again reuses the cached result.
