### PR TITLE
Fixing Redis usage and Payload Map structure for TokenUsage

### DIFF
--- a/internal/completions/client/anthropic/anthropic.go
+++ b/internal/completions/client/anthropic/anthropic.go
@@ -64,7 +64,7 @@ func (a *anthropicClient) Complete(
 		completion += content.Text
 	}
 
-	err = a.tokenManager.UpdateAnthropicModelUsage(response.Usage.InputTokens, response.Usage.OutputTokens, "anthropic/"+requestParams.Model, string(feature))
+	err = a.tokenManager.UpdateAnthropicModelUsage(response.Usage.InputTokens, response.Usage.OutputTokens, "anthropic/"+requestParams.Model, string(feature), tokenusage.Anthropic)
 	if err != nil {
 		return nil, err
 	}
@@ -124,7 +124,7 @@ func (a *anthropicClient) Stream(
 		case "message_delta":
 			if event.Delta != nil {
 				stopReason = event.Delta.StopReason
-				err = a.tokenManager.UpdateAnthropicModelUsage(inputPromptTokens, event.Usage.OutputTokens, "anthropic/"+requestParams.Model, string(feature))
+				err = a.tokenManager.UpdateAnthropicModelUsage(inputPromptTokens, event.Usage.OutputTokens, "anthropic/"+requestParams.Model, string(feature), tokenusage.Anthropic)
 				if err != nil {
 					logger.Warn("Failed to count tokens with the token manager %w ", log.Error(err))
 				}

--- a/internal/completions/client/awsbedrock/bedrock.go
+++ b/internal/completions/client/awsbedrock/bedrock.go
@@ -68,7 +68,7 @@ func (c *awsBedrockAnthropicCompletionStreamClient) Complete(
 		completion += content.Text
 	}
 
-	err = c.tokenManager.UpdateAnthropicModelUsage(response.Usage.InputTokens, response.Usage.OutputTokens, "anthropic/"+requestParams.Model, string(feature))
+	err = c.tokenManager.UpdateAnthropicModelUsage(response.Usage.InputTokens, response.Usage.OutputTokens, "anthropic/"+requestParams.Model, string(feature), tokenusage.AwsBedrock)
 	if err != nil {
 		return nil, err
 	}
@@ -153,7 +153,7 @@ func (a *awsBedrockAnthropicCompletionStreamClient) Stream(
 		case "message_delta":
 			if event.Delta != nil {
 				stopReason = event.Delta.StopReason
-				err = a.tokenManager.UpdateAnthropicModelUsage(inputPromptTokens, event.Usage.OutputTokens, "anthropic/"+requestParams.Model, string(feature))
+				err = a.tokenManager.UpdateAnthropicModelUsage(inputPromptTokens, event.Usage.OutputTokens, "anthropic/"+requestParams.Model, string(feature), tokenusage.AwsBedrock)
 				if err != nil {
 					logger.Warn("Failed to count tokens with the token manager %w ", log.Error(err))
 				}

--- a/internal/completions/client/azureopenai/openai.go
+++ b/internal/completions/client/azureopenai/openai.go
@@ -230,7 +230,7 @@ func streamAutocomplete(
 		// stream is done
 		if errors.Is(err, io.EOF) {
 			tokenManager := tokenusage.NewManager()
-			err = tokenManager.TokenizeAndCalculateUsage(requestParams.Messages, content, tokenizer.AzureModel+"/"+requestParams.Model, "code_completions")
+			err = tokenManager.TokenizeAndCalculateUsage(requestParams.Messages, content, tokenizer.AzureModel+"/"+requestParams.Model, "code_completions", tokenusage.AzureOpenAI)
 			if err != nil {
 				logger.Warn("Failed to count tokens with the token manager %w ", log.Error(err))
 			}
@@ -282,7 +282,7 @@ func streamChat(
 		// stream is done
 		if errors.Is(err, io.EOF) {
 			tokenManager := tokenusage.NewManager()
-			err = tokenManager.TokenizeAndCalculateUsage(requestParams.Messages, content, tokenizer.AzureModel+"/"+requestParams.Model, "chat_completions")
+			err = tokenManager.TokenizeAndCalculateUsage(requestParams.Messages, content, tokenizer.AzureModel+"/"+requestParams.Model, "chat_completions", tokenusage.AzureOpenAI)
 			if err != nil {
 				logger.Warn("Failed to count tokens with the token manager %w ", log.Error(err))
 			}

--- a/internal/completions/client/openai/openai.go
+++ b/internal/completions/client/openai/openai.go
@@ -67,7 +67,7 @@ func (c *openAIChatCompletionStreamClient) Complete(
 		// Empty response.
 		return &types.CompletionResponse{}, nil
 	}
-	err = c.tokenManager.TokenizeAndCalculateUsage(requestParams.Messages, response.Choices[0].Text, tokenizer.OpenAIModel+"/"+requestParams.Model, string(feature))
+	err = c.tokenManager.TokenizeAndCalculateUsage(requestParams.Messages, response.Choices[0].Text, tokenizer.OpenAIModel+"/"+requestParams.Model, string(feature), tokenusage.OpenAI)
 	if err != nil {
 		logger.Warn("Failed to count tokens with the token manager %w ", log.Error(err))
 	}
@@ -139,7 +139,7 @@ func (c *openAIChatCompletionStreamClient) Stream(
 	if dec.Err() != nil {
 		return dec.Err()
 	}
-	err = c.tokenManager.TokenizeAndCalculateUsage(requestParams.Messages, content, tokenizer.OpenAIModel+"/"+requestParams.Model, string(feature))
+	err = c.tokenManager.TokenizeAndCalculateUsage(requestParams.Messages, content, tokenizer.OpenAIModel+"/"+requestParams.Model, string(feature), tokenusage.OpenAI)
 	if err != nil {
 		logger.Warn("Failed to count tokens with the token manager %w", log.Error(err))
 	}

--- a/internal/completions/tokenusage/tokenusage.go
+++ b/internal/completions/tokenusage/tokenusage.go
@@ -21,7 +21,7 @@ type ModelData struct {
 
 func NewManager() *Manager {
 	return &Manager{
-		Cache: rcache.New("LLMUsage"),
+		Cache: rcache.NewWithRedisStore("LLMUsage"),
 	}
 }
 
@@ -86,10 +86,9 @@ func (m *Manager) RetrieveAndResetTokenUsageData() (map[string]interface{}, erro
 		}
 		modelsData = append(modelsData, modelData)
 	}
-
 	result := map[string]interface{}{
-		"llm_usage": map[string]interface{}{
-			"models": modelsData,
+		"llm_usage": []map[string]interface{}{
+			{"models": modelsData},
 		},
 	}
 	return result, nil

--- a/internal/completions/tokenusage/tokenusage.go
+++ b/internal/completions/tokenusage/tokenusage.go
@@ -25,7 +25,16 @@ func NewManager() *Manager {
 	}
 }
 
-func (m *Manager) TokenizeAndCalculateUsage(inputMessages []types.Message, outputText, model, feature string) error {
+type Provider string
+
+const (
+	OpenAI      Provider = "openai"
+	AzureOpenAI Provider = "azureopenai"
+	AwsBedrock  Provider = "awsbedrock"
+	Anthropic   Provider = "anthropic"
+)
+
+func (m *Manager) TokenizeAndCalculateUsage(inputMessages []types.Message, outputText, model, feature string, provider Provider) error {
 	tokenizer, err := tokenizer.NewTokenizer(model)
 	if err != nil {
 		return errors.Newf("failed to create tokenizer: %w", err)
@@ -41,7 +50,7 @@ func (m *Manager) TokenizeAndCalculateUsage(inputMessages []types.Message, outpu
 		return errors.Newf("failed to tokenize output text: %w", err)
 	}
 
-	baseKey := fmt.Sprintf("%s:%s:", model, feature)
+	baseKey := fmt.Sprintf("%s:%s:%s:", provider, model, feature)
 
 	if err := m.updateTokenCounts(baseKey+"input", int64(numInputTokens)); err != nil {
 		return errors.Newf("failed to update input token counts: %w", err)
@@ -52,8 +61,8 @@ func (m *Manager) TokenizeAndCalculateUsage(inputMessages []types.Message, outpu
 	return nil
 }
 
-func (m *Manager) UpdateAnthropicModelUsage(inputTokens, outputTokens int, model, feature string) error {
-	baseKey := fmt.Sprintf("%s:%s:", model, feature)
+func (m *Manager) UpdateAnthropicModelUsage(inputTokens, outputTokens int, model, feature string, provider Provider) error {
+	baseKey := fmt.Sprintf("%s:%s:%s:", provider, model, feature)
 
 	if err := m.updateTokenCounts(baseKey+"input", int64(inputTokens)); err != nil {
 		return errors.Newf("failed to update input token counts: %w", err)

--- a/internal/completions/tokenusage/tokenusage_test.go
+++ b/internal/completions/tokenusage/tokenusage_test.go
@@ -17,14 +17,14 @@ func TestTokenizeAndCalculateUsage(t *testing.T) {
 		{Speaker: "human", Text: "Hello"},
 		{Speaker: "user", Text: "Hi"},
 	}
-	err := manager.TokenizeAndCalculateUsage(messages, "output text", tokenizer.OpenAIModel+"/gpt-4", "feature1")
+	err := manager.TokenizeAndCalculateUsage(messages, "output text", tokenizer.OpenAIModel+"/gpt-4", "feature1", tokenusage.OpenAI)
 	if err != nil {
 		t.Fatalf("TokenizeAndCalculateUsage returned an error: %v", err)
 	}
 
 	// Verify that token counts are updated in the cache
-	inputKey := "openai/gpt-4:feature1:input"
-	outputKey := "openai/gpt-4:feature1:output"
+	inputKey := "openai:openai/gpt-4:feature1:input"
+	outputKey := "openai:openai/gpt-4:feature1:output"
 
 	if val, exists, _ := mockCache.GetInt64(inputKey); !exists || val <= 0 {
 		t.Errorf("Expected input token count to be updated in cache, but key %s was not found or value is not positive", inputKey)

--- a/internal/completions/tokenusage/tokenusage_test.go
+++ b/internal/completions/tokenusage/tokenusage_test.go
@@ -48,12 +48,12 @@ func TestGetAllTokenUsageData(t *testing.T) {
 		t.Error(err)
 	}
 
-	llmUsage, ok := usageSummary["llm_usage"].(map[string]interface{})
+	llmUsage, ok := usageSummary["llm_usage"].([]map[string]interface{})
 	if !ok {
 		t.Fatalf("Expected llm_usage key to be present and be a map")
 	}
 
-	models, ok := llmUsage["models"].([]tokenusage.ModelData)
+	models, ok := llmUsage[0]["models"].([]tokenusage.ModelData)
 	if !ok || len(models) != 2 {
 		t.Fatalf("Expected models to be a slice of map with 2 items, got %d", len(models))
 	}


### PR DESCRIPTION
This PR does two things

1. Fixes the Payload to be sent to Pings for llm_usage 

<img width="659" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/11155207/0dd85eb2-34a4-403e-8241-b64b9dfbda02">

<img width="678" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/11155207/fe391ddc-e7a1-4c35-85e0-343198bcc904">

2. Fixes the token usage cache to use a more stable redis. 
3. Adds provider name to the redis cache key to make it easy to differentiate the keys 


## Test plan
- Run CI
