### PR TITLE
pipeline: more pipeline config fixes

### DIFF
--- a/dev/ci/internal/ci/config.go
+++ b/dev/ci/internal/ci/config.go
@@ -94,10 +94,8 @@ func NewConfig(now time.Time) Config {
 		} else {
 			baseBranch := os.Getenv("BUILDKITE_PULL_REQUEST_BASE_BRANCH")
 			if diffArgs, err := determineDiffArgs(baseBranch, commit); err != nil {
-				fmt.Fprintf(os.Stderr, "1.CONFUSED SCREAMING:\nBase: %q, DiffArgs: %q", baseBranch, diffArgs)
 				panic(err)
 			} else {
-				fmt.Fprintf(os.Stderr, "2.CONFUSED SCREAMING:\nBase: %q, DiffArgs: %q", baseBranch, diffArgs)
 				// the base we want to diff against should exist locally now so we can diff!
 				diffCommand = append(diffCommand, diffArgs)
 			}
@@ -107,6 +105,7 @@ func NewConfig(now time.Time) Config {
 		// for testing
 		commit = "1234567890123456789012345678901234567890"
 	}
+	fmt.Fprintf(os.Stderr, "running diff command: git %v\n", diffCommand)
 	if output, err := exec.Command("git", diffCommand...).Output(); err != nil {
 		panic(err)
 	} else {
@@ -157,10 +156,10 @@ func determineDiffArgs(baseBranch, commit string) (string, error) {
 
 	// fetch the branch to make sure it exists
 	refspec := fmt.Sprintf("+refs/heads/%s:refs/remotes/origin/%s", baseBranch, baseBranch)
-	if output, err := exec.Command("git", "fetch", "origin", refspec).Output(); err != nil {
+	if _, err := exec.Command("git", "fetch", "origin", refspec).Output(); err != nil {
 		return "", errors.Newf("failed to fetch %s: %s", baseBranch, err)
 	} else {
-		fmt.Fprintf(os.Stderr, "Fetched %s: %s\n", baseBranch, output)
+		fmt.Fprintf(os.Stderr, "fetched %s\n", baseBranch)
 		return fmt.Sprintf("origin/%s...%s", baseBranch, commit), nil
 	}
 }

--- a/dev/ci/internal/ci/config.go
+++ b/dev/ci/internal/ci/config.go
@@ -94,8 +94,10 @@ func NewConfig(now time.Time) Config {
 		} else {
 			baseBranch := os.Getenv("BUILDKITE_PULL_REQUEST_BASE_BRANCH")
 			if diffArgs, err := determineDiffArgs(baseBranch, commit); err != nil {
+				fmt.Fprintf(os.Stderr, "1.CONFUSED SCREAMING:\nBase: %q, DiffArgs: %q", baseBranch, diffArgs)
 				panic(err)
 			} else {
+				fmt.Fprintf(os.Stderr, "2.CONFUSED SCREAMING:\nBase: %q, DiffArgs: %q", baseBranch, diffArgs)
 				// the base we want to diff against should exist locally now so we can diff!
 				diffCommand = append(diffCommand, diffArgs)
 			}

--- a/dev/ci/internal/ci/config.go
+++ b/dev/ci/internal/ci/config.go
@@ -119,7 +119,7 @@ func NewConfig(now time.Time) Config {
 		changedFiles,
 		diff.String(),
 	)
-	fmt.Fprint(os.Stderr, "The generated build pipeline will now follow, see you next time!")
+	fmt.Fprint(os.Stderr, "The generated build pipeline will now follow, see you next time!\n")
 
 	return Config{
 		RunType: runType,

--- a/dev/ci/internal/ci/config.go
+++ b/dev/ci/internal/ci/config.go
@@ -92,21 +92,13 @@ func NewConfig(now time.Time) Config {
 			// We run builds on every commit in main, so on main, just look at the diff of the current commit.
 			diffCommand = append(diffCommand, "@^")
 		} else {
-			// We have a different base branch (possibily) and on aspect agents we are in a detached state with only 100 commit depth
-			// so we might not know about this base branch ... so we first fetch the base and then diff
-			//
-			// Determine the base branch
 			baseBranch := os.Getenv("BUILDKITE_PULL_REQUEST_BASE_BRANCH")
-			if baseBranch == "" {
-				baseBranch = "main"
+			if diffArgs, err := determineDiffArgs(baseBranch, commit); err != nil {
+				panic(err)
+			} else {
+				// the base we want to diff against should exist locally now so we can diff!
+				diffCommand = append(diffCommand, diffArgs)
 			}
-			// fetch the branch to make sure it exists
-			refspec := fmt.Sprintf("+refs/heads/%s:refs/remotes/origin/%s", baseBranch, baseBranch)
-			if _, err := exec.Command("git", "fetch", "origin", refspec).Output(); err != nil {
-				panic(fmt.Sprintf("failed to fetch %s: %s", baseBranch, err))
-			}
-			// the base we want to diff against should exist locally now so we can diff!
-			diffCommand = append(diffCommand, fmt.Sprintf("origin/%s...%s", baseBranch, commit))
 		}
 	} else {
 		diffCommand = append(diffCommand, "origin/main...")
@@ -147,6 +139,27 @@ func NewConfig(now time.Time) Config {
 			Channel:    "#buildkite-main",
 			SlackToken: os.Getenv("SLACK_INTEGRATION_TOKEN"),
 		},
+	}
+}
+
+func determineDiffArgs(baseBranch, commit string) (string, error) {
+	// We have a different base branch (possibily) and on aspect agents we are in a detached state with only 100 commit depth
+	// so we might not know about this base branch ... so we first fetch the base and then diff
+	//
+	// Determine the base branch
+	if baseBranch == "" {
+		// When the base branch is not set, then this is probably a build where a commit got merged
+		// onto the current branch. So we just diff with the current commit
+		return "@^", nil
+	}
+
+	// fetch the branch to make sure it exists
+	refspec := fmt.Sprintf("+refs/heads/%s:refs/remotes/origin/%s", baseBranch, baseBranch)
+	if output, err := exec.Command("git", "fetch", "origin", refspec).Output(); err != nil {
+		return "", errors.Newf("failed to fetch %s: %s", baseBranch, err)
+	} else {
+		fmt.Fprintf(os.Stderr, "Fetched %s: %s\n", baseBranch, output)
+		return fmt.Sprintf("origin/%s...%s", baseBranch, commit), nil
 	}
 }
 


### PR DESCRIPTION
Sooooooooooooo. Backport builds are still failing see https://buildkite.com/sourcegraph/sourcegraph/builds/268392

The base branch is empty when it's a merge into a branch - when a PR for a backport gets merged into the backport branch ... In that case - what we actually want to do:

1. Diff with the previous commit on _this_ branch
2. NOT DIFF WITH origin/main ... right?

## Test plan
CI and attempting a merge into _this_ branch