### PR TITLE
Revert "chore(sg): rfc flags are now position independent"

### DIFF
--- a/dev/sg/sg_rfc.go
+++ b/dev/sg/sg_rfc.go
@@ -12,17 +12,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
-// rfcFlags are the flags that are common to all subcommands of the rfc command. This allows to not have to remember which position the flags are
-// to be inputted on the CLI.
-var rfcFlags = []cli.Flag{
-	&cli.BoolFlag{
-		Name:     "private",
-		Usage:    "perform the RFC action on the private RFC drive",
-		Required: false,
-		Value:    false,
-	},
-}
-
 var rfcCommand = &cli.Command{
 	Name:  "rfc",
 	Usage: `List, search, and open Sourcegraph RFCs`,
@@ -37,33 +26,40 @@ var rfcCommand = &cli.Command{
 sg rfc list
 
 # List all Private RFCs
-sg rfc list --private
+sg rfc --private list
 
 # Search for a Public RFC
 sg rfc search "search terms"
 
 # Search for a Private RFC
-sg rfc search --private "search terms"
+sg rfc --private search "search terms"
 
 # Open a specific Public RFC
 sg rfc open 420
 
 # Open a specific private RFC
-sg rfc open --private 420
+sg rfc --private open 420
 
 # Create a new public RFC
 sg rfc create "title"
 
 # Create a new private RFC. Possible types: [solution]
-sg rfc create --private --type <type> "title"
+sg rfc --private create --type <type> "title"
 `,
 	Category: category.Company,
-	Flags:    rfcFlags,
+	Flags: []cli.Flag{
+		&cli.BoolFlag{
+			Name:     "private",
+			Usage:    "perform the RFC action on the private RFC drive",
+			Required: false,
+			Value:    false,
+		},
+	},
 	Subcommands: []*cli.Command{
 		{
-			Name:  "list",
-			Usage: "List Sourcegraph RFCs",
-			Flags: rfcFlags,
+			Name:      "list",
+			ArgsUsage: " ",
+			Usage:     "List Sourcegraph RFCs",
 			Action: func(c *cli.Context) error {
 				driveSpec := rfc.PublicDrive
 				if c.Bool("private") {
@@ -75,7 +71,6 @@ sg rfc create --private --type <type> "title"
 		{
 			Name:      "search",
 			ArgsUsage: "[query]",
-			Flags:     rfcFlags,
 			Usage:     "Search Sourcegraph RFCs",
 			Action: func(c *cli.Context) error {
 				driveSpec := rfc.PublicDrive
@@ -91,7 +86,6 @@ sg rfc create --private --type <type> "title"
 		{
 			Name:      "open",
 			ArgsUsage: "[number]",
-			Flags:     rfcFlags,
 			Usage:     "Open a Sourcegraph RFC - find and list RFC numbers with 'sg rfc list' or 'sg rfc search'",
 			Action: func(c *cli.Context) error {
 				driveSpec := rfc.PublicDrive
@@ -106,12 +100,14 @@ sg rfc create --private --type <type> "title"
 		},
 		{
 			Name:      "create",
-			ArgsUsage: "[title...]",
-			Flags: append(rfcFlags, &cli.StringFlag{
-				Name:  "type",
-				Usage: "the type of the RFC to create (valid: solution)",
-				Value: rfc.ProblemSolutionDriveTemplate.Name,
-			}),
+			ArgsUsage: "--type <type> [title...]",
+			Flags: []cli.Flag{
+				&cli.StringFlag{
+					Name:  "type",
+					Usage: "the type of the RFC to create (valid: solution)",
+					Value: rfc.ProblemSolutionDriveTemplate.Name,
+				},
+			},
 			Usage: "Create Sourcegraph RFCs",
 			Action: func(c *cli.Context) error {
 				driveSpec := rfc.PublicDrive


### PR DESCRIPTION
Reverts sourcegraph/sourcegraph#61529

I managed to miss an edge case during the QA.

Test plan: CI 