### PR TITLE
ci: disable emitting execution log for bazel

### DIFF
--- a/.aspect/bazelrc/ci.sourcegraph.bazelrc
+++ b/.aspect/bazelrc/ci.sourcegraph.bazelrc
@@ -58,5 +58,3 @@ test --flaky_test_attempts=2
 # See https://github.com/aspect-build/rules_js/issues/1412
 # Sometimes the build fails due to some flakiness where a npm package fails to be copied
 common --noexperimental_merged_skyframe_analysis_execution
-
-build --experimental_execution_log_compact_file=/workflows/artifacts/executionlog.zstd


### PR DESCRIPTION
Causing excessive log spam :disappointed: 

https://github.com/bazelbuild/bazel/issues/21820

## Test plan

CI