### PR TITLE
sec: emit security event for RBAC changes

### DIFF
--- a/internal/database/security_event_logs.go
+++ b/internal/database/security_event_logs.go
@@ -47,6 +47,11 @@ const (
 	SecurityEventNameRoleChangeDenied  SecurityEventName = "RoleChangeDenied"
 	SecurityEventNameRoleChangeGranted SecurityEventName = "RoleChangeGranted"
 
+	SecurityEventNameRBACRoleAdded     SecurityEventName = "RBACRoleAdded"
+	SecurityEventNameRBACRoleRemoved   SecurityEventName = "RBACRoleRemoved"
+	SecurityEventNameRBACRoleSet       SecurityEventName = "RBACRoleSet"
+	SecurityEventNameRBACPermissionSet SecurityEventName = "RBACPermissionSet"
+
 	SecurityEventNameAccessGranted SecurityEventName = "AccessGranted"
 
 	SecurityEventAccessTokenCreated             SecurityEventName = "AccessTokenCreated"


### PR DESCRIPTION
RBAC changes can be sensitive and can have a big impact. This adds event logging for changes to RBAC.

## Test plan
CI tests.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
