### PR TITLE
Revert "ci: publish release images to public artifact registry"

### DIFF
--- a/dev/ci/images/images.go
+++ b/dev/ci/images/images.go
@@ -17,9 +17,6 @@ const (
 	// SourcegraphDockerPublishRegistry is a public registry for final images, and does not require authentication to pull from.
 	// TODO RFC795: safeguard
 	SourcegraphDockerPublishRegistry = "index.docker.io/sourcegraph"
-	// SourcegraphArtifactRegistryPublicRegistry is a public registry for storing public images.
-	// It is a migitation for the upcoming Docker Hub rate limits on GCP starting July 15, 2024
-	SourcegraphArtifactRegistryPublicRegistry = "us-docker.pkg.dev/sourcegraph-public-images/sourcegraph-public-images"
 	// SourcegraphInternalReleaseRegistry is a private registry storing internal releases.
 	SourcegraphInternalReleaseRegistry = "us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal"
 	// SourcegraphPublicReleaseRegistry is a currently private registry for storing public releases.

--- a/dev/ci/internal/ci/images_operations.go
+++ b/dev/ci/internal/ci/images_operations.go
@@ -95,17 +95,14 @@ func bazelPushImagesCmd(c Config, isCandidate bool, opts ...bk.StepOpt) func(*bk
 	// Default registries.
 	devRegistry := images.SourcegraphDockerDevRegistry
 	prodRegistry := images.SourcegraphDockerPublishRegistry
-	additionalProdRegistry := images.SourcegraphArtifactRegistryPublicRegistry
 
 	// If we're building an internal release, we push the final images to that specific registry instead.
 	// See also: release_operations.go
 	switch c.RunType {
 	case runtype.InternalRelease:
 		prodRegistry = images.SourcegraphInternalReleaseRegistry
-		additionalProdRegistry = "" // we don't want to push to the public registry on internal releases
 	case runtype.CloudEphemeral:
 		devRegistry = images.CloudEphemeralRegistry
-		additionalProdRegistry = "" // we don't want to push to the public registry on cloud ephemeral
 	}
 
 	_, bazelRC := aspectBazelRC()
@@ -119,7 +116,6 @@ func bazelPushImagesCmd(c Config, isCandidate bool, opts ...bk.StepOpt) func(*bk
 				bk.Env("CANDIDATE_ONLY", candidate),
 				bk.Env("DEV_REGISTRY", devRegistry),
 				bk.Env("PROD_REGISTRY", prodRegistry),
-				bk.Env("ADDITIONAL_PROD_REGISTRY", additionalProdRegistry),
 				bk.Cmd(bazelStampedCmd(fmt.Sprintf(`build $$(bazel --bazelrc=%s --bazelrc=.aspect/bazelrc/ci.sourcegraph.bazelrc query 'kind("oci_push rule", //...)')`, bazelRC))),
 				bk.AnnotatedCmd(
 					"./dev/ci/push_all.sh",

--- a/dev/ci/push_all.sh
+++ b/dev/ci/push_all.sh
@@ -88,11 +88,6 @@ prod_registries=(
   "$PROD_REGISTRY"
 )
 
-additional_prod_registry=${ADDITIONAL_PROD_REGISTRY:-""}
-if [ -n "$additional_prod_registry" ]; then
-  prod_registries+=("$additional_prod_registry")
-fi
-
 date_fragment="$(date +%Y-%m-%d)"
 
 dev_tags=(


### PR DESCRIPTION
Reverts sourcegraph/sourcegraph#61764

https://buildkite.com/sourcegraph/sourcegraph/builds/268490#018ecdb6-8925-4a25-a070-0c1f6f05f1a2/401-483

needs to fix builder machine image to configure credhelper for new `us-docker.pkg.dev` registry

fix requires https://github.com/sourcegraph/infra-aspect-dev/pull/119, but let's revert for now to unblock main

### Test plan

CI