### PR TITLE
Revert "bazel: migrate dind dockerfile to rules_oci"

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -156,11 +156,9 @@ http_archive(
     url = "https://github.com/aspect-build/aspect-cli/archive/5.8.20.tar.gz",
 )
 
-load("@aspect_bazel_lib//lib:repositories.bzl", "register_expand_template_toolchains", "register_jq_toolchains")
+load("@aspect_bazel_lib//lib:repositories.bzl", "register_jq_toolchains")
 
 register_jq_toolchains()
-
-register_expand_template_toolchains()
 
 # hermetic_cc_toolchain setup ================================
 HERMETIC_CC_TOOLCHAIN_VERSION = "v2.2.1"

--- a/dev/bazel_stamp_vars.sh
+++ b/dev/bazel_stamp_vars.sh
@@ -2,7 +2,6 @@
 
 echo STABLE_VERSION "$VERSION"
 echo VERSION_TIMESTAMP "$(date +%s)"
-echo VERSION_TIMESTAMP_RFC3339 "$(date --iso-8601=s)"
 
 # Unstable Buildkite env vars
 echo "BUILDKITE $BUILDKITE"

--- a/dev/oci_deps.bzl
+++ b/dev/oci_deps.bzl
@@ -219,9 +219,9 @@ def oci_deps():
     )
 
     oci_pull(
-        name = "upstream_dind_base",
-        digest = "sha256:b52760bc3766143ca050ab3f36f01108c30bbd6bc16094400855adfb9bd66f12",
-        image = "index.docker.io/library/docker",
+        name = "legacy_dind_base",
+        digest = "sha256:0893c2e6103cde39b609efea0ebd6423c7af8dafdf19d613debbc12b05fefd54",
+        image = "index.docker.io/sourcegraph/dind",
     )
 
     oci_pull(

--- a/docker-images/dind/BUILD.bazel
+++ b/docker-images/dind/BUILD.bazel
@@ -1,44 +1,9 @@
-load("@aspect_bazel_lib//lib:expand_template.bzl", "expand_template")
-load("@rules_pkg//:pkg.bzl", "pkg_tar")
 load("//dev:oci_defs.bzl", "image_repository", "oci_image", "oci_push", "oci_tarball")
-
-expand_template(
-    name = "label_stamps",
-    out = "labels.txt",
-    stamp_substitutions = {
-        "COMMIT_SHA": "{{BUILDKITE_COMMIT}}",
-        "DATE": "{{VERSION_TIMESTAMP_RFC3339}}",
-        "STABLE_VERSION": "{{STABLE_VERSION}}",
-    },
-    template = [
-        "org.opencontainers.image.revision=COMMIT_SHA",
-        "org.opencontainers.image.created=DATE",
-        "org.opencontainers.image.version=STABLE_VERSION",
-        "org.opencontainers.image.url=https://sourcegraph.com/",
-        "org.opencontainers.image.source=https://github.com/sourcegraph/sourcegraph/",
-        "org.opencontainers.image.documentation=https://sourcegraph.com/docs/",
-        "com.sourcegraph.github.url=https://github.com/sourcegraph/sourcegraph/commit/COMMIT_SHA",
-    ],
-)
-
-pkg_tar(
-    name = "tar_whiteout",
-    srcs = [],
-    empty_files = [
-        # we can't run rm <file> so we use whiteout files to do it - see the following link for more info
-        # https://github.com/opencontainers/image-spec/blob/main/layer.md#whiteouts
-        "/usr/local/libexec/docker/cli-plugins/.wh.docker-compose",
-        "/usr/local/libexec/docker/cli-plugins/.wh.docker-buildx",
-    ],
-)
+load("@rules_pkg//:pkg.bzl", "pkg_tar")
 
 oci_image(
     name = "image",
-    base = "@upstream_dind_base",
-    cmd = [],
-    entrypoint = ["dockerd-entrypoint.sh"],
-    labels = ":label_stamps",
-    tars = [":tar_whiteout"],
+    base = "@legacy_dind_base",
 )
 
 oci_tarball(

--- a/docker-images/dind/Dockerfile
+++ b/docker-images/dind/Dockerfile
@@ -1,0 +1,22 @@
+FROM docker:26.0.0-dind@sha256:b52760bc3766143ca050ab3f36f01108c30bbd6bc16094400855adfb9bd66f12
+
+RUN rm -f /usr/libexec/docker/cli-plugins/docker-compose && \
+    rm -f /usr/libexec/docker/cli-plugins/docker-buildx
+
+ARG COMMIT_SHA="unknown"
+ARG DATE="unknown"
+ARG VERSION="unknown"
+
+LABEL org.opencontainers.image.revision=${COMMIT_SHA}
+LABEL org.opencontainers.image.created=${DATE}
+LABEL org.opencontainers.image.version=${VERSION}
+LABEL org.opencontainers.image.url=https://sourcegraph.com/
+LABEL org.opencontainers.image.source=https://github.com/sourcegraph/sourcegraph/
+LABEL org.opencontainers.image.documentation=https://sourcegraph.com/docs/
+LABEL com.sourcegraph.github.url=https://github.com/sourcegraph/sourcegraph/commit/${COMMIT_SHA}
+
+VOLUME /var/lib/docker
+EXPOSE 2375 2376
+
+ENTRYPOINT ["dockerd-entrypoint.sh"]
+CMD []

--- a/docker-images/dind/build.sh
+++ b/docker-images/dind/build.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -eou pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+IMAGE=${IMAGE:-sourcegraph/dind}
+
+echo "--- docker build ${IMAGE}"
+docker build -t "${IMAGE}" . \
+  --progress=plain \
+  --build-arg COMMIT_SHA \
+  --build-arg DATE \
+  --build-arg VERSION


### PR DESCRIPTION
Google Container Registry doesn't like this image for some reason, so we're gonna hold out until we're moved to Artifact Registry

# Test plan

reverting