### PR TITLE
Context: fix bug with result limits

### DIFF
--- a/internal/codycontext/context.go
+++ b/internal/codycontext/context.go
@@ -301,6 +301,12 @@ func (c *CodyContextClient) getKeywordContext(ctx context.Context, args GetConte
 			mu.Lock()
 			defer mu.Unlock()
 
+			// Another caller may have already hit the limit, but we haven't yet responded
+			// to the cancellation. Return immediately in this case.
+			if len(collected) >= limit {
+				return
+			}
+
 			for _, res := range e.Results {
 				if fm, ok := res.(*result.FileMatch); ok {
 					collected = append(collected, filter(fileMatchToContextMatches(fm))...)


### PR DESCRIPTION
While writing eval scripts for Cody context, I noticed that when searching
multiple repos, we sometimes we return greater than the intended number of
results. This PR makes a small fix so we always respect the result limits.

## Test plan

This is hard to check through automated tests since it requires a certain set
of concurrent steps to occur. I tested manually before and after the change and
this fixed it.