### PR TITLE
sg: Enable otel-collector in enterprise-codeintel preset

### DIFF
--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -1527,7 +1527,7 @@ commandsets:
       - blobstore
       - codeintel-worker
       - codeintel-executor
-      # - otel-collector
+      - otel-collector
       - jaeger
       - grafana
       - prometheus


### PR DESCRIPTION
This is needed to actually see captured traces in Jaeger, so it's
not useful to have it be disabled by default.

## Test plan

n/a