### PR TITLE
Replace Mixtral 8x22 with 8x22-instruct-preview

### DIFF
--- a/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/ModelBadges.tsx
+++ b/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/ModelBadges.tsx
@@ -61,7 +61,7 @@ function modelBadgeVariant(model: string, mode: 'completions' | 'embeddings'): '
             case 'fireworks/accounts/fireworks/models/llama-v2-34b-code-instruct':
             case 'fireworks/accounts/fireworks/models/mistral-7b-instruct-4k':
             case 'fireworks/accounts/fireworks/models/mixtral-8x7b-instruct':
-            case 'fireworks/accounts/fireworks/models/mixtral-8x22b': {
+            case 'fireworks/accounts/fireworks/models/mixtral-8x22b-instruct-preview': {
                 return 'secondary'
             }
             default: {

--- a/cmd/cody-gateway/shared/config/config.go
+++ b/cmd/cody-gateway/shared/config/config.go
@@ -234,7 +234,7 @@ func (c *Config) Load() {
 			"accounts/fireworks/models/llama-v2-34b-code-instruct",
 			"accounts/fireworks/models/mistral-7b-instruct-4k",
 			"accounts/fireworks/models/mixtral-8x7b-instruct",
-			"accounts/fireworks/models/mixtral-8x22b",
+			"accounts/fireworks/models/mixtral-8x22b-instruct-preview",
 			// Deprecated model strings
 			"accounts/fireworks/models/starcoder-3b-w8a16",
 			"accounts/fireworks/models/starcoder-1b-w8a16",

--- a/cmd/frontend/internal/dotcom/productsubscription/codygateway_dotcom_user.go
+++ b/cmd/frontend/internal/dotcom/productsubscription/codygateway_dotcom_user.go
@@ -365,7 +365,7 @@ func allowedModels(scope types.CompletionsFeature, isProUser bool) []string {
 			"anthropic/" + anthropic.Claude3Sonnet,
 			"anthropic/" + anthropic.Claude3Opus,
 			"fireworks/" + fireworks.Mixtral8x7bInstruct,
-			"fireworks/" + fireworks.Mixtral8x22,
+			"fireworks/" + fireworks.Mixtral8x22InstructPreview,
 			"openai/gpt-3.5-turbo",
 			"openai/gpt-4-turbo",
 			"openai/gpt-4-turbo-preview",

--- a/internal/completions/client/fireworks/fireworks.go
+++ b/internal/completions/client/fireworks/fireworks.go
@@ -30,7 +30,7 @@ const Llama213bCodeInstruct = "accounts/fireworks/models/llama-v2-13b-code-instr
 const Llama234bCodeInstruct = "accounts/fireworks/models/llama-v2-34b-code-instruct"
 const Mistral7bInstruct = "accounts/fireworks/models/mistral-7b-instruct-4k"
 const Mixtral8x7bInstruct = "accounts/fireworks/models/mixtral-8x7b-instruct"
-const Mixtral8x22 = "accounts/fireworks/models/mixtral-8x22b"
+const Mixtral8x22InstructPreview = "accounts/fireworks/models/mixtral-8x22b-instruct-preview"
 
 func NewClient(cli httpcli.Doer, endpoint, accessToken string) types.CompletionsClient {
 	return &fireworksClient{

--- a/internal/completions/httpapi/chat.go
+++ b/internal/completions/httpapi/chat.go
@@ -80,7 +80,7 @@ func isAllowedCustomChatModel(model string, isProUser bool) bool {
 			"anthropic/" + anthropic.Claude3Sonnet,
 			"anthropic/" + anthropic.Claude3Opus,
 			"fireworks/" + fireworks.Mixtral8x7bInstruct,
-			"fireworks/" + fireworks.Mixtral8x22,
+			"fireworks/" + fireworks.Mixtral8x22InstructPreview,
 			"openai/gpt-3.5-turbo",
 			"openai/gpt-4-turbo",
 			"openai/gpt-4-turbo-preview",


### PR DESCRIPTION
The base model wasn't useful for chat but now that Fireworks released the first IT version, let's use that instead :) 

https://twitter.com/FireworksAI_HQ/status/1778617118583586852

## Test plan

Trivial change, CI will test (and we will test on cody gatewat dev)

```
curl 'https://sourcegraph.test:3443/.api/completions/stream' -i \
-X POST \
-H 'authorization: token' \
--data-raw '{"messages":[{"speaker":"human","text":"What is your name?"}],"maxTokensToSample":30,"temperature":0,"stopSequences":[],"timeoutMs":5000,"stream":true,"model":"fireworks/accounts/fireworks/models/mixtral-8x22b-instruct-preview"}'
HTTP/2 200
access-control-allow-credentials: true
access-control-allow-origin:
alt-svc: h3=":3443"; ma=2592000
cache-control: no-cache
content-type: text/event-stream
date: Fri, 12 Apr 2024 09:06:15 GMT
server: Caddy
server: Caddy
set-cookie: sourcegraphDeviceId=12e1d2b1-ce45-41e9-b056-e24994a7896c; Expires=Sat, 12 Apr 2025 09:06:14 GMT; Secure
vary: Cookie, Accept-Encoding, Authorization, Cookie, Authorization, X-Requested-With, Cookie
x-accel-buffering: no
x-content-type-options: nosniff
x-frame-options: DENY
x-powered-by: Express
x-trace: 5b7f85ad135b2ae644db5791dff7b55e
x-trace-span: ce0e9f496653234c
x-trace-url: https://sourcegraph.test:3443/-/debug/jaeger/trace/5b7f85ad135b2ae644db5791dff7b55e
x-xss-protection: 1; mode=block

event: completion
data: {"completion":"","stopReason":""}

event: completion
data: {"completion":"My name","stopReason":""}

event: completion
data: {"completion":"My name is AI Helper.","stopReason":""}

event: completion
data: {"completion":"My name is AI Helper.","stopReason":"stop"}

event: done
data: {}
```