### PR TITLE
codeintel: Add fine-grained spans for uploads

### DIFF
--- a/internal/codeintel/uploads/internal/background/expirer/mocks_test.go
+++ b/internal/codeintel/uploads/internal/background/expirer/mocks_test.go
@@ -8932,7 +8932,7 @@ func NewMockLSIFStore() *MockLSIFStore {
 			},
 		},
 		NewSyntacticSCIPWriterFunc: &LSIFStoreNewSyntacticSCIPWriterFunc{
-			defaultHook: func(context.Context, int) (r0 lsifstore.SCIPWriter, r1 error) {
+			defaultHook: func(int) (r0 lsifstore.SCIPWriter, r1 error) {
 				return
 			},
 		},
@@ -8989,7 +8989,7 @@ func NewStrictMockLSIFStore() *MockLSIFStore {
 			},
 		},
 		NewSyntacticSCIPWriterFunc: &LSIFStoreNewSyntacticSCIPWriterFunc{
-			defaultHook: func(context.Context, int) (lsifstore.SCIPWriter, error) {
+			defaultHook: func(int) (lsifstore.SCIPWriter, error) {
 				panic("unexpected invocation of MockLSIFStore.NewSyntacticSCIPWriter")
 			},
 		},
@@ -9724,24 +9724,24 @@ func (c LSIFStoreNewPreciseSCIPWriterFuncCall) Results() []interface{} {
 // NewSyntacticSCIPWriter method of the parent MockLSIFStore instance is
 // invoked.
 type LSIFStoreNewSyntacticSCIPWriterFunc struct {
-	defaultHook func(context.Context, int) (lsifstore.SCIPWriter, error)
-	hooks       []func(context.Context, int) (lsifstore.SCIPWriter, error)
+	defaultHook func(int) (lsifstore.SCIPWriter, error)
+	hooks       []func(int) (lsifstore.SCIPWriter, error)
 	history     []LSIFStoreNewSyntacticSCIPWriterFuncCall
 	mutex       sync.Mutex
 }
 
 // NewSyntacticSCIPWriter delegates to the next hook function in the queue
 // and stores the parameter and result values of this invocation.
-func (m *MockLSIFStore) NewSyntacticSCIPWriter(v0 context.Context, v1 int) (lsifstore.SCIPWriter, error) {
-	r0, r1 := m.NewSyntacticSCIPWriterFunc.nextHook()(v0, v1)
-	m.NewSyntacticSCIPWriterFunc.appendCall(LSIFStoreNewSyntacticSCIPWriterFuncCall{v0, v1, r0, r1})
+func (m *MockLSIFStore) NewSyntacticSCIPWriter(v0 int) (lsifstore.SCIPWriter, error) {
+	r0, r1 := m.NewSyntacticSCIPWriterFunc.nextHook()(v0)
+	m.NewSyntacticSCIPWriterFunc.appendCall(LSIFStoreNewSyntacticSCIPWriterFuncCall{v0, r0, r1})
 	return r0, r1
 }
 
 // SetDefaultHook sets function that is called when the
 // NewSyntacticSCIPWriter method of the parent MockLSIFStore instance is
 // invoked and the hook queue is empty.
-func (f *LSIFStoreNewSyntacticSCIPWriterFunc) SetDefaultHook(hook func(context.Context, int) (lsifstore.SCIPWriter, error)) {
+func (f *LSIFStoreNewSyntacticSCIPWriterFunc) SetDefaultHook(hook func(int) (lsifstore.SCIPWriter, error)) {
 	f.defaultHook = hook
 }
 
@@ -9750,7 +9750,7 @@ func (f *LSIFStoreNewSyntacticSCIPWriterFunc) SetDefaultHook(hook func(context.C
 // invokes the hook at the front of the queue and discards it. After the
 // queue is empty, the default hook function is invoked for any future
 // action.
-func (f *LSIFStoreNewSyntacticSCIPWriterFunc) PushHook(hook func(context.Context, int) (lsifstore.SCIPWriter, error)) {
+func (f *LSIFStoreNewSyntacticSCIPWriterFunc) PushHook(hook func(int) (lsifstore.SCIPWriter, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -9759,19 +9759,19 @@ func (f *LSIFStoreNewSyntacticSCIPWriterFunc) PushHook(hook func(context.Context
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
 func (f *LSIFStoreNewSyntacticSCIPWriterFunc) SetDefaultReturn(r0 lsifstore.SCIPWriter, r1 error) {
-	f.SetDefaultHook(func(context.Context, int) (lsifstore.SCIPWriter, error) {
+	f.SetDefaultHook(func(int) (lsifstore.SCIPWriter, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
 func (f *LSIFStoreNewSyntacticSCIPWriterFunc) PushReturn(r0 lsifstore.SCIPWriter, r1 error) {
-	f.PushHook(func(context.Context, int) (lsifstore.SCIPWriter, error) {
+	f.PushHook(func(int) (lsifstore.SCIPWriter, error) {
 		return r0, r1
 	})
 }
 
-func (f *LSIFStoreNewSyntacticSCIPWriterFunc) nextHook() func(context.Context, int) (lsifstore.SCIPWriter, error) {
+func (f *LSIFStoreNewSyntacticSCIPWriterFunc) nextHook() func(int) (lsifstore.SCIPWriter, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -9807,10 +9807,7 @@ func (f *LSIFStoreNewSyntacticSCIPWriterFunc) History() []LSIFStoreNewSyntacticS
 type LSIFStoreNewSyntacticSCIPWriterFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
-	Arg0 context.Context
-	// Arg1 is the value of the 2nd argument passed to this method
-	// invocation.
-	Arg1 int
+	Arg0 int
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 lsifstore.SCIPWriter
@@ -9822,7 +9819,7 @@ type LSIFStoreNewSyntacticSCIPWriterFuncCall struct {
 // Args returns an interface slice containing the arguments of this
 // invocation.
 func (c LSIFStoreNewSyntacticSCIPWriterFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
+	return []interface{}{c.Arg0}
 }
 
 // Results returns an interface slice containing the results of this

--- a/internal/codeintel/uploads/internal/background/processor/mocks_test.go
+++ b/internal/codeintel/uploads/internal/background/processor/mocks_test.go
@@ -8746,7 +8746,7 @@ func NewMockLSIFStore() *MockLSIFStore {
 			},
 		},
 		NewSyntacticSCIPWriterFunc: &LSIFStoreNewSyntacticSCIPWriterFunc{
-			defaultHook: func(context.Context, int) (r0 lsifstore.SCIPWriter, r1 error) {
+			defaultHook: func(int) (r0 lsifstore.SCIPWriter, r1 error) {
 				return
 			},
 		},
@@ -8803,7 +8803,7 @@ func NewStrictMockLSIFStore() *MockLSIFStore {
 			},
 		},
 		NewSyntacticSCIPWriterFunc: &LSIFStoreNewSyntacticSCIPWriterFunc{
-			defaultHook: func(context.Context, int) (lsifstore.SCIPWriter, error) {
+			defaultHook: func(int) (lsifstore.SCIPWriter, error) {
 				panic("unexpected invocation of MockLSIFStore.NewSyntacticSCIPWriter")
 			},
 		},
@@ -9538,24 +9538,24 @@ func (c LSIFStoreNewPreciseSCIPWriterFuncCall) Results() []interface{} {
 // NewSyntacticSCIPWriter method of the parent MockLSIFStore instance is
 // invoked.
 type LSIFStoreNewSyntacticSCIPWriterFunc struct {
-	defaultHook func(context.Context, int) (lsifstore.SCIPWriter, error)
-	hooks       []func(context.Context, int) (lsifstore.SCIPWriter, error)
+	defaultHook func(int) (lsifstore.SCIPWriter, error)
+	hooks       []func(int) (lsifstore.SCIPWriter, error)
 	history     []LSIFStoreNewSyntacticSCIPWriterFuncCall
 	mutex       sync.Mutex
 }
 
 // NewSyntacticSCIPWriter delegates to the next hook function in the queue
 // and stores the parameter and result values of this invocation.
-func (m *MockLSIFStore) NewSyntacticSCIPWriter(v0 context.Context, v1 int) (lsifstore.SCIPWriter, error) {
-	r0, r1 := m.NewSyntacticSCIPWriterFunc.nextHook()(v0, v1)
-	m.NewSyntacticSCIPWriterFunc.appendCall(LSIFStoreNewSyntacticSCIPWriterFuncCall{v0, v1, r0, r1})
+func (m *MockLSIFStore) NewSyntacticSCIPWriter(v0 int) (lsifstore.SCIPWriter, error) {
+	r0, r1 := m.NewSyntacticSCIPWriterFunc.nextHook()(v0)
+	m.NewSyntacticSCIPWriterFunc.appendCall(LSIFStoreNewSyntacticSCIPWriterFuncCall{v0, r0, r1})
 	return r0, r1
 }
 
 // SetDefaultHook sets function that is called when the
 // NewSyntacticSCIPWriter method of the parent MockLSIFStore instance is
 // invoked and the hook queue is empty.
-func (f *LSIFStoreNewSyntacticSCIPWriterFunc) SetDefaultHook(hook func(context.Context, int) (lsifstore.SCIPWriter, error)) {
+func (f *LSIFStoreNewSyntacticSCIPWriterFunc) SetDefaultHook(hook func(int) (lsifstore.SCIPWriter, error)) {
 	f.defaultHook = hook
 }
 
@@ -9564,7 +9564,7 @@ func (f *LSIFStoreNewSyntacticSCIPWriterFunc) SetDefaultHook(hook func(context.C
 // invokes the hook at the front of the queue and discards it. After the
 // queue is empty, the default hook function is invoked for any future
 // action.
-func (f *LSIFStoreNewSyntacticSCIPWriterFunc) PushHook(hook func(context.Context, int) (lsifstore.SCIPWriter, error)) {
+func (f *LSIFStoreNewSyntacticSCIPWriterFunc) PushHook(hook func(int) (lsifstore.SCIPWriter, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -9573,19 +9573,19 @@ func (f *LSIFStoreNewSyntacticSCIPWriterFunc) PushHook(hook func(context.Context
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
 func (f *LSIFStoreNewSyntacticSCIPWriterFunc) SetDefaultReturn(r0 lsifstore.SCIPWriter, r1 error) {
-	f.SetDefaultHook(func(context.Context, int) (lsifstore.SCIPWriter, error) {
+	f.SetDefaultHook(func(int) (lsifstore.SCIPWriter, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
 func (f *LSIFStoreNewSyntacticSCIPWriterFunc) PushReturn(r0 lsifstore.SCIPWriter, r1 error) {
-	f.PushHook(func(context.Context, int) (lsifstore.SCIPWriter, error) {
+	f.PushHook(func(int) (lsifstore.SCIPWriter, error) {
 		return r0, r1
 	})
 }
 
-func (f *LSIFStoreNewSyntacticSCIPWriterFunc) nextHook() func(context.Context, int) (lsifstore.SCIPWriter, error) {
+func (f *LSIFStoreNewSyntacticSCIPWriterFunc) nextHook() func(int) (lsifstore.SCIPWriter, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -9621,10 +9621,7 @@ func (f *LSIFStoreNewSyntacticSCIPWriterFunc) History() []LSIFStoreNewSyntacticS
 type LSIFStoreNewSyntacticSCIPWriterFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
-	Arg0 context.Context
-	// Arg1 is the value of the 2nd argument passed to this method
-	// invocation.
-	Arg1 int
+	Arg0 int
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 lsifstore.SCIPWriter
@@ -9636,7 +9633,7 @@ type LSIFStoreNewSyntacticSCIPWriterFuncCall struct {
 // Args returns an interface slice containing the arguments of this
 // invocation.
 func (c LSIFStoreNewSyntacticSCIPWriterFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
+	return []interface{}{c.Arg0}
 }
 
 // Results returns an interface slice containing the results of this

--- a/internal/codeintel/uploads/internal/background/processor/scip.go
+++ b/internal/codeintel/uploads/internal/background/processor/scip.go
@@ -368,7 +368,7 @@ func writeSCIPDocuments(
 		var scipWriter lsifstore.SCIPWriter
 
 		if upload.Indexer == shared.SyntacticIndexer {
-			scipWriter, err = tx.NewSyntacticSCIPWriter(ctx, upload.ID)
+			scipWriter, err = tx.NewSyntacticSCIPWriter(upload.ID)
 		} else {
 			scipWriter, err = tx.NewPreciseSCIPWriter(ctx, upload.ID)
 		}

--- a/internal/codeintel/uploads/internal/lsifstore/BUILD.bazel
+++ b/internal/codeintel/uploads/internal/lsifstore/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
         "//internal/codeintel/shared/ranges",
         "//internal/codeintel/shared/trie",
         "//internal/codeintel/uploads/shared",
+        "//internal/collections",
         "//internal/database/basestore",
         "//internal/database/batch",
         "//internal/database/dbutil",

--- a/internal/codeintel/uploads/internal/lsifstore/insert.go
+++ b/internal/codeintel/uploads/internal/lsifstore/insert.go
@@ -5,20 +5,19 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
-	"sort"
-	"sync/atomic"
-
 	"github.com/keegancsmith/sqlf"
 	"github.com/lib/pq"
 	"github.com/sourcegraph/log"
 	"go.opentelemetry.io/otel/attribute"
 	"google.golang.org/protobuf/proto"
+	"sort"
 
 	"github.com/sourcegraph/scip/bindings/go/scip"
 
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/shared/ranges"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/shared/trie"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/uploads/shared"
+	"github.com/sourcegraph/sourcegraph/internal/collections"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/database/batch"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
@@ -100,12 +99,13 @@ INSERT INTO codeintel_scip_metadata (upload_id, text_document_encoding, tool_nam
 VALUES (%s, %s, %s, %s, %s, %s)
 `
 
-func (s *store) NewSyntacticSCIPWriter(ctx context.Context, uploadID int) (SCIPWriter, error) {
+func (s *store) NewSyntacticSCIPWriter(uploadID int) (SCIPWriter, error) {
 	scipWriter := &scipWriter{
 		uploadID:             uploadID,
 		db:                   s.db,
 		insertedSymbolsCount: 0,
 		isSyntactic:          true,
+		operations:           s.operations.writerOperations,
 	}
 	return scipWriter, nil
 }
@@ -151,6 +151,7 @@ func (s *store) NewPreciseSCIPWriter(ctx context.Context, uploadID int) (SCIPWri
 		symbolNameInserter:   symbolNameInserter,
 		symbolInserter:       symbolInserter,
 		insertedSymbolsCount: 0,
+		operations:           s.operations.writerOperations,
 	}
 
 	return scipWriter, nil
@@ -185,6 +186,7 @@ type scipWriter struct {
 	insertedSymbolsCount uint32
 	batchPayloadSum      int
 	batch                []bufferedDocument
+	operations           writerOperations
 }
 
 type bufferedDocument struct {
@@ -201,7 +203,7 @@ const (
 
 func (s *scipWriter) InsertDocument(ctx context.Context, path string, scipDocument *scip.Document) error {
 	if s.batchPayloadSum >= MaxBatchPayloadSum {
-		if err := s.flush(ctx); err != nil {
+		if err := s.flushDocuments(ctx); err != nil {
 			return err
 		}
 	}
@@ -225,19 +227,58 @@ func (s *scipWriter) InsertDocument(ctx context.Context, path string, scipDocume
 	s.batchPayloadSum += len(payload)
 
 	if len(s.batch) >= DocumentsBatchSize {
-		if err := s.flush(ctx); err != nil {
+		if err := s.flushDocuments(ctx); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func (s *scipWriter) flush(ctx context.Context) error {
+func (s *scipWriter) flushDocuments(ctx context.Context) error {
 	documents := s.batch
 	s.batch = nil
+	totalDocumentSize := s.batchPayloadSum
 	s.batchPayloadSum = 0
 
-	documentIDs, err := batch.WithInserterForIdentifiers(
+	documentIDs, err := s.insertDocuments(ctx, documents, totalDocumentSize)
+	if err != nil {
+		return err
+	}
+
+	documentLookupIDs, err := s.insertDocumentLookups(ctx, documents, documentIDs)
+	if err != nil {
+		return err
+	}
+
+	// We don't write symbols for syntactic indexes, because we can't perform
+	// fuzzy matching against the trie datastructure we build for symbols in the database
+	if s.isSyntactic {
+		return nil
+	}
+
+	invertedRangeIndexes, symbolNameTrie := s.constructTrie(ctx, documents)
+
+	idsBySymbolName := map[string]int{}
+	if err = s.insertSymbolNames(ctx, symbolNameTrie, idsBySymbolName); err != nil {
+		return err
+	}
+
+	if err = s.insertSymbols(ctx, invertedRangeIndexes, idsBySymbolName, documentLookupIDs); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Post-condition: len(documentIDs) == len(documents)
+func (s *scipWriter) insertDocuments(ctx context.Context, documents []bufferedDocument, totalDocumentSize int) (documentIDs []int, err error) {
+	ctx, _, endObservation := s.operations.insertDocuments.With(ctx, &err, observation.Args{Attrs: []attribute.KeyValue{
+		attribute.Int("numDocuments", len(documents)),
+		attribute.Int("totalDocumentSize", totalDocumentSize),
+	}})
+	defer endObservation(1, observation.Args{})
+
+	documentIDs, err = batch.WithInserterForIdentifiers(
 		ctx,
 		s.db.Handle(),
 		"codeintel_scip_documents",
@@ -255,13 +296,13 @@ func (s *scipWriter) flush(ctx context.Context) error {
 					return err
 				}
 			}
-
 			return nil
 		},
 	)
 	if err != nil {
-		return err
+		return nil, err
 	}
+
 	if len(documentIDs) != len(documents) {
 		hashes := make([][]byte, 0, len(documents))
 		hashSet := make(map[string]struct{}, len(documents))
@@ -274,18 +315,28 @@ func (s *scipWriter) flush(ctx context.Context) error {
 		}
 		idsByHash, err := scanIDsByHash(s.db.Query(ctx, sqlf.Sprintf(scipWriterWriteFetchDocumentsQuery, pq.Array(hashes))))
 		if err != nil {
-			return err
+			return nil, err
 		}
 		documentIDs = documentIDs[:0]
 		for _, document := range documents {
 			documentIDs = append(documentIDs, idsByHash[hex.EncodeToString(document.payloadHash)])
 		}
 		if len(idsByHash) != len(hashes) {
-			return errors.New("unexpected number of document records inserted/retrieved")
+			return nil, errors.New("unexpected number of document records inserted/retrieved")
 		}
 	}
 
-	documentLookupIDs, err := batch.WithInserterForIdentifiers(
+	return documentIDs, nil
+}
+
+// Pre-condition: len(documents) == len(documentIDs)
+func (s *scipWriter) insertDocumentLookups(ctx context.Context, documents []bufferedDocument, documentIDs []int) (documentLookupIDs []int, err error) {
+	ctx, _, endObservation := s.operations.insertDocumentLookups.With(ctx, &err, observation.Args{Attrs: []attribute.KeyValue{
+		attribute.Int("numDocuments", len(documents)),
+	}})
+	defer endObservation(1, observation.Args{})
+
+	documentLookupIDs, err = batch.WithInserterForIdentifiers(
 		ctx,
 		s.db.Handle(),
 		"codeintel_scip_document_lookup",
@@ -303,50 +354,69 @@ func (s *scipWriter) flush(ctx context.Context) error {
 					return err
 				}
 			}
-
 			return nil
 		},
 	)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	if len(documentLookupIDs) != len(documents) {
-		return errors.New("unexpected number of document lookup records inserted")
+		return nil, errors.New("unexpected number of document lookup records inserted")
 	}
 
-	return s.writeSymbols(ctx, documents, documentLookupIDs)
-
+	return documentLookupIDs, nil
 }
 
-func (s *scipWriter) writeSymbols(ctx context.Context, documents []bufferedDocument, documentLookupIDs []int) error {
-	// We don't write symbols for syntactic indexes, because we can't perform
-	// fuzzy matching against the trie datastructure we build for symbols in the database
-	if s.isSyntactic {
-		return nil
-	}
-	symbolNameMap := map[string]struct{}{}
+func ptrToZero() *int {
+	z := 0
+	return &z
+}
+
+func (s *scipWriter) constructTrie(ctx context.Context, documents []bufferedDocument) ([][]shared.InvertedRangeIndex, trie.Trie) {
+	var err error
+	_, _, endObservation := s.operations.constructTrie.With(ctx, &err, observation.Args{})
+	numSymbolNames := ptrToZero()
+	defer func() {
+		endObservation(1, observation.Args{Attrs: []attribute.KeyValue{
+			attribute.Int("numSymbolNames", *numSymbolNames),
+		}})
+	}()
+
+	symbolNameSet := collections.NewSet[string]()
 	invertedRangeIndexes := make([][]shared.InvertedRangeIndex, 0, len(documents))
 	for _, document := range documents {
 		index := shared.ExtractSymbolIndexes(document.scipDocument)
 		invertedRangeIndexes = append(invertedRangeIndexes, index)
 
 		for _, invertedRange := range index {
-			symbolNameMap[invertedRange.SymbolName] = struct{}{}
+			symbolNameSet.Add(invertedRange.SymbolName)
 		}
 	}
-	symbolNames := make([]string, 0, len(symbolNameMap))
-	for symbolName := range symbolNameMap {
+	symbolNames := make([]string, 0, len(symbolNameSet))
+	for symbolName := range symbolNameSet {
 		symbolNames = append(symbolNames, symbolName)
 	}
 	sort.Strings(symbolNames)
+	*numSymbolNames = len(symbolNames)
 
 	var symbolNameTrie trie.Trie
 	symbolNameTrie, s.nextID = trie.NewTrie(symbolNames, s.nextID)
+	return invertedRangeIndexes, symbolNameTrie
+}
+
+func (s *scipWriter) insertSymbolNames(ctx context.Context, symbolNameTrie trie.Trie, idsBySymbolName map[string]int) (err error) {
+	ctx, _, endObservation := s.operations.insertSymbolNames.With(ctx, &err, observation.Args{})
+	// In general, this number will be higher than numSymbolNames because of the prefix tree structure.
+	// For example, if making a prefix tree with ['abc','abd'] will give 3 nodes ['ab','c','d'].
+	symbolNameFragmentCount := ptrToZero()
+	defer func() {
+		endObservation(1, observation.Args{Attrs: []attribute.KeyValue{
+			attribute.Int("numSymbolNameFragments", *symbolNameFragmentCount),
+		}})
+	}()
 
 	symbolNameByIDs := map[int]string{}
-	idsBySymbolName := map[string]int{}
-
-	if err := symbolNameTrie.Traverse(func(id int, parentID *int, prefix string) error {
+	return symbolNameTrie.Traverse(func(id int, parentID *int, prefix string) error {
 		name := prefix
 		if parentID != nil {
 			parentPrefix, ok := symbolNameByIDs[*parentID]
@@ -362,11 +432,24 @@ func (s *scipWriter) writeSymbols(ctx context.Context, documents []bufferedDocum
 		if err := s.symbolNameInserter.Insert(ctx, id, prefix, parentID); err != nil {
 			return err
 		}
+		*symbolNameFragmentCount = *symbolNameFragmentCount + 1
 
 		return nil
-	}); err != nil {
-		return err
-	}
+	})
+}
+
+func (s *scipWriter) insertSymbols(ctx context.Context, invertedRangeIndexes [][]shared.InvertedRangeIndex, idsBySymbolName map[string]int, documentLookupIDs []int) (err error) {
+	ctx, _, endObservation := s.operations.insertSymbols.With(ctx, &err, observation.Args{Attrs: []attribute.KeyValue{
+		attribute.Int("numSymbolIDs", len(idsBySymbolName)),
+	}})
+	rangeCount := ptrToZero()
+	insertCount := ptrToZero()
+	defer func() {
+		endObservation(1, observation.Args{Attrs: []attribute.KeyValue{
+			attribute.Int("numRanges", *rangeCount),
+			attribute.Int("numInserts", *insertCount),
+		}})
+	}()
 
 	for i, invertedRangeIndexes := range invertedRangeIndexes {
 		for _, index := range invertedRangeIndexes {
@@ -386,6 +469,8 @@ func (s *scipWriter) writeSymbols(ctx context.Context, documents []bufferedDocum
 			if err != nil {
 				return err
 			}
+			*rangeCount = *rangeCount + ((len(index.DefinitionRanges) + len(index.ReferenceRanges) +
+				len(index.ImplementationRanges) + len(index.TypeDefinitionRanges)) / 4)
 
 			symbolID, ok := idsBySymbolName[index.SymbolName]
 			if !ok {
@@ -403,11 +488,10 @@ func (s *scipWriter) writeSymbols(ctx context.Context, documents []bufferedDocum
 			); err != nil {
 				return err
 			}
-
-			atomic.AddUint32(&s.insertedSymbolsCount, 1)
+			*insertCount = *insertCount + 1
+			s.insertedSymbolsCount = s.insertedSymbolsCount + 1
 		}
 	}
-
 	return nil
 }
 
@@ -420,32 +504,42 @@ WHERE payload_hash = ANY(%s)
 `
 
 func (s *scipWriter) Flush(ctx context.Context) (uint32, error) {
-	// Flush all buffered documents
-	if err := s.flush(ctx); err != nil {
+	if err := s.flushDocuments(ctx); err != nil {
 		return 0, err
 	}
-
 	// We don't need to flush symbols for syntactic indexes, as we don't write any for them
 	if s.isSyntactic {
 		return s.insertedSymbolsCount, nil
 	}
-
-	// Flush all symbols data into temp tables
-	if err := s.symbolNameInserter.Flush(ctx); err != nil {
+	if err := s.flushSymbolNames(ctx); err != nil {
 		return 0, err
 	}
-	if err := s.symbolInserter.Flush(ctx); err != nil {
-		return 0, err
-	}
-
-	// Move all symbols data from temp tables into target tables
-	if err := s.db.Exec(ctx, sqlf.Sprintf(scipWriterFlushSymbolNamesQuery, s.uploadID)); err != nil {
-		return 0, err
-	}
-	if err := s.db.Exec(ctx, sqlf.Sprintf(scipWriterFlushSymbolsQuery, s.uploadID, 1)); err != nil {
+	if err := s.flushSymbols(ctx); err != nil {
 		return 0, err
 	}
 	return s.insertedSymbolsCount, nil
+}
+
+func (s *scipWriter) flushSymbols(ctx context.Context) (err error) {
+	ctx, _, endObservation := s.operations.flushSymbols.With(ctx, &err, observation.Args{})
+	defer endObservation(1, observation.Args{})
+
+	if err := s.symbolInserter.Flush(ctx); err != nil {
+		return err
+	}
+	return s.db.Exec(ctx, sqlf.Sprintf(scipWriterFlushSymbolsQuery, s.uploadID, 1))
+}
+
+func (s *scipWriter) flushSymbolNames(ctx context.Context) (err error) {
+	ctx, _, endObservation := s.operations.flushSymbolNames.With(ctx, &err, observation.Args{})
+	defer endObservation(1, observation.Args{})
+
+	// Flush all symbols data into temp tables
+	if err := s.symbolNameInserter.Flush(ctx); err != nil {
+		return err
+	}
+	// Move all data from temp tables into target tables
+	return s.db.Exec(ctx, sqlf.Sprintf(scipWriterFlushSymbolNamesQuery, s.uploadID))
 }
 
 const scipWriterFlushSymbolNamesQuery = `

--- a/internal/codeintel/uploads/internal/lsifstore/observability.go
+++ b/internal/codeintel/uploads/internal/lsifstore/observability.go
@@ -13,6 +13,17 @@ type operations struct {
 	reconcileCandidates         *observation.Operation
 	deleteLsifDataByUploadIds   *observation.Operation
 	deleteUnreferencedDocuments *observation.Operation
+	writerOperations            writerOperations
+}
+
+type writerOperations struct {
+	insertDocuments       *observation.Operation
+	insertDocumentLookups *observation.Operation
+	constructTrie         *observation.Operation
+	insertSymbolNames     *observation.Operation
+	insertSymbols         *observation.Operation
+	flushSymbolNames      *observation.Operation
+	flushSymbols          *observation.Operation
 }
 
 var m = new(metrics.SingletonREDMetrics)
@@ -41,5 +52,14 @@ func newOperations(observationCtx *observation.Context) *operations {
 		reconcileCandidates:         op("ReconcileCandidates"),
 		deleteLsifDataByUploadIds:   op("DeleteLsifDataByUploadIds"),
 		deleteUnreferencedDocuments: op("DeleteUnreferencedDocuments"),
+		writerOperations: writerOperations{
+			insertDocuments:       op("InsertDocuments"),
+			insertDocumentLookups: op("InsertDocumentLookups"),
+			constructTrie:         op("ConstructTrie"),
+			insertSymbols:         op("InsertSymbols"),
+			insertSymbolNames:     op("InsertSymbolNames"),
+			flushSymbolNames:      op("flushSymbolNames"),
+			flushSymbols:          op("flushSymbols"),
+		},
 	}
 }

--- a/internal/codeintel/uploads/internal/lsifstore/store.go
+++ b/internal/codeintel/uploads/internal/lsifstore/store.go
@@ -17,7 +17,7 @@ type Store interface {
 	// Insert
 	InsertMetadata(ctx context.Context, uploadID int, meta ProcessedMetadata) error
 	NewPreciseSCIPWriter(ctx context.Context, uploadID int) (SCIPWriter, error)
-	NewSyntacticSCIPWriter(ctx context.Context, uploadID int) (SCIPWriter, error)
+	NewSyntacticSCIPWriter(uploadID int) (SCIPWriter, error)
 
 	// Reconciliation and cleanup
 	IDsWithMeta(ctx context.Context, ids []int) ([]int, error)

--- a/internal/codeintel/uploads/mocks_test.go
+++ b/internal/codeintel/uploads/mocks_test.go
@@ -8471,7 +8471,7 @@ func NewMockLSIFStore() *MockLSIFStore {
 			},
 		},
 		NewSyntacticSCIPWriterFunc: &LSIFStoreNewSyntacticSCIPWriterFunc{
-			defaultHook: func(context.Context, int) (r0 lsifstore.SCIPWriter, r1 error) {
+			defaultHook: func(int) (r0 lsifstore.SCIPWriter, r1 error) {
 				return
 			},
 		},
@@ -8528,7 +8528,7 @@ func NewStrictMockLSIFStore() *MockLSIFStore {
 			},
 		},
 		NewSyntacticSCIPWriterFunc: &LSIFStoreNewSyntacticSCIPWriterFunc{
-			defaultHook: func(context.Context, int) (lsifstore.SCIPWriter, error) {
+			defaultHook: func(int) (lsifstore.SCIPWriter, error) {
 				panic("unexpected invocation of MockLSIFStore.NewSyntacticSCIPWriter")
 			},
 		},
@@ -9263,24 +9263,24 @@ func (c LSIFStoreNewPreciseSCIPWriterFuncCall) Results() []interface{} {
 // NewSyntacticSCIPWriter method of the parent MockLSIFStore instance is
 // invoked.
 type LSIFStoreNewSyntacticSCIPWriterFunc struct {
-	defaultHook func(context.Context, int) (lsifstore.SCIPWriter, error)
-	hooks       []func(context.Context, int) (lsifstore.SCIPWriter, error)
+	defaultHook func(int) (lsifstore.SCIPWriter, error)
+	hooks       []func(int) (lsifstore.SCIPWriter, error)
 	history     []LSIFStoreNewSyntacticSCIPWriterFuncCall
 	mutex       sync.Mutex
 }
 
 // NewSyntacticSCIPWriter delegates to the next hook function in the queue
 // and stores the parameter and result values of this invocation.
-func (m *MockLSIFStore) NewSyntacticSCIPWriter(v0 context.Context, v1 int) (lsifstore.SCIPWriter, error) {
-	r0, r1 := m.NewSyntacticSCIPWriterFunc.nextHook()(v0, v1)
-	m.NewSyntacticSCIPWriterFunc.appendCall(LSIFStoreNewSyntacticSCIPWriterFuncCall{v0, v1, r0, r1})
+func (m *MockLSIFStore) NewSyntacticSCIPWriter(v0 int) (lsifstore.SCIPWriter, error) {
+	r0, r1 := m.NewSyntacticSCIPWriterFunc.nextHook()(v0)
+	m.NewSyntacticSCIPWriterFunc.appendCall(LSIFStoreNewSyntacticSCIPWriterFuncCall{v0, r0, r1})
 	return r0, r1
 }
 
 // SetDefaultHook sets function that is called when the
 // NewSyntacticSCIPWriter method of the parent MockLSIFStore instance is
 // invoked and the hook queue is empty.
-func (f *LSIFStoreNewSyntacticSCIPWriterFunc) SetDefaultHook(hook func(context.Context, int) (lsifstore.SCIPWriter, error)) {
+func (f *LSIFStoreNewSyntacticSCIPWriterFunc) SetDefaultHook(hook func(int) (lsifstore.SCIPWriter, error)) {
 	f.defaultHook = hook
 }
 
@@ -9289,7 +9289,7 @@ func (f *LSIFStoreNewSyntacticSCIPWriterFunc) SetDefaultHook(hook func(context.C
 // invokes the hook at the front of the queue and discards it. After the
 // queue is empty, the default hook function is invoked for any future
 // action.
-func (f *LSIFStoreNewSyntacticSCIPWriterFunc) PushHook(hook func(context.Context, int) (lsifstore.SCIPWriter, error)) {
+func (f *LSIFStoreNewSyntacticSCIPWriterFunc) PushHook(hook func(int) (lsifstore.SCIPWriter, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -9298,19 +9298,19 @@ func (f *LSIFStoreNewSyntacticSCIPWriterFunc) PushHook(hook func(context.Context
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
 func (f *LSIFStoreNewSyntacticSCIPWriterFunc) SetDefaultReturn(r0 lsifstore.SCIPWriter, r1 error) {
-	f.SetDefaultHook(func(context.Context, int) (lsifstore.SCIPWriter, error) {
+	f.SetDefaultHook(func(int) (lsifstore.SCIPWriter, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
 func (f *LSIFStoreNewSyntacticSCIPWriterFunc) PushReturn(r0 lsifstore.SCIPWriter, r1 error) {
-	f.PushHook(func(context.Context, int) (lsifstore.SCIPWriter, error) {
+	f.PushHook(func(int) (lsifstore.SCIPWriter, error) {
 		return r0, r1
 	})
 }
 
-func (f *LSIFStoreNewSyntacticSCIPWriterFunc) nextHook() func(context.Context, int) (lsifstore.SCIPWriter, error) {
+func (f *LSIFStoreNewSyntacticSCIPWriterFunc) nextHook() func(int) (lsifstore.SCIPWriter, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -9346,10 +9346,7 @@ func (f *LSIFStoreNewSyntacticSCIPWriterFunc) History() []LSIFStoreNewSyntacticS
 type LSIFStoreNewSyntacticSCIPWriterFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
-	Arg0 context.Context
-	// Arg1 is the value of the 2nd argument passed to this method
-	// invocation.
-	Arg1 int
+	Arg0 int
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 lsifstore.SCIPWriter
@@ -9361,7 +9358,7 @@ type LSIFStoreNewSyntacticSCIPWriterFuncCall struct {
 // Args returns an interface slice containing the arguments of this
 // invocation.
 func (c LSIFStoreNewSyntacticSCIPWriterFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
+	return []interface{}{c.Arg0}
 }
 
 // Results returns an interface slice containing the results of this


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/61822
Fixes ENG-23610

Mostly, this PR splits up the code involved in writing data to various tables into
smaller functions, each of which has its own span for traces. The patch respects
the changes made by Christoph for syntactic indexes.

With this patch, we can see more fine-grained information in Jaeger's statistics view
when traces are enabled.

![CleanShot 2024-04-12 at 19 22 37@2x](https://github.com/sourcegraph/sourcegraph/assets/93103176/e2da84fa-9511-4db5-b98f-68547662a9e3)

## Test plan

Manually performed some uploads. Covered by existing tests.