### PR TITLE
ci: separate combined --repository flags into individual commands in push_all.sh

### DIFF
--- a/dev/ci/push_all.sh
+++ b/dev/ci/push_all.sh
@@ -65,19 +65,16 @@ function create_push_command() {
     repository="scip-ctags"
   fi
 
-  repositories_args=""
   for registry in "${registries[@]}"; do
-    repositories_args="$repositories_args --repository ${registry}/${repository}"
+    cmd="bazel \
+      ${bazelrc[*]} \
+      run \
+      $target \
+      --stamp \
+      --workspace_status_command=./dev/bazel_stamp_vars.sh"
+
+    echo "$cmd -- $tags_args --repository ${registry}/${repository} && $(echo_append_annotation "$repository" "${registries[@]}" "${tags_args[@]}")"
   done
-
-  cmd="bazel \
-    ${bazelrc[*]} \
-    run \
-    $target \
-    --stamp \
-    --workspace_status_command=./dev/bazel_stamp_vars.sh"
-
-  echo "$cmd -- $tags_args $repositories_args && $(echo_append_annotation "$repository" "${registries[@]}" "${tags_args[@]}")"
 }
 
 dev_registries=(


### PR DESCRIPTION
Previously we would pass >=1 values for the `--repository` flag to `oci_push` targets when pushing images. This isn't actually supported[[1]](https://sourcegraph.com/github.com/bazel-contrib/rules_oci@bde8b2e31977a7d74523e152509a80c9945cbeea/-/blob/oci/private/push.sh.tpl)[[2]](https://github.com/bazel-contrib/rules_oci/issues/248), resulting in all but the last value passed in a single `bazel run <oci_push target>` being ignored. This manifested in us not pushing some images to index.docker.io when a command looked like `bazel run //cmd/<target>:candidate_push --tag insiders --repository index.docker.io/sourcegraph/<target> --repository us-docker.pkg.dev/sourcegraph-public-images/<target>`


## Test plan

CI on main