### PR TITLE
Revert "Remove unused internal/k8s package"

### DIFF
--- a/internal/k8s/resource/BUILD.bazel
+++ b/internal/k8s/resource/BUILD.bazel
@@ -1,0 +1,8 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "resource",
+    srcs = ["doc.go"],
+    importpath = "github.com/sourcegraph/sourcegraph/internal/k8s/resource",
+    visibility = ["//:__subpackages__"],
+)

--- a/internal/k8s/resource/configmap/BUILD.bazel
+++ b/internal/k8s/resource/configmap/BUILD.bazel
@@ -1,0 +1,31 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("//dev:go_defs.bzl", "go_test")
+
+go_library(
+    name = "configmap",
+    srcs = ["configmap.go"],
+    importpath = "github.com/sourcegraph/sourcegraph/internal/k8s/resource/configmap",
+    visibility = ["//:__subpackages__"],
+    deps = [
+        "//internal/maps",
+        "//lib/pointers",
+        "@io_k8s_api//core/v1:core",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:meta",
+    ],
+)
+
+go_test(
+    name = "configmap_test",
+    srcs = [
+        "configmap_test.go",
+        "example_test.go",
+    ],
+    embed = [":configmap"],
+    deps = [
+        "//lib/pointers",
+        "@com_github_google_go_cmp//cmp",
+        "@io_k8s_api//core/v1:core",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:meta",
+        "@io_k8s_sigs_yaml//:yaml",
+    ],
+)

--- a/internal/k8s/resource/configmap/configmap.go
+++ b/internal/k8s/resource/configmap/configmap.go
@@ -1,0 +1,81 @@
+package configmap
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/sourcegraph/sourcegraph/internal/maps"
+	"github.com/sourcegraph/sourcegraph/lib/pointers"
+)
+
+// NewConfigMap creates a new k8s ConfigMap with default values.
+//
+// Default values include:
+//
+//   - Immutable set to false.
+//
+// Additional options can be passed to modify the default values.
+func NewConfigMap(name, namespace string, options ...Option) (corev1.ConfigMap, error) {
+	configMap := corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				"deploy": "sourcegraph",
+			},
+		},
+		Immutable: pointers.Ptr(false),
+	}
+
+	// apply any given options
+	for _, opt := range options {
+		err := opt(&configMap)
+		if err != nil {
+			return corev1.ConfigMap{}, err
+		}
+	}
+	return configMap, nil
+}
+
+// Option sets an option for a ConfigMap.
+type Option func(configMap *corev1.ConfigMap) error
+
+// WithLabels set ConfigMap labels without overriding existing labels.
+func WithLabels(labels map[string]string) Option {
+	return func(configMap *corev1.ConfigMap) error {
+		configMap.Labels = maps.MergePreservingExistingKeys(configMap.Labels, labels)
+		return nil
+	}
+}
+
+// WithAnnotations set ConfigMap annotations without overriding existing annotations.
+func WithAnnotations(annotations map[string]string) Option {
+	return func(configMap *corev1.ConfigMap) error {
+		configMap.Annotations = maps.MergePreservingExistingKeys(configMap.Annotations, annotations)
+		return nil
+	}
+}
+
+// Immutable sets a ConfigMap to be immutable.
+func Immutable() Option {
+	return func(configMap *corev1.ConfigMap) error {
+		configMap.Immutable = pointers.Ptr(true)
+		return nil
+	}
+}
+
+// WithData sets the given string data to a ConfigMap.
+func WithData(data map[string]string) Option {
+	return func(configMap *corev1.ConfigMap) error {
+		configMap.Data = data
+		return nil
+	}
+}
+
+// WithBinaryData sets the given binary data to a ConfigMap.
+func WithBinaryData(data map[string][]byte) Option {
+	return func(configMap *corev1.ConfigMap) error {
+		configMap.BinaryData = data
+		return nil
+	}
+}

--- a/internal/k8s/resource/configmap/configmap_test.go
+++ b/internal/k8s/resource/configmap/configmap_test.go
@@ -1,0 +1,177 @@
+package configmap
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/sourcegraph/sourcegraph/lib/pointers"
+)
+
+func TestNewConfigMap(t *testing.T) {
+	t.Parallel()
+
+	type args struct {
+		name      string
+		namespace string
+		options   []Option
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want corev1.ConfigMap
+	}{
+		{
+			name: "default configmap",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+			},
+			want: corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph",
+					},
+				},
+				Immutable: pointers.Ptr(false),
+			},
+		},
+		{
+			name: "with labels",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithLabels(map[string]string{
+						"foo": "bar",
+					}),
+				},
+			},
+			want: corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph",
+						"foo":    "bar",
+					},
+				},
+				Immutable: pointers.Ptr(false),
+			},
+		},
+		{
+			name: "with annotations",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithAnnotations(map[string]string{
+						"foo": "bar",
+					}),
+				},
+			},
+			want: corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph",
+					},
+					Annotations: map[string]string{
+						"foo": "bar",
+					},
+				},
+				Immutable: pointers.Ptr(false),
+			},
+		},
+		{
+			name: "immutable",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					Immutable(),
+				},
+			},
+			want: corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph",
+					},
+				},
+				Immutable: pointers.Ptr(true),
+			},
+		},
+		{
+			name: "with data",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithData(map[string]string{
+						"data": "foo",
+					}),
+				},
+			},
+			want: corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph",
+					},
+				},
+				Immutable: pointers.Ptr(false),
+				Data: map[string]string{
+					"data": "foo",
+				},
+			},
+		},
+		{
+			name: "with binary data",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithBinaryData(map[string][]byte{
+						"data": []byte("foo"),
+					}),
+				},
+			},
+			want: corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph",
+					},
+				},
+				Immutable: pointers.Ptr(false),
+				Data:      nil,
+				BinaryData: map[string][]byte{
+					"data": []byte("foo"),
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := NewConfigMap(tt.args.name, tt.args.namespace, tt.args.options...)
+			if err != nil {
+				t.Errorf("NewConfigMap() error: %v", err)
+			}
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("NewConfigMap() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/internal/k8s/resource/configmap/example_test.go
+++ b/internal/k8s/resource/configmap/example_test.go
@@ -1,0 +1,28 @@
+package configmap
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"sigs.k8s.io/yaml"
+)
+
+func ExampleConfigMap() {
+	cm, _ := NewConfigMap("test", "sourcegraph")
+
+	jcm, _ := json.Marshal(cm)
+	fmt.Println(string(jcm))
+
+	ycm, _ := yaml.Marshal(cm)
+	fmt.Println(string(ycm))
+
+	// Output:
+	// {"metadata":{"name":"test","namespace":"sourcegraph","creationTimestamp":null,"labels":{"deploy":"sourcegraph"}},"immutable":false}
+	// immutable: false
+	// metadata:
+	//   creationTimestamp: null
+	//   labels:
+	//     deploy: sourcegraph
+	//   name: test
+	//   namespace: sourcegraph
+}

--- a/internal/k8s/resource/container/BUILD.bazel
+++ b/internal/k8s/resource/container/BUILD.bazel
@@ -1,0 +1,33 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("//dev:go_defs.bzl", "go_test")
+
+go_library(
+    name = "container",
+    srcs = ["container.go"],
+    importpath = "github.com/sourcegraph/sourcegraph/internal/k8s/resource/container",
+    visibility = ["//:__subpackages__"],
+    deps = [
+        "//lib/pointers",
+        "@io_k8s_api//core/v1:core",
+        "@io_k8s_apimachinery//pkg/api/resource",
+        "@io_k8s_apimachinery//pkg/util/intstr",
+    ],
+)
+
+go_test(
+    name = "container_test",
+    srcs = [
+        "container_test.go",
+        "example_test.go",
+    ],
+    embed = [":container"],
+    deps = [
+        "//lib/pointers",
+        "@com_github_google_go_cmp//cmp",
+        "@io_k8s_api//core/v1:core",
+        "@io_k8s_apimachinery//pkg/api/resource",
+        "@io_k8s_apimachinery//pkg/util/intstr",
+        "@io_k8s_sigs_yaml//:yaml",
+        "@io_k8s_utils//pointer",
+    ],
+)

--- a/internal/k8s/resource/container/container.go
+++ b/internal/k8s/resource/container/container.go
@@ -1,0 +1,264 @@
+package container
+
+import (
+	"sort"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	"github.com/sourcegraph/sourcegraph/lib/pointers"
+)
+
+// NewContainer creates a new k8s Container with default values.
+//
+// Default values include:
+//
+//   - ImagePullPolicy: PullIfNotPresent
+//   - TerminationMessagePolicy: TerminationMessageFallbackToLogsOnError
+//   - CPU/memory resource limits and requests.
+//   - SecurityContext with defaults.
+//
+// Additional options can be passed to modify the default values.
+func NewContainer(name string, options ...Option) (corev1.Container, error) {
+	container := corev1.Container{
+		Name:                     name,
+		ImagePullPolicy:          corev1.PullIfNotPresent,
+		TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
+		Resources: corev1.ResourceRequirements{
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("1"),
+				corev1.ResourceMemory: resource.MustParse("500Mi"),
+			},
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("500m"),
+				corev1.ResourceMemory: resource.MustParse("100Mi"),
+			},
+		},
+		SecurityContext: &corev1.SecurityContext{
+			RunAsUser:                pointers.Ptr[int64](100),
+			RunAsGroup:               pointers.Ptr[int64](101),
+			AllowPrivilegeEscalation: pointers.Ptr(false),
+			ReadOnlyRootFilesystem:   pointers.Ptr(true),
+		},
+	}
+
+	// apply any given options
+	for _, opt := range options {
+		err := opt(&container)
+		if err != nil {
+			return corev1.Container{}, err
+		}
+	}
+
+	return container, nil
+}
+
+// Option sets an option for a Container.
+type Option func(container *corev1.Container) error
+
+// WithImage sets the image field on the Container.
+func WithImage(image string) Option {
+	return func(container *corev1.Container) error {
+		container.Image = image
+		return nil
+	}
+}
+
+// WithCommand sets the command field on the Container to the provided
+// command and arguments.
+func WithCommand(command ...string) Option {
+	return func(container *corev1.Container) error {
+		container.Command = command
+		return nil
+	}
+}
+
+// WithArgs sets the args field on the Container to the provided arguments.
+func WithArgs(args ...string) Option {
+	return func(container *corev1.Container) error {
+		container.Args = args
+		return nil
+	}
+}
+
+// WithWorkingDir sets the working directory on the Container.
+func WithWorkingDir(dir string) Option {
+	return func(container *corev1.Container) error {
+		container.WorkingDir = dir
+		return nil
+	}
+}
+
+// WithPorts adds the provided ContainerPorts to the Container if they do not already exist.
+// It also sorts the ports by name for accurate comparison of resources.
+func WithPorts(ports ...corev1.ContainerPort) Option {
+	return func(container *corev1.Container) error {
+		for _, p := range ports {
+			if !portExists(p.Name, container) {
+				container.Ports = append(container.Ports, p)
+			}
+		}
+
+		// sort ports by names
+		sort.SliceStable(container.Ports, func(i, j int) bool {
+			return container.Ports[i].Name < container.Ports[j].Name
+		})
+		return nil
+	}
+}
+
+func portExists(name string, container *corev1.Container) bool {
+	for _, p := range container.Ports {
+		if p.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+// WithEnv adds the provided EnvVars to the Container if they do not already exist.
+func WithEnv(vars ...corev1.EnvVar) Option {
+	return func(container *corev1.Container) error {
+		for _, v := range vars {
+			if envExists(v.Name, container) {
+				continue
+			}
+			container.Env = append(container.Env, v)
+		}
+		return nil
+	}
+}
+
+func envExists(name string, container *corev1.Container) bool {
+	for _, env := range container.Env {
+		if env.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+// WithResources sets the given ResourceRequirements on the Container.
+func WithResources(resources corev1.ResourceRequirements) Option {
+	return func(container *corev1.Container) error {
+		container.Resources = resources
+		return nil
+	}
+}
+
+// WithVolumeMounts adds the provided VolumeMounts to the Container if they do not already exist.
+// It also sorts the VolumeMounts by name for accurate comparison of resources.
+func WithVolumeMounts(volumeMounts []corev1.VolumeMount) Option {
+	return func(container *corev1.Container) error {
+		for _, v := range volumeMounts {
+			if !volumeMountExists(v, container) {
+				container.VolumeMounts = append(container.VolumeMounts, v)
+			}
+		}
+
+		sort.SliceStable(container.VolumeMounts, func(i, j int) bool {
+			return container.VolumeMounts[i].Name < container.VolumeMounts[j].Name
+		})
+		return nil
+	}
+}
+
+func volumeMountExists(volumeMount corev1.VolumeMount, container *corev1.Container) bool {
+	for _, volMount := range container.VolumeMounts {
+		if volMount.Name == volumeMount.Name || volMount.MountPath == volumeMount.MountPath {
+			return true
+		}
+	}
+	return false
+}
+
+// WithLivenessProbe sets the given *corev1.Probe as the LivenessProbe on the Container.
+func WithLivenessProbe(livenessProbe *corev1.Probe) Option {
+	return func(container *corev1.Container) error {
+		container.LivenessProbe = livenessProbe
+		return nil
+	}
+}
+
+// WithDefaultLivenessProbe sets a default LivenessProbe on the Container
+// that is commonly used for Sourcegraph services.
+//
+// The default probe is:
+//
+//	&corev1.Probe{
+//		ProbeHandler: corev1.ProbeHandler{
+//			HTTPGet: &corev1.HTTPGetAction{
+//				Path:   "/",
+//				Port:   intstr.FromString(container.Name),
+//				Scheme: corev1.URISchemeHTTP,
+//			},
+//		},
+//		InitialDelaySeconds: 60,
+//		TimeoutSeconds:      5,
+//	}
+func WithDefaultLivenessProbe() Option {
+	return func(container *corev1.Container) error {
+		container.LivenessProbe = &corev1.Probe{
+			ProbeHandler: corev1.ProbeHandler{
+				HTTPGet: &corev1.HTTPGetAction{
+					Path:   "/",
+					Port:   intstr.FromString(container.Name),
+					Scheme: corev1.URISchemeHTTP,
+				},
+			},
+			InitialDelaySeconds: 60,
+			TimeoutSeconds:      5,
+		}
+		return nil
+	}
+}
+
+// WithReadinessProbe sets the given *corev1.Probe as the ReadinessProbe on the Container.
+func WithReadinessProbe(readinessProbe *corev1.Probe) Option {
+	return func(container *corev1.Container) error {
+		container.ReadinessProbe = readinessProbe
+		return nil
+	}
+}
+
+// WithDefaultReadinessProbe sets a default ReadinessProbe on the Container
+// that is commonly used for Sourcegraph services.
+//
+// The default probe is:
+//
+//	&corev1.Probe{
+//		ProbeHandler: corev1.ProbeHandler{
+//			HTTPGet: &corev1.HTTPGetAction{
+//				Path:   "/",
+//				Port:   intstr.FromString(container.Name),
+//				Scheme: corev1.URISchemeHTTP,
+//			},
+//		},
+//		PeriodSeconds:  5,
+//		TimeoutSeconds: 5,
+//	}
+func WithDefaultReadinessProbe() Option {
+	return func(container *corev1.Container) error {
+		container.ReadinessProbe = &corev1.Probe{
+			ProbeHandler: corev1.ProbeHandler{
+				HTTPGet: &corev1.HTTPGetAction{
+					Path:   "/",
+					Port:   intstr.FromString(container.Name),
+					Scheme: corev1.URISchemeHTTP,
+				},
+			},
+			PeriodSeconds:  5,
+			TimeoutSeconds: 5,
+		}
+		return nil
+	}
+}
+
+// WithSecurityContext sets the given corev1.SecurityContext on the Container.
+func WithSecurityContext(securityContext corev1.SecurityContext) Option {
+	return func(container *corev1.Container) error {
+		container.SecurityContext = &securityContext
+		return nil
+	}
+}

--- a/internal/k8s/resource/container/container_test.go
+++ b/internal/k8s/resource/container/container_test.go
@@ -1,0 +1,639 @@
+package container
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/pointer"
+
+	"github.com/sourcegraph/sourcegraph/lib/pointers"
+)
+
+func TestNewContainer(t *testing.T) {
+	t.Parallel()
+
+	type args struct {
+		name    string
+		options []Option
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want corev1.Container
+	}{
+		{
+			name: "default container",
+			args: args{
+				name: "foo",
+			},
+			want: corev1.Container{
+				Name:                     "foo",
+				ImagePullPolicy:          corev1.PullIfNotPresent,
+				TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("1"),
+						corev1.ResourceMemory: resource.MustParse("500Mi"),
+					},
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("500m"),
+						corev1.ResourceMemory: resource.MustParse("100Mi"),
+					},
+				},
+				SecurityContext: &corev1.SecurityContext{
+					RunAsUser:                pointers.Ptr[int64](100),
+					RunAsGroup:               pointers.Ptr[int64](101),
+					AllowPrivilegeEscalation: pointers.Ptr(false),
+					ReadOnlyRootFilesystem:   pointers.Ptr(true),
+				},
+			},
+		},
+		{
+			name: "with image",
+			args: args{
+				name: "foo",
+				options: []Option{
+					WithImage("ghcr.io/sourcegraph/service"),
+				},
+			},
+			want: corev1.Container{
+				Name:                     "foo",
+				ImagePullPolicy:          corev1.PullIfNotPresent,
+				Image:                    "ghcr.io/sourcegraph/service",
+				TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("1"),
+						corev1.ResourceMemory: resource.MustParse("500Mi"),
+					},
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("500m"),
+						corev1.ResourceMemory: resource.MustParse("100Mi"),
+					},
+				},
+				SecurityContext: &corev1.SecurityContext{
+					RunAsUser:                pointers.Ptr[int64](100),
+					RunAsGroup:               pointers.Ptr[int64](101),
+					AllowPrivilegeEscalation: pointers.Ptr(false),
+					ReadOnlyRootFilesystem:   pointers.Ptr(true),
+				},
+			},
+		},
+		{
+			name: "with command",
+			args: args{
+				name: "foo",
+				options: []Option{
+					WithCommand("ls", "-a"),
+				},
+			},
+			want: corev1.Container{
+				Name:                     "foo",
+				ImagePullPolicy:          corev1.PullIfNotPresent,
+				TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
+				Command: []string{
+					"ls",
+					"-a",
+				},
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("1"),
+						corev1.ResourceMemory: resource.MustParse("500Mi"),
+					},
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("500m"),
+						corev1.ResourceMemory: resource.MustParse("100Mi"),
+					},
+				},
+				SecurityContext: &corev1.SecurityContext{
+					RunAsUser:                pointers.Ptr[int64](100),
+					RunAsGroup:               pointers.Ptr[int64](101),
+					AllowPrivilegeEscalation: pointers.Ptr(false),
+					ReadOnlyRootFilesystem:   pointers.Ptr(true),
+				},
+			},
+		},
+		{
+			name: "with args",
+			args: args{
+				name: "foo",
+				options: []Option{
+					WithArgs("foo", "bar"),
+				},
+			},
+			want: corev1.Container{
+				Name:                     "foo",
+				ImagePullPolicy:          corev1.PullIfNotPresent,
+				TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
+				Args: []string{
+					"foo",
+					"bar",
+				},
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("1"),
+						corev1.ResourceMemory: resource.MustParse("500Mi"),
+					},
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("500m"),
+						corev1.ResourceMemory: resource.MustParse("100Mi"),
+					},
+				},
+				SecurityContext: &corev1.SecurityContext{
+					RunAsUser:                pointers.Ptr[int64](100),
+					RunAsGroup:               pointers.Ptr[int64](101),
+					AllowPrivilegeEscalation: pointers.Ptr(false),
+					ReadOnlyRootFilesystem:   pointers.Ptr(true),
+				},
+			},
+		},
+		{
+			name: "with working dir",
+			args: args{
+				name: "foo",
+				options: []Option{
+					WithWorkingDir("/home/foo"),
+				},
+			},
+			want: corev1.Container{
+				Name:                     "foo",
+				ImagePullPolicy:          corev1.PullIfNotPresent,
+				TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
+				WorkingDir:               "/home/foo",
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("1"),
+						corev1.ResourceMemory: resource.MustParse("500Mi"),
+					},
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("500m"),
+						corev1.ResourceMemory: resource.MustParse("100Mi"),
+					},
+				},
+				SecurityContext: &corev1.SecurityContext{
+					RunAsUser:                pointers.Ptr[int64](100),
+					RunAsGroup:               pointers.Ptr[int64](101),
+					AllowPrivilegeEscalation: pointers.Ptr(false),
+					ReadOnlyRootFilesystem:   pointers.Ptr(true),
+				},
+			},
+		},
+		{
+			name: "with ports",
+			args: args{
+				name: "foo",
+				options: []Option{
+					WithPorts([]corev1.ContainerPort{
+						{
+							Name:          "prometheus",
+							HostPort:      9000,
+							ContainerPort: 9000,
+							Protocol:      "TCP",
+						},
+						{
+							// try to add duplicate port
+							Name:          "prometheus",
+							HostPort:      9000,
+							ContainerPort: 9000,
+							Protocol:      "TCP",
+						},
+						{
+							// ports should be sorted by function
+							Name:          "http",
+							HostPort:      80,
+							ContainerPort: 80,
+							Protocol:      "TCP",
+						},
+					}...),
+				},
+			},
+			want: corev1.Container{
+				Name:                     "foo",
+				ImagePullPolicy:          corev1.PullIfNotPresent,
+				TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
+				Ports: []corev1.ContainerPort{
+					{
+						Name:          "http",
+						HostPort:      80,
+						ContainerPort: 80,
+						Protocol:      "TCP",
+					},
+					{
+						Name:          "prometheus",
+						HostPort:      9000,
+						ContainerPort: 9000,
+						Protocol:      "TCP",
+					},
+				},
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("1"),
+						corev1.ResourceMemory: resource.MustParse("500Mi"),
+					},
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("500m"),
+						corev1.ResourceMemory: resource.MustParse("100Mi"),
+					},
+				},
+				SecurityContext: &corev1.SecurityContext{
+					RunAsUser:                pointers.Ptr[int64](100),
+					RunAsGroup:               pointers.Ptr[int64](101),
+					AllowPrivilegeEscalation: pointers.Ptr(false),
+					ReadOnlyRootFilesystem:   pointers.Ptr(true),
+				},
+			},
+		},
+		{
+			name: "with env",
+			args: args{
+				name: "foo",
+				options: []Option{
+					WithEnv(corev1.EnvVar{
+						Name:      "DEBUG",
+						Value:     "TRUE",
+						ValueFrom: nil,
+					}),
+					WithEnv(corev1.EnvVar{
+						Name:      "DEBUG",
+						Value:     "FALSE",
+						ValueFrom: nil,
+					}),
+				},
+			},
+			want: corev1.Container{
+				Name:                     "foo",
+				ImagePullPolicy:          corev1.PullIfNotPresent,
+				TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("1"),
+						corev1.ResourceMemory: resource.MustParse("500Mi"),
+					},
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("500m"),
+						corev1.ResourceMemory: resource.MustParse("100Mi"),
+					},
+				},
+				SecurityContext: &corev1.SecurityContext{
+					RunAsUser:                pointers.Ptr[int64](100),
+					RunAsGroup:               pointers.Ptr[int64](101),
+					AllowPrivilegeEscalation: pointers.Ptr(false),
+					ReadOnlyRootFilesystem:   pointers.Ptr(true),
+				},
+				Env: []corev1.EnvVar{
+					{
+						Name:      "DEBUG",
+						Value:     "TRUE",
+						ValueFrom: nil,
+					},
+				},
+			},
+		},
+		{
+			name: "with resources",
+			args: args{
+				name: "foo",
+				options: []Option{
+					WithResources(corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("10"),
+							corev1.ResourceMemory: resource.MustParse("5G"),
+						},
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("10"),
+							corev1.ResourceMemory: resource.MustParse("5G"),
+						},
+					}),
+				},
+			},
+			want: corev1.Container{
+				Name:                     "foo",
+				ImagePullPolicy:          corev1.PullIfNotPresent,
+				TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("10"),
+						corev1.ResourceMemory: resource.MustParse("5G"),
+					},
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("10"),
+						corev1.ResourceMemory: resource.MustParse("5G"),
+					},
+				},
+				SecurityContext: &corev1.SecurityContext{
+					RunAsUser:                pointers.Ptr[int64](100),
+					RunAsGroup:               pointers.Ptr[int64](101),
+					AllowPrivilegeEscalation: pointers.Ptr(false),
+					ReadOnlyRootFilesystem:   pointers.Ptr(true),
+				},
+			},
+		},
+		{
+			name: "with volume mounts",
+			args: args{
+				name: "foo",
+				options: []Option{
+					WithVolumeMounts([]corev1.VolumeMount{
+						{
+							Name:      "stuff",
+							ReadOnly:  true,
+							MountPath: "/data",
+						},
+						{
+							Name:      "other stuff",
+							ReadOnly:  false,
+							MountPath: "/tmp",
+						},
+						{
+							Name:      "other stuff",
+							ReadOnly:  false,
+							MountPath: "/var/log",
+						},
+					}),
+				},
+			},
+			want: corev1.Container{
+				Name:                     "foo",
+				ImagePullPolicy:          corev1.PullIfNotPresent,
+				TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("1"),
+						corev1.ResourceMemory: resource.MustParse("500Mi"),
+					},
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("500m"),
+						corev1.ResourceMemory: resource.MustParse("100Mi"),
+					},
+				},
+				SecurityContext: &corev1.SecurityContext{
+					RunAsUser:                pointers.Ptr[int64](100),
+					RunAsGroup:               pointers.Ptr[int64](101),
+					AllowPrivilegeEscalation: pointers.Ptr(false),
+					ReadOnlyRootFilesystem:   pointers.Ptr(true),
+				},
+				VolumeMounts: []corev1.VolumeMount{
+					// Notice the order here, volumes should be sorted
+					// and won't overwrite an existing volume
+					{
+						Name:      "other stuff",
+						ReadOnly:  false,
+						MountPath: "/tmp",
+					},
+					{
+						Name:      "stuff",
+						ReadOnly:  true,
+						MountPath: "/data",
+					},
+				},
+			},
+		},
+		{
+			name: "with liveness probe",
+			args: args{
+				name: "foo",
+				options: []Option{
+					WithLivenessProbe(&corev1.Probe{
+						ProbeHandler: corev1.ProbeHandler{
+							HTTPGet: &corev1.HTTPGetAction{
+								Path:   "/ready",
+								Port:   intstr.FromString("foo"),
+								Scheme: corev1.URISchemeHTTP,
+							},
+						},
+						PeriodSeconds:                 5,
+						TerminationGracePeriodSeconds: pointers.Ptr[int64](10),
+					}),
+				},
+			},
+			want: corev1.Container{
+				Name:                     "foo",
+				ImagePullPolicy:          corev1.PullIfNotPresent,
+				TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("1"),
+						corev1.ResourceMemory: resource.MustParse("500Mi"),
+					},
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("500m"),
+						corev1.ResourceMemory: resource.MustParse("100Mi"),
+					},
+				},
+				SecurityContext: &corev1.SecurityContext{
+					RunAsUser:                pointers.Ptr[int64](100),
+					RunAsGroup:               pointers.Ptr[int64](101),
+					AllowPrivilegeEscalation: pointers.Ptr(false),
+					ReadOnlyRootFilesystem:   pointers.Ptr(true),
+				},
+				LivenessProbe: &corev1.Probe{
+					ProbeHandler: corev1.ProbeHandler{
+						HTTPGet: &corev1.HTTPGetAction{
+							Path:   "/ready",
+							Port:   intstr.FromString("foo"),
+							Scheme: corev1.URISchemeHTTP,
+						},
+					},
+					PeriodSeconds:                 5,
+					TerminationGracePeriodSeconds: pointer.Int64(10),
+				},
+			},
+		},
+		{
+			name: "with default liveness probe",
+			args: args{
+				name: "foo",
+				options: []Option{
+					WithDefaultLivenessProbe(),
+				},
+			},
+			want: corev1.Container{
+				Name:                     "foo",
+				ImagePullPolicy:          corev1.PullIfNotPresent,
+				TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("1"),
+						corev1.ResourceMemory: resource.MustParse("500Mi"),
+					},
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("500m"),
+						corev1.ResourceMemory: resource.MustParse("100Mi"),
+					},
+				},
+				SecurityContext: &corev1.SecurityContext{
+					RunAsUser:                pointers.Ptr[int64](100),
+					RunAsGroup:               pointers.Ptr[int64](101),
+					AllowPrivilegeEscalation: pointers.Ptr(false),
+					ReadOnlyRootFilesystem:   pointers.Ptr(true),
+				},
+				LivenessProbe: &corev1.Probe{
+					ProbeHandler: corev1.ProbeHandler{
+						HTTPGet: &corev1.HTTPGetAction{
+							Path:   "/",
+							Port:   intstr.FromString("foo"),
+							Scheme: corev1.URISchemeHTTP,
+						},
+					},
+					InitialDelaySeconds: 60,
+					TimeoutSeconds:      5,
+				},
+			},
+		},
+		{
+			name: "with readiness probe",
+			args: args{
+				name: "foo",
+				options: []Option{
+					WithReadinessProbe(&corev1.Probe{
+						ProbeHandler: corev1.ProbeHandler{
+							HTTPGet: &corev1.HTTPGetAction{
+								Path:   "/ready",
+								Port:   intstr.FromString("foo"),
+								Scheme: corev1.URISchemeHTTP,
+							},
+						},
+						InitialDelaySeconds:           6,
+						TimeoutSeconds:                10,
+						PeriodSeconds:                 10,
+						SuccessThreshold:              3,
+						FailureThreshold:              10,
+						TerminationGracePeriodSeconds: pointer.Int64(10),
+					}),
+				},
+			},
+			want: corev1.Container{
+				Name:                     "foo",
+				ImagePullPolicy:          corev1.PullIfNotPresent,
+				TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("1"),
+						corev1.ResourceMemory: resource.MustParse("500Mi"),
+					},
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("500m"),
+						corev1.ResourceMemory: resource.MustParse("100Mi"),
+					},
+				},
+				SecurityContext: &corev1.SecurityContext{
+					RunAsUser:                pointers.Ptr[int64](100),
+					RunAsGroup:               pointers.Ptr[int64](101),
+					AllowPrivilegeEscalation: pointers.Ptr(false),
+					ReadOnlyRootFilesystem:   pointers.Ptr(true),
+				},
+				ReadinessProbe: &corev1.Probe{
+					ProbeHandler: corev1.ProbeHandler{
+						HTTPGet: &corev1.HTTPGetAction{
+							Path:   "/ready",
+							Port:   intstr.FromString("foo"),
+							Scheme: corev1.URISchemeHTTP,
+						},
+					},
+					InitialDelaySeconds:           6,
+					TimeoutSeconds:                10,
+					PeriodSeconds:                 10,
+					SuccessThreshold:              3,
+					FailureThreshold:              10,
+					TerminationGracePeriodSeconds: pointer.Int64(10),
+				},
+			},
+		},
+		{
+			name: "with default readiness probe",
+			args: args{
+				name: "foo",
+				options: []Option{
+					WithDefaultReadinessProbe(),
+				},
+			},
+			want: corev1.Container{
+				Name:                     "foo",
+				ImagePullPolicy:          corev1.PullIfNotPresent,
+				TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("1"),
+						corev1.ResourceMemory: resource.MustParse("500Mi"),
+					},
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("500m"),
+						corev1.ResourceMemory: resource.MustParse("100Mi"),
+					},
+				},
+				SecurityContext: &corev1.SecurityContext{
+					RunAsUser:                pointers.Ptr[int64](100),
+					RunAsGroup:               pointers.Ptr[int64](101),
+					AllowPrivilegeEscalation: pointers.Ptr(false),
+					ReadOnlyRootFilesystem:   pointers.Ptr(true),
+				},
+				ReadinessProbe: &corev1.Probe{
+					ProbeHandler: corev1.ProbeHandler{
+						HTTPGet: &corev1.HTTPGetAction{
+							Path:   "/",
+							Port:   intstr.FromString("foo"),
+							Scheme: corev1.URISchemeHTTP,
+						},
+					},
+					TimeoutSeconds: 5,
+					PeriodSeconds:  5,
+				},
+			},
+		},
+		{
+			name: "with security context",
+			args: args{
+				name: "foo",
+				options: []Option{
+					WithSecurityContext(corev1.SecurityContext{
+						Privileged:               pointers.Ptr(true),
+						RunAsUser:                pointers.Ptr[int64](5000),
+						RunAsGroup:               pointers.Ptr[int64](9000),
+						ReadOnlyRootFilesystem:   pointers.Ptr(true),
+						AllowPrivilegeEscalation: pointers.Ptr(false),
+					}),
+				},
+			},
+			want: corev1.Container{
+				Name:                     "foo",
+				ImagePullPolicy:          corev1.PullIfNotPresent,
+				TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("1"),
+						corev1.ResourceMemory: resource.MustParse("500Mi"),
+					},
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("500m"),
+						corev1.ResourceMemory: resource.MustParse("100Mi"),
+					},
+				},
+				SecurityContext: &corev1.SecurityContext{
+					Privileged:               pointers.Ptr(true),
+					RunAsUser:                pointers.Ptr[int64](5000),
+					RunAsGroup:               pointers.Ptr[int64](9000),
+					ReadOnlyRootFilesystem:   pointers.Ptr(true),
+					AllowPrivilegeEscalation: pointers.Ptr(false),
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := NewContainer(tt.args.name, tt.args.options...)
+			if err != nil {
+				t.Errorf("NewContainer() error: %v", err)
+			}
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("NewContainer() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/internal/k8s/resource/container/example_test.go
+++ b/internal/k8s/resource/container/example_test.go
@@ -1,0 +1,106 @@
+package container
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"sigs.k8s.io/yaml"
+)
+
+func ExampleContainer() {
+	c, _ := NewContainer("test")
+
+	jc, _ := json.Marshal(c)
+	fmt.Println(string(jc))
+
+	yc, _ := yaml.Marshal(c)
+	fmt.Println(string(yc))
+
+	// Output:
+	// {"name":"test","resources":{"limits":{"cpu":"1","memory":"500Mi"},"requests":{"cpu":"500m","memory":"100Mi"}},"terminationMessagePolicy":"FallbackToLogsOnError","imagePullPolicy":"IfNotPresent","securityContext":{"runAsUser":100,"runAsGroup":101,"readOnlyRootFilesystem":true,"allowPrivilegeEscalation":false}}
+	// imagePullPolicy: IfNotPresent
+	// name: test
+	// resources:
+	//   limits:
+	//     cpu: "1"
+	//     memory: 500Mi
+	//   requests:
+	//     cpu: 500m
+	//     memory: 100Mi
+	// securityContext:
+	//   allowPrivilegeEscalation: false
+	//   readOnlyRootFilesystem: true
+	//   runAsGroup: 101
+	//   runAsUser: 100
+	// terminationMessagePolicy: FallbackToLogsOnError
+}
+
+func ExampleWithDefaultLivenessProbe() {
+	c, _ := NewContainer("test", WithDefaultLivenessProbe())
+
+	jc, _ := json.Marshal(c)
+	fmt.Println(string(jc))
+
+	yc, _ := yaml.Marshal(c)
+	fmt.Println(string(yc))
+
+	// Output:
+	// {"name":"test","resources":{"limits":{"cpu":"1","memory":"500Mi"},"requests":{"cpu":"500m","memory":"100Mi"}},"livenessProbe":{"httpGet":{"path":"/","port":"test","scheme":"HTTP"},"initialDelaySeconds":60,"timeoutSeconds":5},"terminationMessagePolicy":"FallbackToLogsOnError","imagePullPolicy":"IfNotPresent","securityContext":{"runAsUser":100,"runAsGroup":101,"readOnlyRootFilesystem":true,"allowPrivilegeEscalation":false}}
+	// imagePullPolicy: IfNotPresent
+	// livenessProbe:
+	//   httpGet:
+	//     path: /
+	//     port: test
+	//     scheme: HTTP
+	//   initialDelaySeconds: 60
+	//   timeoutSeconds: 5
+	// name: test
+	// resources:
+	//   limits:
+	//     cpu: "1"
+	//     memory: 500Mi
+	//   requests:
+	//     cpu: 500m
+	//     memory: 100Mi
+	// securityContext:
+	//   allowPrivilegeEscalation: false
+	//   readOnlyRootFilesystem: true
+	//   runAsGroup: 101
+	//   runAsUser: 100
+	// terminationMessagePolicy: FallbackToLogsOnError
+}
+
+func ExampleWithDefaultReadinessProbe() {
+	c, _ := NewContainer("test", WithDefaultReadinessProbe())
+
+	jc, _ := json.Marshal(c)
+	fmt.Println(string(jc))
+
+	yc, _ := yaml.Marshal(c)
+	fmt.Println(string(yc))
+
+	// Output:
+	// {"name":"test","resources":{"limits":{"cpu":"1","memory":"500Mi"},"requests":{"cpu":"500m","memory":"100Mi"}},"readinessProbe":{"httpGet":{"path":"/","port":"test","scheme":"HTTP"},"timeoutSeconds":5,"periodSeconds":5},"terminationMessagePolicy":"FallbackToLogsOnError","imagePullPolicy":"IfNotPresent","securityContext":{"runAsUser":100,"runAsGroup":101,"readOnlyRootFilesystem":true,"allowPrivilegeEscalation":false}}
+	// imagePullPolicy: IfNotPresent
+	// name: test
+	// readinessProbe:
+	//   httpGet:
+	//     path: /
+	//     port: test
+	//     scheme: HTTP
+	//   periodSeconds: 5
+	//   timeoutSeconds: 5
+	// resources:
+	//   limits:
+	//     cpu: "1"
+	//     memory: 500Mi
+	//   requests:
+	//     cpu: 500m
+	//     memory: 100Mi
+	// securityContext:
+	//   allowPrivilegeEscalation: false
+	//   readOnlyRootFilesystem: true
+	//   runAsGroup: 101
+	//   runAsUser: 100
+	// terminationMessagePolicy: FallbackToLogsOnError
+}

--- a/internal/k8s/resource/deployment/BUILD.bazel
+++ b/internal/k8s/resource/deployment/BUILD.bazel
@@ -1,0 +1,34 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("//dev:go_defs.bzl", "go_test")
+
+go_library(
+    name = "deployment",
+    srcs = ["deployment.go"],
+    importpath = "github.com/sourcegraph/sourcegraph/internal/k8s/resource/deployment",
+    visibility = ["//:__subpackages__"],
+    deps = [
+        "//internal/maps",
+        "//lib/pointers",
+        "@io_k8s_api//apps/v1:apps",
+        "@io_k8s_api//core/v1:core",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:meta",
+    ],
+)
+
+go_test(
+    name = "deployment_test",
+    srcs = [
+        "deployment_test.go",
+        "example_test.go",
+    ],
+    embed = [":deployment"],
+    deps = [
+        "//internal/k8s/resource/pod",
+        "//lib/pointers",
+        "@com_github_google_go_cmp//cmp",
+        "@io_k8s_api//apps/v1:apps",
+        "@io_k8s_api//core/v1:core",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:meta",
+        "@io_k8s_sigs_yaml//:yaml",
+    ],
+)

--- a/internal/k8s/resource/deployment/deployment.go
+++ b/internal/k8s/resource/deployment/deployment.go
@@ -1,0 +1,127 @@
+package deployment
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/sourcegraph/sourcegraph/internal/maps"
+	"github.com/sourcegraph/sourcegraph/lib/pointers"
+)
+
+// NewDeployment creates a new k8s Deployment with default values.
+//
+// Default values include:
+//
+//   - MinReadySeconds: 10
+//   - Replicas: 1
+//   - RevisionHistoryLimit: 10
+//   - Selector: "app": <name>
+//   - DeploymentStrategy: RecreateDeploymentStrategy
+//
+// Additional options can be passed to modify the default values.
+func NewDeployment(name, namespace string, options ...Option) (appsv1.Deployment, error) {
+	deployment := appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				"deploy": "sourcegraph",
+			},
+		},
+		Spec: appsv1.DeploymentSpec{
+			MinReadySeconds:      int32(10),
+			Replicas:             pointers.Ptr[int32](1),
+			RevisionHistoryLimit: pointers.Ptr[int32](10),
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app": name,
+				},
+			},
+			Strategy: appsv1.DeploymentStrategy{
+				Type: appsv1.RecreateDeploymentStrategyType,
+			},
+		},
+	}
+
+	// apply any given options
+	for _, opt := range options {
+		err := opt(&deployment)
+		if err != nil {
+			return appsv1.Deployment{}, err
+		}
+	}
+
+	return deployment, nil
+}
+
+// Option sets an option for a Deployment.
+type Option func(deployment *appsv1.Deployment) error
+
+// WithLabels sets Deployment labels without overriding existing labels.
+func WithLabels(labels map[string]string) Option {
+	return func(deployment *appsv1.Deployment) error {
+		deployment.Labels = maps.MergePreservingExistingKeys(deployment.Labels, labels)
+		return nil
+	}
+}
+
+// WithAnnotations sets Deployment annotations without overriding existing annotations.
+func WithAnnotations(annotations map[string]string) Option {
+	return func(deployment *appsv1.Deployment) error {
+		deployment.Annotations = maps.MergePreservingExistingKeys(deployment.Annotations, annotations)
+		return nil
+	}
+}
+
+// WithMinReadySeconds sets the minimum number of seconds for which a newly
+// created Pod should be ready without any of its containers crashing, for it to
+// be considered available.
+func WithMinReadySeconds(seconds int32) Option {
+	return func(deployment *appsv1.Deployment) error {
+		deployment.Spec.MinReadySeconds = seconds
+		return nil
+	}
+}
+
+// WithReplicas sets the number of replicas for the Deployment.
+func WithReplicas(replicas int32) Option {
+	return func(deployment *appsv1.Deployment) error {
+		deployment.Spec.Replicas = pointers.Ptr[int32](replicas)
+		return nil
+	}
+}
+
+// WithRevisionHistoryLimit sets the revision history limit for the Deployment.
+func WithRevisionHistoryLimit(revisionHistoryLimit int32) Option {
+	return func(deployment *appsv1.Deployment) error {
+		deployment.Spec.RevisionHistoryLimit = pointers.Ptr[int32](revisionHistoryLimit)
+		return nil
+	}
+}
+
+// WithSelector sets the selector for the Deployment. The selector determines which Pods are managed by the Deployment.
+func WithSelector(selector metav1.LabelSelector) Option {
+	return func(deployment *appsv1.Deployment) error {
+		deployment.Spec.Selector = &selector
+		return nil
+	}
+}
+
+// WithDeploymentStrategy sets the deployment strategy for the Deployment.
+// The deployment strategy determines how Pods are created/updated/deleted when the Deployment is updated.
+func WithDeploymentStrategy(deploymentStrategy appsv1.DeploymentStrategy) Option {
+	return func(deployment *appsv1.Deployment) error {
+		deployment.Spec.Strategy = deploymentStrategy
+		return nil
+	}
+}
+
+// WithPodTemplateSpec sets the pod template spec for the Deployment. The pod template spec
+// defines the pods that will be created by the Deployment.
+func WithPodTemplateSpec(podTemplate corev1.PodTemplateSpec) Option {
+	return func(deployment *appsv1.Deployment) error {
+		deployment.Spec.Template = podTemplate
+		return nil
+	}
+}

--- a/internal/k8s/resource/deployment/deployment_test.go
+++ b/internal/k8s/resource/deployment/deployment_test.go
@@ -1,0 +1,378 @@
+package deployment
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/sourcegraph/sourcegraph/internal/k8s/resource/pod"
+	"github.com/sourcegraph/sourcegraph/lib/pointers"
+)
+
+func TestNewDeployment(t *testing.T) {
+	t.Parallel()
+
+	type args struct {
+		name      string
+		namespace string
+		options   []Option
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want appsv1.Deployment
+	}{
+		{
+			name: "default deployment",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+			},
+			want: appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph",
+					},
+				},
+				Spec: appsv1.DeploymentSpec{
+					MinReadySeconds:      int32(10),
+					Replicas:             pointers.Ptr[int32](1),
+					RevisionHistoryLimit: pointers.Ptr[int32](10),
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"app": "foo",
+						},
+					},
+					Strategy: appsv1.DeploymentStrategy{
+						Type: appsv1.RecreateDeploymentStrategyType,
+					},
+					Template: corev1.PodTemplateSpec{},
+				},
+			},
+		},
+		{
+			name: "with labels",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithLabels(map[string]string{
+						"deploy": "horsegraph",
+						"app":    "horsegraph",
+					}),
+				},
+			},
+			want: appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"app":    "horsegraph",
+						"deploy": "sourcegraph",
+					},
+				},
+				Spec: appsv1.DeploymentSpec{
+					MinReadySeconds:      int32(10),
+					Replicas:             pointers.Ptr[int32](1),
+					RevisionHistoryLimit: pointers.Ptr[int32](10),
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"app": "foo",
+						},
+					},
+					Strategy: appsv1.DeploymentStrategy{
+						Type: appsv1.RecreateDeploymentStrategyType,
+					},
+					Template: corev1.PodTemplateSpec{},
+				},
+			},
+		},
+		{
+			name: "with annotations",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithAnnotations(map[string]string{
+						"app": "horsegraph",
+						"foo": "bar",
+					}),
+				},
+			},
+			want: appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph",
+					},
+					Annotations: map[string]string{
+						"app": "horsegraph",
+						"foo": "bar",
+					},
+				},
+				Spec: appsv1.DeploymentSpec{
+					MinReadySeconds:      int32(10),
+					Replicas:             pointers.Ptr[int32](1),
+					RevisionHistoryLimit: pointers.Ptr[int32](10),
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"app": "foo",
+						},
+					},
+					Strategy: appsv1.DeploymentStrategy{
+						Type: appsv1.RecreateDeploymentStrategyType,
+					},
+					Template: corev1.PodTemplateSpec{},
+				},
+			},
+		},
+		{
+			name: "with minreadyseconds",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithMinReadySeconds(int32(20)),
+				},
+			},
+			want: appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph",
+					},
+				},
+				Spec: appsv1.DeploymentSpec{
+					MinReadySeconds:      int32(20),
+					Replicas:             pointers.Ptr[int32](1),
+					RevisionHistoryLimit: pointers.Ptr[int32](10),
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"app": "foo",
+						},
+					},
+					Strategy: appsv1.DeploymentStrategy{
+						Type: appsv1.RecreateDeploymentStrategyType,
+					},
+					Template: corev1.PodTemplateSpec{},
+				},
+			},
+		},
+		{
+			name: "with replicas",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithReplicas(int32(10)),
+				},
+			},
+			want: appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph",
+					},
+				},
+				Spec: appsv1.DeploymentSpec{
+					MinReadySeconds:      int32(10),
+					Replicas:             pointers.Ptr[int32](10),
+					RevisionHistoryLimit: pointers.Ptr[int32](10),
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"app": "foo",
+						},
+					},
+					Strategy: appsv1.DeploymentStrategy{
+						Type: appsv1.RecreateDeploymentStrategyType,
+					},
+					Template: corev1.PodTemplateSpec{},
+				},
+			},
+		},
+		{
+			name: "with revision history limit",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithRevisionHistoryLimit(int32(100)),
+				},
+			},
+			want: appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph",
+					},
+				},
+				Spec: appsv1.DeploymentSpec{
+					MinReadySeconds:      int32(10),
+					Replicas:             pointers.Ptr[int32](1),
+					RevisionHistoryLimit: pointers.Ptr[int32](100),
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"app": "foo",
+						},
+					},
+					Strategy: appsv1.DeploymentStrategy{
+						Type: appsv1.RecreateDeploymentStrategyType,
+					},
+					Template: corev1.PodTemplateSpec{},
+				},
+			},
+		},
+		{
+			name: "with selector",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithSelector(metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"app": "bar",
+						},
+					}),
+				},
+			},
+			want: appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph",
+					},
+				},
+				Spec: appsv1.DeploymentSpec{
+					MinReadySeconds:      int32(10),
+					Replicas:             pointers.Ptr[int32](1),
+					RevisionHistoryLimit: pointers.Ptr[int32](10),
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"app": "bar",
+						},
+					},
+					Strategy: appsv1.DeploymentStrategy{
+						Type: appsv1.RecreateDeploymentStrategyType,
+					},
+					Template: corev1.PodTemplateSpec{},
+				},
+			},
+		},
+		{
+			name: "with deployment strategy",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithDeploymentStrategy(appsv1.DeploymentStrategy{
+						Type: appsv1.RollingUpdateDeploymentStrategyType,
+					}),
+				},
+			},
+			want: appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph",
+					},
+				},
+				Spec: appsv1.DeploymentSpec{
+					MinReadySeconds:      int32(10),
+					Replicas:             pointers.Ptr[int32](1),
+					RevisionHistoryLimit: pointers.Ptr[int32](10),
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"app": "foo",
+						},
+					},
+					Strategy: appsv1.DeploymentStrategy{
+						Type: appsv1.RollingUpdateDeploymentStrategyType,
+					},
+					Template: corev1.PodTemplateSpec{},
+				},
+			},
+		},
+		{
+			name: "with pod template spec",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithPodTemplateSpec(func() corev1.PodTemplateSpec {
+						ts, _ := pod.NewPodTemplate("foo", "sourcegraph")
+						return ts.Template
+					}()),
+				},
+			},
+			want: appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph",
+					},
+				},
+				Spec: appsv1.DeploymentSpec{
+					MinReadySeconds:      int32(10),
+					Replicas:             pointers.Ptr[int32](1),
+					RevisionHistoryLimit: pointers.Ptr[int32](10),
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"app": "foo",
+						},
+					},
+					Strategy: appsv1.DeploymentStrategy{
+						Type: appsv1.RecreateDeploymentStrategyType,
+					},
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "foo",
+							Namespace: "sourcegraph",
+							Annotations: map[string]string{
+								"kubectl.kubernetes.io/default-container": "foo",
+							},
+							Labels: map[string]string{
+								"app":    "foo",
+								"deploy": "sourcegraph",
+							},
+						},
+						Spec: corev1.PodSpec{
+							SecurityContext: &corev1.PodSecurityContext{
+								RunAsUser:           pointers.Ptr[int64](100),
+								RunAsGroup:          pointers.Ptr[int64](101),
+								FSGroup:             pointers.Ptr[int64](101),
+								FSGroupChangePolicy: pointers.Ptr(corev1.FSGroupChangeOnRootMismatch),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := NewDeployment(tt.args.name, tt.args.namespace, tt.args.options...)
+			if err != nil {
+				t.Errorf("NewDeployment() error: %v", err)
+			}
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("NewDeployment() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/internal/k8s/resource/deployment/example_test.go
+++ b/internal/k8s/resource/deployment/example_test.go
@@ -1,0 +1,42 @@
+package deployment
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"sigs.k8s.io/yaml"
+)
+
+func ExampleDeployment() {
+	d, _ := NewDeployment("test", "sourcegraph")
+
+	jd, _ := json.Marshal(d)
+	fmt.Println(string(jd))
+
+	yd, _ := yaml.Marshal(d)
+	fmt.Println(string(yd))
+
+	// Output:
+	// {"metadata":{"name":"test","namespace":"sourcegraph","creationTimestamp":null,"labels":{"deploy":"sourcegraph"}},"spec":{"replicas":1,"selector":{"matchLabels":{"app":"test"}},"template":{"metadata":{"creationTimestamp":null},"spec":{"containers":null}},"strategy":{"type":"Recreate"},"minReadySeconds":10,"revisionHistoryLimit":10},"status":{}}
+	// metadata:
+	//   creationTimestamp: null
+	//   labels:
+	//     deploy: sourcegraph
+	//   name: test
+	//   namespace: sourcegraph
+	// spec:
+	//   minReadySeconds: 10
+	//   replicas: 1
+	//   revisionHistoryLimit: 10
+	//   selector:
+	//     matchLabels:
+	//       app: test
+	//   strategy:
+	//     type: Recreate
+	//   template:
+	//     metadata:
+	//       creationTimestamp: null
+	//     spec:
+	//       containers: null
+	// status: {}
+}

--- a/internal/k8s/resource/doc.go
+++ b/internal/k8s/resource/doc.go
@@ -1,0 +1,2 @@
+// Package resource contains functions to build Kubernetes resources using patterns and defaults common to Sourcegraph.
+package resource

--- a/internal/k8s/resource/ingress/BUILD.bazel
+++ b/internal/k8s/resource/ingress/BUILD.bazel
@@ -1,0 +1,30 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("//dev:go_defs.bzl", "go_test")
+
+go_library(
+    name = "ingress",
+    srcs = ["ingress.go"],
+    importpath = "github.com/sourcegraph/sourcegraph/internal/k8s/resource/ingress",
+    visibility = ["//:__subpackages__"],
+    deps = [
+        "//internal/maps",
+        "@io_k8s_api//networking/v1:networking",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:meta",
+    ],
+)
+
+go_test(
+    name = "ingress_test",
+    srcs = [
+        "example_test.go",
+        "ingress_test.go",
+    ],
+    embed = [":ingress"],
+    deps = [
+        "//lib/pointers",
+        "@com_github_google_go_cmp//cmp",
+        "@io_k8s_api//networking/v1:networking",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:meta",
+        "@io_k8s_sigs_yaml//:yaml",
+    ],
+)

--- a/internal/k8s/resource/ingress/example_test.go
+++ b/internal/k8s/resource/ingress/example_test.go
@@ -1,0 +1,30 @@
+package ingress
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"sigs.k8s.io/yaml"
+)
+
+func ExampleIngress() {
+	i, _ := NewIngress("test", "sourcegraph")
+
+	ji, _ := json.Marshal(i)
+	fmt.Println(string(ji))
+
+	yc, _ := yaml.Marshal(i)
+	fmt.Println(string(yc))
+
+	// Output:
+	// {"metadata":{"name":"test","namespace":"sourcegraph","creationTimestamp":null,"labels":{"deploy":"sourcegraph"}},"spec":{},"status":{"loadBalancer":{}}}
+	// metadata:
+	//   creationTimestamp: null
+	//   labels:
+	//     deploy: sourcegraph
+	//   name: test
+	//   namespace: sourcegraph
+	// spec: {}
+	// status:
+	//   loadBalancer: {}
+}

--- a/internal/k8s/resource/ingress/ingress.go
+++ b/internal/k8s/resource/ingress/ingress.go
@@ -1,0 +1,81 @@
+package ingress
+
+import (
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/sourcegraph/sourcegraph/internal/maps"
+)
+
+func NewIngress(name, namespace string, options ...Option) (networkingv1.Ingress, error) {
+	ingress := networkingv1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				"deploy": "sourcegraph",
+			},
+		},
+		Spec: networkingv1.IngressSpec{},
+	}
+
+	// apply any given options
+	for _, opt := range options {
+		err := opt(&ingress)
+		if err != nil {
+			return networkingv1.Ingress{}, err
+		}
+	}
+	return ingress, nil
+}
+
+// Option sets an option for an Ingress.
+type Option func(ingress *networkingv1.Ingress) error
+
+// WithLabels sets ingress labels without overriding existing labels.
+func WithLabels(labels map[string]string) Option {
+	return func(ingress *networkingv1.Ingress) error {
+		ingress.Labels = maps.MergePreservingExistingKeys(ingress.Labels, labels)
+		return nil
+	}
+}
+
+// WithAnnotations sets ingress annotations without overriding existing labels.
+func WithAnnotations(annotations map[string]string) Option {
+	return func(ingress *networkingv1.Ingress) error {
+		ingress.Annotations = maps.MergePreservingExistingKeys(ingress.Annotations, annotations)
+		return nil
+	}
+}
+
+// WithIngressClassName sets the name of the IngressClass cluster resource.
+func WithIngressClassName(ingressClassName string) Option {
+	return func(ingress *networkingv1.Ingress) error {
+		ingress.Spec.IngressClassName = &ingressClassName
+		return nil
+	}
+}
+
+// WithDefaultIngressBackend sets the default ingress backend.
+func WithDefaultIngressBackend(defaultBackend networkingv1.IngressBackend) Option {
+	return func(ingress *networkingv1.Ingress) error {
+		ingress.Spec.DefaultBackend = &defaultBackend
+		return nil
+	}
+}
+
+// WithIngressTLS sets the ingress TLS settings.
+func WithIngressTLS(tls []networkingv1.IngressTLS) Option {
+	return func(ingress *networkingv1.Ingress) error {
+		ingress.Spec.TLS = tls
+		return nil
+	}
+}
+
+// WithIngressRules sets the ingress rules.
+func WithIngressRules(rules []networkingv1.IngressRule) Option {
+	return func(ingress *networkingv1.Ingress) error {
+		ingress.Spec.Rules = rules
+		return nil
+	}
+}

--- a/internal/k8s/resource/ingress/ingress_test.go
+++ b/internal/k8s/resource/ingress/ingress_test.go
@@ -1,0 +1,226 @@
+package ingress
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/sourcegraph/sourcegraph/lib/pointers"
+)
+
+func TestNewIngress(t *testing.T) {
+	t.Parallel()
+
+	type args struct {
+		name      string
+		namespace string
+		options   []Option
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want networkingv1.Ingress
+	}{
+		{
+			name: "default ingress",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+			},
+			want: networkingv1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph",
+					},
+				},
+			},
+		},
+		{
+			name: "with labels",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithLabels(map[string]string{
+						"foo": "bar",
+					}),
+				},
+			},
+			want: networkingv1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph",
+						"foo":    "bar",
+					},
+				},
+			},
+		},
+		{
+			name: "with annotations",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithAnnotations(map[string]string{
+						"foo": "bar",
+					}),
+				},
+			},
+			want: networkingv1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph",
+					},
+					Annotations: map[string]string{
+						"foo": "bar",
+					},
+				},
+			},
+		},
+		{
+			name: "with ingress class name",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithIngressClassName("foo"),
+				},
+			},
+			want: networkingv1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph",
+					},
+				},
+				Spec: networkingv1.IngressSpec{
+					IngressClassName: pointers.Ptr("foo"),
+				},
+			},
+		},
+		{
+			name: "with ingress TLS",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithIngressTLS([]networkingv1.IngressTLS{
+						{
+							Hosts:      []string{"foo"},
+							SecretName: "bar",
+						},
+					}),
+				},
+			},
+			want: networkingv1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph",
+					},
+				},
+				Spec: networkingv1.IngressSpec{
+					TLS: []networkingv1.IngressTLS{
+						{
+							Hosts:      []string{"foo"},
+							SecretName: "bar",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "with default ingress backend",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithDefaultIngressBackend(networkingv1.IngressBackend{
+						Service: &networkingv1.IngressServiceBackend{
+							Name: "foo",
+							Port: networkingv1.ServiceBackendPort{
+								Name:   "http",
+								Number: 80,
+							},
+						},
+					}),
+				},
+			},
+			want: networkingv1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph",
+					},
+				},
+				Spec: networkingv1.IngressSpec{
+					DefaultBackend: &networkingv1.IngressBackend{
+						Service: &networkingv1.IngressServiceBackend{
+							Name: "foo",
+							Port: networkingv1.ServiceBackendPort{
+								Name:   "http",
+								Number: 80,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "with ingress rules",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithIngressRules([]networkingv1.IngressRule{
+						{
+							Host: "foo",
+						},
+					}),
+				},
+			},
+			want: networkingv1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph",
+					},
+				},
+				Spec: networkingv1.IngressSpec{
+					Rules: []networkingv1.IngressRule{
+						{
+							Host: "foo",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := NewIngress(tt.args.name, tt.args.namespace, tt.args.options...)
+			if err != nil {
+				t.Errorf("NewIngress() error: %v", err)
+			}
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("NewIngress() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/internal/k8s/resource/pod/BUILD.bazel
+++ b/internal/k8s/resource/pod/BUILD.bazel
@@ -1,0 +1,33 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("//dev:go_defs.bzl", "go_test")
+
+go_library(
+    name = "pod",
+    srcs = ["pod.go"],
+    importpath = "github.com/sourcegraph/sourcegraph/internal/k8s/resource/pod",
+    visibility = ["//:__subpackages__"],
+    deps = [
+        "//internal/maps",
+        "//lib/pointers",
+        "@io_k8s_api//core/v1:core",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:meta",
+    ],
+)
+
+go_test(
+    name = "pod_test",
+    srcs = [
+        "example_test.go",
+        "pod_test.go",
+    ],
+    embed = [":pod"],
+    deps = [
+        "//internal/k8s/resource/container",
+        "//lib/pointers",
+        "@com_github_google_go_cmp//cmp",
+        "@io_k8s_api//core/v1:core",
+        "@io_k8s_apimachinery//pkg/api/resource",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:meta",
+        "@io_k8s_sigs_yaml//:yaml",
+    ],
+)

--- a/internal/k8s/resource/pod/example_test.go
+++ b/internal/k8s/resource/pod/example_test.go
@@ -1,0 +1,40 @@
+package pod
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"sigs.k8s.io/yaml"
+)
+
+func ExamplePodTemplate() {
+	pt, _ := NewPodTemplate("test", "sourcegraph")
+
+	jpt, _ := json.Marshal(pt)
+	fmt.Println(string(jpt))
+
+	ypt, _ := yaml.Marshal(pt)
+	fmt.Println(string(ypt))
+
+	// Output:
+	// {"metadata":{"creationTimestamp":null},"template":{"metadata":{"name":"test","namespace":"sourcegraph","creationTimestamp":null,"labels":{"app":"test","deploy":"sourcegraph"},"annotations":{"kubectl.kubernetes.io/default-container":"test"}},"spec":{"containers":null,"securityContext":{"runAsUser":100,"runAsGroup":101,"fsGroup":101,"fsGroupChangePolicy":"OnRootMismatch"}}}}
+	// metadata:
+	//   creationTimestamp: null
+	// template:
+	//   metadata:
+	//     annotations:
+	//       kubectl.kubernetes.io/default-container: test
+	//     creationTimestamp: null
+	//     labels:
+	//       app: test
+	//       deploy: sourcegraph
+	//     name: test
+	//     namespace: sourcegraph
+	//   spec:
+	//     containers: null
+	//     securityContext:
+	//       fsGroup: 101
+	//       fsGroupChangePolicy: OnRootMismatch
+	//       runAsGroup: 101
+	//       runAsUser: 100
+}

--- a/internal/k8s/resource/pod/pod.go
+++ b/internal/k8s/resource/pod/pod.go
@@ -1,0 +1,174 @@
+package pod
+
+import (
+	"sort"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/sourcegraph/sourcegraph/internal/maps"
+	"github.com/sourcegraph/sourcegraph/lib/pointers"
+)
+
+// NewPodTemplate creates a new k8s PodTemplate with default values.
+//
+// Default values include:
+//
+//   - Default container annotations
+//   - Default Sourcegraph `app` and `deploy` labels
+//   - SecurityContext with defaults.
+//
+// Additional options can be passed to modify the default values.
+func NewPodTemplate(name, namespace string, options ...Option) (corev1.PodTemplate, error) {
+	podTemplate := corev1.PodTemplate{
+		Template: corev1.PodTemplateSpec{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+				Annotations: map[string]string{
+					"kubectl.kubernetes.io/default-container": name,
+				},
+				Labels: map[string]string{
+					"app":    name,
+					"deploy": "sourcegraph",
+				},
+			},
+			Spec: corev1.PodSpec{
+				SecurityContext: &corev1.PodSecurityContext{
+					RunAsUser:           pointers.Ptr[int64](100),
+					RunAsGroup:          pointers.Ptr[int64](101),
+					FSGroup:             pointers.Ptr[int64](101),
+					FSGroupChangePolicy: pointers.Ptr(corev1.FSGroupChangeOnRootMismatch),
+				},
+			},
+		},
+	}
+
+	// apply any given options
+	for _, opt := range options {
+		err := opt(&podTemplate)
+		if err != nil {
+			return corev1.PodTemplate{}, err
+		}
+	}
+
+	return podTemplate, nil
+}
+
+// Option sets an option for a PodTemplate.
+type Option func(podTemplate *corev1.PodTemplate) error
+
+// WithLabels sets PodTemplate labels without overriding existing labels.
+func WithLabels(labels map[string]string) Option {
+	return func(podTemplate *corev1.PodTemplate) error {
+		podTemplate.Template.Labels = maps.MergePreservingExistingKeys(podTemplate.Template.Labels, labels)
+		return nil
+	}
+}
+
+// WithAnnotations sets PodTemplate annotations without overriding existing annotations.
+func WithAnnotations(annotations map[string]string) Option {
+	return func(podTemplate *corev1.PodTemplate) error {
+		podTemplate.Template.Annotations = maps.MergePreservingExistingKeys(podTemplate.Template.Annotations, annotations)
+		return nil
+	}
+}
+
+// WithAffinity sets a default affinity on the PodTemplate.
+func WithAffinity(affinity corev1.Affinity) Option {
+	return func(podTemplate *corev1.PodTemplate) error {
+		podTemplate.Template.Spec.Affinity = &affinity
+		return nil
+	}
+}
+
+// WithVolumes appends the given volumes to the PodSpec without overriding existing volumes.
+func WithVolumes(volumes []corev1.Volume) Option {
+	return func(podTemplate *corev1.PodTemplate) error {
+		for _, v := range volumes {
+			if !volumeExists(v.Name, podTemplate) {
+				podTemplate.Template.Spec.Volumes = append(podTemplate.Template.Spec.Volumes, v)
+			}
+		}
+
+		sort.SliceStable(podTemplate.Template.Spec.Volumes, func(i, j int) bool {
+			return podTemplate.Template.Spec.Volumes[i].Name < podTemplate.Template.Spec.Volumes[j].Name
+		})
+		return nil
+	}
+}
+
+func volumeExists(name string, podTemplate *corev1.PodTemplate) bool {
+	for _, v := range podTemplate.Template.Spec.Volumes {
+		if v.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+// WithTerminationGracePeriod sets the given termination grace period.
+func WithTerminationGracePeriod(period int64) Option {
+	return func(podTemplate *corev1.PodTemplate) error {
+		podTemplate.Template.Spec.TerminationGracePeriodSeconds = &period
+		return nil
+	}
+}
+
+// WithInitContainers appends the given InitContainers to the Pod without overriding existing containers.
+func WithInitContainers(initContainers ...corev1.Container) Option {
+	return func(podTemplate *corev1.PodTemplate) error {
+		for _, c := range initContainers {
+			if !initContainerExists(c.Name, podTemplate) {
+				podTemplate.Template.Spec.InitContainers = append(podTemplate.Template.Spec.InitContainers, c)
+			}
+		}
+		return nil
+	}
+}
+
+func initContainerExists(name string, podTemplate *corev1.PodTemplate) bool {
+	for _, c := range podTemplate.Template.Spec.InitContainers {
+		if c.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+// WithContainers appends the given containers to the Pod without overriding existing containers.
+func WithContainers(containers ...corev1.Container) Option {
+	return func(podTemplate *corev1.PodTemplate) error {
+		for _, c := range containers {
+			if !containerExists(c.Name, podTemplate) {
+				podTemplate.Template.Spec.Containers = append(podTemplate.Template.Spec.Containers, c)
+			}
+		}
+		return nil
+	}
+}
+
+func containerExists(name string, podTemplate *corev1.PodTemplate) bool {
+	for _, c := range podTemplate.Template.Spec.Containers {
+		if c.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+// WithServiceAccount sets the given Service Account on the pod.
+func WithServiceAccount(serviceAccount string) Option {
+	return func(podTemplate *corev1.PodTemplate) error {
+		podTemplate.Template.Spec.ServiceAccountName = serviceAccount
+		return nil
+	}
+}
+
+// WithSecurityContext sets the given Pod Security Context on the pod.
+func WithSecurityContext(securityContext corev1.PodSecurityContext) Option {
+	return func(podTemplate *corev1.PodTemplate) error {
+		podTemplate.Template.Spec.SecurityContext = &securityContext
+		return nil
+	}
+}

--- a/internal/k8s/resource/pod/pod_test.go
+++ b/internal/k8s/resource/pod/pod_test.go
@@ -1,0 +1,486 @@
+package pod
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/sourcegraph/sourcegraph/internal/k8s/resource/container"
+	"github.com/sourcegraph/sourcegraph/lib/pointers"
+)
+
+func TestNewPodTemplate(t *testing.T) {
+	t.Parallel()
+
+	type args struct {
+		name      string
+		namespace string
+		options   []Option
+	}
+
+	tests := []struct {
+		name    string
+		args    args
+		want    corev1.PodTemplate
+		wantErr bool
+	}{
+		{
+			name: "default container",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+			},
+			want: corev1.PodTemplate{
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "foo",
+						Namespace: "sourcegraph",
+						Annotations: map[string]string{
+							"kubectl.kubernetes.io/default-container": "foo",
+						},
+						Labels: map[string]string{
+							"app":    "foo",
+							"deploy": "sourcegraph",
+						},
+					},
+					Spec: corev1.PodSpec{
+						SecurityContext: &corev1.PodSecurityContext{
+							RunAsUser:           pointers.Ptr[int64](100),
+							RunAsGroup:          pointers.Ptr[int64](101),
+							FSGroup:             pointers.Ptr[int64](101),
+							FSGroupChangePolicy: pointers.Ptr(corev1.FSGroupChangeOnRootMismatch),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "with labels",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithLabels(map[string]string{
+						"app":         "bar",
+						"environment": "prod",
+					}),
+				},
+			},
+			want: corev1.PodTemplate{
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "foo",
+						Namespace: "sourcegraph",
+						Annotations: map[string]string{
+							"kubectl.kubernetes.io/default-container": "foo",
+						},
+						Labels: map[string]string{
+							"app":         "foo",
+							"deploy":      "sourcegraph",
+							"environment": "prod",
+						},
+					},
+					Spec: corev1.PodSpec{
+						SecurityContext: &corev1.PodSecurityContext{
+							RunAsUser:           pointers.Ptr[int64](100),
+							RunAsGroup:          pointers.Ptr[int64](101),
+							FSGroup:             pointers.Ptr[int64](101),
+							FSGroupChangePolicy: pointers.Ptr(corev1.FSGroupChangeOnRootMismatch),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "with annotations",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithAnnotations(map[string]string{
+						"kubectl.kubernetes.io/default-container": "bar",
+						"environment": "prod",
+					}),
+				},
+			},
+			want: corev1.PodTemplate{
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "foo",
+						Namespace: "sourcegraph",
+						Annotations: map[string]string{
+							"kubectl.kubernetes.io/default-container": "foo",
+							"environment": "prod",
+						},
+						Labels: map[string]string{
+							"app":    "foo",
+							"deploy": "sourcegraph",
+						},
+					},
+					Spec: corev1.PodSpec{
+						SecurityContext: &corev1.PodSecurityContext{
+							RunAsUser:           pointers.Ptr[int64](100),
+							RunAsGroup:          pointers.Ptr[int64](101),
+							FSGroup:             pointers.Ptr[int64](101),
+							FSGroupChangePolicy: pointers.Ptr(corev1.FSGroupChangeOnRootMismatch),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "with affinity",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithAffinity(corev1.Affinity{
+						NodeAffinity: &corev1.NodeAffinity{
+							RequiredDuringSchedulingIgnoredDuringExecution:  nil,
+							PreferredDuringSchedulingIgnoredDuringExecution: nil,
+						},
+						PodAffinity:     nil,
+						PodAntiAffinity: nil,
+					}),
+				},
+			},
+			want: corev1.PodTemplate{
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "foo",
+						Namespace: "sourcegraph",
+						Annotations: map[string]string{
+							"kubectl.kubernetes.io/default-container": "foo",
+						},
+						Labels: map[string]string{
+							"app":    "foo",
+							"deploy": "sourcegraph",
+						},
+					},
+					Spec: corev1.PodSpec{
+						SecurityContext: &corev1.PodSecurityContext{
+							RunAsUser:           pointers.Ptr[int64](100),
+							RunAsGroup:          pointers.Ptr[int64](101),
+							FSGroup:             pointers.Ptr[int64](101),
+							FSGroupChangePolicy: pointers.Ptr(corev1.FSGroupChangeOnRootMismatch),
+						},
+						Affinity: &corev1.Affinity{
+							NodeAffinity: &corev1.NodeAffinity{
+								RequiredDuringSchedulingIgnoredDuringExecution:  nil,
+								PreferredDuringSchedulingIgnoredDuringExecution: nil,
+							},
+							PodAffinity:     nil,
+							PodAntiAffinity: nil,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "with volumes",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithVolumes([]corev1.Volume{
+						{
+							Name: "stuff",
+						},
+						{
+							Name: "data",
+						},
+					}),
+				},
+			},
+			want: corev1.PodTemplate{
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "foo",
+						Namespace: "sourcegraph",
+						Annotations: map[string]string{
+							"kubectl.kubernetes.io/default-container": "foo",
+						},
+						Labels: map[string]string{
+							"app":    "foo",
+							"deploy": "sourcegraph",
+						},
+					},
+					Spec: corev1.PodSpec{
+						SecurityContext: &corev1.PodSecurityContext{
+							RunAsUser:           pointers.Ptr[int64](100),
+							RunAsGroup:          pointers.Ptr[int64](101),
+							FSGroup:             pointers.Ptr[int64](101),
+							FSGroupChangePolicy: pointers.Ptr(corev1.FSGroupChangeOnRootMismatch),
+						},
+						Volumes: []corev1.Volume{
+							{
+								Name: "data",
+							},
+							{
+								Name: "stuff",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "with termination grace period",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithTerminationGracePeriod(int64(10)),
+				},
+			},
+			want: corev1.PodTemplate{
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "foo",
+						Namespace: "sourcegraph",
+						Annotations: map[string]string{
+							"kubectl.kubernetes.io/default-container": "foo",
+						},
+						Labels: map[string]string{
+							"app":    "foo",
+							"deploy": "sourcegraph",
+						},
+					},
+					Spec: corev1.PodSpec{
+						SecurityContext: &corev1.PodSecurityContext{
+							RunAsUser:           pointers.Ptr[int64](100),
+							RunAsGroup:          pointers.Ptr[int64](101),
+							FSGroup:             pointers.Ptr[int64](101),
+							FSGroupChangePolicy: pointers.Ptr(corev1.FSGroupChangeOnRootMismatch),
+						},
+						TerminationGracePeriodSeconds: pointers.Ptr[int64](10),
+					},
+				},
+			},
+		},
+		{
+			name: "with init containers",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithInitContainers(func() corev1.Container {
+						c, _ := container.NewContainer("foo")
+						return c
+					}()),
+				},
+			},
+			want: corev1.PodTemplate{
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "foo",
+						Namespace: "sourcegraph",
+						Annotations: map[string]string{
+							"kubectl.kubernetes.io/default-container": "foo",
+						},
+						Labels: map[string]string{
+							"app":    "foo",
+							"deploy": "sourcegraph",
+						},
+					},
+					Spec: corev1.PodSpec{
+						SecurityContext: &corev1.PodSecurityContext{
+							RunAsUser:           pointers.Ptr[int64](100),
+							RunAsGroup:          pointers.Ptr[int64](101),
+							FSGroup:             pointers.Ptr[int64](101),
+							FSGroupChangePolicy: pointers.Ptr(corev1.FSGroupChangeOnRootMismatch),
+						},
+						InitContainers: []corev1.Container{
+							{
+								Name:                     "foo",
+								ImagePullPolicy:          corev1.PullIfNotPresent,
+								TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
+								Resources: corev1.ResourceRequirements{
+									Limits: corev1.ResourceList{
+										corev1.ResourceCPU:    resource.MustParse("1"),
+										corev1.ResourceMemory: resource.MustParse("500Mi"),
+									},
+									Requests: corev1.ResourceList{
+										corev1.ResourceCPU:    resource.MustParse("500m"),
+										corev1.ResourceMemory: resource.MustParse("100Mi"),
+									},
+								},
+								SecurityContext: &corev1.SecurityContext{
+									RunAsUser:                pointers.Ptr[int64](100),
+									RunAsGroup:               pointers.Ptr[int64](101),
+									AllowPrivilegeEscalation: pointers.Ptr(false),
+									ReadOnlyRootFilesystem:   pointers.Ptr(true),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "with containers",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithContainers(func() corev1.Container {
+						c, _ := container.NewContainer("foo")
+						return c
+					}()),
+				},
+			},
+			want: corev1.PodTemplate{
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "foo",
+						Namespace: "sourcegraph",
+						Annotations: map[string]string{
+							"kubectl.kubernetes.io/default-container": "foo",
+						},
+						Labels: map[string]string{
+							"app":    "foo",
+							"deploy": "sourcegraph",
+						},
+					},
+					Spec: corev1.PodSpec{
+						SecurityContext: &corev1.PodSecurityContext{
+							RunAsUser:           pointers.Ptr[int64](100),
+							RunAsGroup:          pointers.Ptr[int64](101),
+							FSGroup:             pointers.Ptr[int64](101),
+							FSGroupChangePolicy: pointers.Ptr(corev1.FSGroupChangeOnRootMismatch),
+						},
+						Containers: []corev1.Container{
+							{
+								Name:                     "foo",
+								ImagePullPolicy:          corev1.PullIfNotPresent,
+								TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
+								Resources: corev1.ResourceRequirements{
+									Limits: corev1.ResourceList{
+										corev1.ResourceCPU:    resource.MustParse("1"),
+										corev1.ResourceMemory: resource.MustParse("500Mi"),
+									},
+									Requests: corev1.ResourceList{
+										corev1.ResourceCPU:    resource.MustParse("500m"),
+										corev1.ResourceMemory: resource.MustParse("100Mi"),
+									},
+								},
+								SecurityContext: &corev1.SecurityContext{
+									RunAsUser:                pointers.Ptr[int64](100),
+									RunAsGroup:               pointers.Ptr[int64](101),
+									AllowPrivilegeEscalation: pointers.Ptr(false),
+									ReadOnlyRootFilesystem:   pointers.Ptr(true),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "with service account",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithServiceAccount("foobar"),
+				},
+			},
+			want: corev1.PodTemplate{
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "foo",
+						Namespace: "sourcegraph",
+						Annotations: map[string]string{
+							"kubectl.kubernetes.io/default-container": "foo",
+						},
+						Labels: map[string]string{
+							"app":    "foo",
+							"deploy": "sourcegraph",
+						},
+					},
+					Spec: corev1.PodSpec{
+						SecurityContext: &corev1.PodSecurityContext{
+							RunAsUser:           pointers.Ptr[int64](100),
+							RunAsGroup:          pointers.Ptr[int64](101),
+							FSGroup:             pointers.Ptr[int64](101),
+							FSGroupChangePolicy: pointers.Ptr(corev1.FSGroupChangeOnRootMismatch),
+						},
+						ServiceAccountName: "foobar",
+					},
+				},
+			},
+		},
+		{
+			name: "with security context",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithSecurityContext(corev1.PodSecurityContext{
+						RunAsUser:           pointers.Ptr[int64](999),
+						RunAsGroup:          pointers.Ptr[int64](101),
+						FSGroup:             pointers.Ptr[int64](101),
+						FSGroupChangePolicy: pointers.Ptr(corev1.FSGroupChangeAlways),
+					}),
+				},
+			},
+			want: corev1.PodTemplate{
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "foo",
+						Namespace: "sourcegraph",
+						Annotations: map[string]string{
+							"kubectl.kubernetes.io/default-container": "foo",
+						},
+						Labels: map[string]string{
+							"app":    "foo",
+							"deploy": "sourcegraph",
+						},
+					},
+					Spec: corev1.PodSpec{
+						SecurityContext: &corev1.PodSecurityContext{
+							RunAsUser:           pointers.Ptr[int64](999),
+							RunAsGroup:          pointers.Ptr[int64](101),
+							FSGroup:             pointers.Ptr[int64](101),
+							FSGroupChangePolicy: pointers.Ptr(corev1.FSGroupChangeAlways),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "with error",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					func(podTemplate *corev1.PodTemplate) error {
+						return errors.New("test error")
+					},
+				},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := NewPodTemplate(tt.args.name, tt.args.namespace, tt.args.options...)
+			if err != nil && tt.wantErr == false {
+				t.Errorf("NewPodTemplate() error: %v", err)
+			}
+			if err != nil && tt.wantErr == true {
+				return
+			}
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("NewPodTemplate() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/internal/k8s/resource/pvc/BUILD.bazel
+++ b/internal/k8s/resource/pvc/BUILD.bazel
@@ -1,0 +1,33 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("//dev:go_defs.bzl", "go_test")
+
+go_library(
+    name = "pvc",
+    srcs = ["pvc.go"],
+    importpath = "github.com/sourcegraph/sourcegraph/internal/k8s/resource/pvc",
+    visibility = ["//:__subpackages__"],
+    deps = [
+        "//internal/maps",
+        "//lib/pointers",
+        "@io_k8s_api//core/v1:core",
+        "@io_k8s_apimachinery//pkg/api/resource",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:meta",
+    ],
+)
+
+go_test(
+    name = "pvc_test",
+    srcs = [
+        "example_test.go",
+        "pvc_test.go",
+    ],
+    embed = [":pvc"],
+    deps = [
+        "//lib/pointers",
+        "@com_github_google_go_cmp//cmp",
+        "@io_k8s_api//core/v1:core",
+        "@io_k8s_apimachinery//pkg/api/resource",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:meta",
+        "@io_k8s_sigs_yaml//:yaml",
+    ],
+)

--- a/internal/k8s/resource/pvc/example_test.go
+++ b/internal/k8s/resource/pvc/example_test.go
@@ -1,0 +1,34 @@
+package pvc
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"sigs.k8s.io/yaml"
+)
+
+func ExamplePersistentVolumeClaim() {
+	p, _ := NewPersistentVolumeClaim("test", "sourcegraph")
+
+	jp, _ := json.Marshal(p)
+	fmt.Println(string(jp))
+
+	yp, _ := yaml.Marshal(p)
+	fmt.Println(string(yp))
+
+	// Output:
+	// {"metadata":{"name":"test","namespace":"sourcegraph","creationTimestamp":null,"labels":{"deploy":"sourcegraph"}},"spec":{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"10Gi"}}},"status":{}}
+	// metadata:
+	//   creationTimestamp: null
+	//   labels:
+	//     deploy: sourcegraph
+	//   name: test
+	//   namespace: sourcegraph
+	// spec:
+	//   accessModes:
+	//   - ReadWriteOnce
+	//   resources:
+	//     requests:
+	//       storage: 10Gi
+	// status: {}
+}

--- a/internal/k8s/resource/pvc/pvc.go
+++ b/internal/k8s/resource/pvc/pvc.go
@@ -1,0 +1,100 @@
+package pvc
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/sourcegraph/sourcegraph/internal/maps"
+	"github.com/sourcegraph/sourcegraph/lib/pointers"
+)
+
+// NewPersistentVolumeClaim creates a new k8s PVC with default values.
+//
+// Default values include:
+//
+//   - Access mode of `ReadWriteOnce`.
+//   - Storage request of 10Gi.
+//
+// Additional options can be passed to modify the default values.
+func NewPersistentVolumeClaim(name, namespace string, options ...Option) (corev1.PersistentVolumeClaim, error) {
+	pvc := corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				"deploy": "sourcegraph",
+			},
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			AccessModes: []corev1.PersistentVolumeAccessMode{
+				corev1.ReadWriteOnce,
+			},
+			Resources: corev1.VolumeResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceStorage: resource.MustParse("10Gi"),
+				},
+			},
+		},
+	}
+
+	for _, opt := range options {
+		err := opt(&pvc)
+		if err != nil {
+			return corev1.PersistentVolumeClaim{}, err
+		}
+	}
+
+	return pvc, nil
+}
+
+// Option sets an option for a PVC.
+type Option func(pvc *corev1.PersistentVolumeClaim) error
+
+// WithLabels sets the PVC labels without overriding existing labels.
+func WithLabels(labels map[string]string) Option {
+	return func(pvc *corev1.PersistentVolumeClaim) error {
+		pvc.Labels = maps.MergePreservingExistingKeys(pvc.Labels, labels)
+		return nil
+	}
+}
+
+// WithAnnotations sets the PVC annotations without overriding existing annotations.
+func WithAnnotations(annotations map[string]string) Option {
+	return func(pvc *corev1.PersistentVolumeClaim) error {
+		pvc.Annotations = maps.MergePreservingExistingKeys(pvc.Annotations, annotations)
+		return nil
+	}
+}
+
+// WithAccessMode sets the Access Mode for the PVC.
+func WithAccessMode(accessModes []corev1.PersistentVolumeAccessMode) Option {
+	return func(pvc *corev1.PersistentVolumeClaim) error {
+		pvc.Spec.AccessModes = accessModes
+		return nil
+	}
+}
+
+// WithResources sets the given Resource Requirements for the PVC.
+func WithResources(resources corev1.VolumeResourceRequirements) Option {
+	return func(pvc *corev1.PersistentVolumeClaim) error {
+		pvc.Spec.Resources = resources
+		return nil
+	}
+}
+
+// WithStorageClassName sets the storage class name for the PVC.
+func WithStorageClassName(storageClassName string) Option {
+	return func(pvc *corev1.PersistentVolumeClaim) error {
+		pvc.Spec.StorageClassName = pointers.Ptr(storageClassName)
+		return nil
+	}
+}
+
+// WithVolumeName sets the given volume name for the PVC.
+func WithVolumeName(volumeName string) Option {
+	return func(pvc *corev1.PersistentVolumeClaim) error {
+		pvc.Spec.VolumeName = volumeName
+		return nil
+	}
+}

--- a/internal/k8s/resource/pvc/pvc_test.go
+++ b/internal/k8s/resource/pvc/pvc_test.go
@@ -1,0 +1,260 @@
+package pvc
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/sourcegraph/sourcegraph/lib/pointers"
+)
+
+func TestNewPersistentVolumeClaim(t *testing.T) {
+	t.Parallel()
+
+	type args struct {
+		name      string
+		namespace string
+		options   []Option
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want corev1.PersistentVolumeClaim
+	}{
+		{
+			name: "default pvc",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+			},
+			want: corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph",
+					},
+				},
+				Spec: corev1.PersistentVolumeClaimSpec{
+					AccessModes: []corev1.PersistentVolumeAccessMode{
+						corev1.ReadWriteOnce,
+					},
+					Resources: corev1.VolumeResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceStorage: resource.MustParse("10Gi"),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "with labels",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithLabels(map[string]string{
+						"app":    "foobar",
+						"deploy": "horsegraph",
+					}),
+				},
+			},
+			want: corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"app":    "foobar",
+						"deploy": "sourcegraph",
+					},
+				},
+				Spec: corev1.PersistentVolumeClaimSpec{
+					AccessModes: []corev1.PersistentVolumeAccessMode{
+						corev1.ReadWriteOnce,
+					},
+					Resources: corev1.VolumeResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceStorage: resource.MustParse("10Gi"),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "with annotations",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithAnnotations(map[string]string{
+						"app": "horsegraph",
+					}),
+				},
+			},
+			want: corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph",
+					},
+					Annotations: map[string]string{
+						"app": "horsegraph",
+					},
+				},
+				Spec: corev1.PersistentVolumeClaimSpec{
+					AccessModes: []corev1.PersistentVolumeAccessMode{
+						corev1.ReadWriteOnce,
+					},
+					Resources: corev1.VolumeResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceStorage: resource.MustParse("10Gi"),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "with access mode",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithAccessMode([]corev1.PersistentVolumeAccessMode{
+						corev1.ReadWriteMany,
+					}),
+				},
+			},
+			want: corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph",
+					},
+				},
+				Spec: corev1.PersistentVolumeClaimSpec{
+					AccessModes: []corev1.PersistentVolumeAccessMode{
+						corev1.ReadWriteMany,
+					},
+					Resources: corev1.VolumeResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceStorage: resource.MustParse("10Gi"),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "with resources",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithResources(corev1.VolumeResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceStorage: resource.MustParse("100Gi"),
+						},
+					}),
+				},
+			},
+			want: corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph",
+					},
+				},
+				Spec: corev1.PersistentVolumeClaimSpec{
+					AccessModes: []corev1.PersistentVolumeAccessMode{
+						corev1.ReadWriteOnce,
+					},
+					Resources: corev1.VolumeResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceStorage: resource.MustParse("100Gi"),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "with storage class name",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithStorageClassName("sourcegraph"),
+				},
+			},
+			want: corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph",
+					},
+				},
+				Spec: corev1.PersistentVolumeClaimSpec{
+					AccessModes: []corev1.PersistentVolumeAccessMode{
+						corev1.ReadWriteOnce,
+					},
+					Resources: corev1.VolumeResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceStorage: resource.MustParse("10Gi"),
+						},
+					},
+					StorageClassName: pointers.Ptr("sourcegraph"),
+				},
+			},
+		},
+		{
+			name: "with volume name",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithVolumeName("testing"),
+				},
+			},
+			want: corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph",
+					},
+				},
+				Spec: corev1.PersistentVolumeClaimSpec{
+					AccessModes: []corev1.PersistentVolumeAccessMode{
+						corev1.ReadWriteOnce,
+					},
+					Resources: corev1.VolumeResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceStorage: resource.MustParse("10Gi"),
+						},
+					},
+					VolumeName: "testing",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := NewPersistentVolumeClaim(tt.args.name, tt.args.namespace, tt.args.options...)
+			if err != nil {
+				t.Errorf("NewPersistentVolumeClaim() error: %v", err)
+			}
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("NewPersistentVolumeClaim() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/internal/k8s/resource/role/BUILD.bazel
+++ b/internal/k8s/resource/role/BUILD.bazel
@@ -1,0 +1,29 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("//dev:go_defs.bzl", "go_test")
+
+go_library(
+    name = "role",
+    srcs = ["role.go"],
+    importpath = "github.com/sourcegraph/sourcegraph/internal/k8s/resource/role",
+    visibility = ["//:__subpackages__"],
+    deps = [
+        "//internal/maps",
+        "@io_k8s_api//rbac/v1:rbac",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:meta",
+    ],
+)
+
+go_test(
+    name = "role_test",
+    srcs = [
+        "example_test.go",
+        "role_test.go",
+    ],
+    embed = [":role"],
+    deps = [
+        "@com_github_google_go_cmp//cmp",
+        "@io_k8s_api//rbac/v1:rbac",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:meta",
+        "@io_k8s_sigs_yaml//:yaml",
+    ],
+)

--- a/internal/k8s/resource/role/example_test.go
+++ b/internal/k8s/resource/role/example_test.go
@@ -1,0 +1,28 @@
+package role
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"sigs.k8s.io/yaml"
+)
+
+func ExampleRole() {
+	r, _ := NewRole("test", "sourcegraph")
+
+	jr, _ := json.Marshal(r)
+	fmt.Println(string(jr))
+
+	yr, _ := yaml.Marshal(r)
+	fmt.Println(string(yr))
+
+	// Output:
+	// {"metadata":{"name":"test","namespace":"sourcegraph","creationTimestamp":null,"labels":{"deploy":"sourcegraph"}},"rules":null}
+	// metadata:
+	//   creationTimestamp: null
+	//   labels:
+	//     deploy: sourcegraph
+	//   name: test
+	//   namespace: sourcegraph
+	// rules: null
+}

--- a/internal/k8s/resource/role/role.go
+++ b/internal/k8s/resource/role/role.go
@@ -1,0 +1,71 @@
+package role
+
+import (
+	"sort"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/sourcegraph/sourcegraph/internal/maps"
+)
+
+// NewRole creates a new k8s RBAC role with default values.
+//
+// Default values include:
+//
+//   - Labels common for Sourcegraph deployments.
+//
+// Additional options can be passed to modify the default values.
+func NewRole(name, namespace string, options ...Option) (rbacv1.Role, error) {
+	role := rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				"deploy": "sourcegraph",
+			},
+		},
+	}
+
+	// apply any options
+	for _, opt := range options {
+		err := opt(&role)
+		if err != nil {
+			return rbacv1.Role{}, err
+		}
+	}
+
+	return role, nil
+}
+
+// Option sets an option for a Role.
+type Option func(role *rbacv1.Role) error
+
+// WithLabels sets Role labels without overriding existing labels.
+func WithLabels(labels map[string]string) Option {
+	return func(role *rbacv1.Role) error {
+		role.Labels = maps.MergePreservingExistingKeys(role.Labels, labels)
+		return nil
+	}
+}
+
+// WithAnnotations sets Role annotations without overriding existing annotations.
+func WithAnnotations(annotations map[string]string) Option {
+	return func(role *rbacv1.Role) error {
+		role.Annotations = maps.MergePreservingExistingKeys(role.Annotations, annotations)
+		return nil
+	}
+}
+
+// WithRules sets Role Policy Rules, sorting by name for accurate comparison of resources.
+func WithRules(rules []rbacv1.PolicyRule) Option {
+	return func(role *rbacv1.Role) error {
+		role.Rules = rules
+
+		sort.SliceStable(role.Rules, func(i, j int) bool {
+			return role.Rules[i].Verbs[0] < role.Rules[j].Verbs[0]
+		})
+
+		return nil
+	}
+}

--- a/internal/k8s/resource/role/role_test.go
+++ b/internal/k8s/resource/role/role_test.go
@@ -1,0 +1,134 @@
+package role
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestNewRole(t *testing.T) {
+	t.Parallel()
+
+	type args struct {
+		name      string
+		namespace string
+		options   []Option
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want rbacv1.Role
+	}{
+		{
+			name: "default role",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+			},
+			want: rbacv1.Role{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph",
+					},
+				},
+			},
+		},
+		{
+			name: "with labels",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithLabels(map[string]string{
+						"foo": "bar",
+					}),
+				},
+			},
+			want: rbacv1.Role{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph",
+						"foo":    "bar",
+					},
+				},
+			},
+		},
+		{
+			name: "with annotations",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithAnnotations(map[string]string{
+						"foo": "bar",
+					}),
+				},
+			},
+			want: rbacv1.Role{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph",
+					},
+					Annotations: map[string]string{
+						"foo": "bar",
+					},
+				},
+			},
+		},
+		{
+			name: "with rules",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithRules([]rbacv1.PolicyRule{
+						{
+							Verbs:     []string{"get", "list", "watch"},
+							APIGroups: []string{"core"},
+							Resources: []string{"pods"},
+						},
+					}),
+				},
+			},
+			want: rbacv1.Role{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph",
+					},
+				},
+				Rules: []rbacv1.PolicyRule{
+					{
+						Verbs:     []string{"get", "list", "watch"},
+						APIGroups: []string{"core"},
+						Resources: []string{"pods"},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := NewRole(tt.args.name, tt.args.namespace, tt.args.options...)
+			if err != nil {
+				t.Errorf("NewRole() error: %v", err)
+			}
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("NewRole() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/internal/k8s/resource/rolebinding/BUILD.bazel
+++ b/internal/k8s/resource/rolebinding/BUILD.bazel
@@ -1,0 +1,29 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("//dev:go_defs.bzl", "go_test")
+
+go_library(
+    name = "rolebinding",
+    srcs = ["rolebinding.go"],
+    importpath = "github.com/sourcegraph/sourcegraph/internal/k8s/resource/rolebinding",
+    visibility = ["//:__subpackages__"],
+    deps = [
+        "//internal/maps",
+        "@io_k8s_api//rbac/v1:rbac",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:meta",
+    ],
+)
+
+go_test(
+    name = "rolebinding_test",
+    srcs = [
+        "example_test.go",
+        "rolebinding_test.go",
+    ],
+    embed = [":rolebinding"],
+    deps = [
+        "@com_github_google_go_cmp//cmp",
+        "@io_k8s_api//rbac/v1:rbac",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:meta",
+        "@io_k8s_sigs_yaml//:yaml",
+    ],
+)

--- a/internal/k8s/resource/rolebinding/example_test.go
+++ b/internal/k8s/resource/rolebinding/example_test.go
@@ -1,0 +1,31 @@
+package rolebinding
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"sigs.k8s.io/yaml"
+)
+
+func ExampleRoleBinding() {
+	rb, _ := NewRoleBinding("test", "sourcegraph")
+
+	jrb, _ := json.Marshal(rb)
+	fmt.Println(string(jrb))
+
+	yrb, _ := yaml.Marshal(rb)
+	fmt.Println(string(yrb))
+
+	// Output:
+	// {"metadata":{"name":"test","namespace":"sourcegraph","creationTimestamp":null,"labels":{"deploy":"sourcegraph"}},"roleRef":{"apiGroup":"","kind":"","name":""}}
+	// metadata:
+	//   creationTimestamp: null
+	//   labels:
+	//     deploy: sourcegraph
+	//   name: test
+	//   namespace: sourcegraph
+	// roleRef:
+	//   apiGroup: ""
+	//   kind: ""
+	//   name: ""
+}

--- a/internal/k8s/resource/rolebinding/rolebinding.go
+++ b/internal/k8s/resource/rolebinding/rolebinding.go
@@ -1,0 +1,72 @@
+package rolebinding
+
+import (
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/sourcegraph/sourcegraph/internal/maps"
+)
+
+// NewRoleBinding creates a new k8s RoleBinding with default values.
+//
+// Default values include:
+//
+//   - Labels common for Sourcegraph deployments.
+//
+// Additional options can be passed to modify the default values.
+func NewRoleBinding(name, namespace string, options ...Option) (rbacv1.RoleBinding, error) {
+	roleBinding := rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				"deploy": "sourcegraph",
+			},
+		},
+	}
+
+	// apply any given options
+	for _, opt := range options {
+		err := opt(&roleBinding)
+		if err != nil {
+			return rbacv1.RoleBinding{}, err
+		}
+	}
+
+	return roleBinding, nil
+}
+
+// Option sets an option for a RoleBinding.
+type Option func(rolebinding *rbacv1.RoleBinding) error
+
+// WithLabels sets RoleBinding labels without overriding existing labels.
+func WithLabels(labels map[string]string) Option {
+	return func(rolebinding *rbacv1.RoleBinding) error {
+		rolebinding.Labels = maps.MergePreservingExistingKeys(rolebinding.Labels, labels)
+		return nil
+	}
+}
+
+// WithAnnotations sets RoleBinding annotations without overriding existing labels.
+func WithAnnotations(annotations map[string]string) Option {
+	return func(rolebinding *rbacv1.RoleBinding) error {
+		rolebinding.Annotations = maps.MergePreservingExistingKeys(rolebinding.Annotations, annotations)
+		return nil
+	}
+}
+
+// WithRoleRef sets the given RoleRef for the RoleBinding.
+func WithRoleRef(roleRef rbacv1.RoleRef) Option {
+	return func(rolebinding *rbacv1.RoleBinding) error {
+		rolebinding.RoleRef = roleRef
+		return nil
+	}
+}
+
+// WithSubjects sets the given Subjects for the RoleBinding.
+func WithSubjects(subjects []rbacv1.Subject) Option {
+	return func(rolebinding *rbacv1.RoleBinding) error {
+		rolebinding.Subjects = subjects
+		return nil
+	}
+}

--- a/internal/k8s/resource/rolebinding/rolebinding_test.go
+++ b/internal/k8s/resource/rolebinding/rolebinding_test.go
@@ -1,0 +1,162 @@
+package rolebinding
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestNewRoleBinding(t *testing.T) {
+	t.Parallel()
+
+	type args struct {
+		name      string
+		namespace string
+		options   []Option
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want rbacv1.RoleBinding
+	}{
+		{
+			name: "default rolebindings",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+			},
+			want: rbacv1.RoleBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph",
+					},
+				},
+			},
+		},
+		{
+			name: "with labels",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithLabels(map[string]string{
+						"foo": "bar",
+					}),
+				},
+			},
+			want: rbacv1.RoleBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph",
+						"foo":    "bar",
+					},
+				},
+			},
+		},
+		{
+			name: "with annotations",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithAnnotations(map[string]string{
+						"foo": "bar",
+					}),
+				},
+			},
+			want: rbacv1.RoleBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph",
+					},
+					Annotations: map[string]string{
+						"foo": "bar",
+					},
+				},
+			},
+		},
+		{
+			name: "with role ref",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithRoleRef(rbacv1.RoleRef{
+						APIGroup: "rbac.authorization.k8s.io",
+						Kind:     "Role",
+						Name:     "foorole",
+					}),
+				},
+			},
+			want: rbacv1.RoleBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph",
+					},
+				},
+				RoleRef: rbacv1.RoleRef{
+					APIGroup: "rbac.authorization.k8s.io",
+					Kind:     "Role",
+					Name:     "foorole",
+				},
+			},
+		},
+		{
+			name: "with subjects",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithSubjects([]rbacv1.Subject{
+						{
+							Kind:     "User",
+							Name:     "foouser",
+							APIGroup: "rbac.authorization.k8s.io",
+						},
+					}),
+				},
+			},
+			want: rbacv1.RoleBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph",
+					},
+				},
+				Subjects: []rbacv1.Subject{
+					{
+						Kind:     "User",
+						Name:     "foouser",
+						APIGroup: "rbac.authorization.k8s.io",
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := NewRoleBinding(tt.args.name, tt.args.namespace, tt.args.options...)
+			if err != nil {
+				t.Errorf("NewRoleBinding() error: %v", err)
+			}
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("NewRoleBinding() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/internal/k8s/resource/secret/BUILD.bazel
+++ b/internal/k8s/resource/secret/BUILD.bazel
@@ -1,0 +1,31 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("//dev:go_defs.bzl", "go_test")
+
+go_library(
+    name = "secret",
+    srcs = ["secret.go"],
+    importpath = "github.com/sourcegraph/sourcegraph/internal/k8s/resource/secret",
+    visibility = ["//:__subpackages__"],
+    deps = [
+        "//internal/maps",
+        "//lib/pointers",
+        "@io_k8s_api//core/v1:core",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:meta",
+    ],
+)
+
+go_test(
+    name = "secret_test",
+    srcs = [
+        "example_test.go",
+        "secret_test.go",
+    ],
+    embed = [":secret"],
+    deps = [
+        "//lib/pointers",
+        "@com_github_google_go_cmp//cmp",
+        "@io_k8s_api//core/v1:core",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:meta",
+        "@io_k8s_sigs_yaml//:yaml",
+    ],
+)

--- a/internal/k8s/resource/secret/example_test.go
+++ b/internal/k8s/resource/secret/example_test.go
@@ -1,0 +1,29 @@
+package secret
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"sigs.k8s.io/yaml"
+)
+
+func ExampleSecret() {
+	s, _ := NewSecret("test", "sourcegraph")
+
+	js, _ := json.Marshal(s)
+	fmt.Println(string(js))
+
+	ys, _ := yaml.Marshal(s)
+	fmt.Println(string(ys))
+
+	// Output:
+	// {"metadata":{"name":"test","namespace":"sourcegraph","creationTimestamp":null,"labels":{"deploy":"sourcegraph"}},"immutable":false,"type":"Opaque"}
+	// immutable: false
+	// metadata:
+	//   creationTimestamp: null
+	//   labels:
+	//     deploy: sourcegraph
+	//   name: test
+	//   namespace: sourcegraph
+	// type: Opaque
+}

--- a/internal/k8s/resource/secret/secret.go
+++ b/internal/k8s/resource/secret/secret.go
@@ -1,0 +1,91 @@
+package secret
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/sourcegraph/sourcegraph/internal/maps"
+	"github.com/sourcegraph/sourcegraph/lib/pointers"
+)
+
+// NewSecret creates a new k8s Secret with default values.
+//
+// Default values include:
+//
+//   - Immutable set to false.
+//   - Default type of `SecretTypeOpaque`
+//
+// Additional options can be passed to modify the default values.
+func NewSecret(name, namespace string, options ...Option) (corev1.Secret, error) {
+	secret := corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				"deploy": "sourcegraph",
+			},
+		},
+		Immutable: pointers.Ptr(false),
+		Type:      corev1.SecretTypeOpaque,
+	}
+
+	// apply any options
+	for _, opt := range options {
+		err := opt(&secret)
+		if err != nil {
+			return corev1.Secret{}, err
+		}
+	}
+	return secret, nil
+}
+
+// Option sets an option for a Secret.
+type Option func(secret *corev1.Secret) error
+
+// WithLabels sets Secret labels without overriding existing labels.
+func WithLabels(labels map[string]string) Option {
+	return func(secret *corev1.Secret) error {
+		secret.Labels = maps.MergePreservingExistingKeys(secret.Labels, labels)
+		return nil
+	}
+}
+
+// WithAnnotations sets Secret annotations without overriding existing annotations.
+func WithAnnotations(annotations map[string]string) Option {
+	return func(secret *corev1.Secret) error {
+		secret.Annotations = maps.MergePreservingExistingKeys(secret.Annotations, annotations)
+		return nil
+	}
+}
+
+// Immutable sets a secret to be immutable.
+func Immutable() Option {
+	return func(secret *corev1.Secret) error {
+		secret.Immutable = pointers.Ptr(true)
+		return nil
+	}
+}
+
+// WithData sets the given binary data to a Secret.
+func WithData(data map[string][]byte) Option {
+	return func(secret *corev1.Secret) error {
+		secret.Data = data
+		return nil
+	}
+}
+
+// WithStringData sets the given string data to a Secret.
+func WithStringData(data map[string]string) Option {
+	return func(secret *corev1.Secret) error {
+		secret.StringData = data
+		return nil
+	}
+}
+
+// OfType sets the given SecretType to the Secret.
+func OfType(secretType corev1.SecretType) Option {
+	return func(secret *corev1.Secret) error {
+		secret.Type = secretType
+		return nil
+	}
+}

--- a/internal/k8s/resource/secret/secret_test.go
+++ b/internal/k8s/resource/secret/secret_test.go
@@ -1,0 +1,206 @@
+package secret
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/sourcegraph/sourcegraph/lib/pointers"
+)
+
+func TestNewSecret(t *testing.T) {
+	t.Parallel()
+
+	type args struct {
+		name      string
+		namespace string
+		options   []Option
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want corev1.Secret
+	}{
+		{
+			name: "default secret",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+			},
+			want: corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph",
+					},
+				},
+				Immutable: pointers.Ptr(false),
+				Type:      corev1.SecretTypeOpaque,
+			},
+		},
+		{
+			name: "with labels",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithLabels(map[string]string{
+						"foo": "bar",
+					}),
+				},
+			},
+			want: corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph",
+						"foo":    "bar",
+					},
+				},
+				Immutable: pointers.Ptr(false),
+				Type:      corev1.SecretTypeOpaque,
+			},
+		},
+		{
+			name: "with annotations",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithAnnotations(map[string]string{
+						"foo": "bar",
+					}),
+				},
+			},
+			want: corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph",
+					},
+					Annotations: map[string]string{
+						"foo": "bar",
+					},
+				},
+				Immutable: pointers.Ptr(false),
+				Type:      corev1.SecretTypeOpaque,
+			},
+		},
+		{
+			name: "immutable",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					Immutable(),
+				},
+			},
+			want: corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph",
+					},
+				},
+				Immutable: pointers.Ptr(true),
+				Type:      corev1.SecretTypeOpaque,
+			},
+		},
+		{
+			name: "with data",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithData(map[string][]byte{
+						"username": []byte("myuser"),
+						"password": []byte("mypass"),
+					}),
+				},
+			},
+			want: corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph",
+					},
+				},
+				Immutable: pointers.Ptr(false),
+				Data: map[string][]byte{
+					"username": []byte("myuser"),
+					"password": []byte("mypass"),
+				},
+				Type: corev1.SecretTypeOpaque,
+			},
+		},
+		{
+			name: "with string data",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithStringData(map[string]string{
+						"foo": "bar",
+					}),
+				},
+			},
+			want: corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph",
+					},
+				},
+				Immutable: pointers.Ptr(false),
+				StringData: map[string]string{
+					"foo": "bar",
+				},
+				Type: corev1.SecretTypeOpaque,
+			},
+		},
+		{
+			name: "of type",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					OfType(corev1.SecretTypeBasicAuth),
+				},
+			},
+			want: corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph",
+					},
+				},
+				Immutable: pointers.Ptr(false),
+				Type:      corev1.SecretTypeBasicAuth,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := NewSecret(tt.args.name, tt.args.namespace, tt.args.options...)
+			if err != nil {
+				t.Errorf("NewPodTemplate() error: %v", err)
+			}
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("NewSecret() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/internal/k8s/resource/service/BUILD.bazel
+++ b/internal/k8s/resource/service/BUILD.bazel
@@ -1,0 +1,30 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("//dev:go_defs.bzl", "go_test")
+
+go_library(
+    name = "service",
+    srcs = ["service.go"],
+    importpath = "github.com/sourcegraph/sourcegraph/internal/k8s/resource/service",
+    visibility = ["//:__subpackages__"],
+    deps = [
+        "//internal/maps",
+        "@io_k8s_api//core/v1:core",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:meta",
+    ],
+)
+
+go_test(
+    name = "service_test",
+    srcs = [
+        "example_test.go",
+        "service_test.go",
+    ],
+    embed = [":service"],
+    deps = [
+        "@com_github_google_go_cmp//cmp",
+        "@io_k8s_api//core/v1:core",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:meta",
+        "@io_k8s_apimachinery//pkg/util/intstr",
+        "@io_k8s_sigs_yaml//:yaml",
+    ],
+)

--- a/internal/k8s/resource/service/example_test.go
+++ b/internal/k8s/resource/service/example_test.go
@@ -1,0 +1,34 @@
+package service
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"sigs.k8s.io/yaml"
+)
+
+func ExampleService() {
+	s, _ := NewService("test", "sourcegraph")
+
+	js, _ := json.Marshal(s)
+	fmt.Println(string(js))
+
+	ys, _ := yaml.Marshal(s)
+	fmt.Println(string(ys))
+
+	// Output:
+	// {"metadata":{"name":"test","namespace":"sourcegraph","creationTimestamp":null,"labels":{"app":"test","deploy":"sourcegraph"}},"spec":{"selector":{"app":"test"},"type":"ClusterIP"},"status":{"loadBalancer":{}}}
+	// metadata:
+	//   creationTimestamp: null
+	//   labels:
+	//     app: test
+	//     deploy: sourcegraph
+	//   name: test
+	//   namespace: sourcegraph
+	// spec:
+	//   selector:
+	//     app: test
+	//   type: ClusterIP
+	// status:
+	//   loadBalancer: {}
+}

--- a/internal/k8s/resource/service/service.go
+++ b/internal/k8s/resource/service/service.go
@@ -1,0 +1,116 @@
+package service
+
+import (
+	"sort"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/sourcegraph/sourcegraph/internal/maps"
+)
+
+// NewService creates a new k8s Service with default values.
+//
+// Default values include:
+//   - Selector based on the provided service name.
+//   - Service type of Cluster IP.
+//
+// Additional options can be passed to modify the default values.
+func NewService(name, namespace string, options ...Option) (corev1.Service, error) {
+	service := corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				"app":    name,
+				"deploy": "sourcegraph",
+			},
+		},
+		Spec: corev1.ServiceSpec{
+			Selector: map[string]string{
+				"app": name,
+			},
+			Type: corev1.ServiceTypeClusterIP,
+		},
+	}
+
+	// apply any given options
+	for _, opt := range options {
+		err := opt(&service)
+		if err != nil {
+			return corev1.Service{}, err
+		}
+	}
+
+	return service, nil
+}
+
+// Option sets an option for a Service.
+type Option func(service *corev1.Service) error
+
+// WithLabels sets Service labels without overriding existing labels.
+func WithLabels(labels map[string]string) Option {
+	return func(service *corev1.Service) error {
+		service.Labels = maps.MergePreservingExistingKeys(service.Labels, labels)
+		return nil
+	}
+}
+
+// WithAnnotations sets Service annotations without overriding existing annotations.
+func WithAnnotations(annotations map[string]string) Option {
+	return func(service *corev1.Service) error {
+		service.Annotations = maps.MergePreservingExistingKeys(service.Annotations, annotations)
+		return nil
+	}
+}
+
+// WithPorts adds the provided ServicePorts to the Service if they do not already exist.
+// It also sorts the Ports by name for accurate comparison of resources.
+func WithPorts(ports ...corev1.ServicePort) Option {
+	return func(service *corev1.Service) error {
+		for _, p := range ports {
+			if !portExists(p.Name, service) {
+				service.Spec.Ports = append(service.Spec.Ports, p)
+			}
+		}
+
+		// sort ports by name
+		sort.SliceStable(service.Spec.Ports, func(i, j int) bool {
+			return service.Spec.Ports[i].Name < service.Spec.Ports[j].Name
+		})
+		return nil
+	}
+}
+
+func portExists(name string, service *corev1.Service) bool {
+	for _, p := range service.Spec.Ports {
+		if p.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+// WithSelector sets the given selector as the Selector on the Service.
+func WithSelector(selector map[string]string) Option {
+	return func(service *corev1.Service) error {
+		service.Spec.Selector = selector
+		return nil
+	}
+}
+
+// WithServiceType sets the given serviceType on the Service.
+func WithServiceType(serviceType corev1.ServiceType) Option {
+	return func(service *corev1.Service) error {
+		service.Spec.Type = serviceType
+		return nil
+	}
+}
+
+// WithClusterIP sets the Service cluster IP manually.
+func WithClusterIP(clusterIP string) Option {
+	return func(service *corev1.Service) error {
+		service.Spec.ClusterIP = clusterIP
+		return nil
+	}
+}

--- a/internal/k8s/resource/service/service_test.go
+++ b/internal/k8s/resource/service/service_test.go
@@ -1,0 +1,251 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+func TestNewService(t *testing.T) {
+	t.Parallel()
+
+	type args struct {
+		name      string
+		namespace string
+		options   []Option
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want corev1.Service
+	}{
+		{
+			name: "default service",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+			},
+			want: corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"app":    "foo",
+						"deploy": "sourcegraph",
+					},
+				},
+				Spec: corev1.ServiceSpec{
+					Selector: map[string]string{
+						"app": "foo",
+					},
+					Type: corev1.ServiceTypeClusterIP,
+				},
+			},
+		},
+		{
+			name: "with labels",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithLabels(map[string]string{
+						"app":         "bar",
+						"deploy":      "horsegraph",
+						"environment": "testing",
+					}),
+				},
+			},
+			want: corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"app":         "foo",
+						"deploy":      "sourcegraph",
+						"environment": "testing",
+					},
+				},
+				Spec: corev1.ServiceSpec{
+					Selector: map[string]string{
+						"app": "foo",
+					},
+					Type: corev1.ServiceTypeClusterIP,
+				},
+			},
+		},
+		{
+			name: "with annotations",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithAnnotations(map[string]string{
+						"foo":  "bar",
+						"type": "test",
+					}),
+				},
+			},
+			want: corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"app":    "foo",
+						"deploy": "sourcegraph",
+					},
+					Annotations: map[string]string{
+						"foo":  "bar",
+						"type": "test",
+					},
+				},
+				Spec: corev1.ServiceSpec{
+					Selector: map[string]string{
+						"app": "foo",
+					},
+					Type: corev1.ServiceTypeClusterIP,
+				},
+			},
+		},
+		{
+			name: "with ports",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithPorts([]corev1.ServicePort{
+						{
+							Name:     "http",
+							Protocol: "TCP",
+							Port:     8080,
+							TargetPort: intstr.IntOrString{
+								Type:   0,
+								IntVal: 8080,
+							},
+							NodePort: 8080,
+						},
+						{
+							Name:     "app",
+							Protocol: "TCP",
+							Port:     400,
+							TargetPort: intstr.IntOrString{
+								Type:   0,
+								IntVal: 400,
+							},
+							NodePort: 400,
+						},
+					}...),
+				},
+			},
+			want: corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"app":    "foo",
+						"deploy": "sourcegraph",
+					},
+				},
+				Spec: corev1.ServiceSpec{
+					Selector: map[string]string{
+						"app": "foo",
+					},
+					Type: corev1.ServiceTypeClusterIP,
+					Ports: []corev1.ServicePort{
+						{
+							Name:     "app",
+							Protocol: "TCP",
+							Port:     400,
+							TargetPort: intstr.IntOrString{
+								Type:   0,
+								IntVal: 400,
+							},
+							NodePort: 400,
+						},
+						{
+							Name:     "http",
+							Protocol: "TCP",
+							Port:     8080,
+							TargetPort: intstr.IntOrString{
+								Type:   0,
+								IntVal: 8080,
+							},
+							NodePort: 8080,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "with selector",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithSelector(map[string]string{
+						"app": "horsegraph",
+					}),
+				},
+			},
+			want: corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"app":    "foo",
+						"deploy": "sourcegraph",
+					},
+				},
+				Spec: corev1.ServiceSpec{
+					Selector: map[string]string{
+						"app": "horsegraph",
+					},
+					Type: corev1.ServiceTypeClusterIP,
+				},
+			},
+		},
+		{
+			name: "with service type",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithServiceType(corev1.ServiceTypeLoadBalancer),
+				},
+			},
+			want: corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"app":    "foo",
+						"deploy": "sourcegraph",
+					},
+				},
+				Spec: corev1.ServiceSpec{
+					Selector: map[string]string{
+						"app": "foo",
+					},
+					Type: corev1.ServiceTypeLoadBalancer,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := NewService(tt.args.name, tt.args.namespace, tt.args.options...)
+			if err != nil {
+				t.Errorf("NewContainer() error: %v", err)
+			}
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("NewService() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/internal/k8s/resource/serviceaccount/BUILD.bazel
+++ b/internal/k8s/resource/serviceaccount/BUILD.bazel
@@ -1,0 +1,29 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("//dev:go_defs.bzl", "go_test")
+
+go_library(
+    name = "serviceaccount",
+    srcs = ["serviceaccount.go"],
+    importpath = "github.com/sourcegraph/sourcegraph/internal/k8s/resource/serviceaccount",
+    visibility = ["//:__subpackages__"],
+    deps = [
+        "//internal/maps",
+        "@io_k8s_api//core/v1:core",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:meta",
+    ],
+)
+
+go_test(
+    name = "serviceaccount_test",
+    srcs = [
+        "example_test.go",
+        "serviceaccount_test.go",
+    ],
+    embed = [":serviceaccount"],
+    deps = [
+        "@com_github_google_go_cmp//cmp",
+        "@io_k8s_api//core/v1:core",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:meta",
+        "@io_k8s_sigs_yaml//:yaml",
+    ],
+)

--- a/internal/k8s/resource/serviceaccount/example_test.go
+++ b/internal/k8s/resource/serviceaccount/example_test.go
@@ -1,0 +1,27 @@
+package serviceaccount
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"sigs.k8s.io/yaml"
+)
+
+func ExampleServiceAccount() {
+	sa, _ := NewServiceAccount("test", "sourcegraph")
+
+	sat, _ := json.Marshal(sa)
+	fmt.Println(string(sat))
+
+	yat, _ := yaml.Marshal(sa)
+	fmt.Println(string(yat))
+
+	// Output:
+	// {"metadata":{"name":"test","namespace":"sourcegraph","creationTimestamp":null,"labels":{"deploy":"sourcegraph"}}}
+	// metadata:
+	//   creationTimestamp: null
+	//   labels:
+	//     deploy: sourcegraph
+	//   name: test
+	//   namespace: sourcegraph
+}

--- a/internal/k8s/resource/serviceaccount/serviceaccount.go
+++ b/internal/k8s/resource/serviceaccount/serviceaccount.go
@@ -1,0 +1,56 @@
+package serviceaccount
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/sourcegraph/sourcegraph/internal/maps"
+)
+
+// NewServiceAccount creates a new k8s ServiceAccount with default values.
+//
+// Default values include:
+//
+//   - Labels common for Sourcegraph deployments.
+//
+// Additional options can be passed to modify the default values.
+func NewServiceAccount(name, namespace string, options ...Option) (corev1.ServiceAccount, error) {
+	serviceAccount := corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				"deploy": "sourcegraph",
+			},
+		},
+	}
+
+	// apply any given options
+	for _, opt := range options {
+		err := opt(&serviceAccount)
+		if err != nil {
+			return corev1.ServiceAccount{}, err
+		}
+	}
+
+	return serviceAccount, nil
+}
+
+// Option sets an option for a ServiceAccount.
+type Option func(serviceAccount *corev1.ServiceAccount) error
+
+// WithLabels sets ServiceAccount labels without overriding existing labels.
+func WithLabels(labels map[string]string) Option {
+	return func(serviceAccount *corev1.ServiceAccount) error {
+		serviceAccount.Labels = maps.MergePreservingExistingKeys(serviceAccount.Labels, labels)
+		return nil
+	}
+}
+
+// WithAnnotations sets ServiceAccount annotations without overriding existing annotations.
+func WithAnnotations(annotations map[string]string) Option {
+	return func(serviceAccount *corev1.ServiceAccount) error {
+		serviceAccount.Annotations = maps.MergePreservingExistingKeys(serviceAccount.Annotations, annotations)
+		return nil
+	}
+}

--- a/internal/k8s/resource/serviceaccount/serviceaccount_test.go
+++ b/internal/k8s/resource/serviceaccount/serviceaccount_test.go
@@ -1,0 +1,102 @@
+package serviceaccount
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestNewServiceAccount(t *testing.T) {
+	t.Parallel()
+
+	type args struct {
+		name      string
+		namespace string
+		options   []Option
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want corev1.ServiceAccount
+	}{
+		{
+			name: "default service account",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+			},
+			want: corev1.ServiceAccount{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph",
+					},
+				},
+			},
+		},
+		{
+			name: "with labels",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithLabels(map[string]string{
+						"foo": "bar",
+					}),
+				},
+			},
+			want: corev1.ServiceAccount{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph",
+						"foo":    "bar",
+					},
+				},
+			},
+		},
+		{
+			name: "with annotations",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithAnnotations(map[string]string{
+						"foo": "bar",
+					}),
+				},
+			},
+			want: corev1.ServiceAccount{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph",
+					},
+					Annotations: map[string]string{
+						"foo": "bar",
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := NewServiceAccount(tt.args.name, tt.args.namespace, tt.args.options...)
+			if err != nil {
+				t.Errorf("NewServiceAccount() error: %v", err)
+			}
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("NewServiceAccount() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/internal/k8s/resource/statefulset/BUILD.bazel
+++ b/internal/k8s/resource/statefulset/BUILD.bazel
@@ -1,0 +1,35 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("//dev:go_defs.bzl", "go_test")
+
+go_library(
+    name = "statefulset",
+    srcs = ["statefulset.go"],
+    importpath = "github.com/sourcegraph/sourcegraph/internal/k8s/resource/statefulset",
+    visibility = ["//:__subpackages__"],
+    deps = [
+        "//internal/maps",
+        "//lib/pointers",
+        "@io_k8s_api//apps/v1:apps",
+        "@io_k8s_api//core/v1:core",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:meta",
+    ],
+)
+
+go_test(
+    name = "statefulset_test",
+    srcs = [
+        "example_test.go",
+        "statefulset_test.go",
+    ],
+    embed = [":statefulset"],
+    deps = [
+        "//internal/k8s/resource/pod",
+        "//lib/pointers",
+        "@com_github_google_go_cmp//cmp",
+        "@io_k8s_api//apps/v1:apps",
+        "@io_k8s_api//core/v1:core",
+        "@io_k8s_apimachinery//pkg/api/resource",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:meta",
+        "@io_k8s_sigs_yaml//:yaml",
+    ],
+)

--- a/internal/k8s/resource/statefulset/example_test.go
+++ b/internal/k8s/resource/statefulset/example_test.go
@@ -1,0 +1,46 @@
+package statefulset
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"sigs.k8s.io/yaml"
+)
+
+func ExampleStatefulSet() {
+	ss, _ := NewStatefulSet("test", "sourcegraph")
+
+	jss, _ := json.Marshal(ss)
+	fmt.Println(string(jss))
+
+	yss, _ := yaml.Marshal(ss)
+	fmt.Println(string(yss))
+
+	// Output:
+	// {"metadata":{"name":"test","namespace":"sourcegraph","creationTimestamp":null,"labels":{"deploy":"sourcegraph"}},"spec":{"replicas":1,"selector":{"matchLabels":{"app":"test"}},"template":{"metadata":{"creationTimestamp":null},"spec":{"containers":null}},"serviceName":"test","podManagementPolicy":"OrderedReady","updateStrategy":{"type":"RollingUpdate"},"revisionHistoryLimit":10,"minReadySeconds":10},"status":{"replicas":0,"availableReplicas":0}}
+	// metadata:
+	//   creationTimestamp: null
+	//   labels:
+	//     deploy: sourcegraph
+	//   name: test
+	//   namespace: sourcegraph
+	// spec:
+	//   minReadySeconds: 10
+	//   podManagementPolicy: OrderedReady
+	//   replicas: 1
+	//   revisionHistoryLimit: 10
+	//   selector:
+	//     matchLabels:
+	//       app: test
+	//   serviceName: test
+	//   template:
+	//     metadata:
+	//       creationTimestamp: null
+	//     spec:
+	//       containers: null
+	//   updateStrategy:
+	//     type: RollingUpdate
+	// status:
+	//   availableReplicas: 0
+	//   replicas: 0
+}

--- a/internal/k8s/resource/statefulset/statefulset.go
+++ b/internal/k8s/resource/statefulset/statefulset.go
@@ -1,0 +1,152 @@
+package statefulset
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/sourcegraph/sourcegraph/internal/maps"
+	"github.com/sourcegraph/sourcegraph/lib/pointers"
+)
+
+// NewStatefulSet creates a new k8s StatefulSet with default values.
+//
+// Default values include:
+//
+//   - MinReadySeconds: 10
+//   - RevisionHistoryLimit: 10
+//   - UpdateStrategy: RollingUpdateStrategy
+//   - PodManagementPolicy: OrderedReadyPodManagement
+//   - ServiceName: <name>
+//   - Selector: "app": <name>
+//   - Replicas: 1
+//
+// Additional options can be passed to modify the default values.
+func NewStatefulSet(name, namespace string, options ...Option) (appsv1.StatefulSet, error) {
+	statefulSet := appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				"deploy": "sourcegraph",
+			},
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: pointers.Ptr[int32](1),
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app": name,
+				},
+			},
+			ServiceName:         name,
+			PodManagementPolicy: appsv1.OrderedReadyPodManagement,
+			UpdateStrategy: appsv1.StatefulSetUpdateStrategy{
+				Type: appsv1.RollingUpdateStatefulSetStrategyType,
+			},
+			RevisionHistoryLimit: pointers.Ptr[int32](10),
+			MinReadySeconds:      int32(10),
+		},
+	}
+
+	// apply any given options
+	for _, opt := range options {
+		err := opt(&statefulSet)
+		if err != nil {
+			return appsv1.StatefulSet{}, err
+		}
+	}
+
+	return statefulSet, nil
+}
+
+// Option sets an option for a StatefulSet.
+type Option func(statefulSet *appsv1.StatefulSet) error
+
+// WithLabels sets StatefulSet labels without overriding existing labels.
+func WithLabels(labels map[string]string) Option {
+	return func(statefulSet *appsv1.StatefulSet) error {
+		statefulSet.Labels = maps.MergePreservingExistingKeys(statefulSet.Labels, labels)
+		return nil
+	}
+}
+
+// WithAnnotations sets StatefulSet annotations without overriding existing annotations.
+func WithAnnotations(annotations map[string]string) Option {
+	return func(statefulSet *appsv1.StatefulSet) error {
+		statefulSet.Annotations = maps.MergePreservingExistingKeys(statefulSet.Annotations, annotations)
+		return nil
+	}
+}
+
+// WithReplicas sets the given number of Replicas for the StatefulSet.
+func WithReplicas(replicas int32) Option {
+	return func(statefulSet *appsv1.StatefulSet) error {
+		statefulSet.Spec.Replicas = pointers.Ptr[int32](replicas)
+		return nil
+	}
+}
+
+// WithSelector sets the given Selector for the StatefulSet.
+func WithSelector(selector metav1.LabelSelector) Option {
+	return func(statefulSet *appsv1.StatefulSet) error {
+		statefulSet.Spec.Selector = &selector
+		return nil
+	}
+}
+
+// WithPodTemplateSpec sets the given PodTemplateSpec for the StatefulSet.
+func WithPodTemplateSpec(template corev1.PodTemplateSpec) Option {
+	return func(statefulSet *appsv1.StatefulSet) error {
+		statefulSet.Spec.Template = template
+		return nil
+	}
+}
+
+// WithVolumeClaimTemplate sets the given PersistentVolumeClaim templates for the StatefulSet.
+func WithVolumeClaimTemplate(template ...corev1.PersistentVolumeClaim) Option {
+	return func(statefulSet *appsv1.StatefulSet) error {
+		statefulSet.Spec.VolumeClaimTemplates = template
+		return nil
+	}
+}
+
+// WithServiceName sets the given Service name for the StatefulSet.
+func WithServiceName(serviceName string) Option {
+	return func(statefulSet *appsv1.StatefulSet) error {
+		statefulSet.Spec.ServiceName = serviceName
+		return nil
+	}
+}
+
+// WithPodManagementPolicy sets the given PodManagementPolicy for the StatefulSet.
+func WithPodManagementPolicy(podManagementPolicy appsv1.PodManagementPolicyType) Option {
+	return func(statefulSet *appsv1.StatefulSet) error {
+		statefulSet.Spec.PodManagementPolicy = podManagementPolicy
+		return nil
+	}
+}
+
+// WithUpdateStrategy sets the given StatefulSetUpdateStrategy for the StatefulSet.
+func WithUpdateStrategy(updateStrategy appsv1.StatefulSetUpdateStrategy) Option {
+	return func(statefulSet *appsv1.StatefulSet) error {
+		statefulSet.Spec.UpdateStrategy = updateStrategy
+		return nil
+	}
+}
+
+// WithRevisionHistoryLimit sets the given RevisionHistoryLimit for the StatefulSet.
+func WithRevisionHistoryLimit(limit int32) Option {
+	return func(statefulSet *appsv1.StatefulSet) error {
+		statefulSet.Spec.RevisionHistoryLimit = pointers.Ptr[int32](limit)
+		return nil
+	}
+}
+
+// WithMinReadySeconds sets the minimum number of seconds for which a newly created
+// Pod should be ready without any of its containers crashing, for it to be considered available.
+func WithMinReadySeconds(minReadySeconds int32) Option {
+	return func(statefulSet *appsv1.StatefulSet) error {
+		statefulSet.Spec.MinReadySeconds = minReadySeconds
+		return nil
+	}
+}

--- a/internal/k8s/resource/statefulset/statefulset_test.go
+++ b/internal/k8s/resource/statefulset/statefulset_test.go
@@ -1,0 +1,520 @@
+package statefulset
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/sourcegraph/sourcegraph/internal/k8s/resource/pod"
+	"github.com/sourcegraph/sourcegraph/lib/pointers"
+)
+
+func TestNewStatefulSet(t *testing.T) {
+	t.Parallel()
+
+	type args struct {
+		name      string
+		namespace string
+		options   []Option
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want appsv1.StatefulSet
+	}{
+		{
+			name: "default statefulset",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+			},
+			want: appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph",
+					},
+				},
+				Spec: appsv1.StatefulSetSpec{
+					MinReadySeconds:      int32(10),
+					PodManagementPolicy:  appsv1.OrderedReadyPodManagement,
+					Replicas:             pointers.Ptr[int32](1),
+					RevisionHistoryLimit: pointers.Ptr[int32](10),
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"app": "foo",
+						},
+					},
+					ServiceName: "foo",
+					UpdateStrategy: appsv1.StatefulSetUpdateStrategy{
+						Type: appsv1.RollingUpdateStatefulSetStrategyType,
+					},
+				},
+			},
+		},
+		{
+			name: "with labels",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithLabels(map[string]string{
+						"deploy": "horsegraph",
+						"app":    "bar",
+					}),
+				},
+			},
+			want: appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"app":    "bar",
+						"deploy": "sourcegraph",
+					},
+				},
+				Spec: appsv1.StatefulSetSpec{
+					MinReadySeconds:      int32(10),
+					PodManagementPolicy:  appsv1.OrderedReadyPodManagement,
+					Replicas:             pointers.Ptr[int32](1),
+					RevisionHistoryLimit: pointers.Ptr[int32](10),
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"app": "foo",
+						},
+					},
+					ServiceName: "foo",
+					UpdateStrategy: appsv1.StatefulSetUpdateStrategy{
+						Type: appsv1.RollingUpdateStatefulSetStrategyType,
+					},
+				},
+			},
+		},
+		{
+			name: "with annotations",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithAnnotations(map[string]string{
+						"foo": "bar",
+					}),
+				},
+			},
+			want: appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph",
+					},
+					Annotations: map[string]string{
+						"foo": "bar",
+					},
+				},
+				Spec: appsv1.StatefulSetSpec{
+					MinReadySeconds:      int32(10),
+					PodManagementPolicy:  appsv1.OrderedReadyPodManagement,
+					Replicas:             pointers.Ptr[int32](1),
+					RevisionHistoryLimit: pointers.Ptr[int32](10),
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"app": "foo",
+						},
+					},
+					ServiceName: "foo",
+					UpdateStrategy: appsv1.StatefulSetUpdateStrategy{
+						Type: appsv1.RollingUpdateStatefulSetStrategyType,
+					},
+				},
+			},
+		},
+		{
+			name: "with replicas",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithReplicas(int32(5)),
+				},
+			},
+			want: appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph",
+					},
+				},
+				Spec: appsv1.StatefulSetSpec{
+					MinReadySeconds:      int32(10),
+					PodManagementPolicy:  appsv1.OrderedReadyPodManagement,
+					Replicas:             pointers.Ptr[int32](5),
+					RevisionHistoryLimit: pointers.Ptr[int32](10),
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"app": "foo",
+						},
+					},
+					ServiceName: "foo",
+					UpdateStrategy: appsv1.StatefulSetUpdateStrategy{
+						Type: appsv1.RollingUpdateStatefulSetStrategyType,
+					},
+				},
+			},
+		},
+		{
+			name: "with selector",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithSelector(metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"app": "horsegraph",
+						},
+					}),
+				},
+			},
+			want: appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph",
+					},
+				},
+				Spec: appsv1.StatefulSetSpec{
+					MinReadySeconds:      int32(10),
+					PodManagementPolicy:  appsv1.OrderedReadyPodManagement,
+					Replicas:             pointers.Ptr[int32](1),
+					RevisionHistoryLimit: pointers.Ptr[int32](10),
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"app": "horsegraph",
+						},
+					},
+					ServiceName: "foo",
+					UpdateStrategy: appsv1.StatefulSetUpdateStrategy{
+						Type: appsv1.RollingUpdateStatefulSetStrategyType,
+					},
+				},
+			},
+		},
+		{
+			name: "with pod template spec",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithPodTemplateSpec(func() corev1.PodTemplateSpec {
+						ts, _ := pod.NewPodTemplate("foo", "sourcegraph")
+						return ts.Template
+					}()),
+				},
+			},
+			want: appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph",
+					},
+				},
+				Spec: appsv1.StatefulSetSpec{
+					MinReadySeconds:      int32(10),
+					PodManagementPolicy:  appsv1.OrderedReadyPodManagement,
+					Replicas:             pointers.Ptr[int32](1),
+					RevisionHistoryLimit: pointers.Ptr[int32](10),
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"app": "foo",
+						},
+					},
+					ServiceName: "foo",
+					UpdateStrategy: appsv1.StatefulSetUpdateStrategy{
+						Type: appsv1.RollingUpdateStatefulSetStrategyType,
+					},
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "foo",
+							Namespace: "sourcegraph",
+							Labels: map[string]string{
+								"app":    "foo",
+								"deploy": "sourcegraph",
+							},
+							Annotations: map[string]string{
+								"kubectl.kubernetes.io/default-container": "foo",
+							},
+						},
+						Spec: corev1.PodSpec{
+							SecurityContext: &corev1.PodSecurityContext{
+								RunAsUser:           pointers.Ptr[int64](100),
+								RunAsGroup:          pointers.Ptr[int64](101),
+								FSGroup:             pointers.Ptr[int64](101),
+								FSGroupChangePolicy: pointers.Ptr(corev1.FSGroupChangeOnRootMismatch),
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "with volume claim template",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithVolumeClaimTemplate(corev1.PersistentVolumeClaim{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "repos",
+						},
+						Spec: corev1.PersistentVolumeClaimSpec{
+							AccessModes: []corev1.PersistentVolumeAccessMode{
+								corev1.ReadWriteOnce,
+							},
+							Resources: corev1.VolumeResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceStorage: resource.MustParse("200Gi"),
+								},
+							},
+						},
+					}),
+				},
+			},
+			want: appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph",
+					},
+				},
+				Spec: appsv1.StatefulSetSpec{
+					MinReadySeconds:      int32(10),
+					PodManagementPolicy:  appsv1.OrderedReadyPodManagement,
+					Replicas:             pointers.Ptr[int32](1),
+					RevisionHistoryLimit: pointers.Ptr[int32](10),
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"app": "foo",
+						},
+					},
+					ServiceName: "foo",
+					UpdateStrategy: appsv1.StatefulSetUpdateStrategy{
+						Type: appsv1.RollingUpdateStatefulSetStrategyType,
+					},
+					VolumeClaimTemplates: []corev1.PersistentVolumeClaim{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "repos",
+							},
+							Spec: corev1.PersistentVolumeClaimSpec{
+								AccessModes: []corev1.PersistentVolumeAccessMode{
+									corev1.ReadWriteOnce,
+								},
+								Resources: corev1.VolumeResourceRequirements{
+									Requests: corev1.ResourceList{
+										corev1.ResourceStorage: resource.MustParse("200Gi"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "with service name",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithServiceName("test"),
+				},
+			},
+			want: appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph",
+					},
+				},
+				Spec: appsv1.StatefulSetSpec{
+					MinReadySeconds:      int32(10),
+					PodManagementPolicy:  appsv1.OrderedReadyPodManagement,
+					Replicas:             pointers.Ptr[int32](1),
+					RevisionHistoryLimit: pointers.Ptr[int32](10),
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"app": "foo",
+						},
+					},
+					ServiceName: "test",
+					UpdateStrategy: appsv1.StatefulSetUpdateStrategy{
+						Type: appsv1.RollingUpdateStatefulSetStrategyType,
+					},
+				},
+			},
+		},
+		{
+			name: "with pod management policy",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithPodManagementPolicy(appsv1.ParallelPodManagement),
+				},
+			},
+			want: appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph",
+					},
+				},
+				Spec: appsv1.StatefulSetSpec{
+					MinReadySeconds:      int32(10),
+					PodManagementPolicy:  appsv1.ParallelPodManagement,
+					Replicas:             pointers.Ptr[int32](1),
+					RevisionHistoryLimit: pointers.Ptr[int32](10),
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"app": "foo",
+						},
+					},
+					ServiceName: "foo",
+					UpdateStrategy: appsv1.StatefulSetUpdateStrategy{
+						Type: appsv1.RollingUpdateStatefulSetStrategyType,
+					},
+				},
+			},
+		},
+		{
+			name: "with update strategy",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithUpdateStrategy(appsv1.StatefulSetUpdateStrategy{
+						Type: appsv1.OnDeleteStatefulSetStrategyType,
+					}),
+				},
+			},
+			want: appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph",
+					},
+				},
+				Spec: appsv1.StatefulSetSpec{
+					MinReadySeconds:      int32(10),
+					PodManagementPolicy:  appsv1.OrderedReadyPodManagement,
+					Replicas:             pointers.Ptr[int32](1),
+					RevisionHistoryLimit: pointers.Ptr[int32](10),
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"app": "foo",
+						},
+					},
+					ServiceName: "foo",
+					UpdateStrategy: appsv1.StatefulSetUpdateStrategy{
+						Type: appsv1.OnDeleteStatefulSetStrategyType,
+					},
+				},
+			},
+		},
+		{
+			name: "with revision history",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithRevisionHistoryLimit(int32(5)),
+				},
+			},
+			want: appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph",
+					},
+				},
+				Spec: appsv1.StatefulSetSpec{
+					MinReadySeconds:      int32(10),
+					PodManagementPolicy:  appsv1.OrderedReadyPodManagement,
+					Replicas:             pointers.Ptr[int32](1),
+					RevisionHistoryLimit: pointers.Ptr[int32](5),
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"app": "foo",
+						},
+					},
+					ServiceName: "foo",
+					UpdateStrategy: appsv1.StatefulSetUpdateStrategy{
+						Type: appsv1.RollingUpdateStatefulSetStrategyType,
+					},
+				},
+			},
+		},
+		{
+			name: "with minready seconds",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithMinReadySeconds(int32(12)),
+				},
+			},
+			want: appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph",
+					},
+				},
+				Spec: appsv1.StatefulSetSpec{
+					MinReadySeconds:      int32(12),
+					PodManagementPolicy:  appsv1.OrderedReadyPodManagement,
+					Replicas:             pointers.Ptr[int32](1),
+					RevisionHistoryLimit: pointers.Ptr[int32](10),
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"app": "foo",
+						},
+					},
+					ServiceName: "foo",
+					UpdateStrategy: appsv1.StatefulSetUpdateStrategy{
+						Type: appsv1.RollingUpdateStatefulSetStrategyType,
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := NewStatefulSet(tt.args.name, tt.args.namespace, tt.args.options...)
+			if err != nil {
+				t.Errorf("NewStatefulSets() error: %v", err)
+			}
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("NewStatefulSets() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/internal/k8s/resource/storage/BUILD.bazel
+++ b/internal/k8s/resource/storage/BUILD.bazel
@@ -1,0 +1,33 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("//dev:go_defs.bzl", "go_test")
+
+go_library(
+    name = "storage",
+    srcs = ["storageclass.go"],
+    importpath = "github.com/sourcegraph/sourcegraph/internal/k8s/resource/storage",
+    visibility = ["//:__subpackages__"],
+    deps = [
+        "//internal/maps",
+        "//lib/pointers",
+        "@io_k8s_api//core/v1:core",
+        "@io_k8s_api//storage/v1:storage",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:meta",
+    ],
+)
+
+go_test(
+    name = "storage_test",
+    srcs = [
+        "example_test.go",
+        "storageclass_test.go",
+    ],
+    embed = [":storage"],
+    deps = [
+        "//lib/pointers",
+        "@com_github_google_go_cmp//cmp",
+        "@io_k8s_api//core/v1:core",
+        "@io_k8s_api//storage/v1:storage",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:meta",
+        "@io_k8s_sigs_yaml//:yaml",
+    ],
+)

--- a/internal/k8s/resource/storage/example_test.go
+++ b/internal/k8s/resource/storage/example_test.go
@@ -1,0 +1,31 @@
+package storage
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"sigs.k8s.io/yaml"
+)
+
+func ExampleStorageClass() {
+	sc, _ := NewStorageClass("test", "sourcegraph")
+
+	jsc, _ := json.Marshal(sc)
+	fmt.Println(string(jsc))
+
+	ysc, _ := yaml.Marshal(sc)
+	fmt.Println(string(ysc))
+
+	// Output:
+	// {"metadata":{"name":"test","namespace":"sourcegraph","creationTimestamp":null,"labels":{"deploy":"sourcegraph-storage"}},"provisioner":"","reclaimPolicy":"Retain","allowVolumeExpansion":true,"volumeBindingMode":"WaitForFirstConsumer"}
+	// allowVolumeExpansion: true
+	// metadata:
+	//   creationTimestamp: null
+	//   labels:
+	//     deploy: sourcegraph-storage
+	//   name: test
+	//   namespace: sourcegraph
+	// provisioner: ""
+	// reclaimPolicy: Retain
+	// volumeBindingMode: WaitForFirstConsumer
+}

--- a/internal/k8s/resource/storage/storageclass.go
+++ b/internal/k8s/resource/storage/storageclass.go
@@ -1,0 +1,121 @@
+package storage
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/sourcegraph/sourcegraph/internal/maps"
+	"github.com/sourcegraph/sourcegraph/lib/pointers"
+)
+
+// NewStorageClass creates a new k8s StorageClass with default values.
+//
+// Default values include:
+//
+//   - AllowVolumeExpansion: true
+//   - ReclaimPolicy: PersistentVolumeReclaimRetain
+//   - VolumeBindingMode: VolumeBindingWaitForFirstConsumer
+//
+// Additional options can be passed to modify the default values.
+func NewStorageClass(name, namespace string, options ...Option) (storagev1.StorageClass, error) {
+	storageClass := storagev1.StorageClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				"deploy": "sourcegraph-storage",
+			},
+		},
+		AllowVolumeExpansion: pointers.Ptr(true),
+		ReclaimPolicy:        pointers.Ptr(corev1.PersistentVolumeReclaimRetain),
+		VolumeBindingMode:    pointers.Ptr(storagev1.VolumeBindingWaitForFirstConsumer),
+	}
+
+	// apply any given options
+	for _, opt := range options {
+		err := opt(&storageClass)
+		if err != nil {
+			return storagev1.StorageClass{}, err
+		}
+	}
+
+	return storageClass, nil
+}
+
+// Option sets an option for a StorageClass.
+type Option func(storageClass *storagev1.StorageClass) error
+
+// WithLabels sets StorageClass labels without overriding existing labels.
+func WithLabels(labels map[string]string) Option {
+	return func(storageClass *storagev1.StorageClass) error {
+		storageClass.Labels = maps.MergePreservingExistingKeys(storageClass.Labels, labels)
+		return nil
+	}
+}
+
+// WithAnnotations sets StorageClass annotations without overriding existing annotations.
+func WithAnnotations(annotations map[string]string) Option {
+	return func(storageClass *storagev1.StorageClass) error {
+		storageClass.Annotations = maps.MergePreservingExistingKeys(storageClass.Annotations, annotations)
+		return nil
+	}
+}
+
+// WithType sets the given type on the StorageClass.
+func WithType(typeParam string) Option {
+	return func(storageClass *storagev1.StorageClass) error {
+		storageClass.Parameters = maps.Merge(storageClass.Parameters, map[string]string{
+			"type": typeParam,
+		})
+		return nil
+	}
+}
+
+// WithParameters sets the given parameters on the StorageClass.
+func WithParameters(params map[string]string) Option {
+	return func(storageClass *storagev1.StorageClass) error {
+		storageClass.Parameters = maps.MergePreservingExistingKeys(storageClass.Parameters, params)
+		return nil
+	}
+}
+
+// WithProvisioner sets the given provisioner on the StorageClass.
+func WithProvisioner(provisioner string) Option {
+	return func(storageClass *storagev1.StorageClass) error {
+		storageClass.Provisioner = provisioner
+		return nil
+	}
+}
+
+// WithReclaimPolicy sets the given PersistentVolumeReclaimPolicy on the StorageClass.
+func WithReclaimPolicy(reclaimPolicy corev1.PersistentVolumeReclaimPolicy) Option {
+	return func(storageClass *storagev1.StorageClass) error {
+		storageClass.ReclaimPolicy = &reclaimPolicy
+		return nil
+	}
+}
+
+// AllowVolumeExpansion allows volume expansion on the StorageClass.
+func AllowVolumeExpansion() Option {
+	return func(storageClass *storagev1.StorageClass) error {
+		storageClass.AllowVolumeExpansion = pointers.Ptr(true)
+		return nil
+	}
+}
+
+// DisallowVolumeExpansion disallows volume expansion on the StorageClass.
+func DisallowVolumeExpansion() Option {
+	return func(storageClass *storagev1.StorageClass) error {
+		storageClass.AllowVolumeExpansion = pointers.Ptr(false)
+		return nil
+	}
+}
+
+// WithVolumeBindingMode sets the given VolumeBindingMode on the StorageClass.
+func WithVolumeBindingMode(volumeBindingMode storagev1.VolumeBindingMode) Option {
+	return func(storageClass *storagev1.StorageClass) error {
+		storageClass.VolumeBindingMode = &volumeBindingMode
+		return nil
+	}
+}

--- a/internal/k8s/resource/storage/storageclass_test.go
+++ b/internal/k8s/resource/storage/storageclass_test.go
@@ -1,0 +1,257 @@
+package storage
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/sourcegraph/sourcegraph/lib/pointers"
+)
+
+func TestNewStorageClass(t *testing.T) {
+	t.Parallel()
+
+	type args struct {
+		name      string
+		namespace string
+		options   []Option
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want storagev1.StorageClass
+	}{
+		{
+			name: "default storageclass",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+			},
+			want: storagev1.StorageClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph-storage",
+					},
+				},
+				ReclaimPolicy:        pointers.Ptr(corev1.PersistentVolumeReclaimRetain),
+				AllowVolumeExpansion: pointers.Ptr(true),
+				VolumeBindingMode:    pointers.Ptr(storagev1.VolumeBindingWaitForFirstConsumer),
+			},
+		},
+		{
+			name: "with labels",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithLabels(map[string]string{
+						"app": "bar",
+					}),
+				},
+			},
+			want: storagev1.StorageClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"app":    "bar",
+						"deploy": "sourcegraph-storage",
+					},
+				},
+				ReclaimPolicy:        pointers.Ptr(corev1.PersistentVolumeReclaimRetain),
+				AllowVolumeExpansion: pointers.Ptr(true),
+				VolumeBindingMode:    pointers.Ptr(storagev1.VolumeBindingWaitForFirstConsumer),
+			},
+		},
+		{
+			name: "with annotations",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithAnnotations(map[string]string{
+						"foo": "bar",
+					}),
+				},
+			},
+			want: storagev1.StorageClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph-storage",
+					},
+					Annotations: map[string]string{
+						"foo": "bar",
+					},
+				},
+				ReclaimPolicy:        pointers.Ptr(corev1.PersistentVolumeReclaimRetain),
+				AllowVolumeExpansion: pointers.Ptr(true),
+				VolumeBindingMode:    pointers.Ptr(storagev1.VolumeBindingWaitForFirstConsumer),
+			},
+		},
+		{
+			name: "with type",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithType("ssd"),
+				},
+			},
+			want: storagev1.StorageClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph-storage",
+					},
+				},
+				Parameters: map[string]string{
+					"type": "ssd",
+				},
+				ReclaimPolicy:        pointers.Ptr(corev1.PersistentVolumeReclaimRetain),
+				AllowVolumeExpansion: pointers.Ptr(true),
+				VolumeBindingMode:    pointers.Ptr(storagev1.VolumeBindingWaitForFirstConsumer),
+			},
+		},
+		{
+			name: "with parameters",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithParameters(map[string]string{
+						"type":  "ssd",
+						"stuff": "here",
+					}),
+				},
+			},
+			want: storagev1.StorageClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph-storage",
+					},
+				},
+				Parameters: map[string]string{
+					"stuff": "here",
+					"type":  "ssd",
+				},
+				ReclaimPolicy:        pointers.Ptr(corev1.PersistentVolumeReclaimRetain),
+				AllowVolumeExpansion: pointers.Ptr(true),
+				VolumeBindingMode:    pointers.Ptr(storagev1.VolumeBindingWaitForFirstConsumer),
+			},
+		},
+		{
+			name: "with provisioner",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithProvisioner("test"),
+				},
+			},
+			want: storagev1.StorageClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph-storage",
+					},
+				},
+				Provisioner:          "test",
+				ReclaimPolicy:        pointers.Ptr(corev1.PersistentVolumeReclaimRetain),
+				AllowVolumeExpansion: pointers.Ptr(true),
+				VolumeBindingMode:    pointers.Ptr(storagev1.VolumeBindingWaitForFirstConsumer),
+			},
+		},
+		{
+			name: "with reclaim policy",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithReclaimPolicy(corev1.PersistentVolumeReclaimDelete),
+				},
+			},
+			want: storagev1.StorageClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph-storage",
+					},
+				},
+				ReclaimPolicy:        pointers.Ptr(corev1.PersistentVolumeReclaimDelete),
+				AllowVolumeExpansion: pointers.Ptr(true),
+				VolumeBindingMode:    pointers.Ptr(storagev1.VolumeBindingWaitForFirstConsumer),
+			},
+		},
+		{
+			name: "disallow volume expansion",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					DisallowVolumeExpansion(),
+				},
+			},
+			want: storagev1.StorageClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph-storage",
+					},
+				},
+				ReclaimPolicy:        pointers.Ptr(corev1.PersistentVolumeReclaimRetain),
+				AllowVolumeExpansion: pointers.Ptr(false),
+				VolumeBindingMode:    pointers.Ptr(storagev1.VolumeBindingWaitForFirstConsumer),
+			},
+		},
+		{
+			name: "with volume binding mode",
+			args: args{
+				name:      "foo",
+				namespace: "sourcegraph",
+				options: []Option{
+					WithVolumeBindingMode(storagev1.VolumeBindingImmediate),
+				},
+			},
+			want: storagev1.StorageClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "sourcegraph",
+					Labels: map[string]string{
+						"deploy": "sourcegraph-storage",
+					},
+				},
+				ReclaimPolicy:        pointers.Ptr(corev1.PersistentVolumeReclaimRetain),
+				AllowVolumeExpansion: pointers.Ptr(true),
+				VolumeBindingMode:    pointers.Ptr(storagev1.VolumeBindingImmediate),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := NewStorageClass(tt.args.name, tt.args.namespace, tt.args.options...)
+			if err != nil {
+				t.Errorf("NewStorageClass() error: %v", err)
+			}
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("NewStorageClass() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/internal/maps/BUILD.bazel
+++ b/internal/maps/BUILD.bazel
@@ -1,0 +1,19 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("//dev:go_defs.bzl", "go_test")
+
+go_library(
+    name = "maps",
+    srcs = ["maps.go"],
+    importpath = "github.com/sourcegraph/sourcegraph/internal/maps",
+    visibility = ["//:__subpackages__"],
+)
+
+go_test(
+    name = "maps_test",
+    srcs = [
+        "example_test.go",
+        "maps_test.go",
+    ],
+    embed = [":maps"],
+    deps = ["@com_github_google_go_cmp//cmp"],
+)

--- a/internal/maps/example_test.go
+++ b/internal/maps/example_test.go
@@ -1,0 +1,19 @@
+package maps
+
+import "fmt"
+
+func ExampleMerge() {
+	m := Merge(map[string]int{"a": 1, "b": 2}, map[string]int{"b": 3, "c": 4})
+	fmt.Printf("%#v\n", m)
+
+	// Output:
+	// map[string]int{"a":1, "b":3, "c":4}
+}
+
+func ExampleMergePreservingExistingKeys() {
+	m := MergePreservingExistingKeys(map[string]int{"a": 1, "b": 2}, map[string]int{"b": 3, "c": 4})
+	fmt.Printf("%#v\n", m)
+
+	// Output:
+	// map[string]int{"a":1, "b":2, "c":4}
+}

--- a/internal/maps/maps.go
+++ b/internal/maps/maps.go
@@ -1,0 +1,36 @@
+package maps
+
+// Merge merges the source map into the destination map, overwriting existing values if necessary.
+func Merge[K comparable, V any](dest, src map[K]V) map[K]V {
+	if dest == nil {
+		if src == nil {
+			return make(map[K]V)
+		}
+		dest = make(map[K]V, len(src))
+	}
+
+	for k, v := range src {
+		dest[k] = v
+	}
+
+	return dest
+}
+
+// MergePreservingExistingKeys merges the source map into the destination map,
+// without overwriting any existing keys in the destination.
+func MergePreservingExistingKeys[K comparable, V any](dest, src map[K]V) map[K]V {
+	if dest == nil {
+		if src == nil {
+			return make(map[K]V)
+		}
+		dest = make(map[K]V, len(src))
+	}
+
+	for k, v := range src {
+		if _, exists := dest[k]; !exists {
+			dest[k] = v
+		}
+	}
+
+	return dest
+}

--- a/internal/maps/maps_test.go
+++ b/internal/maps/maps_test.go
@@ -1,0 +1,174 @@
+package maps
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+type testCase[K comparable, V any] struct {
+	name string
+	src  map[K]V
+	dest map[K]V
+	want map[K]V
+}
+
+func runMergeTest[K comparable, V any](t *testing.T, tt testCase[K, V]) {
+	t.Helper()
+
+	t.Run(tt.name, func(t *testing.T) {
+		t.Parallel()
+		got := Merge(tt.dest, tt.src)
+		if diff := cmp.Diff(tt.want, got); diff != "" {
+			t.Errorf("Merge() mismatch (-want +got):\n%s", diff)
+		}
+	})
+}
+
+func TestMerge(t *testing.T) {
+	t.Parallel()
+
+	strIntTests := []testCase[string, int]{
+		{
+			name: "merge with overlapping keys",
+			dest: map[string]int{"a": 1, "b": 2},
+			src:  map[string]int{"b": 3, "c": 4},
+			want: map[string]int{"a": 1, "b": 3, "c": 4},
+		},
+		{
+			name: "src is nil",
+			dest: map[string]int{"a": 1},
+			src:  nil,
+			want: map[string]int{"a": 1},
+		},
+		{
+			name: "dest is nil",
+			dest: nil,
+			src:  map[string]int{"a": 1},
+			want: map[string]int{"a": 1},
+		},
+		{
+			name: "both are nil",
+			dest: nil,
+			src:  nil,
+			want: map[string]int{},
+		},
+	}
+
+	strStrTests := []testCase[string, string]{
+		{
+			name: "merge with overlapping keys",
+			dest: map[string]string{"a": "1", "b": "2"},
+			src:  map[string]string{"b": "3", "c": "4"},
+			want: map[string]string{"a": "1", "b": "3", "c": "4"},
+		},
+		{
+			name: "rc is nil",
+			dest: map[string]string{"a": "1"},
+			src:  nil,
+			want: map[string]string{"a": "1"},
+		},
+		{
+			name: "dest is nil",
+			dest: nil,
+			src:  map[string]string{"a": "1"},
+			want: map[string]string{"a": "1"},
+		},
+		{
+			name: "both are nil",
+			dest: nil,
+			src:  nil,
+			want: map[string]string{},
+		},
+	}
+
+	for _, tt := range strIntTests {
+		tt := tt
+		runMergeTest(t, tt)
+	}
+
+	for _, tt := range strStrTests {
+		tt := tt
+		runMergeTest(t, tt)
+	}
+}
+
+func runMergePreservingExistingKeysTest[K comparable, V any](t *testing.T, tt testCase[K, V]) {
+	t.Helper()
+
+	t.Run(tt.name, func(t *testing.T) {
+		t.Parallel()
+		got := MergePreservingExistingKeys(tt.dest, tt.src)
+		if diff := cmp.Diff(tt.want, got); diff != "" {
+			t.Errorf("MergePreservingExistingKeys() mismatch (-want +got):\n%s", diff)
+		}
+	})
+}
+
+func TestMergePreservingExistingKeys(t *testing.T) {
+	t.Parallel()
+
+	strIntTests := []testCase[string, int]{
+		{
+			name: "merge with overlapping keys",
+			dest: map[string]int{"a": 1, "b": 2},
+			src:  map[string]int{"b": 3, "c": 4},
+			want: map[string]int{"a": 1, "b": 2, "c": 4},
+		},
+		{
+			name: "src is nil",
+			dest: map[string]int{"a": 1},
+			src:  nil,
+			want: map[string]int{"a": 1},
+		},
+		{
+			name: "dest is nil",
+			dest: nil,
+			src:  map[string]int{"a": 1},
+			want: map[string]int{"a": 1},
+		},
+		{
+			name: "both are nil",
+			dest: nil,
+			src:  nil,
+			want: map[string]int{},
+		},
+	}
+
+	strStrTests := []testCase[string, string]{
+		{
+			name: "merge with overlapping keys",
+			dest: map[string]string{"a": "1", "b": "2"},
+			src:  map[string]string{"b": "3", "c": "4"},
+			want: map[string]string{"a": "1", "b": "2", "c": "4"},
+		},
+		{
+			name: "src is nil",
+			dest: map[string]string{"a": "1"},
+			src:  nil,
+			want: map[string]string{"a": "1"},
+		},
+		{
+			name: "dest is nil",
+			dest: nil,
+			src:  map[string]string{"a": "1"},
+			want: map[string]string{"a": "1"},
+		},
+		{
+			name: "both are nil",
+			dest: nil,
+			src:  nil,
+			want: map[string]string{},
+		},
+	}
+
+	for _, tt := range strIntTests {
+		tt := tt
+		runMergePreservingExistingKeysTest(t, tt)
+	}
+
+	for _, tt := range strStrTests {
+		tt := tt
+		runMergePreservingExistingKeysTest(t, tt)
+	}
+}


### PR DESCRIPTION
Reverts sourcegraph/sourcegraph#61812

While these pkgs are not in use at the moment, they will be shortly as we have several branches using these packages that are WIP.

Putting these in ahead of time allowed us to reduce merge conflicts and have smaller PRs.

Is there a way to denote this so we don't hit this issue again in the future? 

## Test plan

Revert, see original PRs for test plan. TLDR: Full unit test coverage.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
