### PR TITLE
monitoring: fix "instance" dropdown for Zoekt

### DIFF
--- a/monitoring/definitions/zoekt.go
+++ b/monitoring/definitions/zoekt.go
@@ -30,7 +30,7 @@ func Zoekt() *monitoring.Dashboard {
 				Label: "Instance",
 				Name:  "instance",
 				OptionsLabelValues: monitoring.ContainerVariableOptionsLabelValues{
-					Query:         "index_num_assigned",
+					Query:         "index_num_indexed",
 					LabelName:     "instance",
 					ExampleOption: "zoekt-indexserver-0:6072",
 				},


### PR DESCRIPTION
The index_num_assigned metric no longer exists. This should fix a few all the graphs that you are able to select which indexserver to look at.

Test Plan: tested this metric had the requisite fields via dotcom's explore. Tried to test with local grafana setup but it seems to have regressed so will follow-up on that.
