### PR TITLE
Move authz.SetProviders call to cmd/ package

### DIFF
--- a/cmd/syntactic-code-intel-worker/shared/BUILD.bazel
+++ b/cmd/syntactic-code-intel-worker/shared/BUILD.bazel
@@ -11,7 +11,11 @@ go_library(
     importpath = "github.com/sourcegraph/sourcegraph/cmd/syntactic-code-intel-worker/shared",
     visibility = ["//visibility:public"],
     deps = [
+        "//internal/authz",
         "//internal/codeintel/syntactic_indexing/jobstore",
+        "//internal/conf",
+        "//internal/conf/conftypes",
+        "//internal/database/connections/live",
         "//internal/debugserver",
         "//internal/encryption/keyring",
         "//internal/env",

--- a/cmd/syntactic-code-intel-worker/shared/shared.go
+++ b/cmd/syntactic-code-intel-worker/shared/shared.go
@@ -2,12 +2,18 @@ package shared
 
 import (
 	"context"
+	"database/sql"
 
 	"net/http"
 	"time"
 
 	"github.com/sourcegraph/log"
+
+	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/syntactic_indexing/jobstore"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
+	connections "github.com/sourcegraph/sourcegraph/internal/database/connections/live"
 	"github.com/sourcegraph/sourcegraph/internal/encryption/keyring"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
 	"github.com/sourcegraph/sourcegraph/internal/httpserver"
@@ -27,7 +33,9 @@ func Main(ctx context.Context, observationCtx *observation.Context, ready servic
 		log.String("path to scip-syntax CLI", config.IndexingWorkerConfig.CliPath),
 		log.String("API address", config.ListenAddress))
 
-	jobStore, err := jobstore.NewStore(observationCtx, "syntactic-code-intel-indexer")
+	db := initDB(observationCtx, "syntactic-code-intel-indexer")
+
+	jobStore, err := jobstore.NewStoreWithDB(observationCtx, db)
 	if err != nil {
 		return errors.Wrap(err, "initializing worker store")
 	}
@@ -45,4 +53,28 @@ func Main(ctx context.Context, observationCtx *observation.Context, ready servic
 	goroutine.MonitorBackgroundRoutines(ctx, server, indexingWorker)
 
 	return nil
+}
+
+func initDB(observationCtx *observation.Context, name string) *sql.DB {
+	// This is an internal service, so we rely on the
+	// frontend to do authz checks for user requests.
+	// Authz checks are enforced by the DB layer
+	//
+	// This call to SetProviders is here so that calls to GetProviders don't block.
+	// Relevant PR: https://github.com/sourcegraph/sourcegraph/pull/15755
+	// Relevant issue: https://github.com/sourcegraph/sourcegraph/issues/15962
+
+	authz.SetProviders(true, []authz.Provider{})
+
+	dsn := conf.GetServiceConnectionValueAndRestartOnChange(func(serviceConnections conftypes.ServiceConnections) string {
+		return serviceConnections.PostgresDSN
+	})
+
+	sqlDB, err := connections.EnsureNewFrontendDB(observationCtx, dsn, name)
+
+	if err != nil {
+		log.Scoped("init db ("+name+")").Fatal("Failed to connect to frontend database", log.Error(err))
+	}
+
+	return sqlDB
 }

--- a/internal/codeintel/syntactic_indexing/jobstore/BUILD.bazel
+++ b/internal/codeintel/syntactic_indexing/jobstore/BUILD.bazel
@@ -10,17 +10,12 @@ go_library(
     importpath = "github.com/sourcegraph/sourcegraph/internal/codeintel/syntactic_indexing/jobstore",
     visibility = ["//:__subpackages__"],
     deps = [
-        "//internal/authz",
-        "//internal/conf",
-        "//internal/conf/conftypes",
         "//internal/database/basestore",
-        "//internal/database/connections/live",
         "//internal/database/dbutil",
         "//internal/observation",
         "//internal/workerutil",
         "//internal/workerutil/dbworker/store",
         "@com_github_keegancsmith_sqlf//:sqlf",
-        "@com_github_sourcegraph_log//:log",
     ],
 )
 


### PR DESCRIPTION
Found that we call SetProviders in an internal package, if someone decides to call NewStore from another binary we'll unset authz providers which can disable certain auth checks, so that felt a bit risky.

Test plan:

Just moved a bit of code around.


