### PR TITLE
Fix nil dereference from wrong bool operator

### DIFF
--- a/internal/batches/sources/sources.go
+++ b/internal/batches/sources/sources.go
@@ -653,7 +653,7 @@ func CopyRepoAsFork(repo *types.Repo, metadata any, nameAndOwner, forkNameAndOwn
 	forkSources := map[string]*types.SourceInfo{}
 
 	for urn, src := range repo.Sources {
-		if src != nil || src.CloneURL != "" {
+		if src != nil && src.CloneURL != "" {
 			forkURL := strings.Replace(
 				strings.ToLower(src.CloneURL),
 				strings.ToLower(nameAndOwner),


### PR DESCRIPTION
This seems to have meant to use && instead of || - in the current form this can panic if src is nil.

Test plan:

Code review, trivial change.
