### PR TITLE
Context: return no results for stopwords query

### DIFF
--- a/internal/search/codycontext/job.go
+++ b/internal/search/codycontext/job.go
@@ -19,7 +19,10 @@ func NewSearchJob(plan query.Plan, newJob func(query.Basic) (job.Job, error)) (j
 
 	basicQuery := plan[0].ToParseTree()
 	q, err := queryStringToKeywordQuery(query.StringHuman(basicQuery))
-	if err != nil || q == nil {
+
+	// If there are no patterns left, this query was entirely composed of
+	// stopwords, so we return no results.
+	if err != nil || len(q.patterns) == 0 {
 		return nil, err
 	}
 

--- a/internal/search/job/jobutil/job_test.go
+++ b/internal/search/job/jobutil/job_test.go
@@ -1112,6 +1112,22 @@ func TestNewPlanJob(t *testing.T) {
                 (patternInfo.fileMatchLimit . 10000)))))))))
 `),
 		},
+		{
+			query:      `context:global repo:sourcegraph/.* what's going on'? lang:go`,
+			protocol:   search.Streaming,
+			searchType: query.SearchTypeCodyContext,
+			want: autogold.Expect(`
+(LOG
+  (ALERT
+    (features . error decoding features)
+    (protocol . Streaming)
+    (onSourcegraphDotCom . true)
+    (query . )
+    (originalQuery . )
+    (patternType . codycontext)
+    ))
+`),
+		},
 		// The next query shows an unexpected way that a query is
 		// translated into a global zoekt query, all depending on if context:
 		// is specified (which it normally is). We expect to just have one


### PR DESCRIPTION
In #60106, we fixed a bug where the context search threw an error when the query
was composed entirely of stopwords. However, the queries were still returning
results (based on filename match). This means that for a stopwords-only query
like "what's going on?" we return a fairly random set of files, which confuses
the LLM.

Now we make sure to return an empty search, which returns no results.

## Test plan

Added a new unit test. Tested Cody web locally.