### PR TITLE
v2t: add v2t to src/user

### DIFF
--- a/client/web/src/storm/pages/LayoutPage/LayoutPage.tsx
+++ b/client/web/src/storm/pages/LayoutPage/LayoutPage.tsx
@@ -205,6 +205,7 @@ export const Layout: React.FC<LegacyLayoutProps> = props => {
             {!isSiteInit && props.isSourcegraphDotCom && props.authenticatedUser && (
                 <CodySurveyToast
                     telemetryService={props.telemetryService}
+                    telemetryRecorder={props.platformContext.telemetryRecorder}
                     authenticatedUser={props.authenticatedUser}
                 />
             )}

--- a/client/web/src/user/settings/accessTokens/UserSettingsTokensArea.tsx
+++ b/client/web/src/user/settings/accessTokens/UserSettingsTokensArea.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useState } from 'react'
 
 import { Route, Routes } from 'react-router-dom'
 
+import type { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 
 import { NotFoundPage } from '../../../components/HeroPage'
@@ -12,7 +13,10 @@ import { UserSettingsCreateAccessTokenCallbackPage } from './UserSettingsCreateA
 import { UserSettingsCreateAccessTokenPage } from './UserSettingsCreateAccessTokenPage'
 import { UserSettingsTokensPage } from './UserSettingsTokensPage'
 
-interface Props extends Pick<UserSettingsAreaRouteContext, 'user' | 'authenticatedUser'>, TelemetryProps {
+interface Props
+    extends Pick<UserSettingsAreaRouteContext, 'user' | 'authenticatedUser'>,
+        TelemetryProps,
+        TelemetryV2Props {
     isSourcegraphDotCom: boolean
 }
 

--- a/client/web/src/user/settings/accessTokens/UserSettingsTokensPage.tsx
+++ b/client/web/src/user/settings/accessTokens/UserSettingsTokensPage.tsx
@@ -5,6 +5,7 @@ import { type Observable, Subject } from 'rxjs'
 import { map } from 'rxjs/operators'
 
 import { dataOrThrowErrors, gql } from '@sourcegraph/http-client'
+import type { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Container, PageHeader, Button, Icon, Text, ButtonLink, Tooltip } from '@sourcegraph/wildcard'
 
@@ -25,7 +26,10 @@ import {
 } from '../../../settings/tokens/AccessTokenNode'
 import type { UserSettingsAreaRouteContext } from '../UserSettingsArea'
 
-interface Props extends Pick<UserSettingsAreaRouteContext, 'authenticatedUser' | 'user'>, TelemetryProps {
+interface Props
+    extends Pick<UserSettingsAreaRouteContext, 'authenticatedUser' | 'user'>,
+        TelemetryProps,
+        TelemetryV2Props {
     /**
      * The newly created token, if any. This component must call onDidPresentNewToken
      * when it is finished presenting the token secret to the user.
@@ -48,10 +52,12 @@ export const UserSettingsTokensPage: React.FunctionComponent<React.PropsWithChil
     user,
     newToken,
     onDidPresentNewToken,
+    telemetryRecorder,
 }) => {
     useEffect(() => {
         telemetryService.logViewEvent('UserSettingsTokens')
-    }, [telemetryService])
+        telemetryRecorder.recordEvent('settings.tokens', 'view')
+    }, [telemetryService, telemetryRecorder])
 
     useEffect(
         () => () => {

--- a/client/web/src/user/settings/accessTokens/create.ts
+++ b/client/web/src/user/settings/accessTokens/create.ts
@@ -3,17 +3,23 @@ import { map } from 'rxjs/operators'
 
 import { createAggregateError } from '@sourcegraph/common'
 import { gql } from '@sourcegraph/http-client'
+import type { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import { EVENT_LOGGER } from '@sourcegraph/shared/src/telemetry/web/eventLogger'
 
 import { requestGraphQL } from '../../../backend/graphql'
 import type { CreateAccessTokenResult, CreateAccessTokenVariables, Scalars } from '../../../graphql-operations'
 
-export function createAccessToken(
-    user: Scalars['ID'],
-    scopes: string[],
-    note: string,
+interface createAccessTokenProps extends TelemetryV2Props {
+    user: Scalars['ID']
+    scopes: string[]
+    note: string
     durationSeconds: number | null
+}
+
+export function createAccessToken(
+    props: createAccessTokenProps
 ): Observable<CreateAccessTokenResult['createAccessToken']> {
+    const { user, scopes, note, durationSeconds, telemetryRecorder } = props
     return requestGraphQL<CreateAccessTokenResult, CreateAccessTokenVariables>(
         gql`
             mutation CreateAccessToken($user: ID!, $scopes: [String!]!, $note: String!, $durationSeconds: Int) {
@@ -28,9 +34,11 @@ export function createAccessToken(
         map(({ data, errors }) => {
             if (!data?.createAccessToken || (errors && errors.length > 0)) {
                 EVENT_LOGGER.log('CreateAccessTokenFailed')
+                telemetryRecorder.recordEvent('settings.token', 'createFail')
                 throw createAggregateError(errors)
             }
             EVENT_LOGGER.log('AccessTokenCreated')
+            telemetryRecorder.recordEvent('settings.token', 'create')
             return data.createAccessToken
         })
     )

--- a/client/web/src/user/settings/auth/ExternalAccount.tsx
+++ b/client/web/src/user/settings/auth/ExternalAccount.tsx
@@ -31,7 +31,7 @@ export const ExternalAccount: React.FunctionComponent<React.PropsWithChildren<Pr
     const [isRemoveAccountModalOpen, setIsRemoveAccountModalOpen] = useState(false)
     const [isAddGerritAccountModalOpen, setIsGerritAccountModalOpen] = useState(false)
 
-    useEffect(() => telemetryRecorder.recordEvent('settings.externalAccount', 'view'))
+    useEffect(() => telemetryRecorder.recordEvent('settings.externalAccount', 'view'), [telemetryRecorder])
 
     const navigateToAuthProvider = useCallback((): void => {
         if (authProvider.serviceType === 'gerrit') {

--- a/client/web/src/user/settings/auth/ExternalAccount.tsx
+++ b/client/web/src/user/settings/auth/ExternalAccount.tsx
@@ -1,6 +1,7 @@
-import React, { useState, useCallback, type FC } from 'react'
+import React, { useState, useCallback, type FC, useEffect } from 'react'
 
 import type { ErrorLike } from '@sourcegraph/common'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import { Button, Link, H3 } from '@sourcegraph/wildcard'
 
 import { LoaderButton } from '../../../components/LoaderButton'
@@ -10,7 +11,7 @@ import { AddGerritAccountModal } from './AddGerritAccountModal'
 import type { NormalizedExternalAccount } from './ExternalAccountsSignIn'
 import { RemoveExternalAccountModal } from './RemoveExternalAccountModal'
 
-interface Props {
+interface Props extends TelemetryV2Props {
     account: NormalizedExternalAccount
     authProvider: AuthProvider
     onDidRemove: (id: string, name: string) => void
@@ -24,10 +25,13 @@ export const ExternalAccount: React.FunctionComponent<React.PropsWithChildren<Pr
     onDidRemove,
     onDidError,
     onDidAdd,
+    telemetryRecorder,
 }) => {
     const [isLoading, setIsLoading] = useState(false)
     const [isRemoveAccountModalOpen, setIsRemoveAccountModalOpen] = useState(false)
     const [isAddGerritAccountModalOpen, setIsGerritAccountModalOpen] = useState(false)
+
+    useEffect(() => telemetryRecorder.recordEvent('settings.externalAccount', 'view'))
 
     const navigateToAuthProvider = useCallback((): void => {
         if (authProvider.serviceType === 'gerrit') {

--- a/client/web/src/user/settings/auth/ExternalAccountsSignIn.test.tsx
+++ b/client/web/src/user/settings/auth/ExternalAccountsSignIn.test.tsx
@@ -1,6 +1,8 @@
 import { render } from '@testing-library/react'
 import { describe, expect, test } from 'vitest'
 
+import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
+
 import type { AuthProvider } from '../../../jscontext'
 
 import { ExternalAccountsSignIn } from './ExternalAccountsSignIn'
@@ -52,6 +54,7 @@ describe('ExternalAccountsSignIn', () => {
                 onDidRemove={() => {}}
                 onDidAdd={() => {}}
                 onDidError={() => {}}
+                telemetryRecorder={noOpTelemetryRecorder}
             />
         )
         expect(cmp.asFragment()).toMatchSnapshot()

--- a/client/web/src/user/settings/auth/ExternalAccountsSignIn.tsx
+++ b/client/web/src/user/settings/auth/ExternalAccountsSignIn.tsx
@@ -4,6 +4,7 @@ import classNames from 'classnames'
 import type { AuthProvider } from 'src/jscontext'
 
 import type { ErrorLike } from '@sourcegraph/common'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 
 import { defaultExternalAccounts } from '../../../components/externalAccounts/externalAccounts'
 
@@ -22,7 +23,7 @@ export interface NormalizedExternalAccount {
     }
 }
 
-interface Props {
+interface Props extends TelemetryV2Props {
     accounts: UserExternalAccount[]
     authProviders: AuthProvider[]
     onDidRemove: (id: string, name: string) => void
@@ -84,6 +85,7 @@ export const ExternalAccountsSignIn: React.FunctionComponent<React.PropsWithChil
     onDidRemove,
     onDidError,
     onDidAdd,
+    telemetryRecorder,
 }) => {
     const accountGroups = authProviders.map(authProvider => ({
         authProvider,
@@ -97,6 +99,7 @@ export const ExternalAccountsSignIn: React.FunctionComponent<React.PropsWithChil
                 className={classNames('list-group-item', styles.externalAccount)}
             >
                 <ExternalAccount
+                    telemetryRecorder={telemetryRecorder}
                     account={account}
                     authProvider={account.authProvider}
                     onDidRemove={onDidRemove}

--- a/client/web/src/user/settings/auth/UserSettingsPasswordPage.tsx
+++ b/client/web/src/user/settings/auth/UserSettingsPasswordPage.tsx
@@ -4,6 +4,7 @@ import { Subject, Subscription } from 'rxjs'
 import { catchError, filter, mergeMap, tap } from 'rxjs/operators'
 
 import { logger } from '@sourcegraph/common'
+import type { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import { EVENT_LOGGER } from '@sourcegraph/shared/src/telemetry/web/eventLogger'
 import {
     Button,
@@ -27,7 +28,7 @@ import { updatePassword } from '../backend'
 
 import styles from './UserSettingsPasswordPage.module.scss'
 
-interface Props {
+interface Props extends TelemetryV2Props {
     user: UserAreaUserFields
     authenticatedUser: AuthenticatedUser
 }
@@ -58,19 +59,25 @@ export class UserSettingsPasswordPage extends React.Component<Props, State> {
 
     public componentDidMount(): void {
         EVENT_LOGGER.logViewEvent('UserSettingsPassword')
+        this.props.telemetryRecorder.recordEvent('settings.password', 'view')
+
         this.subscriptions.add(
             this.submits
                 .pipe(
                     tap(event => {
                         event.preventDefault()
                         EVENT_LOGGER.log('UpdatePasswordClicked')
+                        this.props.telemetryRecorder.recordEvent('settings.password', 'update')
                     }),
                     filter(event => event.currentTarget.checkValidity()),
                     tap(() => this.setState({ loading: true })),
                     mergeMap(() =>
                         updatePassword({
-                            oldPassword: this.state.oldPassword,
-                            newPassword: this.state.newPassword,
+                            args: {
+                                oldPassword: this.state.oldPassword,
+                                newPassword: this.state.newPassword,
+                            },
+                            telemetryRecorder: this.props.telemetryRecorder,
                         }).pipe(
                             // Sign the user out after their password is changed.
                             // We do this because the backend will no longer accept their current session

--- a/client/web/src/user/settings/auth/UserSettingsSecurityPage.tsx
+++ b/client/web/src/user/settings/auth/UserSettingsSecurityPage.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react'
 
 import type { ErrorLike } from '@sourcegraph/common'
 import { useMutation, useQuery } from '@sourcegraph/http-client'
+import type { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import { EVENT_LOGGER } from '@sourcegraph/shared/src/telemetry/web/eventLogger'
 import {
     Container,
@@ -54,7 +55,7 @@ interface UserExternalAccountsResult {
     }
 }
 
-interface Props {
+interface Props extends TelemetryV2Props {
     user: UserAreaUserFields
     authenticatedUser: AuthenticatedUser
     context: Pick<SourcegraphContext, 'authProviders'>
@@ -92,9 +93,10 @@ export const UserSettingsSecurityPage: React.FunctionComponent<React.PropsWithCh
 
     useEffect(() => {
         EVENT_LOGGER.logPageView('UserSettingsPassword')
+        props.telemetryRecorder.recordEvent('settings.security', 'view')
 
         setAccounts({ fetched: data?.user?.externalAccounts.nodes, lastRemoved: '' })
-    }, [data])
+    }, [data, props.telemetryRecorder])
 
     const onAccountRemoval = (removeId: string, name: string): void => {
         // keep every account that doesn't match removeId
@@ -207,6 +209,7 @@ export const UserSettingsSecurityPage: React.FunctionComponent<React.PropsWithCh
                         onDidError={handleError}
                         onDidRemove={onAccountRemoval}
                         onDidAdd={onAccountAdd}
+                        telemetryRecorder={props.telemetryRecorder}
                     />
                 </Container>
             )}

--- a/client/web/src/user/settings/emails/AddUserEmailForm.tsx
+++ b/client/web/src/user/settings/emails/AddUserEmailForm.tsx
@@ -5,11 +5,8 @@ import { lastValueFrom } from 'rxjs'
 
 import { asError, isErrorLike, type ErrorLike } from '@sourcegraph/common'
 import { gql, dataOrThrowErrors } from '@sourcegraph/http-client'
-<<<<<<< HEAD
+import type { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import { EVENT_LOGGER } from '@sourcegraph/shared/src/telemetry/web/eventLogger'
-=======
-import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
->>>>>>> 4288eaf65c (v2t: add v2t to src/user)
 import { deriveInputClassName, useInputValidation } from '@sourcegraph/shared/src/util/useInputValidation'
 import { screenReaderAnnounce, Input, Label, ErrorAlert } from '@sourcegraph/wildcard'
 
@@ -75,12 +72,8 @@ export const AddUserEmailForm: FunctionComponent<React.PropsWithChildren<Props>>
                     )
                 )
 
-<<<<<<< HEAD
                 EVENT_LOGGER.log('NewUserEmailAddressAdded')
-=======
-                eventLogger.log('NewUserEmailAddressAdded')
                 telemetryRecorder.recordEvent('settings.email', 'add')
->>>>>>> 4288eaf65c (v2t: add v2t to src/user)
                 screenReaderAnnounce('Email address added')
 
                 overrideEmailState({ value: '' })

--- a/client/web/src/user/settings/emails/AddUserEmailForm.tsx
+++ b/client/web/src/user/settings/emails/AddUserEmailForm.tsx
@@ -5,7 +5,11 @@ import { lastValueFrom } from 'rxjs'
 
 import { asError, isErrorLike, type ErrorLike } from '@sourcegraph/common'
 import { gql, dataOrThrowErrors } from '@sourcegraph/http-client'
+<<<<<<< HEAD
 import { EVENT_LOGGER } from '@sourcegraph/shared/src/telemetry/web/eventLogger'
+=======
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
+>>>>>>> 4288eaf65c (v2t: add v2t to src/user)
 import { deriveInputClassName, useInputValidation } from '@sourcegraph/shared/src/util/useInputValidation'
 import { screenReaderAnnounce, Input, Label, ErrorAlert } from '@sourcegraph/wildcard'
 
@@ -13,7 +17,7 @@ import { requestGraphQL } from '../../../backend/graphql'
 import { LoaderButton } from '../../../components/LoaderButton'
 import type { AddUserEmailResult, AddUserEmailVariables, UserSettingsAreaUserFields } from '../../../graphql-operations'
 
-interface Props {
+interface Props extends TelemetryV2Props {
     user: Pick<UserSettingsAreaUserFields, 'id' | 'scimControlled'>
     onDidAdd: () => void
     emails: Set<string>
@@ -35,6 +39,7 @@ export const AddUserEmailForm: FunctionComponent<React.PropsWithChildren<Props>>
     className,
     onDidAdd,
     emails,
+    telemetryRecorder,
 }) => {
     const [statusOrError, setStatusOrError] = useState<Status>()
 
@@ -70,7 +75,12 @@ export const AddUserEmailForm: FunctionComponent<React.PropsWithChildren<Props>>
                     )
                 )
 
+<<<<<<< HEAD
                 EVENT_LOGGER.log('NewUserEmailAddressAdded')
+=======
+                eventLogger.log('NewUserEmailAddressAdded')
+                telemetryRecorder.recordEvent('settings.email', 'add')
+>>>>>>> 4288eaf65c (v2t: add v2t to src/user)
                 screenReaderAnnounce('Email address added')
 
                 overrideEmailState({ value: '' })

--- a/client/web/src/user/settings/emails/SetUserPrimaryEmailForm.tsx
+++ b/client/web/src/user/settings/emails/SetUserPrimaryEmailForm.tsx
@@ -5,6 +5,7 @@ import { lastValueFrom } from 'rxjs'
 
 import { asError, type ErrorLike, isErrorLike } from '@sourcegraph/common'
 import { gql, dataOrThrowErrors } from '@sourcegraph/http-client'
+import type { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import { EVENT_LOGGER } from '@sourcegraph/shared/src/telemetry/web/eventLogger'
 import { Select, ErrorAlert, Form } from '@sourcegraph/wildcard'
 
@@ -21,7 +22,7 @@ import styles from './SetUserPrimaryEmailForm.module.scss'
 
 type UserEmail = (NonNullable<UserEmailsResult['node']> & { __typename: 'User' })['emails'][number]
 
-interface Props {
+interface Props extends TelemetryV2Props {
     user: Pick<UserSettingsAreaUserFields, 'id' | 'scimControlled'>
     emails: UserEmail[]
     onDidSet: () => void
@@ -38,6 +39,7 @@ export const SetUserPrimaryEmailForm: FunctionComponent<React.PropsWithChildren<
     emails,
     onDidSet,
     className,
+    telemetryRecorder,
 }) => {
     const currentPrimaryEmail = findPrimaryEmail(emails)
     const [primaryEmail, setPrimaryEmail] = useState<string | undefined>(currentPrimaryEmail)
@@ -74,6 +76,7 @@ export const SetUserPrimaryEmailForm: FunctionComponent<React.PropsWithChildren<
                 )
 
                 EVENT_LOGGER.log('UserEmailAddressSetAsPrimary')
+                telemetryRecorder.recordEvent('settings.email', 'setAsPrimary')
                 setStatusOrError(undefined)
 
                 if (onDidSet) {
@@ -83,7 +86,7 @@ export const SetUserPrimaryEmailForm: FunctionComponent<React.PropsWithChildren<
                 setStatusOrError(asError(error))
             }
         },
-        [user, primaryEmail, onDidSet]
+        [user, primaryEmail, onDidSet, telemetryRecorder]
     )
 
     return (

--- a/client/web/src/user/settings/emails/UserSettingsEmailsPage.tsx
+++ b/client/web/src/user/settings/emails/UserSettingsEmailsPage.tsx
@@ -5,6 +5,7 @@ import { lastValueFrom } from 'rxjs'
 
 import { asError, type ErrorLike, isErrorLike } from '@sourcegraph/common'
 import { gql, dataOrThrowErrors, useQuery } from '@sourcegraph/http-client'
+import type { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import { EVENT_LOGGER } from '@sourcegraph/shared/src/telemetry/web/eventLogger'
 import { Container, PageHeader, LoadingSpinner, Alert, ErrorAlert } from '@sourcegraph/wildcard'
 
@@ -27,7 +28,7 @@ import { UserEmail } from './UserEmail'
 
 import styles from './UserSettingsEmailsPage.module.scss'
 
-interface Props {
+interface Props extends TelemetryV2Props {
     user: UserSettingsAreaUserFields
 }
 
@@ -45,7 +46,10 @@ const FLAGS_QUERY = gql`
     }
 `
 
-export const UserSettingsEmailsPage: FunctionComponent<React.PropsWithChildren<Props>> = ({ user }) => {
+export const UserSettingsEmailsPage: FunctionComponent<React.PropsWithChildren<Props>> = ({
+    user,
+    telemetryRecorder,
+}) => {
     const [emails, setEmails] = useState<UserEmailType[]>([])
     const [statusOrError, setStatusOrError] = useState<Status>()
     const [emailActionError, setEmailActionError] = useState<EmailActionError>()
@@ -80,7 +84,8 @@ export const UserSettingsEmailsPage: FunctionComponent<React.PropsWithChildren<P
 
     useEffect(() => {
         EVENT_LOGGER.logViewEvent('UserSettingsEmails')
-    }, [])
+        telemetryRecorder.recordEvent('settings.emails', 'view')
+    }, [telemetryRecorder])
 
     useEffect(() => {
         fetchEmails().catch(error => {
@@ -120,6 +125,7 @@ export const UserSettingsEmailsPage: FunctionComponent<React.PropsWithChildren<P
                                 onDidRemove={onEmailRemove}
                                 onError={setEmailActionError}
                                 disableControls={user.scimControlled}
+                                telemetryRecorder={telemetryRecorder}
                             />
                         </li>
                     ))}
@@ -134,9 +140,15 @@ export const UserSettingsEmailsPage: FunctionComponent<React.PropsWithChildren<P
                 user={user}
                 onDidAdd={fetchEmails}
                 emails={new Set(emails.map(userEmail => userEmail.email))}
+                telemetryRecorder={telemetryRecorder}
             />
             <hr className="my-4" aria-hidden="true" />
-            <SetUserPrimaryEmailForm user={user} emails={emails} onDidSet={fetchEmails} />
+            <SetUserPrimaryEmailForm
+                user={user}
+                emails={emails}
+                onDidSet={fetchEmails}
+                telemetryRecorder={telemetryRecorder}
+            />
         </div>
     )
 }

--- a/client/web/src/user/settings/profile/UserSettingsProfilePage.test.tsx
+++ b/client/web/src/user/settings/profile/UserSettingsProfilePage.test.tsx
@@ -4,6 +4,7 @@ import { MemoryRouter } from 'react-router-dom'
 import { beforeAll, beforeEach, describe, expect, it } from 'vitest'
 
 import { getDocumentNode } from '@sourcegraph/http-client'
+import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
 import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
 
 import { UPDATE_USER } from './EditUserProfileForm'
@@ -56,7 +57,7 @@ describe('UserSettingsProfilePage', () => {
         queries = render(
             <MockedTestProvider mocks={mocks}>
                 <MemoryRouter>
-                    <UserSettingsProfilePage user={mockUser} />
+                    <UserSettingsProfilePage user={mockUser} telemetryRecorder={noOpTelemetryRecorder} />
                 </MemoryRouter>
             </MockedTestProvider>
         )

--- a/client/web/src/user/settings/profile/UserSettingsProfilePage.tsx
+++ b/client/web/src/user/settings/profile/UserSettingsProfilePage.tsx
@@ -2,6 +2,7 @@ import React, { useEffect } from 'react'
 
 import { Timestamp } from '@sourcegraph/branded/src/components/Timestamp'
 import { gql } from '@sourcegraph/http-client'
+import type { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import { EVENT_LOGGER } from '@sourcegraph/shared/src/telemetry/web/eventLogger'
 import { Link, PageHeader, Text } from '@sourcegraph/wildcard'
 
@@ -25,12 +26,18 @@ export const EditUserProfilePageGQLFragment = gql`
     }
 `
 
-interface Props {
+interface Props extends TelemetryV2Props {
     user: EditUserProfilePageFragment
 }
 
-export const UserSettingsProfilePage: React.FunctionComponent<React.PropsWithChildren<Props>> = ({ user }) => {
-    useEffect(() => EVENT_LOGGER.logViewEvent('UserProfile'), [])
+export const UserSettingsProfilePage: React.FunctionComponent<React.PropsWithChildren<Props>> = ({
+    user,
+    telemetryRecorder,
+}) => {
+    useEffect(() => {
+        telemetryRecorder.recordEvent('settings.profile', 'view')
+        EVENT_LOGGER.logViewEvent('UserProfile')
+    }, [telemetryRecorder])
 
     return (
         <div>
@@ -57,6 +64,7 @@ export const UserSettingsProfilePage: React.FunctionComponent<React.PropsWithChi
                 <EditUserProfileForm
                     user={user}
                     initialValue={user}
+                    telemetryRecorder={telemetryRecorder}
                     after={
                         window.context.sourcegraphDotComMode && (
                             <Text className="mt-4">

--- a/client/web/src/user/settings/research/ProductResearch.test.tsx
+++ b/client/web/src/user/settings/research/ProductResearch.test.tsx
@@ -1,6 +1,7 @@
 import { render, type RenderResult } from '@testing-library/react'
 import { beforeEach, describe, expect, test } from 'vitest'
 
+import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
 
 import { ProductResearchPage } from './ProductResearch'
@@ -12,6 +13,7 @@ describe('ProductResearchPage', () => {
         queries = render(
             <ProductResearchPage
                 telemetryService={NOOP_TELEMETRY_SERVICE}
+                telemetryRecorder={noOpTelemetryRecorder}
                 authenticatedUser={{
                     emails: [{ email: 'test@sourcegraph.com', isPrimary: true, verified: true }],
                 }}

--- a/client/web/src/user/settings/research/ProductResearch.tsx
+++ b/client/web/src/user/settings/research/ProductResearch.tsx
@@ -2,13 +2,14 @@ import React, { useEffect } from 'react'
 
 import { mdiOpenInNew } from '@mdi/js'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryService } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Container, PageHeader, ButtonLink, Icon, Text } from '@sourcegraph/wildcard'
 
 import type { AuthenticatedUser } from '../../../auth'
 import { PageTitle } from '../../../components/PageTitle'
 
-interface Props {
+interface Props extends TelemetryV2Props {
     telemetryService: TelemetryService
     authenticatedUser: Pick<AuthenticatedUser, 'emails'>
 }
@@ -17,11 +18,13 @@ const SIGN_UP_FORM_URL = 'https://info.sourcegraph.com/product-research'
 
 export const ProductResearchPage: React.FunctionComponent<React.PropsWithChildren<Props>> = ({
     telemetryService,
+    telemetryRecorder,
     authenticatedUser,
 }) => {
     useEffect(() => {
         telemetryService.logViewEvent('UserSettingsProductResearch')
-    }, [telemetryService])
+        telemetryRecorder.recordEvent('settings.productResearch', 'view')
+    }, [telemetryService, telemetryRecorder])
 
     const signUpForm = new URL(SIGN_UP_FORM_URL)
     const primaryEmail = authenticatedUser.emails.find(email => email.isPrimary)


### PR DESCRIPTION
Context:

* https://github.com/sourcegraph/sourcegraph/pull/60127
* https://github.com/sourcegraph/sourcegraph/pull/60192
* https://github.com/sourcegraph/sourcegraph/pull/60219
* https://github.com/sourcegraph/sourcegraph/pull/60343
* https://github.com/sourcegraph/sourcegraph/pull/60377
* https://github.com/sourcegraph/sourcegraph/pull/60382
* https://github.com/sourcegraph/sourcegraph/pull/60764
* https://github.com/sourcegraph/sourcegraph/pull/60765
* https://github.com/sourcegraph/sourcegraph/pull/60767
* https://github.com/sourcegraph/sourcegraph/pull/60768
* https://github.com/sourcegraph/sourcegraph/pull/60788
* https://github.com/sourcegraph/sourcegraph/pull/60789
* https://github.com/sourcegraph/sourcegraph/pull/60803
* https://github.com/sourcegraph/sourcegraph/pull/60812
* https://github.com/sourcegraph/sourcegraph/pull/60850
* https://github.com/sourcegraph/sourcegraph/pull/60851
* https://github.com/sourcegraph/sourcegraph/pull/60939
* https://github.com/sourcegraph/sourcegraph/pull/60971
* https://github.com/sourcegraph/sourcegraph/pull/61205
* https://github.com/sourcegraph/sourcegraph/pull/61457
* https://github.com/sourcegraph/sourcegraph/pull/61503
* https://github.com/sourcegraph/sourcegraph/pull/61504
* https://github.com/sourcegraph/sourcegraph/pull/61506
* https://github.com/sourcegraph/sourcegraph/pull/61507
* https://github.com/sourcegraph/sourcegraph/pull/61516
* https://github.com/sourcegraph/sourcegraph/pull/61707
* https://github.com/sourcegraph/sourcegraph/pull/61748
* https://github.com/sourcegraph/sourcegraph/pull/61758
* https://github.com/sourcegraph/sourcegraph/pull/61762
* https://github.com/sourcegraph/sourcegraph/pull/61768
* https://github.com/sourcegraph/sourcegraph/pull/61808
* https://github.com/sourcegraph/sourcegraph/pull/61818
* https://github.com/sourcegraph/sourcegraph/pull/61850

## Test plan

`sg start`
visit page
check if events appear in `event_logs` table locally