### PR TITLE
gitserver: Clarify what RepositoryLock indicates

### DIFF
--- a/cmd/gitserver/internal/repo_info.go
+++ b/cmd/gitserver/internal/repo_info.go
@@ -20,10 +20,14 @@ func repoCloneProgress(fs gitserverfs.FS, locker RepositoryLocker, repo api.Repo
 	resp := protocol.RepoCloneProgress{
 		Cloned: cloned,
 	}
-	resp.CloneProgress, resp.CloneInProgress = locker.Status(repo)
+	cloneProgress, locked := locker.Status(repo)
 	if isAlwaysCloningTest(repo) {
 		resp.CloneInProgress = true
 		resp.CloneProgress = "This will never finish cloning"
+	}
+	if !cloned && locked {
+		resp.CloneInProgress = true
+		resp.CloneProgress = cloneProgress
 	}
 	return &resp, nil
 }

--- a/cmd/gitserver/internal/server_grpc.go
+++ b/cmd/gitserver/internal/server_grpc.go
@@ -1422,7 +1422,11 @@ func (gs *grpcServer) checkRepoExists(ctx context.Context, repo api.RepoName) er
 		}
 	}
 
-	cloneProgress, cloneInProgress := gs.locker.Status(repo)
+	cloneProgress, locked := gs.locker.Status(repo)
+
+	// We checked above that the repo is not cloned. So if the repo is currently
+	// locked, it must be a clone in progress.
+	cloneInProgress := locked
 
 	return newRepoNotFoundError(repo, cloneInProgress, cloneProgress)
 }

--- a/cmd/gitserver/internal/serverutil.go
+++ b/cmd/gitserver/internal/serverutil.go
@@ -14,11 +14,11 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
-func cloneStatus(cloned, cloning bool) types.CloneStatus {
+func cloneStatus(cloned, locked bool) types.CloneStatus {
 	switch {
 	case cloned:
 		return types.CloneStatusCloned
-	case cloning:
+	case locked:
 		return types.CloneStatusCloning
 	}
 	return types.CloneStatusNotCloned

--- a/cmd/gitserver/internal/statesyncer.go
+++ b/cmd/gitserver/internal/statesyncer.go
@@ -201,14 +201,14 @@ func syncRepoState(
 				// Failed to determine cloned state, we have to skip this record for now.
 				continue
 			}
-			_, cloning := locker.Status(repo.Name)
+			_, locked := locker.Status(repo.Name)
 
 			var shouldUpdate bool
 			if repo.ShardID != shardID {
 				repo.ShardID = shardID
 				shouldUpdate = true
 			}
-			cloneStatus := cloneStatus(cloned, cloning)
+			cloneStatus := cloneStatus(cloned, locked)
 			if repo.CloneStatus != cloneStatus {
 				repo.CloneStatus = cloneStatus
 				// Since the repo has been recloned or is being cloned


### PR DESCRIPTION
After refactoring to use the same locker for both tasks, this no longer only resembles cloneInProgress, so cleaned this up a little.

Test plan:

Existing test suites.
