### PR TITLE
gitserver: Add progressWriter to VCS fetch

### DIFF
--- a/cmd/gitserver/internal/server_test.go
+++ b/cmd/gitserver/internal/server_test.go
@@ -1141,7 +1141,7 @@ type mockVCSSyncer struct {
 	mockTypeFunc    func() string
 	mockIsCloneable func(ctx context.Context, repoName api.RepoName) error
 	mockClone       func(ctx context.Context, repo api.RepoName, targetDir common.GitDir, tmpPath string, progressWriter io.Writer) error
-	mockFetch       func(ctx context.Context, repoName api.RepoName, dir common.GitDir) ([]byte, error)
+	mockFetch       func(ctx context.Context, repoName api.RepoName, dir common.GitDir, progressWriter io.Writer) error
 }
 
 func (m *mockVCSSyncer) Type() string {
@@ -1168,12 +1168,12 @@ func (m *mockVCSSyncer) Clone(ctx context.Context, repo api.RepoName, targetDir 
 	return errors.New("no mock for Clone() is set")
 }
 
-func (m *mockVCSSyncer) Fetch(ctx context.Context, repoName api.RepoName, dir common.GitDir) ([]byte, error) {
+func (m *mockVCSSyncer) Fetch(ctx context.Context, repoName api.RepoName, dir common.GitDir, progressWriter io.Writer) error {
 	if m.mockFetch != nil {
-		return m.mockFetch(ctx, repoName, dir)
+		return m.mockFetch(ctx, repoName, dir, progressWriter)
 	}
 
-	return nil, errors.New("no mock for Fetch() is set")
+	return errors.New("no mock for Fetch() is set")
 }
 
 var _ vcssyncer.VCSSyncer = &mockVCSSyncer{}

--- a/cmd/gitserver/internal/vcssyncer/instrumented_syncer.go
+++ b/cmd/gitserver/internal/vcssyncer/instrumented_syncer.go
@@ -96,9 +96,9 @@ func (i *instrumentedSyncer) Clone(ctx context.Context, repo api.RepoName, targe
 	return i.base.Clone(ctx, repo, targetDir, tmpPath, progressWriter)
 }
 
-func (i *instrumentedSyncer) Fetch(ctx context.Context, repoName api.RepoName, dir common.GitDir) (output []byte, err error) {
+func (i *instrumentedSyncer) Fetch(ctx context.Context, repoName api.RepoName, dir common.GitDir, progressWriter io.Writer) (err error) {
 	if !i.shouldObserve() {
-		return i.base.Fetch(ctx, repoName, dir)
+		return i.base.Fetch(ctx, repoName, dir, progressWriter)
 	}
 
 	start := time.Now()
@@ -109,7 +109,7 @@ func (i *instrumentedSyncer) Fetch(ctx context.Context, repoName api.RepoName, d
 		metricFetchDuration.WithLabelValues(i.formattedTypeLabel, strconv.FormatBool(succeeded)).Observe(duration)
 	}()
 
-	return i.base.Fetch(ctx, repoName, dir)
+	return i.base.Fetch(ctx, repoName, dir, progressWriter)
 }
 
 func (i *instrumentedSyncer) shouldObserve() bool {

--- a/cmd/gitserver/internal/vcssyncer/mock.go
+++ b/cmd/gitserver/internal/vcssyncer/mock.go
@@ -44,7 +44,7 @@ func NewMockVCSSyncer() *MockVCSSyncer {
 			},
 		},
 		FetchFunc: &VCSSyncerFetchFunc{
-			defaultHook: func(context.Context, api.RepoName, common.GitDir) (r0 []byte, r1 error) {
+			defaultHook: func(context.Context, api.RepoName, common.GitDir, io.Writer) (r0 error) {
 				return
 			},
 		},
@@ -71,7 +71,7 @@ func NewStrictMockVCSSyncer() *MockVCSSyncer {
 			},
 		},
 		FetchFunc: &VCSSyncerFetchFunc{
-			defaultHook: func(context.Context, api.RepoName, common.GitDir) ([]byte, error) {
+			defaultHook: func(context.Context, api.RepoName, common.GitDir, io.Writer) error {
 				panic("unexpected invocation of MockVCSSyncer.Fetch")
 			},
 		},
@@ -223,23 +223,23 @@ func (c VCSSyncerCloneFuncCall) Results() []interface{} {
 // VCSSyncerFetchFunc describes the behavior when the Fetch method of the
 // parent MockVCSSyncer instance is invoked.
 type VCSSyncerFetchFunc struct {
-	defaultHook func(context.Context, api.RepoName, common.GitDir) ([]byte, error)
-	hooks       []func(context.Context, api.RepoName, common.GitDir) ([]byte, error)
+	defaultHook func(context.Context, api.RepoName, common.GitDir, io.Writer) error
+	hooks       []func(context.Context, api.RepoName, common.GitDir, io.Writer) error
 	history     []VCSSyncerFetchFuncCall
 	mutex       sync.Mutex
 }
 
 // Fetch delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockVCSSyncer) Fetch(v0 context.Context, v1 api.RepoName, v2 common.GitDir) ([]byte, error) {
-	r0, r1 := m.FetchFunc.nextHook()(v0, v1, v2)
-	m.FetchFunc.appendCall(VCSSyncerFetchFuncCall{v0, v1, v2, r0, r1})
-	return r0, r1
+func (m *MockVCSSyncer) Fetch(v0 context.Context, v1 api.RepoName, v2 common.GitDir, v3 io.Writer) error {
+	r0 := m.FetchFunc.nextHook()(v0, v1, v2, v3)
+	m.FetchFunc.appendCall(VCSSyncerFetchFuncCall{v0, v1, v2, v3, r0})
+	return r0
 }
 
 // SetDefaultHook sets function that is called when the Fetch method of the
 // parent MockVCSSyncer instance is invoked and the hook queue is empty.
-func (f *VCSSyncerFetchFunc) SetDefaultHook(hook func(context.Context, api.RepoName, common.GitDir) ([]byte, error)) {
+func (f *VCSSyncerFetchFunc) SetDefaultHook(hook func(context.Context, api.RepoName, common.GitDir, io.Writer) error) {
 	f.defaultHook = hook
 }
 
@@ -247,7 +247,7 @@ func (f *VCSSyncerFetchFunc) SetDefaultHook(hook func(context.Context, api.RepoN
 // Fetch method of the parent MockVCSSyncer instance invokes the hook at the
 // front of the queue and discards it. After the queue is empty, the default
 // hook function is invoked for any future action.
-func (f *VCSSyncerFetchFunc) PushHook(hook func(context.Context, api.RepoName, common.GitDir) ([]byte, error)) {
+func (f *VCSSyncerFetchFunc) PushHook(hook func(context.Context, api.RepoName, common.GitDir, io.Writer) error) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -255,20 +255,20 @@ func (f *VCSSyncerFetchFunc) PushHook(hook func(context.Context, api.RepoName, c
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *VCSSyncerFetchFunc) SetDefaultReturn(r0 []byte, r1 error) {
-	f.SetDefaultHook(func(context.Context, api.RepoName, common.GitDir) ([]byte, error) {
-		return r0, r1
+func (f *VCSSyncerFetchFunc) SetDefaultReturn(r0 error) {
+	f.SetDefaultHook(func(context.Context, api.RepoName, common.GitDir, io.Writer) error {
+		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *VCSSyncerFetchFunc) PushReturn(r0 []byte, r1 error) {
-	f.PushHook(func(context.Context, api.RepoName, common.GitDir) ([]byte, error) {
-		return r0, r1
+func (f *VCSSyncerFetchFunc) PushReturn(r0 error) {
+	f.PushHook(func(context.Context, api.RepoName, common.GitDir, io.Writer) error {
+		return r0
 	})
 }
 
-func (f *VCSSyncerFetchFunc) nextHook() func(context.Context, api.RepoName, common.GitDir) ([]byte, error) {
+func (f *VCSSyncerFetchFunc) nextHook() func(context.Context, api.RepoName, common.GitDir, io.Writer) error {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -310,24 +310,24 @@ type VCSSyncerFetchFuncCall struct {
 	// Arg2 is the value of the 3rd argument passed to this method
 	// invocation.
 	Arg2 common.GitDir
+	// Arg3 is the value of the 4th argument passed to this method
+	// invocation.
+	Arg3 io.Writer
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 []byte
-	// Result1 is the value of the 2nd result returned from this method
-	// invocation.
-	Result1 error
+	Result0 error
 }
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
 func (c VCSSyncerFetchFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c VCSSyncerFetchFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+	return []interface{}{c.Result0}
 }
 
 // VCSSyncerIsCloneableFunc describes the behavior when the IsCloneable

--- a/cmd/gitserver/internal/vcssyncer/packages_syncer_test.go
+++ b/cmd/gitserver/internal/vcssyncer/packages_syncer_test.go
@@ -66,7 +66,7 @@ func TestVcsDependenciesSyncer_Fetch(t *testing.T) {
 	depsSource.Add("foo@0.0.1")
 
 	t.Run("one version from service", func(t *testing.T) {
-		_, err := s.Fetch(ctx, "", dir)
+		err := s.Fetch(ctx, "", dir, io.Discard)
 		require.NoError(t, err)
 
 		s.assertRefs(t, dir, map[string]string{
@@ -89,7 +89,7 @@ func TestVcsDependenciesSyncer_Fetch(t *testing.T) {
 	oneVersionOneDownload := map[string]int{"foo@0.0.1": 1, "foo@0.0.2": 1}
 
 	t.Run("two versions, service and config", func(t *testing.T) {
-		_, err := s.Fetch(ctx, "", dir)
+		err := s.Fetch(ctx, "", dir, io.Discard)
 		require.NoError(t, err)
 
 		s.assertRefs(t, dir, allVersionsHaveRefs)
@@ -99,7 +99,7 @@ func TestVcsDependenciesSyncer_Fetch(t *testing.T) {
 	depsSource.Delete("foo@0.0.2")
 
 	t.Run("cached tag not re-downloaded (404 not found)", func(t *testing.T) {
-		_, err := s.Fetch(ctx, "", dir)
+		err := s.Fetch(ctx, "", dir, io.Discard)
 		require.NoError(t, err)
 
 		// v0.0.2 is still present in the git repo because we didn't send a second download request.
@@ -111,7 +111,7 @@ func TestVcsDependenciesSyncer_Fetch(t *testing.T) {
 	depsSource.download["foo@0.0.1"] = errors.New("401 unauthorized")
 
 	t.Run("cached tag not re-downloaded (401 unauthorized)", func(t *testing.T) {
-		_, err := s.Fetch(ctx, "", dir)
+		err := s.Fetch(ctx, "", dir, io.Discard)
 		// v0.0.1 is still present in the git repo because we didn't send a second download request.
 		require.NoError(t, err)
 		s.assertRefs(t, dir, allVersionsHaveRefs)
@@ -126,7 +126,7 @@ func TestVcsDependenciesSyncer_Fetch(t *testing.T) {
 	}
 
 	t.Run("service version deleted", func(t *testing.T) {
-		_, err := s.Fetch(ctx, "", dir)
+		err := s.Fetch(ctx, "", dir, io.Discard)
 		require.NoError(t, err)
 
 		s.assertRefs(t, dir, onlyV2Refs)
@@ -136,7 +136,7 @@ func TestVcsDependenciesSyncer_Fetch(t *testing.T) {
 	s.configDeps = []string{}
 
 	t.Run("all versions deleted", func(t *testing.T) {
-		_, err := s.Fetch(ctx, "", dir)
+		err := s.Fetch(ctx, "", dir, io.Discard)
 		require.NoError(t, err)
 
 		s.assertRefs(t, dir, map[string]string{})
@@ -148,7 +148,7 @@ func TestVcsDependenciesSyncer_Fetch(t *testing.T) {
 	depsService.Add("foo@0.0.2")
 	depsSource.Add("foo@0.0.2")
 	t.Run("error aggregation", func(t *testing.T) {
-		_, err := s.Fetch(ctx, "", dir)
+		err := s.Fetch(ctx, "", dir, io.Discard)
 		require.ErrorContains(t, err, "401 unauthorized")
 
 		// The foo@0.0.1 tag was not created because of the 401 error.

--- a/cmd/gitserver/internal/vcssyncer/perforce.go
+++ b/cmd/gitserver/internal/vcssyncer/perforce.go
@@ -208,20 +208,20 @@ func (s *perforceDepotSyncer) buildP4FusionCmd(ctx context.Context, depot, usern
 }
 
 // Fetch tries to fetch updates of a Perforce depot as a Git repository.
-func (s *perforceDepotSyncer) Fetch(ctx context.Context, repoName api.RepoName, dir common.GitDir) ([]byte, error) {
+func (s *perforceDepotSyncer) Fetch(ctx context.Context, repoName api.RepoName, dir common.GitDir, progressWriter io.Writer) error {
 	source, err := s.getRemoteURLSource(ctx, repoName)
 	if err != nil {
-		return nil, errors.Wrap(err, "getting remote URL source")
+		return errors.Wrap(err, "getting remote URL source")
 	}
 
 	remoteURL, err := source.RemoteURL(ctx)
 	if err != nil {
-		return nil, errors.Wrap(err, "getting remote URL") // This should never happen for Perforce
+		return errors.Wrap(err, "getting remote URL") // This should never happen for Perforce
 	}
 
 	p4user, p4passwd, p4port, depot, err := perforce.DecomposePerforceRemoteURL(remoteURL)
 	if err != nil {
-		return nil, errors.Wrap(err, "invalid perforce remote URL")
+		return errors.Wrap(err, "invalid perforce remote URL")
 	}
 
 	// First, do a quick check if we can reach the Perforce server.
@@ -231,7 +231,7 @@ func (s *perforceDepotSyncer) Fetch(ctx context.Context, repoName api.RepoName, 
 		P4Passwd: p4passwd,
 	})
 	if err != nil {
-		return nil, errors.Wrap(err, "verifying connection to perforce server")
+		return errors.Wrap(err, "verifying connection to perforce server")
 	}
 
 	var cmd *wrexec.Cmd
@@ -246,7 +246,7 @@ func (s *perforceDepotSyncer) Fetch(ctx context.Context, repoName api.RepoName, 
 	}
 	cmd.Env, err = s.p4CommandEnv(string(dir), p4port, p4user, p4passwd)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to build p4 command env")
+		return errors.Wrap(err, "failed to build p4 command env")
 	}
 	dir.Set(cmd.Cmd)
 
@@ -254,14 +254,15 @@ func (s *perforceDepotSyncer) Fetch(ctx context.Context, repoName api.RepoName, 
 	// we have runRemoteGitCommand which sets TLS settings/etc. Do we need
 	// something for p4?
 	output, err := cmd.CombinedOutput()
+	tryWrite(s.logger, progressWriter, urlredactor.New(remoteURL).Redact(string(output)))
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to update with output %q", urlredactor.New(remoteURL).Redact(string(output)))
+		return errors.Wrapf(err, "failed to update")
 	}
 
 	if !s.fusionConfig.Enabled {
 		p4home, err := s.fs.P4HomeDir()
 		if err != nil {
-			return nil, errors.Wrap(err, "failed to create p4home")
+			return errors.Wrap(err, "failed to create p4home")
 		}
 
 		// Force update "master" to "refs/remotes/p4/master" where changes are synced into
@@ -274,7 +275,7 @@ func (s *perforceDepotSyncer) Fetch(ctx context.Context, repoName api.RepoName, 
 		)
 		dir.Set(cmd.Cmd)
 		if output, err := cmd.CombinedOutput(); err != nil {
-			return nil, errors.Wrapf(err, "failed to force update branch with output %q", string(output))
+			return errors.Wrapf(err, "failed to force update branch with output %q", string(output))
 		}
 	}
 
@@ -286,7 +287,7 @@ func (s *perforceDepotSyncer) Fetch(ctx context.Context, repoName api.RepoName, 
 		s.logger.Error("failed to touch HEAD after perforce fetch", log.Error(err))
 	}
 
-	return output, nil
+	return nil
 }
 
 func (s *perforceDepotSyncer) p4CommandOptions() []string {

--- a/cmd/gitserver/internal/vcssyncer/syncer.go
+++ b/cmd/gitserver/internal/vcssyncer/syncer.go
@@ -62,7 +62,9 @@ type VCSSyncer interface {
 	// Output returned from this function should NEVER contain sensitive information.
 	// The VCSSyncer implementation is responsible of redacting potentially
 	// sensitive data like secrets.
-	Fetch(ctx context.Context, repoName api.RepoName, dir common.GitDir) ([]byte, error)
+	// Progress reported through the progressWriter will be streamed line-by-line
+	// with both LF and CR being valid line terminators.
+	Fetch(ctx context.Context, repoName api.RepoName, dir common.GitDir, progressWriter io.Writer) error
 }
 
 type NewVCSSyncerOpts struct {


### PR DESCRIPTION
Clone already did this, now Fetch does the same.

This will allow to also get access to the progress while it's happening, not only afterwards.

Test plan:

Existing clone / update tests still pass.
