### PR TITLE
gitserver: Rename RepoUpdate to FetchRepository

### DIFF
--- a/cmd/gitserver/internal/BUILD.bazel
+++ b/cmd/gitserver/internal/BUILD.bazel
@@ -129,7 +129,6 @@ go_test(
         "//internal/limiter",
         "//internal/observation",
         "//internal/ratelimit",
-        "//internal/trace",
         "//internal/types",
         "//internal/vcs",
         "//internal/wrexec",

--- a/cmd/gitserver/internal/ensurerevision.go
+++ b/cmd/gitserver/internal/ensurerevision.go
@@ -32,7 +32,7 @@ func (s *Server) EnsureRevision(ctx context.Context, repo api.RepoName, rev stri
 	}
 
 	// Revision not found, update before returning.
-	_, _, err := s.RepoUpdate(ctx, repo)
+	_, _, err := s.FetchRepository(ctx, repo)
 	if err != nil {
 		if ctx.Err() == nil {
 			ensureRevisionCounter.WithLabelValues("update_failed").Inc()

--- a/cmd/gitserver/internal/integration_tests/clone_test.go
+++ b/cmd/gitserver/internal/integration_tests/clone_test.go
@@ -91,7 +91,7 @@ func TestClone(t *testing.T) {
 
 	// Requesting a repo update should figure out that the repo is not yet
 	// cloned and call clone. We expect that clone to succeed.
-	_, _, err := s.RepoUpdate(ctx, repo)
+	_, _, err := s.FetchRepository(ctx, repo)
 	require.NoError(t, err)
 
 	// Should have acquired a lock.
@@ -194,7 +194,7 @@ func TestClone_Fail(t *testing.T) {
 	// Requesting a repo update should figure out that the repo is not yet
 	// cloned and call clone. We expect that clone to fail, because vcssyncer.IsCloneable
 	// fails here.
-	_, _, err := s.RepoUpdate(ctx, repo)
+	_, _, err := s.FetchRepository(ctx, repo)
 	require.Error(t, err)
 	// Note that this error is from IsCloneable(), not from Clone().
 	require.Contains(t, err.Error(), "error cloning repo: repo github.com/test/repo not cloneable:")
@@ -232,7 +232,7 @@ func TestClone_Fail(t *testing.T) {
 	// Requesting another repo update should figure out that the repo is not yet
 	// cloned and call clone. We expect that clone to fail, but in the vcssyncer.Clone
 	// stage this time, not vcssyncer.IsCloneable.
-	_, _, err = s.RepoUpdate(ctx, repo)
+	_, _, err = s.FetchRepository(ctx, repo)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "failed to clone github.com/test/repo: clone failed. Output: Creating bare repo\nCreated bare repo at")
 

--- a/cmd/gitserver/internal/integration_tests/resolverevisions_test.go
+++ b/cmd/gitserver/internal/integration_tests/resolverevisions_test.go
@@ -126,7 +126,7 @@ func TestClient_ResolveRevision(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run("", func(t *testing.T) {
-			_, _, err := s.RepoUpdate(ctx, api.RepoName(remote))
+			_, _, err := s.FetchRepository(ctx, api.RepoName(remote))
 			require.NoError(t, err)
 
 			got, err := cli.ResolveRevision(ctx, api.RepoName(remote), test.input, gitserver.ResolveRevisionOptions{EnsureRevision: false})

--- a/cmd/gitserver/internal/integration_tests/utils_test.go
+++ b/cmd/gitserver/internal/integration_tests/utils_test.go
@@ -145,7 +145,7 @@ func MakeGitRepository(t testing.TB, cmds ...string) api.RepoName {
 	t.Helper()
 	dir := InitGitRepository(t, cmds...)
 	repo := api.RepoName(filepath.Base(dir))
-	_, _, err := testServer.RepoUpdate(context.Background(), repo)
+	_, _, err := testServer.FetchRepository(context.Background(), repo)
 	require.NoError(t, err)
 	return repo
 }

--- a/cmd/gitserver/internal/repositoryservice.go
+++ b/cmd/gitserver/internal/repositoryservice.go
@@ -70,7 +70,7 @@ func (s *repositoryServiceServer) FetchRepository(ctx context.Context, req *prot
 
 	repoName := api.RepoName(req.GetRepoName())
 
-	lastFetched, lastChanged, err := s.svc.RepoUpdate(ctx, repoName)
+	lastFetched, lastChanged, err := s.svc.FetchRepository(ctx, repoName)
 	if err != nil {
 		return nil, status.New(codes.Internal, errors.Wrap(err, "failed to fetch repository").Error()).Err()
 	}

--- a/cmd/gitserver/internal/server.go
+++ b/cmd/gitserver/internal/server.go
@@ -35,7 +35,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/limiter"
 	"github.com/sourcegraph/sourcegraph/internal/ratelimit"
-	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/internal/vcs"
 	"github.com/sourcegraph/sourcegraph/internal/wrexec"
@@ -277,12 +276,12 @@ func (s *Server) IsRepoCloneable(ctx context.Context, repo api.RepoName) (protoc
 	return resp, nil
 }
 
-// RepoUpdate triggers an update for the given repo.
+// FetchRepository triggers an update for the given repo.
 // If the repo is not cloned, a blocking clone will be triggered instead.
 // This function will not return until the update is complete.
 // Canceling the context will not cancel the update, but it will let the caller
 // escape the function early.
-func (s *Server) RepoUpdate(ctx context.Context, repoName api.RepoName) (lastFetched, lastChanged time.Time, err error) {
+func (s *Server) FetchRepository(ctx context.Context, repoName api.RepoName) (lastFetched, lastChanged time.Time, err error) {
 	err = s.repoUpdateOrClone(ctx, repoName)
 	if err != nil {
 		return lastFetched, lastChanged, err
@@ -755,8 +754,4 @@ func (s *Server) doRepoUpdate(ctx context.Context, repo api.RepoName, lock Repos
 	}
 
 	return err
-}
-
-func (s *Server) SearchWithObservability(ctx context.Context, tr trace.Trace, args *protocol.SearchRequest, onMatch func(*protocol.CommitMatch) error) (limitHit bool, err error) {
-	return searchWithObservability(ctx, s.logger, s.fs.RepoDir(args.Repo), tr, args, onMatch)
 }

--- a/cmd/gitserver/internal/server_test.go
+++ b/cmd/gitserver/internal/server_test.go
@@ -382,7 +382,7 @@ func TestCloneRepo(t *testing.T) {
 	cmd("git", "tag", "HEAD")
 
 	// Enqueue repo clone.
-	_, _, err := s.RepoUpdate(ctx, repoName)
+	_, _, err := s.FetchRepository(ctx, repoName)
 	require.NoError(t, err)
 
 	wantRepoSize, err := s.fs.DirSize(string(s.fs.RepoDir(repoName)))
@@ -475,7 +475,7 @@ func TestCloneRepoRecordsFailures(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			s.getVCSSyncer = tc.getVCSSyncer
-			_, _, _ = s.RepoUpdate(ctx, repoName)
+			_, _, _ = s.FetchRepository(ctx, repoName)
 			assertRepoState(types.CloneStatusNotCloned, 0, tc.wantErr)
 		})
 	}
@@ -543,7 +543,7 @@ func TestHandleRepoUpdate(t *testing.T) {
 		}), nil
 	}
 
-	_, _, err := s.RepoUpdate(ctx, repoName)
+	_, _, err := s.FetchRepository(ctx, repoName)
 	require.Error(t, err)
 
 	size, err := s.fs.DirSize(string(s.fs.RepoDir(repoName)))
@@ -575,7 +575,7 @@ func TestHandleRepoUpdate(t *testing.T) {
 	// This will perform an initial clone
 	s.getRemoteURLFunc = oldRemoveURLFunc
 	s.getVCSSyncer = oldVCSSyncer
-	_, _, err = s.RepoUpdate(ctx, repoName)
+	_, _, err = s.FetchRepository(ctx, repoName)
 	require.NoError(t, err)
 
 	size, err = s.fs.DirSize(string(s.fs.RepoDir(repoName)))
@@ -604,7 +604,7 @@ func TestHandleRepoUpdate(t *testing.T) {
 	t.Cleanup(func() { doBackgroundRepoUpdateMock = nil })
 
 	// This will trigger an update since the repo is already cloned
-	_, _, err = s.RepoUpdate(ctx, repoName)
+	_, _, err = s.FetchRepository(ctx, repoName)
 	require.Error(t, err)
 
 	want = &types.GitserverRepo{
@@ -628,7 +628,7 @@ func TestHandleRepoUpdate(t *testing.T) {
 	doBackgroundRepoUpdateMock = nil
 
 	// This will trigger an update since the repo is already cloned
-	_, _, err = s.RepoUpdate(ctx, repoName)
+	_, _, err = s.FetchRepository(ctx, repoName)
 	require.NoError(t, err)
 
 	// we compute the new size

--- a/internal/gitserver/protocol/BUILD.bazel
+++ b/internal/gitserver/protocol/BUILD.bazel
@@ -4,7 +4,6 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "protocol",
     srcs = [
-        "gitolite_phabricator.go",
         "gitserver.go",
         "search.go",
         "search_reduce.go",

--- a/internal/gitserver/protocol/gitolite_phabricator.go
+++ b/internal/gitserver/protocol/gitolite_phabricator.go
@@ -1,7 +1,0 @@
-package protocol
-
-// GitolitePhabricatorMetadataResponse is the response for a request
-// for Phabricator metadata through the Gitolite API
-type GitolitePhabricatorMetadataResponse struct {
-	Callsign string `json:"callsign"`
-}


### PR DESCRIPTION
Just a simple name change to reflect the gRPC API surface in the service layer.

Test plan:

CI and go compiler
