### PR TITLE
depgraph: Fix spurious error when no subcommand name is passed

### DIFF
--- a/dev/depgraph/main.go
+++ b/dev/depgraph/main.go
@@ -20,6 +20,9 @@ var rootFlagSet = flag.NewFlagSet("depgraph", flag.ExitOnError)
 var rootCommand = &ffcli.Command{
 	ShortUsage: "depgraph [flags] <subcommand>",
 	FlagSet:    rootFlagSet,
+	Exec: func(ctx context.Context, args []string) error {
+		return flag.ErrHelp
+	},
 	Subcommands: []*ffcli.Command{
 		summaryCommand,
 		traceCommand,


### PR DESCRIPTION
This confused me:

```
terminal command () doesn't define an Exec function
```

Now it prints a help text.

Test plan:

Verified the above behavior by hand.