### PR TITLE
sg: add `application/vnd.oci.image.manifest.v1+json` to accepted image types for `ops update-images`

### DIFF
--- a/dev/sg/internal/images/dockerhub.go
+++ b/dev/sg/internal/images/dockerhub.go
@@ -125,7 +125,7 @@ func (r *DockerHub) fetchDigest(repo string, tag string) (digest.Digest, error) 
 		return "", err
 	}
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
-	req.Header.Set("Accept", "application/vnd.docker.distribution.manifest.v2+json")
+	req.Header.Set("Accept", "application/vnd.docker.distribution.manifest.v2+json, application/vnd.oci.image.manifest.v1+json")
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return "", err

--- a/dev/sg/internal/images/gcr.go
+++ b/dev/sg/internal/images/gcr.go
@@ -60,7 +60,7 @@ func (r *GCR) fetchDigest(repo string, tag string) (digest.Digest, error) {
 		return "", err
 	}
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", r.token))
-	req.Header.Set("Accept", "application/vnd.docker.distribution.manifest.v2+json")
+	req.Header.Set("Accept", "application/vnd.docker.distribution.manifest.v2+json, application/vnd.oci.image.manifest.v1+json")
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
Docker image type has changed. Update the accepted types to fix the `sg ops update-images` command by including `application/vnd.oci.image.manifest.v1+json`
## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
tested locally command ran successfully