### PR TITLE
Log events in a non-blocking way

### DIFF
--- a/client/web/src/cody/onboarding/CodyOnboarding.tsx
+++ b/client/web/src/cody/onboarding/CodyOnboarding.tsx
@@ -308,10 +308,13 @@ function PurposeStep({
         if (choice) {
             const metadata = { variant: 'treatment' }
 
-            eventLogger.log(EventName.CODY_HANDRAISER_TEST_ENROLLMENT, metadata, metadata)
-            telemetryRecorder.recordEvent('cody.onboarding.purpose', 'select', {
-                metadata: { onboardingCall: choice.checked ? 1 : 0 },
-            })
+            void new Promise(resolve => {
+                eventLogger.log(EventName.CODY_HANDRAISER_TEST_ENROLLMENT, metadata, metadata)
+                telemetryRecorder.recordEvent('cody.onboarding.purpose', 'select', {
+                    metadata: { onboardingCall: choice.checked ? 1 : 0 },
+                })
+                resolve(undefined)
+            }).then(() => {})
         }
     }
 

--- a/client/web/src/cody/onboarding/CodyOnboarding.tsx
+++ b/client/web/src/cody/onboarding/CodyOnboarding.tsx
@@ -314,7 +314,11 @@ function PurposeStep({
                     metadata: { onboardingCall: choice.checked ? 1 : 0 },
                 })
                 resolve(undefined)
-            }).then(() => {}).catch(() => { /* Swallow errors */})
+            })
+                .then(() => {})
+                .catch(() => {
+                    /* Swallow errors */
+                })
         }
     }
 
@@ -331,11 +335,25 @@ function PurposeStep({
                     formId="19f34edd-1a98-4fc9-9b2b-c1edca727720"
                     onFormSubmitted={() => {
                         onNext()
-                        telemetryRecorder.recordEvent('cody.onboarding.qualificationSurvey', 'succeeded', {})
+                        void new Promise(resolve => {
+                            eventLogger.log(EventName.CODY_ONBOARDING_FORM_SUBMITTED)
+                            telemetryRecorder.recordEvent('cody.onboarding.qualificationSurvey', 'succeeded', {})
+                        })
+                            .then(() => {})
+                            .catch(() => {
+                                /* Swallow errors */
+                            })
                     }}
                     onFormLoadError={() => {
                         onNext()
-                        telemetryRecorder.recordEvent('cody.onboarding.qualificationSurvey', 'failed', {})
+                        void new Promise(resolve => {
+                            eventLogger.log(EventName.CODY_ONBOARDING_FORM_LOAD_ERRORED)
+                            telemetryRecorder.recordEvent('cody.onboarding.qualificationSurvey', 'failed', {})
+                        })
+                            .then(() => {})
+                            .catch(() => {
+                                /* Swallow errors */
+                            })
                     }}
                     userId={authenticatedUser.id}
                     userEmail={primaryEmail}

--- a/client/web/src/cody/onboarding/CodyOnboarding.tsx
+++ b/client/web/src/cody/onboarding/CodyOnboarding.tsx
@@ -331,9 +331,11 @@ function PurposeStep({
                     formId="19f34edd-1a98-4fc9-9b2b-c1edca727720"
                     onFormSubmitted={() => {
                         onNext()
+                        telemetryRecorder.recordEvent('cody.onboarding.qualificationSurvey', 'succeeded', {})
                     }}
                     onFormLoadError={() => {
                         onNext()
+                        telemetryRecorder.recordEvent('cody.onboarding.qualificationSurvey', 'failed', {})
                     }}
                     userId={authenticatedUser.id}
                     userEmail={primaryEmail}

--- a/client/web/src/cody/onboarding/CodyOnboarding.tsx
+++ b/client/web/src/cody/onboarding/CodyOnboarding.tsx
@@ -314,7 +314,7 @@ function PurposeStep({
                     metadata: { onboardingCall: choice.checked ? 1 : 0 },
                 })
                 resolve(undefined)
-            }).then(() => {})
+            }).then(() => {}).catch(() => { /* Swallow errors */})
         }
     }
 

--- a/client/web/src/util/constants.ts
+++ b/client/web/src/util/constants.ts
@@ -52,6 +52,8 @@ export const enum EventName {
     CODY_MANAGE_SUBSCRIPTION_CLICKED = 'CodyManageSubscriptionClicked',
     CODY_ONBOARDING_WELCOME_VIEWED = 'CodyWelcomeViewed',
     CODY_ONBOARDING_PURPOSE_VIEWED = 'CodyUseCaseViewed',
+    CODY_ONBOARDING_FORM_SUBMITTED = 'CodyOnboardingFormSubmitted',
+    CODY_ONBOARDING_FORM_LOAD_ERRORED = 'CodyOnboardingFormLoadErrored',
     CODY_ONBOARDING_PURPOSE_SELECTED = 'CodyUseCaseSelected',
     CODY_ONBOARDING_CHOOSE_EDITOR_VIEWED = 'CodyEditorViewed',
     CODY_ONBOARDING_CHOOSE_EDITOR_SKIPPED = 'CodyEditorSkipped',


### PR DESCRIPTION
We got this from a customer ([source](https://sourcegraph.slack.com/archives/C05SZB829D0/p1713020068425919))

> Hi! 
> 
> I have tried without success quite a few times to log in to start using Cody, but the onboarding process is stuck on the first hurdle.
> 
> Clicking get started does nothing and a 403 error is in the console. 
> 
> I've disabled all my plugins and tried multiple browsers, and nothing seems to work. 
> 
> I can get to the dashboard by editing the html and deleting the modal, but when I try to log in from my Rider IDE, it just comes here, and I can't log in.
> 
> Can you help?

We suspect it's due to failing to dismiss the dialog until we emit some telemetry event, which is being blocked at the DNS level or similar.

## Test plan

Add `console.log` after the logging code and see whether it gets triggered after this change, plus check if there's no race condition by navigating away from the page shortly after submitting the form (while having the `ab-hubspot-form-workpersonal-to-handraiser` ff enabled. Done this, got the console log, and experienced no page reload:

![CleanShot 2024-04-15 at 13 12 57@2x](https://github.com/sourcegraph/sourcegraph/assets/2552265/96928070-eae4-44f9-b946-aa3ae3ed0c37)
