### PR TITLE
bazel: patch rules_apko to copy, not symlink, lockfile

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -170,6 +170,8 @@ http_archive(
         "//third_party/rules_apko:repository_label_strip.patch",
         # required until a release contains https://github.com/chainguard-dev/rules_apko/pull/53
         "//third_party/rules_apko:apko_run_runfiles_path.patch",
+        # symlinking the lockfile appears to be problematic in CI https://github.com/sourcegraph/sourcegraph/pull/61877
+        "//third_party/rules_apko:copy_dont_symlink_lockfile.patch",
     ],
     sha256 = "f176171f95ee2b6eef1572c6da796d627940a1e898a32d476a2d7a9a99332960",
     strip_prefix = "rules_apko-1.2.2",

--- a/third_party/rules_apko/copy_dont_symlink_lockfile.patch
+++ b/third_party/rules_apko/copy_dont_symlink_lockfile.patch
@@ -1,0 +1,14 @@
+diff --git a/apko/translate_lock.bzl b/apko/translate_lock.bzl
+index 9fef1a9..a02da58 100644
+--- a/apko/translate_lock.bzl
++++ b/apko/translate_lock.bzl
+@@ -66,7 +66,8 @@ def _translate_apko_lock_impl(rctx):
+
+     # We copy the lockfile (.lock.json) to avoid visibility problems when we reference it from another module.
+     lock_file_local = "lockfile_copy"
+-    rctx.symlink(rctx.attr.lock, lock_file_local)
++    rctx.file(lock_file_local, rctx.read(rctx.attr.lock))
++    # rctx.symlink(rctx.attr.lock, lock_file_local)
+
+     apks = []
+     indexes = []


### PR DESCRIPTION
CI started failing with a bunch of the following for every apko target
```
...
(10:27:41) ERROR: /mnt/ephemeral/workdir/sourcegraph/sourcegraph/cmd/batcheshelper/BUILD.bazel:78:11: Action cmd/batcheshelper/wolfi_base_apko failed: missing input file '@@batcheshelper_apko_lock//:lockfile_copy'
(10:27:41) ERROR: /mnt/ephemeral/workdir/sourcegraph/sourcegraph/cmd/batcheshelper/BUILD.bazel:78:11: Action cmd/batcheshelper/wolfi_base_apko failed: 1 input file(s) do not exist
...
```

This line seemed suspect, so lets replace it with an actual full copy instead of :raised_eyebrow: symlink https://sourcegraph.com/github.com/chainguard-dev/rules_apko@1d78765293a0baf3f92ca49efa51d6c02b9c828e/-/blob/apko/translate_lock.bzl?L69

## Test plan

CI goes green again :sunglasses: 