### PR TITLE
rbac: make user permissions additive

### DIFF
--- a/cmd/frontend/internal/bg/update_permissions.go
+++ b/cmd/frontend/internal/bg/update_permissions.go
@@ -53,21 +53,15 @@ func UpdatePermissions(ctx context.Context, logger log.Logger, db database.DB) {
 				return errors.Wrap(err, "creating new permissions")
 			}
 
-			roles := []types.SystemRole{types.SiteAdministratorSystemRole, types.UserSystemRole}
-			excludedRoles := collections.NewSet[rtypes.PermissionNamespace](rbacSchema.ExcludeFromUserRole...)
+			permissionsToIncludeForUserRole := collections.NewSet[rtypes.PermissionNamespace](rbacSchema.IncludeInUserRole...)
 			for _, permission := range permissions {
-				// Assign the permission to both SITE_ADMINISTRATOR and USER roles. We do this so
-				// that we don't break the current experience and always assume that everyone has
-				// access until a site administrator revokes that access. Context:
-				// https://sourcegraph.slack.com/archives/C044BUJET7C/p1675292124253779?thread_ts=1675280399.192819&cid=C044BUJET7C
-
-				rolesToAssign := roles
-				if excludedRoles.Has(permission.Namespace) {
-					// The only exception to the above rule (at the moment) is Ownership, because it
-					// is clearly a permission which should be explicitly granted and only
-					// SITE_ADMINISTRATOR has it by default. All exceptions can be added to the
-					// `excludeFromUserRole` attribute of RBAC schema.
-					rolesToAssign = []types.SystemRole{types.SiteAdministratorSystemRole}
+				rolesToAssign := []types.SystemRole{types.SiteAdministratorSystemRole}
+				if permissionsToIncludeForUserRole.Has(permission.Namespace) {
+					// After the incident: https://app.incident.io/sourcegraph/incidents/292?source=slack_bookmark,
+					// we decided to make the permissions assignment to the user role additive. Thus, developers
+					// will have to explicitly state in the rbac schema the permissions they'd like to assign
+					// to the user role.
+					rolesToAssign = append(rolesToAssign, types.UserSystemRole)
 				}
 				if err := rolePermissionStore.BulkAssignPermissionsToSystemRoles(ctx, database.BulkAssignPermissionsToSystemRolesOpts{
 					Roles:        rolesToAssign,

--- a/cmd/frontend/internal/bg/update_permissions.go
+++ b/cmd/frontend/internal/bg/update_permissions.go
@@ -53,7 +53,7 @@ func UpdatePermissions(ctx context.Context, logger log.Logger, db database.DB) {
 				return errors.Wrap(err, "creating new permissions")
 			}
 
-			permissionsToIncludeForUserRole := collections.NewSet[rtypes.PermissionNamespace](rbacSchema.IncludeInUserRole...)
+			permissionsToIncludeForUserRole := collections.NewSet[rtypes.PermissionNamespace](rbacSchema.UserDefaultNamespaces...)
 			for _, permission := range permissions {
 				rolesToAssign := []types.SystemRole{types.SiteAdministratorSystemRole}
 				if permissionsToIncludeForUserRole.Has(permission.Namespace) {

--- a/internal/rbac/schema.yaml
+++ b/internal/rbac/schema.yaml
@@ -19,8 +19,9 @@ namespaces:
       - WRITE
 
 # 🚨 SECURITY: ALL PERMISSIONS defined above are granted by default to the base
-# USER role, unless specified in the below list. Namespaces that should NOT
-# be granted by default MUST be listed below.
-excludeFromUserRole:
-  - OWNERSHIP
-  - PRODUCT_SUBSCRIPTIONS
+# SITE_ADMINISTRATOR role, unless specified in the below list.
+# Namespaces that should be granted by default to the USER role MUST be listed below.
+defaultNamespacesForUserRole:
+  - BATCH_CHANGES
+  - REPO_METADATA
+  - CODY

--- a/internal/rbac/types.go
+++ b/internal/rbac/types.go
@@ -5,8 +5,8 @@ import rtypes "github.com/sourcegraph/sourcegraph/internal/rbac/types"
 // Schema refers to the RBAC structure which acts as a source of truth for permissions within
 // the RBAC system.
 type Schema struct {
-	Namespaces        []Namespace                  `yaml:"namespaces"`
-	IncludeInUserRole []rtypes.PermissionNamespace `yaml:"includeInUserRole"`
+	Namespaces            []Namespace                  `yaml:"namespaces"`
+	UserDefaultNamespaces []rtypes.PermissionNamespace `yaml:"defaultNamespacesForUserRole"`
 }
 
 // Namespace represents a feature to be guarded by RBAC. (example: Batch Changes, Code Insights e.t.c)

--- a/internal/rbac/types.go
+++ b/internal/rbac/types.go
@@ -5,8 +5,8 @@ import rtypes "github.com/sourcegraph/sourcegraph/internal/rbac/types"
 // Schema refers to the RBAC structure which acts as a source of truth for permissions within
 // the RBAC system.
 type Schema struct {
-	Namespaces          []Namespace                  `yaml:"namespaces"`
-	ExcludeFromUserRole []rtypes.PermissionNamespace `yaml:"excludeFromUserRole"`
+	Namespaces        []Namespace                  `yaml:"namespaces"`
+	IncludeInUserRole []rtypes.PermissionNamespace `yaml:"includeInUserRole"`
 }
 
 // Namespace represents a feature to be guarded by RBAC. (example: Batch Changes, Code Insights e.t.c)


### PR DESCRIPTION
Before this PR, RBAC permissions were automatically added to the User role and devs would have to explicitly declare permission namespaces that shouldn't be added to the user role.
This PR flips this logic by ensuring devs would explicitly have to specify permissions to be added to the User namespace.

[Context](https://app.incident.io/sourcegraph/incidents/292?source=slack_bookmark)

## Test plan

- Manual testing
- Add unit test
