### PR TITLE
Break dependency of internal/batches/webhooks on cmd/frontend

### DIFF
--- a/internal/batches/webhooks/BUILD.bazel
+++ b/internal/batches/webhooks/BUILD.bazel
@@ -40,7 +40,6 @@ go_test(
         "requires-network",
     ],
     deps = [
-        "//cmd/frontend/graphqlbackend",
         "//internal/actor",
         "//internal/batches/graphql",
         "//internal/batches/store",
@@ -53,6 +52,7 @@ go_test(
         "@com_github_google_go_cmp//cmp",
         "@com_github_google_go_cmp//cmp/cmpopts",
         "@com_github_graph_gophers_graphql_go//:graphql-go",
+        "@com_github_graph_gophers_graphql_go//relay",
         "@com_github_sourcegraph_log//logtest",
         "@com_github_stretchr_testify//mock",
         "@com_github_stretchr_testify//require",

--- a/internal/batches/webhooks/batch_change_test.go
+++ b/internal/batches/webhooks/batch_change_test.go
@@ -9,11 +9,11 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/graph-gophers/graphql-go/relay"
 	"github.com/sourcegraph/log/logtest"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
-	gql "github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	bgql "github.com/sourcegraph/sourcegraph/internal/batches/graphql"
 	"github.com/sourcegraph/sourcegraph/internal/batches/store"
@@ -30,7 +30,7 @@ func TestMarshalBatchChange(t *testing.T) {
 	db := database.NewDB(logger, dbtest.NewDB(t))
 
 	userID := bt.CreateTestUser(t, db, true).ID
-	marshalledUserID := gql.MarshalUserID(userID)
+	marshalledUserID := relay.MarshalID("User", userID)
 	now := timeutil.Now()
 	clock := func() time.Time { return now }
 	bstore := store.NewWithClock(db, observation.TestContextTB(t), nil, clock)

--- a/internal/batches/webhooks/changeset_test.go
+++ b/internal/batches/webhooks/changeset_test.go
@@ -13,11 +13,11 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/graph-gophers/graphql-go"
+	"github.com/graph-gophers/graphql-go/relay"
 	"github.com/sourcegraph/log/logtest"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
-	gql "github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	bgql "github.com/sourcegraph/sourcegraph/internal/batches/graphql"
 	"github.com/sourcegraph/sourcegraph/internal/batches/store"
@@ -47,10 +47,10 @@ func TestMarshalChangeset(t *testing.T) {
 	repos, _ := bt.CreateTestRepos(t, ctx, db, 3)
 
 	repoOne := repos[0]
-	repoOneID := gql.MarshalRepositoryID(repoOne.ID)
+	repoOneID := relay.MarshalID("Repository", repoOne.ID)
 
 	repoTwo := repos[1]
-	repoTwoID := gql.MarshalRepositoryID(repoTwo.ID)
+	repoTwoID := relay.MarshalID("Repository", repoTwo.ID)
 
 	uc := bt.CreateChangeset(t, ctx, bstore, bt.TestChangesetOpts{
 		Repo:               repoOne.ID,
@@ -113,7 +113,7 @@ func TestMarshalChangeset(t *testing.T) {
 			want: &changeset{
 				ID:                 mucID,
 				ExternalID:         uc.ExternalID,
-				RepositoryID:       gql.MarshalRepositoryID(uc.RepoID),
+				RepositoryID:       relay.MarshalID("Repository", uc.RepoID),
 				CreatedAt:          now,
 				UpdatedAt:          now,
 				BatchChangeIDs:     []graphql.ID{mbID},
@@ -147,7 +147,7 @@ func TestMarshalChangeset(t *testing.T) {
 			want: &changeset{
 				ID:                 micID,
 				ExternalID:         uc.ExternalID,
-				RepositoryID:       gql.MarshalRepositoryID(ic.RepoID),
+				RepositoryID:       relay.MarshalID("Repository", ic.RepoID),
 				CreatedAt:          now,
 				UpdatedAt:          now,
 				BatchChangeIDs:     []graphql.ID{mbID},


### PR DESCRIPTION
Was just used for one marshal operation in testing, so this simplifies the dependency graph by not importing from cmd/frontend.

Test plan:

Tests still pass, code compiles.