### PR TITLE
telemetry-gateway: wrap publish errors in error details for Sentry

### DIFF
--- a/cmd/telemetry-gateway/internal/events/events.go
+++ b/cmd/telemetry-gateway/internal/events/events.go
@@ -160,6 +160,10 @@ func (p *Publisher) Publish(ctx context.Context, events []*telemetrygatewayv1.Ev
 			// We can't error forever, as the instance will keep trying to deliver
 			// this event - for now, we just pretend the event succeeded, and log
 			// some diagnostics.
+			//
+			// TODO: Maybe we can merge this with how we handle errors in
+			// summarizePublishEventsResults - for now, we stick with this
+			// special handling for extra visibility.
 			if len(payload) >= googlepubsub.MaxPublishRequestBytes {
 				trace.Logger(ctx, p.logger).Error("discarding oversized event",
 					log.Error(errors.Newf("event %s/%s is oversized",
@@ -170,6 +174,7 @@ func (p *Publisher) Publish(ctx context.Context, events []*telemetrygatewayv1.Ev
 						redact.Safe(event.GetFeature()),
 						redact.Safe(event.GetAction()))),
 					log.String("eventID", event.GetId()),
+					log.String("eventSource", event.GetSource().String()),
 					log.Int("size", len(payload)),
 					// Record a section of the event content for diagnostics
 					log.String("eventSnippet", strings.ToValidUTF8(string(eventJSON[:256]), "�")))

--- a/cmd/telemetry-gateway/internal/events/events.go
+++ b/cmd/telemetry-gateway/internal/events/events.go
@@ -176,8 +176,11 @@ func (p *Publisher) Publish(ctx context.Context, events []*telemetrygatewayv1.Ev
 					log.String("eventID", event.GetId()),
 					log.String("eventSource", event.GetSource().String()),
 					log.Int("size", len(payload)),
-					// Record a section of the event content for diagnostics
-					log.String("eventSnippet", strings.ToValidUTF8(string(eventJSON[:256]), "�")))
+					// Record a section of the event content for diagnostics.
+					// Keep in mind the size of Context objects in Sentry:
+					// https://develop.sentry.dev/sdk/data-handling/#variable-size
+					// And GCP logging limits: https://cloud.google.com/logging/quotas
+					log.String("eventSnippet", strings.ToValidUTF8(string(eventJSON[:512]), "�")))
 				// We must return nil, pretending the publish succeeded, so that
 				// the client stops attempting to publish an event that will
 				// never succeed.

--- a/cmd/telemetry-gateway/internal/server/BUILD.bazel
+++ b/cmd/telemetry-gateway/internal/server/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
         "//internal/telemetrygateway/v1:telemetrygateway",
         "//internal/trace",
         "//lib/errors",
+        "@com_github_cockroachdb_redact//:redact",
         "@com_github_sourcegraph_log//:log",
         "@io_opentelemetry_go_otel//:otel",
         "@io_opentelemetry_go_otel//attribute",
@@ -39,7 +40,9 @@ go_test(
     deps = [
         "//cmd/telemetry-gateway/internal/events",
         "//internal/telemetrygateway/v1:telemetrygateway",
+        "//lib/errors",
         "@com_github_hexops_autogold_v2//:autogold",
         "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/lib/errors/cockroach.go
+++ b/lib/errors/cockroach.go
@@ -38,6 +38,20 @@ var (
 	// called. Useful for sentinel errors.
 	WithStack = errors.WithStack
 
+	// WithSafeDetails annotates an error with the given reportable details.
+	// The format is made available as a PII-free string, alongside
+	// with a PII-free representation of every additional argument.
+	// Arguments can be reported as-is (without redaction) by wrapping
+	// them using the Safe() function.
+	//
+	// If the format is empty and there are no arguments, the
+	// error argument is returned unchanged.
+	//
+	// Detail is shown:
+	// - when formatting with `%+v`.
+	// - in Sentry reports.
+	WithSafeDetails = errors.WithSafeDetails
+
 	Is        = errors.Is
 	IsAny     = errors.IsAny
 	As        = errors.As


### PR DESCRIPTION
We aggregate all errors on a single log entry to get accurate representations of issues in Sentry, while not generating thousands of log entries at the same time. Because this means we only get higher-level logger context, we must annotate the errors directly with some hidden details to preserve Sentry grouping while adding context for diagnostics.

We do this by using CockroachDB error's `WithSafeDetails` helper, which annotates an error with details that are _not_ rendered by `err.Error()` but _are_ included in Sentry reports (via the `Message` field). Currently, we annotate the event ID, feature, action, and source (see example output below)

Context on this request: https://sourcegraph.slack.com/archives/C06CCJR4K9R/p1713054354443579

## Test plan

_Super_ jank unit tests that try to emulate how we build Sentry reports, relying on knowledge of how our Sentry report building works internally. I opened https://github.com/sourcegraph/log/issues/65 in case there are new use cases for this in the future. Running the test with `-v` demonstrates the output:

```
$ go test -timeout 30s -run ^TestSummarizeFailedEvents$ github.com/sourcegraph/sourcegraph/cmd/telemetry-gateway/internal/server -v
=== RUN   TestSummarizeFailedEvents
=== RUN   TestSummarizeFailedEvents/all_failed
=== RUN   TestSummarizeFailedEvents/all_failed/Sentry_report
    publish_events_test.go:83: Sentry Error message for field "error.0":
        
        publish_events_test.go:38: event publish failed
        (1) feature:"feature_0" action:"action_0" id:"id_0" server:{version:"TestSummarizeFailedEvents/all_failed"}  client:{name:"test_client"}
        Wraps: (2) attached stack trace
          -- stack trace:
          | github.com/sourcegraph/sourcegraph/cmd/telemetry-gateway/internal/server.TestSummarizeFailedEvents.func1
          |     /Users/robert@sourcegraph.com/Projects/sourcegraph/sourcegraph/cmd/telemetry-gateway/internal/server/publish_events_test.go:38
          | testing.tRunner
          |     /Users/robert@sourcegraph.com/.asdf/installs/golang/1.22.1/go/src/testing/testing.go:1689
          | runtime.goexit
          |     /Users/robert@sourcegraph.com/.asdf/installs/golang/1.22.1/go/src/runtime/asm_arm64.s:1222
        Wraps: (3) event publish failed
        Error types: (1) *safedetails.withSafeDetails (2) *withstack.withStack (3) *errutil.leafError
        -- report composition:
        *errutil.leafError: event publish failed
        publish_events_test.go:38: *withstack.withStack (top exception)
        *safedetails.withSafeDetails: feature:"feature_0" action:"action_0" id:"id_0" server:{version:"TestSummarizeFailedEvents/all_failed"}  client:{name:"test_client"}
        
    publish_events_test.go:83: Sentry Error message for field "error.1":
        
        publish_events_test.go:38: event publish failed
        (1) feature:"feature_1" action:"action_1" id:"id_1" server:{version:"TestSummarizeFailedEvents/all_failed"}
        Wraps: (2) attached stack trace
          -- stack trace:
          | github.com/sourcegraph/sourcegraph/cmd/telemetry-gateway/internal/server.TestSummarizeFailedEvents.func1
          |     /Users/robert@sourcegraph.com/Projects/sourcegraph/sourcegraph/cmd/telemetry-gateway/internal/server/publish_events_test.go:38
          | testing.tRunner
          |     /Users/robert@sourcegraph.com/.asdf/installs/golang/1.22.1/go/src/testing/testing.go:1689
          | runtime.goexit
          |     /Users/robert@sourcegraph.com/.asdf/installs/golang/1.22.1/go/src/runtime/asm_arm64.s:1222
        Wraps: (3) event publish failed
        Error types: (1) *safedetails.withSafeDetails (2) *withstack.withStack (3) *errutil.leafError
        -- report composition:
        *errutil.leafError: event publish failed
        publish_events_test.go:38: *withstack.withStack (top exception)
        *safedetails.withSafeDetails: feature:"feature_1" action:"action_1" id:"id_1" server:{version:"TestSummarizeFailedEvents/all_failed"}
        
    publish_events_test.go:83: Sentry Error message for field "error.2":
        
        publish_events_test.go:38: event publish failed
        (1) feature:"feature_2" action:"action_2" id:"id_2" server:{version:"TestSummarizeFailedEvents/all_failed"}  client:{name:"test_client"}
        Wraps: (2) attached stack trace
          -- stack trace:
          | github.com/sourcegraph/sourcegraph/cmd/telemetry-gateway/internal/server.TestSummarizeFailedEvents.func1
          |     /Users/robert@sourcegraph.com/Projects/sourcegraph/sourcegraph/cmd/telemetry-gateway/internal/server/publish_events_test.go:38
          | testing.tRunner
          |     /Users/robert@sourcegraph.com/.asdf/installs/golang/1.22.1/go/src/testing/testing.go:1689
          | runtime.goexit
          |     /Users/robert@sourcegraph.com/.asdf/installs/golang/1.22.1/go/src/runtime/asm_arm64.s:1222
        Wraps: (3) event publish failed
        Error types: (1) *safedetails.withSafeDetails (2) *withstack.withStack (3) *errutil.leafError
        -- report composition:
        *errutil.leafError: event publish failed
        publish_events_test.go:38: *withstack.withStack (top exception)
        *safedetails.withSafeDetails: feature:"feature_2" action:"action_2" id:"id_2" server:{version:"TestSummarizeFailedEvents/all_failed"}  client:{name:"test_client"}
        
    publish_events_test.go:83: Sentry Error message for field "error.3":
        
        publish_events_test.go:38: event publish failed
        (1) feature:"feature_3" action:"action_3" id:"id_3" server:{version:"TestSummarizeFailedEvents/all_failed"}
        Wraps: (2) attached stack trace
          -- stack trace:
          | github.com/sourcegraph/sourcegraph/cmd/telemetry-gateway/internal/server.TestSummarizeFailedEvents.func1
          |     /Users/robert@sourcegraph.com/Projects/sourcegraph/sourcegraph/cmd/telemetry-gateway/internal/server/publish_events_test.go:38
          | testing.tRunner
          |     /Users/robert@sourcegraph.com/.asdf/installs/golang/1.22.1/go/src/testing/testing.go:1689
          | runtime.goexit
          |     /Users/robert@sourcegraph.com/.asdf/installs/golang/1.22.1/go/src/runtime/asm_arm64.s:1222
        Wraps: (3) event publish failed
        Error types: (1) *safedetails.withSafeDetails (2) *withstack.withStack (3) *errutil.leafError
        -- report composition:
        *errutil.leafError: event publish failed
        publish_events_test.go:38: *withstack.withStack (top exception)
        *safedetails.withSafeDetails: feature:"feature_3" action:"action_3" id:"id_3" server:{version:"TestSummarizeFailedEvents/all_failed"}
        
    publish_events_test.go:83: Sentry Error message for field "error.4":
        
        publish_events_test.go:38: event publish failed
        (1) feature:"feature_4" action:"action_4" id:"id_4" server:{version:"TestSummarizeFailedEvents/all_failed"}  client:{name:"test_client"}
        Wraps: (2) attached stack trace
          -- stack trace:
          | github.com/sourcegraph/sourcegraph/cmd/telemetry-gateway/internal/server.TestSummarizeFailedEvents.func1
          |     /Users/robert@sourcegraph.com/Projects/sourcegraph/sourcegraph/cmd/telemetry-gateway/internal/server/publish_events_test.go:38
          | testing.tRunner
          |     /Users/robert@sourcegraph.com/.asdf/installs/golang/1.22.1/go/src/testing/testing.go:1689
          | runtime.goexit
          |     /Users/robert@sourcegraph.com/.asdf/installs/golang/1.22.1/go/src/runtime/asm_arm64.s:1222
        Wraps: (3) event publish failed
        Error types: (1) *safedetails.withSafeDetails (2) *withstack.withStack (3) *errutil.leafError
        -- report composition:
        *errutil.leafError: event publish failed
        publish_events_test.go:38: *withstack.withStack (top exception)
        *safedetails.withSafeDetails: feature:"feature_4" action:"action_4" id:"id_4" server:{version:"TestSummarizeFailedEvents/all_failed"}  client:{name:"test_client"}
        
=== RUN   TestSummarizeFailedEvents/some_failed
=== RUN   TestSummarizeFailedEvents/all_succeeded
=== RUN   TestSummarizeFailedEvents/all_succeeded_(large_set)
--- PASS: TestSummarizeFailedEvents (0.23s)
    --- PASS: TestSummarizeFailedEvents/all_failed (0.22s)
        --- PASS: TestSummarizeFailedEvents/all_failed/Sentry_report (0.00s)
    --- PASS: TestSummarizeFailedEvents/some_failed (0.00s)
    --- PASS: TestSummarizeFailedEvents/all_succeeded (0.00s)
    --- PASS: TestSummarizeFailedEvents/all_succeeded_(large_set) (0.00s)
PASS
ok      github.com/sourcegraph/sourcegraph/cmd/telemetry-gateway/internal/server        (cached)
```