### PR TITLE
telemetry-gateway: use live dev instance locally by default

### DIFF
--- a/cmd/worker/internal/telemetrygatewayexporter/exporter.go
+++ b/cmd/worker/internal/telemetrygatewayexporter/exporter.go
@@ -108,7 +108,9 @@ func (j *exporterJob) Handle(ctx context.Context) error {
 		return nil
 	}
 
-	logger.Debug("exporting events", log.Int("count", len(batch)))
+	logger.Debug("exporting events",
+		log.Int("count", len(batch)),
+		log.String("address", ConfigInst.ExportAddress.String()))
 
 	// Send out events
 	succeeded, exportErr := exporter.ExportEvents(ctx, batch)

--- a/doc/dev/how-to/telemetry_gateway.md
+++ b/doc/dev/how-to/telemetry_gateway.md
@@ -13,12 +13,30 @@ To learn more about the Sourcegraph's new Telemetry framework, refer to [the tel
 > NOTE: In the Sourcegraph application, the [new events being exported using `internal/telemetry`](../background-information/telemetry/index.md) are sometimes loosely referred to as "V2", as it supersedes the existing mechanisms of writing directly to the `event_logs` database table.
 > The *Telemetry Gateway* schema, however, is `telemetrygateway/v1`, as it is the first iteration of the service's API.
 
+## Default development behaviour
+
+A test deployment is available at `telemetry-gateway.sgdev.org` (see [go/msp-ops/telemetry-gateway#dev](https://handbook.sourcegraph.com/departments/engineering/managed-services/telemetry-gateway/#dev)), which publishes events to a test topic and development pipeline - currently [`sourcegraph-telligent-testing/event-telemetry-test`](https://console.cloud.google.com/cloudpubsub/topic/edit/event-telemetry-test?project=sourcegraph-telligent-testing).
+This instance only accepts licensed instance events that use a development-only license key, and is continuously deployed using MSP rollouts.
+
+Exports of [V2 telemetry events](../background-information/telemetry/index.md) to this development instance is enabled by default in development using the `TELEMETRY_GATEWAY_EXPORTER_EXPORT_ADDR` environment variable configured in `sg.config.yaml` - for example, `sg start` will export V2 telemetry events to this instance.
+
 ## Running Telemetry Gateway locally
 
-Exports of [telemetry events](../background-information/telemetry/index.md) to a locally running Telemetry Gateway instance that is started as part of `sg start` and `sg start dotcom` are enabled by default in development using the `TELEMETRY_GATEWAY_EXPORTER_EXPORT_ADDR` environment variable configured in `sg.config.yaml`.
-By default, the local Telemetry Gateway instance will simply log any events it receives at `debug` level without forwarding the events anywhere.
+First, start a Telemetry Gateway instance locally:
 
-To see the message payloads it *would* emit in a production environment, configure the log level in `sg.config.overwrite.yaml`:
+```sh
+sg run telemetry-gateway
+```
+
+Then, configure the `TELEMETRY_GATEWAY_EXPORTER_EXPORT_ADDR` environment variable in `sg.config.overwrite.yaml` to send events to this locally running instance:
+
+```yaml
+env:
+  TELEMETRY_GATEWAY_EXPORTER_EXPORT_ADDR: 'http://127.0.0.1:6080'
+```
+
+By default, the local Telemetry Gateway instance will simply log any events it receives at `debug` level without forwarding the events anywhere.
+To see the message payloads it *would* emit in a production environment, configure the log level in `sg.config.overwrite.yaml` as well:
 
 ```yaml
 commands:
@@ -35,15 +53,3 @@ env:
 ```
 
 In development, a gRPC interface is enabled for Telemetry Gateway as well at `http://127.0.0.1:10085/debug/grpcui/`.
-
-## Testing against a remote Telemetry Gateway
-
-A test deployment is available at `telemetry-gateway.sgdev.org`, which publishes events to a test topic and development pipeline - currently [`sourcegraph-telligent-testing/event-telemetry-test`](https://console.cloud.google.com/cloudpubsub/topic/edit/event-telemetry-test?project=sourcegraph-telligent-testing).
-In local development, you can configure Sourcegraph to export to this test deployment by setting the following in `sg.config.yaml`:
-
-```yaml
-env:
-  TELEMETRY_GATEWAY_EXPORTER_EXPORT_ADDR: "https://telemetry-gateway.sgdev.org:443"
-```
-
-For details about live Telemetry Gateway deployments, refer to [the handbook Telemetry Gateway page](https://handbook.sourcegraph.com/departments/engineering/teams/core-services/managed-services/telemetry-gateway/).

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -129,7 +129,14 @@ env:
   GRPC_INTERNAL_ERROR_LOGGING_LOG_PROTOBUF_MESSAGES_JSON_TRUNCATION_SIZE_BYTES: '1KB'
   GRPC_INTERNAL_ERROR_LOGGING_LOG_PROTOBUF_MESSAGES_HANDLING_MAX_MESSAGE_SIZE_BYTES: '100MB'
 
-  TELEMETRY_GATEWAY_EXPORTER_EXPORT_ADDR: 'http://127.0.0.1:6080'
+  # Telemetry V2 export configuration. By default, this points to a test
+  # instance (go/msp-ops/telemetry-gateway#dev). Set the following:
+  #
+  #   TELEMETRY_GATEWAY_EXPORTER_EXPORT_ADDR: 'http://127.0.0.1:6080'
+  #
+  # in 'sg.config.overwrite.yaml' to point to a locally running Telemetry
+  # Gateway instead (via 'sg run telemetry-gateway')
+  TELEMETRY_GATEWAY_EXPORTER_EXPORT_ADDR: "https://telemetry-gateway.sgdev.org:443"
   SRC_TELEMETRY_EVENTS_EXPORT_ALL: 'true'
 
   # By default, allow temporary edits to external services.
@@ -1345,7 +1352,6 @@ commandsets:
       - zoekt-web-1
       - blobstore
       - embeddings
-      - telemetry-gateway
     env:
       DISABLE_CODE_INSIGHTS_HISTORICAL: false
       DISABLE_CODE_INSIGHTS: false
@@ -1383,7 +1389,6 @@ commandsets:
       - zoekt-web-1
       - blobstore
       - embeddings
-      - telemetry-gateway
       - cody-gateway
     env:
       SOURCEGRAPHDOTCOM_MODE: true
@@ -1821,7 +1826,6 @@ commandsets:
       - zoekt-web-1
       - blobstore
       - embeddings
-      - telemetry-gateway
     env:
       SVELTEKIT: true
 


### PR DESCRIPTION
We have a continuous-deployed dev deployment of Telemetry Gateway available but it receives practically no traffic, partly because a) it only accepts dev-signed-licenses and b) nothing uses it by default.

This change makes it so that local dev (`sg start`, `sg start dotcom`, etc) exports events to this live dev instance by default, allowing us to more effectively dogfood changes before rolling them out to prod. Prod stability is especially important as we move towards a V2-telemetry-only world.

Docs have been updated to describe this, and showcase how to run and use local Telemetry Gateway as before.

Thread: https://sourcegraph.slack.com/archives/C05BGNBEPKL/p1713222710245669

## Test plan

Locally, `sg start`:
<img width="1118" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/23356519/10a8b794-b49f-438e-801c-44b357ca1c24">

In dev logs:
![image](https://github.com/sourcegraph/sourcegraph/assets/23356519/6b6d3f4f-c102-4529-bbb9-3d3f1f7ba0b4)
