### PR TITLE
svcmain: Simplify service setup

### DIFF
--- a/internal/service/svcmain/svcmain.go
+++ b/internal/service/svcmain/svcmain.go
@@ -41,7 +41,7 @@ func SingleServiceMain(svc sgservice.Service) {
 		),
 	)
 	logger := log.Scoped("sourcegraph")
-	run(liblog, logger, []sgservice.Service{svc}, nil)
+	run(liblog, logger, svc, nil)
 }
 
 // OutOfBandConfiguration declares additional configuration that happens continuously,
@@ -73,13 +73,13 @@ func SingleServiceMainWithoutConf(svc sgservice.Service, oobConfig OutOfBandConf
 		),
 	)
 	logger := log.Scoped("sourcegraph")
-	run(liblog, logger, []sgservice.Service{svc}, &oobConfig)
+	run(liblog, logger, svc, &oobConfig)
 }
 
 func run(
 	liblog *log.PostInitCallbacks,
 	logger log.Logger,
-	services []sgservice.Service,
+	service sgservice.Service,
 	// If nil, will use site config
 	oobConfig *OutOfBandConfiguration,
 ) {
@@ -106,75 +106,38 @@ func run(
 
 	profiler.Init()
 
-	obctx := observation.NewContext(logger)
+	obctx := observation.ContextWithLogger(log.Scoped(service.Name()), observation.NewContext(logger))
 	ctx := context.Background()
 
-	allReady := make(chan struct{})
+	// Run the service Configure func before env vars are locked.
+	serviceConfig, debugserverEndpoints := service.Configure()
 
-	// Run the services' Configure funcs before env vars are locked.
-	var (
-		serviceConfigs          = make([]env.Config, len(services))
-		allDebugserverEndpoints []debugserver.Endpoint
-	)
-	for i, s := range services {
-		var debugserverEndpoints []debugserver.Endpoint
-		serviceConfigs[i], debugserverEndpoints = s.Configure()
-		allDebugserverEndpoints = append(allDebugserverEndpoints, debugserverEndpoints...)
-	}
-
-	// Validate each service's configuration.
+	// Validate the service's configuration.
 	//
 	// This cannot be done for executor, see the executorcmd package for details.
-	for i, c := range serviceConfigs {
-		if c == nil {
-			continue
-		}
-		if err := c.Validate(); err != nil {
-			logger.Fatal("invalid configuration", log.String("service", services[i].Name()), log.Error(err))
+	if serviceConfig != nil {
+		if err := serviceConfig.Validate(); err != nil {
+			logger.Fatal("invalid configuration", log.String("service", service.Name()), log.Error(err))
 		}
 	}
 
 	env.Lock()
 	env.HandleHelpFlag()
 
-	// Start the debug server. The ready boolean state it publishes will become true when *all*
-	// services report ready.
-	var allReadyWG sync.WaitGroup
-	var allDoneWG sync.WaitGroup
-	go debugserver.NewServerRoutine(allReady, allDebugserverEndpoints...).Start()
+	// Start the debug server. The ready boolean state it publishes will become true when
+	// the service reports ready.
+	ready := make(chan struct{})
+	go debugserver.NewServerRoutine(ready, debugserverEndpoints...).Start()
 
-	// Start the services.
-	for i := range services {
-		service := services[i]
-		serviceConfig := serviceConfigs[i]
-		allReadyWG.Add(1)
-		allDoneWG.Add(1)
-		go func() {
-			// TODO(sqs): TODO(single-binary): Consider using the goroutine package and/or the errgroup package to report
-			// errors and listen to signals to initiate cleanup in a consistent way across all
-			// services.
-			obctx := observation.ContextWithLogger(log.Scoped(service.Name()), obctx)
+	readyFunc := sync.OnceFunc(func() {
+		close(ready)
+	})
 
-			// ensure ready is only called once and always call it.
-			ready := sync.OnceFunc(allReadyWG.Done)
-			defer ready()
-
-			// TODO: It's not clear or enforced but all the service.Start calls block until the service is completed
-			// This should be made explicit or refactored to accept to done channel or function in addition to ready.
-			err := service.Start(ctx, obctx, ready, serviceConfig)
-			allDoneWG.Done()
-			if err != nil {
-				logger.Fatal("failed to start service", log.String("service", service.Name()), log.Error(err))
-			}
-		}()
+	// Start the service.
+	// TODO: It's not clear or enforced but all the service.Start calls block until the service is completed
+	// This should be made explicit or refactored to accept to done channel or function in addition to ready.
+	err := service.Start(ctx, obctx, readyFunc, serviceConfig)
+	if err != nil {
+		logger.Fatal("failed to start service", log.String("service", service.Name()), log.Error(err))
 	}
-
-	// Pass along the signal to the debugserver that all started services are ready.
-	go func() {
-		allReadyWG.Wait()
-		close(allReady)
-	}()
-
-	// wait for all services to stop
-	allDoneWG.Wait()
 }


### PR DESCRIPTION
Since we switched away from single binary, we always pass down a single service. So we can simplify this logic a little bit.

Test plan:

sg start still works and the E2E / integration test suites are still passing.
