### PR TITLE
Remove unnecessary dotcom checks

### DIFF
--- a/cmd/frontend/graphqlbackend/BUILD.bazel
+++ b/cmd/frontend/graphqlbackend/BUILD.bazel
@@ -542,7 +542,6 @@ go_test(
         "@com_github_derision_test_go_mockgen_v2//testutil/assert",
         "@com_github_derision_test_go_mockgen_v2//testutil/require",
         "@com_github_go_enry_go_enry_v2//:go-enry",
-        "@com_github_gofrs_uuid//:uuid",
         "@com_github_golang_jwt_jwt_v4//:jwt",
         "@com_github_google_go_cmp//cmp",
         "@com_github_google_go_cmp//cmp/cmpopts",

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -100,7 +100,7 @@ type Mutation {
 
     Only authenticated users may perform this mutation.
     """
-    createOrganization(name: String!, displayName: String, statsID: ID): Org!
+    createOrganization(name: String!, displayName: String): Org!
     """
     Updates an organization.
 

--- a/cmd/frontend/graphqlbackend/site_flags.go
+++ b/cmd/frontend/graphqlbackend/site_flags.go
@@ -13,10 +13,6 @@ import (
 )
 
 func (r *siteResolver) NeedsRepositoryConfiguration(ctx context.Context) (bool, error) {
-	if dotcom.SourcegraphDotComMode() {
-		return false, nil
-	}
-
 	// 🚨 SECURITY: The site alerts may contain sensitive data, so only site
 	// admins may view them.
 	if err := auth.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {

--- a/internal/database/BUILD.bazel
+++ b/internal/database/BUILD.bazel
@@ -309,7 +309,6 @@ go_test(
         "//schema",
         "@com_github_cockroachdb_errors//errbase",
         "@com_github_gitchander_permutation//:permutation",
-        "@com_github_gofrs_uuid//:uuid",
         "@com_github_gomodule_oauth1//oauth",
         "@com_github_google_go_cmp//cmp",
         "@com_github_google_go_cmp//cmp/cmpopts",

--- a/internal/database/dbmocks/mocks_temp.go
+++ b/internal/database/dbmocks/mocks_temp.go
@@ -44239,9 +44239,6 @@ func (c OrgMemberStoreWithTransactFuncCall) Results() []interface{} {
 // package github.com/sourcegraph/sourcegraph/internal/database) used for
 // unit testing.
 type MockOrgStore struct {
-	// AddOrgsOpenBetaStatsFunc is an instance of a mock function object
-	// controlling the behavior of the method AddOrgsOpenBetaStats.
-	AddOrgsOpenBetaStatsFunc *OrgStoreAddOrgsOpenBetaStatsFunc
 	// CountFunc is an instance of a mock function object controlling the
 	// behavior of the method Count.
 	CountFunc *OrgStoreCountFunc
@@ -44278,9 +44275,6 @@ type MockOrgStore struct {
 	// UpdateFunc is an instance of a mock function object controlling the
 	// behavior of the method Update.
 	UpdateFunc *OrgStoreUpdateFunc
-	// UpdateOrgsOpenBetaStatsFunc is an instance of a mock function object
-	// controlling the behavior of the method UpdateOrgsOpenBetaStats.
-	UpdateOrgsOpenBetaStatsFunc *OrgStoreUpdateOrgsOpenBetaStatsFunc
 	// WithFunc is an instance of a mock function object controlling the
 	// behavior of the method With.
 	WithFunc *OrgStoreWithFunc
@@ -44290,11 +44284,6 @@ type MockOrgStore struct {
 // return zero values for all results, unless overwritten.
 func NewMockOrgStore() *MockOrgStore {
 	return &MockOrgStore{
-		AddOrgsOpenBetaStatsFunc: &OrgStoreAddOrgsOpenBetaStatsFunc{
-			defaultHook: func(context.Context, int32, string) (r0 string, r1 error) {
-				return
-			},
-		},
 		CountFunc: &OrgStoreCountFunc{
 			defaultHook: func(context.Context, database.OrgsListOptions) (r0 int, r1 error) {
 				return
@@ -44355,11 +44344,6 @@ func NewMockOrgStore() *MockOrgStore {
 				return
 			},
 		},
-		UpdateOrgsOpenBetaStatsFunc: &OrgStoreUpdateOrgsOpenBetaStatsFunc{
-			defaultHook: func(context.Context, string, int32) (r0 error) {
-				return
-			},
-		},
 		WithFunc: &OrgStoreWithFunc{
 			defaultHook: func(basestore.ShareableStore) (r0 database.OrgStore) {
 				return
@@ -44372,11 +44356,6 @@ func NewMockOrgStore() *MockOrgStore {
 // methods panic on invocation, unless overwritten.
 func NewStrictMockOrgStore() *MockOrgStore {
 	return &MockOrgStore{
-		AddOrgsOpenBetaStatsFunc: &OrgStoreAddOrgsOpenBetaStatsFunc{
-			defaultHook: func(context.Context, int32, string) (string, error) {
-				panic("unexpected invocation of MockOrgStore.AddOrgsOpenBetaStats")
-			},
-		},
 		CountFunc: &OrgStoreCountFunc{
 			defaultHook: func(context.Context, database.OrgsListOptions) (int, error) {
 				panic("unexpected invocation of MockOrgStore.Count")
@@ -44437,11 +44416,6 @@ func NewStrictMockOrgStore() *MockOrgStore {
 				panic("unexpected invocation of MockOrgStore.Update")
 			},
 		},
-		UpdateOrgsOpenBetaStatsFunc: &OrgStoreUpdateOrgsOpenBetaStatsFunc{
-			defaultHook: func(context.Context, string, int32) error {
-				panic("unexpected invocation of MockOrgStore.UpdateOrgsOpenBetaStats")
-			},
-		},
 		WithFunc: &OrgStoreWithFunc{
 			defaultHook: func(basestore.ShareableStore) database.OrgStore {
 				panic("unexpected invocation of MockOrgStore.With")
@@ -44454,9 +44428,6 @@ func NewStrictMockOrgStore() *MockOrgStore {
 // methods delegate to the given implementation, unless overwritten.
 func NewMockOrgStoreFrom(i database.OrgStore) *MockOrgStore {
 	return &MockOrgStore{
-		AddOrgsOpenBetaStatsFunc: &OrgStoreAddOrgsOpenBetaStatsFunc{
-			defaultHook: i.AddOrgsOpenBetaStats,
-		},
 		CountFunc: &OrgStoreCountFunc{
 			defaultHook: i.Count,
 		},
@@ -44493,125 +44464,10 @@ func NewMockOrgStoreFrom(i database.OrgStore) *MockOrgStore {
 		UpdateFunc: &OrgStoreUpdateFunc{
 			defaultHook: i.Update,
 		},
-		UpdateOrgsOpenBetaStatsFunc: &OrgStoreUpdateOrgsOpenBetaStatsFunc{
-			defaultHook: i.UpdateOrgsOpenBetaStats,
-		},
 		WithFunc: &OrgStoreWithFunc{
 			defaultHook: i.With,
 		},
 	}
-}
-
-// OrgStoreAddOrgsOpenBetaStatsFunc describes the behavior when the
-// AddOrgsOpenBetaStats method of the parent MockOrgStore instance is
-// invoked.
-type OrgStoreAddOrgsOpenBetaStatsFunc struct {
-	defaultHook func(context.Context, int32, string) (string, error)
-	hooks       []func(context.Context, int32, string) (string, error)
-	history     []OrgStoreAddOrgsOpenBetaStatsFuncCall
-	mutex       sync.Mutex
-}
-
-// AddOrgsOpenBetaStats delegates to the next hook function in the queue and
-// stores the parameter and result values of this invocation.
-func (m *MockOrgStore) AddOrgsOpenBetaStats(v0 context.Context, v1 int32, v2 string) (string, error) {
-	r0, r1 := m.AddOrgsOpenBetaStatsFunc.nextHook()(v0, v1, v2)
-	m.AddOrgsOpenBetaStatsFunc.appendCall(OrgStoreAddOrgsOpenBetaStatsFuncCall{v0, v1, v2, r0, r1})
-	return r0, r1
-}
-
-// SetDefaultHook sets function that is called when the AddOrgsOpenBetaStats
-// method of the parent MockOrgStore instance is invoked and the hook queue
-// is empty.
-func (f *OrgStoreAddOrgsOpenBetaStatsFunc) SetDefaultHook(hook func(context.Context, int32, string) (string, error)) {
-	f.defaultHook = hook
-}
-
-// PushHook adds a function to the end of hook queue. Each invocation of the
-// AddOrgsOpenBetaStats method of the parent MockOrgStore instance invokes
-// the hook at the front of the queue and discards it. After the queue is
-// empty, the default hook function is invoked for any future action.
-func (f *OrgStoreAddOrgsOpenBetaStatsFunc) PushHook(hook func(context.Context, int32, string) (string, error)) {
-	f.mutex.Lock()
-	f.hooks = append(f.hooks, hook)
-	f.mutex.Unlock()
-}
-
-// SetDefaultReturn calls SetDefaultHook with a function that returns the
-// given values.
-func (f *OrgStoreAddOrgsOpenBetaStatsFunc) SetDefaultReturn(r0 string, r1 error) {
-	f.SetDefaultHook(func(context.Context, int32, string) (string, error) {
-		return r0, r1
-	})
-}
-
-// PushReturn calls PushHook with a function that returns the given values.
-func (f *OrgStoreAddOrgsOpenBetaStatsFunc) PushReturn(r0 string, r1 error) {
-	f.PushHook(func(context.Context, int32, string) (string, error) {
-		return r0, r1
-	})
-}
-
-func (f *OrgStoreAddOrgsOpenBetaStatsFunc) nextHook() func(context.Context, int32, string) (string, error) {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-
-	if len(f.hooks) == 0 {
-		return f.defaultHook
-	}
-
-	hook := f.hooks[0]
-	f.hooks = f.hooks[1:]
-	return hook
-}
-
-func (f *OrgStoreAddOrgsOpenBetaStatsFunc) appendCall(r0 OrgStoreAddOrgsOpenBetaStatsFuncCall) {
-	f.mutex.Lock()
-	f.history = append(f.history, r0)
-	f.mutex.Unlock()
-}
-
-// History returns a sequence of OrgStoreAddOrgsOpenBetaStatsFuncCall
-// objects describing the invocations of this function.
-func (f *OrgStoreAddOrgsOpenBetaStatsFunc) History() []OrgStoreAddOrgsOpenBetaStatsFuncCall {
-	f.mutex.Lock()
-	history := make([]OrgStoreAddOrgsOpenBetaStatsFuncCall, len(f.history))
-	copy(history, f.history)
-	f.mutex.Unlock()
-
-	return history
-}
-
-// OrgStoreAddOrgsOpenBetaStatsFuncCall is an object that describes an
-// invocation of method AddOrgsOpenBetaStats on an instance of MockOrgStore.
-type OrgStoreAddOrgsOpenBetaStatsFuncCall struct {
-	// Arg0 is the value of the 1st argument passed to this method
-	// invocation.
-	Arg0 context.Context
-	// Arg1 is the value of the 2nd argument passed to this method
-	// invocation.
-	Arg1 int32
-	// Arg2 is the value of the 3rd argument passed to this method
-	// invocation.
-	Arg2 string
-	// Result0 is the value of the 1st result returned from this method
-	// invocation.
-	Result0 string
-	// Result1 is the value of the 2nd result returned from this method
-	// invocation.
-	Result1 error
-}
-
-// Args returns an interface slice containing the arguments of this
-// invocation.
-func (c OrgStoreAddOrgsOpenBetaStatsFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
-}
-
-// Results returns an interface slice containing the results of this
-// invocation.
-func (c OrgStoreAddOrgsOpenBetaStatsFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
 }
 
 // OrgStoreCountFunc describes the behavior when the Count method of the
@@ -45879,117 +45735,6 @@ func (c OrgStoreUpdateFuncCall) Args() []interface{} {
 // invocation.
 func (c OrgStoreUpdateFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
-}
-
-// OrgStoreUpdateOrgsOpenBetaStatsFunc describes the behavior when the
-// UpdateOrgsOpenBetaStats method of the parent MockOrgStore instance is
-// invoked.
-type OrgStoreUpdateOrgsOpenBetaStatsFunc struct {
-	defaultHook func(context.Context, string, int32) error
-	hooks       []func(context.Context, string, int32) error
-	history     []OrgStoreUpdateOrgsOpenBetaStatsFuncCall
-	mutex       sync.Mutex
-}
-
-// UpdateOrgsOpenBetaStats delegates to the next hook function in the queue
-// and stores the parameter and result values of this invocation.
-func (m *MockOrgStore) UpdateOrgsOpenBetaStats(v0 context.Context, v1 string, v2 int32) error {
-	r0 := m.UpdateOrgsOpenBetaStatsFunc.nextHook()(v0, v1, v2)
-	m.UpdateOrgsOpenBetaStatsFunc.appendCall(OrgStoreUpdateOrgsOpenBetaStatsFuncCall{v0, v1, v2, r0})
-	return r0
-}
-
-// SetDefaultHook sets function that is called when the
-// UpdateOrgsOpenBetaStats method of the parent MockOrgStore instance is
-// invoked and the hook queue is empty.
-func (f *OrgStoreUpdateOrgsOpenBetaStatsFunc) SetDefaultHook(hook func(context.Context, string, int32) error) {
-	f.defaultHook = hook
-}
-
-// PushHook adds a function to the end of hook queue. Each invocation of the
-// UpdateOrgsOpenBetaStats method of the parent MockOrgStore instance
-// invokes the hook at the front of the queue and discards it. After the
-// queue is empty, the default hook function is invoked for any future
-// action.
-func (f *OrgStoreUpdateOrgsOpenBetaStatsFunc) PushHook(hook func(context.Context, string, int32) error) {
-	f.mutex.Lock()
-	f.hooks = append(f.hooks, hook)
-	f.mutex.Unlock()
-}
-
-// SetDefaultReturn calls SetDefaultHook with a function that returns the
-// given values.
-func (f *OrgStoreUpdateOrgsOpenBetaStatsFunc) SetDefaultReturn(r0 error) {
-	f.SetDefaultHook(func(context.Context, string, int32) error {
-		return r0
-	})
-}
-
-// PushReturn calls PushHook with a function that returns the given values.
-func (f *OrgStoreUpdateOrgsOpenBetaStatsFunc) PushReturn(r0 error) {
-	f.PushHook(func(context.Context, string, int32) error {
-		return r0
-	})
-}
-
-func (f *OrgStoreUpdateOrgsOpenBetaStatsFunc) nextHook() func(context.Context, string, int32) error {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-
-	if len(f.hooks) == 0 {
-		return f.defaultHook
-	}
-
-	hook := f.hooks[0]
-	f.hooks = f.hooks[1:]
-	return hook
-}
-
-func (f *OrgStoreUpdateOrgsOpenBetaStatsFunc) appendCall(r0 OrgStoreUpdateOrgsOpenBetaStatsFuncCall) {
-	f.mutex.Lock()
-	f.history = append(f.history, r0)
-	f.mutex.Unlock()
-}
-
-// History returns a sequence of OrgStoreUpdateOrgsOpenBetaStatsFuncCall
-// objects describing the invocations of this function.
-func (f *OrgStoreUpdateOrgsOpenBetaStatsFunc) History() []OrgStoreUpdateOrgsOpenBetaStatsFuncCall {
-	f.mutex.Lock()
-	history := make([]OrgStoreUpdateOrgsOpenBetaStatsFuncCall, len(f.history))
-	copy(history, f.history)
-	f.mutex.Unlock()
-
-	return history
-}
-
-// OrgStoreUpdateOrgsOpenBetaStatsFuncCall is an object that describes an
-// invocation of method UpdateOrgsOpenBetaStats on an instance of
-// MockOrgStore.
-type OrgStoreUpdateOrgsOpenBetaStatsFuncCall struct {
-	// Arg0 is the value of the 1st argument passed to this method
-	// invocation.
-	Arg0 context.Context
-	// Arg1 is the value of the 2nd argument passed to this method
-	// invocation.
-	Arg1 string
-	// Arg2 is the value of the 3rd argument passed to this method
-	// invocation.
-	Arg2 int32
-	// Result0 is the value of the 1st result returned from this method
-	// invocation.
-	Result0 error
-}
-
-// Args returns an interface slice containing the arguments of this
-// invocation.
-func (c OrgStoreUpdateOrgsOpenBetaStatsFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
-}
-
-// Results returns an interface slice containing the results of this
-// invocation.
-func (c OrgStoreUpdateOrgsOpenBetaStatsFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0}
 }
 
 // OrgStoreWithFunc describes the behavior when the With method of the

--- a/internal/database/orgs.go
+++ b/internal/database/orgs.go
@@ -29,7 +29,6 @@ func (e *OrgNotFoundError) NotFound() bool {
 var errOrgNameAlreadyExists = errors.New("organization name is already taken (by a user, team, or another organization)")
 
 type OrgStore interface {
-	AddOrgsOpenBetaStats(ctx context.Context, userID int32, data string) (string, error)
 	Count(context.Context, OrgsListOptions) (int, error)
 	Create(ctx context.Context, name string, displayName *string) (*types.Org, error)
 	Delete(ctx context.Context, id int32) (err error)
@@ -41,7 +40,6 @@ type OrgStore interface {
 	List(context.Context, *OrgsListOptions) ([]*types.Org, error)
 	Transact(context.Context) (OrgStore, error)
 	Update(ctx context.Context, id int32, displayName *string) (*types.Org, error)
-	UpdateOrgsOpenBetaStats(ctx context.Context, id string, orgID int32) error
 	With(basestore.ShareableStore) OrgStore
 	basestore.ShareableStore
 }
@@ -330,18 +328,4 @@ func (o *orgStore) HardDelete(ctx context.Context, id int32) (err error) {
 	}
 
 	return nil
-}
-
-func (o *orgStore) AddOrgsOpenBetaStats(ctx context.Context, userID int32, data string) (id string, err error) {
-	query := sqlf.Sprintf("INSERT INTO orgs_open_beta_stats(user_id, data) VALUES(%d, %s) RETURNING id;", userID, data)
-
-	err = o.Handle().QueryRowContext(ctx, query.Query(sqlf.PostgresBindVar), query.Args()...).Scan(&id)
-	return id, err
-}
-
-func (o *orgStore) UpdateOrgsOpenBetaStats(ctx context.Context, id string, orgID int32) error {
-	query := sqlf.Sprintf("UPDATE orgs_open_beta_stats SET org_id=%d WHERE id=%s;", orgID, id)
-
-	_, err := o.Handle().ExecContext(ctx, query.Query(sqlf.PostgresBindVar), query.Args()...)
-	return err
 }

--- a/internal/repos/gitlab.go
+++ b/internal/repos/gitlab.go
@@ -13,7 +13,6 @@ import (
 	"github.com/sourcegraph/log"
 
 	"github.com/sourcegraph/sourcegraph/internal/conf/reposource"
-	"github.com/sourcegraph/sourcegraph/internal/dotcom"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/auth"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/gitlab"
@@ -131,16 +130,14 @@ func newGitLabSource(logger log.Logger, svc *types.ExternalService, c *schema.Gi
 		client = provider.GetPATClient(c.Token, "")
 	}
 
-	if !dotcom.SourcegraphDotComMode() || svc.CloudDefault {
-		client.ExternalRateLimiter().SetCollector(&ratelimit.MetricsCollector{
-			Remaining: func(n float64) {
-				gitlabRemainingGauge.WithLabelValues("rest", svc.DisplayName).Set(n)
-			},
-			WaitDuration: func(n time.Duration) {
-				gitlabRatelimitWaitCounter.WithLabelValues("rest", svc.DisplayName).Add(n.Seconds())
-			},
-		})
-	}
+	client.ExternalRateLimiter().SetCollector(&ratelimit.MetricsCollector{
+		Remaining: func(n float64) {
+			gitlabRemainingGauge.WithLabelValues("rest", svc.DisplayName).Set(n)
+		},
+		WaitDuration: func(n time.Duration) {
+			gitlabRatelimitWaitCounter.WithLabelValues("rest", svc.DisplayName).Add(n.Seconds())
+		},
+	})
 
 	return &GitLabSource{
 		svc:                       svc,


### PR DESCRIPTION
These checks for dotcom mode are no longer necessary, so let's remove the number of code paths.

Test plan:

Test suites are still passing, also code review.


