### PR TITLE
telemetry-gateway: distinguish between retryable/nonretryable errors, telemetry: add callsite validation of feature/action

### DIFF
--- a/cmd/frontend/internal/telemetry/resolvers/telemetrygateway.go
+++ b/cmd/frontend/internal/telemetry/resolvers/telemetrygateway.go
@@ -23,6 +23,13 @@ func newTelemetryGatewayEvents(
 ) ([]*telemetrygatewayv1.Event, error) {
 	gatewayEvents := make([]*telemetrygatewayv1.Event, len(gqlEvents))
 	for i, gqlEvent := range gqlEvents {
+		if gqlEvent.Feature == "" {
+			return nil, errors.Newf("feature is required for event %d", i)
+		}
+		if gqlEvent.Action == "" {
+			return nil, errors.Newf("action is required for event %d", i)
+		}
+
 		event := telemetrygatewayv1.NewEventWithDefaults(ctx, now, newUUID)
 
 		if gqlEvent.Timestamp != nil {

--- a/cmd/telemetry-gateway/internal/events/events_test.go
+++ b/cmd/telemetry-gateway/internal/events/events_test.go
@@ -48,8 +48,9 @@ func TestPublish(t *testing.T) {
 		})
 	require.NoError(t, err)
 
-	// Check the evaluated source
+	// Check evaluated attributes
 	assert.Equal(t, "licensed_instance", publisher.GetSourceName())
+	assert.True(t, publisher.IsSourcegraphInstance())
 
 	events := make([]*telemetrygatewayv1.Event, concurrency)
 	for i := range events {

--- a/internal/telemetry/BUILD.bazel
+++ b/internal/telemetry/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "//internal/telemetrygateway/v1:telemetrygateway",
         "//internal/trace",
         "//internal/version",
+        "//lib/errors",
         "@com_github_sourcegraph_log//:log",
         "@org_golang_google_protobuf//types/known/structpb",
     ],

--- a/internal/telemetry/besteffort.go
+++ b/internal/telemetry/besteffort.go
@@ -19,7 +19,10 @@ type BestEffortEventRecorder struct {
 // implementation. In general, prefer to use the telemetryrecorder.NewBestEffort()
 // constructor instead.
 func NewBestEffortEventRecorder(logger log.Logger, recorder *EventRecorder) *BestEffortEventRecorder {
-	return &BestEffortEventRecorder{logger: logger, recorder: recorder}
+	return &BestEffortEventRecorder{
+		logger:   logger.AddCallerSkip(1), // report from Recorder callsite
+		recorder: recorder,
+	}
 }
 
 // Record records a single telemetry event with the context's Sourcegraph

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -5,6 +5,7 @@ package telemetry
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	telemetrygatewayv1 "github.com/sourcegraph/sourcegraph/internal/telemetrygateway/v1"
@@ -91,8 +92,17 @@ func NewEventRecorder(store EventsStore) *EventRecorder {
 }
 
 // Record records a single telemetry event with the context's Sourcegraph
-// actor. Parameters are optional.
+// actor. Parameters are optional - everything else is required.
 func (r *EventRecorder) Record(ctx context.Context, feature eventFeature, action eventAction, parameters *EventParameters) error {
+	if ctx == nil {
+		return errors.New("context is required")
+	}
+	if feature == "" {
+		return errors.New("feature is required")
+	}
+	if action == "" {
+		return errors.New("action is required")
+	}
 	return r.store.StoreEvents(ctx, []*telemetrygatewayv1.Event{
 		newTelemetryGatewayEvent(ctx, time.Now(), telemetrygatewayv1.DefaultEventIDFunc, feature, action, parameters),
 	})

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -5,10 +5,10 @@ package telemetry
 
 import (
 	"context"
-	"errors"
 	"time"
 
 	telemetrygatewayv1 "github.com/sourcegraph/sourcegraph/internal/telemetrygateway/v1"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 // constString effectively requires strings to be statically defined constants.


### PR DESCRIPTION
1. Distinguish between retryable/nonretryable errors in Telemetry Gateway, and only report retryable errors to Sourcegraph instances after logging them. This prevents instances from endlessly retrying events that will never be accepted
2. Add callsite validation of feature/action in graphqlbackend and the backend telemetry recorder - we are seeing lots of events without these required fields

Thread: https://sourcegraph.slack.com/archives/C06CCJR4K9R/p1713249734994549?thread_ts=1713054354.443579&cid=C06CCJR4K9R

## Test plan

CI