### PR TITLE
Pass conf down to authz providers

### DIFF
--- a/cmd/embeddings/shared/main.go
+++ b/cmd/embeddings/shared/main.go
@@ -177,7 +177,7 @@ func mustInitializeFrontendDB(observationCtx *observation.Context) *sql.DB {
 // the jobs configured in this service. This also enables repository update operations to fetch
 // permissions from code hosts.
 func setAuthzProviders(ctx context.Context, db database.DB) {
-	for range time.NewTicker(providers.RefreshInterval()).C {
+	for range time.NewTicker(providers.RefreshInterval(conf.Get())).C {
 		allowAccessByDefault, authzProviders, _, _, _ := providers.ProvidersFromConfig(ctx, conf.Get(), db)
 		authz.SetProviders(allowAccessByDefault, authzProviders)
 	}

--- a/cmd/precise-code-intel-worker/shared/shared.go
+++ b/cmd/precise-code-intel-worker/shared/shared.go
@@ -114,7 +114,7 @@ func mustInitializeDB(observationCtx *observation.Context) *sql.DB {
 	ctx := context.Background()
 	db := database.NewDB(observationCtx.Logger, sqlDB)
 	go func() {
-		for range time.NewTicker(providers.RefreshInterval()).C {
+		for range time.NewTicker(providers.RefreshInterval(conf.Get())).C {
 			allowAccessByDefault, authzProviders, _, _, _ := providers.ProvidersFromConfig(ctx, conf.Get(), db)
 			authz.SetProviders(allowAccessByDefault, authzProviders)
 		}

--- a/cmd/repo-updater/shared/main.go
+++ b/cmd/repo-updater/shared/main.go
@@ -383,7 +383,7 @@ func newUnclonedReposManager(ctx context.Context, logger log.Logger, isSourcegra
 // watchAuthzProviders updates authz providers if config changes.
 func watchAuthzProviders(ctx context.Context, db database.DB) {
 	go func() {
-		t := time.NewTicker(providers.RefreshInterval())
+		t := time.NewTicker(providers.RefreshInterval(conf.Get()))
 		for range t.C {
 			allowAccessByDefault, authzProviders, _, _, _ := providers.ProvidersFromConfig(
 				ctx,

--- a/cmd/worker/internal/permissions/perms_syncer_scheduler.go
+++ b/cmd/worker/internal/permissions/perms_syncer_scheduler.go
@@ -79,7 +79,7 @@ func (p *permissionSyncJobScheduler) Routines(_ context.Context, observationCtx 
 			context.Background(),
 			goroutine.HandlerFunc(
 				func(ctx context.Context) error {
-					if providers.PermissionSyncingDisabled() {
+					if providers.PermissionSyncingDisabled(conf.Get()) {
 						logger.Debug("scheduler disabled due to permission syncing disabled")
 						return nil
 					}

--- a/cmd/worker/shared/main.go
+++ b/cmd/worker/shared/main.go
@@ -389,7 +389,7 @@ func setAuthzProviders(ctx context.Context, observationCtx *observation.Context)
 		return
 	}
 
-	for range time.NewTicker(providers.RefreshInterval()).C {
+	for range time.NewTicker(providers.RefreshInterval(conf.Get())).C {
 		allowAccessByDefault, authzProviders, _, _, _ := providers.ProvidersFromConfig(ctx, conf.Get(), db)
 		authz.SetProviders(allowAccessByDefault, authzProviders)
 	}

--- a/internal/authz/providers/BUILD.bazel
+++ b/internal/authz/providers/BUILD.bazel
@@ -15,7 +15,6 @@ go_library(
         "//internal/authz/providers/github",
         "//internal/authz/providers/gitlab",
         "//internal/authz/providers/perforce",
-        "//internal/conf",
         "//internal/conf/conftypes",
         "//internal/database",
         "//internal/extsvc",

--- a/internal/authz/providers/authz.go
+++ b/internal/authz/providers/authz.go
@@ -15,7 +15,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/authz/providers/github"
 	"github.com/sourcegraph/sourcegraph/internal/authz/providers/gitlab"
 	"github.com/sourcegraph/sourcegraph/internal/authz/providers/perforce"
-	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
@@ -172,8 +171,8 @@ func ProvidersFromConfig(
 	return allowAccessByDefault, initResult.Providers, initResult.Problems, initResult.Warnings, initResult.InvalidConnections
 }
 
-func RefreshInterval() time.Duration {
-	interval := conf.Get().AuthzRefreshInterval
+func RefreshInterval(cfg conftypes.UnifiedQuerier) time.Duration {
+	interval := cfg.SiteConfig().AuthzRefreshInterval
 	if interval <= 0 {
 		return 5 * time.Second
 	}
@@ -185,11 +184,11 @@ func RefreshInterval() time.Duration {
 //   - There are no code host connections with authorization or enforcePermissions enabled
 //   - Not purchased with the current license
 //   - `disableAutoCodeHostSyncs` site setting is set to true
-func PermissionSyncingDisabled() bool {
+func PermissionSyncingDisabled(cfg conftypes.UnifiedQuerier) bool {
 	_, p := authz.GetProviders()
 	return len(p) == 0 ||
 		licensing.Check(licensing.FeatureACLs) != nil ||
-		conf.Get().DisableAutoCodeHostSyncs
+		cfg.SiteConfig().DisableAutoCodeHostSyncs
 }
 
 var ValidateExternalServiceConfig = database.MakeValidateExternalServiceConfigFunc(

--- a/internal/authz/providers/authz_test.go
+++ b/internal/authz/providers/authz_test.go
@@ -813,7 +813,7 @@ func TestPermissionSyncingDisabled(t *testing.T) {
 			authz.SetProviders(true, []authz.Provider{&mockProvider{}})
 		})
 
-		assert.True(t, PermissionSyncingDisabled())
+		assert.True(t, PermissionSyncingDisabled(&conf.Unified{}))
 	})
 
 	t.Run("permissions user mapping enabled", func(t *testing.T) {
@@ -823,7 +823,7 @@ func TestPermissionSyncingDisabled(t *testing.T) {
 			conf.Mock(nil)
 		})
 
-		assert.False(t, PermissionSyncingDisabled())
+		assert.False(t, PermissionSyncingDisabled(&conf.Unified{}))
 	})
 
 	t.Run("license does not have acls feature", func(t *testing.T) {
@@ -831,23 +831,15 @@ func TestPermissionSyncingDisabled(t *testing.T) {
 		t.Cleanup(func() {
 			licensing.MockCheckFeatureError("")
 		})
-		assert.True(t, PermissionSyncingDisabled())
+		assert.True(t, PermissionSyncingDisabled(&conf.Unified{}))
 	})
 
 	t.Run("Auto code host syncs disabled", func(t *testing.T) {
-		conf.Mock(&conf.Unified{SiteConfiguration: schema.SiteConfiguration{DisableAutoCodeHostSyncs: true}})
-		t.Cleanup(func() {
-			conf.Mock(nil)
-		})
-		assert.True(t, PermissionSyncingDisabled())
+		assert.True(t, PermissionSyncingDisabled(&conf.Unified{SiteConfiguration: schema.SiteConfiguration{DisableAutoCodeHostSyncs: true}}))
 	})
 
 	t.Run("Auto code host syncs enabled", func(t *testing.T) {
-		conf.Mock(&conf.Unified{SiteConfiguration: schema.SiteConfiguration{DisableAutoCodeHostSyncs: false}})
-		t.Cleanup(func() {
-			conf.Mock(nil)
-		})
-		assert.False(t, PermissionSyncingDisabled())
+		assert.False(t, PermissionSyncingDisabled(&conf.Unified{SiteConfiguration: schema.SiteConfiguration{DisableAutoCodeHostSyncs: false}}))
 	})
 }
 


### PR DESCRIPTION
This makes the dependency on conf clearer so that you understand that you must have a working connection to confserver when you're calling this function in the package.

Test plan:

Existing test suites