### PR TITLE
Add caddy to DeploySourcegraphDockerImages

### DIFF
--- a/dev/ci/images/images.go
+++ b/dev/ci/images/images.go
@@ -106,6 +106,7 @@ var DeploySourcegraphDockerImages = []string{
 	"alpine-3.14",
 	"postgres-12-alpine",
 	"blobstore",
+	"caddy",
 	"cadvisor",
 	"codeinsights-db",
 	"codeintel-db",


### PR DESCRIPTION
This is required for `sg ops update-images` to update the image tag in the deploy-sourcegraph-docker repo.

## Test plan

- CI
- Confirmed that `sg ops update-images [...]` now includes caddy image

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
