### PR TITLE
[backport] Redirect to sign-in provider when there is only one (#61919)

### DIFF
--- a/client/web/src/auth/SignInPage.tsx
+++ b/client/web/src/auth/SignInPage.tsx
@@ -91,9 +91,15 @@ export const SignInPage: React.FunctionComponent<React.PropsWithChildren<SignInP
     }
 
     const thirdPartyAuthProviders = nonBuiltinAuthProviders.filter(provider => shouldShowProvider(provider))
-    // If there is only one auth provider that is going to be displayed on dotcom, we want to redirect to it directly.
-    if (context.sourcegraphDotComMode && thirdPartyAuthProviders.length === 1) {
-        window.location.replace(thirdPartyAuthProviders[0].authenticationURL)
+    // If there is only one auth provider that is going to be displayed, we want to redirect to it directly.
+    if (thirdPartyAuthProviders.length === 1 && !builtInAuthProvider) {
+        // Add '?returnTo=' + encodeURIComponent(returnTo) to thirdPartyAuthProviders[0].authenticationURL in a safe way.
+        const redirectUrl = new URL(thirdPartyAuthProviders[0].authenticationURL, window.location.href)
+        if (returnTo) {
+            redirectUrl.searchParams.set('returnTo', new URL(returnTo, window.location.href).toString())
+        }
+        window.location.replace(redirectUrl)
+
         return (
             <>
                 <PageTitle title="Signing in..." />


### PR DESCRIPTION
(cherry picked from commit 5653a5f75e0a3012df1cddf4f22d4240b7171693)



## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
