### PR TITLE
Remove p4 test from repo-updater image

### DIFF
--- a/cmd/repo-updater/image_test.yaml
+++ b/cmd/repo-updater/image_test.yaml
@@ -8,11 +8,6 @@ commandTests:
         value: "true"
   - name: "coursier is runnable"
     command: "coursier"
-  # TODO: This test can be removed after the 5.3 release
-  # - name: "p4 is runnable"
-  #   command: "p4"
-  #   args:
-  #     - -h
 
   - name: "not running as root"
     command: "/usr/bin/id"


### PR DESCRIPTION
I just spotted that we never completed the follow-up of removing the `p4` test from repo-updater after we removed the `p4` binary in 5.3.

Context is [here](https://github.com/sourcegraph/sourcegraph/pull/60324) - we no longer required the p4 binary in this image, but due to some complexities around release branches we couldn't remove it until after the release. This is now long completed, so we should clean up the associated test that's been commented out.

## Test plan

- CI

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
