### PR TITLE
telemetry: unexport internal type, add SafeMetadataKey

### DIFF
--- a/cmd/frontend/internal/bg/store_token_usage_in_postgres.go
+++ b/cmd/frontend/internal/bg/store_token_usage_in_postgres.go
@@ -32,8 +32,7 @@ func storeTokenUsageinDb(ctx context.Context, db database.DB) error {
 	}
 	convertedTokenUsageData := make(telemetry.EventMetadata)
 	for key, value := range tokenUsageData {
-		castedKey := telemetry.ConstString(key) // Cast the key to telemetry.ConstString
-		convertedTokenUsageData[castedKey] = value
+		convertedTokenUsageData[telemetry.SafeMetadataKey(key)] = value
 	}
 
 	// This extra variable helps demarcate that this was NOT the final fetch and sync before the redis was reset

--- a/internal/search/job/jobutil/log_job.go
+++ b/internal/search/job/jobutil/log_job.go
@@ -148,7 +148,7 @@ func (l *LogJob) logEvent(ctx context.Context, clients job.RuntimeClients, durat
 		a := actor.FromContext(ctx)
 		if a.IsAuthenticated() && !a.IsMockUser() { // Do not log in tests
 			// New event
-			events.Record(ctx, "search.latencies", telemetry.Action(types[0]), &telemetry.EventParameters{
+			events.Record(ctx, "search.latencies", telemetry.SafeAction(types[0]), &telemetry.EventParameters{
 				Metadata: telemetry.EventMetadata{
 					"durationMs": float64(duration.Milliseconds()),
 				},

--- a/internal/telemetry/CODEOWNERS
+++ b/internal/telemetry/CODEOWNERS
@@ -1,0 +1,2 @@
+**/* @sourcegraph/core-services
+**/* @sourcegraph/data-team

--- a/internal/telemetry/events.go
+++ b/internal/telemetry/events.go
@@ -8,6 +8,9 @@ import "strings"
 // This is a private type, requiring the values to be declared in-package or
 // be const strings. This roughly prevents arbitrary string values (potentially
 // unsafe) from being cast to this type.
+//
+// 🚨 DO NOT EXPORT - this is intentionally unexported to avoid casting that
+// may expose unsafe strings.
 type eventFeature string
 
 const (
@@ -28,6 +31,9 @@ const (
 // be const strings. This roughly prevents arbitrary string values (potentially
 // unsafe) from being cast to this type. The telemetry.Action() constructor is
 // available as a fallback - see the relevant docstring for more details.
+//
+// 🚨 DO NOT EXPORT - this is intentionally unexported to avoid casting that
+// may expose unsafe strings.
 type eventAction string
 
 const (

--- a/internal/telemetry/events.go
+++ b/internal/telemetry/events.go
@@ -47,12 +47,12 @@ const (
 	ActionAttempted eventAction = "attempted"
 )
 
-// Action is an escape hatch for constructing eventAction from variable strings
+// SafeAction is an escape hatch for constructing eventAction from variable strings
 // for known string enums. Where possible, prefer to use a constant string or a
 // predefined action constant in the internal/telemetry package instead.
 //
 // 🚨 SECURITY: Use with care, as variable strings can accidentally contain data
 // sensitive to standalone Sourcegraph instances.
-func Action(parts ...string) eventAction {
+func SafeAction(parts ...string) eventAction {
 	return eventAction(strings.Join(parts, "."))
 }

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -11,12 +11,23 @@ import (
 )
 
 // constString effectively requires strings to be statically defined constants.
-type ConstString string
+//
+// 🚨 DO NOT EXPORT - this is intentionally unexported to avoid casting that
+// may expose unsafe strings.
+type constString string
+
+// SafeMetadataKey is an escape hatch for constructing keys for EventMetadata from
+// variable strings for known string enums. Where possible, prefer to use a
+// constant string.
+//
+// 🚨 SECURITY: Use with care, as variable strings can accidentally contain data
+// sensitive to standalone Sourcegraph instances.
+func SafeMetadataKey(key string) constString { return constString(key) }
 
 // EventMetadata is secure, PII-free metadata that can be attached to events.
 // Keys must be const strings, to avoid the accidental addition of sensitive
 // metadata.
-type EventMetadata map[ConstString]float64
+type EventMetadata map[constString]float64
 
 // Bool returns 1 for true and 0 for false, for use in EventMetadata's
 // restricted int64 values.

--- a/internal/telemetrygateway/CODEOWNERS
+++ b/internal/telemetrygateway/CODEOWNERS
@@ -1,0 +1,2 @@
+**/* @sourcegraph/core-services
+**/* @sourcegraph/data-team

--- a/internal/updatecheck/client.go
+++ b/internal/updatecheck/client.go
@@ -415,8 +415,7 @@ func storeTokenUsageinDbBeforeRedisSync(ctx context.Context, db database.DB) err
 	}
 	convertedTokenUsageData := make(telemetry.EventMetadata)
 	for key, value := range tokenUsageData {
-		castedKey := telemetry.ConstString(key) // Cast the key to telemetry.ConstString
-		convertedTokenUsageData[castedKey] = value
+		convertedTokenUsageData[telemetry.SafeMetadataKey(key)] = value
 	}
 
 	// This extra variable helps demarcate that this was the final fetch and sync before the redis was reset


### PR DESCRIPTION
I noticed the `telemetry.constString` type was wrongly exported in a previous PR (https://github.com/sourcegraph/sourcegraph/pull/61134). This type is intentionally unexported to prevent the exact use case the PR used the exported type for - this scenario (list keys and include it in metadata) is exactly the scenario where something bad might unexpectedly show up in our telemetry (an unexpected Redis key is matched, an unexpected value is provided to be stored, etc - the cause of multiple data leakage incidents in the past)

However, given the format I was unable to quickly come up with a better alternative. Moving it to private metadata is also not possible, as because judging from the description of #61134 we need this to be exported from on-prem as a business need.

For now:

1. Add loud warnings on the various intentionally-internal types to not export them
2. Add a constructor `telemetry.SafeMetadataKey(...)` to support the current use case, with warnings - callers more or less "sign off" on owning problems here if there are any. In the future if we have any regex strategy we want to apply we can add them to these constructors as well.
3. Add CODEOWNERS to make sure changes to telemetry do not go without adequate review

## Test plan

CI