### PR TITLE
Gateway: Increase token limits for flagging

### DIFF
--- a/cmd/cody-gateway/internal/httpapi/completions/anthropic_test.go
+++ b/cmd/cody-gateway/internal/httpapi/completions/anthropic_test.go
@@ -21,16 +21,16 @@ func TestIsFlaggedAnthropicRequest(t *testing.T) {
 	validPreamble := "You are cody-gateway."
 
 	cfg := config.FlaggingConfig{
-		PromptTokenFlaggingLimit:       18000,
-		PromptTokenBlockingLimit:       20000,
+		PromptTokenFlaggingLimit:       48000,
+		PromptTokenBlockingLimit:       50000,
 		MaxTokensToSample:              0, // Not used within isFlaggedRequest.
 		MaxTokensToSampleFlaggingLimit: 4000,
 		ResponseTokenBlockingLimit:     4000,
 		RequestBlockingEnabled:         true,
 	}
 	cfgWithPreamble := config.FlaggingConfig{
-		PromptTokenFlaggingLimit:       18000,
-		PromptTokenBlockingLimit:       20000,
+		PromptTokenFlaggingLimit:       48000,
+		PromptTokenBlockingLimit:       50000,
 		MaxTokensToSample:              0, // Not used within isFlaggedRequest.
 		MaxTokensToSampleFlaggingLimit: 4000,
 		ResponseTokenBlockingLimit:     4000,

--- a/cmd/cody-gateway/internal/httpapi/completions/anthropicmessages_test.go
+++ b/cmd/cody-gateway/internal/httpapi/completions/anthropicmessages_test.go
@@ -20,16 +20,16 @@ func TestIsFlaggedAnthropicMessagesRequest(t *testing.T) {
 	validPreamble := "You are cody-gateway."
 
 	cfg := config.FlaggingConfig{
-		PromptTokenFlaggingLimit:       18000,
-		PromptTokenBlockingLimit:       20000,
+		PromptTokenFlaggingLimit:       48000,
+		PromptTokenBlockingLimit:       50000,
 		MaxTokensToSample:              0, // Not used within isFlaggedRequest.
 		MaxTokensToSampleFlaggingLimit: 4000,
 		ResponseTokenBlockingLimit:     4000,
 		RequestBlockingEnabled:         true,
 	}
 	cfgWithPreamble := config.FlaggingConfig{
-		PromptTokenFlaggingLimit:       18000,
-		PromptTokenBlockingLimit:       20000,
+		PromptTokenFlaggingLimit:       48000,
+		PromptTokenBlockingLimit:       50000,
 		MaxTokensToSample:              0, // Not used within isFlaggedRequest.
 		MaxTokensToSampleFlaggingLimit: 4000,
 		ResponseTokenBlockingLimit:     4000,

--- a/cmd/cody-gateway/internal/httpapi/completions/flagging_test.go
+++ b/cmd/cody-gateway/internal/httpapi/completions/flagging_test.go
@@ -42,15 +42,15 @@ func TestIsFlaggedRequest(t *testing.T) {
 	validPreamble := "You are cody-gateway."
 
 	basicCfg := flaggingConfig{
-		PromptTokenFlaggingLimit:       18000,
-		PromptTokenBlockingLimit:       20000,
+		PromptTokenFlaggingLimit:       48000,
+		PromptTokenBlockingLimit:       50000,
 		MaxTokensToSampleFlaggingLimit: 4000,
 		ResponseTokenBlockingLimit:     4000,
 		RequestBlockingEnabled:         true,
 	}
 	cfgWithPreamble := flaggingConfig{
-		PromptTokenFlaggingLimit:       18000,
-		PromptTokenBlockingLimit:       20000,
+		PromptTokenFlaggingLimit:       48000,
+		PromptTokenBlockingLimit:       50000,
 		MaxTokensToSampleFlaggingLimit: 4000,
 		ResponseTokenBlockingLimit:     4000,
 		RequestBlockingEnabled:         true,

--- a/cmd/cody-gateway/shared/config/config.go
+++ b/cmd/cody-gateway/shared/config/config.go
@@ -314,8 +314,8 @@ func (c *Config) loadFlaggingConfig(cfg *FlaggingConfig, envVarPrefix string) {
 	cfg.BlockedPromptPatterns = maybeLoadLowercaseSlice(envVarPrefix+"BLOCKED_PROMPT_PATTERNS", "Patterns to block in prompt.")
 	cfg.RequestBlockingEnabled = c.GetBool(envVarPrefix+"REQUEST_BLOCKING_ENABLED", "false", "Whether we should block requests that match our blocking criteria.")
 
-	cfg.PromptTokenBlockingLimit = c.GetInt(envVarPrefix+"PROMPT_TOKEN_BLOCKING_LIMIT", "20000", "Maximum number of prompt tokens to allow without blocking.")
-	cfg.PromptTokenFlaggingLimit = c.GetInt(envVarPrefix+"PROMPT_TOKEN_FLAGGING_LIMIT", "18000", "Maximum number of prompt tokens to allow without flagging.")
+	cfg.PromptTokenBlockingLimit = c.GetInt(envVarPrefix+"PROMPT_TOKEN_BLOCKING_LIMIT", "50000", "Maximum number of prompt tokens to allow without blocking.")
+	cfg.PromptTokenFlaggingLimit = c.GetInt(envVarPrefix+"PROMPT_TOKEN_FLAGGING_LIMIT", "48000", "Maximum number of prompt tokens to allow without flagging.")
 	cfg.ResponseTokenBlockingLimit = c.GetInt(envVarPrefix+"RESPONSE_TOKEN_BLOCKING_LIMIT", "4000", "Maximum number of completion tokens to allow without blocking.")
 }
 


### PR DESCRIPTION
CONTEXT: https://sourcegraph.slack.com/archives/C05AGQYD528/p1713301835301859?thread_ts=1713298825.150649&cid=C05AGQYD528

This PR increases the token limits for flagging requests in the completions API:

- The prompt token flagging limit has been increased from 18,000 to 48,000 tokens. 
- The prompt token blocking limit has been raised from 20,000 to 50,000 tokens. 

These changes are made in the flagging configuration structs and test cases:

- cmd/cody-gateway/internal/httpapi/completions/anthropic_test.go
- cmd/cody-gateway/internal/httpapi/completions/anthropicmessages_test.go 
- cmd/cody-gateway/internal/httpapi/completions/flagging_test.go

By increasing these limits, we allow longer prompt sequences before flagging and blocking requests. This should reduce false positives when we increase the context window on the client side.

The changes are backwards compatible and should not impact existing behavior below the new limits.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->

Test cases updated to use the new limits.