### PR TITLE
Fix legacy docs

### DIFF
--- a/doc/_resources/templates/root.html
+++ b/doc/_resources/templates/root.html
@@ -84,7 +84,7 @@
 
                     // Append the current path to the redirect link.
                     //
-                    // The resource estimator doesn't have yet an equivalent on the new docsite, so for that
+                    // The resource estimator doesn't yet have an equivalent on the new docsite, so for that
                     // one we don't append the path.
                     if ( ! window.location.pathname.startsWith("/admin/deploy/resource_estimator") ) {
                         document.getElementById("latest-docs-redirect").href += window.location.pathname

--- a/doc/_resources/templates/root.html
+++ b/doc/_resources/templates/root.html
@@ -53,9 +53,13 @@
 
         <!-- Default to light theme if no JavaScript -->
 		<body class="theme-light">
-             <nav class="notice" style="display: flex; flex-direction: row; width: 100%; position: fixed; z-index: 9999; background: #ec624d; padding: 0.5rem; text-align: center; margin: 0 auto .5rem; color: black;">
-                    <p style="text-align: center; display: flex; margin: 0 auto; align-items: center;">⚠️ You're viewing our old docs, which we no longer maintain. For all the new updates, read our <a style="background: black; padding: 0.2rem 0.6rem; border-radius: 5px; margin-left: 0.5rem; color: white;" href="https://sourcegraph.com/docs" id="latest-docs-redirect">Latest Docs »</a></p>
+             <nav id="notice-old-docs" class="notice" style="display: none; flex-direction: row; width: 100%; position: fixed; z-index: 9999; background: #ec624d; padding: 0.5rem; text-align: center; margin: 0 auto .5rem; color: black;">
+                    <p style="text-align: center; display: flex; margin: 0 auto; align-items: center;">⚠️You're viewing our legacy docs, which we no longer maintain. For all the new updates, read our <a style="background: black; padding: 0.2rem 0.6rem; border-radius: 5px; margin-left: 0.5rem; color: white;" href="https://sourcegraph.com/docs" id="latest-docs-redirect">Latest Docs »</a></p>
             </nav>
+             <nav id="notice-dev-docs" class="notice" style="display: none; flex-direction: row; width: 100%; position: fixed; z-index: 9999; background: #FFAC1C; padding: 0.5rem; text-align: center; margin: 0 auto .5rem; color: black;">
+                    <p style="text-align: center; display: flex; margin: 0 auto; align-items: center;">⚠️You're viewing our dev docs, which are in the process of being migrated. Last sync done on April 16th, for up to date content please read them from<a style="background: black; padding: 0.2rem 0.6rem; border-radius: 5px; margin-left: 0.5rem; color: white;" href="https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/doc/dev/index.md">here</a> &nbsp; for the time being.</p>
+            </nav>
+
             <script>
                 // If dark theme is requested, set it immediately to avoid flashing.
                 // The rest of theme handling happens in docsite.js.
@@ -70,8 +74,21 @@
 
             <script>
                 document.addEventListener("DOMContentLoaded", function() {
-                    // append the current path to the redirect link
-                    document.getElementById("latest-docs-redirect").href += window.location.pathname
+                    if ( window.location.pathname.startsWith("/dev") ) {
+                        document.getElementById("notice-old-docs").style.display = "none";
+                        document.getElementById("notice-dev-docs").style.display = "flex";
+                    } else {
+                        document.getElementById("notice-old-docs").style.display = "flex";
+                        document.getElementById("notice-dev-docs").style.display = "none";
+                    }
+
+                    // Append the current path to the redirect link.
+                    //
+                    // The resource estimator doesn't have yet an equivalent on the new docsite, so for that
+                    // one we don't append the path.
+                    if ( ! window.location.pathname.startsWith("/admin/deploy/resource_estimator") ) {
+                        document.getElementById("latest-docs-redirect").href += window.location.pathname
+                    }
                 });
             </script>
             <script type="module">

--- a/doc/dev/background-information/architecture/index.md
+++ b/doc/dev/background-information/architecture/index.md
@@ -282,3 +282,4 @@ If you want to learn more about observability:
 ## Other resources
 
 - [Life of a ping](life-of-a-ping.md)
+- [Row level security (discontinued)](row_level_security.md)

--- a/doc/dev/background-information/architecture/row_level_security.md
+++ b/doc/dev/background-information/architecture/row_level_security.md
@@ -1,0 +1,173 @@
+# Row-level security
+
+> NOTE: this document is deprecated, but preserved for historical and informational purposes.
+
+Starting with version 9.5, Postgres provides a [row-level security](https://www.postgresql.org/docs/13/ddl-rowsecurity.html) mechanism (abbreviated as "RLS") that can restrict table access in a granular, per-user fashion. Sourcegraph uses this mechanism to provide data isolation and protection guarantees beyond those supplied by application-level techniques. This document serves as a brief overview of the concept, its application at Sourcegraph and administrative implications.
+
+## Basics of RLS
+
+Row-level security is enabled for a given table using the `ALTER TABLE <name> ENABLE ROW LEVEL SECURITY` statement. Once executed, all rows within that table immediately become inaccessible to all users _except_ for the table owner or superuser roles who have the `BYPASSRLS` attribute set. Access must then be explicitly permitted by the creation of one or more security policies which are then applied to the table.
+
+Sourcegraph currently uses a single row security policy, which is applied to the `repo` table and covers all commands (`INSERT`, `SELECT`, etc.)
+
+```
+# select tablename, policyname, roles, cmd, format('%s...', left(qual, 16)) as policy from pg_policies;
+┌───────────┬───────────────────────┬──────────────┬─────┬─────────────────────┐
+│ tablename │      policyname       │    roles     │ cmd │       policy        │
+╞═══════════╪═══════════════════════╪══════════════╪═════╪═════════════════════╡
+│ repo      │ sg_repo_access_policy │ {sg_service} │ ALL │ (((NOT (current_... │
+└───────────┴───────────────────────┴──────────────┴─────┴─────────────────────┘
+(1 row)
+
+Time: 0.657 ms
+```
+
+## Reducing privileges
+
+It's not feasible to create a Postgres role for each individual Sourcegraph user. Instead, a dedicated `sg_service` role has been introduced that services can assume to downgrade their own capabilities on demand.
+
+```
+# select rolname, rolcanlogin, rolbypassrls from pg_roles where rolname like 'sg_%';
+┌────────────┬─────────────┬──────────────┐
+│  rolname   │ rolcanlogin │ rolbypassrls │
+╞════════════╪═════════════╪══════════════╡
+│ sg_service │ f           │ f            │
+└────────────┴─────────────┴──────────────┘
+(1 row)
+
+Time: 24.462 ms
+```
+
+The `sg_service` role is not associated with any particular application-level Sourcegraph user, nor is it a user capable of logging in by itself. The policy applied to the `repo` table requires several `rls` values to be set, and these values dynamically alter how each query will behave.
+
+For example, the default `sourcegraph` role in this sample database is permitted to see all 552 rows in the `repo` table because it's the owner of the table.
+
+```
+# select current_user;
+┌──────────────┐
+│ current_user │
+╞══════════════╡
+│ sourcegraph  │
+└──────────────┘
+(1 row)
+
+Time: 0.197 ms
+
+# select count(1) from repo;
+┌───────┐
+│ count │
+╞═══════╡
+│   552 │
+└───────┘
+(1 row)
+
+Time: 15.781 ms
+```
+
+Once the `sg_service` role is assumed, Postgres needs additional information about which Sourcegraph user is executing the query. In this case, user 42 does not have permission to see the repositories owned by user 1 and no rows are returned. Note that we are executing the same query as before, but receiving different results.
+
+```
+# set role sg_service;
+SET
+Time: 1.187 ms
+
+# set rls.user_id = 42;
+SET
+Time: 1.206 ms
+
+# set rls.permission = 'read';
+SET
+Time: 0.333 ms
+
+# set rls.use_permissions_user_mapping = true;
+SET
+Time: 0.327 ms
+
+# select current_user;
+┌──────────────┐
+│ current_user │
+╞══════════════╡
+│ sg_service   │
+└──────────────┘
+(1 row)
+
+Time: 0.381 ms
+
+# select count(1) from repo;
+┌───────┐
+│ count │
+╞═══════╡
+│     0 │
+└───────┘
+(1 row)
+
+Time: 28.288 ms
+```
+
+## Bypassing RLS
+
+Row-level security can be bypassed by setting the `BYPASSRLS` attribute on a role. For example, if we were to create a `poweruser` role without this attribute, the existing security policy would prevent access to the `repo` table by default.
+
+```
+# create role poweruser;
+CREATE ROLE
+Time: 7.015 ms
+
+# set role poweruser;
+SET
+Time: 0.349 ms
+
+# select count(1) from repo;
+┌───────┐
+│ count │
+╞═══════╡
+│     0 │
+└───────┘
+(1 row)
+
+Time: 21.373 ms
+```
+
+We can alter this role to set the `BYPASSRLS` attribute, at which point the security policy will be skipped and the role will have the normal level of access it would expect.
+
+```
+# alter role poweruser bypassrls;
+ALTER ROLE
+Time: 0.852 ms
+
+# set role poweruser;
+SET
+Time: 0.229 ms
+
+# select count(1) from repo;
+┌───────┐
+│ count │
+╞═══════╡
+│   552 │
+└───────┘
+(1 row)
+
+Time: 6.280 ms
+```
+
+Additionally, it is possible to bypass RLS by supplying a policy that explicitly allows a particular role to access the table.
+
+```
+# create policy sg_poweruser_access_policy on repo for all to poweruser using (true);
+CREATE POLICY
+Time: 8.525 ms
+
+# set role poweruser;
+SET
+Time: 0.338 ms
+
+# select count(1) from repo;
+┌───────┐
+│ count │
+╞═══════╡
+│   552 │
+└───────┘
+(1 row)
+
+Time: 5.782 ms
+```

--- a/doc/dev/background-information/bazel/containers.md
+++ b/doc/dev/background-information/bazel/containers.md
@@ -1,52 +1,52 @@
 # Building container images with Bazel
 
-Building containers with Bazel, and using Wolfi for the base images is faster, more reliable and provides much better caching capabilities. This allows us to build the containers in PRs pipelines, not only on the `main` branch. 
-You'll find a lot of mentions of [OCI](https://opencontainers.org/) throughout this document, which refers to the standard for container formats and runtime.  
+Building containers with Bazel, and using Wolfi for the base images is faster, more reliable and provides much better caching capabilities. This allows us to build the containers in PRs pipelines, not only on the `main` branch.
+You'll find a lot of mentions of [OCI](https://opencontainers.org/) throughout this document, which refers to the standard for container formats and runtime.
 
-We use [`rules_oci`](https://github.com/bazel-contrib/rules_oci) and [Wolfi](https://github.com/wolfi-dev) to produce the container images. 
+We use [`rules_oci`](https://github.com/bazel-contrib/rules_oci) and [Wolfi](https://github.com/wolfi-dev) to produce the container images.
 
-See [Bazel at Sourcegraph](./index.md) for general bazel info/setup.
+See [Bazel at Sourcegraph](./index) for general bazel info/setup.
 
-## Why using Bazel to build containers 
+## Why using Bazel to build containers
 
-Bazel being a build system, it's not just for compiling code, it can produce tarballs and all artefacts that we ship to  
+Bazel being a build system, it's not just for compiling code, it can produce tarballs and all artefacts that we ship to
 customers. Our initial approach when we migrated to Bazel was to keep the existing Dockerfiles, and simply use the Bazel
-produced binaries instead of the old ones. 
+produced binaries instead of the old ones.
 
-This sped up the CI significantly, but because Bazel is not aware of the image building process, every build on the `main` branch was recreating the Docker images, which is a time consuming process. In particular, the server image has been the slowest of them all, as it required to build all other service and to package them into a very large image that also contained all the third parties necessary to run them (such as `git`, `p4`, `universal-ctags`). 
+This sped up the CI significantly, but because Bazel is not aware of the image building process, every build on the `main` branch was recreating the Docker images, which is a time consuming process. In particular, the server image has been the slowest of them all, as it required to build all other service and to package them into a very large image that also contained all the third parties necessary to run them (such as `git`, `p4`, `universal-ctags`).
 
-All of these additional steps can fail, due to transient network issues, or a a particular URL becoming unavailable. By switching to Bazel to produce the container images, we are leveraging its reproduceability and cacheability in exactly the same way we do for building binaries. 
+All of these additional steps can fail, due to transient network issues, or a a particular URL becoming unavailable. By switching to Bazel to produce the container images, we are leveraging its reproduceability and cacheability in exactly the same way we do for building binaries.
 
-This results in more reliable and faster builds, fast enough that we can afford to build those images in PRs as Bazel will cache the result, meaning we don't rebuild them unless we have to, in a deterministic fashion. 
+This results in more reliable and faster builds, fast enough that we can afford to build those images in PRs as Bazel will cache the result, meaning we don't rebuild them unless we have to, in a deterministic fashion.
 
 ## Anatomy of a Bazel built containers
 
-Containers are composed of multiple layers (conceptually, not talking about container layers): 
+Containers are composed of multiple layers (conceptually, not talking about container layers):
 
-- Sourcegraph Base Image 
+- Sourcegraph Base Image
   - Distroless base, powered by Wolfi
-  - Packages common to all services. 
+  - Packages common to all services.
 - Per Service Base Image
-  - Packages specific to a given service 
-- Service specific outputs (`pkg_tar` rules) 
+  - Packages specific to a given service
+- Service specific outputs (`pkg_tar` rules)
   - Configuration files, if needed
-  - Binaries (targeting `linux/amd64`) 
-- Image configuration  (`oci_image` rules) 
-  - Environment variables 
+  - Binaries (targeting `linux/amd64`)
+- Image configuration  (`oci_image` rules)
+  - Environment variables
   - Entrypoint
-- Image tests (`container_structure_test` rules) 
+- Image tests (`container_structure_test` rules)
   - Check for correct permissions
-  - Check presence of necessary packages 
+  - Check presence of necessary packages
   - Check that binaries are runnable inside the image
-- Default publishing target (`oci_push` rules) 
+- Default publishing target (`oci_push` rules)
   - They all refer to our internal registry.
-  - Please note that only enterprise variant is published. 
+  - Please note that only enterprise variant is published.
 
 The first two layers are handled by Wolfi and the rest if handled by Bazel.
 
-### Wolfi 
+### Wolfi
 
-See [the dedicated page for Wolfi](../wolfi/index.md). 
+See [the dedicated page for Wolfi](../wolfi/index.md).
 
 ### Bazel
 
@@ -65,7 +65,7 @@ pkg_tar(
 )
 ```
 
-Will create a tarball containing the outputs from the `:frontend` target, which can then be added to an image, through the `tars` attribute of the `oci_image` rule. Example: 
+Will create a tarball containing the outputs from the `:frontend` target, which can then be added to an image, through the `tars` attribute of the `oci_image` rule. Example:
 
 ```
 oci_image(
@@ -75,9 +75,9 @@ oci_image(
 )
 ```
 
-We can add this way as many tarballs we want. In practice, it's best to prefer having multiple smaller tarballs instead of of a big one, as it enabled to cache them individually, to avoid having to rebuild all of them on a tiny change. 
+We can add this way as many tarballs we want. In practice, it's best to prefer having multiple smaller tarballs instead of of a big one, as it enabled to cache them individually, to avoid having to rebuild all of them on a tiny change.
 
-The `oci_image` rule is used to express other aspect of the image we're building, such as the `base` image to use, the `entry_point`, environment variables and which `user` should the image run the entry point with. Example: 
+The `oci_image` rule is used to express other aspect of the image we're building, such as the `base` image to use, the `entry_point`, environment variables and which `user` should the image run the entry point with. Example:
 
 ```
 oci_image(
@@ -96,11 +96,11 @@ oci_image(
 )
 ```
 
-💡 Convention: we define environment variables on the the `oci_image` rule. We could hypothetically define some of them in the base image, on the Wolfi layer, but we much prefer to have everything easily readable in the Buildfile of a given service. 
+💡 Convention: we define environment variables on the the `oci_image` rule. We could hypothetically define some of them in the base image, on the Wolfi layer, but we much prefer to have everything easily readable in the Buildfile of a given service.
 
-The definition for `@wolfi_base` (and other images) is located in [`dev/oci_deps.bzl`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/dev/oci_deps.bzl).  
+The definition for `@wolfi_base` (and other images) is located in [`dev/oci_deps.bzl`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/dev/oci_deps.bzl).
 
-Once we have an image being defined, we need an additional rule to turn it into a tarball that can be fed to `docker load` and later on be published. It defines the default tags for that image. Example: 
+Once we have an image being defined, we need an additional rule to turn it into a tarball that can be fed to `docker load` and later on be published. It defines the default tags for that image. Example:
 
 ```
 oci_tarball(
@@ -110,7 +110,7 @@ oci_tarball(
 )
 ```
 
-At this point, we can also write [container tests](https://github.com/GoogleContainerTools/container-structure-test), with the `container_structure_test` rule: 
+At this point, we can also write [container tests](https://github.com/GoogleContainerTools/container-structure-test), with the `container_structure_test` rule:
 
 ```
 container_structure_test(
@@ -140,24 +140,24 @@ commandTests:
     exitCode: 0
 ```
 
-We can now build this image _locally_ and run those tests as well (please note that if you're working locally on a Linux/amd64 machine, you don't need the `--config darwin-docker` flag). 
+We can now build this image _locally_ and run those tests as well.
 
 💡 The image building process is much faster than the old Docker build scripts, and because most actions are cached, this makes it very easy to iterate locally on both the image definition and the container structure tests.
 
-Example: 
+Example:
 
 ```
 # Create a tarball that can be loaded in Docker of the worker service:
-bazel build //cmd/worker:image_tarball --config darwin-docker
+bazel build //cmd/worker:image_tarball
 
-# Load the image in Docker: 
-docker load --input $(bazel cquery //cmd/worker:image_tarball  --config darwin-docker --output=files)
+# Load the image in Docker:
+docker load --input $(bazel cquery //cmd/worker:image_tarball  --output=files)
 
-# Run the container structure tests 
-bazel test //cmd/worker:image_test --config darwin-docker
+# Run the container structure tests
+bazel test //cmd/worker:image_test
 ```
 
-Finally, _if and only if_ we want our image to be released on registries, we need to add the `oci_push` rule. It will take care of definining which registry to push on, as well as tagging the image, through a process referred as `stamping` that we will cover a bit further. 
+Finally, _if and only if_ we want our image to be released on registries, we need to add the `oci_push` rule. It will take care of definining which registry to push on, as well as tagging the image, through a process referred as `stamping` that we will cover a bit further.
 
 Apart from the `image` attribute which refers to the above `oci_rule`, `repository` refers to the internal (development) registry. Example:
 
@@ -170,7 +170,7 @@ oci_push(
 )
 ```
 
-### Pushing images on registries 
+### Pushing images on registries
 
 Image are never pushed anywhere, unless we are on the `main` branch. Because we are definining a `container_structure_test` rulee, the `bazel test //...` job in CI will always build your image, even in branches. They will just be cached and never pushed.
 
@@ -178,14 +178,14 @@ On the `main` branch (or if branch is `main_dry_run` runtype), a final CI job, n
 
 ### Stamping
 
-Stamping refers to the process of marking artifacts in varied ways, so we can identify and how it was produced. It used at various levels in our pipeline, with the most two notables ones being the `Version` global that we ship within all our Go binaries and the image tags. 
+Stamping refers to the process of marking artifacts in varied ways, so we can identify and how it was produced. It used at various levels in our pipeline, with the most two notables ones being the `Version` global that we ship within all our Go binaries and the image tags.
 
-Example of stamps for Go rules: 
+Example of stamps for Go rules:
 
 ```
 go_library(
     name = "worker_lib",
-    # (...) 
+    # (...)
     x_defs = {
         "github.com/sourcegraph/sourcegraph/internal/version.version": "{STABLE_VERSION}",
         "github.com/sourcegraph/sourcegraph/internal/version.timestamp": "{VERSION_TIMESTAMP}",
@@ -200,5 +200,4 @@ go build \
   -ldflags "-X github.com/sourcegraph/sourcegraph/internal/version.version=$VERSION -X github.com/sourcegraph/sourcegraph/internal/version.timestamp=$(date +%s)" # (...)
 ```
 
-When we are building and testing our targets, we do not stamp our binaries with any specific versions. This enables to cache all outputs. But when we're releasing them, we do want to stamp them before releasing them in the wild. 
-
+When we are building and testing our targets, we do not stamp our binaries with any specific versions. This enables to cache all outputs. But when we're releasing them, we do want to stamp them before releasing them in the wild.

--- a/doc/dev/background-information/bazel/index.md
+++ b/doc/dev/background-information/bazel/index.md
@@ -12,6 +12,7 @@ Sourcegraph uses [Bazel](https://bazel.build) as its build system. Reach out on 
 - **Context specific**
   - [Bazel and Go](./go.md)
   - [Bazel and client](./web.md)
+  - [Bazel and Rust](./rust.md)
   - [Overview of the Bazel configuration for client](./web_overview.md)
   - [Bazel and container images](./containers.md)
 - **How-tos**

--- a/doc/dev/background-information/bazel/rust.md
+++ b/doc/dev/background-information/bazel/rust.md
@@ -1,0 +1,50 @@
+# Bazel for Rust
+
+Also checkout the [FAQ](faq.md) for common issues and solutions.
+
+## TL;DR
+
+- Commands:
+  - `sg bazel configure rustdeps` after changing workspace members or dependencies.
+    - Setting `CARGO_BAZEL_ISOLATED=0` can be set if repinning is too slow, if doing it frequently in local development.
+  - `CARGO_BAZEL_REPIN=<crate name> sg bazel configure rustdeps` after adding/updating a dependency.
+
+## Overview
+
+The rules interfacing Rust are named [`rules_rust`](https://github.com/bazelbuild/rules_rust/) and they provide all the plumbing to call the Rust compiler and run the tests.
+
+Bazel and Rust works slightly differently to Bazel and Go. Unlike with Go, `BUILD.bazel` files are not updated with `sg bazel configure` (they must be updated/configured/created by hand), and instead of there being one `BUILD.bazel` file per directory, it's one per workspace member.
+There exists [gazelle_rust](https://github.com/Calsign/gazelle_rust), a plugin for [Gazelle](https://github.com/bazelbuild/bazel-gazelle) which is invoked via `sg bazel configure`, that may address the first point but we have decided not to invest in using it at the time of writing.
+
+## Rules for Rust
+
+The rules you'll see for Rust are [`rust_binary`](https://bazelbuild.github.io/rules_rust/defs.html#rust_binary), [`rust_library`](https://bazelbuild.github.io/rules_rust/defs.html#rust_library), [`rust_test`](https://bazelbuild.github.io/rules_rust/defs.html#rust_test) and [`rust_proc_macro`](https://bazelbuild.github.io/rules_rust/defs.html#rust_proc_macro).
+
+Each rule type will have a certain set of common attribute values between them for dependency and proc-macro resolution, alongside others such as `name` and rule-specific attributes with values specific to those particular instances that are each briefly explained in the docs for the relevant rules, found at the links above.
+
+`rust_binary` and `rust_library` targets have the following displayed attribute values in common:
+
+```python
+aliases = aliases(),
+proc_macro_deps = all_crate_deps(
+  proc_macro = True,
+),
+deps = all_crate_deps(
+  normal = True,
+),
+```
+
+while `rust_test` targets have the following displayed attribute values in common:
+
+```python
+aliases = aliases(
+  normal_dev = True,
+  proc_macro_dev = True,
+),
+proc_macro_deps = all_crate_deps(
+  proc_macro_dev = True,
+),
+deps = all_crate_deps(
+  normal_dev = True,
+),
+```

--- a/doc/dev/background-information/grpc_tutorial.md
+++ b/doc/dev/background-information/grpc_tutorial.md
@@ -1,0 +1,24 @@
+# gRPC
+
+As of Sourcegraph `5.3.X`, [gRPC](https://grpc.io/about/) has supplanted REST as our default mode of communication between our microservices for our internal APIs.
+
+<Callout type="note">An "internal" API is one that's solely used for intra-service communication/RPCs (think `searcher` fetching an archive from `gitserver`). Internal APIs don't include things like the GraphQL API that external people can use (including our web interface).</Callout>
+
+## gRPC Tutorial
+
+The [`internal/grpc/example`](https://github.com/sourcegraph/sourcegraph/tree/main/internal/grpc/example) package in the [sourcegraph/sourcegraph monorepo](https://github.com/sourcegraph/sourcegraph) contains a simple, runnable example of a gRPC service and client. It is a good starting point for understanding how to write a gRPC service that covers the following topics:
+
+- All the basic Protobuf types (e.g. primitives, enums, messages, one-ofs, etc.)
+- All the basic RPC types (e.g. unary, server streaming, client streaming, bidirectional streaming)
+- Error handling (e.g. gRPC errors, wrapping status errors, etc.)
+- Implementing a gRPC server (with proper separation of concerns)
+- Implementing a gRPC client
+- Some known footguns (non-utf8 strings, huge messages, etc.)
+- Some Sourcegraph-specific helper packages and patterns ([grpc/defaults](https://github.com/sourcegraph/sourcegraph/tree/main/internal/grpc/defaults), [grpc/streamio](https://github.com/sourcegraph/sourcegraph/tree/main/internal/grpc/streamio), etc.)
+
+When going through this example for the first time, it is recommended to:
+
+1. Read the protobuf definitions in [weather/v1/weather.proto](https://github.com/sourcegraph/sourcegraph/blob/main/internal/grpc/example/weather/v1/weather.proto) to get a sense of the service.
+2. Run the server and client examples in [server/](https://github.com/sourcegraph/sourcegraph/tree/main/internal/grpc/example/server) and [client/](https://github.com/sourcegraph/sourcegraph/tree/main/internal/grpc/example/client) (via [server/run-server.sh](https://github.com/sourcegraph/sourcegraph/blob/main/internal/grpc/example/server/run-server.sh) and [client/run-client.sh](https://github.com/sourcegraph/sourcegraph/blob/main/internal/grpc/example/client/run-client.sh)) respectively to see the service in action. You can see a recording of this below:
+    - [![asciicast](https://asciinema.org/a/wFAVGl59oxSWuLSazBgdpO5ks.svg)](https://asciinema.org/a/wFAVGl59oxSWuLSazBgdpO5ks)
+3. Read the implementation of the [server](https://github.com/sourcegraph/sourcegraph/tree/main/internal/grpc/example/server) and [client](https://github.com/sourcegraph/sourcegraph/tree/main/internal/grpc/example/client) to get a sense of how things are implemented, and follow the explanatory comments in the code.

--- a/doc/dev/background-information/scim_api.md
+++ b/doc/dev/background-information/scim_api.md
@@ -31,11 +31,11 @@ You can also just use [cURL](https://curl.se/) if you prefer a CLI tool.
 
 The creators of major IdPs supply validators that one can use to test their SCIM implementation.
 
-We used three validators when testing our implementation: two for Okta and one for Azure AD.
+We used three validators when testing our implementation: two for Okta and one for Microsoft Entra ID.
 
 1. Okta SPEC test – Follow [this guide](https://developer.okta.com/docs/guides/scim-provisioning-integration-prepare/main/#test-your-scim-api) to set it up in five minutes. Tests should be green.
 2. Okta CRUD test – Follow [this guide](https://developer.okta.com/docs/guides/scim-provisioning-integration-test/main/) to set up these tests in your Runscope. This also needs access to an Okta application, which you can find [here](https://dev-433675-admin.oktapreview.com/admin/app/dev-433675_k8ssgdevorgsamlscim_1/instance/0oa1l85zn9a0tgzKP0h8/). Log in with shared credentials in 1Password. Tests should be green, except for the last ones that rely on soft deletion which we don't support yet.
-3. Azure AD validator – It's [here](https://scimvalidator.microsoft.com). It doesn't have a lot of docs. Just use "Discover my schema", then enter the endpoint (for example, https://sourcegraph.test:3443/search/.api/scim/v2) and the token you have in your settings. It should work right away, and all tests should pass.
+3. Microsoft Entra ID validator – It's [here](https://scimvalidator.microsoft.com). It doesn't have a lot of docs. Just use "Discover my schema", then enter the endpoint (for example, https://sourcegraph.test:3443/search/.api/scim/v2) and the token you have in your settings. It should work right away, and all tests should pass.
 
 ## Publishing on Okta
 

--- a/doc/dev/background-information/sg/index.md
+++ b/doc/dev/background-information/sg/index.md
@@ -186,10 +186,8 @@ env:
 commands:
   gitserver:
     install: |
-      config=""
-      [[ $(uname) == "Darwin" ]] && config="--config darwin-docker"
-      bazel build //cmd/gitserver:image_tarball ${config} && \
-      docker load --input $(bazel cquery //cmd/gitserver:image_tarball ${config} --output=files)
+      bazel build //cmd/gitserver:image_tarball && \
+      docker load --input $(bazel cquery //cmd/gitserver:image_tarball --output=files)
   gitserver-0:
     cmd: |
       docker inspect gitserver-${GITSERVER_INDEX} >/dev/null 2>&1 && docker stop gitserver-${GITSERVER_INDEX}

--- a/doc/dev/background-information/sql/index.md
+++ b/doc/dev/background-information/sql/index.md
@@ -8,3 +8,4 @@ Guidance and documentation about writing database interactions within the Source
   - [Batch operations](batch_operations.md)
   - [Materialized cache](materialized_cache.md)
 - [Locking behavior](locking_behavior.md)
+- [Upgrades and Migrator Design](upgrades_and_migrator_design.md)

--- a/doc/dev/background-information/sql/upgrades_and_migrator_design.md
+++ b/doc/dev/background-information/sql/upgrades_and_migrator_design.md
@@ -1,0 +1,352 @@
+# Upgrades and Migrator Design
+
+<p className="subtitle">This doc is based on a preface for [RFC 850 WIP: Improving The Upgrade
+Experience](https://docs.google.com/document/d/1ne8ai60iQnZfaYuB7QLDMIWgU5188Vn4_HBeUQ3GASY/edit)
+and acts as a summary of the current design of our upgrade and database schema
+management design. Subsequently additions have been made. The docs initial aim was to provide general information about the
+relationship of our migrator service to our deployment types and
+migrator's dependencies during the release process.</p>
+
+## Migrator Overview
+
+The `migrator` service is a short-lived container responsible for managing
+Sourcegraph's databases (`pgsql` (*also referred to as frontend*), `codeintel-db`,
+and `codeinsights-db`), and running schema migrations during startup and upgrades.
+
+Its design accounts for  various unique characteristics of
+versioning and database management at Sourcegraph. Specifically graphical
+schema migrations, out-of-band migrations, and periodic schema migration squashing.
+
+Sourcegraph utilizes a [directed acyclic graph](https://github.com/sourcegraph/sourcegraph/pull/30664)
+of migration definitions, rather than a linear chain. In Sourcegraph's early days when schema migrations
+were applied linearly, schema changes were frequent enough that schema changes generally conflicted with
+the master branch by the time a PR passed CI. Moving to a graph of migrations means, devs won't need to
+worry about other teammates concurrent schema changes unless they are working on the same table.
+
+Similarly [squashing](#squashing-migrations) of schema migrations into a root definition reduced the number of migrations run on startup,
+alleviating a common issue in which frequent transaction locks caused failed migration on Sourcegraph startup.
+You can learn more in our [migrations overview docs](/migrations_overview#in-band-migrations).
+Information on out of bound migrations can also be found there.
+
+
+Migrator with its relevant artifacts in the sourcegraph/sourcegraph repo can be viewed as an orchestrator with two special functions --
+
+1.  Migrator constructs migration plans given version ranges and a table
+    of migrations which have been successfully applied (each schema has
+    a table to track applied migrations within that schema). This logic
+    is supported by a variety of files generated during releases and
+    depends on the parent/child metadata of migrations generated via the
+    sg migration tool.
+
+2.  Migrator manages out-of-band migrations. These are data migrations
+    that must be run within specific schema boundaries. Running OOB
+    migrations at/after the deprecated version is unsupported. Migrator
+    ensures that the necessary OOB migrations are run at [stopping
+    points](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/internal/oobmigration/upgrade.go?L32-42)
+    in a multiversion upgrade -- learn more
+    [here](https://about.sourcegraph.com/blog/introducing-migrator-service).
+
+### CLI design
+
+Migrator is designed with a CLI tool interface -- taking various commands to alter
+the state of the database and apply necessary schema changes. This
+design was initially implemented as a tool for TS team members to assist
+in multiversion upgrades and because it could easily be included over
+multiple deployment methods as a containerized process run separately
+from the frontend during startup ([which originally caused
+issues](https://about.sourcegraph.com/blog/introducing-migrator-service)).
+This replaced earlier go/migrate based strategies which ran in the
+frontend on startup. While the migrator can operate as a CLI tool, it's
+containerized as if it was another application which allows it to be run
+as an initContainer (in Kubernetes deployments) or as a dependent
+service (for Docker Compose deployments) to ensure that the necessary
+migrations are applied before startup of the application proper.
+Check out [RFC 469](https://docs.google.com/document/d/1_wqvNbEGhMzu45CHZNrLQYys7gl0AtVpLluGp4cbQKk/edit#heading=h.ddeuyk4t99yx) to learn more.
+
+### Important Commands
+
+The most important migrator commands are `up` and `upgrade`, with a notable mention to `drift`:
+
+-   **Up** : The default command of migrator, `up` ensures that
+    for a given version of the migrator, every migration defined at
+    that build has been successfully applied in the connected database,
+    this is specifically important to ensure *patch version migrations are run*.
+    ***This must be run with the target version migrator image/build**.*
+    If migrator and frontend pods are deployed in version lockstep, `up`
+    ensures that ALL migrations required by the frontend will be successfully applied prior to boot.
+    This is a syntactic sugar over a more internal `upto` command.
+-   **Upgrade**: `upgrade` runs all migrations defined between two minor versions
+    of Sourcegraph and requires that other services which may access the
+    database are brought down. Before running, the database is checked
+    for and schema drifts in order to prevent a failure while attempting
+    a migration. `upgrade` relies on `stitched-migration-graph.json`.
+-   **Drift**: This command pulls runs a diff between the current database
+    schema and an expected definition packaged in migrator during the
+    release process. Many migrator operations run this check before
+    proceeding to ensure the database is in the expected state.
+
+In general, the `up` command can be thought of as a **standard** upgrade
+(rolling upgrades with no downtime) while the upgrade command is what
+enables **multiversion** upgrades. In part, `up` was designed to maintain
+our previous upgrade policy and is thus run as an initContainer (or
+initContainer-like mechanism) of the frontend, i.e. between two versions
+of Sourcegraph, the antecedent Sourcegraph services will continue to
+work after the consequent version's migrations have been applied.
+
+## Current Startup Dependency
+
+
+![Migrator Startup Dependency](https://storage.googleapis.com/sourcegraph-assets/Docs/migrator-startup.png)
+
+All of our deployment types currently utilize migrator during startup.
+The frontend service won't start until migrator has been run with the
+default up command. The frontend service will also validate the expected
+schema (and OOB migration progress), and die on startup if this
+validation pass fails. This ensures that the expected migrations for the
+version in question have been run.
+
+In docker-compose (*see diagram)*, this is accomplished via a chain of
+`depends_on` clauses in the docker-compose.yaml
+([link](https://sourcegraph.com/github.com/sourcegraph/deploy-sourcegraph-docker/-/blob/docker-compose/docker-compose.yaml?L217-223)).
+
+**For our k8s based deployments (including the AMIs) migrator is run as
+an initContainer within the frontend utilizing the up command on the
+given pods startup.**
+
+-   [Helm Ex](https://sourcegraph.com/github.com/sourcegraph/deploy-sourcegraph-helm/-/blob/charts/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml?L49-76)
+-   [Kustomize Ex](https://sourcegraph.com/github.com/sourcegraph/deploy-sourcegraph-k8s/-/blob/base/sourcegraph/frontend/sourcegraph-frontend.Deployment.yaml?L30-48)
+
+
+## Auto-upgrade
+
+Migrator has been incrementally improved over the last year in an
+attempt to get closer and closer to auto-upgrades. After migrator v5.0.0
+logic was added to the `pgsql` database and `frontend`/`frontend-internal` service to
+attempt an automatic upgrade to the latest version of Sourcegraph on the startup of the frontend.
+
+For more information about how this works see the
+[docs](https://docs.sourcegraph.com/admin/updates/automatic#automatic-multi-version-upgrades).
+Some notable points:
+
+-   The upgrade operations in this case are
+    [triggered](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@cf85b5803d32a91425f243930a4f50364625bcd2/-/blob/cmd/frontend/internal/cli/serve_cmd.go?L94-96)
+    and
+    [run](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@cf85b5803d32a91425f243930a4f50364625bcd2/-/blob/cmd/frontend/internal/cli/autoupgrade.go?L37-145)
+    by the frontend container.
+
+-   Migrator [looks
+    for](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@cf85b5803d32a91425f243930a4f50364625bcd2/-/blob/internal/database/migration/cliutil/up.go?L125-128)
+    the existence of the env var SRC_AUTOUPGRADE=true on services
+    `sourcegraph-frontend`, `sourcegraph-frontend-internal`, and `migrator`.
+    Otherwise it [looks in the frontend
+    db](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@cf85b5803d32a91425f243930a4f50364625bcd2/-/blob/internal/database/migration/cliutil/up.go?L120-123)
+    for the value of the autoupgrade column. These checks are performed
+    with either the up or upgrade commands defined on the migrator.
+
+-   The internal connections package to the DB now uses a special
+    [sentinel
+    value](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/internal/database/dbconn/connect.go?L31-37)
+    to make connection attempts sleep if migrations are in progress.
+
+-   A limited frontend is
+    [served](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@cf85b5803d32a91425f243930a4f50364625bcd2/-/blob/cmd/frontend/internal/cli/autoupgrade.go?L78-88)
+    by the frontend during an autoupgrade, displaying progress of the
+    upgrade and any drift encountered.
+
+-   All autoupgrades hit the multiversion upgrade endpoint and assume downtime for all Sourcegraph services besides the migrator and dbs.
+
+## Migrator Release Artifacts
+
+During the release of migrator we construct and build some artifacts
+used by migrator to support its operations. Different artifacts must be
+generated depending on the release type --
+
+-   **Major**
+
+    -   [lastMinorVersionInMajorRelease](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/internal/oobmigration/version.go?L84-87):
+        Used to evaluate what oobmigrations must run, must be updated
+        every major release. This essentially tells us when a minor
+        version becomes a major version. *It may be useful elsewhere at
+        some point.*
+
+-   **Minor**
+
+    -   [maxVersionString](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@5851edf/-/blob/internal/database/migration/shared/data/cmd/generator/consts.go?L12I):
+        Defined in `consts.go` this string is used to tell migrator the
+        latest **minor** version targetable for MVU and oobmigrations.
+        [If not
+        updated](https://github.com/sourcegraph/sourcegraph/issues/55048)
+        multiversion upgrades cannot target the latest release. *Note
+        this is used to determine how many versions should be included
+        in the `stitched-migration-graph.json` file.*
+
+    -   [Stitched-migration.json](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@v5.2.0/-/blob/internal/database/migration/shared/data/stitched-migration-graph.json):
+        Used by multiversion upgrades to unsquash migrations. Generated
+        during release
+        [here](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/dev/release/src/release.ts?L1101-1110).
+        Learn more below.
+
+-   **Patch**
+
+    -   [Git_versions](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/cmd/migrator/generate.sh?L69-79):
+        Defined in `generate.sh` this string array contains versions of
+        Sourcegraph whose schemas should be embedded in migrator during a
+        migrator build to enable drift detection without having to pull them
+        directly from GitHub or, for older versions, from a pre-prepared GCS
+        bucket (this is necessary in air gapped environments). This should
+        be kept up to date with maxVersionString. [Learn
+        more](https://github.com/sourcegraph/sourcegraph/issues/49813).
+
+    -   [Squashed.sql](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@v5.2.0/-/blob/migrations/frontend/squashed.sql):
+        for each database we
+        [generate](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/internal/database/gen.sh?L18-20)
+        a new squashed.sql file. It is
+        [used](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@v5.2.0/-/blob/internal/database/migration/drift/util_search.go?L12-31)
+        to help suggest fixes for certain types of database drift. For
+        example for a missing database column [this
+        search](https://sourcegraph.com/search?patternType=regexp&q=repo%3A%5Egithub%5C.com%2Fsourcegraph%2Fsourcegraph%24%40v5.0.6+file%3A%5Emigrations%2Ffrontend%2Fsquashed%5C.sql%24+%28%5E%7C%5Cb%29CREATE%5CsTABLE%5Csexternal_service_sync_jobs%28%24%7C%5Cb%29+OR+%28%5E%7C%5Cb%29ALTER%5CsTABLE%5CsONLY%5Csexternal_service_sync_jobs%28%24%7C%5Cb%29&groupBy=path)
+        is used to suggest a definition.
+    -   [Schema
+        descriptions](https://raw.githubusercontent.com/sourcegraph/sourcegraph/v5.2.0/internal/database/schema.json):
+        schema descriptions are
+        [embedded](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@v5.2.0/-/blob/cmd/migrator/generate.sh?L64-66)
+        in migrator on each new build as a reference for the expected schema
+        state during drift checking.
+
+### Stitched Migration JSON and Squashing Migrations
+
+![migration graph](https://storage.googleapis.com/sourcegraph-assets/Docs/migration%20graph.png)
+
+*\^\^ Generated with `sg migrations visualize --db frontend` on v5.2.0*
+
+#### Squashing Migrations
+
+[Periodically we
+squash](https://github.com/sourcegraph/sourcegraph/pull/41819)
+all migrations from two versions behind the current version into a
+single migration using sg migration squash. This reduces the time
+required to initialize a new database. This means that the migrator
+image is built with a set of definitions embedded that doesn't reflect
+the definition set in older versions. For multiversion upgrades this
+presents a problem. To get around this, on minor releases we generate a
+`stitched-migration-graph.json` file. Reference links:
+[Bazel](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/dev/release/src/util.ts?L293-327),
+[Embed](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/internal/database/migration/shared/embed.go?L15-22),
+[Generator](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/internal/database/migration/shared/data/cmd/generator/main.go)
+
+####  Stitched Migration Graph
+
+`stitched-migrations-graph.json` [stitches](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@v5.2.0/-/blob/internal/database/migration/stitch/stitch.go) (you can think of this as unsquashing) historic migrations using git magic, enabling the migrator to have a reference of older migrations. This serves a few purposes:
+
+1.  When jumping across multiple versions we do not have access to a
+    full record of migration definitions on migrator disk because some
+    migrations will likely have been squashed. Therefore we need a way
+    to ensure we don't miss migrations on a squash boundary. *Note we
+    can't just re-apply the root migration after a squash because some
+    schema state that\'s already represented in the root migration. This
+    means the squashed root migration isn't always idempotent.*
+
+2.  During a multiversion upgrade migrator must schedule out of band
+    migrations to be started at some version and completed before
+    upgrading past some later version. Migrator needs access to the
+    unsquashed migration definitions to know which migrations must have
+    run at the time the oob migration is triggered.
+
+In standard/`up` upgrades `stitched-migrations.json` isn't necessary. This
+is because `up` determines migrations to run by [comparing
+migrations](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/internal/database/migration/definition/definition.go?L214-244)
+listed as already run in the relevant db's `migration_logs` table directly
+to those migration definitions
+[embedded](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/migrations/embed.go)
+in the migrator disk at build time for the current version, and running
+any which haven't been run. We never squash away the previous minor
+version of Sourcegraph, in this way we can guarantee the `migration_logs`
+table migrations always has migrations in common with the migration
+definitions on disk.
+
+### Database Drifts
+
+Database drift is any difference between the expected state of the
+database at a given version and the actual state of the database. How
+does it come to be? We've observed drift in customer databases for a
+number of reasons, both due to admin tampering and problems in our own
+release process:
+
+-   **A backup/restore process that didn't include all objects**: This
+    notably happened in a customer production instance causing their
+    database to have no indexes, primary keys, or unique constraints defined.
+-   **Modifying the database explicitly**: These are untracked manual
+    changes to the database schema, observed occasionally in the wild,
+    and in our dotcom deployment.
+-   **Migration failures:** that occur during multi-version upgrade or
+    the up command will cause the set of *successfully applied
+    migrations* to be between two versions, where drift is well-defined.
+-   **Site Admins Error:** Errors in git-ops like deploying to
+    production on the wrong version of Sourcegraph manifests have
+    introduced drift. Another source is the incorrect procedure in
+    downgrading.
+-   **Historic Bugs**: We, at one point, [too eagerly backfilled
+    records that we should've instead
+    applied](https://github.com/sourcegraph/sourcegraph/pull/55650).
+    This bug was the result of changes being backported to the metadata
+    definition of a migrations parent migrations, violating assumptions
+    made during the generation of the stitched-migration-graph.json.
+
+Database drift existing at the time of a migration can cause migrations
+to fail when they try to reference some table property that is not in
+the expected state. Not to mention the application may not behave as
+expected if drift is present. Migrator includes a `drift` command intended
+to help admins and CS team members to diagnose and resolve drift in
+customer instances. Multiversion upgrades in particular check for drift
+before starting unless the `--skip-drift-check argument` is supplied.
+
+### Implementation Details
+
+#### Versions & Runner
+
+On startup the migrator service creates a
+[runner](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@30d4d1dd457cde87c863a6d05cbcc0444025ed96/-/blob/cmd/migrator/shared/main.go?L31-36).
+
+The `runner` is responsible for connecting to the given databases and
+[running](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@4728edb797bc9affdbac940821c9e98c3fde2430/-/blob/internal/database/migration/runner/run.go)
+any schema migrations defined in the embedded `migrations` directory
+via the `up` entry command.
+
+A `runner` [infers](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@4728edb797bc9affdbac940821c9e98c3fde2430/-/blob/internal/database/migration/schemas/schemas.go) the expected state of the database from schema definitions
+[embeded in migrator](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@30d4d1dd457cde87c863a6d05cbcc0444025ed96/-/blob/migrations/embed.go)
+when a migrator image is compiled. What this means is that migrator's concept of version,
+ is the set of migrations defined in the `migrations` at compile time. In this way the `up` command easily facilitates dev versions of database schemas.
+
+This "version" definition at compile time also tightly binds migrators concept of "version" to a given tag of Sourcegraph.
+**The `up` command will only initialize a version of Sourcegraph, when the `migrator`
+used to run `up` is the tagged version associated with the desired Sourcegraph version.**
+For this reason a later version of `migrator` cannot be used to initialize an earlier
+version of Sourcegraph.
+
+For example, you use the latest migrator release `v5.6.9` to run the `upgrade` command bringing your databases from
+`v4.2.0` to `v5.6.3`, rather than `v5.6.9`. Your security team hasn't approved images past this point. The upgrade command will have applied OOB migrations and schema migrations defined up to `v5.6.0`, the last minor release. To start your image you'll need to run migrator
+`up` using the `v5.6.3` image, this will apply any schema migrations which may have been defined in the patch releases up to `v5.6.3` and thus existent in the embeded from `migrations` directory at the time of migrators compilation.
+
+#### Migration Plan
+
+While the `up` command's concept of version is a set of embedded definitions --
+the `upgrade` command does have a concept of schema migrations associated to
+version. This is the `stitched-migration-graph.json`. This file is generated on
+minor releases of Sourcegraph, and defines migrations expected to have been run
+at each minor version. This is necessary for two reasons --
+
+1.  The root migration defined in the `migration` directory is a squashed
+    migration, meaning, it represents many migrations composed into a single
+    sql statement.
+2.  Out of Bound migrations are triggered at a given version, and must complete
+    before the schema is changed in some subsequent version.
+
+This means that when applying migrations defined accross multiple versions, migrator
+must stop and wait for OOB migrations to complete. To do this it needs to
+know which migrations should have run at a given stopping point, which may have been
+obscured by a subsequent squashing operation. This is where the `stitched-migration-graph.json`
+file comes into play. It defines the set of migrations that should have been run at
+a given minor version. Helping to construct a "[migration plan](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@4728edb797bc9affdbac940821c9e98c3fde2430/-/blob/internal/database/migration/multiversion/plan.go)" or path for `runner` to traverse.
+
+The `stitched-migration.json` file is [generated](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@4728edb797bc9affdbac940821c9e98c3fde2430/-/blob/internal/database/migration/stitch/stitch.go) on every minor release, and is informed
+by the state of the acyclic graph of migrations defined in the `migration` directory.

--- a/doc/dev/how-to/add_permissions.md
+++ b/doc/dev/how-to/add_permissions.md
@@ -1,4 +1,4 @@
-# Permissions
+# RBAC Permissions
 
 This doc is for engineers who want to add permissions for features they want to protect using the Access Control System. The permission referred to in this context differs from repository permissions; the latter concerns permissions from code hosts relating to repositories.
 
@@ -22,10 +22,10 @@ To add permissions for a new feature, follow these steps:
 
 1. Add the namespace and action to [`schema.yaml`](https://sourcegraph.sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/internal/rbac/schema.yaml). Namespace string must be unique.
 
-2. Generate the access control constants with the command `sg gen`. This will generate access control constants for [Typescript](https://sourcegraph.sourcegraph.com/github.com/sourcegraph/sourcegraph@8b4e1cb/-/blob/client/web/src/rbac/constants.ts) and [Go](https://sourcegraph.sourcegraph.com/github.com/sourcegraph/sourcegraph@8b4e1cb4374d1449c918f695c21d2c933c5a1d15/-/blob/internal/rbac/constants.go).
+2. Generate the access control constants with the command `bazel run //dev:write_all_generated`. This will generate access control constants for [Typescript](https://sourcegraph.sourcegraph.com/github.com/sourcegraph/sourcegraph@8b4e1cb/-/blob/client/web/src/rbac/constants.ts) and [Go](https://sourcegraph.sourcegraph.com/github.com/sourcegraph/sourcegraph@8b4e1cb4374d1449c918f695c21d2c933c5a1d15/-/blob/internal/rbac/constants.go).
     - Additionally modify [schema.graphql](https://sourcegraph.sourcegraph.com/github.com/sourcegraph/sourcegraph@2badaeb3ccb0d9bf660234e8b5eddb4cba6598bb/-/blob/cmd/frontend/graphqlbackend/schema.graphql?L9729) by adding a new namespace enum
 
-3. Once these constants have been generated, you can protect any resource using the access control system. 
+3. Once these constants have been generated, you can protect any resource using the access control system.
     * In Go, you can do this by importing the [`CheckCurrentUserHasPermission`](https://sourcegraph.sourcegraph.com/github.com/sourcegraph/sourcegraph@8b4e1cb/-/blob/internal/rbac/permission.go) method from the `internal/rbac` package. [Example](https://github.com/sourcegraph/sourcegraph/pull/49594/files).
 
     * In Typescript, you can do this by accessing the authenticated user's permissions and verifying the [permission](https://sourcegraph.sourcegraph.com/github.com/sourcegraph/sourcegraph@8b4e1cb4374d1449c918f695c21d2c933c5a1d15/-/blob/client/web/src/rbac/constants.ts?L5:14-5:41) you require is contained in the array. [Example](https://sourcegraph.sourcegraph.com/github.com/sourcegraph/sourcegraph@8b4e1cb4374d1449c918f695c21d2c933c5a1d15/-/blob/client/web/src/batches/utils.ts?L6)

--- a/doc/dev/how-to/add_support_for_a_language.md
+++ b/doc/dev/how-to/add_support_for_a_language.md
@@ -101,17 +101,31 @@ For example:
 }
 ```
 
+
 ### Adding New Syntax Highlighting
 
-To support syntax highlighting on code files, search results, diff views, and more:
 
-1. Follow the [directions](https://github.com/sourcegraph/syntect_server#adding-languages) to add a language to [syntect server](https://github.com/sourcegraph/syntect_server).
-1. Update the [SyntectLanguageMap](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@56a9eec78566499b108e1f869712865d90cc29cf/-/blob/internal/highlight/syntect_language_map.go#L5:5) in [sourcegraph/sourcegraph](https://github.com/sourcegraph/sourcegraph).
+To add syntax highlighting on a new language follow the following steps in the [sourcegraph/sourcegraph](https://github.com/sourcegraph/sourcegraph) repository. (You can also refer to this [PR](https://github.com/sourcegraph/sourcegraph/pull/61478) that added highlighting support for the Pkl language)
 
-To support syntax highlighting in hovers:
 
-1. Update the [highlight.js contributions](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@e7ffd56b10e9bae004dfbb5d7d1c1accc93072fd/-/blob/client/shared/src/highlight/contributions.ts#L21) map in [sourcegraph/sourcegraph](https://github.com/sourcegraph/sourcegraph).
+**Under [docker-images/syntax-highlighter/crates](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@main/-/tree/docker-images/syntax-highlighter/crates):**
 
-## Search support
+1. In  [tree-sitter-all-languages](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@main/-/blob/docker-images/syntax-highlighter/crates/tree-sitter-all-languages/README.md) add a [Tree-sitter](https://tree-sitter.github.io/tree-sitter/) grammar dependency for the language in the crate (e.g. `cargo add --git https://github.com/example/repo.git --rev abcdef1234` ).
 
-Coming soon.
+1. In [tree-sitter-all-languages/lib.rs](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@main/-/blob/docker-images/syntax-highlighter/crates/tree-sitter-all-languages/src/lib.rs) add new entries in the `ParserId` enum and associated references.
+
+1. In [syntax-analysis/queries](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@main/-/tree/docker-images/syntax-highlighter/crates/syntax-analysis/queries) add a folder for the language with three files in it (`highlights.scm`, `locals.scm`, and `injections.scm`). These files can be empty besides `highlights.scm`, which must contain tree-sitter queries for identifying and labeling all tokens in the language requiring highlighting. For more information on writing tree-sitter queries, see the [tree-sitter docs](https://tree-sitter.github.io/tree-sitter/syntax-highlighting#highlights) or refer to the other `.scm` files in the folder.
+
+1. In [syntax-analysis/src/highlighting/snapshots/files](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@main/-/tree/docker-images/syntax-highlighter/crates/syntax-analysis/src/highlighting/snapshots/files) add an example file for the language which demonstrates all key language elements needing highlighting. Try to keep file minimal and avoid redundancy.
+
+1.  In [syntax-analysis/src/highlighting](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@main/-/tree/docker-images/syntax-highlighter/crates/syntax-analysis) run cargo tests `cargo test` to execute the tests and `cargo insta review` to update and regenerate new snapshots. Please review the snapshot generated and ensure the file has proper highlighting annotations ([example](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@main/-/blob/docker-images/syntax-highlighter/crates/syntax-analysis/src/highlighting/snapshots/syntax_analysis__highlighting__tree_sitter__test__python.py.snap)).
+
+
+**Under [internal/gosyntect/languages.go](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@main/-/blob/internal/gosyntect/languages.go):**
+1. Add the new language to the list of tree-sitter supported file types.
+
+
+**(Optional) If the language is not yet supported in [go-enry](https://github.com/go-enry/go-enry)**
+
+Under [lib/codeintel/languages/extensions.go](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@main/-/blob/lib/codeintel/languages/extensions.go?L67):
+1. Add a mapping of the language's extension to name in the `unsupportedByEnryExtensionsMap` and update associated unit test

--- a/doc/dev/how-to/cody_gateway.md
+++ b/doc/dev/how-to/cody_gateway.md
@@ -1,6 +1,6 @@
 # How to set up Cody Gateway locally
 
-> WARNING: This is a development guide - to use Cody Gateway for Sourcegraph, refer to [Sourcegraph Cody Gateway](../../cody/core-concepts/cody-gateway.md).
+> WARNING: This is a development guide - to use Cody Gateway for Sourcegraph, refer to [Sourcegraph Cody Gateway](https://sourcegraph.com/docs/cody/core-concepts/cody-gateway).
 
 This guide documents how to set up [Cody Gateway](https://handbook.sourcegraph.com/departments/engineering/teams/cody/cody-gateway/) locally for development.
 
@@ -16,13 +16,7 @@ To use the locally running Cody Gateway, follow the steps in [use a locally runn
 
 ## Use a locally running Cody Gateway
 
-First, set up some feature flags on your local Sourcegraph instance:
-
-- `product-subscriptions-service-account`: set to `true` globally for convenience.
-  In production, this flag is used to denote service accounts, but in development it doesn't matter.
-  - You can also create an additional user and set this flag to `true` only for that user for more robust testing.
-
-To use this locally running Cody Gateway from your local Sourcegraph instance, configure Cody features to talk to your local Cody Gateway in site configuration, similar to what [customers do to enable Cody Enterprise](../../cody/overview/enable-cody-enterprise.md):
+To use this locally running Cody Gateway from your local Sourcegraph instance, configure Cody features to talk to your local Cody Gateway in site configuration, similar to what [customers do to enable Cody Enterprise](https://sourcegraph.com/docs/cody/overview/enable-cody-enterprise):
 
 ```json
 {
@@ -32,7 +26,7 @@ To use this locally running Cody Gateway from your local Sourcegraph instance, c
     "endpoint": "http://localhost:9992",
     "chatModel": "anthropic/claude-2",
     "completionModel": "anthropic/claude-instant-1",
-    // Create a subscription and create a license key:
+    // Create an Enterprise subscription and license key:
     // https://sourcegraph.test:3443/site-admin/dotcom/product/subscriptions
     // Under "Cody services", ensure access is enabled and get the access token
     // to use here.
@@ -42,7 +36,7 @@ To use this locally running Cody Gateway from your local Sourcegraph instance, c
 }
 ```
 
-Similar values can be [configured for embeddings](https://docs.sourcegraph.com/cody/core-concepts/embeddings) to use embeddings through your local Cody Gateway isntead.
+Similar values can be [configured for embeddings](https://sourcegraph.com/docs/cody/core-concepts/embeddings) to use embeddings through your local Cody Gateway isntead.
 
 Now, we need to make sure your local Cody Gateway instance can access upstream LLM services.
 Add the following to your `sg.config.overwrite.yaml`:
@@ -55,8 +49,8 @@ commands:
       # https://start.1password.com/open/i?a=HEDEDSLHPBFGRBTKAKJWE23XX4&h=my.1password.com&i=athw572l6xqqvtnbbgadevgbqi&v=dnrhbauihkhjs5ag6vszsme45a
       CODY_GATEWAY_ANTHROPIC_ACCESS_TOKEN: "..."
       # Create a personal access token on https://sourcegraph.test:3443/user/settings/tokens
-      # or on your `product-subscriptions-service-account` user. This allows your
-      # local Cody Gateway to access user information in the Sourcegraph instance.
+      # for your local site admin user. This allows your local Cody Gateway to
+      # access user information in the Sourcegraph instance.
       CODY_GATEWAY_DOTCOM_ACCESS_TOKEN: "..."
       # Other values, such as CODY_GATEWAY_OPENAI_ACCESS_TOKEN and
       # CODY_GATEWAY_OPENAI_ORG_ID, can be set to access OpenAI services as well.
@@ -87,7 +81,7 @@ commands:
       CODY_GATEWAY_BIGQUERY_PROJECT_ID: cody-gateway-dev
 ```
 
-Then to view events statistics on the product subscription page, add the following section in the site configuration, and run the `sg start dotcom` stack:
+Then to view events statistics on the Enterprise subscriptions page, add the following section in the site configuration, and run the `sg start dotcom` stack:
 
 ```json
 {

--- a/doc/dev/how-to/debug_permissions.md
+++ b/doc/dev/how-to/debug_permissions.md
@@ -1,0 +1,68 @@
+# Debugging Repository Permissions
+
+This document provides a list of options to try when debugging permissions issues.
+
+## Check the user permissions screen
+
+1. As a site administrator, visit the **Site admin** > **User administration** page and search for the user in question.
+![](https://storage.googleapis.com/sourcegraph-assets/Docs/how-to/debug-permissions/user_search.png)
+2. Click on their username and navigate to their **Settings** > **Permissions** page.
+   This page gives an overview of a user's permission sync jobs, as well as the repositories they have access to and why.
+![](https://storage.googleapis.com/sourcegraph-assets/Docs/how-to/debug-permissions/permissions_page.png)
+3. At the bottom of the **Permissions** page, you'll find a list of repositories the user can access and the reason for their access. Possible access reasons are:
+    - **Public** - The repository is marked as public on the code host, so all users on the Sourcegraph instance can access this repository.
+    - **Unrestricted** - The code host connection that this repository belongs to is not enforcing authorization, so all users on the Sourcegraph instance can access this repository.
+    - **Permissions Sync** - The user has access to this repository because they have connected an external account with access to it on the code host.
+    - **Explicit API** - The user has been granted explicit access to this repository using the explicit permissions API.
+![](https://storage.googleapis.com/sourcegraph-assets/Docs/how-to/debug-permissions/accessible_repos.png)
+4. If the user should have access to a repository, but the repository is not at all present in this list, check if the user has connected their code host account to their user profile.
+
+## Check the user's Account security page
+
+1. As a site administrator, navigate to the user's settings and select **Account security**.
+![](https://storage.googleapis.com/sourcegraph-assets/Docs/how-to/debug-permissions/account_security_page.png)
+    - This page shows a user's connected external accounts. An external account is required to sync user permissions from code hosts.
+2. If a user has not connected their code host account, the user will have to do that by visiting their Account security settings and clicking on Add. Without a connected code host account, Sourcegraph is not able to associate their Sourcegraph identity with a code host identity to map permissions. If you don’t see the provider for your code host here, you have to [configure it first](https://sourcegraph.com/docs/admin/auth).
+3. If the account is connected, you can revisit the Permissions page, schedule another permissions sync, and see if anything changes. If nothing changes when a permission sync is complete, check the outbound requests log to verify that code host API calls are succeeding.
+
+## Check the outbound requests log
+
+1. On the Site admin settings page, click on the Outbound requests option near the bottom.
+![](https://storage.googleapis.com/sourcegraph-assets/Docs/how-to/debug-permissions/outbound_requests_option.png)
+2. If outbound requests aren’t enabled, you’ll need to enable it first. In the site configuration, add `"outboundRequestLogLimit": 50`, (50 indicates the number of most recent requests to store. Adjust as needed).
+3. The Outbound requests page will show a list of all the HTTP requests Sourcegraph is making to outside services. Calls made to do user/repo permissions syncs will also show up here. You can try to catch a user permission sync "in the act" by scheduling a sync and visiting the Outbound requests page.
+![](https://storage.googleapis.com/sourcegraph-assets/Docs/how-to/debug-permissions/outbound_requests.png)
+4. Here, we can see a bunch of API calls being made to the GitLab API, and they seem to be succeeding. To stop the list from refreshing every 5 seconds, you can click on the Pause updating button, and to see more details, you can click on the More info option.
+    - You'll need to use your judgment to determine if anything looks out of place. Ideally, you'd like to see calls to the code host. You want to see those calls succeed with a 200 OK status code. Look at the URLs to see if they make sense. Does anything seem weird?
+
+## Configure authorization for a code host connection
+
+1. Select the Code host connections section on the Site admin settings page. You should see a list of code host connections.
+![](https://storage.googleapis.com/sourcegraph-assets/Docs/how-to/debug-permissions/code_host_connections.png)
+2. Select the code host that you’d like to view, which should show you its configuration page.
+![](https://storage.googleapis.com/sourcegraph-assets/Docs/how-to/debug-permissions/gitlab_connection.png)
+    - Here you can see that this GitLab connection is configured with authorization. If the authorization field is missing completely then the code host connection will be marked as “unrestricted” and all repositories synced by that code host connection will be accessible to everyone on Sourcegraph.
+    - Not all authorization configurations are the same. Visit the [code hosts docs page](https://sourcegraph.com/docs/admin/external_service#configure-a-code-host-connection) for more detailed information on configuring authorization for the specific code host you’re dealing with.
+3. Once you’ve adjusted and saved the config, a sync should be triggered for the code host. If no sync was triggered, hit the Trigger manual sync button.
+4. Next, check the user permissions screen to see if things are behaving as expected now, and if nothing has changed, try scheduling a permissions sync.
+
+## Is the repo public on the code host but not public on Sourcegraph or vice versa?
+
+1. Confirm that the repository on the code host has the visibility you expect it to have.
+    - Does the code host even have a concept of visibility? Some enterprise code hosts don’t have a concept of “publically available” repositories.
+2. Confirm that the visibility of the repository on Sourcegraph differs from what you saw on the code host itself.
+![](https://storage.googleapis.com/sourcegraph-assets/Docs/how-to/debug-permissions/repo_search.png)
+    - Private repositories on Sourcegraph will have the Private label as displayed above. If that label is not there, consider the repo to be public.
+3. If there is a discrepancy between the visibility of the repository on the code host vs. Sourcegraph, it could point to a bug on Sourcegraph’s side.
+
+## Is the repository actually present on Sourcegraph?
+
+1. Navigate to the **Site admin** settings and select **Repositories** under the **Repositories** section in the navigation menu.
+![](https://storage.googleapis.com/sourcegraph-assets/Docs/how-to/debug-permissions/repositories_option.png)
+2. Search for the repository in question.
+![](https://storage.googleapis.com/sourcegraph-assets/Docs/how-to/debug-permissions/repo_search.png)
+3. If the repository does not show up, but you expect it to, the instance may be configured to enforce repository permissions even for site admins. In this case, the site admin can only see the repository if they have explicit access. It may be worth temporarily turning off this enforcement for debugging purposes.
+4. To disable permissions enforcement for site administrators, navigate to the Site Configuration section.
+![](https://storage.googleapis.com/sourcegraph-assets/Docs/how-to/debug-permissions/site_config_option.png)
+5. In the site configuration, there will be a line that reads `"authz.enforceForSiteAdmins": true` . Set it to false. Attempt to search for the repository again.
+    - If there is no such entry, or if the setting is already set to false, the repository is not synced to Sourcegraph at all, and the fault is most likely in the code host connection.

--- a/doc/dev/how-to/index.md
+++ b/doc/dev/how-to/index.md
@@ -62,6 +62,10 @@
 
 - [Adding permissions](add_permissions.md)
 
+## Repository Permissions
+
+- [Debugging Repository permissions](debug_permissions.md)
+
 ## Wolfi
 
 - [How to add and update Wolfi packages](wolfi/add_update_packages.md)

--- a/doc/dev/how-to/telemetry_gateway.md
+++ b/doc/dev/how-to/telemetry_gateway.md
@@ -13,12 +13,30 @@ To learn more about the Sourcegraph's new Telemetry framework, refer to [the tel
 > NOTE: In the Sourcegraph application, the [new events being exported using `internal/telemetry`](../background-information/telemetry/index.md) are sometimes loosely referred to as "V2", as it supersedes the existing mechanisms of writing directly to the `event_logs` database table.
 > The *Telemetry Gateway* schema, however, is `telemetrygateway/v1`, as it is the first iteration of the service's API.
 
+## Default development behaviour
+
+A test deployment is available at `telemetry-gateway.sgdev.org` (see [go/msp-ops/telemetry-gateway#dev](https://handbook.sourcegraph.com/departments/engineering/managed-services/telemetry-gateway/#dev)), which publishes events to a test topic and development pipeline - currently [`sourcegraph-telligent-testing/event-telemetry-test`](https://console.cloud.google.com/cloudpubsub/topic/edit/event-telemetry-test?project=sourcegraph-telligent-testing).
+This instance only accepts licensed instance events that use a development-only license key, and is continuously deployed using MSP rollouts.
+
+Exports of [V2 telemetry events](../background-information/telemetry/index.md) to this development instance is enabled by default in development using the `TELEMETRY_GATEWAY_EXPORTER_EXPORT_ADDR` environment variable configured in `sg.config.yaml` - for example, `sg start` will export V2 telemetry events to this instance.
+
 ## Running Telemetry Gateway locally
 
-Exports of [telemetry events](../background-information/telemetry/index.md) to a locally running Telemetry Gateway instance that is started as part of `sg start` and `sg start dotcom` are enabled by default in development using the `TELEMETRY_GATEWAY_EXPORTER_EXPORT_ADDR` environment variable configured in `sg.config.yaml`.
-By default, the local Telemetry Gateway instance will simply log any events it receives at `debug` level without forwarding the events anywhere.
+First, start a Telemetry Gateway instance locally:
 
-To see the message payloads it *would* emit in a production environment, configure the log level in `sg.config.overwrite.yaml`:
+```sh
+sg run telemetry-gateway
+```
+
+Then, configure the `TELEMETRY_GATEWAY_EXPORTER_EXPORT_ADDR` environment variable in `sg.config.overwrite.yaml` to send events to this locally running instance:
+
+```yaml
+env:
+  TELEMETRY_GATEWAY_EXPORTER_EXPORT_ADDR: 'http://127.0.0.1:6080'
+```
+
+By default, the local Telemetry Gateway instance will simply log any events it receives at `debug` level without forwarding the events anywhere.
+To see the message payloads it *would* emit in a production environment, configure the log level in `sg.config.overwrite.yaml` as well:
 
 ```yaml
 commands:
@@ -35,15 +53,3 @@ env:
 ```
 
 In development, a gRPC interface is enabled for Telemetry Gateway as well at `http://127.0.0.1:10085/debug/grpcui/`.
-
-## Testing against a remote Telemetry Gateway
-
-A test deployment is available at `telemetry-gateway.sgdev.org`, which publishes events to a test topic and development pipeline - currently [`sourcegraph-telligent-testing/event-telemetry-test`](https://console.cloud.google.com/cloudpubsub/topic/edit/event-telemetry-test?project=sourcegraph-telligent-testing).
-In local development, you can configure Sourcegraph to export to this test deployment by setting the following in `sg.config.yaml`:
-
-```yaml
-env:
-  TELEMETRY_GATEWAY_EXPORTER_EXPORT_ADDR: "https://telemetry-gateway.sgdev.org:443"
-```
-
-For details about live Telemetry Gateway deployments, refer to [the handbook Telemetry Gateway page](https://handbook.sourcegraph.com/departments/engineering/teams/core-services/managed-services/telemetry-gateway/).

--- a/doc/dev/how-to/wolfi/add_update_images.md
+++ b/doc/dev/how-to/wolfi/add_update_images.md
@@ -8,24 +8,38 @@ Wolfi base images are built _from scratch_ using [apko](https://github.com/chain
 
 Base images are defined using an apko YAML configuration file, found under [wolfi-images](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/tree/wolfi-images).
 
-These configuration files can be processed with apko, which will generate a base image. You can build these locally using `sg wolfi image <image-name>`.
+To make this YAML file declarative for Bazel, we generate a lockfile from the YAML similar to Go's `go.mod` or NPM's `package-lock.json`. This lockfile captures the exact versions and hashes of packages that will be included in the base image.
+
+These lockfiles files are processed by the rules_apko Bazel ruleset, which outputs a base image.
+
+You can see how this works locally:
+
+- Edit `wolfi-images/gitserver.yaml` to add a new package
+- Run `sg wolfi lock gitserver`
+  - Inspect the gitserver lockfile at `wolfi-images/gitserver.lock.json` to see that it now includes your new package, pinned at a specific version
+  - The lockfile may also include updated versions for other packages
+- Run `sg wolfi image gitserver`
+  - This uses Bazel to build the gitserver base image using the exact set of package versions defined in `gitserver.lock.json`.
+  - This wraps `bazel run //<image>:base_tarball`, but will automatically run `sg wolfi lock` whenever the YAML is changed.
 
 ## How to...
 
-### Update base images for a new release
+### Update base image dependencies
 
-Before each release, we should update the base images to ensure we include any updated packages and vulnerability fixes. To update the images:
+Periodically, we should update the base images to ensure we include any updated packages and vulnerability fixes. To update the images:
 
-- Review the [auto-update pull request](https://github.com/sourcegraph/sourcegraph/pulls?q=is:pr+head:wolfi-auto-update/main+is:open) opened by Buildkite, and merge it
+- Review the [auto-update pull requests](https://github.com/sourcegraph/sourcegraph/pulls?q=is:pr+head:wolfi-auto-update/+is:open+) opened by Buildkite, and merge them.
+
+Note: there are separate pull requests for `main` and the current release branch to avoid merge conflicts.
 
 #### Automation
 
 This process is automated by Buildkite, which runs a daily scheduled build to:
 
-- Rebuild Wolfi base images, pulling in any updated dependencies.
-- Push the updated base images to Docker Hub.
-- Update the base image hashes in `dev/oci_deps.bzl`.
-- Open, or update the already open pull request updating the hashes.
+- Run `sg wolfi lock` to update the base image lockfiles, pulling in the latest versions of each package.
+- Open, or update the previously-opened [pull request](https://github.com/sourcegraph/sourcegraph/pulls?q=is:pr+head:wolfi-auto-update/+is:open+).
+
+The automatic PR is updated daily with the expectation it will be merged before each release, rather than merged daily.
 
 To rerun the automation manually (perhaps to pick up a just-released package version or a change you made), open [Buildkite for sourcegraph/sourcegraph](https://buildkite.com/sourcegraph/sourcegraph) and choose New Build > Options > set Environment Variables to `WOLFI_BASE_REBUILD=true` and Create Build.
 
@@ -33,25 +47,20 @@ To rerun the automation manually (perhaps to pick up a just-released package ver
 
 If the automation fails and a manual update is needed, follow these steps:
 
-- Run [`wolfi-images/rebuild-images.sh`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@main/-/blob/wolfi-images/rebuild-images.sh) script, commit the updated YAML files, and merge to main.
-- Wait for the `main` branch's Buildkite run to complete.
-  - Buildkite will rebuild the base images and publish them to Dockerhub.
-- Run `sg wolfi update-hashes` locally to update the base image hashes in `dev/oci_deps.bzl`. Commit these changes and merge to `main`.
-  - This fetches the updated base image hashes from the images that were pushed to Dockerhub in the previous step.
-- Backport the PR that updated `dev/oci_deps.bzl` to the release branch.
+- Run `sg wolfi lock` to pull in the latest package versions in all images
+- Stage and commit changes using `git add wolfi-images/*.lock.json && git commit -m "Update base image lockfiles"`
+- Create a PR and merge to the target branch.
 
 ### Modify an existing base image
 
-To modify a base image to add packages, users, or directories:
+To modify a base image, for example to add packages, users, or directories:
 
-- Update its apko YAML configuration file, which can be found under [`wolfi-images/`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/wolfi-images/)
-- Build the image
-  - To build locally, use `sg wolfi image <image-name>`.
-  - To build on CI, push your changes and Buildkite will build your image and push it to our `us.gcr.io/sourcegraph-dev/` dev repository. Instructions for pulling this image will be shown at the top of the Buildkite page.
-- Test your changes by exec-ing into the image, or update `dev/oci_deps.bzl` to point at your dev base image and build the full image with Bazel.
-- Once happy, merge your changes and wait for the `main` branch's Buildkite run to complete.
-  - Buildkite will rebuild the base image and publish it to Dockerhub.
-- Run `sg wolfi update-hashes <image-name>` to update the hashes for the changed image in `dev/oci_deps.bzl`. Commit and merge these changes.
+- Update the image's apko YAML configuration file, which can be found under [`wolfi-images/`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/wolfi-images/)
+- To build the **base image** (all depencencies listed in the YAML file, *without* Sourcegraph binaries) run `sg wolfi image <image-name>`
+- To build the **full image** (all dependencies *and* Sourcegraph binaries):
+  - Run `sg wolfi lock <image-name>`
+  - Use Bazel to build the full image e.g. `bazel run //cmd/gitserver:image_tarball`
+- Once happy, commit any changes in `wolfi-images/` and push. Your changes changes to the image will be reflected in the Buildkite pipeline, and in the production images once merged to `main`.
 
 ### Create a new base image
 
@@ -63,10 +72,10 @@ Otherwise, you can create a new base image configuration file:
 - Add any required packages, users, directory structure, or metadata.
   - See [apko file format](https://github.com/chainguard-dev/apko/blob/main/docs/apko_file.md) for a full list of supported configuration.
   - See the other images under [`wolfi-images/`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/wolfi-images/) and [`chainguard-images/images`](https://github.com/chainguard-images/images/tree/main/images) for examples and best practices.
-- Build the image:
-  - To build locally, use `sg wolfi image <image-name>`.
-  - To build on CI, push your changes and Buildkite will build your image and push it to our `us.gcr.io/sourcegraph-dev/` dev repository.
-- Test your changes by exec-ing into the image, or update `dev/oci_deps.bzl` to point at your dev base image and build the full image with Bazel.
-- Commit your updated YAML file and merge it to main. Buildkite will build and publish your new image to Dockerhub.
+- Build the base image locally using `sg wolfi image <image-name>`
+  - Test your changes by exec-ing into the image
+- Review existing `BUILD.bazel` files like `cmd/gitserver/BUILD.bazel` for examples of how to declare an `oci_image()` build target that uses your new base image.
+  - The key parts are to ensure the directory matches the YAML filename, calling `wolfi_base()`, and referencing `:wolfi_base_image`.
+  - Test the build using the relevant Bazel targets e.g. `bazel run //cmd/gitserver:image_tarball`
 
-Once complete, treat the published image it as a standard Docker image, and add it to `dev/oci_deps.bzl`.
+This [pull request](https://github.com/sourcegraph/sourcegraph/pull/61881) provides a worked example of the above.

--- a/doc/dev/how-to/wolfi/add_update_packages.md
+++ b/doc/dev/how-to/wolfi/add_update_packages.md
@@ -39,15 +39,15 @@ It's common to need to update a package to the most recent release in order to p
 - You should also reset the `package.epoch` field to 0 when updating the version.
   - The `version` is the version of the dependency being packaged, but the `epoch` is like the version of the _package itself_. It should be incremented whenever making changes, and reset to 0 when the dependency version increases.
 
-3. Optionally, build the package locally with `sg wolfi package <package-name>`.
+3. Optionally, build the package locally with `sg wolfi package <package-name>` and test by following the instructions in the output.
 
-4. Push your branch and create a PR. Open the Buildkite page for your build (`sg ci status --web`) - the pipeline will automatically rebuild any base images that use this package and show instructions for how to pull these locally for testing.
+4. Push your branch and open the Buildkite page `sg ci status --web`. Buildkite will build your package, push it to our dev package repository, and provide instructions at the top of the page for testing it locally.
 
-5. After validating the new package and base images, merge to `main`. This will add the updated packages to the [Sourcegraph package repository](#sourcegraph-package-repository) and push the updated base images to Dockerhub.
+5. After validating the new package and base images, merge to `main`. This will add the updated packages to the [Sourcegraph package repository](#sourcegraph-package-repository).
 
-6. Wait until the Buildkite pipeline for `main` has run - the next step depends on the images that this pipeline pushes to Dockerhub.
+6. Wait until the Buildkite pipeline for `main` has run - the next step depends on the packages having been pushed to our production package repo.
 
-7. Check out main, create a new branch, and run `sg wolfi update-hashes <image-name>` locally to update the base images digests in `dev/oci_deps.bzl`. Create another PR and merge to main. This ensures that the updated base images are used when building final images.
+7. Create a new PR from `main`, and run `sg wolfi lock`. This will pull in the new version of your packages in any image that uses them. Push, and merge.
 
 ### Create a new package
 

--- a/doc/dev/index.md
+++ b/doc/dev/index.md
@@ -109,7 +109,7 @@ Clarification and discussion about key concepts, architecture, and development s
     - [Testing web code](background-information/testing_web_code.md)
 - [Building p4-fusion](background-information/build_p4_fusion.md)
 - [The `gitserver` API](background-information/gitserver-api.md)
-- [Using gRPC alongside REST for internal APIs](background-information/gRPC_internal_api.md)
+- [gRPC Tutorial](background-information/grpc_tutorial.md)
 
 ### Git
 

--- a/doc/dev/security/secret_formats.md
+++ b/doc/dev/security/secret_formats.md
@@ -2,17 +2,30 @@
 
 Sourcegraph uses a number of secret formats to store authentication tokens and keys. This page documents each secret type, and the regular expressions that can be used to match each format.
 
-| Token Name                                   | Description                                                                      | Type                       | Regular Expression                                |
-| -------------------------------------------- | -------------------------------------------------------------------------------- | -------------------------- | ------------------------------------------------- |
-| Sourcegraph Access Token (v3)                | Token used to access the Sourcegraph GraphQL API                                 | User-generated             | `sgp_(?:[a-fA-F0-9]{16} \|local)_[a-fA-F0-9]{40}` |
-| Sourcegraph Access Token (v2, deprecated)    | Token used to access the Sourcegraph GraphQL API                                 | User-generated             | `sgp_[a-fA-F0-9]{40}`                             |
-| Sourcegraph Access Token (v1, deprecated)    | Token used to access the Sourcegraph GraphQL API                                 | User-generated             | `[a-fA-F0-9]{40}`                                 |
-| Sourcegraph Dotcom User Gateway Access Token | Token used to grant sourcegraph.com users access to Cody                         | Backend (not user-visible) | `sgd_[a-fA-F0-9]{64}`                             |
-| Sourcegraph License Key Token                | Token used for product subscriptions, derived from a Sourcegraph license key     | Backend (not user-visible) | `slk_[a-fA-F0-9]{64}`                             |
-| Sourcegraph Product Subscription Token       | Token used for product subscriptions, not derived from a Sourcegraph license key | Backend (not user-visible) | `sgs_[a-fA-F0-9]{64}`                             |
+|                  Token Name                  |                                   Description                                    |            Type            |    Regular Expression     |                         |
+| -------------------------------------------- | -------------------------------------------------------------------------------- | -------------------------- | ------------------------- | ----------------------- |
+| Sourcegraph Access Token (v3)                | Token used to access the Sourcegraph GraphQL API                                 | User-generated             | `sgp_(?:[a-fA-F0-9]{16} \ | local)_[a-fA-F0-9]{40}` |
+| Sourcegraph Access Token (v2, deprecated)    | Token used to access the Sourcegraph GraphQL API                                 | User-generated             | `sgp_[a-fA-F0-9]{40}`     |                         |
+| Sourcegraph Access Token (v1, deprecated)    | Token used to access the Sourcegraph GraphQL API                                 | User-generated             | `[a-fA-F0-9]{40}`         |                         |
+| Sourcegraph Dotcom User Gateway Access Token | Token used to grant sourcegraph.com users access to Cody                         | Backend (not user-visible) | `sgd_[a-fA-F0-9]{64}`     |                         |
+| Sourcegraph License Key Token                | Token used for product subscriptions, derived from a Sourcegraph license key     | Backend (not user-visible) | `slk_[a-fA-F0-9]{64}`     |                         |
+| Sourcegraph Enterprise subscription (aka "product subscription") Token       | Token used for Enterprise subscriptions, derived from a Sourcegraph license key | Backend (not user-visible) | `sgs_[a-fA-F0-9]{64}`     |                         |
 
 For further information about Sourcegraph Access Tokens, see:
-- [Creating an access token](../../cli/how-tos/creating_an_access_token.md)
-- [Revoking an access token](../../cli/how-tos/revoking_an_access_token.md)
+- [Creating an access token](https://sourcegraph.com/docs/cli/how-tos/creating_an_access_token)
+- [Revoking an access token](https://sourcegraph.com/docs/cli/how-tos/revoking_an_access_token)
 
 Sourcegraph is in the process of rolling out a new Sourcegraph Access Token format. When generating an access token you may receive a token in v2 or v3 format depending on your Sourcegraph instance's version. Newer instances are fully backwards-compatible with all older formats.
+
+
+### Sourcegraph Access Token (v3) Instance Identifier
+The Sourcegraph Access Token (v3) includes an *instance identifier* which can be used by Sourcegraph to securely identify which instance the token was generated for. In the event of a token leak, this allows us to inform the relevant customer.
+
+```
+sgp _ <instance identifier> _ <token value>
+```
+
+The *instance identifier* is intentionally **not** verified when a token is used, so tokens will remain valid if it is modified. This doesn't impact the security of our access tokens. For example, the following tokens have the same *token value* so are equivalent:
+
+* `sgp_foobar_abcdef0123456789`
+* `sgp_bazbar_abcdef0123456789`

--- a/doc/dev/setup/quickstart.md
+++ b/doc/dev/setup/quickstart.md
@@ -4,7 +4,7 @@ This is the quickstart guide for [developing Sourcegraph](../index.md).
 
 > NOTE: If you run into any troubles, reach out on Slack:
 >
-> - [As an open source contributor](https://sourcegraph-community.slack.com/archives/C02BG0M0ZJ7)
+> - [As an open source contributor](https://discord.com/servers/sourcegraph-969688426372825169)
 > - [As a Sourcegraph employee](https://sourcegraph.slack.com/archives/C01N83PS4TU)
 >
 > You can also get help on our [developer experience discussion forum](https://github.com/sourcegraph/sourcegraph/discussions/categories/developer-experience).


### PR DESCRIPTION
This PR fixes a few issues with the legacy docs that are currently served on docs.sourcegraph.com: 

- When serving pages from the dev docs, a banner (orange) indicates when it was last refreshed and how to find up to date content.
  - Because the banner sent users straight to the docsite v2, which doesn't have the dev docs anymore, this was creating broken links
- When serving pages from the normal docs, the banner is the same as before, but we force the link to the docs v2 root if and only if serving the resource estimator page.
  - This is to avoid serving a broken link, as the resource estimator doesn't have yet an equivalent on the dev docs. 
  - See https://sourcegraph.slack.com/archives/C01DXLN3D0T/p1713333693488469
- A fresh copy of the latest dev docs, so at least the content is up to date with stuff from https://github.com/sourcegraph/sourcegraph/pull/61931

Instead of using `v5.3.9104` as the pinned revision that docs.sourcegraph.com uses, we'll use the target branch of this PR. 


## Test plan

![CleanShot 2024-04-17 at 14 36 42@2x](https://github.com/sourcegraph/sourcegraph/assets/10151/e89326e6-939d-479d-adba-7dbd9e1789e4)

![CleanShot 2024-04-17 at 14 36 54@2x](https://github.com/sourcegraph/sourcegraph/assets/10151/80a7d6c8-70fc-4aca-b80f-f336bf62f459)

![CleanShot 2024-04-17 at 14 37 14@2x](https://github.com/sourcegraph/sourcegraph/assets/10151/9a0d2760-8d43-41e3-a524-b9b8883c3d8b)


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
