### PR TITLE
file view: Fix code intel popovers, pinned and token navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Updated the Docker-in-Docker image to 26.0.0 to resolve several vulnerabilities. [#61735](https://github.com/sourcegraph/sourcegraph/pull/61735)
 - The GetCommit() RPC in the gitserver service now uses the correct protobuf type that allows for non-utf8 byte sequences in commit messages, author names, and author emails. [#61940](https://github.com/sourcegraph/sourcegraph/pull/61940)
 - The ArchiveReader() RPC in the gitserver service now uses the correct protobuf type that allows for non-utf8 byte sequences in file paths. [#61970](https://github.com/sourcegraph/sourcegraph/pull/61970)
+- Pinned code intel popovers and popovers opened via the keyboard are properly shown again. [#61966](https://github.com/sourcegraph/sourcegraph/pull/61966)
 
 ## Unreleased (April Patch Release - 22nd April, 2024)
 

--- a/client/web/src/repo/blob/codemirror/codeintel/pin.ts
+++ b/client/web/src/repo/blob/codemirror/codeintel/pin.ts
@@ -42,7 +42,7 @@ export const pinnedRange = Facet.define<{ from: number; to: number } | null, { f
                 return [
                     // Show loading tooltip after 50ms if the hover tooltip is not yet available
                     merge(from(getHoverTooltip(state, range.from)), timer(50).pipe(map(() => loadingTooltip))).pipe(
-                        takeWhile(tooltip => tooltip !== loadingTooltip, true)
+                        takeWhile(tooltip => tooltip === loadingTooltip, true)
                     ),
                 ]
             }

--- a/client/web/src/repo/blob/codemirror/codeintel/token-selection.ts
+++ b/client/web/src/repo/blob/codemirror/codeintel/token-selection.ts
@@ -246,7 +246,7 @@ const selectedToken = StateField.define<{
                         merge(
                             from(getHoverTooltip(view.state, selected.range.from)),
                             timer(50).pipe(map(() => loadingTooltip))
-                        ).pipe(takeWhile(tooltip => tooltip !== loadingTooltip, true))
+                        ).pipe(takeWhile(tooltip => tooltip === loadingTooltip, true))
                     )
                     return true
                 },


### PR DESCRIPTION
Fixes #61964 

When upgrading and migrating rxjs methods, this way of "racing" the loading popover was incorrectly implemented. The condition needs to be reversed so that the observable completes once the non-loading tooltip was emitted.


## Test plan

Manual testing. Use token navigation to go to a token and press space. The expected popover appears.
