### PR TITLE
chore(bazel): enable rules_esbuild sandbox with object-inspect workaround

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -258,6 +258,12 @@ swc_register_toolchains(
 # rules_esbuild setup ===========================
 http_archive(
     name = "aspect_rules_esbuild",
+    patch_args = ["-p1"],
+    patches = [
+        # Includes https://github.com/aspect-build/rules_esbuild/pull/201 as well as a fix for
+        # object-inspect being weird, see the comments in the patch for further links.
+        "//third_party/rules_esbuild:sandbox-plugin-fixes.patch",
+    ],
     sha256 = "ef7163a2e8e319f8a9a70560788dd899126aebf3538c76f8bc1f0b4b52ba4b56",
     strip_prefix = "rules_esbuild-0.21.0-rc1",
     url = "https://github.com/aspect-build/rules_esbuild/releases/download/v0.21.0-rc1/rules_esbuild-v0.21.0-rc1.tar.gz",

--- a/client/testing/BUILD.bazel
+++ b/client/testing/BUILD.bazel
@@ -60,7 +60,7 @@ npm_package(
 js_library(
     name = "fetch-mock",
     srcs = ["src/fetch.js"],
-    declarations = ["src/fetch.js"],
+    types = ["src/fetch.js"],
     visibility = ["//visibility:public"],
     deps = [
         "//:node_modules/node-fetch",

--- a/dev/esbuild.bzl
+++ b/dev/esbuild.bzl
@@ -4,8 +4,6 @@ load("@aspect_rules_esbuild//esbuild:defs.bzl", _esbuild = "esbuild")
 def esbuild(name, **kwargs):
     _esbuild(
         name,
-        # TODO: work through build failures when sandbox plugin is enabled so that bundling is hermetic
-        bazel_sandbox_plugin = False,
         **kwargs
     )
 
@@ -14,8 +12,6 @@ def esbuild_web_app(name, **kwargs):
 
     _esbuild(
         name = bundle_name,
-        # TODO: work through build failures when sandbox plugin is enabled so that bundling is hermetic
-        bazel_sandbox_plugin = False,
         **kwargs
     )
 

--- a/dev/mocha.bzl
+++ b/dev/mocha.bzl
@@ -49,8 +49,6 @@ def mocha_test(name, tests, deps = [], args = [], data = [], env = {}, is_percy_
                 ".node": "copy",
             },
         },
-        # TODO: work through build failures when sandbox plugin is enabled so that bundling is hermetic
-        bazel_sandbox_plugin = False,
     )
 
     args = [

--- a/package.json
+++ b/package.json
@@ -451,6 +451,21 @@
           "ws": "*"
         }
       },
+      "mz": {
+        "dependencies": {
+          "graceful-fs": "*"
+        }
+      },
+      "follow-redirects": {
+        "dependencies": {
+          "debug": "*"
+        }
+      },
+      "debug": {
+        "dependencies": {
+          "supports-color": "*"
+        }
+      },
       "@graphql-codegen/cli@5": {
         "peerDependencies": {
           "@graphql-codegen/typescript": "*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ overrides:
   cssnano: 4.1.10
   tslib: 2.1.0
 
-packageExtensionsChecksum: dd95e2509ba76d0489f870c0fbed3202
+packageExtensionsChecksum: f2efae6ae360a154188d7bdc16a0ca69
 
 importers:
 
@@ -1856,7 +1856,6 @@ packages:
       yargs: 15.4.1
     transitivePeerDependencies:
       - encoding
-      - supports-color
     dev: true
 
   /@ardatan/sync-fetch@0.0.1:
@@ -1938,8 +1937,6 @@ packages:
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
-    transitivePeerDependencies:
-      - supports-color
 
   /@babel/generator@7.23.6:
     resolution: {integrity: sha512-qrSfCYxYQB5owCmGLbl8XRpX1ytXlpueOb0N0UmQwA073KZxejgQTzAmJezxvpwQD9uGtK2shHdi55QT+MbjIw==}
@@ -2011,8 +2008,6 @@ packages:
       debug: 4.3.4
       lodash.debounce: 4.0.8
       resolve: 1.22.8
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /@babel/helper-define-polyfill-provider@0.6.1(@babel/core@7.24.0):
@@ -2026,8 +2021,6 @@ packages:
       debug: 4.3.4
       lodash.debounce: 4.0.8
       resolve: 1.22.8
-    transitivePeerDependencies:
-      - supports-color
 
   /@babel/helper-environment-visitor@7.22.20:
     resolution: {integrity: sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==}
@@ -2148,8 +2141,6 @@ packages:
       '@babel/template': 7.24.0
       '@babel/traverse': 7.24.0
       '@babel/types': 7.24.0
-    transitivePeerDependencies:
-      - supports-color
 
   /@babel/highlight@7.23.4:
     resolution: {integrity: sha512-acGdbYSfp2WheJoJm/EBBBLh/ID8KDc64ISZ9DYtBmC8/Q204PZJLHyzeB5qMzJ5trcOkybd78M4x2KWsUq++A==}
@@ -2968,8 +2959,6 @@ packages:
       babel-plugin-polyfill-corejs3: 0.9.0(@babel/core@7.24.0)
       babel-plugin-polyfill-regenerator: 0.5.5(@babel/core@7.24.0)
       semver: 6.3.1
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /@babel/plugin-transform-shorthand-properties@7.24.1(@babel/core@7.24.0):
@@ -3156,8 +3145,6 @@ packages:
       babel-plugin-polyfill-regenerator: 0.6.1(@babel/core@7.24.0)
       core-js-compat: 3.36.1
       semver: 6.3.1
-    transitivePeerDependencies:
-      - supports-color
 
   /@babel/preset-flow@7.24.1(@babel/core@7.24.0):
     resolution: {integrity: sha512-sWCV2G9pcqZf+JHyv/RyqEIpFypxdCSxWIxQjpdaQxenNog7cN1pr76hg8u0Fz8Qgg0H4ETkGcJnXL8d4j0PPA==}
@@ -3242,8 +3229,6 @@ packages:
       debug: 4.3.4
       globals: 11.12.0
       lodash: 4.17.21
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /@babel/traverse@7.24.0:
@@ -3260,8 +3245,6 @@ packages:
       '@babel/types': 7.24.0
       debug: 4.3.4
       globals: 11.12.0
-    transitivePeerDependencies:
-      - supports-color
 
   /@babel/types@7.10.5:
     resolution: {integrity: sha512-ixV66KWfCI6GKoA/2H9v6bQdbfXEwwpOdQ8cRvb4F+eyvhlaHxWFMQB4+3d9QFJXZsiiiqVrewNV0DFEQpyT4Q==}
@@ -4038,8 +4021,6 @@ packages:
       js-yaml: 4.1.0
       minimatch: 3.1.2
       strip-json-comments: 3.1.1
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /@eslint/eslintrc@2.1.4:
@@ -4055,8 +4036,6 @@ packages:
       js-yaml: 4.1.0
       minimatch: 3.1.2
       strip-json-comments: 3.1.1
-    transitivePeerDependencies:
-      - supports-color
 
   /@eslint/js@8.57.0:
     resolution: {integrity: sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==}
@@ -4267,7 +4246,6 @@ packages:
       - bufferutil
       - encoding
       - enquirer
-      - supports-color
       - ts-node
       - typescript
       - utf-8-validate
@@ -4332,7 +4310,6 @@ packages:
       - cosmiconfig-toml-loader
       - encoding
       - enquirer
-      - supports-color
       - typescript
       - utf-8-validate
     dev: true
@@ -4376,7 +4353,6 @@ packages:
       tslib: 2.1.0
     transitivePeerDependencies:
       - encoding
-      - supports-color
     dev: true
 
   /@graphql-codegen/plugin-helpers@2.7.2(graphql@15.4.0):
@@ -4456,7 +4432,6 @@ packages:
       tslib: 2.1.0
     transitivePeerDependencies:
       - encoding
-      - supports-color
     dev: true
 
   /@graphql-codegen/typescript-apollo-client-helpers@2.2.6(graphql@15.4.0):
@@ -4472,7 +4447,6 @@ packages:
       tslib: 2.1.0
     transitivePeerDependencies:
       - encoding
-      - supports-color
     dev: true
 
   /@graphql-codegen/typescript-operations@2.5.10(graphql@15.4.0):
@@ -4488,7 +4462,6 @@ packages:
       tslib: 2.1.0
     transitivePeerDependencies:
       - encoding
-      - supports-color
     dev: true
 
   /@graphql-codegen/typescript-operations@4.0.1(graphql@15.4.0):
@@ -4504,7 +4477,6 @@ packages:
       tslib: 2.1.0
     transitivePeerDependencies:
       - encoding
-      - supports-color
     dev: true
 
   /@graphql-codegen/typescript@2.8.5(graphql@15.4.0):
@@ -4520,7 +4492,6 @@ packages:
       tslib: 2.1.0
     transitivePeerDependencies:
       - encoding
-      - supports-color
     dev: true
 
   /@graphql-codegen/typescript@4.0.1(graphql@15.4.0):
@@ -4536,7 +4507,6 @@ packages:
       tslib: 2.1.0
     transitivePeerDependencies:
       - encoding
-      - supports-color
     dev: true
 
   /@graphql-codegen/visitor-plugin-common@2.13.1(graphql@15.4.0):
@@ -4557,7 +4527,6 @@ packages:
       tslib: 2.1.0
     transitivePeerDependencies:
       - encoding
-      - supports-color
     dev: true
 
   /@graphql-codegen/visitor-plugin-common@2.13.5(graphql@15.4.0):
@@ -4578,7 +4547,6 @@ packages:
       tslib: 2.1.0
     transitivePeerDependencies:
       - encoding
-      - supports-color
     dev: true
 
   /@graphql-codegen/visitor-plugin-common@4.0.1(graphql@15.4.0):
@@ -4599,7 +4567,6 @@ packages:
       tslib: 2.1.0
     transitivePeerDependencies:
       - encoding
-      - supports-color
     dev: true
 
   /@graphql-tools/apollo-engine-loader@7.3.21(graphql@15.4.0):
@@ -4669,7 +4636,6 @@ packages:
       unixify: 1.0.0
     transitivePeerDependencies:
       - '@babel/core'
-      - supports-color
     dev: true
 
   /@graphql-tools/code-file-loader@8.0.3(graphql@15.4.0):
@@ -4684,8 +4650,6 @@ packages:
       graphql: 15.4.0
       tslib: 2.1.0
       unixify: 1.0.0
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /@graphql-tools/delegate@10.0.3(graphql@15.4.0):
@@ -4865,7 +4829,6 @@ packages:
       unixify: 1.0.0
     transitivePeerDependencies:
       - '@babel/core'
-      - supports-color
     dev: true
 
   /@graphql-tools/git-loader@8.0.3(graphql@15.4.0):
@@ -4881,8 +4844,6 @@ packages:
       micromatch: 4.0.5
       tslib: 2.1.0
       unixify: 1.0.0
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /@graphql-tools/github-loader@7.3.22(@babel/core@7.24.0)(graphql@15.4.0):
@@ -4899,7 +4860,6 @@ packages:
     transitivePeerDependencies:
       - '@babel/core'
       - encoding
-      - supports-color
     dev: true
 
   /@graphql-tools/github-loader@8.0.0(@types/node@20.8.0)(graphql@15.4.0):
@@ -4919,7 +4879,6 @@ packages:
     transitivePeerDependencies:
       - '@types/node'
       - encoding
-      - supports-color
     dev: true
 
   /@graphql-tools/graphql-file-loader@7.5.13(graphql@15.4.0):
@@ -4963,7 +4922,6 @@ packages:
       tslib: 2.1.0
     transitivePeerDependencies:
       - '@babel/core'
-      - supports-color
     dev: true
 
   /@graphql-tools/graphql-tag-pluck@8.1.0(graphql@15.4.0):
@@ -4980,8 +4938,6 @@ packages:
       '@graphql-tools/utils': 10.0.11(graphql@15.4.0)
       graphql: 15.4.0
       tslib: 2.1.0
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /@graphql-tools/import@6.7.14(graphql@15.4.0):
@@ -5148,7 +5104,6 @@ packages:
       - '@types/node'
       - bufferutil
       - encoding
-      - supports-color
       - utf-8-validate
     dev: true
 
@@ -5181,7 +5136,6 @@ packages:
       - '@types/node'
       - bufferutil
       - encoding
-      - supports-color
       - utf-8-validate
     dev: true
 
@@ -5196,7 +5150,6 @@ packages:
       tslib: 2.1.0
     transitivePeerDependencies:
       - encoding
-      - supports-color
     dev: true
 
   /@graphql-tools/relay-operation-optimizer@7.0.0(graphql@15.4.0):
@@ -5211,7 +5164,6 @@ packages:
       tslib: 2.1.0
     transitivePeerDependencies:
       - encoding
-      - supports-color
     dev: true
 
   /@graphql-tools/schema@10.0.2(graphql@15.4.0):
@@ -5403,8 +5355,6 @@ packages:
       '@humanwhocodes/object-schema': 2.0.2
       debug: 4.3.4
       minimatch: 3.1.2
-    transitivePeerDependencies:
-      - supports-color
 
   /@humanwhocodes/config-array@0.9.5:
     resolution: {integrity: sha512-ObyMyWxZiCu/yTisA7uzx81s40xR2fD5Cg/2Kq7G02ajkNubJf6BopgDTmDyc3U7sXpNKM8cYOw7s7Tyr+DnCw==}
@@ -5413,8 +5363,6 @@ packages:
       '@humanwhocodes/object-schema': 1.2.1
       debug: 4.3.4
       minimatch: 3.1.2
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /@humanwhocodes/module-importer@1.0.1:
@@ -5446,8 +5394,6 @@ packages:
       lodash.clone: 4.5.0
       lodash.isequal: 4.5.0
       prettier: 2.8.1
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /@iarna/toml@2.2.5:
@@ -5474,8 +5420,6 @@ packages:
       kolorist: 1.8.0
       local-pkg: 0.5.0
       mlly: 1.7.0
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /@internationalized/date@3.5.1:
@@ -5570,8 +5514,6 @@ packages:
       pirates: 4.0.6
       slash: 3.0.0
       write-file-atomic: 4.0.2
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /@jest/types@26.6.2:
@@ -5855,8 +5797,6 @@ packages:
       outvariant: 1.4.0
       strict-event-emitter: 0.2.8
       web-encoding: 1.1.5
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /@n1ru4l/push-pull-async-iterable-iterator@3.2.0:
@@ -6351,8 +6291,6 @@ packages:
       '@opentelemetry/instrumentation': 0.35.1(@opentelemetry/api@1.8.0)
       '@opentelemetry/sdk-trace-web': 1.9.1(@opentelemetry/api@1.8.0)
       '@opentelemetry/semantic-conventions': 1.9.1
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /@opentelemetry/instrumentation@0.35.1(@opentelemetry/api@1.8.0):
@@ -6365,8 +6303,6 @@ packages:
       require-in-the-middle: 5.1.0
       semver: 7.6.0
       shimmer: 1.2.1
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /@opentelemetry/otlp-exporter-base@0.35.1(@opentelemetry/api@1.8.0):
@@ -6478,7 +6414,6 @@ packages:
       '@percy/cli-exec': 1.24.0
     transitivePeerDependencies:
       - bufferutil
-      - supports-color
       - utf-8-validate
     dev: true
 
@@ -6489,7 +6424,6 @@ packages:
       '@percy/cli-command': 1.24.0
     transitivePeerDependencies:
       - bufferutil
-      - supports-color
       - utf-8-validate
     dev: true
 
@@ -6503,7 +6437,6 @@ packages:
       '@percy/logger': 1.24.0
     transitivePeerDependencies:
       - bufferutil
-      - supports-color
       - utf-8-validate
     dev: true
 
@@ -6514,7 +6447,6 @@ packages:
       '@percy/cli-command': 1.24.0
     transitivePeerDependencies:
       - bufferutil
-      - supports-color
       - utf-8-validate
     dev: true
 
@@ -6527,7 +6459,6 @@ packages:
       which: 2.0.2
     transitivePeerDependencies:
       - bufferutil
-      - supports-color
       - utf-8-validate
     dev: true
 
@@ -6539,7 +6470,6 @@ packages:
       yaml: 2.4.1
     transitivePeerDependencies:
       - bufferutil
-      - supports-color
       - utf-8-validate
     dev: true
 
@@ -6552,7 +6482,6 @@ packages:
       image-size: 1.1.1
     transitivePeerDependencies:
       - bufferutil
-      - supports-color
       - utf-8-validate
     dev: true
 
@@ -6572,7 +6501,6 @@ packages:
       '@percy/logger': 1.24.0
     transitivePeerDependencies:
       - bufferutil
-      - supports-color
       - utf-8-validate
     dev: true
 
@@ -6614,7 +6542,6 @@ packages:
       ws: 8.16.0
     transitivePeerDependencies:
       - bufferutil
-      - supports-color
       - utf-8-validate
     dev: true
 
@@ -6713,8 +6640,6 @@ packages:
       http-graceful-shutdown: 2.3.2
       morgan: 1.10.0
       nocache: 2.1.0
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /@pollyjs/persister-fs@5.0.0:
@@ -6722,8 +6647,6 @@ packages:
     dependencies:
       '@pollyjs/node-server': 5.0.0
       '@pollyjs/persister': 5.0.0
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /@pollyjs/persister@5.0.0:
@@ -7588,8 +7511,6 @@ packages:
     resolution: {integrity: sha512-SjUKKsx5FmcK9G6Pb6UBFT0s9JexVStK5WInmANw75Hm7YokVvHEgtprQDz2Uvy5znX5g2ujzrkIU//T15KQzA==}
     dependencies:
       serve-static: 1.15.0
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /@react-native-community/cli-doctor@12.3.6:
@@ -7671,7 +7592,6 @@ packages:
     transitivePeerDependencies:
       - bufferutil
       - encoding
-      - supports-color
       - utf-8-validate
     dev: false
 
@@ -7724,7 +7644,6 @@ packages:
     transitivePeerDependencies:
       - bufferutil
       - encoding
-      - supports-color
       - utf-8-validate
     dev: false
 
@@ -7740,7 +7659,6 @@ packages:
       '@react-native/codegen': 0.73.3(@babel/preset-env@7.24.3)
     transitivePeerDependencies:
       - '@babel/preset-env'
-      - supports-color
     dev: false
 
   /@react-native/babel-preset@0.73.21(@babel/core@7.24.0)(@babel/preset-env@7.24.3):
@@ -7793,7 +7711,6 @@ packages:
       react-refresh: 0.14.0
     transitivePeerDependencies:
       - '@babel/preset-env'
-      - supports-color
     dev: false
 
   /@react-native/codegen@0.73.3(@babel/preset-env@7.24.3):
@@ -7810,8 +7727,6 @@ packages:
       jscodeshift: 0.14.0(@babel/preset-env@7.24.3)
       mkdirp: 0.5.6
       nullthrows: 1.1.1
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /@react-native/community-cli-plugin@0.73.17(@babel/core@7.24.0)(@babel/preset-env@7.24.3):
@@ -7834,7 +7749,6 @@ packages:
       - '@babel/preset-env'
       - bufferutil
       - encoding
-      - supports-color
       - utf-8-validate
     dev: false
 
@@ -7861,7 +7775,6 @@ packages:
     transitivePeerDependencies:
       - bufferutil
       - encoding
-      - supports-color
       - utf-8-validate
     dev: false
 
@@ -7887,7 +7800,6 @@ packages:
       nullthrows: 1.1.1
     transitivePeerDependencies:
       - '@babel/preset-env'
-      - supports-color
     dev: false
 
   /@react-native/normalize-colors@0.73.2:
@@ -8229,7 +8141,6 @@ packages:
       unplugin: 1.0.1
     transitivePeerDependencies:
       - encoding
-      - supports-color
     dev: true
 
   /@sentry/cli@1.74.6:
@@ -8247,7 +8158,6 @@ packages:
       which: 2.0.2
     transitivePeerDependencies:
       - encoding
-      - supports-color
     dev: true
 
   /@sentry/cli@2.21.1:
@@ -8263,7 +8173,6 @@ packages:
       which: 2.0.2
     transitivePeerDependencies:
       - encoding
-      - supports-color
     dev: true
 
   /@sentry/core@7.70.0:
@@ -8294,7 +8203,6 @@ packages:
       uuid: 9.0.0
     transitivePeerDependencies:
       - encoding
-      - supports-color
     dev: true
 
   /@sentry/hub@7.8.1:
@@ -8318,8 +8226,6 @@ packages:
       https-proxy-agent: 5.0.1
       lru_map: 0.3.3
       tslib: 2.1.0
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /@sentry/types@7.70.0:
@@ -8455,8 +8361,6 @@ packages:
       is-stream: 1.1.0
       p-queue: 6.6.2
       p-retry: 4.6.0
-    transitivePeerDependencies:
-      - debug
     dev: true
 
   /@sourcegraph/codemod-cli@1.0.0:
@@ -8520,7 +8424,6 @@ packages:
       - eslint
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
-      - supports-color
       - typescript
     dev: true
 
@@ -8545,8 +8448,6 @@ packages:
       semver: 7.6.0
       tsutils: 3.21.0(typescript@5.4.2)
       typescript: 5.4.2
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /@sourcegraph/extension-api-classes@1.1.0(sourcegraph@25.7.0):
@@ -8757,7 +8658,6 @@ packages:
       - '@types/react'
       - '@types/react-dom'
       - encoding
-      - supports-color
     dev: true
 
   /@storybook/addon-controls@8.0.5(@types/react@18.0.8)(react-dom@18.1.0)(react@18.1.0):
@@ -8771,7 +8671,6 @@ packages:
       - encoding
       - react
       - react-dom
-      - supports-color
     dev: true
 
   /@storybook/addon-designs@7.0.5(@storybook/addon-docs@7.6.17)(@storybook/addons@7.4.6)(@storybook/components@7.6.17)(@storybook/manager-api@7.6.17)(@storybook/preview-api@7.6.17)(@storybook/theming@7.6.17)(react-dom@18.1.0)(react@18.1.0):
@@ -8833,7 +8732,6 @@ packages:
       - '@types/react'
       - '@types/react-dom'
       - encoding
-      - supports-color
     dev: true
 
   /@storybook/addon-docs@8.0.5:
@@ -8861,7 +8759,6 @@ packages:
       ts-dedent: 2.2.0
     transitivePeerDependencies:
       - encoding
-      - supports-color
     dev: true
 
   /@storybook/addon-essentials@8.0.5(@types/react@18.0.8)(react-dom@18.1.0)(react@18.1.0):
@@ -8886,7 +8783,6 @@ packages:
       - encoding
       - react
       - react-dom
-      - supports-color
     dev: true
 
   /@storybook/addon-highlight@7.4.6:
@@ -9097,7 +8993,6 @@ packages:
       - '@types/react'
       - '@types/react-dom'
       - encoding
-      - supports-color
     dev: true
 
   /@storybook/blocks@7.6.17(@types/react-dom@18.0.2)(@types/react@18.0.8)(react-dom@18.1.0)(react@18.1.0):
@@ -9135,7 +9030,6 @@ packages:
       - '@types/react'
       - '@types/react-dom'
       - encoding
-      - supports-color
     dev: true
 
   /@storybook/blocks@8.0.5(@types/react@18.0.8)(react-dom@18.1.0)(react@18.1.0):
@@ -9178,7 +9072,6 @@ packages:
     transitivePeerDependencies:
       - '@types/react'
       - encoding
-      - supports-color
     dev: true
 
   /@storybook/builder-manager@7.4.6:
@@ -9202,7 +9095,6 @@ packages:
       util: 0.12.5
     transitivePeerDependencies:
       - encoding
-      - supports-color
     dev: true
 
   /@storybook/builder-manager@8.0.5:
@@ -9224,7 +9116,6 @@ packages:
       util: 0.12.5
     transitivePeerDependencies:
       - encoding
-      - supports-color
     dev: true
 
   /@storybook/builder-vite@7.4.6(typescript@5.4.2)(vite@4.5.2):
@@ -9265,7 +9156,6 @@ packages:
       vite: 4.5.2(@types/node@20.8.0)(sass@1.32.4)
     transitivePeerDependencies:
       - encoding
-      - supports-color
     dev: true
 
   /@storybook/builder-vite@8.0.5(typescript@5.4.2)(vite@5.1.5):
@@ -9304,7 +9194,6 @@ packages:
       vite: 5.1.5(@types/node@20.8.0)(sass@1.32.4)
     transitivePeerDependencies:
       - encoding
-      - supports-color
     dev: true
 
   /@storybook/channels@7.4.6:
@@ -9386,7 +9275,6 @@ packages:
     transitivePeerDependencies:
       - bufferutil
       - encoding
-      - supports-color
       - utf-8-validate
     dev: true
 
@@ -9436,7 +9324,6 @@ packages:
       - encoding
       - react
       - react-dom
-      - supports-color
       - utf-8-validate
     dev: true
 
@@ -9481,8 +9368,6 @@ packages:
       lodash: 4.17.21
       prettier: 2.8.1
       recast: 0.23.6
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /@storybook/codemod@8.0.5:
@@ -9503,8 +9388,6 @@ packages:
       prettier: 3.2.5
       recast: 0.23.6
       tiny-invariant: 1.3.3
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /@storybook/components@7.4.6(@types/react-dom@18.0.2)(@types/react@18.0.8)(react-dom@18.1.0)(react@18.1.0):
@@ -9609,7 +9492,6 @@ packages:
       ts-dedent: 2.2.0
     transitivePeerDependencies:
       - encoding
-      - supports-color
     dev: true
 
   /@storybook/core-common@7.6.17:
@@ -9640,7 +9522,6 @@ packages:
       ts-dedent: 2.2.0
     transitivePeerDependencies:
       - encoding
-      - supports-color
     dev: true
 
   /@storybook/core-common@8.0.5:
@@ -9676,7 +9557,6 @@ packages:
       util: 0.12.5
     transitivePeerDependencies:
       - encoding
-      - supports-color
     dev: true
 
   /@storybook/core-events@7.4.6:
@@ -9743,7 +9623,6 @@ packages:
     transitivePeerDependencies:
       - bufferutil
       - encoding
-      - supports-color
       - utf-8-validate
     dev: true
 
@@ -9798,7 +9677,6 @@ packages:
       - encoding
       - react
       - react-dom
-      - supports-color
       - utf-8-validate
     dev: true
 
@@ -9807,8 +9685,6 @@ packages:
     dependencies:
       '@storybook/csf-tools': 7.4.6
       unplugin: 1.10.1
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /@storybook/csf-plugin@7.6.17:
@@ -9816,8 +9692,6 @@ packages:
     dependencies:
       '@storybook/csf-tools': 7.6.17
       unplugin: 1.10.1
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /@storybook/csf-plugin@8.0.5:
@@ -9825,8 +9699,6 @@ packages:
     dependencies:
       '@storybook/csf-tools': 8.0.5
       unplugin: 1.10.1
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /@storybook/csf-tools@7.4.6:
@@ -9841,8 +9713,6 @@ packages:
       fs-extra: 11.2.0
       recast: 0.23.6
       ts-dedent: 2.2.0
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /@storybook/csf-tools@7.6.17:
@@ -9857,8 +9727,6 @@ packages:
       fs-extra: 11.2.0
       recast: 0.23.6
       ts-dedent: 2.2.0
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /@storybook/csf-tools@8.0.5:
@@ -9873,8 +9741,6 @@ packages:
       fs-extra: 11.2.0
       recast: 0.23.6
       ts-dedent: 2.2.0
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /@storybook/csf@0.0.1:
@@ -9907,7 +9773,6 @@ packages:
       lodash: 4.17.21
     transitivePeerDependencies:
       - encoding
-      - supports-color
     dev: true
 
   /@storybook/docs-tools@7.6.17:
@@ -9922,7 +9787,6 @@ packages:
       lodash: 4.17.21
     transitivePeerDependencies:
       - encoding
-      - supports-color
     dev: true
 
   /@storybook/docs-tools@8.0.5:
@@ -9937,7 +9801,6 @@ packages:
       lodash: 4.17.21
     transitivePeerDependencies:
       - encoding
-      - supports-color
     dev: true
 
   /@storybook/global@5.0.0:
@@ -10181,7 +10044,6 @@ packages:
       - '@preact/preset-vite'
       - encoding
       - rollup
-      - supports-color
       - typescript
       - vite-plugin-glimmerx
     dev: true
@@ -10223,7 +10085,6 @@ packages:
       util-deprecate: 1.0.2
     transitivePeerDependencies:
       - encoding
-      - supports-color
     dev: true
 
   /@storybook/router@7.4.6(react-dom@18.1.0)(react@18.1.0):
@@ -10300,7 +10161,6 @@ packages:
       - sass
       - stylus
       - sugarss
-      - supports-color
       - typescript
       - vite-plugin-glimmerx
     dev: true
@@ -10323,7 +10183,6 @@ packages:
       type-fest: 2.19.0
     transitivePeerDependencies:
       - encoding
-      - supports-color
     dev: true
 
   /@storybook/sveltekit@8.0.5(@babel/core@7.24.0)(@sveltejs/vite-plugin-svelte@3.0.1)(postcss@8.4.35)(sass@1.32.4)(svelte@4.1.1)(typescript@5.4.2)(vite@5.1.5):
@@ -10352,7 +10211,6 @@ packages:
       - sass
       - stylus
       - sugarss
-      - supports-color
       - typescript
       - vite-plugin-glimmerx
     dev: true
@@ -10370,7 +10228,6 @@ packages:
       read-pkg-up: 7.0.1
     transitivePeerDependencies:
       - encoding
-      - supports-color
     dev: true
 
   /@storybook/telemetry@8.0.5:
@@ -10386,7 +10243,6 @@ packages:
       read-pkg-up: 7.0.1
     transitivePeerDependencies:
       - encoding
-      - supports-color
     dev: true
 
   /@storybook/test@8.0.5(vitest@1.3.1):
@@ -10557,8 +10413,6 @@ packages:
       debug: 4.3.4
       svelte: 4.1.1
       vite: 5.1.5(@types/node@20.8.0)(sass@1.32.4)
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /@sveltejs/vite-plugin-svelte@3.0.1(svelte@4.1.1)(vite@5.1.5):
@@ -10577,8 +10431,6 @@ packages:
       svelte-hmr: 0.15.3(svelte@4.1.1)
       vite: 5.1.5(@types/node@20.8.0)(sass@1.32.4)
       vitefu: 0.2.5(vite@5.1.5)
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /@swc/helpers@0.5.3:
@@ -11605,8 +11457,6 @@ packages:
       semver: 7.6.0
       ts-api-utils: 1.0.3(typescript@5.4.2)
       typescript: 5.4.2
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /@typescript-eslint/experimental-utils@5.4.0(eslint@8.57.0)(typescript@5.4.2):
@@ -11623,7 +11473,6 @@ packages:
       eslint-scope: 5.1.1
       eslint-utils: 3.0.0(eslint@8.57.0)
     transitivePeerDependencies:
-      - supports-color
       - typescript
     dev: true
 
@@ -11643,8 +11492,6 @@ packages:
       debug: 4.3.4
       eslint: 8.57.0
       typescript: 5.4.2
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /@typescript-eslint/parser@6.9.0(eslint@8.57.0)(typescript@5.4.2):
@@ -11664,8 +11511,6 @@ packages:
       debug: 4.3.4
       eslint: 8.57.0
       typescript: 5.4.2
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /@typescript-eslint/scope-manager@5.4.0:
@@ -11708,8 +11553,6 @@ packages:
       eslint: 8.57.0
       ts-api-utils: 1.0.3(typescript@5.4.2)
       typescript: 5.4.2
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /@typescript-eslint/types@5.4.0:
@@ -11744,8 +11587,6 @@ packages:
       semver: 7.6.0
       tsutils: 3.21.0(typescript@5.4.2)
       typescript: 5.4.2
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /@typescript-eslint/typescript-estree@5.62.0(typescript@5.4.2):
@@ -11765,8 +11606,6 @@ packages:
       semver: 7.6.0
       tsutils: 3.21.0(typescript@5.4.2)
       typescript: 5.4.2
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /@typescript-eslint/typescript-estree@6.9.0(typescript@5.4.2):
@@ -11786,8 +11625,6 @@ packages:
       semver: 7.6.0
       ts-api-utils: 1.0.3(typescript@5.4.2)
       typescript: 5.4.2
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /@typescript-eslint/utils@5.62.0(eslint@8.57.0)(typescript@5.4.2):
@@ -11806,7 +11643,6 @@ packages:
       eslint-scope: 5.1.1
       semver: 7.6.0
     transitivePeerDependencies:
-      - supports-color
       - typescript
     dev: true
 
@@ -11825,7 +11661,6 @@ packages:
       eslint: 8.57.0
       semver: 7.6.0
     transitivePeerDependencies:
-      - supports-color
       - typescript
     dev: true
 
@@ -12078,8 +11913,6 @@ packages:
       magic-string: 0.27.0
       react-refresh: 0.14.0
       vite: 4.5.2(@types/node@20.8.0)(sass@1.32.4)
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /@vitest/expect@1.0.0-beta.4:
@@ -12162,8 +11995,6 @@ packages:
       https-proxy-agent: 5.0.1
       jszip: 3.10.1
       semver: 7.6.0
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /@vscode/vsce@2.24.0:
@@ -12544,16 +12375,12 @@ packages:
     engines: {node: '>= 6.0.0'}
     dependencies:
       debug: 4.3.4
-    transitivePeerDependencies:
-      - supports-color
 
   /agent-base@7.1.0:
     resolution: {integrity: sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==}
     engines: {node: '>= 14'}
     dependencies:
       debug: 4.3.4
-    transitivePeerDependencies:
-      - supports-color
 
   /aggregate-error@3.1.0:
     resolution: {integrity: sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==}
@@ -12958,8 +12785,6 @@ packages:
     resolution: {integrity: sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==}
     dependencies:
       follow-redirects: 1.15.1
-    transitivePeerDependencies:
-      - debug
     dev: true
 
   /axobject-query@2.2.0:
@@ -12994,8 +12819,6 @@ packages:
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-instrument: 5.1.0
       test-exclude: 6.0.0
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /babel-plugin-polyfill-corejs2@0.4.10(@babel/core@7.24.0):
@@ -13007,8 +12830,6 @@ packages:
       '@babel/core': 7.24.0
       '@babel/helper-define-polyfill-provider': 0.6.1(@babel/core@7.24.0)
       semver: 6.3.1
-    transitivePeerDependencies:
-      - supports-color
 
   /babel-plugin-polyfill-corejs3@0.10.4(@babel/core@7.24.0):
     resolution: {integrity: sha512-25J6I8NGfa5YkCDogHRID3fVCadIR8/pGl1/spvCkzb6lVn6SR3ojpx9nOn9iEBcUsjY24AmdKm5khcfKdylcg==}
@@ -13018,8 +12839,6 @@ packages:
       '@babel/core': 7.24.0
       '@babel/helper-define-polyfill-provider': 0.6.1(@babel/core@7.24.0)
       core-js-compat: 3.36.1
-    transitivePeerDependencies:
-      - supports-color
 
   /babel-plugin-polyfill-corejs3@0.9.0(@babel/core@7.24.0):
     resolution: {integrity: sha512-7nZPG1uzK2Ymhy/NbaOWTg3uibM2BmGASS4vHS4szRZAIR8R6GwA/xAujpdrXU5iyklrimWnLWU+BLF9suPTqg==}
@@ -13029,8 +12848,6 @@ packages:
       '@babel/core': 7.24.0
       '@babel/helper-define-polyfill-provider': 0.5.0(@babel/core@7.24.0)
       core-js-compat: 3.36.1
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /babel-plugin-polyfill-regenerator@0.5.5(@babel/core@7.24.0):
@@ -13040,8 +12857,6 @@ packages:
     dependencies:
       '@babel/core': 7.24.0
       '@babel/helper-define-polyfill-provider': 0.5.0(@babel/core@7.24.0)
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /babel-plugin-polyfill-regenerator@0.6.1(@babel/core@7.24.0):
@@ -13051,8 +12866,6 @@ packages:
     dependencies:
       '@babel/core': 7.24.0
       '@babel/helper-define-polyfill-provider': 0.6.1(@babel/core@7.24.0)
-    transitivePeerDependencies:
-      - supports-color
 
   /babel-plugin-syntax-trailing-function-commas@7.0.0-beta.0:
     resolution: {integrity: sha512-Xj9XuRuz3nTSbaTXWv3itLOcxyF4oPD8douBBmj7U9BBC6nEBYfyOJYQMf/8PJAFotC62UY5dFfIGEPr7WswzQ==}
@@ -13196,8 +13009,6 @@ packages:
       raw-body: 2.5.1
       type-is: 1.6.18
       unpipe: 1.0.0
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /boolbase@1.0.0:
@@ -13718,8 +13529,6 @@ packages:
       escape-string-regexp: 4.0.0
       is-wsl: 2.2.0
       lighthouse-logger: 1.4.2
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /chrome-trace-event@1.0.3:
@@ -13757,8 +13566,6 @@ packages:
       lighthouse-logger: 1.4.2
       mkdirp: 1.0.4
       rimraf: 3.0.2
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /ci-env@1.16.0:
@@ -14069,8 +13876,6 @@ packages:
       on-headers: 1.0.2
       safe-buffer: 5.1.2
       vary: 1.1.2
-    transitivePeerDependencies:
-      - supports-color
 
   /compute-scroll-into-view@1.0.17:
     resolution: {integrity: sha512-j4dx+Fb0URmzbwwMUrhqWM2BEWHdFGx+qZ9qqASHRPqvTYdqvWnHg0H1hIbcyLnvgnoNAVMlwkepyqM3DaIFUg==}
@@ -14121,8 +13926,6 @@ packages:
       finalhandler: 1.1.2
       parseurl: 1.3.3
       utils-merge: 1.0.1
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /console-control-strings@1.1.0:
@@ -14848,31 +14651,26 @@ packages:
 
   /debug@2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
-    peerDependencies:
-      supports-color: '*'
     peerDependenciesMeta:
       supports-color:
         optional: true
     dependencies:
       ms: 2.0.0
+      supports-color: 8.1.1
 
-  /debug@3.2.7(supports-color@5.5.0):
+  /debug@3.2.7:
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
-    peerDependencies:
-      supports-color: '*'
     peerDependenciesMeta:
       supports-color:
         optional: true
     dependencies:
       ms: 2.1.3
-      supports-color: 5.5.0
+      supports-color: 8.1.1
     dev: true
 
-  /debug@4.3.1(supports-color@8.1.1):
+  /debug@4.3.1:
     resolution: {integrity: sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==}
     engines: {node: '>=6.0'}
-    peerDependencies:
-      supports-color: '*'
     peerDependenciesMeta:
       supports-color:
         optional: true
@@ -14884,13 +14682,12 @@ packages:
   /debug@4.3.4:
     resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
     engines: {node: '>=6.0'}
-    peerDependencies:
-      supports-color: '*'
     peerDependenciesMeta:
       supports-color:
         optional: true
     dependencies:
       ms: 2.1.2
+      supports-color: 8.1.1
 
   /debuglog@1.0.1:
     resolution: {integrity: sha512-syBZ+rnAK3EgMsH2aYEOLUW7mZSY9Gb+0wUMCFsZvcmiz+HigA0LOcq/HoQqVuGG+EKykunc7QG2bzrponfaSw==}
@@ -15175,8 +14972,6 @@ packages:
     dependencies:
       address: 1.1.2
       debug: 2.6.9
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /devalue@4.3.2:
@@ -15638,8 +15433,6 @@ packages:
     dependencies:
       debug: 4.3.4
       esbuild: 0.18.20
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /esbuild-register@3.5.0(esbuild@0.19.11):
@@ -15649,8 +15442,6 @@ packages:
     dependencies:
       debug: 4.3.4
       esbuild: 0.19.11
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /esbuild@0.17.14:
@@ -15811,17 +15602,13 @@ packages:
       tsutils: 3.21.0(typescript@5.4.2)
       tsutils-etc: 1.4.1(tsutils@3.21.0)(typescript@5.4.2)
       typescript: 5.4.2
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /eslint-import-resolver-node@0.3.6:
     resolution: {integrity: sha512-0En0w03NRVMn9Uiyn8YRPDKvWjxCWkslUEhGNTdGx15RvPJYQ+lbOlqrlNI2vEAs4pDYK4f/HN2TbDmk5TP0iw==}
     dependencies:
-      debug: 3.2.7(supports-color@5.5.0)
+      debug: 3.2.7
       resolve: 1.22.8
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /eslint-module-utils@2.7.3(@typescript-eslint/parser@5.62.0):
@@ -15843,10 +15630,8 @@ packages:
         optional: true
     dependencies:
       '@typescript-eslint/parser': 5.62.0(eslint@8.57.0)(typescript@5.4.2)
-      debug: 3.2.7(supports-color@5.5.0)
+      debug: 3.2.7
       find-up: 2.1.0
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /eslint-module-utils@2.7.3(@typescript-eslint/parser@6.9.0)(eslint-import-resolver-node@0.3.6):
@@ -15868,11 +15653,9 @@ packages:
         optional: true
     dependencies:
       '@typescript-eslint/parser': 6.9.0(eslint@8.57.0)(typescript@5.4.2)
-      debug: 3.2.7(supports-color@5.5.0)
+      debug: 3.2.7
       eslint-import-resolver-node: 0.3.6
       find-up: 2.1.0
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /eslint-plugin-ban@1.4.0:
@@ -15896,8 +15679,6 @@ packages:
       tslib: 2.1.0
       tsutils: 3.21.0(typescript@5.4.2)
       typescript: 5.4.2
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /eslint-plugin-import@2.26.0(@typescript-eslint/parser@6.9.0)(eslint@8.57.0):
@@ -15928,7 +15709,6 @@ packages:
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
-      - supports-color
     dev: true
 
   /eslint-plugin-jest-dom@5.1.0(@testing-library/dom@8.13.0)(eslint@8.57.0):
@@ -15963,8 +15743,6 @@ packages:
       is-builtin-module: 3.2.1
       semver: 7.6.0
       spdx-expression-parse: 3.0.1
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /eslint-plugin-jsx-a11y@6.5.1(eslint@8.57.0):
@@ -16003,7 +15781,6 @@ packages:
       - eslint-import-resolver-node
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
-      - supports-color
     dev: true
 
   /eslint-plugin-react-hooks@4.5.0(eslint@8.57.0):
@@ -16056,8 +15833,6 @@ packages:
       tsutils: 3.21.0(typescript@5.4.2)
       tsutils-etc: 1.4.1(tsutils@3.21.0)(typescript@5.4.2)
       typescript: 5.4.2
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /eslint-plugin-storybook@0.6.15(eslint@8.57.0)(typescript@5.4.2):
@@ -16072,7 +15847,6 @@ packages:
       requireindex: 1.2.0
       ts-dedent: 2.2.0
     transitivePeerDependencies:
-      - supports-color
       - typescript
     dev: true
 
@@ -16088,7 +15862,6 @@ packages:
       requireindex: 1.2.0
       ts-dedent: 2.2.0
     transitivePeerDependencies:
-      - supports-color
       - typescript
     dev: true
 
@@ -16232,8 +16005,6 @@ packages:
       strip-json-comments: 3.1.1
       text-table: 0.2.0
       v8-compile-cache: 2.3.0
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /eslint@8.57.0:
@@ -16279,8 +16050,6 @@ packages:
       optionator: 0.9.3
       strip-ansi: 6.0.1
       text-table: 0.2.0
-    transitivePeerDependencies:
-      - supports-color
 
   /esm-env@1.0.0:
     resolution: {integrity: sha512-Cf6VksWPsTuW01vU9Mk/3vRue91Zevka5SjyNf3nEpokFRuqt/KjUQoGAwq9qMmhpLTHmXzSIrFRw8zxWzmFBA==}
@@ -16335,8 +16104,6 @@ packages:
       '@babel/traverse': 7.24.0
       '@babel/types': 7.24.0
       c8: 7.14.0
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /estree-walker@2.0.2:
@@ -16478,8 +16245,6 @@ packages:
     resolution: {integrity: sha512-J+xSzdr5lj1cIuZey0ac6nUv22VE7GrdwTERqE8DsrqSXLm1zjeYWTVbK37t8exGwobxBXeWU2bM7eSMjBR4YA==}
     dependencies:
       serve-static: 1.15.0
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /express@4.18.2:
@@ -16517,8 +16282,6 @@ packages:
       type-is: 1.6.18
       utils-merge: 1.0.1
       vary: 1.1.2
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /ext@1.4.0:
@@ -16562,8 +16325,6 @@ packages:
       debug: 2.6.9
       mkdirp: 0.5.6
       yauzl: 2.10.0
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /extract-zip@2.0.1:
@@ -16576,8 +16337,6 @@ packages:
       yauzl: 2.10.0
     optionalDependencies:
       '@types/yauzl': 2.10.0
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /fancy-file-input@2.0.3(jquery@2.2.4):
@@ -16744,8 +16503,6 @@ packages:
       parseurl: 1.3.3
       statuses: 1.5.0
       unpipe: 1.0.0
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /finalhandler@1.2.0:
@@ -16759,8 +16516,6 @@ packages:
       parseurl: 1.3.3
       statuses: 2.0.1
       unpipe: 1.0.0
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /find-cache-dir@2.1.0:
@@ -16861,11 +16616,11 @@ packages:
   /follow-redirects@1.15.1:
     resolution: {integrity: sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==}
     engines: {node: '>=4.0'}
-    peerDependencies:
-      debug: '*'
     peerDependenciesMeta:
       debug:
         optional: true
+    dependencies:
+      debug: 4.3.4
     dev: true
 
   /for-each@0.3.3:
@@ -17067,7 +16822,6 @@ packages:
       node-fetch: 2.7.0
     transitivePeerDependencies:
       - encoding
-      - supports-color
     dev: true
 
   /gcp-metadata@3.2.0:
@@ -17078,7 +16832,6 @@ packages:
       json-bigint: 0.3.0
     transitivePeerDependencies:
       - encoding
-      - supports-color
     dev: true
 
   /generic-names@4.0.0:
@@ -17190,8 +16943,6 @@ packages:
       file-uri-to-path: 2.0.0
       fs-extra: 8.1.0
       ftp: 0.3.10
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /get-user-locale@1.5.1:
@@ -17211,8 +16962,6 @@ packages:
       node-fetch-native: 1.2.0
       pathe: 1.1.2
       tar: 6.1.13
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /github-from-package@0.0.0:
@@ -17400,7 +17149,6 @@ packages:
       lru-cache: 5.1.1
     transitivePeerDependencies:
       - encoding
-      - supports-color
     dev: true
 
   /google-p12-pem@2.0.2:
@@ -17423,7 +17171,6 @@ packages:
       uuid: 3.4.0
     transitivePeerDependencies:
       - encoding
-      - supports-color
     dev: true
 
   /googleapis@47.0.0:
@@ -17434,7 +17181,6 @@ packages:
       googleapis-common: 3.2.0
     transitivePeerDependencies:
       - encoding
-      - supports-color
     dev: true
 
   /gopd@1.0.1:
@@ -17697,7 +17443,6 @@ packages:
       mime: 2.6.0
     transitivePeerDependencies:
       - encoding
-      - supports-color
     dev: true
 
   /gunzip-maybe@1.4.2:
@@ -17982,8 +17727,6 @@ packages:
     engines: {node: '>=4.0.0'}
     dependencies:
       debug: 4.3.4
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /http-proxy-agent@4.0.1:
@@ -17993,8 +17736,6 @@ packages:
       '@tootallnate/once': 1.1.2
       agent-base: 6.0.2
       debug: 4.3.4
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /http-proxy-agent@5.0.0:
@@ -18004,8 +17745,6 @@ packages:
       '@tootallnate/once': 2.0.0
       agent-base: 6.0.2
       debug: 4.3.4
-    transitivePeerDependencies:
-      - supports-color
 
   /http-proxy-agent@7.0.0:
     resolution: {integrity: sha512-+ZT+iBxVUQ1asugqnD6oWoRiS25AkjNfG085dKJGtGxkdwLQrMKU5wJr2bOOFAXzKcTuqq+7fZlTMgG3SRfIYQ==}
@@ -18013,8 +17752,6 @@ packages:
     dependencies:
       agent-base: 7.1.0
       debug: 4.3.4
-    transitivePeerDependencies:
-      - supports-color
 
   /http-proxy-middleware@2.0.6(@types/express@4.17.11):
     resolution: {integrity: sha512-ya/UeJ6HVBYxrgYotAZo1KvPWlgB48kUJLDePFeneHsVujFaW5WNj2NgWCAE//B1Dl02BIfYlpNgBy8Kf8Rjmw==}
@@ -18031,8 +17768,6 @@ packages:
       is-glob: 4.0.3
       is-plain-obj: 3.0.0
       micromatch: 4.0.5
-    transitivePeerDependencies:
-      - debug
     dev: true
 
   /http-proxy@1.18.1:
@@ -18042,8 +17777,6 @@ packages:
       eventemitter3: 4.0.7
       follow-redirects: 1.15.1
       requires-port: 1.0.0
-    transitivePeerDependencies:
-      - debug
     dev: true
 
   /http-status-codes@2.1.4:
@@ -18067,9 +17800,7 @@ packages:
     engines: {node: '>= 4.5.0'}
     dependencies:
       agent-base: 4.3.0
-      debug: 3.2.7(supports-color@5.5.0)
-    transitivePeerDependencies:
-      - supports-color
+      debug: 3.2.7
     dev: true
 
   /https-proxy-agent@4.0.0:
@@ -18078,8 +17809,6 @@ packages:
     dependencies:
       agent-base: 5.1.1
       debug: 4.3.4
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /https-proxy-agent@5.0.1:
@@ -18088,8 +17817,6 @@ packages:
     dependencies:
       agent-base: 6.0.2
       debug: 4.3.4
-    transitivePeerDependencies:
-      - supports-color
 
   /https-proxy-agent@7.0.2:
     resolution: {integrity: sha512-NmLNjm6ucYwtcUmL7JQC1ZQ57LmHP4lT15FQ8D61nak1rO6DH+fz5qNK2Ap5UN4ZapYICE3/0KodcLYSPsPbaA==}
@@ -18097,8 +17824,6 @@ packages:
     dependencies:
       agent-base: 7.1.0
       debug: 4.3.4
-    transitivePeerDependencies:
-      - supports-color
 
   /human-signals@2.1.0:
     resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
@@ -18754,8 +18479,6 @@ packages:
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.0
       semver: 6.3.1
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /istanbul-lib-report@3.0.0:
@@ -19068,8 +18791,6 @@ packages:
       recast: 0.21.5
       temp: 0.8.4
       write-file-atomic: 2.4.3
-    transitivePeerDependencies:
-      - supports-color
 
   /jscodeshift@0.15.2(@babel/preset-env@7.24.3):
     resolution: {integrity: sha512-FquR7Okgmc4Sd0aEDwqho3rEiKR3BdvuG9jfdHjLJ6JQoWSMpavug3AoIfnfWhxFlf+5pzQh8qjqz0DWFrNQzA==}
@@ -19101,8 +18822,6 @@ packages:
       recast: 0.23.6
       temp: 0.8.4
       write-file-atomic: 2.4.3
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /jsdoc-type-pratt-parser@4.0.0:
@@ -19142,7 +18861,6 @@ packages:
       xml-name-validator: 5.0.0
     transitivePeerDependencies:
       - bufferutil
-      - supports-color
       - utf-8-validate
 
   /jsesc@0.5.0:
@@ -19442,8 +19160,6 @@ packages:
       superagent: 7.1.6
       superagent-proxy: 3.0.0(superagent@7.1.6)
       urljoin: 0.1.5
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /license-checker@25.0.1:
@@ -19451,7 +19167,7 @@ packages:
     hasBin: true
     dependencies:
       chalk: 2.4.2
-      debug: 3.2.7(supports-color@5.5.0)
+      debug: 3.2.7
       mkdirp: 0.5.6
       nopt: 4.0.3
       read-installed: 4.0.3
@@ -19460,8 +19176,6 @@ packages:
       spdx-expression-parse: 3.0.1
       spdx-satisfies: 4.0.1
       treeify: 1.1.0
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /lie@3.3.0:
@@ -19475,8 +19189,6 @@ packages:
     dependencies:
       debug: 2.6.9
       marky: 1.2.5
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /lilconfig@2.0.6:
@@ -19986,8 +19698,6 @@ packages:
       micromark-util-types: 1.1.0
       unist-util-stringify-position: 3.0.3
       uvu: 0.5.6
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /mdast-util-to-string@1.1.0:
@@ -20122,8 +19832,6 @@ packages:
       ts-dedent: 2.2.0
       uuid: 9.0.0
       web-worker: 1.3.0
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /meros@1.2.1(@types/node@20.8.0):
@@ -20153,8 +19861,6 @@ packages:
       '@babel/core': 7.24.0
       hermes-parser: 0.19.1
       nullthrows: 1.1.1
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /metro-cache-key@0.80.6:
@@ -20184,7 +19890,6 @@ packages:
     transitivePeerDependencies:
       - bufferutil
       - encoding
-      - supports-color
       - utf-8-validate
     dev: false
 
@@ -20212,8 +19917,6 @@ packages:
       walker: 1.0.8
     optionalDependencies:
       fsevents: 2.3.3
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /metro-minify-terser@0.80.6:
@@ -20247,8 +19950,6 @@ packages:
       ob1: 0.80.6
       source-map: 0.5.7
       vlq: 1.0.1
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /metro-symbolicate@0.80.6:
@@ -20262,8 +19963,6 @@ packages:
       source-map: 0.5.7
       through2: 2.0.5
       vlq: 1.0.1
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /metro-transform-plugins@0.80.6:
@@ -20275,8 +19974,6 @@ packages:
       '@babel/template': 7.24.0
       '@babel/traverse': 7.24.0
       nullthrows: 1.1.1
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /metro-transform-worker@0.80.6:
@@ -20298,7 +19995,6 @@ packages:
     transitivePeerDependencies:
       - bufferutil
       - encoding
-      - supports-color
       - utf-8-validate
     dev: false
 
@@ -20353,7 +20049,6 @@ packages:
     transitivePeerDependencies:
       - bufferutil
       - encoding
-      - supports-color
       - utf-8-validate
     dev: false
 
@@ -20528,8 +20223,6 @@ packages:
       micromark-util-symbol: 1.1.0
       micromark-util-types: 1.1.0
       uvu: 0.5.6
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /micromatch@4.0.5:
@@ -20694,7 +20387,7 @@ packages:
       ansi-colors: 4.1.1
       browser-stdout: 1.3.1
       chokidar: 3.5.1
-      debug: 4.3.1(supports-color@8.1.1)
+      debug: 4.3.1
       diff: 5.0.0
       escape-string-regexp: 4.0.0
       find-up: 5.0.0
@@ -20772,8 +20465,6 @@ packages:
       depd: 2.0.0
       on-finished: 2.3.0
       on-headers: 1.0.2
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /mri@1.2.0:
@@ -20836,7 +20527,6 @@ packages:
       yargs: 17.7.2
     transitivePeerDependencies:
       - encoding
-      - supports-color
     dev: true
 
   /mute-stream@0.0.8:
@@ -20847,6 +20537,7 @@ packages:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
     dependencies:
       any-promise: 1.3.0
+      graceful-fs: 4.2.11
       object-assign: 4.1.1
       thenify-all: 1.6.0
     dev: true
@@ -21003,7 +20694,7 @@ packages:
     hasBin: true
     dependencies:
       chokidar: 3.6.0
-      debug: 3.2.7(supports-color@5.5.0)
+      debug: 3.2.7
       ignore-by-default: 1.0.1
       minimatch: 3.1.2
       pstree.remy: 1.1.8
@@ -21532,8 +21223,6 @@ packages:
       pac-resolver: 5.0.1
       raw-body: 2.5.1
       socks-proxy-agent: 5.0.1
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /pac-resolver@5.0.1:
@@ -22311,8 +22000,6 @@ packages:
       pac-proxy-agent: 5.0.0
       proxy-from-env: 1.1.0
       socks-proxy-agent: 5.0.1
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /proxy-from-env@1.1.0:
@@ -22374,7 +22061,6 @@ packages:
       ws: 6.2.2
     transitivePeerDependencies:
       - bufferutil
-      - supports-color
       - utf-8-validate
     dev: true
 
@@ -22399,7 +22085,6 @@ packages:
     transitivePeerDependencies:
       - bufferutil
       - encoding
-      - supports-color
       - utf-8-validate
     dev: true
 
@@ -22572,8 +22257,6 @@ packages:
       node-dir: 0.1.17
       resolve: 1.22.8
       strip-indent: 3.0.0
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /react-dom@18.1.0(react@18.1.0):
@@ -22759,7 +22442,6 @@ packages:
       - '@babel/preset-env'
       - bufferutil
       - encoding
-      - supports-color
       - utf-8-validate
     dev: false
 
@@ -23419,8 +23101,6 @@ packages:
       debug: 4.3.4
       module-details-from-path: 1.0.3
       resolve: 1.22.8
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /require-main-filename@1.0.1:
@@ -23631,8 +23311,6 @@ packages:
       chalk: 4.1.2
       glob: 7.1.6
       prompts: 2.3.2
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /rxjs@6.6.7:
@@ -23788,8 +23466,6 @@ packages:
       on-finished: 2.4.1
       range-parser: 1.2.1
       statuses: 2.0.1
-    transitivePeerDependencies:
-      - supports-color
 
   /sentence-case@3.0.4:
     resolution: {integrity: sha512-8LS0JInaQMCRoQ7YUytAo/xUu5W2XnQxV2HI/6uM6U7CITS1RqPElr30V6uIqyMKM9lJGRVFy5/4CuzcixNYSg==}
@@ -23824,8 +23500,6 @@ packages:
       escape-html: 1.0.3
       parseurl: 1.3.3
       send: 0.18.0
-    transitivePeerDependencies:
-      - supports-color
 
   /set-blocking@2.0.0:
     resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
@@ -24100,8 +23774,6 @@ packages:
       agent-base: 6.0.2
       debug: 4.3.4
       socks: 2.7.0
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /socks@2.7.0:
@@ -24329,7 +24001,6 @@ packages:
       - encoding
       - react
       - react-dom
-      - supports-color
       - utf-8-validate
     dev: true
 
@@ -24695,8 +24366,6 @@ packages:
       table: 6.8.0
       v8-compile-cache: 2.3.0
       write-file-atomic: 4.0.2
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /stylis@4.3.2:
@@ -24716,8 +24385,6 @@ packages:
       debug: 4.3.4
       proxy-agent: 5.0.0
       superagent: 7.1.6
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /superagent@7.1.6:
@@ -24736,8 +24403,6 @@ packages:
       qs: 6.12.0
       readable-stream: 3.6.2
       semver: 7.6.0
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /supports-color@2.0.0:
@@ -24904,8 +24569,6 @@ packages:
       eslint: 8.4.1
       espree: 9.2.0
       htmlparser2-svelte: 4.1.0
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /svg-tags@1.0.0:
@@ -25784,8 +25447,6 @@ packages:
       kolorist: 1.8.0
       local-pkg: 0.5.0
       unplugin: 1.10.1
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /unplugin@1.0.1:
@@ -26078,7 +25739,6 @@ packages:
       - sass
       - stylus
       - sugarss
-      - supports-color
       - terser
     dev: true
 
@@ -26099,7 +25759,6 @@ packages:
       - sass
       - stylus
       - sugarss
-      - supports-color
       - terser
 
   /vite-plugin-inspect@0.7.35(vite@5.1.5):
@@ -26122,7 +25781,6 @@ packages:
       vite: 5.1.5(@types/node@20.8.0)(sass@1.32.4)
     transitivePeerDependencies:
       - rollup
-      - supports-color
     dev: true
 
   /vite-plugin-turbosnap@1.0.3:
@@ -26280,7 +25938,6 @@ packages:
       - sass
       - stylus
       - sugarss
-      - supports-color
       - terser
     dev: true
 
@@ -26338,7 +25995,6 @@ packages:
       - sass
       - stylus
       - sugarss
-      - supports-color
       - terser
 
   /vlq@1.0.1:

--- a/third_party/rules_esbuild/BUILD.bazel
+++ b/third_party/rules_esbuild/BUILD.bazel
@@ -1,0 +1,1 @@
+exports_files(glob(["**"]))

--- a/third_party/rules_esbuild/sandbox-plugin-fixes.patch
+++ b/third_party/rules_esbuild/sandbox-plugin-fixes.patch
@@ -1,0 +1,47 @@
+diff --git a/esbuild/private/plugins/bazel-sandbox.js b/esbuild/private/plugins/bazel-sandbox.js
+index c58b668..0ba6cff 100644
+--- a/esbuild/private/plugins/bazel-sandbox.js
++++ b/esbuild/private/plugins/bazel-sandbox.js
+@@ -24,7 +24,15 @@ function bazelSandboxPlugin() {
+           }
+           otherOptions.pluginData.executedSandboxPlugin = true
+
+-          return await resolveInExecroot(build, importPath, otherOptions)
++          const res = await resolveInExecroot(build, importPath, otherOptions)
++          // Needed due to an issue with esbuild when it comes to plguins + `"browser": false` in package.json
++          // that manifests with object-inspect package.
++          // https://github.com/evanw/esbuild/issues/2970
++          // https://github.com/evanw/esbuild/issues/2123
++          if (res.path.endsWith('util.inspect')) {
++            res.path = res.path + ".js"
++          }
++          return res
+         }
+       )
+     },
+@@ -48,8 +56,25 @@ async function resolveInExecroot(build, importPath, otherOptions) {
+     return result
+   }
+
++  return correctImportPath(result, otherOptions, false)
++}
++
++function correctImportPath(result, otherOptions, firstEntry) {
+   // If esbuild attempts to leave the execroot, map the path back into the execroot.
+   if (!result.path.startsWith(execroot)) {
++    // A relative path that is marked as external. If it was not marked as external, it would error in the build.resolve call.
++    // We need to make it an absolute path from its importer and then re-attempt correcting it to be within the execroot.
++    if (result.path.startsWith("..")) {
++      const absPath = path.resolve(otherOptions.importer, result.path)
++      if (!!process.env.JS_BINARY__LOG_DEBUG) {
++        console.error(
++          `DEBUG: [bazel-sandbox] relative & external path found ${result.path}, making absolute relative to its importer ${otherOptions.importer} and then reattempting making it relative to the execroot (${execroot}): ${absPath}`
++        )
++      }
++      result.path = absPath
++      return correctImportPath(result, otherOptions, true)
++    }
++
+     // If it tried to leave bazel-bin, error out completely.
+     if (!result.path.includes(bindir)) {
+       throw new Error(


### PR DESCRIPTION
Sandbox escapes be-gone

## Test plan

Tested in CI and locally with `bazel build //client/...` as well as a lot of blood, sweat n tears tearing through failed sandboxes

## Changelog