### PR TITLE
Fixup update metadata for several packages

### DIFF
--- a/wolfi-packages/ctags.yaml
+++ b/wolfi-packages/ctags.yaml
@@ -4,7 +4,7 @@
 package:
   name: ctags
   version: 6.0.0
-  epoch: 5
+  epoch: 6
   description: "A maintained ctags implementation"
   target-architecture:
     - x86_64
@@ -52,4 +52,4 @@ update:
   enabled: true
   github:
     identifier: universal-ctags/ctags
-    strip-prefix: "Universal Ctags "
+    strip-prefix: "v"

--- a/wolfi-packages/jaeger.yaml
+++ b/wolfi-packages/jaeger.yaml
@@ -4,7 +4,7 @@
 package:
   name: jaeger
   version: 1.45.0 # Keep in sync with version in sg.config.yaml
-  epoch: 7
+  epoch: 8
   description: "Distributed Tracing Platform"
   target-architecture:
     - x86_64
@@ -58,4 +58,4 @@ update:
   enabled: true
   github:
     identifier: jaegertracing/jaeger
-    strip-prefix: "Release "
+    strip-prefix: "v"

--- a/wolfi-packages/opentelemetry-collector.yaml
+++ b/wolfi-packages/opentelemetry-collector.yaml
@@ -1,7 +1,7 @@
 package:
   name: opentelemetry-collector
   version: 0.92.0 # Keep in sync with go.opentelemetry.io/collector version in go.mod
-  epoch: 6
+  epoch: 7
   description: "Vendor-agnostic implementation on how to receive, process and export telemetry data"
   target-architecture:
     - x86_64
@@ -50,4 +50,4 @@ update:
   enabled: true
   github:
     identifier: open-telemetry/opentelemetry-collector
-    strip-prefix: "v"
+    strip-prefix: "cmd/builder/v" # This may break as otel release tags have a lot of variation

--- a/wolfi-packages/p4-fusion.yaml
+++ b/wolfi-packages/p4-fusion.yaml
@@ -3,7 +3,7 @@
 package:
   name: p4-fusion
   version: 1.12
-  epoch: 10
+  epoch: 11
   description: "A fast Perforce to Git conversion tool"
   target-architecture:
     - x86_64
@@ -89,4 +89,4 @@ update:
   enabled: true
   github:
     identifier: salesforce/p4-fusion
-    strip-prefix: "p4-fusion v"
+    strip-prefix: "v"


### PR DESCRIPTION
The update metadata for several packages needs to be tweaked to work with the wolfictl automation. These `strip-prefix` fields now match the tag formats for the upstream repos.

Tracking issue: https://github.com/sourcegraph/security/issues/1411

## Test plan

- CI
- Manually testing `wolfictl` locally - this will run in GitHub actions soon

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
