### PR TITLE
gomod: bump Zoekt for BM25 score fix

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -5431,8 +5431,8 @@ def go_dependencies():
         patches = [
             "//third_party/com_github_sourcegraph_zoekt:x_defs_version.patch",
         ],
-        sum = "h1:tMqptvT8zd2xD1Yl11zDd42fBHxlT40zJoPU+Vl8REI=",
-        version = "v0.0.0-20240402071238-c39011a14191",
+        sum = "h1:3DJmyiTtoczytYdvoBqwawkSRZEGZeZB9v0DjfQ6irY=",
+        version = "v0.0.0-20240417165306-43b92256ba71",
     )
     go_repository(
         name = "com_github_spaolacci_murmur3",

--- a/go.mod
+++ b/go.mod
@@ -588,7 +588,7 @@ require (
 	github.com/scim2/filter-parser/v2 v2.2.0
 	github.com/sourcegraph/conc v0.3.1-0.20240108182409-4afefce20f9b
 	github.com/sourcegraph/mountinfo v0.0.0-20240201124957-b314c0befab1
-	github.com/sourcegraph/zoekt v0.0.0-20240402071238-c39011a14191
+	github.com/sourcegraph/zoekt v0.0.0-20240417165306-43b92256ba71
 	github.com/spf13/cobra v1.8.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1700,8 +1700,8 @@ github.com/sourcegraph/sourcegraph-accounts-sdk-go v0.0.0-20240401190202-87f6c28
 github.com/sourcegraph/sourcegraph-accounts-sdk-go v0.0.0-20240401190202-87f6c282658b/go.mod h1:84opHsgiuXnmBcCTSemIHyHAbyRj8JDtGrOZypMEB/g=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152 h1:z/MpntplPaW6QW95pzcAR/72Z5TWDyDnSo0EOcyij9o=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152/go.mod h1:GIjDIg/heH5DOkXY3YJ/wNhfHsQHoXGjl8G8amsYQ1I=
-github.com/sourcegraph/zoekt v0.0.0-20240402071238-c39011a14191 h1:tMqptvT8zd2xD1Yl11zDd42fBHxlT40zJoPU+Vl8REI=
-github.com/sourcegraph/zoekt v0.0.0-20240402071238-c39011a14191/go.mod h1:+j+huwz4ZnffJmDHeLJyI9AY4a8DKQnfNV0J//upnyo=
+github.com/sourcegraph/zoekt v0.0.0-20240417165306-43b92256ba71 h1:3DJmyiTtoczytYdvoBqwawkSRZEGZeZB9v0DjfQ6irY=
+github.com/sourcegraph/zoekt v0.0.0-20240417165306-43b92256ba71/go.mod h1:+j+huwz4ZnffJmDHeLJyI9AY4a8DKQnfNV0J//upnyo=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v0.0.0-20170901052352-ee1bd8ee15a1/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=


### PR DESCRIPTION
- https://github.com/sourcegraph/zoekt/commit/ab1b8f0919 Tests: disable global git configs
- https://github.com/sourcegraph/zoekt/commit/59ab9491e1 Ranking: tidy up scoring code
- https://github.com/sourcegraph/zoekt/commit/43b92256ba Ranking: include filename matches in bm25

## Test plan

Zoekt and Sourcegraph CI