### PR TITLE
Remove path verification for archive reader

### DIFF
--- a/cmd/gitserver/internal/git/gitcli/archivereader.go
+++ b/cmd/gitserver/internal/git/gitcli/archivereader.go
@@ -15,9 +15,11 @@ import (
 )
 
 func (g *gitCLIBackend) ArchiveReader(ctx context.Context, format git.ArchiveFormat, treeish string, paths []string) (io.ReadCloser, error) {
-	if err := g.verifyPaths(ctx, treeish, paths); err != nil {
-		return nil, err
-	}
+	// TODO(pjlast): temporary removal of path verification because it has edge
+	// cases that we're not handling correctly.
+	// if err := g.verifyPaths(ctx, treeish, paths); err != nil {
+	// 	return nil, err
+	// }
 
 	archiveArgs := buildArchiveArgs(format, treeish, paths)
 

--- a/cmd/gitserver/internal/git/gitcli/archivereader_test.go
+++ b/cmd/gitserver/internal/git/gitcli/archivereader_test.go
@@ -6,13 +6,11 @@ import (
 	"bytes"
 	"context"
 	"io"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/sourcegraph/sourcegraph/cmd/gitserver/internal/git"
-	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
@@ -153,29 +151,31 @@ func TestGitCLIBackend_ArchiveReader(t *testing.T) {
 		require.Equal(t, "qrst\n", contents)
 	})
 
-	t.Run("non existent commit", func(t *testing.T) {
-		_, err := backend.ArchiveReader(ctx, "tar", "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef", nil)
-		require.Error(t, err)
-		require.True(t, errors.HasType(err, &gitdomain.RevisionNotFoundError{}))
-	})
+	// TODO(pjlast): temporary removal of path verification because it has edge
+	// cases that we're not handling correctly.
+	// t.Run("non existent commit", func(t *testing.T) {
+	// 	_, err := backend.ArchiveReader(ctx, "tar", "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef", nil)
+	// 	require.Error(t, err)
+	// 	require.True(t, errors.HasType(err, &gitdomain.RevisionNotFoundError{}))
+	// })
 
-	t.Run("non existent ref", func(t *testing.T) {
-		_, err := backend.ArchiveReader(ctx, "tar", "head-2", nil)
-		require.Error(t, err)
-		require.True(t, errors.HasType(err, &gitdomain.RevisionNotFoundError{}))
-	})
+	// t.Run("non existent ref", func(t *testing.T) {
+	// 	_, err := backend.ArchiveReader(ctx, "tar", "head-2", nil)
+	// 	require.Error(t, err)
+	// 	require.True(t, errors.HasType(err, &gitdomain.RevisionNotFoundError{}))
+	// })
 
-	t.Run("non existent file", func(t *testing.T) {
-		_, err := backend.ArchiveReader(ctx, "tar", string(commitID), []string{"no-file"})
-		require.Error(t, err)
-		require.True(t, os.IsNotExist(err))
-	})
+	// t.Run("non existent file", func(t *testing.T) {
+	// 	_, err := backend.ArchiveReader(ctx, "tar", string(commitID), []string{"no-file"})
+	// 	require.Error(t, err)
+	// 	require.True(t, os.IsNotExist(err))
+	// })
 
-	t.Run("invalid path pattern", func(t *testing.T) {
-		_, err := backend.ArchiveReader(ctx, "tar", string(commitID), []string{"dir1/*"})
-		require.Error(t, err)
-		require.True(t, os.IsNotExist(err))
-	})
+	// t.Run("invalid path pattern", func(t *testing.T) {
+	// 	_, err := backend.ArchiveReader(ctx, "tar", string(commitID), []string{"dir1/*"})
+	// 	require.Error(t, err)
+	// 	require.True(t, os.IsNotExist(err))
+	// })
 
 	// Verify that if the context is canceled, the reader returns an error.
 	t.Run("context cancelation", func(t *testing.T) {


### PR DESCRIPTION
Removes path verification for ArchiveReader calls since there are edge cases that we're not handling correctly.

## Test plan

Manual tests that `src batch preview` works now.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
