### PR TITLE
gitserver: Completely remove Archive path validation

### DIFF
--- a/cmd/gitserver/internal/git/gitcli/BUILD.bazel
+++ b/cmd/gitserver/internal/git/gitcli/BUILD.bazel
@@ -29,8 +29,6 @@ go_library(
         "//cmd/gitserver/internal/git",
         "//internal/actor",
         "//internal/api",
-        "//internal/byteutils",
-        "//internal/collections",
         "//internal/conf",
         "//internal/gitserver/gitdomain",
         "//internal/honey",

--- a/cmd/gitserver/internal/git/gitcli/archivereader.go
+++ b/cmd/gitserver/internal/git/gitcli/archivereader.go
@@ -1,25 +1,18 @@
 package gitcli
 
 import (
-	"bufio"
-	"bytes"
 	"context"
 	"io"
-	"os"
 
 	"github.com/sourcegraph/sourcegraph/cmd/gitserver/internal/git"
-	"github.com/sourcegraph/sourcegraph/internal/byteutils"
-	"github.com/sourcegraph/sourcegraph/internal/collections"
-	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
-	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 func (g *gitCLIBackend) ArchiveReader(ctx context.Context, format git.ArchiveFormat, treeish string, paths []string) (io.ReadCloser, error) {
-	// TODO(pjlast): temporary removal of path verification because it has edge
-	// cases that we're not handling correctly.
-	// if err := g.verifyPaths(ctx, treeish, paths); err != nil {
-	// 	return nil, err
-	// }
+	// Verify the tree-ish exists, if it doesn't this will return a RevisionNotFoundError:
+	_, err := g.getObjectType(ctx, treeish)
+	if err != nil {
+		return nil, err
+	}
 
 	archiveArgs := buildArchiveArgs(format, treeish, paths)
 
@@ -46,53 +39,3 @@ func buildArchiveArgs(format git.ArchiveFormat, treeish string, paths []string) 
 //
 // See: https://git-scm.com/docs/gitglossary#Documentation/gitglossary.txt-literal
 func pathspecLiteral(s string) string { return ":(literal)" + s }
-
-func (g *gitCLIBackend) verifyPaths(ctx context.Context, treeish string, paths []string) error {
-	args := []string{"ls-tree", "-z", "--name-only", treeish, "--"}
-	for _, p := range paths {
-		args = append(args, pathspecLiteral(p))
-	}
-	r, err := g.NewCommand(ctx, WithArguments(args...))
-	if err != nil {
-		return err
-	}
-	defer r.Close()
-
-	scanner := bufio.NewScanner(r)
-	scanner.Split(byteutils.ScanNullLines)
-	fileSet := make(collections.Set[string], len(paths))
-	for scanner.Scan() {
-		fileSet.Add(scanner.Text())
-	}
-	err = scanner.Err()
-	if err != nil {
-		// If exit code is 128 and `not a tree object` is part of stderr, most likely we
-		// are referencing a commit that does not exist.
-		// We want to return a gitdomain.RevisionNotFoundError in that case.
-		var e *CommandFailedError
-		if errors.As(err, &e) && e.ExitStatus == 128 && (bytes.Contains(e.Stderr, []byte("not a tree object")) || bytes.Contains(e.Stderr, []byte("Not a valid object name"))) {
-			return &gitdomain.RevisionNotFoundError{Repo: g.repoName, Spec: treeish}
-		}
-
-		return err
-	}
-
-	// Check if the resulting objects match the requested
-	// paths. If not, one or more of the requested
-	// file paths don't exist.
-
-	if len(paths) == 0 {
-		return nil
-	}
-
-	pathsSet := make(collections.Set[string], len(paths))
-	pathsSet.Add(paths...)
-
-	diff := pathsSet.Difference(fileSet)
-
-	if len(diff) != 0 {
-		return &os.PathError{Op: "open", Path: diff.Values()[0], Err: os.ErrNotExist}
-	}
-
-	return nil
-}

--- a/cmd/gitserver/internal/git/gitcli/archivereader_test.go
+++ b/cmd/gitserver/internal/git/gitcli/archivereader_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/sourcegraph/sourcegraph/cmd/gitserver/internal/git"
+	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
@@ -151,31 +152,17 @@ func TestGitCLIBackend_ArchiveReader(t *testing.T) {
 		require.Equal(t, "qrst\n", contents)
 	})
 
-	// TODO(pjlast): temporary removal of path verification because it has edge
-	// cases that we're not handling correctly.
-	// t.Run("non existent commit", func(t *testing.T) {
-	// 	_, err := backend.ArchiveReader(ctx, "tar", "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef", nil)
-	// 	require.Error(t, err)
-	// 	require.True(t, errors.HasType(err, &gitdomain.RevisionNotFoundError{}))
-	// })
+	t.Run("non existent commit", func(t *testing.T) {
+		_, err := backend.ArchiveReader(ctx, "tar", "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef", nil)
+		require.Error(t, err)
+		require.True(t, errors.HasType(err, &gitdomain.RevisionNotFoundError{}))
+	})
 
-	// t.Run("non existent ref", func(t *testing.T) {
-	// 	_, err := backend.ArchiveReader(ctx, "tar", "head-2", nil)
-	// 	require.Error(t, err)
-	// 	require.True(t, errors.HasType(err, &gitdomain.RevisionNotFoundError{}))
-	// })
-
-	// t.Run("non existent file", func(t *testing.T) {
-	// 	_, err := backend.ArchiveReader(ctx, "tar", string(commitID), []string{"no-file"})
-	// 	require.Error(t, err)
-	// 	require.True(t, os.IsNotExist(err))
-	// })
-
-	// t.Run("invalid path pattern", func(t *testing.T) {
-	// 	_, err := backend.ArchiveReader(ctx, "tar", string(commitID), []string{"dir1/*"})
-	// 	require.Error(t, err)
-	// 	require.True(t, os.IsNotExist(err))
-	// })
+	t.Run("non existent ref", func(t *testing.T) {
+		_, err := backend.ArchiveReader(ctx, "tar", "head-2", nil)
+		require.Error(t, err)
+		require.True(t, errors.HasType(err, &gitdomain.RevisionNotFoundError{}))
+	})
 
 	// Verify that if the context is canceled, the reader returns an error.
 	t.Run("context cancelation", func(t *testing.T) {

--- a/cmd/gitserver/internal/git/iface.go
+++ b/cmd/gitserver/internal/git/iface.go
@@ -53,7 +53,6 @@ type GitBackend interface {
 	// paths to include in the archive. If empty, all paths are included.
 	//
 	// If the commit does not exist, a RevisionNotFoundError is returned.
-	// If any path does not exist, a os.PathError is returned.
 	ArchiveReader(ctx context.Context, format ArchiveFormat, treeish string, paths []string) (io.ReadCloser, error)
 	// ResolveRevision resolves the given revspec to a commit ID.
 	// I.e., HEAD, deadbeefdeadbeefdeadbeefdeadbeef, or refs/heads/main.

--- a/cmd/gitserver/internal/server_grpc.go
+++ b/cmd/gitserver/internal/server_grpc.go
@@ -291,25 +291,6 @@ func (gs *grpcServer) Archive(req *proto.ArchiveRequest, ss proto.GitserverServi
 
 	r, err := backend.ArchiveReader(ctx, format, req.GetTreeish(), byteSlicesToStrings(req.GetPaths()))
 	if err != nil {
-		if os.IsNotExist(err) {
-			var path string
-			var pathError *os.PathError
-			if errors.As(err, &pathError) {
-				path = pathError.Path
-			}
-			s, err := status.New(codes.NotFound, "file not found").WithDetails(&proto.FileNotFoundPayload{
-				Repo: string(repoName),
-				// TODO: I'm not sure this should be allowed, a treeish is not necessarily
-				// a commit.
-				Commit: string(req.GetTreeish()),
-				Path:   path,
-			})
-			if err != nil {
-				return err
-			}
-			return s.Err()
-		}
-
 		var e *gitdomain.RevisionNotFoundError
 		if errors.As(err, &e) {
 			s, err := status.New(codes.NotFound, "revision not found").WithDetails(&proto.RevisionNotFoundPayload{

--- a/cmd/gitserver/internal/server_grpc_test.go
+++ b/cmd/gitserver/internal/server_grpc_test.go
@@ -582,22 +582,9 @@ func TestGRPCServer_Archive(t *testing.T) {
 			}
 		}
 
-		// Invalid file path.
-		b.ArchiveReaderFunc.SetDefaultReturn(nil, os.ErrNotExist)
-		cc, err := cli.Archive(context.Background(), &v1.ArchiveRequest{
-			Repo:    "therepo",
-			Treeish: "HEAD",
-			Format:  proto.ArchiveFormat_ARCHIVE_FORMAT_ZIP,
-		})
-		require.NoError(t, err)
-		_, err = cc.Recv()
-		require.Error(t, err)
-		assertGRPCStatusCode(t, err, codes.NotFound)
-		assertHasGRPCErrorDetailOfType(t, err, &proto.FileNotFoundPayload{})
-
 		// TODO: Do we return this?
 		b.ArchiveReaderFunc.SetDefaultReturn(nil, &gitdomain.RevisionNotFoundError{})
-		cc, err = cli.Archive(context.Background(), &v1.ArchiveRequest{
+		cc, err := cli.Archive(context.Background(), &v1.ArchiveRequest{
 			Repo:    "therepo",
 			Treeish: "HEAD",
 			Format:  proto.ArchiveFormat_ARCHIVE_FORMAT_ZIP,

--- a/internal/gitserver/commands.go
+++ b/internal/gitserver/commands.go
@@ -1877,20 +1877,6 @@ func (c *clientImplementor) ArchiveReader(ctx context.Context, repo api.RepoName
 	// ie. revision not found errors or invalid git command.
 	firstMessage, firstErr := cli.Recv()
 	if firstErr != nil {
-		if s, ok := status.FromError(firstErr); ok {
-			if s.Code() == codes.NotFound {
-				for _, d := range s.Details() {
-					switch d.(type) {
-					case *proto.FileNotFoundPayload:
-						cancel()
-						err = firstErr
-						endObservation(1, observation.Args{})
-						// We don't have a specific path here, so we return ErrNotExist instead of PathError.
-						return nil, os.ErrNotExist
-					}
-				}
-			}
-		}
 		if errors.HasType(firstErr, &gitdomain.RevisionNotFoundError{}) {
 			cancel()
 			err = firstErr

--- a/internal/gitserver/commands_test.go
+++ b/internal/gitserver/commands_test.go
@@ -1827,25 +1827,6 @@ func TestClient_ArchiveReader(t *testing.T) {
 		require.NoError(t, r.Close())
 		require.Equal(t, "", string(content))
 	})
-	t.Run("file not found errors are returned early", func(t *testing.T) {
-		source := NewTestClientSource(t, []string{"gitserver"}, func(o *TestClientSourceOptions) {
-			o.ClientFunc = func(cc *grpc.ClientConn) proto.GitserverServiceClient {
-				c := NewMockGitserverServiceClient()
-				rfc := NewMockGitserverService_ArchiveClient()
-				s, err := status.New(codes.NotFound, "not found").WithDetails(&proto.FileNotFoundPayload{})
-				require.NoError(t, err)
-				rfc.RecvFunc.PushReturn(nil, s.Err())
-				c.ArchiveFunc.SetDefaultReturn(rfc, nil)
-				return c
-			}
-		})
-
-		c := NewTestClient(t).WithClientSource(source)
-
-		_, err := c.ArchiveReader(context.Background(), "repo", ArchiveOptions{Treeish: "deadbeef", Format: ArchiveFormatTar, Paths: []string{"file"}})
-		require.Error(t, err)
-		require.True(t, os.IsNotExist(err))
-	})
 	t.Run("revision not found errors are returned early", func(t *testing.T) {
 		source := NewTestClientSource(t, []string{"gitserver"}, func(o *TestClientSourceOptions) {
 			o.ClientFunc = func(cc *grpc.ClientConn) proto.GitserverServiceClient {

--- a/internal/gitserver/v1/gitserver.proto
+++ b/internal/gitserver/v1/gitserver.proto
@@ -33,8 +33,8 @@ service GitserverService {
   // currently not filter parts of the archive, so this would be considered
   // leaking information.
   //
-  // If the given treeish does not exist, an error with a
-  // RevisionNotFoundPayload is returned.
+  // If the given treeish does not exist, an error with a RevisionNotFoundPayload
+  // is returned.
   //
   // If the given repo is not cloned, it will be enqueued for cloning and a
   // NotFound error will be returned, with a RepoNotFoundPayload in the details.


### PR DESCRIPTION
This didn't add a ton of benefits as the response will just be an empty archive and no error, but broke some callers of this, so we decided to remove it entirely.

Test plan:

Existing tests pass, adjusted tests to no longer account for the not found case.
