### PR TITLE
Revert "[backport] Redirect to sign-in provider when there is only one (#61919)"

### DIFF
--- a/client/web/src/auth/SignInPage.tsx
+++ b/client/web/src/auth/SignInPage.tsx
@@ -91,15 +91,9 @@ export const SignInPage: React.FunctionComponent<React.PropsWithChildren<SignInP
     }
 
     const thirdPartyAuthProviders = nonBuiltinAuthProviders.filter(provider => shouldShowProvider(provider))
-    // If there is only one auth provider that is going to be displayed, we want to redirect to it directly.
-    if (thirdPartyAuthProviders.length === 1 && !builtInAuthProvider) {
-        // Add '?returnTo=' + encodeURIComponent(returnTo) to thirdPartyAuthProviders[0].authenticationURL in a safe way.
-        const redirectUrl = new URL(thirdPartyAuthProviders[0].authenticationURL, window.location.href)
-        if (returnTo) {
-            redirectUrl.searchParams.set('returnTo', new URL(returnTo, window.location.href).toString())
-        }
-        window.location.replace(redirectUrl)
-
+    // If there is only one auth provider that is going to be displayed on dotcom, we want to redirect to it directly.
+    if (context.sourcegraphDotComMode && thirdPartyAuthProviders.length === 1) {
+        window.location.replace(thirdPartyAuthProviders[0].authenticationURL)
         return (
             <>
                 <PageTitle title="Signing in..." />


### PR DESCRIPTION
Reverts sourcegraph/sourcegraph#61927 due to https://sourcegraph.slack.com/archives/C02E4HE42BX/p1713367559532589?thread_ts=1713361578.175539&cid=C02E4HE42BX