### PR TITLE
Cody: Remove preview from Mixtral8x22b Instruct model id

### DIFF
--- a/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/ModelBadges.tsx
+++ b/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/ModelBadges.tsx
@@ -61,7 +61,7 @@ function modelBadgeVariant(model: string, mode: 'completions' | 'embeddings'): '
             case 'fireworks/accounts/fireworks/models/llama-v2-34b-code-instruct':
             case 'fireworks/accounts/fireworks/models/mistral-7b-instruct-4k':
             case 'fireworks/accounts/fireworks/models/mixtral-8x7b-instruct':
-            case 'fireworks/accounts/fireworks/models/mixtral-8x22b-instruct-preview': {
+            case 'fireworks/accounts/fireworks/models/mixtral-8x22b-instruct': {
                 return 'secondary'
             }
             default: {

--- a/cmd/cody-gateway/shared/config/config.go
+++ b/cmd/cody-gateway/shared/config/config.go
@@ -234,7 +234,7 @@ func (c *Config) Load() {
 			"accounts/fireworks/models/llama-v2-34b-code-instruct",
 			"accounts/fireworks/models/mistral-7b-instruct-4k",
 			"accounts/fireworks/models/mixtral-8x7b-instruct",
-			"accounts/fireworks/models/mixtral-8x22b-instruct-preview",
+			"accounts/fireworks/models/mixtral-8x22b-instruct",
 			// Deprecated model strings
 			"accounts/fireworks/models/starcoder-3b-w8a16",
 			"accounts/fireworks/models/starcoder-1b-w8a16",

--- a/cmd/frontend/internal/dotcom/productsubscription/codygateway_dotcom_user.go
+++ b/cmd/frontend/internal/dotcom/productsubscription/codygateway_dotcom_user.go
@@ -365,7 +365,7 @@ func allowedModels(scope types.CompletionsFeature, isProUser bool) []string {
 			"anthropic/" + anthropic.Claude3Sonnet,
 			"anthropic/" + anthropic.Claude3Opus,
 			"fireworks/" + fireworks.Mixtral8x7bInstruct,
-			"fireworks/" + fireworks.Mixtral8x22InstructPreview,
+			"fireworks/" + fireworks.Mixtral8x22Instruct,
 			"openai/gpt-3.5-turbo",
 			"openai/gpt-4-turbo",
 			"openai/gpt-4-turbo-preview",

--- a/internal/completions/client/fireworks/fireworks.go
+++ b/internal/completions/client/fireworks/fireworks.go
@@ -30,7 +30,7 @@ const Llama213bCodeInstruct = "accounts/fireworks/models/llama-v2-13b-code-instr
 const Llama234bCodeInstruct = "accounts/fireworks/models/llama-v2-34b-code-instruct"
 const Mistral7bInstruct = "accounts/fireworks/models/mistral-7b-instruct-4k"
 const Mixtral8x7bInstruct = "accounts/fireworks/models/mixtral-8x7b-instruct"
-const Mixtral8x22InstructPreview = "accounts/fireworks/models/mixtral-8x22b-instruct-preview"
+const Mixtral8x22Instruct = "accounts/fireworks/models/mixtral-8x22b-instruct"
 
 func NewClient(cli httpcli.Doer, endpoint, accessToken string) types.CompletionsClient {
 	return &fireworksClient{

--- a/internal/completions/httpapi/chat.go
+++ b/internal/completions/httpapi/chat.go
@@ -80,7 +80,7 @@ func isAllowedCustomChatModel(model string, isProUser bool) bool {
 			"anthropic/" + anthropic.Claude3Sonnet,
 			"anthropic/" + anthropic.Claude3Opus,
 			"fireworks/" + fireworks.Mixtral8x7bInstruct,
-			"fireworks/" + fireworks.Mixtral8x22InstructPreview,
+			"fireworks/" + fireworks.Mixtral8x22Instruct,
 			"openai/gpt-3.5-turbo",
 			"openai/gpt-4-turbo",
 			"openai/gpt-4-turbo-preview",


### PR DESCRIPTION
CONTEXT: https://sourcegraph.slack.com/archives/C05MW2TMYAV/p1713390648511539

Update to remove the preview string from the Mixtral8x22b Instruct model ID, as that is no longer supported by fireworks.

On fireworks website:

![image](https://github.com/sourcegraph/sourcegraph/assets/68532117/3acab221-430b-4fda-bb43-f2346a898801)

Error returned by Cody Gateway:

![image](https://github.com/sourcegraph/sourcegraph/assets/68532117/19e8eb03-9eb7-443d-a453-1bdd5ac55ce2)

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->

Verify the model id matches: https://fireworks.ai/models/fireworks/mixtral-8x22b-instruct
Verify the old model id is no longer supported: https://fireworks.ai/models/fireworks/mixtral-8x22b-instruct-preview