### PR TITLE
ci: move git operations from ci config to it's own package

### DIFF
--- a/dev/ci/gitops/BUILD.bazel
+++ b/dev/ci/gitops/BUILD.bazel
@@ -1,0 +1,12 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "gitops",
+    srcs = ["git_ops.go"],
+    importpath = "github.com/sourcegraph/sourcegraph/dev/ci/gitops",
+    visibility = ["//dev/ci:__subpackages__"],
+    deps = [
+        "//internal/oobmigration",
+        "//lib/errors",
+    ],
+)

--- a/dev/ci/gitops/git_ops.go
+++ b/dev/ci/gitops/git_ops.go
@@ -1,0 +1,73 @@
+package gitops
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"github.com/sourcegraph/sourcegraph/internal/oobmigration"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+var ErrNoTags = errors.New("no tags found")
+
+func DetermineDiffArgs(baseBranch, commit string) (string, error) {
+	// We have a different base branch (possibily) and on aspect agents we are in a detached state with only 100 commit depth
+	// so we might not know about this base branch ... so we first fetch the base and then diff
+	//
+	// Determine the base branch
+	if baseBranch == "" {
+		// When the base branch is not set, then this is probably a build where a commit got merged
+		// onto the current branch. So we just diff with the current commit
+		return "@^", nil
+	}
+
+	// fetch the branch to make sure it exists
+	refspec := fmt.Sprintf("+refs/heads/%s:refs/remotes/origin/%s", baseBranch, baseBranch)
+	if _, err := exec.Command("git", "fetch", "origin", refspec).Output(); err != nil {
+		return "", errors.Newf("failed to fetch %s: %s", baseBranch, err)
+	} else {
+		return fmt.Sprintf("origin/%s...%s", baseBranch, commit), nil
+	}
+}
+
+func GetLatestTag() (string, error) {
+	output, err := exec.Command("git", "tag", "--list", "v*").CombinedOutput()
+	if err != nil {
+		return "", err
+	}
+
+	tagMap := map[string]struct{}{}
+	for _, tag := range strings.Split(string(output), "\n") {
+		if version, ok := oobmigration.NewVersionFromString(tag); ok {
+			tagMap[version.String()] = struct{}{}
+		}
+	}
+	if len(tagMap) == 0 {
+		return "", ErrNoTags
+	}
+
+	versions := make([]oobmigration.Version, 0, len(tagMap))
+	for tag := range tagMap {
+		version, _ := oobmigration.NewVersionFromString(tag)
+		versions = append(versions, version)
+	}
+	oobmigration.SortVersions(versions)
+
+	return versions[len(versions)-1].String(), nil
+}
+
+func HasIncludedCommit(included ...string) (bool, error) {
+	found := false
+	var errs error
+	for _, mustIncludeCommit := range included {
+		output, err := exec.Command("git", "merge-base", "--is-ancestor", mustIncludeCommit, "HEAD").CombinedOutput()
+		if err == nil {
+			found = true
+			break
+		}
+		errs = errors.Append(errs, errors.Errorf("%v | Output: %q", err, string(output)))
+	}
+
+	return found, errs
+}

--- a/dev/ci/internal/ci/BUILD.bazel
+++ b/dev/ci/internal/ci/BUILD.bazel
@@ -24,6 +24,7 @@ go_library(
     importpath = "github.com/sourcegraph/sourcegraph/dev/ci/internal/ci",
     visibility = ["//dev/ci:__subpackages__"],
     deps = [
+        "//dev/ci/gitops",
         "//dev/ci/images",
         "//dev/ci/internal/buildkite",
         "//dev/ci/internal/ci/changed",
@@ -31,7 +32,6 @@ go_library(
         "//dev/ci/runtype",
         "//dev/sg/root",
         "//internal/lazyregexp",
-        "//internal/oobmigration",
         "//lib/errors",
         "@com_github_grafana_regexp//:regexp",
         "@com_github_masterminds_semver//:semver",


### PR DESCRIPTION
I needed the code that determines the latestTag for use in a branchTag in `sg` and it felt like a waste to just reimplement it elsewhere.

So I moved the git operations that the config was doing to its own package that can be imported from somewhere else.

## Test plan
CI