### PR TITLE
chore(rel): also push promoted images on GAR

### DIFF
--- a/dev/ci/internal/ci/release_operations.go
+++ b/dev/ci/internal/ci/release_operations.go
@@ -21,6 +21,7 @@ func releasePromoteImages(c Config) operations.Operation {
 			bk.Env("VERSION", c.Version),
 			bk.Env("INTERNAL_REGISTRY", images.SourcegraphInternalReleaseRegistry),
 			bk.Env("PUBLIC_REGISTRY", images.SourcegraphDockerPublishRegistry),
+			bk.Env("ADDITIONAL_PROD_REGISTRY", images.SourcegraphArtifactRegistryPublicRegistry),
 			bk.AnnotatedCmd(
 				fmt.Sprintf("./tools/release/promote_images.sh %s", image_args),
 				bk.AnnotatedCmdOpts{

--- a/tools/release/promote_images.sh
+++ b/tools/release/promote_images.sh
@@ -15,11 +15,19 @@ fi
 echo -e "## Release: image promotions" > ./annotations/image_promotions.md
 echo -e "\n| Name | From | To |\n|---|---|---|" >> ./annotations/image_promotions.md
 for name in "${@:1}"; do
-  echo "--- Copying ${name} from private registry to public registry"
+  echo "--- Copying ${name} from private registry to public registries"
 
+  # Pull the internal release
   docker pull "${INTERNAL_REGISTRY}/${name}:${VERSION}"
+
+  # Push it on the classic public registry (DockerHub)
   docker tag "${INTERNAL_REGISTRY}/${name}:${VERSION}" "${PUBLIC_REGISTRY}/${name}:${VERSION}"
   docker push "${PUBLIC_REGISTRY}/${name}:${VERSION}"
 
-  echo -e "| ${name} | \`${INTERNAL_REGISTRY}/${name}:${VERSION}\` | \`${PUBLIC_REGISTRY}/${name}:${VERSION}\` |" >>./annotations/image_promotions.md
+  # We're transitioning to GAR because of DockerHub new rate limiting affecting GCP
+  # See https://github.com/sourcegraph/sourcegraph/issues/61696
+  docker tag "${INTERNAL_REGISTRY}/${name}:${VERSION}" "${ADDITIONAL_PROD_REGISTRY}/${name}:${VERSION}"
+  docker push "${ADDITIONAL_PROD_REGISTRY}/${name}:${VERSION}"
+
+  echo -e "| ${name} | \`${INTERNAL_REGISTRY}/${name}:${VERSION}\` | \`${PUBLIC_REGISTRY}/${name}:${VERSION}\` \`${ADDITIONAL_PROD_REGISTRY}/${name}:${VERSION}\` |" >>./annotations/image_promotions.md
 done


### PR DESCRIPTION
Part of https://github.com/sourcegraph/sourcegraph/issues/61696 

Basically, while we obviously do not push on the new GAR public registry when creating an internal release, we still need to also push the images there (next to the classic public registry) when promoting a release. 

## Test plan

CI 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
