### PR TITLE
Disable flaky symbols sidebar E2E tests

### DIFF
--- a/client/web/src/end-to-end/code-intel/repository-component.test.ts
+++ b/client/web/src/end-to-end/code-intel/repository-component.test.ts
@@ -271,7 +271,8 @@ describe('Repository component', () => {
         })
     })
 
-    describe('symbol sidebar', () => {
+    // FLAKE: Disabled on 2024-04-18 because our E2E test suite is down to 69% reliability.
+    describe.skip('symbol sidebar', () => {
         const listSymbolsTests = [
             {
                 name: 'lists symbols in file for Go',


### PR DESCRIPTION
https://sourcegraph.slack.com/archives/C04MYFW01NV/p1713444706157679

Reliability of the E2E testsuite is 69% with 56 flakes in the past 7 days. The second worst test only flaked 7 times. Time to disable this test until someone can fix it. https://buildkite.com/organizations/sourcegraph/analytics/suites/sourcegraph-bazel/tests/0189f3a8-28d8-7392-be6a-e1ab56d20fab?branch=main

Test plan:

CI doesn't flake.
