### PR TITLE
ci: relax the buildifier timeout

### DIFF
--- a/.aspect/workflows/config.yaml
+++ b/.aspect/workflows/config.yaml
@@ -11,7 +11,7 @@ tasks:
   # Checks that BUILD files are formatted
   - buildifier:
       queue: aspect-small
-      timeout_in_minutes: 2
+      timeout_in_minutes: 3
   # Checks that BUILD file content is up-to-date with sources
   - gazelle:
       queue: aspect-small


### PR DESCRIPTION
I've seen buildifier timeout a few times this week at 2 mins and looking at the job, it's initialization of the job that takes up most of the time. This can further make it tight it there are actual change buildifier needs to check - as in there were bazel file changes - then time budget is simply extremely tight.

## Test plan
CI