### PR TITLE
Support setting clientID for calls from Cody Gateway to sourcegraph.com

### DIFF
--- a/cmd/cody-gateway/internal/dotcom/BUILD.bazel
+++ b/cmd/cody-gateway/internal/dotcom/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
     visibility = ["//cmd/cody-gateway:__subpackages__"],
     deps = [
         "//cmd/cody-gateway/internal/dotcom/genhelper",
+        "//internal/version",
         "@com_github_khan_genqlient//graphql",
         "@io_opentelemetry_go_otel//:otel",
         "@io_opentelemetry_go_otel//attribute",

--- a/cmd/cody-gateway/internal/dotcom/dotcom.go
+++ b/cmd/cody-gateway/internal/dotcom/dotcom.go
@@ -28,8 +28,9 @@ import (
 func NewClient(endpoint, token, clientID string) graphql.Client {
 	return &tracedClient{graphql.NewClient(endpoint, &http.Client{
 		Transport: &tokenAuthTransport{
-			token:   token,
-			wrapped: http.DefaultTransport,
+			token:    token,
+			wrapped:  http.DefaultTransport,
+			clientID: clientID,
 		},
 	})}
 }

--- a/cmd/cody-gateway/internal/dotcom/dotcom.go
+++ b/cmd/cody-gateway/internal/dotcom/dotcom.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 
 	"github.com/Khan/genqlient/graphql"
+	"github.com/sourcegraph/sourcegraph/internal/version"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
@@ -25,12 +26,13 @@ import (
 //	println(resp.GetDotcom().ProductSubscriptionByAccessToken.LlmProxyAccess.Enabled)
 //
 // The client generator automatically ensures we're up-to-date with the GraphQL schema.
-func NewClient(endpoint, token, clientID string) graphql.Client {
+func NewClient(endpoint, token, clientID, env string) graphql.Client {
 	return &tracedClient{graphql.NewClient(endpoint, &http.Client{
 		Transport: &tokenAuthTransport{
-			token:    token,
-			wrapped:  http.DefaultTransport,
-			clientID: clientID,
+			token:       token,
+			wrapped:     http.DefaultTransport,
+			clientID:    clientID,
+			environment: env,
 		},
 	})}
 }
@@ -70,11 +72,13 @@ func (tc *tracedClient) MakeRequest(
 	return err
 }
 
-// tokenAuthTransport adds token header authentication to requests.
+// tokenAuthTransport adds token header authentication to requests and sets headers used to help identify Cody Gateway
+// in Cloudflare / sourcegraph.com
 type tokenAuthTransport struct {
-	token    string
-	clientID string
-	wrapped  http.RoundTripper
+	token       string
+	clientID    string
+	environment string
+	wrapped     http.RoundTripper
 }
 
 func (t *tokenAuthTransport) RoundTrip(req *http.Request) (*http.Response, error) {
@@ -87,5 +91,6 @@ func (t *tokenAuthTransport) RoundTrip(req *http.Request) (*http.Response, error
 	if t.clientID != "" {
 		req.Header.Set("X-Sourcegraph-Client-ID", t.clientID)
 	}
+	req.Header.Set("User-Agent", fmt.Sprintf("Cody-Gateway/%s %s", t.environment, version.Version()))
 	return t.wrapped.RoundTrip(req)
 }

--- a/cmd/cody-gateway/internal/dotcom/dotcom_test.go
+++ b/cmd/cody-gateway/internal/dotcom/dotcom_test.go
@@ -17,7 +17,7 @@ func TestOpInQuery(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := NewClient(srv.URL, "test-token")
+	c := NewClient(srv.URL, "test-token", "random")
 	// We don't care about the actual result of the call
 	_, _ = CheckAccessToken(context.Background(), c, "slk_foobar")
 	// But we do care that we did get through to the handler

--- a/cmd/cody-gateway/internal/dotcom/dotcom_test.go
+++ b/cmd/cody-gateway/internal/dotcom/dotcom_test.go
@@ -17,7 +17,7 @@ func TestOpInQuery(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := NewClient(srv.URL, "test-token", "random")
+	c := NewClient(srv.URL, "test-token", "random", "dev")
 	// We don't care about the actual result of the call
 	_, _ = CheckAccessToken(context.Background(), c, "slk_foobar")
 	// But we do care that we did get through to the handler

--- a/cmd/cody-gateway/internal/httpapi/attribution/handler_test.go
+++ b/cmd/cody-gateway/internal/httpapi/attribution/handler_test.go
@@ -116,7 +116,7 @@ func TestSuccess(t *testing.T) {
 			},
 		},
 	}
-	dotcomClient := dotcom.NewClient(fakeDotcom.url, "fake auth token", "random")
+	dotcomClient := dotcom.NewClient(fakeDotcom.url, "fake auth token", "random", "dev")
 	handler, err := httpapi.NewHandler(logger, nil, nil, nil, authr, nil, config, dotcomClient)
 	require.NoError(t, err)
 	r := request(t)

--- a/cmd/cody-gateway/internal/httpapi/attribution/handler_test.go
+++ b/cmd/cody-gateway/internal/httpapi/attribution/handler_test.go
@@ -116,7 +116,7 @@ func TestSuccess(t *testing.T) {
 			},
 		},
 	}
-	dotcomClient := dotcom.NewClient(fakeDotcom.url, "fake auth token")
+	dotcomClient := dotcom.NewClient(fakeDotcom.url, "fake auth token", "random")
 	handler, err := httpapi.NewHandler(logger, nil, nil, nil, authr, nil, config, dotcomClient)
 	require.NoError(t, err)
 	r := request(t)

--- a/cmd/cody-gateway/shared/config/config.go
+++ b/cmd/cody-gateway/shared/config/config.go
@@ -73,6 +73,8 @@ type Config struct {
 
 	// SAMSClientConfig for verifying and generating SAMS access tokens.
 	SAMSClientConfig SAMSClientConfig
+	// one of "production", "staging" or "dev" (all 3 can connect to sourcegraph.com)
+	Environment string
 }
 
 type OpenTelemetryConfig struct {
@@ -289,6 +291,8 @@ func (c *Config) Load() {
 	c.SAMSClientConfig.URL = c.GetOptional("SAMS_URL", "SAMS service endpoint")
 	c.SAMSClientConfig.ClientID = c.GetOptional("SAMS_CLIENT_ID", "SAMS OAuth client ID")
 	c.SAMSClientConfig.ClientSecret = c.GetOptional("SAMS_CLIENT_SECRET", "SAMS OAuth client secret")
+
+	c.Environment = c.Get("CODY_GATEWAY_ENVIRONMENT", "dev", "Environment name.")
 }
 
 // loadFlaggingConfig loads the common set of flagging-related environment variables for

--- a/cmd/cody-gateway/shared/config/config.go
+++ b/cmd/cody-gateway/shared/config/config.go
@@ -33,6 +33,8 @@ type Config struct {
 		// Prompts that get flagged are stored in Redis for a short-time, for
 		// better understanding the nature of any ongoing spam/abuse waves.
 		FlaggedPromptRecorderTTL time.Duration
+
+		ClientID string
 	}
 
 	Anthropic AnthropicConfig
@@ -151,6 +153,8 @@ func (c *Config) Load() {
 
 	c.Dotcom.AccessToken = c.GetOptional("CODY_GATEWAY_DOTCOM_ACCESS_TOKEN",
 		"The Sourcegraph.com access token to be used. If not provided, dotcom-based actor sources will be disabled.")
+	c.Dotcom.ClientID = c.GetOptional("CODY_GATEWAY_DOTCOM_CLIENT_ID",
+		"Value of X-Sourcegraph-Client-Id header to be passed to sourcegraph.com.")
 	c.Dotcom.URL = c.Get("CODY_GATEWAY_DOTCOM_API_URL", "https://sourcegraph.com/.api/graphql", "Custom override for the dotcom API endpoint")
 	if _, err := url.Parse(c.Dotcom.URL); err != nil {
 		c.AddError(errors.Wrap(err, "invalid CODY_GATEWAY_DOTCOM_API_URL"))

--- a/cmd/cody-gateway/shared/main.go
+++ b/cmd/cody-gateway/shared/main.go
@@ -143,7 +143,7 @@ func Main(ctx context.Context, obctx *observation.Context, ready service.ReadyFu
 		// dotcom-based actor sources only if an access token is provided for
 		// us to talk with the client
 		obctx.Logger.Info("dotcom-based actor sources are enabled")
-		dotcomClient = dotcom.NewClient(cfg.Dotcom.URL, cfg.Dotcom.AccessToken)
+		dotcomClient = dotcom.NewClient(cfg.Dotcom.URL, cfg.Dotcom.AccessToken, cfg.Dotcom.ClientID)
 		sources.Add(
 			productsubscription.NewSource(
 				obctx.Logger,

--- a/cmd/cody-gateway/shared/main.go
+++ b/cmd/cody-gateway/shared/main.go
@@ -143,7 +143,7 @@ func Main(ctx context.Context, obctx *observation.Context, ready service.ReadyFu
 		// dotcom-based actor sources only if an access token is provided for
 		// us to talk with the client
 		obctx.Logger.Info("dotcom-based actor sources are enabled")
-		dotcomClient = dotcom.NewClient(cfg.Dotcom.URL, cfg.Dotcom.AccessToken, cfg.Dotcom.ClientID)
+		dotcomClient = dotcom.NewClient(cfg.Dotcom.URL, cfg.Dotcom.AccessToken, cfg.Dotcom.ClientID, cfg.Environment)
 		sources.Add(
 			productsubscription.NewSource(
 				obctx.Logger,


### PR DESCRIPTION
Add a header that we can use to identify Cody Gateway requests to sourcegraph.com - [context](https://sourcegraph.slack.com/archives/C05497E9MDW/p1713453541038879?thread_ts=1713431784.192999&cid=C05497E9MDW).

## Test plan

- local testing