### PR TITLE
svelte: Fix playwright tests

### DIFF
--- a/client/web-sveltekit/package.json
+++ b/client/web-sveltekit/package.json
@@ -6,6 +6,7 @@
     "dev:dotcom": "vite dev --mode=dotcom",
     "dev:enterprise": "DEPLOY_TYPE=dev vite build --watch",
     "build": "vite build",
+    "build:preview": "vite build --mode=preview",
     "build:watch": "vite build --watch",
     "preview": "vite preview",
     "test": "playwright test",

--- a/client/web-sveltekit/playwright.config.ts
+++ b/client/web-sveltekit/playwright.config.ts
@@ -5,7 +5,7 @@ const PORT = process.env.PORT ? Number(process.env.PORT) : 4173
 const config: PlaywrightTestConfig = {
     testMatch: '**/*.spec.ts',
     webServer: {
-        command: 'pnpm run build && pnpm run preview',
+        command: 'pnpm run build:preview && pnpm run preview',
         port: PORT,
         reuseExistingServer: !process.env.CI,
     },

--- a/client/web-sveltekit/src/lib/navigation.ts
+++ b/client/web-sveltekit/src/lib/navigation.ts
@@ -1,3 +1,5 @@
+import { dev } from '$app/environment'
+
 import { svelteKitRoutes, type SvelteKitRoute } from './routes'
 
 let knownRoutesRegex: RegExp | undefined
@@ -16,8 +18,19 @@ function getKnownRoutesRegex(): RegExp {
  *
  * Callers should pass an actual route ID retrived from SvelteKit not an
  * arbitrary path.
+ *
+ * NOTE: When in dev or preview mode, all routes are always enabled.
+ *
+ * @param pathname The pathname of the route to check.
+ * @returns Whether the SvelteKit app is enabled for the given route.
  */
 export function isRouteEnabled(pathname: string): boolean {
+    // Preview mode is like production mode but with all routes enabled.
+    // This necessary for running `pnpm run preview` or playwright tests.
+    if (dev || import.meta.env.MODE === 'preview') {
+        return true
+    }
+
     if (!pathname) {
         return false
     }

--- a/client/web-sveltekit/src/routes/+layout.svelte
+++ b/client/web-sveltekit/src/routes/+layout.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
     import { writable } from 'svelte/store'
 
-    import { browser, dev } from '$app/environment'
+    import { browser } from '$app/environment'
     import { isErrorLike } from '$lib/common'
     import { classNames } from '$lib/dom'
     import { TemporarySettingsStorage } from '$lib/shared'
@@ -67,7 +67,7 @@
             return
         }
 
-        if (dev || isRouteEnabled(navigation.to.url.pathname)) {
+        if (isRouteEnabled(navigation.to.url.pathname)) {
             // Routes are handled by SvelteKit
             return
         }

--- a/client/web-sveltekit/src/routes/layout.spec.ts
+++ b/client/web-sveltekit/src/routes/layout.spec.ts
@@ -10,10 +10,12 @@ test('has sign in button', async ({ page }) => {
     await expect(page).toHaveURL('/sign-in')
 })
 
-test('has experimental web app toggle button', async ({ page }) => {
+test('has experimental opt out popover', async ({ sg, page }) => {
+    sg.signIn({ username: 'test' })
+
     await page.goto('/')
-    await page.getByLabel('Leave experimental web app').click()
-    await expect(page).toHaveURL(/\?feat=-web-next/)
+    await page.getByText('Experimental').hover()
+    await expect(page.getByRole('link', { name: 'opt out' })).toBeVisible()
 })
 
 test('has user menu', async ({ sg, page }) => {

--- a/client/web-sveltekit/src/routes/search/page.spec.ts
+++ b/client/web-sveltekit/src/routes/search/page.spec.ts
@@ -72,7 +72,7 @@ test('fills search query from URL', async ({ page }) => {
 })
 
 test('main navbar menus are visible above search input', async ({ page, sg }) => {
-    const stream = sg.mockSearchStream()
+    const stream = await sg.mockSearchStream()
     await page.goto('/search?q=test')
     await stream.publish(createProgressEvent(), createDoneEvent())
     await stream.close()
@@ -85,7 +85,7 @@ test.use({
     permissions: ['clipboard-write', 'clipboard-read'],
 })
 test('copy path button appears and copies path', async ({ page, sg }) => {
-    const stream = sg.mockSearchStream()
+    const stream = await sg.mockSearchStream()
     await page.goto('/search?q=test')
     await page.getByRole('heading', { name: 'Filter results' }).waitFor()
 
@@ -140,7 +140,7 @@ test.describe('preview panel', async () => {
         language: 'text',
     }
     test('can be opened and closed', async ({ page, sg }) => {
-        const stream = sg.mockSearchStream()
+        const stream = await sg.mockSearchStream()
         await page.goto('/search?q=test')
         await page.getByRole('heading', { name: 'Filter results' }).waitFor()
         sg.mockOperations({
@@ -173,7 +173,7 @@ test.describe('preview panel', async () => {
     })
 
     test('can iterate over matches', async ({ page, sg }) => {
-        const stream = sg.mockSearchStream()
+        const stream = await sg.mockSearchStream()
         await page.goto('/search?q=test')
         await page.getByRole('heading', { name: 'Filter results' }).waitFor()
         await stream.publish(

--- a/client/web-sveltekit/src/testing/integration.ts
+++ b/client/web-sveltekit/src/testing/integration.ts
@@ -119,8 +119,8 @@ class Sourcegraph {
      * the search results being received. The returned function will wait for the search results
      * page to be "ready" by waiting for the "Filter results" heading to be visible.
      */
-    public mockSearchStream(): MockSearchStream {
-        this.page.addInitScript(function () {
+    public async mockSearchStream(): Promise<MockSearchStream> {
+        await this.page.addInitScript(function () {
             window.$$sources = []
             window.EventSource = class MockEventSource {
                 static readonly CONNECTING = 0


### PR DESCRIPTION
Running playwright tests on the production build has been broken for some tests for two reasons:

- In the production build the app has knowledege about which routes are enabled. It assumes none are and so any navigation event results in the page reloading. This can have some unexpected effects on the state of the application.
- `this.page.addInitScript` returns a promise that has to be awaited. Otherwise we cannot be sure that it has executed before the other steps of the test. I don't know why that wasn't a problem in the development build.

To solve the first issue I added a new "preview" build which is identical to the production build except that every route is "enabled" and served normally. I've updated the playwright config to use that build instead. It can also be used "manually" by running `pnpm build:preview`.

For anyone whose curious about this: `dev || import.meta.env.MODE === 'preview'` is being complete removed from the build output.

## Test plan

`pnpm test` runs without error
