### PR TITLE
svelte: Remove full page scrolling of repo pages

### DIFF
--- a/client/web-sveltekit/src/lib/CodeMirrorBlob.svelte
+++ b/client/web-sveltekit/src/lib/CodeMirrorBlob.svelte
@@ -28,8 +28,6 @@
         languages: string[]
     }
 
-    const extensionsCompartment = new Compartment()
-
     const defaultTheme = EditorView.theme({
         '&': {
             height: '100%',
@@ -42,6 +40,7 @@
             lineHeight: '1rem',
             fontFamily: 'var(--code-font-family)',
             fontSize: 'var(--code-font-size)',
+            overflow: 'auto',
         },
         '.cm-content': {
             padding: 0,
@@ -106,20 +105,12 @@
         defaultTheme,
         linkify,
     ]
-
-    function configureSyntaxHighlighting(content: string, lsif: string): Extension {
-        return lsif ? syntaxHighlight.of({ content, lsif }) : []
-    }
-
-    function configureMiscSettings({ wrapLines }: { wrapLines: boolean }): Extension {
-        return [wrapLines ? EditorView.lineWrapping : []]
-    }
 </script>
 
 <script lang="ts">
     import '$lib/highlight.scss'
 
-    import { Compartment, EditorState, type Extension } from '@codemirror/state'
+    import { EditorState, type Extension } from '@codemirror/state'
     import { EditorView } from '@codemirror/view'
     import { createEventDispatcher, onMount } from 'svelte'
 
@@ -136,14 +127,22 @@
         linkify,
         createCodeIntelExtension,
         syncSelection,
-        temporaryTooltip,
         showBlame as showBlameColumn,
         blameData as blameDataFacet,
         type BlameHunkData,
+        lockFirstVisibleLine,
+        temporaryTooltip,
     } from '$lib/web'
 
     import BlameDecoration from './blame/BlameDecoration.svelte'
     import { type Range, staticHighlights } from './codemirror/static-highlights'
+    import {
+        createCompartments,
+        restoreScrollSnapshot,
+        type ExtensionType,
+        type ScrollSnapshot,
+        getScrollSnapshot as getScrollSnapshot_internal,
+    } from './codemirror/utils'
     import { goToDefinition, openImplementations, openReferences } from './repo/blob'
 
     export let blobInfo: BlobInfo
@@ -152,21 +151,34 @@
     export let selectedLines: LineOrPositionOrRange | null = null
     export let codeIntelAPI: CodeIntelAPI
     export let staticHighlightRanges: Range[] = []
+    /**
+     * The initial scroll position when the editor is first mounted.
+     * Changing the value afterwards has no effect.
+     */
+    export let initialScrollPosition: ScrollSnapshot | null = null
 
     export let showBlame: boolean = false
     export let blameData: BlameHunkData | undefined = undefined
 
+    export function getScrollSnapshot(): ScrollSnapshot | null {
+        return view ? getScrollSnapshot_internal(view) : null
+    }
+
     const dispatch = createEventDispatcher<{ selectline: SelectedLineRange }>()
-
-    let editor: EditorView
-    let container: HTMLDivElement | null = null
-
-    const lineNumbers = selectableLineNumbers({
-        onSelection(range) {
-            dispatch('selectline', range)
-        },
-        initialSelection: selectedLines?.line === undefined ? null : selectedLines,
+    const extensionsCompartment = createCompartments({
+        selectableLineNumbers: null,
+        syntaxHighlighting: null,
+        lineWrapping: null,
+        temporaryTooltip,
+        codeIntelExtension: null,
+        staticExtensions,
+        staticHighlightExtension: null,
+        blameDataExtension: null,
+        blameColumnExtension: null,
     })
+
+    let container: HTMLDivElement | null = null
+    let view: EditorView | undefined = undefined
 
     $: documentInfo = {
         repoName: blobInfo.repoName,
@@ -198,8 +210,8 @@
             }
         },
     })
-    $: settings = configureMiscSettings({ wrapLines })
-    $: sh = configureSyntaxHighlighting(blobInfo.content, highlights)
+    $: lineWrapping = wrapLines ? EditorView.lineWrapping : []
+    $: syntaxHighlighting = highlights ? syntaxHighlight.of({ content: blobInfo.content, lsif: highlights }) : []
     $: staticHighlightExtension = staticHighlights(staticHighlightRanges)
 
     $: blameColumnExtension = showBlame
@@ -216,51 +228,96 @@
         : []
     $: blameDataExtension = blameDataFacet(blameData)
 
-    $: extensions = [
-        sh,
-        settings,
-        lineNumbers,
-        temporaryTooltip,
-        codeIntelExtension,
-        staticExtensions,
-        staticHighlightExtension,
-        blameColumnExtension,
-        blameDataExtension,
-    ]
-
-    function update(blobInfo: BlobInfo, extensions: Extension, range: LineOrPositionOrRange | null) {
-        if (editor) {
-            // TODO(fkling): Find a way to combine this into a single transaction.
-            if (editor.state.sliceDoc() !== blobInfo.content) {
-                editor.setState(
-                    EditorState.create({ doc: blobInfo.content, extensions: extensionsCompartment.of(extensions) })
-                )
-            } else {
-                editor.dispatch({ effects: [extensionsCompartment.reconfigure(extensions)] })
-            }
-            editor.dispatch({
-                effects: setSelectedLines.of(range?.line && isValidLineRange(range, editor.state.doc) ? range : null),
-            })
-
-            if (range) {
-                syncSelection(editor, range)
-            }
+    // Reinitialize the editor when its content changes. Update only the extensions when they change.
+    $: update(view => {
+        // blameColumnExtension is omitted here. It's updated separately below because we need to
+        // apply additional effects when it changes (but only when it changes).
+        const extensions: Partial<ExtensionType<typeof extensionsCompartment>> = {
+            codeIntelExtension,
+            lineWrapping,
+            syntaxHighlighting,
+            staticHighlightExtension,
+            blameDataExtension,
         }
-    }
+        if (view.state.sliceDoc() !== blobInfo.content) {
+            view.setState(createEditorState(blobInfo, extensions))
+        } else {
+            extensionsCompartment.update(view, extensions)
+        }
+    })
 
-    $: update(blobInfo, extensions, selectedLines)
+    // Show/hide the blame column and ensure that the style changes do not change the scroll position
+    $: update(view => {
+        extensionsCompartment.update(view, { blameColumnExtension }, ...lockFirstVisibleLine(view))
+    })
+
+    // Update the selected lines. This will scroll the selected lines into view. Also set the editor's
+    // selection (essentially the cursor position) to the selected lines. This is necessary in case the
+    // selected range references a symbol.
+    $: update(view => {
+        view.dispatch({
+            effects: setSelectedLines.of(
+                selectedLines?.line && isValidLineRange(selectedLines, view.state.doc) ? selectedLines : null
+            ),
+        })
+        if (selectedLines) {
+            syncSelection(view, selectedLines)
+        }
+    })
 
     onMount(() => {
         if (container) {
-            editor = new EditorView({
-                state: EditorState.create({ doc: blobInfo.content, extensions: extensionsCompartment.of(extensions) }),
+            view = new EditorView({
+                // On first render initialize all extensions
+                state: createEditorState(blobInfo, {
+                    codeIntelExtension,
+                    lineWrapping,
+                    syntaxHighlighting,
+                    staticHighlightExtension,
+                    blameDataExtension,
+                    blameColumnExtension,
+                }),
                 parent: container,
             })
             if (selectedLines) {
-                syncSelection(editor, selectedLines)
+                syncSelection(view, selectedLines)
+            }
+            if (initialScrollPosition) {
+                restoreScrollSnapshot(view, initialScrollPosition)
             }
         }
+        return () => {
+            view?.destroy()
+        }
     })
+
+    // Helper function to update the editor state whithout depending on the view variable
+    // (those updates should only run on subsequent updates)
+    function update(updater: (view: EditorView) => void) {
+        if (view) {
+            updater(view)
+        }
+    }
+
+    function createEditorState(blobInfo: BlobInfo, extensions: Partial<ExtensionType<typeof extensionsCompartment>>) {
+        return EditorState.create({
+            doc: blobInfo.content,
+            extensions: extensionsCompartment.init({
+                selectableLineNumbers: selectableLineNumbers({
+                    onSelection(range) {
+                        dispatch('selectline', range)
+                    },
+                    initialSelection: selectedLines?.line === undefined ? null : selectedLines,
+                    // We don't want to scroll the selected line into view when a scroll position is explicitly set.
+                    skipInitialScrollIntoView: initialScrollPosition !== null,
+                }),
+                ...extensions,
+            }),
+            selection: {
+                anchor: 0,
+            },
+        })
+    }
 </script>
 
 {#if browser}
@@ -273,9 +330,10 @@
 
 <style lang="scss">
     .root {
-        display: contents;
         --blame-decoration-width: 400px;
         --blame-recency-width: 4px;
+
+        height: 100%;
     }
     pre {
         margin: 0;

--- a/client/web-sveltekit/src/lib/codemirror/utils.ts
+++ b/client/web-sveltekit/src/lib/codemirror/utils.ts
@@ -105,17 +105,17 @@ export function getScrollSnapshot(view: EditorView): ScrollSnapshot {
  * @param snapshot The scroll snapshot
  */
 export function restoreScrollSnapshot(view: EditorView, snapshot: ScrollSnapshot): void {
-    if (snapshot.scrollTop !== undefined) {
-        // We are using request measure here to ensure that the DOM has been updated/painted
+    const {scrollTop} = snapshot
+
+    if (scrollTop !== undefined) {
+        // We are using request measure here to ensure that the DOM has been updated
         // before updating the scroll position.
         view.requestMeasure({
             read() {
                 return null
             },
             write(_measure, view) {
-                if (snapshot.scrollTop !== undefined) {
-                    view.scrollDOM.scrollTop = snapshot.scrollTop
-                }
+                view.scrollDOM.scrollTop = scrollTop
             },
         })
     }

--- a/client/web-sveltekit/src/lib/codemirror/utils.ts
+++ b/client/web-sveltekit/src/lib/codemirror/utils.ts
@@ -1,59 +1,122 @@
 import { Compartment, type StateEffect, type Extension } from '@codemirror/state'
-import type { EditorView } from '@codemirror/view'
+import { EditorView } from '@codemirror/view'
 
-type Extensions = Record<string, Extension>
-type UpdatedExtensions<T extends Extensions> = { [key in keyof T]: Extension }
+type Extensions = Record<string, Extension | null>
+type UpdatedExtensions<T extends Extensions> = { [key in keyof T]?: Extension | null }
+export type ExtensionType<T> = T extends Compartments<infer U> ? UpdatedExtensions<U> : never
 
 interface Compartments<T extends Extensions> {
     extension: Extension
     /**
-     * Initialize compartments with a different value
+     * Initialize compartments with a different value.
+     *
+     * @param extensions The values for the compartments
+     * @returns An extension
      */
     init(extensions: UpdatedExtensions<T>): Extension
     /**
-     * Update compartments. Only compartments for which the provided
-     * value has changed will be updated.
+     * Update compartments. Only compartments for which the provided value has changed will be updated.
+     * Additional effects can be provided to be dispatched with the compartment updates, but they will
+     * only be dispatched if at least one compartment has changed.
+     *
+     * @param view The editor view
+     * @param extensions The updated values for the compartments
+     * @param additionalEffects Additional effects to be dispatched with the compartment updates
      */
-    update(view: EditorView, extensions: UpdatedExtensions<T>): void
+    update(view: EditorView, extensions: UpdatedExtensions<T>, ...additionalEffects: StateEffect<unknown>[]): void
 }
+
+const emptyExtension: Extension = []
 
 /**
  * Helper function for creating a compartments extension. Each record
  * entry will get its own compartment and the value will be the initial
  * value of the compartment.
+ * The order/presedence of the extensions is determined by the order of the
+ * keys in the initialExtensions record.
+ *
+ * @param initialExtensions Initial values for the compartments
+ * @returns Compartments extension
  */
-export function createCompartments<T extends Record<string, Extension>>(extensions: T): Compartments<T> {
-    const compartments: Record<string, Compartment> = {}
+export function createCompartments<T extends Extensions>(initialExtensions: T): Compartments<T> {
+    const compartments: Map<string, Compartment> = new Map()
 
-    function init(extensions: UpdatedExtensions<T>, compartments: Record<string, Compartment>): Extension {
-        const extension: Extension[] = []
+    function init(extensions: UpdatedExtensions<T>, compartments: Map<string, Compartment>): Extension {
+        const values: Map<string, Extension> = new Map()
+
         for (const [name, ext] of Object.entries(extensions)) {
-            let compartment = compartments[name]
+            let compartment = compartments.get(name)
             if (!compartment) {
-                compartment = compartments[name] = new Compartment()
+                compartments.set(name, (compartment = new Compartment()))
             }
-            extension.push(compartment.of(ext))
+            values.set(name, compartment.of(ext ?? emptyExtension))
         }
-        return extension
+
+        // Return extensions in the order of the initialExtensions record
+        return Array.from(compartments.keys(), name => values.get(name) ?? emptyExtension)
     }
 
     return {
-        extension: init(extensions, compartments),
+        extension: init(initialExtensions, compartments),
         init(extensions) {
-            return init(extensions, compartments)
+            return init({ ...initialExtensions, ...extensions }, compartments)
         },
-        update(view, extensions) {
+        update(view, extensions, ...additionalEffects) {
             const effects: StateEffect<unknown>[] = []
 
             for (const [name, ext] of Object.entries(extensions)) {
-                if (compartments[name].get(view.state) !== ext) {
-                    effects.push(compartments[name].reconfigure(ext))
+                const compartment = compartments.get(name)
+                if (compartment && compartment.get(view.state) !== ext) {
+                    effects.push(compartment.reconfigure(ext ?? emptyExtension))
                 }
             }
 
             if (effects.length > 0) {
-                view.dispatch({ effects })
+                view.dispatch({ effects: effects.concat(additionalEffects) })
             }
         },
+    }
+}
+
+/**
+ * An object representing the scroll state of a CodeMirror instance.
+ */
+export interface ScrollSnapshot {
+    scrollTop?: number
+}
+
+/**
+ * Returns a snapshot of the editors scroll state that is serializable (unlike CodeMirror's
+ * native scroll snapshot).
+ *
+ * @param view The editor view
+ * @returns The scroll snapshot
+ */
+export function getScrollSnapshot(view: EditorView): ScrollSnapshot {
+    return {
+        scrollTop: view.scrollDOM.scrollTop,
+    }
+}
+
+/**
+ * Restores the scroll state of the editor from a snapshot.
+ *
+ * @param view The editor view
+ * @param snapshot The scroll snapshot
+ */
+export function restoreScrollSnapshot(view: EditorView, snapshot: ScrollSnapshot): void {
+    if (snapshot.scrollTop !== undefined) {
+        // We are using request measure here to ensure that the DOM has been updated/painted
+        // before updating the scroll position.
+        view.requestMeasure({
+            read() {
+                return null
+            },
+            write(_measure, view) {
+                if (snapshot.scrollTop !== undefined) {
+                    view.scrollDOM.scrollTop = snapshot.scrollTop
+                }
+            },
+        })
     }
 }

--- a/client/web-sveltekit/src/lib/codemirror/utils.ts
+++ b/client/web-sveltekit/src/lib/codemirror/utils.ts
@@ -105,7 +105,7 @@ export function getScrollSnapshot(view: EditorView): ScrollSnapshot {
  * @param snapshot The scroll snapshot
  */
 export function restoreScrollSnapshot(view: EditorView, snapshot: ScrollSnapshot): void {
-    const {scrollTop} = snapshot
+    const { scrollTop } = snapshot
 
     if (scrollTop !== undefined) {
         // We are using request measure here to ensure that the DOM has been updated

--- a/client/web-sveltekit/src/lib/repo/FileHeader.svelte
+++ b/client/web-sveltekit/src/lib/repo/FileHeader.svelte
@@ -74,8 +74,6 @@
         align-items: baseline;
         padding: 0.25rem 0.5rem;
         border-bottom: 1px solid var(--border-color);
-        position: sticky;
-        top: 0px;
         background-color: var(--color-bg-1);
         z-index: 1;
         gap: 0.5rem;

--- a/client/web-sveltekit/src/lib/stores.ts
+++ b/client/web-sveltekit/src/lib/stores.ts
@@ -81,5 +81,3 @@ export function createLocalWritable<T>(localStorageKey: string, defaultValue: T)
         },
     }
 }
-
-export const scrollAll = writable(false)

--- a/client/web-sveltekit/src/lib/web.ts
+++ b/client/web-sveltekit/src/lib/web.ts
@@ -10,6 +10,7 @@ export { linkify } from '@sourcegraph/web/src/repo/blob/codemirror/links'
 export { createCodeIntelExtension } from '@sourcegraph/web/src/repo/blob/codemirror/codeintel/extension'
 export type { TooltipViewOptions } from '@sourcegraph/web/src/repo/blob/codemirror/codeintel/api'
 export { positionToOffset, locationToURL } from '@sourcegraph/web/src/repo/blob/codemirror/utils'
+export { lockFirstVisibleLine } from '@sourcegraph/web/src/repo/blob/codemirror/lock-line'
 export { syncSelection } from '@sourcegraph/web/src/repo/blob/codemirror/codeintel/token-selection'
 export {
     showTemporaryTooltip,

--- a/client/web-sveltekit/src/routes/+layout.svelte
+++ b/client/web-sveltekit/src/routes/+layout.svelte
@@ -3,9 +3,8 @@
 
     import { browser } from '$app/environment'
     import { isErrorLike } from '$lib/common'
-    import { classNames } from '$lib/dom'
     import { TemporarySettingsStorage } from '$lib/shared'
-    import { isLightTheme, setAppContext, scrollAll } from '$lib/stores'
+    import { isLightTheme, setAppContext } from '$lib/stores'
     import { createTemporarySettingsStorage } from '$lib/temporarySettings'
 
     import Header from './Header.svelte'
@@ -93,8 +92,6 @@
     <meta name="description" content="Code search" />
 </svelte:head>
 
-<svelte:body use:classNames={$scrollAll ? '' : 'overflowHidden'} />
-
 {#await data.globalSiteAlerts then globalSiteAlerts}
     {#if globalSiteAlerts}
         <GlobalNotification globalAlerts={globalSiteAlerts} />
@@ -108,15 +105,11 @@
 </main>
 
 <style lang="scss">
-    :global(body.overflowHidden) {
-        display: flex;
-        flex-direction: column;
+    :global(body) {
         height: 100vh;
         overflow: hidden;
-
-        main {
-            overflow-y: auto;
-        }
+        display: flex;
+        flex-direction: column;
     }
 
     main {
@@ -125,5 +118,6 @@
         display: flex;
         flex-direction: column;
         box-sizing: border-box;
+        overflow-y: auto;
     }
 </style>

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/+layout.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/+layout.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
-    import { onMount, tick } from 'svelte'
+    import { tick } from 'svelte'
 
-    import { afterNavigate, disableScrollHandling, goto } from '$app/navigation'
+    import { goto } from '$app/navigation'
     import { page } from '$app/stores'
     import { isErrorLike } from '$lib/common'
     import LoadingSpinner from '$lib/LoadingSpinner.svelte'
@@ -11,7 +11,6 @@
     import SidebarToggleButton from '$lib/repo/SidebarToggleButton.svelte'
     import { sidebarOpen } from '$lib/repo/stores'
     import Separator, { getSeparatorPosition } from '$lib/Separator.svelte'
-    import { scrollAll } from '$lib/stores'
     import TabPanel from '$lib/TabPanel.svelte'
     import Tabs from '$lib/Tabs.svelte'
     import { Alert } from '$lib/wildcard'
@@ -94,34 +93,6 @@
 
     const sidebarSize = getSeparatorPosition('repo-sidebar', 0.2)
     $: sidebarWidth = `max(200px, ${$sidebarSize * 100}%)`
-
-    onMount(() => {
-        // We want the whole page to be scrollable and hide page and repo navigation
-        scrollAll.set(true)
-        return () => scrollAll.set(false)
-    })
-
-    afterNavigate(() => {
-        // When navigating to a new page we want to ensure two things:
-        // - The file sidebar doesn't move. It feels bad when you clicked on a file entry
-        //   and the click target moves away because the page is scrolled all the way to the top.
-        // - The beginning of the content should be visible (e.g. the top of the file or the
-        //   top of the file table).
-        // In other words, we want to scroll to the top but not all the way
-
-        // Prevents SvelteKit from resetting the scroll position to the very top of the page
-        disableScrollHandling()
-
-        if (rootElement) {
-            // Because the whole page is scrollable we can get the current scroll position from
-            // the window object
-            const top = rootElement.offsetTop
-            if (window.scrollY > top) {
-                // Reset scroll to top of the content
-                window.scrollTo(0, top)
-            }
-        }
-    })
 </script>
 
 <section bind:this={rootElement}>
@@ -182,9 +153,8 @@
     section {
         display: flex;
         flex: 1;
-        flex-shrink: 0;
         background-color: var(--code-bg);
-        min-height: 100vh;
+        overflow: hidden;
     }
 
     header {
@@ -205,9 +175,6 @@
         background-color: var(--body-bg);
         padding: 0.5rem;
         padding-bottom: 0;
-        position: sticky;
-        top: 0;
-        max-height: 100vh;
     }
 
     .main {
@@ -215,6 +182,7 @@
         display: flex;
         flex-direction: column;
         min-width: 0;
+        overflow: hidden;
     }
 
     h3 {
@@ -232,8 +200,6 @@
     }
 
     .bottom-panel {
-        position: sticky;
-        bottom: 0px;
         background-color: var(--code-bg);
         --align-tabs: flex-start;
         border-top: 1px solid var(--border-color);

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/+layout.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/+layout.svelte
@@ -66,7 +66,6 @@
     const fileTreeStore = createFileTreeStore({ fetchFileTreeData: fetchSidebarFileTree })
     let selectedTab: number | null = null
     let historyPanel: HistoryPanel
-    let rootElement: HTMLElement | null = null
     let commitHistory: GitHistory_HistoryConnection | null
     let lastCommit: LastCommitFragment | null
 
@@ -95,7 +94,7 @@
     $: sidebarWidth = `max(200px, ${$sidebarSize * 100}%)`
 </script>
 
-<section bind:this={rootElement}>
+<section>
     <div class="sidebar" class:open={$sidebarOpen} style:min-width={sidebarWidth} style:max-width={sidebarWidth}>
         <header>
             <h3>

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/tree/[...path]/+page.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/tree/[...path]/+page.svelte
@@ -82,12 +82,13 @@
 <style lang="scss">
     .content {
         flex: 1;
+        overflow: auto;
     }
 
     .header {
         background-color: var(--body-bg);
         position: sticky;
-        top: 2.8rem;
+        top: 0;
         padding: 0.5rem;
         border-bottom: 1px solid var(--border-color);
         margin: 0;

--- a/package.json
+++ b/package.json
@@ -280,7 +280,7 @@
     "@codemirror/lint": "^6.0.0",
     "@codemirror/search": "^6.0.1",
     "@codemirror/state": "^6.4.0",
-    "@codemirror/view": "^6.23.1",
+    "@codemirror/view": "^6.26.3",
     "@date-fns/utc": "^1.1.1",
     "@graphiql/react": "^0.10.0",
     "@lezer/common": "^1.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,7 +21,7 @@ importers:
         version: 3.8.0-alpha.7(graphql-ws@5.15.0)(graphql@15.4.0)(react-dom@18.1.0)(react@18.1.0)
       '@codemirror/autocomplete':
         specifier: ^6.1.0
-        version: 6.1.0(@codemirror/language@6.2.0)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1)(@lezer/common@1.0.0)
+        version: 6.1.0(@codemirror/language@6.2.0)(@codemirror/state@6.4.0)(@codemirror/view@6.26.3)(@lezer/common@1.0.0)
       '@codemirror/commands':
         specifier: ^6.0.1
         version: 6.0.1
@@ -47,8 +47,8 @@ importers:
         specifier: ^6.4.0
         version: 6.4.0
       '@codemirror/view':
-        specifier: ^6.23.1
-        version: 6.23.1
+        specifier: ^6.26.3
+        version: 6.26.3
       '@date-fns/utc':
         specifier: ^1.1.1
         version: 1.1.1
@@ -75,7 +75,7 @@ importers:
         version: 0.0.1
       '@opencodegraph/codemirror-extension':
         specifier: ^0.0.1
-        version: 0.0.1(@codemirror/state@6.4.0)(@codemirror/view@6.23.1)(react-dom@18.1.0)(react@18.1.0)
+        version: 0.0.1(@codemirror/state@6.4.0)(@codemirror/view@6.26.3)(react-dom@18.1.0)(react@18.1.0)
       '@opentelemetry/api':
         specifier: ^1.4.0
         version: 1.4.0
@@ -3241,7 +3241,7 @@ packages:
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
     dev: true
 
-  /@codemirror/autocomplete@6.1.0(@codemirror/language@6.2.0)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1)(@lezer/common@1.0.0):
+  /@codemirror/autocomplete@6.1.0(@codemirror/language@6.2.0)(@codemirror/state@6.4.0)(@codemirror/view@6.26.3)(@lezer/common@1.0.0):
     resolution: {integrity: sha512-wtO4O5WDyXhhCd4q4utDIDZxnQfmJ++3dGBCG9LMtI79+92OcA1DVk/n7BEupKmjIr8AzvptDz7YQ9ud6OkU+A==}
     peerDependencies:
       '@codemirror/language': ^6.0.0
@@ -3251,7 +3251,7 @@ packages:
     dependencies:
       '@codemirror/language': 6.2.0
       '@codemirror/state': 6.4.0
-      '@codemirror/view': 6.23.1
+      '@codemirror/view': 6.26.3
       '@lezer/common': 1.0.0
     dev: false
 
@@ -3260,14 +3260,14 @@ packages:
     dependencies:
       '@codemirror/language': 6.2.0
       '@codemirror/state': 6.4.0
-      '@codemirror/view': 6.23.1
+      '@codemirror/view': 6.26.3
       '@lezer/common': 1.0.0
     dev: false
 
-  /@codemirror/lang-css@6.0.0(@codemirror/view@6.23.1)(@lezer/common@1.0.0):
+  /@codemirror/lang-css@6.0.0(@codemirror/view@6.26.3)(@lezer/common@1.0.0):
     resolution: {integrity: sha512-jBqc+BTuwhNOTlrimFghLlSrN6iFuE44HULKWoR4qKYObhOIl9Lci1iYj6zMIte1XTQmZguNvjXMyr43LUKwSw==}
     dependencies:
-      '@codemirror/autocomplete': 6.1.0(@codemirror/language@6.2.0)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1)(@lezer/common@1.0.0)
+      '@codemirror/autocomplete': 6.1.0(@codemirror/language@6.2.0)(@codemirror/state@6.4.0)(@codemirror/view@6.26.3)(@lezer/common@1.0.0)
       '@codemirror/language': 6.2.0
       '@codemirror/state': 6.4.0
       '@lezer/css': 1.0.0
@@ -3276,11 +3276,11 @@ packages:
       - '@lezer/common'
     dev: false
 
-  /@codemirror/lang-html@6.1.0(@codemirror/view@6.23.1):
+  /@codemirror/lang-html@6.1.0(@codemirror/view@6.26.3):
     resolution: {integrity: sha512-gA7NmJxqvnhwza05CvR7W/39Ap9r/4Vs9uiC0IeFYo1hSlJzc/8N6Evviz6vTW1x8SpHcRYyqKOf6rpl6LfWtg==}
     dependencies:
-      '@codemirror/autocomplete': 6.1.0(@codemirror/language@6.2.0)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1)(@lezer/common@1.0.0)
-      '@codemirror/lang-css': 6.0.0(@codemirror/view@6.23.1)(@lezer/common@1.0.0)
+      '@codemirror/autocomplete': 6.1.0(@codemirror/language@6.2.0)(@codemirror/state@6.4.0)(@codemirror/view@6.26.3)(@lezer/common@1.0.0)
+      '@codemirror/lang-css': 6.0.0(@codemirror/view@6.26.3)(@lezer/common@1.0.0)
       '@codemirror/lang-javascript': 6.0.1
       '@codemirror/language': 6.2.0
       '@codemirror/state': 6.4.0
@@ -3293,11 +3293,11 @@ packages:
   /@codemirror/lang-javascript@6.0.1:
     resolution: {integrity: sha512-kjGbBEosl+ozDU5ruDV48w4v3H6KECTFiDjqMLT0KhVwESPfv3wOvnDrTT0uaMOg3YRGnBWsyiIoKHl/tNWWDg==}
     dependencies:
-      '@codemirror/autocomplete': 6.1.0(@codemirror/language@6.2.0)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1)(@lezer/common@1.0.0)
+      '@codemirror/autocomplete': 6.1.0(@codemirror/language@6.2.0)(@codemirror/state@6.4.0)(@codemirror/view@6.26.3)(@lezer/common@1.0.0)
       '@codemirror/language': 6.2.0
       '@codemirror/lint': 6.0.0
       '@codemirror/state': 6.4.0
-      '@codemirror/view': 6.23.1
+      '@codemirror/view': 6.26.3
       '@lezer/common': 1.0.0
       '@lezer/javascript': 1.0.1
     dev: false
@@ -3312,10 +3312,10 @@ packages:
   /@codemirror/lang-markdown@6.0.0:
     resolution: {integrity: sha512-ozJaO1W4WgGlwWOoYCSYzbVhhM0YM/4lAWLrNsBbmhh5Ztpl0qm4CgEQRl3t8/YcylTZYBIXiskui8sHNGd4dg==}
     dependencies:
-      '@codemirror/lang-html': 6.1.0(@codemirror/view@6.23.1)
+      '@codemirror/lang-html': 6.1.0(@codemirror/view@6.26.3)
       '@codemirror/language': 6.2.0
       '@codemirror/state': 6.4.0
-      '@codemirror/view': 6.23.1
+      '@codemirror/view': 6.26.3
       '@lezer/common': 1.0.0
       '@lezer/markdown': 1.0.1
     dev: false
@@ -3324,7 +3324,7 @@ packages:
     resolution: {integrity: sha512-tabB0Ef/BflwoEmTB4a//WZ9P90UQyne9qWB9YFsmeS4bnEqSys7UpGk/da1URMXhyfuzWCwp+AQNMhvu8SfnA==}
     dependencies:
       '@codemirror/state': 6.4.0
-      '@codemirror/view': 6.23.1
+      '@codemirror/view': 6.26.3
       '@lezer/common': 1.0.0
       '@lezer/highlight': 1.0.0
       '@lezer/lr': 1.2.0
@@ -3341,7 +3341,7 @@ packages:
     resolution: {integrity: sha512-nUUXcJW1Xp54kNs+a1ToPLK8MadO0rMTnJB8Zk4Z8gBdrN0kqV7uvUraU/T2yqg+grDNR38Vmy/MrhQN/RgwiA==}
     dependencies:
       '@codemirror/state': 6.4.0
-      '@codemirror/view': 6.23.1
+      '@codemirror/view': 6.26.3
       crelt: 1.0.5
     dev: false
 
@@ -3349,7 +3349,7 @@ packages:
     resolution: {integrity: sha512-uOinkOrM+daMduCgMPomDfKLr7drGHB4jHl3Vq6xY2WRlL7MkNsBE0b+XHYa/Mee2npsJOgwvkW4n1lMFeBW2Q==}
     dependencies:
       '@codemirror/state': 6.4.0
-      '@codemirror/view': 6.23.1
+      '@codemirror/view': 6.26.3
       crelt: 1.0.5
     dev: false
 
@@ -3357,8 +3357,8 @@ packages:
     resolution: {integrity: sha512-hm8XshYj5Fo30Bb922QX9hXB/bxOAVH+qaqHBzw5TKa72vOeslyGwd4X8M0c1dJ9JqxlaMceOQ8RsL9tC7gU0A==}
     dev: false
 
-  /@codemirror/view@6.23.1:
-    resolution: {integrity: sha512-J2Xnn5lFYT1ZN/5ewEoMBCmLlL71lZ3mBdb7cUEuHhX2ESoSrNEucpsDXpX22EuTGm9LOgC9v4Z0wx+Ez8QmGA==}
+  /@codemirror/view@6.26.3:
+    resolution: {integrity: sha512-gmqxkPALZjkgSxIeeweY/wGQXBfwTUaLs8h7OKtSwfbj9Ct3L11lD+u1sS7XHppxFQoMDiMDp07P9f3I2jWOHw==}
     dependencies:
       '@codemirror/state': 6.4.0
       style-mod: 4.1.0
@@ -6159,14 +6159,14 @@ packages:
       rxjs: 7.8.1
     dev: false
 
-  /@opencodegraph/codemirror-extension@0.0.1(@codemirror/state@6.4.0)(@codemirror/view@6.23.1)(react-dom@18.1.0)(react@18.1.0):
+  /@opencodegraph/codemirror-extension@0.0.1(@codemirror/state@6.4.0)(@codemirror/view@6.26.3)(react-dom@18.1.0)(react@18.1.0):
     resolution: {integrity: sha512-n3WP/88qcgeJboqGI7HOfPujkhnTAJ5TGV9IIs03MAyY/V4/+/J8TclhUzjCX5Pu27eoG4RuZlY7379ejUvYkw==}
     peerDependencies:
       '@codemirror/state': ^6.2.0
       '@codemirror/view': ^6.7.2
     dependencies:
       '@codemirror/state': 6.4.0
-      '@codemirror/view': 6.23.1
+      '@codemirror/view': 6.26.3
       '@opencodegraph/client': 0.0.1
       '@opencodegraph/ui-react': 0.0.1(react-dom@18.1.0)(react@18.1.0)
       deep-equal: 2.2.3


### PR DESCRIPTION
This commit removes the full page scrolling behavior for repo root, directory and file pages. The implementation had several issues.

In the new implementation the scroll container is CodeMirror itself. It provides the following behavior:

- Show the top of the file when navigating to a new file.
- Scroll the selected line into view when opening a URL containing a position.
- Do not scroll when selecting a line (currently broken).
- Restore previous scroll position when navigating backward or forward in the browser history.
- Toggling the blame view maintains the current line view (well, almost but that's as best as we can do at the moment).

Additional changes in this commit:

- Removed logic to enable/disable full page scrolling.
- Remove CSS for making elements `sticky`.
- Update "scroll selected line into view" logic to prevent scrolling when restoring the previous scroll position.
- Update `codemirror/view` to include a recent fix for a scroll related bug.

NOTE: Due to these changes we lost scroll restoration for repo root and directory pages. This will be fixed in a separate PR.

## Test plan

`pnpm test` passes

Manual testing:

- Open file page in new tab -> file is scrolled to the top
- Open file page with selected line in new tab -> selected line is scrolled into view
- Navigate to new file via file tree -> new file is scrolled to the top
- Scroll file, navigate to new file and back -> scroll position is restored
- Scroll file, navigate back, navigate forward -> scroll position is restored

- Preview panel appears to be working (can scroll and navigate between matches)
- Directory page is scrollable
- Repo root page is scrollable
