### PR TITLE
Context: avoid panic on stopwords query

### DIFF
--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -1137,6 +1137,52 @@ func testSearchClient(t *testing.T, client searchClient) {
 		}
 	})
 
+	t.Run("Cody context search", func(t *testing.T) {
+		tests := []struct {
+			name       string
+			query      string
+			zeroResult bool
+		}{
+			{
+				name:       "Cody context, simple query, results",
+				query:      `repo:^github\.com/sgtest/go-diff$ patterntype:codycontext PrintMultiFileDiff unified `,
+				zeroResult: false,
+			},
+			{
+				name:       "Cody context, simple query, no results",
+				query:      `repo:^github\.com/sgtest/go-diff$ patterntype:codycontext DOES_NOT_EXIST ALSO_DOES_NOT_EXIST `,
+				zeroResult: true,
+			},
+			{
+				name:       "Cody context, all stopwords in query",
+				query:      `repo:^github\.com/sgtest/go-diff$ patterntype:codycontext tell me again!`,
+				zeroResult: true,
+			},
+		}
+		for _, test := range tests {
+			t.Run(test.name, func(t *testing.T) {
+				results, err := client.SearchFiles(test.query)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				if results.Alert != nil {
+					t.Fatalf("Unexpected alert %v", results.Alert)
+				}
+
+				if test.zeroResult {
+					if len(results.Results) > 0 {
+						t.Fatalf("Want zero result but got %d", len(results.Results))
+					}
+				} else {
+					if len(results.Results) == 0 {
+						t.Fatal("Want non-zero results but got 0")
+					}
+				}
+			})
+		}
+	})
+
 	type counts struct {
 		Repo    int
 		Commit  int

--- a/internal/search/job/jobutil/job_test.go
+++ b/internal/search/job/jobutil/job_test.go
@@ -1125,7 +1125,7 @@ func TestNewPlanJob(t *testing.T) {
     (query . )
     (originalQuery . )
     (patternType . codycontext)
-    ))
+    NOOP))
 `),
 		},
 		// The next query shows an unexpected way that a query is


### PR DESCRIPTION
In #61848, we tried to fix an issue when the query contained only stopwords. In
this case, we returned all content. This fix introduced a panic by returning a
nil search job, which is anot allowed by the our job framework.

Now, we return a `noopJob` which returns no results. This is the same approach
we use [when an AND/ OR query has no operands](https://sourcegraph.sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/internal/search/job/jobutil/job.go?L1042).

## Test plan

My testing was clearly lacking in the previous fix!! This time, I've added new
end-to-end GraphQL tests using `patterntype:codycontext`. Also tested manually
and checked there are no errors or panics in logs.