### PR TITLE
gitserver: RUsage and high mem exec logging

### DIFF
--- a/cmd/gitserver/internal/git/gitcli/BUILD.bazel
+++ b/cmd/gitserver/internal/git/gitcli/BUILD.bazel
@@ -29,6 +29,7 @@ go_library(
         "//cmd/gitserver/internal/git",
         "//internal/actor",
         "//internal/api",
+        "//internal/bytesize",
         "//internal/conf",
         "//internal/gitserver/gitdomain",
         "//internal/honey",

--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -6350,6 +6350,37 @@ Query:
 
 <br />
 
+#### gitserver: high_memory_git_commands
+
+<p class="subtitle">Number of git commands that exceeded the threshold for high memory usage</p>
+
+This graph tracks the number of git subcommands that gitserver ran that exceeded the threshold for high memory usage.
+This graph in itself is not an alert, but it is used to learn about the memory usage of gitserver.
+
+If gitserver frequently serves requests where the status code is KILLED, this graph might help to correlate that
+with the high memory usage.
+
+This graph spiking is not a problem necessarily. But when subcommands or the whole gitserver service are getting
+OOM killed and this graph shows spikes, increasing the memory might be useful.
+
+This panel has no related alerts.
+
+To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=100021` on your Sourcegraph instance.
+
+<sub>*Managed by the [Sourcegraph Source team](https://handbook.sourcegraph.com/departments/engineering/teams/source).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Query:
+
+```
+sort_desc(sum(sum_over_time(src_gitserver_exec_high_memory_usage_count{instance=~`${shard:regex}`}[2m])) by (cmd))
+```
+</details>
+
+<br />
+
 #### gitserver: running_git_commands
 
 <p class="subtitle">Git commands running on each gitserver instance</p>


### PR DESCRIPTION
This PR adds additional observation tools and warning logs for git commands that required a lot of memory. That should help us better identify where potential for OOMs exists and what endpoints could benefit from optimization.

```
[    gitserver-0] WARN gitserver.cleanup gitcli/command.go:307 High memory usage exec request {"TraceId": "f70c73e500ed7831207ce9a7c6dc63fb", "SpanId": "705d1dcfd0b44a06", "ev.Fields": {"exit_status": "0", "cmd_duration_ms": "1944", "user_time": "234.915ms", "cmd_ru_minflt": "10231", "cmd_ru_majflt": "7", "duration_ms": "1944", "trace": "https://sourcegraph.test:3443/-/debug/jaeger/trace/f70c73e500ed7831207ce9a7c6dc63fb", "cmd_ru_maxrss_kib": "160672", "actor": "0", "traceID": "f70c73e500ed7831207ce9a7c6dc63fb", "repo": "github.com/sourcegraph/sourcegraph", "args": "[git commit-graph write --reachable --changed-paths --size-multiple=4 --split]", "system_time": "1.679428s", "cmd_ru_inblock": "0", "cmd_ru_oublock": "0", "cmd": "commit-graph"}}
```

Test plan:

Tried this locally using some command I know will use a bunch of memory, see test output above.
