### PR TITLE
sg: print teammate details to terminal

### DIFF
--- a/dev/sg/sg_teammate.go
+++ b/dev/sg/sg_teammate.go
@@ -56,6 +56,7 @@ sg teammate handbook asdine
 				if err != nil {
 					return err
 				}
+
 				teammate, err := resolver.ResolveByName(ctx.Context, strings.Join(args, " "))
 				if err != nil {
 					return err
@@ -84,7 +85,44 @@ sg teammate handbook asdine
 				std.Out.Writef("Opening handbook link for %s: %s", teammate.Name, teammate.HandbookLink)
 				return open.URL(teammate.HandbookLink)
 			},
-		}},
+		},
+			{
+				Name:      "details",
+				ArgsUsage: "<nickname>",
+				Usage:     "print the details of a Sourcegraph",
+				Action: func(ctx *cli.Context) error {
+					args := ctx.Args().Slice()
+					if len(args) == 0 {
+						return errors.New("no nickname provided")
+					}
+					handle := strings.Join(args, "")
+					resolver, err := getTeamResolver(ctx.Context)
+					if err != nil {
+						return err
+					}
+					teammate, err := resolver.ResolveByGitHubHandle(ctx.Context, handle)
+					if err != nil {
+						return err
+					}
+					markdownFmt := `**Name**       : %s
+**Slack**      : %s
+**Email**      : %s
+**GitHub**     : %s
+**Location**   : %s
+**Role**       : %s
+**Description**: %s`
+					markdown := fmt.Sprintf(markdownFmt,
+						teammate.Name,
+						teammate.SlackName,
+						teammate.Email,
+						fmt.Sprintf("[%s](https://github.com/%s)", teammate.GitHub, teammate.GitHub),
+						teammate.Description,
+						teammate.Location,
+						teammate.Role)
+					return std.Out.WriteMarkdown(markdown)
+				},
+			},
+		},
 	}
 )
 

--- a/lib/output/output.go
+++ b/lib/output/output.go
@@ -290,6 +290,7 @@ func (o *Output) WriteMarkdown(str string, opts ...MarkdownStyleOpts) error {
 		// wrap output at slightly less than terminal width
 		glamour.WithWordWrap(o.caps.Width*4/5),
 		glamour.WithEmoji(),
+		glamour.WithPreservedNewLines(),
 	)
 	if err != nil {
 		return errors.Wrap(err, "renderer")


### PR DESCRIPTION
while looking into why certain github handles were not picked up and I noticed this was missing and it seems pretty useful

## Test plan
* Unit tests
* CI
* Locally
```
go run ./dev/sg teammate details william bezuidenhout

  Name       : William Bezuidenhout
  Slack      : william.bezuidenhout
  Email      : william.bezuidenhout@sourcegraph.com mailto:william.bezuidenhout@sourcegraph.com
  GitHub     : burmudar https://github.com/burmudar
  Location   : Cape Town, South Africa 🇿🇦
  Role       : Software Engineer
  Description: William lives in the beautiful Cape Town, South Africa. He enjoys running and moutain biking and when the weather permits (and his motivation) he can be out riding some trail at a wine
  farm or taking a leisure run. Besides the outdoor stuff, he loves to tinker and can often be found working on one of his side projects and reading up a storm on either tech, sci-fi, or fantasy! He
  loves animals and can easily be distracted by a dog.
```
