### PR TITLE
appliance: golden/snapshot testing

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -643,8 +643,8 @@ def go_dependencies():
         name = "com_github_bazelbuild_rules_go",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/bazelbuild/rules_go",
-        sum = "h1:uJStI9o5obVWSwquy9WxKNWfZxf2sKA2rpEsX6x5RVM=",
-        version = "v0.44.0",
+        sum = "h1:TTl2buKt0lqJe5s6up5FtaB1F95Wg997Lv15MWetU88=",
+        version = "v0.47.0",
     )
     go_repository(
         name = "com_github_becheran_wildmatch_go",
@@ -2398,8 +2398,8 @@ def go_dependencies():
         name = "com_github_golang_mock",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/golang/mock",
-        sum = "h1:ErTB+efbowRARo13NNdxyJji2egdxLGQhRaY+DUumQc=",
-        version = "v1.6.0",
+        sum = "h1:YojYx61/OLFsiv6Rw1Z96LpldJIy31o+UHmwAUMJ6/U=",
+        version = "v1.7.0-rc.1",
     )
     go_repository(
         name = "com_github_golang_protobuf",

--- a/dev/tool_deps.bzl
+++ b/dev/tool_deps.bzl
@@ -4,6 +4,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_file"
 
 DOCSITE_VERSION = "1.9.4"
 SRC_CLI_VERSION = "5.3.0"
+KUBEBUILDER_ASSETS_VERSION = "1.28.0"
 CTAGS_VERSION = "6.0.0.2783f009"
 PACKER_VERSION = "1.8.3"
 P4_FUSION_VERSION = "v1.13.2-sg.04a293a"
@@ -22,6 +23,14 @@ SRC_CLI_BUILDFILE = """
 filegroup(
     name = "src-cli-{}",
     srcs = ["src"],
+    visibility = ["//visibility:public"],
+)
+"""
+
+KUBEBUILDER_ASSETS_BUILDFILE = """
+filegroup(
+    name = "kubebuilder-assets",
+    srcs = glob(["*"]),
     visibility = ["//visibility:public"],
 )
 """
@@ -100,6 +109,31 @@ def tool_deps():
         build_file_content = SRC_CLI_BUILDFILE.format("darwin-arm64"),
         sha256 = "d2100e9dce86036c405490b89ab0dec40ee427884dead883c4ba69cc474caf45",
         url = "https://github.com/sourcegraph/src-cli/releases/download/{0}/src-cli_{0}_darwin_arm64.tar.gz".format(SRC_CLI_VERSION),
+    )
+
+    # Needed for internal/appliance tests
+    http_archive(
+        name = "kubebuilder-assets-darwin-arm64",
+        build_file_content = KUBEBUILDER_ASSETS_BUILDFILE,
+        sha256 = "c87c6b3c0aec4233e68a12dc9690bcbe2f8d6cd72c23e670602b17b2d7118325",
+        urls = ["https://storage.googleapis.com/kubebuilder-tools/kubebuilder-tools-{}-darwin-arm64.tar.gz".format(KUBEBUILDER_ASSETS_VERSION)],
+        strip_prefix = "kubebuilder/bin",
+    )
+
+    http_archive(
+        name = "kubebuilder-assets-darwin-amd64",
+        build_file_content = KUBEBUILDER_ASSETS_BUILDFILE,
+        sha256 = "a02e33a3981712c8d2702520f95357bd6c7d03d24b83a4f8ac1c89a9ba4d78c1",
+        urls = ["https://storage.googleapis.com/kubebuilder-tools/kubebuilder-tools-{}-darwin-amd64.tar.gz".format(KUBEBUILDER_ASSETS_VERSION)],
+        strip_prefix = "kubebuilder/bin",
+    )
+
+    http_archive(
+        name = "kubebuilder-assets-linux-amd64",
+        build_file_content = KUBEBUILDER_ASSETS_BUILDFILE,
+        sha256 = "8c816871604cbe119ca9dd8072b576552ae369b96eebc3cdaaf50edd7e3c0c7b",
+        urls = ["https://storage.googleapis.com/kubebuilder-tools/kubebuilder-tools-{}-linux-amd64.tar.gz".format(KUBEBUILDER_ASSETS_VERSION)],
+        strip_prefix = "kubebuilder/bin",
     )
 
     # universal-ctags

--- a/dev/tools/BUILD.bazel
+++ b/dev/tools/BUILD.bazel
@@ -107,3 +107,13 @@ sh_binary(
     }),
     visibility = ["//visibility:public"],
 )
+
+alias(
+    name = "kubebuilder-assets",
+    actual = select({
+        "@bazel_tools//src/conditions:darwin_x86_64": "@kubebuilder-assets-darwin-amd64//:kubebuilder-assets",
+        "@bazel_tools//src/conditions:darwin_arm64": "@kubebuilder-assets-darwin-arm64//:kubebuilder-assets",
+        "@bazel_tools//src/conditions:linux_x86_64": "@kubebuilder-assets-linux-amd64//:kubebuilder-assets",
+    }),
+    visibility = ["//visibility:public"],
+)

--- a/go.mod
+++ b/go.mod
@@ -252,6 +252,7 @@ require (
 	github.com/aws/constructs-go/constructs/v10 v10.2.69
 	github.com/aws/jsii-runtime-go v1.84.0
 	github.com/bazelbuild/bazel-gazelle v0.35.0
+	github.com/bazelbuild/rules_go v0.47.0
 	github.com/derision-test/go-mockgen/v2 v2.0.1
 	github.com/dghubble/gologin/v2 v2.4.0
 	github.com/edsrzf/mmap-go v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -298,8 +298,8 @@ github.com/bazelbuild/bazel-gazelle v0.35.0 h1:Bvg+zEHWYwWrhJT4WxyvcU3y1DEJpT/Xl
 github.com/bazelbuild/bazel-gazelle v0.35.0/go.mod h1:o2+s90f3w3U6jjw0gcdok0EJOfNK0AK/9RyVP7QkRDk=
 github.com/bazelbuild/buildtools v0.0.0-20231115204819-d4c9dccdfbb1 h1:2Gc2Q6hVR1SJ8bBI9Ybzoggp8u/ED2WkM4MfvEIn9+c=
 github.com/bazelbuild/buildtools v0.0.0-20231115204819-d4c9dccdfbb1/go.mod h1:689QdV3hBP7Vo9dJMmzhoYIyo/9iMhEmHkJcnaPRCbo=
-github.com/bazelbuild/rules_go v0.44.0 h1:uJStI9o5obVWSwquy9WxKNWfZxf2sKA2rpEsX6x5RVM=
-github.com/bazelbuild/rules_go v0.44.0/go.mod h1:z7Y8GZ90V4mwgYizbNbEQKmOmx93Q3Btcel4vX7pXoc=
+github.com/bazelbuild/rules_go v0.47.0 h1:TTl2buKt0lqJe5s6up5FtaB1F95Wg997Lv15MWetU88=
+github.com/bazelbuild/rules_go v0.47.0/go.mod h1:Dhcz716Kqg1RHNWos+N6MlXNkjNP2EwZQ0LukRKJfMs=
 github.com/becheran/wildmatch-go v1.0.0 h1:mE3dGGkTmpKtT4Z+88t8RStG40yN9T+kFEGj2PZFSzA=
 github.com/becheran/wildmatch-go v1.0.0/go.mod h1:gbMvj0NtVdJ15Mg/mH9uxk2R1QCistMyU7d9KFzroX4=
 github.com/beevik/etree v1.1.0/go.mod h1:r8Aw8JqVegEf0w2fDnATrX9VpkMcyFeM0FhwO62wh+A=
@@ -847,8 +847,8 @@ github.com/golang/mock v1.4.1/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt
 github.com/golang/mock v1.4.3/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt3cw=
 github.com/golang/mock v1.4.4/go.mod h1:l3mdAwkq5BuhzHwde/uurv3sEJeZMXNpwsxVWU71h+4=
 github.com/golang/mock v1.5.0/go.mod h1:CWnOUgYIOo4TcNZ0wHX3YZCqsaM1I1Jvs6v3mP3KVu8=
-github.com/golang/mock v1.6.0 h1:ErTB+efbowRARo13NNdxyJji2egdxLGQhRaY+DUumQc=
-github.com/golang/mock v1.6.0/go.mod h1:p6yTPP+5HYm5mzsMV8JkE6ZKdX+/wYM6Hr+LicevLPs=
+github.com/golang/mock v1.7.0-rc.1 h1:YojYx61/OLFsiv6Rw1Z96LpldJIy31o+UHmwAUMJ6/U=
+github.com/golang/mock v1.7.0-rc.1/go.mod h1:s42URUywIqd+OcERslBJvOjepvNymP31m3q8d/GkuRs=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=

--- a/internal/appliance/BUILD.bazel
+++ b/internal/appliance/BUILD.bazel
@@ -37,20 +37,31 @@ go_library(
     ],
 )
 
+filegroup(
+    name = "testdata",
+    srcs = glob(["testdata/**"]),
+)
+
 go_test(
     name = "appliance_test",
     srcs = [
         "blobstore_test.go",
         "golden_test.go",
-        "kubernetes_test.go",
-        "reconcile_test.go",
+        "helpers_test.go",
     ],
-    data = glob(["testdata/**"]),
+    data = [
+        ":testdata",
+        "//dev/tools:kubebuilder-assets",
+    ],
     embed = [":appliance"],
+    env = {
+        "KUBEBUILDER_ASSET_PATHS": "$(rlocationpaths //dev/tools:kubebuilder-assets)",
+    },
     deps = [
         "@com_github_go_logr_stdr//:stdr",
         "@com_github_stretchr_testify//require",
         "@com_github_stretchr_testify//suite",
+        "@io_bazel_rules_go//go/runfiles:go_default_library",
         "@io_k8s_api//core/v1:core",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:meta",
         "@io_k8s_apimachinery//pkg/runtime/schema",

--- a/internal/appliance/BUILD.bazel
+++ b/internal/appliance/BUILD.bazel
@@ -39,6 +39,27 @@ go_library(
 
 go_test(
     name = "appliance_test",
-    srcs = ["blobstore_test.go"],
+    srcs = [
+        "blobstore_test.go",
+        "golden_test.go",
+        "kubernetes_test.go",
+        "reconcile_test.go",
+    ],
+    data = glob(["testdata/**"]),
     embed = [":appliance"],
+    deps = [
+        "@com_github_go_logr_stdr//:stdr",
+        "@com_github_stretchr_testify//require",
+        "@com_github_stretchr_testify//suite",
+        "@io_k8s_api//core/v1:core",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:meta",
+        "@io_k8s_apimachinery//pkg/runtime/schema",
+        "@io_k8s_client_go//kubernetes",
+        "@io_k8s_client_go//kubernetes/scheme",
+        "@io_k8s_sigs_controller_runtime//:controller-runtime",
+        "@io_k8s_sigs_controller_runtime//pkg/client",
+        "@io_k8s_sigs_controller_runtime//pkg/envtest",
+        "@io_k8s_sigs_controller_runtime//pkg/metrics/server",
+        "@io_k8s_sigs_yaml//:yaml",
+    ],
 )

--- a/internal/appliance/BUILD.bazel
+++ b/internal/appliance/BUILD.bazel
@@ -57,6 +57,10 @@ go_test(
     env = {
         "KUBEBUILDER_ASSET_PATHS": "$(rlocationpaths //dev/tools:kubebuilder-assets)",
     },
+    tags = [
+        # Test starts kube-apiserver, which needs to bind an address.
+        "requires-network",
+    ],
     deps = [
         "@com_github_go_logr_stdr//:stdr",
         "@com_github_stretchr_testify//require",

--- a/internal/appliance/BUILD.bazel
+++ b/internal/appliance/BUILD.bazel
@@ -57,10 +57,6 @@ go_test(
     env = {
         "KUBEBUILDER_ASSET_PATHS": "$(rlocationpaths //dev/tools:kubebuilder-assets)",
     },
-    tags = [
-        # Test starts kube-apiserver, which needs to bind an address.
-        "requires-network",
-    ],
     deps = [
         "@com_github_go_logr_stdr//:stdr",
         "@com_github_stretchr_testify//require",

--- a/internal/appliance/blobstore.go
+++ b/internal/appliance/blobstore.go
@@ -3,6 +3,12 @@ package appliance
 import (
 	"context"
 
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
 	"github.com/sourcegraph/sourcegraph/internal/k8s/resource/container"
 	"github.com/sourcegraph/sourcegraph/internal/k8s/resource/deployment"
 	"github.com/sourcegraph/sourcegraph/internal/k8s/resource/pod"
@@ -10,11 +16,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/k8s/resource/service"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 	"github.com/sourcegraph/sourcegraph/lib/pointers"
-	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
-	"k8s.io/apimachinery/pkg/util/intstr"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func (r *Reconciler) reconcileBlobstore(ctx context.Context, sg *Sourcegraph, owner client.Object) error {
@@ -108,7 +109,7 @@ func (r *Reconciler) reconcileBlobstoreServices(ctx context.Context, sg *Sourceg
 func buildBlobstoreDeployment(sg *Sourcegraph) (appsv1.Deployment, error) {
 	name := "blobstore"
 
-	containerImage := ""
+	containerImage := "TODO"
 
 	containerPorts := corev1.ContainerPort{
 		Name:          name,
@@ -186,7 +187,7 @@ func buildBlobstoreDeployment(sg *Sourcegraph) (appsv1.Deployment, error) {
 		},
 	}
 
-	podTemplate, err := pod.NewPodTemplate(name, sg.Namespace,
+	podTemplate, err := pod.NewPodTemplate(name,
 		pod.WithContainers(defaultContainer),
 		pod.WithVolumes(podVolumes),
 	)

--- a/internal/appliance/blobstore.go
+++ b/internal/appliance/blobstore.go
@@ -109,7 +109,8 @@ func (r *Reconciler) reconcileBlobstoreServices(ctx context.Context, sg *Sourceg
 func buildBlobstoreDeployment(sg *Sourcegraph) (appsv1.Deployment, error) {
 	name := "blobstore"
 
-	containerImage := "TODO"
+	// TODO: https://github.com/sourcegraph/sourcegraph/issues/62076
+	containerImage := "index.docker.io/sourcegraph/blobstore:5.3.2@sha256:d625be1eefe61cc42f94498e3c588bf212c4159c8b20c519db84eae4ff715efa"
 
 	containerPorts := corev1.ContainerPort{
 		Name:          name,

--- a/internal/appliance/blobstore_test.go
+++ b/internal/appliance/blobstore_test.go
@@ -1,1 +1,46 @@
 package appliance
+
+import (
+	"time"
+)
+
+// Simple test cases in which we want to assert that a given configmap causes a
+// certain set of resources to be deployed can go here. sg and golden fixtures
+// are in testdata/ and named after the test case name.
+func (suite *ApplianceTestSuite) TestDeployBlobstore() {
+	for _, tc := range []struct {
+		name string
+	}{
+		{
+			name: "blobstore-default",
+		},
+	} {
+		suite.Run(tc.name, func() {
+			namespace := suite.createConfigMap(tc.name)
+
+			// Wait for reconciliation to be finished.
+			suite.Require().Eventually(func() bool {
+				return suite.getConfigMapReconcileEventCount(namespace) > 0
+			}, time.Second*10, time.Millisecond*200)
+
+			suite.makeGoldenAssertions(namespace, tc.name)
+		})
+	}
+}
+
+// More complex test cases involving updates to the configmap can have their own
+// test blocks
+func (suite *ApplianceTestSuite) TestBlobstoreResourcesDeletedWhenDisabled() {
+	namespace := suite.createConfigMap("blobstore-default")
+	suite.Require().Eventually(func() bool {
+		return suite.getConfigMapReconcileEventCount(namespace) > 0
+	}, time.Second*10, time.Millisecond*200)
+
+	eventsSeenSoFar := suite.getConfigMapReconcileEventCount(namespace)
+	suite.updateConfigMap(namespace, "everything-disabled")
+	suite.Require().Eventually(func() bool {
+		return suite.getConfigMapReconcileEventCount(namespace) > eventsSeenSoFar
+	}, time.Second*10, time.Millisecond*200)
+
+	suite.makeGoldenAssertions(namespace, "blobstore-subsequent-disable")
+}

--- a/internal/appliance/development.md
+++ b/internal/appliance/development.md
@@ -1,0 +1,19 @@
+# Appliance development
+
+## Running tests
+
+To (re)generate golden fixtures, pass the following argument to `go test`:
+
+```
+go test -args appliance-update-golden-files
+```
+
+In order to run `go test` (with or without arguments), you must have
+`setup-envtest` available:
+
+```
+go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+```
+
+This is not a requirement for the Bazel environment (`bazel test
+:appliance_test` in this module).

--- a/internal/appliance/golden_test.go
+++ b/internal/appliance/golden_test.go
@@ -1,0 +1,130 @@
+package appliance
+
+import (
+	"os"
+	"path/filepath"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/yaml"
+)
+
+// Test helpers
+
+// creationTimestamp and uid need to be normalized
+var magicTime = metav1.NewTime(time.Date(2024, time.April, 19, 0, 0, 0, 0, time.UTC))
+
+type goldenFile struct {
+	Resources []client.Object `json:"resources"`
+}
+
+func (suite *ApplianceTestSuite) makeGoldenAssertions(namespace, goldenFileName string) {
+	require := suite.Require()
+
+	goldenFilePath := filepath.Join("testdata", "golden-fixtures", goldenFileName+".yaml")
+	obtainedResources := goldenFile{Resources: suite.gatherResources(namespace)}
+	obtainedBytes, err := yaml.Marshal(obtainedResources)
+	require.NoError(err)
+	if len(os.Args) > 0 && os.Args[len(os.Args)-1] == "appliance-update-golden-files" {
+		err := os.WriteFile(goldenFilePath, obtainedBytes, 0600)
+		require.NoError(err)
+	}
+
+	goldenBytes, err := os.ReadFile(goldenFilePath)
+	require.NoError(err)
+
+	// testify prints a readable yaml diff
+	require.Equal(string(goldenBytes), string(obtainedBytes))
+}
+
+// When new owned types are declared in SetupWithManager() in reconcile.go, we
+// must gather them here for golden testing to be reliable.
+func (suite *ApplianceTestSuite) gatherResources(namespace string) []client.Object {
+	var objs []client.Object
+
+	// We set the GVK ourselves, as this is missing from the List response:
+	// https://github.com/kubernetes/client-go/issues/861
+	// This makes eyeballing golden file diffs a little easier, as we can see
+	// which object is being changed.
+	//
+	// Certain common fields must be normalized in order to make golden testing
+	// work, such as the creationTimestamp and UID, which would differ every
+	// test run. Some resource-specific normalizations are also performed.
+	deps, err := suite.k8sClient.AppsV1().Deployments(namespace).List(suite.ctx, metav1.ListOptions{})
+	suite.Require().NoError(err)
+	for _, obj := range deps.Items {
+		obj.SetGroupVersionKind(schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"})
+		normalizeObj(&obj)
+		objs = append(objs, &obj)
+	}
+	ssets, err := suite.k8sClient.AppsV1().StatefulSets(namespace).List(suite.ctx, metav1.ListOptions{})
+	suite.Require().NoError(err)
+	for _, obj := range ssets.Items {
+		obj.SetGroupVersionKind(schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "StatefulSet"})
+		normalizeObj(&obj)
+		objs = append(objs, &obj)
+	}
+	cmaps, err := suite.k8sClient.CoreV1().ConfigMaps(namespace).List(suite.ctx, metav1.ListOptions{})
+	suite.Require().NoError(err)
+	for _, obj := range cmaps.Items {
+		obj.SetGroupVersionKind(schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMap"})
+		normalizeObj(&obj)
+		objs = append(objs, &obj)
+	}
+	pvcs, err := suite.k8sClient.CoreV1().PersistentVolumeClaims(namespace).List(suite.ctx, metav1.ListOptions{})
+	suite.Require().NoError(err)
+	for _, obj := range pvcs.Items {
+		if obj.DeletionTimestamp != nil {
+			obj.DeletionTimestamp = &magicTime
+		}
+		obj.SetGroupVersionKind(schema.GroupVersionKind{Group: "", Version: "v1", Kind: "PersistentVolumeClaim"})
+		normalizeObj(&obj)
+		objs = append(objs, &obj)
+	}
+	pods, err := suite.k8sClient.CoreV1().Pods(namespace).List(suite.ctx, metav1.ListOptions{})
+	suite.Require().NoError(err)
+	for _, obj := range pods.Items {
+		obj.SetGroupVersionKind(schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"})
+		normalizeObj(&obj)
+		objs = append(objs, &obj)
+	}
+
+	// These are just test secrets, nothing truly sensitive should end up in the
+	// golden files.
+	secrets, err := suite.k8sClient.CoreV1().Secrets(namespace).List(suite.ctx, metav1.ListOptions{})
+	suite.Require().NoError(err)
+	for _, obj := range secrets.Items {
+		obj.SetGroupVersionKind(schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Secret"})
+		normalizeObj(&obj)
+		objs = append(objs, &obj)
+	}
+
+	sas, err := suite.k8sClient.CoreV1().ServiceAccounts(namespace).List(suite.ctx, metav1.ListOptions{})
+	suite.Require().NoError(err)
+	for _, obj := range sas.Items {
+		obj.SetGroupVersionKind(schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ServiceAccount"})
+		normalizeObj(&obj)
+		objs = append(objs, &obj)
+	}
+	svcs, err := suite.k8sClient.CoreV1().Services(namespace).List(suite.ctx, metav1.ListOptions{})
+	suite.Require().NoError(err)
+	for _, obj := range svcs.Items {
+		obj.Spec.ClusterIP = "NORMALIZED_FOR_TESTING"
+		obj.Spec.ClusterIPs = []string{"NORMALIZED_FOR_TESTING"}
+		obj.SetGroupVersionKind(schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Service"})
+		normalizeObj(&obj)
+		objs = append(objs, &obj)
+	}
+
+	return objs
+}
+
+func normalizeObj(obj client.Object) {
+	obj.SetUID("NORMALIZED_FOR_TESTING")
+	obj.SetCreationTimestamp(magicTime)
+	obj.SetManagedFields(nil)
+	obj.SetNamespace("NORMALIZED_FOR_TESTING")
+	obj.SetResourceVersion("NORMALIZED_FOR_TESTING")
+}

--- a/internal/appliance/golden_test.go
+++ b/internal/appliance/golden_test.go
@@ -55,6 +55,7 @@ func (suite *ApplianceTestSuite) gatherResources(namespace string) []client.Obje
 	deps, err := suite.k8sClient.AppsV1().Deployments(namespace).List(suite.ctx, metav1.ListOptions{})
 	suite.Require().NoError(err)
 	for _, obj := range deps.Items {
+		obj := obj // see exportloopref
 		obj.SetGroupVersionKind(schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"})
 		normalizeObj(&obj)
 		objs = append(objs, &obj)
@@ -62,6 +63,7 @@ func (suite *ApplianceTestSuite) gatherResources(namespace string) []client.Obje
 	ssets, err := suite.k8sClient.AppsV1().StatefulSets(namespace).List(suite.ctx, metav1.ListOptions{})
 	suite.Require().NoError(err)
 	for _, obj := range ssets.Items {
+		obj := obj
 		obj.SetGroupVersionKind(schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "StatefulSet"})
 		normalizeObj(&obj)
 		objs = append(objs, &obj)
@@ -69,6 +71,7 @@ func (suite *ApplianceTestSuite) gatherResources(namespace string) []client.Obje
 	cmaps, err := suite.k8sClient.CoreV1().ConfigMaps(namespace).List(suite.ctx, metav1.ListOptions{})
 	suite.Require().NoError(err)
 	for _, obj := range cmaps.Items {
+		obj := obj
 		obj.SetGroupVersionKind(schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMap"})
 		normalizeObj(&obj)
 		objs = append(objs, &obj)
@@ -76,6 +79,7 @@ func (suite *ApplianceTestSuite) gatherResources(namespace string) []client.Obje
 	pvcs, err := suite.k8sClient.CoreV1().PersistentVolumeClaims(namespace).List(suite.ctx, metav1.ListOptions{})
 	suite.Require().NoError(err)
 	for _, obj := range pvcs.Items {
+		obj := obj
 		if obj.DeletionTimestamp != nil {
 			obj.DeletionTimestamp = &magicTime
 		}
@@ -86,6 +90,7 @@ func (suite *ApplianceTestSuite) gatherResources(namespace string) []client.Obje
 	pods, err := suite.k8sClient.CoreV1().Pods(namespace).List(suite.ctx, metav1.ListOptions{})
 	suite.Require().NoError(err)
 	for _, obj := range pods.Items {
+		obj := obj
 		obj.SetGroupVersionKind(schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"})
 		normalizeObj(&obj)
 		objs = append(objs, &obj)
@@ -96,6 +101,7 @@ func (suite *ApplianceTestSuite) gatherResources(namespace string) []client.Obje
 	secrets, err := suite.k8sClient.CoreV1().Secrets(namespace).List(suite.ctx, metav1.ListOptions{})
 	suite.Require().NoError(err)
 	for _, obj := range secrets.Items {
+		obj := obj
 		obj.SetGroupVersionKind(schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Secret"})
 		normalizeObj(&obj)
 		objs = append(objs, &obj)
@@ -104,6 +110,7 @@ func (suite *ApplianceTestSuite) gatherResources(namespace string) []client.Obje
 	sas, err := suite.k8sClient.CoreV1().ServiceAccounts(namespace).List(suite.ctx, metav1.ListOptions{})
 	suite.Require().NoError(err)
 	for _, obj := range sas.Items {
+		obj := obj
 		obj.SetGroupVersionKind(schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ServiceAccount"})
 		normalizeObj(&obj)
 		objs = append(objs, &obj)
@@ -111,6 +118,7 @@ func (suite *ApplianceTestSuite) gatherResources(namespace string) []client.Obje
 	svcs, err := suite.k8sClient.CoreV1().Services(namespace).List(suite.ctx, metav1.ListOptions{})
 	suite.Require().NoError(err)
 	for _, obj := range svcs.Items {
+		obj := obj
 		obj.Spec.ClusterIP = "NORMALIZED_FOR_TESTING"
 		obj.Spec.ClusterIPs = []string{"NORMALIZED_FOR_TESTING"}
 		obj.SetGroupVersionKind(schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Service"})

--- a/internal/appliance/helpers_test.go
+++ b/internal/appliance/helpers_test.go
@@ -63,6 +63,9 @@ func (suite *ApplianceTestSuite) setupEnvtest() {
 		AttachControlPlaneOutput: true,
 		BinaryAssetsDirectory:    suite.kubebuilderAssetPath(),
 	}
+	apiServerCfg := suite.testEnv.ControlPlane.GetAPIServer()
+	apiServerCfg.Configure().Set("bind-address", "127.0.0.1")
+	apiServerCfg.Configure().Set("advertise-address", "127.0.0.1")
 	cfg, err := suite.testEnv.Start()
 	require.NoError(t, err)
 

--- a/internal/appliance/helpers_test.go
+++ b/internal/appliance/helpers_test.go
@@ -60,7 +60,8 @@ func (suite *ApplianceTestSuite) setupEnvtest() {
 	logger := stdr.New(stdlog.New(os.Stderr, "", stdlog.LstdFlags))
 
 	suite.testEnv = &envtest.Environment{
-		BinaryAssetsDirectory: suite.kubebuilderAssetPath(),
+		AttachControlPlaneOutput: true,
+		BinaryAssetsDirectory:    suite.kubebuilderAssetPath(),
 	}
 	cfg, err := suite.testEnv.Start()
 	require.NoError(t, err)

--- a/internal/appliance/kubernetes.go
+++ b/internal/appliance/kubernetes.go
@@ -33,7 +33,7 @@ import (
 // limitations of Go generics.
 func createOrUpdateObject[R client.Object](
 	ctx context.Context, r *Reconciler, updateIfChanged any,
-	owner client.Object, obj client.Object, objKind R,
+	owner client.Object, obj, objKind R,
 ) error {
 	logger := log.FromContext(ctx).WithValues("kind", obj.GetObjectKind().GroupVersionKind(), "namespace", obj.GetNamespace(), "name", obj.GetName())
 	namespacedName := types.NamespacedName{Namespace: obj.GetNamespace(), Name: obj.GetName()}

--- a/internal/appliance/kubernetes_test.go
+++ b/internal/appliance/kubernetes_test.go
@@ -1,0 +1,171 @@
+package appliance
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	stdlog "log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/go-logr/stdr"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+)
+
+// Test helpers
+
+type ApplianceTestSuite struct {
+	suite.Suite
+
+	ctx       context.Context
+	cancelCtx context.CancelFunc
+
+	testEnv     *envtest.Environment
+	ctrlMgrDone chan (struct{})
+
+	k8sClient *kubernetes.Clientset
+}
+
+func TestApplianceTestSuite(t *testing.T) {
+	suite.Run(t, new(ApplianceTestSuite))
+}
+
+func (s *ApplianceTestSuite) SetupSuite() {
+	s.ctx, s.cancelCtx = context.WithCancel(context.Background())
+	s.setupEnvtest()
+}
+
+func (s *ApplianceTestSuite) TearDownSuite() {
+	t := s.T()
+	s.cancelCtx()
+	require.NoError(t, s.testEnv.Stop())
+	<-s.ctrlMgrDone
+}
+
+func (s *ApplianceTestSuite) setupEnvtest() {
+	t := s.T()
+	logger := stdr.New(stdlog.New(os.Stderr, "", stdlog.LstdFlags))
+
+	// TODO figure out a way to make this work with bazel. Either download the
+	// etcd/k8s executables that setup-envtest downloads and pass that directory
+	// into BinaryAssetsDirectory below, or download setup-envtest without
+	// assuming it's already on the PATH.
+	// Ideally these assets could be cached in buildkite too.
+	setupEnvTestCmd := exec.Command("setup-envtest", "use", "1.28.0", "--bin-dir", "/tmp/envtest", "-p", "path")
+	var envtestOut bytes.Buffer
+	setupEnvTestCmd.Stdout = &envtestOut
+	err := setupEnvTestCmd.Run()
+	require.NoError(t, err)
+
+	s.testEnv = &envtest.Environment{
+		BinaryAssetsDirectory: strings.TrimSpace(envtestOut.String()),
+	}
+	cfg, err := s.testEnv.Start()
+	require.NoError(t, err)
+
+	// If we had CRDs, this is where we'd add them to the scheme
+
+	ctrlMgr, err := ctrl.NewManager(cfg, ctrl.Options{
+		Logger: logger,
+		Scheme: scheme.Scheme,
+
+		// On macos with the built-in firewall enabled, every test run will
+		// cause a firewall dialog box to pop. That's incredibly annoying. This
+		// can be solved by binding the metrics server to localhost, but we
+		// don't need it, so we disable it altogether.
+		Metrics: metricsserver.Options{BindAddress: "0"},
+	})
+	require.NoError(t, err)
+	s.k8sClient, err = kubernetes.NewForConfig(cfg)
+	require.NoError(t, err)
+
+	reconciler := &Reconciler{
+		Client:   ctrlMgr.GetClient(),
+		Scheme:   ctrlMgr.GetScheme(),
+		Recorder: ctrlMgr.GetEventRecorderFor("appliance"),
+	}
+	require.NoError(t, reconciler.SetupWithManager(ctrlMgr))
+
+	// Start controller manager async. We'll stop it with context cancellation
+	// later.
+	s.ctrlMgrDone = make(chan struct{})
+	go func() {
+		require.NoError(t, ctrlMgr.Start(s.ctx))
+		close(s.ctrlMgrDone)
+	}()
+}
+
+func (s *ApplianceTestSuite) createConfigMap(fixtureFileName string) string {
+	// Create a random namespace for each test
+	namespace := "test-appliance-" + s.randomSlug()
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: namespace,
+		},
+	}
+	_, err := s.k8sClient.CoreV1().Namespaces().Create(s.ctx, ns, metav1.CreateOptions{})
+	s.Require().NoError(err)
+
+	cfgMap := s.newConfigMap(namespace, fixtureFileName)
+	_, err = s.k8sClient.CoreV1().ConfigMaps(namespace).Create(s.ctx, cfgMap, metav1.CreateOptions{})
+	s.Require().NoError(err)
+	return namespace
+}
+
+func (s *ApplianceTestSuite) updateConfigMap(namespace, fixtureFileName string) {
+	cfgMap := s.newConfigMap(namespace, fixtureFileName)
+	_, err := s.k8sClient.CoreV1().ConfigMaps(namespace).Update(s.ctx, cfgMap, metav1.UpdateOptions{})
+	s.Require().NoError(err)
+}
+
+// Synchronize test and controller code by counting ReconcileFInished events.
+// Some tests might want to wait for more than 1 to appear.
+func (suite *ApplianceTestSuite) getConfigMapReconcileEventCount(namespace string) int32 {
+	t := suite.T()
+	events, err := suite.k8sClient.CoreV1().Events(namespace).List(suite.ctx, metav1.ListOptions{
+		FieldSelector: "involvedObject.name=sg,reason=ReconcileFinished",
+		TypeMeta:      metav1.TypeMeta{Kind: "ConfigMap"},
+	})
+	require.NoError(t, err)
+	if len(events.Items) == 0 {
+		return 0
+	}
+	event := events.Items[0]
+	return event.Count
+}
+
+func (s *ApplianceTestSuite) newConfigMap(namespace, fixtureFileName string) *corev1.ConfigMap {
+	t := s.T()
+	cfgBytes, err := os.ReadFile(filepath.Join("testdata", "sg", fixtureFileName+".yaml"))
+	require.NoError(t, err)
+
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "sg",
+			Namespace: namespace,
+			Annotations: map[string]string{
+				annotationKeyManaged: "true",
+			},
+		},
+		Data: map[string]string{"spec": string(cfgBytes)},
+	}
+}
+
+func (s *ApplianceTestSuite) randomSlug() string {
+	buf := make([]byte, 3)
+	_, err := rand.Read(buf)
+	s.Require().NoError(err)
+	return hex.EncodeToString(buf)
+}

--- a/internal/appliance/kubernetes_test.go
+++ b/internal/appliance/kubernetes_test.go
@@ -33,7 +33,7 @@ type ApplianceTestSuite struct {
 	cancelCtx context.CancelFunc
 
 	testEnv     *envtest.Environment
-	ctrlMgrDone chan (struct{})
+	ctrlMgrDone chan struct{}
 
 	k8sClient *kubernetes.Clientset
 }

--- a/internal/appliance/kubernetes_test.go
+++ b/internal/appliance/kubernetes_test.go
@@ -130,7 +130,7 @@ func (s *ApplianceTestSuite) updateConfigMap(namespace, fixtureFileName string) 
 	s.Require().NoError(err)
 }
 
-// Synchronize test and controller code by counting ReconcileFInished events.
+// Synchronize test and controller code by counting ReconcileFinished events.
 // Some tests might want to wait for more than 1 to appear.
 func (suite *ApplianceTestSuite) getConfigMapReconcileEventCount(namespace string) int32 {
 	t := suite.T()

--- a/internal/appliance/reconcile.go
+++ b/internal/appliance/reconcile.go
@@ -20,6 +20,7 @@ import (
 )
 
 const (
+	annotationKeyManaged        = "appliance.sourcegraph.com/managed"
 	annotationKeyCurrentVersion = "appliance.sourcegraph.com/currentVersion"
 	annotationKeyConfigHash     = "appliance.sourcegraph.com/configHash"
 )
@@ -45,6 +46,13 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		reqLog.Error(err, "failed to fetch sourcegraph appliance spec")
 		return ctrl.Result{}, err
 	}
+
+	// Emit a ReconcileFinished event at the end. Currently, this is only used
+	// to synchronize this reconcile loop with test code, allowing reliable
+	// assertions on the state of the cluster at the time this event is emitted.
+	// Perhaps this should be feature-flagged so that it is only emitted during
+	// tests, if it isn't useful elsewhere.
+	defer r.Recorder.Event(&applianceSpec, "Normal", "ReconcileFinished", "Reconcile finished.")
 
 	// TODO place holder code until we get the configmap spec'd out and working'
 	data, ok := applianceSpec.Data["spec"]
@@ -84,9 +92,11 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 
 func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 	applianceAnnotationPredicate := predicate.NewPredicateFuncs(func(object client.Object) bool {
-		return object.GetAnnotations()["appliance.sourcegraph.com/managed"] == "true"
+		return object.GetAnnotations()[annotationKeyManaged] == "true"
 	})
 
+	// When updating this list of owned resources, please update the
+	// corresponding code in gatherResources() in golden_test.go.
 	return ctrl.NewControllerManagedBy(mgr).
 		WithEventFilter(applianceAnnotationPredicate).
 		For(&corev1.ConfigMap{}).

--- a/internal/appliance/reconcile_test.go
+++ b/internal/appliance/reconcile_test.go
@@ -1,0 +1,3 @@
+package appliance
+
+// TODO test that only non-annotated configmaps don't cause anything to happen

--- a/internal/appliance/reconcile_test.go
+++ b/internal/appliance/reconcile_test.go
@@ -1,3 +1,0 @@
-package appliance
-
-// TODO test that only non-annotated configmaps don't cause anything to happen

--- a/internal/appliance/spec.go
+++ b/internal/appliance/spec.go
@@ -29,7 +29,7 @@ type DatabaseSpec struct {
 type BlobstoreSpec struct {
 	// Disabled defines if Blobstore is enabled or not.
 	// Default: false
-	Disabled bool `json:"enabled,omitempty"`
+	Disabled bool `json:"disabled,omitempty"`
 
 	// StorageSize defines the requested amount of storage for the PVC.
 	// Default: 200Gi
@@ -265,9 +265,9 @@ type RepoUpdaterSpec struct {
 
 // SearcherSpec defines the desired state of the Searcher service.
 type SearcherSpec struct {
-	// Enabled defines if Code Intel is enabled or not.
-	// Default: true
-	Enabled bool `json:"enabled,omitempty"`
+	// Disabled defines if Code Intel is enabled or not.
+	// Default: false
+	Disabled bool `json:"disabled,omitempty"`
 
 	// Replicas defines the number of Searcher pod replicas.
 	// Default: 1

--- a/internal/appliance/testdata/golden-fixtures/blobstore-default.yaml
+++ b/internal/appliance/testdata/golden-fixtures/blobstore-default.yaml
@@ -1,0 +1,205 @@
+resources:
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    annotations:
+      appliance.sourcegraph.com/configHash: ec8df597cb447c262ad15de9e72b1f836e1b631c928fcc06914500caa58f8cc3
+    creationTimestamp: "2024-04-19T00:00:00Z"
+    generation: 1
+    labels:
+      app.kubernetes.io/component: blobstore
+      app.kubernetes.io/name: sourcegraph
+      app.kubernetes.io/version: 5.3.9104
+      deploy: sourcegraph
+    name: blobstore
+    namespace: NORMALIZED_FOR_TESTING
+    resourceVersion: NORMALIZED_FOR_TESTING
+    uid: NORMALIZED_FOR_TESTING
+  spec:
+    minReadySeconds: 10
+    progressDeadlineSeconds: 600
+    replicas: 1
+    revisionHistoryLimit: 10
+    selector:
+      matchLabels:
+        app: blobstore
+    strategy:
+      type: Recreate
+    template:
+      metadata:
+        annotations:
+          kubectl.kubernetes.io/default-container: blobstore
+        creationTimestamp: null
+        labels:
+          app: blobstore
+          deploy: sourcegraph
+        name: blobstore
+      spec:
+        containers:
+        - image: TODO
+          imagePullPolicy: IfNotPresent
+          name: blobstore
+          ports:
+          - containerPort: 9000
+            name: blobstore
+            protocol: TCP
+          resources:
+            limits:
+              cpu: "1"
+              memory: 500M
+            requests:
+              cpu: "1"
+              memory: 500M
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsGroup: 101
+            runAsUser: 100
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: FallbackToLogsOnError
+          volumeMounts:
+          - mountPath: /blobstore
+            name: blobstore
+          - mountPath: /data
+            name: blobstore-data
+        dnsPolicy: ClusterFirst
+        restartPolicy: Always
+        schedulerName: default-scheduler
+        securityContext:
+          fsGroup: 101
+          fsGroupChangePolicy: OnRootMismatch
+          runAsGroup: 101
+          runAsUser: 100
+        terminationGracePeriodSeconds: 30
+        volumes:
+        - emptyDir: {}
+          name: blobstore
+        - name: blobstore-data
+          persistentVolumeClaim:
+            claimName: blobstore
+  status: {}
+- apiVersion: v1
+  data:
+    spec: |
+      spec:
+        requestedVersion: "5.3.9104"
+
+        blobstore: {}
+
+        codeInsights:
+          disabled: true
+
+        codeIntel:
+          disabled: true
+
+        frontend:
+          disabled: true
+
+        gitServer:
+          disabled: true
+
+        indexedSearch:
+          disabled: true
+
+        indexedSearchIndexer:
+          disabled: true
+
+        pgsql:
+          disabled: true
+
+        postgresExporter:
+          disabled: true
+
+        preciseCodeIntel:
+          disabled: true
+
+        redisCache:
+          disabled: true
+
+        redisExporter:
+          disabled: true
+
+        redisStore:
+          disabled: true
+
+        repoUpdater:
+          disabled: true
+
+        searcher:
+          disabled: true
+
+        symbols:
+          disabled: true
+
+        syntectServer:
+          disabled: true
+
+        worker:
+          disabled: true
+  kind: ConfigMap
+  metadata:
+    annotations:
+      appliance.sourcegraph.com/currentVersion: 5.3.9104
+      appliance.sourcegraph.com/managed: "true"
+    creationTimestamp: "2024-04-19T00:00:00Z"
+    labels:
+      sourcegraph.k8s.sourcegraph.com/template-hash: "142411231"
+    name: sg
+    namespace: NORMALIZED_FOR_TESTING
+    resourceVersion: NORMALIZED_FOR_TESTING
+    uid: NORMALIZED_FOR_TESTING
+- apiVersion: v1
+  kind: PersistentVolumeClaim
+  metadata:
+    annotations:
+      appliance.sourcegraph.com/configHash: ec8df597cb447c262ad15de9e72b1f836e1b631c928fcc06914500caa58f8cc3
+    creationTimestamp: "2024-04-19T00:00:00Z"
+    finalizers:
+    - kubernetes.io/pvc-protection
+    labels:
+      deploy: sourcegraph
+    name: blobstore
+    namespace: NORMALIZED_FOR_TESTING
+    resourceVersion: NORMALIZED_FOR_TESTING
+    uid: NORMALIZED_FOR_TESTING
+  spec:
+    accessModes:
+    - ReadWriteOnce
+    resources:
+      requests:
+        storage: 100Gi
+    volumeMode: Filesystem
+  status:
+    phase: Pending
+- apiVersion: v1
+  kind: Service
+  metadata:
+    annotations:
+      appliance.sourcegraph.com/configHash: ec8df597cb447c262ad15de9e72b1f836e1b631c928fcc06914500caa58f8cc3
+    creationTimestamp: "2024-04-19T00:00:00Z"
+    labels:
+      app: blobstore
+      deploy: sourcegraph
+    name: blobstore
+    namespace: NORMALIZED_FOR_TESTING
+    resourceVersion: NORMALIZED_FOR_TESTING
+    uid: NORMALIZED_FOR_TESTING
+  spec:
+    clusterIP: NORMALIZED_FOR_TESTING
+    clusterIPs:
+    - NORMALIZED_FOR_TESTING
+    internalTrafficPolicy: Cluster
+    ipFamilies:
+    - IPv4
+    ipFamilyPolicy: SingleStack
+    ports:
+    - name: blobstore
+      port: 9000
+      protocol: TCP
+      targetPort: blobstore
+    selector:
+      app: blobstore
+    sessionAffinity: None
+    type: ClusterIP
+  status:
+    loadBalancer: {}

--- a/internal/appliance/testdata/golden-fixtures/blobstore-default.yaml
+++ b/internal/appliance/testdata/golden-fixtures/blobstore-default.yaml
@@ -36,7 +36,7 @@ resources:
         name: blobstore
       spec:
         containers:
-        - image: TODO
+        - image: index.docker.io/sourcegraph/blobstore:5.3.2@sha256:d625be1eefe61cc42f94498e3c588bf212c4159c8b20c519db84eae4ff715efa
           imagePullPolicy: IfNotPresent
           name: blobstore
           ports:

--- a/internal/appliance/testdata/golden-fixtures/blobstore-default.yaml
+++ b/internal/appliance/testdata/golden-fixtures/blobstore-default.yaml
@@ -142,8 +142,6 @@ resources:
       appliance.sourcegraph.com/currentVersion: 5.3.9104
       appliance.sourcegraph.com/managed: "true"
     creationTimestamp: "2024-04-19T00:00:00Z"
-    labels:
-      sourcegraph.k8s.sourcegraph.com/template-hash: "142411231"
     name: sg
     namespace: NORMALIZED_FOR_TESTING
     resourceVersion: NORMALIZED_FOR_TESTING

--- a/internal/appliance/testdata/golden-fixtures/blobstore-subsequent-disable.yaml
+++ b/internal/appliance/testdata/golden-fixtures/blobstore-subsequent-disable.yaml
@@ -1,0 +1,97 @@
+resources:
+- apiVersion: v1
+  data:
+    spec: |
+      spec:
+        requestedVersion: "5.3.9104"
+
+        blobstore:
+          disabled: true
+
+        codeInsights:
+          disabled: true
+
+        codeIntel:
+          disabled: true
+
+        frontend:
+          disabled: true
+
+        gitServer:
+          disabled: true
+
+        indexedSearch:
+          disabled: true
+
+        indexedSearchIndexer:
+          disabled: true
+
+        pgsql:
+          disabled: true
+
+        postgresExporter:
+          disabled: true
+
+        preciseCodeIntel:
+          disabled: true
+
+        redisCache:
+          disabled: true
+
+        redisExporter:
+          disabled: true
+
+        redisStore:
+          disabled: true
+
+        repoUpdater:
+          disabled: true
+
+        searcher:
+          disabled: true
+
+        symbols:
+          disabled: true
+
+        syntectServer:
+          disabled: true
+
+        worker:
+          disabled: true
+  kind: ConfigMap
+  metadata:
+    annotations:
+      appliance.sourcegraph.com/currentVersion: 5.3.9104
+      appliance.sourcegraph.com/managed: "true"
+    creationTimestamp: "2024-04-19T00:00:00Z"
+    labels:
+      sourcegraph.k8s.sourcegraph.com/template-hash: "3961876447"
+    name: sg
+    namespace: NORMALIZED_FOR_TESTING
+    resourceVersion: NORMALIZED_FOR_TESTING
+    uid: NORMALIZED_FOR_TESTING
+- apiVersion: v1
+  kind: PersistentVolumeClaim
+  metadata:
+    annotations:
+      appliance.sourcegraph.com/configHash: ec8df597cb447c262ad15de9e72b1f836e1b631c928fcc06914500caa58f8cc3
+    creationTimestamp: "2024-04-19T00:00:00Z"
+    deletionGracePeriodSeconds: 0
+    deletionTimestamp: "2024-04-19T00:00:00Z"
+    finalizers:
+    - kubernetes.io/pvc-protection
+    labels:
+      deploy: sourcegraph
+    name: blobstore
+    namespace: NORMALIZED_FOR_TESTING
+    resourceVersion: NORMALIZED_FOR_TESTING
+    uid: NORMALIZED_FOR_TESTING
+  spec:
+    accessModes:
+    - ReadWriteOnce
+    resources:
+      requests:
+        storage: 100Gi
+    volumeMode: Filesystem
+  status:
+    phase: Pending

--- a/internal/appliance/testdata/golden-fixtures/blobstore-subsequent-disable.yaml
+++ b/internal/appliance/testdata/golden-fixtures/blobstore-subsequent-disable.yaml
@@ -64,8 +64,6 @@ resources:
       appliance.sourcegraph.com/currentVersion: 5.3.9104
       appliance.sourcegraph.com/managed: "true"
     creationTimestamp: "2024-04-19T00:00:00Z"
-    labels:
-      sourcegraph.k8s.sourcegraph.com/template-hash: "3961876447"
     name: sg
     namespace: NORMALIZED_FOR_TESTING
     resourceVersion: NORMALIZED_FOR_TESTING

--- a/internal/appliance/testdata/sg/blobstore-default.yaml
+++ b/internal/appliance/testdata/sg/blobstore-default.yaml
@@ -1,0 +1,55 @@
+spec:
+  requestedVersion: "5.3.9104"
+
+  blobstore: {}
+
+  codeInsights:
+    disabled: true
+
+  codeIntel:
+    disabled: true
+
+  frontend:
+    disabled: true
+
+  gitServer:
+    disabled: true
+
+  indexedSearch:
+    disabled: true
+
+  indexedSearchIndexer:
+    disabled: true
+
+  pgsql:
+    disabled: true
+
+  postgresExporter:
+    disabled: true
+
+  preciseCodeIntel:
+    disabled: true
+
+  redisCache:
+    disabled: true
+
+  redisExporter:
+    disabled: true
+
+  redisStore:
+    disabled: true
+
+  repoUpdater:
+    disabled: true
+
+  searcher:
+    disabled: true
+
+  symbols:
+    disabled: true
+
+  syntectServer:
+    disabled: true
+
+  worker:
+    disabled: true

--- a/internal/appliance/testdata/sg/everything-disabled.yaml
+++ b/internal/appliance/testdata/sg/everything-disabled.yaml
@@ -1,0 +1,56 @@
+spec:
+  requestedVersion: "5.3.9104"
+
+  blobstore:
+    disabled: true
+
+  codeInsights:
+    disabled: true
+
+  codeIntel:
+    disabled: true
+
+  frontend:
+    disabled: true
+
+  gitServer:
+    disabled: true
+
+  indexedSearch:
+    disabled: true
+
+  indexedSearchIndexer:
+    disabled: true
+
+  pgsql:
+    disabled: true
+
+  postgresExporter:
+    disabled: true
+
+  preciseCodeIntel:
+    disabled: true
+
+  redisCache:
+    disabled: true
+
+  redisExporter:
+    disabled: true
+
+  redisStore:
+    disabled: true
+
+  repoUpdater:
+    disabled: true
+
+  searcher:
+    disabled: true
+
+  symbols:
+    disabled: true
+
+  syntectServer:
+    disabled: true
+
+  worker:
+    disabled: true

--- a/internal/k8s/resource/deployment/deployment_test.go
+++ b/internal/k8s/resource/deployment/deployment_test.go
@@ -375,7 +375,7 @@ func TestNewDeployment(t *testing.T) {
 					},
 					Template: corev1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
-							Name:      "foo",
+							Name: "foo",
 							Annotations: map[string]string{
 								"kubectl.kubernetes.io/default-container": "foo",
 							},

--- a/internal/k8s/resource/deployment/deployment_test.go
+++ b/internal/k8s/resource/deployment/deployment_test.go
@@ -345,7 +345,7 @@ func TestNewDeployment(t *testing.T) {
 				version:   "1.2.3",
 				options: []Option{
 					WithPodTemplateSpec(func() corev1.PodTemplateSpec {
-						ts, _ := pod.NewPodTemplate("foo", "sourcegraph")
+						ts, _ := pod.NewPodTemplate("foo")
 						return ts.Template
 					}()),
 				},
@@ -376,7 +376,6 @@ func TestNewDeployment(t *testing.T) {
 					Template: corev1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      "foo",
-							Namespace: "sourcegraph",
 							Annotations: map[string]string{
 								"kubectl.kubernetes.io/default-container": "foo",
 							},

--- a/internal/k8s/resource/pod/example_test.go
+++ b/internal/k8s/resource/pod/example_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func ExamplePodTemplate() {
-	pt, _ := NewPodTemplate("test", "sourcegraph")
+	pt, _ := NewPodTemplate("test")
 
 	jpt, _ := json.Marshal(pt)
 	fmt.Println(string(jpt))
@@ -17,7 +17,7 @@ func ExamplePodTemplate() {
 	fmt.Println(string(ypt))
 
 	// Output:
-	// {"metadata":{"creationTimestamp":null},"template":{"metadata":{"name":"test","namespace":"sourcegraph","creationTimestamp":null,"labels":{"app":"test","deploy":"sourcegraph"},"annotations":{"kubectl.kubernetes.io/default-container":"test"}},"spec":{"containers":null,"securityContext":{"runAsUser":100,"runAsGroup":101,"fsGroup":101,"fsGroupChangePolicy":"OnRootMismatch"}}}}
+	// {"metadata":{"creationTimestamp":null},"template":{"metadata":{"name":"test","creationTimestamp":null,"labels":{"app":"test","deploy":"sourcegraph"},"annotations":{"kubectl.kubernetes.io/default-container":"test"}},"spec":{"containers":null,"securityContext":{"runAsUser":100,"runAsGroup":101,"fsGroup":101,"fsGroupChangePolicy":"OnRootMismatch"}}}}
 	// metadata:
 	//   creationTimestamp: null
 	// template:
@@ -29,7 +29,6 @@ func ExamplePodTemplate() {
 	//       app: test
 	//       deploy: sourcegraph
 	//     name: test
-	//     namespace: sourcegraph
 	//   spec:
 	//     containers: null
 	//     securityContext:

--- a/internal/k8s/resource/pod/pod.go
+++ b/internal/k8s/resource/pod/pod.go
@@ -19,12 +19,11 @@ import (
 //   - SecurityContext with defaults.
 //
 // Additional options can be passed to modify the default values.
-func NewPodTemplate(name, namespace string, options ...Option) (corev1.PodTemplate, error) {
+func NewPodTemplate(name string, options ...Option) (corev1.PodTemplate, error) {
 	podTemplate := corev1.PodTemplate{
 		Template: corev1.PodTemplateSpec{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      name,
-				Namespace: namespace,
+				Name: name,
 				Annotations: map[string]string{
 					"kubectl.kubernetes.io/default-container": name,
 				},

--- a/internal/k8s/resource/pod/pod_test.go
+++ b/internal/k8s/resource/pod/pod_test.go
@@ -17,9 +17,8 @@ func TestNewPodTemplate(t *testing.T) {
 	t.Parallel()
 
 	type args struct {
-		name      string
-		namespace string
-		options   []Option
+		name    string
+		options []Option
 	}
 
 	tests := []struct {
@@ -31,14 +30,12 @@ func TestNewPodTemplate(t *testing.T) {
 		{
 			name: "default container",
 			args: args{
-				name:      "foo",
-				namespace: "sourcegraph",
+				name: "foo",
 			},
 			want: corev1.PodTemplate{
 				Template: corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "foo",
-						Namespace: "sourcegraph",
+						Name: "foo",
 						Annotations: map[string]string{
 							"kubectl.kubernetes.io/default-container": "foo",
 						},
@@ -61,8 +58,7 @@ func TestNewPodTemplate(t *testing.T) {
 		{
 			name: "with labels",
 			args: args{
-				name:      "foo",
-				namespace: "sourcegraph",
+				name: "foo",
 				options: []Option{
 					WithLabels(map[string]string{
 						"app":         "bar",
@@ -73,8 +69,7 @@ func TestNewPodTemplate(t *testing.T) {
 			want: corev1.PodTemplate{
 				Template: corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "foo",
-						Namespace: "sourcegraph",
+						Name: "foo",
 						Annotations: map[string]string{
 							"kubectl.kubernetes.io/default-container": "foo",
 						},
@@ -98,8 +93,7 @@ func TestNewPodTemplate(t *testing.T) {
 		{
 			name: "with annotations",
 			args: args{
-				name:      "foo",
-				namespace: "sourcegraph",
+				name: "foo",
 				options: []Option{
 					WithAnnotations(map[string]string{
 						"kubectl.kubernetes.io/default-container": "bar",
@@ -110,8 +104,7 @@ func TestNewPodTemplate(t *testing.T) {
 			want: corev1.PodTemplate{
 				Template: corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "foo",
-						Namespace: "sourcegraph",
+						Name: "foo",
 						Annotations: map[string]string{
 							"kubectl.kubernetes.io/default-container": "foo",
 							"environment": "prod",
@@ -135,8 +128,7 @@ func TestNewPodTemplate(t *testing.T) {
 		{
 			name: "with affinity",
 			args: args{
-				name:      "foo",
-				namespace: "sourcegraph",
+				name: "foo",
 				options: []Option{
 					WithAffinity(corev1.Affinity{
 						NodeAffinity: &corev1.NodeAffinity{
@@ -151,8 +143,7 @@ func TestNewPodTemplate(t *testing.T) {
 			want: corev1.PodTemplate{
 				Template: corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "foo",
-						Namespace: "sourcegraph",
+						Name: "foo",
 						Annotations: map[string]string{
 							"kubectl.kubernetes.io/default-container": "foo",
 						},
@@ -183,8 +174,7 @@ func TestNewPodTemplate(t *testing.T) {
 		{
 			name: "with volumes",
 			args: args{
-				name:      "foo",
-				namespace: "sourcegraph",
+				name: "foo",
 				options: []Option{
 					WithVolumes([]corev1.Volume{
 						{
@@ -199,8 +189,7 @@ func TestNewPodTemplate(t *testing.T) {
 			want: corev1.PodTemplate{
 				Template: corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "foo",
-						Namespace: "sourcegraph",
+						Name: "foo",
 						Annotations: map[string]string{
 							"kubectl.kubernetes.io/default-container": "foo",
 						},
@@ -231,8 +220,7 @@ func TestNewPodTemplate(t *testing.T) {
 		{
 			name: "with termination grace period",
 			args: args{
-				name:      "foo",
-				namespace: "sourcegraph",
+				name: "foo",
 				options: []Option{
 					WithTerminationGracePeriod(int64(10)),
 				},
@@ -240,8 +228,7 @@ func TestNewPodTemplate(t *testing.T) {
 			want: corev1.PodTemplate{
 				Template: corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "foo",
-						Namespace: "sourcegraph",
+						Name: "foo",
 						Annotations: map[string]string{
 							"kubectl.kubernetes.io/default-container": "foo",
 						},
@@ -265,8 +252,7 @@ func TestNewPodTemplate(t *testing.T) {
 		{
 			name: "with init containers",
 			args: args{
-				name:      "foo",
-				namespace: "sourcegraph",
+				name: "foo",
 				options: []Option{
 					WithInitContainers(func() corev1.Container {
 						c, _ := container.NewContainer("foo")
@@ -277,8 +263,7 @@ func TestNewPodTemplate(t *testing.T) {
 			want: corev1.PodTemplate{
 				Template: corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "foo",
-						Namespace: "sourcegraph",
+						Name: "foo",
 						Annotations: map[string]string{
 							"kubectl.kubernetes.io/default-container": "foo",
 						},
@@ -324,8 +309,7 @@ func TestNewPodTemplate(t *testing.T) {
 		{
 			name: "with containers",
 			args: args{
-				name:      "foo",
-				namespace: "sourcegraph",
+				name: "foo",
 				options: []Option{
 					WithContainers(func() corev1.Container {
 						c, _ := container.NewContainer("foo")
@@ -336,8 +320,7 @@ func TestNewPodTemplate(t *testing.T) {
 			want: corev1.PodTemplate{
 				Template: corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "foo",
-						Namespace: "sourcegraph",
+						Name: "foo",
 						Annotations: map[string]string{
 							"kubectl.kubernetes.io/default-container": "foo",
 						},
@@ -383,8 +366,7 @@ func TestNewPodTemplate(t *testing.T) {
 		{
 			name: "with service account",
 			args: args{
-				name:      "foo",
-				namespace: "sourcegraph",
+				name: "foo",
 				options: []Option{
 					WithServiceAccount("foobar"),
 				},
@@ -392,8 +374,7 @@ func TestNewPodTemplate(t *testing.T) {
 			want: corev1.PodTemplate{
 				Template: corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "foo",
-						Namespace: "sourcegraph",
+						Name: "foo",
 						Annotations: map[string]string{
 							"kubectl.kubernetes.io/default-container": "foo",
 						},
@@ -417,8 +398,7 @@ func TestNewPodTemplate(t *testing.T) {
 		{
 			name: "with security context",
 			args: args{
-				name:      "foo",
-				namespace: "sourcegraph",
+				name: "foo",
 				options: []Option{
 					WithSecurityContext(corev1.PodSecurityContext{
 						RunAsUser:           pointers.Ptr[int64](999),
@@ -431,8 +411,7 @@ func TestNewPodTemplate(t *testing.T) {
 			want: corev1.PodTemplate{
 				Template: corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "foo",
-						Namespace: "sourcegraph",
+						Name: "foo",
 						Annotations: map[string]string{
 							"kubectl.kubernetes.io/default-container": "foo",
 						},
@@ -455,8 +434,7 @@ func TestNewPodTemplate(t *testing.T) {
 		{
 			name: "with error",
 			args: args{
-				name:      "foo",
-				namespace: "sourcegraph",
+				name: "foo",
 				options: []Option{
 					func(podTemplate *corev1.PodTemplate) error {
 						return errors.New("test error")
@@ -471,7 +449,7 @@ func TestNewPodTemplate(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			got, err := NewPodTemplate(tt.args.name, tt.args.namespace, tt.args.options...)
+			got, err := NewPodTemplate(tt.args.name, tt.args.options...)
 			if err != nil && tt.wantErr == false {
 				t.Errorf("NewPodTemplate() error: %v", err)
 			}

--- a/internal/k8s/resource/statefulset/statefulset_test.go
+++ b/internal/k8s/resource/statefulset/statefulset_test.go
@@ -214,7 +214,7 @@ func TestNewStatefulSet(t *testing.T) {
 				namespace: "sourcegraph",
 				options: []Option{
 					WithPodTemplateSpec(func() corev1.PodTemplateSpec {
-						ts, _ := pod.NewPodTemplate("foo", "sourcegraph")
+						ts, _ := pod.NewPodTemplate("foo")
 						return ts.Template
 					}()),
 				},
@@ -244,7 +244,6 @@ func TestNewStatefulSet(t *testing.T) {
 					Template: corev1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      "foo",
-							Namespace: "sourcegraph",
 							Labels: map[string]string{
 								"app":    "foo",
 								"deploy": "sourcegraph",

--- a/internal/k8s/resource/statefulset/statefulset_test.go
+++ b/internal/k8s/resource/statefulset/statefulset_test.go
@@ -243,7 +243,7 @@ func TestNewStatefulSet(t *testing.T) {
 					},
 					Template: corev1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
-							Name:      "foo",
+							Name: "foo",
 							Labels: map[string]string{
 								"app":    "foo",
 								"deploy": "sourcegraph",


### PR DESCRIPTION
Use envtest (https://book.kubebuilder.io/reference/envtest.html) to start a real Kubernetes API server, backed by a real etcd instance, in tests. The only controller running is our appliance controller, so these tests assert on the changes our controller actually makes to Kubernetes API objects in response to some input, but don't depend on complex infrastruture like container runtimes or persistent volume controllers (since no such controllers are actually running, unlike in a useful Kubernetes cluster).

This commit adds a test harness to the appliance package:
* It starts the k8s API server only once, not once per test, as this is a relatively slow operation.
* Helper functions to run each test in a unique namespace to avoid inter-test dependency. This opens the door to parallelism, but note that testify/suite doesn't currently support parallel tests.
* Helper functions to load input ConfigMaps from fixture files.
* Passing `-args appliance-update-golden-files` to `go test` will cause checked-in golden files to be updated.

See self-review notes below for more info.

Closes https://github.com/sourcegraph/sourcegraph/issues/62015

## Test plan

This whole PR is about introducing a new test harness for the appliance component.
