### PR TITLE
Pin cURL version and update packages for release

### DIFF
--- a/wolfi-images/batcheshelper.lock.json
+++ b/wolfi-images/batcheshelper.lock.json
@@ -204,60 +204,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q13piSoRiT6p5eziGu2iPxSkXxf+g=",
+        "checksum": "Q1+rBEmKEIywe0o/a65ZPjWoUECRQ=",
         "control": {
-          "checksum": "sha1-3piSoRiT6p5eziGu2iPxSkXxf+g=",
-          "range": "bytes=704-1039"
+          "checksum": "sha1-+rBEmKEIywe0o/a65ZPjWoUECRQ=",
+          "range": "bytes=703-1054"
         },
         "data": {
-          "checksum": "sha256-+iLQJV5/mU/hTpwsy9zYBfzVIVkd8lXBBqMScHFhHfI=",
-          "range": "bytes=1040-87982"
+          "checksum": "sha256-fcShKjtj6wR6kgjwToU1J8hU+AGRf1OGZt9jeXJdM0Q=",
+          "range": "bytes=1055-82406"
         },
         "name": "openssl-config",
         "signature": {
-          "checksum": "sha1-fsygjfZl7YLgdpBZ5OVKJG/N2HI=",
-          "range": "bytes=0-703"
+          "checksum": "sha1-RT/o4gi2oC/l+6IhikP9/PH5awg=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/openssl-config-3.2.1-r0.apk",
-        "version": "3.2.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/openssl-config-3.3.0-r5.apk",
+        "version": "3.3.0-r5"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1kERnIFBBwTWZsA+cmGLkIU75THk=",
+        "checksum": "Q11DkfNRzraQMj7ue8LFH6VN6d7Bo=",
         "control": {
-          "checksum": "sha1-kERnIFBBwTWZsA+cmGLkIU75THk=",
-          "range": "bytes=694-1066"
+          "checksum": "sha1-1DkfNRzraQMj7ue8LFH6VN6d7Bo=",
+          "range": "bytes=707-1092"
         },
         "data": {
-          "checksum": "sha256-MB5ZoAsBJ0Osps0a1V0KsM/qQhfZQvYupElgoF1rNLE=",
-          "range": "bytes=1067-5895270"
+          "checksum": "sha256-c95GJNThldUhfxVSGbchUI0pS4j6h45Yx6JDPXHaAI0=",
+          "range": "bytes=1093-5915048"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-vTJq+p2AjVQQjJ4gSkR9ySDQr3k=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-EmjggcTaE4QTKI1FzSom0rXam1c=",
+          "range": "bytes=0-706"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.2.1-r0.apk",
-        "version": "3.2.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r5.apk",
+        "version": "3.3.0-r5"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1RFDJtvcstAQi4NjU00ApvNIvoEI=",
+        "checksum": "Q15sT5bGF6kgE7DepzZIHCpPpuP70=",
         "control": {
-          "checksum": "sha1-RFDJtvcstAQi4NjU00ApvNIvoEI=",
-          "range": "bytes=694-1065"
+          "checksum": "sha1-5sT5bGF6kgE7DepzZIHCpPpuP70=",
+          "range": "bytes=702-1085"
         },
         "data": {
-          "checksum": "sha256-oocCJOj9IF7jv3Ov8bPbaAGfq6oaYXuPNnZW9DnOdnE=",
-          "range": "bytes=1066-1135402"
+          "checksum": "sha256-fWOAfZYgXO6+yM4Dpo/y7dvV3uxSEhhfO4SUX79TQDw=",
+          "range": "bytes=1086-1196497"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-wJVFcqH/ewopq4lxwz8OYrZ9/Ws=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-4+7eITv9weTmoYBAAyd92WsXS24=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.2.1-r0.apk",
-        "version": "3.2.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r5.apk",
+        "version": "3.3.0-r5"
       },
       {
         "architecture": "x86_64",
@@ -337,22 +337,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1txYNrxLRCA8tpCe/aXw9Zeb30xw=",
+        "checksum": "Q1sGD1MEAazAXpfNixX74EpwafGo0=",
         "control": {
-          "checksum": "sha1-txYNrxLRCA8tpCe/aXw9Zeb30xw=",
-          "range": "bytes=703-1071"
+          "checksum": "sha1-sGD1MEAazAXpfNixX74EpwafGo0=",
+          "range": "bytes=698-1059"
         },
         "data": {
-          "checksum": "sha256-QgGnbFCQGaCUjwfFVcF2eOXDjZHaJjntdJlM1thwxd0=",
-          "range": "bytes=1072-252873"
+          "checksum": "sha256-s+9m0l/R7hVKQ5YLbU90D2E6DPC2QVTxdjhToMi5iYU=",
+          "range": "bytes=1060-251831"
         },
         "name": "libnghttp2-14",
         "signature": {
-          "checksum": "sha1-VWNh1CR9wcBEPwOH88Qr6n7OR08=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-wOIYtvU72n76UGvbargK2ccZx0E=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.60.0-r0.apk",
-        "version": "1.60.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.61.0-r0.apk",
+        "version": "1.61.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -432,41 +432,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1YKX8zXXVrSZ1a+od3zegHGvE7K4=",
+        "checksum": "Q1NZCvjmGBZ7soi6T4endRPtDztk4=",
         "control": {
-          "checksum": "sha1-YKX8zXXVrSZ1a+od3zegHGvE7K4=",
-          "range": "bytes=701-1168"
+          "checksum": "sha1-NZCvjmGBZ7soi6T4endRPtDztk4=",
+          "range": "bytes=698-1162"
         },
         "data": {
-          "checksum": "sha256-KnMN4TtaDNZqReNINaTivjzUoQigGvtRZgVEqc1EDHo=",
-          "range": "bytes=1169-2555088"
+          "checksum": "sha256-q79pSkGvnDzz1dHsQceLPqyVC+cFCyWWJB5L2EfkZRc=",
+          "range": "bytes=1163-2556930"
         },
         "name": "nghttp2",
         "signature": {
-          "checksum": "sha1-MWKiH9LAxjnWqAm536DCFrsZXCg=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-UuOeekThV8UC737772jFTRj0Y50=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.60.0-r0.apk",
-        "version": "1.60.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.61.0-r0.apk",
+        "version": "1.61.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1D/+xxUxpR+m3nGP5l/8Ed78nNC0=",
+        "checksum": "Q1O/sL8Kjkxzh39Ffh9gJl+0olkF4=",
         "control": {
-          "checksum": "sha1-D/+xxUxpR+m3nGP5l/8Ed78nNC0=",
-          "range": "bytes=700-1067"
+          "checksum": "sha1-O/sL8Kjkxzh39Ffh9gJl+0olkF4=",
+          "range": "bytes=700-1061"
         },
         "data": {
-          "checksum": "sha256-fKV2YLH6EP/NFtRSErdaCwZX+Mg6KJrfmt1VpRWeKis=",
-          "range": "bytes=1068-634389"
+          "checksum": "sha256-6qS8u1yYrzO+4Ypa+g4zfz3m16/7O/U4wjiRrKl8/vw=",
+          "range": "bytes=1062-631650"
         },
         "name": "nghttp2-dev",
         "signature": {
-          "checksum": "sha1-ZRWYUK14qaTBE3NC7OOWumdkSyY=",
+          "checksum": "sha1-avAz/6snsG86C9jh8Gxa59gs29U=",
           "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.60.0-r0.apk",
-        "version": "1.60.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.61.0-r0.apk",
+        "version": "1.61.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -508,41 +508,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1l9z4OGVfdVISNbyGQdXlz2GPchM=",
+        "checksum": "Q1wJPtj5XZtnPiVWGM5dsT+nyfWXc=",
         "control": {
-          "checksum": "sha1-l9z4OGVfdVISNbyGQdXlz2GPchM=",
-          "range": "bytes=695-1222"
+          "checksum": "sha1-wJPtj5XZtnPiVWGM5dsT+nyfWXc=",
+          "range": "bytes=705-1234"
         },
         "data": {
-          "checksum": "sha256-0Z+mq/0A1P+F5KIZKnsYpg8Eqb3GDRT7VDrZlTEg+4Y=",
-          "range": "bytes=1223-3863194"
+          "checksum": "sha256-sw+CjlpsjO01q6lqzXgHnniiJKn7bqOSNO6vNqdGc7I=",
+          "range": "bytes=1235-3873775"
         },
         "name": "bind-libs",
         "signature": {
-          "checksum": "sha1-YX2+1oZh/hXHVjZriSnJZQzpifg=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-9zDzmHAeu7mWpidXAatqrLZVzUs=",
+          "range": "bytes=0-704"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bind-libs-9.18.25-r0.apk",
-        "version": "9.18.25-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/bind-libs-9.18.26-r0.apk",
+        "version": "9.18.26-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Xb5w/MUeHFBeLgnHBmG7dqAMxzQ=",
+        "checksum": "Q1AxEQdi8fVcYtGc3zHTCW3OZdY2Q=",
         "control": {
-          "checksum": "sha1-Xb5w/MUeHFBeLgnHBmG7dqAMxzQ=",
-          "range": "bytes=705-1217"
+          "checksum": "sha1-AxEQdi8fVcYtGc3zHTCW3OZdY2Q=",
+          "range": "bytes=694-1208"
         },
         "data": {
-          "checksum": "sha256-/0zOh1KQW58NOuJgauDOdqJA4G4g0p6jPUOP45HN/f8=",
-          "range": "bytes=1218-892798"
+          "checksum": "sha256-/dt3qJw5D9iSJ/mKkRQkhWD8R52selhpcwXyw7KLMhg=",
+          "range": "bytes=1209-879444"
         },
         "name": "bind-tools",
         "signature": {
-          "checksum": "sha1-3GgaViNXeX4dd75pxgwR8yYgov0=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-VTb0YdUzPMk8Po0p4nj0y5Jey6k=",
+          "range": "bytes=0-693"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bind-tools-9.18.25-r0.apk",
-        "version": "9.18.25-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/bind-tools-9.18.26-r0.apk",
+        "version": "9.18.26-r0"
       },
       {
         "architecture": "x86_64",
@@ -698,41 +698,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1CC3jnItQWZ4ya5EB/TNDLOICnRc=",
+        "checksum": "Q1hgEBBo1tLreSINI2qiCUpUrIE9k=",
         "control": {
-          "checksum": "sha1-CC3jnItQWZ4ya5EB/TNDLOICnRc=",
-          "range": "bytes=701-1140"
+          "checksum": "sha1-hgEBBo1tLreSINI2qiCUpUrIE9k=",
+          "range": "bytes=700-1139"
         },
         "data": {
-          "checksum": "sha256-2EP9UQKOVph+9hElnh20s8ViX126cAnPyNI+IF2pQ4Y=",
-          "range": "bytes=1141-838149"
+          "checksum": "sha256-OFDWkK8l015fs0YvTCXVKLQmOxq+7W5RgJHIqKYZsTE=",
+          "range": "bytes=1140-808582"
         },
         "name": "libcurl-openssl4",
         "signature": {
-          "checksum": "sha1-IxMuIpRYevSLukva0eWmB5RkhMY=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-sygIdNZXB/W8fyOrdelY5RXh3aA=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.7.1-r0.apk",
-        "version": "8.7.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.6.0-r0.apk",
+        "version": "8.6.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1DzKkXRny9JZJvzjFt3jIuvkDP8E=",
+        "checksum": "Q1eQzLI9XN4FM69fm9B4LWd9frcwM=",
         "control": {
-          "checksum": "sha1-DzKkXRny9JZJvzjFt3jIuvkDP8E=",
-          "range": "bytes=700-1101"
+          "checksum": "sha1-eQzLI9XN4FM69fm9B4LWd9frcwM=",
+          "range": "bytes=703-1098"
         },
         "data": {
-          "checksum": "sha256-l1iebyEPmteOEBcPDwPzstpqs9SMvCn8PqlvRU3O7jk=",
-          "range": "bytes=1102-351141"
+          "checksum": "sha256-zkew7+IbyyyENezhlStwO062zaWd+yP/lpbI+CCJVZQ=",
+          "range": "bytes=1099-281166"
         },
         "name": "curl",
         "signature": {
-          "checksum": "sha1-iVKgcLEjgrpj4c2TrRzHznPaWXA=",
-          "range": "bytes=0-699"
+          "checksum": "sha1-igXspQSxo3Eu3o8DeNrYt3YxSbY=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.7.1-r0.apk",
-        "version": "8.7.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.6.0-r0.apk",
+        "version": "8.6.0-r0"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/blobstore.lock.json
+++ b/wolfi-images/blobstore.lock.json
@@ -204,60 +204,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q13piSoRiT6p5eziGu2iPxSkXxf+g=",
+        "checksum": "Q1+rBEmKEIywe0o/a65ZPjWoUECRQ=",
         "control": {
-          "checksum": "sha1-3piSoRiT6p5eziGu2iPxSkXxf+g=",
-          "range": "bytes=704-1039"
+          "checksum": "sha1-+rBEmKEIywe0o/a65ZPjWoUECRQ=",
+          "range": "bytes=703-1054"
         },
         "data": {
-          "checksum": "sha256-+iLQJV5/mU/hTpwsy9zYBfzVIVkd8lXBBqMScHFhHfI=",
-          "range": "bytes=1040-87982"
+          "checksum": "sha256-fcShKjtj6wR6kgjwToU1J8hU+AGRf1OGZt9jeXJdM0Q=",
+          "range": "bytes=1055-82406"
         },
         "name": "openssl-config",
         "signature": {
-          "checksum": "sha1-fsygjfZl7YLgdpBZ5OVKJG/N2HI=",
-          "range": "bytes=0-703"
+          "checksum": "sha1-RT/o4gi2oC/l+6IhikP9/PH5awg=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/openssl-config-3.2.1-r0.apk",
-        "version": "3.2.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/openssl-config-3.3.0-r5.apk",
+        "version": "3.3.0-r5"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1kERnIFBBwTWZsA+cmGLkIU75THk=",
+        "checksum": "Q11DkfNRzraQMj7ue8LFH6VN6d7Bo=",
         "control": {
-          "checksum": "sha1-kERnIFBBwTWZsA+cmGLkIU75THk=",
-          "range": "bytes=694-1066"
+          "checksum": "sha1-1DkfNRzraQMj7ue8LFH6VN6d7Bo=",
+          "range": "bytes=707-1092"
         },
         "data": {
-          "checksum": "sha256-MB5ZoAsBJ0Osps0a1V0KsM/qQhfZQvYupElgoF1rNLE=",
-          "range": "bytes=1067-5895270"
+          "checksum": "sha256-c95GJNThldUhfxVSGbchUI0pS4j6h45Yx6JDPXHaAI0=",
+          "range": "bytes=1093-5915048"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-vTJq+p2AjVQQjJ4gSkR9ySDQr3k=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-EmjggcTaE4QTKI1FzSom0rXam1c=",
+          "range": "bytes=0-706"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.2.1-r0.apk",
-        "version": "3.2.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r5.apk",
+        "version": "3.3.0-r5"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1RFDJtvcstAQi4NjU00ApvNIvoEI=",
+        "checksum": "Q15sT5bGF6kgE7DepzZIHCpPpuP70=",
         "control": {
-          "checksum": "sha1-RFDJtvcstAQi4NjU00ApvNIvoEI=",
-          "range": "bytes=694-1065"
+          "checksum": "sha1-5sT5bGF6kgE7DepzZIHCpPpuP70=",
+          "range": "bytes=702-1085"
         },
         "data": {
-          "checksum": "sha256-oocCJOj9IF7jv3Ov8bPbaAGfq6oaYXuPNnZW9DnOdnE=",
-          "range": "bytes=1066-1135402"
+          "checksum": "sha256-fWOAfZYgXO6+yM4Dpo/y7dvV3uxSEhhfO4SUX79TQDw=",
+          "range": "bytes=1086-1196497"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-wJVFcqH/ewopq4lxwz8OYrZ9/Ws=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-4+7eITv9weTmoYBAAyd92WsXS24=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.2.1-r0.apk",
-        "version": "3.2.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r5.apk",
+        "version": "3.3.0-r5"
       },
       {
         "architecture": "x86_64",
@@ -337,22 +337,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1txYNrxLRCA8tpCe/aXw9Zeb30xw=",
+        "checksum": "Q1sGD1MEAazAXpfNixX74EpwafGo0=",
         "control": {
-          "checksum": "sha1-txYNrxLRCA8tpCe/aXw9Zeb30xw=",
-          "range": "bytes=703-1071"
+          "checksum": "sha1-sGD1MEAazAXpfNixX74EpwafGo0=",
+          "range": "bytes=698-1059"
         },
         "data": {
-          "checksum": "sha256-QgGnbFCQGaCUjwfFVcF2eOXDjZHaJjntdJlM1thwxd0=",
-          "range": "bytes=1072-252873"
+          "checksum": "sha256-s+9m0l/R7hVKQ5YLbU90D2E6DPC2QVTxdjhToMi5iYU=",
+          "range": "bytes=1060-251831"
         },
         "name": "libnghttp2-14",
         "signature": {
-          "checksum": "sha1-VWNh1CR9wcBEPwOH88Qr6n7OR08=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-wOIYtvU72n76UGvbargK2ccZx0E=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.60.0-r0.apk",
-        "version": "1.60.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.61.0-r0.apk",
+        "version": "1.61.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -432,41 +432,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1YKX8zXXVrSZ1a+od3zegHGvE7K4=",
+        "checksum": "Q1NZCvjmGBZ7soi6T4endRPtDztk4=",
         "control": {
-          "checksum": "sha1-YKX8zXXVrSZ1a+od3zegHGvE7K4=",
-          "range": "bytes=701-1168"
+          "checksum": "sha1-NZCvjmGBZ7soi6T4endRPtDztk4=",
+          "range": "bytes=698-1162"
         },
         "data": {
-          "checksum": "sha256-KnMN4TtaDNZqReNINaTivjzUoQigGvtRZgVEqc1EDHo=",
-          "range": "bytes=1169-2555088"
+          "checksum": "sha256-q79pSkGvnDzz1dHsQceLPqyVC+cFCyWWJB5L2EfkZRc=",
+          "range": "bytes=1163-2556930"
         },
         "name": "nghttp2",
         "signature": {
-          "checksum": "sha1-MWKiH9LAxjnWqAm536DCFrsZXCg=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-UuOeekThV8UC737772jFTRj0Y50=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.60.0-r0.apk",
-        "version": "1.60.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.61.0-r0.apk",
+        "version": "1.61.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1D/+xxUxpR+m3nGP5l/8Ed78nNC0=",
+        "checksum": "Q1O/sL8Kjkxzh39Ffh9gJl+0olkF4=",
         "control": {
-          "checksum": "sha1-D/+xxUxpR+m3nGP5l/8Ed78nNC0=",
-          "range": "bytes=700-1067"
+          "checksum": "sha1-O/sL8Kjkxzh39Ffh9gJl+0olkF4=",
+          "range": "bytes=700-1061"
         },
         "data": {
-          "checksum": "sha256-fKV2YLH6EP/NFtRSErdaCwZX+Mg6KJrfmt1VpRWeKis=",
-          "range": "bytes=1068-634389"
+          "checksum": "sha256-6qS8u1yYrzO+4Ypa+g4zfz3m16/7O/U4wjiRrKl8/vw=",
+          "range": "bytes=1062-631650"
         },
         "name": "nghttp2-dev",
         "signature": {
-          "checksum": "sha1-ZRWYUK14qaTBE3NC7OOWumdkSyY=",
+          "checksum": "sha1-avAz/6snsG86C9jh8Gxa59gs29U=",
           "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.60.0-r0.apk",
-        "version": "1.60.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.61.0-r0.apk",
+        "version": "1.61.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -508,41 +508,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1l9z4OGVfdVISNbyGQdXlz2GPchM=",
+        "checksum": "Q1wJPtj5XZtnPiVWGM5dsT+nyfWXc=",
         "control": {
-          "checksum": "sha1-l9z4OGVfdVISNbyGQdXlz2GPchM=",
-          "range": "bytes=695-1222"
+          "checksum": "sha1-wJPtj5XZtnPiVWGM5dsT+nyfWXc=",
+          "range": "bytes=705-1234"
         },
         "data": {
-          "checksum": "sha256-0Z+mq/0A1P+F5KIZKnsYpg8Eqb3GDRT7VDrZlTEg+4Y=",
-          "range": "bytes=1223-3863194"
+          "checksum": "sha256-sw+CjlpsjO01q6lqzXgHnniiJKn7bqOSNO6vNqdGc7I=",
+          "range": "bytes=1235-3873775"
         },
         "name": "bind-libs",
         "signature": {
-          "checksum": "sha1-YX2+1oZh/hXHVjZriSnJZQzpifg=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-9zDzmHAeu7mWpidXAatqrLZVzUs=",
+          "range": "bytes=0-704"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bind-libs-9.18.25-r0.apk",
-        "version": "9.18.25-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/bind-libs-9.18.26-r0.apk",
+        "version": "9.18.26-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Xb5w/MUeHFBeLgnHBmG7dqAMxzQ=",
+        "checksum": "Q1AxEQdi8fVcYtGc3zHTCW3OZdY2Q=",
         "control": {
-          "checksum": "sha1-Xb5w/MUeHFBeLgnHBmG7dqAMxzQ=",
-          "range": "bytes=705-1217"
+          "checksum": "sha1-AxEQdi8fVcYtGc3zHTCW3OZdY2Q=",
+          "range": "bytes=694-1208"
         },
         "data": {
-          "checksum": "sha256-/0zOh1KQW58NOuJgauDOdqJA4G4g0p6jPUOP45HN/f8=",
-          "range": "bytes=1218-892798"
+          "checksum": "sha256-/dt3qJw5D9iSJ/mKkRQkhWD8R52selhpcwXyw7KLMhg=",
+          "range": "bytes=1209-879444"
         },
         "name": "bind-tools",
         "signature": {
-          "checksum": "sha1-3GgaViNXeX4dd75pxgwR8yYgov0=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-VTb0YdUzPMk8Po0p4nj0y5Jey6k=",
+          "range": "bytes=0-693"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bind-tools-9.18.25-r0.apk",
-        "version": "9.18.25-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/bind-tools-9.18.26-r0.apk",
+        "version": "9.18.26-r0"
       },
       {
         "architecture": "x86_64",
@@ -698,41 +698,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1CC3jnItQWZ4ya5EB/TNDLOICnRc=",
+        "checksum": "Q1hgEBBo1tLreSINI2qiCUpUrIE9k=",
         "control": {
-          "checksum": "sha1-CC3jnItQWZ4ya5EB/TNDLOICnRc=",
-          "range": "bytes=701-1140"
+          "checksum": "sha1-hgEBBo1tLreSINI2qiCUpUrIE9k=",
+          "range": "bytes=700-1139"
         },
         "data": {
-          "checksum": "sha256-2EP9UQKOVph+9hElnh20s8ViX126cAnPyNI+IF2pQ4Y=",
-          "range": "bytes=1141-838149"
+          "checksum": "sha256-OFDWkK8l015fs0YvTCXVKLQmOxq+7W5RgJHIqKYZsTE=",
+          "range": "bytes=1140-808582"
         },
         "name": "libcurl-openssl4",
         "signature": {
-          "checksum": "sha1-IxMuIpRYevSLukva0eWmB5RkhMY=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-sygIdNZXB/W8fyOrdelY5RXh3aA=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.7.1-r0.apk",
-        "version": "8.7.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.6.0-r0.apk",
+        "version": "8.6.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1DzKkXRny9JZJvzjFt3jIuvkDP8E=",
+        "checksum": "Q1eQzLI9XN4FM69fm9B4LWd9frcwM=",
         "control": {
-          "checksum": "sha1-DzKkXRny9JZJvzjFt3jIuvkDP8E=",
-          "range": "bytes=700-1101"
+          "checksum": "sha1-eQzLI9XN4FM69fm9B4LWd9frcwM=",
+          "range": "bytes=703-1098"
         },
         "data": {
-          "checksum": "sha256-l1iebyEPmteOEBcPDwPzstpqs9SMvCn8PqlvRU3O7jk=",
-          "range": "bytes=1102-351141"
+          "checksum": "sha256-zkew7+IbyyyENezhlStwO062zaWd+yP/lpbI+CCJVZQ=",
+          "range": "bytes=1099-281166"
         },
         "name": "curl",
         "signature": {
-          "checksum": "sha1-iVKgcLEjgrpj4c2TrRzHznPaWXA=",
-          "range": "bytes=0-699"
+          "checksum": "sha1-igXspQSxo3Eu3o8DeNrYt3YxSbY=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.7.1-r0.apk",
-        "version": "8.7.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.6.0-r0.apk",
+        "version": "8.6.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -1021,41 +1021,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1lvdA+lSrWHVV6Vr18x+/3LikSk4=",
+        "checksum": "Q1IxgR/wmdOn2AsmEHjMadMzuPQf0=",
         "control": {
-          "checksum": "sha1-lvdA+lSrWHVV6Vr18x+/3LikSk4=",
-          "range": "bytes=700-1124"
+          "checksum": "sha1-IxgR/wmdOn2AsmEHjMadMzuPQf0=",
+          "range": "bytes=700-1123"
         },
         "data": {
-          "checksum": "sha256-Q908LtL0QFkmCEWR0UWAvg77FAMvwHgEovQUVYimSzM=",
-          "range": "bytes=1125-170693231"
+          "checksum": "sha256-ol0W8r/3Jnxynw63fsti8It4+4qUGXhN7n1Y07rM8cc=",
+          "range": "bytes=1124-170633676"
         },
         "name": "openjdk-11-jre-base",
         "signature": {
-          "checksum": "sha1-9P0sgsaCywxIyYQyds49pFd1qrs=",
+          "checksum": "sha1-13kdahGdHBkiAvl2w4Vnu+wwSiY=",
           "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/openjdk-11-jre-base-11.0.22-r1.apk",
-        "version": "11.0.22-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/openjdk-11-jre-base-11.0.23-r0.apk",
+        "version": "11.0.23-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1DOpnVgCHt9X1JbD7ah50Zo37sqM=",
+        "checksum": "Q1JGEQUEzk0sgQSUHNHdaJfAFxMpI=",
         "control": {
-          "checksum": "sha1-DOpnVgCHt9X1JbD7ah50Zo37sqM=",
-          "range": "bytes=703-1088"
+          "checksum": "sha1-JGEQUEzk0sgQSUHNHdaJfAFxMpI=",
+          "range": "bytes=703-1092"
         },
         "data": {
-          "checksum": "sha256-kDId5IzqtfCkgK2xtbXMaMYC0Mz0/h882V+NEfUp6eM=",
-          "range": "bytes=1089-2870300"
+          "checksum": "sha256-SWIwrskhqqNaFEXU9U89+Ql5xq71vFUWhZobPsPA3SY=",
+          "range": "bytes=1093-2949213"
         },
         "name": "openjdk-11-jre",
         "signature": {
-          "checksum": "sha1-D+jR+Wjw8dB6iHAWackwQO56eb8=",
+          "checksum": "sha1-LHBJoUKCsjv6MmxxSujYUbqQDIQ=",
           "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/openjdk-11-jre-11.0.22-r1.apk",
-        "version": "11.0.22-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/openjdk-11-jre-11.0.23-r0.apk",
+        "version": "11.0.23-r0"
       },
       {
         "architecture": "x86_64",
@@ -1078,22 +1078,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1tiHRz3neVleu/DGKRU4GAhTH94Y=",
+        "checksum": "Q1xVK1i+Nx2yIBrf6+nklKnt3xmGU=",
         "control": {
-          "checksum": "sha1-tiHRz3neVleu/DGKRU4GAhTH94Y=",
-          "range": "bytes=700-1081"
+          "checksum": "sha1-xVK1i+Nx2yIBrf6+nklKnt3xmGU=",
+          "range": "bytes=699-1084"
         },
         "data": {
-          "checksum": "sha256-sv6Bkx5JQVWEmCEmJVJa2243BP5y8FgEz/Tj4sRRbOI=",
-          "range": "bytes=1082-34108"
+          "checksum": "sha256-KkVCAWCnkYOYQSvbxhunxAWxMYWIF8+7R2HW/cdWxKE=",
+          "range": "bytes=1085-33972"
         },
         "name": "openjdk-11-default-jvm",
         "signature": {
-          "checksum": "sha1-wno2UEFotgQgdk310I6he2VX9bM=",
-          "range": "bytes=0-699"
+          "checksum": "sha1-Gww5qNU3Rsg0OTMu3DY9otvhVO0=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/openjdk-11-default-jvm-11.0.22-r1.apk",
-        "version": "11.0.22-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/openjdk-11-default-jvm-11.0.23-r0.apk",
+        "version": "11.0.23-r0"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/bundled-executor.lock.json
+++ b/wolfi-images/bundled-executor.lock.json
@@ -204,60 +204,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q13piSoRiT6p5eziGu2iPxSkXxf+g=",
+        "checksum": "Q1+rBEmKEIywe0o/a65ZPjWoUECRQ=",
         "control": {
-          "checksum": "sha1-3piSoRiT6p5eziGu2iPxSkXxf+g=",
-          "range": "bytes=704-1039"
+          "checksum": "sha1-+rBEmKEIywe0o/a65ZPjWoUECRQ=",
+          "range": "bytes=703-1054"
         },
         "data": {
-          "checksum": "sha256-+iLQJV5/mU/hTpwsy9zYBfzVIVkd8lXBBqMScHFhHfI=",
-          "range": "bytes=1040-87982"
+          "checksum": "sha256-fcShKjtj6wR6kgjwToU1J8hU+AGRf1OGZt9jeXJdM0Q=",
+          "range": "bytes=1055-82406"
         },
         "name": "openssl-config",
         "signature": {
-          "checksum": "sha1-fsygjfZl7YLgdpBZ5OVKJG/N2HI=",
-          "range": "bytes=0-703"
+          "checksum": "sha1-RT/o4gi2oC/l+6IhikP9/PH5awg=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/openssl-config-3.2.1-r0.apk",
-        "version": "3.2.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/openssl-config-3.3.0-r5.apk",
+        "version": "3.3.0-r5"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1kERnIFBBwTWZsA+cmGLkIU75THk=",
+        "checksum": "Q11DkfNRzraQMj7ue8LFH6VN6d7Bo=",
         "control": {
-          "checksum": "sha1-kERnIFBBwTWZsA+cmGLkIU75THk=",
-          "range": "bytes=694-1066"
+          "checksum": "sha1-1DkfNRzraQMj7ue8LFH6VN6d7Bo=",
+          "range": "bytes=707-1092"
         },
         "data": {
-          "checksum": "sha256-MB5ZoAsBJ0Osps0a1V0KsM/qQhfZQvYupElgoF1rNLE=",
-          "range": "bytes=1067-5895270"
+          "checksum": "sha256-c95GJNThldUhfxVSGbchUI0pS4j6h45Yx6JDPXHaAI0=",
+          "range": "bytes=1093-5915048"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-vTJq+p2AjVQQjJ4gSkR9ySDQr3k=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-EmjggcTaE4QTKI1FzSom0rXam1c=",
+          "range": "bytes=0-706"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.2.1-r0.apk",
-        "version": "3.2.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r5.apk",
+        "version": "3.3.0-r5"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1RFDJtvcstAQi4NjU00ApvNIvoEI=",
+        "checksum": "Q15sT5bGF6kgE7DepzZIHCpPpuP70=",
         "control": {
-          "checksum": "sha1-RFDJtvcstAQi4NjU00ApvNIvoEI=",
-          "range": "bytes=694-1065"
+          "checksum": "sha1-5sT5bGF6kgE7DepzZIHCpPpuP70=",
+          "range": "bytes=702-1085"
         },
         "data": {
-          "checksum": "sha256-oocCJOj9IF7jv3Ov8bPbaAGfq6oaYXuPNnZW9DnOdnE=",
-          "range": "bytes=1066-1135402"
+          "checksum": "sha256-fWOAfZYgXO6+yM4Dpo/y7dvV3uxSEhhfO4SUX79TQDw=",
+          "range": "bytes=1086-1196497"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-wJVFcqH/ewopq4lxwz8OYrZ9/Ws=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-4+7eITv9weTmoYBAAyd92WsXS24=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.2.1-r0.apk",
-        "version": "3.2.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r5.apk",
+        "version": "3.3.0-r5"
       },
       {
         "architecture": "x86_64",
@@ -337,22 +337,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1txYNrxLRCA8tpCe/aXw9Zeb30xw=",
+        "checksum": "Q1sGD1MEAazAXpfNixX74EpwafGo0=",
         "control": {
-          "checksum": "sha1-txYNrxLRCA8tpCe/aXw9Zeb30xw=",
-          "range": "bytes=703-1071"
+          "checksum": "sha1-sGD1MEAazAXpfNixX74EpwafGo0=",
+          "range": "bytes=698-1059"
         },
         "data": {
-          "checksum": "sha256-QgGnbFCQGaCUjwfFVcF2eOXDjZHaJjntdJlM1thwxd0=",
-          "range": "bytes=1072-252873"
+          "checksum": "sha256-s+9m0l/R7hVKQ5YLbU90D2E6DPC2QVTxdjhToMi5iYU=",
+          "range": "bytes=1060-251831"
         },
         "name": "libnghttp2-14",
         "signature": {
-          "checksum": "sha1-VWNh1CR9wcBEPwOH88Qr6n7OR08=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-wOIYtvU72n76UGvbargK2ccZx0E=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.60.0-r0.apk",
-        "version": "1.60.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.61.0-r0.apk",
+        "version": "1.61.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -432,41 +432,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1YKX8zXXVrSZ1a+od3zegHGvE7K4=",
+        "checksum": "Q1NZCvjmGBZ7soi6T4endRPtDztk4=",
         "control": {
-          "checksum": "sha1-YKX8zXXVrSZ1a+od3zegHGvE7K4=",
-          "range": "bytes=701-1168"
+          "checksum": "sha1-NZCvjmGBZ7soi6T4endRPtDztk4=",
+          "range": "bytes=698-1162"
         },
         "data": {
-          "checksum": "sha256-KnMN4TtaDNZqReNINaTivjzUoQigGvtRZgVEqc1EDHo=",
-          "range": "bytes=1169-2555088"
+          "checksum": "sha256-q79pSkGvnDzz1dHsQceLPqyVC+cFCyWWJB5L2EfkZRc=",
+          "range": "bytes=1163-2556930"
         },
         "name": "nghttp2",
         "signature": {
-          "checksum": "sha1-MWKiH9LAxjnWqAm536DCFrsZXCg=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-UuOeekThV8UC737772jFTRj0Y50=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.60.0-r0.apk",
-        "version": "1.60.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.61.0-r0.apk",
+        "version": "1.61.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1D/+xxUxpR+m3nGP5l/8Ed78nNC0=",
+        "checksum": "Q1O/sL8Kjkxzh39Ffh9gJl+0olkF4=",
         "control": {
-          "checksum": "sha1-D/+xxUxpR+m3nGP5l/8Ed78nNC0=",
-          "range": "bytes=700-1067"
+          "checksum": "sha1-O/sL8Kjkxzh39Ffh9gJl+0olkF4=",
+          "range": "bytes=700-1061"
         },
         "data": {
-          "checksum": "sha256-fKV2YLH6EP/NFtRSErdaCwZX+Mg6KJrfmt1VpRWeKis=",
-          "range": "bytes=1068-634389"
+          "checksum": "sha256-6qS8u1yYrzO+4Ypa+g4zfz3m16/7O/U4wjiRrKl8/vw=",
+          "range": "bytes=1062-631650"
         },
         "name": "nghttp2-dev",
         "signature": {
-          "checksum": "sha1-ZRWYUK14qaTBE3NC7OOWumdkSyY=",
+          "checksum": "sha1-avAz/6snsG86C9jh8Gxa59gs29U=",
           "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.60.0-r0.apk",
-        "version": "1.60.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.61.0-r0.apk",
+        "version": "1.61.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -508,41 +508,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1l9z4OGVfdVISNbyGQdXlz2GPchM=",
+        "checksum": "Q1wJPtj5XZtnPiVWGM5dsT+nyfWXc=",
         "control": {
-          "checksum": "sha1-l9z4OGVfdVISNbyGQdXlz2GPchM=",
-          "range": "bytes=695-1222"
+          "checksum": "sha1-wJPtj5XZtnPiVWGM5dsT+nyfWXc=",
+          "range": "bytes=705-1234"
         },
         "data": {
-          "checksum": "sha256-0Z+mq/0A1P+F5KIZKnsYpg8Eqb3GDRT7VDrZlTEg+4Y=",
-          "range": "bytes=1223-3863194"
+          "checksum": "sha256-sw+CjlpsjO01q6lqzXgHnniiJKn7bqOSNO6vNqdGc7I=",
+          "range": "bytes=1235-3873775"
         },
         "name": "bind-libs",
         "signature": {
-          "checksum": "sha1-YX2+1oZh/hXHVjZriSnJZQzpifg=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-9zDzmHAeu7mWpidXAatqrLZVzUs=",
+          "range": "bytes=0-704"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bind-libs-9.18.25-r0.apk",
-        "version": "9.18.25-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/bind-libs-9.18.26-r0.apk",
+        "version": "9.18.26-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Xb5w/MUeHFBeLgnHBmG7dqAMxzQ=",
+        "checksum": "Q1AxEQdi8fVcYtGc3zHTCW3OZdY2Q=",
         "control": {
-          "checksum": "sha1-Xb5w/MUeHFBeLgnHBmG7dqAMxzQ=",
-          "range": "bytes=705-1217"
+          "checksum": "sha1-AxEQdi8fVcYtGc3zHTCW3OZdY2Q=",
+          "range": "bytes=694-1208"
         },
         "data": {
-          "checksum": "sha256-/0zOh1KQW58NOuJgauDOdqJA4G4g0p6jPUOP45HN/f8=",
-          "range": "bytes=1218-892798"
+          "checksum": "sha256-/dt3qJw5D9iSJ/mKkRQkhWD8R52selhpcwXyw7KLMhg=",
+          "range": "bytes=1209-879444"
         },
         "name": "bind-tools",
         "signature": {
-          "checksum": "sha1-3GgaViNXeX4dd75pxgwR8yYgov0=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-VTb0YdUzPMk8Po0p4nj0y5Jey6k=",
+          "range": "bytes=0-693"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bind-tools-9.18.25-r0.apk",
-        "version": "9.18.25-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/bind-tools-9.18.26-r0.apk",
+        "version": "9.18.26-r0"
       },
       {
         "architecture": "x86_64",
@@ -717,41 +717,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1CC3jnItQWZ4ya5EB/TNDLOICnRc=",
+        "checksum": "Q1hgEBBo1tLreSINI2qiCUpUrIE9k=",
         "control": {
-          "checksum": "sha1-CC3jnItQWZ4ya5EB/TNDLOICnRc=",
-          "range": "bytes=701-1140"
+          "checksum": "sha1-hgEBBo1tLreSINI2qiCUpUrIE9k=",
+          "range": "bytes=700-1139"
         },
         "data": {
-          "checksum": "sha256-2EP9UQKOVph+9hElnh20s8ViX126cAnPyNI+IF2pQ4Y=",
-          "range": "bytes=1141-838149"
+          "checksum": "sha256-OFDWkK8l015fs0YvTCXVKLQmOxq+7W5RgJHIqKYZsTE=",
+          "range": "bytes=1140-808582"
         },
         "name": "libcurl-openssl4",
         "signature": {
-          "checksum": "sha1-IxMuIpRYevSLukva0eWmB5RkhMY=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-sygIdNZXB/W8fyOrdelY5RXh3aA=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.7.1-r0.apk",
-        "version": "8.7.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.6.0-r0.apk",
+        "version": "8.6.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1DzKkXRny9JZJvzjFt3jIuvkDP8E=",
+        "checksum": "Q1eQzLI9XN4FM69fm9B4LWd9frcwM=",
         "control": {
-          "checksum": "sha1-DzKkXRny9JZJvzjFt3jIuvkDP8E=",
-          "range": "bytes=700-1101"
+          "checksum": "sha1-eQzLI9XN4FM69fm9B4LWd9frcwM=",
+          "range": "bytes=703-1098"
         },
         "data": {
-          "checksum": "sha256-l1iebyEPmteOEBcPDwPzstpqs9SMvCn8PqlvRU3O7jk=",
-          "range": "bytes=1102-351141"
+          "checksum": "sha256-zkew7+IbyyyENezhlStwO062zaWd+yP/lpbI+CCJVZQ=",
+          "range": "bytes=1099-281166"
         },
         "name": "curl",
         "signature": {
-          "checksum": "sha1-iVKgcLEjgrpj4c2TrRzHznPaWXA=",
-          "range": "bytes=0-699"
+          "checksum": "sha1-igXspQSxo3Eu3o8DeNrYt3YxSbY=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.7.1-r0.apk",
-        "version": "8.7.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.6.0-r0.apk",
+        "version": "8.6.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -1059,79 +1059,79 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1lvdA+lSrWHVV6Vr18x+/3LikSk4=",
+        "checksum": "Q1IxgR/wmdOn2AsmEHjMadMzuPQf0=",
         "control": {
-          "checksum": "sha1-lvdA+lSrWHVV6Vr18x+/3LikSk4=",
-          "range": "bytes=700-1124"
+          "checksum": "sha1-IxgR/wmdOn2AsmEHjMadMzuPQf0=",
+          "range": "bytes=700-1123"
         },
         "data": {
-          "checksum": "sha256-Q908LtL0QFkmCEWR0UWAvg77FAMvwHgEovQUVYimSzM=",
-          "range": "bytes=1125-170693231"
+          "checksum": "sha256-ol0W8r/3Jnxynw63fsti8It4+4qUGXhN7n1Y07rM8cc=",
+          "range": "bytes=1124-170633676"
         },
         "name": "openjdk-11-jre-base",
         "signature": {
-          "checksum": "sha1-9P0sgsaCywxIyYQyds49pFd1qrs=",
+          "checksum": "sha1-13kdahGdHBkiAvl2w4Vnu+wwSiY=",
           "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/openjdk-11-jre-base-11.0.22-r1.apk",
-        "version": "11.0.22-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/openjdk-11-jre-base-11.0.23-r0.apk",
+        "version": "11.0.23-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1DOpnVgCHt9X1JbD7ah50Zo37sqM=",
+        "checksum": "Q1JGEQUEzk0sgQSUHNHdaJfAFxMpI=",
         "control": {
-          "checksum": "sha1-DOpnVgCHt9X1JbD7ah50Zo37sqM=",
-          "range": "bytes=703-1088"
+          "checksum": "sha1-JGEQUEzk0sgQSUHNHdaJfAFxMpI=",
+          "range": "bytes=703-1092"
         },
         "data": {
-          "checksum": "sha256-kDId5IzqtfCkgK2xtbXMaMYC0Mz0/h882V+NEfUp6eM=",
-          "range": "bytes=1089-2870300"
+          "checksum": "sha256-SWIwrskhqqNaFEXU9U89+Ql5xq71vFUWhZobPsPA3SY=",
+          "range": "bytes=1093-2949213"
         },
         "name": "openjdk-11-jre",
         "signature": {
-          "checksum": "sha1-D+jR+Wjw8dB6iHAWackwQO56eb8=",
+          "checksum": "sha1-LHBJoUKCsjv6MmxxSujYUbqQDIQ=",
           "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/openjdk-11-jre-11.0.22-r1.apk",
-        "version": "11.0.22-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/openjdk-11-jre-11.0.23-r0.apk",
+        "version": "11.0.23-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Qzd3SHcxMLEI9PnDm3G0tch8E/Y=",
+        "checksum": "Q1NezDGCThsJFk+As7ckWqsw/x2UM=",
         "control": {
-          "checksum": "sha1-Qzd3SHcxMLEI9PnDm3G0tch8E/Y=",
-          "range": "bytes=699-1059"
+          "checksum": "sha1-NezDGCThsJFk+As7ckWqsw/x2UM=",
+          "range": "bytes=703-1065"
         },
         "data": {
-          "checksum": "sha256-Op3s/Rv4xpz/8fYyRgVtOn3nVCv76Fe4D0MCYoFrq44=",
-          "range": "bytes=1060-619546"
+          "checksum": "sha256-nfdYUC0YabMNmRV2m0rjbKU7uTSnPJsI0JqtdLuefKc=",
+          "range": "bytes=1066-589383"
         },
         "name": "openjdk-11",
         "signature": {
-          "checksum": "sha1-RyqV6KsyoiTYgH2sLFNK0fcA3ro=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-9n00Xix4Xm+W5NDaHgnICO08WK8=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/openjdk-11-11.0.22-r1.apk",
-        "version": "11.0.22-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/openjdk-11-11.0.23-r0.apk",
+        "version": "11.0.23-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1tiHRz3neVleu/DGKRU4GAhTH94Y=",
+        "checksum": "Q1xVK1i+Nx2yIBrf6+nklKnt3xmGU=",
         "control": {
-          "checksum": "sha1-tiHRz3neVleu/DGKRU4GAhTH94Y=",
-          "range": "bytes=700-1081"
+          "checksum": "sha1-xVK1i+Nx2yIBrf6+nklKnt3xmGU=",
+          "range": "bytes=699-1084"
         },
         "data": {
-          "checksum": "sha256-sv6Bkx5JQVWEmCEmJVJa2243BP5y8FgEz/Tj4sRRbOI=",
-          "range": "bytes=1082-34108"
+          "checksum": "sha256-KkVCAWCnkYOYQSvbxhunxAWxMYWIF8+7R2HW/cdWxKE=",
+          "range": "bytes=1085-33972"
         },
         "name": "openjdk-11-default-jvm",
         "signature": {
-          "checksum": "sha1-wno2UEFotgQgdk310I6he2VX9bM=",
-          "range": "bytes=0-699"
+          "checksum": "sha1-Gww5qNU3Rsg0OTMu3DY9otvhVO0=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/openjdk-11-default-jvm-11.0.22-r1.apk",
-        "version": "11.0.22-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/openjdk-11-default-jvm-11.0.23-r0.apk",
+        "version": "11.0.23-r0"
       },
       {
         "architecture": "x86_64",
@@ -1249,60 +1249,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1D8X74+a2sutMM4df4P63Q+jOtzw=",
+        "checksum": "Q1LPejw4CnrXdaD6OHwAoFM/7vA7s=",
         "control": {
-          "checksum": "sha1-D8X74+a2sutMM4df4P63Q+jOtzw=",
-          "range": "bytes=695-1203"
+          "checksum": "sha1-LPejw4CnrXdaD6OHwAoFM/7vA7s=",
+          "range": "bytes=700-1217"
         },
         "data": {
-          "checksum": "sha256-UbrH++J9cwOI+rQwn8kPVIP2yS2hTvb9aPFECfF6tB8=",
-          "range": "bytes=1204-42123590"
+          "checksum": "sha256-r23KtCFip48cIupEQhoBPL12Ldsyr6u5LKT8la+mZfo=",
+          "range": "bytes=1218-40574201"
         },
         "name": "python-3.12-base",
         "signature": {
-          "checksum": "sha1-X2u0OA9U6goK8Dt9EB4ejml2/BE=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-5EREXBj3ZFrVW1zyGKgNw/DUyEM=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/python-3.12-base-3.12.2-r8.apk",
-        "version": "3.12.2-r8"
+        "url": "https://packages.wolfi.dev/os/x86_64/python-3.12-base-3.12.3-r0.apk",
+        "version": "3.12.3-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q19dQz13v/WahZBP19atGsVQLAV0Q=",
+        "checksum": "Q1zJd5jSTT2iNfEP+Lg6n5DL2N5iM=",
         "control": {
-          "checksum": "sha1-9dQz13v/WahZBP19atGsVQLAV0Q=",
-          "range": "bytes=698-1062"
+          "checksum": "sha1-zJd5jSTT2iNfEP+Lg6n5DL2N5iM=",
+          "range": "bytes=708-1079"
         },
         "data": {
-          "checksum": "sha256-6e1OR1RuGUAHP762Ek6Oub/Do13jH2BITZLcSrfb50I=",
-          "range": "bytes=1063-42235"
+          "checksum": "sha256-ZEgYPjLoERnzSvMfi4YYzoVQa7U8OJDGCidlrjCkBBw=",
+          "range": "bytes=1080-42121"
         },
         "name": "python-3.12",
         "signature": {
-          "checksum": "sha1-Fy9ND0Cx9lWHbyWqbAmfoQB2q9c=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-oqY6wsK+/SWuhGEnD7sZM/qdjdU=",
+          "range": "bytes=0-707"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/python-3.12-3.12.2-r8.apk",
-        "version": "3.12.2-r8"
+        "url": "https://packages.wolfi.dev/os/x86_64/python-3.12-3.12.3-r0.apk",
+        "version": "3.12.3-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1vdD7C5SKGgW8BqFM3B4xQDrAin8=",
+        "checksum": "Q1486/VjzINhsPjk+ptdC/bxeQSKU=",
         "control": {
-          "checksum": "sha1-vdD7C5SKGgW8BqFM3B4xQDrAin8=",
-          "range": "bytes=698-1095"
+          "checksum": "sha1-486/VjzINhsPjk+ptdC/bxeQSKU=",
+          "range": "bytes=702-1110"
         },
         "data": {
-          "checksum": "sha256-/9qOyQCI4Mx2tACKlYls3kTes1dDjUUnLcHmkYkD8FI=",
-          "range": "bytes=1096-6753635"
+          "checksum": "sha256-chQoDcMkmNAbqROhXcSzC53e/Yao1Kr/5YaGlMK1eFU=",
+          "range": "bytes=1111-6838627"
         },
         "name": "py3.12-setuptools",
         "signature": {
-          "checksum": "sha1-iHU6xuaZzmbZzMXg1e4+W2COTDY=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-OO0VOnH5b1qAaueHznESHWFp5Wg=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/py3.12-setuptools-69.2.0-r0.apk",
-        "version": "69.2.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/py3.12-setuptools-69.5.1-r0.apk",
+        "version": "69.5.1-r0"
       },
       {
         "architecture": "x86_64",
@@ -1439,22 +1439,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1plC6GdgJa+y1/7lUwOvpCt04GkU=",
+        "checksum": "Q18MwodMSl0hPDM6pNflIS7qcJGwM=",
         "control": {
-          "checksum": "sha1-plC6GdgJa+y1/7lUwOvpCt04GkU=",
+          "checksum": "sha1-8MwodMSl0hPDM6pNflIS7qcJGwM=",
           "range": "bytes=660-994"
         },
         "data": {
-          "checksum": "sha256-GFhG/D5t7Pne1qqqG6rtab2Ogg8L4rKCRFJrCu7bwos=",
-          "range": "bytes=995-375347"
+          "checksum": "sha256-8EDi7Nbl0EgIihNbJCDf8mbS1cuygpFYTbCKy0RF2Ic=",
+          "range": "bytes=995-346849"
         },
         "name": "xmlstarlet",
         "signature": {
-          "checksum": "sha1-ZME+lTIcLxpDhbjvwSLzW4MHjA4=",
+          "checksum": "sha1-cbMSrD9JRT8VK5VVW9m/OuIXY8k=",
           "range": "bytes=0-659"
         },
-        "url": "https://packages.sgdev.org/main/x86_64/xmlstarlet-1.6.1-r2.apk",
-        "version": "1.6.1-r2"
+        "url": "https://packages.sgdev.org/main/x86_64/xmlstarlet-1.6.1-r3.apk",
+        "version": "1.6.1-r3"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/caddy.lock.json
+++ b/wolfi-images/caddy.lock.json
@@ -508,41 +508,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1l9z4OGVfdVISNbyGQdXlz2GPchM=",
+        "checksum": "Q1wJPtj5XZtnPiVWGM5dsT+nyfWXc=",
         "control": {
-          "checksum": "sha1-l9z4OGVfdVISNbyGQdXlz2GPchM=",
-          "range": "bytes=695-1222"
+          "checksum": "sha1-wJPtj5XZtnPiVWGM5dsT+nyfWXc=",
+          "range": "bytes=705-1234"
         },
         "data": {
-          "checksum": "sha256-0Z+mq/0A1P+F5KIZKnsYpg8Eqb3GDRT7VDrZlTEg+4Y=",
-          "range": "bytes=1223-3863194"
+          "checksum": "sha256-sw+CjlpsjO01q6lqzXgHnniiJKn7bqOSNO6vNqdGc7I=",
+          "range": "bytes=1235-3873775"
         },
         "name": "bind-libs",
         "signature": {
-          "checksum": "sha1-YX2+1oZh/hXHVjZriSnJZQzpifg=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-9zDzmHAeu7mWpidXAatqrLZVzUs=",
+          "range": "bytes=0-704"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bind-libs-9.18.25-r0.apk",
-        "version": "9.18.25-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/bind-libs-9.18.26-r0.apk",
+        "version": "9.18.26-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Xb5w/MUeHFBeLgnHBmG7dqAMxzQ=",
+        "checksum": "Q1AxEQdi8fVcYtGc3zHTCW3OZdY2Q=",
         "control": {
-          "checksum": "sha1-Xb5w/MUeHFBeLgnHBmG7dqAMxzQ=",
-          "range": "bytes=705-1217"
+          "checksum": "sha1-AxEQdi8fVcYtGc3zHTCW3OZdY2Q=",
+          "range": "bytes=694-1208"
         },
         "data": {
-          "checksum": "sha256-/0zOh1KQW58NOuJgauDOdqJA4G4g0p6jPUOP45HN/f8=",
-          "range": "bytes=1218-892798"
+          "checksum": "sha256-/dt3qJw5D9iSJ/mKkRQkhWD8R52selhpcwXyw7KLMhg=",
+          "range": "bytes=1209-879444"
         },
         "name": "bind-tools",
         "signature": {
-          "checksum": "sha1-3GgaViNXeX4dd75pxgwR8yYgov0=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-VTb0YdUzPMk8Po0p4nj0y5Jey6k=",
+          "range": "bytes=0-693"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bind-tools-9.18.25-r0.apk",
-        "version": "9.18.25-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/bind-tools-9.18.26-r0.apk",
+        "version": "9.18.26-r0"
       },
       {
         "architecture": "x86_64",
@@ -717,41 +717,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1CC3jnItQWZ4ya5EB/TNDLOICnRc=",
+        "checksum": "Q1hgEBBo1tLreSINI2qiCUpUrIE9k=",
         "control": {
-          "checksum": "sha1-CC3jnItQWZ4ya5EB/TNDLOICnRc=",
-          "range": "bytes=701-1140"
+          "checksum": "sha1-hgEBBo1tLreSINI2qiCUpUrIE9k=",
+          "range": "bytes=700-1139"
         },
         "data": {
-          "checksum": "sha256-2EP9UQKOVph+9hElnh20s8ViX126cAnPyNI+IF2pQ4Y=",
-          "range": "bytes=1141-838149"
+          "checksum": "sha256-OFDWkK8l015fs0YvTCXVKLQmOxq+7W5RgJHIqKYZsTE=",
+          "range": "bytes=1140-808582"
         },
         "name": "libcurl-openssl4",
         "signature": {
-          "checksum": "sha1-IxMuIpRYevSLukva0eWmB5RkhMY=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-sygIdNZXB/W8fyOrdelY5RXh3aA=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.7.1-r0.apk",
-        "version": "8.7.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.6.0-r0.apk",
+        "version": "8.6.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1DzKkXRny9JZJvzjFt3jIuvkDP8E=",
+        "checksum": "Q1eQzLI9XN4FM69fm9B4LWd9frcwM=",
         "control": {
-          "checksum": "sha1-DzKkXRny9JZJvzjFt3jIuvkDP8E=",
-          "range": "bytes=700-1101"
+          "checksum": "sha1-eQzLI9XN4FM69fm9B4LWd9frcwM=",
+          "range": "bytes=703-1098"
         },
         "data": {
-          "checksum": "sha256-l1iebyEPmteOEBcPDwPzstpqs9SMvCn8PqlvRU3O7jk=",
-          "range": "bytes=1102-351141"
+          "checksum": "sha256-zkew7+IbyyyENezhlStwO062zaWd+yP/lpbI+CCJVZQ=",
+          "range": "bytes=1099-281166"
         },
         "name": "curl",
         "signature": {
-          "checksum": "sha1-iVKgcLEjgrpj4c2TrRzHznPaWXA=",
-          "range": "bytes=0-699"
+          "checksum": "sha1-igXspQSxo3Eu3o8DeNrYt3YxSbY=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.7.1-r0.apk",
-        "version": "8.7.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.6.0-r0.apk",
+        "version": "8.6.0-r0"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/cadvisor.lock.json
+++ b/wolfi-images/cadvisor.lock.json
@@ -204,60 +204,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q13piSoRiT6p5eziGu2iPxSkXxf+g=",
+        "checksum": "Q1+rBEmKEIywe0o/a65ZPjWoUECRQ=",
         "control": {
-          "checksum": "sha1-3piSoRiT6p5eziGu2iPxSkXxf+g=",
-          "range": "bytes=704-1039"
+          "checksum": "sha1-+rBEmKEIywe0o/a65ZPjWoUECRQ=",
+          "range": "bytes=703-1054"
         },
         "data": {
-          "checksum": "sha256-+iLQJV5/mU/hTpwsy9zYBfzVIVkd8lXBBqMScHFhHfI=",
-          "range": "bytes=1040-87982"
+          "checksum": "sha256-fcShKjtj6wR6kgjwToU1J8hU+AGRf1OGZt9jeXJdM0Q=",
+          "range": "bytes=1055-82406"
         },
         "name": "openssl-config",
         "signature": {
-          "checksum": "sha1-fsygjfZl7YLgdpBZ5OVKJG/N2HI=",
-          "range": "bytes=0-703"
+          "checksum": "sha1-RT/o4gi2oC/l+6IhikP9/PH5awg=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/openssl-config-3.2.1-r0.apk",
-        "version": "3.2.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/openssl-config-3.3.0-r5.apk",
+        "version": "3.3.0-r5"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1kERnIFBBwTWZsA+cmGLkIU75THk=",
+        "checksum": "Q11DkfNRzraQMj7ue8LFH6VN6d7Bo=",
         "control": {
-          "checksum": "sha1-kERnIFBBwTWZsA+cmGLkIU75THk=",
-          "range": "bytes=694-1066"
+          "checksum": "sha1-1DkfNRzraQMj7ue8LFH6VN6d7Bo=",
+          "range": "bytes=707-1092"
         },
         "data": {
-          "checksum": "sha256-MB5ZoAsBJ0Osps0a1V0KsM/qQhfZQvYupElgoF1rNLE=",
-          "range": "bytes=1067-5895270"
+          "checksum": "sha256-c95GJNThldUhfxVSGbchUI0pS4j6h45Yx6JDPXHaAI0=",
+          "range": "bytes=1093-5915048"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-vTJq+p2AjVQQjJ4gSkR9ySDQr3k=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-EmjggcTaE4QTKI1FzSom0rXam1c=",
+          "range": "bytes=0-706"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.2.1-r0.apk",
-        "version": "3.2.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r5.apk",
+        "version": "3.3.0-r5"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1RFDJtvcstAQi4NjU00ApvNIvoEI=",
+        "checksum": "Q15sT5bGF6kgE7DepzZIHCpPpuP70=",
         "control": {
-          "checksum": "sha1-RFDJtvcstAQi4NjU00ApvNIvoEI=",
-          "range": "bytes=694-1065"
+          "checksum": "sha1-5sT5bGF6kgE7DepzZIHCpPpuP70=",
+          "range": "bytes=702-1085"
         },
         "data": {
-          "checksum": "sha256-oocCJOj9IF7jv3Ov8bPbaAGfq6oaYXuPNnZW9DnOdnE=",
-          "range": "bytes=1066-1135402"
+          "checksum": "sha256-fWOAfZYgXO6+yM4Dpo/y7dvV3uxSEhhfO4SUX79TQDw=",
+          "range": "bytes=1086-1196497"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-wJVFcqH/ewopq4lxwz8OYrZ9/Ws=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-4+7eITv9weTmoYBAAyd92WsXS24=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.2.1-r0.apk",
-        "version": "3.2.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r5.apk",
+        "version": "3.3.0-r5"
       },
       {
         "architecture": "x86_64",
@@ -337,22 +337,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1txYNrxLRCA8tpCe/aXw9Zeb30xw=",
+        "checksum": "Q1sGD1MEAazAXpfNixX74EpwafGo0=",
         "control": {
-          "checksum": "sha1-txYNrxLRCA8tpCe/aXw9Zeb30xw=",
-          "range": "bytes=703-1071"
+          "checksum": "sha1-sGD1MEAazAXpfNixX74EpwafGo0=",
+          "range": "bytes=698-1059"
         },
         "data": {
-          "checksum": "sha256-QgGnbFCQGaCUjwfFVcF2eOXDjZHaJjntdJlM1thwxd0=",
-          "range": "bytes=1072-252873"
+          "checksum": "sha256-s+9m0l/R7hVKQ5YLbU90D2E6DPC2QVTxdjhToMi5iYU=",
+          "range": "bytes=1060-251831"
         },
         "name": "libnghttp2-14",
         "signature": {
-          "checksum": "sha1-VWNh1CR9wcBEPwOH88Qr6n7OR08=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-wOIYtvU72n76UGvbargK2ccZx0E=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.60.0-r0.apk",
-        "version": "1.60.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.61.0-r0.apk",
+        "version": "1.61.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -432,41 +432,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1YKX8zXXVrSZ1a+od3zegHGvE7K4=",
+        "checksum": "Q1NZCvjmGBZ7soi6T4endRPtDztk4=",
         "control": {
-          "checksum": "sha1-YKX8zXXVrSZ1a+od3zegHGvE7K4=",
-          "range": "bytes=701-1168"
+          "checksum": "sha1-NZCvjmGBZ7soi6T4endRPtDztk4=",
+          "range": "bytes=698-1162"
         },
         "data": {
-          "checksum": "sha256-KnMN4TtaDNZqReNINaTivjzUoQigGvtRZgVEqc1EDHo=",
-          "range": "bytes=1169-2555088"
+          "checksum": "sha256-q79pSkGvnDzz1dHsQceLPqyVC+cFCyWWJB5L2EfkZRc=",
+          "range": "bytes=1163-2556930"
         },
         "name": "nghttp2",
         "signature": {
-          "checksum": "sha1-MWKiH9LAxjnWqAm536DCFrsZXCg=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-UuOeekThV8UC737772jFTRj0Y50=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.60.0-r0.apk",
-        "version": "1.60.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.61.0-r0.apk",
+        "version": "1.61.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1D/+xxUxpR+m3nGP5l/8Ed78nNC0=",
+        "checksum": "Q1O/sL8Kjkxzh39Ffh9gJl+0olkF4=",
         "control": {
-          "checksum": "sha1-D/+xxUxpR+m3nGP5l/8Ed78nNC0=",
-          "range": "bytes=700-1067"
+          "checksum": "sha1-O/sL8Kjkxzh39Ffh9gJl+0olkF4=",
+          "range": "bytes=700-1061"
         },
         "data": {
-          "checksum": "sha256-fKV2YLH6EP/NFtRSErdaCwZX+Mg6KJrfmt1VpRWeKis=",
-          "range": "bytes=1068-634389"
+          "checksum": "sha256-6qS8u1yYrzO+4Ypa+g4zfz3m16/7O/U4wjiRrKl8/vw=",
+          "range": "bytes=1062-631650"
         },
         "name": "nghttp2-dev",
         "signature": {
-          "checksum": "sha1-ZRWYUK14qaTBE3NC7OOWumdkSyY=",
+          "checksum": "sha1-avAz/6snsG86C9jh8Gxa59gs29U=",
           "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.60.0-r0.apk",
-        "version": "1.60.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.61.0-r0.apk",
+        "version": "1.61.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -508,41 +508,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1l9z4OGVfdVISNbyGQdXlz2GPchM=",
+        "checksum": "Q1wJPtj5XZtnPiVWGM5dsT+nyfWXc=",
         "control": {
-          "checksum": "sha1-l9z4OGVfdVISNbyGQdXlz2GPchM=",
-          "range": "bytes=695-1222"
+          "checksum": "sha1-wJPtj5XZtnPiVWGM5dsT+nyfWXc=",
+          "range": "bytes=705-1234"
         },
         "data": {
-          "checksum": "sha256-0Z+mq/0A1P+F5KIZKnsYpg8Eqb3GDRT7VDrZlTEg+4Y=",
-          "range": "bytes=1223-3863194"
+          "checksum": "sha256-sw+CjlpsjO01q6lqzXgHnniiJKn7bqOSNO6vNqdGc7I=",
+          "range": "bytes=1235-3873775"
         },
         "name": "bind-libs",
         "signature": {
-          "checksum": "sha1-YX2+1oZh/hXHVjZriSnJZQzpifg=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-9zDzmHAeu7mWpidXAatqrLZVzUs=",
+          "range": "bytes=0-704"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bind-libs-9.18.25-r0.apk",
-        "version": "9.18.25-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/bind-libs-9.18.26-r0.apk",
+        "version": "9.18.26-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Xb5w/MUeHFBeLgnHBmG7dqAMxzQ=",
+        "checksum": "Q1AxEQdi8fVcYtGc3zHTCW3OZdY2Q=",
         "control": {
-          "checksum": "sha1-Xb5w/MUeHFBeLgnHBmG7dqAMxzQ=",
-          "range": "bytes=705-1217"
+          "checksum": "sha1-AxEQdi8fVcYtGc3zHTCW3OZdY2Q=",
+          "range": "bytes=694-1208"
         },
         "data": {
-          "checksum": "sha256-/0zOh1KQW58NOuJgauDOdqJA4G4g0p6jPUOP45HN/f8=",
-          "range": "bytes=1218-892798"
+          "checksum": "sha256-/dt3qJw5D9iSJ/mKkRQkhWD8R52selhpcwXyw7KLMhg=",
+          "range": "bytes=1209-879444"
         },
         "name": "bind-tools",
         "signature": {
-          "checksum": "sha1-3GgaViNXeX4dd75pxgwR8yYgov0=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-VTb0YdUzPMk8Po0p4nj0y5Jey6k=",
+          "range": "bytes=0-693"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bind-tools-9.18.25-r0.apk",
-        "version": "9.18.25-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/bind-tools-9.18.26-r0.apk",
+        "version": "9.18.26-r0"
       },
       {
         "architecture": "x86_64",
@@ -717,41 +717,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1CC3jnItQWZ4ya5EB/TNDLOICnRc=",
+        "checksum": "Q1hgEBBo1tLreSINI2qiCUpUrIE9k=",
         "control": {
-          "checksum": "sha1-CC3jnItQWZ4ya5EB/TNDLOICnRc=",
-          "range": "bytes=701-1140"
+          "checksum": "sha1-hgEBBo1tLreSINI2qiCUpUrIE9k=",
+          "range": "bytes=700-1139"
         },
         "data": {
-          "checksum": "sha256-2EP9UQKOVph+9hElnh20s8ViX126cAnPyNI+IF2pQ4Y=",
-          "range": "bytes=1141-838149"
+          "checksum": "sha256-OFDWkK8l015fs0YvTCXVKLQmOxq+7W5RgJHIqKYZsTE=",
+          "range": "bytes=1140-808582"
         },
         "name": "libcurl-openssl4",
         "signature": {
-          "checksum": "sha1-IxMuIpRYevSLukva0eWmB5RkhMY=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-sygIdNZXB/W8fyOrdelY5RXh3aA=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.7.1-r0.apk",
-        "version": "8.7.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.6.0-r0.apk",
+        "version": "8.6.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1DzKkXRny9JZJvzjFt3jIuvkDP8E=",
+        "checksum": "Q1eQzLI9XN4FM69fm9B4LWd9frcwM=",
         "control": {
-          "checksum": "sha1-DzKkXRny9JZJvzjFt3jIuvkDP8E=",
-          "range": "bytes=700-1101"
+          "checksum": "sha1-eQzLI9XN4FM69fm9B4LWd9frcwM=",
+          "range": "bytes=703-1098"
         },
         "data": {
-          "checksum": "sha256-l1iebyEPmteOEBcPDwPzstpqs9SMvCn8PqlvRU3O7jk=",
-          "range": "bytes=1102-351141"
+          "checksum": "sha256-zkew7+IbyyyENezhlStwO062zaWd+yP/lpbI+CCJVZQ=",
+          "range": "bytes=1099-281166"
         },
         "name": "curl",
         "signature": {
-          "checksum": "sha1-iVKgcLEjgrpj4c2TrRzHznPaWXA=",
-          "range": "bytes=0-699"
+          "checksum": "sha1-igXspQSxo3Eu3o8DeNrYt3YxSbY=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.7.1-r0.apk",
-        "version": "8.7.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.6.0-r0.apk",
+        "version": "8.6.0-r0"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/cloud-mi2.lock.json
+++ b/wolfi-images/cloud-mi2.lock.json
@@ -204,60 +204,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q13piSoRiT6p5eziGu2iPxSkXxf+g=",
+        "checksum": "Q1+rBEmKEIywe0o/a65ZPjWoUECRQ=",
         "control": {
-          "checksum": "sha1-3piSoRiT6p5eziGu2iPxSkXxf+g=",
-          "range": "bytes=704-1039"
+          "checksum": "sha1-+rBEmKEIywe0o/a65ZPjWoUECRQ=",
+          "range": "bytes=703-1054"
         },
         "data": {
-          "checksum": "sha256-+iLQJV5/mU/hTpwsy9zYBfzVIVkd8lXBBqMScHFhHfI=",
-          "range": "bytes=1040-87982"
+          "checksum": "sha256-fcShKjtj6wR6kgjwToU1J8hU+AGRf1OGZt9jeXJdM0Q=",
+          "range": "bytes=1055-82406"
         },
         "name": "openssl-config",
         "signature": {
-          "checksum": "sha1-fsygjfZl7YLgdpBZ5OVKJG/N2HI=",
-          "range": "bytes=0-703"
+          "checksum": "sha1-RT/o4gi2oC/l+6IhikP9/PH5awg=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/openssl-config-3.2.1-r0.apk",
-        "version": "3.2.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/openssl-config-3.3.0-r5.apk",
+        "version": "3.3.0-r5"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1kERnIFBBwTWZsA+cmGLkIU75THk=",
+        "checksum": "Q11DkfNRzraQMj7ue8LFH6VN6d7Bo=",
         "control": {
-          "checksum": "sha1-kERnIFBBwTWZsA+cmGLkIU75THk=",
-          "range": "bytes=694-1066"
+          "checksum": "sha1-1DkfNRzraQMj7ue8LFH6VN6d7Bo=",
+          "range": "bytes=707-1092"
         },
         "data": {
-          "checksum": "sha256-MB5ZoAsBJ0Osps0a1V0KsM/qQhfZQvYupElgoF1rNLE=",
-          "range": "bytes=1067-5895270"
+          "checksum": "sha256-c95GJNThldUhfxVSGbchUI0pS4j6h45Yx6JDPXHaAI0=",
+          "range": "bytes=1093-5915048"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-vTJq+p2AjVQQjJ4gSkR9ySDQr3k=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-EmjggcTaE4QTKI1FzSom0rXam1c=",
+          "range": "bytes=0-706"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.2.1-r0.apk",
-        "version": "3.2.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r5.apk",
+        "version": "3.3.0-r5"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1RFDJtvcstAQi4NjU00ApvNIvoEI=",
+        "checksum": "Q15sT5bGF6kgE7DepzZIHCpPpuP70=",
         "control": {
-          "checksum": "sha1-RFDJtvcstAQi4NjU00ApvNIvoEI=",
-          "range": "bytes=694-1065"
+          "checksum": "sha1-5sT5bGF6kgE7DepzZIHCpPpuP70=",
+          "range": "bytes=702-1085"
         },
         "data": {
-          "checksum": "sha256-oocCJOj9IF7jv3Ov8bPbaAGfq6oaYXuPNnZW9DnOdnE=",
-          "range": "bytes=1066-1135402"
+          "checksum": "sha256-fWOAfZYgXO6+yM4Dpo/y7dvV3uxSEhhfO4SUX79TQDw=",
+          "range": "bytes=1086-1196497"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-wJVFcqH/ewopq4lxwz8OYrZ9/Ws=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-4+7eITv9weTmoYBAAyd92WsXS24=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.2.1-r0.apk",
-        "version": "3.2.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r5.apk",
+        "version": "3.3.0-r5"
       },
       {
         "architecture": "x86_64",
@@ -337,22 +337,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1txYNrxLRCA8tpCe/aXw9Zeb30xw=",
+        "checksum": "Q1sGD1MEAazAXpfNixX74EpwafGo0=",
         "control": {
-          "checksum": "sha1-txYNrxLRCA8tpCe/aXw9Zeb30xw=",
-          "range": "bytes=703-1071"
+          "checksum": "sha1-sGD1MEAazAXpfNixX74EpwafGo0=",
+          "range": "bytes=698-1059"
         },
         "data": {
-          "checksum": "sha256-QgGnbFCQGaCUjwfFVcF2eOXDjZHaJjntdJlM1thwxd0=",
-          "range": "bytes=1072-252873"
+          "checksum": "sha256-s+9m0l/R7hVKQ5YLbU90D2E6DPC2QVTxdjhToMi5iYU=",
+          "range": "bytes=1060-251831"
         },
         "name": "libnghttp2-14",
         "signature": {
-          "checksum": "sha1-VWNh1CR9wcBEPwOH88Qr6n7OR08=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-wOIYtvU72n76UGvbargK2ccZx0E=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.60.0-r0.apk",
-        "version": "1.60.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.61.0-r0.apk",
+        "version": "1.61.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -432,41 +432,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1YKX8zXXVrSZ1a+od3zegHGvE7K4=",
+        "checksum": "Q1NZCvjmGBZ7soi6T4endRPtDztk4=",
         "control": {
-          "checksum": "sha1-YKX8zXXVrSZ1a+od3zegHGvE7K4=",
-          "range": "bytes=701-1168"
+          "checksum": "sha1-NZCvjmGBZ7soi6T4endRPtDztk4=",
+          "range": "bytes=698-1162"
         },
         "data": {
-          "checksum": "sha256-KnMN4TtaDNZqReNINaTivjzUoQigGvtRZgVEqc1EDHo=",
-          "range": "bytes=1169-2555088"
+          "checksum": "sha256-q79pSkGvnDzz1dHsQceLPqyVC+cFCyWWJB5L2EfkZRc=",
+          "range": "bytes=1163-2556930"
         },
         "name": "nghttp2",
         "signature": {
-          "checksum": "sha1-MWKiH9LAxjnWqAm536DCFrsZXCg=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-UuOeekThV8UC737772jFTRj0Y50=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.60.0-r0.apk",
-        "version": "1.60.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.61.0-r0.apk",
+        "version": "1.61.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1D/+xxUxpR+m3nGP5l/8Ed78nNC0=",
+        "checksum": "Q1O/sL8Kjkxzh39Ffh9gJl+0olkF4=",
         "control": {
-          "checksum": "sha1-D/+xxUxpR+m3nGP5l/8Ed78nNC0=",
-          "range": "bytes=700-1067"
+          "checksum": "sha1-O/sL8Kjkxzh39Ffh9gJl+0olkF4=",
+          "range": "bytes=700-1061"
         },
         "data": {
-          "checksum": "sha256-fKV2YLH6EP/NFtRSErdaCwZX+Mg6KJrfmt1VpRWeKis=",
-          "range": "bytes=1068-634389"
+          "checksum": "sha256-6qS8u1yYrzO+4Ypa+g4zfz3m16/7O/U4wjiRrKl8/vw=",
+          "range": "bytes=1062-631650"
         },
         "name": "nghttp2-dev",
         "signature": {
-          "checksum": "sha1-ZRWYUK14qaTBE3NC7OOWumdkSyY=",
+          "checksum": "sha1-avAz/6snsG86C9jh8Gxa59gs29U=",
           "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.60.0-r0.apk",
-        "version": "1.60.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.61.0-r0.apk",
+        "version": "1.61.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -508,41 +508,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1l9z4OGVfdVISNbyGQdXlz2GPchM=",
+        "checksum": "Q1wJPtj5XZtnPiVWGM5dsT+nyfWXc=",
         "control": {
-          "checksum": "sha1-l9z4OGVfdVISNbyGQdXlz2GPchM=",
-          "range": "bytes=695-1222"
+          "checksum": "sha1-wJPtj5XZtnPiVWGM5dsT+nyfWXc=",
+          "range": "bytes=705-1234"
         },
         "data": {
-          "checksum": "sha256-0Z+mq/0A1P+F5KIZKnsYpg8Eqb3GDRT7VDrZlTEg+4Y=",
-          "range": "bytes=1223-3863194"
+          "checksum": "sha256-sw+CjlpsjO01q6lqzXgHnniiJKn7bqOSNO6vNqdGc7I=",
+          "range": "bytes=1235-3873775"
         },
         "name": "bind-libs",
         "signature": {
-          "checksum": "sha1-YX2+1oZh/hXHVjZriSnJZQzpifg=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-9zDzmHAeu7mWpidXAatqrLZVzUs=",
+          "range": "bytes=0-704"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bind-libs-9.18.25-r0.apk",
-        "version": "9.18.25-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/bind-libs-9.18.26-r0.apk",
+        "version": "9.18.26-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Xb5w/MUeHFBeLgnHBmG7dqAMxzQ=",
+        "checksum": "Q1AxEQdi8fVcYtGc3zHTCW3OZdY2Q=",
         "control": {
-          "checksum": "sha1-Xb5w/MUeHFBeLgnHBmG7dqAMxzQ=",
-          "range": "bytes=705-1217"
+          "checksum": "sha1-AxEQdi8fVcYtGc3zHTCW3OZdY2Q=",
+          "range": "bytes=694-1208"
         },
         "data": {
-          "checksum": "sha256-/0zOh1KQW58NOuJgauDOdqJA4G4g0p6jPUOP45HN/f8=",
-          "range": "bytes=1218-892798"
+          "checksum": "sha256-/dt3qJw5D9iSJ/mKkRQkhWD8R52selhpcwXyw7KLMhg=",
+          "range": "bytes=1209-879444"
         },
         "name": "bind-tools",
         "signature": {
-          "checksum": "sha1-3GgaViNXeX4dd75pxgwR8yYgov0=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-VTb0YdUzPMk8Po0p4nj0y5Jey6k=",
+          "range": "bytes=0-693"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bind-tools-9.18.25-r0.apk",
-        "version": "9.18.25-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/bind-tools-9.18.26-r0.apk",
+        "version": "9.18.26-r0"
       },
       {
         "architecture": "x86_64",
@@ -698,41 +698,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1CC3jnItQWZ4ya5EB/TNDLOICnRc=",
+        "checksum": "Q1hgEBBo1tLreSINI2qiCUpUrIE9k=",
         "control": {
-          "checksum": "sha1-CC3jnItQWZ4ya5EB/TNDLOICnRc=",
-          "range": "bytes=701-1140"
+          "checksum": "sha1-hgEBBo1tLreSINI2qiCUpUrIE9k=",
+          "range": "bytes=700-1139"
         },
         "data": {
-          "checksum": "sha256-2EP9UQKOVph+9hElnh20s8ViX126cAnPyNI+IF2pQ4Y=",
-          "range": "bytes=1141-838149"
+          "checksum": "sha256-OFDWkK8l015fs0YvTCXVKLQmOxq+7W5RgJHIqKYZsTE=",
+          "range": "bytes=1140-808582"
         },
         "name": "libcurl-openssl4",
         "signature": {
-          "checksum": "sha1-IxMuIpRYevSLukva0eWmB5RkhMY=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-sygIdNZXB/W8fyOrdelY5RXh3aA=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.7.1-r0.apk",
-        "version": "8.7.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.6.0-r0.apk",
+        "version": "8.6.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1DzKkXRny9JZJvzjFt3jIuvkDP8E=",
+        "checksum": "Q1eQzLI9XN4FM69fm9B4LWd9frcwM=",
         "control": {
-          "checksum": "sha1-DzKkXRny9JZJvzjFt3jIuvkDP8E=",
-          "range": "bytes=700-1101"
+          "checksum": "sha1-eQzLI9XN4FM69fm9B4LWd9frcwM=",
+          "range": "bytes=703-1098"
         },
         "data": {
-          "checksum": "sha256-l1iebyEPmteOEBcPDwPzstpqs9SMvCn8PqlvRU3O7jk=",
-          "range": "bytes=1102-351141"
+          "checksum": "sha256-zkew7+IbyyyENezhlStwO062zaWd+yP/lpbI+CCJVZQ=",
+          "range": "bytes=1099-281166"
         },
         "name": "curl",
         "signature": {
-          "checksum": "sha1-iVKgcLEjgrpj4c2TrRzHznPaWXA=",
-          "range": "bytes=0-699"
+          "checksum": "sha1-igXspQSxo3Eu3o8DeNrYt3YxSbY=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.7.1-r0.apk",
-        "version": "8.7.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.6.0-r0.apk",
+        "version": "8.6.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -964,22 +964,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1IHzRViqIf0JDy09Jq0wBjLddWF8=",
+        "checksum": "Q1oX1h9TIDGTLETKClCLgkwAXqXmI=",
         "control": {
-          "checksum": "sha1-IHzRViqIf0JDy09Jq0wBjLddWF8=",
-          "range": "bytes=707-1056"
+          "checksum": "sha1-oX1h9TIDGTLETKClCLgkwAXqXmI=",
+          "range": "bytes=703-1059"
         },
         "data": {
-          "checksum": "sha256-1PopAYOsQM6qH1BMxY/wjwVDeCNEYTNuuxinV+uHHgQ=",
-          "range": "bytes=1057-9154848"
+          "checksum": "sha256-LVvxvpznc+qM19GIABlreJ29G1v5sGdqLUBL+BQGHvc=",
+          "range": "bytes=1060-9195881"
         },
         "name": "npm",
         "signature": {
-          "checksum": "sha1-rxPX+79rzdVMR2AGsRYAIDQp3sU=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-zqCBoJe1we9P1scmx/TrFXSBmVk=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/npm-10.5.1-r0.apk",
-        "version": "10.5.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/npm-10.5.2-r0.apk",
+        "version": "10.5.2-r0"
       },
       {
         "architecture": "x86_64",
@@ -1002,22 +1002,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1gKd/Y9pQ9g1b/+kx9aw0bUDIOYg=",
+        "checksum": "Q1nT6dPh3gATOD5fAiJYDDhXLYURU=",
         "control": {
-          "checksum": "sha1-gKd/Y9pQ9g1b/+kx9aw0bUDIOYg=",
-          "range": "bytes=659-945"
+          "checksum": "sha1-nT6dPh3gATOD5fAiJYDDhXLYURU=",
+          "range": "bytes=660-947"
         },
         "data": {
-          "checksum": "sha256-9Iy6eQVCYGkk08IlkLdz4SKHCIBKq6AjMcmqbq3uddw=",
-          "range": "bytes=946-67313239"
+          "checksum": "sha256-f0gogUshtaqB5N3eM21aFobI8XVJfl0I2lwjYxiSteM=",
+          "range": "bytes=948-67288856"
         },
         "name": "terraform",
         "signature": {
-          "checksum": "sha1-DZq5vcZsZ0TdVUh6xre0oQRdB1E=",
-          "range": "bytes=0-658"
+          "checksum": "sha1-PwB/hREZdm3YSmkcZKIUva5nc+s=",
+          "range": "bytes=0-659"
         },
-        "url": "https://packages.sgdev.org/main/x86_64/terraform-1.5.6-r1.apk",
-        "version": "1.5.6-r1"
+        "url": "https://packages.sgdev.org/main/x86_64/terraform-1.5.6-r2.apk",
+        "version": "1.5.6-r2"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/executor-kubernetes.lock.json
+++ b/wolfi-images/executor-kubernetes.lock.json
@@ -204,60 +204,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q13piSoRiT6p5eziGu2iPxSkXxf+g=",
+        "checksum": "Q1+rBEmKEIywe0o/a65ZPjWoUECRQ=",
         "control": {
-          "checksum": "sha1-3piSoRiT6p5eziGu2iPxSkXxf+g=",
-          "range": "bytes=704-1039"
+          "checksum": "sha1-+rBEmKEIywe0o/a65ZPjWoUECRQ=",
+          "range": "bytes=703-1054"
         },
         "data": {
-          "checksum": "sha256-+iLQJV5/mU/hTpwsy9zYBfzVIVkd8lXBBqMScHFhHfI=",
-          "range": "bytes=1040-87982"
+          "checksum": "sha256-fcShKjtj6wR6kgjwToU1J8hU+AGRf1OGZt9jeXJdM0Q=",
+          "range": "bytes=1055-82406"
         },
         "name": "openssl-config",
         "signature": {
-          "checksum": "sha1-fsygjfZl7YLgdpBZ5OVKJG/N2HI=",
-          "range": "bytes=0-703"
+          "checksum": "sha1-RT/o4gi2oC/l+6IhikP9/PH5awg=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/openssl-config-3.2.1-r0.apk",
-        "version": "3.2.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/openssl-config-3.3.0-r5.apk",
+        "version": "3.3.0-r5"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1kERnIFBBwTWZsA+cmGLkIU75THk=",
+        "checksum": "Q11DkfNRzraQMj7ue8LFH6VN6d7Bo=",
         "control": {
-          "checksum": "sha1-kERnIFBBwTWZsA+cmGLkIU75THk=",
-          "range": "bytes=694-1066"
+          "checksum": "sha1-1DkfNRzraQMj7ue8LFH6VN6d7Bo=",
+          "range": "bytes=707-1092"
         },
         "data": {
-          "checksum": "sha256-MB5ZoAsBJ0Osps0a1V0KsM/qQhfZQvYupElgoF1rNLE=",
-          "range": "bytes=1067-5895270"
+          "checksum": "sha256-c95GJNThldUhfxVSGbchUI0pS4j6h45Yx6JDPXHaAI0=",
+          "range": "bytes=1093-5915048"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-vTJq+p2AjVQQjJ4gSkR9ySDQr3k=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-EmjggcTaE4QTKI1FzSom0rXam1c=",
+          "range": "bytes=0-706"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.2.1-r0.apk",
-        "version": "3.2.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r5.apk",
+        "version": "3.3.0-r5"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1RFDJtvcstAQi4NjU00ApvNIvoEI=",
+        "checksum": "Q15sT5bGF6kgE7DepzZIHCpPpuP70=",
         "control": {
-          "checksum": "sha1-RFDJtvcstAQi4NjU00ApvNIvoEI=",
-          "range": "bytes=694-1065"
+          "checksum": "sha1-5sT5bGF6kgE7DepzZIHCpPpuP70=",
+          "range": "bytes=702-1085"
         },
         "data": {
-          "checksum": "sha256-oocCJOj9IF7jv3Ov8bPbaAGfq6oaYXuPNnZW9DnOdnE=",
-          "range": "bytes=1066-1135402"
+          "checksum": "sha256-fWOAfZYgXO6+yM4Dpo/y7dvV3uxSEhhfO4SUX79TQDw=",
+          "range": "bytes=1086-1196497"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-wJVFcqH/ewopq4lxwz8OYrZ9/Ws=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-4+7eITv9weTmoYBAAyd92WsXS24=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.2.1-r0.apk",
-        "version": "3.2.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r5.apk",
+        "version": "3.3.0-r5"
       },
       {
         "architecture": "x86_64",
@@ -337,22 +337,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1txYNrxLRCA8tpCe/aXw9Zeb30xw=",
+        "checksum": "Q1sGD1MEAazAXpfNixX74EpwafGo0=",
         "control": {
-          "checksum": "sha1-txYNrxLRCA8tpCe/aXw9Zeb30xw=",
-          "range": "bytes=703-1071"
+          "checksum": "sha1-sGD1MEAazAXpfNixX74EpwafGo0=",
+          "range": "bytes=698-1059"
         },
         "data": {
-          "checksum": "sha256-QgGnbFCQGaCUjwfFVcF2eOXDjZHaJjntdJlM1thwxd0=",
-          "range": "bytes=1072-252873"
+          "checksum": "sha256-s+9m0l/R7hVKQ5YLbU90D2E6DPC2QVTxdjhToMi5iYU=",
+          "range": "bytes=1060-251831"
         },
         "name": "libnghttp2-14",
         "signature": {
-          "checksum": "sha1-VWNh1CR9wcBEPwOH88Qr6n7OR08=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-wOIYtvU72n76UGvbargK2ccZx0E=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.60.0-r0.apk",
-        "version": "1.60.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.61.0-r0.apk",
+        "version": "1.61.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -432,41 +432,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1YKX8zXXVrSZ1a+od3zegHGvE7K4=",
+        "checksum": "Q1NZCvjmGBZ7soi6T4endRPtDztk4=",
         "control": {
-          "checksum": "sha1-YKX8zXXVrSZ1a+od3zegHGvE7K4=",
-          "range": "bytes=701-1168"
+          "checksum": "sha1-NZCvjmGBZ7soi6T4endRPtDztk4=",
+          "range": "bytes=698-1162"
         },
         "data": {
-          "checksum": "sha256-KnMN4TtaDNZqReNINaTivjzUoQigGvtRZgVEqc1EDHo=",
-          "range": "bytes=1169-2555088"
+          "checksum": "sha256-q79pSkGvnDzz1dHsQceLPqyVC+cFCyWWJB5L2EfkZRc=",
+          "range": "bytes=1163-2556930"
         },
         "name": "nghttp2",
         "signature": {
-          "checksum": "sha1-MWKiH9LAxjnWqAm536DCFrsZXCg=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-UuOeekThV8UC737772jFTRj0Y50=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.60.0-r0.apk",
-        "version": "1.60.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.61.0-r0.apk",
+        "version": "1.61.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1D/+xxUxpR+m3nGP5l/8Ed78nNC0=",
+        "checksum": "Q1O/sL8Kjkxzh39Ffh9gJl+0olkF4=",
         "control": {
-          "checksum": "sha1-D/+xxUxpR+m3nGP5l/8Ed78nNC0=",
-          "range": "bytes=700-1067"
+          "checksum": "sha1-O/sL8Kjkxzh39Ffh9gJl+0olkF4=",
+          "range": "bytes=700-1061"
         },
         "data": {
-          "checksum": "sha256-fKV2YLH6EP/NFtRSErdaCwZX+Mg6KJrfmt1VpRWeKis=",
-          "range": "bytes=1068-634389"
+          "checksum": "sha256-6qS8u1yYrzO+4Ypa+g4zfz3m16/7O/U4wjiRrKl8/vw=",
+          "range": "bytes=1062-631650"
         },
         "name": "nghttp2-dev",
         "signature": {
-          "checksum": "sha1-ZRWYUK14qaTBE3NC7OOWumdkSyY=",
+          "checksum": "sha1-avAz/6snsG86C9jh8Gxa59gs29U=",
           "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.60.0-r0.apk",
-        "version": "1.60.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.61.0-r0.apk",
+        "version": "1.61.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -508,41 +508,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1l9z4OGVfdVISNbyGQdXlz2GPchM=",
+        "checksum": "Q1wJPtj5XZtnPiVWGM5dsT+nyfWXc=",
         "control": {
-          "checksum": "sha1-l9z4OGVfdVISNbyGQdXlz2GPchM=",
-          "range": "bytes=695-1222"
+          "checksum": "sha1-wJPtj5XZtnPiVWGM5dsT+nyfWXc=",
+          "range": "bytes=705-1234"
         },
         "data": {
-          "checksum": "sha256-0Z+mq/0A1P+F5KIZKnsYpg8Eqb3GDRT7VDrZlTEg+4Y=",
-          "range": "bytes=1223-3863194"
+          "checksum": "sha256-sw+CjlpsjO01q6lqzXgHnniiJKn7bqOSNO6vNqdGc7I=",
+          "range": "bytes=1235-3873775"
         },
         "name": "bind-libs",
         "signature": {
-          "checksum": "sha1-YX2+1oZh/hXHVjZriSnJZQzpifg=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-9zDzmHAeu7mWpidXAatqrLZVzUs=",
+          "range": "bytes=0-704"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bind-libs-9.18.25-r0.apk",
-        "version": "9.18.25-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/bind-libs-9.18.26-r0.apk",
+        "version": "9.18.26-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Xb5w/MUeHFBeLgnHBmG7dqAMxzQ=",
+        "checksum": "Q1AxEQdi8fVcYtGc3zHTCW3OZdY2Q=",
         "control": {
-          "checksum": "sha1-Xb5w/MUeHFBeLgnHBmG7dqAMxzQ=",
-          "range": "bytes=705-1217"
+          "checksum": "sha1-AxEQdi8fVcYtGc3zHTCW3OZdY2Q=",
+          "range": "bytes=694-1208"
         },
         "data": {
-          "checksum": "sha256-/0zOh1KQW58NOuJgauDOdqJA4G4g0p6jPUOP45HN/f8=",
-          "range": "bytes=1218-892798"
+          "checksum": "sha256-/dt3qJw5D9iSJ/mKkRQkhWD8R52selhpcwXyw7KLMhg=",
+          "range": "bytes=1209-879444"
         },
         "name": "bind-tools",
         "signature": {
-          "checksum": "sha1-3GgaViNXeX4dd75pxgwR8yYgov0=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-VTb0YdUzPMk8Po0p4nj0y5Jey6k=",
+          "range": "bytes=0-693"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bind-tools-9.18.25-r0.apk",
-        "version": "9.18.25-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/bind-tools-9.18.26-r0.apk",
+        "version": "9.18.26-r0"
       },
       {
         "architecture": "x86_64",
@@ -698,41 +698,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1CC3jnItQWZ4ya5EB/TNDLOICnRc=",
+        "checksum": "Q1hgEBBo1tLreSINI2qiCUpUrIE9k=",
         "control": {
-          "checksum": "sha1-CC3jnItQWZ4ya5EB/TNDLOICnRc=",
-          "range": "bytes=701-1140"
+          "checksum": "sha1-hgEBBo1tLreSINI2qiCUpUrIE9k=",
+          "range": "bytes=700-1139"
         },
         "data": {
-          "checksum": "sha256-2EP9UQKOVph+9hElnh20s8ViX126cAnPyNI+IF2pQ4Y=",
-          "range": "bytes=1141-838149"
+          "checksum": "sha256-OFDWkK8l015fs0YvTCXVKLQmOxq+7W5RgJHIqKYZsTE=",
+          "range": "bytes=1140-808582"
         },
         "name": "libcurl-openssl4",
         "signature": {
-          "checksum": "sha1-IxMuIpRYevSLukva0eWmB5RkhMY=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-sygIdNZXB/W8fyOrdelY5RXh3aA=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.7.1-r0.apk",
-        "version": "8.7.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.6.0-r0.apk",
+        "version": "8.6.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1DzKkXRny9JZJvzjFt3jIuvkDP8E=",
+        "checksum": "Q1eQzLI9XN4FM69fm9B4LWd9frcwM=",
         "control": {
-          "checksum": "sha1-DzKkXRny9JZJvzjFt3jIuvkDP8E=",
-          "range": "bytes=700-1101"
+          "checksum": "sha1-eQzLI9XN4FM69fm9B4LWd9frcwM=",
+          "range": "bytes=703-1098"
         },
         "data": {
-          "checksum": "sha256-l1iebyEPmteOEBcPDwPzstpqs9SMvCn8PqlvRU3O7jk=",
-          "range": "bytes=1102-351141"
+          "checksum": "sha256-zkew7+IbyyyENezhlStwO062zaWd+yP/lpbI+CCJVZQ=",
+          "range": "bytes=1099-281166"
         },
         "name": "curl",
         "signature": {
-          "checksum": "sha1-iVKgcLEjgrpj4c2TrRzHznPaWXA=",
-          "range": "bytes=0-699"
+          "checksum": "sha1-igXspQSxo3Eu3o8DeNrYt3YxSbY=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.7.1-r0.apk",
-        "version": "8.7.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.6.0-r0.apk",
+        "version": "8.6.0-r0"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/executor.lock.json
+++ b/wolfi-images/executor.lock.json
@@ -204,60 +204,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q13piSoRiT6p5eziGu2iPxSkXxf+g=",
+        "checksum": "Q1+rBEmKEIywe0o/a65ZPjWoUECRQ=",
         "control": {
-          "checksum": "sha1-3piSoRiT6p5eziGu2iPxSkXxf+g=",
-          "range": "bytes=704-1039"
+          "checksum": "sha1-+rBEmKEIywe0o/a65ZPjWoUECRQ=",
+          "range": "bytes=703-1054"
         },
         "data": {
-          "checksum": "sha256-+iLQJV5/mU/hTpwsy9zYBfzVIVkd8lXBBqMScHFhHfI=",
-          "range": "bytes=1040-87982"
+          "checksum": "sha256-fcShKjtj6wR6kgjwToU1J8hU+AGRf1OGZt9jeXJdM0Q=",
+          "range": "bytes=1055-82406"
         },
         "name": "openssl-config",
         "signature": {
-          "checksum": "sha1-fsygjfZl7YLgdpBZ5OVKJG/N2HI=",
-          "range": "bytes=0-703"
+          "checksum": "sha1-RT/o4gi2oC/l+6IhikP9/PH5awg=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/openssl-config-3.2.1-r0.apk",
-        "version": "3.2.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/openssl-config-3.3.0-r5.apk",
+        "version": "3.3.0-r5"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1kERnIFBBwTWZsA+cmGLkIU75THk=",
+        "checksum": "Q11DkfNRzraQMj7ue8LFH6VN6d7Bo=",
         "control": {
-          "checksum": "sha1-kERnIFBBwTWZsA+cmGLkIU75THk=",
-          "range": "bytes=694-1066"
+          "checksum": "sha1-1DkfNRzraQMj7ue8LFH6VN6d7Bo=",
+          "range": "bytes=707-1092"
         },
         "data": {
-          "checksum": "sha256-MB5ZoAsBJ0Osps0a1V0KsM/qQhfZQvYupElgoF1rNLE=",
-          "range": "bytes=1067-5895270"
+          "checksum": "sha256-c95GJNThldUhfxVSGbchUI0pS4j6h45Yx6JDPXHaAI0=",
+          "range": "bytes=1093-5915048"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-vTJq+p2AjVQQjJ4gSkR9ySDQr3k=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-EmjggcTaE4QTKI1FzSom0rXam1c=",
+          "range": "bytes=0-706"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.2.1-r0.apk",
-        "version": "3.2.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r5.apk",
+        "version": "3.3.0-r5"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1RFDJtvcstAQi4NjU00ApvNIvoEI=",
+        "checksum": "Q15sT5bGF6kgE7DepzZIHCpPpuP70=",
         "control": {
-          "checksum": "sha1-RFDJtvcstAQi4NjU00ApvNIvoEI=",
-          "range": "bytes=694-1065"
+          "checksum": "sha1-5sT5bGF6kgE7DepzZIHCpPpuP70=",
+          "range": "bytes=702-1085"
         },
         "data": {
-          "checksum": "sha256-oocCJOj9IF7jv3Ov8bPbaAGfq6oaYXuPNnZW9DnOdnE=",
-          "range": "bytes=1066-1135402"
+          "checksum": "sha256-fWOAfZYgXO6+yM4Dpo/y7dvV3uxSEhhfO4SUX79TQDw=",
+          "range": "bytes=1086-1196497"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-wJVFcqH/ewopq4lxwz8OYrZ9/Ws=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-4+7eITv9weTmoYBAAyd92WsXS24=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.2.1-r0.apk",
-        "version": "3.2.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r5.apk",
+        "version": "3.3.0-r5"
       },
       {
         "architecture": "x86_64",
@@ -337,22 +337,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1txYNrxLRCA8tpCe/aXw9Zeb30xw=",
+        "checksum": "Q1sGD1MEAazAXpfNixX74EpwafGo0=",
         "control": {
-          "checksum": "sha1-txYNrxLRCA8tpCe/aXw9Zeb30xw=",
-          "range": "bytes=703-1071"
+          "checksum": "sha1-sGD1MEAazAXpfNixX74EpwafGo0=",
+          "range": "bytes=698-1059"
         },
         "data": {
-          "checksum": "sha256-QgGnbFCQGaCUjwfFVcF2eOXDjZHaJjntdJlM1thwxd0=",
-          "range": "bytes=1072-252873"
+          "checksum": "sha256-s+9m0l/R7hVKQ5YLbU90D2E6DPC2QVTxdjhToMi5iYU=",
+          "range": "bytes=1060-251831"
         },
         "name": "libnghttp2-14",
         "signature": {
-          "checksum": "sha1-VWNh1CR9wcBEPwOH88Qr6n7OR08=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-wOIYtvU72n76UGvbargK2ccZx0E=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.60.0-r0.apk",
-        "version": "1.60.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.61.0-r0.apk",
+        "version": "1.61.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -432,41 +432,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1YKX8zXXVrSZ1a+od3zegHGvE7K4=",
+        "checksum": "Q1NZCvjmGBZ7soi6T4endRPtDztk4=",
         "control": {
-          "checksum": "sha1-YKX8zXXVrSZ1a+od3zegHGvE7K4=",
-          "range": "bytes=701-1168"
+          "checksum": "sha1-NZCvjmGBZ7soi6T4endRPtDztk4=",
+          "range": "bytes=698-1162"
         },
         "data": {
-          "checksum": "sha256-KnMN4TtaDNZqReNINaTivjzUoQigGvtRZgVEqc1EDHo=",
-          "range": "bytes=1169-2555088"
+          "checksum": "sha256-q79pSkGvnDzz1dHsQceLPqyVC+cFCyWWJB5L2EfkZRc=",
+          "range": "bytes=1163-2556930"
         },
         "name": "nghttp2",
         "signature": {
-          "checksum": "sha1-MWKiH9LAxjnWqAm536DCFrsZXCg=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-UuOeekThV8UC737772jFTRj0Y50=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.60.0-r0.apk",
-        "version": "1.60.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.61.0-r0.apk",
+        "version": "1.61.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1D/+xxUxpR+m3nGP5l/8Ed78nNC0=",
+        "checksum": "Q1O/sL8Kjkxzh39Ffh9gJl+0olkF4=",
         "control": {
-          "checksum": "sha1-D/+xxUxpR+m3nGP5l/8Ed78nNC0=",
-          "range": "bytes=700-1067"
+          "checksum": "sha1-O/sL8Kjkxzh39Ffh9gJl+0olkF4=",
+          "range": "bytes=700-1061"
         },
         "data": {
-          "checksum": "sha256-fKV2YLH6EP/NFtRSErdaCwZX+Mg6KJrfmt1VpRWeKis=",
-          "range": "bytes=1068-634389"
+          "checksum": "sha256-6qS8u1yYrzO+4Ypa+g4zfz3m16/7O/U4wjiRrKl8/vw=",
+          "range": "bytes=1062-631650"
         },
         "name": "nghttp2-dev",
         "signature": {
-          "checksum": "sha1-ZRWYUK14qaTBE3NC7OOWumdkSyY=",
+          "checksum": "sha1-avAz/6snsG86C9jh8Gxa59gs29U=",
           "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.60.0-r0.apk",
-        "version": "1.60.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.61.0-r0.apk",
+        "version": "1.61.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -508,41 +508,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1l9z4OGVfdVISNbyGQdXlz2GPchM=",
+        "checksum": "Q1wJPtj5XZtnPiVWGM5dsT+nyfWXc=",
         "control": {
-          "checksum": "sha1-l9z4OGVfdVISNbyGQdXlz2GPchM=",
-          "range": "bytes=695-1222"
+          "checksum": "sha1-wJPtj5XZtnPiVWGM5dsT+nyfWXc=",
+          "range": "bytes=705-1234"
         },
         "data": {
-          "checksum": "sha256-0Z+mq/0A1P+F5KIZKnsYpg8Eqb3GDRT7VDrZlTEg+4Y=",
-          "range": "bytes=1223-3863194"
+          "checksum": "sha256-sw+CjlpsjO01q6lqzXgHnniiJKn7bqOSNO6vNqdGc7I=",
+          "range": "bytes=1235-3873775"
         },
         "name": "bind-libs",
         "signature": {
-          "checksum": "sha1-YX2+1oZh/hXHVjZriSnJZQzpifg=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-9zDzmHAeu7mWpidXAatqrLZVzUs=",
+          "range": "bytes=0-704"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bind-libs-9.18.25-r0.apk",
-        "version": "9.18.25-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/bind-libs-9.18.26-r0.apk",
+        "version": "9.18.26-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Xb5w/MUeHFBeLgnHBmG7dqAMxzQ=",
+        "checksum": "Q1AxEQdi8fVcYtGc3zHTCW3OZdY2Q=",
         "control": {
-          "checksum": "sha1-Xb5w/MUeHFBeLgnHBmG7dqAMxzQ=",
-          "range": "bytes=705-1217"
+          "checksum": "sha1-AxEQdi8fVcYtGc3zHTCW3OZdY2Q=",
+          "range": "bytes=694-1208"
         },
         "data": {
-          "checksum": "sha256-/0zOh1KQW58NOuJgauDOdqJA4G4g0p6jPUOP45HN/f8=",
-          "range": "bytes=1218-892798"
+          "checksum": "sha256-/dt3qJw5D9iSJ/mKkRQkhWD8R52selhpcwXyw7KLMhg=",
+          "range": "bytes=1209-879444"
         },
         "name": "bind-tools",
         "signature": {
-          "checksum": "sha1-3GgaViNXeX4dd75pxgwR8yYgov0=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-VTb0YdUzPMk8Po0p4nj0y5Jey6k=",
+          "range": "bytes=0-693"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bind-tools-9.18.25-r0.apk",
-        "version": "9.18.25-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/bind-tools-9.18.26-r0.apk",
+        "version": "9.18.26-r0"
       },
       {
         "architecture": "x86_64",
@@ -717,60 +717,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1CC3jnItQWZ4ya5EB/TNDLOICnRc=",
+        "checksum": "Q1hgEBBo1tLreSINI2qiCUpUrIE9k=",
         "control": {
-          "checksum": "sha1-CC3jnItQWZ4ya5EB/TNDLOICnRc=",
-          "range": "bytes=701-1140"
+          "checksum": "sha1-hgEBBo1tLreSINI2qiCUpUrIE9k=",
+          "range": "bytes=700-1139"
         },
         "data": {
-          "checksum": "sha256-2EP9UQKOVph+9hElnh20s8ViX126cAnPyNI+IF2pQ4Y=",
-          "range": "bytes=1141-838149"
+          "checksum": "sha256-OFDWkK8l015fs0YvTCXVKLQmOxq+7W5RgJHIqKYZsTE=",
+          "range": "bytes=1140-808582"
         },
         "name": "libcurl-openssl4",
         "signature": {
-          "checksum": "sha1-IxMuIpRYevSLukva0eWmB5RkhMY=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-sygIdNZXB/W8fyOrdelY5RXh3aA=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.7.1-r0.apk",
-        "version": "8.7.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.6.0-r0.apk",
+        "version": "8.6.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1DzKkXRny9JZJvzjFt3jIuvkDP8E=",
+        "checksum": "Q1eQzLI9XN4FM69fm9B4LWd9frcwM=",
         "control": {
-          "checksum": "sha1-DzKkXRny9JZJvzjFt3jIuvkDP8E=",
-          "range": "bytes=700-1101"
+          "checksum": "sha1-eQzLI9XN4FM69fm9B4LWd9frcwM=",
+          "range": "bytes=703-1098"
         },
         "data": {
-          "checksum": "sha256-l1iebyEPmteOEBcPDwPzstpqs9SMvCn8PqlvRU3O7jk=",
-          "range": "bytes=1102-351141"
+          "checksum": "sha256-zkew7+IbyyyENezhlStwO062zaWd+yP/lpbI+CCJVZQ=",
+          "range": "bytes=1099-281166"
         },
         "name": "curl",
         "signature": {
-          "checksum": "sha1-iVKgcLEjgrpj4c2TrRzHznPaWXA=",
-          "range": "bytes=0-699"
+          "checksum": "sha1-igXspQSxo3Eu3o8DeNrYt3YxSbY=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.7.1-r0.apk",
-        "version": "8.7.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.6.0-r0.apk",
+        "version": "8.6.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Fpxq4IrJypqqHA9n5hsBr5JOAQk=",
+        "checksum": "Q1rrtcqnxTY3IjSpfwlSckqk1mBLE=",
         "control": {
-          "checksum": "sha1-Fpxq4IrJypqqHA9n5hsBr5JOAQk=",
-          "range": "bytes=661-993"
+          "checksum": "sha1-rrtcqnxTY3IjSpfwlSckqk1mBLE=",
+          "range": "bytes=660-992"
         },
         "data": {
-          "checksum": "sha256-9dtEfq2bmhmQJXyknOKgp3lQi1xBgtN/BkVQmnDzvlU=",
-          "range": "bytes=994-34766569"
+          "checksum": "sha256-kka/N79pty5fiLp+OSDfhucE1jSYCPdjYDoKV+4ASX0=",
+          "range": "bytes=993-34738060"
         },
         "name": "docker-client",
         "signature": {
-          "checksum": "sha1-i6Xxi+Xady8AAnFzQriWZttv3p8=",
-          "range": "bytes=0-660"
+          "checksum": "sha1-DlyRMBC4Qj0hcLyPs0BPHnZkFvg=",
+          "range": "bytes=0-659"
         },
-        "url": "https://packages.sgdev.org/main/x86_64/docker-client-24.0.0-r2.apk",
-        "version": "24.0.0-r2"
+        "url": "https://packages.sgdev.org/main/x86_64/docker-client-24.0.0-r3.apk",
+        "version": "24.0.0-r3"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/gitserver.lock.json
+++ b/wolfi-images/gitserver.lock.json
@@ -261,60 +261,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q13piSoRiT6p5eziGu2iPxSkXxf+g=",
+        "checksum": "Q1+rBEmKEIywe0o/a65ZPjWoUECRQ=",
         "control": {
-          "checksum": "sha1-3piSoRiT6p5eziGu2iPxSkXxf+g=",
-          "range": "bytes=704-1039"
+          "checksum": "sha1-+rBEmKEIywe0o/a65ZPjWoUECRQ=",
+          "range": "bytes=703-1054"
         },
         "data": {
-          "checksum": "sha256-+iLQJV5/mU/hTpwsy9zYBfzVIVkd8lXBBqMScHFhHfI=",
-          "range": "bytes=1040-87982"
+          "checksum": "sha256-fcShKjtj6wR6kgjwToU1J8hU+AGRf1OGZt9jeXJdM0Q=",
+          "range": "bytes=1055-82406"
         },
         "name": "openssl-config",
         "signature": {
-          "checksum": "sha1-fsygjfZl7YLgdpBZ5OVKJG/N2HI=",
-          "range": "bytes=0-703"
+          "checksum": "sha1-RT/o4gi2oC/l+6IhikP9/PH5awg=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/openssl-config-3.2.1-r0.apk",
-        "version": "3.2.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/openssl-config-3.3.0-r5.apk",
+        "version": "3.3.0-r5"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1kERnIFBBwTWZsA+cmGLkIU75THk=",
+        "checksum": "Q11DkfNRzraQMj7ue8LFH6VN6d7Bo=",
         "control": {
-          "checksum": "sha1-kERnIFBBwTWZsA+cmGLkIU75THk=",
-          "range": "bytes=694-1066"
+          "checksum": "sha1-1DkfNRzraQMj7ue8LFH6VN6d7Bo=",
+          "range": "bytes=707-1092"
         },
         "data": {
-          "checksum": "sha256-MB5ZoAsBJ0Osps0a1V0KsM/qQhfZQvYupElgoF1rNLE=",
-          "range": "bytes=1067-5895270"
+          "checksum": "sha256-c95GJNThldUhfxVSGbchUI0pS4j6h45Yx6JDPXHaAI0=",
+          "range": "bytes=1093-5915048"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-vTJq+p2AjVQQjJ4gSkR9ySDQr3k=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-EmjggcTaE4QTKI1FzSom0rXam1c=",
+          "range": "bytes=0-706"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.2.1-r0.apk",
-        "version": "3.2.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r5.apk",
+        "version": "3.3.0-r5"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1RFDJtvcstAQi4NjU00ApvNIvoEI=",
+        "checksum": "Q15sT5bGF6kgE7DepzZIHCpPpuP70=",
         "control": {
-          "checksum": "sha1-RFDJtvcstAQi4NjU00ApvNIvoEI=",
-          "range": "bytes=694-1065"
+          "checksum": "sha1-5sT5bGF6kgE7DepzZIHCpPpuP70=",
+          "range": "bytes=702-1085"
         },
         "data": {
-          "checksum": "sha256-oocCJOj9IF7jv3Ov8bPbaAGfq6oaYXuPNnZW9DnOdnE=",
-          "range": "bytes=1066-1135402"
+          "checksum": "sha256-fWOAfZYgXO6+yM4Dpo/y7dvV3uxSEhhfO4SUX79TQDw=",
+          "range": "bytes=1086-1196497"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-wJVFcqH/ewopq4lxwz8OYrZ9/Ws=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-4+7eITv9weTmoYBAAyd92WsXS24=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.2.1-r0.apk",
-        "version": "3.2.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r5.apk",
+        "version": "3.3.0-r5"
       },
       {
         "architecture": "x86_64",
@@ -394,22 +394,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1txYNrxLRCA8tpCe/aXw9Zeb30xw=",
+        "checksum": "Q1sGD1MEAazAXpfNixX74EpwafGo0=",
         "control": {
-          "checksum": "sha1-txYNrxLRCA8tpCe/aXw9Zeb30xw=",
-          "range": "bytes=703-1071"
+          "checksum": "sha1-sGD1MEAazAXpfNixX74EpwafGo0=",
+          "range": "bytes=698-1059"
         },
         "data": {
-          "checksum": "sha256-QgGnbFCQGaCUjwfFVcF2eOXDjZHaJjntdJlM1thwxd0=",
-          "range": "bytes=1072-252873"
+          "checksum": "sha256-s+9m0l/R7hVKQ5YLbU90D2E6DPC2QVTxdjhToMi5iYU=",
+          "range": "bytes=1060-251831"
         },
         "name": "libnghttp2-14",
         "signature": {
-          "checksum": "sha1-VWNh1CR9wcBEPwOH88Qr6n7OR08=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-wOIYtvU72n76UGvbargK2ccZx0E=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.60.0-r0.apk",
-        "version": "1.60.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.61.0-r0.apk",
+        "version": "1.61.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -489,41 +489,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1YKX8zXXVrSZ1a+od3zegHGvE7K4=",
+        "checksum": "Q1NZCvjmGBZ7soi6T4endRPtDztk4=",
         "control": {
-          "checksum": "sha1-YKX8zXXVrSZ1a+od3zegHGvE7K4=",
-          "range": "bytes=701-1168"
+          "checksum": "sha1-NZCvjmGBZ7soi6T4endRPtDztk4=",
+          "range": "bytes=698-1162"
         },
         "data": {
-          "checksum": "sha256-KnMN4TtaDNZqReNINaTivjzUoQigGvtRZgVEqc1EDHo=",
-          "range": "bytes=1169-2555088"
+          "checksum": "sha256-q79pSkGvnDzz1dHsQceLPqyVC+cFCyWWJB5L2EfkZRc=",
+          "range": "bytes=1163-2556930"
         },
         "name": "nghttp2",
         "signature": {
-          "checksum": "sha1-MWKiH9LAxjnWqAm536DCFrsZXCg=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-UuOeekThV8UC737772jFTRj0Y50=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.60.0-r0.apk",
-        "version": "1.60.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.61.0-r0.apk",
+        "version": "1.61.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1D/+xxUxpR+m3nGP5l/8Ed78nNC0=",
+        "checksum": "Q1O/sL8Kjkxzh39Ffh9gJl+0olkF4=",
         "control": {
-          "checksum": "sha1-D/+xxUxpR+m3nGP5l/8Ed78nNC0=",
-          "range": "bytes=700-1067"
+          "checksum": "sha1-O/sL8Kjkxzh39Ffh9gJl+0olkF4=",
+          "range": "bytes=700-1061"
         },
         "data": {
-          "checksum": "sha256-fKV2YLH6EP/NFtRSErdaCwZX+Mg6KJrfmt1VpRWeKis=",
-          "range": "bytes=1068-634389"
+          "checksum": "sha256-6qS8u1yYrzO+4Ypa+g4zfz3m16/7O/U4wjiRrKl8/vw=",
+          "range": "bytes=1062-631650"
         },
         "name": "nghttp2-dev",
         "signature": {
-          "checksum": "sha1-ZRWYUK14qaTBE3NC7OOWumdkSyY=",
+          "checksum": "sha1-avAz/6snsG86C9jh8Gxa59gs29U=",
           "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.60.0-r0.apk",
-        "version": "1.60.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.61.0-r0.apk",
+        "version": "1.61.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -565,41 +565,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1l9z4OGVfdVISNbyGQdXlz2GPchM=",
+        "checksum": "Q1wJPtj5XZtnPiVWGM5dsT+nyfWXc=",
         "control": {
-          "checksum": "sha1-l9z4OGVfdVISNbyGQdXlz2GPchM=",
-          "range": "bytes=695-1222"
+          "checksum": "sha1-wJPtj5XZtnPiVWGM5dsT+nyfWXc=",
+          "range": "bytes=705-1234"
         },
         "data": {
-          "checksum": "sha256-0Z+mq/0A1P+F5KIZKnsYpg8Eqb3GDRT7VDrZlTEg+4Y=",
-          "range": "bytes=1223-3863194"
+          "checksum": "sha256-sw+CjlpsjO01q6lqzXgHnniiJKn7bqOSNO6vNqdGc7I=",
+          "range": "bytes=1235-3873775"
         },
         "name": "bind-libs",
         "signature": {
-          "checksum": "sha1-YX2+1oZh/hXHVjZriSnJZQzpifg=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-9zDzmHAeu7mWpidXAatqrLZVzUs=",
+          "range": "bytes=0-704"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bind-libs-9.18.25-r0.apk",
-        "version": "9.18.25-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/bind-libs-9.18.26-r0.apk",
+        "version": "9.18.26-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Xb5w/MUeHFBeLgnHBmG7dqAMxzQ=",
+        "checksum": "Q1AxEQdi8fVcYtGc3zHTCW3OZdY2Q=",
         "control": {
-          "checksum": "sha1-Xb5w/MUeHFBeLgnHBmG7dqAMxzQ=",
-          "range": "bytes=705-1217"
+          "checksum": "sha1-AxEQdi8fVcYtGc3zHTCW3OZdY2Q=",
+          "range": "bytes=694-1208"
         },
         "data": {
-          "checksum": "sha256-/0zOh1KQW58NOuJgauDOdqJA4G4g0p6jPUOP45HN/f8=",
-          "range": "bytes=1218-892798"
+          "checksum": "sha256-/dt3qJw5D9iSJ/mKkRQkhWD8R52selhpcwXyw7KLMhg=",
+          "range": "bytes=1209-879444"
         },
         "name": "bind-tools",
         "signature": {
-          "checksum": "sha1-3GgaViNXeX4dd75pxgwR8yYgov0=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-VTb0YdUzPMk8Po0p4nj0y5Jey6k=",
+          "range": "bytes=0-693"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bind-tools-9.18.25-r0.apk",
-        "version": "9.18.25-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/bind-tools-9.18.26-r0.apk",
+        "version": "9.18.26-r0"
       },
       {
         "architecture": "x86_64",
@@ -660,22 +660,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q18DXOCGQccaBV9A5r/surTzWqW/o=",
+        "checksum": "Q1L9rArzLWlXjTBTMt4R4rKPLw2qo=",
         "control": {
-          "checksum": "sha1-8DXOCGQccaBV9A5r/surTzWqW/o=",
-          "range": "bytes=657-1007"
+          "checksum": "sha1-L9rArzLWlXjTBTMt4R4rKPLw2qo=",
+          "range": "bytes=660-1009"
         },
         "data": {
-          "checksum": "sha256-e1xbeh3L6Li3xcK1EO3/rWIFrGyxqNG9G651Qi/oiUk=",
-          "range": "bytes=1008-59687101"
+          "checksum": "sha256-zaAqDv39QN1OwYSWZY5ILzlTqUmpVTE8lBBSsKRO/AU=",
+          "range": "bytes=1010-59654512"
         },
         "name": "coursier",
         "signature": {
-          "checksum": "sha1-OvNg0xO/vjOWr45Urdbfa7ExS+U=",
-          "range": "bytes=0-656"
+          "checksum": "sha1-qlZ+I72V1IIyjsqJpeKaaTMfSQc=",
+          "range": "bytes=0-659"
         },
-        "url": "https://packages.sgdev.org/main/x86_64/coursier-2.0.13-r2.apk",
-        "version": "2.0.13-r2"
+        "url": "https://packages.sgdev.org/main/x86_64/coursier-2.0.13-r3.apk",
+        "version": "2.0.13-r3"
       },
       {
         "architecture": "x86_64",
@@ -774,41 +774,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1CC3jnItQWZ4ya5EB/TNDLOICnRc=",
+        "checksum": "Q1hgEBBo1tLreSINI2qiCUpUrIE9k=",
         "control": {
-          "checksum": "sha1-CC3jnItQWZ4ya5EB/TNDLOICnRc=",
-          "range": "bytes=701-1140"
+          "checksum": "sha1-hgEBBo1tLreSINI2qiCUpUrIE9k=",
+          "range": "bytes=700-1139"
         },
         "data": {
-          "checksum": "sha256-2EP9UQKOVph+9hElnh20s8ViX126cAnPyNI+IF2pQ4Y=",
-          "range": "bytes=1141-838149"
+          "checksum": "sha256-OFDWkK8l015fs0YvTCXVKLQmOxq+7W5RgJHIqKYZsTE=",
+          "range": "bytes=1140-808582"
         },
         "name": "libcurl-openssl4",
         "signature": {
-          "checksum": "sha1-IxMuIpRYevSLukva0eWmB5RkhMY=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-sygIdNZXB/W8fyOrdelY5RXh3aA=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.7.1-r0.apk",
-        "version": "8.7.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.6.0-r0.apk",
+        "version": "8.6.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1DzKkXRny9JZJvzjFt3jIuvkDP8E=",
+        "checksum": "Q1eQzLI9XN4FM69fm9B4LWd9frcwM=",
         "control": {
-          "checksum": "sha1-DzKkXRny9JZJvzjFt3jIuvkDP8E=",
-          "range": "bytes=700-1101"
+          "checksum": "sha1-eQzLI9XN4FM69fm9B4LWd9frcwM=",
+          "range": "bytes=703-1098"
         },
         "data": {
-          "checksum": "sha256-l1iebyEPmteOEBcPDwPzstpqs9SMvCn8PqlvRU3O7jk=",
-          "range": "bytes=1102-351141"
+          "checksum": "sha256-zkew7+IbyyyENezhlStwO062zaWd+yP/lpbI+CCJVZQ=",
+          "range": "bytes=1099-281166"
         },
         "name": "curl",
         "signature": {
-          "checksum": "sha1-iVKgcLEjgrpj4c2TrRzHznPaWXA=",
-          "range": "bytes=0-699"
+          "checksum": "sha1-igXspQSxo3Eu3o8DeNrYt3YxSbY=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.7.1-r0.apk",
-        "version": "8.7.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.6.0-r0.apk",
+        "version": "8.6.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -983,41 +983,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Z9DazMtZP+To5LyRwctr1Uokn5A=",
+        "checksum": "Q1LbqvA8R46fS+Zwl18guXt5zvYrw=",
         "control": {
-          "checksum": "sha1-Z9DazMtZP+To5LyRwctr1Uokn5A=",
-          "range": "bytes=663-1040"
+          "checksum": "sha1-LbqvA8R46fS+Zwl18guXt5zvYrw=",
+          "range": "bytes=660-1037"
         },
         "data": {
-          "checksum": "sha256-S/mI1CiAUK7r1C4P/v1o4F/JK1I42zI/8VlYWV47pGQ=",
-          "range": "bytes=1041-20465725"
+          "checksum": "sha256-Onbp332eMogVPHfUpduSsjA5w+xpyHcCb7VuMA4T1x8=",
+          "range": "bytes=1038-20466045"
         },
         "name": "p4-fusion-sg",
         "signature": {
-          "checksum": "sha1-qmBhbGYBgh/WGr9cGpOH0uYf3lc=",
-          "range": "bytes=0-662"
+          "checksum": "sha1-29MX0Y8RvdpmHPm4IPFCo3diYzY=",
+          "range": "bytes=0-659"
         },
-        "url": "https://packages.sgdev.org/main/x86_64/p4-fusion-sg-1.13.2-r2.apk",
-        "version": "1.13.2-r2"
+        "url": "https://packages.sgdev.org/main/x86_64/p4-fusion-sg-1.13.2-r3.apk",
+        "version": "1.13.2-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1cHKiymYHwbYyrA79BwJQx64e/jo=",
+        "checksum": "Q1rx1vd22w8TCeTwwQycXB0QGl6Ds=",
         "control": {
-          "checksum": "sha1-cHKiymYHwbYyrA79BwJQx64e/jo=",
-          "range": "bytes=661-1006"
+          "checksum": "sha1-rx1vd22w8TCeTwwQycXB0QGl6Ds=",
+          "range": "bytes=660-1005"
         },
         "data": {
-          "checksum": "sha256-vYWtpGcq2+9YJWsn1ULd97MlTvTkN9fZzow39s3S92U=",
-          "range": "bytes=1007-10325900"
+          "checksum": "sha256-LUsh0caZMI+gMZNGuqGxkM3bdm5WAfKY1UFiAA0Y1TM=",
+          "range": "bytes=1006-10325900"
         },
         "name": "p4cli",
         "signature": {
-          "checksum": "sha1-Hzc2YmWpLg1udDGkuYNe5NBsVCU=",
-          "range": "bytes=0-660"
+          "checksum": "sha1-+VP7upg+lI20xw+mJc+jYb+FsCY=",
+          "range": "bytes=0-659"
         },
-        "url": "https://packages.sgdev.org/main/x86_64/p4cli-23.1-r2.apk",
-        "version": "23.1-r2"
+        "url": "https://packages.sgdev.org/main/x86_64/p4cli-23.1-r3.apk",
+        "version": "23.1-r3"
       },
       {
         "architecture": "x86_64",
@@ -1135,41 +1135,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1D8X74+a2sutMM4df4P63Q+jOtzw=",
+        "checksum": "Q1LPejw4CnrXdaD6OHwAoFM/7vA7s=",
         "control": {
-          "checksum": "sha1-D8X74+a2sutMM4df4P63Q+jOtzw=",
-          "range": "bytes=695-1203"
+          "checksum": "sha1-LPejw4CnrXdaD6OHwAoFM/7vA7s=",
+          "range": "bytes=700-1217"
         },
         "data": {
-          "checksum": "sha256-UbrH++J9cwOI+rQwn8kPVIP2yS2hTvb9aPFECfF6tB8=",
-          "range": "bytes=1204-42123590"
+          "checksum": "sha256-r23KtCFip48cIupEQhoBPL12Ldsyr6u5LKT8la+mZfo=",
+          "range": "bytes=1218-40574201"
         },
         "name": "python-3.12-base",
         "signature": {
-          "checksum": "sha1-X2u0OA9U6goK8Dt9EB4ejml2/BE=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-5EREXBj3ZFrVW1zyGKgNw/DUyEM=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/python-3.12-base-3.12.2-r8.apk",
-        "version": "3.12.2-r8"
+        "url": "https://packages.wolfi.dev/os/x86_64/python-3.12-base-3.12.3-r0.apk",
+        "version": "3.12.3-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q19dQz13v/WahZBP19atGsVQLAV0Q=",
+        "checksum": "Q1zJd5jSTT2iNfEP+Lg6n5DL2N5iM=",
         "control": {
-          "checksum": "sha1-9dQz13v/WahZBP19atGsVQLAV0Q=",
-          "range": "bytes=698-1062"
+          "checksum": "sha1-zJd5jSTT2iNfEP+Lg6n5DL2N5iM=",
+          "range": "bytes=708-1079"
         },
         "data": {
-          "checksum": "sha256-6e1OR1RuGUAHP762Ek6Oub/Do13jH2BITZLcSrfb50I=",
-          "range": "bytes=1063-42235"
+          "checksum": "sha256-ZEgYPjLoERnzSvMfi4YYzoVQa7U8OJDGCidlrjCkBBw=",
+          "range": "bytes=1080-42121"
         },
         "name": "python-3.12",
         "signature": {
-          "checksum": "sha1-Fy9ND0Cx9lWHbyWqbAmfoQB2q9c=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-oqY6wsK+/SWuhGEnD7sZM/qdjdU=",
+          "range": "bytes=0-707"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/python-3.12-3.12.2-r8.apk",
-        "version": "3.12.2-r8"
+        "url": "https://packages.wolfi.dev/os/x86_64/python-3.12-3.12.3-r0.apk",
+        "version": "3.12.3-r0"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/grafana.lock.json
+++ b/wolfi-images/grafana.lock.json
@@ -18,25 +18,6 @@
     "packages": [
       {
         "architecture": "x86_64",
-        "checksum": "Q13piSoRiT6p5eziGu2iPxSkXxf+g=",
-        "control": {
-          "checksum": "sha1-3piSoRiT6p5eziGu2iPxSkXxf+g=",
-          "range": "bytes=704-1039"
-        },
-        "data": {
-          "checksum": "sha256-+iLQJV5/mU/hTpwsy9zYBfzVIVkd8lXBBqMScHFhHfI=",
-          "range": "bytes=1040-87982"
-        },
-        "name": "openssl-config",
-        "signature": {
-          "checksum": "sha1-fsygjfZl7YLgdpBZ5OVKJG/N2HI=",
-          "range": "bytes=0-703"
-        },
-        "url": "https://packages.wolfi.dev/os/x86_64/openssl-config-3.2.1-r0.apk",
-        "version": "3.2.1-r0"
-      },
-      {
-        "architecture": "x86_64",
         "checksum": "Q1YQmPfQ1Ym4tfjrCMChbESrrRg/o=",
         "control": {
           "checksum": "sha1-YQmPfQ1Ym4tfjrCMChbESrrRg/o=",
@@ -132,41 +113,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1kERnIFBBwTWZsA+cmGLkIU75THk=",
+        "checksum": "Q1+rBEmKEIywe0o/a65ZPjWoUECRQ=",
         "control": {
-          "checksum": "sha1-kERnIFBBwTWZsA+cmGLkIU75THk=",
-          "range": "bytes=694-1066"
+          "checksum": "sha1-+rBEmKEIywe0o/a65ZPjWoUECRQ=",
+          "range": "bytes=703-1054"
         },
         "data": {
-          "checksum": "sha256-MB5ZoAsBJ0Osps0a1V0KsM/qQhfZQvYupElgoF1rNLE=",
-          "range": "bytes=1067-5895270"
+          "checksum": "sha256-fcShKjtj6wR6kgjwToU1J8hU+AGRf1OGZt9jeXJdM0Q=",
+          "range": "bytes=1055-82406"
         },
-        "name": "libcrypto3",
+        "name": "openssl-config",
         "signature": {
-          "checksum": "sha1-vTJq+p2AjVQQjJ4gSkR9ySDQr3k=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-RT/o4gi2oC/l+6IhikP9/PH5awg=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.2.1-r0.apk",
-        "version": "3.2.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/openssl-config-3.3.0-r5.apk",
+        "version": "3.3.0-r5"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1RFDJtvcstAQi4NjU00ApvNIvoEI=",
+        "checksum": "Q11DkfNRzraQMj7ue8LFH6VN6d7Bo=",
         "control": {
-          "checksum": "sha1-RFDJtvcstAQi4NjU00ApvNIvoEI=",
-          "range": "bytes=694-1065"
+          "checksum": "sha1-1DkfNRzraQMj7ue8LFH6VN6d7Bo=",
+          "range": "bytes=707-1092"
         },
         "data": {
-          "checksum": "sha256-oocCJOj9IF7jv3Ov8bPbaAGfq6oaYXuPNnZW9DnOdnE=",
-          "range": "bytes=1066-1135402"
+          "checksum": "sha256-c95GJNThldUhfxVSGbchUI0pS4j6h45Yx6JDPXHaAI0=",
+          "range": "bytes=1093-5915048"
+        },
+        "name": "libcrypto3",
+        "signature": {
+          "checksum": "sha1-EmjggcTaE4QTKI1FzSom0rXam1c=",
+          "range": "bytes=0-706"
+        },
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r5.apk",
+        "version": "3.3.0-r5"
+      },
+      {
+        "architecture": "x86_64",
+        "checksum": "Q15sT5bGF6kgE7DepzZIHCpPpuP70=",
+        "control": {
+          "checksum": "sha1-5sT5bGF6kgE7DepzZIHCpPpuP70=",
+          "range": "bytes=702-1085"
+        },
+        "data": {
+          "checksum": "sha256-fWOAfZYgXO6+yM4Dpo/y7dvV3uxSEhhfO4SUX79TQDw=",
+          "range": "bytes=1086-1196497"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-wJVFcqH/ewopq4lxwz8OYrZ9/Ws=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-4+7eITv9weTmoYBAAyd92WsXS24=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.2.1-r0.apk",
-        "version": "3.2.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r5.apk",
+        "version": "3.3.0-r5"
       },
       {
         "architecture": "x86_64",
@@ -550,41 +550,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1wfTTH2grvHJI3HouslTTa5skj/g=",
+        "checksum": "Q1f1askbmC5qhWzOcoTndoTZFttH4=",
         "control": {
-          "checksum": "sha1-wfTTH2grvHJI3HouslTTa5skj/g=",
-          "range": "bytes=698-1062"
+          "checksum": "sha1-f1askbmC5qhWzOcoTndoTZFttH4=",
+          "range": "bytes=700-1076"
         },
         "data": {
-          "checksum": "sha256-/3nmDcWbj5pEWKxz2libZO1juTaBHu78dBNCFmUGIqg=",
-          "range": "bytes=1063-183006"
+          "checksum": "sha256-qXIWD8OQroVJK9uQVSe0hZLfHjEDuSqd7khmNQd5NX8=",
+          "range": "bytes=1077-181897"
         },
         "name": "openssl-provider-legacy",
         "signature": {
-          "checksum": "sha1-rnnESs7/5E/vOGbtoDN8JCcHLDM=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-3t4XypeYwpIG/zvG0YZZ+3bxRQ4=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/openssl-provider-legacy-3.2.1-r0.apk",
-        "version": "3.2.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/openssl-provider-legacy-3.3.0-r5.apk",
+        "version": "3.3.0-r5"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Q/lziOVin9xdUz5LZuzGMQhBbE0=",
+        "checksum": "Q1z87sCebNsJLbGZ3B0hD+fcWwGvk=",
         "control": {
-          "checksum": "sha1-Q/lziOVin9xdUz5LZuzGMQhBbE0=",
-          "range": "bytes=696-1107"
+          "checksum": "sha1-z87sCebNsJLbGZ3B0hD+fcWwGvk=",
+          "range": "bytes=705-1130"
         },
         "data": {
-          "checksum": "sha256-u6gHnegwEfQEMP30jh6Sla9MvxglhjPIkRCxWsuC39Y=",
-          "range": "bytes=1108-1205858"
+          "checksum": "sha256-eYhePOF+iUml8ilKATvtt0cL1oSZkx1jYyrSO8xWt2w=",
+          "range": "bytes=1131-1210649"
         },
         "name": "openssl",
         "signature": {
-          "checksum": "sha1-m04AMEimebqnPL4bopZWPldcuTg=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-kzgJpvCQ0sqBI0C09mdZJ86e1sc=",
+          "range": "bytes=0-704"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/openssl-3.2.1-r0.apk",
-        "version": "3.2.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/openssl-3.3.0-r5.apk",
+        "version": "3.3.0-r5"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/jaeger-agent.lock.json
+++ b/wolfi-images/jaeger-agent.lock.json
@@ -204,60 +204,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q13piSoRiT6p5eziGu2iPxSkXxf+g=",
+        "checksum": "Q1+rBEmKEIywe0o/a65ZPjWoUECRQ=",
         "control": {
-          "checksum": "sha1-3piSoRiT6p5eziGu2iPxSkXxf+g=",
-          "range": "bytes=704-1039"
+          "checksum": "sha1-+rBEmKEIywe0o/a65ZPjWoUECRQ=",
+          "range": "bytes=703-1054"
         },
         "data": {
-          "checksum": "sha256-+iLQJV5/mU/hTpwsy9zYBfzVIVkd8lXBBqMScHFhHfI=",
-          "range": "bytes=1040-87982"
+          "checksum": "sha256-fcShKjtj6wR6kgjwToU1J8hU+AGRf1OGZt9jeXJdM0Q=",
+          "range": "bytes=1055-82406"
         },
         "name": "openssl-config",
         "signature": {
-          "checksum": "sha1-fsygjfZl7YLgdpBZ5OVKJG/N2HI=",
-          "range": "bytes=0-703"
+          "checksum": "sha1-RT/o4gi2oC/l+6IhikP9/PH5awg=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/openssl-config-3.2.1-r0.apk",
-        "version": "3.2.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/openssl-config-3.3.0-r5.apk",
+        "version": "3.3.0-r5"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1kERnIFBBwTWZsA+cmGLkIU75THk=",
+        "checksum": "Q11DkfNRzraQMj7ue8LFH6VN6d7Bo=",
         "control": {
-          "checksum": "sha1-kERnIFBBwTWZsA+cmGLkIU75THk=",
-          "range": "bytes=694-1066"
+          "checksum": "sha1-1DkfNRzraQMj7ue8LFH6VN6d7Bo=",
+          "range": "bytes=707-1092"
         },
         "data": {
-          "checksum": "sha256-MB5ZoAsBJ0Osps0a1V0KsM/qQhfZQvYupElgoF1rNLE=",
-          "range": "bytes=1067-5895270"
+          "checksum": "sha256-c95GJNThldUhfxVSGbchUI0pS4j6h45Yx6JDPXHaAI0=",
+          "range": "bytes=1093-5915048"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-vTJq+p2AjVQQjJ4gSkR9ySDQr3k=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-EmjggcTaE4QTKI1FzSom0rXam1c=",
+          "range": "bytes=0-706"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.2.1-r0.apk",
-        "version": "3.2.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r5.apk",
+        "version": "3.3.0-r5"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1RFDJtvcstAQi4NjU00ApvNIvoEI=",
+        "checksum": "Q15sT5bGF6kgE7DepzZIHCpPpuP70=",
         "control": {
-          "checksum": "sha1-RFDJtvcstAQi4NjU00ApvNIvoEI=",
-          "range": "bytes=694-1065"
+          "checksum": "sha1-5sT5bGF6kgE7DepzZIHCpPpuP70=",
+          "range": "bytes=702-1085"
         },
         "data": {
-          "checksum": "sha256-oocCJOj9IF7jv3Ov8bPbaAGfq6oaYXuPNnZW9DnOdnE=",
-          "range": "bytes=1066-1135402"
+          "checksum": "sha256-fWOAfZYgXO6+yM4Dpo/y7dvV3uxSEhhfO4SUX79TQDw=",
+          "range": "bytes=1086-1196497"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-wJVFcqH/ewopq4lxwz8OYrZ9/Ws=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-4+7eITv9weTmoYBAAyd92WsXS24=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.2.1-r0.apk",
-        "version": "3.2.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r5.apk",
+        "version": "3.3.0-r5"
       },
       {
         "architecture": "x86_64",
@@ -337,22 +337,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1txYNrxLRCA8tpCe/aXw9Zeb30xw=",
+        "checksum": "Q1sGD1MEAazAXpfNixX74EpwafGo0=",
         "control": {
-          "checksum": "sha1-txYNrxLRCA8tpCe/aXw9Zeb30xw=",
-          "range": "bytes=703-1071"
+          "checksum": "sha1-sGD1MEAazAXpfNixX74EpwafGo0=",
+          "range": "bytes=698-1059"
         },
         "data": {
-          "checksum": "sha256-QgGnbFCQGaCUjwfFVcF2eOXDjZHaJjntdJlM1thwxd0=",
-          "range": "bytes=1072-252873"
+          "checksum": "sha256-s+9m0l/R7hVKQ5YLbU90D2E6DPC2QVTxdjhToMi5iYU=",
+          "range": "bytes=1060-251831"
         },
         "name": "libnghttp2-14",
         "signature": {
-          "checksum": "sha1-VWNh1CR9wcBEPwOH88Qr6n7OR08=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-wOIYtvU72n76UGvbargK2ccZx0E=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.60.0-r0.apk",
-        "version": "1.60.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.61.0-r0.apk",
+        "version": "1.61.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -432,41 +432,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1YKX8zXXVrSZ1a+od3zegHGvE7K4=",
+        "checksum": "Q1NZCvjmGBZ7soi6T4endRPtDztk4=",
         "control": {
-          "checksum": "sha1-YKX8zXXVrSZ1a+od3zegHGvE7K4=",
-          "range": "bytes=701-1168"
+          "checksum": "sha1-NZCvjmGBZ7soi6T4endRPtDztk4=",
+          "range": "bytes=698-1162"
         },
         "data": {
-          "checksum": "sha256-KnMN4TtaDNZqReNINaTivjzUoQigGvtRZgVEqc1EDHo=",
-          "range": "bytes=1169-2555088"
+          "checksum": "sha256-q79pSkGvnDzz1dHsQceLPqyVC+cFCyWWJB5L2EfkZRc=",
+          "range": "bytes=1163-2556930"
         },
         "name": "nghttp2",
         "signature": {
-          "checksum": "sha1-MWKiH9LAxjnWqAm536DCFrsZXCg=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-UuOeekThV8UC737772jFTRj0Y50=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.60.0-r0.apk",
-        "version": "1.60.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.61.0-r0.apk",
+        "version": "1.61.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1D/+xxUxpR+m3nGP5l/8Ed78nNC0=",
+        "checksum": "Q1O/sL8Kjkxzh39Ffh9gJl+0olkF4=",
         "control": {
-          "checksum": "sha1-D/+xxUxpR+m3nGP5l/8Ed78nNC0=",
-          "range": "bytes=700-1067"
+          "checksum": "sha1-O/sL8Kjkxzh39Ffh9gJl+0olkF4=",
+          "range": "bytes=700-1061"
         },
         "data": {
-          "checksum": "sha256-fKV2YLH6EP/NFtRSErdaCwZX+Mg6KJrfmt1VpRWeKis=",
-          "range": "bytes=1068-634389"
+          "checksum": "sha256-6qS8u1yYrzO+4Ypa+g4zfz3m16/7O/U4wjiRrKl8/vw=",
+          "range": "bytes=1062-631650"
         },
         "name": "nghttp2-dev",
         "signature": {
-          "checksum": "sha1-ZRWYUK14qaTBE3NC7OOWumdkSyY=",
+          "checksum": "sha1-avAz/6snsG86C9jh8Gxa59gs29U=",
           "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.60.0-r0.apk",
-        "version": "1.60.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.61.0-r0.apk",
+        "version": "1.61.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -508,41 +508,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1l9z4OGVfdVISNbyGQdXlz2GPchM=",
+        "checksum": "Q1wJPtj5XZtnPiVWGM5dsT+nyfWXc=",
         "control": {
-          "checksum": "sha1-l9z4OGVfdVISNbyGQdXlz2GPchM=",
-          "range": "bytes=695-1222"
+          "checksum": "sha1-wJPtj5XZtnPiVWGM5dsT+nyfWXc=",
+          "range": "bytes=705-1234"
         },
         "data": {
-          "checksum": "sha256-0Z+mq/0A1P+F5KIZKnsYpg8Eqb3GDRT7VDrZlTEg+4Y=",
-          "range": "bytes=1223-3863194"
+          "checksum": "sha256-sw+CjlpsjO01q6lqzXgHnniiJKn7bqOSNO6vNqdGc7I=",
+          "range": "bytes=1235-3873775"
         },
         "name": "bind-libs",
         "signature": {
-          "checksum": "sha1-YX2+1oZh/hXHVjZriSnJZQzpifg=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-9zDzmHAeu7mWpidXAatqrLZVzUs=",
+          "range": "bytes=0-704"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bind-libs-9.18.25-r0.apk",
-        "version": "9.18.25-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/bind-libs-9.18.26-r0.apk",
+        "version": "9.18.26-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Xb5w/MUeHFBeLgnHBmG7dqAMxzQ=",
+        "checksum": "Q1AxEQdi8fVcYtGc3zHTCW3OZdY2Q=",
         "control": {
-          "checksum": "sha1-Xb5w/MUeHFBeLgnHBmG7dqAMxzQ=",
-          "range": "bytes=705-1217"
+          "checksum": "sha1-AxEQdi8fVcYtGc3zHTCW3OZdY2Q=",
+          "range": "bytes=694-1208"
         },
         "data": {
-          "checksum": "sha256-/0zOh1KQW58NOuJgauDOdqJA4G4g0p6jPUOP45HN/f8=",
-          "range": "bytes=1218-892798"
+          "checksum": "sha256-/dt3qJw5D9iSJ/mKkRQkhWD8R52selhpcwXyw7KLMhg=",
+          "range": "bytes=1209-879444"
         },
         "name": "bind-tools",
         "signature": {
-          "checksum": "sha1-3GgaViNXeX4dd75pxgwR8yYgov0=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-VTb0YdUzPMk8Po0p4nj0y5Jey6k=",
+          "range": "bytes=0-693"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bind-tools-9.18.25-r0.apk",
-        "version": "9.18.25-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/bind-tools-9.18.26-r0.apk",
+        "version": "9.18.26-r0"
       },
       {
         "architecture": "x86_64",
@@ -698,60 +698,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1CC3jnItQWZ4ya5EB/TNDLOICnRc=",
+        "checksum": "Q1hgEBBo1tLreSINI2qiCUpUrIE9k=",
         "control": {
-          "checksum": "sha1-CC3jnItQWZ4ya5EB/TNDLOICnRc=",
-          "range": "bytes=701-1140"
+          "checksum": "sha1-hgEBBo1tLreSINI2qiCUpUrIE9k=",
+          "range": "bytes=700-1139"
         },
         "data": {
-          "checksum": "sha256-2EP9UQKOVph+9hElnh20s8ViX126cAnPyNI+IF2pQ4Y=",
-          "range": "bytes=1141-838149"
+          "checksum": "sha256-OFDWkK8l015fs0YvTCXVKLQmOxq+7W5RgJHIqKYZsTE=",
+          "range": "bytes=1140-808582"
         },
         "name": "libcurl-openssl4",
         "signature": {
-          "checksum": "sha1-IxMuIpRYevSLukva0eWmB5RkhMY=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-sygIdNZXB/W8fyOrdelY5RXh3aA=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.7.1-r0.apk",
-        "version": "8.7.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.6.0-r0.apk",
+        "version": "8.6.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1DzKkXRny9JZJvzjFt3jIuvkDP8E=",
+        "checksum": "Q1eQzLI9XN4FM69fm9B4LWd9frcwM=",
         "control": {
-          "checksum": "sha1-DzKkXRny9JZJvzjFt3jIuvkDP8E=",
-          "range": "bytes=700-1101"
+          "checksum": "sha1-eQzLI9XN4FM69fm9B4LWd9frcwM=",
+          "range": "bytes=703-1098"
         },
         "data": {
-          "checksum": "sha256-l1iebyEPmteOEBcPDwPzstpqs9SMvCn8PqlvRU3O7jk=",
-          "range": "bytes=1102-351141"
+          "checksum": "sha256-zkew7+IbyyyENezhlStwO062zaWd+yP/lpbI+CCJVZQ=",
+          "range": "bytes=1099-281166"
         },
         "name": "curl",
         "signature": {
-          "checksum": "sha1-iVKgcLEjgrpj4c2TrRzHznPaWXA=",
-          "range": "bytes=0-699"
+          "checksum": "sha1-igXspQSxo3Eu3o8DeNrYt3YxSbY=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.7.1-r0.apk",
-        "version": "8.7.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.6.0-r0.apk",
+        "version": "8.6.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1CXp7MOosK1ntfixL7EcDW9hioZo=",
+        "checksum": "Q1o9e4leINqO2zIqiIlY4NwIOk0iI=",
         "control": {
-          "checksum": "sha1-CXp7MOosK1ntfixL7EcDW9hioZo=",
-          "range": "bytes=660-944"
+          "checksum": "sha1-o9e4leINqO2zIqiIlY4NwIOk0iI=",
+          "range": "bytes=660-943"
         },
         "data": {
-          "checksum": "sha256-PBf33gMynovN3wgb4vN4iMdJZAy6W4mDj7JCv9B7nCg=",
-          "range": "bytes=945-24974840"
+          "checksum": "sha256-BIRu5lDaXPoGuQnWT86IBG30SzXQAafnupyriXLPMsE=",
+          "range": "bytes=944-24942259"
         },
         "name": "jaeger-agent",
         "signature": {
-          "checksum": "sha1-LLGSgX8QutjbVv7CLTYAeFpYQl0=",
+          "checksum": "sha1-TaZlIj7TUksudLfDmvW7ulUJakA=",
           "range": "bytes=0-659"
         },
-        "url": "https://packages.sgdev.org/main/x86_64/jaeger-agent-1.45.0-r6.apk",
-        "version": "1.45.0-r6"
+        "url": "https://packages.sgdev.org/main/x86_64/jaeger-agent-1.45.0-r8.apk",
+        "version": "1.45.0-r8"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/jaeger-all-in-one.lock.json
+++ b/wolfi-images/jaeger-all-in-one.lock.json
@@ -204,60 +204,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q13piSoRiT6p5eziGu2iPxSkXxf+g=",
+        "checksum": "Q1+rBEmKEIywe0o/a65ZPjWoUECRQ=",
         "control": {
-          "checksum": "sha1-3piSoRiT6p5eziGu2iPxSkXxf+g=",
-          "range": "bytes=704-1039"
+          "checksum": "sha1-+rBEmKEIywe0o/a65ZPjWoUECRQ=",
+          "range": "bytes=703-1054"
         },
         "data": {
-          "checksum": "sha256-+iLQJV5/mU/hTpwsy9zYBfzVIVkd8lXBBqMScHFhHfI=",
-          "range": "bytes=1040-87982"
+          "checksum": "sha256-fcShKjtj6wR6kgjwToU1J8hU+AGRf1OGZt9jeXJdM0Q=",
+          "range": "bytes=1055-82406"
         },
         "name": "openssl-config",
         "signature": {
-          "checksum": "sha1-fsygjfZl7YLgdpBZ5OVKJG/N2HI=",
-          "range": "bytes=0-703"
+          "checksum": "sha1-RT/o4gi2oC/l+6IhikP9/PH5awg=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/openssl-config-3.2.1-r0.apk",
-        "version": "3.2.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/openssl-config-3.3.0-r5.apk",
+        "version": "3.3.0-r5"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1kERnIFBBwTWZsA+cmGLkIU75THk=",
+        "checksum": "Q11DkfNRzraQMj7ue8LFH6VN6d7Bo=",
         "control": {
-          "checksum": "sha1-kERnIFBBwTWZsA+cmGLkIU75THk=",
-          "range": "bytes=694-1066"
+          "checksum": "sha1-1DkfNRzraQMj7ue8LFH6VN6d7Bo=",
+          "range": "bytes=707-1092"
         },
         "data": {
-          "checksum": "sha256-MB5ZoAsBJ0Osps0a1V0KsM/qQhfZQvYupElgoF1rNLE=",
-          "range": "bytes=1067-5895270"
+          "checksum": "sha256-c95GJNThldUhfxVSGbchUI0pS4j6h45Yx6JDPXHaAI0=",
+          "range": "bytes=1093-5915048"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-vTJq+p2AjVQQjJ4gSkR9ySDQr3k=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-EmjggcTaE4QTKI1FzSom0rXam1c=",
+          "range": "bytes=0-706"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.2.1-r0.apk",
-        "version": "3.2.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r5.apk",
+        "version": "3.3.0-r5"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1RFDJtvcstAQi4NjU00ApvNIvoEI=",
+        "checksum": "Q15sT5bGF6kgE7DepzZIHCpPpuP70=",
         "control": {
-          "checksum": "sha1-RFDJtvcstAQi4NjU00ApvNIvoEI=",
-          "range": "bytes=694-1065"
+          "checksum": "sha1-5sT5bGF6kgE7DepzZIHCpPpuP70=",
+          "range": "bytes=702-1085"
         },
         "data": {
-          "checksum": "sha256-oocCJOj9IF7jv3Ov8bPbaAGfq6oaYXuPNnZW9DnOdnE=",
-          "range": "bytes=1066-1135402"
+          "checksum": "sha256-fWOAfZYgXO6+yM4Dpo/y7dvV3uxSEhhfO4SUX79TQDw=",
+          "range": "bytes=1086-1196497"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-wJVFcqH/ewopq4lxwz8OYrZ9/Ws=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-4+7eITv9weTmoYBAAyd92WsXS24=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.2.1-r0.apk",
-        "version": "3.2.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r5.apk",
+        "version": "3.3.0-r5"
       },
       {
         "architecture": "x86_64",
@@ -337,22 +337,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1txYNrxLRCA8tpCe/aXw9Zeb30xw=",
+        "checksum": "Q1sGD1MEAazAXpfNixX74EpwafGo0=",
         "control": {
-          "checksum": "sha1-txYNrxLRCA8tpCe/aXw9Zeb30xw=",
-          "range": "bytes=703-1071"
+          "checksum": "sha1-sGD1MEAazAXpfNixX74EpwafGo0=",
+          "range": "bytes=698-1059"
         },
         "data": {
-          "checksum": "sha256-QgGnbFCQGaCUjwfFVcF2eOXDjZHaJjntdJlM1thwxd0=",
-          "range": "bytes=1072-252873"
+          "checksum": "sha256-s+9m0l/R7hVKQ5YLbU90D2E6DPC2QVTxdjhToMi5iYU=",
+          "range": "bytes=1060-251831"
         },
         "name": "libnghttp2-14",
         "signature": {
-          "checksum": "sha1-VWNh1CR9wcBEPwOH88Qr6n7OR08=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-wOIYtvU72n76UGvbargK2ccZx0E=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.60.0-r0.apk",
-        "version": "1.60.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.61.0-r0.apk",
+        "version": "1.61.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -432,41 +432,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1YKX8zXXVrSZ1a+od3zegHGvE7K4=",
+        "checksum": "Q1NZCvjmGBZ7soi6T4endRPtDztk4=",
         "control": {
-          "checksum": "sha1-YKX8zXXVrSZ1a+od3zegHGvE7K4=",
-          "range": "bytes=701-1168"
+          "checksum": "sha1-NZCvjmGBZ7soi6T4endRPtDztk4=",
+          "range": "bytes=698-1162"
         },
         "data": {
-          "checksum": "sha256-KnMN4TtaDNZqReNINaTivjzUoQigGvtRZgVEqc1EDHo=",
-          "range": "bytes=1169-2555088"
+          "checksum": "sha256-q79pSkGvnDzz1dHsQceLPqyVC+cFCyWWJB5L2EfkZRc=",
+          "range": "bytes=1163-2556930"
         },
         "name": "nghttp2",
         "signature": {
-          "checksum": "sha1-MWKiH9LAxjnWqAm536DCFrsZXCg=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-UuOeekThV8UC737772jFTRj0Y50=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.60.0-r0.apk",
-        "version": "1.60.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.61.0-r0.apk",
+        "version": "1.61.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1D/+xxUxpR+m3nGP5l/8Ed78nNC0=",
+        "checksum": "Q1O/sL8Kjkxzh39Ffh9gJl+0olkF4=",
         "control": {
-          "checksum": "sha1-D/+xxUxpR+m3nGP5l/8Ed78nNC0=",
-          "range": "bytes=700-1067"
+          "checksum": "sha1-O/sL8Kjkxzh39Ffh9gJl+0olkF4=",
+          "range": "bytes=700-1061"
         },
         "data": {
-          "checksum": "sha256-fKV2YLH6EP/NFtRSErdaCwZX+Mg6KJrfmt1VpRWeKis=",
-          "range": "bytes=1068-634389"
+          "checksum": "sha256-6qS8u1yYrzO+4Ypa+g4zfz3m16/7O/U4wjiRrKl8/vw=",
+          "range": "bytes=1062-631650"
         },
         "name": "nghttp2-dev",
         "signature": {
-          "checksum": "sha1-ZRWYUK14qaTBE3NC7OOWumdkSyY=",
+          "checksum": "sha1-avAz/6snsG86C9jh8Gxa59gs29U=",
           "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.60.0-r0.apk",
-        "version": "1.60.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.61.0-r0.apk",
+        "version": "1.61.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -508,41 +508,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1l9z4OGVfdVISNbyGQdXlz2GPchM=",
+        "checksum": "Q1wJPtj5XZtnPiVWGM5dsT+nyfWXc=",
         "control": {
-          "checksum": "sha1-l9z4OGVfdVISNbyGQdXlz2GPchM=",
-          "range": "bytes=695-1222"
+          "checksum": "sha1-wJPtj5XZtnPiVWGM5dsT+nyfWXc=",
+          "range": "bytes=705-1234"
         },
         "data": {
-          "checksum": "sha256-0Z+mq/0A1P+F5KIZKnsYpg8Eqb3GDRT7VDrZlTEg+4Y=",
-          "range": "bytes=1223-3863194"
+          "checksum": "sha256-sw+CjlpsjO01q6lqzXgHnniiJKn7bqOSNO6vNqdGc7I=",
+          "range": "bytes=1235-3873775"
         },
         "name": "bind-libs",
         "signature": {
-          "checksum": "sha1-YX2+1oZh/hXHVjZriSnJZQzpifg=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-9zDzmHAeu7mWpidXAatqrLZVzUs=",
+          "range": "bytes=0-704"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bind-libs-9.18.25-r0.apk",
-        "version": "9.18.25-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/bind-libs-9.18.26-r0.apk",
+        "version": "9.18.26-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Xb5w/MUeHFBeLgnHBmG7dqAMxzQ=",
+        "checksum": "Q1AxEQdi8fVcYtGc3zHTCW3OZdY2Q=",
         "control": {
-          "checksum": "sha1-Xb5w/MUeHFBeLgnHBmG7dqAMxzQ=",
-          "range": "bytes=705-1217"
+          "checksum": "sha1-AxEQdi8fVcYtGc3zHTCW3OZdY2Q=",
+          "range": "bytes=694-1208"
         },
         "data": {
-          "checksum": "sha256-/0zOh1KQW58NOuJgauDOdqJA4G4g0p6jPUOP45HN/f8=",
-          "range": "bytes=1218-892798"
+          "checksum": "sha256-/dt3qJw5D9iSJ/mKkRQkhWD8R52selhpcwXyw7KLMhg=",
+          "range": "bytes=1209-879444"
         },
         "name": "bind-tools",
         "signature": {
-          "checksum": "sha1-3GgaViNXeX4dd75pxgwR8yYgov0=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-VTb0YdUzPMk8Po0p4nj0y5Jey6k=",
+          "range": "bytes=0-693"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bind-tools-9.18.25-r0.apk",
-        "version": "9.18.25-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/bind-tools-9.18.26-r0.apk",
+        "version": "9.18.26-r0"
       },
       {
         "architecture": "x86_64",
@@ -698,60 +698,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1CC3jnItQWZ4ya5EB/TNDLOICnRc=",
+        "checksum": "Q1hgEBBo1tLreSINI2qiCUpUrIE9k=",
         "control": {
-          "checksum": "sha1-CC3jnItQWZ4ya5EB/TNDLOICnRc=",
-          "range": "bytes=701-1140"
+          "checksum": "sha1-hgEBBo1tLreSINI2qiCUpUrIE9k=",
+          "range": "bytes=700-1139"
         },
         "data": {
-          "checksum": "sha256-2EP9UQKOVph+9hElnh20s8ViX126cAnPyNI+IF2pQ4Y=",
-          "range": "bytes=1141-838149"
+          "checksum": "sha256-OFDWkK8l015fs0YvTCXVKLQmOxq+7W5RgJHIqKYZsTE=",
+          "range": "bytes=1140-808582"
         },
         "name": "libcurl-openssl4",
         "signature": {
-          "checksum": "sha1-IxMuIpRYevSLukva0eWmB5RkhMY=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-sygIdNZXB/W8fyOrdelY5RXh3aA=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.7.1-r0.apk",
-        "version": "8.7.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.6.0-r0.apk",
+        "version": "8.6.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1DzKkXRny9JZJvzjFt3jIuvkDP8E=",
+        "checksum": "Q1eQzLI9XN4FM69fm9B4LWd9frcwM=",
         "control": {
-          "checksum": "sha1-DzKkXRny9JZJvzjFt3jIuvkDP8E=",
-          "range": "bytes=700-1101"
+          "checksum": "sha1-eQzLI9XN4FM69fm9B4LWd9frcwM=",
+          "range": "bytes=703-1098"
         },
         "data": {
-          "checksum": "sha256-l1iebyEPmteOEBcPDwPzstpqs9SMvCn8PqlvRU3O7jk=",
-          "range": "bytes=1102-351141"
+          "checksum": "sha256-zkew7+IbyyyENezhlStwO062zaWd+yP/lpbI+CCJVZQ=",
+          "range": "bytes=1099-281166"
         },
         "name": "curl",
         "signature": {
-          "checksum": "sha1-iVKgcLEjgrpj4c2TrRzHznPaWXA=",
-          "range": "bytes=0-699"
+          "checksum": "sha1-igXspQSxo3Eu3o8DeNrYt3YxSbY=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.7.1-r0.apk",
-        "version": "8.7.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.6.0-r0.apk",
+        "version": "8.6.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1qp7tiYqB6SPWzTktEJFnAGEfnaA=",
+        "checksum": "Q1g2+Zngxp8/xUjBMANozn8Drd5rk=",
         "control": {
-          "checksum": "sha1-qp7tiYqB6SPWzTktEJFnAGEfnaA=",
-          "range": "bytes=660-952"
+          "checksum": "sha1-g2+Zngxp8/xUjBMANozn8Drd5rk=",
+          "range": "bytes=663-957"
         },
         "data": {
-          "checksum": "sha256-hhvZqTCrzhtUHdgFX1hJQ1SOiuwBAc7seccdW/YD1A0=",
-          "range": "bytes=953-54578749"
+          "checksum": "sha256-rsAqdjzl6i8RetpH+ddceYYg6cJvVFhlOrnypRcXM7c=",
+          "range": "bytes=958-54546178"
         },
         "name": "jaeger-all-in-one",
         "signature": {
-          "checksum": "sha1-usH8OeeU2LgTluWLfpmdMEY+fIk=",
-          "range": "bytes=0-659"
+          "checksum": "sha1-BIgU471bpWckjCThz8G1+He2HM0=",
+          "range": "bytes=0-662"
         },
-        "url": "https://packages.sgdev.org/main/x86_64/jaeger-all-in-one-1.45.0-r6.apk",
-        "version": "1.45.0-r6"
+        "url": "https://packages.sgdev.org/main/x86_64/jaeger-all-in-one-1.45.0-r8.apk",
+        "version": "1.45.0-r8"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/node-exporter.lock.json
+++ b/wolfi-images/node-exporter.lock.json
@@ -204,60 +204,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q13piSoRiT6p5eziGu2iPxSkXxf+g=",
+        "checksum": "Q1+rBEmKEIywe0o/a65ZPjWoUECRQ=",
         "control": {
-          "checksum": "sha1-3piSoRiT6p5eziGu2iPxSkXxf+g=",
-          "range": "bytes=704-1039"
+          "checksum": "sha1-+rBEmKEIywe0o/a65ZPjWoUECRQ=",
+          "range": "bytes=703-1054"
         },
         "data": {
-          "checksum": "sha256-+iLQJV5/mU/hTpwsy9zYBfzVIVkd8lXBBqMScHFhHfI=",
-          "range": "bytes=1040-87982"
+          "checksum": "sha256-fcShKjtj6wR6kgjwToU1J8hU+AGRf1OGZt9jeXJdM0Q=",
+          "range": "bytes=1055-82406"
         },
         "name": "openssl-config",
         "signature": {
-          "checksum": "sha1-fsygjfZl7YLgdpBZ5OVKJG/N2HI=",
-          "range": "bytes=0-703"
+          "checksum": "sha1-RT/o4gi2oC/l+6IhikP9/PH5awg=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/openssl-config-3.2.1-r0.apk",
-        "version": "3.2.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/openssl-config-3.3.0-r5.apk",
+        "version": "3.3.0-r5"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1kERnIFBBwTWZsA+cmGLkIU75THk=",
+        "checksum": "Q11DkfNRzraQMj7ue8LFH6VN6d7Bo=",
         "control": {
-          "checksum": "sha1-kERnIFBBwTWZsA+cmGLkIU75THk=",
-          "range": "bytes=694-1066"
+          "checksum": "sha1-1DkfNRzraQMj7ue8LFH6VN6d7Bo=",
+          "range": "bytes=707-1092"
         },
         "data": {
-          "checksum": "sha256-MB5ZoAsBJ0Osps0a1V0KsM/qQhfZQvYupElgoF1rNLE=",
-          "range": "bytes=1067-5895270"
+          "checksum": "sha256-c95GJNThldUhfxVSGbchUI0pS4j6h45Yx6JDPXHaAI0=",
+          "range": "bytes=1093-5915048"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-vTJq+p2AjVQQjJ4gSkR9ySDQr3k=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-EmjggcTaE4QTKI1FzSom0rXam1c=",
+          "range": "bytes=0-706"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.2.1-r0.apk",
-        "version": "3.2.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r5.apk",
+        "version": "3.3.0-r5"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1RFDJtvcstAQi4NjU00ApvNIvoEI=",
+        "checksum": "Q15sT5bGF6kgE7DepzZIHCpPpuP70=",
         "control": {
-          "checksum": "sha1-RFDJtvcstAQi4NjU00ApvNIvoEI=",
-          "range": "bytes=694-1065"
+          "checksum": "sha1-5sT5bGF6kgE7DepzZIHCpPpuP70=",
+          "range": "bytes=702-1085"
         },
         "data": {
-          "checksum": "sha256-oocCJOj9IF7jv3Ov8bPbaAGfq6oaYXuPNnZW9DnOdnE=",
-          "range": "bytes=1066-1135402"
+          "checksum": "sha256-fWOAfZYgXO6+yM4Dpo/y7dvV3uxSEhhfO4SUX79TQDw=",
+          "range": "bytes=1086-1196497"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-wJVFcqH/ewopq4lxwz8OYrZ9/Ws=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-4+7eITv9weTmoYBAAyd92WsXS24=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.2.1-r0.apk",
-        "version": "3.2.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r5.apk",
+        "version": "3.3.0-r5"
       },
       {
         "architecture": "x86_64",
@@ -337,22 +337,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1txYNrxLRCA8tpCe/aXw9Zeb30xw=",
+        "checksum": "Q1sGD1MEAazAXpfNixX74EpwafGo0=",
         "control": {
-          "checksum": "sha1-txYNrxLRCA8tpCe/aXw9Zeb30xw=",
-          "range": "bytes=703-1071"
+          "checksum": "sha1-sGD1MEAazAXpfNixX74EpwafGo0=",
+          "range": "bytes=698-1059"
         },
         "data": {
-          "checksum": "sha256-QgGnbFCQGaCUjwfFVcF2eOXDjZHaJjntdJlM1thwxd0=",
-          "range": "bytes=1072-252873"
+          "checksum": "sha256-s+9m0l/R7hVKQ5YLbU90D2E6DPC2QVTxdjhToMi5iYU=",
+          "range": "bytes=1060-251831"
         },
         "name": "libnghttp2-14",
         "signature": {
-          "checksum": "sha1-VWNh1CR9wcBEPwOH88Qr6n7OR08=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-wOIYtvU72n76UGvbargK2ccZx0E=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.60.0-r0.apk",
-        "version": "1.60.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.61.0-r0.apk",
+        "version": "1.61.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -432,41 +432,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1YKX8zXXVrSZ1a+od3zegHGvE7K4=",
+        "checksum": "Q1NZCvjmGBZ7soi6T4endRPtDztk4=",
         "control": {
-          "checksum": "sha1-YKX8zXXVrSZ1a+od3zegHGvE7K4=",
-          "range": "bytes=701-1168"
+          "checksum": "sha1-NZCvjmGBZ7soi6T4endRPtDztk4=",
+          "range": "bytes=698-1162"
         },
         "data": {
-          "checksum": "sha256-KnMN4TtaDNZqReNINaTivjzUoQigGvtRZgVEqc1EDHo=",
-          "range": "bytes=1169-2555088"
+          "checksum": "sha256-q79pSkGvnDzz1dHsQceLPqyVC+cFCyWWJB5L2EfkZRc=",
+          "range": "bytes=1163-2556930"
         },
         "name": "nghttp2",
         "signature": {
-          "checksum": "sha1-MWKiH9LAxjnWqAm536DCFrsZXCg=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-UuOeekThV8UC737772jFTRj0Y50=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.60.0-r0.apk",
-        "version": "1.60.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.61.0-r0.apk",
+        "version": "1.61.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1D/+xxUxpR+m3nGP5l/8Ed78nNC0=",
+        "checksum": "Q1O/sL8Kjkxzh39Ffh9gJl+0olkF4=",
         "control": {
-          "checksum": "sha1-D/+xxUxpR+m3nGP5l/8Ed78nNC0=",
-          "range": "bytes=700-1067"
+          "checksum": "sha1-O/sL8Kjkxzh39Ffh9gJl+0olkF4=",
+          "range": "bytes=700-1061"
         },
         "data": {
-          "checksum": "sha256-fKV2YLH6EP/NFtRSErdaCwZX+Mg6KJrfmt1VpRWeKis=",
-          "range": "bytes=1068-634389"
+          "checksum": "sha256-6qS8u1yYrzO+4Ypa+g4zfz3m16/7O/U4wjiRrKl8/vw=",
+          "range": "bytes=1062-631650"
         },
         "name": "nghttp2-dev",
         "signature": {
-          "checksum": "sha1-ZRWYUK14qaTBE3NC7OOWumdkSyY=",
+          "checksum": "sha1-avAz/6snsG86C9jh8Gxa59gs29U=",
           "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.60.0-r0.apk",
-        "version": "1.60.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.61.0-r0.apk",
+        "version": "1.61.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -508,41 +508,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1l9z4OGVfdVISNbyGQdXlz2GPchM=",
+        "checksum": "Q1wJPtj5XZtnPiVWGM5dsT+nyfWXc=",
         "control": {
-          "checksum": "sha1-l9z4OGVfdVISNbyGQdXlz2GPchM=",
-          "range": "bytes=695-1222"
+          "checksum": "sha1-wJPtj5XZtnPiVWGM5dsT+nyfWXc=",
+          "range": "bytes=705-1234"
         },
         "data": {
-          "checksum": "sha256-0Z+mq/0A1P+F5KIZKnsYpg8Eqb3GDRT7VDrZlTEg+4Y=",
-          "range": "bytes=1223-3863194"
+          "checksum": "sha256-sw+CjlpsjO01q6lqzXgHnniiJKn7bqOSNO6vNqdGc7I=",
+          "range": "bytes=1235-3873775"
         },
         "name": "bind-libs",
         "signature": {
-          "checksum": "sha1-YX2+1oZh/hXHVjZriSnJZQzpifg=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-9zDzmHAeu7mWpidXAatqrLZVzUs=",
+          "range": "bytes=0-704"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bind-libs-9.18.25-r0.apk",
-        "version": "9.18.25-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/bind-libs-9.18.26-r0.apk",
+        "version": "9.18.26-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Xb5w/MUeHFBeLgnHBmG7dqAMxzQ=",
+        "checksum": "Q1AxEQdi8fVcYtGc3zHTCW3OZdY2Q=",
         "control": {
-          "checksum": "sha1-Xb5w/MUeHFBeLgnHBmG7dqAMxzQ=",
-          "range": "bytes=705-1217"
+          "checksum": "sha1-AxEQdi8fVcYtGc3zHTCW3OZdY2Q=",
+          "range": "bytes=694-1208"
         },
         "data": {
-          "checksum": "sha256-/0zOh1KQW58NOuJgauDOdqJA4G4g0p6jPUOP45HN/f8=",
-          "range": "bytes=1218-892798"
+          "checksum": "sha256-/dt3qJw5D9iSJ/mKkRQkhWD8R52selhpcwXyw7KLMhg=",
+          "range": "bytes=1209-879444"
         },
         "name": "bind-tools",
         "signature": {
-          "checksum": "sha1-3GgaViNXeX4dd75pxgwR8yYgov0=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-VTb0YdUzPMk8Po0p4nj0y5Jey6k=",
+          "range": "bytes=0-693"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bind-tools-9.18.25-r0.apk",
-        "version": "9.18.25-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/bind-tools-9.18.26-r0.apk",
+        "version": "9.18.26-r0"
       },
       {
         "architecture": "x86_64",
@@ -698,41 +698,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1CC3jnItQWZ4ya5EB/TNDLOICnRc=",
+        "checksum": "Q1hgEBBo1tLreSINI2qiCUpUrIE9k=",
         "control": {
-          "checksum": "sha1-CC3jnItQWZ4ya5EB/TNDLOICnRc=",
-          "range": "bytes=701-1140"
+          "checksum": "sha1-hgEBBo1tLreSINI2qiCUpUrIE9k=",
+          "range": "bytes=700-1139"
         },
         "data": {
-          "checksum": "sha256-2EP9UQKOVph+9hElnh20s8ViX126cAnPyNI+IF2pQ4Y=",
-          "range": "bytes=1141-838149"
+          "checksum": "sha256-OFDWkK8l015fs0YvTCXVKLQmOxq+7W5RgJHIqKYZsTE=",
+          "range": "bytes=1140-808582"
         },
         "name": "libcurl-openssl4",
         "signature": {
-          "checksum": "sha1-IxMuIpRYevSLukva0eWmB5RkhMY=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-sygIdNZXB/W8fyOrdelY5RXh3aA=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.7.1-r0.apk",
-        "version": "8.7.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.6.0-r0.apk",
+        "version": "8.6.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1DzKkXRny9JZJvzjFt3jIuvkDP8E=",
+        "checksum": "Q1eQzLI9XN4FM69fm9B4LWd9frcwM=",
         "control": {
-          "checksum": "sha1-DzKkXRny9JZJvzjFt3jIuvkDP8E=",
-          "range": "bytes=700-1101"
+          "checksum": "sha1-eQzLI9XN4FM69fm9B4LWd9frcwM=",
+          "range": "bytes=703-1098"
         },
         "data": {
-          "checksum": "sha256-l1iebyEPmteOEBcPDwPzstpqs9SMvCn8PqlvRU3O7jk=",
-          "range": "bytes=1102-351141"
+          "checksum": "sha256-zkew7+IbyyyENezhlStwO062zaWd+yP/lpbI+CCJVZQ=",
+          "range": "bytes=1099-281166"
         },
         "name": "curl",
         "signature": {
-          "checksum": "sha1-iVKgcLEjgrpj4c2TrRzHznPaWXA=",
-          "range": "bytes=0-699"
+          "checksum": "sha1-igXspQSxo3Eu3o8DeNrYt3YxSbY=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.7.1-r0.apk",
-        "version": "8.7.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.6.0-r0.apk",
+        "version": "8.6.0-r0"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/opentelemetry-collector.lock.json
+++ b/wolfi-images/opentelemetry-collector.lock.json
@@ -204,60 +204,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q13piSoRiT6p5eziGu2iPxSkXxf+g=",
+        "checksum": "Q1+rBEmKEIywe0o/a65ZPjWoUECRQ=",
         "control": {
-          "checksum": "sha1-3piSoRiT6p5eziGu2iPxSkXxf+g=",
-          "range": "bytes=704-1039"
+          "checksum": "sha1-+rBEmKEIywe0o/a65ZPjWoUECRQ=",
+          "range": "bytes=703-1054"
         },
         "data": {
-          "checksum": "sha256-+iLQJV5/mU/hTpwsy9zYBfzVIVkd8lXBBqMScHFhHfI=",
-          "range": "bytes=1040-87982"
+          "checksum": "sha256-fcShKjtj6wR6kgjwToU1J8hU+AGRf1OGZt9jeXJdM0Q=",
+          "range": "bytes=1055-82406"
         },
         "name": "openssl-config",
         "signature": {
-          "checksum": "sha1-fsygjfZl7YLgdpBZ5OVKJG/N2HI=",
-          "range": "bytes=0-703"
+          "checksum": "sha1-RT/o4gi2oC/l+6IhikP9/PH5awg=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/openssl-config-3.2.1-r0.apk",
-        "version": "3.2.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/openssl-config-3.3.0-r5.apk",
+        "version": "3.3.0-r5"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1kERnIFBBwTWZsA+cmGLkIU75THk=",
+        "checksum": "Q11DkfNRzraQMj7ue8LFH6VN6d7Bo=",
         "control": {
-          "checksum": "sha1-kERnIFBBwTWZsA+cmGLkIU75THk=",
-          "range": "bytes=694-1066"
+          "checksum": "sha1-1DkfNRzraQMj7ue8LFH6VN6d7Bo=",
+          "range": "bytes=707-1092"
         },
         "data": {
-          "checksum": "sha256-MB5ZoAsBJ0Osps0a1V0KsM/qQhfZQvYupElgoF1rNLE=",
-          "range": "bytes=1067-5895270"
+          "checksum": "sha256-c95GJNThldUhfxVSGbchUI0pS4j6h45Yx6JDPXHaAI0=",
+          "range": "bytes=1093-5915048"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-vTJq+p2AjVQQjJ4gSkR9ySDQr3k=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-EmjggcTaE4QTKI1FzSom0rXam1c=",
+          "range": "bytes=0-706"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.2.1-r0.apk",
-        "version": "3.2.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r5.apk",
+        "version": "3.3.0-r5"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1RFDJtvcstAQi4NjU00ApvNIvoEI=",
+        "checksum": "Q15sT5bGF6kgE7DepzZIHCpPpuP70=",
         "control": {
-          "checksum": "sha1-RFDJtvcstAQi4NjU00ApvNIvoEI=",
-          "range": "bytes=694-1065"
+          "checksum": "sha1-5sT5bGF6kgE7DepzZIHCpPpuP70=",
+          "range": "bytes=702-1085"
         },
         "data": {
-          "checksum": "sha256-oocCJOj9IF7jv3Ov8bPbaAGfq6oaYXuPNnZW9DnOdnE=",
-          "range": "bytes=1066-1135402"
+          "checksum": "sha256-fWOAfZYgXO6+yM4Dpo/y7dvV3uxSEhhfO4SUX79TQDw=",
+          "range": "bytes=1086-1196497"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-wJVFcqH/ewopq4lxwz8OYrZ9/Ws=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-4+7eITv9weTmoYBAAyd92WsXS24=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.2.1-r0.apk",
-        "version": "3.2.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r5.apk",
+        "version": "3.3.0-r5"
       },
       {
         "architecture": "x86_64",
@@ -337,22 +337,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1txYNrxLRCA8tpCe/aXw9Zeb30xw=",
+        "checksum": "Q1sGD1MEAazAXpfNixX74EpwafGo0=",
         "control": {
-          "checksum": "sha1-txYNrxLRCA8tpCe/aXw9Zeb30xw=",
-          "range": "bytes=703-1071"
+          "checksum": "sha1-sGD1MEAazAXpfNixX74EpwafGo0=",
+          "range": "bytes=698-1059"
         },
         "data": {
-          "checksum": "sha256-QgGnbFCQGaCUjwfFVcF2eOXDjZHaJjntdJlM1thwxd0=",
-          "range": "bytes=1072-252873"
+          "checksum": "sha256-s+9m0l/R7hVKQ5YLbU90D2E6DPC2QVTxdjhToMi5iYU=",
+          "range": "bytes=1060-251831"
         },
         "name": "libnghttp2-14",
         "signature": {
-          "checksum": "sha1-VWNh1CR9wcBEPwOH88Qr6n7OR08=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-wOIYtvU72n76UGvbargK2ccZx0E=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.60.0-r0.apk",
-        "version": "1.60.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.61.0-r0.apk",
+        "version": "1.61.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -432,41 +432,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1YKX8zXXVrSZ1a+od3zegHGvE7K4=",
+        "checksum": "Q1NZCvjmGBZ7soi6T4endRPtDztk4=",
         "control": {
-          "checksum": "sha1-YKX8zXXVrSZ1a+od3zegHGvE7K4=",
-          "range": "bytes=701-1168"
+          "checksum": "sha1-NZCvjmGBZ7soi6T4endRPtDztk4=",
+          "range": "bytes=698-1162"
         },
         "data": {
-          "checksum": "sha256-KnMN4TtaDNZqReNINaTivjzUoQigGvtRZgVEqc1EDHo=",
-          "range": "bytes=1169-2555088"
+          "checksum": "sha256-q79pSkGvnDzz1dHsQceLPqyVC+cFCyWWJB5L2EfkZRc=",
+          "range": "bytes=1163-2556930"
         },
         "name": "nghttp2",
         "signature": {
-          "checksum": "sha1-MWKiH9LAxjnWqAm536DCFrsZXCg=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-UuOeekThV8UC737772jFTRj0Y50=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.60.0-r0.apk",
-        "version": "1.60.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.61.0-r0.apk",
+        "version": "1.61.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1D/+xxUxpR+m3nGP5l/8Ed78nNC0=",
+        "checksum": "Q1O/sL8Kjkxzh39Ffh9gJl+0olkF4=",
         "control": {
-          "checksum": "sha1-D/+xxUxpR+m3nGP5l/8Ed78nNC0=",
-          "range": "bytes=700-1067"
+          "checksum": "sha1-O/sL8Kjkxzh39Ffh9gJl+0olkF4=",
+          "range": "bytes=700-1061"
         },
         "data": {
-          "checksum": "sha256-fKV2YLH6EP/NFtRSErdaCwZX+Mg6KJrfmt1VpRWeKis=",
-          "range": "bytes=1068-634389"
+          "checksum": "sha256-6qS8u1yYrzO+4Ypa+g4zfz3m16/7O/U4wjiRrKl8/vw=",
+          "range": "bytes=1062-631650"
         },
         "name": "nghttp2-dev",
         "signature": {
-          "checksum": "sha1-ZRWYUK14qaTBE3NC7OOWumdkSyY=",
+          "checksum": "sha1-avAz/6snsG86C9jh8Gxa59gs29U=",
           "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.60.0-r0.apk",
-        "version": "1.60.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.61.0-r0.apk",
+        "version": "1.61.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -508,41 +508,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1l9z4OGVfdVISNbyGQdXlz2GPchM=",
+        "checksum": "Q1wJPtj5XZtnPiVWGM5dsT+nyfWXc=",
         "control": {
-          "checksum": "sha1-l9z4OGVfdVISNbyGQdXlz2GPchM=",
-          "range": "bytes=695-1222"
+          "checksum": "sha1-wJPtj5XZtnPiVWGM5dsT+nyfWXc=",
+          "range": "bytes=705-1234"
         },
         "data": {
-          "checksum": "sha256-0Z+mq/0A1P+F5KIZKnsYpg8Eqb3GDRT7VDrZlTEg+4Y=",
-          "range": "bytes=1223-3863194"
+          "checksum": "sha256-sw+CjlpsjO01q6lqzXgHnniiJKn7bqOSNO6vNqdGc7I=",
+          "range": "bytes=1235-3873775"
         },
         "name": "bind-libs",
         "signature": {
-          "checksum": "sha1-YX2+1oZh/hXHVjZriSnJZQzpifg=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-9zDzmHAeu7mWpidXAatqrLZVzUs=",
+          "range": "bytes=0-704"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bind-libs-9.18.25-r0.apk",
-        "version": "9.18.25-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/bind-libs-9.18.26-r0.apk",
+        "version": "9.18.26-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Xb5w/MUeHFBeLgnHBmG7dqAMxzQ=",
+        "checksum": "Q1AxEQdi8fVcYtGc3zHTCW3OZdY2Q=",
         "control": {
-          "checksum": "sha1-Xb5w/MUeHFBeLgnHBmG7dqAMxzQ=",
-          "range": "bytes=705-1217"
+          "checksum": "sha1-AxEQdi8fVcYtGc3zHTCW3OZdY2Q=",
+          "range": "bytes=694-1208"
         },
         "data": {
-          "checksum": "sha256-/0zOh1KQW58NOuJgauDOdqJA4G4g0p6jPUOP45HN/f8=",
-          "range": "bytes=1218-892798"
+          "checksum": "sha256-/dt3qJw5D9iSJ/mKkRQkhWD8R52selhpcwXyw7KLMhg=",
+          "range": "bytes=1209-879444"
         },
         "name": "bind-tools",
         "signature": {
-          "checksum": "sha1-3GgaViNXeX4dd75pxgwR8yYgov0=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-VTb0YdUzPMk8Po0p4nj0y5Jey6k=",
+          "range": "bytes=0-693"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bind-tools-9.18.25-r0.apk",
-        "version": "9.18.25-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/bind-tools-9.18.26-r0.apk",
+        "version": "9.18.26-r0"
       },
       {
         "architecture": "x86_64",
@@ -698,41 +698,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1CC3jnItQWZ4ya5EB/TNDLOICnRc=",
+        "checksum": "Q1hgEBBo1tLreSINI2qiCUpUrIE9k=",
         "control": {
-          "checksum": "sha1-CC3jnItQWZ4ya5EB/TNDLOICnRc=",
-          "range": "bytes=701-1140"
+          "checksum": "sha1-hgEBBo1tLreSINI2qiCUpUrIE9k=",
+          "range": "bytes=700-1139"
         },
         "data": {
-          "checksum": "sha256-2EP9UQKOVph+9hElnh20s8ViX126cAnPyNI+IF2pQ4Y=",
-          "range": "bytes=1141-838149"
+          "checksum": "sha256-OFDWkK8l015fs0YvTCXVKLQmOxq+7W5RgJHIqKYZsTE=",
+          "range": "bytes=1140-808582"
         },
         "name": "libcurl-openssl4",
         "signature": {
-          "checksum": "sha1-IxMuIpRYevSLukva0eWmB5RkhMY=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-sygIdNZXB/W8fyOrdelY5RXh3aA=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.7.1-r0.apk",
-        "version": "8.7.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.6.0-r0.apk",
+        "version": "8.6.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1DzKkXRny9JZJvzjFt3jIuvkDP8E=",
+        "checksum": "Q1eQzLI9XN4FM69fm9B4LWd9frcwM=",
         "control": {
-          "checksum": "sha1-DzKkXRny9JZJvzjFt3jIuvkDP8E=",
-          "range": "bytes=700-1101"
+          "checksum": "sha1-eQzLI9XN4FM69fm9B4LWd9frcwM=",
+          "range": "bytes=703-1098"
         },
         "data": {
-          "checksum": "sha256-l1iebyEPmteOEBcPDwPzstpqs9SMvCn8PqlvRU3O7jk=",
-          "range": "bytes=1102-351141"
+          "checksum": "sha256-zkew7+IbyyyENezhlStwO062zaWd+yP/lpbI+CCJVZQ=",
+          "range": "bytes=1099-281166"
         },
         "name": "curl",
         "signature": {
-          "checksum": "sha1-iVKgcLEjgrpj4c2TrRzHznPaWXA=",
-          "range": "bytes=0-699"
+          "checksum": "sha1-igXspQSxo3Eu3o8DeNrYt3YxSbY=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.7.1-r0.apk",
-        "version": "8.7.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.6.0-r0.apk",
+        "version": "8.6.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -755,22 +755,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q15QqBPtaweR5J4BdwDGPX/8RMB/c=",
+        "checksum": "Q1rbqSkkmmv1u0qIlXaMJlECAL++8=",
         "control": {
-          "checksum": "sha1-5QqBPtaweR5J4BdwDGPX/8RMB/c=",
-          "range": "bytes=660-1055"
+          "checksum": "sha1-rbqSkkmmv1u0qIlXaMJlECAL++8=",
+          "range": "bytes=662-1056"
         },
         "data": {
-          "checksum": "sha256-NOl2jSuCf2PMpuXZAxHLqjb6MfTThv3mr0sjaTbUTt4=",
-          "range": "bytes=1056-101706215"
+          "checksum": "sha256-JExtSd5jJ++EltuXBoPUSVrpPHvTzLW0EDtiqQSCU8c=",
+          "range": "bytes=1057-102062736"
         },
         "name": "opentelemetry-collector",
         "signature": {
-          "checksum": "sha1-Xe1kI+sv8p+m0ZIMkiQFbxHfrfI=",
-          "range": "bytes=0-659"
+          "checksum": "sha1-JHLXe7uu3KaUeeqxCaRx8ob8Zgk=",
+          "range": "bytes=0-661"
         },
-        "url": "https://packages.sgdev.org/main/x86_64/opentelemetry-collector-0.92.0-r5.apk",
-        "version": "0.92.0-r5"
+        "url": "https://packages.sgdev.org/main/x86_64/opentelemetry-collector-0.92.0-r7.apk",
+        "version": "0.92.0-r7"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/postgres-exporter.lock.json
+++ b/wolfi-images/postgres-exporter.lock.json
@@ -204,60 +204,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q13piSoRiT6p5eziGu2iPxSkXxf+g=",
+        "checksum": "Q1+rBEmKEIywe0o/a65ZPjWoUECRQ=",
         "control": {
-          "checksum": "sha1-3piSoRiT6p5eziGu2iPxSkXxf+g=",
-          "range": "bytes=704-1039"
+          "checksum": "sha1-+rBEmKEIywe0o/a65ZPjWoUECRQ=",
+          "range": "bytes=703-1054"
         },
         "data": {
-          "checksum": "sha256-+iLQJV5/mU/hTpwsy9zYBfzVIVkd8lXBBqMScHFhHfI=",
-          "range": "bytes=1040-87982"
+          "checksum": "sha256-fcShKjtj6wR6kgjwToU1J8hU+AGRf1OGZt9jeXJdM0Q=",
+          "range": "bytes=1055-82406"
         },
         "name": "openssl-config",
         "signature": {
-          "checksum": "sha1-fsygjfZl7YLgdpBZ5OVKJG/N2HI=",
-          "range": "bytes=0-703"
+          "checksum": "sha1-RT/o4gi2oC/l+6IhikP9/PH5awg=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/openssl-config-3.2.1-r0.apk",
-        "version": "3.2.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/openssl-config-3.3.0-r5.apk",
+        "version": "3.3.0-r5"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1kERnIFBBwTWZsA+cmGLkIU75THk=",
+        "checksum": "Q11DkfNRzraQMj7ue8LFH6VN6d7Bo=",
         "control": {
-          "checksum": "sha1-kERnIFBBwTWZsA+cmGLkIU75THk=",
-          "range": "bytes=694-1066"
+          "checksum": "sha1-1DkfNRzraQMj7ue8LFH6VN6d7Bo=",
+          "range": "bytes=707-1092"
         },
         "data": {
-          "checksum": "sha256-MB5ZoAsBJ0Osps0a1V0KsM/qQhfZQvYupElgoF1rNLE=",
-          "range": "bytes=1067-5895270"
+          "checksum": "sha256-c95GJNThldUhfxVSGbchUI0pS4j6h45Yx6JDPXHaAI0=",
+          "range": "bytes=1093-5915048"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-vTJq+p2AjVQQjJ4gSkR9ySDQr3k=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-EmjggcTaE4QTKI1FzSom0rXam1c=",
+          "range": "bytes=0-706"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.2.1-r0.apk",
-        "version": "3.2.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r5.apk",
+        "version": "3.3.0-r5"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1RFDJtvcstAQi4NjU00ApvNIvoEI=",
+        "checksum": "Q15sT5bGF6kgE7DepzZIHCpPpuP70=",
         "control": {
-          "checksum": "sha1-RFDJtvcstAQi4NjU00ApvNIvoEI=",
-          "range": "bytes=694-1065"
+          "checksum": "sha1-5sT5bGF6kgE7DepzZIHCpPpuP70=",
+          "range": "bytes=702-1085"
         },
         "data": {
-          "checksum": "sha256-oocCJOj9IF7jv3Ov8bPbaAGfq6oaYXuPNnZW9DnOdnE=",
-          "range": "bytes=1066-1135402"
+          "checksum": "sha256-fWOAfZYgXO6+yM4Dpo/y7dvV3uxSEhhfO4SUX79TQDw=",
+          "range": "bytes=1086-1196497"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-wJVFcqH/ewopq4lxwz8OYrZ9/Ws=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-4+7eITv9weTmoYBAAyd92WsXS24=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.2.1-r0.apk",
-        "version": "3.2.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r5.apk",
+        "version": "3.3.0-r5"
       },
       {
         "architecture": "x86_64",
@@ -337,22 +337,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1txYNrxLRCA8tpCe/aXw9Zeb30xw=",
+        "checksum": "Q1sGD1MEAazAXpfNixX74EpwafGo0=",
         "control": {
-          "checksum": "sha1-txYNrxLRCA8tpCe/aXw9Zeb30xw=",
-          "range": "bytes=703-1071"
+          "checksum": "sha1-sGD1MEAazAXpfNixX74EpwafGo0=",
+          "range": "bytes=698-1059"
         },
         "data": {
-          "checksum": "sha256-QgGnbFCQGaCUjwfFVcF2eOXDjZHaJjntdJlM1thwxd0=",
-          "range": "bytes=1072-252873"
+          "checksum": "sha256-s+9m0l/R7hVKQ5YLbU90D2E6DPC2QVTxdjhToMi5iYU=",
+          "range": "bytes=1060-251831"
         },
         "name": "libnghttp2-14",
         "signature": {
-          "checksum": "sha1-VWNh1CR9wcBEPwOH88Qr6n7OR08=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-wOIYtvU72n76UGvbargK2ccZx0E=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.60.0-r0.apk",
-        "version": "1.60.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.61.0-r0.apk",
+        "version": "1.61.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -432,41 +432,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1YKX8zXXVrSZ1a+od3zegHGvE7K4=",
+        "checksum": "Q1NZCvjmGBZ7soi6T4endRPtDztk4=",
         "control": {
-          "checksum": "sha1-YKX8zXXVrSZ1a+od3zegHGvE7K4=",
-          "range": "bytes=701-1168"
+          "checksum": "sha1-NZCvjmGBZ7soi6T4endRPtDztk4=",
+          "range": "bytes=698-1162"
         },
         "data": {
-          "checksum": "sha256-KnMN4TtaDNZqReNINaTivjzUoQigGvtRZgVEqc1EDHo=",
-          "range": "bytes=1169-2555088"
+          "checksum": "sha256-q79pSkGvnDzz1dHsQceLPqyVC+cFCyWWJB5L2EfkZRc=",
+          "range": "bytes=1163-2556930"
         },
         "name": "nghttp2",
         "signature": {
-          "checksum": "sha1-MWKiH9LAxjnWqAm536DCFrsZXCg=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-UuOeekThV8UC737772jFTRj0Y50=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.60.0-r0.apk",
-        "version": "1.60.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.61.0-r0.apk",
+        "version": "1.61.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1D/+xxUxpR+m3nGP5l/8Ed78nNC0=",
+        "checksum": "Q1O/sL8Kjkxzh39Ffh9gJl+0olkF4=",
         "control": {
-          "checksum": "sha1-D/+xxUxpR+m3nGP5l/8Ed78nNC0=",
-          "range": "bytes=700-1067"
+          "checksum": "sha1-O/sL8Kjkxzh39Ffh9gJl+0olkF4=",
+          "range": "bytes=700-1061"
         },
         "data": {
-          "checksum": "sha256-fKV2YLH6EP/NFtRSErdaCwZX+Mg6KJrfmt1VpRWeKis=",
-          "range": "bytes=1068-634389"
+          "checksum": "sha256-6qS8u1yYrzO+4Ypa+g4zfz3m16/7O/U4wjiRrKl8/vw=",
+          "range": "bytes=1062-631650"
         },
         "name": "nghttp2-dev",
         "signature": {
-          "checksum": "sha1-ZRWYUK14qaTBE3NC7OOWumdkSyY=",
+          "checksum": "sha1-avAz/6snsG86C9jh8Gxa59gs29U=",
           "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.60.0-r0.apk",
-        "version": "1.60.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.61.0-r0.apk",
+        "version": "1.61.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -508,41 +508,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1l9z4OGVfdVISNbyGQdXlz2GPchM=",
+        "checksum": "Q1wJPtj5XZtnPiVWGM5dsT+nyfWXc=",
         "control": {
-          "checksum": "sha1-l9z4OGVfdVISNbyGQdXlz2GPchM=",
-          "range": "bytes=695-1222"
+          "checksum": "sha1-wJPtj5XZtnPiVWGM5dsT+nyfWXc=",
+          "range": "bytes=705-1234"
         },
         "data": {
-          "checksum": "sha256-0Z+mq/0A1P+F5KIZKnsYpg8Eqb3GDRT7VDrZlTEg+4Y=",
-          "range": "bytes=1223-3863194"
+          "checksum": "sha256-sw+CjlpsjO01q6lqzXgHnniiJKn7bqOSNO6vNqdGc7I=",
+          "range": "bytes=1235-3873775"
         },
         "name": "bind-libs",
         "signature": {
-          "checksum": "sha1-YX2+1oZh/hXHVjZriSnJZQzpifg=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-9zDzmHAeu7mWpidXAatqrLZVzUs=",
+          "range": "bytes=0-704"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bind-libs-9.18.25-r0.apk",
-        "version": "9.18.25-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/bind-libs-9.18.26-r0.apk",
+        "version": "9.18.26-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Xb5w/MUeHFBeLgnHBmG7dqAMxzQ=",
+        "checksum": "Q1AxEQdi8fVcYtGc3zHTCW3OZdY2Q=",
         "control": {
-          "checksum": "sha1-Xb5w/MUeHFBeLgnHBmG7dqAMxzQ=",
-          "range": "bytes=705-1217"
+          "checksum": "sha1-AxEQdi8fVcYtGc3zHTCW3OZdY2Q=",
+          "range": "bytes=694-1208"
         },
         "data": {
-          "checksum": "sha256-/0zOh1KQW58NOuJgauDOdqJA4G4g0p6jPUOP45HN/f8=",
-          "range": "bytes=1218-892798"
+          "checksum": "sha256-/dt3qJw5D9iSJ/mKkRQkhWD8R52selhpcwXyw7KLMhg=",
+          "range": "bytes=1209-879444"
         },
         "name": "bind-tools",
         "signature": {
-          "checksum": "sha1-3GgaViNXeX4dd75pxgwR8yYgov0=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-VTb0YdUzPMk8Po0p4nj0y5Jey6k=",
+          "range": "bytes=0-693"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bind-tools-9.18.25-r0.apk",
-        "version": "9.18.25-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/bind-tools-9.18.26-r0.apk",
+        "version": "9.18.26-r0"
       },
       {
         "architecture": "x86_64",
@@ -698,41 +698,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1CC3jnItQWZ4ya5EB/TNDLOICnRc=",
+        "checksum": "Q1hgEBBo1tLreSINI2qiCUpUrIE9k=",
         "control": {
-          "checksum": "sha1-CC3jnItQWZ4ya5EB/TNDLOICnRc=",
-          "range": "bytes=701-1140"
+          "checksum": "sha1-hgEBBo1tLreSINI2qiCUpUrIE9k=",
+          "range": "bytes=700-1139"
         },
         "data": {
-          "checksum": "sha256-2EP9UQKOVph+9hElnh20s8ViX126cAnPyNI+IF2pQ4Y=",
-          "range": "bytes=1141-838149"
+          "checksum": "sha256-OFDWkK8l015fs0YvTCXVKLQmOxq+7W5RgJHIqKYZsTE=",
+          "range": "bytes=1140-808582"
         },
         "name": "libcurl-openssl4",
         "signature": {
-          "checksum": "sha1-IxMuIpRYevSLukva0eWmB5RkhMY=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-sygIdNZXB/W8fyOrdelY5RXh3aA=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.7.1-r0.apk",
-        "version": "8.7.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.6.0-r0.apk",
+        "version": "8.6.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1DzKkXRny9JZJvzjFt3jIuvkDP8E=",
+        "checksum": "Q1eQzLI9XN4FM69fm9B4LWd9frcwM=",
         "control": {
-          "checksum": "sha1-DzKkXRny9JZJvzjFt3jIuvkDP8E=",
-          "range": "bytes=700-1101"
+          "checksum": "sha1-eQzLI9XN4FM69fm9B4LWd9frcwM=",
+          "range": "bytes=703-1098"
         },
         "data": {
-          "checksum": "sha256-l1iebyEPmteOEBcPDwPzstpqs9SMvCn8PqlvRU3O7jk=",
-          "range": "bytes=1102-351141"
+          "checksum": "sha256-zkew7+IbyyyENezhlStwO062zaWd+yP/lpbI+CCJVZQ=",
+          "range": "bytes=1099-281166"
         },
         "name": "curl",
         "signature": {
-          "checksum": "sha1-iVKgcLEjgrpj4c2TrRzHznPaWXA=",
-          "range": "bytes=0-699"
+          "checksum": "sha1-igXspQSxo3Eu3o8DeNrYt3YxSbY=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.7.1-r0.apk",
-        "version": "8.7.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.6.0-r0.apk",
+        "version": "8.6.0-r0"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/postgresql-12-codeinsights.lock.json
+++ b/wolfi-images/postgresql-12-codeinsights.lock.json
@@ -204,60 +204,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q13piSoRiT6p5eziGu2iPxSkXxf+g=",
+        "checksum": "Q1+rBEmKEIywe0o/a65ZPjWoUECRQ=",
         "control": {
-          "checksum": "sha1-3piSoRiT6p5eziGu2iPxSkXxf+g=",
-          "range": "bytes=704-1039"
+          "checksum": "sha1-+rBEmKEIywe0o/a65ZPjWoUECRQ=",
+          "range": "bytes=703-1054"
         },
         "data": {
-          "checksum": "sha256-+iLQJV5/mU/hTpwsy9zYBfzVIVkd8lXBBqMScHFhHfI=",
-          "range": "bytes=1040-87982"
+          "checksum": "sha256-fcShKjtj6wR6kgjwToU1J8hU+AGRf1OGZt9jeXJdM0Q=",
+          "range": "bytes=1055-82406"
         },
         "name": "openssl-config",
         "signature": {
-          "checksum": "sha1-fsygjfZl7YLgdpBZ5OVKJG/N2HI=",
-          "range": "bytes=0-703"
+          "checksum": "sha1-RT/o4gi2oC/l+6IhikP9/PH5awg=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/openssl-config-3.2.1-r0.apk",
-        "version": "3.2.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/openssl-config-3.3.0-r5.apk",
+        "version": "3.3.0-r5"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1kERnIFBBwTWZsA+cmGLkIU75THk=",
+        "checksum": "Q11DkfNRzraQMj7ue8LFH6VN6d7Bo=",
         "control": {
-          "checksum": "sha1-kERnIFBBwTWZsA+cmGLkIU75THk=",
-          "range": "bytes=694-1066"
+          "checksum": "sha1-1DkfNRzraQMj7ue8LFH6VN6d7Bo=",
+          "range": "bytes=707-1092"
         },
         "data": {
-          "checksum": "sha256-MB5ZoAsBJ0Osps0a1V0KsM/qQhfZQvYupElgoF1rNLE=",
-          "range": "bytes=1067-5895270"
+          "checksum": "sha256-c95GJNThldUhfxVSGbchUI0pS4j6h45Yx6JDPXHaAI0=",
+          "range": "bytes=1093-5915048"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-vTJq+p2AjVQQjJ4gSkR9ySDQr3k=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-EmjggcTaE4QTKI1FzSom0rXam1c=",
+          "range": "bytes=0-706"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.2.1-r0.apk",
-        "version": "3.2.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r5.apk",
+        "version": "3.3.0-r5"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1RFDJtvcstAQi4NjU00ApvNIvoEI=",
+        "checksum": "Q15sT5bGF6kgE7DepzZIHCpPpuP70=",
         "control": {
-          "checksum": "sha1-RFDJtvcstAQi4NjU00ApvNIvoEI=",
-          "range": "bytes=694-1065"
+          "checksum": "sha1-5sT5bGF6kgE7DepzZIHCpPpuP70=",
+          "range": "bytes=702-1085"
         },
         "data": {
-          "checksum": "sha256-oocCJOj9IF7jv3Ov8bPbaAGfq6oaYXuPNnZW9DnOdnE=",
-          "range": "bytes=1066-1135402"
+          "checksum": "sha256-fWOAfZYgXO6+yM4Dpo/y7dvV3uxSEhhfO4SUX79TQDw=",
+          "range": "bytes=1086-1196497"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-wJVFcqH/ewopq4lxwz8OYrZ9/Ws=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-4+7eITv9weTmoYBAAyd92WsXS24=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.2.1-r0.apk",
-        "version": "3.2.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r5.apk",
+        "version": "3.3.0-r5"
       },
       {
         "architecture": "x86_64",
@@ -337,22 +337,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1txYNrxLRCA8tpCe/aXw9Zeb30xw=",
+        "checksum": "Q1sGD1MEAazAXpfNixX74EpwafGo0=",
         "control": {
-          "checksum": "sha1-txYNrxLRCA8tpCe/aXw9Zeb30xw=",
-          "range": "bytes=703-1071"
+          "checksum": "sha1-sGD1MEAazAXpfNixX74EpwafGo0=",
+          "range": "bytes=698-1059"
         },
         "data": {
-          "checksum": "sha256-QgGnbFCQGaCUjwfFVcF2eOXDjZHaJjntdJlM1thwxd0=",
-          "range": "bytes=1072-252873"
+          "checksum": "sha256-s+9m0l/R7hVKQ5YLbU90D2E6DPC2QVTxdjhToMi5iYU=",
+          "range": "bytes=1060-251831"
         },
         "name": "libnghttp2-14",
         "signature": {
-          "checksum": "sha1-VWNh1CR9wcBEPwOH88Qr6n7OR08=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-wOIYtvU72n76UGvbargK2ccZx0E=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.60.0-r0.apk",
-        "version": "1.60.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.61.0-r0.apk",
+        "version": "1.61.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -432,41 +432,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1YKX8zXXVrSZ1a+od3zegHGvE7K4=",
+        "checksum": "Q1NZCvjmGBZ7soi6T4endRPtDztk4=",
         "control": {
-          "checksum": "sha1-YKX8zXXVrSZ1a+od3zegHGvE7K4=",
-          "range": "bytes=701-1168"
+          "checksum": "sha1-NZCvjmGBZ7soi6T4endRPtDztk4=",
+          "range": "bytes=698-1162"
         },
         "data": {
-          "checksum": "sha256-KnMN4TtaDNZqReNINaTivjzUoQigGvtRZgVEqc1EDHo=",
-          "range": "bytes=1169-2555088"
+          "checksum": "sha256-q79pSkGvnDzz1dHsQceLPqyVC+cFCyWWJB5L2EfkZRc=",
+          "range": "bytes=1163-2556930"
         },
         "name": "nghttp2",
         "signature": {
-          "checksum": "sha1-MWKiH9LAxjnWqAm536DCFrsZXCg=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-UuOeekThV8UC737772jFTRj0Y50=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.60.0-r0.apk",
-        "version": "1.60.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.61.0-r0.apk",
+        "version": "1.61.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1D/+xxUxpR+m3nGP5l/8Ed78nNC0=",
+        "checksum": "Q1O/sL8Kjkxzh39Ffh9gJl+0olkF4=",
         "control": {
-          "checksum": "sha1-D/+xxUxpR+m3nGP5l/8Ed78nNC0=",
-          "range": "bytes=700-1067"
+          "checksum": "sha1-O/sL8Kjkxzh39Ffh9gJl+0olkF4=",
+          "range": "bytes=700-1061"
         },
         "data": {
-          "checksum": "sha256-fKV2YLH6EP/NFtRSErdaCwZX+Mg6KJrfmt1VpRWeKis=",
-          "range": "bytes=1068-634389"
+          "checksum": "sha256-6qS8u1yYrzO+4Ypa+g4zfz3m16/7O/U4wjiRrKl8/vw=",
+          "range": "bytes=1062-631650"
         },
         "name": "nghttp2-dev",
         "signature": {
-          "checksum": "sha1-ZRWYUK14qaTBE3NC7OOWumdkSyY=",
+          "checksum": "sha1-avAz/6snsG86C9jh8Gxa59gs29U=",
           "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.60.0-r0.apk",
-        "version": "1.60.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.61.0-r0.apk",
+        "version": "1.61.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -508,41 +508,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1l9z4OGVfdVISNbyGQdXlz2GPchM=",
+        "checksum": "Q1wJPtj5XZtnPiVWGM5dsT+nyfWXc=",
         "control": {
-          "checksum": "sha1-l9z4OGVfdVISNbyGQdXlz2GPchM=",
-          "range": "bytes=695-1222"
+          "checksum": "sha1-wJPtj5XZtnPiVWGM5dsT+nyfWXc=",
+          "range": "bytes=705-1234"
         },
         "data": {
-          "checksum": "sha256-0Z+mq/0A1P+F5KIZKnsYpg8Eqb3GDRT7VDrZlTEg+4Y=",
-          "range": "bytes=1223-3863194"
+          "checksum": "sha256-sw+CjlpsjO01q6lqzXgHnniiJKn7bqOSNO6vNqdGc7I=",
+          "range": "bytes=1235-3873775"
         },
         "name": "bind-libs",
         "signature": {
-          "checksum": "sha1-YX2+1oZh/hXHVjZriSnJZQzpifg=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-9zDzmHAeu7mWpidXAatqrLZVzUs=",
+          "range": "bytes=0-704"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bind-libs-9.18.25-r0.apk",
-        "version": "9.18.25-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/bind-libs-9.18.26-r0.apk",
+        "version": "9.18.26-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Xb5w/MUeHFBeLgnHBmG7dqAMxzQ=",
+        "checksum": "Q1AxEQdi8fVcYtGc3zHTCW3OZdY2Q=",
         "control": {
-          "checksum": "sha1-Xb5w/MUeHFBeLgnHBmG7dqAMxzQ=",
-          "range": "bytes=705-1217"
+          "checksum": "sha1-AxEQdi8fVcYtGc3zHTCW3OZdY2Q=",
+          "range": "bytes=694-1208"
         },
         "data": {
-          "checksum": "sha256-/0zOh1KQW58NOuJgauDOdqJA4G4g0p6jPUOP45HN/f8=",
-          "range": "bytes=1218-892798"
+          "checksum": "sha256-/dt3qJw5D9iSJ/mKkRQkhWD8R52selhpcwXyw7KLMhg=",
+          "range": "bytes=1209-879444"
         },
         "name": "bind-tools",
         "signature": {
-          "checksum": "sha1-3GgaViNXeX4dd75pxgwR8yYgov0=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-VTb0YdUzPMk8Po0p4nj0y5Jey6k=",
+          "range": "bytes=0-693"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bind-tools-9.18.25-r0.apk",
-        "version": "9.18.25-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/bind-tools-9.18.26-r0.apk",
+        "version": "9.18.26-r0"
       },
       {
         "architecture": "x86_64",
@@ -698,41 +698,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1CC3jnItQWZ4ya5EB/TNDLOICnRc=",
+        "checksum": "Q1hgEBBo1tLreSINI2qiCUpUrIE9k=",
         "control": {
-          "checksum": "sha1-CC3jnItQWZ4ya5EB/TNDLOICnRc=",
-          "range": "bytes=701-1140"
+          "checksum": "sha1-hgEBBo1tLreSINI2qiCUpUrIE9k=",
+          "range": "bytes=700-1139"
         },
         "data": {
-          "checksum": "sha256-2EP9UQKOVph+9hElnh20s8ViX126cAnPyNI+IF2pQ4Y=",
-          "range": "bytes=1141-838149"
+          "checksum": "sha256-OFDWkK8l015fs0YvTCXVKLQmOxq+7W5RgJHIqKYZsTE=",
+          "range": "bytes=1140-808582"
         },
         "name": "libcurl-openssl4",
         "signature": {
-          "checksum": "sha1-IxMuIpRYevSLukva0eWmB5RkhMY=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-sygIdNZXB/W8fyOrdelY5RXh3aA=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.7.1-r0.apk",
-        "version": "8.7.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.6.0-r0.apk",
+        "version": "8.6.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1DzKkXRny9JZJvzjFt3jIuvkDP8E=",
+        "checksum": "Q1eQzLI9XN4FM69fm9B4LWd9frcwM=",
         "control": {
-          "checksum": "sha1-DzKkXRny9JZJvzjFt3jIuvkDP8E=",
-          "range": "bytes=700-1101"
+          "checksum": "sha1-eQzLI9XN4FM69fm9B4LWd9frcwM=",
+          "range": "bytes=703-1098"
         },
         "data": {
-          "checksum": "sha256-l1iebyEPmteOEBcPDwPzstpqs9SMvCn8PqlvRU3O7jk=",
-          "range": "bytes=1102-351141"
+          "checksum": "sha256-zkew7+IbyyyENezhlStwO062zaWd+yP/lpbI+CCJVZQ=",
+          "range": "bytes=1099-281166"
         },
         "name": "curl",
         "signature": {
-          "checksum": "sha1-iVKgcLEjgrpj4c2TrRzHznPaWXA=",
-          "range": "bytes=0-699"
+          "checksum": "sha1-igXspQSxo3Eu3o8DeNrYt3YxSbY=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.7.1-r0.apk",
-        "version": "8.7.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.6.0-r0.apk",
+        "version": "8.6.0-r0"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/postgresql-12.lock.json
+++ b/wolfi-images/postgresql-12.lock.json
@@ -204,60 +204,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q13piSoRiT6p5eziGu2iPxSkXxf+g=",
+        "checksum": "Q1+rBEmKEIywe0o/a65ZPjWoUECRQ=",
         "control": {
-          "checksum": "sha1-3piSoRiT6p5eziGu2iPxSkXxf+g=",
-          "range": "bytes=704-1039"
+          "checksum": "sha1-+rBEmKEIywe0o/a65ZPjWoUECRQ=",
+          "range": "bytes=703-1054"
         },
         "data": {
-          "checksum": "sha256-+iLQJV5/mU/hTpwsy9zYBfzVIVkd8lXBBqMScHFhHfI=",
-          "range": "bytes=1040-87982"
+          "checksum": "sha256-fcShKjtj6wR6kgjwToU1J8hU+AGRf1OGZt9jeXJdM0Q=",
+          "range": "bytes=1055-82406"
         },
         "name": "openssl-config",
         "signature": {
-          "checksum": "sha1-fsygjfZl7YLgdpBZ5OVKJG/N2HI=",
-          "range": "bytes=0-703"
+          "checksum": "sha1-RT/o4gi2oC/l+6IhikP9/PH5awg=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/openssl-config-3.2.1-r0.apk",
-        "version": "3.2.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/openssl-config-3.3.0-r5.apk",
+        "version": "3.3.0-r5"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1kERnIFBBwTWZsA+cmGLkIU75THk=",
+        "checksum": "Q11DkfNRzraQMj7ue8LFH6VN6d7Bo=",
         "control": {
-          "checksum": "sha1-kERnIFBBwTWZsA+cmGLkIU75THk=",
-          "range": "bytes=694-1066"
+          "checksum": "sha1-1DkfNRzraQMj7ue8LFH6VN6d7Bo=",
+          "range": "bytes=707-1092"
         },
         "data": {
-          "checksum": "sha256-MB5ZoAsBJ0Osps0a1V0KsM/qQhfZQvYupElgoF1rNLE=",
-          "range": "bytes=1067-5895270"
+          "checksum": "sha256-c95GJNThldUhfxVSGbchUI0pS4j6h45Yx6JDPXHaAI0=",
+          "range": "bytes=1093-5915048"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-vTJq+p2AjVQQjJ4gSkR9ySDQr3k=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-EmjggcTaE4QTKI1FzSom0rXam1c=",
+          "range": "bytes=0-706"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.2.1-r0.apk",
-        "version": "3.2.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r5.apk",
+        "version": "3.3.0-r5"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1RFDJtvcstAQi4NjU00ApvNIvoEI=",
+        "checksum": "Q15sT5bGF6kgE7DepzZIHCpPpuP70=",
         "control": {
-          "checksum": "sha1-RFDJtvcstAQi4NjU00ApvNIvoEI=",
-          "range": "bytes=694-1065"
+          "checksum": "sha1-5sT5bGF6kgE7DepzZIHCpPpuP70=",
+          "range": "bytes=702-1085"
         },
         "data": {
-          "checksum": "sha256-oocCJOj9IF7jv3Ov8bPbaAGfq6oaYXuPNnZW9DnOdnE=",
-          "range": "bytes=1066-1135402"
+          "checksum": "sha256-fWOAfZYgXO6+yM4Dpo/y7dvV3uxSEhhfO4SUX79TQDw=",
+          "range": "bytes=1086-1196497"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-wJVFcqH/ewopq4lxwz8OYrZ9/Ws=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-4+7eITv9weTmoYBAAyd92WsXS24=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.2.1-r0.apk",
-        "version": "3.2.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r5.apk",
+        "version": "3.3.0-r5"
       },
       {
         "architecture": "x86_64",
@@ -337,22 +337,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1txYNrxLRCA8tpCe/aXw9Zeb30xw=",
+        "checksum": "Q1sGD1MEAazAXpfNixX74EpwafGo0=",
         "control": {
-          "checksum": "sha1-txYNrxLRCA8tpCe/aXw9Zeb30xw=",
-          "range": "bytes=703-1071"
+          "checksum": "sha1-sGD1MEAazAXpfNixX74EpwafGo0=",
+          "range": "bytes=698-1059"
         },
         "data": {
-          "checksum": "sha256-QgGnbFCQGaCUjwfFVcF2eOXDjZHaJjntdJlM1thwxd0=",
-          "range": "bytes=1072-252873"
+          "checksum": "sha256-s+9m0l/R7hVKQ5YLbU90D2E6DPC2QVTxdjhToMi5iYU=",
+          "range": "bytes=1060-251831"
         },
         "name": "libnghttp2-14",
         "signature": {
-          "checksum": "sha1-VWNh1CR9wcBEPwOH88Qr6n7OR08=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-wOIYtvU72n76UGvbargK2ccZx0E=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.60.0-r0.apk",
-        "version": "1.60.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.61.0-r0.apk",
+        "version": "1.61.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -432,41 +432,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1YKX8zXXVrSZ1a+od3zegHGvE7K4=",
+        "checksum": "Q1NZCvjmGBZ7soi6T4endRPtDztk4=",
         "control": {
-          "checksum": "sha1-YKX8zXXVrSZ1a+od3zegHGvE7K4=",
-          "range": "bytes=701-1168"
+          "checksum": "sha1-NZCvjmGBZ7soi6T4endRPtDztk4=",
+          "range": "bytes=698-1162"
         },
         "data": {
-          "checksum": "sha256-KnMN4TtaDNZqReNINaTivjzUoQigGvtRZgVEqc1EDHo=",
-          "range": "bytes=1169-2555088"
+          "checksum": "sha256-q79pSkGvnDzz1dHsQceLPqyVC+cFCyWWJB5L2EfkZRc=",
+          "range": "bytes=1163-2556930"
         },
         "name": "nghttp2",
         "signature": {
-          "checksum": "sha1-MWKiH9LAxjnWqAm536DCFrsZXCg=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-UuOeekThV8UC737772jFTRj0Y50=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.60.0-r0.apk",
-        "version": "1.60.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.61.0-r0.apk",
+        "version": "1.61.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1D/+xxUxpR+m3nGP5l/8Ed78nNC0=",
+        "checksum": "Q1O/sL8Kjkxzh39Ffh9gJl+0olkF4=",
         "control": {
-          "checksum": "sha1-D/+xxUxpR+m3nGP5l/8Ed78nNC0=",
-          "range": "bytes=700-1067"
+          "checksum": "sha1-O/sL8Kjkxzh39Ffh9gJl+0olkF4=",
+          "range": "bytes=700-1061"
         },
         "data": {
-          "checksum": "sha256-fKV2YLH6EP/NFtRSErdaCwZX+Mg6KJrfmt1VpRWeKis=",
-          "range": "bytes=1068-634389"
+          "checksum": "sha256-6qS8u1yYrzO+4Ypa+g4zfz3m16/7O/U4wjiRrKl8/vw=",
+          "range": "bytes=1062-631650"
         },
         "name": "nghttp2-dev",
         "signature": {
-          "checksum": "sha1-ZRWYUK14qaTBE3NC7OOWumdkSyY=",
+          "checksum": "sha1-avAz/6snsG86C9jh8Gxa59gs29U=",
           "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.60.0-r0.apk",
-        "version": "1.60.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.61.0-r0.apk",
+        "version": "1.61.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -508,41 +508,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1l9z4OGVfdVISNbyGQdXlz2GPchM=",
+        "checksum": "Q1wJPtj5XZtnPiVWGM5dsT+nyfWXc=",
         "control": {
-          "checksum": "sha1-l9z4OGVfdVISNbyGQdXlz2GPchM=",
-          "range": "bytes=695-1222"
+          "checksum": "sha1-wJPtj5XZtnPiVWGM5dsT+nyfWXc=",
+          "range": "bytes=705-1234"
         },
         "data": {
-          "checksum": "sha256-0Z+mq/0A1P+F5KIZKnsYpg8Eqb3GDRT7VDrZlTEg+4Y=",
-          "range": "bytes=1223-3863194"
+          "checksum": "sha256-sw+CjlpsjO01q6lqzXgHnniiJKn7bqOSNO6vNqdGc7I=",
+          "range": "bytes=1235-3873775"
         },
         "name": "bind-libs",
         "signature": {
-          "checksum": "sha1-YX2+1oZh/hXHVjZriSnJZQzpifg=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-9zDzmHAeu7mWpidXAatqrLZVzUs=",
+          "range": "bytes=0-704"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bind-libs-9.18.25-r0.apk",
-        "version": "9.18.25-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/bind-libs-9.18.26-r0.apk",
+        "version": "9.18.26-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Xb5w/MUeHFBeLgnHBmG7dqAMxzQ=",
+        "checksum": "Q1AxEQdi8fVcYtGc3zHTCW3OZdY2Q=",
         "control": {
-          "checksum": "sha1-Xb5w/MUeHFBeLgnHBmG7dqAMxzQ=",
-          "range": "bytes=705-1217"
+          "checksum": "sha1-AxEQdi8fVcYtGc3zHTCW3OZdY2Q=",
+          "range": "bytes=694-1208"
         },
         "data": {
-          "checksum": "sha256-/0zOh1KQW58NOuJgauDOdqJA4G4g0p6jPUOP45HN/f8=",
-          "range": "bytes=1218-892798"
+          "checksum": "sha256-/dt3qJw5D9iSJ/mKkRQkhWD8R52selhpcwXyw7KLMhg=",
+          "range": "bytes=1209-879444"
         },
         "name": "bind-tools",
         "signature": {
-          "checksum": "sha1-3GgaViNXeX4dd75pxgwR8yYgov0=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-VTb0YdUzPMk8Po0p4nj0y5Jey6k=",
+          "range": "bytes=0-693"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bind-tools-9.18.25-r0.apk",
-        "version": "9.18.25-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/bind-tools-9.18.26-r0.apk",
+        "version": "9.18.26-r0"
       },
       {
         "architecture": "x86_64",
@@ -698,41 +698,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1CC3jnItQWZ4ya5EB/TNDLOICnRc=",
+        "checksum": "Q1hgEBBo1tLreSINI2qiCUpUrIE9k=",
         "control": {
-          "checksum": "sha1-CC3jnItQWZ4ya5EB/TNDLOICnRc=",
-          "range": "bytes=701-1140"
+          "checksum": "sha1-hgEBBo1tLreSINI2qiCUpUrIE9k=",
+          "range": "bytes=700-1139"
         },
         "data": {
-          "checksum": "sha256-2EP9UQKOVph+9hElnh20s8ViX126cAnPyNI+IF2pQ4Y=",
-          "range": "bytes=1141-838149"
+          "checksum": "sha256-OFDWkK8l015fs0YvTCXVKLQmOxq+7W5RgJHIqKYZsTE=",
+          "range": "bytes=1140-808582"
         },
         "name": "libcurl-openssl4",
         "signature": {
-          "checksum": "sha1-IxMuIpRYevSLukva0eWmB5RkhMY=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-sygIdNZXB/W8fyOrdelY5RXh3aA=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.7.1-r0.apk",
-        "version": "8.7.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.6.0-r0.apk",
+        "version": "8.6.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1DzKkXRny9JZJvzjFt3jIuvkDP8E=",
+        "checksum": "Q1eQzLI9XN4FM69fm9B4LWd9frcwM=",
         "control": {
-          "checksum": "sha1-DzKkXRny9JZJvzjFt3jIuvkDP8E=",
-          "range": "bytes=700-1101"
+          "checksum": "sha1-eQzLI9XN4FM69fm9B4LWd9frcwM=",
+          "range": "bytes=703-1098"
         },
         "data": {
-          "checksum": "sha256-l1iebyEPmteOEBcPDwPzstpqs9SMvCn8PqlvRU3O7jk=",
-          "range": "bytes=1102-351141"
+          "checksum": "sha256-zkew7+IbyyyENezhlStwO062zaWd+yP/lpbI+CCJVZQ=",
+          "range": "bytes=1099-281166"
         },
         "name": "curl",
         "signature": {
-          "checksum": "sha1-iVKgcLEjgrpj4c2TrRzHznPaWXA=",
-          "range": "bytes=0-699"
+          "checksum": "sha1-igXspQSxo3Eu3o8DeNrYt3YxSbY=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.7.1-r0.apk",
-        "version": "8.7.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.6.0-r0.apk",
+        "version": "8.6.0-r0"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/prometheus.lock.json
+++ b/wolfi-images/prometheus.lock.json
@@ -204,60 +204,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q13piSoRiT6p5eziGu2iPxSkXxf+g=",
+        "checksum": "Q1+rBEmKEIywe0o/a65ZPjWoUECRQ=",
         "control": {
-          "checksum": "sha1-3piSoRiT6p5eziGu2iPxSkXxf+g=",
-          "range": "bytes=704-1039"
+          "checksum": "sha1-+rBEmKEIywe0o/a65ZPjWoUECRQ=",
+          "range": "bytes=703-1054"
         },
         "data": {
-          "checksum": "sha256-+iLQJV5/mU/hTpwsy9zYBfzVIVkd8lXBBqMScHFhHfI=",
-          "range": "bytes=1040-87982"
+          "checksum": "sha256-fcShKjtj6wR6kgjwToU1J8hU+AGRf1OGZt9jeXJdM0Q=",
+          "range": "bytes=1055-82406"
         },
         "name": "openssl-config",
         "signature": {
-          "checksum": "sha1-fsygjfZl7YLgdpBZ5OVKJG/N2HI=",
-          "range": "bytes=0-703"
+          "checksum": "sha1-RT/o4gi2oC/l+6IhikP9/PH5awg=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/openssl-config-3.2.1-r0.apk",
-        "version": "3.2.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/openssl-config-3.3.0-r5.apk",
+        "version": "3.3.0-r5"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1kERnIFBBwTWZsA+cmGLkIU75THk=",
+        "checksum": "Q11DkfNRzraQMj7ue8LFH6VN6d7Bo=",
         "control": {
-          "checksum": "sha1-kERnIFBBwTWZsA+cmGLkIU75THk=",
-          "range": "bytes=694-1066"
+          "checksum": "sha1-1DkfNRzraQMj7ue8LFH6VN6d7Bo=",
+          "range": "bytes=707-1092"
         },
         "data": {
-          "checksum": "sha256-MB5ZoAsBJ0Osps0a1V0KsM/qQhfZQvYupElgoF1rNLE=",
-          "range": "bytes=1067-5895270"
+          "checksum": "sha256-c95GJNThldUhfxVSGbchUI0pS4j6h45Yx6JDPXHaAI0=",
+          "range": "bytes=1093-5915048"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-vTJq+p2AjVQQjJ4gSkR9ySDQr3k=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-EmjggcTaE4QTKI1FzSom0rXam1c=",
+          "range": "bytes=0-706"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.2.1-r0.apk",
-        "version": "3.2.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r5.apk",
+        "version": "3.3.0-r5"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1RFDJtvcstAQi4NjU00ApvNIvoEI=",
+        "checksum": "Q15sT5bGF6kgE7DepzZIHCpPpuP70=",
         "control": {
-          "checksum": "sha1-RFDJtvcstAQi4NjU00ApvNIvoEI=",
-          "range": "bytes=694-1065"
+          "checksum": "sha1-5sT5bGF6kgE7DepzZIHCpPpuP70=",
+          "range": "bytes=702-1085"
         },
         "data": {
-          "checksum": "sha256-oocCJOj9IF7jv3Ov8bPbaAGfq6oaYXuPNnZW9DnOdnE=",
-          "range": "bytes=1066-1135402"
+          "checksum": "sha256-fWOAfZYgXO6+yM4Dpo/y7dvV3uxSEhhfO4SUX79TQDw=",
+          "range": "bytes=1086-1196497"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-wJVFcqH/ewopq4lxwz8OYrZ9/Ws=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-4+7eITv9weTmoYBAAyd92WsXS24=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.2.1-r0.apk",
-        "version": "3.2.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r5.apk",
+        "version": "3.3.0-r5"
       },
       {
         "architecture": "x86_64",
@@ -337,22 +337,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1txYNrxLRCA8tpCe/aXw9Zeb30xw=",
+        "checksum": "Q1sGD1MEAazAXpfNixX74EpwafGo0=",
         "control": {
-          "checksum": "sha1-txYNrxLRCA8tpCe/aXw9Zeb30xw=",
-          "range": "bytes=703-1071"
+          "checksum": "sha1-sGD1MEAazAXpfNixX74EpwafGo0=",
+          "range": "bytes=698-1059"
         },
         "data": {
-          "checksum": "sha256-QgGnbFCQGaCUjwfFVcF2eOXDjZHaJjntdJlM1thwxd0=",
-          "range": "bytes=1072-252873"
+          "checksum": "sha256-s+9m0l/R7hVKQ5YLbU90D2E6DPC2QVTxdjhToMi5iYU=",
+          "range": "bytes=1060-251831"
         },
         "name": "libnghttp2-14",
         "signature": {
-          "checksum": "sha1-VWNh1CR9wcBEPwOH88Qr6n7OR08=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-wOIYtvU72n76UGvbargK2ccZx0E=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.60.0-r0.apk",
-        "version": "1.60.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.61.0-r0.apk",
+        "version": "1.61.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -432,41 +432,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1YKX8zXXVrSZ1a+od3zegHGvE7K4=",
+        "checksum": "Q1NZCvjmGBZ7soi6T4endRPtDztk4=",
         "control": {
-          "checksum": "sha1-YKX8zXXVrSZ1a+od3zegHGvE7K4=",
-          "range": "bytes=701-1168"
+          "checksum": "sha1-NZCvjmGBZ7soi6T4endRPtDztk4=",
+          "range": "bytes=698-1162"
         },
         "data": {
-          "checksum": "sha256-KnMN4TtaDNZqReNINaTivjzUoQigGvtRZgVEqc1EDHo=",
-          "range": "bytes=1169-2555088"
+          "checksum": "sha256-q79pSkGvnDzz1dHsQceLPqyVC+cFCyWWJB5L2EfkZRc=",
+          "range": "bytes=1163-2556930"
         },
         "name": "nghttp2",
         "signature": {
-          "checksum": "sha1-MWKiH9LAxjnWqAm536DCFrsZXCg=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-UuOeekThV8UC737772jFTRj0Y50=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.60.0-r0.apk",
-        "version": "1.60.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.61.0-r0.apk",
+        "version": "1.61.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1D/+xxUxpR+m3nGP5l/8Ed78nNC0=",
+        "checksum": "Q1O/sL8Kjkxzh39Ffh9gJl+0olkF4=",
         "control": {
-          "checksum": "sha1-D/+xxUxpR+m3nGP5l/8Ed78nNC0=",
-          "range": "bytes=700-1067"
+          "checksum": "sha1-O/sL8Kjkxzh39Ffh9gJl+0olkF4=",
+          "range": "bytes=700-1061"
         },
         "data": {
-          "checksum": "sha256-fKV2YLH6EP/NFtRSErdaCwZX+Mg6KJrfmt1VpRWeKis=",
-          "range": "bytes=1068-634389"
+          "checksum": "sha256-6qS8u1yYrzO+4Ypa+g4zfz3m16/7O/U4wjiRrKl8/vw=",
+          "range": "bytes=1062-631650"
         },
         "name": "nghttp2-dev",
         "signature": {
-          "checksum": "sha1-ZRWYUK14qaTBE3NC7OOWumdkSyY=",
+          "checksum": "sha1-avAz/6snsG86C9jh8Gxa59gs29U=",
           "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.60.0-r0.apk",
-        "version": "1.60.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.61.0-r0.apk",
+        "version": "1.61.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -508,41 +508,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1l9z4OGVfdVISNbyGQdXlz2GPchM=",
+        "checksum": "Q1wJPtj5XZtnPiVWGM5dsT+nyfWXc=",
         "control": {
-          "checksum": "sha1-l9z4OGVfdVISNbyGQdXlz2GPchM=",
-          "range": "bytes=695-1222"
+          "checksum": "sha1-wJPtj5XZtnPiVWGM5dsT+nyfWXc=",
+          "range": "bytes=705-1234"
         },
         "data": {
-          "checksum": "sha256-0Z+mq/0A1P+F5KIZKnsYpg8Eqb3GDRT7VDrZlTEg+4Y=",
-          "range": "bytes=1223-3863194"
+          "checksum": "sha256-sw+CjlpsjO01q6lqzXgHnniiJKn7bqOSNO6vNqdGc7I=",
+          "range": "bytes=1235-3873775"
         },
         "name": "bind-libs",
         "signature": {
-          "checksum": "sha1-YX2+1oZh/hXHVjZriSnJZQzpifg=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-9zDzmHAeu7mWpidXAatqrLZVzUs=",
+          "range": "bytes=0-704"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bind-libs-9.18.25-r0.apk",
-        "version": "9.18.25-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/bind-libs-9.18.26-r0.apk",
+        "version": "9.18.26-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Xb5w/MUeHFBeLgnHBmG7dqAMxzQ=",
+        "checksum": "Q1AxEQdi8fVcYtGc3zHTCW3OZdY2Q=",
         "control": {
-          "checksum": "sha1-Xb5w/MUeHFBeLgnHBmG7dqAMxzQ=",
-          "range": "bytes=705-1217"
+          "checksum": "sha1-AxEQdi8fVcYtGc3zHTCW3OZdY2Q=",
+          "range": "bytes=694-1208"
         },
         "data": {
-          "checksum": "sha256-/0zOh1KQW58NOuJgauDOdqJA4G4g0p6jPUOP45HN/f8=",
-          "range": "bytes=1218-892798"
+          "checksum": "sha256-/dt3qJw5D9iSJ/mKkRQkhWD8R52selhpcwXyw7KLMhg=",
+          "range": "bytes=1209-879444"
         },
         "name": "bind-tools",
         "signature": {
-          "checksum": "sha1-3GgaViNXeX4dd75pxgwR8yYgov0=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-VTb0YdUzPMk8Po0p4nj0y5Jey6k=",
+          "range": "bytes=0-693"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bind-tools-9.18.25-r0.apk",
-        "version": "9.18.25-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/bind-tools-9.18.26-r0.apk",
+        "version": "9.18.26-r0"
       },
       {
         "architecture": "x86_64",
@@ -698,41 +698,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1CC3jnItQWZ4ya5EB/TNDLOICnRc=",
+        "checksum": "Q1hgEBBo1tLreSINI2qiCUpUrIE9k=",
         "control": {
-          "checksum": "sha1-CC3jnItQWZ4ya5EB/TNDLOICnRc=",
-          "range": "bytes=701-1140"
+          "checksum": "sha1-hgEBBo1tLreSINI2qiCUpUrIE9k=",
+          "range": "bytes=700-1139"
         },
         "data": {
-          "checksum": "sha256-2EP9UQKOVph+9hElnh20s8ViX126cAnPyNI+IF2pQ4Y=",
-          "range": "bytes=1141-838149"
+          "checksum": "sha256-OFDWkK8l015fs0YvTCXVKLQmOxq+7W5RgJHIqKYZsTE=",
+          "range": "bytes=1140-808582"
         },
         "name": "libcurl-openssl4",
         "signature": {
-          "checksum": "sha1-IxMuIpRYevSLukva0eWmB5RkhMY=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-sygIdNZXB/W8fyOrdelY5RXh3aA=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.7.1-r0.apk",
-        "version": "8.7.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.6.0-r0.apk",
+        "version": "8.6.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1DzKkXRny9JZJvzjFt3jIuvkDP8E=",
+        "checksum": "Q1eQzLI9XN4FM69fm9B4LWd9frcwM=",
         "control": {
-          "checksum": "sha1-DzKkXRny9JZJvzjFt3jIuvkDP8E=",
-          "range": "bytes=700-1101"
+          "checksum": "sha1-eQzLI9XN4FM69fm9B4LWd9frcwM=",
+          "range": "bytes=703-1098"
         },
         "data": {
-          "checksum": "sha256-l1iebyEPmteOEBcPDwPzstpqs9SMvCn8PqlvRU3O7jk=",
-          "range": "bytes=1102-351141"
+          "checksum": "sha256-zkew7+IbyyyENezhlStwO062zaWd+yP/lpbI+CCJVZQ=",
+          "range": "bytes=1099-281166"
         },
         "name": "curl",
         "signature": {
-          "checksum": "sha1-iVKgcLEjgrpj4c2TrRzHznPaWXA=",
-          "range": "bytes=0-699"
+          "checksum": "sha1-igXspQSxo3Eu3o8DeNrYt3YxSbY=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.7.1-r0.apk",
-        "version": "8.7.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.6.0-r0.apk",
+        "version": "8.6.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -755,22 +755,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1N66g6pfCuFCU4ZKfPQ6n3eDggB0=",
+        "checksum": "Q11rWEg82oHyjUZI+8zzUmTJ1D/74=",
         "control": {
-          "checksum": "sha1-N66g6pfCuFCU4ZKfPQ6n3eDggB0=",
-          "range": "bytes=704-1140"
+          "checksum": "sha1-1rWEg82oHyjUZI+8zzUmTJ1D/74=",
+          "range": "bytes=703-1150"
         },
         "data": {
-          "checksum": "sha256-oNmytBov2qEeWj5pqaQ41GWo6ziLezAWfxDGXkwcr6c=",
-          "range": "bytes=1141-186189735"
+          "checksum": "sha256-ZPmuc49YzWCEyVdde2xydAUGVTJWbQ/x4bE0y3KvUi8=",
+          "range": "bytes=1151-186189747"
         },
         "name": "prometheus-2.51",
         "signature": {
-          "checksum": "sha1-o6tienifJogUi4/gZsxqhkHcVr4=",
-          "range": "bytes=0-703"
+          "checksum": "sha1-id0YIveOCeBApldSkhNpoF5uUZQ=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/prometheus-2.51-2.51.1-r1.apk",
-        "version": "2.51.1-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/prometheus-2.51-2.51.2-r0.apk",
+        "version": "2.51.2-r0"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/qdrant.lock.json
+++ b/wolfi-images/qdrant.lock.json
@@ -204,60 +204,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q13piSoRiT6p5eziGu2iPxSkXxf+g=",
+        "checksum": "Q1+rBEmKEIywe0o/a65ZPjWoUECRQ=",
         "control": {
-          "checksum": "sha1-3piSoRiT6p5eziGu2iPxSkXxf+g=",
-          "range": "bytes=704-1039"
+          "checksum": "sha1-+rBEmKEIywe0o/a65ZPjWoUECRQ=",
+          "range": "bytes=703-1054"
         },
         "data": {
-          "checksum": "sha256-+iLQJV5/mU/hTpwsy9zYBfzVIVkd8lXBBqMScHFhHfI=",
-          "range": "bytes=1040-87982"
+          "checksum": "sha256-fcShKjtj6wR6kgjwToU1J8hU+AGRf1OGZt9jeXJdM0Q=",
+          "range": "bytes=1055-82406"
         },
         "name": "openssl-config",
         "signature": {
-          "checksum": "sha1-fsygjfZl7YLgdpBZ5OVKJG/N2HI=",
-          "range": "bytes=0-703"
+          "checksum": "sha1-RT/o4gi2oC/l+6IhikP9/PH5awg=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/openssl-config-3.2.1-r0.apk",
-        "version": "3.2.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/openssl-config-3.3.0-r5.apk",
+        "version": "3.3.0-r5"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1kERnIFBBwTWZsA+cmGLkIU75THk=",
+        "checksum": "Q11DkfNRzraQMj7ue8LFH6VN6d7Bo=",
         "control": {
-          "checksum": "sha1-kERnIFBBwTWZsA+cmGLkIU75THk=",
-          "range": "bytes=694-1066"
+          "checksum": "sha1-1DkfNRzraQMj7ue8LFH6VN6d7Bo=",
+          "range": "bytes=707-1092"
         },
         "data": {
-          "checksum": "sha256-MB5ZoAsBJ0Osps0a1V0KsM/qQhfZQvYupElgoF1rNLE=",
-          "range": "bytes=1067-5895270"
+          "checksum": "sha256-c95GJNThldUhfxVSGbchUI0pS4j6h45Yx6JDPXHaAI0=",
+          "range": "bytes=1093-5915048"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-vTJq+p2AjVQQjJ4gSkR9ySDQr3k=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-EmjggcTaE4QTKI1FzSom0rXam1c=",
+          "range": "bytes=0-706"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.2.1-r0.apk",
-        "version": "3.2.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r5.apk",
+        "version": "3.3.0-r5"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1RFDJtvcstAQi4NjU00ApvNIvoEI=",
+        "checksum": "Q15sT5bGF6kgE7DepzZIHCpPpuP70=",
         "control": {
-          "checksum": "sha1-RFDJtvcstAQi4NjU00ApvNIvoEI=",
-          "range": "bytes=694-1065"
+          "checksum": "sha1-5sT5bGF6kgE7DepzZIHCpPpuP70=",
+          "range": "bytes=702-1085"
         },
         "data": {
-          "checksum": "sha256-oocCJOj9IF7jv3Ov8bPbaAGfq6oaYXuPNnZW9DnOdnE=",
-          "range": "bytes=1066-1135402"
+          "checksum": "sha256-fWOAfZYgXO6+yM4Dpo/y7dvV3uxSEhhfO4SUX79TQDw=",
+          "range": "bytes=1086-1196497"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-wJVFcqH/ewopq4lxwz8OYrZ9/Ws=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-4+7eITv9weTmoYBAAyd92WsXS24=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.2.1-r0.apk",
-        "version": "3.2.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r5.apk",
+        "version": "3.3.0-r5"
       },
       {
         "architecture": "x86_64",
@@ -337,22 +337,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1txYNrxLRCA8tpCe/aXw9Zeb30xw=",
+        "checksum": "Q1sGD1MEAazAXpfNixX74EpwafGo0=",
         "control": {
-          "checksum": "sha1-txYNrxLRCA8tpCe/aXw9Zeb30xw=",
-          "range": "bytes=703-1071"
+          "checksum": "sha1-sGD1MEAazAXpfNixX74EpwafGo0=",
+          "range": "bytes=698-1059"
         },
         "data": {
-          "checksum": "sha256-QgGnbFCQGaCUjwfFVcF2eOXDjZHaJjntdJlM1thwxd0=",
-          "range": "bytes=1072-252873"
+          "checksum": "sha256-s+9m0l/R7hVKQ5YLbU90D2E6DPC2QVTxdjhToMi5iYU=",
+          "range": "bytes=1060-251831"
         },
         "name": "libnghttp2-14",
         "signature": {
-          "checksum": "sha1-VWNh1CR9wcBEPwOH88Qr6n7OR08=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-wOIYtvU72n76UGvbargK2ccZx0E=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.60.0-r0.apk",
-        "version": "1.60.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.61.0-r0.apk",
+        "version": "1.61.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -432,41 +432,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1YKX8zXXVrSZ1a+od3zegHGvE7K4=",
+        "checksum": "Q1NZCvjmGBZ7soi6T4endRPtDztk4=",
         "control": {
-          "checksum": "sha1-YKX8zXXVrSZ1a+od3zegHGvE7K4=",
-          "range": "bytes=701-1168"
+          "checksum": "sha1-NZCvjmGBZ7soi6T4endRPtDztk4=",
+          "range": "bytes=698-1162"
         },
         "data": {
-          "checksum": "sha256-KnMN4TtaDNZqReNINaTivjzUoQigGvtRZgVEqc1EDHo=",
-          "range": "bytes=1169-2555088"
+          "checksum": "sha256-q79pSkGvnDzz1dHsQceLPqyVC+cFCyWWJB5L2EfkZRc=",
+          "range": "bytes=1163-2556930"
         },
         "name": "nghttp2",
         "signature": {
-          "checksum": "sha1-MWKiH9LAxjnWqAm536DCFrsZXCg=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-UuOeekThV8UC737772jFTRj0Y50=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.60.0-r0.apk",
-        "version": "1.60.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.61.0-r0.apk",
+        "version": "1.61.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1D/+xxUxpR+m3nGP5l/8Ed78nNC0=",
+        "checksum": "Q1O/sL8Kjkxzh39Ffh9gJl+0olkF4=",
         "control": {
-          "checksum": "sha1-D/+xxUxpR+m3nGP5l/8Ed78nNC0=",
-          "range": "bytes=700-1067"
+          "checksum": "sha1-O/sL8Kjkxzh39Ffh9gJl+0olkF4=",
+          "range": "bytes=700-1061"
         },
         "data": {
-          "checksum": "sha256-fKV2YLH6EP/NFtRSErdaCwZX+Mg6KJrfmt1VpRWeKis=",
-          "range": "bytes=1068-634389"
+          "checksum": "sha256-6qS8u1yYrzO+4Ypa+g4zfz3m16/7O/U4wjiRrKl8/vw=",
+          "range": "bytes=1062-631650"
         },
         "name": "nghttp2-dev",
         "signature": {
-          "checksum": "sha1-ZRWYUK14qaTBE3NC7OOWumdkSyY=",
+          "checksum": "sha1-avAz/6snsG86C9jh8Gxa59gs29U=",
           "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.60.0-r0.apk",
-        "version": "1.60.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.61.0-r0.apk",
+        "version": "1.61.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -508,41 +508,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1l9z4OGVfdVISNbyGQdXlz2GPchM=",
+        "checksum": "Q1wJPtj5XZtnPiVWGM5dsT+nyfWXc=",
         "control": {
-          "checksum": "sha1-l9z4OGVfdVISNbyGQdXlz2GPchM=",
-          "range": "bytes=695-1222"
+          "checksum": "sha1-wJPtj5XZtnPiVWGM5dsT+nyfWXc=",
+          "range": "bytes=705-1234"
         },
         "data": {
-          "checksum": "sha256-0Z+mq/0A1P+F5KIZKnsYpg8Eqb3GDRT7VDrZlTEg+4Y=",
-          "range": "bytes=1223-3863194"
+          "checksum": "sha256-sw+CjlpsjO01q6lqzXgHnniiJKn7bqOSNO6vNqdGc7I=",
+          "range": "bytes=1235-3873775"
         },
         "name": "bind-libs",
         "signature": {
-          "checksum": "sha1-YX2+1oZh/hXHVjZriSnJZQzpifg=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-9zDzmHAeu7mWpidXAatqrLZVzUs=",
+          "range": "bytes=0-704"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bind-libs-9.18.25-r0.apk",
-        "version": "9.18.25-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/bind-libs-9.18.26-r0.apk",
+        "version": "9.18.26-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Xb5w/MUeHFBeLgnHBmG7dqAMxzQ=",
+        "checksum": "Q1AxEQdi8fVcYtGc3zHTCW3OZdY2Q=",
         "control": {
-          "checksum": "sha1-Xb5w/MUeHFBeLgnHBmG7dqAMxzQ=",
-          "range": "bytes=705-1217"
+          "checksum": "sha1-AxEQdi8fVcYtGc3zHTCW3OZdY2Q=",
+          "range": "bytes=694-1208"
         },
         "data": {
-          "checksum": "sha256-/0zOh1KQW58NOuJgauDOdqJA4G4g0p6jPUOP45HN/f8=",
-          "range": "bytes=1218-892798"
+          "checksum": "sha256-/dt3qJw5D9iSJ/mKkRQkhWD8R52selhpcwXyw7KLMhg=",
+          "range": "bytes=1209-879444"
         },
         "name": "bind-tools",
         "signature": {
-          "checksum": "sha1-3GgaViNXeX4dd75pxgwR8yYgov0=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-VTb0YdUzPMk8Po0p4nj0y5Jey6k=",
+          "range": "bytes=0-693"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bind-tools-9.18.25-r0.apk",
-        "version": "9.18.25-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/bind-tools-9.18.26-r0.apk",
+        "version": "9.18.26-r0"
       },
       {
         "architecture": "x86_64",
@@ -698,60 +698,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1CC3jnItQWZ4ya5EB/TNDLOICnRc=",
+        "checksum": "Q1hgEBBo1tLreSINI2qiCUpUrIE9k=",
         "control": {
-          "checksum": "sha1-CC3jnItQWZ4ya5EB/TNDLOICnRc=",
-          "range": "bytes=701-1140"
+          "checksum": "sha1-hgEBBo1tLreSINI2qiCUpUrIE9k=",
+          "range": "bytes=700-1139"
         },
         "data": {
-          "checksum": "sha256-2EP9UQKOVph+9hElnh20s8ViX126cAnPyNI+IF2pQ4Y=",
-          "range": "bytes=1141-838149"
+          "checksum": "sha256-OFDWkK8l015fs0YvTCXVKLQmOxq+7W5RgJHIqKYZsTE=",
+          "range": "bytes=1140-808582"
         },
         "name": "libcurl-openssl4",
         "signature": {
-          "checksum": "sha1-IxMuIpRYevSLukva0eWmB5RkhMY=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-sygIdNZXB/W8fyOrdelY5RXh3aA=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.7.1-r0.apk",
-        "version": "8.7.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.6.0-r0.apk",
+        "version": "8.6.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1DzKkXRny9JZJvzjFt3jIuvkDP8E=",
+        "checksum": "Q1eQzLI9XN4FM69fm9B4LWd9frcwM=",
         "control": {
-          "checksum": "sha1-DzKkXRny9JZJvzjFt3jIuvkDP8E=",
-          "range": "bytes=700-1101"
+          "checksum": "sha1-eQzLI9XN4FM69fm9B4LWd9frcwM=",
+          "range": "bytes=703-1098"
         },
         "data": {
-          "checksum": "sha256-l1iebyEPmteOEBcPDwPzstpqs9SMvCn8PqlvRU3O7jk=",
-          "range": "bytes=1102-351141"
+          "checksum": "sha256-zkew7+IbyyyENezhlStwO062zaWd+yP/lpbI+CCJVZQ=",
+          "range": "bytes=1099-281166"
         },
         "name": "curl",
         "signature": {
-          "checksum": "sha1-iVKgcLEjgrpj4c2TrRzHznPaWXA=",
-          "range": "bytes=0-699"
+          "checksum": "sha1-igXspQSxo3Eu3o8DeNrYt3YxSbY=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.7.1-r0.apk",
-        "version": "8.7.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.6.0-r0.apk",
+        "version": "8.6.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1qJ/8aokcxpoWR4Q1clvXUiSDZEU=",
+        "checksum": "Q19yTFZBeYlCCMWWWtfHBXivqZKfc=",
         "control": {
-          "checksum": "sha1-qJ/8aokcxpoWR4Q1clvXUiSDZEU=",
-          "range": "bytes=661-995"
+          "checksum": "sha1-9yTFZBeYlCCMWWWtfHBXivqZKfc=",
+          "range": "bytes=657-991"
         },
         "data": {
-          "checksum": "sha256-Q3fG+WWle2l349xG+8QDtnIZhHFyHEdeCBcvpOtS+Yo=",
-          "range": "bytes=996-42546360"
+          "checksum": "sha256-2FUyZ+/OJ9o/PTteTNS/jIlOBJuw7eJrhAbxiFIbU9Q=",
+          "range": "bytes=992-42513766"
         },
         "name": "qdrant",
         "signature": {
-          "checksum": "sha1-f7Q5dMt+xcV9fYkGtbSquja+Z4Y=",
-          "range": "bytes=0-660"
+          "checksum": "sha1-ZfLA+OrzXH+JAysAXgT9IoFbiRA=",
+          "range": "bytes=0-656"
         },
-        "url": "https://packages.sgdev.org/main/x86_64/qdrant-1.5.1-r2.apk",
-        "version": "1.5.1-r2"
+        "url": "https://packages.sgdev.org/main/x86_64/qdrant-1.5.1-r4.apk",
+        "version": "1.5.1-r4"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/redis-exporter.lock.json
+++ b/wolfi-images/redis-exporter.lock.json
@@ -204,60 +204,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q13piSoRiT6p5eziGu2iPxSkXxf+g=",
+        "checksum": "Q1+rBEmKEIywe0o/a65ZPjWoUECRQ=",
         "control": {
-          "checksum": "sha1-3piSoRiT6p5eziGu2iPxSkXxf+g=",
-          "range": "bytes=704-1039"
+          "checksum": "sha1-+rBEmKEIywe0o/a65ZPjWoUECRQ=",
+          "range": "bytes=703-1054"
         },
         "data": {
-          "checksum": "sha256-+iLQJV5/mU/hTpwsy9zYBfzVIVkd8lXBBqMScHFhHfI=",
-          "range": "bytes=1040-87982"
+          "checksum": "sha256-fcShKjtj6wR6kgjwToU1J8hU+AGRf1OGZt9jeXJdM0Q=",
+          "range": "bytes=1055-82406"
         },
         "name": "openssl-config",
         "signature": {
-          "checksum": "sha1-fsygjfZl7YLgdpBZ5OVKJG/N2HI=",
-          "range": "bytes=0-703"
+          "checksum": "sha1-RT/o4gi2oC/l+6IhikP9/PH5awg=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/openssl-config-3.2.1-r0.apk",
-        "version": "3.2.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/openssl-config-3.3.0-r5.apk",
+        "version": "3.3.0-r5"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1kERnIFBBwTWZsA+cmGLkIU75THk=",
+        "checksum": "Q11DkfNRzraQMj7ue8LFH6VN6d7Bo=",
         "control": {
-          "checksum": "sha1-kERnIFBBwTWZsA+cmGLkIU75THk=",
-          "range": "bytes=694-1066"
+          "checksum": "sha1-1DkfNRzraQMj7ue8LFH6VN6d7Bo=",
+          "range": "bytes=707-1092"
         },
         "data": {
-          "checksum": "sha256-MB5ZoAsBJ0Osps0a1V0KsM/qQhfZQvYupElgoF1rNLE=",
-          "range": "bytes=1067-5895270"
+          "checksum": "sha256-c95GJNThldUhfxVSGbchUI0pS4j6h45Yx6JDPXHaAI0=",
+          "range": "bytes=1093-5915048"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-vTJq+p2AjVQQjJ4gSkR9ySDQr3k=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-EmjggcTaE4QTKI1FzSom0rXam1c=",
+          "range": "bytes=0-706"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.2.1-r0.apk",
-        "version": "3.2.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r5.apk",
+        "version": "3.3.0-r5"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1RFDJtvcstAQi4NjU00ApvNIvoEI=",
+        "checksum": "Q15sT5bGF6kgE7DepzZIHCpPpuP70=",
         "control": {
-          "checksum": "sha1-RFDJtvcstAQi4NjU00ApvNIvoEI=",
-          "range": "bytes=694-1065"
+          "checksum": "sha1-5sT5bGF6kgE7DepzZIHCpPpuP70=",
+          "range": "bytes=702-1085"
         },
         "data": {
-          "checksum": "sha256-oocCJOj9IF7jv3Ov8bPbaAGfq6oaYXuPNnZW9DnOdnE=",
-          "range": "bytes=1066-1135402"
+          "checksum": "sha256-fWOAfZYgXO6+yM4Dpo/y7dvV3uxSEhhfO4SUX79TQDw=",
+          "range": "bytes=1086-1196497"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-wJVFcqH/ewopq4lxwz8OYrZ9/Ws=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-4+7eITv9weTmoYBAAyd92WsXS24=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.2.1-r0.apk",
-        "version": "3.2.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r5.apk",
+        "version": "3.3.0-r5"
       },
       {
         "architecture": "x86_64",
@@ -337,22 +337,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1txYNrxLRCA8tpCe/aXw9Zeb30xw=",
+        "checksum": "Q1sGD1MEAazAXpfNixX74EpwafGo0=",
         "control": {
-          "checksum": "sha1-txYNrxLRCA8tpCe/aXw9Zeb30xw=",
-          "range": "bytes=703-1071"
+          "checksum": "sha1-sGD1MEAazAXpfNixX74EpwafGo0=",
+          "range": "bytes=698-1059"
         },
         "data": {
-          "checksum": "sha256-QgGnbFCQGaCUjwfFVcF2eOXDjZHaJjntdJlM1thwxd0=",
-          "range": "bytes=1072-252873"
+          "checksum": "sha256-s+9m0l/R7hVKQ5YLbU90D2E6DPC2QVTxdjhToMi5iYU=",
+          "range": "bytes=1060-251831"
         },
         "name": "libnghttp2-14",
         "signature": {
-          "checksum": "sha1-VWNh1CR9wcBEPwOH88Qr6n7OR08=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-wOIYtvU72n76UGvbargK2ccZx0E=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.60.0-r0.apk",
-        "version": "1.60.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.61.0-r0.apk",
+        "version": "1.61.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -432,41 +432,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1YKX8zXXVrSZ1a+od3zegHGvE7K4=",
+        "checksum": "Q1NZCvjmGBZ7soi6T4endRPtDztk4=",
         "control": {
-          "checksum": "sha1-YKX8zXXVrSZ1a+od3zegHGvE7K4=",
-          "range": "bytes=701-1168"
+          "checksum": "sha1-NZCvjmGBZ7soi6T4endRPtDztk4=",
+          "range": "bytes=698-1162"
         },
         "data": {
-          "checksum": "sha256-KnMN4TtaDNZqReNINaTivjzUoQigGvtRZgVEqc1EDHo=",
-          "range": "bytes=1169-2555088"
+          "checksum": "sha256-q79pSkGvnDzz1dHsQceLPqyVC+cFCyWWJB5L2EfkZRc=",
+          "range": "bytes=1163-2556930"
         },
         "name": "nghttp2",
         "signature": {
-          "checksum": "sha1-MWKiH9LAxjnWqAm536DCFrsZXCg=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-UuOeekThV8UC737772jFTRj0Y50=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.60.0-r0.apk",
-        "version": "1.60.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.61.0-r0.apk",
+        "version": "1.61.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1D/+xxUxpR+m3nGP5l/8Ed78nNC0=",
+        "checksum": "Q1O/sL8Kjkxzh39Ffh9gJl+0olkF4=",
         "control": {
-          "checksum": "sha1-D/+xxUxpR+m3nGP5l/8Ed78nNC0=",
-          "range": "bytes=700-1067"
+          "checksum": "sha1-O/sL8Kjkxzh39Ffh9gJl+0olkF4=",
+          "range": "bytes=700-1061"
         },
         "data": {
-          "checksum": "sha256-fKV2YLH6EP/NFtRSErdaCwZX+Mg6KJrfmt1VpRWeKis=",
-          "range": "bytes=1068-634389"
+          "checksum": "sha256-6qS8u1yYrzO+4Ypa+g4zfz3m16/7O/U4wjiRrKl8/vw=",
+          "range": "bytes=1062-631650"
         },
         "name": "nghttp2-dev",
         "signature": {
-          "checksum": "sha1-ZRWYUK14qaTBE3NC7OOWumdkSyY=",
+          "checksum": "sha1-avAz/6snsG86C9jh8Gxa59gs29U=",
           "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.60.0-r0.apk",
-        "version": "1.60.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.61.0-r0.apk",
+        "version": "1.61.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -508,41 +508,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1l9z4OGVfdVISNbyGQdXlz2GPchM=",
+        "checksum": "Q1wJPtj5XZtnPiVWGM5dsT+nyfWXc=",
         "control": {
-          "checksum": "sha1-l9z4OGVfdVISNbyGQdXlz2GPchM=",
-          "range": "bytes=695-1222"
+          "checksum": "sha1-wJPtj5XZtnPiVWGM5dsT+nyfWXc=",
+          "range": "bytes=705-1234"
         },
         "data": {
-          "checksum": "sha256-0Z+mq/0A1P+F5KIZKnsYpg8Eqb3GDRT7VDrZlTEg+4Y=",
-          "range": "bytes=1223-3863194"
+          "checksum": "sha256-sw+CjlpsjO01q6lqzXgHnniiJKn7bqOSNO6vNqdGc7I=",
+          "range": "bytes=1235-3873775"
         },
         "name": "bind-libs",
         "signature": {
-          "checksum": "sha1-YX2+1oZh/hXHVjZriSnJZQzpifg=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-9zDzmHAeu7mWpidXAatqrLZVzUs=",
+          "range": "bytes=0-704"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bind-libs-9.18.25-r0.apk",
-        "version": "9.18.25-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/bind-libs-9.18.26-r0.apk",
+        "version": "9.18.26-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Xb5w/MUeHFBeLgnHBmG7dqAMxzQ=",
+        "checksum": "Q1AxEQdi8fVcYtGc3zHTCW3OZdY2Q=",
         "control": {
-          "checksum": "sha1-Xb5w/MUeHFBeLgnHBmG7dqAMxzQ=",
-          "range": "bytes=705-1217"
+          "checksum": "sha1-AxEQdi8fVcYtGc3zHTCW3OZdY2Q=",
+          "range": "bytes=694-1208"
         },
         "data": {
-          "checksum": "sha256-/0zOh1KQW58NOuJgauDOdqJA4G4g0p6jPUOP45HN/f8=",
-          "range": "bytes=1218-892798"
+          "checksum": "sha256-/dt3qJw5D9iSJ/mKkRQkhWD8R52selhpcwXyw7KLMhg=",
+          "range": "bytes=1209-879444"
         },
         "name": "bind-tools",
         "signature": {
-          "checksum": "sha1-3GgaViNXeX4dd75pxgwR8yYgov0=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-VTb0YdUzPMk8Po0p4nj0y5Jey6k=",
+          "range": "bytes=0-693"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bind-tools-9.18.25-r0.apk",
-        "version": "9.18.25-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/bind-tools-9.18.26-r0.apk",
+        "version": "9.18.26-r0"
       },
       {
         "architecture": "x86_64",
@@ -698,41 +698,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1CC3jnItQWZ4ya5EB/TNDLOICnRc=",
+        "checksum": "Q1hgEBBo1tLreSINI2qiCUpUrIE9k=",
         "control": {
-          "checksum": "sha1-CC3jnItQWZ4ya5EB/TNDLOICnRc=",
-          "range": "bytes=701-1140"
+          "checksum": "sha1-hgEBBo1tLreSINI2qiCUpUrIE9k=",
+          "range": "bytes=700-1139"
         },
         "data": {
-          "checksum": "sha256-2EP9UQKOVph+9hElnh20s8ViX126cAnPyNI+IF2pQ4Y=",
-          "range": "bytes=1141-838149"
+          "checksum": "sha256-OFDWkK8l015fs0YvTCXVKLQmOxq+7W5RgJHIqKYZsTE=",
+          "range": "bytes=1140-808582"
         },
         "name": "libcurl-openssl4",
         "signature": {
-          "checksum": "sha1-IxMuIpRYevSLukva0eWmB5RkhMY=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-sygIdNZXB/W8fyOrdelY5RXh3aA=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.7.1-r0.apk",
-        "version": "8.7.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.6.0-r0.apk",
+        "version": "8.6.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1DzKkXRny9JZJvzjFt3jIuvkDP8E=",
+        "checksum": "Q1eQzLI9XN4FM69fm9B4LWd9frcwM=",
         "control": {
-          "checksum": "sha1-DzKkXRny9JZJvzjFt3jIuvkDP8E=",
-          "range": "bytes=700-1101"
+          "checksum": "sha1-eQzLI9XN4FM69fm9B4LWd9frcwM=",
+          "range": "bytes=703-1098"
         },
         "data": {
-          "checksum": "sha256-l1iebyEPmteOEBcPDwPzstpqs9SMvCn8PqlvRU3O7jk=",
-          "range": "bytes=1102-351141"
+          "checksum": "sha256-zkew7+IbyyyENezhlStwO062zaWd+yP/lpbI+CCJVZQ=",
+          "range": "bytes=1099-281166"
         },
         "name": "curl",
         "signature": {
-          "checksum": "sha1-iVKgcLEjgrpj4c2TrRzHznPaWXA=",
-          "range": "bytes=0-699"
+          "checksum": "sha1-igXspQSxo3Eu3o8DeNrYt3YxSbY=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.7.1-r0.apk",
-        "version": "8.7.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.6.0-r0.apk",
+        "version": "8.6.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -755,22 +755,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1uuD6n4YysusfkzW5qMM/q/8Gh5Y=",
+        "checksum": "Q1Wssaf/PtoXUJXozvAY14p7Df8X4=",
         "control": {
-          "checksum": "sha1-uuD6n4YysusfkzW5qMM/q/8Gh5Y=",
-          "range": "bytes=660-996"
+          "checksum": "sha1-Wssaf/PtoXUJXozvAY14p7Df8X4=",
+          "range": "bytes=661-997"
         },
         "data": {
-          "checksum": "sha256-9ta8cYx+vWMxGeyh05UYfrOvpgNUk0FsCINXiOrJ7B0=",
-          "range": "bytes=997-9652657"
+          "checksum": "sha256-XT/JUWP4GdmYqU4pSDJX47G96ltpofLC8CifFIsjY78=",
+          "range": "bytes=998-9624176"
         },
         "name": "redis_exporter",
         "signature": {
-          "checksum": "sha1-LxrtYa7FnTnaZq5n2rCAY5YrSjE=",
-          "range": "bytes=0-659"
+          "checksum": "sha1-1gxRtHgl1TyYKXGFMNWZH0lynK0=",
+          "range": "bytes=0-660"
         },
-        "url": "https://packages.sgdev.org/main/x86_64/redis_exporter-1.35.0-r2.apk",
-        "version": "1.35.0-r2"
+        "url": "https://packages.sgdev.org/main/x86_64/redis_exporter-1.35.0-r3.apk",
+        "version": "1.35.0-r3"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/redis.lock.json
+++ b/wolfi-images/redis.lock.json
@@ -204,60 +204,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q13piSoRiT6p5eziGu2iPxSkXxf+g=",
+        "checksum": "Q1+rBEmKEIywe0o/a65ZPjWoUECRQ=",
         "control": {
-          "checksum": "sha1-3piSoRiT6p5eziGu2iPxSkXxf+g=",
-          "range": "bytes=704-1039"
+          "checksum": "sha1-+rBEmKEIywe0o/a65ZPjWoUECRQ=",
+          "range": "bytes=703-1054"
         },
         "data": {
-          "checksum": "sha256-+iLQJV5/mU/hTpwsy9zYBfzVIVkd8lXBBqMScHFhHfI=",
-          "range": "bytes=1040-87982"
+          "checksum": "sha256-fcShKjtj6wR6kgjwToU1J8hU+AGRf1OGZt9jeXJdM0Q=",
+          "range": "bytes=1055-82406"
         },
         "name": "openssl-config",
         "signature": {
-          "checksum": "sha1-fsygjfZl7YLgdpBZ5OVKJG/N2HI=",
-          "range": "bytes=0-703"
+          "checksum": "sha1-RT/o4gi2oC/l+6IhikP9/PH5awg=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/openssl-config-3.2.1-r0.apk",
-        "version": "3.2.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/openssl-config-3.3.0-r5.apk",
+        "version": "3.3.0-r5"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1kERnIFBBwTWZsA+cmGLkIU75THk=",
+        "checksum": "Q11DkfNRzraQMj7ue8LFH6VN6d7Bo=",
         "control": {
-          "checksum": "sha1-kERnIFBBwTWZsA+cmGLkIU75THk=",
-          "range": "bytes=694-1066"
+          "checksum": "sha1-1DkfNRzraQMj7ue8LFH6VN6d7Bo=",
+          "range": "bytes=707-1092"
         },
         "data": {
-          "checksum": "sha256-MB5ZoAsBJ0Osps0a1V0KsM/qQhfZQvYupElgoF1rNLE=",
-          "range": "bytes=1067-5895270"
+          "checksum": "sha256-c95GJNThldUhfxVSGbchUI0pS4j6h45Yx6JDPXHaAI0=",
+          "range": "bytes=1093-5915048"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-vTJq+p2AjVQQjJ4gSkR9ySDQr3k=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-EmjggcTaE4QTKI1FzSom0rXam1c=",
+          "range": "bytes=0-706"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.2.1-r0.apk",
-        "version": "3.2.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r5.apk",
+        "version": "3.3.0-r5"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1RFDJtvcstAQi4NjU00ApvNIvoEI=",
+        "checksum": "Q15sT5bGF6kgE7DepzZIHCpPpuP70=",
         "control": {
-          "checksum": "sha1-RFDJtvcstAQi4NjU00ApvNIvoEI=",
-          "range": "bytes=694-1065"
+          "checksum": "sha1-5sT5bGF6kgE7DepzZIHCpPpuP70=",
+          "range": "bytes=702-1085"
         },
         "data": {
-          "checksum": "sha256-oocCJOj9IF7jv3Ov8bPbaAGfq6oaYXuPNnZW9DnOdnE=",
-          "range": "bytes=1066-1135402"
+          "checksum": "sha256-fWOAfZYgXO6+yM4Dpo/y7dvV3uxSEhhfO4SUX79TQDw=",
+          "range": "bytes=1086-1196497"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-wJVFcqH/ewopq4lxwz8OYrZ9/Ws=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-4+7eITv9weTmoYBAAyd92WsXS24=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.2.1-r0.apk",
-        "version": "3.2.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r5.apk",
+        "version": "3.3.0-r5"
       },
       {
         "architecture": "x86_64",
@@ -337,22 +337,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1txYNrxLRCA8tpCe/aXw9Zeb30xw=",
+        "checksum": "Q1sGD1MEAazAXpfNixX74EpwafGo0=",
         "control": {
-          "checksum": "sha1-txYNrxLRCA8tpCe/aXw9Zeb30xw=",
-          "range": "bytes=703-1071"
+          "checksum": "sha1-sGD1MEAazAXpfNixX74EpwafGo0=",
+          "range": "bytes=698-1059"
         },
         "data": {
-          "checksum": "sha256-QgGnbFCQGaCUjwfFVcF2eOXDjZHaJjntdJlM1thwxd0=",
-          "range": "bytes=1072-252873"
+          "checksum": "sha256-s+9m0l/R7hVKQ5YLbU90D2E6DPC2QVTxdjhToMi5iYU=",
+          "range": "bytes=1060-251831"
         },
         "name": "libnghttp2-14",
         "signature": {
-          "checksum": "sha1-VWNh1CR9wcBEPwOH88Qr6n7OR08=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-wOIYtvU72n76UGvbargK2ccZx0E=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.60.0-r0.apk",
-        "version": "1.60.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.61.0-r0.apk",
+        "version": "1.61.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -432,41 +432,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1YKX8zXXVrSZ1a+od3zegHGvE7K4=",
+        "checksum": "Q1NZCvjmGBZ7soi6T4endRPtDztk4=",
         "control": {
-          "checksum": "sha1-YKX8zXXVrSZ1a+od3zegHGvE7K4=",
-          "range": "bytes=701-1168"
+          "checksum": "sha1-NZCvjmGBZ7soi6T4endRPtDztk4=",
+          "range": "bytes=698-1162"
         },
         "data": {
-          "checksum": "sha256-KnMN4TtaDNZqReNINaTivjzUoQigGvtRZgVEqc1EDHo=",
-          "range": "bytes=1169-2555088"
+          "checksum": "sha256-q79pSkGvnDzz1dHsQceLPqyVC+cFCyWWJB5L2EfkZRc=",
+          "range": "bytes=1163-2556930"
         },
         "name": "nghttp2",
         "signature": {
-          "checksum": "sha1-MWKiH9LAxjnWqAm536DCFrsZXCg=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-UuOeekThV8UC737772jFTRj0Y50=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.60.0-r0.apk",
-        "version": "1.60.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.61.0-r0.apk",
+        "version": "1.61.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1D/+xxUxpR+m3nGP5l/8Ed78nNC0=",
+        "checksum": "Q1O/sL8Kjkxzh39Ffh9gJl+0olkF4=",
         "control": {
-          "checksum": "sha1-D/+xxUxpR+m3nGP5l/8Ed78nNC0=",
-          "range": "bytes=700-1067"
+          "checksum": "sha1-O/sL8Kjkxzh39Ffh9gJl+0olkF4=",
+          "range": "bytes=700-1061"
         },
         "data": {
-          "checksum": "sha256-fKV2YLH6EP/NFtRSErdaCwZX+Mg6KJrfmt1VpRWeKis=",
-          "range": "bytes=1068-634389"
+          "checksum": "sha256-6qS8u1yYrzO+4Ypa+g4zfz3m16/7O/U4wjiRrKl8/vw=",
+          "range": "bytes=1062-631650"
         },
         "name": "nghttp2-dev",
         "signature": {
-          "checksum": "sha1-ZRWYUK14qaTBE3NC7OOWumdkSyY=",
+          "checksum": "sha1-avAz/6snsG86C9jh8Gxa59gs29U=",
           "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.60.0-r0.apk",
-        "version": "1.60.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.61.0-r0.apk",
+        "version": "1.61.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -508,41 +508,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1l9z4OGVfdVISNbyGQdXlz2GPchM=",
+        "checksum": "Q1wJPtj5XZtnPiVWGM5dsT+nyfWXc=",
         "control": {
-          "checksum": "sha1-l9z4OGVfdVISNbyGQdXlz2GPchM=",
-          "range": "bytes=695-1222"
+          "checksum": "sha1-wJPtj5XZtnPiVWGM5dsT+nyfWXc=",
+          "range": "bytes=705-1234"
         },
         "data": {
-          "checksum": "sha256-0Z+mq/0A1P+F5KIZKnsYpg8Eqb3GDRT7VDrZlTEg+4Y=",
-          "range": "bytes=1223-3863194"
+          "checksum": "sha256-sw+CjlpsjO01q6lqzXgHnniiJKn7bqOSNO6vNqdGc7I=",
+          "range": "bytes=1235-3873775"
         },
         "name": "bind-libs",
         "signature": {
-          "checksum": "sha1-YX2+1oZh/hXHVjZriSnJZQzpifg=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-9zDzmHAeu7mWpidXAatqrLZVzUs=",
+          "range": "bytes=0-704"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bind-libs-9.18.25-r0.apk",
-        "version": "9.18.25-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/bind-libs-9.18.26-r0.apk",
+        "version": "9.18.26-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Xb5w/MUeHFBeLgnHBmG7dqAMxzQ=",
+        "checksum": "Q1AxEQdi8fVcYtGc3zHTCW3OZdY2Q=",
         "control": {
-          "checksum": "sha1-Xb5w/MUeHFBeLgnHBmG7dqAMxzQ=",
-          "range": "bytes=705-1217"
+          "checksum": "sha1-AxEQdi8fVcYtGc3zHTCW3OZdY2Q=",
+          "range": "bytes=694-1208"
         },
         "data": {
-          "checksum": "sha256-/0zOh1KQW58NOuJgauDOdqJA4G4g0p6jPUOP45HN/f8=",
-          "range": "bytes=1218-892798"
+          "checksum": "sha256-/dt3qJw5D9iSJ/mKkRQkhWD8R52selhpcwXyw7KLMhg=",
+          "range": "bytes=1209-879444"
         },
         "name": "bind-tools",
         "signature": {
-          "checksum": "sha1-3GgaViNXeX4dd75pxgwR8yYgov0=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-VTb0YdUzPMk8Po0p4nj0y5Jey6k=",
+          "range": "bytes=0-693"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bind-tools-9.18.25-r0.apk",
-        "version": "9.18.25-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/bind-tools-9.18.26-r0.apk",
+        "version": "9.18.26-r0"
       },
       {
         "architecture": "x86_64",
@@ -698,41 +698,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1CC3jnItQWZ4ya5EB/TNDLOICnRc=",
+        "checksum": "Q1hgEBBo1tLreSINI2qiCUpUrIE9k=",
         "control": {
-          "checksum": "sha1-CC3jnItQWZ4ya5EB/TNDLOICnRc=",
-          "range": "bytes=701-1140"
+          "checksum": "sha1-hgEBBo1tLreSINI2qiCUpUrIE9k=",
+          "range": "bytes=700-1139"
         },
         "data": {
-          "checksum": "sha256-2EP9UQKOVph+9hElnh20s8ViX126cAnPyNI+IF2pQ4Y=",
-          "range": "bytes=1141-838149"
+          "checksum": "sha256-OFDWkK8l015fs0YvTCXVKLQmOxq+7W5RgJHIqKYZsTE=",
+          "range": "bytes=1140-808582"
         },
         "name": "libcurl-openssl4",
         "signature": {
-          "checksum": "sha1-IxMuIpRYevSLukva0eWmB5RkhMY=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-sygIdNZXB/W8fyOrdelY5RXh3aA=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.7.1-r0.apk",
-        "version": "8.7.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.6.0-r0.apk",
+        "version": "8.6.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1DzKkXRny9JZJvzjFt3jIuvkDP8E=",
+        "checksum": "Q1eQzLI9XN4FM69fm9B4LWd9frcwM=",
         "control": {
-          "checksum": "sha1-DzKkXRny9JZJvzjFt3jIuvkDP8E=",
-          "range": "bytes=700-1101"
+          "checksum": "sha1-eQzLI9XN4FM69fm9B4LWd9frcwM=",
+          "range": "bytes=703-1098"
         },
         "data": {
-          "checksum": "sha256-l1iebyEPmteOEBcPDwPzstpqs9SMvCn8PqlvRU3O7jk=",
-          "range": "bytes=1102-351141"
+          "checksum": "sha256-zkew7+IbyyyENezhlStwO062zaWd+yP/lpbI+CCJVZQ=",
+          "range": "bytes=1099-281166"
         },
         "name": "curl",
         "signature": {
-          "checksum": "sha1-iVKgcLEjgrpj4c2TrRzHznPaWXA=",
-          "range": "bytes=0-699"
+          "checksum": "sha1-igXspQSxo3Eu3o8DeNrYt3YxSbY=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.7.1-r0.apk",
-        "version": "8.7.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.6.0-r0.apk",
+        "version": "8.6.0-r0"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/repo-updater.lock.json
+++ b/wolfi-images/repo-updater.lock.json
@@ -204,60 +204,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q13piSoRiT6p5eziGu2iPxSkXxf+g=",
+        "checksum": "Q1+rBEmKEIywe0o/a65ZPjWoUECRQ=",
         "control": {
-          "checksum": "sha1-3piSoRiT6p5eziGu2iPxSkXxf+g=",
-          "range": "bytes=704-1039"
+          "checksum": "sha1-+rBEmKEIywe0o/a65ZPjWoUECRQ=",
+          "range": "bytes=703-1054"
         },
         "data": {
-          "checksum": "sha256-+iLQJV5/mU/hTpwsy9zYBfzVIVkd8lXBBqMScHFhHfI=",
-          "range": "bytes=1040-87982"
+          "checksum": "sha256-fcShKjtj6wR6kgjwToU1J8hU+AGRf1OGZt9jeXJdM0Q=",
+          "range": "bytes=1055-82406"
         },
         "name": "openssl-config",
         "signature": {
-          "checksum": "sha1-fsygjfZl7YLgdpBZ5OVKJG/N2HI=",
-          "range": "bytes=0-703"
+          "checksum": "sha1-RT/o4gi2oC/l+6IhikP9/PH5awg=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/openssl-config-3.2.1-r0.apk",
-        "version": "3.2.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/openssl-config-3.3.0-r5.apk",
+        "version": "3.3.0-r5"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1kERnIFBBwTWZsA+cmGLkIU75THk=",
+        "checksum": "Q11DkfNRzraQMj7ue8LFH6VN6d7Bo=",
         "control": {
-          "checksum": "sha1-kERnIFBBwTWZsA+cmGLkIU75THk=",
-          "range": "bytes=694-1066"
+          "checksum": "sha1-1DkfNRzraQMj7ue8LFH6VN6d7Bo=",
+          "range": "bytes=707-1092"
         },
         "data": {
-          "checksum": "sha256-MB5ZoAsBJ0Osps0a1V0KsM/qQhfZQvYupElgoF1rNLE=",
-          "range": "bytes=1067-5895270"
+          "checksum": "sha256-c95GJNThldUhfxVSGbchUI0pS4j6h45Yx6JDPXHaAI0=",
+          "range": "bytes=1093-5915048"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-vTJq+p2AjVQQjJ4gSkR9ySDQr3k=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-EmjggcTaE4QTKI1FzSom0rXam1c=",
+          "range": "bytes=0-706"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.2.1-r0.apk",
-        "version": "3.2.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r5.apk",
+        "version": "3.3.0-r5"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1RFDJtvcstAQi4NjU00ApvNIvoEI=",
+        "checksum": "Q15sT5bGF6kgE7DepzZIHCpPpuP70=",
         "control": {
-          "checksum": "sha1-RFDJtvcstAQi4NjU00ApvNIvoEI=",
-          "range": "bytes=694-1065"
+          "checksum": "sha1-5sT5bGF6kgE7DepzZIHCpPpuP70=",
+          "range": "bytes=702-1085"
         },
         "data": {
-          "checksum": "sha256-oocCJOj9IF7jv3Ov8bPbaAGfq6oaYXuPNnZW9DnOdnE=",
-          "range": "bytes=1066-1135402"
+          "checksum": "sha256-fWOAfZYgXO6+yM4Dpo/y7dvV3uxSEhhfO4SUX79TQDw=",
+          "range": "bytes=1086-1196497"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-wJVFcqH/ewopq4lxwz8OYrZ9/Ws=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-4+7eITv9weTmoYBAAyd92WsXS24=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.2.1-r0.apk",
-        "version": "3.2.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r5.apk",
+        "version": "3.3.0-r5"
       },
       {
         "architecture": "x86_64",
@@ -337,22 +337,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1txYNrxLRCA8tpCe/aXw9Zeb30xw=",
+        "checksum": "Q1sGD1MEAazAXpfNixX74EpwafGo0=",
         "control": {
-          "checksum": "sha1-txYNrxLRCA8tpCe/aXw9Zeb30xw=",
-          "range": "bytes=703-1071"
+          "checksum": "sha1-sGD1MEAazAXpfNixX74EpwafGo0=",
+          "range": "bytes=698-1059"
         },
         "data": {
-          "checksum": "sha256-QgGnbFCQGaCUjwfFVcF2eOXDjZHaJjntdJlM1thwxd0=",
-          "range": "bytes=1072-252873"
+          "checksum": "sha256-s+9m0l/R7hVKQ5YLbU90D2E6DPC2QVTxdjhToMi5iYU=",
+          "range": "bytes=1060-251831"
         },
         "name": "libnghttp2-14",
         "signature": {
-          "checksum": "sha1-VWNh1CR9wcBEPwOH88Qr6n7OR08=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-wOIYtvU72n76UGvbargK2ccZx0E=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.60.0-r0.apk",
-        "version": "1.60.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.61.0-r0.apk",
+        "version": "1.61.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -432,41 +432,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1YKX8zXXVrSZ1a+od3zegHGvE7K4=",
+        "checksum": "Q1NZCvjmGBZ7soi6T4endRPtDztk4=",
         "control": {
-          "checksum": "sha1-YKX8zXXVrSZ1a+od3zegHGvE7K4=",
-          "range": "bytes=701-1168"
+          "checksum": "sha1-NZCvjmGBZ7soi6T4endRPtDztk4=",
+          "range": "bytes=698-1162"
         },
         "data": {
-          "checksum": "sha256-KnMN4TtaDNZqReNINaTivjzUoQigGvtRZgVEqc1EDHo=",
-          "range": "bytes=1169-2555088"
+          "checksum": "sha256-q79pSkGvnDzz1dHsQceLPqyVC+cFCyWWJB5L2EfkZRc=",
+          "range": "bytes=1163-2556930"
         },
         "name": "nghttp2",
         "signature": {
-          "checksum": "sha1-MWKiH9LAxjnWqAm536DCFrsZXCg=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-UuOeekThV8UC737772jFTRj0Y50=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.60.0-r0.apk",
-        "version": "1.60.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.61.0-r0.apk",
+        "version": "1.61.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1D/+xxUxpR+m3nGP5l/8Ed78nNC0=",
+        "checksum": "Q1O/sL8Kjkxzh39Ffh9gJl+0olkF4=",
         "control": {
-          "checksum": "sha1-D/+xxUxpR+m3nGP5l/8Ed78nNC0=",
-          "range": "bytes=700-1067"
+          "checksum": "sha1-O/sL8Kjkxzh39Ffh9gJl+0olkF4=",
+          "range": "bytes=700-1061"
         },
         "data": {
-          "checksum": "sha256-fKV2YLH6EP/NFtRSErdaCwZX+Mg6KJrfmt1VpRWeKis=",
-          "range": "bytes=1068-634389"
+          "checksum": "sha256-6qS8u1yYrzO+4Ypa+g4zfz3m16/7O/U4wjiRrKl8/vw=",
+          "range": "bytes=1062-631650"
         },
         "name": "nghttp2-dev",
         "signature": {
-          "checksum": "sha1-ZRWYUK14qaTBE3NC7OOWumdkSyY=",
+          "checksum": "sha1-avAz/6snsG86C9jh8Gxa59gs29U=",
           "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.60.0-r0.apk",
-        "version": "1.60.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.61.0-r0.apk",
+        "version": "1.61.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -508,41 +508,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1l9z4OGVfdVISNbyGQdXlz2GPchM=",
+        "checksum": "Q1wJPtj5XZtnPiVWGM5dsT+nyfWXc=",
         "control": {
-          "checksum": "sha1-l9z4OGVfdVISNbyGQdXlz2GPchM=",
-          "range": "bytes=695-1222"
+          "checksum": "sha1-wJPtj5XZtnPiVWGM5dsT+nyfWXc=",
+          "range": "bytes=705-1234"
         },
         "data": {
-          "checksum": "sha256-0Z+mq/0A1P+F5KIZKnsYpg8Eqb3GDRT7VDrZlTEg+4Y=",
-          "range": "bytes=1223-3863194"
+          "checksum": "sha256-sw+CjlpsjO01q6lqzXgHnniiJKn7bqOSNO6vNqdGc7I=",
+          "range": "bytes=1235-3873775"
         },
         "name": "bind-libs",
         "signature": {
-          "checksum": "sha1-YX2+1oZh/hXHVjZriSnJZQzpifg=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-9zDzmHAeu7mWpidXAatqrLZVzUs=",
+          "range": "bytes=0-704"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bind-libs-9.18.25-r0.apk",
-        "version": "9.18.25-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/bind-libs-9.18.26-r0.apk",
+        "version": "9.18.26-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Xb5w/MUeHFBeLgnHBmG7dqAMxzQ=",
+        "checksum": "Q1AxEQdi8fVcYtGc3zHTCW3OZdY2Q=",
         "control": {
-          "checksum": "sha1-Xb5w/MUeHFBeLgnHBmG7dqAMxzQ=",
-          "range": "bytes=705-1217"
+          "checksum": "sha1-AxEQdi8fVcYtGc3zHTCW3OZdY2Q=",
+          "range": "bytes=694-1208"
         },
         "data": {
-          "checksum": "sha256-/0zOh1KQW58NOuJgauDOdqJA4G4g0p6jPUOP45HN/f8=",
-          "range": "bytes=1218-892798"
+          "checksum": "sha256-/dt3qJw5D9iSJ/mKkRQkhWD8R52selhpcwXyw7KLMhg=",
+          "range": "bytes=1209-879444"
         },
         "name": "bind-tools",
         "signature": {
-          "checksum": "sha1-3GgaViNXeX4dd75pxgwR8yYgov0=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-VTb0YdUzPMk8Po0p4nj0y5Jey6k=",
+          "range": "bytes=0-693"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bind-tools-9.18.25-r0.apk",
-        "version": "9.18.25-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/bind-tools-9.18.26-r0.apk",
+        "version": "9.18.26-r0"
       },
       {
         "architecture": "x86_64",
@@ -603,22 +603,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q18DXOCGQccaBV9A5r/surTzWqW/o=",
+        "checksum": "Q1L9rArzLWlXjTBTMt4R4rKPLw2qo=",
         "control": {
-          "checksum": "sha1-8DXOCGQccaBV9A5r/surTzWqW/o=",
-          "range": "bytes=657-1007"
+          "checksum": "sha1-L9rArzLWlXjTBTMt4R4rKPLw2qo=",
+          "range": "bytes=660-1009"
         },
         "data": {
-          "checksum": "sha256-e1xbeh3L6Li3xcK1EO3/rWIFrGyxqNG9G651Qi/oiUk=",
-          "range": "bytes=1008-59687101"
+          "checksum": "sha256-zaAqDv39QN1OwYSWZY5ILzlTqUmpVTE8lBBSsKRO/AU=",
+          "range": "bytes=1010-59654512"
         },
         "name": "coursier",
         "signature": {
-          "checksum": "sha1-OvNg0xO/vjOWr45Urdbfa7ExS+U=",
-          "range": "bytes=0-656"
+          "checksum": "sha1-qlZ+I72V1IIyjsqJpeKaaTMfSQc=",
+          "range": "bytes=0-659"
         },
-        "url": "https://packages.sgdev.org/main/x86_64/coursier-2.0.13-r2.apk",
-        "version": "2.0.13-r2"
+        "url": "https://packages.sgdev.org/main/x86_64/coursier-2.0.13-r3.apk",
+        "version": "2.0.13-r3"
       },
       {
         "architecture": "x86_64",
@@ -717,41 +717,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1CC3jnItQWZ4ya5EB/TNDLOICnRc=",
+        "checksum": "Q1hgEBBo1tLreSINI2qiCUpUrIE9k=",
         "control": {
-          "checksum": "sha1-CC3jnItQWZ4ya5EB/TNDLOICnRc=",
-          "range": "bytes=701-1140"
+          "checksum": "sha1-hgEBBo1tLreSINI2qiCUpUrIE9k=",
+          "range": "bytes=700-1139"
         },
         "data": {
-          "checksum": "sha256-2EP9UQKOVph+9hElnh20s8ViX126cAnPyNI+IF2pQ4Y=",
-          "range": "bytes=1141-838149"
+          "checksum": "sha256-OFDWkK8l015fs0YvTCXVKLQmOxq+7W5RgJHIqKYZsTE=",
+          "range": "bytes=1140-808582"
         },
         "name": "libcurl-openssl4",
         "signature": {
-          "checksum": "sha1-IxMuIpRYevSLukva0eWmB5RkhMY=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-sygIdNZXB/W8fyOrdelY5RXh3aA=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.7.1-r0.apk",
-        "version": "8.7.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.6.0-r0.apk",
+        "version": "8.6.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1DzKkXRny9JZJvzjFt3jIuvkDP8E=",
+        "checksum": "Q1eQzLI9XN4FM69fm9B4LWd9frcwM=",
         "control": {
-          "checksum": "sha1-DzKkXRny9JZJvzjFt3jIuvkDP8E=",
-          "range": "bytes=700-1101"
+          "checksum": "sha1-eQzLI9XN4FM69fm9B4LWd9frcwM=",
+          "range": "bytes=703-1098"
         },
         "data": {
-          "checksum": "sha256-l1iebyEPmteOEBcPDwPzstpqs9SMvCn8PqlvRU3O7jk=",
-          "range": "bytes=1102-351141"
+          "checksum": "sha256-zkew7+IbyyyENezhlStwO062zaWd+yP/lpbI+CCJVZQ=",
+          "range": "bytes=1099-281166"
         },
         "name": "curl",
         "signature": {
-          "checksum": "sha1-iVKgcLEjgrpj4c2TrRzHznPaWXA=",
-          "range": "bytes=0-699"
+          "checksum": "sha1-igXspQSxo3Eu3o8DeNrYt3YxSbY=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.7.1-r0.apk",
-        "version": "8.7.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.6.0-r0.apk",
+        "version": "8.6.0-r0"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/search-indexer.lock.json
+++ b/wolfi-images/search-indexer.lock.json
@@ -204,60 +204,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q13piSoRiT6p5eziGu2iPxSkXxf+g=",
+        "checksum": "Q1+rBEmKEIywe0o/a65ZPjWoUECRQ=",
         "control": {
-          "checksum": "sha1-3piSoRiT6p5eziGu2iPxSkXxf+g=",
-          "range": "bytes=704-1039"
+          "checksum": "sha1-+rBEmKEIywe0o/a65ZPjWoUECRQ=",
+          "range": "bytes=703-1054"
         },
         "data": {
-          "checksum": "sha256-+iLQJV5/mU/hTpwsy9zYBfzVIVkd8lXBBqMScHFhHfI=",
-          "range": "bytes=1040-87982"
+          "checksum": "sha256-fcShKjtj6wR6kgjwToU1J8hU+AGRf1OGZt9jeXJdM0Q=",
+          "range": "bytes=1055-82406"
         },
         "name": "openssl-config",
         "signature": {
-          "checksum": "sha1-fsygjfZl7YLgdpBZ5OVKJG/N2HI=",
-          "range": "bytes=0-703"
+          "checksum": "sha1-RT/o4gi2oC/l+6IhikP9/PH5awg=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/openssl-config-3.2.1-r0.apk",
-        "version": "3.2.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/openssl-config-3.3.0-r5.apk",
+        "version": "3.3.0-r5"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1kERnIFBBwTWZsA+cmGLkIU75THk=",
+        "checksum": "Q11DkfNRzraQMj7ue8LFH6VN6d7Bo=",
         "control": {
-          "checksum": "sha1-kERnIFBBwTWZsA+cmGLkIU75THk=",
-          "range": "bytes=694-1066"
+          "checksum": "sha1-1DkfNRzraQMj7ue8LFH6VN6d7Bo=",
+          "range": "bytes=707-1092"
         },
         "data": {
-          "checksum": "sha256-MB5ZoAsBJ0Osps0a1V0KsM/qQhfZQvYupElgoF1rNLE=",
-          "range": "bytes=1067-5895270"
+          "checksum": "sha256-c95GJNThldUhfxVSGbchUI0pS4j6h45Yx6JDPXHaAI0=",
+          "range": "bytes=1093-5915048"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-vTJq+p2AjVQQjJ4gSkR9ySDQr3k=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-EmjggcTaE4QTKI1FzSom0rXam1c=",
+          "range": "bytes=0-706"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.2.1-r0.apk",
-        "version": "3.2.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r5.apk",
+        "version": "3.3.0-r5"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1RFDJtvcstAQi4NjU00ApvNIvoEI=",
+        "checksum": "Q15sT5bGF6kgE7DepzZIHCpPpuP70=",
         "control": {
-          "checksum": "sha1-RFDJtvcstAQi4NjU00ApvNIvoEI=",
-          "range": "bytes=694-1065"
+          "checksum": "sha1-5sT5bGF6kgE7DepzZIHCpPpuP70=",
+          "range": "bytes=702-1085"
         },
         "data": {
-          "checksum": "sha256-oocCJOj9IF7jv3Ov8bPbaAGfq6oaYXuPNnZW9DnOdnE=",
-          "range": "bytes=1066-1135402"
+          "checksum": "sha256-fWOAfZYgXO6+yM4Dpo/y7dvV3uxSEhhfO4SUX79TQDw=",
+          "range": "bytes=1086-1196497"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-wJVFcqH/ewopq4lxwz8OYrZ9/Ws=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-4+7eITv9weTmoYBAAyd92WsXS24=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.2.1-r0.apk",
-        "version": "3.2.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r5.apk",
+        "version": "3.3.0-r5"
       },
       {
         "architecture": "x86_64",
@@ -337,22 +337,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1txYNrxLRCA8tpCe/aXw9Zeb30xw=",
+        "checksum": "Q1sGD1MEAazAXpfNixX74EpwafGo0=",
         "control": {
-          "checksum": "sha1-txYNrxLRCA8tpCe/aXw9Zeb30xw=",
-          "range": "bytes=703-1071"
+          "checksum": "sha1-sGD1MEAazAXpfNixX74EpwafGo0=",
+          "range": "bytes=698-1059"
         },
         "data": {
-          "checksum": "sha256-QgGnbFCQGaCUjwfFVcF2eOXDjZHaJjntdJlM1thwxd0=",
-          "range": "bytes=1072-252873"
+          "checksum": "sha256-s+9m0l/R7hVKQ5YLbU90D2E6DPC2QVTxdjhToMi5iYU=",
+          "range": "bytes=1060-251831"
         },
         "name": "libnghttp2-14",
         "signature": {
-          "checksum": "sha1-VWNh1CR9wcBEPwOH88Qr6n7OR08=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-wOIYtvU72n76UGvbargK2ccZx0E=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.60.0-r0.apk",
-        "version": "1.60.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.61.0-r0.apk",
+        "version": "1.61.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -432,41 +432,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1YKX8zXXVrSZ1a+od3zegHGvE7K4=",
+        "checksum": "Q1NZCvjmGBZ7soi6T4endRPtDztk4=",
         "control": {
-          "checksum": "sha1-YKX8zXXVrSZ1a+od3zegHGvE7K4=",
-          "range": "bytes=701-1168"
+          "checksum": "sha1-NZCvjmGBZ7soi6T4endRPtDztk4=",
+          "range": "bytes=698-1162"
         },
         "data": {
-          "checksum": "sha256-KnMN4TtaDNZqReNINaTivjzUoQigGvtRZgVEqc1EDHo=",
-          "range": "bytes=1169-2555088"
+          "checksum": "sha256-q79pSkGvnDzz1dHsQceLPqyVC+cFCyWWJB5L2EfkZRc=",
+          "range": "bytes=1163-2556930"
         },
         "name": "nghttp2",
         "signature": {
-          "checksum": "sha1-MWKiH9LAxjnWqAm536DCFrsZXCg=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-UuOeekThV8UC737772jFTRj0Y50=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.60.0-r0.apk",
-        "version": "1.60.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.61.0-r0.apk",
+        "version": "1.61.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1D/+xxUxpR+m3nGP5l/8Ed78nNC0=",
+        "checksum": "Q1O/sL8Kjkxzh39Ffh9gJl+0olkF4=",
         "control": {
-          "checksum": "sha1-D/+xxUxpR+m3nGP5l/8Ed78nNC0=",
-          "range": "bytes=700-1067"
+          "checksum": "sha1-O/sL8Kjkxzh39Ffh9gJl+0olkF4=",
+          "range": "bytes=700-1061"
         },
         "data": {
-          "checksum": "sha256-fKV2YLH6EP/NFtRSErdaCwZX+Mg6KJrfmt1VpRWeKis=",
-          "range": "bytes=1068-634389"
+          "checksum": "sha256-6qS8u1yYrzO+4Ypa+g4zfz3m16/7O/U4wjiRrKl8/vw=",
+          "range": "bytes=1062-631650"
         },
         "name": "nghttp2-dev",
         "signature": {
-          "checksum": "sha1-ZRWYUK14qaTBE3NC7OOWumdkSyY=",
+          "checksum": "sha1-avAz/6snsG86C9jh8Gxa59gs29U=",
           "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.60.0-r0.apk",
-        "version": "1.60.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.61.0-r0.apk",
+        "version": "1.61.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -508,41 +508,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1l9z4OGVfdVISNbyGQdXlz2GPchM=",
+        "checksum": "Q1wJPtj5XZtnPiVWGM5dsT+nyfWXc=",
         "control": {
-          "checksum": "sha1-l9z4OGVfdVISNbyGQdXlz2GPchM=",
-          "range": "bytes=695-1222"
+          "checksum": "sha1-wJPtj5XZtnPiVWGM5dsT+nyfWXc=",
+          "range": "bytes=705-1234"
         },
         "data": {
-          "checksum": "sha256-0Z+mq/0A1P+F5KIZKnsYpg8Eqb3GDRT7VDrZlTEg+4Y=",
-          "range": "bytes=1223-3863194"
+          "checksum": "sha256-sw+CjlpsjO01q6lqzXgHnniiJKn7bqOSNO6vNqdGc7I=",
+          "range": "bytes=1235-3873775"
         },
         "name": "bind-libs",
         "signature": {
-          "checksum": "sha1-YX2+1oZh/hXHVjZriSnJZQzpifg=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-9zDzmHAeu7mWpidXAatqrLZVzUs=",
+          "range": "bytes=0-704"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bind-libs-9.18.25-r0.apk",
-        "version": "9.18.25-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/bind-libs-9.18.26-r0.apk",
+        "version": "9.18.26-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Xb5w/MUeHFBeLgnHBmG7dqAMxzQ=",
+        "checksum": "Q1AxEQdi8fVcYtGc3zHTCW3OZdY2Q=",
         "control": {
-          "checksum": "sha1-Xb5w/MUeHFBeLgnHBmG7dqAMxzQ=",
-          "range": "bytes=705-1217"
+          "checksum": "sha1-AxEQdi8fVcYtGc3zHTCW3OZdY2Q=",
+          "range": "bytes=694-1208"
         },
         "data": {
-          "checksum": "sha256-/0zOh1KQW58NOuJgauDOdqJA4G4g0p6jPUOP45HN/f8=",
-          "range": "bytes=1218-892798"
+          "checksum": "sha256-/dt3qJw5D9iSJ/mKkRQkhWD8R52selhpcwXyw7KLMhg=",
+          "range": "bytes=1209-879444"
         },
         "name": "bind-tools",
         "signature": {
-          "checksum": "sha1-3GgaViNXeX4dd75pxgwR8yYgov0=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-VTb0YdUzPMk8Po0p4nj0y5Jey6k=",
+          "range": "bytes=0-693"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bind-tools-9.18.25-r0.apk",
-        "version": "9.18.25-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/bind-tools-9.18.26-r0.apk",
+        "version": "9.18.26-r0"
       },
       {
         "architecture": "x86_64",
@@ -622,22 +622,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1dGFbiBgyu1lUt4vBNm7r2mESS28=",
+        "checksum": "Q168tjKa9EJjh47h3gyGn4ThsOI0Y=",
         "control": {
-          "checksum": "sha1-dGFbiBgyu1lUt4vBNm7r2mESS28=",
-          "range": "bytes=662-1025"
+          "checksum": "sha1-68tjKa9EJjh47h3gyGn4ThsOI0Y=",
+          "range": "bytes=661-1023"
         },
         "data": {
-          "checksum": "sha256-LAD/RnKpyL0sWf9jJmOCehGrx1YOb6BQHtDz0Fz6fSI=",
-          "range": "bytes=1026-3654982"
+          "checksum": "sha256-w6qWTXBItkDiwjv1e03YFmm1yN4SmchoRth3p8a6Jno=",
+          "range": "bytes=1024-3626526"
         },
         "name": "ctags",
         "signature": {
-          "checksum": "sha1-o2j+eAV5drdyb1ohr7/+204Y4DQ=",
-          "range": "bytes=0-661"
+          "checksum": "sha1-2gi15ZhMJMoqzWB1KcbB1eZnX1w=",
+          "range": "bytes=0-660"
         },
-        "url": "https://packages.sgdev.org/main/x86_64/ctags-6.0.0-r4.apk",
-        "version": "6.0.0-r4"
+        "url": "https://packages.sgdev.org/main/x86_64/ctags-6.0.0-r6.apk",
+        "version": "6.0.0-r6"
       },
       {
         "architecture": "x86_64",
@@ -736,41 +736,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1CC3jnItQWZ4ya5EB/TNDLOICnRc=",
+        "checksum": "Q1hgEBBo1tLreSINI2qiCUpUrIE9k=",
         "control": {
-          "checksum": "sha1-CC3jnItQWZ4ya5EB/TNDLOICnRc=",
-          "range": "bytes=701-1140"
+          "checksum": "sha1-hgEBBo1tLreSINI2qiCUpUrIE9k=",
+          "range": "bytes=700-1139"
         },
         "data": {
-          "checksum": "sha256-2EP9UQKOVph+9hElnh20s8ViX126cAnPyNI+IF2pQ4Y=",
-          "range": "bytes=1141-838149"
+          "checksum": "sha256-OFDWkK8l015fs0YvTCXVKLQmOxq+7W5RgJHIqKYZsTE=",
+          "range": "bytes=1140-808582"
         },
         "name": "libcurl-openssl4",
         "signature": {
-          "checksum": "sha1-IxMuIpRYevSLukva0eWmB5RkhMY=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-sygIdNZXB/W8fyOrdelY5RXh3aA=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.7.1-r0.apk",
-        "version": "8.7.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.6.0-r0.apk",
+        "version": "8.6.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1DzKkXRny9JZJvzjFt3jIuvkDP8E=",
+        "checksum": "Q1eQzLI9XN4FM69fm9B4LWd9frcwM=",
         "control": {
-          "checksum": "sha1-DzKkXRny9JZJvzjFt3jIuvkDP8E=",
-          "range": "bytes=700-1101"
+          "checksum": "sha1-eQzLI9XN4FM69fm9B4LWd9frcwM=",
+          "range": "bytes=703-1098"
         },
         "data": {
-          "checksum": "sha256-l1iebyEPmteOEBcPDwPzstpqs9SMvCn8PqlvRU3O7jk=",
-          "range": "bytes=1102-351141"
+          "checksum": "sha256-zkew7+IbyyyENezhlStwO062zaWd+yP/lpbI+CCJVZQ=",
+          "range": "bytes=1099-281166"
         },
         "name": "curl",
         "signature": {
-          "checksum": "sha1-iVKgcLEjgrpj4c2TrRzHznPaWXA=",
-          "range": "bytes=0-699"
+          "checksum": "sha1-igXspQSxo3Eu3o8DeNrYt3YxSbY=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.7.1-r0.apk",
-        "version": "8.7.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.6.0-r0.apk",
+        "version": "8.6.0-r0"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/searcher.lock.json
+++ b/wolfi-images/searcher.lock.json
@@ -204,60 +204,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q13piSoRiT6p5eziGu2iPxSkXxf+g=",
+        "checksum": "Q1+rBEmKEIywe0o/a65ZPjWoUECRQ=",
         "control": {
-          "checksum": "sha1-3piSoRiT6p5eziGu2iPxSkXxf+g=",
-          "range": "bytes=704-1039"
+          "checksum": "sha1-+rBEmKEIywe0o/a65ZPjWoUECRQ=",
+          "range": "bytes=703-1054"
         },
         "data": {
-          "checksum": "sha256-+iLQJV5/mU/hTpwsy9zYBfzVIVkd8lXBBqMScHFhHfI=",
-          "range": "bytes=1040-87982"
+          "checksum": "sha256-fcShKjtj6wR6kgjwToU1J8hU+AGRf1OGZt9jeXJdM0Q=",
+          "range": "bytes=1055-82406"
         },
         "name": "openssl-config",
         "signature": {
-          "checksum": "sha1-fsygjfZl7YLgdpBZ5OVKJG/N2HI=",
-          "range": "bytes=0-703"
+          "checksum": "sha1-RT/o4gi2oC/l+6IhikP9/PH5awg=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/openssl-config-3.2.1-r0.apk",
-        "version": "3.2.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/openssl-config-3.3.0-r5.apk",
+        "version": "3.3.0-r5"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1kERnIFBBwTWZsA+cmGLkIU75THk=",
+        "checksum": "Q11DkfNRzraQMj7ue8LFH6VN6d7Bo=",
         "control": {
-          "checksum": "sha1-kERnIFBBwTWZsA+cmGLkIU75THk=",
-          "range": "bytes=694-1066"
+          "checksum": "sha1-1DkfNRzraQMj7ue8LFH6VN6d7Bo=",
+          "range": "bytes=707-1092"
         },
         "data": {
-          "checksum": "sha256-MB5ZoAsBJ0Osps0a1V0KsM/qQhfZQvYupElgoF1rNLE=",
-          "range": "bytes=1067-5895270"
+          "checksum": "sha256-c95GJNThldUhfxVSGbchUI0pS4j6h45Yx6JDPXHaAI0=",
+          "range": "bytes=1093-5915048"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-vTJq+p2AjVQQjJ4gSkR9ySDQr3k=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-EmjggcTaE4QTKI1FzSom0rXam1c=",
+          "range": "bytes=0-706"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.2.1-r0.apk",
-        "version": "3.2.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r5.apk",
+        "version": "3.3.0-r5"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1RFDJtvcstAQi4NjU00ApvNIvoEI=",
+        "checksum": "Q15sT5bGF6kgE7DepzZIHCpPpuP70=",
         "control": {
-          "checksum": "sha1-RFDJtvcstAQi4NjU00ApvNIvoEI=",
-          "range": "bytes=694-1065"
+          "checksum": "sha1-5sT5bGF6kgE7DepzZIHCpPpuP70=",
+          "range": "bytes=702-1085"
         },
         "data": {
-          "checksum": "sha256-oocCJOj9IF7jv3Ov8bPbaAGfq6oaYXuPNnZW9DnOdnE=",
-          "range": "bytes=1066-1135402"
+          "checksum": "sha256-fWOAfZYgXO6+yM4Dpo/y7dvV3uxSEhhfO4SUX79TQDw=",
+          "range": "bytes=1086-1196497"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-wJVFcqH/ewopq4lxwz8OYrZ9/Ws=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-4+7eITv9weTmoYBAAyd92WsXS24=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.2.1-r0.apk",
-        "version": "3.2.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r5.apk",
+        "version": "3.3.0-r5"
       },
       {
         "architecture": "x86_64",
@@ -337,22 +337,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1txYNrxLRCA8tpCe/aXw9Zeb30xw=",
+        "checksum": "Q1sGD1MEAazAXpfNixX74EpwafGo0=",
         "control": {
-          "checksum": "sha1-txYNrxLRCA8tpCe/aXw9Zeb30xw=",
-          "range": "bytes=703-1071"
+          "checksum": "sha1-sGD1MEAazAXpfNixX74EpwafGo0=",
+          "range": "bytes=698-1059"
         },
         "data": {
-          "checksum": "sha256-QgGnbFCQGaCUjwfFVcF2eOXDjZHaJjntdJlM1thwxd0=",
-          "range": "bytes=1072-252873"
+          "checksum": "sha256-s+9m0l/R7hVKQ5YLbU90D2E6DPC2QVTxdjhToMi5iYU=",
+          "range": "bytes=1060-251831"
         },
         "name": "libnghttp2-14",
         "signature": {
-          "checksum": "sha1-VWNh1CR9wcBEPwOH88Qr6n7OR08=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-wOIYtvU72n76UGvbargK2ccZx0E=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.60.0-r0.apk",
-        "version": "1.60.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.61.0-r0.apk",
+        "version": "1.61.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -432,41 +432,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1YKX8zXXVrSZ1a+od3zegHGvE7K4=",
+        "checksum": "Q1NZCvjmGBZ7soi6T4endRPtDztk4=",
         "control": {
-          "checksum": "sha1-YKX8zXXVrSZ1a+od3zegHGvE7K4=",
-          "range": "bytes=701-1168"
+          "checksum": "sha1-NZCvjmGBZ7soi6T4endRPtDztk4=",
+          "range": "bytes=698-1162"
         },
         "data": {
-          "checksum": "sha256-KnMN4TtaDNZqReNINaTivjzUoQigGvtRZgVEqc1EDHo=",
-          "range": "bytes=1169-2555088"
+          "checksum": "sha256-q79pSkGvnDzz1dHsQceLPqyVC+cFCyWWJB5L2EfkZRc=",
+          "range": "bytes=1163-2556930"
         },
         "name": "nghttp2",
         "signature": {
-          "checksum": "sha1-MWKiH9LAxjnWqAm536DCFrsZXCg=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-UuOeekThV8UC737772jFTRj0Y50=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.60.0-r0.apk",
-        "version": "1.60.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.61.0-r0.apk",
+        "version": "1.61.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1D/+xxUxpR+m3nGP5l/8Ed78nNC0=",
+        "checksum": "Q1O/sL8Kjkxzh39Ffh9gJl+0olkF4=",
         "control": {
-          "checksum": "sha1-D/+xxUxpR+m3nGP5l/8Ed78nNC0=",
-          "range": "bytes=700-1067"
+          "checksum": "sha1-O/sL8Kjkxzh39Ffh9gJl+0olkF4=",
+          "range": "bytes=700-1061"
         },
         "data": {
-          "checksum": "sha256-fKV2YLH6EP/NFtRSErdaCwZX+Mg6KJrfmt1VpRWeKis=",
-          "range": "bytes=1068-634389"
+          "checksum": "sha256-6qS8u1yYrzO+4Ypa+g4zfz3m16/7O/U4wjiRrKl8/vw=",
+          "range": "bytes=1062-631650"
         },
         "name": "nghttp2-dev",
         "signature": {
-          "checksum": "sha1-ZRWYUK14qaTBE3NC7OOWumdkSyY=",
+          "checksum": "sha1-avAz/6snsG86C9jh8Gxa59gs29U=",
           "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.60.0-r0.apk",
-        "version": "1.60.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.61.0-r0.apk",
+        "version": "1.61.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -508,41 +508,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1l9z4OGVfdVISNbyGQdXlz2GPchM=",
+        "checksum": "Q1wJPtj5XZtnPiVWGM5dsT+nyfWXc=",
         "control": {
-          "checksum": "sha1-l9z4OGVfdVISNbyGQdXlz2GPchM=",
-          "range": "bytes=695-1222"
+          "checksum": "sha1-wJPtj5XZtnPiVWGM5dsT+nyfWXc=",
+          "range": "bytes=705-1234"
         },
         "data": {
-          "checksum": "sha256-0Z+mq/0A1P+F5KIZKnsYpg8Eqb3GDRT7VDrZlTEg+4Y=",
-          "range": "bytes=1223-3863194"
+          "checksum": "sha256-sw+CjlpsjO01q6lqzXgHnniiJKn7bqOSNO6vNqdGc7I=",
+          "range": "bytes=1235-3873775"
         },
         "name": "bind-libs",
         "signature": {
-          "checksum": "sha1-YX2+1oZh/hXHVjZriSnJZQzpifg=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-9zDzmHAeu7mWpidXAatqrLZVzUs=",
+          "range": "bytes=0-704"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bind-libs-9.18.25-r0.apk",
-        "version": "9.18.25-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/bind-libs-9.18.26-r0.apk",
+        "version": "9.18.26-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Xb5w/MUeHFBeLgnHBmG7dqAMxzQ=",
+        "checksum": "Q1AxEQdi8fVcYtGc3zHTCW3OZdY2Q=",
         "control": {
-          "checksum": "sha1-Xb5w/MUeHFBeLgnHBmG7dqAMxzQ=",
-          "range": "bytes=705-1217"
+          "checksum": "sha1-AxEQdi8fVcYtGc3zHTCW3OZdY2Q=",
+          "range": "bytes=694-1208"
         },
         "data": {
-          "checksum": "sha256-/0zOh1KQW58NOuJgauDOdqJA4G4g0p6jPUOP45HN/f8=",
-          "range": "bytes=1218-892798"
+          "checksum": "sha256-/dt3qJw5D9iSJ/mKkRQkhWD8R52selhpcwXyw7KLMhg=",
+          "range": "bytes=1209-879444"
         },
         "name": "bind-tools",
         "signature": {
-          "checksum": "sha1-3GgaViNXeX4dd75pxgwR8yYgov0=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-VTb0YdUzPMk8Po0p4nj0y5Jey6k=",
+          "range": "bytes=0-693"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bind-tools-9.18.25-r0.apk",
-        "version": "9.18.25-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/bind-tools-9.18.26-r0.apk",
+        "version": "9.18.26-r0"
       },
       {
         "architecture": "x86_64",
@@ -641,22 +641,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1mgvhz4DeFAHJKsHO1xoxFMyzfo8=",
+        "checksum": "Q1fmA7aey0Pbi31iuLRoeAN/aLvSY=",
         "control": {
-          "checksum": "sha1-mgvhz4DeFAHJKsHO1xoxFMyzfo8=",
-          "range": "bytes=659-1065"
+          "checksum": "sha1-fmA7aey0Pbi31iuLRoeAN/aLvSY=",
+          "range": "bytes=660-1064"
         },
         "data": {
-          "checksum": "sha256-exOy7XIVk7HGVu0hJ4m5dWI2Efy3aHS2Blk1JYSjb/E=",
-          "range": "bytes=1066-40300574"
+          "checksum": "sha256-SJ+zA+Y9HVzRRzDxSZWagfXRJGGSHXwS0PLMSI1lYnw=",
+          "range": "bytes=1065-40272023"
         },
         "name": "comby",
         "signature": {
-          "checksum": "sha1-piB4TcFT0AjHyiM96hjnzBDFpTk=",
-          "range": "bytes=0-658"
+          "checksum": "sha1-fM4DVr7gJpjhHkonA30jTRjfjIE=",
+          "range": "bytes=0-659"
         },
-        "url": "https://packages.sgdev.org/main/x86_64/comby-1.8.1-r3.apk",
-        "version": "1.8.1-r3"
+        "url": "https://packages.sgdev.org/main/x86_64/comby-1.8.1-r4.apk",
+        "version": "1.8.1-r4"
       },
       {
         "architecture": "x86_64",
@@ -755,41 +755,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1CC3jnItQWZ4ya5EB/TNDLOICnRc=",
+        "checksum": "Q1hgEBBo1tLreSINI2qiCUpUrIE9k=",
         "control": {
-          "checksum": "sha1-CC3jnItQWZ4ya5EB/TNDLOICnRc=",
-          "range": "bytes=701-1140"
+          "checksum": "sha1-hgEBBo1tLreSINI2qiCUpUrIE9k=",
+          "range": "bytes=700-1139"
         },
         "data": {
-          "checksum": "sha256-2EP9UQKOVph+9hElnh20s8ViX126cAnPyNI+IF2pQ4Y=",
-          "range": "bytes=1141-838149"
+          "checksum": "sha256-OFDWkK8l015fs0YvTCXVKLQmOxq+7W5RgJHIqKYZsTE=",
+          "range": "bytes=1140-808582"
         },
         "name": "libcurl-openssl4",
         "signature": {
-          "checksum": "sha1-IxMuIpRYevSLukva0eWmB5RkhMY=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-sygIdNZXB/W8fyOrdelY5RXh3aA=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.7.1-r0.apk",
-        "version": "8.7.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.6.0-r0.apk",
+        "version": "8.6.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1DzKkXRny9JZJvzjFt3jIuvkDP8E=",
+        "checksum": "Q1eQzLI9XN4FM69fm9B4LWd9frcwM=",
         "control": {
-          "checksum": "sha1-DzKkXRny9JZJvzjFt3jIuvkDP8E=",
-          "range": "bytes=700-1101"
+          "checksum": "sha1-eQzLI9XN4FM69fm9B4LWd9frcwM=",
+          "range": "bytes=703-1098"
         },
         "data": {
-          "checksum": "sha256-l1iebyEPmteOEBcPDwPzstpqs9SMvCn8PqlvRU3O7jk=",
-          "range": "bytes=1102-351141"
+          "checksum": "sha256-zkew7+IbyyyENezhlStwO062zaWd+yP/lpbI+CCJVZQ=",
+          "range": "bytes=1099-281166"
         },
         "name": "curl",
         "signature": {
-          "checksum": "sha1-iVKgcLEjgrpj4c2TrRzHznPaWXA=",
-          "range": "bytes=0-699"
+          "checksum": "sha1-igXspQSxo3Eu3o8DeNrYt3YxSbY=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.7.1-r0.apk",
-        "version": "8.7.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.6.0-r0.apk",
+        "version": "8.6.0-r0"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/server.lock.json
+++ b/wolfi-images/server.lock.json
@@ -265,60 +265,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q13piSoRiT6p5eziGu2iPxSkXxf+g=",
+        "checksum": "Q1+rBEmKEIywe0o/a65ZPjWoUECRQ=",
         "control": {
-          "checksum": "sha1-3piSoRiT6p5eziGu2iPxSkXxf+g=",
-          "range": "bytes=704-1039"
+          "checksum": "sha1-+rBEmKEIywe0o/a65ZPjWoUECRQ=",
+          "range": "bytes=703-1054"
         },
         "data": {
-          "checksum": "sha256-+iLQJV5/mU/hTpwsy9zYBfzVIVkd8lXBBqMScHFhHfI=",
-          "range": "bytes=1040-87982"
+          "checksum": "sha256-fcShKjtj6wR6kgjwToU1J8hU+AGRf1OGZt9jeXJdM0Q=",
+          "range": "bytes=1055-82406"
         },
         "name": "openssl-config",
         "signature": {
-          "checksum": "sha1-fsygjfZl7YLgdpBZ5OVKJG/N2HI=",
-          "range": "bytes=0-703"
+          "checksum": "sha1-RT/o4gi2oC/l+6IhikP9/PH5awg=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/openssl-config-3.2.1-r0.apk",
-        "version": "3.2.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/openssl-config-3.3.0-r5.apk",
+        "version": "3.3.0-r5"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1kERnIFBBwTWZsA+cmGLkIU75THk=",
+        "checksum": "Q11DkfNRzraQMj7ue8LFH6VN6d7Bo=",
         "control": {
-          "checksum": "sha1-kERnIFBBwTWZsA+cmGLkIU75THk=",
-          "range": "bytes=694-1066"
+          "checksum": "sha1-1DkfNRzraQMj7ue8LFH6VN6d7Bo=",
+          "range": "bytes=707-1092"
         },
         "data": {
-          "checksum": "sha256-MB5ZoAsBJ0Osps0a1V0KsM/qQhfZQvYupElgoF1rNLE=",
-          "range": "bytes=1067-5895270"
+          "checksum": "sha256-c95GJNThldUhfxVSGbchUI0pS4j6h45Yx6JDPXHaAI0=",
+          "range": "bytes=1093-5915048"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-vTJq+p2AjVQQjJ4gSkR9ySDQr3k=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-EmjggcTaE4QTKI1FzSom0rXam1c=",
+          "range": "bytes=0-706"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.2.1-r0.apk",
-        "version": "3.2.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r5.apk",
+        "version": "3.3.0-r5"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1RFDJtvcstAQi4NjU00ApvNIvoEI=",
+        "checksum": "Q15sT5bGF6kgE7DepzZIHCpPpuP70=",
         "control": {
-          "checksum": "sha1-RFDJtvcstAQi4NjU00ApvNIvoEI=",
-          "range": "bytes=694-1065"
+          "checksum": "sha1-5sT5bGF6kgE7DepzZIHCpPpuP70=",
+          "range": "bytes=702-1085"
         },
         "data": {
-          "checksum": "sha256-oocCJOj9IF7jv3Ov8bPbaAGfq6oaYXuPNnZW9DnOdnE=",
-          "range": "bytes=1066-1135402"
+          "checksum": "sha256-fWOAfZYgXO6+yM4Dpo/y7dvV3uxSEhhfO4SUX79TQDw=",
+          "range": "bytes=1086-1196497"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-wJVFcqH/ewopq4lxwz8OYrZ9/Ws=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-4+7eITv9weTmoYBAAyd92WsXS24=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.2.1-r0.apk",
-        "version": "3.2.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r5.apk",
+        "version": "3.3.0-r5"
       },
       {
         "architecture": "x86_64",
@@ -398,22 +398,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1txYNrxLRCA8tpCe/aXw9Zeb30xw=",
+        "checksum": "Q1sGD1MEAazAXpfNixX74EpwafGo0=",
         "control": {
-          "checksum": "sha1-txYNrxLRCA8tpCe/aXw9Zeb30xw=",
-          "range": "bytes=703-1071"
+          "checksum": "sha1-sGD1MEAazAXpfNixX74EpwafGo0=",
+          "range": "bytes=698-1059"
         },
         "data": {
-          "checksum": "sha256-QgGnbFCQGaCUjwfFVcF2eOXDjZHaJjntdJlM1thwxd0=",
-          "range": "bytes=1072-252873"
+          "checksum": "sha256-s+9m0l/R7hVKQ5YLbU90D2E6DPC2QVTxdjhToMi5iYU=",
+          "range": "bytes=1060-251831"
         },
         "name": "libnghttp2-14",
         "signature": {
-          "checksum": "sha1-VWNh1CR9wcBEPwOH88Qr6n7OR08=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-wOIYtvU72n76UGvbargK2ccZx0E=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.60.0-r0.apk",
-        "version": "1.60.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.61.0-r0.apk",
+        "version": "1.61.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -493,41 +493,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1YKX8zXXVrSZ1a+od3zegHGvE7K4=",
+        "checksum": "Q1NZCvjmGBZ7soi6T4endRPtDztk4=",
         "control": {
-          "checksum": "sha1-YKX8zXXVrSZ1a+od3zegHGvE7K4=",
-          "range": "bytes=701-1168"
+          "checksum": "sha1-NZCvjmGBZ7soi6T4endRPtDztk4=",
+          "range": "bytes=698-1162"
         },
         "data": {
-          "checksum": "sha256-KnMN4TtaDNZqReNINaTivjzUoQigGvtRZgVEqc1EDHo=",
-          "range": "bytes=1169-2555088"
+          "checksum": "sha256-q79pSkGvnDzz1dHsQceLPqyVC+cFCyWWJB5L2EfkZRc=",
+          "range": "bytes=1163-2556930"
         },
         "name": "nghttp2",
         "signature": {
-          "checksum": "sha1-MWKiH9LAxjnWqAm536DCFrsZXCg=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-UuOeekThV8UC737772jFTRj0Y50=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.60.0-r0.apk",
-        "version": "1.60.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.61.0-r0.apk",
+        "version": "1.61.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1D/+xxUxpR+m3nGP5l/8Ed78nNC0=",
+        "checksum": "Q1O/sL8Kjkxzh39Ffh9gJl+0olkF4=",
         "control": {
-          "checksum": "sha1-D/+xxUxpR+m3nGP5l/8Ed78nNC0=",
-          "range": "bytes=700-1067"
+          "checksum": "sha1-O/sL8Kjkxzh39Ffh9gJl+0olkF4=",
+          "range": "bytes=700-1061"
         },
         "data": {
-          "checksum": "sha256-fKV2YLH6EP/NFtRSErdaCwZX+Mg6KJrfmt1VpRWeKis=",
-          "range": "bytes=1068-634389"
+          "checksum": "sha256-6qS8u1yYrzO+4Ypa+g4zfz3m16/7O/U4wjiRrKl8/vw=",
+          "range": "bytes=1062-631650"
         },
         "name": "nghttp2-dev",
         "signature": {
-          "checksum": "sha1-ZRWYUK14qaTBE3NC7OOWumdkSyY=",
+          "checksum": "sha1-avAz/6snsG86C9jh8Gxa59gs29U=",
           "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.60.0-r0.apk",
-        "version": "1.60.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.61.0-r0.apk",
+        "version": "1.61.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -569,41 +569,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1l9z4OGVfdVISNbyGQdXlz2GPchM=",
+        "checksum": "Q1wJPtj5XZtnPiVWGM5dsT+nyfWXc=",
         "control": {
-          "checksum": "sha1-l9z4OGVfdVISNbyGQdXlz2GPchM=",
-          "range": "bytes=695-1222"
+          "checksum": "sha1-wJPtj5XZtnPiVWGM5dsT+nyfWXc=",
+          "range": "bytes=705-1234"
         },
         "data": {
-          "checksum": "sha256-0Z+mq/0A1P+F5KIZKnsYpg8Eqb3GDRT7VDrZlTEg+4Y=",
-          "range": "bytes=1223-3863194"
+          "checksum": "sha256-sw+CjlpsjO01q6lqzXgHnniiJKn7bqOSNO6vNqdGc7I=",
+          "range": "bytes=1235-3873775"
         },
         "name": "bind-libs",
         "signature": {
-          "checksum": "sha1-YX2+1oZh/hXHVjZriSnJZQzpifg=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-9zDzmHAeu7mWpidXAatqrLZVzUs=",
+          "range": "bytes=0-704"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bind-libs-9.18.25-r0.apk",
-        "version": "9.18.25-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/bind-libs-9.18.26-r0.apk",
+        "version": "9.18.26-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Xb5w/MUeHFBeLgnHBmG7dqAMxzQ=",
+        "checksum": "Q1AxEQdi8fVcYtGc3zHTCW3OZdY2Q=",
         "control": {
-          "checksum": "sha1-Xb5w/MUeHFBeLgnHBmG7dqAMxzQ=",
-          "range": "bytes=705-1217"
+          "checksum": "sha1-AxEQdi8fVcYtGc3zHTCW3OZdY2Q=",
+          "range": "bytes=694-1208"
         },
         "data": {
-          "checksum": "sha256-/0zOh1KQW58NOuJgauDOdqJA4G4g0p6jPUOP45HN/f8=",
-          "range": "bytes=1218-892798"
+          "checksum": "sha256-/dt3qJw5D9iSJ/mKkRQkhWD8R52selhpcwXyw7KLMhg=",
+          "range": "bytes=1209-879444"
         },
         "name": "bind-tools",
         "signature": {
-          "checksum": "sha1-3GgaViNXeX4dd75pxgwR8yYgov0=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-VTb0YdUzPMk8Po0p4nj0y5Jey6k=",
+          "range": "bytes=0-693"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bind-tools-9.18.25-r0.apk",
-        "version": "9.18.25-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/bind-tools-9.18.26-r0.apk",
+        "version": "9.18.26-r0"
       },
       {
         "architecture": "x86_64",
@@ -721,41 +721,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1mgvhz4DeFAHJKsHO1xoxFMyzfo8=",
+        "checksum": "Q1fmA7aey0Pbi31iuLRoeAN/aLvSY=",
         "control": {
-          "checksum": "sha1-mgvhz4DeFAHJKsHO1xoxFMyzfo8=",
-          "range": "bytes=659-1065"
+          "checksum": "sha1-fmA7aey0Pbi31iuLRoeAN/aLvSY=",
+          "range": "bytes=660-1064"
         },
         "data": {
-          "checksum": "sha256-exOy7XIVk7HGVu0hJ4m5dWI2Efy3aHS2Blk1JYSjb/E=",
-          "range": "bytes=1066-40300574"
+          "checksum": "sha256-SJ+zA+Y9HVzRRzDxSZWagfXRJGGSHXwS0PLMSI1lYnw=",
+          "range": "bytes=1065-40272023"
         },
         "name": "comby",
         "signature": {
-          "checksum": "sha1-piB4TcFT0AjHyiM96hjnzBDFpTk=",
-          "range": "bytes=0-658"
+          "checksum": "sha1-fM4DVr7gJpjhHkonA30jTRjfjIE=",
+          "range": "bytes=0-659"
         },
-        "url": "https://packages.sgdev.org/main/x86_64/comby-1.8.1-r3.apk",
-        "version": "1.8.1-r3"
+        "url": "https://packages.sgdev.org/main/x86_64/comby-1.8.1-r4.apk",
+        "version": "1.8.1-r4"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q18DXOCGQccaBV9A5r/surTzWqW/o=",
+        "checksum": "Q1L9rArzLWlXjTBTMt4R4rKPLw2qo=",
         "control": {
-          "checksum": "sha1-8DXOCGQccaBV9A5r/surTzWqW/o=",
-          "range": "bytes=657-1007"
+          "checksum": "sha1-L9rArzLWlXjTBTMt4R4rKPLw2qo=",
+          "range": "bytes=660-1009"
         },
         "data": {
-          "checksum": "sha256-e1xbeh3L6Li3xcK1EO3/rWIFrGyxqNG9G651Qi/oiUk=",
-          "range": "bytes=1008-59687101"
+          "checksum": "sha256-zaAqDv39QN1OwYSWZY5ILzlTqUmpVTE8lBBSsKRO/AU=",
+          "range": "bytes=1010-59654512"
         },
         "name": "coursier",
         "signature": {
-          "checksum": "sha1-OvNg0xO/vjOWr45Urdbfa7ExS+U=",
-          "range": "bytes=0-656"
+          "checksum": "sha1-qlZ+I72V1IIyjsqJpeKaaTMfSQc=",
+          "range": "bytes=0-659"
         },
-        "url": "https://packages.sgdev.org/main/x86_64/coursier-2.0.13-r2.apk",
-        "version": "2.0.13-r2"
+        "url": "https://packages.sgdev.org/main/x86_64/coursier-2.0.13-r3.apk",
+        "version": "2.0.13-r3"
       },
       {
         "architecture": "x86_64",
@@ -778,22 +778,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1dGFbiBgyu1lUt4vBNm7r2mESS28=",
+        "checksum": "Q168tjKa9EJjh47h3gyGn4ThsOI0Y=",
         "control": {
-          "checksum": "sha1-dGFbiBgyu1lUt4vBNm7r2mESS28=",
-          "range": "bytes=662-1025"
+          "checksum": "sha1-68tjKa9EJjh47h3gyGn4ThsOI0Y=",
+          "range": "bytes=661-1023"
         },
         "data": {
-          "checksum": "sha256-LAD/RnKpyL0sWf9jJmOCehGrx1YOb6BQHtDz0Fz6fSI=",
-          "range": "bytes=1026-3654982"
+          "checksum": "sha256-w6qWTXBItkDiwjv1e03YFmm1yN4SmchoRth3p8a6Jno=",
+          "range": "bytes=1024-3626526"
         },
         "name": "ctags",
         "signature": {
-          "checksum": "sha1-o2j+eAV5drdyb1ohr7/+204Y4DQ=",
-          "range": "bytes=0-661"
+          "checksum": "sha1-2gi15ZhMJMoqzWB1KcbB1eZnX1w=",
+          "range": "bytes=0-660"
         },
-        "url": "https://packages.sgdev.org/main/x86_64/ctags-6.0.0-r4.apk",
-        "version": "6.0.0-r4"
+        "url": "https://packages.sgdev.org/main/x86_64/ctags-6.0.0-r6.apk",
+        "version": "6.0.0-r6"
       },
       {
         "architecture": "x86_64",
@@ -892,41 +892,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1CC3jnItQWZ4ya5EB/TNDLOICnRc=",
+        "checksum": "Q1hgEBBo1tLreSINI2qiCUpUrIE9k=",
         "control": {
-          "checksum": "sha1-CC3jnItQWZ4ya5EB/TNDLOICnRc=",
-          "range": "bytes=701-1140"
+          "checksum": "sha1-hgEBBo1tLreSINI2qiCUpUrIE9k=",
+          "range": "bytes=700-1139"
         },
         "data": {
-          "checksum": "sha256-2EP9UQKOVph+9hElnh20s8ViX126cAnPyNI+IF2pQ4Y=",
-          "range": "bytes=1141-838149"
+          "checksum": "sha256-OFDWkK8l015fs0YvTCXVKLQmOxq+7W5RgJHIqKYZsTE=",
+          "range": "bytes=1140-808582"
         },
         "name": "libcurl-openssl4",
         "signature": {
-          "checksum": "sha1-IxMuIpRYevSLukva0eWmB5RkhMY=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-sygIdNZXB/W8fyOrdelY5RXh3aA=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.7.1-r0.apk",
-        "version": "8.7.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.6.0-r0.apk",
+        "version": "8.6.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1DzKkXRny9JZJvzjFt3jIuvkDP8E=",
+        "checksum": "Q1eQzLI9XN4FM69fm9B4LWd9frcwM=",
         "control": {
-          "checksum": "sha1-DzKkXRny9JZJvzjFt3jIuvkDP8E=",
-          "range": "bytes=700-1101"
+          "checksum": "sha1-eQzLI9XN4FM69fm9B4LWd9frcwM=",
+          "range": "bytes=703-1098"
         },
         "data": {
-          "checksum": "sha256-l1iebyEPmteOEBcPDwPzstpqs9SMvCn8PqlvRU3O7jk=",
-          "range": "bytes=1102-351141"
+          "checksum": "sha256-zkew7+IbyyyENezhlStwO062zaWd+yP/lpbI+CCJVZQ=",
+          "range": "bytes=1099-281166"
         },
         "name": "curl",
         "signature": {
-          "checksum": "sha1-iVKgcLEjgrpj4c2TrRzHznPaWXA=",
-          "range": "bytes=0-699"
+          "checksum": "sha1-igXspQSxo3Eu3o8DeNrYt3YxSbY=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.7.1-r0.apk",
-        "version": "8.7.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.6.0-r0.apk",
+        "version": "8.6.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -1082,41 +1082,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Euec0+VKNGIFXS0oKkm1TejSZuA=",
+        "checksum": "Q1fipCUw5BfMwiDYYuPU3OR2vacfE=",
         "control": {
-          "checksum": "sha1-Euec0+VKNGIFXS0oKkm1TejSZuA=",
-          "range": "bytes=702-1161"
+          "checksum": "sha1-fipCUw5BfMwiDYYuPU3OR2vacfE=",
+          "range": "bytes=703-1150"
         },
         "data": {
-          "checksum": "sha256-4/n9T387+xy87dxpJBiMGqWH7R0yDMJjLLmI0S7K0zI=",
-          "range": "bytes=1162-1352419"
+          "checksum": "sha256-n1ovCnevOmS8bktwohyFVAErxKJDury5L9OyV+pm7hg=",
+          "range": "bytes=1151-1349528"
         },
         "name": "nginx-mainline",
         "signature": {
-          "checksum": "sha1-O5KG0XE9jSfTsNmRq8UjBKeYxGo=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-JUxrgMHyqd5nzkgpU+9H7Odki4I=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nginx-mainline-1.25.4-r1.apk",
-        "version": "1.25.4-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/nginx-mainline-1.25.5-r0.apk",
+        "version": "1.25.5-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1GrsXw9T9K0q2nlzWVkESZrphTOg=",
+        "checksum": "Q1D64yCUEUniKOXV1PjdCUwEUA6pU=",
         "control": {
-          "checksum": "sha1-GrsXw9T9K0q2nlzWVkESZrphTOg=",
-          "range": "bytes=700-1098"
+          "checksum": "sha1-D64yCUEUniKOXV1PjdCUwEUA6pU=",
+          "range": "bytes=700-1091"
         },
         "data": {
-          "checksum": "sha256-ERB3F6kZbuVuktHSVoBt5A12yYki6FZlf6AWb+UZlq0=",
-          "range": "bytes=1099-75159"
+          "checksum": "sha256-znzw7DuRPbsYBEM0oDXQ/ceQj2sJAeuJSPwq2VH9jl8=",
+          "range": "bytes=1092-61271"
         },
         "name": "nginx-mainline-config",
         "signature": {
-          "checksum": "sha1-oCTI58R+Znf7VMIjRVA2EjZroxM=",
+          "checksum": "sha1-tXJL2TxomZKdNgySJSxvjIt8IMY=",
           "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nginx-mainline-config-1.25.4-r1.apk",
-        "version": "1.25.4-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/nginx-mainline-config-1.25.5-r0.apk",
+        "version": "1.25.5-r0"
       },
       {
         "architecture": "x86_64",
@@ -1329,79 +1329,79 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1lvdA+lSrWHVV6Vr18x+/3LikSk4=",
+        "checksum": "Q1IxgR/wmdOn2AsmEHjMadMzuPQf0=",
         "control": {
-          "checksum": "sha1-lvdA+lSrWHVV6Vr18x+/3LikSk4=",
-          "range": "bytes=700-1124"
+          "checksum": "sha1-IxgR/wmdOn2AsmEHjMadMzuPQf0=",
+          "range": "bytes=700-1123"
         },
         "data": {
-          "checksum": "sha256-Q908LtL0QFkmCEWR0UWAvg77FAMvwHgEovQUVYimSzM=",
-          "range": "bytes=1125-170693231"
+          "checksum": "sha256-ol0W8r/3Jnxynw63fsti8It4+4qUGXhN7n1Y07rM8cc=",
+          "range": "bytes=1124-170633676"
         },
         "name": "openjdk-11-jre-base",
         "signature": {
-          "checksum": "sha1-9P0sgsaCywxIyYQyds49pFd1qrs=",
+          "checksum": "sha1-13kdahGdHBkiAvl2w4Vnu+wwSiY=",
           "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/openjdk-11-jre-base-11.0.22-r1.apk",
-        "version": "11.0.22-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/openjdk-11-jre-base-11.0.23-r0.apk",
+        "version": "11.0.23-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1DOpnVgCHt9X1JbD7ah50Zo37sqM=",
+        "checksum": "Q1JGEQUEzk0sgQSUHNHdaJfAFxMpI=",
         "control": {
-          "checksum": "sha1-DOpnVgCHt9X1JbD7ah50Zo37sqM=",
-          "range": "bytes=703-1088"
+          "checksum": "sha1-JGEQUEzk0sgQSUHNHdaJfAFxMpI=",
+          "range": "bytes=703-1092"
         },
         "data": {
-          "checksum": "sha256-kDId5IzqtfCkgK2xtbXMaMYC0Mz0/h882V+NEfUp6eM=",
-          "range": "bytes=1089-2870300"
+          "checksum": "sha256-SWIwrskhqqNaFEXU9U89+Ql5xq71vFUWhZobPsPA3SY=",
+          "range": "bytes=1093-2949213"
         },
         "name": "openjdk-11-jre",
         "signature": {
-          "checksum": "sha1-D+jR+Wjw8dB6iHAWackwQO56eb8=",
+          "checksum": "sha1-LHBJoUKCsjv6MmxxSujYUbqQDIQ=",
           "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/openjdk-11-jre-11.0.22-r1.apk",
-        "version": "11.0.22-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/openjdk-11-jre-11.0.23-r0.apk",
+        "version": "11.0.23-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Qzd3SHcxMLEI9PnDm3G0tch8E/Y=",
+        "checksum": "Q1NezDGCThsJFk+As7ckWqsw/x2UM=",
         "control": {
-          "checksum": "sha1-Qzd3SHcxMLEI9PnDm3G0tch8E/Y=",
-          "range": "bytes=699-1059"
+          "checksum": "sha1-NezDGCThsJFk+As7ckWqsw/x2UM=",
+          "range": "bytes=703-1065"
         },
         "data": {
-          "checksum": "sha256-Op3s/Rv4xpz/8fYyRgVtOn3nVCv76Fe4D0MCYoFrq44=",
-          "range": "bytes=1060-619546"
+          "checksum": "sha256-nfdYUC0YabMNmRV2m0rjbKU7uTSnPJsI0JqtdLuefKc=",
+          "range": "bytes=1066-589383"
         },
         "name": "openjdk-11",
         "signature": {
-          "checksum": "sha1-RyqV6KsyoiTYgH2sLFNK0fcA3ro=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-9n00Xix4Xm+W5NDaHgnICO08WK8=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/openjdk-11-11.0.22-r1.apk",
-        "version": "11.0.22-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/openjdk-11-11.0.23-r0.apk",
+        "version": "11.0.23-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1tiHRz3neVleu/DGKRU4GAhTH94Y=",
+        "checksum": "Q1xVK1i+Nx2yIBrf6+nklKnt3xmGU=",
         "control": {
-          "checksum": "sha1-tiHRz3neVleu/DGKRU4GAhTH94Y=",
-          "range": "bytes=700-1081"
+          "checksum": "sha1-xVK1i+Nx2yIBrf6+nklKnt3xmGU=",
+          "range": "bytes=699-1084"
         },
         "data": {
-          "checksum": "sha256-sv6Bkx5JQVWEmCEmJVJa2243BP5y8FgEz/Tj4sRRbOI=",
-          "range": "bytes=1082-34108"
+          "checksum": "sha256-KkVCAWCnkYOYQSvbxhunxAWxMYWIF8+7R2HW/cdWxKE=",
+          "range": "bytes=1085-33972"
         },
         "name": "openjdk-11-default-jvm",
         "signature": {
-          "checksum": "sha1-wno2UEFotgQgdk310I6he2VX9bM=",
-          "range": "bytes=0-699"
+          "checksum": "sha1-Gww5qNU3Rsg0OTMu3DY9otvhVO0=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/openjdk-11-default-jvm-11.0.22-r1.apk",
-        "version": "11.0.22-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/openjdk-11-default-jvm-11.0.23-r0.apk",
+        "version": "11.0.23-r0"
       },
       {
         "architecture": "x86_64",
@@ -1443,41 +1443,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Z9DazMtZP+To5LyRwctr1Uokn5A=",
+        "checksum": "Q1LbqvA8R46fS+Zwl18guXt5zvYrw=",
         "control": {
-          "checksum": "sha1-Z9DazMtZP+To5LyRwctr1Uokn5A=",
-          "range": "bytes=663-1040"
+          "checksum": "sha1-LbqvA8R46fS+Zwl18guXt5zvYrw=",
+          "range": "bytes=660-1037"
         },
         "data": {
-          "checksum": "sha256-S/mI1CiAUK7r1C4P/v1o4F/JK1I42zI/8VlYWV47pGQ=",
-          "range": "bytes=1041-20465725"
+          "checksum": "sha256-Onbp332eMogVPHfUpduSsjA5w+xpyHcCb7VuMA4T1x8=",
+          "range": "bytes=1038-20466045"
         },
         "name": "p4-fusion-sg",
         "signature": {
-          "checksum": "sha1-qmBhbGYBgh/WGr9cGpOH0uYf3lc=",
-          "range": "bytes=0-662"
+          "checksum": "sha1-29MX0Y8RvdpmHPm4IPFCo3diYzY=",
+          "range": "bytes=0-659"
         },
-        "url": "https://packages.sgdev.org/main/x86_64/p4-fusion-sg-1.13.2-r2.apk",
-        "version": "1.13.2-r2"
+        "url": "https://packages.sgdev.org/main/x86_64/p4-fusion-sg-1.13.2-r3.apk",
+        "version": "1.13.2-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1cHKiymYHwbYyrA79BwJQx64e/jo=",
+        "checksum": "Q1rx1vd22w8TCeTwwQycXB0QGl6Ds=",
         "control": {
-          "checksum": "sha1-cHKiymYHwbYyrA79BwJQx64e/jo=",
-          "range": "bytes=661-1006"
+          "checksum": "sha1-rx1vd22w8TCeTwwQycXB0QGl6Ds=",
+          "range": "bytes=660-1005"
         },
         "data": {
-          "checksum": "sha256-vYWtpGcq2+9YJWsn1ULd97MlTvTkN9fZzow39s3S92U=",
-          "range": "bytes=1007-10325900"
+          "checksum": "sha256-LUsh0caZMI+gMZNGuqGxkM3bdm5WAfKY1UFiAA0Y1TM=",
+          "range": "bytes=1006-10325900"
         },
         "name": "p4cli",
         "signature": {
-          "checksum": "sha1-Hzc2YmWpLg1udDGkuYNe5NBsVCU=",
-          "range": "bytes=0-660"
+          "checksum": "sha1-+VP7upg+lI20xw+mJc+jYb+FsCY=",
+          "range": "bytes=0-659"
         },
-        "url": "https://packages.sgdev.org/main/x86_64/p4cli-23.1-r2.apk",
-        "version": "23.1-r2"
+        "url": "https://packages.sgdev.org/main/x86_64/p4cli-23.1-r3.apk",
+        "version": "23.1-r3"
       },
       {
         "architecture": "x86_64",
@@ -1595,22 +1595,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1N66g6pfCuFCU4ZKfPQ6n3eDggB0=",
+        "checksum": "Q11rWEg82oHyjUZI+8zzUmTJ1D/74=",
         "control": {
-          "checksum": "sha1-N66g6pfCuFCU4ZKfPQ6n3eDggB0=",
-          "range": "bytes=704-1140"
+          "checksum": "sha1-1rWEg82oHyjUZI+8zzUmTJ1D/74=",
+          "range": "bytes=703-1150"
         },
         "data": {
-          "checksum": "sha256-oNmytBov2qEeWj5pqaQ41GWo6ziLezAWfxDGXkwcr6c=",
-          "range": "bytes=1141-186189735"
+          "checksum": "sha256-ZPmuc49YzWCEyVdde2xydAUGVTJWbQ/x4bE0y3KvUi8=",
+          "range": "bytes=1151-186189747"
         },
         "name": "prometheus-2.51",
         "signature": {
-          "checksum": "sha1-o6tienifJogUi4/gZsxqhkHcVr4=",
-          "range": "bytes=0-703"
+          "checksum": "sha1-id0YIveOCeBApldSkhNpoF5uUZQ=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/prometheus-2.51-2.51.1-r1.apk",
-        "version": "2.51.1-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/prometheus-2.51-2.51.2-r0.apk",
+        "version": "2.51.2-r0"
       },
       {
         "architecture": "x86_64",
@@ -1709,41 +1709,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1D8X74+a2sutMM4df4P63Q+jOtzw=",
+        "checksum": "Q1LPejw4CnrXdaD6OHwAoFM/7vA7s=",
         "control": {
-          "checksum": "sha1-D8X74+a2sutMM4df4P63Q+jOtzw=",
-          "range": "bytes=695-1203"
+          "checksum": "sha1-LPejw4CnrXdaD6OHwAoFM/7vA7s=",
+          "range": "bytes=700-1217"
         },
         "data": {
-          "checksum": "sha256-UbrH++J9cwOI+rQwn8kPVIP2yS2hTvb9aPFECfF6tB8=",
-          "range": "bytes=1204-42123590"
+          "checksum": "sha256-r23KtCFip48cIupEQhoBPL12Ldsyr6u5LKT8la+mZfo=",
+          "range": "bytes=1218-40574201"
         },
         "name": "python-3.12-base",
         "signature": {
-          "checksum": "sha1-X2u0OA9U6goK8Dt9EB4ejml2/BE=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-5EREXBj3ZFrVW1zyGKgNw/DUyEM=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/python-3.12-base-3.12.2-r8.apk",
-        "version": "3.12.2-r8"
+        "url": "https://packages.wolfi.dev/os/x86_64/python-3.12-base-3.12.3-r0.apk",
+        "version": "3.12.3-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q19dQz13v/WahZBP19atGsVQLAV0Q=",
+        "checksum": "Q1zJd5jSTT2iNfEP+Lg6n5DL2N5iM=",
         "control": {
-          "checksum": "sha1-9dQz13v/WahZBP19atGsVQLAV0Q=",
-          "range": "bytes=698-1062"
+          "checksum": "sha1-zJd5jSTT2iNfEP+Lg6n5DL2N5iM=",
+          "range": "bytes=708-1079"
         },
         "data": {
-          "checksum": "sha256-6e1OR1RuGUAHP762Ek6Oub/Do13jH2BITZLcSrfb50I=",
-          "range": "bytes=1063-42235"
+          "checksum": "sha256-ZEgYPjLoERnzSvMfi4YYzoVQa7U8OJDGCidlrjCkBBw=",
+          "range": "bytes=1080-42121"
         },
         "name": "python-3.12",
         "signature": {
-          "checksum": "sha1-Fy9ND0Cx9lWHbyWqbAmfoQB2q9c=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-oqY6wsK+/SWuhGEnD7sZM/qdjdU=",
+          "range": "bytes=0-707"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/python-3.12-3.12.2-r8.apk",
-        "version": "3.12.2-r8"
+        "url": "https://packages.wolfi.dev/os/x86_64/python-3.12-3.12.3-r0.apk",
+        "version": "3.12.3-r0"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/sourcegraph-base.lock.json
+++ b/wolfi-images/sourcegraph-base.lock.json
@@ -204,60 +204,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q13piSoRiT6p5eziGu2iPxSkXxf+g=",
+        "checksum": "Q1+rBEmKEIywe0o/a65ZPjWoUECRQ=",
         "control": {
-          "checksum": "sha1-3piSoRiT6p5eziGu2iPxSkXxf+g=",
-          "range": "bytes=704-1039"
+          "checksum": "sha1-+rBEmKEIywe0o/a65ZPjWoUECRQ=",
+          "range": "bytes=703-1054"
         },
         "data": {
-          "checksum": "sha256-+iLQJV5/mU/hTpwsy9zYBfzVIVkd8lXBBqMScHFhHfI=",
-          "range": "bytes=1040-87982"
+          "checksum": "sha256-fcShKjtj6wR6kgjwToU1J8hU+AGRf1OGZt9jeXJdM0Q=",
+          "range": "bytes=1055-82406"
         },
         "name": "openssl-config",
         "signature": {
-          "checksum": "sha1-fsygjfZl7YLgdpBZ5OVKJG/N2HI=",
-          "range": "bytes=0-703"
+          "checksum": "sha1-RT/o4gi2oC/l+6IhikP9/PH5awg=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/openssl-config-3.2.1-r0.apk",
-        "version": "3.2.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/openssl-config-3.3.0-r5.apk",
+        "version": "3.3.0-r5"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1kERnIFBBwTWZsA+cmGLkIU75THk=",
+        "checksum": "Q11DkfNRzraQMj7ue8LFH6VN6d7Bo=",
         "control": {
-          "checksum": "sha1-kERnIFBBwTWZsA+cmGLkIU75THk=",
-          "range": "bytes=694-1066"
+          "checksum": "sha1-1DkfNRzraQMj7ue8LFH6VN6d7Bo=",
+          "range": "bytes=707-1092"
         },
         "data": {
-          "checksum": "sha256-MB5ZoAsBJ0Osps0a1V0KsM/qQhfZQvYupElgoF1rNLE=",
-          "range": "bytes=1067-5895270"
+          "checksum": "sha256-c95GJNThldUhfxVSGbchUI0pS4j6h45Yx6JDPXHaAI0=",
+          "range": "bytes=1093-5915048"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-vTJq+p2AjVQQjJ4gSkR9ySDQr3k=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-EmjggcTaE4QTKI1FzSom0rXam1c=",
+          "range": "bytes=0-706"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.2.1-r0.apk",
-        "version": "3.2.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r5.apk",
+        "version": "3.3.0-r5"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1RFDJtvcstAQi4NjU00ApvNIvoEI=",
+        "checksum": "Q15sT5bGF6kgE7DepzZIHCpPpuP70=",
         "control": {
-          "checksum": "sha1-RFDJtvcstAQi4NjU00ApvNIvoEI=",
-          "range": "bytes=694-1065"
+          "checksum": "sha1-5sT5bGF6kgE7DepzZIHCpPpuP70=",
+          "range": "bytes=702-1085"
         },
         "data": {
-          "checksum": "sha256-oocCJOj9IF7jv3Ov8bPbaAGfq6oaYXuPNnZW9DnOdnE=",
-          "range": "bytes=1066-1135402"
+          "checksum": "sha256-fWOAfZYgXO6+yM4Dpo/y7dvV3uxSEhhfO4SUX79TQDw=",
+          "range": "bytes=1086-1196497"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-wJVFcqH/ewopq4lxwz8OYrZ9/Ws=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-4+7eITv9weTmoYBAAyd92WsXS24=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.2.1-r0.apk",
-        "version": "3.2.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r5.apk",
+        "version": "3.3.0-r5"
       },
       {
         "architecture": "x86_64",
@@ -337,22 +337,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1txYNrxLRCA8tpCe/aXw9Zeb30xw=",
+        "checksum": "Q1sGD1MEAazAXpfNixX74EpwafGo0=",
         "control": {
-          "checksum": "sha1-txYNrxLRCA8tpCe/aXw9Zeb30xw=",
-          "range": "bytes=703-1071"
+          "checksum": "sha1-sGD1MEAazAXpfNixX74EpwafGo0=",
+          "range": "bytes=698-1059"
         },
         "data": {
-          "checksum": "sha256-QgGnbFCQGaCUjwfFVcF2eOXDjZHaJjntdJlM1thwxd0=",
-          "range": "bytes=1072-252873"
+          "checksum": "sha256-s+9m0l/R7hVKQ5YLbU90D2E6DPC2QVTxdjhToMi5iYU=",
+          "range": "bytes=1060-251831"
         },
         "name": "libnghttp2-14",
         "signature": {
-          "checksum": "sha1-VWNh1CR9wcBEPwOH88Qr6n7OR08=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-wOIYtvU72n76UGvbargK2ccZx0E=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.60.0-r0.apk",
-        "version": "1.60.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.61.0-r0.apk",
+        "version": "1.61.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -432,41 +432,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1YKX8zXXVrSZ1a+od3zegHGvE7K4=",
+        "checksum": "Q1NZCvjmGBZ7soi6T4endRPtDztk4=",
         "control": {
-          "checksum": "sha1-YKX8zXXVrSZ1a+od3zegHGvE7K4=",
-          "range": "bytes=701-1168"
+          "checksum": "sha1-NZCvjmGBZ7soi6T4endRPtDztk4=",
+          "range": "bytes=698-1162"
         },
         "data": {
-          "checksum": "sha256-KnMN4TtaDNZqReNINaTivjzUoQigGvtRZgVEqc1EDHo=",
-          "range": "bytes=1169-2555088"
+          "checksum": "sha256-q79pSkGvnDzz1dHsQceLPqyVC+cFCyWWJB5L2EfkZRc=",
+          "range": "bytes=1163-2556930"
         },
         "name": "nghttp2",
         "signature": {
-          "checksum": "sha1-MWKiH9LAxjnWqAm536DCFrsZXCg=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-UuOeekThV8UC737772jFTRj0Y50=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.60.0-r0.apk",
-        "version": "1.60.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.61.0-r0.apk",
+        "version": "1.61.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1D/+xxUxpR+m3nGP5l/8Ed78nNC0=",
+        "checksum": "Q1O/sL8Kjkxzh39Ffh9gJl+0olkF4=",
         "control": {
-          "checksum": "sha1-D/+xxUxpR+m3nGP5l/8Ed78nNC0=",
-          "range": "bytes=700-1067"
+          "checksum": "sha1-O/sL8Kjkxzh39Ffh9gJl+0olkF4=",
+          "range": "bytes=700-1061"
         },
         "data": {
-          "checksum": "sha256-fKV2YLH6EP/NFtRSErdaCwZX+Mg6KJrfmt1VpRWeKis=",
-          "range": "bytes=1068-634389"
+          "checksum": "sha256-6qS8u1yYrzO+4Ypa+g4zfz3m16/7O/U4wjiRrKl8/vw=",
+          "range": "bytes=1062-631650"
         },
         "name": "nghttp2-dev",
         "signature": {
-          "checksum": "sha1-ZRWYUK14qaTBE3NC7OOWumdkSyY=",
+          "checksum": "sha1-avAz/6snsG86C9jh8Gxa59gs29U=",
           "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.60.0-r0.apk",
-        "version": "1.60.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.61.0-r0.apk",
+        "version": "1.61.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -508,41 +508,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1l9z4OGVfdVISNbyGQdXlz2GPchM=",
+        "checksum": "Q1wJPtj5XZtnPiVWGM5dsT+nyfWXc=",
         "control": {
-          "checksum": "sha1-l9z4OGVfdVISNbyGQdXlz2GPchM=",
-          "range": "bytes=695-1222"
+          "checksum": "sha1-wJPtj5XZtnPiVWGM5dsT+nyfWXc=",
+          "range": "bytes=705-1234"
         },
         "data": {
-          "checksum": "sha256-0Z+mq/0A1P+F5KIZKnsYpg8Eqb3GDRT7VDrZlTEg+4Y=",
-          "range": "bytes=1223-3863194"
+          "checksum": "sha256-sw+CjlpsjO01q6lqzXgHnniiJKn7bqOSNO6vNqdGc7I=",
+          "range": "bytes=1235-3873775"
         },
         "name": "bind-libs",
         "signature": {
-          "checksum": "sha1-YX2+1oZh/hXHVjZriSnJZQzpifg=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-9zDzmHAeu7mWpidXAatqrLZVzUs=",
+          "range": "bytes=0-704"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bind-libs-9.18.25-r0.apk",
-        "version": "9.18.25-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/bind-libs-9.18.26-r0.apk",
+        "version": "9.18.26-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Xb5w/MUeHFBeLgnHBmG7dqAMxzQ=",
+        "checksum": "Q1AxEQdi8fVcYtGc3zHTCW3OZdY2Q=",
         "control": {
-          "checksum": "sha1-Xb5w/MUeHFBeLgnHBmG7dqAMxzQ=",
-          "range": "bytes=705-1217"
+          "checksum": "sha1-AxEQdi8fVcYtGc3zHTCW3OZdY2Q=",
+          "range": "bytes=694-1208"
         },
         "data": {
-          "checksum": "sha256-/0zOh1KQW58NOuJgauDOdqJA4G4g0p6jPUOP45HN/f8=",
-          "range": "bytes=1218-892798"
+          "checksum": "sha256-/dt3qJw5D9iSJ/mKkRQkhWD8R52selhpcwXyw7KLMhg=",
+          "range": "bytes=1209-879444"
         },
         "name": "bind-tools",
         "signature": {
-          "checksum": "sha1-3GgaViNXeX4dd75pxgwR8yYgov0=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-VTb0YdUzPMk8Po0p4nj0y5Jey6k=",
+          "range": "bytes=0-693"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bind-tools-9.18.25-r0.apk",
-        "version": "9.18.25-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/bind-tools-9.18.26-r0.apk",
+        "version": "9.18.26-r0"
       },
       {
         "architecture": "x86_64",
@@ -698,41 +698,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1CC3jnItQWZ4ya5EB/TNDLOICnRc=",
+        "checksum": "Q1hgEBBo1tLreSINI2qiCUpUrIE9k=",
         "control": {
-          "checksum": "sha1-CC3jnItQWZ4ya5EB/TNDLOICnRc=",
-          "range": "bytes=701-1140"
+          "checksum": "sha1-hgEBBo1tLreSINI2qiCUpUrIE9k=",
+          "range": "bytes=700-1139"
         },
         "data": {
-          "checksum": "sha256-2EP9UQKOVph+9hElnh20s8ViX126cAnPyNI+IF2pQ4Y=",
-          "range": "bytes=1141-838149"
+          "checksum": "sha256-OFDWkK8l015fs0YvTCXVKLQmOxq+7W5RgJHIqKYZsTE=",
+          "range": "bytes=1140-808582"
         },
         "name": "libcurl-openssl4",
         "signature": {
-          "checksum": "sha1-IxMuIpRYevSLukva0eWmB5RkhMY=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-sygIdNZXB/W8fyOrdelY5RXh3aA=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.7.1-r0.apk",
-        "version": "8.7.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.6.0-r0.apk",
+        "version": "8.6.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1DzKkXRny9JZJvzjFt3jIuvkDP8E=",
+        "checksum": "Q1eQzLI9XN4FM69fm9B4LWd9frcwM=",
         "control": {
-          "checksum": "sha1-DzKkXRny9JZJvzjFt3jIuvkDP8E=",
-          "range": "bytes=700-1101"
+          "checksum": "sha1-eQzLI9XN4FM69fm9B4LWd9frcwM=",
+          "range": "bytes=703-1098"
         },
         "data": {
-          "checksum": "sha256-l1iebyEPmteOEBcPDwPzstpqs9SMvCn8PqlvRU3O7jk=",
-          "range": "bytes=1102-351141"
+          "checksum": "sha256-zkew7+IbyyyENezhlStwO062zaWd+yP/lpbI+CCJVZQ=",
+          "range": "bytes=1099-281166"
         },
         "name": "curl",
         "signature": {
-          "checksum": "sha1-iVKgcLEjgrpj4c2TrRzHznPaWXA=",
-          "range": "bytes=0-699"
+          "checksum": "sha1-igXspQSxo3Eu3o8DeNrYt3YxSbY=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.7.1-r0.apk",
-        "version": "8.7.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.6.0-r0.apk",
+        "version": "8.6.0-r0"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/sourcegraph-dev.lock.json
+++ b/wolfi-images/sourcegraph-dev.lock.json
@@ -128,60 +128,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q13piSoRiT6p5eziGu2iPxSkXxf+g=",
+        "checksum": "Q1+rBEmKEIywe0o/a65ZPjWoUECRQ=",
         "control": {
-          "checksum": "sha1-3piSoRiT6p5eziGu2iPxSkXxf+g=",
-          "range": "bytes=704-1039"
+          "checksum": "sha1-+rBEmKEIywe0o/a65ZPjWoUECRQ=",
+          "range": "bytes=703-1054"
         },
         "data": {
-          "checksum": "sha256-+iLQJV5/mU/hTpwsy9zYBfzVIVkd8lXBBqMScHFhHfI=",
-          "range": "bytes=1040-87982"
+          "checksum": "sha256-fcShKjtj6wR6kgjwToU1J8hU+AGRf1OGZt9jeXJdM0Q=",
+          "range": "bytes=1055-82406"
         },
         "name": "openssl-config",
         "signature": {
-          "checksum": "sha1-fsygjfZl7YLgdpBZ5OVKJG/N2HI=",
-          "range": "bytes=0-703"
+          "checksum": "sha1-RT/o4gi2oC/l+6IhikP9/PH5awg=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/openssl-config-3.2.1-r0.apk",
-        "version": "3.2.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/openssl-config-3.3.0-r5.apk",
+        "version": "3.3.0-r5"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1kERnIFBBwTWZsA+cmGLkIU75THk=",
+        "checksum": "Q11DkfNRzraQMj7ue8LFH6VN6d7Bo=",
         "control": {
-          "checksum": "sha1-kERnIFBBwTWZsA+cmGLkIU75THk=",
-          "range": "bytes=694-1066"
+          "checksum": "sha1-1DkfNRzraQMj7ue8LFH6VN6d7Bo=",
+          "range": "bytes=707-1092"
         },
         "data": {
-          "checksum": "sha256-MB5ZoAsBJ0Osps0a1V0KsM/qQhfZQvYupElgoF1rNLE=",
-          "range": "bytes=1067-5895270"
+          "checksum": "sha256-c95GJNThldUhfxVSGbchUI0pS4j6h45Yx6JDPXHaAI0=",
+          "range": "bytes=1093-5915048"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-vTJq+p2AjVQQjJ4gSkR9ySDQr3k=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-EmjggcTaE4QTKI1FzSom0rXam1c=",
+          "range": "bytes=0-706"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.2.1-r0.apk",
-        "version": "3.2.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r5.apk",
+        "version": "3.3.0-r5"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1RFDJtvcstAQi4NjU00ApvNIvoEI=",
+        "checksum": "Q15sT5bGF6kgE7DepzZIHCpPpuP70=",
         "control": {
-          "checksum": "sha1-RFDJtvcstAQi4NjU00ApvNIvoEI=",
-          "range": "bytes=694-1065"
+          "checksum": "sha1-5sT5bGF6kgE7DepzZIHCpPpuP70=",
+          "range": "bytes=702-1085"
         },
         "data": {
-          "checksum": "sha256-oocCJOj9IF7jv3Ov8bPbaAGfq6oaYXuPNnZW9DnOdnE=",
-          "range": "bytes=1066-1135402"
+          "checksum": "sha256-fWOAfZYgXO6+yM4Dpo/y7dvV3uxSEhhfO4SUX79TQDw=",
+          "range": "bytes=1086-1196497"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-wJVFcqH/ewopq4lxwz8OYrZ9/Ws=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-4+7eITv9weTmoYBAAyd92WsXS24=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.2.1-r0.apk",
-        "version": "3.2.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r5.apk",
+        "version": "3.3.0-r5"
       },
       {
         "architecture": "x86_64",
@@ -356,22 +356,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1txYNrxLRCA8tpCe/aXw9Zeb30xw=",
+        "checksum": "Q1sGD1MEAazAXpfNixX74EpwafGo0=",
         "control": {
-          "checksum": "sha1-txYNrxLRCA8tpCe/aXw9Zeb30xw=",
-          "range": "bytes=703-1071"
+          "checksum": "sha1-sGD1MEAazAXpfNixX74EpwafGo0=",
+          "range": "bytes=698-1059"
         },
         "data": {
-          "checksum": "sha256-QgGnbFCQGaCUjwfFVcF2eOXDjZHaJjntdJlM1thwxd0=",
-          "range": "bytes=1072-252873"
+          "checksum": "sha256-s+9m0l/R7hVKQ5YLbU90D2E6DPC2QVTxdjhToMi5iYU=",
+          "range": "bytes=1060-251831"
         },
         "name": "libnghttp2-14",
         "signature": {
-          "checksum": "sha1-VWNh1CR9wcBEPwOH88Qr6n7OR08=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-wOIYtvU72n76UGvbargK2ccZx0E=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.60.0-r0.apk",
-        "version": "1.60.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.61.0-r0.apk",
+        "version": "1.61.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -451,41 +451,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1YKX8zXXVrSZ1a+od3zegHGvE7K4=",
+        "checksum": "Q1NZCvjmGBZ7soi6T4endRPtDztk4=",
         "control": {
-          "checksum": "sha1-YKX8zXXVrSZ1a+od3zegHGvE7K4=",
-          "range": "bytes=701-1168"
+          "checksum": "sha1-NZCvjmGBZ7soi6T4endRPtDztk4=",
+          "range": "bytes=698-1162"
         },
         "data": {
-          "checksum": "sha256-KnMN4TtaDNZqReNINaTivjzUoQigGvtRZgVEqc1EDHo=",
-          "range": "bytes=1169-2555088"
+          "checksum": "sha256-q79pSkGvnDzz1dHsQceLPqyVC+cFCyWWJB5L2EfkZRc=",
+          "range": "bytes=1163-2556930"
         },
         "name": "nghttp2",
         "signature": {
-          "checksum": "sha1-MWKiH9LAxjnWqAm536DCFrsZXCg=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-UuOeekThV8UC737772jFTRj0Y50=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.60.0-r0.apk",
-        "version": "1.60.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.61.0-r0.apk",
+        "version": "1.61.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1D/+xxUxpR+m3nGP5l/8Ed78nNC0=",
+        "checksum": "Q1O/sL8Kjkxzh39Ffh9gJl+0olkF4=",
         "control": {
-          "checksum": "sha1-D/+xxUxpR+m3nGP5l/8Ed78nNC0=",
-          "range": "bytes=700-1067"
+          "checksum": "sha1-O/sL8Kjkxzh39Ffh9gJl+0olkF4=",
+          "range": "bytes=700-1061"
         },
         "data": {
-          "checksum": "sha256-fKV2YLH6EP/NFtRSErdaCwZX+Mg6KJrfmt1VpRWeKis=",
-          "range": "bytes=1068-634389"
+          "checksum": "sha256-6qS8u1yYrzO+4Ypa+g4zfz3m16/7O/U4wjiRrKl8/vw=",
+          "range": "bytes=1062-631650"
         },
         "name": "nghttp2-dev",
         "signature": {
-          "checksum": "sha1-ZRWYUK14qaTBE3NC7OOWumdkSyY=",
+          "checksum": "sha1-avAz/6snsG86C9jh8Gxa59gs29U=",
           "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.60.0-r0.apk",
-        "version": "1.60.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.61.0-r0.apk",
+        "version": "1.61.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -527,41 +527,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1l9z4OGVfdVISNbyGQdXlz2GPchM=",
+        "checksum": "Q1wJPtj5XZtnPiVWGM5dsT+nyfWXc=",
         "control": {
-          "checksum": "sha1-l9z4OGVfdVISNbyGQdXlz2GPchM=",
-          "range": "bytes=695-1222"
+          "checksum": "sha1-wJPtj5XZtnPiVWGM5dsT+nyfWXc=",
+          "range": "bytes=705-1234"
         },
         "data": {
-          "checksum": "sha256-0Z+mq/0A1P+F5KIZKnsYpg8Eqb3GDRT7VDrZlTEg+4Y=",
-          "range": "bytes=1223-3863194"
+          "checksum": "sha256-sw+CjlpsjO01q6lqzXgHnniiJKn7bqOSNO6vNqdGc7I=",
+          "range": "bytes=1235-3873775"
         },
         "name": "bind-libs",
         "signature": {
-          "checksum": "sha1-YX2+1oZh/hXHVjZriSnJZQzpifg=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-9zDzmHAeu7mWpidXAatqrLZVzUs=",
+          "range": "bytes=0-704"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bind-libs-9.18.25-r0.apk",
-        "version": "9.18.25-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/bind-libs-9.18.26-r0.apk",
+        "version": "9.18.26-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Xb5w/MUeHFBeLgnHBmG7dqAMxzQ=",
+        "checksum": "Q1AxEQdi8fVcYtGc3zHTCW3OZdY2Q=",
         "control": {
-          "checksum": "sha1-Xb5w/MUeHFBeLgnHBmG7dqAMxzQ=",
-          "range": "bytes=705-1217"
+          "checksum": "sha1-AxEQdi8fVcYtGc3zHTCW3OZdY2Q=",
+          "range": "bytes=694-1208"
         },
         "data": {
-          "checksum": "sha256-/0zOh1KQW58NOuJgauDOdqJA4G4g0p6jPUOP45HN/f8=",
-          "range": "bytes=1218-892798"
+          "checksum": "sha256-/dt3qJw5D9iSJ/mKkRQkhWD8R52selhpcwXyw7KLMhg=",
+          "range": "bytes=1209-879444"
         },
         "name": "bind-tools",
         "signature": {
-          "checksum": "sha1-3GgaViNXeX4dd75pxgwR8yYgov0=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-VTb0YdUzPMk8Po0p4nj0y5Jey6k=",
+          "range": "bytes=0-693"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bind-tools-9.18.25-r0.apk",
-        "version": "9.18.25-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/bind-tools-9.18.26-r0.apk",
+        "version": "9.18.26-r0"
       },
       {
         "architecture": "x86_64",
@@ -717,41 +717,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1CC3jnItQWZ4ya5EB/TNDLOICnRc=",
+        "checksum": "Q1hgEBBo1tLreSINI2qiCUpUrIE9k=",
         "control": {
-          "checksum": "sha1-CC3jnItQWZ4ya5EB/TNDLOICnRc=",
-          "range": "bytes=701-1140"
+          "checksum": "sha1-hgEBBo1tLreSINI2qiCUpUrIE9k=",
+          "range": "bytes=700-1139"
         },
         "data": {
-          "checksum": "sha256-2EP9UQKOVph+9hElnh20s8ViX126cAnPyNI+IF2pQ4Y=",
-          "range": "bytes=1141-838149"
+          "checksum": "sha256-OFDWkK8l015fs0YvTCXVKLQmOxq+7W5RgJHIqKYZsTE=",
+          "range": "bytes=1140-808582"
         },
         "name": "libcurl-openssl4",
         "signature": {
-          "checksum": "sha1-IxMuIpRYevSLukva0eWmB5RkhMY=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-sygIdNZXB/W8fyOrdelY5RXh3aA=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.7.1-r0.apk",
-        "version": "8.7.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.6.0-r0.apk",
+        "version": "8.6.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1DzKkXRny9JZJvzjFt3jIuvkDP8E=",
+        "checksum": "Q1eQzLI9XN4FM69fm9B4LWd9frcwM=",
         "control": {
-          "checksum": "sha1-DzKkXRny9JZJvzjFt3jIuvkDP8E=",
-          "range": "bytes=700-1101"
+          "checksum": "sha1-eQzLI9XN4FM69fm9B4LWd9frcwM=",
+          "range": "bytes=703-1098"
         },
         "data": {
-          "checksum": "sha256-l1iebyEPmteOEBcPDwPzstpqs9SMvCn8PqlvRU3O7jk=",
-          "range": "bytes=1102-351141"
+          "checksum": "sha256-zkew7+IbyyyENezhlStwO062zaWd+yP/lpbI+CCJVZQ=",
+          "range": "bytes=1099-281166"
         },
         "name": "curl",
         "signature": {
-          "checksum": "sha1-iVKgcLEjgrpj4c2TrRzHznPaWXA=",
-          "range": "bytes=0-699"
+          "checksum": "sha1-igXspQSxo3Eu3o8DeNrYt3YxSbY=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.7.1-r0.apk",
-        "version": "8.7.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.6.0-r0.apk",
+        "version": "8.6.0-r0"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/sourcegraph-template.lock.json
+++ b/wolfi-images/sourcegraph-template.lock.json
@@ -1,5 +1,5 @@
 {
-  "configHash": "5fed9a9ff05047132124e47112d127aa2b1df80b92242da7e43215ad4995c95a",
+  "configHash": "d6728ac5dafc7b8372e5d7874dae1e413e9299fdc78b52038bb739af7e0c3093",
   "contents": {
     "keyring": [
       {
@@ -698,41 +698,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1CC3jnItQWZ4ya5EB/TNDLOICnRc=",
+        "checksum": "Q1hgEBBo1tLreSINI2qiCUpUrIE9k=",
         "control": {
-          "checksum": "sha1-CC3jnItQWZ4ya5EB/TNDLOICnRc=",
-          "range": "bytes=701-1140"
+          "checksum": "sha1-hgEBBo1tLreSINI2qiCUpUrIE9k=",
+          "range": "bytes=700-1139"
         },
         "data": {
-          "checksum": "sha256-2EP9UQKOVph+9hElnh20s8ViX126cAnPyNI+IF2pQ4Y=",
-          "range": "bytes=1141-838149"
+          "checksum": "sha256-OFDWkK8l015fs0YvTCXVKLQmOxq+7W5RgJHIqKYZsTE=",
+          "range": "bytes=1140-808582"
         },
         "name": "libcurl-openssl4",
         "signature": {
-          "checksum": "sha1-IxMuIpRYevSLukva0eWmB5RkhMY=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-sygIdNZXB/W8fyOrdelY5RXh3aA=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.7.1-r0.apk",
-        "version": "8.7.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.6.0-r0.apk",
+        "version": "8.6.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1DzKkXRny9JZJvzjFt3jIuvkDP8E=",
+        "checksum": "Q1eQzLI9XN4FM69fm9B4LWd9frcwM=",
         "control": {
-          "checksum": "sha1-DzKkXRny9JZJvzjFt3jIuvkDP8E=",
-          "range": "bytes=700-1101"
+          "checksum": "sha1-eQzLI9XN4FM69fm9B4LWd9frcwM=",
+          "range": "bytes=703-1098"
         },
         "data": {
-          "checksum": "sha256-l1iebyEPmteOEBcPDwPzstpqs9SMvCn8PqlvRU3O7jk=",
-          "range": "bytes=1102-351141"
+          "checksum": "sha256-zkew7+IbyyyENezhlStwO062zaWd+yP/lpbI+CCJVZQ=",
+          "range": "bytes=1099-281166"
         },
         "name": "curl",
         "signature": {
-          "checksum": "sha1-iVKgcLEjgrpj4c2TrRzHznPaWXA=",
-          "range": "bytes=0-699"
+          "checksum": "sha1-igXspQSxo3Eu3o8DeNrYt3YxSbY=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.7.1-r0.apk",
-        "version": "8.7.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.6.0-r0.apk",
+        "version": "8.6.0-r0"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/sourcegraph-template.yaml
+++ b/wolfi-images/sourcegraph-template.yaml
@@ -16,9 +16,12 @@ contents:
 
     # TODO: Dev tools - remove in future release
     - busybox
-    - curl
+    - curl=8.6.0-r0 # TODO(will): Remove pin after resolving git fetch bug
     - wget
     - bind-tools
+
+    # TODO(will): Remove explicit add of libcurl after resolving git fetch bug
+    - libcurl-openssl4=8.6.0-r0
 
 # Add sourcegraph user and group
 # NOTE: Adding other accounts in files where sourcegraph-template.yaml is included will overwrite these users

--- a/wolfi-images/symbols.lock.json
+++ b/wolfi-images/symbols.lock.json
@@ -204,60 +204,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q13piSoRiT6p5eziGu2iPxSkXxf+g=",
+        "checksum": "Q1+rBEmKEIywe0o/a65ZPjWoUECRQ=",
         "control": {
-          "checksum": "sha1-3piSoRiT6p5eziGu2iPxSkXxf+g=",
-          "range": "bytes=704-1039"
+          "checksum": "sha1-+rBEmKEIywe0o/a65ZPjWoUECRQ=",
+          "range": "bytes=703-1054"
         },
         "data": {
-          "checksum": "sha256-+iLQJV5/mU/hTpwsy9zYBfzVIVkd8lXBBqMScHFhHfI=",
-          "range": "bytes=1040-87982"
+          "checksum": "sha256-fcShKjtj6wR6kgjwToU1J8hU+AGRf1OGZt9jeXJdM0Q=",
+          "range": "bytes=1055-82406"
         },
         "name": "openssl-config",
         "signature": {
-          "checksum": "sha1-fsygjfZl7YLgdpBZ5OVKJG/N2HI=",
-          "range": "bytes=0-703"
+          "checksum": "sha1-RT/o4gi2oC/l+6IhikP9/PH5awg=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/openssl-config-3.2.1-r0.apk",
-        "version": "3.2.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/openssl-config-3.3.0-r5.apk",
+        "version": "3.3.0-r5"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1kERnIFBBwTWZsA+cmGLkIU75THk=",
+        "checksum": "Q11DkfNRzraQMj7ue8LFH6VN6d7Bo=",
         "control": {
-          "checksum": "sha1-kERnIFBBwTWZsA+cmGLkIU75THk=",
-          "range": "bytes=694-1066"
+          "checksum": "sha1-1DkfNRzraQMj7ue8LFH6VN6d7Bo=",
+          "range": "bytes=707-1092"
         },
         "data": {
-          "checksum": "sha256-MB5ZoAsBJ0Osps0a1V0KsM/qQhfZQvYupElgoF1rNLE=",
-          "range": "bytes=1067-5895270"
+          "checksum": "sha256-c95GJNThldUhfxVSGbchUI0pS4j6h45Yx6JDPXHaAI0=",
+          "range": "bytes=1093-5915048"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-vTJq+p2AjVQQjJ4gSkR9ySDQr3k=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-EmjggcTaE4QTKI1FzSom0rXam1c=",
+          "range": "bytes=0-706"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.2.1-r0.apk",
-        "version": "3.2.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r5.apk",
+        "version": "3.3.0-r5"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1RFDJtvcstAQi4NjU00ApvNIvoEI=",
+        "checksum": "Q15sT5bGF6kgE7DepzZIHCpPpuP70=",
         "control": {
-          "checksum": "sha1-RFDJtvcstAQi4NjU00ApvNIvoEI=",
-          "range": "bytes=694-1065"
+          "checksum": "sha1-5sT5bGF6kgE7DepzZIHCpPpuP70=",
+          "range": "bytes=702-1085"
         },
         "data": {
-          "checksum": "sha256-oocCJOj9IF7jv3Ov8bPbaAGfq6oaYXuPNnZW9DnOdnE=",
-          "range": "bytes=1066-1135402"
+          "checksum": "sha256-fWOAfZYgXO6+yM4Dpo/y7dvV3uxSEhhfO4SUX79TQDw=",
+          "range": "bytes=1086-1196497"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-wJVFcqH/ewopq4lxwz8OYrZ9/Ws=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-4+7eITv9weTmoYBAAyd92WsXS24=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.2.1-r0.apk",
-        "version": "3.2.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r5.apk",
+        "version": "3.3.0-r5"
       },
       {
         "architecture": "x86_64",
@@ -337,22 +337,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1txYNrxLRCA8tpCe/aXw9Zeb30xw=",
+        "checksum": "Q1sGD1MEAazAXpfNixX74EpwafGo0=",
         "control": {
-          "checksum": "sha1-txYNrxLRCA8tpCe/aXw9Zeb30xw=",
-          "range": "bytes=703-1071"
+          "checksum": "sha1-sGD1MEAazAXpfNixX74EpwafGo0=",
+          "range": "bytes=698-1059"
         },
         "data": {
-          "checksum": "sha256-QgGnbFCQGaCUjwfFVcF2eOXDjZHaJjntdJlM1thwxd0=",
-          "range": "bytes=1072-252873"
+          "checksum": "sha256-s+9m0l/R7hVKQ5YLbU90D2E6DPC2QVTxdjhToMi5iYU=",
+          "range": "bytes=1060-251831"
         },
         "name": "libnghttp2-14",
         "signature": {
-          "checksum": "sha1-VWNh1CR9wcBEPwOH88Qr6n7OR08=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-wOIYtvU72n76UGvbargK2ccZx0E=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.60.0-r0.apk",
-        "version": "1.60.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.61.0-r0.apk",
+        "version": "1.61.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -432,41 +432,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1YKX8zXXVrSZ1a+od3zegHGvE7K4=",
+        "checksum": "Q1NZCvjmGBZ7soi6T4endRPtDztk4=",
         "control": {
-          "checksum": "sha1-YKX8zXXVrSZ1a+od3zegHGvE7K4=",
-          "range": "bytes=701-1168"
+          "checksum": "sha1-NZCvjmGBZ7soi6T4endRPtDztk4=",
+          "range": "bytes=698-1162"
         },
         "data": {
-          "checksum": "sha256-KnMN4TtaDNZqReNINaTivjzUoQigGvtRZgVEqc1EDHo=",
-          "range": "bytes=1169-2555088"
+          "checksum": "sha256-q79pSkGvnDzz1dHsQceLPqyVC+cFCyWWJB5L2EfkZRc=",
+          "range": "bytes=1163-2556930"
         },
         "name": "nghttp2",
         "signature": {
-          "checksum": "sha1-MWKiH9LAxjnWqAm536DCFrsZXCg=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-UuOeekThV8UC737772jFTRj0Y50=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.60.0-r0.apk",
-        "version": "1.60.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.61.0-r0.apk",
+        "version": "1.61.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1D/+xxUxpR+m3nGP5l/8Ed78nNC0=",
+        "checksum": "Q1O/sL8Kjkxzh39Ffh9gJl+0olkF4=",
         "control": {
-          "checksum": "sha1-D/+xxUxpR+m3nGP5l/8Ed78nNC0=",
-          "range": "bytes=700-1067"
+          "checksum": "sha1-O/sL8Kjkxzh39Ffh9gJl+0olkF4=",
+          "range": "bytes=700-1061"
         },
         "data": {
-          "checksum": "sha256-fKV2YLH6EP/NFtRSErdaCwZX+Mg6KJrfmt1VpRWeKis=",
-          "range": "bytes=1068-634389"
+          "checksum": "sha256-6qS8u1yYrzO+4Ypa+g4zfz3m16/7O/U4wjiRrKl8/vw=",
+          "range": "bytes=1062-631650"
         },
         "name": "nghttp2-dev",
         "signature": {
-          "checksum": "sha1-ZRWYUK14qaTBE3NC7OOWumdkSyY=",
+          "checksum": "sha1-avAz/6snsG86C9jh8Gxa59gs29U=",
           "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.60.0-r0.apk",
-        "version": "1.60.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.61.0-r0.apk",
+        "version": "1.61.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -508,41 +508,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1l9z4OGVfdVISNbyGQdXlz2GPchM=",
+        "checksum": "Q1wJPtj5XZtnPiVWGM5dsT+nyfWXc=",
         "control": {
-          "checksum": "sha1-l9z4OGVfdVISNbyGQdXlz2GPchM=",
-          "range": "bytes=695-1222"
+          "checksum": "sha1-wJPtj5XZtnPiVWGM5dsT+nyfWXc=",
+          "range": "bytes=705-1234"
         },
         "data": {
-          "checksum": "sha256-0Z+mq/0A1P+F5KIZKnsYpg8Eqb3GDRT7VDrZlTEg+4Y=",
-          "range": "bytes=1223-3863194"
+          "checksum": "sha256-sw+CjlpsjO01q6lqzXgHnniiJKn7bqOSNO6vNqdGc7I=",
+          "range": "bytes=1235-3873775"
         },
         "name": "bind-libs",
         "signature": {
-          "checksum": "sha1-YX2+1oZh/hXHVjZriSnJZQzpifg=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-9zDzmHAeu7mWpidXAatqrLZVzUs=",
+          "range": "bytes=0-704"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bind-libs-9.18.25-r0.apk",
-        "version": "9.18.25-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/bind-libs-9.18.26-r0.apk",
+        "version": "9.18.26-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Xb5w/MUeHFBeLgnHBmG7dqAMxzQ=",
+        "checksum": "Q1AxEQdi8fVcYtGc3zHTCW3OZdY2Q=",
         "control": {
-          "checksum": "sha1-Xb5w/MUeHFBeLgnHBmG7dqAMxzQ=",
-          "range": "bytes=705-1217"
+          "checksum": "sha1-AxEQdi8fVcYtGc3zHTCW3OZdY2Q=",
+          "range": "bytes=694-1208"
         },
         "data": {
-          "checksum": "sha256-/0zOh1KQW58NOuJgauDOdqJA4G4g0p6jPUOP45HN/f8=",
-          "range": "bytes=1218-892798"
+          "checksum": "sha256-/dt3qJw5D9iSJ/mKkRQkhWD8R52selhpcwXyw7KLMhg=",
+          "range": "bytes=1209-879444"
         },
         "name": "bind-tools",
         "signature": {
-          "checksum": "sha1-3GgaViNXeX4dd75pxgwR8yYgov0=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-VTb0YdUzPMk8Po0p4nj0y5Jey6k=",
+          "range": "bytes=0-693"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bind-tools-9.18.25-r0.apk",
-        "version": "9.18.25-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/bind-tools-9.18.26-r0.apk",
+        "version": "9.18.26-r0"
       },
       {
         "architecture": "x86_64",
@@ -641,22 +641,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1dGFbiBgyu1lUt4vBNm7r2mESS28=",
+        "checksum": "Q168tjKa9EJjh47h3gyGn4ThsOI0Y=",
         "control": {
-          "checksum": "sha1-dGFbiBgyu1lUt4vBNm7r2mESS28=",
-          "range": "bytes=662-1025"
+          "checksum": "sha1-68tjKa9EJjh47h3gyGn4ThsOI0Y=",
+          "range": "bytes=661-1023"
         },
         "data": {
-          "checksum": "sha256-LAD/RnKpyL0sWf9jJmOCehGrx1YOb6BQHtDz0Fz6fSI=",
-          "range": "bytes=1026-3654982"
+          "checksum": "sha256-w6qWTXBItkDiwjv1e03YFmm1yN4SmchoRth3p8a6Jno=",
+          "range": "bytes=1024-3626526"
         },
         "name": "ctags",
         "signature": {
-          "checksum": "sha1-o2j+eAV5drdyb1ohr7/+204Y4DQ=",
-          "range": "bytes=0-661"
+          "checksum": "sha1-2gi15ZhMJMoqzWB1KcbB1eZnX1w=",
+          "range": "bytes=0-660"
         },
-        "url": "https://packages.sgdev.org/main/x86_64/ctags-6.0.0-r4.apk",
-        "version": "6.0.0-r4"
+        "url": "https://packages.sgdev.org/main/x86_64/ctags-6.0.0-r6.apk",
+        "version": "6.0.0-r6"
       },
       {
         "architecture": "x86_64",
@@ -755,41 +755,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1CC3jnItQWZ4ya5EB/TNDLOICnRc=",
+        "checksum": "Q1hgEBBo1tLreSINI2qiCUpUrIE9k=",
         "control": {
-          "checksum": "sha1-CC3jnItQWZ4ya5EB/TNDLOICnRc=",
-          "range": "bytes=701-1140"
+          "checksum": "sha1-hgEBBo1tLreSINI2qiCUpUrIE9k=",
+          "range": "bytes=700-1139"
         },
         "data": {
-          "checksum": "sha256-2EP9UQKOVph+9hElnh20s8ViX126cAnPyNI+IF2pQ4Y=",
-          "range": "bytes=1141-838149"
+          "checksum": "sha256-OFDWkK8l015fs0YvTCXVKLQmOxq+7W5RgJHIqKYZsTE=",
+          "range": "bytes=1140-808582"
         },
         "name": "libcurl-openssl4",
         "signature": {
-          "checksum": "sha1-IxMuIpRYevSLukva0eWmB5RkhMY=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-sygIdNZXB/W8fyOrdelY5RXh3aA=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.7.1-r0.apk",
-        "version": "8.7.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.6.0-r0.apk",
+        "version": "8.6.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1DzKkXRny9JZJvzjFt3jIuvkDP8E=",
+        "checksum": "Q1eQzLI9XN4FM69fm9B4LWd9frcwM=",
         "control": {
-          "checksum": "sha1-DzKkXRny9JZJvzjFt3jIuvkDP8E=",
-          "range": "bytes=700-1101"
+          "checksum": "sha1-eQzLI9XN4FM69fm9B4LWd9frcwM=",
+          "range": "bytes=703-1098"
         },
         "data": {
-          "checksum": "sha256-l1iebyEPmteOEBcPDwPzstpqs9SMvCn8PqlvRU3O7jk=",
-          "range": "bytes=1102-351141"
+          "checksum": "sha256-zkew7+IbyyyENezhlStwO062zaWd+yP/lpbI+CCJVZQ=",
+          "range": "bytes=1099-281166"
         },
         "name": "curl",
         "signature": {
-          "checksum": "sha1-iVKgcLEjgrpj4c2TrRzHznPaWXA=",
-          "range": "bytes=0-699"
+          "checksum": "sha1-igXspQSxo3Eu3o8DeNrYt3YxSbY=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.7.1-r0.apk",
-        "version": "8.7.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.6.0-r0.apk",
+        "version": "8.6.0-r0"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/syntax-highlighter.lock.json
+++ b/wolfi-images/syntax-highlighter.lock.json
@@ -204,60 +204,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q13piSoRiT6p5eziGu2iPxSkXxf+g=",
+        "checksum": "Q1+rBEmKEIywe0o/a65ZPjWoUECRQ=",
         "control": {
-          "checksum": "sha1-3piSoRiT6p5eziGu2iPxSkXxf+g=",
-          "range": "bytes=704-1039"
+          "checksum": "sha1-+rBEmKEIywe0o/a65ZPjWoUECRQ=",
+          "range": "bytes=703-1054"
         },
         "data": {
-          "checksum": "sha256-+iLQJV5/mU/hTpwsy9zYBfzVIVkd8lXBBqMScHFhHfI=",
-          "range": "bytes=1040-87982"
+          "checksum": "sha256-fcShKjtj6wR6kgjwToU1J8hU+AGRf1OGZt9jeXJdM0Q=",
+          "range": "bytes=1055-82406"
         },
         "name": "openssl-config",
         "signature": {
-          "checksum": "sha1-fsygjfZl7YLgdpBZ5OVKJG/N2HI=",
-          "range": "bytes=0-703"
+          "checksum": "sha1-RT/o4gi2oC/l+6IhikP9/PH5awg=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/openssl-config-3.2.1-r0.apk",
-        "version": "3.2.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/openssl-config-3.3.0-r5.apk",
+        "version": "3.3.0-r5"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1kERnIFBBwTWZsA+cmGLkIU75THk=",
+        "checksum": "Q11DkfNRzraQMj7ue8LFH6VN6d7Bo=",
         "control": {
-          "checksum": "sha1-kERnIFBBwTWZsA+cmGLkIU75THk=",
-          "range": "bytes=694-1066"
+          "checksum": "sha1-1DkfNRzraQMj7ue8LFH6VN6d7Bo=",
+          "range": "bytes=707-1092"
         },
         "data": {
-          "checksum": "sha256-MB5ZoAsBJ0Osps0a1V0KsM/qQhfZQvYupElgoF1rNLE=",
-          "range": "bytes=1067-5895270"
+          "checksum": "sha256-c95GJNThldUhfxVSGbchUI0pS4j6h45Yx6JDPXHaAI0=",
+          "range": "bytes=1093-5915048"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-vTJq+p2AjVQQjJ4gSkR9ySDQr3k=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-EmjggcTaE4QTKI1FzSom0rXam1c=",
+          "range": "bytes=0-706"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.2.1-r0.apk",
-        "version": "3.2.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r5.apk",
+        "version": "3.3.0-r5"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1RFDJtvcstAQi4NjU00ApvNIvoEI=",
+        "checksum": "Q15sT5bGF6kgE7DepzZIHCpPpuP70=",
         "control": {
-          "checksum": "sha1-RFDJtvcstAQi4NjU00ApvNIvoEI=",
-          "range": "bytes=694-1065"
+          "checksum": "sha1-5sT5bGF6kgE7DepzZIHCpPpuP70=",
+          "range": "bytes=702-1085"
         },
         "data": {
-          "checksum": "sha256-oocCJOj9IF7jv3Ov8bPbaAGfq6oaYXuPNnZW9DnOdnE=",
-          "range": "bytes=1066-1135402"
+          "checksum": "sha256-fWOAfZYgXO6+yM4Dpo/y7dvV3uxSEhhfO4SUX79TQDw=",
+          "range": "bytes=1086-1196497"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-wJVFcqH/ewopq4lxwz8OYrZ9/Ws=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-4+7eITv9weTmoYBAAyd92WsXS24=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.2.1-r0.apk",
-        "version": "3.2.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r5.apk",
+        "version": "3.3.0-r5"
       },
       {
         "architecture": "x86_64",
@@ -337,22 +337,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1txYNrxLRCA8tpCe/aXw9Zeb30xw=",
+        "checksum": "Q1sGD1MEAazAXpfNixX74EpwafGo0=",
         "control": {
-          "checksum": "sha1-txYNrxLRCA8tpCe/aXw9Zeb30xw=",
-          "range": "bytes=703-1071"
+          "checksum": "sha1-sGD1MEAazAXpfNixX74EpwafGo0=",
+          "range": "bytes=698-1059"
         },
         "data": {
-          "checksum": "sha256-QgGnbFCQGaCUjwfFVcF2eOXDjZHaJjntdJlM1thwxd0=",
-          "range": "bytes=1072-252873"
+          "checksum": "sha256-s+9m0l/R7hVKQ5YLbU90D2E6DPC2QVTxdjhToMi5iYU=",
+          "range": "bytes=1060-251831"
         },
         "name": "libnghttp2-14",
         "signature": {
-          "checksum": "sha1-VWNh1CR9wcBEPwOH88Qr6n7OR08=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-wOIYtvU72n76UGvbargK2ccZx0E=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.60.0-r0.apk",
-        "version": "1.60.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.61.0-r0.apk",
+        "version": "1.61.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -432,41 +432,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1YKX8zXXVrSZ1a+od3zegHGvE7K4=",
+        "checksum": "Q1NZCvjmGBZ7soi6T4endRPtDztk4=",
         "control": {
-          "checksum": "sha1-YKX8zXXVrSZ1a+od3zegHGvE7K4=",
-          "range": "bytes=701-1168"
+          "checksum": "sha1-NZCvjmGBZ7soi6T4endRPtDztk4=",
+          "range": "bytes=698-1162"
         },
         "data": {
-          "checksum": "sha256-KnMN4TtaDNZqReNINaTivjzUoQigGvtRZgVEqc1EDHo=",
-          "range": "bytes=1169-2555088"
+          "checksum": "sha256-q79pSkGvnDzz1dHsQceLPqyVC+cFCyWWJB5L2EfkZRc=",
+          "range": "bytes=1163-2556930"
         },
         "name": "nghttp2",
         "signature": {
-          "checksum": "sha1-MWKiH9LAxjnWqAm536DCFrsZXCg=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-UuOeekThV8UC737772jFTRj0Y50=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.60.0-r0.apk",
-        "version": "1.60.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.61.0-r0.apk",
+        "version": "1.61.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1D/+xxUxpR+m3nGP5l/8Ed78nNC0=",
+        "checksum": "Q1O/sL8Kjkxzh39Ffh9gJl+0olkF4=",
         "control": {
-          "checksum": "sha1-D/+xxUxpR+m3nGP5l/8Ed78nNC0=",
-          "range": "bytes=700-1067"
+          "checksum": "sha1-O/sL8Kjkxzh39Ffh9gJl+0olkF4=",
+          "range": "bytes=700-1061"
         },
         "data": {
-          "checksum": "sha256-fKV2YLH6EP/NFtRSErdaCwZX+Mg6KJrfmt1VpRWeKis=",
-          "range": "bytes=1068-634389"
+          "checksum": "sha256-6qS8u1yYrzO+4Ypa+g4zfz3m16/7O/U4wjiRrKl8/vw=",
+          "range": "bytes=1062-631650"
         },
         "name": "nghttp2-dev",
         "signature": {
-          "checksum": "sha1-ZRWYUK14qaTBE3NC7OOWumdkSyY=",
+          "checksum": "sha1-avAz/6snsG86C9jh8Gxa59gs29U=",
           "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.60.0-r0.apk",
-        "version": "1.60.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.61.0-r0.apk",
+        "version": "1.61.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -508,41 +508,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1l9z4OGVfdVISNbyGQdXlz2GPchM=",
+        "checksum": "Q1wJPtj5XZtnPiVWGM5dsT+nyfWXc=",
         "control": {
-          "checksum": "sha1-l9z4OGVfdVISNbyGQdXlz2GPchM=",
-          "range": "bytes=695-1222"
+          "checksum": "sha1-wJPtj5XZtnPiVWGM5dsT+nyfWXc=",
+          "range": "bytes=705-1234"
         },
         "data": {
-          "checksum": "sha256-0Z+mq/0A1P+F5KIZKnsYpg8Eqb3GDRT7VDrZlTEg+4Y=",
-          "range": "bytes=1223-3863194"
+          "checksum": "sha256-sw+CjlpsjO01q6lqzXgHnniiJKn7bqOSNO6vNqdGc7I=",
+          "range": "bytes=1235-3873775"
         },
         "name": "bind-libs",
         "signature": {
-          "checksum": "sha1-YX2+1oZh/hXHVjZriSnJZQzpifg=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-9zDzmHAeu7mWpidXAatqrLZVzUs=",
+          "range": "bytes=0-704"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bind-libs-9.18.25-r0.apk",
-        "version": "9.18.25-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/bind-libs-9.18.26-r0.apk",
+        "version": "9.18.26-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Xb5w/MUeHFBeLgnHBmG7dqAMxzQ=",
+        "checksum": "Q1AxEQdi8fVcYtGc3zHTCW3OZdY2Q=",
         "control": {
-          "checksum": "sha1-Xb5w/MUeHFBeLgnHBmG7dqAMxzQ=",
-          "range": "bytes=705-1217"
+          "checksum": "sha1-AxEQdi8fVcYtGc3zHTCW3OZdY2Q=",
+          "range": "bytes=694-1208"
         },
         "data": {
-          "checksum": "sha256-/0zOh1KQW58NOuJgauDOdqJA4G4g0p6jPUOP45HN/f8=",
-          "range": "bytes=1218-892798"
+          "checksum": "sha256-/dt3qJw5D9iSJ/mKkRQkhWD8R52selhpcwXyw7KLMhg=",
+          "range": "bytes=1209-879444"
         },
         "name": "bind-tools",
         "signature": {
-          "checksum": "sha1-3GgaViNXeX4dd75pxgwR8yYgov0=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-VTb0YdUzPMk8Po0p4nj0y5Jey6k=",
+          "range": "bytes=0-693"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bind-tools-9.18.25-r0.apk",
-        "version": "9.18.25-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/bind-tools-9.18.26-r0.apk",
+        "version": "9.18.26-r0"
       },
       {
         "architecture": "x86_64",
@@ -698,60 +698,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1CC3jnItQWZ4ya5EB/TNDLOICnRc=",
+        "checksum": "Q1hgEBBo1tLreSINI2qiCUpUrIE9k=",
         "control": {
-          "checksum": "sha1-CC3jnItQWZ4ya5EB/TNDLOICnRc=",
-          "range": "bytes=701-1140"
+          "checksum": "sha1-hgEBBo1tLreSINI2qiCUpUrIE9k=",
+          "range": "bytes=700-1139"
         },
         "data": {
-          "checksum": "sha256-2EP9UQKOVph+9hElnh20s8ViX126cAnPyNI+IF2pQ4Y=",
-          "range": "bytes=1141-838149"
+          "checksum": "sha256-OFDWkK8l015fs0YvTCXVKLQmOxq+7W5RgJHIqKYZsTE=",
+          "range": "bytes=1140-808582"
         },
         "name": "libcurl-openssl4",
         "signature": {
-          "checksum": "sha1-IxMuIpRYevSLukva0eWmB5RkhMY=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-sygIdNZXB/W8fyOrdelY5RXh3aA=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.7.1-r0.apk",
-        "version": "8.7.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.6.0-r0.apk",
+        "version": "8.6.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1DzKkXRny9JZJvzjFt3jIuvkDP8E=",
+        "checksum": "Q1eQzLI9XN4FM69fm9B4LWd9frcwM=",
         "control": {
-          "checksum": "sha1-DzKkXRny9JZJvzjFt3jIuvkDP8E=",
-          "range": "bytes=700-1101"
+          "checksum": "sha1-eQzLI9XN4FM69fm9B4LWd9frcwM=",
+          "range": "bytes=703-1098"
         },
         "data": {
-          "checksum": "sha256-l1iebyEPmteOEBcPDwPzstpqs9SMvCn8PqlvRU3O7jk=",
-          "range": "bytes=1102-351141"
+          "checksum": "sha256-zkew7+IbyyyENezhlStwO062zaWd+yP/lpbI+CCJVZQ=",
+          "range": "bytes=1099-281166"
         },
         "name": "curl",
         "signature": {
-          "checksum": "sha1-iVKgcLEjgrpj4c2TrRzHznPaWXA=",
-          "range": "bytes=0-699"
+          "checksum": "sha1-igXspQSxo3Eu3o8DeNrYt3YxSbY=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.7.1-r0.apk",
-        "version": "8.7.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.6.0-r0.apk",
+        "version": "8.6.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1qm88ybuvQ7iPsBe2+1JkG7tJWTU=",
+        "checksum": "Q1GSk1Jwgf63rR8cF38DSN3T+uSxg=",
         "control": {
-          "checksum": "sha1-qm88ybuvQ7iPsBe2+1JkG7tJWTU=",
-          "range": "bytes=661-1002"
+          "checksum": "sha1-GSk1Jwgf63rR8cF38DSN3T+uSxg=",
+          "range": "bytes=660-1000"
         },
         "data": {
-          "checksum": "sha256-ZYrK7MsKPVUwu3pK70RXFB7KIXFwjmLumH/6tzdH0PQ=",
-          "range": "bytes=1003-17496449"
+          "checksum": "sha256-dTzS22SU1qHOT6aAOQfPYH7QrHkOKTQLkTzcJ3sodhc=",
+          "range": "bytes=1001-17447372"
         },
         "name": "http-server-stabilizer",
         "signature": {
-          "checksum": "sha1-DiAExfU0bu6xzPrwLOi1aACakNc=",
-          "range": "bytes=0-660"
+          "checksum": "sha1-a47keLXsSHZ8Imay1bD93qkHsBI=",
+          "range": "bytes=0-659"
         },
-        "url": "https://packages.sgdev.org/main/x86_64/http-server-stabilizer-1.1.0-r2.apk",
-        "version": "1.1.0-r2"
+        "url": "https://packages.sgdev.org/main/x86_64/http-server-stabilizer-1.1.0-r3.apk",
+        "version": "1.1.0-r3"
       },
       {
         "architecture": "x86_64",


### PR DESCRIPTION
* Pin curl and libcurl to 8.6.0-r0 due to a regression introduced in 8.7.1-r0 that affects gitserver
  * Pinning an older version of curl introduces CVE-2024-2398. This is rated Medium (though trivy reports it as high 🤔) and not exploitable  
* Update all other package to latest versions

cc @eseliger 

## Test plan

- Buildkite CI

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
