### PR TITLE
Pin curl packages and update base images

### DIFF
--- a/wolfi-images/sourcegraph-base.yaml
+++ b/wolfi-images/sourcegraph-base.yaml
@@ -16,9 +16,12 @@ contents:
 
     # TODO: Dev tools - remove in future release
     - busybox
-    - curl
+    - curl=8.6.0-r0 # TODO(will): Remove pin after resolving git fetch bug
     - wget
     - bind-tools
+
+    # TODO(will): Remove explicit add of libcurl after resolving git fetch bug
+    - libcurl-openssl4=8.6.0-r0
 
 # Add sourcegraph user and group
 # NOTE: Adding other accounts in files where sourcegraph-base.yaml is included will overwrite these users


### PR DESCRIPTION
@eseliger and I [identified a regression](https://sourcegraph.slack.com/archives/C1JH2BEHZ/p1713493749089869) in gitserver caused by libcurl 8.7.1, which was not present in 8.6.0.

To fix, pin the curl and libcurl packages to an older version. Although this reintroduces a medium-severity CVE, but this is an acceptable tradeoff due to its medium severity and lack of exploitability.

This PR also updates all the base images to pull in updated packages.

## Test plan

- CI
- Check `curl --version` output

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
