### PR TITLE
[Backport 5.3.9104] Context: avoid panic on stopwords query (#62026)

### DIFF
--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -1105,6 +1105,52 @@ func testSearchClient(t *testing.T, client searchClient) {
 		}
 	})
 
+	t.Run("Cody context search", func(t *testing.T) {
+		tests := []struct {
+			name       string
+			query      string
+			zeroResult bool
+		}{
+			{
+				name:       "Cody context, simple query, results",
+				query:      `repo:^github\.com/sgtest/go-diff$ patterntype:codycontext PrintMultiFileDiff unified `,
+				zeroResult: false,
+			},
+			{
+				name:       "Cody context, simple query, no results",
+				query:      `repo:^github\.com/sgtest/go-diff$ patterntype:codycontext DOES_NOT_EXIST ALSO_DOES_NOT_EXIST `,
+				zeroResult: true,
+			},
+			{
+				name:       "Cody context, all stopwords in query",
+				query:      `repo:^github\.com/sgtest/go-diff$ patterntype:codycontext tell me again!`,
+				zeroResult: true,
+			},
+		}
+		for _, test := range tests {
+			t.Run(test.name, func(t *testing.T) {
+				results, err := client.SearchFiles(test.query)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				if results.Alert != nil {
+					t.Fatalf("Unexpected alert %v", results.Alert)
+				}
+
+				if test.zeroResult {
+					if len(results.Results) > 0 {
+						t.Fatalf("Want zero result but got %d", len(results.Results))
+					}
+				} else {
+					if len(results.Results) == 0 {
+						t.Fatal("Want non-zero results but got 0")
+					}
+				}
+			})
+		}
+	})
+
 	type counts struct {
 		Repo    int
 		Commit  int

--- a/internal/search/codycontext/job.go
+++ b/internal/search/codycontext/job.go
@@ -19,7 +19,10 @@ func NewSearchJob(plan query.Plan, newJob func(query.Basic) (job.Job, error)) (j
 
 	basicQuery := plan[0].ToParseTree()
 	q, err := queryStringToKeywordQuery(query.StringHuman(basicQuery))
-	if err != nil || q == nil {
+
+	// If there are no patterns left, this query was entirely composed of
+	// stopwords, so we return no results.
+	if err != nil || len(q.patterns) == 0 {
 		return nil, err
 	}
 

--- a/internal/search/job/jobutil/job_test.go
+++ b/internal/search/job/jobutil/job_test.go
@@ -1110,6 +1110,22 @@ func TestNewPlanJob(t *testing.T) {
             (patternInfo.fileMatchLimit . 10000)))))))
 `),
 		},
+		{
+			query:      `context:global repo:sourcegraph/.* what's going on'? lang:go`,
+			protocol:   search.Streaming,
+			searchType: query.SearchTypeCodyContext,
+			want: autogold.Expect(`
+(LOG
+  (ALERT
+    (features . error decoding features)
+    (protocol . Streaming)
+    (onSourcegraphDotCom . true)
+    (query . )
+    (originalQuery . )
+    (patternType . codycontext)
+    ))
+`),
+		},
 		// The next query shows an unexpected way that a query is
 		// translated into a global zoekt query, all depending on if context:
 		// is specified (which it normally is). We expect to just have one

--- a/internal/search/job/jobutil/job_test.go
+++ b/internal/search/job/jobutil/job_test.go
@@ -1123,7 +1123,7 @@ func TestNewPlanJob(t *testing.T) {
     (query . )
     (originalQuery . )
     (patternType . codycontext)
-    ))
+    NOOP))
 `),
 		},
 		// The next query shows an unexpected way that a query is


### PR DESCRIPTION
This backport folds together these two PRs, which together fix a bug around
queries containing only stopwords:
* https://github.com/sourcegraph/sourcegraph/pull/61848
* https://github.com/sourcegraph/sourcegraph/pull/62026

## Test plan

Same test plan as original PRs