### PR TITLE
WIP: Move SSC frontend to the monorepo

### DIFF
--- a/client/cody-plg/package.json
+++ b/client/cody-plg/package.json
@@ -1,0 +1,19 @@
+{
+  "private": true,
+  "name": "@sourcegraph/cody-plg",
+  "version": "0.0.7",
+  "description": "Cody PLG library",
+  "license": "Apache-2.0",
+  "main": "src/index.ts",
+  "sideEffects": false,
+  "dependencies": {
+    "@stripe/react-stripe-js": "^2.4.0",
+    "@stripe/stripe-js": "^2.3.0"
+  },
+  "scripts": {
+    "build": "tsc --build && cp -R src/* dist/",
+    "lint": "pnpm run lint:js",
+    "lint:js": "eslint --cache '**/*.[tj]s?(x)'",
+    "test": "vitest"
+  }
+}

--- a/client/shared/src/settings/temporary/TemporarySettings.ts
+++ b/client/shared/src/settings/temporary/TemporarySettings.ts
@@ -91,6 +91,10 @@ export interface TemporarySettingsSchema {
 
     /** OpenCodeGraph */
     'openCodeGraph.annotations.visible': boolean
+
+    /** PLG */
+    'sourcegraph.debug.show-subscription-details': boolean
+    'sourcegraph.debug.always-show-new-signup': boolean
 }
 
 /**

--- a/client/web/package.json
+++ b/client/web/package.json
@@ -46,6 +46,7 @@
     "@sourcegraph/schema": "workspace:*",
     "@sourcegraph/shared": "workspace:*",
     "@sourcegraph/telemetry": "^0.11.0",
-    "@sourcegraph/wildcard": "workspace:*"
+    "@sourcegraph/wildcard": "workspace:*",
+    "@sourcegraph/cody-plg": "workspace:*"
   }
 }

--- a/client/web/src/cody/plan/BackIcon.tsx
+++ b/client/web/src/cody/plan/BackIcon.tsx
@@ -1,0 +1,12 @@
+import { FunctionComponent } from 'react'
+
+export const BackIcon: FunctionComponent = () => {
+    return (
+        <svg width="17" height="17" viewBox="0 0 17 17" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <path
+                d="M6.49967 12.8667L7.43967 11.9267L4.38634 8.86666H15.1663V7.53333H4.38634L7.44634 4.47333L6.49967 3.53333L1.83301 8.19999L6.49967 12.8667Z"
+                fill="#0B70DB"
+            />
+        </svg>
+    )
+}

--- a/client/web/src/cody/plan/CodyPlanPage.module.scss
+++ b/client/web/src/cody/plan/CodyPlanPage.module.scss
@@ -1,0 +1,76 @@
+@import 'wildcard/src/global-styles/breakpoints';
+
+.responsive-container {
+    @media (--sm-breakpoint-down) {
+        flex-direction: column;
+        align-items: center;
+
+        > div {
+            border: none !important;
+            align-items: center;
+        }
+    }
+}
+
+.container {
+    border-radius: 6px;
+    border: 1px solid (--border-color);
+    box-shadow: 0 1px 1px rgba(0, 0, 0, 0.05);
+}
+
+.plan-name {
+    font-size: 1.5rem;
+    font-weight: 600;
+}
+
+.counter {
+    font-size: 1.25rem;
+}
+
+.ide-name {
+    font-size: 1rem;
+}
+
+.modal {
+    width: 50rem;
+}
+
+.release-stage {
+    color: var(--gray-07);
+}
+
+.ide-header {
+    padding: calc(var(--spacer) * 0.5);
+    margin: calc(var(--spacer) * -0.5);
+    border-radius: var(--border-radius);
+}
+
+.ide-header:hover {
+    cursor: pointer;
+    background: var(--subtle-bg);
+}
+
+.upgrade-to-pro-banner {
+    background-color: #f8eceb;
+    border-radius: 0.375rem;
+    box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.03), 0 1px 1px 0 rgba(0, 0, 0, 0.05);
+
+    :global(.theme-dark) & {
+        background-color: var(--color-bg-1);
+    }
+}
+
+.dont-lose-cody-pro-banner {
+    background: linear-gradient(0deg, rgba(255, 255, 255, 0.9), rgba(255, 255, 255, 0.9)),
+        linear-gradient(90deg, #7048e8 0%, #4ac1e8 32.21%, #4d0b79 65.39%, #ff5543 104.43%), #eff2f5;
+    border-radius: 0.375rem;
+    :global(.theme-dark) & {
+        background: linear-gradient(0deg, rgba(255, 255, 255, 0.9) 0%, rgba(255, 255, 255, 0.9) 100%),
+            linear-gradient(90deg, #7048e8 0%, #4ac1e8 32.21%, #4d0b79 65.39%, #ff5543 104.43%);
+        box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.03), 0 1px 1px 0 rgba(0, 0, 0, 0.05);
+    }
+}
+
+.credit-card-emoji {
+    font-size: 2rem;
+}

--- a/client/web/src/cody/plan/CodyPlanPage.tsx
+++ b/client/web/src/cody/plan/CodyPlanPage.tsx
@@ -1,0 +1,153 @@
+import React, { useCallback, useEffect } from 'react'
+
+import { mdiCreditCardOutline } from '@mdi/js'
+import classNames from 'classnames'
+import { useNavigate } from 'react-router-dom'
+
+import { useQuery } from '@sourcegraph/http-client'
+import type { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
+import { ButtonLink, H1, H2, Icon, Link, PageHeader, Text, useSearchParameters } from '@sourcegraph/wildcard'
+
+import type { AuthenticatedUser } from '../../auth'
+import { Page } from '../../components/Page'
+import { PageTitle } from '../../components/PageTitle'
+import {
+    type UserCodyPlanResult,
+    type UserCodyPlanVariables,
+    CodySubscriptionPlan,
+} from '../../graphql-operations'
+import { CodyProIcon, DashboardIcon } from '../components/CodyIcon'
+import { isCodyEnabled } from '../isCodyEnabled'
+import { CodyOnboarding } from '../onboarding/CodyOnboarding'
+import { useCodyPaymentsUrl } from '../subscription/CodySubscriptionPage'
+import { USER_CODY_PLAN } from '../subscription/queries'
+
+import styles from './CodyPlanPage.module.scss'
+
+interface CodyPlanPageProps extends TelemetryV2Props {
+    isSourcegraphDotCom: boolean
+    authenticatedUser: AuthenticatedUser | null
+}
+
+export enum EditorStep {
+    SetupInstructions = 0,
+    CodyFeatures = 1,
+}
+
+export const CodyPlanPage: React.FunctionComponent<CodyPlanPageProps> = ({
+    isSourcegraphDotCom,
+    authenticatedUser,
+    telemetryRecorder,
+}) => {
+    const parameters = useSearchParameters()
+
+    const utm_source = parameters.get('utm_source')
+
+    useEffect(() => {
+        telemetryRecorder.recordEvent('cody.management', 'view')
+    }, [utm_source, telemetryRecorder])
+
+    const { data, error: dataError } = useQuery<UserCodyPlanResult, UserCodyPlanVariables>(USER_CODY_PLAN, {})
+
+    const subscription = data?.currentUser?.codySubscription
+
+    const codyPaymentsUrl = useCodyPaymentsUrl()
+    const manageSubscriptionRedirectURL = `${codyPaymentsUrl}/cody/subscription`
+
+    const navigate = useNavigate()
+
+    useEffect(() => {
+        if (!!data && !data?.currentUser) {
+            navigate('/sign-in?returnTo=/cody/manage')
+        }
+    }, [data, navigate])
+
+    const onClickUpgradeToProCTA = useCallback(() => {
+        telemetryRecorder.recordEvent('cody.management.upgradeToProCTA', 'click')
+    }, [telemetryRecorder])
+
+    if (dataError) {
+        throw dataError
+    }
+
+    if (!isCodyEnabled() || !isSourcegraphDotCom || !subscription) {
+        return null
+    }
+
+    const isUserOnProTier = subscription.plan === CodySubscriptionPlan.PRO
+
+    return (
+        <>
+            <Page className={classNames('d-flex flex-column')}>
+                <PageTitle title="Your Cody plan" />
+                <PageHeader className="mb-4 mt-4">
+                    <PageHeader.Heading as="h2" styleAs="h1">
+                        <div className="d-inline-flex align-items-center">
+                            <DashboardIcon className="mr-2" /> Your Cody plan
+                        </div>
+                    </PageHeader.Heading>
+                </PageHeader>
+
+                {!isUserOnProTier && <UpgradeToProBanner onClick={onClickUpgradeToProCTA} />}
+
+                <div className={classNames('p-4 border bg-1 mt-4', styles.container)}>
+                    <div className="d-flex justify-content-between align-items-center border-bottom pb-3">
+                        <div>
+                            <H2>My subscription</H2>
+                            <Text className="text-muted mb-0">
+                                {isUserOnProTier ? (
+                                    'You are on the Pro tier.'
+                                ) : (
+                                    <span>
+                                        You are on the Free tier.{' '}
+                                        <Link to="/cody/subscription">Upgrade to the Pro tier.</Link>
+                                    </span>
+                                )}
+                            </Text>
+                        </div>
+                        {isUserOnProTier && (
+                            <div>
+                                <ButtonLink
+                                    variant="primary"
+                                    size="sm"
+                                    href={manageSubscriptionRedirectURL}
+                                    onClick={event => {
+                                        event.preventDefault()
+                                        telemetryRecorder.recordEvent('cody.manageSubscription', 'click')
+                                        window.location.href = manageSubscriptionRedirectURL
+                                    }}
+                                >
+                                    <Icon svgPath={mdiCreditCardOutline} className="mr-1" aria-hidden={true} />
+                                    Manage subscription
+                                </ButtonLink>
+                            </div>
+                        )}
+                    </div>
+                </div>
+            </Page>
+            <CodyOnboarding authenticatedUser={authenticatedUser} telemetryRecorder={telemetryRecorder} />
+        </>
+    )
+}
+
+const UpgradeToProBanner: React.FunctionComponent<{
+    onClick: () => void
+}> = ({ onClick }) => (
+    <div className={classNames('d-flex justify-content-between align-items-center p-4', styles.upgradeToProBanner)}>
+        <div>
+            <H1>
+                Become limitless with
+                <CodyProIcon className="ml-1" />
+            </H1>
+            <ul className="pl-4 mb-0">
+                <li>Unlimited autocompletions</li>
+                <li>Unlimited chat messages</li>
+            </ul>
+        </div>
+        <div>
+            <ButtonLink to="/cody/subscription" variant="primary" size="sm" onClick={onClick}>
+                Upgrade
+            </ButtonLink>
+        </div>
+    </div>
+)

--- a/client/web/src/cody/plan/LoadingPage.tsx
+++ b/client/web/src/cody/plan/LoadingPage.tsx
@@ -1,0 +1,9 @@
+import { FunctionComponent } from 'react'
+
+export const LoadingPage: FunctionComponent = () => {
+    return (
+        <main className="flex justify-center items-center h-screen">
+            <div className="spinner w-8 h-8 border-4 border-blue-700 border-t-transparent rounded-full animate-spin"></div>
+        </main>
+    )
+}

--- a/client/web/src/routes.constants.ts
+++ b/client/web/src/routes.constants.ts
@@ -40,6 +40,7 @@ export enum PageRoutes {
     Cody = '/cody',
     CodyChat = '/cody/chat',
     CodyManagement = '/cody/manage',
+    CodyPlan = '/cody/plan',
     CodySubscription = '/cody/subscription',
     Own = '/own',
 }

--- a/client/web/src/routes.tsx
+++ b/client/web/src/routes.tsx
@@ -9,6 +9,7 @@ import { communitySearchContextsRoutes } from './communitySearchContexts/routes'
 import { type LegacyLayoutRouteContext, LegacyRoute } from './LegacyRouteContext'
 import { PageRoutes } from './routes.constants'
 import { isSearchJobsEnabled } from './search-jobs/utility'
+import { CodyPlanPage } from './cody/plan/CodyPlanPage'
 
 const SiteAdminArea = lazyComponent(() => import('./site-admin/SiteAdminArea'), 'SiteAdminArea')
 const SearchConsolePage = lazyComponent(() => import('./search/SearchConsolePage'), 'SearchConsolePage')
@@ -391,6 +392,17 @@ export const routes: RouteObject[] = [
             <LegacyRoute
                 render={props => (
                     <CodyManagementPage {...props} telemetryRecorder={props.platformContext.telemetryRecorder} />
+                )}
+                condition={({ licenseFeatures }) => licenseFeatures.isCodyEnabled}
+            />
+        ),
+    },
+    {
+        path: PageRoutes.CodyPlan,
+        element: (
+            <LegacyRoute
+                render={props => (
+                    <CodyPlanPage {...props} telemetryRecorder={props.platformContext.telemetryRecorder} />
                 )}
                 condition={({ licenseFeatures }) => licenseFeatures.isCodyEnabled}
             />

--- a/cmd/frontend/internal/app/ui/router.go
+++ b/cmd/frontend/internal/app/ui/router.go
@@ -145,9 +145,10 @@ func InitRouter(db database.DB) {
 		{path: "/search/cody", name: "cody-search", title: "Search (Cody)", index: false},
 		{path: "/app/coming-soon", name: "app-coming-soon", title: "Coming soon", index: false},
 		{path: "/app/auth/callback", name: "app-auth-callback", title: "Auth callback", index: false},
-		{path: "/cody/manage", name: "cody", title: "Cody Manage", index: false},
-		{path: "/cody/subscription", name: "cody", title: "Cody Pricing", index: false},
-		{path: "/cody/chat", name: "cody", title: "Cody", index: false},
+		{path: "/cody/manage", name: "cody-manage", title: "Cody Manage", index: false},
+		{path: "/cody/subscription", name: "cody-subscription", title: "Cody Pricing", index: false},
+		{path: "/cody/plan", name: "cody-plan", title: "Cody Plan", index: false},
+		{path: "/cody/chat", name: "cody-chat", title: "Cody", index: false},
 		{path: "/cody/chat/{chatID}", name: "cody-chat", title: "Cody", index: false},
 		// TODO: [TEMPORARY] remove this redirect route when the marketing page is added.
 		{path: "/cody", name: "cody", title: "Cody", index: false},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1220,6 +1220,15 @@ importers:
         specifier: workspace:*
         version: link:../testing
 
+  client/cody-plg:
+    dependencies:
+      '@stripe/react-stripe-js':
+        specifier: ^2.4.0
+        version: 2.7.0(@stripe/stripe-js@2.4.0)(react-dom@18.1.0)(react@18.1.0)
+      '@stripe/stripe-js':
+        specifier: ^2.3.0
+        version: 2.4.0
+
   client/cody-shared:
     dependencies:
       '@microsoft/fetch-event-source':
@@ -1469,6 +1478,9 @@ importers:
       '@sourcegraph/codeintellify':
         specifier: workspace:*
         version: link:../codeintellify
+      '@sourcegraph/cody-plg':
+        specifier: workspace:*
+        version: link:../cody-plg
       '@sourcegraph/cody-shared':
         specifier: workspace:*
         version: link:../cody-shared
@@ -10393,6 +10405,23 @@ packages:
       '@storybook/channels': 8.0.5
       '@types/express': 4.17.11
       file-system-cache: 2.3.0
+
+  /@stripe/react-stripe-js@2.7.0(@stripe/stripe-js@2.4.0)(react-dom@18.1.0)(react@18.1.0):
+    resolution: {integrity: sha512-kTkIZl2ZleBuDR9c6fDy/s4m33llII8a5al6BDAMSTrfVq/4gSZv3RBO5KS/xvnxS+fDapJ3bKvjD8Lqj+AKdQ==}
+    peerDependencies:
+      '@stripe/stripe-js': ^1.44.1 || ^2.0.0 || ^3.0.0
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+    dependencies:
+      '@stripe/stripe-js': 2.4.0
+      prop-types: 15.8.1
+      react: 18.1.0
+      react-dom: 18.1.0(react@18.1.0)
+    dev: false
+
+  /@stripe/stripe-js@2.4.0:
+    resolution: {integrity: sha512-WFkQx1mbs2b5+7looI9IV1BLa3bIApuN3ehp9FP58xGg7KL9hCHDECgW3BwO9l9L+xBPVAD7Yjn1EhGe6EDTeA==}
+    dev: false
 
   /@sveltejs/adapter-auto@3.1.1(@sveltejs/kit@2.4.2):
     resolution: {integrity: sha512-6LeZft2Fo/4HfmLBi5CucMYmgRxgcETweQl/yQoZo/895K3S9YWYN4Sfm/IhwlIpbJp3QNvhKmwCHbsqQNYQpw==}


### PR DESCRIPTION
Little progress with moving the SSC front end to the monorepo.

Caveats / WIP parts:
- Three major components missing
- Need to replace Tailwind styling with CSS (Cody or ChatGPT should help)
- Need to replace icons with Wildcard icons
- Need to import Stripe through `@sourcegraph/cody-plg` rather than directly
- "refetch" needs to be mocked
- Absolutely untested

## Test plan

Move first, then make sure it works with the mocked back end. Once it works, we can merge this branch behind a feature flag if needed. Without a feature flag, it might be confusing: even if we don't publish the link anywhere, someone might stumble upon it.
But we could also just continue by connecting it to the back end.