### PR TITLE
KeywordSearch: Honor default search pattern type if present

### DIFF
--- a/client/web/src/stores/navbarSearchQueryState.test.ts
+++ b/client/web/src/stores/navbarSearchQueryState.test.ts
@@ -157,7 +157,7 @@ describe('navbar query state', () => {
             expect(useNavbarQueryState.getState()).toHaveProperty('searchPatternType', SearchPatternType.regexp)
         })
 
-        it('prefers keyword search over user settings if keyword search is enabled', () => {
+        it('honors default user settings even if keyword search is enabled', () => {
             setQueryStateFromURL(parseSearchURL(''))
             setQueryStateFromSettings({
                 subjects: [],

--- a/client/web/src/stores/navbarSearchQueryState.test.ts
+++ b/client/web/src/stores/navbarSearchQueryState.test.ts
@@ -162,7 +162,7 @@ describe('navbar query state', () => {
             setQueryStateFromSettings({
                 subjects: [],
                 final: {
-                    'search.defaultPatternType': SearchPatternType.standard,
+                    'search.defaultPatternType': SearchPatternType.regexp,
                     experimentalFeatures: {
                         keywordSearch: true,
                     },
@@ -170,7 +170,7 @@ describe('navbar query state', () => {
             })
 
             expect(useNavbarQueryState.getState()).toHaveProperty('searchMode', SearchMode.Precise)
-            expect(useNavbarQueryState.getState()).toHaveProperty('searchPatternType', SearchPatternType.keyword)
+            expect(useNavbarQueryState.getState()).toHaveProperty('searchPatternType', SearchPatternType.regexp)
         })
 
         it('chooses correct defaults when keyword search is enabled', () => {

--- a/client/web/src/util/settings.ts
+++ b/client/web/src/util/settings.ts
@@ -61,12 +61,14 @@ export function defaultSearchModeFromSettings(settingsCascade: SettingsCascadeOr
  * configured by the user.
  */
 export function defaultPatternTypeFromSettings(settingsCascade: SettingsCascadeOrError): SearchPatternType | undefined {
-    // When the 'keyword search' language update is enabled, default to the 'keyword' patterntype
-    if (isKeywordSearchEnabled(settingsCascade)) {
-        return SearchPatternType.keyword
-    }
-
-    return getFromSettings(settingsCascade, 'search.defaultPatternType')
+    const defaultPatternType: SearchPatternType | undefined = getFromSettings(
+        settingsCascade,
+        'search.defaultPatternType'
+    )
+    // When the 'keyword search' language update is enabled, default to the 'keyword' patterntype if none set
+    return isKeywordSearchEnabled(settingsCascade)
+        ? defaultPatternType ?? SearchPatternType.keyword
+        : defaultPatternType
 }
 
 /**

--- a/client/web/src/util/settings.ts
+++ b/client/web/src/util/settings.ts
@@ -66,9 +66,10 @@ export function defaultPatternTypeFromSettings(settingsCascade: SettingsCascadeO
         'search.defaultPatternType'
     )
     // When the 'keyword search' language update is enabled, default to the 'keyword' patterntype if none set
-    return isKeywordSearchEnabled(settingsCascade)
-        ? defaultPatternType ?? SearchPatternType.keyword
-        : defaultPatternType
+    if (isKeywordSearchEnabled(settingsCascade)) {
+        return defaultPatternType ?? SearchPatternType.keyword
+    }
+    return defaultPatternType
 }
 
 /**


### PR DESCRIPTION
Fixes #61937 

It looks like we hardcoded keyword if the feature was enabled. This change honors an existing default

 


## Test plan
- Manual testing of different permutations of default and no-default settings