### PR TITLE
Adding logging for getLLMUsageData data failed

### DIFF
--- a/internal/updatecheck/client.go
+++ b/internal/updatecheck/client.go
@@ -710,6 +710,9 @@ func updateBody(ctx context.Context, logger log.Logger, db database.DB) (io.Read
 		logFunc("repoMetadataUsage failed", log.Error(err))
 	}
 	r.LlmUsage, err = getLLMUsageData(ctx, db)
+	if err != nil {
+		logFunc("getLLMUsageData failed", log.Error(err))
+	}
 	r.HasExtURL = conf.UsingExternalURL()
 	r.BuiltinSignupAllowed = conf.IsBuiltinSignupAllowed()
 	r.AccessRequestEnabled = conf.IsAccessRequestEnabled()


### PR DESCRIPTION
Title says it all. 
Facing some issues on my testing in some instances but I don't have enough logging to be able to solve those issues so I am adding this PR

## Test plan
Just check the new logs on failure

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
