### PR TITLE
dotcom: Remove side-effect of dotcom mode on GCP profiler

### DIFF
--- a/internal/profiler/BUILD.bazel
+++ b/internal/profiler/BUILD.bazel
@@ -6,11 +6,9 @@ go_library(
     importpath = "github.com/sourcegraph/sourcegraph/internal/profiler",
     visibility = ["//:__subpackages__"],
     deps = [
-        "//internal/conf/deploy",
-        "//internal/dotcom",
         "//internal/env",
         "//internal/version",
-        "@com_github_inconshreveable_log15//:log15",
+        "@com_github_sourcegraph_log//:log",
         "@com_google_cloud_go_profiler//:profiler",
     ],
 )

--- a/internal/profiler/profiler.go
+++ b/internal/profiler/profiler.go
@@ -3,22 +3,19 @@ package profiler
 import (
 	"cloud.google.com/go/profiler"
 
-	"github.com/inconshreveable/log15" //nolint:logging // TODO move all logging to sourcegraph/log
+	"github.com/sourcegraph/log"
 
-	"github.com/sourcegraph/sourcegraph/internal/conf/deploy"
-	"github.com/sourcegraph/sourcegraph/internal/dotcom"
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/version"
 )
 
 var gcpProfilerEnabled = env.MustGetBool("GOOGLE_CLOUD_PROFILER_ENABLED", false, "If true, enable Google Cloud Profiler. See https://cloud.google.com/profiler/docs/profiling-go")
 
-// Init starts the Google Cloud Profiler if configured.
-// Will enable when in sourcegraph.com mode in production, or when
+// Init starts the Google Cloud Profiler if the environment variable
 // GOOGLE_CLOUD_PROFILER_ENABLED is truthy.
 // See https://cloud.google.com/profiler/docs/profiling-go.
-func Init() {
-	if !shouldEnableProfiler() {
+func Init(logger log.Logger) {
+	if !gcpProfilerEnabled {
 		return
 	}
 
@@ -29,21 +26,6 @@ func Init() {
 		AllocForceGC:   true,
 	})
 	if err != nil {
-		log15.Error("profiler.Init google cloud profiler", "error", err)
+		logger.Error("profiler.Init google cloud profiler", log.Error(err))
 	}
-}
-
-func shouldEnableProfiler() bool {
-	// Force overwrite.
-	if gcpProfilerEnabled {
-		return true
-	}
-	if dotcom.SourcegraphDotComMode() {
-		// SourcegraphDotComMode can be true in dev, so check we are in a k8s
-		// cluster.
-		if deploy.IsDeployTypeKubernetes(deploy.Type()) {
-			return true
-		}
-	}
-	return false
 }

--- a/internal/service/svcmain/svcmain.go
+++ b/internal/service/svcmain/svcmain.go
@@ -104,7 +104,7 @@ func run(
 		tracer.Init(log.Scoped("tracer"), oobConfig.Tracing)
 	}
 
-	profiler.Init()
+	profiler.Init(logger)
 
 	obctx := observation.ContextWithLogger(log.Scoped(service.Name()), observation.NewContext(logger))
 	ctx := context.Background()


### PR DESCRIPTION
We currently have it implicitly enabled in dotcom mode, but this is a non-useful side-effect of that flag, and we should instead be explicit in the deployment, and remove that check here.

https://github.com/sourcegraph/deploy-sourcegraph-cloud/pull/18540 sets this env var explicitly.

Test plan:

Watch rollout of the deploy repo.