### PR TITLE
Temporarily republish base images for backport

### DIFF
--- a/dev/ci/internal/ci/pipeline.go
+++ b/dev/ci/internal/ci/pipeline.go
@@ -144,12 +144,15 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 		ops.Merge(securityOps)
 
 		// Wolfi package and apko lock check
-		packageOps, apkoOps := addWolfiOps(c)
+		packageOps, baseImageOps, apkoOps := addWolfiOps(c)
 		if apkoOps != nil {
 			ops.Merge(apkoOps)
 		}
 		if packageOps != nil {
 			ops.Merge(packageOps)
+		}
+		if baseImageOps != nil {
+			ops.Merge(baseImageOps)
 		}
 
 		if c.Diff.Has(changed.ClientBrowserExtensions) {
@@ -323,12 +326,15 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 		))
 
 		// Wolfi package and base images
-		packageOps, apkoOps := addWolfiOps(c)
+		packageOps, baseImageOps, apkoOps := addWolfiOps(c)
 		if apkoOps != nil {
 			ops.Merge(apkoOps)
 		}
 		if packageOps != nil {
 			ops.Merge(packageOps)
+		}
+		if baseImageOps != nil {
+			ops.Merge(baseImageOps)
 		}
 
 		// All operations before this point are required

--- a/dev/ci/internal/ci/wolfi_operations.go
+++ b/dev/ci/internal/ci/wolfi_operations.go
@@ -269,7 +269,7 @@ func getPackagesFromBaseImageConfig(configFile string) ([]string, error) {
 }
 
 // addWolfiOps adds operations to rebuild modified Wolfi packages and base images.
-func addWolfiOps(c Config) (packageOps, apkoOps *operations.Set) {
+func addWolfiOps(c Config) (packageOps, baseImageOps, apkoOps *operations.Set) {
 	// Rebuild Wolfi packages that have config changes
 	var updatedPackages []string
 	if c.Diff.Has(changed.WolfiPackages) {
@@ -287,10 +287,16 @@ func addWolfiOps(c Config) (packageOps, apkoOps *operations.Set) {
 	imagesToRebuild = sortUniq(imagesToRebuild)
 
 	if len(imagesToRebuild) > 0 {
+		baseImageOps, _ = WolfiBaseImagesOperations(
+			imagesToRebuild,
+			c.Version,
+			(len(updatedPackages) > 0),
+		)
+
 		apkoOps = WolfiCheckApkoLocks()
 	}
 
-	return packageOps, apkoOps
+	return packageOps, baseImageOps, apkoOps
 }
 
 // wolfiBaseImageLockAndCreatePR updates base image hashes and creates a PR in GitHub

--- a/wolfi-images/batcheshelper.lock.json
+++ b/wolfi-images/batcheshelper.lock.json
@@ -1,5 +1,5 @@
 {
-  "configHash": "501d23b045ac731cdeca7c1a35ef253ba8754fc03da98cdd96c4fd1ce8583c42",
+  "configHash": "3ed671542726fde77a91219e7c99afb0927ad2c9bc62c9b34042e25266c3db61",
   "contents": {
     "keyring": [
       {

--- a/wolfi-images/batcheshelper.lock.json
+++ b/wolfi-images/batcheshelper.lock.json
@@ -52,60 +52,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1DyZ5L88J9MmDMYgbsywXdJdnw04=",
+        "checksum": "Q1uuAznXPkDNBMP/eILVO7UDGj1pU=",
         "control": {
-          "checksum": "sha1-DyZ5L88J9MmDMYgbsywXdJdnw04=",
-          "range": "bytes=699-1107"
+          "checksum": "sha1-uuAznXPkDNBMP/eILVO7UDGj1pU=",
+          "range": "bytes=702-1112"
         },
         "data": {
-          "checksum": "sha256-3xIIHf7osttdb7FoJTbfURbo4YuaB3knm5Kd3B5p+dI=",
-          "range": "bytes=1108-267814"
+          "checksum": "sha256-Ath31YTTsiakoEktGl5txvNQpnr/grvFQHlmXa5E7fI=",
+          "range": "bytes=1113-267815"
         },
         "name": "ld-linux",
         "signature": {
-          "checksum": "sha1-lxFSv68mPMJwO+PthEdXfKHuLWk=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-oh4vr00LXL4ArbAOR9LS1VzzfYc=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1UvgNLBt9CKIOp7pN3EI0pgBlzXo=",
+        "checksum": "Q1TXuyiDJBsTNDwvPq7HFxaeBQ33w=",
         "control": {
-          "checksum": "sha1-UvgNLBt9CKIOp7pN3EI0pgBlzXo=",
-          "range": "bytes=696-1051"
+          "checksum": "sha1-TXuyiDJBsTNDwvPq7HFxaeBQ33w=",
+          "range": "bytes=703-1059"
         },
         "data": {
-          "checksum": "sha256-NaRRsIIgVTbofef14Qsnf+rysYDJXOXPKgfj6bAhP94=",
-          "range": "bytes=1052-408274"
+          "checksum": "sha256-3s2Fygt+ZuHj/StxP7YffswmhHE7EJ4TxZ7EWlRQ4NA=",
+          "range": "bytes=1060-408275"
         },
         "name": "glibc-locale-posix",
         "signature": {
-          "checksum": "sha1-Iug0EjR+0K/k6fl0wi0prJHKBBo=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-FbeSNtuEgFmzNamDx5Dj1LGVgsQ=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1PnEJFSqU/wFNmbOLGHbgqFwS/yU=",
+        "checksum": "Q1SD8az8RMNr5tnb8/mPZdR+A6V5k=",
         "control": {
-          "checksum": "sha1-PnEJFSqU/wFNmbOLGHbgqFwS/yU=",
-          "range": "bytes=695-1321"
+          "checksum": "sha1-SD8az8RMNr5tnb8/mPZdR+A6V5k=",
+          "range": "bytes=701-1330"
         },
         "data": {
-          "checksum": "sha256-D6XvEcPrHmlsiI6HbbE51xmiTM1c5y6DV4MrHrCVuNo=",
-          "range": "bytes=1322-5861480"
+          "checksum": "sha256-QvhWs/fGBaX5calu0uES9fcTMx6+R1xKZHdxkxxSxsg=",
+          "range": "bytes=1331-5861481"
         },
         "name": "glibc",
         "signature": {
-          "checksum": "sha1-ypPC9SJASGEATsvLoDuEEUobhAs=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-v4LRB2eP5VLe623v8sJ3f4wDNFM=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",
@@ -565,22 +565,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1szp02tM1WkRUzhOGBkFjl6dA5pQ=",
+        "checksum": "Q1drCieAMJpJBP1KWvJk6Vhq7Zj20=",
         "control": {
-          "checksum": "sha1-szp02tM1WkRUzhOGBkFjl6dA5pQ=",
-          "range": "bytes=698-1101"
+          "checksum": "sha1-drCieAMJpJBP1KWvJk6Vhq7Zj20=",
+          "range": "bytes=701-1108"
         },
         "data": {
-          "checksum": "sha256-hrc/6rvJR5nb97Gu5Hep8419+WyFmd7maV78ni7zQAc=",
-          "range": "bytes=1102-21604"
+          "checksum": "sha256-LcGaT+nLHN7YtUab5sY0EoXErbOj/S58FXtf1JVxWbM=",
+          "range": "bytes=1109-21605"
         },
         "name": "libcrypt1",
         "signature": {
-          "checksum": "sha1-Jk/8hSLRyZ7scdep1XfbpKABePY=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-wwLYQc1joetP6IOipSVSCQsZHsM=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/batcheshelper.yaml
+++ b/wolfi-images/batcheshelper.yaml
@@ -8,3 +8,5 @@ contents:
 
     ## batcheshelper packages
     - 'git'
+
+# MANUAL REBUILD: 

--- a/wolfi-images/blobstore.lock.json
+++ b/wolfi-images/blobstore.lock.json
@@ -1,5 +1,5 @@
 {
-  "configHash": "b954aeb9411bf8f92d4591244af9bb1ccc01f54f5581a6581d94fe1cd57c2920",
+  "configHash": "2aba945ea0f7c42623838e8ab49f7940df011f0fc73b17a201fab440b57562ce",
   "contents": {
     "keyring": [
       {

--- a/wolfi-images/blobstore.lock.json
+++ b/wolfi-images/blobstore.lock.json
@@ -52,60 +52,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1DyZ5L88J9MmDMYgbsywXdJdnw04=",
+        "checksum": "Q1uuAznXPkDNBMP/eILVO7UDGj1pU=",
         "control": {
-          "checksum": "sha1-DyZ5L88J9MmDMYgbsywXdJdnw04=",
-          "range": "bytes=699-1107"
+          "checksum": "sha1-uuAznXPkDNBMP/eILVO7UDGj1pU=",
+          "range": "bytes=702-1112"
         },
         "data": {
-          "checksum": "sha256-3xIIHf7osttdb7FoJTbfURbo4YuaB3knm5Kd3B5p+dI=",
-          "range": "bytes=1108-267814"
+          "checksum": "sha256-Ath31YTTsiakoEktGl5txvNQpnr/grvFQHlmXa5E7fI=",
+          "range": "bytes=1113-267815"
         },
         "name": "ld-linux",
         "signature": {
-          "checksum": "sha1-lxFSv68mPMJwO+PthEdXfKHuLWk=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-oh4vr00LXL4ArbAOR9LS1VzzfYc=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1UvgNLBt9CKIOp7pN3EI0pgBlzXo=",
+        "checksum": "Q1TXuyiDJBsTNDwvPq7HFxaeBQ33w=",
         "control": {
-          "checksum": "sha1-UvgNLBt9CKIOp7pN3EI0pgBlzXo=",
-          "range": "bytes=696-1051"
+          "checksum": "sha1-TXuyiDJBsTNDwvPq7HFxaeBQ33w=",
+          "range": "bytes=703-1059"
         },
         "data": {
-          "checksum": "sha256-NaRRsIIgVTbofef14Qsnf+rysYDJXOXPKgfj6bAhP94=",
-          "range": "bytes=1052-408274"
+          "checksum": "sha256-3s2Fygt+ZuHj/StxP7YffswmhHE7EJ4TxZ7EWlRQ4NA=",
+          "range": "bytes=1060-408275"
         },
         "name": "glibc-locale-posix",
         "signature": {
-          "checksum": "sha1-Iug0EjR+0K/k6fl0wi0prJHKBBo=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-FbeSNtuEgFmzNamDx5Dj1LGVgsQ=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1PnEJFSqU/wFNmbOLGHbgqFwS/yU=",
+        "checksum": "Q1SD8az8RMNr5tnb8/mPZdR+A6V5k=",
         "control": {
-          "checksum": "sha1-PnEJFSqU/wFNmbOLGHbgqFwS/yU=",
-          "range": "bytes=695-1321"
+          "checksum": "sha1-SD8az8RMNr5tnb8/mPZdR+A6V5k=",
+          "range": "bytes=701-1330"
         },
         "data": {
-          "checksum": "sha256-D6XvEcPrHmlsiI6HbbE51xmiTM1c5y6DV4MrHrCVuNo=",
-          "range": "bytes=1322-5861480"
+          "checksum": "sha256-QvhWs/fGBaX5calu0uES9fcTMx6+R1xKZHdxkxxSxsg=",
+          "range": "bytes=1331-5861481"
         },
         "name": "glibc",
         "signature": {
-          "checksum": "sha1-ypPC9SJASGEATsvLoDuEEUobhAs=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-v4LRB2eP5VLe623v8sJ3f4wDNFM=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",
@@ -565,22 +565,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1szp02tM1WkRUzhOGBkFjl6dA5pQ=",
+        "checksum": "Q1drCieAMJpJBP1KWvJk6Vhq7Zj20=",
         "control": {
-          "checksum": "sha1-szp02tM1WkRUzhOGBkFjl6dA5pQ=",
-          "range": "bytes=698-1101"
+          "checksum": "sha1-drCieAMJpJBP1KWvJk6Vhq7Zj20=",
+          "range": "bytes=701-1108"
         },
         "data": {
-          "checksum": "sha256-hrc/6rvJR5nb97Gu5Hep8419+WyFmd7maV78ni7zQAc=",
-          "range": "bytes=1102-21604"
+          "checksum": "sha256-LcGaT+nLHN7YtUab5sY0EoXErbOj/S58FXtf1JVxWbM=",
+          "range": "bytes=1109-21605"
         },
         "name": "libcrypt1",
         "signature": {
-          "checksum": "sha1-Jk/8hSLRyZ7scdep1XfbpKABePY=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-wwLYQc1joetP6IOipSVSCQsZHsM=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/blobstore.yaml
+++ b/wolfi-images/blobstore.yaml
@@ -17,3 +17,5 @@ paths:
     permissions: 0o755
 
 work-dir: /opt/s3proxy
+
+# MANUAL REBUILD: 

--- a/wolfi-images/bundled-executor.lock.json
+++ b/wolfi-images/bundled-executor.lock.json
@@ -1,5 +1,5 @@
 {
-  "configHash": "9a7fdc53fef8840d9e7514428ead81846a62ea9f1ffb91ba466f41f9dc2a3063",
+  "configHash": "a32ba2be8b4dfa6e05380bd64a0bd2679ec69fdb91352dba8359e2e58c56abee",
   "contents": {
     "keyring": [
       {

--- a/wolfi-images/bundled-executor.lock.json
+++ b/wolfi-images/bundled-executor.lock.json
@@ -52,60 +52,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1DyZ5L88J9MmDMYgbsywXdJdnw04=",
+        "checksum": "Q1uuAznXPkDNBMP/eILVO7UDGj1pU=",
         "control": {
-          "checksum": "sha1-DyZ5L88J9MmDMYgbsywXdJdnw04=",
-          "range": "bytes=699-1107"
+          "checksum": "sha1-uuAznXPkDNBMP/eILVO7UDGj1pU=",
+          "range": "bytes=702-1112"
         },
         "data": {
-          "checksum": "sha256-3xIIHf7osttdb7FoJTbfURbo4YuaB3knm5Kd3B5p+dI=",
-          "range": "bytes=1108-267814"
+          "checksum": "sha256-Ath31YTTsiakoEktGl5txvNQpnr/grvFQHlmXa5E7fI=",
+          "range": "bytes=1113-267815"
         },
         "name": "ld-linux",
         "signature": {
-          "checksum": "sha1-lxFSv68mPMJwO+PthEdXfKHuLWk=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-oh4vr00LXL4ArbAOR9LS1VzzfYc=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1UvgNLBt9CKIOp7pN3EI0pgBlzXo=",
+        "checksum": "Q1TXuyiDJBsTNDwvPq7HFxaeBQ33w=",
         "control": {
-          "checksum": "sha1-UvgNLBt9CKIOp7pN3EI0pgBlzXo=",
-          "range": "bytes=696-1051"
+          "checksum": "sha1-TXuyiDJBsTNDwvPq7HFxaeBQ33w=",
+          "range": "bytes=703-1059"
         },
         "data": {
-          "checksum": "sha256-NaRRsIIgVTbofef14Qsnf+rysYDJXOXPKgfj6bAhP94=",
-          "range": "bytes=1052-408274"
+          "checksum": "sha256-3s2Fygt+ZuHj/StxP7YffswmhHE7EJ4TxZ7EWlRQ4NA=",
+          "range": "bytes=1060-408275"
         },
         "name": "glibc-locale-posix",
         "signature": {
-          "checksum": "sha1-Iug0EjR+0K/k6fl0wi0prJHKBBo=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-FbeSNtuEgFmzNamDx5Dj1LGVgsQ=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1PnEJFSqU/wFNmbOLGHbgqFwS/yU=",
+        "checksum": "Q1SD8az8RMNr5tnb8/mPZdR+A6V5k=",
         "control": {
-          "checksum": "sha1-PnEJFSqU/wFNmbOLGHbgqFwS/yU=",
-          "range": "bytes=695-1321"
+          "checksum": "sha1-SD8az8RMNr5tnb8/mPZdR+A6V5k=",
+          "range": "bytes=701-1330"
         },
         "data": {
-          "checksum": "sha256-D6XvEcPrHmlsiI6HbbE51xmiTM1c5y6DV4MrHrCVuNo=",
-          "range": "bytes=1322-5861480"
+          "checksum": "sha256-QvhWs/fGBaX5calu0uES9fcTMx6+R1xKZHdxkxxSxsg=",
+          "range": "bytes=1331-5861481"
         },
         "name": "glibc",
         "signature": {
-          "checksum": "sha1-ypPC9SJASGEATsvLoDuEEUobhAs=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-v4LRB2eP5VLe623v8sJ3f4wDNFM=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",
@@ -565,22 +565,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1szp02tM1WkRUzhOGBkFjl6dA5pQ=",
+        "checksum": "Q1drCieAMJpJBP1KWvJk6Vhq7Zj20=",
         "control": {
-          "checksum": "sha1-szp02tM1WkRUzhOGBkFjl6dA5pQ=",
-          "range": "bytes=698-1101"
+          "checksum": "sha1-drCieAMJpJBP1KWvJk6Vhq7Zj20=",
+          "range": "bytes=701-1108"
         },
         "data": {
-          "checksum": "sha256-hrc/6rvJR5nb97Gu5Hep8419+WyFmd7maV78ni7zQAc=",
-          "range": "bytes=1102-21604"
+          "checksum": "sha256-LcGaT+nLHN7YtUab5sY0EoXErbOj/S58FXtf1JVxWbM=",
+          "range": "bytes=1109-21605"
         },
         "name": "libcrypt1",
         "signature": {
-          "checksum": "sha1-Jk/8hSLRyZ7scdep1XfbpKABePY=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-wwLYQc1joetP6IOipSVSCQsZHsM=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/bundled-executor.yaml
+++ b/wolfi-images/bundled-executor.yaml
@@ -21,3 +21,5 @@ paths:
   - path: /usr/local/bin
     type: directory
     permissions: 0o755
+
+# MANUAL REBUILD: 

--- a/wolfi-images/caddy.lock.json
+++ b/wolfi-images/caddy.lock.json
@@ -52,60 +52,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1DyZ5L88J9MmDMYgbsywXdJdnw04=",
+        "checksum": "Q1uuAznXPkDNBMP/eILVO7UDGj1pU=",
         "control": {
-          "checksum": "sha1-DyZ5L88J9MmDMYgbsywXdJdnw04=",
-          "range": "bytes=699-1107"
+          "checksum": "sha1-uuAznXPkDNBMP/eILVO7UDGj1pU=",
+          "range": "bytes=702-1112"
         },
         "data": {
-          "checksum": "sha256-3xIIHf7osttdb7FoJTbfURbo4YuaB3knm5Kd3B5p+dI=",
-          "range": "bytes=1108-267814"
+          "checksum": "sha256-Ath31YTTsiakoEktGl5txvNQpnr/grvFQHlmXa5E7fI=",
+          "range": "bytes=1113-267815"
         },
         "name": "ld-linux",
         "signature": {
-          "checksum": "sha1-lxFSv68mPMJwO+PthEdXfKHuLWk=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-oh4vr00LXL4ArbAOR9LS1VzzfYc=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1UvgNLBt9CKIOp7pN3EI0pgBlzXo=",
+        "checksum": "Q1TXuyiDJBsTNDwvPq7HFxaeBQ33w=",
         "control": {
-          "checksum": "sha1-UvgNLBt9CKIOp7pN3EI0pgBlzXo=",
-          "range": "bytes=696-1051"
+          "checksum": "sha1-TXuyiDJBsTNDwvPq7HFxaeBQ33w=",
+          "range": "bytes=703-1059"
         },
         "data": {
-          "checksum": "sha256-NaRRsIIgVTbofef14Qsnf+rysYDJXOXPKgfj6bAhP94=",
-          "range": "bytes=1052-408274"
+          "checksum": "sha256-3s2Fygt+ZuHj/StxP7YffswmhHE7EJ4TxZ7EWlRQ4NA=",
+          "range": "bytes=1060-408275"
         },
         "name": "glibc-locale-posix",
         "signature": {
-          "checksum": "sha1-Iug0EjR+0K/k6fl0wi0prJHKBBo=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-FbeSNtuEgFmzNamDx5Dj1LGVgsQ=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1PnEJFSqU/wFNmbOLGHbgqFwS/yU=",
+        "checksum": "Q1SD8az8RMNr5tnb8/mPZdR+A6V5k=",
         "control": {
-          "checksum": "sha1-PnEJFSqU/wFNmbOLGHbgqFwS/yU=",
-          "range": "bytes=695-1321"
+          "checksum": "sha1-SD8az8RMNr5tnb8/mPZdR+A6V5k=",
+          "range": "bytes=701-1330"
         },
         "data": {
-          "checksum": "sha256-D6XvEcPrHmlsiI6HbbE51xmiTM1c5y6DV4MrHrCVuNo=",
-          "range": "bytes=1322-5861480"
+          "checksum": "sha256-QvhWs/fGBaX5calu0uES9fcTMx6+R1xKZHdxkxxSxsg=",
+          "range": "bytes=1331-5861481"
         },
         "name": "glibc",
         "signature": {
-          "checksum": "sha1-ypPC9SJASGEATsvLoDuEEUobhAs=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-v4LRB2eP5VLe623v8sJ3f4wDNFM=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",
@@ -565,22 +565,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1szp02tM1WkRUzhOGBkFjl6dA5pQ=",
+        "checksum": "Q1drCieAMJpJBP1KWvJk6Vhq7Zj20=",
         "control": {
-          "checksum": "sha1-szp02tM1WkRUzhOGBkFjl6dA5pQ=",
-          "range": "bytes=698-1101"
+          "checksum": "sha1-drCieAMJpJBP1KWvJk6Vhq7Zj20=",
+          "range": "bytes=701-1108"
         },
         "data": {
-          "checksum": "sha256-hrc/6rvJR5nb97Gu5Hep8419+WyFmd7maV78ni7zQAc=",
-          "range": "bytes=1102-21604"
+          "checksum": "sha256-LcGaT+nLHN7YtUab5sY0EoXErbOj/S58FXtf1JVxWbM=",
+          "range": "bytes=1109-21605"
         },
         "name": "libcrypt1",
         "signature": {
-          "checksum": "sha1-Jk/8hSLRyZ7scdep1XfbpKABePY=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-wwLYQc1joetP6IOipSVSCQsZHsM=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",
@@ -603,22 +603,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1rjerqZWEgOAfcADFOLkaVfXxK1s=",
+        "checksum": "Q1n0mN+HXLe/6DSayCL7lyOJrVBMA=",
         "control": {
-          "checksum": "sha1-rjerqZWEgOAfcADFOLkaVfXxK1s=",
-          "range": "bytes=701-1087"
+          "checksum": "sha1-n0mN+HXLe/6DSayCL7lyOJrVBMA=",
+          "range": "bytes=694-1091"
         },
         "data": {
-          "checksum": "sha256-0VNIVmBgUcGMk7bk8Pou0Dj9goU8aSNSzT6bgHz1LuI=",
-          "range": "bytes=1088-41640439"
+          "checksum": "sha256-zFLgLLDxIOhRWZ8vWoLO6FfnxrPV5QlQurChfb1vqDg=",
+          "range": "bytes=1092-41640451"
         },
         "name": "caddy",
         "signature": {
-          "checksum": "sha1-I4LZ7o/JV8NiBwaS/ZoSZBrsV9k=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-8sr6tyZMUpd1wRGq0IXcFQqOnK0=",
+          "range": "bytes=0-693"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/caddy-2.7.6-r6.apk",
-        "version": "2.7.6-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/caddy-2.7.6-r7.apk",
+        "version": "2.7.6-r7"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/caddy.lock.json
+++ b/wolfi-images/caddy.lock.json
@@ -1,5 +1,5 @@
 {
-  "configHash": "fa1a8046df3d8d171d27915e7cb8600b1a0b21ea76133ea1e2e40318656f05db",
+  "configHash": "e46abee367a7b01954d89ca89613f0e37637b2ea49a9f6c621a792f9b435f3e4",
   "contents": {
     "keyring": [
       {

--- a/wolfi-images/caddy.yaml
+++ b/wolfi-images/caddy.yaml
@@ -42,3 +42,5 @@ annotations:
   org.opencontainers.image.title: Caddy
   org.opencontainers.image.description: "a powerful, enterprise-ready, open source web server with automatic HTTPS written in Go"
   org.opencontainers.image.licenses: "Apache-2.0"
+
+# MANUAL REBUILD: 

--- a/wolfi-images/cadvisor.lock.json
+++ b/wolfi-images/cadvisor.lock.json
@@ -52,60 +52,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1DyZ5L88J9MmDMYgbsywXdJdnw04=",
+        "checksum": "Q1uuAznXPkDNBMP/eILVO7UDGj1pU=",
         "control": {
-          "checksum": "sha1-DyZ5L88J9MmDMYgbsywXdJdnw04=",
-          "range": "bytes=699-1107"
+          "checksum": "sha1-uuAznXPkDNBMP/eILVO7UDGj1pU=",
+          "range": "bytes=702-1112"
         },
         "data": {
-          "checksum": "sha256-3xIIHf7osttdb7FoJTbfURbo4YuaB3knm5Kd3B5p+dI=",
-          "range": "bytes=1108-267814"
+          "checksum": "sha256-Ath31YTTsiakoEktGl5txvNQpnr/grvFQHlmXa5E7fI=",
+          "range": "bytes=1113-267815"
         },
         "name": "ld-linux",
         "signature": {
-          "checksum": "sha1-lxFSv68mPMJwO+PthEdXfKHuLWk=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-oh4vr00LXL4ArbAOR9LS1VzzfYc=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1UvgNLBt9CKIOp7pN3EI0pgBlzXo=",
+        "checksum": "Q1TXuyiDJBsTNDwvPq7HFxaeBQ33w=",
         "control": {
-          "checksum": "sha1-UvgNLBt9CKIOp7pN3EI0pgBlzXo=",
-          "range": "bytes=696-1051"
+          "checksum": "sha1-TXuyiDJBsTNDwvPq7HFxaeBQ33w=",
+          "range": "bytes=703-1059"
         },
         "data": {
-          "checksum": "sha256-NaRRsIIgVTbofef14Qsnf+rysYDJXOXPKgfj6bAhP94=",
-          "range": "bytes=1052-408274"
+          "checksum": "sha256-3s2Fygt+ZuHj/StxP7YffswmhHE7EJ4TxZ7EWlRQ4NA=",
+          "range": "bytes=1060-408275"
         },
         "name": "glibc-locale-posix",
         "signature": {
-          "checksum": "sha1-Iug0EjR+0K/k6fl0wi0prJHKBBo=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-FbeSNtuEgFmzNamDx5Dj1LGVgsQ=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1PnEJFSqU/wFNmbOLGHbgqFwS/yU=",
+        "checksum": "Q1SD8az8RMNr5tnb8/mPZdR+A6V5k=",
         "control": {
-          "checksum": "sha1-PnEJFSqU/wFNmbOLGHbgqFwS/yU=",
-          "range": "bytes=695-1321"
+          "checksum": "sha1-SD8az8RMNr5tnb8/mPZdR+A6V5k=",
+          "range": "bytes=701-1330"
         },
         "data": {
-          "checksum": "sha256-D6XvEcPrHmlsiI6HbbE51xmiTM1c5y6DV4MrHrCVuNo=",
-          "range": "bytes=1322-5861480"
+          "checksum": "sha256-QvhWs/fGBaX5calu0uES9fcTMx6+R1xKZHdxkxxSxsg=",
+          "range": "bytes=1331-5861481"
         },
         "name": "glibc",
         "signature": {
-          "checksum": "sha1-ypPC9SJASGEATsvLoDuEEUobhAs=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-v4LRB2eP5VLe623v8sJ3f4wDNFM=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",
@@ -565,22 +565,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1szp02tM1WkRUzhOGBkFjl6dA5pQ=",
+        "checksum": "Q1drCieAMJpJBP1KWvJk6Vhq7Zj20=",
         "control": {
-          "checksum": "sha1-szp02tM1WkRUzhOGBkFjl6dA5pQ=",
-          "range": "bytes=698-1101"
+          "checksum": "sha1-drCieAMJpJBP1KWvJk6Vhq7Zj20=",
+          "range": "bytes=701-1108"
         },
         "data": {
-          "checksum": "sha256-hrc/6rvJR5nb97Gu5Hep8419+WyFmd7maV78ni7zQAc=",
-          "range": "bytes=1102-21604"
+          "checksum": "sha256-LcGaT+nLHN7YtUab5sY0EoXErbOj/S58FXtf1JVxWbM=",
+          "range": "bytes=1109-21605"
         },
         "name": "libcrypt1",
         "signature": {
-          "checksum": "sha1-Jk/8hSLRyZ7scdep1XfbpKABePY=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-wwLYQc1joetP6IOipSVSCQsZHsM=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/cadvisor.lock.json
+++ b/wolfi-images/cadvisor.lock.json
@@ -1,5 +1,5 @@
 {
-  "configHash": "4bc91b632e89948aec3b44e538b7bfcba5c149aa99b52d3429cce60c7327bcf4",
+  "configHash": "d0de158408748722b0227ea0ffadfa8042d1ce34bc1102ec4a88ab99ac55b507",
   "contents": {
     "keyring": [
       {

--- a/wolfi-images/cadvisor.yaml
+++ b/wolfi-images/cadvisor.yaml
@@ -8,3 +8,5 @@ contents:
 
     ## cadvisor dependencies
     - cadvisor
+
+# MANUAL REBUILD: 

--- a/wolfi-images/cloud-mi2.lock.json
+++ b/wolfi-images/cloud-mi2.lock.json
@@ -1,5 +1,5 @@
 {
-  "configHash": "4834997e0fb9640c710c8c1a0e70125b9ec4cefebc7d3dd9788a563c420bc412",
+  "configHash": "08129e6390fc2098c7157143a11e7f1c96c8f3f019640f83ab6cc4a97f63e18d",
   "contents": {
     "keyring": [
       {

--- a/wolfi-images/cloud-mi2.lock.json
+++ b/wolfi-images/cloud-mi2.lock.json
@@ -52,60 +52,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1DyZ5L88J9MmDMYgbsywXdJdnw04=",
+        "checksum": "Q1uuAznXPkDNBMP/eILVO7UDGj1pU=",
         "control": {
-          "checksum": "sha1-DyZ5L88J9MmDMYgbsywXdJdnw04=",
-          "range": "bytes=699-1107"
+          "checksum": "sha1-uuAznXPkDNBMP/eILVO7UDGj1pU=",
+          "range": "bytes=702-1112"
         },
         "data": {
-          "checksum": "sha256-3xIIHf7osttdb7FoJTbfURbo4YuaB3knm5Kd3B5p+dI=",
-          "range": "bytes=1108-267814"
+          "checksum": "sha256-Ath31YTTsiakoEktGl5txvNQpnr/grvFQHlmXa5E7fI=",
+          "range": "bytes=1113-267815"
         },
         "name": "ld-linux",
         "signature": {
-          "checksum": "sha1-lxFSv68mPMJwO+PthEdXfKHuLWk=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-oh4vr00LXL4ArbAOR9LS1VzzfYc=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1UvgNLBt9CKIOp7pN3EI0pgBlzXo=",
+        "checksum": "Q1TXuyiDJBsTNDwvPq7HFxaeBQ33w=",
         "control": {
-          "checksum": "sha1-UvgNLBt9CKIOp7pN3EI0pgBlzXo=",
-          "range": "bytes=696-1051"
+          "checksum": "sha1-TXuyiDJBsTNDwvPq7HFxaeBQ33w=",
+          "range": "bytes=703-1059"
         },
         "data": {
-          "checksum": "sha256-NaRRsIIgVTbofef14Qsnf+rysYDJXOXPKgfj6bAhP94=",
-          "range": "bytes=1052-408274"
+          "checksum": "sha256-3s2Fygt+ZuHj/StxP7YffswmhHE7EJ4TxZ7EWlRQ4NA=",
+          "range": "bytes=1060-408275"
         },
         "name": "glibc-locale-posix",
         "signature": {
-          "checksum": "sha1-Iug0EjR+0K/k6fl0wi0prJHKBBo=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-FbeSNtuEgFmzNamDx5Dj1LGVgsQ=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1PnEJFSqU/wFNmbOLGHbgqFwS/yU=",
+        "checksum": "Q1SD8az8RMNr5tnb8/mPZdR+A6V5k=",
         "control": {
-          "checksum": "sha1-PnEJFSqU/wFNmbOLGHbgqFwS/yU=",
-          "range": "bytes=695-1321"
+          "checksum": "sha1-SD8az8RMNr5tnb8/mPZdR+A6V5k=",
+          "range": "bytes=701-1330"
         },
         "data": {
-          "checksum": "sha256-D6XvEcPrHmlsiI6HbbE51xmiTM1c5y6DV4MrHrCVuNo=",
-          "range": "bytes=1322-5861480"
+          "checksum": "sha256-QvhWs/fGBaX5calu0uES9fcTMx6+R1xKZHdxkxxSxsg=",
+          "range": "bytes=1331-5861481"
         },
         "name": "glibc",
         "signature": {
-          "checksum": "sha1-ypPC9SJASGEATsvLoDuEEUobhAs=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-v4LRB2eP5VLe623v8sJ3f4wDNFM=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",
@@ -565,22 +565,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1szp02tM1WkRUzhOGBkFjl6dA5pQ=",
+        "checksum": "Q1drCieAMJpJBP1KWvJk6Vhq7Zj20=",
         "control": {
-          "checksum": "sha1-szp02tM1WkRUzhOGBkFjl6dA5pQ=",
-          "range": "bytes=698-1101"
+          "checksum": "sha1-drCieAMJpJBP1KWvJk6Vhq7Zj20=",
+          "range": "bytes=701-1108"
         },
         "data": {
-          "checksum": "sha256-hrc/6rvJR5nb97Gu5Hep8419+WyFmd7maV78ni7zQAc=",
-          "range": "bytes=1102-21604"
+          "checksum": "sha256-LcGaT+nLHN7YtUab5sY0EoXErbOj/S58FXtf1JVxWbM=",
+          "range": "bytes=1109-21605"
         },
         "name": "libcrypt1",
         "signature": {
-          "checksum": "sha1-Jk/8hSLRyZ7scdep1XfbpKABePY=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-wwLYQc1joetP6IOipSVSCQsZHsM=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/cloud-mi2.yaml
+++ b/wolfi-images/cloud-mi2.yaml
@@ -23,3 +23,5 @@ contents:
 # it does not support running container with non-root user.
 accounts:
   run-as: root
+
+# MANUAL REBUILD: 

--- a/wolfi-images/executor-kubernetes.lock.json
+++ b/wolfi-images/executor-kubernetes.lock.json
@@ -52,60 +52,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1DyZ5L88J9MmDMYgbsywXdJdnw04=",
+        "checksum": "Q1uuAznXPkDNBMP/eILVO7UDGj1pU=",
         "control": {
-          "checksum": "sha1-DyZ5L88J9MmDMYgbsywXdJdnw04=",
-          "range": "bytes=699-1107"
+          "checksum": "sha1-uuAznXPkDNBMP/eILVO7UDGj1pU=",
+          "range": "bytes=702-1112"
         },
         "data": {
-          "checksum": "sha256-3xIIHf7osttdb7FoJTbfURbo4YuaB3knm5Kd3B5p+dI=",
-          "range": "bytes=1108-267814"
+          "checksum": "sha256-Ath31YTTsiakoEktGl5txvNQpnr/grvFQHlmXa5E7fI=",
+          "range": "bytes=1113-267815"
         },
         "name": "ld-linux",
         "signature": {
-          "checksum": "sha1-lxFSv68mPMJwO+PthEdXfKHuLWk=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-oh4vr00LXL4ArbAOR9LS1VzzfYc=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1UvgNLBt9CKIOp7pN3EI0pgBlzXo=",
+        "checksum": "Q1TXuyiDJBsTNDwvPq7HFxaeBQ33w=",
         "control": {
-          "checksum": "sha1-UvgNLBt9CKIOp7pN3EI0pgBlzXo=",
-          "range": "bytes=696-1051"
+          "checksum": "sha1-TXuyiDJBsTNDwvPq7HFxaeBQ33w=",
+          "range": "bytes=703-1059"
         },
         "data": {
-          "checksum": "sha256-NaRRsIIgVTbofef14Qsnf+rysYDJXOXPKgfj6bAhP94=",
-          "range": "bytes=1052-408274"
+          "checksum": "sha256-3s2Fygt+ZuHj/StxP7YffswmhHE7EJ4TxZ7EWlRQ4NA=",
+          "range": "bytes=1060-408275"
         },
         "name": "glibc-locale-posix",
         "signature": {
-          "checksum": "sha1-Iug0EjR+0K/k6fl0wi0prJHKBBo=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-FbeSNtuEgFmzNamDx5Dj1LGVgsQ=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1PnEJFSqU/wFNmbOLGHbgqFwS/yU=",
+        "checksum": "Q1SD8az8RMNr5tnb8/mPZdR+A6V5k=",
         "control": {
-          "checksum": "sha1-PnEJFSqU/wFNmbOLGHbgqFwS/yU=",
-          "range": "bytes=695-1321"
+          "checksum": "sha1-SD8az8RMNr5tnb8/mPZdR+A6V5k=",
+          "range": "bytes=701-1330"
         },
         "data": {
-          "checksum": "sha256-D6XvEcPrHmlsiI6HbbE51xmiTM1c5y6DV4MrHrCVuNo=",
-          "range": "bytes=1322-5861480"
+          "checksum": "sha256-QvhWs/fGBaX5calu0uES9fcTMx6+R1xKZHdxkxxSxsg=",
+          "range": "bytes=1331-5861481"
         },
         "name": "glibc",
         "signature": {
-          "checksum": "sha1-ypPC9SJASGEATsvLoDuEEUobhAs=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-v4LRB2eP5VLe623v8sJ3f4wDNFM=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",
@@ -565,22 +565,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1szp02tM1WkRUzhOGBkFjl6dA5pQ=",
+        "checksum": "Q1drCieAMJpJBP1KWvJk6Vhq7Zj20=",
         "control": {
-          "checksum": "sha1-szp02tM1WkRUzhOGBkFjl6dA5pQ=",
-          "range": "bytes=698-1101"
+          "checksum": "sha1-drCieAMJpJBP1KWvJk6Vhq7Zj20=",
+          "range": "bytes=701-1108"
         },
         "data": {
-          "checksum": "sha256-hrc/6rvJR5nb97Gu5Hep8419+WyFmd7maV78ni7zQAc=",
-          "range": "bytes=1102-21604"
+          "checksum": "sha256-LcGaT+nLHN7YtUab5sY0EoXErbOj/S58FXtf1JVxWbM=",
+          "range": "bytes=1109-21605"
         },
         "name": "libcrypt1",
         "signature": {
-          "checksum": "sha1-Jk/8hSLRyZ7scdep1XfbpKABePY=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-wwLYQc1joetP6IOipSVSCQsZHsM=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/executor-kubernetes.lock.json
+++ b/wolfi-images/executor-kubernetes.lock.json
@@ -1,5 +1,5 @@
 {
-  "configHash": "1cb8edea905b768756479bf48f64ff066dbfd58005060d8e2ed16b05d3ae6478",
+  "configHash": "cbca2227f18cd26d1f84c5fed767b41eebee0f8fdd6402e831edfcb14786b22a",
   "contents": {
     "keyring": [
       {

--- a/wolfi-images/executor-kubernetes.yaml
+++ b/wolfi-images/executor-kubernetes.yaml
@@ -8,3 +8,5 @@ contents:
 
     ## executor-kubernetes packages
     - git
+
+# MANUAL REBUILD: 

--- a/wolfi-images/executor.lock.json
+++ b/wolfi-images/executor.lock.json
@@ -52,60 +52,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1DyZ5L88J9MmDMYgbsywXdJdnw04=",
+        "checksum": "Q1uuAznXPkDNBMP/eILVO7UDGj1pU=",
         "control": {
-          "checksum": "sha1-DyZ5L88J9MmDMYgbsywXdJdnw04=",
-          "range": "bytes=699-1107"
+          "checksum": "sha1-uuAznXPkDNBMP/eILVO7UDGj1pU=",
+          "range": "bytes=702-1112"
         },
         "data": {
-          "checksum": "sha256-3xIIHf7osttdb7FoJTbfURbo4YuaB3knm5Kd3B5p+dI=",
-          "range": "bytes=1108-267814"
+          "checksum": "sha256-Ath31YTTsiakoEktGl5txvNQpnr/grvFQHlmXa5E7fI=",
+          "range": "bytes=1113-267815"
         },
         "name": "ld-linux",
         "signature": {
-          "checksum": "sha1-lxFSv68mPMJwO+PthEdXfKHuLWk=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-oh4vr00LXL4ArbAOR9LS1VzzfYc=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1UvgNLBt9CKIOp7pN3EI0pgBlzXo=",
+        "checksum": "Q1TXuyiDJBsTNDwvPq7HFxaeBQ33w=",
         "control": {
-          "checksum": "sha1-UvgNLBt9CKIOp7pN3EI0pgBlzXo=",
-          "range": "bytes=696-1051"
+          "checksum": "sha1-TXuyiDJBsTNDwvPq7HFxaeBQ33w=",
+          "range": "bytes=703-1059"
         },
         "data": {
-          "checksum": "sha256-NaRRsIIgVTbofef14Qsnf+rysYDJXOXPKgfj6bAhP94=",
-          "range": "bytes=1052-408274"
+          "checksum": "sha256-3s2Fygt+ZuHj/StxP7YffswmhHE7EJ4TxZ7EWlRQ4NA=",
+          "range": "bytes=1060-408275"
         },
         "name": "glibc-locale-posix",
         "signature": {
-          "checksum": "sha1-Iug0EjR+0K/k6fl0wi0prJHKBBo=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-FbeSNtuEgFmzNamDx5Dj1LGVgsQ=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1PnEJFSqU/wFNmbOLGHbgqFwS/yU=",
+        "checksum": "Q1SD8az8RMNr5tnb8/mPZdR+A6V5k=",
         "control": {
-          "checksum": "sha1-PnEJFSqU/wFNmbOLGHbgqFwS/yU=",
-          "range": "bytes=695-1321"
+          "checksum": "sha1-SD8az8RMNr5tnb8/mPZdR+A6V5k=",
+          "range": "bytes=701-1330"
         },
         "data": {
-          "checksum": "sha256-D6XvEcPrHmlsiI6HbbE51xmiTM1c5y6DV4MrHrCVuNo=",
-          "range": "bytes=1322-5861480"
+          "checksum": "sha256-QvhWs/fGBaX5calu0uES9fcTMx6+R1xKZHdxkxxSxsg=",
+          "range": "bytes=1331-5861481"
         },
         "name": "glibc",
         "signature": {
-          "checksum": "sha1-ypPC9SJASGEATsvLoDuEEUobhAs=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-v4LRB2eP5VLe623v8sJ3f4wDNFM=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",
@@ -565,22 +565,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1szp02tM1WkRUzhOGBkFjl6dA5pQ=",
+        "checksum": "Q1drCieAMJpJBP1KWvJk6Vhq7Zj20=",
         "control": {
-          "checksum": "sha1-szp02tM1WkRUzhOGBkFjl6dA5pQ=",
-          "range": "bytes=698-1101"
+          "checksum": "sha1-drCieAMJpJBP1KWvJk6Vhq7Zj20=",
+          "range": "bytes=701-1108"
         },
         "data": {
-          "checksum": "sha256-hrc/6rvJR5nb97Gu5Hep8419+WyFmd7maV78ni7zQAc=",
-          "range": "bytes=1102-21604"
+          "checksum": "sha256-LcGaT+nLHN7YtUab5sY0EoXErbOj/S58FXtf1JVxWbM=",
+          "range": "bytes=1109-21605"
         },
         "name": "libcrypt1",
         "signature": {
-          "checksum": "sha1-Jk/8hSLRyZ7scdep1XfbpKABePY=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-wwLYQc1joetP6IOipSVSCQsZHsM=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/executor.lock.json
+++ b/wolfi-images/executor.lock.json
@@ -1,5 +1,5 @@
 {
-  "configHash": "b970af3909e4bde636e0cc6056204ef9e1b4117c9132fa1386af4d6c445e444e",
+  "configHash": "faccd68e9ed11e1de0a8a9d2d4024e08b3597580f66b7371cd8afde94ae0c1cb",
   "contents": {
     "keyring": [
       {

--- a/wolfi-images/executor.yaml
+++ b/wolfi-images/executor.yaml
@@ -15,3 +15,5 @@ paths:
   - path: /usr/local/bin
     type: directory
     permissions: 0o755
+
+# MANUAL REBUILD: 

--- a/wolfi-images/gitserver.lock.json
+++ b/wolfi-images/gitserver.lock.json
@@ -71,60 +71,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1DyZ5L88J9MmDMYgbsywXdJdnw04=",
+        "checksum": "Q1uuAznXPkDNBMP/eILVO7UDGj1pU=",
         "control": {
-          "checksum": "sha1-DyZ5L88J9MmDMYgbsywXdJdnw04=",
-          "range": "bytes=699-1107"
+          "checksum": "sha1-uuAznXPkDNBMP/eILVO7UDGj1pU=",
+          "range": "bytes=702-1112"
         },
         "data": {
-          "checksum": "sha256-3xIIHf7osttdb7FoJTbfURbo4YuaB3knm5Kd3B5p+dI=",
-          "range": "bytes=1108-267814"
+          "checksum": "sha256-Ath31YTTsiakoEktGl5txvNQpnr/grvFQHlmXa5E7fI=",
+          "range": "bytes=1113-267815"
         },
         "name": "ld-linux",
         "signature": {
-          "checksum": "sha1-lxFSv68mPMJwO+PthEdXfKHuLWk=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-oh4vr00LXL4ArbAOR9LS1VzzfYc=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1UvgNLBt9CKIOp7pN3EI0pgBlzXo=",
+        "checksum": "Q1TXuyiDJBsTNDwvPq7HFxaeBQ33w=",
         "control": {
-          "checksum": "sha1-UvgNLBt9CKIOp7pN3EI0pgBlzXo=",
-          "range": "bytes=696-1051"
+          "checksum": "sha1-TXuyiDJBsTNDwvPq7HFxaeBQ33w=",
+          "range": "bytes=703-1059"
         },
         "data": {
-          "checksum": "sha256-NaRRsIIgVTbofef14Qsnf+rysYDJXOXPKgfj6bAhP94=",
-          "range": "bytes=1052-408274"
+          "checksum": "sha256-3s2Fygt+ZuHj/StxP7YffswmhHE7EJ4TxZ7EWlRQ4NA=",
+          "range": "bytes=1060-408275"
         },
         "name": "glibc-locale-posix",
         "signature": {
-          "checksum": "sha1-Iug0EjR+0K/k6fl0wi0prJHKBBo=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-FbeSNtuEgFmzNamDx5Dj1LGVgsQ=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1PnEJFSqU/wFNmbOLGHbgqFwS/yU=",
+        "checksum": "Q1SD8az8RMNr5tnb8/mPZdR+A6V5k=",
         "control": {
-          "checksum": "sha1-PnEJFSqU/wFNmbOLGHbgqFwS/yU=",
-          "range": "bytes=695-1321"
+          "checksum": "sha1-SD8az8RMNr5tnb8/mPZdR+A6V5k=",
+          "range": "bytes=701-1330"
         },
         "data": {
-          "checksum": "sha256-D6XvEcPrHmlsiI6HbbE51xmiTM1c5y6DV4MrHrCVuNo=",
-          "range": "bytes=1322-5861480"
+          "checksum": "sha256-QvhWs/fGBaX5calu0uES9fcTMx6+R1xKZHdxkxxSxsg=",
+          "range": "bytes=1331-5861481"
         },
         "name": "glibc",
         "signature": {
-          "checksum": "sha1-ypPC9SJASGEATsvLoDuEEUobhAs=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-v4LRB2eP5VLe623v8sJ3f4wDNFM=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",
@@ -622,22 +622,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1szp02tM1WkRUzhOGBkFjl6dA5pQ=",
+        "checksum": "Q1drCieAMJpJBP1KWvJk6Vhq7Zj20=",
         "control": {
-          "checksum": "sha1-szp02tM1WkRUzhOGBkFjl6dA5pQ=",
-          "range": "bytes=698-1101"
+          "checksum": "sha1-drCieAMJpJBP1KWvJk6Vhq7Zj20=",
+          "range": "bytes=701-1108"
         },
         "data": {
-          "checksum": "sha256-hrc/6rvJR5nb97Gu5Hep8419+WyFmd7maV78ni7zQAc=",
-          "range": "bytes=1102-21604"
+          "checksum": "sha256-LcGaT+nLHN7YtUab5sY0EoXErbOj/S58FXtf1JVxWbM=",
+          "range": "bytes=1109-21605"
         },
         "name": "libcrypt1",
         "signature": {
-          "checksum": "sha1-Jk/8hSLRyZ7scdep1XfbpKABePY=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-wwLYQc1joetP6IOipSVSCQsZHsM=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/gitserver.lock.json
+++ b/wolfi-images/gitserver.lock.json
@@ -1,5 +1,5 @@
 {
-  "configHash": "da70ef3732e18eb498f54b15ee16bf466c34ec8ac25fa28954aaa9cefd89cc30",
+  "configHash": "2045ef1b52081f23b1bbb08d9bbba5d3f0e39aded17d5e99e7c300b8e6881fe8",
   "contents": {
     "keyring": [
       {

--- a/wolfi-images/gitserver.yaml
+++ b/wolfi-images/gitserver.yaml
@@ -26,3 +26,5 @@ paths:
     permissions: 0o755
 
 work-dir: /
+
+# MANUAL REBUILD: 

--- a/wolfi-images/grafana.lock.json
+++ b/wolfi-images/grafana.lock.json
@@ -1,5 +1,5 @@
 {
-  "configHash": "9ed4d915d1c5e54360e87305c3bab861102413e764f535d8b066632f7c98c195",
+  "configHash": "9718b530b480918b294b0cbc0bd163d09f3783dfb3ee58ee092c3335eb7df397",
   "contents": {
     "keyring": [
       {

--- a/wolfi-images/grafana.lock.json
+++ b/wolfi-images/grafana.lock.json
@@ -56,60 +56,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1DyZ5L88J9MmDMYgbsywXdJdnw04=",
+        "checksum": "Q1uuAznXPkDNBMP/eILVO7UDGj1pU=",
         "control": {
-          "checksum": "sha1-DyZ5L88J9MmDMYgbsywXdJdnw04=",
-          "range": "bytes=699-1107"
+          "checksum": "sha1-uuAznXPkDNBMP/eILVO7UDGj1pU=",
+          "range": "bytes=702-1112"
         },
         "data": {
-          "checksum": "sha256-3xIIHf7osttdb7FoJTbfURbo4YuaB3knm5Kd3B5p+dI=",
-          "range": "bytes=1108-267814"
+          "checksum": "sha256-Ath31YTTsiakoEktGl5txvNQpnr/grvFQHlmXa5E7fI=",
+          "range": "bytes=1113-267815"
         },
         "name": "ld-linux",
         "signature": {
-          "checksum": "sha1-lxFSv68mPMJwO+PthEdXfKHuLWk=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-oh4vr00LXL4ArbAOR9LS1VzzfYc=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1UvgNLBt9CKIOp7pN3EI0pgBlzXo=",
+        "checksum": "Q1TXuyiDJBsTNDwvPq7HFxaeBQ33w=",
         "control": {
-          "checksum": "sha1-UvgNLBt9CKIOp7pN3EI0pgBlzXo=",
-          "range": "bytes=696-1051"
+          "checksum": "sha1-TXuyiDJBsTNDwvPq7HFxaeBQ33w=",
+          "range": "bytes=703-1059"
         },
         "data": {
-          "checksum": "sha256-NaRRsIIgVTbofef14Qsnf+rysYDJXOXPKgfj6bAhP94=",
-          "range": "bytes=1052-408274"
+          "checksum": "sha256-3s2Fygt+ZuHj/StxP7YffswmhHE7EJ4TxZ7EWlRQ4NA=",
+          "range": "bytes=1060-408275"
         },
         "name": "glibc-locale-posix",
         "signature": {
-          "checksum": "sha1-Iug0EjR+0K/k6fl0wi0prJHKBBo=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-FbeSNtuEgFmzNamDx5Dj1LGVgsQ=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1PnEJFSqU/wFNmbOLGHbgqFwS/yU=",
+        "checksum": "Q1SD8az8RMNr5tnb8/mPZdR+A6V5k=",
         "control": {
-          "checksum": "sha1-PnEJFSqU/wFNmbOLGHbgqFwS/yU=",
-          "range": "bytes=695-1321"
+          "checksum": "sha1-SD8az8RMNr5tnb8/mPZdR+A6V5k=",
+          "range": "bytes=701-1330"
         },
         "data": {
-          "checksum": "sha256-D6XvEcPrHmlsiI6HbbE51xmiTM1c5y6DV4MrHrCVuNo=",
-          "range": "bytes=1322-5861480"
+          "checksum": "sha256-QvhWs/fGBaX5calu0uES9fcTMx6+R1xKZHdxkxxSxsg=",
+          "range": "bytes=1331-5861481"
         },
         "name": "glibc",
         "signature": {
-          "checksum": "sha1-ypPC9SJASGEATsvLoDuEEUobhAs=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-v4LRB2eP5VLe623v8sJ3f4wDNFM=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",
@@ -227,22 +227,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1szp02tM1WkRUzhOGBkFjl6dA5pQ=",
+        "checksum": "Q1drCieAMJpJBP1KWvJk6Vhq7Zj20=",
         "control": {
-          "checksum": "sha1-szp02tM1WkRUzhOGBkFjl6dA5pQ=",
-          "range": "bytes=698-1101"
+          "checksum": "sha1-drCieAMJpJBP1KWvJk6Vhq7Zj20=",
+          "range": "bytes=701-1108"
         },
         "data": {
-          "checksum": "sha256-hrc/6rvJR5nb97Gu5Hep8419+WyFmd7maV78ni7zQAc=",
-          "range": "bytes=1102-21604"
+          "checksum": "sha256-LcGaT+nLHN7YtUab5sY0EoXErbOj/S58FXtf1JVxWbM=",
+          "range": "bytes=1109-21605"
         },
         "name": "libcrypt1",
         "signature": {
-          "checksum": "sha1-Jk/8hSLRyZ7scdep1XfbpKABePY=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-wwLYQc1joetP6IOipSVSCQsZHsM=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",
@@ -265,22 +265,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1qLbMbmgFOXNEspWQUcjRuuekaAE=",
+        "checksum": "Q1cB2DKwrO+Pwb0nk1xtR8eOCPWDE=",
         "control": {
-          "checksum": "sha1-qLbMbmgFOXNEspWQUcjRuuekaAE=",
-          "range": "bytes=708-1033"
+          "checksum": "sha1-cB2DKwrO+Pwb0nk1xtR8eOCPWDE=",
+          "range": "bytes=699-1027"
         },
         "data": {
-          "checksum": "sha256-UnfXdmp5QzhslWzz6ghNwqDnCLKHE/4963TnjO2/7hU=",
-          "range": "bytes=1034-61049958"
+          "checksum": "sha256-gPHRw2Z2/3gjIt6O0AdmSs00lbUyMmge+e0Gg+tU0Gw=",
+          "range": "bytes=1028-61049959"
         },
         "name": "glibc-locale-en",
         "signature": {
-          "checksum": "sha1-YyzlLTZZkVz2l55qSEMSqrF5wZQ=",
-          "range": "bytes=0-707"
+          "checksum": "sha1-Iwu06mppUw/+LJRsr8byQnuSlv8=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-en-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-en-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/grafana.yaml
+++ b/wolfi-images/grafana.yaml
@@ -103,3 +103,5 @@ annotations:
   org.opencontainers.image.url: https://sourcegraph.com/
   org.opencontainers.image.source: https://github.com/sourcegraph/sourcegraph/
   org.opencontainers.image.documentation: https://sourcegraph.com/docs/
+
+# MANUAL REBUILD: 

--- a/wolfi-images/jaeger-agent.lock.json
+++ b/wolfi-images/jaeger-agent.lock.json
@@ -1,5 +1,5 @@
 {
-  "configHash": "3344e1ec92f0936169f62ad43d1c3f043c1fa03a3fbaea4a1f72b4d10183867f",
+  "configHash": "59baec866309d1e1c5be076c9022b6ddabdeaa769e8716c8e69acd762f369a43",
   "contents": {
     "keyring": [
       {

--- a/wolfi-images/jaeger-agent.lock.json
+++ b/wolfi-images/jaeger-agent.lock.json
@@ -52,60 +52,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1DyZ5L88J9MmDMYgbsywXdJdnw04=",
+        "checksum": "Q1uuAznXPkDNBMP/eILVO7UDGj1pU=",
         "control": {
-          "checksum": "sha1-DyZ5L88J9MmDMYgbsywXdJdnw04=",
-          "range": "bytes=699-1107"
+          "checksum": "sha1-uuAznXPkDNBMP/eILVO7UDGj1pU=",
+          "range": "bytes=702-1112"
         },
         "data": {
-          "checksum": "sha256-3xIIHf7osttdb7FoJTbfURbo4YuaB3knm5Kd3B5p+dI=",
-          "range": "bytes=1108-267814"
+          "checksum": "sha256-Ath31YTTsiakoEktGl5txvNQpnr/grvFQHlmXa5E7fI=",
+          "range": "bytes=1113-267815"
         },
         "name": "ld-linux",
         "signature": {
-          "checksum": "sha1-lxFSv68mPMJwO+PthEdXfKHuLWk=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-oh4vr00LXL4ArbAOR9LS1VzzfYc=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1UvgNLBt9CKIOp7pN3EI0pgBlzXo=",
+        "checksum": "Q1TXuyiDJBsTNDwvPq7HFxaeBQ33w=",
         "control": {
-          "checksum": "sha1-UvgNLBt9CKIOp7pN3EI0pgBlzXo=",
-          "range": "bytes=696-1051"
+          "checksum": "sha1-TXuyiDJBsTNDwvPq7HFxaeBQ33w=",
+          "range": "bytes=703-1059"
         },
         "data": {
-          "checksum": "sha256-NaRRsIIgVTbofef14Qsnf+rysYDJXOXPKgfj6bAhP94=",
-          "range": "bytes=1052-408274"
+          "checksum": "sha256-3s2Fygt+ZuHj/StxP7YffswmhHE7EJ4TxZ7EWlRQ4NA=",
+          "range": "bytes=1060-408275"
         },
         "name": "glibc-locale-posix",
         "signature": {
-          "checksum": "sha1-Iug0EjR+0K/k6fl0wi0prJHKBBo=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-FbeSNtuEgFmzNamDx5Dj1LGVgsQ=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1PnEJFSqU/wFNmbOLGHbgqFwS/yU=",
+        "checksum": "Q1SD8az8RMNr5tnb8/mPZdR+A6V5k=",
         "control": {
-          "checksum": "sha1-PnEJFSqU/wFNmbOLGHbgqFwS/yU=",
-          "range": "bytes=695-1321"
+          "checksum": "sha1-SD8az8RMNr5tnb8/mPZdR+A6V5k=",
+          "range": "bytes=701-1330"
         },
         "data": {
-          "checksum": "sha256-D6XvEcPrHmlsiI6HbbE51xmiTM1c5y6DV4MrHrCVuNo=",
-          "range": "bytes=1322-5861480"
+          "checksum": "sha256-QvhWs/fGBaX5calu0uES9fcTMx6+R1xKZHdxkxxSxsg=",
+          "range": "bytes=1331-5861481"
         },
         "name": "glibc",
         "signature": {
-          "checksum": "sha1-ypPC9SJASGEATsvLoDuEEUobhAs=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-v4LRB2eP5VLe623v8sJ3f4wDNFM=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",
@@ -565,22 +565,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1szp02tM1WkRUzhOGBkFjl6dA5pQ=",
+        "checksum": "Q1drCieAMJpJBP1KWvJk6Vhq7Zj20=",
         "control": {
-          "checksum": "sha1-szp02tM1WkRUzhOGBkFjl6dA5pQ=",
-          "range": "bytes=698-1101"
+          "checksum": "sha1-drCieAMJpJBP1KWvJk6Vhq7Zj20=",
+          "range": "bytes=701-1108"
         },
         "data": {
-          "checksum": "sha256-hrc/6rvJR5nb97Gu5Hep8419+WyFmd7maV78ni7zQAc=",
-          "range": "bytes=1102-21604"
+          "checksum": "sha256-LcGaT+nLHN7YtUab5sY0EoXErbOj/S58FXtf1JVxWbM=",
+          "range": "bytes=1109-21605"
         },
         "name": "libcrypt1",
         "signature": {
-          "checksum": "sha1-Jk/8hSLRyZ7scdep1XfbpKABePY=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-wwLYQc1joetP6IOipSVSCQsZHsM=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/jaeger-agent.yaml
+++ b/wolfi-images/jaeger-agent.yaml
@@ -19,3 +19,5 @@ accounts:
     - username: jaeger
       uid: 10001
       gid: 10002
+
+# MANUAL REBUILD: 

--- a/wolfi-images/jaeger-all-in-one.lock.json
+++ b/wolfi-images/jaeger-all-in-one.lock.json
@@ -1,5 +1,5 @@
 {
-  "configHash": "ed80b9492ce2f63681cf0493c5095e525bd777ae3cca716592bc0e1522cb631d",
+  "configHash": "ba51d333a2fa640667d750c9adbcc8f89a6d72e2c73ba5246048ccc7b9bcaa18",
   "contents": {
     "keyring": [
       {

--- a/wolfi-images/jaeger-all-in-one.lock.json
+++ b/wolfi-images/jaeger-all-in-one.lock.json
@@ -52,60 +52,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1DyZ5L88J9MmDMYgbsywXdJdnw04=",
+        "checksum": "Q1uuAznXPkDNBMP/eILVO7UDGj1pU=",
         "control": {
-          "checksum": "sha1-DyZ5L88J9MmDMYgbsywXdJdnw04=",
-          "range": "bytes=699-1107"
+          "checksum": "sha1-uuAznXPkDNBMP/eILVO7UDGj1pU=",
+          "range": "bytes=702-1112"
         },
         "data": {
-          "checksum": "sha256-3xIIHf7osttdb7FoJTbfURbo4YuaB3knm5Kd3B5p+dI=",
-          "range": "bytes=1108-267814"
+          "checksum": "sha256-Ath31YTTsiakoEktGl5txvNQpnr/grvFQHlmXa5E7fI=",
+          "range": "bytes=1113-267815"
         },
         "name": "ld-linux",
         "signature": {
-          "checksum": "sha1-lxFSv68mPMJwO+PthEdXfKHuLWk=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-oh4vr00LXL4ArbAOR9LS1VzzfYc=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1UvgNLBt9CKIOp7pN3EI0pgBlzXo=",
+        "checksum": "Q1TXuyiDJBsTNDwvPq7HFxaeBQ33w=",
         "control": {
-          "checksum": "sha1-UvgNLBt9CKIOp7pN3EI0pgBlzXo=",
-          "range": "bytes=696-1051"
+          "checksum": "sha1-TXuyiDJBsTNDwvPq7HFxaeBQ33w=",
+          "range": "bytes=703-1059"
         },
         "data": {
-          "checksum": "sha256-NaRRsIIgVTbofef14Qsnf+rysYDJXOXPKgfj6bAhP94=",
-          "range": "bytes=1052-408274"
+          "checksum": "sha256-3s2Fygt+ZuHj/StxP7YffswmhHE7EJ4TxZ7EWlRQ4NA=",
+          "range": "bytes=1060-408275"
         },
         "name": "glibc-locale-posix",
         "signature": {
-          "checksum": "sha1-Iug0EjR+0K/k6fl0wi0prJHKBBo=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-FbeSNtuEgFmzNamDx5Dj1LGVgsQ=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1PnEJFSqU/wFNmbOLGHbgqFwS/yU=",
+        "checksum": "Q1SD8az8RMNr5tnb8/mPZdR+A6V5k=",
         "control": {
-          "checksum": "sha1-PnEJFSqU/wFNmbOLGHbgqFwS/yU=",
-          "range": "bytes=695-1321"
+          "checksum": "sha1-SD8az8RMNr5tnb8/mPZdR+A6V5k=",
+          "range": "bytes=701-1330"
         },
         "data": {
-          "checksum": "sha256-D6XvEcPrHmlsiI6HbbE51xmiTM1c5y6DV4MrHrCVuNo=",
-          "range": "bytes=1322-5861480"
+          "checksum": "sha256-QvhWs/fGBaX5calu0uES9fcTMx6+R1xKZHdxkxxSxsg=",
+          "range": "bytes=1331-5861481"
         },
         "name": "glibc",
         "signature": {
-          "checksum": "sha1-ypPC9SJASGEATsvLoDuEEUobhAs=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-v4LRB2eP5VLe623v8sJ3f4wDNFM=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",
@@ -565,22 +565,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1szp02tM1WkRUzhOGBkFjl6dA5pQ=",
+        "checksum": "Q1drCieAMJpJBP1KWvJk6Vhq7Zj20=",
         "control": {
-          "checksum": "sha1-szp02tM1WkRUzhOGBkFjl6dA5pQ=",
-          "range": "bytes=698-1101"
+          "checksum": "sha1-drCieAMJpJBP1KWvJk6Vhq7Zj20=",
+          "range": "bytes=701-1108"
         },
         "data": {
-          "checksum": "sha256-hrc/6rvJR5nb97Gu5Hep8419+WyFmd7maV78ni7zQAc=",
-          "range": "bytes=1102-21604"
+          "checksum": "sha256-LcGaT+nLHN7YtUab5sY0EoXErbOj/S58FXtf1JVxWbM=",
+          "range": "bytes=1109-21605"
         },
         "name": "libcrypt1",
         "signature": {
-          "checksum": "sha1-Jk/8hSLRyZ7scdep1XfbpKABePY=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-wwLYQc1joetP6IOipSVSCQsZHsM=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/jaeger-all-in-one.yaml
+++ b/wolfi-images/jaeger-all-in-one.yaml
@@ -25,3 +25,5 @@ paths:
     type: directory
     uid: 10001
     permissions: 0o755
+
+# MANUAL REBUILD: 

--- a/wolfi-images/node-exporter.lock.json
+++ b/wolfi-images/node-exporter.lock.json
@@ -1,5 +1,5 @@
 {
-  "configHash": "3db6ddedd2b70859755afbdaef8e063b9eec37ccc7cf9ad3a71a48da7180422e",
+  "configHash": "4d9771b757a2a3b4f7b63d6ea59480a9c775f825a0b8c197f97ef81c238a2a5b",
   "contents": {
     "keyring": [
       {

--- a/wolfi-images/node-exporter.lock.json
+++ b/wolfi-images/node-exporter.lock.json
@@ -52,60 +52,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1DyZ5L88J9MmDMYgbsywXdJdnw04=",
+        "checksum": "Q1uuAznXPkDNBMP/eILVO7UDGj1pU=",
         "control": {
-          "checksum": "sha1-DyZ5L88J9MmDMYgbsywXdJdnw04=",
-          "range": "bytes=699-1107"
+          "checksum": "sha1-uuAznXPkDNBMP/eILVO7UDGj1pU=",
+          "range": "bytes=702-1112"
         },
         "data": {
-          "checksum": "sha256-3xIIHf7osttdb7FoJTbfURbo4YuaB3knm5Kd3B5p+dI=",
-          "range": "bytes=1108-267814"
+          "checksum": "sha256-Ath31YTTsiakoEktGl5txvNQpnr/grvFQHlmXa5E7fI=",
+          "range": "bytes=1113-267815"
         },
         "name": "ld-linux",
         "signature": {
-          "checksum": "sha1-lxFSv68mPMJwO+PthEdXfKHuLWk=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-oh4vr00LXL4ArbAOR9LS1VzzfYc=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1UvgNLBt9CKIOp7pN3EI0pgBlzXo=",
+        "checksum": "Q1TXuyiDJBsTNDwvPq7HFxaeBQ33w=",
         "control": {
-          "checksum": "sha1-UvgNLBt9CKIOp7pN3EI0pgBlzXo=",
-          "range": "bytes=696-1051"
+          "checksum": "sha1-TXuyiDJBsTNDwvPq7HFxaeBQ33w=",
+          "range": "bytes=703-1059"
         },
         "data": {
-          "checksum": "sha256-NaRRsIIgVTbofef14Qsnf+rysYDJXOXPKgfj6bAhP94=",
-          "range": "bytes=1052-408274"
+          "checksum": "sha256-3s2Fygt+ZuHj/StxP7YffswmhHE7EJ4TxZ7EWlRQ4NA=",
+          "range": "bytes=1060-408275"
         },
         "name": "glibc-locale-posix",
         "signature": {
-          "checksum": "sha1-Iug0EjR+0K/k6fl0wi0prJHKBBo=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-FbeSNtuEgFmzNamDx5Dj1LGVgsQ=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1PnEJFSqU/wFNmbOLGHbgqFwS/yU=",
+        "checksum": "Q1SD8az8RMNr5tnb8/mPZdR+A6V5k=",
         "control": {
-          "checksum": "sha1-PnEJFSqU/wFNmbOLGHbgqFwS/yU=",
-          "range": "bytes=695-1321"
+          "checksum": "sha1-SD8az8RMNr5tnb8/mPZdR+A6V5k=",
+          "range": "bytes=701-1330"
         },
         "data": {
-          "checksum": "sha256-D6XvEcPrHmlsiI6HbbE51xmiTM1c5y6DV4MrHrCVuNo=",
-          "range": "bytes=1322-5861480"
+          "checksum": "sha256-QvhWs/fGBaX5calu0uES9fcTMx6+R1xKZHdxkxxSxsg=",
+          "range": "bytes=1331-5861481"
         },
         "name": "glibc",
         "signature": {
-          "checksum": "sha1-ypPC9SJASGEATsvLoDuEEUobhAs=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-v4LRB2eP5VLe623v8sJ3f4wDNFM=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",
@@ -565,22 +565,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1szp02tM1WkRUzhOGBkFjl6dA5pQ=",
+        "checksum": "Q1drCieAMJpJBP1KWvJk6Vhq7Zj20=",
         "control": {
-          "checksum": "sha1-szp02tM1WkRUzhOGBkFjl6dA5pQ=",
-          "range": "bytes=698-1101"
+          "checksum": "sha1-drCieAMJpJBP1KWvJk6Vhq7Zj20=",
+          "range": "bytes=701-1108"
         },
         "data": {
-          "checksum": "sha256-hrc/6rvJR5nb97Gu5Hep8419+WyFmd7maV78ni7zQAc=",
-          "range": "bytes=1102-21604"
+          "checksum": "sha256-LcGaT+nLHN7YtUab5sY0EoXErbOj/S58FXtf1JVxWbM=",
+          "range": "bytes=1109-21605"
         },
         "name": "libcrypt1",
         "signature": {
-          "checksum": "sha1-Jk/8hSLRyZ7scdep1XfbpKABePY=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-wwLYQc1joetP6IOipSVSCQsZHsM=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/node-exporter.yaml
+++ b/wolfi-images/node-exporter.yaml
@@ -4,3 +4,5 @@ contents:
   packages:
     ## node-exporter-specific packages
     - prometheus-node-exporter
+
+# MANUAL REBUILD: 

--- a/wolfi-images/opentelemetry-collector.lock.json
+++ b/wolfi-images/opentelemetry-collector.lock.json
@@ -52,60 +52,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1DyZ5L88J9MmDMYgbsywXdJdnw04=",
+        "checksum": "Q1uuAznXPkDNBMP/eILVO7UDGj1pU=",
         "control": {
-          "checksum": "sha1-DyZ5L88J9MmDMYgbsywXdJdnw04=",
-          "range": "bytes=699-1107"
+          "checksum": "sha1-uuAznXPkDNBMP/eILVO7UDGj1pU=",
+          "range": "bytes=702-1112"
         },
         "data": {
-          "checksum": "sha256-3xIIHf7osttdb7FoJTbfURbo4YuaB3knm5Kd3B5p+dI=",
-          "range": "bytes=1108-267814"
+          "checksum": "sha256-Ath31YTTsiakoEktGl5txvNQpnr/grvFQHlmXa5E7fI=",
+          "range": "bytes=1113-267815"
         },
         "name": "ld-linux",
         "signature": {
-          "checksum": "sha1-lxFSv68mPMJwO+PthEdXfKHuLWk=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-oh4vr00LXL4ArbAOR9LS1VzzfYc=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1UvgNLBt9CKIOp7pN3EI0pgBlzXo=",
+        "checksum": "Q1TXuyiDJBsTNDwvPq7HFxaeBQ33w=",
         "control": {
-          "checksum": "sha1-UvgNLBt9CKIOp7pN3EI0pgBlzXo=",
-          "range": "bytes=696-1051"
+          "checksum": "sha1-TXuyiDJBsTNDwvPq7HFxaeBQ33w=",
+          "range": "bytes=703-1059"
         },
         "data": {
-          "checksum": "sha256-NaRRsIIgVTbofef14Qsnf+rysYDJXOXPKgfj6bAhP94=",
-          "range": "bytes=1052-408274"
+          "checksum": "sha256-3s2Fygt+ZuHj/StxP7YffswmhHE7EJ4TxZ7EWlRQ4NA=",
+          "range": "bytes=1060-408275"
         },
         "name": "glibc-locale-posix",
         "signature": {
-          "checksum": "sha1-Iug0EjR+0K/k6fl0wi0prJHKBBo=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-FbeSNtuEgFmzNamDx5Dj1LGVgsQ=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1PnEJFSqU/wFNmbOLGHbgqFwS/yU=",
+        "checksum": "Q1SD8az8RMNr5tnb8/mPZdR+A6V5k=",
         "control": {
-          "checksum": "sha1-PnEJFSqU/wFNmbOLGHbgqFwS/yU=",
-          "range": "bytes=695-1321"
+          "checksum": "sha1-SD8az8RMNr5tnb8/mPZdR+A6V5k=",
+          "range": "bytes=701-1330"
         },
         "data": {
-          "checksum": "sha256-D6XvEcPrHmlsiI6HbbE51xmiTM1c5y6DV4MrHrCVuNo=",
-          "range": "bytes=1322-5861480"
+          "checksum": "sha256-QvhWs/fGBaX5calu0uES9fcTMx6+R1xKZHdxkxxSxsg=",
+          "range": "bytes=1331-5861481"
         },
         "name": "glibc",
         "signature": {
-          "checksum": "sha1-ypPC9SJASGEATsvLoDuEEUobhAs=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-v4LRB2eP5VLe623v8sJ3f4wDNFM=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",
@@ -565,22 +565,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1szp02tM1WkRUzhOGBkFjl6dA5pQ=",
+        "checksum": "Q1drCieAMJpJBP1KWvJk6Vhq7Zj20=",
         "control": {
-          "checksum": "sha1-szp02tM1WkRUzhOGBkFjl6dA5pQ=",
-          "range": "bytes=698-1101"
+          "checksum": "sha1-drCieAMJpJBP1KWvJk6Vhq7Zj20=",
+          "range": "bytes=701-1108"
         },
         "data": {
-          "checksum": "sha256-hrc/6rvJR5nb97Gu5Hep8419+WyFmd7maV78ni7zQAc=",
-          "range": "bytes=1102-21604"
+          "checksum": "sha256-LcGaT+nLHN7YtUab5sY0EoXErbOj/S58FXtf1JVxWbM=",
+          "range": "bytes=1109-21605"
         },
         "name": "libcrypt1",
         "signature": {
-          "checksum": "sha1-Jk/8hSLRyZ7scdep1XfbpKABePY=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-wwLYQc1joetP6IOipSVSCQsZHsM=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/opentelemetry-collector.lock.json
+++ b/wolfi-images/opentelemetry-collector.lock.json
@@ -1,5 +1,5 @@
 {
-  "configHash": "23fa1caa5030ad1d2fff79dba5334206e25d0fe1fceeae007440efec4084656b",
+  "configHash": "19e7917357207bcc5f47729b2672104891fb7f68eb38b84da0cf285e2718219d",
   "contents": {
     "keyring": [
       {

--- a/wolfi-images/opentelemetry-collector.yaml
+++ b/wolfi-images/opentelemetry-collector.yaml
@@ -15,3 +15,5 @@ paths:
     permissions: 0o755
 
 work-dir: /otel-collector
+
+# MANUAL REBUILD: 

--- a/wolfi-images/postgres-exporter.lock.json
+++ b/wolfi-images/postgres-exporter.lock.json
@@ -1,5 +1,5 @@
 {
-  "configHash": "b9d9404b91b3c5c06fefb0580cc06146c6e89ca927028aa5fce706d400e75209",
+  "configHash": "727d245b7e8ea1ab3a2d991476e00444b0fcf7446ef0080741edac6a8d0d0df4",
   "contents": {
     "keyring": [
       {

--- a/wolfi-images/postgres-exporter.lock.json
+++ b/wolfi-images/postgres-exporter.lock.json
@@ -52,60 +52,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1DyZ5L88J9MmDMYgbsywXdJdnw04=",
+        "checksum": "Q1uuAznXPkDNBMP/eILVO7UDGj1pU=",
         "control": {
-          "checksum": "sha1-DyZ5L88J9MmDMYgbsywXdJdnw04=",
-          "range": "bytes=699-1107"
+          "checksum": "sha1-uuAznXPkDNBMP/eILVO7UDGj1pU=",
+          "range": "bytes=702-1112"
         },
         "data": {
-          "checksum": "sha256-3xIIHf7osttdb7FoJTbfURbo4YuaB3knm5Kd3B5p+dI=",
-          "range": "bytes=1108-267814"
+          "checksum": "sha256-Ath31YTTsiakoEktGl5txvNQpnr/grvFQHlmXa5E7fI=",
+          "range": "bytes=1113-267815"
         },
         "name": "ld-linux",
         "signature": {
-          "checksum": "sha1-lxFSv68mPMJwO+PthEdXfKHuLWk=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-oh4vr00LXL4ArbAOR9LS1VzzfYc=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1UvgNLBt9CKIOp7pN3EI0pgBlzXo=",
+        "checksum": "Q1TXuyiDJBsTNDwvPq7HFxaeBQ33w=",
         "control": {
-          "checksum": "sha1-UvgNLBt9CKIOp7pN3EI0pgBlzXo=",
-          "range": "bytes=696-1051"
+          "checksum": "sha1-TXuyiDJBsTNDwvPq7HFxaeBQ33w=",
+          "range": "bytes=703-1059"
         },
         "data": {
-          "checksum": "sha256-NaRRsIIgVTbofef14Qsnf+rysYDJXOXPKgfj6bAhP94=",
-          "range": "bytes=1052-408274"
+          "checksum": "sha256-3s2Fygt+ZuHj/StxP7YffswmhHE7EJ4TxZ7EWlRQ4NA=",
+          "range": "bytes=1060-408275"
         },
         "name": "glibc-locale-posix",
         "signature": {
-          "checksum": "sha1-Iug0EjR+0K/k6fl0wi0prJHKBBo=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-FbeSNtuEgFmzNamDx5Dj1LGVgsQ=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1PnEJFSqU/wFNmbOLGHbgqFwS/yU=",
+        "checksum": "Q1SD8az8RMNr5tnb8/mPZdR+A6V5k=",
         "control": {
-          "checksum": "sha1-PnEJFSqU/wFNmbOLGHbgqFwS/yU=",
-          "range": "bytes=695-1321"
+          "checksum": "sha1-SD8az8RMNr5tnb8/mPZdR+A6V5k=",
+          "range": "bytes=701-1330"
         },
         "data": {
-          "checksum": "sha256-D6XvEcPrHmlsiI6HbbE51xmiTM1c5y6DV4MrHrCVuNo=",
-          "range": "bytes=1322-5861480"
+          "checksum": "sha256-QvhWs/fGBaX5calu0uES9fcTMx6+R1xKZHdxkxxSxsg=",
+          "range": "bytes=1331-5861481"
         },
         "name": "glibc",
         "signature": {
-          "checksum": "sha1-ypPC9SJASGEATsvLoDuEEUobhAs=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-v4LRB2eP5VLe623v8sJ3f4wDNFM=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",
@@ -565,22 +565,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1szp02tM1WkRUzhOGBkFjl6dA5pQ=",
+        "checksum": "Q1drCieAMJpJBP1KWvJk6Vhq7Zj20=",
         "control": {
-          "checksum": "sha1-szp02tM1WkRUzhOGBkFjl6dA5pQ=",
-          "range": "bytes=698-1101"
+          "checksum": "sha1-drCieAMJpJBP1KWvJk6Vhq7Zj20=",
+          "range": "bytes=701-1108"
         },
         "data": {
-          "checksum": "sha256-hrc/6rvJR5nb97Gu5Hep8419+WyFmd7maV78ni7zQAc=",
-          "range": "bytes=1102-21604"
+          "checksum": "sha256-LcGaT+nLHN7YtUab5sY0EoXErbOj/S58FXtf1JVxWbM=",
+          "range": "bytes=1109-21605"
         },
         "name": "libcrypt1",
         "signature": {
-          "checksum": "sha1-Jk/8hSLRyZ7scdep1XfbpKABePY=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-wwLYQc1joetP6IOipSVSCQsZHsM=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",
@@ -736,22 +736,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1gvtJ8wLt/qj2KMwI37796EiCOws=",
+        "checksum": "Q1v9j36aKj/QDucW2TWthgb0lFN5c=",
         "control": {
-          "checksum": "sha1-gvtJ8wLt/qj2KMwI37796EiCOws=",
-          "range": "bytes=703-1080"
+          "checksum": "sha1-v9j36aKj/QDucW2TWthgb0lFN5c=",
+          "range": "bytes=703-1088"
         },
         "data": {
-          "checksum": "sha256-+ah0KYZAyas3blgs4qTtdc9KgZkmI1GADOkbxfr8aok=",
-          "range": "bytes=1081-13096940"
+          "checksum": "sha256-x/hkY8PBEFsAYRDrU7hhTRaL1lVe5dlPK5I7y8ayw7w=",
+          "range": "bytes=1089-13096952"
         },
         "name": "prometheus-postgres-exporter",
         "signature": {
-          "checksum": "sha1-46uaLZr9cEfwB5TzhvZwIPM+ej8=",
+          "checksum": "sha1-nMuUyXCQD2YI4Wm6TeBRrsiT7ds=",
           "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/prometheus-postgres-exporter-0.15.0-r6.apk",
-        "version": "0.15.0-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/prometheus-postgres-exporter-0.15.0-r7.apk",
+        "version": "0.15.0-r7"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/postgres-exporter.yaml
+++ b/wolfi-images/postgres-exporter.yaml
@@ -18,3 +18,5 @@ accounts:
     - username: postgres_exporter
       uid: 20001
       gid: 102
+
+# MANUAL REBUILD: 

--- a/wolfi-images/postgresql-12-codeinsights.lock.json
+++ b/wolfi-images/postgresql-12-codeinsights.lock.json
@@ -52,60 +52,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1DyZ5L88J9MmDMYgbsywXdJdnw04=",
+        "checksum": "Q1uuAznXPkDNBMP/eILVO7UDGj1pU=",
         "control": {
-          "checksum": "sha1-DyZ5L88J9MmDMYgbsywXdJdnw04=",
-          "range": "bytes=699-1107"
+          "checksum": "sha1-uuAznXPkDNBMP/eILVO7UDGj1pU=",
+          "range": "bytes=702-1112"
         },
         "data": {
-          "checksum": "sha256-3xIIHf7osttdb7FoJTbfURbo4YuaB3knm5Kd3B5p+dI=",
-          "range": "bytes=1108-267814"
+          "checksum": "sha256-Ath31YTTsiakoEktGl5txvNQpnr/grvFQHlmXa5E7fI=",
+          "range": "bytes=1113-267815"
         },
         "name": "ld-linux",
         "signature": {
-          "checksum": "sha1-lxFSv68mPMJwO+PthEdXfKHuLWk=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-oh4vr00LXL4ArbAOR9LS1VzzfYc=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1UvgNLBt9CKIOp7pN3EI0pgBlzXo=",
+        "checksum": "Q1TXuyiDJBsTNDwvPq7HFxaeBQ33w=",
         "control": {
-          "checksum": "sha1-UvgNLBt9CKIOp7pN3EI0pgBlzXo=",
-          "range": "bytes=696-1051"
+          "checksum": "sha1-TXuyiDJBsTNDwvPq7HFxaeBQ33w=",
+          "range": "bytes=703-1059"
         },
         "data": {
-          "checksum": "sha256-NaRRsIIgVTbofef14Qsnf+rysYDJXOXPKgfj6bAhP94=",
-          "range": "bytes=1052-408274"
+          "checksum": "sha256-3s2Fygt+ZuHj/StxP7YffswmhHE7EJ4TxZ7EWlRQ4NA=",
+          "range": "bytes=1060-408275"
         },
         "name": "glibc-locale-posix",
         "signature": {
-          "checksum": "sha1-Iug0EjR+0K/k6fl0wi0prJHKBBo=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-FbeSNtuEgFmzNamDx5Dj1LGVgsQ=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1PnEJFSqU/wFNmbOLGHbgqFwS/yU=",
+        "checksum": "Q1SD8az8RMNr5tnb8/mPZdR+A6V5k=",
         "control": {
-          "checksum": "sha1-PnEJFSqU/wFNmbOLGHbgqFwS/yU=",
-          "range": "bytes=695-1321"
+          "checksum": "sha1-SD8az8RMNr5tnb8/mPZdR+A6V5k=",
+          "range": "bytes=701-1330"
         },
         "data": {
-          "checksum": "sha256-D6XvEcPrHmlsiI6HbbE51xmiTM1c5y6DV4MrHrCVuNo=",
-          "range": "bytes=1322-5861480"
+          "checksum": "sha256-QvhWs/fGBaX5calu0uES9fcTMx6+R1xKZHdxkxxSxsg=",
+          "range": "bytes=1331-5861481"
         },
         "name": "glibc",
         "signature": {
-          "checksum": "sha1-ypPC9SJASGEATsvLoDuEEUobhAs=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-v4LRB2eP5VLe623v8sJ3f4wDNFM=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",
@@ -565,22 +565,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1szp02tM1WkRUzhOGBkFjl6dA5pQ=",
+        "checksum": "Q1drCieAMJpJBP1KWvJk6Vhq7Zj20=",
         "control": {
-          "checksum": "sha1-szp02tM1WkRUzhOGBkFjl6dA5pQ=",
-          "range": "bytes=698-1101"
+          "checksum": "sha1-drCieAMJpJBP1KWvJk6Vhq7Zj20=",
+          "range": "bytes=701-1108"
         },
         "data": {
-          "checksum": "sha256-hrc/6rvJR5nb97Gu5Hep8419+WyFmd7maV78ni7zQAc=",
-          "range": "bytes=1102-21604"
+          "checksum": "sha256-LcGaT+nLHN7YtUab5sY0EoXErbOj/S58FXtf1JVxWbM=",
+          "range": "bytes=1109-21605"
         },
         "name": "libcrypt1",
         "signature": {
-          "checksum": "sha1-Jk/8hSLRyZ7scdep1XfbpKABePY=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-wwLYQc1joetP6IOipSVSCQsZHsM=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",
@@ -736,22 +736,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1qLbMbmgFOXNEspWQUcjRuuekaAE=",
+        "checksum": "Q1cB2DKwrO+Pwb0nk1xtR8eOCPWDE=",
         "control": {
-          "checksum": "sha1-qLbMbmgFOXNEspWQUcjRuuekaAE=",
-          "range": "bytes=708-1033"
+          "checksum": "sha1-cB2DKwrO+Pwb0nk1xtR8eOCPWDE=",
+          "range": "bytes=699-1027"
         },
         "data": {
-          "checksum": "sha256-UnfXdmp5QzhslWzz6ghNwqDnCLKHE/4963TnjO2/7hU=",
-          "range": "bytes=1034-61049958"
+          "checksum": "sha256-gPHRw2Z2/3gjIt6O0AdmSs00lbUyMmge+e0Gg+tU0Gw=",
+          "range": "bytes=1028-61049959"
         },
         "name": "glibc-locale-en",
         "signature": {
-          "checksum": "sha1-YyzlLTZZkVz2l55qSEMSqrF5wZQ=",
-          "range": "bytes=0-707"
+          "checksum": "sha1-Iwu06mppUw/+LJRsr8byQnuSlv8=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-en-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-en-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/postgresql-12-codeinsights.lock.json
+++ b/wolfi-images/postgresql-12-codeinsights.lock.json
@@ -1,5 +1,5 @@
 {
-  "configHash": "4ad6479b16a324b7a21dce915b9cfef8c5ef6779403cf8e507a55e75ef49e80b",
+  "configHash": "62edfdde4133669bab09c06fc1e57a69182636d7ef7f9efc04f0920e8d1a966d",
   "contents": {
     "keyring": [
       {

--- a/wolfi-images/postgresql-12-codeinsights.yaml
+++ b/wolfi-images/postgresql-12-codeinsights.yaml
@@ -55,3 +55,5 @@ accounts:
     - username: postgres
       uid: 70
       gid: 70
+
+# MANUAL REBUILD: 

--- a/wolfi-images/postgresql-12.lock.json
+++ b/wolfi-images/postgresql-12.lock.json
@@ -52,60 +52,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1DyZ5L88J9MmDMYgbsywXdJdnw04=",
+        "checksum": "Q1uuAznXPkDNBMP/eILVO7UDGj1pU=",
         "control": {
-          "checksum": "sha1-DyZ5L88J9MmDMYgbsywXdJdnw04=",
-          "range": "bytes=699-1107"
+          "checksum": "sha1-uuAznXPkDNBMP/eILVO7UDGj1pU=",
+          "range": "bytes=702-1112"
         },
         "data": {
-          "checksum": "sha256-3xIIHf7osttdb7FoJTbfURbo4YuaB3knm5Kd3B5p+dI=",
-          "range": "bytes=1108-267814"
+          "checksum": "sha256-Ath31YTTsiakoEktGl5txvNQpnr/grvFQHlmXa5E7fI=",
+          "range": "bytes=1113-267815"
         },
         "name": "ld-linux",
         "signature": {
-          "checksum": "sha1-lxFSv68mPMJwO+PthEdXfKHuLWk=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-oh4vr00LXL4ArbAOR9LS1VzzfYc=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1UvgNLBt9CKIOp7pN3EI0pgBlzXo=",
+        "checksum": "Q1TXuyiDJBsTNDwvPq7HFxaeBQ33w=",
         "control": {
-          "checksum": "sha1-UvgNLBt9CKIOp7pN3EI0pgBlzXo=",
-          "range": "bytes=696-1051"
+          "checksum": "sha1-TXuyiDJBsTNDwvPq7HFxaeBQ33w=",
+          "range": "bytes=703-1059"
         },
         "data": {
-          "checksum": "sha256-NaRRsIIgVTbofef14Qsnf+rysYDJXOXPKgfj6bAhP94=",
-          "range": "bytes=1052-408274"
+          "checksum": "sha256-3s2Fygt+ZuHj/StxP7YffswmhHE7EJ4TxZ7EWlRQ4NA=",
+          "range": "bytes=1060-408275"
         },
         "name": "glibc-locale-posix",
         "signature": {
-          "checksum": "sha1-Iug0EjR+0K/k6fl0wi0prJHKBBo=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-FbeSNtuEgFmzNamDx5Dj1LGVgsQ=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1PnEJFSqU/wFNmbOLGHbgqFwS/yU=",
+        "checksum": "Q1SD8az8RMNr5tnb8/mPZdR+A6V5k=",
         "control": {
-          "checksum": "sha1-PnEJFSqU/wFNmbOLGHbgqFwS/yU=",
-          "range": "bytes=695-1321"
+          "checksum": "sha1-SD8az8RMNr5tnb8/mPZdR+A6V5k=",
+          "range": "bytes=701-1330"
         },
         "data": {
-          "checksum": "sha256-D6XvEcPrHmlsiI6HbbE51xmiTM1c5y6DV4MrHrCVuNo=",
-          "range": "bytes=1322-5861480"
+          "checksum": "sha256-QvhWs/fGBaX5calu0uES9fcTMx6+R1xKZHdxkxxSxsg=",
+          "range": "bytes=1331-5861481"
         },
         "name": "glibc",
         "signature": {
-          "checksum": "sha1-ypPC9SJASGEATsvLoDuEEUobhAs=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-v4LRB2eP5VLe623v8sJ3f4wDNFM=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",
@@ -565,22 +565,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1szp02tM1WkRUzhOGBkFjl6dA5pQ=",
+        "checksum": "Q1drCieAMJpJBP1KWvJk6Vhq7Zj20=",
         "control": {
-          "checksum": "sha1-szp02tM1WkRUzhOGBkFjl6dA5pQ=",
-          "range": "bytes=698-1101"
+          "checksum": "sha1-drCieAMJpJBP1KWvJk6Vhq7Zj20=",
+          "range": "bytes=701-1108"
         },
         "data": {
-          "checksum": "sha256-hrc/6rvJR5nb97Gu5Hep8419+WyFmd7maV78ni7zQAc=",
-          "range": "bytes=1102-21604"
+          "checksum": "sha256-LcGaT+nLHN7YtUab5sY0EoXErbOj/S58FXtf1JVxWbM=",
+          "range": "bytes=1109-21605"
         },
         "name": "libcrypt1",
         "signature": {
-          "checksum": "sha1-Jk/8hSLRyZ7scdep1XfbpKABePY=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-wwLYQc1joetP6IOipSVSCQsZHsM=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",
@@ -736,22 +736,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1qLbMbmgFOXNEspWQUcjRuuekaAE=",
+        "checksum": "Q1cB2DKwrO+Pwb0nk1xtR8eOCPWDE=",
         "control": {
-          "checksum": "sha1-qLbMbmgFOXNEspWQUcjRuuekaAE=",
-          "range": "bytes=708-1033"
+          "checksum": "sha1-cB2DKwrO+Pwb0nk1xtR8eOCPWDE=",
+          "range": "bytes=699-1027"
         },
         "data": {
-          "checksum": "sha256-UnfXdmp5QzhslWzz6ghNwqDnCLKHE/4963TnjO2/7hU=",
-          "range": "bytes=1034-61049958"
+          "checksum": "sha256-gPHRw2Z2/3gjIt6O0AdmSs00lbUyMmge+e0Gg+tU0Gw=",
+          "range": "bytes=1028-61049959"
         },
         "name": "glibc-locale-en",
         "signature": {
-          "checksum": "sha1-YyzlLTZZkVz2l55qSEMSqrF5wZQ=",
-          "range": "bytes=0-707"
+          "checksum": "sha1-Iwu06mppUw/+LJRsr8byQnuSlv8=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-en-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-en-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/postgresql-12.lock.json
+++ b/wolfi-images/postgresql-12.lock.json
@@ -1,5 +1,5 @@
 {
-  "configHash": "90bdb3884fecede00b8769eec14c6fd0d41e1c5bb92506c92b99e2e6f2682d26",
+  "configHash": "dc20126b60c309593bcf099d4404f5ab7ffdc1423ac990580058224659f46052",
   "contents": {
     "keyring": [
       {

--- a/wolfi-images/postgresql-12.yaml
+++ b/wolfi-images/postgresql-12.yaml
@@ -58,3 +58,5 @@ paths:
     uid: 999
     gid: 999
     permissions: 0o755
+
+# MANUAL REBUILD: 

--- a/wolfi-images/prometheus.lock.json
+++ b/wolfi-images/prometheus.lock.json
@@ -52,60 +52,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1DyZ5L88J9MmDMYgbsywXdJdnw04=",
+        "checksum": "Q1uuAznXPkDNBMP/eILVO7UDGj1pU=",
         "control": {
-          "checksum": "sha1-DyZ5L88J9MmDMYgbsywXdJdnw04=",
-          "range": "bytes=699-1107"
+          "checksum": "sha1-uuAznXPkDNBMP/eILVO7UDGj1pU=",
+          "range": "bytes=702-1112"
         },
         "data": {
-          "checksum": "sha256-3xIIHf7osttdb7FoJTbfURbo4YuaB3knm5Kd3B5p+dI=",
-          "range": "bytes=1108-267814"
+          "checksum": "sha256-Ath31YTTsiakoEktGl5txvNQpnr/grvFQHlmXa5E7fI=",
+          "range": "bytes=1113-267815"
         },
         "name": "ld-linux",
         "signature": {
-          "checksum": "sha1-lxFSv68mPMJwO+PthEdXfKHuLWk=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-oh4vr00LXL4ArbAOR9LS1VzzfYc=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1UvgNLBt9CKIOp7pN3EI0pgBlzXo=",
+        "checksum": "Q1TXuyiDJBsTNDwvPq7HFxaeBQ33w=",
         "control": {
-          "checksum": "sha1-UvgNLBt9CKIOp7pN3EI0pgBlzXo=",
-          "range": "bytes=696-1051"
+          "checksum": "sha1-TXuyiDJBsTNDwvPq7HFxaeBQ33w=",
+          "range": "bytes=703-1059"
         },
         "data": {
-          "checksum": "sha256-NaRRsIIgVTbofef14Qsnf+rysYDJXOXPKgfj6bAhP94=",
-          "range": "bytes=1052-408274"
+          "checksum": "sha256-3s2Fygt+ZuHj/StxP7YffswmhHE7EJ4TxZ7EWlRQ4NA=",
+          "range": "bytes=1060-408275"
         },
         "name": "glibc-locale-posix",
         "signature": {
-          "checksum": "sha1-Iug0EjR+0K/k6fl0wi0prJHKBBo=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-FbeSNtuEgFmzNamDx5Dj1LGVgsQ=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1PnEJFSqU/wFNmbOLGHbgqFwS/yU=",
+        "checksum": "Q1SD8az8RMNr5tnb8/mPZdR+A6V5k=",
         "control": {
-          "checksum": "sha1-PnEJFSqU/wFNmbOLGHbgqFwS/yU=",
-          "range": "bytes=695-1321"
+          "checksum": "sha1-SD8az8RMNr5tnb8/mPZdR+A6V5k=",
+          "range": "bytes=701-1330"
         },
         "data": {
-          "checksum": "sha256-D6XvEcPrHmlsiI6HbbE51xmiTM1c5y6DV4MrHrCVuNo=",
-          "range": "bytes=1322-5861480"
+          "checksum": "sha256-QvhWs/fGBaX5calu0uES9fcTMx6+R1xKZHdxkxxSxsg=",
+          "range": "bytes=1331-5861481"
         },
         "name": "glibc",
         "signature": {
-          "checksum": "sha1-ypPC9SJASGEATsvLoDuEEUobhAs=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-v4LRB2eP5VLe623v8sJ3f4wDNFM=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",
@@ -565,22 +565,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1szp02tM1WkRUzhOGBkFjl6dA5pQ=",
+        "checksum": "Q1drCieAMJpJBP1KWvJk6Vhq7Zj20=",
         "control": {
-          "checksum": "sha1-szp02tM1WkRUzhOGBkFjl6dA5pQ=",
-          "range": "bytes=698-1101"
+          "checksum": "sha1-drCieAMJpJBP1KWvJk6Vhq7Zj20=",
+          "range": "bytes=701-1108"
         },
         "data": {
-          "checksum": "sha256-hrc/6rvJR5nb97Gu5Hep8419+WyFmd7maV78ni7zQAc=",
-          "range": "bytes=1102-21604"
+          "checksum": "sha256-LcGaT+nLHN7YtUab5sY0EoXErbOj/S58FXtf1JVxWbM=",
+          "range": "bytes=1109-21605"
         },
         "name": "libcrypt1",
         "signature": {
-          "checksum": "sha1-Jk/8hSLRyZ7scdep1XfbpKABePY=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-wwLYQc1joetP6IOipSVSCQsZHsM=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",
@@ -755,41 +755,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q11rWEg82oHyjUZI+8zzUmTJ1D/74=",
+        "checksum": "Q1UmcDqeuODUV8+OpvLzUyx0yI8xc=",
         "control": {
-          "checksum": "sha1-1rWEg82oHyjUZI+8zzUmTJ1D/74=",
-          "range": "bytes=703-1150"
+          "checksum": "sha1-UmcDqeuODUV8+OpvLzUyx0yI8xc=",
+          "range": "bytes=698-1144"
         },
         "data": {
-          "checksum": "sha256-ZPmuc49YzWCEyVdde2xydAUGVTJWbQ/x4bE0y3KvUi8=",
-          "range": "bytes=1151-186189747"
+          "checksum": "sha256-b4esuCNDnZjnPFuKsFFEVf4YtzS4090D1TxWga/nvWs=",
+          "range": "bytes=1145-186251251"
         },
         "name": "prometheus-2.51",
         "signature": {
-          "checksum": "sha1-id0YIveOCeBApldSkhNpoF5uUZQ=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-Dd6iX7TS/jcSD3fMqnagSEvize0=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/prometheus-2.51-2.51.2-r0.apk",
-        "version": "2.51.2-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/prometheus-2.51-2.51.2-r1.apk",
+        "version": "2.51.2-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Cvy3ADS3PdGaFFwROjHVPlWH/gk=",
+        "checksum": "Q1d50lhC89U1NMDfOR59tXcSxwhoI=",
         "control": {
-          "checksum": "sha1-Cvy3ADS3PdGaFFwROjHVPlWH/gk=",
-          "range": "bytes=697-1062"
+          "checksum": "sha1-d50lhC89U1NMDfOR59tXcSxwhoI=",
+          "range": "bytes=703-1074"
         },
         "data": {
-          "checksum": "sha256-3a5i42ZWgxXyV/+UFB7Ns6sdHRwMX8R7yz/hGBHTKpc=",
-          "range": "bytes=1063-57256559"
+          "checksum": "sha256-1hO2vJ48CDakvu2qdsvRm+VFmtEaxx7ECLIhmzn1U+A=",
+          "range": "bytes=1075-57320339"
         },
         "name": "prometheus-alertmanager",
         "signature": {
-          "checksum": "sha1-k1KFRC9YGc/kuXxVooWR37YuhZ4=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-cSE9DHjKcHhrVZ202d3cVA6lnnA=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/prometheus-alertmanager-0.27.0-r3.apk",
-        "version": "0.27.0-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/prometheus-alertmanager-0.27.0-r4.apk",
+        "version": "0.27.0-r4"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/prometheus.lock.json
+++ b/wolfi-images/prometheus.lock.json
@@ -1,5 +1,5 @@
 {
-  "configHash": "097b0ad3ce30d179b4c76772a1c887c369cf7377cfc547471e36963cd5ff7a50",
+  "configHash": "2ff0f4dc09b864dfbb7cde5fc4173de95bd4e6dded5f83c605c191d2478f58e7",
   "contents": {
     "keyring": [
       {

--- a/wolfi-images/prometheus.yaml
+++ b/wolfi-images/prometheus.yaml
@@ -23,3 +23,5 @@ paths:
     permissions: 0o755
 
 work-dir: /prometheus
+
+# MANUAL REBUILD: 

--- a/wolfi-images/qdrant.lock.json
+++ b/wolfi-images/qdrant.lock.json
@@ -52,60 +52,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1DyZ5L88J9MmDMYgbsywXdJdnw04=",
+        "checksum": "Q1uuAznXPkDNBMP/eILVO7UDGj1pU=",
         "control": {
-          "checksum": "sha1-DyZ5L88J9MmDMYgbsywXdJdnw04=",
-          "range": "bytes=699-1107"
+          "checksum": "sha1-uuAznXPkDNBMP/eILVO7UDGj1pU=",
+          "range": "bytes=702-1112"
         },
         "data": {
-          "checksum": "sha256-3xIIHf7osttdb7FoJTbfURbo4YuaB3knm5Kd3B5p+dI=",
-          "range": "bytes=1108-267814"
+          "checksum": "sha256-Ath31YTTsiakoEktGl5txvNQpnr/grvFQHlmXa5E7fI=",
+          "range": "bytes=1113-267815"
         },
         "name": "ld-linux",
         "signature": {
-          "checksum": "sha1-lxFSv68mPMJwO+PthEdXfKHuLWk=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-oh4vr00LXL4ArbAOR9LS1VzzfYc=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1UvgNLBt9CKIOp7pN3EI0pgBlzXo=",
+        "checksum": "Q1TXuyiDJBsTNDwvPq7HFxaeBQ33w=",
         "control": {
-          "checksum": "sha1-UvgNLBt9CKIOp7pN3EI0pgBlzXo=",
-          "range": "bytes=696-1051"
+          "checksum": "sha1-TXuyiDJBsTNDwvPq7HFxaeBQ33w=",
+          "range": "bytes=703-1059"
         },
         "data": {
-          "checksum": "sha256-NaRRsIIgVTbofef14Qsnf+rysYDJXOXPKgfj6bAhP94=",
-          "range": "bytes=1052-408274"
+          "checksum": "sha256-3s2Fygt+ZuHj/StxP7YffswmhHE7EJ4TxZ7EWlRQ4NA=",
+          "range": "bytes=1060-408275"
         },
         "name": "glibc-locale-posix",
         "signature": {
-          "checksum": "sha1-Iug0EjR+0K/k6fl0wi0prJHKBBo=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-FbeSNtuEgFmzNamDx5Dj1LGVgsQ=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1PnEJFSqU/wFNmbOLGHbgqFwS/yU=",
+        "checksum": "Q1SD8az8RMNr5tnb8/mPZdR+A6V5k=",
         "control": {
-          "checksum": "sha1-PnEJFSqU/wFNmbOLGHbgqFwS/yU=",
-          "range": "bytes=695-1321"
+          "checksum": "sha1-SD8az8RMNr5tnb8/mPZdR+A6V5k=",
+          "range": "bytes=701-1330"
         },
         "data": {
-          "checksum": "sha256-D6XvEcPrHmlsiI6HbbE51xmiTM1c5y6DV4MrHrCVuNo=",
-          "range": "bytes=1322-5861480"
+          "checksum": "sha256-QvhWs/fGBaX5calu0uES9fcTMx6+R1xKZHdxkxxSxsg=",
+          "range": "bytes=1331-5861481"
         },
         "name": "glibc",
         "signature": {
-          "checksum": "sha1-ypPC9SJASGEATsvLoDuEEUobhAs=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-v4LRB2eP5VLe623v8sJ3f4wDNFM=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",
@@ -565,22 +565,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1szp02tM1WkRUzhOGBkFjl6dA5pQ=",
+        "checksum": "Q1drCieAMJpJBP1KWvJk6Vhq7Zj20=",
         "control": {
-          "checksum": "sha1-szp02tM1WkRUzhOGBkFjl6dA5pQ=",
-          "range": "bytes=698-1101"
+          "checksum": "sha1-drCieAMJpJBP1KWvJk6Vhq7Zj20=",
+          "range": "bytes=701-1108"
         },
         "data": {
-          "checksum": "sha256-hrc/6rvJR5nb97Gu5Hep8419+WyFmd7maV78ni7zQAc=",
-          "range": "bytes=1102-21604"
+          "checksum": "sha256-LcGaT+nLHN7YtUab5sY0EoXErbOj/S58FXtf1JVxWbM=",
+          "range": "bytes=1109-21605"
         },
         "name": "libcrypt1",
         "signature": {
-          "checksum": "sha1-Jk/8hSLRyZ7scdep1XfbpKABePY=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-wwLYQc1joetP6IOipSVSCQsZHsM=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/qdrant.lock.json
+++ b/wolfi-images/qdrant.lock.json
@@ -1,5 +1,5 @@
 {
-  "configHash": "e5e236ded6b2a6d541220e1dac0a9ef469002f1072cb24e7d6b36708a899e18c",
+  "configHash": "f5dfaea80b9aa5f34f3aa22bfa12474efd99bdde5587dbff22187b5731e4b5ae",
   "contents": {
     "keyring": [
       {

--- a/wolfi-images/qdrant.yaml
+++ b/wolfi-images/qdrant.yaml
@@ -16,3 +16,5 @@ paths:
 
 entrypoint:
   command: /sbin/tini -- /usr/local/bin/qdrant --config-path /etc/qdrant/config.yaml
+
+# MANUAL REBUILD: 

--- a/wolfi-images/redis-exporter.lock.json
+++ b/wolfi-images/redis-exporter.lock.json
@@ -1,5 +1,5 @@
 {
-  "configHash": "4af602d32f191f25a5daeb3578fdd71265fb1dbc6aa2671fe235b1870acf4a79",
+  "configHash": "c4860f8b024ff5c5214efc1ea275342c3d497c139fdfc82500a10739e13d70b2",
   "contents": {
     "keyring": [
       {

--- a/wolfi-images/redis-exporter.lock.json
+++ b/wolfi-images/redis-exporter.lock.json
@@ -52,60 +52,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1DyZ5L88J9MmDMYgbsywXdJdnw04=",
+        "checksum": "Q1uuAznXPkDNBMP/eILVO7UDGj1pU=",
         "control": {
-          "checksum": "sha1-DyZ5L88J9MmDMYgbsywXdJdnw04=",
-          "range": "bytes=699-1107"
+          "checksum": "sha1-uuAznXPkDNBMP/eILVO7UDGj1pU=",
+          "range": "bytes=702-1112"
         },
         "data": {
-          "checksum": "sha256-3xIIHf7osttdb7FoJTbfURbo4YuaB3knm5Kd3B5p+dI=",
-          "range": "bytes=1108-267814"
+          "checksum": "sha256-Ath31YTTsiakoEktGl5txvNQpnr/grvFQHlmXa5E7fI=",
+          "range": "bytes=1113-267815"
         },
         "name": "ld-linux",
         "signature": {
-          "checksum": "sha1-lxFSv68mPMJwO+PthEdXfKHuLWk=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-oh4vr00LXL4ArbAOR9LS1VzzfYc=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1UvgNLBt9CKIOp7pN3EI0pgBlzXo=",
+        "checksum": "Q1TXuyiDJBsTNDwvPq7HFxaeBQ33w=",
         "control": {
-          "checksum": "sha1-UvgNLBt9CKIOp7pN3EI0pgBlzXo=",
-          "range": "bytes=696-1051"
+          "checksum": "sha1-TXuyiDJBsTNDwvPq7HFxaeBQ33w=",
+          "range": "bytes=703-1059"
         },
         "data": {
-          "checksum": "sha256-NaRRsIIgVTbofef14Qsnf+rysYDJXOXPKgfj6bAhP94=",
-          "range": "bytes=1052-408274"
+          "checksum": "sha256-3s2Fygt+ZuHj/StxP7YffswmhHE7EJ4TxZ7EWlRQ4NA=",
+          "range": "bytes=1060-408275"
         },
         "name": "glibc-locale-posix",
         "signature": {
-          "checksum": "sha1-Iug0EjR+0K/k6fl0wi0prJHKBBo=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-FbeSNtuEgFmzNamDx5Dj1LGVgsQ=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1PnEJFSqU/wFNmbOLGHbgqFwS/yU=",
+        "checksum": "Q1SD8az8RMNr5tnb8/mPZdR+A6V5k=",
         "control": {
-          "checksum": "sha1-PnEJFSqU/wFNmbOLGHbgqFwS/yU=",
-          "range": "bytes=695-1321"
+          "checksum": "sha1-SD8az8RMNr5tnb8/mPZdR+A6V5k=",
+          "range": "bytes=701-1330"
         },
         "data": {
-          "checksum": "sha256-D6XvEcPrHmlsiI6HbbE51xmiTM1c5y6DV4MrHrCVuNo=",
-          "range": "bytes=1322-5861480"
+          "checksum": "sha256-QvhWs/fGBaX5calu0uES9fcTMx6+R1xKZHdxkxxSxsg=",
+          "range": "bytes=1331-5861481"
         },
         "name": "glibc",
         "signature": {
-          "checksum": "sha1-ypPC9SJASGEATsvLoDuEEUobhAs=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-v4LRB2eP5VLe623v8sJ3f4wDNFM=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",
@@ -565,22 +565,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1szp02tM1WkRUzhOGBkFjl6dA5pQ=",
+        "checksum": "Q1drCieAMJpJBP1KWvJk6Vhq7Zj20=",
         "control": {
-          "checksum": "sha1-szp02tM1WkRUzhOGBkFjl6dA5pQ=",
-          "range": "bytes=698-1101"
+          "checksum": "sha1-drCieAMJpJBP1KWvJk6Vhq7Zj20=",
+          "range": "bytes=701-1108"
         },
         "data": {
-          "checksum": "sha256-hrc/6rvJR5nb97Gu5Hep8419+WyFmd7maV78ni7zQAc=",
-          "range": "bytes=1102-21604"
+          "checksum": "sha256-LcGaT+nLHN7YtUab5sY0EoXErbOj/S58FXtf1JVxWbM=",
+          "range": "bytes=1109-21605"
         },
         "name": "libcrypt1",
         "signature": {
-          "checksum": "sha1-Jk/8hSLRyZ7scdep1XfbpKABePY=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-wwLYQc1joetP6IOipSVSCQsZHsM=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/redis-exporter.yaml
+++ b/wolfi-images/redis-exporter.yaml
@@ -8,3 +8,5 @@ contents:
 
     ## redis_exporter packages
     - redis_exporter@sourcegraph
+
+# MANUAL REBUILD: 

--- a/wolfi-images/redis.lock.json
+++ b/wolfi-images/redis.lock.json
@@ -1,5 +1,5 @@
 {
-  "configHash": "ea11b538567781bc93aec32217da4bd38990c2c7fdcffd4525fe89609587bdbf",
+  "configHash": "37d5f4ff4a34d555095c4d7356b984d0490e6c39f23c4f2d96f3fc963e17c292",
   "contents": {
     "keyring": [
       {

--- a/wolfi-images/redis.lock.json
+++ b/wolfi-images/redis.lock.json
@@ -52,60 +52,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1DyZ5L88J9MmDMYgbsywXdJdnw04=",
+        "checksum": "Q1uuAznXPkDNBMP/eILVO7UDGj1pU=",
         "control": {
-          "checksum": "sha1-DyZ5L88J9MmDMYgbsywXdJdnw04=",
-          "range": "bytes=699-1107"
+          "checksum": "sha1-uuAznXPkDNBMP/eILVO7UDGj1pU=",
+          "range": "bytes=702-1112"
         },
         "data": {
-          "checksum": "sha256-3xIIHf7osttdb7FoJTbfURbo4YuaB3knm5Kd3B5p+dI=",
-          "range": "bytes=1108-267814"
+          "checksum": "sha256-Ath31YTTsiakoEktGl5txvNQpnr/grvFQHlmXa5E7fI=",
+          "range": "bytes=1113-267815"
         },
         "name": "ld-linux",
         "signature": {
-          "checksum": "sha1-lxFSv68mPMJwO+PthEdXfKHuLWk=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-oh4vr00LXL4ArbAOR9LS1VzzfYc=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1UvgNLBt9CKIOp7pN3EI0pgBlzXo=",
+        "checksum": "Q1TXuyiDJBsTNDwvPq7HFxaeBQ33w=",
         "control": {
-          "checksum": "sha1-UvgNLBt9CKIOp7pN3EI0pgBlzXo=",
-          "range": "bytes=696-1051"
+          "checksum": "sha1-TXuyiDJBsTNDwvPq7HFxaeBQ33w=",
+          "range": "bytes=703-1059"
         },
         "data": {
-          "checksum": "sha256-NaRRsIIgVTbofef14Qsnf+rysYDJXOXPKgfj6bAhP94=",
-          "range": "bytes=1052-408274"
+          "checksum": "sha256-3s2Fygt+ZuHj/StxP7YffswmhHE7EJ4TxZ7EWlRQ4NA=",
+          "range": "bytes=1060-408275"
         },
         "name": "glibc-locale-posix",
         "signature": {
-          "checksum": "sha1-Iug0EjR+0K/k6fl0wi0prJHKBBo=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-FbeSNtuEgFmzNamDx5Dj1LGVgsQ=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1PnEJFSqU/wFNmbOLGHbgqFwS/yU=",
+        "checksum": "Q1SD8az8RMNr5tnb8/mPZdR+A6V5k=",
         "control": {
-          "checksum": "sha1-PnEJFSqU/wFNmbOLGHbgqFwS/yU=",
-          "range": "bytes=695-1321"
+          "checksum": "sha1-SD8az8RMNr5tnb8/mPZdR+A6V5k=",
+          "range": "bytes=701-1330"
         },
         "data": {
-          "checksum": "sha256-D6XvEcPrHmlsiI6HbbE51xmiTM1c5y6DV4MrHrCVuNo=",
-          "range": "bytes=1322-5861480"
+          "checksum": "sha256-QvhWs/fGBaX5calu0uES9fcTMx6+R1xKZHdxkxxSxsg=",
+          "range": "bytes=1331-5861481"
         },
         "name": "glibc",
         "signature": {
-          "checksum": "sha1-ypPC9SJASGEATsvLoDuEEUobhAs=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-v4LRB2eP5VLe623v8sJ3f4wDNFM=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",
@@ -565,22 +565,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1szp02tM1WkRUzhOGBkFjl6dA5pQ=",
+        "checksum": "Q1drCieAMJpJBP1KWvJk6Vhq7Zj20=",
         "control": {
-          "checksum": "sha1-szp02tM1WkRUzhOGBkFjl6dA5pQ=",
-          "range": "bytes=698-1101"
+          "checksum": "sha1-drCieAMJpJBP1KWvJk6Vhq7Zj20=",
+          "range": "bytes=701-1108"
         },
         "data": {
-          "checksum": "sha256-hrc/6rvJR5nb97Gu5Hep8419+WyFmd7maV78ni7zQAc=",
-          "range": "bytes=1102-21604"
+          "checksum": "sha256-LcGaT+nLHN7YtUab5sY0EoXErbOj/S58FXtf1JVxWbM=",
+          "range": "bytes=1109-21605"
         },
         "name": "libcrypt1",
         "signature": {
-          "checksum": "sha1-Jk/8hSLRyZ7scdep1XfbpKABePY=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-wwLYQc1joetP6IOipSVSCQsZHsM=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",
@@ -812,22 +812,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1wrxprQGeD5dn/VGkPP46hGPEChw=",
+        "checksum": "Q1ueo4UWPln3T3+XsY1t4rr5k77uc=",
         "control": {
-          "checksum": "sha1-wrxprQGeD5dn/VGkPP46hGPEChw=",
-          "range": "bytes=702-1168"
+          "checksum": "sha1-ueo4UWPln3T3+XsY1t4rr5k77uc=",
+          "range": "bytes=705-1170"
         },
         "data": {
-          "checksum": "sha256-spqeE2+7COXu1WG8x4d9FmdIbE8RIUhbmguf5hqeKrc=",
-          "range": "bytes=1169-373950"
+          "checksum": "sha256-rXBoHBmHqzaLSdLi2nk0lnDGLbhjJ1JXwMkEi73DQW0=",
+          "range": "bytes=1171-373951"
         },
         "name": "posix-libc-utils",
         "signature": {
-          "checksum": "sha1-YxNF3yqWELLDOGK+TjEz01Pt1yI=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-hdlD8UIp3IX9ED5IOOvsVs4Zb0M=",
+          "range": "bytes=0-704"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/posix-libc-utils-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/posix-libc-utils-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/redis.yaml
+++ b/wolfi-images/redis.yaml
@@ -31,3 +31,5 @@ work-dir: /redis-data
 
 entrypoint:
   command: redis-server
+
+# MANUAL REBUILD: 

--- a/wolfi-images/repo-updater.lock.json
+++ b/wolfi-images/repo-updater.lock.json
@@ -1,5 +1,5 @@
 {
-  "configHash": "24c37df9a4699fecde10d4796f9318b947885895181f4f0b385e2cb69c979f11",
+  "configHash": "c5101d49d066ebf1c957e9e81465ed4421a6329708200b7c849c5ba3e00902fe",
   "contents": {
     "keyring": [
       {

--- a/wolfi-images/repo-updater.lock.json
+++ b/wolfi-images/repo-updater.lock.json
@@ -52,60 +52,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1DyZ5L88J9MmDMYgbsywXdJdnw04=",
+        "checksum": "Q1uuAznXPkDNBMP/eILVO7UDGj1pU=",
         "control": {
-          "checksum": "sha1-DyZ5L88J9MmDMYgbsywXdJdnw04=",
-          "range": "bytes=699-1107"
+          "checksum": "sha1-uuAznXPkDNBMP/eILVO7UDGj1pU=",
+          "range": "bytes=702-1112"
         },
         "data": {
-          "checksum": "sha256-3xIIHf7osttdb7FoJTbfURbo4YuaB3knm5Kd3B5p+dI=",
-          "range": "bytes=1108-267814"
+          "checksum": "sha256-Ath31YTTsiakoEktGl5txvNQpnr/grvFQHlmXa5E7fI=",
+          "range": "bytes=1113-267815"
         },
         "name": "ld-linux",
         "signature": {
-          "checksum": "sha1-lxFSv68mPMJwO+PthEdXfKHuLWk=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-oh4vr00LXL4ArbAOR9LS1VzzfYc=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1UvgNLBt9CKIOp7pN3EI0pgBlzXo=",
+        "checksum": "Q1TXuyiDJBsTNDwvPq7HFxaeBQ33w=",
         "control": {
-          "checksum": "sha1-UvgNLBt9CKIOp7pN3EI0pgBlzXo=",
-          "range": "bytes=696-1051"
+          "checksum": "sha1-TXuyiDJBsTNDwvPq7HFxaeBQ33w=",
+          "range": "bytes=703-1059"
         },
         "data": {
-          "checksum": "sha256-NaRRsIIgVTbofef14Qsnf+rysYDJXOXPKgfj6bAhP94=",
-          "range": "bytes=1052-408274"
+          "checksum": "sha256-3s2Fygt+ZuHj/StxP7YffswmhHE7EJ4TxZ7EWlRQ4NA=",
+          "range": "bytes=1060-408275"
         },
         "name": "glibc-locale-posix",
         "signature": {
-          "checksum": "sha1-Iug0EjR+0K/k6fl0wi0prJHKBBo=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-FbeSNtuEgFmzNamDx5Dj1LGVgsQ=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1PnEJFSqU/wFNmbOLGHbgqFwS/yU=",
+        "checksum": "Q1SD8az8RMNr5tnb8/mPZdR+A6V5k=",
         "control": {
-          "checksum": "sha1-PnEJFSqU/wFNmbOLGHbgqFwS/yU=",
-          "range": "bytes=695-1321"
+          "checksum": "sha1-SD8az8RMNr5tnb8/mPZdR+A6V5k=",
+          "range": "bytes=701-1330"
         },
         "data": {
-          "checksum": "sha256-D6XvEcPrHmlsiI6HbbE51xmiTM1c5y6DV4MrHrCVuNo=",
-          "range": "bytes=1322-5861480"
+          "checksum": "sha256-QvhWs/fGBaX5calu0uES9fcTMx6+R1xKZHdxkxxSxsg=",
+          "range": "bytes=1331-5861481"
         },
         "name": "glibc",
         "signature": {
-          "checksum": "sha1-ypPC9SJASGEATsvLoDuEEUobhAs=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-v4LRB2eP5VLe623v8sJ3f4wDNFM=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",
@@ -565,22 +565,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1szp02tM1WkRUzhOGBkFjl6dA5pQ=",
+        "checksum": "Q1drCieAMJpJBP1KWvJk6Vhq7Zj20=",
         "control": {
-          "checksum": "sha1-szp02tM1WkRUzhOGBkFjl6dA5pQ=",
-          "range": "bytes=698-1101"
+          "checksum": "sha1-drCieAMJpJBP1KWvJk6Vhq7Zj20=",
+          "range": "bytes=701-1108"
         },
         "data": {
-          "checksum": "sha256-hrc/6rvJR5nb97Gu5Hep8419+WyFmd7maV78ni7zQAc=",
-          "range": "bytes=1102-21604"
+          "checksum": "sha256-LcGaT+nLHN7YtUab5sY0EoXErbOj/S58FXtf1JVxWbM=",
+          "range": "bytes=1109-21605"
         },
         "name": "libcrypt1",
         "signature": {
-          "checksum": "sha1-Jk/8hSLRyZ7scdep1XfbpKABePY=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-wwLYQc1joetP6IOipSVSCQsZHsM=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/repo-updater.yaml
+++ b/wolfi-images/repo-updater.yaml
@@ -8,3 +8,5 @@ contents:
 
     ## repo-updater packages
     - coursier@sourcegraph
+
+# MANUAL REBUILD: 

--- a/wolfi-images/search-indexer.lock.json
+++ b/wolfi-images/search-indexer.lock.json
@@ -1,5 +1,5 @@
 {
-  "configHash": "35ef2cb8839c66575609872fde276c9182c55071128406deb4f08275d96945ef",
+  "configHash": "604eda47fcaf8b845371608a85af2ebf1a975deaf4865d130a6514f5075962ee",
   "contents": {
     "keyring": [
       {

--- a/wolfi-images/search-indexer.lock.json
+++ b/wolfi-images/search-indexer.lock.json
@@ -52,60 +52,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1DyZ5L88J9MmDMYgbsywXdJdnw04=",
+        "checksum": "Q1uuAznXPkDNBMP/eILVO7UDGj1pU=",
         "control": {
-          "checksum": "sha1-DyZ5L88J9MmDMYgbsywXdJdnw04=",
-          "range": "bytes=699-1107"
+          "checksum": "sha1-uuAznXPkDNBMP/eILVO7UDGj1pU=",
+          "range": "bytes=702-1112"
         },
         "data": {
-          "checksum": "sha256-3xIIHf7osttdb7FoJTbfURbo4YuaB3knm5Kd3B5p+dI=",
-          "range": "bytes=1108-267814"
+          "checksum": "sha256-Ath31YTTsiakoEktGl5txvNQpnr/grvFQHlmXa5E7fI=",
+          "range": "bytes=1113-267815"
         },
         "name": "ld-linux",
         "signature": {
-          "checksum": "sha1-lxFSv68mPMJwO+PthEdXfKHuLWk=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-oh4vr00LXL4ArbAOR9LS1VzzfYc=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1UvgNLBt9CKIOp7pN3EI0pgBlzXo=",
+        "checksum": "Q1TXuyiDJBsTNDwvPq7HFxaeBQ33w=",
         "control": {
-          "checksum": "sha1-UvgNLBt9CKIOp7pN3EI0pgBlzXo=",
-          "range": "bytes=696-1051"
+          "checksum": "sha1-TXuyiDJBsTNDwvPq7HFxaeBQ33w=",
+          "range": "bytes=703-1059"
         },
         "data": {
-          "checksum": "sha256-NaRRsIIgVTbofef14Qsnf+rysYDJXOXPKgfj6bAhP94=",
-          "range": "bytes=1052-408274"
+          "checksum": "sha256-3s2Fygt+ZuHj/StxP7YffswmhHE7EJ4TxZ7EWlRQ4NA=",
+          "range": "bytes=1060-408275"
         },
         "name": "glibc-locale-posix",
         "signature": {
-          "checksum": "sha1-Iug0EjR+0K/k6fl0wi0prJHKBBo=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-FbeSNtuEgFmzNamDx5Dj1LGVgsQ=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1PnEJFSqU/wFNmbOLGHbgqFwS/yU=",
+        "checksum": "Q1SD8az8RMNr5tnb8/mPZdR+A6V5k=",
         "control": {
-          "checksum": "sha1-PnEJFSqU/wFNmbOLGHbgqFwS/yU=",
-          "range": "bytes=695-1321"
+          "checksum": "sha1-SD8az8RMNr5tnb8/mPZdR+A6V5k=",
+          "range": "bytes=701-1330"
         },
         "data": {
-          "checksum": "sha256-D6XvEcPrHmlsiI6HbbE51xmiTM1c5y6DV4MrHrCVuNo=",
-          "range": "bytes=1322-5861480"
+          "checksum": "sha256-QvhWs/fGBaX5calu0uES9fcTMx6+R1xKZHdxkxxSxsg=",
+          "range": "bytes=1331-5861481"
         },
         "name": "glibc",
         "signature": {
-          "checksum": "sha1-ypPC9SJASGEATsvLoDuEEUobhAs=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-v4LRB2eP5VLe623v8sJ3f4wDNFM=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",
@@ -565,22 +565,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1szp02tM1WkRUzhOGBkFjl6dA5pQ=",
+        "checksum": "Q1drCieAMJpJBP1KWvJk6Vhq7Zj20=",
         "control": {
-          "checksum": "sha1-szp02tM1WkRUzhOGBkFjl6dA5pQ=",
-          "range": "bytes=698-1101"
+          "checksum": "sha1-drCieAMJpJBP1KWvJk6Vhq7Zj20=",
+          "range": "bytes=701-1108"
         },
         "data": {
-          "checksum": "sha256-hrc/6rvJR5nb97Gu5Hep8419+WyFmd7maV78ni7zQAc=",
-          "range": "bytes=1102-21604"
+          "checksum": "sha256-LcGaT+nLHN7YtUab5sY0EoXErbOj/S58FXtf1JVxWbM=",
+          "range": "bytes=1109-21605"
         },
         "name": "libcrypt1",
         "signature": {
-          "checksum": "sha1-Jk/8hSLRyZ7scdep1XfbpKABePY=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-wwLYQc1joetP6IOipSVSCQsZHsM=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/search-indexer.yaml
+++ b/wolfi-images/search-indexer.yaml
@@ -22,3 +22,5 @@ paths:
     uid: 100
     gid: 101
     permissions: 0o755
+
+# MANUAL REBUILD: 

--- a/wolfi-images/searcher.lock.json
+++ b/wolfi-images/searcher.lock.json
@@ -52,60 +52,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1DyZ5L88J9MmDMYgbsywXdJdnw04=",
+        "checksum": "Q1uuAznXPkDNBMP/eILVO7UDGj1pU=",
         "control": {
-          "checksum": "sha1-DyZ5L88J9MmDMYgbsywXdJdnw04=",
-          "range": "bytes=699-1107"
+          "checksum": "sha1-uuAznXPkDNBMP/eILVO7UDGj1pU=",
+          "range": "bytes=702-1112"
         },
         "data": {
-          "checksum": "sha256-3xIIHf7osttdb7FoJTbfURbo4YuaB3knm5Kd3B5p+dI=",
-          "range": "bytes=1108-267814"
+          "checksum": "sha256-Ath31YTTsiakoEktGl5txvNQpnr/grvFQHlmXa5E7fI=",
+          "range": "bytes=1113-267815"
         },
         "name": "ld-linux",
         "signature": {
-          "checksum": "sha1-lxFSv68mPMJwO+PthEdXfKHuLWk=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-oh4vr00LXL4ArbAOR9LS1VzzfYc=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1UvgNLBt9CKIOp7pN3EI0pgBlzXo=",
+        "checksum": "Q1TXuyiDJBsTNDwvPq7HFxaeBQ33w=",
         "control": {
-          "checksum": "sha1-UvgNLBt9CKIOp7pN3EI0pgBlzXo=",
-          "range": "bytes=696-1051"
+          "checksum": "sha1-TXuyiDJBsTNDwvPq7HFxaeBQ33w=",
+          "range": "bytes=703-1059"
         },
         "data": {
-          "checksum": "sha256-NaRRsIIgVTbofef14Qsnf+rysYDJXOXPKgfj6bAhP94=",
-          "range": "bytes=1052-408274"
+          "checksum": "sha256-3s2Fygt+ZuHj/StxP7YffswmhHE7EJ4TxZ7EWlRQ4NA=",
+          "range": "bytes=1060-408275"
         },
         "name": "glibc-locale-posix",
         "signature": {
-          "checksum": "sha1-Iug0EjR+0K/k6fl0wi0prJHKBBo=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-FbeSNtuEgFmzNamDx5Dj1LGVgsQ=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1PnEJFSqU/wFNmbOLGHbgqFwS/yU=",
+        "checksum": "Q1SD8az8RMNr5tnb8/mPZdR+A6V5k=",
         "control": {
-          "checksum": "sha1-PnEJFSqU/wFNmbOLGHbgqFwS/yU=",
-          "range": "bytes=695-1321"
+          "checksum": "sha1-SD8az8RMNr5tnb8/mPZdR+A6V5k=",
+          "range": "bytes=701-1330"
         },
         "data": {
-          "checksum": "sha256-D6XvEcPrHmlsiI6HbbE51xmiTM1c5y6DV4MrHrCVuNo=",
-          "range": "bytes=1322-5861480"
+          "checksum": "sha256-QvhWs/fGBaX5calu0uES9fcTMx6+R1xKZHdxkxxSxsg=",
+          "range": "bytes=1331-5861481"
         },
         "name": "glibc",
         "signature": {
-          "checksum": "sha1-ypPC9SJASGEATsvLoDuEEUobhAs=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-v4LRB2eP5VLe623v8sJ3f4wDNFM=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",
@@ -565,22 +565,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1szp02tM1WkRUzhOGBkFjl6dA5pQ=",
+        "checksum": "Q1drCieAMJpJBP1KWvJk6Vhq7Zj20=",
         "control": {
-          "checksum": "sha1-szp02tM1WkRUzhOGBkFjl6dA5pQ=",
-          "range": "bytes=698-1101"
+          "checksum": "sha1-drCieAMJpJBP1KWvJk6Vhq7Zj20=",
+          "range": "bytes=701-1108"
         },
         "data": {
-          "checksum": "sha256-hrc/6rvJR5nb97Gu5Hep8419+WyFmd7maV78ni7zQAc=",
-          "range": "bytes=1102-21604"
+          "checksum": "sha256-LcGaT+nLHN7YtUab5sY0EoXErbOj/S58FXtf1JVxWbM=",
+          "range": "bytes=1109-21605"
         },
         "name": "libcrypt1",
         "signature": {
-          "checksum": "sha1-Jk/8hSLRyZ7scdep1XfbpKABePY=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-wwLYQc1joetP6IOipSVSCQsZHsM=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/searcher.lock.json
+++ b/wolfi-images/searcher.lock.json
@@ -1,5 +1,5 @@
 {
-  "configHash": "dc6b4a8510d621b2ace12ff83f69ef04876f149dcf160e05e64c6cdb680c2a4e",
+  "configHash": "2e29aeb1374167290a66847c0c313cd6b3e65ceb942000cca522430d44780fb5",
   "contents": {
     "keyring": [
       {

--- a/wolfi-images/searcher.yaml
+++ b/wolfi-images/searcher.yaml
@@ -18,3 +18,5 @@ paths:
     uid: 100
     gid: 101
     permissions: 0o755
+
+# MANUAL REBUILD: 

--- a/wolfi-images/server.lock.json
+++ b/wolfi-images/server.lock.json
@@ -1,5 +1,5 @@
 {
-  "configHash": "d1cd03d19330eb62faf4743d680b61458f72e9d11cf525a95422e2dbbfa1bf4c",
+  "configHash": "10234e8518d28bca515593d790452c1aa44d4ea8a31fbd850b05c0369a5af6ea",
   "contents": {
     "keyring": [
       {

--- a/wolfi-images/server.lock.json
+++ b/wolfi-images/server.lock.json
@@ -75,60 +75,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1DyZ5L88J9MmDMYgbsywXdJdnw04=",
+        "checksum": "Q1uuAznXPkDNBMP/eILVO7UDGj1pU=",
         "control": {
-          "checksum": "sha1-DyZ5L88J9MmDMYgbsywXdJdnw04=",
-          "range": "bytes=699-1107"
+          "checksum": "sha1-uuAznXPkDNBMP/eILVO7UDGj1pU=",
+          "range": "bytes=702-1112"
         },
         "data": {
-          "checksum": "sha256-3xIIHf7osttdb7FoJTbfURbo4YuaB3knm5Kd3B5p+dI=",
-          "range": "bytes=1108-267814"
+          "checksum": "sha256-Ath31YTTsiakoEktGl5txvNQpnr/grvFQHlmXa5E7fI=",
+          "range": "bytes=1113-267815"
         },
         "name": "ld-linux",
         "signature": {
-          "checksum": "sha1-lxFSv68mPMJwO+PthEdXfKHuLWk=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-oh4vr00LXL4ArbAOR9LS1VzzfYc=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1UvgNLBt9CKIOp7pN3EI0pgBlzXo=",
+        "checksum": "Q1TXuyiDJBsTNDwvPq7HFxaeBQ33w=",
         "control": {
-          "checksum": "sha1-UvgNLBt9CKIOp7pN3EI0pgBlzXo=",
-          "range": "bytes=696-1051"
+          "checksum": "sha1-TXuyiDJBsTNDwvPq7HFxaeBQ33w=",
+          "range": "bytes=703-1059"
         },
         "data": {
-          "checksum": "sha256-NaRRsIIgVTbofef14Qsnf+rysYDJXOXPKgfj6bAhP94=",
-          "range": "bytes=1052-408274"
+          "checksum": "sha256-3s2Fygt+ZuHj/StxP7YffswmhHE7EJ4TxZ7EWlRQ4NA=",
+          "range": "bytes=1060-408275"
         },
         "name": "glibc-locale-posix",
         "signature": {
-          "checksum": "sha1-Iug0EjR+0K/k6fl0wi0prJHKBBo=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-FbeSNtuEgFmzNamDx5Dj1LGVgsQ=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1PnEJFSqU/wFNmbOLGHbgqFwS/yU=",
+        "checksum": "Q1SD8az8RMNr5tnb8/mPZdR+A6V5k=",
         "control": {
-          "checksum": "sha1-PnEJFSqU/wFNmbOLGHbgqFwS/yU=",
-          "range": "bytes=695-1321"
+          "checksum": "sha1-SD8az8RMNr5tnb8/mPZdR+A6V5k=",
+          "range": "bytes=701-1330"
         },
         "data": {
-          "checksum": "sha256-D6XvEcPrHmlsiI6HbbE51xmiTM1c5y6DV4MrHrCVuNo=",
-          "range": "bytes=1322-5861480"
+          "checksum": "sha256-QvhWs/fGBaX5calu0uES9fcTMx6+R1xKZHdxkxxSxsg=",
+          "range": "bytes=1331-5861481"
         },
         "name": "glibc",
         "signature": {
-          "checksum": "sha1-ypPC9SJASGEATsvLoDuEEUobhAs=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-v4LRB2eP5VLe623v8sJ3f4wDNFM=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",
@@ -626,22 +626,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1szp02tM1WkRUzhOGBkFjl6dA5pQ=",
+        "checksum": "Q1drCieAMJpJBP1KWvJk6Vhq7Zj20=",
         "control": {
-          "checksum": "sha1-szp02tM1WkRUzhOGBkFjl6dA5pQ=",
-          "range": "bytes=698-1101"
+          "checksum": "sha1-drCieAMJpJBP1KWvJk6Vhq7Zj20=",
+          "range": "bytes=701-1108"
         },
         "data": {
-          "checksum": "sha256-hrc/6rvJR5nb97Gu5Hep8419+WyFmd7maV78ni7zQAc=",
-          "range": "bytes=1102-21604"
+          "checksum": "sha256-LcGaT+nLHN7YtUab5sY0EoXErbOj/S58FXtf1JVxWbM=",
+          "range": "bytes=1109-21605"
         },
         "name": "libcrypt1",
         "signature": {
-          "checksum": "sha1-Jk/8hSLRyZ7scdep1XfbpKABePY=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-wwLYQc1joetP6IOipSVSCQsZHsM=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",
@@ -1044,22 +1044,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1qLbMbmgFOXNEspWQUcjRuuekaAE=",
+        "checksum": "Q1cB2DKwrO+Pwb0nk1xtR8eOCPWDE=",
         "control": {
-          "checksum": "sha1-qLbMbmgFOXNEspWQUcjRuuekaAE=",
-          "range": "bytes=708-1033"
+          "checksum": "sha1-cB2DKwrO+Pwb0nk1xtR8eOCPWDE=",
+          "range": "bytes=699-1027"
         },
         "data": {
-          "checksum": "sha256-UnfXdmp5QzhslWzz6ghNwqDnCLKHE/4963TnjO2/7hU=",
-          "range": "bytes=1034-61049958"
+          "checksum": "sha256-gPHRw2Z2/3gjIt6O0AdmSs00lbUyMmge+e0Gg+tU0Gw=",
+          "range": "bytes=1028-61049959"
         },
         "name": "glibc-locale-en",
         "signature": {
-          "checksum": "sha1-YyzlLTZZkVz2l55qSEMSqrF5wZQ=",
-          "range": "bytes=0-707"
+          "checksum": "sha1-Iwu06mppUw/+LJRsr8byQnuSlv8=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-en-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-en-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",
@@ -1481,22 +1481,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1wrxprQGeD5dn/VGkPP46hGPEChw=",
+        "checksum": "Q1ueo4UWPln3T3+XsY1t4rr5k77uc=",
         "control": {
-          "checksum": "sha1-wrxprQGeD5dn/VGkPP46hGPEChw=",
-          "range": "bytes=702-1168"
+          "checksum": "sha1-ueo4UWPln3T3+XsY1t4rr5k77uc=",
+          "range": "bytes=705-1170"
         },
         "data": {
-          "checksum": "sha256-spqeE2+7COXu1WG8x4d9FmdIbE8RIUhbmguf5hqeKrc=",
-          "range": "bytes=1169-373950"
+          "checksum": "sha256-rXBoHBmHqzaLSdLi2nk0lnDGLbhjJ1JXwMkEi73DQW0=",
+          "range": "bytes=1171-373951"
         },
         "name": "posix-libc-utils",
         "signature": {
-          "checksum": "sha1-YxNF3yqWELLDOGK+TjEz01Pt1yI=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-hdlD8UIp3IX9ED5IOOvsVs4Zb0M=",
+          "range": "bytes=0-704"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/posix-libc-utils-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/posix-libc-utils-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",
@@ -1595,60 +1595,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q11rWEg82oHyjUZI+8zzUmTJ1D/74=",
+        "checksum": "Q1UmcDqeuODUV8+OpvLzUyx0yI8xc=",
         "control": {
-          "checksum": "sha1-1rWEg82oHyjUZI+8zzUmTJ1D/74=",
-          "range": "bytes=703-1150"
+          "checksum": "sha1-UmcDqeuODUV8+OpvLzUyx0yI8xc=",
+          "range": "bytes=698-1144"
         },
         "data": {
-          "checksum": "sha256-ZPmuc49YzWCEyVdde2xydAUGVTJWbQ/x4bE0y3KvUi8=",
-          "range": "bytes=1151-186189747"
+          "checksum": "sha256-b4esuCNDnZjnPFuKsFFEVf4YtzS4090D1TxWga/nvWs=",
+          "range": "bytes=1145-186251251"
         },
         "name": "prometheus-2.51",
         "signature": {
-          "checksum": "sha1-id0YIveOCeBApldSkhNpoF5uUZQ=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-Dd6iX7TS/jcSD3fMqnagSEvize0=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/prometheus-2.51-2.51.2-r0.apk",
-        "version": "2.51.2-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/prometheus-2.51-2.51.2-r1.apk",
+        "version": "2.51.2-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Cvy3ADS3PdGaFFwROjHVPlWH/gk=",
+        "checksum": "Q1d50lhC89U1NMDfOR59tXcSxwhoI=",
         "control": {
-          "checksum": "sha1-Cvy3ADS3PdGaFFwROjHVPlWH/gk=",
-          "range": "bytes=697-1062"
+          "checksum": "sha1-d50lhC89U1NMDfOR59tXcSxwhoI=",
+          "range": "bytes=703-1074"
         },
         "data": {
-          "checksum": "sha256-3a5i42ZWgxXyV/+UFB7Ns6sdHRwMX8R7yz/hGBHTKpc=",
-          "range": "bytes=1063-57256559"
+          "checksum": "sha256-1hO2vJ48CDakvu2qdsvRm+VFmtEaxx7ECLIhmzn1U+A=",
+          "range": "bytes=1075-57320339"
         },
         "name": "prometheus-alertmanager",
         "signature": {
-          "checksum": "sha1-k1KFRC9YGc/kuXxVooWR37YuhZ4=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-cSE9DHjKcHhrVZ202d3cVA6lnnA=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/prometheus-alertmanager-0.27.0-r3.apk",
-        "version": "0.27.0-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/prometheus-alertmanager-0.27.0-r4.apk",
+        "version": "0.27.0-r4"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1gvtJ8wLt/qj2KMwI37796EiCOws=",
+        "checksum": "Q1v9j36aKj/QDucW2TWthgb0lFN5c=",
         "control": {
-          "checksum": "sha1-gvtJ8wLt/qj2KMwI37796EiCOws=",
-          "range": "bytes=703-1080"
+          "checksum": "sha1-v9j36aKj/QDucW2TWthgb0lFN5c=",
+          "range": "bytes=703-1088"
         },
         "data": {
-          "checksum": "sha256-+ah0KYZAyas3blgs4qTtdc9KgZkmI1GADOkbxfr8aok=",
-          "range": "bytes=1081-13096940"
+          "checksum": "sha256-x/hkY8PBEFsAYRDrU7hhTRaL1lVe5dlPK5I7y8ayw7w=",
+          "range": "bytes=1089-13096952"
         },
         "name": "prometheus-postgres-exporter",
         "signature": {
-          "checksum": "sha1-46uaLZr9cEfwB5TzhvZwIPM+ej8=",
+          "checksum": "sha1-nMuUyXCQD2YI4Wm6TeBRrsiT7ds=",
           "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/prometheus-postgres-exporter-0.15.0-r6.apk",
-        "version": "0.15.0-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/prometheus-postgres-exporter-0.15.0-r7.apk",
+        "version": "0.15.0-r7"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/server.yaml
+++ b/wolfi-images/server.yaml
@@ -86,3 +86,5 @@ paths:
   - path: /sg_grafana_additional_dashboards
     type: directory
     permissions: 0o755
+
+# MANUAL REBUILD: 

--- a/wolfi-images/sourcegraph-base.lock.json
+++ b/wolfi-images/sourcegraph-base.lock.json
@@ -1,5 +1,5 @@
 {
-  "configHash": "9d7eed0a4cb2859be4a618d6d3361d84100e198fb3ac996c193c161d0b98313c",
+  "configHash": "b05193cc3a4f40e29d13c03eecce717c88fd570a8d0acc5ad920dff4d0ceaa31",
   "contents": {
     "keyring": [
       {

--- a/wolfi-images/sourcegraph-base.lock.json
+++ b/wolfi-images/sourcegraph-base.lock.json
@@ -52,60 +52,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1DyZ5L88J9MmDMYgbsywXdJdnw04=",
+        "checksum": "Q1uuAznXPkDNBMP/eILVO7UDGj1pU=",
         "control": {
-          "checksum": "sha1-DyZ5L88J9MmDMYgbsywXdJdnw04=",
-          "range": "bytes=699-1107"
+          "checksum": "sha1-uuAznXPkDNBMP/eILVO7UDGj1pU=",
+          "range": "bytes=702-1112"
         },
         "data": {
-          "checksum": "sha256-3xIIHf7osttdb7FoJTbfURbo4YuaB3knm5Kd3B5p+dI=",
-          "range": "bytes=1108-267814"
+          "checksum": "sha256-Ath31YTTsiakoEktGl5txvNQpnr/grvFQHlmXa5E7fI=",
+          "range": "bytes=1113-267815"
         },
         "name": "ld-linux",
         "signature": {
-          "checksum": "sha1-lxFSv68mPMJwO+PthEdXfKHuLWk=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-oh4vr00LXL4ArbAOR9LS1VzzfYc=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1UvgNLBt9CKIOp7pN3EI0pgBlzXo=",
+        "checksum": "Q1TXuyiDJBsTNDwvPq7HFxaeBQ33w=",
         "control": {
-          "checksum": "sha1-UvgNLBt9CKIOp7pN3EI0pgBlzXo=",
-          "range": "bytes=696-1051"
+          "checksum": "sha1-TXuyiDJBsTNDwvPq7HFxaeBQ33w=",
+          "range": "bytes=703-1059"
         },
         "data": {
-          "checksum": "sha256-NaRRsIIgVTbofef14Qsnf+rysYDJXOXPKgfj6bAhP94=",
-          "range": "bytes=1052-408274"
+          "checksum": "sha256-3s2Fygt+ZuHj/StxP7YffswmhHE7EJ4TxZ7EWlRQ4NA=",
+          "range": "bytes=1060-408275"
         },
         "name": "glibc-locale-posix",
         "signature": {
-          "checksum": "sha1-Iug0EjR+0K/k6fl0wi0prJHKBBo=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-FbeSNtuEgFmzNamDx5Dj1LGVgsQ=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1PnEJFSqU/wFNmbOLGHbgqFwS/yU=",
+        "checksum": "Q1SD8az8RMNr5tnb8/mPZdR+A6V5k=",
         "control": {
-          "checksum": "sha1-PnEJFSqU/wFNmbOLGHbgqFwS/yU=",
-          "range": "bytes=695-1321"
+          "checksum": "sha1-SD8az8RMNr5tnb8/mPZdR+A6V5k=",
+          "range": "bytes=701-1330"
         },
         "data": {
-          "checksum": "sha256-D6XvEcPrHmlsiI6HbbE51xmiTM1c5y6DV4MrHrCVuNo=",
-          "range": "bytes=1322-5861480"
+          "checksum": "sha256-QvhWs/fGBaX5calu0uES9fcTMx6+R1xKZHdxkxxSxsg=",
+          "range": "bytes=1331-5861481"
         },
         "name": "glibc",
         "signature": {
-          "checksum": "sha1-ypPC9SJASGEATsvLoDuEEUobhAs=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-v4LRB2eP5VLe623v8sJ3f4wDNFM=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",
@@ -565,22 +565,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1szp02tM1WkRUzhOGBkFjl6dA5pQ=",
+        "checksum": "Q1drCieAMJpJBP1KWvJk6Vhq7Zj20=",
         "control": {
-          "checksum": "sha1-szp02tM1WkRUzhOGBkFjl6dA5pQ=",
-          "range": "bytes=698-1101"
+          "checksum": "sha1-drCieAMJpJBP1KWvJk6Vhq7Zj20=",
+          "range": "bytes=701-1108"
         },
         "data": {
-          "checksum": "sha256-hrc/6rvJR5nb97Gu5Hep8419+WyFmd7maV78ni7zQAc=",
-          "range": "bytes=1102-21604"
+          "checksum": "sha256-LcGaT+nLHN7YtUab5sY0EoXErbOj/S58FXtf1JVxWbM=",
+          "range": "bytes=1109-21605"
         },
         "name": "libcrypt1",
         "signature": {
-          "checksum": "sha1-Jk/8hSLRyZ7scdep1XfbpKABePY=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-wwLYQc1joetP6IOipSVSCQsZHsM=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/sourcegraph-base.yaml
+++ b/wolfi-images/sourcegraph-base.yaml
@@ -39,3 +39,5 @@ paths:
     uid: 100
     gid: 101
     permissions: 0o755
+
+# MANUAL REBUILD: 

--- a/wolfi-images/sourcegraph-dev.lock.json
+++ b/wolfi-images/sourcegraph-dev.lock.json
@@ -1,5 +1,5 @@
 {
-  "configHash": "5c247a2c3db7257497f7309ad4f7a6b5b96e0cc0b195bc8c7f17ffe49d0cb294",
+  "configHash": "8e05050a7b629148d53f4e204d1d88faeed605a56c44ad4f531bfeeb890f2368",
   "contents": {
     "keyring": [
       {

--- a/wolfi-images/sourcegraph-dev.lock.json
+++ b/wolfi-images/sourcegraph-dev.lock.json
@@ -52,60 +52,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1DyZ5L88J9MmDMYgbsywXdJdnw04=",
+        "checksum": "Q1uuAznXPkDNBMP/eILVO7UDGj1pU=",
         "control": {
-          "checksum": "sha1-DyZ5L88J9MmDMYgbsywXdJdnw04=",
-          "range": "bytes=699-1107"
+          "checksum": "sha1-uuAznXPkDNBMP/eILVO7UDGj1pU=",
+          "range": "bytes=702-1112"
         },
         "data": {
-          "checksum": "sha256-3xIIHf7osttdb7FoJTbfURbo4YuaB3knm5Kd3B5p+dI=",
-          "range": "bytes=1108-267814"
+          "checksum": "sha256-Ath31YTTsiakoEktGl5txvNQpnr/grvFQHlmXa5E7fI=",
+          "range": "bytes=1113-267815"
         },
         "name": "ld-linux",
         "signature": {
-          "checksum": "sha1-lxFSv68mPMJwO+PthEdXfKHuLWk=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-oh4vr00LXL4ArbAOR9LS1VzzfYc=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1UvgNLBt9CKIOp7pN3EI0pgBlzXo=",
+        "checksum": "Q1TXuyiDJBsTNDwvPq7HFxaeBQ33w=",
         "control": {
-          "checksum": "sha1-UvgNLBt9CKIOp7pN3EI0pgBlzXo=",
-          "range": "bytes=696-1051"
+          "checksum": "sha1-TXuyiDJBsTNDwvPq7HFxaeBQ33w=",
+          "range": "bytes=703-1059"
         },
         "data": {
-          "checksum": "sha256-NaRRsIIgVTbofef14Qsnf+rysYDJXOXPKgfj6bAhP94=",
-          "range": "bytes=1052-408274"
+          "checksum": "sha256-3s2Fygt+ZuHj/StxP7YffswmhHE7EJ4TxZ7EWlRQ4NA=",
+          "range": "bytes=1060-408275"
         },
         "name": "glibc-locale-posix",
         "signature": {
-          "checksum": "sha1-Iug0EjR+0K/k6fl0wi0prJHKBBo=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-FbeSNtuEgFmzNamDx5Dj1LGVgsQ=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1PnEJFSqU/wFNmbOLGHbgqFwS/yU=",
+        "checksum": "Q1SD8az8RMNr5tnb8/mPZdR+A6V5k=",
         "control": {
-          "checksum": "sha1-PnEJFSqU/wFNmbOLGHbgqFwS/yU=",
-          "range": "bytes=695-1321"
+          "checksum": "sha1-SD8az8RMNr5tnb8/mPZdR+A6V5k=",
+          "range": "bytes=701-1330"
         },
         "data": {
-          "checksum": "sha256-D6XvEcPrHmlsiI6HbbE51xmiTM1c5y6DV4MrHrCVuNo=",
-          "range": "bytes=1322-5861480"
+          "checksum": "sha256-QvhWs/fGBaX5calu0uES9fcTMx6+R1xKZHdxkxxSxsg=",
+          "range": "bytes=1331-5861481"
         },
         "name": "glibc",
         "signature": {
-          "checksum": "sha1-ypPC9SJASGEATsvLoDuEEUobhAs=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-v4LRB2eP5VLe623v8sJ3f4wDNFM=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",
@@ -584,22 +584,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1szp02tM1WkRUzhOGBkFjl6dA5pQ=",
+        "checksum": "Q1drCieAMJpJBP1KWvJk6Vhq7Zj20=",
         "control": {
-          "checksum": "sha1-szp02tM1WkRUzhOGBkFjl6dA5pQ=",
-          "range": "bytes=698-1101"
+          "checksum": "sha1-drCieAMJpJBP1KWvJk6Vhq7Zj20=",
+          "range": "bytes=701-1108"
         },
         "data": {
-          "checksum": "sha256-hrc/6rvJR5nb97Gu5Hep8419+WyFmd7maV78ni7zQAc=",
-          "range": "bytes=1102-21604"
+          "checksum": "sha256-LcGaT+nLHN7YtUab5sY0EoXErbOj/S58FXtf1JVxWbM=",
+          "range": "bytes=1109-21605"
         },
         "name": "libcrypt1",
         "signature": {
-          "checksum": "sha1-Jk/8hSLRyZ7scdep1XfbpKABePY=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-wwLYQc1joetP6IOipSVSCQsZHsM=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/sourcegraph-dev.yaml
+++ b/wolfi-images/sourcegraph-dev.yaml
@@ -8,3 +8,5 @@ contents:
 
     ## Dev-specific tools
     - apk-tools
+
+# MANUAL REBUILD: 

--- a/wolfi-images/sourcegraph-template.lock.json
+++ b/wolfi-images/sourcegraph-template.lock.json
@@ -1,5 +1,5 @@
 {
-  "configHash": "d6728ac5dafc7b8372e5d7874dae1e413e9299fdc78b52038bb739af7e0c3093",
+  "configHash": "1e76da86ed6603b78bea43bf58437a0b5908409ed031c05ac9de4471400115aa",
   "contents": {
     "keyring": [
       {

--- a/wolfi-images/sourcegraph-template.lock.json
+++ b/wolfi-images/sourcegraph-template.lock.json
@@ -52,60 +52,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1DyZ5L88J9MmDMYgbsywXdJdnw04=",
+        "checksum": "Q1uuAznXPkDNBMP/eILVO7UDGj1pU=",
         "control": {
-          "checksum": "sha1-DyZ5L88J9MmDMYgbsywXdJdnw04=",
-          "range": "bytes=699-1107"
+          "checksum": "sha1-uuAznXPkDNBMP/eILVO7UDGj1pU=",
+          "range": "bytes=702-1112"
         },
         "data": {
-          "checksum": "sha256-3xIIHf7osttdb7FoJTbfURbo4YuaB3knm5Kd3B5p+dI=",
-          "range": "bytes=1108-267814"
+          "checksum": "sha256-Ath31YTTsiakoEktGl5txvNQpnr/grvFQHlmXa5E7fI=",
+          "range": "bytes=1113-267815"
         },
         "name": "ld-linux",
         "signature": {
-          "checksum": "sha1-lxFSv68mPMJwO+PthEdXfKHuLWk=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-oh4vr00LXL4ArbAOR9LS1VzzfYc=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1UvgNLBt9CKIOp7pN3EI0pgBlzXo=",
+        "checksum": "Q1TXuyiDJBsTNDwvPq7HFxaeBQ33w=",
         "control": {
-          "checksum": "sha1-UvgNLBt9CKIOp7pN3EI0pgBlzXo=",
-          "range": "bytes=696-1051"
+          "checksum": "sha1-TXuyiDJBsTNDwvPq7HFxaeBQ33w=",
+          "range": "bytes=703-1059"
         },
         "data": {
-          "checksum": "sha256-NaRRsIIgVTbofef14Qsnf+rysYDJXOXPKgfj6bAhP94=",
-          "range": "bytes=1052-408274"
+          "checksum": "sha256-3s2Fygt+ZuHj/StxP7YffswmhHE7EJ4TxZ7EWlRQ4NA=",
+          "range": "bytes=1060-408275"
         },
         "name": "glibc-locale-posix",
         "signature": {
-          "checksum": "sha1-Iug0EjR+0K/k6fl0wi0prJHKBBo=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-FbeSNtuEgFmzNamDx5Dj1LGVgsQ=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1PnEJFSqU/wFNmbOLGHbgqFwS/yU=",
+        "checksum": "Q1SD8az8RMNr5tnb8/mPZdR+A6V5k=",
         "control": {
-          "checksum": "sha1-PnEJFSqU/wFNmbOLGHbgqFwS/yU=",
-          "range": "bytes=695-1321"
+          "checksum": "sha1-SD8az8RMNr5tnb8/mPZdR+A6V5k=",
+          "range": "bytes=701-1330"
         },
         "data": {
-          "checksum": "sha256-D6XvEcPrHmlsiI6HbbE51xmiTM1c5y6DV4MrHrCVuNo=",
-          "range": "bytes=1322-5861480"
+          "checksum": "sha256-QvhWs/fGBaX5calu0uES9fcTMx6+R1xKZHdxkxxSxsg=",
+          "range": "bytes=1331-5861481"
         },
         "name": "glibc",
         "signature": {
-          "checksum": "sha1-ypPC9SJASGEATsvLoDuEEUobhAs=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-v4LRB2eP5VLe623v8sJ3f4wDNFM=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",
@@ -565,22 +565,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1szp02tM1WkRUzhOGBkFjl6dA5pQ=",
+        "checksum": "Q1drCieAMJpJBP1KWvJk6Vhq7Zj20=",
         "control": {
-          "checksum": "sha1-szp02tM1WkRUzhOGBkFjl6dA5pQ=",
-          "range": "bytes=698-1101"
+          "checksum": "sha1-drCieAMJpJBP1KWvJk6Vhq7Zj20=",
+          "range": "bytes=701-1108"
         },
         "data": {
-          "checksum": "sha256-hrc/6rvJR5nb97Gu5Hep8419+WyFmd7maV78ni7zQAc=",
-          "range": "bytes=1102-21604"
+          "checksum": "sha256-LcGaT+nLHN7YtUab5sY0EoXErbOj/S58FXtf1JVxWbM=",
+          "range": "bytes=1109-21605"
         },
         "name": "libcrypt1",
         "signature": {
-          "checksum": "sha1-Jk/8hSLRyZ7scdep1XfbpKABePY=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-wwLYQc1joetP6IOipSVSCQsZHsM=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/sourcegraph-template.yaml
+++ b/wolfi-images/sourcegraph-template.yaml
@@ -44,3 +44,5 @@ annotations:
   org.opencontainers.image.url: https://sourcegraph.com/
   org.opencontainers.image.source: https://github.com/sourcegraph/sourcegraph/
   org.opencontainers.image.documentation: https://sourcegraph.com/docs/
+
+# MANUAL REBUILD: 

--- a/wolfi-images/symbols.lock.json
+++ b/wolfi-images/symbols.lock.json
@@ -1,5 +1,5 @@
 {
-  "configHash": "3849e9853ac10946ff0609634e50b8b9d60b7db630c446e7964428652a09f6f6",
+  "configHash": "81d25c03422c88e5a2799d62a63deb6e3d5da4eda97bcabfe44e8cd122849ee4",
   "contents": {
     "keyring": [
       {

--- a/wolfi-images/symbols.lock.json
+++ b/wolfi-images/symbols.lock.json
@@ -52,60 +52,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1DyZ5L88J9MmDMYgbsywXdJdnw04=",
+        "checksum": "Q1uuAznXPkDNBMP/eILVO7UDGj1pU=",
         "control": {
-          "checksum": "sha1-DyZ5L88J9MmDMYgbsywXdJdnw04=",
-          "range": "bytes=699-1107"
+          "checksum": "sha1-uuAznXPkDNBMP/eILVO7UDGj1pU=",
+          "range": "bytes=702-1112"
         },
         "data": {
-          "checksum": "sha256-3xIIHf7osttdb7FoJTbfURbo4YuaB3knm5Kd3B5p+dI=",
-          "range": "bytes=1108-267814"
+          "checksum": "sha256-Ath31YTTsiakoEktGl5txvNQpnr/grvFQHlmXa5E7fI=",
+          "range": "bytes=1113-267815"
         },
         "name": "ld-linux",
         "signature": {
-          "checksum": "sha1-lxFSv68mPMJwO+PthEdXfKHuLWk=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-oh4vr00LXL4ArbAOR9LS1VzzfYc=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1UvgNLBt9CKIOp7pN3EI0pgBlzXo=",
+        "checksum": "Q1TXuyiDJBsTNDwvPq7HFxaeBQ33w=",
         "control": {
-          "checksum": "sha1-UvgNLBt9CKIOp7pN3EI0pgBlzXo=",
-          "range": "bytes=696-1051"
+          "checksum": "sha1-TXuyiDJBsTNDwvPq7HFxaeBQ33w=",
+          "range": "bytes=703-1059"
         },
         "data": {
-          "checksum": "sha256-NaRRsIIgVTbofef14Qsnf+rysYDJXOXPKgfj6bAhP94=",
-          "range": "bytes=1052-408274"
+          "checksum": "sha256-3s2Fygt+ZuHj/StxP7YffswmhHE7EJ4TxZ7EWlRQ4NA=",
+          "range": "bytes=1060-408275"
         },
         "name": "glibc-locale-posix",
         "signature": {
-          "checksum": "sha1-Iug0EjR+0K/k6fl0wi0prJHKBBo=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-FbeSNtuEgFmzNamDx5Dj1LGVgsQ=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1PnEJFSqU/wFNmbOLGHbgqFwS/yU=",
+        "checksum": "Q1SD8az8RMNr5tnb8/mPZdR+A6V5k=",
         "control": {
-          "checksum": "sha1-PnEJFSqU/wFNmbOLGHbgqFwS/yU=",
-          "range": "bytes=695-1321"
+          "checksum": "sha1-SD8az8RMNr5tnb8/mPZdR+A6V5k=",
+          "range": "bytes=701-1330"
         },
         "data": {
-          "checksum": "sha256-D6XvEcPrHmlsiI6HbbE51xmiTM1c5y6DV4MrHrCVuNo=",
-          "range": "bytes=1322-5861480"
+          "checksum": "sha256-QvhWs/fGBaX5calu0uES9fcTMx6+R1xKZHdxkxxSxsg=",
+          "range": "bytes=1331-5861481"
         },
         "name": "glibc",
         "signature": {
-          "checksum": "sha1-ypPC9SJASGEATsvLoDuEEUobhAs=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-v4LRB2eP5VLe623v8sJ3f4wDNFM=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",
@@ -565,22 +565,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1szp02tM1WkRUzhOGBkFjl6dA5pQ=",
+        "checksum": "Q1drCieAMJpJBP1KWvJk6Vhq7Zj20=",
         "control": {
-          "checksum": "sha1-szp02tM1WkRUzhOGBkFjl6dA5pQ=",
-          "range": "bytes=698-1101"
+          "checksum": "sha1-drCieAMJpJBP1KWvJk6Vhq7Zj20=",
+          "range": "bytes=701-1108"
         },
         "data": {
-          "checksum": "sha256-hrc/6rvJR5nb97Gu5Hep8419+WyFmd7maV78ni7zQAc=",
-          "range": "bytes=1102-21604"
+          "checksum": "sha256-LcGaT+nLHN7YtUab5sY0EoXErbOj/S58FXtf1JVxWbM=",
+          "range": "bytes=1109-21605"
         },
         "name": "libcrypt1",
         "signature": {
-          "checksum": "sha1-Jk/8hSLRyZ7scdep1XfbpKABePY=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-wwLYQc1joetP6IOipSVSCQsZHsM=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/symbols.yaml
+++ b/wolfi-images/symbols.yaml
@@ -18,3 +18,5 @@ paths:
     uid: 100
     gid: 101
     permissions: 0o755
+
+# MANUAL REBUILD: 

--- a/wolfi-images/syntax-highlighter.lock.json
+++ b/wolfi-images/syntax-highlighter.lock.json
@@ -1,5 +1,5 @@
 {
-  "configHash": "ae75e81be02bef20c8ccfe29b35982cb17113f359874f61a8c36ab991e98842c",
+  "configHash": "e19f24b50f7a3aadc792e0c9c546bb17bba4c1b985ebf1c21f0b9832e1f6fec8",
   "contents": {
     "keyring": [
       {

--- a/wolfi-images/syntax-highlighter.lock.json
+++ b/wolfi-images/syntax-highlighter.lock.json
@@ -52,60 +52,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1DyZ5L88J9MmDMYgbsywXdJdnw04=",
+        "checksum": "Q1uuAznXPkDNBMP/eILVO7UDGj1pU=",
         "control": {
-          "checksum": "sha1-DyZ5L88J9MmDMYgbsywXdJdnw04=",
-          "range": "bytes=699-1107"
+          "checksum": "sha1-uuAznXPkDNBMP/eILVO7UDGj1pU=",
+          "range": "bytes=702-1112"
         },
         "data": {
-          "checksum": "sha256-3xIIHf7osttdb7FoJTbfURbo4YuaB3knm5Kd3B5p+dI=",
-          "range": "bytes=1108-267814"
+          "checksum": "sha256-Ath31YTTsiakoEktGl5txvNQpnr/grvFQHlmXa5E7fI=",
+          "range": "bytes=1113-267815"
         },
         "name": "ld-linux",
         "signature": {
-          "checksum": "sha1-lxFSv68mPMJwO+PthEdXfKHuLWk=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-oh4vr00LXL4ArbAOR9LS1VzzfYc=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1UvgNLBt9CKIOp7pN3EI0pgBlzXo=",
+        "checksum": "Q1TXuyiDJBsTNDwvPq7HFxaeBQ33w=",
         "control": {
-          "checksum": "sha1-UvgNLBt9CKIOp7pN3EI0pgBlzXo=",
-          "range": "bytes=696-1051"
+          "checksum": "sha1-TXuyiDJBsTNDwvPq7HFxaeBQ33w=",
+          "range": "bytes=703-1059"
         },
         "data": {
-          "checksum": "sha256-NaRRsIIgVTbofef14Qsnf+rysYDJXOXPKgfj6bAhP94=",
-          "range": "bytes=1052-408274"
+          "checksum": "sha256-3s2Fygt+ZuHj/StxP7YffswmhHE7EJ4TxZ7EWlRQ4NA=",
+          "range": "bytes=1060-408275"
         },
         "name": "glibc-locale-posix",
         "signature": {
-          "checksum": "sha1-Iug0EjR+0K/k6fl0wi0prJHKBBo=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-FbeSNtuEgFmzNamDx5Dj1LGVgsQ=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1PnEJFSqU/wFNmbOLGHbgqFwS/yU=",
+        "checksum": "Q1SD8az8RMNr5tnb8/mPZdR+A6V5k=",
         "control": {
-          "checksum": "sha1-PnEJFSqU/wFNmbOLGHbgqFwS/yU=",
-          "range": "bytes=695-1321"
+          "checksum": "sha1-SD8az8RMNr5tnb8/mPZdR+A6V5k=",
+          "range": "bytes=701-1330"
         },
         "data": {
-          "checksum": "sha256-D6XvEcPrHmlsiI6HbbE51xmiTM1c5y6DV4MrHrCVuNo=",
-          "range": "bytes=1322-5861480"
+          "checksum": "sha256-QvhWs/fGBaX5calu0uES9fcTMx6+R1xKZHdxkxxSxsg=",
+          "range": "bytes=1331-5861481"
         },
         "name": "glibc",
         "signature": {
-          "checksum": "sha1-ypPC9SJASGEATsvLoDuEEUobhAs=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-v4LRB2eP5VLe623v8sJ3f4wDNFM=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",
@@ -565,22 +565,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1szp02tM1WkRUzhOGBkFjl6dA5pQ=",
+        "checksum": "Q1drCieAMJpJBP1KWvJk6Vhq7Zj20=",
         "control": {
-          "checksum": "sha1-szp02tM1WkRUzhOGBkFjl6dA5pQ=",
-          "range": "bytes=698-1101"
+          "checksum": "sha1-drCieAMJpJBP1KWvJk6Vhq7Zj20=",
+          "range": "bytes=701-1108"
         },
         "data": {
-          "checksum": "sha256-hrc/6rvJR5nb97Gu5Hep8419+WyFmd7maV78ni7zQAc=",
-          "range": "bytes=1102-21604"
+          "checksum": "sha256-LcGaT+nLHN7YtUab5sY0EoXErbOj/S58FXtf1JVxWbM=",
+          "range": "bytes=1109-21605"
         },
         "name": "libcrypt1",
         "signature": {
-          "checksum": "sha1-Jk/8hSLRyZ7scdep1XfbpKABePY=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-wwLYQc1joetP6IOipSVSCQsZHsM=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r1.apk",
-        "version": "2.39-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r2.apk",
+        "version": "2.39-r2"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/syntax-highlighter.yaml
+++ b/wolfi-images/syntax-highlighter.yaml
@@ -9,3 +9,5 @@ contents:
     ## syntax-highlighter packages
     - libstdc++
     - http-server-stabilizer@sourcegraph
+
+# MANUAL REBUILD: 


### PR DESCRIPTION
We've identified an issue in gitserver caused by a regression in libcurl that causes some `git fetch` operations to fail. We are temporarily resolving this issue by downgrading `libcurl` to from version `8.7.0` -> `8.6.0` - a full fix should arrive in git 2.45.

We recently switched from building containers using base images to using rules_apko - but the old release branch still uses the old base image method. This means that we can't simply backport a change, as the old method relied on building images in CI on the `main` branch.

To get around this we can:

* Temporarily merge this PR, which re-enables building base images in CI
* Once the images are built and uploaded to Docker Hub, update the base image hashes on the release branch
* Revert this PR

[Additional context from Slack](https://sourcegraph.slack.com/archives/C02E4HE42BX/p1713775531525999)

## Test plan

- CI

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
