### PR TITLE
Update gitserver image to pull in libcurl fix

### DIFF
--- a/dev/oci_deps.bzl
+++ b/dev/oci_deps.bzl
@@ -65,8 +65,8 @@ def oci_deps():
 
     oci_pull(
         name = "wolfi_gitserver_base",
-        digest = "sha256:a8aebb67aeb50423804388219657029c2fafb0efdefa3907d36a0fba580a7619",
-        image = "index.docker.io/sourcegraph/wolfi-gitserver-base",
+        digest = "sha256:5bd36c10277c17a23e51f48e26193a21df05986d26150d1d1841a2e418ca7125",
+        image = "us.gcr.io/sourcegraph-dev/wolfi-gitserver-base",
     )
 
     oci_pull(


### PR DESCRIPTION
This PR updates the gitserver base image - it downgrades curl to `8.6.0` due to a regression in curl `8.7.0` that affects  `git fetch`. As a side effect, a number of other packages are also upgraded but I don't foresee this being a problem assuming it passes all release tests.

[Context from Slack](https://sourcegraph.slack.com/archives/C02E4HE42BX/p1713775531525999)

Image hash taken from https://buildkite.com/sourcegraph/sourcegraph/builds/270158. Updated image url from dockerhub to us.gcr.io as we no longer push to Dockerhub.

Running affected `git fetch` against broken `sourcegraph/gitserver:5.3.9104` image:

```
Initialized empty Git repository in /data/repos/
error: RPC failed; HTTP 400 curl 22 The requested URL returned error: 400
fatal: unable to write request to remote: Broken pipe
```

Running against this base image:

```
Initialized empty Git repository in /data/repos/
remote: Enumerating objects: 2378395, done.
remote: Counting objects: 100% (8632/8632), done.
remote: Compressing objects: 100% (4701/4701), done.
Receiving objects:  25% (594599/2378395), 502.08 MiB | 31.11 MiB/s
[...]
```


## Test plan

- Tested image against problematic git command
- CI

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
