### PR TITLE
Svelte [blob page]: Fix open in editor icon position

### DIFF
--- a/client/web-sveltekit/src/lib/repo/FileHeader.svelte
+++ b/client/web-sveltekit/src/lib/repo/FileHeader.svelte
@@ -175,7 +175,7 @@
 
         display: flex;
         gap: 1rem;
-        align-items: baseline;
+        align-items: center;
 
         // With overflow:visible the actions won't shrink past their content size,
         // and this allows us to measure the space needed to show actions fully.

--- a/client/web-sveltekit/src/lib/repo/open-in-editor/OpenInEditor.svelte
+++ b/client/web-sveltekit/src/lib/repo/open-in-editor/OpenInEditor.svelte
@@ -54,6 +54,10 @@
 
 <style lang="scss">
     a {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 0.25rem;
         color: var(--body-color);
         text-decoration: none;
         white-space: nowrap;


### PR DESCRIPTION
Small fix for open in IDE icon position 

| Before | After |
| ----- | ------ |
| <img width="379" alt="Screenshot 2024-04-22 at 18 06 54" src="https://github.com/sourcegraph/sourcegraph/assets/18492575/3afa55ca-6571-481b-83f1-efb88a1763ef">  |  <img width="390" alt="Screenshot 2024-04-22 at 18 06 31" src="https://github.com/sourcegraph/sourcegraph/assets/18492575/8af76755-bc4f-45f3-899d-6eec59264e4a"> |
| <img width="226" alt="Screenshot 2024-04-22 at 18 06 48" src="https://github.com/sourcegraph/sourcegraph/assets/18492575/b9f8eff1-c086-4c6d-affb-113630c743ca"> |  <img width="257" alt="Screenshot 2024-04-22 at 18 06 40" src="https://github.com/sourcegraph/sourcegraph/assets/18492575/ea8498a5-c54f-45c5-a9b6-966be525e7e7"> | 



## Test plan
- Check that the visually open in IDE icon looks correct 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
