### PR TITLE
Fixing cache methods to use the right method to retrieve key value stores

### DIFF
--- a/internal/rcache/rcache.go
+++ b/internal/rcache/rcache.go
@@ -134,14 +134,14 @@ func (r *Cache) GetInt64(key string) (int64, bool, error) {
 // IncrByInt64 increments the integer value of a key by the given amount.
 // It returns the new value after the increment.
 func (r *Cache) IncrByInt64(key string, value int64) (int64, error) {
-	newValue, err := kv().IncrByInt64(r.rkeyPrefix()+key, value)
+	newValue, err := r.kv().IncrByInt64(r.rkeyPrefix()+key, value)
 	if err != nil {
 		return newValue, errors.Newf("failed to execute redis command", "cmd", "INCRBY", "error", err)
 	}
 
 	if r.ttlSeconds > 0 {
 		// Optionally, set a TTL on the key if ttlSeconds is specified for the cache.
-		err = kv().Expire(r.rkeyPrefix()+key, r.ttlSeconds)
+		err = r.kv().Expire(r.rkeyPrefix()+key, r.ttlSeconds)
 		if err != nil {
 			return newValue, errors.Newf("failed to execute redis command", "cmd", "INCRBY", "error", err)
 		}
@@ -153,14 +153,14 @@ func (r *Cache) IncrByInt64(key string, value int64) (int64, error) {
 // DecrByInt64 increments the decrements value of a key by the given amount.
 // It returns the new value after the increment.
 func (r *Cache) DecrByInt64(key string, value int64) (int64, error) {
-	newValue, err := kv().DecrByInt64(r.rkeyPrefix()+key, value)
+	newValue, err := r.kv().DecrByInt64(r.rkeyPrefix()+key, value)
 	if err != nil {
 		return newValue, errors.Newf("failed to execute redis command", "cmd", "DECRBY", "error", err)
 	}
 
 	if r.ttlSeconds > 0 {
 		// Optionally, set a TTL on the key if ttlSeconds is specified for the cache.
-		err = kv().Expire(r.rkeyPrefix()+key, r.ttlSeconds)
+		err = r.kv().Expire(r.rkeyPrefix()+key, r.ttlSeconds)
 		if err != nil {
 			return newValue, errors.Newf("failed to execute redis command", "cmd", "DECRBY", "error", err)
 		}


### PR DESCRIPTION
Fixing some methods for cache selection of key values stores for redis. 


## Test plan
- I tested it on the instance

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
