### PR TITLE
Fix icons color

### DIFF
--- a/client/web-sveltekit/src/lib/Icon.svelte
+++ b/client/web-sveltekit/src/lib/Icon.svelte
@@ -27,14 +27,13 @@
 
 <style lang="scss">
     :root {
-        --icon-size: 1rem;
-        --icon-fill-color: inherit;
+        --icon-size: 1.5rem;
     }
 
     svg {
         width: var(--icon-size);
         height: var(--icon-size);
-        color: var(--icon-fill-color, inherit);
+        color: var(--icon-fill-color, var(--color, inherit));
         fill: currentColor;
     }
 </style>


### PR DESCRIPTION
Regression after https://github.com/sourcegraph/sourcegraph/pull/62012

In https://github.com/sourcegraph/sourcegraph/pull/62012 I changed Icon.svelte CSS variable API but didn't make a proper migration, so in this fix, I just bring back old variable support. 

## A few words about naming

So originally we have `--color` variable to set the color for `Icon.svelte` but this seemed a bit too generic so I wanted to rename it to `--icon-color` but we already have this variable as a design token (too bad, we should revisit our CSS color variables it looks a bit chaotic at the moment), eventually I ended up with `--icon-fill-color`, not ideal but doesn't overlap with other css variables.

## Test plan
- Check that icons have proper colors in different context (file tree extension icons, global nav icons color, etc.)

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
