### PR TITLE
Update changelog for patch release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,12 +37,15 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Added
 
+- Indexed-search now supports draining a replica of indexes to support zero-downtime reduction in cluster size. [#62005](https://github.com/sourcegraph/sourcegraph/pull/62005)
+
 ## Changed
 
 ## Fixed
 - Rust binaries are now built in release mode to avoid unnecessary debug checks. [#61740](https://github.com/sourcegraph/sourcegraph/pull/61740)
 - Fixed how scip-ctags reports errors to avoid failing search indexing on non-fatal errors. [#61712](https://github.com/sourcegraph/sourcegraph/pull/61712)
 - Fixed a bug in Enterprise Cody context for queries containing only stopwords. [#61848](https://github.com/sourcegraph/sourcegraph/pull/61848), [#62026](https://github.com/sourcegraph/sourcegraph/pull/62026)
+- Fixed the instance dropdown on the zoekt grafana dashboard. [#61836](https://github.com/sourcegraph/sourcegraph/pull/61836)
 
 ## 5.3.11625
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,9 @@ All notable changes to Sourcegraph are documented in this file.
 ## Changed
 
 ## Fixed
+- Rust binaries are now built in release mode to avoid unnecessary debug checks. [#61740](https://github.com/sourcegraph/sourcegraph/pull/61740)
+- Fixed how scip-ctags reports errors to avoid failing search indexing on non-fatal errors. [#61712](https://github.com/sourcegraph/sourcegraph/pull/61712)
+- Fixed a bug in Enterprise Cody context for queries containing only stopwords. [#61848](https://github.com/sourcegraph/sourcegraph/pull/61848), [#62026](https://github.com/sourcegraph/sourcegraph/pull/62026)
 
 ## 5.3.11625
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ All notable changes to Sourcegraph are documented in this file.
 ## Changed
 
 ## Fixed
+
 - Rust binaries are now built in release mode to avoid unnecessary debug checks. [#61740](https://github.com/sourcegraph/sourcegraph/pull/61740)
 - Fixed how scip-ctags reports errors to avoid failing search indexing on non-fatal errors. [#61712](https://github.com/sourcegraph/sourcegraph/pull/61712)
 - Fixed a bug in Enterprise Cody context for queries containing only stopwords. [#61848](https://github.com/sourcegraph/sourcegraph/pull/61848), [#62026](https://github.com/sourcegraph/sourcegraph/pull/62026)
@@ -52,11 +53,13 @@ All notable changes to Sourcegraph are documented in this file.
 ### Changed
 
 - Notices configured in the site config now allow for specifying a style or color. [#61338](https://github.com/sourcegraph/sourcegraph/pull/61338)
+- Reduce spamming error logs when canceling symbols indexing or canceling a syntax highlighting request. [#61880](https://github.com/sourcegraph/sourcegraph/pull/61880), [#61719](https://github.com/sourcegraph/sourcegraph/pull/61719), [#61732](https://github.com/sourcegraph/sourcegraph/pull/61732)
 
 ### Fixed
 
 - Fixed a bug where the `src batch preview` command could fail due to an incorrect file-not-found error. [#61984](https://github.com/sourcegraph/sourcegraph/pull/61984)
 - Fixed a bug where the Roles page in the Site Admin view was inaccessible. [#61738](https://github.com/sourcegraph/sourcegraph/pull/61738)
+- Fixed a panic in Cody Attribution in sourcegraph-frontend when reporting an error. [#60439](https://github.com/sourcegraph/sourcegraph/issues/60439)
 
 ## 5.3.9104
 


### PR DESCRIPTION
This PR adds some missing changelog entries for the April 22nd patch release.

## Test plan

Docs-only change