### PR TITLE
Simplify path mapping of p4-fusion package

### DIFF
--- a/wolfi-packages/p4-fusion-sg.yaml
+++ b/wolfi-packages/p4-fusion-sg.yaml
@@ -3,7 +3,7 @@
 package:
   name: p4-fusion-sg
   version: 1.13.2
-  epoch: 3
+  epoch: 4
   description: "A fast Perforce to Git conversion tool, Sourcegraph fork"
   target-architecture:
     - x86_64
@@ -83,7 +83,7 @@ pipeline:
   # Copy p4-fusion binary
   - runs: |
       mkdir -p ${{targets.destdir}}/usr/local/bin/
-      cp p4-fusion-src/build/p4-fusion/p4-fusion ${{targets.destdir}}/usr/local/bin/p4-fusion-binary
+      cp p4-fusion-src/build/p4-fusion/p4-fusion ${{targets.destdir}}/usr/local/bin/p4-fusion
 
 update:
   enabled: false # Our p4-fusion fork does not provide releases or tags

--- a/wolfi-packages/p4-fusion.yaml
+++ b/wolfi-packages/p4-fusion.yaml
@@ -3,7 +3,7 @@
 package:
   name: p4-fusion
   version: 1.12
-  epoch: 11
+  epoch: 12
   description: "A fast Perforce to Git conversion tool"
   target-architecture:
     - x86_64
@@ -83,7 +83,7 @@ pipeline:
   # Copy p4-fusion binary
   - runs: |
       mkdir -p ${{targets.destdir}}/usr/local/bin/
-      cp p4-fusion-src/build/p4-fusion/p4-fusion ${{targets.destdir}}/usr/local/bin/p4-fusion-binary
+      cp p4-fusion-src/build/p4-fusion/p4-fusion ${{targets.destdir}}/usr/local/bin/p4-fusion
 
 update:
   enabled: true


### PR DESCRIPTION
This PR is a precursor to a second PR that will drop the shell layer in between gitserver and p4-fusion. We will be able to track command outputs and resource requirements separately, so there should be no need for this additional layer of complexity that could potentially mess with process groups and exit code forwarding etc.

Test plan:

This just bumps the package and simplifies the path, a follow-up PR will make use of this new epoch.
