### PR TITLE
Forward LLM completion in a sequential model, concurrently with filtering.

### DIFF
--- a/internal/guardrails/attribution_filter2.go
+++ b/internal/guardrails/attribution_filter2.go
@@ -1,0 +1,80 @@
+package guardrails
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+
+	"github.com/sourcegraph/sourcegraph/internal/completions/types"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+// NewCompletionsFilter2 returns a fully initialized streaming filter.
+// This filter should be used for only a single code completions streaming
+// since it keeps internal state. Public methods are synchronized.
+func NewCompletionsFilter2(config CompletionsFilterConfig) (CompletionsFilter, error) {
+	if config.Sink == nil || config.Test == nil || config.AttributionError == nil {
+		return nil, errors.New("Attribution filtering misconfigured.")
+	}
+	return &attributionRunFilter{
+		config:                config,
+		closeOnSearchFinished: make(chan struct{}),
+	}, nil
+}
+
+// attributionRunFilter
+type attributionRunFilter struct {
+	config CompletionsFilterConfig
+	// Just to make sure we have run attribution once.
+	attributionSearch sync.Once
+	// Attribution search result, true = successful, false is any of {not run, pending, failed, error}.
+	attributionSucceeded atomic.Bool
+	// Channel that the attribution routine closes when attribution is finished.
+	closeOnSearchFinished chan struct{}
+	// Unsynchronized - only referred to from Send and WaitDone, which are executed in sequence.
+	last *types.CompletionResponse
+}
+
+func (d *attributionRunFilter) Send(ctx context.Context, r types.CompletionResponse) error {
+	if d.shortEnough(r) {
+		d.last = nil  // last seen completion was sent
+		return d.config.Sink(r)
+	}
+	d.attributionSearch.Do(func () { go d.runAttribution(ctx, r) })
+	if d.attributionSucceeded.Load() {
+		d.last = nil  // last seen completion was sent
+		return d.config.Sink(r)
+	}
+	d.last = &r  // last seen completion not sent
+	return nil
+}
+
+func (d *attributionRunFilter) WaitDone(ctx context.Context) error {
+	select {
+	case <-ctx.Done():
+		// Request cancelled, return.
+		return ctx.Err()
+	case <-d.closeOnSearchFinished:
+		// When search finishes successfully and last seen completion was not sent, send it now, and finish.
+		if d.attributionSucceeded.Load() && d.last != nil {
+			return d.config.Sink(*d.last)
+		}
+		return nil
+	}
+}
+
+func (d *attributionRunFilter) shortEnough(r types.CompletionResponse) bool {
+	return !NewThreshold().ShouldSearch(r.Completion)
+}
+
+func (d *attributionRunFilter) runAttribution(ctx context.Context, r types.CompletionResponse) {
+	defer close(d.closeOnSearchFinished)
+	canUse, err := d.config.Test(ctx, r.Completion)
+	if err != nil {
+		d.config.AttributionError(err)
+		return
+	}
+	if canUse {
+		d.attributionSucceeded.Store(true)
+	}
+}


### PR DESCRIPTION
Guardrails attribution is [panicking](https://sourcegraph.slack.com/archives/C05JDP433DL/p1713475382871579) the likely cause is a race between (a) attribution search (b) LLM responses being streamed back (c) request timeout and (d) sending back the last seen LLM response after search finishes.

This PR changes the implementation of an LLM filter to a simpler one - in hopes of making code _so simple there are obviously no bugs in it, as opposed to code so complex that there are no obvious bugs in it_ ([link](https://wiki.haskell.org/Hoare_Property)).

The way it works is that the handler interacts with the filter via `Send` and `WaitDone` calls:

- `Send` is invoked every time LLM streams back a completion prefix (which gets bigger and bigger)
- initially the filter forwards all completion prefixes back to the client,
- internally the filter fires an attribution search once prefix reaches 10 newline characters and pauses forwarding,
- an attribution search with the smallest 10-line-long prefix is fired async,
- when the search comes back, we carry on sending the LLM completions.

In practice that last part can happen in any order with:

- request being cancelled (and serving resources cleaned up)
- LLM finishing streaming response to the sourcegraph instance

One thing former implementation did was that it would memoize the last LLM completion that was not forwarded to the client. Then on the event of attribution search coming back with no results (no attribution = can serve completion) - it would _concurrently to the request serving_ respond back with that last memoized piece.

Proposed implementation makes sure forwarding completions is contained only in the execution stack of the handler (so only in context of `Send` and `WaitDone` calls). In case of successful attribution result - we forward the latest unsent prefix within `WaitDone` an not how it was done previously - synchronized, but concurrently. 

Hopefully this way we'll clearly capture request infra lifecycle and not attempt writing to a recycled writer.

## Test plan

- [ ] Existing unit tests
- [ ] Manual testing
