### PR TITLE
(sg/bug) check that sg overwrite file exists

### DIFF
--- a/dev/sg/main.go
+++ b/dev/sg/main.go
@@ -375,7 +375,7 @@ func watchConfig(ctx context.Context) (<-chan *sgconf.Config, error) {
 
 	// start file watcher on configuration files
 	paths := []string{configFile}
-	if !disableOverwrite {
+	if !disableOverwrite && exists(configOverwriteFile) {
 		paths = append(paths, configOverwriteFile)
 	}
 	updates, err := run.WatchPaths(ctx, paths)
@@ -412,4 +412,9 @@ func watchConfig(ctx context.Context) (<-chan *sgconf.Config, error) {
 	}()
 
 	return output, err
+}
+
+func exists(file string) bool {
+	_, err := os.Stat(file)
+	return !os.IsNotExist(err)
 }


### PR DESCRIPTION
As title. Instead of just assuming that sg.config.overwrite.yaml exists, check for it before watching.
## Test plan
Ran locally
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
