### PR TITLE
svelte: Show code intel popovers above global navigation

### DIFF
--- a/client/web-sveltekit/src/lib/navigation/GlobalHeader.svelte
+++ b/client/web-sveltekit/src/lib/navigation/GlobalHeader.svelte
@@ -111,9 +111,6 @@
         border-bottom: 1px solid var(--border-color-2);
         background-color: var(--color-bg-1);
 
-        // This ensures that all arbitrary content is rendered above
-        // other elements on the page.
-        z-index: 1;
         position: relative;
         height: 50px;
         min-width: 0;

--- a/client/web-sveltekit/src/routes/search/SearchResults.svelte
+++ b/client/web-sveltekit/src/routes/search/SearchResults.svelte
@@ -127,7 +127,9 @@
 </svelte:head>
 
 <GlobalHeaderPortal>
-    <SearchInput {queryState} size="compat" />
+    <div class="search-header">
+        <SearchInput {queryState} size="compat" />
+    </div>
 </GlobalHeaderPortal>
 
 <div class="search-results">
@@ -179,6 +181,13 @@
 </div>
 
 <style lang="scss">
+    .search-header {
+        width: 100%;
+        // This ensures that the search suggestions panel is displayed above the
+        // search results panel.
+        z-index: 1;
+    }
+
     .search-results {
         display: flex;
         flex: 1;


### PR DESCRIPTION
On the file page it's possible that a popover is extending outside the file view and "reaching" into the global header. Because the global header has z-index: 1 it's currently rendered above all other, partially covering the popover.

This commit solves this issue by removing the z-index from the global header and instead moves it where it's needed, namely rendering search input suggestions above search results.

| Before | After |
|------------|--------|
| ![2024-04-23_21-00](https://github.com/sourcegraph/sourcegraph/assets/179026/8bb426e3-17e9-4c58-bfc4-999df03266e0) | ![2024-04-23_21-01](https://github.com/sourcegraph/sourcegraph/assets/179026/3c1e4c33-d7aa-4dfa-80e5-b124bee9efdd) | 


## Test plan

Manually tested code intel popover.
Manually tested search input suggestions on search results page.