### PR TITLE
sg/msp: filter generated environments by category

### DIFF
--- a/dev/managedservicesplatform/cdktf.go
+++ b/dev/managedservicesplatform/cdktf.go
@@ -32,8 +32,9 @@ func (c CDKTF) OutputDir() string {
 // configured.
 func (c CDKTF) Synthesize() error {
 	// Forcibly shut down the JSII runtime post-Synth to make sure that we don't
-	// get bizarre side-effects from multiple apps being rendered.
-	defer jsiiruntime.Close()
+	// get bizarre side-effects from multiple apps being rendered. We use a panic
+	// catcher to discard useless panics from the library.
+	defer (&panics.Catcher{}).Try(jsiiruntime.Close)
 
 	// CDKTF is prone to panics for no good reason, so make a best-effort
 	// attempt to capture them.

--- a/lib/output/line.go
+++ b/lib/output/line.go
@@ -45,7 +45,7 @@ func Emoji(emoji string, s string) FancyLine {
 	return Line(emoji, StyleReset, s)
 }
 
-// Emoji creates a new FancyLine with an emoji prefix and style.
+// Emoji creates a new FancyLine with an emoji prefix and format string.
 func Emojif(emoji string, s string, a ...any) FancyLine {
 	return Linef(emoji, StyleReset, s, a...)
 }

--- a/lib/output/style.go
+++ b/lib/output/style.go
@@ -9,6 +9,14 @@ type Style struct{ code string }
 
 func (s Style) String() string { return s.code }
 
+// Line returns a FancyLine using this style as an alias for using output.Styledf(...)
+func (s Style) Line(format string) FancyLine { return Styled(s, format) }
+
+// Linef returns a FancyLine using this style as an alias for using output.Styledf(...)
+func (s Style) Linef(format string, args ...interface{}) FancyLine {
+	return Styledf(s, format, args...)
+}
+
 func CombineStyles(styles ...Style) Style {
 	sb := strings.Builder{}
 	for _, s := range styles {


### PR DESCRIPTION
Part of https://github.com/sourcegraph/managed-services/issues/599

See https://github.com/sourcegraph/managed-services/pull/1288 for how this mechanism will be used.

## Test plan

```sh
sg msp generate -all -category=test
```

![image](https://github.com/sourcegraph/sourcegraph/assets/23356519/d27c5df5-6d13-43fa-96c2-5523da24693a)