### PR TITLE
Svelte: invalidate all loaders when a query is submitted

### DIFF
--- a/client/web-sveltekit/src/lib/search/input/SearchInput.svelte
+++ b/client/web-sveltekit/src/lib/search/input/SearchInput.svelte
@@ -8,7 +8,7 @@
     import { EditorView } from '@codemirror/view'
     import { mdiCodeBrackets, mdiFormatLetterCase, mdiRegex } from '@mdi/js'
 
-    import { goto, invalidate } from '$app/navigation'
+    import { goto } from '$app/navigation'
     import {
         type Option,
         type Action,
@@ -180,10 +180,7 @@
     }
 
     async function submitQuery(state: QueryState): Promise<void> {
-        // This ensures that the same query can be resubmitted from the search input. Without
-        // this, SvelteKit will not re-run the loader because the URL hasn't changed.
-        await invalidate(`query:${state.query}--${state.caseSensitive}`)
-        void goto(getQueryURL(state))
+        void goto(getQueryURL(state), { invalidateAll: true })
     }
 
     async function handleSubmit(event: Event) {

--- a/client/web-sveltekit/src/routes/search/+page.ts
+++ b/client/web-sveltekit/src/routes/search/+page.ts
@@ -82,9 +82,8 @@ class NonCachingStreamManager {
 
 const streamManager = browser ? new CachingStreamManager() : new NonCachingStreamManager()
 
-export const load: PageLoad = ({ url, depends }) => {
+export const load: PageLoad = ({ url }) => {
     const hasQuery = url.searchParams.has('q')
-    const caseSensitiveURL = url.searchParams.get('case') === 'yes'
     const cachePolicy = getCachePolicyFromURL(url)
     const trace = url.searchParams.get('trace') ?? undefined
 
@@ -97,9 +96,6 @@ export const load: PageLoad = ({ url, depends }) => {
             caseSensitive,
             filters: queryFilters,
         } = parsedQuery
-        // Necessary for allowing to submit the same query again
-        // FIXME: This is not correct
-        depends(`query:${query}--${caseSensitiveURL}`)
 
         let searchContext = 'global'
         if (filterExists(query, FilterType.context)) {


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/61636

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
