### PR TITLE
svelte: Fix search result header alignment

### DIFF
--- a/client/web-sveltekit/src/routes/search/RepoRev.svelte
+++ b/client/web-sveltekit/src/routes/search/RepoRev.svelte
@@ -17,7 +17,7 @@
     }
 </script>
 
-<div class="root">
+<span class="root">
     <CodeHostIcon repository={repoName} />
     <!-- #key is needed here to recreate the link because use:highlightRanges changes the DOM -->
     {#key highlights}
@@ -28,11 +28,11 @@
             {/if}
         </a>
     {/key}
-</div>
+</span>
 
 <style lang="scss">
     .root {
-        display: flex;
+        display: inline-flex;
         align-items: center;
         gap: 0.375rem;
 


### PR DESCRIPTION
Currently the title for repository search results is split over multiple lines. That's because the `RepoRev` component is rendered as a block component.

This commit changes the root element to a `span` to emphasize that this component should be an inline component, and uses `inline-flex` instead of `flex`.

| Before | After |
|--------|--------|
| 
![2024-04-24_09-15](https://github.com/sourcegraph/sourcegraph/assets/179026/a597fb62-262d-4fdf-bbe7-27b295dcba2c)
 | ![2024-04-24_09-16](https://github.com/sourcegraph/sourcegraph/assets/179026/1752f07c-5ff6-4145-a722-4c3489cc4f06) | 


## Test plan

Manual inspection.