### PR TITLE
chore(rel): run requirements check for every command

### DIFF
--- a/dev/sg/internal/release/config.go
+++ b/dev/sg/internal/release/config.go
@@ -277,6 +277,10 @@ func (r *releaseRunner) PromoteFinalize(ctx context.Context) error {
 }
 
 func (r *releaseRunner) Test(ctx context.Context) error {
+	if err := r.checkDeps(ctx); err != nil {
+		return nil
+	}
+
 	if len(r.m.Test.Steps) == 0 {
 		announce2("test", "Skipping release tests, none defined")
 		return nil

--- a/dev/sg/internal/release/config.go
+++ b/dev/sg/internal/release/config.go
@@ -262,7 +262,7 @@ func (r *releaseRunner) checkRequirements(ctx context.Context, stage string) err
 	var failed bool
 	for _, req := range r.m.Requirements {
 		if shouldSkipReqCheck(req, stage) {
-			saySuccess("reqs", "SKIP %s (excluded for %s)", req.Name, stage)
+			saySuccess("reqs", "🔕 %s (excluded for %s)", req.Name, stage)
 			return nil
 		}
 
@@ -272,23 +272,23 @@ func (r *releaseRunner) checkRequirements(ctx context.Context, stage string) err
 		if req.Env != "" {
 			if _, ok := os.LookupEnv(req.Env); !ok {
 				failed = true
-				sayFail("reqs", "FAIL %s, $%s is not defined.", req.Name, req.Env)
+				sayFail("reqs", "❌ %s, $%s is not defined.", req.Name, req.Env)
 				continue
 			}
-			saySuccess("reqs", "OK %s", req.Name)
+			saySuccess("reqs", "✅ %s", req.Name)
 			continue
 		}
 
 		lines, err := run.Cmd(ctx, req.Cmd).Run().Lines()
 		if err != nil {
 			failed = true
-			sayFail("reqs", "FAIL %s", req.Name)
+			sayFail("reqs", "❌ %s", req.Name)
 			sayFail("reqs", "  Error: %s", err.Error())
 			for _, line := range lines {
 				sayFail("reqs", "  "+line)
 			}
 		} else {
-			saySuccess("reqs", "OK %s", req.Name)
+			saySuccess("reqs", "✅ %s", req.Name)
 		}
 	}
 	if failed {

--- a/dev/sg/internal/release/config.go
+++ b/dev/sg/internal/release/config.go
@@ -258,7 +258,10 @@ func (r *releaseRunner) checkDeps(ctx context.Context) error {
 }
 
 func (r *releaseRunner) InternalFinalize(ctx context.Context) error {
-	// TODO skip check deps
+	if err := r.checkDeps(ctx); err != nil {
+		return nil
+	}
+
 	if len(r.m.Internal.Finalize.Steps) == 0 {
 		announce2("finalize", "Skipping internal release finalization, none defined")
 		return nil
@@ -267,7 +270,10 @@ func (r *releaseRunner) InternalFinalize(ctx context.Context) error {
 	return r.runSteps(ctx, r.m.Internal.Finalize.Steps)
 }
 func (r *releaseRunner) PromoteFinalize(ctx context.Context) error {
-	// TODO skip check deps
+	if err := r.checkDeps(ctx); err != nil {
+		return nil
+	}
+
 	if len(r.m.PromoteToPublic.Finalize.Steps) == 0 {
 		announce2("finalize", "Skipping public release finalization, none defined")
 		return nil

--- a/dev/sg/internal/release/config.go
+++ b/dev/sg/internal/release/config.go
@@ -30,12 +30,7 @@ type ReleaseManifest struct {
 	// Requirements is a list of commands that must exit without errors for the manifest to be
 	// considered to be valid. Alternatively, instead of defining Cmd, Env can be set to
 	// ensure an environment variable is defnined.
-	Requirements []struct {
-		Name            string `yaml:"name"`
-		Cmd             string `yaml:"cmd"`
-		Env             string `yaml:"env"`
-		FixInstructions string `yaml:"fixInstructions"`
-	} `yaml:"requirements"`
+	Requirements []requirement `yaml:"requirements,omitempty"`
 	// Inputs defines a list of k=v strings, defining the required inputs for that release manifest.
 	// Typically, this is either empty or server=vX.Y.Z to build a release that uses that particular
 	// server version.
@@ -75,6 +70,46 @@ type ReleaseManifest struct {
 			Steps []cmdManifest `yaml:"steps"`
 		} `yaml:"finalize"`
 	} `yaml:"promoteToPublic"`
+}
+
+type requirement struct {
+	Name            string `yaml:"name"`
+	Cmd             string `yaml:"cmd"`
+	Env             string `yaml:"env"`
+	FixInstructions string `yaml:"fixInstructions"`
+	// Only allows to check a requirement just for a specific stage.
+	Only []string `yaml:"only,omitempty"`
+}
+
+const (
+	stageInternalCreate   = "internal.create"
+	stageInternalFinalize = "internal.finalize"
+	stageTest             = "test"
+	stagePromoteCreate    = "promoteToPublic.create"
+	stagePromoteFinalize  = "promoteToPublic.finalize"
+)
+
+func validateRequirementOnly(only []string) error {
+	if len(only) == 0 {
+		return nil
+	}
+	for _, str := range only {
+		switch str {
+		case stageInternalCreate:
+			continue
+		case stageInternalFinalize:
+			continue
+		case stageTest:
+			continue
+		case stagePromoteCreate:
+			continue
+		case stagePromoteFinalize:
+			continue
+		default:
+			return errors.Newf("invalid only value: %q", str)
+		}
+	}
+	return nil
 }
 
 type cmdManifest struct {
@@ -205,26 +240,32 @@ func NewReleaseRunner(ctx context.Context, workdir string, version string, input
 	return r, nil
 }
 
-func parseInputs(str string) (map[string]string, error) {
-	if str == "" {
-		return nil, nil
+func shouldSkipReqCheck(req requirement, stage string) bool {
+	if len(req.Only) == 0 {
+		return false
 	}
-	m := map[string]string{}
-	parts := strings.Split(str, ",")
-	for _, part := range parts {
-		subparts := strings.Split(part, "=")
-		if len(subparts) != 2 {
-			return nil, errors.New("invalid inputs")
+	for _, o := range req.Only {
+		if o == stage {
+			return false
 		}
-		m[subparts[0]] = subparts[1]
 	}
-	return m, nil
+	return true
 }
 
-func (r *releaseRunner) checkDeps(ctx context.Context) error {
+func (r *releaseRunner) checkRequirements(ctx context.Context, stage string) error {
 	announce2("reqs", "Checking requirements...")
+
+	if len(r.m.Requirements) == 0 {
+		saySuccess("reqs", "Requirement checks skipped, no requirements defined.")
+	}
+
 	var failed bool
 	for _, req := range r.m.Requirements {
+		if shouldSkipReqCheck(req, stage) {
+			saySuccess("reqs", "SKIP %s (excluded for %s)", req.Name, stage)
+			return nil
+		}
+
 		if req.Env != "" && req.Cmd != "" {
 			return errors.Newf("requirement %q can't have both env and cmd defined", req.Name)
 		}
@@ -257,46 +298,8 @@ func (r *releaseRunner) checkDeps(ctx context.Context) error {
 	return nil
 }
 
-func (r *releaseRunner) InternalFinalize(ctx context.Context) error {
-	if err := r.checkDeps(ctx); err != nil {
-		return nil
-	}
-
-	if len(r.m.Internal.Finalize.Steps) == 0 {
-		announce2("finalize", "Skipping internal release finalization, none defined")
-		return nil
-	}
-	announce2("finalize", "Running finalize steps for %s", r.version)
-	return r.runSteps(ctx, r.m.Internal.Finalize.Steps)
-}
-func (r *releaseRunner) PromoteFinalize(ctx context.Context) error {
-	if err := r.checkDeps(ctx); err != nil {
-		return nil
-	}
-
-	if len(r.m.PromoteToPublic.Finalize.Steps) == 0 {
-		announce2("finalize", "Skipping public release finalization, none defined")
-		return nil
-	}
-	announce2("finalize", "Running promote finalize steps for %s", r.version)
-	return r.runSteps(ctx, r.m.PromoteToPublic.Finalize.Steps)
-}
-
-func (r *releaseRunner) Test(ctx context.Context) error {
-	if err := r.checkDeps(ctx); err != nil {
-		return nil
-	}
-
-	if len(r.m.Test.Steps) == 0 {
-		announce2("test", "Skipping release tests, none defined")
-		return nil
-	}
-	announce2("test", "Running testing steps for %s", r.version)
-	return r.runSteps(ctx, r.m.Test.Steps)
-}
-
 func (r *releaseRunner) CreateRelease(ctx context.Context) error {
-	if err := r.checkDeps(ctx); err != nil {
+	if err := r.checkRequirements(ctx, stageInternalCreate); err != nil {
 		return nil
 	}
 
@@ -320,12 +323,51 @@ func (r *releaseRunner) CreateRelease(ctx context.Context) error {
 	return r.runSteps(ctx, steps)
 }
 
+func (r *releaseRunner) InternalFinalize(ctx context.Context) error {
+	if err := r.checkRequirements(ctx, stageInternalCreate); err != nil {
+		return nil
+	}
+
+	if len(r.m.Internal.Finalize.Steps) == 0 {
+		announce2("finalize", "Skipping internal release finalization, none defined")
+		return nil
+	}
+	announce2("finalize", "Running finalize steps for %s", r.version)
+	return r.runSteps(ctx, r.m.Internal.Finalize.Steps)
+}
+
+func (r *releaseRunner) Test(ctx context.Context) error {
+	if err := r.checkRequirements(ctx, stageTest); err != nil {
+		return nil
+	}
+
+	if len(r.m.Test.Steps) == 0 {
+		announce2("test", "Skipping release tests, none defined")
+		return nil
+	}
+	announce2("test", "Running testing steps for %s", r.version)
+	return r.runSteps(ctx, r.m.Test.Steps)
+}
+
 func (r *releaseRunner) Promote(ctx context.Context) error {
-	if err := r.checkDeps(ctx); err != nil {
+	if err := r.checkRequirements(ctx, stagePromoteCreate); err != nil {
 		return nil
 	}
 	announce2("promote", "Will promote %q to a public release", r.version)
 	return r.runSteps(ctx, r.m.PromoteToPublic.Create.Steps)
+}
+
+func (r *releaseRunner) PromoteFinalize(ctx context.Context) error {
+	if err := r.checkRequirements(ctx, stagePromoteFinalize); err != nil {
+		return nil
+	}
+
+	if len(r.m.PromoteToPublic.Finalize.Steps) == 0 {
+		announce2("finalize", "Skipping public release finalization, none defined")
+		return nil
+	}
+	announce2("finalize", "Running promote finalize steps for %s", r.version)
+	return r.runSteps(ctx, r.m.PromoteToPublic.Finalize.Steps)
 }
 
 func (r *releaseRunner) runSteps(ctx context.Context, steps []cmdManifest) error {
@@ -381,4 +423,20 @@ func saySuccess(section string, format string, a ...any) {
 
 func sayKind(style output.Style, section string, format string, a ...any) {
 	std.Out.WriteLine(output.Linef("  ", style, fmt.Sprintf("[%10s] %s", section, format), a...))
+}
+
+func parseInputs(str string) (map[string]string, error) {
+	if str == "" {
+		return nil, nil
+	}
+	m := map[string]string{}
+	parts := strings.Split(str, ",")
+	for _, part := range parts {
+		subparts := strings.Split(part, "=")
+		if len(subparts) != 2 {
+			return nil, errors.New("invalid inputs")
+		}
+		m[subparts[0]] = subparts[1]
+	}
+	return m, nil
 }

--- a/release.yaml
+++ b/release.yaml
@@ -26,13 +26,13 @@ requirements:
     only:
       - promoteToPublic.finalize
 
-  # #announce-engineering slack webhook url:
-  # https://start.1password.com/open/i?a=HEDEDSLHPBFGRBTKAKJWE23XX4&v=dnrhbauihkhjs5ag6vszsme45a&i=pldpna5vivapxe4phewnqd42ji&h=team-sourcegraph.1password.com
+   # announce-engineering slack webhook url:
+   # https://start.1password.com/open/i?a=HEDEDSLHPBFGRBTKAKJWE23XX4&v=dnrhbauihkhjs5ag6vszsme45a&i=pldpna5vivapxe4phewnqd42ji&h=team-sourcegraph.1password.com
 
-  # #bolaji-release-testing
-  # https://start.1password.com/open/i?a=HEDEDSLHPBFGRBTKAKJWE23XX4&v=isv4abynddpox72wwbhaamo76e&i=7zjax5rm5hlilbgrzeb257i62i&h=team-sourcegraph.1password.com
-  # - name: 'Slack Webhook URL'
-  #   env: SLACK_WEBHOOK_URL
+   # bolaji-release-testing
+   # https://start.1password.com/open/i?a=HEDEDSLHPBFGRBTKAKJWE23XX4&v=isv4abynddpox72wwbhaamo76e&i=7zjax5rm5hlilbgrzeb257i62i&h=team-sourcegraph.1password.com
+  - name: 'Slack Webhook URL'
+    env: SLACK_WEBHOOK_URL
 
 internal:
   create:
@@ -66,7 +66,6 @@ internal:
     steps:
       - name: 'Register on release registry'
         cmd: |
-          exit 0
           echo "Registering internal sourcegraph/sourcegraph {{version}} release on release registry"
           body=$(wget --content-on-error -O- --header="Content-Type: application/json" --header="Authorization: ${RELEASE_REGISTRY_TOKEN}" --post-data '{
               "name": "sourcegraph",
@@ -88,7 +87,6 @@ internal:
       - name: 'notifications'
         cmd: |
           set -eu
-          exit 0
 
           # Post an annotation.
           cat << EOF | buildkite-agent annotate --style info

--- a/release.yaml
+++ b/release.yaml
@@ -66,6 +66,7 @@ internal:
     steps:
       - name: 'Register on release registry'
         cmd: |
+          exit 0
           echo "Registering internal sourcegraph/sourcegraph {{version}} release on release registry"
           body=$(wget --content-on-error -O- --header="Content-Type: application/json" --header="Authorization: ${RELEASE_REGISTRY_TOKEN}" --post-data '{
               "name": "sourcegraph",
@@ -87,6 +88,7 @@ internal:
       - name: 'notifications'
         cmd: |
           set -eu
+          exit 0
 
           # Post an annotation.
           cat << EOF | buildkite-agent annotate --style info

--- a/release.yaml
+++ b/release.yaml
@@ -8,22 +8,31 @@ requirements:
   # We use wget here, because curl --fail-with-body was introduced in a version ulterior to what we can have on the CI agents.
   - name: "wget"
     cmd: "wget --help"
+  - name: "jq"
+    cmd: "jq --help"
   - name: "Buidkite access token"
+    env: BUILDKITE_ACCESS_TOKEN
+    only: # We only need this to create CI builds.
+      - internal.create
+      - promoteToPublic.create
     # `write_builds` permission is all that's needed here
     # You also need to ensure you add access to the Sourcegraph organization on Buildkite.
-    env: BUILDKITE_ACCESS_TOKEN
-  - name: "GitHub CLI "
+  - name: "GitHub CLI"
     cmd: "which gh"
+    only:
+      - promoteToPublic.finalize
   - name: "GitHub CLI auth status"
     cmd: "gh auth status"
+    only:
+      - promoteToPublic.finalize
 
   # #announce-engineering slack webhook url:
   # https://start.1password.com/open/i?a=HEDEDSLHPBFGRBTKAKJWE23XX4&v=dnrhbauihkhjs5ag6vszsme45a&i=pldpna5vivapxe4phewnqd42ji&h=team-sourcegraph.1password.com
 
   # #bolaji-release-testing
   # https://start.1password.com/open/i?a=HEDEDSLHPBFGRBTKAKJWE23XX4&v=isv4abynddpox72wwbhaamo76e&i=7zjax5rm5hlilbgrzeb257i62i&h=team-sourcegraph.1password.com
-  - name: 'Slack Webhook URL'
-    env: SLACK_WEBHOOK_URL
+  # - name: 'Slack Webhook URL'
+  #   env: SLACK_WEBHOOK_URL
 
 internal:
   create:

--- a/release.yaml
+++ b/release.yaml
@@ -12,6 +12,10 @@ requirements:
     # `write_builds` permission is all that's needed here
     # You also need to ensure you add access to the Sourcegraph organization on Buildkite.
     env: BUILDKITE_ACCESS_TOKEN
+  - name: "GitHub CLI "
+    cmd: "which gh"
+  - name: "GitHub CLI auth status"
+    cmd: "gh auth status"
 
   # #announce-engineering slack webhook url:
   # https://start.1password.com/open/i?a=HEDEDSLHPBFGRBTKAKJWE23XX4&v=dnrhbauihkhjs5ag6vszsme45a&i=pldpna5vivapxe4phewnqd42ji&h=team-sourcegraph.1password.com


### PR DESCRIPTION
Requirement checks are now done for every phase. Because phases can be executed in different enviroments, it can happen that a check is mandatory at a given stage but problematic in another. For example we need `BUILDKITE_ACCESS_TOKEN` to create builds, but this env var is not set in CI, nor it's necessary at this stage. 

At first, I went for having a `requirements:` field on every phase, but this felt error prone, because you would repeat the same check, i.e. with `BUILDKITE_ACCESS_TOKEN` you'd need it on both `internal.create` and `promoteToPublic.create`. 

You could use the YAML features to avoid the repeatition, but they're extremely error prone and frustrating to work with. 

Instead, I kept the original idea that we want the requirements to be clear and at the top of the release manifest, and added a `only` field that allows to express that a particular check affects only a particular phase: 

```yaml
meta:
  productName: sourcegraph
  repository: 'github.com/sourcegraph/sourcegraph'
  owners:
    - '@sourcegraph/release'

requirements:
  - name: "curl"
    cmd: "curl --help"
  - name: "jq"
    cmd: "jq --help"
  - name: "Buidkite access token"
    env: BUILDKITE_ACCESS_TOKEN
    only: # We only need this to create CI builds.
      - internal.create
      - promoteToPublic.create
    # `write_builds` permission is all that's needed here
    # You also need to ensure you add access to the Sourcegraph organization on Buildkite.
  - name: "GitHub CLI"
    cmd: "which gh"
    only:
      - promoteToPublic.finalize
  - name: "GitHub CLI auth status"
    cmd: "gh auth status"
    only:
      - promoteToPublic.finalize
```

Another approach might be to declare the requirements, and then reference their names, but it feels even harder to get right, as you'd need to keep in mind the full list when reviewing, or we'd have to add `only/skip` fields, which would further confuse at review time. 

For clarity's sake, when checking requirements, the skip ones are displayed: 

```
~/work/sourcegraph US jh/rel/tests-check-reqs $ go run ./dev/sg release create --version 5.3.666 --pretend
👉 [     setup] Finding release manifest in "."
   [     setup] No explicit branch name was provided, assuming current branch is the target: jh/rel/tests-check-reqs
   [     setup] Found manifest for "sourcegraph" (github.com/sourcegraph/sourcegraph)
   [      meta] Owners: @sourcegraph/release
   [      meta] Repository: github.com/sourcegraph/sourcegraph
👉 [      vars] Variables
   [      vars] version="v5.3.666"
   [      vars] tag="5.3.666"
   [      vars] config="{\"version\":\"v5.3.666\",\"inputs\":\"\",\"type\":\"patch\"}"
   [      vars] git.branch="jh/rel/tests-check-reqs"
👉 [      reqs] Checking requirements...
   [      reqs] ✅ curl
   [      reqs] ✅ jq
   [      reqs] ✅ Buidkite access token
   [      reqs] 🔕 GitHub CLI (excluded for internal.create)
``` 

## Test plan

### release tests runs the checks: 

See https://buildkite.com/sourcegraph/sourcegraph/builds/270796#018f14f9-4c6c-4f75-9855-e406ba349bb1/194-220
