### PR TITLE
search jobs: add index on state column

### DIFF
--- a/internal/database/migration/shared/data/stitched-migration-graph.json
+++ b/internal/database/migration/shared/data/stitched-migration-graph.json
@@ -11192,6 +11192,21 @@
 				],
 				"IsCreateIndexConcurrently": false,
 				"IndexMetadata": null
+			},
+			{
+				"ID": 1713958707,
+				"Name": "search jobs add index on state col",
+				"UpQuery": "CREATE INDEX IF NOT EXISTS exhaustive_search_jobs_state ON exhaustive_search_jobs (state);\nCREATE INDEX IF NOT EXISTS exhaustive_search_repo_jobs_state ON exhaustive_search_repo_jobs (state);\nCREATE INDEX IF NOT EXISTS exhaustive_search_repo_revision_jobs_state ON exhaustive_search_repo_revision_jobs (state);",
+				"DownQuery": "DROP INDEX IF EXISTS exhaustive_search_jobs_state;\nDROP INDEX IF EXISTS exhaustive_search_repo_jobs_state;\nDROP INDEX IF EXISTS exhaustive_search_repo_revision_jobs_state;",
+				"Privileged": false,
+				"NonIdempotent": false,
+				"Parents": [
+					1709738515,
+					1711003437,
+					1711538234
+				],
+				"IsCreateIndexConcurrently": false,
+				"IndexMetadata": null
 			}
 		],
 		"BoundsByRev": {
@@ -11443,9 +11458,7 @@
 			"v5.3.0": {
 				"RootID": 1648051770,
 				"LeafIDs": [
-					1709738515,
-					1711003437,
-					1711538234
+					1713958707
 				],
 				"PreCreation": false
 			}

--- a/internal/database/schema.json
+++ b/internal/database/schema.json
@@ -11813,6 +11813,16 @@
           "IndexDefinition": "CREATE UNIQUE INDEX exhaustive_search_jobs_pkey ON exhaustive_search_jobs USING btree (id)",
           "ConstraintType": "p",
           "ConstraintDefinition": "PRIMARY KEY (id)"
+        },
+        {
+          "Name": "exhaustive_search_jobs_state",
+          "IsPrimaryKey": false,
+          "IsUnique": false,
+          "IsExclusion": false,
+          "IsDeferrable": false,
+          "IndexDefinition": "CREATE INDEX exhaustive_search_jobs_state ON exhaustive_search_jobs USING btree (state)",
+          "ConstraintType": "",
+          "ConstraintDefinition": ""
         }
       ],
       "Constraints": [
@@ -12075,6 +12085,16 @@
           "IndexDefinition": "CREATE UNIQUE INDEX exhaustive_search_repo_jobs_pkey ON exhaustive_search_repo_jobs USING btree (id)",
           "ConstraintType": "p",
           "ConstraintDefinition": "PRIMARY KEY (id)"
+        },
+        {
+          "Name": "exhaustive_search_repo_jobs_state",
+          "IsPrimaryKey": false,
+          "IsUnique": false,
+          "IsExclusion": false,
+          "IsDeferrable": false,
+          "IndexDefinition": "CREATE INDEX exhaustive_search_repo_jobs_state ON exhaustive_search_repo_jobs USING btree (state)",
+          "ConstraintType": "",
+          "ConstraintDefinition": ""
         }
       ],
       "Constraints": [
@@ -12331,6 +12351,16 @@
           "IndexDefinition": "CREATE UNIQUE INDEX exhaustive_search_repo_revision_jobs_pkey ON exhaustive_search_repo_revision_jobs USING btree (id)",
           "ConstraintType": "p",
           "ConstraintDefinition": "PRIMARY KEY (id)"
+        },
+        {
+          "Name": "exhaustive_search_repo_revision_jobs_state",
+          "IsPrimaryKey": false,
+          "IsUnique": false,
+          "IsExclusion": false,
+          "IsDeferrable": false,
+          "IndexDefinition": "CREATE INDEX exhaustive_search_repo_revision_jobs_state ON exhaustive_search_repo_revision_jobs USING btree (state)",
+          "ConstraintType": "",
+          "ConstraintDefinition": ""
         }
       ],
       "Constraints": [

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -1584,6 +1584,7 @@ Referenced by:
  queued_at         | timestamp with time zone |           |          | now()
 Indexes:
     "exhaustive_search_jobs_pkey" PRIMARY KEY, btree (id)
+    "exhaustive_search_jobs_state" btree (state)
 Foreign-key constraints:
     "exhaustive_search_jobs_initiator_id_fkey" FOREIGN KEY (initiator_id) REFERENCES users(id) ON UPDATE CASCADE ON DELETE CASCADE DEFERRABLE
 Referenced by:
@@ -1615,6 +1616,7 @@ Referenced by:
  queued_at         | timestamp with time zone |           |          | now()
 Indexes:
     "exhaustive_search_repo_jobs_pkey" PRIMARY KEY, btree (id)
+    "exhaustive_search_repo_jobs_state" btree (state)
 Foreign-key constraints:
     "exhaustive_search_repo_jobs_repo_id_fkey" FOREIGN KEY (repo_id) REFERENCES repo(id) ON DELETE CASCADE
     "exhaustive_search_repo_jobs_search_job_id_fkey" FOREIGN KEY (search_job_id) REFERENCES exhaustive_search_jobs(id) ON DELETE CASCADE
@@ -1646,6 +1648,7 @@ Referenced by:
  queued_at          | timestamp with time zone |           |          | now()
 Indexes:
     "exhaustive_search_repo_revision_jobs_pkey" PRIMARY KEY, btree (id)
+    "exhaustive_search_repo_revision_jobs_state" btree (state)
 Foreign-key constraints:
     "exhaustive_search_repo_revision_jobs_search_repo_job_id_fkey" FOREIGN KEY (search_repo_job_id) REFERENCES exhaustive_search_repo_jobs(id) ON DELETE CASCADE
 

--- a/migrations/frontend/1713958707_search_jobs_add_index_on_state_col/down.sql
+++ b/migrations/frontend/1713958707_search_jobs_add_index_on_state_col/down.sql
@@ -1,0 +1,3 @@
+DROP INDEX IF EXISTS exhaustive_search_jobs_state;
+DROP INDEX IF EXISTS exhaustive_search_repo_jobs_state;
+DROP INDEX IF EXISTS exhaustive_search_repo_revision_jobs_state;

--- a/migrations/frontend/1713958707_search_jobs_add_index_on_state_col/metadata.yaml
+++ b/migrations/frontend/1713958707_search_jobs_add_index_on_state_col/metadata.yaml
@@ -1,0 +1,2 @@
+name: search jobs add index on state col
+parents: [1709738515, 1711003437, 1711538234]

--- a/migrations/frontend/1713958707_search_jobs_add_index_on_state_col/up.sql
+++ b/migrations/frontend/1713958707_search_jobs_add_index_on_state_col/up.sql
@@ -1,0 +1,3 @@
+CREATE INDEX IF NOT EXISTS exhaustive_search_jobs_state ON exhaustive_search_jobs (state);
+CREATE INDEX IF NOT EXISTS exhaustive_search_repo_jobs_state ON exhaustive_search_repo_jobs (state);
+CREATE INDEX IF NOT EXISTS exhaustive_search_repo_revision_jobs_state ON exhaustive_search_repo_revision_jobs (state);

--- a/migrations/frontend/squashed.sql
+++ b/migrations/frontend/squashed.sql
@@ -6077,6 +6077,12 @@ CREATE UNIQUE INDEX executor_secrets_unique_key_namespace_org ON executor_secret
 
 CREATE UNIQUE INDEX executor_secrets_unique_key_namespace_user ON executor_secrets USING btree (key, namespace_user_id, scope) WHERE (namespace_user_id IS NOT NULL);
 
+CREATE INDEX exhaustive_search_jobs_state ON exhaustive_search_jobs USING btree (state);
+
+CREATE INDEX exhaustive_search_repo_jobs_state ON exhaustive_search_repo_jobs USING btree (state);
+
+CREATE INDEX exhaustive_search_repo_revision_jobs_state ON exhaustive_search_repo_revision_jobs USING btree (state);
+
 CREATE INDEX explicit_permissions_bitbucket_projects_jobs_project_key_extern ON explicit_permissions_bitbucket_projects_jobs USING btree (project_key, external_service_id, state);
 
 CREATE INDEX explicit_permissions_bitbucket_projects_jobs_queued_at_idx ON explicit_permissions_bitbucket_projects_jobs USING btree (queued_at);


### PR DESCRIPTION
The search jobs tables are missing an index on the state column that most worker tables have - the dequeue query on dotcom takes 12.07s at the moment.

Test plan:
`sg migration up --db frontend; sg migration undo`


