### PR TITLE
ci: only emit build event protocol file for test command

### DIFF
--- a/.aspect/bazelrc/ci.sourcegraph.bazelrc
+++ b/.aspect/bazelrc/ci.sourcegraph.bazelrc
@@ -59,7 +59,7 @@ test --flaky_test_attempts=2
 # Sometimes the build fails due to some flakiness where a npm package fails to be copied
 common --noexperimental_merged_skyframe_analysis_execution
 
-common --build_event_binary_file=build_event_log.bin
-common --build_event_binary_file_path_conversion=false
-common --build_event_binary_file_upload_mode=wait_for_upload_complete
-common --build_event_publish_all_actions=true
+test --build_event_binary_file=build_event_log.bin
+test --build_event_binary_file_path_conversion=false
+test --build_event_binary_file_upload_mode=wait_for_upload_complete
+test --build_event_publish_all_actions=true


### PR DESCRIPTION
The file from the Test step was being overwritten by aquery and other commands in the Delivery Manifest step 

## Test plan

CI on main
