### PR TITLE
ci: don't remotely cache copy{dir,file} operations

### DIFF
--- a/.aspect/bazelrc/ci.sourcegraph.bazelrc
+++ b/.aspect/bazelrc/ci.sourcegraph.bazelrc
@@ -63,3 +63,11 @@ test --build_event_binary_file=build_event_log.bin
 test --build_event_binary_file_path_conversion=false
 test --build_event_binary_file_upload_mode=wait_for_upload_complete
 test --build_event_publish_all_actions=true
+common --build_event_binary_file=build_event_log.bin
+common --build_event_binary_file_path_conversion=false
+common --build_event_binary_file_upload_mode=wait_for_upload_complete
+common --build_event_publish_all_actions=true
+
+# These likely perform faster locally than the overhead of pulling/pushing from/to the remote cache,
+# as well as being able to reduce how much we push to the cache
+common --modify_execution_info=CopyDirectory=+no-remote,CopyToDirectory=+no-remote,CopyFile=+no-remote


### PR DESCRIPTION
May alleviate cache pressure, as well as potentially giving a slight boost to performance 

See https://github.com/aspect-build/rules_js/issues/1469 and https://sourcegraph.slack.com/archives/C04BWU1519D/p1713473625997359


## Test plan

CI passes green
