### PR TITLE
Search: fix case-sensitive queries with lang filters

### DIFF
--- a/internal/search/zoekt/query_test.go
+++ b/internal/search/zoekt/query_test.go
@@ -82,13 +82,19 @@ func TestQueryToZoektQuery(t *testing.T) {
 			Name:            "Languages get passed as file filter",
 			Type:            search.TextRequest,
 			Query:           `file:\.go$ lang:go`,
-			WantZoektOutput: autogold.Expect(`(and file_regex:"\\.go(?m:$)" file_regex:"(?i:\\.GO)(?m:$)")`),
+			WantZoektOutput: autogold.Expect(`(and file_regex:"(?i:\\.GO)(?m:$)" file_regex:"\\.go(?m:$)")`),
 		},
 		{
-			Name:            "Languages still use case_insensitive in case sensitivity mode",
+			Name:            "Languages still use case_insensitive in case sensitivity mode (Go)",
 			Type:            search.TextRequest,
 			Query:           `file:\.go$ lang:go case:true`,
-			WantZoektOutput: autogold.Expect(`(and case_file_regex:"\\.go(?m:$)" case_file_regex:"(?i:\\.GO)(?m:$)")`),
+			WantZoektOutput: autogold.Expect(`(and file_regex:"(?i:\\.GO)(?m:$)" case_file_regex:"\\.go(?m:$)")`),
+		},
+		{
+			Name:            "Languages still use case_insensitive in case sensitivity mode (Typescript)",
+			Type:            search.TextRequest,
+			Query:           `lang:typescript case:true`,
+			WantZoektOutput: autogold.Expect(`file_regex:"(?i:\\.)(?:(?i:TS)(?m:$)|(?i:CTS)(?m:$)|(?i:MTS)(?m:$))"`),
 		},
 		{
 			Name:  "Language get passed as lang: query",


### PR DESCRIPTION
This PR fixes a regression where language filters might not match when case
sensitivity is enabled. Before, we just appended `(?i)` to the file filters to
indicate case insensitivity, but still passed a case-sensitive file query to
Zoekt (called `case_file_regex`). Now, we make sure that the Zoekt queries are
also case insensitive so there is no conflict in how to interpret them.

Co-authored-by: Matthew Manela <mmanela@users.noreply.github.com>

## Test plan

Adapted unit tests. TODO: add an end-to-end test exercising the original bug!