### PR TITLE
workflows: remove sg-msp variant from sg publish

### DIFF
--- a/.github/workflows/sg-binary-release.yml
+++ b/.github/workflows/sg-binary-release.yml
@@ -106,25 +106,21 @@ jobs:
         run: |
           cd dev/sg
           GOARCH=${{ matrix.arch }} go build -o "sg_$(go env GOOS)_${{ matrix.arch }}" -trimpath -ldflags "-s -w -X main.BuildCommit=$(git rev-list -1 HEAD .)" .
-          GOARCH=${{ matrix.arch }} go build -o "sg-msp_$(go env GOOS)_${{ matrix.arch }}" -tags=msp -trimpath -ldflags "-s -w -X main.BuildCommit=$(git rev-list -1 HEAD .)" .
 
       - name: Build and upload Linux
         if: startsWith(matrix.os, 'ubuntu-') == true
         run: |
           cd dev/sg
           GOARCH=${{ matrix.arch }} go build -o "sg_$(go env GOOS)_${{ matrix.arch }}" -trimpath -ldflags "-s -w -X main.BuildCommit=$(git rev-list -1 HEAD .)" .
-          GOARCH=${{ matrix.arch }} go build -o "sg-msp_$(go env GOOS)_${{ matrix.arch }}" -tags=msp -trimpath -ldflags "-s -w -X main.BuildCommit=$(git rev-list -1 HEAD .)" .
 
           # On certain CI agents, the glibc might not be the right one, so we build a static variant
           CGO_ENABLED=0 GOARCH=${{ matrix.arch }} go build -o "sg_$(go env GOOS)_${{ matrix.arch }}_static" -trimpath -ldflags "-s -w -X main.BuildCommit=$(git rev-list -1 HEAD .)" .
-          CGO_ENABLED=0 GOARCH=${{ matrix.arch }} go build -o "sg-msp_$(go env GOOS)_${{ matrix.arch }}_static" -tags=msp -trimpath -ldflags "-s -w -X main.BuildCommit=$(git rev-list -1 HEAD .)" .
 
       - name: Upload release asset
         run: |
           cd dev/sg
           release_name="${{ needs.create_release.outputs.release_name }}"
           gh release upload -R="${repo}" ${release_name} "sg_$(go env GOOS)_${{ matrix.arch }}"
-          gh release upload -R="${repo}" ${release_name} "sg-msp_$(go env GOOS)_${{ matrix.arch }}"
         env:
           repo: sourcegraph/sg
           GITHUB_TOKEN: ${{ secrets.SG_RELEASE_TOKEN }}
@@ -135,7 +131,6 @@ jobs:
           cd dev/sg
           release_name="${{ needs.create_release.outputs.release_name }}"
           gh release upload -R="${repo}" ${release_name} "sg_$(go env GOOS)_${{ matrix.arch }}_static"
-          gh release upload -R="${repo}" ${release_name} "sg-msp_$(go env GOOS)_${{ matrix.arch }}_static"
         env:
           repo: sourcegraph/sg
           GITHUB_TOKEN: ${{ secrets.SG_RELEASE_TOKEN }}


### PR DESCRIPTION
We no longer require a build variant, and MSP is now included by default since https://github.com/sourcegraph/sourcegraph/pull/59087.

Remaining reference to the variant will be removed in https://github.com/sourcegraph/managed-services/pull/1288. Do not merge this until https://github.com/sourcegraph/managed-services/pull/1288 is merged.

## Test plan

https://github.com/sourcegraph/managed-services/pull/1288