### PR TITLE
Context: allow embeddings only for testing

### DIFF
--- a/cmd/frontend/internal/embeddings/resolvers/BUILD.bazel
+++ b/cmd/frontend/internal/embeddings/resolvers/BUILD.bazel
@@ -46,7 +46,6 @@ go_test(
         "//internal/database",
         "//internal/database/dbmocks",
         "//internal/database/dbtest",
-        "//internal/dotcom",
         "//internal/embeddings",
         "//internal/embeddings/background/repo",
         "//internal/featureflag",

--- a/cmd/frontend/internal/embeddings/resolvers/repo_embedding_jobs_test.go
+++ b/cmd/frontend/internal/embeddings/resolvers/repo_embedding_jobs_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
-	"github.com/sourcegraph/sourcegraph/internal/dotcom"
 	"github.com/sourcegraph/sourcegraph/internal/embeddings/background/repo"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/lib/pointers"
@@ -40,7 +39,7 @@ func TestDBPaginationWithRepoFilter(t *testing.T) {
 	require.NoError(t, err)
 
 	// Enable embeddings, so that resolvers work:
-	dotcom.MockSourcegraphDotComMode(t, true)
+	conf.MockForceAllowEmbeddings(t, true)
 
 	conf.Mock(&conf.Unified{
 		SiteConfiguration: schema.SiteConfiguration{

--- a/cmd/frontend/internal/embeddings/resolvers/resolvers_test.go
+++ b/cmd/frontend/internal/embeddings/resolvers/resolvers_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbmocks"
-	"github.com/sourcegraph/sourcegraph/internal/dotcom"
 	"github.com/sourcegraph/sourcegraph/internal/embeddings"
 	"github.com/sourcegraph/sourcegraph/internal/embeddings/background/repo"
 	"github.com/sourcegraph/sourcegraph/internal/featureflag"
@@ -32,7 +31,7 @@ import (
 
 func TestEmbeddingSearchResolver(t *testing.T) {
 	logger := logtest.Scoped(t)
-	dotcom.MockSourcegraphDotComMode(t, true)
+	conf.MockForceAllowEmbeddings(t, true)
 
 	oldMock := licensing.MockCheckFeature
 	licensing.MockCheckFeature = func(feature licensing.Feature) error {

--- a/internal/conf/BUILD.bazel
+++ b/internal/conf/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
         "computed.go",
         "conf.go",
         "diff.go",
+        "embeddings.go",
         "helpers.go",
         "init.go",
         "log_sinks.go",

--- a/internal/conf/computed.go
+++ b/internal/conf/computed.go
@@ -13,7 +13,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/conf/confdefaults"
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	"github.com/sourcegraph/sourcegraph/internal/conf/deploy"
-	"github.com/sourcegraph/sourcegraph/internal/dotcom"
 	"github.com/sourcegraph/sourcegraph/internal/hashutil"
 	"github.com/sourcegraph/sourcegraph/internal/license"
 	srccli "github.com/sourcegraph/sourcegraph/internal/src-cli"
@@ -916,8 +915,8 @@ func GetEmbeddingsConfig(siteConfig schema.SiteConfiguration) *conftypes.Embeddi
 		return nil
 	}
 
-	// Only allow embeddings on dotcom
-	if !dotcom.SourcegraphDotComMode() {
+	// Only allow embeddings as part of evaluating context quality.
+	if !ForceAllowEmbeddings() {
 		return nil
 	}
 

--- a/internal/conf/embeddings.go
+++ b/internal/conf/embeddings.go
@@ -6,7 +6,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/env"
 )
 
-var embeddingsAllowed, _ = strconv.ParseBool(env.Get(
+var allowEmbeddings, _ = strconv.ParseBool(env.Get(
 	"SRC_INTERNAL_EMBEDDINGS_ALLOWED",
 	"false",
 	"Allow embeddings jobs and search to be enabled. NOTE: only intended for internal testing.",
@@ -15,5 +15,16 @@ var embeddingsAllowed, _ = strconv.ParseBool(env.Get(
 // ForceAllowEmbeddings is true if we allow embeddings jobs and search to be enabled. It's only
 // intended for internal evaluation and should never be enabled outside a development environment.
 func ForceAllowEmbeddings() bool {
-	return embeddingsAllowed
+	return allowEmbeddings
+}
+
+type TB interface {
+	Cleanup(func())
+}
+
+// MockForceAllowEmbeddings is used by tests to mock the result of ForceAllowEmbeddings.
+func MockForceAllowEmbeddings(t TB, value bool) {
+	orig := allowEmbeddings
+	allowEmbeddings = value
+	t.Cleanup(func() { allowEmbeddings = orig })
 }

--- a/internal/conf/embeddings.go
+++ b/internal/conf/embeddings.go
@@ -7,7 +7,7 @@ import (
 )
 
 var embeddingsAllowed, _ = strconv.ParseBool(env.Get(
-	"SRC_EMBEDDINGS_ALLOWED",
+	"SRC_INTERNAL_EMBEDDINGS_ALLOWED",
 	"false",
 	"Allow embeddings jobs and search to be enabled. NOTE: only intended for internal testing.",
 ))

--- a/internal/conf/embeddings.go
+++ b/internal/conf/embeddings.go
@@ -1,0 +1,19 @@
+package conf
+
+import (
+	"strconv"
+
+	"github.com/sourcegraph/sourcegraph/internal/env"
+)
+
+var embeddingsAllowed, _ = strconv.ParseBool(env.Get(
+	"SRC_EMBEDDINGS_ALLOWED",
+	"false",
+	"Allow embeddings jobs and search to be enabled. NOTE: only intended for internal testing.",
+))
+
+// ForceAllowEmbeddings is true if we allow embeddings jobs and search to be enabled. It's only
+// intended for internal evaluation and should never be enabled outside a development environment.
+func ForceAllowEmbeddings() bool {
+	return embeddingsAllowed
+}

--- a/internal/embeddings/background/repo/store_test.go
+++ b/internal/embeddings/background/repo/store_test.go
@@ -348,7 +348,7 @@ func TestGetEmbeddableReposLimit(t *testing.T) {
 }
 
 func TestGetEmbeddableRepoOpts(t *testing.T) {
-	dotcom.MockSourcegraphDotComMode(t, true)
+	conf.MockForceAllowEmbeddings(t, true)
 
 	conf.Mock(&conf.Unified{})
 	defer conf.Mock(nil)


### PR DESCRIPTION
As we're evaluating the quality of Cody's context, it's really useful to be
able to compare against Enterprise embeddings. However, we completely disabled
Enterprise embeddings when we turned them off for customers.

This PR adds an environment variable `SRC_EMBEDDINGS_ALLOWED` that lets us
enable and test embeddings locally. It is not advertised and should never be
enabled in production use.

## Test plan

Local testing using the [context eval repo](https://github.com/sourcegraph/context-eval). The README now contains instructions
for how to run locally using `SRC_EMBEDDINGS_ALLOWED=true sg start`.