### PR TITLE
Fixing OpenAI TokenUsage to replace internally implemented token counter with openai response

### DIFF
--- a/internal/completions/client/anthropic/anthropic.go
+++ b/internal/completions/client/anthropic/anthropic.go
@@ -64,7 +64,7 @@ func (a *anthropicClient) Complete(
 		completion += content.Text
 	}
 
-	err = a.tokenManager.UpdateAnthropicModelUsage(response.Usage.InputTokens, response.Usage.OutputTokens, "anthropic/"+requestParams.Model, string(feature), tokenusage.Anthropic)
+	err = a.tokenManager.UpdateTokenCountsFromModelUsage(response.Usage.InputTokens, response.Usage.OutputTokens, "anthropic/"+requestParams.Model, string(feature), tokenusage.Anthropic)
 	if err != nil {
 		return nil, err
 	}
@@ -124,7 +124,7 @@ func (a *anthropicClient) Stream(
 		case "message_delta":
 			if event.Delta != nil {
 				stopReason = event.Delta.StopReason
-				err = a.tokenManager.UpdateAnthropicModelUsage(inputPromptTokens, event.Usage.OutputTokens, "anthropic/"+requestParams.Model, string(feature), tokenusage.Anthropic)
+				err = a.tokenManager.UpdateTokenCountsFromModelUsage(inputPromptTokens, event.Usage.OutputTokens, "anthropic/"+requestParams.Model, string(feature), tokenusage.Anthropic)
 				if err != nil {
 					logger.Warn("Failed to count tokens with the token manager %w ", log.Error(err))
 				}

--- a/internal/completions/client/awsbedrock/bedrock.go
+++ b/internal/completions/client/awsbedrock/bedrock.go
@@ -68,7 +68,7 @@ func (c *awsBedrockAnthropicCompletionStreamClient) Complete(
 		completion += content.Text
 	}
 
-	err = c.tokenManager.UpdateAnthropicModelUsage(response.Usage.InputTokens, response.Usage.OutputTokens, "anthropic/"+requestParams.Model, string(feature), tokenusage.AwsBedrock)
+	err = c.tokenManager.UpdateTokenCountsFromModelUsage(response.Usage.InputTokens, response.Usage.OutputTokens, "anthropic/"+requestParams.Model, string(feature), tokenusage.AwsBedrock)
 	if err != nil {
 		return nil, err
 	}
@@ -153,7 +153,7 @@ func (a *awsBedrockAnthropicCompletionStreamClient) Stream(
 		case "message_delta":
 			if event.Delta != nil {
 				stopReason = event.Delta.StopReason
-				err = a.tokenManager.UpdateAnthropicModelUsage(inputPromptTokens, event.Usage.OutputTokens, "anthropic/"+requestParams.Model, string(feature), tokenusage.AwsBedrock)
+				err = a.tokenManager.UpdateTokenCountsFromModelUsage(inputPromptTokens, event.Usage.OutputTokens, "anthropic/"+requestParams.Model, string(feature), tokenusage.AwsBedrock)
 				if err != nil {
 					logger.Warn("Failed to count tokens with the token manager %w ", log.Error(err))
 				}

--- a/internal/completions/client/openai/openai.go
+++ b/internal/completions/client/openai/openai.go
@@ -104,6 +104,8 @@ func (c *openAIChatCompletionStreamClient) Stream(
 	dec := NewDecoder(resp.Body)
 	var content string
 	var ev types.CompletionResponse
+	var promptTokens, completionTokens int
+
 	for dec.Scan() {
 		if ctx.Err() != nil && ctx.Err() == context.Canceled {
 			return nil
@@ -118,6 +120,14 @@ func (c *openAIChatCompletionStreamClient) Stream(
 		var event openaiResponse
 		if err := json.Unmarshal(data, &event); err != nil {
 			return errors.Errorf("failed to decode event payload: %w - body: %s", err, string(data))
+		}
+
+		// These are only included in the last message, so we're not worried about overwriting
+		if event.Usage.PromptTokens > 0 {
+			promptTokens = event.Usage.PromptTokens
+		}
+		if event.Usage.CompletionTokens > 0 {
+			completionTokens = event.Usage.CompletionTokens
 		}
 
 		if len(event.Choices) > 0 {
@@ -139,7 +149,7 @@ func (c *openAIChatCompletionStreamClient) Stream(
 	if dec.Err() != nil {
 		return dec.Err()
 	}
-	err = c.tokenManager.TokenizeAndCalculateUsage(requestParams.Messages, content, tokenizer.OpenAIModel+"/"+requestParams.Model, string(feature), tokenusage.OpenAI)
+	err = c.tokenManager.UpdateTokenCountsFromModelUsage(promptTokens, completionTokens, tokenizer.OpenAIModel+"/"+requestParams.Model, string(feature), tokenusage.OpenAI)
 	if err != nil {
 		logger.Warn("Failed to count tokens with the token manager %w", log.Error(err))
 	}

--- a/internal/completions/client/openai/openai.go
+++ b/internal/completions/client/openai/openai.go
@@ -67,7 +67,7 @@ func (c *openAIChatCompletionStreamClient) Complete(
 		// Empty response.
 		return &types.CompletionResponse{}, nil
 	}
-	err = c.tokenManager.TokenizeAndCalculateUsage(requestParams.Messages, response.Choices[0].Text, tokenizer.OpenAIModel+"/"+requestParams.Model, string(feature), tokenusage.OpenAI)
+	err = c.tokenManager.UpdateTokenCountsFromModelUsage(response.Usage.PromptTokens, response.Usage.CompletionTokens, tokenizer.OpenAIModel+"/"+requestParams.Model, string(feature), tokenusage.OpenAI)
 	if err != nil {
 		logger.Warn("Failed to count tokens with the token manager %w ", log.Error(err))
 	}

--- a/internal/completions/tokenusage/tokenusage.go
+++ b/internal/completions/tokenusage/tokenusage.go
@@ -61,7 +61,7 @@ func (m *Manager) TokenizeAndCalculateUsage(inputMessages []types.Message, outpu
 	return nil
 }
 
-func (m *Manager) UpdateAnthropicModelUsage(inputTokens, outputTokens int, model, feature string, provider Provider) error {
+func (m *Manager) UpdateTokenCountsFromModelUsage(inputTokens, outputTokens int, model, feature string, provider Provider) error {
 	baseKey := fmt.Sprintf("%s:%s:%s:", provider, model, feature)
 
 	if err := m.updateTokenCounts(baseKey+"input", int64(inputTokens)); err != nil {


### PR DESCRIPTION
Thanks to @rafax 
<img width="1136" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/11155207/a881a20d-2b2d-4d34-9df6-36a896f5dbaa">

Next Steps:
- Try to make it work in Azure too(It didn't work in my tiny experiments)
- If you can't make something similar work in azure then write a separate tokenizer for azure

## Test plan
Tested locally with the entire debugger environment


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
