### PR TITLE
gitserver: port FirstEverCommit functionality from client to git cli backend

### DIFF
--- a/cmd/gitserver/internal/git/iface.go
+++ b/cmd/gitserver/internal/git/iface.go
@@ -95,6 +95,12 @@ type GitBackend interface {
 	// No new usages of it should be introduced and once the migration is done we will
 	// remove this method.
 	Exec(ctx context.Context, args ...string) (io.ReadCloser, error)
+
+	// FirstEverCommit returns the first commit ever made to the repository.
+	//
+	// If the repository is empty, a RevisionNotFoundError is returned (as the
+	// "HEAD" ref does not exist).
+	FirstEverCommit(ctx context.Context) (api.CommitID, error)
 }
 
 type GitDiffComparisonType int

--- a/cmd/gitserver/internal/git/observability.go
+++ b/cmd/gitserver/internal/git/observability.go
@@ -369,6 +369,16 @@ func (b *observableBackend) ContributorCounts(ctx context.Context, opt Contribut
 	return b.backend.ContributorCounts(ctx, opt)
 }
 
+func (b *observableBackend) FirstEverCommit(ctx context.Context) (_ api.CommitID, err error) {
+	ctx, _, endObservation := b.operations.firstEverCommit.With(ctx, &err, observation.Args{})
+	defer endObservation(1, observation.Args{})
+
+	concurrentOps.WithLabelValues("FirstEverCommit").Inc()
+	defer concurrentOps.WithLabelValues("FirstEverCommit").Dec()
+
+	return b.backend.FirstEverCommit(ctx)
+}
+
 type operations struct {
 	configGet         *observation.Operation
 	configSet         *observation.Operation
@@ -387,6 +397,7 @@ type operations struct {
 	revAtTime         *observation.Operation
 	rawDiff           *observation.Operation
 	contributorCounts *observation.Operation
+	firstEverCommit   *observation.Operation
 }
 
 func newOperations(observationCtx *observation.Context) *operations {

--- a/internal/gitserver/gitdomain/errors.go
+++ b/internal/gitserver/gitdomain/errors.go
@@ -25,6 +25,12 @@ func (e *RevisionNotFoundError) NotFound() bool {
 	return true
 }
 
+// IsRevisionNotFoundError reports if err is a RevisionNotFoundError.
+func IsRevisionNotFoundError(err error) bool {
+	var e *RevisionNotFoundError
+	return errors.As(err, &e)
+}
+
 type BadCommitError struct {
 	Spec   string
 	Commit api.CommitID

--- a/internal/insights/gitserver/BUILD.bazel
+++ b/internal/insights/gitserver/BUILD.bazel
@@ -23,6 +23,7 @@ go_test(
     srcs = ["first_commit_test.go"],
     embed = [":gitserver"],
     deps = [
+        "//internal/gitserver/gitdomain",
         "//lib/errors",
         "@com_github_hexops_autogold_v2//:autogold",
     ],

--- a/internal/insights/gitserver/first_commit.go
+++ b/internal/insights/gitserver/first_commit.go
@@ -18,6 +18,10 @@ var (
 const emptyRepoErrMessage = `git command [rev-list --reverse --date-order --max-parents=0 HEAD] failed (output: ""): exit status 129`
 
 func isFirstCommitEmptyRepoError(err error) bool {
+	if gitdomain.IsRevisionNotFoundError(err) {
+		return true
+	}
+
 	if strings.Contains(err.Error(), emptyRepoErrMessage) {
 		return true
 	}

--- a/internal/insights/gitserver/first_commit_test.go
+++ b/internal/insights/gitserver/first_commit_test.go
@@ -3,6 +3,8 @@ package gitserver
 import (
 	"testing"
 
+	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
+
 	"github.com/hexops/autogold/v2"
 
 	"github.com/sourcegraph/sourcegraph/lib/errors"
@@ -34,6 +36,14 @@ func Test_IsEmptyRepoError(t *testing.T) {
 		{
 			err:  errors.New("A different error"),
 			want: autogold.Expect(false),
+		},
+		{
+			err:  &gitdomain.RevisionNotFoundError{Repo: "foo", Spec: "HEAD"},
+			want: autogold.Expect(true),
+		},
+		{
+			err:  errors.Wrapf(&gitdomain.RevisionNotFoundError{Repo: "foo", Spec: "HEAD"}, "nice!"),
+			want: autogold.Expect(true),
 		},
 	}
 	for _, tc := range testCases {


### PR DESCRIPTION
Part of [#61689](https://github.com/sourcegraph/sourcegraph/issues/61689)

## Overview

This PR adapts the existing FirstEverCommit logic from the gitserver client to our new git cli backend. This is the first step as part of a set of stacked PRs to port the functionality to gRPC.

Existing `func (c *clientImplementor) FirstEverCommit()` implementation for reference: 

https://github.com/sourcegraph/sourcegraph/blob/412654f098492856f32a6c561eda471800924d71/internal/gitserver/commands.go#L1734-L1757

## Note

One of the existing tests that I ported called out that code insights depended on the formatting of a specific error string in order to detect if the repository was empty.

(Test in question):

https://github.com/sourcegraph/sourcegraph/blob/948848bca6e87e84878a9c1a9222d36734103fa2/internal/gitserver/commands_test.go#L721-L729

(String checking logic in code insights):

https://github.com/sourcegraph/sourcegraph/blob/2443801b4ea4a4d48a8badf3c34ed2761af65db4/internal/insights/gitserver/first_commit.go#L18-L38

This is quite brittle, as any unrelated formatting change with our errors could change the semantics here. I decided to create a new sentinel error for this condition, `gitdomain.RepoEmptyErr`, to 1) better state our intent and 2) make this check more robust against minor formatting changes in our error libraries. When we generate the gRPC bindings, we'll need to create a new protobuf message for this error and write `ToProto/FromProto` functions, etc.


## Test plan

Adapted existing unit tests
