### PR TITLE
Svelte: render search alerts

### DIFF
--- a/client/shared/src/search/stream.ts
+++ b/client/shared/src/search/stream.ts
@@ -287,7 +287,7 @@ export interface Filter {
 export type SmartSearchAlertKind = 'smart-search-additional-results' | 'smart-search-pure-results'
 export type AlertKind = SmartSearchAlertKind | 'unowned-results'
 
-interface Alert {
+export interface Alert {
     title: string
     description?: string | null
     kind?: AlertKind | null

--- a/client/web-sveltekit/src/lib/shared.ts
+++ b/client/web-sveltekit/src/lib/shared.ts
@@ -44,6 +44,7 @@ export {
     type Range,
     type Filter,
     type SearchEvent,
+    type Alert,
 } from '@sourcegraph/shared/src/search/stream'
 export {
     type MatchItem,

--- a/client/web-sveltekit/src/routes/search/SearchAlert.svelte
+++ b/client/web-sveltekit/src/routes/search/SearchAlert.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+    import type { Alert as SearchAlert } from '$lib/shared'
+    import { Alert } from '$lib/wildcard'
+    import Markdown from '$lib/wildcard/Markdown.svelte'
+
+    export let alert: SearchAlert
+</script>
+
+<Alert variant="warning">
+    <div>
+        <h3>{alert.title}</h3>
+        <Markdown content={alert.description ?? ''} />
+    </div>
+</Alert>

--- a/client/web-sveltekit/src/routes/search/SearchResults.svelte
+++ b/client/web-sveltekit/src/routes/search/SearchResults.svelte
@@ -23,15 +23,12 @@
     import { limitHit } from '$lib/branded'
     import Icon from '$lib/Icon.svelte'
     import { observeIntersection } from '$lib/intersection-observer'
+    import GlobalHeaderPortal from '$lib/navigation/GlobalHeaderPortal.svelte'
     import type { URLQueryFilter } from '$lib/search/dynamicFilters'
     import DynamicFiltersSidebar from '$lib/search/dynamicFilters/Sidebar.svelte'
     import { createRecentSearchesStore } from '$lib/search/input/recentSearches'
     import SearchInput from '$lib/search/input/SearchInput.svelte'
     import { getQueryURL, type QueryStateStore } from '$lib/search/state'
-    import GlobalHeaderPortal from '$lib/navigation/GlobalHeaderPortal.svelte'
-    import PanelGroup from '$lib/wildcard/resizable-panel/PanelGroup.svelte'
-    import Panel from '$lib/wildcard/resizable-panel/Panel.svelte'
-    import PanelResizeHandle from '$lib/wildcard/resizable-panel/PanelResizeHandle.svelte'
     import {
         type AggregateStreamingSearchResults,
         type PathMatch,
@@ -39,8 +36,12 @@
         type SymbolMatch,
         type ContentMatch,
     } from '$lib/shared'
+    import Panel from '$lib/wildcard/resizable-panel/Panel.svelte'
+    import PanelGroup from '$lib/wildcard/resizable-panel/PanelGroup.svelte'
+    import PanelResizeHandle from '$lib/wildcard/resizable-panel/PanelResizeHandle.svelte'
 
     import PreviewPanel from './PreviewPanel.svelte'
+    import SearchAlert from './SearchAlert.svelte'
     import { getSearchResultComponent } from './searchResultFactory'
     import { setSearchResultsContext } from './searchResultsContext'
     import StreamingProgress from './StreamingProgress.svelte'
@@ -149,6 +150,11 @@
                     <StreamingProgress {state} progress={$stream.progress} on:submit={onResubmitQuery} />
                 </aside>
                 <div class="result-list" bind:this={resultContainer}>
+                    {#if $stream.alert}
+                        <div class="message-container">
+                            <SearchAlert alert={$stream.alert} />
+                        </div>
+                    {/if}
                     <ol>
                         {#each resultsToShow as result, i}
                             {@const component = getSearchResultComponent(result)}
@@ -162,7 +168,7 @@
                         {/each}
                     </ol>
                     {#if resultsToShow.length === 0 && state !== 'loading'}
-                        <div class="no-result">
+                        <div class="message-container">
                             <Icon svgPath={mdiCloseOctagonOutline} />
                             <p>No results found</p>
                         </div>
@@ -226,12 +232,13 @@
             }
         }
 
-        .no-result {
+        .message-container {
             display: flex;
             flex-direction: column;
             align-items: center;
             margin: auto;
             color: var(--text-muted);
+            margin: 2rem;
         }
     }
 </style>

--- a/client/web-sveltekit/src/routes/search/page.spec.ts
+++ b/client/web-sveltekit/src/routes/search/page.spec.ts
@@ -10,6 +10,34 @@ import {
     createSymbolMatch,
 } from '../../testing/search-testdata'
 
+const chunkMatch: ContentMatch = {
+    type: 'content',
+    path: 'README.md',
+    pathMatches: [],
+    repository: 'github.com/sourcegraph/conc',
+    repoStars: 9001,
+    commit: 'abcde12345',
+    chunkMatches: [
+        {
+            content: 'lorem ipsum\ndolor sit\namet',
+            contentStart: { offset: 0, line: 1, column: 1 },
+            ranges: [
+                {
+                    // "lorem"
+                    start: { offset: 0, line: 0, column: 0 },
+                    end: { offset: 5, line: 0, column: 5 },
+                },
+                {
+                    // "sit"
+                    start: { offset: 18, line: 1, column: 6 },
+                    end: { offset: 21, line: 1, column: 9 },
+                },
+            ],
+        },
+    ],
+    language: 'text',
+}
+
 test('search input is autofocused', async ({ page }) => {
     await page.goto('/search')
     const searchInput = page.getByRole('textbox')
@@ -112,33 +140,6 @@ test('copy path button appears and copies path', async ({ page, sg }) => {
 })
 
 test.describe('preview panel', async () => {
-    const chunkMatch: ContentMatch = {
-        type: 'content',
-        path: 'README.md',
-        pathMatches: [],
-        repository: 'github.com/sourcegraph/conc',
-        repoStars: 9001,
-        commit: 'abcde12345',
-        chunkMatches: [
-            {
-                content: 'lorem ipsum\ndolor sit\namet',
-                contentStart: { offset: 0, line: 1, column: 1 },
-                ranges: [
-                    {
-                        // "lorem"
-                        start: { offset: 0, line: 0, column: 0 },
-                        end: { offset: 5, line: 0, column: 5 },
-                    },
-                    {
-                        // "sit"
-                        start: { offset: 18, line: 1, column: 6 },
-                        end: { offset: 21, line: 1, column: 9 },
-                    },
-                ],
-            },
-        ],
-        language: 'text',
-    }
     test('can be opened and closed', async ({ page, sg }) => {
         const stream = await sg.mockSearchStream()
         await page.goto('/search?q=test')
@@ -212,5 +213,47 @@ test.describe('preview panel', async () => {
 
         await nextButton.click()
         await expect(currentSelection, 'clicking next on the last result should wrap forwards').toHaveText('lorem')
+    })
+})
+
+test.describe('search results', async () => {
+    test('first result visible', async ({ page, sg }) => {
+        const stream = await sg.mockSearchStream()
+        await page.goto('/search?q=test')
+        await page.getByRole('heading', { name: 'Filter results' }).waitFor()
+        await stream.publish(
+            {
+                type: 'matches',
+                data: [chunkMatch],
+            },
+            createProgressEvent(),
+            createDoneEvent()
+        )
+        await stream.close()
+
+        const chunkPath = page.getByRole('link', { name: 'README.md' })
+        await expect(chunkPath).toBeVisible()
+    })
+
+    test('alert is shown', async ({ page, sg }) => {
+        const stream = await sg.mockSearchStream()
+        await page.goto('/search?q=test')
+        await page.getByRole('heading', { name: 'Filter results' }).waitFor()
+        await stream.publish(
+            {
+                type: 'alert',
+                data: {
+                    title: 'Test alert',
+                    description: 'Test description',
+                    proposedQueries: null,
+                },
+            },
+            createProgressEvent(),
+            createDoneEvent()
+        )
+        await stream.close()
+
+        const alert = page.getByRole('heading', { name: 'Test alert' })
+        await expect(alert).toBeVisible()
     })
 })


### PR DESCRIPTION
Before this, we were completely ignoring any alerts that come from the search backend. This fixes that.

## Test plan

Added simple playwright test that ensures the alert is visible if it is sent on the stream.

![screenshot-2024-04-24_15-06-51@2x](https://github.com/sourcegraph/sourcegraph/assets/12631702/33bf527e-40cd-4502-9c4d-ecb0d353c33f)
