### PR TITLE
gitserver: grpc: switch clientImplementor to use new dedicated gRPC method for FirstEverCommit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Improved the performance of Language Stats Insights by 50-70% by increasing the concurrent requests from the frontend to the gitserver from 1 to 4. You can override the concurrency with the `GET_INVENTORY_GIT_SERVER_CONCURRENCY` environment variable. [#62011](https://github.com/sourcegraph/sourcegraph/pull/62011)
 - Raised the backend timeout for Language Stats Insights from 3 minutes to 5 minutes. You can override this with the `GET_INVENTORY_TIMEOUT` environment variable. [#62011](https://github.com/sourcegraph/sourcegraph/pull/62011)
 - Code insights drilldown behavior has been changed from a diff search to a point-in-time search with the new `rev:at.time()`. [#61953](https://github.com/sourcegraph/sourcegraph/pull/61953)
+- The `FirstEverCommit` gitserver client method has been changed to use a new bespoke gRPC endpoint instead of the legacy `exec` endpoint. [#62173](https://github.com/sourcegraph/sourcegraph/pull/62173)
 
 ### Fixed
 

--- a/internal/gitserver/BUILD.bazel
+++ b/internal/gitserver/BUILD.bazel
@@ -81,6 +81,7 @@ go_test(
         "//lib/errors",
         "//schema",
         "@com_github_google_go_cmp//cmp",
+        "@com_github_google_go_cmp//cmp/cmpopts",
         "@com_github_sourcegraph_go_diff//diff",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",

--- a/internal/gitserver/commands_test.go
+++ b/internal/gitserver/commands_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -649,82 +650,6 @@ func TestRepository_HasCommitAfter(t *testing.T) {
 					t.Errorf("got %t hascommitafter, want %t", got, tc.wantSubRepoTest)
 				}
 			})
-		}
-	})
-}
-
-func TestRepository_FirstEverCommit(t *testing.T) {
-	ClientMocks.LocalGitserver = true
-	defer ResetClientMocks()
-	ctx := actor.WithActor(context.Background(), &actor.Actor{
-		UID: 1,
-	})
-
-	testCases := []struct {
-		commitDates []string
-		want        string
-	}{
-		{
-			commitDates: []string{
-				"2006-01-02T15:04:05Z",
-				"2007-01-02T15:04:05Z",
-				"2008-01-02T15:04:05Z",
-			},
-			want: "2006-01-02T15:04:05Z",
-		},
-		{
-			commitDates: []string{
-				"2007-01-02T15:04:05Z", // Don't think this is possible, but if it is we still want the first commit (not strictly "oldest")
-				"2006-01-02T15:04:05Z",
-				"2007-01-02T15:04:06Z",
-			},
-			want: "2007-01-02T15:04:05Z",
-		},
-	}
-
-	t.Run("basic", func(t *testing.T) {
-		for _, tc := range testCases {
-			gitCommands := make([]string, len(tc.commitDates))
-			for i, date := range tc.commitDates {
-				gitCommands[i] = fmt.Sprintf("GIT_COMMITTER_NAME=a GIT_COMMITTER_EMAIL=a@a.com GIT_COMMITTER_DATE=%s git commit --allow-empty -m foo --author='a <a@a.com>'", date)
-			}
-
-			repo := MakeGitRepository(t, gitCommands...)
-
-			client := NewTestClient(t).WithClientSource(NewTestClientSource(t, []string{"test"}, func(o *TestClientSourceOptions) {
-				o.ClientFunc = func(conn *grpc.ClientConn) proto.GitserverServiceClient {
-					date, err := time.Parse(time.RFC3339, tc.want)
-					require.NoError(t, err)
-					c := NewMockGitserverServiceClient()
-					c.GetCommitFunc.SetDefaultReturn(&proto.GetCommitResponse{
-						Commit: &proto.GitCommit{
-							Committer: &proto.GitSignature{
-								Date: timestamppb.New(date),
-							},
-						},
-					}, nil)
-					return c
-				}
-			}))
-
-			gotCommit, err := client.FirstEverCommit(ctx, repo)
-			if err != nil {
-				t.Fatal(err)
-			}
-			got := gotCommit.Committer.Date.Format(time.RFC3339)
-			if got != tc.want {
-				t.Errorf("got %q, want %q", got, tc.want)
-			}
-		}
-	})
-
-	// Added for awareness if this error message changes. Insights skip over empty repos and check against error message
-	t.Run("empty repo", func(t *testing.T) {
-		repo := MakeGitRepository(t)
-		_, err := NewClient("test").FirstEverCommit(ctx, repo)
-		wantErr := `git command [rev-list --reverse --date-order --max-parents=0 HEAD] failed (output: ""): exit status 128`
-		if err.Error() != wantErr {
-			t.Errorf("expected :%s, got :%s", wantErr, err)
 		}
 	})
 }
@@ -2255,5 +2180,77 @@ func TestClient_ContributorCounts(t *testing.T) {
 		_, err := c.ContributorCount(context.Background(), "repo", ContributorOptions{})
 		require.Error(t, err)
 		require.True(t, errors.HasType(err, &gitdomain.RevisionNotFoundError{}))
+	})
+}
+
+func TestClient_FirstEverCommit(t *testing.T) {
+	t.Run("correctly returns server response", func(t *testing.T) {
+
+		expectedCommit := gitdomain.Commit{
+			ID:        "deadbeef",
+			Author:    gitdomain.Signature{Name: "Foo", Email: "foo@bar.com"},
+			Committer: &gitdomain.Signature{Name: "Bar", Email: "bar@bar.com"},
+			Message:   "Initial commit",
+			Parents:   []api.CommitID{},
+		}
+		source := NewTestClientSource(t, []string{"gitserver"}, func(o *TestClientSourceOptions) {
+			o.ClientFunc = func(cc *grpc.ClientConn) proto.GitserverServiceClient {
+
+				c := NewMockGitserverServiceClient()
+				c.FirstEverCommitFunc.SetDefaultReturn(&proto.FirstEverCommitResponse{
+					Commit: expectedCommit.ToProto(),
+				}, nil)
+
+				return c
+			}
+		})
+
+		c := NewTestClient(t).WithClientSource(source)
+
+		actualCommit, err := c.FirstEverCommit(context.Background(), "repo")
+		require.NoError(t, err)
+
+		if diff := cmp.Diff(expectedCommit, actualCommit, cmpopts.EquateEmpty()); diff != "" {
+			t.Fatalf("unexpected commit (-want +got):\n%s", diff)
+		}
+	})
+	t.Run("returns well known error types", func(t *testing.T) {
+		t.Run("repository not found", func(t *testing.T) {
+			source := NewTestClientSource(t, []string{"gitserver"}, func(o *TestClientSourceOptions) {
+				o.ClientFunc = func(cc *grpc.ClientConn) proto.GitserverServiceClient {
+					c := NewMockGitserverServiceClient()
+					s, err := status.New(codes.NotFound, "repository not found").WithDetails(&proto.RepoNotFoundPayload{Repo: "repo", CloneInProgress: true})
+					require.NoError(t, err)
+					c.FirstEverCommitFunc.PushReturn(nil, s.Err())
+					return c
+				}
+			})
+
+			c := NewTestClient(t).WithClientSource(source)
+
+			// Should fail with clone error
+			_, err := c.FirstEverCommit(context.Background(), "repo")
+			require.Error(t, err)
+			require.True(t, errors.HasType(err, &gitdomain.RepoNotExistError{}))
+		})
+
+		t.Run("empty repository", func(t *testing.T) {
+			source := NewTestClientSource(t, []string{"gitserver"}, func(o *TestClientSourceOptions) {
+				o.ClientFunc = func(cc *grpc.ClientConn) proto.GitserverServiceClient {
+					c := NewMockGitserverServiceClient()
+					s, err := status.New(codes.FailedPrecondition, "empty repo").WithDetails(&proto.RevisionNotFoundPayload{Repo: "repo", Spec: "HEAD"})
+					require.NoError(t, err)
+					c.FirstEverCommitFunc.SetDefaultReturn(nil, s.Err())
+					return c
+				}
+			})
+
+			c := NewTestClient(t).WithClientSource(source)
+
+			// Should fail with RepositoryEmptyError
+			_, err := c.FirstEverCommit(context.Background(), "repo")
+			require.Error(t, err)
+			require.True(t, errors.HasType(err, &gitdomain.RevisionNotFoundError{}))
+		})
 	})
 }

--- a/internal/gitserver/commands_test.go
+++ b/internal/gitserver/commands_test.go
@@ -2186,7 +2186,7 @@ func TestClient_ContributorCounts(t *testing.T) {
 func TestClient_FirstEverCommit(t *testing.T) {
 	t.Run("correctly returns server response", func(t *testing.T) {
 
-		expectedCommit := gitdomain.Commit{
+		expectedCommit := &gitdomain.Commit{
 			ID:        "deadbeef",
 			Author:    gitdomain.Signature{Name: "Foo", Email: "foo@bar.com"},
 			Committer: &gitdomain.Signature{Name: "Bar", Email: "bar@bar.com"},

--- a/internal/insights/gitserver/first_commit.go
+++ b/internal/insights/gitserver/first_commit.go
@@ -33,11 +33,7 @@ func isFirstCommitEmptyRepoError(err error) bool {
 }
 
 func GitFirstEverCommit(ctx context.Context, gitserverClient gitserver.Client, repoName api.RepoName) (*gitdomain.Commit, error) {
-	commit, err := gitserverClient.FirstEverCommit(ctx, repoName)
-	if err != nil && isFirstCommitEmptyRepoError(err) {
-		return nil, errors.Wrap(EmptyRepoErr, err.Error())
-	}
-	return commit, err
+	return gitserverClient.FirstEverCommit(ctx, repoName)
 }
 
 func NewCachedGitFirstEverCommit() *CachedGitFirstEverCommit {


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/61689

This PR switches the gitserver client implementation to use the new gRPC FirstCommitEver() method introduced in https://github.com/sourcegraph/sourcegraph/pull/62169 instead of shoving it through the `exec()` endpoint.

## Test plan

Unit tests 