### PR TITLE
Code insights: followup from #62011

### DIFF
--- a/cmd/frontend/internal/inventory/BUILD.bazel
+++ b/cmd/frontend/internal/inventory/BUILD.bazel
@@ -15,7 +15,6 @@ go_library(
         "//lib/errors",
         "@com_github_go_enry_go_enry_v2//:go-enry",
         "@com_github_go_enry_go_enry_v2//data",
-        "@com_github_grafana_regexp//:regexp",
         "@com_github_sourcegraph_conc//iter",
         "@com_github_sourcegraph_log//:log",
         "@io_opentelemetry_go_otel//attribute",
@@ -29,7 +28,6 @@ go_test(
         "inventory_test.go",
     ],
     embed = [":inventory"],
-    race = "off",
     deps = [
         "//internal/fileutil",
         "//lib/errors",

--- a/cmd/frontend/internal/inventory/inventory_test.go
+++ b/cmd/frontend/internal/inventory/inventory_test.go
@@ -65,7 +65,6 @@ func TestGetLang_language(t *testing.T) {
 		t.Run(label, func(t *testing.T) {
 			lang, err := getLang(context.Background(),
 				test.file,
-				make([]byte, fileReadBufferSize),
 				makeFileReader(test.file.Contents))
 			if err != nil {
 				t.Fatal(err)
@@ -130,7 +129,7 @@ func TestGet_readFile(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.file.Name(), func(t *testing.T) {
 			fr := makeFileReader(test.file.(fi).Contents)
-			lang, err := getLang(context.Background(), test.file, make([]byte, fileReadBufferSize), fr)
+			lang, err := getLang(context.Background(), test.file, fr)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -160,12 +159,11 @@ func BenchmarkGetLang(b *testing.B) {
 		b.Fatal(err)
 	}
 	fr := newFileReader(files)
-	buf := make([]byte, fileReadBufferSize)
 	b.Logf("Calling Get on %d files.", len(files))
 	b.ResetTimer()
 	for range b.N {
 		for _, file := range files {
-			_, err = getLang(context.Background(), file, buf, fr)
+			_, err = getLang(context.Background(), file, fr)
 			if err != nil {
 				b.Fatal(err)
 			}
@@ -255,28 +253,4 @@ export function baz(n) {
 	default:
 		return ""
 	}
-}
-
-func TestIsExcluded(t *testing.T) {
-	t.Run("should exclude lock file", func(t *testing.T) {
-		excluded, err := isExcluded("yarn.lock")
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		if !excluded {
-			t.Errorf("expected file to be excluded")
-		}
-	})
-
-	t.Run("should not exclude non-lock file", func(t *testing.T) {
-		excluded, err := isExcluded("hello-world.md")
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		if excluded {
-			t.Errorf("expected file to not be excluded")
-		}
-	})
 }


### PR DESCRIPTION
This is just a couple of followups from #62011 that I had asked for. This is @bahrmichael's branch that I am just pushing up to get reviewed and merged. Consider it reviewed and approved by me, feel free to just stamp.

This:
- Removes the lockfile ignoring logic that was added in #62011 
- Fixes a race condition on a shared buffer by allocating a new buffer for each file

I'm not concerned about the perf of the allocation because it is a fixed-size allocation for each file (we process the file in a streaming manner) and there is already a network request for each file.

## Test plan

Bazel tests pass after re-enabling race detection.