### PR TITLE
sg-binary-release: stamp with GitHub release name

### DIFF
--- a/.github/workflows/sg-binary-release.yml
+++ b/.github/workflows/sg-binary-release.yml
@@ -105,16 +105,19 @@ jobs:
         if: startsWith(matrix.os, 'macos-') == true
         run: |
           cd dev/sg
-          GOARCH=${{ matrix.arch }} go build -o "sg_$(go env GOOS)_${{ matrix.arch }}" -trimpath -ldflags "-s -w -X main.BuildCommit=$(git rev-list -1 HEAD .)" .
+          GOARCH=${{ matrix.arch }} go build -o "sg_$(go env GOOS)_${{ matrix.arch }}" -trimpath \
+            -ldflags "-s -w -X main.BuildCommit=$(git rev-list -1 HEAD .) -X main.ReleaseName=${{ needs.create_release.outputs.release_name }}" .
 
       - name: Build and upload Linux
         if: startsWith(matrix.os, 'ubuntu-') == true
         run: |
           cd dev/sg
-          GOARCH=${{ matrix.arch }} go build -o "sg_$(go env GOOS)_${{ matrix.arch }}" -trimpath -ldflags "-s -w -X main.BuildCommit=$(git rev-list -1 HEAD .)" .
+          GOARCH=${{ matrix.arch }} go build -o "sg_$(go env GOOS)_${{ matrix.arch }}" -trimpath \
+            -ldflags "-s -w -X main.BuildCommit=$(git rev-list -1 HEAD .) -X main.ReleaseName=${{ needs.create_release.outputs.release_name }}" .
 
           # On certain CI agents, the glibc might not be the right one, so we build a static variant
-          CGO_ENABLED=0 GOARCH=${{ matrix.arch }} go build -o "sg_$(go env GOOS)_${{ matrix.arch }}_static" -trimpath -ldflags "-s -w -X main.BuildCommit=$(git rev-list -1 HEAD .)" .
+          CGO_ENABLED=0 GOARCH=${{ matrix.arch }} go build -o "sg_$(go env GOOS)_${{ matrix.arch }}_static" -trimpath \
+            -ldflags "-s -w -X main.BuildCommit=$(git rev-list -1 HEAD .) -X main.ReleaseName=${{ needs.create_release.outputs.release_name }}" .
 
       - name: Upload release asset
         run: |

--- a/dev/sg/main.go
+++ b/dev/sg/main.go
@@ -51,9 +51,13 @@ func main() {
 	}
 }
 
+// Values to be stamped at build time.
 var (
-	BuildCommit = "dev"
+	BuildCommit = "dev"     // git commit hash of build
+	ReleaseName = "unknown" // human-friendlier name for the release, e.g. '2024-04-24-16-44-3623ecb2'
+)
 
+var (
 	// configFile is the path to use with sgconf.Get - it must not be used before flag
 	// initialization.
 	configFile string
@@ -87,7 +91,7 @@ const sgBugReportTemplate = "https://github.com/sourcegraph/sourcegraph/issues/n
 var sg = &cli.App{
 	Usage:       "The Sourcegraph developer tool!",
 	Description: "Learn more: https://sourcegraph.com/docs/dev/background-information/sg",
-	Version:     BuildCommit,
+	Version:     ReleaseName, // use friendly name as version
 	Compiled:    time.Now(),
 	Flags: []cli.Flag{
 		&cli.BoolFlag{
@@ -182,7 +186,7 @@ var sg = &cli.App{
 			}
 
 			// Ensure analytics are persisted
-			interrupt.Register(func() { analytics.Persist(cmd.Context) })
+			interrupt.Register(func() { _ = analytics.Persist(cmd.Context) })
 
 			// Add analytics to each command
 			addAnalyticsHooks([]string{"sg"}, cmd.App.Commands)
@@ -255,7 +259,7 @@ var sg = &cli.App{
 			// Wait for background jobs to finish up, iff not in autocomplete mode
 			background.Wait(cmd.Context, std.Out)
 			// Persist analytics
-			analytics.Persist(cmd.Context)
+			_ = analytics.Persist(cmd.Context)
 		}
 
 		return nil

--- a/dev/sg/sg_doctor.go
+++ b/dev/sg/sg_doctor.go
@@ -90,11 +90,10 @@ func runDoctorDiagnostics(cmd *cli.Context) error {
 	if o.Mode()&os.ModeCharDevice != os.ModeCharDevice {
 		// our output has been redirected to another program, so lets just render it raw
 		fmt.Println(markdown)
-	} else {
-		// rendering to a terminal! so lets make it nice
-		diagOut.WriteMarkdown(markdown)
+		return nil
 	}
-	return nil
+	// rendering to a terminal! so lets make it nice
+	return diagOut.WriteMarkdown(markdown)
 }
 
 func (d *diagnosticRunner) Run(ctx context.Context) DiagnosticReport {
@@ -123,6 +122,7 @@ func buildMarkdownReport(report DiagnosticReport) string {
 	fmt.Fprintf(&sb, "# Diagnostic Report\n\n")
 	// General information
 	fmt.Fprintf(&sb, "sg commit: `%s`\n\n", BuildCommit)
+	fmt.Fprintf(&sb, "sg release: `%s`\n\n", ReleaseName)
 	fmt.Fprintf(&sb, "generated on: `%s`\n\n", time.Now())
 	titleCaser := cases.Title(language.English)
 

--- a/dev/sg/sg_version.go
+++ b/dev/sg/sg_version.go
@@ -48,8 +48,13 @@ var (
 	}
 )
 
-func versionExec(ctx *cli.Context) error {
-	std.Out.Write(BuildCommit)
+func versionExec(c *cli.Context) error {
+	if verbose {
+		std.Out.Writef("Version: %s\nBuild commit: %s",
+			c.App.Version, BuildCommit)
+	} else {
+		std.Out.Write(c.App.Version)
+	}
 	return nil
 }
 
@@ -72,10 +77,10 @@ func changelogExec(ctx *cli.Context) error {
 		current := strings.TrimPrefix(BuildCommit, "dev-")
 		if versionChangelogNext {
 			logArgs = append(logArgs, current+"..origin/main")
-			title = fmt.Sprintf("Changes since sg release %s", BuildCommit)
+			title = fmt.Sprintf("Changes since sg release %s", ReleaseName)
 		} else {
 			logArgs = append(logArgs, current)
-			title = fmt.Sprintf("Changes in sg release %s", BuildCommit)
+			title = fmt.Sprintf("Changes in sg release %s", ReleaseName)
 		}
 	} else {
 		std.Out.WriteWarningf("Dev version detected - just showing recent changes.")


### PR DESCRIPTION
We have nice release names in https://github.com/sourcegraph/sg/releases, but it's not actually programmatically available - this causes a discrepancy between the `sg` version one might pull, and the version of `sg` that is known in-code, and means that we can't do something like #62134.

This change adds a `ReleaseName` variable to be stamped at build/release time, and updates a few references to `BuildCommit` where I think it might be more prudent to report `ReleaseName` instead, and also fixes some yellow squiggles in my IDE on files I visited (sorry) and some noisy `-v` output (sorry again)

## Test plan

```
$ go build -ldflags "-s -w -X main.BuildCommit=$(git rev-list -1 HEAD .) -X main.ReleaseName=hello-world" -o ./sg ./dev/sg                       
$ ./sg version
hello-world
$ ./sg -v version
Version: hello-world
Build commit: b23db0be5ef0f950e2583dbb74883575638911e5
```