### PR TITLE
gitserver: Improve signal handling and maxRSS reporting

### DIFF
--- a/cmd/gitserver/internal/git/gitcli/archivereader_test.go
+++ b/cmd/gitserver/internal/git/gitcli/archivereader_test.go
@@ -179,6 +179,6 @@ func TestGitCLIBackend_ArchiveReader(t *testing.T) {
 		require.Error(t, err)
 		require.True(t, errors.Is(err, context.Canceled), "unexpected error: %v", err)
 
-		require.NoError(t, r.Close())
+		require.True(t, errors.Is(r.Close(), context.Canceled), "unexpected error: %v", err)
 	})
 }

--- a/cmd/gitserver/internal/git/gitcli/blame_test.go
+++ b/cmd/gitserver/internal/git/gitcli/blame_test.go
@@ -119,7 +119,7 @@ func TestGitCLIBackend_Blame(t *testing.T) {
 		require.Error(t, err)
 		require.True(t, errors.Is(err, context.Canceled), "unexpected error: %v", err)
 
-		require.NoError(t, hr.Close())
+		require.True(t, errors.Is(hr.Close(), context.Canceled), "unexpected error: %v", err)
 	})
 
 	t.Run("commit not found", func(t *testing.T) {

--- a/cmd/gitserver/internal/git/gitcli/command.go
+++ b/cmd/gitserver/internal/git/gitcli/command.go
@@ -113,7 +113,29 @@ func (g *gitCLIBackend) NewCommand(ctx context.Context, optFns ...CommandOptionF
 	}
 
 	cmd := exec.CommandContext(ctx, "git", opts.arguments...)
+	cmd.Cancel = func() error {
+		// Send SIGKILL to the process group instead of just the process
+		return syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+	}
 	g.dir.Set(cmd)
+
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	// We use setpgid here so that child processes live in their own process groups.
+	// This is helpful for two things:
+	// - We can kill a process group to make sure that any subprocesses git might spawn
+	//   will also receive the termination signal. The standard go implementation sends
+	//   a SIGKILL only to the process itself. By using process groups, we can tell all
+	//   children to shut down as well.
+	// - We want to track maxRSS for tracking purposes to identify memory usage by command
+	//   and linux tracks the maxRSS as "the maximum resident set size used (in kilobytes)"
+	//   of the process in the process group that had the highest maximum resident set size.
+	//   Read: If we don't use a separate process group here, we usually get the maxRSS from
+	//   the process with the biggest memory usage in the process group, which is gitserver.
+	//   So we cannot track the memory well. This is leaky, as it only tracks the largest sub-
+	//   process, but it gives us a good indication of the general resource consumption.
+	cmd.SysProcAttr.Setpgid = true
 
 	stderr, stderrBuf := stderrBuffer()
 	cmd.Stderr = stderr
@@ -139,19 +161,21 @@ func (g *gitCLIBackend) NewCommand(ctx context.Context, optFns ...CommandOptionF
 
 	execRunning.WithLabelValues(subCmd).Inc()
 
-	return &cmdReader{
-		ctx:        ctx,
-		subCmd:     subCmd,
-		ctxCancel:  cancel,
-		cmdStart:   cmdStart,
-		ReadCloser: stdout,
-		cmd:        wrappedCmd,
-		stderr:     stderrBuf,
-		repoName:   g.repoName,
-		logger:     logger,
-		git:        g,
-		tr:         tr,
-	}, nil
+	cr := &cmdReader{
+		ctx:       ctx,
+		subCmd:    subCmd,
+		ctxCancel: cancel,
+		cmdStart:  cmdStart,
+		stdout:    stdout,
+		cmd:       wrappedCmd,
+		stderr:    stderrBuf,
+		repoName:  g.repoName,
+		logger:    logger,
+		git:       g,
+		tr:        tr,
+	}
+
+	return cr, nil
 }
 
 // ErrBadGitCommand is returned from the git CLI backend if the arguments provided
@@ -187,7 +211,7 @@ func (e *CommandFailedError) Error() string {
 }
 
 type cmdReader struct {
-	io.ReadCloser
+	stdout    io.Reader
 	ctx       context.Context
 	ctxCancel context.CancelFunc
 	subCmd    string
@@ -198,20 +222,20 @@ type cmdReader struct {
 	git       git.GitBackend
 	repoName  api.RepoName
 	mu        sync.Mutex
-	closed    bool
 	tr        trace.Trace
 	err       error
+	waitOnce  sync.Once
 }
 
 func (rc *cmdReader) Read(p []byte) (n int, err error) {
 	rc.mu.Lock()
 	defer rc.mu.Unlock()
 
-	n, err = rc.ReadCloser.Read(p)
+	n, err = rc.stdout.Read(p)
+	// If the command has finished, we close the stdout pipe and wait on the command
+	// to free any leftover resources. If it errored, this will return the command
+	// error from Read.
 	if err == io.EOF {
-		rc.ReadCloser.Close()
-		rc.closed = true
-
 		if err := rc.waitCmd(); err != nil {
 			return n, err
 		}
@@ -223,33 +247,28 @@ func (rc *cmdReader) Close() error {
 	rc.mu.Lock()
 	defer rc.mu.Unlock()
 
-	if rc.closed {
-		return nil
-	}
-
-	// Close the underlying reader.
-	err := rc.ReadCloser.Close()
-
-	// And finalize the command.
-	return errors.Append(err, rc.waitCmd())
+	return rc.waitCmd()
 }
 
-func (rc *cmdReader) waitCmd() (err error) {
-	defer rc.ctxCancel()
+func (rc *cmdReader) waitCmd() error {
+	// Waiting on a command should only happen once, so
+	// we synchronize all potential calls to Read and Close
+	// here, and memoize the error.
+	rc.waitOnce.Do(func() {
+		rc.err = rc.cmd.Wait()
 
-	defer rc.tr.EndWithErr(&err)
-
-	rc.err = rc.cmd.Wait()
-
-	if rc.err != nil {
-		if checkMaybeCorruptRepo(rc.ctx, rc.logger, rc.git, rc.repoName, rc.stderr.String()) {
-			rc.err = common.ErrRepoCorrupted{Reason: rc.stderr.String()}
-		} else {
-			rc.err = commandFailedError(rc.ctx, err, rc.cmd, rc.stderr.Bytes())
+		if rc.err != nil {
+			if checkMaybeCorruptRepo(rc.logger, rc.git, rc.repoName, rc.stderr.String()) {
+				rc.err = common.ErrRepoCorrupted{Reason: rc.stderr.String()}
+			} else {
+				rc.err = commandFailedError(rc.ctx, rc.err, rc.cmd, rc.stderr.Bytes())
+			}
 		}
-	}
 
-	rc.trace()
+		rc.trace()
+		rc.tr.EndWithErr(&rc.err)
+		rc.ctxCancel()
+	})
 
 	return rc.err
 }
@@ -369,7 +388,7 @@ func (l *limitWriter) Write(p []byte) (int, error) {
 	return n, err
 }
 
-func checkMaybeCorruptRepo(ctx context.Context, logger log.Logger, git git.GitBackend, repo api.RepoName, stderr string) bool {
+func checkMaybeCorruptRepo(logger log.Logger, git git.GitBackend, repo api.RepoName, stderr string) bool {
 	if !stdErrIndicatesCorruption(stderr) {
 		return false
 	}
@@ -379,7 +398,9 @@ func checkMaybeCorruptRepo(ctx context.Context, logger log.Logger, git git.GitBa
 
 	// We set a flag in the config for the cleanup janitor job to fix. The janitor
 	// runs every minute.
-	err := git.Config().Set(ctx, gitConfigMaybeCorrupt, strconv.FormatInt(time.Now().Unix(), 10))
+	// We use a background context here to record corruption events even when the
+	// context has since been cancelled.
+	err := git.Config().Set(context.Background(), gitConfigMaybeCorrupt, strconv.FormatInt(time.Now().Unix(), 10))
 	if err != nil {
 		logger.Error("failed to set maybeCorruptRepo config", log.Error(err))
 	}

--- a/cmd/gitserver/internal/git/gitcli/diff_test.go
+++ b/cmd/gitserver/internal/git/gitcli/diff_test.go
@@ -101,6 +101,6 @@ index 0000000000000000000000000000000000000000..8a6a2d098ecaf90105f1cf2fa90fc460
 		require.Error(t, err)
 		require.True(t, errors.Is(err, context.Canceled), "unexpected error: %v", err)
 
-		require.NoError(t, r.Close())
+		require.True(t, errors.Is(r.Close(), context.Canceled), "unexpected error: %v", err)
 	})
 }

--- a/cmd/gitserver/internal/git/gitcli/exec_test.go
+++ b/cmd/gitserver/internal/git/gitcli/exec_test.go
@@ -34,7 +34,7 @@ func TestIsAllowedGitCmd(t *testing.T) {
 		{"commit", "--file=relative/path"},
 	}
 
-	logger := logtest.Scoped(t)
+	logger := logtest.NoOp(t)
 	for _, args := range isAllowed {
 		t.Run("", func(t *testing.T) {
 			if !IsAllowedGitCmd(logger, args, "/fake/path") {
@@ -76,7 +76,7 @@ func TestIsAllowedDiffGitCmd(t *testing.T) {
 		{args: []string{"diff", "a1c0f7d19f6e9eb76facc67c1c22c07bb2ad39c4...c70f79c26526ba74f38ecff2e1e686fc3e2bdcdd"}, pass: true},
 	}
 
-	logger := logtest.Scoped(t)
+	logger := logtest.NoOp(t)
 	for _, cmd := range allowed {
 		t.Run(fmt.Sprintf("%s returns %t", strings.Join(cmd.args, " "), cmd.pass), func(t *testing.T) {
 			assert.Equal(t, cmd.pass, IsAllowedGitCmd(logger, cmd.args, "/foo/baz"))

--- a/cmd/gitserver/internal/git/gitcli/odb_test.go
+++ b/cmd/gitserver/internal/git/gitcli/odb_test.go
@@ -163,6 +163,8 @@ func TestGitCLIBackend_ReadFile_GoroutineLeak(t *testing.T) {
 	// Don't complete reading all the output, instead, bail and close the reader.
 	require.NoError(t, r.Close())
 
+	time.Sleep(time.Millisecond)
+
 	// Expect no leaked routines.
 	routinesAfter := runtime.NumGoroutine()
 	require.Equal(t, routinesBefore, routinesAfter)

--- a/cmd/gitserver/internal/git/gitcli/refs_test.go
+++ b/cmd/gitserver/internal/git/gitcli/refs_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"runtime"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -345,7 +346,7 @@ func TestGitCLIBackend_ListRefs(t *testing.T) {
 		require.Error(t, err)
 		require.True(t, errors.Is(err, context.Canceled), "unexpected error: %v", err)
 
-		require.NoError(t, it.Close())
+		require.True(t, errors.Is(it.Close(), context.Canceled), "unexpected error: %v", err)
 	})
 
 	// For now, we don't want to error for this case.
@@ -398,6 +399,8 @@ func TestGitCLIBackend_ListRefs_GoroutineLeak(t *testing.T) {
 
 	// Don't complete reading all the output, instead, bail and close the reader.
 	require.NoError(t, it.Close())
+
+	time.Sleep(time.Millisecond)
 
 	// Expect no leaked routines.
 	routinesAfter := runtime.NumGoroutine()

--- a/cmd/gitserver/shared/shared.go
+++ b/cmd/gitserver/shared/shared.go
@@ -324,7 +324,7 @@ func recordCommandsOnRepos(repos []string, ignoredGitCommands []string) wrexec.S
 	// we won't record any git commands with these commands since they are considered to be not destructive
 	ignoredGitCommandsMap := collections.NewSet(ignoredGitCommands...)
 
-	return func(ctx context.Context, cmd *exec.Cmd) bool {
+	return func(_ context.Context, cmd *exec.Cmd) bool {
 		base := filepath.Base(cmd.Path)
 		if base != "git" {
 			return false


### PR DESCRIPTION
This PR makes a change to how we spawn git processes, it puts them in separate process groups. This will allow us to track maxRSS reliably, and also lets us handle context cancellations a bit nicer; we can now 
- trigger a SIGTERM first for a more graceful shutdown
- later send a SIGKILL if that doesn't stop the process
- and make sure subprocesses are also always properly killed, by killing the group and not just the parent process

We've done a bit of back and forth here on Slack before on whether this has any other unintended side-effects, but the parent ID is untouched so the worst that could happen is that someone kills the process group where gitserver runs and the git processes aren't properly shut down by that. The pipes will break though so that should propagate quite okay.
In a containerized environment, this will not matter as all children of the init process will be reaped, and they remain children of that.

## Test plan

Integration and E2E tests pass.