### PR TITLE
Bump caddy to fix CVE-2023-45288

### DIFF
--- a/wolfi-images/caddy.lock.json
+++ b/wolfi-images/caddy.lock.json
@@ -603,22 +603,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1n0mN+HXLe/6DSayCL7lyOJrVBMA=",
+        "checksum": "Q1ogVH6vzHzlj2jWVN5DGCCex8d94=",
         "control": {
-          "checksum": "sha1-n0mN+HXLe/6DSayCL7lyOJrVBMA=",
-          "range": "bytes=694-1091"
+          "checksum": "sha1-ogVH6vzHzlj2jWVN5DGCCex8d94=",
+          "range": "bytes=693-1080"
         },
         "data": {
-          "checksum": "sha256-zFLgLLDxIOhRWZ8vWoLO6FfnxrPV5QlQurChfb1vqDg=",
-          "range": "bytes=1092-41640451"
+          "checksum": "sha256-whrhuRmbxESHR76NDrXc6A7xLhleXpILJRlu9BHQOa8=",
+          "range": "bytes=1081-41669142"
         },
         "name": "caddy",
         "signature": {
-          "checksum": "sha1-8sr6tyZMUpd1wRGq0IXcFQqOnK0=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-1JElWFYu+EbZrSTGutNrcZzdXBQ=",
+          "range": "bytes=0-692"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/caddy-2.7.6-r7.apk",
-        "version": "2.7.6-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/caddy-2.7.6-r8.apk",
+        "version": "2.7.6-r8"
       },
       {
         "architecture": "x86_64",


### PR DESCRIPTION
Update caddy version to fix CVE-2023-45288

## Test plan

- CI

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
