### PR TITLE
chore(rel): use wget instead of curl

### DIFF
--- a/release.yaml
+++ b/release.yaml
@@ -5,8 +5,9 @@ meta:
     - '@sourcegraph/release'
 
 requirements:
-  - name: "curl"
-    cmd: "curl --help"
+  # We use wget here, because curl --fail-with-body was introduced in a version ulterior to what we can have on the CI agents.
+  - name: "wget"
+    cmd: "wget --help"
   - name: "Buidkite access token"
     # `write_builds` permission is all that's needed here
     # You also need to ensure you add access to the Sourcegraph organization on Buildkite.
@@ -27,15 +28,15 @@ internal:
         - name: 'buildkite'
           cmd: |
             echo "Triggering build on sourcegraph/sourcegraph with VERSION={{version}} on branch {{git.branch}}"
-            body=$(curl -s --fail-with-body -X POST "https://api.buildkite.com/v2/organizations/sourcegraph/pipelines/sourcegraph/builds" -H "Content-Type: application/json" -H "Authorization: Bearer $BUILDKITE_ACCESS_TOKEN" -d '{
-                "commit": "HEAD",
-                "branch": "{{git.branch}}",
-                "message": "Internal release build for {{version}}",
-                "env": {
-                  "RELEASE_INTERNAL": "true",
-                  "VERSION": "{{tag}}"
-                }
-              }')
+            body=$(wget --content-on-error -O- --header="Content-Type: application/json" --header="Authorization: Bearer $BUILDKITE_ACCESS_TOKEN" --post-data '{
+              "commit": "HEAD",
+              "branch": "{{git.branch}}",
+              "message": "Internal release build for {{version}}",
+              "env": {
+                    "RELEASE_INTERNAL": "true",
+                    "VERSION": "{{tag}}"
+              }
+            }' https://api.buildkite.com/v2/organizations/sourcegraph/pipelines/sourcegraph/builds)
             exit_code=$?
 
             if [ $exit_code != 0 ]; then
@@ -53,11 +54,11 @@ internal:
       - name: 'Register on release registry'
         cmd: |
           echo "Registering internal sourcegraph/sourcegraph {{version}} release on release registry"
-          body=$(curl -s --fail-with-body -X POST "https://releaseregistry.sourcegraph.com/v1/releases" -H "Content-Type: application/json" -H "Authorization: ${RELEASE_REGISTRY_TOKEN}" -d '{
+          body=$(wget --content-on-error -O- --header="Content-Type: application/json" --header="Authorization: ${RELEASE_REGISTRY_TOKEN}" --post-data '{
               "name": "sourcegraph",
               "version": "{{version}}",
               "git_sha": "${COMMIT_SHA}"
-            }')
+            }' "https://releaseregistry.sourcegraph.com/v1/releases")
           exit_code=$?
 
           if [ $exit_code != 0 ]; then
@@ -157,16 +158,16 @@ promoteToPublic:
           # We set DISABLE_ASPECT_WORKFLOWS to true, because the promotion is purely about retagging images
           # and we don't rely on AW at all.
           echo "Triggering build on sourcegraph/sourcegraph with VERSION={{version}} on branch {{git.branch}}"
-          body=$(curl -s --fail-with-body -X POST "https://api.buildkite.com/v2/organizations/sourcegraph/pipelines/sourcegraph/builds" -H "Content-Type: application/json" -H "Authorization: Bearer $BUILDKITE_ACCESS_TOKEN" -d '{
-              "commit": "HEAD",
-              "branch": "{{git.branch}}",
-              "message": "Promoting internal release {{version}} to public",
-              "env": {
-                "DISABLE_ASPECT_WORKFLOWS": "true",
-                "RELEASE_PUBLIC": "true",
-                "VERSION": "{{tag}}"
-              }
-            }')
+          body=$(wget --content-on-error -O- --header="Content-Type: application/json" --header="Authorization: Bearer $BUILDKITE_ACCESS_TOKEN" --post-data '{
+            "commit": "HEAD",
+            "branch": "{{git.branch}}",
+            "message": "Promoting internal release {{version}} to public",
+            "env": {
+              "DISABLE_ASPECT_WORKFLOWS": "true",
+              "RELEASE_PUBLIC": "true",
+              "VERSION": "{{tag}}"
+            }
+          }' "https://api.buildkite.com/v2/organizations/sourcegraph/pipelines/sourcegraph/builds")
           exit_code=$?
 
           if [ $exit_code != 0 ]; then
@@ -184,7 +185,7 @@ promoteToPublic:
       - name: 'Promote on release registry'
         cmd: |
           echo "Promoting sourcegraph/sourcegraph {{version}} release on release registry"
-            body=$(curl -s --fail-with-body -X POST "https://releaseregistry.sourcegraph.com/v1/releases/sourcegraph/{{version}}/promote" -H "Content-Type: application/json" -H "Authorization: ${RELEASE_REGISTRY_TOKEN}")
+            body=$(wget --content-on-error -O- --header="Content-Type: application/json" --header="Authorization: ${RELEASE_REGISTRY_TOKEN}" --post-data '' "https://releaseregistry.sourcegraph.com/v1/releases/sourcegraph/{{version}}/promote")
             exit_code=$?
 
             if [ $exit_code != 0 ]; then
@@ -249,10 +250,10 @@ promoteToPublic:
           echo "Posting slack notification for release"
           tag="{{tag}}"
           changelog_version="${tag//./}"
-          body=$(curl -s --fail-with-body -X POST "$SLACK_WEBHOOK_URL" -H "Content-Type: application/json" -d '{
-            "type": "mrkdwn"
+          body=$(wget --content-on-error -O- --header="Content-Type: application/json" --post-data '{
+            "type": "mrkdwn",
             "text": "*Sourcegraph {{tag}} has been published*\n\n• <https://sourcegraph.com/docs/CHANGELOG#${changelog_version} | Changelog>\n• <https://github.com/sourcegraph/sourcegraph/releases/tag/{{version}} | GitHub release>"
-          }')
+          }' "$SLACK_WEBHOOK_URL")
           exit_code=$?
 
           if [ $exit_code != 0 ]; then


### PR DESCRIPTION
After dabbling with various options to handle the missing `curl --fail-with-body` flag because the curl version that supports that older than what we have in CI, I couldn't let go of this feature, because it's so damn useful when trying to understand what went wrong. 

There are some ways to tame `curl` in doing that in earlier versions, but frankly, it's quite complicated and involves non trivial piping and toying with the output, which is really not what we want for the release manifests. 

I discovered that `wget` has what we want, and tested that on our agents, `wget` has those, so we're good. 

## Test plan

![CleanShot 2024-04-25 at 16 23 05@2x](https://github.com/sourcegraph/sourcegraph/assets/10151/c744bcb0-da7e-4781-b747-ab7f82d15c5b)


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
