### PR TITLE
Svelte: fix resubmit query

### DIFF
--- a/client/web-sveltekit/src/lib/search/input/SearchInput.svelte
+++ b/client/web-sveltekit/src/lib/search/input/SearchInput.svelte
@@ -180,10 +180,11 @@
     }
 
     async function submitQuery(state: QueryState): Promise<void> {
+        const url = getQueryURL(state)
         // This ensures that the same query can be resubmitted from the search input. Without
         // this, SvelteKit will not re-run the loader because the URL hasn't changed.
-        await invalidate(`query:${state.query}--${state.caseSensitive}`)
-        void goto(getQueryURL(state))
+        await invalidate(`search:${url}`)
+        void goto(url)
     }
 
     async function handleSubmit(event: Event) {

--- a/client/web-sveltekit/src/routes/search/+page.ts
+++ b/client/web-sveltekit/src/routes/search/+page.ts
@@ -84,7 +84,6 @@ const streamManager = browser ? new CachingStreamManager() : new NonCachingStrea
 
 export const load: PageLoad = ({ url, depends }) => {
     const hasQuery = url.searchParams.has('q')
-    const caseSensitiveURL = url.searchParams.get('case') === 'yes'
     const cachePolicy = getCachePolicyFromURL(url)
     const trace = url.searchParams.get('trace') ?? undefined
 
@@ -97,9 +96,7 @@ export const load: PageLoad = ({ url, depends }) => {
             caseSensitive,
             filters: queryFilters,
         } = parsedQuery
-        // Necessary for allowing to submit the same query again
-        // FIXME: This is not correct
-        depends(`query:${query}--${caseSensitiveURL}`)
+        depends(`search:${url}`)
 
         let searchContext = 'global'
         if (filterExists(query, FilterType.context)) {


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/61636

## Test plan

Manually tested that hitting enter in the query bar re-submits the query. Verified that the only request made is a search request and `EditTemporarySettings`, which seems to be run after ever search request for reasons unbeknownst to me.