### PR TITLE
Svelte: add no newline extension

### DIFF
--- a/client/web-sveltekit/src/lib/CodeMirrorBlob.svelte
+++ b/client/web-sveltekit/src/lib/CodeMirrorBlob.svelte
@@ -104,6 +104,7 @@
         }),
         defaultTheme,
         linkify,
+        hideEmptyLastLine,
     ]
 </script>
 
@@ -132,6 +133,7 @@
         type BlameHunkData,
         lockFirstVisibleLine,
         temporaryTooltip,
+        hideEmptyLastLine,
     } from '$lib/web'
 
     import BlameDecoration from './blame/BlameDecoration.svelte'

--- a/client/web-sveltekit/src/lib/web.ts
+++ b/client/web-sveltekit/src/lib/web.ts
@@ -29,6 +29,7 @@ export {
     type SelectedLineRange,
     setSelectedLines,
 } from '@sourcegraph/web/src/repo/blob/codemirror/linenumbers'
+export { hideEmptyLastLine } from '@sourcegraph/web/src/repo/blob/codemirror/eof'
 export { isValidLineRange } from '@sourcegraph/web/src/repo/blob/codemirror/utils'
 export { blobPropsFacet } from '@sourcegraph/web/src/repo/blob/codemirror'
 export { defaultSearchModeFromSettings, defaultPatternTypeFromSettings } from '@sourcegraph/web/src/util/settings'


### PR DESCRIPTION
This adds the "no newline at end of file" extension, which makes it so we do not incorrectly show an extra line at the end of the file when there is a trailing newline and adds a message if there is no trailing newline.

## Test plan

![screenshot-2024-04-25_13-01-39@2x](https://github.com/sourcegraph/sourcegraph/assets/12631702/3da3687a-86d1-4f61-8c82-ca689f74e92d)