### PR TITLE
svelte: First iteration of history panel/diff view redesign

### DIFF
--- a/client/common/src/util/url.ts
+++ b/client/common/src/util/url.ts
@@ -379,8 +379,10 @@ export class SourcegraphURL {
     /**
      * Removes a search parameter from the URL.
      */
-    public deleteSearchParameter(key: string): this {
-        this.url.searchParams.delete(key)
+    public deleteSearchParameter(...keys: string[]): this {
+        for (const key of keys) {
+            this.url.searchParams.delete(key)
+        }
         return this
     }
 

--- a/client/web-sveltekit/src/lib/TabPanel.svelte
+++ b/client/web-sveltekit/src/lib/TabPanel.svelte
@@ -5,6 +5,10 @@
     import { type TabsContext, KEY } from './Tabs.svelte'
 
     export let title: string
+    /**
+     * SVG path for the icon to display in the tab header.
+     */
+    export let icon: string | undefined = undefined
 
     const context = getContext<TabsContext>(KEY)
     const id = uuid.v4()
@@ -13,6 +17,7 @@
         context.register({
             id: tabId,
             title,
+            icon,
         })
     )
     $: selectedId = context.selectedTabID

--- a/client/web-sveltekit/src/lib/Tabs.svelte
+++ b/client/web-sveltekit/src/lib/Tabs.svelte
@@ -18,6 +18,7 @@
     import { createEventDispatcher, setContext } from 'svelte'
     import { derived, writable, type Readable, type Writable, type Unsubscriber } from 'svelte/store'
     import * as uuid from 'uuid'
+
     import Icon from './Icon.svelte'
 
     /**
@@ -54,7 +55,7 @@
     })
 
     function selectTab(event: MouseEvent) {
-        const index = (event.target as HTMLElement).id.match(/\d+$/)?.[0]
+        const index = (event.target as HTMLElement).closest('[role="tab"]')?.id.match(/\d+$/)?.[0]
         if (index) {
             $selectedTab = $selectedTab === +index && toggable ? null : +index
             dispatch('select', $selectedTab)
@@ -72,9 +73,10 @@
                 tabindex={$selectedTab === index ? 0 : -1}
                 role="tab"
                 on:click={selectTab}
-                data-tab-title={tab.title}
                 data-tab
-                >{#if tab.icon}<Icon svgPath={tab.icon} aria-hidden inline /> {/if}{tab.title}</button
+                >{#if tab.icon}<Icon svgPath={tab.icon} aria-hidden inline /> {/if}<span data-tab-title={tab.title}
+                    >{tab.title}</span
+                ></button
             >
         {/each}
     </div>
@@ -89,41 +91,46 @@
     }
 
     .tabs-header {
+        --icon-fill-color: var(--header-icon-color);
+
         display: flex;
+        align-items: stretch;
         justify-content: var(--align-tabs, center);
         gap: var(--tabs-gap, 0);
     }
 
-    button {
+    [role='tab'] {
+        all: unset;
+
         cursor: pointer;
-        border: none;
-        background: none;
-        letter-spacing: normal;
-        margin: 0;
-        min-height: 2rem;
-        padding: 0.5rem;
-        border-radius: 0.125rem;
-        color: var(--body-color);
-        text-transform: none;
+        color: var(--text-body);
+        padding: 0.5rem 0.75rem;
         white-space: nowrap;
+
         border-bottom: 2px solid transparent;
 
-        &[aria-selected='true'],
-        &:hover {
-            color: var(--body-color);
-            background-color: var(--color-bg-2);
-        }
-
         &[aria-selected='true'] {
-            font-weight: 500;
+            border-color: var(--brand-secondary);
+            font-weight: 700;
+            color: var(--text-title);
         }
 
-        &::before {
-            content: attr(data-tab-title);
-            display: block;
-            font-weight: 500;
-            height: 0;
-            visibility: hidden;
+        &:hover {
+            border-color: var(--border-color-2);
+        }
+
+        span {
+            display: inline-block;
+
+            // Hidden rendering of the bold tab title to prevent
+            // shifting when the tab is selected.
+            &::before {
+                content: attr(data-tab-title);
+                display: block;
+                font-weight: 700;
+                height: 0;
+                visibility: hidden;
+            }
         }
     }
 </style>

--- a/client/web-sveltekit/src/lib/Tabs.svelte
+++ b/client/web-sveltekit/src/lib/Tabs.svelte
@@ -2,6 +2,7 @@
     export interface Tab {
         id: string
         title: string
+        icon?: string
     }
 
     export interface TabsContext {
@@ -17,6 +18,7 @@
     import { createEventDispatcher, setContext } from 'svelte'
     import { derived, writable, type Readable, type Writable, type Unsubscriber } from 'svelte/store'
     import * as uuid from 'uuid'
+    import Icon from './Icon.svelte'
 
     /**
      * The index of the tab that should be selected by default.
@@ -71,7 +73,8 @@
                 role="tab"
                 on:click={selectTab}
                 data-tab-title={tab.title}
-                data-tab>{tab.title}</button
+                data-tab
+                >{#if tab.icon}<Icon svgPath={tab.icon} aria-hidden inline /> {/if}{tab.title}</button
             >
         {/each}
     </div>
@@ -95,7 +98,6 @@
         cursor: pointer;
         border: none;
         background: none;
-        align-items: center;
         letter-spacing: normal;
         margin: 0;
         min-height: 2rem;
@@ -103,9 +105,6 @@
         border-radius: 0.125rem;
         color: var(--body-color);
         text-transform: none;
-        display: inline-flex;
-        flex-direction: column;
-        justify-content: center;
         white-space: nowrap;
         border-bottom: 2px solid transparent;
 

--- a/client/web-sveltekit/src/lib/Tabs.svelte
+++ b/client/web-sveltekit/src/lib/Tabs.svelte
@@ -109,14 +109,18 @@
 
         border-bottom: 2px solid transparent;
 
+        &:hover {
+            border-color: var(--border-color-2);
+        }
+
         &[aria-selected='true'] {
             border-color: var(--brand-secondary);
             font-weight: 700;
             color: var(--text-title);
-        }
 
-        &:hover {
-            border-color: var(--border-color-2);
+            &:hover {
+                border-color: var(--brand-secondary);
+            }
         }
 
         span {

--- a/client/web-sveltekit/src/lib/actions.ts
+++ b/client/web-sveltekit/src/lib/actions.ts
@@ -1,7 +1,0 @@
-import type { Action } from 'svelte/action'
-
-export const scrollIntoView: Action<HTMLElement, boolean> = (node: HTMLElement, scroll: boolean) => {
-    if (scroll) {
-        setTimeout(() => node.scrollIntoView({ block: 'center' }), 0)
-    }
-}

--- a/client/web-sveltekit/src/lib/dom.ts
+++ b/client/web-sveltekit/src/lib/dom.ts
@@ -409,3 +409,15 @@ export const overflow: Action<HTMLElement, { class: string; measureClass?: strin
         },
     }
 }
+
+/**
+ * This action scrolls the associated element into view when it is mounted and the argument is true.
+ *
+ * @param node The element to scroll into view.
+ * @param scroll Whether to scroll the element into view.
+ */
+export const scrollIntoViewOnMount: Action<HTMLElement, boolean> = (node: HTMLElement, scroll: boolean) => {
+    if (scroll) {
+        window.requestAnimationFrame(() => node.scrollIntoView({ block: 'center' }))
+    }
+}

--- a/client/web-sveltekit/src/lib/repo/FileDiff.svelte
+++ b/client/web-sveltekit/src/lib/repo/FileDiff.svelte
@@ -57,7 +57,9 @@
     {/if}
 </div>
 {#if !isBinary && expanded}
-    <FileDiffHunks hunks={fileDiff.hunks} />
+    <div class="hunks">
+        <FileDiffHunks hunks={fileDiff.hunks} />
+    </div>
 {/if}
 
 <style lang="scss">
@@ -69,6 +71,11 @@
 
     .file-link {
         margin-left: 0.5rem;
+    }
+
+    .hunks {
+        border-radius: var(--border-radius);
+        border: 1px solid var(--border-color);
     }
 
     button {

--- a/client/web-sveltekit/src/lib/repo/FileDiffHunks.svelte
+++ b/client/web-sveltekit/src/lib/repo/FileDiffHunks.svelte
@@ -19,8 +19,7 @@
         <tbody>
             {#each hunks as hunk (hunk.oldRange.startLine)}
                 <tr>
-                    <td colspan="2" />
-                    <td class="content">
+                    <td class="header" colspan="3">
                         @@ -{hunk.oldRange.startLine},{hunk.oldRange.lines} +{hunk.newRange.startLine},{hunk.newRange
                             .lines}
                         {#if hunk.section}
@@ -53,8 +52,6 @@
     table {
         width: 100%;
         border-collapse: collapse;
-        border-radius: var(--border-radius);
-        border: 1px solid var(--border-color);
     }
 
     tr {
@@ -80,23 +77,29 @@
             text-align: right;
             -webkit-user-select: none;
             user-select: none;
-            vertical-align: top !important;
+            vertical-align: top;
             padding: 0 0.5rem;
+            color: var(--text-muted);
+        }
+
+        &.header {
+            white-space: pre-wrap;
+            background-color: var(--color-bg-2);
+            color: var(--body-color);
+            padding: 0.25rem 1rem;
         }
 
         &.content {
-            padding-left: 0.5rem;
-            padding-right: 0.5rem;
             white-space: pre-wrap;
-            color: var(--body-color);
 
-            & > :global(*) {
-                display: inline-block;
+            > :global(*) {
+                display: inline;
             }
 
             &::before {
                 padding-right: 0.5rem;
                 content: attr(data-diff-marker);
+                color: var(--text-muted);
             }
         }
     }

--- a/client/web-sveltekit/src/lib/repo/FileHeader.svelte
+++ b/client/web-sveltekit/src/lib/repo/FileHeader.svelte
@@ -26,7 +26,6 @@
             index < all.length - 1 || type === 'tree' ? TREE_ROUTE_ID : BLOB_ROUTE_ID,
             {
                 repo: revision ? `${repoName}@${revision}` : repoName,
-                validrev: revision,
                 path: all.slice(0, index + 1).join('/'),
             }
         ),

--- a/client/web-sveltekit/src/lib/repo/FileTable.svelte
+++ b/client/web-sveltekit/src/lib/repo/FileTable.svelte
@@ -3,7 +3,7 @@
 
     import Icon from '$lib/Icon.svelte'
     import type { TreeEntryWithCommitInfo } from './FileTable.gql'
-    import { replaceRevisionInURL } from '$lib/web'
+    import { replaceRevisionInURL } from '$lib/shared'
     import Timestamp from '$lib/Timestamp.svelte'
     import type { TreeEntryFields } from './api/tree'
 

--- a/client/web-sveltekit/src/lib/repo/HistoryPanel.gql
+++ b/client/web-sveltekit/src/lib/repo/HistoryPanel.gql
@@ -1,6 +1,7 @@
 fragment HistoryPanel_HistoryConnection on GitCommitConnection {
     nodes {
         id
+        oid
         abbreviatedOID
         subject
         author {

--- a/client/web-sveltekit/src/lib/repo/HistoryPanel.svelte
+++ b/client/web-sveltekit/src/lib/repo/HistoryPanel.svelte
@@ -9,13 +9,14 @@
     import { tick } from 'svelte'
 
     import { page } from '$app/stores'
-    import { scrollIntoView } from '$lib/actions'
+    import { scrollIntoViewOnMount } from '$lib/dom'
     import Avatar from '$lib/Avatar.svelte'
     import Icon from '$lib/Icon.svelte'
     import LoadingSpinner from '$lib/LoadingSpinner.svelte'
     import Scroller, { type Capture as ScrollerCapture } from '$lib/Scroller.svelte'
     import Timestamp from '$lib/Timestamp.svelte'
     import Tooltip from '$lib/Tooltip.svelte'
+    import { Badge } from '$lib/wildcard'
 
     import type { HistoryPanel_HistoryConnection } from './HistoryPanel.gql'
 
@@ -59,7 +60,8 @@
         selectedRev &&
         history &&
         history.nodes.length > 0 &&
-        !history.nodes.some(commit => commit.abbreviatedOID === selectedRev)
+        !history.nodes.some(commit => commit.abbreviatedOID === selectedRev) &&
+        history.pageInfo.hasNextPage
     ) {
         loadMore()
     }
@@ -73,10 +75,9 @@
         <table>
             {#each history.nodes as commit (commit.id)}
                 {@const selected = commit.abbreviatedOID === selectedRev}
-                <tr class:selected use:scrollIntoView={selected}>
+                <tr class:selected use:scrollIntoViewOnMount={selected}>
                     <td>
-                        <Avatar avatar={commit.author.person} />&nbsp;
-                        {commit.author.person.displayName}
+                        <Badge variant="link"><a href={commit.canonicalURL}>{commit.abbreviatedOID}</a></Badge>
                     </td>
                     <td class="subject">
                         {#if enableInlineDiffs}
@@ -85,15 +86,18 @@
                             {commit.subject}
                         {/if}
                     </td>
-                    <td><Timestamp date={new Date(commit.author.date)} strict /></td>
-                    <td><a href={commit.canonicalURL}>{commit.abbreviatedOID}</a></td>
                     <td>
-                        {#if selected}
+                        <Avatar avatar={commit.author.person} />&nbsp;
+                        {commit.author.person.displayName}
+                    </td>
+                    <td><Timestamp date={new Date(commit.author.date)} strict /></td>
+                    {#if selected}
+                        <td>
                             <Tooltip tooltip="Hide comparison">
                                 <a href={clearURL}><Icon svgPath={mdiClose} inline /></a>
                             </Tooltip>
-                        {/if}
-                    </td>
+                        </td>
+                    {/if}
                 </tr>
             {/each}
         </table>
@@ -110,7 +114,7 @@
     }
 
     td {
-        padding: 0.25rem;
+        padding: 0.5rem 1rem;
         white-space: nowrap;
 
         &.subject {
@@ -122,7 +126,7 @@
         border-bottom: 1px solid var(--border-color);
 
         &.selected {
-            background-color: var(--color-bg-2);
+            background-color: var(--color-bg-3);
         }
     }
 </style>

--- a/client/web-sveltekit/src/lib/repo/HistoryPanel.svelte
+++ b/client/web-sveltekit/src/lib/repo/HistoryPanel.svelte
@@ -120,6 +120,10 @@
         padding: 0.5rem 1rem;
         white-space: nowrap;
 
+        :global([data-avatar]) {
+            vertical-align: middle;
+        }
+
         &.subject {
             white-space: normal;
         }

--- a/client/web-sveltekit/src/lib/repo/Permalink.svelte
+++ b/client/web-sveltekit/src/lib/repo/Permalink.svelte
@@ -7,8 +7,8 @@
 
     import { page } from '$app/stores'
     import Icon from '$lib/Icon.svelte'
+    import { replaceRevisionInURL } from '$lib/shared'
     import Tooltip from '$lib/Tooltip.svelte'
-    import { replaceRevisionInURL } from '$lib/web'
 
     export let commitID: string
 

--- a/client/web-sveltekit/src/lib/repo/blob.ts
+++ b/client/web-sveltekit/src/lib/repo/blob.ts
@@ -1,7 +1,5 @@
 import type { EditorView } from '@codemirror/view'
-import { Subject, from, of } from 'rxjs'
-import { switchMap, map, startWith, catchError } from 'rxjs/operators'
-import { get, type Readable, readable } from 'svelte/store'
+import { get } from 'svelte/store'
 
 import { goto as svelteGoto } from '$app/navigation'
 import { page } from '$app/stores'
@@ -14,8 +12,6 @@ import {
     locationToURL,
     type DocumentInfo,
 } from '$lib/web'
-
-import type { BlobPage_Blob } from '../../routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/page.gql'
 
 /**
  * The minimum number of milliseconds that must elapse before we handle a "Go to
@@ -117,82 +113,5 @@ export function openImplementations(
     const offset = positionToOffset(view.state.doc, occurrence.range.start)
     if (offset) {
         showTemporaryTooltip(view, 'Not supported yet: Find implementations', offset, 2000)
-    }
-}
-
-interface CombinedBlobData {
-    blob: BlobPage_Blob | null
-    /**
-     * JSON encoded highlighting information. Can be an empty string.
-     */
-    highlights: string
-    blobPending: boolean
-    highlightsPending: boolean
-    blobError: Error | null
-    highlightsError: Error | null
-}
-
-interface BlobDataHandler extends Readable<CombinedBlobData> {
-    set(blob: PromiseLike<BlobPage_Blob | null>, highlight: PromiseLike<string | undefined>): void
-}
-
-/**
- * This store synchronizes the state of the blob data and the highlights. While new blob data is
- * loading, the old blob and highlights data is still available. Once the blob data is loaded, the
- * highlights are updated.
- */
-export function createBlobDataHandler(): BlobDataHandler {
-    const input = new Subject<{ blob: PromiseLike<BlobPage_Blob | null>; highlight: PromiseLike<string | undefined> }>()
-
-    return {
-        ...readable<CombinedBlobData>(
-            {
-                blob: null,
-                highlights: '',
-                blobPending: false,
-                highlightsPending: false,
-                blobError: null,
-                highlightsError: null,
-            },
-            (_set, update) => {
-                const subscription = input
-                    .pipe(
-                        switchMap(({ blob, highlight }) => {
-                            return from(blob).pipe(
-                                switchMap(blob => {
-                                    return from(highlight).pipe(
-                                        map((highlights = '') => ({
-                                            highlights,
-                                            highlightsPending: false,
-                                            highlightsError: null,
-                                        })),
-                                        startWith({
-                                            blob,
-                                            blobPending: false,
-                                            blobError: null,
-                                            highlights: '',
-                                            highlightsPending: true,
-                                            highlightsError: null,
-                                        }),
-                                        catchError(error =>
-                                            of({ highlights: '', highlightsPending: false, highlightsError: error })
-                                        )
-                                    )
-                                }),
-                                startWith({ blobPending: true }),
-                                catchError(error => of({ blob: null, blobPending: false, blobError: error }))
-                            )
-                        })
-                    )
-                    .subscribe(updatedCombinedData => {
-                        update(combinedData => ({ ...combinedData, ...updatedCombinedData }))
-                    })
-                return () => subscription.unsubscribe()
-            }
-        ),
-
-        set(blob, highlight) {
-            input.next({ blob, highlight })
-        },
     }
 }

--- a/client/web-sveltekit/src/lib/shared.ts
+++ b/client/web-sveltekit/src/lib/shared.ts
@@ -7,6 +7,7 @@ export {
     toPrettyBlobURL,
     toRepoURL,
     type AbsoluteRepoFile,
+    replaceRevisionInURL,
 } from '@sourcegraph/shared/src/util/url'
 export {
     isCloneInProgressErrorLike,

--- a/client/web-sveltekit/src/lib/utils/assert.ts
+++ b/client/web-sveltekit/src/lib/utils/assert.ts
@@ -1,0 +1,5 @@
+export function assertNonNullable<T>(value: T | null | undefined, message: string): asserts value is T {
+    if (value === null || value === undefined) {
+        throw new Error(message)
+    }
+}

--- a/client/web-sveltekit/src/lib/utils/index.ts
+++ b/client/web-sveltekit/src/lib/utils/index.ts
@@ -1,3 +1,4 @@
+export * from './assert'
+export * from './formatting'
 export * from './promises'
 export * from './stores'
-export * from './formatting'

--- a/client/web-sveltekit/src/lib/utils/promises.ts
+++ b/client/web-sveltekit/src/lib/utils/promises.ts
@@ -28,9 +28,9 @@ interface ResultPending<T, E> {
     pending: true
 }
 
-type Result<T, E = Error> = ResultSuccess<T> | ResultError<E> | ResultPending<T, E>
+export type Loadable<T, E = Error> = ResultSuccess<T> | ResultError<E> | ResultPending<T, E>
 
-interface PromiseStore<D, E = Error> extends Readable<Result<D | null, E>> {
+interface PromiseStore<D, E = Error> extends Readable<Loadable<D | null, E>> {
     /**
      * Sets the passed promise as the current promise and tracks its status.
      * Does nothing if the same promise as the current one is passed. The argument
@@ -46,7 +46,7 @@ interface PromiseStore<D, E = Error> extends Readable<Result<D | null, E>> {
 export function createPromiseStore<D, E = Error>(): PromiseStore<D, E> {
     let currentPromise: PromiseLike<D> | null | undefined
 
-    const resultStore = writable<Result<D | null, E>>({ value: null, error: null, pending: true })
+    const resultStore = writable<Loadable<D | null, E>>({ value: null, error: null, pending: true })
 
     function resolve(promise?: PromiseLike<D> | null) {
         currentPromise = promise
@@ -85,15 +85,15 @@ export function createPromiseStore<D, E = Error>(): PromiseStore<D, E> {
 /**
  * Returns a store that publishes updates when the promise is resolved or rejected.
  */
-export function toReadable<D, E = Error>(promise: PromiseLike<D>): Readable<Result<D, E>> {
-    const resultStore = writable<Result<D, E>>({ value: null, error: null, pending: true })
+export function toReadable<D, E = Error>(promise: PromiseLike<D>): Readable<Loadable<D, E>> {
+    const { subscribe, set } = writable<Loadable<D, E>>({ value: null, error: null, pending: true })
     promise.then(
         result => {
-            resultStore.set({ value: result, error: null, pending: false })
+            set({ value: result, error: null, pending: false })
         },
         error => {
-            resultStore.set({ value: null, error: error, pending: false })
+            set({ value: null, error: error, pending: false })
         }
     )
-    return resultStore
+    return { subscribe }
 }

--- a/client/web-sveltekit/src/lib/web.ts
+++ b/client/web-sveltekit/src/lib/web.ts
@@ -3,7 +3,6 @@
 
 export { parseSearchURL, type ParsedSearchURL } from '@sourcegraph/web/src/search/index'
 export { createSuggestionsSource } from '@sourcegraph/web/src/search/input/suggestions'
-export { replaceRevisionInURL } from '@sourcegraph/web/src/util/url'
 
 export { syntaxHighlight } from '@sourcegraph/web/src/repo/blob/codemirror/highlight'
 export { linkify } from '@sourcegraph/web/src/repo/blob/codemirror/links'

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/+layout.ts
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/+layout.ts
@@ -2,7 +2,7 @@ import { dirname } from 'path'
 
 import { from } from 'rxjs'
 
-import { SourcegraphURL } from '$lib/common'
+import type { LineOrPositionOrRange } from '$lib/common'
 import { getGraphQLClient, infinityQuery, mapOrThrow } from '$lib/graphql'
 import { GitRefType } from '$lib/graphql-types'
 import { fetchSidebarFileTree } from '$lib/repo/api/tree'
@@ -21,14 +21,11 @@ import {
 const HISTORY_COMMITS_PER_PAGE = 20
 const REFERENCES_PER_PAGE = 20
 
-export const load: LayoutLoad = async ({ parent, params, url }) => {
+export const load: LayoutLoad = async ({ parent, params }) => {
     const client = getGraphQLClient()
     const { repoName, revision = '' } = parseRepoRevision(params.repo)
     const parentPath = params.path ? dirname(params.path) : ''
     const resolvedRevision = resolveRevision(parent, revision)
-    const sgURL = SourcegraphURL.from(url)
-    const lineOrPosition = sgURL.lineRange
-    const view = sgURL.viewState
 
     // Prefetch the sidebar file tree for the parent path.
     // (we don't want to wait for the file tree to execute the query)
@@ -96,66 +93,63 @@ export const load: LayoutLoad = async ({ parent, params, url }) => {
             },
         }),
 
-        references:
-            view === 'references' && lineOrPosition?.line && lineOrPosition?.character
-                ? infinityQuery({
-                      client,
-                      query: RepoPage_PreciseCodeIntel,
-                      variables: from(
-                          resolvedRevision.then(revspec => ({
-                              repoName,
-                              revspec,
-                              filePath: params.path ?? '',
-                              first: REFERENCES_PER_PAGE,
-                              // Line and character are 1-indexed, but the API expects 0-indexed
-                              line: lineOrPosition.line - 1,
-                              character: lineOrPosition.character! - 1,
-                              afterCursor: null as string | null,
-                          }))
-                      ),
-                      nextVariables: previousResult => {
-                          if (previousResult?.data?.repository?.commit?.blob?.lsif?.references.pageInfo.hasNextPage) {
-                              return {
-                                  afterCursor:
-                                      previousResult.data.repository.commit.blob.lsif.references.pageInfo.endCursor,
-                              }
-                          }
-                          return undefined
-                      },
-                      combine: (previousResult, nextResult) => {
-                          if (!nextResult.data?.repository?.commit?.blob?.lsif) {
-                              return nextResult
-                          }
+        // We are not extracting the selected position from the URL because that creates a dependency
+        // on the full URL, which causes this loader to be re-executed on every URL change.
+        getReferenceStore: (lineOrPosition: LineOrPositionOrRange & { line: number }) =>
+            infinityQuery({
+                client,
+                query: RepoPage_PreciseCodeIntel,
+                variables: from(
+                    resolvedRevision.then(revspec => ({
+                        repoName,
+                        revspec,
+                        filePath: params.path ?? '',
+                        first: REFERENCES_PER_PAGE,
+                        // Line and character are 1-indexed, but the API expects 0-indexed
+                        line: lineOrPosition.line - 1,
+                        character: lineOrPosition.character! - 1,
+                        afterCursor: null as string | null,
+                    }))
+                ),
+                nextVariables: previousResult => {
+                    if (previousResult?.data?.repository?.commit?.blob?.lsif?.references.pageInfo.hasNextPage) {
+                        return {
+                            afterCursor: previousResult.data.repository.commit.blob.lsif.references.pageInfo.endCursor,
+                        }
+                    }
+                    return undefined
+                },
+                combine: (previousResult, nextResult) => {
+                    if (!nextResult.data?.repository?.commit?.blob?.lsif) {
+                        return nextResult
+                    }
 
-                          const previousNodes =
-                              previousResult.data?.repository?.commit?.blob?.lsif?.references?.nodes ?? []
-                          const nextNodes = nextResult.data?.repository?.commit?.blob?.lsif?.references?.nodes ?? []
+                    const previousNodes = previousResult.data?.repository?.commit?.blob?.lsif?.references?.nodes ?? []
+                    const nextNodes = nextResult.data?.repository?.commit?.blob?.lsif?.references?.nodes ?? []
 
-                          return {
-                              ...nextResult,
-                              data: {
-                                  repository: {
-                                      ...nextResult.data.repository,
-                                      commit: {
-                                          ...nextResult.data.repository.commit,
-                                          blob: {
-                                              ...nextResult.data.repository.commit.blob,
-                                              lsif: {
-                                                  ...nextResult.data.repository.commit.blob.lsif,
-                                                  references: {
-                                                      ...nextResult.data.repository.commit.blob.lsif.references,
-                                                      nodes: [...previousNodes, ...nextNodes],
-                                                  },
-                                              },
-                                          },
-                                      },
-                                  },
-                              },
-                          }
-                      },
-                  })
-                : null,
-
+                    return {
+                        ...nextResult,
+                        data: {
+                            repository: {
+                                ...nextResult.data.repository,
+                                commit: {
+                                    ...nextResult.data.repository.commit,
+                                    blob: {
+                                        ...nextResult.data.repository.commit.blob,
+                                        lsif: {
+                                            ...nextResult.data.repository.commit.blob.lsif,
+                                            references: {
+                                                ...nextResult.data.repository.commit.blob.lsif.references,
+                                                nodes: [...previousNodes, ...nextNodes],
+                                            },
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                    }
+                },
+            }),
         // Repository pickers queries (branch, tags and commits)
         getRepoBranches: (searchTerm: string) =>
             getGraphQLClient()

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/+page.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/+page.svelte
@@ -3,7 +3,7 @@
 <script lang="ts">
     import { onMount } from 'svelte'
 
-    import { SVELTE_LOGGER, SVELTE_TELEMETRY_EVENTS, codeCopiedEvent } from '$lib/telemetry'
+    import { SVELTE_LOGGER, SVELTE_TELEMETRY_EVENTS } from '$lib/telemetry'
 
     import type { PageData, Snapshot } from './$types'
     import DiffView from './DiffView.svelte'
@@ -43,5 +43,9 @@
 {#if data.type === 'DiffView'}
     <DiffView {data} />
 {:else}
-    <FileView bind:this={fileView} {data} {embedded} {disableCodeIntel} />
+    <FileView bind:this={fileView} {data} {embedded} {disableCodeIntel}>
+        <svelte:fragment slot="actions">
+            <slot name="actions" />
+        </svelte:fragment>
+    </FileView>
 {/if}

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/+page.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/+page.svelte
@@ -2,37 +2,12 @@
 
 <script lang="ts">
     import { onMount } from 'svelte'
-    import { mdiFileEyeOutline, mdiMapSearch, mdiWrap, mdiWrapDisabled } from '@mdi/js'
-    import { capitalize } from 'lodash'
-    import { from } from 'rxjs'
-    import { writable } from 'svelte/store'
 
-    import { afterNavigate, goto, preloadData } from '$app/navigation'
-    import { page } from '$app/stores'
     import { SVELTE_LOGGER, SVELTE_TELEMETRY_EVENTS, codeCopiedEvent } from '$lib/telemetry'
-    import type { ScrollSnapshot } from '$lib/codemirror/utils'
-    import CodeMirrorBlob from '$lib/CodeMirrorBlob.svelte'
-    import { isErrorLike, SourcegraphURL, type LineOrPositionOrRange, pluralize } from '$lib/common'
-    import { toGraphQLResult } from '$lib/graphql'
-    import Icon from '$lib/Icon.svelte'
-    import LoadingSpinner from '$lib/LoadingSpinner.svelte'
-    import { createBlobDataHandler } from '$lib/repo/blob'
-    import FileHeader from '$lib/repo/FileHeader.svelte'
-    import FileIcon from '$lib/repo/FileIcon.svelte'
-    import OpenInEditor from '$lib/repo/open-in-editor/OpenInEditor.svelte'
-    import Permalink from '$lib/repo/Permalink.svelte'
-    import { createCodeIntelAPI } from '$lib/shared'
-    import { formatBytes } from '$lib/utils'
-    import { Alert, MenuButton, MenuLink } from '$lib/wildcard'
-    import markdownStyles from '$lib/wildcard/Markdown.module.scss'
-    import FileDiffHunks from '$lib/repo/FileDiffHunks.svelte'
 
     import type { PageData, Snapshot } from './$types'
-    import FileViewModeSwitcher from './FileViewModeSwitcher.svelte'
-    import OpenInCodeHostAction from './OpenInCodeHostAction.svelte'
-    import { toViewMode, ViewMode } from './util'
-    import DiffSummaryHeader from './DiffSummaryHeader.svelte'
-    import CloseDiffViewAction from './CloseDiffViewAction.svelte'
+    import DiffView from './DiffView.svelte'
+    import FileView from './FileView.svelte'
 
     export let data: PageData
 
@@ -41,301 +16,32 @@
     export let embedded = false
     export let disableCodeIntel = embedded
 
-    export const snapshot: Snapshot<ScrollSnapshot | null> = {
+    export const snapshot: Snapshot = {
         capture() {
-            return cmblob?.getScrollSnapshot() ?? null
+            return {
+                fileView: fileView?.capture(),
+            }
         },
         restore(data) {
-            initialScrollPosition = data
+            if (data.fileView) {
+                fileView?.restore(data.fileView)
+            }
         },
     }
 
-    const combinedBlobData = createBlobDataHandler()
-    const lineWrap = writable<boolean>(false)
-    let cmblob: CodeMirrorBlob | null = null
-    let blob: Awaited<PageData['blob']> | null = null
-    let highlights: Awaited<PageData['highlights']> = ''
-    let selectedPosition: LineOrPositionOrRange | null = null
-    let initialScrollPosition: ScrollSnapshot | null = null
-
-    $: ({
-        repoURL,
-        revision,
-        resolvedRevision: { commitID },
-        repoName,
-        filePath,
-        settings,
-        graphQLClient,
-        blameData,
-    } = data)
-    $: combinedBlobData.set(data.blob, data.highlights)
-
-    $: if (!$combinedBlobData.blobPending) {
-        blob = $combinedBlobData.blob
-        highlights = $combinedBlobData.highlights
-        selectedPosition = data.lineOrPosition
-    }
-    $: fileNotFound = $combinedBlobData.blobPending ? null : !$combinedBlobData.blob
-    $: fileLoadingError = $combinedBlobData.blobPending ? null : !$combinedBlobData.blob && $combinedBlobData.blobError
-    $: isFormatted = !!$combinedBlobData.blob?.richHTML
-
-    $: viewMode = toViewMode($page.url.searchParams.get('view'))
-    $: showBlame = viewMode === ViewMode.Blame
-    $: showFormatted = isFormatted && viewMode === ViewMode.Default && !showBlame
-
-    $: codeIntelAPI = disableCodeIntel
-        ? null
-        : createCodeIntelAPI({
-              settings: setting => (isErrorLike(settings?.final) ? undefined : settings?.final?.[setting]),
-              requestGraphQL(options) {
-                  return from(graphQLClient.query(options.request, options.variables).then(toGraphQLResult))
-              },
-          })
+    let fileView: FileView
 
     onMount(() => {
         SVELTE_LOGGER.logViewEvent(SVELTE_TELEMETRY_EVENTS.ViewBlobPage)
     })
-
-    afterNavigate(event => {
-        // Only restore scroll position when the user used the browser history to navigate back
-        // and forth. When the user reloads the page, in which case SvelteKit will also call
-        // Snapshot.restore, we don't want to restore the scroll position. Instead we want the
-        // selected line (if any) to scroll into view.
-        if (event.type !== 'popstate') {
-            initialScrollPosition = null
-        }
-    })
-
-    function handleCopy(): void {
-        SVELTE_LOGGER.log(...codeCopiedEvent('blob-view'))
-    }
-
-    function onViewModeChange(event: CustomEvent<ViewMode>): void {
-        // TODO: track other blob mode
-        if (event.detail === ViewMode.Blame) {
-            SVELTE_LOGGER.log(SVELTE_TELEMETRY_EVENTS.GitBlameEnabled)
-        }
-
-        goto(viewModeURL(event.detail), { replaceState: true, keepFocus: true })
-    }
-
-    function viewModeURL(viewMode: ViewMode) {
-        switch (viewMode) {
-            case ViewMode.Code: {
-                const url = SourcegraphURL.from($page.url)
-                if (isFormatted) {
-                    url.setSearchParameter('view', 'raw')
-                } else {
-                    url.deleteSearchParameter('view')
-                }
-                return url.toString()
-            }
-            case ViewMode.Blame:
-                const url = SourcegraphURL.from($page.url)
-                url.setSearchParameter('view', 'blame')
-                return url.toString()
-            case ViewMode.Default:
-                return SourcegraphURL.from($page.url).deleteSearchParameter('view').toString()
-        }
-    }
 </script>
 
 <svelte:head>
-    <title>{filePath} - {data.displayRepoName} - Sourcegraph</title>
+    <title>{data.filePath} - {data.displayRepoName} - Sourcegraph</title>
 </svelte:head>
 
-<!-- File header -->
-<!-- Note: Splitting this at this level is not great but Svelte doesn't allow to conditionally render slots (yet) -->
-{#if data.compare}
-    <FileHeader type="blob" {repoName} {revision} path={filePath}>
-        <FileIcon slot="icon" file={blob} inline />
-        <svelte:fragment slot="actions">
-            <CloseDiffViewAction />
-        </svelte:fragment>
-    </FileHeader>
-{:else if embedded}
-    <FileHeader type="blob" {repoName} {revision} path={filePath} hideSidebarToggle>
-        <FileIcon slot="icon" file={blob} inline />
-        <svelte:fragment slot="actions">
-            <slot name="actions" />
-        </svelte:fragment>
-    </FileHeader>
+{#if data.type === 'DiffView'}
+    <DiffView {data} />
 {:else}
-    <FileHeader type="blob" {repoName} {revision} path={filePath}>
-        <FileIcon slot="icon" file={blob} inline />
-        <svelte:fragment slot="actions">
-            {#await data.externalServiceType then externalServiceType}
-                {#if externalServiceType}
-                    <OpenInEditor {externalServiceType} />
-                {/if}
-            {/await}
-            {#if blob}
-                <OpenInCodeHostAction data={blob} />
-            {/if}
-            <Permalink {commitID} />
-        </svelte:fragment>
-        <svelte:fragment slot="actionmenu">
-            <MenuLink href="{repoURL}/-/raw/{filePath}" target="_blank">
-                <Icon svgPath={mdiFileEyeOutline} inline /> View raw
-            </MenuLink>
-            <MenuButton
-                on:click={() => lineWrap.update(wrap => !wrap)}
-                disabled={viewMode === ViewMode.Default && isFormatted}
-            >
-                <Icon svgPath={$lineWrap ? mdiWrap : mdiWrapDisabled} inline />
-                {$lineWrap ? 'Disable' : 'Enable'} wrapping long lines
-            </MenuButton>
-        </svelte:fragment>
-    </FileHeader>
+    <FileView bind:this={fileView} {data} {embedded} {disableCodeIntel} />
 {/if}
-
-<!-- additional content information (file or diff info) -->
-{#if blob && !blob.binary && !data.compare && !embedded}
-    <div class="file-info">
-        <FileViewModeSwitcher
-            aria-label="View mode"
-            value={viewMode}
-            options={isFormatted
-                ? [ViewMode.Default, ViewMode.Code, ViewMode.Blame]
-                : [ViewMode.Default, ViewMode.Blame]}
-            on:preload={event => preloadData(viewModeURL(event.detail))}
-            on:change={onViewModeChange}
-        >
-            <svelte:fragment slot="label" let:value>
-                {value === ViewMode.Default ? (isFormatted ? 'Formatted' : 'Code') : capitalize(value)}
-            </svelte:fragment>
-        </FileViewModeSwitcher>
-        <code>
-            {blob.totalLines}
-            {pluralize('line', blob.totalLines)} · {formatBytes(blob.byteSize)}
-        </code>
-    </div>
-{:else if data.compare}
-    <div class="file-info">
-        {#await data.compare.commit then commit}
-            {#if commit}
-                <DiffSummaryHeader {commit} />
-            {:else}
-                (unable to load commit information)
-            {/if}
-        {/await}
-    </div>
-{/if}
-
-<!-- File content or diff view -->
-<div class="content" class:loading={$combinedBlobData.blobPending} class:compare={!!data.compare} class:fileNotFound>
-    {#if !$combinedBlobData.highlightsPending && $combinedBlobData.highlightsError}
-        <Alert variant="danger">
-            Unable to load syntax highlighting: {$combinedBlobData.highlightsError.message}
-        </Alert>
-    {/if}
-    {#if data.compare}
-        {#await data.compare.commit}
-            <LoadingSpinner />
-        {:then commit}
-            {@const hunks = commit?.diff.fileDiffs.nodes.at(0)?.hunks}
-            {#if hunks}
-                <FileDiffHunks {hunks} />
-            {:else}
-                <Alert variant="danger">Unable to load diff information.</Alert>
-            {/if}
-        {/await}
-    {:else if $combinedBlobData.blob && showFormatted}
-        <div class={`rich ${markdownStyles.markdown}`}>
-            {@html $combinedBlobData.blob.richHTML}
-        </div>
-    {:else if blob}
-        <!--
-            This ensures that a new CodeMirror instance is created when the file changes.
-            This makes the CodeMirror behavior more predictable and avoids issues with
-            carrying over state from the previous file.
-            Specifically this will make it so that the scroll position is reset to
-            `initialScrollPosition` when the file changes.
-        -->
-        {#key blob.canonicalURL}
-            <CodeMirrorBlob
-                bind:this={cmblob}
-                {initialScrollPosition}
-                blobInfo={{
-                    ...blob,
-                    repoName,
-                    commitID,
-                    revision: revision ?? '',
-                    filePath,
-                }}
-                {highlights}
-                {showBlame}
-                blameData={$blameData}
-                wrapLines={$lineWrap}
-                selectedLines={selectedPosition?.line ? selectedPosition : null}
-                on:selectline={({ detail: range }) => {
-                    goto(
-                        SourcegraphURL.from($page.url.searchParams)
-                            .setLineRange(range ? { line: range.line, endLine: range.endLine } : null)
-                            .deleteSearchParameter('popover').search
-                    )
-                }}
-                {codeIntelAPI}
-                onCopy={handleCopy}
-            />
-        {/key}
-    {:else if fileLoadingError}
-        <Alert variant="danger">
-            Unable to load file data: {fileLoadingError.message}
-        </Alert>
-    {:else if fileNotFound}
-        <div class="circle">
-            <Icon svgPath={mdiMapSearch} size={80} />
-        </div>
-        <h2>File not found</h2>
-    {/if}
-</div>
-
-<style lang="scss">
-    .content {
-        display: flex;
-        flex-direction: column;
-        overflow: auto;
-        flex: 1;
-        background-color: var(--color-bg-1);
-
-        &.compare {
-            flex-direction: column;
-        }
-
-        &.fileNotFound {
-            background-color: var(--body-bg);
-            flex-direction: column;
-            align-items: center;
-        }
-    }
-
-    .file-info {
-        background: var(--color-bg-1);
-        padding: 0.5rem;
-        color: var(--text-muted);
-        display: flex;
-        gap: 1rem;
-        align-items: baseline;
-    }
-
-    .loading {
-        filter: blur(1px);
-    }
-
-    .rich {
-        padding: 1rem;
-        max-width: 50rem;
-    }
-
-    .circle {
-        background-color: var(--color-bg-2);
-        border-radius: 50%;
-        padding: 1.5rem;
-        margin: 1rem;
-    }
-
-    .actions {
-        margin-left: auto;
-    }
-</style>

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/+page.ts
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/+page.ts
@@ -6,17 +6,43 @@ import { SourcegraphURL } from '$lib/common'
 import { getGraphQLClient, mapOrThrow } from '$lib/graphql'
 import { resolveRevision } from '$lib/repo/utils'
 import { parseRepoRevision } from '$lib/shared'
+import { assertNonNullable } from '$lib/utils'
 
-import type { PageLoad } from './$types'
-import { BlobDiffQuery, BlobPageQuery, BlobSyntaxHighlightQuery } from './page.gql'
+import type { PageLoad, PageLoadEvent } from './$types'
+import {
+    BlobDiffViewCommitQuery,
+    BlobFileViewHighlightedFileQuery,
+    BlobFileViewCommitQuery_revisionOverride,
+    BlobFileViewBlobQuery,
+} from './page.gql'
 
-export const load: PageLoad = ({ parent, params, url }) => {
-    const revisionToCompare = url.searchParams.get('rev')
+function loadDiffView({ params, url }: PageLoadEvent) {
     const client = getGraphQLClient()
-    const { repoName, revision = '' } = parseRepoRevision(params.repo)
-    const resolvedRevision = resolveRevision(parent, revision)
+    const revisionOverride = url.searchParams.get('rev')
+    const { repoName } = parseRepoRevision(params.repo)
+
+    assertNonNullable(revisionOverride, 'revisionOverride is set')
+
+    return {
+        type: 'DiffView' as const,
+        filePath: params.path,
+        commit: client
+            .query(BlobDiffViewCommitQuery, {
+                repoName,
+                revspec: revisionOverride,
+                path: params.path,
+            })
+            .then(mapOrThrow(result => result.data?.repository?.commit ?? null)),
+    }
+}
+
+async function loadFileView({ parent, params, url }: PageLoadEvent) {
+    const client = getGraphQLClient()
+    const revisionOverride = url.searchParams.get('rev')
     const isBlame = url.searchParams.get('view') === 'blame'
     const lineOrPosition = SourcegraphURL.from(url).lineRange
+    const { repoName, revision = '' } = parseRepoRevision(params.repo)
+    const resolvedRevision = revisionOverride ? Promise.resolve(revisionOverride) : resolveRevision(parent, revision)
 
     // Create a BehaviorSubject so preloading does not create a subscriberless observable
     const blameData = new BehaviorSubject<BlameHunkData>({ current: undefined, externalURLs: undefined })
@@ -42,12 +68,13 @@ export const load: PageLoad = ({ parent, params, url }) => {
     }
 
     return {
+        type: 'FileView' as const,
         graphQLClient: client,
         lineOrPosition,
         filePath: params.path,
         blob: resolvedRevision
             .then(resolvedRevision =>
-                client.query(BlobPageQuery, {
+                client.query(BlobFileViewBlobQuery, {
                     repoName,
                     revspec: resolvedRevision,
                     path: params.path,
@@ -56,25 +83,22 @@ export const load: PageLoad = ({ parent, params, url }) => {
             .then(mapOrThrow(result => result.data?.repository?.commit?.blob ?? null)),
         highlights: resolvedRevision
             .then(resolvedRevision =>
-                client.query(BlobSyntaxHighlightQuery, {
+                client.query(BlobFileViewHighlightedFileQuery, {
                     repoName,
                     revspec: resolvedRevision,
                     path: params.path,
                     disableTimeout: false,
                 })
             )
-            .then(mapOrThrow(result => result.data?.repository?.commit?.blob?.highlight.lsif ?? '')),
-        compare: revisionToCompare
-            ? {
-                  revisionToCompare,
-                  commit: client
-                      .query(BlobDiffQuery, {
-                          repoName,
-                          revspec: revisionToCompare,
-                          paths: [params.path],
-                      })
-                      .then(mapOrThrow(result => result.data?.repository?.commit ?? null)),
-              }
+            .then(mapOrThrow(result => result.data?.repository?.commit?.blob?.highlight ?? null)),
+        // We can ignore the error because if the revision doesn't exist, other queryies will fail as well
+        revisionOverride: revisionOverride
+            ? await client
+                  .query(BlobFileViewCommitQuery_revisionOverride, {
+                      repoName,
+                      revspec: revisionOverride,
+                  })
+                  .then(result => result.data?.repository?.commit)
             : null,
         externalServiceType: parent()
             .then(({ resolvedRevision }) => resolvedRevision.repo?.externalRepository?.serviceType)
@@ -84,4 +108,14 @@ export const load: PageLoad = ({ parent, params, url }) => {
             }),
         blameData,
     }
+}
+
+export const load: PageLoad = event => {
+    const showDiff = event.url.searchParams.has('diff')
+    const revisionOverride = event.url.searchParams.get('rev')
+
+    if (showDiff && revisionOverride) {
+        return loadDiffView(event)
+    }
+    return loadFileView(event)
 }

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/+page.ts
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/+page.ts
@@ -67,13 +67,13 @@ export const load: PageLoad = ({ parent, params, url }) => {
         compare: revisionToCompare
             ? {
                   revisionToCompare,
-                  diff: client
+                  commit: client
                       .query(BlobDiffQuery, {
                           repoName,
                           revspec: revisionToCompare,
                           paths: [params.path],
                       })
-                      .then(mapOrThrow(result => result.data?.repository?.commit?.diff.fileDiffs.nodes[0] ?? null)),
+                      .then(mapOrThrow(result => result.data?.repository?.commit ?? null)),
               }
             : null,
         externalServiceType: parent()

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/CloseDiffViewAction.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/CloseDiffViewAction.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+    import { mdiClose } from '@mdi/js'
+
+    import { page } from '$app/stores'
+    import { SourcegraphURL } from '$lib/common'
+    import Icon from '$lib/Icon.svelte'
+    import Tooltip from '$lib/Tooltip.svelte'
+
+    $: href = SourcegraphURL.from($page.url).deleteSearchParameter('rev').toString()
+</script>
+
+<Tooltip tooltip="Close diff">
+    <a {href}><Icon svgPath={mdiClose} inline /> <span data-action-label>Close diff</span></a>
+</Tooltip>
+
+<style lang="scss">
+    a,
+    a:hover {
+        color: var(--text-color);
+        text-decoration: none;
+        white-space: nowrap;
+    }
+</style>

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/CloseViewAction.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/CloseViewAction.svelte
@@ -6,11 +6,13 @@
     import Icon from '$lib/Icon.svelte'
     import Tooltip from '$lib/Tooltip.svelte'
 
-    $: href = SourcegraphURL.from($page.url).deleteSearchParameter('rev').toString()
+    export let label: string
+
+    $: href = SourcegraphURL.from($page.url).deleteSearchParameter('rev', 'diff').toString()
 </script>
 
-<Tooltip tooltip="Close diff">
-    <a {href}><Icon svgPath={mdiClose} inline /> <span data-action-label>Close diff</span></a>
+<Tooltip tooltip={label}>
+    <a {href}><Icon svgPath={mdiClose} inline /> <span data-action-label>{label}</span></a>
 </Tooltip>
 
 <style lang="scss">

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/DiffSummaryHeader.gql
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/DiffSummaryHeader.gql
@@ -10,7 +10,7 @@ fragment DiffSummaryHeaderCommit on GitCommit {
         }
     }
     diff {
-        fileDiffs(paths: $paths) {
+        fileDiffs(paths: [$path]) {
             diffStat {
                 added
                 deleted

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/DiffSummaryHeader.gql
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/DiffSummaryHeader.gql
@@ -1,0 +1,20 @@
+fragment DiffSummaryHeaderCommit on GitCommit {
+    id
+    abbreviatedOID
+    canonicalURL
+    ancestors(first: 2) {
+        nodes {
+            id
+            abbreviatedOID
+            canonicalURL
+        }
+    }
+    diff {
+        fileDiffs(paths: $paths) {
+            diffStat {
+                added
+                deleted
+            }
+        }
+    }
+}

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/DiffSummaryHeader.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/DiffSummaryHeader.svelte
@@ -1,0 +1,76 @@
+<script lang="ts">
+    import { mdiCompareHorizontal } from '@mdi/js'
+
+    import { Badge } from '$lib/wildcard'
+
+    import type { DiffSummaryHeaderCommit } from './DiffSummaryHeader.gql'
+    import Icon from '$lib/Icon.svelte'
+    import DiffSquares from '$lib/repo/DiffSquares.svelte'
+    import { numberWithCommas } from '$lib/common'
+
+    export let commit: DiffSummaryHeaderCommit
+
+    $: parent = commit.ancestors.nodes.at(1)
+    $: diffStat = commit.diff.fileDiffs.diffStat
+</script>
+
+<span class="root">
+    <span class="label">
+        <Badge variant="link">
+            <a href={commit.canonicalURL}>{commit.abbreviatedOID}</a>
+        </Badge>&nbsp;(selected)</span
+    >
+    <Icon svgPath={mdiCompareHorizontal} aria-hidden />
+    <span class="label">
+        {#if parent}
+            <Badge variant="link">
+                <a href={parent.canonicalURL}>{parent.abbreviatedOID}</a>
+            </Badge>&nbsp;(parent)
+        {:else}
+            (parent unavailable)
+        {/if}
+    </span>
+    <span class="squares">
+        <small>
+            {#if diffStat.added > 0}
+                <span class="added">+{numberWithCommas(diffStat.added)}</span>
+            {/if}
+            {#if diffStat.deleted > 0}
+                <span class="deleted">-{numberWithCommas(diffStat.deleted)}</span>
+            {/if}
+        </small>
+        &nbsp;
+        <DiffSquares added={diffStat.added} deleted={diffStat.deleted} />
+    </span>
+</span>
+
+<style lang="scss">
+    .root {
+        flex-shrink: 0;
+        display: inline-flex;
+        gap: 1rem;
+    }
+
+    small,
+    .squares {
+        white-space: nowrap;
+    }
+
+    .label {
+        color: var(--text-muted);
+    }
+
+    .squares {
+        display: inline-flex;
+        align-items: center;
+        margin-left: 1rem;
+
+        .added {
+            color: var(--success);
+        }
+
+        .deleted {
+            color: var(--danger);
+        }
+    }
+</style>

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/DiffSummaryHeader.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/DiffSummaryHeader.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
     import { mdiCompareHorizontal } from '@mdi/js'
 
+    import { numberWithCommas } from '$lib/common'
+    import Icon from '$lib/Icon.svelte'
+    import DiffSquares from '$lib/repo/DiffSquares.svelte'
     import { Badge } from '$lib/wildcard'
 
     import type { DiffSummaryHeaderCommit } from './DiffSummaryHeader.gql'
-    import Icon from '$lib/Icon.svelte'
-    import DiffSquares from '$lib/repo/DiffSquares.svelte'
-    import { numberWithCommas } from '$lib/common'
 
     export let commit: DiffSummaryHeaderCommit
 

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/DiffView.gql
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/DiffView.gql
@@ -1,0 +1,17 @@
+fragment DiffViewGitBlob on GitBlob {
+    ...FileIcon_GitBlob
+}
+
+fragment DiffViewCommit on GitCommit {
+    diff {
+        fileDiffs(paths: [$path]) {
+            nodes {
+                hunks {
+                    ...FileDiffHunks_Hunk
+                }
+            }
+        }
+    }
+
+    ...DiffSummaryHeaderCommit
+}

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/DiffView.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/DiffView.svelte
@@ -1,0 +1,65 @@
+<script lang="ts">
+    import LoadingSpinner from '$lib/LoadingSpinner.svelte'
+    import FileDiffHunks from '$lib/repo/FileDiffHunks.svelte'
+    import FileHeader from '$lib/repo/FileHeader.svelte'
+    import FileIcon from '$lib/repo/FileIcon.svelte'
+    import { toReadable } from '$lib/utils'
+    import { Alert } from '$lib/wildcard'
+
+    import type { PageData } from './$types'
+    import CloseViewAction from './CloseViewAction.svelte'
+    import DiffSummaryHeader from './DiffSummaryHeader.svelte'
+
+    export let data: Extract<PageData, { type: 'DiffView' }>
+
+    $: commit = toReadable(data.commit)
+    $: hunks = $commit.value?.diff.fileDiffs.nodes.at(0)?.hunks
+</script>
+
+<FileHeader type="blob" repoName={data.repoName} path={data.filePath}>
+    {#if $commit.value?.blob}
+        <FileIcon slot="icon" file={$commit.value.blob} inline />
+    {/if}
+    <CloseViewAction slot="actions" label="Close diff" />
+</FileHeader>
+
+<div class="file-info">
+    {#if $commit.value}
+        <DiffSummaryHeader commit={$commit.value} />
+    {/if}
+</div>
+
+<div class="content" class:center={!!($commit.error || !hunks)}>
+    {#if $commit.pending}
+        <LoadingSpinner />
+    {:else if $commit.error}
+        <Alert variant="danger">Unable to load diff information: {$commit.error.message}</Alert>
+    {:else if !hunks}
+        <Alert variant="danger">Unable to load diff information.</Alert>
+    {:else}
+        <FileDiffHunks {hunks} />
+    {/if}
+</div>
+
+<style lang="scss">
+    .content {
+        overflow: auto;
+        flex: 1;
+        background-color: var(--color-bg-1);
+
+        &.center {
+            align-items: center;
+            display: flex;
+            flex-direction: column;
+        }
+    }
+
+    .file-info {
+        background: var(--color-bg-1);
+        padding: 0.5rem;
+        color: var(--text-muted);
+        display: flex;
+        gap: 1rem;
+        align-items: baseline;
+    }
+</style>

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/DiffView.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/DiffView.svelte
@@ -16,7 +16,7 @@
     $: hunks = $commit.value?.diff.fileDiffs.nodes.at(0)?.hunks
 </script>
 
-<FileHeader type="blob" repoName={data.repoName} path={data.filePath}>
+<FileHeader type="blob" repoName={data.repoName} revision={data.revision} path={data.filePath}>
     {#if $commit.value?.blob}
         <FileIcon slot="icon" file={$commit.value.blob} inline />
     {/if}

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/FileView.gql
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/FileView.gql
@@ -1,0 +1,32 @@
+fragment FileViewGitBlob on GitBlob {
+    canonicalURL
+    binary
+    content
+    richHTML
+    languages
+    totalLines
+    byteSize
+
+    ...OpenInCodeHostAction
+    ...FileIcon_GitBlob
+}
+
+fragment FileViewHighlightedFile on HighlightedFile {
+    aborted
+    lsif
+}
+
+fragment FileView_ResolvedRevision on Repository {
+    externalRepository {
+        serviceType
+    }
+    externalURLs {
+        url
+        serviceKind
+    }
+}
+
+fragment FileViewCommit on GitCommit {
+    canonicalURL
+    abbreviatedOID
+}

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/FileView.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/FileView.svelte
@@ -1,0 +1,308 @@
+<script lang="ts" context="module">
+    const graphQLClient = getGraphQLClient()
+</script>
+
+<script lang="ts">
+    import { mdiFileEyeOutline, mdiMapSearch, mdiWrap, mdiWrapDisabled } from '@mdi/js'
+    import { capitalize } from 'lodash'
+    import { from } from 'rxjs'
+    import { writable } from 'svelte/store'
+
+    import { goto, preloadData, afterNavigate } from '$app/navigation'
+    import { page } from '$app/stores'
+    import type { ScrollSnapshot } from '$lib/codemirror/utils'
+    import CodeMirrorBlob from '$lib/CodeMirrorBlob.svelte'
+    import { isErrorLike, pluralize, SourcegraphURL, type LineOrPositionOrRange } from '$lib/common'
+    import { getGraphQLClient, toGraphQLResult } from '$lib/graphql'
+    import Icon from '$lib/Icon.svelte'
+    import FileHeader from '$lib/repo/FileHeader.svelte'
+    import FileIcon from '$lib/repo/FileIcon.svelte'
+    import OpenInEditor from '$lib/repo/open-in-editor/OpenInEditor.svelte'
+    import Permalink from '$lib/repo/Permalink.svelte'
+    import { createCodeIntelAPI } from '$lib/shared'
+    import { settings } from '$lib/stores'
+    import { codeCopiedEvent, SVELTE_LOGGER, SVELTE_TELEMETRY_EVENTS } from '$lib/telemetry'
+    import { createPromiseStore, formatBytes } from '$lib/utils'
+    import { Alert, Badge, MenuButton, MenuLink } from '$lib/wildcard'
+    import markdownStyles from '$lib/wildcard/Markdown.module.scss'
+
+    import type { PageData } from './$types'
+    import CloseDiffViewAction from './CloseViewAction.svelte'
+    import { FileViewGitBlob, FileViewHighlightedFile } from './FileView.gql'
+    import FileViewModeSwitcher from './FileViewModeSwitcher.svelte'
+    import OpenInCodeHostAction from './OpenInCodeHostAction.svelte'
+    import { CodeViewMode, toCodeViewMode } from './util'
+
+    export let embedded: boolean
+    export let disableCodeIntel: boolean
+    export let data: Extract<PageData, { type: 'FileView' }>
+
+    export function capture(): ScrollSnapshot | null {
+        return cmblob?.getScrollSnapshot() ?? null
+    }
+
+    export function restore(data: ScrollSnapshot | null) {
+        initialScrollPosition = data
+    }
+
+    const lineWrap = writable<boolean>(false)
+    const blobLoader = createPromiseStore<Awaited<PageData['blob']>>()
+    const highlightsLoader = createPromiseStore<Awaited<PageData['highlights']>>()
+
+    let blob: FileViewGitBlob | null = null
+    let highlights: FileViewHighlightedFile | null = null
+    let cmblob: CodeMirrorBlob | null = null
+    let initialScrollPosition: ScrollSnapshot | null = null
+    let selectedPosition: LineOrPositionOrRange | null = null
+
+    $: ({
+        repoName,
+        filePath,
+        repoURL,
+        blameData,
+        revision,
+        resolvedRevision: { commitID },
+        revisionOverride,
+    } = data)
+    $: blobLoader.set(data.blob)
+    $: highlightsLoader.set(data.highlights)
+
+    $: if (!$blobLoader.pending) {
+        blob = $blobLoader.value ?? null
+        highlights = $highlightsLoader.pending ? null : $highlightsLoader.value ?? null
+        selectedPosition = data.lineOrPosition
+    }
+    $: fileLoadingError = !$blobLoader.pending && $blobLoader.error
+    $: fileNotFound = !$blobLoader.pending && !blob
+    $: codeViewMode = toCodeViewMode($page.url.searchParams.get('view'))
+    $: isFormatted = !!blob?.richHTML
+    $: showBlame = codeViewMode === CodeViewMode.Blame
+    $: showFormatted = isFormatted && codeViewMode === CodeViewMode.Default && !showBlame
+    $: isBinary = blob?.binary ?? false
+    $: showFileModeSwitcher = blob && !isBinary && !embedded
+    $: showCodeView = !isBinary && !isFormatted
+    $: codeIntelAPI =
+        disableCodeIntel || showCodeView
+            ? null
+            : createCodeIntelAPI({
+                  settings: setting => (isErrorLike($settings?.final) ? undefined : $settings?.final?.[setting]),
+                  requestGraphQL(options) {
+                      return from(graphQLClient.query(options.request, options.variables).then(toGraphQLResult))
+                  },
+              })
+
+    function viewModeURL(viewMode: CodeViewMode) {
+        switch (viewMode) {
+            case CodeViewMode.Code: {
+                const url = SourcegraphURL.from($page.url)
+                if (isFormatted) {
+                    url.setSearchParameter('view', 'raw')
+                } else {
+                    url.deleteSearchParameter('view')
+                }
+                return url.toString()
+            }
+            case CodeViewMode.Blame:
+                const url = SourcegraphURL.from($page.url)
+                url.setSearchParameter('view', 'blame')
+                return url.toString()
+            case CodeViewMode.Default:
+                return SourcegraphURL.from($page.url).deleteSearchParameter('view').toString()
+        }
+    }
+
+    function handleCopy(): void {
+        SVELTE_LOGGER.log(...codeCopiedEvent('blob-view'))
+    }
+
+    function onViewModeChange(event: CustomEvent<CodeViewMode>): void {
+        // TODO: track other blob mode
+        if (event.detail === CodeViewMode.Blame) {
+            SVELTE_LOGGER.log(SVELTE_TELEMETRY_EVENTS.GitBlameEnabled)
+        }
+
+        goto(viewModeURL(event.detail), { replaceState: true, keepFocus: true })
+    }
+
+    afterNavigate(event => {
+        // Only restore scroll position when the user used the browser history to navigate back
+        // and forth. When the user reloads the page, in which case SvelteKit will also call
+        // Snapshot.restore, we don't want to restore the scroll position. Instead we want the
+        // selected line (if any) to scroll into view.
+        if (event.type !== 'popstate') {
+            initialScrollPosition = null
+        }
+    })
+</script>
+
+{#if embedded}
+    <FileHeader type="blob" repoName={data.repoName} path={data.filePath} {revision} hideSidebarToggle>
+        <FileIcon slot="icon" file={blob} inline />
+        <svelte:fragment slot="actions">
+            <slot name="actions" />
+        </svelte:fragment>
+    </FileHeader>
+{:else if revisionOverride}
+    <FileHeader type="blob" repoName={data.repoName} path={data.filePath} {revision}>
+        <FileIcon slot="icon" file={blob} inline />
+        <svelte:fragment slot="actions">
+            <CloseDiffViewAction label="Close commit" />
+        </svelte:fragment>
+    </FileHeader>
+{:else}
+    <FileHeader type="blob" repoName={data.repoName} path={data.filePath} {revision}>
+        <FileIcon slot="icon" file={blob} inline />
+        <svelte:fragment slot="actions">
+            {#await data.externalServiceType then externalServiceType}
+                {#if externalServiceType && !isBinary}
+                    <OpenInEditor {externalServiceType} />
+                {/if}
+            {/await}
+            {#if blob}
+                <OpenInCodeHostAction data={blob} />
+            {/if}
+            <Permalink {commitID} />
+        </svelte:fragment>
+        <svelte:fragment slot="actionmenu">
+            <MenuLink href="{repoURL}/-/raw/{filePath}" target="_blank">
+                <Icon svgPath={mdiFileEyeOutline} inline /> View raw
+            </MenuLink>
+            <MenuButton
+                on:click={() => lineWrap.update(wrap => !wrap)}
+                disabled={codeViewMode === CodeViewMode.Default && isFormatted}
+            >
+                <Icon svgPath={$lineWrap ? mdiWrap : mdiWrapDisabled} inline />
+                {$lineWrap ? 'Disable' : 'Enable'} wrapping long lines
+            </MenuButton>
+        </svelte:fragment>
+    </FileHeader>
+{/if}
+
+<div class="file-info">
+    {#if revisionOverride}
+        <Badge variant="link">
+            <a href={revisionOverride.canonicalURL}>{revisionOverride.abbreviatedOID}</a>
+        </Badge>
+    {:else if showFileModeSwitcher}
+        <FileViewModeSwitcher
+            aria-label="View mode"
+            value={codeViewMode}
+            options={isFormatted
+                ? [CodeViewMode.Default, CodeViewMode.Code, CodeViewMode.Blame]
+                : [CodeViewMode.Default, CodeViewMode.Blame]}
+            on:preload={event => preloadData(viewModeURL(event.detail))}
+            on:change={onViewModeChange}
+        >
+            <svelte:fragment slot="label" let:value>
+                {value === CodeViewMode.Default ? (isFormatted ? 'Formatted' : 'Code') : capitalize(value)}
+            </svelte:fragment>
+        </FileViewModeSwitcher>
+        {#if blob}
+            <code>
+                {blob.totalLines}
+                {pluralize('line', blob.totalLines)} · {formatBytes(blob.byteSize)}
+            </code>
+        {/if}
+    {/if}
+</div>
+
+<div class="content" class:loading={$blobLoader.pending} class:center={fileLoadingError || fileNotFound || isBinary}>
+    {#if fileLoadingError}
+        <Alert variant="danger">
+            Unable to load file data: {fileLoadingError.message}
+        </Alert>
+    {:else if fileNotFound}
+        <div class="circle">
+            <Icon svgPath={mdiMapSearch} size={80} />
+        </div>
+        <h2>File not found</h2>
+    {:else if isBinary}
+        <Alert variant="info">
+            This is a binary file and cannot be displayed.
+            <br />
+            <a href="{repoURL}/-/raw/{filePath}" target="_blank" download>Download file</a>
+        </Alert>
+    {:else if blob && showFormatted}
+        <div class={`rich ${markdownStyles.markdown}`}>
+            {@html blob.richHTML}
+        </div>
+    {:else if blob && showCodeView}
+        <!--
+            This ensures that a new CodeMirror instance is created when the file changes.
+            This makes the CodeMirror behavior more predictable and avoids issues with
+            carrying over state from the previous file.
+            Specifically this will make it so that the scroll position is reset to
+            `initialScrollPosition` when the file changes.
+        -->
+        {#key blob.canonicalURL}
+            <CodeMirrorBlob
+                bind:this={cmblob}
+                {initialScrollPosition}
+                blobInfo={{
+                    ...blob,
+                    repoName,
+                    commitID,
+                    revision: revision ?? '',
+                    filePath,
+                }}
+                highlights={highlights?.lsif ?? ''}
+                {showBlame}
+                blameData={$blameData}
+                wrapLines={$lineWrap}
+                selectedLines={selectedPosition?.line ? selectedPosition : null}
+                on:selectline={({ detail: range }) => {
+                    goto(
+                        SourcegraphURL.from($page.url.searchParams)
+                            .setLineRange(range ? { line: range.line, endLine: range.endLine } : null)
+                            .deleteSearchParameter('popover').search
+                    )
+                }}
+                {codeIntelAPI}
+                onCopy={handleCopy}
+            />
+        {/key}
+    {/if}
+</div>
+
+<style lang="scss">
+    .content {
+        overflow: auto;
+        flex: 1;
+        background-color: var(--color-bg-1);
+
+        &.center {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+        }
+    }
+
+    .file-info {
+        background: var(--color-bg-1);
+        padding: 0.5rem;
+        color: var(--text-muted);
+        display: flex;
+        gap: 1rem;
+        align-items: baseline;
+    }
+
+    .loading {
+        filter: blur(1px);
+    }
+
+    .rich {
+        padding: 1rem;
+        max-width: 50rem;
+    }
+
+    .circle {
+        background-color: var(--color-bg-2);
+        border-radius: 50%;
+        padding: 1.5rem;
+        margin: 1rem;
+    }
+
+    .actions {
+        margin-left: auto;
+    }
+</style>

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/FileView.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/FileView.svelte
@@ -68,6 +68,8 @@
     $: highlightsLoader.set(data.highlights)
 
     $: if (!$blobLoader.pending) {
+        // Only update highlights and position after the file content has been loaded.
+        // While the file content is loading we show the previous file content.
         blob = $blobLoader.value ?? null
         highlights = $highlightsLoader.pending ? null : $highlightsLoader.value ?? null
         selectedPosition = data.lineOrPosition

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/FileViewModeSwitcher.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/FileViewModeSwitcher.svelte
@@ -96,6 +96,7 @@
         border-radius: var(--border-radius);
         color: var(--text-muted);
         margin: calc(var(--border-width) * -1);
+        user-select: none;
 
         &:focus-visible {
             box-shadow: 0 0 0 2px var(--primary-2);

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/page.gql
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/page.gql
@@ -1,57 +1,33 @@
-query BlobDiffQuery($repoName: String!, $revspec: String!, $paths: [String!]) {
-    repository(name: $repoName) {
-        id
-        commit(rev: $revspec) {
-            ...DiffSummaryHeaderCommit
-            diff {
-                fileDiffs(paths: $paths) {
-                    nodes {
-                        hunks {
-                            ...FileDiffHunks_Hunk
-                        }
-                    }
-                }
-            }
-        }
-    }
-}
-
-query BlobPageQuery($repoName: String!, $revspec: String!, $path: String!) {
+query BlobDiffViewCommitQuery($repoName: String!, $revspec: String!, $path: String!) {
     repository(name: $repoName) {
         id
         commit(rev: $revspec) {
             id
+
+            blob(path: $path) {
+                ...DiffViewGitBlob
+            }
+
+            ...DiffViewCommit
+        }
+    }
+}
+
+query BlobFileViewBlobQuery($repoName: String!, $revspec: String!, $path: String!) {
+    repository(name: $repoName) {
+        id
+
+        commit(rev: $revspec) {
+            id
             oid
             blob(path: $path) {
-                ...BlobPage_Blob
+                ...FileViewGitBlob
             }
         }
     }
 }
 
-fragment BlobPage_ResolvedRevision on Repository {
-    externalRepository {
-        serviceType
-    }
-    externalURLs {
-        url
-        serviceKind
-    }
-}
-
-fragment BlobPage_Blob on GitBlob {
-    canonicalURL
-    content
-    richHTML
-    languages
-    binary
-    totalLines
-    byteSize
-    ...OpenInCodeHostAction
-    ...FileIcon_GitBlob
-}
-
-query BlobSyntaxHighlightQuery(
+query BlobFileViewHighlightedFileQuery(
     $repoName: String!
     $revspec: String!
     $path: String!
@@ -65,10 +41,21 @@ query BlobSyntaxHighlightQuery(
             blob(path: $path) {
                 canonicalURL
                 highlight(disableTimeout: $disableTimeout, format: $format) {
-                    aborted
-                    lsif
+                    ...FileViewHighlightedFile
                 }
             }
         }
     }
+}
+
+query BlobFileViewCommitQuery_revisionOverride($repoName: String!, $revspec: String!) {
+    repository(name: $repoName) {
+        commit(rev: $revspec) {
+            ...FileViewCommit
+        }
+    }
+}
+
+fragment BlobPage_ResolvedRevision on Repository {
+    ...FileView_ResolvedRevision
 }

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/page.gql
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/page.gql
@@ -2,11 +2,13 @@ query BlobDiffQuery($repoName: String!, $revspec: String!, $paths: [String!]) {
     repository(name: $repoName) {
         id
         commit(rev: $revspec) {
-            id
+            ...DiffSummaryHeaderCommit
             diff {
                 fileDiffs(paths: $paths) {
                     nodes {
-                        ...FileDiff_Diff
+                        hunks {
+                            ...FileDiffHunks_Hunk
+                        }
                     }
                 }
             }

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/util.test.ts
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/util.test.ts
@@ -1,18 +1,18 @@
 import { describe, test, expect } from 'vitest'
 
-import { ViewMode, toViewMode } from './util'
+import { CodeViewMode, toCodeViewMode } from './util'
 
 describe('toViewMode', () => {
     test.each`
         input        | expected
-        ${undefined} | ${ViewMode.Default}
-        ${null}      | ${ViewMode.Default}
-        ${'code'}    | ${ViewMode.Code}
-        ${'CoDe'}    | ${ViewMode.Code}
-        ${'raw'}     | ${ViewMode.Code}
-        ${'blame'}   | ${ViewMode.Blame}
-        ${'BlAmE'}   | ${ViewMode.Blame}
+        ${undefined} | ${CodeViewMode.Default}
+        ${null}      | ${CodeViewMode.Default}
+        ${'code'}    | ${CodeViewMode.Code}
+        ${'CoDe'}    | ${CodeViewMode.Code}
+        ${'raw'}     | ${CodeViewMode.Code}
+        ${'blame'}   | ${CodeViewMode.Blame}
+        ${'BlAmE'}   | ${CodeViewMode.Blame}
     `('$input -> $expected', ({ input, expected }) => {
-        expect(toViewMode(input)).toBe(expected)
+        expect(toCodeViewMode(input)).toBe(expected)
     })
 })

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/util.ts
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/util.ts
@@ -1,4 +1,15 @@
-export enum ViewMode {
+export enum FileViewMode {
+    CodeFile = 2 ** 1,
+    BinaryFile = 2 ** 2,
+    AtRevision = 2 ** 3,
+    Diff = 2 ** 4,
+}
+
+export function isFileViewMode(viewMode: FileViewMode, mode: FileViewMode): boolean {
+    return (viewMode & mode) != 0
+}
+
+export enum CodeViewMode {
     Default = 'default',
     Code = 'code',
     Blame = 'blame',
@@ -10,14 +21,14 @@ export enum ViewMode {
  * @param rawViewMode The raw view mode value.
  * @returns The ViewMode enum value.
  */
-export function toViewMode(rawViewMode: string | null | undefined): ViewMode {
+export function toCodeViewMode(rawViewMode: string | null | undefined): CodeViewMode {
     switch (rawViewMode?.toLowerCase()) {
         case 'code':
         case 'raw':
-            return ViewMode.Code
+            return CodeViewMode.Code
         case 'blame':
-            return ViewMode.Blame
+            return CodeViewMode.Blame
         default:
-            return ViewMode.Default
+            return CodeViewMode.Default
     }
 }

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/FileTree.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/FileTree.svelte
@@ -5,14 +5,14 @@
     import { onMount } from 'svelte'
 
     import { afterNavigate, goto } from '$app/navigation'
-    import { Alert } from '$lib/wildcard'
     import Icon from '$lib/Icon.svelte'
     import { type FileTreeProvider, NODE_LIMIT, type FileTreeNodeValue, type TreeEntryFields } from '$lib/repo/api/tree'
+    import FileIcon from '$lib/repo/FileIcon.svelte'
     import { getSidebarFileTreeStateForRepo } from '$lib/repo/stores'
+    import { replaceRevisionInURL } from '$lib/shared'
     import TreeView, { setTreeContext } from '$lib/TreeView.svelte'
     import { createForwardStore } from '$lib/utils'
-    import { replaceRevisionInURL } from '$lib/web'
-    import FileIcon from '$lib/repo/FileIcon.svelte'
+    import { Alert } from '$lib/wildcard'
 
     export let repoName: string
     export let treeProvider: FileTreeProvider

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/RepositoryRevPicker.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/RepositoryRevPicker.svelte
@@ -14,11 +14,10 @@
 <script lang="ts">
     import { mdiClose, mdiSourceBranch, mdiTagOutline, mdiSourceCommit } from '@mdi/js'
 
-    import { replaceRevisionInURL } from '@sourcegraph/shared/src/util/url'
-
     import { goto } from '$app/navigation'
     import Icon from '$lib/Icon.svelte'
     import Popover from '$lib/Popover.svelte'
+    import { replaceRevisionInURL } from '$lib/shared'
     import TabPanel from '$lib/TabPanel.svelte'
     import Tabs from '$lib/Tabs.svelte'
     import Tooltip from '$lib/Tooltip.svelte'

--- a/client/web-sveltekit/src/routes/search/PreviewPanel.svelte
+++ b/client/web-sveltekit/src/routes/search/PreviewPanel.svelte
@@ -33,8 +33,8 @@
     // the cache. It may make sense to pass loaders into this function
     // rather than adding a dependency on the blob page.
     import {
-        BlobPageQuery,
-        BlobSyntaxHighlightQuery,
+        BlobFileViewBlobQuery,
+        BlobFileViewHighlightedFileQuery,
     } from '../[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/page.gql'
 
     import { getSearchResultsContext } from './searchResultsContext'
@@ -53,7 +53,7 @@
 
     $: blobStore = toReadable(
         client
-            .query(BlobPageQuery, {
+            .query(BlobFileViewBlobQuery, {
                 repoName: result.repository,
                 revspec: result.commit ?? '',
                 path: result.path,
@@ -63,7 +63,7 @@
 
     $: highlightStore = toReadable(
         client
-            .query(BlobSyntaxHighlightQuery, {
+            .query(BlobFileViewHighlightedFileQuery, {
                 repoName: result.repository,
                 revspec: result.commit ?? '',
                 path: result.path,


### PR DESCRIPTION
This commit implements some parts of the history panel and diff view redesign. In particular it

- Updates the file header to provide an option to close the diff view and to show meta information about the diff.
- Updates the history panel design
- Adds icons to bottom panel tabs
- Updates the hunk view

| Before | After |
|--------|--------|
| ![2024-04-25_21-53](https://github.com/sourcegraph/sourcegraph/assets/179026/ff2339d7-9e22-43de-af5c-fcf3c588fb3c) | ![2024-04-25_21-32](https://github.com/sourcegraph/sourcegraph/assets/179026/5ff7b747-42ca-494c-b4c4-3b4ad80d1eb4) |

TODO, likely in a follow up PR (I'll create an issue before merging):

- [x] Add additional actions for viewing the whole file and browsing the code at a specific commit.
- [ ] Use custom comparison icon.
- [ ] Add "commit icon" to beginning of each row.

## Test plan

Manual testing.
