### PR TITLE
sg/update: allow users to specify a release with '-release'

### DIFF
--- a/dev/sg/sg_update.go
+++ b/dev/sg/sg_update.go
@@ -23,20 +23,49 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/output"
 )
 
+const sgReleases = "https://github.com/sourcegraph/sg/releases"
+
 var updateCommand = &cli.Command{
 	Name:  "update",
 	Usage: "Update local sg installation",
-	Description: `Update local sg installation with the latest changes. To see what's new, run:
+	Description: fmt.Sprintf(`Update local sg installation with the latest changes. To see what's new, run:
 
-    sg version changelog -next`,
+    sg version changelog -next
+
+A custom release from %s can be installed with the '-release' flag.`, sgReleases),
 	Category: category.Util,
+	Flags: []cli.Flag{
+		&cli.StringFlag{
+			Name:    "release",
+			Aliases: []string{"r"},
+			Usage:   fmt.Sprintf("The name of the release in %s to update to", sgReleases),
+			Value:   "latest",
+		},
+	},
 	Action: func(cmd *cli.Context) error {
-		p := std.Out.Pending(output.Styled(output.StylePending, "Downloading latest sg release..."))
-		if _, err := updateToPrebuiltSG(cmd.Context); err != nil {
+		release := cmd.String("release")
+		if release != "latest" {
+			if release == cmd.App.Version {
+				std.Out.WriteNoticef("sg is already up to date (currently installed version: %q)",
+					cmd.App.Version)
+				return nil
+			}
+
+			// If user specifies non-latest release, chances are they are interested
+			// in using an older revision intentionally. Let them know that they
+			// may want to disable auto-updates.
+			std.Out.WriteWarningf("Installing user-specified release %q - "+
+				"'sg' auto-updates might update your 'sg' installation anyway, "+
+				"set 'SG_SKIP_AUTO_UPDATE=false' to disable auto-updates.", release)
+		}
+
+		p := std.Out.Pending(output.StylePending.Linef("Downloading sg release %q...", release))
+		if _, err := updateToPrebuiltSG(cmd.Context, release); err != nil {
 			p.Destroy()
 			return err
 		}
-		p.Complete(output.Line(output.EmojiSuccess, output.StyleSuccess, "sg has been updated!"))
+		p.Complete(output.Linef(output.EmojiSuccess, output.StyleSuccess,
+			"sg has been updated to %q!", release))
 
 		std.Out.Write("To see what's new, run 'sg version changelog'.")
 		return nil
@@ -44,8 +73,10 @@ var updateCommand = &cli.Command{
 }
 
 // updateToPrebuiltSG downloads the latest release of sg prebuilt binaries and install it.
-func updateToPrebuiltSG(ctx context.Context) (bool, error) {
-	req, err := http.NewRequestWithContext(ctx, "GET", "https://github.com/sourcegraph/sg/releases/latest", nil)
+func updateToPrebuiltSG(ctx context.Context, release string) (bool, error) {
+	req, err := http.NewRequestWithContext(ctx, "GET",
+		fmt.Sprintf("%s/%s", sgReleases, release),
+		nil)
 	if err != nil {
 		return false, err
 	}
@@ -53,19 +84,33 @@ func updateToPrebuiltSG(ctx context.Context) (bool, error) {
 	// with redirections.
 	resp, err := http.DefaultTransport.RoundTrip(req)
 	if err != nil {
-		return false, errors.Wrap(err, "GitHub latest release")
+		return false, errors.Newf("Fetch GitHub release %q", release)
 	}
 	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotFound {
+		return false, errors.Newf("GitHub release %q not found", release)
+	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 400 {
-		return false, errors.Newf("GitHub latest release: unexpected status code %d", resp.StatusCode)
+		return false, errors.Newf("Fetch GitHub release %q: unexpected status code %d",
+			release, resp.StatusCode)
 	}
 
-	location := resp.Header.Get("location")
-	if location == "" {
-		return false, errors.New("GitHub latest release: empty location")
+	var downloadURL string
+	if release == "latest" {
+		// GitHub redirects to the latest release, so we need to fetch the
+		// location header to get the download URL.
+		location := resp.Header.Get("location")
+		if location == "" {
+			return false, errors.New("GitHub latest release: empty location")
+		}
+		location = strings.ReplaceAll(location, "/tag/", "/download/")
+		downloadURL = fmt.Sprintf("%s/sg_%s_%s", location, runtime.GOOS, runtime.GOARCH)
+	} else {
+		// Otherwise, we can compose the download link from the user-provided
+		// release name.
+		downloadURL = fmt.Sprintf("%s/download/%s/sg_%s_%s",
+			sgReleases, release, runtime.GOOS, runtime.GOARCH)
 	}
-	location = strings.ReplaceAll(location, "/tag/", "/download/")
-	downloadURL := fmt.Sprintf("%s/sg_%s_%s", location, runtime.GOOS, runtime.GOARCH)
 
 	currentExecPath, err := os.Executable()
 	if err != nil {
@@ -123,20 +168,17 @@ func checkSgVersionAndUpdate(ctx context.Context, out *std.Output, skipUpdate bo
 	span.SetAttributes(attribute.String("rev-list", revList))
 
 	if skipUpdate {
-		out.WriteLine(output.Styled(output.StyleSearchMatch, "╭──────────────────────────────────────────────────────────────────╮  "))
-		out.WriteLine(output.Styled(output.StyleSearchMatch, "│                                                                  │░░"))
-		out.WriteLine(output.Styled(output.StyleSearchMatch, "│ HEY! New version of sg available. Run 'sg update' to install it. │░░"))
-		out.WriteLine(output.Styled(output.StyleSearchMatch, "│       To see what's new, run 'sg version changelog -next'.       │░░"))
-		out.WriteLine(output.Styled(output.StyleSearchMatch, "│                                                                  │░░"))
-		out.WriteLine(output.Styled(output.StyleSearchMatch, "╰──────────────────────────────────────────────────────────────────╯░░"))
-		out.WriteLine(output.Styled(output.StyleSearchMatch, "  ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░"))
+		out.WriteLine(output.Styled(output.StyleSearchMatch, "╭───────────────────────────────────────────────────────────────────────╮"))
+		out.WriteLine(output.Styled(output.StyleSearchMatch, "│ HEY! A new version of sg is available. Run 'sg update' to install it. │"))
+		out.WriteLine(output.Styled(output.StyleSearchMatch, "│         To see what's new, run 'sg version changelog -next'.          │"))
+		out.WriteLine(output.Styled(output.StyleSearchMatch, "╰───────────────────────────────────────────────────────────────────────╯"))
 
 		span.Skipped()
 		return nil
 	}
 
 	out.WriteLine(output.Line(output.EmojiInfo, output.StyleSuggestion, "Auto updating sg ..."))
-	updated, err := updateToPrebuiltSG(ctx)
+	updated, err := updateToPrebuiltSG(ctx, "latest") // always install latest when auto-updating
 	if err != nil {
 		span.RecordError("failed", err)
 		return errors.Newf("failed to install update: %s", err)

--- a/dev/sg/sg_update.go
+++ b/dev/sg/sg_update.go
@@ -84,7 +84,7 @@ func updateToPrebuiltSG(ctx context.Context, release string) (bool, error) {
 	// with redirections.
 	resp, err := http.DefaultTransport.RoundTrip(req)
 	if err != nil {
-		return false, errors.Newf("Fetch GitHub release %q", release)
+		return false, errors.Wrapf(err, "Fetch GitHub release %q", release)
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode == http.StatusNotFound {


### PR DESCRIPTION
MSP pins `sg` version per environment category to control rollout of changes: https://github.com/sourcegraph/sourcegraph/pull/62134

This allows users to update to a specified release (instead of always `latest`) with a new `-release` flag on `sg update`:

```
sg update -release ${release_name}
```

Example usage: https://github.com/sourcegraph/sourcegraph/pull/62134#discussion_r1580114111, details on how `sg msp` version pinning works: https://sourcegraph.notion.site/Deploying-new-versions-of-MSP-1808e7e45bd54f419dd93af542d99238#58dabe4992754ca18ed39bc212ccbbba

## Test plan

Install specified release:

```sh
$ go build -o ./sg ./dev/sg && ./sg install -f -p=false
$ sg version
unknown
$ sg update -r 2024-04-24-16-44-3623ecb2               
⚠️ Installing user-specified release "2024-04-24-16-44-3623ecb2" - 'sg' auto-updates might update your 'sg' installation anyway, set 'SG_SKIP_AUTO_UPDATE=false' to disable auto-updates.
✅ sg has been updated to "2024-04-24-16-44-3623ecb2"!
To see what's new, run 'sg version changelog'.
$ sg version
3623ecb2cfcec81390e37a49540dabb6f67aaa99
```

Default behaviour (latest):

```sh
$ go build -o ./sg ./dev/sg && ./sg install -f -p=false
$ sg version
unknown
$ sg update 
✅ sg has been updated to "latest"!
To see what's new, run 'sg version changelog'.
$ sg version
2024-04-25-15-45-d52b6411
```