### PR TITLE
sg/rfc: add -s for filtering by status(es)

### DIFF
--- a/dev/sg/internal/rfc/rfc.go
+++ b/dev/sg/internal/rfc/rfc.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -362,13 +363,14 @@ func queryRFCs(ctx context.Context, query string, driveSpec DriveSpec, pager fun
 	return list.Pages(ctx, pager)
 }
 
-func List(ctx context.Context, driveSpec DriveSpec, out *std.Output) error {
-	return queryRFCs(ctx, "", driveSpec, rfcTitlesPrinter(out), out)
+func List(ctx context.Context, driveSpec DriveSpec, out *std.Output, statuses []string) error {
+	return queryRFCs(ctx, "", driveSpec, rfcTitlesPrinter(out, statuses), out)
 }
 
-func Search(ctx context.Context, query string, driveSpec DriveSpec, out *std.Output) error {
+func Search(ctx context.Context, query string, driveSpec DriveSpec, out *std.Output, statuses []string) error {
 	driveSpec.OrderBy = "" // fullText queries are always ordered by relevance and fail if an order is specified
-	return queryRFCs(ctx, fmt.Sprintf("(name contains '%[1]s' or fullText contains '%[1]s')", query), driveSpec, rfcTitlesPrinter(out), out)
+	return queryRFCs(ctx, fmt.Sprintf("(name contains '%[1]s' or fullText contains '%[1]s')", query),
+		driveSpec, rfcTitlesPrinter(out, statuses), out)
 }
 
 func openFile(f *drive.File, out *std.Output) {
@@ -402,7 +404,12 @@ var rfcTitleRegex = regexp.MustCompile(`RFC\s(\d+):*\s([\w\s]+):\s(.*)$`)
 var rfcIDRegex = regexp.MustCompile(`RFC\s(\d+)`)
 var rfcDocRegex = regexp.MustCompile(`(RFC.*)(number)(.*:.*)(title)`)
 
-func rfcTitlesPrinter(out *std.Output) func(r *drive.FileList) error {
+// onlyStatuses, if non-empty, discards any RFCs that do not have one of the specified statuses.
+func rfcTitlesPrinter(out *std.Output, onlyStatuses []string) func(r *drive.FileList) error {
+	for i := range onlyStatuses {
+		onlyStatuses[i] = strings.ToUpper(onlyStatuses[i])
+	}
+
 	return func(r *drive.FileList) error {
 		if len(r.Files) == 0 {
 			return nil
@@ -420,6 +427,19 @@ func rfcTitlesPrinter(out *std.Output) func(r *drive.FileList) error {
 				number := matches[1]
 				statuses := strings.Split(strings.ToUpper(matches[2]), " ")
 				name := matches[3]
+
+				if len(onlyStatuses) > 0 {
+					var matchesStatusFilter bool
+					for _, s := range statuses {
+						if slices.Contains(onlyStatuses, strings.ToUpper(s)) {
+							matchesStatusFilter = true
+							break
+						}
+					}
+					if !matchesStatusFilter {
+						continue // skip this file
+					}
+				}
 
 				var statusColor output.Style = output.StyleItalic
 				for _, s := range statuses {
@@ -452,6 +472,9 @@ func rfcTitlesPrinter(out *std.Output) func(r *drive.FileList) error {
 					output.StyleSuggestion, modified.Format("2006-01-02"), f.Description,
 					output.StyleReset)
 			} else {
+				if len(onlyStatuses) > 0 {
+					continue // skip this file, it doesn't have a recognized format
+				}
 				out.Writef("%s%s", f.Name, output.StyleReset)
 			}
 		}

--- a/dev/sg/sg_rfc.go
+++ b/dev/sg/sg_rfc.go
@@ -28,6 +28,9 @@ sg rfc list
 # List all Private RFCs
 sg rfc --private list
 
+# List all Public RFCs that match one of some statuses
+sg rfc list -s approved -s implemented -s done
+
 # Search for a Public RFC
 sg rfc search "search terms"
 
@@ -60,18 +63,32 @@ sg rfc --private create --type <type> "title"
 			Name:      "list",
 			ArgsUsage: " ",
 			Usage:     "List Sourcegraph RFCs",
+			Flags: []cli.Flag{
+				&cli.StringSliceFlag{
+					Name:    "status",
+					Aliases: []string{"s"},
+					Usage:   "Only show RFCs with the given status(es)",
+				},
+			},
 			Action: func(c *cli.Context) error {
 				driveSpec := rfc.PublicDrive
 				if c.Bool("private") {
 					driveSpec = rfc.PrivateDrive
 				}
-				return rfc.List(c.Context, driveSpec, std.Out)
+				return rfc.List(c.Context, driveSpec, std.Out, c.StringSlice("status"))
 			},
 		},
 		{
 			Name:      "search",
 			ArgsUsage: "[query]",
 			Usage:     "Search Sourcegraph RFCs",
+			Flags: []cli.Flag{
+				&cli.StringSliceFlag{
+					Name:    "status",
+					Aliases: []string{"s"},
+					Usage:   "Only show RFCs with the given status(es)",
+				},
+			},
 			Action: func(c *cli.Context) error {
 				driveSpec := rfc.PublicDrive
 				if c.Bool("private") {
@@ -80,7 +97,7 @@ sg rfc --private create --type <type> "title"
 				if c.Args().Len() == 0 {
 					return errors.New("no search query given")
 				}
-				return rfc.Search(c.Context, strings.Join(c.Args().Slice(), " "), driveSpec, std.Out)
+				return rfc.Search(c.Context, strings.Join(c.Args().Slice(), " "), driveSpec, std.Out, c.StringSlice("status"))
 			},
 		},
 		{


### PR DESCRIPTION
We do this in the printer, where we have more control over interpreting the file titles.

Context: https://sourcegraph.slack.com/archives/C015P61EXV1/p1714085557621709?thread_ts=1714070620.515829&cid=C015P61EXV1

## Test plan

```
sg rfc list -s approved -s implemented -s done
```

Note that this only covers public RFCs, you need `-private` as well to get the private RFCs.

![image](https://github.com/sourcegraph/sourcegraph/assets/23356519/91a4f25b-97b8-46fe-9c8c-0b2ac5ee2ff9)

There are some recent RFCs at the bottom, so the format is still used :)