### PR TITLE
Svelte: fix file header links

### DIFF
--- a/client/web-sveltekit/src/lib/repo/FileHeader.svelte
+++ b/client/web-sveltekit/src/lib/repo/FileHeader.svelte
@@ -14,17 +14,23 @@
     const BLOB_ROUTE_ID = '/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]'
 
     export let repoName: string
+    export let revision: string | undefined
     export let path: string
     export let hideSidebarToggle = false
     export let type: 'blob' | 'tree'
 
-    $: breadcrumbs = path.split('/')
-        .map((part, index, all): [string, string] => [
-            part,
-            resolveRoute(
-                type === 'tree' ? TREE_ROUTE_ID : BLOB_ROUTE_ID,
-                { repo: repoName, path: all.slice(0, index + 1).join('/') }),
-        ])
+    $: breadcrumbs = path.split('/').map((part, index, all): [string, string] => [
+        part,
+        resolveRoute(
+            // Only the last element in a path can be a blob
+            index < all.length - 1 || type === 'tree' ? TREE_ROUTE_ID : BLOB_ROUTE_ID,
+            {
+                repo: revision ? `${repoName}@${revision}` : repoName,
+                validrev: revision,
+                path: all.slice(0, index + 1).join('/'),
+            }
+        ),
+    ])
 </script>
 
 <div class="header">

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/+page.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/+page.svelte
@@ -125,21 +125,21 @@
 
 <!-- Note: Splitting this at this level is not great but Svelte doesn't allow to conditionally render slots (yet) -->
 {#if data.compare}
-    <FileHeader type="blob" {repoName} path={filePath}>
+    <FileHeader type="blob" {repoName} {revision} path={filePath}>
         <FileIcon slot="icon" file={blob} inline />
         <svelte:fragment slot="actions">
             <span>{data.compare.revisionToCompare}</span>
         </svelte:fragment>
     </FileHeader>
 {:else if embedded}
-    <FileHeader type="blob" {repoName} path={filePath} hideSidebarToggle>
+    <FileHeader type="blob" {repoName} {revision} path={filePath} hideSidebarToggle>
         <FileIcon slot="icon" file={blob} inline />
         <svelte:fragment slot="actions">
             <slot name="actions" />
         </svelte:fragment>
     </FileHeader>
 {:else}
-    <FileHeader type="blob" {repoName} path={filePath}>
+    <FileHeader type="blob" {repoName} {revision} path={filePath}>
         <FileIcon slot="icon" file={blob} inline />
         <svelte:fragment slot="actions">
             {#await data.externalServiceType then externalServiceType}

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/page.spec.ts
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/page.spec.ts
@@ -241,6 +241,15 @@ test.describe('file header', () => {
         await expect(page.getByText('12.35 KB')).toBeVisible()
         await expect(page.getByText('42 lines')).toBeVisible()
     })
+
+    test('breadcrumbs', async ({ page }) => {
+        await page.goto(url)
+        const parentBreadcrumb = page.getByRole('link', { name: 'src' })
+        await expect(parentBreadcrumb).toBeVisible()
+        await parentBreadcrumb.click()
+        await page.waitForURL(`${repoName}/-/tree/src`)
+        await expect(page.getByRole('link', { name: 'src' })).toBeVisible()
+    })
 })
 
 test.describe('scroll behavior', () => {

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/tree/[...path]/+page.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/tree/[...path]/+page.svelte
@@ -2,16 +2,16 @@
     import { mdiMapSearch } from '@mdi/js'
 
     import Icon from '$lib/Icon.svelte'
+    import LoadingSpinner from '$lib/LoadingSpinner.svelte'
     import FileHeader from '$lib/repo/FileHeader.svelte'
+    import type { TreeEntryWithCommitInfo } from '$lib/repo/FileTable.gql'
+    import FileTable from '$lib/repo/FileTable.svelte'
     import Permalink from '$lib/repo/Permalink.svelte'
+    import Readme from '$lib/repo/Readme.svelte'
     import { createPromiseStore } from '$lib/utils'
+    import { Alert } from '$lib/wildcard'
 
     import type { PageData } from './$types'
-    import FileTable from '$lib/repo/FileTable.svelte'
-    import Readme from '$lib/repo/Readme.svelte'
-    import LoadingSpinner from '$lib/LoadingSpinner.svelte'
-    import { Alert } from '$lib/wildcard'
-    import type { TreeEntryWithCommitInfo } from '$lib/repo/FileTable.gql'
 
     export let data: PageData
 
@@ -24,7 +24,7 @@
     <title>{data.filePath} - {data.displayRepoName} - Sourcegraph</title>
 </svelte:head>
 
-<FileHeader type="tree" repoName={data.repoName} path={data.filePath}>
+<FileHeader type="tree" repoName={data.repoName} revision={data.revision} path={data.filePath}>
     <svelte:fragment slot="actions">
         <Permalink commitID={data.resolvedRevision.commitID} />
     </svelte:fragment>


### PR DESCRIPTION
This fixes some issues with the breadcrumbs in the file header:
1) The links did not preserve the current revision
2) The links assumed that if the current page was a blob, all parent breadcrumbs are also blobs. Everything but the last element in the path is guaranteed to be a tree.

## Test plan

Added a playwright test that we link back to a tree page correctly. Manually tested the current revision stuff. 

