### PR TITLE
Sort packages by exact match

### DIFF
--- a/internal/codeintel/dependencies/internal/store/store.go
+++ b/internal/codeintel/dependencies/internal/store/store.go
@@ -97,7 +97,7 @@ func (s *store) ListPackageRepoRefs(ctx context.Context, opts ListDependencyRepo
 	orderBy := sqlf.Sprintf("ORDER BY lr.id ASC")
 
 	if opts.Name != "" {
-		orderBy = sqlf.Sprintf("ORDER BY (CASE WHEN lr.name = %s THEN 1 ELSE 2 END), lr.name", opts.Name)
+		orderBy = sqlf.Sprintf("ORDER BY (CASE WHEN lr.name = %s THEN 1 ELSE 2 END) ASC, lr.id ASC", opts.Name)
 	}
 
 	query := sqlf.Sprintf(

--- a/internal/codeintel/dependencies/internal/store/store.go
+++ b/internal/codeintel/dependencies/internal/store/store.go
@@ -97,6 +97,7 @@ func (s *store) ListPackageRepoRefs(ctx context.Context, opts ListDependencyRepo
 	orderBy := sqlf.Sprintf("ORDER BY lr.id ASC")
 
 	if opts.Name != "" {
+		// this ordering ensures that the exact match will always be first on the list
 		orderBy = sqlf.Sprintf("ORDER BY (CASE WHEN lr.name = %s THEN 1 ELSE 2 END) ASC, lr.id ASC", opts.Name)
 	}
 

--- a/internal/codeintel/dependencies/internal/store/store_test.go
+++ b/internal/codeintel/dependencies/internal/store/store_test.go
@@ -213,7 +213,7 @@ func TestListPackageRepoRefsFuzzyExactMatchOrdering(t *testing.T) {
 
 	for _, test := range []struct {
 		opts    ListDependencyReposOpts
-		results []shared.PackageRepoReference
+		results []string
 	}{
 		// no exact-match present, order by id
 		{
@@ -222,28 +222,7 @@ func TestListPackageRepoRefsFuzzyExactMatchOrdering(t *testing.T) {
 				Scheme:    "npm",
 				Fuzziness: FuzzinessWildcard,
 			},
-			results: []shared.PackageRepoReference{
-				{
-					ID:     4,
-					Scheme: "npm",
-					Name:   "react-dom",
-					Versions: []shared.PackageRepoRefVersion{{
-						ID:           4,
-						PackageRefID: 4,
-						Version:      "1.0.0",
-					}},
-				},
-				{
-					ID:     5,
-					Scheme: "npm",
-					Name:   "react-docs",
-					Versions: []shared.PackageRepoRefVersion{{
-						ID:           5,
-						PackageRefID: 5,
-						Version:      "1.0.0",
-					}},
-				},
-			},
+			results: []string{"react-dom", "react-docs"},
 		},
 		// exact match present, order by exact match and then by id
 		{
@@ -252,48 +231,7 @@ func TestListPackageRepoRefsFuzzyExactMatchOrdering(t *testing.T) {
 				Scheme:    "npm",
 				Fuzziness: FuzzinessWildcard,
 			},
-			results: []shared.PackageRepoReference{
-				{
-					ID:     3,
-					Scheme: "npm",
-					Name:   "react",
-					Versions: []shared.PackageRepoRefVersion{{
-						ID:           3,
-						PackageRefID: 3,
-						Version:      "1.0.0",
-					}},
-				},
-				{
-					ID:     2,
-					Scheme: "npm",
-					Name:   "reactify",
-					Versions: []shared.PackageRepoRefVersion{{
-						ID:           2,
-						PackageRefID: 2,
-						Version:      "1.0.0",
-					}},
-				},
-				{
-					ID:     4,
-					Scheme: "npm",
-					Name:   "react-dom",
-					Versions: []shared.PackageRepoRefVersion{{
-						ID:           4,
-						PackageRefID: 4,
-						Version:      "1.0.0",
-					}},
-				},
-				{
-					ID:     5,
-					Scheme: "npm",
-					Name:   "react-docs",
-					Versions: []shared.PackageRepoRefVersion{{
-						ID:           5,
-						PackageRefID: 5,
-						Version:      "1.0.0",
-					}},
-				},
-			},
+			results: []string{"react", "reactify", "react-dom", "react-docs"},
 		},
 	} {
 		listedPkgs, _, _, err := store.ListPackageRepoRefs(ctx, test.opts)
@@ -301,7 +239,13 @@ func TestListPackageRepoRefsFuzzyExactMatchOrdering(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if diff := cmp.Diff(test.results, listedPkgs); diff != "" {
+		pkgNames := make([]string, 0)
+
+		for _, pkg := range listedPkgs {
+			pkgNames = append(pkgNames, string(pkg.Name))
+		}
+
+		if diff := cmp.Diff(test.results, pkgNames); diff != "" {
 			t.Errorf("mismatch (-want, +got): %s", diff)
 		}
 	}


### PR DESCRIPTION
The `packageRepoReferences` API lists repositories by doing a fuzzy search against the `name` argument but it doesn't sort them according to name or exact match.

This PR addresses the issue and first sorts the results by exact match and then by id asc

## Test plan

unit tests added