### PR TITLE
appliance: de-dup common service features

### DIFF
--- a/internal/appliance/BUILD.bazel
+++ b/internal/appliance/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
     importpath = "github.com/sourcegraph/sourcegraph/internal/appliance",
     visibility = ["//:__subpackages__"],
     deps = [
+        "//internal/appliance/config",
         "//internal/appliance/v1:appliance",
         "//internal/k8s/resource/container",
         "//internal/k8s/resource/deployment",
@@ -21,9 +22,7 @@ go_library(
         "//internal/k8s/resource/pvc",
         "//internal/k8s/resource/service",
         "//internal/k8s/resource/serviceaccount",
-        "//internal/maps",
         "//lib/errors",
-        "//lib/pointers",
         "@io_k8s_api//apps/v1:apps",
         "@io_k8s_api//core/v1:core",
         "@io_k8s_apimachinery//pkg/api/errors",
@@ -39,6 +38,7 @@ go_library(
         "@io_k8s_sigs_controller_runtime//pkg/predicate",
         "@io_k8s_sigs_controller_runtime//pkg/reconcile",
         "@io_k8s_sigs_yaml//:yaml",
+        "@io_k8s_utils//ptr",
     ],
 )
 

--- a/internal/appliance/blobstore.go
+++ b/internal/appliance/blobstore.go
@@ -114,27 +114,22 @@ func buildBlobstoreDeployment(sg *Sourcegraph) appsv1.Deployment {
 		},
 	}
 
-	defaultContainer := container.NewContainer(name, sg.Spec.Blobstore)
+	defaultContainer := container.NewContainer(name, sg.Spec.Blobstore, corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("1"),
+			corev1.ResourceMemory: resource.MustParse("500M"),
+		},
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("1"),
+			corev1.ResourceMemory: resource.MustParse("500M"),
+		},
+	})
 
 	// TODO: https://github.com/sourcegraph/sourcegraph/issues/62076
 	defaultContainer.Image = "index.docker.io/sourcegraph/blobstore:5.3.2@sha256:d625be1eefe61cc42f94498e3c588bf212c4159c8b20c519db84eae4ff715efa"
 
 	defaultContainer.Ports = containerPorts
 	defaultContainer.VolumeMounts = containerVolumeMounts
-
-	// default resources
-	if container.HasNoConfiguredResources(defaultContainer) {
-		defaultContainer.Resources = corev1.ResourceRequirements{
-			Requests: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("1"),
-				corev1.ResourceMemory: resource.MustParse("500M"),
-			},
-			Limits: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("1"),
-				corev1.ResourceMemory: resource.MustParse("500M"),
-			},
-		}
-	}
 
 	podVolumes := []corev1.Volume{
 		{

--- a/internal/appliance/blobstore.go
+++ b/internal/appliance/blobstore.go
@@ -15,7 +15,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/k8s/resource/pvc"
 	"github.com/sourcegraph/sourcegraph/internal/k8s/resource/service"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
-	"github.com/sourcegraph/sourcegraph/lib/pointers"
 )
 
 func (r *Reconciler) reconcileBlobstore(ctx context.Context, sg *Sourcegraph, owner client.Object) error {
@@ -70,13 +69,13 @@ func (r *Reconciler) reconcileBlobstorePersistentVolumeClaims(ctx context.Contex
 		return err
 	}
 
-	return reconcileBlobStoreObject(ctx, r, &p, &corev1.PersistentVolumeClaim{}, sg, owner)
+	return reconcileObject(ctx, r, sg.Spec.Blobstore, &p, &corev1.PersistentVolumeClaim{}, sg, owner)
 }
 
 func buildBlobstoreService(sg *Sourcegraph) corev1.Service {
 	name := "blobstore"
 
-	s := service.NewService(name, sg.Namespace)
+	s := service.NewService(name, sg.Namespace, sg.Spec.Blobstore)
 	s.Spec.Ports = []corev1.ServicePort{
 		{
 			Name:       name,
@@ -93,7 +92,7 @@ func buildBlobstoreService(sg *Sourcegraph) corev1.Service {
 
 func (r *Reconciler) reconcileBlobstoreServices(ctx context.Context, sg *Sourcegraph, owner client.Object) error {
 	s := buildBlobstoreService(sg)
-	return reconcileBlobStoreObject(ctx, r, &s, &corev1.Service{}, sg, owner)
+	return reconcileObject(ctx, r, sg.Spec.Blobstore, &s, &corev1.Service{}, sg, owner)
 }
 
 func buildBlobstoreDeployment(sg *Sourcegraph) appsv1.Deployment {
@@ -103,38 +102,6 @@ func buildBlobstoreDeployment(sg *Sourcegraph) appsv1.Deployment {
 		Name:          name,
 		ContainerPort: 9000,
 	}}
-
-	containerResources := corev1.ResourceRequirements{
-		Limits: corev1.ResourceList{
-			corev1.ResourceCPU:    resource.MustParse("1"),
-			corev1.ResourceMemory: resource.MustParse("500M"),
-		},
-		Requests: corev1.ResourceList{
-			corev1.ResourceCPU:    resource.MustParse("1"),
-			corev1.ResourceMemory: resource.MustParse("500M"),
-		},
-	}
-	if sg.Spec.Blobstore.Resources != nil {
-		limCPU := sg.Spec.Blobstore.Resources.Limits.Cpu()
-		limMem := sg.Spec.Blobstore.Resources.Limits.Memory()
-		reqCPU := sg.Spec.Blobstore.Resources.Limits.Cpu()
-		reqMem := sg.Spec.Blobstore.Resources.Limits.Memory()
-
-		containerResources = corev1.ResourceRequirements{
-			Limits: corev1.ResourceList{
-				corev1.ResourceCPU:    pointers.DerefZero(limCPU),
-				corev1.ResourceMemory: pointers.DerefZero(limMem),
-			},
-			Requests: corev1.ResourceList{
-				corev1.ResourceCPU:    pointers.DerefZero(reqCPU),
-				corev1.ResourceMemory: pointers.DerefZero(reqMem),
-			},
-		}
-	}
-
-	if sg.Spec.LocalDevMode {
-		containerResources = corev1.ResourceRequirements{}
-	}
 
 	containerVolumeMounts := []corev1.VolumeMount{
 		{
@@ -147,14 +114,27 @@ func buildBlobstoreDeployment(sg *Sourcegraph) appsv1.Deployment {
 		},
 	}
 
-	defaultContainer := container.NewContainer(name)
+	defaultContainer := container.NewContainer(name, sg.Spec.Blobstore)
 
 	// TODO: https://github.com/sourcegraph/sourcegraph/issues/62076
 	defaultContainer.Image = "index.docker.io/sourcegraph/blobstore:5.3.2@sha256:d625be1eefe61cc42f94498e3c588bf212c4159c8b20c519db84eae4ff715efa"
 
 	defaultContainer.Ports = containerPorts
-	defaultContainer.Resources = containerResources
 	defaultContainer.VolumeMounts = containerVolumeMounts
+
+	// default resources
+	if container.HasNoConfiguredResources(defaultContainer) {
+		defaultContainer.Resources = corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("1"),
+				corev1.ResourceMemory: resource.MustParse("500M"),
+			},
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("1"),
+				corev1.ResourceMemory: resource.MustParse("500M"),
+			},
+		}
+	}
 
 	podVolumes := []corev1.Volume{
 		{
@@ -189,24 +169,5 @@ func buildBlobstoreDeployment(sg *Sourcegraph) appsv1.Deployment {
 
 func (r *Reconciler) reconcileBlobstoreDeployments(ctx context.Context, sg *Sourcegraph, owner client.Object) error {
 	d := buildBlobstoreDeployment(sg)
-	return reconcileBlobStoreObject(ctx, r, &d, &appsv1.Deployment{}, sg, owner)
-}
-
-func reconcileBlobStoreObject[T client.Object](ctx context.Context, r *Reconciler, obj, objKind T, sg *Sourcegraph, owner client.Object) error {
-	if sg.Spec.Blobstore.Disabled {
-		return r.ensureObjectDeleted(ctx, obj)
-	}
-
-	// Any secrets (or other configmaps) referenced in BlobStoreSpec can be
-	// added to this struct so that they are hashed, and cause an update to the
-	// Deployment if changed.
-	updateIfChanged := struct {
-		BlobstoreSpec
-		Version string
-	}{
-		BlobstoreSpec: sg.Spec.Blobstore,
-		Version:       sg.Spec.RequestedVersion,
-	}
-
-	return createOrUpdateObject(ctx, r, updateIfChanged, owner, obj, objKind)
+	return reconcileObject(ctx, r, sg.Spec.Blobstore, &d, &appsv1.Deployment{}, sg, owner)
 }

--- a/internal/appliance/config/BUILD.bazel
+++ b/internal/appliance/config/BUILD.bazel
@@ -1,0 +1,9 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "config",
+    srcs = ["config.go"],
+    importpath = "github.com/sourcegraph/sourcegraph/internal/appliance/config",
+    visibility = ["//:__subpackages__"],
+    deps = ["@io_k8s_api//core/v1:core"],
+)

--- a/internal/appliance/config/config.go
+++ b/internal/appliance/config/config.go
@@ -4,7 +4,7 @@ import corev1 "k8s.io/api/core/v1"
 
 type StandardComponent interface {
 	Disableable
-	GetResources() map[string]*corev1.ResourceRequirements
+	GetResources() map[string]corev1.ResourceRequirements
 	GetServiceAccountAnnotations() map[string]string
 	PrometheusPort() *int
 }
@@ -14,13 +14,13 @@ type Disableable interface {
 }
 
 type StandardConfig struct {
-	Disabled                  bool                                    `json:"disabled,omitempty"`
-	Resources                 map[string]*corev1.ResourceRequirements `json:"resources,omitempty"`
-	ServiceAccountAnnotations map[string]string                       `json:"serviceAccountAnnotations,omitempty"`
+	Disabled                  bool                                   `json:"disabled,omitempty"`
+	Resources                 map[string]corev1.ResourceRequirements `json:"resources,omitempty"`
+	ServiceAccountAnnotations map[string]string                      `json:"serviceAccountAnnotations,omitempty"`
 }
 
-func (c StandardConfig) IsDisabled() bool                                      { return c.Disabled }
-func (c StandardConfig) GetResources() map[string]*corev1.ResourceRequirements { return c.Resources }
+func (c StandardConfig) IsDisabled() bool                                     { return c.Disabled }
+func (c StandardConfig) GetResources() map[string]corev1.ResourceRequirements { return c.Resources }
 func (c StandardConfig) GetServiceAccountAnnotations() map[string]string {
 	return c.ServiceAccountAnnotations
 }

--- a/internal/appliance/config/config.go
+++ b/internal/appliance/config/config.go
@@ -1,0 +1,26 @@
+package config
+
+import corev1 "k8s.io/api/core/v1"
+
+type StandardComponent interface {
+	Disableable
+	GetResources() map[string]*corev1.ResourceRequirements
+	GetServiceAccountAnnotations() map[string]string
+	PrometheusPort() *int
+}
+
+type Disableable interface {
+	IsDisabled() bool
+}
+
+type StandardConfig struct {
+	Disabled                  bool                                    `json:"disabled,omitempty"`
+	Resources                 map[string]*corev1.ResourceRequirements `json:"resources,omitempty"`
+	ServiceAccountAnnotations map[string]string                       `json:"serviceAccountAnnotations,omitempty"`
+}
+
+func (c StandardConfig) IsDisabled() bool                                      { return c.Disabled }
+func (c StandardConfig) GetResources() map[string]*corev1.ResourceRequirements { return c.Resources }
+func (c StandardConfig) GetServiceAccountAnnotations() map[string]string {
+	return c.ServiceAccountAnnotations
+}

--- a/internal/appliance/development.md
+++ b/internal/appliance/development.md
@@ -27,8 +27,8 @@ By embedding StandardConfig, you'll get various features for almost-free:
   logic at all, usually.
 - Container resources
 - Service account annotations
-   - This is an extremely common customization need, e.g. to enable GKE
-     workload-identity bindings.
+  - This is an extremely common customization need, e.g. to enable GKE
+    workload-identity bindings.
 - Adding standard prometheus scrape directive annotations to Services (k8s
   v1.Service - there's that term overloading again).
 
@@ -43,7 +43,7 @@ prometheus annotations appear? Fix / add standard features as required.
 
 ### Reconciler
 
-`reconciler.go` is the entrypoint to start at. The aim is to write a function
+`reconcile.go` is the entrypoint to start at. The aim is to write a function
 that converges the cluster onto some desired state based on the config input.
 See the `reconcileXYZ` (e.g. `reconcileBlobstore`). Follow the patterns other
 services use, to create/update/delete Kubernetes objects required for your

--- a/internal/appliance/development.md
+++ b/internal/appliance/development.md
@@ -1,5 +1,88 @@
 # Appliance development
 
+## Adding a new service
+
+Note: the term "service" is overloaded. In this context, it refers to a
+Sourcegraph component, e.g. blobstore, or repo-updater. Sometimes you will see
+the word "component" used instead.
+
+The next 4 sections aim to act as a rough quickstart. Please also look at recent
+commits that touch this directory, and speak to authors if you like! We
+recommend reading all 3 sections up-front, and re-shuffling / blending all 4
+activities while developing your service config. For example, you could sketch
+out config in a test, before you start writing your reconciler, then jump back
+and forth between the two.
+
+### Config
+
+First, add a config element to SourcegraphSpec in spec.go (or modify an existing
+one). Consider "how unique" this service is, and whether it could benefit from
+embedding StandardConfig. Take a look at this struct, and the corresponding
+StandardComponent interface, in the `config` subpackage.
+
+By embedding StandardConfig, you'll get various features for almost-free:
+
+- The ability to disable the service, which allows the use of
+  `reconcileObject()`. This frees the developer from writing any upsert/delete
+  logic at all, usually.
+- Container resources
+- Service account annotations
+   - This is an extremely common customization need, e.g. to enable GKE
+     workload-identity bindings.
+- Adding standard prometheus scrape directive annotations to Services (k8s
+  v1.Service - there's that term overloading again).
+
+The idea is that most services have a lot in common, and by making these aspects
+framework-supported, we reduce the probability of errors. There's a big pile of
+config to write, and errors can be like needles in a haystack.
+
+Remember, everything is permanently WIP, never finished. It's possible some of
+these standard features may be incomplete. Write tests, and inspect your golden
+fixtures closely - did container resources propagate as expected? Do the
+prometheus annotations appear? Fix / add standard features as required.
+
+### Reconciler
+
+`reconciler.go` is the entrypoint to start at. The aim is to write a function
+that converges the cluster onto some desired state based on the config input.
+See the `reconcileXYZ` (e.g. `reconcileBlobstore`). Follow the patterns other
+services use, to create/update/delete Kubernetes objects required for your
+service.
+
+`kubernetes.go` contains some generic functions for creating, updating, and
+deleting kubernetes objects. It's worth having a quick look at these, and seeing
+how other services make use of them.
+
+### Golden tests
+
+This package makes use of `kubernetes/controller-runtime/envtest` and the
+concept of [golden fixtures](https://ro-che.info/articles/2017-12-04-golden-tests)
+to examine the set of resources that our reconciler will deploy to a Kubernetes
+API server in response to some config input.
+
+At the time of writing, `testify/suite` is used to start the kube-apiserver and
+etcd once, before all tests run, and stop it at the end. See `blobstore_test.go`
+for an example of an existing service that makes use of golden tests.
+
+See the "Running tests" section below for more info on generating golden
+fixtures and running the tests.
+
+### That's a lot of YAML, how do I even know this is what I want?
+
+The `dev/compare-helm` subpackage contains a developer utility that allows you
+to compare a golden fixture with the resources output by our Helm chart for the
+same service. See the README in that package for more details.
+
+We don't want to produce a 1:1 replica of Helm - with the appliance, we may even
+remove customization that is not useful, and add customization that is - but the
+diff is a useful guide.
+
+Become familiar with the templates in `deploy-sourcegraph-helm` that pertain to
+your service, and also the general helpers and values that feed into
+if-statements and loops in those templates. You may want to pass values to Helm
+(see -helm-template-extra-args docs in the README), and add corresponding
+customization controls in your config element in the appliance.
+
 ## Running tests
 
 To (re)generate golden fixtures, pass the following argument to `go test`:

--- a/internal/appliance/repo_updater.go
+++ b/internal/appliance/repo_updater.go
@@ -45,7 +45,16 @@ func (r *Reconciler) reconcileRepoUpdaterDeployment(ctx context.Context, sg *Sou
 	cfg := sg.Spec.RepoUpdater
 	name := "repo-updater"
 
-	ctr := container.NewContainer(name, cfg)
+	ctr := container.NewContainer(name, cfg, corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("1"),
+			corev1.ResourceMemory: resource.MustParse("500Mi"),
+		},
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("1"),
+			corev1.ResourceMemory: resource.MustParse("2Gi"),
+		},
+	})
 
 	// TODO: https://github.com/sourcegraph/sourcegraph/issues/62076
 	ctr.Image = "index.docker.io/sourcegraph/repo-updater:5.3.2@sha256:5a414aa030c7e0922700664a43b449ee5f3fafa68834abef93988c5992c747c6"
@@ -87,20 +96,6 @@ func (r *Reconciler) reconcileRepoUpdaterDeployment(ctx context.Context, sg *Sou
 		FailureThreshold: 3,
 		PeriodSeconds:    1,
 		TimeoutSeconds:   5,
-	}
-
-	// default resources
-	if container.HasNoConfiguredResources(ctr) {
-		ctr.Resources = corev1.ResourceRequirements{
-			Requests: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("1"),
-				corev1.ResourceMemory: resource.MustParse("500Mi"),
-			},
-			Limits: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("1"),
-				corev1.ResourceMemory: resource.MustParse("2Gi"),
-			},
-		}
 	}
 
 	podTemplate := pod.NewPodTemplate(name)

--- a/internal/appliance/repo_updater.go
+++ b/internal/appliance/repo_updater.go
@@ -14,7 +14,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/k8s/resource/pod"
 	"github.com/sourcegraph/sourcegraph/internal/k8s/resource/service"
 	"github.com/sourcegraph/sourcegraph/internal/k8s/resource/serviceaccount"
-	"github.com/sourcegraph/sourcegraph/internal/maps"
 )
 
 func (r *Reconciler) reconcileRepoUpdater(ctx context.Context, sg *Sourcegraph, owner client.Object) error {
@@ -31,7 +30,7 @@ func (r *Reconciler) reconcileRepoUpdater(ctx context.Context, sg *Sourcegraph, 
 }
 
 func (r *Reconciler) reconcileRepoUpdaterService(ctx context.Context, sg *Sourcegraph, owner client.Object) error {
-	svc := service.NewService("repo-updater", sg.Namespace)
+	svc := service.NewService("repo-updater", sg.Namespace, sg.Spec.RepoUpdater)
 	svc.Spec.Ports = []corev1.ServicePort{
 		{Name: "http", TargetPort: intstr.FromString("http"), Port: 3182},
 	}
@@ -39,14 +38,14 @@ func (r *Reconciler) reconcileRepoUpdaterService(ctx context.Context, sg *Source
 		"app": "repo-updater",
 	}
 
-	return reconcileRepoUpdaterObject(ctx, r, &svc, &corev1.Service{}, sg, owner)
+	return reconcileObject(ctx, r, sg.Spec.RepoUpdater, &svc, &corev1.Service{}, sg, owner)
 }
 
 func (r *Reconciler) reconcileRepoUpdaterDeployment(ctx context.Context, sg *Sourcegraph, owner client.Object) error {
 	cfg := sg.Spec.RepoUpdater
 	name := "repo-updater"
 
-	ctr := container.NewContainer(name)
+	ctr := container.NewContainer(name, cfg)
 
 	// TODO: https://github.com/sourcegraph/sourcegraph/issues/62076
 	ctr.Image = "index.docker.io/sourcegraph/repo-updater:5.3.2@sha256:5a414aa030c7e0922700664a43b449ee5f3fafa68834abef93988c5992c747c6"
@@ -91,19 +90,17 @@ func (r *Reconciler) reconcileRepoUpdaterDeployment(ctx context.Context, sg *Sou
 	}
 
 	// default resources
-	ctr.Resources = corev1.ResourceRequirements{
-		Requests: corev1.ResourceList{
-			corev1.ResourceCPU:    resource.MustParse("1"),
-			corev1.ResourceMemory: resource.MustParse("500Mi"),
-		},
-		Limits: corev1.ResourceList{
-			corev1.ResourceCPU:    resource.MustParse("1"),
-			corev1.ResourceMemory: resource.MustParse("2Gi"),
-		},
-	}
-
-	if cfg.Resources != nil {
-		ctr.Resources = *cfg.Resources
+	if container.HasNoConfiguredResources(ctr) {
+		ctr.Resources = corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("1"),
+				corev1.ResourceMemory: resource.MustParse("500Mi"),
+			},
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("1"),
+				corev1.ResourceMemory: resource.MustParse("2Gi"),
+			},
+		}
 	}
 
 	podTemplate := pod.NewPodTemplate(name)
@@ -113,31 +110,11 @@ func (r *Reconciler) reconcileRepoUpdaterDeployment(ctx context.Context, sg *Sou
 	dep.Spec.Template = podTemplate.Template
 	dep.Spec.Template.Spec.ServiceAccountName = name
 
-	return reconcileRepoUpdaterObject(ctx, r, &dep, &appsv1.Deployment{}, sg, owner)
+	return reconcileObject(ctx, r, sg.Spec.RepoUpdater, &dep, &appsv1.Deployment{}, sg, owner)
 }
 
 func (r *Reconciler) reconcileRepoUpdaterServiceAccount(ctx context.Context, sg *Sourcegraph, owner client.Object) error {
 	cfg := sg.Spec.RepoUpdater
-	sa := serviceaccount.NewServiceAccount("repo-updater", sg.Namespace)
-	sa.SetAnnotations(maps.Merge(sa.GetAnnotations(), cfg.ServiceAccountAnnotations))
-	return reconcileRepoUpdaterObject(ctx, r, &sa, &corev1.ServiceAccount{}, sg, owner)
-}
-
-func reconcileRepoUpdaterObject[T client.Object](ctx context.Context, r *Reconciler, obj, objKind T, sg *Sourcegraph, owner client.Object) error {
-	if sg.Spec.RepoUpdater.Disabled {
-		return r.ensureObjectDeleted(ctx, obj)
-	}
-
-	// Any secrets (or other configmaps) referenced in this spec can be
-	// added to this struct so that they are hashed, and cause an update to the
-	// resource if changed.
-	updateIfChanged := struct {
-		RepoUpdaterSpec
-		Version string
-	}{
-		RepoUpdaterSpec: sg.Spec.RepoUpdater,
-		Version:         sg.Spec.RequestedVersion,
-	}
-
-	return createOrUpdateObject(ctx, r, updateIfChanged, owner, obj, objKind)
+	sa := serviceaccount.NewServiceAccount("repo-updater", sg.Namespace, cfg)
+	return reconcileObject(ctx, r, sg.Spec.RepoUpdater, &sa, &corev1.ServiceAccount{}, sg, owner)
 }

--- a/internal/appliance/repo_updater_test.go
+++ b/internal/appliance/repo_updater_test.go
@@ -10,6 +10,7 @@ func (suite *ApplianceTestSuite) TestDeployRepoUpdater() {
 	}{
 		{name: "repo-updater-default"},
 		{name: "repo-updater-with-resources"},
+		{name: "repo-updater-with-no-resources"},
 		{name: "repo-updater-with-sa-annotations"},
 	} {
 		suite.Run(tc.name, func() {

--- a/internal/appliance/spec.go
+++ b/internal/appliance/spec.go
@@ -3,6 +3,9 @@ package appliance
 import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+
+	"github.com/sourcegraph/sourcegraph/internal/appliance/config"
 )
 
 type ManagementStateType string
@@ -27,20 +30,17 @@ type DatabaseSpec struct {
 
 // BlobstoreSpec defines the desired state of Blobstore.
 type BlobstoreSpec struct {
-	// Disabled defines if Blobstore is enabled or not.
-	// Default: false
-	Disabled bool `json:"disabled,omitempty"`
+	config.StandardConfig
 
 	// StorageSize defines the requested amount of storage for the PVC.
 	// Default: 200Gi
 	StorageSize string `json:"storageSize,omitempty"`
 
-	// Resources allows for custom resource limits and requests.
-	Resources *corev1.ResourceRequirements `json:"resources,omitempty"`
-
 	// Env defines environment variables for Blobstore.
 	Env map[string]string `json:"env,omitempty"`
 }
+
+func (BlobstoreSpec) PrometheusPort() *int { return nil }
 
 // CodeInsightsDBSpec defines the desired state of Code Insights database.
 type CodeInsightsDBSpec struct {
@@ -256,18 +256,13 @@ type RedisStoreSpec struct {
 
 // RepoUpdaterSpec defines the desired state of the Repo Updater service.
 type RepoUpdaterSpec struct {
-	// Disabled defines if Repo Updater is enabled or not.
-	// Default: false
-	Disabled bool `json:"disabled,omitempty"`
-
-	// Resources allows for custom resource limits and requests.
-	Resources *corev1.ResourceRequirements `json:"resources,omitempty"`
+	config.StandardConfig
 
 	// Env defines environment variables for Redis Updater.
 	Env map[string]string `json:"env,omitempty"`
-
-	ServiceAccountAnnotations map[string]string `json:"serviceAccountAnnotations,omitempty"`
 }
+
+func (RepoUpdaterSpec) PrometheusPort() *int { return ptr.To(6060) }
 
 // SearcherSpec defines the desired state of the Searcher service.
 type SearcherSpec struct {
@@ -361,11 +356,6 @@ type SourcegraphSpec struct {
 	// ManagementState defines if Sourcegraph should be managed by the operator or not.
 	// Default is managed.
 	ManagementState ManagementStateType `json:"managementState,omitempty"`
-
-	// LocalDevMode will remove all resource requests, allowing the scheduler to best-fit pods.
-	// Intended for local development with limited resources.
-	// Default: false
-	LocalDevMode bool `json:"localDevMode,omitempty"`
 
 	// MaintenancePassword will set the password for the administrator maintenance UI.
 	// If no password is set, a random password will be generated and storage in a secret.

--- a/internal/appliance/testdata/golden-fixtures/blobstore-default.yaml
+++ b/internal/appliance/testdata/golden-fixtures/blobstore-default.yaml
@@ -3,7 +3,7 @@ resources:
   kind: Deployment
   metadata:
     annotations:
-      appliance.sourcegraph.com/configHash: ec8df597cb447c262ad15de9e72b1f836e1b631c928fcc06914500caa58f8cc3
+      appliance.sourcegraph.com/configHash: bd6ab558ec98ed6b2607b80469bb9f209b485fa44a6dd5beaf18c37011340afc
     creationTimestamp: "2024-04-19T00:00:00Z"
     generation: 1
     labels:
@@ -153,7 +153,7 @@ resources:
   kind: PersistentVolumeClaim
   metadata:
     annotations:
-      appliance.sourcegraph.com/configHash: ec8df597cb447c262ad15de9e72b1f836e1b631c928fcc06914500caa58f8cc3
+      appliance.sourcegraph.com/configHash: bd6ab558ec98ed6b2607b80469bb9f209b485fa44a6dd5beaf18c37011340afc
     creationTimestamp: "2024-04-19T00:00:00Z"
     finalizers:
     - kubernetes.io/pvc-protection
@@ -176,10 +176,11 @@ resources:
   kind: Service
   metadata:
     annotations:
-      appliance.sourcegraph.com/configHash: ec8df597cb447c262ad15de9e72b1f836e1b631c928fcc06914500caa58f8cc3
+      appliance.sourcegraph.com/configHash: bd6ab558ec98ed6b2607b80469bb9f209b485fa44a6dd5beaf18c37011340afc
     creationTimestamp: "2024-04-19T00:00:00Z"
     labels:
       app: blobstore
+      app.kubernetes.io/component: blobstore
       deploy: sourcegraph
     name: blobstore
     namespace: NORMALIZED_FOR_TESTING

--- a/internal/appliance/testdata/golden-fixtures/blobstore-subsequent-disable.yaml
+++ b/internal/appliance/testdata/golden-fixtures/blobstore-subsequent-disable.yaml
@@ -72,7 +72,7 @@ resources:
   kind: PersistentVolumeClaim
   metadata:
     annotations:
-      appliance.sourcegraph.com/configHash: ec8df597cb447c262ad15de9e72b1f836e1b631c928fcc06914500caa58f8cc3
+      appliance.sourcegraph.com/configHash: bd6ab558ec98ed6b2607b80469bb9f209b485fa44a6dd5beaf18c37011340afc
     creationTimestamp: "2024-04-19T00:00:00Z"
     deletionGracePeriodSeconds: 0
     deletionTimestamp: "2024-04-19T00:00:00Z"

--- a/internal/appliance/testdata/golden-fixtures/repo-updater-default.yaml
+++ b/internal/appliance/testdata/golden-fixtures/repo-updater-default.yaml
@@ -3,7 +3,7 @@ resources:
   kind: Deployment
   metadata:
     annotations:
-      appliance.sourcegraph.com/configHash: ec8df597cb447c262ad15de9e72b1f836e1b631c928fcc06914500caa58f8cc3
+      appliance.sourcegraph.com/configHash: bd6ab558ec98ed6b2607b80469bb9f209b485fa44a6dd5beaf18c37011340afc
     creationTimestamp: "2024-04-19T00:00:00Z"
     generation: 1
     labels:
@@ -183,7 +183,7 @@ resources:
   kind: ServiceAccount
   metadata:
     annotations:
-      appliance.sourcegraph.com/configHash: ec8df597cb447c262ad15de9e72b1f836e1b631c928fcc06914500caa58f8cc3
+      appliance.sourcegraph.com/configHash: bd6ab558ec98ed6b2607b80469bb9f209b485fa44a6dd5beaf18c37011340afc
     creationTimestamp: "2024-04-19T00:00:00Z"
     labels:
       deploy: sourcegraph
@@ -195,10 +195,13 @@ resources:
   kind: Service
   metadata:
     annotations:
-      appliance.sourcegraph.com/configHash: ec8df597cb447c262ad15de9e72b1f836e1b631c928fcc06914500caa58f8cc3
+      appliance.sourcegraph.com/configHash: bd6ab558ec98ed6b2607b80469bb9f209b485fa44a6dd5beaf18c37011340afc
+      prometheus.io/port: "6060"
+      sourcegraph.prometheus/scrape: "true"
     creationTimestamp: "2024-04-19T00:00:00Z"
     labels:
       app: repo-updater
+      app.kubernetes.io/component: repo-updater
       deploy: sourcegraph
     name: repo-updater
     namespace: NORMALIZED_FOR_TESTING

--- a/internal/appliance/testdata/golden-fixtures/repo-updater-with-no-resources.yaml
+++ b/internal/appliance/testdata/golden-fixtures/repo-updater-with-no-resources.yaml
@@ -1,0 +1,224 @@
+resources:
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    annotations:
+      appliance.sourcegraph.com/configHash: 194a6cc637fde1a16b0c81a98a8c5320c807f7e832158a658b49bb33afe76bd3
+    creationTimestamp: "2024-04-19T00:00:00Z"
+    generation: 1
+    labels:
+      app.kubernetes.io/component: repo-updater
+      app.kubernetes.io/name: sourcegraph
+      app.kubernetes.io/version: 5.3.9104
+      deploy: sourcegraph
+    name: repo-updater
+    namespace: NORMALIZED_FOR_TESTING
+    resourceVersion: NORMALIZED_FOR_TESTING
+    uid: NORMALIZED_FOR_TESTING
+  spec:
+    minReadySeconds: 10
+    progressDeadlineSeconds: 600
+    replicas: 1
+    revisionHistoryLimit: 10
+    selector:
+      matchLabels:
+        app: repo-updater
+    strategy:
+      rollingUpdate:
+        maxSurge: 25%
+        maxUnavailable: 25%
+      type: RollingUpdate
+    template:
+      metadata:
+        annotations:
+          kubectl.kubernetes.io/default-container: repo-updater
+        creationTimestamp: null
+        labels:
+          app: repo-updater
+          deploy: sourcegraph
+        name: repo-updater
+      spec:
+        containers:
+        - env:
+          - name: REDIS_CACHE_ENDPOINT
+            valueFrom:
+              secretKeyRef:
+                key: endpoint
+                name: redis-cache
+          - name: REDIS_STORE_ENDPOINT
+            valueFrom:
+              secretKeyRef:
+                key: endpoint
+                name: redis-store
+          - name: OTEL_AGENT_HOST
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: status.hostIP
+          - name: OTEL_EXPORTER_OTLP_ENDPOINT
+            value: http://$(OTEL_AGENT_HOST):4317
+          image: index.docker.io/sourcegraph/repo-updater:5.3.2@sha256:5a414aa030c7e0922700664a43b449ee5f3fafa68834abef93988c5992c747c6
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /healthz
+              port: debug
+              scheme: HTTP
+            periodSeconds: 1
+            successThreshold: 1
+            timeoutSeconds: 5
+          name: repo-updater
+          ports:
+          - containerPort: 3182
+            name: http
+            protocol: TCP
+          - containerPort: 6060
+            name: debug
+            protocol: TCP
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /ready
+              port: debug
+              scheme: HTTP
+            periodSeconds: 1
+            successThreshold: 1
+            timeoutSeconds: 5
+          resources: {}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsGroup: 101
+            runAsUser: 100
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: FallbackToLogsOnError
+        dnsPolicy: ClusterFirst
+        restartPolicy: Always
+        schedulerName: default-scheduler
+        securityContext:
+          fsGroup: 101
+          fsGroupChangePolicy: OnRootMismatch
+          runAsGroup: 101
+          runAsUser: 100
+        serviceAccount: repo-updater
+        serviceAccountName: repo-updater
+        terminationGracePeriodSeconds: 30
+  status: {}
+- apiVersion: v1
+  data:
+    spec: |
+      spec:
+        requestedVersion: "5.3.9104"
+
+        blobstore:
+          disabled: true
+
+        codeInsights:
+          disabled: true
+
+        codeIntel:
+          disabled: true
+
+        frontend:
+          disabled: true
+
+        gitServer:
+          disabled: true
+
+        indexedSearch:
+          disabled: true
+
+        indexedSearchIndexer:
+          disabled: true
+
+        pgsql:
+          disabled: true
+
+        postgresExporter:
+          disabled: true
+
+        preciseCodeIntel:
+          disabled: true
+
+        redisCache:
+          disabled: true
+
+        redisExporter:
+          disabled: true
+
+        redisStore:
+          disabled: true
+
+        repoUpdater:
+          resources:
+            repo-updater: null
+
+        searcher:
+          disabled: true
+
+        symbols:
+          disabled: true
+
+        syntectServer:
+          disabled: true
+
+        worker:
+          disabled: true
+  kind: ConfigMap
+  metadata:
+    annotations:
+      appliance.sourcegraph.com/currentVersion: 5.3.9104
+      appliance.sourcegraph.com/managed: "true"
+    creationTimestamp: "2024-04-19T00:00:00Z"
+    name: sg
+    namespace: NORMALIZED_FOR_TESTING
+    resourceVersion: NORMALIZED_FOR_TESTING
+    uid: NORMALIZED_FOR_TESTING
+- apiVersion: v1
+  kind: ServiceAccount
+  metadata:
+    annotations:
+      appliance.sourcegraph.com/configHash: 194a6cc637fde1a16b0c81a98a8c5320c807f7e832158a658b49bb33afe76bd3
+    creationTimestamp: "2024-04-19T00:00:00Z"
+    labels:
+      deploy: sourcegraph
+    name: repo-updater
+    namespace: NORMALIZED_FOR_TESTING
+    resourceVersion: NORMALIZED_FOR_TESTING
+    uid: NORMALIZED_FOR_TESTING
+- apiVersion: v1
+  kind: Service
+  metadata:
+    annotations:
+      appliance.sourcegraph.com/configHash: 194a6cc637fde1a16b0c81a98a8c5320c807f7e832158a658b49bb33afe76bd3
+      prometheus.io/port: "6060"
+      sourcegraph.prometheus/scrape: "true"
+    creationTimestamp: "2024-04-19T00:00:00Z"
+    labels:
+      app: repo-updater
+      app.kubernetes.io/component: repo-updater
+      deploy: sourcegraph
+    name: repo-updater
+    namespace: NORMALIZED_FOR_TESTING
+    resourceVersion: NORMALIZED_FOR_TESTING
+    uid: NORMALIZED_FOR_TESTING
+  spec:
+    clusterIP: NORMALIZED_FOR_TESTING
+    clusterIPs:
+    - NORMALIZED_FOR_TESTING
+    internalTrafficPolicy: Cluster
+    ipFamilies:
+    - IPv4
+    ipFamilyPolicy: SingleStack
+    ports:
+    - name: http
+      port: 3182
+      protocol: TCP
+      targetPort: http
+    selector:
+      app: repo-updater
+    sessionAffinity: None
+    type: ClusterIP
+  status:
+    loadBalancer: {}

--- a/internal/appliance/testdata/golden-fixtures/repo-updater-with-resources.yaml
+++ b/internal/appliance/testdata/golden-fixtures/repo-updater-with-resources.yaml
@@ -3,7 +3,7 @@ resources:
   kind: Deployment
   metadata:
     annotations:
-      appliance.sourcegraph.com/configHash: b6b2ed73a9ac2811b743313a77fb778117be88e6c5cea8e08f0384870726653d
+      appliance.sourcegraph.com/configHash: 83dee16b8bed37d368c11b4de97740a70fe3a1589992154040c17b045f263488
     creationTimestamp: "2024-04-19T00:00:00Z"
     generation: 1
     labels:
@@ -158,12 +158,13 @@ resources:
 
         repoUpdater:
           resources:
-            requests:
-              cpu: 1500m
-              memory: 2Gi
-            limits:
-              cpu: "4"
-              memory: 4Gi
+            repo-updater:
+              requests:
+                cpu: 1500m
+                memory: 2Gi
+              limits:
+                cpu: "4"
+                memory: 4Gi
 
         searcher:
           disabled: true
@@ -190,7 +191,7 @@ resources:
   kind: ServiceAccount
   metadata:
     annotations:
-      appliance.sourcegraph.com/configHash: b6b2ed73a9ac2811b743313a77fb778117be88e6c5cea8e08f0384870726653d
+      appliance.sourcegraph.com/configHash: 83dee16b8bed37d368c11b4de97740a70fe3a1589992154040c17b045f263488
     creationTimestamp: "2024-04-19T00:00:00Z"
     labels:
       deploy: sourcegraph
@@ -202,10 +203,13 @@ resources:
   kind: Service
   metadata:
     annotations:
-      appliance.sourcegraph.com/configHash: b6b2ed73a9ac2811b743313a77fb778117be88e6c5cea8e08f0384870726653d
+      appliance.sourcegraph.com/configHash: 83dee16b8bed37d368c11b4de97740a70fe3a1589992154040c17b045f263488
+      prometheus.io/port: "6060"
+      sourcegraph.prometheus/scrape: "true"
     creationTimestamp: "2024-04-19T00:00:00Z"
     labels:
       app: repo-updater
+      app.kubernetes.io/component: repo-updater
       deploy: sourcegraph
     name: repo-updater
     namespace: NORMALIZED_FOR_TESTING

--- a/internal/appliance/testdata/golden-fixtures/repo-updater-with-sa-annotations.yaml
+++ b/internal/appliance/testdata/golden-fixtures/repo-updater-with-sa-annotations.yaml
@@ -3,7 +3,7 @@ resources:
   kind: Deployment
   metadata:
     annotations:
-      appliance.sourcegraph.com/configHash: d73279f7ebebb47045eb1d91067d2496b4cbc68be737857d4ac87e25566a98ff
+      appliance.sourcegraph.com/configHash: 230da28e00c1e55a03bd1337e6d09fbb05ddfda1dec6600a4f96ef456f174f7d
     creationTimestamp: "2024-04-19T00:00:00Z"
     generation: 1
     labels:
@@ -185,7 +185,7 @@ resources:
   kind: ServiceAccount
   metadata:
     annotations:
-      appliance.sourcegraph.com/configHash: d73279f7ebebb47045eb1d91067d2496b4cbc68be737857d4ac87e25566a98ff
+      appliance.sourcegraph.com/configHash: 230da28e00c1e55a03bd1337e6d09fbb05ddfda1dec6600a4f96ef456f174f7d
       foo: bar
     creationTimestamp: "2024-04-19T00:00:00Z"
     labels:
@@ -198,10 +198,13 @@ resources:
   kind: Service
   metadata:
     annotations:
-      appliance.sourcegraph.com/configHash: d73279f7ebebb47045eb1d91067d2496b4cbc68be737857d4ac87e25566a98ff
+      appliance.sourcegraph.com/configHash: 230da28e00c1e55a03bd1337e6d09fbb05ddfda1dec6600a4f96ef456f174f7d
+      prometheus.io/port: "6060"
+      sourcegraph.prometheus/scrape: "true"
     creationTimestamp: "2024-04-19T00:00:00Z"
     labels:
       app: repo-updater
+      app.kubernetes.io/component: repo-updater
       deploy: sourcegraph
     name: repo-updater
     namespace: NORMALIZED_FOR_TESTING

--- a/internal/appliance/testdata/sg/repo-updater-with-no-resources.yaml
+++ b/internal/appliance/testdata/sg/repo-updater-with-no-resources.yaml
@@ -1,0 +1,57 @@
+spec:
+  requestedVersion: "5.3.9104"
+
+  blobstore:
+    disabled: true
+
+  codeInsights:
+    disabled: true
+
+  codeIntel:
+    disabled: true
+
+  frontend:
+    disabled: true
+
+  gitServer:
+    disabled: true
+
+  indexedSearch:
+    disabled: true
+
+  indexedSearchIndexer:
+    disabled: true
+
+  pgsql:
+    disabled: true
+
+  postgresExporter:
+    disabled: true
+
+  preciseCodeIntel:
+    disabled: true
+
+  redisCache:
+    disabled: true
+
+  redisExporter:
+    disabled: true
+
+  redisStore:
+    disabled: true
+
+  repoUpdater:
+    resources:
+      repo-updater: null
+
+  searcher:
+    disabled: true
+
+  symbols:
+    disabled: true
+
+  syntectServer:
+    disabled: true
+
+  worker:
+    disabled: true

--- a/internal/appliance/testdata/sg/repo-updater-with-resources.yaml
+++ b/internal/appliance/testdata/sg/repo-updater-with-resources.yaml
@@ -42,12 +42,13 @@ spec:
 
   repoUpdater:
     resources:
-      requests:
-        cpu: 1500m
-        memory: 2Gi
-      limits:
-        cpu: "4"
-        memory: 4Gi
+      repo-updater:
+        requests:
+          cpu: 1500m
+          memory: 2Gi
+        limits:
+          cpu: "4"
+          memory: 4Gi
 
   searcher:
     disabled: true

--- a/internal/k8s/resource/container/BUILD.bazel
+++ b/internal/k8s/resource/container/BUILD.bazel
@@ -6,9 +6,9 @@ go_library(
     importpath = "github.com/sourcegraph/sourcegraph/internal/k8s/resource/container",
     visibility = ["//:__subpackages__"],
     deps = [
+        "//internal/appliance/config",
         "//lib/pointers",
         "@io_k8s_api//core/v1:core",
-        "@io_k8s_apimachinery//pkg/api/resource",
         "@io_k8s_apimachinery//pkg/util/intstr",
     ],
 )

--- a/internal/k8s/resource/container/container.go
+++ b/internal/k8s/resource/container/container.go
@@ -2,28 +2,18 @@ package container
 
 import (
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
+	"github.com/sourcegraph/sourcegraph/internal/appliance/config"
 	"github.com/sourcegraph/sourcegraph/lib/pointers"
 )
 
 // NewContainer creates a new k8s Container with some default values set.
-func NewContainer(name string) corev1.Container {
-	return corev1.Container{
+func NewContainer(name string, cfg config.StandardComponent) corev1.Container {
+	ctr := corev1.Container{
 		Name:                     name,
 		ImagePullPolicy:          corev1.PullIfNotPresent,
 		TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
-		Resources: corev1.ResourceRequirements{
-			Limits: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("1"),
-				corev1.ResourceMemory: resource.MustParse("500Mi"),
-			},
-			Requests: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("500m"),
-				corev1.ResourceMemory: resource.MustParse("100Mi"),
-			},
-		},
 		SecurityContext: &corev1.SecurityContext{
 			RunAsUser:                pointers.Ptr[int64](100),
 			RunAsGroup:               pointers.Ptr[int64](101),
@@ -31,6 +21,14 @@ func NewContainer(name string) corev1.Container {
 			ReadOnlyRootFilesystem:   pointers.Ptr(true),
 		},
 	}
+
+	if cfg != nil {
+		if ctrResources := cfg.GetResources()[name]; ctrResources != nil {
+			ctr.Resources = *ctrResources
+		}
+	}
+
+	return ctr
 }
 
 // NewDefaultLivenessProbe creates a default LivenessProbe that is commonly used
@@ -88,4 +86,8 @@ func NewEnvVarFieldRef(name, fieldPath string) corev1.EnvVar {
 			},
 		},
 	}
+}
+
+func HasNoConfiguredResources(ctr corev1.Container) bool {
+	return ctr.Resources.Limits == nil && ctr.Resources.Requests == nil
 }

--- a/internal/k8s/resource/container/container.go
+++ b/internal/k8s/resource/container/container.go
@@ -9,11 +9,12 @@ import (
 )
 
 // NewContainer creates a new k8s Container with some default values set.
-func NewContainer(name string, cfg config.StandardComponent) corev1.Container {
+func NewContainer(name string, cfg config.StandardComponent, defaultResources corev1.ResourceRequirements) corev1.Container {
 	ctr := corev1.Container{
 		Name:                     name,
 		ImagePullPolicy:          corev1.PullIfNotPresent,
 		TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
+		Resources:                defaultResources,
 		SecurityContext: &corev1.SecurityContext{
 			RunAsUser:                pointers.Ptr[int64](100),
 			RunAsGroup:               pointers.Ptr[int64](101),
@@ -23,8 +24,8 @@ func NewContainer(name string, cfg config.StandardComponent) corev1.Container {
 	}
 
 	if cfg != nil {
-		if ctrResources := cfg.GetResources()[name]; ctrResources != nil {
-			ctr.Resources = *ctrResources
+		if ctrResources, ok := cfg.GetResources()[name]; ok {
+			ctr.Resources = ctrResources
 		}
 	}
 
@@ -86,8 +87,4 @@ func NewEnvVarFieldRef(name, fieldPath string) corev1.EnvVar {
 			},
 		},
 	}
-}
-
-func HasNoConfiguredResources(ctr corev1.Container) bool {
-	return ctr.Resources.Limits == nil && ctr.Resources.Requests == nil
 }

--- a/internal/k8s/resource/service/BUILD.bazel
+++ b/internal/k8s/resource/service/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/sourcegraph/sourcegraph/internal/k8s/resource/service",
     visibility = ["//:__subpackages__"],
     deps = [
+        "//internal/appliance/config",
         "@io_k8s_api//core/v1:core",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:meta",
     ],

--- a/internal/k8s/resource/service/service.go
+++ b/internal/k8s/resource/service/service.go
@@ -1,19 +1,24 @@
 package service
 
 import (
+	"fmt"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/sourcegraph/sourcegraph/internal/appliance/config"
 )
 
 // NewService creates a new k8s Service with some default values set.
-func NewService(name, namespace string) corev1.Service {
-	return corev1.Service{
+func NewService(name, namespace string, cfg config.StandardComponent) corev1.Service {
+	svc := corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
 			Labels: map[string]string{
-				"app":    name,
-				"deploy": "sourcegraph",
+				"app":                         name,
+				"app.kubernetes.io/component": name,
+				"deploy":                      "sourcegraph",
 			},
 		},
 		Spec: corev1.ServiceSpec{
@@ -23,4 +28,16 @@ func NewService(name, namespace string) corev1.Service {
 			Type: corev1.ServiceTypeClusterIP,
 		},
 	}
+
+	if cfg != nil {
+		if promPort := cfg.PrometheusPort(); promPort != nil {
+			annotations := map[string]string{
+				"prometheus.io/port":            fmt.Sprintf("%d", *promPort),
+				"sourcegraph.prometheus/scrape": "true",
+			}
+			svc.SetAnnotations(annotations)
+		}
+	}
+
+	return svc
 }

--- a/internal/k8s/resource/serviceaccount/BUILD.bazel
+++ b/internal/k8s/resource/serviceaccount/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/sourcegraph/sourcegraph/internal/k8s/resource/serviceaccount",
     visibility = ["//:__subpackages__"],
     deps = [
+        "//internal/appliance/config",
         "@io_k8s_api//core/v1:core",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:meta",
     ],

--- a/internal/k8s/resource/serviceaccount/serviceaccount.go
+++ b/internal/k8s/resource/serviceaccount/serviceaccount.go
@@ -3,12 +3,14 @@ package serviceaccount
 import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/sourcegraph/sourcegraph/internal/appliance/config"
 )
 
 // NewServiceAccount creates a new k8s ServiceAccount with some default values
 // set.
-func NewServiceAccount(name, namespace string) corev1.ServiceAccount {
-	return corev1.ServiceAccount{
+func NewServiceAccount(name, namespace string, cfg config.StandardComponent) corev1.ServiceAccount {
+	sa := corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
@@ -17,4 +19,10 @@ func NewServiceAccount(name, namespace string) corev1.ServiceAccount {
 			},
 		},
 	}
+
+	if cfg != nil {
+		sa.SetAnnotations(cfg.GetServiceAccountAnnotations())
+	}
+
+	return sa
 }


### PR DESCRIPTION
Create a "common" config struct+interface that can be embedded in service config, to get various facilities for free. The aim is to reduce the prospect for errors given how much service config the appliance will soon handle.

See changes to development.md for a full explanation of what I'm trying to do here.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->

Tests included.