### PR TITLE
Exclude files for getCodyContext keyword search

### DIFF
--- a/cmd/frontend/internal/codycontext/context.go
+++ b/cmd/frontend/internal/codycontext/context.go
@@ -250,7 +250,6 @@ func getKeywordContextExcludeFilePathsQuery() string {
 	var excludeFilePaths = []string{
 		"\\.min\\.js$",
 		"\\.map$",
-		"dist\\",
 	}
 
 	filters := []string{}
@@ -261,7 +260,7 @@ func getKeywordContextExcludeFilePathsQuery() string {
 	return strings.Join(filters, " ")
 }
 
-var keywordContextExcludeFilePaths = getKeywordContextExcludeFilePathsQuery()
+var keywordContextExcludeFilePathsQuery = getKeywordContextExcludeFilePathsQuery()
 
 // getKeywordContext uses keyword search to find relevant bits of context for Cody
 func (c *CodyContextClient) getKeywordContext(ctx context.Context, args GetContextArgs, matcher FileMatcher) (_ []FileChunkContext, err error) {
@@ -283,7 +282,7 @@ func (c *CodyContextClient) getKeywordContext(ctx context.Context, args GetConte
 		regexEscapedRepoNames[i] = regexp.QuoteMeta(string(repo.Name))
 	}
 
-	keywordQuery := fmt.Sprintf(`repo:^%s$ type:file type:path %s %s`, query.UnionRegExps(regexEscapedRepoNames), keywordContextExcludeFilePaths, args.Query)
+	keywordQuery := fmt.Sprintf(`repo:^%s$ type:file type:path %s %s`, query.UnionRegExps(regexEscapedRepoNames), keywordContextExcludeFilePathsQuery, args.Query)
 
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()

--- a/cmd/frontend/internal/codycontext/context.go
+++ b/cmd/frontend/internal/codycontext/context.go
@@ -3,6 +3,7 @@ package codycontext
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 
 	"github.com/grafana/regexp"
@@ -245,6 +246,23 @@ func (c *CodyContextClient) getEmbeddingsContext(ctx context.Context, args GetCo
 	return filtered, nil
 }
 
+func getKeywordContextExcludeFilePathsQuery() string {
+	var excludeFilePaths = []string{
+		"\\.min\\.js$",
+		"\\.map$",
+		"dist\\",
+	}
+
+	filters := []string{}
+	for _, filePath := range excludeFilePaths {
+		filters = append(filters, fmt.Sprintf("-file:%v", filePath))
+	}
+
+	return strings.Join(filters, " ")
+}
+
+var keywordContextExcludeFilePaths = getKeywordContextExcludeFilePathsQuery()
+
 // getKeywordContext uses keyword search to find relevant bits of context for Cody
 func (c *CodyContextClient) getKeywordContext(ctx context.Context, args GetContextArgs, matcher FileMatcher) (_ []FileChunkContext, err error) {
 	ctx, _, endObservation := c.getKeywordContextOp.With(ctx, &err, observation.Args{Attrs: args.Attrs()})
@@ -265,7 +283,7 @@ func (c *CodyContextClient) getKeywordContext(ctx context.Context, args GetConte
 		regexEscapedRepoNames[i] = regexp.QuoteMeta(string(repo.Name))
 	}
 
-	keywordQuery := fmt.Sprintf(`repo:^%s$ type:file type:path %s`, query.UnionRegExps(regexEscapedRepoNames), args.Query)
+	keywordQuery := fmt.Sprintf(`repo:^%s$ type:file type:path %s %s`, query.UnionRegExps(regexEscapedRepoNames), keywordContextExcludeFilePaths, args.Query)
 
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()

--- a/cmd/frontend/internal/codycontext/context.go
+++ b/cmd/frontend/internal/codycontext/context.go
@@ -260,8 +260,6 @@ func getKeywordContextExcludeFilePathsQuery() string {
 	return strings.Join(filters, " ")
 }
 
-var keywordContextExcludeFilePathsQuery = getKeywordContextExcludeFilePathsQuery()
-
 // getKeywordContext uses keyword search to find relevant bits of context for Cody
 func (c *CodyContextClient) getKeywordContext(ctx context.Context, args GetContextArgs, matcher FileMatcher) (_ []FileChunkContext, err error) {
 	ctx, _, endObservation := c.getKeywordContextOp.With(ctx, &err, observation.Args{Attrs: args.Attrs()})
@@ -282,7 +280,7 @@ func (c *CodyContextClient) getKeywordContext(ctx context.Context, args GetConte
 		regexEscapedRepoNames[i] = regexp.QuoteMeta(string(repo.Name))
 	}
 
-	keywordQuery := fmt.Sprintf(`repo:^%s$ type:file type:path %s %s`, query.UnionRegExps(regexEscapedRepoNames), keywordContextExcludeFilePathsQuery, args.Query)
+	keywordQuery := fmt.Sprintf(`repo:^%s$ type:file type:path %s %s`, query.UnionRegExps(regexEscapedRepoNames), getKeywordContextExcludeFilePathsQuery(), args.Query)
 
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()


### PR DESCRIPTION
Exclude `.map` and `.min.js` files from keyword search behind getCodyContext. 

## Test plan

Tested manually with `getCodyContext` API for react repo.

Normal search gets results from `scheduler.profiling.min.js`
![CleanShot 2024-04-29 at 11 27 41@2x](https://github.com/sourcegraph/sourcegraph/assets/22571395/49e76b8f-df13-455b-9e73-99ef95c8bed0)


But `getCodyContext` does not:
![CleanShot 2024-04-29 at 11 28 47@2x](https://github.com/sourcegraph/sourcegraph/assets/22571395/3d482e2c-5b01-4e64-bccf-f3d91e2e2d72)


Before:
![CleanShot 2024-04-29 at 11 52 43@2x](https://github.com/sourcegraph/sourcegraph/assets/22571395/5612e709-e6d4-436a-94ff-e48b97864105)

