### PR TITLE
batches: fix changeset status computation for changesets with skipped ci checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ All notable changes to Sourcegraph are documented in this file.
 - The ArchiveReader() RPC in the gitserver service now uses the correct protobuf type that allows for non-utf8 byte sequences in file paths. [#61970](https://github.com/sourcegraph/sourcegraph/pull/61970)
 - Pinned code intel popovers and popovers opened via the keyboard are properly shown again. [#61966](https://github.com/sourcegraph/sourcegraph/pull/61966)
 - Syntax highlighting works correctly for JSX files. [#62027](https://github.com/sourcegraph/sourcegraph/pull/62027)
+- Changesets with a skipped CI check are now incorrectly displayed in the Batch Changes UI. [#62204](https://github.com/sourcegraph/sourcegraph/pull/62204)
 
 ## 5.3.12303
 

--- a/internal/batches/state/state.go
+++ b/internal/batches/state/state.go
@@ -448,15 +448,15 @@ func combineCheckStates(states []btypes.ChangesetCheckState) btypes.ChangesetChe
 	}
 
 	switch {
-	case stateMap[btypes.ChangesetCheckStateUnknown]:
-		// If there are unknown states, overall is Pending.
-		return btypes.ChangesetCheckStateUnknown
 	case stateMap[btypes.ChangesetCheckStatePending]:
 		// If there are pending states, overall is Pending.
 		return btypes.ChangesetCheckStatePending
 	case stateMap[btypes.ChangesetCheckStateFailed]:
 		// If there are no pending states, but we have errors then overall is Failed.
 		return btypes.ChangesetCheckStateFailed
+	case stateMap[btypes.ChangesetCheckStateUnknown]:
+		// If there are unknown states, overall is Unknown.
+		return btypes.ChangesetCheckStateUnknown
 	case stateMap[btypes.ChangesetCheckStatePassed]:
 		// No pending or error states then overall is Passed.
 		return btypes.ChangesetCheckStatePassed
@@ -482,6 +482,7 @@ func parseGithubCheckState(s string) btypes.ChangesetCheckState {
 func parseGithubCheckSuiteState(status, conclusion string) btypes.ChangesetCheckState {
 	status = strings.ToUpper(status)
 	conclusion = strings.ToUpper(conclusion)
+
 	switch status {
 	case "IN_PROGRESS", "QUEUED", "REQUESTED":
 		return btypes.ChangesetCheckStatePending
@@ -489,8 +490,9 @@ func parseGithubCheckSuiteState(status, conclusion string) btypes.ChangesetCheck
 	if status != "COMPLETED" {
 		return btypes.ChangesetCheckStateUnknown
 	}
+
 	switch conclusion {
-	case "SUCCESS", "NEUTRAL":
+	case "SUCCESS", "NEUTRAL", "SKIPPED":
 		return btypes.ChangesetCheckStatePassed
 	case "ACTION_REQUIRED":
 		return btypes.ChangesetCheckStatePending

--- a/internal/batches/state/state_test.go
+++ b/internal/batches/state/state_test.go
@@ -159,6 +159,30 @@ func TestComputeGithubCheckState(t *testing.T) {
 			},
 			want: btypes.ChangesetCheckStateFailed,
 		},
+		{
+			name: "completed suites with a successful run",
+			events: []*btypes.ChangesetEvent{
+				commitEvent(1, "ctx1", "SUCCESS"),
+				checkSuiteEvent(1, "cs1", "COMPLETED", "SUCCESS"),
+			},
+			want: btypes.ChangesetCheckStatePassed,
+		},
+		{
+			name: "completed suites with a skipped run",
+			events: []*btypes.ChangesetEvent{
+				commitEvent(1, "ctx1", "SUCCESS"),
+				checkSuiteEvent(1, "cs1", "COMPLETED", "SKIPPED"),
+			},
+			want: btypes.ChangesetCheckStatePassed,
+		},
+		{
+			name: "completed suites with a failed run",
+			events: []*btypes.ChangesetEvent{
+				commitEvent(1, "ctx1", "SUCCESS"),
+				checkSuiteEvent(1, "cs1", "COMPLETED", "FAILURE"),
+			},
+			want: btypes.ChangesetCheckStatePassed,
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
Closes #62133

The computation for parsing the changeset for a Pull Request was incorrect, this caused GitHub pull request with a status of `SKIPPED` to be treated as a state of `UNKNOWN`.
We also treated any changeset with at least one status of `UNKNOWN` to have an overall status of `UNKNOWN`, I changed that logic to prioritize `FAILED` and `PENDING` statuses ahead of `UNKNOWN`.

## Test plan

* Manual testing
* Unit testing

![CleanShot 2024-04-26 at 14 19 35@2x](https://github.com/sourcegraph/sourcegraph/assets/25608335/f2e14926-9a7e-4e3a-82f8-76b3ba06da2e)
