### PR TITLE
msp/redis: make tier changes graceful

### DIFF
--- a/dev/managedservicesplatform/internal/resource/redis/BUILD.bazel
+++ b/dev/managedservicesplatform/internal/resource/redis/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
         "//dev/managedservicesplatform/spec",
         "//lib/pointers",
         "@com_github_aws_constructs_go_constructs_v10//:constructs",
+        "@com_github_hashicorp_terraform_cdk_go_cdktf//:cdktf",
         "@com_github_sourcegraph_managed_services_platform_cdktf_gen_google//computenetwork",
         "@com_github_sourcegraph_managed_services_platform_cdktf_gen_google//redisinstance",
     ],

--- a/dev/managedservicesplatform/internal/resource/redis/redis.go
+++ b/dev/managedservicesplatform/internal/resource/redis/redis.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/aws/constructs-go/constructs/v10"
+	"github.com/hashicorp/terraform-cdk-go/cdktf"
 	"github.com/sourcegraph/managed-services-platform-cdktf/gen/google/computenetwork"
 	"github.com/sourcegraph/managed-services-platform-cdktf/gen/google/redisinstance"
 
@@ -30,18 +31,32 @@ type Config struct {
 }
 
 func New(scope constructs.Construct, id resourceid.ID, config Config) (*Output, error) {
+	// Default to 'true' - TODO(@bobheadxi) migrate default to false
+	// after explicitly configuring production instances to use HA
+	// Redis for now.
+	useHA := pointers.Deref(config.Spec.HighAvailability, true)
+	instanceName := id.DisplayName()
+	if !useHA {
+		// Tier changes require recreation. We give basic-tier instance different
+		// naming so that basic-tier gets recreated, rather than HA-tier.
+		instanceName = fmt.Sprintf("%s-basic", instanceName)
+	}
+
 	redis := redisinstance.NewRedisInstance(scope,
 		id.TerraformID("instance"),
 		&redisinstance.RedisInstanceConfig{
 			Project: pointers.Ptr(config.ProjectID),
 			Region:  &config.Region,
-			Name:    pointers.Ptr(id.DisplayName()),
+			Name:    &instanceName,
+			DisplayName: pointers.Ptr(func() string {
+				if useHA {
+					return "Regional Redis (standard HA)"
+				}
+				return "Zonal Redis (basic)"
+			}()),
 
 			Tier: pointers.Ptr(func() string {
-				// Default to 'true' - TODO(@bobheadxi) migrate default to false
-				// after explicitly configuring production instances to use HA
-				// Redis for now.
-				if pointers.Deref(config.Spec.HighAvailability, true) {
+				if useHA {
 					return "STANDARD_HA" // multi-zone in a region
 				}
 				return "BASIC" // single-zone
@@ -56,13 +71,21 @@ func New(scope constructs.Construct, id resourceid.ID, config Config) (*Output, 
 			},
 
 			AuthorizedNetwork: config.Network.SelfLink(),
+
+			Lifecycle: &cdktf.TerraformResourceLifecycle{
+				// Make sure new instance is available before destroying old one.
+				// Also helps us prevent unintentional recreation.
+				CreateBeforeDestroy: pointers.Ptr(true),
+			},
 		})
 
 	// Share CA certificate for connecting to Redis over TLS as a GSM secret
 	redisCACert := gsmsecret.New(scope, id.Group("ca-cert"), gsmsecret.Config{
 		ProjectID: config.ProjectID,
-		ID:        strings.ToUpper(id.DisplayName()) + "_CA_CERT",
-		Value:     *redis.ServerCaCerts().Get(pointers.Float64(0)).Cert(),
+		// Redis recreation doesn't matter, we use the same secret, and Cloud
+		// Run revisions pin to a specific version of the secret.
+		ID:    strings.ToUpper(id.DisplayName()) + "_CA_CERT",
+		Value: *redis.ServerCaCerts().Get(pointers.Float64(0)).Cert(),
 	})
 
 	return &Output{


### PR DESCRIPTION
Makes the downgrade option introduced in https://github.com/sourcegraph/sourcegraph/pull/62137 usable, since a tier change in Redis is a force-recreate situation (unlike Cloud SQL)

Documented this noob mistake in https://sourcegraph.notion.site/MSP-infrastructure-upgrades-1808e7e45bd54f419dd93af542d99238#545745ef335148d5a0e22655b216db29

## Test plan

- [x] Applied downgrade directly in msp-testbed-robert https://app.terraform.io/app/sourcegraph/workspaces/msp-msp-testbed-robert-cloudrun/runs
- [x] Switched robert back to VCS mode, monitored upgrade https://app.terraform.io/app/sourcegraph/workspaces/msp-msp-testbed-robert-cloudrun/runs/run-PFTNBXLBdZGWTm1Z

No alerts fired during either of the above