### PR TITLE
gitserver: grpc: port GetBehindAhead from client to gitcli backend

### DIFF
--- a/cmd/gitserver/internal/git/gitcli/odb.go
+++ b/cmd/gitserver/internal/git/gitcli/odb.go
@@ -189,12 +189,20 @@ func (g *gitCLIBackend) getBlobOID(ctx context.Context, commit api.CommitID, pat
 	return api.CommitID(fields[2]), nil
 }
 
-func (g *gitCLIBackend) GetBehindAhead(ctx context.Context, left, right string) (*gitdomain.BehindAhead, error) {
+func (g *gitCLIBackend) BehindAhead(ctx context.Context, left, right string) (*gitdomain.BehindAhead, error) {
 	if err := checkSpecArgSafety(left); err != nil {
 		return nil, err
 	}
 	if err := checkSpecArgSafety(right); err != nil {
 		return nil, err
+	}
+
+	if left == "" {
+		left = "HEAD"
+	}
+
+	if right == "" {
+		right = "HEAD"
 	}
 
 	rc, err := g.NewCommand(ctx, WithArguments("rev-list", "--count", "--left-right", fmt.Sprintf("%s...%s", left, right)))
@@ -228,7 +236,7 @@ func (g *gitCLIBackend) GetBehindAhead(ctx context.Context, left, right string) 
 	}
 	a, err := strconv.ParseUint(behindAhead[1], 10, 0)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrapf(err, "failed to parse behindahead output %q", out)
 	}
 	return &gitdomain.BehindAhead{Behind: uint32(b), Ahead: uint32(a)}, nil
 }

--- a/cmd/gitserver/internal/git/gitcli/odb_test.go
+++ b/cmd/gitserver/internal/git/gitcli/odb_test.go
@@ -382,4 +382,11 @@ func TestGitCLIBackend_GetBehindAhead(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, &gitdomain.BehindAhead{Behind: 0, Ahead: 0}, behindAhead)
 	})
+
+	t.Run("invalid object id", func(t *testing.T) {
+		_, err := backend.GetBehindAhead(ctx, "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef", right)
+		require.Error(t, err)
+		var e *gitdomain.RevisionNotFoundError
+		require.True(t, errors.As(err, &e))
+	})
 }

--- a/cmd/gitserver/internal/git/gitcli/odb_test.go
+++ b/cmd/gitserver/internal/git/gitcli/odb_test.go
@@ -331,60 +331,89 @@ func TestGitCLIBackend_GetBehindAhead(t *testing.T) {
 
 	// Prepare repo state:
 	backend := BackendWithRepoCommands(t,
+		// This is the commit graph we are creating
+		//
+		//         +-----> 3  -----> 4           (branch1)
+		//         |
+		//         |
+		// 0 ----> 1  ----> 2 -----> 5  -----> 6  (master)
+		//
+		"echo abcd > file0",
+		"git add file0",
+		"git commit -m commit0 --author='Foo Author <foo@sourcegraph.com>'",
+
 		"echo abcd > file1",
 		"git add file1",
 		"git commit -m commit1 --author='Foo Author <foo@sourcegraph.com>'",
+
 		"git branch branch1",
+
 		"echo efgh > file2",
 		"git add file2",
 		"git commit -m commit2 --author='Foo Author <foo@sourcegraph.com>'",
+
 		"git checkout branch1",
+
 		"echo ijkl > file3",
 		"git add file3",
 		"git commit -m commit3 --author='Foo Author <foo@sourcegraph.com>'",
+
+		"echo ijkl > file4",
+		"git add file4",
+		"git commit -m commit4 --author='Foo Author <foo@sourcegraph.com>'",
+
+		"git checkout master",
+
+		"echo ijkl > file5",
+		"git add file5",
+		"git commit -m commit5 --author='Foo Author <foo@sourcegraph.com>'",
+
+		"echo ijkl > file6",
+		"git add file6",
+		"git commit -m commit6 --author='Foo Author <foo@sourcegraph.com>'",
 	)
 
 	left := "branch1"
 	right := "master"
 
 	t.Run("valid branches", func(t *testing.T) {
-		behindAhead, err := backend.GetBehindAhead(ctx, left, right)
+		behindAhead, err := backend.BehindAhead(ctx, left, right)
 		require.NoError(t, err)
-		require.Equal(t, &gitdomain.BehindAhead{Behind: 1, Ahead: 1}, behindAhead)
+		require.Equal(t, &gitdomain.BehindAhead{Behind: 2, Ahead: 3}, behindAhead)
 	})
 
 	t.Run("missing left branch", func(t *testing.T) {
-		_, err := backend.GetBehindAhead(ctx, left, "")
+		_, err := backend.BehindAhead(ctx, left, "")
 		require.NoError(t, err) // Should compare to HEAD
 	})
 
 	t.Run("missing right branch", func(t *testing.T) {
-		_, err := backend.GetBehindAhead(ctx, "", right)
+		_, err := backend.BehindAhead(ctx, "", right)
 		require.NoError(t, err) // Should compare to HEAD
 	})
 
 	t.Run("invalid left branch", func(t *testing.T) {
-		_, err := backend.GetBehindAhead(ctx, "invalid-branch", right)
+		_, err := backend.BehindAhead(ctx, "invalid-branch", right)
 		require.Error(t, err)
 		var e *gitdomain.RevisionNotFoundError
 		require.True(t, errors.As(err, &e))
 	})
 
 	t.Run("invalid right branch", func(t *testing.T) {
-		_, err := backend.GetBehindAhead(ctx, left, "invalid-branch")
+		_, err := backend.BehindAhead(ctx, left, "invalid-branch")
 		require.Error(t, err)
 		var e *gitdomain.RevisionNotFoundError
 		require.True(t, errors.As(err, &e))
 	})
 
 	t.Run("same branch", func(t *testing.T) {
-		behindAhead, err := backend.GetBehindAhead(ctx, left, left)
+		behindAhead, err := backend.BehindAhead(ctx, left, left)
 		require.NoError(t, err)
 		require.Equal(t, &gitdomain.BehindAhead{Behind: 0, Ahead: 0}, behindAhead)
 	})
 
 	t.Run("invalid object id", func(t *testing.T) {
-		_, err := backend.GetBehindAhead(ctx, "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef", right)
+		_, err := backend.BehindAhead(ctx, "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef", right)
 		require.Error(t, err)
 		var e *gitdomain.RevisionNotFoundError
 		require.True(t, errors.As(err, &e))

--- a/cmd/gitserver/internal/git/iface.go
+++ b/cmd/gitserver/internal/git/iface.go
@@ -93,7 +93,7 @@ type GitBackend interface {
 
 	// Exec is a temporary helper to run arbitrary git commands from the exec endpoint.
 	// No new usages of it should be introduced and once the migration is done we will
-	// remove this method.
+	// remove this method. q
 	Exec(ctx context.Context, args ...string) (io.ReadCloser, error)
 
 	// FirstEverCommit returns the first commit ever made to the repository.
@@ -102,11 +102,25 @@ type GitBackend interface {
 	// "HEAD" ref does not exist).
 	FirstEverCommit(ctx context.Context) (api.CommitID, error)
 
-	// GetBehindAhead returns the behind/ahead commit counts information for right vs. left (both Git
+	// BehindAhead returns the behind/ahead commit counts information for the symmetric difference left...right (both Git
 	// revspecs).
+	//
+	// Behind is the number of commits that are solely reachable in "left" but not "right".
+	// Ahead is the number of commits that are solely reachable in "right" but not "left".
+	//
+	//  For the example, given the graph below, BehindAhead("A", "B") would return {Behind: 3, Ahead: 2}.
+	//
+	//	     y---b---b  branch B
+	//	    / \ /
+	//	   /   .
+	//	  /   / \
+	//	 o---x---a---a---a  branch A
+	//
+	// If either left or right are the empty string (""), the HEAD commit is implicitly used.
+	//
 	// If one of the two given revspecs does not exist, a RevisionNotFoundError
 	// is returned.
-	GetBehindAhead(ctx context.Context, left, right string) (*gitdomain.BehindAhead, error)
+	BehindAhead(ctx context.Context, left, right string) (*gitdomain.BehindAhead, error)
 }
 
 type GitDiffComparisonType int

--- a/cmd/gitserver/internal/git/iface.go
+++ b/cmd/gitserver/internal/git/iface.go
@@ -101,6 +101,12 @@ type GitBackend interface {
 	// If the repository is empty, a RevisionNotFoundError is returned (as the
 	// "HEAD" ref does not exist).
 	FirstEverCommit(ctx context.Context) (api.CommitID, error)
+
+	// GetBehindAhead returns the behind/ahead commit counts information for right vs. left (both Git
+	// revspecs).
+	// If one of the two given revspecs does not exist, a RevisionNotFoundError
+	// is returned.
+	GetBehindAhead(ctx context.Context, left, right string) (*gitdomain.BehindAhead, error)
 }
 
 type GitDiffComparisonType int

--- a/cmd/gitserver/internal/git/iface.go
+++ b/cmd/gitserver/internal/git/iface.go
@@ -93,7 +93,7 @@ type GitBackend interface {
 
 	// Exec is a temporary helper to run arbitrary git commands from the exec endpoint.
 	// No new usages of it should be introduced and once the migration is done we will
-	// remove this method. q
+	// remove this method.
 	Exec(ctx context.Context, args ...string) (io.ReadCloser, error)
 
 	// FirstEverCommit returns the first commit ever made to the repository.

--- a/cmd/gitserver/internal/git/mock.go
+++ b/cmd/gitserver/internal/git/mock.go
@@ -287,6 +287,9 @@ type MockGitBackend struct {
 	// ArchiveReaderFunc is an instance of a mock function object
 	// controlling the behavior of the method ArchiveReader.
 	ArchiveReaderFunc *GitBackendArchiveReaderFunc
+	// BehindAheadFunc is an instance of a mock function object controlling
+	// the behavior of the method BehindAhead.
+	BehindAheadFunc *GitBackendBehindAheadFunc
 	// BlameFunc is an instance of a mock function object controlling the
 	// behavior of the method Blame.
 	BlameFunc *GitBackendBlameFunc
@@ -302,9 +305,6 @@ type MockGitBackend struct {
 	// FirstEverCommitFunc is an instance of a mock function object
 	// controlling the behavior of the method FirstEverCommit.
 	FirstEverCommitFunc *GitBackendFirstEverCommitFunc
-	// GetBehindAheadFunc is an instance of a mock function object
-	// controlling the behavior of the method GetBehindAhead.
-	GetBehindAheadFunc *GitBackendGetBehindAheadFunc
 	// GetCommitFunc is an instance of a mock function object controlling
 	// the behavior of the method GetCommit.
 	GetCommitFunc *GitBackendGetCommitFunc
@@ -346,6 +346,11 @@ func NewMockGitBackend() *MockGitBackend {
 				return
 			},
 		},
+		BehindAheadFunc: &GitBackendBehindAheadFunc{
+			defaultHook: func(context.Context, string, string) (r0 *gitdomain.BehindAhead, r1 error) {
+				return
+			},
+		},
 		BlameFunc: &GitBackendBlameFunc{
 			defaultHook: func(context.Context, api.CommitID, string, BlameOptions) (r0 BlameHunkReader, r1 error) {
 				return
@@ -368,11 +373,6 @@ func NewMockGitBackend() *MockGitBackend {
 		},
 		FirstEverCommitFunc: &GitBackendFirstEverCommitFunc{
 			defaultHook: func(context.Context) (r0 api.CommitID, r1 error) {
-				return
-			},
-		},
-		GetBehindAheadFunc: &GitBackendGetBehindAheadFunc{
-			defaultHook: func(context.Context, string, string) (r0 *gitdomain.BehindAhead, r1 error) {
 				return
 			},
 		},
@@ -438,6 +438,11 @@ func NewStrictMockGitBackend() *MockGitBackend {
 				panic("unexpected invocation of MockGitBackend.ArchiveReader")
 			},
 		},
+		BehindAheadFunc: &GitBackendBehindAheadFunc{
+			defaultHook: func(context.Context, string, string) (*gitdomain.BehindAhead, error) {
+				panic("unexpected invocation of MockGitBackend.BehindAhead")
+			},
+		},
 		BlameFunc: &GitBackendBlameFunc{
 			defaultHook: func(context.Context, api.CommitID, string, BlameOptions) (BlameHunkReader, error) {
 				panic("unexpected invocation of MockGitBackend.Blame")
@@ -461,11 +466,6 @@ func NewStrictMockGitBackend() *MockGitBackend {
 		FirstEverCommitFunc: &GitBackendFirstEverCommitFunc{
 			defaultHook: func(context.Context) (api.CommitID, error) {
 				panic("unexpected invocation of MockGitBackend.FirstEverCommit")
-			},
-		},
-		GetBehindAheadFunc: &GitBackendGetBehindAheadFunc{
-			defaultHook: func(context.Context, string, string) (*gitdomain.BehindAhead, error) {
-				panic("unexpected invocation of MockGitBackend.GetBehindAhead")
 			},
 		},
 		GetCommitFunc: &GitBackendGetCommitFunc{
@@ -528,6 +528,9 @@ func NewMockGitBackendFrom(i GitBackend) *MockGitBackend {
 		ArchiveReaderFunc: &GitBackendArchiveReaderFunc{
 			defaultHook: i.ArchiveReader,
 		},
+		BehindAheadFunc: &GitBackendBehindAheadFunc{
+			defaultHook: i.BehindAhead,
+		},
 		BlameFunc: &GitBackendBlameFunc{
 			defaultHook: i.Blame,
 		},
@@ -542,9 +545,6 @@ func NewMockGitBackendFrom(i GitBackend) *MockGitBackend {
 		},
 		FirstEverCommitFunc: &GitBackendFirstEverCommitFunc{
 			defaultHook: i.FirstEverCommit,
-		},
-		GetBehindAheadFunc: &GitBackendGetBehindAheadFunc{
-			defaultHook: i.GetBehindAhead,
 		},
 		GetCommitFunc: &GitBackendGetCommitFunc{
 			defaultHook: i.GetCommit,
@@ -690,6 +690,117 @@ func (c GitBackendArchiveReaderFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c GitBackendArchiveReaderFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
+}
+
+// GitBackendBehindAheadFunc describes the behavior when the BehindAhead
+// method of the parent MockGitBackend instance is invoked.
+type GitBackendBehindAheadFunc struct {
+	defaultHook func(context.Context, string, string) (*gitdomain.BehindAhead, error)
+	hooks       []func(context.Context, string, string) (*gitdomain.BehindAhead, error)
+	history     []GitBackendBehindAheadFuncCall
+	mutex       sync.Mutex
+}
+
+// BehindAhead delegates to the next hook function in the queue and stores
+// the parameter and result values of this invocation.
+func (m *MockGitBackend) BehindAhead(v0 context.Context, v1 string, v2 string) (*gitdomain.BehindAhead, error) {
+	r0, r1 := m.BehindAheadFunc.nextHook()(v0, v1, v2)
+	m.BehindAheadFunc.appendCall(GitBackendBehindAheadFuncCall{v0, v1, v2, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the BehindAhead method
+// of the parent MockGitBackend instance is invoked and the hook queue is
+// empty.
+func (f *GitBackendBehindAheadFunc) SetDefaultHook(hook func(context.Context, string, string) (*gitdomain.BehindAhead, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// BehindAhead method of the parent MockGitBackend instance invokes the hook
+// at the front of the queue and discards it. After the queue is empty, the
+// default hook function is invoked for any future action.
+func (f *GitBackendBehindAheadFunc) PushHook(hook func(context.Context, string, string) (*gitdomain.BehindAhead, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *GitBackendBehindAheadFunc) SetDefaultReturn(r0 *gitdomain.BehindAhead, r1 error) {
+	f.SetDefaultHook(func(context.Context, string, string) (*gitdomain.BehindAhead, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *GitBackendBehindAheadFunc) PushReturn(r0 *gitdomain.BehindAhead, r1 error) {
+	f.PushHook(func(context.Context, string, string) (*gitdomain.BehindAhead, error) {
+		return r0, r1
+	})
+}
+
+func (f *GitBackendBehindAheadFunc) nextHook() func(context.Context, string, string) (*gitdomain.BehindAhead, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *GitBackendBehindAheadFunc) appendCall(r0 GitBackendBehindAheadFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of GitBackendBehindAheadFuncCall objects
+// describing the invocations of this function.
+func (f *GitBackendBehindAheadFunc) History() []GitBackendBehindAheadFuncCall {
+	f.mutex.Lock()
+	history := make([]GitBackendBehindAheadFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// GitBackendBehindAheadFuncCall is an object that describes an invocation
+// of method BehindAhead on an instance of MockGitBackend.
+type GitBackendBehindAheadFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 string
+	// Arg2 is the value of the 3rd argument passed to this method
+	// invocation.
+	Arg2 string
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 *gitdomain.BehindAhead
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c GitBackendBehindAheadFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c GitBackendBehindAheadFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 
@@ -1229,117 +1340,6 @@ func (c GitBackendFirstEverCommitFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c GitBackendFirstEverCommitFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
-}
-
-// GitBackendGetBehindAheadFunc describes the behavior when the
-// GetBehindAhead method of the parent MockGitBackend instance is invoked.
-type GitBackendGetBehindAheadFunc struct {
-	defaultHook func(context.Context, string, string) (*gitdomain.BehindAhead, error)
-	hooks       []func(context.Context, string, string) (*gitdomain.BehindAhead, error)
-	history     []GitBackendGetBehindAheadFuncCall
-	mutex       sync.Mutex
-}
-
-// GetBehindAhead delegates to the next hook function in the queue and
-// stores the parameter and result values of this invocation.
-func (m *MockGitBackend) GetBehindAhead(v0 context.Context, v1 string, v2 string) (*gitdomain.BehindAhead, error) {
-	r0, r1 := m.GetBehindAheadFunc.nextHook()(v0, v1, v2)
-	m.GetBehindAheadFunc.appendCall(GitBackendGetBehindAheadFuncCall{v0, v1, v2, r0, r1})
-	return r0, r1
-}
-
-// SetDefaultHook sets function that is called when the GetBehindAhead
-// method of the parent MockGitBackend instance is invoked and the hook
-// queue is empty.
-func (f *GitBackendGetBehindAheadFunc) SetDefaultHook(hook func(context.Context, string, string) (*gitdomain.BehindAhead, error)) {
-	f.defaultHook = hook
-}
-
-// PushHook adds a function to the end of hook queue. Each invocation of the
-// GetBehindAhead method of the parent MockGitBackend instance invokes the
-// hook at the front of the queue and discards it. After the queue is empty,
-// the default hook function is invoked for any future action.
-func (f *GitBackendGetBehindAheadFunc) PushHook(hook func(context.Context, string, string) (*gitdomain.BehindAhead, error)) {
-	f.mutex.Lock()
-	f.hooks = append(f.hooks, hook)
-	f.mutex.Unlock()
-}
-
-// SetDefaultReturn calls SetDefaultHook with a function that returns the
-// given values.
-func (f *GitBackendGetBehindAheadFunc) SetDefaultReturn(r0 *gitdomain.BehindAhead, r1 error) {
-	f.SetDefaultHook(func(context.Context, string, string) (*gitdomain.BehindAhead, error) {
-		return r0, r1
-	})
-}
-
-// PushReturn calls PushHook with a function that returns the given values.
-func (f *GitBackendGetBehindAheadFunc) PushReturn(r0 *gitdomain.BehindAhead, r1 error) {
-	f.PushHook(func(context.Context, string, string) (*gitdomain.BehindAhead, error) {
-		return r0, r1
-	})
-}
-
-func (f *GitBackendGetBehindAheadFunc) nextHook() func(context.Context, string, string) (*gitdomain.BehindAhead, error) {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-
-	if len(f.hooks) == 0 {
-		return f.defaultHook
-	}
-
-	hook := f.hooks[0]
-	f.hooks = f.hooks[1:]
-	return hook
-}
-
-func (f *GitBackendGetBehindAheadFunc) appendCall(r0 GitBackendGetBehindAheadFuncCall) {
-	f.mutex.Lock()
-	f.history = append(f.history, r0)
-	f.mutex.Unlock()
-}
-
-// History returns a sequence of GitBackendGetBehindAheadFuncCall objects
-// describing the invocations of this function.
-func (f *GitBackendGetBehindAheadFunc) History() []GitBackendGetBehindAheadFuncCall {
-	f.mutex.Lock()
-	history := make([]GitBackendGetBehindAheadFuncCall, len(f.history))
-	copy(history, f.history)
-	f.mutex.Unlock()
-
-	return history
-}
-
-// GitBackendGetBehindAheadFuncCall is an object that describes an
-// invocation of method GetBehindAhead on an instance of MockGitBackend.
-type GitBackendGetBehindAheadFuncCall struct {
-	// Arg0 is the value of the 1st argument passed to this method
-	// invocation.
-	Arg0 context.Context
-	// Arg1 is the value of the 2nd argument passed to this method
-	// invocation.
-	Arg1 string
-	// Arg2 is the value of the 3rd argument passed to this method
-	// invocation.
-	Arg2 string
-	// Result0 is the value of the 1st result returned from this method
-	// invocation.
-	Result0 *gitdomain.BehindAhead
-	// Result1 is the value of the 2nd result returned from this method
-	// invocation.
-	Result1 error
-}
-
-// Args returns an interface slice containing the arguments of this
-// invocation.
-func (c GitBackendGetBehindAheadFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
-}
-
-// Results returns an interface slice containing the results of this
-// invocation.
-func (c GitBackendGetBehindAheadFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 

--- a/cmd/gitserver/internal/git/mock.go
+++ b/cmd/gitserver/internal/git/mock.go
@@ -302,6 +302,9 @@ type MockGitBackend struct {
 	// FirstEverCommitFunc is an instance of a mock function object
 	// controlling the behavior of the method FirstEverCommit.
 	FirstEverCommitFunc *GitBackendFirstEverCommitFunc
+	// GetBehindAheadFunc is an instance of a mock function object
+	// controlling the behavior of the method GetBehindAhead.
+	GetBehindAheadFunc *GitBackendGetBehindAheadFunc
 	// GetCommitFunc is an instance of a mock function object controlling
 	// the behavior of the method GetCommit.
 	GetCommitFunc *GitBackendGetCommitFunc
@@ -365,6 +368,11 @@ func NewMockGitBackend() *MockGitBackend {
 		},
 		FirstEverCommitFunc: &GitBackendFirstEverCommitFunc{
 			defaultHook: func(context.Context) (r0 api.CommitID, r1 error) {
+				return
+			},
+		},
+		GetBehindAheadFunc: &GitBackendGetBehindAheadFunc{
+			defaultHook: func(context.Context, string, string) (r0 *gitdomain.BehindAhead, r1 error) {
 				return
 			},
 		},
@@ -455,6 +463,11 @@ func NewStrictMockGitBackend() *MockGitBackend {
 				panic("unexpected invocation of MockGitBackend.FirstEverCommit")
 			},
 		},
+		GetBehindAheadFunc: &GitBackendGetBehindAheadFunc{
+			defaultHook: func(context.Context, string, string) (*gitdomain.BehindAhead, error) {
+				panic("unexpected invocation of MockGitBackend.GetBehindAhead")
+			},
+		},
 		GetCommitFunc: &GitBackendGetCommitFunc{
 			defaultHook: func(context.Context, api.CommitID, bool) (*GitCommitWithFiles, error) {
 				panic("unexpected invocation of MockGitBackend.GetCommit")
@@ -529,6 +542,9 @@ func NewMockGitBackendFrom(i GitBackend) *MockGitBackend {
 		},
 		FirstEverCommitFunc: &GitBackendFirstEverCommitFunc{
 			defaultHook: i.FirstEverCommit,
+		},
+		GetBehindAheadFunc: &GitBackendGetBehindAheadFunc{
+			defaultHook: i.GetBehindAhead,
 		},
 		GetCommitFunc: &GitBackendGetCommitFunc{
 			defaultHook: i.GetCommit,
@@ -1213,6 +1229,117 @@ func (c GitBackendFirstEverCommitFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c GitBackendFirstEverCommitFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
+}
+
+// GitBackendGetBehindAheadFunc describes the behavior when the
+// GetBehindAhead method of the parent MockGitBackend instance is invoked.
+type GitBackendGetBehindAheadFunc struct {
+	defaultHook func(context.Context, string, string) (*gitdomain.BehindAhead, error)
+	hooks       []func(context.Context, string, string) (*gitdomain.BehindAhead, error)
+	history     []GitBackendGetBehindAheadFuncCall
+	mutex       sync.Mutex
+}
+
+// GetBehindAhead delegates to the next hook function in the queue and
+// stores the parameter and result values of this invocation.
+func (m *MockGitBackend) GetBehindAhead(v0 context.Context, v1 string, v2 string) (*gitdomain.BehindAhead, error) {
+	r0, r1 := m.GetBehindAheadFunc.nextHook()(v0, v1, v2)
+	m.GetBehindAheadFunc.appendCall(GitBackendGetBehindAheadFuncCall{v0, v1, v2, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the GetBehindAhead
+// method of the parent MockGitBackend instance is invoked and the hook
+// queue is empty.
+func (f *GitBackendGetBehindAheadFunc) SetDefaultHook(hook func(context.Context, string, string) (*gitdomain.BehindAhead, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// GetBehindAhead method of the parent MockGitBackend instance invokes the
+// hook at the front of the queue and discards it. After the queue is empty,
+// the default hook function is invoked for any future action.
+func (f *GitBackendGetBehindAheadFunc) PushHook(hook func(context.Context, string, string) (*gitdomain.BehindAhead, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *GitBackendGetBehindAheadFunc) SetDefaultReturn(r0 *gitdomain.BehindAhead, r1 error) {
+	f.SetDefaultHook(func(context.Context, string, string) (*gitdomain.BehindAhead, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *GitBackendGetBehindAheadFunc) PushReturn(r0 *gitdomain.BehindAhead, r1 error) {
+	f.PushHook(func(context.Context, string, string) (*gitdomain.BehindAhead, error) {
+		return r0, r1
+	})
+}
+
+func (f *GitBackendGetBehindAheadFunc) nextHook() func(context.Context, string, string) (*gitdomain.BehindAhead, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *GitBackendGetBehindAheadFunc) appendCall(r0 GitBackendGetBehindAheadFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of GitBackendGetBehindAheadFuncCall objects
+// describing the invocations of this function.
+func (f *GitBackendGetBehindAheadFunc) History() []GitBackendGetBehindAheadFuncCall {
+	f.mutex.Lock()
+	history := make([]GitBackendGetBehindAheadFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// GitBackendGetBehindAheadFuncCall is an object that describes an
+// invocation of method GetBehindAhead on an instance of MockGitBackend.
+type GitBackendGetBehindAheadFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 string
+	// Arg2 is the value of the 3rd argument passed to this method
+	// invocation.
+	Arg2 string
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 *gitdomain.BehindAhead
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c GitBackendGetBehindAheadFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c GitBackendGetBehindAheadFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 

--- a/cmd/gitserver/internal/git/observability.go
+++ b/cmd/gitserver/internal/git/observability.go
@@ -39,6 +39,16 @@ type observableBackend struct {
 	backend    GitBackend
 }
 
+func (b *observableBackend) GetBehindAhead(ctx context.Context, left, right string) (*gitdomain.BehindAhead, error) {
+	ctx, _, endObservation := b.operations.getBehindAhead.With(ctx, nil, observation.Args{})
+	defer endObservation(1, observation.Args{})
+
+	concurrentOps.WithLabelValues("GetBehindAhead").Inc()
+	defer concurrentOps.WithLabelValues("GetBehindAhead").Dec()
+
+	return b.backend.GetBehindAhead(ctx, left, right)
+}
+
 func (b *observableBackend) Config() GitConfigBackend {
 	return &observableGitConfigBackend{
 		backend:    b.backend.Config(),
@@ -398,6 +408,7 @@ type operations struct {
 	rawDiff           *observation.Operation
 	contributorCounts *observation.Operation
 	firstEverCommit   *observation.Operation
+	getBehindAhead    *observation.Operation
 }
 
 func newOperations(observationCtx *observation.Context) *operations {
@@ -444,6 +455,7 @@ func newOperations(observationCtx *observation.Context) *operations {
 		rawDiff:           op("raw-diff"),
 		contributorCounts: op("contributor-counts"),
 		firstEverCommit:   op("first-ever-commit"),
+		getBehindAhead:    op("get-behind-ahead"),
 	}
 }
 

--- a/cmd/gitserver/internal/git/observability.go
+++ b/cmd/gitserver/internal/git/observability.go
@@ -39,14 +39,14 @@ type observableBackend struct {
 	backend    GitBackend
 }
 
-func (b *observableBackend) GetBehindAhead(ctx context.Context, left, right string) (*gitdomain.BehindAhead, error) {
+func (b *observableBackend) BehindAhead(ctx context.Context, left, right string) (*gitdomain.BehindAhead, error) {
 	ctx, _, endObservation := b.operations.getBehindAhead.With(ctx, nil, observation.Args{})
 	defer endObservation(1, observation.Args{})
 
-	concurrentOps.WithLabelValues("GetBehindAhead").Inc()
-	defer concurrentOps.WithLabelValues("GetBehindAhead").Dec()
+	concurrentOps.WithLabelValues("BehindAhead").Inc()
+	defer concurrentOps.WithLabelValues("BehindAhead").Dec()
 
-	return b.backend.GetBehindAhead(ctx, left, right)
+	return b.backend.BehindAhead(ctx, left, right)
 }
 
 func (b *observableBackend) Config() GitConfigBackend {


### PR DESCRIPTION
Part of https://github.com/sourcegraph/sourcegraph/issues/62101

This PR ports the GetBehindAhead implementation from the gitserver client to the new gitserver.Backend interface.

Here is the original implementation from the client for reference:

```go
// GetBehindAhead returns the behind/ahead commit counts information for right vs. left (both Git
// revspecs).
func (c *clientImplementor) GetBehindAhead(ctx context.Context, repo api.RepoName, left, right string) (_ *gitdomain.BehindAhead, err error) {
	ctx, _, endObservation := c.operations.getBehindAhead.With(ctx, &err, observation.Args{
		MetricLabelValues: []string{c.scope},
		Attrs: []attribute.KeyValue{
			repo.Attr(),
			attribute.String("left", left),
			attribute.String("right", right),
		},
	})
	defer endObservation(1, observation.Args{})

	if err := checkSpecArgSafety(left); err != nil {
		return nil, err
	}
	if err := checkSpecArgSafety(right); err != nil {
		return nil, err
	}

	cmd := c.gitCommand(repo, "rev-list", "--count", "--left-right", fmt.Sprintf("%s...%s", left, right))
	out, err := cmd.Output(ctx)
	if err != nil {
		return nil, err
	}
	behindAhead := strings.Split(strings.TrimSuffix(string(out), "\n"), "\t")
	b, err := strconv.ParseUint(behindAhead[0], 10, 0)
	if err != nil {
		return nil, err
	}
	a, err := strconv.ParseUint(behindAhead[1], 10, 0)
	if err != nil {
		return nil, err
	}
	return &gitdomain.BehindAhead{Behind: uint32(b), Ahead: uint32(a)}, nil
}
```

## Test plan

New unit tests 