### PR TITLE
gitserver: grpc: swap client implementation of GetAheadBehind from Exec to bespoke gRPC endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Raised the backend timeout for Language Stats Insights from 3 minutes to 5 minutes. You can override this with the `GET_INVENTORY_TIMEOUT` environment variable. [#62011](https://github.com/sourcegraph/sourcegraph/pull/62011)
 - Code insights drilldown behavior has been changed from a diff search to a point-in-time search with the new `rev:at.time()`. [#61953](https://github.com/sourcegraph/sourcegraph/pull/61953)
 - The `FirstEverCommit` gitserver client method has been changed to use a new bespoke gRPC endpoint instead of the legacy `exec` endpoint. [#62173](https://github.com/sourcegraph/sourcegraph/pull/62173)
+- The `GetBehindAhead` gitserver client method has been changed to use a new bespoke gRPC endpoint instead of the legacy `exec` endpoint. [#62217](https://github.com/sourcegraph/sourcegraph/pull/62217)
 
 ### Fixed
 

--- a/internal/gitserver/commands_test.go
+++ b/internal/gitserver/commands_test.go
@@ -2255,6 +2255,76 @@ func TestClient_FirstEverCommit(t *testing.T) {
 	})
 }
 
+func TestClient_GetBehindAhead(t *testing.T) {
+	t.Run("correctly returns server response", func(t *testing.T) {
+		source := NewTestClientSource(t, []string{"gitserver"}, func(o *TestClientSourceOptions) {
+			o.ClientFunc = func(cc *grpc.ClientConn) proto.GitserverServiceClient {
+				c := NewMockGitserverServiceClient()
+				c.BehindAheadFunc.SetDefaultReturn(&proto.BehindAheadResponse{
+					Behind: 5,
+					Ahead:  3,
+				}, nil)
+
+				return c
+			}
+		})
+
+		c := NewTestClient(t).WithClientSource(source)
+
+		actualBehindAhead, err := c.BehindAhead(context.Background(), "repo", "left", "right")
+		require.NoError(t, err)
+
+		expected := &gitdomain.BehindAhead{
+			Behind: 5,
+			Ahead:  3,
+		}
+
+		if diff := cmp.Diff(expected, actualBehindAhead, cmpopts.EquateEmpty()); diff != "" {
+			t.Fatalf("unexpected behind/ahead (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("returns well known error types", func(t *testing.T) {
+		t.Run("repository not found", func(t *testing.T) {
+			source := NewTestClientSource(t, []string{"gitserver"}, func(o *TestClientSourceOptions) {
+				o.ClientFunc = func(cc *grpc.ClientConn) proto.GitserverServiceClient {
+					c := NewMockGitserverServiceClient()
+					s, err := status.New(codes.NotFound, "repository not found").WithDetails(&proto.RepoNotFoundPayload{Repo: "repo", CloneInProgress: true})
+					require.NoError(t, err)
+					c.BehindAheadFunc.PushReturn(nil, s.Err())
+					return c
+				}
+			})
+
+			c := NewTestClient(t).WithClientSource(source)
+
+			// Should fail with clone error
+			_, err := c.BehindAhead(context.Background(), "repo", "left", "right")
+			require.Error(t, err)
+			require.True(t, errors.HasType(err, &gitdomain.RepoNotExistError{}))
+		})
+
+		t.Run("revision not found", func(t *testing.T) {
+			source := NewTestClientSource(t, []string{"gitserver"}, func(o *TestClientSourceOptions) {
+				o.ClientFunc = func(cc *grpc.ClientConn) proto.GitserverServiceClient {
+					c := NewMockGitserverServiceClient()
+					s, err := status.New(codes.NotFound, "revision not found").WithDetails(&proto.RevisionNotFoundPayload{Repo: "repo", Spec: "right"})
+					require.NoError(t, err)
+					c.BehindAheadFunc.SetDefaultReturn(nil, s.Err())
+					return c
+				}
+			})
+
+			c := NewTestClient(t).WithClientSource(source)
+
+			// Should fail with RevisionNotFoundError
+			_, err := c.BehindAhead(context.Background(), "repo", "left", "right")
+			require.Error(t, err)
+			require.True(t, errors.HasType(err, &gitdomain.RevisionNotFoundError{}))
+		})
+	})
+}
+
 func TestRevList(t *testing.T) {
 	ClientMocks.LocalGitserver = true
 	defer ResetClientMocks()


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/62101

This PR swaps the gitserver client implemenation of GetBehindAhead to use the new bespoke endpoint introduced in #62216 instead of the all-encompasing `exec` endpoint.

## Test plan

- Unit tests