### PR TITLE
chore: Use min/max builtins over math.Max/math.Min

### DIFF
--- a/cmd/frontend/graphqlbackend/repository_contributors.go
+++ b/cmd/frontend/graphqlbackend/repository_contributors.go
@@ -2,7 +2,6 @@ package graphqlbackend
 
 import (
 	"context"
-	"math"
 	"strconv"
 	"sync"
 	"time"
@@ -125,18 +124,18 @@ func (s *repositoryContributorConnectionStore) compute(ctx context.Context) ([]*
 func offsetBasedCursorSlice[T any](nodes []T, args *database.PaginationArgs) ([]T, int, error) {
 	start := 0
 	end := 0
-	totalFloat := float64(len(nodes))
+	total := len(nodes)
 	if args.First != nil {
 		if len(args.After) > 0 {
-			start = int(math.Min(float64(args.After[0].(int))+1, totalFloat))
+			start = min(args.After[0].(int)+1, total)
 		}
-		end = int(math.Min(float64(start+*args.First), totalFloat))
+		end = min(start+*args.First, total)
 	} else if args.Last != nil {
-		end = int(totalFloat)
+		end = total
 		if len(args.Before) > 0 {
-			end = int(math.Max(float64(args.Before[0].(int)), 0))
+			end = max(args.Before[0].(int), 0)
 		}
-		start = int(math.Max(float64(end-*args.Last), 0))
+		start = max(end-*args.Last, 0)
 	} else {
 		return nil, 0, errors.New(`args.First and args.Last are nil`)
 	}

--- a/internal/codeintel/policies/internal/store/configurations_test.go
+++ b/internal/codeintel/policies/internal/store/configurations_test.go
@@ -3,7 +3,6 @@ package store
 import (
 	"context"
 	"fmt"
-	"math"
 	"testing"
 	"time"
 
@@ -185,7 +184,7 @@ func TestGetConfigurationPolicies(t *testing.T) {
 			runTest(testCase, 0, 0)
 		} else {
 			for lo := range n {
-				if numErrors := runTest(testCase, lo, int(math.Min(float64(lo)+3, float64(n)))); numErrors > 0 {
+				if numErrors := runTest(testCase, lo, min(lo+3, n)); numErrors > 0 {
 					break
 				}
 			}

--- a/internal/codeintel/uploads/internal/store/uploads_test.go
+++ b/internal/codeintel/uploads/internal/store/uploads_test.go
@@ -3,7 +3,6 @@ package store
 import (
 	"context"
 	"fmt"
-	"math"
 	"sort"
 	"strings"
 	"testing"
@@ -207,7 +206,7 @@ func TestGetUploads(t *testing.T) {
 			runTest(testCase, 0, 0)
 		} else {
 			for lo := range n {
-				if numErrors := runTest(testCase, lo, int(math.Min(float64(lo)+3, float64(n)))); numErrors > 0 {
+				if numErrors := runTest(testCase, lo, min(lo+3, n)); numErrors > 0 {
 					break
 				}
 			}

--- a/internal/database/executors_test.go
+++ b/internal/database/executors_test.go
@@ -3,7 +3,6 @@ package database
 import (
 	"context"
 	"fmt"
-	"math"
 	"testing"
 	"time"
 
@@ -133,7 +132,7 @@ func TestExecutorsList(t *testing.T) {
 			runTest(testCase, 0, 0)
 		} else {
 			for lo := range n {
-				if numErrors := runTest(testCase, lo, int(math.Min(float64(lo)+3, float64(n)))); numErrors > 0 {
+				if numErrors := runTest(testCase, lo, min(lo+3, n)); numErrors > 0 {
 					break
 				}
 			}

--- a/internal/insights/scheduler/backfill_state_inprogress_handler.go
+++ b/internal/insights/scheduler/backfill_state_inprogress_handler.go
@@ -3,7 +3,6 @@ package scheduler
 import (
 	"context"
 	"fmt"
-	"math"
 	"sync"
 	"time"
 
@@ -388,7 +387,7 @@ func getInterruptAfter() time.Duration {
 func getPageSize() int {
 	val := conf.Get().InsightsBackfillRepositoryGroupSize
 	if val > 0 {
-		return int(math.Min(float64(val), 100))
+		return min(val, 100)
 	}
 	return 10
 }
@@ -396,7 +395,7 @@ func getPageSize() int {
 func getRepoConcurrency() int {
 	val := conf.Get().InsightsBackfillRepositoryConcurrency
 	if val > 0 {
-		return int(math.Min(float64(val), 10))
+		return min(val, 10)
 	}
 	return 3
 }

--- a/internal/insights/scheduler/iterator/repo_iterator.go
+++ b/internal/insights/scheduler/iterator/repo_iterator.go
@@ -375,7 +375,7 @@ func (p *PersistentRepoIterator) doFinishN(ctx context.Context, store *basestore
 			errorsCount++
 		}
 	}
-	successfulRepoCount := int(math.Max(float64(len(repos)-errorsCount), 0))
+	successfulRepoCount := max(len(repos)-errorsCount, 0)
 	if isRetry {
 		cursorOffset = 0
 	}

--- a/internal/insights/scheduler/iterator/repo_iterator.go
+++ b/internal/insights/scheduler/iterator/repo_iterator.go
@@ -2,7 +2,6 @@ package iterator
 
 import (
 	"context"
-	"math"
 	"time"
 
 	"github.com/derision-test/glock"
@@ -328,7 +327,7 @@ func peekN(offset, num int, repos []int32) ([]int32, bool) {
 	if offset >= len(repos) {
 		return []int32{}, false
 	}
-	end := int32(math.Min(float64(offset+num), float64(len(repos))))
+	end := int32(min(offset+num, len(repos)))
 	return repos[offset:end], true
 }
 

--- a/internal/usagestats/usage_stats.go
+++ b/internal/usagestats/usage_stats.go
@@ -242,12 +242,5 @@ func activeUsers(ctx context.Context, db database.DB, dayPeriods, weekPeriods, m
 }
 
 func minIntOrZero(a, b int) int {
-	min := b
-	if a < b {
-		min = a
-	}
-	if min < 0 {
-		return 0
-	}
-	return min
+	return max(min(a, b), 0)
 }

--- a/lib/codeintel/lsif/conversion/group.go
+++ b/lib/codeintel/lsif/conversion/group.go
@@ -2,7 +2,6 @@ package conversion
 
 import (
 	"context"
-	"math"
 	"sort"
 	"strings"
 
@@ -22,7 +21,7 @@ const resultsPerResultChunk = 512
 // groupBundleData converts a raw (but canonicalized) correlation State into a GroupedBundleData.
 func groupBundleData(ctx context.Context, state *State) *precise.GroupedBundleDataChans {
 	numResults := len(state.DefinitionData) + len(state.ReferenceData) + len(state.ImplementationData)
-	numResultChunks := int(math.Max(1, math.Floor(float64(numResults)/resultsPerResultChunk)))
+	numResultChunks := max(1, numResults/resultsPerResultChunk)
 
 	meta := precise.MetaData{NumResultChunks: numResultChunks}
 	documents := serializeBundleDocuments(ctx, state)


### PR DESCRIPTION
These were introduced in Go 1.21 and avoid int->float64->int conversions

## Test plan

Covered by existing tests