### PR TITLE
release: fix regression in release requirements check

### DIFF
--- a/dev/sg/internal/release/config.go
+++ b/dev/sg/internal/release/config.go
@@ -308,8 +308,6 @@ func (r *releaseRunner) CreateRelease(ctx context.Context) error {
 		return err
 	}
 
-	fmt.Println("gotten an error ----")
-
 	var steps []cmdManifest
 	switch r.typ {
 	case "patch":

--- a/dev/sg/internal/release/config.go
+++ b/dev/sg/internal/release/config.go
@@ -268,7 +268,7 @@ func (r *releaseRunner) checkRequirements(ctx context.Context, stage string) err
 	for _, req := range r.m.Requirements {
 		if shouldSkipReqCheck(req, stage) {
 			saySuccess("reqs", "🔕 %s (excluded for %s)", req.Name, stage)
-			return nil
+			continue
 		}
 
 		if req.Env != "" && req.Cmd != "" {
@@ -305,8 +305,10 @@ func (r *releaseRunner) checkRequirements(ctx context.Context, stage string) err
 
 func (r *releaseRunner) CreateRelease(ctx context.Context) error {
 	if err := r.checkRequirements(ctx, stageInternalCreate); err != nil {
-		return nil
+		return err
 	}
+
+	fmt.Println("gotten an error ----")
 
 	var steps []cmdManifest
 	switch r.typ {


### PR DESCRIPTION
The update to requirements check introduced a regression where excluded requirements would short-circuit the function for requirement checking and return a nil error.

This allowed the `createRelease` function to be executed even when requirements were missing.

## Test plan

* Manual testing
![CleanShot 2024-04-29 at 14 59 49@2x](https://github.com/sourcegraph/sourcegraph/assets/25608335/3bba4d75-8929-4abc-b23d-c9accced094e)
