### PR TITLE
appliance: remove default deployment replica scale

### DIFF
--- a/internal/k8s/resource/deployment/deployment.go
+++ b/internal/k8s/resource/deployment/deployment.go
@@ -9,6 +9,11 @@ import (
 
 // NewDeployment creates a new k8s Deployment with some default values set.
 func NewDeployment(name, namespace, version string) appsv1.Deployment {
+	// Note that we don't set a default spec.replicas because the default is 1
+	// anyway, and if this field is explicitly set but also managed by an HPA,
+	// configuration changes will cause downscale events. Even when the HPA
+	// subsequently scales back out, there may have been a period of service
+	// disruption as requests saturate the single replica.
 	return appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -22,7 +27,6 @@ func NewDeployment(name, namespace, version string) appsv1.Deployment {
 		},
 		Spec: appsv1.DeploymentSpec{
 			MinReadySeconds:      int32(10),
-			Replicas:             pointers.Ptr[int32](1),
 			RevisionHistoryLimit: pointers.Ptr[int32](10),
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{


### PR DESCRIPTION
The default is 1 anyway, and if this field is explicitly set but also
managed by an HPA, configuration changes will cause downscale events.
Even when the HPA subsequently scales back out, there may have been a
period of service disruption as requests saturate the single replica.



## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->

Note that this change causes no golden fixture changes, proving that the Deployment.spec.replicas default is already being defaulted to 1 by the Kubernetes resource schema.