### PR TITLE
release: fix error handling with `sg release`

### DIFF
--- a/dev/sg/internal/release/config.go
+++ b/dev/sg/internal/release/config.go
@@ -330,7 +330,7 @@ func (r *releaseRunner) CreateRelease(ctx context.Context) error {
 
 func (r *releaseRunner) InternalFinalize(ctx context.Context) error {
 	if err := r.checkRequirements(ctx, stageInternalCreate); err != nil {
-		return nil
+		return err
 	}
 
 	if len(r.m.Internal.Finalize.Steps) == 0 {
@@ -343,7 +343,7 @@ func (r *releaseRunner) InternalFinalize(ctx context.Context) error {
 
 func (r *releaseRunner) Test(ctx context.Context) error {
 	if err := r.checkRequirements(ctx, stageTest); err != nil {
-		return nil
+		return err
 	}
 
 	if len(r.m.Test.Steps) == 0 {
@@ -356,7 +356,7 @@ func (r *releaseRunner) Test(ctx context.Context) error {
 
 func (r *releaseRunner) Promote(ctx context.Context) error {
 	if err := r.checkRequirements(ctx, stagePromoteCreate); err != nil {
-		return nil
+		return err
 	}
 	announce2("promote", "Will promote %q to a public release", r.version)
 	return r.runSteps(ctx, r.m.PromoteToPublic.Create.Steps)
@@ -364,7 +364,7 @@ func (r *releaseRunner) Promote(ctx context.Context) error {
 
 func (r *releaseRunner) PromoteFinalize(ctx context.Context) error {
 	if err := r.checkRequirements(ctx, stagePromoteFinalize); err != nil {
-		return nil
+		return err
 	}
 
 	if len(r.m.PromoteToPublic.Finalize.Steps) == 0 {


### PR DESCRIPTION
I didn't cover all the cases with the regression in my previous PR.
I cut an internal release earlier and realized some steps passed even though there were failures, so this should fix all those now.

![CleanShot 2024-04-29 at 16 10 44@2x](https://github.com/sourcegraph/sourcegraph/assets/25608335/24e70749-f5e9-4c9f-b216-4fa249d3df06)

## Test plan

* Manual testing
