### PR TITLE
chore(sg): sg bazel uses remote cache by default (unless in CI) 

### DIFF
--- a/.aspect/bazelrc/remote_cache_for_local.bazelrc
+++ b/.aspect/bazelrc/remote_cache_for_local.bazelrc
@@ -1,0 +1,19 @@
+# Only download remote outputs of top level targets to the local machine.
+# Docs: https://bazel.build/reference/command-line-reference#flag--remote_download_toplevel
+build --remote_download_toplevel
+
+# Upload locally executed action results to the remote cache.
+# Docs: https://bazel.build/reference/command-line-reference#flag--remote_upload_local_results
+build --remote_upload_local_results
+
+# Fall back to standalone local execution strategy if remote execution fails. If the grpc remote
+# cache connection fails, it will fail the build, add this so it falls back to the local cache.
+# Docs: https://bazel.build/reference/command-line-reference#flag--remote_local_fallback
+build --remote_local_fallback
+
+# These likely perform faster locally than the overhead of pulling/pushing from/to the remote cache,
+# as well as being able to reduce how much we push to the cache
+common --modify_execution_info=CopyDirectory=+no-remote,CopyToDirectory=+no-remote,CopyFile=+no-remote
+
+common --credential_helper=storage.googleapis.com=%workspace%/dev/remote_cache_local_env.sh
+common --remote_cache=https://storage.googleapis.com/local_bazel_remote_cache

--- a/.aspect/bazelrc/remote_cache_for_local.bazelrc
+++ b/.aspect/bazelrc/remote_cache_for_local.bazelrc
@@ -17,3 +17,7 @@ common --modify_execution_info=CopyDirectory=+no-remote,CopyToDirectory=+no-remo
 
 common --credential_helper=storage.googleapis.com=%workspace%/dev/remote_cache_local_env.sh
 common --remote_cache=https://storage.googleapis.com/local_bazel_remote_cache
+
+# If true, remote cache I/O will happen in the background instead of taking place as the part of a spawn.
+# Docs: https://bazel.build/reference/command-line-reference#flag--experimental_remote_cache_async
+common  --experimental_remote_cache_async

--- a/dev/remote_cache_local_env.sh
+++ b/dev/remote_cache_local_env.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-GCP_PROJECT="sourcegraph-ci"
+GCP_PROJECT="sourcegraph-local-dev"
 
 function emit_headers() {
   echo "{\"headers\":{\"Authorization\":[\"Bearer ${1}\"]}}"

--- a/dev/remote_cache_local_env.sh
+++ b/dev/remote_cache_local_env.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+GCP_PROJECT="sourcegraph-ci"
+
+function emit_headers() {
+  echo "{\"headers\":{\"Authorization\":[\"Bearer ${1}\"]}}"
+}
+
+emit_headers "$(gcloud --project ${GCP_PROJECT} auth print-access-token)"
+exit 0

--- a/dev/sg/sg_bazel.go
+++ b/dev/sg/sg_bazel.go
@@ -51,13 +51,41 @@ var bazelCommand = &cli.Command{
 	HideHelpCommand: true,
 	Usage:           "Proxies the bazel CLI with custom commands for local dev convenience",
 	Category:        category.Dev,
-	Action: func(ctx *cli.Context) error {
-		if slices.Equal(ctx.Args().Slice(), []string{"help"}) || slices.Equal(ctx.Args().Slice(), []string{"--help"}) || slices.Equal(ctx.Args().Slice(), []string{"-h"}) {
+	Action: func(cctx *cli.Context) error {
+		if slices.Equal(cctx.Args().Slice(), []string{"help"}) || slices.Equal(cctx.Args().Slice(), []string{"--help"}) || slices.Equal(cctx.Args().Slice(), []string{"-h"}) {
 			fmt.Println("Additional commands from sg:")
 			fmt.Println("  configure           Wrappers around some commands to generate various files required by Bazel")
+			fmt.Println("Additional flags from sg:")
+			fmt.Println("  --disable-remote-cache           Disable use of the remote cache for local env.")
 		}
 
-		cmd := exec.CommandContext(ctx.Context, "bazel", ctx.Args().Slice()...)
+		// Walk the args, looking for our custom flag to disable the remote cache.
+		// If we find it, we take not of it, but do not append it to the final args
+		// that will be passed to the bazel command. Everything else is passed as-is.
+		var disableRemoteCache bool
+		args := make([]string, 0, len(cctx.Args().Slice()))
+		for _, arg := range cctx.Args().Slice() {
+			switch arg {
+			case "--disable-remote-cache":
+				disableRemoteCache = true
+			case "--disable-remote-cache=true":
+				disableRemoteCache = true
+			case "--disable-remote-cache=false":
+				disableRemoteCache = false
+			default:
+				args = append(args, arg)
+			}
+		}
+
+		if !disableRemoteCache {
+			newArgs := make([]string, 0, len(args)+1)
+			// Bazelrc flags must be added before the actual command (build, run, test ...)
+			newArgs = append(newArgs, "--bazelrc=.aspect/bazelrc/remote_cache_for_local.bazelrc")
+			newArgs = append(newArgs, args...)
+			args = newArgs
+		}
+
+		cmd := exec.CommandContext(cctx.Context, "bazel", args...)
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
 		cmd.Stdin = os.Stdin

--- a/dev/sg/sg_bazel.go
+++ b/dev/sg/sg_bazel.go
@@ -77,6 +77,12 @@ var bazelCommand = &cli.Command{
 			}
 		}
 
+		// If we end up running `sg bazel` in CI, we don't want to use the remote cache for local environment,
+		// so we force disable the flag explicilty.
+		if os.Getenv("CI") == "true" || os.Getenv("BUILDKITE") == "true" {
+			disableRemoteCache = true
+		}
+
 		if !disableRemoteCache {
 			newArgs := make([]string, 0, len(args)+1)
 			// Bazelrc flags must be added before the actual command (build, run, test ...)


### PR DESCRIPTION
Using a GCS bucket + a custom credential helper, we can enable the remote cache for everyone without having to perform explicit authentication or setup. Authentication is fully delegated to `gcloud`. And because every teammate can access the secrets for the local env, they can also write on the cache. 

In case of emergency, `--disable-remote-cache` can disable the remote cache flags, and normal `bazel [cmd]` are unaffected. 

Bystanders that would like to test this: 

```
git fetch
git checkout jh/bzl/local-remote-cache
go run ./dev/sg bazel build //cmd/gitserver
```

💡 Additionally, this creates the incentive we were looking for to teach folks to use `sg bazel` over `bazel`.

## Test plan

Locally tested (and @eseliger tested it too, to avoid ending up in a scenario where I have special perms on that GCP project). 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
