### PR TITLE
Svelte: Visual update for search results

### DIFF
--- a/client/web-sveltekit/src/lib/CodeExcerpt.svelte
+++ b/client/web-sveltekit/src/lib/CodeExcerpt.svelte
@@ -81,7 +81,7 @@
 
         font-family: var(--code-font-family);
         font-size: var(--code-font-size);
-        line-height: 1rem;
+        line-height: 1.2rem;
         white-space: pre;
 
         :global(td.line::before) {

--- a/client/web-sveltekit/src/lib/search/resultsIndicator/ResultsIndicator.svelte
+++ b/client/web-sveltekit/src/lib/search/resultsIndicator/ResultsIndicator.svelte
@@ -41,7 +41,7 @@
         {#if loading}
             <LoadingSpinner inline />
         {:else}
-            <Icon svgPath={icons[severity]} size={16} --color={isError ? 'var(--danger)' : 'var(--text-title)'} />
+            <Icon svgPath={icons[severity]} size={18} --color={isError ? 'var(--danger)' : 'var(--text-title)'} />
         {/if}
     </div>
 
@@ -55,7 +55,7 @@
             <span>Running search...</span>
         {/if}
     </div>
-    <Icon svgPath={mdiChevronDown} size={16} --color={isError ? 'var(--danger)' : 'var(--text-title)'} />
+    <Icon svgPath={mdiChevronDown} size={18} --color={isError ? 'var(--danger)' : 'var(--text-title)'} />
 </div>
 
 <style lang="scss">

--- a/client/web-sveltekit/src/lib/search/resultsIndicator/ResultsIndicator.svelte
+++ b/client/web-sveltekit/src/lib/search/resultsIndicator/ResultsIndicator.svelte
@@ -41,7 +41,7 @@
         {#if loading}
             <LoadingSpinner inline />
         {:else}
-            <Icon svgPath={icons[severity]} size={18} --color={isError ? 'var(--danger)' : 'var(--text-title)'} />
+            <Icon svgPath={icons[severity]} size={16} --color={isError ? 'var(--danger)' : 'var(--text-title)'} />
         {/if}
     </div>
 
@@ -52,10 +52,10 @@
         {:else if done}
             <SuggestedAction {progress} {suggestedItems} {severity} {state} />
         {:else}
-            <small>Running Search</small>
+            <span>Running search...</span>
         {/if}
     </div>
-    <Icon svgPath={mdiChevronDown} size={18} --color={isError ? 'var(--danger)' : 'var(--text-title)'} />
+    <Icon svgPath={mdiChevronDown} size={16} --color={isError ? 'var(--danger)' : 'var(--text-title)'} />
 </div>
 
 <style lang="scss">
@@ -80,7 +80,7 @@
             row-gap: 0.25rem;
         }
 
-        small {
+        span {
             color: var(--text-muted);
         }
     }

--- a/client/web-sveltekit/src/routes/search/FileSearchResultHeader.svelte
+++ b/client/web-sveltekit/src/routes/search/FileSearchResultHeader.svelte
@@ -39,13 +39,10 @@
 
     .interpunct {
         margin: 0 0.5rem;
-        color: var(--text-muted);
+        color: var(--text-disabled);
     }
 
     .path {
         color: var(--text-body);
-        .file-name {
-            font-weight: 600;
-        }
     }
 </style>

--- a/client/web-sveltekit/src/routes/search/RepoRev.svelte
+++ b/client/web-sveltekit/src/routes/search/RepoRev.svelte
@@ -38,7 +38,8 @@
 
         .repo-link {
             align-self: baseline;
-            color: var(--text-body);
+            color: var(--body-color);
+            font-weight: 500;
             .rev {
                 color: var(--text-muted);
             }

--- a/client/web-sveltekit/src/routes/search/SearchResult.svelte
+++ b/client/web-sveltekit/src/routes/search/SearchResult.svelte
@@ -33,7 +33,7 @@
     .header {
         display: flex;
         align-items: center;
-        padding: 0.5rem;
+        padding: 0.5rem 0.75rem;
         position: sticky;
         top: 0;
         background-color: var(--body-bg);


### PR DESCRIPTION
# Context
More visual update goodness for search results.

## Before
![CleanShot 2024-04-29 at 17 11 03@2x](https://github.com/sourcegraph/sourcegraph/assets/5337876/805ffe00-cd8e-41b0-bf40-bb692b3953de)

![CleanShot 2024-04-29 at 17 11 21@2x](https://github.com/sourcegraph/sourcegraph/assets/5337876/94ed6a41-de8b-4544-9afe-b395df4c83d6)


## After
![CleanShot 2024-04-29 at 17 10 19@2x](https://github.com/sourcegraph/sourcegraph/assets/5337876/907ef718-18b8-4e20-b0ba-76c5a0532add)

![CleanShot 2024-04-29 at 17 09 54@2x](https://github.com/sourcegraph/sourcegraph/assets/5337876/41c36140-2bec-48c2-9f64-3a4650cb1b40)

## Test plan
Locally tested for visual changes.