### PR TITLE
bug(sg): fix issue where path to bazelrc would fail

### DIFF
--- a/dev/sg/sg_bazel.go
+++ b/dev/sg/sg_bazel.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"slices"
 	"strings"
 
@@ -13,6 +14,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/category"
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/std"
+	"github.com/sourcegraph/sourcegraph/dev/sg/root"
 	"github.com/sourcegraph/sourcegraph/lib/cliutil/completions"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 	"github.com/sourcegraph/sourcegraph/lib/output"
@@ -84,9 +86,13 @@ var bazelCommand = &cli.Command{
 		}
 
 		if !disableRemoteCache {
+			rootDir, err := root.RepositoryRoot()
+			if err != nil {
+				return errors.Wrap(err, "getting repository root")
+			}
 			newArgs := make([]string, 0, len(args)+1)
 			// Bazelrc flags must be added before the actual command (build, run, test ...)
-			newArgs = append(newArgs, "--bazelrc=.aspect/bazelrc/remote_cache_for_local.bazelrc")
+			newArgs = append(newArgs, fmt.Sprintf("--bazelrc=%s", filepath.Join(rootDir, ".aspect/bazelrc/remote_cache_for_local.bazelrc")))
 			newArgs = append(newArgs, args...)
 			args = newArgs
 		}


### PR DESCRIPTION
Fix a small bug, if you're not running `sg` at the root of the repo, the bazelrc path would be incorrect.

## Test plan

Locally tested. 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
