### PR TITLE
Code monitors: add some levers for tuning resource usage

### DIFF
--- a/internal/codemonitors/background/workers.go
+++ b/internal/codemonitors/background/workers.go
@@ -33,7 +33,7 @@ func newTriggerQueryRunner(ctx context.Context, observationCtx *observation.Cont
 	options := workerutil.WorkerOptions{
 		Name:                 "code_monitors_trigger_jobs_worker",
 		Description:          "runs trigger queries for code monitors",
-		NumHandlers:          4,
+		NumHandlers:          conf.CodeMonitors().Concurrency,
 		Interval:             5 * time.Second,
 		HeartbeatInterval:    15 * time.Second,
 		Metrics:              metrics.workerMetrics,
@@ -42,7 +42,7 @@ func newTriggerQueryRunner(ctx context.Context, observationCtx *observation.Cont
 
 	store := createDBWorkerStoreForTriggerJobs(observationCtx, db)
 
-	worker := dbworker.NewWorker[*database.TriggerJob](ctx, store, &queryRunner{db: db}, options)
+	worker := dbworker.NewWorker(ctx, store, &queryRunner{db: db}, options)
 	return worker
 }
 
@@ -103,7 +103,7 @@ func newActionRunner(ctx context.Context, observationCtx *observation.Context, s
 
 	store := createDBWorkerStoreForActionJobs(observationCtx, s)
 
-	worker := dbworker.NewWorker[*database.ActionJob](ctx, store, &actionRunner{s}, options)
+	worker := dbworker.NewWorker(ctx, store, &actionRunner{s}, options)
 	return worker
 }
 
@@ -185,7 +185,7 @@ func (r *queryRunner) Handle(ctx context.Context, logger log.Logger, triggerJob 
 
 	// Log next_run and latest_result to table cm_queries.
 	newLatestResult := latestResultTime(q.LatestResult, results, searchErr)
-	err = cm.SetQueryTriggerNextRun(ctx, q.ID, cm.Clock()().Add(5*time.Minute), newLatestResult.UTC())
+	err = cm.SetQueryTriggerNextRun(ctx, q.ID, cm.Clock()().Add(conf.CodeMonitors().PollInterval), newLatestResult.UTC())
 	if err != nil {
 		return err
 	}

--- a/internal/codemonitors/search.go
+++ b/internal/codemonitors/search.go
@@ -158,6 +158,7 @@ func addCodeMonitorHook(in job.Job, hook commit.CodeMonitorHook) (_ job.Job, err
 			}
 			cp := *v
 			cp.CodeMonitorSearchWrapper = hook
+			cp.Concurrency = 1
 			return &cp
 		case *repos.ComputeExcludedJob, *jobutil.NoopJob:
 			// ComputeExcludedJob is fine for code monitor jobs, but should be

--- a/internal/conf/computed.go
+++ b/internal/conf/computed.go
@@ -176,6 +176,47 @@ func BatchChangesRestrictedToAdmins() bool {
 	return false
 }
 
+func init() {
+	ContributeValidator(func(querier conftypes.SiteConfigQuerier) (problems Problems) {
+		cm := querier.SiteConfig().CodeMonitors
+		if cm == nil {
+			return nil
+		}
+		if cm.Concurrency < 0 {
+			problems = append(problems, NewSiteProblem("codeMonitors.concurrency must be greater than zero"))
+		}
+		if cm.PollInterval != "" {
+			if _, err := time.ParseDuration(cm.PollInterval); err != nil {
+				problems = append(problems, NewSiteProblem("codeMonitors.pollInterval must be parseable as a duration"))
+			}
+		}
+		return problems
+	})
+}
+
+type ComputedCodeMonitors struct {
+	Concurrency  int
+	PollInterval time.Duration
+}
+
+func CodeMonitors() ComputedCodeMonitors {
+	// Start with default values and override if set
+	res := ComputedCodeMonitors{
+		Concurrency:  4,
+		PollInterval: 5 * time.Minute,
+	}
+	if cm := Get().CodeMonitors; cm != nil {
+		if cm.Concurrency != 0 {
+			res.Concurrency = cm.Concurrency
+		}
+		if cm.PollInterval != "" {
+			dur, _ := time.ParseDuration(cm.PollInterval)
+			res.PollInterval = dur
+		}
+	}
+	return res
+}
+
 // CodyEnabled returns whether Cody is enabled on this instance.
 //
 // If `cody.enabled` is not set or set to false, it's not enabled.

--- a/internal/conf/computed.go
+++ b/internal/conf/computed.go
@@ -210,6 +210,7 @@ func CodeMonitors() ComputedCodeMonitors {
 			res.Concurrency = cm.Concurrency
 		}
 		if cm.PollInterval != "" {
+			// ignore err since it's validated above
 			dur, _ := time.ParseDuration(cm.PollInterval)
 			res.PollInterval = dur
 		}

--- a/internal/search/commit/commit.go
+++ b/internal/search/commit/commit.go
@@ -95,7 +95,7 @@ func (j *SearchJob) Run(ctx context.Context, clients job.RuntimeClients, stream 
 		return doSearch(args)
 	}
 
-	p := pool.New().WithContext(ctx).WithMaxGoroutines(4).WithFirstError()
+	p := pool.New().WithContext(ctx).WithMaxGoroutines(j.Concurrency).WithFirstError()
 
 	for _, repoRev := range j.Repos {
 		repoRev := repoRev

--- a/internal/search/job/jobutil/exhaustive_job.go
+++ b/internal/search/job/jobutil/exhaustive_job.go
@@ -82,6 +82,7 @@ func NewExhaustive(inputs *search.Inputs) (Exhaustive, error) {
 			Diff:                 diff,
 			Limit:                b.MaxResults(inputs.DefaultLimit()),
 			IncludeModifiedFiles: authz.SubRepoEnabled(authz.DefaultSubRepoPermsChecker) || own,
+			Concurrency:          4,
 		}
 
 		planJob =

--- a/internal/search/job/jobutil/job.go
+++ b/internal/search/job/jobutil/job.go
@@ -177,6 +177,7 @@ func NewBasicJob(inputs *search.Inputs, b query.Basic) (job.Job, error) {
 				Diff:                 diff,
 				Limit:                int(fileMatchLimit),
 				IncludeModifiedFiles: authz.SubRepoEnabled(authz.DefaultSubRepoPermsChecker) || own,
+				Concurrency:          4,
 			}
 
 			addJob(

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -610,6 +610,14 @@ type CloudKMSEncryptionKey struct {
 	Type            string `json:"type"`
 }
 
+// CodeMonitors description: Configuration options for code monitors
+type CodeMonitors struct {
+	// Concurrency description: The number of code monitor jobs allowed to run concurrenctly. Decrease to reduce peak load.
+	Concurrency int `json:"concurrency,omitempty"`
+	// PollInterval description: The interval at which a monitor checks for new changes. Increase to reduce average load.
+	PollInterval string `json:"pollInterval,omitempty"`
+}
+
 // Codeintel description: The configuration for the codeintel queue.
 type Codeintel struct {
 	// Limit description: The maximum number of dequeues allowed within the expiration window.
@@ -2753,6 +2761,8 @@ type SiteConfiguration struct {
 	CodeIntelRankingDocumentReferenceCountsGraphKey string `json:"codeIntelRanking.documentReferenceCountsGraphKey,omitempty"`
 	// CodeIntelRankingStaleResultsAge description: The interval at which to run the reduce job that computes document reference counts. Default is 24hrs.
 	CodeIntelRankingStaleResultsAge int `json:"codeIntelRanking.staleResultsAge,omitempty"`
+	// CodeMonitors description: Configuration options for code monitors
+	CodeMonitors *CodeMonitors `json:"codeMonitors,omitempty"`
 	// CodyContextFilters description: Rules defining the repositories that will never be shared by Cody with third-party LLM providers.
 	CodyContextFilters *CodyContextFilters `json:"cody.contextFilters,omitempty"`
 	// CodyEnabled description: Enable or disable Cody instance-wide. When Cody is disabled, all Cody endpoints and GraphQL queries will return errors, Cody will not show up in the site-admin sidebar, and Cody in the global navbar will only show a call-to-action for site-admins to enable Cody.
@@ -3025,6 +3035,7 @@ func (v *SiteConfiguration) UnmarshalJSON(data []byte) error {
 	delete(m, "codeIntelRanking.documentReferenceCountsEnabled")
 	delete(m, "codeIntelRanking.documentReferenceCountsGraphKey")
 	delete(m, "codeIntelRanking.staleResultsAge")
+	delete(m, "codeMonitors")
 	delete(m, "cody.contextFilters")
 	delete(m, "cody.enabled")
 	delete(m, "cody.permissions")

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -934,6 +934,22 @@
       "default": -1,
       "group": "External services"
     },
+    "codeMonitors": {
+      "description": "Configuration options for code monitors",
+      "type": "object",
+      "properties": {
+        "pollInterval": {
+          "description": "The interval at which a monitor checks for new changes. Increase to reduce average load.",
+          "type": "string",
+          "default": "5m"
+        },
+        "concurrency": {
+          "description": "The number of code monitor jobs allowed to run concurrenctly. Decrease to reduce peak load.",
+          "type": "integer",
+          "default": 4
+        }
+      }
+    },
     "syntaxHighlighting": {
       "title": "SyntaxHighlighting",
       "description": "Syntax highlighting configuration",


### PR DESCRIPTION
This adds a couple of configuration options which will allow us to tune the cost of code monitors in the event that we are seeing issues. It does not change the default values.

## Test plan

Tested that the conf validation works and that the intervals actually updated.