### PR TITLE
svelte: Add infinity scroll and search to tags page

### DIFF
--- a/client/web-sveltekit/src/lib/repo/FileHeader.svelte
+++ b/client/web-sveltekit/src/lib/repo/FileHeader.svelte
@@ -124,7 +124,7 @@
         a {
             color: var(--text-body);
 
-            &:hover{
+            &:hover {
                 color: var(--text-title);
             }
         }

--- a/client/web-sveltekit/src/lib/wildcard/Button.svelte
+++ b/client/web-sveltekit/src/lib/wildcard/Button.svelte
@@ -27,7 +27,7 @@
 
 <slot name="custom" {buttonClass}>
     <!-- $$restProps holds all the additional props that are passed to the component -->
-    <button class={buttonClass} {...$$restProps} on:click|preventDefault>
+    <button class={buttonClass} type="button" {...$$restProps} on:click>
         <slot />
     </button>
 </slot>

--- a/client/web-sveltekit/src/lib/wildcard/Input.svelte
+++ b/client/web-sveltekit/src/lib/wildcard/Input.svelte
@@ -5,11 +5,11 @@
     import LoadingSpinner from '../LoadingSpinner.svelte'
 
     export let value: string
-    export let placeholder: string | undefined
-    export let autofocus: boolean | undefined
+    export let placeholder: string | undefined = undefined
+    export let autofocus: boolean | undefined = undefined
     export let onInput: FormEventHandler<HTMLInputElement> | undefined = undefined
     export let input: HTMLInputElement | undefined = undefined
-    export let actions: Array<(node: HTMLInputElement) => ActionReturn>
+    export let actions: Array<(node: HTMLInputElement) => ActionReturn> = []
     export let loading: boolean = false
 
     $: bindAction = function bindAction(node: HTMLInputElement) {

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/Picker.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/Picker.svelte
@@ -114,10 +114,10 @@
     .root {
         display: flex;
         flex-direction: column;
-    }
 
-    :global([data-input-container]) {
-        margin: 0.75rem;
+        :global([data-input-container]) {
+            margin: 0.75rem;
+        }
     }
 
     .loading-state,

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/-/tags/+page.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/-/tags/+page.svelte
@@ -1,11 +1,40 @@
 <script lang="ts">
+    import { get } from 'svelte/store'
+
+    import { navigating } from '$app/stores'
     import LoadingSpinner from '$lib/LoadingSpinner.svelte'
     import GitReference from '$lib/repo/GitReference.svelte'
+    import Scroller, { type Capture as ScrollerCapture } from '$lib/Scroller.svelte'
     import { Alert } from '$lib/wildcard'
 
-    import type { PageData } from './$types'
+    import type { PageData, Snapshot } from './$types'
+    import type { GitTagsConnection } from './page.gql'
 
     export let data: PageData
+
+    export const snapshot: Snapshot<{ count: number; scroller: ScrollerCapture }> = {
+        capture() {
+            return {
+                count: tagsConnection?.nodes.length ?? 0,
+                scroller: scroller.capture(),
+            }
+        },
+        async restore(snapshot) {
+            if (snapshot?.count && get(navigating)?.type === 'popstate') {
+                await tagsQuery?.restore(result => {
+                    const count = result.data?.repository?.gitRefs?.nodes?.length
+                    return !!count && count < snapshot.count
+                })
+            }
+            scroller.restore(snapshot.scroller)
+        },
+    }
+
+    let scroller: Scroller
+    let tagsConnection: GitTagsConnection
+
+    $: tagsQuery = data.tagsQuery
+    $: tagsConnection = $tagsQuery.data?.repository?.gitRefs ?? tagsConnection
 </script>
 
 <svelte:head>
@@ -13,16 +42,13 @@
 </svelte:head>
 
 <section>
-    <div>
-        {#await data.tags}
-            <LoadingSpinner />
-        {:then connection}
+    {#if !$tagsQuery.restoring && tagsConnection}
+        <Scroller bind:this={scroller} margin={600} on:more={tagsQuery.fetchMore}>
             <!-- TODO: Search input to filter tags by name -->
-            <!-- TODO: Pagination -->
             <table>
                 <tbody>
-                    {#each connection.nodes as node (node.id)}
-                        <GitReference ref={node} />
+                    {#each tagsConnection.nodes as tag (tag)}
+                        <GitReference ref={tag} />
                     {:else}
                         <tr>
                             <td colspan="2">
@@ -32,27 +58,44 @@
                     {/each}
                 </tbody>
             </table>
-            <small class="text-muted">{connection.totalCount} tags total</small>
-        {:catch error}
-            <Alert variant="danger">{error.message}</Alert>
-        {/await}
-    </div>
+            <div>
+                {#if $tagsQuery.fetching || $tagsQuery.restoring}
+                    <LoadingSpinner />
+                {:else if $tagsQuery.error}
+                    <Alert variant="danger">
+                        Unable to load tags: {$tagsQuery.error.message}
+                    </Alert>
+                {/if}
+            </div>
+        </Scroller>
+        <div class="footer">
+            {tagsConnection.totalCount} tags total (showing {tagsConnection.nodes.length})
+        </div>
+    {/if}
 </section>
 
 <style lang="scss">
+    div,
+    table {
+        max-width: var(--viewport-xl);
+        margin: 0 auto;
+    }
+
     table {
         width: 100%;
         border-spacing: 0;
     }
 
     section {
-        overflow: auto;
+        display: flex;
+        flex-direction: column;
         margin-top: 2rem;
+        height: 100%;
+        overflow: hidden;
     }
 
-    div {
-        max-width: 54rem;
-        margin-left: auto;
-        margin-right: auto;
+    .footer {
+        color: var(--text-muted);
+        padding: 1rem;
     }
 </style>

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/-/tags/+page.ts
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/-/tags/+page.ts
@@ -6,11 +6,13 @@ import { TagsPage_TagsQuery } from './page.gql'
 
 const PAGE_SIZE = 50
 
-export const load: PageLoad = ({ params }) => {
+export const load: PageLoad = ({ params, url }) => {
     const client = getGraphQLClient()
     const { repoName } = parseRepoRevision(params.repo)
+    const query = url.searchParams.get('query') ?? ''
 
     return {
+        query,
         tagsQuery: infinityQuery({
             client,
             query: TagsPage_TagsQuery,
@@ -18,6 +20,7 @@ export const load: PageLoad = ({ params }) => {
                 repoName,
                 first: PAGE_SIZE,
                 withBehindAhead: false,
+                query,
             },
             nextVariables: previousResult => {
                 if (previousResult?.data?.repository?.gitRefs?.pageInfo?.hasNextPage) {

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/-/tags/page.gql
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/-/tags/page.gql
@@ -1,7 +1,13 @@
-query TagsPage_TagsQuery($repoName: String!, $first: Int!, $withBehindAhead: Boolean!, $revspec: String = "") {
+query TagsPage_TagsQuery(
+    $repoName: String!
+    $first: Int!
+    $withBehindAhead: Boolean!
+    $revspec: String = ""
+    $query: String = ""
+) {
     repository(name: $repoName) {
         id
-        gitRefs(first: $first, type: GIT_TAG) {
+        gitRefs(first: $first, type: GIT_TAG, query: $query) {
             ...GitTagsConnection
         }
     }

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/-/tags/page.gql
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/-/tags/page.gql
@@ -12,5 +12,8 @@ fragment GitTagsConnection on GitRefConnection {
         id
         ...GitReference_Ref
     }
+    pageInfo {
+        hasNextPage
+    }
     totalCount
 }


### PR DESCRIPTION
Closes #61633 

This uses a similar approach as the commits page, except that pagination works a little bit differently.

Note that unlike the React app, every submission adds a new history entry, but also search submission has to be done explicitly. We can iterate on either if desired.

![2024-04-30_00-54](https://github.com/sourcegraph/sourcegraph/assets/179026/6679c6e5-37fb-4947-bd94-2f11ddbc678e)
![2024-04-30_00-54_1](https://github.com/sourcegraph/sourcegraph/assets/179026/1dd592f5-14ff-42d6-9a22-58687ce36dc5)




## Test plan

Manual testing.

- Scrolling loads more tags
- Search can be submitted via 'enter' or clicking the submit button
- Going back or forth restores previously loaded data and scroll position
