### PR TITLE
Add SSC backend API Proxy

### DIFF
--- a/internal/ssc/BUILD.bazel
+++ b/internal/ssc/BUILD.bazel
@@ -31,10 +31,14 @@ go_test(
     srcs = ["ssc_proxy_test.go"],
     embed = [":ssc"],
     deps = [
+        "//internal/actor",
+        "//internal/database",
         "//internal/database/dbmocks",
         "//internal/extsvc",
+        "//schema",
         "@com_github_sourcegraph_log//logtest",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
+        "@org_golang_x_oauth2//:oauth2",
     ],
 )

--- a/internal/ssc/BUILD.bazel
+++ b/internal/ssc/BUILD.bazel
@@ -1,19 +1,40 @@
+load("//dev:go_defs.bzl", "go_test")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "ssc",
     srcs = [
         "ssc.go",
+        "ssc_proxy.go",
         "types.go",
     ],
     importpath = "github.com/sourcegraph/sourcegraph/internal/ssc",
     visibility = ["//:__subpackages__"],
     deps = [
+        "//internal/actor",
         "//internal/conf",
+        "//internal/database",
+        "//internal/encryption",
         "//internal/trace",
         "//lib/errors",
+        "//schema",
+        "@com_github_sourcegraph_log//:log",
         "@io_opentelemetry_go_otel//attribute",
         "@org_golang_x_oauth2//:oauth2",
         "@org_golang_x_oauth2//clientcredentials",
+    ],
+)
+
+go_test(
+    name = "ssc_test",
+    timeout = "short",
+    srcs = ["ssc_proxy_test.go"],
+    embed = [":ssc"],
+    deps = [
+        "//internal/database/dbmocks",
+        "//internal/extsvc",
+        "@com_github_sourcegraph_log//logtest",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/internal/ssc/ssc_proxy.go
+++ b/internal/ssc/ssc_proxy.go
@@ -76,10 +76,9 @@ func (p *APIProxyHandler) buildProxyRequest(sourceReq *http.Request, token strin
 	// Source: ".api/ssc/proxy/" + "teams/current/members"
 	// Proxy :    "cody/api/v1/" + "teams/current/members"
 	sourceURLPath := strings.TrimPrefix(sourceReq.URL.Path, p.URLPrefix)
+	sourceURLPath = "/" + sourceURLPath // Force the path to be rooted.
+	// nosemgrep: resolving the supplied path, to concatenate with the SSC API URL prefix below.
 	sourceURLPath = path.Clean(sourceURLPath)
-	// Don't allow this sort of URL traversal, since we want to
-	// enforce that the URL contains the SSC prefix.
-	sourceURLPath = strings.Replace(sourceURLPath, "../", "", -1)
 
 	sscURLPath, err := url.JoinPath(
 		p.CodyProConfig.SscBackendOrigin,

--- a/internal/ssc/ssc_proxy.go
+++ b/internal/ssc/ssc_proxy.go
@@ -1,0 +1,227 @@
+package ssc
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"golang.org/x/oauth2"
+
+	"github.com/sourcegraph/log"
+
+	"github.com/sourcegraph/sourcegraph/internal/actor"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/encryption"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"github.com/sourcegraph/sourcegraph/schema"
+)
+
+// SSCAPIProxy is an HTTP handler that essentially proxies API requests from the
+// current Sourcegraph instance to the SSC backend, but exchanging the credentials
+// of the calling Sourcegraph user with an access token for their SAMS identity.
+//
+// This way we can transparently serve an HTTP API from Sourcegraph.com, when in
+// actuality it is processed by a different service all together. (And thereby
+// allowing us to decouple Cody Pro-specifc functionality from the Sourcegraph
+// Enterprise instance.)
+//
+// The API Proxy simply handles the credential exchange and verification. But
+// will send along the HTTP request. (Even if the URL and method aren't supported,
+// and would serve a 404/405 response, etc.)
+type APIProxyHandler struct {
+	CodyProConfig *schema.CodyProConfig
+	DB            database.DB
+	Logger        log.Logger
+
+	// URLPrefix of where the handler is served. e.g. ".api/ssc/proxy/". This
+	// will be replaced with the SSC-specific URL prefix ()"cody/api/v1/").
+	URLPrefix string
+}
+
+var _ http.Handler = (*APIProxyHandler)(nil)
+
+// getUserIDFromRequest extracts the Sourcegraph User ID from the incomming request,
+// or returns an error suitable for sending to the end user.
+func (p *APIProxyHandler) getUserIDFromRequest(r *http.Request) (int32, error) {
+	ctx := r.Context()
+	callingActor := actor.FromContext(ctx)
+	if callingActor == nil || !callingActor.IsAuthenticated() {
+		p.Logger.Warn("rejecting request made by unauthenticated Sourcegraph user")
+		return 0, errors.New("no credentials available")
+	}
+	if callingActor.IsInternal() || callingActor.SourcegraphOperator {
+		p.Logger.Warn("rejecting request made by internal service / Sourcegraph Operator")
+		return 0, errors.New("request not made on behalf of a user")
+	}
+	return callingActor.UID, nil
+}
+
+// buildProxyRequest converts the incomming HTTP request into what will be sent to the SSC backend.
+func (p *APIProxyHandler) buildProxyRequest(sourceReq *http.Request, token string) (*http.Request, error) {
+	// For simplicity, read the full request body before sending the proxy request.
+	var bodyReader io.Reader
+	if sourceReq.Body != nil {
+		bodyBytes, err := io.ReadAll(sourceReq.Body)
+		if err != nil {
+			return nil, errors.Wrap(err, "reading source request body")
+		}
+		bodyReader = strings.NewReader(string(bodyBytes))
+	}
+
+	// Construct the remapped URL on the SSC backend.
+	// For example:
+	// Source: ".api/ssc/proxy/" + "teams/current/members"
+	// Proxy :    "cody/api/v1/" + "teams/current/members"
+	sourceURLPath := strings.TrimPrefix(sourceReq.URL.Path, p.URLPrefix)
+	sscURL := fmt.Sprintf(
+		"%s/cody/api/v1%s?%s",
+		p.CodyProConfig.SscBackendOrigin,
+		sourceURLPath,
+		sourceReq.URL.Query().Encode())
+	p.Logger.Info("Building proxy request", log.String("method", sourceReq.Method), log.String("url", sscURL))
+	proxyReq, err := http.NewRequest(sourceReq.Method, sscURL, bodyReader)
+	if err != nil {
+		return nil, errors.Wrap(err, "creating request")
+	}
+
+	proxyReq.Header.Add("Authorization", "Bearer "+token)
+	return proxyReq, nil
+}
+
+// getSAMSCredentialsForUser fetches the OAuth token from the user's SAMS external identity.
+func (p *APIProxyHandler) getSAMSCredentialsForUser(ctx context.Context, userID int32) (*oauth2.Token, error) {
+	// NOTE: It's possible for a user to have multiple SAMS identities attached to the same Sourcegraph
+	// user account. The underlying implementation provides a stable result sorting by ID, so we
+	// just return the first SAMS identity found.
+	//
+	// BUG: This needs to be reconciled with the logic in internal/ssc/subscription.go. Since when it
+	// comes to returning the user's Cody Pro subscription, we take *ALL* SAMS identities into account.
+	// So in order to provide a consistent view of a user's Cody Pro subscription data, we need to
+	// ensure that for the ~80 or so users in this situation can safely use their "first" SAMS ID when
+	// they are sorted lexographically.
+	extAccounts, err := p.DB.UserExternalAccounts().List(ctx, database.ExternalAccountsListOptions{
+		UserID:      userID,
+		ServiceType: "openidconnect",
+		// We expect the SAMS backend origin to match the registered identity provider,
+		// e.g. "https://accounts.sourcegraph.com" or "http://localhost:9992".
+		ServiceID:      p.CodyProConfig.SamsBackendOrigin,
+		ExcludeExpired: true,
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "listing user external accounts")
+	}
+	switch len(extAccounts) {
+	case 0:
+		return nil, errors.New("user does not have a SAMS identity")
+	case 1:
+		// Expected, AOK
+	default:
+		// Exceptional case. The user has multiple identities, and we will just take
+		// the first. (Which may be confusing the user in some circumstances.)
+		p.Logger.Warn("user has multiple SAMS identities", log.Int32("uid", userID))
+	}
+
+	// Load the specific external account (SAMS identity).
+	samsIdentity, err := p.DB.UserExternalAccounts().Get(ctx, extAccounts[0].ID)
+	if err != nil {
+		return nil, errors.Wrap(err, "getting user SAMS identity")
+	}
+
+	// Decrypt and unmarshall as an OAuth token.
+	token, err := encryption.DecryptJSON[oauth2.Token](ctx, samsIdentity.AuthData)
+	if err != nil {
+		return nil, errors.Wrap(err, "decrypting/unmarshalling SAMS auth data")
+	}
+	return token, nil
+}
+
+func (p *APIProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	p.Logger.Info("proxying SSC API request", log.String("url", r.URL.String()))
+
+	sgUserID, err := p.getUserIDFromRequest(r)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusUnauthorized)
+		return
+	}
+
+	// Lookup the user's SAMS credentials.
+	samsToken, err := p.getSAMSCredentialsForUser(ctx, sgUserID)
+	if err != nil {
+		// Here we assume that the function will only fail because of an IO problem.
+		// And not that a user simply doesn't have a SAMS identity. (Since for dotcom
+		// that is guaranteed to be the case.)
+		p.Logger.Error("getting SAMS credentials for user", log.Int32("uid", sgUserID), log.Error(err))
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// SAMS credentials have a shorter lifetime than the Sourcegraph session.
+	// So it's likely that even though the user is still logged into sourcegraph.com,
+	// the request to the SSC backend will fail because the OAuth credentials
+	// associated with their SAMS login has expired.
+	//
+	// The frontend needs to expect this 401 response, and force the user to
+	// reauthenticate. (Which would then pick up a new SAMS auth token.) Or
+	// we need to have a background process that will periodically refresh the
+	// user's SAMS credentials, so that the refresh and access token for the
+	// user's SAMS account are sufficiently fresh.
+	if samsToken.Expiry.Before(time.Now()) {
+		p.Logger.Warn("the user's SAMS token has expired", log.Time("expiry", samsToken.Expiry))
+		http.Error(w, "Sourcegraph Accounts identity has expired", http.StatusUnauthorized)
+		return
+	}
+
+	// Copy the incomming request and send it to the SSC backend.
+	proxyRequest, err := p.buildProxyRequest(r, samsToken.AccessToken)
+	if err != nil {
+		p.Logger.Error("building SSC proxy request", log.Error(err))
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		return
+	}
+
+	client := http.DefaultClient
+	proxyResponse, err := client.Do(proxyRequest)
+	if err != nil {
+		p.Logger.Error("sending SSC proxy request", log.Error(err))
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		return
+	}
+
+	var bodyBytes []byte
+	if bodyReader := proxyResponse.Body; bodyReader != nil {
+		bodyBytes, err = io.ReadAll(bodyReader)
+		if err != nil {
+			p.Logger.Error("reading SSC response", log.Error(err))
+			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			return
+		}
+		if err = bodyReader.Close(); err != nil {
+			p.Logger.Error("closing SSC response body", log.Error(err))
+			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			return
+		}
+	}
+
+	// For any SSC 5xx errors, surface that as a 502 from this Sourcegraph instance,
+	// to make it clear that the underlying error didn't happen "here".
+	if proxyResponse.StatusCode >= 500 {
+		p.Logger.Error(
+			"received 5xx response from SSC backend",
+			log.String("responseBody", string(bodyBytes)))
+		http.Error(w, http.StatusText(http.StatusBadGateway), http.StatusBadGateway)
+		return
+	}
+
+	// Success! Serve the proxied response.
+	p.Logger.Debug("serving proxied response from the SSC backend",
+		log.Int("code", proxyResponse.StatusCode),
+		log.Int("bodySize", len(bodyBytes)))
+	w.WriteHeader(proxyResponse.StatusCode)
+	if _, err = w.Write(bodyBytes); err != nil {
+		p.Logger.Error("writing proxied response body", log.Error(err))
+	}
+}

--- a/internal/ssc/ssc_proxy_test.go
+++ b/internal/ssc/ssc_proxy_test.go
@@ -152,6 +152,12 @@ func TestSSCAPIProxy(t *testing.T) {
 					testURLPrefix + "../../../../some-unknown-parent-folder",
 					"/cody/api/v1/some-unknown-parent-folder", "",
 				},
+				{
+					// Another instance of URL canonicalization, and it not
+					// escaping the "/cody/api/v1" prefix.
+					testURLPrefix + "legit/../../../not-legit",
+					"/cody/api/v1/not-legit", "",
+				},
 			}
 			for i, test := range tests {
 				inURL := "https://sourcegraph.com" + test.ReqURLPath

--- a/internal/ssc/ssc_proxy_test.go
+++ b/internal/ssc/ssc_proxy_test.go
@@ -129,27 +129,28 @@ func TestSSCAPIProxy(t *testing.T) {
 				// where the HTTP handler is registered.
 				{
 					"/users/settings",
-					// BUG? The double slash here isn't great, but we kinda need the incomming URL
-					// to match the APIProxy.URLPrefix value anyways. So we don't care?
-					"/cody/api/v1//users/settings", "",
+					"/cody/api/v1/users/settings", "",
 				},
 				{
 					"users/settings",
 					// BUG? A quirk of how this test runs. We prefix the input string with
 					// "https://sourcegraph.com", so "sourcegraph.comuser/settings" comes
 					// out looking weird...
-					"/cody/api/v1//settings", "",
+					"/cody/api/v1/settings", "",
 				},
 
 				// URL path schenanigans. We escape the incomming URL so that the proxied request
 				// always has the required route prefix.
 				{
+					// The source URL path is cleaned, so the "folder1/folder2" gets removed.
 					testURLPrefix + "folder1/folder2/../../some-other-folder",
-					"/cody/api/v1/folder1/folder2/../../some-other-folder", "",
+					"/cody/api/v1/some-other-folder", "",
 				},
 				{
+					// But the cleaning is only applied to the user-controlled URL path.
+					// So we will always have the SSC-side URL prefix.
 					testURLPrefix + "../../../../some-unknown-parent-folder",
-					"/cody/api/v1/../../../../some-unknown-parent-folder", "",
+					"/cody/api/v1/some-unknown-parent-folder", "",
 				},
 			}
 			for i, test := range tests {

--- a/internal/ssc/ssc_proxy_test.go
+++ b/internal/ssc/ssc_proxy_test.go
@@ -1,0 +1,233 @@
+package ssc
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
+
+	"github.com/sourcegraph/log/logtest"
+
+	"github.com/sourcegraph/sourcegraph/internal/actor"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbmocks"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc"
+	"github.com/sourcegraph/sourcegraph/schema"
+)
+
+func TestSSCAPIProxy(t *testing.T) {
+	// Fixed configuration values of the testHandler for easy reference.
+	var (
+		testURLPrefix     = "/.api/ssc/proxy"
+		testCodyProConfig = schema.CodyProConfig{
+			SamsBackendOrigin: "https://sams.sourcegraph.com:1234",
+			SscBackendOrigin:  "https://ssc.sourcegraph.com:1234",
+		}
+	)
+
+	testHandler := APIProxyHandler{
+		CodyProConfig: &testCodyProConfig,
+		DB:            nil,
+		Logger:        logtest.NoOp(t),
+		URLPrefix:     testURLPrefix,
+	}
+
+	const testUserID = int32(12345)
+
+	// Confirm that we pull the Sourcegraph user details from the
+	// incomming request context correctly, and return the expected
+	// errors.
+	t.Run("getUserIDFromContext", func(t *testing.T) {
+		// Call getUserIDFromContext with the supplied actor in the request context.
+		runTest := func(a *actor.Actor) (int32, error) {
+			ctx := actor.WithActor(context.Background(), a)
+			return testHandler.getUserIDFromContext(ctx)
+		}
+
+		t.Run("Success", func(t *testing.T) {
+			userID, err := runTest(&actor.Actor{
+				UID: testUserID,
+			})
+			assert.EqualValues(t, testUserID, userID)
+			assert.NoError(t, err)
+		})
+		t.Run("ErrorNoActor", func(t *testing.T) {
+			_, err := runTest(nil)
+			assert.ErrorContains(t, err, "no credentials available")
+		})
+		t.Run("ErrorNonNuman", func(t *testing.T) {
+			_, err := runTest(&actor.Actor{
+				UID:                 testUserID,
+				SourcegraphOperator: true,
+			})
+			assert.ErrorContains(t, err, "request not made on behalf of a user")
+		})
+	})
+
+	t.Run("buildProxyRequest", func(t *testing.T) {
+		t.Run("Basics", func(t *testing.T) {
+			reqBody := `
+			{
+				"addMember": {
+					"accountID": "...",
+					"role": "member"
+				}
+			}
+			`
+			req := httptest.NewRequest(
+				http.MethodPatch,
+				testURLPrefix+"teams/current/members?api-version=2",
+				strings.NewReader(reqBody))
+			req.Header.Add("Authorization", "Bearer original-access-token")
+			req.Header.Add("X-Sourcegraph", "Another random header")
+
+			proxyReq, err := testHandler.buildProxyRequest(req, "sams-access-token")
+			require.NoError(t, err)
+
+			// HTTP method and URL.
+			assert.Equal(t, http.MethodPatch, proxyReq.Method)
+			wantURL := testCodyProConfig.SscBackendOrigin + "/cody/api/v1/teams/current/members?api-version=2"
+			assert.Equal(t, wantURL, proxyReq.URL.String())
+
+			// We do NOT pass along all HTTP request headers, and only pass the SAMS auth token.
+			assert.Equal(t, 1, len(proxyReq.Header))
+			assert.Equal(t, "Bearer sams-access-token", proxyReq.Header.Get("Authorization"))
+
+			// The request body was copied as well.
+			require.NotNil(t, proxyReq.Body)
+			proxyReqBodyBytes, err := io.ReadAll(proxyReq.Body)
+			require.NoError(t, err)
+			assert.Equal(t, reqBody, string(proxyReqBodyBytes))
+		})
+		t.Run("URLRewriting", func(t *testing.T) {
+			tests := []struct {
+				ReqURLPath      string
+				WantURLPath     string
+				WantQueryParams string
+			}{
+				{
+					testURLPrefix + "source/url/path",
+					"/cody/api/v1/source/url/path", "",
+				},
+				// Confirm URL query parameters are handled correctly.
+				{
+					testURLPrefix + "endpoint/alpha?param=1234&continuationToken='xxxxxxx'",
+					// The query parameters will be canonicalized by URL encoding and
+					// sorting by key.
+					"/cody/api/v1/endpoint/alpha", "continuationToken=%27xxxxxxx%27&param=1234",
+				},
+
+				// Pathalogical case where the URL prefix is different from
+				// where the HTTP handler is registered.
+				{
+					"/users/settings",
+					// BUG? The double slash here isn't great, but we kinda need the incomming URL
+					// to match the APIProxy.URLPrefix value anyways. So we don't care?
+					"/cody/api/v1//users/settings", "",
+				},
+				{
+					"users/settings",
+					// BUG? A quirk of how this test runs. We prefix the input string with
+					// "https://sourcegraph.com", so "sourcegraph.comuser/settings" comes
+					// out looking weird...
+					"/cody/api/v1//settings", "",
+				},
+
+				// URL path schenanigans. We escape the incomming URL so that the proxied request
+				// always has the required route prefix.
+				{
+					testURLPrefix + "folder1/folder2/../../some-other-folder",
+					"/cody/api/v1/folder1/folder2/../../some-other-folder", "",
+				},
+				{
+					testURLPrefix + "../../../../some-unknown-parent-folder",
+					"/cody/api/v1/../../../../some-unknown-parent-folder", "",
+				},
+			}
+			for i, test := range tests {
+				inURL := "https://sourcegraph.com" + test.ReqURLPath
+				sourceReq := httptest.NewRequest(http.MethodGet, inURL, nil /* body */)
+				proxyReq, err := testHandler.buildProxyRequest(sourceReq, "")
+				assert.NoError(t, err, "URL rewriting scenario %d", i)
+
+				assert.True(t, strings.HasPrefix(proxyReq.URL.String(), testCodyProConfig.SscBackendOrigin))
+				assert.Equal(t, test.WantURLPath, proxyReq.URL.Path)
+				assert.Equal(t, test.WantQueryParams, proxyReq.URL.RawQuery)
+			}
+		})
+	})
+
+	t.Run("getSAMSCredentialsForUser", func(t *testing.T) {
+		testToken := oauth2.Token{
+			RefreshToken: "refresh-token",
+			AccessToken:  "access-token",
+			TokenType:    "token-type",
+			Expiry:       time.Now(),
+		}
+		testTokenJSON, err := json.Marshal(testToken)
+		require.NoError(t, err)
+
+		const testAccountID = int32(1)
+		validSAMSIdentity := &extsvc.Account{
+			ID:     testAccountID,
+			UserID: testUserID,
+			AccountData: extsvc.AccountData{
+				AuthData: extsvc.NewUnencryptedData(testTokenJSON),
+			},
+		}
+
+		t.Run("Success", func(t *testing.T) {
+			// Setup the database mocks to return the test token.
+			mockDB := dbmocks.NewMockDB()
+			testHandler.DB = mockDB
+
+			mockUEA := dbmocks.NewMockUserExternalAccountsStore()
+			mockDB.UserExternalAccountsFunc.SetDefaultReturn(mockUEA)
+
+			// Run a quick test before we mock the List call. Confirm error that the user
+			// has no available SAMS identity.
+			t.Run("ErrorNoSAMSIdentity", func(t *testing.T) {
+				ctx := context.Background()
+				_, err := testHandler.getSAMSCredentialsForUser(ctx, testUserID)
+				assert.ErrorContains(t, err, "user does not have a SAMS identity")
+			})
+
+			// List user accounts
+			mockUEA.ListFunc.PushHook(func(_ context.Context, opts database.ExternalAccountsListOptions) ([]*extsvc.Account, error) {
+				assert.Equal(t, testUserID, opts.UserID)
+				assert.Equal(t, "openidconnect", opts.ServiceType)
+				assert.Equal(t, testCodyProConfig.SamsBackendOrigin, opts.ServiceID)
+
+				return []*extsvc.Account{
+					validSAMSIdentity,
+					// Bogus user identities that we are implicity confirming won't
+					// cause problems. (We only get the first.)
+					nil,
+					nil,
+				}, nil
+			})
+			// Get the first SAMS identity / external user account.
+			mockUEA.GetFunc.PushHook(func(_ context.Context, id int32) (*extsvc.Account, error) {
+				assert.Equal(t, testAccountID, id)
+				return validSAMSIdentity, nil
+			})
+
+			// Try to get the user's SAMS creds given this.
+			ctx := context.Background()
+			token, err := testHandler.getSAMSCredentialsForUser(ctx, testUserID)
+			require.NoError(t, err)
+
+			assert.Equal(t, testToken.AccessToken, token.AccessToken)
+			assert.Equal(t, testToken.RefreshToken, token.RefreshToken)
+			assert.WithinDuration(t, testToken.Expiry, token.Expiry, time.Second)
+		})
+	})
+}


### PR DESCRIPTION
> ~~ℹ️ This PR is stacked on top of https://github.com/sourcegraph/sourcegraph/pull/62255.~~

This PR adds an HTTP handler that will proxy HTTP requests sent to `http://sourcegraph.com/.api/ssc/proxy/*` to `https://accounts.sourcegraph.com/cody/api/v1/*`.

> **Why?**
> For a variety of reasons we are moving the SSC UI from accounts.sourcegraph.com into sourcegraph.com. It doesn't make a lot of sense to add Cody Pro-specific APIs to the Sourcegraph instance's GraphQL API, since the resolver step would just require us to translate/proxy the HTTP request anyways.
>
> So this "universal API proxy" approach is the simplest way to achieve the intended result. Although if this is too frightening, there are some alternatives we can pursue to make this more palatable...

This is done by introducing a new `ssc.APIProxy` type that implements the `http.Handler` interface. (Pedantically, the term "proxy" is probably generous, as there are any number of features that it does not support and/or it does not do correctly, such as a setting an `X-Forwarded-For` header. We don't need this type to be particularly robust beyond just handling prototypical HTTP requests sending/receiving small JSON payloads.)

So essentially we are just converting:

```diff
# Hypothetical HTTP request if it were JSON
{
    "method": "PATCH",
-   "targetDomain": "https://sourcegraph.com"
+   "targetDomain": "https://accounts.sourcegraph.com"
-   "urlPath": ".ssc/proxy/teams/members",
+   "urlPath": "cody/api/v1/teams/members",
   "headers": {
+       "Authorization": "Bearer {calling user's SAMS access token}",
-       "Cookie": "sgs={sourcegraph-session-cookie}",
   }
   "body": { ... }
}
```

## Key Feature: Setting the `Authorization` Header

The key feature of this API proxy is that it exchanges the credentials from the calling user for their backing SAMS access token. (And if no such external account is available for the calling user, a `401 Unauthorized` response is returned.)

The SSC backend only uses SAMS tokens, and we want to move away from any hard dependencies on sourcegraph.com. Such as needing to contact sourcegraph.com to verify tokens, for _it's view_ of user accounts. And instead, the SSC backend uses SAMS as the source of truth for users.

So in order for this "dotcom to SSC backend proxy" request to work, we need the following conditions to be met:

- The `http.Request`'s `context.Context` contains an authenticated `actor.Actor`. (Which is done via authentication middleware registered elsewhere in the HTTP handler registration.)
- The backing Sourcegraph user has an OIDC external account that is managed by SAMS. (For Sourcegraph.com this is the only registered authentication provider, and all active Sourcegraph.com accounts have a SAMS identity.)
- The credentials associated with that SAMS identity/external account (an `oauth2.Token`) is still valid. (A later PR will maybe add a background process to automatically refresh active user SAMS tokens, but for now we just serve a 401 if it has expired.)

## Additional Notes

While the proxied request URL, body, method, etc. are all user controlled, the _destination_ is not. The `sscBackendOrigin` is a site-level configuration knob. So this shouldn't be susceptible to an SSRF-style attack (I believe).

**Alternative Design**

If having a generic, open-ended proxy is too scary (no judgement), then an alternative would be to just replicate the exact URL routes that we have on the SSC backend in [backend/apis.go here](https://github.com/sourcegraph/self-serve-cody/blob/main/cody/backend/apis.go#L242).

So rather than having an HTTP handler for `.api/ssc/proxy/*`, we would need to maintain a list of more specific endpoints that align with what is offered on the SSC side. e.g.

```go
allowList := []urlRoute{
    {"GET", "/teams/current" },
    {"PATCH", "/teams/current" },
    {"LIST", "/teams/current/members" },
    {"GET", "/team/{teamID}/invites/{inviteID}" },
    {"POST", "/team/{teamID}/invites/{inviteID}" },
    ...
}
```

You can see that this will probably get tedious enough why I'm starting with a generic `/proxy/*` endpoint, and hoping that it is constrained enough that we are not worried about security threats.

## Test plan

Added new unit tests, and verified things are working locally (with some other local commits stacked on top).