### PR TITLE
rockskip: Switch from long-running process to pagination

### DIFF
--- a/internal/gitserver/BUILD.bazel
+++ b/internal/gitserver/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
         "//internal/actor",
         "//internal/api",
         "//internal/authz",
+        "//internal/byteutils",
         "//internal/conf",
         "//internal/conf/conftypes",
         "//internal/extsvc/gitolite",

--- a/internal/gitserver/client.go
+++ b/internal/gitserver/client.go
@@ -494,9 +494,10 @@ type Client interface {
 	// LogReverseEach runs git log in reverse order and calls the given callback for each entry.
 	LogReverseEach(ctx context.Context, repo string, commit string, n int, onLogEntry func(entry gitdomain.LogEntry) error) error
 
-	// RevList makes a git rev-list call and iterates through the resulting commits, calling the provided
-	// onCommit function for each.
-	RevList(ctx context.Context, repo string, commit string, onCommit func(commit string) (bool, error)) error
+	// RevList makes a git rev-list call and returns up to count commits. if nextCursor
+	// is non-empty, it is used as the starting point for the next call, use it to iterate
+	// to iterate over the whole history.
+	RevList(ctx context.Context, repo api.RepoName, commit string, count int) (_ []api.CommitID, nextCursor string, err error)
 
 	// SystemsInfo returns information about all gitserver instances associated with a Sourcegraph instance.
 	SystemsInfo(ctx context.Context) ([]protocol.SystemInfo, error)

--- a/internal/gitserver/commands_test.go
+++ b/internal/gitserver/commands_test.go
@@ -2254,3 +2254,57 @@ func TestClient_FirstEverCommit(t *testing.T) {
 		})
 	})
 }
+
+func TestRevList(t *testing.T) {
+	ClientMocks.LocalGitserver = true
+	defer ResetClientMocks()
+
+	gitCommands := []string{
+		"git commit --allow-empty -m commit1",
+		"git commit --allow-empty -m commit2",
+		"git commit --allow-empty -m commit3",
+	}
+	repo := MakeGitRepository(t, gitCommands...)
+	allCommits := []api.CommitID{
+		"4ac04f2761285633cd35188c696a6e08de03c00c",
+		"e7d0b23cb4e2e975ad657b163793bc83926c21b2",
+		"a04652fa1998a0a7d2f2f77ecb7021de943d3aab",
+	}
+
+	t.Run("returns commits in reverse chronological order", func(t *testing.T) {
+		client := NewTestClient(t)
+		commits, _, err := client.RevList(context.Background(), repo, "HEAD", 999)
+		require.NoError(t, err)
+		require.Equal(t, allCommits, commits)
+	})
+
+	t.Run("returns next cursor when more commits exist", func(t *testing.T) {
+		gitCommands := []string{
+			"git commit --allow-empty -m commit1",
+			"git commit --allow-empty -m commit2",
+			"git commit --allow-empty -m commit3",
+		}
+		repo := MakeGitRepository(t, gitCommands...)
+		client := NewTestClient(t)
+		nextCursor := "HEAD"
+		haveCommits := []api.CommitID{}
+		for {
+			commits, next, err := client.RevList(context.Background(), repo, nextCursor, 1)
+			require.NoError(t, err)
+			nextCursor = next
+			haveCommits = append(haveCommits, commits...)
+			if nextCursor == "" {
+				break
+			}
+		}
+		require.Equal(t, allCommits, haveCommits)
+	})
+
+	t.Run("returns error when commit does not exist", func(t *testing.T) {
+		repo := MakeGitRepository(t)
+		client := NewTestClient(t)
+		_, _, err := client.RevList(context.Background(), repo, "nonexistent", 10)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "exit status 128")
+	})
+}

--- a/internal/gitserver/gitdomain/log.go
+++ b/internal/gitserver/gitdomain/log.go
@@ -44,26 +44,6 @@ func LogReverseArgs(n int, givenCommit string) []string {
 	}
 }
 
-func RevListEach(stdout io.Reader, onCommit func(commit string) (shouldContinue bool, err error)) error {
-	reader := bufio.NewReader(stdout)
-
-	for {
-		commit, err := reader.ReadString('\n')
-		if err == io.EOF {
-			break
-		} else if err != nil {
-			return err
-		}
-		commit = commit[:len(commit)-1] // Drop the trailing newline
-		shouldContinue, err := onCommit(commit)
-		if !shouldContinue {
-			return err
-		}
-	}
-
-	return nil
-}
-
 func ParseLogReverseEach(stdout io.Reader, onLogEntry func(entry LogEntry) error) error {
 	reader := bufio.NewReader(stdout)
 

--- a/internal/rockskip/BUILD.bazel
+++ b/internal/rockskip/BUILD.bazel
@@ -64,5 +64,6 @@ go_test(
         "//lib/pointers",
         "@com_github_google_go_cmp//cmp",
         "@com_github_sourcegraph_go_ctags//:go-ctags",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/internal/rockskip/server_test.go
+++ b/internal/rockskip/server_test.go
@@ -2,6 +2,7 @@ package rockskip
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -15,6 +16,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/sourcegraph/go-ctags"
+	"github.com/stretchr/testify/require"
 
 	"github.com/sourcegraph/sourcegraph/cmd/symbols/fetcher"
 	"github.com/sourcegraph/sourcegraph/internal/api"
@@ -45,50 +47,22 @@ func (mockParser) Parse(path string, bytes []byte) ([]*ctags.Entry, error) {
 func (mockParser) Close() {}
 
 func TestIndex(t *testing.T) {
-	fatalIfError := func(err error, message string) {
-		if err != nil {
-			t.Fatal(errors.Wrap(err, message))
-		}
-	}
-
-	gitDir, err := os.MkdirTemp("", "rockskip-test-index")
-	fatalIfError(err, "faiMkdirTemp")
-
-	t.Cleanup(func() {
-		if t.Failed() {
-			t.Logf("git dir %s left intact for inspection", gitDir)
-		} else {
-			os.RemoveAll(gitDir)
-		}
-	})
-
-	gitCmd := func(args ...string) *exec.Cmd {
-		cmd := exec.Command("git", args...)
-		cmd.Dir = gitDir
-		return cmd
-	}
-
-	gitRun := func(args ...string) {
-		fatalIfError(gitCmd(args...).Run(), "git "+strings.Join(args, " "))
-	}
-
-	gitStdout := func(args ...string) string {
-		stdout, err := gitCmd(args...).Output()
-		fatalIfError(err, "git "+strings.Join(args, " "))
-		return string(stdout)
-	}
-
-	getHead := func() string {
-		return strings.TrimSpace(gitStdout("rev-parse", "HEAD"))
-	}
+	gitserver.ClientMocks.LocalGitserver = true
+	t.Cleanup(gitserver.ResetClientMocks)
+	repo, repoDir := gitserver.MakeGitRepositoryAndReturnDir(t)
 
 	state := map[string][]string{}
 
+	gitRun := func(args ...string) {
+		out, err := gitserver.CreateGitCommand(repoDir, "git", args...).CombinedOutput()
+		require.NoError(t, err, string(out))
+	}
+
 	add := func(filename string, contents string) {
-		fatalIfError(os.WriteFile(path.Join(gitDir, filename), []byte(contents), 0644), "os.WriteFile")
+		require.NoError(t, os.WriteFile(path.Join(repoDir, filename), []byte(contents), 0644), "os.WriteFile")
 		gitRun("add", filename)
 		symbols, err := mockParser{}.Parse(filename, []byte(contents))
-		fatalIfError(err, "simpleParse")
+		require.NoError(t, err)
 		state[filename] = []string{}
 		for _, symbol := range symbols {
 			state[filename] = append(state[filename], symbol.Name)
@@ -104,8 +78,8 @@ func TestIndex(t *testing.T) {
 	// Needed in CI
 	gitRun("config", "user.email", "test@sourcegraph.com")
 
-	git, err := NewSubprocessGit(gitDir)
-	fatalIfError(err, "NewSubprocessGit")
+	git, err := NewSubprocessGit(t, repoDir)
+	require.NoError(t, err)
 	defer git.Close()
 
 	db := dbtest.NewDB(t)
@@ -114,18 +88,20 @@ func TestIndex(t *testing.T) {
 	createParser := func() (ctags.Parser, error) { return mockParser{}, nil }
 
 	service, err := NewService(db, git, newMockRepositoryFetcher(git), createParser, 1, 1, false, 1, 1, 1, false)
-	fatalIfError(err, "NewService")
+	require.NoError(t, err)
 
 	verifyBlobs := func() {
-		repo := "somerepo"
-		commit := getHead()
+		out, err := gitserver.CreateGitCommand(repoDir, "git", "rev-parse", "HEAD").CombinedOutput()
+		require.NoError(t, err, string(out))
+		commit := string(bytes.TrimSpace(out))
+
 		args := search.SymbolsParameters{
 			Repo:         api.RepoName(repo),
 			CommitID:     api.CommitID(commit),
 			Query:        "",
 			IncludeLangs: []string{"Text"}}
 		symbols, err := service.Search(context.Background(), args)
-		fatalIfError(err, "Search")
+		require.NoError(t, err)
 
 		// Make sure the paths match.
 		gotPathSet := map[string]struct{}{}
@@ -149,7 +125,7 @@ func TestIndex(t *testing.T) {
 			fmt.Println("unexpected paths (-got +want)")
 			fmt.Println(diff)
 			err = PrintInternals(context.Background(), db)
-			fatalIfError(err, "PrintInternals")
+			require.NoError(t, err)
 			t.FailNow()
 		}
 
@@ -167,7 +143,7 @@ func TestIndex(t *testing.T) {
 				fmt.Println("unexpected symbols (-got +want)")
 				fmt.Println(diff)
 				err = PrintInternals(context.Background(), db)
-				fatalIfError(err, "PrintInternals")
+				require.NoError(t, err)
 				t.FailNow()
 			}
 		}
@@ -204,9 +180,10 @@ type SubprocessGit struct {
 	catFileCmd    *exec.Cmd
 	catFileStdin  io.WriteCloser
 	catFileStdout bufio.Reader
+	gs            gitserver.Client
 }
 
-func NewSubprocessGit(gitDir string) (*SubprocessGit, error) {
+func NewSubprocessGit(t testing.TB, gitDir string) (*SubprocessGit, error) {
 	cmd := exec.Command("git", "cat-file", "--batch")
 	cmd.Dir = gitDir
 
@@ -230,6 +207,7 @@ func NewSubprocessGit(gitDir string) (*SubprocessGit, error) {
 		catFileCmd:    cmd,
 		catFileStdin:  stdin,
 		catFileStdout: *bufio.NewReader(stdout),
+		gs:            gitserver.NewTestClient(t),
 	}, nil
 }
 
@@ -263,26 +241,28 @@ func (g SubprocessGit) LogReverseEach(ctx context.Context, repo string, givenCom
 	return gitdomain.ParseLogReverseEach(output, onLogEntry)
 }
 
-func (g SubprocessGit) RevList(ctx context.Context, repo string, givenCommit string, onCommit func(commit string) (shouldContinue bool, err error)) (returnError error) {
-	revList := exec.Command("git", gitserver.RevListArgs(givenCommit)...)
-	revList.Dir = g.gitDir
-	output, err := revList.StdoutPipe()
-	if err != nil {
-		return err
-	}
-
-	err = revList.Start()
-	if err != nil {
-		return err
-	}
-	defer func() {
-		err = revList.Wait()
+func (g *SubprocessGit) RevList(ctx context.Context, repo string, commit string, onCommit func(commit string) (shouldContinue bool, err error)) (returnError error) {
+	nextCursor := commit
+	for {
+		var commits []api.CommitID
+		var err error
+		commits, nextCursor, err = g.gs.RevList(ctx, api.RepoName(repo), nextCursor, 100)
 		if err != nil {
-			returnError = err
+			return err
 		}
-	}()
-
-	return gitdomain.RevListEach(output, onCommit)
+		for _, c := range commits {
+			shouldContinue, err := onCommit(string(c))
+			if err != nil {
+				return err
+			}
+			if !shouldContinue {
+				return nil
+			}
+		}
+		if nextCursor == "" {
+			return nil
+		}
+	}
 }
 
 func newMockRepositoryFetcher(git *SubprocessGit) fetcher.RepositoryFetcher {


### PR DESCRIPTION
We want to migrate this call to gRPC. However, it isn't good practice to have to keep this process running for potentially hours, as any server restart will have to make the process start over.
With pagination here, we're not occupying a process slot on gitserver, and rollouts of gitserver should much less affect rockskip, as individual pages can be retried before being returned to the rockskip code.

Test plan:

Existing tests still pass, but not a Rockskip expert so requesting review from the owners.