### PR TITLE
Exclude more files from getCodyContext

### DIFF
--- a/cmd/frontend/internal/codycontext/context.go
+++ b/cmd/frontend/internal/codycontext/context.go
@@ -250,6 +250,10 @@ func getKeywordContextExcludeFilePathsQuery() string {
 	var excludeFilePaths = []string{
 		"\\.min\\.js$",
 		"\\.map$",
+		"\\.tsbuildinfo$",
+		"/umd/",
+		"/amd/",
+		"/cjs/",
 	}
 
 	filters := []string{}


### PR DESCRIPTION
Update the exclude file paths based on the filters used in the PR: https://github.com/sourcegraph/cody/pull/3939

![CleanShot 2024-04-30 at 10 36 22@2x](https://github.com/sourcegraph/sourcegraph/assets/22571395/dd06c1b9-bded-49a4-8f64-45280be55400)

## Test plan

tested via search