### PR TITLE
release: handle more registries for promotion

### DIFF
--- a/dev/ci/internal/ci/images_operations.go
+++ b/dev/ci/internal/ci/images_operations.go
@@ -125,7 +125,7 @@ func bazelPushImagesCmd(c Config, isCandidate bool, opts ...bk.StepOpt) func(*bk
 				bk.Env("CLOUD_EPHEMERAL", cloudEphemeral),
 				bk.Env("DEV_REGISTRY", devRegistry),
 				bk.Env("PROD_REGISTRY", prodRegistry),
-				bk.Env("ADDITIONAL_PROD_REGISTRY", additionalProdRegistry),
+				bk.Env("ADDITIONAL_PROD_REGISTRIES", additionalProdRegistry),
 				bk.Cmd(bazelStampedCmd(fmt.Sprintf(`build $$(bazel --bazelrc=%s --bazelrc=.aspect/bazelrc/ci.sourcegraph.bazelrc query 'kind("oci_push rule", //...)')`, bazelRC))),
 				bk.ArtifactPaths("build_event_log.bin"),
 				bk.AnnotatedCmd(

--- a/dev/ci/internal/ci/release_operations.go
+++ b/dev/ci/internal/ci/release_operations.go
@@ -21,7 +21,7 @@ func releasePromoteImages(c Config) operations.Operation {
 			bk.Env("VERSION", c.Version),
 			bk.Env("INTERNAL_REGISTRY", images.SourcegraphInternalReleaseRegistry),
 			bk.Env("PUBLIC_REGISTRY", images.SourcegraphDockerPublishRegistry),
-			bk.Env("ADDITIONAL_PROD_REGISTRY", images.SourcegraphArtifactRegistryPublicRegistry),
+			bk.Env("ADDITIONAL_PROD_REGISTRIES", images.SourcegraphArtifactRegistryPublicRegistry),
 			bk.AnnotatedCmd(
 				fmt.Sprintf("./tools/release/promote_images.sh %s", image_args),
 				bk.AnnotatedCmdOpts{

--- a/dev/ci/push_all.sh
+++ b/dev/ci/push_all.sh
@@ -76,9 +76,9 @@ prod_registries=(
   "$PROD_REGISTRY"
 )
 
-additional_prod_registry=${ADDITIONAL_PROD_REGISTRY:-""}
-if [ -n "$additional_prod_registry" ]; then
-  prod_registries+=("$additional_prod_registry")
+if [ -n "${ADDITIONAL_PROD_REGISTRIES}" ]; then
+  IFS=' ' read -r -a registries <<< "$ADDITIONAL_PROD_REGISTRIES"
+  prod_registries+=("${registries[@]}")
 fi
 
 date_fragment="$(date +%Y-%m-%d)"

--- a/tools/release/promote_images.sh
+++ b/tools/release/promote_images.sh
@@ -12,6 +12,16 @@ if [ "$#" -lt 1 ]; then
   exit 1
 fi
 
+# We're transitioning to GAR because of DockerHub new rate limiting affecting GCP
+# See https://github.com/sourcegraph/sourcegraph/issues/61696
+while read -r registry; do
+  PROMOTION_REGISTRIES+=("$registry")
+done <<< $ADDITIONAL_PROD_REGISTRIES
+
+# Set IFS to space and read into an array
+IFS=' ' read -r -a PROMOTION_REGISTRIES <<< "$ADDITIONAL_PROD_REGISTRIES"
+PROMOTION_REGISTRIES=("$PUBLIC_REGISTRY" ${PROMOTION_REGISTRIES[@]} )
+
 echo -e "## Release: image promotions" > ./annotations/image_promotions.md
 echo -e "\n| Name | From | To |\n|---|---|---|" >> ./annotations/image_promotions.md
 for name in "${@:1}"; do
@@ -21,13 +31,13 @@ for name in "${@:1}"; do
   docker pull "${INTERNAL_REGISTRY}/${name}:${VERSION}"
 
   # Push it on the classic public registry (DockerHub)
-  docker tag "${INTERNAL_REGISTRY}/${name}:${VERSION}" "${PUBLIC_REGISTRY}/${name}:${VERSION}"
-  docker push "${PUBLIC_REGISTRY}/${name}:${VERSION}"
+  pushed=""
+  for registry in "${PROMOTION_REGISTRIES[@]}"; do
+    target="${registry}/${name}:${VERSION}"
+    docker tag "${INTERNAL_REGISTRY}/${name}:${VERSION}" "$target"
+    docker push "$target"
+    pushed="$pushed \`$target\`"
+  done
 
-  # We're transitioning to GAR because of DockerHub new rate limiting affecting GCP
-  # See https://github.com/sourcegraph/sourcegraph/issues/61696
-  docker tag "${INTERNAL_REGISTRY}/${name}:${VERSION}" "${ADDITIONAL_PROD_REGISTRY}/${name}:${VERSION}"
-  docker push "${ADDITIONAL_PROD_REGISTRY}/${name}:${VERSION}"
-
-  echo -e "| ${name} | \`${INTERNAL_REGISTRY}/${name}:${VERSION}\` | \`${PUBLIC_REGISTRY}/${name}:${VERSION}\` \`${ADDITIONAL_PROD_REGISTRY}/${name}:${VERSION}\` |" >>./annotations/image_promotions.md
+  echo -e "| ${name} | \`${INTERNAL_REGISTRY}/${name}:${VERSION}\` | ${pushed} |" >>./annotations/image_promotions.md
 done

--- a/tools/release/promote_images.sh
+++ b/tools/release/promote_images.sh
@@ -16,11 +16,11 @@ fi
 # See https://github.com/sourcegraph/sourcegraph/issues/61696
 while read -r registry; do
   PROMOTION_REGISTRIES+=("$registry")
-done <<< $ADDITIONAL_PROD_REGISTRIES
+done <<< "$ADDITIONAL_PROD_REGISTRIES"
 
 # Set IFS to space and read into an array
 IFS=' ' read -r -a PROMOTION_REGISTRIES <<< "$ADDITIONAL_PROD_REGISTRIES"
-PROMOTION_REGISTRIES=("$PUBLIC_REGISTRY" ${PROMOTION_REGISTRIES[@]} )
+PROMOTION_REGISTRIES=("$PUBLIC_REGISTRY" "${PROMOTION_REGISTRIES[@]}" )
 
 echo -e "## Release: image promotions" > ./annotations/image_promotions.md
 echo -e "\n| Name | From | To |\n|---|---|---|" >> ./annotations/image_promotions.md

--- a/tools/release/promote_images.sh
+++ b/tools/release/promote_images.sh
@@ -14,10 +14,6 @@ fi
 
 # We're transitioning to GAR because of DockerHub new rate limiting affecting GCP
 # See https://github.com/sourcegraph/sourcegraph/issues/61696
-while read -r registry; do
-  PROMOTION_REGISTRIES+=("$registry")
-done <<< "$ADDITIONAL_PROD_REGISTRIES"
-
 # Set IFS to space and read into an array
 IFS=' ' read -r -a PROMOTION_REGISTRIES <<< "$ADDITIONAL_PROD_REGISTRIES"
 PROMOTION_REGISTRIES=("$PUBLIC_REGISTRY" "${PROMOTION_REGISTRIES[@]}" )


### PR DESCRIPTION
For cloud-ephemeral we want release also to be pushed to it's registry so that people launch ephemeral environments for releases.

This refactor the promotion script to handle handle additional registries. As a follow up a util func will be added to handle formating of the additional registries to ensure they're separated by a ` ` so that array splitting can happen.

Part of https://github.com/sourcegraph/sourcegraph/issues/61086
## Test plan
Tested locally
vars
```
export VERSION=6.6.666
export PUBLIC_REGISTRY='index.docker.io/sourcegraph-dev'
export ADDITIONAL_PROD_REGISTRY="us.gcr.io/sourcegraph-dev us.gcr.io/sourcegraph/cloud-ephemeral"
export INTERNAL_REGISTRY="us.gcr.io/sourcegraph/internal"
```
```
./tools/release/promote_images.sh gitserver
--- Copying gitserver from private registry to public registries
docker pull "us.gcr.io/sourcegraph/internal/gitserver:6.6.666"
docker tag "us.gcr.io/sourcegraph/internal/gitserver:6.6.666" "index.docker.io/sourcegraph-dev/gitserver:6.6.666"
docker push "index.docker.io/sourcegraph-dev/gitserver:6.6.666"
docker tag "us.gcr.io/sourcegraph/internal/gitserver:6.6.666" "us.gcr.io/sourcegraph-dev/gitserver:6.6.666"
docker push "us.gcr.io/sourcegraph-dev/gitserver:6.6.666"
docker tag "us.gcr.io/sourcegraph/internal/gitserver:6.6.666" "us.gcr.io/sourcegraph/cloud-ephemeral/gitserver:6.6.666"
docker push "us.gcr.io/sourcegraph/cloud-ephemeral/gitserver:6.6.666"
```
Annotation
```
## Release: image promotions

| Name | From | To |
|---|---|---|
| gitserver | `us.gcr.io/sourcegraph/internal/gitserver:6.6.666` |  `index.docker.io/sourcegraph-dev/gitserver:6.6.666` `us.gcr.io/sourcegraph-dev/gitserver:6.6.666` `us.gcr.io/sourcegraph/cloud-ephemeral/gitserver:6.6.666` |

```