### PR TITLE
Fix search box `/` shourtcut

### DIFF
--- a/client/web-sveltekit/src/lib/Hotkey.test.ts
+++ b/client/web-sveltekit/src/lib/Hotkey.test.ts
@@ -3,7 +3,7 @@
 import hotkeys from 'hotkeys-js'
 import { expect, describe, it, vi, beforeEach } from 'vitest'
 
-import {evaluateKey, exportedForTesting, registerHotkey} from './Hotkey'
+import { evaluateKey, exportedForTesting, registerHotkey } from './Hotkey'
 
 const mocks = vi.hoisted(() => ({
     isLinuxPlatform: vi.fn(),
@@ -178,26 +178,26 @@ describe('Hotkey', () => {
     describe('isContentElement', () => {
         describe('with getAttribute', () => {
             it('should return false is no condition is met', () => {
-                const element = document.createElement('div');
-                expect(exportedForTesting.isContentElement(element)).toBe(false);
-            });
+                const element = document.createElement('div')
+                expect(exportedForTesting.isContentElement(element)).toBe(false)
+            })
 
             it('should return true if contenteditable is true', () => {
-                const element = document.createElement('div');
-                element.setAttribute('contenteditable', 'true');
-                expect(exportedForTesting.isContentElement(element)).toBe(true);
-            });
+                const element = document.createElement('div')
+                element.setAttribute('contenteditable', 'true')
+                expect(exportedForTesting.isContentElement(element)).toBe(true)
+            })
 
             it.each(['textarea', 'input', 'textbox'])('should return true if the role is %s', role => {
-                const element = document.createElement('div');
-                element.setAttribute('role', role);
-                expect(exportedForTesting.isContentElement(element)).toBe(true);
-            });
+                const element = document.createElement('div')
+                element.setAttribute('role', role)
+                expect(exportedForTesting.isContentElement(element)).toBe(true)
+            })
 
             it.each(['INPUT', 'TEXTAREA'])('should return true if the tagName is %s', tagName => {
-                const element = document.createElement(tagName.toLowerCase());
-                expect(exportedForTesting.isContentElement(element)).toBe(true);
-            });
+                const element = document.createElement(tagName.toLowerCase())
+                expect(exportedForTesting.isContentElement(element)).toBe(true)
+            })
         })
     })
 })

--- a/client/web-sveltekit/src/lib/Hotkey.test.ts
+++ b/client/web-sveltekit/src/lib/Hotkey.test.ts
@@ -3,7 +3,7 @@
 import hotkeys from 'hotkeys-js'
 import { expect, describe, it, vi, beforeEach } from 'vitest'
 
-import { evaluateKey, registerHotkey } from './Hotkey'
+import {evaluateKey, exportedForTesting, registerHotkey} from './Hotkey'
 
 const mocks = vi.hoisted(() => ({
     isLinuxPlatform: vi.fn(),
@@ -172,6 +172,32 @@ describe('Hotkey', () => {
             hotkeys.trigger('hello')
             expect(counter_1).toBe(0)
             expect(counter_2).toBe(1)
+        })
+    })
+
+    describe('isContentElement', () => {
+        describe('with getAttribute', () => {
+            it('should return false is no condition is met', () => {
+                const element = document.createElement('div');
+                expect(exportedForTesting.isContentElement(element)).toBe(false);
+            });
+
+            it('should return true if contenteditable is true', () => {
+                const element = document.createElement('div');
+                element.setAttribute('contenteditable', 'true');
+                expect(exportedForTesting.isContentElement(element)).toBe(true);
+            });
+
+            it.each(['textarea', 'input', 'textbox'])('should return true if the role is %s', role => {
+                const element = document.createElement('div');
+                element.setAttribute('role', role);
+                expect(exportedForTesting.isContentElement(element)).toBe(true);
+            });
+
+            it.each(['INPUT', 'TEXTAREA'])('should return true if the tagName is %s', tagName => {
+                const element = document.createElement(tagName.toLowerCase());
+                expect(exportedForTesting.isContentElement(element)).toBe(true);
+            });
         })
     })
 })

--- a/client/web-sveltekit/src/lib/Hotkey.ts
+++ b/client/web-sveltekit/src/lib/Hotkey.ts
@@ -24,6 +24,20 @@ function isElement(t: any): t is Element {
 }
 
 /**
+ * This is an internal function to check if an Element has attributes that indicate it is a content field.
+ * It's exported for testing only.
+ * @param target Element
+ */
+function isContentElement(target: Element): boolean {
+    return (
+        target.getAttribute('contenteditable') === 'true' ||
+        // textarea and input are from the HTML standard, textbox is from svelte
+        ['textarea', 'input', 'textbox'].includes(target.getAttribute('role') ?? '') ||
+        ['INPUT', 'TEXTAREA'].includes(target.tagName)
+    )
+}
+
+/**
  * This function determines if the field that's focussed by the KeyboardEvent is some kind of input.
  * The implementation makes some assumptions about how the UI sets up content fields, which are also
  * specific to Svelte. It may need adjustment in the future.
@@ -35,12 +49,7 @@ function isContentField(event: KeyboardEvent): boolean {
     }
     const target = event.target
     if (isElement(target)) {
-        return (
-            target.getAttribute('contenteditable') === 'true' ||
-            // textarea and input are from the HTML standard, textbox is from svelte
-            ['textarea', 'input', 'textbox'].includes(target.getAttribute('role') ?? '') ||
-            ['INPUT', 'TEXTAREA'].includes(target.tagName)
-        )
+        return isContentElement(target)
     }
     return false
 }
@@ -164,4 +173,9 @@ export function registerHotkey({ keys, handler, allowDefault, ignoreInputFields 
             }
         },
     }
+}
+
+export const exportedForTesting = {
+    isContentElement,
+    wrapHandler,
 }

--- a/client/web-sveltekit/src/lib/Hotkey.ts
+++ b/client/web-sveltekit/src/lib/Hotkey.ts
@@ -38,7 +38,8 @@ function isContentField(event: KeyboardEvent): boolean {
         return (
             target.getAttribute('contenteditable') === 'true' ||
             // textarea and input are from the HTML standard, textbox is from svelte
-            ['textarea', 'input', 'textbox'].includes(target.getAttribute('role') ?? '')
+            ['textarea', 'input', 'textbox'].includes(target.getAttribute('role') ?? '') ||
+            ['INPUT', 'TEXTAREA'].includes(target.tagName)
         )
     }
     return false
@@ -53,7 +54,7 @@ function wrapHandler(handler: KeyHandler, allowDefault: boolean = false, ignoreI
         }
 
         if (!(ignoreInputFields && isContentField(keyboardEvent))) {
-            handler(keyboardEvent, hotkeysEvent)
+            return handler(keyboardEvent, hotkeysEvent) ?? allowDefault
         }
 
         // Returning false stops the event and prevents default browser events on macOS.

--- a/client/web-sveltekit/src/lib/search/input/SearchInput.svelte
+++ b/client/web-sveltekit/src/lib/search/input/SearchInput.svelte
@@ -156,14 +156,10 @@
 
     registerHotkey({
         keys: { key: '/' },
+        // Allows `/` symbol to populate input's value
+        // when input is focused
         allowDefault: true,
         handler: () => {
-            // If input already has focus, pass `/` symbol to the
-            // input element value
-            if (editor && editor.hasFocus) {
-                return true
-            }
-
             // If the search input doesn't have focus, focus it
             // and disallow `/` symbol populate the input value
             focus()

--- a/client/web-sveltekit/src/lib/search/input/SearchInput.svelte
+++ b/client/web-sveltekit/src/lib/search/input/SearchInput.svelte
@@ -158,10 +158,14 @@
         keys: { key: '/' },
         allowDefault: true,
         handler: () => {
-            if (editor?.hasFocus) {
+            // If input already has focus, pass `/` symbol to the
+            // input element value
+            if (editor && editor.hasFocus) {
                 return true
             }
 
+            // If the search input doesn't have focus, focus it
+            // and disallow `/` symbol populate the input value
             focus()
             return false
         },

--- a/client/web-sveltekit/src/lib/search/input/SearchInput.svelte
+++ b/client/web-sveltekit/src/lib/search/input/SearchInput.svelte
@@ -156,7 +156,15 @@
 
     registerHotkey({
         keys: { key: '/' },
-        handler: focus,
+        allowDefault: true,
+        handler: () => {
+            if (editor?.hasFocus) {
+                return true
+            }
+
+            focus()
+            return false
+        },
     })
 
     $: regularExpressionEnabled = $queryState.patternType === SearchPatternType.regexp

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/-/commits/[...path]/page.gql
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/-/commits/[...path]/page.gql
@@ -8,7 +8,13 @@ fragment CommitsPage_GitCommitConnection on GitCommitConnection {
     }
 }
 
-query CommitsPage_CommitsQuery($repoName: String!, $revision: String!, $first: Int, $path: String, $afterCursor: String) {
+query CommitsPage_CommitsQuery(
+    $repoName: String!
+    $revision: String!
+    $first: Int
+    $path: String
+    $afterCursor: String
+) {
     repository(name: $repoName) {
         id
         commit(rev: $revision) {


### PR DESCRIPTION
Fixes problem which was introduced by https://github.com/sourcegraph/sourcegraph/pull/62234

The original PR doesn't set `allowDefaults` which prevents populating input from entering the symbol which also was registered as a shortcut. Also there is a fix for catching field-like events 

## Test plan
- Check that `/` focuses the search box input on the home, result and blob UI pages
- Check that if the search input already got focus entering `/` leads to the adding `/` to the input value
- Check that if other input or form elements have focus entering `/` doesn't lead to the focusing search box input

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
