### PR TITLE
[Svelte]: Visual fixes for svelte blame panel

### DIFF
--- a/client/web-sveltekit/src/lib/CodeMirrorBlob.svelte
+++ b/client/web-sveltekit/src/lib/CodeMirrorBlob.svelte
@@ -56,7 +56,7 @@
             backgroundColor: 'transparent',
         },
         '.cm-gutters': {
-            'background-color': 'transparent',
+            'background-color': 'var(--code-bg)',
             border: 'none',
             color: 'var(--line-number-color)',
         },
@@ -68,8 +68,10 @@
                 color: 'var(--text-body)',
             },
         },
+        '.cm-lineNumbers .cm-gutterElement': {
+            padding: '0 1.5ex',
+        },
         '.cm-line': {
-            paddingLeft: '3ex',
             lineHeight: '1.54',
         },
         '.selected-line': {

--- a/client/web-sveltekit/src/lib/CodeMirrorBlob.svelte
+++ b/client/web-sveltekit/src/lib/CodeMirrorBlob.svelte
@@ -345,7 +345,7 @@
 
 <style lang="scss">
     .root {
-        --blame-decoration-width: 400px;
+        --blame-decoration-width: 300px;
         --blame-recency-width: 4px;
 
         height: 100%;

--- a/client/web-sveltekit/src/lib/Timestamp.svelte
+++ b/client/web-sveltekit/src/lib/Timestamp.svelte
@@ -47,5 +47,5 @@
 </script>
 
 <Tooltip tooltip={showAbsolute ? relativeDate : formattedDate}>
-    <span class="timestamp" data-testid="timestamp" data-timestamp>{showAbsolute ? formattedDate : relativeDate} </span>
+    <span class="timestamp" data-testid="timestamp">{showAbsolute ? formattedDate : relativeDate} </span>
 </Tooltip>

--- a/client/web-sveltekit/src/lib/Timestamp.svelte
+++ b/client/web-sveltekit/src/lib/Timestamp.svelte
@@ -1,14 +1,17 @@
 <script lang="ts" context="module">
-    function formatDate(date: Date, options: { utc?: boolean }): string {
+    import { addMinutes, format as dateFnsFormat } from 'date-fns'
+
+    export function formatDate(date: Date, options: { utc?: boolean; format?: TimestampFormat }): string {
         if (options.utc) {
             date = addMinutes(date, date.getTimezoneOffset())
         }
         const dateHasTime = date.toString().includes('T')
-        const defaultFormat = dateHasTime ? TimestampFormat.FULL_DATE_TIME : TimestampFormat.FULL_DATE
-        return format(date, defaultFormat) + (options.utc ? ' UTC' : '')
+        const defaultFormat =
+            options.format ?? (dateHasTime ? TimestampFormat.FULL_DATE_TIME : TimestampFormat.FULL_DATE)
+        return dateFnsFormat(date, defaultFormat) + (options.utc ? ' UTC' : '')
     }
 
-    enum TimestampFormat {
+    export enum TimestampFormat {
         FULL_TIME = 'HH:mm:ss',
         FULL_DATE = 'yyyy-MM-dd',
         FULL_DATE_TIME = 'yyyy-MM-dd pp',
@@ -16,7 +19,7 @@
 </script>
 
 <script lang="ts">
-    import { addMinutes, format, formatDistance, formatDistanceStrict } from 'date-fns'
+    import { formatDistance, formatDistanceStrict } from 'date-fns'
 
     import { currentDate } from './stores'
     import Tooltip from './Tooltip.svelte'
@@ -44,5 +47,5 @@
 </script>
 
 <Tooltip tooltip={showAbsolute ? relativeDate : formattedDate}>
-    <span class="timestamp" data-testid="timestamp">{showAbsolute ? formattedDate : relativeDate} </span>
+    <span class="timestamp" data-testid="timestamp" data-timestamp>{showAbsolute ? formattedDate : relativeDate} </span>
 </Tooltip>

--- a/client/web-sveltekit/src/lib/blame/BlameDecoration.svelte
+++ b/client/web-sveltekit/src/lib/blame/BlameDecoration.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
-    import type { Avatar_Person, Avatar_User } from '$lib/Avatar.gql'
-    import Avatar from '$lib/Avatar.svelte'
     import type { BlameHunk } from '$lib/web'
+    import { formatDate, TimestampFormat } from '$lib/Timestamp.svelte'
 
     export let hunk: BlameHunk
 
@@ -14,30 +13,12 @@
     // export let externalURLs: BlameHunkData['externalURLs']
 
     $: info = hunk.displayInfo
-
-    function getAvatar(author: BlameHunk['author']): Avatar_Person | Avatar_User {
-        // Avatar expects GraphQL types, but since these come from the
-        // blame view, our types don't quite match. Massage them a bit
-        // to get them in the right shape.
-        if (author.person.user) {
-            return { __typename: 'User', ...author.person.user }
-        } else {
-            return {
-                __typename: 'Person',
-                displayName: author.person.displayName,
-                name: author.person.displayName,
-                avatarURL: author.person.avatarURL,
-            }
-        }
-    }
 </script>
 
 <div class="root">
-    <span class="date">{info.dateString}</span>
-    <Avatar avatar={getAvatar(hunk.author)} />
+    <span class="date">{formatDate(info.commitDate, { format: TimestampFormat.FULL_DATE })}</span>
     <a href={info.linkURL} target="_blank" rel="noreferrer noopener">
-        {`${info.displayName}${info.username}`.split(' ')[0]}
-        {' • '}
+        <span class="name">{`${info.displayName}${info.username}`.split(' ')[0]}</span>
         <span class="message">{info.message}</span>
     </a>
 </div>
@@ -52,7 +33,8 @@
         gap: 0.5em;
 
         .date {
-            min-width: 80px;
+            font-weight: bold;
+            margin-right: 0.25rem;
         }
 
         a {
@@ -60,6 +42,16 @@
             text-overflow: ellipsis;
             white-space: nowrap;
             color: inherit;
+            width: 100%;
+        }
+
+        .date,
+        .name {
+            font-family: monospace;
+        }
+
+        .message {
+            margin-left: 0.5rem;
         }
     }
 </style>

--- a/client/web/src/repo/blob/codemirror/blame-decorations.ts
+++ b/client/web/src/repo/blob/codemirror/blame-decorations.ts
@@ -311,7 +311,7 @@ const blameGutter: Extension = [
         },
         '.sg-recency-gutter': {
             width: 'var(--blame-recency-width)',
-            marginLeft: '8px',
+            minWidth: 'var(--blame-recency-width)'
         },
         '.sg-recency-marker': {
             position: 'relative',

--- a/client/web/src/repo/blob/codemirror/blame-decorations.ts
+++ b/client/web/src/repo/blob/codemirror/blame-decorations.ts
@@ -127,7 +127,7 @@ const blameDecorationTheme = EditorView.theme({
         // Move the start of the line to after the blame decoration.
         // This is necessary because the start of the line is used for
         // aligning tab characters.
-        paddingLeft: 'var(--blame-decoration-width) !important',
+        paddingLeft: 'calc(var(--blame-decoration-width) + 10px) !important',
         lineHeight: '1.5rem',
         // Avoid jumping when blame decorations are streamed in because we use a border
         // borderTop: '1px solid transparent',
@@ -283,6 +283,7 @@ const blameGutter: Extension = [
 
     // Gutter for recency indicator
     gutter({
+        class: 'sg-recency-gutter',
         lineMarker(view, line) {
             const lineNumber = view.state.doc.lineAt(line.from).number
             const hunks = view.state.facet(blameDataFacet).lines
@@ -307,6 +308,10 @@ const blameGutter: Extension = [
         '.blame-gutter': {
             background: 'var(--body-bg)',
             width: 'var(--blame-decoration-width)',
+        },
+        '.sg-recency-gutter': {
+            width: 'var(--blame-recency-width)',
+            marginLeft: '8px',
         },
         '.sg-recency-marker': {
             position: 'relative',

--- a/client/web/src/repo/blob/codemirror/blame-decorations.ts
+++ b/client/web/src/repo/blob/codemirror/blame-decorations.ts
@@ -311,7 +311,7 @@ const blameGutter: Extension = [
         },
         '.sg-recency-gutter': {
             width: 'var(--blame-recency-width)',
-            minWidth: 'var(--blame-recency-width)'
+            minWidth: 'var(--blame-recency-width)',
         },
         '.sg-recency-marker': {
             position: 'relative',


### PR DESCRIPTION
Adds a few visual tweaks to the blame panel 
- Fixes padding problem with gutters in blame UI
- Removes blame avatars
- Fixes width for dates (making it monospace)
- Make the blame panel a bit smaller by width (ideally we should make it resizable I think, made it smaller because it takes almost all width on my mid-size screen)

| Before | After |
| -------- | ------- |
| <img width="1102" alt="Screenshot 2024-04-30 at 13 53 28" src="https://github.com/sourcegraph/sourcegraph/assets/18492575/d6804e91-6615-4195-b350-45b00636b6f1"> | <img width="1114" alt="Screenshot 2024-04-30 at 13 52 48" src="https://github.com/sourcegraph/sourcegraph/assets/18492575/6c513ebe-7f73-48ac-a96d-fa14e019bfae"> |

 
## Test plan
- Check git blame panel, make sure it looks ok
- Check other code mirror editors like file preview panel 
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
