### PR TITLE
Svelte: Fix `kbd` badge styles for svelte version

### DIFF
--- a/client/web-sveltekit/src/routes/styles.scss
+++ b/client/web-sveltekit/src/routes/styles.scss
@@ -26,3 +26,21 @@ button:focus-visible {
 input:focus-visible {
     box-shadow: 0 0 0 2px var(--primary-2);
 }
+
+kbd {
+    display: inline;
+    height: 1.125rem;
+    margin: 0 0.125rem;
+    padding: 0 0.25rem 0.1rem 0.25rem;
+    line-height: (16/12);
+    vertical-align: middle;
+
+    font-size: var(--code-font-size);
+    font-family: var(--monospace-font-family);
+    color: var(--text-muted);
+
+    border-radius: 4px;
+    border: 1px solid var(--border-color-2);
+    background-color: var(--color-bg-1);
+    box-shadow: inset 0 -2px 0 var(--color-bg-2);
+}


### PR DESCRIPTION

Prior to this PR it looked like kbd badge has a slightly off layout (it cuts the lower part of the symbol since we use box-shadow inset) 

| Before | After |
| ------- | ------- | 
| <img width="360" alt="Screenshot 2024-04-30 at 14 17 42" src="https://github.com/sourcegraph/sourcegraph/assets/18492575/964df1b2-eff6-4f96-b76e-433c568dacc0"> | <img width="372" alt="Screenshot 2024-04-30 at 14 17 35" src="https://github.com/sourcegraph/sourcegraph/assets/18492575/2762c83e-39eb-452f-aba4-9699746f2193"> |

## Test plan
- Check that kbd badges in search box suggestions, filters and in search box trigger button on the blob UI pages look good.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
