### PR TITLE
svelte: Fix showing code intel hovercards

### DIFF
--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/FileView.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/FileView.svelte
@@ -84,14 +84,14 @@
     $: showFileModeSwitcher = blob && !isBinary && !embedded
     $: showCodeView = !isBinary && !isFormatted
     $: codeIntelAPI =
-        disableCodeIntel || showCodeView
-            ? null
-            : createCodeIntelAPI({
+        showCodeView && !disableCodeIntel
+            ? createCodeIntelAPI({
                   settings: setting => (isErrorLike($settings?.final) ? undefined : $settings?.final?.[setting]),
                   requestGraphQL(options) {
                       return from(graphQLClient.query(options.request, options.variables).then(toGraphQLResult))
                   },
               })
+            : null
 
     function viewModeURL(viewMode: CodeViewMode) {
         switch (viewMode) {


### PR DESCRIPTION
Regression introduced by #62187 . The condition for checking `showCodeView` is the wrong way round.



## Test plan

Manually tested.