### PR TITLE
appliance: pod template standard config

### DIFF
--- a/internal/appliance/blobstore.go
+++ b/internal/appliance/blobstore.go
@@ -138,7 +138,7 @@ func buildBlobstoreDeployment(sg *Sourcegraph) appsv1.Deployment {
 		},
 	}
 
-	podTemplate := pod.NewPodTemplate(name)
+	podTemplate := pod.NewPodTemplate(name, sg.Spec.Blobstore)
 	podTemplate.Template.Spec.Containers = []corev1.Container{defaultContainer}
 	podTemplate.Template.Spec.Volumes = podVolumes
 

--- a/internal/appliance/config/config.go
+++ b/internal/appliance/config/config.go
@@ -4,6 +4,7 @@ import corev1 "k8s.io/api/core/v1"
 
 type StandardComponent interface {
 	Disableable
+	GetPodTemplateConfig() PodTemplateConfig
 	GetResources() map[string]corev1.ResourceRequirements
 	GetServiceAccountAnnotations() map[string]string
 	PrometheusPort() *int
@@ -15,11 +16,22 @@ type Disableable interface {
 
 type StandardConfig struct {
 	Disabled                  bool                                   `json:"disabled,omitempty"`
+	PodTemplateConfig         PodTemplateConfig                      `json:"podTemplateConfig,omitempty"`
 	Resources                 map[string]corev1.ResourceRequirements `json:"resources,omitempty"`
 	ServiceAccountAnnotations map[string]string                      `json:"serviceAccountAnnotations,omitempty"`
 }
 
+// Config that applies to all Pod templates produced by a Service. If this needs
+// to differ between pod templates, split another service definition.
+type PodTemplateConfig struct {
+	Affinity         *corev1.Affinity              `json:"affinity,omitempty"`
+	ImagePullSecrets []corev1.LocalObjectReference `json:"imagePullSecrets,omitempty"`
+	NodeSelector     map[string]string             `json:"nodeSelector,omitempty"`
+	Tolerations      []corev1.Toleration           `json:"tolerations,omitempty"`
+}
+
 func (c StandardConfig) IsDisabled() bool                                     { return c.Disabled }
+func (c StandardConfig) GetPodTemplateConfig() PodTemplateConfig              { return c.PodTemplateConfig }
 func (c StandardConfig) GetResources() map[string]corev1.ResourceRequirements { return c.Resources }
 func (c StandardConfig) GetServiceAccountAnnotations() map[string]string {
 	return c.ServiceAccountAnnotations

--- a/internal/appliance/development.md
+++ b/internal/appliance/development.md
@@ -26,6 +26,8 @@ By embedding StandardConfig, you'll get various features for almost-free:
   `reconcileObject()`. This frees the developer from writing any upsert/delete
   logic at all, usually.
 - Container resources
+- Node selectors, tolerations, and affinities.
+- Image pull secrets for use with private image registries.
 - Service account annotations
   - This is an extremely common customization need, e.g. to enable GKE
     workload-identity bindings.

--- a/internal/appliance/repo_updater.go
+++ b/internal/appliance/repo_updater.go
@@ -98,7 +98,7 @@ func (r *Reconciler) reconcileRepoUpdaterDeployment(ctx context.Context, sg *Sou
 		TimeoutSeconds:   5,
 	}
 
-	podTemplate := pod.NewPodTemplate(name)
+	podTemplate := pod.NewPodTemplate(name, cfg)
 	podTemplate.Template.Spec.Containers = []corev1.Container{ctr}
 
 	dep := deployment.NewDeployment(name, sg.Namespace, sg.Spec.RequestedVersion)

--- a/internal/appliance/repo_updater_test.go
+++ b/internal/appliance/repo_updater_test.go
@@ -9,6 +9,7 @@ func (suite *ApplianceTestSuite) TestDeployRepoUpdater() {
 		name string
 	}{
 		{name: "repo-updater-default"},
+		{name: "repo-updater-with-pod-template-config"},
 		{name: "repo-updater-with-resources"},
 		{name: "repo-updater-with-no-resources"},
 		{name: "repo-updater-with-sa-annotations"},

--- a/internal/appliance/symbols.go
+++ b/internal/appliance/symbols.go
@@ -118,7 +118,7 @@ func (r *Reconciler) reconcileSymbolsStatefulSet(ctx context.Context, sg *Source
 		{Name: "tmp", MountPath: "/mnt/tmp"},
 	}
 
-	podTemplate := pod.NewPodTemplate(name)
+	podTemplate := pod.NewPodTemplate(name, cfg)
 	podTemplate.Template.Spec.Containers = []corev1.Container{ctr}
 	podTemplate.Template.Spec.ServiceAccountName = name
 	podTemplate.Template.Spec.Volumes = []corev1.Volume{

--- a/internal/appliance/testdata/golden-fixtures/blobstore-subsequent-disable.yaml
+++ b/internal/appliance/testdata/golden-fixtures/blobstore-subsequent-disable.yaml
@@ -72,7 +72,7 @@ resources:
   kind: PersistentVolumeClaim
   metadata:
     annotations:
-      appliance.sourcegraph.com/configHash: bd6ab558ec98ed6b2607b80469bb9f209b485fa44a6dd5beaf18c37011340afc
+      appliance.sourcegraph.com/configHash: 2f021d876cf221dde4ceda68a06356aaf5a8ab038e83b5ab776381470a4a0dbb
     creationTimestamp: "2024-04-19T00:00:00Z"
     deletionGracePeriodSeconds: 0
     deletionTimestamp: "2024-04-19T00:00:00Z"

--- a/internal/appliance/testdata/golden-fixtures/repo-updater-default.yaml
+++ b/internal/appliance/testdata/golden-fixtures/repo-updater-default.yaml
@@ -3,7 +3,7 @@ resources:
   kind: Deployment
   metadata:
     annotations:
-      appliance.sourcegraph.com/configHash: bd6ab558ec98ed6b2607b80469bb9f209b485fa44a6dd5beaf18c37011340afc
+      appliance.sourcegraph.com/configHash: 2f021d876cf221dde4ceda68a06356aaf5a8ab038e83b5ab776381470a4a0dbb
     creationTimestamp: "2024-04-19T00:00:00Z"
     generation: 1
     labels:
@@ -183,7 +183,7 @@ resources:
   kind: ServiceAccount
   metadata:
     annotations:
-      appliance.sourcegraph.com/configHash: bd6ab558ec98ed6b2607b80469bb9f209b485fa44a6dd5beaf18c37011340afc
+      appliance.sourcegraph.com/configHash: 2f021d876cf221dde4ceda68a06356aaf5a8ab038e83b5ab776381470a4a0dbb
     creationTimestamp: "2024-04-19T00:00:00Z"
     labels:
       deploy: sourcegraph
@@ -195,7 +195,7 @@ resources:
   kind: Service
   metadata:
     annotations:
-      appliance.sourcegraph.com/configHash: bd6ab558ec98ed6b2607b80469bb9f209b485fa44a6dd5beaf18c37011340afc
+      appliance.sourcegraph.com/configHash: 2f021d876cf221dde4ceda68a06356aaf5a8ab038e83b5ab776381470a4a0dbb
       prometheus.io/port: "6060"
       sourcegraph.prometheus/scrape: "true"
     creationTimestamp: "2024-04-19T00:00:00Z"

--- a/internal/appliance/testdata/golden-fixtures/repo-updater-with-no-resources.yaml
+++ b/internal/appliance/testdata/golden-fixtures/repo-updater-with-no-resources.yaml
@@ -3,7 +3,7 @@ resources:
   kind: Deployment
   metadata:
     annotations:
-      appliance.sourcegraph.com/configHash: 194a6cc637fde1a16b0c81a98a8c5320c807f7e832158a658b49bb33afe76bd3
+      appliance.sourcegraph.com/configHash: 65c15b5a2a6b486842f08e9935aee4e4f5684254884f6f55040bf752ea78f999
     creationTimestamp: "2024-04-19T00:00:00Z"
     generation: 1
     labels:
@@ -179,7 +179,7 @@ resources:
   kind: ServiceAccount
   metadata:
     annotations:
-      appliance.sourcegraph.com/configHash: 194a6cc637fde1a16b0c81a98a8c5320c807f7e832158a658b49bb33afe76bd3
+      appliance.sourcegraph.com/configHash: 65c15b5a2a6b486842f08e9935aee4e4f5684254884f6f55040bf752ea78f999
     creationTimestamp: "2024-04-19T00:00:00Z"
     labels:
       deploy: sourcegraph
@@ -191,7 +191,7 @@ resources:
   kind: Service
   metadata:
     annotations:
-      appliance.sourcegraph.com/configHash: 194a6cc637fde1a16b0c81a98a8c5320c807f7e832158a658b49bb33afe76bd3
+      appliance.sourcegraph.com/configHash: 65c15b5a2a6b486842f08e9935aee4e4f5684254884f6f55040bf752ea78f999
       prometheus.io/port: "6060"
       sourcegraph.prometheus/scrape: "true"
     creationTimestamp: "2024-04-19T00:00:00Z"

--- a/internal/appliance/testdata/golden-fixtures/repo-updater-with-pod-template-config.yaml
+++ b/internal/appliance/testdata/golden-fixtures/repo-updater-with-pod-template-config.yaml
@@ -3,15 +3,15 @@ resources:
   kind: Deployment
   metadata:
     annotations:
-      appliance.sourcegraph.com/configHash: 2f021d876cf221dde4ceda68a06356aaf5a8ab038e83b5ab776381470a4a0dbb
+      appliance.sourcegraph.com/configHash: fb4350077a4cece06beb351dd3f29f58b6706ab3c3aaf8532b9ab07f68073983
     creationTimestamp: "2024-04-19T00:00:00Z"
     generation: 1
     labels:
-      app.kubernetes.io/component: blobstore
+      app.kubernetes.io/component: repo-updater
       app.kubernetes.io/name: sourcegraph
       app.kubernetes.io/version: 5.3.9104
       deploy: sourcegraph
-    name: blobstore
+    name: repo-updater
     namespace: NORMALIZED_FOR_TESTING
     resourceVersion: NORMALIZED_FOR_TESTING
     uid: NORMALIZED_FOR_TESTING
@@ -22,7 +22,7 @@ resources:
     revisionHistoryLimit: 10
     selector:
       matchLabels:
-        app: blobstore
+        app: repo-updater
     strategy:
       rollingUpdate:
         maxSurge: 25%
@@ -31,28 +31,76 @@ resources:
     template:
       metadata:
         annotations:
-          kubectl.kubernetes.io/default-container: blobstore
+          kubectl.kubernetes.io/default-container: repo-updater
         creationTimestamp: null
         labels:
-          app: blobstore
+          app: repo-updater
           deploy: sourcegraph
-        name: blobstore
+        name: repo-updater
       spec:
+        affinity:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+              - matchExpressions:
+                - key: disktype
+                  operator: In
+                  values:
+                  - ssd
         containers:
-        - image: index.docker.io/sourcegraph/blobstore:5.3.2@sha256:d625be1eefe61cc42f94498e3c588bf212c4159c8b20c519db84eae4ff715efa
+        - env:
+          - name: REDIS_CACHE_ENDPOINT
+            valueFrom:
+              secretKeyRef:
+                key: endpoint
+                name: redis-cache
+          - name: REDIS_STORE_ENDPOINT
+            valueFrom:
+              secretKeyRef:
+                key: endpoint
+                name: redis-store
+          - name: OTEL_AGENT_HOST
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: status.hostIP
+          - name: OTEL_EXPORTER_OTLP_ENDPOINT
+            value: http://$(OTEL_AGENT_HOST):4317
+          image: index.docker.io/sourcegraph/repo-updater:5.3.2@sha256:5a414aa030c7e0922700664a43b449ee5f3fafa68834abef93988c5992c747c6
           imagePullPolicy: IfNotPresent
-          name: blobstore
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /healthz
+              port: debug
+              scheme: HTTP
+            periodSeconds: 1
+            successThreshold: 1
+            timeoutSeconds: 5
+          name: repo-updater
           ports:
-          - containerPort: 9000
-            name: blobstore
+          - containerPort: 3182
+            name: http
             protocol: TCP
+          - containerPort: 6060
+            name: debug
+            protocol: TCP
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /ready
+              port: debug
+              scheme: HTTP
+            periodSeconds: 1
+            successThreshold: 1
+            timeoutSeconds: 5
           resources:
             limits:
               cpu: "1"
-              memory: 500M
+              memory: 2Gi
             requests:
               cpu: "1"
-              memory: 500M
+              memory: 500Mi
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
@@ -60,12 +108,11 @@ resources:
             runAsUser: 100
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: FallbackToLogsOnError
-          volumeMounts:
-          - mountPath: /blobstore
-            name: blobstore
-          - mountPath: /data
-            name: blobstore-data
         dnsPolicy: ClusterFirst
+        imagePullSecrets:
+        - name: myPrivateRegistrySecret
+        nodeSelector:
+          my-node-label: some-value
         restartPolicy: Always
         schedulerName: default-scheduler
         securityContext:
@@ -73,13 +120,14 @@ resources:
           fsGroupChangePolicy: OnRootMismatch
           runAsGroup: 101
           runAsUser: 100
+        serviceAccount: repo-updater
+        serviceAccountName: repo-updater
         terminationGracePeriodSeconds: 30
-        volumes:
-        - emptyDir: {}
-          name: blobstore
-        - name: blobstore-data
-          persistentVolumeClaim:
-            claimName: blobstore
+        tolerations:
+        - effect: NoSchedule
+          key: key1
+          operator: Equal
+          value: value1
   status: {}
 - apiVersion: v1
   data:
@@ -87,7 +135,8 @@ resources:
       spec:
         requestedVersion: "5.3.9104"
 
-        blobstore: {}
+        blobstore:
+          disabled: true
 
         codeInsights:
           disabled: true
@@ -126,7 +175,25 @@ resources:
           disabled: true
 
         repoUpdater:
-          disabled: true
+          podTemplateConfig:
+            affinity:
+              nodeAffinity:
+                requiredDuringSchedulingIgnoredDuringExecution:
+                  nodeSelectorTerms:
+                  - matchExpressions:
+                    - key: disktype
+                      operator: In
+                      values:
+                      - ssd
+            imagePullSecrets:
+              - name: myPrivateRegistrySecret
+            nodeSelector:
+              my-node-label: some-value
+            tolerations:
+              - key: "key1"
+                operator: "Equal"
+                value: "value1"
+                effect: "NoSchedule"
 
         searcher:
           disabled: true
@@ -150,40 +217,30 @@ resources:
     resourceVersion: NORMALIZED_FOR_TESTING
     uid: NORMALIZED_FOR_TESTING
 - apiVersion: v1
-  kind: PersistentVolumeClaim
+  kind: ServiceAccount
   metadata:
     annotations:
-      appliance.sourcegraph.com/configHash: 2f021d876cf221dde4ceda68a06356aaf5a8ab038e83b5ab776381470a4a0dbb
+      appliance.sourcegraph.com/configHash: fb4350077a4cece06beb351dd3f29f58b6706ab3c3aaf8532b9ab07f68073983
     creationTimestamp: "2024-04-19T00:00:00Z"
-    finalizers:
-    - kubernetes.io/pvc-protection
     labels:
       deploy: sourcegraph
-    name: blobstore
+    name: repo-updater
     namespace: NORMALIZED_FOR_TESTING
     resourceVersion: NORMALIZED_FOR_TESTING
     uid: NORMALIZED_FOR_TESTING
-  spec:
-    accessModes:
-    - ReadWriteOnce
-    resources:
-      requests:
-        storage: 100Gi
-    storageClassName: sourcegraph
-    volumeMode: Filesystem
-  status:
-    phase: Pending
 - apiVersion: v1
   kind: Service
   metadata:
     annotations:
-      appliance.sourcegraph.com/configHash: 2f021d876cf221dde4ceda68a06356aaf5a8ab038e83b5ab776381470a4a0dbb
+      appliance.sourcegraph.com/configHash: fb4350077a4cece06beb351dd3f29f58b6706ab3c3aaf8532b9ab07f68073983
+      prometheus.io/port: "6060"
+      sourcegraph.prometheus/scrape: "true"
     creationTimestamp: "2024-04-19T00:00:00Z"
     labels:
-      app: blobstore
-      app.kubernetes.io/component: blobstore
+      app: repo-updater
+      app.kubernetes.io/component: repo-updater
       deploy: sourcegraph
-    name: blobstore
+    name: repo-updater
     namespace: NORMALIZED_FOR_TESTING
     resourceVersion: NORMALIZED_FOR_TESTING
     uid: NORMALIZED_FOR_TESTING
@@ -196,12 +253,12 @@ resources:
     - IPv4
     ipFamilyPolicy: SingleStack
     ports:
-    - name: blobstore
-      port: 9000
+    - name: http
+      port: 3182
       protocol: TCP
-      targetPort: blobstore
+      targetPort: http
     selector:
-      app: blobstore
+      app: repo-updater
     sessionAffinity: None
     type: ClusterIP
   status:

--- a/internal/appliance/testdata/golden-fixtures/repo-updater-with-resources.yaml
+++ b/internal/appliance/testdata/golden-fixtures/repo-updater-with-resources.yaml
@@ -3,7 +3,7 @@ resources:
   kind: Deployment
   metadata:
     annotations:
-      appliance.sourcegraph.com/configHash: 83dee16b8bed37d368c11b4de97740a70fe3a1589992154040c17b045f263488
+      appliance.sourcegraph.com/configHash: 26dafd55dfc76af52bc1afed151289a0d96e4303da2e4c398d72be432c741169
     creationTimestamp: "2024-04-19T00:00:00Z"
     generation: 1
     labels:
@@ -191,7 +191,7 @@ resources:
   kind: ServiceAccount
   metadata:
     annotations:
-      appliance.sourcegraph.com/configHash: 83dee16b8bed37d368c11b4de97740a70fe3a1589992154040c17b045f263488
+      appliance.sourcegraph.com/configHash: 26dafd55dfc76af52bc1afed151289a0d96e4303da2e4c398d72be432c741169
     creationTimestamp: "2024-04-19T00:00:00Z"
     labels:
       deploy: sourcegraph
@@ -203,7 +203,7 @@ resources:
   kind: Service
   metadata:
     annotations:
-      appliance.sourcegraph.com/configHash: 83dee16b8bed37d368c11b4de97740a70fe3a1589992154040c17b045f263488
+      appliance.sourcegraph.com/configHash: 26dafd55dfc76af52bc1afed151289a0d96e4303da2e4c398d72be432c741169
       prometheus.io/port: "6060"
       sourcegraph.prometheus/scrape: "true"
     creationTimestamp: "2024-04-19T00:00:00Z"

--- a/internal/appliance/testdata/golden-fixtures/repo-updater-with-sa-annotations.yaml
+++ b/internal/appliance/testdata/golden-fixtures/repo-updater-with-sa-annotations.yaml
@@ -3,7 +3,7 @@ resources:
   kind: Deployment
   metadata:
     annotations:
-      appliance.sourcegraph.com/configHash: 230da28e00c1e55a03bd1337e6d09fbb05ddfda1dec6600a4f96ef456f174f7d
+      appliance.sourcegraph.com/configHash: 87fd1f68482dc8b23cbb7ea3a7c3749e25e93d4ebb72265d65a0f4150046d2b3
     creationTimestamp: "2024-04-19T00:00:00Z"
     generation: 1
     labels:
@@ -185,7 +185,7 @@ resources:
   kind: ServiceAccount
   metadata:
     annotations:
-      appliance.sourcegraph.com/configHash: 230da28e00c1e55a03bd1337e6d09fbb05ddfda1dec6600a4f96ef456f174f7d
+      appliance.sourcegraph.com/configHash: 87fd1f68482dc8b23cbb7ea3a7c3749e25e93d4ebb72265d65a0f4150046d2b3
       foo: bar
     creationTimestamp: "2024-04-19T00:00:00Z"
     labels:
@@ -198,7 +198,7 @@ resources:
   kind: Service
   metadata:
     annotations:
-      appliance.sourcegraph.com/configHash: 230da28e00c1e55a03bd1337e6d09fbb05ddfda1dec6600a4f96ef456f174f7d
+      appliance.sourcegraph.com/configHash: 87fd1f68482dc8b23cbb7ea3a7c3749e25e93d4ebb72265d65a0f4150046d2b3
       prometheus.io/port: "6060"
       sourcegraph.prometheus/scrape: "true"
     creationTimestamp: "2024-04-19T00:00:00Z"

--- a/internal/appliance/testdata/golden-fixtures/symbols-default.yaml
+++ b/internal/appliance/testdata/golden-fixtures/symbols-default.yaml
@@ -3,7 +3,7 @@ resources:
   kind: StatefulSet
   metadata:
     annotations:
-      appliance.sourcegraph.com/configHash: bd6ab558ec98ed6b2607b80469bb9f209b485fa44a6dd5beaf18c37011340afc
+      appliance.sourcegraph.com/configHash: 2f021d876cf221dde4ceda68a06356aaf5a8ab038e83b5ab776381470a4a0dbb
     creationTimestamp: "2024-04-19T00:00:00Z"
     generation: 1
     labels:
@@ -222,7 +222,7 @@ resources:
   kind: ServiceAccount
   metadata:
     annotations:
-      appliance.sourcegraph.com/configHash: bd6ab558ec98ed6b2607b80469bb9f209b485fa44a6dd5beaf18c37011340afc
+      appliance.sourcegraph.com/configHash: 2f021d876cf221dde4ceda68a06356aaf5a8ab038e83b5ab776381470a4a0dbb
     creationTimestamp: "2024-04-19T00:00:00Z"
     labels:
       deploy: sourcegraph
@@ -234,7 +234,7 @@ resources:
   kind: Service
   metadata:
     annotations:
-      appliance.sourcegraph.com/configHash: bd6ab558ec98ed6b2607b80469bb9f209b485fa44a6dd5beaf18c37011340afc
+      appliance.sourcegraph.com/configHash: 2f021d876cf221dde4ceda68a06356aaf5a8ab038e83b5ab776381470a4a0dbb
       prometheus.io/port: "6060"
       sourcegraph.prometheus/scrape: "true"
     creationTimestamp: "2024-04-19T00:00:00Z"

--- a/internal/appliance/testdata/golden-fixtures/symbols-with-storage.yaml
+++ b/internal/appliance/testdata/golden-fixtures/symbols-with-storage.yaml
@@ -3,7 +3,7 @@ resources:
   kind: StatefulSet
   metadata:
     annotations:
-      appliance.sourcegraph.com/configHash: d89fe1af0a19ed5d6a4ec2e1c45be18f6aeff38380a90e718e9a15509dfd50cc
+      appliance.sourcegraph.com/configHash: d33e42f7a0651e109c1a55ae881f9e3000e194cb5257dad1714cf26d5a370b3c
     creationTimestamp: "2024-04-19T00:00:00Z"
     generation: 1
     labels:
@@ -223,7 +223,7 @@ resources:
   kind: ServiceAccount
   metadata:
     annotations:
-      appliance.sourcegraph.com/configHash: d89fe1af0a19ed5d6a4ec2e1c45be18f6aeff38380a90e718e9a15509dfd50cc
+      appliance.sourcegraph.com/configHash: d33e42f7a0651e109c1a55ae881f9e3000e194cb5257dad1714cf26d5a370b3c
     creationTimestamp: "2024-04-19T00:00:00Z"
     labels:
       deploy: sourcegraph
@@ -235,7 +235,7 @@ resources:
   kind: Service
   metadata:
     annotations:
-      appliance.sourcegraph.com/configHash: d89fe1af0a19ed5d6a4ec2e1c45be18f6aeff38380a90e718e9a15509dfd50cc
+      appliance.sourcegraph.com/configHash: d33e42f7a0651e109c1a55ae881f9e3000e194cb5257dad1714cf26d5a370b3c
       prometheus.io/port: "6060"
       sourcegraph.prometheus/scrape: "true"
     creationTimestamp: "2024-04-19T00:00:00Z"

--- a/internal/appliance/testdata/sg/repo-updater-with-pod-template-config.yaml
+++ b/internal/appliance/testdata/sg/repo-updater-with-pod-template-config.yaml
@@ -1,0 +1,74 @@
+spec:
+  requestedVersion: "5.3.9104"
+
+  blobstore:
+    disabled: true
+
+  codeInsights:
+    disabled: true
+
+  codeIntel:
+    disabled: true
+
+  frontend:
+    disabled: true
+
+  gitServer:
+    disabled: true
+
+  indexedSearch:
+    disabled: true
+
+  indexedSearchIndexer:
+    disabled: true
+
+  pgsql:
+    disabled: true
+
+  postgresExporter:
+    disabled: true
+
+  preciseCodeIntel:
+    disabled: true
+
+  redisCache:
+    disabled: true
+
+  redisExporter:
+    disabled: true
+
+  redisStore:
+    disabled: true
+
+  repoUpdater:
+    podTemplateConfig:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: disktype
+                operator: In
+                values:
+                - ssd
+      imagePullSecrets:
+        - name: myPrivateRegistrySecret
+      nodeSelector:
+        my-node-label: some-value
+      tolerations:
+        - key: "key1"
+          operator: "Equal"
+          value: "value1"
+          effect: "NoSchedule"
+
+  searcher:
+    disabled: true
+
+  symbols:
+    disabled: true
+
+  syntectServer:
+    disabled: true
+
+  worker:
+    disabled: true

--- a/internal/k8s/resource/pod/BUILD.bazel
+++ b/internal/k8s/resource/pod/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/sourcegraph/sourcegraph/internal/k8s/resource/pod",
     visibility = ["//:__subpackages__"],
     deps = [
+        "//internal/appliance/config",
         "//lib/pointers",
         "@io_k8s_api//core/v1:core",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:meta",

--- a/internal/k8s/resource/pod/pod.go
+++ b/internal/k8s/resource/pod/pod.go
@@ -4,12 +4,13 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/sourcegraph/sourcegraph/internal/appliance/config"
 	"github.com/sourcegraph/sourcegraph/lib/pointers"
 )
 
 // NewPodTemplate creates a new k8s PodTemplate with some default values set.
-func NewPodTemplate(name string) corev1.PodTemplate {
-	return corev1.PodTemplate{
+func NewPodTemplate(name string, cfg config.StandardComponent) corev1.PodTemplate {
+	template := corev1.PodTemplate{
 		Template: corev1.PodTemplateSpec{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: name,
@@ -31,6 +32,15 @@ func NewPodTemplate(name string) corev1.PodTemplate {
 			},
 		},
 	}
+
+	if cfg != nil {
+		template.Template.Spec.Affinity = cfg.GetPodTemplateConfig().Affinity
+		template.Template.Spec.ImagePullSecrets = cfg.GetPodTemplateConfig().ImagePullSecrets
+		template.Template.Spec.NodeSelector = cfg.GetPodTemplateConfig().NodeSelector
+		template.Template.Spec.Tolerations = cfg.GetPodTemplateConfig().Tolerations
+	}
+
+	return template
 }
 
 func NewVolumeEmptyDir(name string) corev1.Volume {


### PR DESCRIPTION
User deployments may need to set image pull secrets for private
registries, and/or node selectors/tolerations/affinities for use with
custom node pools. These are supported for all services in the helm
chart. Embed this in standard config so that all services get this for
free.

This is part of a stack, needs rebase when base branch merges.


## Test plan

Golden tests included.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
