### PR TITLE
Svelte: Search result code line height adjustment

### DIFF
--- a/client/web-sveltekit/src/lib/CodeExcerpt.svelte
+++ b/client/web-sveltekit/src/lib/CodeExcerpt.svelte
@@ -81,7 +81,7 @@
 
         font-family: var(--code-font-family);
         font-size: var(--code-font-size);
-        line-height: 1.2rem;
+        line-height: 1.1rem;
         white-space: pre;
 
         :global(td.line::before) {


### PR DESCRIPTION
Extremely minor adjustment to the line-height of the code excerpt on search results.

Got a little overzealous with the last update, reducing it now.


## Test plan
Manually tested locally.