### PR TITLE
Svelte: simplify file header

### DIFF
--- a/client/web-sveltekit/src/lib/shared.ts
+++ b/client/web-sveltekit/src/lib/shared.ts
@@ -92,11 +92,3 @@ export function displayRepoName(repoName: string): string {
     }
     return parts.join('/')
 }
-
-/**
- * Splits the repository name into the dir and base components.
- */
-export function splitPath(path: string): [string, string] {
-    const components = path.split('/')
-    return [components.slice(0, -1).join('/'), components.at(-1) ?? '']
-}

--- a/client/web-sveltekit/src/routes/search/FileSearchResultHeader.svelte
+++ b/client/web-sveltekit/src/routes/search/FileSearchResultHeader.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import { highlightRanges } from '$lib/dom'
-    import { splitPath, getFileMatchUrl, type ContentMatch, type PathMatch, type SymbolMatch } from '$lib/shared'
+    import { getFileMatchUrl, type ContentMatch, type PathMatch, type SymbolMatch } from '$lib/shared'
 
     import CopyPathButton from './CopyPathButton.svelte'
     import RepoRev from './RepoRev.svelte'
@@ -8,7 +8,6 @@
     export let result: ContentMatch | PathMatch | SymbolMatch
 
     $: fileURL = getFileMatchUrl(result)
-    $: [fileBase, fileName] = splitPath(result.path)
     $: rev = result.branches?.[0]
 
     $: matches =
@@ -22,7 +21,7 @@
 <span class="root">
     {#key result}
         <a class="path" href={fileURL} use:highlightRanges={{ ranges: matches }}>
-            {#if fileBase}{fileBase}/{/if}<span class="file-name">{fileName}</span>
+            {result.path}
         </a>
     {/key}
     <CopyPathButton path={result.path} />


### PR DESCRIPTION
Followup from https://github.com/sourcegraph/sourcegraph/pull/62246/files#r1583375607

Now that we don't style the file name differently than the rest of the path, this component can be simplified a bit.

## Test plan

Quick manual test.
![screenshot-2024-04-30_08-15-34@2x](https://github.com/sourcegraph/sourcegraph/assets/12631702/144b9e5e-fca0-4ae3-9bce-c80b0ccf9ab1)

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
