### PR TITLE
svelte: Add infinity scroll and search to all branches page.

### DIFF
--- a/client/web-sveltekit/src/lib/Scroller.svelte
+++ b/client/web-sveltekit/src/lib/Scroller.svelte
@@ -53,7 +53,7 @@
 </script>
 
 <div class="viewport" bind:this={viewport}>
-    <div class="scroller" bind:this={scroller} on:scroll={handleScroll}>
+    <div class="scroller" bind:this={scroller} on:scroll={handleScroll} data-scroller>
         <slot />
     </div>
 </div>

--- a/client/web-sveltekit/src/lib/repo/GitReference.svelte
+++ b/client/web-sveltekit/src/lib/repo/GitReference.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
-    import Timestamp from '$lib/Timestamp.svelte'
     import { numberWithCommas } from '$lib/common'
+    import Timestamp from '$lib/Timestamp.svelte'
+    import { Badge } from '$lib/wildcard'
+
     import type { GitReference_Ref } from './GitReference.gql'
 
     export let ref: GitReference_Ref
@@ -13,19 +15,26 @@
 
 <tr>
     <td>
-        <a href={ref.url}><span class="ref px-1 py-0">{ref.displayName}</span></a>
+        <Badge variant="link"><a href={ref.url}>{ref.displayName}</a></Badge>
     </td>
     <td colspan={behind || ahead ? 1 : 2}>
         <a href={ref.url}>
             <small
-                >Updated {#if authorDate}<Timestamp date={authorDate} strict />{/if} by {authorName}</small
+                >Updated {#if authorDate}<span><Timestamp date={authorDate} strict /></span>{/if}
+                <span
+                    >by
+                    {authorName}</span
+                ></small
             ></a
         >
     </td>
     {#if ahead || behind}
         <td class="diff">
             <a href={ref.url}
-                ><small>{numberWithCommas(behind ?? 0)} behind, {numberWithCommas(ahead ?? 0)} ahead</small></a
+                ><small
+                    ><span>{numberWithCommas(behind ?? 0)} behind,</span>
+                    <span>{numberWithCommas(ahead ?? 0)} ahead</span></small
+                ></a
             >
         </td>
     {/if}
@@ -41,9 +50,8 @@
         border: none;
     }
 
-    .ref {
-        background-color: var(--subtle-bg);
-        border-radius: var(--border-radius);
+    span {
+        white-space: nowrap;
     }
 
     a {

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/-/branches/+layout.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/-/branches/+layout.svelte
@@ -9,39 +9,38 @@
 </script>
 
 <section>
-    <div>
-        <ul class="mb-3">
-            <li class:active={subpage === 'overview'}><a href="{data.repoURL}/-/branches">Overview</a></li>
-            <li class:active={subpage === 'all'}><a href="{data.repoURL}/-/branches/all">All branches</a></li>
-        </ul>
-        <slot />
-    </div>
+    <ul>
+        <li class:active={subpage === 'overview'}><a href="{data.repoURL}/-/branches">Overview</a></li>
+        <li class:active={subpage === 'all'}><a href="{data.repoURL}/-/branches/all">All branches</a></li>
+    </ul>
+    <slot />
 </section>
 
 <style lang="scss">
-    ul {
-        margin: 0;
-        padding: 0;
-        list-style: none;
+    section {
         display: flex;
+        flex-direction: column;
+        height: 100%;
+        overflow: hidden;
+    }
+
+    ul {
+        align-self: center;
+        max-width: var(--viewport-xl);
+        width: 100%;
+
+        padding: 1rem;
+        margin: 0;
+
+        display: flex;
+        gap: 1rem;
+
+        list-style: none;
 
         li {
-            margin-right: 1rem;
-
             &.active {
                 font-weight: bold;
             }
         }
-    }
-
-    section {
-        overflow: auto;
-        margin-top: 2rem;
-    }
-
-    div {
-        max-width: 54rem;
-        margin-left: auto;
-        margin-right: auto;
     }
 </style>

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/-/branches/+page.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/-/branches/+page.svelte
@@ -12,38 +12,54 @@
     <title>Branches - {data.displayRepoName} - Sourcegraph</title>
 </svelte:head>
 
-{#await data.overview}
-    <LoadingSpinner />
-{:then result}
-    {@const activeBranches = result.branches.nodes.filter(branch => branch.id !== result.defaultBranch?.id)}
+<section>
+    <div>
+        {#await data.overview}
+            <LoadingSpinner />
+        {:then result}
+            {@const activeBranches = result.branches.nodes.filter(branch => branch.id !== result.defaultBranch?.id)}
 
-    {#if result.defaultBranch}
-        <table class="mb-3">
-            <thead><tr><th colspan="3">Default branch</th></tr></thead>
-            <tbody>
-                <GitReference ref={result.defaultBranch} />
-            </tbody>
-        </table>
-    {/if}
+            {#if result.defaultBranch}
+                <table class="mb-3">
+                    <thead><tr><th colspan="3">Default branch</th></tr></thead>
+                    <tbody>
+                        <GitReference ref={result.defaultBranch} />
+                    </tbody>
+                </table>
+            {/if}
 
-    {#if activeBranches.length > 0}
-        <table>
-            <thead><tr><th colspan="3">Active branches</th></tr></thead>
-            <tbody>
-                {#each activeBranches as branch (branch.id)}
-                    <GitReference ref={branch} />
-                {/each}
-            </tbody>
-        </table>
-    {/if}
-{:catch error}
-    <Alert variant="danger">
-        Unable to fetch branches:
-        {error.message}
-    </Alert>
-{/await}
+            {#if activeBranches.length > 0}
+                <table>
+                    <thead><tr><th colspan="3">Active branches</th></tr></thead>
+                    <tbody>
+                        {#each activeBranches as branch (branch.id)}
+                            <GitReference ref={branch} />
+                        {/each}
+                    </tbody>
+                </table>
+            {/if}
+        {:catch error}
+            <Alert variant="danger">
+                Unable to fetch branches:
+                {error.message}
+            </Alert>
+        {/await}
+    </div>
+</section>
 
 <style lang="scss">
+    section {
+        overflow: auto;
+    }
+
+    div {
+        max-width: var(--viewport-xl);
+        width: 100%;
+        margin: 0 auto;
+
+        padding: 1rem;
+    }
+
     table {
         width: 100%;
         border: 1px solid var(--border-color-2);

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/-/branches/all/+page.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/-/branches/all/+page.svelte
@@ -23,7 +23,7 @@
         async restore(snapshot) {
             if (snapshot?.count && get(navigating)?.type === 'popstate') {
                 await branchesQuery?.restore(result => {
-                    const count = result.data?.repository?.gitRefs?.nodes?.length
+                    const count = result.data?.repository?.branches?.nodes?.length
                     return !!count && count < snapshot.count
                 })
             }

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/-/branches/all/+page.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/-/branches/all/+page.svelte
@@ -94,6 +94,11 @@
         flex-direction: column;
         height: 100%;
         overflow: hidden;
+
+        :global([data-scroller]) {
+            display: flex;
+            flex-direction: column;
+        }
     }
 
     form {

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/-/branches/all/+page.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/-/branches/all/+page.svelte
@@ -1,40 +1,131 @@
 <script lang="ts">
+    import { get } from 'svelte/store'
+
+    import { navigating } from '$app/stores'
+    import { pluralize } from '$lib/common'
     import LoadingSpinner from '$lib/LoadingSpinner.svelte'
     import GitReference from '$lib/repo/GitReference.svelte'
+    import Scroller, { type Capture as ScrollerCapture } from '$lib/Scroller.svelte'
+    import { Alert, Button, Input } from '$lib/wildcard'
+    import type { GitBranchesConnection } from '$testing/graphql-type-mocks'
 
-    import type { PageData } from './$types'
-    import { Alert } from '$lib/wildcard'
+    import type { PageData, Snapshot } from './$types'
 
     export let data: PageData
+
+    export const snapshot: Snapshot<{ count: number; scroller: ScrollerCapture }> = {
+        capture() {
+            return {
+                count: branchesConnection?.nodes.length ?? 0,
+                scroller: scroller.capture(),
+            }
+        },
+        async restore(snapshot) {
+            if (snapshot?.count && get(navigating)?.type === 'popstate') {
+                await branchesQuery?.restore(result => {
+                    const count = result.data?.repository?.gitRefs?.nodes?.length
+                    return !!count && count < snapshot.count
+                })
+            }
+            scroller.restore(snapshot.scroller)
+        },
+    }
+
+    let scroller: Scroller
+    let branchesConnection: GitBranchesConnection | undefined
+
+    $: query = data.query
+    $: branchesQuery = data.branchesQuery
+    $: branchesConnection = $branchesQuery.data?.repository?.branches ?? branchesConnection
+    $: if (branchesQuery) {
+        branchesConnection = undefined
+    }
 </script>
 
 <svelte:head>
     <title>All branches - {data.displayRepoName} - Sourcegraph</title>
 </svelte:head>
 
-{#await data.branches}
-    <LoadingSpinner />
-{:then branches}
-    <!-- TODO: Search input to filter branches by name -->
-    <!-- TODO: Pagination -->
-    <table>
-        <tbody>
-            {#each branches.nodes as node (node.id)}
-                <GitReference ref={node} />
-            {/each}
-        </tbody>
-    </table>
-    <small class="text-muted">{branches.totalCount} branches total</small>
-{:catch error}
-    <Alert variant="danger">
-        Unable to fetch branches information:
-        {error.message}
-    </Alert>
-{/await}
+<section>
+    <form method="GET">
+        <Input type="search" name="query" placeholder="Search branches" value={query} autofocus />
+        <Button variant="primary" type="submit">Search</Button>
+    </form>
+    <Scroller bind:this={scroller} margin={600} on:more={branchesQuery.fetchMore}>
+        {#if !$branchesQuery.restoring && branchesConnection}
+            <table>
+                <tbody>
+                    {#each branchesConnection.nodes as tag (tag)}
+                        <GitReference ref={tag} />
+                    {:else}
+                        <tr>
+                            <td colspan="2">
+                                <Alert variant="info">No tags found</Alert>
+                            </td>
+                        </tr>
+                    {/each}
+                </tbody>
+            </table>
+        {/if}
+        <div>
+            {#if $branchesQuery.fetching || $branchesQuery.restoring}
+                <LoadingSpinner />
+            {:else if $branchesQuery.error}
+                <Alert variant="danger">
+                    Unable to load branches: {$branchesQuery.error.message}
+                </Alert>
+            {/if}
+        </div>
+    </Scroller>
+    {#if branchesConnection && branchesConnection.nodes.length > 0}
+        <div class="footer">
+            {branchesConnection.totalCount}
+            {pluralize('branch', branchesConnection.totalCount)} total
+            {#if branchesConnection.totalCount > branchesConnection.nodes.length}
+                (showing {branchesConnection.nodes.length})
+            {/if}
+        </div>
+    {/if}
+</section>
 
 <style lang="scss">
+    section {
+        display: flex;
+        flex-direction: column;
+        height: 100%;
+        overflow: hidden;
+    }
+
+    form {
+        display: flex;
+        gap: 1rem;
+
+        :global([data-input-container]) {
+            flex: 1;
+        }
+    }
+
+    form,
+    div,
+    :global([data-scroller]) {
+        padding: 1rem;
+    }
+
+    form,
+    div,
     table {
+        align-self: center;
+        max-width: var(--viewport-xl);
         width: 100%;
+    }
+
+    table {
         border-spacing: 0;
+    }
+
+    .footer {
+        color: var(--text-muted);
+        // Unset `div` width: 100% to allow the footer to be centered
+        width: initial;
     }
 </style>

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/-/branches/all/page.gql
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/-/branches/all/page.gql
@@ -3,10 +3,11 @@ query AllBranchesPage_BranchesQuery(
     $first: Int!
     $withBehindAhead: Boolean!
     $revspec: String = ""
+    $query: String = ""
 ) {
     repository(name: $repoName) {
         id
-        branches(first: $first) {
+        branches(first: $first, query: $query) {
             ...GitBranchesConnection
         }
     }
@@ -16,6 +17,9 @@ fragment GitBranchesConnection on GitRefConnection {
     nodes {
         id
         ...GitReference_Ref
+    }
+    pageInfo {
+        hasNextPage
     }
     totalCount
 }

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/-/tags/+page.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/-/tags/+page.svelte
@@ -53,7 +53,6 @@
     </form>
     <Scroller bind:this={scroller} margin={600} on:more={tagsQuery.fetchMore}>
         {#if !$tagsQuery.restoring && tagsConnection}
-            <!-- TODO: Search input to filter tags by name -->
             <table>
                 <tbody>
                     {#each tagsConnection.nodes as tag (tag)}
@@ -98,14 +97,8 @@
     }
 
     form {
-        align-self: stretch;
-
         display: flex;
         gap: 1rem;
-        max-width: var(--viewport-xl);
-        width: 100%;
-
-        margin: 1rem auto;
 
         :global([data-input-container]) {
             flex: 1;
@@ -113,9 +106,17 @@
     }
 
     div,
+    form,
+    :global([data-scroller]) {
+        padding: 1rem;
+    }
+
+    div,
+    form,
     table {
+        align-self: center;
         max-width: var(--viewport-xl);
-        margin: 0 auto;
+        width: 100%;
     }
 
     table {
@@ -125,6 +126,7 @@
 
     .footer {
         color: var(--text-muted);
-        padding: 1rem;
+        // Unset `div` width: 100% to allow the footer to be centered
+        width: initial;
     }
 </style>

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/-/tags/+page.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/-/tags/+page.svelte
@@ -94,6 +94,11 @@
         flex-direction: column;
         height: 100%;
         overflow: hidden;
+
+        :global([data-scroller]) {
+            display: flex;
+            flex-direction: column;
+        }
     }
 
     form {
@@ -105,14 +110,14 @@
         }
     }
 
-    div,
     form,
+    div,
     :global([data-scroller]) {
         padding: 1rem;
     }
 
-    div,
     form,
+    div,
     table {
         align-self: center;
         max-width: var(--viewport-xl);
@@ -120,7 +125,6 @@
     }
 
     table {
-        width: 100%;
         border-spacing: 0;
     }
 


### PR DESCRIPTION
Closes #61634

Similar to #62257. I copied most of the code because I assume we'll redesign those pages anyway, so there is no point spending time to make these components reusable.

I implemented it such that the content is centered and the scrollbar is at the right edge of the screen. I added some padding so that there is some space between edge and content on smaller screens (I made the same change to the tags page).

I also updated the `GitReference` component to use `Badge` instead, which also affects the tags page.

| Before | After |
|--------|--------|
| ![2024-04-30_16-12](https://github.com/sourcegraph/sourcegraph/assets/179026/80214c8c-6ae5-4cb6-b72e-652e80416f35) | ![2024-04-30_16-13](https://github.com/sourcegraph/sourcegraph/assets/179026/69a3e69a-d612-40ac-8d4f-67b994f4d443) | 

Note: the table layout is not idea, I assume we'll redesign this anyway.

## Test plan

Manual testing.

- Scrolling/loading
- Back and forth navigation restores position and data
- Search works
