### PR TITLE
Svelte: fix line numbering for highlighted search results

### DIFF
--- a/client/web-sveltekit/src/lib/CodeExcerpt.svelte
+++ b/client/web-sveltekit/src/lib/CodeExcerpt.svelte
@@ -56,7 +56,7 @@
                 <tbody>
                     {#each plaintextLines as line, index}
                         <tr>
-                            <td class="line" data-line={startLine + index} />
+                            <td class="line" data-line={startLine + index + 1} />
                             <td class="code">{line}</td>
                         </tr>
                     {/each}

--- a/client/web-sveltekit/src/routes/search/FileContentSearchResult.svelte
+++ b/client/web-sveltekit/src/routes/search/FileContentSearchResult.svelte
@@ -9,12 +9,12 @@
 <script lang="ts">
     import { mdiChevronDown, mdiChevronUp } from '@mdi/js'
 
+    import CodeExcerpt from '$lib/CodeExcerpt.svelte'
     import { pluralize, SourcegraphURL } from '$lib/common'
     import Icon from '$lib/Icon.svelte'
     import { observeIntersection } from '$lib/intersection-observer'
     import RepoStars from '$lib/repo/RepoStars.svelte'
     import { fetchFileRangeMatches } from '$lib/search/api/highlighting'
-    import CodeExcerpt from '$lib/CodeExcerpt.svelte'
     import { rankContentMatch } from '$lib/search/results'
     import { getFileMatchUrl, type ContentMatch, rankByLine, rankPassthrough } from '$lib/shared'
     import { settings } from '$lib/stores'
@@ -96,7 +96,7 @@
                     -->
                     {#await highlightedHTMLRows}
                         <CodeExcerpt
-                            startLine={group.startLine + 1}
+                            startLine={group.startLine}
                             matches={group.matches}
                             plaintextLines={group.plaintextLines}
                             --background-color="transparent"


### PR DESCRIPTION
There was a [regression](https://github.com/sourcegraph/sourcegraph/pull/62168/files#diff-8ae1a53166d42f8d47a6b4ec281c89db4cab47aa9ef6fb8db9a04af94dbc0a54L99-R99) that caused the line numbers for plaintext lines and highlighted lines to disagree, causing shifts in the highlighted ranges and the line numbers when the syntax highlighted code snippets loaded. This fixes it. 

## Test plan

Before:

https://github.com/sourcegraph/sourcegraph/assets/12631702/a2d3096c-4c11-47d7-bc03-80610ea4c611



After:

https://github.com/sourcegraph/sourcegraph/assets/12631702/f0894dc8-8715-44cb-94ef-2f6046c2f59d





<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
