### PR TITLE
Svelte: [Search results] Code excerpt hover state updated

### DIFF
--- a/client/web-sveltekit/src/routes/search/FileContentSearchResult.svelte
+++ b/client/web-sveltekit/src/routes/search/FileContentSearchResult.svelte
@@ -157,7 +157,7 @@
         }
 
         &:hover {
-            background-color: var(--subtle-bg-2);
+            background-color: var(--color-bg-2);
         }
 
         a {


### PR DESCRIPTION
# Context
Hover state for code excerpt on the search results page is too dull. This increases the contrast a bit.

## Before
![CleanShot 2024-04-30 at 17 54 54@2x](https://github.com/sourcegraph/sourcegraph/assets/5337876/34de536a-98dd-4600-91f9-acced15c81fa)

## After
![CleanShot 2024-04-30 at 17 54 36@2x](https://github.com/sourcegraph/sourcegraph/assets/5337876/d0792edd-9e36-4203-8316-bed4221ff39f)

## Test plan
Locally previewed and tested for visual change.