### PR TITLE
codeinsights: remove now useless empty repo string error check

### DIFF
--- a/internal/insights/gitserver/first_commit.go
+++ b/internal/insights/gitserver/first_commit.go
@@ -2,7 +2,6 @@ package gitserver
 
 import (
 	"context"
-	"strings"
 	"sync"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
@@ -15,16 +14,11 @@ var (
 	EmptyRepoErr = errors.New("empty repository")
 )
 
-const emptyRepoErrMessage = `git command [rev-list --reverse --date-order --max-parents=0 HEAD] failed (output: ""): exit status 129`
-
 func isFirstCommitEmptyRepoError(err error) bool {
 	if gitdomain.IsRevisionNotFoundError(err) {
 		return true
 	}
 
-	if strings.Contains(err.Error(), emptyRepoErrMessage) {
-		return true
-	}
 	unwrappedErr := errors.Unwrap(err)
 	if unwrappedErr != nil {
 		return isFirstCommitEmptyRepoError(unwrappedErr)

--- a/internal/insights/gitserver/first_commit_test.go
+++ b/internal/insights/gitserver/first_commit_test.go
@@ -18,18 +18,6 @@ func Test_IsEmptyRepoError(t *testing.T) {
 		want autogold.Value
 	}{
 		{
-			err:  errors.New(emptyRepoErrMessage),
-			want: autogold.Expect(true),
-		},
-		{
-			err:  errors.Newf("Another message: %w", errors.New(emptyRepoErrMessage)),
-			want: autogold.Expect(true),
-		},
-		{
-			err:  errors.Newf("Another message: %w", errors.Newf("Deep nested: %w", errors.New(emptyRepoErrMessage))),
-			want: autogold.Expect(true),
-		},
-		{
 			err:  errors.Newf("Another message: %w", errors.New("Not an empty repo")),
 			want: autogold.Expect(false),
 		},


### PR DESCRIPTION
https://github.com/sourcegraph/sourcegraph/pull/62165#discussion_r1584695272

## Test plan

CI