### PR TITLE
Svelte: Badge count text color updated on search results

### DIFF
--- a/client/web-sveltekit/src/lib/search/dynamicFilters/CountBadge.svelte
+++ b/client/web-sveltekit/src/lib/search/dynamicFilters/CountBadge.svelte
@@ -34,6 +34,6 @@
 <style lang="scss">
     span.count :global(span) {
         background-color: var(--secondary-2);
-        color: var(--text-muted);
+        color: var(--text-body);
     }
 </style>


### PR DESCRIPTION
# Context
Made the count badge text slightly more visible on search results filters.

## Before 
<img width="441" alt="CleanShot 2024-04-30 at 19 04 47@2x" src="https://github.com/sourcegraph/sourcegraph/assets/5337876/46d27fad-84f9-47c3-abf0-61c5eee75d1a">

## After
<img width="418" alt="CleanShot 2024-04-30 at 19 04 23@2x" src="https://github.com/sourcegraph/sourcegraph/assets/5337876/9b46a265-6d44-408e-8a64-cab2ac96ad1c">

## Test plan
Locally tested for visual change.