### PR TITLE
Svelte: Hover BG color updated on revision items in revision picker

### DIFF
--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/Picker.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/Picker.svelte
@@ -162,7 +162,7 @@
 
         &:hover,
         &[data-highlighted] {
-            background: var(--color-bg-3);
+            background: var(--color-bg-2);
         }
     }
 


### PR DESCRIPTION
Minor update that tones down the hover color on hovering revision items on the revision picker.


## Test plan
Manually checked locally for visual changes.