### PR TITLE
Svelte: Minor visual tweaks to code-blame switcher

### DIFF
--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/FileViewModeSwitcher.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/FileViewModeSwitcher.svelte
@@ -82,7 +82,6 @@
         --border-width: 1px;
 
         display: inline-flex;
-        gap: 0.25rem;
         background-color: var(--secondary-4);
         border-radius: var(--border-radius);
         align-items: center;
@@ -92,9 +91,9 @@
     [role='radio'] {
         border: var(--border-width) solid transparent;
         cursor: pointer;
-        padding: 0.25rem 0.5rem;
+        padding: 0.25rem 0.75rem;
         border-radius: var(--border-radius);
-        color: var(--text-muted);
+        color: var(--text-body);
         margin: calc(var(--border-width) * -1);
         user-select: none;
 


### PR DESCRIPTION
A few minor CSS tweaks to the code/blame view switcher.

## Before
<img width="380" alt="CleanShot 2024-04-30 at 19 44 28@2x" src="https://github.com/sourcegraph/sourcegraph/assets/5337876/e83fef3d-79ba-42e5-971a-4163153d942d">

## After
<img width="402" alt="CleanShot 2024-04-30 at 19 44 08@2x" src="https://github.com/sourcegraph/sourcegraph/assets/5337876/926cf21a-e010-4f93-9584-af24b17853df">

## Test plan
Tested locally for visual changes.