### PR TITLE
Svelte: fix icon sizing

### DIFF
--- a/client/web-sveltekit/src/lib/Icon.svelte
+++ b/client/web-sveltekit/src/lib/Icon.svelte
@@ -18,21 +18,25 @@
 
     export let svgPath: string
     export let inline: boolean = false
-    export let size: number = 24
 </script>
 
-<svg class:icon-inline={inline} height={size} width={size} viewBox="0 0 24 24" data-icon {...$$restProps}>
+<svg class:icon-inline={inline} viewBox="0 0 24 24" data-icon {...$$restProps}>
     <path d={svgPath} />
 </svg>
 
 <style lang="scss">
     :root {
         --icon-size: 1.5rem;
+        --icon-inline-size: #{(16 / 14)}em;
     }
 
     svg {
         width: var(--icon-size);
         height: var(--icon-size);
+        &.icon-inline {
+            width: var(--icon-inline-size);
+            height: var(--icon-inline-size);
+        }
         color: var(--icon-fill-color, var(--color, inherit));
         fill: currentColor;
     }

--- a/client/web-sveltekit/src/lib/Icon.svelte
+++ b/client/web-sveltekit/src/lib/Icon.svelte
@@ -25,17 +25,15 @@
 </svg>
 
 <style lang="scss">
-    :root {
-        --icon-size: 1.5rem;
-        --icon-inline-size: #{(16 / 14)}em;
-    }
+    $iconSize: var(--icon-size, 1.5rem);
+    $iconInlineSize: var(--icon-inline-size, #{(16 / 14)}em);
 
     svg {
-        width: var(--icon-size);
-        height: var(--icon-size);
+        width: $iconSize;
+        height: $iconSize;
         &.icon-inline {
-            width: var(--icon-inline-size);
-            height: var(--icon-inline-size);
+            width: $iconInlineSize;
+            height: $iconInlineSize;
         }
         color: var(--icon-fill-color, var(--color, inherit));
         fill: currentColor;

--- a/client/web-sveltekit/src/lib/repo/RepoPopover/RepoPopover.svelte
+++ b/client/web-sveltekit/src/lib/repo/RepoPopover/RepoPopover.svelte
@@ -53,7 +53,7 @@ For example:
                 </div>
             </div>
             <div class="code-host">
-                <Icon svgPath={codeHostIcon} --color="var(--text-body)" --size={24} />
+                <Icon svgPath={codeHostIcon} --color="var(--text-body)" --icon-size="24px" />
                 <div><small>{capitalize(codeHostKind)}</small></div>
             </div>
         </div>

--- a/client/web-sveltekit/src/lib/search/resultsIndicator/ResultsIndicator.svelte
+++ b/client/web-sveltekit/src/lib/search/resultsIndicator/ResultsIndicator.svelte
@@ -39,9 +39,13 @@
 <div class="indicator">
     <div>
         {#if loading}
-            <LoadingSpinner inline />
+            <LoadingSpinner --icon-size="18px" inline />
         {:else}
-            <Icon svgPath={icons[severity]} size={18} --color={isError ? 'var(--danger)' : 'var(--text-title)'} />
+            <Icon
+                svgPath={icons[severity]}
+                --icon-size="18px"
+                --color={isError ? 'var(--danger)' : 'var(--text-title)'}
+            />
         {/if}
     </div>
 
@@ -55,7 +59,7 @@
             <span>Running search...</span>
         {/if}
     </div>
-    <Icon svgPath={mdiChevronDown} size={18} --color={isError ? 'var(--danger)' : 'var(--text-title)'} />
+    <Icon svgPath={mdiChevronDown} --icon-size="18px" --color={isError ? 'var(--danger)' : 'var(--text-title)'} />
 </div>
 
 <style lang="scss">

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/FileView.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/FileView.svelte
@@ -215,7 +215,7 @@
         </Alert>
     {:else if fileNotFound}
         <div class="circle">
-            <Icon svgPath={mdiMapSearch} size={80} />
+            <Icon svgPath={mdiMapSearch} --icon-size="80px" />
         </div>
         <h2>File not found</h2>
     {:else if isBinary}

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/tree/[...path]/+page.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/tree/[...path]/+page.svelte
@@ -38,7 +38,7 @@
         {#if result === null}
             <div class="error-wrapper">
                 <div class="circle">
-                    <Icon svgPath={mdiMapSearch} size={80} />
+                    <Icon svgPath={mdiMapSearch} --icon-size="80px" />
                 </div>
                 <h2>Directory not found</h2>
             </div>

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/RepositoryRevPicker.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/RepositoryRevPicker.svelte
@@ -78,7 +78,7 @@
                         variant="secondary"
                         on:click={() => handleGoToDefaultBranch(resolvedRevision.defaultBranch)}
                     >
-                        <Icon svgPath={mdiClose} size={16} />
+                        <Icon svgPath={mdiClose} --icon-size="16px" />
                     </Button>
                 </Tooltip>
             </span>

--- a/client/web-sveltekit/src/routes/search/PreviewPanel.svelte
+++ b/client/web-sveltekit/src/routes/search/PreviewPanel.svelte
@@ -77,7 +77,7 @@
     <div class="header">
         <h3>File Preview</h3>
         <button data-testid="preview-close" on:click={() => searchResultContext.setPreview(null)}>
-            <Icon svgPath={mdiClose} class="close-icon" size={16} inline />
+            <Icon svgPath={mdiClose} class="close-icon" --icon-size="16px" inline />
         </button>
     </div>
     <div class="file-link">


### PR DESCRIPTION
This fixes an issue with the sizing of the `Icon` component. There was a `size` prop, but it wasn't actually being respected. Additionally, it stops relying on the global `.icon-inline` class.

This changes the `Icon` component to use only CSS variables to set its size. By default, it uses the `--icon-size` variable. If in `inline` mode, it uses the `--icon-inline-size` variable. 

## Test plan

Before:
![screenshot-2024-04-30_14-55-40@2x](https://github.com/sourcegraph/sourcegraph/assets/12631702/ff6d28d3-7238-45b6-9efb-3c5d5fb0bb33)

After:
![screenshot-2024-04-30_14-56-19@2x](https://github.com/sourcegraph/sourcegraph/assets/12631702/e17fbc39-4379-4f33-aa06-fb5766151926)


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
