### PR TITLE
sg/msp: add service lists to help text, improve completions

### DIFF
--- a/dev/sg/msp/BUILD.bazel
+++ b/dev/sg/msp/BUILD.bazel
@@ -28,7 +28,6 @@ go_library(
         "//dev/sg/msp/example",
         "//dev/sg/msp/repo",
         "//dev/sg/msp/schema",
-        "//lib/cliutil/completions",
         "//lib/errors",
         "//lib/output",
         "//lib/pointers",

--- a/dev/sg/msp/helpers.go
+++ b/dev/sg/msp/helpers.go
@@ -355,7 +355,7 @@ func generateCloudDeployDocstring(projectID, serviceID, gcpRegion, cloudDeployFi
 		projectID, serviceID, gcpRegion, cloudDeployFilename)
 }
 
-func CollectAlertPolicies(svc *spec.Spec) (map[string]terraform.AlertPolicy, error) {
+func collectAlertPolicies(svc *spec.Spec) (map[string]terraform.AlertPolicy, error) {
 	// Deduplicate alerts across environments into a single map
 	collectedAlerts := make(map[string]terraform.AlertPolicy)
 	for _, env := range svc.ListEnvironmentIDs() {

--- a/dev/sg/msp/sg_msp.go
+++ b/dev/sg/msp/sg_msp.go
@@ -31,7 +31,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/dev/sg/msp/example"
 	msprepo "github.com/sourcegraph/sourcegraph/dev/sg/msp/repo"
 	"github.com/sourcegraph/sourcegraph/dev/sg/msp/schema"
-	"github.com/sourcegraph/sourcegraph/lib/cliutil/completions"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 	"github.com/sourcegraph/sourcegraph/lib/pointers"
 )
@@ -41,19 +40,13 @@ import (
 var Command = &cli.Command{
 	Name:    "managed-services-platform",
 	Aliases: []string{"msp"},
-	Usage:   "EXPERIMENTAL: Generate and manage services deployed on the Sourcegraph Managed Services Platform",
-	Description: `WARNING: MSP is currently still an experimental project.
-To learm more, refer to go/rfc-msp and go/msp (https://handbook.sourcegraph.com/departments/engineering/teams/core-services/managed-services/platform)`,
-	UsageText: `
-# Create a service specification
-sg msp init $SERVICE
+	Usage:   "Generate and manage services deployed on the Sourcegraph Managed Services Platform (MSP)",
+	Description: `To learm more about MSP, refer to go/msp (https://sourcegraph.notion.site/712a0389f54c4d3a90d069aa2d979a59).
 
-# Provision Terraform Cloud workspaces
-sg msp tfc sync $SERVICE $ENVIRONMENT
+MSP infrastructure manifests are managed in https://github.com/sourcegraph/managed-services - many commands expect you to be operating within a local copy of this repository.
+Refer to https://github.com/sourcegraph/managed-services/blob/main/README.md#tooling-setup for more information.
 
-# Generate Terraform manifests
-sg msp generate $SERVICE $ENVIRONMENT
-`,
+Please reach out to #discuss-core-services for assistance if you have any questions!`,
 	Category: category.Company,
 	Subcommands: []*cli.Command{
 		{
@@ -198,6 +191,10 @@ sg msp init -owner core-services -name "MSP Example Service" msp-example
 			Name:      "init-env",
 			ArgsUsage: "<service ID> <env ID>",
 			Usage:     "Add an environment to an existing Managed Services Platform service",
+			Description: fmt.Sprintf(`Templates a new environment to be added to an existing Managed Services Platform service.
+If your service does not exist yet, use 'sg msp init' to get started.
+
+%s`, msprepo.DescribeServicesOptions()),
 			Flags: []cli.Flag{
 				&cli.IntFlag{
 					Name:  "project-id-suffix-length",
@@ -205,11 +202,8 @@ sg msp init -owner core-services -name "MSP Example Service" msp-example
 					Value: spec.DefaultSuffixLength,
 				},
 			},
-			Before: msprepo.UseManagedServicesRepo,
-			BashComplete: completions.CompleteArgs(func() (options []string) {
-				ss, _ := msprepo.ListServices()
-				return ss
-			}),
+			Before:       msprepo.UseManagedServicesRepo,
+			BashComplete: msprepo.ServicesCompletions(),
 			Action: func(c *cli.Context) error {
 				svc, err := useServiceArgument(c, false) // we're expecting a potential second argument
 				if err != nil {
@@ -265,11 +259,13 @@ sg msp init -owner core-services -name "MSP Example Service" msp-example
 		{
 			Name:      "generate",
 			Aliases:   []string{"gen"},
-			ArgsUsage: "<service ID>",
+			ArgsUsage: "<service ID> <env ID>",
 			Usage:     "Generate Terraform assets for a Managed Services Platform service spec",
-			Description: `Optionally use '-all' to sync all environments for a service.
+			Description: fmt.Sprintf(`Optionally use '-all' to sync all environments for a service.
 
-Supports completions on services and environments.`,
+This command supports completions on services and environments.
+
+%s`, msprepo.DescribeServicesOptions()),
 			UsageText: `
 # generate single env for a single service
 sg msp generate <service> <env>
@@ -379,14 +375,18 @@ sg msp generate -all -category=test
 			},
 		},
 		{
-			Name:    "operations",
-			Aliases: []string{"ops"},
-			Usage:   "Generate operational reference for a service",
-			Before:  msprepo.UseManagedServicesRepo,
-			BashComplete: completions.CompleteArgs(func() (options []string) {
-				ss, _ := msprepo.ListServices()
-				return ss
-			}),
+			Name:      "operations",
+			Aliases:   []string{"ops"},
+			Usage:     "Generate operational reference for a service",
+			ArgsUsage: `<service ID>`,
+			UsageText: "sg msp ops [command options] <service ID>",
+			Description: fmt.Sprintf(`Directly view operational reference documentation for a service - also available in go/msp-ops.
+
+This command supports completions on services and environments.
+
+%s`, msprepo.DescribeServicesOptions()),
+			Before:       msprepo.UseManagedServicesRepo,
+			BashComplete: msprepo.ServicesCompletions(),
 			Flags: []cli.Flag{
 				&cli.BoolFlag{
 					Name:  "pretty",
@@ -405,7 +405,7 @@ sg msp generate -all -category=test
 					return errors.Wrap(err, "msprepo.GitRevision")
 				}
 
-				collectedAlerts, err := CollectAlertPolicies(svc)
+				collectedAlerts, err := collectAlertPolicies(svc)
 				if err != nil {
 					return errors.Wrap(err, "CollectAlertPolicies")
 				}
@@ -487,7 +487,7 @@ The '-handbook-path' flag can also be used to specify where sourcegraph/handbook
 								return errors.Wrapf(err, "load service %q", s)
 							}
 							serviceSpecs = append(serviceSpecs, svc)
-							collectedAlerts, err := CollectAlertPolicies(svc)
+							collectedAlerts, err := collectAlertPolicies(svc)
 							opts.AlertPolicies = collectedAlerts
 							if err != nil {
 								return errors.Wrapf(err, "%s: CollectAlertPolicies", s)
@@ -520,8 +520,14 @@ The '-handbook-path' flag can also be used to specify where sourcegraph/handbook
 			},
 		},
 		{
-			Name:   "logs",
-			Usage:  "Quick links for logs of various MSP components",
+			Name:      "logs",
+			Usage:     "Quick links for logs of various MSP components",
+			ArgsUsage: "<service ID> <environment ID>",
+			Description: fmt.Sprintf(`View logs of various MSP infrastructure components for a specified service environment and component.
+
+This command supports completions on services and environments.
+
+%s`, msprepo.DescribeServicesOptions()),
 			Before: msprepo.UseManagedServicesRepo,
 			Flags: []cli.Flag{
 				&cli.StringFlag{
@@ -556,7 +562,7 @@ The '-handbook-path' flag can also be used to specify where sourcegraph/handbook
 				{
 					Name:  "connect",
 					Usage: "Connect to the PostgreSQL instance",
-					Description: `
+					Description: fmt.Sprintf(`
 This command runs 'cloud-sql-proxy' authenticated against the specified MSP
 service environment, and provides 'psql' commands for interacting with the
 database through the proxy.
@@ -566,7 +572,12 @@ install 'cloud-sql-proxy'.
 
 By default, you will only have 'SELECT' privileges through the connection - for
 full access, use the '-write-access' flag.
-`,
+
+You may need Entitle grants to use this command - see go/msp-ops for more details.
+
+This command supports completions on services and environments.
+
+%s`, msprepo.DescribeServicesOptions()),
 					ArgsUsage: "<service ID> <environment ID>",
 					Flags: []cli.Flag{
 						&cli.IntFlag{
@@ -679,9 +690,15 @@ full access, use the '-write-access' flag.
 			Before:  msprepo.UseManagedServicesRepo,
 			Subcommands: []*cli.Command{
 				{
-					Name:        "view",
-					Usage:       "View MSP Terraform Cloud workspaces",
-					Description: "You may need to request access to the workspaces - see https://handbook.sourcegraph.com/departments/engineering/teams/core-services/managed-services/platform/#terraform-cloud",
+					Name:  "view",
+					Usage: "View MSP Terraform Cloud workspaces",
+					Description: fmt.Sprintf(`View Terraform Cloud workspaces for a given service or service environment.
+
+You may need to request access to the workspaces via Entitle - refer to go/msp-ops for more details.
+
+This command supports completions on services and environments.
+
+%s`, msprepo.DescribeServicesOptions()),
 					UsageText: `
 # View all workspaces for all MSP services
 sg msp tfc view
@@ -723,9 +740,11 @@ sg msp tfc view <service> <environment>
 				{
 					Name:  "sync",
 					Usage: "Create or update all required Terraform Cloud workspaces for an environment",
-					Description: `Optionally use '-all' to sync all environments for a service.
+					Description: fmt.Sprintf(`Optionally use '-all' to sync all environments for a service.
 
-Supports completions on services and environments.`,
+This command supports completions on services and environments.
+
+%s`, msprepo.DescribeServicesOptions()),
 					ArgsUsage: "<service ID> [environment ID]",
 					Flags: []cli.Flag{
 						&cli.BoolFlag{


### PR DESCRIPTION
Despite recent efforts to surface service options in `sg msp` commands better, such as https://github.com/sourcegraph/sourcegraph/pull/61620, it seems "what is a service argument" remains a point of confusion. It's not helped that some of the command help texts are not super helpful.

This change:

1. Adds explicit lists of available services in help text when we can get it
2. Improves service ID completion so that it works in any subdirectory in the managed-services repo

## Test plan

```sh
Projects/sourcegraph/managed-services » cd services
sourcegraph/managed-services/services » sg msp ops -h
NAME:
   sg managed-services-platform operations - Generate operational reference for a service

USAGE:
   sg msp ops [command options] <service ID>

DESCRIPTION:
   Directly view operational reference documentation for a service - also available in go/msp-ops.

   Available services:
   - build-tracker
   - cloud-ops
   - cloud-relay
   - cody-analytics
   - entitler
   - gatekeeper
   - msp-testbed
   - pings
   - releaseregistry
   - sams
   - sourcegraph-accounts
   - support-integration
   - telemetry-gateway

COMMANDS:
   help, h  Shows a list of commands or help for one command

OPTIONS:
   --pretty    Render syntax-highlighed Markdown (default: true)
   --help, -h  show help
sourcegraph/managed-services/services » sg msp ops # <tab>
help  h  -- Shows a list of commands or help for one command                                                                            
build-tracker         cody-analytics        msp-testbed           sams                  telemetry-gateway                         
cloud-ops             entitler              pings                 sourcegraph-accounts                                          
cloud-relay           gatekeeper            releaseregistry       support-integration      
```