### PR TITLE
Svelte: compress progress indicator

### DIFF
--- a/client/web-sveltekit/src/lib/LoadingSpinner.svelte
+++ b/client/web-sveltekit/src/lib/LoadingSpinner.svelte
@@ -8,8 +8,6 @@
 </div>
 
 <style lang="scss">
-    $size: var(--size, 1rem);
-
     .center {
         display: flex;
         flex-direction: column;
@@ -28,12 +26,11 @@
             --loading-spinner-inner-color: var(--white);
         }
 
-        width: $size;
-        height: $size;
+        width: var(--size, 1rem);
+        height: var(--size, 1rem);
         &.inline {
-            $inlineSize: #{(16 / 14)}em;
-            width: $inlineSize;
-            height: $inlineSize;
+            width: #{(16 / 14)}em;
+            height: #{(16 / 14)}em;
 
             vertical-align: bottom;
             display: inline-flex;

--- a/client/web-sveltekit/src/lib/LoadingSpinner.svelte
+++ b/client/web-sveltekit/src/lib/LoadingSpinner.svelte
@@ -4,10 +4,12 @@
 </script>
 
 <div class:center>
-    <div class="loading-spinner" class:icon-inline={inline} aria-label="loading" aria-live="polite" />
+    <div class="loading-spinner" class:inline aria-label="loading" aria-live="polite" />
 </div>
 
 <style lang="scss">
+    $size: var(--size, 1rem);
+
     .center {
         display: flex;
         flex-direction: column;
@@ -26,9 +28,18 @@
             --loading-spinner-inner-color: var(--white);
         }
 
-        margin: 0.125rem;
-        width: 1rem;
-        height: 1rem;
+        width: $size;
+        height: $size;
+        &.inline {
+            $inlineSize: #{(16 / 14)}em;
+            width: $inlineSize;
+            height: $inlineSize;
+
+            vertical-align: bottom;
+            display: inline-flex;
+            align-items: center;
+        }
+
         border-radius: 50%;
         animation: loading-spinner-spin 1s linear infinite;
         border: 2px solid var(--loading-spinner-outer-color, rgba(0, 0, 0, 0.3));

--- a/client/web-sveltekit/src/lib/search/resultsIndicator/ResultsIndicator.svelte
+++ b/client/web-sveltekit/src/lib/search/resultsIndicator/ResultsIndicator.svelte
@@ -37,17 +37,11 @@
 </script>
 
 <div class="indicator">
-    <div>
-        {#if loading}
-            <LoadingSpinner --icon-size="18px" inline />
-        {:else}
-            <Icon
-                svgPath={icons[severity]}
-                --icon-size="18px"
-                --color={isError ? 'var(--danger)' : 'var(--text-title)'}
-            />
-        {/if}
-    </div>
+    {#if loading}
+        <LoadingSpinner --size="16px" />
+    {:else}
+        <Icon svgPath={icons[severity]} --icon-size="16px" --color={isError ? 'var(--danger)' : 'var(--text-title)'} />
+    {/if}
 
     <div class="messages">
         <ProgressMessage {state} {progress} {severity} />
@@ -59,25 +53,25 @@
             <span>Running search...</span>
         {/if}
     </div>
-    <Icon svgPath={mdiChevronDown} --icon-size="18px" --color={isError ? 'var(--danger)' : 'var(--text-title)'} />
+
+    <Icon svgPath={mdiChevronDown} --icon-size="12px" --color={isError ? 'var(--danger)' : 'var(--text-title)'} />
 </div>
 
 <style lang="scss">
     .indicator {
         display: flex;
         flex-flow: row nowrap;
-        justify-content: space-evenly;
+        justify-content: space-between;
         align-items: center;
-        gap: 0.5rem;
-        min-width: 200px;
-        max-width: fit-content;
+        gap: 0.75rem;
+        padding: 0.375rem 0.75rem;
 
         .messages {
             display: flex;
             flex-flow: column nowrap;
             justify-content: center;
             align-items: flex-start;
-            row-gap: 0.25rem;
+            row-gap: 0.125rem;
         }
 
         span {

--- a/client/web-sveltekit/src/lib/search/resultsIndicator/ResultsIndicator.svelte
+++ b/client/web-sveltekit/src/lib/search/resultsIndicator/ResultsIndicator.svelte
@@ -72,15 +72,11 @@
         min-width: 200px;
         max-width: fit-content;
 
-        padding: 0.25rem;
-
         .messages {
             display: flex;
             flex-flow: column nowrap;
             justify-content: center;
             align-items: flex-start;
-            margin-right: 0.75rem;
-            margin-left: 0.5rem;
             row-gap: 0.25rem;
         }
 

--- a/client/web-sveltekit/src/routes/search/SearchResults.svelte
+++ b/client/web-sveltekit/src/routes/search/SearchResults.svelte
@@ -21,11 +21,15 @@
 
     import { beforeNavigate, goto } from '$app/navigation'
     import { limitHit } from '$lib/branded'
+    import Icon from '$lib/Icon.svelte'
     import { observeIntersection } from '$lib/intersection-observer'
+    import GlobalHeaderPortal from '$lib/navigation/GlobalHeaderPortal.svelte'
     import type { URLQueryFilter } from '$lib/search/dynamicFilters'
+    import DynamicFiltersSidebar from '$lib/search/dynamicFilters/Sidebar.svelte'
     import { createRecentSearchesStore } from '$lib/search/input/recentSearches'
+    import SearchInput from '$lib/search/input/SearchInput.svelte'
     import { getQueryURL, type QueryStateStore } from '$lib/search/state'
-    import { SVELTE_LOGGER, SVELTE_TELEMETRY_EVENTS, codeCopiedEvent } from '$lib/telemetry'
+    import type { QueryState } from '$lib/search/state'
     import {
         type AggregateStreamingSearchResults,
         type PathMatch,
@@ -33,14 +37,10 @@
         type SymbolMatch,
         type ContentMatch,
     } from '$lib/shared'
-    import type { QueryState } from '$lib/search/state'
-    import Icon from '$lib/Icon.svelte'
+    import { SVELTE_LOGGER, SVELTE_TELEMETRY_EVENTS, codeCopiedEvent } from '$lib/telemetry'
     import Panel from '$lib/wildcard/resizable-panel/Panel.svelte'
     import PanelGroup from '$lib/wildcard/resizable-panel/PanelGroup.svelte'
     import PanelResizeHandle from '$lib/wildcard/resizable-panel/PanelResizeHandle.svelte'
-    import SearchInput from '$lib/search/input/SearchInput.svelte'
-    import DynamicFiltersSidebar from '$lib/search/dynamicFilters/Sidebar.svelte'
-    import GlobalHeaderPortal from '$lib/navigation/GlobalHeaderPortal.svelte'
 
     import PreviewPanel from './PreviewPanel.svelte'
     import SearchAlert from './SearchAlert.svelte'
@@ -238,8 +238,7 @@
 
         .actions {
             border-bottom: 1px solid var(--border-color);
-            padding: 0.5rem 0;
-            padding-left: 0.25rem;
+            padding: 0.5rem;
             display: flex;
             align-items: center;
             flex-shrink: 0;

--- a/client/web-sveltekit/src/routes/search/StreamingProgress.svelte
+++ b/client/web-sveltekit/src/routes/search/StreamingProgress.svelte
@@ -163,7 +163,6 @@
     .progress-button {
         border: 1px solid var(--border-color-2);
         border-radius: 4px;
-        margin-left: 0.3rem;
     }
 
     .streaming-popover {

--- a/client/web-sveltekit/src/routes/search/StreamingProgress.svelte
+++ b/client/web-sveltekit/src/routes/search/StreamingProgress.svelte
@@ -163,6 +163,7 @@
     .progress-button {
         border: 1px solid var(--border-color-2);
         border-radius: 4px;
+        padding: 0;
     }
 
     .streaming-popover {


### PR DESCRIPTION
This removes some extra padding from the progress indicator and also simplifies some of the padding so it's symmetrical and doesn't rely on adding padding together to get the right layout. 

## Test plan

Before: 
![screenshot-2024-04-30_16-58-19@2x](https://github.com/sourcegraph/sourcegraph/assets/12631702/d281e99e-686e-4924-b218-68a642d34e14)




After: 
![screenshot-2024-04-30_16-58-03@2x](https://github.com/sourcegraph/sourcegraph/assets/12631702/47e08d4c-da76-4dac-8da3-6f9ae43ccadb)


