### PR TITLE
embeddings: Use default InternalDoer

### DIFF
--- a/internal/embeddings/client.go
+++ b/internal/embeddings/client.go
@@ -25,16 +25,8 @@ func defaultEndpoints() *endpoint.Map {
 	})
 }
 
-var defaultDoer = func() httpcli.Doer {
-	d, err := httpcli.NewInternalClientFactory("embeddings").Doer()
-	if err != nil {
-		panic(err)
-	}
-	return d
-}()
-
 func NewDefaultClient() Client {
-	return NewClient(defaultEndpoints(), defaultDoer)
+	return NewClient(defaultEndpoints(), httpcli.InternalDoer)
 }
 
 func NewClient(endpoints *endpoint.Map, doer httpcli.Doer) Client {


### PR DESCRIPTION
We don't really use embeddings right now and this lets me encapsulate the factory better in the next PR, as this is the only external caller of NewInternalClientFactory.

Test plan:

CI still passes.