### PR TITLE
httpcli: Unexport internal client factory

### DIFF
--- a/internal/httpcli/client.go
+++ b/internal/httpcli/client.go
@@ -209,9 +209,9 @@ var ExternalClient, _ = ExternalClientFactory.Client()
 // WARN: This client does not cache responses. To cache responses see ExternalClient instead.
 var UncachedExternalClient, _ = UncachedExternalClientFactory.Client()
 
-// InternalClientFactory is a httpcli.Factory with common options
+// internalClientFactory is a httpcli.Factory with common options
 // and middleware pre-set for communicating with internal services.
-var InternalClientFactory = NewInternalClientFactory("internal")
+var internalClientFactory = newInternalClientFactory("internal")
 
 var (
 	internalTimeout, _               = time.ParseDuration(env.Get("SRC_HTTP_CLI_INTERNAL_TIMEOUT", "0", "Timeout for internal HTTP requests"))
@@ -221,10 +221,10 @@ var (
 	internalRetryAfterMaxDuration, _ = time.ParseDuration(env.Get("SRC_HTTP_CLI_INTERNAL_RETRY_AFTER_MAX_DURATION", "3s", "Max duration to wait in retry-after header before we won't auto-retry"))
 )
 
-// NewInternalClientFactory returns a httpcli.Factory with common options
+// newInternalClientFactory returns a httpcli.Factory with common options
 // and middleware pre-set for communicating with internal services. Additional
 // middleware can also be provided to e.g. enable logging with NewLoggingMiddleware.
-func NewInternalClientFactory(subsystem string, middleware ...Middleware) *Factory {
+func newInternalClientFactory(subsystem string, middleware ...Middleware) *Factory {
 	mw := []Middleware{
 		ContextErrorMiddleware,
 	}
@@ -248,11 +248,11 @@ func NewInternalClientFactory(subsystem string, middleware ...Middleware) *Facto
 
 // InternalDoer is a shared client for internal communication. This is a
 // convenience for existing uses of http.DefaultClient.
-var InternalDoer, _ = InternalClientFactory.Doer()
+var InternalDoer, _ = internalClientFactory.Doer()
 
 // InternalClient returns a shared client for internal communication. This is
 // a convenience for existing uses of http.DefaultClient.
-var InternalClient, _ = InternalClientFactory.Client()
+var InternalClient, _ = internalClientFactory.Client()
 
 // Doer returns a new Doer wrapped with the middleware stack
 // provided in the Factory constructor and with the given common


### PR DESCRIPTION
Not used anymore outside of this package, and is in line with what we do for the external doer factory.

Test plan:

CI passes, go compiler doesn't complain.