### PR TITLE
Prevent automatic redirection to the OAuth sign-in page when access requests are enabled

### DIFF
--- a/client/web/src/auth/SignInPage.tsx
+++ b/client/web/src/auth/SignInPage.tsx
@@ -87,7 +87,7 @@ export const SignInPage: React.FunctionComponent<React.PropsWithChildren<SignInP
 
     const thirdPartyAuthProviders = nonBuiltinAuthProviders.filter(provider => shouldShowProvider(provider))
     // If there is only one auth provider that is going to be displayed, we want to redirect to it directly.
-    if (thirdPartyAuthProviders.length === 1 && !builtInAuthProvider) {
+    if (context.sourcegraphDotComMode && thirdPartyAuthProviders.length === 1) {
         // Add '?returnTo=' + encodeURIComponent(returnTo) to thirdPartyAuthProviders[0].authenticationURL in a safe way.
         const redirectUrl = new URL(thirdPartyAuthProviders[0].authenticationURL, window.location.href)
         if (returnTo) {

--- a/cmd/frontend/internal/auth/oauth/middleware.go
+++ b/cmd/frontend/internal/auth/oauth/middleware.go
@@ -19,6 +19,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/auth"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/auth/providers"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
@@ -60,7 +61,7 @@ func NewMiddleware(db database.DB, serviceType, authPrefix string, isAPIHandler 
 		//
 		// For sign-out requests (signout cookie is  present), the user will be redirected to the SG login page.
 		pc := getExactlyOneOAuthProvider()
-		if pc != nil && !isAPIHandler && pc.AuthPrefix == authPrefix && !auth.HasSignOutCookie(r) && isHuman(r) {
+		if pc != nil && !isAPIHandler && pc.AuthPrefix == authPrefix && !auth.HasSignOutCookie(r) && isHuman(r) && !conf.IsAccessRequestEnabled() {
 			span.AddEvent("redirect to signin")
 			v := make(url.Values)
 			v.Set("redirect", auth.SafeRedirectURL(r.URL.String()))


### PR DESCRIPTION
Added a check to prevent automatic redirection to the sign-in page when access requests are enabled. 
There are redirects happening in the frontend and backend so I tried to keep those separated.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
