### PR TITLE
chore: Run bazel configure

### DIFF
--- a/internal/appliance/v1/BUILD.bazel
+++ b/internal/appliance/v1/BUILD.bazel
@@ -5,7 +5,6 @@ load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 proto_library(
     name = "v1_proto",
     srcs = ["appliance.proto"],
-    strip_import_prefix = "/internal",
     visibility = ["//:__subpackages__"],
 )
 

--- a/internal/grpc/example/weather/v1/BUILD.bazel
+++ b/internal/grpc/example/weather/v1/BUILD.bazel
@@ -12,7 +12,6 @@ go_library(
 proto_library(
     name = "grpc_example_weather_v1_proto",
     srcs = ["weather.proto"],
-    strip_import_prefix = "/internal",
     visibility = ["//:__subpackages__"],
     deps = ["@com_google_protobuf//:timestamp_proto"],
 )

--- a/internal/grpc/testprotos/news/v1/BUILD.bazel
+++ b/internal/grpc/testprotos/news/v1/BUILD.bazel
@@ -5,7 +5,6 @@ load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 proto_library(
     name = "news_proto",
     srcs = ["news.proto"],
-    strip_import_prefix = "/internal",
     visibility = ["//:__subpackages__"],
     deps = ["@com_google_protobuf//:timestamp_proto"],
 )


### PR DESCRIPTION
Not sure why this wasn't caught by the CI check?
Have we stopped running this?

## Test plan

Run `bazel configure`