### PR TITLE
go.mod: bump zoekt

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -590,7 +590,7 @@ require (
 	github.com/scim2/filter-parser/v2 v2.2.0
 	github.com/sourcegraph/conc v0.3.1-0.20240108182409-4afefce20f9b
 	github.com/sourcegraph/mountinfo v0.0.0-20240201124957-b314c0befab1
-	github.com/sourcegraph/zoekt v0.0.0-20240418025752-74e75efaded6
+	github.com/sourcegraph/zoekt v0.0.0-20240501072156-72f95004e6d6
 	github.com/spf13/cobra v1.8.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1709,6 +1709,8 @@ github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152 h1:z/MpntplPaW6
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152/go.mod h1:GIjDIg/heH5DOkXY3YJ/wNhfHsQHoXGjl8G8amsYQ1I=
 github.com/sourcegraph/zoekt v0.0.0-20240418025752-74e75efaded6 h1:ZoA5u9P6wjoUFwfgi+alUVLJ60dc0XkshTjzDNoQpGg=
 github.com/sourcegraph/zoekt v0.0.0-20240418025752-74e75efaded6/go.mod h1:+j+huwz4ZnffJmDHeLJyI9AY4a8DKQnfNV0J//upnyo=
+github.com/sourcegraph/zoekt v0.0.0-20240501072156-72f95004e6d6 h1:aXHLpH1rhdvg4gQOiQWLkqVd3D/DG2li5Nnf6WE7mRs=
+github.com/sourcegraph/zoekt v0.0.0-20240501072156-72f95004e6d6/go.mod h1:K7dYKxtKLPBRwu55Useje/JUZEuWgzlu5O1F8VFHfwE=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v0.0.0-20170901052352-ee1bd8ee15a1/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=


### PR DESCRIPTION
This includes the following changes

- 783a51a784 docker: use go1.22 and alpine3.19
- 301c735b9c docker: fix typo in builder name
- a0f051e95e all: remove gob and SSE rpc endpoints
- 8619902b5d gitindex: include environ for git tests
- 55b7aeee2d docker: simplify apk add lines
- 734f5b64f8 gomod: update deps for CVE-2023-45288 and CVE-2024-24786
- 6df055493b gitindex: interpret SSH URLs
- 5ecbc14cac zoekt-indexserver: prune branches on fetch
- 5411e9b32e zoekt-mirror-gerrit: allow to use reponame without host in the index
- 570757e20b Honor regex flags for case-sensitivity
- 68d04651cc zoekt-mirror-gerrit: handle http authentication
- 72f95004e6 fix: don't modify finalCands

Test plan:
Zoekt CI


