### PR TITLE
release: allow development flag in release ops

### DIFF
--- a/dev/ci/internal/ci/release_operations.go
+++ b/dev/ci/internal/ci/release_operations.go
@@ -51,7 +51,7 @@ func releaseTestOperation(c Config) operations.Operation {
 			bk.Env("PROD_REGISTRY", prodRegistry),
 			bk.Env("VERSION", c.Version),
 			bk.AnnotatedCmd(
-				bazelCmd(`run --run_under="cd $$PWD &&" //dev/sg -- release run test --branch $$BUILDKITE_BRANCH --version $$VERSION`),
+				bazelCmd(`run --run_under="cd $$PWD &&" //dev/sg -- release run test --branch $$BUILDKITE_BRANCH --version $$VERSION --development=$$IS_DEVELOPMENT_RELEASE`),
 				bk.AnnotatedCmdOpts{
 					Annotations: &bk.AnnotationOpts{
 						Type:         bk.AnnotationTypeInfo,
@@ -80,7 +80,7 @@ func releaseFinalizeOperation(c Config) operations.Operation {
 			bk.Agent("queue", AspectWorkflows.QueueDefault),
 			bk.Env("VERSION", c.Version),
 			bk.AnnotatedCmd(
-				bazelCmd(fmt.Sprintf(`run --run_under="cd $$PWD &&" //dev/sg -- release run %s finalize --branch $$BUILDKITE_BRANCH --version $$VERSION`, command)),
+				bazelCmd(fmt.Sprintf(`run --run_under="cd $$PWD &&" //dev/sg -- release run %s finalize --branch $$BUILDKITE_BRANCH --version $$VERSION --development=$$IS_DEVELOPMENT_RELEASE`, command)),
 				bk.AnnotatedCmdOpts{
 					Annotations: &bk.AnnotationOpts{
 						Type:         bk.AnnotationTypeInfo,


### PR DESCRIPTION

## Test plan

Pass the `IS_DEVELOPMENT` flag into the `sg` commands
