### PR TITLE
release: update requirement for slack webhook url

### DIFF
--- a/release.yaml
+++ b/release.yaml
@@ -28,14 +28,17 @@ requirements:
 
    # announce-engineering slack webhook url:
    # https://start.1password.com/open/i?a=HEDEDSLHPBFGRBTKAKJWE23XX4&v=dnrhbauihkhjs5ag6vszsme45a&i=pldpna5vivapxe4phewnqd42ji&h=team-sourcegraph.1password.com
-
-
-   # team-cloud-ops salck webhook url:
-   # https://start.1password.com/open/i?a=HEDEDSLHPBFGRBTKAKJWE23XX4&v=dnrhbauihkhjs5ag6vszsme45a&i=xwwpaakz5iajowr2fruueoevba&h=team-sourcegraph.1password.com
   - name: 'Slack Webhook URL'
     env: SLACK_WEBHOOK_URL
+    only:
+      - promoteToPublic.finalize
+
+  # team-cloud-ops slack webhook url:
+  # https://start.1password.com/open/i?a=HEDEDSLHPBFGRBTKAKJWE23XX4&v=dnrhbauihkhjs5ag6vszsme45a&i=xwwpaakz5iajowr2fruueoevba&h=team-sourcegraph.1password.com
   - name: 'Slack Webhook URL Cloud Ops'
     env: SLACK_WEBHOOK_URL_CLOUD_OPS
+    only:
+      - promoteToPublic.finalize
 
 internal:
   create:


### PR DESCRIPTION
The slack webhook urls are not needed for running the release tests

## Test plan

Release tests!
![CleanShot 2024-05-01 at 10 04 15@2x](https://github.com/sourcegraph/sourcegraph/assets/25608335/50a5551b-a724-42fd-9785-c9d6a55f1f02)
