### PR TITLE
chore: Group upload matching options into struct

### DIFF
--- a/internal/codeintel/codenav/iface.go
+++ b/internal/codeintel/codenav/iface.go
@@ -11,5 +11,5 @@ type UploadService interface {
 	GetCompletedUploadsWithDefinitionsForMonikers(ctx context.Context, monikers []precise.QualifiedMonikerData) (_ []shared.CompletedUpload, err error)
 	GetUploadIDsWithReferences(ctx context.Context, orderedMonikers []precise.QualifiedMonikerData, ignoreIDs []int, repositoryID int, commit string, limit int, offset int) (ids []int, recordsScanned int, totalCount int, err error)
 	GetCompletedUploadsByIDs(ctx context.Context, ids []int) (_ []shared.CompletedUpload, err error)
-	InferClosestUploads(ctx context.Context, repositoryID int, commit, path string, exactPath bool, indexer string) (_ []shared.CompletedUpload, err error)
+	InferClosestUploads(ctx context.Context, opts shared.UploadMatchingOptions) (_ []shared.CompletedUpload, err error)
 }

--- a/internal/codeintel/codenav/mocks_test.go
+++ b/internal/codeintel/codenav/mocks_test.go
@@ -3001,7 +3001,7 @@ func NewMockUploadService() *MockUploadService {
 			},
 		},
 		InferClosestUploadsFunc: &UploadServiceInferClosestUploadsFunc{
-			defaultHook: func(context.Context, int, string, string, bool, string) (r0 []shared1.CompletedUpload, r1 error) {
+			defaultHook: func(context.Context, shared1.UploadMatchingOptions) (r0 []shared1.CompletedUpload, r1 error) {
 				return
 			},
 		},
@@ -3028,7 +3028,7 @@ func NewStrictMockUploadService() *MockUploadService {
 			},
 		},
 		InferClosestUploadsFunc: &UploadServiceInferClosestUploadsFunc{
-			defaultHook: func(context.Context, int, string, string, bool, string) ([]shared1.CompletedUpload, error) {
+			defaultHook: func(context.Context, shared1.UploadMatchingOptions) ([]shared1.CompletedUpload, error) {
 				panic("unexpected invocation of MockUploadService.InferClosestUploads")
 			},
 		},
@@ -3418,24 +3418,24 @@ func (c UploadServiceGetUploadIDsWithReferencesFuncCall) Results() []interface{}
 // InferClosestUploads method of the parent MockUploadService instance is
 // invoked.
 type UploadServiceInferClosestUploadsFunc struct {
-	defaultHook func(context.Context, int, string, string, bool, string) ([]shared1.CompletedUpload, error)
-	hooks       []func(context.Context, int, string, string, bool, string) ([]shared1.CompletedUpload, error)
+	defaultHook func(context.Context, shared1.UploadMatchingOptions) ([]shared1.CompletedUpload, error)
+	hooks       []func(context.Context, shared1.UploadMatchingOptions) ([]shared1.CompletedUpload, error)
 	history     []UploadServiceInferClosestUploadsFuncCall
 	mutex       sync.Mutex
 }
 
 // InferClosestUploads delegates to the next hook function in the queue and
 // stores the parameter and result values of this invocation.
-func (m *MockUploadService) InferClosestUploads(v0 context.Context, v1 int, v2 string, v3 string, v4 bool, v5 string) ([]shared1.CompletedUpload, error) {
-	r0, r1 := m.InferClosestUploadsFunc.nextHook()(v0, v1, v2, v3, v4, v5)
-	m.InferClosestUploadsFunc.appendCall(UploadServiceInferClosestUploadsFuncCall{v0, v1, v2, v3, v4, v5, r0, r1})
+func (m *MockUploadService) InferClosestUploads(v0 context.Context, v1 shared1.UploadMatchingOptions) ([]shared1.CompletedUpload, error) {
+	r0, r1 := m.InferClosestUploadsFunc.nextHook()(v0, v1)
+	m.InferClosestUploadsFunc.appendCall(UploadServiceInferClosestUploadsFuncCall{v0, v1, r0, r1})
 	return r0, r1
 }
 
 // SetDefaultHook sets function that is called when the InferClosestUploads
 // method of the parent MockUploadService instance is invoked and the hook
 // queue is empty.
-func (f *UploadServiceInferClosestUploadsFunc) SetDefaultHook(hook func(context.Context, int, string, string, bool, string) ([]shared1.CompletedUpload, error)) {
+func (f *UploadServiceInferClosestUploadsFunc) SetDefaultHook(hook func(context.Context, shared1.UploadMatchingOptions) ([]shared1.CompletedUpload, error)) {
 	f.defaultHook = hook
 }
 
@@ -3444,7 +3444,7 @@ func (f *UploadServiceInferClosestUploadsFunc) SetDefaultHook(hook func(context.
 // invokes the hook at the front of the queue and discards it. After the
 // queue is empty, the default hook function is invoked for any future
 // action.
-func (f *UploadServiceInferClosestUploadsFunc) PushHook(hook func(context.Context, int, string, string, bool, string) ([]shared1.CompletedUpload, error)) {
+func (f *UploadServiceInferClosestUploadsFunc) PushHook(hook func(context.Context, shared1.UploadMatchingOptions) ([]shared1.CompletedUpload, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -3453,19 +3453,19 @@ func (f *UploadServiceInferClosestUploadsFunc) PushHook(hook func(context.Contex
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
 func (f *UploadServiceInferClosestUploadsFunc) SetDefaultReturn(r0 []shared1.CompletedUpload, r1 error) {
-	f.SetDefaultHook(func(context.Context, int, string, string, bool, string) ([]shared1.CompletedUpload, error) {
+	f.SetDefaultHook(func(context.Context, shared1.UploadMatchingOptions) ([]shared1.CompletedUpload, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
 func (f *UploadServiceInferClosestUploadsFunc) PushReturn(r0 []shared1.CompletedUpload, r1 error) {
-	f.PushHook(func(context.Context, int, string, string, bool, string) ([]shared1.CompletedUpload, error) {
+	f.PushHook(func(context.Context, shared1.UploadMatchingOptions) ([]shared1.CompletedUpload, error) {
 		return r0, r1
 	})
 }
 
-func (f *UploadServiceInferClosestUploadsFunc) nextHook() func(context.Context, int, string, string, bool, string) ([]shared1.CompletedUpload, error) {
+func (f *UploadServiceInferClosestUploadsFunc) nextHook() func(context.Context, shared1.UploadMatchingOptions) ([]shared1.CompletedUpload, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -3504,19 +3504,7 @@ type UploadServiceInferClosestUploadsFuncCall struct {
 	Arg0 context.Context
 	// Arg1 is the value of the 2nd argument passed to this method
 	// invocation.
-	Arg1 int
-	// Arg2 is the value of the 3rd argument passed to this method
-	// invocation.
-	Arg2 string
-	// Arg3 is the value of the 4th argument passed to this method
-	// invocation.
-	Arg3 string
-	// Arg4 is the value of the 5th argument passed to this method
-	// invocation.
-	Arg4 bool
-	// Arg5 is the value of the 6th argument passed to this method
-	// invocation.
-	Arg5 string
+	Arg1 shared1.UploadMatchingOptions
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 []shared1.CompletedUpload
@@ -3528,7 +3516,7 @@ type UploadServiceInferClosestUploadsFuncCall struct {
 // Args returns an interface slice containing the arguments of this
 // invocation.
 func (c UploadServiceInferClosestUploadsFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4, c.Arg5}
+	return []interface{}{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this

--- a/internal/codeintel/codenav/transport/graphql/iface.go
+++ b/internal/codeintel/codenav/transport/graphql/iface.go
@@ -17,7 +17,7 @@ type CodeNavService interface {
 	GetDiagnostics(ctx context.Context, args codenav.PositionalRequestArgs, requestState codenav.RequestState) (diagnosticsAtUploads []codenav.DiagnosticAtUpload, _ int, err error)
 	GetRanges(ctx context.Context, args codenav.PositionalRequestArgs, requestState codenav.RequestState, startLine, endLine int) (adjustedRanges []codenav.AdjustedCodeIntelligenceRange, err error)
 	GetStencil(ctx context.Context, args codenav.PositionalRequestArgs, requestState codenav.RequestState) (adjustedRanges []shared.Range, err error)
-	GetClosestCompletedUploadsForBlob(ctx context.Context, repositoryID int, commit, path string, exactPath bool, indexer string) (_ []uploadsshared.CompletedUpload, err error)
+	GetClosestCompletedUploadsForBlob(context.Context, uploadsshared.UploadMatchingOptions) (_ []uploadsshared.CompletedUpload, err error)
 	VisibleUploadsForPath(ctx context.Context, requestState codenav.RequestState) ([]uploadsshared.CompletedUpload, error)
 	SnapshotForDocument(ctx context.Context, repositoryID int, commit, path string, uploadID int) (data []shared.SnapshotData, err error)
 }

--- a/internal/codeintel/codenav/transport/graphql/mocks_test.go
+++ b/internal/codeintel/codenav/transport/graphql/mocks_test.go
@@ -219,7 +219,7 @@ type MockCodeNavService struct {
 func NewMockCodeNavService() *MockCodeNavService {
 	return &MockCodeNavService{
 		GetClosestCompletedUploadsForBlobFunc: &CodeNavServiceGetClosestCompletedUploadsForBlobFunc{
-			defaultHook: func(context.Context, int, string, string, bool, string) (r0 []shared.CompletedUpload, r1 error) {
+			defaultHook: func(context.Context, shared.UploadMatchingOptions) (r0 []shared.CompletedUpload, r1 error) {
 				return
 			},
 		},
@@ -281,7 +281,7 @@ func NewMockCodeNavService() *MockCodeNavService {
 func NewStrictMockCodeNavService() *MockCodeNavService {
 	return &MockCodeNavService{
 		GetClosestCompletedUploadsForBlobFunc: &CodeNavServiceGetClosestCompletedUploadsForBlobFunc{
-			defaultHook: func(context.Context, int, string, string, bool, string) ([]shared.CompletedUpload, error) {
+			defaultHook: func(context.Context, shared.UploadMatchingOptions) ([]shared.CompletedUpload, error) {
 				panic("unexpected invocation of MockCodeNavService.GetClosestCompletedUploadsForBlob")
 			},
 		},
@@ -383,24 +383,24 @@ func NewMockCodeNavServiceFrom(i CodeNavService) *MockCodeNavService {
 // behavior when the GetClosestCompletedUploadsForBlob method of the parent
 // MockCodeNavService instance is invoked.
 type CodeNavServiceGetClosestCompletedUploadsForBlobFunc struct {
-	defaultHook func(context.Context, int, string, string, bool, string) ([]shared.CompletedUpload, error)
-	hooks       []func(context.Context, int, string, string, bool, string) ([]shared.CompletedUpload, error)
+	defaultHook func(context.Context, shared.UploadMatchingOptions) ([]shared.CompletedUpload, error)
+	hooks       []func(context.Context, shared.UploadMatchingOptions) ([]shared.CompletedUpload, error)
 	history     []CodeNavServiceGetClosestCompletedUploadsForBlobFuncCall
 	mutex       sync.Mutex
 }
 
 // GetClosestCompletedUploadsForBlob delegates to the next hook function in
 // the queue and stores the parameter and result values of this invocation.
-func (m *MockCodeNavService) GetClosestCompletedUploadsForBlob(v0 context.Context, v1 int, v2 string, v3 string, v4 bool, v5 string) ([]shared.CompletedUpload, error) {
-	r0, r1 := m.GetClosestCompletedUploadsForBlobFunc.nextHook()(v0, v1, v2, v3, v4, v5)
-	m.GetClosestCompletedUploadsForBlobFunc.appendCall(CodeNavServiceGetClosestCompletedUploadsForBlobFuncCall{v0, v1, v2, v3, v4, v5, r0, r1})
+func (m *MockCodeNavService) GetClosestCompletedUploadsForBlob(v0 context.Context, v1 shared.UploadMatchingOptions) ([]shared.CompletedUpload, error) {
+	r0, r1 := m.GetClosestCompletedUploadsForBlobFunc.nextHook()(v0, v1)
+	m.GetClosestCompletedUploadsForBlobFunc.appendCall(CodeNavServiceGetClosestCompletedUploadsForBlobFuncCall{v0, v1, r0, r1})
 	return r0, r1
 }
 
 // SetDefaultHook sets function that is called when the
 // GetClosestCompletedUploadsForBlob method of the parent MockCodeNavService
 // instance is invoked and the hook queue is empty.
-func (f *CodeNavServiceGetClosestCompletedUploadsForBlobFunc) SetDefaultHook(hook func(context.Context, int, string, string, bool, string) ([]shared.CompletedUpload, error)) {
+func (f *CodeNavServiceGetClosestCompletedUploadsForBlobFunc) SetDefaultHook(hook func(context.Context, shared.UploadMatchingOptions) ([]shared.CompletedUpload, error)) {
 	f.defaultHook = hook
 }
 
@@ -409,7 +409,7 @@ func (f *CodeNavServiceGetClosestCompletedUploadsForBlobFunc) SetDefaultHook(hoo
 // instance invokes the hook at the front of the queue and discards it.
 // After the queue is empty, the default hook function is invoked for any
 // future action.
-func (f *CodeNavServiceGetClosestCompletedUploadsForBlobFunc) PushHook(hook func(context.Context, int, string, string, bool, string) ([]shared.CompletedUpload, error)) {
+func (f *CodeNavServiceGetClosestCompletedUploadsForBlobFunc) PushHook(hook func(context.Context, shared.UploadMatchingOptions) ([]shared.CompletedUpload, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -418,19 +418,19 @@ func (f *CodeNavServiceGetClosestCompletedUploadsForBlobFunc) PushHook(hook func
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
 func (f *CodeNavServiceGetClosestCompletedUploadsForBlobFunc) SetDefaultReturn(r0 []shared.CompletedUpload, r1 error) {
-	f.SetDefaultHook(func(context.Context, int, string, string, bool, string) ([]shared.CompletedUpload, error) {
+	f.SetDefaultHook(func(context.Context, shared.UploadMatchingOptions) ([]shared.CompletedUpload, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
 func (f *CodeNavServiceGetClosestCompletedUploadsForBlobFunc) PushReturn(r0 []shared.CompletedUpload, r1 error) {
-	f.PushHook(func(context.Context, int, string, string, bool, string) ([]shared.CompletedUpload, error) {
+	f.PushHook(func(context.Context, shared.UploadMatchingOptions) ([]shared.CompletedUpload, error) {
 		return r0, r1
 	})
 }
 
-func (f *CodeNavServiceGetClosestCompletedUploadsForBlobFunc) nextHook() func(context.Context, int, string, string, bool, string) ([]shared.CompletedUpload, error) {
+func (f *CodeNavServiceGetClosestCompletedUploadsForBlobFunc) nextHook() func(context.Context, shared.UploadMatchingOptions) ([]shared.CompletedUpload, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -470,19 +470,7 @@ type CodeNavServiceGetClosestCompletedUploadsForBlobFuncCall struct {
 	Arg0 context.Context
 	// Arg1 is the value of the 2nd argument passed to this method
 	// invocation.
-	Arg1 int
-	// Arg2 is the value of the 3rd argument passed to this method
-	// invocation.
-	Arg2 string
-	// Arg3 is the value of the 4th argument passed to this method
-	// invocation.
-	Arg3 string
-	// Arg4 is the value of the 5th argument passed to this method
-	// invocation.
-	Arg4 bool
-	// Arg5 is the value of the 6th argument passed to this method
-	// invocation.
-	Arg5 string
+	Arg1 shared.UploadMatchingOptions
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 []shared.CompletedUpload
@@ -494,7 +482,7 @@ type CodeNavServiceGetClosestCompletedUploadsForBlobFuncCall struct {
 // Args returns an interface slice containing the arguments of this
 // invocation.
 func (c CodeNavServiceGetClosestCompletedUploadsForBlobFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4, c.Arg5}
+	return []interface{}{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this

--- a/internal/codeintel/codenav/transport/graphql/root_resolver.go
+++ b/internal/codeintel/codenav/transport/graphql/root_resolver.go
@@ -70,16 +70,11 @@ func NewRootResolver(
 
 // 🚨 SECURITY: dbstore layer handles authz for query resolution
 func (r *rootResolver) GitBlobLSIFData(ctx context.Context, args *resolverstubs.GitBlobLSIFDataArgs) (_ resolverstubs.GitBlobLSIFDataResolver, err error) {
-	ctx, _, endObservation := r.operations.gitBlobLsifData.WithErrors(ctx, &err, observation.Args{Attrs: []attribute.KeyValue{
-		attribute.Int("repoID", int(args.Repo.ID)),
-		args.Commit.Attr(),
-		attribute.String("path", args.Path),
-		attribute.Bool("exactPath", args.ExactPath),
-		attribute.String("toolName", args.ToolName),
-	}})
+	opts := args.Options()
+	ctx, _, endObservation := r.operations.gitBlobLsifData.WithErrors(ctx, &err, observation.Args{Attrs: opts.Attrs()})
 	endObservation.OnCancel(ctx, 1, observation.Args{})
 
-	uploads, err := r.svc.GetClosestCompletedUploadsForBlob(ctx, int(args.Repo.ID), string(args.Commit), args.Path, args.ExactPath, args.ToolName)
+	uploads, err := r.svc.GetClosestCompletedUploadsForBlob(ctx, opts)
 	if err != nil || len(uploads) == 0 {
 		return nil, err
 	}

--- a/internal/codeintel/resolvers/BUILD.bazel
+++ b/internal/codeintel/resolvers/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
     visibility = ["//:__subpackages__"],
     deps = [
         "//internal/api",
+        "//internal/codeintel/uploads/shared",
         "//internal/gitserver/gitdomain",
         "//internal/gqlutil",
         "//internal/markdown",

--- a/internal/codeintel/resolvers/codenav.go
+++ b/internal/codeintel/resolvers/codenav.go
@@ -6,6 +6,7 @@ import (
 	"github.com/graph-gophers/graphql-go"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/codeintel/uploads/shared"
 	"github.com/sourcegraph/sourcegraph/internal/markdown"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
@@ -20,6 +21,20 @@ type GitBlobLSIFDataArgs struct {
 	Path      string
 	ExactPath bool
 	ToolName  string
+}
+
+func (a *GitBlobLSIFDataArgs) Options() shared.UploadMatchingOptions {
+	matching := shared.RootMustEnclosePath
+	if !a.ExactPath {
+		matching = shared.RootEnclosesPathOrPathEnclosesRoot
+	}
+	return shared.UploadMatchingOptions{
+		RepositoryID:       int(a.Repo.ID),
+		Commit:             string(a.Commit),
+		Path:               a.Path,
+		RootToPathMatching: matching,
+		Indexer:            a.ToolName,
+	}
 }
 
 type GitBlobLSIFDataResolver interface {

--- a/internal/codeintel/uploads/BUILD.bazel
+++ b/internal/codeintel/uploads/BUILD.bazel
@@ -37,7 +37,6 @@ go_library(
         "//lib/errors",
         "@com_github_prometheus_client_golang//prometheus",
         "@com_github_sourcegraph_log//:log",
-        "@io_opentelemetry_go_otel//attribute",
     ],
 )
 

--- a/internal/codeintel/uploads/internal/background/backfiller/mocks_test.go
+++ b/internal/codeintel/uploads/internal/background/backfiller/mocks_test.go
@@ -299,12 +299,12 @@ func NewMockStore() *MockStore {
 			},
 		},
 		FindClosestCompletedUploadsFunc: &StoreFindClosestCompletedUploadsFunc{
-			defaultHook: func(context.Context, int, string, string, bool, string) (r0 []shared.CompletedUpload, r1 error) {
+			defaultHook: func(context.Context, shared.UploadMatchingOptions) (r0 []shared.CompletedUpload, r1 error) {
 				return
 			},
 		},
 		FindClosestCompletedUploadsFromGraphFragmentFunc: &StoreFindClosestCompletedUploadsFromGraphFragmentFunc{
-			defaultHook: func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) (r0 []shared.CompletedUpload, r1 error) {
+			defaultHook: func(context.Context, shared.UploadMatchingOptions, *gitdomain.CommitGraph) (r0 []shared.CompletedUpload, r1 error) {
 				return
 			},
 		},
@@ -626,12 +626,12 @@ func NewStrictMockStore() *MockStore {
 			},
 		},
 		FindClosestCompletedUploadsFunc: &StoreFindClosestCompletedUploadsFunc{
-			defaultHook: func(context.Context, int, string, string, bool, string) ([]shared.CompletedUpload, error) {
+			defaultHook: func(context.Context, shared.UploadMatchingOptions) ([]shared.CompletedUpload, error) {
 				panic("unexpected invocation of MockStore.FindClosestCompletedUploads")
 			},
 		},
 		FindClosestCompletedUploadsFromGraphFragmentFunc: &StoreFindClosestCompletedUploadsFromGraphFragmentFunc{
-			defaultHook: func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared.CompletedUpload, error) {
+			defaultHook: func(context.Context, shared.UploadMatchingOptions, *gitdomain.CommitGraph) ([]shared.CompletedUpload, error) {
 				panic("unexpected invocation of MockStore.FindClosestCompletedUploadsFromGraphFragment")
 			},
 		},
@@ -2318,24 +2318,24 @@ func (c StoreExpireFailedRecordsFuncCall) Results() []interface{} {
 // FindClosestCompletedUploads method of the parent MockStore instance is
 // invoked.
 type StoreFindClosestCompletedUploadsFunc struct {
-	defaultHook func(context.Context, int, string, string, bool, string) ([]shared.CompletedUpload, error)
-	hooks       []func(context.Context, int, string, string, bool, string) ([]shared.CompletedUpload, error)
+	defaultHook func(context.Context, shared.UploadMatchingOptions) ([]shared.CompletedUpload, error)
+	hooks       []func(context.Context, shared.UploadMatchingOptions) ([]shared.CompletedUpload, error)
 	history     []StoreFindClosestCompletedUploadsFuncCall
 	mutex       sync.Mutex
 }
 
 // FindClosestCompletedUploads delegates to the next hook function in the
 // queue and stores the parameter and result values of this invocation.
-func (m *MockStore) FindClosestCompletedUploads(v0 context.Context, v1 int, v2 string, v3 string, v4 bool, v5 string) ([]shared.CompletedUpload, error) {
-	r0, r1 := m.FindClosestCompletedUploadsFunc.nextHook()(v0, v1, v2, v3, v4, v5)
-	m.FindClosestCompletedUploadsFunc.appendCall(StoreFindClosestCompletedUploadsFuncCall{v0, v1, v2, v3, v4, v5, r0, r1})
+func (m *MockStore) FindClosestCompletedUploads(v0 context.Context, v1 shared.UploadMatchingOptions) ([]shared.CompletedUpload, error) {
+	r0, r1 := m.FindClosestCompletedUploadsFunc.nextHook()(v0, v1)
+	m.FindClosestCompletedUploadsFunc.appendCall(StoreFindClosestCompletedUploadsFuncCall{v0, v1, r0, r1})
 	return r0, r1
 }
 
 // SetDefaultHook sets function that is called when the
 // FindClosestCompletedUploads method of the parent MockStore instance is
 // invoked and the hook queue is empty.
-func (f *StoreFindClosestCompletedUploadsFunc) SetDefaultHook(hook func(context.Context, int, string, string, bool, string) ([]shared.CompletedUpload, error)) {
+func (f *StoreFindClosestCompletedUploadsFunc) SetDefaultHook(hook func(context.Context, shared.UploadMatchingOptions) ([]shared.CompletedUpload, error)) {
 	f.defaultHook = hook
 }
 
@@ -2344,7 +2344,7 @@ func (f *StoreFindClosestCompletedUploadsFunc) SetDefaultHook(hook func(context.
 // invokes the hook at the front of the queue and discards it. After the
 // queue is empty, the default hook function is invoked for any future
 // action.
-func (f *StoreFindClosestCompletedUploadsFunc) PushHook(hook func(context.Context, int, string, string, bool, string) ([]shared.CompletedUpload, error)) {
+func (f *StoreFindClosestCompletedUploadsFunc) PushHook(hook func(context.Context, shared.UploadMatchingOptions) ([]shared.CompletedUpload, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -2353,19 +2353,19 @@ func (f *StoreFindClosestCompletedUploadsFunc) PushHook(hook func(context.Contex
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
 func (f *StoreFindClosestCompletedUploadsFunc) SetDefaultReturn(r0 []shared.CompletedUpload, r1 error) {
-	f.SetDefaultHook(func(context.Context, int, string, string, bool, string) ([]shared.CompletedUpload, error) {
+	f.SetDefaultHook(func(context.Context, shared.UploadMatchingOptions) ([]shared.CompletedUpload, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
 func (f *StoreFindClosestCompletedUploadsFunc) PushReturn(r0 []shared.CompletedUpload, r1 error) {
-	f.PushHook(func(context.Context, int, string, string, bool, string) ([]shared.CompletedUpload, error) {
+	f.PushHook(func(context.Context, shared.UploadMatchingOptions) ([]shared.CompletedUpload, error) {
 		return r0, r1
 	})
 }
 
-func (f *StoreFindClosestCompletedUploadsFunc) nextHook() func(context.Context, int, string, string, bool, string) ([]shared.CompletedUpload, error) {
+func (f *StoreFindClosestCompletedUploadsFunc) nextHook() func(context.Context, shared.UploadMatchingOptions) ([]shared.CompletedUpload, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -2404,19 +2404,7 @@ type StoreFindClosestCompletedUploadsFuncCall struct {
 	Arg0 context.Context
 	// Arg1 is the value of the 2nd argument passed to this method
 	// invocation.
-	Arg1 int
-	// Arg2 is the value of the 3rd argument passed to this method
-	// invocation.
-	Arg2 string
-	// Arg3 is the value of the 4th argument passed to this method
-	// invocation.
-	Arg3 string
-	// Arg4 is the value of the 5th argument passed to this method
-	// invocation.
-	Arg4 bool
-	// Arg5 is the value of the 6th argument passed to this method
-	// invocation.
-	Arg5 string
+	Arg1 shared.UploadMatchingOptions
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 []shared.CompletedUpload
@@ -2428,7 +2416,7 @@ type StoreFindClosestCompletedUploadsFuncCall struct {
 // Args returns an interface slice containing the arguments of this
 // invocation.
 func (c StoreFindClosestCompletedUploadsFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4, c.Arg5}
+	return []interface{}{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
@@ -2441,8 +2429,8 @@ func (c StoreFindClosestCompletedUploadsFuncCall) Results() []interface{} {
 // behavior when the FindClosestCompletedUploadsFromGraphFragment method of
 // the parent MockStore instance is invoked.
 type StoreFindClosestCompletedUploadsFromGraphFragmentFunc struct {
-	defaultHook func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared.CompletedUpload, error)
-	hooks       []func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared.CompletedUpload, error)
+	defaultHook func(context.Context, shared.UploadMatchingOptions, *gitdomain.CommitGraph) ([]shared.CompletedUpload, error)
+	hooks       []func(context.Context, shared.UploadMatchingOptions, *gitdomain.CommitGraph) ([]shared.CompletedUpload, error)
 	history     []StoreFindClosestCompletedUploadsFromGraphFragmentFuncCall
 	mutex       sync.Mutex
 }
@@ -2450,16 +2438,16 @@ type StoreFindClosestCompletedUploadsFromGraphFragmentFunc struct {
 // FindClosestCompletedUploadsFromGraphFragment delegates to the next hook
 // function in the queue and stores the parameter and result values of this
 // invocation.
-func (m *MockStore) FindClosestCompletedUploadsFromGraphFragment(v0 context.Context, v1 int, v2 string, v3 string, v4 bool, v5 string, v6 *gitdomain.CommitGraph) ([]shared.CompletedUpload, error) {
-	r0, r1 := m.FindClosestCompletedUploadsFromGraphFragmentFunc.nextHook()(v0, v1, v2, v3, v4, v5, v6)
-	m.FindClosestCompletedUploadsFromGraphFragmentFunc.appendCall(StoreFindClosestCompletedUploadsFromGraphFragmentFuncCall{v0, v1, v2, v3, v4, v5, v6, r0, r1})
+func (m *MockStore) FindClosestCompletedUploadsFromGraphFragment(v0 context.Context, v1 shared.UploadMatchingOptions, v2 *gitdomain.CommitGraph) ([]shared.CompletedUpload, error) {
+	r0, r1 := m.FindClosestCompletedUploadsFromGraphFragmentFunc.nextHook()(v0, v1, v2)
+	m.FindClosestCompletedUploadsFromGraphFragmentFunc.appendCall(StoreFindClosestCompletedUploadsFromGraphFragmentFuncCall{v0, v1, v2, r0, r1})
 	return r0, r1
 }
 
 // SetDefaultHook sets function that is called when the
 // FindClosestCompletedUploadsFromGraphFragment method of the parent
 // MockStore instance is invoked and the hook queue is empty.
-func (f *StoreFindClosestCompletedUploadsFromGraphFragmentFunc) SetDefaultHook(hook func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared.CompletedUpload, error)) {
+func (f *StoreFindClosestCompletedUploadsFromGraphFragmentFunc) SetDefaultHook(hook func(context.Context, shared.UploadMatchingOptions, *gitdomain.CommitGraph) ([]shared.CompletedUpload, error)) {
 	f.defaultHook = hook
 }
 
@@ -2468,7 +2456,7 @@ func (f *StoreFindClosestCompletedUploadsFromGraphFragmentFunc) SetDefaultHook(h
 // MockStore instance invokes the hook at the front of the queue and
 // discards it. After the queue is empty, the default hook function is
 // invoked for any future action.
-func (f *StoreFindClosestCompletedUploadsFromGraphFragmentFunc) PushHook(hook func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared.CompletedUpload, error)) {
+func (f *StoreFindClosestCompletedUploadsFromGraphFragmentFunc) PushHook(hook func(context.Context, shared.UploadMatchingOptions, *gitdomain.CommitGraph) ([]shared.CompletedUpload, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -2477,19 +2465,19 @@ func (f *StoreFindClosestCompletedUploadsFromGraphFragmentFunc) PushHook(hook fu
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
 func (f *StoreFindClosestCompletedUploadsFromGraphFragmentFunc) SetDefaultReturn(r0 []shared.CompletedUpload, r1 error) {
-	f.SetDefaultHook(func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared.CompletedUpload, error) {
+	f.SetDefaultHook(func(context.Context, shared.UploadMatchingOptions, *gitdomain.CommitGraph) ([]shared.CompletedUpload, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
 func (f *StoreFindClosestCompletedUploadsFromGraphFragmentFunc) PushReturn(r0 []shared.CompletedUpload, r1 error) {
-	f.PushHook(func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared.CompletedUpload, error) {
+	f.PushHook(func(context.Context, shared.UploadMatchingOptions, *gitdomain.CommitGraph) ([]shared.CompletedUpload, error) {
 		return r0, r1
 	})
 }
 
-func (f *StoreFindClosestCompletedUploadsFromGraphFragmentFunc) nextHook() func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared.CompletedUpload, error) {
+func (f *StoreFindClosestCompletedUploadsFromGraphFragmentFunc) nextHook() func(context.Context, shared.UploadMatchingOptions, *gitdomain.CommitGraph) ([]shared.CompletedUpload, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -2529,22 +2517,10 @@ type StoreFindClosestCompletedUploadsFromGraphFragmentFuncCall struct {
 	Arg0 context.Context
 	// Arg1 is the value of the 2nd argument passed to this method
 	// invocation.
-	Arg1 int
+	Arg1 shared.UploadMatchingOptions
 	// Arg2 is the value of the 3rd argument passed to this method
 	// invocation.
-	Arg2 string
-	// Arg3 is the value of the 4th argument passed to this method
-	// invocation.
-	Arg3 string
-	// Arg4 is the value of the 5th argument passed to this method
-	// invocation.
-	Arg4 bool
-	// Arg5 is the value of the 6th argument passed to this method
-	// invocation.
-	Arg5 string
-	// Arg6 is the value of the 7th argument passed to this method
-	// invocation.
-	Arg6 *gitdomain.CommitGraph
+	Arg2 *gitdomain.CommitGraph
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 []shared.CompletedUpload
@@ -2556,7 +2532,7 @@ type StoreFindClosestCompletedUploadsFromGraphFragmentFuncCall struct {
 // Args returns an interface slice containing the arguments of this
 // invocation.
 func (c StoreFindClosestCompletedUploadsFromGraphFragmentFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4, c.Arg5, c.Arg6}
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
 }
 
 // Results returns an interface slice containing the results of this

--- a/internal/codeintel/uploads/internal/background/expirer/mocks_test.go
+++ b/internal/codeintel/uploads/internal/background/expirer/mocks_test.go
@@ -643,12 +643,12 @@ func NewMockStore() *MockStore {
 			},
 		},
 		FindClosestCompletedUploadsFunc: &StoreFindClosestCompletedUploadsFunc{
-			defaultHook: func(context.Context, int, string, string, bool, string) (r0 []shared1.CompletedUpload, r1 error) {
+			defaultHook: func(context.Context, shared1.UploadMatchingOptions) (r0 []shared1.CompletedUpload, r1 error) {
 				return
 			},
 		},
 		FindClosestCompletedUploadsFromGraphFragmentFunc: &StoreFindClosestCompletedUploadsFromGraphFragmentFunc{
-			defaultHook: func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) (r0 []shared1.CompletedUpload, r1 error) {
+			defaultHook: func(context.Context, shared1.UploadMatchingOptions, *gitdomain.CommitGraph) (r0 []shared1.CompletedUpload, r1 error) {
 				return
 			},
 		},
@@ -970,12 +970,12 @@ func NewStrictMockStore() *MockStore {
 			},
 		},
 		FindClosestCompletedUploadsFunc: &StoreFindClosestCompletedUploadsFunc{
-			defaultHook: func(context.Context, int, string, string, bool, string) ([]shared1.CompletedUpload, error) {
+			defaultHook: func(context.Context, shared1.UploadMatchingOptions) ([]shared1.CompletedUpload, error) {
 				panic("unexpected invocation of MockStore.FindClosestCompletedUploads")
 			},
 		},
 		FindClosestCompletedUploadsFromGraphFragmentFunc: &StoreFindClosestCompletedUploadsFromGraphFragmentFunc{
-			defaultHook: func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared1.CompletedUpload, error) {
+			defaultHook: func(context.Context, shared1.UploadMatchingOptions, *gitdomain.CommitGraph) ([]shared1.CompletedUpload, error) {
 				panic("unexpected invocation of MockStore.FindClosestCompletedUploadsFromGraphFragment")
 			},
 		},
@@ -2662,24 +2662,24 @@ func (c StoreExpireFailedRecordsFuncCall) Results() []interface{} {
 // FindClosestCompletedUploads method of the parent MockStore instance is
 // invoked.
 type StoreFindClosestCompletedUploadsFunc struct {
-	defaultHook func(context.Context, int, string, string, bool, string) ([]shared1.CompletedUpload, error)
-	hooks       []func(context.Context, int, string, string, bool, string) ([]shared1.CompletedUpload, error)
+	defaultHook func(context.Context, shared1.UploadMatchingOptions) ([]shared1.CompletedUpload, error)
+	hooks       []func(context.Context, shared1.UploadMatchingOptions) ([]shared1.CompletedUpload, error)
 	history     []StoreFindClosestCompletedUploadsFuncCall
 	mutex       sync.Mutex
 }
 
 // FindClosestCompletedUploads delegates to the next hook function in the
 // queue and stores the parameter and result values of this invocation.
-func (m *MockStore) FindClosestCompletedUploads(v0 context.Context, v1 int, v2 string, v3 string, v4 bool, v5 string) ([]shared1.CompletedUpload, error) {
-	r0, r1 := m.FindClosestCompletedUploadsFunc.nextHook()(v0, v1, v2, v3, v4, v5)
-	m.FindClosestCompletedUploadsFunc.appendCall(StoreFindClosestCompletedUploadsFuncCall{v0, v1, v2, v3, v4, v5, r0, r1})
+func (m *MockStore) FindClosestCompletedUploads(v0 context.Context, v1 shared1.UploadMatchingOptions) ([]shared1.CompletedUpload, error) {
+	r0, r1 := m.FindClosestCompletedUploadsFunc.nextHook()(v0, v1)
+	m.FindClosestCompletedUploadsFunc.appendCall(StoreFindClosestCompletedUploadsFuncCall{v0, v1, r0, r1})
 	return r0, r1
 }
 
 // SetDefaultHook sets function that is called when the
 // FindClosestCompletedUploads method of the parent MockStore instance is
 // invoked and the hook queue is empty.
-func (f *StoreFindClosestCompletedUploadsFunc) SetDefaultHook(hook func(context.Context, int, string, string, bool, string) ([]shared1.CompletedUpload, error)) {
+func (f *StoreFindClosestCompletedUploadsFunc) SetDefaultHook(hook func(context.Context, shared1.UploadMatchingOptions) ([]shared1.CompletedUpload, error)) {
 	f.defaultHook = hook
 }
 
@@ -2688,7 +2688,7 @@ func (f *StoreFindClosestCompletedUploadsFunc) SetDefaultHook(hook func(context.
 // invokes the hook at the front of the queue and discards it. After the
 // queue is empty, the default hook function is invoked for any future
 // action.
-func (f *StoreFindClosestCompletedUploadsFunc) PushHook(hook func(context.Context, int, string, string, bool, string) ([]shared1.CompletedUpload, error)) {
+func (f *StoreFindClosestCompletedUploadsFunc) PushHook(hook func(context.Context, shared1.UploadMatchingOptions) ([]shared1.CompletedUpload, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -2697,19 +2697,19 @@ func (f *StoreFindClosestCompletedUploadsFunc) PushHook(hook func(context.Contex
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
 func (f *StoreFindClosestCompletedUploadsFunc) SetDefaultReturn(r0 []shared1.CompletedUpload, r1 error) {
-	f.SetDefaultHook(func(context.Context, int, string, string, bool, string) ([]shared1.CompletedUpload, error) {
+	f.SetDefaultHook(func(context.Context, shared1.UploadMatchingOptions) ([]shared1.CompletedUpload, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
 func (f *StoreFindClosestCompletedUploadsFunc) PushReturn(r0 []shared1.CompletedUpload, r1 error) {
-	f.PushHook(func(context.Context, int, string, string, bool, string) ([]shared1.CompletedUpload, error) {
+	f.PushHook(func(context.Context, shared1.UploadMatchingOptions) ([]shared1.CompletedUpload, error) {
 		return r0, r1
 	})
 }
 
-func (f *StoreFindClosestCompletedUploadsFunc) nextHook() func(context.Context, int, string, string, bool, string) ([]shared1.CompletedUpload, error) {
+func (f *StoreFindClosestCompletedUploadsFunc) nextHook() func(context.Context, shared1.UploadMatchingOptions) ([]shared1.CompletedUpload, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -2748,19 +2748,7 @@ type StoreFindClosestCompletedUploadsFuncCall struct {
 	Arg0 context.Context
 	// Arg1 is the value of the 2nd argument passed to this method
 	// invocation.
-	Arg1 int
-	// Arg2 is the value of the 3rd argument passed to this method
-	// invocation.
-	Arg2 string
-	// Arg3 is the value of the 4th argument passed to this method
-	// invocation.
-	Arg3 string
-	// Arg4 is the value of the 5th argument passed to this method
-	// invocation.
-	Arg4 bool
-	// Arg5 is the value of the 6th argument passed to this method
-	// invocation.
-	Arg5 string
+	Arg1 shared1.UploadMatchingOptions
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 []shared1.CompletedUpload
@@ -2772,7 +2760,7 @@ type StoreFindClosestCompletedUploadsFuncCall struct {
 // Args returns an interface slice containing the arguments of this
 // invocation.
 func (c StoreFindClosestCompletedUploadsFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4, c.Arg5}
+	return []interface{}{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
@@ -2785,8 +2773,8 @@ func (c StoreFindClosestCompletedUploadsFuncCall) Results() []interface{} {
 // behavior when the FindClosestCompletedUploadsFromGraphFragment method of
 // the parent MockStore instance is invoked.
 type StoreFindClosestCompletedUploadsFromGraphFragmentFunc struct {
-	defaultHook func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared1.CompletedUpload, error)
-	hooks       []func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared1.CompletedUpload, error)
+	defaultHook func(context.Context, shared1.UploadMatchingOptions, *gitdomain.CommitGraph) ([]shared1.CompletedUpload, error)
+	hooks       []func(context.Context, shared1.UploadMatchingOptions, *gitdomain.CommitGraph) ([]shared1.CompletedUpload, error)
 	history     []StoreFindClosestCompletedUploadsFromGraphFragmentFuncCall
 	mutex       sync.Mutex
 }
@@ -2794,16 +2782,16 @@ type StoreFindClosestCompletedUploadsFromGraphFragmentFunc struct {
 // FindClosestCompletedUploadsFromGraphFragment delegates to the next hook
 // function in the queue and stores the parameter and result values of this
 // invocation.
-func (m *MockStore) FindClosestCompletedUploadsFromGraphFragment(v0 context.Context, v1 int, v2 string, v3 string, v4 bool, v5 string, v6 *gitdomain.CommitGraph) ([]shared1.CompletedUpload, error) {
-	r0, r1 := m.FindClosestCompletedUploadsFromGraphFragmentFunc.nextHook()(v0, v1, v2, v3, v4, v5, v6)
-	m.FindClosestCompletedUploadsFromGraphFragmentFunc.appendCall(StoreFindClosestCompletedUploadsFromGraphFragmentFuncCall{v0, v1, v2, v3, v4, v5, v6, r0, r1})
+func (m *MockStore) FindClosestCompletedUploadsFromGraphFragment(v0 context.Context, v1 shared1.UploadMatchingOptions, v2 *gitdomain.CommitGraph) ([]shared1.CompletedUpload, error) {
+	r0, r1 := m.FindClosestCompletedUploadsFromGraphFragmentFunc.nextHook()(v0, v1, v2)
+	m.FindClosestCompletedUploadsFromGraphFragmentFunc.appendCall(StoreFindClosestCompletedUploadsFromGraphFragmentFuncCall{v0, v1, v2, r0, r1})
 	return r0, r1
 }
 
 // SetDefaultHook sets function that is called when the
 // FindClosestCompletedUploadsFromGraphFragment method of the parent
 // MockStore instance is invoked and the hook queue is empty.
-func (f *StoreFindClosestCompletedUploadsFromGraphFragmentFunc) SetDefaultHook(hook func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared1.CompletedUpload, error)) {
+func (f *StoreFindClosestCompletedUploadsFromGraphFragmentFunc) SetDefaultHook(hook func(context.Context, shared1.UploadMatchingOptions, *gitdomain.CommitGraph) ([]shared1.CompletedUpload, error)) {
 	f.defaultHook = hook
 }
 
@@ -2812,7 +2800,7 @@ func (f *StoreFindClosestCompletedUploadsFromGraphFragmentFunc) SetDefaultHook(h
 // MockStore instance invokes the hook at the front of the queue and
 // discards it. After the queue is empty, the default hook function is
 // invoked for any future action.
-func (f *StoreFindClosestCompletedUploadsFromGraphFragmentFunc) PushHook(hook func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared1.CompletedUpload, error)) {
+func (f *StoreFindClosestCompletedUploadsFromGraphFragmentFunc) PushHook(hook func(context.Context, shared1.UploadMatchingOptions, *gitdomain.CommitGraph) ([]shared1.CompletedUpload, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -2821,19 +2809,19 @@ func (f *StoreFindClosestCompletedUploadsFromGraphFragmentFunc) PushHook(hook fu
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
 func (f *StoreFindClosestCompletedUploadsFromGraphFragmentFunc) SetDefaultReturn(r0 []shared1.CompletedUpload, r1 error) {
-	f.SetDefaultHook(func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared1.CompletedUpload, error) {
+	f.SetDefaultHook(func(context.Context, shared1.UploadMatchingOptions, *gitdomain.CommitGraph) ([]shared1.CompletedUpload, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
 func (f *StoreFindClosestCompletedUploadsFromGraphFragmentFunc) PushReturn(r0 []shared1.CompletedUpload, r1 error) {
-	f.PushHook(func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared1.CompletedUpload, error) {
+	f.PushHook(func(context.Context, shared1.UploadMatchingOptions, *gitdomain.CommitGraph) ([]shared1.CompletedUpload, error) {
 		return r0, r1
 	})
 }
 
-func (f *StoreFindClosestCompletedUploadsFromGraphFragmentFunc) nextHook() func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared1.CompletedUpload, error) {
+func (f *StoreFindClosestCompletedUploadsFromGraphFragmentFunc) nextHook() func(context.Context, shared1.UploadMatchingOptions, *gitdomain.CommitGraph) ([]shared1.CompletedUpload, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -2873,22 +2861,10 @@ type StoreFindClosestCompletedUploadsFromGraphFragmentFuncCall struct {
 	Arg0 context.Context
 	// Arg1 is the value of the 2nd argument passed to this method
 	// invocation.
-	Arg1 int
+	Arg1 shared1.UploadMatchingOptions
 	// Arg2 is the value of the 3rd argument passed to this method
 	// invocation.
-	Arg2 string
-	// Arg3 is the value of the 4th argument passed to this method
-	// invocation.
-	Arg3 string
-	// Arg4 is the value of the 5th argument passed to this method
-	// invocation.
-	Arg4 bool
-	// Arg5 is the value of the 6th argument passed to this method
-	// invocation.
-	Arg5 string
-	// Arg6 is the value of the 7th argument passed to this method
-	// invocation.
-	Arg6 *gitdomain.CommitGraph
+	Arg2 *gitdomain.CommitGraph
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 []shared1.CompletedUpload
@@ -2900,7 +2876,7 @@ type StoreFindClosestCompletedUploadsFromGraphFragmentFuncCall struct {
 // Args returns an interface slice containing the arguments of this
 // invocation.
 func (c StoreFindClosestCompletedUploadsFromGraphFragmentFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4, c.Arg5, c.Arg6}
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
 }
 
 // Results returns an interface slice containing the results of this

--- a/internal/codeintel/uploads/internal/background/processor/mocks_test.go
+++ b/internal/codeintel/uploads/internal/background/processor/mocks_test.go
@@ -457,12 +457,12 @@ func NewMockStore() *MockStore {
 			},
 		},
 		FindClosestCompletedUploadsFunc: &StoreFindClosestCompletedUploadsFunc{
-			defaultHook: func(context.Context, int, string, string, bool, string) (r0 []shared.CompletedUpload, r1 error) {
+			defaultHook: func(context.Context, shared.UploadMatchingOptions) (r0 []shared.CompletedUpload, r1 error) {
 				return
 			},
 		},
 		FindClosestCompletedUploadsFromGraphFragmentFunc: &StoreFindClosestCompletedUploadsFromGraphFragmentFunc{
-			defaultHook: func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) (r0 []shared.CompletedUpload, r1 error) {
+			defaultHook: func(context.Context, shared.UploadMatchingOptions, *gitdomain.CommitGraph) (r0 []shared.CompletedUpload, r1 error) {
 				return
 			},
 		},
@@ -784,12 +784,12 @@ func NewStrictMockStore() *MockStore {
 			},
 		},
 		FindClosestCompletedUploadsFunc: &StoreFindClosestCompletedUploadsFunc{
-			defaultHook: func(context.Context, int, string, string, bool, string) ([]shared.CompletedUpload, error) {
+			defaultHook: func(context.Context, shared.UploadMatchingOptions) ([]shared.CompletedUpload, error) {
 				panic("unexpected invocation of MockStore.FindClosestCompletedUploads")
 			},
 		},
 		FindClosestCompletedUploadsFromGraphFragmentFunc: &StoreFindClosestCompletedUploadsFromGraphFragmentFunc{
-			defaultHook: func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared.CompletedUpload, error) {
+			defaultHook: func(context.Context, shared.UploadMatchingOptions, *gitdomain.CommitGraph) ([]shared.CompletedUpload, error) {
 				panic("unexpected invocation of MockStore.FindClosestCompletedUploadsFromGraphFragment")
 			},
 		},
@@ -2476,24 +2476,24 @@ func (c StoreExpireFailedRecordsFuncCall) Results() []interface{} {
 // FindClosestCompletedUploads method of the parent MockStore instance is
 // invoked.
 type StoreFindClosestCompletedUploadsFunc struct {
-	defaultHook func(context.Context, int, string, string, bool, string) ([]shared.CompletedUpload, error)
-	hooks       []func(context.Context, int, string, string, bool, string) ([]shared.CompletedUpload, error)
+	defaultHook func(context.Context, shared.UploadMatchingOptions) ([]shared.CompletedUpload, error)
+	hooks       []func(context.Context, shared.UploadMatchingOptions) ([]shared.CompletedUpload, error)
 	history     []StoreFindClosestCompletedUploadsFuncCall
 	mutex       sync.Mutex
 }
 
 // FindClosestCompletedUploads delegates to the next hook function in the
 // queue and stores the parameter and result values of this invocation.
-func (m *MockStore) FindClosestCompletedUploads(v0 context.Context, v1 int, v2 string, v3 string, v4 bool, v5 string) ([]shared.CompletedUpload, error) {
-	r0, r1 := m.FindClosestCompletedUploadsFunc.nextHook()(v0, v1, v2, v3, v4, v5)
-	m.FindClosestCompletedUploadsFunc.appendCall(StoreFindClosestCompletedUploadsFuncCall{v0, v1, v2, v3, v4, v5, r0, r1})
+func (m *MockStore) FindClosestCompletedUploads(v0 context.Context, v1 shared.UploadMatchingOptions) ([]shared.CompletedUpload, error) {
+	r0, r1 := m.FindClosestCompletedUploadsFunc.nextHook()(v0, v1)
+	m.FindClosestCompletedUploadsFunc.appendCall(StoreFindClosestCompletedUploadsFuncCall{v0, v1, r0, r1})
 	return r0, r1
 }
 
 // SetDefaultHook sets function that is called when the
 // FindClosestCompletedUploads method of the parent MockStore instance is
 // invoked and the hook queue is empty.
-func (f *StoreFindClosestCompletedUploadsFunc) SetDefaultHook(hook func(context.Context, int, string, string, bool, string) ([]shared.CompletedUpload, error)) {
+func (f *StoreFindClosestCompletedUploadsFunc) SetDefaultHook(hook func(context.Context, shared.UploadMatchingOptions) ([]shared.CompletedUpload, error)) {
 	f.defaultHook = hook
 }
 
@@ -2502,7 +2502,7 @@ func (f *StoreFindClosestCompletedUploadsFunc) SetDefaultHook(hook func(context.
 // invokes the hook at the front of the queue and discards it. After the
 // queue is empty, the default hook function is invoked for any future
 // action.
-func (f *StoreFindClosestCompletedUploadsFunc) PushHook(hook func(context.Context, int, string, string, bool, string) ([]shared.CompletedUpload, error)) {
+func (f *StoreFindClosestCompletedUploadsFunc) PushHook(hook func(context.Context, shared.UploadMatchingOptions) ([]shared.CompletedUpload, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -2511,19 +2511,19 @@ func (f *StoreFindClosestCompletedUploadsFunc) PushHook(hook func(context.Contex
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
 func (f *StoreFindClosestCompletedUploadsFunc) SetDefaultReturn(r0 []shared.CompletedUpload, r1 error) {
-	f.SetDefaultHook(func(context.Context, int, string, string, bool, string) ([]shared.CompletedUpload, error) {
+	f.SetDefaultHook(func(context.Context, shared.UploadMatchingOptions) ([]shared.CompletedUpload, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
 func (f *StoreFindClosestCompletedUploadsFunc) PushReturn(r0 []shared.CompletedUpload, r1 error) {
-	f.PushHook(func(context.Context, int, string, string, bool, string) ([]shared.CompletedUpload, error) {
+	f.PushHook(func(context.Context, shared.UploadMatchingOptions) ([]shared.CompletedUpload, error) {
 		return r0, r1
 	})
 }
 
-func (f *StoreFindClosestCompletedUploadsFunc) nextHook() func(context.Context, int, string, string, bool, string) ([]shared.CompletedUpload, error) {
+func (f *StoreFindClosestCompletedUploadsFunc) nextHook() func(context.Context, shared.UploadMatchingOptions) ([]shared.CompletedUpload, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -2562,19 +2562,7 @@ type StoreFindClosestCompletedUploadsFuncCall struct {
 	Arg0 context.Context
 	// Arg1 is the value of the 2nd argument passed to this method
 	// invocation.
-	Arg1 int
-	// Arg2 is the value of the 3rd argument passed to this method
-	// invocation.
-	Arg2 string
-	// Arg3 is the value of the 4th argument passed to this method
-	// invocation.
-	Arg3 string
-	// Arg4 is the value of the 5th argument passed to this method
-	// invocation.
-	Arg4 bool
-	// Arg5 is the value of the 6th argument passed to this method
-	// invocation.
-	Arg5 string
+	Arg1 shared.UploadMatchingOptions
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 []shared.CompletedUpload
@@ -2586,7 +2574,7 @@ type StoreFindClosestCompletedUploadsFuncCall struct {
 // Args returns an interface slice containing the arguments of this
 // invocation.
 func (c StoreFindClosestCompletedUploadsFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4, c.Arg5}
+	return []interface{}{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
@@ -2599,8 +2587,8 @@ func (c StoreFindClosestCompletedUploadsFuncCall) Results() []interface{} {
 // behavior when the FindClosestCompletedUploadsFromGraphFragment method of
 // the parent MockStore instance is invoked.
 type StoreFindClosestCompletedUploadsFromGraphFragmentFunc struct {
-	defaultHook func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared.CompletedUpload, error)
-	hooks       []func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared.CompletedUpload, error)
+	defaultHook func(context.Context, shared.UploadMatchingOptions, *gitdomain.CommitGraph) ([]shared.CompletedUpload, error)
+	hooks       []func(context.Context, shared.UploadMatchingOptions, *gitdomain.CommitGraph) ([]shared.CompletedUpload, error)
 	history     []StoreFindClosestCompletedUploadsFromGraphFragmentFuncCall
 	mutex       sync.Mutex
 }
@@ -2608,16 +2596,16 @@ type StoreFindClosestCompletedUploadsFromGraphFragmentFunc struct {
 // FindClosestCompletedUploadsFromGraphFragment delegates to the next hook
 // function in the queue and stores the parameter and result values of this
 // invocation.
-func (m *MockStore) FindClosestCompletedUploadsFromGraphFragment(v0 context.Context, v1 int, v2 string, v3 string, v4 bool, v5 string, v6 *gitdomain.CommitGraph) ([]shared.CompletedUpload, error) {
-	r0, r1 := m.FindClosestCompletedUploadsFromGraphFragmentFunc.nextHook()(v0, v1, v2, v3, v4, v5, v6)
-	m.FindClosestCompletedUploadsFromGraphFragmentFunc.appendCall(StoreFindClosestCompletedUploadsFromGraphFragmentFuncCall{v0, v1, v2, v3, v4, v5, v6, r0, r1})
+func (m *MockStore) FindClosestCompletedUploadsFromGraphFragment(v0 context.Context, v1 shared.UploadMatchingOptions, v2 *gitdomain.CommitGraph) ([]shared.CompletedUpload, error) {
+	r0, r1 := m.FindClosestCompletedUploadsFromGraphFragmentFunc.nextHook()(v0, v1, v2)
+	m.FindClosestCompletedUploadsFromGraphFragmentFunc.appendCall(StoreFindClosestCompletedUploadsFromGraphFragmentFuncCall{v0, v1, v2, r0, r1})
 	return r0, r1
 }
 
 // SetDefaultHook sets function that is called when the
 // FindClosestCompletedUploadsFromGraphFragment method of the parent
 // MockStore instance is invoked and the hook queue is empty.
-func (f *StoreFindClosestCompletedUploadsFromGraphFragmentFunc) SetDefaultHook(hook func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared.CompletedUpload, error)) {
+func (f *StoreFindClosestCompletedUploadsFromGraphFragmentFunc) SetDefaultHook(hook func(context.Context, shared.UploadMatchingOptions, *gitdomain.CommitGraph) ([]shared.CompletedUpload, error)) {
 	f.defaultHook = hook
 }
 
@@ -2626,7 +2614,7 @@ func (f *StoreFindClosestCompletedUploadsFromGraphFragmentFunc) SetDefaultHook(h
 // MockStore instance invokes the hook at the front of the queue and
 // discards it. After the queue is empty, the default hook function is
 // invoked for any future action.
-func (f *StoreFindClosestCompletedUploadsFromGraphFragmentFunc) PushHook(hook func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared.CompletedUpload, error)) {
+func (f *StoreFindClosestCompletedUploadsFromGraphFragmentFunc) PushHook(hook func(context.Context, shared.UploadMatchingOptions, *gitdomain.CommitGraph) ([]shared.CompletedUpload, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -2635,19 +2623,19 @@ func (f *StoreFindClosestCompletedUploadsFromGraphFragmentFunc) PushHook(hook fu
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
 func (f *StoreFindClosestCompletedUploadsFromGraphFragmentFunc) SetDefaultReturn(r0 []shared.CompletedUpload, r1 error) {
-	f.SetDefaultHook(func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared.CompletedUpload, error) {
+	f.SetDefaultHook(func(context.Context, shared.UploadMatchingOptions, *gitdomain.CommitGraph) ([]shared.CompletedUpload, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
 func (f *StoreFindClosestCompletedUploadsFromGraphFragmentFunc) PushReturn(r0 []shared.CompletedUpload, r1 error) {
-	f.PushHook(func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared.CompletedUpload, error) {
+	f.PushHook(func(context.Context, shared.UploadMatchingOptions, *gitdomain.CommitGraph) ([]shared.CompletedUpload, error) {
 		return r0, r1
 	})
 }
 
-func (f *StoreFindClosestCompletedUploadsFromGraphFragmentFunc) nextHook() func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared.CompletedUpload, error) {
+func (f *StoreFindClosestCompletedUploadsFromGraphFragmentFunc) nextHook() func(context.Context, shared.UploadMatchingOptions, *gitdomain.CommitGraph) ([]shared.CompletedUpload, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -2687,22 +2675,10 @@ type StoreFindClosestCompletedUploadsFromGraphFragmentFuncCall struct {
 	Arg0 context.Context
 	// Arg1 is the value of the 2nd argument passed to this method
 	// invocation.
-	Arg1 int
+	Arg1 shared.UploadMatchingOptions
 	// Arg2 is the value of the 3rd argument passed to this method
 	// invocation.
-	Arg2 string
-	// Arg3 is the value of the 4th argument passed to this method
-	// invocation.
-	Arg3 string
-	// Arg4 is the value of the 5th argument passed to this method
-	// invocation.
-	Arg4 bool
-	// Arg5 is the value of the 6th argument passed to this method
-	// invocation.
-	Arg5 string
-	// Arg6 is the value of the 7th argument passed to this method
-	// invocation.
-	Arg6 *gitdomain.CommitGraph
+	Arg2 *gitdomain.CommitGraph
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 []shared.CompletedUpload
@@ -2714,7 +2690,7 @@ type StoreFindClosestCompletedUploadsFromGraphFragmentFuncCall struct {
 // Args returns an interface slice containing the arguments of this
 // invocation.
 func (c StoreFindClosestCompletedUploadsFromGraphFragmentFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4, c.Arg5, c.Arg6}
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
 }
 
 // Results returns an interface slice containing the results of this

--- a/internal/codeintel/uploads/internal/store/commitgraph.go
+++ b/internal/codeintel/uploads/internal/store/commitgraph.go
@@ -274,9 +274,7 @@ LIMIT %s
 `
 
 // FindClosestCompletedUploads returns the set of uploads that can most accurately answer queries for the given repository, commit, path, and
-// optional indexer. If rootMustEnclosePath is true, then only dumps with a root which is a prefix of path are returned. Otherwise,
-// any dump with a root intersecting the given path is returned.
-// Syntactic indexes are not returned unless the requested indexer is shared.SyntacticIndexer
+// optional indexer.
 //
 // This method should be used when the commit is known to exist in the lsif_nearest_uploads table. If it doesn't, then this method
 // will return no dumps (as the input commit is not reachable from anything with an upload). The nearest uploads table must be
@@ -295,19 +293,13 @@ LIMIT %s
 // It is possible for some dumps to overlap theoretically, e.g. if someone uploads one dump covering the repository root and then later
 // splits the repository into multiple dumps. For this reason, the returned dumps are always sorted in most-recently-finished order to
 // prevent returning data from stale dumps.
-func (s *store) FindClosestCompletedUploads(ctx context.Context, repositoryID int, commit, path string, rootMustEnclosePath bool, indexer string) (_ []shared.CompletedUpload, err error) {
-	ctx, trace, endObservation := s.operations.findClosestCompletedUploads.With(ctx, &err, observation.Args{Attrs: []attribute.KeyValue{
-		attribute.Int("repositoryID", repositoryID),
-		attribute.String("commit", commit),
-		attribute.String("path", path),
-		attribute.Bool("rootMustEnclosePath", rootMustEnclosePath),
-		attribute.String("indexer", indexer),
-	}})
+func (s *store) FindClosestCompletedUploads(ctx context.Context, opts shared.UploadMatchingOptions) (_ []shared.CompletedUpload, err error) {
+	ctx, trace, endObservation := s.operations.findClosestCompletedUploads.With(ctx, &err, observation.Args{Attrs: opts.Attrs()})
 	defer endObservation(1, observation.Args{})
 
-	conds := makeFindClosestProcessUploadsConditions(path, rootMustEnclosePath, indexer)
+	conds := makeFindClosestProcessUploadsConditions(opts)
 	// TODO(id: completed-state-check) Make sure we only return uploads with state = 'completed' here
-	query := sqlf.Sprintf(findClosestCompletedUploadsQuery, makeVisibleUploadsQuery(repositoryID, commit), sqlf.Join(conds, " AND "))
+	query := sqlf.Sprintf(findClosestCompletedUploadsQuery, makeVisibleUploadsQuery(opts.RepositoryID, opts.Commit), sqlf.Join(conds, " AND "))
 
 	uploads, err := scanCompletedUploads(s.db.Query(ctx, query))
 	if err != nil {
@@ -347,15 +339,9 @@ ORDER BY u.finished_at DESC
 
 // FindClosestCompletedUploadsFromGraphFragment returns the set of uploads that can most accurately answer queries for the given repository, commit,
 // path, and optional indexer by only considering the given fragment of the full git graph. See FindClosestCompletedUploads for additional details.
-func (s *store) FindClosestCompletedUploadsFromGraphFragment(ctx context.Context, repositoryID int, commit, path string, rootMustEnclosePath bool, indexer string, commitGraph *gitdomain.CommitGraph) (_ []shared.CompletedUpload, err error) {
-	ctx, trace, endObservation := s.operations.findClosestCompletedUploadsFromGraphFragment.With(ctx, &err, observation.Args{Attrs: []attribute.KeyValue{
-		attribute.Int("repositoryID", repositoryID),
-		attribute.String("commit", commit),
-		attribute.String("path", path),
-		attribute.Bool("rootMustEnclosePath", rootMustEnclosePath),
-		attribute.String("indexer", indexer),
-		attribute.Int("numCommitGraphKeys", len(commitGraph.Order())),
-	}})
+func (s *store) FindClosestCompletedUploadsFromGraphFragment(ctx context.Context, opts shared.UploadMatchingOptions, commitGraph *gitdomain.CommitGraph) (_ []shared.CompletedUpload, err error) {
+	ctx, trace, endObservation := s.operations.findClosestCompletedUploadsFromGraphFragment.With(ctx, &err,
+		observation.Args{Attrs: append(opts.Attrs(), attribute.Int("numCommitGraphKeys", len(commitGraph.Order())))})
 	defer endObservation(1, observation.Args{})
 
 	if len(commitGraph.Order()) == 0 {
@@ -369,9 +355,9 @@ func (s *store) FindClosestCompletedUploadsFromGraphFragment(ctx context.Context
 
 	commitGraphView, err := scanCommitGraphView(s.db.Query(ctx, sqlf.Sprintf(
 		findClosestCompletedUploadsFromGraphFragmentCommitGraphQuery,
-		repositoryID,
+		opts.RepositoryID,
 		sqlf.Join(commitQueries, ", "),
-		repositoryID,
+		opts.RepositoryID,
 		sqlf.Join(commitQueries, ", "),
 	)))
 	if err != nil {
@@ -382,14 +368,14 @@ func (s *store) FindClosestCompletedUploadsFromGraphFragment(ctx context.Context
 		attribute.Int("numCommitGraphViewTokenKeys", len(commitGraphView.Tokens)))
 
 	var ids []*sqlf.Query
-	for _, uploadMeta := range commitgraph.NewGraph(commitGraph, commitGraphView).UploadsVisibleAtCommit(commit) {
+	for _, uploadMeta := range commitgraph.NewGraph(commitGraph, commitGraphView).UploadsVisibleAtCommit(opts.Commit) {
 		ids = append(ids, sqlf.Sprintf("%d", uploadMeta.UploadID))
 	}
 	if len(ids) == 0 {
 		return nil, nil
 	}
 
-	conds := makeFindClosestProcessUploadsConditions(path, rootMustEnclosePath, indexer)
+	conds := makeFindClosestProcessUploadsConditions(opts)
 	// TODO(id: completed-state-check) Make sure we only return uploads with state = 'completed' here
 	query := sqlf.Sprintf(findClosestCompletedUploadsFromGraphFragmentQuery, sqlf.Join(ids, ","), sqlf.Join(conds, " AND "))
 
@@ -1087,16 +1073,17 @@ func (s *uploadMetaListSerializer) take() []byte {
 //
 //
 
-func makeFindClosestProcessUploadsConditions(path string, rootMustEnclosePath bool, indexer string) (conds []*sqlf.Query) {
-	if rootMustEnclosePath {
+func makeFindClosestProcessUploadsConditions(opts shared.UploadMatchingOptions) (conds []*sqlf.Query) {
+	switch opts.RootToPathMatching {
+	case shared.RootMustEnclosePath:
 		// Ensure that the root is a prefix of the path
-		conds = append(conds, sqlf.Sprintf(`%s LIKE (u.root || '%%%%')`, path))
-	} else {
+		conds = append(conds, sqlf.Sprintf(`%s LIKE (u.root || '%%%%')`, opts.Path))
+	case shared.RootEnclosesPathOrPathEnclosesRoot:
 		// Ensure that the root is a prefix of the path or vice versa
-		conds = append(conds, sqlf.Sprintf(`(%s LIKE (u.root || '%%%%') OR u.root LIKE (%s || '%%%%'))`, path, path))
+		conds = append(conds, sqlf.Sprintf(`(%s LIKE (u.root || '%%%%') OR u.root LIKE (%s || '%%%%'))`, opts.Path, opts.Path))
 	}
-	if indexer != "" {
-		conds = append(conds, sqlf.Sprintf("indexer = %s", indexer))
+	if opts.Indexer != "" {
+		conds = append(conds, sqlf.Sprintf("indexer = %s", opts.Indexer))
 	} else {
 		// NOTE(id: explicit-syntactic-index): Ignore syntactic indices unless they're
 		// explicitly requested to maintain backwards compatibility with older APIs

--- a/internal/codeintel/uploads/internal/store/commitgraph_test.go
+++ b/internal/codeintel/uploads/internal/store/commitgraph_test.go
@@ -1288,6 +1288,14 @@ type FindClosestCompletedUploadsTestCase struct {
 	allOfIDs            []int
 }
 
+func (t *FindClosestCompletedUploadsTestCase) uploadMatchingOptions() shared.UploadMatchingOptions {
+	matching := shared.RootMustEnclosePath
+	if !t.rootMustEnclosePath {
+		matching = shared.RootEnclosesPathOrPathEnclosesRoot
+	}
+	return shared.UploadMatchingOptions{50, t.commit, t.file, matching, t.indexer}
+}
+
 func testFindClosestCompletedUploads(t *testing.T, store Store, testCases []FindClosestCompletedUploadsTestCase) {
 	for _, testCase := range testCases {
 		name := fmt.Sprintf(
@@ -1317,7 +1325,7 @@ func testFindClosestCompletedUploads(t *testing.T, store Store, testCases []Find
 
 		if !testCase.graphFragmentOnly {
 			t.Run(name, func(t *testing.T) {
-				uploads, err := store.FindClosestCompletedUploads(context.Background(), 50, testCase.commit, testCase.file, testCase.rootMustEnclosePath, testCase.indexer)
+				uploads, err := store.FindClosestCompletedUploads(context.Background(), testCase.uploadMatchingOptions())
 				if err != nil {
 					t.Fatalf("unexpected error finding closest uploads: %s", err)
 				}
@@ -1328,7 +1336,7 @@ func testFindClosestCompletedUploads(t *testing.T, store Store, testCases []Find
 
 		if testCase.graph != nil {
 			t.Run(name+" [graph-fragment]", func(t *testing.T) {
-				uploads, err := store.FindClosestCompletedUploadsFromGraphFragment(context.Background(), 50, testCase.commit, testCase.file, testCase.rootMustEnclosePath, testCase.indexer, testCase.graph)
+				uploads, err := store.FindClosestCompletedUploadsFromGraphFragment(context.Background(), testCase.uploadMatchingOptions(), testCase.graph)
 				if err != nil {
 					t.Fatalf("unexpected error finding closest uploads: %s", err)
 				}

--- a/internal/codeintel/uploads/internal/store/store.go
+++ b/internal/codeintel/uploads/internal/store/store.go
@@ -68,8 +68,8 @@ type Store interface {
 	GetDirtyRepositories(ctx context.Context) ([]shared.DirtyRepository, error)
 	UpdateUploadsVisibleToCommits(ctx context.Context, repositoryID int, graph *gitdomain.CommitGraph, refs map[string][]gitdomain.Ref, maxAgeForNonStaleBranches, maxAgeForNonStaleTags time.Duration, dirtyToken int, now time.Time) error
 	GetCommitsVisibleToUpload(ctx context.Context, uploadID, limit int, token *string) ([]string, *string, error)
-	FindClosestCompletedUploads(ctx context.Context, repositoryID int, commit, path string, rootMustEnclosePath bool, indexer string) ([]shared.CompletedUpload, error)
-	FindClosestCompletedUploadsFromGraphFragment(ctx context.Context, repositoryID int, commit, path string, rootMustEnclosePath bool, indexer string, commitGraph *gitdomain.CommitGraph) ([]shared.CompletedUpload, error)
+	FindClosestCompletedUploads(context.Context, shared.UploadMatchingOptions) ([]shared.CompletedUpload, error)
+	FindClosestCompletedUploadsFromGraphFragment(_ context.Context, _ shared.UploadMatchingOptions, commitGraph *gitdomain.CommitGraph) ([]shared.CompletedUpload, error)
 	GetRepositoriesMaxStaleAge(ctx context.Context) (time.Duration, error)
 	GetCommitGraphMetadata(ctx context.Context, repositoryID int) (stale bool, updatedAt *time.Time, _ error)
 

--- a/internal/codeintel/uploads/mocks_test.go
+++ b/internal/codeintel/uploads/mocks_test.go
@@ -306,12 +306,12 @@ func NewMockStore() *MockStore {
 			},
 		},
 		FindClosestCompletedUploadsFunc: &StoreFindClosestCompletedUploadsFunc{
-			defaultHook: func(context.Context, int, string, string, bool, string) (r0 []shared.CompletedUpload, r1 error) {
+			defaultHook: func(context.Context, shared.UploadMatchingOptions) (r0 []shared.CompletedUpload, r1 error) {
 				return
 			},
 		},
 		FindClosestCompletedUploadsFromGraphFragmentFunc: &StoreFindClosestCompletedUploadsFromGraphFragmentFunc{
-			defaultHook: func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) (r0 []shared.CompletedUpload, r1 error) {
+			defaultHook: func(context.Context, shared.UploadMatchingOptions, *gitdomain.CommitGraph) (r0 []shared.CompletedUpload, r1 error) {
 				return
 			},
 		},
@@ -633,12 +633,12 @@ func NewStrictMockStore() *MockStore {
 			},
 		},
 		FindClosestCompletedUploadsFunc: &StoreFindClosestCompletedUploadsFunc{
-			defaultHook: func(context.Context, int, string, string, bool, string) ([]shared.CompletedUpload, error) {
+			defaultHook: func(context.Context, shared.UploadMatchingOptions) ([]shared.CompletedUpload, error) {
 				panic("unexpected invocation of MockStore.FindClosestCompletedUploads")
 			},
 		},
 		FindClosestCompletedUploadsFromGraphFragmentFunc: &StoreFindClosestCompletedUploadsFromGraphFragmentFunc{
-			defaultHook: func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared.CompletedUpload, error) {
+			defaultHook: func(context.Context, shared.UploadMatchingOptions, *gitdomain.CommitGraph) ([]shared.CompletedUpload, error) {
 				panic("unexpected invocation of MockStore.FindClosestCompletedUploadsFromGraphFragment")
 			},
 		},
@@ -2325,24 +2325,24 @@ func (c StoreExpireFailedRecordsFuncCall) Results() []interface{} {
 // FindClosestCompletedUploads method of the parent MockStore instance is
 // invoked.
 type StoreFindClosestCompletedUploadsFunc struct {
-	defaultHook func(context.Context, int, string, string, bool, string) ([]shared.CompletedUpload, error)
-	hooks       []func(context.Context, int, string, string, bool, string) ([]shared.CompletedUpload, error)
+	defaultHook func(context.Context, shared.UploadMatchingOptions) ([]shared.CompletedUpload, error)
+	hooks       []func(context.Context, shared.UploadMatchingOptions) ([]shared.CompletedUpload, error)
 	history     []StoreFindClosestCompletedUploadsFuncCall
 	mutex       sync.Mutex
 }
 
 // FindClosestCompletedUploads delegates to the next hook function in the
 // queue and stores the parameter and result values of this invocation.
-func (m *MockStore) FindClosestCompletedUploads(v0 context.Context, v1 int, v2 string, v3 string, v4 bool, v5 string) ([]shared.CompletedUpload, error) {
-	r0, r1 := m.FindClosestCompletedUploadsFunc.nextHook()(v0, v1, v2, v3, v4, v5)
-	m.FindClosestCompletedUploadsFunc.appendCall(StoreFindClosestCompletedUploadsFuncCall{v0, v1, v2, v3, v4, v5, r0, r1})
+func (m *MockStore) FindClosestCompletedUploads(v0 context.Context, v1 shared.UploadMatchingOptions) ([]shared.CompletedUpload, error) {
+	r0, r1 := m.FindClosestCompletedUploadsFunc.nextHook()(v0, v1)
+	m.FindClosestCompletedUploadsFunc.appendCall(StoreFindClosestCompletedUploadsFuncCall{v0, v1, r0, r1})
 	return r0, r1
 }
 
 // SetDefaultHook sets function that is called when the
 // FindClosestCompletedUploads method of the parent MockStore instance is
 // invoked and the hook queue is empty.
-func (f *StoreFindClosestCompletedUploadsFunc) SetDefaultHook(hook func(context.Context, int, string, string, bool, string) ([]shared.CompletedUpload, error)) {
+func (f *StoreFindClosestCompletedUploadsFunc) SetDefaultHook(hook func(context.Context, shared.UploadMatchingOptions) ([]shared.CompletedUpload, error)) {
 	f.defaultHook = hook
 }
 
@@ -2351,7 +2351,7 @@ func (f *StoreFindClosestCompletedUploadsFunc) SetDefaultHook(hook func(context.
 // invokes the hook at the front of the queue and discards it. After the
 // queue is empty, the default hook function is invoked for any future
 // action.
-func (f *StoreFindClosestCompletedUploadsFunc) PushHook(hook func(context.Context, int, string, string, bool, string) ([]shared.CompletedUpload, error)) {
+func (f *StoreFindClosestCompletedUploadsFunc) PushHook(hook func(context.Context, shared.UploadMatchingOptions) ([]shared.CompletedUpload, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -2360,19 +2360,19 @@ func (f *StoreFindClosestCompletedUploadsFunc) PushHook(hook func(context.Contex
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
 func (f *StoreFindClosestCompletedUploadsFunc) SetDefaultReturn(r0 []shared.CompletedUpload, r1 error) {
-	f.SetDefaultHook(func(context.Context, int, string, string, bool, string) ([]shared.CompletedUpload, error) {
+	f.SetDefaultHook(func(context.Context, shared.UploadMatchingOptions) ([]shared.CompletedUpload, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
 func (f *StoreFindClosestCompletedUploadsFunc) PushReturn(r0 []shared.CompletedUpload, r1 error) {
-	f.PushHook(func(context.Context, int, string, string, bool, string) ([]shared.CompletedUpload, error) {
+	f.PushHook(func(context.Context, shared.UploadMatchingOptions) ([]shared.CompletedUpload, error) {
 		return r0, r1
 	})
 }
 
-func (f *StoreFindClosestCompletedUploadsFunc) nextHook() func(context.Context, int, string, string, bool, string) ([]shared.CompletedUpload, error) {
+func (f *StoreFindClosestCompletedUploadsFunc) nextHook() func(context.Context, shared.UploadMatchingOptions) ([]shared.CompletedUpload, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -2411,19 +2411,7 @@ type StoreFindClosestCompletedUploadsFuncCall struct {
 	Arg0 context.Context
 	// Arg1 is the value of the 2nd argument passed to this method
 	// invocation.
-	Arg1 int
-	// Arg2 is the value of the 3rd argument passed to this method
-	// invocation.
-	Arg2 string
-	// Arg3 is the value of the 4th argument passed to this method
-	// invocation.
-	Arg3 string
-	// Arg4 is the value of the 5th argument passed to this method
-	// invocation.
-	Arg4 bool
-	// Arg5 is the value of the 6th argument passed to this method
-	// invocation.
-	Arg5 string
+	Arg1 shared.UploadMatchingOptions
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 []shared.CompletedUpload
@@ -2435,7 +2423,7 @@ type StoreFindClosestCompletedUploadsFuncCall struct {
 // Args returns an interface slice containing the arguments of this
 // invocation.
 func (c StoreFindClosestCompletedUploadsFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4, c.Arg5}
+	return []interface{}{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
@@ -2448,8 +2436,8 @@ func (c StoreFindClosestCompletedUploadsFuncCall) Results() []interface{} {
 // behavior when the FindClosestCompletedUploadsFromGraphFragment method of
 // the parent MockStore instance is invoked.
 type StoreFindClosestCompletedUploadsFromGraphFragmentFunc struct {
-	defaultHook func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared.CompletedUpload, error)
-	hooks       []func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared.CompletedUpload, error)
+	defaultHook func(context.Context, shared.UploadMatchingOptions, *gitdomain.CommitGraph) ([]shared.CompletedUpload, error)
+	hooks       []func(context.Context, shared.UploadMatchingOptions, *gitdomain.CommitGraph) ([]shared.CompletedUpload, error)
 	history     []StoreFindClosestCompletedUploadsFromGraphFragmentFuncCall
 	mutex       sync.Mutex
 }
@@ -2457,16 +2445,16 @@ type StoreFindClosestCompletedUploadsFromGraphFragmentFunc struct {
 // FindClosestCompletedUploadsFromGraphFragment delegates to the next hook
 // function in the queue and stores the parameter and result values of this
 // invocation.
-func (m *MockStore) FindClosestCompletedUploadsFromGraphFragment(v0 context.Context, v1 int, v2 string, v3 string, v4 bool, v5 string, v6 *gitdomain.CommitGraph) ([]shared.CompletedUpload, error) {
-	r0, r1 := m.FindClosestCompletedUploadsFromGraphFragmentFunc.nextHook()(v0, v1, v2, v3, v4, v5, v6)
-	m.FindClosestCompletedUploadsFromGraphFragmentFunc.appendCall(StoreFindClosestCompletedUploadsFromGraphFragmentFuncCall{v0, v1, v2, v3, v4, v5, v6, r0, r1})
+func (m *MockStore) FindClosestCompletedUploadsFromGraphFragment(v0 context.Context, v1 shared.UploadMatchingOptions, v2 *gitdomain.CommitGraph) ([]shared.CompletedUpload, error) {
+	r0, r1 := m.FindClosestCompletedUploadsFromGraphFragmentFunc.nextHook()(v0, v1, v2)
+	m.FindClosestCompletedUploadsFromGraphFragmentFunc.appendCall(StoreFindClosestCompletedUploadsFromGraphFragmentFuncCall{v0, v1, v2, r0, r1})
 	return r0, r1
 }
 
 // SetDefaultHook sets function that is called when the
 // FindClosestCompletedUploadsFromGraphFragment method of the parent
 // MockStore instance is invoked and the hook queue is empty.
-func (f *StoreFindClosestCompletedUploadsFromGraphFragmentFunc) SetDefaultHook(hook func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared.CompletedUpload, error)) {
+func (f *StoreFindClosestCompletedUploadsFromGraphFragmentFunc) SetDefaultHook(hook func(context.Context, shared.UploadMatchingOptions, *gitdomain.CommitGraph) ([]shared.CompletedUpload, error)) {
 	f.defaultHook = hook
 }
 
@@ -2475,7 +2463,7 @@ func (f *StoreFindClosestCompletedUploadsFromGraphFragmentFunc) SetDefaultHook(h
 // MockStore instance invokes the hook at the front of the queue and
 // discards it. After the queue is empty, the default hook function is
 // invoked for any future action.
-func (f *StoreFindClosestCompletedUploadsFromGraphFragmentFunc) PushHook(hook func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared.CompletedUpload, error)) {
+func (f *StoreFindClosestCompletedUploadsFromGraphFragmentFunc) PushHook(hook func(context.Context, shared.UploadMatchingOptions, *gitdomain.CommitGraph) ([]shared.CompletedUpload, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -2484,19 +2472,19 @@ func (f *StoreFindClosestCompletedUploadsFromGraphFragmentFunc) PushHook(hook fu
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
 func (f *StoreFindClosestCompletedUploadsFromGraphFragmentFunc) SetDefaultReturn(r0 []shared.CompletedUpload, r1 error) {
-	f.SetDefaultHook(func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared.CompletedUpload, error) {
+	f.SetDefaultHook(func(context.Context, shared.UploadMatchingOptions, *gitdomain.CommitGraph) ([]shared.CompletedUpload, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
 func (f *StoreFindClosestCompletedUploadsFromGraphFragmentFunc) PushReturn(r0 []shared.CompletedUpload, r1 error) {
-	f.PushHook(func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared.CompletedUpload, error) {
+	f.PushHook(func(context.Context, shared.UploadMatchingOptions, *gitdomain.CommitGraph) ([]shared.CompletedUpload, error) {
 		return r0, r1
 	})
 }
 
-func (f *StoreFindClosestCompletedUploadsFromGraphFragmentFunc) nextHook() func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared.CompletedUpload, error) {
+func (f *StoreFindClosestCompletedUploadsFromGraphFragmentFunc) nextHook() func(context.Context, shared.UploadMatchingOptions, *gitdomain.CommitGraph) ([]shared.CompletedUpload, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -2536,22 +2524,10 @@ type StoreFindClosestCompletedUploadsFromGraphFragmentFuncCall struct {
 	Arg0 context.Context
 	// Arg1 is the value of the 2nd argument passed to this method
 	// invocation.
-	Arg1 int
+	Arg1 shared.UploadMatchingOptions
 	// Arg2 is the value of the 3rd argument passed to this method
 	// invocation.
-	Arg2 string
-	// Arg3 is the value of the 4th argument passed to this method
-	// invocation.
-	Arg3 string
-	// Arg4 is the value of the 5th argument passed to this method
-	// invocation.
-	Arg4 bool
-	// Arg5 is the value of the 6th argument passed to this method
-	// invocation.
-	Arg5 string
-	// Arg6 is the value of the 7th argument passed to this method
-	// invocation.
-	Arg6 *gitdomain.CommitGraph
+	Arg2 *gitdomain.CommitGraph
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 []shared.CompletedUpload
@@ -2563,7 +2539,7 @@ type StoreFindClosestCompletedUploadsFromGraphFragmentFuncCall struct {
 // Args returns an interface slice containing the arguments of this
 // invocation.
 func (c StoreFindClosestCompletedUploadsFromGraphFragmentFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4, c.Arg5, c.Arg6}
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
 }
 
 // Results returns an interface slice containing the results of this

--- a/internal/codeintel/uploads/service.go
+++ b/internal/codeintel/uploads/service.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"time"
 
-	"go.opentelemetry.io/otel/attribute"
-
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/uploads/internal/lsifstore"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/uploads/internal/store"
@@ -104,17 +102,11 @@ const numAncestors = 100
 // the graph. This will not always produce the full set of visible commits - some responses may not contain
 // all results while a subsequent request made after the lsif_nearest_uploads has been updated to include
 // this commit will.
-func (s *Service) InferClosestUploads(ctx context.Context, repositoryID int, commit, path string, exactPath bool, indexer string) (_ []shared.CompletedUpload, err error) {
-	ctx, _, endObservation := s.operations.inferClosestUploads.With(ctx, &err, observation.Args{Attrs: []attribute.KeyValue{
-		attribute.Int("repositoryID", repositoryID),
-		attribute.String("commit", commit),
-		attribute.String("path", path),
-		attribute.Bool("exactPath", exactPath),
-		attribute.String("indexer", indexer),
-	}})
+func (s *Service) InferClosestUploads(ctx context.Context, opts shared.UploadMatchingOptions) (_ []shared.CompletedUpload, err error) {
+	ctx, _, endObservation := s.operations.inferClosestUploads.With(ctx, &err, observation.Args{Attrs: opts.Attrs()})
 	defer endObservation(1, observation.Args{})
 
-	repo, err := s.repoStore.Get(ctx, api.RepoID(repositoryID))
+	repo, err := s.repoStore.Get(ctx, api.RepoID(opts.RepositoryID))
 	if err != nil {
 		return nil, err
 	}
@@ -123,21 +115,21 @@ func (s *Service) InferClosestUploads(ctx context.Context, repositoryID int, com
 	// that can answer queries for a directory (e.g. diagnostics), we want any dump that happens
 	// to intersect the target directory. If we're looking for dumps that can answer queries for
 	// a single file, then we need a dump with a root that properly encloses that file.
-	if uploads, err := s.store.FindClosestCompletedUploads(ctx, repositoryID, commit, path, exactPath, indexer); err != nil {
+	if uploads, err := s.store.FindClosestCompletedUploads(ctx, opts); err != nil {
 		return nil, errors.Wrap(err, "store.FindClosestCompletedUploads")
 	} else if len(uploads) != 0 {
 		return uploads, nil
 	}
 
 	// Repository has no LSIF data at all
-	if repositoryExists, err := s.store.HasRepository(ctx, repositoryID); err != nil {
+	if repositoryExists, err := s.store.HasRepository(ctx, opts.RepositoryID); err != nil {
 		return nil, errors.Wrap(err, "dbstore.HasRepository")
 	} else if !repositoryExists {
 		return nil, nil
 	}
 
 	// Commit is known and the empty dumps list explicitly means nothing is visible
-	if commitExists, err := s.store.HasCommit(ctx, repositoryID, commit); err != nil {
+	if commitExists, err := s.store.HasCommit(ctx, opts.RepositoryID, opts.Commit); err != nil {
 		return nil, errors.Wrap(err, "dbstore.HasCommit")
 	} else if commitExists {
 		return nil, nil
@@ -149,19 +141,19 @@ func (s *Service) InferClosestUploads(ctx context.Context, repositoryID int, com
 	// graph as dirty so it's updated for subsequent requests.
 
 	graph, err := s.gitserverClient.CommitGraph(ctx, repo.Name, gitserver.CommitGraphOptions{
-		Commit: commit,
+		Commit: opts.Commit,
 		Limit:  numAncestors,
 	})
 	if err != nil {
 		return nil, errors.Wrap(err, "gitserverClient.CommitGraph")
 	}
 
-	uploads, err := s.store.FindClosestCompletedUploadsFromGraphFragment(ctx, repositoryID, commit, path, exactPath, indexer, graph)
+	uploads, err := s.store.FindClosestCompletedUploadsFromGraphFragment(ctx, opts, graph)
 	if err != nil {
 		return nil, errors.Wrap(err, "dbstore.FindClosestCompletedUploadsFromGraphFragment")
 	}
 
-	if err := s.store.SetRepositoryAsDirty(ctx, repositoryID); err != nil {
+	if err := s.store.SetRepositoryAsDirty(ctx, opts.RepositoryID); err != nil {
 		return nil, errors.Wrap(err, "dbstore.MarkRepositoryAsDirty")
 	}
 

--- a/internal/codeintel/uploads/shared/BUILD.bazel
+++ b/internal/codeintel/uploads/shared/BUILD.bazel
@@ -17,5 +17,6 @@ go_library(
         "//lib/codeintel/autoindex/config",
         "//lib/errors",
         "@com_github_sourcegraph_scip//bindings/go/scip",
+        "@io_opentelemetry_go_otel//attribute",
     ],
 )


### PR DESCRIPTION
There are lots of layers of indirection/plumbing for propagating
the various options/settings for matching uploads. There was also
a mix of terminology - 'toolName' in some places and 'indexer'
in some other places. 'exactPath' in some places and 'rootMustEnclosePath'
in other places. Grouping the various options into a struct provides
a central place to document how the path matching happens,
as well as special arguments such as `shared.SyntacticIndexer`.

This also makes it much easier to understand where the various
upload matching options are used via 'Find usages' in the editor.

As a nice side-effect, the noise of creating o11y-related K-V pairs
is also reduced.

## Test plan

Covered by existing tests