### PR TITLE
release: disable promotion of development release & add --development flag to baseFlags

### DIFF
--- a/dev/sg/internal/release/config.go
+++ b/dev/sg/internal/release/config.go
@@ -117,8 +117,6 @@ func validateRequirementOnly(only []string) error {
 type cmdManifest struct {
 	Name string `yaml:"name"`
 	Cmd  string `yaml:"cmd"`
-
-	SkipInDevelopment bool `yaml:"skipInDevelopment"`
 }
 
 type input struct {
@@ -389,11 +387,6 @@ func (r *releaseRunner) PromoteFinalize(ctx context.Context) error {
 
 func (r *releaseRunner) runSteps(ctx context.Context, steps []cmdManifest) error {
 	for _, step := range steps {
-		if r.isDevelopment && step.SkipInDevelopment {
-			announce2("step", "Skipping step %q, this is a development release", step.Name)
-			continue
-		}
-
 		cmd := interpolate(step.Cmd, r.vars)
 		if r.pretend {
 			announce2("step", "Pretending to run step %q", step.Name)

--- a/dev/sg/internal/release/config.go
+++ b/dev/sg/internal/release/config.go
@@ -389,7 +389,7 @@ func (r *releaseRunner) PromoteFinalize(ctx context.Context) error {
 
 func (r *releaseRunner) runSteps(ctx context.Context, steps []cmdManifest) error {
 	for _, step := range steps {
-		if step.SkipInDevelopment && r.isDevelopment {
+		if r.isDevelopment && step.SkipInDevelopment {
 			announce2("step", "Skipping step %q, this is a development release", step.Name)
 			continue
 		}

--- a/dev/sg/internal/release/release.go
+++ b/dev/sg/internal/release/release.go
@@ -49,6 +49,11 @@ var releaseBaseFlags = []cli.Flag{
 		Value: false,
 		Usage: "Infer run configuration from last commit instead of flags.",
 	},
+	&cli.BoolFlag{
+		Name:    "development",
+		Aliases: []string{"d"},
+		Usage:   "Create a development release. This is a release that is not meant to be promoted to public, but is meant to be used by other developers to test their changes. It is not meant to be used by customers.",
+	},
 }
 
 // releaseRunFlags are the flags for the release run * subcommands. Version is optional here, because
@@ -68,11 +73,6 @@ var releaseCreatePromoteFlags = append(releaseBaseFlags, []cli.Flag{
 		Name:     "version",
 		Usage:    "Force version (required)",
 		Required: true,
-	},
-	&cli.BoolFlag{
-		Name:    "development",
-		Aliases: []string{"d"},
-		Usage:   "Create a development release. This is a release that is not meant to be promoted to public, but is meant to be used by other developers to test their changes. It is not meant to be used by customers.",
 	},
 }...)
 

--- a/release.yaml
+++ b/release.yaml
@@ -110,7 +110,6 @@ test:
           exit 1
         fi
     - name: 'check:migrator-schemas'
-      skipInDevelopment: true
       cmd: |
         set -eu
 
@@ -147,7 +146,6 @@ test:
           exit 1
         fi
     - name: 'db:migration:coherence_test'
-      skipInDevelopment: true
       cmd: |
         set -eu
 

--- a/release.yaml
+++ b/release.yaml
@@ -110,6 +110,7 @@ test:
           exit 1
         fi
     - name: 'check:migrator-schemas'
+      skipInDevelopment: true
       cmd: |
         set -eu
 
@@ -146,6 +147,7 @@ test:
           exit 1
         fi
     - name: 'db:migration:coherence_test'
+      skipInDevelopment: true
       cmd: |
         set -eu
 


### PR DESCRIPTION
[Context](https://sourcegraph.slack.com/archives/C05RRHSQ3QD/p1714558200079689?thread_ts=1714493051.206709&cid=C05RRHSQ3QD)

Since the introduction of the `--development` flag for creating development releases, we've made it possible to have more than one release with the same version, however one of them can't be promoted (the development release).
Since this is mostly for testing, 

## Test plan

* Manual testing
