### PR TITLE
Svelte: Visual update to history and reference bottom panel

### DIFF
--- a/client/web-sveltekit/src/lib/Tabs.svelte
+++ b/client/web-sveltekit/src/lib/Tabs.svelte
@@ -110,7 +110,7 @@
         letter-spacing: normal;
         margin: 0;
         min-height: 2rem;
-        padding: 0.5rem 0.75rem;
+        padding: 0.25rem 0.75rem;
         color: var(--text-body);
         text-transform: none;
         display: inline-flex;

--- a/client/web-sveltekit/src/lib/repo/LastCommit.svelte
+++ b/client/web-sveltekit/src/lib/repo/LastCommit.svelte
@@ -39,6 +39,7 @@
         margin-right: 0.5rem;
         white-space: nowrap;
         max-width: 400px;
+        font-size: var(--font-size-small);
     }
 
     .avatar {

--- a/client/web-sveltekit/src/routes/svelte-overrides.scss
+++ b/client/web-sveltekit/src/routes/svelte-overrides.scss
@@ -12,6 +12,7 @@ h6 {
 }
 
 body {
+    --font-size-small: 0.875rem;
     --font-size-base: 0.9375rem;
     --code-font-size: 13px;
     --border-radius: 4px;


### PR DESCRIPTION
# Context
Some of the previous base font-size changes have meant certain elements need application of smaller fonts and padding.

## Before
<img width="1509" alt="CleanShot 2024-05-01 at 13 01 26@2x" src="https://github.com/sourcegraph/sourcegraph/assets/5337876/036c149f-9746-43c9-8a39-88662104e0f9">

## After
<img width="1506" alt="CleanShot 2024-05-01 at 13 01 05@2x" src="https://github.com/sourcegraph/sourcegraph/assets/5337876/e1a0c9b8-4082-41b8-8f5c-814a408b0222">


## Test plan
Tested locally for visual changes.