### PR TITLE
[Svelte]: Improve result indicator layout

### DIFF
--- a/client/web-sveltekit/src/lib/search/resultsIndicator/ResultsIndicator.svelte
+++ b/client/web-sveltekit/src/lib/search/resultsIndicator/ResultsIndicator.svelte
@@ -36,52 +36,66 @@
     $: done = progress.done || state === 'complete'
 </script>
 
-<div class="indicator">
-    <div>
-        {#if loading}
-            <LoadingSpinner --icon-size="18px" inline />
-        {:else}
-            <Icon
-                svgPath={icons[severity]}
-                --icon-size="18px"
-                --color={isError ? 'var(--danger)' : 'var(--text-title)'}
-            />
-        {/if}
+<div class="root">
+    <div class="indicator">
+        <div class="progress-message">
+            <div class="icon">
+                {#if loading}
+                    <LoadingSpinner --icon-size="18px" inline />
+                {:else}
+                    <Icon
+                        svgPath={icons[severity]}
+                        --icon-size="18px"
+                        --color={isError ? 'var(--danger)' : 'var(--text-title)'}
+                    />
+                {/if}
+            </div>
+
+            <ProgressMessage {state} {progress} {severity} />
+        </div>
+
+        <div class="messages">
+            {#if !done && takingTooLong}
+                <TimeoutMessage />
+            {:else if done}
+                <SuggestedAction {progress} {suggestedItems} {severity} {state} />
+            {:else}
+                <span>Running search...</span>
+            {/if}
+        </div>
     </div>
 
-    <div class="messages">
-        <ProgressMessage {state} {progress} {severity} />
-        {#if !done && takingTooLong}
-            <TimeoutMessage />
-        {:else if done}
-            <SuggestedAction {progress} {suggestedItems} {severity} {state} />
-        {:else}
-            <span>Running search...</span>
-        {/if}
-    </div>
     <Icon svgPath={mdiChevronDown} --icon-size="18px" --color={isError ? 'var(--danger)' : 'var(--text-title)'} />
 </div>
 
 <style lang="scss">
+    .root {
+        display: flex;
+        gap: 0.5rem;
+        align-items: center;
+    }
+
     .indicator {
         display: flex;
-        flex-flow: row nowrap;
-        justify-content: space-evenly;
+        flex-wrap: wrap;
         align-items: center;
         gap: 0.5rem;
-        min-width: 200px;
-        max-width: fit-content;
 
-        padding: 0.25rem;
+        .progress-message {
+            display: flex;
+            gap: 0.5rem;
+            align-items: center;
+        }
+
+        .icon {
+            align-self: baseline;
+        }
 
         .messages {
             display: flex;
-            flex-flow: column nowrap;
-            justify-content: center;
-            align-items: flex-start;
-            margin-right: 0.75rem;
-            margin-left: 0.5rem;
-            row-gap: 0.25rem;
+            flex-flow: row nowrap;
+            align-items: baseline;
+            gap: 0.25rem;
         }
 
         span {

--- a/client/web-sveltekit/src/lib/search/resultsIndicator/SuggestedAction.svelte
+++ b/client/web-sveltekit/src/lib/search/resultsIndicator/SuggestedAction.svelte
@@ -10,7 +10,6 @@
     export let state: 'error' | 'complete' | 'loading'
 
     const SEE_MORE = 'See more details'
-    const CENTER_DOT = '\u00B7' // AKA 'interpunct'
 
     interface ItemsBySeverity {
         items: Skipped[]
@@ -40,7 +39,6 @@
     {#if hasSkippedItems && mostSevere}
         <small class="info-badge" class:error-text={isError}>{capitalize(mostSevere?.title ?? mostSevere.title)}</small>
         {#if mostSevere.suggested}
-            <small>{CENTER_DOT}</small>
             <small>{capitalize(mostSevere?.suggested ? mostSevere.suggested.title : '')}</small>
             <small class="code-font">{mostSevere.suggested?.queryExpression}</small>
         {/if}

--- a/client/web-sveltekit/src/routes/search/SearchResults.svelte
+++ b/client/web-sveltekit/src/routes/search/SearchResults.svelte
@@ -237,12 +237,11 @@
         flex-direction: column;
 
         .actions {
-            border-bottom: 1px solid var(--border-color);
-            padding: 0.5rem 0;
-            padding-left: 0.25rem;
+            flex-shrink: 0;
             display: flex;
             align-items: center;
-            flex-shrink: 0;
+            padding: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
         }
 
         .result-list {
@@ -258,10 +257,9 @@
         .message-container {
             display: flex;
             flex-direction: column;
-            align-items: center;
-            margin: auto;
-            color: var(--text-muted);
             margin: 2rem;
+            align-items: center;
+            color: var(--text-muted);
         }
     }
 </style>

--- a/client/web-sveltekit/src/routes/search/StreamingProgress.svelte
+++ b/client/web-sveltekit/src/routes/search/StreamingProgress.svelte
@@ -163,7 +163,6 @@
     .progress-button {
         border: 1px solid var(--border-color-2);
         border-radius: 4px;
-        margin-left: 0.3rem;
     }
 
     .streaming-popover {


### PR DESCRIPTION
The main intention to change here is to save vertical space, we already have a few panels and sticky headers in the search result block, and having an additional row in the sticky header above make this panel crowded especially on mid-size screens

| Before | After |
| ------- | ------- |
| <img width="1179" alt="Screenshot 2024-05-01 at 14 16 47" src="https://github.com/sourcegraph/sourcegraph/assets/18492575/4bd866cc-0f68-4daf-b167-03ac0c2b4bcc"> |  <img width="1179" alt="Screenshot 2024-05-01 at 14 15 52" src="https://github.com/sourcegraph/sourcegraph/assets/18492575/43b49fae-f260-42a1-9768-50410c773281"> |


## Test plan
- Check progress result UI on the search result page

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
