### PR TITLE
build-tracker: fix convenience urls in env

### DIFF
--- a/dev/build-tracker/BUILD.bazel
+++ b/dev/build-tracker/BUILD.bazel
@@ -27,6 +27,7 @@ go_library(
         "@com_github_buildkite_go_buildkite_v3//buildkite",
         "@com_github_gorilla_mux//:mux",
         "@com_github_sourcegraph_log//:log",
+        "@org_golang_x_exp//maps",
     ],
 )
 
@@ -51,6 +52,7 @@ go_test(
         "//dev/build-tracker/notify",
         "//dev/team",
         "//internal/goroutine",
+        "//lib/pointers",
         "@com_github_buildkite_go_buildkite_v3//buildkite",
         "@com_github_gorilla_mux//:mux",
         "@com_github_sourcegraph_log//logtest",

--- a/dev/build-tracker/server_test.go
+++ b/dev/build-tracker/server_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/dev/build-tracker/config"
 	"github.com/sourcegraph/sourcegraph/dev/build-tracker/notify"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
+	"github.com/sourcegraph/sourcegraph/lib/pointers"
 )
 
 func TestGetBuild(t *testing.T) {
@@ -214,24 +215,26 @@ func TestProcessEvent(t *testing.T) {
 		state := "done"
 		pipelineID := "pipeline"
 		pipeline := &buildkite.Pipeline{
-			ID:   &pipelineID,
-			Name: &pipelineID,
+			ID:         &pipelineID,
+			Name:       &pipelineID,
+			Repository: pointers.Ptr("banana"),
 		}
 		jobState := build.JobPassedState
 		if jobExitCode != 0 {
 			jobState = build.JobFailedState
 		}
 		job := buildkite.Job{Name: &name, ExitStatus: &jobExitCode, State: &jobState}
-		return &build.Event{Name: build.EventJobFinished, Build: buildkite.Build{State: &state, Number: &buildNumber, Pipeline: pipeline}, Job: job}
+		return &build.Event{Name: build.EventJobFinished, Build: buildkite.Build{State: &state, Number: &buildNumber, Pipeline: pipeline}, Job: job, Pipeline: *pipeline}
 	}
 	newBuildEvent := func(name string, buildNumber int, state string, branch string, jobExitCode int) *build.Event {
 		job := newJobEvent(name, buildNumber, jobExitCode)
 		pipelineID := "pipeline"
 		pipeline := &buildkite.Pipeline{
-			ID:   &pipelineID,
-			Name: &pipelineID,
+			ID:         &pipelineID,
+			Name:       &pipelineID,
+			Repository: pointers.Ptr("banana"),
 		}
-		return &build.Event{Name: build.EventBuildFinished, Build: buildkite.Build{State: &state, Branch: &branch, Number: &buildNumber, Pipeline: pipeline}, Job: job.Job}
+		return &build.Event{Name: build.EventBuildFinished, Build: buildkite.Build{State: &state, Branch: &branch, Number: &buildNumber, Pipeline: pipeline}, Job: job.Job, Pipeline: *pipeline}
 	}
 	t.Run("no send notification on unfinished builds", func(t *testing.T) {
 		server := NewServer(":8080", logger, config.Config{})

--- a/internal/testutil/istest.go
+++ b/internal/testutil/istest.go
@@ -11,5 +11,5 @@ var IsTest = func() bool {
 	return strings.HasSuffix(filepath.Base(path), "_test") || // Test binary build by Bazel
 		filepath.Ext(path) == ".test" ||
 		strings.Contains(path, "/T/___") || // Test path used by GoLand
-		filepath.Base(path) == "__debug_bin" // Debug binary used by VSCode
+		strings.HasPrefix(filepath.Base(path), "__debug_bin") // Debug binary used by VSCode
 }()


### PR DESCRIPTION
This isnt exactly convenient lol
```
DEVX_TRIGGERED_FROM_BRANCH_URL="/tree/main"
DEVX_TRIGGERED_FROM_BUILD_ID="018f343b-5cfc-420c-9353-02821de45533"
DEVX_TRIGGERED_FROM_BUILD_NUMBER="271872"
DEVX_TRIGGERED_FROM_COMMIT="6d7082d26ee772be9cd3fd2b463c0f33a95ee7dc"
DEVX_TRIGGERED_FROM_COMMIT_URL="/commit/6d7082d26ee772be9cd3fd2b463c0f33a95ee7dc"
DEVX_TRIGGERED_FROM_PIPELINE_SLUG="sourcegraph"
DEVX_TRIGGERED_FROM_PR_NUMBER="0"
DEVX_TRIGGERED_FROM_PR_URL="/pull/0"
```

## Test plan

Live :letsgo: