### PR TITLE
Use newer config settings if available (allow local SAMS/SSC dev)

### DIFF
--- a/cmd/frontend/graphqlbackend/external_account.go
+++ b/cmd/frontend/graphqlbackend/external_account.go
@@ -2,7 +2,6 @@ package graphqlbackend
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/graph-gophers/graphql-go"
 	"github.com/graph-gophers/graphql-go/relay"
@@ -63,7 +62,7 @@ func (r *externalAccountResolver) CodySubscription(ctx context.Context) (*CodySu
 		return nil, errors.New("this feature is only available on sourcegraph.com")
 	}
 
-	if r.account.ServiceType != "openidconnect" || r.account.ServiceID != fmt.Sprintf("https://%s", ssc.GetSAMSHostName()) {
+	if r.account.ServiceType != "openidconnect" || r.account.ServiceID != ssc.GetSAMSServiceID() {
 		return nil, nil
 	}
 

--- a/cmd/frontend/internal/app/ui/router.go
+++ b/cmd/frontend/internal/app/ui/router.go
@@ -80,6 +80,13 @@ var aboutRedirects = map[string]string{
 	"help/terms": "terms",
 }
 
+type staticPageInfo struct {
+	// Specify either path OR pathPrefix.
+	path, pathPrefix string
+	name, title      string
+	index            bool
+}
+
 // Router returns the router that serves pages for our web app.
 func Router() *mux.Router {
 	return uirouter.Router
@@ -111,13 +118,8 @@ func InitRouter(db database.DB) {
 	ghAppRouter := r.PathPrefix("/githubapp/").Subrouter()
 	githubapp.SetupGitHubAppRoutes(ghAppRouter, db)
 
-	// Basic pages with static titles
-	for _, p := range []struct {
-		// Specify either path OR pathPrefix.
-		path, pathPrefix string
-		name, title      string
-		index            bool
-	}{
+	// Basic pages with static titles.
+	staticPages := []staticPageInfo{
 		// with index:
 		{pathPrefix: "/insights", name: "insights", title: "Insights", index: true},
 		{pathPrefix: "/search-jobs", name: "search-jobs", title: "Search Jobs", index: true},
@@ -160,7 +162,8 @@ func InitRouter(db database.DB) {
 		{path: "/survey", name: "survey", title: "Survey", index: false},
 		{path: "/survey/{score}", name: "survey-score", title: "Survey", index: false},
 		{path: "/welcome", name: "welcome", title: "Welcome", index: false},
-	} {
+	}
+	for _, p := range staticPages {
 		var handler http.Handler
 		if p.index {
 			handler = brandedIndex(p.title)

--- a/cmd/frontend/internal/cody/subscription_test.go
+++ b/cmd/frontend/internal/cody/subscription_test.go
@@ -2,7 +2,6 @@ package cody
 
 import (
 	"context"
-	"fmt"
 	"testing"
 	"time"
 
@@ -130,7 +129,7 @@ func TestGetSubscriptionForUser(t *testing.T) {
 					accounts = append(accounts, &extsvc.Account{AccountSpec: extsvc.AccountSpec{
 						AccountID:   MockSSCValue.SAMSAccountID,
 						ServiceType: "openidconnect",
-						ServiceID:   fmt.Sprintf("https://%s/", ssc.GetSAMSHostName()),
+						ServiceID:   ssc.GetSAMSServiceID(),
 					}})
 				}
 

--- a/cmd/frontend/internal/dotcom/productsubscription/codygateway_dotcom_user_test.go
+++ b/cmd/frontend/internal/dotcom/productsubscription/codygateway_dotcom_user_test.go
@@ -2,7 +2,6 @@ package productsubscription_test
 
 import (
 	"context"
-	"fmt"
 	"math"
 	"testing"
 	"time"
@@ -313,7 +312,7 @@ func TestCodyGatewayCompletionsRateLimit(t *testing.T) {
 		AccountSpec: extsvc.AccountSpec{
 			AccountID:   "123",
 			ServiceType: "openidconnect",
-			ServiceID:   fmt.Sprintf("https://%s", ssc.GetSAMSHostName()),
+			ServiceID:   ssc.GetSAMSServiceID(),
 		},
 	})
 	require.NoError(t, err)
@@ -328,7 +327,7 @@ func TestCodyGatewayCompletionsRateLimit(t *testing.T) {
 		AccountSpec: extsvc.AccountSpec{
 			AccountID:   "456",
 			ServiceType: "openidconnect",
-			ServiceID:   fmt.Sprintf("https://%s", ssc.GetSAMSHostName()),
+			ServiceID:   ssc.GetSAMSServiceID(),
 		},
 	})
 	require.NoError(t, err)
@@ -343,7 +342,7 @@ func TestCodyGatewayCompletionsRateLimit(t *testing.T) {
 		AccountSpec: extsvc.AccountSpec{
 			AccountID:   "789",
 			ServiceType: "openidconnect",
-			ServiceID:   fmt.Sprintf("https://%s", ssc.GetSAMSHostName()),
+			ServiceID:   ssc.GetSAMSServiceID(),
 		},
 	})
 	require.NoError(t, err)
@@ -358,7 +357,7 @@ func TestCodyGatewayCompletionsRateLimit(t *testing.T) {
 		AccountSpec: extsvc.AccountSpec{
 			AccountID:   "abc",
 			ServiceType: "openidconnect",
-			ServiceID:   fmt.Sprintf("https://%s", ssc.GetSAMSHostName()),
+			ServiceID:   ssc.GetSAMSServiceID(),
 		},
 	})
 	require.NoError(t, err)

--- a/cmd/frontend/internal/httpapi/ssc.go
+++ b/cmd/frontend/internal/httpapi/ssc.go
@@ -27,7 +27,7 @@ func newSSCRefreshCodyRateLimitHandler(logger log.Logger, db database.DB) http.H
 		oidcAccounts, err := db.UserExternalAccounts().List(ctx, database.ExternalAccountsListOptions{
 			AccountID:   samsAccountID,
 			ServiceType: "openidconnect",
-			ServiceID:   fmt.Sprintf("https://%s", ssc.GetSAMSHostName()),
+			ServiceID:   ssc.GetSAMSServiceID(),
 			LimitOffset: &database.LimitOffset{
 				Limit: 1,
 			},


### PR DESCRIPTION
This PR reworks the way we identify the SAMS or SSC backends from within the Sourcegraph instance. Previously the configuration setting was just a hostname (e.g. `accounts.sourcegraph.com` or `accounts.sgdev.org`.) However, this lead to us hard-coding the HTTPS scheme whenever the hostname was referenced.

This unfortunately makes it impossible(*) to test Sourcegraph locally when running against a SAMS or SSC backend running on `localhost`. Fortunately, we recently added new site config settings, that specify the full HTTP origin. (scheme, domain, and port) So if we use those newer values, things "just work".

The newer configuration values (`dotcom.codyProConfig.*`) are currently not set for sourcegraph.com, and are only used by the new code related to serving the SSC UI from sourcegraph.com. (So there shouldn't be any functional change in this PR, modulo one line.)

## Test plan

Tested locally, and we have validation to ensure the new config settings are correctly specified. (e.g. the `sscBackendOrigin` will never end with a trailing slash, etc.)