### PR TITLE
Pass go debug flags to zoekt to enable better debugging

### DIFF
--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -513,7 +513,6 @@ commands:
       if [ -n "$DELVE" ]; then
         export GCFLAGS='all=-N -l'
       fi
-      export GCFLAGS='all=-N -l'
       mkdir -p .bin
       export GOBIN="${PWD}/.bin"
       go install -gcflags="$GCFLAGS" github.com/sourcegraph/zoekt/cmd/zoekt-archive-index

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -510,6 +510,9 @@ commands:
         -listen "127.0.0.1:$ZOEKT_LISTEN_PORT" \
         -cpu_fraction 0.25
     install: |
+      if [ -n "$DELVE" ]; then
+        export GCFLAGS='all=-N -l'
+      fi
       export GCFLAGS='all=-N -l'
       mkdir -p .bin
       export GOBIN="${PWD}/.bin"
@@ -540,7 +543,9 @@ commands:
 
   zoekt-web-template: &zoekt_webserver_template
     install: |
-      export GCFLAGS='all=-N -l'
+      if [ -n "$DELVE" ]; then
+        export GCFLAGS='all=-N -l'
+      fi
       mkdir -p .bin
       env GOBIN="${PWD}/.bin" go install -gcflags="$GCFLAGS" github.com/sourcegraph/zoekt/cmd/zoekt-webserver
     checkBinary: .bin/zoekt-webserver

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -510,11 +510,12 @@ commands:
         -listen "127.0.0.1:$ZOEKT_LISTEN_PORT" \
         -cpu_fraction 0.25
     install: |
+      export GCFLAGS='all=-N -l'
       mkdir -p .bin
       export GOBIN="${PWD}/.bin"
-      go install github.com/sourcegraph/zoekt/cmd/zoekt-archive-index
-      go install github.com/sourcegraph/zoekt/cmd/zoekt-git-index
-      go install github.com/sourcegraph/zoekt/cmd/zoekt-sourcegraph-indexserver
+      go install -gcflags="$GCFLAGS" github.com/sourcegraph/zoekt/cmd/zoekt-archive-index
+      go install -gcflags="$GCFLAGS" github.com/sourcegraph/zoekt/cmd/zoekt-git-index
+      go install -gcflags="$GCFLAGS" github.com/sourcegraph/zoekt/cmd/zoekt-sourcegraph-indexserver
     checkBinary: .bin/zoekt-sourcegraph-indexserver
     env: &zoektenv
       CTAGS_COMMAND: dev/universal-ctags-dev
@@ -539,8 +540,9 @@ commands:
 
   zoekt-web-template: &zoekt_webserver_template
     install: |
+      export GCFLAGS='all=-N -l'
       mkdir -p .bin
-      env GOBIN="${PWD}/.bin" go install github.com/sourcegraph/zoekt/cmd/zoekt-webserver
+      env GOBIN="${PWD}/.bin" go install -gcflags="$GCFLAGS" github.com/sourcegraph/zoekt/cmd/zoekt-webserver
     checkBinary: .bin/zoekt-webserver
     env:
       JAEGER_DISABLED: true


### PR DESCRIPTION
When testing a change I hit issues debugging zoekt. @ggilmore showed me how we can plumb the proper debug flags to zoekt.  This seems like it would be generally useful for local development.


## Test plan
- Debugged locally and it all worked!