### PR TITLE
Svelte: hide commit body if null

### DIFF
--- a/client/web-sveltekit/src/lib/Commit.svelte
+++ b/client/web-sveltekit/src/lib/Commit.svelte
@@ -54,7 +54,7 @@
             {/if}
         </span>
         <span>committed by <strong>{author.name}</strong> <Timestamp date={commitDate} /></span>
-        {#if expanded}
+        {#if expanded && commit.body}
             <pre>{commit.body}</pre>
         {/if}
     </div>


### PR DESCRIPTION
Just fixes a tiny issue where a null commit body will be rendered as "null" rather than just hidden.

![screenshot-2024-05-01_11-25-59@2x](https://github.com/sourcegraph/sourcegraph/assets/12631702/efc07945-31e5-46ab-981c-14d980e6cca1)

## Test plan
![screenshot-2024-05-01_11-28-39@2x](https://github.com/sourcegraph/sourcegraph/assets/12631702/d6eecb97-4aec-4dcd-b0a9-21b6fd524f24)

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
