### PR TITLE
Svelte: Highlight file/dir name on selected item in file tree.

### DIFF
--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/FileTree.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/FileTree.svelte
@@ -139,6 +139,7 @@
 </div>
 
 <style lang="scss">
+
     div {
         overflow: auto;
 
@@ -153,7 +154,6 @@
 
         :global(.treeitem.selected) > :global(.label) {
             background-color: var(--color-bg-3);
-            color: var(--text-title)
         }
     }
 

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/FileTree.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/FileTree.svelte
@@ -153,6 +153,7 @@
 
         :global(.treeitem.selected) > :global(.label) {
             background-color: var(--color-bg-3);
+            color: var(--text-title)
         }
     }
 
@@ -164,6 +165,10 @@
         white-space: nowrap;
         text-decoration: none;
         padding: 0.1rem 0;
+
+        :global(.treeitem.selected) & {
+            color: var(--text-title);
+        }
 
         &:hover {
             color: var(--text-title);


### PR DESCRIPTION
# Context
Apply slight styling to active items in the file tree.

## Before
<img width="445" alt="CleanShot 2024-05-01 at 19 40 12@2x" src="https://github.com/sourcegraph/sourcegraph/assets/5337876/b33d3ab8-9a1e-4700-9bbb-93614e99e966">

## After
<img width="394" alt="CleanShot 2024-05-01 at 19 38 39@2x" src="https://github.com/sourcegraph/sourcegraph/assets/5337876/5807ba74-3abf-4363-a50f-392313897194">


## Test plan
Tested locally for visual change.