### PR TITLE
Svelte: Font size tweaks for results indicator

### DIFF
--- a/client/web-sveltekit/src/lib/search/resultsIndicator/ProgressMessage.svelte
+++ b/client/web-sveltekit/src/lib/search/resultsIndicator/ProgressMessage.svelte
@@ -21,7 +21,8 @@
 
 <style lang="scss">
     .progress-message {
-        font-size: var(--font-size-base);
+        font-size: var(--font-size-small);
+        color: var(--text-title);
 
         &.error-text {
             color: var(--danger);

--- a/client/web-sveltekit/src/lib/search/resultsIndicator/ResultsIndicator.svelte
+++ b/client/web-sveltekit/src/lib/search/resultsIndicator/ResultsIndicator.svelte
@@ -81,6 +81,7 @@
 
         span {
             color: var(--text-muted);
+            padding: 0.125rem 0;
         }
     }
 </style>

--- a/client/web-sveltekit/src/lib/search/resultsIndicator/ResultsIndicator.svelte
+++ b/client/web-sveltekit/src/lib/search/resultsIndicator/ResultsIndicator.svelte
@@ -65,6 +65,11 @@
         align-items: center;
         gap: 0.75rem;
         padding: 0.375rem 0.75rem;
+        border-radius: var(--border-radius);
+
+        &:hover {
+            background-color: var(--color-bg-2);
+        }
 
         .messages {
             display: flex;

--- a/client/web-sveltekit/src/lib/search/resultsIndicator/ResultsIndicator.svelte
+++ b/client/web-sveltekit/src/lib/search/resultsIndicator/ResultsIndicator.svelte
@@ -76,12 +76,11 @@
             flex-flow: column nowrap;
             justify-content: center;
             align-items: flex-start;
-            row-gap: 0.125rem;
+            row-gap: 0.25rem;
         }
 
         span {
             color: var(--text-muted);
-            padding: 0.125rem 0;
         }
     }
 </style>

--- a/client/web-sveltekit/src/lib/search/resultsIndicator/SuggestedAction.svelte
+++ b/client/web-sveltekit/src/lib/search/resultsIndicator/SuggestedAction.svelte
@@ -58,6 +58,8 @@
         column-gap: 0.5rem;
         color: var(--text-muted);
         white-space: nowrap;
+        padding: 0.125rem 0;
+        font-size: var(--font-size-tiny);
 
         .info-badge {
             background-color: var(--primary-2);

--- a/client/web-sveltekit/src/lib/search/resultsIndicator/SuggestedAction.svelte
+++ b/client/web-sveltekit/src/lib/search/resultsIndicator/SuggestedAction.svelte
@@ -58,7 +58,6 @@
         column-gap: 0.5rem;
         color: var(--text-muted);
         white-space: nowrap;
-        padding: 0.125rem 0;
         font-size: var(--font-size-tiny);
 
         .info-badge {

--- a/client/web-sveltekit/src/routes/svelte-overrides.scss
+++ b/client/web-sveltekit/src/routes/svelte-overrides.scss
@@ -12,8 +12,9 @@ h6 {
 }
 
 body {
-    --font-size-small: 0.875rem;
     --font-size-base: 0.9375rem;
+    --font-size-small: 0.875rem;
+    --font-size-tiny: 0.8125rem;
     --code-font-size: 13px;
     --border-radius: 4px;
 


### PR DESCRIPTION
Follow up to https://github.com/sourcegraph/sourcegraph/pull/62317

## Test plan
Locally tested for visual changes.