### PR TITLE
Updates to cookies sent to HubSpot

### DIFF
--- a/cmd/frontend/hubspot/contacts.go
+++ b/cmd/frontend/hubspot/contacts.go
@@ -21,15 +21,6 @@ func (c *Client) CreateOrUpdateContact(email string, params *ContactProperties) 
 	}
 	var resp ContactResponse
 	err := c.postJSON("CreateOrUpdateContact", c.baseContactURL(email), newAPIValues(params), &resp)
-	if err != nil {
-		return &resp, err
-	}
-	if resp.IsNew {
-		// Certain properties (such as first source URL) should only be sent when a contact is new. Although
-		// the user's cookie value should not change, minimize risk of login via multiple browsers, clearing
-		// of cookies, etc. by not sending these values on subsequent logins.
-		err = c.postJSON("CreateOrUpdateContact", c.baseContactURL(email), firstTimeUserValues(params), &resp)
-	}
 	return &resp, err
 }
 
@@ -51,17 +42,11 @@ type ContactProperties struct {
 	HasAgreedToToS               bool   `json:"has_agreed_to_tos_and_pp"`
 	VSCodyInstalledEmailsEnabled bool   `json:"vs_cody_installed_emails_enabled"`
 
-	// The URL of the first page a user landed on their first session on a Sourcegraph site.
-	FirstSourceURL string `json:"first_source_url"`
-
 	// The URL of the first page a user landed on their latest session on a Sourcegraph site.
 	LastSourceURL string `json:"last_source_url"`
 
 	// The URL of the first page a user landed on the session when they signed up.
 	SignupSessionSourceURL string `json:"signup_session_source_url"`
-
-	// The referrer for a user on their first session on a Sourcegraph site.
-	OriginalReferrer string `json:"original_referrer"`
 
 	// The referrer for a user on their latest session on a Sourcegraph site.
 	LastReferrer string `json:"most_recent_referrer_url"`
@@ -70,19 +55,19 @@ type ContactProperties struct {
 	SignupSessionReferrer string `json:"signup_session_referrer"`
 
 	// The UTM campaign associated with the current session.
-	SessionUTMCampaign string `json:"utm_campaign"`
+	SessionUTMCampaign string `json:"recent_utm_campaign"`
 
 	// The UTM source associated with the current session.
-	SessionUTMSource string `json:"utm_source"`
+	SessionUTMSource string `json:"recent_utm_source"`
 
 	// The UTM medium associated with the current session.
-	SessionUTMMedium string `json:"utm_medium"`
+	SessionUTMMedium string `json:"recent_utm_medium"`
 
 	// The UTM term associated with the current session.
-	SessionUTMTerm string `json:"utm_term"`
+	SessionUTMTerm string `json:"recent_utm_term"`
 
 	// The UTM content associated with the current session.
-	SessionUTMContent string `json:"utm_content"`
+	SessionUTMContent string `json:"recent_utm_content"`
 
 	// The Google Ads click ID
 	GoogleClickID string `json:"gclid"`
@@ -112,21 +97,14 @@ func newAPIValues(h *ContactProperties) *apiProperties {
 	apiProps.set("signup_session_source_url", h.SignupSessionSourceURL)
 	apiProps.set("most_recent_referrer_url", h.LastReferrer)
 	apiProps.set("signup_session_referrer", h.SignupSessionReferrer)
-	apiProps.set("utm_campaign", h.SessionUTMCampaign)
-	apiProps.set("utm_source", h.SessionUTMSource)
-	apiProps.set("utm_medium", h.SessionUTMMedium)
-	apiProps.set("utm_term", h.SessionUTMTerm)
-	apiProps.set("utm_content", h.SessionUTMContent)
+	apiProps.set("recent_utm_campaign", h.SessionUTMCampaign)
+	apiProps.set("recent_utm_source", h.SessionUTMSource)
+	apiProps.set("recent_utm_medium", h.SessionUTMMedium)
+	apiProps.set("recent_utm_term", h.SessionUTMTerm)
+	apiProps.set("recent_utm_content", h.SessionUTMContent)
 	apiProps.set("gclid", h.GoogleClickID)
 	apiProps.set("msclkid", h.MicrosoftClickID)
 	return apiProps
-}
-
-func firstTimeUserValues(h *ContactProperties) *apiProperties {
-	firstTimeUserProps := &apiProperties{}
-	firstTimeUserProps.set("first_source_url", h.FirstSourceURL)
-	firstTimeUserProps.set("original_referrer", h.OriginalReferrer)
-	return firstTimeUserProps
 }
 
 // apiProperties represents a list of HubSpot API-compliant key-value pairs

--- a/cmd/frontend/internal/app/ui/handlers.go
+++ b/cmd/frontend/internal/app/ui/handlers.go
@@ -588,9 +588,7 @@ func servePingFromSelfHosted(w http.ResponseWriter, r *http.Request) error {
 	hubspotutil.SyncUser(email, hubspotutil.SelfHostedSiteInitEventID, &hubspot.ContactProperties{
 		IsServerAdmin:          true,
 		AnonymousUserID:        anonymousUserId,
-		FirstSourceURL:         getCookie("sourcegraphSourceUrl"),
 		LastSourceURL:          getCookie("sourcegraphRecentSourceUrl"),
-		OriginalReferrer:       getCookie("originalReferrer"),
 		LastReferrer:           getCookie("sg_referrer"),
 		SignupSessionSourceURL: getCookie("sourcegraphSignupSourceUrl"),
 		SignupSessionReferrer:  getCookie("sourcegraphSignupReferrer"),

--- a/cmd/frontend/internal/auth/oauth/session.go
+++ b/cmd/frontend/internal/auth/oauth/session.go
@@ -103,9 +103,7 @@ func SessionIssuer(logger log.Logger, db database.DB, s SessionIssuerHelper, ses
 		anonymousId, _ := cookie.AnonymousUID(r)
 		newUserCreated, actr, safeErrMsg, err := s.GetOrCreateUser(ctx, token, &hubspot.ContactProperties{
 			AnonymousUserID:        anonymousId,
-			FirstSourceURL:         getCookie("sourcegraphSourceUrl"),
 			LastSourceURL:          getCookie("sourcegraphRecentSourceUrl"),
-			OriginalReferrer:       getCookie("originalReferrer"),
 			LastReferrer:           getCookie("sg_referrer"),
 			SignupSessionSourceURL: getCookie("sourcegraphSignupSourceUrl"),
 			SignupSessionReferrer:  getCookie("sourcegraphSignupReferrer"),

--- a/cmd/frontend/internal/auth/openidconnect/middleware.go
+++ b/cmd/frontend/internal/auth/openidconnect/middleware.go
@@ -387,9 +387,7 @@ func AuthCallback(logger log.Logger, db database.DB, r *http.Request, usernamePr
 
 	newUserCreated, actor, safeErrMsg, err := getOrCreateUser(ctx, logger, db, p, oauth2Token, idToken, userInfo, &claims, usernamePrefix, userCreateEventProperties, &hubspot.ContactProperties{
 		AnonymousUserID:        anonymousId,
-		FirstSourceURL:         getCookie("sourcegraphSourceUrl"),
 		LastSourceURL:          getCookie("sourcegraphRecentSourceUrl"),
-		OriginalReferrer:       getCookie("originalReferrer"),
 		LastReferrer:           getCookie("sg_referrer"),
 		SignupSessionSourceURL: getCookie("sourcegraphSignupSourceUrl"),
 		SignupSessionReferrer:  getCookie("sourcegraphSignupReferrer"),

--- a/cmd/frontend/internal/auth/openidconnect/user_test.go
+++ b/cmd/frontend/internal/auth/openidconnect/user_test.go
@@ -94,7 +94,6 @@ func TestAllowSignup(t *testing.T) {
 
 				&hubspot.ContactProperties{
 					AnonymousUserID: "anonymous-user-id-123",
-					FirstSourceURL:  "https://example.com/",
 					LastSourceURL:   "https://example.com/",
 				})
 			require.NoError(t, err)

--- a/internal/auth/userpasswd/handlers.go
+++ b/internal/auth/userpasswd/handlers.go
@@ -141,9 +141,7 @@ func handleSignUp(logger log.Logger, db database.DB, eventRecorder *telemetry.Ev
 		go hubspotutil.SyncUser(creds.Email, hubspotutil.SignupEventID, &hubspot.ContactProperties{
 			DatabaseID:             usr.ID,
 			AnonymousUserID:        creds.AnonymousUserID,
-			FirstSourceURL:         creds.FirstSourceURL,
 			LastSourceURL:          creds.LastSourceURL,
-			OriginalReferrer:       getCookie("originalReferrer"),
 			LastReferrer:           getCookie("sg_referrer"),
 			SignupSessionSourceURL: getCookie("sourcegraphSignupSourceUrl"),
 			SignupSessionReferrer:  getCookie("sourcegraphSignupReferrer"),


### PR DESCRIPTION
Updates to cookies sent to HubSpot on user signups on dotcom. Changing property names and eliminating certain fields.

## Test plan

Low risk change that only affects dotcom. Confirmed it compiled and ran locally. CI.