### PR TITLE
gitserver: grpc: add new ChangedFiles method to gitserver client

### DIFF
--- a/cmd/gitserver/internal/server_grpc_logger.go
+++ b/cmd/gitserver/internal/server_grpc_logger.go
@@ -6,17 +6,15 @@ import (
 	"sync/atomic"
 	"time"
 
-	"google.golang.org/grpc/codes"
-
-	"github.com/sourcegraph/sourcegraph/cmd/gitserver/internal/urlredactor"
-	"github.com/sourcegraph/sourcegraph/internal/grpc/grpcutil"
-	"github.com/sourcegraph/sourcegraph/internal/vcs"
-
 	"github.com/sourcegraph/log"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"github.com/sourcegraph/sourcegraph/cmd/gitserver/internal/urlredactor"
 	proto "github.com/sourcegraph/sourcegraph/internal/gitserver/v1"
+	"github.com/sourcegraph/sourcegraph/internal/grpc/grpcutil"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
+	"github.com/sourcegraph/sourcegraph/internal/vcs"
 )
 
 // loggingGRPCServer is a wrapper around the provided GitserverServiceServer

--- a/internal/batches/sources/mocks_test.go
+++ b/internal/batches/sources/mocks_test.go
@@ -10989,6 +10989,9 @@ type MockGitserverClient struct {
 	// BehindAheadFunc is an instance of a mock function object controlling
 	// the behavior of the method BehindAhead.
 	BehindAheadFunc *GitserverClientBehindAheadFunc
+	// ChangedFilesFunc is an instance of a mock function object controlling
+	// the behavior of the method ChangedFiles.
+	ChangedFilesFunc *GitserverClientChangedFilesFunc
 	// CheckPerforceCredentialsFunc is an instance of a mock function object
 	// controlling the behavior of the method CheckPerforceCredentials.
 	CheckPerforceCredentialsFunc *GitserverClientCheckPerforceCredentialsFunc
@@ -11121,6 +11124,11 @@ func NewMockGitserverClient() *MockGitserverClient {
 		},
 		BehindAheadFunc: &GitserverClientBehindAheadFunc{
 			defaultHook: func(context.Context, api.RepoName, string, string) (r0 *gitdomain.BehindAhead, r1 error) {
+				return
+			},
+		},
+		ChangedFilesFunc: &GitserverClientChangedFilesFunc{
+			defaultHook: func(context.Context, api.RepoName, string, string) (r0 gitserver.ChangedFilesIterator, r1 error) {
 				return
 			},
 		},
@@ -11336,6 +11344,11 @@ func NewStrictMockGitserverClient() *MockGitserverClient {
 				panic("unexpected invocation of MockGitserverClient.BehindAhead")
 			},
 		},
+		ChangedFilesFunc: &GitserverClientChangedFilesFunc{
+			defaultHook: func(context.Context, api.RepoName, string, string) (gitserver.ChangedFilesIterator, error) {
+				panic("unexpected invocation of MockGitserverClient.ChangedFiles")
+			},
+		},
 		CheckPerforceCredentialsFunc: &GitserverClientCheckPerforceCredentialsFunc{
 			defaultHook: func(context.Context, protocol.PerforceConnectionDetails) error {
 				panic("unexpected invocation of MockGitserverClient.CheckPerforceCredentials")
@@ -11542,6 +11555,9 @@ func NewMockGitserverClientFrom(i gitserver.Client) *MockGitserverClient {
 		},
 		BehindAheadFunc: &GitserverClientBehindAheadFunc{
 			defaultHook: i.BehindAhead,
+		},
+		ChangedFilesFunc: &GitserverClientChangedFilesFunc{
+			defaultHook: i.ChangedFiles,
 		},
 		CheckPerforceCredentialsFunc: &GitserverClientCheckPerforceCredentialsFunc{
 			defaultHook: i.CheckPerforceCredentials,
@@ -11988,6 +12004,121 @@ func (c GitserverClientBehindAheadFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c GitserverClientBehindAheadFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
+}
+
+// GitserverClientChangedFilesFunc describes the behavior when the
+// ChangedFiles method of the parent MockGitserverClient instance is
+// invoked.
+type GitserverClientChangedFilesFunc struct {
+	defaultHook func(context.Context, api.RepoName, string, string) (gitserver.ChangedFilesIterator, error)
+	hooks       []func(context.Context, api.RepoName, string, string) (gitserver.ChangedFilesIterator, error)
+	history     []GitserverClientChangedFilesFuncCall
+	mutex       sync.Mutex
+}
+
+// ChangedFiles delegates to the next hook function in the queue and stores
+// the parameter and result values of this invocation.
+func (m *MockGitserverClient) ChangedFiles(v0 context.Context, v1 api.RepoName, v2 string, v3 string) (gitserver.ChangedFilesIterator, error) {
+	r0, r1 := m.ChangedFilesFunc.nextHook()(v0, v1, v2, v3)
+	m.ChangedFilesFunc.appendCall(GitserverClientChangedFilesFuncCall{v0, v1, v2, v3, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the ChangedFiles method
+// of the parent MockGitserverClient instance is invoked and the hook queue
+// is empty.
+func (f *GitserverClientChangedFilesFunc) SetDefaultHook(hook func(context.Context, api.RepoName, string, string) (gitserver.ChangedFilesIterator, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// ChangedFiles method of the parent MockGitserverClient instance invokes
+// the hook at the front of the queue and discards it. After the queue is
+// empty, the default hook function is invoked for any future action.
+func (f *GitserverClientChangedFilesFunc) PushHook(hook func(context.Context, api.RepoName, string, string) (gitserver.ChangedFilesIterator, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *GitserverClientChangedFilesFunc) SetDefaultReturn(r0 gitserver.ChangedFilesIterator, r1 error) {
+	f.SetDefaultHook(func(context.Context, api.RepoName, string, string) (gitserver.ChangedFilesIterator, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *GitserverClientChangedFilesFunc) PushReturn(r0 gitserver.ChangedFilesIterator, r1 error) {
+	f.PushHook(func(context.Context, api.RepoName, string, string) (gitserver.ChangedFilesIterator, error) {
+		return r0, r1
+	})
+}
+
+func (f *GitserverClientChangedFilesFunc) nextHook() func(context.Context, api.RepoName, string, string) (gitserver.ChangedFilesIterator, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *GitserverClientChangedFilesFunc) appendCall(r0 GitserverClientChangedFilesFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of GitserverClientChangedFilesFuncCall objects
+// describing the invocations of this function.
+func (f *GitserverClientChangedFilesFunc) History() []GitserverClientChangedFilesFuncCall {
+	f.mutex.Lock()
+	history := make([]GitserverClientChangedFilesFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// GitserverClientChangedFilesFuncCall is an object that describes an
+// invocation of method ChangedFiles on an instance of MockGitserverClient.
+type GitserverClientChangedFilesFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 api.RepoName
+	// Arg2 is the value of the 3rd argument passed to this method
+	// invocation.
+	Arg2 string
+	// Arg3 is the value of the 4th argument passed to this method
+	// invocation.
+	Arg3 string
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 gitserver.ChangedFilesIterator
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c GitserverClientChangedFilesFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c GitserverClientChangedFilesFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 

--- a/internal/gitserver/client.go
+++ b/internal/gitserver/client.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"io/fs"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -438,6 +439,14 @@ type Client interface {
 	//
 	// If the specified commit does not exist, a RevisionNotFoundError is returned.
 	NewFileReader(ctx context.Context, repo api.RepoName, commit api.CommitID, name string) (io.ReadCloser, error)
+
+	// ChangedFiles returns the list of files that have been added, modified, or
+	// deleted in the entire repository between the two given <tree-ish> identifiers (e.g., commit, branch, tag).
+	//
+	// If base is omitted, the parent of head is used as the base.
+	//
+	// If either the base or head <tree-ish> id does not exist, a gitdomain.RevisionNotFoundError is returned.
+	ChangedFiles(ctx context.Context, repo api.RepoName, base, head string) (ChangedFilesIterator, error)
 
 	// DiffSymbols performs a diff command which is expected to be parsed by our symbols package
 	DiffSymbols(ctx context.Context, repo api.RepoName, commitA, commitB api.CommitID) ([]byte, error)
@@ -1190,3 +1199,60 @@ func (c *clientImplementor) ListGitoliteRepos(ctx context.Context, gitoliteHost 
 
 	return list, nil
 }
+
+// ChangedFilesIterator is an iterator for retrieving the status of changed files in a Git repository.
+// It allows iterating over the changed files and retrieving their paths and statuses.
+//
+// The caller must ensure that they call Close() when the iterator is no longer needed to release any associated resources.
+type ChangedFilesIterator interface {
+	// Next returns the next changed file's path and status.
+	//
+	// If there are no more changed files, Next returns an io.EOF error.
+	// If an error occurs during iteration, Next returns the error that occurred.
+	Next() (gitdomain.PathStatus, error)
+
+	// Close closes the iterator and releases any associated resources.
+	//
+	// It is important to call Close when the iterator is no longer needed to avoid resource leaks.
+	// After calling Close, any subsequent calls to Next will return an io.EOF error.
+	Close()
+}
+
+// NewChangedFilesIteratorFromSlice returns a new ChangedFilesIterator that iterates over the given slice of changed files (in order),
+// which is useful for testing.
+func NewChangedFilesIteratorFromSlice(files []gitdomain.PathStatus) ChangedFilesIterator {
+	return &changedFilesSliceIterator{files: files}
+}
+
+type changedFilesSliceIterator struct {
+	mu     sync.Mutex
+	files  []gitdomain.PathStatus
+	closed bool
+}
+
+func (c *changedFilesSliceIterator) Next() (gitdomain.PathStatus, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.closed {
+		return gitdomain.PathStatus{}, io.EOF
+	}
+
+	if len(c.files) == 0 {
+		return gitdomain.PathStatus{}, io.EOF
+	}
+
+	file := c.files[0]
+	c.files = c.files[1:]
+
+	return file, nil
+}
+
+func (c *changedFilesSliceIterator) Close() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.closed = true
+}
+
+var _ ChangedFilesIterator = &changedFilesSliceIterator{}

--- a/internal/gitserver/commands.go
+++ b/internal/gitserver/commands.go
@@ -302,6 +302,121 @@ func parseTimestamp(timestamp string) (time.Time, error) {
 // the root commit.
 const DevNullSHA = "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
 
+func (c *clientImplementor) ChangedFiles(ctx context.Context, repo api.RepoName, base, head string) (iterator ChangedFilesIterator, err error) {
+	ctx, _, endObservation := c.operations.changedFiles.With(ctx, &err, observation.Args{
+		MetricLabelValues: []string{c.scope},
+		Attrs: []attribute.KeyValue{
+			repo.Attr(),
+			attribute.String("base", base),
+			attribute.String("head", head),
+		},
+	})
+	defer endObservation(1, observation.Args{})
+
+	client, err := c.clientSource.ClientForRepo(ctx, repo)
+	if err != nil {
+		return nil, err
+	}
+
+	ctx, cancel := context.WithCancel(ctx)
+
+	stream, err := client.ChangedFiles(ctx, &proto.ChangedFilesRequest{
+		RepoName: string(repo),
+		Base:     []byte(base),
+		Head:     []byte(head),
+	})
+	if err != nil {
+		cancel()
+		return nil, err
+	}
+
+	fetchFunc := func() ([]gitdomain.PathStatus, error) {
+		resp, err := stream.Recv()
+		if err != nil {
+			cancel()
+			return nil, err
+		}
+
+		protoFiles := resp.GetFiles()
+
+		changes := make([]gitdomain.PathStatus, 0, len(protoFiles))
+		for _, p := range protoFiles {
+			changes = append(changes, gitdomain.PathStatusFromProto(p))
+		}
+
+		return changes, nil
+	}
+
+	closeFunc := func() {
+		cancel()
+	}
+
+	return newChangedFilesIterator(fetchFunc, closeFunc), nil
+}
+
+func newChangedFilesIterator(fetchFunc func() ([]gitdomain.PathStatus, error), closeFunc func()) *changedFilesIterator {
+	return &changedFilesIterator{
+		fetchFunc: fetchFunc,
+		closeFunc: closeFunc,
+		closeChan: make(chan struct{}),
+	}
+}
+
+type changedFilesIterator struct {
+	// fetchFunc is the function that will be invoked when the buffer is empty.
+	//
+	// The function should return the next batch of data, or an error if the fetch
+	// failed.
+	//
+	// fetchFunc should return an io.EOF error when there is no more data to fetch.
+	fetchFunc func() ([]gitdomain.PathStatus, error)
+	fetchErr  error
+
+	closeOnce sync.Once
+	closeFunc func()
+	closeChan chan struct{}
+
+	buffer []gitdomain.PathStatus
+}
+
+func (i *changedFilesIterator) Next() (gitdomain.PathStatus, error) {
+	select {
+	case <-i.closeChan:
+		return gitdomain.PathStatus{}, io.EOF
+	default:
+	}
+
+	if i.fetchErr != nil {
+		return gitdomain.PathStatus{}, i.fetchErr
+	}
+
+	for len(i.buffer) == 0 { // If we've exhausted the buffer, fetch more data
+		// If we've exhausted the buffer, fetch more data
+		//
+		// We keep trying until we get a non-empty buffer since it's technically possible for the fetchFunc to return an empty slice
+		// even if there is more data to fetch.
+
+		i.buffer, i.fetchErr = i.fetchFunc()
+		if i.fetchErr != nil { // Check if there was an error fetching the data
+			return gitdomain.PathStatus{}, i.fetchErr
+		}
+	}
+
+	out := i.buffer[0]
+	i.buffer = i.buffer[1:]
+
+	return out, nil
+}
+
+func (i *changedFilesIterator) Close() {
+	i.closeOnce.Do(func() {
+		if i.closeFunc != nil {
+			i.closeFunc()
+		}
+		close(i.closeChan)
+	})
+}
+
 // DiffSymbols performs a diff command which is expected to be parsed by our symbols package
 func (c *clientImplementor) DiffSymbols(ctx context.Context, repo api.RepoName, commitA, commitB api.CommitID) (_ []byte, err error) {
 	ctx, _, endObservation := c.operations.diffSymbols.With(ctx, &err, observation.Args{

--- a/internal/gitserver/observability.go
+++ b/internal/gitserver/observability.go
@@ -53,6 +53,7 @@ type operations struct {
 	diffSymbols              *observation.Operation
 	commitLog                *observation.Operation
 	diff                     *observation.Operation
+	changedFiles             *observation.Operation
 }
 
 func newOperations(observationCtx *observation.Context) *operations {
@@ -141,6 +142,7 @@ func newOperations(observationCtx *observation.Context) *operations {
 		diffSymbols:              op("DiffSymbols"),
 		commitLog:                op("CommitLog"),
 		diff:                     op("Diff"),
+		changedFiles:             op("ChangedFiles"),
 	}
 }
 


### PR DESCRIPTION
Part of https://github.com/sourcegraph/sourcegraph/issues/60654

This PR builds on https://github.com/sourcegraph/sourcegraph/pull/62216, and creates a new ChangedFiles method in the gitserver client that calls the new gRPC method that was introduced in https://github.com/sourcegraph/sourcegraph/pull/62216.

Note: This PR doesn't change / remove any existing callers of DiffSymbols. I made those changes in future stacked PRs to ensure that they're easy to review. 

## Test plan

New Unit tests 