### PR TITLE
symbols: replace usage of gitserver client's DiffSymbols method with new ChangedFiles method

### DIFF
--- a/cmd/symbols/fetcher/BUILD.bazel
+++ b/cmd/symbols/fetcher/BUILD.bazel
@@ -32,6 +32,7 @@ go_test(
     deps = [
         "//cmd/symbols/gitserver",
         "//internal/api",
+        "//internal/gitserver",
         "//internal/gitserver/gitdomain",
         "//internal/observation",
         "//internal/search",

--- a/cmd/symbols/gitserver/BUILD.bazel
+++ b/cmd/symbols/gitserver/BUILD.bazel
@@ -33,7 +33,6 @@ go_test(
         "//internal/gitserver",
         "//internal/gitserver/gitdomain",
         "//internal/observation",
-        "@com_github_google_go_cmp//cmp",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/cmd/symbols/gitserver/client_test.go
+++ b/cmd/symbols/gitserver/client_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
@@ -12,67 +11,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 )
-
-func TestParseGitDiffOutput(t *testing.T) {
-	testCases := []struct {
-		output          []byte
-		expectedChanges Changes
-		shouldError     bool
-	}{
-		{
-			output: combineBytes(
-				[]byte("A"), NUL, []byte("added1.json"), NUL,
-				[]byte("M"), NUL, []byte("modified1.json"), NUL,
-				[]byte("D"), NUL, []byte("deleted1.json"), NUL,
-				[]byte("A"), NUL, []byte("added2.json"), NUL,
-				[]byte("M"), NUL, []byte("modified2.json"), NUL,
-				[]byte("D"), NUL, []byte("deleted2.json"), NUL,
-				[]byte("A"), NUL, []byte("added3.json"), NUL,
-				[]byte("M"), NUL, []byte("modified3.json"), NUL,
-				[]byte("D"), NUL, []byte("deleted3.json"), NUL,
-			),
-			expectedChanges: Changes{
-				Added:    []string{"added1.json", "added2.json", "added3.json"},
-				Modified: []string{"modified1.json", "modified2.json", "modified3.json"},
-				Deleted:  []string{"deleted1.json", "deleted2.json", "deleted3.json"},
-			},
-		},
-		{
-			output: combineBytes(
-				[]byte("A"), NUL, []byte("added1.json"), NUL,
-				[]byte("M"), NUL, []byte("modified1.json"), NUL,
-				[]byte("D"), NUL,
-			),
-			shouldError: true,
-		},
-		{
-			output: []byte{},
-		},
-	}
-
-	for _, testCase := range testCases {
-		changes, err := parseGitDiffOutput(testCase.output)
-		if err != nil {
-			if !testCase.shouldError {
-				t.Fatalf("unexpected error parsing git diff output: %s", err)
-			}
-		} else if testCase.shouldError {
-			t.Fatalf("expected error, got none")
-		}
-
-		if diff := cmp.Diff(testCase.expectedChanges, changes); diff != "" {
-			t.Errorf("unexpected changes (-want +got):\n%s", diff)
-		}
-	}
-}
-
-func combineBytes(bss ...[]byte) (combined []byte) {
-	for _, bs := range bss {
-		combined = append(combined, bs...)
-	}
-
-	return combined
-}
 
 func TestGitserverClient_PaginatedRevList(t *testing.T) {
 	allCommits := []*gitdomain.Commit{

--- a/cmd/symbols/gitserver/observability.go
+++ b/cmd/symbols/gitserver/observability.go
@@ -30,6 +30,6 @@ func newOperations(observationCtx *observation.Context) *operations {
 
 	return &operations{
 		fetchTar: op("FetchTar"),
-		gitDiff:  op("GitDiff"),
+		gitDiff:  op("ChangedFiles"),
 	}
 }

--- a/cmd/symbols/internal/api/BUILD.bazel
+++ b/cmd/symbols/internal/api/BUILD.bazel
@@ -58,6 +58,7 @@ go_test(
         "//internal/database/dbmocks",
         "//internal/diskcache",
         "//internal/endpoint",
+        "//internal/gitserver",
         "//internal/gitserver/gitdomain",
         "//internal/grpc/defaults",
         "//internal/observation",

--- a/cmd/symbols/internal/database/writer/BUILD.bazel
+++ b/cmd/symbols/internal/database/writer/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
         "//cmd/symbols/parser",
         "//internal/api",
         "//internal/diskcache",
+        "//internal/gitserver/gitdomain",
         "//internal/observation",
         "//internal/search",
         "//lib/errors",

--- a/internal/gitserver/commands.go
+++ b/internal/gitserver/commands.go
@@ -377,6 +377,7 @@ type changedFilesIterator struct {
 	closeChan chan struct{}
 
 	buffer []gitdomain.PathStatus
+	index  int
 }
 
 func (i *changedFilesIterator) Next() (gitdomain.PathStatus, error) {


### PR DESCRIPTION
Part of https://github.com/sourcegraph/sourcegraph/issues/60654

This PR builds on the new ChangedFiles method introduced in https://github.com/sourcegraph/sourcegraph/pull/62354, and changes the symbols service to use it instead of the old custom diff symbols method.

## Test plan

Existing CI pipeline