### PR TITLE
svelte: Fix user name in "last commit" message

### DIFF
--- a/client/web-sveltekit/src/lib/repo/LastCommit.gql
+++ b/client/web-sveltekit/src/lib/repo/LastCommit.gql
@@ -7,6 +7,8 @@ fragment LastCommitFragment on GitCommit {
         date
         person {
             ...Avatar_Person
+            displayName
+            name
         }
     }
 }

--- a/client/web-sveltekit/src/lib/repo/LastCommit.svelte
+++ b/client/web-sveltekit/src/lib/repo/LastCommit.svelte
@@ -18,7 +18,7 @@
         <Avatar avatar={user} />
     </div>
     <div class="display-name">
-        <span class="label">{user.name}</span>
+        <span class="label">{user.displayName || user.name}</span>
     </div>
     <div class="commit-message">
         <a href={canonicalURL}>


### PR DESCRIPTION
Currently we are using `name`, which seems generated. We should try `displayName` first before falling back to `name`.

| Before | After |
|--------|--------|
| ![2024-05-01_22-42](https://github.com/sourcegraph/sourcegraph/assets/179026/f3a04def-0e0a-49f2-acaf-51087b72ffe7) | ![2024-05-01_22-43](https://github.com/sourcegraph/sourcegraph/assets/179026/4a7ca5b8-e159-4779-8211-0f5c7472708a) | 

## Test plan

Manual testing.