### PR TITLE
svelte: Set max width for repo page

### DIFF
--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/+page.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/+page.svelte
@@ -32,11 +32,13 @@
     {/if}
 </h3>
 <div class="content">
-    {#if $readme.value}
-        <Readme file={$readme.value} />
-    {:else if !$readme.pending}
-        {data.resolvedRevision.repo.description}
-    {/if}
+    <div class="inner">
+        {#if $readme.value}
+            <Readme file={$readme.value} />
+        {:else if !$readme.pending}
+            {data.resolvedRevision.repo.description}
+        {/if}
+    </div>
 </div>
 
 <style lang="scss">
@@ -68,8 +70,15 @@
     }
 
     .content {
-        padding: 1rem;
         overflow: auto;
         flex: 1;
+
+        // We use an "inner" element to limit the width of the content while
+        // keeping the scrollbar on the outer element, at the edge of the
+        // viewport.
+        .inner {
+            max-width: var(--viewport-xl);
+            padding: 1rem;
+        }
     }
 </style>


### PR DESCRIPTION
I believe we used to do this, maybe there was a regression.

| Before | After |
|--------|--------|
| ![2024-05-01_22-39](https://github.com/sourcegraph/sourcegraph/assets/179026/0f17d4a4-de62-4827-af0e-55c67dbf7989) | ![2024-05-01_22-38](https://github.com/sourcegraph/sourcegraph/assets/179026/f521519f-6835-4e3a-bcb9-1d56f343a455) | 

## Test plan

Manual testing.
