### PR TITLE
searcher: replace usage of gitserver.DiffSymbols with new gitserver.ChangedFiles client method

### DIFF
--- a/cmd/searcher/internal/search/BUILD.bazel
+++ b/cmd/searcher/internal/search/BUILD.bazel
@@ -25,7 +25,6 @@ go_library(
     importpath = "github.com/sourcegraph/sourcegraph/cmd/searcher/internal/search",
     visibility = ["//cmd/searcher:__subpackages__"],
     deps = [
-        "//cmd/searcher/diff",
         "//cmd/searcher/protocol",
         "//internal/api",
         "//internal/comby",
@@ -33,6 +32,7 @@ go_library(
         "//internal/diskcache",
         "//internal/errcode",
         "//internal/gitserver",
+        "//internal/gitserver/gitdomain",
         "//internal/lazyregexp",
         "//internal/limiter",
         "//internal/metrics",
@@ -141,6 +141,7 @@ go_test(
         "//internal/conf",
         "//internal/errcode",
         "//internal/gitserver",
+        "//internal/gitserver/gitdomain",
         "//internal/grpc",
         "//internal/grpc/defaults",
         "//internal/observation",

--- a/cmd/searcher/internal/search/hybrid.go
+++ b/cmd/searcher/internal/search/hybrid.go
@@ -3,7 +3,9 @@ package search
 import (
 	"bytes"
 	"context"
+	"io"
 	"regexp/syntax" //nolint:depguard // using the grafana fork of regexp clashes with zoekt, which uses the std regexp/syntax.
+	"sort"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -12,10 +14,10 @@ import (
 	"github.com/sourcegraph/zoekt"
 	zoektquery "github.com/sourcegraph/zoekt/query"
 
-	"github.com/sourcegraph/sourcegraph/cmd/searcher/diff"
 	"github.com/sourcegraph/sourcegraph/cmd/searcher/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
+	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
@@ -102,26 +104,55 @@ func (s *Service) hybrid(ctx context.Context, rootLogger log.Logger, p *protocol
 		}
 		logger = logger.With(log.String("indexed", string(indexed)))
 
-		// TODO if our store was more flexible we could cache just based on
-		// indexed and p.Commit and avoid the need of running diff for each
-		// search.
-		out, err := s.GitDiffSymbols(ctx, p.Repo, indexed, p.Commit)
-		if errcode.IsNotFound(err) {
-			recordHybridFinalState("git-diff-not-found")
-			logger.Debug("not doing hybrid search due to likely missing indexed commit on gitserver", log.Error(err))
-			return nil, false, nil
-		} else if err != nil {
-			recordHybridFinalState("git-diff-error")
-			return nil, false, errors.Wrapf(err, "failed to find changed files in %s between %s and %s", p.Repo, indexed, p.Commit)
-		}
+		indexedIgnore, unindexedSearch, err := func() (indexedIgnore []string, unindexedSearch []string, err error) {
+			// TODO if our store was more flexible we could cache just based on
+			// indexed and p.Commit and avoid the need of running diff for each
+			// search.
+			changedFiles, err := s.GitChangedFiles(ctx, p.Repo, indexed, p.Commit)
+			if err != nil {
+				return nil, nil, errors.Wrap(err, "failed to get changed files")
+			}
+			defer changedFiles.Close()
 
-		indexedIgnore, unindexedSearch, err := diff.ParseGitDiffNameStatus(out)
+			for {
+				c, err := changedFiles.Next()
+				if err == io.EOF {
+					break
+				}
+
+				if err != nil {
+					err = errors.Wrap(err, "iterating over changed files in git diff")
+					return nil, nil, err
+				}
+
+				switch c.Status {
+				case gitdomain.DeletedAMD:
+					// no longer appears in "p.Commit"
+					indexedIgnore = append(indexedIgnore, c.Path)
+				case gitdomain.ModifiedAMD:
+					// changed in both "indexed" and "p.Commit"
+					indexedIgnore = append(indexedIgnore, c.Path)
+					unindexedSearch = append(unindexedSearch, c.Path)
+				case gitdomain.AddedAMD:
+					// doesn't exist in "indexed"
+					unindexedSearch = append(unindexedSearch, c.Path)
+				}
+			}
+
+			sort.Strings(indexedIgnore)
+			sort.Strings(unindexedSearch)
+
+			return indexedIgnore, unindexedSearch, nil
+		}()
 		if err != nil {
-			logger.Debug("parseGitDiffNameStatus failed",
-				log.Binary("out", out),
-				log.Error(err))
-			recordHybridFinalState("git-diff-parse-error")
-			return nil, false, errors.Wrapf(err, "failed to parse git diff output of changed files in %s between %s and %s", p.Repo, indexed, p.Commit)
+			if errcode.IsNotFound(err) {
+				recordHybridFinalState("git-diff-not-found")
+				logger.Debug("not doing hybrid search due to likely missing indexed commit on gitserver", log.Error(err))
+			} else if err != nil {
+				recordHybridFinalState("git-diff-error")
+			}
+
+			return nil, false, err
 		}
 
 		totalLenIndexedIgnore := totalStringsLen(indexedIgnore)

--- a/cmd/searcher/internal/search/search.go
+++ b/cmd/searcher/internal/search/search.go
@@ -22,6 +22,8 @@ import (
 	"github.com/sourcegraph/log"
 	"github.com/sourcegraph/zoekt"
 
+	"github.com/sourcegraph/sourcegraph/internal/gitserver"
+
 	"github.com/sourcegraph/sourcegraph/cmd/searcher/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
@@ -43,11 +45,9 @@ type Service struct {
 
 	Indexed zoekt.Streamer
 
-	// GitDiffSymbols returns the stdout of running "git diff -z --name-status
-	// --no-renames commitA commitB" against repo.
-	//
-	// TODO Git client should be exposing a better API here.
-	GitDiffSymbols func(ctx context.Context, repo api.RepoName, commitA, commitB api.CommitID) ([]byte, error)
+	// GitChangedFiles returns an iterator that yields list of changed files that have changed in between commitA and commitB in the given
+	// repo.
+	GitChangedFiles func(ctx context.Context, repo api.RepoName, commitA, commitB api.CommitID) (gitserver.ChangedFilesIterator, error)
 
 	// MaxTotalPathsLength is the maximum sum of lengths of all paths in a
 	// single call to git archive. This mainly needs to be less than ARG_MAX

--- a/cmd/searcher/shared/shared.go
+++ b/cmd/searcher/shared/shared.go
@@ -158,10 +158,10 @@ func Start(ctx context.Context, observationCtx *observation.Context, ready servi
 
 		Indexed: sharedsearch.Indexed(),
 
-		GitDiffSymbols: func(ctx context.Context, repo api.RepoName, commitA, commitB api.CommitID) ([]byte, error) {
+		GitChangedFiles: func(ctx context.Context, repo api.RepoName, commitA, commitB api.CommitID) (gitserver.ChangedFilesIterator, error) {
 			// As this is an internal service call, we need an internal actor.
 			ctx = actor.WithInternalActor(ctx)
-			return git.DiffSymbols(ctx, repo, commitA, commitB)
+			return git.ChangedFiles(ctx, repo, string(commitA), string(commitB))
 		},
 		MaxTotalPathsLength: maxTotalPathsLength,
 


### PR DESCRIPTION
Part of https://github.com/sourcegraph/sourcegraph/issues/60654

This PR replaces hybrid's search use of the gitserver.DiffSymbols endpoint with the new gitserver.ChangedFiles gRPC endpoint introduced in https://github.com/sourcegraph/sourcegraph/pull/62354.

## Test plan

Existing CI pipeline
