### PR TITLE
Svelte: Revert code bg changes

### DIFF
--- a/client/web-sveltekit/src/lib/CodeMirrorBlob.svelte
+++ b/client/web-sveltekit/src/lib/CodeMirrorBlob.svelte
@@ -56,7 +56,7 @@
             backgroundColor: 'transparent',
         },
         '.cm-gutters': {
-            'background-color': 'var(--body-bg)',
+            'background-color': 'var(--code-bg)',
             border: 'none',
             color: 'var(--line-number-color)',
         },

--- a/client/web-sveltekit/src/lib/repo/FileDiffHunks.svelte
+++ b/client/web-sveltekit/src/lib/repo/FileDiffHunks.svelte
@@ -68,6 +68,8 @@
     }
 
     td {
+        background-color: var(--code-bg);
+
         &.num {
             min-width: 2.5rem;
             line-height: 1.6666666667;

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/+layout.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/+layout.svelte
@@ -210,6 +210,7 @@
         display: flex;
         flex: 1;
         overflow: hidden;
+        background-color: var(--code-bg);
     }
 
     header {

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/FileView.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/FileView.svelte
@@ -278,6 +278,7 @@
     .content {
         overflow: auto;
         flex: 1;
+        background-color: var(--code-bg);
 
         &.center {
             display: flex;
@@ -293,6 +294,7 @@
         gap: 1rem;
         padding: 0.5rem;
         color: var(--text-muted);
+        background-color: var(--code-bg);
     }
 
     .revision-info {

--- a/client/web-sveltekit/src/routes/search/FileContentSearchResult.svelte
+++ b/client/web-sveltekit/src/routes/search/FileContentSearchResult.svelte
@@ -135,7 +135,7 @@
         text-align: left;
         border: none;
         padding: 0.25rem 0.5rem;
-        background-color: var(--body-bg);
+        background-color: var(--code-bg);
         color: var(--text-muted);
         cursor: pointer;
 
@@ -146,11 +146,13 @@
 
         &:hover {
             background-color: var(--color-bg-2);
+            color: var(--text-title);
         }
     }
 
     .code {
         border-bottom: 1px solid var(--border-color);
+        background-color: var(--code-bg);
 
         &:last-child {
             border-bottom: none;

--- a/client/web-sveltekit/src/routes/search/SearchResult.svelte
+++ b/client/web-sveltekit/src/routes/search/SearchResult.svelte
@@ -62,6 +62,7 @@
     }
 
     .body:not(:empty) {
+        background-color: var(--code-bg);
         border-bottom: 1px solid var(--border-color);
     }
 </style>

--- a/client/web-sveltekit/src/routes/svelte-overrides.scss
+++ b/client/web-sveltekit/src/routes/svelte-overrides.scss
@@ -31,6 +31,7 @@ body {
     --text-body: var(--gray-08);
     --search-result-header-bg: #eef2f5;
     --line-number-color: var(--gray-06);
+    --code-bg: white;
     --code-selection-bg: rgba(231, 238, 250, 0.8);
 
     // Shadows

--- a/client/web-sveltekit/src/routes/svelte-overrides.scss
+++ b/client/web-sveltekit/src/routes/svelte-overrides.scss
@@ -31,7 +31,7 @@ body {
     --text-body: var(--gray-08);
     --search-result-header-bg: #eef2f5;
     --line-number-color: var(--gray-06);
-    --code-bg: white;
+    --code-bg: var(--white);
     --code-selection-bg: rgba(231, 238, 250, 0.8);
 
     // Shadows


### PR DESCRIPTION
## Before
![CleanShot 2024-05-01 at 23 48 37@2x](https://github.com/sourcegraph/sourcegraph/assets/5337876/f7ad034d-0414-4b0e-bb38-668ad7dbf25f)

## After
![CleanShot 2024-05-01 at 23 46 40@2x](https://github.com/sourcegraph/sourcegraph/assets/5337876/bdabd5a1-a4ae-438d-8926-ff93c15071e0)

## Test plan
Colors manually tested locally.