### PR TITLE
chore: Enable rustfmt

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -42,8 +42,11 @@ test:go-verbose-test --test_env=GO_TEST_WRAP_TESTV=1
 # we instead disable it.
 common --noincompatible_disallow_empty_glob
 
-# Ensure clippy runs for rust targets
+# Ensure clippy and rustfmt run for Rust targets
 build --aspects=@rules_rust//rust:defs.bzl%rust_clippy_aspect
 build --output_groups=+clippy_checks
+build --aspects=@rules_rust//rust:defs.bzl%rustfmt_aspect
+build --output_groups=+rustfmt_checks
+build --@rules_rust//:rustfmt.toml=//docker-images/syntax-highlighter:rustfmt.toml
 
 common --noenable_bzlmod

--- a/docker-images/syntax-highlighter/BUILD.bazel
+++ b/docker-images/syntax-highlighter/BUILD.bazel
@@ -5,6 +5,8 @@ load("@rules_pkg//:pkg.bzl", "pkg_tar")
 load("@container_structure_test//:defs.bzl", "container_structure_test")
 load("//wolfi-images:defs.bzl", "wolfi_base")
 
+exports_files(["rustfmt.toml"])
+
 rust_binary(
     name = "syntect_server",
     srcs = ["src/main.rs"],

--- a/docker-images/syntax-highlighter/README.md
+++ b/docker-images/syntax-highlighter/README.md
@@ -47,6 +47,12 @@ By default on startup, `syntect_server` will list all file types it supports. Th
 2. Use `cargo run --bin syntect_server` to run the server locally.
 3. You can change the `SRC_SYNTECT_SERVER` option in your `sg.config.yaml` to point to whatever port you're running on (usually 8000) and test against that without building the docker image.
 
+For formatting, run:
+
+```bash
+bazel run @rules_rust//:rustfmt
+```
+
 ### Testing syntect -> SCIP grammar mappings
 
 <!-- NOTE(id: only-flag) -->

--- a/docker-images/syntax-highlighter/crates/scip-syntax/src/io.rs
+++ b/docker-images/syntax-highlighter/crates/scip-syntax/src/io.rs
@@ -1,6 +1,6 @@
-use anyhow::{Context, Result};
 use std::{fs::File, io::BufReader, path::PathBuf};
 
+use anyhow::{Context, Result};
 use protobuf::{CodedInputStream, Message};
 
 pub fn read_index_from_file(file: &PathBuf) -> Result<scip::types::Index> {

--- a/docker-images/syntax-highlighter/crates/scip-syntax/src/main.rs
+++ b/docker-images/syntax-highlighter/crates/scip-syntax/src/main.rs
@@ -1,6 +1,7 @@
+use std::path::PathBuf;
+
 use clap::{Parser, Subcommand};
 use scip_syntax::index::{index_command, AnalysisMode, IndexMode, IndexOptions};
-use std::path::PathBuf;
 
 #[derive(Parser)]
 #[command(author, version, about, long_about = None)]

--- a/docker-images/syntax-highlighter/crates/scip-syntax/tests/integration_test.rs
+++ b/docker-images/syntax-highlighter/crates/scip-syntax/tests/integration_test.rs
@@ -1,14 +1,16 @@
-use std::collections::HashMap;
-use std::path::Path;
-use std::process::Command;
-use std::{env::temp_dir, path::PathBuf};
+use std::{
+    collections::HashMap,
+    env::temp_dir,
+    path::{Path, PathBuf},
+    process::Command,
+};
 
-use assert_cmd::cargo::cargo_bin;
-use assert_cmd::prelude::*;
-
-use scip_syntax::evaluate::Evaluator;
-use scip_syntax::index::{index_command, AnalysisMode, IndexMode, IndexOptions};
-use scip_syntax::io::read_index_from_file;
+use assert_cmd::{cargo::cargo_bin, prelude::*};
+use scip_syntax::{
+    evaluate::Evaluator,
+    index::{index_command, AnalysisMode, IndexMode, IndexOptions},
+    io::read_index_from_file,
+};
 
 lazy_static::lazy_static! {
     static ref BINARY_LOCATION: PathBuf = {

--- a/docker-images/syntax-highlighter/crates/syntax-analysis/src/ctags.rs
+++ b/docker-images/syntax-highlighter/crates/syntax-analysis/src/ctags.rs
@@ -200,9 +200,10 @@ pub fn generate_tags<W: std::io::Write>(
             Reply::Error {
                 message: err.to_string(),
                 fatal: false,
-            }.write(buf_writer);
-            return None
-        },
+            }
+            .write(buf_writer);
+            return None;
+        }
     };
 
     let mut scope_deduplicator = HashMap::new();
@@ -253,14 +254,16 @@ pub fn ctags_runner<R: Read, W: Write>(
                     Err(error) => Reply::Error {
                         message: error.to_string(),
                         fatal: false,
-                    }.write(output)
+                    }
+                    .write(output),
                 };
             }
         }
 
         Reply::Completed {
             command: "generate-tags".to_string(),
-        }.write(output);
+        }
+        .write(output);
 
         output.flush().unwrap();
     }

--- a/docker-images/syntax-highlighter/crates/syntax-analysis/src/globals.rs
+++ b/docker-images/syntax-highlighter/crates/syntax-analysis/src/globals.rs
@@ -1,10 +1,9 @@
-use crate::range::Range;
 use anyhow::{Context, Result};
 use bitvec::prelude::*;
 use protobuf::Enum;
 use scip::types::{symbol_information, Descriptor, Document, Occurrence, SymbolInformation};
 
-use crate::languages::TagConfiguration;
+use crate::{languages::TagConfiguration, range::Range};
 
 #[derive(Debug)]
 pub struct Scope {
@@ -319,11 +318,11 @@ pub fn parse_tree<'a>(
 
 #[cfg(test)]
 pub mod test {
-    use crate::snapshot::{self, dump_document_with_config, SnapshotOptions};
     use scip::types::Document;
     use tree_sitter_all_languages::ParserId;
 
     use super::*;
+    use crate::snapshot::{self, dump_document_with_config, SnapshotOptions};
 
     pub fn parse_file_for_lang(config: &TagConfiguration, source_code: &str) -> Document {
         let mut parser = config.get_parser();

--- a/docker-images/syntax-highlighter/crates/syntax-analysis/src/highlighting.rs
+++ b/docker-images/syntax-highlighter/crates/syntax-analysis/src/highlighting.rs
@@ -1,13 +1,17 @@
 pub mod syntect_html;
 pub mod syntect_scip;
 
+use std::{
+    fmt::{Debug, Display, Formatter},
+    path::Path,
+};
+
 use anyhow::anyhow;
 use protobuf::Message;
-use std::fmt::{Debug, Display, Formatter};
-use std::path::Path;
-use syntect::html::ClassStyle;
-
-use syntect::parsing::{SyntaxReference, SyntaxSet};
+use syntect::{
+    html::ClassStyle,
+    parsing::{SyntaxReference, SyntaxSet},
+};
 
 pub mod tree_sitter;
 use crate::highlighting::syntect_html::ClassedTableGenerator;

--- a/docker-images/syntax-highlighter/crates/syntax-analysis/src/highlighting/syntect_html.rs
+++ b/docker-images/syntax-highlighter/crates/syntax-analysis/src/highlighting/syntect_html.rs
@@ -1,4 +1,5 @@
 use std::fmt::Write;
+
 use syntect::{
     html::ClassStyle,
     parsing::{
@@ -234,8 +235,7 @@ impl<'a> fmt::Display for Escape<'a> {
 
 #[cfg(test)]
 mod tests {
-    use crate::highlighting::test::SYNTAX_SET;
-    use crate::highlighting::{FileInfo, HighlightingBackend};
+    use crate::highlighting::{test::SYNTAX_SET, FileInfo, HighlightingBackend};
 
     fn test_css_table_highlight(
         file_info: &FileInfo<'_>,

--- a/docker-images/syntax-highlighter/crates/syntax-analysis/src/highlighting/syntect_scip.rs
+++ b/docker-images/syntax-highlighter/crates/syntax-analysis/src/highlighting/syntect_scip.rs
@@ -537,8 +537,9 @@ mod test {
         io::Read,
     };
 
-    use crate::snapshot::{dump_document_with_config, EmitSymbol, EmitSyntax, SnapshotOptions};
     use pretty_assertions::assert_eq;
+
+    use crate::snapshot::{dump_document_with_config, EmitSymbol, EmitSyntax, SnapshotOptions};
 
     fn snapshot_sciptect_documents(doc: &Document, source: &str) -> String {
         dump_document_with_config(

--- a/docker-images/syntax-highlighter/crates/syntax-analysis/src/highlighting/tree_sitter.rs
+++ b/docker-images/syntax-highlighter/crates/syntax-analysis/src/highlighting/tree_sitter.rs
@@ -1,6 +1,7 @@
+use std::collections::HashMap;
+
 use paste::paste;
 use scip::types::{Document, Occurrence, SyntaxKind};
-use std::collections::HashMap;
 use tree_sitter_all_languages::ParserId;
 use tree_sitter_highlight::{
     Highlight, HighlightConfiguration, HighlightEvent, Highlighter as TSHighlighter,
@@ -9,7 +10,7 @@ use tree_sitter_highlight::{
 use crate::range::Range;
 
 macro_rules! include_scip_query {
-    ($lang: expr, $query: literal) => {
+    ($lang:expr, $query:literal) => {
         include_str!(concat!(
             env!("CARGO_MANIFEST_DIR"),
             "/queries/",
@@ -20,8 +21,9 @@ macro_rules! include_scip_query {
         ))
     };
 }
-use crate::highlighting::TreeSitterLanguageName;
 pub(crate) use include_scip_query;
+
+use crate::highlighting::TreeSitterLanguageName;
 
 #[rustfmt::skip]
 // This table serves two purposes.
@@ -423,10 +425,13 @@ mod test {
         io::Read,
     };
 
-    use super::*;
-    use crate::highlighting::FileInfo;
-    use crate::snapshot::{self, dump_document_with_config};
     use if_chain::if_chain;
+
+    use super::*;
+    use crate::{
+        highlighting::FileInfo,
+        snapshot::{self, dump_document_with_config},
+    };
 
     fn snapshot_treesitter_syntax_kinds(doc: &Document, source: &str) -> String {
         dump_document_with_config(

--- a/docker-images/syntax-highlighter/crates/syntax-analysis/src/languages.rs
+++ b/docker-images/syntax-highlighter/crates/syntax-analysis/src/languages.rs
@@ -1,11 +1,12 @@
 use std::collections::HashMap;
 
-use crate::highlighting::tree_sitter::include_scip_query;
 use once_cell::sync::OnceCell;
 use regex::Regex;
 use scip::types::Descriptor;
 use tree_sitter::{Language, Parser, Query};
 use tree_sitter_all_languages::ParserId;
+
+use crate::highlighting::tree_sitter::include_scip_query;
 
 #[derive(Debug)]
 pub struct Transform {

--- a/docker-images/syntax-highlighter/crates/syntax-analysis/src/lib.rs
+++ b/docker-images/syntax-highlighter/crates/syntax-analysis/src/lib.rs
@@ -36,10 +36,9 @@ pub fn get_locals(parser: ParserId, source: &str) -> Result<Vec<Occurrence>> {
 mod test {
     use std::{io::BufWriter, path::Path};
 
-    use crate::snapshot::dump_document;
     use tree_sitter_all_languages::ParserId;
 
-    use crate::ctags::generate_tags;
+    use crate::{ctags::generate_tags, snapshot::dump_document};
 
     macro_rules! generate_tags_and_snapshot {
         (Scip, $scip_name:tt, $filename:tt) => {

--- a/docker-images/syntax-highlighter/crates/syntax-analysis/testdata/ts-tags.rs
+++ b/docker-images/syntax-highlighter/crates/syntax-analysis/testdata/ts-tags.rs
@@ -1,11 +1,16 @@
+use std::{
+    char,
+    collections::HashMap,
+    ffi::{CStr, CString},
+    mem,
+    ops::Range,
+    os::raw::c_char,
+    str,
+    sync::atomic::{AtomicUsize, Ordering},
+};
+
 use memchr::memchr;
 use regex::Regex;
-use std::collections::HashMap;
-use std::ffi::{CStr, CString};
-use std::ops::Range;
-use std::os::raw::c_char;
-use std::sync::atomic::{AtomicUsize, Ordering};
-use std::{char, mem, str};
 use thiserror::Error;
 use tree_sitter::{
     Language, LossyUtf8, Parser, Point, Query, QueryCursor, QueryError, QueryPredicateArg, Tree,

--- a/docker-images/syntax-highlighter/src/bin/scip-ctags.rs
+++ b/docker-images/syntax-highlighter/src/bin/scip-ctags.rs
@@ -25,7 +25,8 @@ fn main() {
         Reply::Error {
             message: err.to_string(),
             fatal: true,
-        }.write(&mut stdout);
+        }
+        .write(&mut stdout);
         stdout.flush().unwrap()
     }
 }

--- a/docker-images/syntax-highlighter/src/lib.rs
+++ b/docker-images/syntax-highlighter/src/lib.rs
@@ -115,8 +115,7 @@ pub fn syntect_highlight(q: SourcegraphQuery) -> Result<JsonValue, JsonValue> {
             syntax_set,
             line_length_limit: q.line_length_limit,
         };
-        let output = backend.highlight(&q.file_info())
-            .map_err(jsonify_err)?;
+        let output = backend.highlight(&q.file_info()).map_err(jsonify_err)?;
 
         debug_assert!(output.kind == PayloadKind::Html);
         Ok(json!({ "data": output.payload, "plaintext": &output.grammar == "Plain Text", }))


### PR DESCRIPTION
This avoids unnecessary formatting changes in unrelated PRs.

## Test plan

- [x] ~Enforce formatting in CI, not 100% sure how to do this.~ It looks like building the code automatically triggers a formatting check per `.bazelrc` so that should be good enough.