### PR TITLE
svelte: Fix author avatar size on commit page

### DIFF
--- a/client/web-sveltekit/src/lib/Commit.svelte
+++ b/client/web-sveltekit/src/lib/Commit.svelte
@@ -34,7 +34,7 @@
 <div class="root">
     <div class="avatar">
         <Tooltip tooltip={authorAvatarTooltip}>
-            <Avatar avatar={author} --avatar-size="1.5rem" />
+            <Avatar avatar={author} />
         </Tooltip>
     </div>
     {#if committer && committer.name !== author.name}


### PR DESCRIPTION
I noticed that the autor and committer avatars have different sizes.

| Before | After |
|--------|--------|
| ![2024-05-02_08-39](https://github.com/sourcegraph/sourcegraph/assets/179026/0417c753-509c-4810-aabd-d9527f564871) | ![2024-05-02_08-40](https://github.com/sourcegraph/sourcegraph/assets/179026/f81fd8a2-07b6-41f9-938a-b581dc5a5a12) | 

## Test plan

Manual testing
