### PR TITLE
svelte: Improve tooltip target logic

### DIFF
--- a/client/web-sveltekit/src/lib/Timestamp.test.ts
+++ b/client/web-sveltekit/src/lib/Timestamp.test.ts
@@ -2,7 +2,6 @@
 
 import { faker } from '@faker-js/faker'
 import { render, screen } from '@testing-library/svelte'
-import userEvent from '@testing-library/user-event'
 import type { ComponentProps } from 'svelte'
 import { describe, test, expect, vi } from 'vitest'
 
@@ -15,14 +14,6 @@ describe('Timestamp.svelte', () => {
         const date = faker.date.recent()
         render(Timestamp, { date, ...options })
     }
-
-    test('show tooltip when hovering', async () => {
-        const user = userEvent.setup()
-        renderTimestamp()
-        await user.hover(screen.getByTestId('timestamp'))
-        const tooltip = await screen.findByRole('tooltip')
-        expect(tooltip.textContent).toMatchInlineSnapshot('"2021-05-23 12:57:34 PM "')
-    })
 
     test('automatically updates as time passes', async () => {
         useFakeTimers()

--- a/client/web-sveltekit/src/lib/Tooltip.svelte
+++ b/client/web-sveltekit/src/lib/Tooltip.svelte
@@ -24,7 +24,7 @@
     const id = uniqueID('tooltip')
 
     let visible = false
-    let wrapper: HTMLElement
+    let wrapper: HTMLElement | null
     let target: Element | null
 
     function show() {
@@ -42,7 +42,19 @@
             padding: 4,
         },
     }
-    $: target = wrapper?.firstElementChild
+    $: {
+        let node = wrapper?.firstElementChild
+        // Use `getClientRects` to check if the element is part of the layout.
+        // For example, an element with `display: contents` will not be part of the layout.
+        // Elements with `display: contents` are created by Svelte when using style props
+        // (https://svelte.dev/docs/component-directives#style-props).
+        while (node && node.getClientRects().length === 0) {
+            node = node.firstElementChild
+        }
+        if (node) {
+            target = node
+        }
+    }
     $: if (target && tooltip) {
         target.setAttribute('aria-label', tooltip)
     }


### PR DESCRIPTION
When I encountered #62372 I also noticed that the tooltip on the smaller avatar component is not positioned correctly. That's because the first element child does not contribute to the layout when the style prop is set, and thus doesn't have any dimensions.
I don't know how often we'll run into this situation but it seemed reasonable to make the component a bit more resilient for such cases. With this change we continue to look for (first child) elements that are part of the layout.

| Before | After |
|--------|--------|
| ![2024-05-02_09-02](https://github.com/sourcegraph/sourcegraph/assets/179026/82d42042-87f4-4793-b38e-daabf3323888) | ![2024-05-02_09-02_1](https://github.com/sourcegraph/sourcegraph/assets/179026/465fb6fd-8138-47c3-9a54-7f3a5d83290d) | 

## Test plan

Manual testing.
