### PR TITLE
svelte: Enable repo routes by default

### DIFF
--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/+page.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    // @sg RepoRoot
+    // @sg RepoRoot EnableRollout
     import { onMount } from 'svelte'
 
     import { sidebarOpen } from '$lib/repo/stores'

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/+page.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/+page.svelte
@@ -1,6 +1,7 @@
 <svelte:options immutable />
 
 <script lang="ts">
+    // @sg EnableRollout
     import { onMount } from 'svelte'
 
     import { SVELTE_LOGGER, SVELTE_TELEMETRY_EVENTS } from '$lib/telemetry'

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/tree/[...path]/+page.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/tree/[...path]/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+    // @sg EnableRollout
     import { mdiMapSearch } from '@mdi/js'
 
     import Icon from '$lib/Icon.svelte'

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/-/branches/+page.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/-/branches/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+    // @sg EnableRollout
     import LoadingSpinner from '$lib/LoadingSpinner.svelte'
     import GitReference from '$lib/repo/GitReference.svelte'
 

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/-/branches/all/+page.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/-/branches/all/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+    // @sg EnableRollout
     import { get } from 'svelte/store'
 
     import { navigating } from '$app/stores'

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/-/commit/[...revspec]/+page.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/-/commit/[...revspec]/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+    // @sg EnableRollout
     import { get } from 'svelte/store'
 
     import { navigating } from '$app/stores'

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/-/commits/[...path]/+page.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/-/commits/[...path]/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+    // @sg EnableRollout
     import { get } from 'svelte/store'
 
     import { navigating } from '$app/stores'

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/-/tags/+page.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/-/tags/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+    // @sg EnableRollout
     import { get } from 'svelte/store'
 
     import { navigating } from '$app/stores'

--- a/cmd/frontend/internal/app/ui/sveltekit/routes.go
+++ b/cmd/frontend/internal/app/ui/sveltekit/routes.go
@@ -21,37 +21,37 @@ var svelteKitRoutes = []svelteKitRoute{
 	{
 		Id:      "/[...repo=reporev]/(validrev)/(code)",
 		Pattern: regexp.MustCompile("^/(?:(?:(?:[^@/-]|(?:[^/@]{2,}))/)*(?:[^@/-]|(?:[^/@]{2,})))(?:@(?:(?:(?:[^@/-]|(?:[^/@]{2,}))/)*(?:[^@/-]|(?:[^/@]{2,}))))?/?$"),
-		Tag:     tags.EnableOptIn | tags.RepoRoot,
+		Tag:     tags.EnableOptIn | tags.RepoRoot | tags.EnableRollout,
 	},
 	{
 		Id:      "/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]",
 		Pattern: regexp.MustCompile("^/(?:(?:(?:[^@/-]|(?:[^/@]{2,}))/)*(?:[^@/-]|(?:[^/@]{2,})))(?:@(?:(?:(?:[^@/-]|(?:[^/@]{2,}))/)*(?:[^@/-]|(?:[^/@]{2,}))))?/-/blob(?:/.*)?/?$"),
-		Tag:     tags.EnableOptIn,
+		Tag:     tags.EnableOptIn | tags.EnableRollout,
 	},
 	{
 		Id:      "/[...repo=reporev]/(validrev)/(code)/-/tree/[...path]",
 		Pattern: regexp.MustCompile("^/(?:(?:(?:[^@/-]|(?:[^/@]{2,}))/)*(?:[^@/-]|(?:[^/@]{2,})))(?:@(?:(?:(?:[^@/-]|(?:[^/@]{2,}))/)*(?:[^@/-]|(?:[^/@]{2,}))))?/-/tree(?:/.*)?/?$"),
-		Tag:     tags.EnableOptIn,
+		Tag:     tags.EnableOptIn | tags.EnableRollout,
 	},
 	{
 		Id:      "/[...repo=reporev]/(validrev)/-/branches",
 		Pattern: regexp.MustCompile("^/(?:(?:(?:[^@/-]|(?:[^/@]{2,}))/)*(?:[^@/-]|(?:[^/@]{2,})))(?:@(?:(?:(?:[^@/-]|(?:[^/@]{2,}))/)*(?:[^@/-]|(?:[^/@]{2,}))))?/-/branches/?$"),
-		Tag:     tags.EnableOptIn,
+		Tag:     tags.EnableOptIn | tags.EnableRollout,
 	},
 	{
 		Id:      "/[...repo=reporev]/(validrev)/-/branches/all",
 		Pattern: regexp.MustCompile("^/(?:(?:(?:[^@/-]|(?:[^/@]{2,}))/)*(?:[^@/-]|(?:[^/@]{2,})))(?:@(?:(?:(?:[^@/-]|(?:[^/@]{2,}))/)*(?:[^@/-]|(?:[^/@]{2,}))))?/-/branches/all/?$"),
-		Tag:     tags.EnableOptIn,
+		Tag:     tags.EnableOptIn | tags.EnableRollout,
 	},
 	{
 		Id:      "/[...repo=reporev]/(validrev)/-/commit/[...revspec]",
 		Pattern: regexp.MustCompile("^/(?:(?:(?:[^@/-]|(?:[^/@]{2,}))/)*(?:[^@/-]|(?:[^/@]{2,})))(?:@(?:(?:(?:[^@/-]|(?:[^/@]{2,}))/)*(?:[^@/-]|(?:[^/@]{2,}))))?/-/commit(?:/.*)?/?$"),
-		Tag:     tags.EnableOptIn,
+		Tag:     tags.EnableOptIn | tags.EnableRollout,
 	},
 	{
 		Id:      "/[...repo=reporev]/(validrev)/-/commits/[...path]",
 		Pattern: regexp.MustCompile("^/(?:(?:(?:[^@/-]|(?:[^/@]{2,}))/)*(?:[^@/-]|(?:[^/@]{2,})))(?:@(?:(?:(?:[^@/-]|(?:[^/@]{2,}))/)*(?:[^@/-]|(?:[^/@]{2,}))))?/-/commits(?:/.*)?/?$"),
-		Tag:     tags.EnableOptIn,
+		Tag:     tags.EnableOptIn | tags.EnableRollout,
 	},
 	{
 		Id:      "/[...repo=reporev]/(validrev)/-/stats/contributors",
@@ -61,7 +61,7 @@ var svelteKitRoutes = []svelteKitRoute{
 	{
 		Id:      "/[...repo=reporev]/(validrev)/-/tags",
 		Pattern: regexp.MustCompile("^/(?:(?:(?:[^@/-]|(?:[^/@]{2,}))/)*(?:[^@/-]|(?:[^/@]{2,})))(?:@(?:(?:(?:[^@/-]|(?:[^/@]{2,}))/)*(?:[^@/-]|(?:[^/@]{2,}))))?/-/tags/?$"),
-		Tag:     tags.EnableOptIn,
+		Tag:     tags.EnableOptIn | tags.EnableRollout,
 	},
 	{
 		Id:      "/search",


### PR DESCRIPTION
(in preparation for the S2 rollout)

This commit enables the following routes via the `web-next-rollout` flag:

- repo home
- blob
- file
- branches
- tags
- commits
- commit

Question: Should we also enable the contributors page by default? It would be the only page left but it didn't receive any attention.

## Test plan

Inspected generated code.
