### PR TITLE
Svelte: Fix search input shortcut `/` on the repository page

### DIFF
--- a/client/web-sveltekit/src/routes/[...repo=reporev]/RepoSearchInput.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/RepoSearchInput.svelte
@@ -23,7 +23,11 @@
 
     registerHotkey({
         keys: { key: '/' },
-        handler: () => open.set(true),
+        allowDefault: true,
+        handler: () => {
+            open.set(true)
+            return false
+        },
     })
 
     function handleSearchSubmit(state: QueryState): void {


### PR DESCRIPTION

## Test plan
- Check that search input can be opened with `/` and allows input `/` symbols after it was open

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
