### PR TITLE
Svelte: Support custom position target for Popover element

### DIFF
--- a/client/web-sveltekit/src/lib/Popover.svelte
+++ b/client/web-sveltekit/src/lib/Popover.svelte
@@ -12,6 +12,7 @@
 
     let isOpen = false
     let trigger: HTMLElement | null
+    let target: HTMLElement | undefined
     let popoverContainer: HTMLElement | null
 
     function toggle(open?: boolean): void {
@@ -22,6 +23,10 @@
         if (event.detail !== trigger && !trigger?.contains(event.detail)) {
             isOpen = false
         }
+    }
+
+    const registerTarget: Action<HTMLElement> = node => {
+        target = node
     }
 
     const registerTrigger: Action<HTMLElement> = node => {
@@ -72,12 +77,12 @@
     }
 </script>
 
-<slot {toggle} {registerTrigger} />
+<slot {toggle} {registerTrigger} {registerTarget} />
 {#if trigger && isOpen}
     <div
         use:registerPopoverContainer
         use:portal
-        use:popover={{ reference: trigger, options: { placement, shift: { padding: 4 } } }}
+        use:popover={{ reference: target ?? trigger, options: { placement, offset: 3, shift: { padding: 4 } } }}
         use:onClickOutside
         on:click-outside={handleClickOutside}
     >

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/RepositoryRevPicker.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/RepositoryRevPicker.svelte
@@ -60,8 +60,8 @@
     }
 </script>
 
-<Popover let:registerTrigger let:toggle placement="right-start">
-    <div class="button-group" class:is-on-specific-rev={isOnSpecificRev}>
+<Popover let:registerTrigger let:registerTarget let:toggle placement="right-start">
+    <div use:registerTarget class="button-group" class:is-on-specific-rev={isOnSpecificRev}>
         <Button variant="secondary" size="sm">
             <svelte:fragment slot="custom" let:buttonClass>
                 <button use:registerTrigger class={`${buttonClass} revision-trigger`} on:click={() => toggle()}>


### PR DESCRIPTION
Prior to this Popover trigger was used as the only option for the popover target, it didn't fit in the revision popover trigger case, when the target should be a group of buttons to avoid visual overlapping, but trigger still should be different button (not both buttons). 

This PR introduces new prop for Popover to split trigger and target elements.

| Before | After |
| -------- | ------- |
| ![image](https://github.com/sourcegraph/sourcegraph/assets/18492575/636f9f6a-1eba-48b3-a6df-941baf8a6e84) | <img width="804" alt="Screenshot 2024-05-02 at 13 42 57" src="https://github.com/sourcegraph/sourcegraph/assets/18492575/4d062bd8-80f3-4e8a-9516-e2852ca0757a"> |

## Test plan
- Check Repository Rev Popover position


