### PR TITLE
svelte: Make several improvements to the commit page

### DIFF
--- a/client/web-sveltekit/src/lib/repo/DiffSquares.svelte
+++ b/client/web-sveltekit/src/lib/repo/DiffSquares.svelte
@@ -44,6 +44,7 @@
 <style lang="scss">
     .root {
         display: inline-flex;
+        gap: 0.125rem;
     }
 
     .square {
@@ -51,6 +52,5 @@
         width: 0.5rem;
         height: 0.5rem;
         background-color: var(--text-muted);
-        margin-left: 0.125rem;
     }
 </style>

--- a/client/web-sveltekit/src/lib/repo/FileDiff.svelte
+++ b/client/web-sveltekit/src/lib/repo/FileDiff.svelte
@@ -2,14 +2,16 @@
     import { dirname } from 'path'
 
     import { mdiChevronRight, mdiChevronDown } from '@mdi/js'
+    import { createEventDispatcher } from 'svelte'
 
     import { numberWithCommas } from '$lib/common'
     import Icon from '$lib/Icon.svelte'
+    import Badge from '$lib/wildcard/Badge.svelte'
+    import Button from '$lib/wildcard/Button.svelte'
 
     import DiffSquares from './DiffSquares.svelte'
-    import FileDiffHunks from './FileDiffHunks.svelte'
     import type { FileDiff_Diff } from './FileDiff.gql'
-    import { createEventDispatcher } from 'svelte'
+    import FileDiffHunks from './FileDiffHunks.svelte'
 
     export let fileDiff: FileDiff_Diff
     export let expanded = !!fileDiff.newPath
@@ -20,16 +22,8 @@
     $: isNew = !fileDiff.oldPath
     $: isDeleted = !fileDiff.newPath
     $: isRenamed = fileDiff.newPath && fileDiff.oldPath && fileDiff.newPath !== fileDiff.oldPath
+    $: isMoved = isRenamed && dirname(fileDiff.newPath!) !== dirname(fileDiff.oldPath!)
     $: path = isRenamed ? `${fileDiff.oldPath} -> ${fileDiff.newPath}` : isDeleted ? fileDiff.oldPath : fileDiff.newPath
-    $: badgeLabel = isNew
-        ? 'Added'
-        : isDeleted
-        ? 'Deleted'
-        : isRenamed
-        ? dirname(fileDiff.newPath!) !== dirname(fileDiff.oldPath!)
-            ? 'Moved'
-            : 'Renamed'
-        : ''
     $: stat = fileDiff.stat
     $: linkFile = fileDiff.mostRelevantFile.__typename === 'GitBlob'
 
@@ -40,18 +34,23 @@
 </script>
 
 <div class="header">
-    <button type="button" on:click={toggle}>
+    <Button variant="icon" on:click={toggle} aria-label="{expanded ? 'Hide' : 'Show'} file diff">
         <Icon inline svgPath={expanded ? mdiChevronDown : mdiChevronRight} />
-    </button>
-    <div class="headerPathStart">
-        <span>{badgeLabel}</span>
-    </div>
+    </Button>
+    {#if isNew}
+        <Badge variant="success">Added</Badge>
+    {:else if isDeleted}
+        <Badge variant="danger">Deleted</Badge>
+    {:else if isRenamed}
+        <Badge variant="warning">{isMoved ? 'Moved' : 'Renamed'}</Badge>
+    {/if}
     {#if stat}
-        <small>{numberWithCommas(stat.added + stat.deleted)}</small>
+        <small class="added">+{numberWithCommas(stat.added)}</small>
+        <small class="deleted">-{numberWithCommas(stat.deleted)}</small>
         <DiffSquares added={stat.added} deleted={stat.deleted} />
     {/if}
     {#if linkFile}
-        <a class="file-link" href={fileDiff.mostRelevantFile.url}><strong><span title={path}>{path}</span></strong></a>
+        <a href={fileDiff.mostRelevantFile.url}><span title={path}>{path}</span></a>
     {:else}
         <span title={path}>{path}</span>
     {/if}
@@ -66,11 +65,8 @@
     .header {
         display: flex;
         align-items: center;
+        gap: 0.5rem;
         padding: 0.25rem 0rem;
-    }
-
-    .file-link {
-        margin-left: 0.5rem;
     }
 
     .hunks {
@@ -78,9 +74,11 @@
         border: 1px solid var(--border-color);
     }
 
-    button {
-        background-color: transparent;
-        border: none;
-        cursor: pointer;
+    .added {
+        color: var(--success);
+    }
+
+    .deleted {
+        color: var(--danger);
     }
 </style>

--- a/client/web-sveltekit/src/lib/wildcard/CopyButton.svelte
+++ b/client/web-sveltekit/src/lib/wildcard/CopyButton.svelte
@@ -6,23 +6,24 @@
     import Tooltip from '$lib/Tooltip.svelte'
     import { Button } from '$lib/wildcard'
 
-    export let path: string
+    export let value: string
+    export let label = 'Copy to clipboard'
 
     let recentlyCopied = false
     function handleCopyPath(): void {
-        copy(path)
+        copy(value)
         recentlyCopied = true
         setTimeout(() => {
             recentlyCopied = false
         }, 1000)
     }
 
-    $: tooltip = recentlyCopied ? 'Copied!' : 'Copy path to clipboard'
+    $: tooltip = recentlyCopied ? 'Copied!' : label
 </script>
 
-<span data-visible-on-focus class="copy-path-button">
+<span class="copy-path-button">
     <Tooltip {tooltip} placement="bottom">
-        <Button on:click={() => handleCopyPath()} variant="icon" size="sm" aria-label="Copy path to clipboard">
+        <Button on:click={handleCopyPath} variant="icon" size="sm" aria-label={label}>
             <Icon inline svgPath={mdiContentCopy} aria-hidden />
         </Button>
     </Tooltip>
@@ -30,6 +31,8 @@
 
 <style lang="scss">
     .copy-path-button {
+        display: contents;
+
         --color: var(--icon-color);
         &:hover {
             --color: var(--body-color);

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/FileTree.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/FileTree.svelte
@@ -139,7 +139,6 @@
 </div>
 
 <style lang="scss">
-
     div {
         overflow: auto;
 

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/-/commit/[...revspec]/page.gql
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/-/commit/[...revspec]/page.gql
@@ -10,7 +10,10 @@ query CommitPage_CommitQuery($repoName: String!, $revspec: String!) {
                 abbreviatedOID
                 canonicalURL
             }
-
+            externalURLs {
+                url
+                serviceKind
+            }
             ...Commit
         }
     }

--- a/client/web-sveltekit/src/routes/search/FileSearchResultHeader.svelte
+++ b/client/web-sveltekit/src/routes/search/FileSearchResultHeader.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
     import { highlightRanges } from '$lib/dom'
     import { getFileMatchUrl, type ContentMatch, type PathMatch, type SymbolMatch } from '$lib/shared'
+    import CopyButton from '$lib/wildcard/CopyButton.svelte'
 
-    import CopyPathButton from './CopyPathButton.svelte'
     import RepoRev from './RepoRev.svelte'
 
     export let result: ContentMatch | PathMatch | SymbolMatch
@@ -24,16 +24,18 @@
             {result.path}
         </a>
     {/key}
-    <CopyPathButton path={result.path} />
+    <span data-visible-on-focus><CopyButton value={result.path} label="Copy path to clipboard" /></span>
 </span>
 
 <style lang="scss">
     .root {
-        display: flex;
-        align-items: center;
-        gap: 0.5rem;
         font-family: var(--code-font-family);
         font-size: var(--code-font-size);
+
+        a,
+        span {
+            vertical-align: middle;
+        }
     }
 
     .interpunct {

--- a/client/web-sveltekit/src/routes/search/SearchResult.svelte
+++ b/client/web-sveltekit/src/routes/search/SearchResult.svelte
@@ -45,7 +45,7 @@
         overflow: hidden;
         display: flex;
         flex-wrap: wrap;
-        align-items: baseline;
+        align-items: center;
 
         // .title-inner
         overflow-wrap: anywhere;

--- a/client/wildcard/src/components/Button/Button.module.scss
+++ b/client/wildcard/src/components/Button/Button.module.scss
@@ -132,10 +132,14 @@ input.btn {
     padding: 0;
     background: transparent;
     color: inherit;
-    display: flex;
+    display: inline-flex;
     align-items: center;
     border: none;
     cursor: pointer;
+
+    &.btn.btn-block {
+        display: flex;
+    }
 
     &.focus:not(:disabled):not(:global(.disabled)):not([aria-disabled='true']) {
         box-shadow: 0 0 0 2px var(--primary-2);


### PR DESCRIPTION
This adds some style and functionality improvements to the commit page.

 Styling:
 - Commit and parent SHAs as badges
 - Increased avatar size
 - Proper status badges (added, deleted, moved)
 - Normal font weight for file paths

 Behavior:
 - Add copy button for commit SHAs
 - Add a link to browse files at the commit
 - Add links to open commit at code host
 - Split changed lines into added and removed

Obviously there is more that can and should be done (e.g. adding split view), but it's a start.

| Type | Screenshot |
|--------|--------|
| dotcom/React (for reference) | ![2024-05-02_14-52](https://github.com/sourcegraph/sourcegraph/assets/179026/db099f02-8a93-4116-91d1-0c5c0ed83df6) |
| Before | ![2024-05-02_14-52_1](https://github.com/sourcegraph/sourcegraph/assets/179026/2e10b7ef-eeba-48f0-bd8d-f760a86e69bc) |
| After | ![2024-05-02_14-59](https://github.com/sourcegraph/sourcegraph/assets/179026/889f6d01-a539-4e02-804c-2848525dd8d1) | 

Since I updated the file search results to also use the generalized copy button, I made some layout changes to have it properly aligned to with the path name:

| Before | After |
|--------|--------|
| ![2024-05-02_14-54](https://github.com/sourcegraph/sourcegraph/assets/179026/f251db16-ed37-45e7-a7e7-0cb57b83be18) | ![2024-05-02_14-54_1](https://github.com/sourcegraph/sourcegraph/assets/179026/15f3025a-89e2-418f-8a31-681ab07b9725) | 


## Test plan

- Visual inspection
- Click copy buttons
- Click 'browse files' link
- Click 'open on code host' link

