### PR TITLE
fix: update link for fuzzyfinder feedback

### DIFF
--- a/client/web/src/components/fuzzyFinder/FuzzyModal.tsx
+++ b/client/web/src/components/fuzzyFinder/FuzzyModal.tsx
@@ -34,7 +34,6 @@ import {
     TabPanels,
     TabPanel,
     TabList,
-    Badge,
     LoadingSpinner,
 } from '@sourcegraph/wildcard'
 
@@ -421,14 +420,6 @@ export const FuzzyModal: React.FunctionComponent<React.PropsWithChildren<FuzzyMo
                     ) : (
                         <H3>Find files</H3>
                     )}
-                    <Badge
-                        variant="info"
-                        href="https://github.com/sourcegraph/sourcegraph/discussions/42874"
-                        tooltip="Provide feedback on this experimental feature"
-                        className={styles.experimentalBadge}
-                    >
-                        Experimental
-                    </Badge>
                     <Button variant="icon" onClick={onClose} aria-label="Close" className={styles.closeButton}>
                         <Icon aria-hidden={true} svgPath={mdiClose} />
                     </Button>

--- a/client/web/src/components/fuzzyFinder/FuzzyModal.tsx
+++ b/client/web/src/components/fuzzyFinder/FuzzyModal.tsx
@@ -423,7 +423,7 @@ export const FuzzyModal: React.FunctionComponent<React.PropsWithChildren<FuzzyMo
                     )}
                     <Badge
                         variant="info"
-                        href="https://community.sourcegraph.com/"
+                        href="https://community.sourcegraph.com/t/experimental-fuzzy-finder-in-code-search/230"
                         tooltip="Provide feedback on this experimental feature"
                         className={styles.experimentalBadge}
                     >

--- a/client/web/src/components/fuzzyFinder/FuzzyModal.tsx
+++ b/client/web/src/components/fuzzyFinder/FuzzyModal.tsx
@@ -34,6 +34,7 @@ import {
     TabPanels,
     TabPanel,
     TabList,
+    Badge,
     LoadingSpinner,
 } from '@sourcegraph/wildcard'
 
@@ -420,6 +421,14 @@ export const FuzzyModal: React.FunctionComponent<React.PropsWithChildren<FuzzyMo
                     ) : (
                         <H3>Find files</H3>
                     )}
+                    <Badge
+                        variant="info"
+                        href="https://community.sourcegraph.com/"
+                        tooltip="Provide feedback on this experimental feature"
+                        className={styles.experimentalBadge}
+                    >
+                        Experimental
+                    </Badge>
                     <Button variant="icon" onClick={onClose} aria-label="Close" className={styles.closeButton}>
                         <Icon aria-hidden={true} svgPath={mdiClose} />
                     </Button>


### PR DESCRIPTION
This PR updates the link of the experimental badge for the fuzzy finder, which used to target a now non-existent github discussion. It looks like discussions have been disabled on sourcegraph/sourcegraph. Instead we now link to the community forum.

## Test plan

Covered by FuzzyFinder.test.tsx