### PR TITLE
Svelte: Code blame header visual update

### DIFF
--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/+layout.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/+layout.svelte
@@ -265,15 +265,16 @@
         flex-flow: row nowrap;
         justify-content: space-between;
         overflow: hidden;
-        border-top: 1px solid var(--border-color);
         box-shadow: var(--bottom-panel-shadow);
-        background-color: var(--color-bg-1);
+        background-color: var(--code-bg);
         color: var(--text-body);
         // Applying z-index to the bottom panel allows its shadow to cascade correctly
         z-index: 1;
 
         &.open {
             height: 32vh;
+            box-shadow: var(--bottom-panel-open-shadow);
+            border-top: 1px solid var(--secondary-1);
             // Disable flex layout so that tabs simply fill the available space
             display: block;
 

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/DiffView.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/DiffView.svelte
@@ -69,6 +69,8 @@
         color: var(--text-muted);
         background-color: var(--code-bg);
         box-shadow: var(--blame-header-shadow);
+
+        // Allows for its shadow to cascade over the code panel
         z-index: 1;
         border-top: 1px solid var(--border-color);
 

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/DiffView.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/DiffView.svelte
@@ -63,11 +63,14 @@
     .info {
         display: flex;
         justify-content: space-between;
-        padding: 0.5rem;
-
-        background: var(--color-bg-1);
-        color: var(--text-muted);
+        align-items: baseline;
         gap: 1rem;
+        padding: 0.5rem 1rem;
+        color: var(--text-muted);
+        background-color: var(--code-bg);
+        box-shadow: var(--blame-header-shadow);
+        z-index: 1;
+        border-top: 1px solid var(--border-color);
 
         align-items: center;
 

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/FileView.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/FileView.svelte
@@ -297,6 +297,8 @@
         color: var(--text-muted);
         background-color: var(--code-bg);
         box-shadow: var(--blame-header-shadow);
+
+        // Allows for its shadow to cascade over the code panel
         z-index: 1;
         border-top: 1px solid var(--border-color);
     }

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/FileView.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/FileView.svelte
@@ -279,6 +279,7 @@
         overflow: auto;
         flex: 1;
         background-color: var(--code-bg);
+        padding: 0.25rem 0;
 
         &.center {
             display: flex;
@@ -292,9 +293,12 @@
         display: flex;
         align-items: baseline;
         gap: 1rem;
-        padding: 0.5rem;
+        padding: 0.75rem 1rem;
         color: var(--text-muted);
         background-color: var(--code-bg);
+        box-shadow: var(--blame-header-shadow);
+        z-index: 1;
+        border-top: 1px solid var(--border-color);
     }
 
     .revision-info {

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/FileTree.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/FileTree.svelte
@@ -139,7 +139,6 @@
 </div>
 
 <style lang="scss">
-
     div {
         overflow: auto;
 

--- a/client/web-sveltekit/src/routes/svelte-overrides.scss
+++ b/client/web-sveltekit/src/routes/svelte-overrides.scss
@@ -35,7 +35,7 @@ body {
     --code-selection-bg: rgba(231, 238, 250, 0.8);
 
     // Shadows
-    --sidebar-shadow: 0 79px 22px 0 rgba(30, 4, 47, 0), 0 51px 20 0 rgba(30, 4, 47, 0.01),
+    --sidebar-shadow: 0 79px 22px 0 rgba(30, 4, 47, 0), 0 51px 20px 0 rgba(30, 4, 47, 0.01),
         0 29px 17px 0 rgba(30, 4, 47, 0.02), 0 13px 13px 0 rgba(30, 4, 47, 0.03), 0 3px 7px 0 rgba(30, 4, 47, 0.04);
     --fileheader-shadow: 0 6px 2px 0 rgba(0, 0, 0, 0), 0 4px 2px 0 rgba(0, 0, 0, 0.01), 0 2px 1px 0 rgba(0, 0, 0, 0.02),
         0 1px 1px 0 rgba(0, 0, 0, 0.03), 0 0 1px 0 rgba(0, 0, 0, 0.04);

--- a/client/web-sveltekit/src/routes/svelte-overrides.scss
+++ b/client/web-sveltekit/src/routes/svelte-overrides.scss
@@ -42,11 +42,9 @@ body {
     --blame-header-shadow: 0 16px 5px 0 rgba(0, 0, 0, 0), 0 11px 4px 0 rgba(0, 0, 0, 0.01),
         0 6px 4px 0 rgba(0, 0, 0, 0.02), 0 3px 3px 0 rgba(0, 0, 0, 0.03), 0 1px 1px 0 rgba(0, 0, 0, 0.04);
     --bottom-panel-shadow: 0 -19px 5px 0 rgba(1, 6, 12, 0), 0 -12px 5px 0 rgba(1, 6, 12, 0),
-        0 -7px 4px 0 rgba(1, 6, 12, 0.01), 0 -3px 3px 0 rgba(1, 6, 12, 0.02),
-        0 -1px 2px 0 rgba(1, 6, 12, 0.02);
+        0 -7px 4px 0 rgba(1, 6, 12, 0.01), 0 -3px 3px 0 rgba(1, 6, 12, 0.02), 0 -1px 2px 0 rgba(1, 6, 12, 0.02);
     --bottom-panel-open-shadow: 0 -187px 52px 0 rgba(1, 6, 12, 0), 0 -119px 48px 0 rgba(1, 6, 12, 0.01),
-        0 -67px 40px 0 rgba(1, 6, 12, 0.03), 0 -30px 30px 0 rgba(1, 6, 12, 0.05),
-        0 -7px 16px 0 rgba(1, 6, 12, 0.06);
+        0 -67px 40px 0 rgba(1, 6, 12, 0.03), 0 -30px 30px 0 rgba(1, 6, 12, 0.05), 0 -7px 16px 0 rgba(1, 6, 12, 0.06);
     --popover-shadow: 0 174px 49px 0 rgba(0, 0, 0, 0), 0 112px 45px 0 rgba(0, 0, 0, 0.01),
         0 63px 38px 0 rgba(0, 0, 0, 0.02), 0 28px 28px 0 rgba(0, 0, 0, 0.03), 0 7px 15px 0 rgba(0, 0, 0, 0.04);
 }
@@ -71,11 +69,9 @@ body {
     --fileheader-shadow: 0 6px 2px 0 rgba(15, 2, 24, 0.01), 0 4px 2px 0 rgba(15, 2, 24, 0.05),
         0 2px 1px 0 rgba(15, 2, 24, 0.16), 0 1px 1px 0 rgba(15, 2, 24, 0.27), 0 0 1px 0 rgba(15, 2, 24, 0.31);
     --bottom-panel-shadow: 0 -50px 14px 0 rgba(1, 6, 12, 0.01), 0 -32px 13px 0 rgba(1, 6, 12, 0.07),
-        0 -18px 11px 0 rgba(1, 6, 12, 0.24), 0 -8px 8px 0 rgba(1, 6, 12, 0.41),
-        0 -2px 4px 0 rgba(1, 6, 12, 0.47);
+        0 -18px 11px 0 rgba(1, 6, 12, 0.24), 0 -8px 8px 0 rgba(1, 6, 12, 0.41), 0 -2px 4px 0 rgba(1, 6, 12, 0.47);
     --bottom-panel-open-shadow: 0 -187px 52px 0 rgba(1, 6, 12, 0.01), 0 -119px 48px 0 rgba(1, 6, 12, 0.09),
-        0 -67px 40px 0 rgba(1, 6, 12, 0.32), 0 -30px 30px 0 rgba(1, 6, 12, 0.55),
-        0 -7px 16px 0 rgba(1, 6, 12, 0.63);
+        0 -67px 40px 0 rgba(1, 6, 12, 0.32), 0 -30px 30px 0 rgba(1, 6, 12, 0.55), 0 -7px 16px 0 rgba(1, 6, 12, 0.63);
     --popover-shadow: 0 174px 49px 0 rgba(0, 0, 0, 0.01), 0 112px 45px 0 rgba(0, 0, 0, 0.05),
         0 63px 38px 0 rgba(0, 0, 0, 0.16), 0 28px 28px 0 rgba(0, 0, 0, 0.27), 0 7px 15px 0 rgba(0, 0, 0, 0.31);
 }

--- a/client/web-sveltekit/src/routes/svelte-overrides.scss
+++ b/client/web-sveltekit/src/routes/svelte-overrides.scss
@@ -35,18 +35,18 @@ body {
     --code-selection-bg: rgba(231, 238, 250, 0.8);
 
     // Shadows
-    --sidebar-shadow: 0 79px 22px 0 rgba(30, 4, 47, 0), 0 51px 20px 0 rgba(30, 4, 47, 0.01),
+    --sidebar-shadow: 0 79px 22px 0 rgba(30, 4, 47, 0), 0 51px 20 0 rgba(30, 4, 47, 0.01),
         0 29px 17px 0 rgba(30, 4, 47, 0.02), 0 13px 13px 0 rgba(30, 4, 47, 0.03), 0 3px 7px 0 rgba(30, 4, 47, 0.04);
     --fileheader-shadow: 0 6px 2px 0 rgba(0, 0, 0, 0), 0 4px 2px 0 rgba(0, 0, 0, 0.01), 0 2px 1px 0 rgba(0, 0, 0, 0.02),
         0 1px 1px 0 rgba(0, 0, 0, 0.03), 0 0 1px 0 rgba(0, 0, 0, 0.04);
-    --blame-header-shadow: 0px 16px 5px 0px rgba(0, 0, 0, 0), 0px 11px 4px 0px rgba(0, 0, 0, 0.01),
-        0px 6px 4px 0px rgba(0, 0, 0, 0.02), 0px 3px 3px 0px rgba(0, 0, 0, 0.03), 0px 1px 1px 0px rgba(0, 0, 0, 0.04);
-    --bottom-panel-shadow: 0px -19px 5px 0px rgba(1, 6, 12, 0), 0px -12px 5px 0px rgba(1, 6, 12, 0),
-        0px -7px 4px 0px rgba(1, 6, 12, 0.01), 0px -3px 3px 0px rgba(1, 6, 12, 0.02),
-        0px -1px 2px 0px rgba(1, 6, 12, 0.02);
-    --bottom-panel-open-shadow: 0px -187px 52px 0px rgba(1, 6, 12, 0), 0px -119px 48px 0px rgba(1, 6, 12, 0.01),
-        0px -67px 40px 0px rgba(1, 6, 12, 0.03), 0px -30px 30px 0px rgba(1, 6, 12, 0.05),
-        0px -7px 16px 0px rgba(1, 6, 12, 0.06);
+    --blame-header-shadow: 0 16px 5px 0 rgba(0, 0, 0, 0), 0 11px 4px 0 rgba(0, 0, 0, 0.01),
+        0 6px 4px 0 rgba(0, 0, 0, 0.02), 0 3px 3px 0 rgba(0, 0, 0, 0.03), 0 1px 1px 0 rgba(0, 0, 0, 0.04);
+    --bottom-panel-shadow: 0 -19px 5px 0 rgba(1, 6, 12, 0), 0 -12px 5px 0 rgba(1, 6, 12, 0),
+        0 -7px 4px 0 rgba(1, 6, 12, 0.01), 0 -3px 3px 0 rgba(1, 6, 12, 0.02),
+        0 -1px 2px 0 rgba(1, 6, 12, 0.02);
+    --bottom-panel-open-shadow: 0 -187px 52px 0 rgba(1, 6, 12, 0), 0 -119px 48px 0 rgba(1, 6, 12, 0.01),
+        0 -67px 40px 0 rgba(1, 6, 12, 0.03), 0 -30px 30px 0 rgba(1, 6, 12, 0.05),
+        0 -7px 16px 0 rgba(1, 6, 12, 0.06);
     --popover-shadow: 0 174px 49px 0 rgba(0, 0, 0, 0), 0 112px 45px 0 rgba(0, 0, 0, 0.01),
         0 63px 38px 0 rgba(0, 0, 0, 0.02), 0 28px 28px 0 rgba(0, 0, 0, 0.03), 0 7px 15px 0 rgba(0, 0, 0, 0.04);
 }
@@ -66,16 +66,16 @@ body {
     // Shadows
     --sidebar-shadow: 0 318px 89px 0 rgba(12, 1, 19, 0.01), 0 203px 81px 0 rgba(12, 1, 19, 0.05),
         0 114px 69px 0 rgba(12, 1, 19, 0.16), 0 51px 51px 0 rgba(12, 1, 19, 0.27), 0 13px 28px 0 rgba(12, 1, 19, 0.31);
-    --blame-header-shadow: 0px 25px 7px 0px rgba(0, 0, 0, 0), 0px 16px 6px 0px rgba(0, 0, 0, 0.04),
-        0px 9px 5px 0px rgba(0, 0, 0, 0.12), 0px 4px 4px 0px rgba(0, 0, 0, 0.2), 0px 1px 2px 0px rgba(0, 0, 0, 0.24);
+    --blame-header-shadow: 0 25px 7px 0 rgba(0, 0, 0, 0), 0 16px 6px 0 rgba(0, 0, 0, 0.04),
+        0 9px 5px 0 rgba(0, 0, 0, 0.12), 0 4px 4px 0 rgba(0, 0, 0, 0.2), 0 1px 2px 0 rgba(0, 0, 0, 0.24);
     --fileheader-shadow: 0 6px 2px 0 rgba(15, 2, 24, 0.01), 0 4px 2px 0 rgba(15, 2, 24, 0.05),
         0 2px 1px 0 rgba(15, 2, 24, 0.16), 0 1px 1px 0 rgba(15, 2, 24, 0.27), 0 0 1px 0 rgba(15, 2, 24, 0.31);
-    --bottom-panel-shadow: 0px -50px 14px 0px rgba(1, 6, 12, 0.01), 0px -32px 13px 0px rgba(1, 6, 12, 0.07),
-        0px -18px 11px 0px rgba(1, 6, 12, 0.24), 0px -8px 8px 0px rgba(1, 6, 12, 0.41),
-        0px -2px 4px 0px rgba(1, 6, 12, 0.47);
-    --bottom-panel-open-shadow: 0px -187px 52px 0px rgba(1, 6, 12, 0.01), 0px -119px 48px 0px rgba(1, 6, 12, 0.09),
-        0px -67px 40px 0px rgba(1, 6, 12, 0.32), 0px -30px 30px 0px rgba(1, 6, 12, 0.55),
-        0px -7px 16px 0px rgba(1, 6, 12, 0.63);
+    --bottom-panel-shadow: 0 -50px 14px 0 rgba(1, 6, 12, 0.01), 0 -32px 13px 0 rgba(1, 6, 12, 0.07),
+        0 -18px 11px 0 rgba(1, 6, 12, 0.24), 0 -8px 8px 0 rgba(1, 6, 12, 0.41),
+        0 -2px 4px 0 rgba(1, 6, 12, 0.47);
+    --bottom-panel-open-shadow: 0 -187px 52px 0 rgba(1, 6, 12, 0.01), 0 -119px 48px 0 rgba(1, 6, 12, 0.09),
+        0 -67px 40px 0 rgba(1, 6, 12, 0.32), 0 -30px 30px 0 rgba(1, 6, 12, 0.55),
+        0 -7px 16px 0 rgba(1, 6, 12, 0.63);
     --popover-shadow: 0 174px 49px 0 rgba(0, 0, 0, 0.01), 0 112px 45px 0 rgba(0, 0, 0, 0.05),
         0 63px 38px 0 rgba(0, 0, 0, 0.16), 0 28px 28px 0 rgba(0, 0, 0, 0.27), 0 7px 15px 0 rgba(0, 0, 0, 0.31);
 }

--- a/client/web-sveltekit/src/routes/svelte-overrides.scss
+++ b/client/web-sveltekit/src/routes/svelte-overrides.scss
@@ -39,8 +39,14 @@ body {
         0 29px 17px 0 rgba(30, 4, 47, 0.02), 0 13px 13px 0 rgba(30, 4, 47, 0.03), 0 3px 7px 0 rgba(30, 4, 47, 0.04);
     --fileheader-shadow: 0 6px 2px 0 rgba(0, 0, 0, 0), 0 4px 2px 0 rgba(0, 0, 0, 0.01), 0 2px 1px 0 rgba(0, 0, 0, 0.02),
         0 1px 1px 0 rgba(0, 0, 0, 0.03), 0 0 1px 0 rgba(0, 0, 0, 0.04);
-    --bottom-panel-shadow: 0 -37px 10px 0 rgba(1, 6, 12, 0), 0 -24px 10px 0 rgba(1, 6, 12, 0.01),
-        0 -13px 8px 0 rgba(1, 6, 12, 0.02), 0 -6px 6px 0 rgba(1, 6, 12, 0.03), 0 -1px 3px 0 rgba(1, 6, 12, 0.04);
+    --blame-header-shadow: 0px 16px 5px 0px rgba(0, 0, 0, 0), 0px 11px 4px 0px rgba(0, 0, 0, 0.01),
+        0px 6px 4px 0px rgba(0, 0, 0, 0.02), 0px 3px 3px 0px rgba(0, 0, 0, 0.03), 0px 1px 1px 0px rgba(0, 0, 0, 0.04);
+    --bottom-panel-shadow: 0px -19px 5px 0px rgba(1, 6, 12, 0), 0px -12px 5px 0px rgba(1, 6, 12, 0),
+        0px -7px 4px 0px rgba(1, 6, 12, 0.01), 0px -3px 3px 0px rgba(1, 6, 12, 0.02),
+        0px -1px 2px 0px rgba(1, 6, 12, 0.02);
+    --bottom-panel-open-shadow: 0px -187px 52px 0px rgba(1, 6, 12, 0), 0px -119px 48px 0px rgba(1, 6, 12, 0.01),
+        0px -67px 40px 0px rgba(1, 6, 12, 0.03), 0px -30px 30px 0px rgba(1, 6, 12, 0.05),
+        0px -7px 16px 0px rgba(1, 6, 12, 0.06);
     --popover-shadow: 0 174px 49px 0 rgba(0, 0, 0, 0), 0 112px 45px 0 rgba(0, 0, 0, 0.01),
         0 63px 38px 0 rgba(0, 0, 0, 0.02), 0 28px 28px 0 rgba(0, 0, 0, 0.03), 0 7px 15px 0 rgba(0, 0, 0, 0.04);
 }
@@ -60,10 +66,16 @@ body {
     // Shadows
     --sidebar-shadow: 0 318px 89px 0 rgba(12, 1, 19, 0.01), 0 203px 81px 0 rgba(12, 1, 19, 0.05),
         0 114px 69px 0 rgba(12, 1, 19, 0.16), 0 51px 51px 0 rgba(12, 1, 19, 0.27), 0 13px 28px 0 rgba(12, 1, 19, 0.31);
+    --blame-header-shadow: 0px 25px 7px 0px rgba(0, 0, 0, 0), 0px 16px 6px 0px rgba(0, 0, 0, 0.04),
+        0px 9px 5px 0px rgba(0, 0, 0, 0.12), 0px 4px 4px 0px rgba(0, 0, 0, 0.2), 0px 1px 2px 0px rgba(0, 0, 0, 0.24);
     --fileheader-shadow: 0 6px 2px 0 rgba(15, 2, 24, 0.01), 0 4px 2px 0 rgba(15, 2, 24, 0.05),
         0 2px 1px 0 rgba(15, 2, 24, 0.16), 0 1px 1px 0 rgba(15, 2, 24, 0.27), 0 0 1px 0 rgba(15, 2, 24, 0.31);
-    --bottom-panel-shadow: 0 -37px 10 0 rgba(1, 6, 12, 0.01), 0 -24px 10 0 rgba(1, 6, 12, 0.05),
-        0 -13px 8px 0 rgba(1, 6, 12, 0.16), 0 -6px 6px 0 rgba(1, 6, 12, 0.27), 0 -1px 3px 0 rgba(1, 6, 12, 0.31);
+    --bottom-panel-shadow: 0px -50px 14px 0px rgba(1, 6, 12, 0.01), 0px -32px 13px 0px rgba(1, 6, 12, 0.07),
+        0px -18px 11px 0px rgba(1, 6, 12, 0.24), 0px -8px 8px 0px rgba(1, 6, 12, 0.41),
+        0px -2px 4px 0px rgba(1, 6, 12, 0.47);
+    --bottom-panel-open-shadow: 0px -187px 52px 0px rgba(1, 6, 12, 0.01), 0px -119px 48px 0px rgba(1, 6, 12, 0.09),
+        0px -67px 40px 0px rgba(1, 6, 12, 0.32), 0px -30px 30px 0px rgba(1, 6, 12, 0.55),
+        0px -7px 16px 0px rgba(1, 6, 12, 0.63);
     --popover-shadow: 0 174px 49px 0 rgba(0, 0, 0, 0.01), 0 112px 45px 0 rgba(0, 0, 0, 0.05),
         0 63px 38px 0 rgba(0, 0, 0, 0.16), 0 28px 28px 0 rgba(0, 0, 0, 0.27), 0 7px 15px 0 rgba(0, 0, 0, 0.31);
 }


### PR DESCRIPTION
# Context
Visual updates to the code blame header for increased readability and clarity. Plus shadows!

## Before

### Light Mode
![CleanShot 2024-05-02 at 15 42 16@2x](https://github.com/sourcegraph/sourcegraph/assets/5337876/e328fc7d-5377-4004-aff8-5d549e6bf182)

### Dark Mode
![CleanShot 2024-05-02 at 15 41 53@2x](https://github.com/sourcegraph/sourcegraph/assets/5337876/7a9fd8fa-5366-4358-b4f9-f8482d2f1911)


## After

### Light Mode
![CleanShot 2024-05-02 at 15 41 01@2x](https://github.com/sourcegraph/sourcegraph/assets/5337876/6e4c3147-11bf-42cb-bcb5-1e35aec88061)

### Dark Mode
![CleanShot 2024-05-02 at 15 41 26@2x](https://github.com/sourcegraph/sourcegraph/assets/5337876/43f774bb-cd29-4851-8751-8febfcf1e7d7)

## Test plan
Tested locally for visual changes.