### PR TITLE
[Svelte]: Fix popover onHover mode

### DIFF
--- a/client/web-sveltekit/src/lib/Popover.svelte
+++ b/client/web-sveltekit/src/lib/Popover.svelte
@@ -80,10 +80,17 @@
 <slot {toggle} {registerTrigger} {registerTarget} />
 {#if trigger && isOpen}
     <div
-        use:registerPopoverContainer
         use:portal
-        use:popover={{ reference: target ?? trigger, options: { placement, offset: 3, shift: { padding: 4 } } }}
         use:onClickOutside
+        use:registerPopoverContainer
+        use:popover={{
+            reference: target ?? trigger,
+            options: {
+                placement,
+                offset: showOnHover ? 0 : 3,
+                shift: { padding: 4 },
+            },
+        }}
         on:click-outside={handleClickOutside}
     >
         <slot name="content" {toggle} />

--- a/client/web-sveltekit/src/routes/styles.scss
+++ b/client/web-sveltekit/src/routes/styles.scss
@@ -29,6 +29,7 @@ input:focus-visible {
 
 kbd {
     display: inline;
+    height: 1.125rem;
     margin: 0 0.125rem;
     padding: 0 0.25rem 0.1rem 0.25rem;
     line-height: (16/12);

--- a/client/web-sveltekit/src/routes/styles.scss
+++ b/client/web-sveltekit/src/routes/styles.scss
@@ -29,7 +29,6 @@ input:focus-visible {
 
 kbd {
     display: inline;
-    height: 1.125rem;
     margin: 0 0.125rem;
     padding: 0 0.25rem 0.1rem 0.25rem;
     line-height: (16/12);


### PR DESCRIPTION
@fkling catch that now popover hides too fast when we use it with on hover mode because of standard non-zero offset. This PR just removes offset when the popover is used with onHover mode

## Test plan
- Check popover appearance manually 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
