### PR TITLE
svelte: Use file icons on tree page

### DIFF
--- a/client/web-sveltekit/src/lib/repo/FileTable.svelte
+++ b/client/web-sveltekit/src/lib/repo/FileTable.svelte
@@ -5,9 +5,10 @@
     import type { TreeEntryWithCommitInfo } from './FileTable.gql'
     import { replaceRevisionInURL } from '$lib/shared'
     import Timestamp from '$lib/Timestamp.svelte'
-    import type { TreeEntryFields } from './api/tree'
+    import { isFileEntry, type TreeEntry } from './api/tree'
+    import FileIcon from './FileIcon.svelte'
 
-    export let entries: readonly TreeEntryFields[]
+    export let entries: readonly TreeEntry[]
     export let commitInfo: readonly TreeEntryWithCommitInfo[]
     export let revision: string
 
@@ -29,7 +30,11 @@
         {#each entries as entry}
             <tr>
                 <td class="file-name">
-                    <Icon svgPath={entry.isDirectory ? mdiFolderOutline : mdiFileDocumentOutline} inline />
+                    {#if isFileEntry(entry)}
+                        <FileIcon file={entry} inline />
+                    {:else}
+                        <Icon svgPath={entry.isDirectory ? mdiFolderOutline : mdiFileDocumentOutline} inline />
+                    {/if}
                     <a href={replaceRevisionInURL(entry.canonicalURL, revision)}>{entry.name}</a>
                 </td>
                 {#if hasCommitInfo}

--- a/client/web-sveltekit/src/lib/repo/api/tree.ts
+++ b/client/web-sveltekit/src/lib/repo/api/tree.ts
@@ -8,6 +8,10 @@ import { type GitCommitFieldsWithTree, type TreeEntriesVariables, TreeEntries } 
 
 const MAX_FILE_TREE_ENTRIES = 1000
 
+export function isFileEntry(entry: TreeEntry): entry is Extract<TreeEntry, { __typename: 'GitBlob' }> {
+    return entry.__typename === 'GitBlob' || !entry.isDirectory
+}
+
 export function fetchTreeEntries(args: TreeEntriesVariables): Promise<GitCommitFieldsWithTree> {
     return query(
         TreeEntries,
@@ -32,8 +36,8 @@ export function fetchTreeEntries(args: TreeEntriesVariables): Promise<GitCommitF
 export const NODE_LIMIT: unique symbol = Symbol()
 
 type TreeRoot = NonNullable<GitCommitFieldsWithTree['tree']>
-export type TreeEntryFields = NonNullable<GitCommitFieldsWithTree['tree']>['entries'][number]
-type ExpandableFileTreeNodeValues = TreeEntryFields
+export type TreeEntry = NonNullable<GitCommitFieldsWithTree['tree']>['entries'][number]
+type ExpandableFileTreeNodeValues = TreeEntry
 export type FileTreeNodeValue = ExpandableFileTreeNodeValues | typeof NODE_LIMIT
 export type FileTreeData = { root: TreeRoot; values: FileTreeNodeValue[] }
 

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/FileTree.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/FileTree.svelte
@@ -6,7 +6,7 @@
 
     import { afterNavigate, goto } from '$app/navigation'
     import Icon from '$lib/Icon.svelte'
-    import { type FileTreeProvider, NODE_LIMIT, type FileTreeNodeValue, type TreeEntryFields } from '$lib/repo/api/tree'
+    import { type FileTreeProvider, NODE_LIMIT, type FileTreeNodeValue, type TreeEntry } from '$lib/repo/api/tree'
     import FileIcon from '$lib/repo/FileIcon.svelte'
     import { getSidebarFileTreeStateForRepo } from '$lib/repo/stores'
     import { replaceRevisionInURL } from '$lib/shared'
@@ -22,7 +22,7 @@
     /**
      * Returns the corresponding icon for `entry`
      */
-    function getDirectoryIconPath(entry: TreeEntryFields, open: boolean) {
+    function getDirectoryIconPath(entry: TreeEntry, open: boolean) {
         if (entry === treeRoot) {
             return mdiFolderArrowUpOutline
         }


### PR DESCRIPTION
| Before | Header |
|--------|--------|
| ![2024-05-03_08-36](https://github.com/sourcegraph/sourcegraph/assets/179026/abb587e5-2711-422d-8072-b921c10ce157) | ![2024-05-03_08-36_1](https://github.com/sourcegraph/sourcegraph/assets/179026/efccb3e3-9d84-4c8e-ae5b-f1a3a263d415) | 

## Test plan

Manual testing
