### PR TITLE
svelte: Improve file sidebar's scroll into view behavior

### DIFF
--- a/client/web-sveltekit/src/lib/TreeView.svelte
+++ b/client/web-sveltekit/src/lib/TreeView.svelte
@@ -26,8 +26,13 @@
 
     export let treeProvider: TreeProvider<N>
 
-    export function scrollSelectedItemIntoView() {
-        treeRoot?.querySelector('[aria-selected="true"] [data-treeitem-label]')?.scrollIntoView({ block: 'nearest' })
+    /**
+     * Scrolls the selected item into view, either into the center or the nearest edge.
+     *
+     * @param position - The position to scroll the item to. Defaults to 'nearest'.
+     */
+    export function scrollSelectedItemIntoView(position: 'nearest' | 'center' = 'nearest') {
+        treeRoot?.querySelector('[aria-selected="true"] [data-treeitem-label]')?.scrollIntoView({ block: position })
     }
 
     const dispatch = createEventDispatcher<{ select: HTMLElement }>()

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/FileTree.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/FileTree.svelte
@@ -79,9 +79,20 @@
     }
 
     function scrollSelectedItemIntoView() {
-        treeView.scrollSelectedItemIntoView()
+        treeView.scrollSelectedItemIntoView(
+            // Only scroll the active tree entry into the 'center' if the selected entry changed
+            // by something other than user interaction. If we always 'center' then the sidebar
+            // will "jump" as the user selects an entry with the keyboard or mouse, which is
+            // disorienting.
+            // But if we never 'center' then going back and forth might position the selected
+            // entry at the top or bottom of the sidebar, which is not very visible.
+            // So we only 'center' if focus is not on the tree container, which likely means
+            // that the user is not interacting with the tree.
+            container?.contains(document.activeElement) ? 'nearest' : 'center'
+        )
     }
 
+    let container: HTMLElement | undefined
     let treeView: TreeView<FileTreeNodeValue>
     // Since context is only set once when the component is created
     // we need to dynamically sync any changes to the corresponding
@@ -105,7 +116,7 @@
     onMount(scrollSelectedItemIntoView)
 </script>
 
-<div tabindex="-1">
+<div tabindex="-1" bind:this={container}>
     <TreeView bind:this={treeView} {treeProvider} on:select={event => handleSelect(event.detail)}>
         <svelte:fragment let:entry let:expanded>
             {@const isRoot = entry === treeRoot}


### PR DESCRIPTION
At the moment the selected entry is scrolled to the top or bottom of the sidebar, where it is not always that visible.
This commit changes the behavior so that it it's scrolled to the center when the selected entry changes 'indirectly' (e.g. going back and forth via browser history buttons).


## Test plan

- Selected a new entry via mouse and keyboard -> sidebar doesn't move
- Scroll selected entry out of view, selected a new entry, press back button -> selected entry is centered