### PR TITLE
fix: Correctly filter uploads with commit and path existence checks

### DIFF
--- a/internal/codeintel/codenav/BUILD.bazel
+++ b/internal/codeintel/codenav/BUILD.bazel
@@ -49,6 +49,7 @@ go_test(
     srcs = [
         "gittree_translator_test.go",
         "mocks_test.go",
+        "service_closest_uploads_test.go",
         "service_definitions_test.go",
         "service_diagnostics_test.go",
         "service_hover_test.go",
@@ -67,6 +68,7 @@ go_test(
         "//internal/codeintel/codenav/internal/lsifstore",
         "//internal/codeintel/codenav/shared",
         "//internal/codeintel/uploads/shared",
+        "//internal/collections",
         "//internal/database/dbmocks",
         "//internal/gitserver",
         "//internal/gitserver/gitdomain",
@@ -76,6 +78,7 @@ go_test(
         "@com_github_google_go_cmp//cmp",
         "@com_github_sourcegraph_go_diff//diff",
         "@com_github_sourcegraph_scip//bindings/go/scip",
+        "@com_github_stretchr_testify//require",
     ],
 )
 

--- a/internal/codeintel/codenav/service.go
+++ b/internal/codeintel/codenav/service.go
@@ -671,58 +671,34 @@ func (s *Service) GetClosestCompletedUploadsForBlob(ctx context.Context, opts up
 		return nil, err
 	}
 
-	uploadCandidates := copyUploads(candidates)
-	// Disjoint: {uploadCandidates}, {candidates}
-	trace.AddEvent("TODO Domain Owner",
+	trace.AddEvent("InferClosestUploads",
 		attribute.Int("numCandidates", len(candidates)),
-		attribute.String("candidates", uploadIDsToString(uploadCandidates)))
+		attribute.String("candidates", uploadIDsToString(candidates)))
 
 	commitChecker := NewCommitCache(s.repoStore, s.gitserver)
 	commitChecker.SetResolvableCommit(opts.RepositoryID, opts.Commit)
 
-	candidatesWithCommits, err := filterUploadsWithCommits(ctx, commitChecker, uploadCandidates)
-	// Disjoint: {uploadCandidates, candidatesWithCommits}, {candidates}
+	candidatesWithExistingCommits, err := filterUploadsWithCommits(ctx, commitChecker, candidates)
 	if err != nil {
 		return nil, err
 	}
-	trace.AddEvent("TODO Domain Owner",
-		attribute.Int("numCandidatesWithCommits", len(candidatesWithCommits)),
-		attribute.String("candidatesWithCommits", uploadIDsToString(candidatesWithCommits)))
+	trace.AddEvent("filterUploadsWithCommits",
+		attribute.Int("numCandidatesWithExistingCommits", len(candidatesWithExistingCommits)),
+		attribute.String("candidatesWithExistingCommits", uploadIDsToString(candidatesWithExistingCommits)))
 
-	// Filter in-place
-	filtered := candidatesWithCommits[:0]
-	// Disjoint: {uploadCandidates, candidatesWithCommits, filtered}, {candidates}
-
-	for i := range candidatesWithCommits {
-		switch opts.RootToPathMatching {
-		case uploadsshared.RootMustEnclosePath:
-			// Assumption: There is a 1:1 correspondence between candidates[i] and candidatesWithCommits[i]
-			// (since we're looping over candidatesWithCommits), but in general, the latter slice will
-			// be shorter in case some commits have been deleted by force-pushing
-			// TODO - this breaks if the file was renamed in git diff
-			pathExists, err := s.lsifstore.GetPathExists(ctx, candidates[i].ID, strings.TrimPrefix(opts.Path, candidates[i].Root))
-			if err != nil {
-				return nil, errors.Wrap(err, "lsifStore.Exists")
-			}
-			if !pathExists {
-				continue
-			}
-		case uploadsshared.RootEnclosesPathOrPathEnclosesRoot:
-			// TODO(efritz) - ensure there's a valid document path for this condition as well
-		}
-
-		// Relying on aliasing between uploadCandidates and candidatesWithCommits
-		filtered = append(filtered, uploadCandidates[i])
+	candidatesWithExistingCommitsAndPaths, err := filterUploadsWithPaths(ctx, s.lsifstore, opts, candidatesWithExistingCommits)
+	if err != nil {
+		return nil, errors.Wrap(err, "filtering uploads based on paths")
 	}
-	trace.AddEvent("TODO Domain Owner",
-		attribute.Int("numFiltered", len(filtered)),
-		attribute.String("filtered", uploadIDsToString(filtered)))
+	trace.AddEvent("filterUploadsWithPaths",
+		attribute.Int("numFiltered", len(candidatesWithExistingCommitsAndPaths)),
+		attribute.String("filtered", uploadIDsToString(candidatesWithExistingCommitsAndPaths)))
 
-	return filtered, nil
+	return candidatesWithExistingCommitsAndPaths, nil
 }
 
-// filterUploadsWithCommits removes the uploads for commits which are unknown to gitserver from the given
-// slice. The slice is filtered in-place and returned (to update the slice length).
+// filterUploadsWithCommits only keeps the uploads for commits which are known to gitserver.
+// A fresh slice is returned without modifying the original slice.
 func filterUploadsWithCommits(ctx context.Context, commitCache CommitCache, uploads []uploadsshared.CompletedUpload) ([]uploadsshared.CompletedUpload, error) {
 	rcs := make([]RepositoryCommit, 0, len(uploads))
 	for _, upload := range uploads {
@@ -736,13 +712,39 @@ func filterUploadsWithCommits(ctx context.Context, commitCache CommitCache, uplo
 		return nil, err
 	}
 
-	filtered := uploads[:0]
+	filtered := make([]uploadsshared.CompletedUpload, 0, len(uploads))
 	for i, upload := range uploads {
 		if exists[i] {
 			filtered = append(filtered, upload)
 		}
 	}
 
+	return filtered, nil
+}
+
+func filterUploadsWithPaths(
+	ctx context.Context,
+	lsifstore lsifstore.LsifStore,
+	opts uploadsshared.UploadMatchingOptions,
+	candidates []uploadsshared.CompletedUpload,
+) ([]uploadsshared.CompletedUpload, error) {
+	filtered := make([]uploadsshared.CompletedUpload, 0, len(candidates))
+	for _, candidate := range candidates {
+		switch opts.RootToPathMatching {
+		case uploadsshared.RootMustEnclosePath:
+			// TODO - this breaks if the file was renamed in git diff
+			pathExists, err := lsifstore.GetPathExists(ctx, candidate.ID, strings.TrimPrefix(opts.Path, candidate.Root))
+			if err != nil {
+				return nil, errors.Wrap(err, "lsifStore.Exists")
+			}
+			if !pathExists {
+				continue
+			}
+		case uploadsshared.RootEnclosesPathOrPathEnclosesRoot:
+			// TODO(efritz) - ensure there's a valid document path for this condition as well
+		}
+		filtered = append(filtered, candidate)
+	}
 	return filtered, nil
 }
 

--- a/internal/codeintel/codenav/service_closest_uploads_test.go
+++ b/internal/codeintel/codenav/service_closest_uploads_test.go
@@ -41,8 +41,8 @@ func TestGetClosestCompletedUploadsForBlob(t *testing.T) {
 			},
 			lsifStoreAllowedPaths: []idPathPair{{22, "a.c"}},
 			matchingOptions:       shared.UploadMatchingOptions{Commit: "C2", Path: "a.c"},
-			// BUG: has upload for which path check fails
-			expectUploadIDs: []int{23},
+			// bug fix: doesn't have upload for which path check fails
+			expectUploadIDs: []int{},
 		},
 		{
 			closestUploads: []shared.CompletedUpload{
@@ -51,8 +51,8 @@ func TestGetClosestCompletedUploadsForBlob(t *testing.T) {
 			},
 			lsifStoreAllowedPaths: []idPathPair{{23, "a.c"}},
 			matchingOptions:       shared.UploadMatchingOptions{Commit: "C2", Path: "a.c"},
-			// BUG: is missing upload for which path check should succeed
-			expectUploadIDs: []int{},
+			// bug fix: has upload for which path check succeeds
+			expectUploadIDs: []int{23},
 		},
 	}
 	for _, testCase := range testCases {

--- a/internal/codeintel/codenav/service_closest_uploads_test.go
+++ b/internal/codeintel/codenav/service_closest_uploads_test.go
@@ -1,0 +1,109 @@
+package codenav
+
+import (
+	"context"
+	"github.com/google/go-cmp/cmp"
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/codeintel/uploads/shared"
+	"github.com/sourcegraph/sourcegraph/internal/collections"
+	"github.com/sourcegraph/sourcegraph/internal/gitserver"
+	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
+	"github.com/sourcegraph/sourcegraph/internal/types"
+)
+
+type idPathPair struct {
+	uploadID int
+	path     string
+}
+
+type TestCase struct {
+	closestUploads        []shared.CompletedUpload
+	lsifStoreAllowedPaths []idPathPair
+	matchingOptions       shared.UploadMatchingOptions
+	expectUploadIDs       []int
+}
+
+func TestGetClosestCompletedUploadsForBlob(t *testing.T) {
+	const repoID = 37
+	const missingCommitSHA = "C1"
+	const presentCommitSHA = "C2"
+	testCases := []TestCase{
+		{
+			closestUploads: []shared.CompletedUpload{
+				{ID: 22, Commit: missingCommitSHA, Root: ""},
+				{ID: 23, Commit: presentCommitSHA, Root: "subdir/"},
+			},
+			lsifStoreAllowedPaths: []idPathPair{{22, "a.c"}},
+			matchingOptions:       shared.UploadMatchingOptions{Commit: "C2", Path: "a.c"},
+			// BUG: has upload for which path check fails
+			expectUploadIDs: []int{23},
+		},
+		{
+			closestUploads: []shared.CompletedUpload{
+				{ID: 22, Commit: missingCommitSHA, Root: "subdir/"},
+				{ID: 23, Commit: presentCommitSHA, Root: ""},
+			},
+			lsifStoreAllowedPaths: []idPathPair{{23, "a.c"}},
+			matchingOptions:       shared.UploadMatchingOptions{Commit: "C2", Path: "a.c"},
+			// BUG: is missing upload for which path check should succeed
+			expectUploadIDs: []int{},
+		},
+	}
+	for _, testCase := range testCases {
+		// Set up mocks
+		mockRepoStore := defaultMockRepoStore()
+		mockLsifStore := NewMockLsifStore()
+		mockUploadSvc := NewMockUploadService()
+		mockGitserverClient := gitserver.NewMockClient()
+
+		// Init service
+		svc := newService(observation.TestContextTB(t), mockRepoStore, mockLsifStore, mockUploadSvc, mockGitserverClient)
+
+		closestUploads := slices.Clone(testCase.closestUploads)
+		for i := range closestUploads {
+			closestUploads[i].RepositoryID = repoID
+		}
+
+		mockUploadSvc.InferClosestUploadsFunc.SetDefaultReturn(closestUploads, nil)
+		const testRepoName = "yummy.com/cake"
+		mockRepoStore.GetReposSetByIDsFunc.PushReturn(map[api.RepoID]*types.Repo{
+			repoID: {ID: repoID, Name: testRepoName},
+		}, nil)
+
+		mockGitserverClient.GetCommitFunc.SetDefaultHook(func(_ context.Context, repoName api.RepoName, commitID api.CommitID) (*gitdomain.Commit, error) {
+			// C1 is deliberately missing from gitserver
+			if string(repoName) == testRepoName && commitID == presentCommitSHA {
+				return &gitdomain.Commit{ID: presentCommitSHA}, nil
+			}
+			return nil, &gitdomain.RevisionNotFoundError{}
+		})
+
+		mockLsifStore.GetPathExistsFunc.SetDefaultHook(func(_ context.Context, uploadID int, path string) (bool, error) {
+			return collections.NewSet(testCase.lsifStoreAllowedPaths...).Has(
+				idPathPair{uploadID: uploadID, path: path}), nil
+		})
+
+		testCase.matchingOptions.RepositoryID = repoID
+		testCase.matchingOptions.RootToPathMatching = shared.RootMustEnclosePath
+		filtered, err := svc.GetClosestCompletedUploadsForBlob(context.Background(), testCase.matchingOptions)
+		require.NoError(t, err)
+
+		gotIDs := []int{}
+		for _, upload := range filtered {
+			gotIDs = append(gotIDs, upload.ID)
+		}
+		if diff := cmp.Diff(gotIDs, testCase.expectUploadIDs, cmp.Transformer("Sort", func(in []int) []int {
+			out := append([]int(nil), in...)
+			slices.Sort(out)
+			return out
+		})); diff != "" {
+			t.Errorf("unexpected filtered uploads (-want +got):\n%s", diff)
+		}
+	}
+}


### PR DESCRIPTION
Fixes GRAPH-563

The upload filtering code previously did checks whether:
- The commit corresponding to the upload actually existing on gitserver
- The path of interest had an associated SCIP document in that upload.

However, the second code path incorrectly only handled the case when
the first operation was a no-op. Consequently, it was possible to have
the following:
- Some uploads were filtered out due to the path not existing in the
   wrong upload (not itself)
- Some uploads were not filtered out due to the path existing in the
   wrong upload (not itself)

This PR is broken up into three commits.
- The first commits adds a negative test for the bug (I've triggered CI)
- The second commit simply adds comments related to aliasing to help
  reason with the code and better understand the bug.
- The third commit removes all micro-optimization related to in-place filtering,
  the aliasing comments, fixes the bug, and updates the test.

## Test plan

- Added regression tests