### PR TITLE
Svelte: Calm down shadows and strip down blame header

### DIFF
--- a/client/web-sveltekit/src/lib/CodeMirrorBlob.svelte
+++ b/client/web-sveltekit/src/lib/CodeMirrorBlob.svelte
@@ -43,7 +43,6 @@
             overflow: 'auto',
         },
         '.cm-content': {
-            padding: '0.5rem 0',
             '&:focus-visible': {
                 outline: 'none',
                 boxShadow: 'none',

--- a/client/web-sveltekit/src/lib/CodeMirrorBlob.svelte
+++ b/client/web-sveltekit/src/lib/CodeMirrorBlob.svelte
@@ -43,6 +43,7 @@
             overflow: 'auto',
         },
         '.cm-content': {
+            paddingBottom: '1.5rem',
             '&:focus-visible': {
                 outline: 'none',
                 boxShadow: 'none',

--- a/client/web-sveltekit/src/lib/repo/FileHeader.svelte
+++ b/client/web-sveltekit/src/lib/repo/FileHeader.svelte
@@ -96,7 +96,7 @@
         align-items: baseline;
         padding: 0.25rem 0.5rem;
         background-color: var(--color-bg-1);
-        box-shadow: var(--fileheader-shadow);
+        border-bottom: 1px solid var(--border-color);
         z-index: 1;
         gap: 0.5rem;
     }

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/+layout.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/+layout.svelte
@@ -232,7 +232,7 @@
         padding: 0.5rem;
         padding-bottom: 0;
         box-shadow: var(--sidebar-shadow);
-        z-index: 1;
+        z-index: 2;
     }
 
     .main {

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/+layout.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/+layout.svelte
@@ -265,16 +265,15 @@
         flex-flow: row nowrap;
         justify-content: space-between;
         overflow: hidden;
+        border-top: 1px solid var(--border-color);
         box-shadow: var(--bottom-panel-shadow);
-        background-color: var(--code-bg);
+        background-color: var(--color-bg-1);
         color: var(--text-body);
-        // Applying z-index to the bottom panel allows its shadow to cascade correctly
+        // Applying z-index to the bottom panel allows its shadow to cascade correctly on the code but still say behind the left panel
         z-index: 1;
 
         &.open {
             height: 32vh;
-            box-shadow: var(--bottom-panel-open-shadow);
-            border-top: 1px solid var(--secondary-1);
             // Disable flex layout so that tabs simply fill the available space
             display: block;
 

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/DiffView.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/DiffView.svelte
@@ -68,7 +68,7 @@
         padding: 0.5rem 1rem;
         color: var(--text-muted);
         background-color: var(--code-bg);
-        box-shadow: var(--blame-header-shadow);
+        box-shadow: var(--file-header-shadow);
 
         // Allows for its shadow to cascade over the code panel
         z-index: 1;

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/FileView.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/FileView.svelte
@@ -292,8 +292,9 @@
         display: flex;
         align-items: baseline;
         gap: 1rem;
-        padding: 0.75rem;
+        padding: 0.5rem;
         color: var(--text-muted);
+        box-shadow: var(--fileheader-shadow);
 
         // Allows for its shadow to cascade over the code panel
         z-index: 1;

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/FileView.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/FileView.svelte
@@ -295,8 +295,8 @@
         padding: 0.75rem;
         color: var(--text-muted);
 
-        // Allows for its shadow to cascade over the code panel, file header and other right-hand side page elements (besides the page header)
-        z-index: 2;
+        // Allows for its shadow to cascade over the code panel
+        z-index: 1;
     }
 
     .revision-info {

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/FileView.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/FileView.svelte
@@ -279,7 +279,6 @@
         overflow: auto;
         flex: 1;
         background-color: var(--code-bg);
-        padding: 0.25rem 0;
 
         &.center {
             display: flex;
@@ -293,14 +292,11 @@
         display: flex;
         align-items: baseline;
         gap: 1rem;
-        padding: 0.75rem 1rem;
+        padding: 0.75rem;
         color: var(--text-muted);
-        background-color: var(--code-bg);
-        box-shadow: var(--blame-header-shadow);
 
-        // Allows for its shadow to cascade over the code panel
-        z-index: 1;
-        border-top: 1px solid var(--border-color);
+        // Allows for its shadow to cascade over the code panel, file header and other right-hand side page elements (besides the page header)
+        z-index: 2;
     }
 
     .revision-info {

--- a/client/web-sveltekit/src/routes/svelte-overrides.scss
+++ b/client/web-sveltekit/src/routes/svelte-overrides.scss
@@ -68,10 +68,10 @@ body {
         0 9px 5px 0 rgba(0, 0, 0, 0.12), 0 4px 4px 0 rgba(0, 0, 0, 0.2), 0 1px 2px 0 rgba(0, 0, 0, 0.24);
     --fileheader-shadow: 0 6px 2px 0 rgba(15, 2, 24, 0.01), 0 4px 2px 0 rgba(15, 2, 24, 0.05),
         0 2px 1px 0 rgba(15, 2, 24, 0.16), 0 1px 1px 0 rgba(15, 2, 24, 0.27), 0 0 1px 0 rgba(15, 2, 24, 0.31);
-    --bottom-panel-shadow: 0 -50px 14px 0 rgba(1, 6, 12, 0.01), 0 -32px 13px 0 rgba(1, 6, 12, 0.07),
-        0 -18px 11px 0 rgba(1, 6, 12, 0.24), 0 -8px 8px 0 rgba(1, 6, 12, 0.41), 0 -2px 4px 0 rgba(1, 6, 12, 0.47);
-    --bottom-panel-open-shadow: 0 -32px 12px 0 rgba(0, 0, 0, 0.01), 0 -24px 12px 0 rgba(0, 0, 0, 0.02),
-        0 -16px 8px 0 rgba(0, 0, 0, 0.04), 0 -8px 4px 0 rgba(0, 0, 0, 0.08), 0 -2px 4px 0 rgba(0, 0, 0, 0.24);
+    --bottom-panel-shadow: 0 0 4px 0 rgba(1, 6, 12, 0.01), 0 -8px 8px 0 rgba(1, 6, 12, 0.04),
+        0 -12px 6px 0 rgba(1, 6, 12, 0.08), 0 -4px 8px 0 rgba(1, 6, 12, 0.16), 0 -2px 4px 0 rgba(1, 6, 12, 0.32);
+    --bottom-panel-open-shadow: 0 -32px 12px 0 rgba(0, 0, 0, 0.02), 0 -24px 12px 0 rgba(0, 0, 0, 0.04),
+        0 -16px 8px 0 rgba(0, 0, 0, 0.08), 0 -8px 4px 0 rgba(0, 0, 0, 0.16), 0 -2px 4px 0 rgba(0, 0, 0, 0.32);
     --popover-shadow: 0 174px 49px 0 rgba(0, 0, 0, 0.01), 0 112px 45px 0 rgba(0, 0, 0, 0.05),
         0 63px 38px 0 rgba(0, 0, 0, 0.16), 0 28px 28px 0 rgba(0, 0, 0, 0.27), 0 7px 15px 0 rgba(0, 0, 0, 0.31);
 }

--- a/client/web-sveltekit/src/routes/svelte-overrides.scss
+++ b/client/web-sveltekit/src/routes/svelte-overrides.scss
@@ -43,9 +43,9 @@ body {
         0 6px 4px 0 rgba(0, 0, 0, 0.02), 0 3px 3px 0 rgba(0, 0, 0, 0.03), 0 1px 1px 0 rgba(0, 0, 0, 0.04);
     --bottom-panel-shadow: 0 -19px 5px 0 rgba(1, 6, 12, 0), 0 -12px 5px 0 rgba(1, 6, 12, 0),
         0 -7px 4px 0 rgba(1, 6, 12, 0.01), 0 -3px 3px 0 rgba(1, 6, 12, 0.02), 0 -1px 2px 0 rgba(1, 6, 12, 0.02);
-    --bottom-panel-open-shadow: 0px -50px 14px 0px rgba(1, 6, 12, 0), 0px -32px 13px 0px rgba(1, 6, 12, 0.01),
-        0px -18px 11px 0px rgba(1, 6, 12, 0.02), 0px -8px 8px 0px rgba(1, 6, 12, 0.03),
-        0px -2px 4px 0px rgba(1, 6, 12, 0.04);
+    --bottom-panel-open-shadow: 0 -50px 14px 0 rgba(1, 6, 12, 0), 0 -32px 13px 0 rgba(1, 6, 12, 0.01),
+        0 -18px 11px 0 rgba(1, 6, 12, 0.02), 0 -8px 8px 0 rgba(1, 6, 12, 0.03),
+        0 -2px 4px 0 rgba(1, 6, 12, 0.04);
     --popover-shadow: 0 174px 49px 0 rgba(0, 0, 0, 0), 0 112px 45px 0 rgba(0, 0, 0, 0.01),
         0 63px 38px 0 rgba(0, 0, 0, 0.02), 0 28px 28px 0 rgba(0, 0, 0, 0.03), 0 7px 15px 0 rgba(0, 0, 0, 0.04);
 }
@@ -71,9 +71,9 @@ body {
         0 2px 1px 0 rgba(15, 2, 24, 0.16), 0 1px 1px 0 rgba(15, 2, 24, 0.27), 0 0 1px 0 rgba(15, 2, 24, 0.31);
     --bottom-panel-shadow: 0 -50px 14px 0 rgba(1, 6, 12, 0.01), 0 -32px 13px 0 rgba(1, 6, 12, 0.07),
         0 -18px 11px 0 rgba(1, 6, 12, 0.24), 0 -8px 8px 0 rgba(1, 6, 12, 0.41), 0 -2px 4px 0 rgba(1, 6, 12, 0.47);
-    --bottom-panel-open-shadow: 0px -50px 14px 0px rgba(0, 0, 0, 0), 0px -32px 13px 0px rgba(0, 0, 0, 0.04),
-        0px -18px 11px 0px rgba(0, 0, 0, 0.12), 0px -8px 8px 0px rgba(0, 0, 0, 0.2),
-        0px -2px 4px 0px rgba(0, 0, 0, 0.24);
+    --bottom-panel-open-shadow: 0 -50px 14px 0 rgba(0, 0, 0, 0), 0 -32px 13px 0 rgba(0, 0, 0, 0.04),
+        0 -18px 11px 0 rgba(0, 0, 0, 0.12), 0 -8px 8px 0 rgba(0, 0, 0, 0.2),
+        0 -2px 4px 0 rgba(0, 0, 0, 0.24);
     --popover-shadow: 0 174px 49px 0 rgba(0, 0, 0, 0.01), 0 112px 45px 0 rgba(0, 0, 0, 0.05),
         0 63px 38px 0 rgba(0, 0, 0, 0.16), 0 28px 28px 0 rgba(0, 0, 0, 0.27), 0 7px 15px 0 rgba(0, 0, 0, 0.31);
 }

--- a/client/web-sveltekit/src/routes/svelte-overrides.scss
+++ b/client/web-sveltekit/src/routes/svelte-overrides.scss
@@ -63,16 +63,16 @@ body {
     --code-bg: var(--gray-12);
 
     // Shadows
-    --sidebar-shadow: 0 318px 89px 0 rgba(12, 1, 19, 0.01), 0 203px 81px 0 rgba(12, 1, 19, 0.02),
-        0 114px 69px 0 rgba(12, 1, 19, 0.08), 0 51px 51px 0 rgba(12, 1, 19, 0.16), 0 13px 28px 0 rgba(12, 1, 19, 0.24);
+    --sidebar-shadow: 0 240px 80px 0 rgba(12, 1, 19, 0.01), 0 160px 80px 0 rgba(12, 1, 19, 0.02),
+        0 120px 60px 0 rgba(12, 1, 19, 0.08), 0 48px 24px 0 rgba(12, 1, 19, 0.16), 0 12px 28px 0 rgba(12, 1, 19, 0.24);
     --blame-header-shadow: 0 25px 7px 0 rgba(0, 0, 0, 0), 0 16px 6px 0 rgba(0, 0, 0, 0.04),
         0 9px 5px 0 rgba(0, 0, 0, 0.12), 0 4px 4px 0 rgba(0, 0, 0, 0.2), 0 1px 2px 0 rgba(0, 0, 0, 0.24);
     --fileheader-shadow: 0 6px 2px 0 rgba(15, 2, 24, 0.01), 0 4px 2px 0 rgba(15, 2, 24, 0.05),
         0 2px 1px 0 rgba(15, 2, 24, 0.16), 0 1px 1px 0 rgba(15, 2, 24, 0.27), 0 0 1px 0 rgba(15, 2, 24, 0.31);
     --bottom-panel-shadow: 0 -50px 14px 0 rgba(1, 6, 12, 0.01), 0 -32px 13px 0 rgba(1, 6, 12, 0.07),
         0 -18px 11px 0 rgba(1, 6, 12, 0.24), 0 -8px 8px 0 rgba(1, 6, 12, 0.41), 0 -2px 4px 0 rgba(1, 6, 12, 0.47);
-    --bottom-panel-open-shadow: 0 -50px 14px 0 rgba(0, 0, 0, 0), 0 -32px 13px 0 rgba(0, 0, 0, 0.04),
-        0 -18px 11px 0 rgba(0, 0, 0, 0.12), 0 -8px 8px 0 rgba(0, 0, 0, 0.2),
+    --bottom-panel-open-shadow: 0 -32px 12px 0 rgba(0, 0, 0, 0.01), 0 -24px 12px 0 rgba(0, 0, 0, 0.02),
+        0 -16px 8px 0 rgba(0, 0, 0, 0.04), 0 -8px 4px 0 rgba(0, 0, 0, 0.08),
         0 -2px 4px 0 rgba(0, 0, 0, 0.24);
     --popover-shadow: 0 174px 49px 0 rgba(0, 0, 0, 0.01), 0 112px 45px 0 rgba(0, 0, 0, 0.05),
         0 63px 38px 0 rgba(0, 0, 0, 0.16), 0 28px 28px 0 rgba(0, 0, 0, 0.27), 0 7px 15px 0 rgba(0, 0, 0, 0.31);

--- a/client/web-sveltekit/src/routes/svelte-overrides.scss
+++ b/client/web-sveltekit/src/routes/svelte-overrides.scss
@@ -44,8 +44,7 @@ body {
     --bottom-panel-shadow: 0 -19px 5px 0 rgba(1, 6, 12, 0), 0 -12px 5px 0 rgba(1, 6, 12, 0),
         0 -7px 4px 0 rgba(1, 6, 12, 0.01), 0 -3px 3px 0 rgba(1, 6, 12, 0.02), 0 -1px 2px 0 rgba(1, 6, 12, 0.02);
     --bottom-panel-open-shadow: 0 -50px 14px 0 rgba(1, 6, 12, 0), 0 -32px 13px 0 rgba(1, 6, 12, 0.01),
-        0 -18px 11px 0 rgba(1, 6, 12, 0.02), 0 -8px 8px 0 rgba(1, 6, 12, 0.03),
-        0 -2px 4px 0 rgba(1, 6, 12, 0.04);
+        0 -18px 11px 0 rgba(1, 6, 12, 0.02), 0 -8px 8px 0 rgba(1, 6, 12, 0.03), 0 -2px 4px 0 rgba(1, 6, 12, 0.04);
     --popover-shadow: 0 174px 49px 0 rgba(0, 0, 0, 0), 0 112px 45px 0 rgba(0, 0, 0, 0.01),
         0 63px 38px 0 rgba(0, 0, 0, 0.02), 0 28px 28px 0 rgba(0, 0, 0, 0.03), 0 7px 15px 0 rgba(0, 0, 0, 0.04);
 }
@@ -72,8 +71,7 @@ body {
     --bottom-panel-shadow: 0 -50px 14px 0 rgba(1, 6, 12, 0.01), 0 -32px 13px 0 rgba(1, 6, 12, 0.07),
         0 -18px 11px 0 rgba(1, 6, 12, 0.24), 0 -8px 8px 0 rgba(1, 6, 12, 0.41), 0 -2px 4px 0 rgba(1, 6, 12, 0.47);
     --bottom-panel-open-shadow: 0 -32px 12px 0 rgba(0, 0, 0, 0.01), 0 -24px 12px 0 rgba(0, 0, 0, 0.02),
-        0 -16px 8px 0 rgba(0, 0, 0, 0.04), 0 -8px 4px 0 rgba(0, 0, 0, 0.08),
-        0 -2px 4px 0 rgba(0, 0, 0, 0.24);
+        0 -16px 8px 0 rgba(0, 0, 0, 0.04), 0 -8px 4px 0 rgba(0, 0, 0, 0.08), 0 -2px 4px 0 rgba(0, 0, 0, 0.24);
     --popover-shadow: 0 174px 49px 0 rgba(0, 0, 0, 0.01), 0 112px 45px 0 rgba(0, 0, 0, 0.05),
         0 63px 38px 0 rgba(0, 0, 0, 0.16), 0 28px 28px 0 rgba(0, 0, 0, 0.27), 0 7px 15px 0 rgba(0, 0, 0, 0.31);
 }

--- a/client/web-sveltekit/src/routes/svelte-overrides.scss
+++ b/client/web-sveltekit/src/routes/svelte-overrides.scss
@@ -43,8 +43,9 @@ body {
         0 6px 4px 0 rgba(0, 0, 0, 0.02), 0 3px 3px 0 rgba(0, 0, 0, 0.03), 0 1px 1px 0 rgba(0, 0, 0, 0.04);
     --bottom-panel-shadow: 0 -19px 5px 0 rgba(1, 6, 12, 0), 0 -12px 5px 0 rgba(1, 6, 12, 0),
         0 -7px 4px 0 rgba(1, 6, 12, 0.01), 0 -3px 3px 0 rgba(1, 6, 12, 0.02), 0 -1px 2px 0 rgba(1, 6, 12, 0.02);
-    --bottom-panel-open-shadow: 0 -187px 52px 0 rgba(1, 6, 12, 0), 0 -119px 48px 0 rgba(1, 6, 12, 0.01),
-        0 -67px 40px 0 rgba(1, 6, 12, 0.03), 0 -30px 30px 0 rgba(1, 6, 12, 0.05), 0 -7px 16px 0 rgba(1, 6, 12, 0.06);
+    --bottom-panel-open-shadow: 0px -50px 14px 0px rgba(1, 6, 12, 0), 0px -32px 13px 0px rgba(1, 6, 12, 0.01),
+        0px -18px 11px 0px rgba(1, 6, 12, 0.02), 0px -8px 8px 0px rgba(1, 6, 12, 0.03),
+        0px -2px 4px 0px rgba(1, 6, 12, 0.04);
     --popover-shadow: 0 174px 49px 0 rgba(0, 0, 0, 0), 0 112px 45px 0 rgba(0, 0, 0, 0.01),
         0 63px 38px 0 rgba(0, 0, 0, 0.02), 0 28px 28px 0 rgba(0, 0, 0, 0.03), 0 7px 15px 0 rgba(0, 0, 0, 0.04);
 }
@@ -62,16 +63,17 @@ body {
     --code-bg: var(--gray-12);
 
     // Shadows
-    --sidebar-shadow: 0 318px 89px 0 rgba(12, 1, 19, 0.01), 0 203px 81px 0 rgba(12, 1, 19, 0.05),
-        0 114px 69px 0 rgba(12, 1, 19, 0.16), 0 51px 51px 0 rgba(12, 1, 19, 0.27), 0 13px 28px 0 rgba(12, 1, 19, 0.31);
+    --sidebar-shadow: 0 318px 89px 0 rgba(12, 1, 19, 0.01), 0 203px 81px 0 rgba(12, 1, 19, 0.02),
+        0 114px 69px 0 rgba(12, 1, 19, 0.08), 0 51px 51px 0 rgba(12, 1, 19, 0.16), 0 13px 28px 0 rgba(12, 1, 19, 0.24);
     --blame-header-shadow: 0 25px 7px 0 rgba(0, 0, 0, 0), 0 16px 6px 0 rgba(0, 0, 0, 0.04),
         0 9px 5px 0 rgba(0, 0, 0, 0.12), 0 4px 4px 0 rgba(0, 0, 0, 0.2), 0 1px 2px 0 rgba(0, 0, 0, 0.24);
     --fileheader-shadow: 0 6px 2px 0 rgba(15, 2, 24, 0.01), 0 4px 2px 0 rgba(15, 2, 24, 0.05),
         0 2px 1px 0 rgba(15, 2, 24, 0.16), 0 1px 1px 0 rgba(15, 2, 24, 0.27), 0 0 1px 0 rgba(15, 2, 24, 0.31);
     --bottom-panel-shadow: 0 -50px 14px 0 rgba(1, 6, 12, 0.01), 0 -32px 13px 0 rgba(1, 6, 12, 0.07),
         0 -18px 11px 0 rgba(1, 6, 12, 0.24), 0 -8px 8px 0 rgba(1, 6, 12, 0.41), 0 -2px 4px 0 rgba(1, 6, 12, 0.47);
-    --bottom-panel-open-shadow: 0 -187px 52px 0 rgba(1, 6, 12, 0.01), 0 -119px 48px 0 rgba(1, 6, 12, 0.09),
-        0 -67px 40px 0 rgba(1, 6, 12, 0.32), 0 -30px 30px 0 rgba(1, 6, 12, 0.55), 0 -7px 16px 0 rgba(1, 6, 12, 0.63);
+    --bottom-panel-open-shadow: 0px -50px 14px 0px rgba(0, 0, 0, 0), 0px -32px 13px 0px rgba(0, 0, 0, 0.04),
+        0px -18px 11px 0px rgba(0, 0, 0, 0.12), 0px -8px 8px 0px rgba(0, 0, 0, 0.2),
+        0px -2px 4px 0px rgba(0, 0, 0, 0.24);
     --popover-shadow: 0 174px 49px 0 rgba(0, 0, 0, 0.01), 0 112px 45px 0 rgba(0, 0, 0, 0.05),
         0 63px 38px 0 rgba(0, 0, 0, 0.16), 0 28px 28px 0 rgba(0, 0, 0, 0.27), 0 7px 15px 0 rgba(0, 0, 0, 0.31);
 }


### PR DESCRIPTION
# Context

Shadow fixes and other minor styling adjustments to optimise for smaller screens.

# Before

## Light Mode

![CleanShot 2024-05-03 at 15 23 21@2x](https://github.com/sourcegraph/sourcegraph/assets/5337876/71b2e327-9524-4b82-b03c-bd0144e897a9)

![CleanShot 2024-05-03 at 15 23 37@2x](https://github.com/sourcegraph/sourcegraph/assets/5337876/70d1616d-a2ef-40ad-8555-8bde508028a0)

## Dark Mode

![CleanShot 2024-05-03 at 15 24 13@2x](https://github.com/sourcegraph/sourcegraph/assets/5337876/40196ec8-7bd7-453d-8242-f0070a43f248)

![CleanShot 2024-05-03 at 15 24 00@2x](https://github.com/sourcegraph/sourcegraph/assets/5337876/ec465404-f07f-4035-8f90-fd355ee5fb5d)


# After

## Light Mode

![image](https://github.com/sourcegraph/sourcegraph/assets/5337876/83e3133f-87c6-4511-b96b-37795ba78f3d)

![image](https://github.com/sourcegraph/sourcegraph/assets/5337876/bbf8178b-912b-4d3c-88c3-6713274e3407)

## Dark Mode
![image](https://github.com/sourcegraph/sourcegraph/assets/5337876/5f2b280a-f863-4c2c-8c3c-76d30526a61d)

![image](https://github.com/sourcegraph/sourcegraph/assets/5337876/372e1357-a233-4d81-abef-037e803d1769)

# Test plan
Tested locally for visual changes.