### PR TITLE
svelte: Improve utility of commits page

### DIFF
--- a/client/web-sveltekit/src/lib/Commit.svelte
+++ b/client/web-sveltekit/src/lib/Commit.svelte
@@ -7,7 +7,6 @@
     import Icon from '$lib/Icon.svelte'
     import Timestamp from '$lib/Timestamp.svelte'
     import Tooltip from '$lib/Tooltip.svelte'
-    import Badge from '$lib/wildcard/Badge.svelte'
 
     import type { Commit } from './Commit.gql'
 
@@ -59,11 +58,6 @@
             <pre>{commit.body}</pre>
         {/if}
     </div>
-    {#if !alwaysExpanded}
-        <div class="buttons">
-            <Badge variant="link"><a href={commit.canonicalURL}>{commit.abbreviatedOID}</a></Badge>
-        </div>
-    {/if}
 </div>
 
 <style lang="scss">
@@ -83,11 +77,14 @@
         font-weight: 600;
         flex: 0 1 auto;
         padding-right: 0.5rem;
-        overflow: hidden;
-        white-space: nowrap;
-        text-overflow: ellipsis;
         color: var(--body-color);
         min-width: 0;
+
+        @media (--sm-breakpoint-up) {
+            overflow: hidden;
+            white-space: nowrap;
+            text-overflow: ellipsis;
+        }
     }
 
     .avatar {
@@ -106,7 +103,12 @@
         color: var(--body-color);
         border: 1px solid var(--secondary);
         cursor: pointer;
+
+        @media (--xs-breakpoint-down) {
+            align-self: flex-start;
+        }
     }
+
     pre {
         margin-top: 0.5rem;
         margin-bottom: 1.5rem;
@@ -115,9 +117,5 @@
         max-width: 100%;
         word-wrap: break-word;
         white-space: pre-wrap;
-    }
-
-    .buttons {
-        align-self: center;
     }
 </style>

--- a/client/web-sveltekit/src/lib/search/input/SearchInput.svelte
+++ b/client/web-sveltekit/src/lib/search/input/SearchInput.svelte
@@ -296,8 +296,6 @@
 </form>
 
 <style lang="scss">
-    @use '$lib/breakpoints';
-
     form {
         isolation: isolate;
         width: 100%;

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/-/commits/[...path]/+page.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/-/commits/[...path]/+page.svelte
@@ -4,8 +4,10 @@
     import { navigating } from '$app/stores'
     import Commit from '$lib/Commit.svelte'
     import LoadingSpinner from '$lib/LoadingSpinner.svelte'
+    import { getHumanNameForCodeHost } from '$lib/repo/shared/codehost'
     import Scroller, { type Capture as ScrollerCapture } from '$lib/Scroller.svelte'
-    import { Alert } from '$lib/wildcard'
+    import CodeHostIcon from '$lib/search/CodeHostIcon.svelte'
+    import { Alert, Badge } from '$lib/wildcard'
 
     import type { PageData, Snapshot } from './$types'
     import type { CommitsPage_GitCommitConnection } from './page.gql'
@@ -52,15 +54,40 @@
     <title>Commits - {data.displayRepoName} - Sourcegraph</title>
 </svelte:head>
 
+{#if data.path}
+    <h2>Commits in <code>{data.path}</code></h2>
+{/if}
 <section>
-    {#if data.path}
-        <h2>Commits in <code>{data.path}</code></h2>
-    {/if}
     <Scroller bind:this={scroller} margin={600} on:more={fetchMore}>
         {#if !$commitsQuery.restoring && commits}
-            <ul>
+            <ul class="commits">
                 {#each commits.nodes as commit (commit.canonicalURL)}
-                    <li><Commit {commit} /></li>
+                    <li>
+                        <div class="commit">
+                            <Commit {commit} />
+                        </div>
+                        <ul class="actions">
+                            <li>
+                                <Badge variant="link">
+                                    <a href={commit.canonicalURL} title="View commit">{commit.abbreviatedOID}</a>
+                                </Badge>
+                            </li>
+                            <li><a href="/{data.repoName}@{commit.oid}">Browse files</a></li>
+                            {#each commit.externalURLs as { url, serviceKind }}
+                                <li>
+                                    <a href={url}>
+                                        View on
+                                        {#if serviceKind}
+                                            <CodeHostIcon repository={serviceKind} disableTooltip />
+                                            {getHumanNameForCodeHost(serviceKind)}
+                                        {:else}
+                                            code host
+                                        {/if}
+                                    </a>
+                                </li>
+                            {/each}
+                        </ul>
+                    </li>
                 {:else}
                     <li>
                         <Alert variant="info">No commits found</Alert>
@@ -69,11 +96,11 @@
             </ul>
         {/if}
         {#if $commitsQuery.fetching || $commitsQuery.restoring}
-            <div>
+            <div class="footer">
                 <LoadingSpinner />
             </div>
         {:else if !$commitsQuery.fetching && $commitsQuery.error}
-            <div>
+            <div class="footer">
                 <Alert variant="danger">
                     Unable to fetch commits: {$commitsQuery.error.message}
                 </Alert>
@@ -84,37 +111,74 @@
 
 <style lang="scss">
     section {
-        flex: 1;
-        min-height: 0;
         overflow: hidden;
     }
 
+    ul {
+        margin: 0;
+        padding: 0;
+    }
+
     h2,
-    ul,
-    div {
-        padding: 1rem;
+    ul.commits,
+    .footer {
         max-width: var(--viewport-xl);
+        width: 100%;
         margin: 0 auto;
+        padding: 0.5rem;
+
+        @media (--sm-breakpoint-up) {
+            padding: 1rem;
+        }
     }
 
     ul {
         list-style: none;
-        --avatar-size: 2.5rem;
     }
 
-    li {
-        border-bottom: 1px solid var(--border-color);
-        padding: 0.5rem 0;
+    ul.commits {
+        --avatar-size: 2.5rem;
 
-        &:last-child {
-            border: none;
+        > li {
+            border-bottom: 1px solid var(--border-color);
+            display: flex;
+            padding: 0.5rem 0;
+            gap: 1rem;
+
+            @media (--xs-breakpoint-down) {
+                display: block;
+
+                .actions {
+                    display: flex;
+                    gap: 0.5rem;
+                    margin-top: 0.5rem;
+
+                    li:not(:last-child)::after {
+                        content: '•';
+                        padding-left: 0.5rem;
+                        color: var(--text-muted);
+                    }
+                }
+            }
+
+            .commit {
+                flex: 1;
+                min-width: 0;
+            }
+
+            .actions {
+                flex-shrink: 0;
+            }
+
+            &:last-child {
+                border: none;
+            }
         }
     }
 
-    div {
+    .footer {
         &:not(:first-child) {
             border-top: 1px solid var(--border-color);
         }
-        padding: 0.5rem 0;
     }
 </style>

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/-/commits/[...path]/page.gql
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/-/commits/[...path]/page.gql
@@ -1,5 +1,13 @@
 fragment CommitsPage_GitCommitConnection on GitCommitConnection {
     nodes {
+        canonicalURL
+        oid
+        abbreviatedOID
+        externalURLs {
+            serviceKind
+            url
+        }
+
         ...Commit
     }
     pageInfo {

--- a/client/web-sveltekit/vite.config.ts
+++ b/client/web-sveltekit/vite.config.ts
@@ -37,6 +37,7 @@ export default defineConfig(({ mode }) => {
                         // (without it scss @import paths are always relative to the importing file)
                         join(__dirname, '..'),
                     ],
+                    additionalData: `@use '$lib/breakpoints.scss';`,
                 },
             },
             modules: {


### PR DESCRIPTION
This commit makes several changes to the commits page:

- Adds link to browsing files at this commit
- Adds link to open commit on code host
- Better layout for smaller screens
- Fix issue where loading indicator or error are not visible when the page is loaded with a file path (due to additional header)
- The 'open commit' link was moved from the `Commits` component to the commits page because it was only used there and it was not obvious that is controlled by the `alwaysExpanded` prop.

Additionally the way we load custom breakpoints was changed. Usually those need to be imported into every stylesheet, but the Svelte language server generates an error for `@use '$lib/breakpoints';`  (at least for me), which prevents other warnings like unused classes to be reported (I've tried various ways to resolve this error before, to no avail).
Instead the mixin is now prepended to every component's styles, which means the variables can be used without importing and the language server is happy.


| Type | Screenshot |
|--------|--------|
| Before | ![2024-05-03_16-57](https://github.com/sourcegraph/sourcegraph/assets/179026/c1ba0af1-f364-4c56-bfa8-84234b69267b) |
| After (large) | ![2024-05-03_16-44_1](https://github.com/sourcegraph/sourcegraph/assets/179026/f6642e00-bbd9-4a40-96a9-b882530e5e78) |
| After (medium) | ![2024-05-03_16-44](https://github.com/sourcegraph/sourcegraph/assets/179026/2687a654-3480-4e2f-93f5-9a2bf1519988) |
| After (small) | ![2024-05-03_16-40_1](https://github.com/sourcegraph/sourcegraph/assets/179026/b26db9d7-0543-453d-a7aa-7d06b3179b63) | 

## Test plan

- Commits page is centered with scrollbar at the edge of the viewport
- Text is truncated for small screens and up
- Text is wrapped for tiny screens
- Links all work as expected

