### PR TITLE
svelte: Improve page title updates

### DIFF
--- a/client/web-sveltekit/src/routes/+layout.svelte
+++ b/client/web-sveltekit/src/routes/+layout.svelte
@@ -86,7 +86,6 @@
 </script>
 
 <svelte:head>
-    <title>Sourcegraph</title>
     <meta name="description" content="Code search" />
 </svelte:head>
 

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/+page.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/+page.svelte
@@ -21,6 +21,10 @@
     })
 </script>
 
+<svelte:head>
+    <title>{data.displayRepoName} - Sourcegraph</title>
+</svelte:head>
+
 <h3 class="header">
     <div class="sidebar-button" class:hidden={$sidebarOpen}>
         <SidebarToggleButton />

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/+page.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/+page.svelte
@@ -11,11 +11,6 @@
 
     export let data: PageData
 
-    // The following props control the look and file of the file page when used
-    // in a preview context.
-    export let embedded = false
-    export let disableCodeIntel = embedded
-
     export const snapshot: Snapshot = {
         capture() {
             return {
@@ -43,7 +38,7 @@
 {#if data.type === 'DiffView'}
     <DiffView {data} />
 {:else}
-    <FileView bind:this={fileView} {data} {embedded} {disableCodeIntel}>
+    <FileView bind:this={fileView} {data}>
         <svelte:fragment slot="actions">
             <slot name="actions" />
         </svelte:fragment>

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/FileView.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/FileView.svelte
@@ -32,9 +32,9 @@
     import OpenInCodeHostAction from './OpenInCodeHostAction.svelte'
     import { CodeViewMode, toCodeViewMode } from './util'
 
-    export let embedded: boolean
-    export let disableCodeIntel: boolean
     export let data: Extract<PageData, { type: 'FileView' }>
+    export let embedded: boolean = false
+    export let disableCodeIntel: boolean = false
 
     export function capture(): ScrollSnapshot | null {
         return cmblob?.getScrollSnapshot() ?? null

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/FilePreview.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/FilePreview.svelte
@@ -4,7 +4,7 @@
     import { preloadData } from '$app/navigation'
     import LoadingSpinner from '$lib/LoadingSpinner.svelte'
     import { Alert, Button } from '$lib/wildcard'
-    import FilePage from './-/blob/[...path]/+page.svelte'
+    import FileView from './-/blob/[...path]/FileView.svelte'
     import type { PageData } from './-/blob/[...path]/$types'
     import Icon from '$lib/Icon.svelte'
     import { mdiClose } from '@mdi/js'
@@ -36,14 +36,14 @@
             <br />
             <a {href}>Open file directly</a>
         </Alert>
-    {:else if $filePageData.value}
-        <FilePage data={$filePageData.value} embedded>
+    {:else if $filePageData.value?.type === 'FileView'}
+        <FileView data={$filePageData.value} embedded disableCodeIntel>
             <svelte:fragment slot="actions">
                 <Button variant="icon" aria-label="Close preview" on:click={() => dispatch('close')}>
                     <Icon svgPath={mdiClose} aria-hidden inline />
                 </Button>
             </svelte:fragment>
-        </FilePage>
+        </FileView>
     {/if}
 </div>
 

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/-/commits/[...path]/+page.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/-/commits/[...path]/+page.svelte
@@ -46,10 +46,18 @@
     $: if ($commitsQuery?.data?.repository?.commit?.ancestors) {
         commits = $commitsQuery.data.repository.commit.ancestors
     }
+    $: pageTitle = (() => {
+        const parts = ['Commits']
+        if (data.path) {
+            parts.push(data.path)
+        }
+        parts.push(data.displayRepoName, 'Sourcegraph')
+        return parts.join(' - ')
+    })()
 </script>
 
 <svelte:head>
-    <title>Commits - {data.displayRepoName} - Sourcegraph</title>
+    <title>{pageTitle}</title>
 </svelte:head>
 
 <section>

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/+layout.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/+layout.svelte
@@ -58,10 +58,6 @@
     $: ({ repoName, displayRepoName } = data)
 </script>
 
-<svelte:head>
-    <title>{data.displayRepoName} - Sourcegraph</title>
-</svelte:head>
-
 <GlobalHeaderPortal>
     <nav aria-label="repository">
         <h1><a href="/{repoName}">{displayRepoName}</a></h1>

--- a/client/web-sveltekit/src/routes/search/+page.svelte
+++ b/client/web-sveltekit/src/routes/search/+page.svelte
@@ -28,6 +28,10 @@
     $: queryState.setSettings($settings)
 </script>
 
+<svelte:head>
+    <title>{data.queryFromURL ? `${data.queryFromURL} - ` : ''}Sourcegraph</title>
+</svelte:head>
+
 {#if data.searchStream}
     <SearchResults
         bind:this={searchResults}

--- a/client/web-sveltekit/src/routes/search/SearchResults.svelte
+++ b/client/web-sveltekit/src/routes/search/SearchResults.svelte
@@ -146,10 +146,6 @@
     }
 </script>
 
-<svelte:head>
-    <title>{queryFromURL} - Sourcegraph</title>
-</svelte:head>
-
 <GlobalHeaderPortal>
     <div class="search-header">
         <SearchInput {queryState} size="compat" onSubmit={handleSubmit} />


### PR DESCRIPTION
Closes #62429 

I originally thought we have to create the page title in data loaders and set it only in the root layout, but it appears that setting the title in the layout files is what's potentially problematic (sometimes the page title "reverts" to what's being set by the root layout when navigating to a new page).

Only setting the page title in `+page.svelte` files seems to solve the issue. At least for now I prefer that because it makes setting the page title very explicit and consistent.

I also changed the file preview logic to use the (newly refactored) component instead of the page component. Otherwise opening the preview updates the page title, which is not correct.

 Note: One might think that having the title set in loaders would allow
 us to "compose" the title hierarchically more easily. In theory that's
 true, but having to `await` the parent's data is annoying too.



## Test plan

Manual testing by navigating to different pages and verifying that the title updates.
