### PR TITLE
bug/release: Add nil check for undeprecated oob migrations

### DIFF
--- a/cmd/frontend/graphqlbackend/oobmigrations.go
+++ b/cmd/frontend/graphqlbackend/oobmigrations.go
@@ -67,7 +67,7 @@ func (r *schemaResolver) OutOfBandMigrations(ctx context.Context, args *struct {
 				}
 
 				// If the migration is deprecated before the first version of sourcegraph, don't append it to the list.
-				if oobmigration.CompareVersions(firstVersion, *migration.Deprecated) != oobmigration.VersionOrderAfter {
+				if migration.Deprecated != nil && oobmigration.CompareVersions(firstVersion, *migration.Deprecated) != oobmigration.VersionOrderAfter {
 					filtered = append(filtered, migration)
 					continue
 				}

--- a/cmd/frontend/graphqlbackend/oobmigrations.go
+++ b/cmd/frontend/graphqlbackend/oobmigrations.go
@@ -67,7 +67,7 @@ func (r *schemaResolver) OutOfBandMigrations(ctx context.Context, args *struct {
 				}
 
 				// If the migration is deprecated before the first version of sourcegraph, don't append it to the list.
-				if migration.Deprecated != nil && oobmigration.CompareVersions(firstVersion, *migration.Deprecated) != oobmigration.VersionOrderAfter {
+				if oobmigration.CompareVersions(firstVersion, *migration.Deprecated) != oobmigration.VersionOrderAfter {
 					filtered = append(filtered, migration)
 					continue
 				}

--- a/internal/oobmigration/runner.go
+++ b/internal/oobmigration/runner.go
@@ -202,7 +202,7 @@ func (r *Runner) Start(currentVersion, firstVersion Version) {
 			return false
 		}
 
-		if CompareVersions(firstVersion, *migration.Deprecated) == VersionOrderAfter {
+		if migration.Deprecated != nil && CompareVersions(firstVersion, *migration.Deprecated) == VersionOrderAfter {
 			// instance initialized after migration deprecation
 			return false
 		}


### PR DESCRIPTION
```
[         worker] 2024/05/03 18:51:35 goroutine panic: runtime error: invalid memory address or nil pointer dereference
[         worker] goroutine 948 [running]:
[         worker] runtime/debug.Stack()
[         worker]       /Users/erik/.asdf/installs/golang/1.22.1/go/src/runtime/debug/stack.go:24 +0x64
[         worker] github.com/sourcegraph/sourcegraph/lib/background.Go.func1.1()
[         worker]       /Users/erik/Code/sourcegraph/sourcegraph/lib/background/goroutine.go:19 +0x3c
[         worker] panic({0x105db5660?, 0x108af16d0?})
[         worker]       /Users/erik/.asdf/installs/golang/1.22.1/go/src/runtime/panic.go:770 +0xf0
[         worker] github.com/sourcegraph/sourcegraph/internal/oobmigration.(*Runner).Start.func1({0x17, {0x14002509260, 0xd}, {0x14002c864b0, 0x17}, {0x1400360b140, 0x39}, {0x5, 0x0, 0x0}, ...})
[         worker]       /Users/erik/Code/sourcegraph/sourcegraph/internal/oobmigration/runner.go:205 +0x90
[         worker] github.com/sourcegraph/sourcegraph/internal/oobmigration.(*Runner).startInternal(0x14002e3e300, 0x14003280e38)
[         worker]       /Users/erik/Code/sourcegraph/sourcegraph/internal/oobmigration/runner.go:247 +0x3ac
[         worker] github.com/sourcegraph/sourcegraph/internal/oobmigration.(*Runner).Start(0x14002e3e300, {0x5, 0x4, 0x0}, {0x0, 0x0, 0x1})
[         worker]       /Users/erik/Code/sourcegraph/sourcegraph/internal/oobmigration/runner.go:199 +0xa4
[         worker] github.com/sourcegraph/sourcegraph/cmd/worker/internal/migrations.(*outOfBandMigrationRunnerWrapper).Start(0x14003b94140)
[         worker]       /Users/erik/Code/sourcegraph/sourcegraph/cmd/worker/internal/migrations/init.go:91 +0x80
[         worker] github.com/sourcegraph/sourcegraph/lib/background.startAll.func1()
[         worker]       /Users/erik/Code/sourcegraph/sourcegraph/lib/background/background.go:50 +0xb4
[         worker] github.com/sourcegraph/sourcegraph/lib/background.Go.func1()
[         worker]       /Users/erik/Code/sourcegraph/sourcegraph/lib/background/goroutine.go:24 +0x4c
[         worker] created by github.com/sourcegraph/sourcegraph/lib/background.Go in goroutine 1
[         worker]       /Users/erik/Code/sourcegraph/sourcegraph/lib/background/goroutine.go:16 +0x78
```

Bug fix related to recently merged startup checks of oob migration runner: https://github.com/sourcegraph/sourcegraph/pull/61770

## Test plan
Run locally

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
