### PR TITLE
msp: update msp-ops links

### DIFF
--- a/dev/managedservicesplatform/internal/resource/alertpolicy/alertpolicy.go
+++ b/dev/managedservicesplatform/internal/resource/alertpolicy/alertpolicy.go
@@ -115,10 +115,10 @@ const (
 // DescriptionSuffix points to the service page and environment anchor expected to be
 // generated at https://handbook.sourcegraph.com/departments/engineering/teams/core-services/managed-services/platform/,
 // and should be added as a suffix to all alert descriptions.
-func DescriptionSuffix(serviceID, environmentID string) string {
-	return fmt.Sprintf(`See https://handbook.sourcegraph.com/departments/engineering/managed-services/%s#%s for service and infrastructure access details.
+func DescriptionSuffix(s spec.ServiceSpec, environmentID string) string {
+	return fmt.Sprintf(`See %s -> **%s** for service and infrastructure access details for this environment.
 If you need additional assistance, reach out to #discuss-core-services.`,
-		serviceID, environmentID)
+		s.GetHandbookPageURL(), environmentID)
 }
 
 type NotificationChannels map[SeverityLevel][]monitoringnotificationchannel.MonitoringNotificationChannel
@@ -177,7 +177,7 @@ func New(scope constructs.Construct, id resourceid.ID, config *Config) (*Output,
 	} else {
 		config.Description = fmt.Sprintf("%s\n\n%s",
 			config.Description,
-			DescriptionSuffix(config.Service.ID, config.EnvironmentID))
+			DescriptionSuffix(config.Service, config.EnvironmentID))
 	}
 
 	// Set default

--- a/dev/managedservicesplatform/spec/service.go
+++ b/dev/managedservicesplatform/spec/service.go
@@ -60,16 +60,6 @@ func (s ServiceSpec) GetKind() ServiceKind {
 	return pointers.Deref(s.Kind, ServiceKindService)
 }
 
-// GetGoLink returns the https://www.golinks.io/ page for this service's generated
-// infrastructure docs (sg msp operations generate-handbook-pages). The anchor
-// can be used to link to a specific section.
-func (s ServiceSpec) GetGoLink(anchor string) string {
-	if anchor == "" {
-		return "go/msp-ops/" + s.ID
-	}
-	return fmt.Sprintf("go/msp-ops/%s#%s", s.ID, anchor)
-}
-
 func (s ServiceSpec) Validate() []error {
 	var errs []error
 
@@ -99,6 +89,18 @@ func (s ServiceSpec) Validate() []error {
 	}
 
 	return errs
+}
+
+// GetHandbookPageURL returns the public URL of the Notion page that is populated
+// with operational guidance for this service for embedding in docs or help
+// text.
+//
+// If no NotionPageID is configured, this returns a warning message instead.
+func (s ServiceSpec) GetHandbookPageURL() string {
+	if s.NotionPageID == nil {
+		return fmt.Sprintf("<%s service spec does not have a notionPageID configured for generated docs>", s.ID)
+	}
+	return fmt.Sprintf("https://sourcegraph.notion.site/%s", *s.NotionPageID)
 }
 
 type ServiceProtocol string

--- a/dev/managedservicesplatform/stacks/monitoring/monitoring.go
+++ b/dev/managedservicesplatform/stacks/monitoring/monitoring.go
@@ -355,7 +355,7 @@ func NewStack(stacks *stack.Set, vars Variables) (*CrossStackOutput, error) {
 	locals.Add("service_id", vars.Service.ID, "Service ID")
 	locals.Add("environment_id", vars.EnvironmentID, "Environment ID")
 	locals.Add("service_name", vars.Service.GetName(), "Human-readable service name")
-	locals.Add("alert_description_suffix", alertpolicy.DescriptionSuffix(vars.Service.ID, vars.EnvironmentID),
+	locals.Add("alert_description_suffix", alertpolicy.DescriptionSuffix(vars.Service, vars.EnvironmentID),
 		"Supplemental MSP help text intended to be added to alert descriptions")
 
 	// Group alerts by type for dashboard

--- a/dev/sg/msp/sg_msp.go
+++ b/dev/sg/msp/sg_msp.go
@@ -746,7 +746,7 @@ This command supports completions on services and environments.
 							connectionName,
 							serviceAccountEmail,
 							proxyPort,
-							svc.Service.GetGoLink(env.ID))
+							svc.Service.GetHandbookPageURL())
 						if err != nil {
 							return err
 						}


### PR DESCRIPTION
With https://github.com/sourcegraph/sourcegraph/pull/62325 landed, this updates a few references:

1. Service golinks don't work anymore: CORE-105
3. Alerts docs now point to the service handbook page

## Test plan

CI