### PR TITLE
appliance: symbols: fix PVC name

### DIFF
--- a/internal/appliance/repo_updater.go
+++ b/internal/appliance/repo_updater.go
@@ -59,14 +59,8 @@ func (r *Reconciler) reconcileRepoUpdaterDeployment(ctx context.Context, sg *Sou
 	// TODO: https://github.com/sourcegraph/sourcegraph/issues/62076
 	ctr.Image = "index.docker.io/sourcegraph/repo-updater:5.3.2@sha256:5a414aa030c7e0922700664a43b449ee5f3fafa68834abef93988c5992c747c6"
 
-	ctr.Env = []corev1.EnvVar{
-		container.NewEnvVarSecretKeyRef("REDIS_CACHE_ENDPOINT", "redis-cache", "endpoint"),
-		container.NewEnvVarSecretKeyRef("REDIS_STORE_ENDPOINT", "redis-store", "endpoint"),
-
-		// OTEL_AGENT_HOST must be defined before OTEL_EXPORTER_OTLP_ENDPOINT to substitute the node IP on which the DaemonSet pod instance runs in the latter variable
-		container.NewEnvVarFieldRef("OTEL_AGENT_HOST", "status.hostIP"),
-		{Name: "OTEL_EXPORTER_OTLP_ENDPOINT", Value: "http://$(OTEL_AGENT_HOST):4317"},
-	}
+	ctr.Env = append(ctr.Env, container.EnvVarsRedis()...)
+	ctr.Env = append(ctr.Env, container.EnvVarsOtel()...)
 
 	ctr.Ports = []corev1.ContainerPort{
 		{Name: "http", ContainerPort: 3182},

--- a/internal/appliance/symbols.go
+++ b/internal/appliance/symbols.go
@@ -107,13 +107,14 @@ func (r *Reconciler) reconcileSymbolsStatefulSet(ctx context.Context, sg *Source
 	podTemplate.Template.Spec.Containers = []corev1.Container{ctr}
 	podTemplate.Template.Spec.ServiceAccountName = name
 	podTemplate.Template.Spec.Volumes = []corev1.Volume{
+		{Name: "cache"},
 		pod.NewVolumeEmptyDir("tmp"),
 	}
 
 	sset := statefulset.NewStatefulSet(name, sg.Namespace, sg.Spec.RequestedVersion)
 	sset.Spec.Template = podTemplate.Template
 	sset.Spec.VolumeClaimTemplates = []corev1.PersistentVolumeClaim{
-		pvc.NewPersistentVolumeClaimSpecOnly(storageSize, sg.Spec.StorageClass.Name),
+		pvc.NewPersistentVolumeClaim("cache", sg.Namespace, storageSize, sg.Spec.StorageClass.Name),
 	}
 
 	return reconcileObject(ctx, r, sg.Spec.Symbols, &sset, &appsv1.StatefulSet{}, sg, owner)

--- a/internal/appliance/symbols.go
+++ b/internal/appliance/symbols.go
@@ -60,21 +60,18 @@ func (r *Reconciler) reconcileSymbolsStatefulSet(ctx context.Context, sg *Source
 	// TODO: https://github.com/sourcegraph/sourcegraph/issues/62076
 	ctr.Image = "index.docker.io/sourcegraph/symbols:5.3.2@sha256:dd7f923bdbd5dbd231b749a7483110d40d59159084477b9fff84afaf58aad98e"
 
-	ctr.Env = []corev1.EnvVar{
-		container.NewEnvVarSecretKeyRef("REDIS_CACHE_ENDPOINT", "redis-cache", "endpoint"),
-		container.NewEnvVarSecretKeyRef("REDIS_STORE_ENDPOINT", "redis-store", "endpoint"),
-
-		{Name: "SYMBOLS_CACHE_SIZE_MB", Value: fmt.Sprintf("%d", cacheSizeMB)},
+	ctr.Env = container.EnvVarsRedis()
+	ctr.Env = append(
+		ctr.Env,
+		corev1.EnvVar{Name: "SYMBOLS_CACHE_SIZE_MB", Value: fmt.Sprintf("%d", cacheSizeMB)},
 
 		container.NewEnvVarFieldRef("POD_NAME", "metadata.name"),
-		{Name: "SYMBOLS_CACHE_DIR", Value: "/mnt/cache/$(POD_NAME)"},
+		corev1.EnvVar{Name: "SYMBOLS_CACHE_DIR", Value: "/mnt/cache/$(POD_NAME)"},
 
-		{Name: "TMPDIR", Value: "/mnt/tmp"},
+		corev1.EnvVar{Name: "TMPDIR", Value: "/mnt/tmp"},
+	)
+	ctr.Env = append(ctr.Env, container.EnvVarsOtel()...)
 
-		// OTEL_AGENT_HOST must be defined before OTEL_EXPORTER_OTLP_ENDPOINT to substitute the node IP on which the DaemonSet pod instance runs in the latter variable
-		container.NewEnvVarFieldRef("OTEL_AGENT_HOST", "status.hostIP"),
-		{Name: "OTEL_EXPORTER_OTLP_ENDPOINT", Value: "http://$(OTEL_AGENT_HOST):4317"},
-	}
 	ctr.Ports = []corev1.ContainerPort{
 		{Name: "http", ContainerPort: 3184},
 		{Name: "debug", ContainerPort: 6060},

--- a/internal/appliance/testdata/golden-fixtures/symbols-default.yaml
+++ b/internal/appliance/testdata/golden-fixtures/symbols-default.yaml
@@ -129,6 +129,8 @@ resources:
         terminationGracePeriodSeconds: 30
         volumes:
         - emptyDir: {}
+          name: cache
+        - emptyDir: {}
           name: tmp
     updateStrategy:
       type: RollingUpdate
@@ -137,6 +139,9 @@ resources:
       kind: PersistentVolumeClaim
       metadata:
         creationTimestamp: null
+        labels:
+          deploy: sourcegraph
+        name: cache
         namespace: NORMALIZED_FOR_TESTING
       spec:
         accessModes:

--- a/internal/appliance/testdata/golden-fixtures/symbols-with-storage.yaml
+++ b/internal/appliance/testdata/golden-fixtures/symbols-with-storage.yaml
@@ -129,6 +129,8 @@ resources:
         terminationGracePeriodSeconds: 30
         volumes:
         - emptyDir: {}
+          name: cache
+        - emptyDir: {}
           name: tmp
     updateStrategy:
       type: RollingUpdate
@@ -137,6 +139,9 @@ resources:
       kind: PersistentVolumeClaim
       metadata:
         creationTimestamp: null
+        labels:
+          deploy: sourcegraph
+        name: cache
         namespace: NORMALIZED_FOR_TESTING
       spec:
         accessModes:

--- a/internal/k8s/resource/container/container.go
+++ b/internal/k8s/resource/container/container.go
@@ -91,42 +91,15 @@ func NewEnvVarFieldRef(name, fieldPath string) corev1.EnvVar {
 
 func EnvVarsRedis() []corev1.EnvVar {
 	return []corev1.EnvVar{
-		{
-			Name: "REDIS_CACHE_ENDPOINT",
-			ValueFrom: &corev1.EnvVarSource{
-				SecretKeyRef: &corev1.SecretKeySelector{
-					LocalObjectReference: corev1.LocalObjectReference{
-						Name: "redis-cache",
-					},
-					Key: "endpoint",
-				},
-			},
-		}, {
-			Name: "REDIS_STORE_ENDPOINT",
-			ValueFrom: &corev1.EnvVarSource{
-				SecretKeyRef: &corev1.SecretKeySelector{
-					LocalObjectReference: corev1.LocalObjectReference{
-						Name: "redis-store",
-					},
-					Key: "endpoint",
-				},
-			},
-		},
+		NewEnvVarSecretKeyRef("REDIS_CACHE_ENDPOINT", "redis-cache", "endpoint"),
+		NewEnvVarSecretKeyRef("REDIS_STORE_ENDPOINT", "redis-store", "endpoint"),
 	}
 }
 
 func EnvVarsOtel() []corev1.EnvVar {
 	return []corev1.EnvVar{
-		{
-			Name: "OTEL_AGENT_HOST",
-			ValueFrom: &corev1.EnvVarSource{
-				FieldRef: &corev1.ObjectFieldSelector{
-					FieldPath: "status.hostIP",
-				},
-			},
-		}, {
-			Name:  "OTEL_EXPORTER_OTLP_ENDPOINT",
-			Value: "http://$(OTEL_AGENT_HOST):4317",
-		},
+		// OTEL_AGENT_HOST must be defined before OTEL_EXPORTER_OTLP_ENDPOINT to substitute the node IP on which the DaemonSet pod instance runs in the latter variable
+		NewEnvVarFieldRef("OTEL_AGENT_HOST", "status.hostIP"),
+		{Name: "OTEL_EXPORTER_OTLP_ENDPOINT", Value: "http://$(OTEL_AGENT_HOST):4317"},
 	}
 }

--- a/internal/k8s/resource/pvc/pvc.go
+++ b/internal/k8s/resource/pvc/pvc.go
@@ -8,20 +8,14 @@ import (
 
 // NewPersistentVolumeClaim creates a new k8s PVC with some default values set.
 func NewPersistentVolumeClaim(name, namespace string, storage resource.Quantity, storageClassName string) corev1.PersistentVolumeClaim {
-	pvc := NewPersistentVolumeClaimSpecOnly(storage, storageClassName)
-	pvc.ObjectMeta = metav1.ObjectMeta{
-		Name:      name,
-		Namespace: namespace,
-		Labels: map[string]string{
-			"deploy": "sourcegraph",
-		},
-	}
-	return pvc
-}
-
-// Useful for statefulsets, that do not require metadata
-func NewPersistentVolumeClaimSpecOnly(storage resource.Quantity, storageClassName string) corev1.PersistentVolumeClaim {
 	return corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				"deploy": "sourcegraph",
+			},
+		},
 		Spec: corev1.PersistentVolumeClaimSpec{
 			AccessModes: []corev1.PersistentVolumeAccessMode{
 				corev1.ReadWriteOnce,


### PR DESCRIPTION
**appliance: use extracted redis/otel env vars everywhere**




**appliance: symbols: fix PVC name**

We need to set volumeClaimTemplates.metadata.name, and create a volume
mount with matching name, in order for k8s to actually mount the PVC at
the container's volumeMount.



## Test plan

Golden tests included.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
