### PR TITLE
appliance: container image config

### DIFF
--- a/internal/appliance/blobstore.go
+++ b/internal/appliance/blobstore.go
@@ -9,6 +9,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/sourcegraph/sourcegraph/internal/appliance/config"
 	"github.com/sourcegraph/sourcegraph/internal/k8s/resource/container"
 	"github.com/sourcegraph/sourcegraph/internal/k8s/resource/deployment"
 	"github.com/sourcegraph/sourcegraph/internal/k8s/resource/pod"
@@ -95,19 +96,19 @@ func buildBlobstoreDeployment(sg *Sourcegraph) appsv1.Deployment {
 		},
 	}
 
-	defaultContainer := container.NewContainer(name, sg.Spec.Blobstore, corev1.ResourceRequirements{
-		Requests: corev1.ResourceList{
-			corev1.ResourceCPU:    resource.MustParse("1"),
-			corev1.ResourceMemory: resource.MustParse("500M"),
-		},
-		Limits: corev1.ResourceList{
-			corev1.ResourceCPU:    resource.MustParse("1"),
-			corev1.ResourceMemory: resource.MustParse("500M"),
+	defaultContainer := container.NewContainer(name, sg.Spec.Blobstore, config.ContainerConfig{
+		Image: getDefaultImage(sg, name),
+		Resources: &corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("1"),
+				corev1.ResourceMemory: resource.MustParse("500M"),
+			},
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("1"),
+				corev1.ResourceMemory: resource.MustParse("500M"),
+			},
 		},
 	})
-
-	// TODO: https://github.com/sourcegraph/sourcegraph/issues/62076
-	defaultContainer.Image = "index.docker.io/sourcegraph/blobstore:5.3.2@sha256:d625be1eefe61cc42f94498e3c588bf212c4159c8b20c519db84eae4ff715efa"
 
 	defaultContainer.Ports = containerPorts
 	defaultContainer.VolumeMounts = containerVolumeMounts

--- a/internal/appliance/config/config.go
+++ b/internal/appliance/config/config.go
@@ -23,7 +23,16 @@ type StandardConfig struct {
 }
 
 type ContainerConfig struct {
-	Resources corev1.ResourceRequirements `json:"resources,omitempty"`
+	Image string `json:"image,omitempty"`
+
+	// Set BestEffortQOS=true to configure a container without resource limits
+	// or requests. This can be useful for local development.
+	// We need this flag to disambiguate between Resources being null because
+	// the admin is not overriding defaults, or because they do not want to
+	// configure resources.
+	// https://kubernetes.io/docs/tasks/configure-pod-container/quality-service-pod/
+	BestEffortQOS bool                         `json:"bestEffortQOS,omitempty"`
+	Resources     *corev1.ResourceRequirements `json:"resources,omitempty"`
 }
 
 // Config that applies to all Pod templates produced by a Service. If this needs

--- a/internal/appliance/config/config.go
+++ b/internal/appliance/config/config.go
@@ -4,8 +4,8 @@ import corev1 "k8s.io/api/core/v1"
 
 type StandardComponent interface {
 	Disableable
+	GetContainerConfig() map[string]ContainerConfig
 	GetPodTemplateConfig() PodTemplateConfig
-	GetResources() map[string]corev1.ResourceRequirements
 	GetServiceAccountAnnotations() map[string]string
 	GetPrometheusPort() *int
 }
@@ -15,11 +15,15 @@ type Disableable interface {
 }
 
 type StandardConfig struct {
-	Disabled                  bool                                   `json:"disabled,omitempty"`
-	PodTemplateConfig         PodTemplateConfig                      `json:"podTemplateConfig,omitempty"`
-	PrometheusPort            *int                                   `json:"prometheusPort,omitempty"`
-	Resources                 map[string]corev1.ResourceRequirements `json:"resources,omitempty"`
-	ServiceAccountAnnotations map[string]string                      `json:"serviceAccountAnnotations,omitempty"`
+	Disabled                  bool                       `json:"disabled,omitempty"`
+	ContainerConfig           map[string]ContainerConfig `json:"containerConfig,omitempty"`
+	PodTemplateConfig         PodTemplateConfig          `json:"podTemplateConfig,omitempty"`
+	PrometheusPort            *int                       `json:"prometheusPort,omitempty"`
+	ServiceAccountAnnotations map[string]string          `json:"serviceAccountAnnotations,omitempty"`
+}
+
+type ContainerConfig struct {
+	Resources corev1.ResourceRequirements `json:"resources,omitempty"`
 }
 
 // Config that applies to all Pod templates produced by a Service. If this needs
@@ -31,10 +35,10 @@ type PodTemplateConfig struct {
 	Tolerations      []corev1.Toleration           `json:"tolerations,omitempty"`
 }
 
-func (c StandardConfig) IsDisabled() bool                                     { return c.Disabled }
-func (c StandardConfig) GetPodTemplateConfig() PodTemplateConfig              { return c.PodTemplateConfig }
-func (c StandardConfig) GetPrometheusPort() *int                              { return c.PrometheusPort }
-func (c StandardConfig) GetResources() map[string]corev1.ResourceRequirements { return c.Resources }
+func (c StandardConfig) IsDisabled() bool                               { return c.Disabled }
+func (c StandardConfig) GetContainerConfig() map[string]ContainerConfig { return c.ContainerConfig }
+func (c StandardConfig) GetPodTemplateConfig() PodTemplateConfig        { return c.PodTemplateConfig }
+func (c StandardConfig) GetPrometheusPort() *int                        { return c.PrometheusPort }
 func (c StandardConfig) GetServiceAccountAnnotations() map[string]string {
 	return c.ServiceAccountAnnotations
 }

--- a/internal/appliance/defaults.go
+++ b/internal/appliance/defaults.go
@@ -1,6 +1,8 @@
 package appliance
 
 import (
+	"fmt"
+
 	"k8s.io/utils/ptr"
 
 	"github.com/sourcegraph/sourcegraph/internal/appliance/config"
@@ -15,6 +17,10 @@ import (
 func newDefaultConfig() Sourcegraph {
 	return Sourcegraph{
 		Spec: SourcegraphSpec{
+			// Global config
+			ImageRepository: "index.docker.io/sourcegraph",
+
+			// Service-specific config
 			Blobstore: BlobstoreSpec{
 				StorageSize: "100Gi",
 			},
@@ -42,4 +48,20 @@ func newDefaultConfig() Sourcegraph {
 			},
 		},
 	}
+}
+
+// Images
+
+var imagesUpToVersion_5_3_9104 = map[string]string{
+	"blobstore":    "blobstore:5.3.2@sha256:d625be1eefe61cc42f94498e3c588bf212c4159c8b20c519db84eae4ff715efa",
+	"gitserver":    "gitserver:5.3.2@sha256:6c6042cf3e5f3f16de9b82e3d4ab1647f8bb924cd315245bd7a3162f5489e8c4",
+	"repo-updater": "repo-updater:5.3.2@sha256:5a414aa030c7e0922700664a43b449ee5f3fafa68834abef93988c5992c747c6",
+	"symbols":      "symbols:5.3.2@sha256:dd7f923bdbd5dbd231b749a7483110d40d59159084477b9fff84afaf58aad98e",
+}
+
+func getDefaultImage(sg *Sourcegraph, component string) string {
+	// We can imagine doing logic on Sourcegraph.RequestedVersion here, to
+	// select the correct default image for a supported version.
+	tag := imagesUpToVersion_5_3_9104[component]
+	return fmt.Sprintf("%s/%s", sg.Spec.ImageRepository, tag)
 }

--- a/internal/appliance/defaults.go
+++ b/internal/appliance/defaults.go
@@ -6,6 +6,7 @@ import (
 	"k8s.io/utils/ptr"
 
 	"github.com/sourcegraph/sourcegraph/internal/appliance/config"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 // Default config.
@@ -52,16 +53,26 @@ func newDefaultConfig() Sourcegraph {
 
 // Images
 
-var imagesUpToVersion_5_3_9104 = map[string]string{
+// Map of version to map of service to image tag
+var defaultImages = map[string]map[string]string{
+	"5.3.9104": defaultImagesForVersion_5_3_9104,
+}
+
+var defaultImagesForVersion_5_3_9104 = map[string]string{
 	"blobstore":    "blobstore:5.3.2@sha256:d625be1eefe61cc42f94498e3c588bf212c4159c8b20c519db84eae4ff715efa",
 	"gitserver":    "gitserver:5.3.2@sha256:6c6042cf3e5f3f16de9b82e3d4ab1647f8bb924cd315245bd7a3162f5489e8c4",
 	"repo-updater": "repo-updater:5.3.2@sha256:5a414aa030c7e0922700664a43b449ee5f3fafa68834abef93988c5992c747c6",
 	"symbols":      "symbols:5.3.2@sha256:dd7f923bdbd5dbd231b749a7483110d40d59159084477b9fff84afaf58aad98e",
 }
 
-func getDefaultImage(sg *Sourcegraph, component string) string {
-	// We can imagine doing logic on Sourcegraph.RequestedVersion here, to
-	// select the correct default image for a supported version.
-	tag := imagesUpToVersion_5_3_9104[component]
-	return fmt.Sprintf("%s/%s", sg.Spec.ImageRepository, tag)
+func getDefaultImage(sg *Sourcegraph, component string) (string, error) {
+	images, ok := defaultImages[sg.Spec.RequestedVersion]
+	if !ok {
+		return "", errors.Newf("no default images found for version %s", sg.Spec.RequestedVersion)
+	}
+	image, ok := images[component]
+	if !ok {
+		return "", errors.Newf("no default image found for service %s", component)
+	}
+	return fmt.Sprintf("%s/%s", sg.Spec.ImageRepository, image), nil
 }

--- a/internal/appliance/gitserver.go
+++ b/internal/appliance/gitserver.go
@@ -38,8 +38,12 @@ func (r *Reconciler) reconcileGitServerStatefulSet(ctx context.Context, sg *Sour
 	cfg := sg.Spec.GitServer
 	name := "gitserver"
 
+	defaultImage, err := getDefaultImage(sg, name)
+	if err != nil {
+		return err
+	}
 	ctr := container.NewContainer(name, cfg, config.ContainerConfig{
-		Image: getDefaultImage(sg, name),
+		Image: defaultImage,
 		Resources: &corev1.ResourceRequirements{
 			Requests: corev1.ResourceList{
 				corev1.ResourceCPU:    resource.MustParse("4"),

--- a/internal/appliance/repo_updater.go
+++ b/internal/appliance/repo_updater.go
@@ -46,8 +46,12 @@ func (r *Reconciler) reconcileRepoUpdaterDeployment(ctx context.Context, sg *Sou
 	cfg := sg.Spec.RepoUpdater
 	name := "repo-updater"
 
+	defaultImage, err := getDefaultImage(sg, name)
+	if err != nil {
+		return err
+	}
 	ctr := container.NewContainer(name, cfg, config.ContainerConfig{
-		Image: getDefaultImage(sg, name),
+		Image: defaultImage,
 		Resources: &corev1.ResourceRequirements{
 			Requests: corev1.ResourceList{
 				corev1.ResourceCPU:    resource.MustParse("1"),

--- a/internal/appliance/repo_updater.go
+++ b/internal/appliance/repo_updater.go
@@ -9,6 +9,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/sourcegraph/sourcegraph/internal/appliance/config"
 	"github.com/sourcegraph/sourcegraph/internal/k8s/resource/container"
 	"github.com/sourcegraph/sourcegraph/internal/k8s/resource/deployment"
 	"github.com/sourcegraph/sourcegraph/internal/k8s/resource/pod"
@@ -45,19 +46,19 @@ func (r *Reconciler) reconcileRepoUpdaterDeployment(ctx context.Context, sg *Sou
 	cfg := sg.Spec.RepoUpdater
 	name := "repo-updater"
 
-	ctr := container.NewContainer(name, cfg, corev1.ResourceRequirements{
-		Requests: corev1.ResourceList{
-			corev1.ResourceCPU:    resource.MustParse("1"),
-			corev1.ResourceMemory: resource.MustParse("500Mi"),
-		},
-		Limits: corev1.ResourceList{
-			corev1.ResourceCPU:    resource.MustParse("1"),
-			corev1.ResourceMemory: resource.MustParse("2Gi"),
+	ctr := container.NewContainer(name, cfg, config.ContainerConfig{
+		Image: getDefaultImage(sg, name),
+		Resources: &corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("1"),
+				corev1.ResourceMemory: resource.MustParse("500Mi"),
+			},
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("1"),
+				corev1.ResourceMemory: resource.MustParse("2Gi"),
+			},
 		},
 	})
-
-	// TODO: https://github.com/sourcegraph/sourcegraph/issues/62076
-	ctr.Image = "index.docker.io/sourcegraph/repo-updater:5.3.2@sha256:5a414aa030c7e0922700664a43b449ee5f3fafa68834abef93988c5992c747c6"
 
 	ctr.Env = append(ctr.Env, container.EnvVarsRedis()...)
 	ctr.Env = append(ctr.Env, container.EnvVarsOtel()...)

--- a/internal/appliance/spec.go
+++ b/internal/appliance/spec.go
@@ -346,6 +346,9 @@ type SourcegraphSpec struct {
 	// RequestedVersion is the user-requested version of Sourcegraph to deploy.
 	RequestedVersion string `json:"requestedVersion"`
 
+	// ImageRepository overrides the default image repository.
+	ImageRepository string `json:"imageRepository"`
+
 	// ManagementState defines if Sourcegraph should be managed by the operator or not.
 	// Default is managed.
 	ManagementState ManagementStateType `json:"managementState,omitempty"`

--- a/internal/appliance/standard_config_test.go
+++ b/internal/appliance/standard_config_test.go
@@ -13,6 +13,7 @@ func (suite *ApplianceTestSuite) TestStandardFeatures() {
 		{name: "standard/repo-updater-with-resources"},
 		{name: "standard/repo-updater-with-no-resources"},
 		{name: "standard/repo-updater-with-sa-annotations"},
+		{name: "standard/symbols-with-custom-image"},
 	} {
 		suite.Run(tc.name, func() {
 			namespace := suite.createConfigMap(tc.name)

--- a/internal/appliance/symbols.go
+++ b/internal/appliance/symbols.go
@@ -38,8 +38,12 @@ func (r *Reconciler) reconcileSymbolsStatefulSet(ctx context.Context, sg *Source
 	name := "symbols"
 	cfg := sg.Spec.Symbols
 
+	defaultImage, err := getDefaultImage(sg, name)
+	if err != nil {
+		return err
+	}
 	ctr := container.NewContainer(name, cfg, config.ContainerConfig{
-		Image: getDefaultImage(sg, name),
+		Image: defaultImage,
 		Resources: &corev1.ResourceRequirements{
 			Requests: corev1.ResourceList{
 				corev1.ResourceCPU:    resource.MustParse("500m"),

--- a/internal/appliance/testdata/golden-fixtures/standard/repo-updater-with-no-resources.yaml
+++ b/internal/appliance/testdata/golden-fixtures/standard/repo-updater-with-no-resources.yaml
@@ -3,7 +3,7 @@ resources:
   kind: Deployment
   metadata:
     annotations:
-      appliance.sourcegraph.com/configHash: e9ee35891c75d060e7afde1a884f35f00a90ff058b21129b792a934de7164115
+      appliance.sourcegraph.com/configHash: 0cd3f7abdc156f0341a6e3daa82c5c0270eb565a8e32caf7929d770f9e523032
     creationTimestamp: "2024-04-19T00:00:00Z"
     generation: 1
     labels:
@@ -151,8 +151,9 @@ resources:
           disabled: true
 
         repoUpdater:
-          resources:
-            repo-updater: null
+          containerConfig:
+            repo-updater:
+              resources: null
 
         searcher:
           disabled: true
@@ -179,7 +180,7 @@ resources:
   kind: ServiceAccount
   metadata:
     annotations:
-      appliance.sourcegraph.com/configHash: e9ee35891c75d060e7afde1a884f35f00a90ff058b21129b792a934de7164115
+      appliance.sourcegraph.com/configHash: 0cd3f7abdc156f0341a6e3daa82c5c0270eb565a8e32caf7929d770f9e523032
     creationTimestamp: "2024-04-19T00:00:00Z"
     labels:
       deploy: sourcegraph
@@ -191,7 +192,7 @@ resources:
   kind: Service
   metadata:
     annotations:
-      appliance.sourcegraph.com/configHash: e9ee35891c75d060e7afde1a884f35f00a90ff058b21129b792a934de7164115
+      appliance.sourcegraph.com/configHash: 0cd3f7abdc156f0341a6e3daa82c5c0270eb565a8e32caf7929d770f9e523032
       prometheus.io/port: "6060"
       sourcegraph.prometheus/scrape: "true"
     creationTimestamp: "2024-04-19T00:00:00Z"

--- a/internal/appliance/testdata/golden-fixtures/standard/repo-updater-with-resources.yaml
+++ b/internal/appliance/testdata/golden-fixtures/standard/repo-updater-with-resources.yaml
@@ -3,7 +3,7 @@ resources:
   kind: Deployment
   metadata:
     annotations:
-      appliance.sourcegraph.com/configHash: 5e6989e9456ca355fe6cbe036e73384b350ce5a5cd28d28265259642f78aefe0
+      appliance.sourcegraph.com/configHash: ef7e879dd6941a6e3549b796700a532ce0069f41b2a7ecd3dc6dfcce79811954
     creationTimestamp: "2024-04-19T00:00:00Z"
     generation: 1
     labels:
@@ -157,14 +157,15 @@ resources:
           disabled: true
 
         repoUpdater:
-          resources:
+          containerConfig:
             repo-updater:
-              requests:
-                cpu: 1500m
-                memory: 2Gi
-              limits:
-                cpu: "4"
-                memory: 4Gi
+              resources:
+                requests:
+                  cpu: 1500m
+                  memory: 2Gi
+                limits:
+                  cpu: "4"
+                  memory: 4Gi
 
         searcher:
           disabled: true
@@ -191,7 +192,7 @@ resources:
   kind: ServiceAccount
   metadata:
     annotations:
-      appliance.sourcegraph.com/configHash: 5e6989e9456ca355fe6cbe036e73384b350ce5a5cd28d28265259642f78aefe0
+      appliance.sourcegraph.com/configHash: ef7e879dd6941a6e3549b796700a532ce0069f41b2a7ecd3dc6dfcce79811954
     creationTimestamp: "2024-04-19T00:00:00Z"
     labels:
       deploy: sourcegraph
@@ -203,7 +204,7 @@ resources:
   kind: Service
   metadata:
     annotations:
-      appliance.sourcegraph.com/configHash: 5e6989e9456ca355fe6cbe036e73384b350ce5a5cd28d28265259642f78aefe0
+      appliance.sourcegraph.com/configHash: ef7e879dd6941a6e3549b796700a532ce0069f41b2a7ecd3dc6dfcce79811954
       prometheus.io/port: "6060"
       sourcegraph.prometheus/scrape: "true"
     creationTimestamp: "2024-04-19T00:00:00Z"

--- a/internal/appliance/testdata/golden-fixtures/standard/symbols-with-custom-image.yaml
+++ b/internal/appliance/testdata/golden-fixtures/standard/symbols-with-custom-image.yaml
@@ -1,42 +1,41 @@
 resources:
 - apiVersion: apps/v1
-  kind: Deployment
+  kind: StatefulSet
   metadata:
     annotations:
-      appliance.sourcegraph.com/configHash: db60986dc2fa6300a59d62fe32fccd74d3974c69bc88550270eb14ce4f2831ac
+      appliance.sourcegraph.com/configHash: 4310746eaab789e0d69f900836e6a3cea2979fe2e00be351e44120eb9cc43f29
     creationTimestamp: "2024-04-19T00:00:00Z"
     generation: 1
     labels:
-      app.kubernetes.io/component: repo-updater
+      app.kubernetes.io/component: symbols
       app.kubernetes.io/name: sourcegraph
       app.kubernetes.io/version: 5.3.9104
       deploy: sourcegraph
-    name: repo-updater
+    name: symbols
     namespace: NORMALIZED_FOR_TESTING
     resourceVersion: NORMALIZED_FOR_TESTING
     uid: NORMALIZED_FOR_TESTING
   spec:
     minReadySeconds: 10
-    progressDeadlineSeconds: 600
+    persistentVolumeClaimRetentionPolicy:
+      whenDeleted: Retain
+      whenScaled: Retain
+    podManagementPolicy: OrderedReady
     replicas: 1
     revisionHistoryLimit: 10
     selector:
       matchLabels:
-        app: repo-updater
-    strategy:
-      rollingUpdate:
-        maxSurge: 25%
-        maxUnavailable: 25%
-      type: RollingUpdate
+        app: symbols
+    serviceName: symbols
     template:
       metadata:
         annotations:
-          kubectl.kubernetes.io/default-container: repo-updater
+          kubectl.kubernetes.io/default-container: symbols
         creationTimestamp: null
         labels:
-          app: repo-updater
+          app: symbols
           deploy: sourcegraph
-        name: repo-updater
+        name: symbols
       spec:
         containers:
         - env:
@@ -50,6 +49,17 @@ resources:
               secretKeyRef:
                 key: endpoint
                 name: redis-store
+          - name: SYMBOLS_CACHE_SIZE_MB
+            value: "11059"
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.name
+          - name: SYMBOLS_CACHE_DIR
+            value: /mnt/cache/$(POD_NAME)
+          - name: TMPDIR
+            value: /mnt/tmp
           - name: OTEL_AGENT_HOST
             valueFrom:
               fieldRef:
@@ -57,20 +67,21 @@ resources:
                 fieldPath: status.hostIP
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
             value: http://$(OTEL_AGENT_HOST):4317
-          image: index.docker.io/sourcegraph/repo-updater:5.3.2@sha256:5a414aa030c7e0922700664a43b449ee5f3fafa68834abef93988c5992c747c6
+          image: my-custom-image-repository.info/sourcegraph-images/some-image:some-tag
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 3
             httpGet:
               path: /healthz
-              port: debug
+              port: http
               scheme: HTTP
-            periodSeconds: 1
+            initialDelaySeconds: 60
+            periodSeconds: 10
             successThreshold: 1
             timeoutSeconds: 5
-          name: repo-updater
+          name: symbols
           ports:
-          - containerPort: 3182
+          - containerPort: 3184
             name: http
             protocol: TCP
           - containerPort: 6060
@@ -79,13 +90,20 @@ resources:
           readinessProbe:
             failureThreshold: 3
             httpGet:
-              path: /ready
-              port: debug
+              path: /healthz
+              port: http
               scheme: HTTP
-            periodSeconds: 1
+            initialDelaySeconds: 60
+            periodSeconds: 5
             successThreshold: 1
-            timeoutSeconds: 5
-          resources: {}
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: "2"
+              memory: 2G
+            requests:
+              cpu: 500m
+              memory: 500M
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
@@ -93,6 +111,11 @@ resources:
             runAsUser: 100
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: FallbackToLogsOnError
+          volumeMounts:
+          - mountPath: /mnt/cache
+            name: cache
+          - mountPath: /mnt/tmp
+            name: tmp
         dnsPolicy: ClusterFirst
         restartPolicy: Always
         schedulerName: default-scheduler
@@ -101,15 +124,44 @@ resources:
           fsGroupChangePolicy: OnRootMismatch
           runAsGroup: 101
           runAsUser: 100
-        serviceAccount: repo-updater
-        serviceAccountName: repo-updater
+        serviceAccount: symbols
+        serviceAccountName: symbols
         terminationGracePeriodSeconds: 30
-  status: {}
+        volumes:
+        - emptyDir: {}
+          name: cache
+        - emptyDir: {}
+          name: tmp
+    updateStrategy:
+      type: RollingUpdate
+    volumeClaimTemplates:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
+        creationTimestamp: null
+        labels:
+          deploy: sourcegraph
+        name: cache
+        namespace: NORMALIZED_FOR_TESTING
+      spec:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: 12Gi
+        storageClassName: sourcegraph
+        volumeMode: Filesystem
+      status:
+        phase: Pending
+  status:
+    availableReplicas: 0
+    replicas: 0
 - apiVersion: v1
   data:
     spec: |
       spec:
         requestedVersion: "5.3.9104"
+        imageRepository: my-custom-image-repository.info/sourcegraph-images
 
         blobstore:
           disabled: true
@@ -151,15 +203,15 @@ resources:
           disabled: true
 
         repoUpdater:
-          containerConfig:
-            repo-updater:
-              bestEffortQOS: true
+          disabled: true
 
         searcher:
           disabled: true
 
         symbols:
-          disabled: true
+          containerConfig:
+            symbols:
+              image: some-image:some-tag
 
         syntectServer:
           disabled: true
@@ -180,11 +232,11 @@ resources:
   kind: ServiceAccount
   metadata:
     annotations:
-      appliance.sourcegraph.com/configHash: db60986dc2fa6300a59d62fe32fccd74d3974c69bc88550270eb14ce4f2831ac
+      appliance.sourcegraph.com/configHash: 4310746eaab789e0d69f900836e6a3cea2979fe2e00be351e44120eb9cc43f29
     creationTimestamp: "2024-04-19T00:00:00Z"
     labels:
       deploy: sourcegraph
-    name: repo-updater
+    name: symbols
     namespace: NORMALIZED_FOR_TESTING
     resourceVersion: NORMALIZED_FOR_TESTING
     uid: NORMALIZED_FOR_TESTING
@@ -192,15 +244,15 @@ resources:
   kind: Service
   metadata:
     annotations:
-      appliance.sourcegraph.com/configHash: db60986dc2fa6300a59d62fe32fccd74d3974c69bc88550270eb14ce4f2831ac
+      appliance.sourcegraph.com/configHash: 4310746eaab789e0d69f900836e6a3cea2979fe2e00be351e44120eb9cc43f29
       prometheus.io/port: "6060"
       sourcegraph.prometheus/scrape: "true"
     creationTimestamp: "2024-04-19T00:00:00Z"
     labels:
-      app: repo-updater
-      app.kubernetes.io/component: repo-updater
+      app: symbols
+      app.kubernetes.io/component: symbols
       deploy: sourcegraph
-    name: repo-updater
+    name: symbols
     namespace: NORMALIZED_FOR_TESTING
     resourceVersion: NORMALIZED_FOR_TESTING
     uid: NORMALIZED_FOR_TESTING
@@ -214,11 +266,15 @@ resources:
     ipFamilyPolicy: SingleStack
     ports:
     - name: http
-      port: 3182
+      port: 3184
       protocol: TCP
       targetPort: http
+    - name: debug
+      port: 6060
+      protocol: TCP
+      targetPort: debug
     selector:
-      app: repo-updater
+      app: symbols
     sessionAffinity: None
     type: ClusterIP
   status:

--- a/internal/appliance/testdata/sg/standard/repo-updater-with-no-resources.yaml
+++ b/internal/appliance/testdata/sg/standard/repo-updater-with-no-resources.yaml
@@ -41,8 +41,9 @@ spec:
     disabled: true
 
   repoUpdater:
-    resources:
-      repo-updater: null
+    containerConfig:
+      repo-updater:
+        resources: null
 
   searcher:
     disabled: true

--- a/internal/appliance/testdata/sg/standard/repo-updater-with-resources.yaml
+++ b/internal/appliance/testdata/sg/standard/repo-updater-with-resources.yaml
@@ -41,14 +41,15 @@ spec:
     disabled: true
 
   repoUpdater:
-    resources:
+    containerConfig:
       repo-updater:
-        requests:
-          cpu: 1500m
-          memory: 2Gi
-        limits:
-          cpu: "4"
-          memory: 4Gi
+        resources:
+          requests:
+            cpu: 1500m
+            memory: 2Gi
+          limits:
+            cpu: "4"
+            memory: 4Gi
 
   searcher:
     disabled: true

--- a/internal/appliance/testdata/sg/standard/symbols-with-custom-image.yaml
+++ b/internal/appliance/testdata/sg/standard/symbols-with-custom-image.yaml
@@ -1,5 +1,6 @@
 spec:
   requestedVersion: "5.3.9104"
+  imageRepository: my-custom-image-repository.info/sourcegraph-images
 
   blobstore:
     disabled: true
@@ -41,15 +42,15 @@ spec:
     disabled: true
 
   repoUpdater:
-    containerConfig:
-      repo-updater:
-        bestEffortQOS: true
+    disabled: true
 
   searcher:
     disabled: true
 
   symbols:
-    disabled: true
+    containerConfig:
+      symbols:
+        image: some-image:some-tag
 
   syntectServer:
     disabled: true

--- a/internal/k8s/resource/container/BUILD.bazel
+++ b/internal/k8s/resource/container/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//internal/appliance/config",
         "//lib/pointers",
+        "@com_github_grafana_regexp//:regexp",
         "@io_k8s_api//core/v1:core",
         "@io_k8s_apimachinery//pkg/util/intstr",
     ],

--- a/internal/k8s/resource/container/container.go
+++ b/internal/k8s/resource/container/container.go
@@ -24,8 +24,8 @@ func NewContainer(name string, cfg config.StandardComponent, defaultResources co
 	}
 
 	if cfg != nil {
-		if ctrResources, ok := cfg.GetResources()[name]; ok {
-			ctr.Resources = ctrResources
+		if ctrConfig, ok := cfg.GetContainerConfig()[name]; ok {
+			ctr.Resources = ctrConfig.Resources
 		}
 	}
 


### PR DESCRIPTION
**appliance: refactor container config**

In preparation for adding a field for image overrides, move the
resources section into a new ContainerConfig field, to avoid cluttering
the top-level interface.



**appliance: container image config**

Add image defaults and overrides similar to the helm chart: we hardcode
our standard image repository and version-specific tags for each
component as defaults. We expose per-service overrides of the image and
its tag (although _not_ qualified by repository), and a global override
for the repository.

This commit does not support per-service overrides of the repository,
although this is something we could add in the future if there is
demand.

The appliance will need to support a range of SG versions. This commit
adds the beginnings of the scaffolding for that. Most k8s resource
manifest content for most services will not change at all betwen
subequent releases, but all image tags will likely change with every
release. Therefore, we centralize the image management across services
in one file, rather than leaving the image:version mapping to each
service. Service configs can opt out of this mechanism by not calling
getDefaultImage().

Closes https://github.com/sourcegraph/sourcegraph/issues/62076


## Test plan

Golden tests included.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
