### PR TITLE
appliance: fix owner references for new objects

### DIFF
--- a/internal/appliance/golden_test.go
+++ b/internal/appliance/golden_test.go
@@ -16,6 +16,8 @@ import (
 // creationTimestamp and uid need to be normalized
 var magicTime = metav1.NewTime(time.Date(2024, time.April, 19, 0, 0, 0, 0, time.UTC))
 
+const normalizedString = "NORMALIZED_FOR_TESTING"
+
 type goldenFile struct {
 	Resources []client.Object `json:"resources"`
 }
@@ -67,7 +69,7 @@ func (suite *ApplianceTestSuite) gatherResources(namespace string) []client.Obje
 	for _, obj := range ssets.Items {
 		obj := obj
 		for i := range obj.Spec.VolumeClaimTemplates {
-			obj.Spec.VolumeClaimTemplates[i].Namespace = "NORMALIZED_FOR_TESTING"
+			obj.Spec.VolumeClaimTemplates[i].Namespace = normalizedString
 		}
 		obj.SetGroupVersionKind(schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "StatefulSet"})
 		normalizeObj(&obj)
@@ -124,8 +126,8 @@ func (suite *ApplianceTestSuite) gatherResources(namespace string) []client.Obje
 	suite.Require().NoError(err)
 	for _, obj := range svcs.Items {
 		obj := obj
-		obj.Spec.ClusterIP = "NORMALIZED_FOR_TESTING"
-		obj.Spec.ClusterIPs = []string{"NORMALIZED_FOR_TESTING"}
+		obj.Spec.ClusterIP = normalizedString
+		obj.Spec.ClusterIPs = []string{normalizedString}
 		obj.SetGroupVersionKind(schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Service"})
 		normalizeObj(&obj)
 		objs = append(objs, &obj)
@@ -135,9 +137,17 @@ func (suite *ApplianceTestSuite) gatherResources(namespace string) []client.Obje
 }
 
 func normalizeObj(obj client.Object) {
-	obj.SetUID("NORMALIZED_FOR_TESTING")
+	obj.SetUID(normalizedString)
 	obj.SetCreationTimestamp(magicTime)
 	obj.SetManagedFields(nil)
-	obj.SetNamespace("NORMALIZED_FOR_TESTING")
-	obj.SetResourceVersion("NORMALIZED_FOR_TESTING")
+	obj.SetNamespace(normalizedString)
+	obj.SetResourceVersion(normalizedString)
+
+	ownerRefs := obj.GetOwnerReferences()
+	normalizedOwnerRefs := make([]metav1.OwnerReference, len(ownerRefs))
+	for i, ownerRef := range ownerRefs {
+		ownerRef.UID = normalizedString
+		normalizedOwnerRefs[i] = ownerRef
+	}
+	obj.SetOwnerReferences(normalizedOwnerRefs)
 }

--- a/internal/appliance/kubernetes.go
+++ b/internal/appliance/kubernetes.go
@@ -75,6 +75,10 @@ func createOrUpdateObject[R client.Object](
 	annotations[annotationKeyConfigHash] = cfgHash
 	obj.SetAnnotations(annotations)
 
+	if err := ctrl.SetControllerReference(owner, obj, r.Scheme); err != nil {
+		return errors.Newf("setting controller reference: %w", err)
+	}
+
 	existingRes := objKind
 	if err := r.Client.Get(ctx, namespacedName, existingRes); err != nil {
 		if kerrors.IsNotFound(err) {
@@ -88,10 +92,6 @@ func createOrUpdateObject[R client.Object](
 
 		logger.Error(err, "unexpected error getting object")
 		return err
-	}
-
-	if err := ctrl.SetControllerReference(owner, obj, r.Scheme); err != nil {
-		return errors.Newf("setting controller reference: %w", err)
 	}
 
 	if cfgHash != existingRes.GetAnnotations()[annotationKeyConfigHash] {

--- a/internal/appliance/testdata/golden-fixtures/blobstore/default.yaml
+++ b/internal/appliance/testdata/golden-fixtures/blobstore/default.yaml
@@ -13,6 +13,13 @@ resources:
       deploy: sourcegraph
     name: blobstore
     namespace: NORMALIZED_FOR_TESTING
+    ownerReferences:
+    - apiVersion: v1
+      blockOwnerDeletion: true
+      controller: true
+      kind: ConfigMap
+      name: sg
+      uid: NORMALIZED_FOR_TESTING
     resourceVersion: NORMALIZED_FOR_TESTING
     uid: NORMALIZED_FOR_TESTING
   spec:
@@ -161,6 +168,13 @@ resources:
       deploy: sourcegraph
     name: blobstore
     namespace: NORMALIZED_FOR_TESTING
+    ownerReferences:
+    - apiVersion: v1
+      blockOwnerDeletion: true
+      controller: true
+      kind: ConfigMap
+      name: sg
+      uid: NORMALIZED_FOR_TESTING
     resourceVersion: NORMALIZED_FOR_TESTING
     uid: NORMALIZED_FOR_TESTING
   spec:
@@ -185,6 +199,13 @@ resources:
       deploy: sourcegraph
     name: blobstore
     namespace: NORMALIZED_FOR_TESTING
+    ownerReferences:
+    - apiVersion: v1
+      blockOwnerDeletion: true
+      controller: true
+      kind: ConfigMap
+      name: sg
+      uid: NORMALIZED_FOR_TESTING
     resourceVersion: NORMALIZED_FOR_TESTING
     uid: NORMALIZED_FOR_TESTING
   spec:

--- a/internal/appliance/testdata/golden-fixtures/gitserver/default.yaml
+++ b/internal/appliance/testdata/golden-fixtures/gitserver/default.yaml
@@ -13,6 +13,13 @@ resources:
       deploy: sourcegraph
     name: gitserver
     namespace: NORMALIZED_FOR_TESTING
+    ownerReferences:
+    - apiVersion: v1
+      blockOwnerDeletion: true
+      controller: true
+      kind: ConfigMap
+      name: sg
+      uid: NORMALIZED_FOR_TESTING
     resourceVersion: NORMALIZED_FOR_TESTING
     uid: NORMALIZED_FOR_TESTING
   spec:
@@ -210,6 +217,13 @@ resources:
       deploy: sourcegraph
     name: gitserver
     namespace: NORMALIZED_FOR_TESTING
+    ownerReferences:
+    - apiVersion: v1
+      blockOwnerDeletion: true
+      controller: true
+      kind: ConfigMap
+      name: sg
+      uid: NORMALIZED_FOR_TESTING
     resourceVersion: NORMALIZED_FOR_TESTING
     uid: NORMALIZED_FOR_TESTING
 - apiVersion: v1
@@ -226,6 +240,13 @@ resources:
       deploy: sourcegraph
     name: gitserver
     namespace: NORMALIZED_FOR_TESTING
+    ownerReferences:
+    - apiVersion: v1
+      blockOwnerDeletion: true
+      controller: true
+      kind: ConfigMap
+      name: sg
+      uid: NORMALIZED_FOR_TESTING
     resourceVersion: NORMALIZED_FOR_TESTING
     uid: NORMALIZED_FOR_TESTING
   spec:

--- a/internal/appliance/testdata/golden-fixtures/gitserver/with-storage.yaml
+++ b/internal/appliance/testdata/golden-fixtures/gitserver/with-storage.yaml
@@ -13,6 +13,13 @@ resources:
       deploy: sourcegraph
     name: gitserver
     namespace: NORMALIZED_FOR_TESTING
+    ownerReferences:
+    - apiVersion: v1
+      blockOwnerDeletion: true
+      controller: true
+      kind: ConfigMap
+      name: sg
+      uid: NORMALIZED_FOR_TESTING
     resourceVersion: NORMALIZED_FOR_TESTING
     uid: NORMALIZED_FOR_TESTING
   spec:
@@ -211,6 +218,13 @@ resources:
       deploy: sourcegraph
     name: gitserver
     namespace: NORMALIZED_FOR_TESTING
+    ownerReferences:
+    - apiVersion: v1
+      blockOwnerDeletion: true
+      controller: true
+      kind: ConfigMap
+      name: sg
+      uid: NORMALIZED_FOR_TESTING
     resourceVersion: NORMALIZED_FOR_TESTING
     uid: NORMALIZED_FOR_TESTING
 - apiVersion: v1
@@ -227,6 +241,13 @@ resources:
       deploy: sourcegraph
     name: gitserver
     namespace: NORMALIZED_FOR_TESTING
+    ownerReferences:
+    - apiVersion: v1
+      blockOwnerDeletion: true
+      controller: true
+      kind: ConfigMap
+      name: sg
+      uid: NORMALIZED_FOR_TESTING
     resourceVersion: NORMALIZED_FOR_TESTING
     uid: NORMALIZED_FOR_TESTING
   spec:

--- a/internal/appliance/testdata/golden-fixtures/repo-updater/default.yaml
+++ b/internal/appliance/testdata/golden-fixtures/repo-updater/default.yaml
@@ -13,6 +13,13 @@ resources:
       deploy: sourcegraph
     name: repo-updater
     namespace: NORMALIZED_FOR_TESTING
+    ownerReferences:
+    - apiVersion: v1
+      blockOwnerDeletion: true
+      controller: true
+      kind: ConfigMap
+      name: sg
+      uid: NORMALIZED_FOR_TESTING
     resourceVersion: NORMALIZED_FOR_TESTING
     uid: NORMALIZED_FOR_TESTING
   spec:
@@ -189,6 +196,13 @@ resources:
       deploy: sourcegraph
     name: repo-updater
     namespace: NORMALIZED_FOR_TESTING
+    ownerReferences:
+    - apiVersion: v1
+      blockOwnerDeletion: true
+      controller: true
+      kind: ConfigMap
+      name: sg
+      uid: NORMALIZED_FOR_TESTING
     resourceVersion: NORMALIZED_FOR_TESTING
     uid: NORMALIZED_FOR_TESTING
 - apiVersion: v1
@@ -205,6 +219,13 @@ resources:
       deploy: sourcegraph
     name: repo-updater
     namespace: NORMALIZED_FOR_TESTING
+    ownerReferences:
+    - apiVersion: v1
+      blockOwnerDeletion: true
+      controller: true
+      kind: ConfigMap
+      name: sg
+      uid: NORMALIZED_FOR_TESTING
     resourceVersion: NORMALIZED_FOR_TESTING
     uid: NORMALIZED_FOR_TESTING
   spec:

--- a/internal/appliance/testdata/golden-fixtures/standard/blobstore-subsequent-disable.yaml
+++ b/internal/appliance/testdata/golden-fixtures/standard/blobstore-subsequent-disable.yaml
@@ -82,6 +82,13 @@ resources:
       deploy: sourcegraph
     name: blobstore
     namespace: NORMALIZED_FOR_TESTING
+    ownerReferences:
+    - apiVersion: v1
+      blockOwnerDeletion: true
+      controller: true
+      kind: ConfigMap
+      name: sg
+      uid: NORMALIZED_FOR_TESTING
     resourceVersion: NORMALIZED_FOR_TESTING
     uid: NORMALIZED_FOR_TESTING
   spec:

--- a/internal/appliance/testdata/golden-fixtures/standard/repo-updater-with-no-resources.yaml
+++ b/internal/appliance/testdata/golden-fixtures/standard/repo-updater-with-no-resources.yaml
@@ -13,6 +13,13 @@ resources:
       deploy: sourcegraph
     name: repo-updater
     namespace: NORMALIZED_FOR_TESTING
+    ownerReferences:
+    - apiVersion: v1
+      blockOwnerDeletion: true
+      controller: true
+      kind: ConfigMap
+      name: sg
+      uid: NORMALIZED_FOR_TESTING
     resourceVersion: NORMALIZED_FOR_TESTING
     uid: NORMALIZED_FOR_TESTING
   spec:
@@ -186,6 +193,13 @@ resources:
       deploy: sourcegraph
     name: repo-updater
     namespace: NORMALIZED_FOR_TESTING
+    ownerReferences:
+    - apiVersion: v1
+      blockOwnerDeletion: true
+      controller: true
+      kind: ConfigMap
+      name: sg
+      uid: NORMALIZED_FOR_TESTING
     resourceVersion: NORMALIZED_FOR_TESTING
     uid: NORMALIZED_FOR_TESTING
 - apiVersion: v1
@@ -202,6 +216,13 @@ resources:
       deploy: sourcegraph
     name: repo-updater
     namespace: NORMALIZED_FOR_TESTING
+    ownerReferences:
+    - apiVersion: v1
+      blockOwnerDeletion: true
+      controller: true
+      kind: ConfigMap
+      name: sg
+      uid: NORMALIZED_FOR_TESTING
     resourceVersion: NORMALIZED_FOR_TESTING
     uid: NORMALIZED_FOR_TESTING
   spec:

--- a/internal/appliance/testdata/golden-fixtures/standard/repo-updater-with-pod-template-config.yaml
+++ b/internal/appliance/testdata/golden-fixtures/standard/repo-updater-with-pod-template-config.yaml
@@ -13,6 +13,13 @@ resources:
       deploy: sourcegraph
     name: repo-updater
     namespace: NORMALIZED_FOR_TESTING
+    ownerReferences:
+    - apiVersion: v1
+      blockOwnerDeletion: true
+      controller: true
+      kind: ConfigMap
+      name: sg
+      uid: NORMALIZED_FOR_TESTING
     resourceVersion: NORMALIZED_FOR_TESTING
     uid: NORMALIZED_FOR_TESTING
   spec:
@@ -226,6 +233,13 @@ resources:
       deploy: sourcegraph
     name: repo-updater
     namespace: NORMALIZED_FOR_TESTING
+    ownerReferences:
+    - apiVersion: v1
+      blockOwnerDeletion: true
+      controller: true
+      kind: ConfigMap
+      name: sg
+      uid: NORMALIZED_FOR_TESTING
     resourceVersion: NORMALIZED_FOR_TESTING
     uid: NORMALIZED_FOR_TESTING
 - apiVersion: v1
@@ -242,6 +256,13 @@ resources:
       deploy: sourcegraph
     name: repo-updater
     namespace: NORMALIZED_FOR_TESTING
+    ownerReferences:
+    - apiVersion: v1
+      blockOwnerDeletion: true
+      controller: true
+      kind: ConfigMap
+      name: sg
+      uid: NORMALIZED_FOR_TESTING
     resourceVersion: NORMALIZED_FOR_TESTING
     uid: NORMALIZED_FOR_TESTING
   spec:

--- a/internal/appliance/testdata/golden-fixtures/standard/repo-updater-with-resources.yaml
+++ b/internal/appliance/testdata/golden-fixtures/standard/repo-updater-with-resources.yaml
@@ -13,6 +13,13 @@ resources:
       deploy: sourcegraph
     name: repo-updater
     namespace: NORMALIZED_FOR_TESTING
+    ownerReferences:
+    - apiVersion: v1
+      blockOwnerDeletion: true
+      controller: true
+      kind: ConfigMap
+      name: sg
+      uid: NORMALIZED_FOR_TESTING
     resourceVersion: NORMALIZED_FOR_TESTING
     uid: NORMALIZED_FOR_TESTING
   spec:
@@ -198,6 +205,13 @@ resources:
       deploy: sourcegraph
     name: repo-updater
     namespace: NORMALIZED_FOR_TESTING
+    ownerReferences:
+    - apiVersion: v1
+      blockOwnerDeletion: true
+      controller: true
+      kind: ConfigMap
+      name: sg
+      uid: NORMALIZED_FOR_TESTING
     resourceVersion: NORMALIZED_FOR_TESTING
     uid: NORMALIZED_FOR_TESTING
 - apiVersion: v1
@@ -214,6 +228,13 @@ resources:
       deploy: sourcegraph
     name: repo-updater
     namespace: NORMALIZED_FOR_TESTING
+    ownerReferences:
+    - apiVersion: v1
+      blockOwnerDeletion: true
+      controller: true
+      kind: ConfigMap
+      name: sg
+      uid: NORMALIZED_FOR_TESTING
     resourceVersion: NORMALIZED_FOR_TESTING
     uid: NORMALIZED_FOR_TESTING
   spec:

--- a/internal/appliance/testdata/golden-fixtures/standard/repo-updater-with-sa-annotations.yaml
+++ b/internal/appliance/testdata/golden-fixtures/standard/repo-updater-with-sa-annotations.yaml
@@ -13,6 +13,13 @@ resources:
       deploy: sourcegraph
     name: repo-updater
     namespace: NORMALIZED_FOR_TESTING
+    ownerReferences:
+    - apiVersion: v1
+      blockOwnerDeletion: true
+      controller: true
+      kind: ConfigMap
+      name: sg
+      uid: NORMALIZED_FOR_TESTING
     resourceVersion: NORMALIZED_FOR_TESTING
     uid: NORMALIZED_FOR_TESTING
   spec:
@@ -192,6 +199,13 @@ resources:
       deploy: sourcegraph
     name: repo-updater
     namespace: NORMALIZED_FOR_TESTING
+    ownerReferences:
+    - apiVersion: v1
+      blockOwnerDeletion: true
+      controller: true
+      kind: ConfigMap
+      name: sg
+      uid: NORMALIZED_FOR_TESTING
     resourceVersion: NORMALIZED_FOR_TESTING
     uid: NORMALIZED_FOR_TESTING
 - apiVersion: v1
@@ -208,6 +222,13 @@ resources:
       deploy: sourcegraph
     name: repo-updater
     namespace: NORMALIZED_FOR_TESTING
+    ownerReferences:
+    - apiVersion: v1
+      blockOwnerDeletion: true
+      controller: true
+      kind: ConfigMap
+      name: sg
+      uid: NORMALIZED_FOR_TESTING
     resourceVersion: NORMALIZED_FOR_TESTING
     uid: NORMALIZED_FOR_TESTING
   spec:

--- a/internal/appliance/testdata/golden-fixtures/standard/symbols-with-custom-image.yaml
+++ b/internal/appliance/testdata/golden-fixtures/standard/symbols-with-custom-image.yaml
@@ -13,6 +13,13 @@ resources:
       deploy: sourcegraph
     name: symbols
     namespace: NORMALIZED_FOR_TESTING
+    ownerReferences:
+    - apiVersion: v1
+      blockOwnerDeletion: true
+      controller: true
+      kind: ConfigMap
+      name: sg
+      uid: NORMALIZED_FOR_TESTING
     resourceVersion: NORMALIZED_FOR_TESTING
     uid: NORMALIZED_FOR_TESTING
   spec:
@@ -238,6 +245,13 @@ resources:
       deploy: sourcegraph
     name: symbols
     namespace: NORMALIZED_FOR_TESTING
+    ownerReferences:
+    - apiVersion: v1
+      blockOwnerDeletion: true
+      controller: true
+      kind: ConfigMap
+      name: sg
+      uid: NORMALIZED_FOR_TESTING
     resourceVersion: NORMALIZED_FOR_TESTING
     uid: NORMALIZED_FOR_TESTING
 - apiVersion: v1
@@ -254,6 +268,13 @@ resources:
       deploy: sourcegraph
     name: symbols
     namespace: NORMALIZED_FOR_TESTING
+    ownerReferences:
+    - apiVersion: v1
+      blockOwnerDeletion: true
+      controller: true
+      kind: ConfigMap
+      name: sg
+      uid: NORMALIZED_FOR_TESTING
     resourceVersion: NORMALIZED_FOR_TESTING
     uid: NORMALIZED_FOR_TESTING
   spec:

--- a/internal/appliance/testdata/golden-fixtures/symbols/default.yaml
+++ b/internal/appliance/testdata/golden-fixtures/symbols/default.yaml
@@ -13,6 +13,13 @@ resources:
       deploy: sourcegraph
     name: symbols
     namespace: NORMALIZED_FOR_TESTING
+    ownerReferences:
+    - apiVersion: v1
+      blockOwnerDeletion: true
+      controller: true
+      kind: ConfigMap
+      name: sg
+      uid: NORMALIZED_FOR_TESTING
     resourceVersion: NORMALIZED_FOR_TESTING
     uid: NORMALIZED_FOR_TESTING
   spec:
@@ -234,6 +241,13 @@ resources:
       deploy: sourcegraph
     name: symbols
     namespace: NORMALIZED_FOR_TESTING
+    ownerReferences:
+    - apiVersion: v1
+      blockOwnerDeletion: true
+      controller: true
+      kind: ConfigMap
+      name: sg
+      uid: NORMALIZED_FOR_TESTING
     resourceVersion: NORMALIZED_FOR_TESTING
     uid: NORMALIZED_FOR_TESTING
 - apiVersion: v1
@@ -250,6 +264,13 @@ resources:
       deploy: sourcegraph
     name: symbols
     namespace: NORMALIZED_FOR_TESTING
+    ownerReferences:
+    - apiVersion: v1
+      blockOwnerDeletion: true
+      controller: true
+      kind: ConfigMap
+      name: sg
+      uid: NORMALIZED_FOR_TESTING
     resourceVersion: NORMALIZED_FOR_TESTING
     uid: NORMALIZED_FOR_TESTING
   spec:

--- a/internal/appliance/testdata/golden-fixtures/symbols/with-storage.yaml
+++ b/internal/appliance/testdata/golden-fixtures/symbols/with-storage.yaml
@@ -13,6 +13,13 @@ resources:
       deploy: sourcegraph
     name: symbols
     namespace: NORMALIZED_FOR_TESTING
+    ownerReferences:
+    - apiVersion: v1
+      blockOwnerDeletion: true
+      controller: true
+      kind: ConfigMap
+      name: sg
+      uid: NORMALIZED_FOR_TESTING
     resourceVersion: NORMALIZED_FOR_TESTING
     uid: NORMALIZED_FOR_TESTING
   spec:
@@ -235,6 +242,13 @@ resources:
       deploy: sourcegraph
     name: symbols
     namespace: NORMALIZED_FOR_TESTING
+    ownerReferences:
+    - apiVersion: v1
+      blockOwnerDeletion: true
+      controller: true
+      kind: ConfigMap
+      name: sg
+      uid: NORMALIZED_FOR_TESTING
     resourceVersion: NORMALIZED_FOR_TESTING
     uid: NORMALIZED_FOR_TESTING
 - apiVersion: v1
@@ -251,6 +265,13 @@ resources:
       deploy: sourcegraph
     name: symbols
     namespace: NORMALIZED_FOR_TESTING
+    ownerReferences:
+    - apiVersion: v1
+      blockOwnerDeletion: true
+      controller: true
+      kind: ConfigMap
+      name: sg
+      uid: NORMALIZED_FOR_TESTING
     resourceVersion: NORMALIZED_FOR_TESTING
     uid: NORMALIZED_FOR_TESTING
   spec:


### PR DESCRIPTION
Fix a bug in which ownerReferences were not being set on new objects created by the appliance. This meant that kubernetes garbage collection did not trigger (when the configmap is deleted, we expect owned objects to also be deleted).

## Test plan

envtest doesn't actually perform k8s GC, but the golden tests validate that the ownerReferences are in the expected place. I have manually tested the appliance against a real k8s instance to validate our model of how ownerReferences / GC works.

When we have e2e smoke tests against a "real" kube, not just envtest, we should be able to test this more behaviourally if we wish.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
