### PR TITLE
sg: cloud wait for cloud ephemeral before deploying

### DIFF
--- a/.buildkite/pipeline.backcompat.yml
+++ b/.buildkite/pipeline.backcompat.yml
@@ -4,3 +4,5 @@ steps:
     agents: { queue: aspect-default }
     commands:
     - ./dev/backcompat/bazel-backcompat.sh
+    soft_fail:
+    - exit_status: 1

--- a/deps.bzl
+++ b/deps.bzl
@@ -5455,8 +5455,8 @@ def go_dependencies():
         name = "com_github_sourcegraph_cloud_api",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/sourcegraph/cloud-api",
-        sum = "h1:tgqkTr812ydrUTktrJGRD9BpIEt/Gv0/NsJiugr6qe0=",
-        version = "v0.0.0-20240423104735-5602ff6597cc",
+        sum = "h1:ZCHR0jxMJ0QhwHbHnbXuWTJrIeJT6uuJZ5D8V2Csg6g=",
+        version = "v0.0.0-20240501113836-ecd1d4cba9dd",
     )
     go_repository(
         name = "com_github_sourcegraph_conc",

--- a/dev/sg/internal/bk/bk.go
+++ b/dev/sg/internal/bk/bk.go
@@ -121,7 +121,7 @@ func (c *Client) GetBuildByNumber(ctx context.Context, pipeline string, number s
 	b, _, err := c.bk.Builds.Get(BuildkiteOrg, pipeline, number, nil)
 	if err != nil {
 		if strings.Contains(err.Error(), "404 Not Found") {
-			return nil, errors.New("no build found")
+			return nil, errors.Newf("build %s not found on pipeline %q", number, pipeline)
 		}
 		return nil, err
 	}

--- a/dev/sg/internal/cloud/BUILD.bazel
+++ b/dev/sg/internal/cloud/BUILD.bazel
@@ -4,6 +4,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "cloud",
     srcs = [
+        "artifact_registry.go",
         "client.go",
         "common.go",
         "delete_command.go",

--- a/dev/sg/internal/cloud/BUILD.bazel
+++ b/dev/sg/internal/cloud/BUILD.bazel
@@ -1,3 +1,4 @@
+load("//dev:go_defs.bzl", "go_test")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
@@ -34,4 +35,11 @@ go_library(
         "@com_google_cloud_go_artifactregistry//apiv1/artifactregistrypb",
         "@org_golang_google_api//iterator",
     ],
+)
+
+go_test(
+    name = "cloud_test",
+    srcs = ["instance_test.go"],
+    embed = [":cloud"],
+    deps = ["@com_github_sourcegraph_cloud_api//go/cloudapi/v1:cloudapi"],
 )

--- a/dev/sg/internal/cloud/BUILD.bazel
+++ b/dev/sg/internal/cloud/BUILD.bazel
@@ -5,9 +5,11 @@ go_library(
     name = "cloud",
     srcs = [
         "client.go",
+        "common.go",
         "delete_command.go",
         "deploy_command.go",
         "instance.go",
+        "lease_command.go",
         "list_command.go",
         "list_versions_command.go",
         "printers.go",
@@ -34,6 +36,7 @@ go_library(
         "@com_google_cloud_go_artifactregistry//apiv1",
         "@com_google_cloud_go_artifactregistry//apiv1/artifactregistrypb",
         "@org_golang_google_api//iterator",
+        "@org_golang_google_protobuf//types/known/timestamppb",
     ],
 )
 

--- a/dev/sg/internal/cloud/artifact_registry.go
+++ b/dev/sg/internal/cloud/artifact_registry.go
@@ -1,0 +1,106 @@
+package cloud
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"strings"
+
+	artifactregistry "cloud.google.com/go/artifactregistry/apiv1"
+	artifactregistrypb "cloud.google.com/go/artifactregistry/apiv1/artifactregistrypb"
+	"google.golang.org/api/iterator"
+)
+
+// DockerImage is a type alias around the Google artifact registry Docker Image type
+type DockerImage artifactregistrypb.DockerImage
+
+// ArtifactRegistry is wrapper around the Google Artifact Registry client
+type ArtifactRegistry struct {
+	Project        string
+	Location       string
+	RepositoryName string
+	PageSize       int32
+
+	client *artifactregistry.Client
+}
+
+// NewDefaultCloudEphemeralRegistry creates an Artifact Registry with all the details set to point to the cloud
+// ephemeral registry
+func NewDefaultCloudEphemeralRegistry(ctx context.Context) (*ArtifactRegistry, error) {
+	return NewArtifactRegistry(ctx, "sourcegraph-ci", "us-central1", "cloud-ephemeral")
+}
+
+func NewArtifactRegistry(ctx context.Context, project, location, repositoryName string) (*ArtifactRegistry, error) {
+	client, err := artifactregistry.NewClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ArtifactRegistry{
+		Project:        project,
+		Location:       location,
+		RepositoryName: repositoryName,
+		PageSize:       DefaultArtifactRegistryPageSize,
+
+		client: client,
+	}, nil
+}
+
+// Parent returns the parent string in the format of projects/<project>/locations/<location>/repositories/<repositoryName>
+func (ar *ArtifactRegistry) Parent() string {
+	return fmt.Sprintf("projects/%s/locations/%s/repositories/%s", ar.Project, ar.Location, ar.RepositoryName)
+}
+
+func (ar *ArtifactRegistry) String() string {
+	return ar.Parent()
+}
+
+// ListVersions lists all Docker Images present in the Artifact Registry.
+func (ar *ArtifactRegistry) ListDockerImages(ctx context.Context) ([]*DockerImage, error) {
+	req := &artifactregistrypb.ListDockerImagesRequest{
+		Parent:   ar.Parent(),
+		PageSize: ar.PageSize,
+	}
+
+	images := []*DockerImage{}
+	resp := ar.client.ListDockerImages(ctx, req)
+	for {
+		image, err := resp.Next()
+		if err != nil {
+			if err == iterator.Done {
+				break
+			}
+			return nil, err
+		}
+		images = append(images, (*DockerImage)(image))
+	}
+
+	return images, nil
+}
+
+func (ar *ArtifactRegistry) HasDockerImageTag(ctx context.Context, name, tag string) (bool, error) {
+	image, err := ar.GetDockerImage(ctx, name)
+	if err != nil {
+		return false, err
+	}
+
+	idx := slices.IndexFunc(image.Tags, func(t string) bool {
+		return strings.EqualFold(t, tag)
+	})
+
+	return idx != -1, nil
+}
+
+// GetDockerImage gets a Docker Image by name from the Artifact Registry.
+func (ar *ArtifactRegistry) GetDockerImage(ctx context.Context, name string) (*DockerImage, error) {
+	req := &artifactregistrypb.GetDockerImageRequest{
+		Name: name,
+	}
+
+	image, err := ar.client.GetDockerImage(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	return (*DockerImage)(image), nil
+}

--- a/dev/sg/internal/cloud/client.go
+++ b/dev/sg/internal/cloud/client.go
@@ -24,10 +24,6 @@ const APIEndpoint = "https://cloud-ops-dev.sgdev.org/api"
 // DevEnvironment is the environment where Cloud allows ephemeral instance types
 const DevEnvironment = "dev"
 
-// EphemeralInstanceType is the instace type we should use when creating an instance with the cloud API.
-// It is set to internal because in cloud, internal instance types does not have metrics or security enabled.
-const EphemeralInstanceType = "internal"
-
 var _ EphemeralClient = &Client{}
 
 type EphemeralClient interface {
@@ -50,12 +46,12 @@ type DeploymentSpec struct {
 }
 
 func NewDeploymentSpec(name, version string) *DeploymentSpec {
+	features := newInstanceFeatures()
+	features.SetEphemeralInstance(true)
 	return &DeploymentSpec{
-		Name:    sanitizeInstanceName(name),
-		Version: version,
-		InstanceFeatures: map[string]string{
-			"ephemeral": "true", // need to have this to make the instance ephemeral
-		},
+		Name:             sanitizeInstanceName(name),
+		Version:          version,
+		InstanceFeatures: features.Value(),
 	}
 }
 

--- a/dev/sg/internal/cloud/client.go
+++ b/dev/sg/internal/cloud/client.go
@@ -112,15 +112,13 @@ func (c *Client) GetInstance(ctx context.Context, name string) (*Instance, error
 
 func (c *Client) ListInstances(ctx context.Context, all bool) ([]*Instance, error) {
 	var req *connect.Request[cloudapiv1.ListInstancesRequest]
-	if all {
-		req = newRequestWithToken(c.token, &cloudapiv1.ListInstancesRequest{})
-	} else {
-		req = newRequestWithToken(c.token, &cloudapiv1.ListInstancesRequest{
-			InstanceFilter: &cloudapiv1.InstanceFilter{
-				AdminEmail: &c.email,
-			},
-		})
+	listReq := cloudapiv1.ListInstancesRequest{}
+	if !all {
+		listReq.InstanceFilter = &cloudapiv1.InstanceFilter{
+			AdminEmail: &c.email,
+		}
 	}
+
 	resp, err := c.client.ListInstances(
 		ctx,
 		req,

--- a/dev/sg/internal/cloud/client.go
+++ b/dev/sg/internal/cloud/client.go
@@ -111,14 +111,14 @@ func (c *Client) GetInstance(ctx context.Context, name string) (*Instance, error
 }
 
 func (c *Client) ListInstances(ctx context.Context, all bool) ([]*Instance, error) {
-	var req *connect.Request[cloudapiv1.ListInstancesRequest]
-	listReq := cloudapiv1.ListInstancesRequest{}
+	listReq := &cloudapiv1.ListInstancesRequest{}
 	if !all {
 		listReq.InstanceFilter = &cloudapiv1.InstanceFilter{
 			AdminEmail: &c.email,
 		}
 	}
 
+	req := newRequestWithToken(c.token, listReq)
 	resp, err := c.client.ListInstances(
 		ctx,
 		req,

--- a/dev/sg/internal/cloud/client.go
+++ b/dev/sg/internal/cloud/client.go
@@ -5,11 +5,13 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	"time"
 
 	"connectrpc.com/connect"
 	cloudapiv1 "github.com/sourcegraph/cloud-api/go/cloudapi/v1"
 	"github.com/sourcegraph/cloud-api/go/cloudapi/v1/cloudapiv1connect"
 	"github.com/sourcegraph/run"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 	"github.com/sourcegraph/sourcegraph/lib/pointers"
@@ -49,7 +51,7 @@ func NewDeploymentSpec(name, version string) *DeploymentSpec {
 	features := newInstanceFeatures()
 	features.SetEphemeralInstance(true)
 	return &DeploymentSpec{
-		Name:             sanitizeInstanceName(name),
+		Name:             name,
 		Version:          version,
 		InstanceFeatures: features.Value(),
 	}
@@ -160,7 +162,20 @@ func (c *Client) DeleteInstance(ctx context.Context, name string) error {
 	return nil
 }
 
-func sanitizeInstanceName(name string) string {
-	name = strings.ToLower(name)
-	return strings.ReplaceAll(name, "/", "-")
+func (c *Client) ExtendLease(ctx context.Context, name string, extendTime time.Time) (*Instance, error) {
+	req := newRequestWithToken(c.token, &cloudapiv1.UpdateInstanceLeaseRequest{
+		Name:        name,
+		Environment: DevEnvironment,
+		Lease: &timestamppb.Timestamp{
+			Seconds: extendTime.Unix(),
+			Nanos:   0,
+		},
+	})
+
+	resp, err := c.client.UpdateInstanceLease(ctx, req)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to extend lease for instance %q", name)
+	}
+
+	return newInstance(resp.Msg.GetInstance())
 }

--- a/dev/sg/internal/cloud/common.go
+++ b/dev/sg/internal/cloud/common.go
@@ -16,6 +16,7 @@ import (
 var ErrUserCancelled = errors.New("user cancelled")
 var ErrWrongBranch = errors.New("wrong current branch")
 var ErrBranchOutOfSync = errors.New("branch is out of sync with remote")
+var ErrNotEphemeralInstance = errors.New("instance is not ephemeral")
 
 const CloudEmoji = "☁️"
 

--- a/dev/sg/internal/cloud/common.go
+++ b/dev/sg/internal/cloud/common.go
@@ -1,0 +1,77 @@
+package cloud
+
+import (
+	"context"
+	"strings"
+
+	"github.com/sourcegraph/run"
+	"github.com/urfave/cli/v2"
+
+	"github.com/sourcegraph/sourcegraph/dev/sg/internal/repo"
+	"github.com/sourcegraph/sourcegraph/dev/sg/internal/std"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"github.com/sourcegraph/sourcegraph/lib/output"
+)
+
+var ErrUserCancelled = errors.New("user cancelled")
+var ErrWrongBranch = errors.New("wrong current branch")
+var ErrBranchOutOfSync = errors.New("branch is out of sync with remote")
+
+const CloudEmoji = "☁️"
+
+func sanitizeInstanceName(name string) string {
+	name = strings.ToLower(name)
+	return strings.ReplaceAll(name, "/", "-")
+}
+
+func inferInstanceNameFromBranch(ctx context.Context) (string, error) {
+	currentBranch, err := repo.GetCurrentBranch(ctx)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to determine current branch")
+	}
+	return sanitizeInstanceName(currentBranch), nil
+}
+
+func wipAction(actionFn cli.ActionFunc) cli.ActionFunc {
+	if actionFn == nil {
+		return nil
+	}
+	return func(ctx *cli.Context) error {
+		if err := printWIPNotice(ctx); err != nil {
+			return err
+		}
+
+		return actionFn(ctx)
+	}
+}
+
+func printWIPNotice(ctx *cli.Context) error {
+	if ctx.Bool("skip-wip-notice") {
+		return nil
+	}
+	notice := output.Line("🧪", output.StyleBold, "EXPERIMENTAL COMMAND - Do you want to continue? (yes/no)")
+
+	var answer string
+	if _, err := std.FancyPromptAndScan(std.Out, notice, &answer); err != nil {
+		return err
+	}
+
+	if oneOfEquals(answer, "yes", "y") {
+		return nil
+	}
+
+	return ErrUserCancelled
+}
+
+func oneOfEquals(value string, i ...string) bool {
+	for _, item := range i {
+		if value == item {
+			return true
+		}
+	}
+	return false
+}
+
+func getGCloudAccount(ctx context.Context) (string, error) {
+	return run.Cmd(ctx, "gcloud", "config", "get", "account").Run().String()
+}

--- a/dev/sg/internal/cloud/delete_command.go
+++ b/dev/sg/internal/cloud/delete_command.go
@@ -55,8 +55,7 @@ func deleteCloudEphemeral(ctx *cli.Context) error {
 		return ErrUserCancelled
 	}
 
-	cloudEmoji := "☁️"
-	pending := std.Out.Pending(output.Linef(cloudEmoji, output.StylePending, "Deleting ephemeral instance %q", name))
+	pending := std.Out.Pending(output.Linef(CloudEmoji, output.StylePending, "Deleting ephemeral instance %q", name))
 	err = cloudClient.DeleteInstance(ctx.Context, name)
 	if err != nil {
 		pending.Complete(output.Linef(output.EmojiFailure, output.StyleFailure, "deleting of %q failed", name))

--- a/dev/sg/internal/cloud/deploy_command.go
+++ b/dev/sg/internal/cloud/deploy_command.go
@@ -166,7 +166,7 @@ func createDeploymentForVersion(ctx context.Context, name, version string) error
 	}
 
 	pending.Writef("Deploy instance details: \n%s", inst.String())
-	pending.Complete(output.Linef(output.EmojiSuccess, output.StyleSuccess, "Deployment %q created for version %q - access at: %s", name, version, inst.Hostname))
+	pending.Complete(output.Linef(output.EmojiSuccess, output.StyleSuccess, "Deployment %q created for version %q - access at: %s", name, version, inst.URL))
 	return nil
 }
 

--- a/dev/sg/internal/cloud/deploy_command.go
+++ b/dev/sg/internal/cloud/deploy_command.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/buildkite/go-buildkite/v3/buildkite"
-	"github.com/sourcegraph/run"
 	"github.com/urfave/cli/v2"
 
 	"github.com/sourcegraph/sourcegraph/dev/ci/gitops"
@@ -18,10 +17,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/output"
 	"github.com/sourcegraph/sourcegraph/lib/pointers"
 )
-
-var ErrUserCancelled = errors.New("user cancelled")
-var ErrWrongBranch = errors.New("wrong current branch")
-var ErrBranchOutOfSync = errors.New("branch is out of sync with remote")
 
 var DeployEphemeralCommand = cli.Command{
 	Name:        "deploy",
@@ -70,19 +65,6 @@ func determineVersion(build *buildkite.Build, tag string) (string, error) {
 	), nil
 }
 
-func oneOfEquals(value string, i ...string) bool {
-	for _, item := range i {
-		if value == item {
-			return true
-		}
-	}
-	return false
-}
-
-func getGCloudAccount(ctx context.Context) (string, error) {
-	return run.Cmd(ctx, "gcloud", "config", "get", "account").Run().String()
-}
-
 func triggerEphemeralBuild(ctx context.Context, currRepo *repo.GitRepo) (*buildkite.Build, error) {
 	pending := std.Out.Pending(output.Linef("🔨", output.StylePending, "Checking if branch %q is up to date with remote", currRepo.Branch))
 	if isOutOfSync, err := currRepo.IsOutOfSync(ctx); err != nil {
@@ -108,37 +90,6 @@ func triggerEphemeralBuild(ctx context.Context, currRepo *repo.GitRepo) (*buildk
 	return build, nil
 }
 
-func wipAction(actionFn cli.ActionFunc) cli.ActionFunc {
-	if actionFn == nil {
-		return nil
-	}
-	return func(ctx *cli.Context) error {
-		if err := printWIPNotice(ctx); err != nil {
-			return err
-		}
-
-		return actionFn(ctx)
-	}
-}
-
-func printWIPNotice(ctx *cli.Context) error {
-	if ctx.Bool("skip-wip-notice") {
-		return nil
-	}
-	notice := output.Line("🧪", output.StyleBold, "EXPERIMENTAL COMMAND - Do you want to continue? (yes/no)")
-
-	var answer string
-	if _, err := std.FancyPromptAndScan(std.Out, notice, &answer); err != nil {
-		return err
-	}
-
-	if oneOfEquals(answer, "yes", "y") {
-		return nil
-	}
-
-	return ErrUserCancelled
-}
-
 func createDeploymentForVersion(ctx context.Context, name, version string) error {
 	email, err := GetGCloudAccount(ctx)
 	if err != nil {
@@ -156,7 +107,7 @@ func createDeploymentForVersion(ctx context.Context, name, version string) error
 	pending := std.Out.Pending(output.Linef(cloudEmoji, output.StylePending, "Creating deployment %q for version %q", name, version))
 
 	spec := NewDeploymentSpec(
-		name,
+		sanitizeInstanceName(name),
 		version,
 	)
 	inst, err := cloudClient.CreateInstance(ctx, spec)
@@ -171,10 +122,6 @@ func createDeploymentForVersion(ctx context.Context, name, version string) error
 }
 
 func deployCloudEphemeral(ctx *cli.Context) error {
-	// while we work on this command we print a notice and ask to continue
-	if err := printWIPNotice(ctx); err != nil {
-		return err
-	}
 	currentBranch, err := repo.GetCurrentBranch(ctx.Context)
 	if err != nil {
 		return errors.Wrap(err, "failed to determine current branch")

--- a/dev/sg/internal/cloud/deploy_command.go
+++ b/dev/sg/internal/cloud/deploy_command.go
@@ -3,6 +3,7 @@ package cloud
 import (
 	"cmp"
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/buildkite/go-buildkite/v3/buildkite"
@@ -114,7 +115,7 @@ func createDeploymentForVersion(ctx context.Context, name, version string) error
 }
 
 func watchBuild(ctx context.Context, bkClient *bk.Client, build *buildkite.Build, tickEverySec int) (*buildkite.Build, error) {
-	pipeline := pointers.DerefZero(build.Pipeline.ID)
+	pipeline := pointers.DerefZero(build.Pipeline.Slug)
 	number := fmt.Sprintf("%d", pointers.DerefZero(build.Number))
 	pending := std.Out.Pending(output.Linef("🔨", output.StylePending, "Waiting for build %s to complete", number))
 

--- a/dev/sg/internal/cloud/deploy_command.go
+++ b/dev/sg/internal/cloud/deploy_command.go
@@ -135,11 +135,11 @@ tickLoop:
 
 		switch state {
 		case "success":
-			pending.Complete(output.Linef(output.EmojiSuccess, output.StyleSuccess, "Build %s is commplete", number))
+			pending.Complete(output.Linef(output.EmojiSuccess, output.StyleSuccess, "Build %s completed", number))
 			break tickLoop
 		case "failed":
-			pending.Complete(output.Linef(output.EmojiFailure, output.StyleFailure, "Build %s has failed", number))
-			buildError = errors.Newf("build %s has failed", number)
+			pending.Complete(output.Linef(output.EmojiFailure, output.StyleFailure, "Build %s failed", number))
+			buildError = errors.Newf("build %s failed", number)
 			break tickLoop
 		default:
 			pending.Updatef("Build %s still in progress ...", number)
@@ -187,7 +187,7 @@ func deployCloudEphemeral(ctx *cli.Context) error {
 	if version == "" {
 		build, err := triggerAndWaitEphemeralBuild(ctx.Context, currRepo)
 		if err != nil {
-			std.Out.WriteFailuref("A problem occured during the ephemeral build")
+			std.Out.WriteFailuref("Cannot start deployment as there was problem with the ephemeral build")
 			return err
 		}
 		version, err = determineVersion(build, ctx.String("tag"))

--- a/dev/sg/internal/cloud/instance.go
+++ b/dev/sg/internal/cloud/instance.go
@@ -214,7 +214,7 @@ func (f *InstanceFeatures) IsEphemeralInstance() bool {
 }
 
 func (f *InstanceFeatures) SetEphemeralInstance(v bool) {
-	f.features["ephemeral_instance"] = strconv.FormatBool(v)
+	f.features["ephemeral"] = strconv.FormatBool(v)
 }
 
 func (f *InstanceFeatures) SetEphemeralLeaseTime(expiresAt time.Time) {

--- a/dev/sg/internal/cloud/instance.go
+++ b/dev/sg/internal/cloud/instance.go
@@ -90,17 +90,6 @@ type InstanceFeatures struct {
 	features map[string]string
 }
 
-type InstanceLease struct {
-	ExpiresAt *time.Time `json:"expiresAt,omitempty"`
-}
-
-func (l *InstanceLease) String() string {
-	if l.ExpiresAt == nil {
-		return ""
-	}
-	return l.ExpiresAt.Format(time.RFC3339)
-}
-
 func newInstanceStatus(src *cloudapiv1.InstanceState) (*InstanceStatus, error) {
 	url, reason, err := parseStatusReason(src.GetReason())
 	if err != nil {

--- a/dev/sg/internal/cloud/instance.go
+++ b/dev/sg/internal/cloud/instance.go
@@ -159,16 +159,22 @@ func parseStatusReason(reason string) (string, string, error) {
 	if len(parts) != 2 {
 		return "", "", errors.Newf("invalid status reason format: %q", reason)
 	}
-	keyValue := strings.Split(parts[0], ":")
-	if len(keyValue) != 2 {
-		return "", "", errors.Newf("invalid field value at pos 0 in reason: %q", reason)
+	fieldValue := func(s string) (string, error) {
+		colonIdx := strings.Index(s, ":")
+		if colonIdx == -1 {
+			return "", errors.Newf("invalid field format %q", s)
+		}
+		return s[colonIdx+1:], nil
 	}
-	url := keyValue[1]
-	keyValue = strings.Split(parts[1], ":")
-	if len(keyValue) != 2 {
-		return "", "", errors.Newf("invalid field value at pos 0 in reason: %q", reason)
+
+	url, err := fieldValue(parts[0])
+	if err != nil {
+		return "", "", errors.Wrapf(err, "field error at pos 0")
 	}
-	status := keyValue[1]
+	status, err := fieldValue(parts[1])
+	if err != nil {
+		return "", "", errors.Wrapf(err, "field error at pos 1")
+	}
 
 	return url, status, nil
 }

--- a/dev/sg/internal/cloud/instance.go
+++ b/dev/sg/internal/cloud/instance.go
@@ -32,9 +32,9 @@ type Instance struct {
 	AdminEmail   string `json:"adminEmail"`
 	Features     *InstanceFeatures
 
-	CreatedAt time.Time      `json:"createdAt"`
-	DeletedAt time.Time      `json:"deletedAt"`
-	Lease     *InstanceLease `json:"lease"`
+	CreatedAt time.Time `json:"createdAt"`
+	DeletedAt time.Time `json:"deletedAt"`
+	ExpiresAt time.Time `json:"ExpiresAt"`
 
 	Project string         `json:"project"`
 	Region  string         `json:"region"`
@@ -60,7 +60,7 @@ Status       : %s
 ActionURL    : %s
 Error        : %s
 `, i.ID, i.Name, i.InstanceType, i.Environment, i.Version, i.URL, i.AdminEmail,
-		i.CreatedAt.Format(time.RFC3339), i.DeletedAt.Format(time.RFC3339), i.Lease, i.Project, i.Region,
+		i.CreatedAt.Format(time.RFC3339), i.DeletedAt.Format(time.RFC3339), i.ExpiresAt.Format(time.RFC3339), i.Project, i.Region,
 		i.Status.Status, i.Status.ActionURL, i.Status.Error)
 }
 
@@ -73,25 +73,11 @@ func (i *Instance) IsInternal() bool {
 }
 
 func (i *Instance) IsExpired() bool {
-	t, err := i.GetExpiry()
-	if err != nil || t.IsZero() {
+	if i.ExpiresAt.IsZero() {
 		return false
 	}
 
-	return time.Now().After(*t)
-}
-
-func (i *Instance) GetExpiry() (*time.Time, error) {
-	t, err := i.features.GetEphemeralLeaseTime()
-	if err != nil {
-		return nil, err
-	}
-
-	return t, nil
-}
-
-func (i *Instance) SetExpiry(expiresAt time.Time) {
-	i.features.SetEphemeralLeaseTime(expiresAt)
+	return time.Now().After(i.ExpiresAt)
 }
 
 type InstanceStatus struct {
@@ -153,7 +139,6 @@ func newInstance(src *cloudapiv1.Instance) (*Instance, error) {
 	if err != nil && !errors.Is(err, ErrLeaseTimeNotSet) {
 		return nil, err
 	}
-	lease := &InstanceLease{ExpiresAt: expiresAt}
 
 	instanceType := InternalInstanceType
 	if features.IsEphemeralInstance() {
@@ -169,10 +154,10 @@ func newInstance(src *cloudapiv1.Instance) (*Instance, error) {
 		AdminEmail:   pointers.DerefZero(details.AdminEmail),
 		CreatedAt:    platform.GetCreatedAt().AsTime(),
 		DeletedAt:    platform.GetDeletedAt().AsTime(),
+		ExpiresAt:    expiresAt,
 		Project:      platform.GetGcpProjectId(),
 		Region:       platform.GetGcpRegion(),
 		Status:       *status,
-		Lease:        lease,
 		features:     features,
 	}, nil
 }
@@ -247,17 +232,17 @@ func (f *InstanceFeatures) SetEphemeralLeaseTime(expiresAt time.Time) {
 	f.features["ephemeral_instance_lease_time"] = strconv.FormatInt(expiresAt.Unix(), 10)
 }
 
-func (f *InstanceFeatures) GetEphemeralLeaseTime() (*time.Time, error) {
+func (f *InstanceFeatures) GetEphemeralLeaseTime() (time.Time, error) {
 	seconds, ok := f.features["ephemeral_instance_lease_time"]
 	if !ok {
-		return nil, ErrLeaseTimeNotSet
+		return time.Time{}, ErrLeaseTimeNotSet
 	}
 	secondsInt, err := strconv.ParseInt(seconds, 10, 64)
 	if err != nil {
-		return nil, errors.Newf("failed to convert 'ephemeral_instance_lease_time' value %q to int64: %v", seconds, err)
+		return time.Time{}, errors.Newf("failed to convert 'ephemeral_instance_lease_time' value %q to int64: %v", seconds, err)
 	}
 	leaseTime := time.Unix(secondsInt, 0)
-	return &leaseTime, nil
+	return leaseTime, nil
 }
 
 func (f *InstanceFeatures) Value() map[string]string {

--- a/dev/sg/internal/cloud/instance.go
+++ b/dev/sg/internal/cloud/instance.go
@@ -68,6 +68,32 @@ func (i *Instance) IsEphemeral() bool {
 	return i.InstanceType == EphemeralInstanceType
 }
 
+func (i *Instance) IsInternal() bool {
+	return i.InstanceType == InternalInstanceType
+}
+
+func (i *Instance) IsExpired() bool {
+	t, err := i.GetExpiry()
+	if err != nil || t.IsZero() {
+		return false
+	}
+
+	return time.Now().After(*t)
+}
+
+func (i *Instance) GetExpiry() (*time.Time, error) {
+	t, err := i.features.GetEphemeralLeaseTime()
+	if err != nil {
+		return nil, err
+	}
+
+	return t, nil
+}
+
+func (i *Instance) SetExpiry(expiresAt time.Time) {
+	i.features.SetEphemeralLeaseTime(expiresAt)
+}
+
 type InstanceStatus struct {
 	Status    string `json:"status"`
 	ActionURL string `json:"actionUrl"`
@@ -215,6 +241,10 @@ func (f *InstanceFeatures) IsEphemeralInstance() bool {
 
 func (f *InstanceFeatures) SetEphemeralInstance(v bool) {
 	f.features["ephemeral_instance"] = strconv.FormatBool(v)
+}
+
+func (f *InstanceFeatures) SetEphemeralLeaseTime(expiresAt time.Time) {
+	f.features["ephemeral_instance_lease_time"] = strconv.FormatInt(expiresAt.Unix(), 10)
 }
 
 func (f *InstanceFeatures) GetEphemeralLeaseTime() (*time.Time, error) {

--- a/dev/sg/internal/cloud/instance_test.go
+++ b/dev/sg/internal/cloud/instance_test.go
@@ -1,64 +1,90 @@
 package cloud
 
 import (
+	"strconv"
+	"strings"
 	"testing"
+	"time"
 
 	cloudapiv1 "github.com/sourcegraph/cloud-api/go/cloudapi/v1"
 )
 
 func TestInstanceStatus(t *testing.T) {
 	tt := []struct {
-		name      string
-		actionURL string
-		status    string
-		reason    string
-		errText   string
+		name       string
+		actionURL  string
+		statusEnum cloudapiv1.InstanceStatus
+		statusText string
+		reason     string
+		errText    string
 	}{
 		{
-			name:      "failed with actionURL and status",
-			actionURL: "http://test.com/action/123",
-			status:    "failed",
-			reason:    "url:http://test.com/action/123, status: failed",
+			name:       "failed with actionURL and status",
+			actionURL:  "http://test.com/action/123",
+			statusEnum: cloudapiv1.InstanceStatus_INSTANCE_STATUS_FAILED,
+			statusText: "failed",
+			reason:     "url:http://test.com/action/123, status: failed",
 		},
 		{
-			name:      "completed with no actionURL and no status",
-			actionURL: "",
-			status:    "",
-			reason:    "",
+			name:       "completed with no actionURL and no status",
+			actionURL:  "",
+			statusEnum: cloudapiv1.InstanceStatus_INSTANCE_STATUS_OK,
+			statusText: "completed",
+			reason:     "",
 		},
 		{
 			name:    "incorrect reason format",
 			reason:  "https://test.com/action/123",
-			errText: "invalid satus reason format",
+			errText: "invalid status reason format",
 		},
 		{
 			name:    "incorrect reason field format",
 			reason:  "actionURL=https://test.com/action/123, status=completed",
-			errText: "invalid field value",
+			errText: "field error",
 		},
 	}
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
 			src := &cloudapiv1.InstanceState{
-				InstanceStatus: cloudapiv1.InstanceStatus_INSTANCE_STATUS_FAILED,
+				InstanceStatus: tc.statusEnum,
 				Reason:         &tc.reason,
 			}
 
 			instanceSatus, err := newInstanceStatus(src)
 			if err != nil {
-				if tc.errText == "" || !strings.Contains(err.Error(), tc.errText) {
-					t.Errorf("incorrect error. want=%s have=%s", tc.errText, err.Error())
-				} else {
+				if tc.errText == "" {
 					t.Fatal(err)
+				} else if !strings.Contains(err.Error(), tc.errText) {
+					t.Errorf("incorrect error. want=%s have=%s", tc.errText, err.Error())
 				}
+				return
 			}
 
 			if instanceSatus.ActionURL != tc.actionURL {
 				t.Errorf("incorrect action url. want=%s have=%s", tc.actionURL, instanceSatus.ActionURL)
 			}
-			if instanceSatus.Status != tc.status {
-				t.Errorf("incorrect status. want=%s have=%s", tc.status, instanceSatus.Status)
+			if instanceSatus.Status != tc.statusText {
+				t.Errorf("incorrect status. want=%s have=%s", tc.statusText, instanceSatus.Status)
 			}
 		})
+	}
+}
+
+func TestInstanceFeatures(t *testing.T) {
+	now := time.Now()
+	features := newInstanceFeaturesFrom(map[string]string{
+		"ephemeral_instance":            "true",
+		"ephemeral_instance_lease_time": strconv.FormatInt(now.Unix(), 10),
+	})
+
+	if !features.IsEphemeralInstance() {
+		t.Errorf("expected ephemeral instance to be true")
+	}
+	lease, err := features.GetEphemeralLeaseTime()
+	if err != nil {
+		t.Fatalf("failed to instance lease time: %v", err)
+	}
+	if lease.Unix() != now.Unix() {
+		t.Errorf("expected lease to be %d, got %d", now.Unix(), lease.Unix())
 	}
 }

--- a/dev/sg/internal/cloud/instance_test.go
+++ b/dev/sg/internal/cloud/instance_test.go
@@ -1,0 +1,64 @@
+package cloud
+
+import (
+	"testing"
+
+	cloudapiv1 "github.com/sourcegraph/cloud-api/go/cloudapi/v1"
+)
+
+func TestInstanceStatus(t *testing.T) {
+	tt := []struct {
+		name      string
+		actionURL string
+		status    string
+		reason    string
+		errText   string
+	}{
+		{
+			name:      "failed with actionURL and status",
+			actionURL: "http://test.com/action/123",
+			status:    "failed",
+			reason:    "url:http://test.com/action/123, status: failed",
+		},
+		{
+			name:      "completed with no actionURL and no status",
+			actionURL: "",
+			status:    "",
+			reason:    "",
+		},
+		{
+			name:    "incorrect reason format",
+			reason:  "https://test.com/action/123",
+			errText: "invalid satus reason format",
+		},
+		{
+			name:    "incorrect reason field format",
+			reason:  "actionURL=https://test.com/action/123, status=completed",
+			errText: "invalid field value",
+		},
+	}
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			src := &cloudapiv1.InstanceState{
+				InstanceStatus: cloudapiv1.InstanceStatus_INSTANCE_STATUS_FAILED,
+				Reason:         &tc.reason,
+			}
+
+			instanceSatus, err := newInstanceStatus(src)
+			if err != nil {
+				if tc.errText == "" || !strings.Contains(err.Error(), tc.errText) {
+					t.Errorf("incorrect error. want=%s have=%s", tc.errText, err.Error())
+				} else {
+					t.Fatal(err)
+				}
+			}
+
+			if instanceSatus.ActionURL != tc.actionURL {
+				t.Errorf("incorrect action url. want=%s have=%s", tc.actionURL, instanceSatus.ActionURL)
+			}
+			if instanceSatus.Status != tc.status {
+				t.Errorf("incorrect status. want=%s have=%s", tc.status, instanceSatus.Status)
+			}
+		})
+	}
+}

--- a/dev/sg/internal/cloud/lease_command.go
+++ b/dev/sg/internal/cloud/lease_command.go
@@ -1,0 +1,92 @@
+package cloud
+
+import (
+	"time"
+
+	"github.com/urfave/cli/v2"
+
+	"github.com/sourcegraph/sourcegraph/dev/sg/internal/std"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"github.com/sourcegraph/sourcegraph/lib/output"
+)
+
+const MaxDuration = time.Hour * 24 * 4
+
+var ExtendLeaseEphemeralCommand = cli.Command{
+	Name:        "extend-lease",
+	ArgsUsage:   "sg cloud extend-lease [--name instance-name] <duration>",
+	Description: "extend the lease of the instance for the given duration (max 4 days)",
+	Action:      wipAction(extendLeaseCloudEphemeral),
+	Flags: []cli.Flag{
+		&cli.StringFlag{
+			Name:        "name",
+			DefaultText: "name of the instance to extend lease for",
+		},
+	},
+}
+
+func printLeaseTimeDiff(oldTime, newTime time.Time) {
+	std.Out.Write("Updating instance lease with the following values:")
+	std.Out.WriteLine(output.Linef("", output.StyleRed, "- Lease time %s", oldTime.Format(time.RFC3339)))
+	std.Out.WriteLine(output.Linef("", output.StyleGreen, "+ Lease time %s", newTime.Format(time.RFC3339)))
+	std.Out.Write("\n")
+}
+
+func extendLeaseCloudEphemeral(ctx *cli.Context) error {
+	if ctx.Args().Len() != 1 {
+		return errors.New("no duration provided")
+	}
+	duration, err := time.ParseDuration(ctx.Args().First())
+	if err != nil {
+		return errors.Wrapf(err, "failed to parse duration %q", ctx.Args().First())
+	}
+
+	if duration > MaxDuration {
+		std.Out.Writef("duration %s is greater than max duration %s, setting to max duration", duration, MaxDuration)
+		duration = MaxDuration
+	}
+
+	email, err := GetGCloudAccount(ctx.Context)
+	if err != nil {
+		return err
+	}
+
+	cloudClient, err := NewClient(ctx.Context, email, APIEndpoint)
+	if err != nil {
+		return err
+	}
+	name := ctx.String("name")
+	if name == "" {
+		n, err := inferInstanceNameFromBranch(ctx.Context)
+		if err != nil {
+			return err
+		}
+		name = n
+	}
+
+	pending := std.Out.Pending(output.Linef(CloudEmoji, output.StylePending, "Getting instance with name %q", name))
+	inst, err := cloudClient.GetInstance(ctx.Context, name)
+	if err != nil {
+		pending.Complete(output.Linef(output.EmojiFailure, output.StyleFailure, "failed to get instance"))
+		return err
+	}
+	pending.Complete(output.Linef(CloudEmoji, output.StyleSuccess, "Fetched instance with name %q", name))
+
+	pending = std.Out.Pending(output.Linef(CloudEmoji, output.StylePending, "Extending lease of instance %q by %s", name, duration))
+
+	current, err := inst.GetExpiry()
+	if err != nil {
+		errors.Wrap(err, "failed to get instance lease expiry")
+	}
+
+	leaseEndTime := current.Add(duration)
+	printLeaseTimeDiff(*current, leaseEndTime)
+	inst, err = cloudClient.ExtendLease(ctx.Context, name, leaseEndTime)
+	if err != nil {
+		pending.Complete(output.Linef(output.EmojiFailure, output.StyleFailure, "failed to extend lease"))
+	}
+
+	pending.Complete(output.Linef(CloudEmoji, output.StyleSuccess, "Lease of instance %q extended by %s", name, duration))
+	newDefaultTerminalInstancePrinter().Print(inst)
+	return nil
+}

--- a/dev/sg/internal/cloud/lease_command.go
+++ b/dev/sg/internal/cloud/lease_command.go
@@ -14,21 +14,23 @@ const MaxDuration = time.Hour * 24 * 4
 
 var LeaseEphemeralCommand = cli.Command{
 	Name:        "lease",
-	ArgsUsage:   "sg cloud lease [--name instance-name] <duration>",
+	Usage:       "extend or reduce the lease of an ephemeral instance",
+	UsageText:   "sg cloud lease [command options]",
 	Description: "extend the lease of the instance for the given duration (max 4 days)",
 	Action:      wipAction(leaseCloudEphemeral),
 	Flags: []cli.Flag{
 		&cli.StringFlag{
 			Name:        "name",
-			DefaultText: "name of the instance to extend lease for",
+			Usage:       "name of the instance to extend lease for",
+			DefaultText: "current branch name will be used",
 		},
 		&cli.DurationFlag{
-			Name:        "extend",
-			DefaultText: "the duration to extend the lease by (max 4 days = 96h)",
+			Name:  "extend",
+			Usage: "the duration to extend the lease by (max 4 days = 96h)",
 		},
 		&cli.DurationFlag{
-			Name:        "reduce",
-			DefaultText: "the duration to reduce the lease by - if the lease time is reduced to be in the passed the instance will be deleted!",
+			Name:  "reduce",
+			Usage: "the duration to reduce the lease by - if the lease time is reduced to be in the passed the instance will be deleted!",
 		},
 	},
 }

--- a/dev/sg/internal/cloud/list_command.go
+++ b/dev/sg/internal/cloud/list_command.go
@@ -1,11 +1,14 @@
 package cloud
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/urfave/cli/v2"
 
+	"github.com/sourcegraph/sourcegraph/dev/sg/internal/std"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"github.com/sourcegraph/sourcegraph/lib/output"
 )
 
 var ListEphemeralCommand = cli.Command{
@@ -40,10 +43,18 @@ func listCloudEphemeral(ctx *cli.Context) error {
 		return err
 	}
 
+	msg := "Fetching list of instances..."
+	if !ctx.Bool("all") {
+		msg = fmt.Sprintf("Fetching list of instances attached to your GCP account %q", email)
+	}
+
+	pending := std.Out.Pending(output.Linef(CloudEmoji, output.StylePending, msg))
 	instances, err := cloudClient.ListInstances(ctx.Context, ctx.Bool("all"))
 	if err != nil {
+		pending.Complete(output.Linef(CloudEmoji, output.StyleFailure, "failed to list instances: %v", err))
 		return errors.Wrapf(err, "failed to list instances %v", err)
 	}
+	pending.Complete(output.Linef(CloudEmoji, output.StyleSuccess, "Fetched %d instances", len(instances)))
 	var printer Printer
 	switch {
 	case ctx.Bool("json"):

--- a/dev/sg/internal/cloud/list_versions_command.go
+++ b/dev/sg/internal/cloud/list_versions_command.go
@@ -126,14 +126,13 @@ func listTagsCloudEphemeral(ctx *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	cloudEmoji := "☁️"
-	pending := std.Out.Pending(output.Linef(cloudEmoji, output.StylePending, "Retrieving docker images from registry %q", ar.RepositoryName))
+	pending := std.Out.Pending(output.Linef(CloudEmoji, output.StylePending, "Retrieving docker images from registry %q", ar.RepositoryName))
 	images, err := ar.ListDockerImages(ctx.Context)
 	if err != nil {
 		pending.Complete(output.Linef(output.EmojiFailure, output.StyleFailure, "failed to retreive images from registry %q", ar.RepositoryName))
 		return err
 	}
-	pending.Complete(output.Linef(cloudEmoji, output.StyleSuccess, "Retrieved %d docker images from registry %q", len(images), ar.RepositoryName))
+	pending.Complete(output.Linef(CloudEmoji, output.StyleSuccess, "Retrieved %d docker images from registry %q", len(images), ar.RepositoryName))
 
 	imagesByTag := map[string][]*DockerImage{}
 	for _, image := range images {

--- a/dev/sg/internal/cloud/list_versions_command.go
+++ b/dev/sg/internal/cloud/list_versions_command.go
@@ -49,7 +49,7 @@ func listTagsCloudEphemeral(ctx *cli.Context) error {
 	pending := std.Out.Pending(output.Linef(CloudEmoji, output.StylePending, "Retrieving docker images from registry %q", ar.RepositoryName))
 	images, err := ar.ListDockerImages(ctx.Context)
 	if err != nil {
-		pending.Complete(output.Linef(output.EmojiFailure, output.StyleFailure, "failed to retreive images from registry %q", ar.RepositoryName))
+		pending.Complete(output.Linef(output.EmojiFailure, output.StyleFailure, "Failed to retreive images from registry %q", ar.RepositoryName))
 		return err
 	}
 	pending.Complete(output.Linef(CloudEmoji, output.StyleSuccess, "Retrieved %d docker images from registry %q", len(images), ar.RepositoryName))

--- a/dev/sg/internal/cloud/printers.go
+++ b/dev/sg/internal/cloud/printers.go
@@ -34,7 +34,7 @@ func newDefaultTerminalInstancePrinter() *terminalInstancePrinter {
 			name = name[:20]
 		}
 
-		status := inst.Status
+		status := inst.Status.Status
 		createdAt := inst.CreatedAt.String()
 
 		return []any{
@@ -42,7 +42,7 @@ func newDefaultTerminalInstancePrinter() *terminalInstancePrinter {
 		}
 
 	}
-	return newTerminalInstancePrinter(valueFunc, "%-20s %-11s %s", "Name", "Status", "Created At")
+	return newTerminalInstancePrinter(valueFunc, "%-40s %-11s %s", "Name", "Status", "Created At")
 }
 
 func newTerminalInstancePrinter(valueFunc func(i *Instance) []any, headingFmt string, headings ...string) *terminalInstancePrinter {
@@ -63,7 +63,7 @@ func (p *terminalInstancePrinter) Print(items ...*Instance) error {
 	std.Out.WriteLine(output.Line("", output.StyleBold, heading))
 	for _, inst := range items {
 		values := p.valueFunc(inst)
-		line := fmt.Sprintf("%-20s %-11s %s", values...)
+		line := fmt.Sprintf("%-40s %-11s %s", values...)
 		std.Out.WriteLine(output.Line("", output.StyleGrey, line))
 	}
 	return nil

--- a/dev/sg/internal/cloud/printers.go
+++ b/dev/sg/internal/cloud/printers.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"time"
 
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/std"
 	"github.com/sourcegraph/sourcegraph/lib/output"
@@ -35,14 +36,17 @@ func newDefaultTerminalInstancePrinter() *terminalInstancePrinter {
 		}
 
 		status := inst.Status.Status
-		createdAt := inst.CreatedAt.String()
+		expiresAt := "n/a"
+		if inst.Lease != nil {
+			expiresAt = inst.Lease.ExpiresAt.Format(time.RFC3339)
+		}
 
 		return []any{
-			name, status, createdAt,
+			name, status, expiresAt,
 		}
 
 	}
-	return newTerminalInstancePrinter(valueFunc, "%-40s %-11s %s", "Name", "Status", "Created At")
+	return newTerminalInstancePrinter(valueFunc, "%-40s %-11s %s", "Name", "Status", "Expires At")
 }
 
 func newTerminalInstancePrinter(valueFunc func(i *Instance) []any, headingFmt string, headings ...string) *terminalInstancePrinter {

--- a/dev/sg/internal/cloud/printers.go
+++ b/dev/sg/internal/cloud/printers.go
@@ -37,8 +37,8 @@ func newDefaultTerminalInstancePrinter() *terminalInstancePrinter {
 
 		status := inst.Status.Status
 		expiresAt := "n/a"
-		if inst.Lease != nil {
-			expiresAt = inst.Lease.ExpiresAt.Format(time.RFC3339)
+		if !inst.ExpiresAt.IsZero() {
+			expiresAt = inst.ExpiresAt.Format(time.RFC3339)
 		}
 
 		return []any{

--- a/dev/sg/internal/cloud/status_command.go
+++ b/dev/sg/internal/cloud/status_command.go
@@ -53,8 +53,7 @@ func statusCloudEphemeral(ctx *cli.Context) error {
 	}
 	name = sanitizeInstanceName(name)
 
-	cloudEmoji := "☁️"
-	pending := std.Out.Pending(output.Linef(cloudEmoji, output.StylePending, "Getting status of ephemeral instance %q", name))
+	pending := std.Out.Pending(output.Linef(CloudEmoji, output.StylePending, "Getting status of ephemeral instance %q", name))
 	inst, err := cloudClient.GetInstance(ctx.Context, name)
 	if err != nil {
 		pending.Complete(output.Linef(output.EmojiFailure, output.StyleFailure, "getting status of %q failed", name))

--- a/dev/sg/sg_cloud.go
+++ b/dev/sg/sg_cloud.go
@@ -47,7 +47,7 @@ var cloudCommand = &cli.Command{
 		},
 		&cloud.DeleteEphemeralCommand,
 		&cloud.DeployEphemeralCommand,
-		&cloud.ExtendLeaseEphemeralCommand,
+		&cloud.LeaseEphemeralCommand,
 		&cloud.ListEphemeralCommand,
 		&cloud.ListVersionsEphemeralCommand,
 		&cloud.StatusEphemeralCommand,

--- a/dev/sg/sg_cloud.go
+++ b/dev/sg/sg_cloud.go
@@ -45,11 +45,12 @@ var cloudCommand = &cli.Command{
 				return nil
 			},
 		},
+		&cloud.DeleteEphemeralCommand,
 		&cloud.DeployEphemeralCommand,
+		&cloud.ExtendLeaseEphemeralCommand,
 		&cloud.ListEphemeralCommand,
 		&cloud.ListVersionsEphemeralCommand,
 		&cloud.StatusEphemeralCommand,
-		&cloud.DeleteEphemeralCommand,
 	},
 }
 

--- a/go.mod
+++ b/go.mod
@@ -278,7 +278,7 @@ require (
 	github.com/pkoukk/tiktoken-go v0.1.6
 	github.com/pkoukk/tiktoken-go-loader v0.0.1
 	github.com/prometheus/statsd_exporter v0.22.7
-	github.com/sourcegraph/cloud-api v0.0.0-20240423104735-5602ff6597cc
+	github.com/sourcegraph/cloud-api v0.0.0-20240501113836-ecd1d4cba9dd
 	github.com/sourcegraph/log/logr v0.0.0-20240425170707-431bcb6c8668
 	github.com/sourcegraph/managed-services-platform-cdktf/gen/cloudflare v0.0.0-20230822024612-edb48c530722
 	github.com/sourcegraph/managed-services-platform-cdktf/gen/google v0.0.0-20240424172240-25e368a6e822

--- a/go.sum
+++ b/go.sum
@@ -1681,8 +1681,8 @@ github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
 github.com/sourcegraph/alertmanager v0.21.1-0.20211110092431-863f5b1ee51b h1:Mlytsllyx6d1eaKXt8urXX0YjP5Tq4UGV+BfL6Yc1aQ=
 github.com/sourcegraph/alertmanager v0.21.1-0.20211110092431-863f5b1ee51b/go.mod h1:0MLTrjQI8EuVmvykEhcfr/7X0xmaDAZrqMgxIq3OXHk=
-github.com/sourcegraph/cloud-api v0.0.0-20240423104735-5602ff6597cc h1:tgqkTr812ydrUTktrJGRD9BpIEt/Gv0/NsJiugr6qe0=
-github.com/sourcegraph/cloud-api v0.0.0-20240423104735-5602ff6597cc/go.mod h1:1xzM0rrlsGlo7OVxoXx8aj5LBQXSo0BxvRkWJujjIVY=
+github.com/sourcegraph/cloud-api v0.0.0-20240501113836-ecd1d4cba9dd h1:ZCHR0jxMJ0QhwHbHnbXuWTJrIeJT6uuJZ5D8V2Csg6g=
+github.com/sourcegraph/cloud-api v0.0.0-20240501113836-ecd1d4cba9dd/go.mod h1:1xzM0rrlsGlo7OVxoXx8aj5LBQXSo0BxvRkWJujjIVY=
 github.com/sourcegraph/conc v0.3.1-0.20240108182409-4afefce20f9b h1:0FsjN+u9fNXTS2C1JnJ6G/gkgcUg8dscyyfu3PwHWUQ=
 github.com/sourcegraph/conc v0.3.1-0.20240108182409-4afefce20f9b/go.mod h1:Sdozi7LEKbFPqYX2/J+iBAM6HpqSLTASQIKqDmF7Mt0=
 github.com/sourcegraph/go-ctags v0.0.0-20240325032535-71f1ec6e46e4 h1:jppwnpC+DT9tIiRbw21lD0drA9Jqu4X47iA4gTk4w8M=


### PR DESCRIPTION
This changes the operation to be a `sync` since when an upgrade happens of an already deployed instance we need to be 100% sure the images exist. Issuing an upgrade on an instance where the images do not exist will put the deployment in a broken state

## Test plan
Tested locally
