### PR TITLE
sg: cloud handle ephemeral lease extension/reduction

### DIFF
--- a/dev/sg/internal/cloud/BUILD.bazel
+++ b/dev/sg/internal/cloud/BUILD.bazel
@@ -5,9 +5,11 @@ go_library(
     name = "cloud",
     srcs = [
         "client.go",
+        "common.go",
         "delete_command.go",
         "deploy_command.go",
         "instance.go",
+        "lease_command.go",
         "list_command.go",
         "list_versions_command.go",
         "printers.go",
@@ -34,6 +36,7 @@ go_library(
         "@com_google_cloud_go_artifactregistry//apiv1",
         "@com_google_cloud_go_artifactregistry//apiv1/artifactregistrypb",
         "@org_golang_google_api//iterator",
+        "@org_golang_google_protobuf//types/known/timestamppb",
     ],
 )
 

--- a/dev/sg/internal/cloud/client.go
+++ b/dev/sg/internal/cloud/client.go
@@ -112,15 +112,13 @@ func (c *Client) GetInstance(ctx context.Context, name string) (*Instance, error
 
 func (c *Client) ListInstances(ctx context.Context, all bool) ([]*Instance, error) {
 	var req *connect.Request[cloudapiv1.ListInstancesRequest]
-	if all {
-		req = newRequestWithToken(c.token, &cloudapiv1.ListInstancesRequest{})
-	} else {
-		req = newRequestWithToken(c.token, &cloudapiv1.ListInstancesRequest{
-			InstanceFilter: &cloudapiv1.InstanceFilter{
-				AdminEmail: &c.email,
-			},
-		})
+	listReq := cloudapiv1.ListInstancesRequest{}
+	if !all {
+		listReq.InstanceFilter = &cloudapiv1.InstanceFilter{
+			AdminEmail: &c.email,
+		}
 	}
+
 	resp, err := c.client.ListInstances(
 		ctx,
 		req,

--- a/dev/sg/internal/cloud/client.go
+++ b/dev/sg/internal/cloud/client.go
@@ -111,7 +111,6 @@ func (c *Client) GetInstance(ctx context.Context, name string) (*Instance, error
 }
 
 func (c *Client) ListInstances(ctx context.Context, all bool) ([]*Instance, error) {
-	var req *connect.Request[cloudapiv1.ListInstancesRequest]
 	listReq := cloudapiv1.ListInstancesRequest{}
 	if !all {
 		listReq.InstanceFilter = &cloudapiv1.InstanceFilter{
@@ -119,6 +118,7 @@ func (c *Client) ListInstances(ctx context.Context, all bool) ([]*Instance, erro
 		}
 	}
 
+	req := newRequestWithToken(c.token, &listReq)
 	resp, err := c.client.ListInstances(
 		ctx,
 		req,

--- a/dev/sg/internal/cloud/client.go
+++ b/dev/sg/internal/cloud/client.go
@@ -5,11 +5,13 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	"time"
 
 	"connectrpc.com/connect"
 	cloudapiv1 "github.com/sourcegraph/cloud-api/go/cloudapi/v1"
 	"github.com/sourcegraph/cloud-api/go/cloudapi/v1/cloudapiv1connect"
 	"github.com/sourcegraph/run"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 	"github.com/sourcegraph/sourcegraph/lib/pointers"
@@ -49,7 +51,7 @@ func NewDeploymentSpec(name, version string) *DeploymentSpec {
 	features := newInstanceFeatures()
 	features.SetEphemeralInstance(true)
 	return &DeploymentSpec{
-		Name:             sanitizeInstanceName(name),
+		Name:             name,
 		Version:          version,
 		InstanceFeatures: features.Value(),
 	}
@@ -160,7 +162,20 @@ func (c *Client) DeleteInstance(ctx context.Context, name string) error {
 	return nil
 }
 
-func sanitizeInstanceName(name string) string {
-	name = strings.ToLower(name)
-	return strings.ReplaceAll(name, "/", "-")
+func (c *Client) ExtendLease(ctx context.Context, name string, extendTime time.Time) (*Instance, error) {
+	req := newRequestWithToken(c.token, &cloudapiv1.UpdateInstanceLeaseRequest{
+		Name:        name,
+		Environment: DevEnvironment,
+		Lease: &timestamppb.Timestamp{
+			Seconds: extendTime.Unix(),
+			Nanos:   0,
+		},
+	})
+
+	resp, err := c.client.UpdateInstanceLease(ctx, req)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to extend lease for instance %q", name)
+	}
+
+	return newInstance(resp.Msg.GetInstance())
 }

--- a/dev/sg/internal/cloud/common.go
+++ b/dev/sg/internal/cloud/common.go
@@ -16,6 +16,7 @@ import (
 var ErrUserCancelled = errors.New("user cancelled")
 var ErrWrongBranch = errors.New("wrong current branch")
 var ErrBranchOutOfSync = errors.New("branch is out of sync with remote")
+var ErrNotEphemeralInstance = errors.New("instance is not ephemeral")
 
 const CloudEmoji = "☁️"
 

--- a/dev/sg/internal/cloud/common.go
+++ b/dev/sg/internal/cloud/common.go
@@ -17,6 +17,7 @@ var ErrUserCancelled = errors.New("user cancelled")
 var ErrWrongBranch = errors.New("wrong current branch")
 var ErrBranchOutOfSync = errors.New("branch is out of sync with remote")
 var ErrNotEphemeralInstance = errors.New("instance is not ephemeral")
+var ErrExpiredInstance = errors.New("instance has already expired")
 
 const CloudEmoji = "☁️"
 

--- a/dev/sg/internal/cloud/common.go
+++ b/dev/sg/internal/cloud/common.go
@@ -1,0 +1,77 @@
+package cloud
+
+import (
+	"context"
+	"strings"
+
+	"github.com/sourcegraph/run"
+	"github.com/urfave/cli/v2"
+
+	"github.com/sourcegraph/sourcegraph/dev/sg/internal/repo"
+	"github.com/sourcegraph/sourcegraph/dev/sg/internal/std"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"github.com/sourcegraph/sourcegraph/lib/output"
+)
+
+var ErrUserCancelled = errors.New("user cancelled")
+var ErrWrongBranch = errors.New("wrong current branch")
+var ErrBranchOutOfSync = errors.New("branch is out of sync with remote")
+
+const CloudEmoji = "☁️"
+
+func sanitizeInstanceName(name string) string {
+	name = strings.ToLower(name)
+	return strings.ReplaceAll(name, "/", "-")
+}
+
+func inferInstanceNameFromBranch(ctx context.Context) (string, error) {
+	currentBranch, err := repo.GetCurrentBranch(ctx)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to determine current branch")
+	}
+	return sanitizeInstanceName(currentBranch), nil
+}
+
+func wipAction(actionFn cli.ActionFunc) cli.ActionFunc {
+	if actionFn == nil {
+		return nil
+	}
+	return func(ctx *cli.Context) error {
+		if err := printWIPNotice(ctx); err != nil {
+			return err
+		}
+
+		return actionFn(ctx)
+	}
+}
+
+func printWIPNotice(ctx *cli.Context) error {
+	if ctx.Bool("skip-wip-notice") {
+		return nil
+	}
+	notice := output.Line("🧪", output.StyleBold, "EXPERIMENTAL COMMAND - Do you want to continue? (yes/no)")
+
+	var answer string
+	if _, err := std.FancyPromptAndScan(std.Out, notice, &answer); err != nil {
+		return err
+	}
+
+	if oneOfEquals(answer, "yes", "y") {
+		return nil
+	}
+
+	return ErrUserCancelled
+}
+
+func oneOfEquals(value string, i ...string) bool {
+	for _, item := range i {
+		if value == item {
+			return true
+		}
+	}
+	return false
+}
+
+func getGCloudAccount(ctx context.Context) (string, error) {
+	return run.Cmd(ctx, "gcloud", "config", "get", "account").Run().String()
+}

--- a/dev/sg/internal/cloud/delete_command.go
+++ b/dev/sg/internal/cloud/delete_command.go
@@ -55,8 +55,7 @@ func deleteCloudEphemeral(ctx *cli.Context) error {
 		return ErrUserCancelled
 	}
 
-	cloudEmoji := "☁️"
-	pending := std.Out.Pending(output.Linef(cloudEmoji, output.StylePending, "Deleting ephemeral instance %q", name))
+	pending := std.Out.Pending(output.Linef(CloudEmoji, output.StylePending, "Deleting ephemeral instance %q", name))
 	err = cloudClient.DeleteInstance(ctx.Context, name)
 	if err != nil {
 		pending.Complete(output.Linef(output.EmojiFailure, output.StyleFailure, "deleting of %q failed", name))

--- a/dev/sg/internal/cloud/deploy_command.go
+++ b/dev/sg/internal/cloud/deploy_command.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/buildkite/go-buildkite/v3/buildkite"
-	"github.com/sourcegraph/run"
 	"github.com/urfave/cli/v2"
 
 	"github.com/sourcegraph/sourcegraph/dev/ci/gitops"
@@ -18,10 +17,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/output"
 	"github.com/sourcegraph/sourcegraph/lib/pointers"
 )
-
-var ErrUserCancelled = errors.New("user cancelled")
-var ErrWrongBranch = errors.New("wrong current branch")
-var ErrBranchOutOfSync = errors.New("branch is out of sync with remote")
 
 var DeployEphemeralCommand = cli.Command{
 	Name:        "deploy",
@@ -70,19 +65,6 @@ func determineVersion(build *buildkite.Build, tag string) (string, error) {
 	), nil
 }
 
-func oneOfEquals(value string, i ...string) bool {
-	for _, item := range i {
-		if value == item {
-			return true
-		}
-	}
-	return false
-}
-
-func getGCloudAccount(ctx context.Context) (string, error) {
-	return run.Cmd(ctx, "gcloud", "config", "get", "account").Run().String()
-}
-
 func triggerEphemeralBuild(ctx context.Context, currRepo *repo.GitRepo) (*buildkite.Build, error) {
 	pending := std.Out.Pending(output.Linef("🔨", output.StylePending, "Checking if branch %q is up to date with remote", currRepo.Branch))
 	if isOutOfSync, err := currRepo.IsOutOfSync(ctx); err != nil {
@@ -108,37 +90,6 @@ func triggerEphemeralBuild(ctx context.Context, currRepo *repo.GitRepo) (*buildk
 	return build, nil
 }
 
-func wipAction(actionFn cli.ActionFunc) cli.ActionFunc {
-	if actionFn == nil {
-		return nil
-	}
-	return func(ctx *cli.Context) error {
-		if err := printWIPNotice(ctx); err != nil {
-			return err
-		}
-
-		return actionFn(ctx)
-	}
-}
-
-func printWIPNotice(ctx *cli.Context) error {
-	if ctx.Bool("skip-wip-notice") {
-		return nil
-	}
-	notice := output.Line("🧪", output.StyleBold, "EXPERIMENTAL COMMAND - Do you want to continue? (yes/no)")
-
-	var answer string
-	if _, err := std.FancyPromptAndScan(std.Out, notice, &answer); err != nil {
-		return err
-	}
-
-	if oneOfEquals(answer, "yes", "y") {
-		return nil
-	}
-
-	return ErrUserCancelled
-}
-
 func createDeploymentForVersion(ctx context.Context, name, version string) error {
 	email, err := GetGCloudAccount(ctx)
 	if err != nil {
@@ -156,7 +107,7 @@ func createDeploymentForVersion(ctx context.Context, name, version string) error
 	pending := std.Out.Pending(output.Linef(cloudEmoji, output.StylePending, "Creating deployment %q for version %q", name, version))
 
 	spec := NewDeploymentSpec(
-		name,
+		sanitizeInstanceName(name),
 		version,
 	)
 	inst, err := cloudClient.CreateInstance(ctx, spec)
@@ -171,10 +122,6 @@ func createDeploymentForVersion(ctx context.Context, name, version string) error
 }
 
 func deployCloudEphemeral(ctx *cli.Context) error {
-	// while we work on this command we print a notice and ask to continue
-	if err := printWIPNotice(ctx); err != nil {
-		return err
-	}
 	currentBranch, err := repo.GetCurrentBranch(ctx.Context)
 	if err != nil {
 		return errors.Wrap(err, "failed to determine current branch")

--- a/dev/sg/internal/cloud/instance.go
+++ b/dev/sg/internal/cloud/instance.go
@@ -89,17 +89,6 @@ type InstanceFeatures struct {
 	features map[string]string
 }
 
-type InstanceLease struct {
-	ExpiresAt *time.Time `json:"expiresAt,omitempty"`
-}
-
-func (l *InstanceLease) String() string {
-	if l.ExpiresAt == nil {
-		return ""
-	}
-	return l.ExpiresAt.Format(time.RFC3339)
-}
-
 func newInstanceStatus(src *cloudapiv1.InstanceState) (*InstanceStatus, error) {
 	url, reason, err := parseStatusReason(src.GetReason())
 	if err != nil {

--- a/dev/sg/internal/cloud/instance.go
+++ b/dev/sg/internal/cloud/instance.go
@@ -30,7 +30,6 @@ type Instance struct {
 	Version      string `json:"version"`
 	URL          string `json:"hostname"`
 	AdminEmail   string `json:"adminEmail"`
-	Features     *InstanceFeatures
 
 	CreatedAt time.Time      `json:"createdAt"`
 	DeletedAt time.Time      `json:"deletedAt"`

--- a/dev/sg/internal/cloud/lease_command.go
+++ b/dev/sg/internal/cloud/lease_command.go
@@ -98,6 +98,10 @@ func leaseCloudEphemeral(ctx *cli.Context) error {
 		std.Out.WriteWarningf("Cannot update lease time of non-ephemeral instance %q", name)
 		return ErrNotEphemeralInstance
 	}
+	if inst.IsExpired() {
+		std.Out.WriteWarningf(" Cannot update lease time of expired instance %q", name)
+		return ErrExpiredInstance
+	}
 
 	currentLeaseTime := inst.ExpiresAt
 	var leaseEndTime time.Time
@@ -110,7 +114,7 @@ func leaseCloudEphemeral(ctx *cli.Context) error {
 	}
 
 	if leaseEndTime.Sub(currentLeaseTime) > MaxDuration {
-		return errors.Newf("cannot extend lease time by more than %s", MaxDuration)
+		return errors.Newf("cannot update lease time by more than %s", MaxDuration)
 	}
 
 	pending = std.Out.Pending(output.Linef(CloudEmoji, output.StylePending, "Updating lease of instance %q", name))
@@ -121,6 +125,6 @@ func leaseCloudEphemeral(ctx *cli.Context) error {
 		pending.Complete(output.Linef(output.EmojiFailure, output.StyleFailure, "failed to update lease"))
 	}
 
-	pending.Complete(output.Linef(CloudEmoji, output.StyleSuccess, "Lease of instance %q updated by %s", name, currentLeaseTime.Sub(leaseEndTime)))
+	pending.Complete(output.Linef(CloudEmoji, output.StyleSuccess, "Lease of instance %q updated by %s", name, leaseEndTime.Sub(currentLeaseTime)))
 	return newDefaultTerminalInstancePrinter().Print(inst)
 }

--- a/dev/sg/internal/cloud/lease_command.go
+++ b/dev/sg/internal/cloud/lease_command.go
@@ -1,0 +1,92 @@
+package cloud
+
+import (
+	"time"
+
+	"github.com/urfave/cli/v2"
+
+	"github.com/sourcegraph/sourcegraph/dev/sg/internal/std"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"github.com/sourcegraph/sourcegraph/lib/output"
+)
+
+const MaxDuration = time.Hour * 24 * 4
+
+var ExtendLeaseEphemeralCommand = cli.Command{
+	Name:        "extend-lease",
+	ArgsUsage:   "sg cloud extend-lease [--name instance-name] <duration>",
+	Description: "extend the lease of the instance for the given duration (max 4 days)",
+	Action:      wipAction(extendLeaseCloudEphemeral),
+	Flags: []cli.Flag{
+		&cli.StringFlag{
+			Name:        "name",
+			DefaultText: "name of the instance to extend lease for",
+		},
+	},
+}
+
+func printLeaseTimeDiff(oldTime, newTime time.Time) {
+	std.Out.Write("Updating instance lease with the following values:")
+	std.Out.WriteLine(output.Linef("", output.StyleRed, "- Lease time %s", oldTime.Format(time.RFC3339)))
+	std.Out.WriteLine(output.Linef("", output.StyleGreen, "+ Lease time %s", newTime.Format(time.RFC3339)))
+	std.Out.Write("\n")
+}
+
+func extendLeaseCloudEphemeral(ctx *cli.Context) error {
+	if ctx.Args().Len() != 1 {
+		return errors.New("no duration provided")
+	}
+	duration, err := time.ParseDuration(ctx.Args().First())
+	if err != nil {
+		return errors.Wrapf(err, "failed to parse duration %q", ctx.Args().First())
+	}
+
+	if duration > MaxDuration {
+		std.Out.Writef("duration %s is greater than max duration %s, setting to max duration", duration, MaxDuration)
+		duration = MaxDuration
+	}
+
+	email, err := GetGCloudAccount(ctx.Context)
+	if err != nil {
+		return err
+	}
+
+	cloudClient, err := NewClient(ctx.Context, email, APIEndpoint)
+	if err != nil {
+		return err
+	}
+	name := ctx.String("name")
+	if name == "" {
+		n, err := inferInstanceNameFromBranch(ctx.Context)
+		if err != nil {
+			return err
+		}
+		name = n
+	}
+
+	pending := std.Out.Pending(output.Linef(CloudEmoji, output.StylePending, "Getting instance with name %q", name))
+	inst, err := cloudClient.GetInstance(ctx.Context, name)
+	if err != nil {
+		pending.Complete(output.Linef(output.EmojiFailure, output.StyleFailure, "failed to get instance"))
+		return err
+	}
+	pending.Complete(output.Linef(CloudEmoji, output.StyleSuccess, "Fetched instance with name %q", name))
+
+	pending = std.Out.Pending(output.Linef(CloudEmoji, output.StylePending, "Extending lease of instance %q by %s", name, duration))
+
+	current, err := inst.GetExpiry()
+	if err != nil {
+		errors.Wrap(err, "failed to get instance lease expiry")
+	}
+
+	leaseEndTime := current.Add(duration)
+	printLeaseTimeDiff(*current, leaseEndTime)
+	inst, err = cloudClient.ExtendLease(ctx.Context, name, leaseEndTime)
+	if err != nil {
+		pending.Complete(output.Linef(output.EmojiFailure, output.StyleFailure, "failed to extend lease"))
+	}
+
+	pending.Complete(output.Linef(CloudEmoji, output.StyleSuccess, "Lease of instance %q extended by %s", name, duration))
+	newDefaultTerminalInstancePrinter().Print(inst)
+	return nil
+}

--- a/dev/sg/internal/cloud/lease_command.go
+++ b/dev/sg/internal/cloud/lease_command.go
@@ -10,6 +10,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/output"
 )
 
+// MaxDuration is the maximum lease duration by which a deployment can be extended by, which is 4 days
 const MaxDuration = time.Hour * 24 * 4
 
 var LeaseEphemeralCommand = cli.Command{
@@ -106,6 +107,10 @@ func leaseCloudEphemeral(ctx *cli.Context) error {
 		return err
 	} else {
 		leaseEndTime = t
+	}
+
+	if leaseEndTime.Sub(currentLeaseTime) > MaxDuration {
+		return errors.Newf("cannot extend lease time by more than %s", MaxDuration)
 	}
 
 	pending = std.Out.Pending(output.Linef(CloudEmoji, output.StylePending, "Updating lease of instance %q", name))

--- a/dev/sg/internal/cloud/lease_command.go
+++ b/dev/sg/internal/cloud/lease_command.go
@@ -14,21 +14,23 @@ const MaxDuration = time.Hour * 24 * 4
 
 var LeaseEphemeralCommand = cli.Command{
 	Name:        "lease",
-	ArgsUsage:   "sg cloud lease [--name instance-name] <duration>",
+	Usage:       "extend or reduce the lease of an ephemeral instance",
+	UsageText:   "sg cloud lease [command options]",
 	Description: "extend the lease of the instance for the given duration (max 4 days)",
 	Action:      wipAction(leaseCloudEphemeral),
 	Flags: []cli.Flag{
 		&cli.StringFlag{
 			Name:        "name",
-			DefaultText: "name of the instance to extend lease for",
+			Usage:       "name of the instance to extend lease for",
+			DefaultText: "current branch name will be used",
 		},
 		&cli.DurationFlag{
-			Name:        "extend",
-			DefaultText: "the duration to extend the lease by (max 4 days = 96h)",
+			Name:  "extend",
+			Usage: "the duration to extend the lease by (max 4 days = 96h)",
 		},
 		&cli.DurationFlag{
-			Name:        "reduce",
-			DefaultText: "the duration to reduce the lease by - if the lease time is reduced to be in the passed the instance will be deleted!",
+			Name:  "reduce",
+			Usage: "the duration to reduce the lease by - if the lease time is reduced to be in the passed the instance will be deleted!",
 		},
 	},
 }

--- a/dev/sg/internal/cloud/lease_command.go
+++ b/dev/sg/internal/cloud/lease_command.go
@@ -17,21 +17,21 @@ var LeaseEphemeralCommand = cli.Command{
 	Name:        "lease",
 	Usage:       "extend or reduce the lease of an ephemeral instance",
 	UsageText:   "sg cloud lease [command options]",
-	Description: "extend the lease of the instance for the given duration (max 4 days)",
+	Description: "update the lease time of an ephemeral instance",
 	Action:      wipAction(leaseCloudEphemeral),
 	Flags: []cli.Flag{
 		&cli.StringFlag{
 			Name:        "name",
-			Usage:       "name of the instance to extend lease for",
+			Usage:       "name of the instance to update the lease expiry time for",
 			DefaultText: "current branch name will be used",
 		},
 		&cli.DurationFlag{
 			Name:  "extend",
-			Usage: "the duration to extend the lease by (max 4 days = 96h)",
+			Usage: "extend the lease by the given duration value, where the value can be any parseable duration of hours (h) minutes (m) or seconds (s).  Example: --extend '1h' or --extend '50m30s' or --extend '24h50m'",
 		},
 		&cli.DurationFlag{
 			Name:  "reduce",
-			Usage: "the duration to reduce the lease by - if the lease time is reduced to be in the passed the instance will be deleted!",
+			Usage: "reduce the the lease expiry time by the given duration value, where the value ca be any parseable duration of hours (h) minutes (m) or seconds (s). Example: --reduce '1h' or --reduce '50m30s' or --reduce '24h50m'",
 		},
 		&cli.BoolFlag{
 			Name:  "expire-now",

--- a/dev/sg/internal/cloud/list_command.go
+++ b/dev/sg/internal/cloud/list_command.go
@@ -1,11 +1,14 @@
 package cloud
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/urfave/cli/v2"
 
+	"github.com/sourcegraph/sourcegraph/dev/sg/internal/std"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"github.com/sourcegraph/sourcegraph/lib/output"
 )
 
 var ListEphemeralCommand = cli.Command{
@@ -40,10 +43,18 @@ func listCloudEphemeral(ctx *cli.Context) error {
 		return err
 	}
 
+	msg := "Fetching list of instances..."
+	if !ctx.Bool("all") {
+		msg = fmt.Sprintf("Fetching list of instances attached to your GCP account %q", email)
+	}
+
+	pending := std.Out.Pending(output.Linef(CloudEmoji, output.StylePending, msg))
 	instances, err := cloudClient.ListInstances(ctx.Context, ctx.Bool("all"))
 	if err != nil {
+		pending.Complete(output.Linef(CloudEmoji, output.StyleFailure, "failed to list instances: %v", err))
 		return errors.Wrapf(err, "failed to list instances %v", err)
 	}
+	pending.Complete(output.Linef(CloudEmoji, output.StyleSuccess, "Fetched %d instances", len(instances)))
 	var printer Printer
 	switch {
 	case ctx.Bool("json"):

--- a/dev/sg/internal/cloud/list_versions_command.go
+++ b/dev/sg/internal/cloud/list_versions_command.go
@@ -126,14 +126,13 @@ func listTagsCloudEphemeral(ctx *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	cloudEmoji := "☁️"
-	pending := std.Out.Pending(output.Linef(cloudEmoji, output.StylePending, "Retrieving docker images from registry %q", ar.RepositoryName))
+	pending := std.Out.Pending(output.Linef(CloudEmoji, output.StylePending, "Retrieving docker images from registry %q", ar.RepositoryName))
 	images, err := ar.ListDockerImages(ctx.Context)
 	if err != nil {
 		pending.Complete(output.Linef(output.EmojiFailure, output.StyleFailure, "failed to retreive images from registry %q", ar.RepositoryName))
 		return err
 	}
-	pending.Complete(output.Linef(cloudEmoji, output.StyleSuccess, "Retrieved %d docker images from registry %q", len(images), ar.RepositoryName))
+	pending.Complete(output.Linef(CloudEmoji, output.StyleSuccess, "Retrieved %d docker images from registry %q", len(images), ar.RepositoryName))
 
 	imagesByTag := map[string][]*DockerImage{}
 	for _, image := range images {

--- a/dev/sg/internal/cloud/printers.go
+++ b/dev/sg/internal/cloud/printers.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"time"
 
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/std"
 	"github.com/sourcegraph/sourcegraph/lib/output"
@@ -35,14 +36,17 @@ func newDefaultTerminalInstancePrinter() *terminalInstancePrinter {
 		}
 
 		status := inst.Status.Status
-		createdAt := inst.CreatedAt.String()
+		expiresAt := "n/a"
+		if inst.Lease != nil {
+			expiresAt = inst.Lease.ExpiresAt.Format(time.RFC3339)
+		}
 
 		return []any{
-			name, status, createdAt,
+			name, status, expiresAt,
 		}
 
 	}
-	return newTerminalInstancePrinter(valueFunc, "%-40s %-11s %s", "Name", "Status", "Created At")
+	return newTerminalInstancePrinter(valueFunc, "%-40s %-11s %s", "Name", "Status", "Expires At")
 }
 
 func newTerminalInstancePrinter(valueFunc func(i *Instance) []any, headingFmt string, headings ...string) *terminalInstancePrinter {

--- a/dev/sg/internal/cloud/printers.go
+++ b/dev/sg/internal/cloud/printers.go
@@ -31,8 +31,8 @@ type jsonInstancePrinter struct {
 func newDefaultTerminalInstancePrinter() *terminalInstancePrinter {
 	valueFunc := func(inst *Instance) []any {
 		name := inst.Name
-		if len(name) > 20 {
-			name = name[:20]
+		if len(name) > 40 {
+			name = name[:40]
 		}
 
 		status := inst.Status.Status

--- a/dev/sg/internal/cloud/printers.go
+++ b/dev/sg/internal/cloud/printers.go
@@ -37,8 +37,8 @@ func newDefaultTerminalInstancePrinter() *terminalInstancePrinter {
 
 		status := inst.Status.Status
 		expiresAt := "n/a"
-		if inst.Lease != nil {
-			expiresAt = inst.Lease.ExpiresAt.Format(time.RFC3339)
+		if !inst.ExpiresAt.IsZero() {
+			expiresAt = inst.ExpiresAt.Format(time.RFC3339)
 		}
 
 		return []any{

--- a/dev/sg/internal/cloud/printers.go
+++ b/dev/sg/internal/cloud/printers.go
@@ -31,8 +31,8 @@ type jsonInstancePrinter struct {
 func newDefaultTerminalInstancePrinter() *terminalInstancePrinter {
 	valueFunc := func(inst *Instance) []any {
 		name := inst.Name
-		if len(name) > 40 {
-			name = name[:40]
+		if len(name) > 37 {
+			name = name[:37] + "..."
 		}
 
 		status := inst.Status.Status
@@ -70,6 +70,8 @@ func (p *terminalInstancePrinter) Print(items ...*Instance) error {
 		line := fmt.Sprintf("%-40s %-11s %s", values...)
 		std.Out.WriteLine(output.Line("", output.StyleGrey, line))
 	}
+
+	std.Out.WriteSuggestionf("Some names may be truncated. To see the full names use the --raw format")
 	return nil
 }
 

--- a/dev/sg/internal/cloud/status_command.go
+++ b/dev/sg/internal/cloud/status_command.go
@@ -53,8 +53,7 @@ func statusCloudEphemeral(ctx *cli.Context) error {
 	}
 	name = sanitizeInstanceName(name)
 
-	cloudEmoji := "☁️"
-	pending := std.Out.Pending(output.Linef(cloudEmoji, output.StylePending, "Getting status of ephemeral instance %q", name))
+	pending := std.Out.Pending(output.Linef(CloudEmoji, output.StylePending, "Getting status of ephemeral instance %q", name))
 	inst, err := cloudClient.GetInstance(ctx.Context, name)
 	if err != nil {
 		pending.Complete(output.Linef(output.EmojiFailure, output.StyleFailure, "getting status of %q failed", name))

--- a/dev/sg/sg_cloud.go
+++ b/dev/sg/sg_cloud.go
@@ -47,7 +47,7 @@ var cloudCommand = &cli.Command{
 		},
 		&cloud.DeleteEphemeralCommand,
 		&cloud.DeployEphemeralCommand,
-		&cloud.ExtendLeaseEphemeralCommand,
+		&cloud.LeaseEphemeralCommand,
 		&cloud.ListEphemeralCommand,
 		&cloud.ListVersionsEphemeralCommand,
 		&cloud.StatusEphemeralCommand,

--- a/dev/sg/sg_cloud.go
+++ b/dev/sg/sg_cloud.go
@@ -45,11 +45,12 @@ var cloudCommand = &cli.Command{
 				return nil
 			},
 		},
+		&cloud.DeleteEphemeralCommand,
 		&cloud.DeployEphemeralCommand,
+		&cloud.ExtendLeaseEphemeralCommand,
 		&cloud.ListEphemeralCommand,
 		&cloud.ListVersionsEphemeralCommand,
 		&cloud.StatusEphemeralCommand,
-		&cloud.DeleteEphemeralCommand,
 	},
 }
 


### PR DESCRIPTION
Add `sg cloud lease` with the following flags to alter the deployment expiry time
* `--extend` extend the duration by golang parseable duration
* `--reduce` reduce the duration by golang parseable duration
* `--expire-now` sets the expire time to be now

## Test plan
Tested locally
```
go run ./dev/sg cloud lease --name "ff-eph17" --reduce "1h"
🧪 EXPERIMENTAL COMMAND - Do you want to continue? (yes/no) y
☁️ Fetched instance with name "ff-eph17"

Updating instance lease with the following values:
- Lease time 2024-05-03T21:00:59Z
+ Lease time 2024-05-03T20:00:59Z

☁️ Lease of instance "ff-eph17" extended by 1h0m0s

```
```
go run ./dev/sg/ cloud lease --name wb-sg-cloud-eph-delete --expire-now
🧪 EXPERIMENTAL COMMAND - Do you want to continue? (yes/no) y
☁️ Fetched instance with name "wb-sg-cloud-eph-delete"

Updating instance lease with the following values:
- Lease time 2024-05-06T08:41:30Z
+ Lease time 2024-05-06T08:52:26Z

☁️ Lease of instance "wb-sg-cloud-eph-delete" updated by -10m56.821861s
Name                                     Status      Expires At
wb-sg-cloud-eph-dele...                 in progress 2024-05-06T08:52:26Z
💡 Some names may be truncated. To see the full names use the --raw format
```