### PR TITLE
svelte: Give last commit message as much space as possible

### DIFF
--- a/client/web-sveltekit/src/lib/repo/LastCommit.svelte
+++ b/client/web-sveltekit/src/lib/repo/LastCommit.svelte
@@ -14,7 +14,8 @@
 </script>
 
 <div class="last-commit">
-    <div class="avatar">
+    <!-- Wrapper diff necessary to prevent avatar from being squished -->
+    <div>
         <Avatar avatar={user} />
     </div>
     <div class="display-name">
@@ -32,34 +33,22 @@
 
 <style lang="scss">
     .last-commit {
+        --avatar-size: 1.5rem;
+
         display: flex;
-        flex-flow: row nowrap;
         align-items: center;
-        justify-content: space-between;
-        margin-right: 0.5rem;
+        gap: 0.5rem;
         white-space: nowrap;
-        max-width: 400px;
         font-size: var(--font-size-small);
     }
 
-    .avatar {
-        display: flex;
-        flex-flow: row nowrap;
-        align-items: center;
-        margin-right: 0.5rem;
-        --avatar-size: 1.5rem;
-    }
-
     .display-name {
-        margin-right: 0.75rem;
+        margin-right: 0.25rem;
         color: var(--text-body);
     }
 
     .commit-message {
-        align-items: center;
         color: var(--text-muted);
-        margin-right: 0.5rem;
-        max-width: 240px;
         overflow: hidden;
         text-overflow: ellipsis;
         white-space: nowrap;

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/+layout.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/+layout.svelte
@@ -38,10 +38,9 @@
     import type { LayoutData, Snapshot } from './$types'
     import FileTree from './FileTree.svelte'
     import { createFileTreeStore } from './fileTreeStore'
-
     import type { GitHistory_HistoryConnection, RepoPage_ReferencesLocationConnection } from './layout.gql'
-    import RepositoryRevPicker from './RepositoryRevPicker.svelte'
     import ReferencePanel from './ReferencePanel.svelte'
+    import RepositoryRevPicker from './RepositoryRevPicker.svelte'
 
     enum TabPanels {
         History,
@@ -262,8 +261,9 @@
 
         display: flex;
         align-items: center;
-        flex-flow: row nowrap;
         justify-content: space-between;
+        gap: 1rem;
+
         overflow: hidden;
         border-top: 1px solid var(--border-color);
         box-shadow: var(--bottom-panel-shadow);
@@ -271,6 +271,10 @@
         color: var(--text-body);
         // Applying z-index to the bottom panel allows its shadow to cascade correctly on the code but still say behind the left panel
         z-index: 1;
+
+        .last-commit {
+            overflow: hidden;
+        }
 
         &.open {
             height: 32vh;


### PR DESCRIPTION
I don't see a reason why we need to restrict the width to a specific pixel value. I find it annoying when the message is cut off even if enough space is available. There are already conventions about the size of the subject line so most of the time the message won't take up a lot of space anyway.

For smaller screens we should think of a different solution anyway IMO.

We could still restrict it to a relative value of the available width if we wanted to.

| Before | After |
|--------|--------|
| ![2024-05-06_11-50](https://github.com/sourcegraph/sourcegraph/assets/179026/42975e45-957f-48fc-b4c9-7e5a71ae351c)| ![2024-05-06_11-41_1](https://github.com/sourcegraph/sourcegraph/assets/179026/3bb5b8e5-e656-43d1-928f-31102cb2d10b) | 


## Test plan

Manual testing.
