### PR TITLE
chore(rel): fix wrong stage name when checking reqs

### DIFF
--- a/dev/sg/internal/release/config.go
+++ b/dev/sg/internal/release/config.go
@@ -329,7 +329,7 @@ func (r *releaseRunner) CreateRelease(ctx context.Context) error {
 }
 
 func (r *releaseRunner) InternalFinalize(ctx context.Context) error {
-	if err := r.checkRequirements(ctx, stageInternalCreate); err != nil {
+	if err := r.checkRequirements(ctx, stageInternalFinalize); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Fixes https://buildkite.com/sourcegraph/sourcegraph/builds/272793#018f4e91-24e0-480c-8926-460f1b728c14/180-208

## Test plan

Locally tested

![CleanShot 2024-05-06 at 18 06 14@2x](https://github.com/sourcegraph/sourcegraph/assets/10151/fc2ad2c3-4bb4-4bb5-a2fc-868e37f93e33)


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
