### PR TITLE
release(upgradetest): confirm postrelease version is newer than the latest sourcegraph version

### DIFF
--- a/testing/tools/upgradetest/tests-util.go
+++ b/testing/tools/upgradetest/tests-util.go
@@ -800,18 +800,20 @@ func handleVersions(cCtx *cli.Context, overrideStd, overrideMVU, overrideAuto []
 			continue
 		}
 		validTags = append(validTags, v)
-	}
 
-	// Get latest Version and latestMinorVersion
-	for _, tag := range validTags {
 		// Track latest full version
-		if latestFullVer == nil || tag.GreaterThan(latestFullVer) {
-			latestFullVer = tag
+		if latestFullVer == nil || v.GreaterThan(latestFullVer) {
+			latestFullVer = v
 		}
 		latestMinorVer, err = semver.NewVersion(fmt.Sprintf("%d.%d.0", latestFullVer.Major(), latestFullVer.Minor()))
 		if err != nil {
 			return nil, nil, nil, nil, nil, nil, err
 		}
+	}
+
+	semverPostRelease := semver.MustParse(postRelease)
+	if semverPostRelease.LessThan(latestFullVer) {
+		return nil, nil, nil, nil, nil, nil, errors.Newf("post-release %q is older than latest full version.", postRelease)
 	}
 
 	// Std versions tests are all versions within a minor version of the release candidate, all others are MVU.

--- a/testing/tools/upgradetest/tests-util.go
+++ b/testing/tools/upgradetest/tests-util.go
@@ -811,9 +811,11 @@ func handleVersions(cCtx *cli.Context, overrideStd, overrideMVU, overrideAuto []
 		}
 	}
 
-	semverPostRelease := semver.MustParse(postRelease)
-	if semverPostRelease.LessThan(latestFullVer) {
-		return nil, nil, nil, nil, nil, nil, errors.Newf("post-release %q is older than latest full version.", postRelease)
+	if postRelease != "" {
+		semverPostRelease := semver.MustParse(postRelease)
+		if semverPostRelease.LessThan(latestFullVer) {
+			return nil, nil, nil, nil, nil, nil, errors.Newf("post-release %q is older than latest full version.", postRelease)
+		}
 	}
 
 	// Std versions tests are all versions within a minor version of the release candidate, all others are MVU.


### PR DESCRIPTION
Last week, I ran into an obscure error where an internal release build had it's release tests failing. 

[Context](https://sourcegraph.slack.com/archives/C05DWT4ANHH/p1715011866175999)

This led to an hypothesis where we believe the version I was trying to release `5.3.666` was assumed by the tests to be behind the latest version `5.3.12303`. I added this check to ensure this doesn't repeat itself.

## Test plan

Will test during the release testing later.
