### PR TITLE
Executors: run script as script, not as command

### DIFF
--- a/cmd/executor/internal/worker/runtime/kubernetes.go
+++ b/cmd/executor/internal/worker/runtime/kubernetes.go
@@ -67,8 +67,8 @@ func (r *kubernetesRuntime) NewRunnerSpecs(ws workspace.Workspace, job types.Job
 				Key:  key,
 				Name: strings.ReplaceAll(key, ".", "-"),
 				Command: []string{
-					"/bin/sh -c " +
-						filepath.Join(command.KubernetesJobMountPath, files.ScriptsPath, scriptName),
+					"/bin/sh",
+					filepath.Join(command.KubernetesJobMountPath, files.ScriptsPath, scriptName),
 				},
 				Dir:   step.Dir,
 				Env:   step.Env,
@@ -90,7 +90,6 @@ func (r *kubernetesRuntime) NewRunnerSpecs(ws workspace.Workspace, job types.Job
 						Name: strings.ReplaceAll(key, ".", "-"),
 						Command: []string{
 							"/bin/sh",
-							"-c",
 							filepath.Join(command.KubernetesJobMountPath, files.ScriptsPath, ws.ScriptFilenames()[i]),
 						},
 						Dir:       step.Dir,

--- a/cmd/executor/internal/worker/runtime/kubernetes_test.go
+++ b/cmd/executor/internal/worker/runtime/kubernetes_test.go
@@ -58,7 +58,7 @@ func TestKubernetesRuntime_NewRunnerSpecs(t *testing.T) {
 					{
 						Key:       "step.kubernetes.key-1",
 						Name:      "step-kubernetes-key-1",
-						Command:   []string{"/bin/sh", "-c", "/job/.sourcegraph-executor/script.sh"},
+						Command:   []string{"/bin/sh", "/job/.sourcegraph-executor/script.sh"},
 						Dir:       ".",
 						Env:       []string{"FOO=bar"},
 						Operation: operations.Exec,
@@ -99,7 +99,7 @@ func TestKubernetesRuntime_NewRunnerSpecs(t *testing.T) {
 						{
 							Key:       "step.kubernetes.key-1",
 							Name:      "step-kubernetes-key-1",
-							Command:   []string{"/bin/sh", "-c", "/job/.sourcegraph-executor/script1.sh"},
+							Command:   []string{"/bin/sh", "/job/.sourcegraph-executor/script1.sh"},
 							Dir:       ".",
 							Env:       []string{"FOO=bar"},
 							Operation: operations.Exec,
@@ -112,7 +112,7 @@ func TestKubernetesRuntime_NewRunnerSpecs(t *testing.T) {
 						{
 							Key:       "step.kubernetes.key-2",
 							Name:      "step-kubernetes-key-2",
-							Command:   []string{"/bin/sh", "-c", "/job/.sourcegraph-executor/script2.sh"},
+							Command:   []string{"/bin/sh", "/job/.sourcegraph-executor/script2.sh"},
 							Dir:       ".",
 							Env:       []string{"FOO=bar"},
 							Operation: operations.Exec,
@@ -145,7 +145,7 @@ func TestKubernetesRuntime_NewRunnerSpecs(t *testing.T) {
 					{
 						Key:       "step.kubernetes.0",
 						Name:      "step-kubernetes-0",
-						Command:   []string{"/bin/sh", "-c", "/job/.sourcegraph-executor/script.sh"},
+						Command:   []string{"/bin/sh", "/job/.sourcegraph-executor/script.sh"},
 						Dir:       ".",
 						Env:       []string{"FOO=bar"},
 						Operation: operations.Exec,
@@ -182,7 +182,7 @@ func TestKubernetesRuntime_NewRunnerSpecs(t *testing.T) {
 					{
 						Key:     "step.kubernetes.my-key",
 						Name:    "step-kubernetes-my-key",
-						Command: []string{"/bin/sh -c /job/.sourcegraph-executor/42.0_github.com_sourcegraph_sourcegraph@deadbeef.sh"},
+						Command: []string{"/bin/sh", "/job/.sourcegraph-executor/42.0_github.com_sourcegraph_sourcegraph@deadbeef.sh"},
 						Dir:     ".",
 						Env:     []string{"FOO=bar"},
 						Image:   "my-image",


### PR DESCRIPTION
This fixes an issue that is generating failures on repos with spaces in their names.

Previously, we were passing the script name as a shell command with `-c`. However, that means it's subject to shell escaping. If we instead pass the file as a script for `sh` to run, it avoids the need to escape the file name and also reduces the surface area for injection attacks.

[Slack thread](https://sourcegraph.slack.com/archives/C02MR5PPMKJ/p1714772085831219)


## Test plan

Updated unit tests. I still want to test this end-to-end, but I'm struggling to get this all built and running locally, so I'm just going to test the image after-merge. It's a very small, high-confidence change, so I'm not terribly worried.

