### PR TITLE
msp/runtime: make Sentry contract integration usable without runtime

### DIFF
--- a/lib/managedservicesplatform/runtime/BUILD.bazel
+++ b/lib/managedservicesplatform/runtime/BUILD.bazel
@@ -14,7 +14,6 @@ go_library(
         "//lib/background",
         "//lib/managedservicesplatform/runtime/contract",
         "//lib/managedservicesplatform/runtime/internal/opentelemetry",
-        "@com_github_getsentry_sentry_go//:sentry-go",
         "@com_github_sourcegraph_log//:log",
         "@com_google_cloud_go_profiler//:profiler",
     ],

--- a/lib/managedservicesplatform/runtime/contract/BUILD.bazel
+++ b/lib/managedservicesplatform/runtime/contract/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "//lib/managedservicesplatform/bigquerywriter",
         "//lib/managedservicesplatform/runtime/internal/opentelemetry",
         "//lib/pointers",
+        "@com_github_getsentry_sentry_go//:sentry-go",
         "@com_github_jackc_pgx_v5//:pgx",
         "@com_github_jackc_pgx_v5//stdlib",
         "@com_github_prometheus_client_golang//prometheus/promhttp",

--- a/lib/managedservicesplatform/runtime/contract/contract.go
+++ b/lib/managedservicesplatform/runtime/contract/contract.go
@@ -108,6 +108,8 @@ type internalContract struct {
 	logger log.Logger
 	// service is a reference to the service that is being configured.
 	service ServiceMetadataProvider
+	// environmentID is the ID of the MSP environment this service is deployed in.
+	environmentID string
 }
 
 // New returns a new Contract instance from configuration parsed from the Env
@@ -115,14 +117,15 @@ type internalContract struct {
 func New(logger log.Logger, service ServiceMetadataProvider, env *Env) Contract {
 	defaultGCPProjectID := pointers.Deref(env.GetOptional("GOOGLE_CLOUD_PROJECT", "GCP project ID"), "")
 	internal := internalContract{
-		logger:  logger,
-		service: service,
+		logger:        logger,
+		service:       service,
+		environmentID: env.Get("ENVIRONMENT_ID", "unknown", "MSP Service Environment ID"),
 	}
 	isMSP := env.GetBool("MSP", "false", "indicates if we are running in a MSP environment")
 
 	return Contract{
 		MSP:             isMSP,
-		EnvironmentID:   env.Get("ENVIRONMENT_ID", "unknown", "MSP Service Environment ID"),
+		EnvironmentID:   internal.environmentID,
 		Port:            env.GetInt("PORT", "", "service port"),
 		ExternalDNSName: env.GetOptional("EXTERNAL_DNS_NAME", "external DNS name provisioned for the service"),
 		RedisEndpoint:   env.GetOptional("REDIS_ENDPOINT", "full Redis address, including any prerequisite authentication"),

--- a/lib/managedservicesplatform/runtime/service.go
+++ b/lib/managedservicesplatform/runtime/service.go
@@ -6,7 +6,6 @@ import (
 	"os"
 
 	"cloud.google.com/go/profiler"
-	"github.com/getsentry/sentry-go"
 	"github.com/sourcegraph/log"
 
 	"github.com/sourcegraph/sourcegraph/lib/background"
@@ -79,20 +78,7 @@ func Start[
 	}
 
 	// Enable Sentry error log reporting
-	var sentryEnabled bool
-	if ctr.Diagnostics.SentryDSN != nil {
-		liblog.Update(func() log.SinksConfig {
-			sentryEnabled = true
-			return log.SinksConfig{
-				Sentry: &log.SentrySink{
-					ClientOptions: sentry.ClientOptions{
-						Dsn:         *ctr.Diagnostics.SentryDSN,
-						Environment: ctr.EnvironmentID,
-					},
-				},
-			}
-		})()
-	}
+	sentryEnabled := ctr.Diagnostics.ConfigureSentry(liblog)
 
 	// Check for environment errors
 	if err := env.Validate(); err != nil {


### PR DESCRIPTION
Allows services to adopt Sentry integration without buying into `runtime` entirely, similar to #61488 

## Test plan

n/a, just some minor refactoring