### PR TITLE
[Svelte]: Fix default blob page panel distribution

### DIFF
--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/+layout.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/+layout.svelte
@@ -196,15 +196,15 @@
         <PanelResizeHandle id="blob-page-panels-separator" />
     {/if}
 
-    <Panel id="content-panel" order={2}>
+    <Panel id="blob-content-panels" order={2}>
         <PanelGroup id="content-panels" direction="vertical">
-            <Panel id="main-content-panel" order={1} defaultSize={90}>
+            <Panel id="main-content-panel" order={1}>
                 <slot />
             </Panel>
             <PanelResizeHandle />
             <Panel
                 bind:this={bottomPanel}
-                id="bottom-tabs-panel"
+                id="bottom-actions-panel"
                 order={2}
                 defaultSize={1}
                 minSize={20}


### PR DESCRIPTION
Prior to this PR, it was possible to see this incorrect state when the bottom panel collapsed but some of the action tabs were selected

<img width="774" alt="Screenshot 2024-05-07 at 11 40 35" src="https://github.com/sourcegraph/sourcegraph/assets/18492575/524a6d88-4ed6-488a-9d3e-5172de1ea5ca">

This happened because users' panels without saved layout in their local storage tried to calculate an initial layout automatically, and, despite the fact that the bottom panel has default size 1 (which is equal to its collapsed size 1), instead, it got a 1.09... value because the content panel had 90 as a default size and the rest space was distributed proportionally. 

So what we got at the end is 
- Content panel has 98.91... size
- Bottom panel has 1.09... size 
- Resize panels logic sees that panel has a bigger size than its collapsed size and fires onExpand callback 
- This callback set History tab selected
- As a result, a visually collapsed panel but with a selected tab in it. 

In this PR, I removed the default size setting from the content panel, which makes it take all available space (this is how we ensure that the bottom panel always gets 1 as default size). I also changed IDs to make sure that existing values in local storage won't have an effect there.



## Test plan
- Clear the local storage
- Check the blob UI page (directory and file)
- Check that you can expand and collapse panels and go between different files in one session

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
