### PR TITLE
chore(rel): bump minor for stitch graph + add support invalidating migrations repo rule

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -502,6 +502,7 @@ load("//dev:schema_migrations.bzl", "schema_migrations")
 
 schema_migrations(
     name = "schemas_migrations",
+    updated_at = "2024-05-07 14:39",
 )
 
 # wolfi images setup ================================

--- a/dev/schema_migrations.bzl
+++ b/dev/schema_migrations.bzl
@@ -1,3 +1,11 @@
+"""
+Provide a custom repository_rule to fetch database migrations from previous versions from
+a GCS bucket.
+
+The "updated_at" attribute allows to manually invalidate the cache, because the rule itself
+cannot know when to do so, as it will simply skip listing the bucket otherwise.
+"""
+
 def _schema_migrations(rctx):
     """
     This repository is used to download the schema migrations from GCS.
@@ -54,4 +62,7 @@ filegroup(
 
 schema_migrations = repository_rule(
     implementation = _schema_migrations,
+    attrs = {
+        "updated_at": attr.string(mandatory = True),
+    },
 )

--- a/internal/database/migration/shared/data/cmd/generator/consts.go
+++ b/internal/database/migration/shared/data/cmd/generator/consts.go
@@ -10,7 +10,7 @@ import (
 // NOTE: This should be kept up-to-date with the upcoming version to be released, and bumped after.
 // fallback schemas everything we support migrating to. The release tool automates this upgrade, so don't touch this :)
 // This should be the last minor version since patch releases only happen in the release branch.
-const maxVersionString = "5.3.0"
+const maxVersionString = "5.4.0"
 
 // MaxVersion is the highest known released version at the time the migrator was built.
 var MaxVersion = func() oobmigration.Version {

--- a/internal/database/migration/shared/data/stitched-migration-graph.json
+++ b/internal/database/migration/shared/data/stitched-migration-graph.json
@@ -926,6 +926,13 @@
 					1679051112
 				],
 				"PreCreation": false
+			},
+			"v5.4.0": {
+				"RootID": 1000000027,
+				"LeafIDs": [
+					1679051112
+				],
+				"PreCreation": false
 			}
 		}
 	},
@@ -1890,6 +1897,13 @@
 				"PreCreation": false
 			},
 			"v5.3.0": {
+				"RootID": 1000000033,
+				"LeafIDs": [
+					1686315964
+				],
+				"PreCreation": false
+			},
+			"v5.4.0": {
 				"RootID": 1000000033,
 				"LeafIDs": [
 					1686315964
@@ -11456,6 +11470,15 @@
 				"PreCreation": false
 			},
 			"v5.3.0": {
+				"RootID": 1648051770,
+				"LeafIDs": [
+					1709738515,
+					1711003437,
+					1711538234
+				],
+				"PreCreation": false
+			},
+			"v5.4.0": {
 				"RootID": 1648051770,
 				"LeafIDs": [
 					1713958707


### PR DESCRIPTION
This PR does two things: 

- Bumps the minor number for the last manual bit for stitch graph
- Adds a new attribute on the `repository_rule` for fetching the migrations on GCS, as otherwise, it would just skip it unless you clear your cache, which could have dire consequences in CI. 

## Test plan

Locally tested (saw the invalidation)
Stitch graph will checked through review. 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
