### PR TITLE
Cody PLG: Change fine-tuned model identifier for completions

### DIFF
--- a/internal/completions/client/fireworks/fireworks.go
+++ b/internal/completions/client/fireworks/fireworks.go
@@ -32,7 +32,7 @@ const Mistral7bInstruct = "accounts/fireworks/models/mistral-7b-instruct-4k"
 const Mixtral8x7bInstruct = "accounts/fireworks/models/mixtral-8x7b-instruct"
 const Mixtral8x22Instruct = "accounts/fireworks/models/mixtral-8x22b-instruct"
 
-const Mixtral8x7bFineTunedModel = "accounts/sourcegraph/models/codecompletion-m-mixtral-rb-rs-m-go-400k-25e"
+const Mixtral8x7bFineTunedModel = "accounts/sourcegraph/models/codecompletion-mixtral-rust-152k-005e"
 
 func NewClient(cli httpcli.Doer, endpoint, accessToken string) types.CompletionsClient {
 	return &fireworksClient{


### PR DESCRIPTION
## Context
1. Change the fine-tuned model for completions.

## Test plan
```
curl -vS -X POST http://localhost:9992/v1/completions/fireworks -H 'Authorization: bearer <SGD_TOKEN>' -d '{"stream":false,"max_tokens":50, "model": "accounts/sourcegraph/models/codecompletion-mixtral-rust-152k-005e", "stop_sequences": ["\n\n"], "prompt": "const value = ", "stream":false}' -H 'X-sourcegraph-feature: code_completions'
```

