### PR TITLE
chore(rel): remove broken annotation code

### DIFF
--- a/release.yaml
+++ b/release.yaml
@@ -68,9 +68,6 @@ internal:
             else
               echo "Build created, see:"
               echo $body | jq .web_url
-              cat << EOF | buildkite-agent annotate --style info
-              This is a Release build. Learn more about the process in the [reference documentation](https://www.notion.so/sourcegraph/Releases-3429f31510f2451fbc38a7f9ccaa0492)
-              EOF
             fi
   finalize:
     steps:
@@ -221,9 +218,6 @@ promoteToPublic:
           else
             echo "Build created, see:"
             echo $body | jq .web_url
-            cat << EOF | buildkite-agent annotate --style info
-            This is a Release build. Learn more about the process in the [reference documentation](https://www.notion.so/sourcegraph/Releases-3429f31510f2451fbc38a7f9ccaa0492)
-            EOF
           fi
   finalize:
     steps:


### PR DESCRIPTION
@Chickensoupwithrice I completely missed that at review time, the annotation code was added on the `create` and `promote` steps, which are run locally and not in CI. 

## Test plan

Tested over https://buildkite.com/sourcegraph/sourcegraph/builds/273082

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
