### PR TITLE
release: wrap interpolated value with single quote

### DIFF
--- a/release.yaml
+++ b/release.yaml
@@ -80,7 +80,7 @@ internal:
           body=$(wget --content-on-error -O- --header="Content-Type: application/json" --header="Authorization: ${RELEASE_REGISTRY_TOKEN}" --post-data '{
               "name": "sourcegraph",
               "version": "{{version}}",
-              "git_sha": "${COMMIT_SHA}"
+              "git_sha": "'${COMMIT_SHA}':"
             }' "https://releaseregistry.sourcegraph.com/v1/releases")
           exit_code=$?
 

--- a/release.yaml
+++ b/release.yaml
@@ -80,7 +80,7 @@ internal:
           body=$(wget --content-on-error -O- --header="Content-Type: application/json" --header="Authorization: ${RELEASE_REGISTRY_TOKEN}" --post-data '{
               "name": "sourcegraph",
               "version": "{{version}}",
-              "git_sha": "'${COMMIT_SHA}':"
+              "git_sha": "'${COMMIT_SHA}'"
             }' "https://releaseregistry.sourcegraph.com/v1/releases")
           exit_code=$?
 


### PR DESCRIPTION
earlier today, we ran into an issue 

![CleanShot 2024-05-07 at 15 56 23@2x](https://github.com/sourcegraph/sourcegraph/assets/25608335/6d279c14-c821-4887-b037-474d558efd6a)

Where the command to set the Git SHA when creating a release wasn't interpolating the GIT_SHA from Buildkite properly.

## Test plan

Local testing using a snippet and running it.

![CleanShot 2024-05-07 at 16 46 03](https://github.com/sourcegraph/sourcegraph/assets/25608335/1e788ff2-2cc7-4abe-9ef4-0bb96486fed9)
