### PR TITLE
telemetry/resolvers: improve logging on RecordEvents errors

### DIFF
--- a/cmd/frontend/internal/telemetry/resolvers/BUILD.bazel
+++ b/cmd/frontend/internal/telemetry/resolvers/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
         "//internal/gqlutil",
         "//internal/telemetry/teestore",
         "//internal/telemetrygateway/event",
+        "//internal/trace",
         "//internal/version",
         "//lib/errors",
         "//lib/pointers",

--- a/cmd/frontend/internal/telemetry/resolvers/resolvers.go
+++ b/cmd/frontend/internal/telemetry/resolvers/resolvers.go
@@ -81,8 +81,12 @@ func (r *Resolver) RecordEvents(ctx context.Context, args *graphqlbackend.Record
 		return nil, errors.Wrap(err, "invalid events provided")
 	}
 	if err := r.teestore.StoreEvents(ctx, gatewayEvents); err != nil {
+		// This is an important failure, make sure we surface it, as it could be
+		// an implementation error.
+		data, _ := json.Marshal(args.Events)
 		trace.Logger(ctx, r.logger).Error("error storing events",
-			log.Error(err))
+			log.Error(err),
+			log.String("eventData", string(data)))
 		return nil, errors.Wrap(err, "error storing events")
 	}
 	return &graphqlbackend.EmptyResponse{}, nil

--- a/cmd/frontend/internal/telemetry/resolvers/telemetrygateway.go
+++ b/cmd/frontend/internal/telemetry/resolvers/telemetrygateway.go
@@ -27,7 +27,7 @@ func newTelemetryGatewayEvents(
 	for i, gqlEvent := range gqlEvents {
 		if err := telemetrygatewayv1.ValidateEventFeatureAction(gqlEvent.Feature, gqlEvent.Action); err != nil {
 			return nil, errors.Wrapf(err, "invalid feature/action for event %d: %s/%s",
-				i, gqlEvent.Feature, gqlEvent.Action)
+				i, errors.Safe(gqlEvent.Feature), errors.Safe(gqlEvent.Action))
 		}
 
 		event := telemetrygatewayevent.New(ctx, now, newUUID)


### PR DESCRIPTION
I've added Sentry rule for the current scope `enterprise.telemetry` to go to #alerts-telemetry-gateway-prod

## Test plan

CI