### PR TITLE
Fix panic on startup

### DIFF
--- a/cmd/frontend/internal/app/jscontext/jscontext.go
+++ b/cmd/frontend/internal/app/jscontext/jscontext.go
@@ -476,7 +476,9 @@ func NewJSContextFromRequest(req *http.Request, db database.DB) JSContext {
 		SvelteKit: sveltekit.GetJSContext(req.Context()),
 	}
 	if dotcomConfig := conf.Get().Dotcom; dotcomConfig != nil {
-		context.FrontendCodyProConfig = makeFrontendCodyProConfig(dotcomConfig.CodyProConfig)
+		if codyProConfig := dotcomConfig.CodyProConfig; codyProConfig != nil {
+			context.FrontendCodyProConfig = makeFrontendCodyProConfig(dotcomConfig.CodyProConfig)
+		}
 	}
 
 	// If the license a Sourcegraph instance is running under does not support Code Search features
@@ -701,6 +703,9 @@ func licenseInfo() (info LicenseInfo) {
 }
 
 func makeFrontendCodyProConfig(config *schema.CodyProConfig) *FrontendCodyProConfig {
+	if config == nil {
+		return nil
+	}
 	return &FrontendCodyProConfig{
 		StripePublishableKey: config.StripePublishableKey,
 	}


### PR DESCRIPTION
When addressing the PR feedback for a recent change I merged https://github.com/sourcegraph/sourcegraph/pull/62322, I didn't account for a `nil`-check that was in an earlier rev of the code. (😓)

We shouldn't assume that the `codyProConfig` setting is available if we are running in "dotcom mode".

## Test plan

CI/CD