### PR TITLE
fix: deprecation in pkg call

### DIFF
--- a/internal/appliance/gitserver.go
+++ b/internal/appliance/gitserver.go
@@ -119,7 +119,7 @@ func (r *Reconciler) reconcileGitServerStatefulSet(ctx context.Context, sg *Sour
 func (r *Reconciler) reconcileGitServerService(ctx context.Context, sg *Sourcegraph, owner client.Object) error {
 	svc := service.NewService("gitserver", sg.Namespace, sg.Spec.GitServer)
 	svc.Spec.Ports = []corev1.ServicePort{
-		{Name: "unused", TargetPort: intstr.FromInt(10811), Port: 10811},
+		{Name: "unused", TargetPort: intstr.FromInt32(10811), Port: 10811},
 	}
 	svc.Spec.Selector = map[string]string{
 		"app":  "gitserver",


### PR DESCRIPTION
Fix minor deprecation when calling the `intstr` pkg.

## Test plan
Previous tests apply

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
