### PR TITLE
Rockskip: simplify ruler function

### DIFF
--- a/internal/rockskip/server.go
+++ b/internal/rockskip/server.go
@@ -266,11 +266,10 @@ func DeleteOldRepos(ctx context.Context, db *sql.DB, maxRepos int, threadStatus 
 //
 // https://oeis.org/A007814
 func ruler(n int) int {
-	if n == 0 {
-		return 0
+	height := 0
+	for n > 0 && n%2 == 0 {
+		height++
+		n = n / 2
 	}
-	if n%2 != 0 {
-		return 0
-	}
-	return 1 + ruler(n/2)
+	return height
 }

--- a/internal/rockskip/server_test.go
+++ b/internal/rockskip/server_test.go
@@ -366,3 +366,30 @@ func (f *mockRepositoryFetcher) FetchRepositoryArchive(ctx context.Context, repo
 
 	return ch
 }
+
+func TestRuler(t *testing.T) {
+	testCases := []struct {
+		n    int
+		want int
+	}{
+		{0, 0},
+		{1, 0},
+		{2, 1},
+		{3, 0},
+		{4, 2},
+		{5, 0},
+		{6, 1},
+		{7, 0},
+		{8, 3},
+		{64, 6},
+		{96, 5},
+		{123, 0},
+	}
+
+	for _, tc := range testCases {
+		got := ruler(tc.n)
+		if got != tc.want {
+			t.Errorf("ruler(%d): got %d, want %d", tc.n, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
Adds a test for the ruler function and simplifies the function to remove tail
recursion.

A tiny warm-up as we work on improving Rockskip test coverage.

## Test plan

Added new test case.