### PR TITLE
gitserver: Move implementation of HasCommitAfter to caller

### DIFF
--- a/internal/batches/sources/mocks_test.go
+++ b/internal/batches/sources/mocks_test.go
@@ -11019,9 +11019,6 @@ type MockGitserverClient struct {
 	// GetObjectFunc is an instance of a mock function object controlling
 	// the behavior of the method GetObject.
 	GetObjectFunc *GitserverClientGetObjectFunc
-	// HasCommitAfterFunc is an instance of a mock function object
-	// controlling the behavior of the method HasCommitAfter.
-	HasCommitAfterFunc *GitserverClientHasCommitAfterFunc
 	// IsPerforcePathCloneableFunc is an instance of a mock function object
 	// controlling the behavior of the method IsPerforcePathCloneable.
 	IsPerforcePathCloneableFunc *GitserverClientIsPerforcePathCloneableFunc
@@ -11159,11 +11156,6 @@ func NewMockGitserverClient() *MockGitserverClient {
 		},
 		GetObjectFunc: &GitserverClientGetObjectFunc{
 			defaultHook: func(context.Context, api.RepoName, string) (r0 *gitdomain.GitObject, r1 error) {
-				return
-			},
-		},
-		HasCommitAfterFunc: &GitserverClientHasCommitAfterFunc{
-			defaultHook: func(context.Context, api.RepoName, string, string) (r0 bool, r1 error) {
 				return
 			},
 		},
@@ -11354,11 +11346,6 @@ func NewStrictMockGitserverClient() *MockGitserverClient {
 				panic("unexpected invocation of MockGitserverClient.GetObject")
 			},
 		},
-		HasCommitAfterFunc: &GitserverClientHasCommitAfterFunc{
-			defaultHook: func(context.Context, api.RepoName, string, string) (bool, error) {
-				panic("unexpected invocation of MockGitserverClient.HasCommitAfter")
-			},
-		},
 		IsPerforcePathCloneableFunc: &GitserverClientIsPerforcePathCloneableFunc{
 			defaultHook: func(context.Context, protocol.PerforceConnectionDetails, string) error {
 				panic("unexpected invocation of MockGitserverClient.IsPerforcePathCloneable")
@@ -11520,9 +11507,6 @@ func NewMockGitserverClientFrom(i gitserver.Client) *MockGitserverClient {
 		},
 		GetObjectFunc: &GitserverClientGetObjectFunc{
 			defaultHook: i.GetObject,
-		},
-		HasCommitAfterFunc: &GitserverClientHasCommitAfterFunc{
-			defaultHook: i.HasCommitAfter,
 		},
 		IsPerforcePathCloneableFunc: &GitserverClientIsPerforcePathCloneableFunc{
 			defaultHook: i.IsPerforcePathCloneable,
@@ -13045,122 +13029,6 @@ func (c GitserverClientGetObjectFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c GitserverClientGetObjectFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
-}
-
-// GitserverClientHasCommitAfterFunc describes the behavior when the
-// HasCommitAfter method of the parent MockGitserverClient instance is
-// invoked.
-type GitserverClientHasCommitAfterFunc struct {
-	defaultHook func(context.Context, api.RepoName, string, string) (bool, error)
-	hooks       []func(context.Context, api.RepoName, string, string) (bool, error)
-	history     []GitserverClientHasCommitAfterFuncCall
-	mutex       sync.Mutex
-}
-
-// HasCommitAfter delegates to the next hook function in the queue and
-// stores the parameter and result values of this invocation.
-func (m *MockGitserverClient) HasCommitAfter(v0 context.Context, v1 api.RepoName, v2 string, v3 string) (bool, error) {
-	r0, r1 := m.HasCommitAfterFunc.nextHook()(v0, v1, v2, v3)
-	m.HasCommitAfterFunc.appendCall(GitserverClientHasCommitAfterFuncCall{v0, v1, v2, v3, r0, r1})
-	return r0, r1
-}
-
-// SetDefaultHook sets function that is called when the HasCommitAfter
-// method of the parent MockGitserverClient instance is invoked and the hook
-// queue is empty.
-func (f *GitserverClientHasCommitAfterFunc) SetDefaultHook(hook func(context.Context, api.RepoName, string, string) (bool, error)) {
-	f.defaultHook = hook
-}
-
-// PushHook adds a function to the end of hook queue. Each invocation of the
-// HasCommitAfter method of the parent MockGitserverClient instance invokes
-// the hook at the front of the queue and discards it. After the queue is
-// empty, the default hook function is invoked for any future action.
-func (f *GitserverClientHasCommitAfterFunc) PushHook(hook func(context.Context, api.RepoName, string, string) (bool, error)) {
-	f.mutex.Lock()
-	f.hooks = append(f.hooks, hook)
-	f.mutex.Unlock()
-}
-
-// SetDefaultReturn calls SetDefaultHook with a function that returns the
-// given values.
-func (f *GitserverClientHasCommitAfterFunc) SetDefaultReturn(r0 bool, r1 error) {
-	f.SetDefaultHook(func(context.Context, api.RepoName, string, string) (bool, error) {
-		return r0, r1
-	})
-}
-
-// PushReturn calls PushHook with a function that returns the given values.
-func (f *GitserverClientHasCommitAfterFunc) PushReturn(r0 bool, r1 error) {
-	f.PushHook(func(context.Context, api.RepoName, string, string) (bool, error) {
-		return r0, r1
-	})
-}
-
-func (f *GitserverClientHasCommitAfterFunc) nextHook() func(context.Context, api.RepoName, string, string) (bool, error) {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-
-	if len(f.hooks) == 0 {
-		return f.defaultHook
-	}
-
-	hook := f.hooks[0]
-	f.hooks = f.hooks[1:]
-	return hook
-}
-
-func (f *GitserverClientHasCommitAfterFunc) appendCall(r0 GitserverClientHasCommitAfterFuncCall) {
-	f.mutex.Lock()
-	f.history = append(f.history, r0)
-	f.mutex.Unlock()
-}
-
-// History returns a sequence of GitserverClientHasCommitAfterFuncCall
-// objects describing the invocations of this function.
-func (f *GitserverClientHasCommitAfterFunc) History() []GitserverClientHasCommitAfterFuncCall {
-	f.mutex.Lock()
-	history := make([]GitserverClientHasCommitAfterFuncCall, len(f.history))
-	copy(history, f.history)
-	f.mutex.Unlock()
-
-	return history
-}
-
-// GitserverClientHasCommitAfterFuncCall is an object that describes an
-// invocation of method HasCommitAfter on an instance of
-// MockGitserverClient.
-type GitserverClientHasCommitAfterFuncCall struct {
-	// Arg0 is the value of the 1st argument passed to this method
-	// invocation.
-	Arg0 context.Context
-	// Arg1 is the value of the 2nd argument passed to this method
-	// invocation.
-	Arg1 api.RepoName
-	// Arg2 is the value of the 3rd argument passed to this method
-	// invocation.
-	Arg2 string
-	// Arg3 is the value of the 4th argument passed to this method
-	// invocation.
-	Arg3 string
-	// Result0 is the value of the 1st result returned from this method
-	// invocation.
-	Result0 bool
-	// Result1 is the value of the 2nd result returned from this method
-	// invocation.
-	Result1 error
-}
-
-// Args returns an interface slice containing the arguments of this
-// invocation.
-func (c GitserverClientHasCommitAfterFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3}
-}
-
-// Results returns an interface slice containing the results of this
-// invocation.
-func (c GitserverClientHasCommitAfterFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 

--- a/internal/gitserver/client.go
+++ b/internal/gitserver/client.go
@@ -371,10 +371,6 @@ type Client interface {
 	// GetObject fetches git object data in the supplied repo
 	GetObject(ctx context.Context, repo api.RepoName, objectName string) (*gitdomain.GitObject, error)
 
-	// HasCommitAfter indicates the staleness of a repository. It returns a boolean indicating if a repository
-	// contains a commit past a specified date.
-	HasCommitAfter(ctx context.Context, repo api.RepoName, date string, revspec string) (bool, error)
-
 	// IsRepoCloneable returns nil if the repository is cloneable.
 	IsRepoCloneable(context.Context, api.RepoName) error
 

--- a/internal/gitserver/commands.go
+++ b/internal/gitserver/commands.go
@@ -1051,35 +1051,6 @@ func hasAccessToCommit(ctx context.Context, commit *wrappedCommit, repoName api.
 	return false, nil
 }
 
-// HasCommitAfter indicates the staleness of a repository. It returns a boolean indicating if a repository
-// contains a commit past a specified date.
-func (c *clientImplementor) HasCommitAfter(ctx context.Context, repo api.RepoName, date string, revspec string) (_ bool, err error) {
-	ctx, _, endObservation := c.operations.hasCommitAfter.With(ctx, &err, observation.Args{
-		MetricLabelValues: []string{c.scope},
-		Attrs: []attribute.KeyValue{
-			repo.Attr(),
-			attribute.String("date", date),
-			attribute.String("revSpec", revspec),
-		},
-	})
-	defer endObservation(1, observation.Args{})
-
-	if revspec == "" {
-		revspec = "HEAD"
-	}
-
-	// TODO: Because N: 1 currently has a special meaning because of `isRequestForSingleCommit`,
-	// we ask for two commits here, but the second one we never actually need.
-	// One we figure out why `isRequestForSingleCommit` exists in the first place,
-	// we should update this.
-	commits, err := c.Commits(ctx, repo, CommitsOptions{N: 2, After: date, Range: revspec})
-	if err != nil {
-		return false, err
-	}
-
-	return len(commits) > 0, nil
-}
-
 func isBadObjectErr(output, obj string) bool {
 	return output == "fatal: bad object "+obj
 }

--- a/internal/gitserver/mocks_temp.go
+++ b/internal/gitserver/mocks_temp.go
@@ -63,9 +63,6 @@ type MockClient struct {
 	// GetObjectFunc is an instance of a mock function object controlling
 	// the behavior of the method GetObject.
 	GetObjectFunc *ClientGetObjectFunc
-	// HasCommitAfterFunc is an instance of a mock function object
-	// controlling the behavior of the method HasCommitAfter.
-	HasCommitAfterFunc *ClientHasCommitAfterFunc
 	// IsPerforcePathCloneableFunc is an instance of a mock function object
 	// controlling the behavior of the method IsPerforcePathCloneable.
 	IsPerforcePathCloneableFunc *ClientIsPerforcePathCloneableFunc
@@ -203,11 +200,6 @@ func NewMockClient() *MockClient {
 		},
 		GetObjectFunc: &ClientGetObjectFunc{
 			defaultHook: func(context.Context, api.RepoName, string) (r0 *gitdomain.GitObject, r1 error) {
-				return
-			},
-		},
-		HasCommitAfterFunc: &ClientHasCommitAfterFunc{
-			defaultHook: func(context.Context, api.RepoName, string, string) (r0 bool, r1 error) {
 				return
 			},
 		},
@@ -398,11 +390,6 @@ func NewStrictMockClient() *MockClient {
 				panic("unexpected invocation of MockClient.GetObject")
 			},
 		},
-		HasCommitAfterFunc: &ClientHasCommitAfterFunc{
-			defaultHook: func(context.Context, api.RepoName, string, string) (bool, error) {
-				panic("unexpected invocation of MockClient.HasCommitAfter")
-			},
-		},
 		IsPerforcePathCloneableFunc: &ClientIsPerforcePathCloneableFunc{
 			defaultHook: func(context.Context, protocol.PerforceConnectionDetails, string) error {
 				panic("unexpected invocation of MockClient.IsPerforcePathCloneable")
@@ -563,9 +550,6 @@ func NewMockClientFrom(i Client) *MockClient {
 		},
 		GetObjectFunc: &ClientGetObjectFunc{
 			defaultHook: i.GetObject,
-		},
-		HasCommitAfterFunc: &ClientHasCommitAfterFunc{
-			defaultHook: i.HasCommitAfter,
 		},
 		IsPerforcePathCloneableFunc: &ClientIsPerforcePathCloneableFunc{
 			defaultHook: i.IsPerforcePathCloneable,
@@ -2065,120 +2049,6 @@ func (c ClientGetObjectFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c ClientGetObjectFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
-}
-
-// ClientHasCommitAfterFunc describes the behavior when the HasCommitAfter
-// method of the parent MockClient instance is invoked.
-type ClientHasCommitAfterFunc struct {
-	defaultHook func(context.Context, api.RepoName, string, string) (bool, error)
-	hooks       []func(context.Context, api.RepoName, string, string) (bool, error)
-	history     []ClientHasCommitAfterFuncCall
-	mutex       sync.Mutex
-}
-
-// HasCommitAfter delegates to the next hook function in the queue and
-// stores the parameter and result values of this invocation.
-func (m *MockClient) HasCommitAfter(v0 context.Context, v1 api.RepoName, v2 string, v3 string) (bool, error) {
-	r0, r1 := m.HasCommitAfterFunc.nextHook()(v0, v1, v2, v3)
-	m.HasCommitAfterFunc.appendCall(ClientHasCommitAfterFuncCall{v0, v1, v2, v3, r0, r1})
-	return r0, r1
-}
-
-// SetDefaultHook sets function that is called when the HasCommitAfter
-// method of the parent MockClient instance is invoked and the hook queue is
-// empty.
-func (f *ClientHasCommitAfterFunc) SetDefaultHook(hook func(context.Context, api.RepoName, string, string) (bool, error)) {
-	f.defaultHook = hook
-}
-
-// PushHook adds a function to the end of hook queue. Each invocation of the
-// HasCommitAfter method of the parent MockClient instance invokes the hook
-// at the front of the queue and discards it. After the queue is empty, the
-// default hook function is invoked for any future action.
-func (f *ClientHasCommitAfterFunc) PushHook(hook func(context.Context, api.RepoName, string, string) (bool, error)) {
-	f.mutex.Lock()
-	f.hooks = append(f.hooks, hook)
-	f.mutex.Unlock()
-}
-
-// SetDefaultReturn calls SetDefaultHook with a function that returns the
-// given values.
-func (f *ClientHasCommitAfterFunc) SetDefaultReturn(r0 bool, r1 error) {
-	f.SetDefaultHook(func(context.Context, api.RepoName, string, string) (bool, error) {
-		return r0, r1
-	})
-}
-
-// PushReturn calls PushHook with a function that returns the given values.
-func (f *ClientHasCommitAfterFunc) PushReturn(r0 bool, r1 error) {
-	f.PushHook(func(context.Context, api.RepoName, string, string) (bool, error) {
-		return r0, r1
-	})
-}
-
-func (f *ClientHasCommitAfterFunc) nextHook() func(context.Context, api.RepoName, string, string) (bool, error) {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-
-	if len(f.hooks) == 0 {
-		return f.defaultHook
-	}
-
-	hook := f.hooks[0]
-	f.hooks = f.hooks[1:]
-	return hook
-}
-
-func (f *ClientHasCommitAfterFunc) appendCall(r0 ClientHasCommitAfterFuncCall) {
-	f.mutex.Lock()
-	f.history = append(f.history, r0)
-	f.mutex.Unlock()
-}
-
-// History returns a sequence of ClientHasCommitAfterFuncCall objects
-// describing the invocations of this function.
-func (f *ClientHasCommitAfterFunc) History() []ClientHasCommitAfterFuncCall {
-	f.mutex.Lock()
-	history := make([]ClientHasCommitAfterFuncCall, len(f.history))
-	copy(history, f.history)
-	f.mutex.Unlock()
-
-	return history
-}
-
-// ClientHasCommitAfterFuncCall is an object that describes an invocation of
-// method HasCommitAfter on an instance of MockClient.
-type ClientHasCommitAfterFuncCall struct {
-	// Arg0 is the value of the 1st argument passed to this method
-	// invocation.
-	Arg0 context.Context
-	// Arg1 is the value of the 2nd argument passed to this method
-	// invocation.
-	Arg1 api.RepoName
-	// Arg2 is the value of the 3rd argument passed to this method
-	// invocation.
-	Arg2 string
-	// Arg3 is the value of the 4th argument passed to this method
-	// invocation.
-	Arg3 string
-	// Result0 is the value of the 1st result returned from this method
-	// invocation.
-	Result0 bool
-	// Result1 is the value of the 2nd result returned from this method
-	// invocation.
-	Result1 error
-}
-
-// Args returns an interface slice containing the arguments of this
-// invocation.
-func (c ClientHasCommitAfterFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3}
-}
-
-// Results returns an interface slice containing the results of this
-// invocation.
-func (c ClientHasCommitAfterFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 

--- a/internal/gitserver/observability.go
+++ b/internal/gitserver/observability.go
@@ -20,7 +20,6 @@ type operations struct {
 	firstEverCommit          *observation.Operation
 	behindAhead              *observation.Operation
 	getCommit                *observation.Operation
-	hasCommitAfter           *observation.Operation
 	listRefs                 *observation.Operation
 	lstat                    *observation.Operation
 	mergeBase                *observation.Operation
@@ -47,7 +46,6 @@ type operations struct {
 	getObject                *observation.Operation
 	getDefaultBranch         *observation.Operation
 	logReverseEach           *observation.Operation
-	diffSymbols              *observation.Operation
 	diff                     *observation.Operation
 	changedFiles             *observation.Operation
 }
@@ -105,7 +103,6 @@ func newOperations(observationCtx *observation.Context) *operations {
 		firstEverCommit:          op("FirstEverCommit"),
 		behindAhead:              op("BehindAhead"),
 		getCommit:                op("GetCommit"),
-		hasCommitAfter:           op("HasCommitAfter"),
 		listRefs:                 op("ListRefs"),
 		lstat:                    subOp("lStat"),
 		mergeBase:                op("MergeBase"),
@@ -132,7 +129,6 @@ func newOperations(observationCtx *observation.Context) *operations {
 		getObject:                op("GetObject"),
 		getDefaultBranch:         op("GetDefaultBranch"),
 		logReverseEach:           op("LogReverseEach"),
-		diffSymbols:              op("DiffSymbols"),
 		diff:                     op("Diff"),
 		changedFiles:             op("ChangedFiles"),
 	}

--- a/internal/search/repos/repos_test.go
+++ b/internal/search/repos/repos_test.go
@@ -799,16 +799,16 @@ func TestRepoHasCommitAfter(t *testing.T) {
 	}
 
 	mockGitserver := gitserver.NewMockClient()
-	mockGitserver.HasCommitAfterFunc.SetDefaultHook(func(_ context.Context, repoName api.RepoName, _ string, _ string) (bool, error) {
+	mockGitserver.CommitsFunc.SetDefaultHook(func(_ context.Context, repoName api.RepoName, _ gitserver.CommitsOptions) ([]*gitdomain.Commit, error) {
 		switch repoName {
 		case repoA.Name:
-			return true, nil
+			return []*gitdomain.Commit{{ID: "1"}}, nil
 		case repoB.Name:
-			return true, nil
+			return []*gitdomain.Commit{{ID: "1"}}, nil
 		case repoC.Name:
-			return false, nil
+			return []*gitdomain.Commit{}, nil
 		case repoD.Name:
-			return false, &gitdomain.RevisionNotFoundError{}
+			return []*gitdomain.Commit{}, &gitdomain.RevisionNotFoundError{}
 		default:
 			panic("unreachable")
 		}


### PR DESCRIPTION
This is only used in one place, so we're moving the implementation to the caller. Gitserver client only exposes gRPC methods without additional logic on top.

Closes https://github.com/sourcegraph/sourcegraph/issues/61688

Test plan:

Kept the existing tests but rewrote them to test Commits instead so we don't lose coverage for this.