### PR TITLE
dev/linearhooks: add support for project modifier

### DIFF
--- a/dev/linearhooks/config.example.yaml
+++ b/dev/linearhooks/config.example.yaml
@@ -13,3 +13,8 @@ spec:
           # teamId is the identifier of the destination team. Issues that match the rule will be moved to this team.
           # Either identifier (i.e. unique team prefix) or UUID is accepted
           teamId: BAR
+          # modifier is an optional field that allows for additional configuration when moving the issue.
+          # Any errors encountered while applying the modifier will be logged, but the issue will still be moved regardless.
+          modifier:
+            # (optional) projectName is the name of the project that the issue will be moved to in the destination team
+            projectName: 'Test Project 1'

--- a/dev/linearhooks/internal/handlers/BUILD.bazel
+++ b/dev/linearhooks/internal/handlers/BUILD.bazel
@@ -30,6 +30,7 @@ go_test(
         "//dev/linearhooks/internal/lineargql",
         "//dev/linearhooks/internal/lineargql/gqltest",
         "//dev/linearhooks/internal/linearschema",
+        "//lib/errors",
         "@com_github_hexops_autogold_v2//:autogold",
         "@com_github_sourcegraph_log//logtest",
         "@com_github_stretchr_testify//assert",

--- a/dev/linearhooks/internal/handlers/config.go
+++ b/dev/linearhooks/internal/handlers/config.go
@@ -33,6 +33,14 @@ type SrcSpec struct {
 
 type DstSpec struct {
 	TeamID string `json:"teamId,omitempty"`
+	// Modifier is an optional field that allows for additional configuration when moving the issue.
+	// Any errors encountered while applying the modifier will be logged, but the issue will still be moved regardless.
+	Modifier *DstModifierSpec `json:"modifier,omitempty"`
+}
+
+type DstModifierSpec struct {
+	// ProjectName is the name of the project that the issue will be moved to. The project must exist in the destination team.
+	ProjectName string `json:"projectName,omitempty"`
 }
 
 func (c *Config) Validate() error {

--- a/dev/linearhooks/internal/lineargql/generated.go
+++ b/dev/linearhooks/internal/lineargql/generated.go
@@ -8,6 +8,58 @@ import (
 	"github.com/Khan/genqlient/graphql"
 )
 
+// GetProjectsByTeamIdResponse is returned by GetProjectsByTeamId on success.
+type GetProjectsByTeamIdResponse struct {
+	// One specific team.
+	Team GetProjectsByTeamIdTeam `json:"team"`
+}
+
+// GetTeam returns GetProjectsByTeamIdResponse.Team, and is useful for accessing the field via an interface.
+func (v *GetProjectsByTeamIdResponse) GetTeam() GetProjectsByTeamIdTeam { return v.Team }
+
+// GetProjectsByTeamIdTeam includes the requested fields of the GraphQL type Team.
+// The GraphQL type's documentation follows.
+//
+// An organizational unit that contains issues.
+type GetProjectsByTeamIdTeam struct {
+	// Projects associated with the team.
+	Projects GetProjectsByTeamIdTeamProjectsProjectConnection `json:"projects"`
+}
+
+// GetProjects returns GetProjectsByTeamIdTeam.Projects, and is useful for accessing the field via an interface.
+func (v *GetProjectsByTeamIdTeam) GetProjects() GetProjectsByTeamIdTeamProjectsProjectConnection {
+	return v.Projects
+}
+
+// GetProjectsByTeamIdTeamProjectsProjectConnection includes the requested fields of the GraphQL type ProjectConnection.
+type GetProjectsByTeamIdTeamProjectsProjectConnection struct {
+	Nodes []GetProjectsByTeamIdTeamProjectsProjectConnectionNodesProject `json:"nodes"`
+}
+
+// GetNodes returns GetProjectsByTeamIdTeamProjectsProjectConnection.Nodes, and is useful for accessing the field via an interface.
+func (v *GetProjectsByTeamIdTeamProjectsProjectConnection) GetNodes() []GetProjectsByTeamIdTeamProjectsProjectConnectionNodesProject {
+	return v.Nodes
+}
+
+// GetProjectsByTeamIdTeamProjectsProjectConnectionNodesProject includes the requested fields of the GraphQL type Project.
+// The GraphQL type's documentation follows.
+//
+// A project.
+type GetProjectsByTeamIdTeamProjectsProjectConnectionNodesProject struct {
+	// The project's name.
+	Name string `json:"name"`
+	// The unique identifier of the entity.
+	Id string `json:"id"`
+}
+
+// GetName returns GetProjectsByTeamIdTeamProjectsProjectConnectionNodesProject.Name, and is useful for accessing the field via an interface.
+func (v *GetProjectsByTeamIdTeamProjectsProjectConnectionNodesProject) GetName() string {
+	return v.Name
+}
+
+// GetId returns GetProjectsByTeamIdTeamProjectsProjectConnectionNodesProject.Id, and is useful for accessing the field via an interface.
+func (v *GetProjectsByTeamIdTeamProjectsProjectConnectionNodesProject) GetId() string { return v.Id }
+
 // GetTeamByIdResponse is returned by GetTeamById on success.
 type GetTeamByIdResponse struct {
 	// One specific team.
@@ -59,6 +111,18 @@ func (v *MoveIssueToTeamResponse) GetIssueUpdate() MoveIssueToTeamIssueUpdateIss
 	return v.IssueUpdate
 }
 
+// __GetProjectsByTeamIdInput is used internally by genqlient
+type __GetProjectsByTeamIdInput struct {
+	TeamId      string `json:"teamId"`
+	ProjectName string `json:"projectName"`
+}
+
+// GetTeamId returns __GetProjectsByTeamIdInput.TeamId, and is useful for accessing the field via an interface.
+func (v *__GetProjectsByTeamIdInput) GetTeamId() string { return v.TeamId }
+
+// GetProjectName returns __GetProjectsByTeamIdInput.ProjectName, and is useful for accessing the field via an interface.
+func (v *__GetProjectsByTeamIdInput) GetProjectName() string { return v.ProjectName }
+
 // __GetTeamByIdInput is used internally by genqlient
 type __GetTeamByIdInput struct {
 	Id string `json:"id"`
@@ -69,8 +133,9 @@ func (v *__GetTeamByIdInput) GetId() string { return v.Id }
 
 // __MoveIssueToTeamInput is used internally by genqlient
 type __MoveIssueToTeamInput struct {
-	IssueId string `json:"issueId"`
-	TeamId  string `json:"teamId"`
+	IssueId   string `json:"issueId"`
+	TeamId    string `json:"teamId"`
+	ProjectId string `json:"projectId"`
 }
 
 // GetIssueId returns __MoveIssueToTeamInput.IssueId, and is useful for accessing the field via an interface.
@@ -78,6 +143,52 @@ func (v *__MoveIssueToTeamInput) GetIssueId() string { return v.IssueId }
 
 // GetTeamId returns __MoveIssueToTeamInput.TeamId, and is useful for accessing the field via an interface.
 func (v *__MoveIssueToTeamInput) GetTeamId() string { return v.TeamId }
+
+// GetProjectId returns __MoveIssueToTeamInput.ProjectId, and is useful for accessing the field via an interface.
+func (v *__MoveIssueToTeamInput) GetProjectId() string { return v.ProjectId }
+
+// GetProjectsByTeamID returns a list of projects for a team with matching name
+// - teamID: UUID or identifier of the team
+// - projectName: name of the project to filter by
+// It is possible to return multiple projects with the same name but different IDs
+func GetProjectsByTeamId(
+	ctx context.Context,
+	client graphql.Client,
+	teamId string,
+	projectName string,
+) (*GetProjectsByTeamIdResponse, error) {
+	req := &graphql.Request{
+		OpName: "GetProjectsByTeamId",
+		Query: `
+query GetProjectsByTeamId ($teamId: String!, $projectName: String!) {
+	team(id: $teamId) {
+		projects(filter: {name:{eq:$projectName}}) {
+			nodes {
+				name
+				id
+			}
+		}
+	}
+}
+`,
+		Variables: &__GetProjectsByTeamIdInput{
+			TeamId:      teamId,
+			ProjectName: projectName,
+		},
+	}
+	var err error
+
+	var data GetProjectsByTeamIdResponse
+	resp := &graphql.Response{Data: &data}
+
+	err = client.MakeRequest(
+		ctx,
+		req,
+		resp,
+	)
+
+	return &data, err
+}
 
 // GetTeamById returns a team by its identifier or UUID
 func GetTeamById(
@@ -115,26 +226,29 @@ query GetTeamById ($id: String!) {
 }
 
 // MoveIssueToTeam moves issue between teams
-// - issueId: UUID or identifier of the issue to move
-// - teamId: UUID of the team to move the issue to
+// - issueId: UUID or identifier of the issue to move, required
+// - teamId: UUID of the team to move the issue to, required
+// - projectId: UUID of the project to move the issue to, optional
 func MoveIssueToTeam(
 	ctx context.Context,
 	client graphql.Client,
 	issueId string,
 	teamId string,
+	projectId string,
 ) (*MoveIssueToTeamResponse, error) {
 	req := &graphql.Request{
 		OpName: "MoveIssueToTeam",
 		Query: `
-mutation MoveIssueToTeam ($issueId: String!, $teamId: String!) {
-	issueUpdate(id: $issueId, input: {teamId:$teamId}) {
+mutation MoveIssueToTeam ($issueId: String!, $teamId: String!, $projectId: String) {
+	issueUpdate(id: $issueId, input: {teamId:$teamId,projectId:$projectId}) {
 		lastSyncId
 	}
 }
 `,
 		Variables: &__MoveIssueToTeamInput{
-			IssueId: issueId,
-			TeamId:  teamId,
+			IssueId:   issueId,
+			TeamId:    teamId,
+			ProjectId: projectId,
 		},
 	}
 	var err error

--- a/dev/linearhooks/internal/lineargql/gqltest/gqltest.go
+++ b/dev/linearhooks/internal/lineargql/gqltest/gqltest.go
@@ -61,6 +61,13 @@ func MakeRequestResultStub[T any](mockRespData T) MakeRequestStub {
 	}
 }
 
+// MakeRequestErrorStub generates a stub that returns an error
+func MakeRequestResultErrStub(err error) MakeRequestStub {
+	return func(ctx context.Context, req *graphql.Request, resp *graphql.Response) error {
+		return err
+	}
+}
+
 // MakeRequestStubInvocations can be used to use different stubs for each invocation.
 // Stubs are used in order of invocation.
 //

--- a/dev/linearhooks/internal/lineargql/operations.graphql
+++ b/dev/linearhooks/internal/lineargql/operations.graphql
@@ -8,10 +8,26 @@ query GetTeamById($id: String!) {
 }
 
 # MoveIssueToTeam moves issue between teams
-# - issueId: UUID or identifier of the issue to move
-# - teamId: UUID of the team to move the issue to
-mutation MoveIssueToTeam($issueId: String!, $teamId: String!) {
-    issueUpdate(id: $issueId, input: { teamId: $teamId }) {
+# - issueId: UUID or identifier of the issue to move, required
+# - teamId: UUID of the team to move the issue to, required
+# - projectId: UUID of the project to move the issue to, optional
+mutation MoveIssueToTeam($issueId: String!, $teamId: String!, $projectId: String) {
+    issueUpdate(id: $issueId, input: { teamId: $teamId, projectId: $projectId }) {
         lastSyncId
+    }
+}
+
+# GetProjectsByTeamID returns a list of projects for a team with matching name
+# - teamID: UUID or identifier of the team
+# - projectName: name of the project to filter by
+# It is possible to return multiple projects with the same name but different IDs
+query GetProjectsByTeamId($teamId: String!, $projectName: String!) {
+    team(id: $teamId) {
+        projects(filter: { name: { eq: $projectName } }) {
+            nodes {
+                name
+                id
+            }
+        }
     }
 }


### PR DESCRIPTION
https://sourcegraph.slack.com/archives/C06GAS7FUGL/p1715062692858249

implements a `modifier` spec so we can override the project when moving the issue to another team

## Test plan

added tests and manual testing.
 