### PR TITLE
chore: Rename function to reduce confusion

### DIFF
--- a/dev/linearhooks/internal/handlers/handlers.go
+++ b/dev/linearhooks/internal/handlers/handlers.go
@@ -106,7 +106,7 @@ func (h *Handler) HandleIssueMover(w http.ResponseWriter, r *http.Request) {
 
 func moveIssue(logger log.Logger, client graphql.Client, rules []RuleSpec, issue linearschema.IssueData) error {
 	for _, r := range rules {
-		if newTeamId := r.moveToNewTeam(issue); newTeamId != nil {
+		if newTeamId := r.identifyTeamToMoveTo(issue); newTeamId != nil {
 			logger.Info("moving issue",
 				log.String("from.id", issue.Team.Key),
 				log.String("to", r.Dst.TeamID),
@@ -146,7 +146,7 @@ func moveIssueToTeam(ctx context.Context, c graphql.Client, issueId, teamId stri
 	return err
 }
 
-func (r *RuleSpec) moveToNewTeam(issueData linearschema.IssueData) (newTeamId *string) {
+func (r *RuleSpec) identifyTeamToMoveTo(issueData linearschema.IssueData) (newTeamId *string) {
 	if len(r.Src.Labels) == 0 {
 		// This should never happen as we perform validation on startup, but if it does, we should panic.
 		panic("Expected non-empty label set for RuleSet")

--- a/dev/linearhooks/internal/handlers/handlers_test.go
+++ b/dev/linearhooks/internal/handlers/handlers_test.go
@@ -97,7 +97,7 @@ func Test_moveIssue(t *testing.T) {
 	}
 }
 
-func Test_moveToNewTeam(t *testing.T) {
+func Test_identifyTeamToMoveTo(t *testing.T) {
 	t.Parallel()
 
 	defaultDstSpec := DstSpec{TeamID: "dst-team-uuid"}
@@ -161,7 +161,7 @@ func Test_moveToNewTeam(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			require.NoError(t, tc.r.Validate())
-			got := tc.r.moveToNewTeam(
+			got := tc.r.identifyTeamToMoveTo(
 				linearschema.IssueData{
 					Team:   linearschema.IssueTeamData{ID: tc.issueTeamID, Key: tc.issueTeamKey},
 					Labels: labelsToLabelData(tc.issueLabels),


### PR DESCRIPTION
Previously, there were two similarly named functions
moveToNewTeam and moveIssueToTeam, this renames the first
one to identifyTeamToMoveTo

## Test plan

Covered by existing tests