### PR TITLE
Auto-update package lockfiles for Sourcegraph base images

### DIFF
--- a/wolfi-images/batcheshelper.lock.json
+++ b/wolfi-images/batcheshelper.lock.json
@@ -109,25 +109,6 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1mVgCtcYDHEkUa+8x41i7w9cQ4Qg=",
-        "control": {
-          "checksum": "sha1-mVgCtcYDHEkUa+8x41i7w9cQ4Qg=",
-          "range": "bytes=704-1079"
-        },
-        "data": {
-          "checksum": "sha256-xE4spLqr7qIgImPfMC1kMY1a7Xu7xu1/eLkBMgOzSSc=",
-          "range": "bytes=1080-77936"
-        },
-        "name": "protobuf-c",
-        "signature": {
-          "checksum": "sha1-NGL0ELlBK8mhhAzuOkm17d2LbRo=",
-          "range": "bytes=0-703"
-        },
-        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r3.apk",
-        "version": "1.5.0-r3"
-      },
-      {
-        "architecture": "x86_64",
         "checksum": "Q1TAnNLCVTaCylmbN84TlliyM47qM=",
         "control": {
           "checksum": "sha1-TAnNLCVTaCylmbN84TlliyM47qM=",
@@ -258,6 +239,25 @@
         },
         "url": "https://packages.wolfi.dev/os/x86_64/krb5-libs-1.21.2-r1.apk",
         "version": "1.21.2-r1"
+      },
+      {
+        "architecture": "x86_64",
+        "checksum": "Q1Zjfs1uR/mYiortANP+EFcejW+vo=",
+        "control": {
+          "checksum": "sha1-Zjfs1uR/mYiortANP+EFcejW+vo=",
+          "range": "bytes=698-1085"
+        },
+        "data": {
+          "checksum": "sha256-BMd7TzffjbrFwdbopDPVYsX0X9XnusIMNbIf33/8kwc=",
+          "range": "bytes=1086-76881"
+        },
+        "name": "protobuf-c",
+        "signature": {
+          "checksum": "sha1-efGiXyYWsJ5P2uTkB6aXEZ3kl3o=",
+          "range": "bytes=0-697"
+        },
+        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r4.apk",
+        "version": "1.5.0-r4"
       },
       {
         "architecture": "x86_64",
@@ -470,22 +470,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q12eKoxDrTjnN67UapcxL36uSvK6Y=",
+        "checksum": "Q1TS707T+cPGL7TYVHQBCJoWwHZ0E=",
         "control": {
-          "checksum": "sha1-2eKoxDrTjnN67UapcxL36uSvK6Y=",
-          "range": "bytes=694-1086"
+          "checksum": "sha1-TS707T+cPGL7TYVHQBCJoWwHZ0E=",
+          "range": "bytes=706-1098"
         },
         "data": {
-          "checksum": "sha256-xlBSY4KJHzH59eU8L6EFYVJVksfsqUlpE7yt7WtlBos=",
-          "range": "bytes=1087-4546022"
+          "checksum": "sha256-x18L706Vug5qDzq13SXuN/vGdVgzrqB06dW2DdgHGR4=",
+          "range": "bytes=1099-4541967"
         },
         "name": "libxml2",
         "signature": {
-          "checksum": "sha1-sRrMqWd8n9UGVkkp5YwEQ4xr9iY=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-BYhOxDos48sN8df8LMsSpROv2aw=",
+          "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.12.6-r1.apk",
-        "version": "2.12.6-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.12.7-r0.apk",
+        "version": "2.12.7-r0"
       },
       {
         "architecture": "x86_64",
@@ -527,22 +527,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ZvgMPq5RCd5lQ3v2qeBBOLotsXM=",
+        "checksum": "Q1dLQQZAfXkamLwZ7kLZb2atjfZZQ=",
         "control": {
-          "checksum": "sha1-ZvgMPq5RCd5lQ3v2qeBBOLotsXM=",
-          "range": "bytes=698-1093"
+          "checksum": "sha1-dLQQZAfXkamLwZ7kLZb2atjfZZQ=",
+          "range": "bytes=701-1095"
         },
         "data": {
-          "checksum": "sha256-mQrZT/j9v5ff50OwlphGA2m2AApMWZfnnPaoEBil57Q=",
-          "range": "bytes=1094-233900"
+          "checksum": "sha256-9c2Qzrfedb7BJdu6THUm5TLxb0dvov8v4tvfqBWlUuw=",
+          "range": "bytes=1096-233941"
         },
         "name": "libxcrypt",
         "signature": {
-          "checksum": "sha1-THgEEMvz4LUMjzDPVU7db5XBJ+E=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-DFbDoKQ6O4YqS6aru0hhYo/8TUk=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxcrypt-4.4.36-r5.apk",
-        "version": "4.4.36-r5"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxcrypt-4.4.36-r6.apk",
+        "version": "4.4.36-r6"
       },
       {
         "architecture": "x86_64",
@@ -793,22 +793,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1m7SsrH+XnrPIapzhnK0vkoxMen4=",
+        "checksum": "Q1ZrMuP718My90TnZrml7ylUmXGlo=",
         "control": {
-          "checksum": "sha1-m7SsrH+XnrPIapzhnK0vkoxMen4=",
-          "range": "bytes=698-1077"
+          "checksum": "sha1-ZrMuP718My90TnZrml7ylUmXGlo=",
+          "range": "bytes=702-1093"
         },
         "data": {
-          "checksum": "sha256-0WaULqZyE0zNNC6D7YeaXVN4shAVEouyqAEiRlB09C0=",
-          "range": "bytes=1078-54479"
+          "checksum": "sha256-+ZTF5s9bHKtoArLvOvIL/2seV4pE0ElEj9MlAscAdso=",
+          "range": "bytes=1094-53513"
         },
         "name": "tini",
         "signature": {
-          "checksum": "sha1-eomfhWCyCB1OA/2DHboLUzXunvA=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-OK9J/Z8qnRssJzNCu9hER8FuzSk=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/tini-0.19.0-r3.apk",
-        "version": "0.19.0-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/tini-0.19.0-r4.apk",
+        "version": "0.19.0-r4"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/blobstore.lock.json
+++ b/wolfi-images/blobstore.lock.json
@@ -109,25 +109,6 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1mVgCtcYDHEkUa+8x41i7w9cQ4Qg=",
-        "control": {
-          "checksum": "sha1-mVgCtcYDHEkUa+8x41i7w9cQ4Qg=",
-          "range": "bytes=704-1079"
-        },
-        "data": {
-          "checksum": "sha256-xE4spLqr7qIgImPfMC1kMY1a7Xu7xu1/eLkBMgOzSSc=",
-          "range": "bytes=1080-77936"
-        },
-        "name": "protobuf-c",
-        "signature": {
-          "checksum": "sha1-NGL0ELlBK8mhhAzuOkm17d2LbRo=",
-          "range": "bytes=0-703"
-        },
-        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r3.apk",
-        "version": "1.5.0-r3"
-      },
-      {
-        "architecture": "x86_64",
         "checksum": "Q1TAnNLCVTaCylmbN84TlliyM47qM=",
         "control": {
           "checksum": "sha1-TAnNLCVTaCylmbN84TlliyM47qM=",
@@ -258,6 +239,25 @@
         },
         "url": "https://packages.wolfi.dev/os/x86_64/krb5-libs-1.21.2-r1.apk",
         "version": "1.21.2-r1"
+      },
+      {
+        "architecture": "x86_64",
+        "checksum": "Q1Zjfs1uR/mYiortANP+EFcejW+vo=",
+        "control": {
+          "checksum": "sha1-Zjfs1uR/mYiortANP+EFcejW+vo=",
+          "range": "bytes=698-1085"
+        },
+        "data": {
+          "checksum": "sha256-BMd7TzffjbrFwdbopDPVYsX0X9XnusIMNbIf33/8kwc=",
+          "range": "bytes=1086-76881"
+        },
+        "name": "protobuf-c",
+        "signature": {
+          "checksum": "sha1-efGiXyYWsJ5P2uTkB6aXEZ3kl3o=",
+          "range": "bytes=0-697"
+        },
+        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r4.apk",
+        "version": "1.5.0-r4"
       },
       {
         "architecture": "x86_64",
@@ -470,22 +470,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q12eKoxDrTjnN67UapcxL36uSvK6Y=",
+        "checksum": "Q1TS707T+cPGL7TYVHQBCJoWwHZ0E=",
         "control": {
-          "checksum": "sha1-2eKoxDrTjnN67UapcxL36uSvK6Y=",
-          "range": "bytes=694-1086"
+          "checksum": "sha1-TS707T+cPGL7TYVHQBCJoWwHZ0E=",
+          "range": "bytes=706-1098"
         },
         "data": {
-          "checksum": "sha256-xlBSY4KJHzH59eU8L6EFYVJVksfsqUlpE7yt7WtlBos=",
-          "range": "bytes=1087-4546022"
+          "checksum": "sha256-x18L706Vug5qDzq13SXuN/vGdVgzrqB06dW2DdgHGR4=",
+          "range": "bytes=1099-4541967"
         },
         "name": "libxml2",
         "signature": {
-          "checksum": "sha1-sRrMqWd8n9UGVkkp5YwEQ4xr9iY=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-BYhOxDos48sN8df8LMsSpROv2aw=",
+          "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.12.6-r1.apk",
-        "version": "2.12.6-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.12.7-r0.apk",
+        "version": "2.12.7-r0"
       },
       {
         "architecture": "x86_64",
@@ -527,22 +527,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ZvgMPq5RCd5lQ3v2qeBBOLotsXM=",
+        "checksum": "Q1dLQQZAfXkamLwZ7kLZb2atjfZZQ=",
         "control": {
-          "checksum": "sha1-ZvgMPq5RCd5lQ3v2qeBBOLotsXM=",
-          "range": "bytes=698-1093"
+          "checksum": "sha1-dLQQZAfXkamLwZ7kLZb2atjfZZQ=",
+          "range": "bytes=701-1095"
         },
         "data": {
-          "checksum": "sha256-mQrZT/j9v5ff50OwlphGA2m2AApMWZfnnPaoEBil57Q=",
-          "range": "bytes=1094-233900"
+          "checksum": "sha256-9c2Qzrfedb7BJdu6THUm5TLxb0dvov8v4tvfqBWlUuw=",
+          "range": "bytes=1096-233941"
         },
         "name": "libxcrypt",
         "signature": {
-          "checksum": "sha1-THgEEMvz4LUMjzDPVU7db5XBJ+E=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-DFbDoKQ6O4YqS6aru0hhYo/8TUk=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxcrypt-4.4.36-r5.apk",
-        "version": "4.4.36-r5"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxcrypt-4.4.36-r6.apk",
+        "version": "4.4.36-r6"
       },
       {
         "architecture": "x86_64",
@@ -774,22 +774,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q18KuP+fKLMlrBEUlslVwi71FQprk=",
+        "checksum": "Q1EeC4oJcNGILol2exjVmAmCeKe3Y=",
         "control": {
-          "checksum": "sha1-8KuP+fKLMlrBEUlslVwi71FQprk=",
-          "range": "bytes=699-1064"
+          "checksum": "sha1-EeC4oJcNGILol2exjVmAmCeKe3Y=",
+          "range": "bytes=698-1076"
         },
         "data": {
-          "checksum": "sha256-RipTzGOvB+9Og8PqmR9ZHnurS16yjGKnvKN4YbR2qK8=",
-          "range": "bytes=1065-110068"
+          "checksum": "sha256-jG5+Qk19KNjypflTSwO2gF+f/zqWbtjjhuzSO3maxf8=",
+          "range": "bytes=1077-109053"
         },
         "name": "libbz2-1",
         "signature": {
-          "checksum": "sha1-OeXOVUkPHaLBXEUp9euaffLe47Q=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-800rFtecn2FKQ9uM95GkfwOMvnQ=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libbz2-1-1.0.8-r6.apk",
-        "version": "1.0.8-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/libbz2-1-1.0.8-r7.apk",
+        "version": "1.0.8-r7"
       },
       {
         "architecture": "x86_64",
@@ -1002,41 +1002,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1EMrt5zY7UKhtQjR5dP83jt2/okQ=",
+        "checksum": "Q1raWuu6KGfRrKeRl5uFEr9cjJWKo=",
         "control": {
-          "checksum": "sha1-EMrt5zY7UKhtQjR5dP83jt2/okQ=",
-          "range": "bytes=699-1136"
+          "checksum": "sha1-raWuu6KGfRrKeRl5uFEr9cjJWKo=",
+          "range": "bytes=706-1138"
         },
         "data": {
-          "checksum": "sha256-HJfJstMHWUKZ1vIBltQt+jWbepJ9s9fOfDokQfpnBGI=",
-          "range": "bytes=1137-170633686"
+          "checksum": "sha256-+jvnuhSfFV6OMOU85A0d3TL70EU3d9Ih9qFVFBhbKoM=",
+          "range": "bytes=1139-170871296"
         },
         "name": "openjdk-11-jre-base",
         "signature": {
-          "checksum": "sha1-lfioXoCBnapGcLzOcRLKtxpocRA=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-Ndhcwm0bNhKzWlK/0yDLCxF/PyQ=",
+          "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/openjdk-11-jre-base-11.0.23-r1.apk",
-        "version": "11.0.23-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/openjdk-11-jre-base-11.0.23-r2.apk",
+        "version": "11.0.23-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q151W3i3zG+HU4zbt7bSM0VAvhIqw=",
+        "checksum": "Q10FAMpP3Ge3ZAIj7OiagSPVTgBEM=",
         "control": {
-          "checksum": "sha1-51W3i3zG+HU4zbt7bSM0VAvhIqw=",
-          "range": "bytes=707-1104"
+          "checksum": "sha1-0FAMpP3Ge3ZAIj7OiagSPVTgBEM=",
+          "range": "bytes=698-1096"
         },
         "data": {
-          "checksum": "sha256-yExfnYw9DV2WsdXGZPn2eybTv5ssuo7gbJwo2BJVzRc=",
-          "range": "bytes=1105-2949223"
+          "checksum": "sha256-TS14snUwG/K6ETpa3DbKn6vBCV5wo8m8kUiomgRlJsU=",
+          "range": "bytes=1097-2936817"
         },
         "name": "openjdk-11-jre",
         "signature": {
-          "checksum": "sha1-cdTUU2TrXYTeq2PwvWSP3UnlOeg=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-3U3HZ/qDq7BOBiCf8eLprpizKcY=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/openjdk-11-jre-11.0.23-r1.apk",
-        "version": "11.0.23-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/openjdk-11-jre-11.0.23-r2.apk",
+        "version": "11.0.23-r2"
       },
       {
         "architecture": "x86_64",
@@ -1059,22 +1059,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q122/exGCfuYChY+BTo43sN6sLLkk=",
+        "checksum": "Q1ynkAy7XK5aCOCYqW5WpadOWi2vw=",
         "control": {
-          "checksum": "sha1-22/exGCfuYChY+BTo43sN6sLLkk=",
-          "range": "bytes=701-1093"
+          "checksum": "sha1-ynkAy7XK5aCOCYqW5WpadOWi2vw=",
+          "range": "bytes=699-1096"
         },
         "data": {
-          "checksum": "sha256-tV/7GQnI5UE21CsXZPEohjq3kjElWYhRgu4xYMjraeo=",
-          "range": "bytes=1094-33982"
+          "checksum": "sha256-czYtvoMQAmsMJ/5W291ZJ44ALP83WOapmac2aLTW4cw=",
+          "range": "bytes=1097-34024"
         },
         "name": "openjdk-11-default-jvm",
         "signature": {
-          "checksum": "sha1-TWHvNUuHm0ZParPcehm/qLmLF+c=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-d04S5/oCx9/VY0auDTaGs0IO3kY=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/openjdk-11-default-jvm-11.0.23-r1.apk",
-        "version": "11.0.23-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/openjdk-11-default-jvm-11.0.23-r2.apk",
+        "version": "11.0.23-r2"
       },
       {
         "architecture": "x86_64",
@@ -1097,22 +1097,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1m7SsrH+XnrPIapzhnK0vkoxMen4=",
+        "checksum": "Q1ZrMuP718My90TnZrml7ylUmXGlo=",
         "control": {
-          "checksum": "sha1-m7SsrH+XnrPIapzhnK0vkoxMen4=",
-          "range": "bytes=698-1077"
+          "checksum": "sha1-ZrMuP718My90TnZrml7ylUmXGlo=",
+          "range": "bytes=702-1093"
         },
         "data": {
-          "checksum": "sha256-0WaULqZyE0zNNC6D7YeaXVN4shAVEouyqAEiRlB09C0=",
-          "range": "bytes=1078-54479"
+          "checksum": "sha256-+ZTF5s9bHKtoArLvOvIL/2seV4pE0ElEj9MlAscAdso=",
+          "range": "bytes=1094-53513"
         },
         "name": "tini",
         "signature": {
-          "checksum": "sha1-eomfhWCyCB1OA/2DHboLUzXunvA=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-OK9J/Z8qnRssJzNCu9hER8FuzSk=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/tini-0.19.0-r3.apk",
-        "version": "0.19.0-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/tini-0.19.0-r4.apk",
+        "version": "0.19.0-r4"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/bundled-executor.lock.json
+++ b/wolfi-images/bundled-executor.lock.json
@@ -109,25 +109,6 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1mVgCtcYDHEkUa+8x41i7w9cQ4Qg=",
-        "control": {
-          "checksum": "sha1-mVgCtcYDHEkUa+8x41i7w9cQ4Qg=",
-          "range": "bytes=704-1079"
-        },
-        "data": {
-          "checksum": "sha256-xE4spLqr7qIgImPfMC1kMY1a7Xu7xu1/eLkBMgOzSSc=",
-          "range": "bytes=1080-77936"
-        },
-        "name": "protobuf-c",
-        "signature": {
-          "checksum": "sha1-NGL0ELlBK8mhhAzuOkm17d2LbRo=",
-          "range": "bytes=0-703"
-        },
-        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r3.apk",
-        "version": "1.5.0-r3"
-      },
-      {
-        "architecture": "x86_64",
         "checksum": "Q1TAnNLCVTaCylmbN84TlliyM47qM=",
         "control": {
           "checksum": "sha1-TAnNLCVTaCylmbN84TlliyM47qM=",
@@ -258,6 +239,25 @@
         },
         "url": "https://packages.wolfi.dev/os/x86_64/krb5-libs-1.21.2-r1.apk",
         "version": "1.21.2-r1"
+      },
+      {
+        "architecture": "x86_64",
+        "checksum": "Q1Zjfs1uR/mYiortANP+EFcejW+vo=",
+        "control": {
+          "checksum": "sha1-Zjfs1uR/mYiortANP+EFcejW+vo=",
+          "range": "bytes=698-1085"
+        },
+        "data": {
+          "checksum": "sha256-BMd7TzffjbrFwdbopDPVYsX0X9XnusIMNbIf33/8kwc=",
+          "range": "bytes=1086-76881"
+        },
+        "name": "protobuf-c",
+        "signature": {
+          "checksum": "sha1-efGiXyYWsJ5P2uTkB6aXEZ3kl3o=",
+          "range": "bytes=0-697"
+        },
+        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r4.apk",
+        "version": "1.5.0-r4"
       },
       {
         "architecture": "x86_64",
@@ -470,22 +470,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q12eKoxDrTjnN67UapcxL36uSvK6Y=",
+        "checksum": "Q1TS707T+cPGL7TYVHQBCJoWwHZ0E=",
         "control": {
-          "checksum": "sha1-2eKoxDrTjnN67UapcxL36uSvK6Y=",
-          "range": "bytes=694-1086"
+          "checksum": "sha1-TS707T+cPGL7TYVHQBCJoWwHZ0E=",
+          "range": "bytes=706-1098"
         },
         "data": {
-          "checksum": "sha256-xlBSY4KJHzH59eU8L6EFYVJVksfsqUlpE7yt7WtlBos=",
-          "range": "bytes=1087-4546022"
+          "checksum": "sha256-x18L706Vug5qDzq13SXuN/vGdVgzrqB06dW2DdgHGR4=",
+          "range": "bytes=1099-4541967"
         },
         "name": "libxml2",
         "signature": {
-          "checksum": "sha1-sRrMqWd8n9UGVkkp5YwEQ4xr9iY=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-BYhOxDos48sN8df8LMsSpROv2aw=",
+          "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.12.6-r1.apk",
-        "version": "2.12.6-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.12.7-r0.apk",
+        "version": "2.12.7-r0"
       },
       {
         "architecture": "x86_64",
@@ -527,22 +527,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ZvgMPq5RCd5lQ3v2qeBBOLotsXM=",
+        "checksum": "Q1dLQQZAfXkamLwZ7kLZb2atjfZZQ=",
         "control": {
-          "checksum": "sha1-ZvgMPq5RCd5lQ3v2qeBBOLotsXM=",
-          "range": "bytes=698-1093"
+          "checksum": "sha1-dLQQZAfXkamLwZ7kLZb2atjfZZQ=",
+          "range": "bytes=701-1095"
         },
         "data": {
-          "checksum": "sha256-mQrZT/j9v5ff50OwlphGA2m2AApMWZfnnPaoEBil57Q=",
-          "range": "bytes=1094-233900"
+          "checksum": "sha256-9c2Qzrfedb7BJdu6THUm5TLxb0dvov8v4tvfqBWlUuw=",
+          "range": "bytes=1096-233941"
         },
         "name": "libxcrypt",
         "signature": {
-          "checksum": "sha1-THgEEMvz4LUMjzDPVU7db5XBJ+E=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-DFbDoKQ6O4YqS6aru0hhYo/8TUk=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxcrypt-4.4.36-r5.apk",
-        "version": "4.4.36-r5"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxcrypt-4.4.36-r6.apk",
+        "version": "4.4.36-r6"
       },
       {
         "architecture": "x86_64",
@@ -850,22 +850,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q18KuP+fKLMlrBEUlslVwi71FQprk=",
+        "checksum": "Q1EeC4oJcNGILol2exjVmAmCeKe3Y=",
         "control": {
-          "checksum": "sha1-8KuP+fKLMlrBEUlslVwi71FQprk=",
-          "range": "bytes=699-1064"
+          "checksum": "sha1-EeC4oJcNGILol2exjVmAmCeKe3Y=",
+          "range": "bytes=698-1076"
         },
         "data": {
-          "checksum": "sha256-RipTzGOvB+9Og8PqmR9ZHnurS16yjGKnvKN4YbR2qK8=",
-          "range": "bytes=1065-110068"
+          "checksum": "sha256-jG5+Qk19KNjypflTSwO2gF+f/zqWbtjjhuzSO3maxf8=",
+          "range": "bytes=1077-109053"
         },
         "name": "libbz2-1",
         "signature": {
-          "checksum": "sha1-OeXOVUkPHaLBXEUp9euaffLe47Q=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-800rFtecn2FKQ9uM95GkfwOMvnQ=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libbz2-1-1.0.8-r6.apk",
-        "version": "1.0.8-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/libbz2-1-1.0.8-r7.apk",
+        "version": "1.0.8-r7"
       },
       {
         "architecture": "x86_64",
@@ -1040,79 +1040,79 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1EMrt5zY7UKhtQjR5dP83jt2/okQ=",
+        "checksum": "Q1raWuu6KGfRrKeRl5uFEr9cjJWKo=",
         "control": {
-          "checksum": "sha1-EMrt5zY7UKhtQjR5dP83jt2/okQ=",
-          "range": "bytes=699-1136"
+          "checksum": "sha1-raWuu6KGfRrKeRl5uFEr9cjJWKo=",
+          "range": "bytes=706-1138"
         },
         "data": {
-          "checksum": "sha256-HJfJstMHWUKZ1vIBltQt+jWbepJ9s9fOfDokQfpnBGI=",
-          "range": "bytes=1137-170633686"
+          "checksum": "sha256-+jvnuhSfFV6OMOU85A0d3TL70EU3d9Ih9qFVFBhbKoM=",
+          "range": "bytes=1139-170871296"
         },
         "name": "openjdk-11-jre-base",
         "signature": {
-          "checksum": "sha1-lfioXoCBnapGcLzOcRLKtxpocRA=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-Ndhcwm0bNhKzWlK/0yDLCxF/PyQ=",
+          "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/openjdk-11-jre-base-11.0.23-r1.apk",
-        "version": "11.0.23-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/openjdk-11-jre-base-11.0.23-r2.apk",
+        "version": "11.0.23-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q151W3i3zG+HU4zbt7bSM0VAvhIqw=",
+        "checksum": "Q10FAMpP3Ge3ZAIj7OiagSPVTgBEM=",
         "control": {
-          "checksum": "sha1-51W3i3zG+HU4zbt7bSM0VAvhIqw=",
-          "range": "bytes=707-1104"
+          "checksum": "sha1-0FAMpP3Ge3ZAIj7OiagSPVTgBEM=",
+          "range": "bytes=698-1096"
         },
         "data": {
-          "checksum": "sha256-yExfnYw9DV2WsdXGZPn2eybTv5ssuo7gbJwo2BJVzRc=",
-          "range": "bytes=1105-2949223"
+          "checksum": "sha256-TS14snUwG/K6ETpa3DbKn6vBCV5wo8m8kUiomgRlJsU=",
+          "range": "bytes=1097-2936817"
         },
         "name": "openjdk-11-jre",
         "signature": {
-          "checksum": "sha1-cdTUU2TrXYTeq2PwvWSP3UnlOeg=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-3U3HZ/qDq7BOBiCf8eLprpizKcY=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/openjdk-11-jre-11.0.23-r1.apk",
-        "version": "11.0.23-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/openjdk-11-jre-11.0.23-r2.apk",
+        "version": "11.0.23-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q13v9nj3eH194SrUAGxfg7XLDNZCE=",
+        "checksum": "Q1uV85Wia6ar1va+8ctNo9OCi2Mvw=",
         "control": {
-          "checksum": "sha1-3v9nj3eH194SrUAGxfg7XLDNZCE=",
-          "range": "bytes=694-1065"
+          "checksum": "sha1-uV85Wia6ar1va+8ctNo9OCi2Mvw=",
+          "range": "bytes=702-1070"
         },
         "data": {
-          "checksum": "sha256-YvTs+QAQ7zOgmjqgcnscbxRCP82KyA3pMGBC8aHsW/A=",
-          "range": "bytes=1066-589393"
+          "checksum": "sha256-hPFP0eqRxyx12XIHiYliaXKUTt7siMH9lIKbc+IC+g4=",
+          "range": "bytes=1071-589435"
         },
         "name": "openjdk-11",
         "signature": {
-          "checksum": "sha1-KmpmvWAUM4pyI4Gh9w9aOkNNYyQ=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-8ZSyp7kZfhA5CsMh8+BlJEAYd8M=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/openjdk-11-11.0.23-r1.apk",
-        "version": "11.0.23-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/openjdk-11-11.0.23-r2.apk",
+        "version": "11.0.23-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q122/exGCfuYChY+BTo43sN6sLLkk=",
+        "checksum": "Q1ynkAy7XK5aCOCYqW5WpadOWi2vw=",
         "control": {
-          "checksum": "sha1-22/exGCfuYChY+BTo43sN6sLLkk=",
-          "range": "bytes=701-1093"
+          "checksum": "sha1-ynkAy7XK5aCOCYqW5WpadOWi2vw=",
+          "range": "bytes=699-1096"
         },
         "data": {
-          "checksum": "sha256-tV/7GQnI5UE21CsXZPEohjq3kjElWYhRgu4xYMjraeo=",
-          "range": "bytes=1094-33982"
+          "checksum": "sha256-czYtvoMQAmsMJ/5W291ZJ44ALP83WOapmac2aLTW4cw=",
+          "range": "bytes=1097-34024"
         },
         "name": "openjdk-11-default-jvm",
         "signature": {
-          "checksum": "sha1-TWHvNUuHm0ZParPcehm/qLmLF+c=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-d04S5/oCx9/VY0auDTaGs0IO3kY=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/openjdk-11-default-jvm-11.0.23-r1.apk",
-        "version": "11.0.23-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/openjdk-11-default-jvm-11.0.23-r2.apk",
+        "version": "11.0.23-r2"
       },
       {
         "architecture": "x86_64",
@@ -1192,22 +1192,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1EiStgEoALlFPLvk5XIcnXFJNB+I=",
+        "checksum": "Q1Xou3FauSnsDlv/GSiADD5//sbLU=",
         "control": {
-          "checksum": "sha1-EiStgEoALlFPLvk5XIcnXFJNB+I=",
+          "checksum": "sha1-Xou3FauSnsDlv/GSiADD5//sbLU=",
           "range": "bytes=701-1087"
         },
         "data": {
-          "checksum": "sha256-wvlVA16s/y60xxwJagjDDRHHIj+AEyjsTZSL0+CEH8Y=",
-          "range": "bytes=1088-1072931"
+          "checksum": "sha256-pb3t+dcRqtb+NKcRaX+WpCmgwmCys/1yj9ZEv00dz6o=",
+          "range": "bytes=1088-1101261"
         },
         "name": "readline",
         "signature": {
-          "checksum": "sha1-MKok4iQKXLbNr5+K1A6X/ARjcmk=",
+          "checksum": "sha1-UM8oioixvqY+MAGWmuqxp169zNk=",
           "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/readline-8.2-r4.apk",
-        "version": "8.2-r4"
+        "url": "https://packages.wolfi.dev/os/x86_64/readline-8.2-r6.apk",
+        "version": "8.2-r6"
       },
       {
         "architecture": "x86_64",
@@ -1306,22 +1306,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1m7SsrH+XnrPIapzhnK0vkoxMen4=",
+        "checksum": "Q1ZrMuP718My90TnZrml7ylUmXGlo=",
         "control": {
-          "checksum": "sha1-m7SsrH+XnrPIapzhnK0vkoxMen4=",
-          "range": "bytes=698-1077"
+          "checksum": "sha1-ZrMuP718My90TnZrml7ylUmXGlo=",
+          "range": "bytes=702-1093"
         },
         "data": {
-          "checksum": "sha256-0WaULqZyE0zNNC6D7YeaXVN4shAVEouyqAEiRlB09C0=",
-          "range": "bytes=1078-54479"
+          "checksum": "sha256-+ZTF5s9bHKtoArLvOvIL/2seV4pE0ElEj9MlAscAdso=",
+          "range": "bytes=1094-53513"
         },
         "name": "tini",
         "signature": {
-          "checksum": "sha1-eomfhWCyCB1OA/2DHboLUzXunvA=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-OK9J/Z8qnRssJzNCu9hER8FuzSk=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/tini-0.19.0-r3.apk",
-        "version": "0.19.0-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/tini-0.19.0-r4.apk",
+        "version": "0.19.0-r4"
       },
       {
         "architecture": "x86_64",
@@ -1439,22 +1439,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1YeMjhF13RkLgpRK4EC7XDoGICK0=",
+        "checksum": "Q1rgGFaz1Fn11gFWWaieylO2U88ic=",
         "control": {
-          "checksum": "sha1-YeMjhF13RkLgpRK4EC7XDoGICK0=",
-          "range": "bytes=699-1088"
+          "checksum": "sha1-rgGFaz1Fn11gFWWaieylO2U88ic=",
+          "range": "bytes=699-1094"
         },
         "data": {
-          "checksum": "sha256-c1vV3FzaoHNFrJJK9kmBcio7MLmQO4kg5CnImvDTHQU=",
-          "range": "bytes=1089-9943682"
+          "checksum": "sha256-5rss+s8ZsPYpQUE00eVRDGa7IyGRCPzoxq7QLBr1tMk=",
+          "range": "bytes=1095-10722189"
         },
         "name": "yq",
         "signature": {
-          "checksum": "sha1-rQ1JAwRgdTyxp0QPvdJutA/p4QU=",
+          "checksum": "sha1-2g79lHp8gLlI4v9K0fqBz6Rt4Aw=",
           "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/yq-4.43.1-r1.apk",
-        "version": "4.43.1-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/yq-4.44.1-r0.apk",
+        "version": "4.44.1-r0"
       }
     ],
     "repositories": [

--- a/wolfi-images/caddy.lock.json
+++ b/wolfi-images/caddy.lock.json
@@ -109,25 +109,6 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1mVgCtcYDHEkUa+8x41i7w9cQ4Qg=",
-        "control": {
-          "checksum": "sha1-mVgCtcYDHEkUa+8x41i7w9cQ4Qg=",
-          "range": "bytes=704-1079"
-        },
-        "data": {
-          "checksum": "sha256-xE4spLqr7qIgImPfMC1kMY1a7Xu7xu1/eLkBMgOzSSc=",
-          "range": "bytes=1080-77936"
-        },
-        "name": "protobuf-c",
-        "signature": {
-          "checksum": "sha1-NGL0ELlBK8mhhAzuOkm17d2LbRo=",
-          "range": "bytes=0-703"
-        },
-        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r3.apk",
-        "version": "1.5.0-r3"
-      },
-      {
-        "architecture": "x86_64",
         "checksum": "Q1TAnNLCVTaCylmbN84TlliyM47qM=",
         "control": {
           "checksum": "sha1-TAnNLCVTaCylmbN84TlliyM47qM=",
@@ -258,6 +239,25 @@
         },
         "url": "https://packages.wolfi.dev/os/x86_64/krb5-libs-1.21.2-r1.apk",
         "version": "1.21.2-r1"
+      },
+      {
+        "architecture": "x86_64",
+        "checksum": "Q1Zjfs1uR/mYiortANP+EFcejW+vo=",
+        "control": {
+          "checksum": "sha1-Zjfs1uR/mYiortANP+EFcejW+vo=",
+          "range": "bytes=698-1085"
+        },
+        "data": {
+          "checksum": "sha256-BMd7TzffjbrFwdbopDPVYsX0X9XnusIMNbIf33/8kwc=",
+          "range": "bytes=1086-76881"
+        },
+        "name": "protobuf-c",
+        "signature": {
+          "checksum": "sha1-efGiXyYWsJ5P2uTkB6aXEZ3kl3o=",
+          "range": "bytes=0-697"
+        },
+        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r4.apk",
+        "version": "1.5.0-r4"
       },
       {
         "architecture": "x86_64",
@@ -470,22 +470,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q12eKoxDrTjnN67UapcxL36uSvK6Y=",
+        "checksum": "Q1TS707T+cPGL7TYVHQBCJoWwHZ0E=",
         "control": {
-          "checksum": "sha1-2eKoxDrTjnN67UapcxL36uSvK6Y=",
-          "range": "bytes=694-1086"
+          "checksum": "sha1-TS707T+cPGL7TYVHQBCJoWwHZ0E=",
+          "range": "bytes=706-1098"
         },
         "data": {
-          "checksum": "sha256-xlBSY4KJHzH59eU8L6EFYVJVksfsqUlpE7yt7WtlBos=",
-          "range": "bytes=1087-4546022"
+          "checksum": "sha256-x18L706Vug5qDzq13SXuN/vGdVgzrqB06dW2DdgHGR4=",
+          "range": "bytes=1099-4541967"
         },
         "name": "libxml2",
         "signature": {
-          "checksum": "sha1-sRrMqWd8n9UGVkkp5YwEQ4xr9iY=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-BYhOxDos48sN8df8LMsSpROv2aw=",
+          "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.12.6-r1.apk",
-        "version": "2.12.6-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.12.7-r0.apk",
+        "version": "2.12.7-r0"
       },
       {
         "architecture": "x86_64",
@@ -527,22 +527,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ZvgMPq5RCd5lQ3v2qeBBOLotsXM=",
+        "checksum": "Q1dLQQZAfXkamLwZ7kLZb2atjfZZQ=",
         "control": {
-          "checksum": "sha1-ZvgMPq5RCd5lQ3v2qeBBOLotsXM=",
-          "range": "bytes=698-1093"
+          "checksum": "sha1-dLQQZAfXkamLwZ7kLZb2atjfZZQ=",
+          "range": "bytes=701-1095"
         },
         "data": {
-          "checksum": "sha256-mQrZT/j9v5ff50OwlphGA2m2AApMWZfnnPaoEBil57Q=",
-          "range": "bytes=1094-233900"
+          "checksum": "sha256-9c2Qzrfedb7BJdu6THUm5TLxb0dvov8v4tvfqBWlUuw=",
+          "range": "bytes=1096-233941"
         },
         "name": "libxcrypt",
         "signature": {
-          "checksum": "sha1-THgEEMvz4LUMjzDPVU7db5XBJ+E=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-DFbDoKQ6O4YqS6aru0hhYo/8TUk=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxcrypt-4.4.36-r5.apk",
-        "version": "4.4.36-r5"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxcrypt-4.4.36-r6.apk",
+        "version": "4.4.36-r6"
       },
       {
         "architecture": "x86_64",
@@ -584,22 +584,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ogVH6vzHzlj2jWVN5DGCCex8d94=",
+        "checksum": "Q1hmJGKUg5U62/eDsJFXTXql08W5k=",
         "control": {
-          "checksum": "sha1-ogVH6vzHzlj2jWVN5DGCCex8d94=",
-          "range": "bytes=693-1080"
+          "checksum": "sha1-hmJGKUg5U62/eDsJFXTXql08W5k=",
+          "range": "bytes=695-1092"
         },
         "data": {
-          "checksum": "sha256-whrhuRmbxESHR76NDrXc6A7xLhleXpILJRlu9BHQOa8=",
-          "range": "bytes=1081-41669142"
+          "checksum": "sha256-9mtlf5LYMHCQZQcBNv/Nhof+RDrDvqEJB3u/pFo9nXc=",
+          "range": "bytes=1093-41669227"
         },
         "name": "caddy",
         "signature": {
-          "checksum": "sha1-1JElWFYu+EbZrSTGutNrcZzdXBQ=",
-          "range": "bytes=0-692"
+          "checksum": "sha1-sJwUZEAK0xlZda4GGmTA5C6d2pc=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/caddy-2.7.6-r8.apk",
-        "version": "2.7.6-r8"
+        "url": "https://packages.wolfi.dev/os/x86_64/caddy-2.7.6-r9.apk",
+        "version": "2.7.6-r9"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/cadvisor.lock.json
+++ b/wolfi-images/cadvisor.lock.json
@@ -109,25 +109,6 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1mVgCtcYDHEkUa+8x41i7w9cQ4Qg=",
-        "control": {
-          "checksum": "sha1-mVgCtcYDHEkUa+8x41i7w9cQ4Qg=",
-          "range": "bytes=704-1079"
-        },
-        "data": {
-          "checksum": "sha256-xE4spLqr7qIgImPfMC1kMY1a7Xu7xu1/eLkBMgOzSSc=",
-          "range": "bytes=1080-77936"
-        },
-        "name": "protobuf-c",
-        "signature": {
-          "checksum": "sha1-NGL0ELlBK8mhhAzuOkm17d2LbRo=",
-          "range": "bytes=0-703"
-        },
-        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r3.apk",
-        "version": "1.5.0-r3"
-      },
-      {
-        "architecture": "x86_64",
         "checksum": "Q1TAnNLCVTaCylmbN84TlliyM47qM=",
         "control": {
           "checksum": "sha1-TAnNLCVTaCylmbN84TlliyM47qM=",
@@ -258,6 +239,25 @@
         },
         "url": "https://packages.wolfi.dev/os/x86_64/krb5-libs-1.21.2-r1.apk",
         "version": "1.21.2-r1"
+      },
+      {
+        "architecture": "x86_64",
+        "checksum": "Q1Zjfs1uR/mYiortANP+EFcejW+vo=",
+        "control": {
+          "checksum": "sha1-Zjfs1uR/mYiortANP+EFcejW+vo=",
+          "range": "bytes=698-1085"
+        },
+        "data": {
+          "checksum": "sha256-BMd7TzffjbrFwdbopDPVYsX0X9XnusIMNbIf33/8kwc=",
+          "range": "bytes=1086-76881"
+        },
+        "name": "protobuf-c",
+        "signature": {
+          "checksum": "sha1-efGiXyYWsJ5P2uTkB6aXEZ3kl3o=",
+          "range": "bytes=0-697"
+        },
+        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r4.apk",
+        "version": "1.5.0-r4"
       },
       {
         "architecture": "x86_64",
@@ -470,22 +470,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q12eKoxDrTjnN67UapcxL36uSvK6Y=",
+        "checksum": "Q1TS707T+cPGL7TYVHQBCJoWwHZ0E=",
         "control": {
-          "checksum": "sha1-2eKoxDrTjnN67UapcxL36uSvK6Y=",
-          "range": "bytes=694-1086"
+          "checksum": "sha1-TS707T+cPGL7TYVHQBCJoWwHZ0E=",
+          "range": "bytes=706-1098"
         },
         "data": {
-          "checksum": "sha256-xlBSY4KJHzH59eU8L6EFYVJVksfsqUlpE7yt7WtlBos=",
-          "range": "bytes=1087-4546022"
+          "checksum": "sha256-x18L706Vug5qDzq13SXuN/vGdVgzrqB06dW2DdgHGR4=",
+          "range": "bytes=1099-4541967"
         },
         "name": "libxml2",
         "signature": {
-          "checksum": "sha1-sRrMqWd8n9UGVkkp5YwEQ4xr9iY=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-BYhOxDos48sN8df8LMsSpROv2aw=",
+          "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.12.6-r1.apk",
-        "version": "2.12.6-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.12.7-r0.apk",
+        "version": "2.12.7-r0"
       },
       {
         "architecture": "x86_64",
@@ -527,22 +527,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ZvgMPq5RCd5lQ3v2qeBBOLotsXM=",
+        "checksum": "Q1dLQQZAfXkamLwZ7kLZb2atjfZZQ=",
         "control": {
-          "checksum": "sha1-ZvgMPq5RCd5lQ3v2qeBBOLotsXM=",
-          "range": "bytes=698-1093"
+          "checksum": "sha1-dLQQZAfXkamLwZ7kLZb2atjfZZQ=",
+          "range": "bytes=701-1095"
         },
         "data": {
-          "checksum": "sha256-mQrZT/j9v5ff50OwlphGA2m2AApMWZfnnPaoEBil57Q=",
-          "range": "bytes=1094-233900"
+          "checksum": "sha256-9c2Qzrfedb7BJdu6THUm5TLxb0dvov8v4tvfqBWlUuw=",
+          "range": "bytes=1096-233941"
         },
         "name": "libxcrypt",
         "signature": {
-          "checksum": "sha1-THgEEMvz4LUMjzDPVU7db5XBJ+E=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-DFbDoKQ6O4YqS6aru0hhYo/8TUk=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxcrypt-4.4.36-r5.apk",
-        "version": "4.4.36-r5"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxcrypt-4.4.36-r6.apk",
+        "version": "4.4.36-r6"
       },
       {
         "architecture": "x86_64",
@@ -584,22 +584,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Q4s85DmasLwjlGtxDTOZVukvkBk=",
+        "checksum": "Q1FnZKsgMBSvlDuXlEG2PaYaE8RPw=",
         "control": {
-          "checksum": "sha1-Q4s85DmasLwjlGtxDTOZVukvkBk=",
-          "range": "bytes=702-1120"
+          "checksum": "sha1-FnZKsgMBSvlDuXlEG2PaYaE8RPw=",
+          "range": "bytes=696-1122"
         },
         "data": {
-          "checksum": "sha256-z3b58kIInFbFRiU4tmAwoCFS4txk7cQLJ8T4OZ8REXc=",
-          "range": "bytes=1121-37570247"
+          "checksum": "sha256-IfmaVCQGqWrW4v1+0Jjv3v2YIPwoKzWb+U1+s7g6x60=",
+          "range": "bytes=1123-37570300"
         },
         "name": "cadvisor",
         "signature": {
-          "checksum": "sha1-f7Hc5urHHmSGnvLYxsB+dJT6M0Y=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-670YzcWblzXa/YXHTFdgn0yzlCY=",
+          "range": "bytes=0-695"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/cadvisor-0.49.1-r6.apk",
-        "version": "0.49.1-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/cadvisor-0.49.1-r7.apk",
+        "version": "0.49.1-r7"
       },
       {
         "architecture": "x86_64",
@@ -755,22 +755,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1m7SsrH+XnrPIapzhnK0vkoxMen4=",
+        "checksum": "Q1ZrMuP718My90TnZrml7ylUmXGlo=",
         "control": {
-          "checksum": "sha1-m7SsrH+XnrPIapzhnK0vkoxMen4=",
-          "range": "bytes=698-1077"
+          "checksum": "sha1-ZrMuP718My90TnZrml7ylUmXGlo=",
+          "range": "bytes=702-1093"
         },
         "data": {
-          "checksum": "sha256-0WaULqZyE0zNNC6D7YeaXVN4shAVEouyqAEiRlB09C0=",
-          "range": "bytes=1078-54479"
+          "checksum": "sha256-+ZTF5s9bHKtoArLvOvIL/2seV4pE0ElEj9MlAscAdso=",
+          "range": "bytes=1094-53513"
         },
         "name": "tini",
         "signature": {
-          "checksum": "sha1-eomfhWCyCB1OA/2DHboLUzXunvA=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-OK9J/Z8qnRssJzNCu9hER8FuzSk=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/tini-0.19.0-r3.apk",
-        "version": "0.19.0-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/tini-0.19.0-r4.apk",
+        "version": "0.19.0-r4"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/cloud-mi2.lock.json
+++ b/wolfi-images/cloud-mi2.lock.json
@@ -109,25 +109,6 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1mVgCtcYDHEkUa+8x41i7w9cQ4Qg=",
-        "control": {
-          "checksum": "sha1-mVgCtcYDHEkUa+8x41i7w9cQ4Qg=",
-          "range": "bytes=704-1079"
-        },
-        "data": {
-          "checksum": "sha256-xE4spLqr7qIgImPfMC1kMY1a7Xu7xu1/eLkBMgOzSSc=",
-          "range": "bytes=1080-77936"
-        },
-        "name": "protobuf-c",
-        "signature": {
-          "checksum": "sha1-NGL0ELlBK8mhhAzuOkm17d2LbRo=",
-          "range": "bytes=0-703"
-        },
-        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r3.apk",
-        "version": "1.5.0-r3"
-      },
-      {
-        "architecture": "x86_64",
         "checksum": "Q1TAnNLCVTaCylmbN84TlliyM47qM=",
         "control": {
           "checksum": "sha1-TAnNLCVTaCylmbN84TlliyM47qM=",
@@ -258,6 +239,25 @@
         },
         "url": "https://packages.wolfi.dev/os/x86_64/krb5-libs-1.21.2-r1.apk",
         "version": "1.21.2-r1"
+      },
+      {
+        "architecture": "x86_64",
+        "checksum": "Q1Zjfs1uR/mYiortANP+EFcejW+vo=",
+        "control": {
+          "checksum": "sha1-Zjfs1uR/mYiortANP+EFcejW+vo=",
+          "range": "bytes=698-1085"
+        },
+        "data": {
+          "checksum": "sha256-BMd7TzffjbrFwdbopDPVYsX0X9XnusIMNbIf33/8kwc=",
+          "range": "bytes=1086-76881"
+        },
+        "name": "protobuf-c",
+        "signature": {
+          "checksum": "sha1-efGiXyYWsJ5P2uTkB6aXEZ3kl3o=",
+          "range": "bytes=0-697"
+        },
+        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r4.apk",
+        "version": "1.5.0-r4"
       },
       {
         "architecture": "x86_64",
@@ -470,22 +470,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q12eKoxDrTjnN67UapcxL36uSvK6Y=",
+        "checksum": "Q1TS707T+cPGL7TYVHQBCJoWwHZ0E=",
         "control": {
-          "checksum": "sha1-2eKoxDrTjnN67UapcxL36uSvK6Y=",
-          "range": "bytes=694-1086"
+          "checksum": "sha1-TS707T+cPGL7TYVHQBCJoWwHZ0E=",
+          "range": "bytes=706-1098"
         },
         "data": {
-          "checksum": "sha256-xlBSY4KJHzH59eU8L6EFYVJVksfsqUlpE7yt7WtlBos=",
-          "range": "bytes=1087-4546022"
+          "checksum": "sha256-x18L706Vug5qDzq13SXuN/vGdVgzrqB06dW2DdgHGR4=",
+          "range": "bytes=1099-4541967"
         },
         "name": "libxml2",
         "signature": {
-          "checksum": "sha1-sRrMqWd8n9UGVkkp5YwEQ4xr9iY=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-BYhOxDos48sN8df8LMsSpROv2aw=",
+          "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.12.6-r1.apk",
-        "version": "2.12.6-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.12.7-r0.apk",
+        "version": "2.12.7-r0"
       },
       {
         "architecture": "x86_64",
@@ -527,22 +527,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ZvgMPq5RCd5lQ3v2qeBBOLotsXM=",
+        "checksum": "Q1dLQQZAfXkamLwZ7kLZb2atjfZZQ=",
         "control": {
-          "checksum": "sha1-ZvgMPq5RCd5lQ3v2qeBBOLotsXM=",
-          "range": "bytes=698-1093"
+          "checksum": "sha1-dLQQZAfXkamLwZ7kLZb2atjfZZQ=",
+          "range": "bytes=701-1095"
         },
         "data": {
-          "checksum": "sha256-mQrZT/j9v5ff50OwlphGA2m2AApMWZfnnPaoEBil57Q=",
-          "range": "bytes=1094-233900"
+          "checksum": "sha256-9c2Qzrfedb7BJdu6THUm5TLxb0dvov8v4tvfqBWlUuw=",
+          "range": "bytes=1096-233941"
         },
         "name": "libxcrypt",
         "signature": {
-          "checksum": "sha1-THgEEMvz4LUMjzDPVU7db5XBJ+E=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-DFbDoKQ6O4YqS6aru0hhYo/8TUk=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxcrypt-4.4.36-r5.apk",
-        "version": "4.4.36-r5"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxcrypt-4.4.36-r6.apk",
+        "version": "4.4.36-r6"
       },
       {
         "architecture": "x86_64",
@@ -774,22 +774,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1bbptB7BK9TV8fkNhbjMAfmXgO0I=",
+        "checksum": "Q116m2Q5Ln3gJz05D1gRD/3AQz9+4=",
         "control": {
-          "checksum": "sha1-bbptB7BK9TV8fkNhbjMAfmXgO0I=",
-          "range": "bytes=700-1099"
+          "checksum": "sha1-16m2Q5Ln3gJz05D1gRD/3AQz9+4=",
+          "range": "bytes=703-1102"
         },
         "data": {
-          "checksum": "sha256-5liLI8rRhqcWirGFTO1Q7XAsW4C+n5LoB3Pfh7f3+CI=",
-          "range": "bytes=1100-11855689"
+          "checksum": "sha256-nU1+NEgt7CR9vsxeCs5Hr9tHiSAw69pxvz+m0W+N+PI=",
+          "range": "bytes=1103-11855891"
         },
         "name": "git-lfs",
         "signature": {
-          "checksum": "sha1-hMg5onqpgDcOXI8dZSloNlcpK+8=",
-          "range": "bytes=0-699"
+          "checksum": "sha1-z3BWu5hxd1KVtIrVNwIYsNsgYpc=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/git-lfs-3.5.1-r3.apk",
-        "version": "3.5.1-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/git-lfs-3.5.1-r4.apk",
+        "version": "3.5.1-r4"
       },
       {
         "architecture": "x86_64",
@@ -1002,22 +1002,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1m7SsrH+XnrPIapzhnK0vkoxMen4=",
+        "checksum": "Q1ZrMuP718My90TnZrml7ylUmXGlo=",
         "control": {
-          "checksum": "sha1-m7SsrH+XnrPIapzhnK0vkoxMen4=",
-          "range": "bytes=698-1077"
+          "checksum": "sha1-ZrMuP718My90TnZrml7ylUmXGlo=",
+          "range": "bytes=702-1093"
         },
         "data": {
-          "checksum": "sha256-0WaULqZyE0zNNC6D7YeaXVN4shAVEouyqAEiRlB09C0=",
-          "range": "bytes=1078-54479"
+          "checksum": "sha256-+ZTF5s9bHKtoArLvOvIL/2seV4pE0ElEj9MlAscAdso=",
+          "range": "bytes=1094-53513"
         },
         "name": "tini",
         "signature": {
-          "checksum": "sha1-eomfhWCyCB1OA/2DHboLUzXunvA=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-OK9J/Z8qnRssJzNCu9hER8FuzSk=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/tini-0.19.0-r3.apk",
-        "version": "0.19.0-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/tini-0.19.0-r4.apk",
+        "version": "0.19.0-r4"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/executor-kubernetes.lock.json
+++ b/wolfi-images/executor-kubernetes.lock.json
@@ -109,25 +109,6 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1mVgCtcYDHEkUa+8x41i7w9cQ4Qg=",
-        "control": {
-          "checksum": "sha1-mVgCtcYDHEkUa+8x41i7w9cQ4Qg=",
-          "range": "bytes=704-1079"
-        },
-        "data": {
-          "checksum": "sha256-xE4spLqr7qIgImPfMC1kMY1a7Xu7xu1/eLkBMgOzSSc=",
-          "range": "bytes=1080-77936"
-        },
-        "name": "protobuf-c",
-        "signature": {
-          "checksum": "sha1-NGL0ELlBK8mhhAzuOkm17d2LbRo=",
-          "range": "bytes=0-703"
-        },
-        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r3.apk",
-        "version": "1.5.0-r3"
-      },
-      {
-        "architecture": "x86_64",
         "checksum": "Q1TAnNLCVTaCylmbN84TlliyM47qM=",
         "control": {
           "checksum": "sha1-TAnNLCVTaCylmbN84TlliyM47qM=",
@@ -258,6 +239,25 @@
         },
         "url": "https://packages.wolfi.dev/os/x86_64/krb5-libs-1.21.2-r1.apk",
         "version": "1.21.2-r1"
+      },
+      {
+        "architecture": "x86_64",
+        "checksum": "Q1Zjfs1uR/mYiortANP+EFcejW+vo=",
+        "control": {
+          "checksum": "sha1-Zjfs1uR/mYiortANP+EFcejW+vo=",
+          "range": "bytes=698-1085"
+        },
+        "data": {
+          "checksum": "sha256-BMd7TzffjbrFwdbopDPVYsX0X9XnusIMNbIf33/8kwc=",
+          "range": "bytes=1086-76881"
+        },
+        "name": "protobuf-c",
+        "signature": {
+          "checksum": "sha1-efGiXyYWsJ5P2uTkB6aXEZ3kl3o=",
+          "range": "bytes=0-697"
+        },
+        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r4.apk",
+        "version": "1.5.0-r4"
       },
       {
         "architecture": "x86_64",
@@ -470,22 +470,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q12eKoxDrTjnN67UapcxL36uSvK6Y=",
+        "checksum": "Q1TS707T+cPGL7TYVHQBCJoWwHZ0E=",
         "control": {
-          "checksum": "sha1-2eKoxDrTjnN67UapcxL36uSvK6Y=",
-          "range": "bytes=694-1086"
+          "checksum": "sha1-TS707T+cPGL7TYVHQBCJoWwHZ0E=",
+          "range": "bytes=706-1098"
         },
         "data": {
-          "checksum": "sha256-xlBSY4KJHzH59eU8L6EFYVJVksfsqUlpE7yt7WtlBos=",
-          "range": "bytes=1087-4546022"
+          "checksum": "sha256-x18L706Vug5qDzq13SXuN/vGdVgzrqB06dW2DdgHGR4=",
+          "range": "bytes=1099-4541967"
         },
         "name": "libxml2",
         "signature": {
-          "checksum": "sha1-sRrMqWd8n9UGVkkp5YwEQ4xr9iY=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-BYhOxDos48sN8df8LMsSpROv2aw=",
+          "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.12.6-r1.apk",
-        "version": "2.12.6-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.12.7-r0.apk",
+        "version": "2.12.7-r0"
       },
       {
         "architecture": "x86_64",
@@ -527,22 +527,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ZvgMPq5RCd5lQ3v2qeBBOLotsXM=",
+        "checksum": "Q1dLQQZAfXkamLwZ7kLZb2atjfZZQ=",
         "control": {
-          "checksum": "sha1-ZvgMPq5RCd5lQ3v2qeBBOLotsXM=",
-          "range": "bytes=698-1093"
+          "checksum": "sha1-dLQQZAfXkamLwZ7kLZb2atjfZZQ=",
+          "range": "bytes=701-1095"
         },
         "data": {
-          "checksum": "sha256-mQrZT/j9v5ff50OwlphGA2m2AApMWZfnnPaoEBil57Q=",
-          "range": "bytes=1094-233900"
+          "checksum": "sha256-9c2Qzrfedb7BJdu6THUm5TLxb0dvov8v4tvfqBWlUuw=",
+          "range": "bytes=1096-233941"
         },
         "name": "libxcrypt",
         "signature": {
-          "checksum": "sha1-THgEEMvz4LUMjzDPVU7db5XBJ+E=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-DFbDoKQ6O4YqS6aru0hhYo/8TUk=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxcrypt-4.4.36-r5.apk",
-        "version": "4.4.36-r5"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxcrypt-4.4.36-r6.apk",
+        "version": "4.4.36-r6"
       },
       {
         "architecture": "x86_64",
@@ -793,22 +793,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1m7SsrH+XnrPIapzhnK0vkoxMen4=",
+        "checksum": "Q1ZrMuP718My90TnZrml7ylUmXGlo=",
         "control": {
-          "checksum": "sha1-m7SsrH+XnrPIapzhnK0vkoxMen4=",
-          "range": "bytes=698-1077"
+          "checksum": "sha1-ZrMuP718My90TnZrml7ylUmXGlo=",
+          "range": "bytes=702-1093"
         },
         "data": {
-          "checksum": "sha256-0WaULqZyE0zNNC6D7YeaXVN4shAVEouyqAEiRlB09C0=",
-          "range": "bytes=1078-54479"
+          "checksum": "sha256-+ZTF5s9bHKtoArLvOvIL/2seV4pE0ElEj9MlAscAdso=",
+          "range": "bytes=1094-53513"
         },
         "name": "tini",
         "signature": {
-          "checksum": "sha1-eomfhWCyCB1OA/2DHboLUzXunvA=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-OK9J/Z8qnRssJzNCu9hER8FuzSk=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/tini-0.19.0-r3.apk",
-        "version": "0.19.0-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/tini-0.19.0-r4.apk",
+        "version": "0.19.0-r4"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/executor.lock.json
+++ b/wolfi-images/executor.lock.json
@@ -109,25 +109,6 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1mVgCtcYDHEkUa+8x41i7w9cQ4Qg=",
-        "control": {
-          "checksum": "sha1-mVgCtcYDHEkUa+8x41i7w9cQ4Qg=",
-          "range": "bytes=704-1079"
-        },
-        "data": {
-          "checksum": "sha256-xE4spLqr7qIgImPfMC1kMY1a7Xu7xu1/eLkBMgOzSSc=",
-          "range": "bytes=1080-77936"
-        },
-        "name": "protobuf-c",
-        "signature": {
-          "checksum": "sha1-NGL0ELlBK8mhhAzuOkm17d2LbRo=",
-          "range": "bytes=0-703"
-        },
-        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r3.apk",
-        "version": "1.5.0-r3"
-      },
-      {
-        "architecture": "x86_64",
         "checksum": "Q1TAnNLCVTaCylmbN84TlliyM47qM=",
         "control": {
           "checksum": "sha1-TAnNLCVTaCylmbN84TlliyM47qM=",
@@ -258,6 +239,25 @@
         },
         "url": "https://packages.wolfi.dev/os/x86_64/krb5-libs-1.21.2-r1.apk",
         "version": "1.21.2-r1"
+      },
+      {
+        "architecture": "x86_64",
+        "checksum": "Q1Zjfs1uR/mYiortANP+EFcejW+vo=",
+        "control": {
+          "checksum": "sha1-Zjfs1uR/mYiortANP+EFcejW+vo=",
+          "range": "bytes=698-1085"
+        },
+        "data": {
+          "checksum": "sha256-BMd7TzffjbrFwdbopDPVYsX0X9XnusIMNbIf33/8kwc=",
+          "range": "bytes=1086-76881"
+        },
+        "name": "protobuf-c",
+        "signature": {
+          "checksum": "sha1-efGiXyYWsJ5P2uTkB6aXEZ3kl3o=",
+          "range": "bytes=0-697"
+        },
+        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r4.apk",
+        "version": "1.5.0-r4"
       },
       {
         "architecture": "x86_64",
@@ -470,22 +470,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q12eKoxDrTjnN67UapcxL36uSvK6Y=",
+        "checksum": "Q1TS707T+cPGL7TYVHQBCJoWwHZ0E=",
         "control": {
-          "checksum": "sha1-2eKoxDrTjnN67UapcxL36uSvK6Y=",
-          "range": "bytes=694-1086"
+          "checksum": "sha1-TS707T+cPGL7TYVHQBCJoWwHZ0E=",
+          "range": "bytes=706-1098"
         },
         "data": {
-          "checksum": "sha256-xlBSY4KJHzH59eU8L6EFYVJVksfsqUlpE7yt7WtlBos=",
-          "range": "bytes=1087-4546022"
+          "checksum": "sha256-x18L706Vug5qDzq13SXuN/vGdVgzrqB06dW2DdgHGR4=",
+          "range": "bytes=1099-4541967"
         },
         "name": "libxml2",
         "signature": {
-          "checksum": "sha1-sRrMqWd8n9UGVkkp5YwEQ4xr9iY=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-BYhOxDos48sN8df8LMsSpROv2aw=",
+          "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.12.6-r1.apk",
-        "version": "2.12.6-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.12.7-r0.apk",
+        "version": "2.12.7-r0"
       },
       {
         "architecture": "x86_64",
@@ -527,22 +527,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ZvgMPq5RCd5lQ3v2qeBBOLotsXM=",
+        "checksum": "Q1dLQQZAfXkamLwZ7kLZb2atjfZZQ=",
         "control": {
-          "checksum": "sha1-ZvgMPq5RCd5lQ3v2qeBBOLotsXM=",
-          "range": "bytes=698-1093"
+          "checksum": "sha1-dLQQZAfXkamLwZ7kLZb2atjfZZQ=",
+          "range": "bytes=701-1095"
         },
         "data": {
-          "checksum": "sha256-mQrZT/j9v5ff50OwlphGA2m2AApMWZfnnPaoEBil57Q=",
-          "range": "bytes=1094-233900"
+          "checksum": "sha256-9c2Qzrfedb7BJdu6THUm5TLxb0dvov8v4tvfqBWlUuw=",
+          "range": "bytes=1096-233941"
         },
         "name": "libxcrypt",
         "signature": {
-          "checksum": "sha1-THgEEMvz4LUMjzDPVU7db5XBJ+E=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-DFbDoKQ6O4YqS6aru0hhYo/8TUk=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxcrypt-4.4.36-r5.apk",
-        "version": "4.4.36-r5"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxcrypt-4.4.36-r6.apk",
+        "version": "4.4.36-r6"
       },
       {
         "architecture": "x86_64",
@@ -831,22 +831,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1m7SsrH+XnrPIapzhnK0vkoxMen4=",
+        "checksum": "Q1ZrMuP718My90TnZrml7ylUmXGlo=",
         "control": {
-          "checksum": "sha1-m7SsrH+XnrPIapzhnK0vkoxMen4=",
-          "range": "bytes=698-1077"
+          "checksum": "sha1-ZrMuP718My90TnZrml7ylUmXGlo=",
+          "range": "bytes=702-1093"
         },
         "data": {
-          "checksum": "sha256-0WaULqZyE0zNNC6D7YeaXVN4shAVEouyqAEiRlB09C0=",
-          "range": "bytes=1078-54479"
+          "checksum": "sha256-+ZTF5s9bHKtoArLvOvIL/2seV4pE0ElEj9MlAscAdso=",
+          "range": "bytes=1094-53513"
         },
         "name": "tini",
         "signature": {
-          "checksum": "sha1-eomfhWCyCB1OA/2DHboLUzXunvA=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-OK9J/Z8qnRssJzNCu9hER8FuzSk=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/tini-0.19.0-r3.apk",
-        "version": "0.19.0-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/tini-0.19.0-r4.apk",
+        "version": "0.19.0-r4"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/gitserver.lock.json
+++ b/wolfi-images/gitserver.lock.json
@@ -166,25 +166,6 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1mVgCtcYDHEkUa+8x41i7w9cQ4Qg=",
-        "control": {
-          "checksum": "sha1-mVgCtcYDHEkUa+8x41i7w9cQ4Qg=",
-          "range": "bytes=704-1079"
-        },
-        "data": {
-          "checksum": "sha256-xE4spLqr7qIgImPfMC1kMY1a7Xu7xu1/eLkBMgOzSSc=",
-          "range": "bytes=1080-77936"
-        },
-        "name": "protobuf-c",
-        "signature": {
-          "checksum": "sha1-NGL0ELlBK8mhhAzuOkm17d2LbRo=",
-          "range": "bytes=0-703"
-        },
-        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r3.apk",
-        "version": "1.5.0-r3"
-      },
-      {
-        "architecture": "x86_64",
         "checksum": "Q1TAnNLCVTaCylmbN84TlliyM47qM=",
         "control": {
           "checksum": "sha1-TAnNLCVTaCylmbN84TlliyM47qM=",
@@ -315,6 +296,25 @@
         },
         "url": "https://packages.wolfi.dev/os/x86_64/krb5-libs-1.21.2-r1.apk",
         "version": "1.21.2-r1"
+      },
+      {
+        "architecture": "x86_64",
+        "checksum": "Q1Zjfs1uR/mYiortANP+EFcejW+vo=",
+        "control": {
+          "checksum": "sha1-Zjfs1uR/mYiortANP+EFcejW+vo=",
+          "range": "bytes=698-1085"
+        },
+        "data": {
+          "checksum": "sha256-BMd7TzffjbrFwdbopDPVYsX0X9XnusIMNbIf33/8kwc=",
+          "range": "bytes=1086-76881"
+        },
+        "name": "protobuf-c",
+        "signature": {
+          "checksum": "sha1-efGiXyYWsJ5P2uTkB6aXEZ3kl3o=",
+          "range": "bytes=0-697"
+        },
+        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r4.apk",
+        "version": "1.5.0-r4"
       },
       {
         "architecture": "x86_64",
@@ -527,22 +527,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q12eKoxDrTjnN67UapcxL36uSvK6Y=",
+        "checksum": "Q1TS707T+cPGL7TYVHQBCJoWwHZ0E=",
         "control": {
-          "checksum": "sha1-2eKoxDrTjnN67UapcxL36uSvK6Y=",
-          "range": "bytes=694-1086"
+          "checksum": "sha1-TS707T+cPGL7TYVHQBCJoWwHZ0E=",
+          "range": "bytes=706-1098"
         },
         "data": {
-          "checksum": "sha256-xlBSY4KJHzH59eU8L6EFYVJVksfsqUlpE7yt7WtlBos=",
-          "range": "bytes=1087-4546022"
+          "checksum": "sha256-x18L706Vug5qDzq13SXuN/vGdVgzrqB06dW2DdgHGR4=",
+          "range": "bytes=1099-4541967"
         },
         "name": "libxml2",
         "signature": {
-          "checksum": "sha1-sRrMqWd8n9UGVkkp5YwEQ4xr9iY=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-BYhOxDos48sN8df8LMsSpROv2aw=",
+          "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.12.6-r1.apk",
-        "version": "2.12.6-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.12.7-r0.apk",
+        "version": "2.12.7-r0"
       },
       {
         "architecture": "x86_64",
@@ -584,22 +584,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ZvgMPq5RCd5lQ3v2qeBBOLotsXM=",
+        "checksum": "Q1dLQQZAfXkamLwZ7kLZb2atjfZZQ=",
         "control": {
-          "checksum": "sha1-ZvgMPq5RCd5lQ3v2qeBBOLotsXM=",
-          "range": "bytes=698-1093"
+          "checksum": "sha1-dLQQZAfXkamLwZ7kLZb2atjfZZQ=",
+          "range": "bytes=701-1095"
         },
         "data": {
-          "checksum": "sha256-mQrZT/j9v5ff50OwlphGA2m2AApMWZfnnPaoEBil57Q=",
-          "range": "bytes=1094-233900"
+          "checksum": "sha256-9c2Qzrfedb7BJdu6THUm5TLxb0dvov8v4tvfqBWlUuw=",
+          "range": "bytes=1096-233941"
         },
         "name": "libxcrypt",
         "signature": {
-          "checksum": "sha1-THgEEMvz4LUMjzDPVU7db5XBJ+E=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-DFbDoKQ6O4YqS6aru0hhYo/8TUk=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxcrypt-4.4.36-r5.apk",
-        "version": "4.4.36-r5"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxcrypt-4.4.36-r6.apk",
+        "version": "4.4.36-r6"
       },
       {
         "architecture": "x86_64",
@@ -850,22 +850,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1bbptB7BK9TV8fkNhbjMAfmXgO0I=",
+        "checksum": "Q116m2Q5Ln3gJz05D1gRD/3AQz9+4=",
         "control": {
-          "checksum": "sha1-bbptB7BK9TV8fkNhbjMAfmXgO0I=",
-          "range": "bytes=700-1099"
+          "checksum": "sha1-16m2Q5Ln3gJz05D1gRD/3AQz9+4=",
+          "range": "bytes=703-1102"
         },
         "data": {
-          "checksum": "sha256-5liLI8rRhqcWirGFTO1Q7XAsW4C+n5LoB3Pfh7f3+CI=",
-          "range": "bytes=1100-11855689"
+          "checksum": "sha256-nU1+NEgt7CR9vsxeCs5Hr9tHiSAw69pxvz+m0W+N+PI=",
+          "range": "bytes=1103-11855891"
         },
         "name": "git-lfs",
         "signature": {
-          "checksum": "sha1-hMg5onqpgDcOXI8dZSloNlcpK+8=",
-          "range": "bytes=0-699"
+          "checksum": "sha1-z3BWu5hxd1KVtIrVNwIYsNsgYpc=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/git-lfs-3.5.1-r3.apk",
-        "version": "3.5.1-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/git-lfs-3.5.1-r4.apk",
+        "version": "3.5.1-r4"
       },
       {
         "architecture": "x86_64",
@@ -1002,25 +1002,6 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q18KuP+fKLMlrBEUlslVwi71FQprk=",
-        "control": {
-          "checksum": "sha1-8KuP+fKLMlrBEUlslVwi71FQprk=",
-          "range": "bytes=699-1064"
-        },
-        "data": {
-          "checksum": "sha256-RipTzGOvB+9Og8PqmR9ZHnurS16yjGKnvKN4YbR2qK8=",
-          "range": "bytes=1065-110068"
-        },
-        "name": "libbz2-1",
-        "signature": {
-          "checksum": "sha1-OeXOVUkPHaLBXEUp9euaffLe47Q=",
-          "range": "bytes=0-698"
-        },
-        "url": "https://packages.wolfi.dev/os/x86_64/libbz2-1-1.0.8-r6.apk",
-        "version": "1.0.8-r6"
-      },
-      {
-        "architecture": "x86_64",
         "checksum": "Q118DG70EE7F+MWo+gHEmHEsvhWME=",
         "control": {
           "checksum": "sha1-18DG70EE7F+MWo+gHEmHEsvhWME=",
@@ -1037,6 +1018,25 @@
         },
         "url": "https://packages.wolfi.dev/os/x86_64/mpdecimal-4.0.0-r1.apk",
         "version": "4.0.0-r1"
+      },
+      {
+        "architecture": "x86_64",
+        "checksum": "Q1EeC4oJcNGILol2exjVmAmCeKe3Y=",
+        "control": {
+          "checksum": "sha1-EeC4oJcNGILol2exjVmAmCeKe3Y=",
+          "range": "bytes=698-1076"
+        },
+        "data": {
+          "checksum": "sha256-jG5+Qk19KNjypflTSwO2gF+f/zqWbtjjhuzSO3maxf8=",
+          "range": "bytes=1077-109053"
+        },
+        "name": "libbz2-1",
+        "signature": {
+          "checksum": "sha1-800rFtecn2FKQ9uM95GkfwOMvnQ=",
+          "range": "bytes=0-697"
+        },
+        "url": "https://packages.wolfi.dev/os/x86_64/libbz2-1-1.0.8-r7.apk",
+        "version": "1.0.8-r7"
       },
       {
         "architecture": "x86_64",
@@ -1059,25 +1059,6 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1EiStgEoALlFPLvk5XIcnXFJNB+I=",
-        "control": {
-          "checksum": "sha1-EiStgEoALlFPLvk5XIcnXFJNB+I=",
-          "range": "bytes=701-1087"
-        },
-        "data": {
-          "checksum": "sha256-wvlVA16s/y60xxwJagjDDRHHIj+AEyjsTZSL0+CEH8Y=",
-          "range": "bytes=1088-1072931"
-        },
-        "name": "readline",
-        "signature": {
-          "checksum": "sha1-MKok4iQKXLbNr5+K1A6X/ARjcmk=",
-          "range": "bytes=0-700"
-        },
-        "url": "https://packages.wolfi.dev/os/x86_64/readline-8.2-r4.apk",
-        "version": "8.2-r4"
-      },
-      {
-        "architecture": "x86_64",
         "checksum": "Q1T+vy2fZ6QN1z0YTZAGDRggJMVz4=",
         "control": {
           "checksum": "sha1-T+vy2fZ6QN1z0YTZAGDRggJMVz4=",
@@ -1094,6 +1075,25 @@
         },
         "url": "https://packages.wolfi.dev/os/x86_64/libffi-3.4.6-r1.apk",
         "version": "3.4.6-r1"
+      },
+      {
+        "architecture": "x86_64",
+        "checksum": "Q1Xou3FauSnsDlv/GSiADD5//sbLU=",
+        "control": {
+          "checksum": "sha1-Xou3FauSnsDlv/GSiADD5//sbLU=",
+          "range": "bytes=701-1087"
+        },
+        "data": {
+          "checksum": "sha256-pb3t+dcRqtb+NKcRaX+WpCmgwmCys/1yj9ZEv00dz6o=",
+          "range": "bytes=1088-1101261"
+        },
+        "name": "readline",
+        "signature": {
+          "checksum": "sha1-UM8oioixvqY+MAGWmuqxp169zNk=",
+          "range": "bytes=0-700"
+        },
+        "url": "https://packages.wolfi.dev/os/x86_64/readline-8.2-r6.apk",
+        "version": "8.2-r6"
       },
       {
         "architecture": "x86_64",
@@ -1154,22 +1154,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1m7SsrH+XnrPIapzhnK0vkoxMen4=",
+        "checksum": "Q1ZrMuP718My90TnZrml7ylUmXGlo=",
         "control": {
-          "checksum": "sha1-m7SsrH+XnrPIapzhnK0vkoxMen4=",
-          "range": "bytes=698-1077"
+          "checksum": "sha1-ZrMuP718My90TnZrml7ylUmXGlo=",
+          "range": "bytes=702-1093"
         },
         "data": {
-          "checksum": "sha256-0WaULqZyE0zNNC6D7YeaXVN4shAVEouyqAEiRlB09C0=",
-          "range": "bytes=1078-54479"
+          "checksum": "sha256-+ZTF5s9bHKtoArLvOvIL/2seV4pE0ElEj9MlAscAdso=",
+          "range": "bytes=1094-53513"
         },
         "name": "tini",
         "signature": {
-          "checksum": "sha1-eomfhWCyCB1OA/2DHboLUzXunvA=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-OK9J/Z8qnRssJzNCu9hER8FuzSk=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/tini-0.19.0-r3.apk",
-        "version": "0.19.0-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/tini-0.19.0-r4.apk",
+        "version": "0.19.0-r4"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/grafana.lock.json
+++ b/wolfi-images/grafana.lock.json
@@ -189,22 +189,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ZvgMPq5RCd5lQ3v2qeBBOLotsXM=",
+        "checksum": "Q1dLQQZAfXkamLwZ7kLZb2atjfZZQ=",
         "control": {
-          "checksum": "sha1-ZvgMPq5RCd5lQ3v2qeBBOLotsXM=",
-          "range": "bytes=698-1093"
+          "checksum": "sha1-dLQQZAfXkamLwZ7kLZb2atjfZZQ=",
+          "range": "bytes=701-1095"
         },
         "data": {
-          "checksum": "sha256-mQrZT/j9v5ff50OwlphGA2m2AApMWZfnnPaoEBil57Q=",
-          "range": "bytes=1094-233900"
+          "checksum": "sha256-9c2Qzrfedb7BJdu6THUm5TLxb0dvov8v4tvfqBWlUuw=",
+          "range": "bytes=1096-233941"
         },
         "name": "libxcrypt",
         "signature": {
-          "checksum": "sha1-THgEEMvz4LUMjzDPVU7db5XBJ+E=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-DFbDoKQ6O4YqS6aru0hhYo/8TUk=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxcrypt-4.4.36-r5.apk",
-        "version": "4.4.36-r5"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxcrypt-4.4.36-r6.apk",
+        "version": "4.4.36-r6"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/jaeger-agent.lock.json
+++ b/wolfi-images/jaeger-agent.lock.json
@@ -109,25 +109,6 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1mVgCtcYDHEkUa+8x41i7w9cQ4Qg=",
-        "control": {
-          "checksum": "sha1-mVgCtcYDHEkUa+8x41i7w9cQ4Qg=",
-          "range": "bytes=704-1079"
-        },
-        "data": {
-          "checksum": "sha256-xE4spLqr7qIgImPfMC1kMY1a7Xu7xu1/eLkBMgOzSSc=",
-          "range": "bytes=1080-77936"
-        },
-        "name": "protobuf-c",
-        "signature": {
-          "checksum": "sha1-NGL0ELlBK8mhhAzuOkm17d2LbRo=",
-          "range": "bytes=0-703"
-        },
-        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r3.apk",
-        "version": "1.5.0-r3"
-      },
-      {
-        "architecture": "x86_64",
         "checksum": "Q1TAnNLCVTaCylmbN84TlliyM47qM=",
         "control": {
           "checksum": "sha1-TAnNLCVTaCylmbN84TlliyM47qM=",
@@ -258,6 +239,25 @@
         },
         "url": "https://packages.wolfi.dev/os/x86_64/krb5-libs-1.21.2-r1.apk",
         "version": "1.21.2-r1"
+      },
+      {
+        "architecture": "x86_64",
+        "checksum": "Q1Zjfs1uR/mYiortANP+EFcejW+vo=",
+        "control": {
+          "checksum": "sha1-Zjfs1uR/mYiortANP+EFcejW+vo=",
+          "range": "bytes=698-1085"
+        },
+        "data": {
+          "checksum": "sha256-BMd7TzffjbrFwdbopDPVYsX0X9XnusIMNbIf33/8kwc=",
+          "range": "bytes=1086-76881"
+        },
+        "name": "protobuf-c",
+        "signature": {
+          "checksum": "sha1-efGiXyYWsJ5P2uTkB6aXEZ3kl3o=",
+          "range": "bytes=0-697"
+        },
+        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r4.apk",
+        "version": "1.5.0-r4"
       },
       {
         "architecture": "x86_64",
@@ -470,22 +470,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q12eKoxDrTjnN67UapcxL36uSvK6Y=",
+        "checksum": "Q1TS707T+cPGL7TYVHQBCJoWwHZ0E=",
         "control": {
-          "checksum": "sha1-2eKoxDrTjnN67UapcxL36uSvK6Y=",
-          "range": "bytes=694-1086"
+          "checksum": "sha1-TS707T+cPGL7TYVHQBCJoWwHZ0E=",
+          "range": "bytes=706-1098"
         },
         "data": {
-          "checksum": "sha256-xlBSY4KJHzH59eU8L6EFYVJVksfsqUlpE7yt7WtlBos=",
-          "range": "bytes=1087-4546022"
+          "checksum": "sha256-x18L706Vug5qDzq13SXuN/vGdVgzrqB06dW2DdgHGR4=",
+          "range": "bytes=1099-4541967"
         },
         "name": "libxml2",
         "signature": {
-          "checksum": "sha1-sRrMqWd8n9UGVkkp5YwEQ4xr9iY=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-BYhOxDos48sN8df8LMsSpROv2aw=",
+          "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.12.6-r1.apk",
-        "version": "2.12.6-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.12.7-r0.apk",
+        "version": "2.12.7-r0"
       },
       {
         "architecture": "x86_64",
@@ -527,22 +527,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ZvgMPq5RCd5lQ3v2qeBBOLotsXM=",
+        "checksum": "Q1dLQQZAfXkamLwZ7kLZb2atjfZZQ=",
         "control": {
-          "checksum": "sha1-ZvgMPq5RCd5lQ3v2qeBBOLotsXM=",
-          "range": "bytes=698-1093"
+          "checksum": "sha1-dLQQZAfXkamLwZ7kLZb2atjfZZQ=",
+          "range": "bytes=701-1095"
         },
         "data": {
-          "checksum": "sha256-mQrZT/j9v5ff50OwlphGA2m2AApMWZfnnPaoEBil57Q=",
-          "range": "bytes=1094-233900"
+          "checksum": "sha256-9c2Qzrfedb7BJdu6THUm5TLxb0dvov8v4tvfqBWlUuw=",
+          "range": "bytes=1096-233941"
         },
         "name": "libxcrypt",
         "signature": {
-          "checksum": "sha1-THgEEMvz4LUMjzDPVU7db5XBJ+E=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-DFbDoKQ6O4YqS6aru0hhYo/8TUk=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxcrypt-4.4.36-r5.apk",
-        "version": "4.4.36-r5"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxcrypt-4.4.36-r6.apk",
+        "version": "4.4.36-r6"
       },
       {
         "architecture": "x86_64",
@@ -755,22 +755,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1m7SsrH+XnrPIapzhnK0vkoxMen4=",
+        "checksum": "Q1ZrMuP718My90TnZrml7ylUmXGlo=",
         "control": {
-          "checksum": "sha1-m7SsrH+XnrPIapzhnK0vkoxMen4=",
-          "range": "bytes=698-1077"
+          "checksum": "sha1-ZrMuP718My90TnZrml7ylUmXGlo=",
+          "range": "bytes=702-1093"
         },
         "data": {
-          "checksum": "sha256-0WaULqZyE0zNNC6D7YeaXVN4shAVEouyqAEiRlB09C0=",
-          "range": "bytes=1078-54479"
+          "checksum": "sha256-+ZTF5s9bHKtoArLvOvIL/2seV4pE0ElEj9MlAscAdso=",
+          "range": "bytes=1094-53513"
         },
         "name": "tini",
         "signature": {
-          "checksum": "sha1-eomfhWCyCB1OA/2DHboLUzXunvA=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-OK9J/Z8qnRssJzNCu9hER8FuzSk=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/tini-0.19.0-r3.apk",
-        "version": "0.19.0-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/tini-0.19.0-r4.apk",
+        "version": "0.19.0-r4"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/jaeger-all-in-one.lock.json
+++ b/wolfi-images/jaeger-all-in-one.lock.json
@@ -109,25 +109,6 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1mVgCtcYDHEkUa+8x41i7w9cQ4Qg=",
-        "control": {
-          "checksum": "sha1-mVgCtcYDHEkUa+8x41i7w9cQ4Qg=",
-          "range": "bytes=704-1079"
-        },
-        "data": {
-          "checksum": "sha256-xE4spLqr7qIgImPfMC1kMY1a7Xu7xu1/eLkBMgOzSSc=",
-          "range": "bytes=1080-77936"
-        },
-        "name": "protobuf-c",
-        "signature": {
-          "checksum": "sha1-NGL0ELlBK8mhhAzuOkm17d2LbRo=",
-          "range": "bytes=0-703"
-        },
-        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r3.apk",
-        "version": "1.5.0-r3"
-      },
-      {
-        "architecture": "x86_64",
         "checksum": "Q1TAnNLCVTaCylmbN84TlliyM47qM=",
         "control": {
           "checksum": "sha1-TAnNLCVTaCylmbN84TlliyM47qM=",
@@ -258,6 +239,25 @@
         },
         "url": "https://packages.wolfi.dev/os/x86_64/krb5-libs-1.21.2-r1.apk",
         "version": "1.21.2-r1"
+      },
+      {
+        "architecture": "x86_64",
+        "checksum": "Q1Zjfs1uR/mYiortANP+EFcejW+vo=",
+        "control": {
+          "checksum": "sha1-Zjfs1uR/mYiortANP+EFcejW+vo=",
+          "range": "bytes=698-1085"
+        },
+        "data": {
+          "checksum": "sha256-BMd7TzffjbrFwdbopDPVYsX0X9XnusIMNbIf33/8kwc=",
+          "range": "bytes=1086-76881"
+        },
+        "name": "protobuf-c",
+        "signature": {
+          "checksum": "sha1-efGiXyYWsJ5P2uTkB6aXEZ3kl3o=",
+          "range": "bytes=0-697"
+        },
+        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r4.apk",
+        "version": "1.5.0-r4"
       },
       {
         "architecture": "x86_64",
@@ -470,22 +470,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q12eKoxDrTjnN67UapcxL36uSvK6Y=",
+        "checksum": "Q1TS707T+cPGL7TYVHQBCJoWwHZ0E=",
         "control": {
-          "checksum": "sha1-2eKoxDrTjnN67UapcxL36uSvK6Y=",
-          "range": "bytes=694-1086"
+          "checksum": "sha1-TS707T+cPGL7TYVHQBCJoWwHZ0E=",
+          "range": "bytes=706-1098"
         },
         "data": {
-          "checksum": "sha256-xlBSY4KJHzH59eU8L6EFYVJVksfsqUlpE7yt7WtlBos=",
-          "range": "bytes=1087-4546022"
+          "checksum": "sha256-x18L706Vug5qDzq13SXuN/vGdVgzrqB06dW2DdgHGR4=",
+          "range": "bytes=1099-4541967"
         },
         "name": "libxml2",
         "signature": {
-          "checksum": "sha1-sRrMqWd8n9UGVkkp5YwEQ4xr9iY=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-BYhOxDos48sN8df8LMsSpROv2aw=",
+          "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.12.6-r1.apk",
-        "version": "2.12.6-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.12.7-r0.apk",
+        "version": "2.12.7-r0"
       },
       {
         "architecture": "x86_64",
@@ -527,22 +527,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ZvgMPq5RCd5lQ3v2qeBBOLotsXM=",
+        "checksum": "Q1dLQQZAfXkamLwZ7kLZb2atjfZZQ=",
         "control": {
-          "checksum": "sha1-ZvgMPq5RCd5lQ3v2qeBBOLotsXM=",
-          "range": "bytes=698-1093"
+          "checksum": "sha1-dLQQZAfXkamLwZ7kLZb2atjfZZQ=",
+          "range": "bytes=701-1095"
         },
         "data": {
-          "checksum": "sha256-mQrZT/j9v5ff50OwlphGA2m2AApMWZfnnPaoEBil57Q=",
-          "range": "bytes=1094-233900"
+          "checksum": "sha256-9c2Qzrfedb7BJdu6THUm5TLxb0dvov8v4tvfqBWlUuw=",
+          "range": "bytes=1096-233941"
         },
         "name": "libxcrypt",
         "signature": {
-          "checksum": "sha1-THgEEMvz4LUMjzDPVU7db5XBJ+E=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-DFbDoKQ6O4YqS6aru0hhYo/8TUk=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxcrypt-4.4.36-r5.apk",
-        "version": "4.4.36-r5"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxcrypt-4.4.36-r6.apk",
+        "version": "4.4.36-r6"
       },
       {
         "architecture": "x86_64",
@@ -755,22 +755,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1m7SsrH+XnrPIapzhnK0vkoxMen4=",
+        "checksum": "Q1ZrMuP718My90TnZrml7ylUmXGlo=",
         "control": {
-          "checksum": "sha1-m7SsrH+XnrPIapzhnK0vkoxMen4=",
-          "range": "bytes=698-1077"
+          "checksum": "sha1-ZrMuP718My90TnZrml7ylUmXGlo=",
+          "range": "bytes=702-1093"
         },
         "data": {
-          "checksum": "sha256-0WaULqZyE0zNNC6D7YeaXVN4shAVEouyqAEiRlB09C0=",
-          "range": "bytes=1078-54479"
+          "checksum": "sha256-+ZTF5s9bHKtoArLvOvIL/2seV4pE0ElEj9MlAscAdso=",
+          "range": "bytes=1094-53513"
         },
         "name": "tini",
         "signature": {
-          "checksum": "sha1-eomfhWCyCB1OA/2DHboLUzXunvA=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-OK9J/Z8qnRssJzNCu9hER8FuzSk=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/tini-0.19.0-r3.apk",
-        "version": "0.19.0-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/tini-0.19.0-r4.apk",
+        "version": "0.19.0-r4"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/node-exporter.lock.json
+++ b/wolfi-images/node-exporter.lock.json
@@ -109,25 +109,6 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1mVgCtcYDHEkUa+8x41i7w9cQ4Qg=",
-        "control": {
-          "checksum": "sha1-mVgCtcYDHEkUa+8x41i7w9cQ4Qg=",
-          "range": "bytes=704-1079"
-        },
-        "data": {
-          "checksum": "sha256-xE4spLqr7qIgImPfMC1kMY1a7Xu7xu1/eLkBMgOzSSc=",
-          "range": "bytes=1080-77936"
-        },
-        "name": "protobuf-c",
-        "signature": {
-          "checksum": "sha1-NGL0ELlBK8mhhAzuOkm17d2LbRo=",
-          "range": "bytes=0-703"
-        },
-        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r3.apk",
-        "version": "1.5.0-r3"
-      },
-      {
-        "architecture": "x86_64",
         "checksum": "Q1TAnNLCVTaCylmbN84TlliyM47qM=",
         "control": {
           "checksum": "sha1-TAnNLCVTaCylmbN84TlliyM47qM=",
@@ -258,6 +239,25 @@
         },
         "url": "https://packages.wolfi.dev/os/x86_64/krb5-libs-1.21.2-r1.apk",
         "version": "1.21.2-r1"
+      },
+      {
+        "architecture": "x86_64",
+        "checksum": "Q1Zjfs1uR/mYiortANP+EFcejW+vo=",
+        "control": {
+          "checksum": "sha1-Zjfs1uR/mYiortANP+EFcejW+vo=",
+          "range": "bytes=698-1085"
+        },
+        "data": {
+          "checksum": "sha256-BMd7TzffjbrFwdbopDPVYsX0X9XnusIMNbIf33/8kwc=",
+          "range": "bytes=1086-76881"
+        },
+        "name": "protobuf-c",
+        "signature": {
+          "checksum": "sha1-efGiXyYWsJ5P2uTkB6aXEZ3kl3o=",
+          "range": "bytes=0-697"
+        },
+        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r4.apk",
+        "version": "1.5.0-r4"
       },
       {
         "architecture": "x86_64",
@@ -470,22 +470,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q12eKoxDrTjnN67UapcxL36uSvK6Y=",
+        "checksum": "Q1TS707T+cPGL7TYVHQBCJoWwHZ0E=",
         "control": {
-          "checksum": "sha1-2eKoxDrTjnN67UapcxL36uSvK6Y=",
-          "range": "bytes=694-1086"
+          "checksum": "sha1-TS707T+cPGL7TYVHQBCJoWwHZ0E=",
+          "range": "bytes=706-1098"
         },
         "data": {
-          "checksum": "sha256-xlBSY4KJHzH59eU8L6EFYVJVksfsqUlpE7yt7WtlBos=",
-          "range": "bytes=1087-4546022"
+          "checksum": "sha256-x18L706Vug5qDzq13SXuN/vGdVgzrqB06dW2DdgHGR4=",
+          "range": "bytes=1099-4541967"
         },
         "name": "libxml2",
         "signature": {
-          "checksum": "sha1-sRrMqWd8n9UGVkkp5YwEQ4xr9iY=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-BYhOxDos48sN8df8LMsSpROv2aw=",
+          "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.12.6-r1.apk",
-        "version": "2.12.6-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.12.7-r0.apk",
+        "version": "2.12.7-r0"
       },
       {
         "architecture": "x86_64",
@@ -527,22 +527,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ZvgMPq5RCd5lQ3v2qeBBOLotsXM=",
+        "checksum": "Q1dLQQZAfXkamLwZ7kLZb2atjfZZQ=",
         "control": {
-          "checksum": "sha1-ZvgMPq5RCd5lQ3v2qeBBOLotsXM=",
-          "range": "bytes=698-1093"
+          "checksum": "sha1-dLQQZAfXkamLwZ7kLZb2atjfZZQ=",
+          "range": "bytes=701-1095"
         },
         "data": {
-          "checksum": "sha256-mQrZT/j9v5ff50OwlphGA2m2AApMWZfnnPaoEBil57Q=",
-          "range": "bytes=1094-233900"
+          "checksum": "sha256-9c2Qzrfedb7BJdu6THUm5TLxb0dvov8v4tvfqBWlUuw=",
+          "range": "bytes=1096-233941"
         },
         "name": "libxcrypt",
         "signature": {
-          "checksum": "sha1-THgEEMvz4LUMjzDPVU7db5XBJ+E=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-DFbDoKQ6O4YqS6aru0hhYo/8TUk=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxcrypt-4.4.36-r5.apk",
-        "version": "4.4.36-r5"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxcrypt-4.4.36-r6.apk",
+        "version": "4.4.36-r6"
       },
       {
         "architecture": "x86_64",
@@ -717,22 +717,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1DmeAyxnt7LFBKHPDkiG/2rzHBjU=",
+        "checksum": "Q1nuk4yG0xd+GkRDL81R/w5PENRCQ=",
         "control": {
-          "checksum": "sha1-DmeAyxnt7LFBKHPDkiG/2rzHBjU=",
-          "range": "bytes=694-1076"
+          "checksum": "sha1-nuk4yG0xd+GkRDL81R/w5PENRCQ=",
+          "range": "bytes=698-1078"
         },
         "data": {
-          "checksum": "sha256-HwWgrPIe1Tx4S6JEKGkz7LL4GYKBbYTfzSi0OuWYgik=",
-          "range": "bytes=1077-15537589"
+          "checksum": "sha256-y+Nr180+iH7Q2D+H7AeGH5RU226pUwiBOZ8fqTyt/R0=",
+          "range": "bytes=1079-15541726"
         },
         "name": "prometheus-node-exporter",
         "signature": {
-          "checksum": "sha1-mJU8fGK3wjK5OQciCNI318TwWlA=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-5HFvYcuvZUmlWUqjI2ql6dAKFbU=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/prometheus-node-exporter-1.8.0-r0.apk",
-        "version": "1.8.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/prometheus-node-exporter-1.8.0-r2.apk",
+        "version": "1.8.0-r2"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/opentelemetry-collector.lock.json
+++ b/wolfi-images/opentelemetry-collector.lock.json
@@ -109,25 +109,6 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1mVgCtcYDHEkUa+8x41i7w9cQ4Qg=",
-        "control": {
-          "checksum": "sha1-mVgCtcYDHEkUa+8x41i7w9cQ4Qg=",
-          "range": "bytes=704-1079"
-        },
-        "data": {
-          "checksum": "sha256-xE4spLqr7qIgImPfMC1kMY1a7Xu7xu1/eLkBMgOzSSc=",
-          "range": "bytes=1080-77936"
-        },
-        "name": "protobuf-c",
-        "signature": {
-          "checksum": "sha1-NGL0ELlBK8mhhAzuOkm17d2LbRo=",
-          "range": "bytes=0-703"
-        },
-        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r3.apk",
-        "version": "1.5.0-r3"
-      },
-      {
-        "architecture": "x86_64",
         "checksum": "Q1TAnNLCVTaCylmbN84TlliyM47qM=",
         "control": {
           "checksum": "sha1-TAnNLCVTaCylmbN84TlliyM47qM=",
@@ -258,6 +239,25 @@
         },
         "url": "https://packages.wolfi.dev/os/x86_64/krb5-libs-1.21.2-r1.apk",
         "version": "1.21.2-r1"
+      },
+      {
+        "architecture": "x86_64",
+        "checksum": "Q1Zjfs1uR/mYiortANP+EFcejW+vo=",
+        "control": {
+          "checksum": "sha1-Zjfs1uR/mYiortANP+EFcejW+vo=",
+          "range": "bytes=698-1085"
+        },
+        "data": {
+          "checksum": "sha256-BMd7TzffjbrFwdbopDPVYsX0X9XnusIMNbIf33/8kwc=",
+          "range": "bytes=1086-76881"
+        },
+        "name": "protobuf-c",
+        "signature": {
+          "checksum": "sha1-efGiXyYWsJ5P2uTkB6aXEZ3kl3o=",
+          "range": "bytes=0-697"
+        },
+        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r4.apk",
+        "version": "1.5.0-r4"
       },
       {
         "architecture": "x86_64",
@@ -470,22 +470,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q12eKoxDrTjnN67UapcxL36uSvK6Y=",
+        "checksum": "Q1TS707T+cPGL7TYVHQBCJoWwHZ0E=",
         "control": {
-          "checksum": "sha1-2eKoxDrTjnN67UapcxL36uSvK6Y=",
-          "range": "bytes=694-1086"
+          "checksum": "sha1-TS707T+cPGL7TYVHQBCJoWwHZ0E=",
+          "range": "bytes=706-1098"
         },
         "data": {
-          "checksum": "sha256-xlBSY4KJHzH59eU8L6EFYVJVksfsqUlpE7yt7WtlBos=",
-          "range": "bytes=1087-4546022"
+          "checksum": "sha256-x18L706Vug5qDzq13SXuN/vGdVgzrqB06dW2DdgHGR4=",
+          "range": "bytes=1099-4541967"
         },
         "name": "libxml2",
         "signature": {
-          "checksum": "sha1-sRrMqWd8n9UGVkkp5YwEQ4xr9iY=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-BYhOxDos48sN8df8LMsSpROv2aw=",
+          "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.12.6-r1.apk",
-        "version": "2.12.6-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.12.7-r0.apk",
+        "version": "2.12.7-r0"
       },
       {
         "architecture": "x86_64",
@@ -527,22 +527,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ZvgMPq5RCd5lQ3v2qeBBOLotsXM=",
+        "checksum": "Q1dLQQZAfXkamLwZ7kLZb2atjfZZQ=",
         "control": {
-          "checksum": "sha1-ZvgMPq5RCd5lQ3v2qeBBOLotsXM=",
-          "range": "bytes=698-1093"
+          "checksum": "sha1-dLQQZAfXkamLwZ7kLZb2atjfZZQ=",
+          "range": "bytes=701-1095"
         },
         "data": {
-          "checksum": "sha256-mQrZT/j9v5ff50OwlphGA2m2AApMWZfnnPaoEBil57Q=",
-          "range": "bytes=1094-233900"
+          "checksum": "sha256-9c2Qzrfedb7BJdu6THUm5TLxb0dvov8v4tvfqBWlUuw=",
+          "range": "bytes=1096-233941"
         },
         "name": "libxcrypt",
         "signature": {
-          "checksum": "sha1-THgEEMvz4LUMjzDPVU7db5XBJ+E=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-DFbDoKQ6O4YqS6aru0hhYo/8TUk=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxcrypt-4.4.36-r5.apk",
-        "version": "4.4.36-r5"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxcrypt-4.4.36-r6.apk",
+        "version": "4.4.36-r6"
       },
       {
         "architecture": "x86_64",
@@ -755,22 +755,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1m7SsrH+XnrPIapzhnK0vkoxMen4=",
+        "checksum": "Q1ZrMuP718My90TnZrml7ylUmXGlo=",
         "control": {
-          "checksum": "sha1-m7SsrH+XnrPIapzhnK0vkoxMen4=",
-          "range": "bytes=698-1077"
+          "checksum": "sha1-ZrMuP718My90TnZrml7ylUmXGlo=",
+          "range": "bytes=702-1093"
         },
         "data": {
-          "checksum": "sha256-0WaULqZyE0zNNC6D7YeaXVN4shAVEouyqAEiRlB09C0=",
-          "range": "bytes=1078-54479"
+          "checksum": "sha256-+ZTF5s9bHKtoArLvOvIL/2seV4pE0ElEj9MlAscAdso=",
+          "range": "bytes=1094-53513"
         },
         "name": "tini",
         "signature": {
-          "checksum": "sha1-eomfhWCyCB1OA/2DHboLUzXunvA=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-OK9J/Z8qnRssJzNCu9hER8FuzSk=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/tini-0.19.0-r3.apk",
-        "version": "0.19.0-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/tini-0.19.0-r4.apk",
+        "version": "0.19.0-r4"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/postgres-exporter.lock.json
+++ b/wolfi-images/postgres-exporter.lock.json
@@ -109,25 +109,6 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1mVgCtcYDHEkUa+8x41i7w9cQ4Qg=",
-        "control": {
-          "checksum": "sha1-mVgCtcYDHEkUa+8x41i7w9cQ4Qg=",
-          "range": "bytes=704-1079"
-        },
-        "data": {
-          "checksum": "sha256-xE4spLqr7qIgImPfMC1kMY1a7Xu7xu1/eLkBMgOzSSc=",
-          "range": "bytes=1080-77936"
-        },
-        "name": "protobuf-c",
-        "signature": {
-          "checksum": "sha1-NGL0ELlBK8mhhAzuOkm17d2LbRo=",
-          "range": "bytes=0-703"
-        },
-        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r3.apk",
-        "version": "1.5.0-r3"
-      },
-      {
-        "architecture": "x86_64",
         "checksum": "Q1TAnNLCVTaCylmbN84TlliyM47qM=",
         "control": {
           "checksum": "sha1-TAnNLCVTaCylmbN84TlliyM47qM=",
@@ -258,6 +239,25 @@
         },
         "url": "https://packages.wolfi.dev/os/x86_64/krb5-libs-1.21.2-r1.apk",
         "version": "1.21.2-r1"
+      },
+      {
+        "architecture": "x86_64",
+        "checksum": "Q1Zjfs1uR/mYiortANP+EFcejW+vo=",
+        "control": {
+          "checksum": "sha1-Zjfs1uR/mYiortANP+EFcejW+vo=",
+          "range": "bytes=698-1085"
+        },
+        "data": {
+          "checksum": "sha256-BMd7TzffjbrFwdbopDPVYsX0X9XnusIMNbIf33/8kwc=",
+          "range": "bytes=1086-76881"
+        },
+        "name": "protobuf-c",
+        "signature": {
+          "checksum": "sha1-efGiXyYWsJ5P2uTkB6aXEZ3kl3o=",
+          "range": "bytes=0-697"
+        },
+        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r4.apk",
+        "version": "1.5.0-r4"
       },
       {
         "architecture": "x86_64",
@@ -470,22 +470,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q12eKoxDrTjnN67UapcxL36uSvK6Y=",
+        "checksum": "Q1TS707T+cPGL7TYVHQBCJoWwHZ0E=",
         "control": {
-          "checksum": "sha1-2eKoxDrTjnN67UapcxL36uSvK6Y=",
-          "range": "bytes=694-1086"
+          "checksum": "sha1-TS707T+cPGL7TYVHQBCJoWwHZ0E=",
+          "range": "bytes=706-1098"
         },
         "data": {
-          "checksum": "sha256-xlBSY4KJHzH59eU8L6EFYVJVksfsqUlpE7yt7WtlBos=",
-          "range": "bytes=1087-4546022"
+          "checksum": "sha256-x18L706Vug5qDzq13SXuN/vGdVgzrqB06dW2DdgHGR4=",
+          "range": "bytes=1099-4541967"
         },
         "name": "libxml2",
         "signature": {
-          "checksum": "sha1-sRrMqWd8n9UGVkkp5YwEQ4xr9iY=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-BYhOxDos48sN8df8LMsSpROv2aw=",
+          "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.12.6-r1.apk",
-        "version": "2.12.6-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.12.7-r0.apk",
+        "version": "2.12.7-r0"
       },
       {
         "architecture": "x86_64",
@@ -527,22 +527,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ZvgMPq5RCd5lQ3v2qeBBOLotsXM=",
+        "checksum": "Q1dLQQZAfXkamLwZ7kLZb2atjfZZQ=",
         "control": {
-          "checksum": "sha1-ZvgMPq5RCd5lQ3v2qeBBOLotsXM=",
-          "range": "bytes=698-1093"
+          "checksum": "sha1-dLQQZAfXkamLwZ7kLZb2atjfZZQ=",
+          "range": "bytes=701-1095"
         },
         "data": {
-          "checksum": "sha256-mQrZT/j9v5ff50OwlphGA2m2AApMWZfnnPaoEBil57Q=",
-          "range": "bytes=1094-233900"
+          "checksum": "sha256-9c2Qzrfedb7BJdu6THUm5TLxb0dvov8v4tvfqBWlUuw=",
+          "range": "bytes=1096-233941"
         },
         "name": "libxcrypt",
         "signature": {
-          "checksum": "sha1-THgEEMvz4LUMjzDPVU7db5XBJ+E=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-DFbDoKQ6O4YqS6aru0hhYo/8TUk=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxcrypt-4.4.36-r5.apk",
-        "version": "4.4.36-r5"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxcrypt-4.4.36-r6.apk",
+        "version": "4.4.36-r6"
       },
       {
         "architecture": "x86_64",
@@ -717,22 +717,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1v9j36aKj/QDucW2TWthgb0lFN5c=",
+        "checksum": "Q1XIbmz6FFXwWTUG8HhvQerKRe/jw=",
         "control": {
-          "checksum": "sha1-v9j36aKj/QDucW2TWthgb0lFN5c=",
-          "range": "bytes=703-1088"
+          "checksum": "sha1-XIbmz6FFXwWTUG8HhvQerKRe/jw=",
+          "range": "bytes=696-1083"
         },
         "data": {
-          "checksum": "sha256-x/hkY8PBEFsAYRDrU7hhTRaL1lVe5dlPK5I7y8ayw7w=",
-          "range": "bytes=1089-13096952"
+          "checksum": "sha256-UKgbUouSkIdCQsg8PmQTkCgdqcyvoLQgXBBnqCxbIro=",
+          "range": "bytes=1084-13096991"
         },
         "name": "prometheus-postgres-exporter",
         "signature": {
-          "checksum": "sha1-nMuUyXCQD2YI4Wm6TeBRrsiT7ds=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-KOTdEh5gZtZxWaonriTl0RKGtz0=",
+          "range": "bytes=0-695"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/prometheus-postgres-exporter-0.15.0-r7.apk",
-        "version": "0.15.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/prometheus-postgres-exporter-0.15.0-r9.apk",
+        "version": "0.15.0-r9"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/postgresql-12-codeinsights.lock.json
+++ b/wolfi-images/postgresql-12-codeinsights.lock.json
@@ -109,25 +109,6 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1mVgCtcYDHEkUa+8x41i7w9cQ4Qg=",
-        "control": {
-          "checksum": "sha1-mVgCtcYDHEkUa+8x41i7w9cQ4Qg=",
-          "range": "bytes=704-1079"
-        },
-        "data": {
-          "checksum": "sha256-xE4spLqr7qIgImPfMC1kMY1a7Xu7xu1/eLkBMgOzSSc=",
-          "range": "bytes=1080-77936"
-        },
-        "name": "protobuf-c",
-        "signature": {
-          "checksum": "sha1-NGL0ELlBK8mhhAzuOkm17d2LbRo=",
-          "range": "bytes=0-703"
-        },
-        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r3.apk",
-        "version": "1.5.0-r3"
-      },
-      {
-        "architecture": "x86_64",
         "checksum": "Q1TAnNLCVTaCylmbN84TlliyM47qM=",
         "control": {
           "checksum": "sha1-TAnNLCVTaCylmbN84TlliyM47qM=",
@@ -258,6 +239,25 @@
         },
         "url": "https://packages.wolfi.dev/os/x86_64/krb5-libs-1.21.2-r1.apk",
         "version": "1.21.2-r1"
+      },
+      {
+        "architecture": "x86_64",
+        "checksum": "Q1Zjfs1uR/mYiortANP+EFcejW+vo=",
+        "control": {
+          "checksum": "sha1-Zjfs1uR/mYiortANP+EFcejW+vo=",
+          "range": "bytes=698-1085"
+        },
+        "data": {
+          "checksum": "sha256-BMd7TzffjbrFwdbopDPVYsX0X9XnusIMNbIf33/8kwc=",
+          "range": "bytes=1086-76881"
+        },
+        "name": "protobuf-c",
+        "signature": {
+          "checksum": "sha1-efGiXyYWsJ5P2uTkB6aXEZ3kl3o=",
+          "range": "bytes=0-697"
+        },
+        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r4.apk",
+        "version": "1.5.0-r4"
       },
       {
         "architecture": "x86_64",
@@ -470,22 +470,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q12eKoxDrTjnN67UapcxL36uSvK6Y=",
+        "checksum": "Q1TS707T+cPGL7TYVHQBCJoWwHZ0E=",
         "control": {
-          "checksum": "sha1-2eKoxDrTjnN67UapcxL36uSvK6Y=",
-          "range": "bytes=694-1086"
+          "checksum": "sha1-TS707T+cPGL7TYVHQBCJoWwHZ0E=",
+          "range": "bytes=706-1098"
         },
         "data": {
-          "checksum": "sha256-xlBSY4KJHzH59eU8L6EFYVJVksfsqUlpE7yt7WtlBos=",
-          "range": "bytes=1087-4546022"
+          "checksum": "sha256-x18L706Vug5qDzq13SXuN/vGdVgzrqB06dW2DdgHGR4=",
+          "range": "bytes=1099-4541967"
         },
         "name": "libxml2",
         "signature": {
-          "checksum": "sha1-sRrMqWd8n9UGVkkp5YwEQ4xr9iY=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-BYhOxDos48sN8df8LMsSpROv2aw=",
+          "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.12.6-r1.apk",
-        "version": "2.12.6-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.12.7-r0.apk",
+        "version": "2.12.7-r0"
       },
       {
         "architecture": "x86_64",
@@ -527,22 +527,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ZvgMPq5RCd5lQ3v2qeBBOLotsXM=",
+        "checksum": "Q1dLQQZAfXkamLwZ7kLZb2atjfZZQ=",
         "control": {
-          "checksum": "sha1-ZvgMPq5RCd5lQ3v2qeBBOLotsXM=",
-          "range": "bytes=698-1093"
+          "checksum": "sha1-dLQQZAfXkamLwZ7kLZb2atjfZZQ=",
+          "range": "bytes=701-1095"
         },
         "data": {
-          "checksum": "sha256-mQrZT/j9v5ff50OwlphGA2m2AApMWZfnnPaoEBil57Q=",
-          "range": "bytes=1094-233900"
+          "checksum": "sha256-9c2Qzrfedb7BJdu6THUm5TLxb0dvov8v4tvfqBWlUuw=",
+          "range": "bytes=1096-233941"
         },
         "name": "libxcrypt",
         "signature": {
-          "checksum": "sha1-THgEEMvz4LUMjzDPVU7db5XBJ+E=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-DFbDoKQ6O4YqS6aru0hhYo/8TUk=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxcrypt-4.4.36-r5.apk",
-        "version": "4.4.36-r5"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxcrypt-4.4.36-r6.apk",
+        "version": "4.4.36-r6"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/postgresql-12.lock.json
+++ b/wolfi-images/postgresql-12.lock.json
@@ -109,25 +109,6 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1mVgCtcYDHEkUa+8x41i7w9cQ4Qg=",
-        "control": {
-          "checksum": "sha1-mVgCtcYDHEkUa+8x41i7w9cQ4Qg=",
-          "range": "bytes=704-1079"
-        },
-        "data": {
-          "checksum": "sha256-xE4spLqr7qIgImPfMC1kMY1a7Xu7xu1/eLkBMgOzSSc=",
-          "range": "bytes=1080-77936"
-        },
-        "name": "protobuf-c",
-        "signature": {
-          "checksum": "sha1-NGL0ELlBK8mhhAzuOkm17d2LbRo=",
-          "range": "bytes=0-703"
-        },
-        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r3.apk",
-        "version": "1.5.0-r3"
-      },
-      {
-        "architecture": "x86_64",
         "checksum": "Q1TAnNLCVTaCylmbN84TlliyM47qM=",
         "control": {
           "checksum": "sha1-TAnNLCVTaCylmbN84TlliyM47qM=",
@@ -258,6 +239,25 @@
         },
         "url": "https://packages.wolfi.dev/os/x86_64/krb5-libs-1.21.2-r1.apk",
         "version": "1.21.2-r1"
+      },
+      {
+        "architecture": "x86_64",
+        "checksum": "Q1Zjfs1uR/mYiortANP+EFcejW+vo=",
+        "control": {
+          "checksum": "sha1-Zjfs1uR/mYiortANP+EFcejW+vo=",
+          "range": "bytes=698-1085"
+        },
+        "data": {
+          "checksum": "sha256-BMd7TzffjbrFwdbopDPVYsX0X9XnusIMNbIf33/8kwc=",
+          "range": "bytes=1086-76881"
+        },
+        "name": "protobuf-c",
+        "signature": {
+          "checksum": "sha1-efGiXyYWsJ5P2uTkB6aXEZ3kl3o=",
+          "range": "bytes=0-697"
+        },
+        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r4.apk",
+        "version": "1.5.0-r4"
       },
       {
         "architecture": "x86_64",
@@ -470,22 +470,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q12eKoxDrTjnN67UapcxL36uSvK6Y=",
+        "checksum": "Q1TS707T+cPGL7TYVHQBCJoWwHZ0E=",
         "control": {
-          "checksum": "sha1-2eKoxDrTjnN67UapcxL36uSvK6Y=",
-          "range": "bytes=694-1086"
+          "checksum": "sha1-TS707T+cPGL7TYVHQBCJoWwHZ0E=",
+          "range": "bytes=706-1098"
         },
         "data": {
-          "checksum": "sha256-xlBSY4KJHzH59eU8L6EFYVJVksfsqUlpE7yt7WtlBos=",
-          "range": "bytes=1087-4546022"
+          "checksum": "sha256-x18L706Vug5qDzq13SXuN/vGdVgzrqB06dW2DdgHGR4=",
+          "range": "bytes=1099-4541967"
         },
         "name": "libxml2",
         "signature": {
-          "checksum": "sha1-sRrMqWd8n9UGVkkp5YwEQ4xr9iY=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-BYhOxDos48sN8df8LMsSpROv2aw=",
+          "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.12.6-r1.apk",
-        "version": "2.12.6-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.12.7-r0.apk",
+        "version": "2.12.7-r0"
       },
       {
         "architecture": "x86_64",
@@ -527,22 +527,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ZvgMPq5RCd5lQ3v2qeBBOLotsXM=",
+        "checksum": "Q1dLQQZAfXkamLwZ7kLZb2atjfZZQ=",
         "control": {
-          "checksum": "sha1-ZvgMPq5RCd5lQ3v2qeBBOLotsXM=",
-          "range": "bytes=698-1093"
+          "checksum": "sha1-dLQQZAfXkamLwZ7kLZb2atjfZZQ=",
+          "range": "bytes=701-1095"
         },
         "data": {
-          "checksum": "sha256-mQrZT/j9v5ff50OwlphGA2m2AApMWZfnnPaoEBil57Q=",
-          "range": "bytes=1094-233900"
+          "checksum": "sha256-9c2Qzrfedb7BJdu6THUm5TLxb0dvov8v4tvfqBWlUuw=",
+          "range": "bytes=1096-233941"
         },
         "name": "libxcrypt",
         "signature": {
-          "checksum": "sha1-THgEEMvz4LUMjzDPVU7db5XBJ+E=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-DFbDoKQ6O4YqS6aru0hhYo/8TUk=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxcrypt-4.4.36-r5.apk",
-        "version": "4.4.36-r5"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxcrypt-4.4.36-r6.apk",
+        "version": "4.4.36-r6"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/prometheus.lock.json
+++ b/wolfi-images/prometheus.lock.json
@@ -109,25 +109,6 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1mVgCtcYDHEkUa+8x41i7w9cQ4Qg=",
-        "control": {
-          "checksum": "sha1-mVgCtcYDHEkUa+8x41i7w9cQ4Qg=",
-          "range": "bytes=704-1079"
-        },
-        "data": {
-          "checksum": "sha256-xE4spLqr7qIgImPfMC1kMY1a7Xu7xu1/eLkBMgOzSSc=",
-          "range": "bytes=1080-77936"
-        },
-        "name": "protobuf-c",
-        "signature": {
-          "checksum": "sha1-NGL0ELlBK8mhhAzuOkm17d2LbRo=",
-          "range": "bytes=0-703"
-        },
-        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r3.apk",
-        "version": "1.5.0-r3"
-      },
-      {
-        "architecture": "x86_64",
         "checksum": "Q1TAnNLCVTaCylmbN84TlliyM47qM=",
         "control": {
           "checksum": "sha1-TAnNLCVTaCylmbN84TlliyM47qM=",
@@ -258,6 +239,25 @@
         },
         "url": "https://packages.wolfi.dev/os/x86_64/krb5-libs-1.21.2-r1.apk",
         "version": "1.21.2-r1"
+      },
+      {
+        "architecture": "x86_64",
+        "checksum": "Q1Zjfs1uR/mYiortANP+EFcejW+vo=",
+        "control": {
+          "checksum": "sha1-Zjfs1uR/mYiortANP+EFcejW+vo=",
+          "range": "bytes=698-1085"
+        },
+        "data": {
+          "checksum": "sha256-BMd7TzffjbrFwdbopDPVYsX0X9XnusIMNbIf33/8kwc=",
+          "range": "bytes=1086-76881"
+        },
+        "name": "protobuf-c",
+        "signature": {
+          "checksum": "sha1-efGiXyYWsJ5P2uTkB6aXEZ3kl3o=",
+          "range": "bytes=0-697"
+        },
+        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r4.apk",
+        "version": "1.5.0-r4"
       },
       {
         "architecture": "x86_64",
@@ -470,22 +470,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q12eKoxDrTjnN67UapcxL36uSvK6Y=",
+        "checksum": "Q1TS707T+cPGL7TYVHQBCJoWwHZ0E=",
         "control": {
-          "checksum": "sha1-2eKoxDrTjnN67UapcxL36uSvK6Y=",
-          "range": "bytes=694-1086"
+          "checksum": "sha1-TS707T+cPGL7TYVHQBCJoWwHZ0E=",
+          "range": "bytes=706-1098"
         },
         "data": {
-          "checksum": "sha256-xlBSY4KJHzH59eU8L6EFYVJVksfsqUlpE7yt7WtlBos=",
-          "range": "bytes=1087-4546022"
+          "checksum": "sha256-x18L706Vug5qDzq13SXuN/vGdVgzrqB06dW2DdgHGR4=",
+          "range": "bytes=1099-4541967"
         },
         "name": "libxml2",
         "signature": {
-          "checksum": "sha1-sRrMqWd8n9UGVkkp5YwEQ4xr9iY=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-BYhOxDos48sN8df8LMsSpROv2aw=",
+          "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.12.6-r1.apk",
-        "version": "2.12.6-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.12.7-r0.apk",
+        "version": "2.12.7-r0"
       },
       {
         "architecture": "x86_64",
@@ -527,22 +527,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ZvgMPq5RCd5lQ3v2qeBBOLotsXM=",
+        "checksum": "Q1dLQQZAfXkamLwZ7kLZb2atjfZZQ=",
         "control": {
-          "checksum": "sha1-ZvgMPq5RCd5lQ3v2qeBBOLotsXM=",
-          "range": "bytes=698-1093"
+          "checksum": "sha1-dLQQZAfXkamLwZ7kLZb2atjfZZQ=",
+          "range": "bytes=701-1095"
         },
         "data": {
-          "checksum": "sha256-mQrZT/j9v5ff50OwlphGA2m2AApMWZfnnPaoEBil57Q=",
-          "range": "bytes=1094-233900"
+          "checksum": "sha256-9c2Qzrfedb7BJdu6THUm5TLxb0dvov8v4tvfqBWlUuw=",
+          "range": "bytes=1096-233941"
         },
         "name": "libxcrypt",
         "signature": {
-          "checksum": "sha1-THgEEMvz4LUMjzDPVU7db5XBJ+E=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-DFbDoKQ6O4YqS6aru0hhYo/8TUk=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxcrypt-4.4.36-r5.apk",
-        "version": "4.4.36-r5"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxcrypt-4.4.36-r6.apk",
+        "version": "4.4.36-r6"
       },
       {
         "architecture": "x86_64",
@@ -736,60 +736,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1UmcDqeuODUV8+OpvLzUyx0yI8xc=",
+        "checksum": "Q1/xH9NXh2XAN7AiXLSyfKBjj+41g=",
         "control": {
-          "checksum": "sha1-UmcDqeuODUV8+OpvLzUyx0yI8xc=",
-          "range": "bytes=698-1144"
+          "checksum": "sha1-/xH9NXh2XAN7AiXLSyfKBjj+41g=",
+          "range": "bytes=694-1135"
         },
         "data": {
-          "checksum": "sha256-b4esuCNDnZjnPFuKsFFEVf4YtzS4090D1TxWga/nvWs=",
-          "range": "bytes=1145-186251251"
+          "checksum": "sha256-qg8zb40a6hpJUCmj2xctm8npy+TSpC9kumdnnSNRkQE=",
+          "range": "bytes=1136-192879162"
         },
-        "name": "prometheus-2.51",
+        "name": "prometheus-2.52",
         "signature": {
-          "checksum": "sha1-Dd6iX7TS/jcSD3fMqnagSEvize0=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-As1h2B3XeSrL7tXFOnrKY2uEY0U=",
+          "range": "bytes=0-693"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/prometheus-2.51-2.51.2-r1.apk",
-        "version": "2.51.2-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/prometheus-2.52-2.52.0-r1.apk",
+        "version": "2.52.0-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1d50lhC89U1NMDfOR59tXcSxwhoI=",
+        "checksum": "Q1EFV1Q0eivNbJaIY0PhIkKyi/YpM=",
         "control": {
-          "checksum": "sha1-d50lhC89U1NMDfOR59tXcSxwhoI=",
-          "range": "bytes=703-1074"
+          "checksum": "sha1-EFV1Q0eivNbJaIY0PhIkKyi/YpM=",
+          "range": "bytes=692-1063"
         },
         "data": {
-          "checksum": "sha256-1hO2vJ48CDakvu2qdsvRm+VFmtEaxx7ECLIhmzn1U+A=",
-          "range": "bytes=1075-57320339"
+          "checksum": "sha256-8+FNf75bgQE5erENZXCFxI50AnaHUvWSpI08emdqXvM=",
+          "range": "bytes=1064-57320379"
         },
         "name": "prometheus-alertmanager",
         "signature": {
-          "checksum": "sha1-cSE9DHjKcHhrVZ202d3cVA6lnnA=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-YMhX/dlqWFP0BQzWZPUviDQs/Yw=",
+          "range": "bytes=0-691"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/prometheus-alertmanager-0.27.0-r4.apk",
-        "version": "0.27.0-r4"
+        "url": "https://packages.wolfi.dev/os/x86_64/prometheus-alertmanager-0.27.0-r5.apk",
+        "version": "0.27.0-r5"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1m7SsrH+XnrPIapzhnK0vkoxMen4=",
+        "checksum": "Q1ZrMuP718My90TnZrml7ylUmXGlo=",
         "control": {
-          "checksum": "sha1-m7SsrH+XnrPIapzhnK0vkoxMen4=",
-          "range": "bytes=698-1077"
+          "checksum": "sha1-ZrMuP718My90TnZrml7ylUmXGlo=",
+          "range": "bytes=702-1093"
         },
         "data": {
-          "checksum": "sha256-0WaULqZyE0zNNC6D7YeaXVN4shAVEouyqAEiRlB09C0=",
-          "range": "bytes=1078-54479"
+          "checksum": "sha256-+ZTF5s9bHKtoArLvOvIL/2seV4pE0ElEj9MlAscAdso=",
+          "range": "bytes=1094-53513"
         },
         "name": "tini",
         "signature": {
-          "checksum": "sha1-eomfhWCyCB1OA/2DHboLUzXunvA=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-OK9J/Z8qnRssJzNCu9hER8FuzSk=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/tini-0.19.0-r3.apk",
-        "version": "0.19.0-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/tini-0.19.0-r4.apk",
+        "version": "0.19.0-r4"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/redis-exporter.lock.json
+++ b/wolfi-images/redis-exporter.lock.json
@@ -109,25 +109,6 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1mVgCtcYDHEkUa+8x41i7w9cQ4Qg=",
-        "control": {
-          "checksum": "sha1-mVgCtcYDHEkUa+8x41i7w9cQ4Qg=",
-          "range": "bytes=704-1079"
-        },
-        "data": {
-          "checksum": "sha256-xE4spLqr7qIgImPfMC1kMY1a7Xu7xu1/eLkBMgOzSSc=",
-          "range": "bytes=1080-77936"
-        },
-        "name": "protobuf-c",
-        "signature": {
-          "checksum": "sha1-NGL0ELlBK8mhhAzuOkm17d2LbRo=",
-          "range": "bytes=0-703"
-        },
-        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r3.apk",
-        "version": "1.5.0-r3"
-      },
-      {
-        "architecture": "x86_64",
         "checksum": "Q1TAnNLCVTaCylmbN84TlliyM47qM=",
         "control": {
           "checksum": "sha1-TAnNLCVTaCylmbN84TlliyM47qM=",
@@ -258,6 +239,25 @@
         },
         "url": "https://packages.wolfi.dev/os/x86_64/krb5-libs-1.21.2-r1.apk",
         "version": "1.21.2-r1"
+      },
+      {
+        "architecture": "x86_64",
+        "checksum": "Q1Zjfs1uR/mYiortANP+EFcejW+vo=",
+        "control": {
+          "checksum": "sha1-Zjfs1uR/mYiortANP+EFcejW+vo=",
+          "range": "bytes=698-1085"
+        },
+        "data": {
+          "checksum": "sha256-BMd7TzffjbrFwdbopDPVYsX0X9XnusIMNbIf33/8kwc=",
+          "range": "bytes=1086-76881"
+        },
+        "name": "protobuf-c",
+        "signature": {
+          "checksum": "sha1-efGiXyYWsJ5P2uTkB6aXEZ3kl3o=",
+          "range": "bytes=0-697"
+        },
+        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r4.apk",
+        "version": "1.5.0-r4"
       },
       {
         "architecture": "x86_64",
@@ -470,22 +470,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q12eKoxDrTjnN67UapcxL36uSvK6Y=",
+        "checksum": "Q1TS707T+cPGL7TYVHQBCJoWwHZ0E=",
         "control": {
-          "checksum": "sha1-2eKoxDrTjnN67UapcxL36uSvK6Y=",
-          "range": "bytes=694-1086"
+          "checksum": "sha1-TS707T+cPGL7TYVHQBCJoWwHZ0E=",
+          "range": "bytes=706-1098"
         },
         "data": {
-          "checksum": "sha256-xlBSY4KJHzH59eU8L6EFYVJVksfsqUlpE7yt7WtlBos=",
-          "range": "bytes=1087-4546022"
+          "checksum": "sha256-x18L706Vug5qDzq13SXuN/vGdVgzrqB06dW2DdgHGR4=",
+          "range": "bytes=1099-4541967"
         },
         "name": "libxml2",
         "signature": {
-          "checksum": "sha1-sRrMqWd8n9UGVkkp5YwEQ4xr9iY=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-BYhOxDos48sN8df8LMsSpROv2aw=",
+          "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.12.6-r1.apk",
-        "version": "2.12.6-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.12.7-r0.apk",
+        "version": "2.12.7-r0"
       },
       {
         "architecture": "x86_64",
@@ -527,22 +527,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ZvgMPq5RCd5lQ3v2qeBBOLotsXM=",
+        "checksum": "Q1dLQQZAfXkamLwZ7kLZb2atjfZZQ=",
         "control": {
-          "checksum": "sha1-ZvgMPq5RCd5lQ3v2qeBBOLotsXM=",
-          "range": "bytes=698-1093"
+          "checksum": "sha1-dLQQZAfXkamLwZ7kLZb2atjfZZQ=",
+          "range": "bytes=701-1095"
         },
         "data": {
-          "checksum": "sha256-mQrZT/j9v5ff50OwlphGA2m2AApMWZfnnPaoEBil57Q=",
-          "range": "bytes=1094-233900"
+          "checksum": "sha256-9c2Qzrfedb7BJdu6THUm5TLxb0dvov8v4tvfqBWlUuw=",
+          "range": "bytes=1096-233941"
         },
         "name": "libxcrypt",
         "signature": {
-          "checksum": "sha1-THgEEMvz4LUMjzDPVU7db5XBJ+E=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-DFbDoKQ6O4YqS6aru0hhYo/8TUk=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxcrypt-4.4.36-r5.apk",
-        "version": "4.4.36-r5"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxcrypt-4.4.36-r6.apk",
+        "version": "4.4.36-r6"
       },
       {
         "architecture": "x86_64",
@@ -755,22 +755,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1m7SsrH+XnrPIapzhnK0vkoxMen4=",
+        "checksum": "Q1ZrMuP718My90TnZrml7ylUmXGlo=",
         "control": {
-          "checksum": "sha1-m7SsrH+XnrPIapzhnK0vkoxMen4=",
-          "range": "bytes=698-1077"
+          "checksum": "sha1-ZrMuP718My90TnZrml7ylUmXGlo=",
+          "range": "bytes=702-1093"
         },
         "data": {
-          "checksum": "sha256-0WaULqZyE0zNNC6D7YeaXVN4shAVEouyqAEiRlB09C0=",
-          "range": "bytes=1078-54479"
+          "checksum": "sha256-+ZTF5s9bHKtoArLvOvIL/2seV4pE0ElEj9MlAscAdso=",
+          "range": "bytes=1094-53513"
         },
         "name": "tini",
         "signature": {
-          "checksum": "sha1-eomfhWCyCB1OA/2DHboLUzXunvA=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-OK9J/Z8qnRssJzNCu9hER8FuzSk=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/tini-0.19.0-r3.apk",
-        "version": "0.19.0-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/tini-0.19.0-r4.apk",
+        "version": "0.19.0-r4"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/redis.lock.json
+++ b/wolfi-images/redis.lock.json
@@ -109,25 +109,6 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1mVgCtcYDHEkUa+8x41i7w9cQ4Qg=",
-        "control": {
-          "checksum": "sha1-mVgCtcYDHEkUa+8x41i7w9cQ4Qg=",
-          "range": "bytes=704-1079"
-        },
-        "data": {
-          "checksum": "sha256-xE4spLqr7qIgImPfMC1kMY1a7Xu7xu1/eLkBMgOzSSc=",
-          "range": "bytes=1080-77936"
-        },
-        "name": "protobuf-c",
-        "signature": {
-          "checksum": "sha1-NGL0ELlBK8mhhAzuOkm17d2LbRo=",
-          "range": "bytes=0-703"
-        },
-        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r3.apk",
-        "version": "1.5.0-r3"
-      },
-      {
-        "architecture": "x86_64",
         "checksum": "Q1TAnNLCVTaCylmbN84TlliyM47qM=",
         "control": {
           "checksum": "sha1-TAnNLCVTaCylmbN84TlliyM47qM=",
@@ -258,6 +239,25 @@
         },
         "url": "https://packages.wolfi.dev/os/x86_64/krb5-libs-1.21.2-r1.apk",
         "version": "1.21.2-r1"
+      },
+      {
+        "architecture": "x86_64",
+        "checksum": "Q1Zjfs1uR/mYiortANP+EFcejW+vo=",
+        "control": {
+          "checksum": "sha1-Zjfs1uR/mYiortANP+EFcejW+vo=",
+          "range": "bytes=698-1085"
+        },
+        "data": {
+          "checksum": "sha256-BMd7TzffjbrFwdbopDPVYsX0X9XnusIMNbIf33/8kwc=",
+          "range": "bytes=1086-76881"
+        },
+        "name": "protobuf-c",
+        "signature": {
+          "checksum": "sha1-efGiXyYWsJ5P2uTkB6aXEZ3kl3o=",
+          "range": "bytes=0-697"
+        },
+        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r4.apk",
+        "version": "1.5.0-r4"
       },
       {
         "architecture": "x86_64",
@@ -470,22 +470,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q12eKoxDrTjnN67UapcxL36uSvK6Y=",
+        "checksum": "Q1TS707T+cPGL7TYVHQBCJoWwHZ0E=",
         "control": {
-          "checksum": "sha1-2eKoxDrTjnN67UapcxL36uSvK6Y=",
-          "range": "bytes=694-1086"
+          "checksum": "sha1-TS707T+cPGL7TYVHQBCJoWwHZ0E=",
+          "range": "bytes=706-1098"
         },
         "data": {
-          "checksum": "sha256-xlBSY4KJHzH59eU8L6EFYVJVksfsqUlpE7yt7WtlBos=",
-          "range": "bytes=1087-4546022"
+          "checksum": "sha256-x18L706Vug5qDzq13SXuN/vGdVgzrqB06dW2DdgHGR4=",
+          "range": "bytes=1099-4541967"
         },
         "name": "libxml2",
         "signature": {
-          "checksum": "sha1-sRrMqWd8n9UGVkkp5YwEQ4xr9iY=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-BYhOxDos48sN8df8LMsSpROv2aw=",
+          "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.12.6-r1.apk",
-        "version": "2.12.6-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.12.7-r0.apk",
+        "version": "2.12.7-r0"
       },
       {
         "architecture": "x86_64",
@@ -527,22 +527,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ZvgMPq5RCd5lQ3v2qeBBOLotsXM=",
+        "checksum": "Q1dLQQZAfXkamLwZ7kLZb2atjfZZQ=",
         "control": {
-          "checksum": "sha1-ZvgMPq5RCd5lQ3v2qeBBOLotsXM=",
-          "range": "bytes=698-1093"
+          "checksum": "sha1-dLQQZAfXkamLwZ7kLZb2atjfZZQ=",
+          "range": "bytes=701-1095"
         },
         "data": {
-          "checksum": "sha256-mQrZT/j9v5ff50OwlphGA2m2AApMWZfnnPaoEBil57Q=",
-          "range": "bytes=1094-233900"
+          "checksum": "sha256-9c2Qzrfedb7BJdu6THUm5TLxb0dvov8v4tvfqBWlUuw=",
+          "range": "bytes=1096-233941"
         },
         "name": "libxcrypt",
         "signature": {
-          "checksum": "sha1-THgEEMvz4LUMjzDPVU7db5XBJ+E=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-DFbDoKQ6O4YqS6aru0hhYo/8TUk=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxcrypt-4.4.36-r5.apk",
-        "version": "4.4.36-r5"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxcrypt-4.4.36-r6.apk",
+        "version": "4.4.36-r6"
       },
       {
         "architecture": "x86_64",
@@ -850,22 +850,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1m7SsrH+XnrPIapzhnK0vkoxMen4=",
+        "checksum": "Q1ZrMuP718My90TnZrml7ylUmXGlo=",
         "control": {
-          "checksum": "sha1-m7SsrH+XnrPIapzhnK0vkoxMen4=",
-          "range": "bytes=698-1077"
+          "checksum": "sha1-ZrMuP718My90TnZrml7ylUmXGlo=",
+          "range": "bytes=702-1093"
         },
         "data": {
-          "checksum": "sha256-0WaULqZyE0zNNC6D7YeaXVN4shAVEouyqAEiRlB09C0=",
-          "range": "bytes=1078-54479"
+          "checksum": "sha256-+ZTF5s9bHKtoArLvOvIL/2seV4pE0ElEj9MlAscAdso=",
+          "range": "bytes=1094-53513"
         },
         "name": "tini",
         "signature": {
-          "checksum": "sha1-eomfhWCyCB1OA/2DHboLUzXunvA=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-OK9J/Z8qnRssJzNCu9hER8FuzSk=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/tini-0.19.0-r3.apk",
-        "version": "0.19.0-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/tini-0.19.0-r4.apk",
+        "version": "0.19.0-r4"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/repo-updater.lock.json
+++ b/wolfi-images/repo-updater.lock.json
@@ -109,25 +109,6 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1mVgCtcYDHEkUa+8x41i7w9cQ4Qg=",
-        "control": {
-          "checksum": "sha1-mVgCtcYDHEkUa+8x41i7w9cQ4Qg=",
-          "range": "bytes=704-1079"
-        },
-        "data": {
-          "checksum": "sha256-xE4spLqr7qIgImPfMC1kMY1a7Xu7xu1/eLkBMgOzSSc=",
-          "range": "bytes=1080-77936"
-        },
-        "name": "protobuf-c",
-        "signature": {
-          "checksum": "sha1-NGL0ELlBK8mhhAzuOkm17d2LbRo=",
-          "range": "bytes=0-703"
-        },
-        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r3.apk",
-        "version": "1.5.0-r3"
-      },
-      {
-        "architecture": "x86_64",
         "checksum": "Q1TAnNLCVTaCylmbN84TlliyM47qM=",
         "control": {
           "checksum": "sha1-TAnNLCVTaCylmbN84TlliyM47qM=",
@@ -258,6 +239,25 @@
         },
         "url": "https://packages.wolfi.dev/os/x86_64/krb5-libs-1.21.2-r1.apk",
         "version": "1.21.2-r1"
+      },
+      {
+        "architecture": "x86_64",
+        "checksum": "Q1Zjfs1uR/mYiortANP+EFcejW+vo=",
+        "control": {
+          "checksum": "sha1-Zjfs1uR/mYiortANP+EFcejW+vo=",
+          "range": "bytes=698-1085"
+        },
+        "data": {
+          "checksum": "sha256-BMd7TzffjbrFwdbopDPVYsX0X9XnusIMNbIf33/8kwc=",
+          "range": "bytes=1086-76881"
+        },
+        "name": "protobuf-c",
+        "signature": {
+          "checksum": "sha1-efGiXyYWsJ5P2uTkB6aXEZ3kl3o=",
+          "range": "bytes=0-697"
+        },
+        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r4.apk",
+        "version": "1.5.0-r4"
       },
       {
         "architecture": "x86_64",
@@ -470,22 +470,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q12eKoxDrTjnN67UapcxL36uSvK6Y=",
+        "checksum": "Q1TS707T+cPGL7TYVHQBCJoWwHZ0E=",
         "control": {
-          "checksum": "sha1-2eKoxDrTjnN67UapcxL36uSvK6Y=",
-          "range": "bytes=694-1086"
+          "checksum": "sha1-TS707T+cPGL7TYVHQBCJoWwHZ0E=",
+          "range": "bytes=706-1098"
         },
         "data": {
-          "checksum": "sha256-xlBSY4KJHzH59eU8L6EFYVJVksfsqUlpE7yt7WtlBos=",
-          "range": "bytes=1087-4546022"
+          "checksum": "sha256-x18L706Vug5qDzq13SXuN/vGdVgzrqB06dW2DdgHGR4=",
+          "range": "bytes=1099-4541967"
         },
         "name": "libxml2",
         "signature": {
-          "checksum": "sha1-sRrMqWd8n9UGVkkp5YwEQ4xr9iY=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-BYhOxDos48sN8df8LMsSpROv2aw=",
+          "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.12.6-r1.apk",
-        "version": "2.12.6-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.12.7-r0.apk",
+        "version": "2.12.7-r0"
       },
       {
         "architecture": "x86_64",
@@ -527,22 +527,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ZvgMPq5RCd5lQ3v2qeBBOLotsXM=",
+        "checksum": "Q1dLQQZAfXkamLwZ7kLZb2atjfZZQ=",
         "control": {
-          "checksum": "sha1-ZvgMPq5RCd5lQ3v2qeBBOLotsXM=",
-          "range": "bytes=698-1093"
+          "checksum": "sha1-dLQQZAfXkamLwZ7kLZb2atjfZZQ=",
+          "range": "bytes=701-1095"
         },
         "data": {
-          "checksum": "sha256-mQrZT/j9v5ff50OwlphGA2m2AApMWZfnnPaoEBil57Q=",
-          "range": "bytes=1094-233900"
+          "checksum": "sha256-9c2Qzrfedb7BJdu6THUm5TLxb0dvov8v4tvfqBWlUuw=",
+          "range": "bytes=1096-233941"
         },
         "name": "libxcrypt",
         "signature": {
-          "checksum": "sha1-THgEEMvz4LUMjzDPVU7db5XBJ+E=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-DFbDoKQ6O4YqS6aru0hhYo/8TUk=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxcrypt-4.4.36-r5.apk",
-        "version": "4.4.36-r5"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxcrypt-4.4.36-r6.apk",
+        "version": "4.4.36-r6"
       },
       {
         "architecture": "x86_64",
@@ -755,22 +755,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1m7SsrH+XnrPIapzhnK0vkoxMen4=",
+        "checksum": "Q1ZrMuP718My90TnZrml7ylUmXGlo=",
         "control": {
-          "checksum": "sha1-m7SsrH+XnrPIapzhnK0vkoxMen4=",
-          "range": "bytes=698-1077"
+          "checksum": "sha1-ZrMuP718My90TnZrml7ylUmXGlo=",
+          "range": "bytes=702-1093"
         },
         "data": {
-          "checksum": "sha256-0WaULqZyE0zNNC6D7YeaXVN4shAVEouyqAEiRlB09C0=",
-          "range": "bytes=1078-54479"
+          "checksum": "sha256-+ZTF5s9bHKtoArLvOvIL/2seV4pE0ElEj9MlAscAdso=",
+          "range": "bytes=1094-53513"
         },
         "name": "tini",
         "signature": {
-          "checksum": "sha1-eomfhWCyCB1OA/2DHboLUzXunvA=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-OK9J/Z8qnRssJzNCu9hER8FuzSk=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/tini-0.19.0-r3.apk",
-        "version": "0.19.0-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/tini-0.19.0-r4.apk",
+        "version": "0.19.0-r4"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/search-indexer.lock.json
+++ b/wolfi-images/search-indexer.lock.json
@@ -109,25 +109,6 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1mVgCtcYDHEkUa+8x41i7w9cQ4Qg=",
-        "control": {
-          "checksum": "sha1-mVgCtcYDHEkUa+8x41i7w9cQ4Qg=",
-          "range": "bytes=704-1079"
-        },
-        "data": {
-          "checksum": "sha256-xE4spLqr7qIgImPfMC1kMY1a7Xu7xu1/eLkBMgOzSSc=",
-          "range": "bytes=1080-77936"
-        },
-        "name": "protobuf-c",
-        "signature": {
-          "checksum": "sha1-NGL0ELlBK8mhhAzuOkm17d2LbRo=",
-          "range": "bytes=0-703"
-        },
-        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r3.apk",
-        "version": "1.5.0-r3"
-      },
-      {
-        "architecture": "x86_64",
         "checksum": "Q1TAnNLCVTaCylmbN84TlliyM47qM=",
         "control": {
           "checksum": "sha1-TAnNLCVTaCylmbN84TlliyM47qM=",
@@ -258,6 +239,25 @@
         },
         "url": "https://packages.wolfi.dev/os/x86_64/krb5-libs-1.21.2-r1.apk",
         "version": "1.21.2-r1"
+      },
+      {
+        "architecture": "x86_64",
+        "checksum": "Q1Zjfs1uR/mYiortANP+EFcejW+vo=",
+        "control": {
+          "checksum": "sha1-Zjfs1uR/mYiortANP+EFcejW+vo=",
+          "range": "bytes=698-1085"
+        },
+        "data": {
+          "checksum": "sha256-BMd7TzffjbrFwdbopDPVYsX0X9XnusIMNbIf33/8kwc=",
+          "range": "bytes=1086-76881"
+        },
+        "name": "protobuf-c",
+        "signature": {
+          "checksum": "sha1-efGiXyYWsJ5P2uTkB6aXEZ3kl3o=",
+          "range": "bytes=0-697"
+        },
+        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r4.apk",
+        "version": "1.5.0-r4"
       },
       {
         "architecture": "x86_64",
@@ -470,22 +470,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q12eKoxDrTjnN67UapcxL36uSvK6Y=",
+        "checksum": "Q1TS707T+cPGL7TYVHQBCJoWwHZ0E=",
         "control": {
-          "checksum": "sha1-2eKoxDrTjnN67UapcxL36uSvK6Y=",
-          "range": "bytes=694-1086"
+          "checksum": "sha1-TS707T+cPGL7TYVHQBCJoWwHZ0E=",
+          "range": "bytes=706-1098"
         },
         "data": {
-          "checksum": "sha256-xlBSY4KJHzH59eU8L6EFYVJVksfsqUlpE7yt7WtlBos=",
-          "range": "bytes=1087-4546022"
+          "checksum": "sha256-x18L706Vug5qDzq13SXuN/vGdVgzrqB06dW2DdgHGR4=",
+          "range": "bytes=1099-4541967"
         },
         "name": "libxml2",
         "signature": {
-          "checksum": "sha1-sRrMqWd8n9UGVkkp5YwEQ4xr9iY=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-BYhOxDos48sN8df8LMsSpROv2aw=",
+          "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.12.6-r1.apk",
-        "version": "2.12.6-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.12.7-r0.apk",
+        "version": "2.12.7-r0"
       },
       {
         "architecture": "x86_64",
@@ -527,22 +527,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ZvgMPq5RCd5lQ3v2qeBBOLotsXM=",
+        "checksum": "Q1dLQQZAfXkamLwZ7kLZb2atjfZZQ=",
         "control": {
-          "checksum": "sha1-ZvgMPq5RCd5lQ3v2qeBBOLotsXM=",
-          "range": "bytes=698-1093"
+          "checksum": "sha1-dLQQZAfXkamLwZ7kLZb2atjfZZQ=",
+          "range": "bytes=701-1095"
         },
         "data": {
-          "checksum": "sha256-mQrZT/j9v5ff50OwlphGA2m2AApMWZfnnPaoEBil57Q=",
-          "range": "bytes=1094-233900"
+          "checksum": "sha256-9c2Qzrfedb7BJdu6THUm5TLxb0dvov8v4tvfqBWlUuw=",
+          "range": "bytes=1096-233941"
         },
         "name": "libxcrypt",
         "signature": {
-          "checksum": "sha1-THgEEMvz4LUMjzDPVU7db5XBJ+E=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-DFbDoKQ6O4YqS6aru0hhYo/8TUk=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxcrypt-4.4.36-r5.apk",
-        "version": "4.4.36-r5"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxcrypt-4.4.36-r6.apk",
+        "version": "4.4.36-r6"
       },
       {
         "architecture": "x86_64",
@@ -831,22 +831,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1m7SsrH+XnrPIapzhnK0vkoxMen4=",
+        "checksum": "Q1ZrMuP718My90TnZrml7ylUmXGlo=",
         "control": {
-          "checksum": "sha1-m7SsrH+XnrPIapzhnK0vkoxMen4=",
-          "range": "bytes=698-1077"
+          "checksum": "sha1-ZrMuP718My90TnZrml7ylUmXGlo=",
+          "range": "bytes=702-1093"
         },
         "data": {
-          "checksum": "sha256-0WaULqZyE0zNNC6D7YeaXVN4shAVEouyqAEiRlB09C0=",
-          "range": "bytes=1078-54479"
+          "checksum": "sha256-+ZTF5s9bHKtoArLvOvIL/2seV4pE0ElEj9MlAscAdso=",
+          "range": "bytes=1094-53513"
         },
         "name": "tini",
         "signature": {
-          "checksum": "sha1-eomfhWCyCB1OA/2DHboLUzXunvA=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-OK9J/Z8qnRssJzNCu9hER8FuzSk=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/tini-0.19.0-r3.apk",
-        "version": "0.19.0-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/tini-0.19.0-r4.apk",
+        "version": "0.19.0-r4"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/searcher.lock.json
+++ b/wolfi-images/searcher.lock.json
@@ -109,25 +109,6 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1mVgCtcYDHEkUa+8x41i7w9cQ4Qg=",
-        "control": {
-          "checksum": "sha1-mVgCtcYDHEkUa+8x41i7w9cQ4Qg=",
-          "range": "bytes=704-1079"
-        },
-        "data": {
-          "checksum": "sha256-xE4spLqr7qIgImPfMC1kMY1a7Xu7xu1/eLkBMgOzSSc=",
-          "range": "bytes=1080-77936"
-        },
-        "name": "protobuf-c",
-        "signature": {
-          "checksum": "sha1-NGL0ELlBK8mhhAzuOkm17d2LbRo=",
-          "range": "bytes=0-703"
-        },
-        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r3.apk",
-        "version": "1.5.0-r3"
-      },
-      {
-        "architecture": "x86_64",
         "checksum": "Q1TAnNLCVTaCylmbN84TlliyM47qM=",
         "control": {
           "checksum": "sha1-TAnNLCVTaCylmbN84TlliyM47qM=",
@@ -258,6 +239,25 @@
         },
         "url": "https://packages.wolfi.dev/os/x86_64/krb5-libs-1.21.2-r1.apk",
         "version": "1.21.2-r1"
+      },
+      {
+        "architecture": "x86_64",
+        "checksum": "Q1Zjfs1uR/mYiortANP+EFcejW+vo=",
+        "control": {
+          "checksum": "sha1-Zjfs1uR/mYiortANP+EFcejW+vo=",
+          "range": "bytes=698-1085"
+        },
+        "data": {
+          "checksum": "sha256-BMd7TzffjbrFwdbopDPVYsX0X9XnusIMNbIf33/8kwc=",
+          "range": "bytes=1086-76881"
+        },
+        "name": "protobuf-c",
+        "signature": {
+          "checksum": "sha1-efGiXyYWsJ5P2uTkB6aXEZ3kl3o=",
+          "range": "bytes=0-697"
+        },
+        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r4.apk",
+        "version": "1.5.0-r4"
       },
       {
         "architecture": "x86_64",
@@ -470,22 +470,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q12eKoxDrTjnN67UapcxL36uSvK6Y=",
+        "checksum": "Q1TS707T+cPGL7TYVHQBCJoWwHZ0E=",
         "control": {
-          "checksum": "sha1-2eKoxDrTjnN67UapcxL36uSvK6Y=",
-          "range": "bytes=694-1086"
+          "checksum": "sha1-TS707T+cPGL7TYVHQBCJoWwHZ0E=",
+          "range": "bytes=706-1098"
         },
         "data": {
-          "checksum": "sha256-xlBSY4KJHzH59eU8L6EFYVJVksfsqUlpE7yt7WtlBos=",
-          "range": "bytes=1087-4546022"
+          "checksum": "sha256-x18L706Vug5qDzq13SXuN/vGdVgzrqB06dW2DdgHGR4=",
+          "range": "bytes=1099-4541967"
         },
         "name": "libxml2",
         "signature": {
-          "checksum": "sha1-sRrMqWd8n9UGVkkp5YwEQ4xr9iY=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-BYhOxDos48sN8df8LMsSpROv2aw=",
+          "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.12.6-r1.apk",
-        "version": "2.12.6-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.12.7-r0.apk",
+        "version": "2.12.7-r0"
       },
       {
         "architecture": "x86_64",
@@ -527,22 +527,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ZvgMPq5RCd5lQ3v2qeBBOLotsXM=",
+        "checksum": "Q1dLQQZAfXkamLwZ7kLZb2atjfZZQ=",
         "control": {
-          "checksum": "sha1-ZvgMPq5RCd5lQ3v2qeBBOLotsXM=",
-          "range": "bytes=698-1093"
+          "checksum": "sha1-dLQQZAfXkamLwZ7kLZb2atjfZZQ=",
+          "range": "bytes=701-1095"
         },
         "data": {
-          "checksum": "sha256-mQrZT/j9v5ff50OwlphGA2m2AApMWZfnnPaoEBil57Q=",
-          "range": "bytes=1094-233900"
+          "checksum": "sha256-9c2Qzrfedb7BJdu6THUm5TLxb0dvov8v4tvfqBWlUuw=",
+          "range": "bytes=1096-233941"
         },
         "name": "libxcrypt",
         "signature": {
-          "checksum": "sha1-THgEEMvz4LUMjzDPVU7db5XBJ+E=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-DFbDoKQ6O4YqS6aru0hhYo/8TUk=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxcrypt-4.4.36-r5.apk",
-        "version": "4.4.36-r5"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxcrypt-4.4.36-r6.apk",
+        "version": "4.4.36-r6"
       },
       {
         "architecture": "x86_64",
@@ -793,22 +793,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1m7SsrH+XnrPIapzhnK0vkoxMen4=",
+        "checksum": "Q1ZrMuP718My90TnZrml7ylUmXGlo=",
         "control": {
-          "checksum": "sha1-m7SsrH+XnrPIapzhnK0vkoxMen4=",
-          "range": "bytes=698-1077"
+          "checksum": "sha1-ZrMuP718My90TnZrml7ylUmXGlo=",
+          "range": "bytes=702-1093"
         },
         "data": {
-          "checksum": "sha256-0WaULqZyE0zNNC6D7YeaXVN4shAVEouyqAEiRlB09C0=",
-          "range": "bytes=1078-54479"
+          "checksum": "sha256-+ZTF5s9bHKtoArLvOvIL/2seV4pE0ElEj9MlAscAdso=",
+          "range": "bytes=1094-53513"
         },
         "name": "tini",
         "signature": {
-          "checksum": "sha1-eomfhWCyCB1OA/2DHboLUzXunvA=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-OK9J/Z8qnRssJzNCu9hER8FuzSk=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/tini-0.19.0-r3.apk",
-        "version": "0.19.0-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/tini-0.19.0-r4.apk",
+        "version": "0.19.0-r4"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/server.lock.json
+++ b/wolfi-images/server.lock.json
@@ -170,25 +170,6 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1mVgCtcYDHEkUa+8x41i7w9cQ4Qg=",
-        "control": {
-          "checksum": "sha1-mVgCtcYDHEkUa+8x41i7w9cQ4Qg=",
-          "range": "bytes=704-1079"
-        },
-        "data": {
-          "checksum": "sha256-xE4spLqr7qIgImPfMC1kMY1a7Xu7xu1/eLkBMgOzSSc=",
-          "range": "bytes=1080-77936"
-        },
-        "name": "protobuf-c",
-        "signature": {
-          "checksum": "sha1-NGL0ELlBK8mhhAzuOkm17d2LbRo=",
-          "range": "bytes=0-703"
-        },
-        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r3.apk",
-        "version": "1.5.0-r3"
-      },
-      {
-        "architecture": "x86_64",
         "checksum": "Q1TAnNLCVTaCylmbN84TlliyM47qM=",
         "control": {
           "checksum": "sha1-TAnNLCVTaCylmbN84TlliyM47qM=",
@@ -319,6 +300,25 @@
         },
         "url": "https://packages.wolfi.dev/os/x86_64/krb5-libs-1.21.2-r1.apk",
         "version": "1.21.2-r1"
+      },
+      {
+        "architecture": "x86_64",
+        "checksum": "Q1Zjfs1uR/mYiortANP+EFcejW+vo=",
+        "control": {
+          "checksum": "sha1-Zjfs1uR/mYiortANP+EFcejW+vo=",
+          "range": "bytes=698-1085"
+        },
+        "data": {
+          "checksum": "sha256-BMd7TzffjbrFwdbopDPVYsX0X9XnusIMNbIf33/8kwc=",
+          "range": "bytes=1086-76881"
+        },
+        "name": "protobuf-c",
+        "signature": {
+          "checksum": "sha1-efGiXyYWsJ5P2uTkB6aXEZ3kl3o=",
+          "range": "bytes=0-697"
+        },
+        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r4.apk",
+        "version": "1.5.0-r4"
       },
       {
         "architecture": "x86_64",
@@ -531,22 +531,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q12eKoxDrTjnN67UapcxL36uSvK6Y=",
+        "checksum": "Q1TS707T+cPGL7TYVHQBCJoWwHZ0E=",
         "control": {
-          "checksum": "sha1-2eKoxDrTjnN67UapcxL36uSvK6Y=",
-          "range": "bytes=694-1086"
+          "checksum": "sha1-TS707T+cPGL7TYVHQBCJoWwHZ0E=",
+          "range": "bytes=706-1098"
         },
         "data": {
-          "checksum": "sha256-xlBSY4KJHzH59eU8L6EFYVJVksfsqUlpE7yt7WtlBos=",
-          "range": "bytes=1087-4546022"
+          "checksum": "sha256-x18L706Vug5qDzq13SXuN/vGdVgzrqB06dW2DdgHGR4=",
+          "range": "bytes=1099-4541967"
         },
         "name": "libxml2",
         "signature": {
-          "checksum": "sha1-sRrMqWd8n9UGVkkp5YwEQ4xr9iY=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-BYhOxDos48sN8df8LMsSpROv2aw=",
+          "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.12.6-r1.apk",
-        "version": "2.12.6-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.12.7-r0.apk",
+        "version": "2.12.7-r0"
       },
       {
         "architecture": "x86_64",
@@ -588,22 +588,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ZvgMPq5RCd5lQ3v2qeBBOLotsXM=",
+        "checksum": "Q1dLQQZAfXkamLwZ7kLZb2atjfZZQ=",
         "control": {
-          "checksum": "sha1-ZvgMPq5RCd5lQ3v2qeBBOLotsXM=",
-          "range": "bytes=698-1093"
+          "checksum": "sha1-dLQQZAfXkamLwZ7kLZb2atjfZZQ=",
+          "range": "bytes=701-1095"
         },
         "data": {
-          "checksum": "sha256-mQrZT/j9v5ff50OwlphGA2m2AApMWZfnnPaoEBil57Q=",
-          "range": "bytes=1094-233900"
+          "checksum": "sha256-9c2Qzrfedb7BJdu6THUm5TLxb0dvov8v4tvfqBWlUuw=",
+          "range": "bytes=1096-233941"
         },
         "name": "libxcrypt",
         "signature": {
-          "checksum": "sha1-THgEEMvz4LUMjzDPVU7db5XBJ+E=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-DFbDoKQ6O4YqS6aru0hhYo/8TUk=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxcrypt-4.4.36-r5.apk",
-        "version": "4.4.36-r5"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxcrypt-4.4.36-r6.apk",
+        "version": "4.4.36-r6"
       },
       {
         "architecture": "x86_64",
@@ -968,22 +968,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1bbptB7BK9TV8fkNhbjMAfmXgO0I=",
+        "checksum": "Q116m2Q5Ln3gJz05D1gRD/3AQz9+4=",
         "control": {
-          "checksum": "sha1-bbptB7BK9TV8fkNhbjMAfmXgO0I=",
-          "range": "bytes=700-1099"
+          "checksum": "sha1-16m2Q5Ln3gJz05D1gRD/3AQz9+4=",
+          "range": "bytes=703-1102"
         },
         "data": {
-          "checksum": "sha256-5liLI8rRhqcWirGFTO1Q7XAsW4C+n5LoB3Pfh7f3+CI=",
-          "range": "bytes=1100-11855689"
+          "checksum": "sha256-nU1+NEgt7CR9vsxeCs5Hr9tHiSAw69pxvz+m0W+N+PI=",
+          "range": "bytes=1103-11855891"
         },
         "name": "git-lfs",
         "signature": {
-          "checksum": "sha1-hMg5onqpgDcOXI8dZSloNlcpK+8=",
-          "range": "bytes=0-699"
+          "checksum": "sha1-z3BWu5hxd1KVtIrVNwIYsNsgYpc=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/git-lfs-3.5.1-r3.apk",
-        "version": "3.5.1-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/git-lfs-3.5.1-r4.apk",
+        "version": "3.5.1-r4"
       },
       {
         "architecture": "x86_64",
@@ -1063,41 +1063,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ukMqddgvXG5vPZQ+o9hPo0qI0HI=",
+        "checksum": "Q191zIDDWGGmlnPpIVN5G3rE+byGo=",
         "control": {
-          "checksum": "sha1-ukMqddgvXG5vPZQ+o9hPo0qI0HI=",
-          "range": "bytes=706-1159"
+          "checksum": "sha1-91zIDDWGGmlnPpIVN5G3rE+byGo=",
+          "range": "bytes=702-1158"
         },
         "data": {
-          "checksum": "sha256-5ISUayueoXpX10jAF8IDuB1GZv/YfBUl7ly3SZjl5ns=",
-          "range": "bytes=1160-1349538"
+          "checksum": "sha256-W6OeWteP3G5aA4Ko3o/D17L/8HTM93vIw0SvQPbReso=",
+          "range": "bytes=1159-1349570"
         },
-        "name": "nginx-mainline",
+        "name": "nginx-stable",
         "signature": {
-          "checksum": "sha1-C8qJPHzPU7x/yr4Xzk1Fld5oFfY=",
-          "range": "bytes=0-705"
+          "checksum": "sha1-fR0bq7hY8qNjhML4kkjR0NEffMs=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nginx-mainline-1.25.5-r1.apk",
-        "version": "1.25.5-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/nginx-stable-1.26.0-r0.apk",
+        "version": "1.26.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1V0xcmHRZihdDKrpJePraDtjegxI=",
+        "checksum": "Q172cAKkkDUKFCNimN+lEf7gxZcO8=",
         "control": {
-          "checksum": "sha1-V0xcmHRZihdDKrpJePraDtjegxI=",
-          "range": "bytes=703-1104"
+          "checksum": "sha1-72cAKkkDUKFCNimN+lEf7gxZcO8=",
+          "range": "bytes=698-1094"
         },
         "data": {
-          "checksum": "sha256-WFiHmplTs8PZzJw6Pf8WKFQmWLs6hKNCCxbQZmp4ca0=",
-          "range": "bytes=1105-61281"
+          "checksum": "sha256-LGjTn0CCGKvgW1cBIrzzQAaWYNfdRXiRKBa6mBLnddU=",
+          "range": "bytes=1095-61313"
         },
-        "name": "nginx-mainline-config",
+        "name": "nginx-stable-config",
         "signature": {
-          "checksum": "sha1-4t8CekD802ieBIJaL6AZkarTBoM=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-PcxbsesHLvLbanvDf0hRZQEeO9c=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nginx-mainline-config-1.25.5-r1.apk",
-        "version": "1.25.5-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/nginx-stable-config-1.26.0-r0.apk",
+        "version": "1.26.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -1120,22 +1120,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q18KuP+fKLMlrBEUlslVwi71FQprk=",
+        "checksum": "Q1EeC4oJcNGILol2exjVmAmCeKe3Y=",
         "control": {
-          "checksum": "sha1-8KuP+fKLMlrBEUlslVwi71FQprk=",
-          "range": "bytes=699-1064"
+          "checksum": "sha1-EeC4oJcNGILol2exjVmAmCeKe3Y=",
+          "range": "bytes=698-1076"
         },
         "data": {
-          "checksum": "sha256-RipTzGOvB+9Og8PqmR9ZHnurS16yjGKnvKN4YbR2qK8=",
-          "range": "bytes=1065-110068"
+          "checksum": "sha256-jG5+Qk19KNjypflTSwO2gF+f/zqWbtjjhuzSO3maxf8=",
+          "range": "bytes=1077-109053"
         },
         "name": "libbz2-1",
         "signature": {
-          "checksum": "sha1-OeXOVUkPHaLBXEUp9euaffLe47Q=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-800rFtecn2FKQ9uM95GkfwOMvnQ=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libbz2-1-1.0.8-r6.apk",
-        "version": "1.0.8-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/libbz2-1-1.0.8-r7.apk",
+        "version": "1.0.8-r7"
       },
       {
         "architecture": "x86_64",
@@ -1310,79 +1310,79 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1EMrt5zY7UKhtQjR5dP83jt2/okQ=",
+        "checksum": "Q1raWuu6KGfRrKeRl5uFEr9cjJWKo=",
         "control": {
-          "checksum": "sha1-EMrt5zY7UKhtQjR5dP83jt2/okQ=",
-          "range": "bytes=699-1136"
+          "checksum": "sha1-raWuu6KGfRrKeRl5uFEr9cjJWKo=",
+          "range": "bytes=706-1138"
         },
         "data": {
-          "checksum": "sha256-HJfJstMHWUKZ1vIBltQt+jWbepJ9s9fOfDokQfpnBGI=",
-          "range": "bytes=1137-170633686"
+          "checksum": "sha256-+jvnuhSfFV6OMOU85A0d3TL70EU3d9Ih9qFVFBhbKoM=",
+          "range": "bytes=1139-170871296"
         },
         "name": "openjdk-11-jre-base",
         "signature": {
-          "checksum": "sha1-lfioXoCBnapGcLzOcRLKtxpocRA=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-Ndhcwm0bNhKzWlK/0yDLCxF/PyQ=",
+          "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/openjdk-11-jre-base-11.0.23-r1.apk",
-        "version": "11.0.23-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/openjdk-11-jre-base-11.0.23-r2.apk",
+        "version": "11.0.23-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q151W3i3zG+HU4zbt7bSM0VAvhIqw=",
+        "checksum": "Q10FAMpP3Ge3ZAIj7OiagSPVTgBEM=",
         "control": {
-          "checksum": "sha1-51W3i3zG+HU4zbt7bSM0VAvhIqw=",
-          "range": "bytes=707-1104"
+          "checksum": "sha1-0FAMpP3Ge3ZAIj7OiagSPVTgBEM=",
+          "range": "bytes=698-1096"
         },
         "data": {
-          "checksum": "sha256-yExfnYw9DV2WsdXGZPn2eybTv5ssuo7gbJwo2BJVzRc=",
-          "range": "bytes=1105-2949223"
+          "checksum": "sha256-TS14snUwG/K6ETpa3DbKn6vBCV5wo8m8kUiomgRlJsU=",
+          "range": "bytes=1097-2936817"
         },
         "name": "openjdk-11-jre",
         "signature": {
-          "checksum": "sha1-cdTUU2TrXYTeq2PwvWSP3UnlOeg=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-3U3HZ/qDq7BOBiCf8eLprpizKcY=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/openjdk-11-jre-11.0.23-r1.apk",
-        "version": "11.0.23-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/openjdk-11-jre-11.0.23-r2.apk",
+        "version": "11.0.23-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q13v9nj3eH194SrUAGxfg7XLDNZCE=",
+        "checksum": "Q1uV85Wia6ar1va+8ctNo9OCi2Mvw=",
         "control": {
-          "checksum": "sha1-3v9nj3eH194SrUAGxfg7XLDNZCE=",
-          "range": "bytes=694-1065"
+          "checksum": "sha1-uV85Wia6ar1va+8ctNo9OCi2Mvw=",
+          "range": "bytes=702-1070"
         },
         "data": {
-          "checksum": "sha256-YvTs+QAQ7zOgmjqgcnscbxRCP82KyA3pMGBC8aHsW/A=",
-          "range": "bytes=1066-589393"
+          "checksum": "sha256-hPFP0eqRxyx12XIHiYliaXKUTt7siMH9lIKbc+IC+g4=",
+          "range": "bytes=1071-589435"
         },
         "name": "openjdk-11",
         "signature": {
-          "checksum": "sha1-KmpmvWAUM4pyI4Gh9w9aOkNNYyQ=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-8ZSyp7kZfhA5CsMh8+BlJEAYd8M=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/openjdk-11-11.0.23-r1.apk",
-        "version": "11.0.23-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/openjdk-11-11.0.23-r2.apk",
+        "version": "11.0.23-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q122/exGCfuYChY+BTo43sN6sLLkk=",
+        "checksum": "Q1ynkAy7XK5aCOCYqW5WpadOWi2vw=",
         "control": {
-          "checksum": "sha1-22/exGCfuYChY+BTo43sN6sLLkk=",
-          "range": "bytes=701-1093"
+          "checksum": "sha1-ynkAy7XK5aCOCYqW5WpadOWi2vw=",
+          "range": "bytes=699-1096"
         },
         "data": {
-          "checksum": "sha256-tV/7GQnI5UE21CsXZPEohjq3kjElWYhRgu4xYMjraeo=",
-          "range": "bytes=1094-33982"
+          "checksum": "sha256-czYtvoMQAmsMJ/5W291ZJ44ALP83WOapmac2aLTW4cw=",
+          "range": "bytes=1097-34024"
         },
         "name": "openjdk-11-default-jvm",
         "signature": {
-          "checksum": "sha1-TWHvNUuHm0ZParPcehm/qLmLF+c=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-d04S5/oCx9/VY0auDTaGs0IO3kY=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/openjdk-11-default-jvm-11.0.23-r1.apk",
-        "version": "11.0.23-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/openjdk-11-default-jvm-11.0.23-r2.apk",
+        "version": "11.0.23-r2"
       },
       {
         "architecture": "x86_64",
@@ -1576,60 +1576,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1UmcDqeuODUV8+OpvLzUyx0yI8xc=",
+        "checksum": "Q1/xH9NXh2XAN7AiXLSyfKBjj+41g=",
         "control": {
-          "checksum": "sha1-UmcDqeuODUV8+OpvLzUyx0yI8xc=",
-          "range": "bytes=698-1144"
+          "checksum": "sha1-/xH9NXh2XAN7AiXLSyfKBjj+41g=",
+          "range": "bytes=694-1135"
         },
         "data": {
-          "checksum": "sha256-b4esuCNDnZjnPFuKsFFEVf4YtzS4090D1TxWga/nvWs=",
-          "range": "bytes=1145-186251251"
+          "checksum": "sha256-qg8zb40a6hpJUCmj2xctm8npy+TSpC9kumdnnSNRkQE=",
+          "range": "bytes=1136-192879162"
         },
-        "name": "prometheus-2.51",
+        "name": "prometheus-2.52",
         "signature": {
-          "checksum": "sha1-Dd6iX7TS/jcSD3fMqnagSEvize0=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-As1h2B3XeSrL7tXFOnrKY2uEY0U=",
+          "range": "bytes=0-693"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/prometheus-2.51-2.51.2-r1.apk",
-        "version": "2.51.2-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/prometheus-2.52-2.52.0-r1.apk",
+        "version": "2.52.0-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1d50lhC89U1NMDfOR59tXcSxwhoI=",
+        "checksum": "Q1EFV1Q0eivNbJaIY0PhIkKyi/YpM=",
         "control": {
-          "checksum": "sha1-d50lhC89U1NMDfOR59tXcSxwhoI=",
-          "range": "bytes=703-1074"
+          "checksum": "sha1-EFV1Q0eivNbJaIY0PhIkKyi/YpM=",
+          "range": "bytes=692-1063"
         },
         "data": {
-          "checksum": "sha256-1hO2vJ48CDakvu2qdsvRm+VFmtEaxx7ECLIhmzn1U+A=",
-          "range": "bytes=1075-57320339"
+          "checksum": "sha256-8+FNf75bgQE5erENZXCFxI50AnaHUvWSpI08emdqXvM=",
+          "range": "bytes=1064-57320379"
         },
         "name": "prometheus-alertmanager",
         "signature": {
-          "checksum": "sha1-cSE9DHjKcHhrVZ202d3cVA6lnnA=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-YMhX/dlqWFP0BQzWZPUviDQs/Yw=",
+          "range": "bytes=0-691"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/prometheus-alertmanager-0.27.0-r4.apk",
-        "version": "0.27.0-r4"
+        "url": "https://packages.wolfi.dev/os/x86_64/prometheus-alertmanager-0.27.0-r5.apk",
+        "version": "0.27.0-r5"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1v9j36aKj/QDucW2TWthgb0lFN5c=",
+        "checksum": "Q1XIbmz6FFXwWTUG8HhvQerKRe/jw=",
         "control": {
-          "checksum": "sha1-v9j36aKj/QDucW2TWthgb0lFN5c=",
-          "range": "bytes=703-1088"
+          "checksum": "sha1-XIbmz6FFXwWTUG8HhvQerKRe/jw=",
+          "range": "bytes=696-1083"
         },
         "data": {
-          "checksum": "sha256-x/hkY8PBEFsAYRDrU7hhTRaL1lVe5dlPK5I7y8ayw7w=",
-          "range": "bytes=1089-13096952"
+          "checksum": "sha256-UKgbUouSkIdCQsg8PmQTkCgdqcyvoLQgXBBnqCxbIro=",
+          "range": "bytes=1084-13096991"
         },
         "name": "prometheus-postgres-exporter",
         "signature": {
-          "checksum": "sha1-nMuUyXCQD2YI4Wm6TeBRrsiT7ds=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-KOTdEh5gZtZxWaonriTl0RKGtz0=",
+          "range": "bytes=0-695"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/prometheus-postgres-exporter-0.15.0-r7.apk",
-        "version": "0.15.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/prometheus-postgres-exporter-0.15.0-r9.apk",
+        "version": "0.15.0-r9"
       },
       {
         "architecture": "x86_64",
@@ -1671,22 +1671,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1EiStgEoALlFPLvk5XIcnXFJNB+I=",
+        "checksum": "Q1Xou3FauSnsDlv/GSiADD5//sbLU=",
         "control": {
-          "checksum": "sha1-EiStgEoALlFPLvk5XIcnXFJNB+I=",
+          "checksum": "sha1-Xou3FauSnsDlv/GSiADD5//sbLU=",
           "range": "bytes=701-1087"
         },
         "data": {
-          "checksum": "sha256-wvlVA16s/y60xxwJagjDDRHHIj+AEyjsTZSL0+CEH8Y=",
-          "range": "bytes=1088-1072931"
+          "checksum": "sha256-pb3t+dcRqtb+NKcRaX+WpCmgwmCys/1yj9ZEv00dz6o=",
+          "range": "bytes=1088-1101261"
         },
         "name": "readline",
         "signature": {
-          "checksum": "sha1-MKok4iQKXLbNr5+K1A6X/ARjcmk=",
+          "checksum": "sha1-UM8oioixvqY+MAGWmuqxp169zNk=",
           "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/readline-8.2-r4.apk",
-        "version": "8.2-r4"
+        "url": "https://packages.wolfi.dev/os/x86_64/readline-8.2-r6.apk",
+        "version": "8.2-r6"
       },
       {
         "architecture": "x86_64",
@@ -1823,22 +1823,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1m7SsrH+XnrPIapzhnK0vkoxMen4=",
+        "checksum": "Q1ZrMuP718My90TnZrml7ylUmXGlo=",
         "control": {
-          "checksum": "sha1-m7SsrH+XnrPIapzhnK0vkoxMen4=",
-          "range": "bytes=698-1077"
+          "checksum": "sha1-ZrMuP718My90TnZrml7ylUmXGlo=",
+          "range": "bytes=702-1093"
         },
         "data": {
-          "checksum": "sha256-0WaULqZyE0zNNC6D7YeaXVN4shAVEouyqAEiRlB09C0=",
-          "range": "bytes=1078-54479"
+          "checksum": "sha256-+ZTF5s9bHKtoArLvOvIL/2seV4pE0ElEj9MlAscAdso=",
+          "range": "bytes=1094-53513"
         },
         "name": "tini",
         "signature": {
-          "checksum": "sha1-eomfhWCyCB1OA/2DHboLUzXunvA=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-OK9J/Z8qnRssJzNCu9hER8FuzSk=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/tini-0.19.0-r3.apk",
-        "version": "0.19.0-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/tini-0.19.0-r4.apk",
+        "version": "0.19.0-r4"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/sourcegraph-base.lock.json
+++ b/wolfi-images/sourcegraph-base.lock.json
@@ -109,25 +109,6 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1mVgCtcYDHEkUa+8x41i7w9cQ4Qg=",
-        "control": {
-          "checksum": "sha1-mVgCtcYDHEkUa+8x41i7w9cQ4Qg=",
-          "range": "bytes=704-1079"
-        },
-        "data": {
-          "checksum": "sha256-xE4spLqr7qIgImPfMC1kMY1a7Xu7xu1/eLkBMgOzSSc=",
-          "range": "bytes=1080-77936"
-        },
-        "name": "protobuf-c",
-        "signature": {
-          "checksum": "sha1-NGL0ELlBK8mhhAzuOkm17d2LbRo=",
-          "range": "bytes=0-703"
-        },
-        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r3.apk",
-        "version": "1.5.0-r3"
-      },
-      {
-        "architecture": "x86_64",
         "checksum": "Q1TAnNLCVTaCylmbN84TlliyM47qM=",
         "control": {
           "checksum": "sha1-TAnNLCVTaCylmbN84TlliyM47qM=",
@@ -258,6 +239,25 @@
         },
         "url": "https://packages.wolfi.dev/os/x86_64/krb5-libs-1.21.2-r1.apk",
         "version": "1.21.2-r1"
+      },
+      {
+        "architecture": "x86_64",
+        "checksum": "Q1Zjfs1uR/mYiortANP+EFcejW+vo=",
+        "control": {
+          "checksum": "sha1-Zjfs1uR/mYiortANP+EFcejW+vo=",
+          "range": "bytes=698-1085"
+        },
+        "data": {
+          "checksum": "sha256-BMd7TzffjbrFwdbopDPVYsX0X9XnusIMNbIf33/8kwc=",
+          "range": "bytes=1086-76881"
+        },
+        "name": "protobuf-c",
+        "signature": {
+          "checksum": "sha1-efGiXyYWsJ5P2uTkB6aXEZ3kl3o=",
+          "range": "bytes=0-697"
+        },
+        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r4.apk",
+        "version": "1.5.0-r4"
       },
       {
         "architecture": "x86_64",
@@ -470,22 +470,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q12eKoxDrTjnN67UapcxL36uSvK6Y=",
+        "checksum": "Q1TS707T+cPGL7TYVHQBCJoWwHZ0E=",
         "control": {
-          "checksum": "sha1-2eKoxDrTjnN67UapcxL36uSvK6Y=",
-          "range": "bytes=694-1086"
+          "checksum": "sha1-TS707T+cPGL7TYVHQBCJoWwHZ0E=",
+          "range": "bytes=706-1098"
         },
         "data": {
-          "checksum": "sha256-xlBSY4KJHzH59eU8L6EFYVJVksfsqUlpE7yt7WtlBos=",
-          "range": "bytes=1087-4546022"
+          "checksum": "sha256-x18L706Vug5qDzq13SXuN/vGdVgzrqB06dW2DdgHGR4=",
+          "range": "bytes=1099-4541967"
         },
         "name": "libxml2",
         "signature": {
-          "checksum": "sha1-sRrMqWd8n9UGVkkp5YwEQ4xr9iY=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-BYhOxDos48sN8df8LMsSpROv2aw=",
+          "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.12.6-r1.apk",
-        "version": "2.12.6-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.12.7-r0.apk",
+        "version": "2.12.7-r0"
       },
       {
         "architecture": "x86_64",
@@ -527,22 +527,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ZvgMPq5RCd5lQ3v2qeBBOLotsXM=",
+        "checksum": "Q1dLQQZAfXkamLwZ7kLZb2atjfZZQ=",
         "control": {
-          "checksum": "sha1-ZvgMPq5RCd5lQ3v2qeBBOLotsXM=",
-          "range": "bytes=698-1093"
+          "checksum": "sha1-dLQQZAfXkamLwZ7kLZb2atjfZZQ=",
+          "range": "bytes=701-1095"
         },
         "data": {
-          "checksum": "sha256-mQrZT/j9v5ff50OwlphGA2m2AApMWZfnnPaoEBil57Q=",
-          "range": "bytes=1094-233900"
+          "checksum": "sha256-9c2Qzrfedb7BJdu6THUm5TLxb0dvov8v4tvfqBWlUuw=",
+          "range": "bytes=1096-233941"
         },
         "name": "libxcrypt",
         "signature": {
-          "checksum": "sha1-THgEEMvz4LUMjzDPVU7db5XBJ+E=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-DFbDoKQ6O4YqS6aru0hhYo/8TUk=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxcrypt-4.4.36-r5.apk",
-        "version": "4.4.36-r5"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxcrypt-4.4.36-r6.apk",
+        "version": "4.4.36-r6"
       },
       {
         "architecture": "x86_64",
@@ -736,22 +736,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1m7SsrH+XnrPIapzhnK0vkoxMen4=",
+        "checksum": "Q1ZrMuP718My90TnZrml7ylUmXGlo=",
         "control": {
-          "checksum": "sha1-m7SsrH+XnrPIapzhnK0vkoxMen4=",
-          "range": "bytes=698-1077"
+          "checksum": "sha1-ZrMuP718My90TnZrml7ylUmXGlo=",
+          "range": "bytes=702-1093"
         },
         "data": {
-          "checksum": "sha256-0WaULqZyE0zNNC6D7YeaXVN4shAVEouyqAEiRlB09C0=",
-          "range": "bytes=1078-54479"
+          "checksum": "sha256-+ZTF5s9bHKtoArLvOvIL/2seV4pE0ElEj9MlAscAdso=",
+          "range": "bytes=1094-53513"
         },
         "name": "tini",
         "signature": {
-          "checksum": "sha1-eomfhWCyCB1OA/2DHboLUzXunvA=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-OK9J/Z8qnRssJzNCu9hER8FuzSk=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/tini-0.19.0-r3.apk",
-        "version": "0.19.0-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/tini-0.19.0-r4.apk",
+        "version": "0.19.0-r4"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/sourcegraph-dev.lock.json
+++ b/wolfi-images/sourcegraph-dev.lock.json
@@ -185,25 +185,6 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1mVgCtcYDHEkUa+8x41i7w9cQ4Qg=",
-        "control": {
-          "checksum": "sha1-mVgCtcYDHEkUa+8x41i7w9cQ4Qg=",
-          "range": "bytes=704-1079"
-        },
-        "data": {
-          "checksum": "sha256-xE4spLqr7qIgImPfMC1kMY1a7Xu7xu1/eLkBMgOzSSc=",
-          "range": "bytes=1080-77936"
-        },
-        "name": "protobuf-c",
-        "signature": {
-          "checksum": "sha1-NGL0ELlBK8mhhAzuOkm17d2LbRo=",
-          "range": "bytes=0-703"
-        },
-        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r3.apk",
-        "version": "1.5.0-r3"
-      },
-      {
-        "architecture": "x86_64",
         "checksum": "Q1TAnNLCVTaCylmbN84TlliyM47qM=",
         "control": {
           "checksum": "sha1-TAnNLCVTaCylmbN84TlliyM47qM=",
@@ -296,6 +277,25 @@
         },
         "url": "https://packages.wolfi.dev/os/x86_64/krb5-libs-1.21.2-r1.apk",
         "version": "1.21.2-r1"
+      },
+      {
+        "architecture": "x86_64",
+        "checksum": "Q1Zjfs1uR/mYiortANP+EFcejW+vo=",
+        "control": {
+          "checksum": "sha1-Zjfs1uR/mYiortANP+EFcejW+vo=",
+          "range": "bytes=698-1085"
+        },
+        "data": {
+          "checksum": "sha256-BMd7TzffjbrFwdbopDPVYsX0X9XnusIMNbIf33/8kwc=",
+          "range": "bytes=1086-76881"
+        },
+        "name": "protobuf-c",
+        "signature": {
+          "checksum": "sha1-efGiXyYWsJ5P2uTkB6aXEZ3kl3o=",
+          "range": "bytes=0-697"
+        },
+        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r4.apk",
+        "version": "1.5.0-r4"
       },
       {
         "architecture": "x86_64",
@@ -489,22 +489,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q12eKoxDrTjnN67UapcxL36uSvK6Y=",
+        "checksum": "Q1TS707T+cPGL7TYVHQBCJoWwHZ0E=",
         "control": {
-          "checksum": "sha1-2eKoxDrTjnN67UapcxL36uSvK6Y=",
-          "range": "bytes=694-1086"
+          "checksum": "sha1-TS707T+cPGL7TYVHQBCJoWwHZ0E=",
+          "range": "bytes=706-1098"
         },
         "data": {
-          "checksum": "sha256-xlBSY4KJHzH59eU8L6EFYVJVksfsqUlpE7yt7WtlBos=",
-          "range": "bytes=1087-4546022"
+          "checksum": "sha256-x18L706Vug5qDzq13SXuN/vGdVgzrqB06dW2DdgHGR4=",
+          "range": "bytes=1099-4541967"
         },
         "name": "libxml2",
         "signature": {
-          "checksum": "sha1-sRrMqWd8n9UGVkkp5YwEQ4xr9iY=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-BYhOxDos48sN8df8LMsSpROv2aw=",
+          "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.12.6-r1.apk",
-        "version": "2.12.6-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.12.7-r0.apk",
+        "version": "2.12.7-r0"
       },
       {
         "architecture": "x86_64",
@@ -546,22 +546,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ZvgMPq5RCd5lQ3v2qeBBOLotsXM=",
+        "checksum": "Q1dLQQZAfXkamLwZ7kLZb2atjfZZQ=",
         "control": {
-          "checksum": "sha1-ZvgMPq5RCd5lQ3v2qeBBOLotsXM=",
-          "range": "bytes=698-1093"
+          "checksum": "sha1-dLQQZAfXkamLwZ7kLZb2atjfZZQ=",
+          "range": "bytes=701-1095"
         },
         "data": {
-          "checksum": "sha256-mQrZT/j9v5ff50OwlphGA2m2AApMWZfnnPaoEBil57Q=",
-          "range": "bytes=1094-233900"
+          "checksum": "sha256-9c2Qzrfedb7BJdu6THUm5TLxb0dvov8v4tvfqBWlUuw=",
+          "range": "bytes=1096-233941"
         },
         "name": "libxcrypt",
         "signature": {
-          "checksum": "sha1-THgEEMvz4LUMjzDPVU7db5XBJ+E=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-DFbDoKQ6O4YqS6aru0hhYo/8TUk=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxcrypt-4.4.36-r5.apk",
-        "version": "4.4.36-r5"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxcrypt-4.4.36-r6.apk",
+        "version": "4.4.36-r6"
       },
       {
         "architecture": "x86_64",
@@ -755,22 +755,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1m7SsrH+XnrPIapzhnK0vkoxMen4=",
+        "checksum": "Q1ZrMuP718My90TnZrml7ylUmXGlo=",
         "control": {
-          "checksum": "sha1-m7SsrH+XnrPIapzhnK0vkoxMen4=",
-          "range": "bytes=698-1077"
+          "checksum": "sha1-ZrMuP718My90TnZrml7ylUmXGlo=",
+          "range": "bytes=702-1093"
         },
         "data": {
-          "checksum": "sha256-0WaULqZyE0zNNC6D7YeaXVN4shAVEouyqAEiRlB09C0=",
-          "range": "bytes=1078-54479"
+          "checksum": "sha256-+ZTF5s9bHKtoArLvOvIL/2seV4pE0ElEj9MlAscAdso=",
+          "range": "bytes=1094-53513"
         },
         "name": "tini",
         "signature": {
-          "checksum": "sha1-eomfhWCyCB1OA/2DHboLUzXunvA=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-OK9J/Z8qnRssJzNCu9hER8FuzSk=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/tini-0.19.0-r3.apk",
-        "version": "0.19.0-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/tini-0.19.0-r4.apk",
+        "version": "0.19.0-r4"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/sourcegraph-template.lock.json
+++ b/wolfi-images/sourcegraph-template.lock.json
@@ -109,25 +109,6 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1mVgCtcYDHEkUa+8x41i7w9cQ4Qg=",
-        "control": {
-          "checksum": "sha1-mVgCtcYDHEkUa+8x41i7w9cQ4Qg=",
-          "range": "bytes=704-1079"
-        },
-        "data": {
-          "checksum": "sha256-xE4spLqr7qIgImPfMC1kMY1a7Xu7xu1/eLkBMgOzSSc=",
-          "range": "bytes=1080-77936"
-        },
-        "name": "protobuf-c",
-        "signature": {
-          "checksum": "sha1-NGL0ELlBK8mhhAzuOkm17d2LbRo=",
-          "range": "bytes=0-703"
-        },
-        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r3.apk",
-        "version": "1.5.0-r3"
-      },
-      {
-        "architecture": "x86_64",
         "checksum": "Q1TAnNLCVTaCylmbN84TlliyM47qM=",
         "control": {
           "checksum": "sha1-TAnNLCVTaCylmbN84TlliyM47qM=",
@@ -258,6 +239,25 @@
         },
         "url": "https://packages.wolfi.dev/os/x86_64/krb5-libs-1.21.2-r1.apk",
         "version": "1.21.2-r1"
+      },
+      {
+        "architecture": "x86_64",
+        "checksum": "Q1Zjfs1uR/mYiortANP+EFcejW+vo=",
+        "control": {
+          "checksum": "sha1-Zjfs1uR/mYiortANP+EFcejW+vo=",
+          "range": "bytes=698-1085"
+        },
+        "data": {
+          "checksum": "sha256-BMd7TzffjbrFwdbopDPVYsX0X9XnusIMNbIf33/8kwc=",
+          "range": "bytes=1086-76881"
+        },
+        "name": "protobuf-c",
+        "signature": {
+          "checksum": "sha1-efGiXyYWsJ5P2uTkB6aXEZ3kl3o=",
+          "range": "bytes=0-697"
+        },
+        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r4.apk",
+        "version": "1.5.0-r4"
       },
       {
         "architecture": "x86_64",
@@ -470,22 +470,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q12eKoxDrTjnN67UapcxL36uSvK6Y=",
+        "checksum": "Q1TS707T+cPGL7TYVHQBCJoWwHZ0E=",
         "control": {
-          "checksum": "sha1-2eKoxDrTjnN67UapcxL36uSvK6Y=",
-          "range": "bytes=694-1086"
+          "checksum": "sha1-TS707T+cPGL7TYVHQBCJoWwHZ0E=",
+          "range": "bytes=706-1098"
         },
         "data": {
-          "checksum": "sha256-xlBSY4KJHzH59eU8L6EFYVJVksfsqUlpE7yt7WtlBos=",
-          "range": "bytes=1087-4546022"
+          "checksum": "sha256-x18L706Vug5qDzq13SXuN/vGdVgzrqB06dW2DdgHGR4=",
+          "range": "bytes=1099-4541967"
         },
         "name": "libxml2",
         "signature": {
-          "checksum": "sha1-sRrMqWd8n9UGVkkp5YwEQ4xr9iY=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-BYhOxDos48sN8df8LMsSpROv2aw=",
+          "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.12.6-r1.apk",
-        "version": "2.12.6-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.12.7-r0.apk",
+        "version": "2.12.7-r0"
       },
       {
         "architecture": "x86_64",
@@ -527,22 +527,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ZvgMPq5RCd5lQ3v2qeBBOLotsXM=",
+        "checksum": "Q1dLQQZAfXkamLwZ7kLZb2atjfZZQ=",
         "control": {
-          "checksum": "sha1-ZvgMPq5RCd5lQ3v2qeBBOLotsXM=",
-          "range": "bytes=698-1093"
+          "checksum": "sha1-dLQQZAfXkamLwZ7kLZb2atjfZZQ=",
+          "range": "bytes=701-1095"
         },
         "data": {
-          "checksum": "sha256-mQrZT/j9v5ff50OwlphGA2m2AApMWZfnnPaoEBil57Q=",
-          "range": "bytes=1094-233900"
+          "checksum": "sha256-9c2Qzrfedb7BJdu6THUm5TLxb0dvov8v4tvfqBWlUuw=",
+          "range": "bytes=1096-233941"
         },
         "name": "libxcrypt",
         "signature": {
-          "checksum": "sha1-THgEEMvz4LUMjzDPVU7db5XBJ+E=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-DFbDoKQ6O4YqS6aru0hhYo/8TUk=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxcrypt-4.4.36-r5.apk",
-        "version": "4.4.36-r5"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxcrypt-4.4.36-r6.apk",
+        "version": "4.4.36-r6"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/symbols.lock.json
+++ b/wolfi-images/symbols.lock.json
@@ -109,25 +109,6 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1mVgCtcYDHEkUa+8x41i7w9cQ4Qg=",
-        "control": {
-          "checksum": "sha1-mVgCtcYDHEkUa+8x41i7w9cQ4Qg=",
-          "range": "bytes=704-1079"
-        },
-        "data": {
-          "checksum": "sha256-xE4spLqr7qIgImPfMC1kMY1a7Xu7xu1/eLkBMgOzSSc=",
-          "range": "bytes=1080-77936"
-        },
-        "name": "protobuf-c",
-        "signature": {
-          "checksum": "sha1-NGL0ELlBK8mhhAzuOkm17d2LbRo=",
-          "range": "bytes=0-703"
-        },
-        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r3.apk",
-        "version": "1.5.0-r3"
-      },
-      {
-        "architecture": "x86_64",
         "checksum": "Q1TAnNLCVTaCylmbN84TlliyM47qM=",
         "control": {
           "checksum": "sha1-TAnNLCVTaCylmbN84TlliyM47qM=",
@@ -258,6 +239,25 @@
         },
         "url": "https://packages.wolfi.dev/os/x86_64/krb5-libs-1.21.2-r1.apk",
         "version": "1.21.2-r1"
+      },
+      {
+        "architecture": "x86_64",
+        "checksum": "Q1Zjfs1uR/mYiortANP+EFcejW+vo=",
+        "control": {
+          "checksum": "sha1-Zjfs1uR/mYiortANP+EFcejW+vo=",
+          "range": "bytes=698-1085"
+        },
+        "data": {
+          "checksum": "sha256-BMd7TzffjbrFwdbopDPVYsX0X9XnusIMNbIf33/8kwc=",
+          "range": "bytes=1086-76881"
+        },
+        "name": "protobuf-c",
+        "signature": {
+          "checksum": "sha1-efGiXyYWsJ5P2uTkB6aXEZ3kl3o=",
+          "range": "bytes=0-697"
+        },
+        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r4.apk",
+        "version": "1.5.0-r4"
       },
       {
         "architecture": "x86_64",
@@ -470,22 +470,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q12eKoxDrTjnN67UapcxL36uSvK6Y=",
+        "checksum": "Q1TS707T+cPGL7TYVHQBCJoWwHZ0E=",
         "control": {
-          "checksum": "sha1-2eKoxDrTjnN67UapcxL36uSvK6Y=",
-          "range": "bytes=694-1086"
+          "checksum": "sha1-TS707T+cPGL7TYVHQBCJoWwHZ0E=",
+          "range": "bytes=706-1098"
         },
         "data": {
-          "checksum": "sha256-xlBSY4KJHzH59eU8L6EFYVJVksfsqUlpE7yt7WtlBos=",
-          "range": "bytes=1087-4546022"
+          "checksum": "sha256-x18L706Vug5qDzq13SXuN/vGdVgzrqB06dW2DdgHGR4=",
+          "range": "bytes=1099-4541967"
         },
         "name": "libxml2",
         "signature": {
-          "checksum": "sha1-sRrMqWd8n9UGVkkp5YwEQ4xr9iY=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-BYhOxDos48sN8df8LMsSpROv2aw=",
+          "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.12.6-r1.apk",
-        "version": "2.12.6-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.12.7-r0.apk",
+        "version": "2.12.7-r0"
       },
       {
         "architecture": "x86_64",
@@ -527,22 +527,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ZvgMPq5RCd5lQ3v2qeBBOLotsXM=",
+        "checksum": "Q1dLQQZAfXkamLwZ7kLZb2atjfZZQ=",
         "control": {
-          "checksum": "sha1-ZvgMPq5RCd5lQ3v2qeBBOLotsXM=",
-          "range": "bytes=698-1093"
+          "checksum": "sha1-dLQQZAfXkamLwZ7kLZb2atjfZZQ=",
+          "range": "bytes=701-1095"
         },
         "data": {
-          "checksum": "sha256-mQrZT/j9v5ff50OwlphGA2m2AApMWZfnnPaoEBil57Q=",
-          "range": "bytes=1094-233900"
+          "checksum": "sha256-9c2Qzrfedb7BJdu6THUm5TLxb0dvov8v4tvfqBWlUuw=",
+          "range": "bytes=1096-233941"
         },
         "name": "libxcrypt",
         "signature": {
-          "checksum": "sha1-THgEEMvz4LUMjzDPVU7db5XBJ+E=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-DFbDoKQ6O4YqS6aru0hhYo/8TUk=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxcrypt-4.4.36-r5.apk",
-        "version": "4.4.36-r5"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxcrypt-4.4.36-r6.apk",
+        "version": "4.4.36-r6"
       },
       {
         "architecture": "x86_64",
@@ -793,22 +793,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1m7SsrH+XnrPIapzhnK0vkoxMen4=",
+        "checksum": "Q1ZrMuP718My90TnZrml7ylUmXGlo=",
         "control": {
-          "checksum": "sha1-m7SsrH+XnrPIapzhnK0vkoxMen4=",
-          "range": "bytes=698-1077"
+          "checksum": "sha1-ZrMuP718My90TnZrml7ylUmXGlo=",
+          "range": "bytes=702-1093"
         },
         "data": {
-          "checksum": "sha256-0WaULqZyE0zNNC6D7YeaXVN4shAVEouyqAEiRlB09C0=",
-          "range": "bytes=1078-54479"
+          "checksum": "sha256-+ZTF5s9bHKtoArLvOvIL/2seV4pE0ElEj9MlAscAdso=",
+          "range": "bytes=1094-53513"
         },
         "name": "tini",
         "signature": {
-          "checksum": "sha1-eomfhWCyCB1OA/2DHboLUzXunvA=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-OK9J/Z8qnRssJzNCu9hER8FuzSk=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/tini-0.19.0-r3.apk",
-        "version": "0.19.0-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/tini-0.19.0-r4.apk",
+        "version": "0.19.0-r4"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/syntax-highlighter.lock.json
+++ b/wolfi-images/syntax-highlighter.lock.json
@@ -109,25 +109,6 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1mVgCtcYDHEkUa+8x41i7w9cQ4Qg=",
-        "control": {
-          "checksum": "sha1-mVgCtcYDHEkUa+8x41i7w9cQ4Qg=",
-          "range": "bytes=704-1079"
-        },
-        "data": {
-          "checksum": "sha256-xE4spLqr7qIgImPfMC1kMY1a7Xu7xu1/eLkBMgOzSSc=",
-          "range": "bytes=1080-77936"
-        },
-        "name": "protobuf-c",
-        "signature": {
-          "checksum": "sha1-NGL0ELlBK8mhhAzuOkm17d2LbRo=",
-          "range": "bytes=0-703"
-        },
-        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r3.apk",
-        "version": "1.5.0-r3"
-      },
-      {
-        "architecture": "x86_64",
         "checksum": "Q1TAnNLCVTaCylmbN84TlliyM47qM=",
         "control": {
           "checksum": "sha1-TAnNLCVTaCylmbN84TlliyM47qM=",
@@ -258,6 +239,25 @@
         },
         "url": "https://packages.wolfi.dev/os/x86_64/krb5-libs-1.21.2-r1.apk",
         "version": "1.21.2-r1"
+      },
+      {
+        "architecture": "x86_64",
+        "checksum": "Q1Zjfs1uR/mYiortANP+EFcejW+vo=",
+        "control": {
+          "checksum": "sha1-Zjfs1uR/mYiortANP+EFcejW+vo=",
+          "range": "bytes=698-1085"
+        },
+        "data": {
+          "checksum": "sha256-BMd7TzffjbrFwdbopDPVYsX0X9XnusIMNbIf33/8kwc=",
+          "range": "bytes=1086-76881"
+        },
+        "name": "protobuf-c",
+        "signature": {
+          "checksum": "sha1-efGiXyYWsJ5P2uTkB6aXEZ3kl3o=",
+          "range": "bytes=0-697"
+        },
+        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r4.apk",
+        "version": "1.5.0-r4"
       },
       {
         "architecture": "x86_64",
@@ -470,22 +470,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q12eKoxDrTjnN67UapcxL36uSvK6Y=",
+        "checksum": "Q1TS707T+cPGL7TYVHQBCJoWwHZ0E=",
         "control": {
-          "checksum": "sha1-2eKoxDrTjnN67UapcxL36uSvK6Y=",
-          "range": "bytes=694-1086"
+          "checksum": "sha1-TS707T+cPGL7TYVHQBCJoWwHZ0E=",
+          "range": "bytes=706-1098"
         },
         "data": {
-          "checksum": "sha256-xlBSY4KJHzH59eU8L6EFYVJVksfsqUlpE7yt7WtlBos=",
-          "range": "bytes=1087-4546022"
+          "checksum": "sha256-x18L706Vug5qDzq13SXuN/vGdVgzrqB06dW2DdgHGR4=",
+          "range": "bytes=1099-4541967"
         },
         "name": "libxml2",
         "signature": {
-          "checksum": "sha1-sRrMqWd8n9UGVkkp5YwEQ4xr9iY=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-BYhOxDos48sN8df8LMsSpROv2aw=",
+          "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.12.6-r1.apk",
-        "version": "2.12.6-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.12.7-r0.apk",
+        "version": "2.12.7-r0"
       },
       {
         "architecture": "x86_64",
@@ -527,22 +527,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ZvgMPq5RCd5lQ3v2qeBBOLotsXM=",
+        "checksum": "Q1dLQQZAfXkamLwZ7kLZb2atjfZZQ=",
         "control": {
-          "checksum": "sha1-ZvgMPq5RCd5lQ3v2qeBBOLotsXM=",
-          "range": "bytes=698-1093"
+          "checksum": "sha1-dLQQZAfXkamLwZ7kLZb2atjfZZQ=",
+          "range": "bytes=701-1095"
         },
         "data": {
-          "checksum": "sha256-mQrZT/j9v5ff50OwlphGA2m2AApMWZfnnPaoEBil57Q=",
-          "range": "bytes=1094-233900"
+          "checksum": "sha256-9c2Qzrfedb7BJdu6THUm5TLxb0dvov8v4tvfqBWlUuw=",
+          "range": "bytes=1096-233941"
         },
         "name": "libxcrypt",
         "signature": {
-          "checksum": "sha1-THgEEMvz4LUMjzDPVU7db5XBJ+E=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-DFbDoKQ6O4YqS6aru0hhYo/8TUk=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxcrypt-4.4.36-r5.apk",
-        "version": "4.4.36-r5"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxcrypt-4.4.36-r6.apk",
+        "version": "4.4.36-r6"
       },
       {
         "architecture": "x86_64",
@@ -755,22 +755,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1m7SsrH+XnrPIapzhnK0vkoxMen4=",
+        "checksum": "Q1ZrMuP718My90TnZrml7ylUmXGlo=",
         "control": {
-          "checksum": "sha1-m7SsrH+XnrPIapzhnK0vkoxMen4=",
-          "range": "bytes=698-1077"
+          "checksum": "sha1-ZrMuP718My90TnZrml7ylUmXGlo=",
+          "range": "bytes=702-1093"
         },
         "data": {
-          "checksum": "sha256-0WaULqZyE0zNNC6D7YeaXVN4shAVEouyqAEiRlB09C0=",
-          "range": "bytes=1078-54479"
+          "checksum": "sha256-+ZTF5s9bHKtoArLvOvIL/2seV4pE0ElEj9MlAscAdso=",
+          "range": "bytes=1094-53513"
         },
         "name": "tini",
         "signature": {
-          "checksum": "sha1-eomfhWCyCB1OA/2DHboLUzXunvA=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-OK9J/Z8qnRssJzNCu9hER8FuzSk=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/tini-0.19.0-r3.apk",
-        "version": "0.19.0-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/tini-0.19.0-r4.apk",
+        "version": "0.19.0-r4"
       },
       {
         "architecture": "x86_64",


### PR DESCRIPTION
Automatically generated PR to update package lockfiles for Sourcegraph base images.

Built from Buildkite run [#274112](https://buildkite.com/sourcegraph/sourcegraph/builds/274112).
## Test Plan
- CI build verifies image functionality