### PR TITLE
WIP: Refine type for ClosestUploads

### DIFF
--- a/internal/codeintel/codenav/iface.go
+++ b/internal/codeintel/codenav/iface.go
@@ -11,5 +11,5 @@ type UploadService interface {
 	GetCompletedUploadsWithDefinitionsForMonikers(ctx context.Context, monikers []precise.QualifiedMonikerData) (_ []shared.CompletedUpload, err error)
 	GetUploadIDsWithReferences(ctx context.Context, orderedMonikers []precise.QualifiedMonikerData, ignoreIDs []int, repositoryID int, commit string, limit int, offset int) (ids []int, recordsScanned int, totalCount int, err error)
 	GetCompletedUploadsByIDs(ctx context.Context, ids []int) (_ []shared.CompletedUpload, err error)
-	InferClosestUploads(ctx context.Context, opts shared.UploadMatchingOptions) (_ []shared.CompletedUpload, err error)
+	InferClosestUploads(ctx context.Context, opts shared.UploadMatchingOptions) (_ shared.ClosestUploads, err error)
 }

--- a/internal/codeintel/codenav/service.go
+++ b/internal/codeintel/codenav/service.go
@@ -672,8 +672,8 @@ func (s *Service) GetClosestCompletedUploadsForBlob(ctx context.Context, opts up
 	}
 
 	trace.AddEvent("InferClosestUploads",
-		attribute.Int("numCandidates", len(candidates)),
-		attribute.String("candidates", uploadIDsToString(candidates)))
+		attribute.Int("numCandidates", candidates.Len()),
+		attribute.String("candidates", uploadIDsToString2(candidates)))
 
 	commitChecker := NewCommitCache(s.repoStore, s.gitserver)
 	commitChecker.SetResolvableCommit(opts.RepositoryID, opts.Commit)
@@ -683,8 +683,8 @@ func (s *Service) GetClosestCompletedUploadsForBlob(ctx context.Context, opts up
 		return nil, err
 	}
 	trace.AddEvent("filterUploadsWithCommits",
-		attribute.Int("numCandidatesWithExistingCommits", len(candidatesWithExistingCommits)),
-		attribute.String("candidatesWithExistingCommits", uploadIDsToString(candidatesWithExistingCommits)))
+		attribute.Int("numCandidatesWithExistingCommits", candidatesWithExistingCommits.Len()),
+		attribute.String("candidatesWithExistingCommits", uploadIDsToString2(candidatesWithExistingCommits)))
 
 	candidatesWithExistingCommitsAndPaths, err := filterUploadsWithPaths(ctx, s.lsifstore, opts, candidatesWithExistingCommits)
 	if err != nil {
@@ -699,7 +699,7 @@ func (s *Service) GetClosestCompletedUploadsForBlob(ctx context.Context, opts up
 
 // filterUploadsWithCommits only keeps the uploads for commits which are known to gitserver.
 // A fresh slice is returned without modifying the original slice.
-func filterUploadsWithCommits(ctx context.Context, commitCache CommitCache, uploads []uploadsshared.CompletedUpload) ([]uploadsshared.CompletedUpload, error) {
+func filterUploadsWithCommits(ctx context.Context, commitCache CommitCache, uploads uploadsshared.ClosestUploads) (uploadsshared.ClosestUploads, error) {
 	rcs := make([]RepositoryCommit, 0, len(uploads))
 	for _, upload := range uploads {
 		rcs = append(rcs, RepositoryCommit{
@@ -726,16 +726,18 @@ func filterUploadsWithPaths(
 	ctx context.Context,
 	lsifstore lsifstore.LsifStore,
 	opts uploadsshared.UploadMatchingOptions,
-	candidates []uploadsshared.CompletedUpload,
-) ([]uploadsshared.CompletedUpload, error) {
-	filtered := make([]uploadsshared.CompletedUpload, 0, len(candidates))
-	for _, candidate := range candidates {
+	candidates uploadsshared.ClosestUploads,
+) (uploadsshared.ClosestUploads, error) {
+	filtered, _ := uploadsshared.NewClosestUploads(nil)
+	//filtered := make([]uploadsshared.CompletedUpload, 0, candidates.Len())
+	for pair := candidates.Oldest(); pair != nil; pair = pair.Next() {
+		candidate := pair.Value
 		switch opts.RootToPathMatching {
 		case uploadsshared.RootMustEnclosePath:
 			// TODO - this breaks if the file was renamed in git diff
 			pathExists, err := lsifstore.GetPathExists(ctx, candidate.ID, strings.TrimPrefix(opts.Path, candidate.Root))
 			if err != nil {
-				return nil, errors.Wrap(err, "lsifStore.Exists")
+				return uploadsshared.ClosestUploads{}, errors.Wrap(err, "lsifStore.Exists")
 			}
 			if !pathExists {
 				continue
@@ -743,7 +745,7 @@ func filterUploadsWithPaths(
 		case uploadsshared.RootEnclosesPathOrPathEnclosesRoot:
 			// TODO(efritz) - ensure there's a valid document path for this condition as well
 		}
-		filtered = append(filtered, candidate)
+		filtered.AddPairs(*pair)
 	}
 	return filtered, nil
 }

--- a/internal/codeintel/codenav/utils.go
+++ b/internal/codeintel/codenav/utils.go
@@ -38,6 +38,15 @@ func uploadIDsToString(vs []uploadsshared.CompletedUpload) string {
 	return strings.Join(ids, ", ")
 }
 
+func uploadIDsToString2(vs uploadsshared.ClosestUploads) string {
+	ids := make([]string, 0, vs.Len())
+	for pair := vs.Oldest(); pair != nil; pair = pair.Next() {
+		ids = append(ids, strconv.Itoa(pair.Value.ID))
+	}
+
+	return strings.Join(ids, ", ")
+}
+
 func sortRanges(ranges []shared.Range) []shared.Range {
 	sort.Slice(ranges, func(i, j int) bool {
 		iStart := ranges[i].Start

--- a/internal/codeintel/uploads/internal/store/store.go
+++ b/internal/codeintel/uploads/internal/store/store.go
@@ -69,8 +69,8 @@ type Store interface {
 	GetDirtyRepositories(ctx context.Context) ([]shared.DirtyRepository, error)
 	UpdateUploadsVisibleToCommits(ctx context.Context, repositoryID int, graph *commitgraph.CommitGraph, refs map[string][]gitdomain.Ref, maxAgeForNonStaleBranches, maxAgeForNonStaleTags time.Duration, dirtyToken int, now time.Time) error
 	GetCommitsVisibleToUpload(ctx context.Context, uploadID, limit int, token *string) ([]string, *string, error)
-	FindClosestCompletedUploads(context.Context, shared.UploadMatchingOptions) ([]shared.CompletedUpload, error)
-	FindClosestCompletedUploadsFromGraphFragment(_ context.Context, _ shared.UploadMatchingOptions, commitGraph *commitgraph.CommitGraph) ([]shared.CompletedUpload, error)
+	FindClosestCompletedUploads(context.Context, shared.UploadMatchingOptions) (shared.ClosestUploads, error)
+	FindClosestCompletedUploadsFromGraphFragment(_ context.Context, _ shared.UploadMatchingOptions, commitGraph *commitgraph.CommitGraph) (shared.ClosestUploads, error)
 	GetRepositoriesMaxStaleAge(ctx context.Context) (time.Duration, error)
 	GetCommitGraphMetadata(ctx context.Context, repositoryID int) (stale bool, updatedAt *time.Time, _ error)
 

--- a/internal/codeintel/uploads/internal/store/util.go
+++ b/internal/codeintel/uploads/internal/store/util.go
@@ -81,6 +81,8 @@ SELECT
 FROM (
 	SELECT
 		t.*,
+		-- NOTE(id: visible-uploads-uniquing): Only pick a single result for each
+		-- (root, indexer) pair (see also: WHERE clause at end of query)
 		row_number() OVER (PARTITION BY root, indexer ORDER BY distance) AS r
 	FROM (
 		-- Select the set of uploads visible from the given commit. This is done by looking


### PR DESCRIPTION
There is an invariant in the implementation for closest uploads which
is not documented in the function signature. This makes it hard to reason
about which uploads can be returned. This attempts to document that
invariant using types rather than just a comment.

Unfortunately, the OrderedMap type here doesn't expose an API
which allows arbitrary indexing, making it hard to use as a drop-in replacement.

We should probably introduce a collections.MonotonicOrderedMap for that.

## Test plan

Existing tests should pass.