### PR TITLE
chore: Rename locals id -> uploadID, dump -> upload

### DIFF
--- a/internal/codeintel/codenav/internal/lsifstore/lsifstore_documents.go
+++ b/internal/codeintel/codenav/internal/lsifstore/lsifstore_documents.go
@@ -15,10 +15,10 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 )
 
-func (s *store) SCIPDocument(ctx context.Context, id int, path string) (_ *scip.Document, err error) {
+func (s *store) SCIPDocument(ctx context.Context, uploadID int, path string) (_ *scip.Document, err error) {
 	ctx, _, endObservation := s.operations.scipDocument.With(ctx, &err, observation.Args{Attrs: []attribute.KeyValue{
 		attribute.String("path", path),
-		attribute.Int("uploadID", id),
+		attribute.Int("uploadID", uploadID),
 	}})
 	defer endObservation(1, observation.Args{})
 
@@ -39,7 +39,7 @@ func (s *store) SCIPDocument(ctx context.Context, id int, path string) (_ *scip.
 		}
 		return &document, nil
 	})
-	doc, _, err := scanner(s.db.Query(ctx, sqlf.Sprintf(fetchSCIPDocumentQuery, id, path)))
+	doc, _, err := scanner(s.db.Query(ctx, sqlf.Sprintf(fetchSCIPDocumentQuery, uploadID, path)))
 	return doc, err
 }
 

--- a/internal/codeintel/codenav/internal/lsifstore/store.go
+++ b/internal/codeintel/codenav/internal/lsifstore/store.go
@@ -33,7 +33,7 @@ type LsifStore interface {
 	// Metadata by position
 	GetHover(ctx context.Context, bundleID int, path string, line, character int) (string, shared.Range, bool, error)
 	GetDiagnostics(ctx context.Context, bundleID int, prefix string, limit, offset int) ([]shared.Diagnostic, int, error)
-	SCIPDocument(ctx context.Context, id int, path string) (_ *scip.Document, err error)
+	SCIPDocument(ctx context.Context, uploadID int, path string) (_ *scip.Document, err error)
 
 	// Extraction methods
 	ExtractDefinitionLocationsFromPosition(ctx context.Context, locationKey LocationKey) ([]shared.Location, []string, error)

--- a/internal/codeintel/codenav/service.go
+++ b/internal/codeintel/codenav/service.go
@@ -810,14 +810,14 @@ func (s *Service) SnapshotForDocument(ctx context.Context, repositoryID int, com
 		return nil, nil
 	}
 
-	dump := uploads[0]
+	upload := uploads[0]
 
-	document, err := s.lsifstore.SCIPDocument(ctx, dump.ID, strings.TrimPrefix(path, dump.Root))
+	document, err := s.lsifstore.SCIPDocument(ctx, upload.ID, strings.TrimPrefix(path, upload.Root))
 	if err != nil || document == nil {
 		return nil, err
 	}
 
-	r, err := s.gitserver.NewFileReader(ctx, api.RepoName(dump.RepositoryName), api.CommitID(dump.Commit), path)
+	r, err := s.gitserver.NewFileReader(ctx, api.RepoName(upload.RepositoryName), api.CommitID(upload.Commit), path)
 	if err != nil {
 		return nil, err
 	}
@@ -830,7 +830,7 @@ func (s *Service) SnapshotForDocument(ctx context.Context, repositoryID int, com
 	// client-side normalizes the file to LF, so normalize CRLF files to that so the offsets are correct
 	file = bytes.ReplaceAll(file, []byte("\r\n"), []byte("\n"))
 
-	repo, err := s.repoStore.Get(ctx, api.RepoID(dump.RepositoryID))
+	repo, err := s.repoStore.Get(ctx, api.RepoID(upload.RepositoryID))
 	if err != nil {
 		return nil, err
 	}
@@ -922,7 +922,7 @@ func (s *Service) SnapshotForDocument(ctx context.Context, repositoryID int, com
 			}
 		}
 
-		_, newRange, ok, err := gittranslator.GetTargetCommitPositionFromSourcePosition(ctx, dump.Commit, shared.Position{
+		_, newRange, ok, err := gittranslator.GetTargetCommitPositionFromSourcePosition(ctx, upload.Commit, shared.Position{
 			Line:      int(originalRange.Start.Line),
 			Character: int(originalRange.Start.Character),
 		}, false)


### PR DESCRIPTION
Looks like I missed removing this usage of 'dump' here.

## Test plan

n/a