### PR TITLE
sg: cloud ephemeral - add build and upgrade commands

### DIFF
--- a/dev/sg/internal/cloud/BUILD.bazel
+++ b/dev/sg/internal/cloud/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     name = "cloud",
     srcs = [
         "artifact_registry.go",
+        "build_command.go",
         "client.go",
         "common.go",
         "delete_command.go",
@@ -15,6 +16,7 @@ go_library(
         "list_versions_command.go",
         "printers.go",
         "status_command.go",
+        "upgrade_command.go",
     ],
     importpath = "github.com/sourcegraph/sourcegraph/dev/sg/internal/cloud",
     visibility = ["//dev/sg:__subpackages__"],

--- a/dev/sg/internal/cloud/build_command.go
+++ b/dev/sg/internal/cloud/build_command.go
@@ -12,7 +12,7 @@ import (
 
 var BuildEphemeralCommand = cli.Command{
 	Name:        "build",
-	Usage:       "sg could build",
+	Usage:       "trigger a cloud ephemeral build",
 	Description: "Triggers a Cloud Ephemeral build of the current branch which will push images to the cloud ephemeral registry",
 	Action:      wipAction(buildCloudEphemeral),
 }

--- a/dev/sg/internal/cloud/build_command.go
+++ b/dev/sg/internal/cloud/build_command.go
@@ -17,6 +17,17 @@ var BuildEphemeralCommand = cli.Command{
 	Action:      wipAction(buildCloudEphemeral),
 }
 
+func writeAdditionalBuildCommandsSuggestion(version string) {
+	versionLine := fmt.Sprintf("The build will push images with the following tag/version: `%s`", version)
+	deployLine := fmt.Sprintf("create a deployment with this build by running `sg cloud deploy --version %s`", version)
+	upgradeLine := fmt.Sprintf("upgrade the existing deployment with this build by running `sg cloud upgrade --version %s`", version)
+	markdown := `%s
+Once this build completes, you can:
+* %s
+* %s`
+	std.Out.WriteMarkdown(fmt.Sprintf(markdown, versionLine, deployLine, upgradeLine))
+}
+
 func buildCloudEphemeral(ctx *cli.Context) error {
 	currentBranch, err := repo.GetCurrentBranch(ctx.Context)
 	if err != nil {
@@ -41,6 +52,6 @@ Please make sure you have either pushed or pulled the latest changes before tryi
 	if err != nil {
 		return err
 	}
-	std.Out.WriteMarkdown(fmt.Sprintf("The build will push images with the following tag/version: `%s`", version))
+	writeAdditionalBuildCommandsSuggestion(version)
 	return nil
 }

--- a/dev/sg/internal/cloud/build_command.go
+++ b/dev/sg/internal/cloud/build_command.go
@@ -1,0 +1,46 @@
+package cloud
+
+import (
+	"fmt"
+
+	"github.com/urfave/cli/v2"
+
+	"github.com/sourcegraph/sourcegraph/dev/sg/internal/repo"
+	"github.com/sourcegraph/sourcegraph/dev/sg/internal/std"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+var BuildEphemeralCommand = cli.Command{
+	Name:        "build",
+	Usage:       "sg could build",
+	Description: "Triggers a Cloud Ephemeral build of the current branch which will push images to the cloud ephemeral registry",
+	Action:      wipAction(buildCloudEphemeral),
+}
+
+func buildCloudEphemeral(ctx *cli.Context) error {
+	currentBranch, err := repo.GetCurrentBranch(ctx.Context)
+	if err != nil {
+		return errors.Wrap(err, "failed to determine current branch")
+	}
+	// We are on the branch we want to deploy, so we use the current commit
+	head, err := repo.GetHeadCommit(ctx.Context)
+	if err != nil {
+		return errors.Wrap(err, "failed to determine current commit")
+	}
+	currRepo := repo.NewGitRepo(currentBranch, head)
+	build, err := triggerEphemeralBuild(ctx.Context, currRepo)
+	if err != nil {
+		if err == ErrBranchOutOfSync {
+			std.Out.WriteWarningf(`Your branch %q is out of sync with the remote branch.
+
+Please make sure you have either pushed or pulled the latest changes before trying again`, currRepo.Branch)
+		}
+		return errors.Wrapf(err, "failed to trigger epehemeral build for branch")
+	}
+	version, err := determineVersion(build, ctx.String("tag"))
+	if err != nil {
+		return err
+	}
+	std.Out.WriteMarkdown(fmt.Sprintf("The build will push images with the following tag/version: `%s`", version))
+	return nil
+}

--- a/dev/sg/internal/cloud/client.go
+++ b/dev/sg/internal/cloud/client.go
@@ -164,6 +164,20 @@ func (c *Client) CreateInstance(ctx context.Context, spec *DeploymentSpec) (*Ins
 	return newInstance(resp.Msg.GetInstance())
 }
 
+func (c *Client) UpgradeInstance(ctx context.Context, spec *DeploymentSpec) (*Instance, error) {
+	req := newRequestWithToken(c.token, &cloudapiv1.UpdateInstanceVersionRequest{
+		Name:        spec.Name,
+		Environment: DevEnvironment,
+		Version:     spec.Version,
+	})
+	resp, err := c.client.UpdateInstanceVersion(ctx, req)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to upgrade instance")
+	}
+
+	return newInstance(resp.Msg.GetInstance())
+}
+
 func (c *Client) DeleteInstance(ctx context.Context, name string) error {
 	return nil
 }

--- a/dev/sg/internal/cloud/deploy_command.go
+++ b/dev/sg/internal/cloud/deploy_command.go
@@ -24,13 +24,13 @@ var ErrDeploymentExists error = errors.New("deployment already exists")
 
 var DeployEphemeralCommand = cli.Command{
 	Name:        "deploy",
-	Usage:       "sg could deploy --branch <branch> --tag <tag>",
+	Usage:       "sg could deploy --name <name> --version <version>",
 	Description: "Deploy the specified branch or tag to an ephemeral Sourcegraph Cloud environment",
 	Action:      wipAction(deployCloudEphemeral),
 	Flags: []cli.Flag{
 		&cli.StringFlag{
 			Name:        "name",
-			DefaultText: "the name of the ephemeral deployment. If not specified, the name will be derived from the branch name",
+			DefaultText: "the name of the ephemeral deployment. If none is specified, the name will be derived from the branch name",
 		},
 		&cli.StringFlag{
 			Name:        "version",

--- a/dev/sg/internal/cloud/deploy_command.go
+++ b/dev/sg/internal/cloud/deploy_command.go
@@ -24,7 +24,7 @@ var ErrDeploymentExists error = errors.New("deployment already exists")
 
 var DeployEphemeralCommand = cli.Command{
 	Name:        "deploy",
-	Usage:       "sg could deploy --name <name> --version <version>",
+	Usage:       "create a cloud ephemeral deployment",
 	Description: "Deploy the specified branch or tag to an ephemeral Sourcegraph Cloud environment",
 	Action:      wipAction(deployCloudEphemeral),
 	Flags: []cli.Flag{

--- a/dev/sg/internal/cloud/deploy_command.go
+++ b/dev/sg/internal/cloud/deploy_command.go
@@ -130,9 +130,9 @@ func createDeploymentForVersion(ctx context.Context, email, name, version string
 }
 
 func triggerEphemeralBuild(ctx context.Context, currRepo *repo.GitRepo) (*buildkite.Build, error) {
-	pending := std.Out.Pending(output.Linef("🔨", output.StylePending, "Checking if branch %q is up to date with remote", currRepo.Branch))
+	pending := std.Out.Pending(output.Linef("🔨", output.StylePending, "Checking if branch %q is up to date with remote branch", currRepo.Branch))
 	if isOutOfSync, err := currRepo.IsOutOfSync(ctx); err != nil {
-		pending.Complete(output.Linef(output.EmojiFailure, output.StyleFailure, "branch is out of date with remote"))
+		pending.Complete(output.Linef(output.EmojiFailure, output.StyleFailure, "failed to check if branch is out of sync with remote branch"))
 		return nil, err
 	} else if isOutOfSync {
 		return nil, ErrBranchOutOfSync

--- a/dev/sg/internal/cloud/lease_command.go
+++ b/dev/sg/internal/cloud/lease_command.go
@@ -55,12 +55,13 @@ func calcLeaseEnd(currentLeaseTime time.Time, extension, reduction time.Duration
 
 	if extension > 0 {
 		leaseEndTime = currentLeaseTime.Add(extension)
-	} else {
+		return leaseEndTime, nil
+	} else if extension < 0 {
 		return leaseEndTime, errors.New("lease extension value should be a positive value")
 	}
 	if reduction > 0 {
 		leaseEndTime = currentLeaseTime.Add(-reduction)
-	} else {
+	} else if reduction < 0 {
 		return leaseEndTime, errors.New("lease reduction value should be a positive value")
 	}
 

--- a/dev/sg/internal/cloud/list_command.go
+++ b/dev/sg/internal/cloud/list_command.go
@@ -13,7 +13,7 @@ import (
 
 var ListEphemeralCommand = cli.Command{
 	Name:        "list",
-	Usage:       "sg could list",
+	Usage:       "list ephemeral cloud instances",
 	Description: "list ephemeral cloud instances attached to your GCP account",
 	Action:      wipAction(listCloudEphemeral),
 	Flags: []cli.Flag{

--- a/dev/sg/internal/cloud/list_versions_command.go
+++ b/dev/sg/internal/cloud/list_versions_command.go
@@ -28,7 +28,7 @@ var ListVersionsEphemeralCommand = cli.Command{
 		},
 		&cli.IntFlag{
 			Name:  "limit",
-			Usage: "limit the number of versions to list - to list everything set limt to a negative value",
+			Usage: "limit the number of versions to list - to list everything set limit to a negative value",
 			Value: 100,
 		},
 		&cli.StringFlag{

--- a/dev/sg/internal/cloud/list_versions_command.go
+++ b/dev/sg/internal/cloud/list_versions_command.go
@@ -14,7 +14,7 @@ import (
 
 var ListVersionsEphemeralCommand = cli.Command{
 	Name:        "list-versions",
-	Usage:       "sg could list-versions",
+	Usage:       "list docker images in the cloud ephemeral registry",
 	Description: "list ephemeral cloud instances attached to your GCP account",
 	Action:      listTagsCloudEphemeral,
 	Flags: []cli.Flag{

--- a/dev/sg/internal/cloud/status_command.go
+++ b/dev/sg/internal/cloud/status_command.go
@@ -14,7 +14,7 @@ import (
 var StatusEphemeralCommand = cli.Command{
 	Name:        "status",
 	Usage:       "sg could status",
-	Description: "get the status of the ephemeral cloud instance for this branch or instance with the provided slug",
+	Description: "get the status of the ephemeral cloud instance for this branch or instance with the provided name",
 	Action:      wipAction(statusCloudEphemeral),
 	Flags: []cli.Flag{
 		&cli.StringFlag{

--- a/dev/sg/internal/cloud/status_command.go
+++ b/dev/sg/internal/cloud/status_command.go
@@ -13,7 +13,7 @@ import (
 
 var StatusEphemeralCommand = cli.Command{
 	Name:        "status",
-	Usage:       "sg could status",
+	Usage:       "get status of ephemeral cloud instance",
 	Description: "get the status of the ephemeral cloud instance for this branch or instance with the provided name",
 	Action:      wipAction(statusCloudEphemeral),
 	Flags: []cli.Flag{

--- a/dev/sg/internal/cloud/upgrade_command.go
+++ b/dev/sg/internal/cloud/upgrade_command.go
@@ -12,7 +12,7 @@ import (
 )
 
 var UpgradeEphemeralCommand = cli.Command{
-	Name:        "deploy",
+	Name:        "upgrade",
 	Usage:       "sg could upgrade --name <name> --version <version>",
 	Description: "Upgrade the given Ephemeral deployment with the specified version",
 	Action:      wipAction(upgradeCloudEphemeral),
@@ -51,7 +51,7 @@ func upgradeDeploymentForVersion(ctx context.Context, email, name, version strin
 			return errors.Wrapf(err, "failed to check if instance %q already exists", spec.Name)
 		}
 	}
-	inst, err := cloudClient.CreateInstance(ctx, spec)
+	inst, err := cloudClient.UpgradeInstance(ctx, spec)
 	if err != nil {
 		pending.Complete(output.Linef(output.EmojiFailure, output.StyleFailure, "Upgrade of %q failed", spec.Name))
 		return errors.Wrapf(err, "failed to issue upgrade of %q to version %s", spec.Name, spec.Version)

--- a/dev/sg/internal/cloud/upgrade_command.go
+++ b/dev/sg/internal/cloud/upgrade_command.go
@@ -1,0 +1,92 @@
+package cloud
+
+import (
+	"context"
+
+	"github.com/urfave/cli/v2"
+
+	"github.com/sourcegraph/sourcegraph/dev/sg/internal/repo"
+	"github.com/sourcegraph/sourcegraph/dev/sg/internal/std"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"github.com/sourcegraph/sourcegraph/lib/output"
+)
+
+var UpgradeEphemeralCommand = cli.Command{
+	Name:        "deploy",
+	Usage:       "sg could upgrade --name <name> --version <version>",
+	Description: "Upgrade the given Ephemeral deployment with the specified version",
+	Action:      wipAction(upgradeCloudEphemeral),
+	Flags: []cli.Flag{
+		&cli.StringFlag{
+			Name:        "name",
+			DefaultText: "the name of the ephemeral deployment. If not specified, the name will be derived from the branch name",
+		},
+		&cli.StringFlag{
+			Name:        "version",
+			DefaultText: "upgrades an ephemeral cloud Sourcegraph environment with the specified version. The version MUST exist and implies that no build will be created",
+			Required:    true,
+		},
+	},
+}
+
+func upgradeDeploymentForVersion(ctx context.Context, email, name, version string) error {
+	cloudClient, err := NewClient(ctx, email, APIEndpoint)
+	if err != nil {
+		return err
+	}
+
+	spec := NewDeploymentSpec(
+		sanitizeInstanceName(name),
+		version,
+	)
+	cloudEmoji := "☁️"
+	pending := std.Out.Pending(output.Linef(cloudEmoji, output.StylePending, "Upgrading deployment %q to version %q", spec.Name, spec.Version))
+
+	// Check if the deployment already exists
+	_, err = cloudClient.GetInstance(ctx, spec.Name)
+	if err != nil {
+		if errors.Is(err, ErrInstanceNotFound) {
+			return ErrInstanceNotFound
+		} else {
+			return errors.Wrapf(err, "failed to check if instance %q already exists", spec.Name)
+		}
+	}
+	inst, err := cloudClient.CreateInstance(ctx, spec)
+	if err != nil {
+		pending.Complete(output.Linef(output.EmojiFailure, output.StyleFailure, "Upgrade of %q failed", spec.Name))
+		return errors.Wrapf(err, "failed to issue upgrade of %q to version %s", spec.Name, spec.Version)
+	}
+
+	pending.Writef("Instance details: \n%s", inst.String())
+	pending.Complete(output.Linef(output.EmojiSuccess, output.StyleSuccess, "Upgrade of %q to version %q has been triggered - access at: %s", spec.Name, spec.Version, inst.URL))
+	return nil
+}
+
+func upgradeCloudEphemeral(ctx *cli.Context) error {
+	version := ctx.String("version")
+	if version == "" {
+		return errors.New("version is required")
+	} else if err := checkVersionExistsInRegistry(ctx.Context, version); err != nil {
+		return err
+	}
+	currentBranch, err := repo.GetCurrentBranch(ctx.Context)
+	if err != nil {
+		return errors.Wrap(err, "failed to determine current branch")
+	}
+	// if a version is specified we do not build anything and just trigger the cloud deployment
+	email, err := GetGCloudAccount(ctx.Context)
+	if err != nil {
+		return err
+	}
+	deploymentName := createDeploymentName(ctx.String("name"), version, email, currentBranch)
+
+	err = upgradeDeploymentForVersion(ctx.Context, email, deploymentName, version)
+	if err != nil {
+		if errors.Is(err, ErrInstanceNotFound) {
+			std.Out.WriteWarningf("Unable to upgrade %q since no deployment like that exists", deploymentName)
+			std.Out.WriteMarkdown("You can check what deployments exist under your GCP account with `sg cloud list`, or you can see all deployments with `sg cloud list --all`")
+		}
+		return err
+	}
+	return nil
+}

--- a/dev/sg/internal/cloud/upgrade_command.go
+++ b/dev/sg/internal/cloud/upgrade_command.go
@@ -38,6 +38,7 @@ func upgradeDeploymentForVersion(ctx context.Context, email, name, version strin
 	spec := NewDeploymentSpec(
 		sanitizeInstanceName(name),
 		version,
+		"", // we don't need a license during upgrade
 	)
 	cloudEmoji := "☁️"
 	pending := std.Out.Pending(output.Linef(cloudEmoji, output.StylePending, "Upgrading deployment %q to version %q", spec.Name, spec.Version))

--- a/dev/sg/internal/cloud/upgrade_command.go
+++ b/dev/sg/internal/cloud/upgrade_command.go
@@ -13,7 +13,7 @@ import (
 
 var UpgradeEphemeralCommand = cli.Command{
 	Name:        "upgrade",
-	Usage:       "sg could upgrade --name <name> --version <version>",
+	Usage:       "upgrade a cloud ephemeral",
 	Description: "Upgrade the given Ephemeral deployment with the specified version",
 	Action:      wipAction(upgradeCloudEphemeral),
 	Flags: []cli.Flag{

--- a/dev/sg/internal/repo/git_repo.go
+++ b/dev/sg/internal/repo/git_repo.go
@@ -63,11 +63,16 @@ func WithPushRefSpec(ref, branch string) pushOpt {
 // * Does the commit exist remotely?
 func (g *GitRepo) IsOutOfSync(ctx context.Context) (bool, error) {
 	if ok, err := g.HasRemoteBranch(ctx); err != nil {
+		println("HAS REMOTE ERR")
+		println("HAS REMOTE ERR")
+		println("HAS REMOTE ERR")
 		return false, err
 	} else if !ok {
-		return false, nil
+		// We don't have a remote branch, so we're definitely out of sync
+		return true, nil
 	}
 
+	// Now lets check if the commit exists in the remote branch
 	return !g.HasRemoteCommit(ctx), nil
 }
 

--- a/dev/sg/sg_cloud.go
+++ b/dev/sg/sg_cloud.go
@@ -45,6 +45,7 @@ var cloudCommand = &cli.Command{
 				return nil
 			},
 		},
+		&cloud.BuildEphemeralCommand,
 		&cloud.DeleteEphemeralCommand,
 		&cloud.DeployEphemeralCommand,
 		&cloud.LeaseEphemeralCommand,

--- a/dev/sg/sg_cloud.go
+++ b/dev/sg/sg_cloud.go
@@ -51,6 +51,7 @@ var cloudCommand = &cli.Command{
 		&cloud.ListEphemeralCommand,
 		&cloud.ListVersionsEphemeralCommand,
 		&cloud.StatusEphemeralCommand,
+		&cloud.UpgradeEphemeralCommand,
 	},
 }
 


### PR DESCRIPTION
There are times when you just want to create a cloud ephemeral deployment. Previously the only way to get a ephemeral build would've been to run `sg cloud deploy` and then get a deployment failure because a deployment already exists.

In this PR we add:
#### `sg cloud build` which triggers a cloud ephemeral deployment
```
go run ./dev/sg cloud build
🧪 EXPERIMENTAL COMMAND - Do you want to continue? (yes/no) y
✅ Build 273307 created. Build progress can be viewed at https://buildkite.com/sourcegraph/sourcegraph/builds/273307

  The build will push images with the following tag/version:  wb-sg-cloud-upgrade_273307_2024-05-08_5.3-6d0d9eac5838
  Once this build completes, you can:

  • create a deployment with this build by running  sg cloud deploy --version wb-sg-cloud-upgrade_273307_2024-05-08_5.3-6d0d9eac5838
  • upgrade the existing deployment with this build by running  sg cloud upgrade --version wb-sg-cloud-upgrade_273307_2024-05-08_5.3-6d0d9eac5838
```

#### `sg cloud upgrade` to upgrade an existing deployment
`sg cloud deploy` only creates instances and will not upgrade existing instances. This was done to make the semantics of the commands easier and not conflate `deploy` with _too much_ housekeeping tasks
```
sourcegraph on  wb/sg/cloud-upgrade [$!] via 🐹 v1.22.1 took 16s
❯ go run ./dev/sg cloud upgrade --name "wb-sg-cloud-eph-delete" --version "wb-sg-cloud-deploy-api_270801_2024-04-25_5.3-0d48809b20fb"
🧪 EXPERIMENTAL COMMAND - Do you want to continue? (yes/no) y
✅ Version "wb-sg-cloud-deploy-api_270801_2024-04-25_5.3-0d48809b20fb" found in Cloud ephemeral registry
Instance details:
ID           : src-8b8f805ddec0406fdb14
Name         : wb-sg-cloud-eph-delete
InstanceType : ephemeral
Environment  :
Version      : wb-sg-cloud-eph-delete_271241_2024-04-29_5.3-76a614889b0a
URL          : https://wb-sg-cloud-eph-delete.sgdev.dev/
AdminEmail   : william.bezuidenhout@sourcegraph.com
CreatedAt    : 1970-01-01T00:00:00Z
DeletetAt    : 1970-01-01T00:00:00Z
ExpiresAt    : 2024-04-29T20:09:17Z
Project      : src-026f9fde9d8fb6c817c5
Region       : us-central1
Status       : in progress
ActionURL    :
Error        :

✅ Upgrade of "wb-sg-cloud-eph-delete" to version "wb-sg-cloud-deploy-api_270801_2024-04-25_5.3-0d48809b20fb" has been triggered - access at: https://wb-sg-cloud-eph-delete.sgdev.dev/
```
## Test plan
Tested locally
