### PR TITLE
Svelte: Visual updates to diff summary

### DIFF
--- a/client/web-sveltekit/src/lib/repo/DiffSquares.svelte
+++ b/client/web-sveltekit/src/lib/repo/DiffSquares.svelte
@@ -45,6 +45,7 @@
     .root {
         display: inline-flex;
         gap: 0.125rem;
+        margin-left: 0.25rem;
     }
 
     .square {

--- a/client/web-sveltekit/src/lib/repo/DiffSquares.svelte
+++ b/client/web-sveltekit/src/lib/repo/DiffSquares.svelte
@@ -51,6 +51,6 @@
         display: inline-block;
         width: 0.5rem;
         height: 0.5rem;
-        background-color: var(--text-muted);
+        background-color: var(--color-bg-3);
     }
 </style>

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/DiffSummaryHeader.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/DiffSummaryHeader.svelte
@@ -64,6 +64,7 @@
         display: inline-flex;
         align-items: center;
         margin-left: 1rem;
+        font-weight: 700;
 
         .added {
             color: var(--success);

--- a/client/web/src/components/diff/DiffStat.module.scss
+++ b/client/web/src/components/diff/DiffStat.module.scss
@@ -4,7 +4,7 @@
 }
 
 .empty {
-    background-color: var(--text-muted);
+    background-color: var(--color-bg-3);
 }
 
 .square {


### PR DESCRIPTION
Minor visual change for diff summary.

## Before
<img width="143" alt="CleanShot 2024-05-08 at 11 00 35@2x" src="https://github.com/sourcegraph/sourcegraph/assets/5337876/c882c53a-f9c7-49e8-b660-702f6e06a541">

<img width="152" alt="CleanShot 2024-05-08 at 11 00 19@2x" src="https://github.com/sourcegraph/sourcegraph/assets/5337876/677db29a-cf4d-4bb2-928d-d02182ea4ef7">

## After
<img width="148" alt="CleanShot 2024-05-08 at 10 59 39@2x" src="https://github.com/sourcegraph/sourcegraph/assets/5337876/61a414f4-ecc4-4026-8684-a99d04c9299f">

<img width="146" alt="CleanShot 2024-05-08 at 10 59 57@2x" src="https://github.com/sourcegraph/sourcegraph/assets/5337876/2b76492d-604f-4948-a0e1-7a1e61d7b57d">

## Test plan
Visual change tested locally.