### PR TITLE
svelte: Fix file tree behavior

### DIFF
--- a/client/web-sveltekit/src/lib/TreeNode.svelte
+++ b/client/web-sveltekit/src/lib/TreeNode.svelte
@@ -13,6 +13,8 @@
     export let entry: T
     export let treeProvider: TreeProvider<T>
 
+    let label: HTMLElement | undefined
+
     $: treeState = getTreeContext()
     $: nodeID = treeProvider.getNodeID(entry)
     $: expandable = treeProvider.isExpandable(entry)
@@ -32,6 +34,21 @@
             )
         }
     }
+
+    $: if (selected && label) {
+        const container = label.closest('[role="tree"]')
+        if (container) {
+            // Only scroll the active tree entry into the 'center' if the selected entry changed
+            // by something other than user interaction. If we always 'center' then the tree
+            // will "jump" as the user selects an entry with the keyboard or mouse, which is
+            // disorienting.
+            // But if we never 'center' then going back and forth might position the selected
+            // entry at the top or bottom of the scroll container, which is not very visible.
+            // So we only 'center' if focus is not on the tree container, which likely means
+            // that the user is not interacting with the tree.
+            label.scrollIntoView({ block: container.contains(document.activeElement) ? 'nearest' : 'center' })
+        }
+    }
 </script>
 
 <li
@@ -42,7 +59,7 @@
     data-treeitem
     data-node-id={nodeID}
 >
-    <span class="label" data-treeitem-label>
+    <span bind:this={label} class="label" data-treeitem-label>
         <!-- hide the open/close button to preserve alignment with expandable entries -->
         <span class:hidden={!expandable}>
             <!-- We have to stop even propagation because the tree root listens for click events for

--- a/client/web-sveltekit/src/lib/repo/api/tree.ts
+++ b/client/web-sveltekit/src/lib/repo/api/tree.ts
@@ -8,6 +8,11 @@ import { type GitCommitFieldsWithTree, type TreeEntriesVariables, TreeEntries } 
 
 const MAX_FILE_TREE_ENTRIES = 1000
 
+/**
+ * Represents the root path of the repository.
+ */
+export const ROOT_PATH = ''
+
 export function isFileEntry(entry: TreeEntry): entry is Extract<TreeEntry, { __typename: 'GitBlob' }> {
     return entry.__typename === 'GitBlob' || !entry.isDirectory
 }

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/+layout.ts
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/+layout.ts
@@ -5,7 +5,7 @@ import { from } from 'rxjs'
 import type { LineOrPositionOrRange } from '$lib/common'
 import { getGraphQLClient, infinityQuery, mapOrThrow } from '$lib/graphql'
 import { GitRefType } from '$lib/graphql-types'
-import { fetchSidebarFileTree } from '$lib/repo/api/tree'
+import { ROOT_PATH, fetchSidebarFileTree } from '$lib/repo/api/tree'
 import { resolveRevision } from '$lib/repo/utils'
 import { parseRepoRevision } from '$lib/shared'
 
@@ -24,7 +24,7 @@ const REFERENCES_PER_PAGE = 20
 export const load: LayoutLoad = async ({ parent, params }) => {
     const client = getGraphQLClient()
     const { repoName, revision = '' } = parseRepoRevision(params.repo)
-    const parentPath = params.path ? dirname(params.path) : ''
+    const parentPath = params.path ? dirname(params.path) : ROOT_PATH
     const resolvedRevision = resolveRevision(parent, revision)
 
     // Prefetch the sidebar file tree for the parent path.

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/FileTree.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/FileTree.svelte
@@ -2,9 +2,8 @@
 
 <script lang="ts">
     import { mdiFolderArrowUpOutline, mdiFolderOpenOutline, mdiFolderOutline } from '@mdi/js'
-    import { onMount } from 'svelte'
 
-    import { afterNavigate, goto } from '$app/navigation'
+    import { goto } from '$app/navigation'
     import Icon from '$lib/Icon.svelte'
     import { type FileTreeProvider, NODE_LIMIT, type FileTreeNodeValue, type TreeEntry } from '$lib/repo/api/tree'
     import FileIcon from '$lib/repo/FileIcon.svelte'
@@ -78,22 +77,7 @@
         $treeState = { focused: path, selected: path, expandedNodes: nodesCopy }
     }
 
-    function scrollSelectedItemIntoView() {
-        treeView.scrollSelectedItemIntoView(
-            // Only scroll the active tree entry into the 'center' if the selected entry changed
-            // by something other than user interaction. If we always 'center' then the sidebar
-            // will "jump" as the user selects an entry with the keyboard or mouse, which is
-            // disorienting.
-            // But if we never 'center' then going back and forth might position the selected
-            // entry at the top or bottom of the sidebar, which is not very visible.
-            // So we only 'center' if focus is not on the tree container, which likely means
-            // that the user is not interacting with the tree.
-            container?.contains(document.activeElement) ? 'nearest' : 'center'
-        )
-    }
-
     let container: HTMLElement | undefined
-    let treeView: TreeView<FileTreeNodeValue>
     // Since context is only set once when the component is created
     // we need to dynamically sync any changes to the corresponding
     // file tree state store
@@ -106,18 +90,10 @@
     $: treeState.updateStore(getSidebarFileTreeStateForRepo(repoName))
     // Update open and selected nodes when the path changes.
     $: markSelected(selectedPath)
-
-    // Always scroll the selected item into view when we navigate to a different one.
-    // NOTE: At the moment this won't always work because the file tree might not be
-    // fully loaded after navigation.
-    afterNavigate(scrollSelectedItemIntoView)
-    // The documentation says afterNavigate will also run on mount but
-    // that doesn't seem to be the case
-    onMount(scrollSelectedItemIntoView)
 </script>
 
 <div tabindex="-1" bind:this={container}>
-    <TreeView bind:this={treeView} {treeProvider} on:select={event => handleSelect(event.detail)}>
+    <TreeView {treeProvider} on:select={event => handleSelect(event.detail)}>
         <svelte:fragment let:entry let:expanded>
             {@const isRoot = entry === treeRoot}
             {#if entry === NODE_LIMIT}

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/FileTree.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/FileTree.svelte
@@ -5,7 +5,7 @@
 
     import { goto } from '$app/navigation'
     import Icon from '$lib/Icon.svelte'
-    import { type FileTreeProvider, NODE_LIMIT, type FileTreeNodeValue, type TreeEntry } from '$lib/repo/api/tree'
+    import { type FileTreeProvider, NODE_LIMIT, type TreeEntry } from '$lib/repo/api/tree'
     import FileIcon from '$lib/repo/FileIcon.svelte'
     import { getSidebarFileTreeStateForRepo } from '$lib/repo/stores'
     import { replaceRevisionInURL } from '$lib/shared'
@@ -77,7 +77,6 @@
         $treeState = { focused: path, selected: path, expandedNodes: nodesCopy }
     }
 
-    let container: HTMLElement | undefined
     // Since context is only set once when the component is created
     // we need to dynamically sync any changes to the corresponding
     // file tree state store
@@ -92,7 +91,7 @@
     $: markSelected(selectedPath)
 </script>
 
-<div tabindex="-1" bind:this={container}>
+<div tabindex="-1">
     <TreeView {treeProvider} on:select={event => handleSelect(event.detail)}>
         <svelte:fragment let:entry let:expanded>
             {@const isRoot = entry === treeRoot}

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/fileTreeStore.ts
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/fileTreeStore.ts
@@ -3,7 +3,7 @@ import { catchError, distinctUntilChanged, map, switchMap } from 'rxjs/operators
 import { readable, type Readable } from 'svelte/store'
 
 import { browser } from '$app/environment'
-import { FileTreeProvider, type FileTreeData, type FileTreeLoader } from '$lib/repo/api/tree'
+import { FileTreeProvider, ROOT_PATH, type FileTreeData, type FileTreeLoader } from '$lib/repo/api/tree'
 
 /**
  * Keeps track of the top-level directory that has been visited for each repository and revision.
@@ -56,7 +56,7 @@ export function createFileTreeStore(options: FileTreeStoreOptions): FileTreeStor
                     ({ repoName, revision }, { repoName: nextRepoName, revision: nextRevision, path: nextPath }) => {
                         if (browser && repoName === nextRepoName && revision === nextRevision) {
                             const topPath = topTreePathByRepoAndRevision.get(repoName)?.get(revision)
-                            return topPath ? topPath === '.' || nextPath.startsWith(topPath) : false
+                            return topPath !== undefined ? topPath === ROOT_PATH || nextPath.startsWith(topPath) : false
                         }
                         return false
                     }
@@ -65,7 +65,7 @@ export function createFileTreeStore(options: FileTreeStoreOptions): FileTreeStor
                 map(({ repoName, revision, path }) => {
                     if (browser) {
                         const topPath = topTreePathByRepoAndRevision.get(repoName)?.get(revision)
-                        if (topPath && (topPath === '.' || path.startsWith(topPath))) {
+                        if (topPath !== undefined && (topPath === ROOT_PATH || path.startsWith(topPath))) {
                             return { repoName, revision, path: topPath }
                         } else {
                             // new path is new top path


### PR DESCRIPTION
While working on #62494 I noticed that the file tree didn't work as expected.
In particular, when being at the repo root and navigating to a file via the fuzzy finder the file tree would  switch to the parent directory, just like as if the file was directly navigated to.

However, what should happen is that the tree expands all directories to reveal the file, because the repo root is the top level directory and we should always be showing the most top level directory that was visited.

The issue is that we are not properly detecting the repo root level (I think we switched from using `'.'` to `''` at some point). To avoid this problem I'm now using a constant instead.

I also changed how the tree entries are scrolled into view. The current solution doesn't work for deeply nested entries because at the time the scroll logic is invoked the entry hasn't been loaded yet. By moving the logic to the node it can scroll itself into view when it's available.

The waterfall loading nature of the file tree also became much more apparent. We can avoid this by using making use of the `ancestors` field but that needs to be done in a separate PR because that entails larger changes.



## Test plan

Manual testing.
