### PR TITLE
release: return an error when promoting a dev release

### DIFF
--- a/dev/sg/internal/release/config.go
+++ b/dev/sg/internal/release/config.go
@@ -356,8 +356,7 @@ func (r *releaseRunner) Test(ctx context.Context) error {
 
 func (r *releaseRunner) Promote(ctx context.Context) error {
 	if r.isDevelopment {
-		announce2("promote", "Skipping promote, this is a development release")
-		return nil
+		return errors.New("cannot promote a development release")
 	}
 
 	if err := r.checkRequirements(ctx, stagePromoteCreate); err != nil {
@@ -369,8 +368,7 @@ func (r *releaseRunner) Promote(ctx context.Context) error {
 
 func (r *releaseRunner) PromoteFinalize(ctx context.Context) error {
 	if r.isDevelopment {
-		announce2("promote", "Skipping promote finalize, this is a development release")
-		return nil
+		return errors.New("cannot promote a development release")
 	}
 
 	if err := r.checkRequirements(ctx, stagePromoteFinalize); err != nil {


### PR DESCRIPTION

## Test plan

When a release is a development release, we should error out and inform them that promotion isn't possible.
Erroring out ensures no other step runs in the CI