### PR TITLE
chore: Move helper function to database package

### DIFF
--- a/cmd/frontend/graphqlbackend/BUILD.bazel
+++ b/cmd/frontend/graphqlbackend/BUILD.bazel
@@ -426,7 +426,6 @@ go_test(
         "recorded_commands_test.go",
         "repositories_test.go",
         "repository_comparison_test.go",
-        "repository_contributors_test.go",
         "repository_cursor_test.go",
         "repository_metadata_test.go",
         "repository_mirror_test.go",

--- a/cmd/frontend/graphqlbackend/repository_contributors.go
+++ b/cmd/frontend/graphqlbackend/repository_contributors.go
@@ -84,7 +84,7 @@ func (s *repositoryContributorConnectionStore) ComputeNodes(ctx context.Context,
 	}
 
 	var start int
-	results, start, err = offsetBasedCursorSlice(results, args)
+	results, start, err = database.OffsetBasedCursorSlice(results, args)
 	if err != nil {
 		return nil, err
 	}
@@ -119,28 +119,4 @@ func (s *repositoryContributorConnectionStore) compute(ctx context.Context) ([]*
 		s.results, s.err = client.ContributorCount(ctx, s.repo.RepoName(), opt)
 	})
 	return s.results, s.err
-}
-
-func offsetBasedCursorSlice[T any](nodes []T, args *database.PaginationArgs) ([]T, int, error) {
-	start := 0
-	end := 0
-	total := len(nodes)
-	if args.First != nil {
-		if len(args.After) > 0 {
-			start = min(args.After[0].(int)+1, total)
-		}
-		end = min(start+*args.First, total)
-	} else if args.Last != nil {
-		end = total
-		if len(args.Before) > 0 {
-			end = max(args.Before[0].(int), 0)
-		}
-		start = max(end-*args.Last, 0)
-	} else {
-		return nil, 0, errors.New(`args.First and args.Last are nil`)
-	}
-
-	nodes = nodes[start:end]
-
-	return nodes, start, nil
 }

--- a/internal/database/BUILD.bazel
+++ b/internal/database/BUILD.bazel
@@ -210,6 +210,7 @@ go_test(
         "feature_flags_test.go",
         "gitserver_repos_test.go",
         "global_state_test.go",
+        "helpers_test.go",
         "main_test.go",
         "namespace_permissions_test.go",
         "namespaces_test.go",

--- a/internal/database/helpers_test.go
+++ b/internal/database/helpers_test.go
@@ -1,11 +1,10 @@
-package graphqlbackend
+package database
 
 import (
 	"testing"
 
 	"github.com/hexops/autogold/v2"
 
-	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/lib/pointers"
 )
 
@@ -14,34 +13,34 @@ func TestOffsetBasedCursorSlice(t *testing.T) {
 
 	testCases := []struct {
 		name string
-		args *database.PaginationArgs
+		args *PaginationArgs
 		want autogold.Value
 	}{
 		{
 			"first page",
-			&database.PaginationArgs{First: pointers.Ptr(2)},
+			&PaginationArgs{First: pointers.Ptr(2)},
 			autogold.Expect([]int{1, 2}),
 		},
 		{
 			"next page",
-			&database.PaginationArgs{First: pointers.Ptr(2), After: []any{1}},
+			&PaginationArgs{First: pointers.Ptr(2), After: []any{1}},
 			autogold.Expect([]int{3, 4}),
 		},
 		{
 			"last page",
-			&database.PaginationArgs{Last: pointers.Ptr(2)},
+			&PaginationArgs{Last: pointers.Ptr(2)},
 			autogold.Expect([]int{9, 10}),
 		},
 		{
 			"previous page",
-			&database.PaginationArgs{Last: pointers.Ptr(2), Before: []any{8}},
+			&PaginationArgs{Last: pointers.Ptr(2), Before: []any{8}},
 			autogold.Expect([]int{7, 8}),
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			result, _, err := offsetBasedCursorSlice(slice, tc.args)
+			result, _, err := OffsetBasedCursorSlice(slice, tc.args)
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
This allows usage of the function in places other than
the graphqlbackend package.

## Test plan

Covered by existing tests