### PR TITLE
Cody Ignore: use "cache-and-network" fetch policy for context filters query

### DIFF
--- a/client/web/src/cody/useCodyIgnore.tsx
+++ b/client/web/src/cody/useCodyIgnore.tsx
@@ -195,7 +195,7 @@ const CODY_CONTEXT_FILTERS_QUERY = gql`
 const EnterpriseProvider: React.FC<React.PropsWithChildren<{}>> = ({ children }) => {
     const { data, error, loading } = useQuery<ContextFiltersResult, ContextFiltersVariables>(
         CODY_CONTEXT_FILTERS_QUERY,
-        {}
+        { fetchPolicy: 'cache-and-network' }
     )
     const [fns, setFns] = useState<CodyIgnoreFns>({ isRepoIgnored: alwaysTrue, isFileIgnored: alwaysTrue })
 


### PR DESCRIPTION
Occasionally, Firefox cancels `ContextFilters` requests, resulting in an `NS_BINDING_ABORTED` error. This error can lead to inconsistent query results. To ensure that the Cody context filters values on the client remain up-to-date, this change modifies the fetch policy from the default `cache-first` to `cache-and-network`.

## Test plan
- CI
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
