### PR TITLE
release: pass in `IS_DEVELOPMENT_RELEASE` flag to buildkite

### DIFF
--- a/release.yaml
+++ b/release.yaml
@@ -204,7 +204,8 @@ promoteToPublic:
             "env": {
               "DISABLE_ASPECT_WORKFLOWS": "true",
               "RELEASE_PUBLIC": "true",
-              "VERSION": "{{tag}}"
+              "VERSION": "{{tag}}",
+              "IS_DEVELOPMENT_RELEASE": "{{is_development}}"
             }
           }' "https://api.buildkite.com/v2/organizations/sourcegraph/pipelines/sourcegraph/builds")
           exit_code=$?


### PR DESCRIPTION
## Test plan

We didn't pass the `IS_DEVELOPMENT` env to buildkite which caused a failure when running release tests.

![CleanShot 2024-05-08 at 16 28 28@2x](https://github.com/sourcegraph/sourcegraph/assets/25608335/97085f34-e435-47b7-8451-2336436a2d7b)
