### PR TITLE
sg gen buf: fix completions

### DIFF
--- a/dev/sg/generates.go
+++ b/dev/sg/generates.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 
 	"github.com/sourcegraph/sourcegraph/dev/sg/buf"
@@ -22,7 +23,15 @@ var allGenerateTargets = generateTargets{
 		Help:   "Re-generate protocol buffer bindings using buf",
 		Runner: generateProtoRunner,
 		Completer: func() (options []string) {
-			options, _ = buf.CodegenFiles()
+			options, _ = buf.PluginConfigurationFiles()
+			// Try to convert the options into relative paths for brevity
+			if cwd, err := os.Getwd(); err == nil {
+				for i, o := range options {
+					if rel, err := filepath.Rel(cwd, o); err == nil {
+						options[i] = rel
+					}
+				}
+			}
 			return
 		},
 	},


### PR DESCRIPTION
The command accepts `buf.gen.yaml` files, but the current completion provides generated Go files instead. The output is also provided in absolute-path format, which is difficult to read. This change addresses both issues, though the completion is a bit slow still.

## Test plan

Before (incorrect completions):

![image](https://github.com/sourcegraph/sourcegraph/assets/23356519/007cc580-3e2d-4c61-bd45-9326e775e48d)

After (✅):

```sh
go build -o ./sg ./dev/sg && ./sg install -f -p=false # install globally
```

<img width="883" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/23356519/7c1831bb-bffc-4918-bee2-7ecf65386cc8">

Running `sg gen buf` against some of the suggested targets works as expected