### PR TITLE
gitserver: grpc: fixup and add tests for GetCommit RPC

### DIFF
--- a/cmd/gitserver/internal/git/iface.go
+++ b/cmd/gitserver/internal/git/iface.go
@@ -18,6 +18,8 @@ type GitBackend interface {
 	// Config returns a backend for interacting with git configuration at .git/config.
 	Config() GitConfigBackend
 	// GetObject allows to read a git object from the git object database.
+	//
+	// If the object specified by objectName does not exist, a RevisionNotFoundError is returned.
 	GetObject(ctx context.Context, objectName string) (*gitdomain.GitObject, error)
 	// MergeBase finds the merge base commit for the given base and head revspecs.
 	// Returns an empty string and no error if no common merge-base was found.

--- a/internal/gitserver/v1/gitserver.proto
+++ b/internal/gitserver/v1/gitserver.proto
@@ -47,6 +47,14 @@ service GitserverService {
     option idempotency_level = NO_SIDE_EFFECTS;
   }
   rpc Exec(ExecRequest) returns (stream ExecResponse) {}
+
+  // GetObject returns the object with the given OID in the given repository.
+  //
+  // If the object is not found, an error with a RevisionNotFoundPayload is
+  // returned.
+  //
+  // If the given repo is not cloned, it will be enqueued for cloning and a
+  // NotFound error will be returned, with a RepoNotFoundPayload in the details.
   rpc GetObject(GetObjectRequest) returns (GetObjectResponse) {
     option idempotency_level = NO_SIDE_EFFECTS;
   }

--- a/internal/gitserver/v1/gitserver_grpc.pb.go
+++ b/internal/gitserver/v1/gitserver_grpc.pb.go
@@ -194,6 +194,13 @@ type GitserverServiceClient interface {
 	CreateCommitFromPatchBinary(ctx context.Context, opts ...grpc.CallOption) (GitserverService_CreateCommitFromPatchBinaryClient, error)
 	DiskInfo(ctx context.Context, in *DiskInfoRequest, opts ...grpc.CallOption) (*DiskInfoResponse, error)
 	Exec(ctx context.Context, in *ExecRequest, opts ...grpc.CallOption) (GitserverService_ExecClient, error)
+	// GetObject returns the object with the given OID in the given repository.
+	//
+	// If the object is not found, an error with a RevisionNotFoundPayload is
+	// returned.
+	//
+	// If the given repo is not cloned, it will be enqueued for cloning and a
+	// NotFound error will be returned, with a RepoNotFoundPayload in the details.
 	GetObject(ctx context.Context, in *GetObjectRequest, opts ...grpc.CallOption) (*GetObjectResponse, error)
 	IsRepoCloneable(ctx context.Context, in *IsRepoCloneableRequest, opts ...grpc.CallOption) (*IsRepoCloneableResponse, error)
 	ListGitolite(ctx context.Context, in *ListGitoliteRequest, opts ...grpc.CallOption) (*ListGitoliteResponse, error)
@@ -848,6 +855,13 @@ type GitserverServiceServer interface {
 	CreateCommitFromPatchBinary(GitserverService_CreateCommitFromPatchBinaryServer) error
 	DiskInfo(context.Context, *DiskInfoRequest) (*DiskInfoResponse, error)
 	Exec(*ExecRequest, GitserverService_ExecServer) error
+	// GetObject returns the object with the given OID in the given repository.
+	//
+	// If the object is not found, an error with a RevisionNotFoundPayload is
+	// returned.
+	//
+	// If the given repo is not cloned, it will be enqueued for cloning and a
+	// NotFound error will be returned, with a RepoNotFoundPayload in the details.
 	GetObject(context.Context, *GetObjectRequest) (*GetObjectResponse, error)
 	IsRepoCloneable(context.Context, *IsRepoCloneableRequest) (*IsRepoCloneableResponse, error)
 	ListGitolite(context.Context, *ListGitoliteRequest) (*ListGitoliteResponse, error)


### PR DESCRIPTION
Part of https://github.com/sourcegraph/sourcegraph/issues/60411

This PR fixes up the GetObject gRPC server method by:
- Adding unit tests for it since there weren't any before
- Adding a check to fail early if the repository isn't cloned yet (like all of our other grpc methods do). 

## Test plan

New unit tests