### PR TITLE
gitserver: grpc: create proto roundtrip tests for GetObject[Request/Response]

### DIFF
--- a/internal/gitserver/protocol/BUILD.bazel
+++ b/internal/gitserver/protocol/BUILD.bazel
@@ -32,6 +32,7 @@ go_test(
     embed = [":protocol"],
     deps = [
         "//internal/api",
+        "//internal/gitserver/gitdomain",
         "//internal/search/result",
         "@com_github_google_go_cmp//cmp",
         "@com_github_stretchr_testify//require",

--- a/internal/gitserver/protocol/gitserver.go
+++ b/internal/gitserver/protocol/gitserver.go
@@ -543,7 +543,6 @@ func (r *GetObjectResponse) FromProto(p *proto.GetObjectResponse) {
 	*r = GetObjectResponse{
 		Object: gitObj,
 	}
-
 }
 
 // IsPerforcePathCloneableRequest is the request to check if a Perforce path is cloneable.


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/60411

We didn't have any round trip tests for the GetCommit request or response type. This PR adds them.

## Test plan

New unit tests
