### PR TITLE
sg+release: push releases to the cloud ephemeral registry too

### DIFF
--- a/dev/ci/images/go.mod
+++ b/dev/ci/images/go.mod
@@ -1,3 +1,0 @@
-module github.com/sourcegraph/sourcegraph/dev/ci/images
-
-go 1.14

--- a/dev/ci/images/go.mod
+++ b/dev/ci/images/go.mod
@@ -1,0 +1,3 @@
+module github.com/sourcegraph/sourcegraph/dev/ci/images
+
+go 1.22.1

--- a/dev/ci/internal/ci/images_operations.go
+++ b/dev/ci/internal/ci/images_operations.go
@@ -103,7 +103,8 @@ func bazelPushImagesCmd(c Config, isCandidate bool, opts ...bk.StepOpt) func(*bk
 	switch c.RunType {
 	case runtype.InternalRelease:
 		prodRegistry = images.SourcegraphInternalReleaseRegistry
-		additionalProdRegistry = "" // we don't want to push to the public registry on internal releases
+		// we don't want to push to the public registry on internal releases, but we do want to publish the release to the cloud ephemeral registry
+		additionalProdRegistry = images.CloudEphemeralRegistry
 	case runtype.CloudEphemeral:
 		// cloud needs to "prod" tag, so we set the push registry for prod to the cloud ephemeral
 		devRegistry = images.CloudEphemeralRegistry

--- a/dev/ci/internal/ci/release_operations.go
+++ b/dev/ci/internal/ci/release_operations.go
@@ -14,6 +14,7 @@ import (
 // releasePromoteImages runs a script that iterates through all defined images that we're producing that has been uploaded
 // on the internal registry with a given version and retags them to the public registry.
 func releasePromoteImages(c Config) operations.Operation {
+	additionalProdRegistries := strings.Join([]string{images.SourcegraphArtifactRegistryPublicRegistry, images.CloudEphemeralRegistry}, " ")
 	image_args := strings.Join(images.SourcegraphDockerImages, " ")
 	return func(pipeline *bk.Pipeline) {
 		pipeline.AddStep("Promote release to public",
@@ -21,7 +22,7 @@ func releasePromoteImages(c Config) operations.Operation {
 			bk.Env("VERSION", c.Version),
 			bk.Env("INTERNAL_REGISTRY", images.SourcegraphInternalReleaseRegistry),
 			bk.Env("PUBLIC_REGISTRY", images.SourcegraphDockerPublishRegistry),
-			bk.Env("ADDITIONAL_PROD_REGISTRIES", images.SourcegraphArtifactRegistryPublicRegistry),
+			bk.Env("ADDITIONAL_PROD_REGISTRIES", additionalProdRegistries),
 			bk.AnnotatedCmd(
 				fmt.Sprintf("./tools/release/promote_images.sh %s", image_args),
 				bk.AnnotatedCmdOpts{


### PR DESCRIPTION
This allows internal and promoted releases to also publish images to the Cloud Ephemeral registry
## Test plan
CI + the push all script was previously tested to handle multiple registries