### PR TITLE
rockskip: ruler function is just bits.TrailingZeros

### DIFF
--- a/internal/rockskip/server.go
+++ b/internal/rockskip/server.go
@@ -267,5 +267,8 @@ func ruler(n int) int {
 	if n <= 0 {
 		return 0
 	}
+	// ruler(n) is equivalent to asking how many times can you divide n by 2
+	// before you get an odd number. That is the number of 0's at the end of n
+	// when n is written in base 2.
 	return bits.TrailingZeros(uint(n))
 }

--- a/internal/rockskip/server.go
+++ b/internal/rockskip/server.go
@@ -3,6 +3,7 @@ package rockskip
 import (
 	"context"
 	"database/sql"
+	"math/bits"
 	"sync"
 	"time"
 
@@ -263,10 +264,8 @@ func getHops(ctx context.Context, tx dbutil.DB, commit int, tasklog *TaskLog) ([
 //
 // https://oeis.org/A007814
 func ruler(n int) int {
-	height := 0
-	for n > 0 && n%2 == 0 {
-		height++
-		n = n / 2
+	if n <= 0 {
+		return 0
 	}
-	return height
+	return bits.TrailingZeros(uint(n))
 }


### PR DESCRIPTION
I couldn't help but make this change after seeing the algorithm in https://github.com/sourcegraph/sourcegraph/pull/62510. Feel free to just close this if this makes it less clear, but this kinda feels clearer in my head but I am probably weird.

Test Plan: TestRuler passes
