### PR TITLE
sg: cloud - move all cloud ephemeral commands to a sub command `ephemeral`

### DIFF
--- a/dev/sg/internal/cloud/BUILD.bazel
+++ b/dev/sg/internal/cloud/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
         "common.go",
         "delete_command.go",
         "deploy_command.go",
+        "ephemeral_command.go",
         "instance.go",
         "lease_command.go",
         "list_command.go",

--- a/dev/sg/internal/cloud/build_command.go
+++ b/dev/sg/internal/cloud/build_command.go
@@ -10,10 +10,10 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
-var BuildEphemeralCommand = cli.Command{
+var buildEphemeralCommand = cli.Command{
 	Name:        "build",
-	Usage:       "trigger a cloud ephemeral build",
-	Description: "Triggers a Cloud Ephemeral build of the current branch which will push images to the cloud ephemeral registry",
+	Usage:       "Trigger a cloud ephemeral build which will push images to the cloud ephemeral registry",
+	Description: "Trigger a cloud ephemeral build which will push images to the cloud ephemeral registry",
 	Action:      buildCloudEphemeral,
 }
 

--- a/dev/sg/internal/cloud/delete_command.go
+++ b/dev/sg/internal/cloud/delete_command.go
@@ -11,15 +11,16 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/output"
 )
 
-var DeleteEphemeralCommand = cli.Command{
+var deleteEphemeralCommand = cli.Command{
 	Name:        "delete",
-	Usage:       "sg could delete <name/slug>",
-	Description: "delete ephemeral cloud instance identified either by the current branch or provided as a cli arg",
+	Usage:       "Delete an ephemeral instance",
+	Description: "Delete ephemeral instance identified either by the current branch or by name",
 	Action:      deleteCloudEphemeral,
 	Flags: []cli.Flag{
 		&cli.StringFlag{
-			Name:  "name",
-			Usage: "name or slug of the cloud ephemeral instance to delete",
+			Name:        "name",
+			Usage:       "name of the instance to update the lease expiry time for",
+			DefaultText: "current branch name will be used",
 		},
 	},
 }

--- a/dev/sg/internal/cloud/deploy_command.go
+++ b/dev/sg/internal/cloud/deploy_command.go
@@ -22,15 +22,16 @@ import (
 
 var ErrDeploymentExists error = errors.New("deployment already exists")
 
-var DeployEphemeralCommand = cli.Command{
+var deployEphemeralCommand = cli.Command{
 	Name:        "deploy",
-	Usage:       "create a cloud ephemeral deployment",
-	Description: "Deploy the specified branch or tag to an ephemeral Sourcegraph Cloud environment",
+	Usage:       "Deploy a new ephemeral instance from the current branch or specific version",
+	Description: "Deploy a new ephemeral instance from the current branch or specific version",
 	Action:      deployCloudEphemeral,
 	Flags: []cli.Flag{
 		&cli.StringFlag{
 			Name:        "name",
-			DefaultText: "the name of the ephemeral deployment. If none is specified, the name will be derived from the branch name",
+			Usage:       "name of the instance to update the lease expiry time for",
+			DefaultText: "current branch name will be used",
 		},
 		&cli.StringFlag{
 			Name:        "version",

--- a/dev/sg/internal/cloud/ephemeral_command.go
+++ b/dev/sg/internal/cloud/ephemeral_command.go
@@ -1,0 +1,20 @@
+package cloud
+
+import "github.com/urfave/cli/v2"
+
+var EphemeralCommand = cli.Command{
+	Name:        "ephemeral",
+	Aliases:     []string{"eph"},
+	Usage:       "Set of commands that operate on Cloud Ephemeral instances",
+	Description: "Commands to create, inspect or upgrade Cloud Ephemeral instances",
+	Subcommands: []*cli.Command{
+		&buildEphemeralCommand,
+		&deleteEphemeralCommand,
+		&deployEphemeralCommand,
+		&leaseEphemeralCommand,
+		&listEphemeralCommand,
+		&listVersionsEphemeralCommand,
+		&statusEphemeralCommand,
+		&upgradeEphemeralCommand,
+	},
+}

--- a/dev/sg/internal/cloud/lease_command.go
+++ b/dev/sg/internal/cloud/lease_command.go
@@ -13,16 +13,16 @@ import (
 // MaxDuration is the maximum lease duration by which a deployment can be extended by, which is 4 days
 const MaxDuration = time.Hour * 24 * 4
 
-var LeaseEphemeralCommand = cli.Command{
+var leaseEphemeralCommand = cli.Command{
 	Name:        "lease",
-	Usage:       "extend or reduce the lease of an ephemeral instance",
+	Usage:       "Extend or reduce the lease expiry time of an ephemeral instance",
 	UsageText:   "sg cloud lease [command options]",
-	Description: "update the lease time of an ephemeral instance",
+	Description: "Extend or reduce the lease expiry time of an ephemeral instance. Once the expiry time of an ephemeral instance is reached it gets deleted and inaccessible",
 	Action:      leaseCloudEphemeral,
 	Flags: []cli.Flag{
 		&cli.StringFlag{
 			Name:        "name",
-			Usage:       "name of the instance to update the lease expiry time for",
+			Usage:       "name of the ephemeral instance",
 			DefaultText: "current branch name will be used",
 		},
 		&cli.DurationFlag{

--- a/dev/sg/internal/cloud/list_command.go
+++ b/dev/sg/internal/cloud/list_command.go
@@ -11,10 +11,10 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/output"
 )
 
-var ListEphemeralCommand = cli.Command{
+var listEphemeralCommand = cli.Command{
 	Name:        "list",
-	Usage:       "list ephemeral cloud instances",
-	Description: "list ephemeral cloud instances attached to your GCP account",
+	Usage:       "List ephemeral instances assigned to you, or all instances",
+	Description: "List ephemeral instances assigned to your GCP email, or all instances that are deployed",
 	Action:      listCloudEphemeral,
 	Flags: []cli.Flag{
 		&cli.BoolFlag{
@@ -27,7 +27,7 @@ var ListEphemeralCommand = cli.Command{
 		},
 		&cli.BoolFlag{
 			Name:  "all",
-			Usage: "list all instances, not just those that attached to your GCP account",
+			Usage: "list all ephemeral instances, not just those that attached to your GCP account",
 		},
 	},
 }

--- a/dev/sg/internal/cloud/list_versions_command.go
+++ b/dev/sg/internal/cloud/list_versions_command.go
@@ -12,10 +12,10 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/output"
 )
 
-var ListVersionsEphemeralCommand = cli.Command{
+var listVersionsEphemeralCommand = cli.Command{
 	Name:        "list-versions",
-	Usage:       "list docker images in the cloud ephemeral registry",
-	Description: "list ephemeral cloud instances attached to your GCP account",
+	Usage:       "List docker images in the cloud ephemeral registry",
+	Description: "List the tags/versions that are available for deployment from the cloud ephemeral registry",
 	Action:      listTagsCloudEphemeral,
 	Flags: []cli.Flag{
 		&cli.BoolFlag{

--- a/dev/sg/internal/cloud/status_command.go
+++ b/dev/sg/internal/cloud/status_command.go
@@ -11,15 +11,16 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/output"
 )
 
-var StatusEphemeralCommand = cli.Command{
+var statusEphemeralCommand = cli.Command{
 	Name:        "status",
-	Usage:       "get status of ephemeral cloud instance",
-	Description: "get the status of the ephemeral cloud instance for this branch or instance with the provided name",
+	Usage:       "Get the status of a ephemeral instance",
+	Description: "Get the status of the ephemeral instance for this branch or instance with the provided name",
 	Action:      statusCloudEphemeral,
 	Flags: []cli.Flag{
 		&cli.StringFlag{
-			Name:  "name",
-			Usage: "name of the instance to get the status of",
+			Name:        "name",
+			Usage:       "name of the ephemeral instance",
+			DefaultText: "current branch name will be used",
 		},
 		&cli.BoolFlag{
 			Name:  "json",

--- a/dev/sg/internal/cloud/upgrade_command.go
+++ b/dev/sg/internal/cloud/upgrade_command.go
@@ -11,19 +11,20 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/output"
 )
 
-var UpgradeEphemeralCommand = cli.Command{
+var upgradeEphemeralCommand = cli.Command{
 	Name:        "upgrade",
-	Usage:       "upgrade a cloud ephemeral",
-	Description: "Upgrade the given Ephemeral deployment with the specified version",
+	Usage:       "upgrade an ephemeral instance",
+	Description: "upgrade the given ephemeral instance  with the specified version",
 	Action:      upgradeCloudEphemeral,
 	Flags: []cli.Flag{
 		&cli.StringFlag{
 			Name:        "name",
-			DefaultText: "the name of the ephemeral deployment. If not specified, the name will be derived from the branch name",
+			Usage:       "name of the ephemeral instance",
+			DefaultText: "current branch name will be used",
 		},
 		&cli.StringFlag{
 			Name:        "version",
-			DefaultText: "upgrades an ephemeral cloud Sourcegraph environment with the specified version. The version MUST exist and implies that no build will be created",
+			DefaultText: "upgrades an ephemeral instance with the specified version. The version MUST exist in the cloud ephemeral registry  and implies that no build will be created",
 			Required:    true,
 		},
 	},

--- a/dev/sg/sg_cloud.go
+++ b/dev/sg/sg_cloud.go
@@ -45,14 +45,7 @@ var cloudCommand = &cli.Command{
 				return nil
 			},
 		},
-		&cloud.BuildEphemeralCommand,
-		&cloud.DeleteEphemeralCommand,
-		&cloud.DeployEphemeralCommand,
-		&cloud.LeaseEphemeralCommand,
-		&cloud.ListEphemeralCommand,
-		&cloud.ListVersionsEphemeralCommand,
-		&cloud.StatusEphemeralCommand,
-		&cloud.UpgradeEphemeralCommand,
+		&cloud.EphemeralCommand,
 	},
 }
 


### PR DESCRIPTION
```
go run ./dev/sg cloud --help
NAME:
   sg cloud - Install and work with Sourcegraph Cloud tools

USAGE:
   sg cloud command [command options] [arguments...]

DESCRIPTION:
   Learn more about Sourcegraph Cloud:

   - Product: https://sourcegraph.com/docs/cloud
   - Handbook: https://handbook.sourcegraph.com/departments/cloud/


COMMANDS:
   install         Install or upgrade local `mi2` CLI (for Cloud V2)
   ephemeral, eph  Set of commands that operate on Cloud Ephemeral instances
   help, h         Shows a list of commands or help for one command

OPTIONS:
   --help, -h  show help
   ```

And when you do `sg cloud eph` 
```
go run ./dev/sg cloud eph --help
NAME:
   sg cloud ephemeral - Set of commands that operate on Cloud Ephemeral instances

USAGE:
   sg cloud ephemeral command [command options] [arguments...]

DESCRIPTION:
   Commands to create, inspect or upgrade Cloud Ephemeral instances

COMMANDS:
   build          Trigger a cloud ephemeral build which will push images to the cloud ephemeral registry
   delete         Delete an ephemeral instance
   deploy         Deploy a new ephemeral instance from the current branch or specific version
   lease          Extend or reduce the lease expiry time of an ephemeral instance
   list           List ephemeral instances assigned to you, or all instances
   list-versions  List docker images in the cloud ephemeral registry
   status         Get the status of a ephemeral instance
   upgrade        upgrade an ephemeral instance
   help, h        Shows a list of commands or help for one command
```
## Test plan
Tested locally
