### PR TITLE
[Svelte]: Hide suggestion UI after query was submitted

### DIFF
--- a/client/web-sveltekit/src/lib/search/input/SearchInput.svelte
+++ b/client/web-sveltekit/src/lib/search/input/SearchInput.svelte
@@ -198,8 +198,8 @@
         await invalidate(`search:${url}`)
         void goto(url)
 
-        // Rest interaction state since after success submit we should visually hide
-        // any suggestions UI but still keep focus on input, after user interacts with
+        // Reset interaction state since after success submit we should hide
+        // suggestions UI but still keep focus on input, after user interacts with
         // search input again we show suggestion panel
         userHasInteracted = false
     }

--- a/client/web-sveltekit/src/lib/search/input/SearchInput.svelte
+++ b/client/web-sveltekit/src/lib/search/input/SearchInput.svelte
@@ -197,6 +197,11 @@
         // this, SvelteKit will not re-run the loader because the URL hasn't changed.
         await invalidate(`search:${url}`)
         void goto(url)
+
+        // Rest interaction state since after success submit we should visually hide
+        // any suggestions UI but still keep focus on input, after user interacts with
+        // search input again we show suggestion panel
+        userHasInteracted = false
     }
 
     async function handleSubmit(event: Event) {


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/62572

Not the ideal solution but cheap one, I'm curious what @fkling 
thinks about having this as standard behavior for suggestion logic.

https://github.com/sourcegraph/sourcegraph/assets/18492575/52247f4b-3dd9-40ee-b448-7a10ec7cb3f4


## Test plan
- Go to the search result page and try to submit a query 
- You should see no suggestions after the submit action 
- Suggestions should appear right after you interact with the input

