### PR TITLE
release(executors): update ami naming

### DIFF
--- a/cmd/executor/docker-mirror/_ami.build.sh
+++ b/cmd/executor/docker-mirror/_ami.build.sh
@@ -20,7 +20,10 @@ GCP_PROJECT="aspect-dev"
 
 ## Setting up packer
 export PKR_VAR_name
-PKR_VAR_name="${IMAGE_FAMILY}-${BUILDKITE_BUILD_NUMBER}"
+PKR_VAR_name="${IMAGE_FAMILY}"
+if [ "${RELEASE_INTERNAL:-}" == "true" ]; then
+  PKR_VAR_name="${PKR_VAR_name}-${BUILDKITE_BUILD_NUMBER}"
+fi
 export PKR_VAR_image_family="${IMAGE_FAMILY}"
 export PKR_VAR_tagged_release="${EXECUTOR_IS_TAGGED_RELEASE}"
 export PKR_VAR_aws_access_key=${AWS_EXECUTOR_AMI_ACCESS_KEY}

--- a/cmd/executor/docker-mirror/_ami.push.sh
+++ b/cmd/executor/docker-mirror/_ami.push.sh
@@ -9,7 +9,10 @@ export AWS_ACCESS_KEY_ID="${AWS_EXECUTOR_AMI_ACCESS_KEY}"
 export AWS_SECRET_ACCESS_KEY="${AWS_EXECUTOR_AMI_SECRET_KEY}"
 
 # Point to GCP boot disk image/AMI built by build.sh script
-NAME="${IMAGE_FAMILY}-${BUILDKITE_BUILD_NUMBER}"
+NAME="${IMAGE_FAMILY}"
+if [ "${RELEASE_INTERNAL:-}" == "true" ]; then
+  NAME="${NAME}-${BUILDKITE_BUILD_NUMBER}"
+fi
 GOOGLE_IMAGE_NAME="${NAME}"
 
 # Mark GCP boot disk as released and make it usable outside of Sourcegraph.

--- a/cmd/executor/vm-image/_ami.build.sh
+++ b/cmd/executor/vm-image/_ami.build.sh
@@ -35,7 +35,7 @@ GCP_PROJECT="aspect-dev"
 
 export PKR_VAR_name
 PKR_VAR_name="${IMAGE_FAMILY}"
-if [ "${RELEASE_INTERNAL:-}" != "true" ]; then
+if [ "${RELEASE_INTERNAL:-}" == "true" ]; then
   PKR_VAR_name="${PKR_VAR_name}-${BUILDKITE_BUILD_NUMBER}"
 fi
 export PKR_VAR_image_family="${IMAGE_FAMILY}"

--- a/cmd/executor/vm-image/_ami.push.sh
+++ b/cmd/executor/vm-image/_ami.push.sh
@@ -25,7 +25,7 @@ export AWS_SECRET_ACCESS_KEY="${AWS_EXECUTOR_AMI_SECRET_KEY}"
 
 # Point to GCP boot disk image/AMI built by //cmd/executor/vm-image:ami.build
 NAME="${IMAGE_FAMILY}"
-if [ "${RELEASE_INTERNAL:-}" != "true" ]; then
+if [ "${RELEASE_INTERNAL:-}" == "true" ]; then
   NAME="${NAME}-${BUILDKITE_BUILD_NUMBER}"
 fi
 


### PR DESCRIPTION
[Context](https://sourcegraph.slack.com/archives/C072MK5LRA6/p1715270616345209)

## Test plan

We found out during the 5.4.0 release that the amis weren't named properly. Thus PR fixes that.
Below is the matrix for naming AMIs.

### Matrix
| Internal Release  | Public Release  |
|---|---|
| {IMAGE_FAMILY}-{BUILDKITE_BUILD_NUMBER}  | {IMAGE_FAMILY}  |
