### PR TITLE
conf: redact `scim.authToken` in site config UI

### DIFF
--- a/internal/conf/validate.go
+++ b/internal/conf/validate.go
@@ -203,7 +203,11 @@ func ValidateSite(input string) (messages []string, err error) {
 // siteConfigSecrets is the list of secrets in site config needs to be redacted
 // before serving or unredacted before saving.
 var siteConfigSecrets = []struct {
-	readPath  string // gjson uses "." as path separator, uses "\" to escape.
+	// gjson uses "." as path separator, uses "\" to escape if the key itself
+	// contains a "." character. For example,
+	// 	- "scim.authToken" => "scim\.authToken"
+	// 	- "dotcom": { "sams.clientSecret" } => "dotcom.sams\.clientSecret"
+	readPath  string
 	editPaths []string
 }{
 	{readPath: `executors\.accessToken`, editPaths: []string{"executors.accessToken"}},
@@ -223,6 +227,7 @@ var siteConfigSecrets = []struct {
 	{readPath: `completions.accessToken`, editPaths: []string{"completions", "accessToken"}},
 	{readPath: `app.dotcomAuthToken`, editPaths: []string{"app", "dotcomAuthToken"}},
 	{readPath: `attribution\.gateway.accessToken`, editPaths: []string{"attribution.gateway", "accessToken"}},
+	{readPath: `scim\.authToken`, editPaths: []string{"scim.authToken"}},
 }
 
 // UnredactSecrets unredacts unchanged secrets back to their original value for

--- a/internal/conf/validate_test.go
+++ b/internal/conf/validate_test.go
@@ -28,6 +28,7 @@ const (
 	dotcomSrcCliVersionCacheGitHubToken         = "dotcomSrcCliVersionCacheGitHubToken"
 	dotcomSrcCliVersionCacheGitHubWebhookSecret = "dotcomSrcCliVersionCacheGitHubWebhookSecret"
 	dotcomSAMSClientSecret                      = "dotcomSAMSClientSecret"
+	scimAuthToken                               = "scimAuthToken"
 )
 
 func TestValidate(t *testing.T) {
@@ -233,6 +234,7 @@ func TestRedactSecrets(t *testing.T) {
 					dotcomSrcCliVersionCacheGitHubWebhookSecret: dotcomSrcCliVersionCacheGitHubWebhookSecret,
 					dotcomSAMSClientSecret:                      dotcomSAMSClientSecret,
 					authUnlockAccountLinkSigningKey:             authUnlockAccountLinkSigningKey,
+					scimAuthToken:                               scimAuthToken,
 				},
 			),
 		},
@@ -378,6 +380,7 @@ func TestUnredactSecrets(t *testing.T) {
 			dotcomSrcCliVersionCacheGitHubToken:         dotcomSrcCliVersionCacheGitHubToken,
 			dotcomSrcCliVersionCacheGitHubWebhookSecret: dotcomSrcCliVersionCacheGitHubWebhookSecret,
 			authUnlockAccountLinkSigningKey:             authUnlockAccountLinkSigningKey,
+			scimAuthToken:                               scimAuthToken,
 		},
 	)
 
@@ -405,6 +408,7 @@ func TestUnredactSecrets(t *testing.T) {
 				dotcomSrcCliVersionCacheGitHubToken:         redactedSecret,
 				dotcomSrcCliVersionCacheGitHubWebhookSecret: redactedSecret,
 				authUnlockAccountLinkSigningKey:             redactedSecret,
+				scimAuthToken:                               redactedSecret,
 			},
 		)
 		unredactedSite, err := UnredactSecrets(input, conftypes.RawUnified{Site: previousSite})
@@ -426,6 +430,7 @@ func TestUnredactSecrets(t *testing.T) {
 				dotcomSrcCliVersionCacheGitHubToken:         dotcomSrcCliVersionCacheGitHubToken,
 				dotcomSrcCliVersionCacheGitHubWebhookSecret: dotcomSrcCliVersionCacheGitHubWebhookSecret,
 				authUnlockAccountLinkSigningKey:             authUnlockAccountLinkSigningKey,
+				scimAuthToken:                               scimAuthToken,
 			},
 		)
 		assert.Equal(t, want, unredactedSite)
@@ -448,6 +453,7 @@ func TestUnredactSecrets(t *testing.T) {
 				dotcomSrcCliVersionCacheGitHubToken:         redactedSecret,
 				dotcomSrcCliVersionCacheGitHubWebhookSecret: redactedSecret,
 				authUnlockAccountLinkSigningKey:             redactedSecret,
+				scimAuthToken:                               scimAuthToken,
 			},
 			newEmail,
 		)
@@ -470,6 +476,7 @@ func TestUnredactSecrets(t *testing.T) {
 				dotcomSrcCliVersionCacheGitHubToken:         dotcomSrcCliVersionCacheGitHubToken,
 				dotcomSrcCliVersionCacheGitHubWebhookSecret: dotcomSrcCliVersionCacheGitHubWebhookSecret,
 				authUnlockAccountLinkSigningKey:             authUnlockAccountLinkSigningKey,
+				scimAuthToken:                               scimAuthToken,
 			},
 			newEmail,
 		)
@@ -494,6 +501,7 @@ func getTestSiteWithRedactedSecrets() string {
 			dotcomSrcCliVersionCacheGitHubWebhookSecret: redactedSecret,
 			dotcomSAMSClientSecret:                      redactedSecret,
 			authUnlockAccountLinkSigningKey:             redactedSecret,
+			scimAuthToken:                               redactedSecret,
 		},
 	)
 }
@@ -513,6 +521,7 @@ type testSecrets struct {
 	dotcomSrcCliVersionCacheGitHubWebhookSecret string
 	dotcomSAMSClientSecret                      string
 	authUnlockAccountLinkSigningKey             string
+	scimAuthToken                               string
 }
 
 func getTestSiteWithSecrets(testSecrets testSecrets, optionalEdit ...string) string {
@@ -585,6 +594,7 @@ func getTestSiteWithSecrets(testSecrets testSecrets, optionalEdit ...string) str
     "sams.clientSecret": "%s"
   },
   "auth.unlockAccountLinkSigningKey": "%s",
+  "scim.authToken": "%s"
 }`,
 		email,
 		testSecrets.executorsAccessToken,
@@ -602,5 +612,6 @@ func getTestSiteWithSecrets(testSecrets testSecrets, optionalEdit ...string) str
 		testSecrets.dotcomSrcCliVersionCacheGitHubWebhookSecret,
 		testSecrets.dotcomSAMSClientSecret,
 		testSecrets.authUnlockAccountLinkSigningKey,
+		testSecrets.scimAuthToken,
 	)
 }


### PR DESCRIPTION

## Test plan


![CleanShot 2024-05-10 at 09 15 24@2x](https://github.com/sourcegraph/sourcegraph/assets/2946214/ae1275b9-316f-4f02-a89a-72f2d3aeb965)
