### PR TITLE
Batch changes: make window ranges exclusive to avoid infinite loop

### DIFF
--- a/internal/batches/types/scheduler/window/BUILD.bazel
+++ b/internal/batches/types/scheduler/window/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
     deps = [
         "//lib/errors",
         "//schema",
+        "@com_github_sourcegraph_log//:log",
         "@org_uber_go_ratelimit//:ratelimit",
     ],
 )

--- a/internal/batches/types/scheduler/window/config.go
+++ b/internal/batches/types/scheduler/window/config.go
@@ -38,7 +38,7 @@ func (cfg *Configuration) Estimate(now time.Time, n int) *time.Time {
 	// would include the given entry. If we hit a week in the future, we'll
 	// bail, because a lot can happen in a week.
 	rem := n
-	at := now
+	at := now.UTC() // we _should_ always be using UTC, but don't trust the caller
 	until := at.Add(7 * 24 * time.Hour)
 	for at.Before(until) {
 		schedule := cfg.scheduleAt(at)
@@ -54,10 +54,12 @@ func (cfg *Configuration) Estimate(now time.Time, n int) *time.Time {
 			nextAt := schedule.ValidUntil()
 			if nextAt == at {
 				// This loop has a complex end condition, and we've hit infinite loops here before.
-				// As a protective measure, if we make no progress, do not continue looping.
+				// As a protective measure, if we make no progress, do not continue looping
+				// and just return an unknown estimate.
 				log.Scoped("changeset scheduler").Error("infinite loop calculating estimate")
 				return nil
 			}
+			at = nextAt
 			continue
 		}
 

--- a/internal/batches/types/scheduler/window/config_test.go
+++ b/internal/batches/types/scheduler/window/config_test.go
@@ -25,6 +25,31 @@ func timeOfDayPtr(hour, minute int8) *timeOfDay {
 }
 
 func TestConfiguration_Estimate(t *testing.T) {
+	t.Run("possible timeout", func(t *testing.T) {
+		cfg, err := NewConfiguration(&[]*schema.BatchChangeRolloutWindow{
+			{
+				Rate: "15/hour",
+			},
+			{
+				Days:  []string{"monday", "tuesday", "wednesday", "thursday", "friday"},
+				End:   "23:59",
+				Rate:  "10/hour",
+				Start: "13:00",
+			},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		now := time.Date(2024, 3, 10, 15, 35, 0, 0, time.UTC)
+		for i := 0; i < 10000; i++ {
+			now = now.Add(7 * time.Second)
+			t.Run(now.String(), func(t *testing.T) {
+				t.Logf("estimate with %d changesets in queue: %v", 1000, cfg.Estimate(now, 1000))
+			})
+		}
+	})
+
 	t.Run("no windows", func(t *testing.T) {
 		cfg := &Configuration{}
 		now := time.Now()

--- a/internal/batches/types/scheduler/window/config_test.go
+++ b/internal/batches/types/scheduler/window/config_test.go
@@ -25,31 +25,6 @@ func timeOfDayPtr(hour, minute int8) *timeOfDay {
 }
 
 func TestConfiguration_Estimate(t *testing.T) {
-	t.Run("possible timeout", func(t *testing.T) {
-		cfg, err := NewConfiguration(&[]*schema.BatchChangeRolloutWindow{
-			{
-				Rate: "15/hour",
-			},
-			{
-				Days:  []string{"monday", "tuesday", "wednesday", "thursday", "friday"},
-				End:   "23:59",
-				Rate:  "10/hour",
-				Start: "13:00",
-			},
-		})
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		now := time.Date(2024, 3, 10, 15, 35, 0, 0, time.UTC)
-		for i := 0; i < 10000; i++ {
-			now = now.Add(7 * time.Second)
-			t.Run(now.String(), func(t *testing.T) {
-				t.Logf("estimate with %d changesets in queue: %v", 1000, cfg.Estimate(now, 1000))
-			})
-		}
-	})
-
 	t.Run("no windows", func(t *testing.T) {
 		cfg := &Configuration{}
 		now := time.Now()
@@ -179,6 +154,34 @@ func TestConfiguration_Estimate(t *testing.T) {
 			})
 		}
 	})
+
+	t.Run("infinite loop", func(t *testing.T) {
+		// Reproduces a scenario that caused an infinite loop when running Estimate.
+
+		cfg, err := NewConfiguration(&[]*schema.BatchChangeRolloutWindow{
+			{
+				Rate: "15/hour",
+			},
+			{
+				Days:  []string{"monday", "tuesday", "wednesday", "thursday", "friday"},
+				End:   "23:59",
+				Rate:  "10/hour",
+				Start: "13:00",
+			},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		now := time.Date(2024, 3, 10, 15, 35, 0, 0, time.UTC)
+		for i := 0; i < 10000; i++ {
+			now = now.Add(7 * time.Second)
+			t.Run(now.String(), func(t *testing.T) {
+				t.Logf("estimate with %d changesets in queue: %v", 1000, cfg.Estimate(now, 1000))
+			})
+		}
+	})
+
 }
 
 func TestConfiguration_Schedule(t *testing.T) {

--- a/internal/batches/types/scheduler/window/config_test.go
+++ b/internal/batches/types/scheduler/window/config_test.go
@@ -157,6 +157,7 @@ func TestConfiguration_Estimate(t *testing.T) {
 
 	t.Run("infinite loop", func(t *testing.T) {
 		// Reproduces a scenario that caused an infinite loop when running Estimate.
+		// See #62597.
 
 		cfg, err := NewConfiguration(&[]*schema.BatchChangeRolloutWindow{
 			{

--- a/internal/batches/types/scheduler/window/time.go
+++ b/internal/batches/types/scheduler/window/time.go
@@ -25,6 +25,10 @@ func (t timeOfDay) after(other timeOfDay) bool {
 	return t.cmp > other.cmp
 }
 
+func (t timeOfDay) equal(other timeOfDay) bool {
+	return t.cmp == other.cmp
+}
+
 func (t timeOfDay) before(other timeOfDay) bool {
 	return t.cmp < other.cmp
 }

--- a/internal/batches/types/scheduler/window/window.go
+++ b/internal/batches/types/scheduler/window/window.go
@@ -22,7 +22,7 @@ func (w *Window) covers(when timeOfDay) bool {
 		return true
 	}
 
-	return !(when.before(*w.start) || when.after(*w.end))
+	return !(when.before(*w.start) || when.after(*w.end) || when.equal(*w.end))
 }
 
 // IsOpen checks if this window is currently open.


### PR DESCRIPTION
This fixes an issue where we can potentially make no progress in the main loop of `Estimate`. Commentary inline.

Related [Slack thread](https://sourcegraph.slack.com/archives/C05EA9KQUTA/p1713644445735079)

## Test plan

Added unit test for this case and fuzz test to search for other edge cases.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
