### PR TITLE
gitserver: Make ReadDir return an iterator on client side

### DIFF
--- a/cmd/frontend/backend/repos_test.go
+++ b/cmd/frontend/backend/repos_test.go
@@ -173,18 +173,18 @@ func TestReposGetInventory(t *testing.T) {
 		}
 		return &fileutil.FileInfo{Name_: path, Mode_: os.ModeDir, Sys_: gitObjectInfo(wantRootOID)}, nil
 	})
-	gitserverClient.ReadDirFunc.SetDefaultHook(func(_ context.Context, _ api.RepoName, commit api.CommitID, name string, _ bool) ([]fs.FileInfo, error) {
+	gitserverClient.ReadDirFunc.SetDefaultHook(func(_ context.Context, _ api.RepoName, commit api.CommitID, name string, _ bool) (gitserver.ReadDirIterator, error) {
 		if commit != wantCommitID {
 			t.Errorf("got commit %q, want %q", commit, wantCommitID)
 		}
 		switch name {
 		case "":
-			return []fs.FileInfo{
+			return gitserver.NewReadDirIteratorFromSlice([]fs.FileInfo{
 				&fileutil.FileInfo{Name_: "a", Mode_: os.ModeDir, Sys_: gitObjectInfo("oid-a")},
 				&fileutil.FileInfo{Name_: "b.go", Size_: 12},
-			}, nil
+			}), nil
 		case "a":
-			return []fs.FileInfo{&fileutil.FileInfo{Name_: "a/c.m", Size_: 24}}, nil
+			return gitserver.NewReadDirIteratorFromSlice([]fs.FileInfo{&fileutil.FileInfo{Name_: "a/c.m", Size_: 24}}), nil
 		default:
 			panic("unhandled mock ReadDir " + name)
 		}

--- a/cmd/frontend/graphqlbackend/git_commit_test.go
+++ b/cmd/frontend/graphqlbackend/git_commit_test.go
@@ -291,12 +291,12 @@ func TestGitCommitFileNames(t *testing.T) {
 	}
 	backend.Mocks.Repos.MockGetCommit_Return_NoCheck(t, &gitdomain.Commit{ID: exampleCommitSHA1})
 	gitserverClient := gitserver.NewMockClient()
-	gitserverClient.ReadDirFunc.SetDefaultReturn([]fs.FileInfo{
+	gitserverClient.ReadDirFunc.SetDefaultReturn(gitserver.NewReadDirIteratorFromSlice([]fs.FileInfo{
 		&fileutil.FileInfo{Name_: "a"},
 		&fileutil.FileInfo{Name_: "b"},
 		// We also return a dir to check that it's skipped in the output.
 		&fileutil.FileInfo{Name_: "dir", Mode_: os.ModeDir},
-	}, nil)
+	}), nil)
 	defer func() {
 		backend.Mocks = backend.MockServices{}
 	}()
@@ -340,12 +340,12 @@ func TestGitCommitAncestors(t *testing.T) {
 	backend.Mocks.Repos.MockGetCommit_Return_NoCheck(t, &gitdomain.Commit{ID: exampleCommitSHA1})
 
 	client := gitserver.NewMockClient()
-	client.ReadDirFunc.SetDefaultReturn([]fs.FileInfo{
+	client.ReadDirFunc.SetDefaultReturn(gitserver.NewReadDirIteratorFromSlice([]fs.FileInfo{
 		&fileutil.FileInfo{Name_: "a"},
 		&fileutil.FileInfo{Name_: "b"},
 		// We also return a dir to check that it's skipped in the output.
 		&fileutil.FileInfo{Name_: "dir", Mode_: os.ModeDir},
-	}, nil)
+	}), nil)
 
 	// A linear commit tree:
 	// * -> c1 -> c2 -> c3 -> c4 -> c5 (HEAD)

--- a/cmd/frontend/graphqlbackend/git_tree_test.go
+++ b/cmd/frontend/graphqlbackend/git_tree_test.go
@@ -25,9 +25,9 @@ func TestGitTree_History(t *testing.T) {
 	ctx := context.Background()
 	gs := gitserver.NewMockClientFrom(gitserver.NewTestClient(t))
 	gs.ResolveRevisionFunc.SetDefaultReturn("deadbeef", nil)
-	gs.ReadDirFunc.SetDefaultReturn([]fs.FileInfo{
+	gs.ReadDirFunc.SetDefaultReturn(gitserver.NewReadDirIteratorFromSlice([]fs.FileInfo{
 		&fileutil.FileInfo{Name_: "file1"},
-	}, nil)
+	}), nil)
 	gs.CommitsFunc.SetDefaultReturn([]*gitdomain.Commit{
 		{ID: "deadbeef"},
 	}, nil)
@@ -56,11 +56,11 @@ func TestGitTree_Entries(t *testing.T) {
 
 	wantPath := ""
 
-	gitserverClient.ReadDirFunc.SetDefaultHook(func(ctx context.Context, repo api.RepoName, commit api.CommitID, path string, recursive bool) ([]fs.FileInfo, error) {
+	gitserverClient.ReadDirFunc.SetDefaultHook(func(ctx context.Context, repo api.RepoName, commit api.CommitID, path string, recursive bool) (gitserver.ReadDirIterator, error) {
 		switch path {
 		case "", ".", "/":
 			if recursive {
-				return []fs.FileInfo{
+				return gitserver.NewReadDirIteratorFromSlice([]fs.FileInfo{
 					CreateFileInfo(".aspect/", true),
 					CreateFileInfo(".aspect/rules/", true),
 					CreateFileInfo(".aspect/rules/external_repository_action_cache/", true),
@@ -78,17 +78,17 @@ func TestGitTree_Entries(t *testing.T) {
 					CreateFileInfo("folder2/", true),
 					CreateFileInfo("folder2/file", false),
 					CreateFileInfo("file", false),
-				}, nil
+				}), nil
 			}
-			return []fs.FileInfo{
+			return gitserver.NewReadDirIteratorFromSlice([]fs.FileInfo{
 				CreateFileInfo(".aspect/", true),
 				CreateFileInfo("folder/", true),
 				CreateFileInfo("folder2/", true),
 				CreateFileInfo("file", false),
-			}, nil
+			}), nil
 		case "folder/", "folder":
 			if recursive {
-				return []fs.FileInfo{
+				return gitserver.NewReadDirIteratorFromSlice([]fs.FileInfo{
 					CreateFileInfo("folder/", true),
 					CreateFileInfo("folder/nestedfile", false),
 					CreateFileInfo("folder/subfolder/", true),
@@ -96,16 +96,16 @@ func TestGitTree_Entries(t *testing.T) {
 					CreateFileInfo("folder/subfolder2/", true),
 					CreateFileInfo("folder/subfolder2/file", false),
 					CreateFileInfo("folder/subfolder2/file2", false),
-				}, nil
+				}), nil
 			}
-			return []fs.FileInfo{
+			return gitserver.NewReadDirIteratorFromSlice([]fs.FileInfo{
 				CreateFileInfo("folder/nestedfile", false),
 				CreateFileInfo("folder/subfolder/", true),
 				CreateFileInfo("folder/subfolder2/", true),
-			}, nil
+			}), nil
 		case ".aspect/", ".aspect":
 			if recursive {
-				return []fs.FileInfo{
+				return gitserver.NewReadDirIteratorFromSlice([]fs.FileInfo{
 					CreateFileInfo(".aspect/", true),
 					CreateFileInfo(".aspect/rules/", true),
 					CreateFileInfo(".aspect/rules/external_repository_action_cache/", true),
@@ -113,83 +113,83 @@ func TestGitTree_Entries(t *testing.T) {
 					CreateFileInfo(".aspect/cli/", true),
 					CreateFileInfo(".aspect/cli/file1", false),
 					CreateFileInfo(".aspect/cli/file2", false),
-				}, nil
+				}), nil
 			}
-			return []fs.FileInfo{
+			return gitserver.NewReadDirIteratorFromSlice([]fs.FileInfo{
 				CreateFileInfo(".aspect/rules/", true),
 				CreateFileInfo(".aspect/cli/", true),
-			}, nil
+			}), nil
 		case ".aspect/rules/", ".aspect/rules":
 			if recursive {
-				return []fs.FileInfo{
+				return gitserver.NewReadDirIteratorFromSlice([]fs.FileInfo{
 					CreateFileInfo(".aspect/", true),
 					CreateFileInfo(".aspect/rules/", true),
 					CreateFileInfo(".aspect/rules/external_repository_action_cache/", true),
 					CreateFileInfo(".aspect/rules/external_repository_action_cache/file", false),
-				}, nil
+				}), nil
 			}
-			return []fs.FileInfo{
+			return gitserver.NewReadDirIteratorFromSlice([]fs.FileInfo{
 				CreateFileInfo(".aspect/rules/external_repository_action_cache/", true),
-			}, nil
+			}), nil
 		case ".aspect/rules/external_repository_action_cache/", ".aspect/rules/external_repository_action_cache":
 			if recursive {
-				return []fs.FileInfo{
+				return gitserver.NewReadDirIteratorFromSlice([]fs.FileInfo{
 					CreateFileInfo(".aspect/", true),
 					CreateFileInfo(".aspect/rules/", true),
 					CreateFileInfo(".aspect/rules/external_repository_action_cache/", true),
 					CreateFileInfo(".aspect/rules/external_repository_action_cache/file", false),
-				}, nil
+				}), nil
 			}
-			return []fs.FileInfo{
+			return gitserver.NewReadDirIteratorFromSlice([]fs.FileInfo{
 				CreateFileInfo(".aspect/rules/external_repository_action_cache/file", false),
-			}, nil
+			}), nil
 		case ".aspect/cli/", ".aspect/cli":
 			if recursive {
-				return []fs.FileInfo{
+				return gitserver.NewReadDirIteratorFromSlice([]fs.FileInfo{
 					CreateFileInfo(".aspect/", true),
 					CreateFileInfo(".aspect/cli/", true),
 					CreateFileInfo(".aspect/cli/file1", false),
 					CreateFileInfo(".aspect/cli/file2", false),
-				}, nil
+				}), nil
 			}
-			return []fs.FileInfo{
+			return gitserver.NewReadDirIteratorFromSlice([]fs.FileInfo{
 				CreateFileInfo(".aspect/cli/file1", false),
 				CreateFileInfo(".aspect/cli/file2", false),
-			}, nil
+			}), nil
 		case "folder/subfolder/", "folder/subfolder":
 			if recursive {
-				return []fs.FileInfo{
+				return gitserver.NewReadDirIteratorFromSlice([]fs.FileInfo{
 					CreateFileInfo("folder/", true),
 					CreateFileInfo("folder/subfolder/", true),
 					CreateFileInfo("folder/subfolder/deeplynestedfile", false),
-				}, nil
+				}), nil
 			}
-			return []fs.FileInfo{
+			return gitserver.NewReadDirIteratorFromSlice([]fs.FileInfo{
 				CreateFileInfo("folder/subfolder/deeplynestedfile", false),
-			}, nil
+			}), nil
 		case "folder/subfolder2/", "folder/subfolder2":
 			if recursive {
-				return []fs.FileInfo{
+				return gitserver.NewReadDirIteratorFromSlice([]fs.FileInfo{
 					CreateFileInfo("folder/", true),
 					CreateFileInfo("folder/subfolder2/", true),
 					CreateFileInfo("folder/subfolder2/file", false),
 					CreateFileInfo("folder/subfolder2/file2", false),
-				}, nil
+				}), nil
 			}
-			return []fs.FileInfo{
+			return gitserver.NewReadDirIteratorFromSlice([]fs.FileInfo{
 				CreateFileInfo("folder/subfolder2/file", false),
 				CreateFileInfo("folder/subfolder2/file2", false),
-			}, nil
+			}), nil
 		case "folder2/", "folder2":
 			if recursive {
-				return []fs.FileInfo{
+				return gitserver.NewReadDirIteratorFromSlice([]fs.FileInfo{
 					CreateFileInfo("folder2/", true),
 					CreateFileInfo("folder2/file", false),
-				}, nil
+				}), nil
 			}
-			return []fs.FileInfo{
+			return gitserver.NewReadDirIteratorFromSlice([]fs.FileInfo{
 				CreateFileInfo("folder2/file", false),
-			}, nil
+			}), nil
 		default:
 			return nil, errors.Newf("bad argument %q", path)
 		}
@@ -443,16 +443,16 @@ func TestGitTree(t *testing.T) {
 func setupGitserverClient(t *testing.T) gitserver.Client {
 	t.Helper()
 	gsClient := gitserver.NewMockClient()
-	gsClient.ReadDirFunc.SetDefaultHook(func(_ context.Context, _ api.RepoName, commit api.CommitID, name string, recurse bool) ([]fs.FileInfo, error) {
+	gsClient.ReadDirFunc.SetDefaultHook(func(_ context.Context, _ api.RepoName, commit api.CommitID, name string, recurse bool) (gitserver.ReadDirIterator, error) {
 		assert.Equal(t, api.CommitID(exampleCommitSHA1), commit)
 		assert.Equal(t, "foo bar", name)
 		assert.False(t, recurse)
-		return []fs.FileInfo{
+		return gitserver.NewReadDirIteratorFromSlice([]fs.FileInfo{
 			&fileutil.FileInfo{Name_: name + "/testDirectory", Mode_: os.ModeDir},
 			&fileutil.FileInfo{Name_: name + "/Geoffrey's random queries.32r242442bf", Mode_: os.ModeDir},
 			&fileutil.FileInfo{Name_: name + "/testFile", Mode_: 0},
 			&fileutil.FileInfo{Name_: name + "/% token.4288249258.sql", Mode_: 0},
-		}, nil
+		}), nil
 	})
 	gsClient.StatFunc.SetDefaultHook(func(_ context.Context, _ api.RepoName, commit api.CommitID, path string) (fs.FileInfo, error) {
 		assert.Equal(t, api.CommitID(exampleCommitSHA1), commit)

--- a/cmd/frontend/graphqlbackend/search_results_stats_languages_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_stats_languages_test.go
@@ -109,8 +109,8 @@ func TestSearchResultsStatsLanguages(t *testing.T) {
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			gsClient.ReadDirFunc.SetDefaultHook(func(context.Context, api.RepoName, api.CommitID, string, bool) ([]fs.FileInfo, error) {
-				return test.getFiles, nil
+			gsClient.ReadDirFunc.SetDefaultHook(func(context.Context, api.RepoName, api.CommitID, string, bool) (gitserver.ReadDirIterator, error) {
+				return gitserver.NewReadDirIteratorFromSlice(test.getFiles), nil
 			})
 
 			langs, err := searchResultsStatsLanguages(context.Background(), logger, dbmocks.NewMockDB(), gsClient, test.results)

--- a/cmd/frontend/internal/app/ui/raw_test.go
+++ b/cmd/frontend/internal/app/ui/raw_test.go
@@ -281,12 +281,12 @@ func Test_serveRawWithContentTypePlain(t *testing.T) {
 
 		gsClient := gitserver.NewMockClient()
 		gsClient.StatFunc.SetDefaultReturn(&fileutil.FileInfo{Mode_: os.ModeDir}, nil)
-		gsClient.ReadDirFunc.SetDefaultHook(func(context.Context, api.RepoName, api.CommitID, string, bool) ([]fs.FileInfo, error) {
-			return []fs.FileInfo{
+		gsClient.ReadDirFunc.SetDefaultHook(func(context.Context, api.RepoName, api.CommitID, string, bool) (gitserver.ReadDirIterator, error) {
+			return gitserver.NewReadDirIteratorFromSlice([]fs.FileInfo{
 				&fileutil.FileInfo{Name_: "test/a", Mode_: os.ModeDir},
 				&fileutil.FileInfo{Name_: "test/b", Mode_: os.ModeDir},
 				&fileutil.FileInfo{Name_: "c.go", Mode_: 0},
-			}, nil
+			}), nil
 		})
 
 		req := httptest.NewRequest("GET", "/github.com/sourcegraph/sourcegraph/-/raw", nil)

--- a/cmd/worker/internal/embeddings/repo/handler_test.go
+++ b/cmd/worker/internal/embeddings/repo/handler_test.go
@@ -32,8 +32,8 @@ func TestDiff(t *testing.T) {
 	})
 
 	readDirFunc := &gitserver.ClientReadDirFunc{}
-	readDirFunc.SetDefaultHook(func(context.Context, api.RepoName, api.CommitID, string, bool) ([]fs.FileInfo, error) {
-		return []fs.FileInfo{
+	readDirFunc.SetDefaultHook(func(context.Context, api.RepoName, api.CommitID, string, bool) (gitserver.ReadDirIterator, error) {
+		return gitserver.NewReadDirIteratorFromSlice([]fs.FileInfo{
 			FakeFileInfo{
 				name: "modifiedFile",
 				size: 900,
@@ -50,7 +50,7 @@ func TestDiff(t *testing.T) {
 				name: "anotherFile",
 				size: 1200,
 			},
-		}, nil
+		}), nil
 	})
 
 	mockGitServer := &gitserver.MockClient{

--- a/internal/batches/sources/mocks_test.go
+++ b/internal/batches/sources/mocks_test.go
@@ -11225,7 +11225,7 @@ func NewMockGitserverClient() *MockGitserverClient {
 			},
 		},
 		ReadDirFunc: &GitserverClientReadDirFunc{
-			defaultHook: func(context.Context, api.RepoName, api.CommitID, string, bool) (r0 []fs.FileInfo, r1 error) {
+			defaultHook: func(context.Context, api.RepoName, api.CommitID, string, bool) (r0 gitserver.ReadDirIterator, r1 error) {
 				return
 			},
 		},
@@ -11412,7 +11412,7 @@ func NewStrictMockGitserverClient() *MockGitserverClient {
 			},
 		},
 		ReadDirFunc: &GitserverClientReadDirFunc{
-			defaultHook: func(context.Context, api.RepoName, api.CommitID, string, bool) ([]fs.FileInfo, error) {
+			defaultHook: func(context.Context, api.RepoName, api.CommitID, string, bool) (gitserver.ReadDirIterator, error) {
 				panic("unexpected invocation of MockGitserverClient.ReadDir")
 			},
 		},
@@ -14497,15 +14497,15 @@ func (c GitserverClientPerforceUsersFuncCall) Results() []interface{} {
 // GitserverClientReadDirFunc describes the behavior when the ReadDir method
 // of the parent MockGitserverClient instance is invoked.
 type GitserverClientReadDirFunc struct {
-	defaultHook func(context.Context, api.RepoName, api.CommitID, string, bool) ([]fs.FileInfo, error)
-	hooks       []func(context.Context, api.RepoName, api.CommitID, string, bool) ([]fs.FileInfo, error)
+	defaultHook func(context.Context, api.RepoName, api.CommitID, string, bool) (gitserver.ReadDirIterator, error)
+	hooks       []func(context.Context, api.RepoName, api.CommitID, string, bool) (gitserver.ReadDirIterator, error)
 	history     []GitserverClientReadDirFuncCall
 	mutex       sync.Mutex
 }
 
 // ReadDir delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockGitserverClient) ReadDir(v0 context.Context, v1 api.RepoName, v2 api.CommitID, v3 string, v4 bool) ([]fs.FileInfo, error) {
+func (m *MockGitserverClient) ReadDir(v0 context.Context, v1 api.RepoName, v2 api.CommitID, v3 string, v4 bool) (gitserver.ReadDirIterator, error) {
 	r0, r1 := m.ReadDirFunc.nextHook()(v0, v1, v2, v3, v4)
 	m.ReadDirFunc.appendCall(GitserverClientReadDirFuncCall{v0, v1, v2, v3, v4, r0, r1})
 	return r0, r1
@@ -14514,7 +14514,7 @@ func (m *MockGitserverClient) ReadDir(v0 context.Context, v1 api.RepoName, v2 ap
 // SetDefaultHook sets function that is called when the ReadDir method of
 // the parent MockGitserverClient instance is invoked and the hook queue is
 // empty.
-func (f *GitserverClientReadDirFunc) SetDefaultHook(hook func(context.Context, api.RepoName, api.CommitID, string, bool) ([]fs.FileInfo, error)) {
+func (f *GitserverClientReadDirFunc) SetDefaultHook(hook func(context.Context, api.RepoName, api.CommitID, string, bool) (gitserver.ReadDirIterator, error)) {
 	f.defaultHook = hook
 }
 
@@ -14522,7 +14522,7 @@ func (f *GitserverClientReadDirFunc) SetDefaultHook(hook func(context.Context, a
 // ReadDir method of the parent MockGitserverClient instance invokes the
 // hook at the front of the queue and discards it. After the queue is empty,
 // the default hook function is invoked for any future action.
-func (f *GitserverClientReadDirFunc) PushHook(hook func(context.Context, api.RepoName, api.CommitID, string, bool) ([]fs.FileInfo, error)) {
+func (f *GitserverClientReadDirFunc) PushHook(hook func(context.Context, api.RepoName, api.CommitID, string, bool) (gitserver.ReadDirIterator, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -14530,20 +14530,20 @@ func (f *GitserverClientReadDirFunc) PushHook(hook func(context.Context, api.Rep
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *GitserverClientReadDirFunc) SetDefaultReturn(r0 []fs.FileInfo, r1 error) {
-	f.SetDefaultHook(func(context.Context, api.RepoName, api.CommitID, string, bool) ([]fs.FileInfo, error) {
+func (f *GitserverClientReadDirFunc) SetDefaultReturn(r0 gitserver.ReadDirIterator, r1 error) {
+	f.SetDefaultHook(func(context.Context, api.RepoName, api.CommitID, string, bool) (gitserver.ReadDirIterator, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *GitserverClientReadDirFunc) PushReturn(r0 []fs.FileInfo, r1 error) {
-	f.PushHook(func(context.Context, api.RepoName, api.CommitID, string, bool) ([]fs.FileInfo, error) {
+func (f *GitserverClientReadDirFunc) PushReturn(r0 gitserver.ReadDirIterator, r1 error) {
+	f.PushHook(func(context.Context, api.RepoName, api.CommitID, string, bool) (gitserver.ReadDirIterator, error) {
 		return r0, r1
 	})
 }
 
-func (f *GitserverClientReadDirFunc) nextHook() func(context.Context, api.RepoName, api.CommitID, string, bool) ([]fs.FileInfo, error) {
+func (f *GitserverClientReadDirFunc) nextHook() func(context.Context, api.RepoName, api.CommitID, string, bool) (gitserver.ReadDirIterator, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -14593,7 +14593,7 @@ type GitserverClientReadDirFuncCall struct {
 	Arg4 bool
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 []fs.FileInfo
+	Result0 gitserver.ReadDirIterator
 	// Result1 is the value of the 2nd result returned from this method
 	// invocation.
 	Result1 error

--- a/internal/gitserver/mocks_temp.go
+++ b/internal/gitserver/mocks_temp.go
@@ -269,7 +269,7 @@ func NewMockClient() *MockClient {
 			},
 		},
 		ReadDirFunc: &ClientReadDirFunc{
-			defaultHook: func(context.Context, api.RepoName, api.CommitID, string, bool) (r0 []fs.FileInfo, r1 error) {
+			defaultHook: func(context.Context, api.RepoName, api.CommitID, string, bool) (r0 ReadDirIterator, r1 error) {
 				return
 			},
 		},
@@ -456,7 +456,7 @@ func NewStrictMockClient() *MockClient {
 			},
 		},
 		ReadDirFunc: &ClientReadDirFunc{
-			defaultHook: func(context.Context, api.RepoName, api.CommitID, string, bool) ([]fs.FileInfo, error) {
+			defaultHook: func(context.Context, api.RepoName, api.CommitID, string, bool) (ReadDirIterator, error) {
 				panic("unexpected invocation of MockClient.ReadDir")
 			},
 		},
@@ -3489,15 +3489,15 @@ func (c ClientPerforceUsersFuncCall) Results() []interface{} {
 // ClientReadDirFunc describes the behavior when the ReadDir method of the
 // parent MockClient instance is invoked.
 type ClientReadDirFunc struct {
-	defaultHook func(context.Context, api.RepoName, api.CommitID, string, bool) ([]fs.FileInfo, error)
-	hooks       []func(context.Context, api.RepoName, api.CommitID, string, bool) ([]fs.FileInfo, error)
+	defaultHook func(context.Context, api.RepoName, api.CommitID, string, bool) (ReadDirIterator, error)
+	hooks       []func(context.Context, api.RepoName, api.CommitID, string, bool) (ReadDirIterator, error)
 	history     []ClientReadDirFuncCall
 	mutex       sync.Mutex
 }
 
 // ReadDir delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockClient) ReadDir(v0 context.Context, v1 api.RepoName, v2 api.CommitID, v3 string, v4 bool) ([]fs.FileInfo, error) {
+func (m *MockClient) ReadDir(v0 context.Context, v1 api.RepoName, v2 api.CommitID, v3 string, v4 bool) (ReadDirIterator, error) {
 	r0, r1 := m.ReadDirFunc.nextHook()(v0, v1, v2, v3, v4)
 	m.ReadDirFunc.appendCall(ClientReadDirFuncCall{v0, v1, v2, v3, v4, r0, r1})
 	return r0, r1
@@ -3505,7 +3505,7 @@ func (m *MockClient) ReadDir(v0 context.Context, v1 api.RepoName, v2 api.CommitI
 
 // SetDefaultHook sets function that is called when the ReadDir method of
 // the parent MockClient instance is invoked and the hook queue is empty.
-func (f *ClientReadDirFunc) SetDefaultHook(hook func(context.Context, api.RepoName, api.CommitID, string, bool) ([]fs.FileInfo, error)) {
+func (f *ClientReadDirFunc) SetDefaultHook(hook func(context.Context, api.RepoName, api.CommitID, string, bool) (ReadDirIterator, error)) {
 	f.defaultHook = hook
 }
 
@@ -3513,7 +3513,7 @@ func (f *ClientReadDirFunc) SetDefaultHook(hook func(context.Context, api.RepoNa
 // ReadDir method of the parent MockClient instance invokes the hook at the
 // front of the queue and discards it. After the queue is empty, the default
 // hook function is invoked for any future action.
-func (f *ClientReadDirFunc) PushHook(hook func(context.Context, api.RepoName, api.CommitID, string, bool) ([]fs.FileInfo, error)) {
+func (f *ClientReadDirFunc) PushHook(hook func(context.Context, api.RepoName, api.CommitID, string, bool) (ReadDirIterator, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -3521,20 +3521,20 @@ func (f *ClientReadDirFunc) PushHook(hook func(context.Context, api.RepoName, ap
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *ClientReadDirFunc) SetDefaultReturn(r0 []fs.FileInfo, r1 error) {
-	f.SetDefaultHook(func(context.Context, api.RepoName, api.CommitID, string, bool) ([]fs.FileInfo, error) {
+func (f *ClientReadDirFunc) SetDefaultReturn(r0 ReadDirIterator, r1 error) {
+	f.SetDefaultHook(func(context.Context, api.RepoName, api.CommitID, string, bool) (ReadDirIterator, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *ClientReadDirFunc) PushReturn(r0 []fs.FileInfo, r1 error) {
-	f.PushHook(func(context.Context, api.RepoName, api.CommitID, string, bool) ([]fs.FileInfo, error) {
+func (f *ClientReadDirFunc) PushReturn(r0 ReadDirIterator, r1 error) {
+	f.PushHook(func(context.Context, api.RepoName, api.CommitID, string, bool) (ReadDirIterator, error) {
 		return r0, r1
 	})
 }
 
-func (f *ClientReadDirFunc) nextHook() func(context.Context, api.RepoName, api.CommitID, string, bool) ([]fs.FileInfo, error) {
+func (f *ClientReadDirFunc) nextHook() func(context.Context, api.RepoName, api.CommitID, string, bool) (ReadDirIterator, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -3584,7 +3584,7 @@ type ClientReadDirFuncCall struct {
 	Arg4 bool
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 []fs.FileInfo
+	Result0 ReadDirIterator
 	// Result1 is the value of the 2nd result returned from this method
 	// invocation.
 	Result1 error

--- a/internal/own/background/analytics_test.go
+++ b/internal/own/background/analytics_test.go
@@ -30,14 +30,14 @@ type fakeGitServer struct {
 	fileContents map[string]string
 }
 
-func (f fakeGitServer) ReadDir(ctx context.Context, repo api.RepoName, commit api.CommitID, path string, recursive bool) ([]fs.FileInfo, error) {
+func (f fakeGitServer) ReadDir(ctx context.Context, repo api.RepoName, commit api.CommitID, path string, recursive bool) (gitserver.ReadDirIterator, error) {
 	fis := make([]fs.FileInfo, 0, len(f.files))
 	for _, file := range f.files {
 		fis = append(fis, &fileutil.FileInfo{
 			Name_: file,
 		})
 	}
-	return fis, nil
+	return gitserver.NewReadDirIteratorFromSlice(fis), nil
 }
 
 func (f fakeGitServer) ResolveRevision(ctx context.Context, repo api.RepoName, spec string, opt gitserver.ResolveRevisionOptions) (api.CommitID, error) {


### PR DESCRIPTION
There is potentially a lot of FDs in a repo, so we return an iterator instead to encourage callers to consume it one by one and not load all of it into memory.

Test plan:

Existing tests still pass.