### PR TITLE
msp: centralize and expose locations configuration

### DIFF
--- a/dev/managedservicesplatform/internal/resource/bigquery/bigquery.go
+++ b/dev/managedservicesplatform/internal/resource/bigquery/bigquery.go
@@ -31,7 +31,8 @@ type Config struct {
 
 	WorkloadServiceAccount *serviceaccount.Output
 
-	Spec spec.EnvironmentResourceBigQueryDatasetSpec
+	Spec      spec.EnvironmentResourceBigQueryDatasetSpec
+	Locations spec.EnvironmentLocationsSpec
 
 	// PreventDestroys indicates if destroys should be allowed on core components of
 	// this resource.
@@ -44,7 +45,7 @@ func New(scope constructs.Construct, id resourceid.ID, config Config) (*Output, 
 		datasetID = config.Spec.GetDatasetID(config.ServiceID)
 		projectID = pointers.Deref(config.Spec.ProjectID,
 			config.DefaultProjectID)
-		location = pointers.Deref(config.Spec.Location, "US")
+		location = config.Locations.GCPLocation
 		labels   = map[string]*string{
 			"service": &config.ServiceID,
 		}

--- a/dev/managedservicesplatform/operationdocs/operationdocs.go
+++ b/dev/managedservicesplatform/operationdocs/operationdocs.go
@@ -122,15 +122,21 @@ This service is operated on the %s.`,
 
 	if s.Rollout != nil {
 		md.Headingf(1, "Rollouts")
-		region := "us-central1"
-		var rolloutDetails []string
-		// Get final stage to generate pipeline url
-		finalStageEnv := s.Rollout.Stages[len(s.Rollout.Stages)-1].EnvironmentID
-		finalStageProject := s.GetEnvironment(finalStageEnv).ProjectID
-		rolloutDetails = append(rolloutDetails,
-			"Delivery pipeline: "+markdown.Linkf(fmt.Sprintf("`%s-%s-rollout`", s.Service.ID, region),
-				"https://console.cloud.google.com/deploy/delivery-pipelines/%[1]s/%[2]s-%[1]s-rollout?project=%[3]s", region, s.Service.ID, finalStageProject))
+		var (
+			rolloutDetails    []string
+			finalStageEnvID   = s.Rollout.Stages[len(s.Rollout.Stages)-1].EnvironmentID
+			finalStageEnv     = s.GetEnvironment(finalStageEnvID)
+			finalStageProject = finalStageEnv.ProjectID
+			finalStageRegion  = finalStageEnv.GetLocationSpec().GCPRegion
+		)
 
+		// use the final stage to generate pipeline url
+		rolloutDetails = append(rolloutDetails,
+			"Delivery pipeline: "+markdown.Linkf(fmt.Sprintf("`%s-%s-rollout`", s.Service.ID, finalStageRegion),
+				"https://console.cloud.google.com/deploy/delivery-pipelines/%[1]s/%[2]s-%[1]s-rollout?project=%[3]s",
+				finalStageRegion, s.Service.ID, finalStageProject))
+
+		// Generate a list of each stage environment
 		var stages []string
 		for _, stage := range s.Rollout.Stages {
 			envIndex := slices.IndexFunc(environmentHeaders, func(env environmentHeader) bool {

--- a/dev/managedservicesplatform/stacks/cloudrun/cloudrun.go
+++ b/dev/managedservicesplatform/stacks/cloudrun/cloudrun.go
@@ -89,12 +89,6 @@ const (
 	ScaffoldSourceFile = "skaffoldsource.tar.gz"
 )
 
-// Hardcoded variables.
-var (
-	// GCPRegion is currently hardcoded.
-	GCPRegion = "us-central1"
-)
-
 const tfVarKeyResolvedImageTag = "resolved_image_tag"
 
 const SentryOrganization = "sourcegraph"
@@ -121,6 +115,9 @@ func NewStack(stacks *stack.Set, vars Variables) (crossStackOutput *CrossStackOu
 	if err != nil {
 		return nil, err
 	}
+
+	// Resource locationSpec configuration
+	locationSpec := vars.Environment.GetLocationSpec()
 
 	diagnosticsSecret := random.New(stack, resourceid.New("diagnostics-secret"), random.Config{
 		ByteLength: 8,
@@ -180,7 +177,7 @@ func NewStack(stacks *stack.Set, vars Variables) (crossStackOutput *CrossStackOu
 		return privatenetwork.New(stack, resourceid.New("privatenetwork"), privatenetwork.Config{
 			ProjectID: vars.ProjectID,
 			ServiceID: vars.Service.ID,
-			Region:    GCPRegion,
+			Region:    locationSpec.GCPRegion,
 		})
 	})
 
@@ -200,7 +197,7 @@ func NewStack(stacks *stack.Set, vars Variables) (crossStackOutput *CrossStackOu
 			resourceid.New("redis"),
 			redis.Config{
 				ProjectID: vars.ProjectID,
-				Region:    GCPRegion,
+				Region:    locationSpec.GCPRegion,
 				Spec:      *vars.Environment.Resources.Redis,
 				Network:   privateNetwork().Network,
 			})
@@ -233,7 +230,7 @@ func NewStack(stacks *stack.Set, vars Variables) (crossStackOutput *CrossStackOu
 		pgSpec := *vars.Environment.Resources.PostgreSQL
 		sqlInstance, err := cloudsql.New(stack, resourceid.New("postgresql"), cloudsql.Config{
 			ProjectID: vars.ProjectID,
-			Region:    GCPRegion,
+			Region:    locationSpec.GCPRegion,
 			Spec:      pgSpec,
 			Network:   privateNetwork().Network,
 
@@ -288,6 +285,7 @@ func NewStack(stacks *stack.Set, vars Variables) (crossStackOutput *CrossStackOu
 			ServiceID:              vars.Service.ID,
 			WorkloadServiceAccount: vars.IAM.CloudRunWorkloadServiceAccount,
 			Spec:                   *vars.Environment.Resources.BigQueryDataset,
+			Locations:              locationSpec,
 			PreventDestroys:        vars.PreventDestroys,
 		})
 		if err != nil {
@@ -350,7 +348,7 @@ func NewStack(stacks *stack.Set, vars Variables) (crossStackOutput *CrossStackOu
 		ResolvedImageTag:  *imageTag.StringValue,
 		Environment:       vars.Environment,
 		GCPProjectID:      vars.ProjectID,
-		GCPRegion:         GCPRegion,
+		GCPRegion:         locationSpec.GCPRegion,
 		ServiceAccount:    vars.IAM.CloudRunWorkloadServiceAccount,
 		DiagnosticsSecret: diagnosticsSecret,
 		ResourceLimits:    makeContainerResourceLimits(vars.Environment.Instances.Resources),
@@ -375,7 +373,11 @@ func NewStack(stacks *stack.Set, vars Variables) (crossStackOutput *CrossStackOu
 		// pipelines for each. In particular, see https://registry.terraform.io/providers/hashicorp/google/5.10.0/docs/resources/clouddeploy_delivery_pipeline#target_id:
 		//
 		// > The location of the Target is inferred to be the same as the location of the DeliveryPipeline that contains this Stage.
-		var rolloutLocation = GCPRegion
+		//
+		// Updated note: in theory we can change this since we now use a custom
+		// rollout target, but in may be good practice to keep separate regions
+		// separated.
+		var rolloutLocation = locationSpec.GCPRegion
 
 		// stageTargets enumerate stages in order. Cloud Deploy targets are
 		// created separately because the TF provider doesn't support Custom
@@ -433,7 +435,7 @@ func NewStack(stacks *stack.Set, vars Variables) (crossStackOutput *CrossStackOu
 		// locally.
 		skaffoldBucket := storagebucket.NewStorageBucket(stack, id.Group("skaffold").TerraformID("bucket"), &storagebucket.StorageBucketConfig{
 			Name:     pointers.Stringf("%s-cloudrun-skaffold", vars.ProjectID),
-			Location: &GCPRegion,
+			Location: &rolloutLocation,
 		})
 		_ = storagebucketobject.NewStorageBucketObject(stack, id.Group("skaffold").TerraformID("object"), &storagebucketobject.StorageBucketObjectConfig{
 			Name:        pointers.Ptr("source.tar.gz"),
@@ -446,7 +448,7 @@ func NewStack(stacks *stack.Set, vars Variables) (crossStackOutput *CrossStackOu
 		// We manually create it so we can provision IAM access
 		pipelineBucket := storagebucket.NewStorageBucket(stack, id.Group("pipeline").TerraformID("bucket"), &storagebucket.StorageBucketConfig{
 			Name:     pointers.Stringf("%s_clouddeploy", deliveryPipeline.PipelineID),
-			Location: &GCPRegion,
+			Location: &rolloutLocation,
 		})
 
 		// Provision Service Account IAM to create releases

--- a/dev/sg/msp/helpers.go
+++ b/dev/sg/msp/helpers.go
@@ -269,7 +269,7 @@ func generateTerraform(service *spec.Spec, opts generateTerraformOptions) error 
 			// additional configuration for the rollout pipeline that we can't
 			// yet provide with Terraform. In the future, we can hopefully
 			// replace this with a pure-Terraform version.
-			region := cloudrun.GCPRegion // region is currently fixed
+			region := env.GetLocationSpec().GCPRegion
 			deploySpec, err := clouddeploy.RenderSpec(
 				service.Service,
 				service.Build,


### PR DESCRIPTION
This change adds a `locations: { gcpRegion: "...", gcpLocation: "..." }` configuration to centralize all location-related options. `gcpRegion` specifies regional preferences, while `gcpLocation` specifies multi-regional preferences (for resources that support it - only BigQuery in most cases).

Closes CORE-24 - see issue for some context.

## Test plan

```
sg msp generate -all # no diff
```

```
sg msp schema -output='../managed-services/schema/service.schema.json'
```