### PR TITLE
Web: small style fix for jupyter notebooks

### DIFF
--- a/client/wildcard/src/global-styles/jupyter.scss
+++ b/client/wildcard/src/global-styles/jupyter.scss
@@ -190,6 +190,7 @@
     .jp-OutputArea-prompt {
         display: table-cell;
         vertical-align: top;
+        width: var(--jp-cell-prompt-width);
     }
 
     .jp-OutputArea-output {


### PR DESCRIPTION
This is just a quick followup from https://github.com/sourcegraph/sourcegraph/pull/62583 that reserves the right amount of space for cell outputs.

There is likely a second style pass we should take on this whole thing, but this one in particular is something I'd go as far as to consider a bug. 


## Test plan

Before: 
![screenshot-2024-05-10_17-41-38@2x](https://github.com/sourcegraph/sourcegraph/assets/12631702/d66254cc-8118-4e14-8327-5f2eba12a90d)

After:
![screenshot-2024-05-10_17-41-26@2x](https://github.com/sourcegraph/sourcegraph/assets/12631702/b0a2d72d-4946-4f7d-b4a2-e5393dea4e09)

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
