### PR TITLE
Fixup parseDirectoryChildren replacement

### DIFF
--- a/internal/codeintel/uploads/internal/background/processor/job_worker_handler.go
+++ b/internal/codeintel/uploads/internal/background/processor/job_worker_handler.go
@@ -226,6 +226,11 @@ func (h *handler) HandleRawUpload(ctx context.Context, logger log.Logger, upload
 		for _, d := range dirnames {
 			fds, err := h.gitserverClient.ReadDir(ctx, repo.Name, api.CommitID(upload.Commit), d, false)
 			if err != nil {
+				// Ignore non-existent directories, we request all directories in the
+				// upload and some might not exist in the repo, for example node_modules.
+				if os.IsNotExist(err) {
+					continue
+				}
 				return nil, errors.Wrap(err, "gitserverClient.ReadDir")
 			}
 			for _, fd := range fds {


### PR DESCRIPTION
The old implementation skipped over directory names that aren't known, because `git ls-tree` doesn't complain for unknown directories.
This PR restores this behavior.

Test plan:

Will check that sentry errors no longer occur.