### PR TITLE
gitserver: Move repo timestamp updates to caller

### DIFF
--- a/cmd/gitserver/internal/ensurerevision.go
+++ b/cmd/gitserver/internal/ensurerevision.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 )
 
 var (
@@ -32,7 +33,7 @@ func (s *Server) EnsureRevision(ctx context.Context, repo api.RepoName, rev stri
 	}
 
 	// Revision not found, update before returning.
-	_, _, err := s.FetchRepository(ctx, repo)
+	lastFetched, lastChanged, err := s.FetchRepository(ctx, repo)
 	if err != nil {
 		if ctx.Err() == nil {
 			ensureRevisionCounter.WithLabelValues("update_failed").Inc()
@@ -40,6 +41,12 @@ func (s *Server) EnsureRevision(ctx context.Context, repo api.RepoName, rev stri
 		s.logger.Warn("failed to perform background repo update", log.Error(err), log.String("repo", string(repo)), log.String("rev", rev))
 		// TODO: Shouldn't we return false here?
 	} else {
+		if err := s.db.GitserverRepos().SetLastFetched(ctx, repo, database.GitserverFetchData{
+			LastFetched: lastFetched,
+			LastChanged: lastChanged,
+		}); err != nil {
+			s.logger.Error("failed to store repo update timestamps", log.Error(err))
+		}
 		ensureRevisionCounter.WithLabelValues("updated").Inc()
 	}
 	return true

--- a/cmd/repo-updater/internal/scheduler/scheduler.go
+++ b/cmd/repo-updater/internal/scheduler/scheduler.go
@@ -195,6 +195,15 @@ func (s *UpdateScheduler) runUpdateLoop(ctx context.Context) {
 							subLogger.Error("error updating repo", log.Error(err), log.String("uri", string(repo.Name)))
 						}
 					}
+				} else {
+					// If the update succeeded, store the latest values for last_fetched
+					// and last_changed in the database.
+					if err := s.db.GitserverRepos().SetLastFetched(ctx, repo.Name, database.GitserverFetchData{
+						LastFetched: lastFetched,
+						LastChanged: lastChanged,
+					}); err != nil {
+						subLogger.Error("failed to store repo update timestamps", log.Error(err))
+					}
 				}
 
 				if interval := getCustomInterval(subLogger, conf.Get(), string(repo.Name)); interval > 0 {

--- a/cmd/repo-updater/internal/scheduler/scheduler_test.go
+++ b/cmd/repo-updater/internal/scheduler/scheduler_test.go
@@ -1422,6 +1422,7 @@ func TestUpdateScheduler_runUpdateLoop(t *testing.T) {
 
 			contexts := make(chan context.Context, expectedRequestCount)
 			db := dbmocks.NewMockDB()
+			db.GitserverReposFunc.SetDefaultReturn(dbmocks.NewMockGitserverRepoStore())
 			gs := gitserver.NewMockRepositoryServiceClient()
 			gs.FetchRepositoryFunc.SetDefaultHook(func(ctx context.Context, repo api.RepoName) (time.Time, time.Time, error) {
 				select {

--- a/internal/database/gitserver_repos.go
+++ b/internal/database/gitserver_repos.go
@@ -616,8 +616,6 @@ type GitserverFetchData struct {
 	LastFetched time.Time
 	// LastChanged was the last time a fetch changed the contents of the repo (gitserver_repos.last_changed).
 	LastChanged time.Time
-	// ShardID is the name of the gitserver the fetch ran on (gitserver.shard_id).
-	ShardID string
 }
 
 func (s *gitserverRepoStore) SetLastFetched(ctx context.Context, name api.RepoName, data GitserverFetchData) error {
@@ -627,11 +625,10 @@ SET
 	corrupted_at = NULL,
 	last_fetched = %s,
 	last_changed = %s,
-	shard_id = %s,
 	clone_status = %s,
 	updated_at = NOW()
 WHERE repo_id = (SELECT id FROM repo WHERE name = %s)
-`, data.LastFetched, data.LastChanged, data.ShardID, types.CloneStatusCloned, name))
+`, data.LastFetched, data.LastChanged, types.CloneStatusCloned, name))
 	if err != nil {
 		return errors.Wrap(err, "setting last fetched")
 	}


### PR DESCRIPTION
This is a small step towards making gitserver itself less dependent on Sourcegraph concepts like the database, by making the repo-updater scheduler (later, this can be coordinator) write to the DB instead.

Note: Until we decide what to do with ensurerevision which schedules out-of-band updates that affect concurrency and the control flow, I decided to inline this behavior there to make it very explicit.

Test plan:

Existing tests are still passing.