### PR TITLE
gitserver: Implement LatestCommitTimestamp in backend

### DIFF
--- a/cmd/gitserver/internal/git/gitcli/BUILD.bazel
+++ b/cmd/gitserver/internal/git/gitcli/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
         "blame.go",
         "clibackend.go",
         "command.go",
+        "commits.go",
         "config.go",
         "contributors.go",
         "diff.go",
@@ -53,6 +54,7 @@ go_test(
     srcs = [
         "archivereader_test.go",
         "blame_test.go",
+        "commits_test.go",
         "config_test.go",
         "contributors_test.go",
         "diff_test.go",

--- a/cmd/gitserver/internal/git/gitcli/commits.go
+++ b/cmd/gitserver/internal/git/gitcli/commits.go
@@ -1,0 +1,50 @@
+package gitcli
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"strconv"
+	"time"
+
+	"github.com/sourcegraph/log"
+
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+func (g *gitCLIBackend) LatestCommitTimestamp(ctx context.Context) (time.Time, error) {
+	r, err := g.NewCommand(ctx, WithArguments("rev-list", "--all", "--timestamp", "-n", "1"))
+	if err != nil {
+		return time.Time{}, err
+	}
+
+	stdout, err := io.ReadAll(r)
+	err = errors.Append(err, r.Close())
+	if err != nil {
+		return time.Time{}, err
+	}
+
+	now := time.Now().UTC()
+
+	words := bytes.Split(bytes.TrimSpace(stdout), []byte(" "))
+	// An empty rev-list output, without an error, is okay. This is probably just
+	// an empty repository.
+	if len(words) < 2 {
+		return now, nil
+	}
+
+	// We should have a timestamp and a commit hash; format is
+	// 1521316105 ff03fac223b7f16627b301e03bf604e7808989be
+	epoch, err := strconv.ParseInt(string(words[0]), 10, 64)
+	if err != nil {
+		g.logger.Warn("failed to parse LatestCommitTimestamp", log.String("output", string(stdout)))
+		// If the timestamp can't be parsed, we just return time.Now().
+		return now, nil
+	}
+
+	stamp := time.Unix(epoch, 0).UTC()
+	if stamp.After(now) {
+		return now, nil
+	}
+	return stamp, nil
+}

--- a/cmd/gitserver/internal/git/gitcli/commits_test.go
+++ b/cmd/gitserver/internal/git/gitcli/commits_test.go
@@ -1,0 +1,24 @@
+package gitcli
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGitCLIBackend_LatestCommitTimestamp(t *testing.T) {
+	ctx := context.Background()
+
+	// Prepare repo state:
+	backend := BackendWithRepoCommands(t,
+		"echo line1 > f",
+		"git add f",
+		`GIT_COMMITTER_DATE="2015-01-01 00:00 Z" git commit -m foo --author='Foo Author <foo@sourcegraph.com>'`,
+	)
+
+	have, err := backend.LatestCommitTimestamp(ctx)
+	require.NoError(t, err)
+	require.Equal(t, time.Date(2015, 1, 1, 0, 0, 0, 0, time.UTC), have)
+}

--- a/cmd/gitserver/internal/git/gitcli/exec.go
+++ b/cmd/gitserver/internal/git/gitcli/exec.go
@@ -32,7 +32,7 @@ var (
 		"branch":    {"-r", "-a", "--contains", "--merged", "--format"},
 
 		"rev-parse":    {"--abbrev-ref", "--symbolic-full-name", "--glob", "--exclude"},
-		"rev-list":     {"--first-parent", "--max-parents", "--reverse", "--max-count", "--count", "--after", "--before", "--", "-n", "--date-order", "--skip", "--left-right"},
+		"rev-list":     {"--first-parent", "--max-parents", "--reverse", "--max-count", "--count", "--after", "--before", "--", "-n", "--date-order", "--skip", "--left-right", "--timestamp", "--all"},
 		"ls-remote":    {"--get-url"},
 		"symbolic-ref": {"--short"},
 		"archive":      {"--worktree-attributes", "--format", "-0", "HEAD", "--"},

--- a/cmd/gitserver/internal/git/iface.go
+++ b/cmd/gitserver/internal/git/iface.go
@@ -147,6 +147,10 @@ type GitBackend interface {
 	//
 	// If either the base or head <tree-ish> id does not exist, a RevisionNotFoundError is returned.
 	ChangedFiles(ctx context.Context, base, head string) (ChangedFilesIterator, error)
+
+	// LatestCommitTimestamp returns the timestamp of the most recent commit, if any.
+	// If there are no commits or the latest commit is in the future, time.Now is returned.
+	LatestCommitTimestamp(ctx context.Context) (time.Time, error)
 }
 
 type GitDiffComparisonType int

--- a/cmd/gitserver/internal/git/observability.go
+++ b/cmd/gitserver/internal/git/observability.go
@@ -460,29 +460,40 @@ func (hr *observableReadDirIterator) Close() error {
 	return err
 }
 
+func (b *observableBackend) LatestCommitTimestamp(ctx context.Context) (_ time.Time, err error) {
+	ctx, _, endObservation := b.operations.latestCommitTimestamp.With(ctx, &err, observation.Args{})
+	defer endObservation(1, observation.Args{})
+
+	concurrentOps.WithLabelValues("LatestCommitTimestamp").Inc()
+	defer concurrentOps.WithLabelValues("LatestCommitTimestamp").Dec()
+
+	return b.backend.LatestCommitTimestamp(ctx)
+}
+
 type operations struct {
-	configGet         *observation.Operation
-	configSet         *observation.Operation
-	configUnset       *observation.Operation
-	getObject         *observation.Operation
-	mergeBase         *observation.Operation
-	blame             *observation.Operation
-	symbolicRefHead   *observation.Operation
-	revParseHead      *observation.Operation
-	readFile          *observation.Operation
-	exec              *observation.Operation
-	getCommit         *observation.Operation
-	archiveReader     *observation.Operation
-	resolveRevision   *observation.Operation
-	listRefs          *observation.Operation
-	revAtTime         *observation.Operation
-	rawDiff           *observation.Operation
-	contributorCounts *observation.Operation
-	firstEverCommit   *observation.Operation
-	getBehindAhead    *observation.Operation
-	changedFiles      *observation.Operation
-	stat              *observation.Operation
-	readDir           *observation.Operation
+	configGet             *observation.Operation
+	configSet             *observation.Operation
+	configUnset           *observation.Operation
+	getObject             *observation.Operation
+	mergeBase             *observation.Operation
+	blame                 *observation.Operation
+	symbolicRefHead       *observation.Operation
+	revParseHead          *observation.Operation
+	readFile              *observation.Operation
+	exec                  *observation.Operation
+	getCommit             *observation.Operation
+	archiveReader         *observation.Operation
+	resolveRevision       *observation.Operation
+	listRefs              *observation.Operation
+	revAtTime             *observation.Operation
+	rawDiff               *observation.Operation
+	contributorCounts     *observation.Operation
+	firstEverCommit       *observation.Operation
+	getBehindAhead        *observation.Operation
+	changedFiles          *observation.Operation
+	stat                  *observation.Operation
+	readDir               *observation.Operation
+	latestCommitTimestamp *observation.Operation
 }
 
 func newOperations(observationCtx *observation.Context) *operations {
@@ -511,28 +522,29 @@ func newOperations(observationCtx *observation.Context) *operations {
 	}
 
 	return &operations{
-		configGet:         op("config-get"),
-		configSet:         op("config-set"),
-		configUnset:       op("config-unset"),
-		getObject:         op("get-object"),
-		mergeBase:         op("merge-base"),
-		blame:             op("blame"),
-		symbolicRefHead:   op("symbolic-ref-head"),
-		revParseHead:      op("rev-parse-head"),
-		readFile:          op("read-file"),
-		exec:              op("exec"),
-		getCommit:         op("get-commit"),
-		archiveReader:     op("archive-reader"),
-		resolveRevision:   op("resolve-revision"),
-		listRefs:          op("list-refs"),
-		revAtTime:         op("rev-at-time"),
-		rawDiff:           op("raw-diff"),
-		contributorCounts: op("contributor-counts"),
-		firstEverCommit:   op("first-ever-commit"),
-		getBehindAhead:    op("get-behind-ahead"),
-		changedFiles:      op("changed-files"),
-		stat:              op("stat"),
-		readDir:           op("read-dir"),
+		configGet:             op("config-get"),
+		configSet:             op("config-set"),
+		configUnset:           op("config-unset"),
+		getObject:             op("get-object"),
+		mergeBase:             op("merge-base"),
+		blame:                 op("blame"),
+		symbolicRefHead:       op("symbolic-ref-head"),
+		revParseHead:          op("rev-parse-head"),
+		readFile:              op("read-file"),
+		exec:                  op("exec"),
+		getCommit:             op("get-commit"),
+		archiveReader:         op("archive-reader"),
+		resolveRevision:       op("resolve-revision"),
+		listRefs:              op("list-refs"),
+		revAtTime:             op("rev-at-time"),
+		rawDiff:               op("raw-diff"),
+		contributorCounts:     op("contributor-counts"),
+		firstEverCommit:       op("first-ever-commit"),
+		getBehindAhead:        op("get-behind-ahead"),
+		changedFiles:          op("changed-files"),
+		stat:                  op("stat"),
+		readDir:               op("read-dir"),
+		latestCommitTimestamp: op("latest-commit-timestamp"),
 	}
 }
 


### PR DESCRIPTION
This PR moves the implementation of LatestCommitTimestamp to the GitBackend interface. We get proper tracking of the command by that, including error logs, resource usage, invocation count etc.

Test plan:

Tests are still passing.