### PR TITLE
gitserver: Implement RefHash in backend

### DIFF
--- a/cmd/gitserver/internal/git/iface.go
+++ b/cmd/gitserver/internal/git/iface.go
@@ -151,6 +151,12 @@ type GitBackend interface {
 	// LatestCommitTimestamp returns the timestamp of the most recent commit, if any.
 	// If there are no commits or the latest commit is in the future, time.Now is returned.
 	LatestCommitTimestamp(ctx context.Context) (time.Time, error)
+
+	// RefHash computes a hash of all the refs. The hash only changes if the set
+	// of refs and the commits they point to change.
+	// This value can be used to determine if a repository changed since the last
+	// time the hash has been computed.
+	RefHash(ctx context.Context) ([]byte, error)
 }
 
 type GitDiffComparisonType int

--- a/cmd/gitserver/internal/git/mock.go
+++ b/cmd/gitserver/internal/git/mock.go
@@ -333,6 +333,9 @@ type MockGitBackend struct {
 	// ReadFileFunc is an instance of a mock function object controlling the
 	// behavior of the method ReadFile.
 	ReadFileFunc *GitBackendReadFileFunc
+	// RefHashFunc is an instance of a mock function object controlling the
+	// behavior of the method RefHash.
+	RefHashFunc *GitBackendRefHashFunc
 	// ResolveRevisionFunc is an instance of a mock function object
 	// controlling the behavior of the method ResolveRevision.
 	ResolveRevisionFunc *GitBackendResolveRevisionFunc
@@ -431,6 +434,11 @@ func NewMockGitBackend() *MockGitBackend {
 		},
 		ReadFileFunc: &GitBackendReadFileFunc{
 			defaultHook: func(context.Context, api.CommitID, string) (r0 io.ReadCloser, r1 error) {
+				return
+			},
+		},
+		RefHashFunc: &GitBackendRefHashFunc{
+			defaultHook: func(context.Context) (r0 []byte, r1 error) {
 				return
 			},
 		},
@@ -546,6 +554,11 @@ func NewStrictMockGitBackend() *MockGitBackend {
 				panic("unexpected invocation of MockGitBackend.ReadFile")
 			},
 		},
+		RefHashFunc: &GitBackendRefHashFunc{
+			defaultHook: func(context.Context) ([]byte, error) {
+				panic("unexpected invocation of MockGitBackend.RefHash")
+			},
+		},
 		ResolveRevisionFunc: &GitBackendResolveRevisionFunc{
 			defaultHook: func(context.Context, string) (api.CommitID, error) {
 				panic("unexpected invocation of MockGitBackend.ResolveRevision")
@@ -625,6 +638,9 @@ func NewMockGitBackendFrom(i GitBackend) *MockGitBackend {
 		},
 		ReadFileFunc: &GitBackendReadFileFunc{
 			defaultHook: i.ReadFile,
+		},
+		RefHashFunc: &GitBackendRefHashFunc{
+			defaultHook: i.RefHash,
 		},
 		ResolveRevisionFunc: &GitBackendResolveRevisionFunc{
 			defaultHook: i.ResolveRevision,
@@ -2411,6 +2427,111 @@ func (c GitBackendReadFileFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c GitBackendReadFileFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
+}
+
+// GitBackendRefHashFunc describes the behavior when the RefHash method of
+// the parent MockGitBackend instance is invoked.
+type GitBackendRefHashFunc struct {
+	defaultHook func(context.Context) ([]byte, error)
+	hooks       []func(context.Context) ([]byte, error)
+	history     []GitBackendRefHashFuncCall
+	mutex       sync.Mutex
+}
+
+// RefHash delegates to the next hook function in the queue and stores the
+// parameter and result values of this invocation.
+func (m *MockGitBackend) RefHash(v0 context.Context) ([]byte, error) {
+	r0, r1 := m.RefHashFunc.nextHook()(v0)
+	m.RefHashFunc.appendCall(GitBackendRefHashFuncCall{v0, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the RefHash method of
+// the parent MockGitBackend instance is invoked and the hook queue is
+// empty.
+func (f *GitBackendRefHashFunc) SetDefaultHook(hook func(context.Context) ([]byte, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// RefHash method of the parent MockGitBackend instance invokes the hook at
+// the front of the queue and discards it. After the queue is empty, the
+// default hook function is invoked for any future action.
+func (f *GitBackendRefHashFunc) PushHook(hook func(context.Context) ([]byte, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *GitBackendRefHashFunc) SetDefaultReturn(r0 []byte, r1 error) {
+	f.SetDefaultHook(func(context.Context) ([]byte, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *GitBackendRefHashFunc) PushReturn(r0 []byte, r1 error) {
+	f.PushHook(func(context.Context) ([]byte, error) {
+		return r0, r1
+	})
+}
+
+func (f *GitBackendRefHashFunc) nextHook() func(context.Context) ([]byte, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *GitBackendRefHashFunc) appendCall(r0 GitBackendRefHashFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of GitBackendRefHashFuncCall objects
+// describing the invocations of this function.
+func (f *GitBackendRefHashFunc) History() []GitBackendRefHashFuncCall {
+	f.mutex.Lock()
+	history := make([]GitBackendRefHashFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// GitBackendRefHashFuncCall is an object that describes an invocation of
+// method RefHash on an instance of MockGitBackend.
+type GitBackendRefHashFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 []byte
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c GitBackendRefHashFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c GitBackendRefHashFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 

--- a/cmd/gitserver/internal/git/observability.go
+++ b/cmd/gitserver/internal/git/observability.go
@@ -470,6 +470,16 @@ func (b *observableBackend) LatestCommitTimestamp(ctx context.Context) (_ time.T
 	return b.backend.LatestCommitTimestamp(ctx)
 }
 
+func (b *observableBackend) RefHash(ctx context.Context) (_ []byte, err error) {
+	ctx, _, endObservation := b.operations.refHash.With(ctx, &err, observation.Args{})
+	defer endObservation(1, observation.Args{})
+
+	concurrentOps.WithLabelValues("RefHash").Inc()
+	defer concurrentOps.WithLabelValues("RefHash").Dec()
+
+	return b.backend.RefHash(ctx)
+}
+
 type operations struct {
 	configGet             *observation.Operation
 	configSet             *observation.Operation
@@ -494,6 +504,7 @@ type operations struct {
 	stat                  *observation.Operation
 	readDir               *observation.Operation
 	latestCommitTimestamp *observation.Operation
+	refHash               *observation.Operation
 }
 
 func newOperations(observationCtx *observation.Context) *operations {
@@ -545,6 +556,7 @@ func newOperations(observationCtx *observation.Context) *operations {
 		stat:                  op("stat"),
 		readDir:               op("read-dir"),
 		latestCommitTimestamp: op("latest-commit-timestamp"),
+		refHash:               op("ref-hash"),
 	}
 }
 

--- a/cmd/gitserver/internal/postfetch.go
+++ b/cmd/gitserver/internal/postfetch.go
@@ -95,7 +95,7 @@ func gitSetAutoGC(ctx context.Context, c git.GitConfigBackend) error {
 // If a timestamp already exists, we want to update it if and only if
 // the set of references (as determined by `git show-ref`) has changed.
 //
-// To accomplish this, we assert that the file `sg_refhash` in the git
+// To accomplish this, we assert that the file `sg_refhash_v2` in the git
 // directory should, if it exists, contain a hash of the output of
 // `git show-ref`, and have a timestamp of "the last time this changed",
 // except that if we're creating that file for the first time, we set
@@ -108,17 +108,20 @@ func gitSetAutoGC(ctx context.Context, c git.GitConfigBackend) error {
 // that is possibly causing our data to be incorrect, which should
 // be reported.
 func setLastChanged(ctx context.Context, logger log.Logger, dir common.GitDir, backend git.GitBackend) error {
-	hashFile := dir.Path("sg_refhash")
+	hashFile := dir.Path("sg_refhash_v2")
 
-	hash, err := git.ComputeRefHash(dir)
+	// Best effort delete the old refhash file.
+	_ = os.Remove(dir.Path("sg_refhash"))
+
+	hash, err := backend.RefHash(ctx)
 	if err != nil {
-		return errors.Wrapf(err, "computeRefHash failed for %s", dir)
+		return errors.Wrapf(err, "computing ref hash failed for %s", dir)
 	}
 
 	var stamp time.Time
 	if _, err := os.Stat(hashFile); os.IsNotExist(err) {
 		// This is the first time we are calculating the hash. Give a more
-		// approriate timestamp for sg_refhash than the current time.
+		// approriate timestamp for sg_refhash_v2 than the current time.
 		stamp, err = backend.LatestCommitTimestamp(ctx)
 		if err != nil {
 			logger.Warn("failed to get latest commit timestamp, using current time", log.Error(err))

--- a/cmd/gitserver/internal/serverutil.go
+++ b/cmd/gitserver/internal/serverutil.go
@@ -44,9 +44,9 @@ var repoLastFetched = func(dir common.GitDir) (time.Time, error) {
 	return fi.ModTime(), nil
 }
 
-// repoLastChanged returns the mtime of the repo's sg_refhash, which is the
+// repoLastChanged returns the mtime of the repo's sg_refhash_v2, which is the
 // cached timestamp of the most recent commit we could find in the tree. As a
-// special case when sg_refhash is missing we return repoLastFetched(dir).
+// special case when sg_refhash_v2 is missing we return repoLastFetched(dir).
 //
 // This breaks on file systems that do not record mtime. This is a Sourcegraph
 // extension to track last time a repo changed. The file is updated by
@@ -55,7 +55,7 @@ var repoLastFetched = func(dir common.GitDir) (time.Time, error) {
 // As a special case, tries both the directory given, and the .git subdirectory,
 // because we're a bit inconsistent about which name to use.
 var repoLastChanged = func(dir common.GitDir) (time.Time, error) {
-	fi, err := os.Stat(dir.Path("sg_refhash"))
+	fi, err := os.Stat(dir.Path("sg_refhash_v2"))
 	if os.IsNotExist(err) {
 		return repoLastFetched(dir)
 	}

--- a/internal/fileutil/fileutil_test.go
+++ b/internal/fileutil/fileutil_test.go
@@ -9,7 +9,7 @@ import (
 func TestUpdateFileIfDifferent(t *testing.T) {
 	dir := t.TempDir()
 
-	target := filepath.Join(dir, "sg_refhash")
+	target := filepath.Join(dir, "sg_refhash_v2")
 
 	write := func(content string) {
 		err := os.WriteFile(target, []byte(content), 0600)


### PR DESCRIPTION
This PR moves the implementation of ComputeRefHash to the GitBackend interface and reduces the amount of memory needed by it. We get proper tracking of the command by that, including error logs, resource usage, invocation count etc.

Since there is no 1000% guarantee that this didn't change the hash, I opted for resetting the last changed value and recomputing from scratch, by changing the path of the file to _v2.

Test plan:

Tests are still passing.