### PR TITLE
gitserver: Use the same GitBackendSource for all code paths

### DIFF
--- a/cmd/gitserver/internal/cleanup_test.go
+++ b/cmd/gitserver/internal/cleanup_test.go
@@ -81,6 +81,11 @@ UPDATE gitserver_repos SET repo_size_bytes = 5 where repo_id = 3;
 		logger,
 		db,
 		fs,
+		func(dir common.GitDir, repoName api.RepoName) git.GitBackend {
+			b := git.NewMockGitBackend()
+			b.ConfigFunc.SetDefaultReturn(git.NewMockGitConfigBackend())
+			return b
+		},
 		wrexec.NewNoOpRecordingCommandFactory(),
 		"test-gitserver",
 		connection.GitserverAddresses{Addresses: []string{"test-gitserver"}},
@@ -142,6 +147,11 @@ func TestCleanupInactive(t *testing.T) {
 		logtest.Scoped(t),
 		newMockedGitserverDB(),
 		fs,
+		func(dir common.GitDir, repoName api.RepoName) git.GitBackend {
+			b := git.NewMockGitBackend()
+			b.ConfigFunc.SetDefaultReturn(git.NewMockGitConfigBackend())
+			return b
+		},
 		wrexec.NewNoOpRecordingCommandFactory(),
 		"test-gitserver",
 		connection.GitserverAddresses{Addresses: []string{"test-gitserver"}},
@@ -181,6 +191,11 @@ func TestCleanupWrongShard(t *testing.T) {
 			logtest.Scoped(t),
 			newMockedGitserverDB(),
 			fs,
+			func(dir common.GitDir, repoName api.RepoName) git.GitBackend {
+				b := git.NewMockGitBackend()
+				b.ConfigFunc.SetDefaultReturn(git.NewMockGitConfigBackend())
+				return b
+			},
 			wrexec.NewNoOpRecordingCommandFactory(),
 			"does-not-exist",
 			connection.GitserverAddresses{Addresses: []string{"gitserver-0", "gitserver-1"}},
@@ -218,6 +233,11 @@ func TestCleanupWrongShard(t *testing.T) {
 			logtest.Scoped(t),
 			newMockedGitserverDB(),
 			fs,
+			func(dir common.GitDir, repoName api.RepoName) git.GitBackend {
+				b := git.NewMockGitBackend()
+				b.ConfigFunc.SetDefaultReturn(git.NewMockGitConfigBackend())
+				return b
+			},
 			wrexec.NewNoOpRecordingCommandFactory(),
 			"gitserver-0",
 			connection.GitserverAddresses{Addresses: []string{"gitserver-0.cluster.local:3178", "gitserver-1.cluster.local:3178"}},
@@ -255,6 +275,11 @@ func TestCleanupWrongShard(t *testing.T) {
 			logtest.Scoped(t),
 			newMockedGitserverDB(),
 			fs,
+			func(dir common.GitDir, repoName api.RepoName) git.GitBackend {
+				b := git.NewMockGitBackend()
+				b.ConfigFunc.SetDefaultReturn(git.NewMockGitConfigBackend())
+				return b
+			},
 			wrexec.NewNoOpRecordingCommandFactory(),
 			"gitserver-0",
 			connection.GitserverAddresses{Addresses: []string{"gitserver-0", "gitserver-1"}},
@@ -327,6 +352,11 @@ func TestGitGCAuto(t *testing.T) {
 		logtest.Scoped(t),
 		newMockedGitserverDB(),
 		fs,
+		func(dir common.GitDir, repoName api.RepoName) git.GitBackend {
+			b := git.NewMockGitBackend()
+			b.ConfigFunc.SetDefaultReturn(git.NewMockGitConfigBackend())
+			return b
+		},
 		wrexec.NewNoOpRecordingCommandFactory(),
 		"test-gitserver",
 		connection.GitserverAddresses{Addresses: []string{"test-gitserver"}},
@@ -420,6 +450,9 @@ func TestCleanupBroken(t *testing.T) {
 		logtest.Scoped(t),
 		newMockedGitserverDB(),
 		fs,
+		func(dir common.GitDir, repoName api.RepoName) git.GitBackend {
+			return gitcli.NewBackend(logtest.Scoped(t), wrexec.NewNoOpRecordingCommandFactory(), dir, repoName)
+		},
 		wrexec.NewNoOpRecordingCommandFactory(),
 		"test-gitserver",
 		connection.GitserverAddresses{Addresses: []string{"test-gitserver"}},
@@ -471,6 +504,11 @@ func TestCleanup_RemoveNonExistentRepos(t *testing.T) {
 			logtest.Scoped(t),
 			mockDB,
 			fs,
+			func(dir common.GitDir, repoName api.RepoName) git.GitBackend {
+				b := git.NewMockGitBackend()
+				b.ConfigFunc.SetDefaultReturn(git.NewMockGitConfigBackend())
+				return b
+			},
 			wrexec.NewNoOpRecordingCommandFactory(),
 			"test-gitserver",
 			connection.GitserverAddresses{Addresses: []string{"test-gitserver"}},
@@ -500,6 +538,11 @@ func TestCleanup_RemoveNonExistentRepos(t *testing.T) {
 			logtest.Scoped(t),
 			mockDB,
 			fs,
+			func(dir common.GitDir, repoName api.RepoName) git.GitBackend {
+				b := git.NewMockGitBackend()
+				b.ConfigFunc.SetDefaultReturn(git.NewMockGitConfigBackend())
+				return b
+			},
 			wrexec.NewNoOpRecordingCommandFactory(),
 			"test-gitserver",
 			connection.GitserverAddresses{Addresses: []string{"test-gitserver"}},
@@ -652,6 +695,11 @@ func TestCleanupOldLocks(t *testing.T) {
 		logtest.Scoped(t),
 		newMockedGitserverDB(),
 		fs,
+		func(dir common.GitDir, repoName api.RepoName) git.GitBackend {
+			b := git.NewMockGitBackend()
+			b.ConfigFunc.SetDefaultReturn(git.NewMockGitConfigBackend())
+			return b
+		},
 		wrexec.NewNoOpRecordingCommandFactory(),
 		"test-gitserver",
 		connection.GitserverAddresses{Addresses: []string{"gitserver-0"}},

--- a/cmd/gitserver/internal/git/iface.go
+++ b/cmd/gitserver/internal/git/iface.go
@@ -6,9 +6,13 @@ import (
 	"io/fs"
 	"time"
 
+	"github.com/sourcegraph/sourcegraph/cmd/gitserver/internal/common"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 )
+
+// GitBackendSource is a function that returns a GitBackend for a given repository.
+type GitBackendSource func(dir common.GitDir, repoName api.RepoName) GitBackend
 
 // GitBackend is the interface through which operations on a git repository can
 // be performed. It encapsulates the underlying git implementation and allows

--- a/cmd/gitserver/internal/integration_tests/clone_test.go
+++ b/cmd/gitserver/internal/integration_tests/clone_test.go
@@ -58,7 +58,7 @@ func TestClone(t *testing.T) {
 	s := server.NewServer(&server.ServerOpts{
 		Logger: logger,
 		FS:     fs,
-		GetBackendFunc: func(dir common.GitDir, repoName api.RepoName) git.GitBackend {
+		GitBackendSource: func(dir common.GitDir, repoName api.RepoName) git.GitBackend {
 			return gitcli.NewBackend(logtest.Scoped(t), wrexec.NewNoOpRecordingCommandFactory(), dir, repoName)
 		},
 		GetRemoteURLFunc: getRemoteURLFunc,
@@ -161,7 +161,7 @@ func TestClone_Fail(t *testing.T) {
 	s := server.NewServer(&server.ServerOpts{
 		Logger: logger,
 		FS:     fs,
-		GetBackendFunc: func(dir common.GitDir, repoName api.RepoName) git.GitBackend {
+		GitBackendSource: func(dir common.GitDir, repoName api.RepoName) git.GitBackend {
 			return gitcli.NewBackend(logtest.Scoped(t), wrexec.NewNoOpRecordingCommandFactory(), dir, repoName)
 		},
 		GetRemoteURLFunc: getRemoteURLFunc,

--- a/cmd/gitserver/internal/integration_tests/utils_test.go
+++ b/cmd/gitserver/internal/integration_tests/utils_test.go
@@ -90,7 +90,7 @@ func InitGitserver() {
 	s := server.NewServer(&server.ServerOpts{
 		Logger: sglog.Scoped("server"),
 		FS:     fs,
-		GetBackendFunc: func(dir common.GitDir, repoName api.RepoName) git.GitBackend {
+		GitBackendSource: func(dir common.GitDir, repoName api.RepoName) git.GitBackend {
 			return gitcli.NewBackend(logtest.Scoped(&t), wrexec.NewNoOpRecordingCommandFactory(), dir, repoName)
 		},
 		GetRemoteURLFunc: getRemoteURLFunc,

--- a/cmd/gitserver/internal/server.go
+++ b/cmd/gitserver/internal/server.go
@@ -49,8 +49,6 @@ func init() {
 	traceLogs, _ = strconv.ParseBool(env.Get("SRC_GITSERVER_TRACE", "false", "Toggles trace logging to stderr"))
 }
 
-type Backender func(common.GitDir, api.RepoName) git.GitBackend
-
 type ServerOpts struct {
 	// Logger should be used for all logging and logger creation.
 	Logger log.Logger
@@ -59,9 +57,9 @@ type ServerOpts struct {
 	// name on disk and map a dir on disk back to a repo name.
 	FS gitserverfs.FS
 
-	// GetBackendFunc is a function which returns the git backend for a
+	// GitBackendSource is a function which returns the git backend for a
 	// repository.
-	GetBackendFunc Backender
+	GitBackendSource git.GitBackendSource
 
 	// GetRemoteURLFunc is a function which returns the remote URL for a
 	// repository. This is used when cloning or fetching a repository. In
@@ -120,7 +118,7 @@ func NewServer(opt *ServerOpts) *Server {
 
 	return &Server{
 		logger:                  opt.Logger,
-		getBackendFunc:          opt.GetBackendFunc,
+		gitBackendSource:        opt.GitBackendSource,
 		getRemoteURLFunc:        opt.GetRemoteURLFunc,
 		getVCSSyncer:            opt.GetVCSSyncer,
 		hostname:                opt.Hostname,
@@ -146,9 +144,9 @@ type Server struct {
 	// name on disk and map a dir on disk back to a repo name.
 	fs gitserverfs.FS
 
-	// getBackendFunc is a function which returns the git backend for a
+	// gitBackendSource is a function which returns the git backend for a
 	// repository.
-	getBackendFunc Backender
+	gitBackendSource git.GitBackendSource
 
 	// getRemoteURLFunc is a function which returns the remote URL for a
 	// repository. This is used when cloning or fetching a repository. In
@@ -522,7 +520,7 @@ func (s *Server) cloneRepo(ctx context.Context, repo api.RepoName, lock Reposito
 		return errors.Wrapf(cloneErr, "clone failed. Output: %s", output.String())
 	}
 
-	if err := postRepoFetchActions(ctx, logger, s.fs, s.db, s.getBackendFunc(common.GitDir(tmpPath), repo), s.hostname, repo, common.GitDir(tmpPath), syncer); err != nil {
+	if err := postRepoFetchActions(ctx, logger, s.fs, s.db, s.gitBackendSource(common.GitDir(tmpPath), repo), s.hostname, repo, common.GitDir(tmpPath), syncer); err != nil {
 		return err
 	}
 
@@ -746,7 +744,7 @@ func (s *Server) doRepoUpdate(ctx context.Context, repo api.RepoName, lock Repos
 			return errors.Wrapf(err, "failed to fetch repo %q with output %q", repo, output.String())
 		}
 
-		return postRepoFetchActions(ctx, logger, s.fs, s.db, s.getBackendFunc(dir, repo), s.hostname, repo, dir, syncer)
+		return postRepoFetchActions(ctx, logger, s.fs, s.db, s.gitBackendSource(dir, repo), s.hostname, repo, dir, syncer)
 	}(ctx)
 
 	if errors.Is(err, context.DeadlineExceeded) {

--- a/cmd/gitserver/internal/server_grpc_test.go
+++ b/cmd/gitserver/internal/server_grpc_test.go
@@ -82,7 +82,7 @@ func TestGRPCServer_Blame(t *testing.T) {
 		gs := &grpcServer{
 			svc: NewMockService(),
 			fs:  fs,
-			getBackendFunc: func(common.GitDir, api.RepoName) git.GitBackend {
+			gitBackendSource: func(common.GitDir, api.RepoName) git.GitBackend {
 				return b
 			},
 		}
@@ -176,7 +176,7 @@ func TestGRPCServer_DefaultBranch(t *testing.T) {
 		gs := &grpcServer{
 			svc: NewMockService(),
 			fs:  fs,
-			getBackendFunc: func(common.GitDir, api.RepoName) git.GitBackend {
+			gitBackendSource: func(common.GitDir, api.RepoName) git.GitBackend {
 				return b
 			},
 		}
@@ -239,7 +239,7 @@ func TestGRPCServer_MergeBase(t *testing.T) {
 		gs := &grpcServer{
 			svc: NewMockService(),
 			fs:  fs,
-			getBackendFunc: func(common.GitDir, api.RepoName) git.GitBackend {
+			gitBackendSource: func(common.GitDir, api.RepoName) git.GitBackend {
 				b := git.NewMockGitBackend()
 				b.MergeBaseFunc.SetDefaultReturn("", &gitdomain.RevisionNotFoundError{Repo: "therepo", Spec: "b2"})
 				return b
@@ -260,7 +260,7 @@ func TestGRPCServer_MergeBase(t *testing.T) {
 		gs := &grpcServer{
 			svc: NewMockService(),
 			fs:  fs,
-			getBackendFunc: func(common.GitDir, api.RepoName) git.GitBackend {
+			gitBackendSource: func(common.GitDir, api.RepoName) git.GitBackend {
 				return b
 			},
 		}
@@ -320,7 +320,7 @@ func TestGRPCServer_ReadFile(t *testing.T) {
 		gs := &grpcServer{
 			svc: NewMockService(),
 			fs:  fs,
-			getBackendFunc: func(common.GitDir, api.RepoName) git.GitBackend {
+			gitBackendSource: func(common.GitDir, api.RepoName) git.GitBackend {
 				return b
 			},
 		}
@@ -415,7 +415,7 @@ func TestGRPCServer_Archive(t *testing.T) {
 		gs := &grpcServer{
 			svc: NewMockService(),
 			fs:  fs,
-			getBackendFunc: func(common.GitDir, api.RepoName) git.GitBackend {
+			gitBackendSource: func(common.GitDir, api.RepoName) git.GitBackend {
 				return b
 			},
 		}
@@ -517,7 +517,7 @@ func TestGRPCServer_GetCommit(t *testing.T) {
 		gs := &grpcServer{
 			svc: NewMockService(),
 			fs:  fs,
-			getBackendFunc: func(common.GitDir, api.RepoName) git.GitBackend {
+			gitBackendSource: func(common.GitDir, api.RepoName) git.GitBackend {
 				return b
 			},
 		}
@@ -598,7 +598,7 @@ func TestGRPCServer_ResolveRevision(t *testing.T) {
 		gs := &grpcServer{
 			svc: svc,
 			fs:  fs,
-			getBackendFunc: func(common.GitDir, api.RepoName) git.GitBackend {
+			gitBackendSource: func(common.GitDir, api.RepoName) git.GitBackend {
 				return b
 			},
 		}
@@ -677,7 +677,7 @@ func TestGRPCServer_RevAtTime(t *testing.T) {
 		gs := &grpcServer{
 			svc: svc,
 			fs:  fs,
-			getBackendFunc: func(common.GitDir, api.RepoName) git.GitBackend {
+			gitBackendSource: func(common.GitDir, api.RepoName) git.GitBackend {
 				return b
 			},
 		}
@@ -746,7 +746,7 @@ func TestGRPCServer_GetObject(t *testing.T) {
 			svc:    NewMockService(),
 			fs:     fs,
 			logger: logtest.Scoped(t),
-			getBackendFunc: func(common.GitDir, api.RepoName) git.GitBackend {
+			gitBackendSource: func(common.GitDir, api.RepoName) git.GitBackend {
 				return b
 			},
 		}
@@ -815,7 +815,7 @@ func TestGRPCServer_ListRefs(t *testing.T) {
 		gs := &grpcServer{
 			svc: NewMockService(),
 			fs:  fs,
-			getBackendFunc: func(common.GitDir, api.RepoName) git.GitBackend {
+			gitBackendSource: func(common.GitDir, api.RepoName) git.GitBackend {
 				return b
 			},
 		}
@@ -888,7 +888,7 @@ func TestGRPCServer_RawDiff(t *testing.T) {
 		gs := &grpcServer{
 			svc: NewMockService(),
 			fs:  fs,
-			getBackendFunc: func(common.GitDir, api.RepoName) git.GitBackend {
+			gitBackendSource: func(common.GitDir, api.RepoName) git.GitBackend {
 				return b
 			},
 		}
@@ -963,7 +963,7 @@ func TestGRPCServer_ContributorCounts(t *testing.T) {
 		gs := &grpcServer{
 			svc: svc,
 			fs:  fs,
-			getBackendFunc: func(common.GitDir, api.RepoName) git.GitBackend {
+			gitBackendSource: func(common.GitDir, api.RepoName) git.GitBackend {
 				return b
 			},
 		}
@@ -1028,7 +1028,7 @@ func TestGRPCServer_ChangedFiles(t *testing.T) {
 		gs := &grpcServer{
 			svc: NewMockService(),
 			fs:  fs,
-			getBackendFunc: func(common.GitDir, api.RepoName) git.GitBackend {
+			gitBackendSource: func(common.GitDir, api.RepoName) git.GitBackend {
 				b := git.NewMockGitBackend()
 				b.ChangedFilesFunc.SetDefaultReturn(nil, &gitdomain.RevisionNotFoundError{Repo: "therepo", Spec: "base...head"})
 				return b
@@ -1055,7 +1055,7 @@ func TestGRPCServer_ChangedFiles(t *testing.T) {
 		gs := &grpcServer{
 			svc: NewMockService(),
 			fs:  fs,
-			getBackendFunc: func(common.GitDir, api.RepoName) git.GitBackend {
+			gitBackendSource: func(common.GitDir, api.RepoName) git.GitBackend {
 				return b
 			},
 		}
@@ -1142,7 +1142,7 @@ func TestGRPCServer_FirstCommitEver(t *testing.T) {
 		gs := &grpcServer{
 			svc: NewMockService(),
 			fs:  fs,
-			getBackendFunc: func(common.GitDir, api.RepoName) git.GitBackend {
+			gitBackendSource: func(common.GitDir, api.RepoName) git.GitBackend {
 				return b
 			},
 		}
@@ -1204,7 +1204,7 @@ func TestGRPCServer_BehindAhead(t *testing.T) {
 		gs := &grpcServer{
 			svc: NewMockService(),
 			fs:  fs,
-			getBackendFunc: func(common.GitDir, api.RepoName) git.GitBackend {
+			gitBackendSource: func(common.GitDir, api.RepoName) git.GitBackend {
 				b := git.NewMockGitBackend()
 				b.BehindAheadFunc.SetDefaultReturn(&gitdomain.BehindAhead{}, &gitdomain.RevisionNotFoundError{Repo: "therepo", Spec: "base...head"})
 				return b
@@ -1228,7 +1228,7 @@ func TestGRPCServer_BehindAhead(t *testing.T) {
 		gs := &grpcServer{
 			svc: NewMockService(),
 			fs:  fs,
-			getBackendFunc: func(common.GitDir, api.RepoName) git.GitBackend {
+			gitBackendSource: func(common.GitDir, api.RepoName) git.GitBackend {
 				return b
 			},
 		}
@@ -1285,7 +1285,7 @@ func TestGRPCServer_Stat(t *testing.T) {
 		gs := &grpcServer{
 			svc: NewMockService(),
 			fs:  fs,
-			getBackendFunc: func(common.GitDir, api.RepoName) git.GitBackend {
+			gitBackendSource: func(common.GitDir, api.RepoName) git.GitBackend {
 				b := git.NewMockGitBackend()
 				b.StatFunc.SetDefaultReturn(nil, &gitdomain.RevisionNotFoundError{Repo: "therepo", Spec: "base...head"})
 				return b
@@ -1308,7 +1308,7 @@ func TestGRPCServer_Stat(t *testing.T) {
 		gs := &grpcServer{
 			svc: NewMockService(),
 			fs:  fs,
-			getBackendFunc: func(common.GitDir, api.RepoName) git.GitBackend {
+			gitBackendSource: func(common.GitDir, api.RepoName) git.GitBackend {
 				return b
 			},
 		}
@@ -1390,7 +1390,7 @@ func TestGRPCServer_ReadDir(t *testing.T) {
 		gs := &grpcServer{
 			svc: NewMockService(),
 			fs:  fs,
-			getBackendFunc: func(common.GitDir, api.RepoName) git.GitBackend {
+			gitBackendSource: func(common.GitDir, api.RepoName) git.GitBackend {
 				return b
 			},
 		}

--- a/cmd/gitserver/internal/server_test.go
+++ b/cmd/gitserver/internal/server_test.go
@@ -119,7 +119,7 @@ func TestExecRequest(t *testing.T) {
 	s := NewServer(&ServerOpts{
 		Logger: logtest.Scoped(t),
 		FS:     fs,
-		GetBackendFunc: func(dir common.GitDir, repoName api.RepoName) git.GitBackend {
+		GitBackendSource: func(dir common.GitDir, repoName api.RepoName) git.GitBackend {
 			backend := git.NewMockGitBackend()
 			backend.ExecFunc.SetDefaultHook(func(ctx context.Context, args ...string) (io.ReadCloser, error) {
 				if !gitcli.IsAllowedGitCmd(logtest.Scoped(t), args, fs.RepoDir(repoName)) {
@@ -299,7 +299,7 @@ func makeTestServer(ctx context.Context, t *testing.T, repoDir, remote string, d
 	s := NewServer(&ServerOpts{
 		Logger: logger,
 		FS:     fs,
-		GetBackendFunc: func(dir common.GitDir, repoName api.RepoName) git.GitBackend {
+		GitBackendSource: func(dir common.GitDir, repoName api.RepoName) git.GitBackend {
 			return gitcli.NewBackend(logtest.Scoped(t), wrexec.NewNoOpRecordingCommandFactory(), dir, repoName)
 		},
 		GetRemoteURLFunc: getRemoteURLFunc,
@@ -1103,7 +1103,7 @@ func TestServer_IsRepoCloneable_InternalActor(t *testing.T) {
 
 	s := NewServer(&ServerOpts{
 		Logger: logtest.Scoped(t),
-		GetBackendFunc: func(dir common.GitDir, repoName api.RepoName) git.GitBackend {
+		GitBackendSource: func(dir common.GitDir, repoName api.RepoName) git.GitBackend {
 			return git.NewMockGitBackend()
 		},
 		GetRemoteURLFunc: func(_ context.Context, _ api.RepoName) (string, error) {


### PR DESCRIPTION
Currently, the janitor doesn't use the observable backend wrapper, this PR makes all users of backend use the same factory function.

Test plan:

Tests are still passing.