### PR TITLE
gitserver: Reduce number of git config invocations

### DIFF
--- a/cmd/gitserver/internal/cleanup_test.go
+++ b/cmd/gitserver/internal/cleanup_test.go
@@ -1445,3 +1445,30 @@ func TestSGMaintenanceRemovesLock(t *testing.T) {
 		t.Fatal("sg maintenance should have removed the lockfile it created")
 	}
 }
+
+func TestGetSetLastSizeCalculation(t *testing.T) {
+	dir := common.GitDir(t.TempDir())
+	cmd := exec.Command("git", "--bare", "init")
+	dir.Set(cmd)
+	if err := cmd.Run(); err != nil {
+		t.Fatal(err)
+	}
+	at, err := getLastSizeCalculation(dir)
+	require.NoError(t, err)
+	// Never computed, should be zero.
+	require.True(t, at.IsZero())
+	now := time.Now().Truncate(time.Millisecond)
+	// Setting the value should work.
+	err = setLastSizeCalculation(dir, now)
+	require.NoError(t, err)
+	at, err = getLastSizeCalculation(dir)
+	require.NoError(t, err)
+	require.Equal(t, now, at)
+	// Setting again should work.
+	now = time.Now().Truncate(time.Millisecond)
+	err = setLastSizeCalculation(dir, now)
+	require.NoError(t, err)
+	at, err = getLastSizeCalculation(dir)
+	require.NoError(t, err)
+	require.Equal(t, now, at)
+}


### PR DESCRIPTION
Using config is fairly convenient, but got somewhat out of hand. On dotcom, we call this millions of times, because the janitor runs frequently and there are a lot of repos.
Instead, for a few simple things we now use a different mechanism that has less overhead (also, we only abused the git config, those values are of no interest to git itself).
1. The timestamp for the last size calculation is now stored as the mtime of a magic file in the repo dir.
2. The repoType is only loaded when there is a reclone reason, and we might want to skip over Perforce repos

Test plan:

Added a basic test, and integration tests still pass.