### PR TITLE
gitserver: Move spec arg safety check into git layer

### DIFF
--- a/cmd/gitserver/internal/git/git.go
+++ b/cmd/gitserver/internal/git/git.go
@@ -10,7 +10,6 @@ import (
 	"path/filepath"
 	"sort"
 	"strconv"
-	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -179,16 +178,6 @@ func ComputeRefHash(dir common.GitDir) ([]byte, error) {
 	hash := make([]byte, hex.EncodedLen(hasher.Size()))
 	hex.Encode(hash, hasher.Sum(nil))
 	return hash, nil
-}
-
-// CheckSpecArgSafety returns a non-nil err if spec begins with a "-", which could
-// cause it to be interpreted as a git command line argument.
-// TODO: Should be removed once the exec endpoint is gone.
-func CheckSpecArgSafety(spec string) error {
-	if strings.HasPrefix(spec, "-") {
-		return errors.Errorf("invalid git revision spec %q (begins with '-')", spec)
-	}
-	return nil
 }
 
 // MakeBareRepo initializes a new bare repo at the given dir.

--- a/cmd/gitserver/internal/git/gitcli/archivereader.go
+++ b/cmd/gitserver/internal/git/gitcli/archivereader.go
@@ -8,6 +8,10 @@ import (
 )
 
 func (g *gitCLIBackend) ArchiveReader(ctx context.Context, format git.ArchiveFormat, treeish string, paths []string) (io.ReadCloser, error) {
+	if err := checkSpecArgSafety(treeish); err != nil {
+		return nil, err
+	}
+
 	// Verify the tree-ish exists, if it doesn't this will return a RevisionNotFoundError:
 	_, err := g.getObjectType(ctx, treeish)
 	if err != nil {

--- a/cmd/gitserver/internal/server_grpc.go
+++ b/cmd/gitserver/internal/server_grpc.go
@@ -262,10 +262,6 @@ func (gs *grpcServer) Archive(req *proto.ArchiveRequest, ss proto.GitserverServi
 		return status.Error(codes.InvalidArgument, fmt.Sprintf("unknown archive format %q", req.GetFormat()))
 	}
 
-	if err := git.CheckSpecArgSafety(req.GetTreeish()); err != nil {
-		return status.Error(codes.InvalidArgument, err.Error())
-	}
-
 	accesslog.Record(ctx, req.GetRepo(),
 		log.String("treeish", req.GetTreeish()),
 		log.String("format", string(format)),


### PR DESCRIPTION
This is how all the other commands do it, so let's do the same here, and unexport this function.

Test plan:

Git archive tests still pass.