### PR TITLE
gitserver: Fixup error codes for ReadDir

### DIFF
--- a/cmd/gitserver/internal/git/gitcli/odb.go
+++ b/cmd/gitserver/internal/git/gitcli/odb.go
@@ -519,6 +519,9 @@ func (it *readDirIterator) Close() error {
 			if cfe.ExitStatus == 128 && bytes.Contains(cfe.Stderr, []byte("fatal: not a tree object")) {
 				return &gitdomain.RevisionNotFoundError{Repo: it.repoName, Spec: string(it.commit)}
 			}
+			if cfe.ExitStatus == 128 && bytes.Contains(cfe.Stderr, []byte("fatal: Not a valid object name")) {
+				return &gitdomain.RevisionNotFoundError{Repo: it.repoName, Spec: string(it.commit)}
+			}
 		}
 		return err
 	}

--- a/cmd/gitserver/internal/git/gitcli/odb_test.go
+++ b/cmd/gitserver/internal/git/gitcli/odb_test.go
@@ -703,8 +703,12 @@ func TestGitCLIBackend_ReadDir(t *testing.T) {
 		t.Cleanup(func() { it.Close() })
 		_, err = it.Next()
 		require.Error(t, err)
+		require.True(t, errors.HasType(err, &gitdomain.RevisionNotFoundError{}))
 
-		t.Log(err)
+		// Read no entries:
+		it, err = backend.ReadDir(ctx, "notfound", "nested", false)
+		require.NoError(t, err)
+		err = it.Close()
 		require.True(t, errors.HasType(err, &gitdomain.RevisionNotFoundError{}))
 	})
 

--- a/cmd/gitserver/internal/server_grpc.go
+++ b/cmd/gitserver/internal/server_grpc.go
@@ -1641,28 +1641,6 @@ func (gs *grpcServer) ReadDir(req *proto.ReadDirRequest, ss proto.GitserverServi
 
 	it, err := backend.ReadDir(ctx, api.CommitID(req.GetCommitSha()), string(req.GetPath()), req.GetRecursive())
 	if err != nil {
-		if os.IsNotExist(err) {
-			s, err := status.New(codes.NotFound, "file not found").WithDetails(&proto.FileNotFoundPayload{
-				Repo:   req.GetRepoName(),
-				Commit: string(req.GetCommitSha()),
-				Path:   string(req.GetPath()),
-			})
-			if err != nil {
-				return err
-			}
-			return s.Err()
-		}
-		var e *gitdomain.RevisionNotFoundError
-		if errors.As(err, &e) {
-			s, err := status.New(codes.NotFound, "revision not found").WithDetails(&proto.RevisionNotFoundPayload{
-				Repo: req.GetRepoName(),
-				Spec: e.Spec,
-			})
-			if err != nil {
-				return err
-			}
-			return s.Err()
-		}
 		gs.svc.LogIfCorrupt(ctx, repoName, err)
 		return err
 	}
@@ -1673,12 +1651,10 @@ func (gs *grpcServer) ReadDir(req *proto.ReadDirRequest, ss proto.GitserverServi
 			return
 		}
 
-		if err != nil {
-			err = errors.Append(err, closeErr)
+		if err == nil {
+			err = closeErr
 			return
 		}
-
-		err = closeErr
 	}()
 
 	sendFunc := func(fis []*proto.FileInfo) error {
@@ -1696,6 +1672,28 @@ func (gs *grpcServer) ReadDir(req *proto.ReadDirRequest, ss proto.GitserverServi
 		if err != nil {
 			if err == io.EOF {
 				break
+			}
+			if os.IsNotExist(err) {
+				s, err := status.New(codes.NotFound, "file not found").WithDetails(&proto.FileNotFoundPayload{
+					Repo:   req.GetRepoName(),
+					Commit: string(req.GetCommitSha()),
+					Path:   string(req.GetPath()),
+				})
+				if err != nil {
+					return err
+				}
+				return s.Err()
+			}
+			var e *gitdomain.RevisionNotFoundError
+			if errors.As(err, &e) {
+				s, err := status.New(codes.NotFound, "revision not found").WithDetails(&proto.RevisionNotFoundPayload{
+					Repo: req.GetRepoName(),
+					Spec: e.Spec,
+				})
+				if err != nil {
+					return err
+				}
+				return s.Err()
 			}
 			return err
 		}


### PR DESCRIPTION
I messed up the error checking here, and the test for it as well, now gitserver properly returns FileNotFoundPayloads and RevisionNotFoundPayloads for this API.

Test plan:

Adjusted test suite and manually verified using the gRPC UI.