### PR TITLE
chore(ci): bump backcompat target to 5.4.0

### DIFF
--- a/dev/backcompat/bazel-backcompat.sh
+++ b/dev/backcompat/bazel-backcompat.sh
@@ -5,7 +5,7 @@ cd "$(dirname "${BASH_SOURCE[0]}")/../.."
 
 bazelrcs=(--bazelrc=.bazelrc)
 current_commit=$(git rev-parse HEAD)
-tag="5.3.0"
+tag="5.4.0"
 
 function restore_current_commit() {
   git checkout --force "${current_commit}"

--- a/dev/backcompat/flakes.json
+++ b/dev/backcompat/flakes.json
@@ -60,5 +60,5 @@
             "reason": "We remove constraints and the old tests checked that we were failing"
         }
     ],
-    "5.4.0": [],
+    "5.4.0": []
 }

--- a/dev/backcompat/flakes.json
+++ b/dev/backcompat/flakes.json
@@ -59,5 +59,6 @@
             "prefix": "TestFeatureFlagStore",
             "reason": "We remove constraints and the old tests checked that we were failing"
         }
-    ]
+    ],
+    "5.4.0": [],
 }

--- a/dev/ci/internal/ci/pipeline.go
+++ b/dev/ci/internal/ci/pipeline.go
@@ -89,7 +89,7 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 	}
 
 	// Test upgrades from mininum upgradeable Sourcegraph version - updated by release tool
-	const minimumUpgradeableVersion = "5.3.0"
+	const minimumUpgradeableVersion = "5.4.0"
 
 	// Set up operations that add steps to a pipeline.
 	ops := operations.NewSet()


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/devx-support/issues/950

## Test plan

CI 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
