### PR TITLE
build-tracker: use repeated type for agent queues + deref strings

### DIFF
--- a/dev/build-tracker/bigquery.go
+++ b/dev/build-tracker/bigquery.go
@@ -34,12 +34,12 @@ func (b *BuildkiteAgentEvent) Save() (row map[string]bigquery.Value, insertID st
 
 	return map[string]bigquery.Value{
 		"event":      strings.TrimPrefix(b.event, "agent."),
-		"name":       b.Name,
-		"hostname":   b.Hostname,
-		"version":    b.Version,
-		"ip_address": b.IPAddress,
-		"queues":     strings.Join(queues, ","),
-		"user_agent": b.UserAgent,
+		"name":       *b.Name,
+		"hostname":   *b.Hostname,
+		"version":    *b.Version,
+		"ip_address": *b.IPAddress,
+		"queues":     queues,
+		"user_agent": *b.UserAgent,
 		"uuid":       strings.TrimPrefix(string(uuid), "Agent---"),
 	}, "", nil
 }


### PR DESCRIPTION
TIL BigQuery has a native "repeated" type, so we dont have to comma separate this out : )

Not impacting any existing data as the current version isnt live yet (due to an msp misconfiguration) and the bigquery tables not being created yet)

## Test plan

CI and live
