### PR TITLE
feat(docs): make legacy docs noindex,nofollow 

### DIFF
--- a/doc/_resources/templates/document.html
+++ b/doc/_resources/templates/document.html
@@ -1,5 +1,6 @@
 {{define "seo"}}
   <meta property="og:locale" content="en_EN">
+  <meta name="robots" content="noindex,nofollow">
 
   <!-- Always set a title -->
   {{ if .Content }}
@@ -60,7 +61,7 @@
 {{define "head"}}
     {{ if .ContentVersion }}
         <!-- don't index pages from older versions -->
-        <meta name="robots" content="noindex">
+        <!-- <meta name="robots" content="noindex"> -->
     {{ end }}
 {{end}}
 

--- a/doc/docsite.json
+++ b/doc/docsite.json
@@ -3,7 +3,7 @@
   "templates": "_resources/templates",
   "content": ".",
   "baseURLPath": "/",
-  "rootURL": "https://docs.sourcegraph.com",
+  "rootURL": "https://docs-legacy.sourcegraph.com",
   "assets": "_resources/assets",
   "assetsBaseURLPath": "/assets/",
   "check": {


### PR DESCRIPTION
Adds a `<meta>` that says everything is noindex/nofollow. 

The base branch of that PR is the branch served by the legacy docs, which is "frozen" on the commit just before we removed it from the main repo. 

## Test plan

![CleanShot 2024-05-13 at 15 23 54@2x](https://github.com/sourcegraph/sourcegraph/assets/10151/e63b94d9-90ac-4a94-a623-9f0663a47f69)


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
