### PR TITLE
build-tracker: fix handling of agent webhooks

### DIFF
--- a/dev/build-tracker/bigquery.go
+++ b/dev/build-tracker/bigquery.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"encoding/base64"
 	"strings"
 
 	"cloud.google.com/go/bigquery"
@@ -27,20 +26,15 @@ func (b *BuildkiteAgentEvent) Save() (row map[string]bigquery.Value, insertID st
 		}
 	}
 
-	uuid, err := base64.StdEncoding.DecodeString(*b.ID)
-	if err != nil {
-		return nil, "", err
-	}
-
 	return map[string]bigquery.Value{
 		"event":      strings.TrimPrefix(b.event, "agent."),
+		"uuid":       *b.ID,
 		"name":       *b.Name,
 		"hostname":   *b.Hostname,
 		"version":    *b.Version,
 		"ip_address": *b.IPAddress,
 		"queues":     queues,
 		"user_agent": *b.UserAgent,
-		"uuid":       strings.TrimPrefix(string(uuid), "Agent---"),
 	}, "", nil
 }
 

--- a/dev/build-tracker/main.go
+++ b/dev/build-tracker/main.go
@@ -190,7 +190,11 @@ func (s *Server) handleEvent(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	go s.processEvent(&event)
+	if testutil.IsTest {
+		s.processEvent(&event)
+	} else {
+		go s.processEvent(&event)
+	}
 	w.WriteHeader(http.StatusOK)
 }
 
@@ -305,7 +309,7 @@ func (s *Server) processEvent(event *build.Event) {
 				s.logger.Error("failed to trigger metrics pipeline for build", log.Int("buildNumber", event.GetBuildNumber()), log.Error(err))
 			}
 		}
-	} else {
+	} else if event.Agent.ID != nil {
 		if err := s.bqWriter.Write(context.Background(), &BuildkiteAgentEvent{
 			event: event.Name,
 			Agent: event.Agent,


### PR DESCRIPTION
So the graphql API differs quite a bit :upside_down_face: not using that as a reference anymore

## Test plan

updated unit test based on live data