### PR TITLE
Python notebooks: fix anchor offset

### DIFF
--- a/client/web-sveltekit/src/lib/wildcard/Markdown.module.scss
+++ b/client/web-sveltekit/src/lib/wildcard/Markdown.module.scss
@@ -35,8 +35,12 @@
         a:global(.anchor) {
             opacity: 0;
             font-size: 1rem; // keep consistently-sized anchor links
-            margin-left: -1rem;
             padding: 0.125rem;
+
+            // Ensure we reserve exactly the width we shift
+            margin-left: -1rem;
+            width: 1rem;
+            display: inline-block;
 
             &::before {
                 content: '#';

--- a/client/wildcard/src/components/Markdown/Markdown.module.scss
+++ b/client/wildcard/src/components/Markdown/Markdown.module.scss
@@ -23,8 +23,13 @@
         a:global(.anchor) {
             opacity: 0;
             font-size: 1rem; // keep consistently-sized anchor links
-            margin-left: -1rem;
             padding: 0.125rem;
+
+            // Ensure we reserve exactly the width we shift
+            margin-left: -1rem;
+            width: 1rem;
+            display: inline-block;
+
             &::before {
                 content: '#';
             }


### PR DESCRIPTION
This fixes an issue with Jupyter notebook rendering where the offset from the anchor can clip the left side of the header text. The issue is that we use `margin-left: 1rem;` to offset the anchor, but the anchor isn't guaranteed to be exactly 1rem wide. This makes the relationship explicit and adds a comment that those are linked.

![screenshot-2024-05-13_13-17-06@2x](https://github.com/sourcegraph/sourcegraph/assets/12631702/9cd8bb87-697c-435d-96be-1e61861aa3bb)

## Test plan

Manually tested both rendered markdown and rendered notebooks in both the react and svelte webapp. No more clipping.
![screenshot-2024-05-13_13-21-46@2x](https://github.com/sourcegraph/sourcegraph/assets/12631702/64371af3-ea0b-4724-add8-6380f66e59f6)
