### PR TITLE
URL Path Escape Model Name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Fixed
 
+- Fix a bug that caused Bedrock Provisioned Throughput model names to fail [#62642](https://github.com/sourcegraph/sourcegraph/pull/62642)
+
 ## 5.4.0
 
 ### Added

--- a/internal/completions/client/awsbedrock/bedrock.go
+++ b/internal/completions/client/awsbedrock/bedrock.go
@@ -241,9 +241,9 @@ func (c *awsBedrockAnthropicCompletionStreamClient) makeRequest(ctx context.Cont
 	}
 
 	if stream {
-		apiURL.Path = fmt.Sprintf("/model/%s/invoke-with-response-stream", requestParams.Model)
+		apiURL.Path = fmt.Sprintf("/model/%s/invoke-with-response-stream", url.PathEscape(requestParams.Model))
 	} else {
-		apiURL.Path = fmt.Sprintf("/model/%s/invoke", requestParams.Model)
+		apiURL.Path = fmt.Sprintf("/model/%s/invoke", url.PathEscape(requestParams.Model))
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, apiURL.String(), bytes.NewReader(reqBody))


### PR DESCRIPTION
URL Model names weren't path-escaped leading to issues with Bedrock provisioned throughput model names that include `:` and `/` characters. 

## Test plan

- Existing unit tests should pass
