### PR TITLE
sg/msp: fix typo in exernal_health_check description

### DIFF
--- a/dev/managedservicesplatform/stacks/monitoring/service.go
+++ b/dev/managedservicesplatform/stacks/monitoring/service.go
@@ -161,7 +161,7 @@ func createExternalHealthcheckAlert(
 
 		ID:          "external_health_check",
 		Name:        "External Uptime Check",
-		Description: fmt.Sprintf("Service is failing to repond on https://%s - this may be expected if the service was recently provisioned or if its external domain has changed.", externalDNS),
+		Description: fmt.Sprintf("Service is failing to respond on https://%s - this may be expected if the service was recently provisioned or if its external domain has changed.", externalDNS),
 
 		// If a service is not reachable, it's definitely a problem.
 		Severity: alertpolicy.SeverityLevelCritical,


### PR DESCRIPTION
Noticed a typo while looking at a diff in the managed-services repo
## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
ci