### PR TITLE
appliance: namespace scoping

### DIFF
--- a/cmd/appliance/shared/BUILD.bazel
+++ b/cmd/appliance/shared/BUILD.bazel
@@ -24,6 +24,7 @@ go_library(
         "@io_k8s_client_go//tools/clientcmd",
         "@io_k8s_client_go//util/homedir",
         "@io_k8s_sigs_controller_runtime//:controller-runtime",
+        "@io_k8s_sigs_controller_runtime//pkg/cache",
         "@io_k8s_sigs_controller_runtime//pkg/client",
         "@io_k8s_sigs_controller_runtime//pkg/metrics/server",
         "@org_golang_google_grpc//:go_default_library",

--- a/cmd/appliance/shared/config.go
+++ b/cmd/appliance/shared/config.go
@@ -6,6 +6,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/util/homedir"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
@@ -17,6 +18,7 @@ type Config struct {
 	k8sConfig *rest.Config
 	metrics   metricsConfig
 	grpc      grpcConfig
+	namespace string
 }
 
 func (c *Config) Load() {
@@ -37,6 +39,7 @@ func (c *Config) Load() {
 	c.metrics.addr = c.Get("APPLIANCE_METRICS_ADDR", ":8080", "Appliance metrics server address.")
 	c.metrics.secure = c.GetBool("APPLIANCE_METRICS_SECURE", "false", "Appliance metrics server uses https.")
 	c.grpc.addr = c.Get("APPLIANCE_GRPC_ADDR", ":9000", "Appliance gRPC address.")
+	c.namespace = c.Get("APPLIANCE_NAMESPACE", cache.AllNamespaces, "Namespace to monitor. Defaults to all.")
 }
 
 func (c *Config) Validate() error {

--- a/cmd/appliance/shared/shared.go
+++ b/cmd/appliance/shared/shared.go
@@ -10,6 +10,7 @@ import (
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
@@ -44,6 +45,11 @@ func Start(ctx context.Context, observationCtx *observation.Context, ready servi
 		Metrics: metricsserver.Options{
 			BindAddress:   config.metrics.addr,
 			SecureServing: config.metrics.secure,
+		},
+		Cache: cache.Options{
+			DefaultNamespaces: map[string]cache.Config{
+				config.namespace: {},
+			},
 		},
 	})
 	if err != nil {


### PR DESCRIPTION
Allow a namespace to be configured, defaulting to all namespaces.
Without this setting, if an admin deploys the appliance with
namespace-scoped RBAC, it would throw errors due to not being able to
watch ConfigMaps in all namespaces.

## Test plan

Manually tested for now:

1. With default config, all namespaces are watched
1. With a particular namespace configured, that namespace is watched, but configmaps landing in other namespaces do not trigger the reconcile loop.

When we have blackbox/smoke tests, the code in this package will be better-tested.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
