### PR TITLE
web: Cycle through in-file search results when pressing the numpad enter key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to Sourcegraph are documented in this file.
 ### Fixed
 
 - Fix a bug that caused Bedrock Provisioned Throughput model names to fail [#62642](https://github.com/sourcegraph/sourcegraph/pull/62642)
+- Pressing the numpad `Enter` key will now cycle through in-file search results [#62665](https://github.com/sourcegraph/sourcegraph/pull/62665)
 
 ## 5.4.0
 

--- a/client/web/src/repo/blob/codemirror/search.tsx
+++ b/client/web/src/repo/blob/codemirror/search.tsx
@@ -356,7 +356,7 @@ class SearchPanel implements Panel {
     private onkeydown = (event: KeyboardEvent): void => {
         if (runScopeHandlers(this.view, event, 'search-panel')) {
             event.preventDefault()
-        } else if (event.code === 'Enter' && event.target === this.input) {
+        } else if (event.key === 'Enter' && event.target === this.input) {
             event.preventDefault()
             if (event.shiftKey) {
                 this.findPrevious()


### PR DESCRIPTION
We already cycle through results when pressing the "normal" Enter key. This didn't work for the numpad enter key because `event.code` reports `NumpadEnter`, not `Enter`. `event.key` returns the same value for both keys.

This was adjusted in response to customer feedback.


## Test plan

Manual testing.
