### PR TITLE
appliance: default storageclass is nil

### DIFF
--- a/internal/appliance/defaults.go
+++ b/internal/appliance/defaults.go
@@ -29,9 +29,6 @@ func newDefaultConfig() Sourcegraph {
 					PrometheusPort: pointers.Ptr(6060),
 				},
 			},
-			StorageClass: StorageClassSpec{
-				Name: "sourcegraph",
-			},
 			Symbols: SymbolsSpec{
 				StandardConfig: config.StandardConfig{
 					PrometheusPort: pointers.Ptr(6060),

--- a/internal/appliance/spec.go
+++ b/internal/appliance/spec.go
@@ -230,7 +230,7 @@ type WorkerSpec struct {
 type StorageClassSpec struct {
 	// Name is the name of the storageClass.
 	// Default: sourcegraph
-	Name string `json:"name,omitempty"`
+	Name *string `json:"name,omitempty"`
 
 	// Create will enable/disable the creation of storageClass.
 	// Enable if you have your own existing storage class.

--- a/internal/appliance/standard_config_test.go
+++ b/internal/appliance/standard_config_test.go
@@ -16,6 +16,7 @@ func (suite *ApplianceTestSuite) TestStandardFeatures() {
 		{name: "standard/symbols-with-custom-image"},
 		{name: "standard/redis-with-multiple-custom-images"},
 		{name: "standard/precise-code-intel-with-env-vars"},
+		{name: "standard/blobstore-with-named-storage-class"},
 	} {
 		suite.Run(tc.name, func() {
 			namespace := suite.createConfigMap(tc.name)

--- a/internal/appliance/testdata/golden-fixtures/blobstore/default.yaml
+++ b/internal/appliance/testdata/golden-fixtures/blobstore/default.yaml
@@ -180,7 +180,6 @@ resources:
     resources:
       requests:
         storage: 100Gi
-    storageClassName: sourcegraph
     volumeMode: Filesystem
   status:
     phase: Pending

--- a/internal/appliance/testdata/golden-fixtures/gitserver/default.yaml
+++ b/internal/appliance/testdata/golden-fixtures/gitserver/default.yaml
@@ -132,7 +132,6 @@ resources:
         resources:
           requests:
             storage: 200Gi
-        storageClassName: sourcegraph
         volumeMode: Filesystem
       status:
         phase: Pending

--- a/internal/appliance/testdata/golden-fixtures/gitserver/with-storage.yaml
+++ b/internal/appliance/testdata/golden-fixtures/gitserver/with-storage.yaml
@@ -132,7 +132,6 @@ resources:
         resources:
           requests:
             storage: 500Gi
-        storageClassName: sourcegraph
         volumeMode: Filesystem
       status:
         phase: Pending

--- a/internal/appliance/testdata/golden-fixtures/pgsql/default.yaml
+++ b/internal/appliance/testdata/golden-fixtures/pgsql/default.yaml
@@ -398,7 +398,6 @@ resources:
     resources:
       requests:
         storage: 200Gi
-    storageClassName: sourcegraph
     volumeMode: Filesystem
   status:
     phase: Pending

--- a/internal/appliance/testdata/golden-fixtures/pgsql/with-storage.yaml
+++ b/internal/appliance/testdata/golden-fixtures/pgsql/with-storage.yaml
@@ -399,7 +399,6 @@ resources:
     resources:
       requests:
         storage: 500Gi
-    storageClassName: sourcegraph
     volumeMode: Filesystem
   status:
     phase: Pending

--- a/internal/appliance/testdata/golden-fixtures/precise-code-intel/with-blobstore.yaml
+++ b/internal/appliance/testdata/golden-fixtures/precise-code-intel/with-blobstore.yaml
@@ -304,7 +304,6 @@ resources:
     resources:
       requests:
         storage: 100Gi
-    storageClassName: sourcegraph
     volumeMode: Filesystem
   status:
     phase: Pending

--- a/internal/appliance/testdata/golden-fixtures/redis/default.yaml
+++ b/internal/appliance/testdata/golden-fixtures/redis/default.yaml
@@ -340,7 +340,6 @@ resources:
     resources:
       requests:
         storage: 100Gi
-    storageClassName: sourcegraph
     volumeMode: Filesystem
   status:
     phase: Pending
@@ -371,7 +370,6 @@ resources:
     resources:
       requests:
         storage: 100Gi
-    storageClassName: sourcegraph
     volumeMode: Filesystem
   status:
     phase: Pending

--- a/internal/appliance/testdata/golden-fixtures/redis/with-storage.yaml
+++ b/internal/appliance/testdata/golden-fixtures/redis/with-storage.yaml
@@ -342,7 +342,6 @@ resources:
     resources:
       requests:
         storage: 123Gi
-    storageClassName: sourcegraph
     volumeMode: Filesystem
   status:
     phase: Pending
@@ -373,7 +372,6 @@ resources:
     resources:
       requests:
         storage: 123Gi
-    storageClassName: sourcegraph
     volumeMode: Filesystem
   status:
     phase: Pending

--- a/internal/appliance/testdata/golden-fixtures/standard/blobstore-subsequent-disable.yaml
+++ b/internal/appliance/testdata/golden-fixtures/standard/blobstore-subsequent-disable.yaml
@@ -94,7 +94,6 @@ resources:
     resources:
       requests:
         storage: 100Gi
-    storageClassName: sourcegraph
     volumeMode: Filesystem
   status:
     phase: Pending

--- a/internal/appliance/testdata/golden-fixtures/standard/blobstore-with-named-storage-class.yaml
+++ b/internal/appliance/testdata/golden-fixtures/standard/blobstore-with-named-storage-class.yaml
@@ -3,15 +3,15 @@ resources:
   kind: Deployment
   metadata:
     annotations:
-      appliance.sourcegraph.com/configHash: 47d66a78b1de65fcfbf8ab61f1629a4e0eaec6b84314237799f4e7cb02ac1d2f
+      appliance.sourcegraph.com/configHash: d33e42f7a0651e109c1a55ae881f9e3000e194cb5257dad1714cf26d5a370b3c
     creationTimestamp: "2024-04-19T00:00:00Z"
     generation: 1
     labels:
-      app.kubernetes.io/component: redis-cache
+      app.kubernetes.io/component: blobstore
       app.kubernetes.io/name: sourcegraph
       app.kubernetes.io/version: 5.3.9104
       deploy: sourcegraph
-    name: redis-cache
+    name: blobstore
     namespace: NORMALIZED_FOR_TESTING
     ownerReferences:
     - apiVersion: v1
@@ -29,100 +29,64 @@ resources:
     revisionHistoryLimit: 10
     selector:
       matchLabels:
-        app: redis-cache
+        app: blobstore
     strategy:
-      type: Recreate
+      rollingUpdate:
+        maxSurge: 25%
+        maxUnavailable: 25%
+      type: RollingUpdate
     template:
       metadata:
         annotations:
-          kubectl.kubernetes.io/default-container: redis-cache
+          kubectl.kubernetes.io/default-container: blobstore
         creationTimestamp: null
         labels:
-          app: redis-cache
+          app: blobstore
           deploy: sourcegraph
-        name: redis-cache
+        name: blobstore
       spec:
         containers:
-        - image: index.docker.io/sourcegraph/redis-custom-image:default
+        - image: index.docker.io/sourcegraph/blobstore:5.3.2@sha256:d625be1eefe61cc42f94498e3c588bf212c4159c8b20c519db84eae4ff715efa
           imagePullPolicy: IfNotPresent
-          livenessProbe:
-            failureThreshold: 2
-            initialDelaySeconds: 60
-            periodSeconds: 30
-            successThreshold: 1
-            tcpSocket:
-              port: redis
-            timeoutSeconds: 5
-          name: redis-cache
+          name: blobstore
           ports:
-          - containerPort: 6379
-            name: redis
+          - containerPort: 9000
+            name: blobstore
             protocol: TCP
-          readinessProbe:
-            exec:
-              command:
-              - /bin/sh
-              - -c
-              - "\n#!/bin/bash\nif [ -f /etc/redis/redis.conf ]; then\n  REDISCLI_AUTH=$(grep
-                -h \"requirepass\" /etc/redis/redis.conf | cut -d ' ' -f 2)\nfi\nresponse=$(\n
-                \ redis-cli ping\n)\nif [ \"$response\" != \"PONG\" ]; then\n  echo
-                \"$response\"\n  exit 1\nfi\n\t\t\t\t\t"
-            failureThreshold: 3
-            initialDelaySeconds: 5
-            periodSeconds: 10
-            successThreshold: 1
-            timeoutSeconds: 1
           resources:
             limits:
               cpu: "1"
-              memory: 7Gi
+              memory: 500M
             requests:
               cpu: "1"
-              memory: 7Gi
+              memory: 500M
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
-            runAsGroup: 1000
-            runAsUser: 999
+            runAsGroup: 101
+            runAsUser: 100
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: FallbackToLogsOnError
           volumeMounts:
-          - mountPath: /redis-data
-            name: redis-data
-        - image: index.docker.io/sourcegraph/redis-exporter-custom-image:default
-          imagePullPolicy: IfNotPresent
-          name: redis-exporter
-          ports:
-          - containerPort: 9121
-            name: redisexp
-            protocol: TCP
-          resources:
-            limits:
-              cpu: 10m
-              memory: 100Mi
-            requests:
-              cpu: 10m
-              memory: 100Mi
-          securityContext:
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            runAsGroup: 1000
-            runAsUser: 999
-          terminationMessagePath: /dev/termination-log
-          terminationMessagePolicy: FallbackToLogsOnError
+          - mountPath: /blobstore
+            name: blobstore
+          - mountPath: /data
+            name: blobstore-data
         dnsPolicy: ClusterFirst
         restartPolicy: Always
         schedulerName: default-scheduler
         securityContext:
-          fsGroup: 1000
+          fsGroup: 101
           fsGroupChangePolicy: OnRootMismatch
           runAsGroup: 101
           runAsUser: 100
         terminationGracePeriodSeconds: 30
         volumes:
-        - name: redis-data
+        - emptyDir: {}
+          name: blobstore
+        - name: blobstore-data
           persistentVolumeClaim:
-            claimName: redis-cache
+            claimName: blobstore
   status: {}
 - apiVersion: v1
   data:
@@ -130,8 +94,7 @@ resources:
       spec:
         requestedVersion: "5.3.9104"
 
-        blobstore:
-          disabled: true
+        blobstore: {}
 
         codeInsights:
           disabled: true
@@ -161,11 +124,7 @@ resources:
           disabled: true
 
         redisCache:
-          containerConfig:
-            redis-cache:
-              image: redis-custom-image:default
-            redis-exporter:
-              image: redis-exporter-custom-image:default
+          disabled: true
 
         redisStore:
           disabled: true
@@ -184,6 +143,9 @@ resources:
 
         worker:
           disabled: true
+
+        storageClass:
+          name: sourcegraph
   kind: ConfigMap
   metadata:
     annotations:
@@ -198,13 +160,13 @@ resources:
   kind: PersistentVolumeClaim
   metadata:
     annotations:
-      appliance.sourcegraph.com/configHash: 47d66a78b1de65fcfbf8ab61f1629a4e0eaec6b84314237799f4e7cb02ac1d2f
+      appliance.sourcegraph.com/configHash: d33e42f7a0651e109c1a55ae881f9e3000e194cb5257dad1714cf26d5a370b3c
     creationTimestamp: "2024-04-19T00:00:00Z"
     finalizers:
     - kubernetes.io/pvc-protection
     labels:
       deploy: sourcegraph
-    name: redis-cache
+    name: blobstore
     namespace: NORMALIZED_FOR_TESTING
     ownerReferences:
     - apiVersion: v1
@@ -221,47 +183,21 @@ resources:
     resources:
       requests:
         storage: 100Gi
+    storageClassName: sourcegraph
     volumeMode: Filesystem
   status:
     phase: Pending
 - apiVersion: v1
-  data:
-    endpoint: cmVkaXMtY2FjaGU6NjM3OQ==
-  kind: Secret
-  metadata:
-    annotations:
-      appliance.sourcegraph.com/configHash: 47d66a78b1de65fcfbf8ab61f1629a4e0eaec6b84314237799f4e7cb02ac1d2f
-    creationTimestamp: "2024-04-19T00:00:00Z"
-    labels:
-      app.kubernetes.io/component: redis-cache
-      app.kubernetes.io/name: sourcegraph
-      app.kubernetes.io/version: 5.3.9104
-      deploy: sourcegraph
-    name: redis-cache
-    namespace: NORMALIZED_FOR_TESTING
-    ownerReferences:
-    - apiVersion: v1
-      blockOwnerDeletion: true
-      controller: true
-      kind: ConfigMap
-      name: sg
-      uid: NORMALIZED_FOR_TESTING
-    resourceVersion: NORMALIZED_FOR_TESTING
-    uid: NORMALIZED_FOR_TESTING
-  type: Opaque
-- apiVersion: v1
   kind: Service
   metadata:
     annotations:
-      appliance.sourcegraph.com/configHash: 47d66a78b1de65fcfbf8ab61f1629a4e0eaec6b84314237799f4e7cb02ac1d2f
-      prometheus.io/port: "9121"
-      sourcegraph.prometheus/scrape: "true"
+      appliance.sourcegraph.com/configHash: d33e42f7a0651e109c1a55ae881f9e3000e194cb5257dad1714cf26d5a370b3c
     creationTimestamp: "2024-04-19T00:00:00Z"
     labels:
-      app: redis-cache
-      app.kubernetes.io/component: redis-cache
+      app: blobstore
+      app.kubernetes.io/component: blobstore
       deploy: sourcegraph
-    name: redis-cache
+    name: blobstore
     namespace: NORMALIZED_FOR_TESTING
     ownerReferences:
     - apiVersion: v1
@@ -281,12 +217,12 @@ resources:
     - IPv4
     ipFamilyPolicy: SingleStack
     ports:
-    - name: redis
-      port: 6379
+    - name: blobstore
+      port: 9000
       protocol: TCP
-      targetPort: redis
+      targetPort: blobstore
     selector:
-      app: redis-cache
+      app: blobstore
     sessionAffinity: None
     type: ClusterIP
   status:

--- a/internal/appliance/testdata/golden-fixtures/standard/symbols-with-custom-image.yaml
+++ b/internal/appliance/testdata/golden-fixtures/standard/symbols-with-custom-image.yaml
@@ -156,7 +156,6 @@ resources:
         resources:
           requests:
             storage: 12Gi
-        storageClassName: sourcegraph
         volumeMode: Filesystem
       status:
         phase: Pending

--- a/internal/appliance/testdata/golden-fixtures/symbols/default.yaml
+++ b/internal/appliance/testdata/golden-fixtures/symbols/default.yaml
@@ -156,7 +156,6 @@ resources:
         resources:
           requests:
             storage: 12Gi
-        storageClassName: sourcegraph
         volumeMode: Filesystem
       status:
         phase: Pending

--- a/internal/appliance/testdata/golden-fixtures/symbols/with-storage.yaml
+++ b/internal/appliance/testdata/golden-fixtures/symbols/with-storage.yaml
@@ -156,7 +156,6 @@ resources:
         resources:
           requests:
             storage: 100Gi
-        storageClassName: sourcegraph
         volumeMode: Filesystem
       status:
         phase: Pending

--- a/internal/appliance/testdata/sg/standard/blobstore-with-named-storage-class.yaml
+++ b/internal/appliance/testdata/sg/standard/blobstore-with-named-storage-class.yaml
@@ -1,0 +1,55 @@
+spec:
+  requestedVersion: "5.3.9104"
+
+  blobstore: {}
+
+  codeInsights:
+    disabled: true
+
+  codeIntel:
+    disabled: true
+
+  frontend:
+    disabled: true
+
+  gitServer:
+    disabled: true
+
+  indexedSearch:
+    disabled: true
+
+  indexedSearchIndexer:
+    disabled: true
+
+  pgsql:
+    disabled: true
+
+  postgresExporter:
+    disabled: true
+
+  preciseCodeIntel:
+    disabled: true
+
+  redisCache:
+    disabled: true
+
+  redisStore:
+    disabled: true
+
+  repoUpdater:
+    disabled: true
+
+  searcher:
+    disabled: true
+
+  symbols:
+    disabled: true
+
+  syntectServer:
+    disabled: true
+
+  worker:
+    disabled: true
+
+  storageClass:
+    name: sourcegraph

--- a/internal/k8s/resource/pvc/pvc.go
+++ b/internal/k8s/resource/pvc/pvc.go
@@ -7,7 +7,7 @@ import (
 )
 
 // NewPersistentVolumeClaim creates a new k8s PVC with some default values set.
-func NewPersistentVolumeClaim(name, namespace string, storage resource.Quantity, storageClassName string) corev1.PersistentVolumeClaim {
+func NewPersistentVolumeClaim(name, namespace string, storage resource.Quantity, storageClassName *string) corev1.PersistentVolumeClaim {
 	return corev1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -25,7 +25,7 @@ func NewPersistentVolumeClaim(name, namespace string, storage resource.Quantity,
 					corev1.ResourceStorage: storage,
 				},
 			},
-			StorageClassName: &storageClassName,
+			StorageClassName: storageClassName,
 		},
 	}
 }


### PR DESCRIPTION
Let Kubernetes choose its default storage class when one is not explicitly configured. See REL-16 for wider plans around StorageClasses at the appliance level.



## Test plan

Golden tests included

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
