### PR TITLE
build-tracker: include timestamp in agent state change events

### DIFF
--- a/dev/build-tracker/bigquery.go
+++ b/dev/build-tracker/bigquery.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"strings"
+	"time"
 
 	"cloud.google.com/go/bigquery"
 	"github.com/buildkite/go-buildkite/v3/buildkite"
@@ -13,7 +14,8 @@ type BigQueryWriter interface {
 }
 
 type BuildkiteAgentEvent struct {
-	event string
+	event     string
+	timestamp time.Time
 	buildkite.Agent
 }
 
@@ -35,6 +37,7 @@ func (b *BuildkiteAgentEvent) Save() (row map[string]bigquery.Value, insertID st
 		"ip_address": *b.IPAddress,
 		"queues":     queues,
 		"user_agent": *b.UserAgent,
+		"timestamp":  b.timestamp,
 	}, "", nil
 }
 

--- a/dev/build-tracker/main.go
+++ b/dev/build-tracker/main.go
@@ -313,6 +313,9 @@ func (s *Server) processEvent(event *build.Event) {
 		if err := s.bqWriter.Write(context.Background(), &BuildkiteAgentEvent{
 			event: event.Name,
 			Agent: event.Agent,
+			// if using HMAC signature from Buildkite, we could get a timestamp from there.
+			// But we don't currently use that method, so we just use the current time.
+			timestamp: time.Now(),
 		}); err != nil {
 			s.logger.Error("failed to write agent event to BigQuery", log.String("event", event.Name), log.String("agentID", *event.Agent.ID))
 		}


### PR DESCRIPTION
🙃  would be useful to have..

## Test plan

Confirmed bigquery code handles time.Time natively by inspecting the code
