### PR TITLE
gitserver(ListRefs): Fix type detection for lightweight tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 - Fix a bug that caused Bedrock Provisioned Throughput model names to fail [#62642](https://github.com/sourcegraph/sourcegraph/pull/62642)
 - Pressing the numpad `Enter` key will now cycle through in-file search results [#62665](https://github.com/sourcegraph/sourcegraph/pull/62665)
+- Fixed an issue where code graph configuration policies would miscategorize lightweight tags as branches. [#62671](https://github.com/sourcegraph/sourcegraph/pull/62671)
 
 ## 5.4.0
 

--- a/cmd/gitserver/internal/git/gitcli/refs.go
+++ b/cmd/gitserver/internal/git/gitcli/refs.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/sourcegraph/sourcegraph/cmd/gitserver/internal/git"
@@ -96,7 +97,7 @@ func (it *refIterator) Next() (*gitdomain.Ref, error) {
 				createdDate = time.Unix(int64(ts), 0)
 			}
 			return &gitdomain.Ref{
-				Type:        refTypeForString(string(parts[0])),
+				Type:        refTypeForString(string(parts[0]), string(parts[2])),
 				Name:        string(parts[2]),
 				ShortName:   string(parts[3]),
 				CommitID:    api.CommitID(parts[5]),
@@ -114,11 +115,16 @@ func (it *refIterator) Next() (*gitdomain.Ref, error) {
 	return nil, io.EOF
 }
 
-func refTypeForString(s string) gitdomain.RefType {
-	switch s {
+func refTypeForString(objTyp, refname string) gitdomain.RefType {
+	switch objTyp {
 	case "tag":
 		return gitdomain.RefTypeTag
 	case "commit":
+		// lightweight tags are just refs that point to a commit, so we need to
+		// check if the refname is a tag ref.
+		if strings.HasPrefix(refname, "refs/tags/") {
+			return gitdomain.RefTypeTag
+		}
 		return gitdomain.RefTypeBranch
 	default:
 		return gitdomain.RefTypeUnknown

--- a/cmd/gitserver/internal/git/gitcli/refs_test.go
+++ b/cmd/gitserver/internal/git/gitcli/refs_test.go
@@ -25,8 +25,10 @@ func TestGitCLIBackend_ListRefs(t *testing.T) {
 		"echo 'hello\nworld\nfrom\nblame\n' > foo.txt",
 		"git add foo.txt",
 		"git commit -m foo --author='Foo Author <foo@sourcegraph.com>'",
-		// Add a tag.
+		// Add an annotated tag.
 		"git tag -a foo-tag -m foo-tag",
+		// Add a lightweight tag.
+		"git tag light-tag",
 		// Add a second commit on a different branch.
 		"git checkout -b foo",
 		"echo 'hello\nworld\nfrom\nthe best blame\n' > foo.txt",
@@ -59,6 +61,20 @@ func TestGitCLIBackend_ListRefs(t *testing.T) {
 			RefOID:      commit,
 			IsHead:      true,
 			Type:        gitdomain.RefTypeBranch,
+			CreatedDate: ref.CreatedDate,
+		}, ref)
+
+		ref, err = it.Next()
+		require.NoError(t, err)
+
+		assert.Equal(t, &gitdomain.Ref{
+			Name:      "refs/tags/light-tag",
+			ShortName: "light-tag",
+			CommitID:  commit,
+			// for lightweight tags, the RefOID is the same as the CommitID.
+			RefOID:      commit,
+			IsHead:      false,
+			Type:        gitdomain.RefTypeTag,
 			CreatedDate: ref.CreatedDate,
 		}, ref)
 
@@ -130,6 +146,20 @@ func TestGitCLIBackend_ListRefs(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.Equal(t, &gitdomain.Ref{
+			Name:      "refs/tags/light-tag",
+			ShortName: "light-tag",
+			CommitID:  commit,
+			// for lightweight tags, the RefOID is the same as the CommitID.
+			RefOID:      commit,
+			IsHead:      false,
+			Type:        gitdomain.RefTypeTag,
+			CreatedDate: ref.CreatedDate,
+		}, ref)
+
+		ref, err = it.Next()
+		require.NoError(t, err)
+
+		assert.Equal(t, &gitdomain.Ref{
 			Name:      "refs/tags/foo-tag",
 			ShortName: "foo-tag",
 			CommitID:  commit,
@@ -164,6 +194,20 @@ func TestGitCLIBackend_ListRefs(t *testing.T) {
 		require.NoError(t, err)
 
 		ref, err := it.Next()
+		require.NoError(t, err)
+
+		assert.Equal(t, &gitdomain.Ref{
+			Name:      "refs/tags/light-tag",
+			ShortName: "light-tag",
+			CommitID:  commit,
+			// for lightweight tags, the RefOID is the same as the CommitID.
+			RefOID:      commit,
+			IsHead:      false,
+			Type:        gitdomain.RefTypeTag,
+			CreatedDate: ref.CreatedDate,
+		}, ref)
+
+		ref, err = it.Next()
 		require.NoError(t, err)
 
 		assert.Equal(t, &gitdomain.Ref{
@@ -242,6 +286,20 @@ func TestGitCLIBackend_ListRefs(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.Equal(t, &gitdomain.Ref{
+			Name:      "refs/tags/light-tag",
+			ShortName: "light-tag",
+			CommitID:  commit,
+			// for lightweight tags, the RefOID is the same as the CommitID.
+			RefOID:      commit,
+			IsHead:      false,
+			Type:        gitdomain.RefTypeTag,
+			CreatedDate: ref.CreatedDate,
+		}, ref)
+
+		ref, err = it.Next()
+		require.NoError(t, err)
+
+		assert.Equal(t, &gitdomain.Ref{
 			Name:      "refs/tags/foo-tag",
 			ShortName: "foo-tag",
 			CommitID:  commit,
@@ -286,6 +344,20 @@ func TestGitCLIBackend_ListRefs(t *testing.T) {
 			RefOID:      commit,
 			IsHead:      true,
 			Type:        gitdomain.RefTypeBranch,
+			CreatedDate: ref.CreatedDate,
+		}, ref)
+
+		ref, err = it.Next()
+		require.NoError(t, err)
+
+		assert.Equal(t, &gitdomain.Ref{
+			Name:      "refs/tags/light-tag",
+			ShortName: "light-tag",
+			CommitID:  commit,
+			// for lightweight tags, the RefOID is the same as the CommitID.
+			RefOID:      commit,
+			IsHead:      false,
+			Type:        gitdomain.RefTypeTag,
 			CreatedDate: ref.CreatedDate,
 		}, ref)
 


### PR DESCRIPTION
In git, there exist two types of tags: Lightweight tags, those are boring old refs that live in refs/tags/ and point directly to a commit.
And then there are annotated tags, those live in refs/tags/ too, but they don't point to a commit directly, instead they point to a tag object, which then points to a commit object.
That is used to add a message to a tag.

However, we didn't detect lightweight tags correctly, so they would be reported as Type: Branch (as they point to a commit).

This PR fixes it.

Test plan:

Added tests and verified manually using gRPC UI.