### PR TITLE
inference: Add missing defer

### DIFF
--- a/internal/codeintel/autoindexing/internal/inference/iface.go
+++ b/internal/codeintel/autoindexing/internal/inference/iface.go
@@ -35,7 +35,7 @@ func (s *gitService) ReadDir(ctx context.Context, repo api.RepoName, commit api.
 	if err != nil {
 		return nil, err
 	}
-	it.Close()
+	defer it.Close()
 
 	files := make([]fs.FileInfo, 0)
 	for {


### PR DESCRIPTION
Hi. It's me, crashy mc crasher.
This causes inference jobs to always return a context cancelled error. Not sure how that slipped through.

Luckily, we waited with merging this change until after the release so this shouldn't affect any customers.

Test plan:

Verified that locally inference works again.