### PR TITLE
Svelte: follow up on display limit TODO

### DIFF
--- a/client/web-sveltekit/src/routes/search/+page.ts
+++ b/client/web-sveltekit/src/routes/search/+page.ts
@@ -82,7 +82,7 @@ class NonCachingStreamManager {
 
 const streamManager = browser ? new CachingStreamManager() : new NonCachingStreamManager()
 
-export const load: PageLoad = ({ url, depends }) => {
+export const load: PageLoad = async ({ parent, url, depends }) => {
     const hasQuery = url.searchParams.has('q')
     const cachePolicy = getCachePolicyFromURL(url)
     const trace = url.searchParams.get('trace') ?? undefined
@@ -116,8 +116,7 @@ export const load: PageLoad = ({ url, depends }) => {
             featureOverrides: [],
             chunkMatches: true,
             searchMode,
-            // TODO: populate this from user settings
-            displayLimit: 1500,
+            displayLimit: (await parent()).settings?.['search.displayLimit'] ?? 1500,
             // 5kb is a conservative upper bound on a reasonable line to show
             // to a user. In practice we can likely go much lower.
             maxLineLen: 5 * 1024,


### PR DESCRIPTION
This updates the svelte webapp to respect the new `search.displayLimit`.

Followup from https://github.com/sourcegraph/sourcegraph/pull/60761

## Test plan

Added `search.displayLimit: 2000` to my settings, checked that the resulting search request had `displayLimit=2000` in the URL