### PR TITLE
Revert "Svelte [RepoPopover]: Instantiate the RepoPopover result across the web-app

### DIFF
--- a/client/web-sveltekit/src/lib/Popover.svelte
+++ b/client/web-sveltekit/src/lib/Popover.svelte
@@ -1,21 +1,19 @@
 <script lang="ts">
     import type { Placement } from '@floating-ui/dom'
-    import type { Action } from 'svelte/action'
 
     import { popover, onClickOutside, portal } from './dom'
+    import type { Action } from 'svelte/action'
 
     export let placement: Placement = 'bottom'
     /**
      * Show the popover when hovering over the trigger.
      */
     export let showOnHover = false
-    export let delay: number | null = null
 
     let isOpen = false
     let trigger: HTMLElement | null
     let target: HTMLElement | undefined
     let popoverContainer: HTMLElement | null
-    let timeoutId: NodeJS.Timeout | undefined
 
     function toggle(open?: boolean): void {
         isOpen = open === undefined ? !isOpen : open
@@ -35,21 +33,10 @@
         trigger = node
 
         function handleMouseEnterTrigger(): void {
-            if (delay) {
-                timeoutId = setTimeout(() => {
-                    isOpen = true
-                }, delay)
-            } else {
-                isOpen = true
-            }
+            isOpen = true
         }
 
         function handleMouseLeaveTrigger(event: MouseEvent): void {
-            // We have to clear the timeout here, otherwise it would be triggered
-            // even if the mouse leaves the trigger before the delay is over.
-            if (delay) {
-                clearTimeout(timeoutId)
-            }
             // It should be possible to move the mouse from the trigger to the popover without closing it
             if (event.relatedTarget && !popoverContainer?.contains(event.relatedTarget as Node)) {
                 isOpen = false
@@ -93,7 +80,6 @@
 <slot {toggle} {registerTrigger} {registerTarget} />
 {#if trigger && isOpen}
     <div
-        use:registerPopoverContainer
         use:portal
         use:onClickOutside
         use:registerPopoverContainer
@@ -120,9 +106,9 @@
         font-size: 0.875rem;
         background-clip: padding-box;
         background-color: var(--dropdown-bg);
-        color: var(--body-color);
-        box-shadow: var(--dropdown-shadow);
-        border: 0;
+        border: 1px solid var(--dropdown-border-color);
         border-radius: var(--popover-border-radius);
+        color: var(--body-color);
+        box-shadow: var(--popover-shadow);
     }
 </style>

--- a/client/web-sveltekit/src/lib/repo/RepoPopover/RepoPopover.gql
+++ b/client/web-sveltekit/src/lib/repo/RepoPopover/RepoPopover.gql
@@ -1,28 +1,31 @@
-fragment RepoPopoverFragment on Repository {
+fragment RepoPopoverFields on Repository {
     name
     description
     stars
     isPrivate
     language
-    topics
     externalServices {
         totalCount
         nodes {
             kind
         }
     }
+    tags {
+        nodes {
+            name
+        }
+    }
 
     commit(rev: "HEAD") {
         id
-            oid
-            abbreviatedOID
-            subject
-            canonicalURL
-            author {
-                date
-                    person {
-                        ...Avatar_Person
-                    }
+        oid
+        subject
+        canonicalURL
+        author {
+            date
+            person {
+                ...Avatar_Person
             }
+        }
     }
 }

--- a/client/web-sveltekit/src/lib/repo/RepoPopover/RepoPopover.stories.svelte
+++ b/client/web-sveltekit/src/lib/repo/RepoPopover/RepoPopover.stories.svelte
@@ -2,7 +2,7 @@
     import { faker } from '@faker-js/faker'
     import { Story } from '@storybook/addon-svelte-csf'
 
-    import { type RepoPopoverFragment, ExternalServiceKind } from '$testing/graphql-type-mocks'
+    import { type RepoPopoverFields, ExternalServiceKind } from '$testing/graphql-type-mocks'
 
     import RepoPopover from './RepoPopover.svelte'
 
@@ -13,18 +13,18 @@
 
 <script lang="ts">
     faker.seed(1)
-    let repo: RepoPopoverFragment = {
+    let repo: RepoPopoverFields = {
         name: `${faker.lorem.word()} / ${faker.lorem.word()}`,
         description: faker.lorem.sentence(),
         stars: faker.datatype.number(),
-        topics: [
-            faker.lorem.word(),
-            faker.lorem.word(),
-            faker.lorem.word(),
-            faker.lorem.word(),
-            faker.lorem.word(),
-            faker.lorem.word(),
-        ],
+        tags: {
+            nodes: [
+                { name: faker.lorem.word() },
+                { name: faker.lorem.word() },
+                { name: faker.lorem.word() },
+                { name: faker.lorem.word() },
+            ],
+        },
         isPrivate: false,
         language: 'Go',
         externalServices: {
@@ -43,7 +43,6 @@
             author: {
                 date: new Date().toISOString(),
                 person: {
-                    __typename: 'Person',
                     displayName: `${faker.person.firstName()} ${faker.person.lastName()}`,
                     avatarURL: faker.internet.avatar(),
                     name: faker.internet.userName(),

--- a/client/web-sveltekit/src/routes/+layout.ts
+++ b/client/web-sveltekit/src/routes/+layout.ts
@@ -5,13 +5,7 @@ import { getGraphQLClient } from '$lib/graphql'
 import type { Settings } from '$lib/shared'
 
 import type { LayoutLoad } from './$types'
-import {
-    Init,
-    EvaluatedFeatureFlagsQuery,
-    GlobalAlertsSiteFlags,
-    DisableSveltePrototype,
-    RepoPopoverQuery,
-} from './layout.gql'
+import { Init, EvaluatedFeatureFlagsQuery, GlobalAlertsSiteFlags, DisableSveltePrototype } from './layout.gql'
 
 // Disable server side rendering for the whole app
 export const ssr = false
@@ -49,13 +43,6 @@ export const load: LayoutLoad = async ({ fetch }) => {
         settings,
         featureFlags: result.data.evaluatedFeatureFlags,
         globalSiteAlerts: globalSiteAlerts.then(result => result.data?.site),
-        fetchRepoPopoverInfo: async (name: string) => {
-            const response = await client.query(RepoPopoverQuery, { repoName: name })
-            if (!response.data || response.error) {
-                throw new Error(`Failed to fetch repo info: ${response.error}`)
-            }
-            return response.data.repository
-        },
         fetchEvaluatedFeatureFlags: async () => {
             const result = await client.query(EvaluatedFeatureFlagsQuery, {}, { requestPolicy: 'network-only', fetch })
             if (!result.data || result.error) {

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/+layout.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/+layout.svelte
@@ -9,15 +9,15 @@
         mdiTag,
         mdiDotsHorizontal,
     } from '@mdi/js'
-    import { writable } from 'svelte/store'
 
+    import { writable } from 'svelte/store'
+    import { page } from '$app/stores'
     import { getButtonClassName } from '@sourcegraph/wildcard'
 
-    import { page } from '$app/stores'
     import { computeFit } from '$lib/dom'
+    import { DropdownMenu, MenuLink } from '$lib/wildcard'
     import Icon from '$lib/Icon.svelte'
     import GlobalHeaderPortal from '$lib/navigation/GlobalHeaderPortal.svelte'
-    import { DropdownMenu, MenuLink } from '$lib/wildcard'
 
     import type { LayoutData } from './$types'
     import RepoSearchInput from './RepoSearchInput.svelte'

--- a/client/web-sveltekit/src/routes/layout.gql
+++ b/client/web-sveltekit/src/routes/layout.gql
@@ -24,12 +24,6 @@ query GlobalAlertsSiteFlags {
     }
 }
 
-query RepoPopoverQuery($repoName: String!){
-    repository(name: $repoName) {
-        ...RepoPopoverFragment
-    }
-}
-
 mutation DisableSveltePrototype($userID: ID!) {
     overrideWebNext: createFeatureFlagOverride(namespace: $userID, flagName: "web-next", value: false) {
         __typename

--- a/client/web-sveltekit/src/routes/search/RepoRev.svelte
+++ b/client/web-sveltekit/src/routes/search/RepoRev.svelte
@@ -1,28 +1,12 @@
 <script lang="ts">
     import { highlightRanges } from '$lib/dom'
-    import { getGraphQLClient } from '$lib/graphql'
-    import Popover from '$lib/Popover.svelte'
-    import RepoPopover from '$lib/repo/RepoPopover/RepoPopover.svelte'
     import CodeHostIcon from '$lib/search/CodeHostIcon.svelte'
     import { displayRepoName } from '$lib/shared'
-
-    import { RepoPopoverQuery } from '../layout.gql'
 
     export let repoName: string
     export let rev: string | undefined
     export let highlights: [number, number][] = []
 
-    const fetchPopoverInfo = async () => {
-        const client = getGraphQLClient()
-        const popoverInfo = await client.query(RepoPopoverQuery, { repoName })
-        if (popoverInfo.data) {
-            return popoverInfo.data.repository
-        }
-        console.error('Failed to fetch popover info for', popoverInfo.error)
-        throw new Error('Failed to fetch popover info', popoverInfo.error)
-    }
-
-    $: popoverInfo = fetchPopoverInfo()
     $: href = `/${repoName}${rev ? `@${rev}` : ''}`
     $: displayName = displayRepoName(repoName)
     $: if (displayName !== repoName) {
@@ -37,21 +21,12 @@
     <CodeHostIcon repository={repoName} />
     <!-- #key is needed here to recreate the link because use:highlightRanges changes the DOM -->
     {#key highlights}
-        <Popover showOnHover let:registerTrigger placement="bottom-start" delay={300}>
-            <a class="repo-link" {href} use:highlightRanges={{ ranges: highlights }} use:registerTrigger>
-                {displayRepoName(repoName)}
-                {#if rev}
-                    <small class="rev"> @ {rev}</small>
-                {/if}
-            </a>
-            <svelte:fragment slot="content">
-                {#await popoverInfo then popoverInfo}
-                    {#if popoverInfo !== null}
-                        <RepoPopover repo={popoverInfo} withHeader={true} />
-                    {/if}
-                {/await}
-            </svelte:fragment>
-        </Popover>
+        <a class="repo-link" {href} use:highlightRanges={{ ranges: highlights }}>
+            {displayRepoName(repoName)}
+            {#if rev}
+                <small class="rev"> @ {rev}</small>
+            {/if}
+        </a>
     {/key}
 </span>
 
@@ -62,8 +37,9 @@
         gap: 0.375rem;
 
         .repo-link {
-            align-self: flex-start;
-            color: var(--text-body);
+            align-self: baseline;
+            color: var(--body-color);
+            font-weight: 500;
             .rev {
                 color: var(--text-muted);
             }

--- a/client/web-sveltekit/src/routes/search/SearchResults.svelte
+++ b/client/web-sveltekit/src/routes/search/SearchResults.svelte
@@ -174,13 +174,6 @@
                             <SearchAlert alert={$stream.alert} />
                         </div>
                     {/if}
-                    <!--
-                        TODO: Address accessibility issues
-                        1. A11y: visible, non-interactive elements with an on:click event
-                           must be accompanied by an on:keydown, on:keyup, or on:keypress event.
-                        2. A11y: Non-interactive element <ol> should not be assigned mouse
-                           or keyboard event listeners.
-                    -->
                     <ol on:click={handleSearchResultClick} on:copy={handleResultCopy}>
                         {#each resultsToShow as result, i}
                             {@const component = getSearchResultComponent(result)}


### PR DESCRIPTION
Revert https://github.com/sourcegraph/sourcegraph/pull/61989
This reverts commit 0d8003f6553bd5bc39cb4d878b274c6698d93bf3.

It seems that this PR introduced a few problems with Popover styles and it also 
adds problematic data fetching on the search result page (we make too many requests as we render different search result blocks); there is also the problem that most of the requests for the repo rev tooltip fail because of auth error. 

I revert it for now, but will mark this one as something I check that will go to the June release since Jason did most of the work already, we just need to tune it a bit. 

## Test plan
- Check that Popover looks ok in the web app (repository revision, opt-in experiment tooltip, ...)
- Check that Search result repository doesn't produce a lot of queries as we render them
