### PR TITLE
msp/cloudrun: use GA launch stage

### DIFF
--- a/dev/managedservicesplatform/stacks/cloudrun/internal/builder/job/job.go
+++ b/dev/managedservicesplatform/stacks/cloudrun/internal/builder/job/job.go
@@ -81,11 +81,9 @@ func (b *jobBuilder) AddDependency(dep cdktf.ITerraformDependable) {
 
 func (b *jobBuilder) Build(stack cdktf.TerraformStack, vars builder.Variables) (builder.Resource, error) {
 	var vpcAccess *cloudrunv2job.CloudRunV2JobTemplateTemplateVpcAccess
-	var launchStage *string
 	if vars.PrivateNetwork != nil {
 		// https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloud_run_v2_service#example-usage---cloudrunv2-service-directvpc
 		// https://cloud.google.com/run/docs/configuring/vpc-direct-vpc
-		launchStage = pointers.Ptr("BETA") // Direct VPC is still in beta.
 		vpcAccess = &cloudrunv2job.CloudRunV2JobTemplateTemplateVpcAccess{
 			NetworkInterfaces: &[]*cloudrunv2job.CloudRunV2JobTemplateTemplateVpcAccessNetworkInterfaces{{
 				Network:    vars.PrivateNetwork.Network.Id(),
@@ -107,8 +105,6 @@ func (b *jobBuilder) Build(stack cdktf.TerraformStack, vars builder.Variables) (
 		Name:      pointers.Ptr(name),
 		Location:  pointers.Ptr(vars.GCPRegion),
 		DependsOn: &b.dependencies,
-
-		LaunchStage: launchStage,
 
 		Template: &cloudrunv2job.CloudRunV2JobTemplate{
 			TaskCount: pointers.Ptr(float64(1)),

--- a/dev/managedservicesplatform/stacks/cloudrun/internal/builder/service/service.go
+++ b/dev/managedservicesplatform/stacks/cloudrun/internal/builder/service/service.go
@@ -86,11 +86,9 @@ func (b *serviceBuilder) AddDependency(dep cdktf.ITerraformDependable) {
 
 func (b *serviceBuilder) Build(stack cdktf.TerraformStack, vars builder.Variables) (builder.Resource, error) {
 	var vpcAccess *cloudrunv2service.CloudRunV2ServiceTemplateVpcAccess
-	var launchStage *string
 	if vars.PrivateNetwork != nil {
 		// https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloud_run_v2_service#example-usage---cloudrunv2-service-directvpc
 		// https://cloud.google.com/run/docs/configuring/vpc-direct-vpc
-		launchStage = pointers.Ptr("BETA") // Direct VPC is still in beta.
 		vpcAccess = &cloudrunv2service.CloudRunV2ServiceTemplateVpcAccess{
 			NetworkInterfaces: &[]*cloudrunv2service.CloudRunV2ServiceTemplateVpcAccessNetworkInterfaces{{
 				Network:    vars.PrivateNetwork.Network.Id(),
@@ -139,8 +137,6 @@ func (b *serviceBuilder) Build(stack cdktf.TerraformStack, vars builder.Variable
 		Location:  pointers.Ptr(vars.GCPRegion),
 		DependsOn: &b.dependencies,
 		Lifecycle: lifecycle,
-
-		LaunchStage: launchStage,
 
 		//  Disallows direct traffic from public internet, we have a LB set up for that.
 		Ingress: pointers.Ptr("INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER"),


### PR DESCRIPTION
VPC direct egress is now GA: see example in https://registry.terraform.io/providers/hashicorp/google/5.29.0/docs/resources/cloud_run_v2_service#example-usage---cloudrunv2-service-directvpc and https://cloud.google.com/run/docs/configuring/vpc-direct-vpc

![image](https://github.com/sourcegraph/sourcegraph/assets/23356519/93e7df59-d8c1-4b44-ad9e-c80682718c66)

This also fixes the infinite `GA` -> `BETA` drift we have in TFC

## Test plan

n/a