### PR TITLE
Symbols: new backend integration test

### DIFF
--- a/dev/gqltest/BUILD.bazel
+++ b/dev/gqltest/BUILD.bazel
@@ -17,6 +17,7 @@ go_test(
         "search_test.go",
         "site_config_test.go",
         "sub_repo_permissions_test.go",
+        "symbol_search_test.go",
     ],
     visibility = [
         "//testing:__pkg__",

--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -260,27 +260,6 @@ func testSearchClient(t *testing.T, client searchClient) {
 		}
 	})
 
-	t.Run("lang: filter with case sensitivity", func(t *testing.T) {
-		// Guard against a previous regression where case sensitivity broke lang filters. This search
-		// query closely mimics the one the web client ues for search-based code navigation.
-		results, err := client.SearchFiles("type:symbol ^readLine$ lang:go case:yes patterntype:regexp")
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		// Ensure some results are returned
-		if len(results.Results) == 0 {
-			t.Fatal("Want non-zero results but got none")
-		}
-
-		// Make sure we only got .go files
-		for _, r := range results.Results {
-			if !strings.Contains(strings.ToLower(r.File.Name), ".go") {
-				t.Fatalf("Found file name does not end with .go: %s", r.File.Name)
-			}
-		}
-	})
-
 	t.Run("excluding repositories", func(t *testing.T) {
 		results, err := client.SearchFiles("fmt.Sprintf -repo:jsonrpc2")
 		if err != nil {
@@ -665,16 +644,6 @@ func testSearchClient(t *testing.T, client searchClient) {
 			{
 				name:       "search for a non-existent file",
 				query:      "file:asdfasdf.go",
-				zeroResult: true,
-			},
-			// Symbol search
-			{
-				name:  "search for a known symbol",
-				query: "type:symbol count:100 patterntype:regexp ^newroute",
-			},
-			{
-				name:       "search for a non-existent symbol",
-				query:      "type:symbol asdfasdf",
 				zeroResult: true,
 			},
 			// Commit search

--- a/dev/gqltest/symbol_search_test.go
+++ b/dev/gqltest/symbol_search_test.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/sourcegraph/sourcegraph/internal/extsvc"
+	"github.com/sourcegraph/sourcegraph/internal/gqltestutil"
+)
+
+func TestSymbolSearch(t *testing.T) {
+	if len(*githubToken) == 0 {
+		t.Skip("Environment variable GITHUB_TOKEN is not set")
+	}
+
+	// Set up external service
+	esID, err := client.AddExternalService(gqltestutil.AddExternalServiceInput{
+		Kind:        extsvc.KindGitHub,
+		DisplayName: "gqltest-github-search",
+		Config: mustMarshalJSONString(struct {
+			URL                   string   `json:"url"`
+			Token                 string   `json:"token"`
+			Repos                 []string `json:"repos"`
+			RepositoryPathPattern string   `json:"repositoryPathPattern"`
+		}{
+			URL:   "https://ghe.sgdev.org/",
+			Token: *githubToken,
+			Repos: []string{
+				"sgtest/java-langserver",
+				"sgtest/go-diff",
+			},
+			RepositoryPathPattern: "github.com/{nameWithOwner}",
+		}),
+	})
+	require.NoError(t, err)
+
+	removeExternalServiceAfterTest(t, esID)
+
+	err = client.WaitForReposToBeIndexed(
+		"github.com/sgtest/java-langserver",
+		"github.com/sgtest/go-diff",
+	)
+	require.NoError(t, err)
+
+	cases := []struct {
+		name          string
+		query         string
+		zeroResult    bool
+		wantExtension string
+	}{
+		{
+			name:  "search for a known symbol",
+			query: "type:symbol count:100 patterntype:regexp ^newroute",
+		},
+		{
+			name:       "search for a non-existent symbol",
+			query:      "type:symbol asdfasdf",
+			zeroResult: true,
+		},
+		{
+			name:  "search using boolean expression",
+			query: "type:symbol count:100 newroute OR nonexistentsymbol",
+		},
+		{
+			// Mimic the web client's search for 'go to definition'
+			name:          "code nav: go to definition",
+			query:         "type:symbol ^readLine$ lang:go case:yes patterntype:regexp",
+			wantExtension: ".go",
+		},
+		{
+			// Mimic the web client's search for 'find references'
+			name:          "code nav: find references",
+			query:         "type:file \\bBYTES_TO_GIGABYTES\\b lang:java case:yes patterntype:regexp",
+			wantExtension: ".java",
+		},
+		{
+			// Mimic the web client's search for 'find references' with unrecognized language
+			name:          "code nav: find references with unrecognized language",
+			query:         "type:file \\bLIGHTSTEP_INCLUDE_SENSITIVE\\b file:\\.yml case:yes patterntype:regexp",
+			wantExtension: ".yml",
+		},
+	}
+
+	for _, test := range cases {
+		t.Run(test.name, func(t *testing.T) {
+			results, err := client.SearchFiles(test.query)
+			require.NoError(t, err)
+			require.Nil(t, results.Alert)
+
+			if test.zeroResult {
+				if len(results.Results) > 0 {
+					t.Fatalf("Want zero result but got %d", len(results.Results))
+				}
+			} else {
+				if len(results.Results) == 0 {
+					t.Fatal("Want non-zero results but got 0")
+				}
+			}
+
+			for _, r := range results.Results {
+				if !strings.HasSuffix(strings.ToLower(r.File.Name), test.wantExtension) {
+					t.Fatalf("Found file name that does not end with %s: %s", test.wantExtension, r.File.Name)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR creates a new GraphQL integration test file focused on symbol search.
It exercises the same searches the web client uses for code navigation.

In a follow-up, we will add cases for older commits and enable Rockskip.

## Test plan

Added new tests