### PR TITLE
Auto-update package lockfiles for Sourcegraph base images

### DIFF
--- a/wolfi-images/batcheshelper.lock.json
+++ b/wolfi-images/batcheshelper.lock.json
@@ -52,60 +52,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1LbskMUECTvoctOm3XVAJBe6/+O8=",
+        "checksum": "Q15nzyxTcmhST9dTlB9BxV088pKJY=",
         "control": {
-          "checksum": "sha1-LbskMUECTvoctOm3XVAJBe6/+O8=",
-          "range": "bytes=704-1113"
+          "checksum": "sha1-5nzyxTcmhST9dTlB9BxV088pKJY=",
+          "range": "bytes=697-1107"
         },
         "data": {
-          "checksum": "sha256-U8ueoDdtkVXfQ3r8UKQU+ei8sdAH+ayEnmYIcGEM6S8=",
-          "range": "bytes=1114-267813"
+          "checksum": "sha256-i2qrjtws7OeqrKQP83nQo1vFwjqnO0QM3fSTvHHEKps=",
+          "range": "bytes=1108-267856"
         },
         "name": "ld-linux",
         "signature": {
-          "checksum": "sha1-snzU1ONYjrHMX4b2N117nm2p+9s=",
-          "range": "bytes=0-703"
+          "checksum": "sha1-nJTcI836Gt8XuqjMFUh2BBK4pP4=",
+          "range": "bytes=0-696"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r3.apk",
-        "version": "2.39-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r5.apk",
+        "version": "2.39-r5"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ovjsy4Uk7yfyamNBkynUnsHYFMU=",
+        "checksum": "Q1EuFMRKR/2atKFGKHjH/3vivHPEc=",
         "control": {
-          "checksum": "sha1-ovjsy4Uk7yfyamNBkynUnsHYFMU=",
-          "range": "bytes=701-1059"
+          "checksum": "sha1-EuFMRKR/2atKFGKHjH/3vivHPEc=",
+          "range": "bytes=699-1059"
         },
         "data": {
-          "checksum": "sha256-NedZsq170zk14TU+FxyLtc3Dr0vz/fmDP6LbmTqdtF8=",
-          "range": "bytes=1060-408273"
+          "checksum": "sha256-QDrcE6gPZ7R2/02ORkq8ZiVIGQDOwVQ07QetxKwG2jE=",
+          "range": "bytes=1060-408316"
         },
         "name": "glibc-locale-posix",
         "signature": {
-          "checksum": "sha1-G9qkyU9BXJISxwkeJE5Cz/n/H0k=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-hRz3Fq86p+IW4pWkZRP5kxsJFns=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r3.apk",
-        "version": "2.39-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r5.apk",
+        "version": "2.39-r5"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1+bVOClqbAOmgA1y9Q+GYJhEfuJs=",
+        "checksum": "Q19hiFVzu+AzUM0onmSNjApSBdvTw=",
         "control": {
-          "checksum": "sha1-+bVOClqbAOmgA1y9Q+GYJhEfuJs=",
-          "range": "bytes=700-1326"
+          "checksum": "sha1-9hiFVzu+AzUM0onmSNjApSBdvTw=",
+          "range": "bytes=694-1321"
         },
         "data": {
-          "checksum": "sha256-59plMSMECX3LWvyWsiLvadlwbdU3qopW0jRvBCyMGBM=",
-          "range": "bytes=1327-5861479"
+          "checksum": "sha256-eDetP73vFbPoIKaaYcLDZ89dOGzpY4xRBw75zN0Odpg=",
+          "range": "bytes=1322-5861522"
         },
         "name": "glibc",
         "signature": {
-          "checksum": "sha1-NZX+6hpoAYIpCd9O1VsViZI3MM0=",
-          "range": "bytes=0-699"
+          "checksum": "sha1-n8l9a4cNG2heaH82Un+dqHmdqRI=",
+          "range": "bytes=0-693"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r3.apk",
-        "version": "2.39-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r5.apk",
+        "version": "2.39-r5"
       },
       {
         "architecture": "x86_64",
@@ -318,22 +318,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1GG/Qe/wJbfaSQh2/E66qsSZ1d14=",
+        "checksum": "Q1GynPQjsrxTFW54tdQAqopiWsMuo=",
         "control": {
-          "checksum": "sha1-GG/Qe/wJbfaSQh2/E66qsSZ1d14=",
-          "range": "bytes=693-1065"
+          "checksum": "sha1-GynPQjsrxTFW54tdQAqopiWsMuo=",
+          "range": "bytes=697-1068"
         },
         "data": {
-          "checksum": "sha256-83L93TpxngARX3OA5Mm8MzkKPoqcoX6BX4/rslD+ND0=",
-          "range": "bytes=1066-251841"
+          "checksum": "sha256-cFyZH6WiNgbnz+zovA9EJB8aHO70Ao8TIH7052O/w1M=",
+          "range": "bytes=1069-251882"
         },
         "name": "libnghttp2-14",
         "signature": {
-          "checksum": "sha1-nERTCwywhPhwFIvRVZFNWHvzJXk=",
-          "range": "bytes=0-692"
+          "checksum": "sha1-o2sTmr6y1CBY9otWZAKu01XAbM8=",
+          "range": "bytes=0-696"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.61.0-r1.apk",
-        "version": "1.61.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.62.0-r0.apk",
+        "version": "1.62.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -413,41 +413,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1rmRRDukjyxrZKFy/2htPJpXlv6c=",
+        "checksum": "Q1bkh6LBvJiAE8yoq/+3XyeLRcIDE=",
         "control": {
-          "checksum": "sha1-rmRRDukjyxrZKFy/2htPJpXlv6c=",
-          "range": "bytes=699-1169"
+          "checksum": "sha1-bkh6LBvJiAE8yoq/+3XyeLRcIDE=",
+          "range": "bytes=700-1171"
         },
         "data": {
-          "checksum": "sha256-R81rAn3Y5uN4AbPY2STKyJQFy9AlA8AsQBoi6dbaAUA=",
-          "range": "bytes=1170-2556940"
+          "checksum": "sha256-fK9ZYBCiUycuwXY2OUJPlo4VO00LgqbMjSBO0CNMEok=",
+          "range": "bytes=1172-2582013"
         },
         "name": "nghttp2",
         "signature": {
-          "checksum": "sha1-EVy/a8/HRmt7vkLWYZfPCgtTzvE=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-ubcn/WnvFEPpkHx9nfAlqzYVN1o=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.61.0-r1.apk",
-        "version": "1.61.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.62.0-r0.apk",
+        "version": "1.62.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1dKyxN+ghQa6wAlVdT/IeTI/kUCI=",
+        "checksum": "Q1yOG4UBYkzOYPo4RZgfhIm6Mh0sU=",
         "control": {
-          "checksum": "sha1-dKyxN+ghQa6wAlVdT/IeTI/kUCI=",
-          "range": "bytes=699-1067"
+          "checksum": "sha1-yOG4UBYkzOYPo4RZgfhIm6Mh0sU=",
+          "range": "bytes=704-1070"
         },
         "data": {
-          "checksum": "sha256-X5FGVjy9TFT+NbfOA0lbV3pnLHSmqrDGz4BKIeYVBeA=",
-          "range": "bytes=1068-631660"
+          "checksum": "sha256-74kS0GGdLRQfk5b0TynYIEqh6fCEEK7QHP7iNsWb9oE=",
+          "range": "bytes=1071-631901"
         },
         "name": "nghttp2-dev",
         "signature": {
-          "checksum": "sha1-vGUw/0Loh1AWFjrlxevxFU7IKT4=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-AUWNNntPboyRKLJbqFODeq2sX8g=",
+          "range": "bytes=0-703"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.61.0-r1.apk",
-        "version": "1.61.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.62.0-r0.apk",
+        "version": "1.62.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -546,22 +546,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1SX1piz1hZeqGnnSNsfZGhK54I8A=",
+        "checksum": "Q15i44FeGc8cU/Gs+AORIH16osoV8=",
         "control": {
-          "checksum": "sha1-SX1piz1hZeqGnnSNsfZGhK54I8A=",
-          "range": "bytes=699-1103"
+          "checksum": "sha1-5i44FeGc8cU/Gs+AORIH16osoV8=",
+          "range": "bytes=695-1098"
         },
         "data": {
-          "checksum": "sha256-VSxM5PIYwhIc/kJVmh0tsVqLpz68eYyOYyC4cxkP4nw=",
-          "range": "bytes=1104-21603"
+          "checksum": "sha256-72mWEdxOgFKdTQQJGfANOdejkvbhfTVsXD8yNzkwDKo=",
+          "range": "bytes=1099-21646"
         },
         "name": "libcrypt1",
         "signature": {
-          "checksum": "sha1-SRN+qFHoymUHf93USjCViyBMAKU=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-bbdRja3lJyrqB1b1R5lOFXk5Yps=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r3.apk",
-        "version": "2.39-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r5.apk",
+        "version": "2.39-r5"
       },
       {
         "architecture": "x86_64",
@@ -755,22 +755,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ieuXl/3DfkuOLicC/GlvVmzsYM0=",
+        "checksum": "Q1eaot0B2H9IOF054RKMabXG37GUk=",
         "control": {
-          "checksum": "sha1-ieuXl/3DfkuOLicC/GlvVmzsYM0=",
-          "range": "bytes=694-1137"
+          "checksum": "sha1-eaot0B2H9IOF054RKMabXG37GUk=",
+          "range": "bytes=700-1143"
         },
         "data": {
-          "checksum": "sha256-QJ4bdR2CM1ozjfKJ3YY44aPSHHcx/2R999PpMdh/bsA=",
-          "range": "bytes=1138-17230695"
+          "checksum": "sha256-EeuQkVe5Hl+bqWfkBaMgA1Z2Fh91f1upncBbArJu9Gw=",
+          "range": "bytes=1144-17267929"
         },
         "name": "git",
         "signature": {
-          "checksum": "sha1-1X/hk5++g5/PGVylpB3VYqx5hSM=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-yMhNFUJ+emT/s9tdLDQ8zjT2+vY=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/git-2.45.0-r1.apk",
-        "version": "2.45.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/git-2.45.1-r0.apk",
+        "version": "2.45.1-r0"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/blobstore.lock.json
+++ b/wolfi-images/blobstore.lock.json
@@ -52,60 +52,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1LbskMUECTvoctOm3XVAJBe6/+O8=",
+        "checksum": "Q15nzyxTcmhST9dTlB9BxV088pKJY=",
         "control": {
-          "checksum": "sha1-LbskMUECTvoctOm3XVAJBe6/+O8=",
-          "range": "bytes=704-1113"
+          "checksum": "sha1-5nzyxTcmhST9dTlB9BxV088pKJY=",
+          "range": "bytes=697-1107"
         },
         "data": {
-          "checksum": "sha256-U8ueoDdtkVXfQ3r8UKQU+ei8sdAH+ayEnmYIcGEM6S8=",
-          "range": "bytes=1114-267813"
+          "checksum": "sha256-i2qrjtws7OeqrKQP83nQo1vFwjqnO0QM3fSTvHHEKps=",
+          "range": "bytes=1108-267856"
         },
         "name": "ld-linux",
         "signature": {
-          "checksum": "sha1-snzU1ONYjrHMX4b2N117nm2p+9s=",
-          "range": "bytes=0-703"
+          "checksum": "sha1-nJTcI836Gt8XuqjMFUh2BBK4pP4=",
+          "range": "bytes=0-696"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r3.apk",
-        "version": "2.39-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r5.apk",
+        "version": "2.39-r5"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ovjsy4Uk7yfyamNBkynUnsHYFMU=",
+        "checksum": "Q1EuFMRKR/2atKFGKHjH/3vivHPEc=",
         "control": {
-          "checksum": "sha1-ovjsy4Uk7yfyamNBkynUnsHYFMU=",
-          "range": "bytes=701-1059"
+          "checksum": "sha1-EuFMRKR/2atKFGKHjH/3vivHPEc=",
+          "range": "bytes=699-1059"
         },
         "data": {
-          "checksum": "sha256-NedZsq170zk14TU+FxyLtc3Dr0vz/fmDP6LbmTqdtF8=",
-          "range": "bytes=1060-408273"
+          "checksum": "sha256-QDrcE6gPZ7R2/02ORkq8ZiVIGQDOwVQ07QetxKwG2jE=",
+          "range": "bytes=1060-408316"
         },
         "name": "glibc-locale-posix",
         "signature": {
-          "checksum": "sha1-G9qkyU9BXJISxwkeJE5Cz/n/H0k=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-hRz3Fq86p+IW4pWkZRP5kxsJFns=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r3.apk",
-        "version": "2.39-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r5.apk",
+        "version": "2.39-r5"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1+bVOClqbAOmgA1y9Q+GYJhEfuJs=",
+        "checksum": "Q19hiFVzu+AzUM0onmSNjApSBdvTw=",
         "control": {
-          "checksum": "sha1-+bVOClqbAOmgA1y9Q+GYJhEfuJs=",
-          "range": "bytes=700-1326"
+          "checksum": "sha1-9hiFVzu+AzUM0onmSNjApSBdvTw=",
+          "range": "bytes=694-1321"
         },
         "data": {
-          "checksum": "sha256-59plMSMECX3LWvyWsiLvadlwbdU3qopW0jRvBCyMGBM=",
-          "range": "bytes=1327-5861479"
+          "checksum": "sha256-eDetP73vFbPoIKaaYcLDZ89dOGzpY4xRBw75zN0Odpg=",
+          "range": "bytes=1322-5861522"
         },
         "name": "glibc",
         "signature": {
-          "checksum": "sha1-NZX+6hpoAYIpCd9O1VsViZI3MM0=",
-          "range": "bytes=0-699"
+          "checksum": "sha1-n8l9a4cNG2heaH82Un+dqHmdqRI=",
+          "range": "bytes=0-693"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r3.apk",
-        "version": "2.39-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r5.apk",
+        "version": "2.39-r5"
       },
       {
         "architecture": "x86_64",
@@ -318,22 +318,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1GG/Qe/wJbfaSQh2/E66qsSZ1d14=",
+        "checksum": "Q1GynPQjsrxTFW54tdQAqopiWsMuo=",
         "control": {
-          "checksum": "sha1-GG/Qe/wJbfaSQh2/E66qsSZ1d14=",
-          "range": "bytes=693-1065"
+          "checksum": "sha1-GynPQjsrxTFW54tdQAqopiWsMuo=",
+          "range": "bytes=697-1068"
         },
         "data": {
-          "checksum": "sha256-83L93TpxngARX3OA5Mm8MzkKPoqcoX6BX4/rslD+ND0=",
-          "range": "bytes=1066-251841"
+          "checksum": "sha256-cFyZH6WiNgbnz+zovA9EJB8aHO70Ao8TIH7052O/w1M=",
+          "range": "bytes=1069-251882"
         },
         "name": "libnghttp2-14",
         "signature": {
-          "checksum": "sha1-nERTCwywhPhwFIvRVZFNWHvzJXk=",
-          "range": "bytes=0-692"
+          "checksum": "sha1-o2sTmr6y1CBY9otWZAKu01XAbM8=",
+          "range": "bytes=0-696"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.61.0-r1.apk",
-        "version": "1.61.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.62.0-r0.apk",
+        "version": "1.62.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -413,41 +413,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1rmRRDukjyxrZKFy/2htPJpXlv6c=",
+        "checksum": "Q1bkh6LBvJiAE8yoq/+3XyeLRcIDE=",
         "control": {
-          "checksum": "sha1-rmRRDukjyxrZKFy/2htPJpXlv6c=",
-          "range": "bytes=699-1169"
+          "checksum": "sha1-bkh6LBvJiAE8yoq/+3XyeLRcIDE=",
+          "range": "bytes=700-1171"
         },
         "data": {
-          "checksum": "sha256-R81rAn3Y5uN4AbPY2STKyJQFy9AlA8AsQBoi6dbaAUA=",
-          "range": "bytes=1170-2556940"
+          "checksum": "sha256-fK9ZYBCiUycuwXY2OUJPlo4VO00LgqbMjSBO0CNMEok=",
+          "range": "bytes=1172-2582013"
         },
         "name": "nghttp2",
         "signature": {
-          "checksum": "sha1-EVy/a8/HRmt7vkLWYZfPCgtTzvE=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-ubcn/WnvFEPpkHx9nfAlqzYVN1o=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.61.0-r1.apk",
-        "version": "1.61.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.62.0-r0.apk",
+        "version": "1.62.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1dKyxN+ghQa6wAlVdT/IeTI/kUCI=",
+        "checksum": "Q1yOG4UBYkzOYPo4RZgfhIm6Mh0sU=",
         "control": {
-          "checksum": "sha1-dKyxN+ghQa6wAlVdT/IeTI/kUCI=",
-          "range": "bytes=699-1067"
+          "checksum": "sha1-yOG4UBYkzOYPo4RZgfhIm6Mh0sU=",
+          "range": "bytes=704-1070"
         },
         "data": {
-          "checksum": "sha256-X5FGVjy9TFT+NbfOA0lbV3pnLHSmqrDGz4BKIeYVBeA=",
-          "range": "bytes=1068-631660"
+          "checksum": "sha256-74kS0GGdLRQfk5b0TynYIEqh6fCEEK7QHP7iNsWb9oE=",
+          "range": "bytes=1071-631901"
         },
         "name": "nghttp2-dev",
         "signature": {
-          "checksum": "sha1-vGUw/0Loh1AWFjrlxevxFU7IKT4=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-AUWNNntPboyRKLJbqFODeq2sX8g=",
+          "range": "bytes=0-703"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.61.0-r1.apk",
-        "version": "1.61.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.62.0-r0.apk",
+        "version": "1.62.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -546,22 +546,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1SX1piz1hZeqGnnSNsfZGhK54I8A=",
+        "checksum": "Q15i44FeGc8cU/Gs+AORIH16osoV8=",
         "control": {
-          "checksum": "sha1-SX1piz1hZeqGnnSNsfZGhK54I8A=",
-          "range": "bytes=699-1103"
+          "checksum": "sha1-5i44FeGc8cU/Gs+AORIH16osoV8=",
+          "range": "bytes=695-1098"
         },
         "data": {
-          "checksum": "sha256-VSxM5PIYwhIc/kJVmh0tsVqLpz68eYyOYyC4cxkP4nw=",
-          "range": "bytes=1104-21603"
+          "checksum": "sha256-72mWEdxOgFKdTQQJGfANOdejkvbhfTVsXD8yNzkwDKo=",
+          "range": "bytes=1099-21646"
         },
         "name": "libcrypt1",
         "signature": {
-          "checksum": "sha1-SRN+qFHoymUHf93USjCViyBMAKU=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-bbdRja3lJyrqB1b1R5lOFXk5Yps=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r3.apk",
-        "version": "2.39-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r5.apk",
+        "version": "2.39-r5"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/bundled-executor.lock.json
+++ b/wolfi-images/bundled-executor.lock.json
@@ -52,60 +52,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1LbskMUECTvoctOm3XVAJBe6/+O8=",
+        "checksum": "Q15nzyxTcmhST9dTlB9BxV088pKJY=",
         "control": {
-          "checksum": "sha1-LbskMUECTvoctOm3XVAJBe6/+O8=",
-          "range": "bytes=704-1113"
+          "checksum": "sha1-5nzyxTcmhST9dTlB9BxV088pKJY=",
+          "range": "bytes=697-1107"
         },
         "data": {
-          "checksum": "sha256-U8ueoDdtkVXfQ3r8UKQU+ei8sdAH+ayEnmYIcGEM6S8=",
-          "range": "bytes=1114-267813"
+          "checksum": "sha256-i2qrjtws7OeqrKQP83nQo1vFwjqnO0QM3fSTvHHEKps=",
+          "range": "bytes=1108-267856"
         },
         "name": "ld-linux",
         "signature": {
-          "checksum": "sha1-snzU1ONYjrHMX4b2N117nm2p+9s=",
-          "range": "bytes=0-703"
+          "checksum": "sha1-nJTcI836Gt8XuqjMFUh2BBK4pP4=",
+          "range": "bytes=0-696"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r3.apk",
-        "version": "2.39-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r5.apk",
+        "version": "2.39-r5"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ovjsy4Uk7yfyamNBkynUnsHYFMU=",
+        "checksum": "Q1EuFMRKR/2atKFGKHjH/3vivHPEc=",
         "control": {
-          "checksum": "sha1-ovjsy4Uk7yfyamNBkynUnsHYFMU=",
-          "range": "bytes=701-1059"
+          "checksum": "sha1-EuFMRKR/2atKFGKHjH/3vivHPEc=",
+          "range": "bytes=699-1059"
         },
         "data": {
-          "checksum": "sha256-NedZsq170zk14TU+FxyLtc3Dr0vz/fmDP6LbmTqdtF8=",
-          "range": "bytes=1060-408273"
+          "checksum": "sha256-QDrcE6gPZ7R2/02ORkq8ZiVIGQDOwVQ07QetxKwG2jE=",
+          "range": "bytes=1060-408316"
         },
         "name": "glibc-locale-posix",
         "signature": {
-          "checksum": "sha1-G9qkyU9BXJISxwkeJE5Cz/n/H0k=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-hRz3Fq86p+IW4pWkZRP5kxsJFns=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r3.apk",
-        "version": "2.39-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r5.apk",
+        "version": "2.39-r5"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1+bVOClqbAOmgA1y9Q+GYJhEfuJs=",
+        "checksum": "Q19hiFVzu+AzUM0onmSNjApSBdvTw=",
         "control": {
-          "checksum": "sha1-+bVOClqbAOmgA1y9Q+GYJhEfuJs=",
-          "range": "bytes=700-1326"
+          "checksum": "sha1-9hiFVzu+AzUM0onmSNjApSBdvTw=",
+          "range": "bytes=694-1321"
         },
         "data": {
-          "checksum": "sha256-59plMSMECX3LWvyWsiLvadlwbdU3qopW0jRvBCyMGBM=",
-          "range": "bytes=1327-5861479"
+          "checksum": "sha256-eDetP73vFbPoIKaaYcLDZ89dOGzpY4xRBw75zN0Odpg=",
+          "range": "bytes=1322-5861522"
         },
         "name": "glibc",
         "signature": {
-          "checksum": "sha1-NZX+6hpoAYIpCd9O1VsViZI3MM0=",
-          "range": "bytes=0-699"
+          "checksum": "sha1-n8l9a4cNG2heaH82Un+dqHmdqRI=",
+          "range": "bytes=0-693"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r3.apk",
-        "version": "2.39-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r5.apk",
+        "version": "2.39-r5"
       },
       {
         "architecture": "x86_64",
@@ -318,22 +318,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1GG/Qe/wJbfaSQh2/E66qsSZ1d14=",
+        "checksum": "Q1GynPQjsrxTFW54tdQAqopiWsMuo=",
         "control": {
-          "checksum": "sha1-GG/Qe/wJbfaSQh2/E66qsSZ1d14=",
-          "range": "bytes=693-1065"
+          "checksum": "sha1-GynPQjsrxTFW54tdQAqopiWsMuo=",
+          "range": "bytes=697-1068"
         },
         "data": {
-          "checksum": "sha256-83L93TpxngARX3OA5Mm8MzkKPoqcoX6BX4/rslD+ND0=",
-          "range": "bytes=1066-251841"
+          "checksum": "sha256-cFyZH6WiNgbnz+zovA9EJB8aHO70Ao8TIH7052O/w1M=",
+          "range": "bytes=1069-251882"
         },
         "name": "libnghttp2-14",
         "signature": {
-          "checksum": "sha1-nERTCwywhPhwFIvRVZFNWHvzJXk=",
-          "range": "bytes=0-692"
+          "checksum": "sha1-o2sTmr6y1CBY9otWZAKu01XAbM8=",
+          "range": "bytes=0-696"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.61.0-r1.apk",
-        "version": "1.61.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.62.0-r0.apk",
+        "version": "1.62.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -413,41 +413,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1rmRRDukjyxrZKFy/2htPJpXlv6c=",
+        "checksum": "Q1bkh6LBvJiAE8yoq/+3XyeLRcIDE=",
         "control": {
-          "checksum": "sha1-rmRRDukjyxrZKFy/2htPJpXlv6c=",
-          "range": "bytes=699-1169"
+          "checksum": "sha1-bkh6LBvJiAE8yoq/+3XyeLRcIDE=",
+          "range": "bytes=700-1171"
         },
         "data": {
-          "checksum": "sha256-R81rAn3Y5uN4AbPY2STKyJQFy9AlA8AsQBoi6dbaAUA=",
-          "range": "bytes=1170-2556940"
+          "checksum": "sha256-fK9ZYBCiUycuwXY2OUJPlo4VO00LgqbMjSBO0CNMEok=",
+          "range": "bytes=1172-2582013"
         },
         "name": "nghttp2",
         "signature": {
-          "checksum": "sha1-EVy/a8/HRmt7vkLWYZfPCgtTzvE=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-ubcn/WnvFEPpkHx9nfAlqzYVN1o=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.61.0-r1.apk",
-        "version": "1.61.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.62.0-r0.apk",
+        "version": "1.62.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1dKyxN+ghQa6wAlVdT/IeTI/kUCI=",
+        "checksum": "Q1yOG4UBYkzOYPo4RZgfhIm6Mh0sU=",
         "control": {
-          "checksum": "sha1-dKyxN+ghQa6wAlVdT/IeTI/kUCI=",
-          "range": "bytes=699-1067"
+          "checksum": "sha1-yOG4UBYkzOYPo4RZgfhIm6Mh0sU=",
+          "range": "bytes=704-1070"
         },
         "data": {
-          "checksum": "sha256-X5FGVjy9TFT+NbfOA0lbV3pnLHSmqrDGz4BKIeYVBeA=",
-          "range": "bytes=1068-631660"
+          "checksum": "sha256-74kS0GGdLRQfk5b0TynYIEqh6fCEEK7QHP7iNsWb9oE=",
+          "range": "bytes=1071-631901"
         },
         "name": "nghttp2-dev",
         "signature": {
-          "checksum": "sha1-vGUw/0Loh1AWFjrlxevxFU7IKT4=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-AUWNNntPboyRKLJbqFODeq2sX8g=",
+          "range": "bytes=0-703"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.61.0-r1.apk",
-        "version": "1.61.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.62.0-r0.apk",
+        "version": "1.62.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -546,22 +546,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1SX1piz1hZeqGnnSNsfZGhK54I8A=",
+        "checksum": "Q15i44FeGc8cU/Gs+AORIH16osoV8=",
         "control": {
-          "checksum": "sha1-SX1piz1hZeqGnnSNsfZGhK54I8A=",
-          "range": "bytes=699-1103"
+          "checksum": "sha1-5i44FeGc8cU/Gs+AORIH16osoV8=",
+          "range": "bytes=695-1098"
         },
         "data": {
-          "checksum": "sha256-VSxM5PIYwhIc/kJVmh0tsVqLpz68eYyOYyC4cxkP4nw=",
-          "range": "bytes=1104-21603"
+          "checksum": "sha256-72mWEdxOgFKdTQQJGfANOdejkvbhfTVsXD8yNzkwDKo=",
+          "range": "bytes=1099-21646"
         },
         "name": "libcrypt1",
         "signature": {
-          "checksum": "sha1-SRN+qFHoymUHf93USjCViyBMAKU=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-bbdRja3lJyrqB1b1R5lOFXk5Yps=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r3.apk",
-        "version": "2.39-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r5.apk",
+        "version": "2.39-r5"
       },
       {
         "architecture": "x86_64",
@@ -774,22 +774,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ieuXl/3DfkuOLicC/GlvVmzsYM0=",
+        "checksum": "Q1eaot0B2H9IOF054RKMabXG37GUk=",
         "control": {
-          "checksum": "sha1-ieuXl/3DfkuOLicC/GlvVmzsYM0=",
-          "range": "bytes=694-1137"
+          "checksum": "sha1-eaot0B2H9IOF054RKMabXG37GUk=",
+          "range": "bytes=700-1143"
         },
         "data": {
-          "checksum": "sha256-QJ4bdR2CM1ozjfKJ3YY44aPSHHcx/2R999PpMdh/bsA=",
-          "range": "bytes=1138-17230695"
+          "checksum": "sha256-EeuQkVe5Hl+bqWfkBaMgA1Z2Fh91f1upncBbArJu9Gw=",
+          "range": "bytes=1144-17267929"
         },
         "name": "git",
         "signature": {
-          "checksum": "sha1-1X/hk5++g5/PGVylpB3VYqx5hSM=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-yMhNFUJ+emT/s9tdLDQ8zjT2+vY=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/git-2.45.0-r1.apk",
-        "version": "2.45.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/git-2.45.1-r0.apk",
+        "version": "2.45.1-r0"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/caddy.lock.json
+++ b/wolfi-images/caddy.lock.json
@@ -52,60 +52,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1LbskMUECTvoctOm3XVAJBe6/+O8=",
+        "checksum": "Q15nzyxTcmhST9dTlB9BxV088pKJY=",
         "control": {
-          "checksum": "sha1-LbskMUECTvoctOm3XVAJBe6/+O8=",
-          "range": "bytes=704-1113"
+          "checksum": "sha1-5nzyxTcmhST9dTlB9BxV088pKJY=",
+          "range": "bytes=697-1107"
         },
         "data": {
-          "checksum": "sha256-U8ueoDdtkVXfQ3r8UKQU+ei8sdAH+ayEnmYIcGEM6S8=",
-          "range": "bytes=1114-267813"
+          "checksum": "sha256-i2qrjtws7OeqrKQP83nQo1vFwjqnO0QM3fSTvHHEKps=",
+          "range": "bytes=1108-267856"
         },
         "name": "ld-linux",
         "signature": {
-          "checksum": "sha1-snzU1ONYjrHMX4b2N117nm2p+9s=",
-          "range": "bytes=0-703"
+          "checksum": "sha1-nJTcI836Gt8XuqjMFUh2BBK4pP4=",
+          "range": "bytes=0-696"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r3.apk",
-        "version": "2.39-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r5.apk",
+        "version": "2.39-r5"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ovjsy4Uk7yfyamNBkynUnsHYFMU=",
+        "checksum": "Q1EuFMRKR/2atKFGKHjH/3vivHPEc=",
         "control": {
-          "checksum": "sha1-ovjsy4Uk7yfyamNBkynUnsHYFMU=",
-          "range": "bytes=701-1059"
+          "checksum": "sha1-EuFMRKR/2atKFGKHjH/3vivHPEc=",
+          "range": "bytes=699-1059"
         },
         "data": {
-          "checksum": "sha256-NedZsq170zk14TU+FxyLtc3Dr0vz/fmDP6LbmTqdtF8=",
-          "range": "bytes=1060-408273"
+          "checksum": "sha256-QDrcE6gPZ7R2/02ORkq8ZiVIGQDOwVQ07QetxKwG2jE=",
+          "range": "bytes=1060-408316"
         },
         "name": "glibc-locale-posix",
         "signature": {
-          "checksum": "sha1-G9qkyU9BXJISxwkeJE5Cz/n/H0k=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-hRz3Fq86p+IW4pWkZRP5kxsJFns=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r3.apk",
-        "version": "2.39-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r5.apk",
+        "version": "2.39-r5"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1+bVOClqbAOmgA1y9Q+GYJhEfuJs=",
+        "checksum": "Q19hiFVzu+AzUM0onmSNjApSBdvTw=",
         "control": {
-          "checksum": "sha1-+bVOClqbAOmgA1y9Q+GYJhEfuJs=",
-          "range": "bytes=700-1326"
+          "checksum": "sha1-9hiFVzu+AzUM0onmSNjApSBdvTw=",
+          "range": "bytes=694-1321"
         },
         "data": {
-          "checksum": "sha256-59plMSMECX3LWvyWsiLvadlwbdU3qopW0jRvBCyMGBM=",
-          "range": "bytes=1327-5861479"
+          "checksum": "sha256-eDetP73vFbPoIKaaYcLDZ89dOGzpY4xRBw75zN0Odpg=",
+          "range": "bytes=1322-5861522"
         },
         "name": "glibc",
         "signature": {
-          "checksum": "sha1-NZX+6hpoAYIpCd9O1VsViZI3MM0=",
-          "range": "bytes=0-699"
+          "checksum": "sha1-n8l9a4cNG2heaH82Un+dqHmdqRI=",
+          "range": "bytes=0-693"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r3.apk",
-        "version": "2.39-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r5.apk",
+        "version": "2.39-r5"
       },
       {
         "architecture": "x86_64",
@@ -318,22 +318,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1GG/Qe/wJbfaSQh2/E66qsSZ1d14=",
+        "checksum": "Q1GynPQjsrxTFW54tdQAqopiWsMuo=",
         "control": {
-          "checksum": "sha1-GG/Qe/wJbfaSQh2/E66qsSZ1d14=",
-          "range": "bytes=693-1065"
+          "checksum": "sha1-GynPQjsrxTFW54tdQAqopiWsMuo=",
+          "range": "bytes=697-1068"
         },
         "data": {
-          "checksum": "sha256-83L93TpxngARX3OA5Mm8MzkKPoqcoX6BX4/rslD+ND0=",
-          "range": "bytes=1066-251841"
+          "checksum": "sha256-cFyZH6WiNgbnz+zovA9EJB8aHO70Ao8TIH7052O/w1M=",
+          "range": "bytes=1069-251882"
         },
         "name": "libnghttp2-14",
         "signature": {
-          "checksum": "sha1-nERTCwywhPhwFIvRVZFNWHvzJXk=",
-          "range": "bytes=0-692"
+          "checksum": "sha1-o2sTmr6y1CBY9otWZAKu01XAbM8=",
+          "range": "bytes=0-696"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.61.0-r1.apk",
-        "version": "1.61.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.62.0-r0.apk",
+        "version": "1.62.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -413,41 +413,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1rmRRDukjyxrZKFy/2htPJpXlv6c=",
+        "checksum": "Q1bkh6LBvJiAE8yoq/+3XyeLRcIDE=",
         "control": {
-          "checksum": "sha1-rmRRDukjyxrZKFy/2htPJpXlv6c=",
-          "range": "bytes=699-1169"
+          "checksum": "sha1-bkh6LBvJiAE8yoq/+3XyeLRcIDE=",
+          "range": "bytes=700-1171"
         },
         "data": {
-          "checksum": "sha256-R81rAn3Y5uN4AbPY2STKyJQFy9AlA8AsQBoi6dbaAUA=",
-          "range": "bytes=1170-2556940"
+          "checksum": "sha256-fK9ZYBCiUycuwXY2OUJPlo4VO00LgqbMjSBO0CNMEok=",
+          "range": "bytes=1172-2582013"
         },
         "name": "nghttp2",
         "signature": {
-          "checksum": "sha1-EVy/a8/HRmt7vkLWYZfPCgtTzvE=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-ubcn/WnvFEPpkHx9nfAlqzYVN1o=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.61.0-r1.apk",
-        "version": "1.61.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.62.0-r0.apk",
+        "version": "1.62.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1dKyxN+ghQa6wAlVdT/IeTI/kUCI=",
+        "checksum": "Q1yOG4UBYkzOYPo4RZgfhIm6Mh0sU=",
         "control": {
-          "checksum": "sha1-dKyxN+ghQa6wAlVdT/IeTI/kUCI=",
-          "range": "bytes=699-1067"
+          "checksum": "sha1-yOG4UBYkzOYPo4RZgfhIm6Mh0sU=",
+          "range": "bytes=704-1070"
         },
         "data": {
-          "checksum": "sha256-X5FGVjy9TFT+NbfOA0lbV3pnLHSmqrDGz4BKIeYVBeA=",
-          "range": "bytes=1068-631660"
+          "checksum": "sha256-74kS0GGdLRQfk5b0TynYIEqh6fCEEK7QHP7iNsWb9oE=",
+          "range": "bytes=1071-631901"
         },
         "name": "nghttp2-dev",
         "signature": {
-          "checksum": "sha1-vGUw/0Loh1AWFjrlxevxFU7IKT4=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-AUWNNntPboyRKLJbqFODeq2sX8g=",
+          "range": "bytes=0-703"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.61.0-r1.apk",
-        "version": "1.61.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.62.0-r0.apk",
+        "version": "1.62.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -546,22 +546,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1SX1piz1hZeqGnnSNsfZGhK54I8A=",
+        "checksum": "Q15i44FeGc8cU/Gs+AORIH16osoV8=",
         "control": {
-          "checksum": "sha1-SX1piz1hZeqGnnSNsfZGhK54I8A=",
-          "range": "bytes=699-1103"
+          "checksum": "sha1-5i44FeGc8cU/Gs+AORIH16osoV8=",
+          "range": "bytes=695-1098"
         },
         "data": {
-          "checksum": "sha256-VSxM5PIYwhIc/kJVmh0tsVqLpz68eYyOYyC4cxkP4nw=",
-          "range": "bytes=1104-21603"
+          "checksum": "sha256-72mWEdxOgFKdTQQJGfANOdejkvbhfTVsXD8yNzkwDKo=",
+          "range": "bytes=1099-21646"
         },
         "name": "libcrypt1",
         "signature": {
-          "checksum": "sha1-SRN+qFHoymUHf93USjCViyBMAKU=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-bbdRja3lJyrqB1b1R5lOFXk5Yps=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r3.apk",
-        "version": "2.39-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r5.apk",
+        "version": "2.39-r5"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/cadvisor.lock.json
+++ b/wolfi-images/cadvisor.lock.json
@@ -52,60 +52,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1LbskMUECTvoctOm3XVAJBe6/+O8=",
+        "checksum": "Q15nzyxTcmhST9dTlB9BxV088pKJY=",
         "control": {
-          "checksum": "sha1-LbskMUECTvoctOm3XVAJBe6/+O8=",
-          "range": "bytes=704-1113"
+          "checksum": "sha1-5nzyxTcmhST9dTlB9BxV088pKJY=",
+          "range": "bytes=697-1107"
         },
         "data": {
-          "checksum": "sha256-U8ueoDdtkVXfQ3r8UKQU+ei8sdAH+ayEnmYIcGEM6S8=",
-          "range": "bytes=1114-267813"
+          "checksum": "sha256-i2qrjtws7OeqrKQP83nQo1vFwjqnO0QM3fSTvHHEKps=",
+          "range": "bytes=1108-267856"
         },
         "name": "ld-linux",
         "signature": {
-          "checksum": "sha1-snzU1ONYjrHMX4b2N117nm2p+9s=",
-          "range": "bytes=0-703"
+          "checksum": "sha1-nJTcI836Gt8XuqjMFUh2BBK4pP4=",
+          "range": "bytes=0-696"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r3.apk",
-        "version": "2.39-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r5.apk",
+        "version": "2.39-r5"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ovjsy4Uk7yfyamNBkynUnsHYFMU=",
+        "checksum": "Q1EuFMRKR/2atKFGKHjH/3vivHPEc=",
         "control": {
-          "checksum": "sha1-ovjsy4Uk7yfyamNBkynUnsHYFMU=",
-          "range": "bytes=701-1059"
+          "checksum": "sha1-EuFMRKR/2atKFGKHjH/3vivHPEc=",
+          "range": "bytes=699-1059"
         },
         "data": {
-          "checksum": "sha256-NedZsq170zk14TU+FxyLtc3Dr0vz/fmDP6LbmTqdtF8=",
-          "range": "bytes=1060-408273"
+          "checksum": "sha256-QDrcE6gPZ7R2/02ORkq8ZiVIGQDOwVQ07QetxKwG2jE=",
+          "range": "bytes=1060-408316"
         },
         "name": "glibc-locale-posix",
         "signature": {
-          "checksum": "sha1-G9qkyU9BXJISxwkeJE5Cz/n/H0k=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-hRz3Fq86p+IW4pWkZRP5kxsJFns=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r3.apk",
-        "version": "2.39-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r5.apk",
+        "version": "2.39-r5"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1+bVOClqbAOmgA1y9Q+GYJhEfuJs=",
+        "checksum": "Q19hiFVzu+AzUM0onmSNjApSBdvTw=",
         "control": {
-          "checksum": "sha1-+bVOClqbAOmgA1y9Q+GYJhEfuJs=",
-          "range": "bytes=700-1326"
+          "checksum": "sha1-9hiFVzu+AzUM0onmSNjApSBdvTw=",
+          "range": "bytes=694-1321"
         },
         "data": {
-          "checksum": "sha256-59plMSMECX3LWvyWsiLvadlwbdU3qopW0jRvBCyMGBM=",
-          "range": "bytes=1327-5861479"
+          "checksum": "sha256-eDetP73vFbPoIKaaYcLDZ89dOGzpY4xRBw75zN0Odpg=",
+          "range": "bytes=1322-5861522"
         },
         "name": "glibc",
         "signature": {
-          "checksum": "sha1-NZX+6hpoAYIpCd9O1VsViZI3MM0=",
-          "range": "bytes=0-699"
+          "checksum": "sha1-n8l9a4cNG2heaH82Un+dqHmdqRI=",
+          "range": "bytes=0-693"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r3.apk",
-        "version": "2.39-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r5.apk",
+        "version": "2.39-r5"
       },
       {
         "architecture": "x86_64",
@@ -318,22 +318,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1GG/Qe/wJbfaSQh2/E66qsSZ1d14=",
+        "checksum": "Q1GynPQjsrxTFW54tdQAqopiWsMuo=",
         "control": {
-          "checksum": "sha1-GG/Qe/wJbfaSQh2/E66qsSZ1d14=",
-          "range": "bytes=693-1065"
+          "checksum": "sha1-GynPQjsrxTFW54tdQAqopiWsMuo=",
+          "range": "bytes=697-1068"
         },
         "data": {
-          "checksum": "sha256-83L93TpxngARX3OA5Mm8MzkKPoqcoX6BX4/rslD+ND0=",
-          "range": "bytes=1066-251841"
+          "checksum": "sha256-cFyZH6WiNgbnz+zovA9EJB8aHO70Ao8TIH7052O/w1M=",
+          "range": "bytes=1069-251882"
         },
         "name": "libnghttp2-14",
         "signature": {
-          "checksum": "sha1-nERTCwywhPhwFIvRVZFNWHvzJXk=",
-          "range": "bytes=0-692"
+          "checksum": "sha1-o2sTmr6y1CBY9otWZAKu01XAbM8=",
+          "range": "bytes=0-696"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.61.0-r1.apk",
-        "version": "1.61.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.62.0-r0.apk",
+        "version": "1.62.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -413,41 +413,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1rmRRDukjyxrZKFy/2htPJpXlv6c=",
+        "checksum": "Q1bkh6LBvJiAE8yoq/+3XyeLRcIDE=",
         "control": {
-          "checksum": "sha1-rmRRDukjyxrZKFy/2htPJpXlv6c=",
-          "range": "bytes=699-1169"
+          "checksum": "sha1-bkh6LBvJiAE8yoq/+3XyeLRcIDE=",
+          "range": "bytes=700-1171"
         },
         "data": {
-          "checksum": "sha256-R81rAn3Y5uN4AbPY2STKyJQFy9AlA8AsQBoi6dbaAUA=",
-          "range": "bytes=1170-2556940"
+          "checksum": "sha256-fK9ZYBCiUycuwXY2OUJPlo4VO00LgqbMjSBO0CNMEok=",
+          "range": "bytes=1172-2582013"
         },
         "name": "nghttp2",
         "signature": {
-          "checksum": "sha1-EVy/a8/HRmt7vkLWYZfPCgtTzvE=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-ubcn/WnvFEPpkHx9nfAlqzYVN1o=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.61.0-r1.apk",
-        "version": "1.61.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.62.0-r0.apk",
+        "version": "1.62.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1dKyxN+ghQa6wAlVdT/IeTI/kUCI=",
+        "checksum": "Q1yOG4UBYkzOYPo4RZgfhIm6Mh0sU=",
         "control": {
-          "checksum": "sha1-dKyxN+ghQa6wAlVdT/IeTI/kUCI=",
-          "range": "bytes=699-1067"
+          "checksum": "sha1-yOG4UBYkzOYPo4RZgfhIm6Mh0sU=",
+          "range": "bytes=704-1070"
         },
         "data": {
-          "checksum": "sha256-X5FGVjy9TFT+NbfOA0lbV3pnLHSmqrDGz4BKIeYVBeA=",
-          "range": "bytes=1068-631660"
+          "checksum": "sha256-74kS0GGdLRQfk5b0TynYIEqh6fCEEK7QHP7iNsWb9oE=",
+          "range": "bytes=1071-631901"
         },
         "name": "nghttp2-dev",
         "signature": {
-          "checksum": "sha1-vGUw/0Loh1AWFjrlxevxFU7IKT4=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-AUWNNntPboyRKLJbqFODeq2sX8g=",
+          "range": "bytes=0-703"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.61.0-r1.apk",
-        "version": "1.61.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.62.0-r0.apk",
+        "version": "1.62.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -546,22 +546,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1SX1piz1hZeqGnnSNsfZGhK54I8A=",
+        "checksum": "Q15i44FeGc8cU/Gs+AORIH16osoV8=",
         "control": {
-          "checksum": "sha1-SX1piz1hZeqGnnSNsfZGhK54I8A=",
-          "range": "bytes=699-1103"
+          "checksum": "sha1-5i44FeGc8cU/Gs+AORIH16osoV8=",
+          "range": "bytes=695-1098"
         },
         "data": {
-          "checksum": "sha256-VSxM5PIYwhIc/kJVmh0tsVqLpz68eYyOYyC4cxkP4nw=",
-          "range": "bytes=1104-21603"
+          "checksum": "sha256-72mWEdxOgFKdTQQJGfANOdejkvbhfTVsXD8yNzkwDKo=",
+          "range": "bytes=1099-21646"
         },
         "name": "libcrypt1",
         "signature": {
-          "checksum": "sha1-SRN+qFHoymUHf93USjCViyBMAKU=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-bbdRja3lJyrqB1b1R5lOFXk5Yps=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r3.apk",
-        "version": "2.39-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r5.apk",
+        "version": "2.39-r5"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/cloud-mi2.lock.json
+++ b/wolfi-images/cloud-mi2.lock.json
@@ -52,60 +52,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1LbskMUECTvoctOm3XVAJBe6/+O8=",
+        "checksum": "Q15nzyxTcmhST9dTlB9BxV088pKJY=",
         "control": {
-          "checksum": "sha1-LbskMUECTvoctOm3XVAJBe6/+O8=",
-          "range": "bytes=704-1113"
+          "checksum": "sha1-5nzyxTcmhST9dTlB9BxV088pKJY=",
+          "range": "bytes=697-1107"
         },
         "data": {
-          "checksum": "sha256-U8ueoDdtkVXfQ3r8UKQU+ei8sdAH+ayEnmYIcGEM6S8=",
-          "range": "bytes=1114-267813"
+          "checksum": "sha256-i2qrjtws7OeqrKQP83nQo1vFwjqnO0QM3fSTvHHEKps=",
+          "range": "bytes=1108-267856"
         },
         "name": "ld-linux",
         "signature": {
-          "checksum": "sha1-snzU1ONYjrHMX4b2N117nm2p+9s=",
-          "range": "bytes=0-703"
+          "checksum": "sha1-nJTcI836Gt8XuqjMFUh2BBK4pP4=",
+          "range": "bytes=0-696"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r3.apk",
-        "version": "2.39-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r5.apk",
+        "version": "2.39-r5"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ovjsy4Uk7yfyamNBkynUnsHYFMU=",
+        "checksum": "Q1EuFMRKR/2atKFGKHjH/3vivHPEc=",
         "control": {
-          "checksum": "sha1-ovjsy4Uk7yfyamNBkynUnsHYFMU=",
-          "range": "bytes=701-1059"
+          "checksum": "sha1-EuFMRKR/2atKFGKHjH/3vivHPEc=",
+          "range": "bytes=699-1059"
         },
         "data": {
-          "checksum": "sha256-NedZsq170zk14TU+FxyLtc3Dr0vz/fmDP6LbmTqdtF8=",
-          "range": "bytes=1060-408273"
+          "checksum": "sha256-QDrcE6gPZ7R2/02ORkq8ZiVIGQDOwVQ07QetxKwG2jE=",
+          "range": "bytes=1060-408316"
         },
         "name": "glibc-locale-posix",
         "signature": {
-          "checksum": "sha1-G9qkyU9BXJISxwkeJE5Cz/n/H0k=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-hRz3Fq86p+IW4pWkZRP5kxsJFns=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r3.apk",
-        "version": "2.39-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r5.apk",
+        "version": "2.39-r5"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1+bVOClqbAOmgA1y9Q+GYJhEfuJs=",
+        "checksum": "Q19hiFVzu+AzUM0onmSNjApSBdvTw=",
         "control": {
-          "checksum": "sha1-+bVOClqbAOmgA1y9Q+GYJhEfuJs=",
-          "range": "bytes=700-1326"
+          "checksum": "sha1-9hiFVzu+AzUM0onmSNjApSBdvTw=",
+          "range": "bytes=694-1321"
         },
         "data": {
-          "checksum": "sha256-59plMSMECX3LWvyWsiLvadlwbdU3qopW0jRvBCyMGBM=",
-          "range": "bytes=1327-5861479"
+          "checksum": "sha256-eDetP73vFbPoIKaaYcLDZ89dOGzpY4xRBw75zN0Odpg=",
+          "range": "bytes=1322-5861522"
         },
         "name": "glibc",
         "signature": {
-          "checksum": "sha1-NZX+6hpoAYIpCd9O1VsViZI3MM0=",
-          "range": "bytes=0-699"
+          "checksum": "sha1-n8l9a4cNG2heaH82Un+dqHmdqRI=",
+          "range": "bytes=0-693"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r3.apk",
-        "version": "2.39-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r5.apk",
+        "version": "2.39-r5"
       },
       {
         "architecture": "x86_64",
@@ -318,22 +318,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1GG/Qe/wJbfaSQh2/E66qsSZ1d14=",
+        "checksum": "Q1GynPQjsrxTFW54tdQAqopiWsMuo=",
         "control": {
-          "checksum": "sha1-GG/Qe/wJbfaSQh2/E66qsSZ1d14=",
-          "range": "bytes=693-1065"
+          "checksum": "sha1-GynPQjsrxTFW54tdQAqopiWsMuo=",
+          "range": "bytes=697-1068"
         },
         "data": {
-          "checksum": "sha256-83L93TpxngARX3OA5Mm8MzkKPoqcoX6BX4/rslD+ND0=",
-          "range": "bytes=1066-251841"
+          "checksum": "sha256-cFyZH6WiNgbnz+zovA9EJB8aHO70Ao8TIH7052O/w1M=",
+          "range": "bytes=1069-251882"
         },
         "name": "libnghttp2-14",
         "signature": {
-          "checksum": "sha1-nERTCwywhPhwFIvRVZFNWHvzJXk=",
-          "range": "bytes=0-692"
+          "checksum": "sha1-o2sTmr6y1CBY9otWZAKu01XAbM8=",
+          "range": "bytes=0-696"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.61.0-r1.apk",
-        "version": "1.61.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.62.0-r0.apk",
+        "version": "1.62.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -413,41 +413,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1rmRRDukjyxrZKFy/2htPJpXlv6c=",
+        "checksum": "Q1bkh6LBvJiAE8yoq/+3XyeLRcIDE=",
         "control": {
-          "checksum": "sha1-rmRRDukjyxrZKFy/2htPJpXlv6c=",
-          "range": "bytes=699-1169"
+          "checksum": "sha1-bkh6LBvJiAE8yoq/+3XyeLRcIDE=",
+          "range": "bytes=700-1171"
         },
         "data": {
-          "checksum": "sha256-R81rAn3Y5uN4AbPY2STKyJQFy9AlA8AsQBoi6dbaAUA=",
-          "range": "bytes=1170-2556940"
+          "checksum": "sha256-fK9ZYBCiUycuwXY2OUJPlo4VO00LgqbMjSBO0CNMEok=",
+          "range": "bytes=1172-2582013"
         },
         "name": "nghttp2",
         "signature": {
-          "checksum": "sha1-EVy/a8/HRmt7vkLWYZfPCgtTzvE=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-ubcn/WnvFEPpkHx9nfAlqzYVN1o=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.61.0-r1.apk",
-        "version": "1.61.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.62.0-r0.apk",
+        "version": "1.62.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1dKyxN+ghQa6wAlVdT/IeTI/kUCI=",
+        "checksum": "Q1yOG4UBYkzOYPo4RZgfhIm6Mh0sU=",
         "control": {
-          "checksum": "sha1-dKyxN+ghQa6wAlVdT/IeTI/kUCI=",
-          "range": "bytes=699-1067"
+          "checksum": "sha1-yOG4UBYkzOYPo4RZgfhIm6Mh0sU=",
+          "range": "bytes=704-1070"
         },
         "data": {
-          "checksum": "sha256-X5FGVjy9TFT+NbfOA0lbV3pnLHSmqrDGz4BKIeYVBeA=",
-          "range": "bytes=1068-631660"
+          "checksum": "sha256-74kS0GGdLRQfk5b0TynYIEqh6fCEEK7QHP7iNsWb9oE=",
+          "range": "bytes=1071-631901"
         },
         "name": "nghttp2-dev",
         "signature": {
-          "checksum": "sha1-vGUw/0Loh1AWFjrlxevxFU7IKT4=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-AUWNNntPboyRKLJbqFODeq2sX8g=",
+          "range": "bytes=0-703"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.61.0-r1.apk",
-        "version": "1.61.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.62.0-r0.apk",
+        "version": "1.62.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -546,22 +546,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1SX1piz1hZeqGnnSNsfZGhK54I8A=",
+        "checksum": "Q15i44FeGc8cU/Gs+AORIH16osoV8=",
         "control": {
-          "checksum": "sha1-SX1piz1hZeqGnnSNsfZGhK54I8A=",
-          "range": "bytes=699-1103"
+          "checksum": "sha1-5i44FeGc8cU/Gs+AORIH16osoV8=",
+          "range": "bytes=695-1098"
         },
         "data": {
-          "checksum": "sha256-VSxM5PIYwhIc/kJVmh0tsVqLpz68eYyOYyC4cxkP4nw=",
-          "range": "bytes=1104-21603"
+          "checksum": "sha256-72mWEdxOgFKdTQQJGfANOdejkvbhfTVsXD8yNzkwDKo=",
+          "range": "bytes=1099-21646"
         },
         "name": "libcrypt1",
         "signature": {
-          "checksum": "sha1-SRN+qFHoymUHf93USjCViyBMAKU=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-bbdRja3lJyrqB1b1R5lOFXk5Yps=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r3.apk",
-        "version": "2.39-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r5.apk",
+        "version": "2.39-r5"
       },
       {
         "architecture": "x86_64",
@@ -755,22 +755,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ieuXl/3DfkuOLicC/GlvVmzsYM0=",
+        "checksum": "Q1eaot0B2H9IOF054RKMabXG37GUk=",
         "control": {
-          "checksum": "sha1-ieuXl/3DfkuOLicC/GlvVmzsYM0=",
-          "range": "bytes=694-1137"
+          "checksum": "sha1-eaot0B2H9IOF054RKMabXG37GUk=",
+          "range": "bytes=700-1143"
         },
         "data": {
-          "checksum": "sha256-QJ4bdR2CM1ozjfKJ3YY44aPSHHcx/2R999PpMdh/bsA=",
-          "range": "bytes=1138-17230695"
+          "checksum": "sha256-EeuQkVe5Hl+bqWfkBaMgA1Z2Fh91f1upncBbArJu9Gw=",
+          "range": "bytes=1144-17267929"
         },
         "name": "git",
         "signature": {
-          "checksum": "sha1-1X/hk5++g5/PGVylpB3VYqx5hSM=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-yMhNFUJ+emT/s9tdLDQ8zjT2+vY=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/git-2.45.0-r1.apk",
-        "version": "2.45.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/git-2.45.1-r0.apk",
+        "version": "2.45.1-r0"
       },
       {
         "architecture": "x86_64",
@@ -945,22 +945,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1HfYS0IdVh3O8o75OfghXzF2Ee5g=",
+        "checksum": "Q1OwTlRMXb7zHeLIAvkR9u4QSpB3g=",
         "control": {
-          "checksum": "sha1-HfYS0IdVh3O8o75OfghXzF2Ee5g=",
-          "range": "bytes=701-1058"
+          "checksum": "sha1-OwTlRMXb7zHeLIAvkR9u4QSpB3g=",
+          "range": "bytes=696-1054"
         },
         "data": {
-          "checksum": "sha256-I4BZ+k9/q1GhSNloRf8MydDYyt1lL/6GsKK+An5YSig=",
-          "range": "bytes=1059-8944422"
+          "checksum": "sha256-OdJs5w5sVo61nZaAAmGJHi5QXRIwZfqwnauupc1JVMM=",
+          "range": "bytes=1055-8931137"
         },
         "name": "npm",
         "signature": {
-          "checksum": "sha1-ej3ayLdSnwDYAZz81cAUM61JZow=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-x8/Ou0c9cx6tQEiYvZTCqfMeXZM=",
+          "range": "bytes=0-695"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/npm-10.7.0-r0.apk",
-        "version": "10.7.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/npm-10.8.0-r0.apk",
+        "version": "10.8.0-r0"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/executor-kubernetes.lock.json
+++ b/wolfi-images/executor-kubernetes.lock.json
@@ -52,60 +52,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1LbskMUECTvoctOm3XVAJBe6/+O8=",
+        "checksum": "Q15nzyxTcmhST9dTlB9BxV088pKJY=",
         "control": {
-          "checksum": "sha1-LbskMUECTvoctOm3XVAJBe6/+O8=",
-          "range": "bytes=704-1113"
+          "checksum": "sha1-5nzyxTcmhST9dTlB9BxV088pKJY=",
+          "range": "bytes=697-1107"
         },
         "data": {
-          "checksum": "sha256-U8ueoDdtkVXfQ3r8UKQU+ei8sdAH+ayEnmYIcGEM6S8=",
-          "range": "bytes=1114-267813"
+          "checksum": "sha256-i2qrjtws7OeqrKQP83nQo1vFwjqnO0QM3fSTvHHEKps=",
+          "range": "bytes=1108-267856"
         },
         "name": "ld-linux",
         "signature": {
-          "checksum": "sha1-snzU1ONYjrHMX4b2N117nm2p+9s=",
-          "range": "bytes=0-703"
+          "checksum": "sha1-nJTcI836Gt8XuqjMFUh2BBK4pP4=",
+          "range": "bytes=0-696"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r3.apk",
-        "version": "2.39-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r5.apk",
+        "version": "2.39-r5"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ovjsy4Uk7yfyamNBkynUnsHYFMU=",
+        "checksum": "Q1EuFMRKR/2atKFGKHjH/3vivHPEc=",
         "control": {
-          "checksum": "sha1-ovjsy4Uk7yfyamNBkynUnsHYFMU=",
-          "range": "bytes=701-1059"
+          "checksum": "sha1-EuFMRKR/2atKFGKHjH/3vivHPEc=",
+          "range": "bytes=699-1059"
         },
         "data": {
-          "checksum": "sha256-NedZsq170zk14TU+FxyLtc3Dr0vz/fmDP6LbmTqdtF8=",
-          "range": "bytes=1060-408273"
+          "checksum": "sha256-QDrcE6gPZ7R2/02ORkq8ZiVIGQDOwVQ07QetxKwG2jE=",
+          "range": "bytes=1060-408316"
         },
         "name": "glibc-locale-posix",
         "signature": {
-          "checksum": "sha1-G9qkyU9BXJISxwkeJE5Cz/n/H0k=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-hRz3Fq86p+IW4pWkZRP5kxsJFns=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r3.apk",
-        "version": "2.39-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r5.apk",
+        "version": "2.39-r5"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1+bVOClqbAOmgA1y9Q+GYJhEfuJs=",
+        "checksum": "Q19hiFVzu+AzUM0onmSNjApSBdvTw=",
         "control": {
-          "checksum": "sha1-+bVOClqbAOmgA1y9Q+GYJhEfuJs=",
-          "range": "bytes=700-1326"
+          "checksum": "sha1-9hiFVzu+AzUM0onmSNjApSBdvTw=",
+          "range": "bytes=694-1321"
         },
         "data": {
-          "checksum": "sha256-59plMSMECX3LWvyWsiLvadlwbdU3qopW0jRvBCyMGBM=",
-          "range": "bytes=1327-5861479"
+          "checksum": "sha256-eDetP73vFbPoIKaaYcLDZ89dOGzpY4xRBw75zN0Odpg=",
+          "range": "bytes=1322-5861522"
         },
         "name": "glibc",
         "signature": {
-          "checksum": "sha1-NZX+6hpoAYIpCd9O1VsViZI3MM0=",
-          "range": "bytes=0-699"
+          "checksum": "sha1-n8l9a4cNG2heaH82Un+dqHmdqRI=",
+          "range": "bytes=0-693"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r3.apk",
-        "version": "2.39-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r5.apk",
+        "version": "2.39-r5"
       },
       {
         "architecture": "x86_64",
@@ -318,22 +318,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1GG/Qe/wJbfaSQh2/E66qsSZ1d14=",
+        "checksum": "Q1GynPQjsrxTFW54tdQAqopiWsMuo=",
         "control": {
-          "checksum": "sha1-GG/Qe/wJbfaSQh2/E66qsSZ1d14=",
-          "range": "bytes=693-1065"
+          "checksum": "sha1-GynPQjsrxTFW54tdQAqopiWsMuo=",
+          "range": "bytes=697-1068"
         },
         "data": {
-          "checksum": "sha256-83L93TpxngARX3OA5Mm8MzkKPoqcoX6BX4/rslD+ND0=",
-          "range": "bytes=1066-251841"
+          "checksum": "sha256-cFyZH6WiNgbnz+zovA9EJB8aHO70Ao8TIH7052O/w1M=",
+          "range": "bytes=1069-251882"
         },
         "name": "libnghttp2-14",
         "signature": {
-          "checksum": "sha1-nERTCwywhPhwFIvRVZFNWHvzJXk=",
-          "range": "bytes=0-692"
+          "checksum": "sha1-o2sTmr6y1CBY9otWZAKu01XAbM8=",
+          "range": "bytes=0-696"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.61.0-r1.apk",
-        "version": "1.61.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.62.0-r0.apk",
+        "version": "1.62.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -413,41 +413,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1rmRRDukjyxrZKFy/2htPJpXlv6c=",
+        "checksum": "Q1bkh6LBvJiAE8yoq/+3XyeLRcIDE=",
         "control": {
-          "checksum": "sha1-rmRRDukjyxrZKFy/2htPJpXlv6c=",
-          "range": "bytes=699-1169"
+          "checksum": "sha1-bkh6LBvJiAE8yoq/+3XyeLRcIDE=",
+          "range": "bytes=700-1171"
         },
         "data": {
-          "checksum": "sha256-R81rAn3Y5uN4AbPY2STKyJQFy9AlA8AsQBoi6dbaAUA=",
-          "range": "bytes=1170-2556940"
+          "checksum": "sha256-fK9ZYBCiUycuwXY2OUJPlo4VO00LgqbMjSBO0CNMEok=",
+          "range": "bytes=1172-2582013"
         },
         "name": "nghttp2",
         "signature": {
-          "checksum": "sha1-EVy/a8/HRmt7vkLWYZfPCgtTzvE=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-ubcn/WnvFEPpkHx9nfAlqzYVN1o=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.61.0-r1.apk",
-        "version": "1.61.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.62.0-r0.apk",
+        "version": "1.62.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1dKyxN+ghQa6wAlVdT/IeTI/kUCI=",
+        "checksum": "Q1yOG4UBYkzOYPo4RZgfhIm6Mh0sU=",
         "control": {
-          "checksum": "sha1-dKyxN+ghQa6wAlVdT/IeTI/kUCI=",
-          "range": "bytes=699-1067"
+          "checksum": "sha1-yOG4UBYkzOYPo4RZgfhIm6Mh0sU=",
+          "range": "bytes=704-1070"
         },
         "data": {
-          "checksum": "sha256-X5FGVjy9TFT+NbfOA0lbV3pnLHSmqrDGz4BKIeYVBeA=",
-          "range": "bytes=1068-631660"
+          "checksum": "sha256-74kS0GGdLRQfk5b0TynYIEqh6fCEEK7QHP7iNsWb9oE=",
+          "range": "bytes=1071-631901"
         },
         "name": "nghttp2-dev",
         "signature": {
-          "checksum": "sha1-vGUw/0Loh1AWFjrlxevxFU7IKT4=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-AUWNNntPboyRKLJbqFODeq2sX8g=",
+          "range": "bytes=0-703"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.61.0-r1.apk",
-        "version": "1.61.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.62.0-r0.apk",
+        "version": "1.62.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -546,22 +546,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1SX1piz1hZeqGnnSNsfZGhK54I8A=",
+        "checksum": "Q15i44FeGc8cU/Gs+AORIH16osoV8=",
         "control": {
-          "checksum": "sha1-SX1piz1hZeqGnnSNsfZGhK54I8A=",
-          "range": "bytes=699-1103"
+          "checksum": "sha1-5i44FeGc8cU/Gs+AORIH16osoV8=",
+          "range": "bytes=695-1098"
         },
         "data": {
-          "checksum": "sha256-VSxM5PIYwhIc/kJVmh0tsVqLpz68eYyOYyC4cxkP4nw=",
-          "range": "bytes=1104-21603"
+          "checksum": "sha256-72mWEdxOgFKdTQQJGfANOdejkvbhfTVsXD8yNzkwDKo=",
+          "range": "bytes=1099-21646"
         },
         "name": "libcrypt1",
         "signature": {
-          "checksum": "sha1-SRN+qFHoymUHf93USjCViyBMAKU=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-bbdRja3lJyrqB1b1R5lOFXk5Yps=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r3.apk",
-        "version": "2.39-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r5.apk",
+        "version": "2.39-r5"
       },
       {
         "architecture": "x86_64",
@@ -755,22 +755,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ieuXl/3DfkuOLicC/GlvVmzsYM0=",
+        "checksum": "Q1eaot0B2H9IOF054RKMabXG37GUk=",
         "control": {
-          "checksum": "sha1-ieuXl/3DfkuOLicC/GlvVmzsYM0=",
-          "range": "bytes=694-1137"
+          "checksum": "sha1-eaot0B2H9IOF054RKMabXG37GUk=",
+          "range": "bytes=700-1143"
         },
         "data": {
-          "checksum": "sha256-QJ4bdR2CM1ozjfKJ3YY44aPSHHcx/2R999PpMdh/bsA=",
-          "range": "bytes=1138-17230695"
+          "checksum": "sha256-EeuQkVe5Hl+bqWfkBaMgA1Z2Fh91f1upncBbArJu9Gw=",
+          "range": "bytes=1144-17267929"
         },
         "name": "git",
         "signature": {
-          "checksum": "sha1-1X/hk5++g5/PGVylpB3VYqx5hSM=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-yMhNFUJ+emT/s9tdLDQ8zjT2+vY=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/git-2.45.0-r1.apk",
-        "version": "2.45.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/git-2.45.1-r0.apk",
+        "version": "2.45.1-r0"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/executor.lock.json
+++ b/wolfi-images/executor.lock.json
@@ -52,60 +52,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1LbskMUECTvoctOm3XVAJBe6/+O8=",
+        "checksum": "Q15nzyxTcmhST9dTlB9BxV088pKJY=",
         "control": {
-          "checksum": "sha1-LbskMUECTvoctOm3XVAJBe6/+O8=",
-          "range": "bytes=704-1113"
+          "checksum": "sha1-5nzyxTcmhST9dTlB9BxV088pKJY=",
+          "range": "bytes=697-1107"
         },
         "data": {
-          "checksum": "sha256-U8ueoDdtkVXfQ3r8UKQU+ei8sdAH+ayEnmYIcGEM6S8=",
-          "range": "bytes=1114-267813"
+          "checksum": "sha256-i2qrjtws7OeqrKQP83nQo1vFwjqnO0QM3fSTvHHEKps=",
+          "range": "bytes=1108-267856"
         },
         "name": "ld-linux",
         "signature": {
-          "checksum": "sha1-snzU1ONYjrHMX4b2N117nm2p+9s=",
-          "range": "bytes=0-703"
+          "checksum": "sha1-nJTcI836Gt8XuqjMFUh2BBK4pP4=",
+          "range": "bytes=0-696"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r3.apk",
-        "version": "2.39-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r5.apk",
+        "version": "2.39-r5"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ovjsy4Uk7yfyamNBkynUnsHYFMU=",
+        "checksum": "Q1EuFMRKR/2atKFGKHjH/3vivHPEc=",
         "control": {
-          "checksum": "sha1-ovjsy4Uk7yfyamNBkynUnsHYFMU=",
-          "range": "bytes=701-1059"
+          "checksum": "sha1-EuFMRKR/2atKFGKHjH/3vivHPEc=",
+          "range": "bytes=699-1059"
         },
         "data": {
-          "checksum": "sha256-NedZsq170zk14TU+FxyLtc3Dr0vz/fmDP6LbmTqdtF8=",
-          "range": "bytes=1060-408273"
+          "checksum": "sha256-QDrcE6gPZ7R2/02ORkq8ZiVIGQDOwVQ07QetxKwG2jE=",
+          "range": "bytes=1060-408316"
         },
         "name": "glibc-locale-posix",
         "signature": {
-          "checksum": "sha1-G9qkyU9BXJISxwkeJE5Cz/n/H0k=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-hRz3Fq86p+IW4pWkZRP5kxsJFns=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r3.apk",
-        "version": "2.39-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r5.apk",
+        "version": "2.39-r5"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1+bVOClqbAOmgA1y9Q+GYJhEfuJs=",
+        "checksum": "Q19hiFVzu+AzUM0onmSNjApSBdvTw=",
         "control": {
-          "checksum": "sha1-+bVOClqbAOmgA1y9Q+GYJhEfuJs=",
-          "range": "bytes=700-1326"
+          "checksum": "sha1-9hiFVzu+AzUM0onmSNjApSBdvTw=",
+          "range": "bytes=694-1321"
         },
         "data": {
-          "checksum": "sha256-59plMSMECX3LWvyWsiLvadlwbdU3qopW0jRvBCyMGBM=",
-          "range": "bytes=1327-5861479"
+          "checksum": "sha256-eDetP73vFbPoIKaaYcLDZ89dOGzpY4xRBw75zN0Odpg=",
+          "range": "bytes=1322-5861522"
         },
         "name": "glibc",
         "signature": {
-          "checksum": "sha1-NZX+6hpoAYIpCd9O1VsViZI3MM0=",
-          "range": "bytes=0-699"
+          "checksum": "sha1-n8l9a4cNG2heaH82Un+dqHmdqRI=",
+          "range": "bytes=0-693"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r3.apk",
-        "version": "2.39-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r5.apk",
+        "version": "2.39-r5"
       },
       {
         "architecture": "x86_64",
@@ -318,22 +318,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1GG/Qe/wJbfaSQh2/E66qsSZ1d14=",
+        "checksum": "Q1GynPQjsrxTFW54tdQAqopiWsMuo=",
         "control": {
-          "checksum": "sha1-GG/Qe/wJbfaSQh2/E66qsSZ1d14=",
-          "range": "bytes=693-1065"
+          "checksum": "sha1-GynPQjsrxTFW54tdQAqopiWsMuo=",
+          "range": "bytes=697-1068"
         },
         "data": {
-          "checksum": "sha256-83L93TpxngARX3OA5Mm8MzkKPoqcoX6BX4/rslD+ND0=",
-          "range": "bytes=1066-251841"
+          "checksum": "sha256-cFyZH6WiNgbnz+zovA9EJB8aHO70Ao8TIH7052O/w1M=",
+          "range": "bytes=1069-251882"
         },
         "name": "libnghttp2-14",
         "signature": {
-          "checksum": "sha1-nERTCwywhPhwFIvRVZFNWHvzJXk=",
-          "range": "bytes=0-692"
+          "checksum": "sha1-o2sTmr6y1CBY9otWZAKu01XAbM8=",
+          "range": "bytes=0-696"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.61.0-r1.apk",
-        "version": "1.61.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.62.0-r0.apk",
+        "version": "1.62.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -413,41 +413,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1rmRRDukjyxrZKFy/2htPJpXlv6c=",
+        "checksum": "Q1bkh6LBvJiAE8yoq/+3XyeLRcIDE=",
         "control": {
-          "checksum": "sha1-rmRRDukjyxrZKFy/2htPJpXlv6c=",
-          "range": "bytes=699-1169"
+          "checksum": "sha1-bkh6LBvJiAE8yoq/+3XyeLRcIDE=",
+          "range": "bytes=700-1171"
         },
         "data": {
-          "checksum": "sha256-R81rAn3Y5uN4AbPY2STKyJQFy9AlA8AsQBoi6dbaAUA=",
-          "range": "bytes=1170-2556940"
+          "checksum": "sha256-fK9ZYBCiUycuwXY2OUJPlo4VO00LgqbMjSBO0CNMEok=",
+          "range": "bytes=1172-2582013"
         },
         "name": "nghttp2",
         "signature": {
-          "checksum": "sha1-EVy/a8/HRmt7vkLWYZfPCgtTzvE=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-ubcn/WnvFEPpkHx9nfAlqzYVN1o=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.61.0-r1.apk",
-        "version": "1.61.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.62.0-r0.apk",
+        "version": "1.62.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1dKyxN+ghQa6wAlVdT/IeTI/kUCI=",
+        "checksum": "Q1yOG4UBYkzOYPo4RZgfhIm6Mh0sU=",
         "control": {
-          "checksum": "sha1-dKyxN+ghQa6wAlVdT/IeTI/kUCI=",
-          "range": "bytes=699-1067"
+          "checksum": "sha1-yOG4UBYkzOYPo4RZgfhIm6Mh0sU=",
+          "range": "bytes=704-1070"
         },
         "data": {
-          "checksum": "sha256-X5FGVjy9TFT+NbfOA0lbV3pnLHSmqrDGz4BKIeYVBeA=",
-          "range": "bytes=1068-631660"
+          "checksum": "sha256-74kS0GGdLRQfk5b0TynYIEqh6fCEEK7QHP7iNsWb9oE=",
+          "range": "bytes=1071-631901"
         },
         "name": "nghttp2-dev",
         "signature": {
-          "checksum": "sha1-vGUw/0Loh1AWFjrlxevxFU7IKT4=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-AUWNNntPboyRKLJbqFODeq2sX8g=",
+          "range": "bytes=0-703"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.61.0-r1.apk",
-        "version": "1.61.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.62.0-r0.apk",
+        "version": "1.62.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -546,22 +546,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1SX1piz1hZeqGnnSNsfZGhK54I8A=",
+        "checksum": "Q15i44FeGc8cU/Gs+AORIH16osoV8=",
         "control": {
-          "checksum": "sha1-SX1piz1hZeqGnnSNsfZGhK54I8A=",
-          "range": "bytes=699-1103"
+          "checksum": "sha1-5i44FeGc8cU/Gs+AORIH16osoV8=",
+          "range": "bytes=695-1098"
         },
         "data": {
-          "checksum": "sha256-VSxM5PIYwhIc/kJVmh0tsVqLpz68eYyOYyC4cxkP4nw=",
-          "range": "bytes=1104-21603"
+          "checksum": "sha256-72mWEdxOgFKdTQQJGfANOdejkvbhfTVsXD8yNzkwDKo=",
+          "range": "bytes=1099-21646"
         },
         "name": "libcrypt1",
         "signature": {
-          "checksum": "sha1-SRN+qFHoymUHf93USjCViyBMAKU=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-bbdRja3lJyrqB1b1R5lOFXk5Yps=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r3.apk",
-        "version": "2.39-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r5.apk",
+        "version": "2.39-r5"
       },
       {
         "architecture": "x86_64",
@@ -793,22 +793,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ieuXl/3DfkuOLicC/GlvVmzsYM0=",
+        "checksum": "Q1eaot0B2H9IOF054RKMabXG37GUk=",
         "control": {
-          "checksum": "sha1-ieuXl/3DfkuOLicC/GlvVmzsYM0=",
-          "range": "bytes=694-1137"
+          "checksum": "sha1-eaot0B2H9IOF054RKMabXG37GUk=",
+          "range": "bytes=700-1143"
         },
         "data": {
-          "checksum": "sha256-QJ4bdR2CM1ozjfKJ3YY44aPSHHcx/2R999PpMdh/bsA=",
-          "range": "bytes=1138-17230695"
+          "checksum": "sha256-EeuQkVe5Hl+bqWfkBaMgA1Z2Fh91f1upncBbArJu9Gw=",
+          "range": "bytes=1144-17267929"
         },
         "name": "git",
         "signature": {
-          "checksum": "sha1-1X/hk5++g5/PGVylpB3VYqx5hSM=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-yMhNFUJ+emT/s9tdLDQ8zjT2+vY=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/git-2.45.0-r1.apk",
-        "version": "2.45.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/git-2.45.1-r0.apk",
+        "version": "2.45.1-r0"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/gitserver.lock.json
+++ b/wolfi-images/gitserver.lock.json
@@ -71,60 +71,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1LbskMUECTvoctOm3XVAJBe6/+O8=",
+        "checksum": "Q15nzyxTcmhST9dTlB9BxV088pKJY=",
         "control": {
-          "checksum": "sha1-LbskMUECTvoctOm3XVAJBe6/+O8=",
-          "range": "bytes=704-1113"
+          "checksum": "sha1-5nzyxTcmhST9dTlB9BxV088pKJY=",
+          "range": "bytes=697-1107"
         },
         "data": {
-          "checksum": "sha256-U8ueoDdtkVXfQ3r8UKQU+ei8sdAH+ayEnmYIcGEM6S8=",
-          "range": "bytes=1114-267813"
+          "checksum": "sha256-i2qrjtws7OeqrKQP83nQo1vFwjqnO0QM3fSTvHHEKps=",
+          "range": "bytes=1108-267856"
         },
         "name": "ld-linux",
         "signature": {
-          "checksum": "sha1-snzU1ONYjrHMX4b2N117nm2p+9s=",
-          "range": "bytes=0-703"
+          "checksum": "sha1-nJTcI836Gt8XuqjMFUh2BBK4pP4=",
+          "range": "bytes=0-696"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r3.apk",
-        "version": "2.39-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r5.apk",
+        "version": "2.39-r5"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ovjsy4Uk7yfyamNBkynUnsHYFMU=",
+        "checksum": "Q1EuFMRKR/2atKFGKHjH/3vivHPEc=",
         "control": {
-          "checksum": "sha1-ovjsy4Uk7yfyamNBkynUnsHYFMU=",
-          "range": "bytes=701-1059"
+          "checksum": "sha1-EuFMRKR/2atKFGKHjH/3vivHPEc=",
+          "range": "bytes=699-1059"
         },
         "data": {
-          "checksum": "sha256-NedZsq170zk14TU+FxyLtc3Dr0vz/fmDP6LbmTqdtF8=",
-          "range": "bytes=1060-408273"
+          "checksum": "sha256-QDrcE6gPZ7R2/02ORkq8ZiVIGQDOwVQ07QetxKwG2jE=",
+          "range": "bytes=1060-408316"
         },
         "name": "glibc-locale-posix",
         "signature": {
-          "checksum": "sha1-G9qkyU9BXJISxwkeJE5Cz/n/H0k=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-hRz3Fq86p+IW4pWkZRP5kxsJFns=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r3.apk",
-        "version": "2.39-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r5.apk",
+        "version": "2.39-r5"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1+bVOClqbAOmgA1y9Q+GYJhEfuJs=",
+        "checksum": "Q19hiFVzu+AzUM0onmSNjApSBdvTw=",
         "control": {
-          "checksum": "sha1-+bVOClqbAOmgA1y9Q+GYJhEfuJs=",
-          "range": "bytes=700-1326"
+          "checksum": "sha1-9hiFVzu+AzUM0onmSNjApSBdvTw=",
+          "range": "bytes=694-1321"
         },
         "data": {
-          "checksum": "sha256-59plMSMECX3LWvyWsiLvadlwbdU3qopW0jRvBCyMGBM=",
-          "range": "bytes=1327-5861479"
+          "checksum": "sha256-eDetP73vFbPoIKaaYcLDZ89dOGzpY4xRBw75zN0Odpg=",
+          "range": "bytes=1322-5861522"
         },
         "name": "glibc",
         "signature": {
-          "checksum": "sha1-NZX+6hpoAYIpCd9O1VsViZI3MM0=",
-          "range": "bytes=0-699"
+          "checksum": "sha1-n8l9a4cNG2heaH82Un+dqHmdqRI=",
+          "range": "bytes=0-693"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r3.apk",
-        "version": "2.39-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r5.apk",
+        "version": "2.39-r5"
       },
       {
         "architecture": "x86_64",
@@ -375,22 +375,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1GG/Qe/wJbfaSQh2/E66qsSZ1d14=",
+        "checksum": "Q1GynPQjsrxTFW54tdQAqopiWsMuo=",
         "control": {
-          "checksum": "sha1-GG/Qe/wJbfaSQh2/E66qsSZ1d14=",
-          "range": "bytes=693-1065"
+          "checksum": "sha1-GynPQjsrxTFW54tdQAqopiWsMuo=",
+          "range": "bytes=697-1068"
         },
         "data": {
-          "checksum": "sha256-83L93TpxngARX3OA5Mm8MzkKPoqcoX6BX4/rslD+ND0=",
-          "range": "bytes=1066-251841"
+          "checksum": "sha256-cFyZH6WiNgbnz+zovA9EJB8aHO70Ao8TIH7052O/w1M=",
+          "range": "bytes=1069-251882"
         },
         "name": "libnghttp2-14",
         "signature": {
-          "checksum": "sha1-nERTCwywhPhwFIvRVZFNWHvzJXk=",
-          "range": "bytes=0-692"
+          "checksum": "sha1-o2sTmr6y1CBY9otWZAKu01XAbM8=",
+          "range": "bytes=0-696"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.61.0-r1.apk",
-        "version": "1.61.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.62.0-r0.apk",
+        "version": "1.62.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -470,41 +470,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1rmRRDukjyxrZKFy/2htPJpXlv6c=",
+        "checksum": "Q1bkh6LBvJiAE8yoq/+3XyeLRcIDE=",
         "control": {
-          "checksum": "sha1-rmRRDukjyxrZKFy/2htPJpXlv6c=",
-          "range": "bytes=699-1169"
+          "checksum": "sha1-bkh6LBvJiAE8yoq/+3XyeLRcIDE=",
+          "range": "bytes=700-1171"
         },
         "data": {
-          "checksum": "sha256-R81rAn3Y5uN4AbPY2STKyJQFy9AlA8AsQBoi6dbaAUA=",
-          "range": "bytes=1170-2556940"
+          "checksum": "sha256-fK9ZYBCiUycuwXY2OUJPlo4VO00LgqbMjSBO0CNMEok=",
+          "range": "bytes=1172-2582013"
         },
         "name": "nghttp2",
         "signature": {
-          "checksum": "sha1-EVy/a8/HRmt7vkLWYZfPCgtTzvE=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-ubcn/WnvFEPpkHx9nfAlqzYVN1o=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.61.0-r1.apk",
-        "version": "1.61.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.62.0-r0.apk",
+        "version": "1.62.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1dKyxN+ghQa6wAlVdT/IeTI/kUCI=",
+        "checksum": "Q1yOG4UBYkzOYPo4RZgfhIm6Mh0sU=",
         "control": {
-          "checksum": "sha1-dKyxN+ghQa6wAlVdT/IeTI/kUCI=",
-          "range": "bytes=699-1067"
+          "checksum": "sha1-yOG4UBYkzOYPo4RZgfhIm6Mh0sU=",
+          "range": "bytes=704-1070"
         },
         "data": {
-          "checksum": "sha256-X5FGVjy9TFT+NbfOA0lbV3pnLHSmqrDGz4BKIeYVBeA=",
-          "range": "bytes=1068-631660"
+          "checksum": "sha256-74kS0GGdLRQfk5b0TynYIEqh6fCEEK7QHP7iNsWb9oE=",
+          "range": "bytes=1071-631901"
         },
         "name": "nghttp2-dev",
         "signature": {
-          "checksum": "sha1-vGUw/0Loh1AWFjrlxevxFU7IKT4=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-AUWNNntPboyRKLJbqFODeq2sX8g=",
+          "range": "bytes=0-703"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.61.0-r1.apk",
-        "version": "1.61.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.62.0-r0.apk",
+        "version": "1.62.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -603,22 +603,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1SX1piz1hZeqGnnSNsfZGhK54I8A=",
+        "checksum": "Q15i44FeGc8cU/Gs+AORIH16osoV8=",
         "control": {
-          "checksum": "sha1-SX1piz1hZeqGnnSNsfZGhK54I8A=",
-          "range": "bytes=699-1103"
+          "checksum": "sha1-5i44FeGc8cU/Gs+AORIH16osoV8=",
+          "range": "bytes=695-1098"
         },
         "data": {
-          "checksum": "sha256-VSxM5PIYwhIc/kJVmh0tsVqLpz68eYyOYyC4cxkP4nw=",
-          "range": "bytes=1104-21603"
+          "checksum": "sha256-72mWEdxOgFKdTQQJGfANOdejkvbhfTVsXD8yNzkwDKo=",
+          "range": "bytes=1099-21646"
         },
         "name": "libcrypt1",
         "signature": {
-          "checksum": "sha1-SRN+qFHoymUHf93USjCViyBMAKU=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-bbdRja3lJyrqB1b1R5lOFXk5Yps=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r3.apk",
-        "version": "2.39-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r5.apk",
+        "version": "2.39-r5"
       },
       {
         "architecture": "x86_64",
@@ -831,22 +831,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ieuXl/3DfkuOLicC/GlvVmzsYM0=",
+        "checksum": "Q1eaot0B2H9IOF054RKMabXG37GUk=",
         "control": {
-          "checksum": "sha1-ieuXl/3DfkuOLicC/GlvVmzsYM0=",
-          "range": "bytes=694-1137"
+          "checksum": "sha1-eaot0B2H9IOF054RKMabXG37GUk=",
+          "range": "bytes=700-1143"
         },
         "data": {
-          "checksum": "sha256-QJ4bdR2CM1ozjfKJ3YY44aPSHHcx/2R999PpMdh/bsA=",
-          "range": "bytes=1138-17230695"
+          "checksum": "sha256-EeuQkVe5Hl+bqWfkBaMgA1Z2Fh91f1upncBbArJu9Gw=",
+          "range": "bytes=1144-17267929"
         },
         "name": "git",
         "signature": {
-          "checksum": "sha1-1X/hk5++g5/PGVylpB3VYqx5hSM=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-yMhNFUJ+emT/s9tdLDQ8zjT2+vY=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/git-2.45.0-r1.apk",
-        "version": "2.45.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/git-2.45.1-r0.apk",
+        "version": "2.45.1-r0"
       },
       {
         "architecture": "x86_64",
@@ -869,41 +869,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1bgY2qIx8jN5L3tOqqt7QiTpgQ9Q=",
+        "checksum": "Q1AtyQ8BGxIy54FTCVfU4vA3dBujA=",
         "control": {
-          "checksum": "sha1-bgY2qIx8jN5L3tOqqt7QiTpgQ9Q=",
-          "range": "bytes=700-1109"
+          "checksum": "sha1-AtyQ8BGxIy54FTCVfU4vA3dBujA=",
+          "range": "bytes=696-1105"
         },
         "data": {
-          "checksum": "sha256-s2s+7wDCq9x653/jqxhOmy/aDjMzCQ5JemT23452kNU=",
-          "range": "bytes=1110-7554421"
+          "checksum": "sha256-jm7jYqIpUa8S3qayJMbb10cks4vaQbqkkl7r95+SUvc=",
+          "range": "bytes=1106-7568791"
         },
         "name": "git-daemon",
         "signature": {
-          "checksum": "sha1-LLgVia/l0jyJJTxeuMbGBhKekZU=",
-          "range": "bytes=0-699"
+          "checksum": "sha1-WouI+0ZflydIMa2FK5A7CtGW7Uo=",
+          "range": "bytes=0-695"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/git-daemon-2.45.0-r1.apk",
-        "version": "2.45.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/git-daemon-2.45.1-r0.apk",
+        "version": "2.45.1-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1jeUBZvQE2RjD+THqhGKD91Jp1hA=",
+        "checksum": "Q1bxdUk5Zm+DGJ1BJRhi+4lVqQC8M=",
         "control": {
-          "checksum": "sha1-jeUBZvQE2RjD+THqhGKD91Jp1hA=",
-          "range": "bytes=706-1077"
+          "checksum": "sha1-bxdUk5Zm+DGJ1BJRhi+4lVqQC8M=",
+          "range": "bytes=707-1078"
         },
         "data": {
-          "checksum": "sha256-YHrU0Bat1zYFLHSgrR6CDBsRMi+uRh/fqYm3CU88zC4=",
-          "range": "bytes=1078-211547"
+          "checksum": "sha256-n6UB0PG6Q3zvEhvY9YG0J+5fLLQy52aoHxuc/8mNhDo=",
+          "range": "bytes=1079-211589"
         },
         "name": "git-p4",
         "signature": {
-          "checksum": "sha1-NpZUhyIh7ddWCIeS1nmjjafcvaQ=",
-          "range": "bytes=0-705"
+          "checksum": "sha1-7GOnoDsQV3oKBXD6jIlMaFHpzxQ=",
+          "range": "bytes=0-706"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/git-p4-2.45.0-r1.apk",
-        "version": "2.45.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/git-p4-2.45.1-r0.apk",
+        "version": "2.45.1-r0"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/grafana.lock.json
+++ b/wolfi-images/grafana.lock.json
@@ -56,60 +56,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1LbskMUECTvoctOm3XVAJBe6/+O8=",
+        "checksum": "Q15nzyxTcmhST9dTlB9BxV088pKJY=",
         "control": {
-          "checksum": "sha1-LbskMUECTvoctOm3XVAJBe6/+O8=",
-          "range": "bytes=704-1113"
+          "checksum": "sha1-5nzyxTcmhST9dTlB9BxV088pKJY=",
+          "range": "bytes=697-1107"
         },
         "data": {
-          "checksum": "sha256-U8ueoDdtkVXfQ3r8UKQU+ei8sdAH+ayEnmYIcGEM6S8=",
-          "range": "bytes=1114-267813"
+          "checksum": "sha256-i2qrjtws7OeqrKQP83nQo1vFwjqnO0QM3fSTvHHEKps=",
+          "range": "bytes=1108-267856"
         },
         "name": "ld-linux",
         "signature": {
-          "checksum": "sha1-snzU1ONYjrHMX4b2N117nm2p+9s=",
-          "range": "bytes=0-703"
+          "checksum": "sha1-nJTcI836Gt8XuqjMFUh2BBK4pP4=",
+          "range": "bytes=0-696"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r3.apk",
-        "version": "2.39-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r5.apk",
+        "version": "2.39-r5"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ovjsy4Uk7yfyamNBkynUnsHYFMU=",
+        "checksum": "Q1EuFMRKR/2atKFGKHjH/3vivHPEc=",
         "control": {
-          "checksum": "sha1-ovjsy4Uk7yfyamNBkynUnsHYFMU=",
-          "range": "bytes=701-1059"
+          "checksum": "sha1-EuFMRKR/2atKFGKHjH/3vivHPEc=",
+          "range": "bytes=699-1059"
         },
         "data": {
-          "checksum": "sha256-NedZsq170zk14TU+FxyLtc3Dr0vz/fmDP6LbmTqdtF8=",
-          "range": "bytes=1060-408273"
+          "checksum": "sha256-QDrcE6gPZ7R2/02ORkq8ZiVIGQDOwVQ07QetxKwG2jE=",
+          "range": "bytes=1060-408316"
         },
         "name": "glibc-locale-posix",
         "signature": {
-          "checksum": "sha1-G9qkyU9BXJISxwkeJE5Cz/n/H0k=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-hRz3Fq86p+IW4pWkZRP5kxsJFns=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r3.apk",
-        "version": "2.39-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r5.apk",
+        "version": "2.39-r5"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1+bVOClqbAOmgA1y9Q+GYJhEfuJs=",
+        "checksum": "Q19hiFVzu+AzUM0onmSNjApSBdvTw=",
         "control": {
-          "checksum": "sha1-+bVOClqbAOmgA1y9Q+GYJhEfuJs=",
-          "range": "bytes=700-1326"
+          "checksum": "sha1-9hiFVzu+AzUM0onmSNjApSBdvTw=",
+          "range": "bytes=694-1321"
         },
         "data": {
-          "checksum": "sha256-59plMSMECX3LWvyWsiLvadlwbdU3qopW0jRvBCyMGBM=",
-          "range": "bytes=1327-5861479"
+          "checksum": "sha256-eDetP73vFbPoIKaaYcLDZ89dOGzpY4xRBw75zN0Odpg=",
+          "range": "bytes=1322-5861522"
         },
         "name": "glibc",
         "signature": {
-          "checksum": "sha1-NZX+6hpoAYIpCd9O1VsViZI3MM0=",
-          "range": "bytes=0-699"
+          "checksum": "sha1-n8l9a4cNG2heaH82Un+dqHmdqRI=",
+          "range": "bytes=0-693"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r3.apk",
-        "version": "2.39-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r5.apk",
+        "version": "2.39-r5"
       },
       {
         "architecture": "x86_64",
@@ -208,22 +208,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1SX1piz1hZeqGnnSNsfZGhK54I8A=",
+        "checksum": "Q15i44FeGc8cU/Gs+AORIH16osoV8=",
         "control": {
-          "checksum": "sha1-SX1piz1hZeqGnnSNsfZGhK54I8A=",
-          "range": "bytes=699-1103"
+          "checksum": "sha1-5i44FeGc8cU/Gs+AORIH16osoV8=",
+          "range": "bytes=695-1098"
         },
         "data": {
-          "checksum": "sha256-VSxM5PIYwhIc/kJVmh0tsVqLpz68eYyOYyC4cxkP4nw=",
-          "range": "bytes=1104-21603"
+          "checksum": "sha256-72mWEdxOgFKdTQQJGfANOdejkvbhfTVsXD8yNzkwDKo=",
+          "range": "bytes=1099-21646"
         },
         "name": "libcrypt1",
         "signature": {
-          "checksum": "sha1-SRN+qFHoymUHf93USjCViyBMAKU=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-bbdRja3lJyrqB1b1R5lOFXk5Yps=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r3.apk",
-        "version": "2.39-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r5.apk",
+        "version": "2.39-r5"
       },
       {
         "architecture": "x86_64",
@@ -246,22 +246,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1l/Beg7hLAZ2nq/yvn08SgN0dfbQ=",
+        "checksum": "Q1u06OS+YwZxI3J9l6nyLHx2Sn7Hg=",
         "control": {
-          "checksum": "sha1-l/Beg7hLAZ2nq/yvn08SgN0dfbQ=",
-          "range": "bytes=694-1021"
+          "checksum": "sha1-u06OS+YwZxI3J9l6nyLHx2Sn7Hg=",
+          "range": "bytes=696-1023"
         },
         "data": {
-          "checksum": "sha256-LJrbfQdFpPfkW6mTXg4pc83H2E2GlWktO4x6Vd6aOgE=",
-          "range": "bytes=1022-61049957"
+          "checksum": "sha256-Z9YqIzOent28mE3zD4hq3cQKVYEA7b0uMtXQGqZ8ExM=",
+          "range": "bytes=1024-61050000"
         },
         "name": "glibc-locale-en",
         "signature": {
-          "checksum": "sha1-Mu4+oc+G5MqsHFYlEzyNOtGjDDk=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-8ptxZXnKS96Vm/mvZTrB3r5ZddU=",
+          "range": "bytes=0-695"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-en-2.39-r3.apk",
-        "version": "2.39-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-en-2.39-r5.apk",
+        "version": "2.39-r5"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/jaeger-agent.lock.json
+++ b/wolfi-images/jaeger-agent.lock.json
@@ -52,60 +52,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1LbskMUECTvoctOm3XVAJBe6/+O8=",
+        "checksum": "Q15nzyxTcmhST9dTlB9BxV088pKJY=",
         "control": {
-          "checksum": "sha1-LbskMUECTvoctOm3XVAJBe6/+O8=",
-          "range": "bytes=704-1113"
+          "checksum": "sha1-5nzyxTcmhST9dTlB9BxV088pKJY=",
+          "range": "bytes=697-1107"
         },
         "data": {
-          "checksum": "sha256-U8ueoDdtkVXfQ3r8UKQU+ei8sdAH+ayEnmYIcGEM6S8=",
-          "range": "bytes=1114-267813"
+          "checksum": "sha256-i2qrjtws7OeqrKQP83nQo1vFwjqnO0QM3fSTvHHEKps=",
+          "range": "bytes=1108-267856"
         },
         "name": "ld-linux",
         "signature": {
-          "checksum": "sha1-snzU1ONYjrHMX4b2N117nm2p+9s=",
-          "range": "bytes=0-703"
+          "checksum": "sha1-nJTcI836Gt8XuqjMFUh2BBK4pP4=",
+          "range": "bytes=0-696"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r3.apk",
-        "version": "2.39-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r5.apk",
+        "version": "2.39-r5"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ovjsy4Uk7yfyamNBkynUnsHYFMU=",
+        "checksum": "Q1EuFMRKR/2atKFGKHjH/3vivHPEc=",
         "control": {
-          "checksum": "sha1-ovjsy4Uk7yfyamNBkynUnsHYFMU=",
-          "range": "bytes=701-1059"
+          "checksum": "sha1-EuFMRKR/2atKFGKHjH/3vivHPEc=",
+          "range": "bytes=699-1059"
         },
         "data": {
-          "checksum": "sha256-NedZsq170zk14TU+FxyLtc3Dr0vz/fmDP6LbmTqdtF8=",
-          "range": "bytes=1060-408273"
+          "checksum": "sha256-QDrcE6gPZ7R2/02ORkq8ZiVIGQDOwVQ07QetxKwG2jE=",
+          "range": "bytes=1060-408316"
         },
         "name": "glibc-locale-posix",
         "signature": {
-          "checksum": "sha1-G9qkyU9BXJISxwkeJE5Cz/n/H0k=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-hRz3Fq86p+IW4pWkZRP5kxsJFns=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r3.apk",
-        "version": "2.39-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r5.apk",
+        "version": "2.39-r5"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1+bVOClqbAOmgA1y9Q+GYJhEfuJs=",
+        "checksum": "Q19hiFVzu+AzUM0onmSNjApSBdvTw=",
         "control": {
-          "checksum": "sha1-+bVOClqbAOmgA1y9Q+GYJhEfuJs=",
-          "range": "bytes=700-1326"
+          "checksum": "sha1-9hiFVzu+AzUM0onmSNjApSBdvTw=",
+          "range": "bytes=694-1321"
         },
         "data": {
-          "checksum": "sha256-59plMSMECX3LWvyWsiLvadlwbdU3qopW0jRvBCyMGBM=",
-          "range": "bytes=1327-5861479"
+          "checksum": "sha256-eDetP73vFbPoIKaaYcLDZ89dOGzpY4xRBw75zN0Odpg=",
+          "range": "bytes=1322-5861522"
         },
         "name": "glibc",
         "signature": {
-          "checksum": "sha1-NZX+6hpoAYIpCd9O1VsViZI3MM0=",
-          "range": "bytes=0-699"
+          "checksum": "sha1-n8l9a4cNG2heaH82Un+dqHmdqRI=",
+          "range": "bytes=0-693"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r3.apk",
-        "version": "2.39-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r5.apk",
+        "version": "2.39-r5"
       },
       {
         "architecture": "x86_64",
@@ -318,22 +318,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1GG/Qe/wJbfaSQh2/E66qsSZ1d14=",
+        "checksum": "Q1GynPQjsrxTFW54tdQAqopiWsMuo=",
         "control": {
-          "checksum": "sha1-GG/Qe/wJbfaSQh2/E66qsSZ1d14=",
-          "range": "bytes=693-1065"
+          "checksum": "sha1-GynPQjsrxTFW54tdQAqopiWsMuo=",
+          "range": "bytes=697-1068"
         },
         "data": {
-          "checksum": "sha256-83L93TpxngARX3OA5Mm8MzkKPoqcoX6BX4/rslD+ND0=",
-          "range": "bytes=1066-251841"
+          "checksum": "sha256-cFyZH6WiNgbnz+zovA9EJB8aHO70Ao8TIH7052O/w1M=",
+          "range": "bytes=1069-251882"
         },
         "name": "libnghttp2-14",
         "signature": {
-          "checksum": "sha1-nERTCwywhPhwFIvRVZFNWHvzJXk=",
-          "range": "bytes=0-692"
+          "checksum": "sha1-o2sTmr6y1CBY9otWZAKu01XAbM8=",
+          "range": "bytes=0-696"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.61.0-r1.apk",
-        "version": "1.61.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.62.0-r0.apk",
+        "version": "1.62.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -413,41 +413,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1rmRRDukjyxrZKFy/2htPJpXlv6c=",
+        "checksum": "Q1bkh6LBvJiAE8yoq/+3XyeLRcIDE=",
         "control": {
-          "checksum": "sha1-rmRRDukjyxrZKFy/2htPJpXlv6c=",
-          "range": "bytes=699-1169"
+          "checksum": "sha1-bkh6LBvJiAE8yoq/+3XyeLRcIDE=",
+          "range": "bytes=700-1171"
         },
         "data": {
-          "checksum": "sha256-R81rAn3Y5uN4AbPY2STKyJQFy9AlA8AsQBoi6dbaAUA=",
-          "range": "bytes=1170-2556940"
+          "checksum": "sha256-fK9ZYBCiUycuwXY2OUJPlo4VO00LgqbMjSBO0CNMEok=",
+          "range": "bytes=1172-2582013"
         },
         "name": "nghttp2",
         "signature": {
-          "checksum": "sha1-EVy/a8/HRmt7vkLWYZfPCgtTzvE=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-ubcn/WnvFEPpkHx9nfAlqzYVN1o=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.61.0-r1.apk",
-        "version": "1.61.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.62.0-r0.apk",
+        "version": "1.62.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1dKyxN+ghQa6wAlVdT/IeTI/kUCI=",
+        "checksum": "Q1yOG4UBYkzOYPo4RZgfhIm6Mh0sU=",
         "control": {
-          "checksum": "sha1-dKyxN+ghQa6wAlVdT/IeTI/kUCI=",
-          "range": "bytes=699-1067"
+          "checksum": "sha1-yOG4UBYkzOYPo4RZgfhIm6Mh0sU=",
+          "range": "bytes=704-1070"
         },
         "data": {
-          "checksum": "sha256-X5FGVjy9TFT+NbfOA0lbV3pnLHSmqrDGz4BKIeYVBeA=",
-          "range": "bytes=1068-631660"
+          "checksum": "sha256-74kS0GGdLRQfk5b0TynYIEqh6fCEEK7QHP7iNsWb9oE=",
+          "range": "bytes=1071-631901"
         },
         "name": "nghttp2-dev",
         "signature": {
-          "checksum": "sha1-vGUw/0Loh1AWFjrlxevxFU7IKT4=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-AUWNNntPboyRKLJbqFODeq2sX8g=",
+          "range": "bytes=0-703"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.61.0-r1.apk",
-        "version": "1.61.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.62.0-r0.apk",
+        "version": "1.62.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -546,22 +546,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1SX1piz1hZeqGnnSNsfZGhK54I8A=",
+        "checksum": "Q15i44FeGc8cU/Gs+AORIH16osoV8=",
         "control": {
-          "checksum": "sha1-SX1piz1hZeqGnnSNsfZGhK54I8A=",
-          "range": "bytes=699-1103"
+          "checksum": "sha1-5i44FeGc8cU/Gs+AORIH16osoV8=",
+          "range": "bytes=695-1098"
         },
         "data": {
-          "checksum": "sha256-VSxM5PIYwhIc/kJVmh0tsVqLpz68eYyOYyC4cxkP4nw=",
-          "range": "bytes=1104-21603"
+          "checksum": "sha256-72mWEdxOgFKdTQQJGfANOdejkvbhfTVsXD8yNzkwDKo=",
+          "range": "bytes=1099-21646"
         },
         "name": "libcrypt1",
         "signature": {
-          "checksum": "sha1-SRN+qFHoymUHf93USjCViyBMAKU=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-bbdRja3lJyrqB1b1R5lOFXk5Yps=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r3.apk",
-        "version": "2.39-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r5.apk",
+        "version": "2.39-r5"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/jaeger-all-in-one.lock.json
+++ b/wolfi-images/jaeger-all-in-one.lock.json
@@ -52,60 +52,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1LbskMUECTvoctOm3XVAJBe6/+O8=",
+        "checksum": "Q15nzyxTcmhST9dTlB9BxV088pKJY=",
         "control": {
-          "checksum": "sha1-LbskMUECTvoctOm3XVAJBe6/+O8=",
-          "range": "bytes=704-1113"
+          "checksum": "sha1-5nzyxTcmhST9dTlB9BxV088pKJY=",
+          "range": "bytes=697-1107"
         },
         "data": {
-          "checksum": "sha256-U8ueoDdtkVXfQ3r8UKQU+ei8sdAH+ayEnmYIcGEM6S8=",
-          "range": "bytes=1114-267813"
+          "checksum": "sha256-i2qrjtws7OeqrKQP83nQo1vFwjqnO0QM3fSTvHHEKps=",
+          "range": "bytes=1108-267856"
         },
         "name": "ld-linux",
         "signature": {
-          "checksum": "sha1-snzU1ONYjrHMX4b2N117nm2p+9s=",
-          "range": "bytes=0-703"
+          "checksum": "sha1-nJTcI836Gt8XuqjMFUh2BBK4pP4=",
+          "range": "bytes=0-696"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r3.apk",
-        "version": "2.39-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r5.apk",
+        "version": "2.39-r5"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ovjsy4Uk7yfyamNBkynUnsHYFMU=",
+        "checksum": "Q1EuFMRKR/2atKFGKHjH/3vivHPEc=",
         "control": {
-          "checksum": "sha1-ovjsy4Uk7yfyamNBkynUnsHYFMU=",
-          "range": "bytes=701-1059"
+          "checksum": "sha1-EuFMRKR/2atKFGKHjH/3vivHPEc=",
+          "range": "bytes=699-1059"
         },
         "data": {
-          "checksum": "sha256-NedZsq170zk14TU+FxyLtc3Dr0vz/fmDP6LbmTqdtF8=",
-          "range": "bytes=1060-408273"
+          "checksum": "sha256-QDrcE6gPZ7R2/02ORkq8ZiVIGQDOwVQ07QetxKwG2jE=",
+          "range": "bytes=1060-408316"
         },
         "name": "glibc-locale-posix",
         "signature": {
-          "checksum": "sha1-G9qkyU9BXJISxwkeJE5Cz/n/H0k=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-hRz3Fq86p+IW4pWkZRP5kxsJFns=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r3.apk",
-        "version": "2.39-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r5.apk",
+        "version": "2.39-r5"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1+bVOClqbAOmgA1y9Q+GYJhEfuJs=",
+        "checksum": "Q19hiFVzu+AzUM0onmSNjApSBdvTw=",
         "control": {
-          "checksum": "sha1-+bVOClqbAOmgA1y9Q+GYJhEfuJs=",
-          "range": "bytes=700-1326"
+          "checksum": "sha1-9hiFVzu+AzUM0onmSNjApSBdvTw=",
+          "range": "bytes=694-1321"
         },
         "data": {
-          "checksum": "sha256-59plMSMECX3LWvyWsiLvadlwbdU3qopW0jRvBCyMGBM=",
-          "range": "bytes=1327-5861479"
+          "checksum": "sha256-eDetP73vFbPoIKaaYcLDZ89dOGzpY4xRBw75zN0Odpg=",
+          "range": "bytes=1322-5861522"
         },
         "name": "glibc",
         "signature": {
-          "checksum": "sha1-NZX+6hpoAYIpCd9O1VsViZI3MM0=",
-          "range": "bytes=0-699"
+          "checksum": "sha1-n8l9a4cNG2heaH82Un+dqHmdqRI=",
+          "range": "bytes=0-693"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r3.apk",
-        "version": "2.39-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r5.apk",
+        "version": "2.39-r5"
       },
       {
         "architecture": "x86_64",
@@ -318,22 +318,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1GG/Qe/wJbfaSQh2/E66qsSZ1d14=",
+        "checksum": "Q1GynPQjsrxTFW54tdQAqopiWsMuo=",
         "control": {
-          "checksum": "sha1-GG/Qe/wJbfaSQh2/E66qsSZ1d14=",
-          "range": "bytes=693-1065"
+          "checksum": "sha1-GynPQjsrxTFW54tdQAqopiWsMuo=",
+          "range": "bytes=697-1068"
         },
         "data": {
-          "checksum": "sha256-83L93TpxngARX3OA5Mm8MzkKPoqcoX6BX4/rslD+ND0=",
-          "range": "bytes=1066-251841"
+          "checksum": "sha256-cFyZH6WiNgbnz+zovA9EJB8aHO70Ao8TIH7052O/w1M=",
+          "range": "bytes=1069-251882"
         },
         "name": "libnghttp2-14",
         "signature": {
-          "checksum": "sha1-nERTCwywhPhwFIvRVZFNWHvzJXk=",
-          "range": "bytes=0-692"
+          "checksum": "sha1-o2sTmr6y1CBY9otWZAKu01XAbM8=",
+          "range": "bytes=0-696"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.61.0-r1.apk",
-        "version": "1.61.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.62.0-r0.apk",
+        "version": "1.62.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -413,41 +413,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1rmRRDukjyxrZKFy/2htPJpXlv6c=",
+        "checksum": "Q1bkh6LBvJiAE8yoq/+3XyeLRcIDE=",
         "control": {
-          "checksum": "sha1-rmRRDukjyxrZKFy/2htPJpXlv6c=",
-          "range": "bytes=699-1169"
+          "checksum": "sha1-bkh6LBvJiAE8yoq/+3XyeLRcIDE=",
+          "range": "bytes=700-1171"
         },
         "data": {
-          "checksum": "sha256-R81rAn3Y5uN4AbPY2STKyJQFy9AlA8AsQBoi6dbaAUA=",
-          "range": "bytes=1170-2556940"
+          "checksum": "sha256-fK9ZYBCiUycuwXY2OUJPlo4VO00LgqbMjSBO0CNMEok=",
+          "range": "bytes=1172-2582013"
         },
         "name": "nghttp2",
         "signature": {
-          "checksum": "sha1-EVy/a8/HRmt7vkLWYZfPCgtTzvE=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-ubcn/WnvFEPpkHx9nfAlqzYVN1o=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.61.0-r1.apk",
-        "version": "1.61.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.62.0-r0.apk",
+        "version": "1.62.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1dKyxN+ghQa6wAlVdT/IeTI/kUCI=",
+        "checksum": "Q1yOG4UBYkzOYPo4RZgfhIm6Mh0sU=",
         "control": {
-          "checksum": "sha1-dKyxN+ghQa6wAlVdT/IeTI/kUCI=",
-          "range": "bytes=699-1067"
+          "checksum": "sha1-yOG4UBYkzOYPo4RZgfhIm6Mh0sU=",
+          "range": "bytes=704-1070"
         },
         "data": {
-          "checksum": "sha256-X5FGVjy9TFT+NbfOA0lbV3pnLHSmqrDGz4BKIeYVBeA=",
-          "range": "bytes=1068-631660"
+          "checksum": "sha256-74kS0GGdLRQfk5b0TynYIEqh6fCEEK7QHP7iNsWb9oE=",
+          "range": "bytes=1071-631901"
         },
         "name": "nghttp2-dev",
         "signature": {
-          "checksum": "sha1-vGUw/0Loh1AWFjrlxevxFU7IKT4=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-AUWNNntPboyRKLJbqFODeq2sX8g=",
+          "range": "bytes=0-703"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.61.0-r1.apk",
-        "version": "1.61.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.62.0-r0.apk",
+        "version": "1.62.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -546,22 +546,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1SX1piz1hZeqGnnSNsfZGhK54I8A=",
+        "checksum": "Q15i44FeGc8cU/Gs+AORIH16osoV8=",
         "control": {
-          "checksum": "sha1-SX1piz1hZeqGnnSNsfZGhK54I8A=",
-          "range": "bytes=699-1103"
+          "checksum": "sha1-5i44FeGc8cU/Gs+AORIH16osoV8=",
+          "range": "bytes=695-1098"
         },
         "data": {
-          "checksum": "sha256-VSxM5PIYwhIc/kJVmh0tsVqLpz68eYyOYyC4cxkP4nw=",
-          "range": "bytes=1104-21603"
+          "checksum": "sha256-72mWEdxOgFKdTQQJGfANOdejkvbhfTVsXD8yNzkwDKo=",
+          "range": "bytes=1099-21646"
         },
         "name": "libcrypt1",
         "signature": {
-          "checksum": "sha1-SRN+qFHoymUHf93USjCViyBMAKU=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-bbdRja3lJyrqB1b1R5lOFXk5Yps=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r3.apk",
-        "version": "2.39-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r5.apk",
+        "version": "2.39-r5"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/node-exporter.lock.json
+++ b/wolfi-images/node-exporter.lock.json
@@ -52,60 +52,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1LbskMUECTvoctOm3XVAJBe6/+O8=",
+        "checksum": "Q15nzyxTcmhST9dTlB9BxV088pKJY=",
         "control": {
-          "checksum": "sha1-LbskMUECTvoctOm3XVAJBe6/+O8=",
-          "range": "bytes=704-1113"
+          "checksum": "sha1-5nzyxTcmhST9dTlB9BxV088pKJY=",
+          "range": "bytes=697-1107"
         },
         "data": {
-          "checksum": "sha256-U8ueoDdtkVXfQ3r8UKQU+ei8sdAH+ayEnmYIcGEM6S8=",
-          "range": "bytes=1114-267813"
+          "checksum": "sha256-i2qrjtws7OeqrKQP83nQo1vFwjqnO0QM3fSTvHHEKps=",
+          "range": "bytes=1108-267856"
         },
         "name": "ld-linux",
         "signature": {
-          "checksum": "sha1-snzU1ONYjrHMX4b2N117nm2p+9s=",
-          "range": "bytes=0-703"
+          "checksum": "sha1-nJTcI836Gt8XuqjMFUh2BBK4pP4=",
+          "range": "bytes=0-696"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r3.apk",
-        "version": "2.39-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r5.apk",
+        "version": "2.39-r5"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ovjsy4Uk7yfyamNBkynUnsHYFMU=",
+        "checksum": "Q1EuFMRKR/2atKFGKHjH/3vivHPEc=",
         "control": {
-          "checksum": "sha1-ovjsy4Uk7yfyamNBkynUnsHYFMU=",
-          "range": "bytes=701-1059"
+          "checksum": "sha1-EuFMRKR/2atKFGKHjH/3vivHPEc=",
+          "range": "bytes=699-1059"
         },
         "data": {
-          "checksum": "sha256-NedZsq170zk14TU+FxyLtc3Dr0vz/fmDP6LbmTqdtF8=",
-          "range": "bytes=1060-408273"
+          "checksum": "sha256-QDrcE6gPZ7R2/02ORkq8ZiVIGQDOwVQ07QetxKwG2jE=",
+          "range": "bytes=1060-408316"
         },
         "name": "glibc-locale-posix",
         "signature": {
-          "checksum": "sha1-G9qkyU9BXJISxwkeJE5Cz/n/H0k=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-hRz3Fq86p+IW4pWkZRP5kxsJFns=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r3.apk",
-        "version": "2.39-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r5.apk",
+        "version": "2.39-r5"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1+bVOClqbAOmgA1y9Q+GYJhEfuJs=",
+        "checksum": "Q19hiFVzu+AzUM0onmSNjApSBdvTw=",
         "control": {
-          "checksum": "sha1-+bVOClqbAOmgA1y9Q+GYJhEfuJs=",
-          "range": "bytes=700-1326"
+          "checksum": "sha1-9hiFVzu+AzUM0onmSNjApSBdvTw=",
+          "range": "bytes=694-1321"
         },
         "data": {
-          "checksum": "sha256-59plMSMECX3LWvyWsiLvadlwbdU3qopW0jRvBCyMGBM=",
-          "range": "bytes=1327-5861479"
+          "checksum": "sha256-eDetP73vFbPoIKaaYcLDZ89dOGzpY4xRBw75zN0Odpg=",
+          "range": "bytes=1322-5861522"
         },
         "name": "glibc",
         "signature": {
-          "checksum": "sha1-NZX+6hpoAYIpCd9O1VsViZI3MM0=",
-          "range": "bytes=0-699"
+          "checksum": "sha1-n8l9a4cNG2heaH82Un+dqHmdqRI=",
+          "range": "bytes=0-693"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r3.apk",
-        "version": "2.39-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r5.apk",
+        "version": "2.39-r5"
       },
       {
         "architecture": "x86_64",
@@ -318,22 +318,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1GG/Qe/wJbfaSQh2/E66qsSZ1d14=",
+        "checksum": "Q1GynPQjsrxTFW54tdQAqopiWsMuo=",
         "control": {
-          "checksum": "sha1-GG/Qe/wJbfaSQh2/E66qsSZ1d14=",
-          "range": "bytes=693-1065"
+          "checksum": "sha1-GynPQjsrxTFW54tdQAqopiWsMuo=",
+          "range": "bytes=697-1068"
         },
         "data": {
-          "checksum": "sha256-83L93TpxngARX3OA5Mm8MzkKPoqcoX6BX4/rslD+ND0=",
-          "range": "bytes=1066-251841"
+          "checksum": "sha256-cFyZH6WiNgbnz+zovA9EJB8aHO70Ao8TIH7052O/w1M=",
+          "range": "bytes=1069-251882"
         },
         "name": "libnghttp2-14",
         "signature": {
-          "checksum": "sha1-nERTCwywhPhwFIvRVZFNWHvzJXk=",
-          "range": "bytes=0-692"
+          "checksum": "sha1-o2sTmr6y1CBY9otWZAKu01XAbM8=",
+          "range": "bytes=0-696"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.61.0-r1.apk",
-        "version": "1.61.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.62.0-r0.apk",
+        "version": "1.62.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -413,41 +413,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1rmRRDukjyxrZKFy/2htPJpXlv6c=",
+        "checksum": "Q1bkh6LBvJiAE8yoq/+3XyeLRcIDE=",
         "control": {
-          "checksum": "sha1-rmRRDukjyxrZKFy/2htPJpXlv6c=",
-          "range": "bytes=699-1169"
+          "checksum": "sha1-bkh6LBvJiAE8yoq/+3XyeLRcIDE=",
+          "range": "bytes=700-1171"
         },
         "data": {
-          "checksum": "sha256-R81rAn3Y5uN4AbPY2STKyJQFy9AlA8AsQBoi6dbaAUA=",
-          "range": "bytes=1170-2556940"
+          "checksum": "sha256-fK9ZYBCiUycuwXY2OUJPlo4VO00LgqbMjSBO0CNMEok=",
+          "range": "bytes=1172-2582013"
         },
         "name": "nghttp2",
         "signature": {
-          "checksum": "sha1-EVy/a8/HRmt7vkLWYZfPCgtTzvE=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-ubcn/WnvFEPpkHx9nfAlqzYVN1o=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.61.0-r1.apk",
-        "version": "1.61.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.62.0-r0.apk",
+        "version": "1.62.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1dKyxN+ghQa6wAlVdT/IeTI/kUCI=",
+        "checksum": "Q1yOG4UBYkzOYPo4RZgfhIm6Mh0sU=",
         "control": {
-          "checksum": "sha1-dKyxN+ghQa6wAlVdT/IeTI/kUCI=",
-          "range": "bytes=699-1067"
+          "checksum": "sha1-yOG4UBYkzOYPo4RZgfhIm6Mh0sU=",
+          "range": "bytes=704-1070"
         },
         "data": {
-          "checksum": "sha256-X5FGVjy9TFT+NbfOA0lbV3pnLHSmqrDGz4BKIeYVBeA=",
-          "range": "bytes=1068-631660"
+          "checksum": "sha256-74kS0GGdLRQfk5b0TynYIEqh6fCEEK7QHP7iNsWb9oE=",
+          "range": "bytes=1071-631901"
         },
         "name": "nghttp2-dev",
         "signature": {
-          "checksum": "sha1-vGUw/0Loh1AWFjrlxevxFU7IKT4=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-AUWNNntPboyRKLJbqFODeq2sX8g=",
+          "range": "bytes=0-703"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.61.0-r1.apk",
-        "version": "1.61.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.62.0-r0.apk",
+        "version": "1.62.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -546,22 +546,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1SX1piz1hZeqGnnSNsfZGhK54I8A=",
+        "checksum": "Q15i44FeGc8cU/Gs+AORIH16osoV8=",
         "control": {
-          "checksum": "sha1-SX1piz1hZeqGnnSNsfZGhK54I8A=",
-          "range": "bytes=699-1103"
+          "checksum": "sha1-5i44FeGc8cU/Gs+AORIH16osoV8=",
+          "range": "bytes=695-1098"
         },
         "data": {
-          "checksum": "sha256-VSxM5PIYwhIc/kJVmh0tsVqLpz68eYyOYyC4cxkP4nw=",
-          "range": "bytes=1104-21603"
+          "checksum": "sha256-72mWEdxOgFKdTQQJGfANOdejkvbhfTVsXD8yNzkwDKo=",
+          "range": "bytes=1099-21646"
         },
         "name": "libcrypt1",
         "signature": {
-          "checksum": "sha1-SRN+qFHoymUHf93USjCViyBMAKU=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-bbdRja3lJyrqB1b1R5lOFXk5Yps=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r3.apk",
-        "version": "2.39-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r5.apk",
+        "version": "2.39-r5"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/opentelemetry-collector.lock.json
+++ b/wolfi-images/opentelemetry-collector.lock.json
@@ -52,60 +52,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1LbskMUECTvoctOm3XVAJBe6/+O8=",
+        "checksum": "Q15nzyxTcmhST9dTlB9BxV088pKJY=",
         "control": {
-          "checksum": "sha1-LbskMUECTvoctOm3XVAJBe6/+O8=",
-          "range": "bytes=704-1113"
+          "checksum": "sha1-5nzyxTcmhST9dTlB9BxV088pKJY=",
+          "range": "bytes=697-1107"
         },
         "data": {
-          "checksum": "sha256-U8ueoDdtkVXfQ3r8UKQU+ei8sdAH+ayEnmYIcGEM6S8=",
-          "range": "bytes=1114-267813"
+          "checksum": "sha256-i2qrjtws7OeqrKQP83nQo1vFwjqnO0QM3fSTvHHEKps=",
+          "range": "bytes=1108-267856"
         },
         "name": "ld-linux",
         "signature": {
-          "checksum": "sha1-snzU1ONYjrHMX4b2N117nm2p+9s=",
-          "range": "bytes=0-703"
+          "checksum": "sha1-nJTcI836Gt8XuqjMFUh2BBK4pP4=",
+          "range": "bytes=0-696"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r3.apk",
-        "version": "2.39-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r5.apk",
+        "version": "2.39-r5"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ovjsy4Uk7yfyamNBkynUnsHYFMU=",
+        "checksum": "Q1EuFMRKR/2atKFGKHjH/3vivHPEc=",
         "control": {
-          "checksum": "sha1-ovjsy4Uk7yfyamNBkynUnsHYFMU=",
-          "range": "bytes=701-1059"
+          "checksum": "sha1-EuFMRKR/2atKFGKHjH/3vivHPEc=",
+          "range": "bytes=699-1059"
         },
         "data": {
-          "checksum": "sha256-NedZsq170zk14TU+FxyLtc3Dr0vz/fmDP6LbmTqdtF8=",
-          "range": "bytes=1060-408273"
+          "checksum": "sha256-QDrcE6gPZ7R2/02ORkq8ZiVIGQDOwVQ07QetxKwG2jE=",
+          "range": "bytes=1060-408316"
         },
         "name": "glibc-locale-posix",
         "signature": {
-          "checksum": "sha1-G9qkyU9BXJISxwkeJE5Cz/n/H0k=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-hRz3Fq86p+IW4pWkZRP5kxsJFns=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r3.apk",
-        "version": "2.39-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r5.apk",
+        "version": "2.39-r5"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1+bVOClqbAOmgA1y9Q+GYJhEfuJs=",
+        "checksum": "Q19hiFVzu+AzUM0onmSNjApSBdvTw=",
         "control": {
-          "checksum": "sha1-+bVOClqbAOmgA1y9Q+GYJhEfuJs=",
-          "range": "bytes=700-1326"
+          "checksum": "sha1-9hiFVzu+AzUM0onmSNjApSBdvTw=",
+          "range": "bytes=694-1321"
         },
         "data": {
-          "checksum": "sha256-59plMSMECX3LWvyWsiLvadlwbdU3qopW0jRvBCyMGBM=",
-          "range": "bytes=1327-5861479"
+          "checksum": "sha256-eDetP73vFbPoIKaaYcLDZ89dOGzpY4xRBw75zN0Odpg=",
+          "range": "bytes=1322-5861522"
         },
         "name": "glibc",
         "signature": {
-          "checksum": "sha1-NZX+6hpoAYIpCd9O1VsViZI3MM0=",
-          "range": "bytes=0-699"
+          "checksum": "sha1-n8l9a4cNG2heaH82Un+dqHmdqRI=",
+          "range": "bytes=0-693"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r3.apk",
-        "version": "2.39-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r5.apk",
+        "version": "2.39-r5"
       },
       {
         "architecture": "x86_64",
@@ -318,22 +318,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1GG/Qe/wJbfaSQh2/E66qsSZ1d14=",
+        "checksum": "Q1GynPQjsrxTFW54tdQAqopiWsMuo=",
         "control": {
-          "checksum": "sha1-GG/Qe/wJbfaSQh2/E66qsSZ1d14=",
-          "range": "bytes=693-1065"
+          "checksum": "sha1-GynPQjsrxTFW54tdQAqopiWsMuo=",
+          "range": "bytes=697-1068"
         },
         "data": {
-          "checksum": "sha256-83L93TpxngARX3OA5Mm8MzkKPoqcoX6BX4/rslD+ND0=",
-          "range": "bytes=1066-251841"
+          "checksum": "sha256-cFyZH6WiNgbnz+zovA9EJB8aHO70Ao8TIH7052O/w1M=",
+          "range": "bytes=1069-251882"
         },
         "name": "libnghttp2-14",
         "signature": {
-          "checksum": "sha1-nERTCwywhPhwFIvRVZFNWHvzJXk=",
-          "range": "bytes=0-692"
+          "checksum": "sha1-o2sTmr6y1CBY9otWZAKu01XAbM8=",
+          "range": "bytes=0-696"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.61.0-r1.apk",
-        "version": "1.61.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.62.0-r0.apk",
+        "version": "1.62.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -413,41 +413,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1rmRRDukjyxrZKFy/2htPJpXlv6c=",
+        "checksum": "Q1bkh6LBvJiAE8yoq/+3XyeLRcIDE=",
         "control": {
-          "checksum": "sha1-rmRRDukjyxrZKFy/2htPJpXlv6c=",
-          "range": "bytes=699-1169"
+          "checksum": "sha1-bkh6LBvJiAE8yoq/+3XyeLRcIDE=",
+          "range": "bytes=700-1171"
         },
         "data": {
-          "checksum": "sha256-R81rAn3Y5uN4AbPY2STKyJQFy9AlA8AsQBoi6dbaAUA=",
-          "range": "bytes=1170-2556940"
+          "checksum": "sha256-fK9ZYBCiUycuwXY2OUJPlo4VO00LgqbMjSBO0CNMEok=",
+          "range": "bytes=1172-2582013"
         },
         "name": "nghttp2",
         "signature": {
-          "checksum": "sha1-EVy/a8/HRmt7vkLWYZfPCgtTzvE=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-ubcn/WnvFEPpkHx9nfAlqzYVN1o=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.61.0-r1.apk",
-        "version": "1.61.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.62.0-r0.apk",
+        "version": "1.62.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1dKyxN+ghQa6wAlVdT/IeTI/kUCI=",
+        "checksum": "Q1yOG4UBYkzOYPo4RZgfhIm6Mh0sU=",
         "control": {
-          "checksum": "sha1-dKyxN+ghQa6wAlVdT/IeTI/kUCI=",
-          "range": "bytes=699-1067"
+          "checksum": "sha1-yOG4UBYkzOYPo4RZgfhIm6Mh0sU=",
+          "range": "bytes=704-1070"
         },
         "data": {
-          "checksum": "sha256-X5FGVjy9TFT+NbfOA0lbV3pnLHSmqrDGz4BKIeYVBeA=",
-          "range": "bytes=1068-631660"
+          "checksum": "sha256-74kS0GGdLRQfk5b0TynYIEqh6fCEEK7QHP7iNsWb9oE=",
+          "range": "bytes=1071-631901"
         },
         "name": "nghttp2-dev",
         "signature": {
-          "checksum": "sha1-vGUw/0Loh1AWFjrlxevxFU7IKT4=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-AUWNNntPboyRKLJbqFODeq2sX8g=",
+          "range": "bytes=0-703"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.61.0-r1.apk",
-        "version": "1.61.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.62.0-r0.apk",
+        "version": "1.62.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -546,22 +546,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1SX1piz1hZeqGnnSNsfZGhK54I8A=",
+        "checksum": "Q15i44FeGc8cU/Gs+AORIH16osoV8=",
         "control": {
-          "checksum": "sha1-SX1piz1hZeqGnnSNsfZGhK54I8A=",
-          "range": "bytes=699-1103"
+          "checksum": "sha1-5i44FeGc8cU/Gs+AORIH16osoV8=",
+          "range": "bytes=695-1098"
         },
         "data": {
-          "checksum": "sha256-VSxM5PIYwhIc/kJVmh0tsVqLpz68eYyOYyC4cxkP4nw=",
-          "range": "bytes=1104-21603"
+          "checksum": "sha256-72mWEdxOgFKdTQQJGfANOdejkvbhfTVsXD8yNzkwDKo=",
+          "range": "bytes=1099-21646"
         },
         "name": "libcrypt1",
         "signature": {
-          "checksum": "sha1-SRN+qFHoymUHf93USjCViyBMAKU=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-bbdRja3lJyrqB1b1R5lOFXk5Yps=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r3.apk",
-        "version": "2.39-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r5.apk",
+        "version": "2.39-r5"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/postgres-exporter.lock.json
+++ b/wolfi-images/postgres-exporter.lock.json
@@ -52,60 +52,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1LbskMUECTvoctOm3XVAJBe6/+O8=",
+        "checksum": "Q15nzyxTcmhST9dTlB9BxV088pKJY=",
         "control": {
-          "checksum": "sha1-LbskMUECTvoctOm3XVAJBe6/+O8=",
-          "range": "bytes=704-1113"
+          "checksum": "sha1-5nzyxTcmhST9dTlB9BxV088pKJY=",
+          "range": "bytes=697-1107"
         },
         "data": {
-          "checksum": "sha256-U8ueoDdtkVXfQ3r8UKQU+ei8sdAH+ayEnmYIcGEM6S8=",
-          "range": "bytes=1114-267813"
+          "checksum": "sha256-i2qrjtws7OeqrKQP83nQo1vFwjqnO0QM3fSTvHHEKps=",
+          "range": "bytes=1108-267856"
         },
         "name": "ld-linux",
         "signature": {
-          "checksum": "sha1-snzU1ONYjrHMX4b2N117nm2p+9s=",
-          "range": "bytes=0-703"
+          "checksum": "sha1-nJTcI836Gt8XuqjMFUh2BBK4pP4=",
+          "range": "bytes=0-696"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r3.apk",
-        "version": "2.39-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r5.apk",
+        "version": "2.39-r5"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ovjsy4Uk7yfyamNBkynUnsHYFMU=",
+        "checksum": "Q1EuFMRKR/2atKFGKHjH/3vivHPEc=",
         "control": {
-          "checksum": "sha1-ovjsy4Uk7yfyamNBkynUnsHYFMU=",
-          "range": "bytes=701-1059"
+          "checksum": "sha1-EuFMRKR/2atKFGKHjH/3vivHPEc=",
+          "range": "bytes=699-1059"
         },
         "data": {
-          "checksum": "sha256-NedZsq170zk14TU+FxyLtc3Dr0vz/fmDP6LbmTqdtF8=",
-          "range": "bytes=1060-408273"
+          "checksum": "sha256-QDrcE6gPZ7R2/02ORkq8ZiVIGQDOwVQ07QetxKwG2jE=",
+          "range": "bytes=1060-408316"
         },
         "name": "glibc-locale-posix",
         "signature": {
-          "checksum": "sha1-G9qkyU9BXJISxwkeJE5Cz/n/H0k=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-hRz3Fq86p+IW4pWkZRP5kxsJFns=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r3.apk",
-        "version": "2.39-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r5.apk",
+        "version": "2.39-r5"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1+bVOClqbAOmgA1y9Q+GYJhEfuJs=",
+        "checksum": "Q19hiFVzu+AzUM0onmSNjApSBdvTw=",
         "control": {
-          "checksum": "sha1-+bVOClqbAOmgA1y9Q+GYJhEfuJs=",
-          "range": "bytes=700-1326"
+          "checksum": "sha1-9hiFVzu+AzUM0onmSNjApSBdvTw=",
+          "range": "bytes=694-1321"
         },
         "data": {
-          "checksum": "sha256-59plMSMECX3LWvyWsiLvadlwbdU3qopW0jRvBCyMGBM=",
-          "range": "bytes=1327-5861479"
+          "checksum": "sha256-eDetP73vFbPoIKaaYcLDZ89dOGzpY4xRBw75zN0Odpg=",
+          "range": "bytes=1322-5861522"
         },
         "name": "glibc",
         "signature": {
-          "checksum": "sha1-NZX+6hpoAYIpCd9O1VsViZI3MM0=",
-          "range": "bytes=0-699"
+          "checksum": "sha1-n8l9a4cNG2heaH82Un+dqHmdqRI=",
+          "range": "bytes=0-693"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r3.apk",
-        "version": "2.39-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r5.apk",
+        "version": "2.39-r5"
       },
       {
         "architecture": "x86_64",
@@ -318,22 +318,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1GG/Qe/wJbfaSQh2/E66qsSZ1d14=",
+        "checksum": "Q1GynPQjsrxTFW54tdQAqopiWsMuo=",
         "control": {
-          "checksum": "sha1-GG/Qe/wJbfaSQh2/E66qsSZ1d14=",
-          "range": "bytes=693-1065"
+          "checksum": "sha1-GynPQjsrxTFW54tdQAqopiWsMuo=",
+          "range": "bytes=697-1068"
         },
         "data": {
-          "checksum": "sha256-83L93TpxngARX3OA5Mm8MzkKPoqcoX6BX4/rslD+ND0=",
-          "range": "bytes=1066-251841"
+          "checksum": "sha256-cFyZH6WiNgbnz+zovA9EJB8aHO70Ao8TIH7052O/w1M=",
+          "range": "bytes=1069-251882"
         },
         "name": "libnghttp2-14",
         "signature": {
-          "checksum": "sha1-nERTCwywhPhwFIvRVZFNWHvzJXk=",
-          "range": "bytes=0-692"
+          "checksum": "sha1-o2sTmr6y1CBY9otWZAKu01XAbM8=",
+          "range": "bytes=0-696"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.61.0-r1.apk",
-        "version": "1.61.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.62.0-r0.apk",
+        "version": "1.62.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -413,41 +413,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1rmRRDukjyxrZKFy/2htPJpXlv6c=",
+        "checksum": "Q1bkh6LBvJiAE8yoq/+3XyeLRcIDE=",
         "control": {
-          "checksum": "sha1-rmRRDukjyxrZKFy/2htPJpXlv6c=",
-          "range": "bytes=699-1169"
+          "checksum": "sha1-bkh6LBvJiAE8yoq/+3XyeLRcIDE=",
+          "range": "bytes=700-1171"
         },
         "data": {
-          "checksum": "sha256-R81rAn3Y5uN4AbPY2STKyJQFy9AlA8AsQBoi6dbaAUA=",
-          "range": "bytes=1170-2556940"
+          "checksum": "sha256-fK9ZYBCiUycuwXY2OUJPlo4VO00LgqbMjSBO0CNMEok=",
+          "range": "bytes=1172-2582013"
         },
         "name": "nghttp2",
         "signature": {
-          "checksum": "sha1-EVy/a8/HRmt7vkLWYZfPCgtTzvE=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-ubcn/WnvFEPpkHx9nfAlqzYVN1o=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.61.0-r1.apk",
-        "version": "1.61.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.62.0-r0.apk",
+        "version": "1.62.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1dKyxN+ghQa6wAlVdT/IeTI/kUCI=",
+        "checksum": "Q1yOG4UBYkzOYPo4RZgfhIm6Mh0sU=",
         "control": {
-          "checksum": "sha1-dKyxN+ghQa6wAlVdT/IeTI/kUCI=",
-          "range": "bytes=699-1067"
+          "checksum": "sha1-yOG4UBYkzOYPo4RZgfhIm6Mh0sU=",
+          "range": "bytes=704-1070"
         },
         "data": {
-          "checksum": "sha256-X5FGVjy9TFT+NbfOA0lbV3pnLHSmqrDGz4BKIeYVBeA=",
-          "range": "bytes=1068-631660"
+          "checksum": "sha256-74kS0GGdLRQfk5b0TynYIEqh6fCEEK7QHP7iNsWb9oE=",
+          "range": "bytes=1071-631901"
         },
         "name": "nghttp2-dev",
         "signature": {
-          "checksum": "sha1-vGUw/0Loh1AWFjrlxevxFU7IKT4=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-AUWNNntPboyRKLJbqFODeq2sX8g=",
+          "range": "bytes=0-703"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.61.0-r1.apk",
-        "version": "1.61.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.62.0-r0.apk",
+        "version": "1.62.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -546,22 +546,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1SX1piz1hZeqGnnSNsfZGhK54I8A=",
+        "checksum": "Q15i44FeGc8cU/Gs+AORIH16osoV8=",
         "control": {
-          "checksum": "sha1-SX1piz1hZeqGnnSNsfZGhK54I8A=",
-          "range": "bytes=699-1103"
+          "checksum": "sha1-5i44FeGc8cU/Gs+AORIH16osoV8=",
+          "range": "bytes=695-1098"
         },
         "data": {
-          "checksum": "sha256-VSxM5PIYwhIc/kJVmh0tsVqLpz68eYyOYyC4cxkP4nw=",
-          "range": "bytes=1104-21603"
+          "checksum": "sha256-72mWEdxOgFKdTQQJGfANOdejkvbhfTVsXD8yNzkwDKo=",
+          "range": "bytes=1099-21646"
         },
         "name": "libcrypt1",
         "signature": {
-          "checksum": "sha1-SRN+qFHoymUHf93USjCViyBMAKU=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-bbdRja3lJyrqB1b1R5lOFXk5Yps=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r3.apk",
-        "version": "2.39-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r5.apk",
+        "version": "2.39-r5"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/postgresql-12-codeinsights.lock.json
+++ b/wolfi-images/postgresql-12-codeinsights.lock.json
@@ -52,60 +52,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1LbskMUECTvoctOm3XVAJBe6/+O8=",
+        "checksum": "Q15nzyxTcmhST9dTlB9BxV088pKJY=",
         "control": {
-          "checksum": "sha1-LbskMUECTvoctOm3XVAJBe6/+O8=",
-          "range": "bytes=704-1113"
+          "checksum": "sha1-5nzyxTcmhST9dTlB9BxV088pKJY=",
+          "range": "bytes=697-1107"
         },
         "data": {
-          "checksum": "sha256-U8ueoDdtkVXfQ3r8UKQU+ei8sdAH+ayEnmYIcGEM6S8=",
-          "range": "bytes=1114-267813"
+          "checksum": "sha256-i2qrjtws7OeqrKQP83nQo1vFwjqnO0QM3fSTvHHEKps=",
+          "range": "bytes=1108-267856"
         },
         "name": "ld-linux",
         "signature": {
-          "checksum": "sha1-snzU1ONYjrHMX4b2N117nm2p+9s=",
-          "range": "bytes=0-703"
+          "checksum": "sha1-nJTcI836Gt8XuqjMFUh2BBK4pP4=",
+          "range": "bytes=0-696"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r3.apk",
-        "version": "2.39-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r5.apk",
+        "version": "2.39-r5"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ovjsy4Uk7yfyamNBkynUnsHYFMU=",
+        "checksum": "Q1EuFMRKR/2atKFGKHjH/3vivHPEc=",
         "control": {
-          "checksum": "sha1-ovjsy4Uk7yfyamNBkynUnsHYFMU=",
-          "range": "bytes=701-1059"
+          "checksum": "sha1-EuFMRKR/2atKFGKHjH/3vivHPEc=",
+          "range": "bytes=699-1059"
         },
         "data": {
-          "checksum": "sha256-NedZsq170zk14TU+FxyLtc3Dr0vz/fmDP6LbmTqdtF8=",
-          "range": "bytes=1060-408273"
+          "checksum": "sha256-QDrcE6gPZ7R2/02ORkq8ZiVIGQDOwVQ07QetxKwG2jE=",
+          "range": "bytes=1060-408316"
         },
         "name": "glibc-locale-posix",
         "signature": {
-          "checksum": "sha1-G9qkyU9BXJISxwkeJE5Cz/n/H0k=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-hRz3Fq86p+IW4pWkZRP5kxsJFns=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r3.apk",
-        "version": "2.39-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r5.apk",
+        "version": "2.39-r5"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1+bVOClqbAOmgA1y9Q+GYJhEfuJs=",
+        "checksum": "Q19hiFVzu+AzUM0onmSNjApSBdvTw=",
         "control": {
-          "checksum": "sha1-+bVOClqbAOmgA1y9Q+GYJhEfuJs=",
-          "range": "bytes=700-1326"
+          "checksum": "sha1-9hiFVzu+AzUM0onmSNjApSBdvTw=",
+          "range": "bytes=694-1321"
         },
         "data": {
-          "checksum": "sha256-59plMSMECX3LWvyWsiLvadlwbdU3qopW0jRvBCyMGBM=",
-          "range": "bytes=1327-5861479"
+          "checksum": "sha256-eDetP73vFbPoIKaaYcLDZ89dOGzpY4xRBw75zN0Odpg=",
+          "range": "bytes=1322-5861522"
         },
         "name": "glibc",
         "signature": {
-          "checksum": "sha1-NZX+6hpoAYIpCd9O1VsViZI3MM0=",
-          "range": "bytes=0-699"
+          "checksum": "sha1-n8l9a4cNG2heaH82Un+dqHmdqRI=",
+          "range": "bytes=0-693"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r3.apk",
-        "version": "2.39-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r5.apk",
+        "version": "2.39-r5"
       },
       {
         "architecture": "x86_64",
@@ -318,22 +318,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1GG/Qe/wJbfaSQh2/E66qsSZ1d14=",
+        "checksum": "Q1GynPQjsrxTFW54tdQAqopiWsMuo=",
         "control": {
-          "checksum": "sha1-GG/Qe/wJbfaSQh2/E66qsSZ1d14=",
-          "range": "bytes=693-1065"
+          "checksum": "sha1-GynPQjsrxTFW54tdQAqopiWsMuo=",
+          "range": "bytes=697-1068"
         },
         "data": {
-          "checksum": "sha256-83L93TpxngARX3OA5Mm8MzkKPoqcoX6BX4/rslD+ND0=",
-          "range": "bytes=1066-251841"
+          "checksum": "sha256-cFyZH6WiNgbnz+zovA9EJB8aHO70Ao8TIH7052O/w1M=",
+          "range": "bytes=1069-251882"
         },
         "name": "libnghttp2-14",
         "signature": {
-          "checksum": "sha1-nERTCwywhPhwFIvRVZFNWHvzJXk=",
-          "range": "bytes=0-692"
+          "checksum": "sha1-o2sTmr6y1CBY9otWZAKu01XAbM8=",
+          "range": "bytes=0-696"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.61.0-r1.apk",
-        "version": "1.61.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.62.0-r0.apk",
+        "version": "1.62.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -413,41 +413,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1rmRRDukjyxrZKFy/2htPJpXlv6c=",
+        "checksum": "Q1bkh6LBvJiAE8yoq/+3XyeLRcIDE=",
         "control": {
-          "checksum": "sha1-rmRRDukjyxrZKFy/2htPJpXlv6c=",
-          "range": "bytes=699-1169"
+          "checksum": "sha1-bkh6LBvJiAE8yoq/+3XyeLRcIDE=",
+          "range": "bytes=700-1171"
         },
         "data": {
-          "checksum": "sha256-R81rAn3Y5uN4AbPY2STKyJQFy9AlA8AsQBoi6dbaAUA=",
-          "range": "bytes=1170-2556940"
+          "checksum": "sha256-fK9ZYBCiUycuwXY2OUJPlo4VO00LgqbMjSBO0CNMEok=",
+          "range": "bytes=1172-2582013"
         },
         "name": "nghttp2",
         "signature": {
-          "checksum": "sha1-EVy/a8/HRmt7vkLWYZfPCgtTzvE=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-ubcn/WnvFEPpkHx9nfAlqzYVN1o=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.61.0-r1.apk",
-        "version": "1.61.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.62.0-r0.apk",
+        "version": "1.62.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1dKyxN+ghQa6wAlVdT/IeTI/kUCI=",
+        "checksum": "Q1yOG4UBYkzOYPo4RZgfhIm6Mh0sU=",
         "control": {
-          "checksum": "sha1-dKyxN+ghQa6wAlVdT/IeTI/kUCI=",
-          "range": "bytes=699-1067"
+          "checksum": "sha1-yOG4UBYkzOYPo4RZgfhIm6Mh0sU=",
+          "range": "bytes=704-1070"
         },
         "data": {
-          "checksum": "sha256-X5FGVjy9TFT+NbfOA0lbV3pnLHSmqrDGz4BKIeYVBeA=",
-          "range": "bytes=1068-631660"
+          "checksum": "sha256-74kS0GGdLRQfk5b0TynYIEqh6fCEEK7QHP7iNsWb9oE=",
+          "range": "bytes=1071-631901"
         },
         "name": "nghttp2-dev",
         "signature": {
-          "checksum": "sha1-vGUw/0Loh1AWFjrlxevxFU7IKT4=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-AUWNNntPboyRKLJbqFODeq2sX8g=",
+          "range": "bytes=0-703"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.61.0-r1.apk",
-        "version": "1.61.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.62.0-r0.apk",
+        "version": "1.62.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -546,22 +546,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1SX1piz1hZeqGnnSNsfZGhK54I8A=",
+        "checksum": "Q15i44FeGc8cU/Gs+AORIH16osoV8=",
         "control": {
-          "checksum": "sha1-SX1piz1hZeqGnnSNsfZGhK54I8A=",
-          "range": "bytes=699-1103"
+          "checksum": "sha1-5i44FeGc8cU/Gs+AORIH16osoV8=",
+          "range": "bytes=695-1098"
         },
         "data": {
-          "checksum": "sha256-VSxM5PIYwhIc/kJVmh0tsVqLpz68eYyOYyC4cxkP4nw=",
-          "range": "bytes=1104-21603"
+          "checksum": "sha256-72mWEdxOgFKdTQQJGfANOdejkvbhfTVsXD8yNzkwDKo=",
+          "range": "bytes=1099-21646"
         },
         "name": "libcrypt1",
         "signature": {
-          "checksum": "sha1-SRN+qFHoymUHf93USjCViyBMAKU=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-bbdRja3lJyrqB1b1R5lOFXk5Yps=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r3.apk",
-        "version": "2.39-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r5.apk",
+        "version": "2.39-r5"
       },
       {
         "architecture": "x86_64",
@@ -717,22 +717,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1l/Beg7hLAZ2nq/yvn08SgN0dfbQ=",
+        "checksum": "Q1u06OS+YwZxI3J9l6nyLHx2Sn7Hg=",
         "control": {
-          "checksum": "sha1-l/Beg7hLAZ2nq/yvn08SgN0dfbQ=",
-          "range": "bytes=694-1021"
+          "checksum": "sha1-u06OS+YwZxI3J9l6nyLHx2Sn7Hg=",
+          "range": "bytes=696-1023"
         },
         "data": {
-          "checksum": "sha256-LJrbfQdFpPfkW6mTXg4pc83H2E2GlWktO4x6Vd6aOgE=",
-          "range": "bytes=1022-61049957"
+          "checksum": "sha256-Z9YqIzOent28mE3zD4hq3cQKVYEA7b0uMtXQGqZ8ExM=",
+          "range": "bytes=1024-61050000"
         },
         "name": "glibc-locale-en",
         "signature": {
-          "checksum": "sha1-Mu4+oc+G5MqsHFYlEzyNOtGjDDk=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-8ptxZXnKS96Vm/mvZTrB3r5ZddU=",
+          "range": "bytes=0-695"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-en-2.39-r3.apk",
-        "version": "2.39-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-en-2.39-r5.apk",
+        "version": "2.39-r5"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/postgresql-12.lock.json
+++ b/wolfi-images/postgresql-12.lock.json
@@ -52,60 +52,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1LbskMUECTvoctOm3XVAJBe6/+O8=",
+        "checksum": "Q15nzyxTcmhST9dTlB9BxV088pKJY=",
         "control": {
-          "checksum": "sha1-LbskMUECTvoctOm3XVAJBe6/+O8=",
-          "range": "bytes=704-1113"
+          "checksum": "sha1-5nzyxTcmhST9dTlB9BxV088pKJY=",
+          "range": "bytes=697-1107"
         },
         "data": {
-          "checksum": "sha256-U8ueoDdtkVXfQ3r8UKQU+ei8sdAH+ayEnmYIcGEM6S8=",
-          "range": "bytes=1114-267813"
+          "checksum": "sha256-i2qrjtws7OeqrKQP83nQo1vFwjqnO0QM3fSTvHHEKps=",
+          "range": "bytes=1108-267856"
         },
         "name": "ld-linux",
         "signature": {
-          "checksum": "sha1-snzU1ONYjrHMX4b2N117nm2p+9s=",
-          "range": "bytes=0-703"
+          "checksum": "sha1-nJTcI836Gt8XuqjMFUh2BBK4pP4=",
+          "range": "bytes=0-696"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r3.apk",
-        "version": "2.39-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r5.apk",
+        "version": "2.39-r5"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ovjsy4Uk7yfyamNBkynUnsHYFMU=",
+        "checksum": "Q1EuFMRKR/2atKFGKHjH/3vivHPEc=",
         "control": {
-          "checksum": "sha1-ovjsy4Uk7yfyamNBkynUnsHYFMU=",
-          "range": "bytes=701-1059"
+          "checksum": "sha1-EuFMRKR/2atKFGKHjH/3vivHPEc=",
+          "range": "bytes=699-1059"
         },
         "data": {
-          "checksum": "sha256-NedZsq170zk14TU+FxyLtc3Dr0vz/fmDP6LbmTqdtF8=",
-          "range": "bytes=1060-408273"
+          "checksum": "sha256-QDrcE6gPZ7R2/02ORkq8ZiVIGQDOwVQ07QetxKwG2jE=",
+          "range": "bytes=1060-408316"
         },
         "name": "glibc-locale-posix",
         "signature": {
-          "checksum": "sha1-G9qkyU9BXJISxwkeJE5Cz/n/H0k=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-hRz3Fq86p+IW4pWkZRP5kxsJFns=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r3.apk",
-        "version": "2.39-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r5.apk",
+        "version": "2.39-r5"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1+bVOClqbAOmgA1y9Q+GYJhEfuJs=",
+        "checksum": "Q19hiFVzu+AzUM0onmSNjApSBdvTw=",
         "control": {
-          "checksum": "sha1-+bVOClqbAOmgA1y9Q+GYJhEfuJs=",
-          "range": "bytes=700-1326"
+          "checksum": "sha1-9hiFVzu+AzUM0onmSNjApSBdvTw=",
+          "range": "bytes=694-1321"
         },
         "data": {
-          "checksum": "sha256-59plMSMECX3LWvyWsiLvadlwbdU3qopW0jRvBCyMGBM=",
-          "range": "bytes=1327-5861479"
+          "checksum": "sha256-eDetP73vFbPoIKaaYcLDZ89dOGzpY4xRBw75zN0Odpg=",
+          "range": "bytes=1322-5861522"
         },
         "name": "glibc",
         "signature": {
-          "checksum": "sha1-NZX+6hpoAYIpCd9O1VsViZI3MM0=",
-          "range": "bytes=0-699"
+          "checksum": "sha1-n8l9a4cNG2heaH82Un+dqHmdqRI=",
+          "range": "bytes=0-693"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r3.apk",
-        "version": "2.39-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r5.apk",
+        "version": "2.39-r5"
       },
       {
         "architecture": "x86_64",
@@ -318,22 +318,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1GG/Qe/wJbfaSQh2/E66qsSZ1d14=",
+        "checksum": "Q1GynPQjsrxTFW54tdQAqopiWsMuo=",
         "control": {
-          "checksum": "sha1-GG/Qe/wJbfaSQh2/E66qsSZ1d14=",
-          "range": "bytes=693-1065"
+          "checksum": "sha1-GynPQjsrxTFW54tdQAqopiWsMuo=",
+          "range": "bytes=697-1068"
         },
         "data": {
-          "checksum": "sha256-83L93TpxngARX3OA5Mm8MzkKPoqcoX6BX4/rslD+ND0=",
-          "range": "bytes=1066-251841"
+          "checksum": "sha256-cFyZH6WiNgbnz+zovA9EJB8aHO70Ao8TIH7052O/w1M=",
+          "range": "bytes=1069-251882"
         },
         "name": "libnghttp2-14",
         "signature": {
-          "checksum": "sha1-nERTCwywhPhwFIvRVZFNWHvzJXk=",
-          "range": "bytes=0-692"
+          "checksum": "sha1-o2sTmr6y1CBY9otWZAKu01XAbM8=",
+          "range": "bytes=0-696"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.61.0-r1.apk",
-        "version": "1.61.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.62.0-r0.apk",
+        "version": "1.62.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -413,41 +413,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1rmRRDukjyxrZKFy/2htPJpXlv6c=",
+        "checksum": "Q1bkh6LBvJiAE8yoq/+3XyeLRcIDE=",
         "control": {
-          "checksum": "sha1-rmRRDukjyxrZKFy/2htPJpXlv6c=",
-          "range": "bytes=699-1169"
+          "checksum": "sha1-bkh6LBvJiAE8yoq/+3XyeLRcIDE=",
+          "range": "bytes=700-1171"
         },
         "data": {
-          "checksum": "sha256-R81rAn3Y5uN4AbPY2STKyJQFy9AlA8AsQBoi6dbaAUA=",
-          "range": "bytes=1170-2556940"
+          "checksum": "sha256-fK9ZYBCiUycuwXY2OUJPlo4VO00LgqbMjSBO0CNMEok=",
+          "range": "bytes=1172-2582013"
         },
         "name": "nghttp2",
         "signature": {
-          "checksum": "sha1-EVy/a8/HRmt7vkLWYZfPCgtTzvE=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-ubcn/WnvFEPpkHx9nfAlqzYVN1o=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.61.0-r1.apk",
-        "version": "1.61.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.62.0-r0.apk",
+        "version": "1.62.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1dKyxN+ghQa6wAlVdT/IeTI/kUCI=",
+        "checksum": "Q1yOG4UBYkzOYPo4RZgfhIm6Mh0sU=",
         "control": {
-          "checksum": "sha1-dKyxN+ghQa6wAlVdT/IeTI/kUCI=",
-          "range": "bytes=699-1067"
+          "checksum": "sha1-yOG4UBYkzOYPo4RZgfhIm6Mh0sU=",
+          "range": "bytes=704-1070"
         },
         "data": {
-          "checksum": "sha256-X5FGVjy9TFT+NbfOA0lbV3pnLHSmqrDGz4BKIeYVBeA=",
-          "range": "bytes=1068-631660"
+          "checksum": "sha256-74kS0GGdLRQfk5b0TynYIEqh6fCEEK7QHP7iNsWb9oE=",
+          "range": "bytes=1071-631901"
         },
         "name": "nghttp2-dev",
         "signature": {
-          "checksum": "sha1-vGUw/0Loh1AWFjrlxevxFU7IKT4=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-AUWNNntPboyRKLJbqFODeq2sX8g=",
+          "range": "bytes=0-703"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.61.0-r1.apk",
-        "version": "1.61.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.62.0-r0.apk",
+        "version": "1.62.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -546,22 +546,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1SX1piz1hZeqGnnSNsfZGhK54I8A=",
+        "checksum": "Q15i44FeGc8cU/Gs+AORIH16osoV8=",
         "control": {
-          "checksum": "sha1-SX1piz1hZeqGnnSNsfZGhK54I8A=",
-          "range": "bytes=699-1103"
+          "checksum": "sha1-5i44FeGc8cU/Gs+AORIH16osoV8=",
+          "range": "bytes=695-1098"
         },
         "data": {
-          "checksum": "sha256-VSxM5PIYwhIc/kJVmh0tsVqLpz68eYyOYyC4cxkP4nw=",
-          "range": "bytes=1104-21603"
+          "checksum": "sha256-72mWEdxOgFKdTQQJGfANOdejkvbhfTVsXD8yNzkwDKo=",
+          "range": "bytes=1099-21646"
         },
         "name": "libcrypt1",
         "signature": {
-          "checksum": "sha1-SRN+qFHoymUHf93USjCViyBMAKU=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-bbdRja3lJyrqB1b1R5lOFXk5Yps=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r3.apk",
-        "version": "2.39-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r5.apk",
+        "version": "2.39-r5"
       },
       {
         "architecture": "x86_64",
@@ -717,22 +717,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1l/Beg7hLAZ2nq/yvn08SgN0dfbQ=",
+        "checksum": "Q1u06OS+YwZxI3J9l6nyLHx2Sn7Hg=",
         "control": {
-          "checksum": "sha1-l/Beg7hLAZ2nq/yvn08SgN0dfbQ=",
-          "range": "bytes=694-1021"
+          "checksum": "sha1-u06OS+YwZxI3J9l6nyLHx2Sn7Hg=",
+          "range": "bytes=696-1023"
         },
         "data": {
-          "checksum": "sha256-LJrbfQdFpPfkW6mTXg4pc83H2E2GlWktO4x6Vd6aOgE=",
-          "range": "bytes=1022-61049957"
+          "checksum": "sha256-Z9YqIzOent28mE3zD4hq3cQKVYEA7b0uMtXQGqZ8ExM=",
+          "range": "bytes=1024-61050000"
         },
         "name": "glibc-locale-en",
         "signature": {
-          "checksum": "sha1-Mu4+oc+G5MqsHFYlEzyNOtGjDDk=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-8ptxZXnKS96Vm/mvZTrB3r5ZddU=",
+          "range": "bytes=0-695"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-en-2.39-r3.apk",
-        "version": "2.39-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-en-2.39-r5.apk",
+        "version": "2.39-r5"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/prometheus.lock.json
+++ b/wolfi-images/prometheus.lock.json
@@ -52,60 +52,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1LbskMUECTvoctOm3XVAJBe6/+O8=",
+        "checksum": "Q15nzyxTcmhST9dTlB9BxV088pKJY=",
         "control": {
-          "checksum": "sha1-LbskMUECTvoctOm3XVAJBe6/+O8=",
-          "range": "bytes=704-1113"
+          "checksum": "sha1-5nzyxTcmhST9dTlB9BxV088pKJY=",
+          "range": "bytes=697-1107"
         },
         "data": {
-          "checksum": "sha256-U8ueoDdtkVXfQ3r8UKQU+ei8sdAH+ayEnmYIcGEM6S8=",
-          "range": "bytes=1114-267813"
+          "checksum": "sha256-i2qrjtws7OeqrKQP83nQo1vFwjqnO0QM3fSTvHHEKps=",
+          "range": "bytes=1108-267856"
         },
         "name": "ld-linux",
         "signature": {
-          "checksum": "sha1-snzU1ONYjrHMX4b2N117nm2p+9s=",
-          "range": "bytes=0-703"
+          "checksum": "sha1-nJTcI836Gt8XuqjMFUh2BBK4pP4=",
+          "range": "bytes=0-696"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r3.apk",
-        "version": "2.39-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r5.apk",
+        "version": "2.39-r5"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ovjsy4Uk7yfyamNBkynUnsHYFMU=",
+        "checksum": "Q1EuFMRKR/2atKFGKHjH/3vivHPEc=",
         "control": {
-          "checksum": "sha1-ovjsy4Uk7yfyamNBkynUnsHYFMU=",
-          "range": "bytes=701-1059"
+          "checksum": "sha1-EuFMRKR/2atKFGKHjH/3vivHPEc=",
+          "range": "bytes=699-1059"
         },
         "data": {
-          "checksum": "sha256-NedZsq170zk14TU+FxyLtc3Dr0vz/fmDP6LbmTqdtF8=",
-          "range": "bytes=1060-408273"
+          "checksum": "sha256-QDrcE6gPZ7R2/02ORkq8ZiVIGQDOwVQ07QetxKwG2jE=",
+          "range": "bytes=1060-408316"
         },
         "name": "glibc-locale-posix",
         "signature": {
-          "checksum": "sha1-G9qkyU9BXJISxwkeJE5Cz/n/H0k=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-hRz3Fq86p+IW4pWkZRP5kxsJFns=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r3.apk",
-        "version": "2.39-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r5.apk",
+        "version": "2.39-r5"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1+bVOClqbAOmgA1y9Q+GYJhEfuJs=",
+        "checksum": "Q19hiFVzu+AzUM0onmSNjApSBdvTw=",
         "control": {
-          "checksum": "sha1-+bVOClqbAOmgA1y9Q+GYJhEfuJs=",
-          "range": "bytes=700-1326"
+          "checksum": "sha1-9hiFVzu+AzUM0onmSNjApSBdvTw=",
+          "range": "bytes=694-1321"
         },
         "data": {
-          "checksum": "sha256-59plMSMECX3LWvyWsiLvadlwbdU3qopW0jRvBCyMGBM=",
-          "range": "bytes=1327-5861479"
+          "checksum": "sha256-eDetP73vFbPoIKaaYcLDZ89dOGzpY4xRBw75zN0Odpg=",
+          "range": "bytes=1322-5861522"
         },
         "name": "glibc",
         "signature": {
-          "checksum": "sha1-NZX+6hpoAYIpCd9O1VsViZI3MM0=",
-          "range": "bytes=0-699"
+          "checksum": "sha1-n8l9a4cNG2heaH82Un+dqHmdqRI=",
+          "range": "bytes=0-693"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r3.apk",
-        "version": "2.39-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r5.apk",
+        "version": "2.39-r5"
       },
       {
         "architecture": "x86_64",
@@ -318,22 +318,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1GG/Qe/wJbfaSQh2/E66qsSZ1d14=",
+        "checksum": "Q1GynPQjsrxTFW54tdQAqopiWsMuo=",
         "control": {
-          "checksum": "sha1-GG/Qe/wJbfaSQh2/E66qsSZ1d14=",
-          "range": "bytes=693-1065"
+          "checksum": "sha1-GynPQjsrxTFW54tdQAqopiWsMuo=",
+          "range": "bytes=697-1068"
         },
         "data": {
-          "checksum": "sha256-83L93TpxngARX3OA5Mm8MzkKPoqcoX6BX4/rslD+ND0=",
-          "range": "bytes=1066-251841"
+          "checksum": "sha256-cFyZH6WiNgbnz+zovA9EJB8aHO70Ao8TIH7052O/w1M=",
+          "range": "bytes=1069-251882"
         },
         "name": "libnghttp2-14",
         "signature": {
-          "checksum": "sha1-nERTCwywhPhwFIvRVZFNWHvzJXk=",
-          "range": "bytes=0-692"
+          "checksum": "sha1-o2sTmr6y1CBY9otWZAKu01XAbM8=",
+          "range": "bytes=0-696"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.61.0-r1.apk",
-        "version": "1.61.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.62.0-r0.apk",
+        "version": "1.62.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -413,41 +413,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1rmRRDukjyxrZKFy/2htPJpXlv6c=",
+        "checksum": "Q1bkh6LBvJiAE8yoq/+3XyeLRcIDE=",
         "control": {
-          "checksum": "sha1-rmRRDukjyxrZKFy/2htPJpXlv6c=",
-          "range": "bytes=699-1169"
+          "checksum": "sha1-bkh6LBvJiAE8yoq/+3XyeLRcIDE=",
+          "range": "bytes=700-1171"
         },
         "data": {
-          "checksum": "sha256-R81rAn3Y5uN4AbPY2STKyJQFy9AlA8AsQBoi6dbaAUA=",
-          "range": "bytes=1170-2556940"
+          "checksum": "sha256-fK9ZYBCiUycuwXY2OUJPlo4VO00LgqbMjSBO0CNMEok=",
+          "range": "bytes=1172-2582013"
         },
         "name": "nghttp2",
         "signature": {
-          "checksum": "sha1-EVy/a8/HRmt7vkLWYZfPCgtTzvE=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-ubcn/WnvFEPpkHx9nfAlqzYVN1o=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.61.0-r1.apk",
-        "version": "1.61.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.62.0-r0.apk",
+        "version": "1.62.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1dKyxN+ghQa6wAlVdT/IeTI/kUCI=",
+        "checksum": "Q1yOG4UBYkzOYPo4RZgfhIm6Mh0sU=",
         "control": {
-          "checksum": "sha1-dKyxN+ghQa6wAlVdT/IeTI/kUCI=",
-          "range": "bytes=699-1067"
+          "checksum": "sha1-yOG4UBYkzOYPo4RZgfhIm6Mh0sU=",
+          "range": "bytes=704-1070"
         },
         "data": {
-          "checksum": "sha256-X5FGVjy9TFT+NbfOA0lbV3pnLHSmqrDGz4BKIeYVBeA=",
-          "range": "bytes=1068-631660"
+          "checksum": "sha256-74kS0GGdLRQfk5b0TynYIEqh6fCEEK7QHP7iNsWb9oE=",
+          "range": "bytes=1071-631901"
         },
         "name": "nghttp2-dev",
         "signature": {
-          "checksum": "sha1-vGUw/0Loh1AWFjrlxevxFU7IKT4=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-AUWNNntPboyRKLJbqFODeq2sX8g=",
+          "range": "bytes=0-703"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.61.0-r1.apk",
-        "version": "1.61.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.62.0-r0.apk",
+        "version": "1.62.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -546,22 +546,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1SX1piz1hZeqGnnSNsfZGhK54I8A=",
+        "checksum": "Q15i44FeGc8cU/Gs+AORIH16osoV8=",
         "control": {
-          "checksum": "sha1-SX1piz1hZeqGnnSNsfZGhK54I8A=",
-          "range": "bytes=699-1103"
+          "checksum": "sha1-5i44FeGc8cU/Gs+AORIH16osoV8=",
+          "range": "bytes=695-1098"
         },
         "data": {
-          "checksum": "sha256-VSxM5PIYwhIc/kJVmh0tsVqLpz68eYyOYyC4cxkP4nw=",
-          "range": "bytes=1104-21603"
+          "checksum": "sha256-72mWEdxOgFKdTQQJGfANOdejkvbhfTVsXD8yNzkwDKo=",
+          "range": "bytes=1099-21646"
         },
         "name": "libcrypt1",
         "signature": {
-          "checksum": "sha1-SRN+qFHoymUHf93USjCViyBMAKU=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-bbdRja3lJyrqB1b1R5lOFXk5Yps=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r3.apk",
-        "version": "2.39-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r5.apk",
+        "version": "2.39-r5"
       },
       {
         "architecture": "x86_64",
@@ -736,22 +736,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1/xH9NXh2XAN7AiXLSyfKBjj+41g=",
+        "checksum": "Q1wjEh5PI4XEuZMLSqCUBZsNsp5t8=",
         "control": {
-          "checksum": "sha1-/xH9NXh2XAN7AiXLSyfKBjj+41g=",
-          "range": "bytes=694-1135"
+          "checksum": "sha1-wjEh5PI4XEuZMLSqCUBZsNsp5t8=",
+          "range": "bytes=702-1143"
         },
         "data": {
-          "checksum": "sha256-qg8zb40a6hpJUCmj2xctm8npy+TSpC9kumdnnSNRkQE=",
-          "range": "bytes=1136-192879162"
+          "checksum": "sha256-Vbe4KzKdSQ8oya/6+1+E9jHF+kEFJ9dk9E+zkaoBM7w=",
+          "range": "bytes=1144-192879162"
         },
         "name": "prometheus-2.52",
         "signature": {
-          "checksum": "sha1-As1h2B3XeSrL7tXFOnrKY2uEY0U=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-m6xJcvKj0rNtml4eJe5VbyYfryo=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/prometheus-2.52-2.52.0-r1.apk",
-        "version": "2.52.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/prometheus-2.52-2.52.0-r2.apk",
+        "version": "2.52.0-r2"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/redis-exporter.lock.json
+++ b/wolfi-images/redis-exporter.lock.json
@@ -52,60 +52,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1LbskMUECTvoctOm3XVAJBe6/+O8=",
+        "checksum": "Q15nzyxTcmhST9dTlB9BxV088pKJY=",
         "control": {
-          "checksum": "sha1-LbskMUECTvoctOm3XVAJBe6/+O8=",
-          "range": "bytes=704-1113"
+          "checksum": "sha1-5nzyxTcmhST9dTlB9BxV088pKJY=",
+          "range": "bytes=697-1107"
         },
         "data": {
-          "checksum": "sha256-U8ueoDdtkVXfQ3r8UKQU+ei8sdAH+ayEnmYIcGEM6S8=",
-          "range": "bytes=1114-267813"
+          "checksum": "sha256-i2qrjtws7OeqrKQP83nQo1vFwjqnO0QM3fSTvHHEKps=",
+          "range": "bytes=1108-267856"
         },
         "name": "ld-linux",
         "signature": {
-          "checksum": "sha1-snzU1ONYjrHMX4b2N117nm2p+9s=",
-          "range": "bytes=0-703"
+          "checksum": "sha1-nJTcI836Gt8XuqjMFUh2BBK4pP4=",
+          "range": "bytes=0-696"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r3.apk",
-        "version": "2.39-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r5.apk",
+        "version": "2.39-r5"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ovjsy4Uk7yfyamNBkynUnsHYFMU=",
+        "checksum": "Q1EuFMRKR/2atKFGKHjH/3vivHPEc=",
         "control": {
-          "checksum": "sha1-ovjsy4Uk7yfyamNBkynUnsHYFMU=",
-          "range": "bytes=701-1059"
+          "checksum": "sha1-EuFMRKR/2atKFGKHjH/3vivHPEc=",
+          "range": "bytes=699-1059"
         },
         "data": {
-          "checksum": "sha256-NedZsq170zk14TU+FxyLtc3Dr0vz/fmDP6LbmTqdtF8=",
-          "range": "bytes=1060-408273"
+          "checksum": "sha256-QDrcE6gPZ7R2/02ORkq8ZiVIGQDOwVQ07QetxKwG2jE=",
+          "range": "bytes=1060-408316"
         },
         "name": "glibc-locale-posix",
         "signature": {
-          "checksum": "sha1-G9qkyU9BXJISxwkeJE5Cz/n/H0k=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-hRz3Fq86p+IW4pWkZRP5kxsJFns=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r3.apk",
-        "version": "2.39-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r5.apk",
+        "version": "2.39-r5"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1+bVOClqbAOmgA1y9Q+GYJhEfuJs=",
+        "checksum": "Q19hiFVzu+AzUM0onmSNjApSBdvTw=",
         "control": {
-          "checksum": "sha1-+bVOClqbAOmgA1y9Q+GYJhEfuJs=",
-          "range": "bytes=700-1326"
+          "checksum": "sha1-9hiFVzu+AzUM0onmSNjApSBdvTw=",
+          "range": "bytes=694-1321"
         },
         "data": {
-          "checksum": "sha256-59plMSMECX3LWvyWsiLvadlwbdU3qopW0jRvBCyMGBM=",
-          "range": "bytes=1327-5861479"
+          "checksum": "sha256-eDetP73vFbPoIKaaYcLDZ89dOGzpY4xRBw75zN0Odpg=",
+          "range": "bytes=1322-5861522"
         },
         "name": "glibc",
         "signature": {
-          "checksum": "sha1-NZX+6hpoAYIpCd9O1VsViZI3MM0=",
-          "range": "bytes=0-699"
+          "checksum": "sha1-n8l9a4cNG2heaH82Un+dqHmdqRI=",
+          "range": "bytes=0-693"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r3.apk",
-        "version": "2.39-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r5.apk",
+        "version": "2.39-r5"
       },
       {
         "architecture": "x86_64",
@@ -318,22 +318,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1GG/Qe/wJbfaSQh2/E66qsSZ1d14=",
+        "checksum": "Q1GynPQjsrxTFW54tdQAqopiWsMuo=",
         "control": {
-          "checksum": "sha1-GG/Qe/wJbfaSQh2/E66qsSZ1d14=",
-          "range": "bytes=693-1065"
+          "checksum": "sha1-GynPQjsrxTFW54tdQAqopiWsMuo=",
+          "range": "bytes=697-1068"
         },
         "data": {
-          "checksum": "sha256-83L93TpxngARX3OA5Mm8MzkKPoqcoX6BX4/rslD+ND0=",
-          "range": "bytes=1066-251841"
+          "checksum": "sha256-cFyZH6WiNgbnz+zovA9EJB8aHO70Ao8TIH7052O/w1M=",
+          "range": "bytes=1069-251882"
         },
         "name": "libnghttp2-14",
         "signature": {
-          "checksum": "sha1-nERTCwywhPhwFIvRVZFNWHvzJXk=",
-          "range": "bytes=0-692"
+          "checksum": "sha1-o2sTmr6y1CBY9otWZAKu01XAbM8=",
+          "range": "bytes=0-696"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.61.0-r1.apk",
-        "version": "1.61.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.62.0-r0.apk",
+        "version": "1.62.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -413,41 +413,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1rmRRDukjyxrZKFy/2htPJpXlv6c=",
+        "checksum": "Q1bkh6LBvJiAE8yoq/+3XyeLRcIDE=",
         "control": {
-          "checksum": "sha1-rmRRDukjyxrZKFy/2htPJpXlv6c=",
-          "range": "bytes=699-1169"
+          "checksum": "sha1-bkh6LBvJiAE8yoq/+3XyeLRcIDE=",
+          "range": "bytes=700-1171"
         },
         "data": {
-          "checksum": "sha256-R81rAn3Y5uN4AbPY2STKyJQFy9AlA8AsQBoi6dbaAUA=",
-          "range": "bytes=1170-2556940"
+          "checksum": "sha256-fK9ZYBCiUycuwXY2OUJPlo4VO00LgqbMjSBO0CNMEok=",
+          "range": "bytes=1172-2582013"
         },
         "name": "nghttp2",
         "signature": {
-          "checksum": "sha1-EVy/a8/HRmt7vkLWYZfPCgtTzvE=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-ubcn/WnvFEPpkHx9nfAlqzYVN1o=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.61.0-r1.apk",
-        "version": "1.61.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.62.0-r0.apk",
+        "version": "1.62.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1dKyxN+ghQa6wAlVdT/IeTI/kUCI=",
+        "checksum": "Q1yOG4UBYkzOYPo4RZgfhIm6Mh0sU=",
         "control": {
-          "checksum": "sha1-dKyxN+ghQa6wAlVdT/IeTI/kUCI=",
-          "range": "bytes=699-1067"
+          "checksum": "sha1-yOG4UBYkzOYPo4RZgfhIm6Mh0sU=",
+          "range": "bytes=704-1070"
         },
         "data": {
-          "checksum": "sha256-X5FGVjy9TFT+NbfOA0lbV3pnLHSmqrDGz4BKIeYVBeA=",
-          "range": "bytes=1068-631660"
+          "checksum": "sha256-74kS0GGdLRQfk5b0TynYIEqh6fCEEK7QHP7iNsWb9oE=",
+          "range": "bytes=1071-631901"
         },
         "name": "nghttp2-dev",
         "signature": {
-          "checksum": "sha1-vGUw/0Loh1AWFjrlxevxFU7IKT4=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-AUWNNntPboyRKLJbqFODeq2sX8g=",
+          "range": "bytes=0-703"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.61.0-r1.apk",
-        "version": "1.61.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.62.0-r0.apk",
+        "version": "1.62.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -546,22 +546,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1SX1piz1hZeqGnnSNsfZGhK54I8A=",
+        "checksum": "Q15i44FeGc8cU/Gs+AORIH16osoV8=",
         "control": {
-          "checksum": "sha1-SX1piz1hZeqGnnSNsfZGhK54I8A=",
-          "range": "bytes=699-1103"
+          "checksum": "sha1-5i44FeGc8cU/Gs+AORIH16osoV8=",
+          "range": "bytes=695-1098"
         },
         "data": {
-          "checksum": "sha256-VSxM5PIYwhIc/kJVmh0tsVqLpz68eYyOYyC4cxkP4nw=",
-          "range": "bytes=1104-21603"
+          "checksum": "sha256-72mWEdxOgFKdTQQJGfANOdejkvbhfTVsXD8yNzkwDKo=",
+          "range": "bytes=1099-21646"
         },
         "name": "libcrypt1",
         "signature": {
-          "checksum": "sha1-SRN+qFHoymUHf93USjCViyBMAKU=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-bbdRja3lJyrqB1b1R5lOFXk5Yps=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r3.apk",
-        "version": "2.39-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r5.apk",
+        "version": "2.39-r5"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/redis.lock.json
+++ b/wolfi-images/redis.lock.json
@@ -52,60 +52,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1LbskMUECTvoctOm3XVAJBe6/+O8=",
+        "checksum": "Q15nzyxTcmhST9dTlB9BxV088pKJY=",
         "control": {
-          "checksum": "sha1-LbskMUECTvoctOm3XVAJBe6/+O8=",
-          "range": "bytes=704-1113"
+          "checksum": "sha1-5nzyxTcmhST9dTlB9BxV088pKJY=",
+          "range": "bytes=697-1107"
         },
         "data": {
-          "checksum": "sha256-U8ueoDdtkVXfQ3r8UKQU+ei8sdAH+ayEnmYIcGEM6S8=",
-          "range": "bytes=1114-267813"
+          "checksum": "sha256-i2qrjtws7OeqrKQP83nQo1vFwjqnO0QM3fSTvHHEKps=",
+          "range": "bytes=1108-267856"
         },
         "name": "ld-linux",
         "signature": {
-          "checksum": "sha1-snzU1ONYjrHMX4b2N117nm2p+9s=",
-          "range": "bytes=0-703"
+          "checksum": "sha1-nJTcI836Gt8XuqjMFUh2BBK4pP4=",
+          "range": "bytes=0-696"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r3.apk",
-        "version": "2.39-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r5.apk",
+        "version": "2.39-r5"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ovjsy4Uk7yfyamNBkynUnsHYFMU=",
+        "checksum": "Q1EuFMRKR/2atKFGKHjH/3vivHPEc=",
         "control": {
-          "checksum": "sha1-ovjsy4Uk7yfyamNBkynUnsHYFMU=",
-          "range": "bytes=701-1059"
+          "checksum": "sha1-EuFMRKR/2atKFGKHjH/3vivHPEc=",
+          "range": "bytes=699-1059"
         },
         "data": {
-          "checksum": "sha256-NedZsq170zk14TU+FxyLtc3Dr0vz/fmDP6LbmTqdtF8=",
-          "range": "bytes=1060-408273"
+          "checksum": "sha256-QDrcE6gPZ7R2/02ORkq8ZiVIGQDOwVQ07QetxKwG2jE=",
+          "range": "bytes=1060-408316"
         },
         "name": "glibc-locale-posix",
         "signature": {
-          "checksum": "sha1-G9qkyU9BXJISxwkeJE5Cz/n/H0k=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-hRz3Fq86p+IW4pWkZRP5kxsJFns=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r3.apk",
-        "version": "2.39-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r5.apk",
+        "version": "2.39-r5"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1+bVOClqbAOmgA1y9Q+GYJhEfuJs=",
+        "checksum": "Q19hiFVzu+AzUM0onmSNjApSBdvTw=",
         "control": {
-          "checksum": "sha1-+bVOClqbAOmgA1y9Q+GYJhEfuJs=",
-          "range": "bytes=700-1326"
+          "checksum": "sha1-9hiFVzu+AzUM0onmSNjApSBdvTw=",
+          "range": "bytes=694-1321"
         },
         "data": {
-          "checksum": "sha256-59plMSMECX3LWvyWsiLvadlwbdU3qopW0jRvBCyMGBM=",
-          "range": "bytes=1327-5861479"
+          "checksum": "sha256-eDetP73vFbPoIKaaYcLDZ89dOGzpY4xRBw75zN0Odpg=",
+          "range": "bytes=1322-5861522"
         },
         "name": "glibc",
         "signature": {
-          "checksum": "sha1-NZX+6hpoAYIpCd9O1VsViZI3MM0=",
-          "range": "bytes=0-699"
+          "checksum": "sha1-n8l9a4cNG2heaH82Un+dqHmdqRI=",
+          "range": "bytes=0-693"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r3.apk",
-        "version": "2.39-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r5.apk",
+        "version": "2.39-r5"
       },
       {
         "architecture": "x86_64",
@@ -318,22 +318,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1GG/Qe/wJbfaSQh2/E66qsSZ1d14=",
+        "checksum": "Q1GynPQjsrxTFW54tdQAqopiWsMuo=",
         "control": {
-          "checksum": "sha1-GG/Qe/wJbfaSQh2/E66qsSZ1d14=",
-          "range": "bytes=693-1065"
+          "checksum": "sha1-GynPQjsrxTFW54tdQAqopiWsMuo=",
+          "range": "bytes=697-1068"
         },
         "data": {
-          "checksum": "sha256-83L93TpxngARX3OA5Mm8MzkKPoqcoX6BX4/rslD+ND0=",
-          "range": "bytes=1066-251841"
+          "checksum": "sha256-cFyZH6WiNgbnz+zovA9EJB8aHO70Ao8TIH7052O/w1M=",
+          "range": "bytes=1069-251882"
         },
         "name": "libnghttp2-14",
         "signature": {
-          "checksum": "sha1-nERTCwywhPhwFIvRVZFNWHvzJXk=",
-          "range": "bytes=0-692"
+          "checksum": "sha1-o2sTmr6y1CBY9otWZAKu01XAbM8=",
+          "range": "bytes=0-696"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.61.0-r1.apk",
-        "version": "1.61.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.62.0-r0.apk",
+        "version": "1.62.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -413,41 +413,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1rmRRDukjyxrZKFy/2htPJpXlv6c=",
+        "checksum": "Q1bkh6LBvJiAE8yoq/+3XyeLRcIDE=",
         "control": {
-          "checksum": "sha1-rmRRDukjyxrZKFy/2htPJpXlv6c=",
-          "range": "bytes=699-1169"
+          "checksum": "sha1-bkh6LBvJiAE8yoq/+3XyeLRcIDE=",
+          "range": "bytes=700-1171"
         },
         "data": {
-          "checksum": "sha256-R81rAn3Y5uN4AbPY2STKyJQFy9AlA8AsQBoi6dbaAUA=",
-          "range": "bytes=1170-2556940"
+          "checksum": "sha256-fK9ZYBCiUycuwXY2OUJPlo4VO00LgqbMjSBO0CNMEok=",
+          "range": "bytes=1172-2582013"
         },
         "name": "nghttp2",
         "signature": {
-          "checksum": "sha1-EVy/a8/HRmt7vkLWYZfPCgtTzvE=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-ubcn/WnvFEPpkHx9nfAlqzYVN1o=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.61.0-r1.apk",
-        "version": "1.61.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.62.0-r0.apk",
+        "version": "1.62.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1dKyxN+ghQa6wAlVdT/IeTI/kUCI=",
+        "checksum": "Q1yOG4UBYkzOYPo4RZgfhIm6Mh0sU=",
         "control": {
-          "checksum": "sha1-dKyxN+ghQa6wAlVdT/IeTI/kUCI=",
-          "range": "bytes=699-1067"
+          "checksum": "sha1-yOG4UBYkzOYPo4RZgfhIm6Mh0sU=",
+          "range": "bytes=704-1070"
         },
         "data": {
-          "checksum": "sha256-X5FGVjy9TFT+NbfOA0lbV3pnLHSmqrDGz4BKIeYVBeA=",
-          "range": "bytes=1068-631660"
+          "checksum": "sha256-74kS0GGdLRQfk5b0TynYIEqh6fCEEK7QHP7iNsWb9oE=",
+          "range": "bytes=1071-631901"
         },
         "name": "nghttp2-dev",
         "signature": {
-          "checksum": "sha1-vGUw/0Loh1AWFjrlxevxFU7IKT4=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-AUWNNntPboyRKLJbqFODeq2sX8g=",
+          "range": "bytes=0-703"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.61.0-r1.apk",
-        "version": "1.61.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.62.0-r0.apk",
+        "version": "1.62.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -546,22 +546,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1SX1piz1hZeqGnnSNsfZGhK54I8A=",
+        "checksum": "Q15i44FeGc8cU/Gs+AORIH16osoV8=",
         "control": {
-          "checksum": "sha1-SX1piz1hZeqGnnSNsfZGhK54I8A=",
-          "range": "bytes=699-1103"
+          "checksum": "sha1-5i44FeGc8cU/Gs+AORIH16osoV8=",
+          "range": "bytes=695-1098"
         },
         "data": {
-          "checksum": "sha256-VSxM5PIYwhIc/kJVmh0tsVqLpz68eYyOYyC4cxkP4nw=",
-          "range": "bytes=1104-21603"
+          "checksum": "sha256-72mWEdxOgFKdTQQJGfANOdejkvbhfTVsXD8yNzkwDKo=",
+          "range": "bytes=1099-21646"
         },
         "name": "libcrypt1",
         "signature": {
-          "checksum": "sha1-SRN+qFHoymUHf93USjCViyBMAKU=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-bbdRja3lJyrqB1b1R5lOFXk5Yps=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r3.apk",
-        "version": "2.39-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r5.apk",
+        "version": "2.39-r5"
       },
       {
         "architecture": "x86_64",
@@ -793,22 +793,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1osNZl4W7FxvkIsYQWElyBJXw+bg=",
+        "checksum": "Q1FHLh1XfGP1GJWaC8RExj2uVfHq4=",
         "control": {
-          "checksum": "sha1-osNZl4W7FxvkIsYQWElyBJXw+bg=",
-          "range": "bytes=698-1164"
+          "checksum": "sha1-FHLh1XfGP1GJWaC8RExj2uVfHq4=",
+          "range": "bytes=696-1169"
         },
         "data": {
-          "checksum": "sha256-VCOzBSr0cBHnnKs/V41eh0lMFsHwFSKvrnvWLT9LbME=",
-          "range": "bytes=1165-373949"
+          "checksum": "sha256-QxsRdBkZMCQ7A7qN5w7hHJlQFYfouHdJbrPFICd82e8=",
+          "range": "bytes=1170-373992"
         },
         "name": "posix-libc-utils",
         "signature": {
-          "checksum": "sha1-NUfmqSTwQatPMiw5iwifaUlhqt0=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-Nih/VZo/M9vKIyIqZPXM7vxHLzc=",
+          "range": "bytes=0-695"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/posix-libc-utils-2.39-r3.apk",
-        "version": "2.39-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/posix-libc-utils-2.39-r5.apk",
+        "version": "2.39-r5"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/repo-updater.lock.json
+++ b/wolfi-images/repo-updater.lock.json
@@ -52,60 +52,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1LbskMUECTvoctOm3XVAJBe6/+O8=",
+        "checksum": "Q15nzyxTcmhST9dTlB9BxV088pKJY=",
         "control": {
-          "checksum": "sha1-LbskMUECTvoctOm3XVAJBe6/+O8=",
-          "range": "bytes=704-1113"
+          "checksum": "sha1-5nzyxTcmhST9dTlB9BxV088pKJY=",
+          "range": "bytes=697-1107"
         },
         "data": {
-          "checksum": "sha256-U8ueoDdtkVXfQ3r8UKQU+ei8sdAH+ayEnmYIcGEM6S8=",
-          "range": "bytes=1114-267813"
+          "checksum": "sha256-i2qrjtws7OeqrKQP83nQo1vFwjqnO0QM3fSTvHHEKps=",
+          "range": "bytes=1108-267856"
         },
         "name": "ld-linux",
         "signature": {
-          "checksum": "sha1-snzU1ONYjrHMX4b2N117nm2p+9s=",
-          "range": "bytes=0-703"
+          "checksum": "sha1-nJTcI836Gt8XuqjMFUh2BBK4pP4=",
+          "range": "bytes=0-696"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r3.apk",
-        "version": "2.39-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r5.apk",
+        "version": "2.39-r5"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ovjsy4Uk7yfyamNBkynUnsHYFMU=",
+        "checksum": "Q1EuFMRKR/2atKFGKHjH/3vivHPEc=",
         "control": {
-          "checksum": "sha1-ovjsy4Uk7yfyamNBkynUnsHYFMU=",
-          "range": "bytes=701-1059"
+          "checksum": "sha1-EuFMRKR/2atKFGKHjH/3vivHPEc=",
+          "range": "bytes=699-1059"
         },
         "data": {
-          "checksum": "sha256-NedZsq170zk14TU+FxyLtc3Dr0vz/fmDP6LbmTqdtF8=",
-          "range": "bytes=1060-408273"
+          "checksum": "sha256-QDrcE6gPZ7R2/02ORkq8ZiVIGQDOwVQ07QetxKwG2jE=",
+          "range": "bytes=1060-408316"
         },
         "name": "glibc-locale-posix",
         "signature": {
-          "checksum": "sha1-G9qkyU9BXJISxwkeJE5Cz/n/H0k=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-hRz3Fq86p+IW4pWkZRP5kxsJFns=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r3.apk",
-        "version": "2.39-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r5.apk",
+        "version": "2.39-r5"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1+bVOClqbAOmgA1y9Q+GYJhEfuJs=",
+        "checksum": "Q19hiFVzu+AzUM0onmSNjApSBdvTw=",
         "control": {
-          "checksum": "sha1-+bVOClqbAOmgA1y9Q+GYJhEfuJs=",
-          "range": "bytes=700-1326"
+          "checksum": "sha1-9hiFVzu+AzUM0onmSNjApSBdvTw=",
+          "range": "bytes=694-1321"
         },
         "data": {
-          "checksum": "sha256-59plMSMECX3LWvyWsiLvadlwbdU3qopW0jRvBCyMGBM=",
-          "range": "bytes=1327-5861479"
+          "checksum": "sha256-eDetP73vFbPoIKaaYcLDZ89dOGzpY4xRBw75zN0Odpg=",
+          "range": "bytes=1322-5861522"
         },
         "name": "glibc",
         "signature": {
-          "checksum": "sha1-NZX+6hpoAYIpCd9O1VsViZI3MM0=",
-          "range": "bytes=0-699"
+          "checksum": "sha1-n8l9a4cNG2heaH82Un+dqHmdqRI=",
+          "range": "bytes=0-693"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r3.apk",
-        "version": "2.39-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r5.apk",
+        "version": "2.39-r5"
       },
       {
         "architecture": "x86_64",
@@ -318,22 +318,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1GG/Qe/wJbfaSQh2/E66qsSZ1d14=",
+        "checksum": "Q1GynPQjsrxTFW54tdQAqopiWsMuo=",
         "control": {
-          "checksum": "sha1-GG/Qe/wJbfaSQh2/E66qsSZ1d14=",
-          "range": "bytes=693-1065"
+          "checksum": "sha1-GynPQjsrxTFW54tdQAqopiWsMuo=",
+          "range": "bytes=697-1068"
         },
         "data": {
-          "checksum": "sha256-83L93TpxngARX3OA5Mm8MzkKPoqcoX6BX4/rslD+ND0=",
-          "range": "bytes=1066-251841"
+          "checksum": "sha256-cFyZH6WiNgbnz+zovA9EJB8aHO70Ao8TIH7052O/w1M=",
+          "range": "bytes=1069-251882"
         },
         "name": "libnghttp2-14",
         "signature": {
-          "checksum": "sha1-nERTCwywhPhwFIvRVZFNWHvzJXk=",
-          "range": "bytes=0-692"
+          "checksum": "sha1-o2sTmr6y1CBY9otWZAKu01XAbM8=",
+          "range": "bytes=0-696"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.61.0-r1.apk",
-        "version": "1.61.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.62.0-r0.apk",
+        "version": "1.62.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -413,41 +413,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1rmRRDukjyxrZKFy/2htPJpXlv6c=",
+        "checksum": "Q1bkh6LBvJiAE8yoq/+3XyeLRcIDE=",
         "control": {
-          "checksum": "sha1-rmRRDukjyxrZKFy/2htPJpXlv6c=",
-          "range": "bytes=699-1169"
+          "checksum": "sha1-bkh6LBvJiAE8yoq/+3XyeLRcIDE=",
+          "range": "bytes=700-1171"
         },
         "data": {
-          "checksum": "sha256-R81rAn3Y5uN4AbPY2STKyJQFy9AlA8AsQBoi6dbaAUA=",
-          "range": "bytes=1170-2556940"
+          "checksum": "sha256-fK9ZYBCiUycuwXY2OUJPlo4VO00LgqbMjSBO0CNMEok=",
+          "range": "bytes=1172-2582013"
         },
         "name": "nghttp2",
         "signature": {
-          "checksum": "sha1-EVy/a8/HRmt7vkLWYZfPCgtTzvE=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-ubcn/WnvFEPpkHx9nfAlqzYVN1o=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.61.0-r1.apk",
-        "version": "1.61.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.62.0-r0.apk",
+        "version": "1.62.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1dKyxN+ghQa6wAlVdT/IeTI/kUCI=",
+        "checksum": "Q1yOG4UBYkzOYPo4RZgfhIm6Mh0sU=",
         "control": {
-          "checksum": "sha1-dKyxN+ghQa6wAlVdT/IeTI/kUCI=",
-          "range": "bytes=699-1067"
+          "checksum": "sha1-yOG4UBYkzOYPo4RZgfhIm6Mh0sU=",
+          "range": "bytes=704-1070"
         },
         "data": {
-          "checksum": "sha256-X5FGVjy9TFT+NbfOA0lbV3pnLHSmqrDGz4BKIeYVBeA=",
-          "range": "bytes=1068-631660"
+          "checksum": "sha256-74kS0GGdLRQfk5b0TynYIEqh6fCEEK7QHP7iNsWb9oE=",
+          "range": "bytes=1071-631901"
         },
         "name": "nghttp2-dev",
         "signature": {
-          "checksum": "sha1-vGUw/0Loh1AWFjrlxevxFU7IKT4=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-AUWNNntPboyRKLJbqFODeq2sX8g=",
+          "range": "bytes=0-703"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.61.0-r1.apk",
-        "version": "1.61.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.62.0-r0.apk",
+        "version": "1.62.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -546,22 +546,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1SX1piz1hZeqGnnSNsfZGhK54I8A=",
+        "checksum": "Q15i44FeGc8cU/Gs+AORIH16osoV8=",
         "control": {
-          "checksum": "sha1-SX1piz1hZeqGnnSNsfZGhK54I8A=",
-          "range": "bytes=699-1103"
+          "checksum": "sha1-5i44FeGc8cU/Gs+AORIH16osoV8=",
+          "range": "bytes=695-1098"
         },
         "data": {
-          "checksum": "sha256-VSxM5PIYwhIc/kJVmh0tsVqLpz68eYyOYyC4cxkP4nw=",
-          "range": "bytes=1104-21603"
+          "checksum": "sha256-72mWEdxOgFKdTQQJGfANOdejkvbhfTVsXD8yNzkwDKo=",
+          "range": "bytes=1099-21646"
         },
         "name": "libcrypt1",
         "signature": {
-          "checksum": "sha1-SRN+qFHoymUHf93USjCViyBMAKU=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-bbdRja3lJyrqB1b1R5lOFXk5Yps=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r3.apk",
-        "version": "2.39-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r5.apk",
+        "version": "2.39-r5"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/search-indexer.lock.json
+++ b/wolfi-images/search-indexer.lock.json
@@ -52,60 +52,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1LbskMUECTvoctOm3XVAJBe6/+O8=",
+        "checksum": "Q15nzyxTcmhST9dTlB9BxV088pKJY=",
         "control": {
-          "checksum": "sha1-LbskMUECTvoctOm3XVAJBe6/+O8=",
-          "range": "bytes=704-1113"
+          "checksum": "sha1-5nzyxTcmhST9dTlB9BxV088pKJY=",
+          "range": "bytes=697-1107"
         },
         "data": {
-          "checksum": "sha256-U8ueoDdtkVXfQ3r8UKQU+ei8sdAH+ayEnmYIcGEM6S8=",
-          "range": "bytes=1114-267813"
+          "checksum": "sha256-i2qrjtws7OeqrKQP83nQo1vFwjqnO0QM3fSTvHHEKps=",
+          "range": "bytes=1108-267856"
         },
         "name": "ld-linux",
         "signature": {
-          "checksum": "sha1-snzU1ONYjrHMX4b2N117nm2p+9s=",
-          "range": "bytes=0-703"
+          "checksum": "sha1-nJTcI836Gt8XuqjMFUh2BBK4pP4=",
+          "range": "bytes=0-696"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r3.apk",
-        "version": "2.39-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r5.apk",
+        "version": "2.39-r5"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ovjsy4Uk7yfyamNBkynUnsHYFMU=",
+        "checksum": "Q1EuFMRKR/2atKFGKHjH/3vivHPEc=",
         "control": {
-          "checksum": "sha1-ovjsy4Uk7yfyamNBkynUnsHYFMU=",
-          "range": "bytes=701-1059"
+          "checksum": "sha1-EuFMRKR/2atKFGKHjH/3vivHPEc=",
+          "range": "bytes=699-1059"
         },
         "data": {
-          "checksum": "sha256-NedZsq170zk14TU+FxyLtc3Dr0vz/fmDP6LbmTqdtF8=",
-          "range": "bytes=1060-408273"
+          "checksum": "sha256-QDrcE6gPZ7R2/02ORkq8ZiVIGQDOwVQ07QetxKwG2jE=",
+          "range": "bytes=1060-408316"
         },
         "name": "glibc-locale-posix",
         "signature": {
-          "checksum": "sha1-G9qkyU9BXJISxwkeJE5Cz/n/H0k=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-hRz3Fq86p+IW4pWkZRP5kxsJFns=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r3.apk",
-        "version": "2.39-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r5.apk",
+        "version": "2.39-r5"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1+bVOClqbAOmgA1y9Q+GYJhEfuJs=",
+        "checksum": "Q19hiFVzu+AzUM0onmSNjApSBdvTw=",
         "control": {
-          "checksum": "sha1-+bVOClqbAOmgA1y9Q+GYJhEfuJs=",
-          "range": "bytes=700-1326"
+          "checksum": "sha1-9hiFVzu+AzUM0onmSNjApSBdvTw=",
+          "range": "bytes=694-1321"
         },
         "data": {
-          "checksum": "sha256-59plMSMECX3LWvyWsiLvadlwbdU3qopW0jRvBCyMGBM=",
-          "range": "bytes=1327-5861479"
+          "checksum": "sha256-eDetP73vFbPoIKaaYcLDZ89dOGzpY4xRBw75zN0Odpg=",
+          "range": "bytes=1322-5861522"
         },
         "name": "glibc",
         "signature": {
-          "checksum": "sha1-NZX+6hpoAYIpCd9O1VsViZI3MM0=",
-          "range": "bytes=0-699"
+          "checksum": "sha1-n8l9a4cNG2heaH82Un+dqHmdqRI=",
+          "range": "bytes=0-693"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r3.apk",
-        "version": "2.39-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r5.apk",
+        "version": "2.39-r5"
       },
       {
         "architecture": "x86_64",
@@ -318,22 +318,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1GG/Qe/wJbfaSQh2/E66qsSZ1d14=",
+        "checksum": "Q1GynPQjsrxTFW54tdQAqopiWsMuo=",
         "control": {
-          "checksum": "sha1-GG/Qe/wJbfaSQh2/E66qsSZ1d14=",
-          "range": "bytes=693-1065"
+          "checksum": "sha1-GynPQjsrxTFW54tdQAqopiWsMuo=",
+          "range": "bytes=697-1068"
         },
         "data": {
-          "checksum": "sha256-83L93TpxngARX3OA5Mm8MzkKPoqcoX6BX4/rslD+ND0=",
-          "range": "bytes=1066-251841"
+          "checksum": "sha256-cFyZH6WiNgbnz+zovA9EJB8aHO70Ao8TIH7052O/w1M=",
+          "range": "bytes=1069-251882"
         },
         "name": "libnghttp2-14",
         "signature": {
-          "checksum": "sha1-nERTCwywhPhwFIvRVZFNWHvzJXk=",
-          "range": "bytes=0-692"
+          "checksum": "sha1-o2sTmr6y1CBY9otWZAKu01XAbM8=",
+          "range": "bytes=0-696"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.61.0-r1.apk",
-        "version": "1.61.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.62.0-r0.apk",
+        "version": "1.62.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -413,41 +413,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1rmRRDukjyxrZKFy/2htPJpXlv6c=",
+        "checksum": "Q1bkh6LBvJiAE8yoq/+3XyeLRcIDE=",
         "control": {
-          "checksum": "sha1-rmRRDukjyxrZKFy/2htPJpXlv6c=",
-          "range": "bytes=699-1169"
+          "checksum": "sha1-bkh6LBvJiAE8yoq/+3XyeLRcIDE=",
+          "range": "bytes=700-1171"
         },
         "data": {
-          "checksum": "sha256-R81rAn3Y5uN4AbPY2STKyJQFy9AlA8AsQBoi6dbaAUA=",
-          "range": "bytes=1170-2556940"
+          "checksum": "sha256-fK9ZYBCiUycuwXY2OUJPlo4VO00LgqbMjSBO0CNMEok=",
+          "range": "bytes=1172-2582013"
         },
         "name": "nghttp2",
         "signature": {
-          "checksum": "sha1-EVy/a8/HRmt7vkLWYZfPCgtTzvE=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-ubcn/WnvFEPpkHx9nfAlqzYVN1o=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.61.0-r1.apk",
-        "version": "1.61.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.62.0-r0.apk",
+        "version": "1.62.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1dKyxN+ghQa6wAlVdT/IeTI/kUCI=",
+        "checksum": "Q1yOG4UBYkzOYPo4RZgfhIm6Mh0sU=",
         "control": {
-          "checksum": "sha1-dKyxN+ghQa6wAlVdT/IeTI/kUCI=",
-          "range": "bytes=699-1067"
+          "checksum": "sha1-yOG4UBYkzOYPo4RZgfhIm6Mh0sU=",
+          "range": "bytes=704-1070"
         },
         "data": {
-          "checksum": "sha256-X5FGVjy9TFT+NbfOA0lbV3pnLHSmqrDGz4BKIeYVBeA=",
-          "range": "bytes=1068-631660"
+          "checksum": "sha256-74kS0GGdLRQfk5b0TynYIEqh6fCEEK7QHP7iNsWb9oE=",
+          "range": "bytes=1071-631901"
         },
         "name": "nghttp2-dev",
         "signature": {
-          "checksum": "sha1-vGUw/0Loh1AWFjrlxevxFU7IKT4=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-AUWNNntPboyRKLJbqFODeq2sX8g=",
+          "range": "bytes=0-703"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.61.0-r1.apk",
-        "version": "1.61.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.62.0-r0.apk",
+        "version": "1.62.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -546,22 +546,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1SX1piz1hZeqGnnSNsfZGhK54I8A=",
+        "checksum": "Q15i44FeGc8cU/Gs+AORIH16osoV8=",
         "control": {
-          "checksum": "sha1-SX1piz1hZeqGnnSNsfZGhK54I8A=",
-          "range": "bytes=699-1103"
+          "checksum": "sha1-5i44FeGc8cU/Gs+AORIH16osoV8=",
+          "range": "bytes=695-1098"
         },
         "data": {
-          "checksum": "sha256-VSxM5PIYwhIc/kJVmh0tsVqLpz68eYyOYyC4cxkP4nw=",
-          "range": "bytes=1104-21603"
+          "checksum": "sha256-72mWEdxOgFKdTQQJGfANOdejkvbhfTVsXD8yNzkwDKo=",
+          "range": "bytes=1099-21646"
         },
         "name": "libcrypt1",
         "signature": {
-          "checksum": "sha1-SRN+qFHoymUHf93USjCViyBMAKU=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-bbdRja3lJyrqB1b1R5lOFXk5Yps=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r3.apk",
-        "version": "2.39-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r5.apk",
+        "version": "2.39-r5"
       },
       {
         "architecture": "x86_64",
@@ -793,22 +793,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ieuXl/3DfkuOLicC/GlvVmzsYM0=",
+        "checksum": "Q1eaot0B2H9IOF054RKMabXG37GUk=",
         "control": {
-          "checksum": "sha1-ieuXl/3DfkuOLicC/GlvVmzsYM0=",
-          "range": "bytes=694-1137"
+          "checksum": "sha1-eaot0B2H9IOF054RKMabXG37GUk=",
+          "range": "bytes=700-1143"
         },
         "data": {
-          "checksum": "sha256-QJ4bdR2CM1ozjfKJ3YY44aPSHHcx/2R999PpMdh/bsA=",
-          "range": "bytes=1138-17230695"
+          "checksum": "sha256-EeuQkVe5Hl+bqWfkBaMgA1Z2Fh91f1upncBbArJu9Gw=",
+          "range": "bytes=1144-17267929"
         },
         "name": "git",
         "signature": {
-          "checksum": "sha1-1X/hk5++g5/PGVylpB3VYqx5hSM=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-yMhNFUJ+emT/s9tdLDQ8zjT2+vY=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/git-2.45.0-r1.apk",
-        "version": "2.45.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/git-2.45.1-r0.apk",
+        "version": "2.45.1-r0"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/searcher.lock.json
+++ b/wolfi-images/searcher.lock.json
@@ -52,60 +52,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1LbskMUECTvoctOm3XVAJBe6/+O8=",
+        "checksum": "Q15nzyxTcmhST9dTlB9BxV088pKJY=",
         "control": {
-          "checksum": "sha1-LbskMUECTvoctOm3XVAJBe6/+O8=",
-          "range": "bytes=704-1113"
+          "checksum": "sha1-5nzyxTcmhST9dTlB9BxV088pKJY=",
+          "range": "bytes=697-1107"
         },
         "data": {
-          "checksum": "sha256-U8ueoDdtkVXfQ3r8UKQU+ei8sdAH+ayEnmYIcGEM6S8=",
-          "range": "bytes=1114-267813"
+          "checksum": "sha256-i2qrjtws7OeqrKQP83nQo1vFwjqnO0QM3fSTvHHEKps=",
+          "range": "bytes=1108-267856"
         },
         "name": "ld-linux",
         "signature": {
-          "checksum": "sha1-snzU1ONYjrHMX4b2N117nm2p+9s=",
-          "range": "bytes=0-703"
+          "checksum": "sha1-nJTcI836Gt8XuqjMFUh2BBK4pP4=",
+          "range": "bytes=0-696"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r3.apk",
-        "version": "2.39-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r5.apk",
+        "version": "2.39-r5"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ovjsy4Uk7yfyamNBkynUnsHYFMU=",
+        "checksum": "Q1EuFMRKR/2atKFGKHjH/3vivHPEc=",
         "control": {
-          "checksum": "sha1-ovjsy4Uk7yfyamNBkynUnsHYFMU=",
-          "range": "bytes=701-1059"
+          "checksum": "sha1-EuFMRKR/2atKFGKHjH/3vivHPEc=",
+          "range": "bytes=699-1059"
         },
         "data": {
-          "checksum": "sha256-NedZsq170zk14TU+FxyLtc3Dr0vz/fmDP6LbmTqdtF8=",
-          "range": "bytes=1060-408273"
+          "checksum": "sha256-QDrcE6gPZ7R2/02ORkq8ZiVIGQDOwVQ07QetxKwG2jE=",
+          "range": "bytes=1060-408316"
         },
         "name": "glibc-locale-posix",
         "signature": {
-          "checksum": "sha1-G9qkyU9BXJISxwkeJE5Cz/n/H0k=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-hRz3Fq86p+IW4pWkZRP5kxsJFns=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r3.apk",
-        "version": "2.39-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r5.apk",
+        "version": "2.39-r5"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1+bVOClqbAOmgA1y9Q+GYJhEfuJs=",
+        "checksum": "Q19hiFVzu+AzUM0onmSNjApSBdvTw=",
         "control": {
-          "checksum": "sha1-+bVOClqbAOmgA1y9Q+GYJhEfuJs=",
-          "range": "bytes=700-1326"
+          "checksum": "sha1-9hiFVzu+AzUM0onmSNjApSBdvTw=",
+          "range": "bytes=694-1321"
         },
         "data": {
-          "checksum": "sha256-59plMSMECX3LWvyWsiLvadlwbdU3qopW0jRvBCyMGBM=",
-          "range": "bytes=1327-5861479"
+          "checksum": "sha256-eDetP73vFbPoIKaaYcLDZ89dOGzpY4xRBw75zN0Odpg=",
+          "range": "bytes=1322-5861522"
         },
         "name": "glibc",
         "signature": {
-          "checksum": "sha1-NZX+6hpoAYIpCd9O1VsViZI3MM0=",
-          "range": "bytes=0-699"
+          "checksum": "sha1-n8l9a4cNG2heaH82Un+dqHmdqRI=",
+          "range": "bytes=0-693"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r3.apk",
-        "version": "2.39-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r5.apk",
+        "version": "2.39-r5"
       },
       {
         "architecture": "x86_64",
@@ -318,22 +318,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1GG/Qe/wJbfaSQh2/E66qsSZ1d14=",
+        "checksum": "Q1GynPQjsrxTFW54tdQAqopiWsMuo=",
         "control": {
-          "checksum": "sha1-GG/Qe/wJbfaSQh2/E66qsSZ1d14=",
-          "range": "bytes=693-1065"
+          "checksum": "sha1-GynPQjsrxTFW54tdQAqopiWsMuo=",
+          "range": "bytes=697-1068"
         },
         "data": {
-          "checksum": "sha256-83L93TpxngARX3OA5Mm8MzkKPoqcoX6BX4/rslD+ND0=",
-          "range": "bytes=1066-251841"
+          "checksum": "sha256-cFyZH6WiNgbnz+zovA9EJB8aHO70Ao8TIH7052O/w1M=",
+          "range": "bytes=1069-251882"
         },
         "name": "libnghttp2-14",
         "signature": {
-          "checksum": "sha1-nERTCwywhPhwFIvRVZFNWHvzJXk=",
-          "range": "bytes=0-692"
+          "checksum": "sha1-o2sTmr6y1CBY9otWZAKu01XAbM8=",
+          "range": "bytes=0-696"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.61.0-r1.apk",
-        "version": "1.61.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.62.0-r0.apk",
+        "version": "1.62.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -413,41 +413,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1rmRRDukjyxrZKFy/2htPJpXlv6c=",
+        "checksum": "Q1bkh6LBvJiAE8yoq/+3XyeLRcIDE=",
         "control": {
-          "checksum": "sha1-rmRRDukjyxrZKFy/2htPJpXlv6c=",
-          "range": "bytes=699-1169"
+          "checksum": "sha1-bkh6LBvJiAE8yoq/+3XyeLRcIDE=",
+          "range": "bytes=700-1171"
         },
         "data": {
-          "checksum": "sha256-R81rAn3Y5uN4AbPY2STKyJQFy9AlA8AsQBoi6dbaAUA=",
-          "range": "bytes=1170-2556940"
+          "checksum": "sha256-fK9ZYBCiUycuwXY2OUJPlo4VO00LgqbMjSBO0CNMEok=",
+          "range": "bytes=1172-2582013"
         },
         "name": "nghttp2",
         "signature": {
-          "checksum": "sha1-EVy/a8/HRmt7vkLWYZfPCgtTzvE=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-ubcn/WnvFEPpkHx9nfAlqzYVN1o=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.61.0-r1.apk",
-        "version": "1.61.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.62.0-r0.apk",
+        "version": "1.62.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1dKyxN+ghQa6wAlVdT/IeTI/kUCI=",
+        "checksum": "Q1yOG4UBYkzOYPo4RZgfhIm6Mh0sU=",
         "control": {
-          "checksum": "sha1-dKyxN+ghQa6wAlVdT/IeTI/kUCI=",
-          "range": "bytes=699-1067"
+          "checksum": "sha1-yOG4UBYkzOYPo4RZgfhIm6Mh0sU=",
+          "range": "bytes=704-1070"
         },
         "data": {
-          "checksum": "sha256-X5FGVjy9TFT+NbfOA0lbV3pnLHSmqrDGz4BKIeYVBeA=",
-          "range": "bytes=1068-631660"
+          "checksum": "sha256-74kS0GGdLRQfk5b0TynYIEqh6fCEEK7QHP7iNsWb9oE=",
+          "range": "bytes=1071-631901"
         },
         "name": "nghttp2-dev",
         "signature": {
-          "checksum": "sha1-vGUw/0Loh1AWFjrlxevxFU7IKT4=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-AUWNNntPboyRKLJbqFODeq2sX8g=",
+          "range": "bytes=0-703"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.61.0-r1.apk",
-        "version": "1.61.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.62.0-r0.apk",
+        "version": "1.62.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -546,22 +546,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1SX1piz1hZeqGnnSNsfZGhK54I8A=",
+        "checksum": "Q15i44FeGc8cU/Gs+AORIH16osoV8=",
         "control": {
-          "checksum": "sha1-SX1piz1hZeqGnnSNsfZGhK54I8A=",
-          "range": "bytes=699-1103"
+          "checksum": "sha1-5i44FeGc8cU/Gs+AORIH16osoV8=",
+          "range": "bytes=695-1098"
         },
         "data": {
-          "checksum": "sha256-VSxM5PIYwhIc/kJVmh0tsVqLpz68eYyOYyC4cxkP4nw=",
-          "range": "bytes=1104-21603"
+          "checksum": "sha256-72mWEdxOgFKdTQQJGfANOdejkvbhfTVsXD8yNzkwDKo=",
+          "range": "bytes=1099-21646"
         },
         "name": "libcrypt1",
         "signature": {
-          "checksum": "sha1-SRN+qFHoymUHf93USjCViyBMAKU=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-bbdRja3lJyrqB1b1R5lOFXk5Yps=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r3.apk",
-        "version": "2.39-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r5.apk",
+        "version": "2.39-r5"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/server.lock.json
+++ b/wolfi-images/server.lock.json
@@ -75,60 +75,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1LbskMUECTvoctOm3XVAJBe6/+O8=",
+        "checksum": "Q15nzyxTcmhST9dTlB9BxV088pKJY=",
         "control": {
-          "checksum": "sha1-LbskMUECTvoctOm3XVAJBe6/+O8=",
-          "range": "bytes=704-1113"
+          "checksum": "sha1-5nzyxTcmhST9dTlB9BxV088pKJY=",
+          "range": "bytes=697-1107"
         },
         "data": {
-          "checksum": "sha256-U8ueoDdtkVXfQ3r8UKQU+ei8sdAH+ayEnmYIcGEM6S8=",
-          "range": "bytes=1114-267813"
+          "checksum": "sha256-i2qrjtws7OeqrKQP83nQo1vFwjqnO0QM3fSTvHHEKps=",
+          "range": "bytes=1108-267856"
         },
         "name": "ld-linux",
         "signature": {
-          "checksum": "sha1-snzU1ONYjrHMX4b2N117nm2p+9s=",
-          "range": "bytes=0-703"
+          "checksum": "sha1-nJTcI836Gt8XuqjMFUh2BBK4pP4=",
+          "range": "bytes=0-696"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r3.apk",
-        "version": "2.39-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r5.apk",
+        "version": "2.39-r5"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ovjsy4Uk7yfyamNBkynUnsHYFMU=",
+        "checksum": "Q1EuFMRKR/2atKFGKHjH/3vivHPEc=",
         "control": {
-          "checksum": "sha1-ovjsy4Uk7yfyamNBkynUnsHYFMU=",
-          "range": "bytes=701-1059"
+          "checksum": "sha1-EuFMRKR/2atKFGKHjH/3vivHPEc=",
+          "range": "bytes=699-1059"
         },
         "data": {
-          "checksum": "sha256-NedZsq170zk14TU+FxyLtc3Dr0vz/fmDP6LbmTqdtF8=",
-          "range": "bytes=1060-408273"
+          "checksum": "sha256-QDrcE6gPZ7R2/02ORkq8ZiVIGQDOwVQ07QetxKwG2jE=",
+          "range": "bytes=1060-408316"
         },
         "name": "glibc-locale-posix",
         "signature": {
-          "checksum": "sha1-G9qkyU9BXJISxwkeJE5Cz/n/H0k=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-hRz3Fq86p+IW4pWkZRP5kxsJFns=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r3.apk",
-        "version": "2.39-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r5.apk",
+        "version": "2.39-r5"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1+bVOClqbAOmgA1y9Q+GYJhEfuJs=",
+        "checksum": "Q19hiFVzu+AzUM0onmSNjApSBdvTw=",
         "control": {
-          "checksum": "sha1-+bVOClqbAOmgA1y9Q+GYJhEfuJs=",
-          "range": "bytes=700-1326"
+          "checksum": "sha1-9hiFVzu+AzUM0onmSNjApSBdvTw=",
+          "range": "bytes=694-1321"
         },
         "data": {
-          "checksum": "sha256-59plMSMECX3LWvyWsiLvadlwbdU3qopW0jRvBCyMGBM=",
-          "range": "bytes=1327-5861479"
+          "checksum": "sha256-eDetP73vFbPoIKaaYcLDZ89dOGzpY4xRBw75zN0Odpg=",
+          "range": "bytes=1322-5861522"
         },
         "name": "glibc",
         "signature": {
-          "checksum": "sha1-NZX+6hpoAYIpCd9O1VsViZI3MM0=",
-          "range": "bytes=0-699"
+          "checksum": "sha1-n8l9a4cNG2heaH82Un+dqHmdqRI=",
+          "range": "bytes=0-693"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r3.apk",
-        "version": "2.39-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r5.apk",
+        "version": "2.39-r5"
       },
       {
         "architecture": "x86_64",
@@ -379,22 +379,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1GG/Qe/wJbfaSQh2/E66qsSZ1d14=",
+        "checksum": "Q1GynPQjsrxTFW54tdQAqopiWsMuo=",
         "control": {
-          "checksum": "sha1-GG/Qe/wJbfaSQh2/E66qsSZ1d14=",
-          "range": "bytes=693-1065"
+          "checksum": "sha1-GynPQjsrxTFW54tdQAqopiWsMuo=",
+          "range": "bytes=697-1068"
         },
         "data": {
-          "checksum": "sha256-83L93TpxngARX3OA5Mm8MzkKPoqcoX6BX4/rslD+ND0=",
-          "range": "bytes=1066-251841"
+          "checksum": "sha256-cFyZH6WiNgbnz+zovA9EJB8aHO70Ao8TIH7052O/w1M=",
+          "range": "bytes=1069-251882"
         },
         "name": "libnghttp2-14",
         "signature": {
-          "checksum": "sha1-nERTCwywhPhwFIvRVZFNWHvzJXk=",
-          "range": "bytes=0-692"
+          "checksum": "sha1-o2sTmr6y1CBY9otWZAKu01XAbM8=",
+          "range": "bytes=0-696"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.61.0-r1.apk",
-        "version": "1.61.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.62.0-r0.apk",
+        "version": "1.62.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -474,41 +474,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1rmRRDukjyxrZKFy/2htPJpXlv6c=",
+        "checksum": "Q1bkh6LBvJiAE8yoq/+3XyeLRcIDE=",
         "control": {
-          "checksum": "sha1-rmRRDukjyxrZKFy/2htPJpXlv6c=",
-          "range": "bytes=699-1169"
+          "checksum": "sha1-bkh6LBvJiAE8yoq/+3XyeLRcIDE=",
+          "range": "bytes=700-1171"
         },
         "data": {
-          "checksum": "sha256-R81rAn3Y5uN4AbPY2STKyJQFy9AlA8AsQBoi6dbaAUA=",
-          "range": "bytes=1170-2556940"
+          "checksum": "sha256-fK9ZYBCiUycuwXY2OUJPlo4VO00LgqbMjSBO0CNMEok=",
+          "range": "bytes=1172-2582013"
         },
         "name": "nghttp2",
         "signature": {
-          "checksum": "sha1-EVy/a8/HRmt7vkLWYZfPCgtTzvE=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-ubcn/WnvFEPpkHx9nfAlqzYVN1o=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.61.0-r1.apk",
-        "version": "1.61.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.62.0-r0.apk",
+        "version": "1.62.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1dKyxN+ghQa6wAlVdT/IeTI/kUCI=",
+        "checksum": "Q1yOG4UBYkzOYPo4RZgfhIm6Mh0sU=",
         "control": {
-          "checksum": "sha1-dKyxN+ghQa6wAlVdT/IeTI/kUCI=",
-          "range": "bytes=699-1067"
+          "checksum": "sha1-yOG4UBYkzOYPo4RZgfhIm6Mh0sU=",
+          "range": "bytes=704-1070"
         },
         "data": {
-          "checksum": "sha256-X5FGVjy9TFT+NbfOA0lbV3pnLHSmqrDGz4BKIeYVBeA=",
-          "range": "bytes=1068-631660"
+          "checksum": "sha256-74kS0GGdLRQfk5b0TynYIEqh6fCEEK7QHP7iNsWb9oE=",
+          "range": "bytes=1071-631901"
         },
         "name": "nghttp2-dev",
         "signature": {
-          "checksum": "sha1-vGUw/0Loh1AWFjrlxevxFU7IKT4=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-AUWNNntPboyRKLJbqFODeq2sX8g=",
+          "range": "bytes=0-703"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.61.0-r1.apk",
-        "version": "1.61.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.62.0-r0.apk",
+        "version": "1.62.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -607,22 +607,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1SX1piz1hZeqGnnSNsfZGhK54I8A=",
+        "checksum": "Q15i44FeGc8cU/Gs+AORIH16osoV8=",
         "control": {
-          "checksum": "sha1-SX1piz1hZeqGnnSNsfZGhK54I8A=",
-          "range": "bytes=699-1103"
+          "checksum": "sha1-5i44FeGc8cU/Gs+AORIH16osoV8=",
+          "range": "bytes=695-1098"
         },
         "data": {
-          "checksum": "sha256-VSxM5PIYwhIc/kJVmh0tsVqLpz68eYyOYyC4cxkP4nw=",
-          "range": "bytes=1104-21603"
+          "checksum": "sha256-72mWEdxOgFKdTQQJGfANOdejkvbhfTVsXD8yNzkwDKo=",
+          "range": "bytes=1099-21646"
         },
         "name": "libcrypt1",
         "signature": {
-          "checksum": "sha1-SRN+qFHoymUHf93USjCViyBMAKU=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-bbdRja3lJyrqB1b1R5lOFXk5Yps=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r3.apk",
-        "version": "2.39-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r5.apk",
+        "version": "2.39-r5"
       },
       {
         "architecture": "x86_64",
@@ -949,22 +949,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ieuXl/3DfkuOLicC/GlvVmzsYM0=",
+        "checksum": "Q1eaot0B2H9IOF054RKMabXG37GUk=",
         "control": {
-          "checksum": "sha1-ieuXl/3DfkuOLicC/GlvVmzsYM0=",
-          "range": "bytes=694-1137"
+          "checksum": "sha1-eaot0B2H9IOF054RKMabXG37GUk=",
+          "range": "bytes=700-1143"
         },
         "data": {
-          "checksum": "sha256-QJ4bdR2CM1ozjfKJ3YY44aPSHHcx/2R999PpMdh/bsA=",
-          "range": "bytes=1138-17230695"
+          "checksum": "sha256-EeuQkVe5Hl+bqWfkBaMgA1Z2Fh91f1upncBbArJu9Gw=",
+          "range": "bytes=1144-17267929"
         },
         "name": "git",
         "signature": {
-          "checksum": "sha1-1X/hk5++g5/PGVylpB3VYqx5hSM=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-yMhNFUJ+emT/s9tdLDQ8zjT2+vY=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/git-2.45.0-r1.apk",
-        "version": "2.45.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/git-2.45.1-r0.apk",
+        "version": "2.45.1-r0"
       },
       {
         "architecture": "x86_64",
@@ -987,60 +987,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1bgY2qIx8jN5L3tOqqt7QiTpgQ9Q=",
+        "checksum": "Q1AtyQ8BGxIy54FTCVfU4vA3dBujA=",
         "control": {
-          "checksum": "sha1-bgY2qIx8jN5L3tOqqt7QiTpgQ9Q=",
-          "range": "bytes=700-1109"
+          "checksum": "sha1-AtyQ8BGxIy54FTCVfU4vA3dBujA=",
+          "range": "bytes=696-1105"
         },
         "data": {
-          "checksum": "sha256-s2s+7wDCq9x653/jqxhOmy/aDjMzCQ5JemT23452kNU=",
-          "range": "bytes=1110-7554421"
+          "checksum": "sha256-jm7jYqIpUa8S3qayJMbb10cks4vaQbqkkl7r95+SUvc=",
+          "range": "bytes=1106-7568791"
         },
         "name": "git-daemon",
         "signature": {
-          "checksum": "sha1-LLgVia/l0jyJJTxeuMbGBhKekZU=",
-          "range": "bytes=0-699"
+          "checksum": "sha1-WouI+0ZflydIMa2FK5A7CtGW7Uo=",
+          "range": "bytes=0-695"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/git-daemon-2.45.0-r1.apk",
-        "version": "2.45.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/git-daemon-2.45.1-r0.apk",
+        "version": "2.45.1-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1jeUBZvQE2RjD+THqhGKD91Jp1hA=",
+        "checksum": "Q1bxdUk5Zm+DGJ1BJRhi+4lVqQC8M=",
         "control": {
-          "checksum": "sha1-jeUBZvQE2RjD+THqhGKD91Jp1hA=",
-          "range": "bytes=706-1077"
+          "checksum": "sha1-bxdUk5Zm+DGJ1BJRhi+4lVqQC8M=",
+          "range": "bytes=707-1078"
         },
         "data": {
-          "checksum": "sha256-YHrU0Bat1zYFLHSgrR6CDBsRMi+uRh/fqYm3CU88zC4=",
-          "range": "bytes=1078-211547"
+          "checksum": "sha256-n6UB0PG6Q3zvEhvY9YG0J+5fLLQy52aoHxuc/8mNhDo=",
+          "range": "bytes=1079-211589"
         },
         "name": "git-p4",
         "signature": {
-          "checksum": "sha1-NpZUhyIh7ddWCIeS1nmjjafcvaQ=",
-          "range": "bytes=0-705"
+          "checksum": "sha1-7GOnoDsQV3oKBXD6jIlMaFHpzxQ=",
+          "range": "bytes=0-706"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/git-p4-2.45.0-r1.apk",
-        "version": "2.45.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/git-p4-2.45.1-r0.apk",
+        "version": "2.45.1-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1l/Beg7hLAZ2nq/yvn08SgN0dfbQ=",
+        "checksum": "Q1u06OS+YwZxI3J9l6nyLHx2Sn7Hg=",
         "control": {
-          "checksum": "sha1-l/Beg7hLAZ2nq/yvn08SgN0dfbQ=",
-          "range": "bytes=694-1021"
+          "checksum": "sha1-u06OS+YwZxI3J9l6nyLHx2Sn7Hg=",
+          "range": "bytes=696-1023"
         },
         "data": {
-          "checksum": "sha256-LJrbfQdFpPfkW6mTXg4pc83H2E2GlWktO4x6Vd6aOgE=",
-          "range": "bytes=1022-61049957"
+          "checksum": "sha256-Z9YqIzOent28mE3zD4hq3cQKVYEA7b0uMtXQGqZ8ExM=",
+          "range": "bytes=1024-61050000"
         },
         "name": "glibc-locale-en",
         "signature": {
-          "checksum": "sha1-Mu4+oc+G5MqsHFYlEzyNOtGjDDk=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-8ptxZXnKS96Vm/mvZTrB3r5ZddU=",
+          "range": "bytes=0-695"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-en-2.39-r3.apk",
-        "version": "2.39-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-en-2.39-r5.apk",
+        "version": "2.39-r5"
       },
       {
         "architecture": "x86_64",
@@ -1462,22 +1462,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1osNZl4W7FxvkIsYQWElyBJXw+bg=",
+        "checksum": "Q1FHLh1XfGP1GJWaC8RExj2uVfHq4=",
         "control": {
-          "checksum": "sha1-osNZl4W7FxvkIsYQWElyBJXw+bg=",
-          "range": "bytes=698-1164"
+          "checksum": "sha1-FHLh1XfGP1GJWaC8RExj2uVfHq4=",
+          "range": "bytes=696-1169"
         },
         "data": {
-          "checksum": "sha256-VCOzBSr0cBHnnKs/V41eh0lMFsHwFSKvrnvWLT9LbME=",
-          "range": "bytes=1165-373949"
+          "checksum": "sha256-QxsRdBkZMCQ7A7qN5w7hHJlQFYfouHdJbrPFICd82e8=",
+          "range": "bytes=1170-373992"
         },
         "name": "posix-libc-utils",
         "signature": {
-          "checksum": "sha1-NUfmqSTwQatPMiw5iwifaUlhqt0=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-Nih/VZo/M9vKIyIqZPXM7vxHLzc=",
+          "range": "bytes=0-695"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/posix-libc-utils-2.39-r3.apk",
-        "version": "2.39-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/posix-libc-utils-2.39-r5.apk",
+        "version": "2.39-r5"
       },
       {
         "architecture": "x86_64",
@@ -1576,22 +1576,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1/xH9NXh2XAN7AiXLSyfKBjj+41g=",
+        "checksum": "Q1wjEh5PI4XEuZMLSqCUBZsNsp5t8=",
         "control": {
-          "checksum": "sha1-/xH9NXh2XAN7AiXLSyfKBjj+41g=",
-          "range": "bytes=694-1135"
+          "checksum": "sha1-wjEh5PI4XEuZMLSqCUBZsNsp5t8=",
+          "range": "bytes=702-1143"
         },
         "data": {
-          "checksum": "sha256-qg8zb40a6hpJUCmj2xctm8npy+TSpC9kumdnnSNRkQE=",
-          "range": "bytes=1136-192879162"
+          "checksum": "sha256-Vbe4KzKdSQ8oya/6+1+E9jHF+kEFJ9dk9E+zkaoBM7w=",
+          "range": "bytes=1144-192879162"
         },
         "name": "prometheus-2.52",
         "signature": {
-          "checksum": "sha1-As1h2B3XeSrL7tXFOnrKY2uEY0U=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-m6xJcvKj0rNtml4eJe5VbyYfryo=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/prometheus-2.52-2.52.0-r1.apk",
-        "version": "2.52.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/prometheus-2.52-2.52.0-r2.apk",
+        "version": "2.52.0-r2"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/sourcegraph-base.lock.json
+++ b/wolfi-images/sourcegraph-base.lock.json
@@ -52,60 +52,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1LbskMUECTvoctOm3XVAJBe6/+O8=",
+        "checksum": "Q15nzyxTcmhST9dTlB9BxV088pKJY=",
         "control": {
-          "checksum": "sha1-LbskMUECTvoctOm3XVAJBe6/+O8=",
-          "range": "bytes=704-1113"
+          "checksum": "sha1-5nzyxTcmhST9dTlB9BxV088pKJY=",
+          "range": "bytes=697-1107"
         },
         "data": {
-          "checksum": "sha256-U8ueoDdtkVXfQ3r8UKQU+ei8sdAH+ayEnmYIcGEM6S8=",
-          "range": "bytes=1114-267813"
+          "checksum": "sha256-i2qrjtws7OeqrKQP83nQo1vFwjqnO0QM3fSTvHHEKps=",
+          "range": "bytes=1108-267856"
         },
         "name": "ld-linux",
         "signature": {
-          "checksum": "sha1-snzU1ONYjrHMX4b2N117nm2p+9s=",
-          "range": "bytes=0-703"
+          "checksum": "sha1-nJTcI836Gt8XuqjMFUh2BBK4pP4=",
+          "range": "bytes=0-696"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r3.apk",
-        "version": "2.39-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r5.apk",
+        "version": "2.39-r5"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ovjsy4Uk7yfyamNBkynUnsHYFMU=",
+        "checksum": "Q1EuFMRKR/2atKFGKHjH/3vivHPEc=",
         "control": {
-          "checksum": "sha1-ovjsy4Uk7yfyamNBkynUnsHYFMU=",
-          "range": "bytes=701-1059"
+          "checksum": "sha1-EuFMRKR/2atKFGKHjH/3vivHPEc=",
+          "range": "bytes=699-1059"
         },
         "data": {
-          "checksum": "sha256-NedZsq170zk14TU+FxyLtc3Dr0vz/fmDP6LbmTqdtF8=",
-          "range": "bytes=1060-408273"
+          "checksum": "sha256-QDrcE6gPZ7R2/02ORkq8ZiVIGQDOwVQ07QetxKwG2jE=",
+          "range": "bytes=1060-408316"
         },
         "name": "glibc-locale-posix",
         "signature": {
-          "checksum": "sha1-G9qkyU9BXJISxwkeJE5Cz/n/H0k=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-hRz3Fq86p+IW4pWkZRP5kxsJFns=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r3.apk",
-        "version": "2.39-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r5.apk",
+        "version": "2.39-r5"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1+bVOClqbAOmgA1y9Q+GYJhEfuJs=",
+        "checksum": "Q19hiFVzu+AzUM0onmSNjApSBdvTw=",
         "control": {
-          "checksum": "sha1-+bVOClqbAOmgA1y9Q+GYJhEfuJs=",
-          "range": "bytes=700-1326"
+          "checksum": "sha1-9hiFVzu+AzUM0onmSNjApSBdvTw=",
+          "range": "bytes=694-1321"
         },
         "data": {
-          "checksum": "sha256-59plMSMECX3LWvyWsiLvadlwbdU3qopW0jRvBCyMGBM=",
-          "range": "bytes=1327-5861479"
+          "checksum": "sha256-eDetP73vFbPoIKaaYcLDZ89dOGzpY4xRBw75zN0Odpg=",
+          "range": "bytes=1322-5861522"
         },
         "name": "glibc",
         "signature": {
-          "checksum": "sha1-NZX+6hpoAYIpCd9O1VsViZI3MM0=",
-          "range": "bytes=0-699"
+          "checksum": "sha1-n8l9a4cNG2heaH82Un+dqHmdqRI=",
+          "range": "bytes=0-693"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r3.apk",
-        "version": "2.39-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r5.apk",
+        "version": "2.39-r5"
       },
       {
         "architecture": "x86_64",
@@ -318,22 +318,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1GG/Qe/wJbfaSQh2/E66qsSZ1d14=",
+        "checksum": "Q1GynPQjsrxTFW54tdQAqopiWsMuo=",
         "control": {
-          "checksum": "sha1-GG/Qe/wJbfaSQh2/E66qsSZ1d14=",
-          "range": "bytes=693-1065"
+          "checksum": "sha1-GynPQjsrxTFW54tdQAqopiWsMuo=",
+          "range": "bytes=697-1068"
         },
         "data": {
-          "checksum": "sha256-83L93TpxngARX3OA5Mm8MzkKPoqcoX6BX4/rslD+ND0=",
-          "range": "bytes=1066-251841"
+          "checksum": "sha256-cFyZH6WiNgbnz+zovA9EJB8aHO70Ao8TIH7052O/w1M=",
+          "range": "bytes=1069-251882"
         },
         "name": "libnghttp2-14",
         "signature": {
-          "checksum": "sha1-nERTCwywhPhwFIvRVZFNWHvzJXk=",
-          "range": "bytes=0-692"
+          "checksum": "sha1-o2sTmr6y1CBY9otWZAKu01XAbM8=",
+          "range": "bytes=0-696"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.61.0-r1.apk",
-        "version": "1.61.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.62.0-r0.apk",
+        "version": "1.62.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -413,41 +413,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1rmRRDukjyxrZKFy/2htPJpXlv6c=",
+        "checksum": "Q1bkh6LBvJiAE8yoq/+3XyeLRcIDE=",
         "control": {
-          "checksum": "sha1-rmRRDukjyxrZKFy/2htPJpXlv6c=",
-          "range": "bytes=699-1169"
+          "checksum": "sha1-bkh6LBvJiAE8yoq/+3XyeLRcIDE=",
+          "range": "bytes=700-1171"
         },
         "data": {
-          "checksum": "sha256-R81rAn3Y5uN4AbPY2STKyJQFy9AlA8AsQBoi6dbaAUA=",
-          "range": "bytes=1170-2556940"
+          "checksum": "sha256-fK9ZYBCiUycuwXY2OUJPlo4VO00LgqbMjSBO0CNMEok=",
+          "range": "bytes=1172-2582013"
         },
         "name": "nghttp2",
         "signature": {
-          "checksum": "sha1-EVy/a8/HRmt7vkLWYZfPCgtTzvE=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-ubcn/WnvFEPpkHx9nfAlqzYVN1o=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.61.0-r1.apk",
-        "version": "1.61.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.62.0-r0.apk",
+        "version": "1.62.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1dKyxN+ghQa6wAlVdT/IeTI/kUCI=",
+        "checksum": "Q1yOG4UBYkzOYPo4RZgfhIm6Mh0sU=",
         "control": {
-          "checksum": "sha1-dKyxN+ghQa6wAlVdT/IeTI/kUCI=",
-          "range": "bytes=699-1067"
+          "checksum": "sha1-yOG4UBYkzOYPo4RZgfhIm6Mh0sU=",
+          "range": "bytes=704-1070"
         },
         "data": {
-          "checksum": "sha256-X5FGVjy9TFT+NbfOA0lbV3pnLHSmqrDGz4BKIeYVBeA=",
-          "range": "bytes=1068-631660"
+          "checksum": "sha256-74kS0GGdLRQfk5b0TynYIEqh6fCEEK7QHP7iNsWb9oE=",
+          "range": "bytes=1071-631901"
         },
         "name": "nghttp2-dev",
         "signature": {
-          "checksum": "sha1-vGUw/0Loh1AWFjrlxevxFU7IKT4=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-AUWNNntPboyRKLJbqFODeq2sX8g=",
+          "range": "bytes=0-703"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.61.0-r1.apk",
-        "version": "1.61.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.62.0-r0.apk",
+        "version": "1.62.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -546,22 +546,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1SX1piz1hZeqGnnSNsfZGhK54I8A=",
+        "checksum": "Q15i44FeGc8cU/Gs+AORIH16osoV8=",
         "control": {
-          "checksum": "sha1-SX1piz1hZeqGnnSNsfZGhK54I8A=",
-          "range": "bytes=699-1103"
+          "checksum": "sha1-5i44FeGc8cU/Gs+AORIH16osoV8=",
+          "range": "bytes=695-1098"
         },
         "data": {
-          "checksum": "sha256-VSxM5PIYwhIc/kJVmh0tsVqLpz68eYyOYyC4cxkP4nw=",
-          "range": "bytes=1104-21603"
+          "checksum": "sha256-72mWEdxOgFKdTQQJGfANOdejkvbhfTVsXD8yNzkwDKo=",
+          "range": "bytes=1099-21646"
         },
         "name": "libcrypt1",
         "signature": {
-          "checksum": "sha1-SRN+qFHoymUHf93USjCViyBMAKU=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-bbdRja3lJyrqB1b1R5lOFXk5Yps=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r3.apk",
-        "version": "2.39-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r5.apk",
+        "version": "2.39-r5"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/sourcegraph-dev.lock.json
+++ b/wolfi-images/sourcegraph-dev.lock.json
@@ -52,60 +52,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1LbskMUECTvoctOm3XVAJBe6/+O8=",
+        "checksum": "Q15nzyxTcmhST9dTlB9BxV088pKJY=",
         "control": {
-          "checksum": "sha1-LbskMUECTvoctOm3XVAJBe6/+O8=",
-          "range": "bytes=704-1113"
+          "checksum": "sha1-5nzyxTcmhST9dTlB9BxV088pKJY=",
+          "range": "bytes=697-1107"
         },
         "data": {
-          "checksum": "sha256-U8ueoDdtkVXfQ3r8UKQU+ei8sdAH+ayEnmYIcGEM6S8=",
-          "range": "bytes=1114-267813"
+          "checksum": "sha256-i2qrjtws7OeqrKQP83nQo1vFwjqnO0QM3fSTvHHEKps=",
+          "range": "bytes=1108-267856"
         },
         "name": "ld-linux",
         "signature": {
-          "checksum": "sha1-snzU1ONYjrHMX4b2N117nm2p+9s=",
-          "range": "bytes=0-703"
+          "checksum": "sha1-nJTcI836Gt8XuqjMFUh2BBK4pP4=",
+          "range": "bytes=0-696"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r3.apk",
-        "version": "2.39-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r5.apk",
+        "version": "2.39-r5"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ovjsy4Uk7yfyamNBkynUnsHYFMU=",
+        "checksum": "Q1EuFMRKR/2atKFGKHjH/3vivHPEc=",
         "control": {
-          "checksum": "sha1-ovjsy4Uk7yfyamNBkynUnsHYFMU=",
-          "range": "bytes=701-1059"
+          "checksum": "sha1-EuFMRKR/2atKFGKHjH/3vivHPEc=",
+          "range": "bytes=699-1059"
         },
         "data": {
-          "checksum": "sha256-NedZsq170zk14TU+FxyLtc3Dr0vz/fmDP6LbmTqdtF8=",
-          "range": "bytes=1060-408273"
+          "checksum": "sha256-QDrcE6gPZ7R2/02ORkq8ZiVIGQDOwVQ07QetxKwG2jE=",
+          "range": "bytes=1060-408316"
         },
         "name": "glibc-locale-posix",
         "signature": {
-          "checksum": "sha1-G9qkyU9BXJISxwkeJE5Cz/n/H0k=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-hRz3Fq86p+IW4pWkZRP5kxsJFns=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r3.apk",
-        "version": "2.39-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r5.apk",
+        "version": "2.39-r5"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1+bVOClqbAOmgA1y9Q+GYJhEfuJs=",
+        "checksum": "Q19hiFVzu+AzUM0onmSNjApSBdvTw=",
         "control": {
-          "checksum": "sha1-+bVOClqbAOmgA1y9Q+GYJhEfuJs=",
-          "range": "bytes=700-1326"
+          "checksum": "sha1-9hiFVzu+AzUM0onmSNjApSBdvTw=",
+          "range": "bytes=694-1321"
         },
         "data": {
-          "checksum": "sha256-59plMSMECX3LWvyWsiLvadlwbdU3qopW0jRvBCyMGBM=",
-          "range": "bytes=1327-5861479"
+          "checksum": "sha256-eDetP73vFbPoIKaaYcLDZ89dOGzpY4xRBw75zN0Odpg=",
+          "range": "bytes=1322-5861522"
         },
         "name": "glibc",
         "signature": {
-          "checksum": "sha1-NZX+6hpoAYIpCd9O1VsViZI3MM0=",
-          "range": "bytes=0-699"
+          "checksum": "sha1-n8l9a4cNG2heaH82Un+dqHmdqRI=",
+          "range": "bytes=0-693"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r3.apk",
-        "version": "2.39-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r5.apk",
+        "version": "2.39-r5"
       },
       {
         "architecture": "x86_64",
@@ -337,22 +337,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1GG/Qe/wJbfaSQh2/E66qsSZ1d14=",
+        "checksum": "Q1GynPQjsrxTFW54tdQAqopiWsMuo=",
         "control": {
-          "checksum": "sha1-GG/Qe/wJbfaSQh2/E66qsSZ1d14=",
-          "range": "bytes=693-1065"
+          "checksum": "sha1-GynPQjsrxTFW54tdQAqopiWsMuo=",
+          "range": "bytes=697-1068"
         },
         "data": {
-          "checksum": "sha256-83L93TpxngARX3OA5Mm8MzkKPoqcoX6BX4/rslD+ND0=",
-          "range": "bytes=1066-251841"
+          "checksum": "sha256-cFyZH6WiNgbnz+zovA9EJB8aHO70Ao8TIH7052O/w1M=",
+          "range": "bytes=1069-251882"
         },
         "name": "libnghttp2-14",
         "signature": {
-          "checksum": "sha1-nERTCwywhPhwFIvRVZFNWHvzJXk=",
-          "range": "bytes=0-692"
+          "checksum": "sha1-o2sTmr6y1CBY9otWZAKu01XAbM8=",
+          "range": "bytes=0-696"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.61.0-r1.apk",
-        "version": "1.61.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.62.0-r0.apk",
+        "version": "1.62.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -432,41 +432,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1rmRRDukjyxrZKFy/2htPJpXlv6c=",
+        "checksum": "Q1bkh6LBvJiAE8yoq/+3XyeLRcIDE=",
         "control": {
-          "checksum": "sha1-rmRRDukjyxrZKFy/2htPJpXlv6c=",
-          "range": "bytes=699-1169"
+          "checksum": "sha1-bkh6LBvJiAE8yoq/+3XyeLRcIDE=",
+          "range": "bytes=700-1171"
         },
         "data": {
-          "checksum": "sha256-R81rAn3Y5uN4AbPY2STKyJQFy9AlA8AsQBoi6dbaAUA=",
-          "range": "bytes=1170-2556940"
+          "checksum": "sha256-fK9ZYBCiUycuwXY2OUJPlo4VO00LgqbMjSBO0CNMEok=",
+          "range": "bytes=1172-2582013"
         },
         "name": "nghttp2",
         "signature": {
-          "checksum": "sha1-EVy/a8/HRmt7vkLWYZfPCgtTzvE=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-ubcn/WnvFEPpkHx9nfAlqzYVN1o=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.61.0-r1.apk",
-        "version": "1.61.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.62.0-r0.apk",
+        "version": "1.62.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1dKyxN+ghQa6wAlVdT/IeTI/kUCI=",
+        "checksum": "Q1yOG4UBYkzOYPo4RZgfhIm6Mh0sU=",
         "control": {
-          "checksum": "sha1-dKyxN+ghQa6wAlVdT/IeTI/kUCI=",
-          "range": "bytes=699-1067"
+          "checksum": "sha1-yOG4UBYkzOYPo4RZgfhIm6Mh0sU=",
+          "range": "bytes=704-1070"
         },
         "data": {
-          "checksum": "sha256-X5FGVjy9TFT+NbfOA0lbV3pnLHSmqrDGz4BKIeYVBeA=",
-          "range": "bytes=1068-631660"
+          "checksum": "sha256-74kS0GGdLRQfk5b0TynYIEqh6fCEEK7QHP7iNsWb9oE=",
+          "range": "bytes=1071-631901"
         },
         "name": "nghttp2-dev",
         "signature": {
-          "checksum": "sha1-vGUw/0Loh1AWFjrlxevxFU7IKT4=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-AUWNNntPboyRKLJbqFODeq2sX8g=",
+          "range": "bytes=0-703"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.61.0-r1.apk",
-        "version": "1.61.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.62.0-r0.apk",
+        "version": "1.62.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -565,22 +565,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1SX1piz1hZeqGnnSNsfZGhK54I8A=",
+        "checksum": "Q15i44FeGc8cU/Gs+AORIH16osoV8=",
         "control": {
-          "checksum": "sha1-SX1piz1hZeqGnnSNsfZGhK54I8A=",
-          "range": "bytes=699-1103"
+          "checksum": "sha1-5i44FeGc8cU/Gs+AORIH16osoV8=",
+          "range": "bytes=695-1098"
         },
         "data": {
-          "checksum": "sha256-VSxM5PIYwhIc/kJVmh0tsVqLpz68eYyOYyC4cxkP4nw=",
-          "range": "bytes=1104-21603"
+          "checksum": "sha256-72mWEdxOgFKdTQQJGfANOdejkvbhfTVsXD8yNzkwDKo=",
+          "range": "bytes=1099-21646"
         },
         "name": "libcrypt1",
         "signature": {
-          "checksum": "sha1-SRN+qFHoymUHf93USjCViyBMAKU=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-bbdRja3lJyrqB1b1R5lOFXk5Yps=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r3.apk",
-        "version": "2.39-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r5.apk",
+        "version": "2.39-r5"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/sourcegraph-template.lock.json
+++ b/wolfi-images/sourcegraph-template.lock.json
@@ -52,60 +52,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1LbskMUECTvoctOm3XVAJBe6/+O8=",
+        "checksum": "Q15nzyxTcmhST9dTlB9BxV088pKJY=",
         "control": {
-          "checksum": "sha1-LbskMUECTvoctOm3XVAJBe6/+O8=",
-          "range": "bytes=704-1113"
+          "checksum": "sha1-5nzyxTcmhST9dTlB9BxV088pKJY=",
+          "range": "bytes=697-1107"
         },
         "data": {
-          "checksum": "sha256-U8ueoDdtkVXfQ3r8UKQU+ei8sdAH+ayEnmYIcGEM6S8=",
-          "range": "bytes=1114-267813"
+          "checksum": "sha256-i2qrjtws7OeqrKQP83nQo1vFwjqnO0QM3fSTvHHEKps=",
+          "range": "bytes=1108-267856"
         },
         "name": "ld-linux",
         "signature": {
-          "checksum": "sha1-snzU1ONYjrHMX4b2N117nm2p+9s=",
-          "range": "bytes=0-703"
+          "checksum": "sha1-nJTcI836Gt8XuqjMFUh2BBK4pP4=",
+          "range": "bytes=0-696"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r3.apk",
-        "version": "2.39-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r5.apk",
+        "version": "2.39-r5"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ovjsy4Uk7yfyamNBkynUnsHYFMU=",
+        "checksum": "Q1EuFMRKR/2atKFGKHjH/3vivHPEc=",
         "control": {
-          "checksum": "sha1-ovjsy4Uk7yfyamNBkynUnsHYFMU=",
-          "range": "bytes=701-1059"
+          "checksum": "sha1-EuFMRKR/2atKFGKHjH/3vivHPEc=",
+          "range": "bytes=699-1059"
         },
         "data": {
-          "checksum": "sha256-NedZsq170zk14TU+FxyLtc3Dr0vz/fmDP6LbmTqdtF8=",
-          "range": "bytes=1060-408273"
+          "checksum": "sha256-QDrcE6gPZ7R2/02ORkq8ZiVIGQDOwVQ07QetxKwG2jE=",
+          "range": "bytes=1060-408316"
         },
         "name": "glibc-locale-posix",
         "signature": {
-          "checksum": "sha1-G9qkyU9BXJISxwkeJE5Cz/n/H0k=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-hRz3Fq86p+IW4pWkZRP5kxsJFns=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r3.apk",
-        "version": "2.39-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r5.apk",
+        "version": "2.39-r5"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1+bVOClqbAOmgA1y9Q+GYJhEfuJs=",
+        "checksum": "Q19hiFVzu+AzUM0onmSNjApSBdvTw=",
         "control": {
-          "checksum": "sha1-+bVOClqbAOmgA1y9Q+GYJhEfuJs=",
-          "range": "bytes=700-1326"
+          "checksum": "sha1-9hiFVzu+AzUM0onmSNjApSBdvTw=",
+          "range": "bytes=694-1321"
         },
         "data": {
-          "checksum": "sha256-59plMSMECX3LWvyWsiLvadlwbdU3qopW0jRvBCyMGBM=",
-          "range": "bytes=1327-5861479"
+          "checksum": "sha256-eDetP73vFbPoIKaaYcLDZ89dOGzpY4xRBw75zN0Odpg=",
+          "range": "bytes=1322-5861522"
         },
         "name": "glibc",
         "signature": {
-          "checksum": "sha1-NZX+6hpoAYIpCd9O1VsViZI3MM0=",
-          "range": "bytes=0-699"
+          "checksum": "sha1-n8l9a4cNG2heaH82Un+dqHmdqRI=",
+          "range": "bytes=0-693"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r3.apk",
-        "version": "2.39-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r5.apk",
+        "version": "2.39-r5"
       },
       {
         "architecture": "x86_64",
@@ -318,22 +318,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1GG/Qe/wJbfaSQh2/E66qsSZ1d14=",
+        "checksum": "Q1GynPQjsrxTFW54tdQAqopiWsMuo=",
         "control": {
-          "checksum": "sha1-GG/Qe/wJbfaSQh2/E66qsSZ1d14=",
-          "range": "bytes=693-1065"
+          "checksum": "sha1-GynPQjsrxTFW54tdQAqopiWsMuo=",
+          "range": "bytes=697-1068"
         },
         "data": {
-          "checksum": "sha256-83L93TpxngARX3OA5Mm8MzkKPoqcoX6BX4/rslD+ND0=",
-          "range": "bytes=1066-251841"
+          "checksum": "sha256-cFyZH6WiNgbnz+zovA9EJB8aHO70Ao8TIH7052O/w1M=",
+          "range": "bytes=1069-251882"
         },
         "name": "libnghttp2-14",
         "signature": {
-          "checksum": "sha1-nERTCwywhPhwFIvRVZFNWHvzJXk=",
-          "range": "bytes=0-692"
+          "checksum": "sha1-o2sTmr6y1CBY9otWZAKu01XAbM8=",
+          "range": "bytes=0-696"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.61.0-r1.apk",
-        "version": "1.61.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.62.0-r0.apk",
+        "version": "1.62.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -413,41 +413,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1rmRRDukjyxrZKFy/2htPJpXlv6c=",
+        "checksum": "Q1bkh6LBvJiAE8yoq/+3XyeLRcIDE=",
         "control": {
-          "checksum": "sha1-rmRRDukjyxrZKFy/2htPJpXlv6c=",
-          "range": "bytes=699-1169"
+          "checksum": "sha1-bkh6LBvJiAE8yoq/+3XyeLRcIDE=",
+          "range": "bytes=700-1171"
         },
         "data": {
-          "checksum": "sha256-R81rAn3Y5uN4AbPY2STKyJQFy9AlA8AsQBoi6dbaAUA=",
-          "range": "bytes=1170-2556940"
+          "checksum": "sha256-fK9ZYBCiUycuwXY2OUJPlo4VO00LgqbMjSBO0CNMEok=",
+          "range": "bytes=1172-2582013"
         },
         "name": "nghttp2",
         "signature": {
-          "checksum": "sha1-EVy/a8/HRmt7vkLWYZfPCgtTzvE=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-ubcn/WnvFEPpkHx9nfAlqzYVN1o=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.61.0-r1.apk",
-        "version": "1.61.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.62.0-r0.apk",
+        "version": "1.62.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1dKyxN+ghQa6wAlVdT/IeTI/kUCI=",
+        "checksum": "Q1yOG4UBYkzOYPo4RZgfhIm6Mh0sU=",
         "control": {
-          "checksum": "sha1-dKyxN+ghQa6wAlVdT/IeTI/kUCI=",
-          "range": "bytes=699-1067"
+          "checksum": "sha1-yOG4UBYkzOYPo4RZgfhIm6Mh0sU=",
+          "range": "bytes=704-1070"
         },
         "data": {
-          "checksum": "sha256-X5FGVjy9TFT+NbfOA0lbV3pnLHSmqrDGz4BKIeYVBeA=",
-          "range": "bytes=1068-631660"
+          "checksum": "sha256-74kS0GGdLRQfk5b0TynYIEqh6fCEEK7QHP7iNsWb9oE=",
+          "range": "bytes=1071-631901"
         },
         "name": "nghttp2-dev",
         "signature": {
-          "checksum": "sha1-vGUw/0Loh1AWFjrlxevxFU7IKT4=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-AUWNNntPboyRKLJbqFODeq2sX8g=",
+          "range": "bytes=0-703"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.61.0-r1.apk",
-        "version": "1.61.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.62.0-r0.apk",
+        "version": "1.62.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -546,22 +546,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1SX1piz1hZeqGnnSNsfZGhK54I8A=",
+        "checksum": "Q15i44FeGc8cU/Gs+AORIH16osoV8=",
         "control": {
-          "checksum": "sha1-SX1piz1hZeqGnnSNsfZGhK54I8A=",
-          "range": "bytes=699-1103"
+          "checksum": "sha1-5i44FeGc8cU/Gs+AORIH16osoV8=",
+          "range": "bytes=695-1098"
         },
         "data": {
-          "checksum": "sha256-VSxM5PIYwhIc/kJVmh0tsVqLpz68eYyOYyC4cxkP4nw=",
-          "range": "bytes=1104-21603"
+          "checksum": "sha256-72mWEdxOgFKdTQQJGfANOdejkvbhfTVsXD8yNzkwDKo=",
+          "range": "bytes=1099-21646"
         },
         "name": "libcrypt1",
         "signature": {
-          "checksum": "sha1-SRN+qFHoymUHf93USjCViyBMAKU=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-bbdRja3lJyrqB1b1R5lOFXk5Yps=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r3.apk",
-        "version": "2.39-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r5.apk",
+        "version": "2.39-r5"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/symbols.lock.json
+++ b/wolfi-images/symbols.lock.json
@@ -52,60 +52,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1LbskMUECTvoctOm3XVAJBe6/+O8=",
+        "checksum": "Q15nzyxTcmhST9dTlB9BxV088pKJY=",
         "control": {
-          "checksum": "sha1-LbskMUECTvoctOm3XVAJBe6/+O8=",
-          "range": "bytes=704-1113"
+          "checksum": "sha1-5nzyxTcmhST9dTlB9BxV088pKJY=",
+          "range": "bytes=697-1107"
         },
         "data": {
-          "checksum": "sha256-U8ueoDdtkVXfQ3r8UKQU+ei8sdAH+ayEnmYIcGEM6S8=",
-          "range": "bytes=1114-267813"
+          "checksum": "sha256-i2qrjtws7OeqrKQP83nQo1vFwjqnO0QM3fSTvHHEKps=",
+          "range": "bytes=1108-267856"
         },
         "name": "ld-linux",
         "signature": {
-          "checksum": "sha1-snzU1ONYjrHMX4b2N117nm2p+9s=",
-          "range": "bytes=0-703"
+          "checksum": "sha1-nJTcI836Gt8XuqjMFUh2BBK4pP4=",
+          "range": "bytes=0-696"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r3.apk",
-        "version": "2.39-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r5.apk",
+        "version": "2.39-r5"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ovjsy4Uk7yfyamNBkynUnsHYFMU=",
+        "checksum": "Q1EuFMRKR/2atKFGKHjH/3vivHPEc=",
         "control": {
-          "checksum": "sha1-ovjsy4Uk7yfyamNBkynUnsHYFMU=",
-          "range": "bytes=701-1059"
+          "checksum": "sha1-EuFMRKR/2atKFGKHjH/3vivHPEc=",
+          "range": "bytes=699-1059"
         },
         "data": {
-          "checksum": "sha256-NedZsq170zk14TU+FxyLtc3Dr0vz/fmDP6LbmTqdtF8=",
-          "range": "bytes=1060-408273"
+          "checksum": "sha256-QDrcE6gPZ7R2/02ORkq8ZiVIGQDOwVQ07QetxKwG2jE=",
+          "range": "bytes=1060-408316"
         },
         "name": "glibc-locale-posix",
         "signature": {
-          "checksum": "sha1-G9qkyU9BXJISxwkeJE5Cz/n/H0k=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-hRz3Fq86p+IW4pWkZRP5kxsJFns=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r3.apk",
-        "version": "2.39-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r5.apk",
+        "version": "2.39-r5"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1+bVOClqbAOmgA1y9Q+GYJhEfuJs=",
+        "checksum": "Q19hiFVzu+AzUM0onmSNjApSBdvTw=",
         "control": {
-          "checksum": "sha1-+bVOClqbAOmgA1y9Q+GYJhEfuJs=",
-          "range": "bytes=700-1326"
+          "checksum": "sha1-9hiFVzu+AzUM0onmSNjApSBdvTw=",
+          "range": "bytes=694-1321"
         },
         "data": {
-          "checksum": "sha256-59plMSMECX3LWvyWsiLvadlwbdU3qopW0jRvBCyMGBM=",
-          "range": "bytes=1327-5861479"
+          "checksum": "sha256-eDetP73vFbPoIKaaYcLDZ89dOGzpY4xRBw75zN0Odpg=",
+          "range": "bytes=1322-5861522"
         },
         "name": "glibc",
         "signature": {
-          "checksum": "sha1-NZX+6hpoAYIpCd9O1VsViZI3MM0=",
-          "range": "bytes=0-699"
+          "checksum": "sha1-n8l9a4cNG2heaH82Un+dqHmdqRI=",
+          "range": "bytes=0-693"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r3.apk",
-        "version": "2.39-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r5.apk",
+        "version": "2.39-r5"
       },
       {
         "architecture": "x86_64",
@@ -318,22 +318,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1GG/Qe/wJbfaSQh2/E66qsSZ1d14=",
+        "checksum": "Q1GynPQjsrxTFW54tdQAqopiWsMuo=",
         "control": {
-          "checksum": "sha1-GG/Qe/wJbfaSQh2/E66qsSZ1d14=",
-          "range": "bytes=693-1065"
+          "checksum": "sha1-GynPQjsrxTFW54tdQAqopiWsMuo=",
+          "range": "bytes=697-1068"
         },
         "data": {
-          "checksum": "sha256-83L93TpxngARX3OA5Mm8MzkKPoqcoX6BX4/rslD+ND0=",
-          "range": "bytes=1066-251841"
+          "checksum": "sha256-cFyZH6WiNgbnz+zovA9EJB8aHO70Ao8TIH7052O/w1M=",
+          "range": "bytes=1069-251882"
         },
         "name": "libnghttp2-14",
         "signature": {
-          "checksum": "sha1-nERTCwywhPhwFIvRVZFNWHvzJXk=",
-          "range": "bytes=0-692"
+          "checksum": "sha1-o2sTmr6y1CBY9otWZAKu01XAbM8=",
+          "range": "bytes=0-696"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.61.0-r1.apk",
-        "version": "1.61.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.62.0-r0.apk",
+        "version": "1.62.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -413,41 +413,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1rmRRDukjyxrZKFy/2htPJpXlv6c=",
+        "checksum": "Q1bkh6LBvJiAE8yoq/+3XyeLRcIDE=",
         "control": {
-          "checksum": "sha1-rmRRDukjyxrZKFy/2htPJpXlv6c=",
-          "range": "bytes=699-1169"
+          "checksum": "sha1-bkh6LBvJiAE8yoq/+3XyeLRcIDE=",
+          "range": "bytes=700-1171"
         },
         "data": {
-          "checksum": "sha256-R81rAn3Y5uN4AbPY2STKyJQFy9AlA8AsQBoi6dbaAUA=",
-          "range": "bytes=1170-2556940"
+          "checksum": "sha256-fK9ZYBCiUycuwXY2OUJPlo4VO00LgqbMjSBO0CNMEok=",
+          "range": "bytes=1172-2582013"
         },
         "name": "nghttp2",
         "signature": {
-          "checksum": "sha1-EVy/a8/HRmt7vkLWYZfPCgtTzvE=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-ubcn/WnvFEPpkHx9nfAlqzYVN1o=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.61.0-r1.apk",
-        "version": "1.61.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.62.0-r0.apk",
+        "version": "1.62.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1dKyxN+ghQa6wAlVdT/IeTI/kUCI=",
+        "checksum": "Q1yOG4UBYkzOYPo4RZgfhIm6Mh0sU=",
         "control": {
-          "checksum": "sha1-dKyxN+ghQa6wAlVdT/IeTI/kUCI=",
-          "range": "bytes=699-1067"
+          "checksum": "sha1-yOG4UBYkzOYPo4RZgfhIm6Mh0sU=",
+          "range": "bytes=704-1070"
         },
         "data": {
-          "checksum": "sha256-X5FGVjy9TFT+NbfOA0lbV3pnLHSmqrDGz4BKIeYVBeA=",
-          "range": "bytes=1068-631660"
+          "checksum": "sha256-74kS0GGdLRQfk5b0TynYIEqh6fCEEK7QHP7iNsWb9oE=",
+          "range": "bytes=1071-631901"
         },
         "name": "nghttp2-dev",
         "signature": {
-          "checksum": "sha1-vGUw/0Loh1AWFjrlxevxFU7IKT4=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-AUWNNntPboyRKLJbqFODeq2sX8g=",
+          "range": "bytes=0-703"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.61.0-r1.apk",
-        "version": "1.61.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.62.0-r0.apk",
+        "version": "1.62.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -546,22 +546,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1SX1piz1hZeqGnnSNsfZGhK54I8A=",
+        "checksum": "Q15i44FeGc8cU/Gs+AORIH16osoV8=",
         "control": {
-          "checksum": "sha1-SX1piz1hZeqGnnSNsfZGhK54I8A=",
-          "range": "bytes=699-1103"
+          "checksum": "sha1-5i44FeGc8cU/Gs+AORIH16osoV8=",
+          "range": "bytes=695-1098"
         },
         "data": {
-          "checksum": "sha256-VSxM5PIYwhIc/kJVmh0tsVqLpz68eYyOYyC4cxkP4nw=",
-          "range": "bytes=1104-21603"
+          "checksum": "sha256-72mWEdxOgFKdTQQJGfANOdejkvbhfTVsXD8yNzkwDKo=",
+          "range": "bytes=1099-21646"
         },
         "name": "libcrypt1",
         "signature": {
-          "checksum": "sha1-SRN+qFHoymUHf93USjCViyBMAKU=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-bbdRja3lJyrqB1b1R5lOFXk5Yps=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r3.apk",
-        "version": "2.39-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r5.apk",
+        "version": "2.39-r5"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/syntax-highlighter.lock.json
+++ b/wolfi-images/syntax-highlighter.lock.json
@@ -52,60 +52,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1LbskMUECTvoctOm3XVAJBe6/+O8=",
+        "checksum": "Q15nzyxTcmhST9dTlB9BxV088pKJY=",
         "control": {
-          "checksum": "sha1-LbskMUECTvoctOm3XVAJBe6/+O8=",
-          "range": "bytes=704-1113"
+          "checksum": "sha1-5nzyxTcmhST9dTlB9BxV088pKJY=",
+          "range": "bytes=697-1107"
         },
         "data": {
-          "checksum": "sha256-U8ueoDdtkVXfQ3r8UKQU+ei8sdAH+ayEnmYIcGEM6S8=",
-          "range": "bytes=1114-267813"
+          "checksum": "sha256-i2qrjtws7OeqrKQP83nQo1vFwjqnO0QM3fSTvHHEKps=",
+          "range": "bytes=1108-267856"
         },
         "name": "ld-linux",
         "signature": {
-          "checksum": "sha1-snzU1ONYjrHMX4b2N117nm2p+9s=",
-          "range": "bytes=0-703"
+          "checksum": "sha1-nJTcI836Gt8XuqjMFUh2BBK4pP4=",
+          "range": "bytes=0-696"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r3.apk",
-        "version": "2.39-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r5.apk",
+        "version": "2.39-r5"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ovjsy4Uk7yfyamNBkynUnsHYFMU=",
+        "checksum": "Q1EuFMRKR/2atKFGKHjH/3vivHPEc=",
         "control": {
-          "checksum": "sha1-ovjsy4Uk7yfyamNBkynUnsHYFMU=",
-          "range": "bytes=701-1059"
+          "checksum": "sha1-EuFMRKR/2atKFGKHjH/3vivHPEc=",
+          "range": "bytes=699-1059"
         },
         "data": {
-          "checksum": "sha256-NedZsq170zk14TU+FxyLtc3Dr0vz/fmDP6LbmTqdtF8=",
-          "range": "bytes=1060-408273"
+          "checksum": "sha256-QDrcE6gPZ7R2/02ORkq8ZiVIGQDOwVQ07QetxKwG2jE=",
+          "range": "bytes=1060-408316"
         },
         "name": "glibc-locale-posix",
         "signature": {
-          "checksum": "sha1-G9qkyU9BXJISxwkeJE5Cz/n/H0k=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-hRz3Fq86p+IW4pWkZRP5kxsJFns=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r3.apk",
-        "version": "2.39-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r5.apk",
+        "version": "2.39-r5"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1+bVOClqbAOmgA1y9Q+GYJhEfuJs=",
+        "checksum": "Q19hiFVzu+AzUM0onmSNjApSBdvTw=",
         "control": {
-          "checksum": "sha1-+bVOClqbAOmgA1y9Q+GYJhEfuJs=",
-          "range": "bytes=700-1326"
+          "checksum": "sha1-9hiFVzu+AzUM0onmSNjApSBdvTw=",
+          "range": "bytes=694-1321"
         },
         "data": {
-          "checksum": "sha256-59plMSMECX3LWvyWsiLvadlwbdU3qopW0jRvBCyMGBM=",
-          "range": "bytes=1327-5861479"
+          "checksum": "sha256-eDetP73vFbPoIKaaYcLDZ89dOGzpY4xRBw75zN0Odpg=",
+          "range": "bytes=1322-5861522"
         },
         "name": "glibc",
         "signature": {
-          "checksum": "sha1-NZX+6hpoAYIpCd9O1VsViZI3MM0=",
-          "range": "bytes=0-699"
+          "checksum": "sha1-n8l9a4cNG2heaH82Un+dqHmdqRI=",
+          "range": "bytes=0-693"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r3.apk",
-        "version": "2.39-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r5.apk",
+        "version": "2.39-r5"
       },
       {
         "architecture": "x86_64",
@@ -318,22 +318,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1GG/Qe/wJbfaSQh2/E66qsSZ1d14=",
+        "checksum": "Q1GynPQjsrxTFW54tdQAqopiWsMuo=",
         "control": {
-          "checksum": "sha1-GG/Qe/wJbfaSQh2/E66qsSZ1d14=",
-          "range": "bytes=693-1065"
+          "checksum": "sha1-GynPQjsrxTFW54tdQAqopiWsMuo=",
+          "range": "bytes=697-1068"
         },
         "data": {
-          "checksum": "sha256-83L93TpxngARX3OA5Mm8MzkKPoqcoX6BX4/rslD+ND0=",
-          "range": "bytes=1066-251841"
+          "checksum": "sha256-cFyZH6WiNgbnz+zovA9EJB8aHO70Ao8TIH7052O/w1M=",
+          "range": "bytes=1069-251882"
         },
         "name": "libnghttp2-14",
         "signature": {
-          "checksum": "sha1-nERTCwywhPhwFIvRVZFNWHvzJXk=",
-          "range": "bytes=0-692"
+          "checksum": "sha1-o2sTmr6y1CBY9otWZAKu01XAbM8=",
+          "range": "bytes=0-696"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.61.0-r1.apk",
-        "version": "1.61.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.62.0-r0.apk",
+        "version": "1.62.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -413,41 +413,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1rmRRDukjyxrZKFy/2htPJpXlv6c=",
+        "checksum": "Q1bkh6LBvJiAE8yoq/+3XyeLRcIDE=",
         "control": {
-          "checksum": "sha1-rmRRDukjyxrZKFy/2htPJpXlv6c=",
-          "range": "bytes=699-1169"
+          "checksum": "sha1-bkh6LBvJiAE8yoq/+3XyeLRcIDE=",
+          "range": "bytes=700-1171"
         },
         "data": {
-          "checksum": "sha256-R81rAn3Y5uN4AbPY2STKyJQFy9AlA8AsQBoi6dbaAUA=",
-          "range": "bytes=1170-2556940"
+          "checksum": "sha256-fK9ZYBCiUycuwXY2OUJPlo4VO00LgqbMjSBO0CNMEok=",
+          "range": "bytes=1172-2582013"
         },
         "name": "nghttp2",
         "signature": {
-          "checksum": "sha1-EVy/a8/HRmt7vkLWYZfPCgtTzvE=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-ubcn/WnvFEPpkHx9nfAlqzYVN1o=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.61.0-r1.apk",
-        "version": "1.61.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.62.0-r0.apk",
+        "version": "1.62.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1dKyxN+ghQa6wAlVdT/IeTI/kUCI=",
+        "checksum": "Q1yOG4UBYkzOYPo4RZgfhIm6Mh0sU=",
         "control": {
-          "checksum": "sha1-dKyxN+ghQa6wAlVdT/IeTI/kUCI=",
-          "range": "bytes=699-1067"
+          "checksum": "sha1-yOG4UBYkzOYPo4RZgfhIm6Mh0sU=",
+          "range": "bytes=704-1070"
         },
         "data": {
-          "checksum": "sha256-X5FGVjy9TFT+NbfOA0lbV3pnLHSmqrDGz4BKIeYVBeA=",
-          "range": "bytes=1068-631660"
+          "checksum": "sha256-74kS0GGdLRQfk5b0TynYIEqh6fCEEK7QHP7iNsWb9oE=",
+          "range": "bytes=1071-631901"
         },
         "name": "nghttp2-dev",
         "signature": {
-          "checksum": "sha1-vGUw/0Loh1AWFjrlxevxFU7IKT4=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-AUWNNntPboyRKLJbqFODeq2sX8g=",
+          "range": "bytes=0-703"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.61.0-r1.apk",
-        "version": "1.61.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.62.0-r0.apk",
+        "version": "1.62.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -546,22 +546,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1SX1piz1hZeqGnnSNsfZGhK54I8A=",
+        "checksum": "Q15i44FeGc8cU/Gs+AORIH16osoV8=",
         "control": {
-          "checksum": "sha1-SX1piz1hZeqGnnSNsfZGhK54I8A=",
-          "range": "bytes=699-1103"
+          "checksum": "sha1-5i44FeGc8cU/Gs+AORIH16osoV8=",
+          "range": "bytes=695-1098"
         },
         "data": {
-          "checksum": "sha256-VSxM5PIYwhIc/kJVmh0tsVqLpz68eYyOYyC4cxkP4nw=",
-          "range": "bytes=1104-21603"
+          "checksum": "sha256-72mWEdxOgFKdTQQJGfANOdejkvbhfTVsXD8yNzkwDKo=",
+          "range": "bytes=1099-21646"
         },
         "name": "libcrypt1",
         "signature": {
-          "checksum": "sha1-SRN+qFHoymUHf93USjCViyBMAKU=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-bbdRja3lJyrqB1b1R5lOFXk5Yps=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r3.apk",
-        "version": "2.39-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r5.apk",
+        "version": "2.39-r5"
       },
       {
         "architecture": "x86_64",


### PR DESCRIPTION
Automatically generated PR to update package lockfiles for Sourcegraph base images.

Built from Buildkite run [#274474](https://buildkite.com/sourcegraph/sourcegraph/builds/274474).
## Test Plan
- CI build verifies image functionality