### PR TITLE
msp: Expose contract mock for tests

### DIFF
--- a/lib/managedservicesplatform/runtime/contract/BUILD.bazel
+++ b/lib/managedservicesplatform/runtime/contract/BUILD.bazel
@@ -39,11 +39,11 @@ go_test(
     embed = [":contract"],
     deps = [
         "//lib/errors",
+        "//lib/managedservicesplatform/runtime/contract/mock",
         "//lib/pointers",
         "@com_github_hexops_autogold_v2//:autogold",
         "@com_github_sourcegraph_log//logtest",
         "@com_github_stretchr_testify//assert",
-        "@com_github_stretchr_testify//require",
         "@io_opentelemetry_go_otel_sdk//trace",
     ],
 )

--- a/lib/managedservicesplatform/runtime/contract/contract_test.go
+++ b/lib/managedservicesplatform/runtime/contract/contract_test.go
@@ -4,30 +4,24 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
-	"github.com/sourcegraph/log/logtest"
-
-	"github.com/sourcegraph/sourcegraph/lib/managedservicesplatform/runtime/contract"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+	mock "github.com/sourcegraph/sourcegraph/lib/managedservicesplatform/runtime/contract/mock"
 )
-
-type mockServiceMetadata struct{}
-
-func (m mockServiceMetadata) Name() string    { return "mock-name" }
-func (m mockServiceMetadata) Version() string { return "mock-version" }
 
 func TestNewContract(t *testing.T) {
 	t.Run("sanity check", func(t *testing.T) {
-		e, err := contract.ParseEnv([]string{"MSP=true"})
-		require.NoError(t, err)
-
-		c := contract.New(logtest.Scoped(t), mockServiceMetadata{}, e)
+		c, err := mock.NewMockContract(t, mock.MockServiceMetadata{}, "MSP=true")
+		if errors.Is(err, mock.MockError{}) {
+			t.Fatal(err)
+		}
 		assert.NotZero(t, c)
 		assert.True(t, c.MSP)
 
+		// If our error is not a Mockerror, then it could be an environment validation error
 		// Expected to error, as there are missing required env vars.
-		err = e.Validate()
-		assert.Error(t, err)
+		envErr := err
+		assert.Error(t, envErr)
 	})
 
 	// TODO: Add more validation tests

--- a/lib/managedservicesplatform/runtime/contract/mock/contract_mock.go
+++ b/lib/managedservicesplatform/runtime/contract/mock/contract_mock.go
@@ -1,0 +1,37 @@
+package mock
+
+import (
+	"cmp"
+	"testing"
+
+	"github.com/sourcegraph/log/logtest"
+
+	"github.com/sourcegraph/sourcegraph/lib/managedservicesplatform/runtime/contract"
+)
+
+type MockServiceMetadata struct {
+	name    string
+	version string
+}
+
+type MockError struct {
+	error
+}
+
+func (m MockServiceMetadata) Name() string    { return cmp.Or(m.name, "mock-name") }
+func (m MockServiceMetadata) Version() string { return cmp.Or(m.version, "mock-version") }
+
+// NewMockContract returns a new contract instance from the given env. If there is an error parsing the given environment
+// a MockError is returned that contains the error.
+//
+// Otherwise a new contract instance is returned as well as the environment validation result from `env.Validate()`
+func NewMockContract(t *testing.T, mockServiceMeta contract.ServiceMetadataProvider, env ...string) (*contract.Contract, error) {
+	t.Helper()
+	e, err := contract.ParseEnv(env)
+	if err != nil {
+		return nil, MockError{err}
+	}
+
+	c := contract.New(logtest.Scoped(t), mockServiceMeta, e)
+	return &c, e.Validate()
+}

--- a/lib/managedservicesplatform/runtime/contract/mock/contract_mock.go
+++ b/lib/managedservicesplatform/runtime/contract/mock/contract_mock.go
@@ -9,7 +9,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/managedservicesplatform/runtime/contract"
 )
 
-type MockServiceMetadata struct {
+type ServiceMetadata struct {
 	name    string
 	version string
 }
@@ -18,14 +18,14 @@ type MockError struct {
 	error
 }
 
-func (m MockServiceMetadata) Name() string    { return cmp.Or(m.name, "mock-name") }
-func (m MockServiceMetadata) Version() string { return cmp.Or(m.version, "mock-version") }
+func (s ServiceMetadata) Name() string    { return cmp.Or(s.name, "mock-name") }
+func (s ServiceMetadata) Version() string { return cmp.Or(s.version, "mock-version") }
 
 // NewMockContract returns a new contract instance from the given env. If there is an error parsing the given environment
 // a MockError is returned that contains the error.
 //
 // Otherwise a new contract instance is returned as well as the environment validation result from `env.Validate()`
-func NewMockContract(t *testing.T, mockServiceMeta contract.ServiceMetadataProvider, env ...string) (*contract.Contract, error) {
+func NewContract(t *testing.T, mockServiceMeta contract.ServiceMetadataProvider, env ...string) (*contract.Contract, error) {
 	t.Helper()
 	e, err := contract.ParseEnv(env)
 	if err != nil {


### PR DESCRIPTION
I needed to provide a dummy contract and saw that MSP already had this available but it was private.

This PR makes it public while trying to retain it's original intent.

## Test plan
* Tested in spirit here https://github.com/sourcegraph/repoferee/pull/14/commits/5e649af3f47c3300ae7bef6f619ee537523415cd
* `bazel test //lib/managedservicesplatform/runtime/...`
* CI