### PR TITLE
fix: update search timeout docs

### DIFF
--- a/client/branded/src/search-ui/results/sidebar/SearchReference.tsx
+++ b/client/branded/src/search-ui/results/sidebar/SearchReference.tsx
@@ -281,7 +281,7 @@ See [language definition](https://sourcegraph.com/docs/code_search/reference/lan
         ...createQueryExampleFromString('{golang-duration-value}'),
         field: FilterType.timeout,
         description:
-            'Customizes the timeout for searches. The value of the parameter is a string that can be parsed by the [Go time package’s `ParseDuration`](https://golang.org/pkg/time/#ParseDuration) (e.g. 10s, 100ms). By default, the timeout is set to 10 seconds, and the search will optimize for returning results as soon as possible. The timeout value cannot be set longer than 1 minute. When provided, the search is given the full timeout to complete.',
+            'Customizes the timeout for searches. The value of the parameter is a string that can be parsed by the [Go time package’s `ParseDuration`](https://golang.org/pkg/time/#ParseDuration) (e.g. 10s, 100ms). By default, the timeout is set to 1 minute, and the search will optimize for returning results as soon as possible. The value of [`search.limits.maxTimeoutSeconds`](https://sourcegraph.com/docs/code-search/types/exhaustive#timeouts) can be configured by site admins. When provided, the search is given the full timeout to complete.',
         examples: ['repo:^github.com/sourcegraph timeout:15s func count:10000'],
     },
     {


### PR DESCRIPTION
In https://github.com/sourcegraph/sourcegraph/pull/13448 we introduced a configurable timeout. This PR updates a piece of documentation accordingly.

## Test plan

Documentation update. Should be covered by existing CI.