### PR TITLE
Cody Gateway: hacky autocomplete gpt-4o support

### DIFF
--- a/cmd/cody-gateway/internal/httpapi/completions/openai.go
+++ b/cmd/cody-gateway/internal/httpapi/completions/openai.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/cody-gateway/shared/config"
 	"github.com/sourcegraph/sourcegraph/internal/completions/client/openai"
-	"github.com/sourcegraph/sourcegraph/lib/errors"
 
 	"github.com/sourcegraph/sourcegraph/cmd/cody-gateway/internal/events"
 	"github.com/sourcegraph/sourcegraph/cmd/cody-gateway/internal/limiter"
@@ -122,9 +121,9 @@ func (*OpenAIHandlerMethods) getAPIURLByFeature(feature codygateway.Feature) str
 }
 
 func (*OpenAIHandlerMethods) validateRequest(_ context.Context, _ log.Logger, feature codygateway.Feature, _ openaiRequest) error {
-	if feature == codygateway.FeatureCodeCompletions {
-		return errors.Newf("feature %q is currently not supported for OpenAI", feature)
-	}
+	// if feature == codygateway.FeatureCodeCompletions {
+	// 	return errors.Newf("feature %q is currently not supported for OpenAI", feature)
+	// }
 	return nil
 }
 

--- a/cmd/cody-gateway/internal/httpapi/completions/upstream.go
+++ b/cmd/cody-gateway/internal/httpapi/completions/upstream.go
@@ -273,6 +273,7 @@ func makeUpstreamHandler[ReqT UpstreamRequest](
 		// Re-marshal the payload for upstream to unset metadata and remove any properties
 		// not known to us.
 		upstreamPayload, err := json.Marshal(body)
+		fmt.Println("upstreamPayload", string(upstreamPayload))
 		if err != nil {
 			response.JSONError(logger, w, http.StatusInternalServerError, errors.Wrap(err, "failed to marshal request body"))
 			return
@@ -280,6 +281,7 @@ func makeUpstreamHandler[ReqT UpstreamRequest](
 
 		// Create a new request to send upstream, making sure we retain the same context.
 		upstreamURL := methods.getAPIURLByFeature(feature)
+		fmt.Println("upstreamURL", upstreamURL)
 		req, err := http.NewRequestWithContext(ctx, http.MethodPost, upstreamURL, bytes.NewReader(upstreamPayload))
 		if err != nil {
 			response.JSONError(logger, w, http.StatusInternalServerError, errors.Wrap(err, "failed to create request"))

--- a/cmd/frontend/internal/dotcom/productsubscription/codygateway_dotcom_user.go
+++ b/cmd/frontend/internal/dotcom/productsubscription/codygateway_dotcom_user.go
@@ -388,6 +388,7 @@ func allowedModels(scope types.CompletionsFeature, isProUser bool) []string {
 			"anthropic/claude-instant-1.2-cyan",
 			"anthropic/claude-instant-1.2",
 			"fireworks/starcoder",
+			"openai/gpt-4o",
 			"fireworks/" + fireworks.Llama213bCode,
 			"fireworks/" + fireworks.StarcoderTwo15b,
 			"fireworks/" + fireworks.StarcoderTwo7b,

--- a/cmd/frontend/internal/httpapi/completions/codecompletion.go
+++ b/cmd/frontend/internal/httpapi/completions/codecompletion.go
@@ -60,6 +60,7 @@ func allowedCustomModel(model string) string {
 		"fireworks/" + fireworks.Mixtral8x7bFineTunedModel,
 		"anthropic/claude-instant-1.2",
 		"anthropic/claude-3-haiku-20240307",
+		"openai/gpt-4o",
 		// Deprecated model identifiers
 		"anthropic/claude-instant-v1",
 		"anthropic/claude-instant-1",

--- a/cmd/frontend/internal/httpapi/completions/handler.go
+++ b/cmd/frontend/internal/httpapi/completions/handler.go
@@ -113,6 +113,7 @@ func newCompletionsHandler(
 		// TODO: Model is not configurable but technically allowed in the request body right now.
 		var err error
 		requestParams.Model, err = getModel(ctx, requestParams, completionsConfig)
+		fmt.Println("requestParams.Messages", requestParams.Messages)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return


### PR DESCRIPTION
Hacky GPT-4o autocomplete support.

## Test plan

1. Start Cody Gateway locally.
2. Use this branch to test GPT-4o powered autocomplete https://github.com/sourcegraph/cody/pull/4182