### PR TITLE
Svelte: Fix global header navigation layers

### DIFF
--- a/client/web-sveltekit/src/lib/navigation/GlobalHeader.svelte
+++ b/client/web-sveltekit/src/lib/navigation/GlobalHeader.svelte
@@ -39,7 +39,7 @@
     $: withCustomContent = $navigationModeStore === NavigationMode.WithCustomContent
 </script>
 
-<header class="root">
+<header class="root" data-global-header>
     {#if isSidebarNavigationOpen}
         <GlobalSidebarNavigation onClose={() => (isSidebarNavigationOpen = false)} />
     {/if}
@@ -149,6 +149,11 @@
         display: flex;
         align-self: stretch;
         min-width: 0;
+
+        // Ensure that any content inside navigation portal block
+        // can't overlap any static content like sidebar navigation
+        // in the global header layout.
+        isolation: isolate;
 
         &-list {
             display: flex;

--- a/client/web-sveltekit/src/routes/+layout.svelte
+++ b/client/web-sveltekit/src/routes/+layout.svelte
@@ -112,7 +112,15 @@
         flex-direction: column;
     }
 
+    // Ensure that any content in the global header has
+    // more layout priority over any content in the content (main) area
+    :global([data-global-header]) {
+        z-index: 1;
+        isolation: isolate;
+    }
+
     main {
+        z-index: 0;
         isolation: isolate;
         flex: 1;
         display: flex;


### PR DESCRIPTION
Closes: https://github.com/sourcegraph/sourcegraph/issues/62174

This PR fixes the problem with z-indexes, ideally, we shouldn't think about this if we were using the Modal component for the sidebar navigation panel (Modal would render this outside of the common DOM tree and hence there was no problem with z-index) but since we don't have Modal at the moment I tuned stacking layers a bit to fix it. 

## Test plan
- Check any popover element in the global header navigation, and make sure there are no unexpected overlaps between sidebar navigation, search input, and the main content.

