### PR TITLE
sg/msp: add repo annotation to delivery pipeline

### DIFF
--- a/dev/managedservicesplatform/internal/resource/deliverypipeline/deliverypipeline.go
+++ b/dev/managedservicesplatform/internal/resource/deliverypipeline/deliverypipeline.go
@@ -36,6 +36,9 @@ type Config struct {
 	// TargetStages lists targets in the order they should appear in the pipeline.
 	TargetStages []Target
 
+	// Repository is the source repository for this pipeline.
+	Repository string
+
 	// Suspended prevents releases and rollouts from being created, rolled back,
 	// etc using this pipeline: https://cloud.google.com/deploy/docs/suspend-pipeline
 	Suspended bool
@@ -87,6 +90,10 @@ func New(scope constructs.Construct, id resourceid.ID, config Config) (*Output, 
 
 			SerialPipeline: &clouddeploydeliverypipeline.ClouddeployDeliveryPipelineSerialPipeline{
 				Stages: pointers.Ptr(newStages(config)),
+			},
+
+			Annotations: &map[string]*string{
+				"repository": pointers.Ptr(config.Repository),
 			},
 
 			DependsOn: pointers.Ptr(append(config.DependsOn, targetType)),

--- a/dev/managedservicesplatform/managedservicesplatform.go
+++ b/dev/managedservicesplatform/managedservicesplatform.go
@@ -121,6 +121,7 @@ func (r *Renderer) RenderEnvironment(
 		IAM:       *iamOutput,
 
 		Service:     svc.Service,
+		Repository:  svc.Build.Source.Repo,
 		Image:       svc.Build.Image,
 		Environment: env,
 

--- a/dev/managedservicesplatform/stacks/cloudrun/cloudrun.go
+++ b/dev/managedservicesplatform/stacks/cloudrun/cloudrun.go
@@ -66,6 +66,7 @@ type Variables struct {
 	IAM iam.CrossStackOutput
 
 	Service     spec.ServiceSpec
+	Repository  string
 	Image       string
 	Environment spec.EnvironmentSpec
 
@@ -427,6 +428,8 @@ func NewStack(stacks *stack.Set, vars Variables) (crossStackOutput *CrossStackOu
 			ExecutionSA:  vars.IAM.CloudDeployExecutionServiceAccount,
 
 			TargetStages: stageTargets,
+
+			Repository: vars.Repository,
 
 			Suspended: pointers.DerefZero(vars.RolloutPipeline.OriginalSpec.Suspended),
 


### PR DESCRIPTION
Adds the repository as an annotation to the delivery pipeline so that we can later query it e.g. from cloud-relay to include a link to the commit in the message we send to slack

I also tried adding annotations to the releases but unfortunately they don't get sent as part of the notification message

side note: the annotations support free-form text without the same limitations the labels have

part of CORE-36
## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
locally tested