### PR TITLE
feat/msp: do not use tfvars file outside of deploy-type 'subscription'

### DIFF
--- a/dev/managedservicesplatform/managedservicesplatform.go
+++ b/dev/managedservicesplatform/managedservicesplatform.go
@@ -111,7 +111,7 @@ func (r *Renderer) RenderEnvironment(
 		SecretVolumes:   env.SecretVolumes,
 		PreventDestroys: preventDestroys,
 
-		IsFinalStageOfRollout: rolloutPipeline != nil,
+		IsFinalStageOfRollout: rolloutPipeline.IsFinalStage(),
 	})
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create IAM stack")

--- a/dev/managedservicesplatform/spec/environment.go
+++ b/dev/managedservicesplatform/spec/environment.go
@@ -171,6 +171,10 @@ func (c EnvironmentCategory) Validate() error {
 	return nil
 }
 
+func (c EnvironmentCategory) IsProduction() bool {
+	return c == EnvironmentCategoryExternal || c == EnvironmentCategoryInternal
+}
+
 type EnvironmentDeployType string
 
 const (
@@ -178,10 +182,6 @@ const (
 	EnvironmentDeployTypeSubscription = "subscription"
 	EnvironmentDeployTypeRollout      = "rollout"
 )
-
-func (c EnvironmentCategory) IsProduction() bool {
-	return c == EnvironmentCategoryExternal || c == EnvironmentCategoryInternal
-}
 
 type EnvironmentDeploySpec struct {
 	// Type specifies the deployment method for the environment. There are
@@ -197,7 +197,12 @@ type EnvironmentDeploySpec struct {
 
 func (s EnvironmentDeploySpec) Validate() []error {
 	var errs []error
-	if s.Type == EnvironmentDeployTypeSubscription {
+	switch s.Type {
+	case EnvironmentDeployTypeManual:
+		if s.Subscription != nil {
+			errs = append(errs, errors.New("subscription deploy spec provided when type is manual"))
+		}
+	case EnvironmentDeployTypeSubscription:
 		if s.Manual != nil {
 			errs = append(errs, errors.New("manual deploy spec provided when type is subscription"))
 		} else if s.Subscription == nil {
@@ -205,39 +210,12 @@ func (s EnvironmentDeploySpec) Validate() []error {
 		} else if s.Subscription.Tag == "" {
 			errs = append(errs, errors.New("no tag in image subscription specified"))
 		}
-	} else if s.Type == EnvironmentDeployTypeManual {
-		if s.Subscription != nil {
-			errs = append(errs, errors.New("subscription deploy spec provided when type is manual"))
-		}
+	case EnvironmentDeployTypeRollout:
+		// no validation
+	default:
+		errs = append(errs, errors.Newf("invalid deploy type %q", s.Type))
 	}
 	return errs
-}
-
-// ResolveTag uses the deploy spec to resolve an appropriate tag for the environment.
-func (d EnvironmentDeploySpec) ResolveTag(repo string) (string, error) {
-	switch d.Type {
-	case EnvironmentDeployTypeManual:
-		if d.Manual == nil {
-			return "insiders", nil
-		}
-		return d.Manual.Tag, nil
-	case EnvironmentDeployTypeSubscription:
-		// we already validated in Validate(), hence it's fine to assume this won't panic
-		updater, err := imageupdater.New()
-		if err != nil {
-			return "", errors.Wrapf(err, "create image updater")
-		}
-		tagAndDigest, err := updater.ResolveTagAndDigest(repo, d.Subscription.Tag)
-		if err != nil {
-			return "", errors.Wrapf(err, "resolve digest for tag %q", "insiders")
-		}
-		return tagAndDigest, nil
-	case EnvironmentDeployTypeRollout:
-		// Enforce convention
-		return "insiders", nil
-	default:
-		return "", errors.Newf("unable to resolve tag for unknown deploy type %q", d.Type)
-	}
 }
 
 type EnvironmentDeployManualSpec struct {
@@ -245,10 +223,32 @@ type EnvironmentDeployManualSpec struct {
 	Tag string `yaml:"tag,omitempty"`
 }
 
+// GetTag returns the tag to deploy. If empty, defaults to "insiders".
+func (s *EnvironmentDeployManualSpec) GetTag() string {
+	if s == nil {
+		return "insiders"
+	}
+	return s.Tag
+}
+
 type EnvironmentDeployTypeSubscriptionSpec struct {
 	// Tag is the tag to subscribe to.
 	Tag string `yaml:"tag,omitempty"`
 	// TODO: In the future, we may support subscribing by semver constraints.
+}
+
+// ResolveTag fetches the latest digest for the target imageRepo and configured
+// subscription tag, and returns it.
+func (s EnvironmentDeployTypeSubscriptionSpec) ResolveTag(imageRepo string) (string, error) {
+	updater, err := imageupdater.New()
+	if err != nil {
+		return "", errors.Wrapf(err, "create image updater")
+	}
+	tagAndDigest, err := updater.ResolveTagAndDigest(imageRepo, s.Tag)
+	if err != nil {
+		return "", errors.Wrapf(err, "resolve digest for tag %q", "insiders")
+	}
+	return tagAndDigest, nil
 }
 
 type EnvironmentServiceSpec struct {

--- a/dev/managedservicesplatform/stacks/cloudrun/internal/builder/builder.go
+++ b/dev/managedservicesplatform/stacks/cloudrun/internal/builder/builder.go
@@ -17,8 +17,8 @@ type Variables struct {
 
 	// Image and ResolvedImageTag are used to declare the full image reference
 	// to deploy.
-	Image            string
-	ResolvedImageTag string
+	Image    string
+	ImageTag string
 	// GCPProjectID for all resources.
 	GCPProjectID string
 	// GCPRegion for all resources.

--- a/dev/managedservicesplatform/stacks/cloudrun/internal/builder/job/job.go
+++ b/dev/managedservicesplatform/stacks/cloudrun/internal/builder/job/job.go
@@ -138,7 +138,7 @@ func (b *jobBuilder) Build(stack cdktf.TerraformStack, vars builder.Variables) (
 				// Configuration for the single service container.
 				Containers: []*cloudrunv2job.CloudRunV2JobTemplateTemplateContainers{{
 					Name:  pointers.Ptr(vars.Service.ID),
-					Image: pointers.Ptr(fmt.Sprintf("%s:%s", vars.Image, vars.ResolvedImageTag)),
+					Image: pointers.Ptr(fmt.Sprintf("%s:%s", vars.Image, vars.ImageTag)),
 
 					Resources: &cloudrunv2job.CloudRunV2JobTemplateTemplateContainersResources{
 						Limits: &vars.ResourceLimits,

--- a/dev/managedservicesplatform/stacks/cloudrun/internal/builder/service/service.go
+++ b/dev/managedservicesplatform/stacks/cloudrun/internal/builder/service/service.go
@@ -192,7 +192,7 @@ func (b *serviceBuilder) Build(stack cdktf.TerraformStack, vars builder.Variable
 			// Configuration for the single service container.
 			Containers: []*cloudrunv2service.CloudRunV2ServiceTemplateContainers{{
 				Name:  pointers.Ptr(vars.Service.ID),
-				Image: pointers.Ptr(fmt.Sprintf("%s:%s", vars.Image, vars.ResolvedImageTag)),
+				Image: pointers.Ptr(fmt.Sprintf("%s:%s", vars.Image, vars.ImageTag)),
 
 				Resources: &cloudrunv2service.CloudRunV2ServiceTemplateContainersResources{
 					Limits: &vars.ResourceLimits,


### PR DESCRIPTION
Closes CORE-121

The dependency on the generated `tfvars` file is frustrating for first-time MSP setup because it currently requires `-stable=false` to update, and doesn't actually serve any purpose for deploy types other than `subscription` (which uses it to isolate image changes that happen on via GitHub actions). This makes it so that we don't generate, or depend on, the dynamic `tfvars` file unless you are using `subscription`.

I've also added a rollout spec configuration, `initialImageTag`, to make the initial tag we provision environments with configurable (as some services might not publish `insiders` images) - see the docstring.

## Test plan

Inspect output of `sg msp generate -all`