### PR TITLE
gitserver: Allow multiple ranges to be passed to Commits

### DIFF
--- a/cmd/frontend/graphqlbackend/git_commits.go
+++ b/cmd/frontend/graphqlbackend/git_commits.go
@@ -1,6 +1,7 @@
 package graphqlbackend
 
 import (
+	"cmp"
 	"context"
 	"strconv"
 	"sync"
@@ -89,7 +90,7 @@ func (r *gitCommitConnectionResolver) compute(ctx context.Context) ([]*gitdomain
 		}
 
 		return r.gitserverClient.Commits(ctx, r.repo.RepoName(), gitserver.CommitsOptions{
-			Range:        r.revisionRange,
+			Ranges:       []string{cmp.Or(r.revisionRange, "HEAD")},
 			N:            uint(n),
 			MessageQuery: pointers.DerefZero(r.query),
 			Author:       pointers.DerefZero(r.author),

--- a/cmd/frontend/graphqlbackend/repository_comparison_test.go
+++ b/cmd/frontend/graphqlbackend/repository_comparison_test.go
@@ -169,11 +169,9 @@ func TestRepositoryComparison(t *testing.T) {
 
 		mockGSClient := gitserver.NewMockClient()
 		mockGSClient.CommitsFunc.SetDefaultHook(func(_ context.Context, _ api.RepoName, opts gitserver.CommitsOptions) ([]*gitdomain.Commit, error) {
-			wantRange := fmt.Sprintf("%s..%s", wantBaseRevision, wantHeadRevision)
+			wantRanges := []string{fmt.Sprintf("%s..%s", wantBaseRevision, wantHeadRevision)}
 
-			if have, want := opts.Range, wantRange; have != want {
-				t.Fatalf("git.Commits received wrong range. want=%s, have=%s", want, have)
-			}
+			require.Equal(t, wantRanges, opts.Ranges)
 
 			return commits, nil
 		})

--- a/cmd/symbols/gitserver/BUILD.bazel
+++ b/cmd/symbols/gitserver/BUILD.bazel
@@ -18,7 +18,6 @@ go_library(
         "//internal/metrics",
         "//internal/observation",
         "//internal/types",
-        "//lib/errors",
         "@io_opentelemetry_go_otel//attribute",
     ],
 )

--- a/internal/codeintel/policies/matcher.go
+++ b/internal/codeintel/policies/matcher.go
@@ -275,8 +275,8 @@ func commitsUniqueToBranch(ctx context.Context, gitserverClient gitserver.Client
 	}
 
 	commits, err := gitserverClient.Commits(ctx, repo, gitserver.CommitsOptions{
-		Range: rng,
-		After: after,
+		Ranges: []string{rng},
+		After:  after,
 	})
 	if err != nil {
 		return nil, err

--- a/internal/codeintel/policies/matcher_common_test.go
+++ b/internal/codeintel/policies/matcher_common_test.go
@@ -102,7 +102,7 @@ func testUploadExpirerMockGitserverClient(defaultBranchName string, now time.Tim
 
 	commits := func(ctx context.Context, repo api.RepoName, opts gitserver.CommitsOptions) ([]*gitdomain.Commit, error) {
 		commits := []*gitdomain.Commit{}
-		for _, commit := range branchMembers[opts.Range[strings.Index(opts.Range, "..")+2:]] {
+		for _, commit := range branchMembers[opts.Ranges[0][strings.Index(opts.Ranges[0], "..")+2:]] {
 			c := &gitdomain.Commit{
 				ID: api.CommitID(commit),
 				Committer: &gitdomain.Signature{

--- a/internal/codeintel/uploads/service.go
+++ b/internal/codeintel/uploads/service.go
@@ -142,9 +142,9 @@ func (s *Service) InferClosestUploads(ctx context.Context, opts shared.UploadMat
 	// graph as dirty so it's updated for subsequent requests.
 
 	commits, err := s.gitserverClient.Commits(ctx, repo.Name, gitserver.CommitsOptions{
-		Range: opts.Commit,
-		N:     numAncestors,
-		Order: gitserver.CommitsOrderTopoDate,
+		Ranges: []string{opts.Commit},
+		N:      numAncestors,
+		Order:  gitserver.CommitsOrderTopoDate,
 	})
 	if err != nil {
 		return nil, errors.Wrap(err, "gitserverClient.Commits")

--- a/internal/gitserver/commands_test.go
+++ b/internal/gitserver/commands_test.go
@@ -231,9 +231,9 @@ func TestCommits_After(t *testing.T) {
 				}
 				repo := MakeGitRepository(t, gitCommands...)
 				got, err := client.Commits(ctx, repo, CommitsOptions{
-					N:     2,
-					Range: tc.revspec,
-					After: tc.after,
+					N:      2,
+					Ranges: []string{tc.revspec},
+					After:  tc.after,
 				})
 				require.NoError(t, err)
 
@@ -258,9 +258,9 @@ func TestCommits_After(t *testing.T) {
 				client := NewTestClient(t).WithChecker(checker)
 				repo := MakeGitRepository(t, gitCommands...)
 				got, err := client.Commits(ctx, repo, CommitsOptions{
-					N:     2,
-					After: tc.after,
-					Range: tc.revspec,
+					N:      2,
+					After:  tc.after,
+					Ranges: []string{tc.revspec},
 				})
 				if err != nil {
 					t.Errorf("got error: %s", err)
@@ -273,9 +273,9 @@ func TestCommits_After(t *testing.T) {
 				checker = getTestSubRepoPermsChecker("file1", "file2")
 				client = NewTestClient(t).WithChecker(checker)
 				got, err = client.Commits(ctx, repo, CommitsOptions{
-					N:     2,
-					After: tc.after,
-					Range: tc.revspec,
+					N:      2,
+					After:  tc.after,
+					Ranges: []string{tc.revspec},
 				})
 				if err != nil {
 					t.Errorf("got error: %s", err)
@@ -336,10 +336,10 @@ func TestRepository_Commits(t *testing.T) {
 	runCommitsTests := func(checker authz.SubRepoPermissionChecker) {
 		for label, test := range tests {
 			t.Run(label, func(t *testing.T) {
-				testCommits(ctx, label, test.repo, CommitsOptions{Range: string(test.id)}, checker, test.wantCommits, t)
+				testCommits(ctx, label, test.repo, CommitsOptions{Ranges: []string{string(test.id)}}, checker, test.wantCommits, t)
 
 				// Test that trying to get a nonexistent commit returns RevisionNotFoundError.
-				if _, err := client.Commits(ctx, test.repo, CommitsOptions{Range: string(nonExistentCommitID)}); !errors.HasType(err, &gitdomain.RevisionNotFoundError{}) {
+				if _, err := client.Commits(ctx, test.repo, CommitsOptions{Ranges: []string{string(nonExistentCommitID)}}); !errors.HasType(err, &gitdomain.RevisionNotFoundError{}) {
 					t.Errorf("%s: for nonexistent commit: got err %v, want RevisionNotFoundError", label, err)
 				}
 			})
@@ -569,13 +569,13 @@ func TestRepository_Commits_options(t *testing.T) {
 		wantTotal   uint
 	}{
 		"git cmd": {
-			opt:         CommitsOptions{Range: "ade564eba4cf904492fb56dcd287ac633e6e082c", N: 1, Skip: 1},
+			opt:         CommitsOptions{Ranges: []string{"ade564eba4cf904492fb56dcd287ac633e6e082c"}, N: 1, Skip: 1},
 			wantCommits: wantGitCommits,
 			wantTotal:   1,
 		},
 		"git cmd Head": {
 			opt: CommitsOptions{
-				Range: "b266c7e3ca00b1a17ad0b1449825d0854225c007...ade564eba4cf904492fb56dcd287ac633e6e082c",
+				Ranges: []string{"b266c7e3ca00b1a17ad0b1449825d0854225c007...ade564eba4cf904492fb56dcd287ac633e6e082c"},
 			},
 			wantCommits: wantGitCommits2,
 			wantTotal:   1,
@@ -583,7 +583,7 @@ func TestRepository_Commits_options(t *testing.T) {
 		"before": {
 			opt: CommitsOptions{
 				Before: "2006-01-02T15:04:07Z",
-				Range:  "HEAD",
+				Ranges: []string{"HEAD"},
 				N:      1,
 			},
 			wantCommits: []*gitdomain.Commit{
@@ -665,21 +665,21 @@ func TestRepository_Commits_options_path(t *testing.T) {
 	}{
 		"git cmd Path 0": {
 			opt: CommitsOptions{
-				Range: "master",
-				Path:  "doesnt-exist",
+				Ranges: []string{"master"},
+				Path:   "doesnt-exist",
 			},
 			wantCommits: nil,
 		},
 		"git cmd Path 1": {
 			opt: CommitsOptions{
-				Range: "master",
-				Path:  "file1",
+				Ranges: []string{"master"},
+				Path:   "file1",
 			},
 			wantCommits: wantGitCommits,
 		},
 		"git cmd non utf8": {
 			opt: CommitsOptions{
-				Range:  "master",
+				Ranges: []string{"master"},
 				Author: "a\xc0rn",
 			},
 			wantCommits: nil,

--- a/internal/insights/gitserver/client.go
+++ b/internal/insights/gitserver/client.go
@@ -27,7 +27,7 @@ func (g *GitCommitClient) FirstCommit(ctx context.Context, repoName api.RepoName
 func (g *GitCommitClient) RecentCommits(ctx context.Context, repoName api.RepoName, target time.Time, revision string) ([]*gitdomain.Commit, error) {
 	options := gitserver.CommitsOptions{N: 1, Before: target.Format(time.RFC3339), Order: gitserver.CommitsOrderCommitDate}
 	if len(revision) > 0 {
-		options.Range = revision
+		options.Ranges = []string{revision}
 	}
 	return g.gitserverClient.Commits(ctx, repoName, options)
 }

--- a/internal/own/background/recent_contributors.go
+++ b/internal/own/background/recent_contributors.go
@@ -59,9 +59,9 @@ func (r *recentContributorsIndexer) indexRepo(ctx context.Context, repoId api.Re
 		return errors.Wrap(err, "repoStore.Get")
 	}
 	commits, err := r.client.Commits(ctx, repo.Name, gitserver.CommitsOptions{
-		Order: gitserver.CommitsOrderTopoDate,
-		After: time.Now().AddDate(0, 0, -90).Format(time.RFC3339),
-		Range: "HEAD",
+		Order:  gitserver.CommitsOrderTopoDate,
+		After:  time.Now().AddDate(0, 0, -90).Format(time.RFC3339),
+		Ranges: []string{"HEAD"},
 	})
 	if err != nil {
 		return errors.Wrap(err, "Commits")

--- a/internal/rockskip/mocks_test.go
+++ b/internal/rockskip/mocks_test.go
@@ -172,7 +172,7 @@ func (g *subprocessGit) RevList(ctx context.Context, repo string, commit string,
 func (g *subprocessGit) paginatedRevList(ctx context.Context, repo api.RepoName, commit string, count int) (_ []api.CommitID, nextCursor string, _ error) {
 	commits, err := g.gs.Commits(ctx, repo, gitserver.CommitsOptions{
 		N:           uint(count + 1),
-		Range:       commit,
+		Ranges:      []string{commit},
 		FirstParent: true,
 	})
 	if err != nil {

--- a/internal/search/repos/repos.go
+++ b/internal/search/repos/repos.go
@@ -661,7 +661,7 @@ func hasCommitAfter(ctx context.Context, gitserverClient gitserver.Client, repoN
 	// we ask for two commits here, but the second one we never actually need.
 	// One we figure out why `isRequestForSingleCommit` exists in the first place,
 	// we should update this.
-	commits, err := gitserverClient.Commits(ctx, repoName, gitserver.CommitsOptions{N: 2, After: timeRef, Range: revspec})
+	commits, err := gitserverClient.Commits(ctx, repoName, gitserver.CommitsOptions{N: 2, After: timeRef, Ranges: []string{revspec}})
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
This will be useful for commit searches, and is generally supported by git so why not support it here. That also lets you express `A..B` as `B, ^A` if you want to do less string concatenation, for example.

Test plan:

Made sure all existing callers pass a non-empty string to the slice if they specify the slice at all, and all existing tests still pass.