### PR TITLE
feat(ci): docker-images runtype

### DIFF
--- a/dev/ci/internal/ci/legacy_operations.go
+++ b/dev/ci/internal/ci/legacy_operations.go
@@ -41,7 +41,7 @@ func legacyBuildCandidateDockerImages(apps []string, version string, tag string,
 
 			// Add Sentry environment variables if we are building off main branch
 			// to enable building the webapp with source maps enabled
-			if rt.Is(runtype.MainDryRun, runtype.CloudEphemeral) && app == "frontend" {
+			if rt.Is(runtype.MainDryRun, runtype.DockerImages, runtype.CloudEphemeral) && app == "frontend" {
 				cmds = append(cmds,
 					bk.Env("SENTRY_UPLOAD_SOURCE_MAPS", "1"),
 					bk.Env("SENTRY_ORGANIZATION", "sourcegraph"),
@@ -123,7 +123,7 @@ func legacyBuildCandidateDockerImage(app string, version string, tag string, rt 
 
 		// Add Sentry environment variables if we are building off main branch
 		// to enable building the webapp with source maps enabled
-		if rt.Is(runtype.MainDryRun, runtype.CloudEphemeral) && app == "frontend" {
+		if rt.Is(runtype.MainDryRun, runtype.DockerImages, runtype.CloudEphemeral) && app == "frontend" {
 			cmds = append(cmds,
 				bk.Env("SENTRY_UPLOAD_SOURCE_MAPS", "1"),
 				bk.Env("SENTRY_ORGANIZATION", "sourcegraph"),

--- a/dev/ci/internal/ci/misc_operations.go
+++ b/dev/ci/internal/ci/misc_operations.go
@@ -54,7 +54,7 @@ func addSgLints(targets []string) func(*bk.Pipeline) {
 	)
 
 	formatCheck := ""
-	if runType.Is(runtype.MainBranch, runtype.MainDryRun, runtype.CloudEphemeral) {
+	if runType.Is(runtype.MainBranch, runtype.MainDryRun, runtype.DockerImages, runtype.CloudEphemeral) {
 		formatCheck = "--skip-format-check "
 	}
 

--- a/dev/ci/internal/ci/pipeline.go
+++ b/dev/ci/internal/ci/pipeline.go
@@ -290,6 +290,7 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 
 		if c.RunType.Is(
 			runtype.MainDryRun,
+			runtype.DockerImages,
 			runtype.MainBranch,
 			runtype.ReleaseBranch,
 			runtype.TaggedRelease,
@@ -307,7 +308,7 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 		ops.Merge(CoreTestOperations(buildOptions, changed.All, CoreTestOperationsOptions{
 			MinimumUpgradeableVersion: minimumUpgradeableVersion,
 			ForceReadyForReview:       c.MessageFlags.ForceReadyForReview,
-			CacheBundleSize:           c.RunType.Is(runtype.MainBranch, runtype.MainDryRun, runtype.CloudEphemeral),
+			CacheBundleSize:           c.RunType.Is(runtype.MainBranch, runtype.MainDryRun, runtype.DockerImages, runtype.CloudEphemeral),
 			IsMainBranch:              true,
 		}))
 

--- a/dev/ci/push_all.sh
+++ b/dev/ci/push_all.sh
@@ -109,6 +109,11 @@ elif [[ "$BUILDKITE_BRANCH" =~ ^main-dry-run/.*  ]]; then
   dev_tags+=("insiders")
   prod_tags+=("insiders")
   push_prod=false
+elif [[ "$BUILDKITE_BRANCH" =~ ^docker-images/.* ]]; then
+  # We only push on internal registries on a main-dry-run.
+  dev_tags+=("insiders")
+  prod_tags+=("insiders")
+  push_prod=true
 elif [[ "$BUILDKITE_BRANCH" =~ ^[0-9]+\.[0-9]+$ ]]; then
   # All release branch builds must be published to prod tags to support
   # format introduced by https://github.com/sourcegraph/sourcegraph/pull/48050

--- a/dev/ci/runtype/runtype.go
+++ b/dev/ci/runtype/runtype.go
@@ -42,6 +42,7 @@ const (
 	ImagePatchNoTest    // build a patched image without testing
 	ExecutorPatchNoTest // build executor image without testing
 	CandidatesNoTest    // build one or all candidate images without testing
+	DockerImages        // build one or all docker images without testing
 	CloudEphemeral      // build all images and push to cloud ephemeral registry for use with cloud deployment
 
 	BazelDo // run a specific bazel command
@@ -175,6 +176,10 @@ func (t RunType) Matcher() *RunTypeMatcher {
 		return &RunTypeMatcher{
 			Branch: "docker-images-candidates-notest/",
 		}
+	case DockerImages:
+		return &RunTypeMatcher{
+			Branch: "docker-images/",
+		}
 	case BazelDo:
 		return &RunTypeMatcher{
 			Branch: "bazel-do/",
@@ -217,6 +222,8 @@ func (t RunType) String() string {
 		return "Patch image without testing"
 	case CandidatesNoTest:
 		return "Build all candidates without testing"
+	case DockerImages:
+		return "Build all docker images without testing"
 	case ExecutorPatchNoTest:
 		return "Build executor without testing"
 	case BazelDo:

--- a/dev/ci/runtype/runtype.go
+++ b/dev/ci/runtype/runtype.go
@@ -42,7 +42,7 @@ const (
 	ImagePatchNoTest    // build a patched image without testing
 	ExecutorPatchNoTest // build executor image without testing
 	CandidatesNoTest    // build one or all candidate images without testing
-	DockerImages        // build one or all docker images without testing
+	DockerImages        // build, test and push images on DockerHub registry with insider tags.
 	CloudEphemeral      // build all images and push to cloud ephemeral registry for use with cloud deployment
 
 	BazelDo // run a specific bazel command


### PR DESCRIPTION
Following up on [this thread](https://sourcegraph.slack.com/archives/C04MYFW01NV/p1712789750549639), the conclusion was to create a new runtype with the behavior of `main-dry-run` with `push_prod=true`. I created the run type and just included it everywhere the `main-dry-run` type was used. 

I don't understand how that accomplishes what `docker-images-candidates-notest` was doing, but c'est la vie.

## Test plan
Will run on buildkite.

(EDIT @jhchabran): https://buildkite.com/sourcegraph/sourcegraph/builds/275755#018fb9e2-98b1-45e7-b311-7d420c8edc8e 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
