### PR TITLE
gitserver: Use git-diff-tree to simplify validation and improve security

### DIFF
--- a/cmd/gitserver/internal/git/gitcli/BUILD.bazel
+++ b/cmd/gitserver/internal/git/gitcli/BUILD.bazel
@@ -40,7 +40,6 @@ go_library(
         "//internal/wrexec",
         "//lib/errors",
         "@com_github_go_git_go_git_v5//plumbing/format/config",
-        "@com_github_grafana_regexp//:regexp",
         "@com_github_hashicorp_golang_lru_v2//:golang-lru",
         "@com_github_prometheus_client_golang//prometheus",
         "@com_github_prometheus_client_golang//prometheus/promauto",

--- a/cmd/gitserver/internal/git/gitcli/command.go
+++ b/cmd/gitserver/internal/git/gitcli/command.go
@@ -92,7 +92,7 @@ func (g *gitCLIBackend) NewCommand(ctx context.Context, optFns ...CommandOptionF
 
 	logger := g.logger.WithTrace(trace.Context(ctx))
 
-	if !IsAllowedGitCmd(logger, opts.arguments, g.dir) {
+	if !IsAllowedGitCmd(logger, opts.arguments) {
 		blockedCommandExecutedCounter.Inc()
 		return nil, ErrBadGitCommand
 	}

--- a/cmd/gitserver/internal/git/gitcli/diff_test.go
+++ b/cmd/gitserver/internal/git/gitcli/diff_test.go
@@ -92,6 +92,16 @@ index 0000000000000000000000000000000000000000..8a6a2d098ecaf90105f1cf2fa90fc460
 		require.Error(t, err)
 		require.True(t, errors.HasType(err, &gitdomain.RevisionNotFoundError{}))
 	})
+	t.Run("files outside repository", func(t *testing.T) {
+		// We use git-diff-tree, but with git-diff you can diff any files on disk
+		// which is dangerous. So we have this safeguard test here in place to
+		// make sure we don't regress on that.
+		r, err := backend.RawDiff(ctx, "testbase", "HEAD", git.GitDiffComparisonTypeOnlyInHead, "/dev/null", "/etc/hosts")
+		require.NoError(t, err)
+		_, err = io.ReadAll(r)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "is outside repository at")
+	})
 	// Verify that if the context is canceled, the reader returns an error.
 	t.Run("context cancelation", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(ctx)

--- a/cmd/gitserver/internal/git/gitcli/exec.go
+++ b/cmd/gitserver/internal/git/gitcli/exec.go
@@ -3,16 +3,10 @@ package gitcli
 import (
 	"context"
 	"io"
-	"os"
-	"path/filepath"
-	"slices"
 	"strconv"
 	"strings"
 
-	"github.com/grafana/regexp"
 	"github.com/sourcegraph/log"
-
-	"github.com/sourcegraph/sourcegraph/cmd/gitserver/internal/common"
 )
 
 func (g *gitCLIBackend) Exec(ctx context.Context, args ...string) (io.ReadCloser, error) {
@@ -26,7 +20,6 @@ var (
 		"log":       append([]string{}, gitCommonAllowlist...),
 		"show":      append([]string{}, gitCommonAllowlist...),
 		"remote":    {"-v"},
-		"diff":      append([]string{}, gitCommonAllowlist...),
 		"diff-tree": append([]string{"--root"}, gitCommonAllowlist...),
 		"blame":     {"--root", "--incremental", "-w", "-p", "--porcelain", "--"},
 		"branch":    {"-r", "-a", "--contains", "--merged", "--format"},
@@ -87,39 +80,6 @@ var (
 	}
 )
 
-var gitObjectHashRegex = regexp.MustCompile(`^[a-fA-F\d]*$`)
-
-// common revs used with diff
-var knownRevs = map[string]struct{}{
-	"master":     {},
-	"main":       {},
-	"head":       {},
-	"fetch_head": {},
-	"orig_head":  {},
-	"@":          {},
-}
-
-// isAllowedDiffArg checks if diff arg exists as a file. We do some preliminary checks
-// as well as OS calls are more expensive. The function checks for object hashes and
-// common revision names.
-func isAllowedDiffArg(arg string) bool {
-	// a hash is probably not a local file
-	if gitObjectHashRegex.MatchString(arg) {
-		return true
-	}
-
-	// check for parent and copy branch notations
-	for _, c := range []string{" ", "^", "~"} {
-		if _, ok := knownRevs[strings.ToLower(strings.Split(arg, c)[0])]; ok {
-			return true
-		}
-	}
-	// make sure that arg is not a local file
-	_, err := os.Stat(arg)
-
-	return os.IsNotExist(err)
-}
-
 // isAllowedGitArg checks if the arg is allowed.
 func isAllowedGitArg(allowedArgs []string, arg string) bool {
 	// Split the arg at the first equal sign and check the LHS against the allowlist args.
@@ -139,38 +99,11 @@ func isAllowedGitArg(allowedArgs []string, arg string) bool {
 	return false
 }
 
-// isAllowedDiffPathArg checks if the diff path arg is allowed.
-func isAllowedDiffPathArg(arg string, repoDir common.GitDir) bool {
-	// allows diff command path that requires (dot) as path
-	// example: diff --find-renames ... --no-prefix commit -- .
-	if arg == "." {
-		return true
-	}
-
-	arg = filepath.Clean(arg)
-	if !filepath.IsAbs(arg) {
-		arg = repoDir.Path(arg)
-	}
-
-	filePath, err := filepath.Abs(arg)
-	if err != nil {
-		return false
-	}
-
-	// Check if absolute path is a sub path of the repo dir
-	repoRoot, err := filepath.Abs(repoDir.Path())
-	if err != nil {
-		return false
-	}
-
-	return strings.HasPrefix(filePath, repoRoot)
-}
-
 // IsAllowedGitCmd checks if the cmd and arguments are allowed.
 //
 // TODO: This should be unexported and solely be a concern of the CLI package,
 // as other backends should do their own validation passes.
-func IsAllowedGitCmd(logger log.Logger, args []string, dir common.GitDir) bool {
+func IsAllowedGitCmd(logger log.Logger, args []string) bool {
 	if len(args) == 0 || len(gitCmdAllowlist) == 0 {
 		return false
 	}
@@ -183,9 +116,13 @@ func IsAllowedGitCmd(logger log.Logger, args []string, dir common.GitDir) bool {
 		return false
 	}
 
-	// I hate state machines, but I hate them less than complicated multi-argument checking
 	checkFileInput := false
-	for i, arg := range args[1:] {
+	for _, arg := range args[1:] {
+		// Everything past a `--` is interpreted literally by most git commands
+		// and we use it to pass user input to commands.
+		if arg == "--" {
+			break
+		}
 		if checkFileInput {
 			if arg == "-" {
 				checkFileInput = false
@@ -243,20 +180,6 @@ func IsAllowedGitCmd(logger log.Logger, args []string, dir common.GitDir) bool {
 
 			if !isAllowedGitArg(allowedArgs, arg) {
 				logger.Warn("IsAllowedGitCmd.isAllowedGitArgcmd", log.String("cmd", cmd), log.String("arg", arg))
-				return false
-			}
-		}
-		// diff argument may contains file path and isAllowedDiffArg and isAllowedDiffPathArg
-		// helps verifying the file existence in disk
-		if cmd == "diff" {
-			dashIndex := slices.Index(args[1:], "--")
-			if (dashIndex < 0 || i < dashIndex) && !isAllowedDiffArg(arg) {
-				// verifies arguments before --
-				logger.Warn("IsAllowedGitCmd.isAllowedDiffArg", log.String("cmd", cmd), log.String("arg", arg))
-				return false
-			} else if (i > dashIndex && dashIndex >= 0) && !isAllowedDiffPathArg(arg, dir) {
-				// verifies arguments after --
-				logger.Warn("IsAllowedGitCmd.isAllowedDiffPathArg", log.String("cmd", cmd), log.String("arg", arg))
 				return false
 			}
 		}

--- a/cmd/gitserver/internal/git/gitcli/exec_test.go
+++ b/cmd/gitserver/internal/git/gitcli/exec_test.go
@@ -37,14 +37,14 @@ func TestIsAllowedGitCmd(t *testing.T) {
 	logger := logtest.NoOp(t)
 	for _, args := range isAllowed {
 		t.Run("", func(t *testing.T) {
-			if !IsAllowedGitCmd(logger, args, "/fake/path") {
+			if !IsAllowedGitCmd(logger, args) {
 				t.Fatalf("expected args to be allowed: %q", args)
 			}
 		})
 	}
 	for _, args := range notAllowed {
 		t.Run("", func(t *testing.T) {
-			if IsAllowedGitCmd(logger, args, "/fake/path") {
+			if IsAllowedGitCmd(logger, args) {
 				t.Fatalf("expected args to NOT be allowed: %q", args)
 			}
 		})
@@ -56,30 +56,22 @@ func TestIsAllowedDiffGitCmd(t *testing.T) {
 		args []string
 		pass bool
 	}{
-		{args: []string{"diff", "HEAD", "83838383"}, pass: true},
-		{args: []string{"diff", "HEAD", "HEAD~10"}, pass: true},
-		{args: []string{"diff", "HEAD", "HEAD~10", "--", "foo"}, pass: true},
-		{args: []string{"diff", "HEAD", "HEAD~10", "--", "foo/baz"}, pass: true},
-		{args: []string{"diff", "ORIG_HEAD", "@~10", "--", "foo/baz"}, pass: true},
-		{args: []string{"diff", "HEAD~10", "--", "foo"}, pass: true},
-		{args: []string{"diff", "HEAD", "HEAD~10", "--", "foo/baz"}, pass: true},
-		{args: []string{"diff", "refs/heads/list", "HEAD~10", "--", "/foo/baz"}, pass: true},
-		{args: []string{"diff", "/dev/null", "/etc/passwd"}, pass: false},
-		{args: []string{"diff", "/etc/hosts", "/etc/passwd"}, pass: false},
-		{args: []string{"diff", "/dev/null", "/etc/passwd"}, pass: false},
-		{args: []string{"diff", "/etc/hosts", "/etc/passwd"}, pass: false},
-		{args: []string{"diff", "--", "/etc/hosts", "/etc/passwd"}, pass: false},
-		{args: []string{"diff", "--", "/etc/ees", "/etc/ee"}, pass: false},
-		{args: []string{"diff", "--", "../../../etc/ees", "/etc/ee"}, pass: false},
-		{args: []string{"diff", "--", "a/test.txt", "b/test.txt"}, pass: true},
-		{args: []string{"diff", "--find-renames"}, pass: true},
-		{args: []string{"diff", "a1c0f7d19f6e9eb76facc67c1c22c07bb2ad39c4...c70f79c26526ba74f38ecff2e1e686fc3e2bdcdd"}, pass: true},
+		{args: []string{"diff-tree", "HEAD", "83838383"}, pass: true},
+		{args: []string{"diff-tree", "HEAD", "HEAD~10"}, pass: true},
+		{args: []string{"diff-tree", "HEAD", "HEAD~10", "--", "foo"}, pass: true},
+		{args: []string{"diff-tree", "HEAD", "HEAD~10", "--", "foo/baz"}, pass: true},
+		{args: []string{"diff-tree", "ORIG_HEAD", "@~10", "--", "foo/baz"}, pass: true},
+		{args: []string{"diff-tree", "HEAD~10", "--", "foo"}, pass: true},
+		{args: []string{"diff-tree", "HEAD", "HEAD~10", "--", "foo/baz"}, pass: true},
+		{args: []string{"diff-tree", "refs/heads/list", "HEAD~10", "--", "/foo/baz"}, pass: true},
+		{args: []string{"diff-tree", "--find-renames"}, pass: true},
+		{args: []string{"diff-tree", "a1c0f7d19f6e9eb76facc67c1c22c07bb2ad39c4...c70f79c26526ba74f38ecff2e1e686fc3e2bdcdd"}, pass: true},
 	}
 
 	logger := logtest.NoOp(t)
 	for _, cmd := range allowed {
 		t.Run(fmt.Sprintf("%s returns %t", strings.Join(cmd.args, " "), cmd.pass), func(t *testing.T) {
-			assert.Equal(t, cmd.pass, IsAllowedGitCmd(logger, cmd.args, "/foo/baz"))
+			assert.Equal(t, cmd.pass, IsAllowedGitCmd(logger, cmd.args))
 		})
 	}
 }

--- a/cmd/gitserver/internal/patch.go
+++ b/cmd/gitserver/internal/patch.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/sourcegraph/log"
 
-	"github.com/sourcegraph/sourcegraph/cmd/gitserver/internal/common"
 	"github.com/sourcegraph/sourcegraph/cmd/gitserver/internal/executil"
 	"github.com/sourcegraph/sourcegraph/cmd/gitserver/internal/git/gitcli"
 	"github.com/sourcegraph/sourcegraph/cmd/gitserver/internal/perforce"
@@ -126,7 +125,7 @@ func (s *Server) CreateCommitFromPatch(ctx context.Context, req protocol.CreateC
 	// Temporary logging command wrapper
 	prefix := fmt.Sprintf("%d %s ", atomic.AddUint64(&patchID, 1), repo)
 	run := func(cmd *exec.Cmd, reason string, isRemote bool) ([]byte, error) {
-		if !gitcli.IsAllowedGitCmd(logger, cmd.Args[1:], common.GitDir(tmpRepoDir)) {
+		if !gitcli.IsAllowedGitCmd(logger, cmd.Args[1:]) {
 			return nil, errors.New("command not on allow list")
 		}
 

--- a/cmd/gitserver/internal/server_test.go
+++ b/cmd/gitserver/internal/server_test.go
@@ -65,7 +65,7 @@ func TestExecRequest(t *testing.T) {
 			Name: "Command",
 			Request: &v1.ExecRequest{
 				Repo: "github.com/gorilla/mux",
-				Args: [][]byte{[]byte("diff")},
+				Args: [][]byte{[]byte("diff-tree")},
 			},
 			ExpectedCode:  codes.Unknown,
 			ExpectedBody:  "teststdout",
@@ -122,12 +122,12 @@ func TestExecRequest(t *testing.T) {
 		GitBackendSource: func(dir common.GitDir, repoName api.RepoName) git.GitBackend {
 			backend := git.NewMockGitBackend()
 			backend.ExecFunc.SetDefaultHook(func(ctx context.Context, args ...string) (io.ReadCloser, error) {
-				if !gitcli.IsAllowedGitCmd(logtest.Scoped(t), args, fs.RepoDir(repoName)) {
+				if !gitcli.IsAllowedGitCmd(logtest.Scoped(t), args) {
 					return nil, gitcli.ErrBadGitCommand
 				}
 
 				switch args[0] {
-				case "diff":
+				case "diff-tree":
 					var stdout bytes.Buffer
 					stdout.Write([]byte("teststdout"))
 					return &errorReader{


### PR DESCRIPTION
At some point in the past, we noticed that passing /etc/passwd and /dev/null to `git diff` allows to view the file contents, even though it's not part of the repo itself.
That allows to read arbitrary files on disk, so we had to add in-app validation for file paths, including relative paths.
That makes the validation much more complex and harder to reason about, and requires that we didn't make a mistake.

Instead, we switch to `git diff-tree` which validates paths are part of the tree properly.
By that, we can remove a bunch of complexity around git diff argument validation.

See here for the difference:

```
➜  sourcegraph git:(main) git diff-tree --find-renames --full-index --inter-hunk-context=3 --no-prefix -- /etc/hosts /dev/null
fatal: /etc/hosts: '/etc/hosts' is outside repository at '/Users/erik/Code/sourcegraph/sourcegraph'
➜  sourcegraph git:(main) git --no-pager diff --find-renames --full-index --inter-hunk-context=3 --no-prefix -- /etc/hosts /dev/null
diff --git etc/hosts etc/hosts
deleted file mode 100644
index deadbeef..0000000000000000000000000000000000000000
--- etc/hosts
+++ /dev/null
@@ -1,16 +0,0 @@
-##
-# Host Database
-#
-# localhost is used to configure the loopback interface
-# when the system is booting.  Do not change this entry.
-##
-127.0.0.1	localhost
```

This PR also skips over arguments past the `--` boundary which in git means "everything after this will not be interpreted as an argument".
This previously caused `git cat-file HEAD -- -file.txt` to fail argument validation, although it's perfectly valid and not a risk.

Test plan:

Adjusted the tests for argument validation and existing tests for diff and integration and E2E tests are still passing.