### PR TITLE
observability: Fix error checks in ErrorsFilter

### DIFF
--- a/cmd/gitserver/internal/git/observability.go
+++ b/cmd/gitserver/internal/git/observability.go
@@ -522,10 +522,10 @@ func newOperations(observationCtx *observation.Context) *operations {
 			Metrics:           redMetrics,
 			ErrorFilter: func(err error) observation.ErrorFilterBehaviour {
 				if errors.HasType(err, &gitdomain.RevisionNotFoundError{}) {
-					return observation.EmitForNone
+					return observation.EmitForHoney | observation.EmitForTraces
 				}
-				if os.IsNotExist(err) {
-					return observation.EmitForNone
+				if errors.Is(err, os.ErrNotExist) {
+					return observation.EmitForHoney | observation.EmitForTraces
 				}
 				return observation.EmitForDefault
 			},

--- a/internal/observation/observation.go
+++ b/internal/observation/observation.go
@@ -190,6 +190,13 @@ func (e *ErrCollector) Error() string {
 	return e.errs.Error()
 }
 
+func (e *ErrCollector) Unwrap() error {
+	// ErrCollector wraps collected errors, for compatibility with errors.HasType,
+	// errors.Is etc it has to implement Unwrap to return the inner errors the
+	// collector stores.
+	return e.errs
+}
+
 // Args configures the observation behavior of an invocation of an operation.
 type Args struct {
 	// MetricLabelValues that apply only to this invocation of the operation.


### PR DESCRIPTION
The ErrorsFilter function can be used to skip over well known errors for certain log targets. Multiple errors can all be collected in a wrapper, the ErrCollector.
The collector wraps the errors it found, but it doesn't implement Unwrap, so errors.Is and errors.HasType don't work properly here, they will only see the ErrCollector.
This PR adds Unwrap to the ErrCollector to fix that, and fixes the error code detection in gitserver git observability, and makes it less aggressive in what we skip.

Test plan:

Verified that the two errors are no longer erroneously logged.