### PR TITLE
inference: Fix regression for non-absolute commit ID

### DIFF
--- a/internal/codeintel/autoindexing/internal/inference/iface.go
+++ b/internal/codeintel/autoindexing/internal/inference/iface.go
@@ -16,6 +16,7 @@ type SandboxService interface {
 }
 
 type GitService interface {
+	ResolveRevision(ctx context.Context, repo api.RepoName, spec string) (api.CommitID, error)
 	ReadDir(ctx context.Context, repo api.RepoName, commit api.CommitID, path string, recurse bool) ([]fs.FileInfo, error)
 	Archive(ctx context.Context, repo api.RepoName, opts gitserver.ArchiveOptions) (io.ReadCloser, error)
 }
@@ -53,4 +54,10 @@ func (s *gitService) ReadDir(ctx context.Context, repo api.RepoName, commit api.
 
 func (s *gitService) Archive(ctx context.Context, repo api.RepoName, opts gitserver.ArchiveOptions) (io.ReadCloser, error) {
 	return s.client.ArchiveReader(ctx, repo, opts)
+}
+
+func (s *gitService) ResolveRevision(ctx context.Context, repo api.RepoName, spec string) (api.CommitID, error) {
+	return s.client.ResolveRevision(ctx, repo, spec, gitserver.ResolveRevisionOptions{
+		EnsureRevision: false,
+	})
 }

--- a/internal/codeintel/autoindexing/internal/inference/service.go
+++ b/internal/codeintel/autoindexing/internal/inference/service.go
@@ -279,12 +279,19 @@ func (s *Service) resolvePaths(
 		return nil, err
 	}
 
+	// We resolve the commit string to a commit SHA here, the name of the field
+	// is a misnomer and it can also contain non-commit SHAs.
+	commitID, err := invocationContext.gitService.ResolveRevision(ctx, invocationContext.repo, invocationContext.commit)
+	if err != nil {
+		return nil, err
+	}
+
 	// Ideally we can pass the pathspecs from flattenPatterns here and avoid returning
 	// all files in the tree, so we don't need to filter as much further down.
 	// This requires implementing either globbing support in the ReadDir call,
 	// or that the pathpatterns are supported by ReadDir (and thus, in git ls-tree)
 	// which is not the case today.
-	fds, err := invocationContext.gitService.ReadDir(ctx, invocationContext.repo, api.CommitID(invocationContext.commit), "", true)
+	fds, err := invocationContext.gitService.ReadDir(ctx, invocationContext.repo, commitID, "", true)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The previous local implementation allowed anything for the commitID passed, and we pass things like HEAD and such here, which are not actually commits.
So we first let gitserver resolve it to an actual commit ID now.

This will resolve https://sourcegraph.sentry.io/issues/5333275545/?project=6583153&query=is%3Aunresolved++non-absolute+commit+ID&referrer=issue-stream&statsPeriod=14d&stream_index=0.

Test plan:

Code review and will mark the issue as resolved and watch for regression notifications.