### PR TITLE
gitserver: Adjust buckets for cleanup timing

### DIFF
--- a/cmd/gitserver/internal/cleanup.go
+++ b/cmd/gitserver/internal/cleanup.go
@@ -203,8 +203,9 @@ var (
 		Help: "set to 1 when the gitserver janitor background job is running",
 	})
 	jobTimer = promauto.NewHistogramVec(prometheus.HistogramOpts{
-		Name: "src_gitserver_janitor_job_duration_seconds",
-		Help: "Duration of the individual jobs within the gitserver janitor background job",
+		Name:    "src_gitserver_janitor_job_duration_seconds",
+		Help:    "Duration of the individual jobs within the gitserver janitor background job",
+		Buckets: prometheus.ExponentialBucketsRange(0.001, 240, 16),
 	}, []string{"success", "job_name"})
 	maintenanceStatus = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "src_gitserver_maintenance_status",


### PR DESCRIPTION
The default buckets don't serve us too well for the jobs, most just report 5ms (the smallest default) all the time, and some always report 10s (the biggest default) - this should hopefully give us better insight.

Test plan:

Code review.