### PR TITLE
Cody Ignore: lower version constraint fot test mode

### DIFF
--- a/cmd/frontend/internal/httpapi/completions/handler.go
+++ b/cmd/frontend/internal/httpapi/completions/handler.go
@@ -509,13 +509,13 @@ func checkClientCodyIgnoreCompatibility(ctx context.Context, db database.DB, r *
 		cvc = clientVersionConstraint{client: clientName, constraint: ">= 1.20.0"}
 		if isClientsTestMode {
 			// set the constraint to a lower pre-release version to enable testing
-			cvc.constraint = ">= 1.17.0-0"
+			cvc.constraint = ">= 1.16.0-0"
 		}
 	case types.CodyClientJetbrains:
 		cvc = clientVersionConstraint{client: clientName, constraint: ">= 6.0.0"}
 		if isClientsTestMode {
 			// set the constraint to a lower pre-release version to enable testing
-			cvc.constraint = ">= 5.5.10-0"
+			cvc.constraint = ">= 5.5.8-0"
 		}
 	default:
 		return &codyIgnoreCompatibilityError{

--- a/cmd/frontend/internal/httpapi/completions/handler_test.go
+++ b/cmd/frontend/internal/httpapi/completions/handler_test.go
@@ -272,7 +272,7 @@ func TestCheckClientCodyIgnoreCompatibility(t *testing.T) {
 			ccf:  ccf,
 			q: url.Values{
 				"client-name":    []string{string(types.CodyClientJetbrains)},
-				"client-version": []string{"5.5.10"},
+				"client-version": []string{"5.5.8"},
 			},
 			want:              nil,
 			isClientsTestMode: true,
@@ -283,10 +283,10 @@ func TestCheckClientCodyIgnoreCompatibility(t *testing.T) {
 			ccf:  ccf,
 			q: url.Values{
 				"client-name":    []string{string(types.CodyClientJetbrains)},
-				"client-version": []string{"5.5.9-nightly"},
+				"client-version": []string{"5.5.7-nightly"},
 			},
 			want: &codyIgnoreCompatibilityError{
-				reason:     fmt.Sprintf("Cody for %s version \"5.5.9-nightly\" doesn't match version constraint \">= 5.5.10-0\". Please upgrade your client.", types.CodyClientJetbrains),
+				reason:     fmt.Sprintf("Cody for %s version \"5.5.7-nightly\" doesn't match version constraint \">= 5.5.8-0\". Please upgrade your client.", types.CodyClientJetbrains),
 				statusCode: http.StatusNotAcceptable,
 			},
 			isClientsTestMode: true,
@@ -297,7 +297,7 @@ func TestCheckClientCodyIgnoreCompatibility(t *testing.T) {
 			ccf:  ccf,
 			q: url.Values{
 				"client-name":    []string{string(types.CodyClientJetbrains)},
-				"client-version": []string{"6.0.0"},
+				"client-version": []string{"5.5.8-nightly"},
 			},
 			want:              nil,
 			isClientsTestMode: true,
@@ -316,12 +316,11 @@ func TestCheckClientCodyIgnoreCompatibility(t *testing.T) {
 			},
 		},
 		{
-			// See https://pkg.go.dev/github.com/Masterminds/semver#readme-working-with-pre-release-versions
 			name: "vscode: lower version matches constraint if \"cody-context-filters-clients-test-mode\" feature flag is enabled",
 			ccf:  ccf,
 			q: url.Values{
 				"client-name":    []string{string(types.CodyClientVscode)},
-				"client-version": []string{"1.17.1715730510"},
+				"client-version": []string{"1.16.0"},
 			},
 			want:              nil,
 			isClientsTestMode: true,
@@ -332,10 +331,10 @@ func TestCheckClientCodyIgnoreCompatibility(t *testing.T) {
 			ccf:  ccf,
 			q: url.Values{
 				"client-name":    []string{string(types.CodyClientVscode)},
-				"client-version": []string{"1.16.0-alpha"},
+				"client-version": []string{"1.15.1815730510"},
 			},
 			want: &codyIgnoreCompatibilityError{
-				reason:     fmt.Sprintf("Cody for %s version \"1.16.0-alpha\" doesn't match version constraint \">= 1.17.0-0\". Please upgrade your client.", types.CodyClientVscode),
+				reason:     fmt.Sprintf("Cody for %s version \"1.15.1815730510\" doesn't match version constraint \">= 1.16.0-0\". Please upgrade your client.", types.CodyClientVscode),
 				statusCode: http.StatusNotAcceptable,
 			},
 			isClientsTestMode: true,
@@ -346,7 +345,7 @@ func TestCheckClientCodyIgnoreCompatibility(t *testing.T) {
 			ccf:  ccf,
 			q: url.Values{
 				"client-name":    []string{string(types.CodyClientVscode)},
-				"client-version": []string{"1.17.0-localbuild"},
+				"client-version": []string{"1.16.1815730510"},
 			},
 			want:              nil,
 			isClientsTestMode: true,


### PR DESCRIPTION
Sets lower version constraints in test mode to enable clients testing. See [this](https://sourcegraph.slack.com/archives/C06Q9R098N4/p1715801118313989?thread_ts=1715038896.786949&cid=C06Q9R098N4) thread for more details.

## Test plan
- CI
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
