### PR TITLE
chore(process): add structure guide for PRs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,25 +1,34 @@
+<!-- Learn how to write good pull request description: https://www.notion.so/sourcegraph/Write-a-good-pull-request-description-610a7fd3e613496eb76f450db5a49b6e?pvs=4
 
+A pull request description is essential for others to understand the context that led to submitting changes.
+Filling the TODOs below will guide you to cover the basics and make sure your description provides helpful
+context for a long time.
+-->
+
+Fixes TODO
+Before TODO
+After TODO
 
 ## Test plan
 
-<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 
+<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles
 
-Why does it matter? 
+Why does it matter?
 
-These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
-They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
+These test plans are there to demonstrate that are following industry standards which are important or critical for our customers.
+They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure
 your changes are correct!
 
 Here are a non exhaustive list of test plan examples to help you:
 
-- Making changes on a given feature or component: 
+- Making changes on a given feature or component:
   - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
-  - "Added new tests" 
+  - "Added new tests"
   - "Manually tested" (if non trivial, share some output, logs, or screenshot)
-- Updating docs: 
-  - "previewed locally" 
+- Updating docs:
+  - "previewed locally"
   - share a screenshot if you want to be thorough
 - Updating deps, that would typically fail immediately in CI if incorrect
-  - "CI" 
-  - "locally tested" 
+  - "CI"
+  - "locally tested"
 -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,13 +1,18 @@
-<!-- Learn how to write good pull request description: https://www.notion.so/sourcegraph/Write-a-good-pull-request-description-610a7fd3e613496eb76f450db5a49b6e?pvs=4
+<!--
 
-A pull request description is essential for others to understand the context that led to submitting changes.
-Filling the TODOs below will guide you to cover the basics and make sure your description provides helpful
-context for a long time.
+💡 To write a useful PR description, make sure that your description covers:
+
+- WHAT this PR is changing:
+    - How was it PREVIOUSLY.
+    - How it will be from NOW on.
+- WHY this PR is needed.
+- CONTEXT, i.e. to which initiative, project or RFC it belongs.
+
+The structure of the description doesn't matter as much as covering these points, so use
+your best judgement based on your context.
+
+Learn how to write good pull request description: https://www.notion.so/sourcegraph/Write-a-good-pull-request-description-610a7fd3e613496eb76f450db5a49b6e?pvs=4
 -->
-
-Fixes TODO
-Before TODO
-After TODO
 
 ## Test plan
 


### PR DESCRIPTION
Provides guidance to cover the basics with pull request descriptions.

Before there wasn't any and the quality would vary a ton between authors. Now, with that in place, it's a visible reminder to cover the basics and mitigate the blank page syndrome.

I created a _how-to_ in Notion, blank for now that we can use to provide additional context.

## Test plan

CI

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
