### PR TITLE
svelte: Fix various z-index/layering issues

### DIFF
--- a/client/web-sveltekit/src/lib/Popover.svelte
+++ b/client/web-sveltekit/src/lib/Popover.svelte
@@ -101,7 +101,6 @@
     div {
         position: absolute;
         isolation: isolate;
-        z-index: 1;
         min-width: 10rem;
         font-size: 0.875rem;
         background-clip: padding-box;

--- a/client/web-sveltekit/src/lib/navigation/GlobalHeader.svelte
+++ b/client/web-sveltekit/src/lib/navigation/GlobalHeader.svelte
@@ -150,11 +150,6 @@
         align-self: stretch;
         min-width: 0;
 
-        // Ensure that any content inside navigation portal block
-        // can't overlap any static content like sidebar navigation
-        // in the global header layout.
-        isolation: isolate;
-
         &-list {
             display: flex;
             gap: 1rem;

--- a/client/web-sveltekit/src/lib/navigation/GlobalSidebarNavigation.svelte
+++ b/client/web-sveltekit/src/lib/navigation/GlobalSidebarNavigation.svelte
@@ -9,7 +9,7 @@
 <script lang="ts">
     import { mdiClose } from '@mdi/js'
     import { page } from '$app/stores'
-    import { onClickOutside } from '$lib/dom'
+    import { onClickOutside, portal } from '$lib/dom'
     import Icon from '$lib/Icon.svelte'
     import SourcegraphLogo from '$lib/SourcegraphLogo.svelte'
 
@@ -19,7 +19,7 @@
     export let onClose: () => void
 </script>
 
-<div class="root">
+<div class="root" use:portal>
     <div class="content" use:onClickOutside on:click-outside={onClose}>
         <header>
             <button class="close-button" on:click={onClose}>

--- a/client/web-sveltekit/src/lib/wildcard/menu/DropdownMenu.svelte
+++ b/client/web-sveltekit/src/lib/wildcard/menu/DropdownMenu.svelte
@@ -47,7 +47,6 @@
     div,
     div :global([role='menu']) {
         isolation: isolate;
-        z-index: 1000;
         min-width: 12rem;
         font-size: 0.875rem;
         background-clip: padding-box;

--- a/client/web-sveltekit/src/routes/+layout.svelte
+++ b/client/web-sveltekit/src/routes/+layout.svelte
@@ -112,15 +112,7 @@
         flex-direction: column;
     }
 
-    // Ensure that any content in the global header has
-    // more layout priority over any content in the content (main) area
-    :global([data-global-header]) {
-        z-index: 1;
-        isolation: isolate;
-    }
-
     main {
-        z-index: 0;
         isolation: isolate;
         flex: 1;
         display: flex;

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/RepoSearchInput.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/RepoSearchInput.svelte
@@ -14,7 +14,7 @@
     export let repoName: string
 
     const {
-        elements: { trigger, overlay, content },
+        elements: { trigger, overlay, content, portalled },
         states: { open },
     } = createDialog()
 
@@ -43,29 +43,25 @@
 </script>
 
 {#if $open}
-    <div class="wrapper">
+    <div class="wrapper" {...$portalled} use:portalled>
         <div {...$overlay} use:overlay class="overlay" />
         <div {...$content} use:content>
             <SearchInput bind:this={searchInput} {queryState} onSubmit={handleSearchSubmit} />
         </div>
     </div>
-{:else}
-    <button {...$trigger} use:trigger>
-        <Icon svgPath={mdiMagnify} inline aria-hidden="true" />
-        Type <kbd>/</kbd> to search
-    </button>
 {/if}
+<button {...$trigger} use:trigger class:hidden={$open}>
+    <Icon svgPath={mdiMagnify} inline aria-hidden="true" />
+    Type <kbd>/</kbd> to search
+</button>
 
 <style lang="scss">
     .wrapper {
         flex: 1;
         position: absolute;
+        top: 1rem;
         left: 1rem;
         right: 1rem;
-        // This seems needed to prevent the file headers (which are position: sticky) from overlaying
-        // the search input. Alternatively we could portal the search input with melt, but then
-        // it would be more difficult to position it over the repo header.
-        z-index: 2;
 
         .overlay {
             position: fixed;
@@ -75,6 +71,10 @@
             bottom: 0;
             background-color: rgba(0, 0, 0, 0.3);
         }
+    }
+
+    .hidden {
+        visibility: hidden;
     }
 
     button {


### PR DESCRIPTION
While looking into #62713 I stumbled upon two z-index issues:

![2024-05-16_13-37](https://github.com/sourcegraph/sourcegraph/assets/179026/3f149aa4-7966-4d51-9a69-201139dc989e)
![2024-05-16_13-36](https://github.com/sourcegraph/sourcegraph/assets/179026/c15d4c32-8c8c-4045-a87b-9e78e0ba2fd8)

I'm worried that layering already gets out of hand and is difficult to understand. So this commit removes a bunch of z-index settings to simplifying this.

Most importantly:

- Instead of setting a z-index on the header to make the sidebar navigation work, we can "portal" the sidebar to the end of the document.
- Likewise the repo search input is portalled to ensure that it renders above all other content.


## Test plan

Opened popovers/tooltips/etc on various pages:

- Main search input/suggestions
- Global sidebar navigation
- User menu
- `experimental` popover
- Code intel hovercards
- Repo search input
- Tooltips
- Revision picker