### PR TITLE
sg/msp: fix `CustomTargetType` reference in `Target` definition

### DIFF
--- a/dev/managedservicesplatform/internal/resource/deliverypipeline/deliverypipeline.go
+++ b/dev/managedservicesplatform/internal/resource/deliverypipeline/deliverypipeline.go
@@ -105,7 +105,7 @@ func New(scope constructs.Construct, id resourceid.ID, config Config) (*Output, 
 			Name:     &target.ID,
 			Location: &config.Location,
 			CustomTarget: &clouddeploytarget.ClouddeployTargetCustomTarget{
-				CustomTargetType: targetType.Name(),
+				CustomTargetType: targetType.Id(),
 			},
 			DeployParameters: &map[string]*string{
 				"customTarget/serviceID": &config.ServiceID,


### PR DESCRIPTION
<!--

💡 To write a useful PR description, make sure that your description covers:

- WHAT this PR is changing:
    - How was it PREVIOUSLY.
    - How it will be from NOW on.
- WHY this PR is needed.
- CONTEXT, i.e. to which initiative, project or RFC it belongs.

The structure of the description doesn't matter as much as covering these points, so use
your best judgement based on your context.

Learn how to write good pull request description: https://www.notion.so/sourcegraph/Write-a-good-pull-request-description-610a7fd3e613496eb76f450db5a49b6e?pvs=4
-->
Changes the identifier used by targets to reference the custom target type they belong to. Previously this used `targetType.Name()` but should have been `targetType.Id()`. 
Fixes the following error encountered by `repoferee`

```
failed to validate custom target "projects/1058156036563/locations/us-central1/targets/prod-us-central1": failed to parse custom target type name referenced by target "projects/1058156036563/locations/us-central1/targets/prod-us-central1": invalid 3 name: invalid argument
```

docs:
Target:
> [custom_target_type](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/clouddeploy_target#custom_target_type) - (Required) Required. The name of the CustomTargetType. Format must be projects/{project}/locations/{location}/customTargetTypes/{custom_target_type}.

Custom Target Type:
> [id](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/clouddeploy_custom_target_type#id) - an identifier for the resource with format projects/{{project}}/locations/{{location}}/customTargetTypes/{{name}}
## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles

Why does it matter?

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers.
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component:
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests"
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs:
  - "previewed locally"
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI"
  - "locally tested"
-->
inspection of terraform plan 
```
# google_clouddeploy_target.cloudrun-rolloutpipeline-pipeline-target_stage-prod-us-central1 will be updated in-place
  ~ resource "google_clouddeploy_target" "cloudrun-rolloutpipeline-pipeline-target_stage-prod-us-central1" {
        id                    = "projects/repoferee-prod-5317/locations/us-central1/targets/prod-us-central1"
        name                  = "prod-us-central1"
        # (14 unchanged attributes hidden)

      ~ custom_target {
          ~ custom_target_type = "cloud-run-service" -> "projects/repoferee-prod-5317/locations/us-central1/customTargetTypes/cloud-run-service"
        }

        # (1 unchanged block hidden)
    }
```