### PR TITLE
docs: Add link to Entitle permission

### DIFF
--- a/dev/gqltest/README.md
+++ b/dev/gqltest/README.md
@@ -15,7 +15,7 @@ You can also run integration tests locally. Note: this is not a well-trodden pat
 instead.
 
 Steps:
-1. Request "CI Secrets Read Access" in Entitle
+1. Request ["CI Secrets Read Access"](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6Ijg2NDAwIiwianVzdGlmaWNhdGlvbiI6IlJ1bm5pbmcgYmFja2VuZCBpbnRlZ3JhdGlvbiB0ZXN0cyBsb2NhbGx5IiwiYnVuZGxlSWRzIjpbIjA2ZmRkZTIwLWY1Y2MtNDdlMS1iZGYxLWZkZTUwYjhhNDE3MCJdfQ%3D%3D) in Entitle
 2. Run `sg test bazel-backend-integration`
 
 ## How to add new tests


### PR DESCRIPTION
For the reviewer: can you check if the link opens up the Form in the correct state for you?

(I used the 'Copy Form link' button.)

![CleanShot 2024-05-16 at 21 01 03@2x](https://github.com/sourcegraph/sourcegraph/assets/93103176/9ac8f1c2-56e7-4384-90a1-ebce241337d9)

## Test plan

n/a