### PR TITLE
appliance: fix test flakiness when container env vars are specified

### DIFF
--- a/internal/k8s/resource/container/container.go
+++ b/internal/k8s/resource/container/container.go
@@ -1,6 +1,8 @@
 package container
 
 import (
+	"sort"
+
 	"github.com/grafana/regexp"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -29,9 +31,7 @@ func NewContainer(name string, cfg config.StandardComponent, defaults config.Con
 
 	if cfg != nil {
 		if ctrConfig, ok := cfg.GetContainerConfig()[name]; ok {
-			for k, v := range ctrConfig.EnvVars {
-				ctr.Env = append(ctr.Env, corev1.EnvVar{Name: k, Value: v})
-			}
+			ctr.Env = append(ctr.Env, newSortedEnvVars(ctrConfig.EnvVars)...)
 
 			if ctrConfig.BestEffortQOS {
 				ctr.Resources = corev1.ResourceRequirements{}
@@ -149,4 +149,20 @@ func EnvVarsPostgresExporter(secretName string) []corev1.EnvVar {
 			Value: "/config/queries.yaml",
 		},
 	}
+}
+
+func newSortedEnvVars(vars map[string]string) []corev1.EnvVar {
+	keys := make([]string, len(vars))
+	i := 0
+	for key := range vars {
+		keys[i] = key
+		i++
+	}
+	sort.Strings(keys)
+
+	ret := make([]corev1.EnvVar, len(vars))
+	for i, key := range keys {
+		ret[i] = corev1.EnvVar{Name: key, Value: vars[key]}
+	}
+	return ret
 }


### PR DESCRIPTION
Since introducing the standard feature for container env vars in https://github.com/sourcegraph/sourcegraph/pull/62624, some test flakiness has been introduced. This is because container.go was iterating through an unsorted map, which made golden file assertions non-deterministic. This is fixed by sorting the map keys when appending user-provided env vars.

<!--

💡 To write a useful PR description, make sure that your description covers:

- WHAT this PR is changing:
    - How was it PREVIOUSLY.
    - How it will be from NOW on.
- WHY this PR is needed.
- CONTEXT, i.e. to which initiative, project or RFC it belongs.

The structure of the description doesn't matter as much as covering these points, so use
your best judgement based on your context.

Learn how to write good pull request description: https://www.notion.so/sourcegraph/Write-a-good-pull-request-description-610a7fd3e613496eb76f450db5a49b6e?pvs=4
-->

## Test plan

Ran `go test -count=10 -failfast ./internal/appliance` and it passed. Before this commit, 10 runs would reliably tease out the flake.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles

Why does it matter?

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers.
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component:
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests"
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs:
  - "previewed locally"
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI"
  - "locally tested"
-->
