### PR TITLE
feat(sg/repoferee): add security command with `repo-report` subcommand to fetch latest repoferee report

### DIFF
--- a/dev/sg/BUILD.bazel
+++ b/dev/sg/BUILD.bazel
@@ -34,6 +34,7 @@ go_library(
         "sg_rfc.go",
         "sg_run.go",
         "sg_secret.go",
+        "sg_security.go",
         "sg_setup.go",
         "sg_src.go",
         "sg_start.go",

--- a/dev/sg/main.go
+++ b/dev/sg/main.go
@@ -299,6 +299,7 @@ var sg = &cli.App{
 		pageCommand,
 		cloudCommand,
 		msp.Command,
+		securityCommand,
 
 		// Util
 		analyticsCommand,

--- a/dev/sg/sg_security.go
+++ b/dev/sg/sg_security.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"time"
+
+	"github.com/urfave/cli/v2"
+
+	"github.com/sourcegraph/sourcegraph/dev/sg/internal/category"
+)
+
+var securityCommand = &cli.Command{
+	Name:        "security",
+	Usage:       "interact with Sourcegraph security tools",
+	Description: "Learn more about Sourcegraph security: https://about.sourcegraph.com/security",
+	Category:    category.Company,
+	Subcommands: []*cli.Command{
+		{
+			Name:        "repoferee-report",
+			Usage:       "fetch the latest repoferee report",
+			Description: "To learn more about Cloud V2, see https://handbook.sourcegraph.com/departments/cloud/technical-docs/v2.0/",
+			Action:      getRepofereeReport,
+		},
+	},
+}
+
+const RepofereeEndpoint = "https://repoferee.sgdev.org"
+
+func hmacSign(key, message string) []byte {
+	hasher := hmac.New(sha256.New, []byte(key))
+	hasher.Write([]byte(message))
+	return hasher.Sum(nil)
+}
+
+func getRepofereeReport(c *cli.Context) error {
+	authorization := "Bearer 685013726e4bbe8e79f5d6c21902eb66a1e9549fed8e60b0d7efbc7305c4f7f6"
+	timestamp := time.Now().Format(time.RFC3339)
+	path := "/results"
+
+	hmac := "99c045e02363d6ba1742ea8737546cf64597d937292ba3e416a7cd03d2ffa404"
+	urlPath, err := url.JoinPath(RepofereeEndpoint, path)
+	if err != nil {
+		return err
+	}
+	signature := hmacSign(hmac, fmt.Sprintf("%s:%s:%s", timestamp, path, authorization))
+	req, err := http.NewRequest("GET", urlPath, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Add("Authorization", authorization)
+	req.Header.Add("X-Timestamp", timestamp)
+	req.Header.Add("X-Signature", hex.EncodeToString(signature))
+	req.Header.Add("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+
+	value := struct {
+		Results map[string]json.RawMessage `json:"results"`
+		LastRun string                     `json:"last_run_at"`
+		NextRun string                     `json:"next_run_at"`
+	}{}
+	dec := json.NewDecoder(resp.Body)
+	if err := dec.Decode(&value); err != nil {
+		return err
+	}
+
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent(" ", " ")
+	if err := enc.Encode(value); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/dev/sg/sg_security.go
+++ b/dev/sg/sg_security.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/hex"
@@ -14,24 +15,41 @@ import (
 	"github.com/urfave/cli/v2"
 
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/category"
+	"github.com/sourcegraph/sourcegraph/dev/sg/internal/secrets"
+	"github.com/sourcegraph/sourcegraph/dev/sg/internal/std"
+	"github.com/sourcegraph/sourcegraph/lib/output"
 )
 
 var securityCommand = &cli.Command{
 	Name:        "security",
 	Usage:       "interact with Sourcegraph security tools",
-	Description: "Learn more about Sourcegraph security: https://about.sourcegraph.com/security",
+	Description: "Learn more about Sourcegraph security: https://sourcegraph.notion.site/Security-81d50b5ac5474b07bdbadd5359993c80",
 	Category:    category.Company,
 	Subcommands: []*cli.Command{
 		{
-			Name:        "repoferee-report",
+			Name:        "repo-report",
 			Usage:       "fetch the latest repoferee report",
-			Description: "To learn more about Cloud V2, see https://handbook.sourcegraph.com/departments/cloud/technical-docs/v2.0/",
+			Description: "Fetches the latest repoferee report which reports on repositories that conform to set rules. The rules can be found at https://github.com/sourcegraph/repoferee/blob/main/rules.yml",
 			Action:      getRepofereeReport,
+			Flags: []cli.Flag{
+				&cli.StringFlag{
+					Name:        "output-file",
+					DefaultText: "standard out",
+					Usage:       "<filename> to write the report to",
+					Value:       "",
+					Aliases:     []string{"o"},
+				},
+			},
 		},
 	},
 }
 
 const RepofereeEndpoint = "https://repoferee.sgdev.org"
+
+type repofereeSecret struct {
+	AuthToken string
+	HMAC      string
+}
 
 func hmacSign(key, message string) []byte {
 	hasher := hmac.New(sha256.New, []byte(key))
@@ -39,31 +57,90 @@ func hmacSign(key, message string) []byte {
 	return hasher.Sum(nil)
 }
 
-func getRepofereeReport(c *cli.Context) error {
-	authorization := "Bearer 685013726e4bbe8e79f5d6c21902eb66a1e9549fed8e60b0d7efbc7305c4f7f6"
-	timestamp := time.Now().Format(time.RFC3339)
-	path := "/results"
-
-	hmac := "99c045e02363d6ba1742ea8737546cf64597d937292ba3e416a7cd03d2ffa404"
-	urlPath, err := url.JoinPath(RepofereeEndpoint, path)
+func getRepofereeSecrets(ctx context.Context) (repofereeSecret, error) {
+	var values repofereeSecret
+	store, err := secrets.FromContext(ctx)
 	if err != nil {
-		return err
+		return values, err
 	}
-	signature := hmacSign(hmac, fmt.Sprintf("%s:%s:%s", timestamp, path, authorization))
+
+	sec := secrets.ExternalSecret{
+		Project: secrets.LocalDevProject,
+		Name:    "SG_REPOFEREE_AUTH_TOKEN",
+	}
+	values.AuthToken, err = store.GetExternal(ctx, sec)
+	if err != nil {
+		return values, err
+	}
+
+	sec = secrets.ExternalSecret{
+		Project: secrets.LocalDevProject,
+		Name:    "SG_REPOFEREE_HMAC_KEY",
+	}
+	values.HMAC, err = store.GetExternal(ctx, sec)
+	if err != nil {
+		return values, err
+	}
+
+	return values, nil
+}
+
+func newRepofereeReq(ctx context.Context, endpoint, path string) (*http.Request, error) {
+	urlPath, err := url.JoinPath(endpoint, path)
+	if err != nil {
+		return nil, err
+	}
+
 	req, err := http.NewRequest("GET", urlPath, nil)
 	if err != nil {
-		return err
+		return nil, err
 	}
+
+	secrets, err := getRepofereeSecrets(ctx)
+	if err != nil {
+		return nil, err
+	}
+	authorization := fmt.Sprintf("Bearer %s", secrets.AuthToken)
+	timestamp := time.Now().Format(time.RFC3339)
+
+	signature := hmacSign(secrets.HMAC, fmt.Sprintf("%s:%s:%s", timestamp, path, authorization))
 	req.Header.Add("Authorization", authorization)
 	req.Header.Add("X-Timestamp", timestamp)
 	req.Header.Add("X-Signature", hex.EncodeToString(signature))
 	req.Header.Add("Content-Type", "application/json")
 
-	resp, err := http.DefaultClient.Do(req)
+	return req, nil
+}
+
+func getRepofereeReport(ctx *cli.Context) error {
+	pending := std.Out.Pending(output.Line("⌛", output.StylePending, "Fetching latest repoferee report"))
+
+	pending.Update("Creating signed request")
+	req, err := newRepofereeReq(ctx.Context, RepofereeEndpoint, "/results")
 	if err != nil {
+		pending.Complete(output.Line("❌", output.StyleFailure, "Failed to create signed request"))
 		return err
 	}
 
+	pending.Updatef("Making request to %q", req.URL.String())
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		pending.Complete(output.Line("❌", output.StyleFailure, "Request failed"))
+		return err
+	}
+	defer resp.Body.Close()
+	pending.WriteLine(output.Line("✅", output.StyleSuccess, "Response received from repoferee"))
+
+	dst := os.Stderr
+	if ctx.String("output-file") != "" {
+		fd, err := os.Create(ctx.String("output-file"))
+		if err != nil {
+			pending.Complete(output.Line("❌", output.StyleFailure, "Failed to open output file %q"))
+			return err
+		}
+		dst = fd
+	}
+	pending.Update("Decoding and formatting response")
 	value := struct {
 		Results map[string]json.RawMessage `json:"results"`
 		LastRun string                     `json:"last_run_at"`
@@ -71,14 +148,21 @@ func getRepofereeReport(c *cli.Context) error {
 	}{}
 	dec := json.NewDecoder(resp.Body)
 	if err := dec.Decode(&value); err != nil {
+		pending.Complete(output.Line("❌", output.StyleFailure, "Failed to decode response"))
 		return err
 	}
 
-	enc := json.NewEncoder(os.Stdout)
+	filename := "stderr"
+	if dst != os.Stderr {
+		filename = dst.Name()
+	}
+	enc := json.NewEncoder(dst)
 	enc.SetIndent(" ", " ")
 	if err := enc.Encode(value); err != nil {
+		pending.Complete(output.Linef("❌", output.StyleFailure, "Failed to write to %q", filename))
 		return err
 	}
-
+	pending.Complete(output.Linef("✅", output.StyleSuccess, "Report written to %q", filename))
+	std.Out.WriteMarkdown(fmt.Sprintf("Last report run: `%s`\nNext report run: `%s`\n", value.LastRun, value.NextRun))
 	return nil
 }


### PR DESCRIPTION
To fetch the latest results from https://repoferee.sgdev.org/results the request needs to be signed. This is because the report can contain sensitive repo names.

To make it easier to fetch report this PR adds the command `sg security repo-report` which will do the required signing of  the request and fetch the results and then either print the report out to terminal or if the `-o` option is specified, write the results out to file

## Test plan
Tested locally
```
go run ./dev/sg security repo-report -o report.json
✅ Response received from repoferee
✅ Report written to "report.json"

  Last report run:  2024-05-16T16:37:28Z
  Next report run:  2024-05-16T17:07:28Z
```
