### PR TITLE
sg msp: only generate skaffold assets if last stage of rollouts

### DIFF
--- a/dev/sg/msp/helpers.go
+++ b/dev/sg/msp/helpers.go
@@ -262,7 +262,9 @@ func generateTerraform(service *spec.Spec, opts generateTerraformOptions) error 
 			return err
 		}
 
-		if rollout := service.BuildRolloutPipelineConfiguration(env); rollout != nil {
+		// Generate additional rollouts assets IFF this is the final stage of
+		// a rollout pipeline.
+		if rollout := service.BuildRolloutPipelineConfiguration(env); rollout.IsFinalStage() {
 			pending.Updatef("[%s] Building rollout pipeline configurations for environment %q...", serviceID, env.ID)
 
 			// We generate skaffold.yaml archive for upload to GCS. See


### PR DESCRIPTION
#62704 introduced a regression due to the changing of the semantics of `rollouts` configuration in code: previously, only the final stage would get it, but with #62704 this became available on all environments, and to infer the final stage a nil-safe helper `rollout.IsFinalStage()` was introduced.

This change fixes a missed check migration that causes additional assets to be incorrectly generated for non-final environments.

## Test plan

`sg msp generate -all`