### PR TITLE
feat/sg-msp: add more stats to 'fleet' command

### DIFF
--- a/dev/sg/msp/helpers.go
+++ b/dev/sg/msp/helpers.go
@@ -1,6 +1,7 @@
 package msp
 
 import (
+	"cmp"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -338,4 +339,10 @@ func collectAlertPolicies(svc *spec.Spec) (map[string]terraform.AlertPolicy, err
 		maps.Copy(collectedAlerts, monitoring.ResourceType.GoogleMonitoringAlertPolicy)
 	}
 	return collectedAlerts, nil
+}
+
+// sortSlice sorts a slice of elements and returns it, for ease of chaining.
+func sortSlice[S ~[]E, E cmp.Ordered](s S) S {
+	slices.Sort(s)
+	return s
 }


### PR DESCRIPTION
Nice-to-have summaries for adoption of various features:

1. Services vs Jobs
2. Rollout pipelines
3. Deploy types
4. Resource dependencies

## Test plan

![image](https://github.com/sourcegraph/sourcegraph/assets/23356519/733923c8-bfe1-40e2-8577-c3dc22c43bc3)
