### PR TITLE
auth: Make username from email deduplication dotcom only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Pressing the numpad `Enter` key will now cycle through in-file search results [#62665](https://github.com/sourcegraph/sourcegraph/pull/62665)
 - Fixed an issue where code graph configuration policies would miscategorize lightweight tags as branches. [#62671](https://github.com/sourcegraph/sourcegraph/pull/62671)
 - Providing an access token via the [`SRC_ACCESS_TOKEN`](https://sourcegraph.com/docs/cli/how-tos/creating_an_access_token) environment variable is now mandatory for uploading SCIP indexes using [src-cli](https://sourcegraph.com/docs/cli). [#62573](https://github.com/sourcegraph/sourcegraph/pull/62573)
+- Fixed an issue where usernames were too eagerly suffixed with a random ID to prevent duplicates which could cause issues with Bitbucket Server permissions syncing where exact username matches are required. [#62747](https://github.com/sourcegraph/sourcegraph/pull/62747)
 
 ## 5.4.0
 

--- a/cmd/frontend/auth/BUILD.bazel
+++ b/cmd/frontend/auth/BUILD.bazel
@@ -59,6 +59,7 @@ go_test(
         "//internal/conf",
         "//internal/database",
         "//internal/database/dbmocks",
+        "//internal/dotcom",
         "//internal/errcode",
         "//internal/extsvc",
         "//internal/telemetry/telemetrytest",

--- a/cmd/frontend/auth/auth_test.go
+++ b/cmd/frontend/auth/auth_test.go
@@ -8,29 +8,23 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/sourcegraph/sourcegraph/internal/auth/userpasswd"
+	"github.com/sourcegraph/sourcegraph/internal/dotcom"
 )
 
 func TestNormalizeUsername(t *testing.T) {
-	userpasswd.MockAddRandomSuffix = func(s string) (string, error) {
-		return fmt.Sprintf("%s-ubioa", s), nil
-	}
-	t.Cleanup(func() {
-		userpasswd.MockAddRandomSuffix = nil
-	})
-
 	testCases := []struct {
 		in     string
 		out    string
 		hasErr bool
 	}{
 		{in: "username", out: "username"},
-		{in: "john@gmail.com", out: "john-ubioa"},
-		{in: "john.appleseed@gmail.com", out: "john.appleseed-ubioa"},
-		{in: "john+test@gmail.com", out: "john-test-ubioa"},
+		{in: "john@gmail.com", out: "john"},
+		{in: "john.appleseed@gmail.com", out: "john.appleseed"},
+		{in: "john+test@gmail.com", out: "john-test"},
 		{in: "this@is@not-an-email", out: "this-is-not-an-email"},
 		{in: "user.na$e", out: "user.na-e"},
 		{in: "2039f0923f0", out: "2039f0923f0"},
-		{in: "john(test)@gmail.com", out: "john-test-ubioa"},
+		{in: "john(test)@gmail.com", out: "john-test-"},
 		{in: "bob!", out: "bob-"},
 		{in: "john_doe", out: "john_doe"},
 		{in: "john__doe", out: "john__doe"},
@@ -38,7 +32,7 @@ func TestNormalizeUsername(t *testing.T) {
 		{in: "__john", out: "__john"},
 		{in: "bob_", out: "bob_"},
 		{in: "bob__", out: "bob__"},
-		{in: "user_@name", out: "user_-ubioa"},
+		{in: "user_@name", out: "user_"},
 		{in: "1", out: "1"},
 		{in: "a", out: "a"},
 		{in: "a-", out: "a-"},
@@ -51,6 +45,48 @@ func TestNormalizeUsername(t *testing.T) {
 		{in: "user.-name", out: "user-name"},
 		{in: ".", hasErr: true},
 		{in: "-", hasErr: true},
+	}
+
+	for _, tc := range testCases {
+		out, err := NormalizeUsername(tc.in)
+		if tc.hasErr {
+			if err == nil {
+				t.Errorf("Expected error on input %q, but there was none, output was %q", tc.in, out)
+			}
+		} else {
+			if err != nil {
+				t.Errorf("Unexpected error on input %q: %s", tc.in, err)
+			} else if out != tc.out {
+				t.Errorf("Expected %q to normalize to %q, but got %q", tc.in, tc.out, out)
+			}
+
+			if !IsValidUsername(out) {
+				t.Errorf("Normalization succeeded, but output %q is still not a valid username", out)
+			}
+		}
+	}
+}
+
+func TestNormalizeUsernameDotcom(t *testing.T) {
+	userpasswd.MockAddRandomSuffix = func(s string) (string, error) {
+		return fmt.Sprintf("%s-ubioa", s), nil
+	}
+	t.Cleanup(func() {
+		userpasswd.MockAddRandomSuffix = nil
+	})
+	dotcom.MockSourcegraphDotComMode(t, true)
+
+	testCases := []struct {
+		in     string
+		out    string
+		hasErr bool
+	}{
+		{in: "john@gmail.com", out: "john-ubioa"},
+		{in: "john.appleseed@gmail.com", out: "john.appleseed-ubioa"},
+		{in: "john+test@gmail.com", out: "john-test-ubioa"},
+		{in: "this@is@not-an-email", out: "this-is-not-an-email"},
+		{in: "john(test)@gmail.com", out: "john-test-ubioa"},
+		{in: "user_@name", out: "user_-ubioa"},
 	}
 
 	for _, tc := range testCases {

--- a/cmd/frontend/internal/auth/httpheader/BUILD.bazel
+++ b/cmd/frontend/internal/auth/httpheader/BUILD.bazel
@@ -43,7 +43,6 @@ go_test(
         "//cmd/frontend/auth",
         "//internal/actor",
         "//internal/auth/providers",
-        "//internal/auth/userpasswd",
         "//internal/conf",
         "//internal/database",
         "//internal/database/dbtest",

--- a/cmd/frontend/internal/auth/httpheader/middleware_test.go
+++ b/cmd/frontend/internal/auth/httpheader/middleware_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/auth"
 	sgactor "github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/auth/providers"
-	"github.com/sourcegraph/sourcegraph/internal/auth/userpasswd"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/licensing"
@@ -23,12 +22,6 @@ import (
 // SEE ALSO FOR MANUAL TESTING: See the Middleware docstring for information about the testproxy
 // helper program, which helps with manual testing of the HTTP auth proxy behavior.
 func TestMiddleware(t *testing.T) {
-	userpasswd.MockAddRandomSuffix = func(s string) (string, error) {
-		return fmt.Sprintf("%s-ubioa", s), nil
-	}
-	t.Cleanup(func() {
-		userpasswd.MockAddRandomSuffix = nil
-	})
 	defer licensing.TestingSkipFeatureChecks()()
 
 	logger := logtest.Scoped(t)
@@ -141,7 +134,7 @@ func TestMiddleware(t *testing.T) {
 		var calledMock bool
 		auth.MockGetAndSaveUser = func(ctx context.Context, op auth.GetAndSaveUserOp) (newUserCreated bool, userID int32, safeErrMsg string, err error) {
 			calledMock = true
-			if got, want := op.UserProps.Username, "alice-ubioa"; got != want {
+			if got, want := op.UserProps.Username, "alice"; got != want {
 				t.Errorf("expected %v got %v", want, got)
 			}
 			if got, want := op.UserProps.Email, "alice@example.com"; got != want {

--- a/cmd/frontend/internal/auth/scim/BUILD.bazel
+++ b/cmd/frontend/internal/auth/scim/BUILD.bazel
@@ -59,7 +59,6 @@ go_test(
     embed = [":scim"],
     tags = [TAG_PLATFORM_SOURCE],
     deps = [
-        "//internal/auth/userpasswd",
         "//internal/conf",
         "//internal/database",
         "//internal/database/dbmocks",

--- a/cmd/frontend/internal/auth/scim/user_create_test.go
+++ b/cmd/frontend/internal/auth/scim/user_create_test.go
@@ -2,14 +2,12 @@ package scim
 
 import (
 	"context"
-	"fmt"
 	"strconv"
 	"testing"
 
 	"github.com/elimity-com/scim"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/sourcegraph/sourcegraph/internal/auth/userpasswd"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
@@ -18,13 +16,6 @@ import (
 )
 
 func TestUserResourceHandler_Create(t *testing.T) {
-	userpasswd.MockAddRandomSuffix = func(s string) (string, error) {
-		return fmt.Sprintf("%s-ubioa", s), nil
-	}
-	t.Cleanup(func() {
-		userpasswd.MockAddRandomSuffix = nil
-	})
-
 	txemail.DisableSilently()
 	db := getMockDB([]*types.UserForSCIM{
 		{User: types.User{ID: 1, Username: "user1", DisplayName: "Yay Scim", SCIMControlled: true}, Emails: []string{"a@example.com"}, SCIMExternalID: "id1"},
@@ -72,7 +63,7 @@ func TestUserResourceHandler_Create(t *testing.T) {
 			username: "test@company.com",
 			testFunc: func(t *testing.T, usernameInDB string, usernameInResource string, err error) {
 				assert.NoError(t, err)
-				assert.Equal(t, "test-ubioa", usernameInDB)
+				assert.Equal(t, "test", usernameInDB)
 				assert.Equal(t, "test@company.com", usernameInResource)
 			},
 		},
@@ -90,7 +81,7 @@ func TestUserResourceHandler_Create(t *testing.T) {
 			username: "",
 			testFunc: func(t *testing.T, usernameInDB string, usernameInResource string, err error) {
 				assert.NoError(t, err)
-				assert.Len(t, usernameInDB, 6) // -abcde
+				assert.Len(t, usernameInDB, 5) // abcde
 				assert.Equal(t, "", usernameInResource)
 			},
 		},

--- a/internal/auth/userpasswd/BUILD.bazel
+++ b/internal/auth/userpasswd/BUILD.bazel
@@ -33,6 +33,7 @@ go_library(
         "//internal/cookie",
         "//internal/database",
         "//internal/deviceid",
+        "//internal/dotcom",
         "//internal/errcode",
         "//internal/extsvc",
         "//internal/featureflag",


### PR DESCRIPTION
https://github.com/sourcegraph/sourcegraph/pull/60339 introduced a new behavior that would always add a random suffix to usernames that are derived from email addresses.
The reason behind it seems to be that on dotcom, emails are from various domains and there are a lot of duplicates usually, and a lot of names that trigger our suspiciousness detection, like me@sourcegraph.com or me@sgdev.org.

For customer instances, this is not a real risk, and because of historic reasons, we depend on the username to be exactly what was given by the auth provider, so that bitbucket server permission syncing can work.
So this change for customer instances caused https://github.com/sourcegraph/sourcegraph/issues/62676.

To simplify the fix for this and make sure it can land in the next patch release, I opted for making this dotcom specific for now, as that's the least invasive change we can make.

Closes https://github.com/sourcegraph/sourcegraph/issues/62676

Test plan:

Created a new SAML application in Okta dev and lined that to my local instance.
A new user for `erik@sourcegraph.com` on main was called `erik-acbdef` after signup.
On this branch, with everything reset to fresh, a new user for `erik@sourcegraph.com` is called `erik`.
This should fix the bitbucket perms syncing issue.