### PR TITLE
Fix up "Manage team" page UI

### DIFF
--- a/client/web/src/cody/team/CodyManageTeamPage.module.scss
+++ b/client/web/src/cody/team/CodyManageTeamPage.module.scss
@@ -67,3 +67,9 @@
 .avatar-placeholder {
     border: 1px solid var(--border-color);
 }
+
+.team-member-list {
+    display: grid;
+    grid-template-columns: 1fr fit-content(10rem) 1fr fit-content(10rem) fit-content(10rem);
+    gap: 1rem;
+}

--- a/client/web/src/cody/team/CodyManageTeamPage.tsx
+++ b/client/web/src/cody/team/CodyManageTeamPage.tsx
@@ -95,7 +95,7 @@ const AuthenticatedCodyManageTeamPage: React.FunctionComponent<CodyManageTeamPag
                                 <Button
                                     as={Link}
                                     to="/cody/manage/subscription/new"
-                                    variant="primary"
+                                    variant="success"
                                     className="text-nowrap"
                                 >
                                     <Icon aria-hidden={true} svgPath={mdiPlusThick} /> Add seats

--- a/client/web/src/cody/team/CodyManageTeamPage.tsx
+++ b/client/web/src/cody/team/CodyManageTeamPage.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useMemo } from 'react'
 
-import { mdiPlusThick, mdiOpenInNew } from '@mdi/js'
+import { mdiPlusThick } from '@mdi/js'
 import classNames from 'classnames'
 import { useNavigate } from 'react-router-dom'
 
@@ -91,14 +91,6 @@ const AuthenticatedCodyManageTeamPage: React.FunctionComponent<CodyManageTeamPag
                                     }
                                 >
                                     Manage subscription
-                                    <Icon
-                                        svgPath={mdiOpenInNew}
-                                        inline={false}
-                                        aria-hidden={true}
-                                        height="1rem"
-                                        width="1rem"
-                                        className="ml-2"
-                                    />
                                 </Link>
                                 <Button
                                     as={Link}

--- a/client/web/src/cody/team/CodyManageTeamPage.tsx
+++ b/client/web/src/cody/team/CodyManageTeamPage.tsx
@@ -106,7 +106,8 @@ const AuthenticatedCodyManageTeamPage: React.FunctionComponent<CodyManageTeamPag
                 >
                     <PageHeader.Heading as="h2" styleAs="h1">
                         <div className="d-inline-flex align-items-center">
-                            <WhiteIcon name="mdi-account-multiple-plus-gradient" />
+                            <WhiteIcon name="mdi-account-multiple-plus-gradient" className="mr-3" />
+                            Manage team
                         </div>
                     </PageHeader.Heading>
                 </PageHeader>

--- a/client/web/src/cody/team/InviteUsers.tsx
+++ b/client/web/src/cody/team/InviteUsers.tsx
@@ -123,7 +123,7 @@ export const InviteUsers: React.FunctionComponent<InviteUsersProps> = ({
                             />
                             <Text className="text-muted mb-2">Enter email addresses separated by a comma.</Text>
                             <Text className="text-danger mb-2">{emailAddressErrorMessage}</Text>
-                            <div className="d-flex justify-content-end">
+                            <div>
                                 <ButtonLink variant="success" size="sm" onSelect={onSendInvitesClicked}>
                                     Send
                                 </ButtonLink>

--- a/client/web/src/cody/team/InviteUsers.tsx
+++ b/client/web/src/cody/team/InviteUsers.tsx
@@ -119,6 +119,7 @@ export const InviteUsers: React.FunctionComponent<InviteUsersProps> = ({
                                 setEmailAddressErrorMessage(null)
                                 setEmailAddressesString(event.target.value)
                             }}
+                            isValid={emailAddressErrorMessage ? false : undefined}
                         />
                         <Text className="text-muted mb-2">Enter email addresses separated by a comma.</Text>
                         <Text className="text-danger mb-2">{emailAddressErrorMessage}</Text>

--- a/client/web/src/cody/team/InviteUsers.tsx
+++ b/client/web/src/cody/team/InviteUsers.tsx
@@ -95,43 +95,41 @@ export const InviteUsers: React.FunctionComponent<InviteUsersProps> = ({
                 </div>
             )}
 
-            {!!remainingInviteCount && (
-                <div className={classNames('p-4 border bg-1 mb-4 d-flex flex-row', styles.container)}>
-                    <div className="d-flex justify-content-between align-items-center w-100">
+            <div className={classNames('p-4 border bg-1 mb-4 d-flex flex-row', styles.container)}>
+                <div className="d-flex justify-content-between align-items-center w-100">
+                    <div>
+                        <img
+                            src="https://storage.googleapis.com/sourcegraph-assets/cody/user-badges.png"
+                            alt="User badges"
+                            width="230"
+                            height="202"
+                            className={classNames('mr-3')}
+                        />
+                    </div>
+                    <div className="flex-1 d-flex flex-column">
+                        <H2 className={classNames('mb-4', styles.inviteUsersHeader)}>
+                            <strong>Invite users</strong> – You have {remainingInviteCount} free{' '}
+                            {pluralize('seat', remainingInviteCount)}
+                        </H2>
+                        <TextArea
+                            className={classNames('mb-2')}
+                            placeholder="Example: someone@sourcegraph.com, another.user@sourcegraph.com"
+                            rows={4}
+                            onChange={event => {
+                                setEmailAddressErrorMessage(null)
+                                setEmailAddressesString(event.target.value)
+                            }}
+                        />
+                        <Text className="text-muted mb-2">Enter email addresses separated by a comma.</Text>
+                        <Text className="text-danger mb-2">{emailAddressErrorMessage}</Text>
                         <div>
-                            <img
-                                src="https://storage.googleapis.com/sourcegraph-assets/cody/user-badges.png"
-                                alt="User badges"
-                                width="230"
-                                height="202"
-                                className={classNames('mr-3')}
-                            />
-                        </div>
-                        <div className="flex-1 d-flex flex-column">
-                            <H2 className={classNames('mb-4', styles.inviteUsersHeader)}>
-                                <strong>Invite users</strong> – You have {remainingInviteCount} free{' '}
-                                {pluralize('seat', remainingInviteCount)}
-                            </H2>
-                            <TextArea
-                                className={classNames('mb-2')}
-                                placeholder="Example: someone@sourcegraph.com, another.user@sourcegraph.com"
-                                rows={4}
-                                onChange={event => {
-                                    setEmailAddressErrorMessage(null)
-                                    setEmailAddressesString(event.target.value)
-                                }}
-                            />
-                            <Text className="text-muted mb-2">Enter email addresses separated by a comma.</Text>
-                            <Text className="text-danger mb-2">{emailAddressErrorMessage}</Text>
-                            <div>
-                                <ButtonLink variant="success" size="sm" onSelect={onSendInvitesClicked}>
-                                    Send
-                                </ButtonLink>
-                            </div>
+                            <ButtonLink variant="success" size="sm" onSelect={onSendInvitesClicked}>
+                                Send
+                            </ButtonLink>
                         </div>
                     </div>
                 </div>
-            )}
+            </div>
         </>
     )
 }

--- a/client/web/src/cody/team/InviteUsers.tsx
+++ b/client/web/src/cody/team/InviteUsers.tsx
@@ -121,8 +121,12 @@ export const InviteUsers: React.FunctionComponent<InviteUsersProps> = ({
                             }}
                             isValid={emailAddressErrorMessage ? false : undefined}
                         />
-                        <Text className="text-muted mb-2">Enter email addresses separated by a comma.</Text>
-                        <Text className="text-danger mb-2">{emailAddressErrorMessage}</Text>
+                        {emailAddressErrorMessage ? (
+                            <Text className="text-danger mb-2">{emailAddressErrorMessage}</Text>
+                        ) : (
+                            <Text className="text-muted mb-2">Enter email addresses separated by a comma.</Text>
+                        )}
+
                         <div>
                             <ButtonLink variant="success" size="sm" onSelect={onSendInvitesClicked}>
                                 Send

--- a/client/web/src/cody/team/InviteUsers.tsx
+++ b/client/web/src/cody/team/InviteUsers.tsx
@@ -108,8 +108,8 @@ export const InviteUsers: React.FunctionComponent<InviteUsersProps> = ({
                     </div>
                     <div className="flex-1 d-flex flex-column">
                         <H2 className={classNames('mb-4', styles.inviteUsersHeader)}>
-                            <strong>Invite users</strong> – You have {remainingInviteCount} free{' '}
-                            {pluralize('seat', remainingInviteCount)}
+                            <strong>Invite users</strong> – {remainingInviteCount}{' '}
+                            {pluralize('seat', remainingInviteCount)} remaining
                         </H2>
                         <TextArea
                             className={classNames('mb-2')}

--- a/client/web/src/cody/team/TeamMemberList.tsx
+++ b/client/web/src/cody/team/TeamMemberList.tsx
@@ -193,7 +193,11 @@ export const TeamMemberList: FunctionComponent<TeamMemberListProps> = ({
                                 </div>
                             </div>
                             <div className="align-content-center">
-                                {member.role === 'admin' && <Badge variant="primary" className="text-uppercase">admin</Badge>}
+                                {member.role === 'admin' && (
+                                    <Badge variant="primary" className="text-uppercase">
+                                        admin
+                                    </Badge>
+                                )}
                             </div>
                             <div />
                             {isAdmin ? (
@@ -259,7 +263,11 @@ export const TeamMemberList: FunctionComponent<TeamMemberListProps> = ({
                                     <Badge variant="secondary" className="mr-2 text-uppercase">
                                         invited
                                     </Badge>
-                                    {invite.role === 'admin' && <Badge variant="primary" className="text-uppercase">admin</Badge>}
+                                    {invite.role === 'admin' && (
+                                        <Badge variant="primary" className="text-uppercase">
+                                            admin
+                                        </Badge>
+                                    )}
                                 </div>
                                 <div className="align-content-center">
                                     <em>Invite sent {invite.sentAt /* TODO format this */}</em>

--- a/client/web/src/cody/team/TeamMemberList.tsx
+++ b/client/web/src/cody/team/TeamMemberList.tsx
@@ -274,7 +274,7 @@ export const TeamMemberList: FunctionComponent<TeamMemberListProps> = ({
                                         <div className="align-content-center text-center">
                                             <ButtonLink
                                                 to="#"
-                                                variant="success"
+                                                variant="secondary"
                                                 size="sm"
                                                 onClick={() => resendInvite(invite.id)}
                                                 className="ml-2"

--- a/client/web/src/cody/team/TeamMemberList.tsx
+++ b/client/web/src/cody/team/TeamMemberList.tsx
@@ -193,7 +193,7 @@ export const TeamMemberList: FunctionComponent<TeamMemberListProps> = ({
                                 </div>
                             </div>
                             <div className="align-content-center">
-                                {member.role === 'admin' && <Badge variant="primary">ADMIN</Badge>}
+                                {member.role === 'admin' && <Badge variant="primary" className="text-uppercase">admin</Badge>}
                             </div>
                             <div />
                             {isAdmin ? (
@@ -256,10 +256,10 @@ export const TeamMemberList: FunctionComponent<TeamMemberListProps> = ({
                                     </div>
                                 </div>
                                 <div className="align-content-center">
-                                    <Badge variant="secondary" className="mr-2">
-                                        INVITED
+                                    <Badge variant="secondary" className="mr-2 text-uppercase">
+                                        invited
                                     </Badge>
-                                    {invite.role === 'admin' && <Badge variant="primary">ADMIN</Badge>}
+                                    {invite.role === 'admin' && <Badge variant="primary" className="text-uppercase">admin</Badge>}
                                 </div>
                                 <div className="align-content-center">
                                     <em>Invite sent {invite.sentAt /* TODO format this */}</em>

--- a/client/web/src/cody/team/TeamMemberList.tsx
+++ b/client/web/src/cody/team/TeamMemberList.tsx
@@ -170,35 +170,37 @@ export const TeamMemberList: FunctionComponent<TeamMemberListProps> = ({
             <div className={classNames('p-4 border bg-1 d-flex flex-column', styles.container)}>
                 <H2 className="text-lg font-semibold mb-2">Team members</H2>
                 <Text className="text-sm text-gray-500 mb-4">Manage invited and active users</Text>
-                <ul className="space-y-4 d-flex flex-column list-none pl-0">
+                <ul className={classNames(styles.teamMemberList, 'list-none pl-0')}>
                     {teamMembers.map(member => (
-                        <li key={member.accountId} className="d-flex flex-row justify-between mb-4">
-                            <div className="flex-1 d-flex flex-row">
-                                {member.avatarUrl ? (
-                                    <img
-                                        src={member.avatarUrl}
-                                        alt="avatar"
-                                        width="40"
-                                        height="40"
-                                        className={classNames(styles.avatar)}
-                                    />
-                                ) : (
-                                    <div className={classNames(styles.avatar, styles.avatarPlaceholder)} />
-                                )}
-                                <div className="d-flex flex-column justify-content-center ml-2">
-                                    {member.displayName && <strong>{member.displayName}</strong>}
-                                    <Text className="mb-0">{member.email}</Text>
-                                </div>
-                                {member.role === 'admin' && (
+                        <li key={member.accountId} className="d-contents">
+                            <div className="align-content-center">
+                                <div className="d-flex flex-row">
+                                    {member.avatarUrl ? (
+                                        <img
+                                            src={member.avatarUrl}
+                                            alt="avatar"
+                                            width="40"
+                                            height="40"
+                                            className={classNames(styles.avatar)}
+                                        />
+                                    ) : (
+                                        <div className={classNames(styles.avatar, styles.avatarPlaceholder)} />
+                                    )}
                                     <div className="d-flex flex-column justify-content-center ml-2">
-                                        <Badge variant="primary">ADMIN</Badge>
+                                        {member.displayName && <strong>{member.displayName}</strong>}
+                                        <Text className="mb-0">{member.email}</Text>
                                     </div>
-                                )}
+                                </div>
                             </div>
-                            {isAdmin && (
-                                <div className="d-flex">
-                                    {member.role === 'admin' ? (
-                                        <div className="d-flex flex-column justify-content-center ml-2">
+                            <div className="align-content-center">
+                                {member.role === 'admin' && <Badge variant="primary">ADMIN</Badge>}
+                            </div>
+                            <div />
+                            {isAdmin ? (
+                                member.role === 'admin' ? (
+                                    <>
+                                        <div />
+                                        <div className="align-content-center">
                                             <Link
                                                 to="#"
                                                 onClick={() => updateRole(member.accountId, 'member')}
@@ -208,78 +210,79 @@ export const TeamMemberList: FunctionComponent<TeamMemberListProps> = ({
                                                 Revoke admin
                                             </Link>
                                         </div>
-                                    ) : (
-                                        <>
-                                            <div className="d-flex flex-column justify-content-center ml-2">
-                                                <Link
-                                                    to="#"
-                                                    onClick={() => updateRole(member.accountId, 'admin')}
-                                                    className="ml-2"
-                                                >
-                                                    Make admin
-                                                </Link>
-                                            </div>
-                                            <div className="d-flex flex-column justify-content-center ml-2">
-                                                <ButtonLink
-                                                    to="#"
-                                                    variant="danger"
-                                                    size="sm"
-                                                    onClick={() => removeMember(member.accountId)}
-                                                    className="ml-2"
-                                                >
-                                                    Remove
-                                                </ButtonLink>
-                                            </div>
-                                        </>
-                                    )}
-                                </div>
+                                    </>
+                                ) : (
+                                    <>
+                                        <div className="align-content-center">
+                                            <Link
+                                                to="#"
+                                                onClick={() => updateRole(member.accountId, 'admin')}
+                                                className="ml-2"
+                                            >
+                                                Make admin
+                                            </Link>
+                                        </div>
+                                        <div className="align-content-center">
+                                            <ButtonLink
+                                                to="#"
+                                                variant="danger"
+                                                size="sm"
+                                                onClick={() => removeMember(member.accountId)}
+                                                className="ml-2"
+                                            >
+                                                Remove
+                                            </ButtonLink>
+                                        </div>
+                                    </>
+                                )
+                            ) : (
+                                <>
+                                    <div />
+                                    <div />
+                                </>
                             )}
                         </li>
                     ))}
                     {invites
                         .filter(invite => invite.status === 'sent')
                         .map(invite => (
-                            <li key={invite.id} className="d-flex flex-row justify-between mb-4">
-                                <div className="flex-1 d-flex flex-row">
-                                    <div className={classNames(styles.avatar, styles.avatarPlaceholder)} />
-                                    <div className="d-flex flex-column justify-content-center ml-2">
-                                        <Text className="mb-0">{invite.email}</Text>
-                                    </div>
-                                    {invite.role === 'admin' && (
+                            <li key={invite.id} className="d-contents">
+                                <div className="align-content-center">
+                                    <div className="d-flex flex-row">
+                                        <div className={classNames(styles.avatar, styles.avatarPlaceholder)} />
                                         <div className="d-flex flex-column justify-content-center ml-2">
-                                            <Badge variant="primary">ADMIN</Badge>
-                                        </div>
-                                    )}
-                                    <div className="d-flex flex-column justify-content-center ml-2">
-                                        <div className="d-flex flex-row">
-                                            <div className="d-flex flex-column justify-content-center ml-2">
-                                                <Badge variant="secondary">INVITED</Badge>
-                                            </div>
-                                            <em className="ml-4">Invite sent {invite.sentAt /* TODO format this */}</em>
+                                            <Text className="mb-0">{invite.email}</Text>
                                         </div>
                                     </div>
                                 </div>
+                                <div className="align-content-center">
+                                    <Badge variant="secondary" className="mr-2">
+                                        INVITED
+                                    </Badge>
+                                    {invite.role === 'admin' && <Badge variant="primary">ADMIN</Badge>}
+                                </div>
+                                <div className="align-content-center">
+                                    <em>Invite sent {invite.sentAt /* TODO format this */}</em>
+                                </div>
                                 {isAdmin && (
-                                    <div className="d-flex">
-                                        <div className="d-flex row justify-content-center ml-2">
-                                            <div className="d-flex flex-column justify-content-center ml-2">
-                                                <Link to="#" onClick={() => revokeInvite(invite.id)} className="ml-2">
-                                                    Revoke
-                                                </Link>
-                                            </div>
-                                            <div className="d-flex flex-column justify-content-center ml-2">
-                                                <ButtonLink
-                                                    to="#"
-                                                    variant="success"
-                                                    size="sm"
-                                                    onClick={() => resendInvite(invite.id)}
-                                                    className="ml-2"
-                                                >
-                                                    Resend invite
-                                                </ButtonLink>
-                                            </div>
+                                    <>
+                                        <div className="align-content-center">
+                                            <Link to="#" onClick={() => revokeInvite(invite.id)} className="ml-2">
+                                                Revoke
+                                            </Link>
                                         </div>
-                                    </div>
+                                        <div className="align-content-center">
+                                            <ButtonLink
+                                                to="#"
+                                                variant="success"
+                                                size="sm"
+                                                onClick={() => resendInvite(invite.id)}
+                                                className="ml-2"
+                                            >
+                                                Resend invite
+                                            </ButtonLink>
+                                        </div>
+                                    </>
                                 )}
                             </li>
                         ))}

--- a/client/web/src/cody/team/TeamMemberList.tsx
+++ b/client/web/src/cody/team/TeamMemberList.tsx
@@ -200,7 +200,7 @@ export const TeamMemberList: FunctionComponent<TeamMemberListProps> = ({
                                 member.role === 'admin' ? (
                                     <>
                                         <div />
-                                        <div className="align-content-center">
+                                        <div className="align-content-center text-center">
                                             <Link
                                                 to="#"
                                                 onClick={() => updateRole(member.accountId, 'member')}
@@ -213,7 +213,7 @@ export const TeamMemberList: FunctionComponent<TeamMemberListProps> = ({
                                     </>
                                 ) : (
                                     <>
-                                        <div className="align-content-center">
+                                        <div className="align-content-center text-center">
                                             <Link
                                                 to="#"
                                                 onClick={() => updateRole(member.accountId, 'admin')}
@@ -222,7 +222,7 @@ export const TeamMemberList: FunctionComponent<TeamMemberListProps> = ({
                                                 Make admin
                                             </Link>
                                         </div>
-                                        <div className="align-content-center">
+                                        <div className="align-content-center text-center">
                                             <ButtonLink
                                                 to="#"
                                                 variant="danger"
@@ -266,12 +266,12 @@ export const TeamMemberList: FunctionComponent<TeamMemberListProps> = ({
                                 </div>
                                 {isAdmin && (
                                     <>
-                                        <div className="align-content-center">
+                                        <div className="align-content-center text-center">
                                             <Link to="#" onClick={() => revokeInvite(invite.id)} className="ml-2">
                                                 Revoke
                                             </Link>
                                         </div>
-                                        <div className="align-content-center">
+                                        <div className="align-content-center text-center">
                                             <ButtonLink
                                                 to="#"
                                                 variant="success"

--- a/client/web/src/cody/team/TeamMemberList.tsx
+++ b/client/web/src/cody/team/TeamMemberList.tsx
@@ -279,7 +279,7 @@ export const TeamMemberList: FunctionComponent<TeamMemberListProps> = ({
                                                 onClick={() => resendInvite(invite.id)}
                                                 className="ml-2"
                                             >
-                                                Resend invite
+                                                Re-send invite
                                             </ButtonLink>
                                         </div>
                                     </>

--- a/client/web/src/cody/team/WhiteIcon.tsx
+++ b/client/web/src/cody/team/WhiteIcon.tsx
@@ -1,11 +1,13 @@
 import React from 'react'
 
 import styles from './WhiteIcon.module.scss'
+import classNames from 'classnames'
 
 export const ICON_NAMES = ['mdi-account-multiple-plus-gradient'] as const
 
 interface WhiteIconProps {
     name: typeof ICON_NAMES[number]
+    className?: string
 }
 
 const nameToUrl = {
@@ -14,12 +16,13 @@ const nameToUrl = {
 }
 
 export const WhiteIcon: React.FunctionComponent<WhiteIconProps> = ({ name, ...attributes }) => {
+    const { className, ...otherAttributes } = attributes
     if (!name || !ICON_NAMES.includes(name)) {
         return null
     }
 
     return (
-        <div className={styles.whiteBox} {...attributes}>
+        <div className={classNames(styles.whiteBox, className)} {...otherAttributes}>
             <img className={styles.whiteBoxContent} src={nameToUrl[name]} alt={name} />
             <svg
                 className={styles.whiteBoxBackground}

--- a/client/web/src/cody/team/WhiteIcon.tsx
+++ b/client/web/src/cody/team/WhiteIcon.tsx
@@ -1,7 +1,8 @@
 import React from 'react'
 
-import styles from './WhiteIcon.module.scss'
 import classNames from 'classnames'
+
+import styles from './WhiteIcon.module.scss'
 
 export const ICON_NAMES = ['mdi-account-multiple-plus-gradient'] as const
 


### PR DESCRIPTION
@rrhyne left a bunch of feedback in [this figma](https://www.figma.com/design/FMSdn1oKccJRHQPgf7053o/Cody-PLG-GA?node-id=4658-19941&t=MhldUPrMz6gjSVBy-0) and [this Loom](https://www.loom.com/share/bb527ad52f4442bd9196e833a4e7be92) that I totally overlooked at first.

This PR contains all the fixes listen in the Figma and Loom (unless I mixed something).

This is a complete list:
- Page
    - Added missing page title
    - Removed "open in new" icon from "Manage subscription" link
    - Made the "Add seats" button be of the "success" type (green) rather than "primary" (blue)
- Invites
    - Fixed textarea label copy
    - Added a red outline to textbox if the input has an error
    - Made the error text replace the help text in case of an error
    - Left-aligned "Send" button
- Team member list
    - Converted the list to a table-like arrangement
    - Updated "Re-send invite" button type to "secondary" (outline)
    - Center-aligned action buttons
    - Fix copy: "Resend" → "Re-send" to match the figma

Also:
- Code cleanup: Removed an unneeded condition) – see separate commit
- Use `text-uppercase` class in ADMIN and INVITED labels

## Test plan

[Here is a 2.5-minute Loom](https://www.loom.com/share/7b8f2af1af744217970c4810297c4940) where I demo the changes.