### PR TITLE
chore(licenses): fix khroma and elkjs

### DIFF
--- a/doc/dependency_decisions.yml
+++ b/doc/dependency_decisions.yml
@@ -595,3 +595,16 @@
   - oss.terrastruct.com/util-go
   - ISC
   - *5
+- - :license
+  - khroma
+  - MIT
+  - :who:
+    :why:
+    :versions: []
+    :when: 2024-05-17 13:16:23.875425000 Z
+- - :permit
+  - EPL-2.0
+  - :who:
+    :why: permissive open source license
+    :versions: []
+    :when: 2024-05-17 13:21:45.702008000 Z


### PR DESCRIPTION
<!--

💡 To write a useful PR description, make sure that your description covers:

- WHAT this PR is changing:
    - How was it PREVIOUSLY.
    - How it will be from NOW on.
- WHY this PR is needed.
- CONTEXT, i.e. to which initiative, project or RFC it belongs.

The structure of the description doesn't matter as much as covering these points, so use
your best judgement based on your context.

Learn how to write good pull request description: https://www.notion.so/sourcegraph/Write-a-good-pull-request-description-610a7fd3e613496eb76f450db5a49b6e?pvs=4
-->

Khroma and Elkjs were raising errors in the license checker: 

- ElkJS because its license is EPL-2.0 and we've never had that case before. 
  - Added to allowed licenses. 
- Khroma is [MIT](https://github.com/fabiospampinato/khroma/blob/master/license) but the NPM package is not up to date with regards to that info, and thus the license checker returns "unknown" when querying NPM. 
  - Manually assigned the license.   

## Test plan

CI, in particular the license check action

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles

Why does it matter?

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers.
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component:
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests"
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs:
  - "previewed locally"
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI"
  - "locally tested"
-->
