### PR TITLE
Fix a condition I negated by accident

### DIFF
--- a/client/web/src/cody/subscription/CodySubscriptionPage.tsx
+++ b/client/web/src/cody/subscription/CodySubscriptionPage.tsx
@@ -72,7 +72,7 @@ export const CodySubscriptionPage: React.FunctionComponent<CodySubscriptionPageP
         return null
     }
 
-    const isProUser = data.currentUser.codySubscription?.plan !== CodySubscriptionPlan.PRO
+    const isProUser = data.currentUser.codySubscription?.plan === CodySubscriptionPlan.PRO
 
     return (
         <>


### PR DESCRIPTION
I accidentally negated a condition here: https://github.com/sourcegraph/sourcegraph/pull/62453/files#diff-e49c67a73cb92dfd40a6015761f04bc49b5e72bd3a22b7faa7dc7c5d1390a305L74. This is a fix to revert that.

- I merged the PR on May 15th, 9 am UTC
- Was probably released about 24h later.
- Was wrong for about 30 hours :/

It caused this:

![CleanShot 2024-05-17 at 15 48 29@2x](https://github.com/sourcegraph/sourcegraph/assets/2552265/299d311e-f124-4376-9777-bfa504440276)

to display like this for new users:

![CleanShot 2024-05-17 at 15 49 00@2x](https://github.com/sourcegraph/sourcegraph/assets/2552265/1eda065e-0201-4639-b4ae-cf89057b74c6)

and vice versa.

It probably highly impacted our conversion rate for yesterday.

Why didn't we notice this in the code reviews: I probably messed it up when I was addressing feedback, and didn't wait for the re-review to move fast.

## Test plan

It worked before, I only changed it by accident.