### PR TITLE
fix(sg/eph): handle nil regex

### DIFF
--- a/dev/sg/internal/cloud/artifact_registry.go
+++ b/dev/sg/internal/cloud/artifact_registry.go
@@ -20,6 +20,12 @@ type DockerImageFilterOpt func(image *DockerImage) bool
 
 // FilterTagByRegex filters the Docker Image tags by the given regular expression
 func FilterTagByRegex(regex *regexp.Regexp) DockerImageFilterOpt {
+	if regex == nil {
+		return func(image *DockerImage) bool {
+			return true
+		}
+	}
+
 	return func(image *DockerImage) bool {
 		for _, tag := range image.Tags {
 			if regex.MatchString(tag) {
@@ -103,6 +109,14 @@ func (ar *ArtifactRegistry) ListDockerImages(ctx context.Context, filterOpts ...
 		Parent:   ar.Parent(),
 		PageSize: ar.PageSize,
 		OrderBy:  "upload_time",
+	}
+
+	// if we have no any filter options, we just accept all images
+	if len(filterOpts) == 0 {
+		acceptAll := func(image *DockerImage) bool {
+			return true
+		}
+		filterOpts = append(filterOpts, acceptAll)
 	}
 
 	images := []*DockerImage{}

--- a/dev/sg/internal/cloud/list_versions_command.go
+++ b/dev/sg/internal/cloud/list_versions_command.go
@@ -102,7 +102,7 @@ Image count           : %d`, tag, image.UploadTime.AsTime().Format(time.DateTime
 					break
 				}
 			}
-			std.Out.WriteSuggestionf("Some tags might have been truncated. To see the full tag ouput use the --raw format or filter the tags by using --filter")
+			std.Out.WriteSuggestionf("Some tags might have been truncated. To see the full tag output use the --raw format or filter the tags by using --filter")
 		}
 	}
 	return nil


### PR DESCRIPTION
if you didn't provide a regex this during filtering list-versions would break. This slipped through while doing last minute refactoring.

```
go run ./dev/sg cloud eph list-versions
☁️ Retrieved 543 docker images from registry "cloud-ephemeral"
Tag                                                Upload time          Image count
b6a5c7dd76f292ce90a6d3c4c029f072ad41848b_272681... 2024-03-15 11:19:33  48
wb-sg-cloud-eph-delete_271241_2024-04-29_5.3-76... 2024-03-15 11:19:33  48
2c328e9e7e08_265572                                2024-03-15 11:19:17  45
23fafbf0fa90eff28fe5ba8b3cdcd3bd09a313d3_269589... 2024-03-15 11:19:33  46
e90a171118c9_2024-03-15                            2024-03-15 11:19:17  45
6d88b156f78664c3a73b45693473ae7de58b25e4_270425... 2024-03-15 11:19:33  47
```

## Test plan
Tested locally
