### PR TITLE
gitserver: Switch corruption logs to use separate file

### DIFF
--- a/cmd/gitserver/internal/cleanup_test.go
+++ b/cmd/gitserver/internal/cleanup_test.go
@@ -421,10 +421,9 @@ func TestCleanupBroken(t *testing.T) {
 		}
 	}
 	{
-		cli := gitcli.NewBackend(logtest.Scoped(t), wrexec.NewNoOpRecordingCommandFactory(), common.GitDir(repoCorrupt), "perforce")
-		if err := cli.Config().Set(ctx, gitConfigMaybeCorrupt, "1"); err != nil {
-			t.Fatal(err)
-		}
+		f, err := os.Create(filepath.Join(repoCorrupt, gitcli.RepoMaybeCorruptFlagFilepath))
+		require.NoError(t, err)
+		require.NoError(t, f.Close())
 	}
 	{
 		cli := gitcli.NewBackend(logtest.Scoped(t), wrexec.NewNoOpRecordingCommandFactory(), common.GitDir(repoPerforceGCOld), "perforce")

--- a/cmd/gitserver/internal/git/gitcli/BUILD.bazel
+++ b/cmd/gitserver/internal/git/gitcli/BUILD.bazel
@@ -55,6 +55,7 @@ go_test(
     srcs = [
         "archivereader_test.go",
         "blame_test.go",
+        "command_test.go",
         "commitlog_test.go",
         "commits_test.go",
         "config_test.go",

--- a/cmd/gitserver/internal/git/gitcli/command_test.go
+++ b/cmd/gitserver/internal/git/gitcli/command_test.go
@@ -1,0 +1,52 @@
+package gitcli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/sourcegraph/sourcegraph/cmd/gitserver/internal/common"
+)
+
+func TestMarkRepoMaybeCorrupt(t *testing.T) {
+	dir := t.TempDir()
+	gitDir := common.GitDir(dir)
+
+	t.Run("creates file if not exists", func(t *testing.T) {
+		require.NoError(t, markRepoMaybeCorrupt(gitDir))
+
+		_, err := os.Stat(filepath.Join(dir, RepoMaybeCorruptFlagFilepath))
+		require.NoError(t, err)
+	})
+
+	t.Run("updates mtime if file exists", func(t *testing.T) {
+		filePath := filepath.Join(dir, RepoMaybeCorruptFlagFilepath)
+		f, err := os.Create(filePath)
+		require.NoError(t, err)
+		require.NoError(t, f.Close())
+
+		oldMtime, err := getFileMtime(filePath)
+		require.NoError(t, err)
+
+		err = markRepoMaybeCorrupt(gitDir)
+		require.NoError(t, err)
+
+		newMtime, err := getFileMtime(filePath)
+		require.NoError(t, err)
+
+		if !newMtime.After(oldMtime) {
+			t.Errorf("file mtime not updated")
+		}
+	})
+}
+
+func getFileMtime(path string) (time.Time, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return time.Time{}, err
+	}
+	return info.ModTime(), nil
+}


### PR DESCRIPTION
We still incur a ton of git config calls, those add pressure to the process spawning, so we instead do a much cheaper fs.Stat now to check for corruption.

Test plan:

Adjusted tests, CI and integration tests still pass.