### PR TITLE
repoupdater: Add retry policy to repositoryservice

### DIFF
--- a/cmd/repo-updater/internal/gitserver/BUILD.bazel
+++ b/cmd/repo-updater/internal/gitserver/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "//internal/api",
         "//internal/gitserver/connection",
         "//internal/gitserver/v1:gitserver",
+        "//internal/grpc/defaults",
     ],
 )
 

--- a/cmd/repo-updater/internal/gitserver/repositoryservice.go
+++ b/cmd/repo-updater/internal/gitserver/repositoryservice.go
@@ -7,6 +7,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/connection"
 	proto "github.com/sourcegraph/sourcegraph/internal/gitserver/v1"
+	"github.com/sourcegraph/sourcegraph/internal/grpc/defaults"
 )
 
 type RepositoryServiceClient interface {
@@ -27,7 +28,7 @@ func (c *repositoryServiceClient) DeleteRepository(ctx context.Context, repo api
 	}
 	_, err = cc.DeleteRepository(ctx, &proto.DeleteRepositoryRequest{
 		RepoName: string(repo),
-	})
+	}, defaults.RetryPolicy...)
 	return err
 }
 
@@ -38,7 +39,7 @@ func (c *repositoryServiceClient) FetchRepository(ctx context.Context, repo api.
 	}
 	resp, err := cc.FetchRepository(ctx, &proto.FetchRepositoryRequest{
 		RepoName: string(repo),
-	})
+	}, defaults.RetryPolicy...)
 	if err != nil {
 		return lastFetched, lastChanged, err
 	}


### PR DESCRIPTION
This new client didn't have any retries set, so we would always fast-fail when gitserver is unavailable. That makes the operation more noisy than it has to be, and potentially all repos back in the fetch queue, because it thinks the fetch itself failed.
All these methods are safe to be called a second time, so we can safely do that.

This is an easy fix to ensure repo updater waits a bit for gitserver to be back online.

Test plan:

Verified locally that fetches don't immediately fail when gitserver is down.