### PR TITLE
fix: Show full info for highlighter errors

### DIFF
--- a/docker-images/syntax-highlighter/Cargo.Bazel.lock
+++ b/docker-images/syntax-highlighter/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "086e602854ce0a57688fe32a92865811f1faabff847fbfff558769af2f1f7573",
+  "checksum": "d3f5c825139d9654d3455b2cbfb5eb0b964cbcd185b6624f3bd0d918f8d2067c",
   "crates": {
     "addr2line 0.20.0": {
       "name": "addr2line",
@@ -11804,6 +11804,10 @@
             {
               "id": "criterion 0.4.0",
               "target": "criterion"
+            },
+            {
+              "id": "insta 1.34.0",
+              "target": "insta"
             }
           ],
           "selects": {}

--- a/docker-images/syntax-highlighter/Cargo.lock
+++ b/docker-images/syntax-highlighter/Cargo.lock
@@ -2140,6 +2140,7 @@ dependencies = [
  "futures",
  "futures-task",
  "futures-util",
+ "insta",
  "protobuf",
  "rocket",
  "rustix",

--- a/docker-images/syntax-highlighter/Cargo.toml
+++ b/docker-images/syntax-highlighter/Cargo.toml
@@ -71,3 +71,4 @@ debug = true
 
 [dev-dependencies]
 criterion = { version = "0.4", features = ["html_reports"] }
+insta.workspace = true

--- a/docker-images/syntax-highlighter/src/lib.rs
+++ b/docker-images/syntax-highlighter/src/lib.rs
@@ -1,3 +1,5 @@
+use std::fmt::Display;
+
 use anyhow::Context;
 use rocket::serde::json::{json, Value as JsonValue};
 use serde::Deserialize;
@@ -105,8 +107,8 @@ impl ScipHighlightQuery {
     }
 }
 
-pub fn jsonify_err(e: impl ToString) -> JsonValue {
-    json!({"error": e.to_string()})
+pub fn jsonify_err(e: impl Display) -> JsonValue {
+    json!({"error": format!("{:#}", e)})
 }
 
 pub fn syntect_highlight(q: SourcegraphQuery) -> Result<JsonValue, JsonValue> {
@@ -155,4 +157,26 @@ pub fn scip_highlight(q: ScipHighlightQuery) -> Result<JsonValue, JsonValue> {
         debug_assert!(output.kind == PayloadKind::Base64EncodedScip);
         Ok(json!({"scip": output.payload, "plaintext": false}))
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use insta;
+
+    use crate::{scip_highlight, ScipHighlightQuery, SyntaxEngine};
+
+    #[test]
+    fn check_error() {
+        let result = scip_highlight(ScipHighlightQuery {
+            engine: SyntaxEngine::TreeSitter,
+            code: "int a = 3;".to_string(),
+            filepath: "a.c".to_string(),
+            filetype: None,
+            line_length_limit: None,
+        });
+        assert!(result.is_err());
+        // The default string formatting for an error only picks the most
+        // recent element. Make sure we're serializing the full context.
+        insta::assert_display_snapshot!(result.unwrap_err());
+    }
 }

--- a/docker-images/syntax-highlighter/src/snapshots/syntect_server__tests__check_error.snap
+++ b/docker-images/syntax-highlighter/src/snapshots/syntect_server__tests__check_error.snap
@@ -1,0 +1,5 @@
+---
+source: src/lib.rs
+expression: result.unwrap_err()
+---
+{"error":"/scip endpoint: Tree-sitter backend requires a language to be specified"}


### PR DESCRIPTION
Previously, if you made a malformed request, the actual error
would not be shown because the default anyhow to_string impl
would only show the top-most context attached to the error
(see: https://docs.rs/anyhow/latest/anyhow/struct.Error.html#display-representations),
which would be something like `/scip endpoint`.

## Test plan

Added snapshot test
