### PR TITLE
gitserver: Clean up some errors from improper API usage

### DIFF
--- a/cmd/gitserver/internal/git/gitcli/odb.go
+++ b/cmd/gitserver/internal/git/gitcli/odb.go
@@ -29,7 +29,15 @@ func (g *gitCLIBackend) GetCommit(ctx context.Context, commit api.CommitID, incl
 		return nil, err
 	}
 
-	args := buildGetCommitArgs(commit, includeModifiedFiles)
+	// commit sometimes is not a commitID today, so we run a revparse first to make
+	// sure we're dealing with a commit ID. This will also report errors like
+	// "cannot resolve to commit" as a RevisionNotFoundError.
+	commitID, err := g.revParse(ctx, string(commit))
+	if err != nil {
+		return nil, err
+	}
+
+	args := buildGetCommitArgs(commitID, includeModifiedFiles)
 
 	r, err := g.NewCommand(ctx, WithArguments(args...))
 	if err != nil {

--- a/cmd/gitserver/internal/git/gitcli/odb_test.go
+++ b/cmd/gitserver/internal/git/gitcli/odb_test.go
@@ -198,8 +198,49 @@ func TestGitCLIBackend_GetCommit(t *testing.T) {
 		require.True(t, errors.HasType(err, &gitdomain.RevisionNotFoundError{}))
 	})
 
+	// This test only exists because we sometimes pass non-commit ID strings to the
+	// api.CommitID input of GetCommit. Once we get to clean that up, we can remove
+	// this test here.
+	t.Run("bad revision", func(t *testing.T) {
+		_, err := backend.GetCommit(ctx, "nonexisting", false)
+		require.Error(t, err)
+		require.True(t, errors.HasType(err, &gitdomain.RevisionNotFoundError{}))
+	})
+
+	// This test only exists because we sometimes pass non-commit ID strings to the
+	// api.CommitID input of GetCommit. Once we get to clean that up, we can remove
+	// this test here.
+	t.Run("empty repo", func(t *testing.T) {
+		backend := BackendWithRepoCommands(t)
+		_, err := backend.GetCommit(ctx, "HEAD", false)
+		require.Error(t, err)
+		require.True(t, errors.HasType(err, &gitdomain.RevisionNotFoundError{}))
+	})
+
 	t.Run("read commit", func(t *testing.T) {
 		c, err := backend.GetCommit(ctx, commitID, false)
+		require.NoError(t, err)
+		require.Equal(t, &git.GitCommitWithFiles{
+			Commit: &gitdomain.Commit{
+				ID:      commitID,
+				Message: "commit2",
+				Author: gitdomain.Signature{
+					Name:  "Foo Author",
+					Email: "foo@sourcegraph.com",
+					Date:  c.Author.Date, // Hard to test
+				},
+				Committer: &gitdomain.Signature{
+					Name:  "a",
+					Email: "a@a.com",
+					Date:  c.Committer.Date, // Hard to test
+				},
+				Parents: []api.CommitID{"405b565ed446e271bc1998a91dbf4fb50dbfabfe"},
+			},
+		}, c)
+		// This should not exist but callers currently pass HEAD as a commitID
+		// to gitserver. Until we get a handle on this, we want to verify that
+		// this works properly.
+		c, err = backend.GetCommit(ctx, "HEAD", false)
 		require.NoError(t, err)
 		require.Equal(t, &git.GitCommitWithFiles{
 			Commit: &gitdomain.Commit{


### PR DESCRIPTION
Unfortunately, some callers seem to be passing non-20-byte OIDs through api.CommitID fields.
We should ultimately clean that up, but in the meantime this should help make the error messages clearer and reduce noise from strange error messages.

Test plan:

Added tests to cover for the cases where this can happen.