### PR TITLE
fix: backporting

### DIFF
--- a/dev/sg/internal/backport/BUILD.bazel
+++ b/dev/sg/internal/backport/BUILD.bazel
@@ -8,7 +8,6 @@ go_library(
     visibility = ["//dev/sg:__subpackages__"],
     deps = [
         "//dev/sg/internal/execute",
-        "//dev/sg/internal/repo",
         "//dev/sg/internal/std",
         "//lib/errors",
         "//lib/output",

--- a/dev/sg/internal/backport/backport.go
+++ b/dev/sg/internal/backport/backport.go
@@ -8,7 +8,6 @@ import (
 	"github.com/urfave/cli/v2"
 
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/execute"
-	"github.com/sourcegraph/sourcegraph/dev/sg/internal/repo"
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/std"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 	"github.com/sourcegraph/sourcegraph/lib/output"
@@ -58,7 +57,6 @@ func Run(cmd *cli.Context, prNumber int64, version string) error {
 
 	// prefixed with "sg/backport-" to avoid conflicts with other branches
 	backportBranch := fmt.Sprintf("sg/backport-%d-to-%s", prNumber, version)
-	backportBranchRepo := repo.NewGitRepo(backportBranch, backportBranch)
 	p = std.Out.Pending(output.Styledf(output.StylePending, "Creating backport branch %q...", backportBranch))
 	if _, err := execute.Git(cmd.Context, "checkout", "-b", backportBranch, fmt.Sprintf("origin/%s", version)); err != nil {
 		p.Destroy()
@@ -68,7 +66,7 @@ func Run(cmd *cli.Context, prNumber int64, version string) error {
 
 	// Fetch latest change from remote
 	p = std.Out.Pending(output.Styled(output.StylePending, "Fetching latest changes from remote..."))
-	if _, err := backportBranchRepo.FetchOrigin(cmd.Context); err != nil {
+	if _, err := execute.Git(cmd.Context, "fetch"); err != nil {
 		p.Destroy()
 		return err
 	}


### PR DESCRIPTION
Revert line that tries to fetch a specific remote branch that has never actually been pushed, back to fetching from the default remote.

I'm not 100% sure this fixes the underlying problem in https://linear.app/sourcegraph/issue/REL-38/having-trouble-back-porting-panw-pr-to-540-need-help, so let's execute the test plan pre-merge.

<!--

💡 To write a useful PR description, make sure that your description covers:

- WHAT this PR is changing:
    - How was it PREVIOUSLY.
    - How it will be from NOW on.
- WHY this PR is needed.
- CONTEXT, i.e. to which initiative, project or RFC it belongs.

The structure of the description doesn't matter as much as covering these points, so use
your best judgement based on your context.

Learn how to write good pull request description: https://www.notion.so/sourcegraph/Write-a-good-pull-request-description-610a7fd3e613496eb76f450db5a49b6e?pvs=4
-->

## Test plan

There don't appear to be many automated tests for backporting, which is fair enough as this is quite fiddly. We can manually test this by running a backport command pre-merge, and seeing if it fixes https://linear.app/sourcegraph/issue/REL-38/having-trouble-back-porting-panw-pr-to-540-need-help:

```
go run ./dev/sg backport <args>
```

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles

Why does it matter?

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers.
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component:
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests"
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs:
  - "previewed locally"
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI"
  - "locally tested"
-->
