### PR TITLE
Make SSC base url dynamic

### DIFF
--- a/client/web/src/cody/management/CodyManagementPage.tsx
+++ b/client/web/src/cody/management/CodyManagementPage.tsx
@@ -22,6 +22,7 @@ import { CodyProIcon, DashboardIcon } from '../components/CodyIcon'
 import { isCodyEnabled } from '../isCodyEnabled'
 import { CodyOnboarding, type IEditor } from '../onboarding/CodyOnboarding'
 import { USER_CODY_PLAN, USER_CODY_USAGE } from '../subscription/queries'
+import { manageSubscriptionRedirectURL } from '../util'
 
 import { SubscriptionStats } from './SubscriptionStats'
 import { UseCodyInEditorSection } from './UseCodyInEditorSection'
@@ -32,8 +33,6 @@ interface CodyManagementPageProps extends TelemetryV2Props {
     isSourcegraphDotCom: boolean
     authenticatedUser: AuthenticatedUser | null
 }
-
-const manageSubscriptionRedirectURL = window.context.frontendCodyProConfig?.sscBaseUrl + '/subscription'
 
 export enum EditorStep {
     SetupInstructions = 0,

--- a/client/web/src/cody/management/CodyManagementPage.tsx
+++ b/client/web/src/cody/management/CodyManagementPage.tsx
@@ -22,7 +22,6 @@ import { CodyProIcon, DashboardIcon } from '../components/CodyIcon'
 import { isCodyEnabled } from '../isCodyEnabled'
 import { CodyOnboarding, type IEditor } from '../onboarding/CodyOnboarding'
 import { USER_CODY_PLAN, USER_CODY_USAGE } from '../subscription/queries'
-import { manageSubscriptionRedirectURL } from '../util'
 
 import { SubscriptionStats } from './SubscriptionStats'
 import { UseCodyInEditorSection } from './UseCodyInEditorSection'
@@ -33,6 +32,8 @@ interface CodyManagementPageProps extends TelemetryV2Props {
     isSourcegraphDotCom: boolean
     authenticatedUser: AuthenticatedUser | null
 }
+
+const manageSubscriptionRedirectURL = window.context.frontendCodyProConfig?.sscBaseUrl + '/subscription'
 
 export enum EditorStep {
     SetupInstructions = 0,

--- a/client/web/src/cody/subscription/CodySubscriptionPage.tsx
+++ b/client/web/src/cody/subscription/CodySubscriptionPage.tsx
@@ -29,7 +29,7 @@ import type { UserCodyPlanResult, UserCodyPlanVariables } from '../../graphql-op
 import { EventName } from '../../util/constants'
 import { CodyColorIcon } from '../chat/CodyPageIcon'
 import { isCodyEnabled } from '../isCodyEnabled'
-import { manageSubscriptionRedirectURL, isEmbeddedCodyProUIEnabled } from '../util'
+import { isEmbeddedCodyProUIEnabled } from '../util'
 
 import { USER_CODY_PLAN } from './queries'
 
@@ -39,6 +39,8 @@ interface CodySubscriptionPageProps extends TelemetryV2Props {
     isSourcegraphDotCom: boolean
     authenticatedUser?: AuthenticatedUser | null
 }
+
+const manageSubscriptionRedirectURL = window.context.frontendCodyProConfig?.sscBaseUrl + '/subscription'
 
 export const CodySubscriptionPage: React.FunctionComponent<CodySubscriptionPageProps> = ({
     isSourcegraphDotCom,

--- a/client/web/src/cody/subscription/CodySubscriptionPage.tsx
+++ b/client/web/src/cody/subscription/CodySubscriptionPage.tsx
@@ -27,7 +27,7 @@ import { CodySubscriptionPlan } from '../../graphql-operations'
 import type { UserCodyPlanResult, UserCodyPlanVariables } from '../../graphql-operations'
 import { CodyColorIcon } from '../chat/CodyPageIcon'
 import { isCodyEnabled } from '../isCodyEnabled'
-import { isEmbeddedCodyProUIEnabled } from '../util'
+import { isEmbeddedCodyProUIEnabled, manageSubscriptionRedirectURL } from '../util'
 
 import { USER_CODY_PLAN } from './queries'
 
@@ -37,8 +37,6 @@ interface CodySubscriptionPageProps extends TelemetryV2Props {
     isSourcegraphDotCom: boolean
     authenticatedUser?: AuthenticatedUser | null
 }
-
-const manageSubscriptionRedirectURL = window.context.frontendCodyProConfig?.sscBaseUrl + '/subscription'
 
 export const CodySubscriptionPage: React.FunctionComponent<CodySubscriptionPageProps> = ({
     isSourcegraphDotCom,

--- a/client/web/src/cody/subscription/CodySubscriptionPage.tsx
+++ b/client/web/src/cody/subscription/CodySubscriptionPage.tsx
@@ -84,7 +84,9 @@ export const CodySubscriptionPage: React.FunctionComponent<CodySubscriptionPageP
                             <Button
                                 variant="primary"
                                 onClick={() => {
-                                    telemetryRecorder.recordEvent('cody.manageSubscription', 'click', { metadata: {tier: 1 }})
+                                    telemetryRecorder.recordEvent('cody.manageSubscription', 'click', {
+                                        metadata: { tier: 1 },
+                                    })
                                     window.location.href = manageSubscriptionRedirectURL
                                 }}
                             >
@@ -225,8 +227,8 @@ export const CodySubscriptionPage: React.FunctionComponent<CodySubscriptionPageP
                                                 telemetryRecorder.recordEvent('cody.planSelection', 'click', {
                                                     metadata: { tier: 1, team: 1 },
                                                 })
-                                                const url = new URL(manageSubscriptionRedirectURL);
-                                                url.searchParams.append('team', '1');
+                                                const url = new URL(manageSubscriptionRedirectURL)
+                                                url.searchParams.append('team', '1')
                                                 window.location.href = url.toString()
                                             }}
                                         >

--- a/client/web/src/cody/subscription/CodySubscriptionPage.tsx
+++ b/client/web/src/cody/subscription/CodySubscriptionPage.tsx
@@ -227,6 +227,9 @@ export const CodySubscriptionPage: React.FunctionComponent<CodySubscriptionPageP
                                                 telemetryRecorder.recordEvent('cody.planSelection', 'click', {
                                                     metadata: { tier: 1, team: 1 },
                                                 })
+                                                // We add ?team=1 to the URL to indicate that the user is creating a team.
+                                                // We can use this info to initialize the UI differently,
+                                                // or even display an entirely different UI.
                                                 const url = new URL(manageSubscriptionRedirectURL)
                                                 url.searchParams.append('team', '1')
                                                 window.location.href = url.toString()

--- a/client/web/src/cody/subscription/CodySubscriptionPage.tsx
+++ b/client/web/src/cody/subscription/CodySubscriptionPage.tsx
@@ -6,7 +6,6 @@ import { useNavigate } from 'react-router-dom'
 
 import { useQuery } from '@sourcegraph/http-client'
 import type { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
-import { EVENT_LOGGER } from '@sourcegraph/shared/src/telemetry/web/eventLogger'
 import {
     Badge,
     Button,
@@ -26,7 +25,6 @@ import { Page } from '../../components/Page'
 import { PageTitle } from '../../components/PageTitle'
 import { CodySubscriptionPlan } from '../../graphql-operations'
 import type { UserCodyPlanResult, UserCodyPlanVariables } from '../../graphql-operations'
-import { EventName } from '../../util/constants'
 import { CodyColorIcon } from '../chat/CodyPageIcon'
 import { isCodyEnabled } from '../isCodyEnabled'
 import { isEmbeddedCodyProUIEnabled } from '../util'
@@ -51,7 +49,6 @@ export const CodySubscriptionPage: React.FunctionComponent<CodySubscriptionPageP
 
     const utm_source = parameters.get('utm_source')
     useEffect(() => {
-        EVENT_LOGGER.log(EventName.CODY_SUBSCRIPTION_PAGE_VIEWED, { utm_source }, { utm_source })
         telemetryRecorder.recordEvent('cody.planSelection', 'view')
     }, [utm_source, telemetryRecorder])
 
@@ -87,7 +84,7 @@ export const CodySubscriptionPage: React.FunctionComponent<CodySubscriptionPageP
                             <Button
                                 variant="primary"
                                 onClick={() => {
-                                    EVENT_LOGGER.log(EventName.CODY_MANAGE_SUBSCRIPTION_CLICKED)
+                                    telemetryRecorder.recordEvent('cody.manageSubscription', 'click', { metadata: {tier: 1 }})
                                     window.location.href = manageSubscriptionRedirectURL
                                 }}
                             >
@@ -211,7 +208,6 @@ export const CodySubscriptionPage: React.FunctionComponent<CodySubscriptionPageP
                                         className="mb-0 text-muted d-inline cursor-pointer"
                                         size="small"
                                         onClick={() => {
-                                            EVENT_LOGGER.log(EventName.CODY_MANAGE_SUBSCRIPTION_CLICKED)
                                             telemetryRecorder.recordEvent('cody.planSelection', 'click', {
                                                 metadata: { tier: 0 },
                                             })
@@ -368,11 +364,6 @@ export const CodySubscriptionPage: React.FunctionComponent<CodySubscriptionPageP
                                 to="https://sourcegraph.com/contact/request-info?utm_source=cody_subscription_page"
                                 target="_blank"
                                 onClick={() => {
-                                    EVENT_LOGGER.log(
-                                        EventName.CODY_SUBSCRIPTION_PLAN_CLICKED,
-                                        { tier: 'enterprise' },
-                                        { tier: 'enterprise' }
-                                    )
                                     telemetryRecorder.recordEvent('cody.planSelection', 'click', {
                                         metadata: { tier: 2 },
                                     })

--- a/client/web/src/cody/subscription/CodySubscriptionPage.tsx
+++ b/client/web/src/cody/subscription/CodySubscriptionPage.tsx
@@ -229,7 +229,9 @@ export const CodySubscriptionPage: React.FunctionComponent<CodySubscriptionPageP
                                                 telemetryRecorder.recordEvent('cody.planSelection', 'click', {
                                                     metadata: { tier: 1, team: 1 },
                                                 })
-                                                window.location.href = manageSubscriptionRedirectURL // TODO: Use team link or argument
+                                                const url = new URL(manageSubscriptionRedirectURL);
+                                                url.searchParams.append('team', '1');
+                                                window.location.href = url.toString()
                                             }}
                                         >
                                             <span className={classNames(styles.proBadge, 'mr-1')} />

--- a/client/web/src/cody/util.ts
+++ b/client/web/src/cody/util.ts
@@ -1,8 +1,6 @@
 // The URL to direct users in order to manage their Cody Pro subscription.
 import { useState, useEffect } from 'react'
 
-export const manageSubscriptionRedirectURL = 'https://accounts.sourcegraph.com/cody/subscription'
-
 /**
  * useEmbeddedCodyProUi returns if we expect the Cody Pro UI to be served from sourcegraph.com. Meaning
  * we should direct the user to `/cody/manage/subscription` for making changes.

--- a/client/web/src/cody/util.ts
+++ b/client/web/src/cody/util.ts
@@ -1,6 +1,8 @@
 // The URL to direct users in order to manage their Cody Pro subscription.
 import { useState, useEffect } from 'react'
 
+export const manageSubscriptionRedirectURL = `${window.context.frontendCodyProConfig?.sscBaseUrl}/subscription`
+
 /**
  * useEmbeddedCodyProUi returns if we expect the Cody Pro UI to be served from sourcegraph.com. Meaning
  * we should direct the user to `/cody/manage/subscription` for making changes.

--- a/client/web/src/jscontext.ts
+++ b/client/web/src/jscontext.ts
@@ -306,6 +306,7 @@ export interface SourcegraphContext extends Pick<Required<SiteConfiguration>, 'e
     /** Configuration for Cody Pro-tier functionality, if applicable. */
     frontendCodyProConfig?: {
         stripePublishableKey: string
+        sscBaseUrl: string
     }
 }
 

--- a/cmd/frontend/internal/app/jscontext/jscontext.go
+++ b/cmd/frontend/internal/app/jscontext/jscontext.go
@@ -152,6 +152,7 @@ type LicenseInfo struct {
 // to the frontend.
 type FrontendCodyProConfig struct {
 	StripePublishableKey string `json:"stripePublishableKey"`
+	SscBaseUrl           string `json:"sscBaseUrl"`
 }
 
 // JSContext is made available to JavaScript code via the
@@ -708,5 +709,6 @@ func makeFrontendCodyProConfig(config *schema.CodyProConfig) *FrontendCodyProCon
 	}
 	return &FrontendCodyProConfig{
 		StripePublishableKey: config.StripePublishableKey,
+		SscBaseUrl:           config.SscBaseUrl,
 	}
 }

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -652,6 +652,8 @@ type CodyProConfig struct {
 	SamsBackendOrigin string `json:"samsBackendOrigin,omitempty"`
 	// SscBackendOrigin description: Origin of the Self-serve Cody backend.
 	SscBackendOrigin string `json:"sscBackendOrigin,omitempty"`
+	// SscBaseUrl description: The base URL of the Self-Serve Cody site.
+	SscBaseUrl string `json:"sscBaseUrl,omitempty"`
 	// StripePublishableKey description: Stripe Publishable Key for use in Stripe Checkout, Stripe Elements. This is not considered a secret.
 	StripePublishableKey string `json:"stripePublishableKey,omitempty"`
 }

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -2277,6 +2277,11 @@
               "default": "",
               "description": "Origin of the Self-serve Cody backend.",
               "examples": ["https://accounts.sourcegraph.com"]
+            },
+            "sscBaseUrl": {
+              "type": "string",
+              "default": "https://accounts.sourcegraph.com/cody",
+              "description": "The base URL of the Self-Serve Cody site."
             }
           }
         }


### PR DESCRIPTION
For a long time, it was annoying that we couldn't properly test some SSC features because `https://accounts.sourcegraph.com/cody/subscription` (production URL) was hard-coded for the "Manage subscription" links.
This PR makes that setting dynamic.

Also:
- It wires up the "Create a Cody Pro team" button to pass an extra `?team=1` argument which we'll handle on the checkout page.
- It contains an unrelated event logging cleanup because the deprecation warnings made it difficult for me to focus on the linter warnings related to my PR.

**Note:** If `sscBaseUrl` is not configured in the site config, it falls back to the previously hard-coded URL `https://accounts.sourcegraph.com/cody`.

The PR consists of four individual commits to make the PR review easier.

## Test plan

Tested it manually: it works nicely.