### PR TITLE
Change "Remove" button to a regular button

### DIFF
--- a/client/web/src/cody/team/TeamMemberList.tsx
+++ b/client/web/src/cody/team/TeamMemberList.tsx
@@ -227,15 +227,13 @@ export const TeamMemberList: FunctionComponent<TeamMemberListProps> = ({
                                             </Link>
                                         </div>
                                         <div className="align-content-center text-center">
-                                            <ButtonLink
+                                            <Link
                                                 to="#"
-                                                variant="danger"
-                                                size="sm"
                                                 onClick={() => removeMember(member.accountId)}
                                                 className="ml-2"
                                             >
                                                 Remove
-                                            </ButtonLink>
+                                            </Link>
                                         </div>
                                     </>
                                 )


### PR DESCRIPTION
The "Remove" button next to teammates in the SSC Team Members list was red, but in the designs, it's just a regular link, as @rrhyne pointed out in [this figma](https://www.figma.com/design/FMSdn1oKccJRHQPgf7053o/Cody-PLG-GA?node-id=4042-4927&t=DUe3gdsNnEfxmjE2-0). This PR fixes this.

## Test plan

Checked it in the browser:

![CleanShot 2024-05-20 at 16 35 35@2x](https://github.com/sourcegraph/sourcegraph/assets/2552265/ebdc00a6-a36e-4ce5-a2b5-7ff0669fb7b3)
