### PR TITLE
sg: cloud ephemeral - handle empty times better and santizes name better

### DIFF
--- a/dev/sg/internal/cloud/common.go
+++ b/dev/sg/internal/cloud/common.go
@@ -20,7 +20,9 @@ const CloudEmoji = "☁️"
 
 func sanitizeInstanceName(name string) string {
 	name = strings.ToLower(name)
-	return strings.ReplaceAll(name, "/", "-")
+	name = strings.ReplaceAll(name, "/", "-")
+	name = strings.ReplaceAll(name, "_", "-")
+	return name
 }
 
 func inferInstanceNameFromBranch(ctx context.Context) (string, error) {

--- a/dev/sg/internal/cloud/deploy_command.go
+++ b/dev/sg/internal/cloud/deploy_command.go
@@ -126,7 +126,7 @@ func createDeploymentForVersion(ctx context.Context, email, name, version string
 	}
 
 	pending.Writef("Deploy instance details: \n%s", inst.String())
-	pending.Complete(output.Linef(output.EmojiSuccess, output.StyleSuccess, "Deployment %q created for version %q - access at: %s", spec.Name, spec.Version, inst.URL))
+	pending.Complete(output.Linef(output.EmojiSuccess, output.StyleSuccess, "Deployment %q created for version %q - access at: %s", inst.Name, inst.Version, inst.URL))
 	return nil
 }
 
@@ -180,8 +180,8 @@ func createDeploymentName(originalName, version, email, branch string) string {
 	} else if version != "" {
 		// if a version is given we generate a name based on the email user and the given version
 		// to make sure the deployment is unique
-		user := strings.ReplaceAll(email[0:strings.Index(email, "@")], ".", "_")
-		deploymentName = user[:min(12, len(user))] + "_" + version
+		user := strings.ReplaceAll(email[0:strings.Index(email, "@")], ".", "-")
+		deploymentName = user[:min(12, len(user))] + "-" + version
 	} else {
 		deploymentName = branch
 	}

--- a/dev/sg/internal/cloud/instance.go
+++ b/dev/sg/internal/cloud/instance.go
@@ -43,6 +43,14 @@ type Instance struct {
 }
 
 func (i *Instance) String() string {
+	// Protobuf returns the unix zero epoch if the time is nil, so we check for that
+	// and we also check if we do have a valid time that it is not zero
+	fmtTime := func(t time.Time) string {
+		if isUnixEpochZero(t) || t.IsZero() {
+			return "n/a"
+		}
+		return i.CreatedAt.Format(time.RFC3339)
+	}
 	return fmt.Sprintf(`ID           : %s
 Name         : %s
 InstanceType : %s
@@ -59,7 +67,7 @@ Status       : %s
 ActionURL    : %s
 Error        : %s
 `, i.ID, i.Name, i.InstanceType, i.Environment, i.Version, i.URL, i.AdminEmail,
-		i.CreatedAt.Format(time.RFC3339), i.DeletedAt.Format(time.RFC3339), i.ExpiresAt.Format(time.RFC3339), i.Project, i.Region,
+		fmtTime(i.CreatedAt), fmtTime(i.DeletedAt), fmtTime(i.ExpiresAt), i.Project, i.Region,
 		i.Status.Status, i.Status.ActionURL, i.Status.Error)
 }
 
@@ -148,6 +156,10 @@ func newInstance(src *cloudapiv1.Instance) (*Instance, error) {
 		Status:       *status,
 		features:     features,
 	}, nil
+}
+
+func isUnixEpochZero(t time.Time) bool {
+	return t.Unix() == 0
 }
 
 func parseStatusReason(reason string) (string, string, error) {


### PR DESCRIPTION
This PR fixes the following from this output
```
sg cloud eph deploy --version 5.4.0
✅ Version "5.4.0" found in Cloud ephemeral registry
Deploy instance details:
ID           : src-9cf5b905f9f966015d4a
Name         : william-bezu-5-4-0
InstanceType : internal
Environment  :
Version      : 5.4.0
URL          : https://william-bezu-5-4-0.sgdev.dev/
AdminEmail   :
CreatedAt    : 1970-01-01T00:00:00Z
DeletetAt    : 1970-01-01T00:00:00Z
ExpiresAt    : 0001-01-01T00:00:00Z
Project      : src-f54e076f7870a06f003c
Region       : us-central1
Status       : in progress
ActionURL    :
Error        :

✅ Deployment "william_bezu_5.4.0" created for version "5.4.0" - access at: https://william-bezu-5-4-0.sgdev.dev/
```
* the deployment name doesn't match to what cloud returns. We now santize the name the same as cloud does
* The returned times have the Unix Zero epoch and the golang time zero. We now check for both and print `n/a`

```
go run ./dev/sg cloud eph status --name william-bezu-5-4-0 --raw
✅ Ephemeral instance "william-bezu-5-4-0" status retrieved
Ephemeral instance details:
ID           : src-9cf5b905f9f966015d4a
Name         : william-bezu-5-4-0
InstanceType : internal
Environment  :
Version      : 5.4.0
URL          : https://william-bezu-5-4-0.sgdev.dev
AdminEmail   :
CreatedAt    : n/a
DeletetAt    : n/a
ExpiresAt    : n/a
Project      : src-f54e076f7870a06f003c
Region       : us-central1
Status       : in progress
ActionURL    : https://github.com/sourcegraph/cloud/actions/runs/9161687255
Error        :
```

## Test plan
Tested locally