### PR TITLE
Fix auth-related error in the SSC REST API client hook

### DIFF
--- a/client/web/src/cody/management/api/client.ts
+++ b/client/web/src/cody/management/api/client.ts
@@ -91,7 +91,7 @@ export class CodyProApiCaller implements Caller {
                 // On a related note, the `fetch` API does NOT include the "origin" header for GET
                 // or HEAD requests by spec. (See https://fetch.spec.whatwg.org/#origin-header.)
                 'x-requested-with': 'Sourcegraph/CodyProApiClient',
-            }
+            },
         })
 
         if (fetchResponse.status >= 200 && fetchResponse.status <= 299) {

--- a/client/web/src/cody/management/api/client.ts
+++ b/client/web/src/cody/management/api/client.ts
@@ -81,6 +81,17 @@ export class CodyProApiCaller implements Caller {
             credentials: 'same-origin',
             method: call.method,
             body: bodyJson,
+            headers: {
+                // In order for the Sourcegraph backend to authenticate the request, we need to
+                // ensure we don't run afoul of our CSRF protections (see csrf_security_model.md).
+                //
+                // Setting the `x-requested-with` header, along with other the current CORS config
+                // is sufficient for backend request to be authenticated. (See `CookieMiddlewareWithCSRFSafety()`.)
+                //
+                // On a related note, the `fetch` API does NOT include the "origin" header for GET
+                // or HEAD requests by spec. (See https://fetch.spec.whatwg.org/#origin-header.)
+                'x-requested-with': 'Sourcegraph/CodyProApiClient',
+            }
         })
 
         if (fetchResponse.status >= 200 && fetchResponse.status <= 299) {


### PR DESCRIPTION
While working on integrating the SSC REST API client hook (https://github.com/sourcegraph/sourcegraph/pull/62715) I spent longer than I would have liked trying to figure out why it wasn't working in some cases...

To cut to the punch line, there is a quirk of the `fetch()` API in that it won't send the "origin" header for `GET` or `HEAD` requests. And that lead to the Sourcegraph backend not treating the request as authenticated, even though we supplied the user's `sgs` session cookie.

After doing my best to understand how things all work, it looks like the simplest thing would be to just supply the `X-Requested-With` header. Which is how the backend authenticates HTTP requests based on the session cookie. (In addition to the `Origin` header if it is made available, which is why I didn't catch this when working on the initial PR -- because I was only using `POST` methods...)

## Test Plan

Testing locally (how I found the book). CI/CD.