### PR TITLE
feat/cody: new site config for smart context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 - Basic support for rendering Jupyter notebooks in the Sourcegraph web app. ([#59685](https://github.com/sourcegraph/sourcegraph/pull/59685))
 - Mermaid diagrams in Markdown are now rendered in the Sourcegraph web app ([#62678](https://github.com/sourcegraph/sourcegraph/pull/62678))
+- A feature flag for Cody, `completions.smartContext` is added and set to "enabled" by default. It allows clients to adjust the context window based on the name of the chat model. When smartContext is enabled, the `completions.chatModelMaxTokens` value is ignored. ([#62802](https://github.com/sourcegraph/sourcegraph/pull/62802))
 
 ### Changed
 

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -7567,9 +7567,13 @@ type CodyLLMConfiguration {
     """
     chatModel: String!
     """
-    Maximum number of tokens client should use when talking to the chatModel.
+    Maximum number of tokens client should use when talking to the chatModel. If smartContext is enabled, this value will be ignored.
     """
     chatModelMaxTokens: Int
+    """
+    Enable Cody clients to adjust context window based on the name of the chat model. If enabled, the chatModelMaxTokens value will be ignored.
+    """
+    smartContext: String!
     """
     Name of the model being used for fast chat.
     """

--- a/cmd/frontend/graphqlbackend/site.go
+++ b/cmd/frontend/graphqlbackend/site.go
@@ -660,6 +660,12 @@ func (c *codyLLMConfigurationResolver) ChatModelMaxTokens() *int32 {
 	}
 	return nil
 }
+func (c *codyLLMConfigurationResolver) SmartContext() string {
+	if c.config.SmartContext == "disabled" {
+		return "disabled"
+	}
+	return "enabled"
+}
 
 func (c *codyLLMConfigurationResolver) FastChatModel() string { return c.config.FastChatModel }
 func (c *codyLLMConfigurationResolver) FastChatModelMaxTokens() *int32 {

--- a/internal/conf/computed.go
+++ b/internal/conf/computed.go
@@ -895,11 +895,16 @@ func GetCompletionsConfig(siteConfig schema.SiteConfiguration) (c *conftypes.Com
 		completionsConfig.CompletionModelMaxTokens = defaultMaxPromptTokens(conftypes.CompletionsProviderName(completionsConfig.Provider), completionsConfig.CompletionModel)
 	}
 
+	if completionsConfig.SmartContext == "" {
+		completionsConfig.SmartContext = "enabled"
+	}
+
 	computedConfig := &conftypes.CompletionsConfig{
 		Provider:                         conftypes.CompletionsProviderName(completionsConfig.Provider),
 		AccessToken:                      completionsConfig.AccessToken,
 		ChatModel:                        completionsConfig.ChatModel,
 		ChatModelMaxTokens:               completionsConfig.ChatModelMaxTokens,
+		SmartContext:                     completionsConfig.SmartContext,
 		FastChatModel:                    completionsConfig.FastChatModel,
 		FastChatModelMaxTokens:           completionsConfig.FastChatModelMaxTokens,
 		CompletionModel:                  completionsConfig.CompletionModel,

--- a/internal/conf/computed_test.go
+++ b/internal/conf/computed_test.go
@@ -320,6 +320,7 @@ func TestGetCompletionsConfig(t *testing.T) {
 	zeroConfigDefaultWithLicense := &conftypes.CompletionsConfig{
 		ChatModel:                "anthropic/claude-3-sonnet-20240229",
 		ChatModelMaxTokens:       12000,
+		SmartContext:             "enabled",
 		FastChatModel:            "anthropic/claude-3-haiku-20240307",
 		FastChatModelMaxTokens:   12000,
 		CompletionModel:          "fireworks/starcoder",
@@ -409,6 +410,7 @@ func TestGetCompletionsConfig(t *testing.T) {
 			wantConfig: &conftypes.CompletionsConfig{
 				ChatModel:                "claude-3-sonnet-20240229",
 				ChatModelMaxTokens:       12000,
+				SmartContext:             "enabled",
 				FastChatModel:            "claude-3-haiku-20240307",
 				FastChatModelMaxTokens:   12000,
 				CompletionModel:          "claude-3-haiku-20240307",
@@ -428,12 +430,14 @@ func TestGetCompletionsConfig(t *testing.T) {
 					Provider:        "anthropic",
 					AccessToken:     "asdf",
 					ChatModel:       "claude-3-opus-20240229",
+					SmartContext:    "disabled",
 					CompletionModel: "claude-instant-1.2",
 				},
 			},
 			wantConfig: &conftypes.CompletionsConfig{
 				ChatModel:                "claude-3-opus-20240229",
 				ChatModelMaxTokens:       12000,
+				SmartContext:             "disabled",
 				FastChatModel:            "claude-3-haiku-20240307",
 				FastChatModelMaxTokens:   12000,
 				CompletionModel:          "claude-instant-1.2",
@@ -467,6 +471,7 @@ func TestGetCompletionsConfig(t *testing.T) {
 			wantConfig: &conftypes.CompletionsConfig{
 				ChatModel:                "gpt-4",
 				ChatModelMaxTokens:       7000,
+				SmartContext:             "enabled",
 				FastChatModel:            "gpt-3.5-turbo",
 				FastChatModelMaxTokens:   16000,
 				CompletionModel:          "gpt-3.5-turbo-instruct",
@@ -486,6 +491,7 @@ func TestGetCompletionsConfig(t *testing.T) {
 					AccessToken:     "asdf",
 					Endpoint:        "https://acmecorp.openai.azure.com",
 					ChatModel:       "gpt4-deployment",
+					SmartContext:    "disabled",
 					FastChatModel:   "gpt35-turbo-deployment",
 					CompletionModel: "gpt35-turbo-deployment",
 				},
@@ -493,6 +499,7 @@ func TestGetCompletionsConfig(t *testing.T) {
 			wantConfig: &conftypes.CompletionsConfig{
 				ChatModel:                "gpt4-deployment",
 				ChatModelMaxTokens:       7000,
+				SmartContext:             "disabled",
 				FastChatModel:            "gpt35-turbo-deployment",
 				FastChatModelMaxTokens:   7000,
 				CompletionModel:          "gpt35-turbo-deployment",
@@ -515,6 +522,7 @@ func TestGetCompletionsConfig(t *testing.T) {
 			wantConfig: &conftypes.CompletionsConfig{
 				ChatModel:                "accounts/fireworks/models/llama-v2-7b",
 				ChatModelMaxTokens:       3000,
+				SmartContext:             "enabled",
 				FastChatModel:            "accounts/fireworks/models/llama-v2-7b",
 				FastChatModelMaxTokens:   3000,
 				CompletionModel:          "starcoder",
@@ -537,6 +545,7 @@ func TestGetCompletionsConfig(t *testing.T) {
 			wantConfig: &conftypes.CompletionsConfig{
 				ChatModel:                "anthropic.claude-v2",
 				ChatModelMaxTokens:       12000,
+				SmartContext:             "enabled",
 				FastChatModel:            "anthropic.claude-instant-v1",
 				FastChatModelMaxTokens:   9000,
 				CompletionModel:          "anthropic.claude-instant-v1",
@@ -561,6 +570,7 @@ func TestGetCompletionsConfig(t *testing.T) {
 			wantConfig: &conftypes.CompletionsConfig{
 				ChatModel:                "anthropic.claude-3-haiku-20240307-v1:0-100k/arn:aws:bedrock:us-west-2:012345678901:provisioned-model/abcdefghijkl",
 				ChatModelMaxTokens:       100_000,
+				SmartContext:             "enabled",
 				FastChatModel:            "anthropic.claude-v2",
 				FastChatModelMaxTokens:   12000,
 				CompletionModel:          "anthropic.claude-instant-v1",
@@ -600,6 +610,7 @@ func TestGetCompletionsConfig(t *testing.T) {
 			wantConfig: &conftypes.CompletionsConfig{
 				ChatModel:                "anthropic/claude-v1.3",
 				ChatModelMaxTokens:       9000,
+				SmartContext:             "enabled",
 				FastChatModel:            "anthropic/claude-instant-1.3",
 				FastChatModelMaxTokens:   9000,
 				CompletionModel:          "anthropic/claude-instant-1.3",

--- a/internal/conf/conftypes/consts.go
+++ b/internal/conf/conftypes/consts.go
@@ -6,6 +6,8 @@ type CompletionsConfig struct {
 	ChatModel          string
 	ChatModelMaxTokens int
 
+	SmartContext string
+
 	FastChatModel          string
 	FastChatModelMaxTokens int
 

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -663,7 +663,7 @@ type Completions struct {
 	// ChatModel description: The model used for chat completions. If using the default provider 'sourcegraph', a reasonable default model will be set.
 	//  NOTE: The Anthropic messages API does not support model names like claude-2 or claude-instant-1 where only the major version is specified as they are retired. We recommend using a specific model identifier as specified here https://docs.anthropic.com/claude/docs/models-overview#model-comparison
 	ChatModel string `json:"chatModel,omitempty"`
-	// ChatModelMaxTokens description: The maximum number of tokens to use as client when talking to chatModel. If not set, clients need to set their own limit.
+	// ChatModelMaxTokens description: The maximum number of tokens to use as client when talking to chatModel. If not set, clients need to set their own limit. If smartContext is enabled, this value will be overridden by the clients.
 	ChatModelMaxTokens int `json:"chatModelMaxTokens,omitempty"`
 	// CompletionModel description: The model used for code completion. If using the default provider 'sourcegraph', a reasonable default model will be set.
 	//  NOTE: The Anthropic messages API does not support model names like claude-2 or claude-instant-1 where only the major version is specified as they are retired. We recommend using a specific model identifier as specified here https://docs.anthropic.com/claude/docs/models-overview#model-comparison
@@ -703,6 +703,8 @@ type Completions struct {
 	PerUserDailyLimit int `json:"perUserDailyLimit,omitempty"`
 	// Provider description: The external completions provider. Defaults to 'sourcegraph'.
 	Provider string `json:"provider,omitempty"`
+	// SmartContext description: Whether the maximum number of tokens should be automatically adjusted by the client based on the name of chatModel. If enabled, it will override the value set in chatModelMaxTokens.
+	SmartContext string `json:"smartContext,omitempty"`
 }
 
 // ConfigFeatures description: Configuration for the completions service.

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -2856,8 +2856,14 @@
           "errorMessage": "The substring 'cumber' is not allowed because it is a bad idea and may lead to unexpected issues."
         },
         "chatModelMaxTokens": {
-          "description": "The maximum number of tokens to use as client when talking to chatModel. If not set, clients need to set their own limit.",
+          "description": "The maximum number of tokens to use as client when talking to chatModel. If not set, clients need to set their own limit. If smartContext is enabled, this value will be overridden by the clients.",
           "type": "integer"
+        },
+        "smartContext": {
+          "description": "Whether the maximum number of tokens should be automatically adjusted by the client based on the name of chatModel. If enabled, it will override the value set in chatModelMaxTokens.",
+          "type": "string",
+          "default": "enabled",
+          "enum": ["enabled", "disabled"]
         },
         "completionModel": {
           "description": "The model used for code completion. If using the default provider 'sourcegraph', a reasonable default model will be set.\n NOTE: The Anthropic messages API does not support model names like claude-2 or claude-instant-1 where only the major version is specified as they are retired. We recommend using a specific model identifier as specified here https://docs.anthropic.com/claude/docs/models-overview#model-comparison ",


### PR DESCRIPTION
CLOSE https://github.com/sourcegraph/cody-issues/issues/76 

See [the linked issue](https://github.com/sourcegraph/cody-issues/issues/76) for details.

Objectives:
- [x] Add a new site config value called `SmartContext` 
- [x] `SmartContext` is default to "enabled"
- [x] Update site config docs for `ChatModelMaxTokens` to indicate it is not respected if `SmartContext` is enabled, and that instead, Cody will determine the max tokens to use based on the model name

Changes:
 - Add `SmartContext` field to `CompletionsConfig` struct
- Implement `SmartContext()` method in `codyLLMConfigurationResolver`
- Set default `SmartContext` value to "enabled" if not provided, and "disabled" to disable the feature
- Update schema and documentation to describe `SmartContext` feature
- Update documentation of `chatModelMaxTokens` regarding how it would be overrides when `SmartContext` is enabled

<!--

💡 To write a useful PR description, make sure that your description covers:

- WHAT this PR is changing:
    - How was it PREVIOUSLY.
    - How it will be from NOW on.
- WHY this PR is needed.
- CONTEXT, i.e. to which initiative, project or RFC it belongs.

The structure of the description doesn't matter as much as covering these points, so use
your best judgement based on your context.

Learn how to write good pull request description: https://www.notion.so/sourcegraph/Write-a-good-pull-request-description-610a7fd3e613496eb76f450db5a49b6e?pvs=4
-->

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles

Why does it matter?

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers.
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component:
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests"
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs:
  - "previewed locally"
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI"
  - "locally tested"
-->

1. Run `sg start` from this branch to start a Sourcegraph instance locally
2. Visit  https://sourcegraph.test:3443/api/console#%7B%22query%22%3A%22%23%20Type%20queries%20here%2C%20with%20completion%2C%20validation%2C%20and%20hovers.%5Cn%23%5Cn%23%20Here's%20an%20example%20query%20to%20get%20you%20started%3A%5Cn%5Cnquery%20CurrentSiteCodyLlmConfiguration%20%7B%5Cn%20%20%20%20site%20%7B%5Cn%20%20%20%20%20%20%20%20codyLLMConfiguration%20%7B%5Cn%20%20%20%20%20%20%20%20%20%20%20%20smartContext%5Cn%20%20%20%20%20%20%20%20%7D%5Cn%20%20%20%20%7D%5Cn%7D%22%2C%22operationName%22%3A%22CurrentSiteCodyLlmConfiguration%22%7D to `RUN` the graphQL query below that the Cody clients would call
3. If `"completions.smartContext"` is not configured in your site configurations, it will be defaulted to "enabled":
  - ![image](https://github.com/sourcegraph/sourcegraph/assets/68532117/2eb23d20-e801-472d-a773-4a569436a6e7)
4. Go to your site configurations and set `"completions.smartContext"` to "disabled"
  - ![image](https://github.com/sourcegraph/sourcegraph/assets/68532117/8aebe885-1272-4bdb-8967-589accc03cf1)
  - ![image](https://github.com/sourcegraph/sourcegraph/assets/68532117/b9c50d59-3a0c-40d2-87f3-391e80e119ea)
5. Run the graphQL query again to verify that it returns "disabled":

![image](https://github.com/sourcegraph/sourcegraph/assets/68532117/269be4f7-3744-421c-92f9-1a4a28edc137)

#### graphQL query

```
query CurrentSiteCodyLlmConfiguration {
    site {
        codyLLMConfiguration {
            smartContext
        }
    }
}
```