### PR TITLE
fix: Make most syntaxHighlighting config fields optional

### DIFF
--- a/internal/conf/validation/highlight.go
+++ b/internal/conf/validation/highlight.go
@@ -12,24 +12,27 @@ import (
 
 func init() {
 	conf.ContributeValidator(func(c conftypes.SiteConfigQuerier) (problems conf.Problems) {
-		highlights := c.SiteConfig().SyntaxHighlighting
-		if highlights == nil {
+		highlightingConfig := c.SiteConfig().SyntaxHighlighting
+		if highlightingConfig == nil {
 			return
 		}
 
-		if _, ok := highlight.EngineNameToEngineType(highlights.Engine.Default); !ok {
-			problems = append(problems, conf.NewSiteProblem(fmt.Sprintf("Not a valid highlights.Engine.Default: `%s`.", highlights.Engine.Default)))
-		}
-
-		for _, engine := range highlights.Engine.Overrides {
-			if _, ok := highlight.EngineNameToEngineType(engine); !ok {
-				problems = append(problems, conf.NewSiteProblem(fmt.Sprintf("Not a valid highlights.Engine.Default: `%s`.", engine)))
+		if highlightingConfig.Engine != nil {
+			if _, ok := highlight.EngineNameToEngineType(highlightingConfig.Engine.Default); !ok {
+				problems = append(problems, conf.NewSiteProblem(fmt.Sprintf("Not a valid highlights.Engine.Default: `%s`.", highlightingConfig.Engine.Default)))
+			}
+			for _, engine := range highlightingConfig.Engine.Overrides {
+				if _, ok := highlight.EngineNameToEngineType(engine); !ok {
+					problems = append(problems, conf.NewSiteProblem(fmt.Sprintf("Not a valid highlights.Engine.Override: `%s`.", engine)))
+				}
 			}
 		}
 
-		for _, pattern := range highlights.Languages.Patterns {
-			if _, err := regexp.Compile(pattern.Pattern); err != nil {
-				problems = append(problems, conf.NewSiteProblem(fmt.Sprintf("Not a valid regexp: `%s`. See the valid syntax: https://golang.org/pkg/regexp/", pattern.Pattern)))
+		if highlightingConfig.Languages != nil {
+			for _, pattern := range highlightingConfig.Languages.Patterns {
+				if _, err := regexp.Compile(pattern.Pattern); err != nil {
+					problems = append(problems, conf.NewSiteProblem(fmt.Sprintf("Not a valid regexp: `%s`. See the valid syntax: https://golang.org/pkg/regexp/", pattern.Pattern)))
+				}
 			}
 		}
 

--- a/internal/highlight/BUILD.bazel
+++ b/internal/highlight/BUILD.bazel
@@ -21,6 +21,7 @@ go_library(
         "//internal/observation",
         "//lib/codeintel/languages",
         "//lib/errors",
+        "//schema",
         "@com_github_grafana_regexp//:regexp",
         "@com_github_prometheus_client_golang//prometheus",
         "@com_github_prometheus_client_golang//prometheus/promauto",
@@ -51,6 +52,7 @@ go_test(
     deps = [
         "//internal/gosyntect",
         "//lib/errors",
+        "//schema",
         "@com_github_google_go_cmp//cmp",
         "@com_github_grafana_regexp//:regexp",
         "@com_github_hexops_autogold_v2//:autogold",

--- a/internal/highlight/language.go
+++ b/internal/highlight/language.go
@@ -163,34 +163,38 @@ func Init() {
 				return
 			}
 
-			if config.SyntaxHighlighting == nil {
+			highlightingConfig := config.SyntaxHighlighting
+			if highlightingConfig == nil {
 				return
 			}
 
-			if defaultEngine, ok := EngineNameToEngineType(config.SyntaxHighlighting.Engine.Default); ok {
-				engineConfig.Default = defaultEngine
-			}
-
-			// Set overrides from configuration
-			//
-			// We populate the confuration with base again, because we need to
-			// create a brand new map to not take any values that were
-			// previously in the table from the last configuration.
-			//
-			// After that, we set the values from the new configuration
-			for name, engine := range config.SyntaxHighlighting.Engine.Overrides {
-				if overrideEngine, ok := EngineNameToEngineType(engine); ok {
-					engineConfig.Overrides[strings.ToLower(name)] = overrideEngine
+			if highlightingConfig.Engine != nil {
+				if defaultEngine, ok := EngineNameToEngineType(highlightingConfig.Engine.Default); ok {
+					engineConfig.Default = defaultEngine
+				}
+				// Set overrides from configuration
+				//
+				// We populate the confuration with base again, because we need to
+				// create a brand new map to not take any values that were
+				// previously in the table from the last configuration.
+				//
+				// After that, we set the values from the new configuration
+				for name, engine := range highlightingConfig.Engine.Overrides {
+					if overrideEngine, ok := EngineNameToEngineType(engine); ok {
+						engineConfig.Overrides[strings.ToLower(name)] = overrideEngine
+					}
 				}
 			}
 
-			for extension, language := range config.SyntaxHighlighting.Languages.Extensions {
-				highlightConfig.Extensions[extension] = language
-			}
-			highlightConfig.Patterns = []languagePattern{}
-			for _, pattern := range config.SyntaxHighlighting.Languages.Patterns {
-				if re, err := regexp.Compile(pattern.Pattern); err == nil {
-					highlightConfig.Patterns = append(highlightConfig.Patterns, languagePattern{pattern: re, language: pattern.Language})
+			if highlightingConfig.Languages != nil {
+				for extension, language := range highlightingConfig.Languages.Extensions {
+					highlightConfig.Extensions[extension] = language
+				}
+				highlightConfig.Patterns = []languagePattern{}
+				for _, pattern := range highlightingConfig.Languages.Patterns {
+					if re, err := regexp.Compile(pattern.Pattern); err == nil {
+						highlightConfig.Patterns = append(highlightConfig.Patterns, languagePattern{pattern: re, language: pattern.Language})
+					}
 				}
 			}
 		})

--- a/internal/highlight/language.go
+++ b/internal/highlight/language.go
@@ -1,6 +1,7 @@
 package highlight
 
 import (
+	"github.com/sourcegraph/sourcegraph/schema"
 	"path/filepath"
 	"strings"
 
@@ -71,29 +72,29 @@ type SyntaxEngineQuery struct {
 	LanguageOverride bool
 }
 
-type syntaxHighlightConfig struct {
+type syntaxHighlightConfig[R any] struct {
 	// Order does not matter. Evaluated before Patterns
 	Extensions map[string]string
 
 	// Order matters for this. First matching pattern matches.
 	// Matches against the entire string.
-	Patterns []languagePattern
+	Patterns []languagePattern[R]
 }
 
-type languagePattern struct {
-	pattern  *regexp.Regexp
+type languagePattern[R any] struct {
+	pattern  R
 	language string
 }
 
-// highlightConfig is the effective configuration for highlighting
+// globalHighlightConfig is the effective configuration for highlighting
 // after applying base and site configuration. Use this to determine
 // what extensions and/or patterns map to what languages.
-var highlightConfig = syntaxHighlightConfig{
+var globalHighlightConfig = syntaxHighlightConfig[*regexp.Regexp]{
 	Extensions: map[string]string{},
-	Patterns:   []languagePattern{},
+	Patterns:   []languagePattern[*regexp.Regexp]{},
 }
 
-var baseHighlightConfig = syntaxHighlightConfig{
+var baseHighlightConfig = syntaxHighlightConfig[*regexp.Regexp]{
 	Extensions: map[string]string{
 		"tsx":  "tsx", // default `getLanguage()` helper doesn't handle TSX
 		"ncl":  "nickel",
@@ -101,7 +102,7 @@ var baseHighlightConfig = syntaxHighlightConfig{
 		"sc":   "scala",
 		"xlsg": "xlsg",
 	},
-	Patterns: []languagePattern{},
+	Patterns: []languagePattern[*regexp.Regexp]{},
 }
 
 type syntaxEngineConfig struct {
@@ -109,10 +110,10 @@ type syntaxEngineConfig struct {
 	Overrides map[string]EngineType
 }
 
-// engineConfig is the effective configuration at any given time
+// globalEngineConfig is the effective configuration at any given time
 // after applying base configuration and site configuration. Use
 // this to determine what engine should be used for highlighting.
-var engineConfig = syntaxEngineConfig{
+var globalEngineConfig = syntaxEngineConfig{
 	// This sets the default syntax engine for the sourcegraph server.
 	Default: EngineSyntect,
 
@@ -123,9 +124,6 @@ var engineConfig = syntaxEngineConfig{
 
 // baseEngineConfig is the configuration that we set up by default,
 // and will enable any languages that we feel confident with tree-sitter.
-//
-// Eventually, we will switch from having `Default` be EngineSyntect and move
-// to having it be EngineTreeSitter.
 var baseEngineConfig = syntaxEngineConfig{
 	Default: EngineTreeSitter,
 	Overrides: map[string]EngineType{
@@ -137,72 +135,73 @@ var baseEngineConfig = syntaxEngineConfig{
 	},
 }
 
+func initializeConfig(
+	siteHighlightingConfig *schema.SyntaxHighlighting,
+	baseEngineConfig syntaxEngineConfig,
+	baseHighlightConfig syntaxHighlightConfig[*regexp.Regexp],
+) (engineConfig syntaxEngineConfig, highlightConfig syntaxHighlightConfig[*regexp.Regexp]) {
+	engineConfig.Default = baseEngineConfig.Default
+
+	engineConfig.Overrides = map[string]EngineType{}
+	for name, engine := range baseEngineConfig.Overrides {
+		engineConfig.Overrides[name] = engine
+	}
+
+	highlightConfig.Extensions = map[string]string{}
+	for extension, language := range baseHighlightConfig.Extensions {
+		highlightConfig.Extensions[extension] = language
+	}
+
+	if siteHighlightingConfig == nil {
+		return
+	}
+
+	if siteHighlightingConfig.Engine != nil {
+		if defaultEngine, ok := EngineNameToEngineType(siteHighlightingConfig.Engine.Default); ok {
+			engineConfig.Default = defaultEngine
+		}
+		// Set overrides from configuration
+		//
+		// We populate the confuration with base again, because we need to
+		// create a brand new map to not take any values that were
+		// previously in the table from the last configuration.
+		//
+		// After that, we set the values from the new configuration
+		for name, engine := range siteHighlightingConfig.Engine.Overrides {
+			if overrideEngine, ok := EngineNameToEngineType(engine); ok {
+				engineConfig.Overrides[strings.ToLower(name)] = overrideEngine
+			}
+		}
+	}
+
+	if siteHighlightingConfig.Languages != nil {
+		for extension, language := range siteHighlightingConfig.Languages.Extensions {
+			highlightConfig.Extensions[extension] = language
+		}
+		highlightConfig.Patterns = []languagePattern[*regexp.Regexp]{}
+		for _, pattern := range siteHighlightingConfig.Languages.Patterns {
+			if re, err := regexp.Compile(pattern.Pattern); err == nil {
+				highlightConfig.Patterns = append(highlightConfig.Patterns, languagePattern[*regexp.Regexp]{pattern: re, language: pattern.Language})
+			}
+		}
+	}
+	return
+}
+
 func Init() {
 	go func() {
 		conf.Watch(func() {
-			// Populate effective configuration with base configuration
-			//    We have to add here to make sure that even if there is no config,
-			//    we still update to use the defaults
-			engineConfig.Default = baseEngineConfig.Default
-			for name, engine := range baseEngineConfig.Overrides {
-				engineConfig.Overrides[name] = engine
+			var inputConfig *schema.SyntaxHighlighting
+			if config := conf.Get(); config != nil {
+				inputConfig = config.SyntaxHighlighting
 			}
-
-			engineConfig.Overrides = map[string]EngineType{}
-			for name, engine := range baseEngineConfig.Overrides {
-				engineConfig.Overrides[name] = engine
-			}
-
-			highlightConfig.Extensions = map[string]string{}
-			for extension, language := range baseHighlightConfig.Extensions {
-				highlightConfig.Extensions[extension] = language
-			}
-
-			config := conf.Get()
-			if config == nil {
-				return
-			}
-
-			highlightingConfig := config.SyntaxHighlighting
-			if highlightingConfig == nil {
-				return
-			}
-
-			if highlightingConfig.Engine != nil {
-				if defaultEngine, ok := EngineNameToEngineType(highlightingConfig.Engine.Default); ok {
-					engineConfig.Default = defaultEngine
-				}
-				// Set overrides from configuration
-				//
-				// We populate the confuration with base again, because we need to
-				// create a brand new map to not take any values that were
-				// previously in the table from the last configuration.
-				//
-				// After that, we set the values from the new configuration
-				for name, engine := range highlightingConfig.Engine.Overrides {
-					if overrideEngine, ok := EngineNameToEngineType(engine); ok {
-						engineConfig.Overrides[strings.ToLower(name)] = overrideEngine
-					}
-				}
-			}
-
-			if highlightingConfig.Languages != nil {
-				for extension, language := range highlightingConfig.Languages.Extensions {
-					highlightConfig.Extensions[extension] = language
-				}
-				highlightConfig.Patterns = []languagePattern{}
-				for _, pattern := range highlightingConfig.Languages.Patterns {
-					if re, err := regexp.Compile(pattern.Pattern); err == nil {
-						highlightConfig.Patterns = append(highlightConfig.Patterns, languagePattern{pattern: re, language: pattern.Language})
-					}
-				}
-			}
+			globalEngineConfig, globalHighlightConfig = initializeConfig(inputConfig, baseEngineConfig, baseHighlightConfig)
 		})
 	}()
 }
 
 // Matches against config. Only returns values if there is a match.
-func getLanguageFromConfig(config syntaxHighlightConfig, path string) (string, bool) {
+func getLanguageFromConfig(config syntaxHighlightConfig[*regexp.Regexp], path string) (string, bool) {
 	extension := strings.ToLower(strings.TrimPrefix(filepath.Ext(path), "."))
 	if ft, ok := config.Extensions[extension]; ok {
 		return ft, true
@@ -220,7 +219,7 @@ func getLanguageFromConfig(config syntaxHighlightConfig, path string) (string, b
 // getLanguage will return the name of the language and default back to enry if
 // no language could be found.
 func getLanguage(path string, contents string) (string, bool) {
-	lang, found := getLanguageFromConfig(highlightConfig, path)
+	lang, found := getLanguageFromConfig(globalHighlightConfig, path)
 	if found {
 		return lang, true
 	}
@@ -237,8 +236,8 @@ func DetectSyntaxHighlightingLanguage(path string, contents string) SyntaxEngine
 	lang, langOverride := getLanguage(path, contents)
 	lang = strings.ToLower(lang)
 
-	engine := engineConfig.Default
-	if overrideEngine, ok := engineConfig.Overrides[lang]; ok {
+	engine := globalEngineConfig.Default
+	if overrideEngine, ok := globalEngineConfig.Overrides[lang]; ok {
 		engine = overrideEngine
 	}
 

--- a/internal/highlight/language_test.go
+++ b/internal/highlight/language_test.go
@@ -1,22 +1,172 @@
 package highlight
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/grafana/regexp"
+	"github.com/hexops/autogold/v2"
+
+	"github.com/sourcegraph/sourcegraph/schema"
 )
 
 type languageTestCase struct {
-	Config   syntaxHighlightConfig
+	Config   syntaxHighlightConfig[*regexp.Regexp]
 	Path     string
 	Expected string
 	Found    bool
 }
 
+func TestInitializeConfig(t *testing.T) {
+	type TestCase struct {
+		siteConfig          *schema.SyntaxHighlighting
+		baseEngineConfig    syntaxEngineConfig
+		baseHighlightConfig syntaxHighlightConfig[*regexp.Regexp]
+		wantEngineConfig    autogold.Value
+		wantHighlightConfig autogold.Value
+	}
+
+	// Update golden values with go test ./internal/highlight/... -update
+	testCases := []TestCase{
+		{
+			siteConfig:          nil,
+			wantEngineConfig:    autogold.Expect(syntaxEngineConfig{Overrides: map[string]EngineType{}}),
+			wantHighlightConfig: autogold.Expect(syntaxHighlightConfig[string]{Extensions: map[string]string{}}),
+		},
+		{
+			siteConfig: &schema.SyntaxHighlighting{
+				Engine: &schema.SyntaxHighlightingEngine{},
+			},
+			wantEngineConfig:    autogold.Expect(syntaxEngineConfig{Overrides: map[string]EngineType{}}),
+			wantHighlightConfig: autogold.Expect(syntaxHighlightConfig[string]{Extensions: map[string]string{}}),
+		},
+		{
+			siteConfig: &schema.SyntaxHighlighting{
+				Engine: &schema.SyntaxHighlightingEngine{
+					Overrides: map[string]string{"go": "syntect"},
+				},
+			},
+			wantEngineConfig: autogold.Expect(syntaxEngineConfig{Overrides: map[string]EngineType{
+				"go": EngineSyntect,
+			}}),
+			wantHighlightConfig: autogold.Expect(syntaxHighlightConfig[string]{Extensions: map[string]string{}}),
+		},
+		{
+			siteConfig: &schema.SyntaxHighlighting{
+				Engine: &schema.SyntaxHighlightingEngine{
+					Default: "syntect",
+				},
+			},
+			wantEngineConfig:    autogold.Expect(syntaxEngineConfig{Default: EngineSyntect, Overrides: map[string]EngineType{}}),
+			wantHighlightConfig: autogold.Expect(syntaxHighlightConfig[string]{Extensions: map[string]string{}}),
+		},
+		{
+			baseEngineConfig:    baseEngineConfig,
+			baseHighlightConfig: baseHighlightConfig,
+			wantEngineConfig: autogold.Expect(syntaxEngineConfig{
+				Default: EngineTreeSitter,
+				Overrides: map[string]EngineType{
+					"go":     EngineScipSyntax,
+					"java":   EngineScipSyntax,
+					"matlab": EngineScipSyntax,
+					"perl":   EngineScipSyntax,
+				},
+			}),
+			wantHighlightConfig: autogold.Expect(syntaxHighlightConfig[string]{Extensions: map[string]string{
+				"ncl":  "nickel",
+				"sbt":  "scala",
+				"sc":   "scala",
+				"tsx":  "tsx",
+				"xlsg": "xlsg",
+			}}),
+		},
+		{
+			siteConfig: &schema.SyntaxHighlighting{
+				Engine: &schema.SyntaxHighlightingEngine{
+					Default: "syntect",
+				},
+			},
+			baseEngineConfig:    baseEngineConfig,
+			baseHighlightConfig: baseHighlightConfig,
+			wantEngineConfig: autogold.Expect(syntaxEngineConfig{Default: EngineSyntect, Overrides: map[string]EngineType{
+				"go":     EngineScipSyntax,
+				"java":   EngineScipSyntax,
+				"matlab": EngineScipSyntax,
+				"perl":   EngineScipSyntax,
+			}}),
+			wantHighlightConfig: autogold.Expect(syntaxHighlightConfig[string]{Extensions: map[string]string{
+				"ncl":  "nickel",
+				"sbt":  "scala",
+				"sc":   "scala",
+				"tsx":  "tsx",
+				"xlsg": "xlsg",
+			}}),
+		},
+		{
+			siteConfig: &schema.SyntaxHighlighting{
+				Languages: &schema.SyntaxHighlightingLanguage{
+					Extensions: map[string]string{
+						"hack": "php",
+					},
+				},
+			},
+			wantEngineConfig: autogold.Expect(syntaxEngineConfig{Overrides: map[string]EngineType{}}),
+			wantHighlightConfig: autogold.Expect(syntaxHighlightConfig[string]{Extensions: map[string]string{
+				"hack": "php",
+			}}),
+		},
+		{
+			siteConfig: &schema.SyntaxHighlighting{
+				Languages: &schema.SyntaxHighlightingLanguage{
+					Patterns: []*schema.SyntaxHighlightingLanguagePatterns{
+						{
+							Pattern:  "BUILD(\\.bzl|\\.bazel)?",
+							Language: "starlark",
+						},
+						{
+							Pattern:  "Makefile",
+							Language: "Make",
+						},
+					},
+				},
+			},
+			wantEngineConfig: autogold.Expect(syntaxEngineConfig{Overrides: map[string]EngineType{}}),
+			wantHighlightConfig: autogold.Expect(syntaxHighlightConfig[string]{
+				Extensions: map[string]string{},
+				Patterns: []languagePattern[string]{
+					{
+						pattern:  "BUILD(\\.bzl|\\.bazel)?",
+						language: "starlark",
+					},
+					{
+						pattern:  "Makefile",
+						language: "Make",
+					},
+				},
+			}),
+		},
+	}
+
+	for i, testCase := range testCases {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			gotEngineConfig, gotHighlightConfig := initializeConfig(testCase.siteConfig, testCase.baseEngineConfig, testCase.baseHighlightConfig)
+			testCase.wantEngineConfig.Equal(t, gotEngineConfig)
+			var patterns []languagePattern[string]
+			for _, p := range gotHighlightConfig.Patterns {
+				patterns = append(patterns, languagePattern[string]{
+					pattern:  p.pattern.String(),
+					language: p.language,
+				})
+			}
+			testCase.wantHighlightConfig.Equal(t, syntaxHighlightConfig[string]{Extensions: gotHighlightConfig.Extensions, Patterns: patterns})
+		})
+	}
+}
+
 func TestGetLanguageFromConfig(t *testing.T) {
 	cases := []languageTestCase{
 		{
-			Config: syntaxHighlightConfig{
+			Config: syntaxHighlightConfig[*regexp.Regexp]{
 				Extensions: map[string]string{
 					"go": "not go",
 				},
@@ -26,7 +176,7 @@ func TestGetLanguageFromConfig(t *testing.T) {
 			Expected: "not go",
 		},
 		{
-			Config: syntaxHighlightConfig{
+			Config: syntaxHighlightConfig[*regexp.Regexp]{
 				Extensions: map[string]string{},
 			},
 			Path:     "example.go",
@@ -35,7 +185,7 @@ func TestGetLanguageFromConfig(t *testing.T) {
 		},
 
 		{
-			Config: syntaxHighlightConfig{
+			Config: syntaxHighlightConfig[*regexp.Regexp]{
 				Extensions: map[string]string{
 					"strato": "scala",
 				},
@@ -46,8 +196,8 @@ func TestGetLanguageFromConfig(t *testing.T) {
 		},
 
 		{
-			Config: syntaxHighlightConfig{
-				Patterns: []languagePattern{
+			Config: syntaxHighlightConfig[*regexp.Regexp]{
+				Patterns: []languagePattern[*regexp.Regexp]{
 					{
 						pattern:  regexp.MustCompile("asdf"),
 						language: "not matching",

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -3217,22 +3217,22 @@ type SymbolConfiguration struct {
 
 // SyntaxHighlighting description: Syntax highlighting configuration
 type SyntaxHighlighting struct {
-	Engine    SyntaxHighlightingEngine   `json:"engine"`
-	Languages SyntaxHighlightingLanguage `json:"languages"`
+	Engine    *SyntaxHighlightingEngine   `json:"engine,omitempty"`
+	Languages *SyntaxHighlightingLanguage `json:"languages,omitempty"`
 	// Symbols description: Configure symbol generation
 	Symbols *SymbolConfiguration `json:"symbols,omitempty"`
 }
 type SyntaxHighlightingEngine struct {
 	// Default description: The default syntax highlighting engine to use
-	Default string `json:"default"`
+	Default string `json:"default,omitempty"`
 	// Overrides description: Manually specify overrides for syntax highlighting engine per language
 	Overrides map[string]string `json:"overrides,omitempty"`
 }
 type SyntaxHighlightingLanguage struct {
 	// Extensions description: Map of extension to language
-	Extensions map[string]string `json:"extensions"`
+	Extensions map[string]string `json:"extensions,omitempty"`
 	// Patterns description: Map of patterns to language. Will return after first match, if any.
-	Patterns []*SyntaxHighlightingLanguagePatterns `json:"patterns"`
+	Patterns []*SyntaxHighlightingLanguagePatterns `json:"patterns,omitempty"`
 }
 type SyntaxHighlightingLanguagePatterns struct {
 	// Language description: Name of the language if pattern matches

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -959,12 +959,10 @@
       "title": "SyntaxHighlighting",
       "description": "Syntax highlighting configuration",
       "type": "object",
-      "required": ["engine", "languages"],
       "properties": {
         "engine": {
           "title": "SyntaxHighlightingEngine",
           "type": "object",
-          "required": ["default"],
           "properties": {
             "default": {
               "description": "The default syntax highlighting engine to use",
@@ -984,7 +982,6 @@
         "languages": {
           "title": "SyntaxHighlightingLanguage",
           "type": "object",
-          "required": ["extensions", "patterns"],
           "properties": {
             "extensions": {
               "description": "Map of extension to language",


### PR DESCRIPTION
At the moment, too many fields are required, which means you need
to specify unnecessary fields when trying to modify only a single
field, such as mapping specific extensions to specific languages.

Fixes https://linear.app/sourcegraph/issue/GRAPH-612

## Test plan

Added unit tests for configuration initialization