### PR TITLE
SSC: Three small fixes for Teams & invites

### DIFF
--- a/client/web/src/cody/subscription/CodySubscriptionPage.tsx
+++ b/client/web/src/cody/subscription/CodySubscriptionPage.tsx
@@ -238,10 +238,11 @@ export const CodySubscriptionPage: React.FunctionComponent<CodySubscriptionPageP
                                         </Button>
                                         <Link
                                             className="text-center"
-                                            to="https://sourcegraph.com/contact/request-info?utm_source=cody_subscription_page"
+                                            to={manageSubscriptionRedirectURL}
                                             target="_blank"
                                             rel="noreferrer noopener"
-                                            onClick={() => {
+                                            onClick={event => {
+                                                event.preventDefault()
                                                 telemetryRecorder.recordEvent('cody.planSelection', 'click', {
                                                     metadata: { tier: 1, team: 0 },
                                                 })

--- a/client/web/src/cody/team/InviteUsers.tsx
+++ b/client/web/src/cody/team/InviteUsers.tsx
@@ -78,7 +78,9 @@ export const InviteUsers: React.FunctionComponent<InviteUsersProps> = ({
         <>
             {invitesSendingStatus === 'success' && (
                 <div className={classNames('mb-4', styles.alert, styles.blueSuccessAlert)}>
-                    <H3>{invitesSentCount} {pluralize('invite', invitesSentCount)} sent!</H3>
+                    <H3>
+                        {invitesSentCount} {pluralize('invite', invitesSentCount)} sent!
+                    </H3>
                     <Text size="small" className="mb-0">
                         Invitees will receive an email from cody@sourcegraph.com.
                     </Text>

--- a/client/web/src/cody/team/InviteUsers.tsx
+++ b/client/web/src/cody/team/InviteUsers.tsx
@@ -23,6 +23,7 @@ export const InviteUsers: React.FunctionComponent<InviteUsersProps> = ({
     const [emailAddressesString, setEmailAddressesString] = useState<string>('')
     const [emailAddressErrorMessage, setEmailAddressErrorMessage] = useState<string | null>(null)
     const [invitesSendingStatus, setInvitesSendingStatus] = useState<'idle' | 'sending' | 'success' | 'error'>('idle')
+    const [invitesSentCount, setInvitesSentCount] = useState(0)
     const [invitesSendingErrorMessage, setInvitesSendingErrorMessage] = useState<string | null>(null)
 
     const onSendInvitesClicked = useCallback(async () => {
@@ -58,6 +59,7 @@ export const InviteUsers: React.FunctionComponent<InviteUsersProps> = ({
                 return
             }
             setInvitesSendingStatus('success')
+            setInvitesSentCount(emailAddresses.length)
             telemetryRecorder.recordEvent('cody.team.sendInvites', 'success', {
                 metadata: { count: emailAddresses.length },
                 privateMetadata: { teamId, emailAddresses },
@@ -76,7 +78,7 @@ export const InviteUsers: React.FunctionComponent<InviteUsersProps> = ({
         <>
             {invitesSendingStatus === 'success' && (
                 <div className={classNames('mb-4', styles.alert, styles.blueSuccessAlert)}>
-                    <H3>4 invites sent!</H3>
+                    <H3>{invitesSentCount} {pluralize('invite', invitesSentCount)} sent!</H3>
                     <Text size="small" className="mb-0">
                         Invitees will receive an email from cody@sourcegraph.com.
                     </Text>

--- a/client/web/src/cody/team/TeamMemberList.tsx
+++ b/client/web/src/cody/team/TeamMemberList.tsx
@@ -104,7 +104,7 @@ export const TeamMemberList: FunctionComponent<TeamMemberListProps> = ({
             if (!loading) {
                 // Avoids sending multiple requests at once
                 setLoading(true)
-                telemetryRecorder.recordEvent('cody.team.revokeInvite', 'click', { privateMetadata: { teamId } })
+                telemetryRecorder.recordEvent('cody.team.resendInvite', 'click', { privateMetadata: { teamId } })
 
                 const response = await requestSSC(`/team/current/invites/${inviteId}/resend`, 'POST')
                 if (!response.ok) {
@@ -126,11 +126,9 @@ export const TeamMemberList: FunctionComponent<TeamMemberListProps> = ({
 
     const removeMember = useCallback(
         async (accountId: string): Promise<void> => {
-            telemetryRecorder.recordEvent('cody.team.removeMember', 'click', { privateMetadata: { teamId, accountId } })
-
             if (!loading) {
                 setLoading(true)
-                telemetryRecorder.recordEvent('cody.team.revokeInvite', 'click', { privateMetadata: { teamId } })
+                telemetryRecorder.recordEvent('cody.team.removeMember', 'click', { privateMetadata: { teamId } })
 
                 const response = await requestSSC(`/team/current/members/${accountId}`, 'DELETE')
                 if (!response.ok) {


### PR DESCRIPTION
Finally, I could start testing the experience end-to-end.
I found the first few mistakes during that.

Three changes:
1. Fixed a few copy-paste mistakes in the team member list action logging
2. The URL in the case of single users was wrong—now it works correctly. Plus the logging was likely suppressed by the "to" part because `event.preventDefault()` was not called.
3. Made the number of invites dynamic in the notification, pluralized:
![CleanShot 2024-05-21 at 14 19 54@2x](https://github.com/sourcegraph/sourcegraph/assets/2552265/22305037-51bb-429d-8e9b-0cf0479fce09)

The three changes are three commits in this PR to make the review easier.

## Test plan

Tested manually.