### PR TITLE
svelte: Preserve current revision in repo search input

### DIFF
--- a/client/web-sveltekit/src/routes/[...repo=reporev]/+layout.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/+layout.svelte
@@ -96,7 +96,15 @@
                 </MenuLink>
             {/each}
         </DropdownMenu>
-        <RepoSearchInput repoName={data.repoName} />
+        <RepoSearchInput
+            repoName={data.repoName}
+            revision={data.resolvedRevision
+                ? {
+                      commitID: data.resolvedRevision.commitID,
+                      revision: data.revision,
+                  }
+                : undefined}
+        />
     </nav>
 </GlobalHeaderPortal>
 

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/+layout.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/+layout.svelte
@@ -96,15 +96,7 @@
                 </MenuLink>
             {/each}
         </DropdownMenu>
-        <RepoSearchInput
-            repoName={data.repoName}
-            revision={data.resolvedRevision
-                ? {
-                      commitID: data.resolvedRevision.commitID,
-                      revision: data.revision,
-                  }
-                : undefined}
-        />
+        <RepoSearchInput repoName={data.repoName} revision={data.displayRevision} />
     </nav>
 </GlobalHeaderPortal>
 

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/+layout.ts
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/+layout.ts
@@ -63,10 +63,40 @@ export const load: LayoutLoad = async ({ params, url, depends }) => {
         repoURL: '/' + params.repo,
         repoName,
         displayRepoName: displayRepoName(repoName),
+        /**
+         * Revision from URL
+         */
         revision,
+        /**
+         * A friendly display form of the revision. This can be:
+         * - an empty string which signifies the default branch
+         * - an abbreviated commit SHA
+         * - a symbolic revision (e.g. a branch or tag name)
+         */
+        displayRevision: displayRevision(revision, resolvedRevision),
         resolvedRevisionOrError,
         resolvedRevision,
     }
+}
+
+/**
+ * Returns a friendly display form of the revision. If the resolved revision's commit ID starts with the revision,
+ * the first 7 characters of the commit ID are returned. Otherwise, the revision is returned as is.
+ *
+ * @param revision The revision from the URL
+ * @param resolvedRevision The resolved revision
+ * @returns A human readable revision string
+ */
+function displayRevision(revision: string, resolvedRevision: ResolvedRevision | undefined): string {
+    if (!resolvedRevision) {
+        return revision
+    }
+
+    if (resolvedRevision.commitID.startsWith(revision)) {
+        return resolvedRevision.commitID.slice(0, 7)
+    }
+
+    return revision
 }
 
 function redirectToExternalHost(externalRedirectURL: string, currentURL: URL): never {

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/+layout.ts
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/+layout.ts
@@ -33,12 +33,15 @@ export const load: LayoutLoad = async ({ params, url, depends }) => {
     // inside markdown is loaded.
     loadMarkdownSyntaxHighlighting()
 
-    const { repoName, revision } = parseRepoRevision(params.repo)
+    // An empty revision means we are at the default branch
+    const { repoName, revision = '' } = parseRepoRevision(params.repo)
 
     let resolvedRevisionOrError: ResolvedRevision | ErrorLike
+    let resolvedRevision: ResolvedRevision | undefined
 
     try {
         resolvedRevisionOrError = await resolveRepoRevision({ client, repoName, revision })
+        resolvedRevision = resolvedRevisionOrError
     } catch (repoError: unknown) {
         const redirect = isRepoSeeOtherErrorLike(repoError)
 
@@ -46,7 +49,7 @@ export const load: LayoutLoad = async ({ params, url, depends }) => {
             redirectToExternalHost(redirect, url)
         }
 
-        // TODO: use differenr error codes for different types of errors
+        // TODO: use different error codes for different types of errors
         // Let revision errors be handled by the nested layout so that we can
         // still render the main repo navigation and header
         if (!isRevisionNotFoundErrorLike(repoError)) {
@@ -62,6 +65,7 @@ export const load: LayoutLoad = async ({ params, url, depends }) => {
         displayRepoName: displayRepoName(repoName),
         revision,
         resolvedRevisionOrError,
+        resolvedRevision,
     }
 }
 

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/RepoSearchInput.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/RepoSearchInput.svelte
@@ -15,7 +15,7 @@
     /**
      * The revision to search in. If not provided, the default branch is used.
      */
-    export let revision: { commitID: string; revision: string } | undefined
+    export let revision: string
 
     const {
         elements: { trigger, overlay, content, portalled },
@@ -37,24 +37,7 @@
         )
     }
 
-    function formatRevision(revision: string, commitID: string): string {
-        // Do not append revison for the default branch
-        if (!revision) {
-            return ''
-        }
-
-        // If the (URL) revision is or starts with the commit ID, use the abbreviated commit ID
-        if (commitID.startsWith(revision)) {
-            return '@' + commitID.slice(0, 7)
-        }
-
-        // Otherwise, use the revision as is
-        return '@' + revision
-    }
-
-    $: query = `repo:${repositoryInsertText({ repository: repoName })}${
-        revision ? formatRevision(revision.revision, revision.commitID) : ''
-    } `
+    $: query = `repo:${repositoryInsertText({ repository: repoName })}${revision ? `@${revision}` : ''}`
     $: queryState = queryStateStore({ query }, $settings)
     $: if ($open) {
         // @melt-ui automatically focuses the search input but that positions the cursor at the

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/RepoSearchInput.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/RepoSearchInput.svelte
@@ -12,6 +12,10 @@
     import { registerHotkey } from '$lib/Hotkey'
 
     export let repoName: string
+    /**
+     * The revision to search in. If not provided, the default branch is used.
+     */
+    export let revision: { commitID: string; revision: string } | undefined
 
     const {
         elements: { trigger, overlay, content, portalled },
@@ -19,7 +23,6 @@
     } = createDialog()
 
     let searchInput: SearchInput | undefined
-    let queryState = queryStateStore({ query: `repo:${repositoryInsertText({ repository: repoName })} ` }, $settings)
 
     registerHotkey({
         keys: { key: '/' },
@@ -34,6 +37,25 @@
         )
     }
 
+    function formatRevision(revision: string, commitID: string): string {
+        // Do not append revison for the default branch
+        if (!revision) {
+            return ''
+        }
+
+        // If the (URL) revision is or starts with the commit ID, use the abbreviated commit ID
+        if (commitID.startsWith(revision)) {
+            return '@' + commitID.slice(0, 7)
+        }
+
+        // Otherwise, use the revision as is
+        return '@' + revision
+    }
+
+    $: query = `repo:${repositoryInsertText({ repository: repoName })}${
+        revision ? formatRevision(revision.revision, revision.commitID) : ''
+    } `
+    $: queryState = queryStateStore({ query }, $settings)
     $: if ($open) {
         // @melt-ui automatically focuses the search input but that positions the cursor at the
         // start of the input. We can move the cursor to the end by calling focus(), but we need


### PR DESCRIPTION
Closes #62713 

## Test plan

Manually tested with default revision, selected branch and selected revision.
