### PR TITLE
gitserver: Fix CommitLog on some git versions

### DIFF
--- a/cmd/gitserver/internal/git/gitcli/commitlog.go
+++ b/cmd/gitserver/internal/git/gitcli/commitlog.go
@@ -81,7 +81,6 @@ func buildCommitLogArgs(opt git.CommitLogOpts) ([]string, error) {
 		args = append(args, "--first-parent")
 	}
 
-	args = append(args, opt.Ranges...)
 	if opt.AllRefs {
 		args = append(args, "--all")
 	}
@@ -92,6 +91,9 @@ func buildCommitLogArgs(opt git.CommitLogOpts) ([]string, error) {
 	if opt.FollowPathRenames {
 		args = append(args, "--follow")
 	}
+
+	args = append(args, opt.Ranges...)
+
 	if opt.Path != "" {
 		args = append(args, "--", opt.Path)
 	}


### PR DESCRIPTION
I don't have a clue yet why this happens, but I'll let the two outputs below speak for themselves:

On my mac:

```
➜  sourcegraph git:(main) git log --format='format:%x1e%H%x00%aN%x00%aE%x00%at%x00%cN%x00%cE%x00%ct%x00%B%x00%P%x00' --after=2024-02-21T18:26:09Z --topo-order HEAD --name-only
➜  sourcegraph git:(main) git version
git version 2.45.1
```

In the latest gitserver docker image from main:

```
/data/repos $ git log --format='format:%x1e%H%x00%aN%x00%aE%x00%at%x00%cN%x00%cE%x00%ct%x00%B%x00%P%x00' --after=2024-02-2
1T18:26:09Z --topo-order HEAD --name-only
fatal: option '--name-only' must come before non-option arguments
/data/repos $ git version
git version 2.45.1
```

Test plan:

Verified the generated command runs alright inside our docker image.