### PR TITLE
svelte: Add tailling space to default repo search input

### DIFF
--- a/client/web-sveltekit/src/routes/[...repo=reporev]/RepoSearchInput.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/RepoSearchInput.svelte
@@ -37,7 +37,7 @@
         )
     }
 
-    $: query = `repo:${repositoryInsertText({ repository: repoName })}${revision ? `@${revision}` : ''}`
+    $: query = `repo:${repositoryInsertText({ repository: repoName })}${revision ? `@${revision}` : ''} `
     $: queryState = queryStateStore({ query }, $settings)
     $: if ($open) {
         // @melt-ui automatically focuses the search input but that positions the cursor at the


### PR DESCRIPTION
The input is missing a trailing space. I messed that up when making changes to #62822.

## Test plan

Trivial change.
