### PR TITLE
Svelte: remove site-admin-only data from repo popover

### DIFF
--- a/client/web-sveltekit/src/lib/repo/RepoPopover/RepoPopover.gql
+++ b/client/web-sveltekit/src/lib/repo/RepoPopover/RepoPopover.gql
@@ -10,11 +10,8 @@ fragment RepoPopoverFragment on Repository {
     stars
     isPrivate
     topics
-    externalServices {
-        totalCount
-        nodes {
-            kind
-        }
+    externalRepository {
+        serviceType
     }
 
     commit(rev: "HEAD") {

--- a/client/web-sveltekit/src/lib/repo/RepoPopover/RepoPopover.svelte
+++ b/client/web-sveltekit/src/lib/repo/RepoPopover/RepoPopover.svelte
@@ -14,7 +14,6 @@
 
 <script lang="ts">
     import { mdiSourceMerge } from '@mdi/js'
-    import { capitalize } from 'lodash'
 
     import Avatar from '$lib/Avatar.svelte'
     import Icon from '$lib/Icon.svelte'

--- a/client/web-sveltekit/src/lib/repo/RepoPopover/RepoPopover.svelte
+++ b/client/web-sveltekit/src/lib/repo/RepoPopover/RepoPopover.svelte
@@ -23,7 +23,7 @@
     import Badge from '$lib/wildcard/Badge.svelte'
 
     import RepoStars from '../RepoStars.svelte'
-    import { getIconPathForCodeHost } from '../shared/codehost'
+    import { getHumanNameForCodeHost, getIconPathForCodeHost } from '../shared/codehost'
 
     import type { RepoPopoverFragment } from './RepoPopover.gql'
 
@@ -32,7 +32,6 @@
 
     $: commit = data.commit
     $: author = commit?.author
-    $: codeHostKind = data.externalServices.nodes[0].kind
 </script>
 
 <div class="root">
@@ -46,8 +45,12 @@
                 </Badge>
             </div>
             <div class="right">
-                <Icon svgPath={getIconPathForCodeHost(codeHostKind)} --icon-fill-color="var(--text-body)" --size={24} />
-                <small>{capitalize(codeHostKind)}</small>
+                <Icon
+                    svgPath={getIconPathForCodeHost(data.externalRepository.serviceType)}
+                    --icon-fill-color="var(--text-body)"
+                    --size={24}
+                />
+                <small>{getHumanNameForCodeHost(data.externalRepository.serviceType)}</small>
             </div>
         </div>
     {/if}

--- a/client/web-sveltekit/src/routes/search/RepoRev.svelte
+++ b/client/web-sveltekit/src/routes/search/RepoRev.svelte
@@ -6,6 +6,7 @@
     import CodeHostIcon from '$lib/search/CodeHostIcon.svelte'
     import { displayRepoName } from '$lib/shared'
     import { delay } from '$lib/utils'
+    import Alert from '$lib/wildcard/Alert.svelte'
 
     export let repoName: string
     export let rev: string | undefined
@@ -37,6 +38,8 @@
             <svelte:fragment slot="content">
                 {#await delay(fetchRepoPopoverData(client, repoName), 200) then data}
                     <RepoPopover {data} withHeader />
+                {:catch error}
+                    <Alert variant="danger" size="slim">{error}</Alert>
                 {/await}
             </svelte:fragment>
         </Popover>


### PR DESCRIPTION
The repo popover has deployed to S2, but it's not visible to anyone who is not a site admin because one of the GraphQL fields used is restricted to only site admins.

This updates the query to use a non-restricted field, and also fixes the code host capitalization while I'm at it.

Additionally, if there is an error, it now displays it in the popover so it should be easier to catch these in the future.

# Test plan

Manually tested it still works when I use a user with no site admin permissions. This is a great motivator for getting solid end-to-end tests working 🙂 