### PR TITLE
Fix woes related to undefined frontendCodyProConfig.sscBaseUrl

### DIFF
--- a/client/web/src/cody/util.ts
+++ b/client/web/src/cody/util.ts
@@ -1,7 +1,14 @@
 // The URL to direct users in order to manage their Cody Pro subscription.
 import { useState, useEffect } from 'react'
 
-export const manageSubscriptionRedirectURL = `${window.context.frontendCodyProConfig?.sscBaseUrl}/subscription`
+// URL the user needs to navigate to in order to modify their Cody Pro subscription.
+//
+// BUG: This should be configurable via the `window.context.frontendCodyProConfig`,
+// but because the backend doesn't supply a meaningful default, and this is used
+// as a value instead of a function to compute the value, we just fix things by
+// going back to hard-coding it.
+// export const manageSubscriptionRedirectURL = `${window.context.frontendCodyProConfig?.sscBaseUrl}/subscription`
+export const manageSubscriptionRedirectURL = 'https://accounts.sourcegraph.com/cody/subscription'
 
 /**
  * useEmbeddedCodyProUi returns if we expect the Cody Pro UI to be served from sourcegraph.com. Meaning


### PR DESCRIPTION
We need a URL to point the user to the webpage to manage their Cody Pro subscription in a couple places. And to support testing in lower environments, we made that configurable in https://github.com/sourcegraph/sourcegraph/pull/62790/files#diff-70a08658447c0eeaf1f548b8e325cac30a08567323d32e50b1953786404a5b07.

There was a problem in that PR however, the "default" value in the `site.schema.json` doesn't do what you'd think. So at runtime the value for `frontendCodyProConfig.sscBaseUrl` was always always the empty string. This leads to confusing errors whenever you try to manage your Cody Pro subscription.

I tried to just update the Sourcegraph.com site config to supply that value like intended, however in doing that the Sourcegraph.com frontend jobs would start to crash loop. (Because only supplying the `sscBaseUrl` config value means that the `codyProConfig` settings contain "invalid values" for `sscBackendOrigin`.

... since things have been broken in production for XX hours now, and I'd like to making any logic changes under duress, this PR just backs out the problematic line of code in that earlier PR. (So instead of reading the uninitialized config setting, it just hard-codes the default value.)

The ideal fix for this, IMHO, would be to expose a new config settings `showEmbeddedUi` so that the function `isEmbeddedCodyProUIEnabled()` can rely on that. Since that way, we can supply all of the `codyProConfig` configuration data for Sourcegraph.com, without any fears of unintentionally enabling the new UI. Otherwise, it seems dangerous to set all of the config values, but somehow _not_ the Stripe Publishable key because _that_ is the thing that controls the UI we display.

## Test Plan

Tested locally.