### PR TITLE
svelte: Show correct byline when commit has author and committer

### DIFF
--- a/client/web-sveltekit/src/lib/Commit.gql
+++ b/client/web-sveltekit/src/lib/Commit.gql
@@ -8,6 +8,7 @@ fragment Commit on GitCommit {
         date
         person {
             name
+            email
             ...Avatar_Person
         }
     }

--- a/client/web-sveltekit/src/lib/Commit.svelte
+++ b/client/web-sveltekit/src/lib/Commit.svelte
@@ -13,7 +13,7 @@
     export let commit: Commit
     export let alwaysExpanded: boolean = false
 
-    function getCommitter({ committer }: Commit): NonNullable<Commit['committer']>['person'] | null {
+    function getCommitter({ committer }: Commit): NonNullable<Commit['committer']> | null {
         if (!committer) {
             return null
         }
@@ -21,26 +21,27 @@
         if (committer.person.name === 'GitHub' && committer.person.email === 'noreply@github.com') {
             return null
         }
-        return committer.person
+        return committer
     }
 
-    $: commitDate = new Date(commit.committer ? commit.committer.date : commit.author.date)
-    $: author = commit.author.person
-    $: committer = getCommitter(commit)
-    $: authorAvatarTooltip = author.name + (committer ? ' (author)' : '')
+    $: author = commit.author
+    $: committer = getCommitter(commit) ?? author
+    $: committerIsAuthor = committer.person.email === author.person.email
+    $: commitDate = new Date(committer.date)
+    $: authorAvatarTooltip = author.person.name + (committer ? ' (author)' : '')
     let expanded = alwaysExpanded
 </script>
 
 <div class="root">
     <div class="avatar">
         <Tooltip tooltip={authorAvatarTooltip}>
-            <Avatar avatar={author} />
+            <Avatar avatar={author.person} />
         </Tooltip>
     </div>
-    {#if committer && committer.name !== author.name}
+    {#if !committerIsAuthor}
         <div class="avatar">
-            <Tooltip tooltip="{committer.name} (committer)">
-                <Avatar avatar={committer} />
+            <Tooltip tooltip="{committer.person.name} (committer)">
+                <Avatar avatar={committer.person} />
             </Tooltip>
         </div>
     {/if}
@@ -53,7 +54,11 @@
                 </button>
             {/if}
         </span>
-        <span>committed by <strong>{author.name}</strong> <Timestamp date={commitDate} /></span>
+        <span>
+            {#if !committerIsAuthor}authored by <strong>{author.person.name}</strong> and{/if}
+            committed by <strong>{committer.person.name}</strong>
+            <Timestamp date={commitDate} />
+        </span>
         {#if expanded && commit.body}
             <pre>{commit.body}</pre>
         {/if}


### PR DESCRIPTION
It was reported ([Slack thread](https://sourcegraph.slack.com/archives/C05MHAP318B/p1716347420277679)) that the "byline" isn't correct when a commit has an author and a committer.

This fixes it.

| Before | After |
|--------|--------|
| ![2024-05-22_10-30](https://github.com/sourcegraph/sourcegraph/assets/179026/0b0e32cc-14df-4910-888a-3ef549411373)| ![2024-05-22_10-24](https://github.com/sourcegraph/sourcegraph/assets/179026/4fd56dca-4641-48eb-9ad5-9d9376b1f504) | 

<!--

💡 To write a useful PR description, make sure that your description covers:

- WHAT this PR is changing:
    - How was it PREVIOUSLY.
    - How it will be from NOW on.
- WHY this PR is needed.
- CONTEXT, i.e. to which initiative, project or RFC it belongs.

The structure of the description doesn't matter as much as covering these points, so use
your best judgement based on your context.

Learn how to write good pull request description: https://www.notion.so/sourcegraph/Write-a-good-pull-request-description-610a7fd3e613496eb76f450db5a49b6e?pvs=4
-->

## Test plan

Manual testing.
