### PR TITLE
Make the URL dynamic, now with a fallback

### DIFF
--- a/client/web/src/cody/util.ts
+++ b/client/web/src/cody/util.ts
@@ -1,7 +1,7 @@
 // The URL to direct users in order to manage their Cody Pro subscription.
 import { useState, useEffect } from 'react'
 
-// URL the user needs to navigate to in4 order to modify their Cody Pro subscription.
+// URL the user needs to navigate to in order to modify their Cody Pro subscription.
 export const manageSubscriptionRedirectURL = `${
     window.context.frontendCodyProConfig?.sscBaseUrl || 'https://accounts.sourcegraph.com/cody'
 }/subscription`

--- a/client/web/src/cody/util.ts
+++ b/client/web/src/cody/util.ts
@@ -1,14 +1,10 @@
 // The URL to direct users in order to manage their Cody Pro subscription.
 import { useState, useEffect } from 'react'
 
-// URL the user needs to navigate to in order to modify their Cody Pro subscription.
-//
-// BUG: This should be configurable via the `window.context.frontendCodyProConfig`,
-// but because the backend doesn't supply a meaningful default, and this is used
-// as a value instead of a function to compute the value, we just fix things by
-// going back to hard-coding it.
-// export const manageSubscriptionRedirectURL = `${window.context.frontendCodyProConfig?.sscBaseUrl}/subscription`
-export const manageSubscriptionRedirectURL = 'https://accounts.sourcegraph.com/cody/subscription'
+// URL the user needs to navigate to in4 order to modify their Cody Pro subscription.
+export const manageSubscriptionRedirectURL = `${
+    window.context.frontendCodyProConfig?.sscBaseUrl || 'https://accounts.sourcegraph.com/cody'
+}/subscription`
 
 /**
  * useEmbeddedCodyProUi returns if we expect the Cody Pro UI to be served from sourcegraph.com. Meaning


### PR DESCRIPTION
I made this URL dynamic before, [here](https://github.com/sourcegraph/sourcegraph/pull/62790), but that didn't work [because](https://github.com/sourcegraph/sourcegraph/pull/62790#issuecomment-2123533378) the "default" value in the `site.schema.json` file doesn't do what I thought it did. So @chrsmith did a quick fix in https://github.com/sourcegraph/sourcegraph/pull/62835, but then we lost the ability to make this dynamic.

So this PR makes it dynamic again, this time with a working fallback.

### Alternatives considered:

I tried to do the same thing on the back end, but it didn't feel right.

1. I tried a transformation in `computed.go`:

```go
// GetCodyProConfig returns the CodyProConfig for the current site config,
// with some handy defaults.
func GetCodyProConfig(siteConfig schema.SiteConfiguration) (c conftypes.CodyProConfig) {
	c.SamsBackendOrigin = "https://accounts.sourcegraph.com"
	c.SscBackendOrigin = "https://accounts.sourcegraph.com"
	c.SscBaseUrl = "https://accounts.sourcegraph.com/cody"
	c.StripePublishableKey = nil

	if siteConfig.Dotcom == nil || siteConfig.Dotcom.CodyProConfig == nil {
		return
	}

	codyProConfig := siteConfig.Dotcom.CodyProConfig
	if codyProConfig != nil {
		c.SamsBackendOrigin = codyProConfig.SamsBackendOrigin
		c.SscBackendOrigin = codyProConfig.SscBackendOrigin
		c.SscBaseUrl = codyProConfig.SscBaseUrl
		c.StripePublishableKey = &codyProConfig.StripePublishableKey
	}
	return
}
```

But having the defaults there was meh, plus I had to introduce the new type `conftypes.CodyProConfig` but nothing prevents another eng to just use the config directly, which might become confusing.

2. I thought about setting the defaults in `makeFrontendCodyProConfig`, which might be better, but then, on the front end, we already have a single location where we access the SSC base URL, and we already had the default there, so I just went with that.

## Test plan

Here is a [1-min Loom](https://www.loom.com/share/a86ed717a19344c5bb14a5d4e45a1f14) where I test it with different settings and demo that it works as intended.