### PR TITLE
chore: Pull in latest http-server-stabilizer version

### DIFF
--- a/wolfi-packages/http-server-stabilizer.yaml
+++ b/wolfi-packages/http-server-stabilizer.yaml
@@ -2,8 +2,8 @@
 
 package:
   name: http-server-stabilizer
-  version: 1.1.0
-  epoch: 3
+  version: 2.0.0
+  epoch: 0
   description: "HTTP server stabilizer for unruly servers"
   target-architecture:
     - x86_64
@@ -28,7 +28,7 @@ pipeline:
   - uses: fetch
     with:
       uri: https://github.com/sourcegraph/http-server-stabilizer/archive/refs/tags/v${{package.version}}.tar.gz
-      expected-sha256: 4d0d2e4e36d20441abc898fd87031c0b4e40ce25057b6023c929bb0ffa0de4f7
+      expected-sha256: 9c157f4275317550ad2888539a2c6fa488c432eeae2e575ce16492860d9ccd91
   - uses: go/build
     with:
       packages: ./...


### PR DESCRIPTION
This PR doesn't update syntax-highlighter's lockfile;
that will happen in a separate PR after the package
gets published to our package repository.

## Test plan

Only a version bump; doesn't affect deployed versions, so n/a