### PR TITLE
chore(gha): link to how-to when license check fail

### DIFF
--- a/.github/workflows/licenses-check.yml
+++ b/.github/workflows/licenses-check.yml
@@ -38,11 +38,11 @@ jobs:
 
       - name: Install license_finder
         id: installLicenseFinder
-        run: exit 1 # gem install license_finder:7.1.0 # sync with licenses-update.yml
+        run: gem install license_finder:7.1.0 # sync with licenses-update.yml
 
       - name: Check dependencies
         id: checkDepedencies
-        run: LICENSE_CHECK=true ./dev/licenses.sh
+        run: exit 1 # LICENSE_CHECK=true ./dev/licenses.sh
 
       # If we detect a failure on the two above steps, we post a comment pointing toward the associated How-to in the handbook.
       - uses: actions/github-script@v6
@@ -53,5 +53,5 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: "> [!TIP] \n> License checking failed, please see [How to deal with third parties licensing](https://www.notion.so/sourcegraph/Dealing-with-third-parties-licensing-2d8247b243d44eaea2c6003f2efae4ef)"
+              body: "> [!CONSULT] \n> License checking failed, please consult: [How to deal with third parties licensing](https://www.notion.so/sourcegraph/Dealing-with-third-parties-licensing-2d8247b243d44eaea2c6003f2efae4ef)."
             })

--- a/.github/workflows/licenses-check.yml
+++ b/.github/workflows/licenses-check.yml
@@ -38,11 +38,11 @@ jobs:
 
       - name: Install license_finder
         id: installLicenseFinder
-        run: gem install license_finder:7.1.0 # sync with licenses-update.yml
+        run: exit 1 # gem install license_finder:7.1.0 # sync with licenses-update.yml
 
       - name: Check dependencies
         id: checkDepedencies
-        run: exit 1 # LICENSE_CHECK=true ./dev/licenses.sh
+        run: LICENSE_CHECK=true ./dev/licenses.sh
 
       # If we detect a failure on the two above steps, we post a comment pointing toward the associated How-to in the handbook.
       - uses: actions/github-script@v6
@@ -53,5 +53,5 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: "> [!CONSULT] \n> License checking failed, please consult: [How to deal with third parties licensing](https://www.notion.so/sourcegraph/Dealing-with-third-parties-licensing-2d8247b243d44eaea2c6003f2efae4ef)."
+              body: "> [!CAUTION] \n> License checking failed, please consult: [How to deal with third parties licensing](https://www.notion.so/sourcegraph/Dealing-with-third-parties-licensing-2d8247b243d44eaea2c6003f2efae4ef)."
             })

--- a/.github/workflows/licenses-check.yml
+++ b/.github/workflows/licenses-check.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Install license_finder
         id: installLicenseFinder
-        run: exit 1 # gem install license_finder:7.1.0 # sync with licenses-update.yml
+        run: gem install license_finder:7.1.0 # sync with licenses-update.yml
 
       - name: Check dependencies
         id: checkDepedencies
@@ -53,5 +53,5 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: "> [!CAUTION] \n> License checking failed, please consult: [How to deal with third parties licensing](https://www.notion.so/sourcegraph/Dealing-with-third-parties-licensing-2d8247b243d44eaea2c6003f2efae4ef)."
+              body: "> [!CAUTION] \n> License checking failed, please read: [how to deal with third parties licensing](https://www.notion.so/sourcegraph/Dealing-with-third-parties-licensing-2d8247b243d44eaea2c6003f2efae4ef)."
             })

--- a/.github/workflows/licenses-check.yml
+++ b/.github/workflows/licenses-check.yml
@@ -37,7 +37,21 @@ jobs:
 
 
       - name: Install license_finder
-        run: gem install license_finder:7.1.0 # sync with licenses-update.yml
+        id: installLicenseFinder
+        run: exit 1 # gem install license_finder:7.1.0 # sync with licenses-update.yml
 
       - name: Check dependencies
+        id: checkDepedencies
         run: LICENSE_CHECK=true ./dev/licenses.sh
+
+      # If we detect a failure on the two above steps, we post a comment pointing toward the associated How-to in the handbook.
+      - uses: actions/github-script@v6
+        if: always() && (steps.installLicenseFinder.outcome == 'failure' || steps.checkDepedencies.outcome == 'failure')
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: "> [!TIP] \n> License checking failed, please see [How to deal with third parties licensing](https://www.notion.so/sourcegraph/Dealing-with-third-parties-licensing-2d8247b243d44eaea2c6003f2efae4ef)"
+            })


### PR DESCRIPTION
Previously, if the license checking action failed, there was no actionnable instructions for the users. This PR adds a conditional step that posts a comment with a link to the how-to in Notion. 

I'm using this PR as a way to QA this, hence the few commits to QA each cases. 

<!--

💡 To write a useful PR description, make sure that your description covers:

- WHAT this PR is changing:
    - How was it PREVIOUSLY.
    - How it will be from NOW on.
- WHY this PR is needed.
- CONTEXT, i.e. to which initiative, project or RFC it belongs.

The structure of the description doesn't matter as much as covering these points, so use
your best judgement based on your context.

Learn how to write good pull request description: https://www.notion.so/sourcegraph/Write-a-good-pull-request-description-610a7fd3e613496eb76f450db5a49b6e?pvs=4
-->

## Test plan

CI + this PR itself (see commits) 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles

Why does it matter?

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers.
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component:
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests"
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs:
  - "previewed locally"
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI"
  - "locally tested"
-->
