### PR TITLE
SSC: Fix invite date formatting

### DIFF
--- a/client/web/BUILD.bazel
+++ b/client/web/BUILD.bazel
@@ -1897,6 +1897,7 @@ ts_project(
         "src/codeintel/ReferencesPanel.mocks.ts",
         "src/codeintel/ReferencesPanel.test.tsx",
         "src/cody/management/api/hooks/useApiClient.test.tsx",
+        "src/cody/team/TeamMemberList.test.ts",
         "src/cody/useCodyIgnore.test.ts",
         "src/components/ErrorBoundary.test.tsx",
         "src/components/FilteredConnection/FilteredConnection.test.tsx",

--- a/client/web/src/cody/team/TeamMemberList.test.ts
+++ b/client/web/src/cody/team/TeamMemberList.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+import { formatInviteDate } from './TeamMemberList'
+
+// This is a bit weird test, but I wanted to give the design some examples for how the formatting looks,
+// and this was the easiest way to do that. Rather than throwing away the test, I'm leaving it here.
+describe('getFilterFnsFromCodyContextFilters', () => {
+    it('looks good for typical input', async () => {
+        // These are in the format of the normal output of our Go back end
+        const inputDates = [
+            '2024-05-22T15:59:55.000000+00:00',
+            '2024-05-22T14:17:55.000000+00:00',
+            '2024-05-21T14:17:55.000000+00:00',
+            '2024-05-15T14:17:55.000000+00:00',
+            ]
+
+        const now = new Date('2024-05-22T16:00:00.000000+00:00')
+
+        const expectedOutput = [
+            '5 seconds ago',
+            '1 hour ago',
+            'yesterday',
+            'last week',
+            ]
+
+        const outputDates = inputDates.map(date => formatInviteDate(date, now))
+
+        expect(outputDates).toEqual(expectedOutput)
+    })
+})

--- a/client/web/src/cody/team/TeamMemberList.test.ts
+++ b/client/web/src/cody/team/TeamMemberList.test.ts
@@ -1,49 +1,33 @@
 import { describe, expect, it } from 'vitest'
+
 import { formatInviteDate } from './TeamMemberList'
 
-// This is a bit weird test, but I wanted to give the design some examples for how the formatting looks,
-// and this was the easiest way to do that. Rather than throwing away the test, I'm leaving it here.
-describe('getFilterFnsFromCodyContextFilters', () => {
-    it('looks good for typical input', async () => {
-        // These are in the format of the normal output of our Go back end
+describe('formatInviteDate', () => {
+    it('shows relative descriptions of time in the desired format', async () => {
+        // ISO-8601 (RFC3339) strings, just the way the backend returns them
         const inputDates = [
             '2024-05-22T15:59:55.000000+00:00',
             '2024-05-22T14:17:55.000000+00:00',
             '2024-05-21T14:17:55.000000+00:00',
             '2024-05-15T14:17:55.000000+00:00',
-            ]
+        ]
 
         const now = new Date('2024-05-22T16:00:00.000000+00:00')
 
-        const expectedOutput = [
-            '5 seconds ago',
-            '1 hour ago',
-            'yesterday',
-            'last week',
-            ]
+        const expectedOutput = ['5 seconds ago', '1 hour ago', 'yesterday', 'last week']
 
         const outputDates = inputDates.map(date => formatInviteDate(date, now))
 
         expect(outputDates).toEqual(expectedOutput)
     })
 
-    it('does not fail too badly with atypical input', async () => {
+    it('handles malformed input', async () => {
         // These are in the format of the normal output of our Go back end
-        const inputDates = [
-            null,
-            '',
-            '1T14:17:55.000000+00:00',
-            '2024-05-15T14:17:55',
-            ]
+        const inputDates = [null, '', '1T14:17:55.000000+00:00', '2024-05-15T14:17:55']
 
         const now = new Date('2024-05-22T16:00:00.000000+00:00')
 
-        const expectedOutput = [
-            '',
-            '',
-            '',
-            'last week',
-        ]
+        const expectedOutput = ['', '', '', 'last week']
 
         const outputDates = inputDates.map(date => formatInviteDate(date, now))
 

--- a/client/web/src/cody/team/TeamMemberList.test.ts
+++ b/client/web/src/cody/team/TeamMemberList.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest'
 import { formatInviteDate } from './TeamMemberList'
 
 describe('formatInviteDate', () => {
-    it('shows relative descriptions of time in the desired format', async () => {
+    it('shows relative descriptions of time in the desired format', () => {
         // ISO-8601 (RFC3339) strings, just the way the backend returns them
         const inputDates = [
             '2024-05-22T15:59:55.000000+00:00',
@@ -21,7 +21,7 @@ describe('formatInviteDate', () => {
         expect(outputDates).toEqual(expectedOutput)
     })
 
-    it('handles malformed input', async () => {
+    it('handles malformed input', () => {
         // These are in the format of the normal output of our Go back end
         const inputDates = [null, '', '1T14:17:55.000000+00:00', '2024-05-15T14:17:55']
 

--- a/client/web/src/cody/team/TeamMemberList.test.ts
+++ b/client/web/src/cody/team/TeamMemberList.test.ts
@@ -26,4 +26,27 @@ describe('getFilterFnsFromCodyContextFilters', () => {
 
         expect(outputDates).toEqual(expectedOutput)
     })
+
+    it('does not fail too badly with atypical input', async () => {
+        // These are in the format of the normal output of our Go back end
+        const inputDates = [
+            null,
+            '',
+            '1T14:17:55.000000+00:00',
+            '2024-05-15T14:17:55',
+            ]
+
+        const now = new Date('2024-05-22T16:00:00.000000+00:00')
+
+        const expectedOutput = [
+            '',
+            '',
+            '',
+            'last week',
+        ]
+
+        const outputDates = inputDates.map(date => formatInviteDate(date, now))
+
+        expect(outputDates).toEqual(expectedOutput)
+    })
 })

--- a/client/web/src/cody/team/TeamMemberList.tsx
+++ b/client/web/src/cody/team/TeamMemberList.tsx
@@ -40,12 +40,11 @@ export const formatInviteDate = (sentAt: string | null, now?: Date): string => {
     try {
         if (sentAt) {
             return intlFormatDistance(sentAt || '', now ?? new Date())
-        } else {
-            return ''
         }
     } catch {
         return ''
     }
+    return ''
 }
 
 export const TeamMemberList: FunctionComponent<TeamMemberListProps> = ({

--- a/client/web/src/cody/team/TeamMemberList.tsx
+++ b/client/web/src/cody/team/TeamMemberList.tsx
@@ -1,6 +1,7 @@
 import { type FunctionComponent, useMemo, useCallback, useState } from 'react'
 
 import classNames from 'classnames'
+import { intlFormatDistance } from 'date-fns'
 
 import type { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import { H2, Text, Badge, Link, ButtonLink } from '@sourcegraph/wildcard'
@@ -8,7 +9,6 @@ import { H2, Text, Badge, Link, ButtonLink } from '@sourcegraph/wildcard'
 import { requestSSC } from '../util'
 
 import styles from './CodyManageTeamPage.module.scss'
-import { intlFormatDistance } from 'date-fns'
 
 export interface TeamMember {
     accountId: string
@@ -35,11 +35,14 @@ export interface TeamInvite {
     acceptedAt: string | null
 }
 
-// This little function is extracted to make it testable.
-// Same for the "now" parameter.
+// This tiny function is extracted to make it testable. Same for the "now" parameter.
 export const formatInviteDate = (sentAt: string | null, now?: Date): string => {
     try {
-        return sentAt ? intlFormatDistance(sentAt || '', now ?? new Date()) : ''
+        if (sentAt) {
+            return intlFormatDistance(sentAt || '', now ?? new Date())
+        } else {
+            return ''
+        }
     } catch {
         return ''
     }

--- a/client/web/src/cody/team/TeamMemberList.tsx
+++ b/client/web/src/cody/team/TeamMemberList.tsx
@@ -8,6 +8,7 @@ import { H2, Text, Badge, Link, ButtonLink } from '@sourcegraph/wildcard'
 import { requestSSC } from '../util'
 
 import styles from './CodyManageTeamPage.module.scss'
+import { intlFormatDistance } from 'date-fns'
 
 export interface TeamMember {
     accountId: string
@@ -33,6 +34,10 @@ export interface TeamInvite {
     sentAt: string | null
     acceptedAt: string | null
 }
+
+// This little function is extracted to make it testable.
+// Same for the "now" parameter.
+export const formatInviteDate = (sentAt: string | null, now?: Date): string => intlFormatDistance(sentAt ?? '', now ?? new Date())
 
 export const TeamMemberList: FunctionComponent<TeamMemberListProps> = ({
     teamId,
@@ -266,7 +271,7 @@ export const TeamMemberList: FunctionComponent<TeamMemberListProps> = ({
                                     )}
                                 </div>
                                 <div className="align-content-center">
-                                    <em>Invite sent {invite.sentAt /* TODO format this */}</em>
+                                    <em>Invite sent {formatInviteDate(invite.sentAt)}</em>
                                 </div>
                                 {isAdmin && (
                                     <>

--- a/client/web/src/cody/team/TeamMemberList.tsx
+++ b/client/web/src/cody/team/TeamMemberList.tsx
@@ -37,7 +37,13 @@ export interface TeamInvite {
 
 // This little function is extracted to make it testable.
 // Same for the "now" parameter.
-export const formatInviteDate = (sentAt: string | null, now?: Date): string => intlFormatDistance(sentAt ?? '', now ?? new Date())
+export const formatInviteDate = (sentAt: string | null, now?: Date): string => {
+    try {
+        return sentAt ? intlFormatDistance(sentAt || '', now ?? new Date()) : ''
+    } catch {
+        return ''
+    }
+}
 
 export const TeamMemberList: FunctionComponent<TeamMemberListProps> = ({
     teamId,

--- a/client/web/src/cody/team/TeamMemberList.tsx
+++ b/client/web/src/cody/team/TeamMemberList.tsx
@@ -39,12 +39,12 @@ export interface TeamInvite {
 export const formatInviteDate = (sentAt: string | null, now?: Date): string => {
     try {
         if (sentAt) {
-            return intlFormatDistance(sentAt || '', now ?? new Date())
+            return intlFormatDistance(sentAt, now ?? new Date())
         }
+        return ''
     } catch {
         return ''
     }
-    return ''
 }
 
 export const TeamMemberList: FunctionComponent<TeamMemberListProps> = ({

--- a/client/web/src/cody/util.ts
+++ b/client/web/src/cody/util.ts
@@ -3,7 +3,7 @@ import { useState, useEffect } from 'react'
 
 // URL the user needs to navigate to in order to modify their Cody Pro subscription.
 export const manageSubscriptionRedirectURL = `${
-    window.context.frontendCodyProConfig?.sscBaseUrl || 'https://accounts.sourcegraph.com/cody'
+    window.context?.frontendCodyProConfig?.sscBaseUrl || 'https://accounts.sourcegraph.com/cody'
 }/subscription`
 
 /**
@@ -14,7 +14,7 @@ export const manageSubscriptionRedirectURL = `${
  * for managing their Cody Pro subscription information.
  */
 export function isEmbeddedCodyProUIEnabled(): boolean {
-    return !!(window.context.frontendCodyProConfig as { stripePublishableKey: string } | undefined)
+    return !!(window.context?.frontendCodyProConfig as { stripePublishableKey: string } | undefined)
         ?.stripePublishableKey
 }
 


### PR DESCRIPTION
This is a step toward https://github.com/sourcegraph/self-serve-cody/issues/725

The list of invitations used to look like this:

![CleanShot 2024-05-22 at 17 16 15@2x](https://github.com/sourcegraph/sourcegraph/assets/2552265/424761eb-1103-46b7-8cb1-f4915e1223c3)

Now it looks like this:

![CleanShot 2024-05-22 at 17 17 19@2x](https://github.com/sourcegraph/sourcegraph/assets/2552265/f0f01b09-fd5e-4e44-9be1-c41c9a5f3a9f)

which intends to match [this design](https://www.figma.com/design/FMSdn1oKccJRHQPgf7053o/Cody-PLG-GA?node-id=4658-18897&t=m1L9vFMX0uBbl2Y0-0).

Some other examples with the current solution are:
- Invite sent 5 seconds ago
- Invite sent 1 hour ago
- Invite sent yesterday
- Invite sent last week
@rrhyne, is this format fine?

## Test plan

- Added tests
- Tested it manually, it renders well.