### PR TITLE
Svelte: linkify and wrap dir entries

### DIFF
--- a/client/web-sveltekit/src/lib/repo/FileHeader.svelte
+++ b/client/web-sveltekit/src/lib/repo/FileHeader.svelte
@@ -34,7 +34,7 @@
             {@const last = index === breadcrumbs.length - 1}
             <!--
                 The elements are arranged like this because we want to
-                ensure that the leading / before a segement always stay with
+                ensure that the leading / before a segment always stays with
                 the segment. I.e.
 
                     path / to / file

--- a/client/web-sveltekit/src/lib/repo/filePopover/FilePopover.svelte
+++ b/client/web-sveltekit/src/lib/repo/filePopover/FilePopover.svelte
@@ -67,17 +67,17 @@
             Ideally we'd be able to use `break-after: avoid;`, but that's not widely supported.
         -->
         {#each displayRepoName(repoName).split('/') as repoFragment, i}
-            <div>
-                {#if i > 0}<div>/</div>{/if}
-                <div>{repoFragment}</div>
-            </div>
+            <span>
+                {#if i > 0}<span>/</span>{/if}
+                <span>{repoFragment}</span>
+            </span>
         {/each}
-        {#if dirNameBreadcrumbs.length}<div>·</div>{/if}
+        {#if dirNameBreadcrumbs.length}<span>·</span>{/if}
         {#each dirNameBreadcrumbs as [name, href], i}
-            <div>
-                {#if i > 0}<div>/</div>{/if}
-                <div><a {href}>{name}</a></div>
-            </div>
+            <span>
+                {#if i > 0}<span>/</span>{/if}
+                <span><a {href}>{name}</a></span>
+            </span>
         {/each}
     </div>
 
@@ -105,7 +105,7 @@
         {/if}
     </div>
 
-    <div class="last-changed section">Last Changed @</div>
+    <div class="last-changed section">Last Changed</div>
 
     <div class="commit">
         <div class="node-line"><NodeLine /></div>
@@ -139,7 +139,7 @@
             display: flex;
             flex-wrap: wrap;
             gap: 0.375em;
-            div {
+            span {
                 display: flex;
                 flex-wrap: nowrap;
                 gap: inherit;

--- a/client/web-sveltekit/src/lib/repo/filePopover/FilePopover.svelte
+++ b/client/web-sveltekit/src/lib/repo/filePopover/FilePopover.svelte
@@ -109,7 +109,7 @@
                     {lastCommit.abbreviatedOID}
                 </a>
             </Badge>
-            <div class="body">{lastCommit.subject}</div>
+            <div class="body"><a href={lastCommit.canonicalURL}>{lastCommit.subject}</a></div>
             <div class="author">
                 <Avatar avatar={lastCommit.author.person} --avatar-size="1.0rem" />
                 {lastCommit.author.person.displayName}
@@ -204,5 +204,8 @@
 
     .body {
         color: var(--text-body);
+        a {
+            color: unset;
+        }
     }
 </style>

--- a/client/web-sveltekit/src/lib/repo/filePopover/FilePopover.svelte
+++ b/client/web-sveltekit/src/lib/repo/filePopover/FilePopover.svelte
@@ -65,11 +65,11 @@
         <small>
             {displayRepoName(repoName).replace('/', ' / ')}
             {#if dirNameBreadcrumbs}·{/if}
-            {#each dirNameBreadcrumbs as [name, path], i}
+            {#each dirNameBreadcrumbs as [name, href], i}
                 {' '}
                 <span>
                     {#if i > 0}/{/if}
-                    <a href={path}>{name}</a>
+                    <a {href}>{name}</a>
                 </span>
             {/each}
         </small>
@@ -131,9 +131,12 @@
 
         .repo-and-path {
             border-bottom: 1px solid var(--border-color);
-            overflow: hidden;
-            text-overflow: ellipsis;
-            white-space: nowrap;
+            a {
+                color: unset;
+                &:hover {
+                    color: var(--text-body);
+                }
+            }
         }
 
         .lang-and-file {

--- a/client/web-sveltekit/src/lib/repo/filePopover/FilePopover.svelte
+++ b/client/web-sveltekit/src/lib/repo/filePopover/FilePopover.svelte
@@ -62,17 +62,23 @@
 
 <div class="root section muted">
     <div class="repo-and-path section mono">
-        <small>
-            {displayRepoName(repoName).replace('/', ' / ')}
-            {#if dirNameBreadcrumbs.length}·{/if}
-            {#each dirNameBreadcrumbs as [name, href], i}
-                {' '}
-                <span>
-                    {#if i > 0}/{/if}
-                    <a {href}>{name}</a>
-                </span>
-            {/each}
-        </small>
+        <!--
+            Extra layer of divs to allow customizing the gap, but wrap before the slashes.
+            Ideally we'd be able to use `break-after: avoid;`, but that's not widely supported.
+        -->
+        {#each displayRepoName(repoName).split('/') as repoFragment, i}
+            <div>
+                {#if i > 0}<div>/</div>{/if}
+                <div>{repoFragment}</div>
+            </div>
+        {/each}
+        {#if dirNameBreadcrumbs.length}<div>·</div>{/if}
+        {#each dirNameBreadcrumbs as [name, href], i}
+            <div>
+                {#if i > 0}<div>/</div>{/if}
+                <div><a {href}>{name}</a></div>
+            </div>
+        {/each}
     </div>
 
     <div class="lang-and-file section">
@@ -130,7 +136,18 @@
         }
 
         .repo-and-path {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.375em;
+            div {
+                display: flex;
+                flex-wrap: nowrap;
+                gap: inherit;
+            }
+
             border-bottom: 1px solid var(--border-color);
+
+            font-size: var(--font-size-tiny);
             a {
                 color: unset;
                 &:hover {

--- a/client/web-sveltekit/src/lib/repo/filePopover/FilePopover.svelte
+++ b/client/web-sveltekit/src/lib/repo/filePopover/FilePopover.svelte
@@ -64,7 +64,7 @@
     <div class="repo-and-path section mono">
         <small>
             {displayRepoName(repoName).replace('/', ' / ')}
-            {#if dirNameBreadcrumbs}·{/if}
+            {#if dirNameBreadcrumbs.length}·{/if}
             {#each dirNameBreadcrumbs as [name, href], i}
                 {' '}
                 <span>

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/FileTree.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/FileTree.svelte
@@ -141,7 +141,7 @@
                     </a>
                     <svelte:fragment slot="content">
                         {#await delay(fetchPopoverData({ repoName, revision, filePath: entry.path }), 300) then entry}
-                            <FilePopover {repoName} {entry} />
+                            <FilePopover {repoName} {revision} {entry} />
                         {/await}
                     </svelte:fragment>
                 </Popover>


### PR DESCRIPTION
This makes each dir entry in the file popover header a link, and allows wrapping so the full path is always visible. Uses the same wrapping logic as the file header so the slashes work right. Additionally, it linkifies the commit message to point to the same page as the OID link

Fixes SRCH-125, SRCH-126, SRCH-127, and SRCH-98

# Test plan

https://github.com/sourcegraph/sourcegraph/assets/12631702/2e773a3c-10c2-41d4-8ada-c2c6b43d5a9c



