### PR TITLE
svelte: Fix failing/skipped playwright tests

### DIFF
--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/+layout.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/+layout.svelte
@@ -190,7 +190,13 @@
         <div class="sidebar" class:collapsed={isCollapsed}>
             <header>
                 <div class="sidebar-action-row">
-                    <Button variant="secondary" outline size="sm" on:click={toggleFileSidePanel}>
+                    <Button
+                        variant="secondary"
+                        outline
+                        size="sm"
+                        on:click={toggleFileSidePanel}
+                        aria-label="{isCollapsed ? 'Open' : 'Close'} sidebar"
+                    >
                         <Icon svgPath={!isCollapsed ? mdiChevronDoubleLeft : mdiChevronDoubleRight} inline />
                     </Button>
 

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/page.spec.ts
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/page.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '../../../../testing/integration'
+import { test, expect, type Page } from '../../../../testing/integration'
 
 const repoName = 'github.com/sourcegraph/sourcegraph'
 
@@ -104,18 +104,19 @@ test.beforeEach(({ sg }) => {
 })
 
 test.describe('file sidebar', () => {
-    test.skip('basic functionality', async ({ page }) => {
+
+    async function openSidebar(page: Page): Promise<void> {
+        return page.getByLabel('Open sidebar').click()
+    }
+
+    test('basic functionality', async ({ page }) => {
         const readmeEntry = page.getByRole('treeitem', { name: 'README.md' })
 
         await page.goto(`/${repoName}`)
-        await expect(readmeEntry).toBeVisible()
-
-        // Close file sidebar
-        await page.getByRole('button', { name: 'Hide sidebar' }).click()
-        await expect(readmeEntry).toBeHidden()
 
         // Open sidebar
-        await page.getByRole('button', { name: 'Show sidebar' }).click()
+        await page.getByLabel('Open sidebar').click()
+        await expect(readmeEntry).toBeVisible()
 
         // Go to a file
         await readmeEntry.click()
@@ -123,14 +124,18 @@ test.describe('file sidebar', () => {
         // Verify that entry is selected
         await expect(page.getByRole('treeitem', { name: 'README.md', selected: true })).toBeVisible()
 
-        // Go other file
+        // Go to other file
         await page.getByRole('treeitem', { name: 'index.js' }).click()
         await expect(page).toHaveURL(`/${repoName}/-/blob/index.js`)
         // Verify that entry is selected
         await expect(page.getByRole('treeitem', { name: 'index.js', selected: true })).toBeVisible()
+
+        // Close file sidebar
+        await page.getByLabel('Close sidebar').click()
+        await expect(readmeEntry).toBeHidden()
     })
 
-    test.skip('error handling root', async ({ page, sg }) => {
+    test('error handling root', async ({ page, sg }) => {
         sg.mockOperations({
             TreeEntries: () => {
                 throw new Error('Sidebar error')
@@ -138,11 +143,13 @@ test.describe('file sidebar', () => {
         })
 
         await page.goto(`/${repoName}`)
+        await openSidebar(page)
         await expect(page.getByText(/Sidebar error/)).toBeVisible()
     })
 
-    test.skip('error handling children', async ({ page, sg }) => {
+    test('error handling children', async ({ page, sg }) => {
         await page.goto(`/${repoName}`)
+        await openSidebar(page)
 
         const treeItem = page.getByRole('treeitem', { name: 'src' })
         // For some reason we need to wait for the tree to be rendered
@@ -160,7 +167,7 @@ test.describe('file sidebar', () => {
         await expect(page.getByText(/Child error/)).toBeVisible()
     })
 
-    test.skip('error handling non-existing directory -> root', async ({ page, sg }) => {
+    test('error handling non-existing directory -> root', async ({ page, sg }) => {
         // Here we expect the sidebar to show an error message, and after navigigating
         // to an existing directory, the directory contents
         sg.mockOperations({
@@ -170,6 +177,7 @@ test.describe('file sidebar', () => {
         })
 
         await page.goto(`/${repoName}/-/tree/non-existing-directory`)
+        await openSidebar(page)
         await expect(page.getByText(/Sidebar error/).first()).toBeVisible()
 
         sg.mockOperations({
@@ -181,6 +189,7 @@ test.describe('file sidebar', () => {
         })
 
         await page.goto(`/${repoName}`)
+        await openSidebar(page)
         await expect(page.getByRole('treeitem', { name: 'README.md' })).toBeVisible()
     })
 })

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/page.spec.ts
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/page.spec.ts
@@ -104,7 +104,6 @@ test.beforeEach(({ sg }) => {
 })
 
 test.describe('file sidebar', () => {
-
     async function openSidebar(page: Page): Promise<void> {
         return page.getByLabel('Open sidebar').click()
     }

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/-/branches/all/page.spec.ts
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/-/branches/all/page.spec.ts
@@ -18,13 +18,17 @@ test.beforeEach(async ({ sg }) => {
             repository: {
                 branches: {
                     nodes: [{ displayName: 'main' }, { displayName: 'feature/branch' }],
+                    pageInfo: {
+                        // Needed to prevent infinity scroll from trying to load more pages
+                        hasNextPage: false,
+                    },
                 },
             },
         }),
     })
 })
 
-test.skip('list branches', async ({ page }) => {
+test('list branches', async ({ page }) => {
     await page.goto(url)
 
     await expect(page.getByRole('link', { name: 'main' })).toBeVisible()

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/-/tags/page.spec.ts
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/-/tags/page.spec.ts
@@ -16,12 +16,16 @@ test.beforeEach(async ({ sg }) => {
     })
 })
 
-test.skip('list tags', async ({ sg, page }) => {
+test('list tags', async ({ sg, page }) => {
     sg.mockOperations({
         TagsPage_TagsQuery: () => ({
             repository: {
                 gitRefs: {
                     nodes: [{ displayName: 'v1.0.0', url: `/${repoName}@v1.0.0` }, { displayName: 'v1.0.1' }],
+                    pageInfo: {
+                        // Needed to prevent infinity scroll from trying to load more pages
+                        hasNextPage: false,
+                    },
                     totalCount: 42,
                 },
             },

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/layout.spec.ts
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/layout.spec.ts
@@ -22,6 +22,9 @@ test.describe('cloned repository', () => {
                 repositoryRedirect: {
                     id: '1',
                     name: repoName,
+                    commit: {
+                        oid: '123456789',
+                    },
                 },
             }),
         })
@@ -32,9 +35,9 @@ test.describe('cloned repository', () => {
         await expect(page.getByRole('heading', { name: 'sourcegraph/sourcegraph' })).toBeVisible()
     })
 
-    test.skip('has search button', async ({ page }) => {
-        await page.getByRole('button', { name: 'Search', exact: true }).click()
-        await expect(page.getByRole('textbox')).toHaveText(String.raw`repo:^github\.com/sourcegraph/sourcegraph$ `)
+    test('has search button', async ({ page }) => {
+        await page.getByRole('button', { name: 'Type / to search', exact: true }).click()
+        await expect(page.getByRole('textbox')).toHaveText(String.raw`repo:^github\.com/sourcegraph/sourcegraph$@1234567 `)
     })
 })
 

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/layout.spec.ts
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/layout.spec.ts
@@ -37,7 +37,9 @@ test.describe('cloned repository', () => {
 
     test('has search button', async ({ page }) => {
         await page.getByRole('button', { name: 'Type / to search', exact: true }).click()
-        await expect(page.getByRole('textbox')).toHaveText(String.raw`repo:^github\.com/sourcegraph/sourcegraph$@1234567 `)
+        await expect(page.getByRole('textbox')).toHaveText(
+            String.raw`repo:^github\.com/sourcegraph/sourcegraph$@1234567 `
+        )
     })
 })
 

--- a/client/web-sveltekit/src/routes/search/page.spec.ts
+++ b/client/web-sveltekit/src/routes/search/page.spec.ts
@@ -99,16 +99,6 @@ test('fills search query from URL', async ({ page }) => {
     await expect(page.getByRole('textbox')).toHaveText('test')
 })
 
-test.skip('main navbar menus are visible above search input', async ({ page, sg }) => {
-    const stream = await sg.mockSearchStream()
-    await page.goto('/search?q=test')
-    await stream.publish(createProgressEvent(), createDoneEvent())
-    await stream.close()
-    await page.getByRole('button', { name: 'Code Search' }).click()
-    await page.getByRole('link', { name: 'Search Home' }).click()
-    await expect(page).toHaveURL(/\/search$/)
-})
-
 test.use({
     permissions: ['clipboard-write', 'clipboard-read'],
 })
@@ -140,12 +130,12 @@ test('copy path button appears and copies path', async ({ page, sg }) => {
 })
 
 test.describe('preview panel', async () => {
-    test.skip('can be opened and closed', async ({ page, sg }) => {
+    test('can be opened and closed', async ({ page, sg }) => {
         const stream = await sg.mockSearchStream()
         await page.goto('/search?q=test')
         await page.getByRole('heading', { name: 'Filter results' }).waitFor()
         sg.mockOperations({
-            BlobPageQuery: () => ({
+            BlobFileViewBlobQuery: () => ({
                 repository: { commit: { blob: { content: chunkMatch.chunkMatches![0].content } } },
             }),
         })
@@ -173,7 +163,7 @@ test.describe('preview panel', async () => {
         await expect(page.getByRole('heading', { name: 'File Preview' })).toBeHidden()
     })
 
-    test.skip('can iterate over matches', async ({ page, sg }) => {
+    test('can iterate over matches', async ({ page, sg }) => {
         const stream = await sg.mockSearchStream()
         await page.goto('/search?q=test')
         await page.getByRole('heading', { name: 'Filter results' }).waitFor()
@@ -188,7 +178,7 @@ test.describe('preview panel', async () => {
         await stream.close()
 
         sg.mockOperations({
-            BlobPageQuery: () => ({
+            BlobFileViewBlobQuery: () => ({
                 repository: { commit: { blob: { content: chunkMatch.chunkMatches![0].content } } },
             }),
         })


### PR DESCRIPTION
Follow up for #62820 to fix failing/skipped tests that are easy to fix (which is all but one).

Re-enabling the syntax highlighting error test should be done in a separate PR.

## Test plan

`pnpm test`
