### PR TITLE
fix/msp/spec: validate against LivenessInterval that is too high

### DIFF
--- a/dev/managedservicesplatform/spec/environment.go
+++ b/dev/managedservicesplatform/spec/environment.go
@@ -524,6 +524,9 @@ func (s *EnvironmentServiceHealthProbesSpec) Validate() []error {
 	if s.GetTimeoutSeconds() > s.GetLivenessIntervalSeconds() {
 		errs = append(errs, errors.New("livenessInterval must be greater than or equal to timeout"))
 	}
+	if s.GetLivenessIntervalSeconds() > 3600 {
+		errs = append(errs, errors.New("livenessInterval must be less than or equal to 3600 seconds"))
+	}
 
 	return errs
 }


### PR DESCRIPTION
Guards against another one of those "only fails at apply time" things (https://github.com/sourcegraph/managed-services/pull/1459)

## Test plan

https://github.com/sourcegraph/managed-services/pull/1459