### PR TITLE
bazel: bump to latest aspect_rules_js, rules_nodejs, aspect_bazel_lib, aspect_rules_ts, aspect_rules_swc

### DIFF
--- a/.aspect/bazelrc/ci.bazelrc
+++ b/.aspect/bazelrc/ci.bazelrc
@@ -1,10 +1,3 @@
-# We recommend enforcing a policy that keeps your CI from being slowed down
-# by individual test targets that should be optimized
-# or split up into multiple test targets with sharding or manually.
-# Set this flag to exclude targets that have their timeout set to eternal (>15m) from running on CI.
-# Docs: https://bazel.build/docs/user-manual#test-timeout-filters
-test --test_timeout_filters=-eternal
-
 # Set this flag to enable re-tries of failed tests on CI.
 # When any test target fails, try one or more times. This applies regardless of whether the "flaky"
 # tag appears on the target definition.

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -28,38 +28,38 @@ bazel_skylib_workspace()
 
 http_archive(
     name = "aspect_bazel_lib",
-    sha256 = "f2c1f91cc0a55f7a44c94b8a79974f21349b844075740c01045acaa49e731307",
-    strip_prefix = "bazel-lib-1.40.3",
-    url = "https://github.com/aspect-build/bazel-lib/releases/download/v1.40.3/bazel-lib-v1.40.3.tar.gz",
+    sha256 = "d0529773764ac61184eb3ad3c687fb835df5bee01afedf07f0cf1a45515c96bc",
+    strip_prefix = "bazel-lib-1.42.3",
+    url = "https://github.com/aspect-build/bazel-lib/releases/download/v1.42.3/bazel-lib-v1.42.3.tar.gz",
 )
 
 # rules_js defines an older rules_nodejs, so we override it here
 http_archive(
     name = "rules_nodejs",
-    sha256 = "162f4adfd719ba42b8a6f16030a20f434dc110c65dc608660ef7b3411c9873f9",
-    strip_prefix = "rules_nodejs-6.0.2",
-    url = "https://github.com/bazelbuild/rules_nodejs/releases/download/v6.0.2/rules_nodejs-v6.0.2.tar.gz",
+    sha256 = "3e8369256ad63197959d2253c473a9dcc57c2841d176190e59b91d25d4fe9e67",
+    strip_prefix = "rules_nodejs-6.1.1",
+    url = "https://github.com/bazelbuild/rules_nodejs/releases/download/v6.1.1/rules_nodejs-v6.1.1.tar.gz",
 )
 
 http_archive(
     name = "aspect_rules_js",
-    sha256 = "76a04ef2120ee00231d85d1ff012ede23963733339ad8db81f590791a031f643",
-    strip_prefix = "rules_js-1.34.1",
-    url = "https://github.com/aspect-build/rules_js/releases/download/v1.34.1/rules_js-v1.34.1.tar.gz",
+    sha256 = "2cfb3875e1231cefd3fada6774f2c0c5a99db0070e0e48ea398acbff7c6c765b",
+    strip_prefix = "rules_js-1.42.3",
+    url = "https://github.com/aspect-build/rules_js/releases/download/v1.42.3/rules_js-v1.42.3.tar.gz",
 )
 
 http_archive(
     name = "aspect_rules_ts",
-    sha256 = "c77f0dfa78c407893806491223c1264c289074feefbf706721743a3556fa7cea",
-    strip_prefix = "rules_ts-2.2.0",
-    url = "https://github.com/aspect-build/rules_ts/releases/download/v2.2.0/rules_ts-v2.2.0.tar.gz",
+    sha256 = "da6620683ab2c28014e9c82e8a8fdbb724cd67f6a1d27317f42a8ceb14048b9b",
+    strip_prefix = "rules_ts-2.4.1",
+    url = "https://github.com/aspect-build/rules_ts/releases/download/v2.4.1/rules_ts-v2.4.1.tar.gz",
 )
 
 http_archive(
     name = "aspect_rules_swc",
-    sha256 = "8eb9e42ed166f20cacedfdb22d8d5b31156352eac190fc3347db55603745a2d8",
-    strip_prefix = "rules_swc-1.1.0",
-    url = "https://github.com/aspect-build/rules_swc/releases/download/v1.1.0/rules_swc-v1.1.0.tar.gz",
+    sha256 = "1908691bde56321423c3f3beaf37f5fc21c51614869572e5f626cea058649373",
+    strip_prefix = "rules_swc-1.2.3",
+    url = "https://github.com/aspect-build/rules_swc/releases/download/v1.2.3/rules_swc-v1.2.3.tar.gz",
 )
 
 http_archive(
@@ -289,10 +289,10 @@ esbuild_register_toolchains(
 
 # Go toolchain setup
 
-load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
 load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies", "go_repository")
-load("//:linter_deps.bzl", "linter_dependencies")
+load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
 load("//:deps.bzl", "go_dependencies")
+load("//:linter_deps.bzl", "linter_dependencies")
 
 go_repository(
     name = "com_github_aws_aws_sdk_go_v2_service_ssooidc",
@@ -451,8 +451,8 @@ rules_proto_dependencies()
 rules_proto_toolchains()
 
 load("@rules_proto_grpc//:repositories.bzl", "rules_proto_grpc_repos", "rules_proto_grpc_toolchains")
-load("@rules_proto_grpc//go:repositories.bzl", rules_proto_grpc_go_repos = "go_repos")
 load("@rules_proto_grpc//doc:repositories.bzl", rules_proto_grpc_doc_repos = "doc_repos")
+load("@rules_proto_grpc//go:repositories.bzl", rules_proto_grpc_go_repos = "go_repos")
 
 rules_proto_grpc_toolchains()
 


### PR DESCRIPTION
The bump in rules_js picks up a fix to prevent the `.../package (No such file or directory)` Bazel flake.

## Test plan

CI
