### PR TITLE
Update blobstore package to remove unused port + ssl properties

### DIFF
--- a/wolfi-packages/s3proxy.yaml
+++ b/wolfi-packages/s3proxy.yaml
@@ -1,13 +1,13 @@
 package:
   name: s3proxy
   version: 2.0.0
-  epoch: 3 # Independent from repo epoch
-  description: "Access other storage backends via the S3 API"
+  epoch: 4 # Independent from repo epoch
+  description: 'Access other storage backends via the S3 API'
   target-architecture:
     - x86_64
   copyright:
     - paths:
-      - "*"
+        - '*'
       attestation: ''
       license: 'Apache License 2.0'
   dependencies:
@@ -33,8 +33,8 @@ pipeline:
   - uses: fetch
     with:
       # Package epoch is independent from repo epoch
-      uri: https://github.com/sourcegraph/s3proxy/archive/refs/tags/s3proxy-${{package.version}}-2.tar.gz
-      expected-sha256: efeda0b7e2d87dbfb053510d706b109f8dcbf83fb7833e9d43b2231a2beaf247
+      uri: https://github.com/sourcegraph/s3proxy/archive/refs/tags/s3proxy-${{package.version}}-3.tar.gz
+      expected-sha256: 21583a5db1483ec89e1da0a2de3b1f9caaa79ce291dd0f7af5b9b1366567c515
       extract: true
   - runs: |
       JAVA_HOME=/usr/lib/jvm/java-11-openjdk/ mvn package -DskipTests


### PR DESCRIPTION
- How was it PREVIOUSLY?
  The blobstore container exposed port with test ssl keys configured
- How it will be from NOW on.
   The blobstore will have just the http port (probably 9000) and we disabled the unused port(ssl)

Blobstore container had unused port open configured with test private keys. After [investigating](https://sourcegraph.slack.com/archives/C02UC4WUX1Q/p1716478617084139) about the unused port, we decided to remove config in the image from upstream `sourcegraph/s3proxy`

<!--

💡 To write a useful PR description, make sure that your description covers:

- WHAT this PR is changing:
    - How was it PREVIOUSLY.
    - How it will be from NOW on.
- WHY this PR is needed.
- CONTEXT, i.e. to which initiative, project or RFC it belongs.

The structure of the description doesn't matter as much as covering these points, so use
your best judgement based on your context.

Learn how to write good pull request description: https://www.notion.so/sourcegraph/Write-a-good-pull-request-description-610a7fd3e613496eb76f450db5a49b6e?pvs=4
-->

## Test plan

- CI 🟢 

Additional testing

```bash
docker exec -u 0 -it blobstore sh
curl -i -X PUT http://127.0.0.1:9000/create-bucket-test-2022-01-09-attempt0
```
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles

Why does it matter?

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers.
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component:
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests"
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs:
  - "previewed locally"
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI"
  - "locally tested"
-->
