### PR TITLE
Pings: Update hardcoded latest release strings

### DIFF
--- a/internal/updatecheck/handler.go
+++ b/internal/updatecheck/handler.go
@@ -32,17 +32,17 @@ var (
 	// non-cluster, non-docker-compose, and non-pure-docker installations what the latest
 	// version is. The version here _must_ be available at https://hub.docker.com/r/sourcegraph/server/tags/
 	// before landing in master.
-	latestReleaseDockerServerImageBuild = newPingResponse("5.3.3")
+	latestReleaseDockerServerImageBuild = newPingResponse("5.4.2198")
 
 	// latestReleaseKubernetesBuild is only used by sourcegraph.com to tell existing Sourcegraph
 	// cluster deployments what the latest version is. The version here _must_ be available in
 	// a tag at https://github.com/sourcegraph/deploy-sourcegraph before landing in master.
-	latestReleaseKubernetesBuild = newPingResponse("5.3.3")
+	latestReleaseKubernetesBuild = newPingResponse("5.4.2198")
 
 	// latestReleaseDockerComposeOrPureDocker is only used by sourcegraph.com to tell existing Sourcegraph
 	// Docker Compose or Pure Docker deployments what the latest version is. The version here _must_ be
 	// available in a tag at https://github.com/sourcegraph/deploy-sourcegraph-docker before landing in master.
-	latestReleaseDockerComposeOrPureDocker = newPingResponse("5.3.3")
+	latestReleaseDockerComposeOrPureDocker = newPingResponse("5.4.2198")
 )
 
 func getLatestRelease(deployType string) pingResponse {


### PR DESCRIPTION
This is a quick fix for `SiteUpdateReadinessCheck` which lets Sourcegraph instances know when a new version of Sourcegraph is released via Pings. Accompanied by change in `deploy-docker` repo to remove `qa-` prefix from those repo tags 

## Test plan
Slight change not tested yet

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles

Why does it matter?

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers.
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component:
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests"
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs:
  - "previewed locally"
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI"
  - "locally tested"
-->
