### PR TITLE
bazel: Add container test for s3proxy

### DIFF
--- a/doc/dev/background-information/bazel/containers.md
+++ b/doc/dev/background-information/bazel/containers.md
@@ -138,6 +138,13 @@ commandTests:
       - -u
     excludedOutput: ["^0"]
     exitCode: 0
+
+  # Each command in the setup section will run in a separate container and then commits a modified image to be the new base image for the test run
+  - name: "fetch and test sg"
+    setup: [["wget", "https://github.com/sourcegraph/sg/releases/download/2024-05-23-19-04-d485d76e/sg_linux_amd64", "-O", "sg"], ["chmod", "+x", "sg"]]
+    command: "./sg"
+    args: ["--help"]
+    expectedOutput: ["The Sourcegraph developer tool"]
 ```
 
 We can now build this image _locally_ and run those tests as well.

--- a/docker-images/blobstore/s3_proxy_image_test.yaml
+++ b/docker-images/blobstore/s3_proxy_image_test.yaml
@@ -9,12 +9,15 @@ commandTests:
     exitCode: 0
   - name: "s3proxy test"
     setup:
+      # Start s3proxy and run in background
       - ["sh", "-c", "/opt/s3proxy/run-docker-container.sh &"]
+      # s3proxy takes several seconds to startup
       - ["sleep", "5"]
     command: "curl"
     args: ["--write-out", "%{http_code}", "-X", "PUT", "http://localhost:9000/create-bucket-test-2022-01-09-attempt0"]
     # args: ["--write-out", "%{http_code}", "--silent", "--output", "/dev/null", "-X", "PUT", "http://localhost:9000/create-bucket-test-2022-01-09-attempt0"]
     teardown:
+      # Terminate s3proxy after curl command completes
       - ["pkill", "java"]
     expectedOutput: ["200"]
 

--- a/docker-images/blobstore/s3_proxy_image_test.yaml
+++ b/docker-images/blobstore/s3_proxy_image_test.yaml
@@ -12,7 +12,7 @@ commandTests:
     command: "sh"
     args: [
       "-c",
-      "/opt/s3proxy/run-docker-container.sh >/dev/null 2>&1 & sleep 5 && curl -X PUT --write-out %{http_code} http://lolhost:9000/create-bucket-test-2022-01-09-attempt0"
+      "/opt/s3proxy/run-docker-container.sh >/dev/null 2>&1 & sleep 5 && curl -X PUT --write-out %{http_code} http://localhost:9000/create-bucket-test-2022-01-09-attempt0"
     ]
     expectedOutput: ["200"]
     exitCode: 0

--- a/docker-images/blobstore/s3_proxy_image_test.yaml
+++ b/docker-images/blobstore/s3_proxy_image_test.yaml
@@ -7,6 +7,16 @@ commandTests:
       - -u
     excludedOutput: ["^0"]
     exitCode: 0
+  - name: "s3proxy test"
+    setup:
+      - ["sh", "-c", "/opt/s3proxy/run-docker-container.sh &"]
+      - ["sleep", "5"]
+    command: "curl"
+    args: ["--write-out", "%{http_code}", "-X", "PUT", "http://localhost:9000/create-bucket-test-2022-01-09-attempt0"]
+    # args: ["--write-out", "%{http_code}", "--silent", "--output", "/dev/null", "-X", "PUT", "http://localhost:9000/create-bucket-test-2022-01-09-attempt0"]
+    teardown:
+      - ["pkill", "java"]
+    expectedOutput: ["200"]
 
 fileExistenceTests:
 - name: 'Test for run-docker-container.sh'

--- a/docker-images/blobstore/s3_proxy_image_test.yaml
+++ b/docker-images/blobstore/s3_proxy_image_test.yaml
@@ -7,19 +7,15 @@ commandTests:
       - -u
     excludedOutput: ["^0"]
     exitCode: 0
+    # This test runs as a single command, as commands run in the setup block are not executed in the same container as the command block
   - name: "s3proxy test"
-    setup:
-      # Start s3proxy and run in background
-      - ["sh", "-c", "/opt/s3proxy/run-docker-container.sh &"]
-      # s3proxy takes several seconds to startup
-      - ["sleep", "5"]
-    command: "curl"
-    args: ["--write-out", "%{http_code}", "-X", "PUT", "http://localhost:9000/create-bucket-test-2022-01-09-attempt0"]
-    # args: ["--write-out", "%{http_code}", "--silent", "--output", "/dev/null", "-X", "PUT", "http://localhost:9000/create-bucket-test-2022-01-09-attempt0"]
-    teardown:
-      # Terminate s3proxy after curl command completes
-      - ["pkill", "java"]
+    command: "sh"
+    args: [
+      "-c",
+      "/opt/s3proxy/run-docker-container.sh >/dev/null 2>&1 & sleep 5 && curl -X PUT --write-out %{http_code} http://lolhost:9000/create-bucket-test-2022-01-09-attempt0"
+    ]
     expectedOutput: ["200"]
+    exitCode: 0
 
 fileExistenceTests:
 - name: 'Test for run-docker-container.sh'


### PR DESCRIPTION
This test checks that the s3proxy service starts as expected, and that we're able to create an example bucket using a curl request. Previously we were running this manually whenever s3proxy was updated.

Also updated the bazel docs to mention a caveat of the setup steps.

## Test plan

- CI
- Running new test locally

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles

Why does it matter?

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers.
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component:
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests"
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs:
  - "previewed locally"
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI"
  - "locally tested"
-->
