### PR TITLE
svelte: Enable 'extended matching' in fuzzy finder

### DIFF
--- a/client/web-sveltekit/src/lib/fuzzyfinder/FuzzyFinder.gql
+++ b/client/web-sveltekit/src/lib/fuzzyfinder/FuzzyFinder.gql
@@ -2,33 +2,34 @@ query FuzzyFinderQuery($query: String!) {
     search(query: $query) {
         results {
             results {
-                ...FuzzyFinderFileMatch
-                ...FuzzyFinderRepository
+                ...FuzzyFinderSearchResult
             }
         }
     }
 }
 
-fragment FuzzyFinderFileMatch on FileMatch {
-    file {
-        path
-        url
-        ...FileIcon_GitBlob
-    }
-    symbols {
-        name
-        kind
-        location {
+fragment FuzzyFinderSearchResult on SearchResult {
+    ... on FileMatch {
+        file {
+            path
             url
+            ...FileIcon_GitBlob
+        }
+        symbols {
+            name
+            kind
+            location {
+                url
+            }
+        }
+        repository {
+            name
+            stars
         }
     }
-    repository {
+
+    ... on Repository {
         name
         stars
     }
-}
-
-fragment FuzzyFinderRepository on Repository {
-    name
-    stars
 }


### PR DESCRIPTION
This commit enables extended matching in fuzzy finder which allows the use of multiple search terms and using special symbols such as ^ and $ to anchor terms.

![2024-05-24_12-43_1](https://github.com/sourcegraph/sourcegraph/assets/179026/dcc9513b-c04a-4cfd-b2a2-f780be91dcad)



I also refactored the code quite a bit to reduce code duplication.

Closes SRCH-133 SRCH-134

## Test plan

Manual testing.
