### PR TITLE
svelte: Fix GraphQL error on contributors page

### DIFF
--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/-/stats/contributors/+page.ts
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/-/stats/contributors/+page.ts
@@ -8,7 +8,7 @@ import { ContributorsPage_ContributorsQuery } from './page.gql'
 const pageSize = 20
 
 export const load: PageLoad = ({ url, params }) => {
-    const afterDate = url.searchParams.get('after') ?? ''
+    const afterDate = url.searchParams.get('after') ?? null
     const { first, last, before, after } = getPaginationParams(url.searchParams, pageSize)
     const client = getGraphQLClient()
     const { repoName } = parseRepoRevision(params.repo)


### PR DESCRIPTION
If no time/date is set we are passing an empty string to the server, which seems to be wrong. Instead we should be passing `null`.

## Test plan

Loading the contributors page doesn't show a GraphQL error anymore.
