### PR TITLE
sg/msp: fix init prompts breaking when encountering whitespace

### DIFF
--- a/dev/sg/internal/std/prompt.go
+++ b/dev/sg/internal/std/prompt.go
@@ -1,7 +1,8 @@
 package std
 
 import (
-	"fmt"
+	"bufio"
+	"os"
 	"strings"
 
 	"github.com/sourcegraph/sourcegraph/lib/output"
@@ -19,38 +20,24 @@ import (
 //	}
 func PromptAndScan(out *Output, prompt string, result *string) (bool, error) {
 	out.Promptf(prompt)
-	n, err := fmt.Scanln(result)
+	reader := bufio.NewReader(os.Stdin)
+	input, err := reader.ReadString('\n')
 	if err != nil {
-		// Ignore newline error and treat it as "no input provided, no error".
-		// There is no exported error type for us to assert, so we have to check
-		// the error string.
-		if err.Error() == "unexpected newline" {
-			return false, nil
-		}
 		return false, err
 	}
-	if n == 0 || strings.TrimSpace(*result) == "" {
-		return false, nil
-	}
-	return true, nil
+	*result = strings.TrimSpace(input)
+	return *result != "", nil
 }
 
 // FancyPromptAndScan is a helper that renders the given fancy prompt into out and scans for the
 // subsequent input up to a newline. The return value indicates if a value was provided at all
 func FancyPromptAndScan(out *Output, prompt output.FancyLine, result *string) (bool, error) {
 	out.FancyPrompt(prompt)
-	n, err := fmt.Scanln(result)
+	reader := bufio.NewReader(os.Stdin)
+	input, err := reader.ReadString('\n')
 	if err != nil {
-		// Ignore newline error and treat it as "no input provided, no error".
-		// There is no exported error type for us to assert, so we have to check
-		// the error string.
-		if err.Error() == "unexpected newline" {
-			return false, nil
-		}
 		return false, err
 	}
-	if n == 0 || strings.TrimSpace(*result) == "" {
-		return false, nil
-	}
-	return true, nil
+	*result = strings.TrimSpace(input)
+	return *result != "", nil
 }


### PR DESCRIPTION
Closes CORE-133

Fixes reading input for `sg msp init` prompts if the input has whitespace
<!--

💡 To write a useful PR description, make sure that your description covers:

- WHAT this PR is changing:
    - How was it PREVIOUSLY.
    - How it will be from NOW on.
- WHY this PR is needed.
- CONTEXT, i.e. to which initiative, project or RFC it belongs.

The structure of the description doesn't matter as much as covering these points, so use
your best judgement based on your context.

Learn how to write good pull request description: https://www.notion.so/sourcegraph/Write-a-good-pull-request-description-610a7fd3e613496eb76f450db5a49b6e?pvs=4
-->

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles

Why does it matter?

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers.
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component:
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests"
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs:
  - "previewed locally"
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI"
  - "locally tested"
-->
locally tested
![image](https://github.com/sourcegraph/sourcegraph/assets/35706755/9e081220-c875-4080-910c-0e79b6a86a75)
