### PR TITLE
svelte: Add link to code-graph page to repo navigation

### DIFF
--- a/client/web-sveltekit/src/routes/[...repo=reporev]/+layout.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/+layout.svelte
@@ -22,23 +22,42 @@
     import type { LayoutData } from './$types'
     import RepoSearchInput from './RepoSearchInput.svelte'
 
+    interface MenuEntry {
+        /**
+         * The (URL) path to the page.
+         */
+        path: string
+        /**
+         * The visible name of the menu entry.
+         */
+        label: string
+        /**
+         * The icon to display next to the title.
+         */
+        icon?: string
+        /**
+         * Who can see this entry.
+         */
+        visibility: 'admin' | 'user'
+    }
+
     export let data: LayoutData
 
     const menuOpen = writable(false)
-    const navEntries: { path: string; icon: string; title: string; user?: boolean }[] = [
-        { path: '', icon: mdiCodeTags, title: 'Code', user: true },
-        { path: '/-/commits', icon: mdiSourceCommit, title: 'Commits', user: true },
-        { path: '/-/branches', icon: mdiSourceBranch, title: 'Branches', user: true },
-        { path: '/-/tags', icon: mdiTag, title: 'Tags', user: true },
-        { path: '/-/stats/contributors', icon: mdiAccount, title: 'Contributors', user: true },
+    const navEntries: MenuEntry[] = [
+        { path: '', icon: mdiCodeTags, label: 'Code', visibility: 'user' },
+        { path: '/-/commits', icon: mdiSourceCommit, label: 'Commits', visibility: 'user' },
+        { path: '/-/branches', icon: mdiSourceBranch, label: 'Branches', visibility: 'user' },
+        { path: '/-/tags', icon: mdiTag, label: 'Tags', visibility: 'user' },
+        { path: '/-/stats/contributors', icon: mdiAccount, label: 'Contributors', visibility: 'user' },
     ]
-    const menuEntries: { path: string; icon: string; title: string; user?: boolean }[] = [
-        { path: '/-/compare', icon: mdiHistory, title: 'Compare', user: true },
-        { path: '/-/own', icon: mdiAccount, title: 'Ownership' },
-        { path: '/-/embeddings', icon: '', title: 'Embeddings' },
-        { path: '/-/code-graph', icon: '', title: 'Code graph data' },
-        { path: '/-/batch-changes', icon: '', title: 'Batch changes' },
-        { path: '/-/settings', icon: mdiCog, title: 'Settings' },
+    const menuEntries: MenuEntry[] = [
+        { path: '/-/compare', icon: mdiHistory, label: 'Compare', visibility: 'user' },
+        { path: '/-/own', icon: mdiAccount, label: 'Ownership', visibility: 'admin' },
+        { path: '/-/embeddings', label: 'Embeddings', visibility: 'admin' },
+        { path: '/-/code-graph', label: 'Code graph data', visibility: 'admin' },
+        { path: '/-/batch-changes', label: 'Batch changes', visibility: 'admin' },
+        { path: '/-/settings', icon: mdiCog, label: 'Settings', visibility: 'admin' },
     ]
 
     let visibleNavEntries = navEntries.length
@@ -65,14 +84,14 @@
 
         <ul use:computeFit on:fit={event => (visibleNavEntries = event.detail.itemCount)}>
             {#each navEntriesToShow as entry}
-                {#if entry.user}
+                {#if entry.visibility === 'user' || (entry.visibility === 'admin' && data.user?.siteAdmin)}
                     {@const href = data.repoURL + entry.path}
                     <li>
                         <a {href} aria-current={isActive(href, $page.url) ? 'page' : undefined}>
                             {#if entry.icon}
                                 <Icon svgPath={entry.icon} inline />
                             {/if}
-                            <span>{entry.title}</span>
+                            <span>{entry.label}</span>
                         </a>
                     </li>
                 {/if}
@@ -88,14 +107,14 @@
                 <Icon svgPath={mdiDotsHorizontal} aria-label="More repo navigation items" />
             </svelte:fragment>
             {#each allMenuEntries as entry}
-                {#if data.user?.siteAdmin || entry.user}
+                {#if entry.visibility === 'user' || (entry.visibility === 'admin' && data.user?.siteAdmin)}
                     {@const href = data.repoURL + entry.path}
                     <MenuLink {href}>
                         <span class="overflow-entry" class:active={isActive(href, $page.url)}>
                             {#if entry.icon}
                                 <Icon svgPath={entry.icon} inline />
                             {/if}
-                            <span>{entry.title}</span>
+                            <span>{entry.label}</span>
                         </span>
                     </MenuLink>
                 {/if}

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/+layout.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/+layout.svelte
@@ -25,17 +25,18 @@
     export let data: LayoutData
 
     const menuOpen = writable(false)
-    const navEntries: { path: string; icon: string; title: string }[] = [
-        { path: '', icon: mdiCodeTags, title: 'Code' },
-        { path: '/-/commits', icon: mdiSourceCommit, title: 'Commits' },
-        { path: '/-/branches', icon: mdiSourceBranch, title: 'Branches' },
-        { path: '/-/tags', icon: mdiTag, title: 'Tags' },
-        { path: '/-/stats/contributors', icon: mdiAccount, title: 'Contributors' },
+    const navEntries: { path: string; icon: string; title: string; user?: boolean }[] = [
+        { path: '', icon: mdiCodeTags, title: 'Code', user: true },
+        { path: '/-/commits', icon: mdiSourceCommit, title: 'Commits', user: true },
+        { path: '/-/branches', icon: mdiSourceBranch, title: 'Branches', user: true },
+        { path: '/-/tags', icon: mdiTag, title: 'Tags', user: true },
+        { path: '/-/stats/contributors', icon: mdiAccount, title: 'Contributors', user: true },
     ]
-    const menuEntries: { path: string; icon: string; title: string }[] = [
-        { path: '/-/compare', icon: mdiHistory, title: 'Compare' },
+    const menuEntries: { path: string; icon: string; title: string; user?: boolean }[] = [
+        { path: '/-/compare', icon: mdiHistory, title: 'Compare', user: true },
         { path: '/-/own', icon: mdiAccount, title: 'Ownership' },
         { path: '/-/embeddings', icon: '', title: 'Embeddings' },
+        { path: '/-/code-graph', icon: '', title: 'Code graph data' },
         { path: '/-/batch-changes', icon: '', title: 'Batch changes' },
         { path: '/-/settings', icon: mdiCog, title: 'Settings' },
     ]
@@ -64,15 +65,17 @@
 
         <ul use:computeFit on:fit={event => (visibleNavEntries = event.detail.itemCount)}>
             {#each navEntriesToShow as entry}
-                {@const href = data.repoURL + entry.path}
-                <li>
-                    <a {href} aria-current={isActive(href, $page.url) ? 'page' : undefined}>
-                        {#if entry.icon}
-                            <Icon svgPath={entry.icon} inline />
-                        {/if}
-                        <span>{entry.title}</span>
-                    </a>
-                </li>
+                {#if entry.user}
+                    {@const href = data.repoURL + entry.path}
+                    <li>
+                        <a {href} aria-current={isActive(href, $page.url) ? 'page' : undefined}>
+                            {#if entry.icon}
+                                <Icon svgPath={entry.icon} inline />
+                            {/if}
+                            <span>{entry.title}</span>
+                        </a>
+                    </li>
+                {/if}
             {/each}
         </ul>
 
@@ -85,15 +88,17 @@
                 <Icon svgPath={mdiDotsHorizontal} aria-label="More repo navigation items" />
             </svelte:fragment>
             {#each allMenuEntries as entry}
-                {@const href = data.repoURL + entry.path}
-                <MenuLink {href}>
-                    <span class="overflow-entry" class:active={isActive(href, $page.url)}>
-                        {#if entry.icon}
-                            <Icon svgPath={entry.icon} inline />
-                        {/if}
-                        <span>{entry.title}</span>
-                    </span>
-                </MenuLink>
+                {#if data.user?.siteAdmin || entry.user}
+                    {@const href = data.repoURL + entry.path}
+                    <MenuLink {href}>
+                        <span class="overflow-entry" class:active={isActive(href, $page.url)}>
+                            {#if entry.icon}
+                                <Icon svgPath={entry.icon} inline />
+                            {/if}
+                            <span>{entry.title}</span>
+                        </span>
+                    </MenuLink>
+                {/if}
             {/each}
         </DropdownMenu>
         <RepoSearchInput repoName={data.repoName} revision={data.displayRevision} />

--- a/client/web-sveltekit/vite.config.ts
+++ b/client/web-sveltekit/vite.config.ts
@@ -52,11 +52,12 @@ export default defineConfig(({ mode }) => {
             proxy: {
                 // Proxy requests to specific endpoints to a real Sourcegraph
                 // instance.
-                '^(/sign-in|/.assets|/-|/.api|/search/stream|/users|/notebooks|/insights)|(/-/raw/)': {
-                    target: process.env.SOURCEGRAPH_API_URL || 'https://sourcegraph.com',
-                    changeOrigin: true,
-                    secure: false,
-                },
+                '^(/sign-in|/.assets|/-|/.api|/search/stream|/users|/notebooks|/insights|/batch-changes)|/-/(raw|compare|own|embeddings|code-graph|batch-changes|settings)(/|$)':
+                    {
+                        target: process.env.SOURCEGRAPH_API_URL || 'https://sourcegraph.com',
+                        changeOrigin: true,
+                        secure: false,
+                    },
             },
         },
 


### PR DESCRIPTION
This adds a link to the repository's code-graph page to the repo navigation.

Additional changes:
- added a flag to each menu item that specifies whether or not show the entry for non-admin users (defaults to `false`)
- updated vite's proxy configuration to properly load React repo pages from the server


| Normal user | Site admin |
|--------|--------|
| ![2024-05-24_14-12](https://github.com/sourcegraph/sourcegraph/assets/179026/e66d4892-0e3a-4765-bd51-a6f116c7e301) | ![2024-05-24_14-12_1](https://github.com/sourcegraph/sourcegraph/assets/179026/c90702a3-c5b1-4144-9b8e-053293f94e2a) | 

## Test plan

Manual testing. The link shows up and redirects to the React code graph page.
