### PR TITLE
svelte: Allow closing the diff and commit view from the history panel

### DIFF
--- a/client/web-sveltekit/src/lib/repo/HistoryPanel.svelte
+++ b/client/web-sveltekit/src/lib/repo/HistoryPanel.svelte
@@ -64,6 +64,7 @@
     }
 
     $: selectedRev = $page.url?.searchParams.get('rev')
+    $: closeURL = SourcegraphURL.from($page.url).deleteSearchParameter('rev', 'diff').toString()
 </script>
 
 <Scroller bind:this={scroller} margin={200} on:more={loadMore}>
@@ -77,7 +78,7 @@
                     </td>
                     <td class="subject">
                         {#if enableInlineDiff}
-                            <a href="?rev={commit.oid}&diff=1">{commit.subject}</a>
+                            <a href={selected ? closeURL : `?rev=${commit.oid}&diff=1`}>{commit.subject}</a>
                         {:else}
                             {commit.subject}
                         {/if}
@@ -89,8 +90,10 @@
                     <td><Timestamp date={new Date(commit.author.date)} strict /></td>
                     {#if enableViewAtCommit}
                         <td>
-                            <Tooltip tooltip="View at commit">
-                                <a href="?rev={commit.oid}"><Icon svgPath={mdiFileDocumentOutline} inline /></a>
+                            <Tooltip tooltip={selected ? 'Close commit' : 'View at commit'}>
+                                <a href={selected ? closeURL : `?rev=${commit.oid}`}
+                                    ><Icon svgPath={mdiFileDocumentOutline} inline /></a
+                                >
                             </Tooltip>
                         </td>
                     {/if}


### PR DESCRIPTION
This updates the history panel entries to allowing closing the diff and commit view by clicking the same link again (i.e. the commit subject or the 'view at commit' button).


## Test plan

Manual testing.
