### PR TITLE
RFC: New icon api

### DIFF
--- a/client/web-sveltekit/package.json
+++ b/client/web-sveltekit/package.json
@@ -30,6 +30,7 @@
     "@graphql-codegen/typescript-operations": "^4.0.1",
     "@graphql-tools/utils": "^10.0.11",
     "@graphql-typed-document-node/core": "^3.2.0",
+    "@iconify-json/lucide": "^1.1.188",
     "@playwright/test": "1.40.1",
     "@storybook/addon-essentials": "^8.0.5",
     "@storybook/addon-svelte-csf": "^4.1.2",
@@ -59,6 +60,7 @@
     "svelte": "^4.1.1",
     "svelte-check": "^3.4.6",
     "tslib": "2.1.0",
+    "unplugin-icons": "^0.19.0",
     "vite": "~5.1.5",
     "vite-plugin-inspect": "^0.7.35",
     "vitest": "^1.3.1"

--- a/client/web-sveltekit/src/app.d.ts
+++ b/client/web-sveltekit/src/app.d.ts
@@ -2,6 +2,8 @@
 // for information about these interfaces
 /// <reference types="@sveltejs/kit" />
 
+import 'unplugin-icons/types/svelte'
+
 declare global {
     namespace App {
         interface PageData {

--- a/client/web-sveltekit/src/lib/Icon2.svelte
+++ b/client/web-sveltekit/src/lib/Icon2.svelte
@@ -1,0 +1,49 @@
+<!--
+    @component
+    Creates an SVG icon. You can overwrite the color by using the --color
+    style directive:
+
+    <Icon svgPath={...} --color="other color" />
+
+    Otherwise the current text color is used.
+-->
+<script lang="ts">
+    import type { ComponentType, SvelteComponent } from 'svelte'
+    import type { SvelteHTMLElements } from 'svelte/elements'
+    import IconClose from 'virtual:icons/lucide/x'
+
+    const icons = {
+        close: IconClose,
+    }
+
+    type $$Props = SvelteHTMLElements['svg'] & {
+        icon: ComponentType<SvelteComponent<SvelteHTMLElements['svg']>> | 'close'
+        inline?: boolean
+    }
+
+    export let icon: ComponentType<SvelteComponent<SvelteHTMLElements['svg']>> | 'close'
+    export let inline: boolean = false
+
+    $: resolvedIcon = typeof icon === 'string' ? icons[icon] : icon
+</script>
+
+<svelte:component this={resolvedIcon} class="icon {inline ? 'icon-inline' : ''}" />
+
+<style lang="scss">
+    $iconSize: var(--icon-size, 1.5rem);
+    $iconInlineSize: var(--icon-inline-size, #{(16 / 14)}em);
+
+    :global(svg.icon) {
+        width: $iconSize;
+        height: $iconSize;
+
+        color: var(--icon-fill-color, var(--color, inherit));
+        fill: currentColor;
+    }
+
+    :global(svg.icon-inline) {
+        width: $iconInlineSize;
+        height: $iconInlineSize;
+        vertical-align: text-bottom;
+    }
+</style>

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/+layout.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/+layout.svelte
@@ -27,8 +27,9 @@
 </script>
 
 <script lang="ts">
-    import { mdiChevronDoubleLeft, mdiChevronDoubleRight, mdiHistory, mdiListBoxOutline, mdiHome } from '@mdi/js'
+    import { mdiChevronDoubleLeft, mdiChevronDoubleRight, mdiHistory, mdiListBoxOutline } from '@mdi/js'
     import { tick } from 'svelte'
+    import IconHome from 'virtual:icons/lucide/home'
 
     import { afterNavigate, goto } from '$app/navigation'
     import { page } from '$app/stores'
@@ -36,6 +37,7 @@
     import { openFuzzyFinder } from '$lib/fuzzyfinder/FuzzyFinderContainer.svelte'
     import { filesHotkey } from '$lib/fuzzyfinder/keys'
     import Icon from '$lib/Icon.svelte'
+    import Icon2 from '$lib/Icon2.svelte'
     import KeyboardShortcut from '$lib/KeyboardShortcut.svelte'
     import LoadingSpinner from '$lib/LoadingSpinner.svelte'
     import { fetchSidebarFileTree } from '$lib/repo/api/tree'
@@ -213,7 +215,7 @@
                         <Button variant="secondary" outline size="sm">
                             <svelte:fragment slot="custom" let:buttonClass>
                                 <a class={buttonClass} href="/{repoName}" on:click={handleGoToRoot}>
-                                    <Icon svgPath={mdiHome} inline />
+                                    <Icon2 icon={IconHome} inline />
                                 </a>
                             </svelte:fragment>
                         </Button>

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/DiffSummaryHeader.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/DiffSummaryHeader.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
-    import { mdiCompareHorizontal } from '@mdi/js'
+    import IconGitCompareArrows from 'virtual:icons/lucide/git-compare-arrows'
 
     import { numberWithCommas } from '$lib/common'
-    import Icon from '$lib/Icon.svelte'
     import DiffSquares from '$lib/repo/DiffSquares.svelte'
     import { Badge } from '$lib/wildcard'
 
@@ -20,7 +19,7 @@
             <a href={commit.canonicalURL}>{commit.abbreviatedOID}</a>
         </Badge>&nbsp;(selected)</span
     >
-    <Icon svgPath={mdiCompareHorizontal} aria-hidden />
+    <IconGitCompareArrows aria-hidden class="icon-inline" />
     <span class="label">
         {#if parent}
             <Badge variant="link">
@@ -48,6 +47,7 @@
     .root {
         flex-shrink: 0;
         display: inline-flex;
+        align-items: center;
         gap: 1rem;
     }
 

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/DiffView.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/DiffView.svelte
@@ -1,9 +1,7 @@
 <script lang="ts">
-    import { mdiClose } from '@mdi/js'
-
     import { page } from '$app/stores'
     import { SourcegraphURL } from '$lib/common'
-    import Icon from '$lib/Icon.svelte'
+    import Icon2 from '$lib/Icon2.svelte'
     import LoadingSpinner from '$lib/LoadingSpinner.svelte'
     import FileDiffHunks from '$lib/repo/FileDiffHunks.svelte'
     import FileHeader from '$lib/repo/FileHeader.svelte'
@@ -30,7 +28,7 @@
     {#if $commit.value}
         <DiffSummaryHeader commit={$commit.value} />
         <a href={SourcegraphURL.from($page.url).deleteSearchParameter('rev', 'diff').toString()}>
-            <Icon svgPath={mdiClose} inline />
+            <Icon2 icon="close" inline aria-hidden />
             <span>Close diff</span>
         </a>
     {/if}

--- a/client/web-sveltekit/src/routes/styles.scss
+++ b/client/web-sveltekit/src/routes/styles.scss
@@ -60,3 +60,24 @@ kbd {
     background-color: var(--color-bg-1);
     box-shadow: inset 0 -2px 0 var(--color-bg-2);
 }
+
+svg {
+    $iconSize: var(--icon-size, 1.5rem);
+    $iconInlineSize: var(--icon-inline-size, #{(16 / 14)}em);
+
+    &.icon {
+        width: $iconSize;
+        height: $iconSize;
+    }
+
+    &.icon-inline {
+        width: $iconInlineSize;
+        height: $iconInlineSize;
+        vertical-align: text-bottom;
+    }
+
+    &.icon,
+    &.icon-inline {
+        color: var(--icon-fill-color, var(--color, inherit));
+    }
+}

--- a/client/web-sveltekit/vite.config.ts
+++ b/client/web-sveltekit/vite.config.ts
@@ -4,6 +4,7 @@ import { sveltekit } from '@sveltejs/kit/vite'
 import { defineConfig, mergeConfig, type UserConfig } from 'vite'
 import inspect from 'vite-plugin-inspect'
 import type { UserConfig as VitestUserConfig } from 'vitest'
+import Icons from 'unplugin-icons/vite'
 
 import graphqlCodegen from './dev/vite-graphql-codegen'
 
@@ -14,6 +15,10 @@ export default defineConfig(({ mode }) => {
     let config: UserConfig & VitestUserConfig = {
         plugins: [
             sveltekit(),
+            Icons({
+                compiler: 'svelte',
+                defaultClass: 'icon',
+            }),
             // Generates typescript types for gql-tags and .gql files
             graphqlCodegen(),
             inspect(),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1609,6 +1609,9 @@ importers:
       '@graphql-typed-document-node/core':
         specifier: ^3.2.0
         version: 3.2.0(graphql@15.4.0)
+      '@iconify-json/lucide':
+        specifier: ^1.1.188
+        version: 1.1.188
       '@playwright/test':
         specifier: 1.40.1
         version: 1.40.1
@@ -1696,6 +1699,9 @@ importers:
       tslib:
         specifier: 2.1.0
         version: 2.1.0
+      unplugin-icons:
+        specifier: ^0.19.0
+        version: 0.19.0
       vite:
         specifier: ~5.1.5
         version: 5.1.5(@types/node@20.8.0)(sass@1.32.4)
@@ -1757,8 +1763,25 @@ packages:
       '@jridgewell/gen-mapping': 0.3.5
       '@jridgewell/trace-mapping': 0.3.25
 
+  /@antfu/install-pkg@0.1.1:
+    resolution: {integrity: sha512-LyB/8+bSfa0DFGC06zpCEfs89/XoWZwws5ygEa5D+Xsm3OfI+aXQ86VgVG7Acyef+rSZ5HE7J8rrxzrQeM3PjQ==}
+    dependencies:
+      execa: 5.1.1
+      find-up: 5.0.0
+    dev: true
+
+  /@antfu/install-pkg@0.3.3:
+    resolution: {integrity: sha512-nHHsk3NXQ6xkCfiRRC8Nfrg8pU5kkr3P3Y9s9dKqiuRmBD0Yap7fymNDjGFKeWhZQHqqbCS5CfeMy9wtExM24w==}
+    dependencies:
+      '@jsdevtools/ez-spawn': 3.0.4
+    dev: true
+
   /@antfu/utils@0.7.5:
     resolution: {integrity: sha512-dlR6LdS+0SzOAPx/TPRhnoi7hE251OVeT2Snw0RguNbBSbjUHdWr0l3vcUUDg26rEysT89kCbtw1lVorBXLLCg==}
+    dev: true
+
+  /@antfu/utils@0.7.8:
+    resolution: {integrity: sha512-rWQkqXRESdjXtc+7NRfK9lASQjpXJu1ayp7qi1d23zZorY+wBHVLHHoVcMsEnkqEBWTFqbztO7/QdJFzyEcLTg==}
     dev: true
 
   /@apidevtools/json-schema-ref-parser@9.0.6:
@@ -5429,6 +5452,30 @@ packages:
     resolution: {integrity: sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==}
     dev: true
 
+  /@iconify-json/lucide@1.1.188:
+    resolution: {integrity: sha512-yJNoU7vX11OvdeSKBiAvmbk/etAq2HPCZQkZX1U687NZhn8dTfx1PfyNhPxtJilrd288XGDKK+NQgygcZ+Ho4g==}
+    dependencies:
+      '@iconify/types': 2.0.0
+    dev: true
+
+  /@iconify/types@2.0.0:
+    resolution: {integrity: sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==}
+    dev: true
+
+  /@iconify/utils@2.1.23:
+    resolution: {integrity: sha512-YGNbHKM5tyDvdWZ92y2mIkrfvm5Fvhe6WJSkWu7vvOFhMtYDP0casZpoRz0XEHZCrYsR4stdGT3cZ52yp5qZdQ==}
+    dependencies:
+      '@antfu/install-pkg': 0.1.1
+      '@antfu/utils': 0.7.8
+      '@iconify/types': 2.0.0
+      debug: 4.3.4
+      kolorist: 1.8.0
+      local-pkg: 0.5.0
+      mlly: 1.7.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@internationalized/date@3.5.1:
     resolution: {integrity: sha512-LUQIfwU9e+Fmutc/DpRTGXSdgYZLBegi4wygCWDSVmUdLTaMHsQyASDiJtREwanwKuQLq0hY76fCJ9J/9I2xOQ==}
     dependencies:
@@ -5612,6 +5659,16 @@ packages:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.4.15
+
+  /@jsdevtools/ez-spawn@3.0.4:
+    resolution: {integrity: sha512-f5DRIOZf7wxogefH03RjMPMdBF7ADTWUMoOs9kaJo06EfwF+aFhMZMDZxHg/Xe12hptN9xoZjGso2fdjapBRIA==}
+    engines: {node: '>=10'}
+    dependencies:
+      call-me-maybe: 1.0.1
+      cross-spawn: 7.0.3
+      string-argv: 0.3.2
+      type-detect: 4.0.8
+    dev: true
 
   /@jsdevtools/ono@7.1.3:
     resolution: {integrity: sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==}
@@ -14050,6 +14107,10 @@ packages:
       yargs: 17.7.2
     dev: true
 
+  /confbox@0.1.7:
+    resolution: {integrity: sha512-uJcB/FKZtBMCJpK8MQji6bJHgu1tixKPxRLeGkNzBoOZzpnZUJm0jm2/sBDWcuBx1dYgxV4JU+g5hmNxCyAmdA==}
+    dev: true
+
   /connect-history-api-fallback@1.6.0:
     resolution: {integrity: sha512-e54B99q/OUoH64zYYRf3HBP5z24G38h5D3qXu23JGRoigpX5Ss4r9ZnDk3g0Z8uQC2x2lPaJ+UlWBc1ZWBWdLg==}
     engines: {node: '>=0.8'}
@@ -19304,6 +19365,10 @@ packages:
     resolution: {integrity: sha512-RTSoaUAfLvpR357vWzAz/50Q/BmHfmE6ETSWfutT0AJiw10e6CmcdYRQJlLRd95B53D0Y2aD1jSxD3V3ySF+PA==}
     dev: true
 
+  /kolorist@1.8.0:
+    resolution: {integrity: sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ==}
+    dev: true
+
   /konva@9.3.6:
     resolution: {integrity: sha512-dqR8EbcM0hjuilZCBP6xauQ5V3kH3m9kBcsDkqPypQuRgsXbcXUrxqYxhNbdvKZpYNW8Amq94jAD/C0NY3qfBQ==}
     dev: false
@@ -20615,6 +20680,15 @@ packages:
       pkg-types: 1.0.3
       ufo: 1.3.2
 
+  /mlly@1.7.0:
+    resolution: {integrity: sha512-U9SDaXGEREBYQgfejV97coK0UL1r+qnF2SyO9A3qcI8MzKnsIFKHNVEkrDyNncQTKQQumsasmeq84eNMdBfsNQ==}
+    dependencies:
+      acorn: 8.11.3
+      pathe: 1.1.2
+      pkg-types: 1.1.1
+      ufo: 1.5.3
+    dev: true
+
   /mocha@8.3.2:
     resolution: {integrity: sha512-UdmISwr/5w+uXLPKspgoV7/RXZwKRTiTjJ2/AC5ZiEztIoOYdfKb19+9jNmEInzx5pBsCyJQzarAxqIGBNYJhg==}
     engines: {node: '>= 10.12.0'}
@@ -21797,6 +21871,14 @@ packages:
       jsonc-parser: 3.2.0
       mlly: 1.5.0
       pathe: 1.1.2
+
+  /pkg-types@1.1.1:
+    resolution: {integrity: sha512-ko14TjmDuQJ14zsotODv7dBlwxKhUKQEhuhmbqo1uCi9BB0Z2alo/wAXg6q1dTR5TyuqYyWhjtfe/Tsh+X28jQ==}
+    dependencies:
+      confbox: 0.1.7
+      mlly: 1.7.0
+      pathe: 1.1.2
+    dev: true
 
   /playwright-core@1.40.1:
     resolution: {integrity: sha512-+hkOycxPiV534c4HhpfX6yrlawqVUzITRKwHAmYfmsVreltEl6fAZJ3DPfLMOODw0H3s1Itd6MDCWmP1fl/QvQ==}
@@ -24296,6 +24378,11 @@ packages:
     resolution: {integrity: sha512-12KWeb+wixJohmnwNFerbyiBrAlq5qJLwIt38etRtKtmmHyDSoGlIqFE9wx+4IwG0aDjI7GV8tc8ZccjWZZtTg==}
     dev: true
 
+  /string-argv@0.3.2:
+    resolution: {integrity: sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==}
+    engines: {node: '>=0.6.19'}
+    dev: true
+
   /string-env-interpolation@1.0.1:
     resolution: {integrity: sha512-78lwMoCcn0nNu8LszbP1UA7g55OeE4v7rCeWnM5B453rnNr4aq+5it3FEYtZrSEiMvHZOZ9Jlqb0OD0M2VInqg==}
     dev: true
@@ -25464,6 +25551,10 @@ packages:
   /ufo@1.3.2:
     resolution: {integrity: sha512-o+ORpgGwaYQXgqGDwd+hkS4PuZ3QnmqMMxRuajK/a38L6fTpcE5GPIfrf+L/KemFzfUpeUQc1rRS1iDBozvnFA==}
 
+  /ufo@1.5.3:
+    resolution: {integrity: sha512-Y7HYmWaFwPUmkoQCUIAYpKqkOf+SbVj/2fJJZ4RJMCfZp0rTGwRbzQD+HghfnhKOjL9E01okqz+ncJskGYfBNw==}
+    dev: true
+
   /uglify-js@3.17.4:
     resolution: {integrity: sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==}
     engines: {node: '>=0.8.0'}
@@ -25626,6 +25717,37 @@ packages:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
 
+  /unplugin-icons@0.19.0:
+    resolution: {integrity: sha512-u5g/gIZPZEj1wUGEQxe9nzftOSqmblhusc+sL3cawIRoIt/xWpE6XYcPOfAeFTYNjSbRrX/3QiX89PFiazgU1w==}
+    peerDependencies:
+      '@svgr/core': '>=7.0.0'
+      '@svgx/core': ^1.0.1
+      '@vue/compiler-sfc': ^3.0.2 || ^2.7.0
+      vue-template-compiler: ^2.6.12
+      vue-template-es2015-compiler: ^1.9.0
+    peerDependenciesMeta:
+      '@svgr/core':
+        optional: true
+      '@svgx/core':
+        optional: true
+      '@vue/compiler-sfc':
+        optional: true
+      vue-template-compiler:
+        optional: true
+      vue-template-es2015-compiler:
+        optional: true
+    dependencies:
+      '@antfu/install-pkg': 0.3.3
+      '@antfu/utils': 0.7.8
+      '@iconify/utils': 2.1.23
+      debug: 4.3.4
+      kolorist: 1.8.0
+      local-pkg: 0.5.0
+      unplugin: 1.10.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /unplugin@1.0.1:
     resolution: {integrity: sha512-aqrHaVBWW1JVKBHmGo33T5TxeL0qWzfvjWokObHA9bYmN7eNDkwOxmLjhioHl9878qDFMAaT51XNroRyuz7WxA==}
     dependencies:
@@ -25637,6 +25759,16 @@ packages:
 
   /unplugin@1.10.0:
     resolution: {integrity: sha512-CuZtvvO8ua2Wl+9q2jEaqH6m3DoQ38N7pvBYQbbaeNlWGvK2l6GHiKi29aIHDPoSxdUzQ7Unevf1/ugil5X6Pg==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      acorn: 8.11.3
+      chokidar: 3.6.0
+      webpack-sources: 3.2.3
+      webpack-virtual-modules: 0.6.1
+    dev: true
+
+  /unplugin@1.10.1:
+    resolution: {integrity: sha512-d6Mhq8RJeGA8UfKCu54Um4lFA0eSaRa3XxdAJg8tIdxbu1ubW0hBCZUL7yI2uGyYCRndvbK8FLHzqy2XKfeMsg==}
     engines: {node: '>=14.0.0'}
     dependencies:
       acorn: 8.11.3


### PR DESCRIPTION
This PR adds the ability to use Lucide icons. Because those icons work differently (you import an SVG element/component, not a text string), we also have to decide how we want to use these icons. Here are three proposals:

### 1) Import and use icon directly as component

```js
import TheIcon from '~icons/lucide/icon'
// or import TheIcon from 'lucide-icons/icons/icon
// or import {TheIcon} from 'lucide-icons'


<TheIcon aria-hidden class="icon-inline" />
```

Pro:
- Only loads the icons that are used

Cons:
- cannot provide "nice" api for icons and needs global CSS for additional styling
- no autocompletion for the first way to import icons

### 2) Import icon and pass to icon component

```js
import TheIcon from '~icons/lucide/icon'
// or import {TheIcon} from 'lucide-icons'
// or import TheIcon from 'lucide-icons/icons/icon

<Icon icon={TheIcon} aria-hidden inline />
```

Pro:
- only loads the icons that are used
- we can have a nicer API for displaying icons (no global CSS needed)

Cons:
- no autocompletion for the first way to import icons

### 3) Specify icon via string

```js
<Icon icon="theicon" aria-hidden inline />
```

where `Icon` defines a map like

```js
import TheIcon from '~icons/lucide/icon'

const icons = {
    theicon: TheIcon
}
```

Pros:
- we abstract from the concrete icon library/set that is used
- we can have a nicer API for displaying icons (no global CSS needed)
- get autocompleteion for icons if the `icon` property is defined accordingly

Cons:
- we possibly import lots of icons that are not currently used for the page


Approach (2) and (3) can also be combined and maybe we only provide string names for icons that are used in multiple places in the app. Then we have all the pros and lessen the cons.

## Test plan

Manual testing.
