### PR TITLE
s3proxy: Fix permissions on s3proxy package binary

### DIFF
--- a/wolfi-packages/s3proxy.yaml
+++ b/wolfi-packages/s3proxy.yaml
@@ -1,7 +1,7 @@
 package:
   name: s3proxy
   version: 2.0.0
-  epoch: 4 # Independent from repo epoch
+  epoch: 5 # Independent from repo epoch
   description: 'Access other storage backends via the S3 API'
   target-architecture:
     - x86_64
@@ -40,5 +40,6 @@ pipeline:
       JAVA_HOME=/usr/lib/jvm/java-11-openjdk/ mvn package -DskipTests
   - runs: |
       mkdir -p ${{targets.destdir}}/opt/
+      chmod 755 target/s3proxy
       cp -r target/ ${{targets.destdir}}/opt/s3proxy
       cp src/main/resources/run-docker-container.sh ${{targets.destdir}}/opt/s3proxy


### PR DESCRIPTION
In our updated s3proxy package, the s3proxy binary had permissions 711 which prevented it from being run. Updated the package config to chmod it to 755.

<!--

💡 To write a useful PR description, make sure that your description covers:

- WHAT this PR is changing:
    - How was it PREVIOUSLY.
    - How it will be from NOW on.
- WHY this PR is needed.
- CONTEXT, i.e. to which initiative, project or RFC it belongs.

The structure of the description doesn't matter as much as covering these points, so use
your best judgement based on your context.

Learn how to write good pull request description: https://www.notion.so/sourcegraph/Write-a-good-pull-request-description-610a7fd3e613496eb76f450db5a49b6e?pvs=4
-->

## Test plan

- Tested locally
- CI

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles

Why does it matter?

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers.
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component:
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests"
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs:
  - "previewed locally"
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI"
  - "locally tested"
-->
