### PR TITLE
privateApp to set `first_source_url` contact property on HubSpot

### DIFF
--- a/cmd/frontend/hubspot/contacts.go
+++ b/cmd/frontend/hubspot/contacts.go
@@ -42,6 +42,12 @@ type ContactProperties struct {
 	HasAgreedToToS               bool   `json:"has_agreed_to_tos_and_pp"`
 	VSCodyInstalledEmailsEnabled bool   `json:"vs_cody_installed_emails_enabled"`
 
+	// The URL of the first page a user landed on their first session on a Sourcegraph site.
+	// The cookie name for tracking the last visited URL within the current session has been updated to 'first_page_seen_url',
+	// however, in the HubSpot integration, we are still using the legacy HubSpot contact property 'first_source_url'
+	// for backward compatibility with existing HubSpot configurations and workflows.
+	FirstSourceURL string `json:"first_source_url"`
+
 	// The URL of the last page the user saw across multiple cookie duration sessions.
 	// Same logic as 'LastsourceUrl' property but storing values across various cookie duration sessions.
 	LastPageSeenShort string `json:"last_page_seen_short"`
@@ -180,6 +186,12 @@ func newAPIValues(h *ContactProperties) *apiProperties {
 	apiProps.set("gclid", h.GoogleClickID)
 	apiProps.set("msclkid", h.MicrosoftClickID)
 	return apiProps
+}
+
+func firstTimeUserValues(h *ContactProperties) *apiProperties {
+	firstTimeUserProps := &apiProperties{}
+	firstTimeUserProps.set("first_source_url", h.FirstSourceURL)
+	return firstTimeUserProps
 }
 
 // apiProperties represents a list of HubSpot API-compliant key-value pairs

--- a/cmd/frontend/hubspot/contacts.go
+++ b/cmd/frontend/hubspot/contacts.go
@@ -153,6 +153,7 @@ func newAPIValues(h *ContactProperties) *apiProperties {
 	apiProps.set("anonymous_user_id", h.AnonymousUserID)
 	apiProps.set("database_id", h.DatabaseID)
 	apiProps.set("has_agreed_to_tos_and_pp", h.HasAgreedToToS)
+	apiProps.set("first_source_url", h.FirstSourceURL)
 	apiProps.set("last_source_url", h.LastSourceURL)
 	apiProps.set("last_page_seen_url_short", h.LastPageSeenShort)
 	apiProps.set("last_page_seen_url_mid", h.LastPageSeenMid)
@@ -186,12 +187,6 @@ func newAPIValues(h *ContactProperties) *apiProperties {
 	apiProps.set("gclid", h.GoogleClickID)
 	apiProps.set("msclkid", h.MicrosoftClickID)
 	return apiProps
-}
-
-func firstTimeUserValues(h *ContactProperties) *apiProperties {
-	firstTimeUserProps := &apiProperties{}
-	firstTimeUserProps.set("first_source_url", h.FirstSourceURL)
-	return firstTimeUserProps
 }
 
 // apiProperties represents a list of HubSpot API-compliant key-value pairs

--- a/cmd/frontend/internal/app/ui/handlers.go
+++ b/cmd/frontend/internal/app/ui/handlers.go
@@ -588,6 +588,7 @@ func servePingFromSelfHosted(w http.ResponseWriter, r *http.Request) error {
 	hubspotutil.SyncUser(email, hubspotutil.SelfHostedSiteInitEventID, &hubspot.ContactProperties{
 		IsServerAdmin:              true,
 		AnonymousUserID:            anonymousUserId,
+		FirstSourceURL:             getCookie("first_page_seen_url"),
 		LastSourceURL:              getCookie("last_page_seen_url"),
 		LastPageSeenShort:          getCookie("last_page_seen_url_short"),
 		LastPageSeenMid:            getCookie("last_page_seen_url_mid"),

--- a/cmd/frontend/internal/auth/oauth/session.go
+++ b/cmd/frontend/internal/auth/oauth/session.go
@@ -103,6 +103,7 @@ func SessionIssuer(logger log.Logger, db database.DB, s SessionIssuerHelper, ses
 		anonymousId, _ := cookie.AnonymousUID(r)
 		newUserCreated, actr, safeErrMsg, err := s.GetOrCreateUser(ctx, token, &hubspot.ContactProperties{
 			AnonymousUserID:            anonymousId,
+			FirstSourceURL:             getCookie("first_page_seen_url"),
 			LastSourceURL:              getCookie("last_page_seen_url"),
 			LastPageSeenShort:          getCookie("last_page_seen_short"),
 			LastPageSeenMid:            getCookie("last_page_seen_mid"),

--- a/cmd/frontend/internal/auth/openidconnect/middleware.go
+++ b/cmd/frontend/internal/auth/openidconnect/middleware.go
@@ -387,6 +387,7 @@ func AuthCallback(logger log.Logger, db database.DB, r *http.Request, usernamePr
 
 	newUserCreated, actor, safeErrMsg, err := getOrCreateUser(ctx, logger, db, p, oauth2Token, idToken, userInfo, &claims, usernamePrefix, userCreateEventProperties, &hubspot.ContactProperties{
 		AnonymousUserID:            anonymousId,
+		FirstSourceURL:             getCookie("first_page_seen_url"),
 		LastSourceURL:              getCookie("last_page_seen_url"),
 		LastPageSeenShort:          getCookie("last_page_seen_short"),
 		LastPageSeenMid:            getCookie("last_page_seen_mid"),

--- a/cmd/frontend/internal/auth/openidconnect/user_test.go
+++ b/cmd/frontend/internal/auth/openidconnect/user_test.go
@@ -94,6 +94,7 @@ func TestAllowSignup(t *testing.T) {
 
 				&hubspot.ContactProperties{
 					AnonymousUserID:            "anonymous-user-id-123",
+					FirstSourceURL:             "https://example.com/",
 					LastSourceURL:              "https://example.com/",
 					LastPageSeenShort:          "https://example.com/",
 					LastPageSeenMid:            "https://example.com/",

--- a/internal/auth/userpasswd/handlers.go
+++ b/internal/auth/userpasswd/handlers.go
@@ -146,6 +146,7 @@ func handleSignUp(logger log.Logger, db database.DB, eventRecorder *telemetry.Ev
 		go hubspotutil.SyncUser(creds.Email, hubspotutil.SignupEventID, &hubspot.ContactProperties{
 			DatabaseID:                 usr.ID,
 			AnonymousUserID:            creds.AnonymousUserID,
+			FirstSourceURL:             creds.FirstSourceURL,
 			LastSourceURL:              creds.LastSourceURL,
 			LastPageSeenShort:          getCookie("last_page_seen_short"),
 			LastPageSeenMid:            getCookie("last_page_seen_mid"),


### PR DESCRIPTION
Based on conversations with the marketing team, they would like the PrivateApp to update `first_source_url` contact property with the cookie `first_page_seen_url` on login/sign up flows. Since `last_page_seen_url` is updated every time seomeone goes to a new page, the `first_source_url` is not actually a source of truth using the backfill method they had planned to use. It becomes whatever page they were just on, not the first page they landed on.

Full thread [here](https://sourcegraph.slack.com/archives/C0678ATBXCG/p1716586196562439)

<!--

💡 To write a useful PR description, make sure that your description covers:

- WHAT this PR is changing:
    - How was it PREVIOUSLY.
    - How it will be from NOW on.
- WHY this PR is needed.
- CONTEXT, i.e. to which initiative, project or RFC it belongs.

The structure of the description doesn't matter as much as covering these points, so use
your best judgement based on your context.

Learn how to write good pull request description: https://www.notion.so/sourcegraph/Write-a-good-pull-request-description-610a7fd3e613496eb76f450db5a49b6e?pvs=4
-->

## Test plan
simple change, test via CI
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles

Why does it matter?

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers.
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component:
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests"
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs:
  - "previewed locally"
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI"
  - "locally tested"
-->
