### PR TITLE
chore: Bump Rust version 1.73.0 -> 1.78.0

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -10,7 +10,7 @@ trivy 0.47.0
 kustomize 4.5.7
 awscli 2.4.7
 python 3.11.3 system
-rust 1.73.0
+rust 1.78.0
 ruby 3.1.3
 pnpm 8.9.2
 python 3.11.3

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -355,7 +355,7 @@ load("@rules_rust//rust:repositories.bzl", "rules_rust_dependencies", "rust_regi
 
 rules_rust_dependencies()
 
-rust_version = "1.73.0"
+rust_version = "1.78.0"
 
 rust_register_toolchains(
     edition = "2021",

--- a/docker-images/syntax-highlighter/Cargo.Bazel.lock
+++ b/docker-images/syntax-highlighter/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "d3f5c825139d9654d3455b2cbfb5eb0b964cbcd185b6624f3bd0d918f8d2067c",
+  "checksum": "296b539d4c595a40878a6f2db34cde2485d34792507243386f1f540fee4ab337",
   "crates": {
     "addr2line 0.20.0": {
       "name": "addr2line",

--- a/docker-images/syntax-highlighter/crates/syntax-analysis/src/highlighting.rs
+++ b/docker-images/syntax-highlighter/crates/syntax-analysis/src/highlighting.rs
@@ -119,7 +119,7 @@ impl<'a> FileInfo<'a> {
             prefix_langs: Vec<(&'static str, &'static str)>,
             default: &'static str,
         }
-        let overrides = vec![
+        let overrides = [
             Override {
                 extension: "cls",
                 prefix_langs: vec![("%", "TeX"), ("\\", "TeX")],

--- a/docker-images/syntax-highlighter/crates/syntax-analysis/src/highlighting/syntect_scip.rs
+++ b/docker-images/syntax-highlighter/crates/syntax-analysis/src/highlighting/syntect_scip.rs
@@ -610,12 +610,13 @@ mod test {
             // As far as I can tell, there is no "matches_snapshot" or similar for `insta`.
             // So we'll just catch the panic for now, push the results and then panic at the end
             // with all the failed files (if applicable)
-            match std::panic::catch_unwind(|| {
+            let panic_or_value = std::panic::catch_unwind(|| {
                 insta::assert_snapshot!(
                     filepath.strip_prefix(&input_dir).unwrap().to_str().unwrap(),
                     snapshot_sciptect_documents(&document, &contents)
                 );
-            }) {
+            });
+            match panic_or_value {
                 Ok(_) => {}
                 Err(_) => failed.push(entry),
             }

--- a/docker-images/syntax-highlighter/crates/syntax-analysis/src/highlighting/tree_sitter.rs
+++ b/docker-images/syntax-highlighter/crates/syntax-analysis/src/highlighting/tree_sitter.rs
@@ -544,12 +544,13 @@ SELECT * FROM my_table
             let document = language.highlight_document(&contents, true).unwrap();
             // TODO: I'm not sure if there's a better way to run the snapshots without
             // panicing and then catching, but this will do for now.
-            match std::panic::catch_unwind(|| {
+            let panic_or_value = std::panic::catch_unwind(|| {
                 insta::assert_snapshot!(
                     filepath.strip_prefix(&input_dir).unwrap().to_str().unwrap(),
                     snapshot_treesitter_syntax_kinds(&document, &contents)
                 );
-            }) {
+            });
+            match panic_or_value {
                 Ok(_) => println!("{}: OK", filepath.to_str().unwrap()),
                 Err(err) => failed_tests.push(err),
             }
@@ -592,12 +593,13 @@ SELECT * FROM my_table
 
             // TODO: I'm not sure if there's a better way to run the snapshots without
             // panicing and then catching, but this will do for now.
-            match std::panic::catch_unwind(|| {
+            let panic_or_value = std::panic::catch_unwind(|| {
                 insta::assert_snapshot!(
                     filepath.strip_prefix(&input_dir).unwrap().to_str().unwrap(),
                     snapshot_treesitter_syntax_and_symbols(&document, &contents)
                 );
-            }) {
+            });
+            match panic_or_value {
                 Ok(_) => println!("{}: OK", filepath.to_str().unwrap()),
                 Err(err) => failed_tests.push(err),
             }

--- a/docker-images/syntax-highlighter/rust-toolchain.toml
+++ b/docker-images/syntax-highlighter/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.73.0"
+channel = "1.78.0"
 # Keep in sync with /WORKSPACE


### PR DESCRIPTION
We're several months out of date.

## Test plan

Covered by existing tests