### PR TITLE
Auto-update package lockfiles for Sourcegraph base images

### DIFF
--- a/wolfi-images/batcheshelper.lock.json
+++ b/wolfi-images/batcheshelper.lock.json
@@ -204,41 +204,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q10Rr8mXMuAm4i4SjxE7xhsgs2UME=",
+        "checksum": "Q1gTZGkWP+QO3mUqLVJth8vrDEzzU=",
         "control": {
-          "checksum": "sha1-0Rr8mXMuAm4i4SjxE7xhsgs2UME=",
-          "range": "bytes=699-1079"
+          "checksum": "sha1-gTZGkWP+QO3mUqLVJth8vrDEzzU=",
+          "range": "bytes=699-1076"
         },
         "data": {
-          "checksum": "sha256-IVV0PRiJiwz4Ov1pWU1VAHf8cM0TgwqsV3vkYEQc0mM=",
-          "range": "bytes=1080-5915633"
+          "checksum": "sha256-/IFXqeKvU0GODNsz1yPIEMcFHgABT+8rbZpSlTLo4e4=",
+          "range": "bytes=1077-5915704"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-OlnuKCVUD1RpZgK+JyGdG/NQ0R0=",
+          "checksum": "sha1-l1o5ixkyWWqqJE3FOfR0QUemJUA=",
           "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r7.apk",
-        "version": "3.3.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r9.apk",
+        "version": "3.3.0-r9"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1xZQl4rSEEOs59w1q/EhMx0+ZVxw=",
+        "checksum": "Q1jhAhggAuZnU7FFHnebGA26mq+jI=",
         "control": {
-          "checksum": "sha1-xZQl4rSEEOs59w1q/EhMx0+ZVxw=",
-          "range": "bytes=697-1082"
+          "checksum": "sha1-jhAhggAuZnU7FFHnebGA26mq+jI=",
+          "range": "bytes=695-1079"
         },
         "data": {
-          "checksum": "sha256-IfGWsH9qFzzKcdVENdnoZqPbAdejcokLcfm7Z53KnPM=",
-          "range": "bytes=1083-1197082"
+          "checksum": "sha256-XTCQYnhGSm7SkGwqV/TQMFqGajVJVYhKAidKfLb2D3Y=",
+          "range": "bytes=1080-1197081"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-CypiuHQ6EuduQ5uexXhBDv5YvvY=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-qVrfDVxubkrb5Yrd2mFTv2A0G7k=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r7.apk",
-        "version": "3.3.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r9.apk",
+        "version": "3.3.0-r9"
       },
       {
         "architecture": "x86_64",
@@ -755,22 +755,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1eaot0B2H9IOF054RKMabXG37GUk=",
+        "checksum": "Q111Aq+tDFOygcfZzOg1hQbtZw1Q4=",
         "control": {
-          "checksum": "sha1-eaot0B2H9IOF054RKMabXG37GUk=",
-          "range": "bytes=700-1143"
+          "checksum": "sha1-11Aq+tDFOygcfZzOg1hQbtZw1Q4=",
+          "range": "bytes=697-1140"
         },
         "data": {
-          "checksum": "sha256-EeuQkVe5Hl+bqWfkBaMgA1Z2Fh91f1upncBbArJu9Gw=",
-          "range": "bytes=1144-17267929"
+          "checksum": "sha256-ednk20seorMQ+xEGnt8zWpxO20xrfj7zOtAmk+XcTbA=",
+          "range": "bytes=1141-17250210"
         },
         "name": "git",
         "signature": {
-          "checksum": "sha1-yMhNFUJ+emT/s9tdLDQ8zjT2+vY=",
-          "range": "bytes=0-699"
+          "checksum": "sha1-T1C3/QmQvuJGLjPH2YyOLIM5ewE=",
+          "range": "bytes=0-696"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/git-2.45.1-r0.apk",
-        "version": "2.45.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/git-2.45.2-r0.apk",
+        "version": "2.45.2-r0"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/blobstore.lock.json
+++ b/wolfi-images/blobstore.lock.json
@@ -204,41 +204,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q10Rr8mXMuAm4i4SjxE7xhsgs2UME=",
+        "checksum": "Q1gTZGkWP+QO3mUqLVJth8vrDEzzU=",
         "control": {
-          "checksum": "sha1-0Rr8mXMuAm4i4SjxE7xhsgs2UME=",
-          "range": "bytes=699-1079"
+          "checksum": "sha1-gTZGkWP+QO3mUqLVJth8vrDEzzU=",
+          "range": "bytes=699-1076"
         },
         "data": {
-          "checksum": "sha256-IVV0PRiJiwz4Ov1pWU1VAHf8cM0TgwqsV3vkYEQc0mM=",
-          "range": "bytes=1080-5915633"
+          "checksum": "sha256-/IFXqeKvU0GODNsz1yPIEMcFHgABT+8rbZpSlTLo4e4=",
+          "range": "bytes=1077-5915704"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-OlnuKCVUD1RpZgK+JyGdG/NQ0R0=",
+          "checksum": "sha1-l1o5ixkyWWqqJE3FOfR0QUemJUA=",
           "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r7.apk",
-        "version": "3.3.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r9.apk",
+        "version": "3.3.0-r9"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1xZQl4rSEEOs59w1q/EhMx0+ZVxw=",
+        "checksum": "Q1jhAhggAuZnU7FFHnebGA26mq+jI=",
         "control": {
-          "checksum": "sha1-xZQl4rSEEOs59w1q/EhMx0+ZVxw=",
-          "range": "bytes=697-1082"
+          "checksum": "sha1-jhAhggAuZnU7FFHnebGA26mq+jI=",
+          "range": "bytes=695-1079"
         },
         "data": {
-          "checksum": "sha256-IfGWsH9qFzzKcdVENdnoZqPbAdejcokLcfm7Z53KnPM=",
-          "range": "bytes=1083-1197082"
+          "checksum": "sha256-XTCQYnhGSm7SkGwqV/TQMFqGajVJVYhKAidKfLb2D3Y=",
+          "range": "bytes=1080-1197081"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-CypiuHQ6EuduQ5uexXhBDv5YvvY=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-qVrfDVxubkrb5Yrd2mFTv2A0G7k=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r7.apk",
-        "version": "3.3.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r9.apk",
+        "version": "3.3.0-r9"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/bundled-executor.lock.json
+++ b/wolfi-images/bundled-executor.lock.json
@@ -204,41 +204,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q10Rr8mXMuAm4i4SjxE7xhsgs2UME=",
+        "checksum": "Q1gTZGkWP+QO3mUqLVJth8vrDEzzU=",
         "control": {
-          "checksum": "sha1-0Rr8mXMuAm4i4SjxE7xhsgs2UME=",
-          "range": "bytes=699-1079"
+          "checksum": "sha1-gTZGkWP+QO3mUqLVJth8vrDEzzU=",
+          "range": "bytes=699-1076"
         },
         "data": {
-          "checksum": "sha256-IVV0PRiJiwz4Ov1pWU1VAHf8cM0TgwqsV3vkYEQc0mM=",
-          "range": "bytes=1080-5915633"
+          "checksum": "sha256-/IFXqeKvU0GODNsz1yPIEMcFHgABT+8rbZpSlTLo4e4=",
+          "range": "bytes=1077-5915704"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-OlnuKCVUD1RpZgK+JyGdG/NQ0R0=",
+          "checksum": "sha1-l1o5ixkyWWqqJE3FOfR0QUemJUA=",
           "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r7.apk",
-        "version": "3.3.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r9.apk",
+        "version": "3.3.0-r9"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1xZQl4rSEEOs59w1q/EhMx0+ZVxw=",
+        "checksum": "Q1jhAhggAuZnU7FFHnebGA26mq+jI=",
         "control": {
-          "checksum": "sha1-xZQl4rSEEOs59w1q/EhMx0+ZVxw=",
-          "range": "bytes=697-1082"
+          "checksum": "sha1-jhAhggAuZnU7FFHnebGA26mq+jI=",
+          "range": "bytes=695-1079"
         },
         "data": {
-          "checksum": "sha256-IfGWsH9qFzzKcdVENdnoZqPbAdejcokLcfm7Z53KnPM=",
-          "range": "bytes=1083-1197082"
+          "checksum": "sha256-XTCQYnhGSm7SkGwqV/TQMFqGajVJVYhKAidKfLb2D3Y=",
+          "range": "bytes=1080-1197081"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-CypiuHQ6EuduQ5uexXhBDv5YvvY=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-qVrfDVxubkrb5Yrd2mFTv2A0G7k=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r7.apk",
-        "version": "3.3.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r9.apk",
+        "version": "3.3.0-r9"
       },
       {
         "architecture": "x86_64",
@@ -774,22 +774,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1eaot0B2H9IOF054RKMabXG37GUk=",
+        "checksum": "Q111Aq+tDFOygcfZzOg1hQbtZw1Q4=",
         "control": {
-          "checksum": "sha1-eaot0B2H9IOF054RKMabXG37GUk=",
-          "range": "bytes=700-1143"
+          "checksum": "sha1-11Aq+tDFOygcfZzOg1hQbtZw1Q4=",
+          "range": "bytes=697-1140"
         },
         "data": {
-          "checksum": "sha256-EeuQkVe5Hl+bqWfkBaMgA1Z2Fh91f1upncBbArJu9Gw=",
-          "range": "bytes=1144-17267929"
+          "checksum": "sha256-ednk20seorMQ+xEGnt8zWpxO20xrfj7zOtAmk+XcTbA=",
+          "range": "bytes=1141-17250210"
         },
         "name": "git",
         "signature": {
-          "checksum": "sha1-yMhNFUJ+emT/s9tdLDQ8zjT2+vY=",
-          "range": "bytes=0-699"
+          "checksum": "sha1-T1C3/QmQvuJGLjPH2YyOLIM5ewE=",
+          "range": "bytes=0-696"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/git-2.45.1-r0.apk",
-        "version": "2.45.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/git-2.45.2-r0.apk",
+        "version": "2.45.2-r0"
       },
       {
         "architecture": "x86_64",
@@ -812,22 +812,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q13aWkG70feJbLGSThmQEKqLYrGNc=",
+        "checksum": "Q19dA+Zcg8X4SxDAZMWWPEjgjeKdc=",
         "control": {
-          "checksum": "sha1-3aWkG70feJbLGSThmQEKqLYrGNc=",
-          "range": "bytes=700-1060"
+          "checksum": "sha1-9dA+Zcg8X4SxDAZMWWPEjgjeKdc=",
+          "range": "bytes=696-1056"
         },
         "data": {
-          "checksum": "sha256-ABzm09Er/gJsfvuqgWDcowvo7CXRrEpILpmatpTwWsM=",
-          "range": "bytes=1061-10428036"
+          "checksum": "sha256-yi3bDtrc3T+EVxl1H6XvaCUcp0Jl6SQOeiWDSoNP1sA=",
+          "range": "bytes=1057-10587175"
         },
         "name": "maven",
         "signature": {
-          "checksum": "sha1-exwnWPSNQTP3ePNLEk7P+bVCU00=",
-          "range": "bytes=0-699"
+          "checksum": "sha1-bNLB1Gu/o9NWJbnqMFLWY514RiY=",
+          "range": "bytes=0-695"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/maven-3.9.6-r3.apk",
-        "version": "3.9.6-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/maven-3.9.7-r0.apk",
+        "version": "3.9.7-r0"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/caddy.lock.json
+++ b/wolfi-images/caddy.lock.json
@@ -204,41 +204,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q10Rr8mXMuAm4i4SjxE7xhsgs2UME=",
+        "checksum": "Q1gTZGkWP+QO3mUqLVJth8vrDEzzU=",
         "control": {
-          "checksum": "sha1-0Rr8mXMuAm4i4SjxE7xhsgs2UME=",
-          "range": "bytes=699-1079"
+          "checksum": "sha1-gTZGkWP+QO3mUqLVJth8vrDEzzU=",
+          "range": "bytes=699-1076"
         },
         "data": {
-          "checksum": "sha256-IVV0PRiJiwz4Ov1pWU1VAHf8cM0TgwqsV3vkYEQc0mM=",
-          "range": "bytes=1080-5915633"
+          "checksum": "sha256-/IFXqeKvU0GODNsz1yPIEMcFHgABT+8rbZpSlTLo4e4=",
+          "range": "bytes=1077-5915704"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-OlnuKCVUD1RpZgK+JyGdG/NQ0R0=",
+          "checksum": "sha1-l1o5ixkyWWqqJE3FOfR0QUemJUA=",
           "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r7.apk",
-        "version": "3.3.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r9.apk",
+        "version": "3.3.0-r9"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1xZQl4rSEEOs59w1q/EhMx0+ZVxw=",
+        "checksum": "Q1jhAhggAuZnU7FFHnebGA26mq+jI=",
         "control": {
-          "checksum": "sha1-xZQl4rSEEOs59w1q/EhMx0+ZVxw=",
-          "range": "bytes=697-1082"
+          "checksum": "sha1-jhAhggAuZnU7FFHnebGA26mq+jI=",
+          "range": "bytes=695-1079"
         },
         "data": {
-          "checksum": "sha256-IfGWsH9qFzzKcdVENdnoZqPbAdejcokLcfm7Z53KnPM=",
-          "range": "bytes=1083-1197082"
+          "checksum": "sha256-XTCQYnhGSm7SkGwqV/TQMFqGajVJVYhKAidKfLb2D3Y=",
+          "range": "bytes=1080-1197081"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-CypiuHQ6EuduQ5uexXhBDv5YvvY=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-qVrfDVxubkrb5Yrd2mFTv2A0G7k=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r7.apk",
-        "version": "3.3.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r9.apk",
+        "version": "3.3.0-r9"
       },
       {
         "architecture": "x86_64",
@@ -584,22 +584,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1hmJGKUg5U62/eDsJFXTXql08W5k=",
+        "checksum": "Q1NwjCiINnUwQNmzalYHK+0Yjeus8=",
         "control": {
-          "checksum": "sha1-hmJGKUg5U62/eDsJFXTXql08W5k=",
-          "range": "bytes=695-1092"
+          "checksum": "sha1-NwjCiINnUwQNmzalYHK+0Yjeus8=",
+          "range": "bytes=698-1095"
         },
         "data": {
-          "checksum": "sha256-9mtlf5LYMHCQZQcBNv/Nhof+RDrDvqEJB3u/pFo9nXc=",
-          "range": "bytes=1093-41669227"
+          "checksum": "sha256-6zSdAtbtdhZWn83oXkg+ZJXkGQ3bWIrSCaiWvVfV0JM=",
+          "range": "bytes=1096-42592384"
         },
         "name": "caddy",
         "signature": {
-          "checksum": "sha1-sJwUZEAK0xlZda4GGmTA5C6d2pc=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-ibNqloTU+QnDByFEObDmJ/8ZVo0=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/caddy-2.7.6-r9.apk",
-        "version": "2.7.6-r9"
+        "url": "https://packages.wolfi.dev/os/x86_64/caddy-2.8.4-r0.apk",
+        "version": "2.8.4-r0"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/cadvisor.lock.json
+++ b/wolfi-images/cadvisor.lock.json
@@ -204,41 +204,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q10Rr8mXMuAm4i4SjxE7xhsgs2UME=",
+        "checksum": "Q1gTZGkWP+QO3mUqLVJth8vrDEzzU=",
         "control": {
-          "checksum": "sha1-0Rr8mXMuAm4i4SjxE7xhsgs2UME=",
-          "range": "bytes=699-1079"
+          "checksum": "sha1-gTZGkWP+QO3mUqLVJth8vrDEzzU=",
+          "range": "bytes=699-1076"
         },
         "data": {
-          "checksum": "sha256-IVV0PRiJiwz4Ov1pWU1VAHf8cM0TgwqsV3vkYEQc0mM=",
-          "range": "bytes=1080-5915633"
+          "checksum": "sha256-/IFXqeKvU0GODNsz1yPIEMcFHgABT+8rbZpSlTLo4e4=",
+          "range": "bytes=1077-5915704"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-OlnuKCVUD1RpZgK+JyGdG/NQ0R0=",
+          "checksum": "sha1-l1o5ixkyWWqqJE3FOfR0QUemJUA=",
           "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r7.apk",
-        "version": "3.3.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r9.apk",
+        "version": "3.3.0-r9"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1xZQl4rSEEOs59w1q/EhMx0+ZVxw=",
+        "checksum": "Q1jhAhggAuZnU7FFHnebGA26mq+jI=",
         "control": {
-          "checksum": "sha1-xZQl4rSEEOs59w1q/EhMx0+ZVxw=",
-          "range": "bytes=697-1082"
+          "checksum": "sha1-jhAhggAuZnU7FFHnebGA26mq+jI=",
+          "range": "bytes=695-1079"
         },
         "data": {
-          "checksum": "sha256-IfGWsH9qFzzKcdVENdnoZqPbAdejcokLcfm7Z53KnPM=",
-          "range": "bytes=1083-1197082"
+          "checksum": "sha256-XTCQYnhGSm7SkGwqV/TQMFqGajVJVYhKAidKfLb2D3Y=",
+          "range": "bytes=1080-1197081"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-CypiuHQ6EuduQ5uexXhBDv5YvvY=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-qVrfDVxubkrb5Yrd2mFTv2A0G7k=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r7.apk",
-        "version": "3.3.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r9.apk",
+        "version": "3.3.0-r9"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/cloud-mi2.lock.json
+++ b/wolfi-images/cloud-mi2.lock.json
@@ -204,41 +204,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q10Rr8mXMuAm4i4SjxE7xhsgs2UME=",
+        "checksum": "Q1gTZGkWP+QO3mUqLVJth8vrDEzzU=",
         "control": {
-          "checksum": "sha1-0Rr8mXMuAm4i4SjxE7xhsgs2UME=",
-          "range": "bytes=699-1079"
+          "checksum": "sha1-gTZGkWP+QO3mUqLVJth8vrDEzzU=",
+          "range": "bytes=699-1076"
         },
         "data": {
-          "checksum": "sha256-IVV0PRiJiwz4Ov1pWU1VAHf8cM0TgwqsV3vkYEQc0mM=",
-          "range": "bytes=1080-5915633"
+          "checksum": "sha256-/IFXqeKvU0GODNsz1yPIEMcFHgABT+8rbZpSlTLo4e4=",
+          "range": "bytes=1077-5915704"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-OlnuKCVUD1RpZgK+JyGdG/NQ0R0=",
+          "checksum": "sha1-l1o5ixkyWWqqJE3FOfR0QUemJUA=",
           "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r7.apk",
-        "version": "3.3.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r9.apk",
+        "version": "3.3.0-r9"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1xZQl4rSEEOs59w1q/EhMx0+ZVxw=",
+        "checksum": "Q1jhAhggAuZnU7FFHnebGA26mq+jI=",
         "control": {
-          "checksum": "sha1-xZQl4rSEEOs59w1q/EhMx0+ZVxw=",
-          "range": "bytes=697-1082"
+          "checksum": "sha1-jhAhggAuZnU7FFHnebGA26mq+jI=",
+          "range": "bytes=695-1079"
         },
         "data": {
-          "checksum": "sha256-IfGWsH9qFzzKcdVENdnoZqPbAdejcokLcfm7Z53KnPM=",
-          "range": "bytes=1083-1197082"
+          "checksum": "sha256-XTCQYnhGSm7SkGwqV/TQMFqGajVJVYhKAidKfLb2D3Y=",
+          "range": "bytes=1080-1197081"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-CypiuHQ6EuduQ5uexXhBDv5YvvY=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-qVrfDVxubkrb5Yrd2mFTv2A0G7k=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r7.apk",
-        "version": "3.3.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r9.apk",
+        "version": "3.3.0-r9"
       },
       {
         "architecture": "x86_64",
@@ -755,41 +755,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1eaot0B2H9IOF054RKMabXG37GUk=",
+        "checksum": "Q111Aq+tDFOygcfZzOg1hQbtZw1Q4=",
         "control": {
-          "checksum": "sha1-eaot0B2H9IOF054RKMabXG37GUk=",
-          "range": "bytes=700-1143"
+          "checksum": "sha1-11Aq+tDFOygcfZzOg1hQbtZw1Q4=",
+          "range": "bytes=697-1140"
         },
         "data": {
-          "checksum": "sha256-EeuQkVe5Hl+bqWfkBaMgA1Z2Fh91f1upncBbArJu9Gw=",
-          "range": "bytes=1144-17267929"
+          "checksum": "sha256-ednk20seorMQ+xEGnt8zWpxO20xrfj7zOtAmk+XcTbA=",
+          "range": "bytes=1141-17250210"
         },
         "name": "git",
         "signature": {
-          "checksum": "sha1-yMhNFUJ+emT/s9tdLDQ8zjT2+vY=",
-          "range": "bytes=0-699"
+          "checksum": "sha1-T1C3/QmQvuJGLjPH2YyOLIM5ewE=",
+          "range": "bytes=0-696"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/git-2.45.1-r0.apk",
-        "version": "2.45.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/git-2.45.2-r0.apk",
+        "version": "2.45.2-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q116m2Q5Ln3gJz05D1gRD/3AQz9+4=",
+        "checksum": "Q1UmMIPtQRrPW2HlaR66LPULlD5AU=",
         "control": {
-          "checksum": "sha1-16m2Q5Ln3gJz05D1gRD/3AQz9+4=",
-          "range": "bytes=703-1102"
+          "checksum": "sha1-UmMIPtQRrPW2HlaR66LPULlD5AU=",
+          "range": "bytes=700-1063"
         },
         "data": {
-          "checksum": "sha256-nU1+NEgt7CR9vsxeCs5Hr9tHiSAw69pxvz+m0W+N+PI=",
-          "range": "bytes=1103-11855891"
+          "checksum": "sha256-Rwf835Uhc/sjB+t9aRxnTWZ8KMZUxlLzZVOG4hawVYI=",
+          "range": "bytes=1064-12733213"
         },
         "name": "git-lfs",
         "signature": {
-          "checksum": "sha1-z3BWu5hxd1KVtIrVNwIYsNsgYpc=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-03OxiuAmYPciOddmufs49rJLRw4=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/git-lfs-3.5.1-r4.apk",
-        "version": "3.5.1-r4"
+        "url": "https://packages.wolfi.dev/os/x86_64/git-lfs-3.5.1-r5.apk",
+        "version": "3.5.1-r5"
       },
       {
         "architecture": "x86_64",
@@ -945,22 +945,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1OwTlRMXb7zHeLIAvkR9u4QSpB3g=",
+        "checksum": "Q1cqvmBqrAP2QlJV4IAn1Hs451O10=",
         "control": {
-          "checksum": "sha1-OwTlRMXb7zHeLIAvkR9u4QSpB3g=",
-          "range": "bytes=696-1054"
+          "checksum": "sha1-cqvmBqrAP2QlJV4IAn1Hs451O10=",
+          "range": "bytes=699-1057"
         },
         "data": {
-          "checksum": "sha256-OdJs5w5sVo61nZaAAmGJHi5QXRIwZfqwnauupc1JVMM=",
-          "range": "bytes=1055-8931137"
+          "checksum": "sha256-hVF8tflwY/oUUrf9jv52TwZfqyvA+nvr1OAYZDTP1QY=",
+          "range": "bytes=1058-8956887"
         },
         "name": "npm",
         "signature": {
-          "checksum": "sha1-x8/Ou0c9cx6tQEiYvZTCqfMeXZM=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-7Rr/2LbH/tpKPSaWYd3jRQUO1s0=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/npm-10.8.0-r0.apk",
-        "version": "10.8.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/npm-10.8.1-r0.apk",
+        "version": "10.8.1-r0"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/executor-kubernetes.lock.json
+++ b/wolfi-images/executor-kubernetes.lock.json
@@ -204,41 +204,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q10Rr8mXMuAm4i4SjxE7xhsgs2UME=",
+        "checksum": "Q1gTZGkWP+QO3mUqLVJth8vrDEzzU=",
         "control": {
-          "checksum": "sha1-0Rr8mXMuAm4i4SjxE7xhsgs2UME=",
-          "range": "bytes=699-1079"
+          "checksum": "sha1-gTZGkWP+QO3mUqLVJth8vrDEzzU=",
+          "range": "bytes=699-1076"
         },
         "data": {
-          "checksum": "sha256-IVV0PRiJiwz4Ov1pWU1VAHf8cM0TgwqsV3vkYEQc0mM=",
-          "range": "bytes=1080-5915633"
+          "checksum": "sha256-/IFXqeKvU0GODNsz1yPIEMcFHgABT+8rbZpSlTLo4e4=",
+          "range": "bytes=1077-5915704"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-OlnuKCVUD1RpZgK+JyGdG/NQ0R0=",
+          "checksum": "sha1-l1o5ixkyWWqqJE3FOfR0QUemJUA=",
           "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r7.apk",
-        "version": "3.3.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r9.apk",
+        "version": "3.3.0-r9"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1xZQl4rSEEOs59w1q/EhMx0+ZVxw=",
+        "checksum": "Q1jhAhggAuZnU7FFHnebGA26mq+jI=",
         "control": {
-          "checksum": "sha1-xZQl4rSEEOs59w1q/EhMx0+ZVxw=",
-          "range": "bytes=697-1082"
+          "checksum": "sha1-jhAhggAuZnU7FFHnebGA26mq+jI=",
+          "range": "bytes=695-1079"
         },
         "data": {
-          "checksum": "sha256-IfGWsH9qFzzKcdVENdnoZqPbAdejcokLcfm7Z53KnPM=",
-          "range": "bytes=1083-1197082"
+          "checksum": "sha256-XTCQYnhGSm7SkGwqV/TQMFqGajVJVYhKAidKfLb2D3Y=",
+          "range": "bytes=1080-1197081"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-CypiuHQ6EuduQ5uexXhBDv5YvvY=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-qVrfDVxubkrb5Yrd2mFTv2A0G7k=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r7.apk",
-        "version": "3.3.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r9.apk",
+        "version": "3.3.0-r9"
       },
       {
         "architecture": "x86_64",
@@ -755,22 +755,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1eaot0B2H9IOF054RKMabXG37GUk=",
+        "checksum": "Q111Aq+tDFOygcfZzOg1hQbtZw1Q4=",
         "control": {
-          "checksum": "sha1-eaot0B2H9IOF054RKMabXG37GUk=",
-          "range": "bytes=700-1143"
+          "checksum": "sha1-11Aq+tDFOygcfZzOg1hQbtZw1Q4=",
+          "range": "bytes=697-1140"
         },
         "data": {
-          "checksum": "sha256-EeuQkVe5Hl+bqWfkBaMgA1Z2Fh91f1upncBbArJu9Gw=",
-          "range": "bytes=1144-17267929"
+          "checksum": "sha256-ednk20seorMQ+xEGnt8zWpxO20xrfj7zOtAmk+XcTbA=",
+          "range": "bytes=1141-17250210"
         },
         "name": "git",
         "signature": {
-          "checksum": "sha1-yMhNFUJ+emT/s9tdLDQ8zjT2+vY=",
-          "range": "bytes=0-699"
+          "checksum": "sha1-T1C3/QmQvuJGLjPH2YyOLIM5ewE=",
+          "range": "bytes=0-696"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/git-2.45.1-r0.apk",
-        "version": "2.45.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/git-2.45.2-r0.apk",
+        "version": "2.45.2-r0"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/executor.lock.json
+++ b/wolfi-images/executor.lock.json
@@ -204,41 +204,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q10Rr8mXMuAm4i4SjxE7xhsgs2UME=",
+        "checksum": "Q1gTZGkWP+QO3mUqLVJth8vrDEzzU=",
         "control": {
-          "checksum": "sha1-0Rr8mXMuAm4i4SjxE7xhsgs2UME=",
-          "range": "bytes=699-1079"
+          "checksum": "sha1-gTZGkWP+QO3mUqLVJth8vrDEzzU=",
+          "range": "bytes=699-1076"
         },
         "data": {
-          "checksum": "sha256-IVV0PRiJiwz4Ov1pWU1VAHf8cM0TgwqsV3vkYEQc0mM=",
-          "range": "bytes=1080-5915633"
+          "checksum": "sha256-/IFXqeKvU0GODNsz1yPIEMcFHgABT+8rbZpSlTLo4e4=",
+          "range": "bytes=1077-5915704"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-OlnuKCVUD1RpZgK+JyGdG/NQ0R0=",
+          "checksum": "sha1-l1o5ixkyWWqqJE3FOfR0QUemJUA=",
           "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r7.apk",
-        "version": "3.3.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r9.apk",
+        "version": "3.3.0-r9"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1xZQl4rSEEOs59w1q/EhMx0+ZVxw=",
+        "checksum": "Q1jhAhggAuZnU7FFHnebGA26mq+jI=",
         "control": {
-          "checksum": "sha1-xZQl4rSEEOs59w1q/EhMx0+ZVxw=",
-          "range": "bytes=697-1082"
+          "checksum": "sha1-jhAhggAuZnU7FFHnebGA26mq+jI=",
+          "range": "bytes=695-1079"
         },
         "data": {
-          "checksum": "sha256-IfGWsH9qFzzKcdVENdnoZqPbAdejcokLcfm7Z53KnPM=",
-          "range": "bytes=1083-1197082"
+          "checksum": "sha256-XTCQYnhGSm7SkGwqV/TQMFqGajVJVYhKAidKfLb2D3Y=",
+          "range": "bytes=1080-1197081"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-CypiuHQ6EuduQ5uexXhBDv5YvvY=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-qVrfDVxubkrb5Yrd2mFTv2A0G7k=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r7.apk",
-        "version": "3.3.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r9.apk",
+        "version": "3.3.0-r9"
       },
       {
         "architecture": "x86_64",
@@ -793,22 +793,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1eaot0B2H9IOF054RKMabXG37GUk=",
+        "checksum": "Q111Aq+tDFOygcfZzOg1hQbtZw1Q4=",
         "control": {
-          "checksum": "sha1-eaot0B2H9IOF054RKMabXG37GUk=",
-          "range": "bytes=700-1143"
+          "checksum": "sha1-11Aq+tDFOygcfZzOg1hQbtZw1Q4=",
+          "range": "bytes=697-1140"
         },
         "data": {
-          "checksum": "sha256-EeuQkVe5Hl+bqWfkBaMgA1Z2Fh91f1upncBbArJu9Gw=",
-          "range": "bytes=1144-17267929"
+          "checksum": "sha256-ednk20seorMQ+xEGnt8zWpxO20xrfj7zOtAmk+XcTbA=",
+          "range": "bytes=1141-17250210"
         },
         "name": "git",
         "signature": {
-          "checksum": "sha1-yMhNFUJ+emT/s9tdLDQ8zjT2+vY=",
-          "range": "bytes=0-699"
+          "checksum": "sha1-T1C3/QmQvuJGLjPH2YyOLIM5ewE=",
+          "range": "bytes=0-696"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/git-2.45.1-r0.apk",
-        "version": "2.45.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/git-2.45.2-r0.apk",
+        "version": "2.45.2-r0"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/gitserver.lock.json
+++ b/wolfi-images/gitserver.lock.json
@@ -261,41 +261,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q10Rr8mXMuAm4i4SjxE7xhsgs2UME=",
+        "checksum": "Q1gTZGkWP+QO3mUqLVJth8vrDEzzU=",
         "control": {
-          "checksum": "sha1-0Rr8mXMuAm4i4SjxE7xhsgs2UME=",
-          "range": "bytes=699-1079"
+          "checksum": "sha1-gTZGkWP+QO3mUqLVJth8vrDEzzU=",
+          "range": "bytes=699-1076"
         },
         "data": {
-          "checksum": "sha256-IVV0PRiJiwz4Ov1pWU1VAHf8cM0TgwqsV3vkYEQc0mM=",
-          "range": "bytes=1080-5915633"
+          "checksum": "sha256-/IFXqeKvU0GODNsz1yPIEMcFHgABT+8rbZpSlTLo4e4=",
+          "range": "bytes=1077-5915704"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-OlnuKCVUD1RpZgK+JyGdG/NQ0R0=",
+          "checksum": "sha1-l1o5ixkyWWqqJE3FOfR0QUemJUA=",
           "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r7.apk",
-        "version": "3.3.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r9.apk",
+        "version": "3.3.0-r9"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1xZQl4rSEEOs59w1q/EhMx0+ZVxw=",
+        "checksum": "Q1jhAhggAuZnU7FFHnebGA26mq+jI=",
         "control": {
-          "checksum": "sha1-xZQl4rSEEOs59w1q/EhMx0+ZVxw=",
-          "range": "bytes=697-1082"
+          "checksum": "sha1-jhAhggAuZnU7FFHnebGA26mq+jI=",
+          "range": "bytes=695-1079"
         },
         "data": {
-          "checksum": "sha256-IfGWsH9qFzzKcdVENdnoZqPbAdejcokLcfm7Z53KnPM=",
-          "range": "bytes=1083-1197082"
+          "checksum": "sha256-XTCQYnhGSm7SkGwqV/TQMFqGajVJVYhKAidKfLb2D3Y=",
+          "range": "bytes=1080-1197081"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-CypiuHQ6EuduQ5uexXhBDv5YvvY=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-qVrfDVxubkrb5Yrd2mFTv2A0G7k=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r7.apk",
-        "version": "3.3.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r9.apk",
+        "version": "3.3.0-r9"
       },
       {
         "architecture": "x86_64",
@@ -831,79 +831,79 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1eaot0B2H9IOF054RKMabXG37GUk=",
+        "checksum": "Q111Aq+tDFOygcfZzOg1hQbtZw1Q4=",
         "control": {
-          "checksum": "sha1-eaot0B2H9IOF054RKMabXG37GUk=",
-          "range": "bytes=700-1143"
+          "checksum": "sha1-11Aq+tDFOygcfZzOg1hQbtZw1Q4=",
+          "range": "bytes=697-1140"
         },
         "data": {
-          "checksum": "sha256-EeuQkVe5Hl+bqWfkBaMgA1Z2Fh91f1upncBbArJu9Gw=",
-          "range": "bytes=1144-17267929"
+          "checksum": "sha256-ednk20seorMQ+xEGnt8zWpxO20xrfj7zOtAmk+XcTbA=",
+          "range": "bytes=1141-17250210"
         },
         "name": "git",
         "signature": {
-          "checksum": "sha1-yMhNFUJ+emT/s9tdLDQ8zjT2+vY=",
-          "range": "bytes=0-699"
+          "checksum": "sha1-T1C3/QmQvuJGLjPH2YyOLIM5ewE=",
+          "range": "bytes=0-696"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/git-2.45.1-r0.apk",
-        "version": "2.45.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/git-2.45.2-r0.apk",
+        "version": "2.45.2-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q116m2Q5Ln3gJz05D1gRD/3AQz9+4=",
+        "checksum": "Q1UmMIPtQRrPW2HlaR66LPULlD5AU=",
         "control": {
-          "checksum": "sha1-16m2Q5Ln3gJz05D1gRD/3AQz9+4=",
-          "range": "bytes=703-1102"
+          "checksum": "sha1-UmMIPtQRrPW2HlaR66LPULlD5AU=",
+          "range": "bytes=700-1063"
         },
         "data": {
-          "checksum": "sha256-nU1+NEgt7CR9vsxeCs5Hr9tHiSAw69pxvz+m0W+N+PI=",
-          "range": "bytes=1103-11855891"
+          "checksum": "sha256-Rwf835Uhc/sjB+t9aRxnTWZ8KMZUxlLzZVOG4hawVYI=",
+          "range": "bytes=1064-12733213"
         },
         "name": "git-lfs",
         "signature": {
-          "checksum": "sha1-z3BWu5hxd1KVtIrVNwIYsNsgYpc=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-03OxiuAmYPciOddmufs49rJLRw4=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/git-lfs-3.5.1-r4.apk",
-        "version": "3.5.1-r4"
+        "url": "https://packages.wolfi.dev/os/x86_64/git-lfs-3.5.1-r5.apk",
+        "version": "3.5.1-r5"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1AtyQ8BGxIy54FTCVfU4vA3dBujA=",
+        "checksum": "Q1/xjUDpfwOCMLFmAYUyXK3hbr7M8=",
         "control": {
-          "checksum": "sha1-AtyQ8BGxIy54FTCVfU4vA3dBujA=",
-          "range": "bytes=696-1105"
+          "checksum": "sha1-/xjUDpfwOCMLFmAYUyXK3hbr7M8=",
+          "range": "bytes=703-1114"
         },
         "data": {
-          "checksum": "sha256-jm7jYqIpUa8S3qayJMbb10cks4vaQbqkkl7r95+SUvc=",
-          "range": "bytes=1106-7568791"
+          "checksum": "sha256-RvBzvJt//AAv6DeDRxBbbW2UG//3UZ38sDmhcMQoRKY=",
+          "range": "bytes=1115-7560368"
         },
         "name": "git-daemon",
         "signature": {
-          "checksum": "sha1-WouI+0ZflydIMa2FK5A7CtGW7Uo=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-dHYurOENIvRxIuBAaHNAeJGQciA=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/git-daemon-2.45.1-r0.apk",
-        "version": "2.45.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/git-daemon-2.45.2-r0.apk",
+        "version": "2.45.2-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1bxdUk5Zm+DGJ1BJRhi+4lVqQC8M=",
+        "checksum": "Q1lmZVnMVaV+BuJ4Zw8v1gIkGVcNc=",
         "control": {
-          "checksum": "sha1-bxdUk5Zm+DGJ1BJRhi+4lVqQC8M=",
-          "range": "bytes=707-1078"
+          "checksum": "sha1-lmZVnMVaV+BuJ4Zw8v1gIkGVcNc=",
+          "range": "bytes=696-1069"
         },
         "data": {
-          "checksum": "sha256-n6UB0PG6Q3zvEhvY9YG0J+5fLLQy52aoHxuc/8mNhDo=",
-          "range": "bytes=1079-211589"
+          "checksum": "sha256-qHYsorfTKRzalTN5p+JzwEZ2NYXNkxiHME9MoyMfeRI=",
+          "range": "bytes=1070-212142"
         },
         "name": "git-p4",
         "signature": {
-          "checksum": "sha1-7GOnoDsQV3oKBXD6jIlMaFHpzxQ=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-eGGtsdgoIw2il+9a5ZT/t126v0c=",
+          "range": "bytes=0-695"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/git-p4-2.45.1-r0.apk",
-        "version": "2.45.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/git-p4-2.45.2-r0.apk",
+        "version": "2.45.2-r0"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/grafana.lock.json
+++ b/wolfi-images/grafana.lock.json
@@ -113,41 +113,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q10Rr8mXMuAm4i4SjxE7xhsgs2UME=",
+        "checksum": "Q1gTZGkWP+QO3mUqLVJth8vrDEzzU=",
         "control": {
-          "checksum": "sha1-0Rr8mXMuAm4i4SjxE7xhsgs2UME=",
-          "range": "bytes=699-1079"
+          "checksum": "sha1-gTZGkWP+QO3mUqLVJth8vrDEzzU=",
+          "range": "bytes=699-1076"
         },
         "data": {
-          "checksum": "sha256-IVV0PRiJiwz4Ov1pWU1VAHf8cM0TgwqsV3vkYEQc0mM=",
-          "range": "bytes=1080-5915633"
+          "checksum": "sha256-/IFXqeKvU0GODNsz1yPIEMcFHgABT+8rbZpSlTLo4e4=",
+          "range": "bytes=1077-5915704"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-OlnuKCVUD1RpZgK+JyGdG/NQ0R0=",
+          "checksum": "sha1-l1o5ixkyWWqqJE3FOfR0QUemJUA=",
           "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r7.apk",
-        "version": "3.3.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r9.apk",
+        "version": "3.3.0-r9"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1xZQl4rSEEOs59w1q/EhMx0+ZVxw=",
+        "checksum": "Q1jhAhggAuZnU7FFHnebGA26mq+jI=",
         "control": {
-          "checksum": "sha1-xZQl4rSEEOs59w1q/EhMx0+ZVxw=",
-          "range": "bytes=697-1082"
+          "checksum": "sha1-jhAhggAuZnU7FFHnebGA26mq+jI=",
+          "range": "bytes=695-1079"
         },
         "data": {
-          "checksum": "sha256-IfGWsH9qFzzKcdVENdnoZqPbAdejcokLcfm7Z53KnPM=",
-          "range": "bytes=1083-1197082"
+          "checksum": "sha256-XTCQYnhGSm7SkGwqV/TQMFqGajVJVYhKAidKfLb2D3Y=",
+          "range": "bytes=1080-1197081"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-CypiuHQ6EuduQ5uexXhBDv5YvvY=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-qVrfDVxubkrb5Yrd2mFTv2A0G7k=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r7.apk",
-        "version": "3.3.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r9.apk",
+        "version": "3.3.0-r9"
       },
       {
         "architecture": "x86_64",
@@ -531,41 +531,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1NzlLfN1k5jpK2xS5gxS0BUbK0rg=",
+        "checksum": "Q1ClRU9LEog4OgkuXujv0JpHDKDiI=",
         "control": {
-          "checksum": "sha1-NzlLfN1k5jpK2xS5gxS0BUbK0rg=",
-          "range": "bytes=698-1077"
+          "checksum": "sha1-ClRU9LEog4OgkuXujv0JpHDKDiI=",
+          "range": "bytes=703-1079"
         },
         "data": {
-          "checksum": "sha256-ZP4LZuoDPsCZ6pbQ4jkiGi0Z6SSPTQWRD0ZnxU00I64=",
-          "range": "bytes=1078-182482"
+          "checksum": "sha256-hC391qobx5DyYe6LmNA1XlgRpG5rpj6iHjAQPkK1SIk=",
+          "range": "bytes=1080-182481"
         },
         "name": "openssl-provider-legacy",
         "signature": {
-          "checksum": "sha1-ZpEyUMtKFAY1UG/VL58J72AHd2w=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-Fbc6Xmeg6vEpNQFZfdi3jb6Z/hw=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/openssl-provider-legacy-3.3.0-r7.apk",
-        "version": "3.3.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/openssl-provider-legacy-3.3.0-r9.apk",
+        "version": "3.3.0-r9"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1rK5w3i6jXlDEOJcsXmIzbJk8hWY=",
+        "checksum": "Q14cgQ7hzxZhRqXzw7CItN8b6TR0s=",
         "control": {
-          "checksum": "sha1-rK5w3i6jXlDEOJcsXmIzbJk8hWY=",
-          "range": "bytes=700-1127"
+          "checksum": "sha1-4cgQ7hzxZhRqXzw7CItN8b6TR0s=",
+          "range": "bytes=696-1122"
         },
         "data": {
-          "checksum": "sha256-F4hLB3k839A/9bWeW7SrEijgtyFQcHeoei760W+MZ44=",
-          "range": "bytes=1128-1242436"
+          "checksum": "sha256-usdB5oXIjCEBQqtiMoloXos6Fn+OyzGqbEevj/UDSLE=",
+          "range": "bytes=1123-1242435"
         },
         "name": "openssl",
         "signature": {
-          "checksum": "sha1-sMuYQwUf0O2Om8Hp/e9ulEBNwKI=",
-          "range": "bytes=0-699"
+          "checksum": "sha1-mjEQyOlQm8wq/ShCz8h/vZVZTkU=",
+          "range": "bytes=0-695"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/openssl-3.3.0-r7.apk",
-        "version": "3.3.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/openssl-3.3.0-r9.apk",
+        "version": "3.3.0-r9"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/jaeger-agent.lock.json
+++ b/wolfi-images/jaeger-agent.lock.json
@@ -204,41 +204,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q10Rr8mXMuAm4i4SjxE7xhsgs2UME=",
+        "checksum": "Q1gTZGkWP+QO3mUqLVJth8vrDEzzU=",
         "control": {
-          "checksum": "sha1-0Rr8mXMuAm4i4SjxE7xhsgs2UME=",
-          "range": "bytes=699-1079"
+          "checksum": "sha1-gTZGkWP+QO3mUqLVJth8vrDEzzU=",
+          "range": "bytes=699-1076"
         },
         "data": {
-          "checksum": "sha256-IVV0PRiJiwz4Ov1pWU1VAHf8cM0TgwqsV3vkYEQc0mM=",
-          "range": "bytes=1080-5915633"
+          "checksum": "sha256-/IFXqeKvU0GODNsz1yPIEMcFHgABT+8rbZpSlTLo4e4=",
+          "range": "bytes=1077-5915704"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-OlnuKCVUD1RpZgK+JyGdG/NQ0R0=",
+          "checksum": "sha1-l1o5ixkyWWqqJE3FOfR0QUemJUA=",
           "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r7.apk",
-        "version": "3.3.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r9.apk",
+        "version": "3.3.0-r9"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1xZQl4rSEEOs59w1q/EhMx0+ZVxw=",
+        "checksum": "Q1jhAhggAuZnU7FFHnebGA26mq+jI=",
         "control": {
-          "checksum": "sha1-xZQl4rSEEOs59w1q/EhMx0+ZVxw=",
-          "range": "bytes=697-1082"
+          "checksum": "sha1-jhAhggAuZnU7FFHnebGA26mq+jI=",
+          "range": "bytes=695-1079"
         },
         "data": {
-          "checksum": "sha256-IfGWsH9qFzzKcdVENdnoZqPbAdejcokLcfm7Z53KnPM=",
-          "range": "bytes=1083-1197082"
+          "checksum": "sha256-XTCQYnhGSm7SkGwqV/TQMFqGajVJVYhKAidKfLb2D3Y=",
+          "range": "bytes=1080-1197081"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-CypiuHQ6EuduQ5uexXhBDv5YvvY=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-qVrfDVxubkrb5Yrd2mFTv2A0G7k=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r7.apk",
-        "version": "3.3.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r9.apk",
+        "version": "3.3.0-r9"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/jaeger-all-in-one.lock.json
+++ b/wolfi-images/jaeger-all-in-one.lock.json
@@ -204,41 +204,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q10Rr8mXMuAm4i4SjxE7xhsgs2UME=",
+        "checksum": "Q1gTZGkWP+QO3mUqLVJth8vrDEzzU=",
         "control": {
-          "checksum": "sha1-0Rr8mXMuAm4i4SjxE7xhsgs2UME=",
-          "range": "bytes=699-1079"
+          "checksum": "sha1-gTZGkWP+QO3mUqLVJth8vrDEzzU=",
+          "range": "bytes=699-1076"
         },
         "data": {
-          "checksum": "sha256-IVV0PRiJiwz4Ov1pWU1VAHf8cM0TgwqsV3vkYEQc0mM=",
-          "range": "bytes=1080-5915633"
+          "checksum": "sha256-/IFXqeKvU0GODNsz1yPIEMcFHgABT+8rbZpSlTLo4e4=",
+          "range": "bytes=1077-5915704"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-OlnuKCVUD1RpZgK+JyGdG/NQ0R0=",
+          "checksum": "sha1-l1o5ixkyWWqqJE3FOfR0QUemJUA=",
           "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r7.apk",
-        "version": "3.3.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r9.apk",
+        "version": "3.3.0-r9"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1xZQl4rSEEOs59w1q/EhMx0+ZVxw=",
+        "checksum": "Q1jhAhggAuZnU7FFHnebGA26mq+jI=",
         "control": {
-          "checksum": "sha1-xZQl4rSEEOs59w1q/EhMx0+ZVxw=",
-          "range": "bytes=697-1082"
+          "checksum": "sha1-jhAhggAuZnU7FFHnebGA26mq+jI=",
+          "range": "bytes=695-1079"
         },
         "data": {
-          "checksum": "sha256-IfGWsH9qFzzKcdVENdnoZqPbAdejcokLcfm7Z53KnPM=",
-          "range": "bytes=1083-1197082"
+          "checksum": "sha256-XTCQYnhGSm7SkGwqV/TQMFqGajVJVYhKAidKfLb2D3Y=",
+          "range": "bytes=1080-1197081"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-CypiuHQ6EuduQ5uexXhBDv5YvvY=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-qVrfDVxubkrb5Yrd2mFTv2A0G7k=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r7.apk",
-        "version": "3.3.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r9.apk",
+        "version": "3.3.0-r9"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/node-exporter.lock.json
+++ b/wolfi-images/node-exporter.lock.json
@@ -204,41 +204,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q10Rr8mXMuAm4i4SjxE7xhsgs2UME=",
+        "checksum": "Q1gTZGkWP+QO3mUqLVJth8vrDEzzU=",
         "control": {
-          "checksum": "sha1-0Rr8mXMuAm4i4SjxE7xhsgs2UME=",
-          "range": "bytes=699-1079"
+          "checksum": "sha1-gTZGkWP+QO3mUqLVJth8vrDEzzU=",
+          "range": "bytes=699-1076"
         },
         "data": {
-          "checksum": "sha256-IVV0PRiJiwz4Ov1pWU1VAHf8cM0TgwqsV3vkYEQc0mM=",
-          "range": "bytes=1080-5915633"
+          "checksum": "sha256-/IFXqeKvU0GODNsz1yPIEMcFHgABT+8rbZpSlTLo4e4=",
+          "range": "bytes=1077-5915704"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-OlnuKCVUD1RpZgK+JyGdG/NQ0R0=",
+          "checksum": "sha1-l1o5ixkyWWqqJE3FOfR0QUemJUA=",
           "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r7.apk",
-        "version": "3.3.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r9.apk",
+        "version": "3.3.0-r9"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1xZQl4rSEEOs59w1q/EhMx0+ZVxw=",
+        "checksum": "Q1jhAhggAuZnU7FFHnebGA26mq+jI=",
         "control": {
-          "checksum": "sha1-xZQl4rSEEOs59w1q/EhMx0+ZVxw=",
-          "range": "bytes=697-1082"
+          "checksum": "sha1-jhAhggAuZnU7FFHnebGA26mq+jI=",
+          "range": "bytes=695-1079"
         },
         "data": {
-          "checksum": "sha256-IfGWsH9qFzzKcdVENdnoZqPbAdejcokLcfm7Z53KnPM=",
-          "range": "bytes=1083-1197082"
+          "checksum": "sha256-XTCQYnhGSm7SkGwqV/TQMFqGajVJVYhKAidKfLb2D3Y=",
+          "range": "bytes=1080-1197081"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-CypiuHQ6EuduQ5uexXhBDv5YvvY=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-qVrfDVxubkrb5Yrd2mFTv2A0G7k=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r7.apk",
-        "version": "3.3.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r9.apk",
+        "version": "3.3.0-r9"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/opentelemetry-collector.lock.json
+++ b/wolfi-images/opentelemetry-collector.lock.json
@@ -204,41 +204,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q10Rr8mXMuAm4i4SjxE7xhsgs2UME=",
+        "checksum": "Q1gTZGkWP+QO3mUqLVJth8vrDEzzU=",
         "control": {
-          "checksum": "sha1-0Rr8mXMuAm4i4SjxE7xhsgs2UME=",
-          "range": "bytes=699-1079"
+          "checksum": "sha1-gTZGkWP+QO3mUqLVJth8vrDEzzU=",
+          "range": "bytes=699-1076"
         },
         "data": {
-          "checksum": "sha256-IVV0PRiJiwz4Ov1pWU1VAHf8cM0TgwqsV3vkYEQc0mM=",
-          "range": "bytes=1080-5915633"
+          "checksum": "sha256-/IFXqeKvU0GODNsz1yPIEMcFHgABT+8rbZpSlTLo4e4=",
+          "range": "bytes=1077-5915704"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-OlnuKCVUD1RpZgK+JyGdG/NQ0R0=",
+          "checksum": "sha1-l1o5ixkyWWqqJE3FOfR0QUemJUA=",
           "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r7.apk",
-        "version": "3.3.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r9.apk",
+        "version": "3.3.0-r9"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1xZQl4rSEEOs59w1q/EhMx0+ZVxw=",
+        "checksum": "Q1jhAhggAuZnU7FFHnebGA26mq+jI=",
         "control": {
-          "checksum": "sha1-xZQl4rSEEOs59w1q/EhMx0+ZVxw=",
-          "range": "bytes=697-1082"
+          "checksum": "sha1-jhAhggAuZnU7FFHnebGA26mq+jI=",
+          "range": "bytes=695-1079"
         },
         "data": {
-          "checksum": "sha256-IfGWsH9qFzzKcdVENdnoZqPbAdejcokLcfm7Z53KnPM=",
-          "range": "bytes=1083-1197082"
+          "checksum": "sha256-XTCQYnhGSm7SkGwqV/TQMFqGajVJVYhKAidKfLb2D3Y=",
+          "range": "bytes=1080-1197081"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-CypiuHQ6EuduQ5uexXhBDv5YvvY=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-qVrfDVxubkrb5Yrd2mFTv2A0G7k=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r7.apk",
-        "version": "3.3.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r9.apk",
+        "version": "3.3.0-r9"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/postgres-exporter.lock.json
+++ b/wolfi-images/postgres-exporter.lock.json
@@ -204,41 +204,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q10Rr8mXMuAm4i4SjxE7xhsgs2UME=",
+        "checksum": "Q1gTZGkWP+QO3mUqLVJth8vrDEzzU=",
         "control": {
-          "checksum": "sha1-0Rr8mXMuAm4i4SjxE7xhsgs2UME=",
-          "range": "bytes=699-1079"
+          "checksum": "sha1-gTZGkWP+QO3mUqLVJth8vrDEzzU=",
+          "range": "bytes=699-1076"
         },
         "data": {
-          "checksum": "sha256-IVV0PRiJiwz4Ov1pWU1VAHf8cM0TgwqsV3vkYEQc0mM=",
-          "range": "bytes=1080-5915633"
+          "checksum": "sha256-/IFXqeKvU0GODNsz1yPIEMcFHgABT+8rbZpSlTLo4e4=",
+          "range": "bytes=1077-5915704"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-OlnuKCVUD1RpZgK+JyGdG/NQ0R0=",
+          "checksum": "sha1-l1o5ixkyWWqqJE3FOfR0QUemJUA=",
           "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r7.apk",
-        "version": "3.3.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r9.apk",
+        "version": "3.3.0-r9"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1xZQl4rSEEOs59w1q/EhMx0+ZVxw=",
+        "checksum": "Q1jhAhggAuZnU7FFHnebGA26mq+jI=",
         "control": {
-          "checksum": "sha1-xZQl4rSEEOs59w1q/EhMx0+ZVxw=",
-          "range": "bytes=697-1082"
+          "checksum": "sha1-jhAhggAuZnU7FFHnebGA26mq+jI=",
+          "range": "bytes=695-1079"
         },
         "data": {
-          "checksum": "sha256-IfGWsH9qFzzKcdVENdnoZqPbAdejcokLcfm7Z53KnPM=",
-          "range": "bytes=1083-1197082"
+          "checksum": "sha256-XTCQYnhGSm7SkGwqV/TQMFqGajVJVYhKAidKfLb2D3Y=",
+          "range": "bytes=1080-1197081"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-CypiuHQ6EuduQ5uexXhBDv5YvvY=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-qVrfDVxubkrb5Yrd2mFTv2A0G7k=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r7.apk",
-        "version": "3.3.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r9.apk",
+        "version": "3.3.0-r9"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/postgresql-12-codeinsights.lock.json
+++ b/wolfi-images/postgresql-12-codeinsights.lock.json
@@ -204,41 +204,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q10Rr8mXMuAm4i4SjxE7xhsgs2UME=",
+        "checksum": "Q1gTZGkWP+QO3mUqLVJth8vrDEzzU=",
         "control": {
-          "checksum": "sha1-0Rr8mXMuAm4i4SjxE7xhsgs2UME=",
-          "range": "bytes=699-1079"
+          "checksum": "sha1-gTZGkWP+QO3mUqLVJth8vrDEzzU=",
+          "range": "bytes=699-1076"
         },
         "data": {
-          "checksum": "sha256-IVV0PRiJiwz4Ov1pWU1VAHf8cM0TgwqsV3vkYEQc0mM=",
-          "range": "bytes=1080-5915633"
+          "checksum": "sha256-/IFXqeKvU0GODNsz1yPIEMcFHgABT+8rbZpSlTLo4e4=",
+          "range": "bytes=1077-5915704"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-OlnuKCVUD1RpZgK+JyGdG/NQ0R0=",
+          "checksum": "sha1-l1o5ixkyWWqqJE3FOfR0QUemJUA=",
           "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r7.apk",
-        "version": "3.3.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r9.apk",
+        "version": "3.3.0-r9"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1xZQl4rSEEOs59w1q/EhMx0+ZVxw=",
+        "checksum": "Q1jhAhggAuZnU7FFHnebGA26mq+jI=",
         "control": {
-          "checksum": "sha1-xZQl4rSEEOs59w1q/EhMx0+ZVxw=",
-          "range": "bytes=697-1082"
+          "checksum": "sha1-jhAhggAuZnU7FFHnebGA26mq+jI=",
+          "range": "bytes=695-1079"
         },
         "data": {
-          "checksum": "sha256-IfGWsH9qFzzKcdVENdnoZqPbAdejcokLcfm7Z53KnPM=",
-          "range": "bytes=1083-1197082"
+          "checksum": "sha256-XTCQYnhGSm7SkGwqV/TQMFqGajVJVYhKAidKfLb2D3Y=",
+          "range": "bytes=1080-1197081"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-CypiuHQ6EuduQ5uexXhBDv5YvvY=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-qVrfDVxubkrb5Yrd2mFTv2A0G7k=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r7.apk",
-        "version": "3.3.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r9.apk",
+        "version": "3.3.0-r9"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/postgresql-12.lock.json
+++ b/wolfi-images/postgresql-12.lock.json
@@ -204,41 +204,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q10Rr8mXMuAm4i4SjxE7xhsgs2UME=",
+        "checksum": "Q1gTZGkWP+QO3mUqLVJth8vrDEzzU=",
         "control": {
-          "checksum": "sha1-0Rr8mXMuAm4i4SjxE7xhsgs2UME=",
-          "range": "bytes=699-1079"
+          "checksum": "sha1-gTZGkWP+QO3mUqLVJth8vrDEzzU=",
+          "range": "bytes=699-1076"
         },
         "data": {
-          "checksum": "sha256-IVV0PRiJiwz4Ov1pWU1VAHf8cM0TgwqsV3vkYEQc0mM=",
-          "range": "bytes=1080-5915633"
+          "checksum": "sha256-/IFXqeKvU0GODNsz1yPIEMcFHgABT+8rbZpSlTLo4e4=",
+          "range": "bytes=1077-5915704"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-OlnuKCVUD1RpZgK+JyGdG/NQ0R0=",
+          "checksum": "sha1-l1o5ixkyWWqqJE3FOfR0QUemJUA=",
           "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r7.apk",
-        "version": "3.3.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r9.apk",
+        "version": "3.3.0-r9"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1xZQl4rSEEOs59w1q/EhMx0+ZVxw=",
+        "checksum": "Q1jhAhggAuZnU7FFHnebGA26mq+jI=",
         "control": {
-          "checksum": "sha1-xZQl4rSEEOs59w1q/EhMx0+ZVxw=",
-          "range": "bytes=697-1082"
+          "checksum": "sha1-jhAhggAuZnU7FFHnebGA26mq+jI=",
+          "range": "bytes=695-1079"
         },
         "data": {
-          "checksum": "sha256-IfGWsH9qFzzKcdVENdnoZqPbAdejcokLcfm7Z53KnPM=",
-          "range": "bytes=1083-1197082"
+          "checksum": "sha256-XTCQYnhGSm7SkGwqV/TQMFqGajVJVYhKAidKfLb2D3Y=",
+          "range": "bytes=1080-1197081"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-CypiuHQ6EuduQ5uexXhBDv5YvvY=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-qVrfDVxubkrb5Yrd2mFTv2A0G7k=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r7.apk",
-        "version": "3.3.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r9.apk",
+        "version": "3.3.0-r9"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/prometheus.lock.json
+++ b/wolfi-images/prometheus.lock.json
@@ -204,41 +204,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q10Rr8mXMuAm4i4SjxE7xhsgs2UME=",
+        "checksum": "Q1gTZGkWP+QO3mUqLVJth8vrDEzzU=",
         "control": {
-          "checksum": "sha1-0Rr8mXMuAm4i4SjxE7xhsgs2UME=",
-          "range": "bytes=699-1079"
+          "checksum": "sha1-gTZGkWP+QO3mUqLVJth8vrDEzzU=",
+          "range": "bytes=699-1076"
         },
         "data": {
-          "checksum": "sha256-IVV0PRiJiwz4Ov1pWU1VAHf8cM0TgwqsV3vkYEQc0mM=",
-          "range": "bytes=1080-5915633"
+          "checksum": "sha256-/IFXqeKvU0GODNsz1yPIEMcFHgABT+8rbZpSlTLo4e4=",
+          "range": "bytes=1077-5915704"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-OlnuKCVUD1RpZgK+JyGdG/NQ0R0=",
+          "checksum": "sha1-l1o5ixkyWWqqJE3FOfR0QUemJUA=",
           "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r7.apk",
-        "version": "3.3.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r9.apk",
+        "version": "3.3.0-r9"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1xZQl4rSEEOs59w1q/EhMx0+ZVxw=",
+        "checksum": "Q1jhAhggAuZnU7FFHnebGA26mq+jI=",
         "control": {
-          "checksum": "sha1-xZQl4rSEEOs59w1q/EhMx0+ZVxw=",
-          "range": "bytes=697-1082"
+          "checksum": "sha1-jhAhggAuZnU7FFHnebGA26mq+jI=",
+          "range": "bytes=695-1079"
         },
         "data": {
-          "checksum": "sha256-IfGWsH9qFzzKcdVENdnoZqPbAdejcokLcfm7Z53KnPM=",
-          "range": "bytes=1083-1197082"
+          "checksum": "sha256-XTCQYnhGSm7SkGwqV/TQMFqGajVJVYhKAidKfLb2D3Y=",
+          "range": "bytes=1080-1197081"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-CypiuHQ6EuduQ5uexXhBDv5YvvY=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-qVrfDVxubkrb5Yrd2mFTv2A0G7k=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r7.apk",
-        "version": "3.3.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r9.apk",
+        "version": "3.3.0-r9"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/redis-exporter.lock.json
+++ b/wolfi-images/redis-exporter.lock.json
@@ -204,41 +204,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q10Rr8mXMuAm4i4SjxE7xhsgs2UME=",
+        "checksum": "Q1gTZGkWP+QO3mUqLVJth8vrDEzzU=",
         "control": {
-          "checksum": "sha1-0Rr8mXMuAm4i4SjxE7xhsgs2UME=",
-          "range": "bytes=699-1079"
+          "checksum": "sha1-gTZGkWP+QO3mUqLVJth8vrDEzzU=",
+          "range": "bytes=699-1076"
         },
         "data": {
-          "checksum": "sha256-IVV0PRiJiwz4Ov1pWU1VAHf8cM0TgwqsV3vkYEQc0mM=",
-          "range": "bytes=1080-5915633"
+          "checksum": "sha256-/IFXqeKvU0GODNsz1yPIEMcFHgABT+8rbZpSlTLo4e4=",
+          "range": "bytes=1077-5915704"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-OlnuKCVUD1RpZgK+JyGdG/NQ0R0=",
+          "checksum": "sha1-l1o5ixkyWWqqJE3FOfR0QUemJUA=",
           "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r7.apk",
-        "version": "3.3.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r9.apk",
+        "version": "3.3.0-r9"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1xZQl4rSEEOs59w1q/EhMx0+ZVxw=",
+        "checksum": "Q1jhAhggAuZnU7FFHnebGA26mq+jI=",
         "control": {
-          "checksum": "sha1-xZQl4rSEEOs59w1q/EhMx0+ZVxw=",
-          "range": "bytes=697-1082"
+          "checksum": "sha1-jhAhggAuZnU7FFHnebGA26mq+jI=",
+          "range": "bytes=695-1079"
         },
         "data": {
-          "checksum": "sha256-IfGWsH9qFzzKcdVENdnoZqPbAdejcokLcfm7Z53KnPM=",
-          "range": "bytes=1083-1197082"
+          "checksum": "sha256-XTCQYnhGSm7SkGwqV/TQMFqGajVJVYhKAidKfLb2D3Y=",
+          "range": "bytes=1080-1197081"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-CypiuHQ6EuduQ5uexXhBDv5YvvY=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-qVrfDVxubkrb5Yrd2mFTv2A0G7k=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r7.apk",
-        "version": "3.3.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r9.apk",
+        "version": "3.3.0-r9"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/redis.lock.json
+++ b/wolfi-images/redis.lock.json
@@ -204,41 +204,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q10Rr8mXMuAm4i4SjxE7xhsgs2UME=",
+        "checksum": "Q1gTZGkWP+QO3mUqLVJth8vrDEzzU=",
         "control": {
-          "checksum": "sha1-0Rr8mXMuAm4i4SjxE7xhsgs2UME=",
-          "range": "bytes=699-1079"
+          "checksum": "sha1-gTZGkWP+QO3mUqLVJth8vrDEzzU=",
+          "range": "bytes=699-1076"
         },
         "data": {
-          "checksum": "sha256-IVV0PRiJiwz4Ov1pWU1VAHf8cM0TgwqsV3vkYEQc0mM=",
-          "range": "bytes=1080-5915633"
+          "checksum": "sha256-/IFXqeKvU0GODNsz1yPIEMcFHgABT+8rbZpSlTLo4e4=",
+          "range": "bytes=1077-5915704"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-OlnuKCVUD1RpZgK+JyGdG/NQ0R0=",
+          "checksum": "sha1-l1o5ixkyWWqqJE3FOfR0QUemJUA=",
           "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r7.apk",
-        "version": "3.3.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r9.apk",
+        "version": "3.3.0-r9"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1xZQl4rSEEOs59w1q/EhMx0+ZVxw=",
+        "checksum": "Q1jhAhggAuZnU7FFHnebGA26mq+jI=",
         "control": {
-          "checksum": "sha1-xZQl4rSEEOs59w1q/EhMx0+ZVxw=",
-          "range": "bytes=697-1082"
+          "checksum": "sha1-jhAhggAuZnU7FFHnebGA26mq+jI=",
+          "range": "bytes=695-1079"
         },
         "data": {
-          "checksum": "sha256-IfGWsH9qFzzKcdVENdnoZqPbAdejcokLcfm7Z53KnPM=",
-          "range": "bytes=1083-1197082"
+          "checksum": "sha256-XTCQYnhGSm7SkGwqV/TQMFqGajVJVYhKAidKfLb2D3Y=",
+          "range": "bytes=1080-1197081"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-CypiuHQ6EuduQ5uexXhBDv5YvvY=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-qVrfDVxubkrb5Yrd2mFTv2A0G7k=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r7.apk",
-        "version": "3.3.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r9.apk",
+        "version": "3.3.0-r9"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/repo-updater.lock.json
+++ b/wolfi-images/repo-updater.lock.json
@@ -204,41 +204,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q10Rr8mXMuAm4i4SjxE7xhsgs2UME=",
+        "checksum": "Q1gTZGkWP+QO3mUqLVJth8vrDEzzU=",
         "control": {
-          "checksum": "sha1-0Rr8mXMuAm4i4SjxE7xhsgs2UME=",
-          "range": "bytes=699-1079"
+          "checksum": "sha1-gTZGkWP+QO3mUqLVJth8vrDEzzU=",
+          "range": "bytes=699-1076"
         },
         "data": {
-          "checksum": "sha256-IVV0PRiJiwz4Ov1pWU1VAHf8cM0TgwqsV3vkYEQc0mM=",
-          "range": "bytes=1080-5915633"
+          "checksum": "sha256-/IFXqeKvU0GODNsz1yPIEMcFHgABT+8rbZpSlTLo4e4=",
+          "range": "bytes=1077-5915704"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-OlnuKCVUD1RpZgK+JyGdG/NQ0R0=",
+          "checksum": "sha1-l1o5ixkyWWqqJE3FOfR0QUemJUA=",
           "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r7.apk",
-        "version": "3.3.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r9.apk",
+        "version": "3.3.0-r9"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1xZQl4rSEEOs59w1q/EhMx0+ZVxw=",
+        "checksum": "Q1jhAhggAuZnU7FFHnebGA26mq+jI=",
         "control": {
-          "checksum": "sha1-xZQl4rSEEOs59w1q/EhMx0+ZVxw=",
-          "range": "bytes=697-1082"
+          "checksum": "sha1-jhAhggAuZnU7FFHnebGA26mq+jI=",
+          "range": "bytes=695-1079"
         },
         "data": {
-          "checksum": "sha256-IfGWsH9qFzzKcdVENdnoZqPbAdejcokLcfm7Z53KnPM=",
-          "range": "bytes=1083-1197082"
+          "checksum": "sha256-XTCQYnhGSm7SkGwqV/TQMFqGajVJVYhKAidKfLb2D3Y=",
+          "range": "bytes=1080-1197081"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-CypiuHQ6EuduQ5uexXhBDv5YvvY=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-qVrfDVxubkrb5Yrd2mFTv2A0G7k=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r7.apk",
-        "version": "3.3.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r9.apk",
+        "version": "3.3.0-r9"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/search-indexer.lock.json
+++ b/wolfi-images/search-indexer.lock.json
@@ -204,41 +204,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q10Rr8mXMuAm4i4SjxE7xhsgs2UME=",
+        "checksum": "Q1gTZGkWP+QO3mUqLVJth8vrDEzzU=",
         "control": {
-          "checksum": "sha1-0Rr8mXMuAm4i4SjxE7xhsgs2UME=",
-          "range": "bytes=699-1079"
+          "checksum": "sha1-gTZGkWP+QO3mUqLVJth8vrDEzzU=",
+          "range": "bytes=699-1076"
         },
         "data": {
-          "checksum": "sha256-IVV0PRiJiwz4Ov1pWU1VAHf8cM0TgwqsV3vkYEQc0mM=",
-          "range": "bytes=1080-5915633"
+          "checksum": "sha256-/IFXqeKvU0GODNsz1yPIEMcFHgABT+8rbZpSlTLo4e4=",
+          "range": "bytes=1077-5915704"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-OlnuKCVUD1RpZgK+JyGdG/NQ0R0=",
+          "checksum": "sha1-l1o5ixkyWWqqJE3FOfR0QUemJUA=",
           "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r7.apk",
-        "version": "3.3.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r9.apk",
+        "version": "3.3.0-r9"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1xZQl4rSEEOs59w1q/EhMx0+ZVxw=",
+        "checksum": "Q1jhAhggAuZnU7FFHnebGA26mq+jI=",
         "control": {
-          "checksum": "sha1-xZQl4rSEEOs59w1q/EhMx0+ZVxw=",
-          "range": "bytes=697-1082"
+          "checksum": "sha1-jhAhggAuZnU7FFHnebGA26mq+jI=",
+          "range": "bytes=695-1079"
         },
         "data": {
-          "checksum": "sha256-IfGWsH9qFzzKcdVENdnoZqPbAdejcokLcfm7Z53KnPM=",
-          "range": "bytes=1083-1197082"
+          "checksum": "sha256-XTCQYnhGSm7SkGwqV/TQMFqGajVJVYhKAidKfLb2D3Y=",
+          "range": "bytes=1080-1197081"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-CypiuHQ6EuduQ5uexXhBDv5YvvY=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-qVrfDVxubkrb5Yrd2mFTv2A0G7k=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r7.apk",
-        "version": "3.3.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r9.apk",
+        "version": "3.3.0-r9"
       },
       {
         "architecture": "x86_64",
@@ -793,22 +793,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1eaot0B2H9IOF054RKMabXG37GUk=",
+        "checksum": "Q111Aq+tDFOygcfZzOg1hQbtZw1Q4=",
         "control": {
-          "checksum": "sha1-eaot0B2H9IOF054RKMabXG37GUk=",
-          "range": "bytes=700-1143"
+          "checksum": "sha1-11Aq+tDFOygcfZzOg1hQbtZw1Q4=",
+          "range": "bytes=697-1140"
         },
         "data": {
-          "checksum": "sha256-EeuQkVe5Hl+bqWfkBaMgA1Z2Fh91f1upncBbArJu9Gw=",
-          "range": "bytes=1144-17267929"
+          "checksum": "sha256-ednk20seorMQ+xEGnt8zWpxO20xrfj7zOtAmk+XcTbA=",
+          "range": "bytes=1141-17250210"
         },
         "name": "git",
         "signature": {
-          "checksum": "sha1-yMhNFUJ+emT/s9tdLDQ8zjT2+vY=",
-          "range": "bytes=0-699"
+          "checksum": "sha1-T1C3/QmQvuJGLjPH2YyOLIM5ewE=",
+          "range": "bytes=0-696"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/git-2.45.1-r0.apk",
-        "version": "2.45.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/git-2.45.2-r0.apk",
+        "version": "2.45.2-r0"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/searcher.lock.json
+++ b/wolfi-images/searcher.lock.json
@@ -204,41 +204,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q10Rr8mXMuAm4i4SjxE7xhsgs2UME=",
+        "checksum": "Q1gTZGkWP+QO3mUqLVJth8vrDEzzU=",
         "control": {
-          "checksum": "sha1-0Rr8mXMuAm4i4SjxE7xhsgs2UME=",
-          "range": "bytes=699-1079"
+          "checksum": "sha1-gTZGkWP+QO3mUqLVJth8vrDEzzU=",
+          "range": "bytes=699-1076"
         },
         "data": {
-          "checksum": "sha256-IVV0PRiJiwz4Ov1pWU1VAHf8cM0TgwqsV3vkYEQc0mM=",
-          "range": "bytes=1080-5915633"
+          "checksum": "sha256-/IFXqeKvU0GODNsz1yPIEMcFHgABT+8rbZpSlTLo4e4=",
+          "range": "bytes=1077-5915704"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-OlnuKCVUD1RpZgK+JyGdG/NQ0R0=",
+          "checksum": "sha1-l1o5ixkyWWqqJE3FOfR0QUemJUA=",
           "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r7.apk",
-        "version": "3.3.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r9.apk",
+        "version": "3.3.0-r9"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1xZQl4rSEEOs59w1q/EhMx0+ZVxw=",
+        "checksum": "Q1jhAhggAuZnU7FFHnebGA26mq+jI=",
         "control": {
-          "checksum": "sha1-xZQl4rSEEOs59w1q/EhMx0+ZVxw=",
-          "range": "bytes=697-1082"
+          "checksum": "sha1-jhAhggAuZnU7FFHnebGA26mq+jI=",
+          "range": "bytes=695-1079"
         },
         "data": {
-          "checksum": "sha256-IfGWsH9qFzzKcdVENdnoZqPbAdejcokLcfm7Z53KnPM=",
-          "range": "bytes=1083-1197082"
+          "checksum": "sha256-XTCQYnhGSm7SkGwqV/TQMFqGajVJVYhKAidKfLb2D3Y=",
+          "range": "bytes=1080-1197081"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-CypiuHQ6EuduQ5uexXhBDv5YvvY=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-qVrfDVxubkrb5Yrd2mFTv2A0G7k=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r7.apk",
-        "version": "3.3.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r9.apk",
+        "version": "3.3.0-r9"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/server.lock.json
+++ b/wolfi-images/server.lock.json
@@ -265,41 +265,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q10Rr8mXMuAm4i4SjxE7xhsgs2UME=",
+        "checksum": "Q1gTZGkWP+QO3mUqLVJth8vrDEzzU=",
         "control": {
-          "checksum": "sha1-0Rr8mXMuAm4i4SjxE7xhsgs2UME=",
-          "range": "bytes=699-1079"
+          "checksum": "sha1-gTZGkWP+QO3mUqLVJth8vrDEzzU=",
+          "range": "bytes=699-1076"
         },
         "data": {
-          "checksum": "sha256-IVV0PRiJiwz4Ov1pWU1VAHf8cM0TgwqsV3vkYEQc0mM=",
-          "range": "bytes=1080-5915633"
+          "checksum": "sha256-/IFXqeKvU0GODNsz1yPIEMcFHgABT+8rbZpSlTLo4e4=",
+          "range": "bytes=1077-5915704"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-OlnuKCVUD1RpZgK+JyGdG/NQ0R0=",
+          "checksum": "sha1-l1o5ixkyWWqqJE3FOfR0QUemJUA=",
           "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r7.apk",
-        "version": "3.3.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r9.apk",
+        "version": "3.3.0-r9"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1xZQl4rSEEOs59w1q/EhMx0+ZVxw=",
+        "checksum": "Q1jhAhggAuZnU7FFHnebGA26mq+jI=",
         "control": {
-          "checksum": "sha1-xZQl4rSEEOs59w1q/EhMx0+ZVxw=",
-          "range": "bytes=697-1082"
+          "checksum": "sha1-jhAhggAuZnU7FFHnebGA26mq+jI=",
+          "range": "bytes=695-1079"
         },
         "data": {
-          "checksum": "sha256-IfGWsH9qFzzKcdVENdnoZqPbAdejcokLcfm7Z53KnPM=",
-          "range": "bytes=1083-1197082"
+          "checksum": "sha256-XTCQYnhGSm7SkGwqV/TQMFqGajVJVYhKAidKfLb2D3Y=",
+          "range": "bytes=1080-1197081"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-CypiuHQ6EuduQ5uexXhBDv5YvvY=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-qVrfDVxubkrb5Yrd2mFTv2A0G7k=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r7.apk",
-        "version": "3.3.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r9.apk",
+        "version": "3.3.0-r9"
       },
       {
         "architecture": "x86_64",
@@ -949,79 +949,79 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1eaot0B2H9IOF054RKMabXG37GUk=",
+        "checksum": "Q111Aq+tDFOygcfZzOg1hQbtZw1Q4=",
         "control": {
-          "checksum": "sha1-eaot0B2H9IOF054RKMabXG37GUk=",
-          "range": "bytes=700-1143"
+          "checksum": "sha1-11Aq+tDFOygcfZzOg1hQbtZw1Q4=",
+          "range": "bytes=697-1140"
         },
         "data": {
-          "checksum": "sha256-EeuQkVe5Hl+bqWfkBaMgA1Z2Fh91f1upncBbArJu9Gw=",
-          "range": "bytes=1144-17267929"
+          "checksum": "sha256-ednk20seorMQ+xEGnt8zWpxO20xrfj7zOtAmk+XcTbA=",
+          "range": "bytes=1141-17250210"
         },
         "name": "git",
         "signature": {
-          "checksum": "sha1-yMhNFUJ+emT/s9tdLDQ8zjT2+vY=",
-          "range": "bytes=0-699"
+          "checksum": "sha1-T1C3/QmQvuJGLjPH2YyOLIM5ewE=",
+          "range": "bytes=0-696"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/git-2.45.1-r0.apk",
-        "version": "2.45.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/git-2.45.2-r0.apk",
+        "version": "2.45.2-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q116m2Q5Ln3gJz05D1gRD/3AQz9+4=",
+        "checksum": "Q1UmMIPtQRrPW2HlaR66LPULlD5AU=",
         "control": {
-          "checksum": "sha1-16m2Q5Ln3gJz05D1gRD/3AQz9+4=",
-          "range": "bytes=703-1102"
+          "checksum": "sha1-UmMIPtQRrPW2HlaR66LPULlD5AU=",
+          "range": "bytes=700-1063"
         },
         "data": {
-          "checksum": "sha256-nU1+NEgt7CR9vsxeCs5Hr9tHiSAw69pxvz+m0W+N+PI=",
-          "range": "bytes=1103-11855891"
+          "checksum": "sha256-Rwf835Uhc/sjB+t9aRxnTWZ8KMZUxlLzZVOG4hawVYI=",
+          "range": "bytes=1064-12733213"
         },
         "name": "git-lfs",
         "signature": {
-          "checksum": "sha1-z3BWu5hxd1KVtIrVNwIYsNsgYpc=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-03OxiuAmYPciOddmufs49rJLRw4=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/git-lfs-3.5.1-r4.apk",
-        "version": "3.5.1-r4"
+        "url": "https://packages.wolfi.dev/os/x86_64/git-lfs-3.5.1-r5.apk",
+        "version": "3.5.1-r5"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1AtyQ8BGxIy54FTCVfU4vA3dBujA=",
+        "checksum": "Q1/xjUDpfwOCMLFmAYUyXK3hbr7M8=",
         "control": {
-          "checksum": "sha1-AtyQ8BGxIy54FTCVfU4vA3dBujA=",
-          "range": "bytes=696-1105"
+          "checksum": "sha1-/xjUDpfwOCMLFmAYUyXK3hbr7M8=",
+          "range": "bytes=703-1114"
         },
         "data": {
-          "checksum": "sha256-jm7jYqIpUa8S3qayJMbb10cks4vaQbqkkl7r95+SUvc=",
-          "range": "bytes=1106-7568791"
+          "checksum": "sha256-RvBzvJt//AAv6DeDRxBbbW2UG//3UZ38sDmhcMQoRKY=",
+          "range": "bytes=1115-7560368"
         },
         "name": "git-daemon",
         "signature": {
-          "checksum": "sha1-WouI+0ZflydIMa2FK5A7CtGW7Uo=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-dHYurOENIvRxIuBAaHNAeJGQciA=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/git-daemon-2.45.1-r0.apk",
-        "version": "2.45.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/git-daemon-2.45.2-r0.apk",
+        "version": "2.45.2-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1bxdUk5Zm+DGJ1BJRhi+4lVqQC8M=",
+        "checksum": "Q1lmZVnMVaV+BuJ4Zw8v1gIkGVcNc=",
         "control": {
-          "checksum": "sha1-bxdUk5Zm+DGJ1BJRhi+4lVqQC8M=",
-          "range": "bytes=707-1078"
+          "checksum": "sha1-lmZVnMVaV+BuJ4Zw8v1gIkGVcNc=",
+          "range": "bytes=696-1069"
         },
         "data": {
-          "checksum": "sha256-n6UB0PG6Q3zvEhvY9YG0J+5fLLQy52aoHxuc/8mNhDo=",
-          "range": "bytes=1079-211589"
+          "checksum": "sha256-qHYsorfTKRzalTN5p+JzwEZ2NYXNkxiHME9MoyMfeRI=",
+          "range": "bytes=1070-212142"
         },
         "name": "git-p4",
         "signature": {
-          "checksum": "sha1-7GOnoDsQV3oKBXD6jIlMaFHpzxQ=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-eGGtsdgoIw2il+9a5ZT/t126v0c=",
+          "range": "bytes=0-695"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/git-p4-2.45.1-r0.apk",
-        "version": "2.45.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/git-p4-2.45.2-r0.apk",
+        "version": "2.45.2-r0"
       },
       {
         "architecture": "x86_64",
@@ -1063,41 +1063,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q191zIDDWGGmlnPpIVN5G3rE+byGo=",
+        "checksum": "Q1YNMkEDZUT73AEO3r2L/SONbEkl8=",
         "control": {
-          "checksum": "sha1-91zIDDWGGmlnPpIVN5G3rE+byGo=",
-          "range": "bytes=702-1158"
+          "checksum": "sha1-YNMkEDZUT73AEO3r2L/SONbEkl8=",
+          "range": "bytes=700-1156"
         },
         "data": {
-          "checksum": "sha256-W6OeWteP3G5aA4Ko3o/D17L/8HTM93vIw0SvQPbReso=",
-          "range": "bytes=1159-1349570"
+          "checksum": "sha256-LCPH1hwVcSqZ1iOofX4m+rq0E1XSqWjqlPMKbCUCyUE=",
+          "range": "bytes=1157-1350119"
         },
         "name": "nginx-stable",
         "signature": {
-          "checksum": "sha1-fR0bq7hY8qNjhML4kkjR0NEffMs=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-TupCz6/CbQTgfmc1B4b0ffEpzwU=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nginx-stable-1.26.0-r0.apk",
-        "version": "1.26.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/nginx-stable-1.26.1-r0.apk",
+        "version": "1.26.1-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q172cAKkkDUKFCNimN+lEf7gxZcO8=",
+        "checksum": "Q1KPos8bEMcG+uuEvNts/rdK6Ir3U=",
         "control": {
-          "checksum": "sha1-72cAKkkDUKFCNimN+lEf7gxZcO8=",
-          "range": "bytes=698-1094"
+          "checksum": "sha1-KPos8bEMcG+uuEvNts/rdK6Ir3U=",
+          "range": "bytes=697-1093"
         },
         "data": {
-          "checksum": "sha256-LGjTn0CCGKvgW1cBIrzzQAaWYNfdRXiRKBa6mBLnddU=",
-          "range": "bytes=1095-61313"
+          "checksum": "sha256-Og1whDqZuZsQvvWlFWqJoiufM3LeQd2UnXWp0t1pgOE=",
+          "range": "bytes=1094-61862"
         },
         "name": "nginx-stable-config",
         "signature": {
-          "checksum": "sha1-PcxbsesHLvLbanvDf0hRZQEeO9c=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-XFg1RNfh3QHkleHBs1wjtbSMLng=",
+          "range": "bytes=0-696"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nginx-stable-config-1.26.0-r0.apk",
-        "version": "1.26.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/nginx-stable-config-1.26.1-r0.apk",
+        "version": "1.26.1-r0"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/sourcegraph-base.lock.json
+++ b/wolfi-images/sourcegraph-base.lock.json
@@ -204,41 +204,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q10Rr8mXMuAm4i4SjxE7xhsgs2UME=",
+        "checksum": "Q1gTZGkWP+QO3mUqLVJth8vrDEzzU=",
         "control": {
-          "checksum": "sha1-0Rr8mXMuAm4i4SjxE7xhsgs2UME=",
-          "range": "bytes=699-1079"
+          "checksum": "sha1-gTZGkWP+QO3mUqLVJth8vrDEzzU=",
+          "range": "bytes=699-1076"
         },
         "data": {
-          "checksum": "sha256-IVV0PRiJiwz4Ov1pWU1VAHf8cM0TgwqsV3vkYEQc0mM=",
-          "range": "bytes=1080-5915633"
+          "checksum": "sha256-/IFXqeKvU0GODNsz1yPIEMcFHgABT+8rbZpSlTLo4e4=",
+          "range": "bytes=1077-5915704"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-OlnuKCVUD1RpZgK+JyGdG/NQ0R0=",
+          "checksum": "sha1-l1o5ixkyWWqqJE3FOfR0QUemJUA=",
           "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r7.apk",
-        "version": "3.3.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r9.apk",
+        "version": "3.3.0-r9"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1xZQl4rSEEOs59w1q/EhMx0+ZVxw=",
+        "checksum": "Q1jhAhggAuZnU7FFHnebGA26mq+jI=",
         "control": {
-          "checksum": "sha1-xZQl4rSEEOs59w1q/EhMx0+ZVxw=",
-          "range": "bytes=697-1082"
+          "checksum": "sha1-jhAhggAuZnU7FFHnebGA26mq+jI=",
+          "range": "bytes=695-1079"
         },
         "data": {
-          "checksum": "sha256-IfGWsH9qFzzKcdVENdnoZqPbAdejcokLcfm7Z53KnPM=",
-          "range": "bytes=1083-1197082"
+          "checksum": "sha256-XTCQYnhGSm7SkGwqV/TQMFqGajVJVYhKAidKfLb2D3Y=",
+          "range": "bytes=1080-1197081"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-CypiuHQ6EuduQ5uexXhBDv5YvvY=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-qVrfDVxubkrb5Yrd2mFTv2A0G7k=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r7.apk",
-        "version": "3.3.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r9.apk",
+        "version": "3.3.0-r9"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/sourcegraph-dev.lock.json
+++ b/wolfi-images/sourcegraph-dev.lock.json
@@ -128,41 +128,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q10Rr8mXMuAm4i4SjxE7xhsgs2UME=",
+        "checksum": "Q1gTZGkWP+QO3mUqLVJth8vrDEzzU=",
         "control": {
-          "checksum": "sha1-0Rr8mXMuAm4i4SjxE7xhsgs2UME=",
-          "range": "bytes=699-1079"
+          "checksum": "sha1-gTZGkWP+QO3mUqLVJth8vrDEzzU=",
+          "range": "bytes=699-1076"
         },
         "data": {
-          "checksum": "sha256-IVV0PRiJiwz4Ov1pWU1VAHf8cM0TgwqsV3vkYEQc0mM=",
-          "range": "bytes=1080-5915633"
+          "checksum": "sha256-/IFXqeKvU0GODNsz1yPIEMcFHgABT+8rbZpSlTLo4e4=",
+          "range": "bytes=1077-5915704"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-OlnuKCVUD1RpZgK+JyGdG/NQ0R0=",
+          "checksum": "sha1-l1o5ixkyWWqqJE3FOfR0QUemJUA=",
           "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r7.apk",
-        "version": "3.3.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r9.apk",
+        "version": "3.3.0-r9"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1xZQl4rSEEOs59w1q/EhMx0+ZVxw=",
+        "checksum": "Q1jhAhggAuZnU7FFHnebGA26mq+jI=",
         "control": {
-          "checksum": "sha1-xZQl4rSEEOs59w1q/EhMx0+ZVxw=",
-          "range": "bytes=697-1082"
+          "checksum": "sha1-jhAhggAuZnU7FFHnebGA26mq+jI=",
+          "range": "bytes=695-1079"
         },
         "data": {
-          "checksum": "sha256-IfGWsH9qFzzKcdVENdnoZqPbAdejcokLcfm7Z53KnPM=",
-          "range": "bytes=1083-1197082"
+          "checksum": "sha256-XTCQYnhGSm7SkGwqV/TQMFqGajVJVYhKAidKfLb2D3Y=",
+          "range": "bytes=1080-1197081"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-CypiuHQ6EuduQ5uexXhBDv5YvvY=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-qVrfDVxubkrb5Yrd2mFTv2A0G7k=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r7.apk",
-        "version": "3.3.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r9.apk",
+        "version": "3.3.0-r9"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/sourcegraph-template.lock.json
+++ b/wolfi-images/sourcegraph-template.lock.json
@@ -204,41 +204,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q10Rr8mXMuAm4i4SjxE7xhsgs2UME=",
+        "checksum": "Q1gTZGkWP+QO3mUqLVJth8vrDEzzU=",
         "control": {
-          "checksum": "sha1-0Rr8mXMuAm4i4SjxE7xhsgs2UME=",
-          "range": "bytes=699-1079"
+          "checksum": "sha1-gTZGkWP+QO3mUqLVJth8vrDEzzU=",
+          "range": "bytes=699-1076"
         },
         "data": {
-          "checksum": "sha256-IVV0PRiJiwz4Ov1pWU1VAHf8cM0TgwqsV3vkYEQc0mM=",
-          "range": "bytes=1080-5915633"
+          "checksum": "sha256-/IFXqeKvU0GODNsz1yPIEMcFHgABT+8rbZpSlTLo4e4=",
+          "range": "bytes=1077-5915704"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-OlnuKCVUD1RpZgK+JyGdG/NQ0R0=",
+          "checksum": "sha1-l1o5ixkyWWqqJE3FOfR0QUemJUA=",
           "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r7.apk",
-        "version": "3.3.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r9.apk",
+        "version": "3.3.0-r9"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1xZQl4rSEEOs59w1q/EhMx0+ZVxw=",
+        "checksum": "Q1jhAhggAuZnU7FFHnebGA26mq+jI=",
         "control": {
-          "checksum": "sha1-xZQl4rSEEOs59w1q/EhMx0+ZVxw=",
-          "range": "bytes=697-1082"
+          "checksum": "sha1-jhAhggAuZnU7FFHnebGA26mq+jI=",
+          "range": "bytes=695-1079"
         },
         "data": {
-          "checksum": "sha256-IfGWsH9qFzzKcdVENdnoZqPbAdejcokLcfm7Z53KnPM=",
-          "range": "bytes=1083-1197082"
+          "checksum": "sha256-XTCQYnhGSm7SkGwqV/TQMFqGajVJVYhKAidKfLb2D3Y=",
+          "range": "bytes=1080-1197081"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-CypiuHQ6EuduQ5uexXhBDv5YvvY=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-qVrfDVxubkrb5Yrd2mFTv2A0G7k=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r7.apk",
-        "version": "3.3.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r9.apk",
+        "version": "3.3.0-r9"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/symbols.lock.json
+++ b/wolfi-images/symbols.lock.json
@@ -204,41 +204,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q10Rr8mXMuAm4i4SjxE7xhsgs2UME=",
+        "checksum": "Q1gTZGkWP+QO3mUqLVJth8vrDEzzU=",
         "control": {
-          "checksum": "sha1-0Rr8mXMuAm4i4SjxE7xhsgs2UME=",
-          "range": "bytes=699-1079"
+          "checksum": "sha1-gTZGkWP+QO3mUqLVJth8vrDEzzU=",
+          "range": "bytes=699-1076"
         },
         "data": {
-          "checksum": "sha256-IVV0PRiJiwz4Ov1pWU1VAHf8cM0TgwqsV3vkYEQc0mM=",
-          "range": "bytes=1080-5915633"
+          "checksum": "sha256-/IFXqeKvU0GODNsz1yPIEMcFHgABT+8rbZpSlTLo4e4=",
+          "range": "bytes=1077-5915704"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-OlnuKCVUD1RpZgK+JyGdG/NQ0R0=",
+          "checksum": "sha1-l1o5ixkyWWqqJE3FOfR0QUemJUA=",
           "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r7.apk",
-        "version": "3.3.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r9.apk",
+        "version": "3.3.0-r9"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1xZQl4rSEEOs59w1q/EhMx0+ZVxw=",
+        "checksum": "Q1jhAhggAuZnU7FFHnebGA26mq+jI=",
         "control": {
-          "checksum": "sha1-xZQl4rSEEOs59w1q/EhMx0+ZVxw=",
-          "range": "bytes=697-1082"
+          "checksum": "sha1-jhAhggAuZnU7FFHnebGA26mq+jI=",
+          "range": "bytes=695-1079"
         },
         "data": {
-          "checksum": "sha256-IfGWsH9qFzzKcdVENdnoZqPbAdejcokLcfm7Z53KnPM=",
-          "range": "bytes=1083-1197082"
+          "checksum": "sha256-XTCQYnhGSm7SkGwqV/TQMFqGajVJVYhKAidKfLb2D3Y=",
+          "range": "bytes=1080-1197081"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-CypiuHQ6EuduQ5uexXhBDv5YvvY=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-qVrfDVxubkrb5Yrd2mFTv2A0G7k=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r7.apk",
-        "version": "3.3.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r9.apk",
+        "version": "3.3.0-r9"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/syntax-highlighter.lock.json
+++ b/wolfi-images/syntax-highlighter.lock.json
@@ -204,41 +204,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q10Rr8mXMuAm4i4SjxE7xhsgs2UME=",
+        "checksum": "Q1gTZGkWP+QO3mUqLVJth8vrDEzzU=",
         "control": {
-          "checksum": "sha1-0Rr8mXMuAm4i4SjxE7xhsgs2UME=",
-          "range": "bytes=699-1079"
+          "checksum": "sha1-gTZGkWP+QO3mUqLVJth8vrDEzzU=",
+          "range": "bytes=699-1076"
         },
         "data": {
-          "checksum": "sha256-IVV0PRiJiwz4Ov1pWU1VAHf8cM0TgwqsV3vkYEQc0mM=",
-          "range": "bytes=1080-5915633"
+          "checksum": "sha256-/IFXqeKvU0GODNsz1yPIEMcFHgABT+8rbZpSlTLo4e4=",
+          "range": "bytes=1077-5915704"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-OlnuKCVUD1RpZgK+JyGdG/NQ0R0=",
+          "checksum": "sha1-l1o5ixkyWWqqJE3FOfR0QUemJUA=",
           "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r7.apk",
-        "version": "3.3.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r9.apk",
+        "version": "3.3.0-r9"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1xZQl4rSEEOs59w1q/EhMx0+ZVxw=",
+        "checksum": "Q1jhAhggAuZnU7FFHnebGA26mq+jI=",
         "control": {
-          "checksum": "sha1-xZQl4rSEEOs59w1q/EhMx0+ZVxw=",
-          "range": "bytes=697-1082"
+          "checksum": "sha1-jhAhggAuZnU7FFHnebGA26mq+jI=",
+          "range": "bytes=695-1079"
         },
         "data": {
-          "checksum": "sha256-IfGWsH9qFzzKcdVENdnoZqPbAdejcokLcfm7Z53KnPM=",
-          "range": "bytes=1083-1197082"
+          "checksum": "sha256-XTCQYnhGSm7SkGwqV/TQMFqGajVJVYhKAidKfLb2D3Y=",
+          "range": "bytes=1080-1197081"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-CypiuHQ6EuduQ5uexXhBDv5YvvY=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-qVrfDVxubkrb5Yrd2mFTv2A0G7k=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r7.apk",
-        "version": "3.3.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r9.apk",
+        "version": "3.3.0-r9"
       },
       {
         "architecture": "x86_64",


### PR DESCRIPTION
Automatically generated PR to update package lockfiles for Sourcegraph base images.

Built from Buildkite run [#275868](https://buildkite.com/sourcegraph/sourcegraph/builds/275868).
## Test Plan
- CI build verifies image functionality