### PR TITLE
chore(sg): cloud ephemeral - account for conclusion field

### DIFF
--- a/dev/sg/internal/cloud/instance.go
+++ b/dev/sg/internal/cloud/instance.go
@@ -71,12 +71,10 @@ DeletetAt    : %s
 ExpiresAt    : %s
 Project      : %s
 Region       : %s
-Status       : %s %s
-ActionURL    : %s
-Error        : %s
+%s
 `, i.ID, i.Name, i.InstanceType, i.Environment, i.Version, i.URL, i.AdminEmail,
 		fmtTime(i.CreatedAt), fmtTime(i.DeletedAt), fmtTime(i.ExpiresAt), i.Project, i.Region,
-		i.Status.Status, i.Status.Reason.GetStepPhaseString(), i.Status.Reason.GetJobURLStateString(), i.Status.Error)
+		i.Status.String())
 }
 
 func (i *Instance) IsEphemeral() bool {
@@ -110,23 +108,30 @@ type StatusReason struct {
 	Phase    string `json:"phase"`
 	JobURL   string `json:"job_url"`
 	JobState string `json:"job_state"`
+	Overall  string `json:"overall"`
 }
 
 func newStatusReason(reason string) (StatusReason, error) {
 	if reason == "" {
 		return StatusReason{}, nil
 	}
-	// step 1/3:creating instance, job-url:https://github.com/sourcegraph/cloud/actions/runs/9209264595, state:in_progress
-	statusRegex := regexp.MustCompile(`^step (\d\/\d):(.*), job-url:(.*), state:(\w+)$`)
+	// step 1/3:creating instance, job-url:https://github.com/sourcegraph/cloud/actions/runs/9209264595, state:in_progress, conclusion: failed
+	statusRegex := regexp.MustCompile(`^step (\d\/\d):(.*), job-url:(.*), state:(\w+)(, conclusion:(\w+))?$`)
 	matches := statusRegex.FindStringSubmatch(reason)
-	if len(matches) != 5 {
+	// if matches is 7, it means we have a conclusion, if matches is 5 then we don't have aa conclusion
+	if len(matches) != 5 && len(matches) != 7 {
 		return StatusReason{}, errors.Newf("failed to parse status reason: %q", reason)
+	}
+	var conclusion string
+	if len(matches) == 7 {
+		conclusion = matches[6]
 	}
 	return StatusReason{
 		Step:     matches[1],
 		Phase:    matches[2],
 		JobURL:   matches[3],
 		JobState: matches[4],
+		Overall:  conclusion,
 	}, nil
 }
 
@@ -147,11 +152,12 @@ func (s *StatusReason) GetJobURLStateString() string {
 }
 
 func (s *InstanceStatus) String() string {
-	return fmt.Sprintf(`Status: %s
-Step: %s
-Phase: %s
-JobURL: %s
-JobState: %s`, s.Status, s.Reason.Step, s.Reason.Phase, s.Reason.JobURL, s.Reason.JobState)
+	return fmt.Sprintf(`Status       : %s
+Step         : %s
+Phase        : %s
+JobURL       : %s
+JobState     : %s
+Overall      : %s`, s.Status, s.Reason.Step, s.Reason.Phase, s.Reason.JobURL, s.Reason.JobState, s.Reason.Overall)
 }
 
 type InstanceFeatures struct {

--- a/dev/sg/internal/cloud/printers.go
+++ b/dev/sg/internal/cloud/printers.go
@@ -47,7 +47,7 @@ func newDefaultTerminalInstancePrinter() *terminalInstancePrinter {
 		if inst.Status.Reason.JobURL != "" {
 			actionURL = inst.Status.Reason.JobURL
 			if inst.Status.Reason.JobState != "" {
-				actionURL = " (" + inst.Status.Reason.JobState + ")"
+				actionURL += " (" + inst.Status.Reason.JobState + ")"
 			}
 		}
 		expiresAt := "n/a"
@@ -60,7 +60,7 @@ func newDefaultTerminalInstancePrinter() *terminalInstancePrinter {
 		}
 
 	}
-	return newTerminalInstancePrinter(valueFunc, "%-40s %-20s %-20s %s", "Name", "Expires At", "Status", "ActionURL")
+	return newTerminalInstancePrinter(valueFunc, "%-40s %-20s %-40s %s", "Name", "Expires At", "Status", "JobURL")
 }
 
 func newTerminalInstancePrinter(valueFunc func(i *Instance) []any, headingFmt string, headings ...string) *terminalInstancePrinter {
@@ -81,7 +81,7 @@ func (p *terminalInstancePrinter) Print(items ...*Instance) error {
 	std.Out.WriteLine(output.Line("", output.StyleBold, heading))
 	for _, inst := range items {
 		values := p.valueFunc(inst)
-		line := fmt.Sprintf("%-40s %-20s %-20s %s", values...)
+		line := fmt.Sprintf("%-40s %-20s %-40s %s", values...)
 		std.Out.WriteLine(output.Line("", output.StyleGrey, line))
 	}
 


### PR DESCRIPTION
The reason field my contain `, conclusion` and sometimes it might not. This accounts for this case and gracefully handles it it is missing

## Test plan
Tested locally
Failure
```
go run ./dev/sg cloud eph status --name wb-feature-x --raw
❌ getting status of "wb-feature-x" failed
❌ failed to parse status reason: "step 1/3:creating instance, job-url:https://github.com/sourcegraph/cloud/actions/runs/9251869285, state:completed, conclusion:failure" 7
exit status 1
```
Fixed
```
go run ./dev/sg cloud eph status --name wb-feature-x --raw
✅ Ephemeral instance "wb-feature-x" status retrieved
Ephemeral instance details:
ID           : src-1eadb696458496ba7407
Name         : wb-feature-x
InstanceType : internal
Environment  : dev
Version      : wb-feature-x_275730_2024-05-27_5.4-d23e2bfd524d
URL          : https://wb-feature-x.sgdev.dev
AdminEmail   :
CreatedAt    : n/a
DeletetAt    : n/a
ExpiresAt    : n/a
Project      : src-94593c750106b959d519
Region       : us-central1
Status       : in-progress
Step         : 1/3
Phase        : creating instance
JobURL       : https://github.com/sourcegraph/cloud/actions/runs/9251869285
JobState     : completed
Overall      : failure
```