### PR TITLE
codeintel: Add stub implementation for usagesForSymbol API

### DIFF
--- a/cmd/frontend/graphqlbackend/codeintel.codenav.graphql
+++ b/cmd/frontend/graphqlbackend/codeintel.codenav.graphql
@@ -411,6 +411,280 @@ type GitBlobLSIFData implements TreeEntryLSIFData {
     snapshot(indexID: ID!): [SnapshotData!]
 }
 
+extend type Query {
+    """
+    Identify usages for either a semantic symbol, or the symbol(s) implied
+    by a source range.
+    Ordering and uniqueness guarantees:
+    1. The usages returned will already be de-duplicated.
+    2. Results for a single file are contiguous.
+    3. Results for a single repository are contiguous.
+    Related: See `codeGraphData` on GitBlob.
+
+    EXPERIMENTAL: This API may make backwards-incompatible changes in the future.
+    """
+    usagesForSymbol(
+        """
+        Symbol to perform the lookup for.
+        If provided, then the start and end position in `range` are optional.
+        If not provided, and if multiple symbols are detected at the same range,
+        the combined results for all symbols will be returned.
+        In that case, `Usage.symbol.name` can be used to group results.
+        """
+        symbol: SymbolComparator,
+
+        """
+        Information about an existing source range for a usage of the symbol.
+        TODO: Specify behavior for various cases of overlap between LookupRange
+        and actual occurrence range.
+        """
+        range: RangeInput!,
+
+        """
+        Filter to allow customization of returned results.
+        """
+        filter: UsagesFilter,
+
+        """
+        When specified, indicates that this request should be paginated and
+        the first N results (relative to the cursor) should be returned. i.e.
+        how many results to return per page.
+        """
+        first: Int
+
+        """
+        When specified, indicates that this request should be paginated and
+        to fetch results starting at this cursor.
+        A future request can be made for more results by passing in the
+        'UsageConnection.pageInfo.endCursor' that is returned.
+        """
+        after: String
+    ): UsageConnection!
+}
+
+"""
+EXPERIMENTAL: This type may make backwards-incompatible changes in the future.
+"""
+input SymbolComparator {
+    name: SymbolNameComparator!
+    provenance: CodeGraphDataProvenanceComparator!
+}
+
+"""
+EXPERIMENTAL: This type may make backwards-incompatible changes in the future.
+"""
+# Implementation note: In the future, we may want to extend this
+# to allow passing in a suffix or a "symbol pattern".
+# See https://github.com/sourcegraph/sourcegraph/issues/59957
+input SymbolNameComparator {
+    equals: String
+}
+
+"""
+A range inside a particular blob.
+
+EXPERIMENTAL: This type may make backwards-incompatible changes in the future.
+"""
+input RangeInput {
+    """
+    Defaults to instance-wide search if the repo is not specified.
+    This field is necessary if SymbolComparator is a repository-local or
+    file-local symbol. It is mandatory for cross-repository symbols
+    due to implementation limitations.
+    """
+    repository: String!
+
+    """
+    Defaults to HEAD of the default branch if not specified.
+    """
+    revision: String
+
+    """
+    Defaults to repo-wide search if the path is not specified.
+    This field is necessary if SymbolComparator is a file-local symbol.
+    It is mandatory for repository-local and cross-repo symbols
+    due to implementation limitations.
+    """
+    path: String!
+
+    """
+    Start position of the range (inclusive)
+    """
+    start: PositionInput
+
+    """
+    End position of the range (exclusive)
+    """
+    end: PositionInput
+}
+
+"""
+Analogous to Position but as an input type.
+
+EXPERIMENTAL: This type may make backwards-incompatible changes in the future.
+"""
+input PositionInput {
+    """
+    Zero-based count of newline (\n or \r\n) characters before this position.
+    """
+    line: Int!
+
+    """
+    Zero-based UTF-16 code unit offset from preceding newline (\n or \r\n) character.
+    """
+    character: Int!
+}
+
+# NOTE(id: filter-vs-comparator-terminology)
+#
+# 'Filter' is used for complex objects whereas 'Comparator' is used
+# for primitive objects.
+
+"""
+An empty filter allows all kinds of usages for all paths in all repositories.
+
+However, if the symbol used for lookup is a file-local symbol or a
+repository-local symbol, then usages will automatically be limited to the
+same file or same repository respectively.
+
+EXPERIMENTAL: This type may make backwards-incompatible changes in the future.
+"""
+# Design Rationale:
+#
+# 1. The ref panel did separate queries for 'this repo' vs 'all other repos'
+#    https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/client/web/src/enterprise/codeintel/searchBased.ts?L105:13-105:23#tab=references
+#    That requires `NOT` (at least for a `repo`).
+# 2. The ref panel has a way to specify paths for filtering. This requires AND.
+#    AND will not be part of the first implementation pass. However,
+#    it would allow fetching less data instead of post-filtering client-side.
+# 3. Currently, the ref panel has a setting for only showing precise results.
+#    Once syntactic is added, if we want to allow the user to specify either
+#    syntactic or precise (but not search-based), we'd need OR.
+#    OR will also not be needed for the first implementation pass.
+input UsagesFilter {
+    not: UsagesFilter
+    repository: RepositoryFilter
+    # TODO(id: usagesForSymbols-v2)
+    # and: [UsagesFilter!]
+    # or: [UsagesFilter!]
+    # path: PathFilter
+    # kind: SymbolUsageKindComparator
+    # provenance: CodeGraphDataProvenanceComparator
+}
+
+"""
+EXPERIMENTAL: This type may make backwards-incompatible changes in the future.
+"""
+input RepositoryFilter {
+    name: StringComparator!
+}
+
+"""
+EXPERIMENTAL: This type may make backwards-incompatible changes in the future.
+"""
+input StringComparator {
+    equals: String
+}
+
+"""
+EXPERIMENTAL: This type may make backwards-incompatible changes in the future.
+"""
+type UsageConnection {
+    nodes: [Usage!]!
+    pageInfo: PageInfo!
+}
+
+"""
+EXPERIMENTAL: This type may make backwards-incompatible changes in the future.
+"""
+type UsageRange {
+    repository: String!
+    """
+    TODO(issue: GRAPH-614): 'revision' field should have type GitCommit
+    before stabilizing this API.
+    """
+    revision: String!
+    path: String!
+    range: Range!
+}
+
+"""
+A place where a symbol is used (defined, referenced, forward-declared, etc.)
+
+EXPERIMENTAL: This type may make backwards-incompatible changes in the future.
+"""
+type Usage {
+    """
+    Information about the symbol itself.
+    """
+    symbol: SymbolInformation!
+
+    # Q: Should we remove functionality from UsageRange and punt more
+    # functionality to `blob: GitBlob`?
+    # """
+    # Invariant: `range.path` == `blob.path`. The path is made available
+    # as part of this type for convenience.
+    # """
+    usageRange: UsageRange
+
+    # TODO: Add a blob: GitBlob field here for more flexibility?
+
+    """
+    Allows accessing a sub-span of the content using relative coordinates
+    from the range of this usage. If linesBefore or linesAfter is negative
+    or exceeds the number of available lines, the value is interpreted as
+    until the start/end of the file.
+    """
+    surroundingContent(surroundingLines: SurroundingLines = {linesBefore: 0, linesAfter: 0}): String
+}
+
+"""
+Type representing useful information about a symbol in code,
+based on 'SymbolInformation' in SCIP.
+
+EXPERIMENTAL: This type may make backwards-incompatible changes in the future.
+"""
+type SymbolInformation {
+    """
+    Symbol name using syntax specified by the SCIP schema.
+    https://github.com/sourcegraph/scip/blob/main/scip.proto#L147-L188
+    This value will generally be used in conjunction with
+    the `usagesBySymbol` API.
+    """
+    name: String!
+
+    """
+    Hover documentation for the symbol, in Markdown format.
+    The caller must take care to escape any particular strings,
+    such as raw HTML, as necessary.
+    The value is null when the hover documentation is not found
+    by 'dataSource'.
+    The value is empty when `dataSource` is confident that there
+    is no appropriate hover documentation to display.
+    """
+    documentation: [String!]
+
+    """
+    Coarse-grained information about the data source.
+    """
+    provenance: CodeGraphDataProvenance!
+
+    """
+    Opaque fine-grained information describing the data source.
+    Provided only for debugging.
+    This field should be ignored when checking structural equality.
+    """
+    dataSource: String
+}
+
+"""
+EXPERIMENTAL: This type may make backwards-incompatible changes in the future.
+"""
+input SurroundingLines {
+    linesBefore: Int
+    linesAfter: Int
+}
+
 """
 The SCIP snapshot decoration for a single SCIP Occurrence.
 """

--- a/cmd/frontend/graphqlbackend/codeintel.codenav.graphql
+++ b/cmd/frontend/graphqlbackend/codeintel.codenav.graphql
@@ -431,19 +431,19 @@ extend type Query {
         the combined results for all symbols will be returned.
         In that case, `Usage.symbol.name` can be used to group results.
         """
-        symbol: SymbolComparator
+        symbol: SymbolComparator,
 
         """
         Information about an existing source range for a usage of the symbol.
         TODO: Specify behavior for various cases of overlap between LookupRange
         and actual occurrence range.
         """
-        range: RangeInput!
+        range: RangeInput!,
 
         """
         Filter to allow customization of returned results.
         """
-        filter: UsagesFilter
+        filter: UsagesFilter,
 
         """
         When specified, indicates that this request should be paginated and
@@ -473,10 +473,10 @@ input SymbolComparator {
 """
 EXPERIMENTAL: This type may make backwards-incompatible changes in the future.
 """
-input # Implementation note: In the future, we may want to extend this
+# Implementation note: In the future, we may want to extend this
 # to allow passing in a suffix or a "symbol pattern".
 # See https://github.com/sourcegraph/sourcegraph/issues/59957
-SymbolNameComparator {
+input SymbolNameComparator {
     equals: String
 }
 
@@ -549,7 +549,7 @@ same file or same repository respectively.
 
 EXPERIMENTAL: This type may make backwards-incompatible changes in the future.
 """
-input # Design Rationale:
+# Design Rationale:
 #
 # 1. The ref panel did separate queries for 'this repo' vs 'all other repos'
 #    https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/client/web/src/enterprise/codeintel/searchBased.ts?L105:13-105:23#tab=references
@@ -561,7 +561,7 @@ input # Design Rationale:
 #    Once syntactic is added, if we want to allow the user to specify either
 #    syntactic or precise (but not search-based), we'd need OR.
 #    OR will also not be needed for the first implementation pass.
-UsagesFilter {
+input UsagesFilter {
     not: UsagesFilter
     repository: RepositoryFilter
     # TODO(id: usagesForSymbols-v2)
@@ -635,7 +635,7 @@ type Usage {
     or exceeds the number of available lines, the value is interpreted as
     until the start/end of the file.
     """
-    surroundingContent(surroundingLines: SurroundingLines = { linesBefore: 0, linesAfter: 0 }): String
+    surroundingContent(surroundingLines: SurroundingLines = {linesBefore: 0, linesAfter: 0}): String
 }
 
 """

--- a/cmd/frontend/graphqlbackend/codeintel.codenav.graphql
+++ b/cmd/frontend/graphqlbackend/codeintel.codenav.graphql
@@ -431,19 +431,19 @@ extend type Query {
         the combined results for all symbols will be returned.
         In that case, `Usage.symbol.name` can be used to group results.
         """
-        symbol: SymbolComparator,
+        symbol: SymbolComparator
 
         """
         Information about an existing source range for a usage of the symbol.
         TODO: Specify behavior for various cases of overlap between LookupRange
         and actual occurrence range.
         """
-        range: RangeInput!,
+        range: RangeInput!
 
         """
         Filter to allow customization of returned results.
         """
-        filter: UsagesFilter,
+        filter: UsagesFilter
 
         """
         When specified, indicates that this request should be paginated and
@@ -473,10 +473,10 @@ input SymbolComparator {
 """
 EXPERIMENTAL: This type may make backwards-incompatible changes in the future.
 """
-# Implementation note: In the future, we may want to extend this
+input # Implementation note: In the future, we may want to extend this
 # to allow passing in a suffix or a "symbol pattern".
 # See https://github.com/sourcegraph/sourcegraph/issues/59957
-input SymbolNameComparator {
+SymbolNameComparator {
     equals: String
 }
 
@@ -549,7 +549,7 @@ same file or same repository respectively.
 
 EXPERIMENTAL: This type may make backwards-incompatible changes in the future.
 """
-# Design Rationale:
+input # Design Rationale:
 #
 # 1. The ref panel did separate queries for 'this repo' vs 'all other repos'
 #    https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/client/web/src/enterprise/codeintel/searchBased.ts?L105:13-105:23#tab=references
@@ -561,7 +561,7 @@ EXPERIMENTAL: This type may make backwards-incompatible changes in the future.
 #    Once syntactic is added, if we want to allow the user to specify either
 #    syntactic or precise (but not search-based), we'd need OR.
 #    OR will also not be needed for the first implementation pass.
-input UsagesFilter {
+UsagesFilter {
     not: UsagesFilter
     repository: RepositoryFilter
     # TODO(id: usagesForSymbols-v2)
@@ -635,7 +635,7 @@ type Usage {
     or exceeds the number of available lines, the value is interpreted as
     until the start/end of the file.
     """
-    surroundingContent(surroundingLines: SurroundingLines = {linesBefore: 0, linesAfter: 0}): String
+    surroundingContent(surroundingLines: SurroundingLines = { linesBefore: 0, linesAfter: 0 }): String
 }
 
 """

--- a/cmd/frontend/graphqlbackend/codeintel.codenav.graphql
+++ b/cmd/frontend/graphqlbackend/codeintel.codenav.graphql
@@ -431,19 +431,19 @@ extend type Query {
         the combined results for all symbols will be returned.
         In that case, `Usage.symbol.name` can be used to group results.
         """
-        symbol: SymbolComparator,
+        symbol: SymbolComparator
 
         """
         Information about an existing source range for a usage of the symbol.
         TODO: Specify behavior for various cases of overlap between LookupRange
         and actual occurrence range.
         """
-        range: RangeInput!,
+        range: RangeInput!
 
         """
         Filter to allow customization of returned results.
         """
-        filter: UsagesFilter,
+        filter: UsagesFilter
 
         """
         When specified, indicates that this request should be paginated and
@@ -473,10 +473,10 @@ input SymbolComparator {
 """
 EXPERIMENTAL: This type may make backwards-incompatible changes in the future.
 """
-# Implementation note: In the future, we may want to extend this
-# to allow passing in a suffix or a "symbol pattern".
-# See https://github.com/sourcegraph/sourcegraph/issues/59957
 input SymbolNameComparator {
+    # Implementation note: In the future, we may want to extend this
+    # to allow passing in a suffix or a "symbol pattern".
+    # See https://github.com/sourcegraph/sourcegraph/issues/59957
     equals: String
 }
 
@@ -549,19 +549,19 @@ same file or same repository respectively.
 
 EXPERIMENTAL: This type may make backwards-incompatible changes in the future.
 """
-# Design Rationale:
-#
-# 1. The ref panel did separate queries for 'this repo' vs 'all other repos'
-#    https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/client/web/src/enterprise/codeintel/searchBased.ts?L105:13-105:23#tab=references
-#    That requires `NOT` (at least for a `repo`).
-# 2. The ref panel has a way to specify paths for filtering. This requires AND.
-#    AND will not be part of the first implementation pass. However,
-#    it would allow fetching less data instead of post-filtering client-side.
-# 3. Currently, the ref panel has a setting for only showing precise results.
-#    Once syntactic is added, if we want to allow the user to specify either
-#    syntactic or precise (but not search-based), we'd need OR.
-#    OR will also not be needed for the first implementation pass.
 input UsagesFilter {
+    # Design Rationale:
+    #
+    # 1. The ref panel did separate queries for 'this repo' vs 'all other repos'
+    #    https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/client/web/src/enterprise/codeintel/searchBased.ts?L105:13-105:23#tab=references
+    #    That requires `NOT` (at least for a `repo`).
+    # 2. The ref panel has a way to specify paths for filtering. This requires AND.
+    #    AND will not be part of the first implementation pass. However,
+    #    it would allow fetching less data instead of post-filtering client-side.
+    # 3. Currently, the ref panel has a setting for only showing precise results.
+    #    Once syntactic is added, if we want to allow the user to specify either
+    #    syntactic or precise (but not search-based), we'd need OR.
+    #    OR will also not be needed for the first implementation pass.
     not: UsagesFilter
     repository: RepositoryFilter
     # TODO(id: usagesForSymbols-v2)
@@ -635,7 +635,7 @@ type Usage {
     or exceeds the number of available lines, the value is interpreted as
     until the start/end of the file.
     """
-    surroundingContent(surroundingLines: SurroundingLines = {linesBefore: 0, linesAfter: 0}): String
+    surroundingContent(surroundingLines: SurroundingLines = { linesBefore: 0, linesAfter: 0 }): String
 }
 
 """

--- a/cmd/frontend/graphqlbackend/codeintel.codenav.graphql
+++ b/cmd/frontend/graphqlbackend/codeintel.codenav.graphql
@@ -466,7 +466,14 @@ extend type Query {
 EXPERIMENTAL: This type may make backwards-incompatible changes in the future.
 """
 input SymbolComparator {
+    """
+    Describes how the symbol name should be compared.
+    """
     name: SymbolNameComparator!
+    """
+    Describes the provenance of the symbol. This value should be based
+    on the provenance value obtained from the CodeGraphData type.
+    """
     provenance: CodeGraphDataProvenanceComparator!
 }
 
@@ -477,6 +484,9 @@ input SymbolNameComparator {
     # Implementation note: In the future, we may want to extend this
     # to allow passing in a suffix or a "symbol pattern".
     # See https://github.com/sourcegraph/sourcegraph/issues/59957
+    """
+    Checks for exact equality.
+    """
     equals: String
 }
 
@@ -562,7 +572,16 @@ input UsagesFilter {
     #    Once syntactic is added, if we want to allow the user to specify either
     #    syntactic or precise (but not search-based), we'd need OR.
     #    OR will also not be needed for the first implementation pass.
+    """
+    Negate another UsageFilter. For example, this can be used to find matches
+    outside of a specific repository.
+    """
     not: UsagesFilter
+    """
+    Filter for limiting which repositories to find the usages in.
+    For cross-repository symbols as well as search-based results,
+    an empty value will find results across the Sourcegraph instance.
+    """
     repository: RepositoryFilter
     # TODO(id: usagesForSymbols-v2)
     # and: [UsagesFilter!]
@@ -576,6 +595,9 @@ input UsagesFilter {
 EXPERIMENTAL: This type may make backwards-incompatible changes in the future.
 """
 input RepositoryFilter {
+    """
+    Compare the repository by name.
+    """
     name: StringComparator!
 }
 
@@ -583,6 +605,11 @@ input RepositoryFilter {
 EXPERIMENTAL: This type may make backwards-incompatible changes in the future.
 """
 input StringComparator {
+    """
+    Checks for exact equality.
+    """
+    # EXTENSION: We may want to allow glob patterns in the future here,
+    # that could be used by both RepositoryFilter and PathFilter.
     equals: String
 }
 
@@ -590,7 +617,13 @@ input StringComparator {
 EXPERIMENTAL: This type may make backwards-incompatible changes in the future.
 """
 type UsageConnection {
+    """
+    A single page of Usages.
+    """
     nodes: [Usage!]!
+    """
+    Pagination information.
+    """
     pageInfo: PageInfo!
 }
 
@@ -598,13 +631,25 @@ type UsageConnection {
 EXPERIMENTAL: This type may make backwards-incompatible changes in the future.
 """
 type UsageRange {
+    """
+    The repository this usage is present in.
+    """
     repository: String!
     """
     TODO(issue: GRAPH-614): 'revision' field should have type GitCommit
     before stabilizing this API.
     """
     revision: String!
+    """
+    The root relative path for the file this usage is present in.
+    """
     path: String!
+    """
+    The source range for the usage.
+
+    CAUTION: Depending on the indexer where this data originated from,
+    this range may have zero length.
+    """
     range: Range!
 }
 
@@ -619,6 +664,9 @@ type Usage {
     """
     symbol: SymbolInformation!
 
+    """
+    Information about where this usage is located.
+    """
     # Q: Should we remove functionality from UsageRange and punt more
     # functionality to `blob: GitBlob`?
     # """
@@ -681,7 +729,13 @@ type SymbolInformation {
 EXPERIMENTAL: This type may make backwards-incompatible changes in the future.
 """
 input SurroundingLines {
+    """
+    The number of lines before the current line to include.
+    """
     linesBefore: Int
+    """
+    The number of lines after the current line to include.
+    """
     linesAfter: Int
 }
 

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -10703,6 +10703,8 @@ type Location {
 
 """
 A range inside a file. The start position is inclusive, and the end position is exclusive.
+
+Invariant: start <= end, where the start == end case is a zero-length range.
 """
 type Range {
     """

--- a/internal/codeintel/codenav/transport/graphql/observability.go
+++ b/internal/codeintel/codenav/transport/graphql/observability.go
@@ -27,6 +27,7 @@ type operations struct {
 	ranges          *observation.Operation
 	snapshot        *observation.Operation
 	visibleIndexes  *observation.Operation
+	usagesForSymbol *observation.Operation
 }
 
 func newOperations(observationCtx *observation.Context) *operations {

--- a/internal/codeintel/codenav/transport/graphql/root_resolver.go
+++ b/internal/codeintel/codenav/transport/graphql/root_resolver.go
@@ -221,6 +221,7 @@ func (r *rootResolver) UsagesForSymbol(ctx context.Context, args *resolverstubs.
 
 	if remainingCount > 0 && provsForSCIPData.SearchBased {
 		// Attempt to get up to remainingCount search-based results.
+		_ = "shut up nogo linter complaining about empty branch"
 	}
 
 	return nil, errors.New("Not implemented yet")

--- a/internal/codeintel/codenav/transport/graphql/root_resolver.go
+++ b/internal/codeintel/codenav/transport/graphql/root_resolver.go
@@ -3,6 +3,7 @@ package graphql
 import (
 	"context"
 	"fmt"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 	"strings"
 	"sync"
 
@@ -188,6 +189,41 @@ func preferUploadsWithLongestRoots(uploads []shared.CompletedUpload) []shared.Co
 		out = append(out, pair.Value)
 	}
 	return out
+}
+
+func (r *rootResolver) UsagesForSymbol(ctx context.Context, args *resolverstubs.UsagesForSymbolArgs) (_ resolverstubs.UsageConnectionResolver, err rror) {
+	ctx, _, endObservation := r.operations.usagesForSymbol.WithErrors(ctx, &err, observation.Args{Attrs: args.Attrs()})
+	numPreciseResults := 0
+	numSyntacticResults := 0
+	numSearchBasedResults := 0
+	defer func() {
+		endObservation.OnCancel(ctx, 1, observation.Args{Attrs: []attribute.KeyValue{
+			attribute.Int("results.precise", numPreciseResults),
+			attribute.Int("results.syntactic", numSyntacticResults),
+			attribute.Int("results.searchBased", numSearchBasedResults),
+		}})
+	}()
+
+	const maxUsagesCount = 100
+	args.Normalize(maxUsagesCount)
+	remainingCount := int(*args.First)
+	provsForSCIPData := args.ProvenancesForSCIPData()
+
+	if provsForSCIPData.Precise {
+		// Attempt to get up to remainingCount precise results.
+		remainingCount = remainingCount - numPreciseResults
+	}
+
+	if remainingCount > 0 && provsForSCIPData.Syntactic {
+		// Attempt to get up to remainingCount syntactic results.
+		remainingCount = remainingCount - numSyntacticResults
+	}
+
+	if remainingCount > 0 && provsForSCIPData.SearchBased {
+		// Attempt to get up to remainingCount search-based results.
+	}
+
+	return nil, errors.New("Not implemented yet")
 }
 
 // gitBlobLSIFDataResolver is the main interface to bundle-related operations exposed to the GraphQL API. This

--- a/internal/codeintel/codenav/transport/graphql/root_resolver.go
+++ b/internal/codeintel/codenav/transport/graphql/root_resolver.go
@@ -191,7 +191,7 @@ func preferUploadsWithLongestRoots(uploads []shared.CompletedUpload) []shared.Co
 	return out
 }
 
-func (r *rootResolver) UsagesForSymbol(ctx context.Context, args *resolverstubs.UsagesForSymbolArgs) (_ resolverstubs.UsageConnectionResolver, err rror) {
+func (r *rootResolver) UsagesForSymbol(ctx context.Context, args *resolverstubs.UsagesForSymbolArgs) (_ resolverstubs.UsageConnectionResolver, err error) {
 	ctx, _, endObservation := r.operations.usagesForSymbol.WithErrors(ctx, &err, observation.Args{Attrs: args.Attrs()})
 	numPreciseResults := 0
 	numSyntacticResults := 0

--- a/internal/codeintel/codenav/transport/graphql/root_resolver.go
+++ b/internal/codeintel/codenav/transport/graphql/root_resolver.go
@@ -3,7 +3,6 @@ package graphql
 import (
 	"context"
 	"fmt"
-	"github.com/sourcegraph/sourcegraph/lib/errors"
 	"strings"
 	"sync"
 
@@ -23,6 +22,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/dotcom"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 type rootResolver struct {

--- a/internal/codeintel/resolvers/codenav.go
+++ b/internal/codeintel/resolvers/codenav.go
@@ -3,6 +3,7 @@ package resolvers
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/graph-gophers/graphql-go"
 	"go.opentelemetry.io/otel/attribute"
@@ -21,6 +22,7 @@ type CodeNavServiceResolver interface {
 	// that it is not what is exactly provided as input from the GraphQL
 	// client.
 	CodeGraphData(ctx context.Context, opts *CodeGraphDataOpts) (*[]CodeGraphDataResolver, error)
+	UsagesForSymbol(ctx context.Context, args *UsagesForSymbolArgs) (UsageConnectionResolver, error)
 }
 
 type GitBlobLSIFDataArgs struct {
@@ -277,3 +279,162 @@ const (
 	SymbolRoleReference         SymbolRole = "REFERENCE"
 	SymbolRoleForwardDefinition SymbolRole = "FORWARD_DEFINITION"
 )
+
+type UsagesForSymbolArgs struct {
+	Symbol *SymbolComparator
+	Range  RangeInput
+	Filter *UsagesFilter
+	First  *int32
+	After  *string
+}
+
+func (args *UsagesForSymbolArgs) ProvenancesForSCIPData() ForEachProvenance[bool] {
+	var out ForEachProvenance[bool]
+	if args == nil || args.Symbol == nil || args.Symbol.Provenance.Equals == nil {
+		out.Precise = true
+		out.Syntactic = true
+		out.SearchBased = true
+	} else {
+		switch p := *args.Symbol.Provenance.Equals; p {
+		case ProvenancePrecise:
+			out.Precise = true
+		case ProvenanceSyntactic:
+			out.Syntactic = true
+		case ProvenanceSearchBased:
+			out.SearchBased = true
+		}
+	}
+	return out
+}
+
+// Normalize sets the First field to a non-null value.
+func (args *UsagesForSymbolArgs) Normalize(maxPageSize int32) {
+	if args == nil {
+		*args = UsagesForSymbolArgs{}
+	}
+	if args.First == nil || *args.First > maxPageSize {
+		args.First = &maxPageSize
+	}
+}
+
+func (args *UsagesForSymbolArgs) Attrs() (out []attribute.KeyValue) {
+	out = append(append(args.Symbol.Attrs(), args.Range.Attrs()...), attribute.String("filter", args.Filter.DebugString()))
+	if args.First != nil {
+		out = append(out, attribute.Int("first", int(*args.First)))
+	}
+	out = append(out, attribute.Bool("hasAfter", args.After != nil))
+	return out
+}
+
+type SymbolComparator struct {
+	Name       SymbolNameComparator
+	Provenance CodeGraphDataProvenanceComparator
+}
+
+func (c *SymbolComparator) Attrs() (out []attribute.KeyValue) {
+	if c == nil {
+		return nil
+	}
+	if c.Name.Equals != nil {
+		out = append(out, attribute.String("symbol.name.equals", *c.Name.Equals))
+	}
+	if c.Provenance.Equals != nil {
+		out = append(out, attribute.String("symbol.provenance.equals", string(*c.Provenance.Equals)))
+	}
+	return out
+}
+
+type SymbolNameComparator struct {
+	Equals *string
+}
+
+type RangeInput struct {
+	Repository string
+	Revision   *string
+	Path       string
+	Start      *PositionInput
+	End        *PositionInput
+}
+
+func (r *RangeInput) Attrs() (out []attribute.KeyValue) {
+	out = append(out, attribute.String("range.repository", r.Repository))
+	if r.Revision != nil {
+		out = append(out, attribute.String("range.revision", *r.Revision))
+	}
+	out = append(out, attribute.String("range.path", r.Path))
+	if r.Start != nil {
+		out = append(out, attribute.Int("range.start.line", int(r.Start.Line)))
+		out = append(out, attribute.Int("range.start.character", int(r.Start.Character)))
+	}
+	if r.End != nil {
+		out = append(out, attribute.Int("range.end.line", int(r.End.Line)))
+		out = append(out, attribute.Int("range.end.character", int(r.End.Character)))
+	}
+	return out
+}
+
+type PositionInput struct {
+	// Zero-based line number
+	Line int32
+	// Zero-based UTF-16 code unit offset
+	Character int32
+}
+
+type UsagesFilter struct {
+	Not        *UsagesFilter
+	Repository *RepositoryFilter
+}
+
+func (f *UsagesFilter) DebugString() string {
+	if f == nil {
+		return ""
+	}
+	result := []string{}
+	if f.Not != nil {
+		result = append(result, fmt.Sprintf("(not %s)", f.Not.DebugString()))
+	}
+	if f.Repository != nil && f.Repository.Name.Equals != nil {
+		result = append(result, fmt.Sprintf("(repo == %s)", *f.Repository.Name.Equals))
+	}
+	return strings.Join(result, " and ")
+}
+
+type RepositoryFilter struct {
+	Name StringComparator
+}
+
+type StringComparator struct {
+	Equals *string
+}
+
+type UsageConnectionResolver interface {
+	ConnectionResolver[UsageResolver]
+	PageInfo(ctx context.Context) (*graphqlutil.ConnectionPageInfo[UsageResolver], error)
+}
+
+type UsageResolver interface {
+	Symbol(context.Context) (SymbolInformationResolver, error)
+	UsageRange(context.Context) (UsageRangeResolver, error)
+	SurroundingContent(_ context.Context, args *struct {
+		*SurroundingLines `json:"surroundingLines"`
+	}) (*string, error)
+}
+
+type SymbolInformationResolver interface {
+	Name() (string, error)
+	Documentation() (*[]string, error)
+	Provenance() (CodeGraphDataProvenance, error)
+	DataSource() *string
+}
+
+type UsageRangeResolver interface {
+	Repository() string
+	Revision() string
+	Path() string
+	Range() RangeResolver
+}
+
+type SurroundingLines struct {
+	LinesBefore *int32 `json:"linesBefore"`
+	LinesAfter  *int32 `json:"linesAfter"`
+}

--- a/internal/codeintel/resolvers/root_resolver.go
+++ b/internal/codeintel/resolvers/root_resolver.go
@@ -129,6 +129,10 @@ func (r *Resolver) CodeGraphData(ctx context.Context, opts *CodeGraphDataOpts) (
 	return r.codenavResolver.CodeGraphData(ctx, opts)
 }
 
+func (r *Resolver) UsagesForSymbol(ctx context.Context, args *UsagesForSymbolArgs) (UsageConnectionResolver, error) {
+	return r.codenavResolver.UsagesForSymbol(ctx, args)
+}
+
 func (r *Resolver) ConfigurationPolicyByID(ctx context.Context, id graphql.ID) (_ CodeIntelligenceConfigurationPolicyResolver, err error) {
 	return r.policiesRootResolver.ConfigurationPolicyByID(ctx, id)
 }


### PR DESCRIPTION
Let's merge a stub implementation with the types in place.

This will allow parallelizing the spike on syntactic and the work
on implementing the API for precise.

## Test plan

[Ran locally](https://sourcegraph.test:3443/api/console#%7B%22query%22%3A%22%23%20query%20GetRepoID(%24name%3A%20String!)%20%7B%5Cn%23%20%20%20repository(name%3A%20%24name)%20%7B%5Cn%23%20%20%20%20%20id%5Cn%23%20%20%20%7D%5Cn%23%20%7D%5Cn%5Cn%5Cnquery%20S()%20%7B%5Cn%20%20usagesForSymbol(range%3A%20%7B%5Cn%20%20%20%20repository%3A%20%5C%22github.com%2Fsourcegraph%2Fconc%5C%22%5Cn%20%20%20%20path%3A%20%5C%22pool%2Fpool.go%5C%22%5Cn%20%20%7D)%20%7B%5Cn%20%20%20%20nodes%20%7B%5Cn%20%20%20%20%20%20symbol%20%7B%5Cn%20%20%20%20%20%20%20%20name%5Cn%20%20%20%20%20%20%7D%5Cn%20%20%20%20%7D%5Cn%20%20%7D%5Cn%7D%5Cn%5Cn%23%20%20%20%5C%22name%5C%22%3A%20%5C%22github.com%2Fvitejs%2Fvite%5C%22%5Cn%22%7D) - got `Not implemented yet` error.

![CleanShot 2024-05-27 at 19 44 58@2x](https://github.com/sourcegraph/sourcegraph/assets/93103176/3026810a-e6da-4217-8cad-3b87aa4ca313)
