### PR TITLE
sg: cloud ephemeral - handle multiple job reasons

### DIFF
--- a/dev/sg/internal/cloud/printers.go
+++ b/dev/sg/internal/cloud/printers.go
@@ -43,13 +43,6 @@ func newDefaultTerminalInstancePrinter() *terminalInstancePrinter {
 			}
 		}
 
-		LastJobURL := "n/a"
-		if inst.Status.Reason.JobURL != "" {
-			LastJobURL = inst.Status.Reason.JobURL
-			if inst.Status.Reason.JobState != "" {
-				LastJobURL += " (" + inst.Status.Reason.JobState + ")"
-			}
-		}
 		expiresAt := "n/a"
 		if !inst.ExpiresAt.IsZero() {
 			expiresAt = inst.ExpiresAt.Format(time.RFC3339)

--- a/dev/sg/internal/cloud/printers.go
+++ b/dev/sg/internal/cloud/printers.go
@@ -43,11 +43,11 @@ func newDefaultTerminalInstancePrinter() *terminalInstancePrinter {
 			}
 		}
 
-		actionURL := "n/a"
+		LastJobURL := "n/a"
 		if inst.Status.Reason.JobURL != "" {
-			actionURL = inst.Status.Reason.JobURL
+			LastJobURL = inst.Status.Reason.JobURL
 			if inst.Status.Reason.JobState != "" {
-				actionURL += " (" + inst.Status.Reason.JobState + ")"
+				LastJobURL += " (" + inst.Status.Reason.JobState + ")"
 			}
 		}
 		expiresAt := "n/a"
@@ -55,12 +55,20 @@ func newDefaultTerminalInstancePrinter() *terminalInstancePrinter {
 			expiresAt = inst.ExpiresAt.Format(time.RFC3339)
 		}
 
+		var jobCount = inst.Status.Reason.JobCount
+		var overallJobStatus = inst.Status.Reason.Overall
+		if inst.Status.Status == InstanceStatusCompleted {
+			overallJobStatus = "completed"
+		} else if overallJobStatus == "" {
+			overallJobStatus = "n/a"
+		}
+
 		return []any{
-			name, expiresAt, status, actionURL,
+			name, expiresAt, status, jobCount, overallJobStatus,
 		}
 
 	}
-	return newTerminalInstancePrinter(valueFunc, "%-40s %-20s %-40s %s", "Name", "Expires At", "Status", "JobURL")
+	return newTerminalInstancePrinter(valueFunc, "%-40s %-20s %-40s %-5s %s", "Name", "Expires at", "Status", "Jobs", "Overall job status")
 }
 
 func newTerminalInstancePrinter(valueFunc func(i *Instance) []any, headingFmt string, headings ...string) *terminalInstancePrinter {
@@ -81,7 +89,7 @@ func (p *terminalInstancePrinter) Print(items ...*Instance) error {
 	std.Out.WriteLine(output.Line("", output.StyleBold, heading))
 	for _, inst := range items {
 		values := p.valueFunc(inst)
-		line := fmt.Sprintf("%-40s %-20s %-40s %s", values...)
+		line := fmt.Sprintf("%-40s %-20s %-40s %-5d %s", values...)
 		std.Out.WriteLine(output.Line("", output.StyleGrey, line))
 	}
 


### PR DESCRIPTION
Sometimes cloud ephemeral can return multiple job reasons seperate by `;`. In this PR we check for the presence of multiple job reasons and parse it accordingly.

Example of reason with multiple job reasons:
```
step 1/3:creating instance, job-url:https://github.com/sourcegraph/cloud/actions/runs/9255560228, state:completed, conclusion:failure; step 1/3:creating instance, job-url:https://github.com/sourcegraph/cloud/actions/runs/9177645150, state:completed, conclusion:failure; step 1/3:creating instance, job-url:https://github.com/sourcegraph/cloud/actions/runs/9161687255, state:completed, conclusion:failure
```

At the moment we're only interested in the last job and the overall status of all jobs.
## Test plan
Tested locally

Failure
```
Name                                     Expires At           Status                                   JobURL
william-bezu-5-4-0                       n/a                  in-progress (1/3 creating instance, job-url:https://github.com/sourcegraph/cloud/actions/runs/9255560228, state:completed, conclusion:failure; step 1/3:creating instance, job-url:https://github.com/sourcegraph/cloud/actions/runs/9177645150, state:completed, conclusion:failure; step 1/3:creating instance) https://github.com/sourcegraph/cloud/actions/runs/9161687255 (completed)
```

Fixed
```
o run ./dev/sg cloud eph status --name william-bezu-5-4-0
✅ Ephemeral instance "william-bezu-5-4-0" status retrieved
Ephemeral instance details:
Name                                     Expires at           Status                                   Job count  Overall job status
william-bezu-5-4-0                       n/a                  in-progress (1/3 creating instance)      3          failure
```

Status with job no reason also still works
```
go run ./dev/sg cloud eph status --name wb-feature-x
✅ Ephemeral instance "wb-feature-x" status retrieved
Ephemeral instance details:
Name                                     Expires at           Status                                   Jobs  Overall job status
wb-feature-x                             2024-05-28T16:00:28Z completed                                0     completed
💡 Some names may be truncated. To see the full names use the --raw format
```

```
go run ./dev/sg cloud eph status --name william-bezu-5-4-0 --raw
✅ Ephemeral instance "william-bezu-5-4-0" status retrieved
Ephemeral instance details:
ID           : src-9cbb2cca0553c5bd2e67
Name         : william-bezu-5-4-0
InstanceType : internal
Environment  : dev
Version      : 5.4.0
URL          : https://william-bezu-5-4-0.sgdev.dev
AdminEmail   :
CreatedAt    : n/a
DeletetAt    : n/a
ExpiresAt    : n/a
Project      : src-096248487daeb92b4055
Region       : us-central1
Status       : in-progress
Step         : 1/3
Phase        : creating instance
JobURL       : https://github.com/sourcegraph/cloud/actions/runs/9161687255
JobState     : completed
Overall      : failure
```
