### PR TITLE
uploads: Fixup nested code intel uploads

### DIFF
--- a/internal/codeintel/uploads/internal/background/processor/job_worker_handler.go
+++ b/internal/codeintel/uploads/internal/background/processor/job_worker_handler.go
@@ -243,9 +243,6 @@ func (h *handler) HandleRawUpload(ctx context.Context, logger log.Logger, upload
 					}
 					return nil, errors.Wrap(err, "gitserverClient.ReadDir.Next")
 				}
-				if fd.IsDir() {
-					continue
-				}
 				if _, ok := seen[fd.Name()]; ok {
 					continue
 				}


### PR DESCRIPTION
I misinterpreted what the client-side version of this did, and accidentally skipped over directories, which meant that it would not traverse deeply into folders. This caused uploads to be incomplete.

Might close GRAPH-632.

Test plan:

Manually verified the before and after behavior and they feel equal to me now from a quick debugger session.
But I don't see precise in my local instance, so perhaps this needs more work.