### PR TITLE
SSC: Add "Welcome to Cody Pro" banner

### DIFF
--- a/client/web/src/cody/components/CodyAlert.module.scss
+++ b/client/web/src/cody/components/CodyAlert.module.scss
@@ -34,6 +34,27 @@
     }
 }
 
+.purple-cody-pro {
+    /* stylelint-disable-next-line declaration-property-unit-allowed-list */
+    padding-left: calc(1.5rem + 135px + 1.5rem);
+    background-color: var(--violet-02);
+    color: var(--gray-11);
+    :global(.theme-dark) & {
+        background-color: var(--pink);
+    }
+    &::after {
+        position: absolute;
+        bottom: 0;
+        left: 1.5rem;
+        /* stylelint-disable-next-line declaration-property-unit-allowed-list */
+        width: 135px;
+        /* stylelint-disable-next-line declaration-property-unit-allowed-list */
+        height: 95px;
+        background-image: url('https://storage.googleapis.com/sourcegraph-assets/cody-pro-card.png');
+        background-size: cover;
+    }
+}
+
 .error-alert {
     /* stylelint-disable-next-line declaration-property-unit-allowed-list */
     padding-left: calc(1.5rem + 124px + 1.5rem);

--- a/client/web/src/cody/components/CodyAlert.tsx
+++ b/client/web/src/cody/components/CodyAlert.tsx
@@ -5,7 +5,7 @@ import classNames from 'classnames'
 import styles from './CodyAlert.module.scss'
 
 interface CodyAlertProps extends React.HTMLAttributes<HTMLDivElement> {
-    variant: 'greenSuccess' | 'purpleSuccess' | 'error'
+    variant: 'greenSuccess' | 'purpleSuccess' | 'purpleCodyPro' | 'error'
     className?: string
     children: React.ReactNode
 }
@@ -17,6 +17,7 @@ export const CodyAlert: React.FunctionComponent<CodyAlertProps> = ({ variant, cl
         {
             [styles.greenSuccessAlert]: variant === 'greenSuccess',
             [styles.purpleSuccessAlert]: variant === 'purpleSuccess',
+            [styles.purpleCodyPro]: variant === 'purpleCodyPro',
             [styles.errorAlert]: variant === 'error',
         },
         className

--- a/client/web/src/cody/invites/AcceptInvitePage.tsx
+++ b/client/web/src/cody/invites/AcceptInvitePage.tsx
@@ -46,7 +46,7 @@ const AuthenticatedCodyAcceptInvitePage: React.FunctionComponent<CodyAcceptInvit
             if (response.ok) {
                 // Wait a second before navigating to the manage team page so that the user sees the success alert.
                 await new Promise(resolve => setTimeout(resolve, 1000))
-                navigate('/cody/team/manage')
+                navigate('/cody/team/manage?welcome=1')
             } else {
                 setErrorMessage(await response.text())
             }

--- a/client/web/src/cody/invites/AcceptInvitePage.tsx
+++ b/client/web/src/cody/invites/AcceptInvitePage.tsx
@@ -46,7 +46,7 @@ const AuthenticatedCodyAcceptInvitePage: React.FunctionComponent<CodyAcceptInvit
             if (response.ok) {
                 // Wait a second before navigating to the manage team page so that the user sees the success alert.
                 await new Promise(resolve => setTimeout(resolve, 1000))
-                navigate('/cody/team/manage?welcome=1')
+                navigate('/cody/manage?welcome=1')
             } else {
                 setErrorMessage(await response.text())
             }

--- a/client/web/src/cody/management/CodyManagementPage.tsx
+++ b/client/web/src/cody/management/CodyManagementPage.tsx
@@ -18,6 +18,7 @@ import {
     type UserCodyUsageVariables,
     CodySubscriptionPlan,
 } from '../../graphql-operations'
+import { CodyAlert } from '../components/CodyAlert'
 import { CodyProIcon, DashboardIcon } from '../components/CodyIcon'
 import { isCodyEnabled } from '../isCodyEnabled'
 import { CodyOnboarding, type IEditor } from '../onboarding/CodyOnboarding'
@@ -28,7 +29,6 @@ import { SubscriptionStats } from './SubscriptionStats'
 import { UseCodyInEditorSection } from './UseCodyInEditorSection'
 
 import styles from './CodyManagementPage.module.scss'
-import { CodyAlert } from '../components/CodyAlert'
 
 interface CodyManagementPageProps extends TelemetryV2Props {
     isSourcegraphDotCom: boolean
@@ -106,7 +106,14 @@ export const CodyManagementPage: React.FunctionComponent<CodyManagementPageProps
         <>
             <Page className={classNames('d-flex flex-column')}>
                 <PageTitle title="Dashboard" />
-                {welcomeToPro && <CodyAlert variant="purpleCodyPro"><H2 className="mt-4">Welcome to Cody Pro</H2><Text size="small" className="mb-0">You now have Cody Pro with access to unlimited autocomplete, chats, and commands.</Text></CodyAlert>}
+                {welcomeToPro && (
+                    <CodyAlert variant="purpleCodyPro">
+                        <H2 className="mt-4">Welcome to Cody Pro</H2>
+                        <Text size="small" className="mb-0">
+                            You now have Cody Pro with access to unlimited autocomplete, chats, and commands.
+                        </Text>
+                    </CodyAlert>
+                )}
                 <PageHeader className="mb-4 mt-4">
                     <PageHeader.Heading as="h2" styleAs="h1">
                         <div className="d-inline-flex align-items-center">

--- a/client/web/src/cody/management/CodyManagementPage.tsx
+++ b/client/web/src/cody/management/CodyManagementPage.tsx
@@ -28,6 +28,7 @@ import { SubscriptionStats } from './SubscriptionStats'
 import { UseCodyInEditorSection } from './UseCodyInEditorSection'
 
 import styles from './CodyManagementPage.module.scss'
+import { CodyAlert } from '../components/CodyAlert'
 
 interface CodyManagementPageProps extends TelemetryV2Props {
     isSourcegraphDotCom: boolean
@@ -62,6 +63,8 @@ export const CodyManagementPage: React.FunctionComponent<CodyManagementPageProps
             navigate(`/cody/switch-account/${codyClientUser}`)
         }
     }, [accountSwitchRequired, codyClientUser, navigate])
+
+    const welcomeToPro = parameters.get('welcome') === '1'
 
     const { data, error: dataError } = useQuery<UserCodyPlanResult, UserCodyPlanVariables>(USER_CODY_PLAN, {})
 
@@ -103,6 +106,7 @@ export const CodyManagementPage: React.FunctionComponent<CodyManagementPageProps
         <>
             <Page className={classNames('d-flex flex-column')}>
                 <PageTitle title="Dashboard" />
+                {welcomeToPro && <CodyAlert variant="purpleCodyPro"><H2 className="mt-4">Welcome to Cody Pro</H2><Text size="small" className="mb-0">You now have Cody Pro with access to unlimited autocomplete, chats, and commands.</Text></CodyAlert>}
                 <PageHeader className="mb-4 mt-4">
                     <PageHeader.Heading as="h2" styleAs="h1">
                         <div className="d-inline-flex align-items-center">

--- a/client/web/src/cody/management/subscription/new/CodyProCheckoutForm.tsx
+++ b/client/web/src/cody/management/subscription/new/CodyProCheckoutForm.tsx
@@ -42,7 +42,7 @@ export const CodyProCheckoutForm: React.FunctionComponent<{
             // and Sourcegraph.com, immediately loading the Dashboard page isn't
             // going to show the right data reliably. We will need to instead show
             // some prompt, to give the backends an opportunity to sync.
-            returnUrl: `${origin}/cody/manage?session_id={CHECKOUT_SESSION_ID}`,
+            returnUrl: `${origin}/cody/manage?session_id={CHECKOUT_SESSION_ID}&welcome=1`,
         }
         return Client.createStripeCheckoutSession(requestBody)
     }, [creatingTeam, customerEmail, showPromoCodeField])

--- a/client/web/src/cody/team/InviteUsers.tsx
+++ b/client/web/src/cody/team/InviteUsers.tsx
@@ -109,7 +109,7 @@ export const InviteUsers: React.FunctionComponent<InviteUsersProps> = ({
                         />
                     </div>
                     <div className="flex-1 d-flex flex-column">
-                        <H2 className="mb-4">
+                        <H2 className="mb-4 font-weight-normal">
                             <strong>Invite users</strong> – {remainingInviteCount}{' '}
                             {pluralize('seat', remainingInviteCount)} remaining
                         </H2>


### PR DESCRIPTION
Contributes to https://github.com/sourcegraph/self-serve-cody/issues/725

We currently don't welcome the user when they first arrive at the Cody Management page. This PR adds a notification.

The changes, each in their own commits:
1. Add the notification to the /cody/manage page
2. Trigger the notification after a user signs up using our new checkout page (the old one is hosted on the SSC site)
3. Trigger the notification after a team invitee accepts the invitation

Unrelated change: fix a header style in the "Team invites" section

Note: for the pic, I used a 4x PNG. The graphic uses gradients that SVG doesn't seem to support (figma export messes up the pic).

## Test plan

- [2-min Loom](https://www.loom.com/share/17912a497b8443afbb2a1f483a78b719?sid=d30df717-7445-43b4-a08d-ca817bfa8013) where I demo that the notification gets triggered in both the "Checkout" and "Accept invite" flows.

The notification looks like:

![CleanShot 2024-05-28 at 00 40 52@2x](https://github.com/sourcegraph/sourcegraph/assets/2552265/e4f1a69b-e8db-4a90-b909-609935aab5e7)

and

![CleanShot 2024-05-28 at 00 40 26@2x](https://github.com/sourcegraph/sourcegraph/assets/2552265/eab24e74-dc98-4f9d-8298-66d520b1e463)

and they are based on [this figma](https://www.figma.com/design/FMSdn1oKccJRHQPgf7053o/Cody-PLG-GA?node-id=4274-7525&t=Z3JJPnyZAzii9KPL-0):

![CleanShot 2024-05-28 at 00 42 06@2x](https://github.com/sourcegraph/sourcegraph/assets/2552265/4c0496c2-22f6-4948-99ca-b52f108825a6)
