### PR TITLE
chore(local): catch bazel-do issues before push

### DIFF
--- a/dev/ci/helpers/BUILD.bazel
+++ b/dev/ci/helpers/BUILD.bazel
@@ -1,0 +1,19 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("//dev:go_defs.bzl", "go_test")
+
+go_library(
+    name = "helpers",
+    srcs = ["bazeldo.go"],
+    importpath = "github.com/sourcegraph/sourcegraph/dev/ci/helpers",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//lib/errors",
+        "@com_github_grafana_regexp//:regexp",
+    ],
+)
+
+go_test(
+    name = "helpers_test",
+    srcs = ["bazeldo_test.go"],
+    embed = [":helpers"],
+)

--- a/dev/ci/helpers/bazeldo.go
+++ b/dev/ci/helpers/bazeldo.go
@@ -1,0 +1,63 @@
+package helpers
+
+import (
+	"strings"
+
+	"github.com/grafana/regexp"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+var allowedBazelFlags = map[string]struct{}{
+	"--runs_per_test":        {},
+	"--nobuild":              {},
+	"--local_test_jobs":      {},
+	"--test_arg":             {},
+	"--nocache_test_results": {},
+	"--test_tag_filters":     {},
+	"--test_timeout":         {},
+	"--config":               {},
+	"--test_output":          {},
+	"--verbose_failures":     {},
+}
+
+var bazelFlagsRe = regexp.MustCompile(`--\w+`)
+
+// VerifyBazelDoCommand checks that the given command is allowed
+// to run as a bazel-do runtype.
+func VerifyBazelCommand(command string) error {
+	// check for shell escape mechanisms.
+	bannedChars := []string{"`", "$", "(", ")", ";", "&", "|", "<", ">"}
+	for _, c := range bannedChars {
+		if strings.Contains(command, c) {
+			return errors.Newf("unauthorized input for bazel command: %q", c)
+		}
+	}
+
+	// check for command and targets
+	strs := strings.Split(command, " ")
+	if len(strs) < 2 {
+		return errors.New("invalid command")
+	}
+
+	// command must be either build or test.
+	switch strs[0] {
+	case "build":
+	case "test":
+	default:
+		return errors.Newf("disallowed bazel command: %q", strs[0])
+	}
+
+	// need at least one target.
+	if !strings.HasPrefix(strs[1], "//") {
+		return errors.New("misconstructed command, need at least one target")
+	}
+
+	// ensure flags are in the allow-list.
+	matches := bazelFlagsRe.FindAllString(command, -1)
+	for _, m := range matches {
+		if _, ok := allowedBazelFlags[m]; !ok {
+			return errors.Newf("disallowed bazel flag: %q", m)
+		}
+	}
+	return nil
+}

--- a/dev/ci/helpers/bazeldo_test.go
+++ b/dev/ci/helpers/bazeldo_test.go
@@ -1,4 +1,4 @@
-package ci
+package helpers
 
 import (
 	"testing"
@@ -46,7 +46,7 @@ func TestVerifyBazelCommand(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.cmd, func(t *testing.T) {
-			err := verifyBazelCommand(test.cmd)
+			err := VerifyBazelCommand(test.cmd)
 			if (test.wantError && err == nil) || (!test.wantError && err != nil) {
 				t.Log(err)
 				t.Fail()

--- a/dev/ci/internal/ci/BUILD.bazel
+++ b/dev/ci/internal/ci/BUILD.bazel
@@ -26,6 +26,7 @@ go_library(
     visibility = ["//dev/ci:__subpackages__"],
     deps = [
         "//dev/ci/gitops",
+        "//dev/ci/helpers",
         "//dev/ci/images",
         "//dev/ci/internal/buildkite",
         "//dev/ci/internal/ci/changed",
@@ -34,7 +35,6 @@ go_library(
         "//dev/sg/root",
         "//internal/lazyregexp",
         "//lib/errors",
-        "@com_github_grafana_regexp//:regexp",
         "@com_github_masterminds_semver//:semver",
         "@com_github_sourcegraph_log//:log",
         "@in_gopkg_yaml_v2//:yaml_v2",
@@ -45,7 +45,6 @@ go_test(
     name = "ci_test",
     srcs = [
         "aspect_workflows_test.go",
-        "bazel_operations_test.go",
         "wolfi_operations_test.go",
     ],
     data = [

--- a/dev/ci/internal/ci/bazel_helpers.go
+++ b/dev/ci/internal/ci/bazel_helpers.go
@@ -4,10 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/grafana/regexp"
-
 	bk "github.com/sourcegraph/sourcegraph/dev/ci/internal/buildkite"
-	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 func bazelBuild(targets ...string) func(*bk.Pipeline) {
@@ -90,57 +87,4 @@ func bazelPrechecks() func(*bk.Pipeline) {
 func bazelAnnouncef(format string, args ...any) bk.StepOpt {
 	msg := fmt.Sprintf(format, args...)
 	return bk.Cmd(fmt.Sprintf(`echo "--- :bazel: %s"`, msg))
-}
-
-var allowedBazelFlags = map[string]struct{}{
-	"--runs_per_test":        {},
-	"--nobuild":              {},
-	"--local_test_jobs":      {},
-	"--test_arg":             {},
-	"--nocache_test_results": {},
-	"--test_tag_filters":     {},
-	"--test_timeout":         {},
-	"--config":               {},
-	"--test_output":          {},
-	"--verbose_failures":     {},
-}
-
-var bazelFlagsRe = regexp.MustCompile(`--\w+`)
-
-func verifyBazelCommand(command string) error {
-	// check for shell escape mechanisms.
-	bannedChars := []string{"`", "$", "(", ")", ";", "&", "|", "<", ">"}
-	for _, c := range bannedChars {
-		if strings.Contains(command, c) {
-			return errors.Newf("unauthorized input for bazel command: %q", c)
-		}
-	}
-
-	// check for command and targets
-	strs := strings.Split(command, " ")
-	if len(strs) < 2 {
-		return errors.New("invalid command")
-	}
-
-	// command must be either build or test.
-	switch strs[0] {
-	case "build":
-	case "test":
-	default:
-		return errors.Newf("disallowed bazel command: %q", strs[0])
-	}
-
-	// need at least one target.
-	if !strings.HasPrefix(strs[1], "//") {
-		return errors.New("misconstructed command, need at least one target")
-	}
-
-	// ensure flags are in the allow-list.
-	matches := bazelFlagsRe.FindAllString(command, -1)
-	for _, m := range matches {
-		if _, ok := allowedBazelFlags[m]; !ok {
-			return errors.Newf("disallowed bazel flag: %q", m)
-		}
-	}
-	return nil
 }

--- a/dev/ci/internal/ci/pipeline.go
+++ b/dev/ci/internal/ci/pipeline.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/sourcegraph/sourcegraph/dev/ci/helpers"
 	"github.com/sourcegraph/sourcegraph/dev/ci/images"
 	bk "github.com/sourcegraph/sourcegraph/dev/ci/internal/buildkite"
 	"github.com/sourcegraph/sourcegraph/dev/ci/internal/ci/changed"
@@ -108,7 +109,7 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 				bzlCmd = strings.TrimSpace(strings.TrimPrefix(line, "!bazel"))
 
 				// sanitize the input
-				if err := verifyBazelCommand(bzlCmd); err != nil {
+				if err := helpers.VerifyBazelCommand(bzlCmd); err != nil {
 					return nil, errors.Wrapf(err, "cannot generate bazel-do")
 				}
 

--- a/dev/sg/ci/BUILD.bazel
+++ b/dev/sg/ci/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     tags = [TAG_INFRA_DEVINFRA],
     visibility = ["//visibility:public"],
     deps = [
+        "//dev/ci/helpers",
         "//dev/ci/runtype",
         "//dev/sg/internal/bk",
         "//dev/sg/internal/category",


### PR DESCRIPTION
Before this PR, you could end up pushing a `bazel-do` runtype build that is disallowed, which is not the nicest feedback loop as you'll only hear back about the problem once the CI picked it up.

Now the command straight up tells you before anything else. I also added a basic [How-to](https://www.notion.so/sourcegraph/Running-an-arbitrary-Bazel-command-in-CI-diagnosing-flakes-for-example-e0ae40ec6f3a4fd5a39a41d9681ec632?pvs=4) covering this and linked to it in the extended usage description. 

## Changelog 

- Prevent pushing Bazel commands/flags that would end up being rejected by the CI due to the allow list. 

<!--

💡 To write a useful PR description, make sure that your description covers:

- WHAT this PR is changing:
    - How was it PREVIOUSLY.
    - How it will be from NOW on.
- WHY this PR is needed.
- CONTEXT, i.e. to which initiative, project or RFC it belongs.

The structure of the description doesn't matter as much as covering these points, so use
your best judgement based on your context.

Learn how to write good pull request description: https://www.notion.so/sourcegraph/Write-a-good-pull-request-description-610a7fd3e613496eb76f450db5a49b6e?pvs=4
-->

## Test plan

CI + locally tested. 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles

Why does it matter?

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers.
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component:
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests"
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs:
  - "previewed locally"
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI"
  - "locally tested"
-->
