### PR TITLE
[DO NOT MERGE] Calls out to searcher for syntactic search

### DIFF
--- a/cmd/frontend/graphqlbackend/codeintel.codenav.graphql
+++ b/cmd/frontend/graphqlbackend/codeintel.codenav.graphql
@@ -411,6 +411,288 @@ type GitBlobLSIFData implements TreeEntryLSIFData {
     snapshot(indexID: ID!): [SnapshotData!]
 }
 
+extend type Query {
+    """
+    Identify usages for either a semantic symbol, or the symbol(s) implied
+    by a source range.
+    Ordering and uniqueness guarantees:
+    1. The usages returned will already be de-duplicated.
+    2. Results for a single file are contiguous.
+    3. Results for a single repository are contiguous.
+    Related: See `codeGraphData` on GitBlob.
+
+    EXPERIMENTAL: This API may make backwards-incompatible changes in the future.
+    """
+    usagesForSymbol(
+        """
+        Symbol to perform the lookup for.
+        If provided, then the start and end position in `range` are optional.
+        If not provided, and if multiple symbols are detected at the same range,
+        the combined results for all symbols will be returned.
+        In that case, `Usage.symbol.name` can be used to group results.
+        """
+        symbol: SymbolComparator,
+
+        """
+        Information about an existing source range for a usage of the symbol.
+        TODO: Specify behavior for various cases of overlap between LookupRange
+        and actual occurrence range.
+        """
+        range: RangeInput!,
+
+        """
+        Filter to allow customization of returned results.
+        """
+        filter: UsagesFilter,
+
+        """
+        When specified, indicates that this request should be paginated and
+        the first N results (relative to the cursor) should be returned. i.e.
+        how many results to return per page.
+        """
+        first: Int
+
+        """
+        When specified, indicates that this request should be paginated and
+        to fetch results starting at this cursor.
+        A future request can be made for more results by passing in the
+        'UsageConnection.pageInfo.endCursor' that is returned.
+        """
+        after: String
+    ): UsageConnection!
+}
+
+"""
+EXPERIMENTAL: This type may make backwards-incompatible changes in the future.
+"""
+input SymbolComparator {
+    name: SymbolNameComparator!
+    provenance: CodeGraphDataProvenanceComparator!
+}
+
+"""
+EXPERIMENTAL: This type may make backwards-incompatible changes in the future.
+"""
+# Implementation note: In the future, we may want to extend this
+# to allow passing in a suffix or a "symbol pattern".
+# See https://github.com/sourcegraph/sourcegraph/issues/59957
+input SymbolNameComparator {
+    equals: String
+}
+
+"""
+A range inside a particular blob.
+
+EXPERIMENTAL: This type may make backwards-incompatible changes in the future.
+"""
+input RangeInput {
+    """
+    Defaults to instance-wide search if the repo is not specified.
+    This field is necessary if SymbolComparator is a repository-local or
+    file-local symbol. It is mandatory for cross-repository symbols
+    due to implementation limitations.
+    """
+    repository: String!
+
+    """
+    Defaults to HEAD of the default branch if not specified.
+    """
+    revision: String
+
+    """
+    Defaults to repo-wide search if the path is not specified.
+    This field is necessary if SymbolComparator is a file-local symbol.
+    It is mandatory for repository-local and cross-repo symbols
+    due to implementation limitations.
+    """
+    path: String!
+
+    """
+    Start position of the range (inclusive)
+    """
+    start: PositionInput
+
+    """
+    End position of the range (exclusive)
+    """
+    end: PositionInput
+}
+
+"""
+Analogous to Position but as an input type.
+
+EXPERIMENTAL: This type may make backwards-incompatible changes in the future.
+"""
+input PositionInput {
+    """
+    Zero-based count of newline (\n or \r\n) characters before this position.
+    """
+    line: Int!
+
+    """
+    Zero-based UTF-16 code unit offset from preceding newline (\n or \r\n) character.
+    """
+    character: Int!
+}
+
+# NOTE(id: filter-vs-comparator-terminology)
+#
+# 'Filter' is used for complex objects whereas 'Comparator' is used
+# for primitive objects.
+
+"""
+An empty filter allows all kinds of usages for all paths in all repositories.
+
+However, if the symbol used for lookup is a file-local symbol or a
+repository-local symbol, then usages will automatically be limited to the
+same file or same repository respectively.
+
+EXPERIMENTAL: This type may make backwards-incompatible changes in the future.
+"""
+# Design Rationale:
+#
+# 1. The ref panel did separate queries for 'this repo' vs 'all other repos'
+#    https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/client/web/src/enterprise/codeintel/searchBased.ts?L105:13-105:23#tab=references
+#    That requires `NOT` (at least for a `repo`).
+# 2. The ref panel has a way to specify paths for filtering. This requires AND.
+#    AND will not be part of the first implementation pass. However,
+#    it would allow fetching less data instead of post-filtering client-side.
+# 3. Currently, the ref panel has a setting for only showing precise results.
+#    Once syntactic is added, if we want to allow the user to specify either
+#    syntactic or precise (but not search-based), we'd need OR.
+#    OR will also not be needed for the first implementation pass.
+input UsagesFilter {
+    not: UsagesFilter
+    repository: RepositoryFilter
+    # TODO(id: usagesForSymbols-v2)
+    # and: [UsagesFilter!]
+    # or: [UsagesFilter!]
+    # path: PathFilter
+    # kind: SymbolUsageKindComparator
+    # provenance: CodeGraphDataProvenanceComparator
+}
+
+"""
+EXPERIMENTAL: This type may make backwards-incompatible changes in the future.
+"""
+input RepositoryFilter {
+    name: StringComparator!
+}
+
+"""
+EXPERIMENTAL: This type may make backwards-incompatible changes in the future.
+"""
+input StringComparator {
+    equals: String
+}
+
+"""
+EXPERIMENTAL: This type may make backwards-incompatible changes in the future.
+"""
+type UsageConnection {
+    nodes: [Usage!]!
+    pageInfo: PageInfo!
+}
+
+"""
+EXPERIMENTAL: This type may make backwards-incompatible changes in the future.
+"""
+type UsageRange {
+    repository: String!
+    """
+    TODO(issue: GRAPH-614): 'revision' field should have type GitCommit
+    before stabilizing this API.
+    """
+    revision: String!
+    path: String!
+    range: Range!
+}
+
+"""
+A place where a symbol is used (defined, referenced, forward-declared, etc.)
+
+EXPERIMENTAL: This type may make backwards-incompatible changes in the future.
+"""
+type Usage {
+    """
+    Information about the symbol itself.
+    """
+    symbol: SymbolInformation!
+
+    """
+    Invariant: `range.path` == `blob.path`. The path is made available
+    as part of this type for convenience.
+    """
+    usageRange: UsageRange
+
+    # Removed for now since GitBlobResolver is in graphqlbackend package.
+    #
+    #    """
+    #    Information about the full blob that contains this usage.
+    #
+    #    NOTE: Instead of requesting `blob.content`, it may be more useful
+    #    to ask for `surroundingContent`.
+    #    """
+    #    # Left as optional in case we support generated files in the future,
+    #    # which may not be represented by GitBlob.
+    #    blob: GitBlob
+
+    """
+    Instead of blob { content }, allows accessing a sub-span of the content
+    using relative coordinates from the range of this usage. If linesBefore
+    or linesAfter is negative or exceeds the number of available lines,
+    the value is interpreted as until the start/end of the file.
+    """
+    surroundingContent(surroundingLines: SurroundingLines = {linesBefore: 0, linesAfter: 0}): String
+}
+
+"""
+Type representing useful information about a symbol in code,
+based on 'SymbolInformation' in SCIP.
+
+EXPERIMENTAL: This type may make backwards-incompatible changes in the future.
+"""
+type SymbolInformation {
+    """
+    Symbol name using syntax specified by the SCIP schema.
+    https://github.com/sourcegraph/scip/blob/main/scip.proto#L147-L188
+    This value will generally be used in conjunction with
+    the `usagesBySymbol` API.
+    """
+    name: String!
+
+    """
+    Hover documentation for the symbol, in Markdown format.
+    The caller must take care to escape any particular strings,
+    such as raw HTML, as necessary.
+    The value is null when the hover documentation is not found
+    by 'dataSource'.
+    The value is empty when `dataSource` is confident that there
+    is no appropriate hover documentation to display.
+    """
+    documentation: [String!]
+
+    """
+    Coarse-grained information about the data source.
+    """
+    provenance: CodeGraphDataProvenance!
+
+    """
+    Opaque fine-grained information describing the data source.
+    Provided only for debugging.
+    This field should be ignored when checking structural equality.
+    """
+    dataSource: String
+}
+
+"""
+EXPERIMENTAL: This type may make backwards-incompatible changes in the future.
+"""
+input SurroundingLines {
+    linesBefore: Int
+    linesAfter: Int
+}
+
 """
 The SCIP snapshot decoration for a single SCIP Occurrence.
 """

--- a/cmd/frontend/graphqlbackend/git_tree_entry.go
+++ b/cmd/frontend/graphqlbackend/git_tree_entry.go
@@ -452,6 +452,10 @@ func (r *GitTreeEntryResolver) IsSingleChild(ctx context.Context) (bool, error) 
 	return err == io.EOF, nil
 }
 
+func NewXZ() *GitTreeEntryResolver {
+	return nil
+}
+
 func (r *GitTreeEntryResolver) LSIF(ctx context.Context, args *struct{ ToolName *string }) (resolverstubs.GitBlobLSIFDataResolver, error) {
 	var toolName string
 	if args.ToolName != nil {

--- a/cmd/frontend/internal/codeintel/init.go
+++ b/cmd/frontend/internal/codeintel/init.go
@@ -2,6 +2,7 @@ package codeintel
 
 import (
 	"context"
+	"github.com/sourcegraph/sourcegraph/internal/search/client"
 	"net/http"
 
 	"github.com/sourcegraph/log"
@@ -54,6 +55,8 @@ func Init(
 	locationResolverFactory := gitresolvers.NewCachedLocationResolverFactory(repoStore, codeIntelServices.GitserverClient)
 	uploadLoaderFactory := uploadgraphql.NewUploadLoaderFactory(codeIntelServices.UploadsService)
 	indexLoaderFactory := uploadgraphql.NewIndexLoaderFactory(codeIntelServices.UploadsService)
+	// TODO(Christoph): Use a proper logger
+	searcherClient := client.New(log.NoOp(), db, codeIntelServices.GitserverClient)
 	preciseIndexResolverFactory := uploadgraphql.NewPreciseIndexResolverFactory(
 		codeIntelServices.UploadsService,
 		codeIntelServices.PoliciesService,
@@ -79,6 +82,7 @@ func Init(
 		codeIntelServices.GitserverClient,
 		siteAdminChecker,
 		repoStore,
+		searcherClient,
 		uploadLoaderFactory,
 		indexLoaderFactory,
 		preciseIndexResolverFactory,

--- a/internal/codeintel/codenav/transport/graphql/observability.go
+++ b/internal/codeintel/codenav/transport/graphql/observability.go
@@ -27,6 +27,7 @@ type operations struct {
 	ranges          *observation.Operation
 	snapshot        *observation.Operation
 	visibleIndexes  *observation.Operation
+	usagesForSymbol *observation.Operation
 }
 
 func newOperations(observationCtx *observation.Context) *operations {

--- a/internal/codeintel/codenav/transport/graphql/root_resolver.go
+++ b/internal/codeintel/codenav/transport/graphql/root_resolver.go
@@ -3,6 +3,7 @@ package graphql
 import (
 	"context"
 	"fmt"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 	"strings"
 	"sync"
 
@@ -188,6 +189,31 @@ func preferUploadsWithLongestRoots(uploads []shared.CompletedUpload) []shared.Co
 		out = append(out, pair.Value)
 	}
 	return out
+}
+
+func (r *rootResolver) UsagesForSymbol(ctx context.Context, args *resolverstubs.UsagesForSymbolArgs) (resolverstubs.UsageConnectionResolver, error) {
+	return nil, errors.New("Not implemented yet")
+	//ctx, _, endObservation := r.operations.usagesForSymbol.WithErrors(ctx, &err, observation.Args{ /*TODO: Add args*/ })
+	//endObservation.OnCancel(ctx, 1, observation.Args{})
+	//
+	//shouldPerformPreciseLookup := false
+	//if args != nil && args.Symbol != nil && args.Symbol.Name.Equals != nil && args.Symbol.Provenance.Equals != nil && *args.Symbol.Provenance.Equals == resolverstubs.ProvenancePrecise {
+	//	shouldPerformPreciseLookup = true
+	//}
+	//if shouldPerformPreciseLookup {
+	//
+	//}
+	//
+	//shouldPerformSearchQuery := false
+	//if shouldPerformSearchQuery {
+	//	symbolString := ""
+	//	// Perform search query with Searcher/Zoekt
+	//	performSearchQuery := func(string s) {}
+	//	performSearchQuery(symbolString) // pass in repo filters
+	//}
+	//if args != nil && args.Symbol != nil && args.S != "" {
+	//	return nil, nil
+	//}
 }
 
 // gitBlobLSIFDataResolver is the main interface to bundle-related operations exposed to the GraphQL API. This

--- a/internal/codeintel/resolvers/root_resolver.go
+++ b/internal/codeintel/resolvers/root_resolver.go
@@ -129,6 +129,10 @@ func (r *Resolver) CodeGraphData(ctx context.Context, opts *CodeGraphDataOpts) (
 	return r.codenavResolver.CodeGraphData(ctx, opts)
 }
 
+func (r *Resolver) UsagesForSymbol(ctx context.Context, args *UsagesForSymbolArgs) (UsageConnectionResolver, error) {
+	return r.codenavResolver.UsagesForSymbol(ctx, args)
+}
+
 func (r *Resolver) ConfigurationPolicyByID(ctx context.Context, id graphql.ID) (_ CodeIntelligenceConfigurationPolicyResolver, err error) {
 	return r.policiesRootResolver.ConfigurationPolicyByID(ctx, id)
 }


### PR DESCRIPTION
PoC for calling out to searcher from the codeintel codenav resolver that'll eventually handle syntactic usages.

## Test plan

Trigger this codepath locally using the apps [GraphQL explorer](https://sourcegraph.test:3443/api/console#%7B%22query%22%3A%22%23%20query%20GetRepoID(%24name%3A%20String!)%20%7B%5Cn%23%20%20%20repository(name%3A%20%24name)%20%7B%5Cn%23%20%20%20%20%20id%5Cn%23%20%20%20%7D%5Cn%23%20%7D%5Cn%5Cn%5Cnquery%20S()%20%7B%5Cn%20%20usagesForSymbol(range%3A%20%7B%5Cn%20%20%20%20repository%3A%20%5C%22github.com%2Fsourcegraph%2Fconc%5C%22%5Cn%20%20%20%20path%3A%20%5C%22pool%2Fpool.go%5C%22%5Cn%20%20%7D)%20%7B%5Cn%20%20%20%20nodes%20%7B%5Cn%20%20%20%20%20%20symbol%20%7B%5Cn%20%20%20%20%20%20%20%20name%5Cn%20%20%20%20%20%20%7D%5Cn%20%20%20%20%7D%5Cn%20%20%7D%5Cn%7D%5Cn%5Cn%23%20%20%20%5C%22name%5C%22%3A%20%5C%22github.com%2Fvitejs%2Fvite%5C%22%5Cn%22%7D) 