### PR TITLE
fix/telemetry: fix dotcom-mode sensitive metadata removal

### DIFF
--- a/internal/telemetry/sensitivemetadataallowlist/BUILD.bazel
+++ b/internal/telemetry/sensitivemetadataallowlist/BUILD.bazel
@@ -29,6 +29,7 @@ go_test(
     embed = [":sensitivemetadataallowlist"],
     tags = [TAG_INFRA_CORESERVICES],
     deps = [
+        "//internal/dotcom",
         "//internal/telemetry",
         "//lib/pointers",
         "//lib/telemetrygateway/v1:telemetrygateway",

--- a/internal/telemetry/sensitivemetadataallowlist/redact.go
+++ b/internal/telemetry/sensitivemetadataallowlist/redact.go
@@ -24,10 +24,10 @@ const (
 
 // 🚨 SECURITY: Be very careful with the redaction mechanisms here, as it impacts
 // what data we export from customer Sourcegraph instances.
-func redactEvent(event *telemetrygatewayv1.Event, mode redactMode, allowedPrivateMetadataKeys []string) {
+func redactEvent(event *telemetrygatewayv1.Event, mode redactMode, allowedPrivateMetadataKeys []string) redactMode {
 	// redactNothing (generally only in dotcom)
 	if mode >= redactNothing {
-		return
+		return mode
 	}
 
 	// redactMarketingAndUnallowedPrivateMetadataKeys
@@ -35,6 +35,9 @@ func redactEvent(event *telemetrygatewayv1.Event, mode redactMode, allowedPrivat
 	if mode >= redactMarketingAndUnallowedPrivateMetadataKeys {
 		// Do private metadata redaction in this if case, as the next case will strip
 		// everything
+		if event.Parameters == nil {
+			return mode
+		}
 		for key, value := range event.Parameters.PrivateMetadata.Fields {
 			if !slices.Contains(allowedPrivateMetadataKeys, key) {
 				// Strip all keys that are NOT in the allowlist, as they are considered sensitive.
@@ -47,11 +50,12 @@ func redactEvent(event *telemetrygatewayv1.Event, mode redactMode, allowedPrivat
 					structpb.NewStringValue(fmt.Sprintf("ERROR: value of allowlisted key was not a string, got: %T", value.Kind))
 			}
 		}
-		return
+		return mode
 	}
 
 	// redactAllSensitive
 	if event.Parameters != nil {
 		event.Parameters.PrivateMetadata = nil
 	}
+	return mode
 }

--- a/internal/telemetry/sensitivemetadataallowlist/redact.go
+++ b/internal/telemetry/sensitivemetadataallowlist/redact.go
@@ -35,10 +35,10 @@ func redactEvent(event *telemetrygatewayv1.Event, mode redactMode, allowedPrivat
 	if mode >= redactMarketingAndUnallowedPrivateMetadataKeys {
 		// Do private metadata redaction in this if case, as the next case will strip
 		// everything
-		if event.Parameters == nil {
+		if event.Parameters == nil || event.Parameters.PrivateMetadata == nil {
 			return mode
 		}
-		for key, value := range event.Parameters.PrivateMetadata.Fields {
+		for key, value := range event.GetParameters().GetPrivateMetadata().GetFields() {
 			if !slices.Contains(allowedPrivateMetadataKeys, key) {
 				// Strip all keys that are NOT in the allowlist, as they are considered sensitive.
 				// No need to check data types, since we're only dealing with keys.

--- a/internal/telemetry/sensitivemetadataallowlist/sensitivemetadataallowlist.go
+++ b/internal/telemetry/sensitivemetadataallowlist/sensitivemetadataallowlist.go
@@ -76,13 +76,13 @@ func eventTypes(types ...EventType) EventTypes {
 //
 // 🚨 SECURITY: Be very careful with the redaction modes used here, as it impacts
 // what data we export from customer Sourcegraph instances.
-func (e EventTypes) Redact(event *telemetrygatewayv1.Event) {
+func (e EventTypes) Redact(event *telemetrygatewayv1.Event) redactMode {
 	if dotcom.SourcegraphDotComMode() {
-		redactEvent(event, redactNothing, nil)
+		return redactEvent(event, redactNothing, nil)
 	} else if keys, allowed := e.IsAllowed(event); allowed {
-		redactEvent(event, redactMarketingAndUnallowedPrivateMetadataKeys, keys)
+		return redactEvent(event, redactMarketingAndUnallowedPrivateMetadataKeys, keys)
 	}
-	redactEvent(event, redactAllSensitive, nil)
+	return redactEvent(event, redactAllSensitive, nil)
 }
 
 // IsAllowed indicates an event is on the sensitive telemetry allowlist, and the fields that


### PR DESCRIPTION
Fixes a regression from #62830 that caused us to remove all sensitive metadata in dotcom mode, even though we generally collect all sensitive metadata in dotcom. This also fixes export of actually-allowlisted private metadata from custom instances.

tl;dr we accidentally started removing all private metadata, all the time

## Test plan

New unit test covering the redact mode that was evaluated