### PR TITLE
feat/enterprise-portal: add offline mode that allows all auth tokens

### DIFF
--- a/cmd/enterprise-portal/internal/samsm2m/BUILD.bazel
+++ b/cmd/enterprise-portal/internal/samsm2m/BUILD.bazel
@@ -3,12 +3,16 @@ load("//dev:go_defs.bzl", "go_test")
 
 go_library(
     name = "samsm2m",
-    srcs = ["samsm2m.go"],
+    srcs = [
+        "offline.go",
+        "samsm2m.go",
+    ],
     importpath = "github.com/sourcegraph/sourcegraph/cmd/enterprise-portal/internal/samsm2m",
     visibility = ["//cmd/enterprise-portal:__subpackages__"],
     deps = [
         "//cmd/enterprise-portal/internal/connectutil",
         "//internal/authbearer",
+        "//internal/env",
         "//lib/errors",
         "@com_connectrpc_connect//:connect",
         "@com_github_sourcegraph_log//:log",

--- a/cmd/enterprise-portal/internal/samsm2m/offline.go
+++ b/cmd/enterprise-portal/internal/samsm2m/offline.go
@@ -1,0 +1,36 @@
+package samsm2m
+
+import (
+	"context"
+	"time"
+
+	"github.com/sourcegraph/log"
+
+	sams "github.com/sourcegraph/sourcegraph-accounts-sdk-go"
+	"github.com/sourcegraph/sourcegraph-accounts-sdk-go/scopes"
+	"github.com/sourcegraph/sourcegraph/internal/env"
+)
+
+// OfflineTokenInstrospector is a TokenIntrospector that always returns a valid
+// introspection response with the configured client ID and scopes.
+//
+// 🚨 Only use for local development!
+type OfflineTokenInstrospector struct {
+	Logger   log.Logger
+	ClientID string
+	Scopes   scopes.Scopes
+}
+
+func (i OfflineTokenInstrospector) IntrospectToken(context.Context, string) (*sams.IntrospectTokenResponse, error) {
+	if !env.InsecureDev {
+		i.Logger.Fatal("only use OfflineTokenInstrospector in development with 'INSECURE_DEV=true'")
+	}
+	i.Logger.Debug("IntrospectToken request",
+		log.Strings("scopes", scopes.ToStrings(i.Scopes)))
+	return &sams.IntrospectTokenResponse{
+		Active:    true,
+		ClientID:  i.ClientID,
+		Scopes:    i.Scopes,
+		ExpiresAt: time.Now().Add(30 * time.Minute),
+	}, nil
+}

--- a/cmd/enterprise-portal/service/BUILD.bazel
+++ b/cmd/enterprise-portal/service/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
     deps = [
         "//cmd/enterprise-portal/internal/codyaccessservice",
         "//cmd/enterprise-portal/internal/dotcomdb",
+        "//cmd/enterprise-portal/internal/samsm2m",
         "//cmd/enterprise-portal/internal/subscriptionsservice",
         "//internal/debugserver",
         "//internal/httpserver",
@@ -22,6 +23,7 @@ go_library(
         "//lib/errors",
         "//lib/managedservicesplatform/cloudsql",
         "//lib/managedservicesplatform/runtime",
+        "//lib/pointers",
         "@com_connectrpc_grpcreflect//:grpcreflect",
         "@com_github_jackc_pgx_v5//:pgx",
         "@com_github_sourcegraph_log//:log",

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -401,9 +401,11 @@ commands:
       DIAGNOSTICS_SECRET: sekret
       SRC_LOG_LEVEL: debug
       GRPC_WEB_UI_ENABLED: 'true'
-      # Used for authentication
+      # Used offline authentication for local development - see
+      # 'cmd/enterprise-portal/internal/samsm2m/offline.go'
+      SAMS_API_URL: offline
       SAMS_URL: https://accounts.sgdev.org
-      # Set real values in sg.config.yaml overrides
+      # Set these values in 'sg.config.overwrite.yaml' for integration testing.
       ENTERPRISE_PORTAL_SAMS_CLIENT_ID: "sams_cid_put_a_real_value_in_sg.config.overwrite.yaml"
       ENTERPRISE_PORTAL_SAMS_CLIENT_SECRET: "sams_cs_put_a_real_value_in_sg.config.overwrite.yaml"
     watch:


### PR DESCRIPTION
For https://github.com/sourcegraph/sourcegraph/pull/62934 we probably want a local dev mode default that is ergonomic and offline for Enterprise Portal, i.e. doesn't need to connect to SAMS-dev, for everyone who works on Cody Gateway, which will now talk to Enterprise Portal instead. This change adds a special `SAMS_API_URL=offline` mode that allows all tokens locally, with various safeguards against this being used in any live deployment environment.

## Test plan
<img width="766" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/23356519/8f1e65b8-2884-4cda-a8b8-63861501a585">

```
[enterprise-...l] DEBUG samsm2m.OfflineTokenInstrospector samsm2m/offline.go:28 IntrospectToken request {"scopes": ["enterprise_portal::codyaccess::read", "enterprise_portal::subscription::read"]}
```