### PR TITLE
feat/sg/enterprise-portal: use externalSecret to configure SAMS client secret

### DIFF
--- a/dev/sg/internal/run/sgconfig_command_options.go
+++ b/dev/sg/internal/run/sgconfig_command_options.go
@@ -21,7 +21,7 @@ type SGConfigCommandOptions struct {
 
 	// Output all logs to a file instead of to stdout/stderr
 	Logfile         string                            `yaml:"logfile"`
-	ExternalSecrets map[string]secrets.ExternalSecret `yaml:"external_secrets"`
+	ExternalSecrets map[string]secrets.ExternalSecret `yaml:"externalSecrets"`
 
 	RepositoryRoot string
 }

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -403,9 +403,13 @@ commands:
       GRPC_WEB_UI_ENABLED: 'true'
       # Used for authentication
       SAMS_URL: https://accounts.sgdev.org
-      # Set real values in sg.config.yaml overrides
-      ENTERPRISE_PORTAL_SAMS_CLIENT_ID: "sams_cid_put_a_real_value_in_sg.config.overwrite.yaml"
-      ENTERPRISE_PORTAL_SAMS_CLIENT_SECRET: "sams_cs_put_a_real_value_in_sg.config.overwrite.yaml"
+      # client name: 'enterprise-portal-local-dev'
+      ENTERPRISE_PORTAL_SAMS_CLIENT_ID: "sams_cid_018fc125-5a92-70fa-8dee-2c6df3adc100"
+    externalSecrets:
+      ENTERPRISE_PORTAL_SAMS_CLIENT_SECRET:
+        project: sourcegraph-local-dev
+        name: ENTERPRISE_PORTAL_LOCAL_SAMS_CLIENT_SECRET
+
     watch:
       - lib
       - cmd/enterprise-portal
@@ -1869,7 +1873,7 @@ tests:
       TEST_USER_PASSWORD: supersecurepassword
       SOURCEGRAPH_BASE_URL: https://sourcegraph.test:3443
       BROWSER: chrome
-    external_secrets:
+    externalSecrets:
       GH_TOKEN:
         project: 'sourcegraph-ci'
         name: 'BUILDKITE_GITHUBDOTCOM_TOKEN'


### PR DESCRIPTION
Use shared credentials for local development - replaces #62952 

## Test plan
```
sg run enterprise-portal
```