### PR TITLE
Batch changes: remove structural search example

### DIFF
--- a/client/web/src/enterprise/batches/batch-spec/edit/library/comby.batch.yaml
+++ b/client/web/src/enterprise/batches/batch-spec/edit/library/comby.batch.yaml
@@ -5,7 +5,7 @@ description: |
 
 # Find all repositories that contain the `fmt.Sprintf` statement using structural search
 on:
-  - repositoriesMatchingQuery: lang:go fmt.Sprintf("%d", :[v]) patterntype:structural
+  - repositoriesMatchingQuery: lang:go fmt.Sprintf\("%d", \w+\) patterntype:regexp
 
 steps:
   # Run Comby (https://comby.dev) to replace the Go statements...

--- a/doc/dev/how-to/opentelemetry_local_dev.md
+++ b/doc/dev/how-to/opentelemetry_local_dev.md
@@ -25,6 +25,6 @@ Set `dev-private` site config to use `"observability.tracing": { "type": "opente
 
 ## Testing
 
-Use `sg start` to start services, and run a complex query with `&trace=1`, e.g. [`foobar(...) patterntype:structural`](https://sourcegraph.test:3443/search?q=context%3Aglobal+foobar%28...%29&patternType=structural&trace=1)—this will show the `View trace` button in the search results.
+Use `sg start` to start services, and run a complex query with `&trace=1`, e.g. [`foobar\(\w+\) patterntype:regexp`](https://sourcegraph.test:3443/search?q=context%3Aglobal+foobar%28...%29&patternType=regexp&trace=1)—this will show the `View trace` button in the search results.
 
 When using different backends, you can use `"urlTemplate"` in `"observability.tracing"` to configure the link.


### PR DESCRIPTION
This PR refactors a batch changes example that uses `patterntype:structural` to
use regex instead. We no longer expose `patterntype:structural` by default, and
want to push users towards other pattern types.

## Test plan

Manually tested the batch changes template.