### PR TITLE
fix: Initialize operation for UsagesForSymbol

### DIFF
--- a/internal/codeintel/codenav/transport/graphql/observability.go
+++ b/internal/codeintel/codenav/transport/graphql/observability.go
@@ -60,6 +60,7 @@ func newOperations(observationCtx *observation.Context) *operations {
 		ranges:          op("Ranges"),
 		snapshot:        op("Snapshot"),
 		visibleIndexes:  op("VisibleIndexes"),
+		usagesForSymbol: op("UsagesForSymbol"),
 	}
 }
 


### PR DESCRIPTION
Accidentally merged this while leaving the operation `nil`

## Changelog

- Fixed a bug in stub implementation of UsagesForSymbol

## Test plan

Open [https://sourcegraph.test:3443/api/console#%7B%22query%22%3A%22%23%20query%20GetRepoID(%24name[…]A%20%5C%22github.com%2Fvitejs%2Fvite%5C%22%5Cn%22%7D](https://sourcegraph.test:3443/api/console#%7B%22query%22%3A%22%23%20query%20GetRepoID(%24name%3A%20String!)%20%7B%5Cn%23%20%20%20repository(name%3A%20%24name)%20%7B%5Cn%23%20%20%20%20%20id%5Cn%23%20%20%20%7D%5Cn%23%20%7D%5Cn%5Cn%5Cnquery%20S()%20%7B%5Cn%20%20usagesForSymbol(range%3A%20%7B%5Cn%20%20%20%20repository%3A%20%5C%22github.com%2Fsourcegraph%2Fconc%5C%22%5Cn%20%20%20%20path%3A%20%5C%22pool%2Fpool.go%5C%22%5Cn%20%20%7D)%20%7B%5Cn%20%20%20%20nodes%20%7B%5Cn%20%20%20%20%20%20symbol%20%7B%5Cn%20%20%20%20%20%20%20%20name%5Cn%20%20%20%20%20%20%7D%5Cn%20%20%20%20%7D%5Cn%20%20%7D%5Cn%7D%5Cn%5Cn%23%20%20%20%5C%22name%5C%22%3A%20%5C%22github.com%2Fvitejs%2Fvite%5C%22%5Cn%22%7D) locally