### PR TITLE
feat(codeintel): If SignatureDocumentation is present in SCIP, use it for hover text

### DIFF
--- a/internal/codeintel/codenav/internal/lsifstore/locations_by_position.go
+++ b/internal/codeintel/codenav/internal/lsifstore/locations_by_position.go
@@ -283,7 +283,7 @@ func extractOccurrenceData(document *scip.Document, occurrence *scip.Occurrence)
 	// we should include in reference and implementation searches.
 
 	if symbol := scip.FindSymbol(document, occurrence.Symbol); symbol != nil {
-		hoverText = symbol.Documentation
+		hoverText = symbolHoverText(symbol)
 
 		for _, rel := range symbol.Relationships {
 			if rel.IsDefinition {
@@ -366,8 +366,15 @@ func monikersToString(vs []precise.MonikerData) string {
 	return strings.Join(strs, ", ")
 }
 
-//
-//
+func symbolHoverText(symbol *scip.SymbolInformation) []string {
+	if symbol.SignatureDocumentation != nil {
+		signature := []string{fmt.Sprintf("```%s\n%s\n```", symbol.SignatureDocumentation.Language, symbol.SignatureDocumentation.Text)}
+		return append(signature, symbol.Documentation...)
+	} else {
+		return symbol.Documentation
+	}
+
+}
 
 func (s *store) ExtractDefinitionLocationsFromPosition(ctx context.Context, locationKey LocationKey) (_ []shared.Location, _ []string, err error) {
 	return s.extractLocationsFromPosition(ctx, extractDefinitionRanges, symbolExtractDefault, s.operations.getDefinitionLocations, locationKey)

--- a/internal/codeintel/codenav/internal/lsifstore/locations_by_position.go
+++ b/internal/codeintel/codenav/internal/lsifstore/locations_by_position.go
@@ -367,18 +367,11 @@ func monikersToString(vs []precise.MonikerData) string {
 }
 
 func symbolHoverText(symbol *scip.SymbolInformation) []string {
-	if symbol.SignatureDocumentation != nil {
-		signature := symbol.SignatureDocumentation
-		if signature.Text != "" && signature.Language != "" {
-			signature := []string{fmt.Sprintf("```%s\n%s\n```", symbol.SignatureDocumentation.Language, symbol.SignatureDocumentation.Text)}
-			return append(signature, symbol.Documentation...)
-		} else {
-			return symbol.Documentation
-		}
-	} else {
-		return symbol.Documentation
+	if sigdoc := symbol.SignatureDocumentation; sigdoc != nil && sigdoc.Text != "" && sigdoc.Language != "" {
+		signature := []string{fmt.Sprintf("```%s\n%s\n```", sigdoc.Language, sigdoc.Text)}
+		return append(signature, symbol.Documentation...)
 	}
-
+	return symbol.Documentation
 }
 
 func (s *store) ExtractDefinitionLocationsFromPosition(ctx context.Context, locationKey LocationKey) (_ []shared.Location, _ []string, err error) {

--- a/internal/codeintel/codenav/internal/lsifstore/locations_by_position.go
+++ b/internal/codeintel/codenav/internal/lsifstore/locations_by_position.go
@@ -368,8 +368,13 @@ func monikersToString(vs []precise.MonikerData) string {
 
 func symbolHoverText(symbol *scip.SymbolInformation) []string {
 	if symbol.SignatureDocumentation != nil {
-		signature := []string{fmt.Sprintf("```%s\n%s\n```", symbol.SignatureDocumentation.Language, symbol.SignatureDocumentation.Text)}
-		return append(signature, symbol.Documentation...)
+		signature := symbol.SignatureDocumentation
+		if signature.Text != "" && signature.Language != "" {
+			signature := []string{fmt.Sprintf("```%s\n%s\n```", symbol.SignatureDocumentation.Language, symbol.SignatureDocumentation.Text)}
+			return append(signature, symbol.Documentation...)
+		} else {
+			return symbol.Documentation
+		}
 	} else {
 		return symbol.Documentation
 	}

--- a/internal/codeintel/codenav/internal/lsifstore/locations_by_position_test.go
+++ b/internal/codeintel/codenav/internal/lsifstore/locations_by_position_test.go
@@ -610,6 +610,27 @@ func TestExtractOccurrenceData(t *testing.T) {
 					"it does the thing",
 				},
 			},
+			{
+				explanation: "#3: SignatureDocumentation is present, but Text/Language are empty",
+				document: &scip.Document{
+					Symbols: []*scip.SymbolInformation{
+						{
+							Symbol:                 "react 17.1 main.go func1",
+							SignatureDocumentation: &scip.Document{},
+							Documentation: []string{
+								"it does the thing",
+							},
+						},
+					},
+				},
+				occurrence: &scip.Occurrence{
+					Symbol:      "react 17.1 main.go func1",
+					SymbolRoles: 1,
+				},
+				hoverText: []string{
+					"it does the thing",
+				},
+			},
 		}
 
 		for _, testCase := range testCases {

--- a/internal/codeintel/codenav/internal/lsifstore/locations_by_position_test.go
+++ b/internal/codeintel/codenav/internal/lsifstore/locations_by_position_test.go
@@ -556,6 +556,69 @@ func TestExtractOccurrenceData(t *testing.T) {
 		}
 	})
 
+	t.Run("documentation and signature documentation", func(t *testing.T) {
+		testCases := []struct {
+			explanation string
+			document    *scip.Document
+			occurrence  *scip.Occurrence
+			hoverText   []string
+		}{
+			{
+				explanation: "#1 backwards compatibility: SignatureDocumentation is absent, Documentation is present",
+				document: &scip.Document{
+					Symbols: []*scip.SymbolInformation{
+						{
+							Symbol: "react 17.1 main.go func1",
+							Documentation: []string{
+								"```go\nfunc1()\n```",
+								"it does the thing",
+							},
+						},
+					},
+				},
+				occurrence: &scip.Occurrence{
+					Symbol:      "react 17.1 main.go func1",
+					SymbolRoles: 1,
+				},
+				hoverText: []string{
+					"```go\nfunc1()\n```",
+					"it does the thing",
+				},
+			},
+			{
+				explanation: "#2: SignatureDocumentation is present",
+				document: &scip.Document{
+					Symbols: []*scip.SymbolInformation{
+						{
+							Symbol: "react 17.1 main.go func1",
+							SignatureDocumentation: &scip.Document{
+								Language: "go",
+								Text:     "func1()",
+							},
+							Documentation: []string{
+								"it does the thing",
+							},
+						},
+					},
+				},
+				occurrence: &scip.Occurrence{
+					Symbol:      "react 17.1 main.go func1",
+					SymbolRoles: 1,
+				},
+				hoverText: []string{
+					"```go\nfunc1()\n```",
+					"it does the thing",
+				},
+			},
+		}
+
+		for _, testCase := range testCases {
+			if diff := cmp.Diff(testCase.hoverText, extractOccurrenceData(testCase.document, testCase.occurrence).hoverText); diff != "" {
+				t.Errorf("unexpected documentation (-want +got):\n%s -- %s", diff, testCase.explanation)
+			}
+		}
+	})
+
 	t.Run("implementations", func(t *testing.T) {
 		testCases := []struct {
 			explanation    string

--- a/internal/codeintel/codenav/internal/lsifstore/metadata_by_position.go
+++ b/internal/codeintel/codenav/internal/lsifstore/metadata_by_position.go
@@ -94,7 +94,7 @@ func (s *store) GetHover(ctx context.Context, bundleID int, path string, line, c
 				}
 
 				// Return first match
-				return strings.Join(symbol.Documentation, "\n"), rangeBySymbol[symbolName], true, nil
+				return strings.Join(symbolHoverText(symbol), "\n"), rangeBySymbol[symbolName], true, nil
 			}
 		}
 	}


### PR DESCRIPTION
Fixes GRAPH-610

1. We prepend a markdown-formatted signature to the hover text if SignatureDocumentation field if present
2. If the field is absent, we fall back to old behaviour of assuming that signature documentation is already present in the hover text

SignatureDocumentation was added to SCIP format a while back but it's not yet being utilised by our indexers. One of the first to do so will be scip-java (https://github.com/sourcegraph/scip-java/pull/707) – with the plan for rollout being:

1. Merge this PR and wait for a Sourcegraph release
2. Merge scip-java PR and tag a release
3. (optionally) update the default scip-java image in SG

This change allows handling both new SCIP indexes (those that emit SignatureDocumentation), and the old ones, which have signature prepended to Documentation field.

## Test plan

- New tests for the signature and documentation


## Changelog

- The backend now respects the SCIP [signature_documentation](https://github.com/sourcegraph/scip/blob/main/scip.proto#L409-L415) field, and if available, uses that to create the initial part of the hover text. SCIP indexers should not repeat the text in signature_documentation inside the documentation field.