### PR TITLE
feat/enterprise-portal: explicit opt-in to serve non-dev/non-internal data

### DIFF
--- a/cmd/enterprise-portal/internal/dotcomdb/dotcomdb.go
+++ b/cmd/enterprise-portal/internal/dotcomdb/dotcomdb.go
@@ -207,7 +207,8 @@ FROM product_subscriptions subscription
 		clauses = append(clauses, "HAVING "+conds.havingClause)
 	}
 	if opts.DevOnly {
-		c := fmt.Sprintf("('%s' = ANY(MAX(active_license.license_tags)) OR '%s' = ANY(MAX(active_license.license_tags)))",
+		// '&&' operator: overlap (have elements in common)
+		c := fmt.Sprintf("ARRAY['%s','%s'] && MAX(active_license.license_tags)",
 			licensing.DevTag, licensing.InternalTag)
 		if conds.havingClause != "" {
 			clauses = append(clauses, "AND "+c)
@@ -325,7 +326,8 @@ LEFT JOIN product_subscriptions subscriptions
 		clauses = append(clauses, "WHERE "+conds.whereClause)
 	}
 	if opts.DevOnly {
-		c := fmt.Sprintf("('%s' = ANY(licenses.license_tags) OR '%s' = ANY(licenses.license_tags))",
+		// '&&' operator: overlap (have elements in common)
+		c := fmt.Sprintf("ARRAY['%s','%s'] && licenses.license_tags",
 			licensing.DevTag, licensing.InternalTag)
 		if conds.whereClause != "" {
 			clauses = append(clauses, "AND "+c)

--- a/cmd/enterprise-portal/internal/dotcomdb/dotcomdb.go
+++ b/cmd/enterprise-portal/internal/dotcomdb/dotcomdb.go
@@ -25,6 +25,13 @@ import (
 
 type Reader struct {
 	conn *pgx.Conn
+	opts ReaderOptions
+}
+
+type ReaderOptions struct {
+	// DevOnly indicates that this Reader should only return subscriptions,
+	// licenses, etc. that are only used for development.
+	DevOnly bool
 }
 
 // NewReader wraps a direct connection to the Sourcegraph.com database. It
@@ -33,8 +40,8 @@ type Reader struct {
 //
 // 👷 This is intended to be a short-lived mechanism, and should be removed
 // as part of https://linear.app/sourcegraph/project/12f1d5047bd2/overview.
-func NewReader(conn *pgx.Conn) *Reader {
-	return &Reader{conn: conn}
+func NewReader(conn *pgx.Conn, opts ReaderOptions) *Reader {
+	return &Reader{conn: conn, opts: opts}
 }
 
 func (r *Reader) Ping(ctx context.Context) error {
@@ -148,7 +155,7 @@ func (q *queryConditions) addWhere(cond string) {
 	}
 }
 
-func newCodyGatewayAccessQuery(conds queryConditions) string {
+func newCodyGatewayAccessQuery(conds queryConditions, opts ReaderOptions) string {
 	const rawClause = `
 SELECT
 	subscription.id,
@@ -199,6 +206,15 @@ FROM product_subscriptions subscription
 	if conds.havingClause != "" {
 		clauses = append(clauses, "HAVING "+conds.havingClause)
 	}
+	if opts.DevOnly {
+		c := fmt.Sprintf("('%s' = ANY(MAX(active_license.license_tags)) OR '%s' = ANY(MAX(active_license.license_tags)))",
+			licensing.DevTag, licensing.InternalTag)
+		if conds.havingClause != "" {
+			clauses = append(clauses, "AND "+c)
+		} else {
+			clauses = append(clauses, "HAVING "+c)
+		}
+	}
 	return strings.Join(clauses, "\n")
 }
 
@@ -210,7 +226,7 @@ type GetCodyGatewayAccessAttributesOpts struct {
 func (r *Reader) GetCodyGatewayAccessAttributesBySubscription(ctx context.Context, subscriptionID string) (*CodyGatewayAccessAttributes, error) {
 	query := newCodyGatewayAccessQuery(queryConditions{
 		whereClause: "subscription.id = $1",
-	})
+	}, r.opts)
 	row := r.conn.QueryRow(ctx, query,
 		strings.TrimPrefix(subscriptionID, subscriptionsv1.EnterpriseSubscriptionIDPrefix))
 	return scanCodyGatewayAccessAttributes(row)
@@ -232,7 +248,7 @@ func (r *Reader) GetCodyGatewayAccessAttributesByAccessToken(ctx context.Context
 
 	query := newCodyGatewayAccessQuery(queryConditions{
 		havingClause: "$1 = ANY(array_agg(tokens.license_key_hash))",
-	})
+	}, r.opts)
 	row := r.conn.QueryRow(ctx, query, decoded)
 	return scanCodyGatewayAccessAttributes(row)
 }
@@ -262,7 +278,7 @@ func scanCodyGatewayAccessAttributes(row pgx.Row) (*CodyGatewayAccessAttributes,
 }
 
 func (r *Reader) GetAllCodyGatewayAccessAttributes(ctx context.Context) ([]*CodyGatewayAccessAttributes, error) {
-	query := newCodyGatewayAccessQuery(queryConditions{})
+	query := newCodyGatewayAccessQuery(queryConditions{}, r.opts)
 	rows, err := r.conn.Query(ctx, query)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get cody gateway access attributes")
@@ -281,7 +297,7 @@ func (r *Reader) GetAllCodyGatewayAccessAttributes(ctx context.Context) ([]*Cody
 
 var ErrEnterpriseSubscriptionLicenseNotFound = errors.New("enterprise subscription license not found")
 
-func newLicensesQuery(conds queryConditions) string {
+func newLicensesQuery(conds queryConditions, opts ReaderOptions) string {
 	const rawClause = `
 SELECT
 	-- EnterpriseSubscriptionLicense
@@ -307,6 +323,15 @@ LEFT JOIN product_subscriptions subscriptions
 	clauses := []string{rawClause}
 	if conds.whereClause != "" {
 		clauses = append(clauses, "WHERE "+conds.whereClause)
+	}
+	if opts.DevOnly {
+		c := fmt.Sprintf("('%s' = ANY(licenses.license_tags) OR '%s' = ANY(licenses.license_tags))",
+			licensing.DevTag, licensing.InternalTag)
+		if conds.whereClause != "" {
+			clauses = append(clauses, "AND "+c)
+		} else {
+			clauses = append(clauses, "WHERE "+c)
+		}
 	}
 	if conds.havingClause != "" {
 		clauses = append(clauses, "HAVING "+conds.havingClause)
@@ -390,7 +415,7 @@ func (r *Reader) ListEnterpriseSubscriptionLicenses(
 		}
 	}
 
-	query := newLicensesQuery(conds)
+	query := newLicensesQuery(conds, r.opts)
 	rows, err := r.conn.Query(ctx, query, args...)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get cody gateway access attributes")

--- a/cmd/enterprise-portal/internal/dotcomdb/dotcomdb_test.go
+++ b/cmd/enterprise-portal/internal/dotcomdb/dotcomdb_test.go
@@ -62,7 +62,9 @@ func newTestDotcomReader(t *testing.T) (database.DB, *dotcomdb.Reader) {
 	require.NoError(t, err)
 
 	// Make sure it works!
-	r := dotcomdb.NewReader(conn)
+	r := dotcomdb.NewReader(conn, dotcomdb.ReaderOptions{
+		DevOnly: true,
+	})
 	require.NoError(t, r.Ping(ctx))
 
 	return database.NewDB(logtest.Scoped(t), sgtestdb), r
@@ -93,6 +95,7 @@ func setupDBAndInsertMockLicense(t *testing.T, dotcomdb database.DB, info licens
 		_, err = licensesdb.Create(ctx, sub, t.Name()+"-barbaz", 2, license.Info{
 			CreatedAt: info.CreatedAt,
 			ExpiresAt: info.ExpiresAt,
+			Tags:      []string{licensing.DevTag},
 		})
 		require.NoError(t, err)
 		result.createdLicenses += 1
@@ -108,12 +111,28 @@ func setupDBAndInsertMockLicense(t *testing.T, dotcomdb database.DB, info licens
 		_, err = licensesdb.Create(ctx, sub, t.Name()+"-archived", 2, license.Info{
 			CreatedAt: info.CreatedAt,
 			ExpiresAt: info.ExpiresAt,
+			Tags:      []string{licensing.DevTag},
 		})
 		require.NoError(t, err)
 		result.createdLicenses += 1
 		// Archive the subscription
 		require.NoError(t, subscriptionsdb.Archive(ctx, sub))
 		result.archivedSubscriptions += 1
+	}
+
+	{
+		// Create a different subscription and license that's not a dev tag,
+		// created at the same time, to ensure we don't use it
+		u, err := dotcomdb.Users().Create(ctx, database.NewUser{Username: "not-dev"})
+		require.NoError(t, err)
+		sub, err := subscriptionsdb.Create(ctx, u.ID, u.Username)
+		require.NoError(t, err)
+		_, err = licensesdb.Create(ctx, sub, t.Name()+"-not-dev", 2, license.Info{
+			CreatedAt: info.CreatedAt,
+			ExpiresAt: info.ExpiresAt,
+			Tags:      []string{},
+		})
+		require.NoError(t, err)
 	}
 
 	// Create the subscription we will assert against
@@ -129,6 +148,7 @@ func setupDBAndInsertMockLicense(t *testing.T, dotcomdb database.DB, info licens
 	_, err = licensesdb.Create(ctx, subid, key1, 2, license.Info{
 		CreatedAt: info.CreatedAt.Add(-time.Hour),
 		ExpiresAt: info.ExpiresAt.Add(-time.Hour),
+		Tags:      []string{licensing.DevTag},
 	})
 	require.NoError(t, err)
 	result.createdLicenses += 1
@@ -154,6 +174,7 @@ func setupDBAndInsertMockLicense(t *testing.T, dotcomdb database.DB, info licens
 		_, err = licensesdb.Create(ctx, sub, t.Name()+"-foobar", 2, license.Info{
 			CreatedAt: info.CreatedAt,
 			ExpiresAt: info.ExpiresAt,
+			Tags:      []string{licensing.DevTag},
 		})
 		require.NoError(t, err)
 		result.createdLicenses += 1
@@ -183,6 +204,7 @@ func TestGetCodyGatewayAccessAttributes(t *testing.T) {
 			CreatedAt: time.Now().Add(-30 * time.Minute),
 			ExpiresAt: time.Now().Add(30 * time.Minute),
 			UserCount: 10,
+			Tags:      []string{licensing.DevTag},
 		},
 		cgAccess: graphqlbackend.UpdateCodyGatewayAccessInput{
 			Enabled: pointers.Ptr(false),
@@ -193,7 +215,7 @@ func TestGetCodyGatewayAccessAttributes(t *testing.T) {
 			CreatedAt: time.Now().Add(-30 * time.Minute),
 			ExpiresAt: time.Now().Add(30 * time.Minute),
 			UserCount: 321,
-			Tags:      []string{licensing.PlanEnterprise1.Tag()},
+			Tags:      []string{licensing.PlanEnterprise1.Tag(), licensing.DevTag},
 		},
 		cgAccess: graphqlbackend.UpdateCodyGatewayAccessInput{Enabled: pointers.Ptr(true)},
 	}, {
@@ -202,6 +224,7 @@ func TestGetCodyGatewayAccessAttributes(t *testing.T) {
 			CreatedAt: time.Now().Add(-30 * time.Minute),
 			ExpiresAt: time.Now().Add(30 * time.Minute),
 			UserCount: 10,
+			Tags:      []string{licensing.DevTag},
 		},
 		cgAccess: graphqlbackend.UpdateCodyGatewayAccessInput{
 			Enabled:                                 pointers.Ptr(true),
@@ -293,7 +316,7 @@ func TestGetAllCodyGatewayAccessAttributes(t *testing.T) {
 		CreatedAt: time.Now().Add(-30 * time.Minute),
 		ExpiresAt: time.Now().Add(30 * time.Minute),
 		UserCount: 321,
-		Tags:      []string{licensing.PlanEnterprise1.Tag()},
+		Tags:      []string{licensing.PlanEnterprise1.Tag(), licensing.DevTag},
 	}
 	cgAccess := graphqlbackend.UpdateCodyGatewayAccessInput{Enabled: pointers.Ptr(true)}
 	mock := setupDBAndInsertMockLicense(t, dotcomdb, info, &cgAccess)
@@ -319,7 +342,7 @@ func TestListEnterpriseSubscriptionLicenses(t *testing.T) {
 	info := license.Info{
 		ExpiresAt: time.Now().Add(30 * time.Minute),
 		UserCount: 321,
-		Tags:      []string{licensing.PlanEnterprise1.Tag()},
+		Tags:      []string{licensing.PlanEnterprise1.Tag(), licensing.DevTag},
 	}
 	rootTestName := t.Name()
 	mock := setupDBAndInsertMockLicense(t, db, info, nil)

--- a/cmd/enterprise-portal/service/config.go
+++ b/cmd/enterprise-portal/service/config.go
@@ -12,6 +12,8 @@ type Config struct {
 		cloudsql.ConnConfig
 
 		PGDSNOverride *string
+
+		IncludeProductionLicenses bool
 	}
 
 	SAMS SAMSConfig
@@ -32,6 +34,8 @@ func (c *Config) Load(env *runtime.Env) {
 	}
 	c.DotComDB.PGDSNOverride = env.GetOptional("DOTCOM_PGDSN_OVERRIDE",
 		"For local dev: custom PostgreSQL DSN, overrides DOTCOM_CLOUDSQL_* options")
+	c.DotComDB.IncludeProductionLicenses = env.GetBool("DOTCOM_INCLUDE_PRODUCTION_LICENSES", "false",
+		"Include production licenses in API results")
 
 	c.SAMS.ConnConfig = sams.NewConnConfigFromEnv(env)
 	c.SAMS.ClientID = env.Get("ENTERPRISE_PORTAL_SAMS_CLIENT_ID", "",

--- a/cmd/enterprise-portal/service/dotcomdb.go
+++ b/cmd/enterprise-portal/service/dotcomdb.go
@@ -11,6 +11,10 @@ import (
 )
 
 func newDotComDBConn(ctx context.Context, config Config) (*dotcomdb.Reader, error) {
+	readerOpts := dotcomdb.ReaderOptions{
+		DevOnly: !config.DotComDB.IncludeProductionLicenses,
+	}
+
 	if override := config.DotComDB.PGDSNOverride; override != nil {
 		config, err := pgx.ParseConfig(*override)
 		if err != nil {
@@ -20,7 +24,7 @@ func newDotComDBConn(ctx context.Context, config Config) (*dotcomdb.Reader, erro
 		if err != nil {
 			return nil, errors.Wrapf(err, "pgx.ConnectConfig %q", *override)
 		}
-		return dotcomdb.NewReader(conn), nil
+		return dotcomdb.NewReader(conn, readerOpts), nil
 	}
 
 	// Use IAM auth to connect to the Cloud SQL database.
@@ -28,5 +32,5 @@ func newDotComDBConn(ctx context.Context, config Config) (*dotcomdb.Reader, erro
 	if err != nil {
 		return nil, errors.Wrap(err, "contract.GetPostgreSQLDB")
 	}
-	return dotcomdb.NewReader(conn), nil
+	return dotcomdb.NewReader(conn, readerOpts), nil
 }

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -401,6 +401,8 @@ commands:
       DIAGNOSTICS_SECRET: sekret
       SRC_LOG_LEVEL: debug
       GRPC_WEB_UI_ENABLED: 'true'
+      # Connects to local database, so include all licenses from local DB
+      DOTCOM_INCLUDE_PRODUCTION_LICENSES: 'true'
       # Used for authentication
       SAMS_URL: https://accounts.sgdev.org
       # client name: 'enterprise-portal-local-dev'


### PR DESCRIPTION
Since we are reading from the dotcom database for the time being, the dev and prod Enterprise Portal instances serve the same data. This change adds a configuration so that we can set up the dev instance to only serve data from licenses with the dev or internal tag, toggled by `DOTCOM_INCLUDE_PRODUCTION_LICENSES`

This will become a non-issue for Enterprise Portal when we have our own database in https://linear.app/sourcegraph/issue/CORE-100, but for now this helps make sure that the dev instance only serves dev data. This is fairly important since we grant Enterprise Portal scopes more liberally in accounts.sgdev.org.

## Test plan

Updated integration tests to use the dev-only mode.

Also tested locally: with `DOTCOM_INCLUDE_PRODUCTION_LICENSES=false`, endpoints return nothing, while with `DOTCOM_INCLUDE_PRODUCTION_LICENSES=true`, endpoints return the expected data.