### PR TITLE
Update titles for and references to the Analytics > Extensions page t…

### DIFF
--- a/client/web/src/site-admin/analytics/AnalyticsExtensionsPage/index.tsx
+++ b/client/web/src/site-admin/analytics/AnalyticsExtensionsPage/index.tsx
@@ -129,7 +129,7 @@ export const AnalyticsExtensionsPage: React.FunctionComponent<Props> = ({ teleme
             dateRange: dateRange.value,
             color: 'var(--purple)',
             description:
-                'Our extensions allow users to complete their goals without switching tools and context. We’ve calculated the time saved by reducing context switching between tools.',
+                'Our search extensions allow users to complete their goals without switching tools and context. We’ve calculated the time saved by reducing context switching between tools.',
             value: totalEvents,
             items: [
                 {
@@ -181,7 +181,7 @@ export const AnalyticsExtensionsPage: React.FunctionComponent<Props> = ({ teleme
 
     return (
         <>
-            <AnalyticsPageTitle>Extensions</AnalyticsPageTitle>
+            <AnalyticsPageTitle>Search extensions</AnalyticsPageTitle>
 
             <Card className="p-3 position-relative">
                 <div className="d-flex justify-content-end align-items-stretch mb-2 text-nowrap">

--- a/client/web/src/site-admin/analytics/AnalyticsOverviewPage/DevTimeSaved.tsx
+++ b/client/web/src/site-admin/analytics/AnalyticsOverviewPage/DevTimeSaved.tsx
@@ -257,7 +257,7 @@ export const DevTimeSaved: React.FunctionComponent<DevTimeSavedProps> = ({ showA
                                         aria-label="Extensions"
                                         className="mr-1"
                                     />
-                                    Extensions
+                                    Search extensions
                                 </Text>
                             </Link>
                         </td>

--- a/client/web/src/site-admin/sidebaritems.ts
+++ b/client/web/src/site-admin/sidebaritems.ts
@@ -62,7 +62,7 @@ const analyticsGroup: SiteAdminSideBarGroup = {
             condition: ({ license }) => license.isCodeSearchEnabled,
         },
         {
-            label: 'Extensions',
+            label: 'Search extensions',
             to: '/site-admin/analytics/extensions',
         },
         {


### PR DESCRIPTION
Update titles for and references to the Analytics > Extensions page to reflect that they cover Search extensions only, not Cody extensions

This addresses some confusion that we have recently seen on the team: https://sourcegraph.slack.com/archives/C04MSD3DP5L/p1716984996942789

## Test plan

CI only given low risk change
