### PR TITLE
fix/msp: test for cron interval changes based on time, add more restrictions

### DIFF
--- a/dev/managedservicesplatform/stacks/monitoring/job.go
+++ b/dev/managedservicesplatform/stacks/monitoring/job.go
@@ -3,10 +3,12 @@ package monitoring
 import (
 	"fmt"
 	"math"
+	"time"
 
 	"github.com/hashicorp/terraform-cdk-go/cdktf"
 
 	"github.com/sourcegraph/managed-services-platform-cdktf/gen/google/monitoringalertpolicy"
+
 	"github.com/sourcegraph/sourcegraph/dev/managedservicesplatform/internal/resource/alertpolicy"
 	"github.com/sourcegraph/sourcegraph/dev/managedservicesplatform/internal/resourceid"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
@@ -53,7 +55,7 @@ func createJobAlerts(
 	}
 	alerts = append(alerts, alert.AlertPolicy)
 
-	interval, err := vars.JobSchedule.FindMaxCronInterval()
+	interval, err := vars.JobSchedule.FindMaxCronInterval(time.Now())
 	if err != nil {
 		return nil, errors.Wrap(err, "JobSchedule.FindMaxCronInterval")
 	}


### PR DESCRIPTION
Addresses problem noticed in https://github.com/sourcegraph/managed-services/pull/1486#issuecomment-2137887423

## Test plan

Unit tests

## Changelog

- Fixed an issue with output of `sg msp generate` for MSP jobs with particular schedules changing throughout the week
- MSP jobs schedules now must be between 15 minutes at the most frequent, and every week at the least frequent