### PR TITLE
feat/msp/spec: require notionPageID if a production env is provisioned

### DIFF
--- a/dev/managedservicesplatform/spec/service.go
+++ b/dev/managedservicesplatform/spec/service.go
@@ -2,6 +2,7 @@ package spec
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/grafana/regexp"
 
@@ -82,6 +83,20 @@ func (s ServiceSpec) Validate() []error {
 	}
 	if len(s.Description) == 0 {
 		errs = append(errs, errors.New("description is required"))
+	}
+	if s.NotionPageID != nil {
+		page := *s.NotionPageID
+		if len(page) == 0 {
+			errs = append(errs, errors.New("notionPageID cannot be empty"))
+		}
+		// Should not be 'www.notion.so' or 'sourcegraph.notion.site'
+		if strings.Contains(page, ".notion.") {
+			errs = append(errs, errors.New("notionPageID must be a page ID, not a URL"))
+		}
+		// Should not have URL query parameters appended by Notion
+		if strings.Contains(page, "?") {
+			errs = append(errs, errors.New("notionPageID must be a page ID, found what looks like a URL query '?'"))
+		}
 	}
 
 	if s.IAM != nil {

--- a/dev/managedservicesplatform/spec/spec.go
+++ b/dev/managedservicesplatform/spec/spec.go
@@ -178,6 +178,13 @@ func (s Spec) Validate() []error {
 				env.ID, env.ProjectID))
 		}
 
+		if env.Category.IsProduction() {
+			if s.Service.NotionPageID == nil {
+				errs = append(errs, errors.Newf("environment %q in category %q requires 'service.notionPageID' to be set",
+					env.ID, env.Category))
+			}
+		}
+
 		if domain := pointers.DerefZero(env.EnvironmentServiceSpec).Domain.GetDNSName(); domain != "" {
 			_, exists := configuredDomains[domain]
 			if exists {


### PR DESCRIPTION
Now that msp-ops pages are opt-in and requires you to provide a notion page ID, it's easy to miss providing one. Once a service gets a production environment, this should be required.

Closes https://linear.app/sourcegraph/issue/CORE-120

## Test plan

#62973 

## Changelog

- MSP services with production environments now must provide a `service.notionPageID` for go/msp-ops