### PR TITLE
feat/sg/msp: add 'sg msp validate' for validating service specifications

### DIFF
--- a/dev/managedservicesplatform/spec/spec.go
+++ b/dev/managedservicesplatform/spec/spec.go
@@ -61,7 +61,7 @@ func Open(specPath string) (*Spec, error) {
 	}
 	spec, err := parse(specData)
 	if err != nil {
-		return nil, errors.Wrap(err, "spec.parse")
+		return spec, errors.Wrap(err, "spec.parse")
 	}
 
 	// Load extraneous resources
@@ -134,7 +134,7 @@ func parse(data []byte) (*Spec, error) {
 	}
 
 	if validationErrs := s.Validate(); len(validationErrs) > 0 {
-		return nil, errors.Append(nil, validationErrs...)
+		return &s, errors.Append(nil, validationErrs...)
 	}
 	return &s, nil
 }


### PR DESCRIPTION
Simple way to test changes to validations, and maybe helpful for operators too.

## Test plan

Testing: https://github.com/sourcegraph/sourcegraph/pull/62972

```
Projects/sourcegraph/managed-services » sg msp validate
✅ [build-tracker] Validated
✅ [cloud-ops] Validated
✅ [cloud-relay] Validated
✅ [cloud-scheduler] Validated
✅ [cody-analytics] Validated
✅ [enterprise-portal] Validated
✅ [entitler] Validated
✅ [gatekeeper] Validated
✅ [linearhooks] Validated
✅ [msp-testbed] Validated
✅ [pings] Validated
✅ [releaseregistry] Validated
❌ [repoferee] Found valdiation errors

                                                                                                                                
  • environment "prod" in category "internal" requires 'service.notionPageID' to be set                                         


✅ [sams] Validated
✅ [sourcegraph-accounts] Validated
✅ [support-hygiene] Validated
✅ [support-integration] Validated
✅ [telemetry-gateway] Validated
Checked 18 service specifications
```

## Changelog

- `sg msp validate` can now be used to get quick feedback on whether MSP service specifications are valid.