### PR TITLE
Svelte: QoL fixes for hover popovers

### DIFF
--- a/client/web-sveltekit/src/lib/Popover.svelte
+++ b/client/web-sveltekit/src/lib/Popover.svelte
@@ -49,9 +49,17 @@
             }
         }
 
+        function handleMouseMoveTrigger(): void {
+            clearTimeout(delayTimer)
+            delayTimer = setTimeout(() => {
+                isOpen = true
+            }, hoverDelay)
+        }
+
         if (showOnHover) {
             node.addEventListener('mouseenter', handleMouseEnterTrigger)
             node.addEventListener('mouseleave', handleMouseLeaveTrigger)
+            node.addEventListener('mousemove', handleMouseMoveTrigger)
         }
 
         return {
@@ -59,6 +67,7 @@
                 trigger = null
                 node.removeEventListener('mouseenter', handleMouseEnterTrigger)
                 node.removeEventListener('mouseleave', handleMouseLeaveTrigger)
+                node.removeEventListener('mousemove', handleMouseMoveTrigger)
             },
         }
     }

--- a/client/web-sveltekit/src/lib/Popover.svelte
+++ b/client/web-sveltekit/src/lib/Popover.svelte
@@ -56,10 +56,16 @@
             }, hoverDelay)
         }
 
+        function handleWindowLoseFocus(): void {
+            clearTimeout(delayTimer)
+            isOpen = false
+        }
+
         if (showOnHover) {
             node.addEventListener('mouseenter', handleMouseEnterTrigger)
             node.addEventListener('mouseleave', handleMouseLeaveTrigger)
             node.addEventListener('mousemove', handleMouseMoveTrigger)
+            window.addEventListener('blur', handleWindowLoseFocus)
         }
 
         return {
@@ -68,6 +74,7 @@
                 node.removeEventListener('mouseenter', handleMouseEnterTrigger)
                 node.removeEventListener('mouseleave', handleMouseLeaveTrigger)
                 node.removeEventListener('mousemove', handleMouseMoveTrigger)
+                window.removeEventListener('blur', handleWindowLoseFocus)
             },
         }
     }

--- a/client/web-sveltekit/src/lib/Popover.svelte
+++ b/client/web-sveltekit/src/lib/Popover.svelte
@@ -22,6 +22,11 @@
         isOpen = open === undefined ? !isOpen : open
     }
 
+    function close(): void {
+        clearTimeout(delayTimer)
+        toggle(false)
+    }
+
     function handleClickOutside(event: { detail: HTMLElement }): void {
         if (!showOnHover && event.detail !== trigger && !trigger?.contains(event.detail)) {
             toggle(false)
@@ -53,22 +58,12 @@
             delayTimer = setTimeout(() => toggle(true), hoverDelay)
         }
 
-        function handleWindowLoseFocus(): void {
-            clearTimeout(delayTimer)
-            toggle(false)
-        }
-
-        function handleClick(): void {
-            clearTimeout(delayTimer)
-            toggle(false)
-        }
-
         if (showOnHover) {
             node.addEventListener('mouseenter', handleMouseEnterTrigger)
             node.addEventListener('mouseleave', handleMouseLeaveTrigger)
             node.addEventListener('mousemove', handleMouseMoveTrigger)
-            node.addEventListener('click', handleClick)
-            window.addEventListener('blur', handleWindowLoseFocus)
+            node.addEventListener('click', close)
+            window.addEventListener('blur', close)
         }
 
         return {
@@ -77,8 +72,8 @@
                 node.removeEventListener('mouseenter', handleMouseEnterTrigger)
                 node.removeEventListener('mouseleave', handleMouseLeaveTrigger)
                 node.removeEventListener('mousemove', handleMouseMoveTrigger)
-                node.removeEventListener('click', handleClick)
-                window.removeEventListener('blur', handleWindowLoseFocus)
+                node.removeEventListener('click', close)
+                window.removeEventListener('blur', close)
             },
         }
     }

--- a/client/web-sveltekit/src/lib/Popover.svelte
+++ b/client/web-sveltekit/src/lib/Popover.svelte
@@ -8,9 +8,9 @@
     /**
      * Show the popover when hovering over the trigger.
      */
-    export let showOnHover = false
-    export let hoverDelay: number = 0
-    export let hoverCloseDelay: number = 0
+    export let showOnHover: boolean = false
+    export let hoverDelay: number = 500
+    export let hoverCloseDelay: number = 150
 
     let isOpen = false
     let trigger: HTMLElement | null
@@ -24,7 +24,7 @@
 
     function handleClickOutside(event: { detail: HTMLElement }): void {
         if (event.detail !== trigger && !trigger?.contains(event.detail)) {
-            isOpen = false
+            toggle(false)
         }
     }
 
@@ -37,31 +37,25 @@
 
         function handleMouseEnterTrigger(): void {
             clearTimeout(delayTimer)
-            delayTimer = setTimeout(() => {
-                isOpen = true
-            }, hoverDelay)
+            delayTimer = setTimeout(() => toggle(true), hoverDelay)
         }
 
         function handleMouseLeaveTrigger(event: MouseEvent): void {
             // It should be possible to move the mouse from the trigger to the popover without closing it
             if (event.relatedTarget && !popoverContainer?.contains(event.relatedTarget as Node)) {
                 clearTimeout(delayTimer)
-                delayTimer = setTimeout(() => {
-                    isOpen = false
-                }, hoverCloseDelay)
+                delayTimer = setTimeout(() => toggle(false), hoverCloseDelay)
             }
         }
 
         function handleMouseMoveTrigger(): void {
             clearTimeout(delayTimer)
-            delayTimer = setTimeout(() => {
-                isOpen = true
-            }, hoverDelay)
+            delayTimer = setTimeout(() => toggle(true), hoverDelay)
         }
 
         function handleWindowLoseFocus(): void {
             clearTimeout(delayTimer)
-            isOpen = false
+            toggle(false)
         }
 
         if (showOnHover) {

--- a/client/web-sveltekit/src/lib/Popover.svelte
+++ b/client/web-sveltekit/src/lib/Popover.svelte
@@ -9,11 +9,13 @@
      * Show the popover when hovering over the trigger.
      */
     export let showOnHover = false
+    export let hoverDelay: number = 0
 
     let isOpen = false
     let trigger: HTMLElement | null
     let target: HTMLElement | undefined
     let popoverContainer: HTMLElement | null
+    let delayTimer: ReturnType<typeof setTimeout>
 
     function toggle(open?: boolean): void {
         isOpen = open === undefined ? !isOpen : open
@@ -33,12 +35,16 @@
         trigger = node
 
         function handleMouseEnterTrigger(): void {
-            isOpen = true
+            clearTimeout(delayTimer)
+            delayTimer = setTimeout(() => {
+                isOpen = true
+            }, hoverDelay)
         }
 
         function handleMouseLeaveTrigger(event: MouseEvent): void {
             // It should be possible to move the mouse from the trigger to the popover without closing it
             if (event.relatedTarget && !popoverContainer?.contains(event.relatedTarget as Node)) {
+                clearTimeout(delayTimer)
                 isOpen = false
             }
         }

--- a/client/web-sveltekit/src/lib/Popover.svelte
+++ b/client/web-sveltekit/src/lib/Popover.svelte
@@ -10,6 +10,7 @@
      */
     export let showOnHover = false
     export let hoverDelay: number = 0
+    export let hoverCloseDelay: number = 0
 
     let isOpen = false
     let trigger: HTMLElement | null
@@ -45,7 +46,9 @@
             // It should be possible to move the mouse from the trigger to the popover without closing it
             if (event.relatedTarget && !popoverContainer?.contains(event.relatedTarget as Node)) {
                 clearTimeout(delayTimer)
-                isOpen = false
+                delayTimer = setTimeout(() => {
+                    isOpen = false
+                }, hoverCloseDelay)
             }
         }
 
@@ -84,15 +87,23 @@
         function handleMouseLeavePopover(event: MouseEvent): void {
             // It should be possible to move the mouse from the popover to the trigger without closing it
             if (event.relatedTarget && !trigger?.contains(event.relatedTarget as Node)) {
-                toggle(false)
+                delayTimer = setTimeout(() => toggle(false), hoverCloseDelay)
             }
         }
+
+        function handleMouseEnterPopover(): void {
+            // When the mouse enters the popover, cancel any pending close events
+            clearTimeout(delayTimer)
+        }
+
         if (showOnHover) {
+            node.addEventListener('mouseenter', handleMouseEnterPopover)
             node.addEventListener('mouseleave', handleMouseLeavePopover)
         }
         return {
             destroy() {
                 popoverContainer = null
+                node.removeEventListener('mouseenter', handleMouseEnterPopover)
                 node.removeEventListener('mouseleave', handleMouseLeavePopover)
             },
         }

--- a/client/web-sveltekit/src/lib/Popover.svelte
+++ b/client/web-sveltekit/src/lib/Popover.svelte
@@ -23,7 +23,7 @@
     }
 
     function handleClickOutside(event: { detail: HTMLElement }): void {
-        if (event.detail !== trigger && !trigger?.contains(event.detail)) {
+        if (!showOnHover && event.detail !== trigger && !trigger?.contains(event.detail)) {
             toggle(false)
         }
     }
@@ -58,10 +58,16 @@
             toggle(false)
         }
 
+        function handleClick(): void {
+            clearTimeout(delayTimer)
+            toggle(false)
+        }
+
         if (showOnHover) {
             node.addEventListener('mouseenter', handleMouseEnterTrigger)
             node.addEventListener('mouseleave', handleMouseLeaveTrigger)
             node.addEventListener('mousemove', handleMouseMoveTrigger)
+            node.addEventListener('click', handleClick)
             window.addEventListener('blur', handleWindowLoseFocus)
         }
 
@@ -71,6 +77,7 @@
                 node.removeEventListener('mouseenter', handleMouseEnterTrigger)
                 node.removeEventListener('mouseleave', handleMouseLeaveTrigger)
                 node.removeEventListener('mousemove', handleMouseMoveTrigger)
+                node.removeEventListener('click', handleClick)
                 window.removeEventListener('blur', handleWindowLoseFocus)
             },
         }

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/FileTree.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/FileTree.svelte
@@ -124,7 +124,7 @@
                     We handle navigation via the TreeView's select event, to preserve the focus state.
                     Using a link here allows us to benefit from data preloading.
                 -->
-                <Popover let:registerTrigger placement="right-end" hover={{ enable: true, delayMillis: 500 }}>
+                <Popover let:registerTrigger placement="right-end" showOnHover>
                     <a
                         href={replaceRevisionInURL(entry.canonicalURL, revision)}
                         on:click|preventDefault={() => {}}

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/FileTree.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/FileTree.svelte
@@ -12,7 +12,7 @@
     import { getSidebarFileTreeStateForRepo } from '$lib/repo/stores'
     import { replaceRevisionInURL } from '$lib/shared'
     import TreeView, { setTreeContext } from '$lib/TreeView.svelte'
-    import { createForwardStore, delay } from '$lib/utils'
+    import { createForwardStore } from '$lib/utils'
     import { Alert } from '$lib/wildcard'
 
     export let repoName: string
@@ -131,6 +131,8 @@
                         tabindex={-1}
                         data-go-up={isRoot ? true : undefined}
                         use:registerTrigger
+                        on:mouseover={/* Preload */ () =>
+                            fetchPopoverData({ repoName, revision, filePath: entry.path })}
                     >
                         {#if entry.isDirectory}
                             <Icon svgPath={getDirectoryIconPath(entry, expanded)} inline />

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/FileTree.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/FileTree.svelte
@@ -124,7 +124,7 @@
                     We handle navigation via the TreeView's select event, to preserve the focus state.
                     Using a link here allows us to benefit from data preloading.
                 -->
-                <Popover let:registerTrigger placement="right-end" showOnHover>
+                <Popover let:registerTrigger placement="right-end" hover={{ enable: true, delayMillis: 500 }}>
                     <a
                         href={replaceRevisionInURL(entry.canonicalURL, revision)}
                         on:click|preventDefault={() => {}}
@@ -140,7 +140,7 @@
                         {isRoot ? '..' : entry.name}
                     </a>
                     <svelte:fragment slot="content">
-                        {#await delay(fetchPopoverData({ repoName, revision, filePath: entry.path }), 300) then entry}
+                        {#await fetchPopoverData({ repoName, revision, filePath: entry.path }) then entry}
                             <FilePopover {repoName} {revision} {entry} />
                         {/await}
                     </svelte:fragment>


### PR DESCRIPTION
Fixes SRCH-449

Each commit is granular and has a useful message describing the change.

In short:
- Adds a `hoverDelay` parameter to `Popover` so each consumer doesn't need to do this manually
- Makes hovers only show when the mouse comes to rest
- Closes the popover when the window loses focus so we don't miss a mouseleave event and have popovers get stuck open
- Adds a delay to popover closing when the mouse leaves one of the target elements so there is room for error when moving the mouse from the trigger to the popover
- Adds preloading back to the file tree because the popover now does not create the element until the delay has passed
- Makes it so clicking the target closes the popover when hover is enabled.

## Test plan

Manual testing for feel. Would love if reviewers would pull this down and try it out on the file tree.

[Video walkthrough](https://share.cleanshot.com/HNpLjjv7)
