### PR TITLE
cmd: frontend: add note that clarifies that your code host needs to be accessible over the network to test connection button

### DIFF
--- a/cmd/frontend/graphqlbackend/external_services_test.go
+++ b/cmd/frontend/graphqlbackend/external_services_test.go
@@ -3,6 +3,7 @@ package graphqlbackend
 import (
 	"context"
 	"fmt"
+	"net"
 	"testing"
 	"time"
 
@@ -1781,6 +1782,54 @@ func TestExternalServiceRepositories(t *testing.T) {
 			},
 		})
 	})
+}
+
+func TestCheckErrCodeHostMaybeInaccessible(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "context deadline exceeded",
+			err:      context.DeadlineExceeded,
+			expected: true,
+		},
+		{
+			name:     "nil error",
+			err:      nil,
+			expected: false,
+		},
+		{
+			name:     "wrapped context deadline exceeded",
+			err:      errors.Wrap(context.DeadlineExceeded, "wrapped error"),
+			expected: true,
+		},
+		{
+			name:     "wrapped DNS error - not found",
+			err:      errors.Wrap(&net.DNSError{Err: "no such host", IsNotFound: true}, "wrapped error"),
+			expected: true,
+		},
+		{
+			name:     "wrapped DNS error - timeout",
+			err:      errors.Wrap(&net.DNSError{Err: "i/o timeout", IsTimeout: true}, "wrapped error"),
+			expected: false,
+		},
+		{
+			name:     "wrapped generic error",
+			err:      errors.Wrap(errors.New("some error"), "wrapped error"),
+			expected: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result := checkErrCodeHostMaybeInaccessible(test.err)
+			if result != test.expected {
+				t.Errorf("unexpected result. want=%v, got=%v", test.expected, result)
+			}
+		})
+	}
 }
 
 type handle struct {


### PR DESCRIPTION
Closes https://linear.app/sourcegraph/issue/SRC-359/

In the case where a user clicks on the "test connection" button and the:

1) The request never completed within 15 seconds
2) The request failed with a [net.DNSerror.isNotFound](https://pkg.go.dev/net#DNSError) error

One pretty good guess is that the code host is not actually accessible to Sourcegraph over the network. This PR tweaks the error message to add this hint + a link to our troubleshooting documentation. (See https://github.com/sourcegraph/docs/pull/374)


## Test plan

Screenshots of this:


![Screenshot 2024-05-30 at 12.43.08 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/5VKJ5spRdhDRvKQ0TTIe/24c19298-3e6c-4038-9db5-c7e4330caa2a.png)


![Screenshot 2024-05-30 at 12.42.29 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/5VKJ5spRdhDRvKQ0TTIe/992ed7c1-91d3-4911-a68c-e07e1e41beb6.png)

Recordings:

1. Testing with a bad domain name

<div class='graphite__hidden'>
          <div>🎥 Video uploaded on Graphite:</div>
            <a href="https://app.graphite.dev/media/video/5VKJ5spRdhDRvKQ0TTIe/cac620ed-d7be-4129-99bd-a6b5f85c70f0.mov">
              <img src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/5VKJ5spRdhDRvKQ0TTIe/cac620ed-d7be-4129-99bd-a6b5f85c70f0.mov">
            </a>
          </div>
<video src="https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/5VKJ5spRdhDRvKQ0TTIe/cac620ed-d7be-4129-99bd-a6b5f85c70f0.mov">recordingtestbadhostname.mov</video>

1. Testing with a timeout (the IP address will never resolve)


<div class='graphite__hidden'>
          <div>🎥 Video uploaded on Graphite:</div>
            <a href="https://app.graphite.dev/media/video/5VKJ5spRdhDRvKQ0TTIe/b1e0befd-8d79-41ed-867e-a02a91b6937a.mov">
              <img src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/5VKJ5spRdhDRvKQ0TTIe/b1e0befd-8d79-41ed-867e-a02a91b6937a.mov">
            </a>
          </div>
<video src="https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/5VKJ5spRdhDRvKQ0TTIe/b1e0befd-8d79-41ed-867e-a02a91b6937a.mov">recordingtimeout.mov</video>

1. Updating an existing code host connection with a bad address


<div class='graphite__hidden'>
          <div>🎥 Video uploaded on Graphite:</div>
            <a href="https://app.graphite.dev/media/video/5VKJ5spRdhDRvKQ0TTIe/69ba889e-7941-4c8d-a72f-f2bdfbeea61b.mov">
              <img src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/5VKJ5spRdhDRvKQ0TTIe/69ba889e-7941-4c8d-a72f-f2bdfbeea61b.mov">
            </a>
          </div>
<video src="https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/5VKJ5spRdhDRvKQ0TTIe/69ba889e-7941-4c8d-a72f-f2bdfbeea61b.mov">Screen Recording 2024-05-30 at 12.42.02 PM.mov</video>

