### PR TITLE
feat/enterprise-portal: only do dotcomdb connection check on-demand

### DIFF
--- a/cmd/enterprise-portal/service/service.go
+++ b/cmd/enterprise-portal/service/service.go
@@ -44,12 +44,6 @@ func (Service) Initialize(ctx context.Context, logger log.Logger, contract runti
 		return nil, errors.Wrap(err, "newDotComDBConn")
 	}
 
-	// Validate connection on startup
-	if err := dotcomDB.Ping(ctx); err != nil {
-		return nil, errors.Wrap(err, "dotcomDB.Ping")
-	}
-	logger.Debug("connected to dotcom database")
-
 	// Prepare SAMS client, so that we can enforce SAMS-based M2M authz/authn
 	logger.Debug("using SAMS client",
 		log.String("samsExternalURL", config.SAMS.ExternalURL),
@@ -73,7 +67,9 @@ func (Service) Initialize(ctx context.Context, logger log.Logger, contract runti
 	httpServer := http.NewServeMux()
 
 	// Register MSP endpoints
-	contract.Diagnostics.RegisterDiagnosticsHandlers(httpServer, serviceState{})
+	contract.Diagnostics.RegisterDiagnosticsHandlers(httpServer, serviceState{
+		dotcomDB: dotcomDB,
+	})
 
 	// Register connect endpoints
 	codyaccessservice.RegisterV1(logger, httpServer, samsClient.Tokens(), dotcomDB)

--- a/cmd/enterprise-portal/service/state.go
+++ b/cmd/enterprise-portal/service/state.go
@@ -3,8 +3,19 @@ package service
 import (
 	"context"
 	"net/url"
+
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
-type serviceState struct{}
+type serviceState struct {
+	dotcomDB interface{ Ping(context.Context) error }
+}
 
-func (s serviceState) Healthy(_ context.Context, _ url.Values) error { return nil }
+func (s serviceState) Healthy(ctx context.Context, query url.Values) error {
+	if query.Has("dotcomdb") {
+		if err := s.dotcomDB.Ping(ctx); err != nil {
+			return errors.Wrap(err, "dotcomdb.Ping")
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
Mostly to make it easier to spin up a prod environment for now; we can add this back later.

## Test plan

n/a