### PR TITLE
Svelte: add lines to directory groups

### DIFF
--- a/client/web-sveltekit/src/lib/TreeNode.svelte
+++ b/client/web-sveltekit/src/lib/TreeNode.svelte
@@ -112,15 +112,13 @@
                 <LoadingSpinner center={false} />
             </div>
         {:then treeProvider}
-            <div class="group-container">
-                <ul role="group">
-                    {#each treeProvider.getEntries() as entry (treeProvider.getNodeID(entry))}
-                        <svelte:self {entry} {treeProvider} let:entry let:toggle let:expanded on:scope-change>
-                            <slot {entry} {toggle} {expanded} />
-                        </svelte:self>
-                    {/each}
-                </ul>
-            </div>
+            <ul role="group">
+                {#each treeProvider.getEntries() as entry (treeProvider.getNodeID(entry))}
+                    <svelte:self {entry} {treeProvider} let:entry let:toggle let:expanded on:scope-change>
+                        <slot {entry} {toggle} {expanded} />
+                    </svelte:self>
+                {/each}
+            </ul>
         {:catch error}
             <slot name="error" {error} />
         {/await}
@@ -193,7 +191,7 @@
         display: flex;
     }
 
-    .group-container {
+    ul {
         position: relative;
         isolation: isolate;
         &::before {

--- a/client/web-sveltekit/src/lib/TreeNode.svelte
+++ b/client/web-sveltekit/src/lib/TreeNode.svelte
@@ -127,7 +127,7 @@
 
 <style lang="scss">
     [role='treeitem'] {
-        --tree-node-left-padding: 0.35rem;
+        --tree-node-left-padding: 1.25rem;
 
         border-radius: var(--border-radius);
 
@@ -137,10 +137,6 @@
             > .label {
                 box-shadow: var(--focus-box-shadow);
             }
-        }
-
-        :global([data-tree-view-flat-list='false']) & {
-            --tree-node-left-padding: 1.25rem;
         }
     }
 


### PR DESCRIPTION
This adds guidelines for open directories in the file tree. I recommend reviewing with whitespace changes hidden.

Fixes SRCH-443

Dark:
![screenshot-2024-05-29_22-50-29@2x](https://github.com/sourcegraph/sourcegraph/assets/12631702/3198da6f-6e47-427e-a6c6-d474280042b9)

Light:
![screenshot-2024-05-29_22-50-54@2x](https://github.com/sourcegraph/sourcegraph/assets/12631702/cdafe358-c285-464a-b174-69d68f50e706)

## Test plan

Manual testing. This is one where a screenshot test would be really nice 🙂 