### PR TITLE
sg/msp: fix nil `domain` and `EnvironmentDomainTypeNone` in diagram gen

### DIFF
--- a/dev/managedservicesplatform/operationdocs/diagram/diagram.go
+++ b/dev/managedservicesplatform/operationdocs/diagram/diagram.go
@@ -199,7 +199,7 @@ func (d *diagram) Generate(s *spec.Spec, e string) error {
 		}
 	}
 
-	if env.EnvironmentServiceSpec != nil {
+	if env.EnvironmentServiceSpec != nil && env.Domain != nil && env.Domain.Type != spec.EnvironmentDomainTypeNone {
 		var loadBalancerNode string
 		graph, loadBalancerNode, err = newLoadBalancerNode(graph, env)
 		if err != nil {

--- a/dev/managedservicesplatform/operationdocs/diagram/diagram.go
+++ b/dev/managedservicesplatform/operationdocs/diagram/diagram.go
@@ -224,7 +224,7 @@ func (d *diagram) Generate(s *spec.Spec, e string) error {
 		// ip: if not proxied through cloudflare
 		// cloudflare: if proxied through cloudflare
 		destination := ipNode
-		if env.Domain.Cloudflare != nil && env.Domain.Cloudflare.ShouldProxy() {
+		if env.Domain != nil && env.Domain.Cloudflare.ShouldProxy() {
 			var cloudflareNode string
 			graph, cloudflareNode, err = newCloudflareNode(graph)
 			if err != nil {

--- a/dev/managedservicesplatform/operationdocs/diagram/msp.go
+++ b/dev/managedservicesplatform/operationdocs/diagram/msp.go
@@ -1,12 +1,13 @@
 package diagram
 
 import (
+	"oss.terrastruct.com/d2/d2graph"
+	"oss.terrastruct.com/d2/d2oracle"
+
 	"github.com/sourcegraph/sourcegraph/dev/managedservicesplatform/operationdocs/diagram/assets"
 	"github.com/sourcegraph/sourcegraph/dev/managedservicesplatform/spec"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 	"github.com/sourcegraph/sourcegraph/lib/pointers"
-	"oss.terrastruct.com/d2/d2graph"
-	"oss.terrastruct.com/d2/d2oracle"
 )
 
 func newBigQueryNode(graph *d2graph.Graph, env *spec.EnvironmentSpec) (*d2graph.Graph, string, error) {
@@ -66,7 +67,7 @@ func newInternetNode(graph *d2graph.Graph) (*d2graph.Graph, string, error) {
 
 func newLoadBalancerNode(graph *d2graph.Graph, env *spec.EnvironmentSpec) (*d2graph.Graph, string, error) {
 	// Create Cloud Armor rules also
-	if env.Category.IsProduction() && env.Domain.Cloudflare.ShouldProxy() {
+	if env.Category.IsProduction() && env.Domain != nil && env.Domain.Cloudflare.ShouldProxy() {
 		// create a container for the load balancer + cloud armor
 		graph, container, err := d2oracle.Create(graph, nil, "loadbalancer_container")
 		if err != nil {


### PR DESCRIPTION
Not specifying a `domain` config or using `EnvironmentDomainTypeNone` was causing a nil panic during diagram generation. This PR fixes that


Closes CORE-140
## Test plan

nil Domain or EnvironmentDomainTypeNone generates a diagram like so:
![image](https://github.com/sourcegraph/sourcegraph/assets/35706755/36072aad-e18d-44db-86d5-14ecfc77624a)
