### PR TITLE
Remove external accounts modal feature flag

### DIFF
--- a/client/web/src/external-account-modal/ExternalAccountsModal.tsx
+++ b/client/web/src/external-account-modal/ExternalAccountsModal.tsx
@@ -9,7 +9,6 @@ import { Button, ErrorAlert, H2, LoadingSpinner, Modal, Text } from '@sourcegrap
 
 import type { AuthenticatedUser } from '../auth'
 import { BrandLogo } from '../components/branding/BrandLogo'
-import { useFeatureFlag } from '../featureFlags/useFeatureFlag'
 import type { UserExternalAccountsWithAccountDataVariables } from '../graphql-operations'
 import type { AuthProvider, SourcegraphContext } from '../jscontext'
 import { ExternalAccountsSignIn } from '../user/settings/auth/ExternalAccountsSignIn'
@@ -85,8 +84,6 @@ function filterAuthProviders(
 }
 
 export const ExternalAccountsModal: React.FunctionComponent<ExternalAccountsModalProps> = props => {
-    const [enableExternalAccountsModal] = useFeatureFlag('external-accounts-modal')
-
     const [seenAuthzProviders, setSeenAuthzProviders] = useTemporarySetting('user.seenAuthProviders', [])
 
     const [userExternalAccounts, setUserExternalAccounts] = useState<{
@@ -106,7 +103,6 @@ export const ExternalAccountsModal: React.FunctionComponent<ExternalAccountsModa
         UserExternalAccountsWithAccountDataVariables
     >(USER_EXTERNAL_ACCOUNTS, {
         variables: { username: props.authenticatedUser.username },
-        skip: !enableExternalAccountsModal,
         onCompleted: res =>
             setUserExternalAccounts({ loading: false, fetched: res.user.externalAccounts.nodes, lastRemoved: '' }),
     })
@@ -162,7 +158,7 @@ export const ExternalAccountsModal: React.FunctionComponent<ExternalAccountsModa
     return (
         <Modal
             aria-label="Connect your external accounts"
-            isOpen={isModalOpen && enableExternalAccountsModal}
+            isOpen={isModalOpen}
             onDismiss={onDismiss}
             className={styles.modal}
             position="center"

--- a/client/web/src/featureFlags/featureFlags.ts
+++ b/client/web/src/featureFlags/featureFlags.ts
@@ -28,7 +28,6 @@ export const FEATURE_FLAGS = [
     'search-debug',
     'signup-survey-enabled',
     'sourcegraph-operator-site-admin-hide-maintenance',
-    'external-accounts-modal',
     'ab-shortened-install-first-signup-flow-cody-2024-04',
 ] as const
 


### PR DESCRIPTION
Closes #62805 

#61721 introduced a modal reminding users to connect external accounts. It was put behind a feature flag in case of malfunction. But since then, it seems to work as expected based on customer feedback.

This PR removes the feature flag, and turns the feature on by default, since we think it's an improvement to the user experience over all.

<!-- 💡 To write a useful PR description, make sure that your description covers:
- WHAT this PR is changing:
    - How was it PREVIOUSLY.
    - How it will be from NOW on.
- WHY this PR is needed.
- CONTEXT, i.e. to which initiative, project or RFC it belongs.

The structure of the description doesn't matter as much as covering these points, so use
your best judgement based on your context.
Learn how to write good pull request description: https://www.notion.so/sourcegraph/Write-a-good-pull-request-description-610a7fd3e613496eb76f450db5a49b6e?pvs=4 -->


## Test plan

Feature flag removed and verified to work by default.

<!-- All pull requests REQUIRE a test plan: https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles -->


## Changelog

<!--
1. Ensure your pull request title is formatted as: $type($domain): $what
2. Add bullet list items for each additional detail you want to cover (see example below)
3. You can edit this after the pull request was merged, as long as release shipping it hasn't been promoted to the public.
4. For more information, please see this how-to https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c?

Audience: TS/CSE > Customers > Teammates (in that order).

Cheat sheet: $type = chore|fix|feature $domain: source|search|ci|release|plg|cody|local|...
-->

<!--
Example:

Title: fix(search): parse quotes with the appropriate context
Changelog section:

## Changelog

- When a quote is used with regexp pattern type, then ...
- Refactored underlying code.
-->
