### PR TITLE
insights: Fix overview page

### DIFF
--- a/internal/insights/gitserver/client.go
+++ b/internal/insights/gitserver/client.go
@@ -28,6 +28,8 @@ func (g *GitCommitClient) RecentCommits(ctx context.Context, repoName api.RepoNa
 	options := gitserver.CommitsOptions{N: 1, Before: target, Order: gitserver.CommitsOrderCommitDate}
 	if len(revision) > 0 {
 		options.Ranges = []string{revision}
+	} else {
+		options.Ranges = []string{"HEAD"}
 	}
 	return g.gitserverClient.Commits(ctx, repoName, options)
 }


### PR DESCRIPTION
Forgot a case here when migrating the API to gRPC that could leave an empty ranges slice, which is now forbidden.

Thanks to Michael for reporting it!

Closes https://github.com/sourcegraph/sourcegraph/issues/62984

Test plan:

Verified manually that the page is broken before this change and works again after.