### PR TITLE
chore: Remove unused code in errors package

### DIFF
--- a/lib/errors/filter.go
+++ b/lib/errors/filter.go
@@ -35,13 +35,6 @@ func Ignore(err error, pred ErrorPredicate) error {
 // ErrorPredicate is a function type that returns whether an error matches a given condition
 type ErrorPredicate func(error) bool
 
-// HasTypePred returns an ErrorPredicate that returns true for errors that unwrap to an error with the same type as target
-func HasTypePred(target error) ErrorPredicate {
-	return func(err error) bool {
-		return HasType(err, target)
-	}
-}
-
 // IsPred returns an ErrorPredicate that returns true for errors that uwrap to the target error
 func IsPred(target error) ErrorPredicate {
 	return func(err error) bool {
@@ -55,8 +48,4 @@ func IsContextCanceled(err error) bool {
 
 func IsDeadlineExceeded(err error) bool {
 	return Is(err, context.DeadlineExceeded)
-}
-
-func IsContextError(err error) bool {
-	return IsAny(err, context.Canceled, context.DeadlineExceeded)
 }

--- a/lib/errors/filter_test.go
+++ b/lib/errors/filter_test.go
@@ -13,7 +13,6 @@ func (t *testError) Error() string { return "testError" }
 func TestIgnore(t *testing.T) {
 	testError1 := New("test1")
 	testError2 := New("test2")
-	testError3 := &testError{}
 
 	cases := []struct {
 		input error
@@ -50,13 +49,6 @@ func TestIgnore(t *testing.T) {
 		pred:  IsPred(testError1),
 		check: func(t *testing.T, err error) {
 			require.NoError(t, err)
-		},
-	}, {
-		input: Append(testError1, testError3),
-		pred:  HasTypePred(testError3),
-		check: func(t *testing.T, err error) {
-			require.ErrorIs(t, err, testError1)
-			require.False(t, HasType(err, testError3))
 		},
 	}, {
 		input: Wrap(Append(testError1, testError2), "wrapped"),


### PR DESCRIPTION
I checked that this code is also not being used in our other packages. ([Sourcegraph query](https://sourcegraph.com/search?q=context:global+repo:github.com/sourcegraph/.*%24+%28HasTypePred+OR+IsContextError%29&patternType=keyword&case=yes&sm=0))

## Test plan

Covered by existing tests

## Changelog
