### PR TITLE
Svelte: Paper cuts for 5.5 release

### DIFF
--- a/client/web-sveltekit/src/auto-imports.d.ts
+++ b/client/web-sveltekit/src/auto-imports.d.ts
@@ -12,5 +12,6 @@ declare global {
   const ILucideHome: typeof import('~icons/lucide/home')['default']
   const ILucideInfo: typeof import('~icons/lucide/info')['default']
   const ILucideRegex: typeof import('~icons/lucide/regex')['default']
+  const ILucideSquareSlash: typeof import('~icons/lucide/square-slash')['default']
   const ILucideX: typeof import('~icons/lucide/x')['default']
 }

--- a/client/web-sveltekit/src/lib/Icon2.module.scss
+++ b/client/web-sveltekit/src/lib/Icon2.module.scss
@@ -4,8 +4,7 @@ $icon-inline-size: var(--icon-inline-size, #{(16 / 14)}em);
 svg.icon {
     width: $icon-size;
     height: $icon-size;
-
-    color: var(--icon-fill-color, var(--color, inherit));
+    color: var(--icon-fill-color, var(--icon-color, inherit));
     fill: currentColor;
     stroke-width: var(--stroke-width, 2);
 

--- a/client/web-sveltekit/src/lib/Icon2.svelte
+++ b/client/web-sveltekit/src/lib/Icon2.svelte
@@ -30,5 +30,4 @@
     export let inline: boolean = false
 </script>
 
-
 <svelte:component this={icon} class="{style.icon} {inline ? style.iconInline : ''}" />

--- a/client/web-sveltekit/src/lib/KeyboardShortcut.svelte
+++ b/client/web-sveltekit/src/lib/KeyboardShortcut.svelte
@@ -6,6 +6,7 @@ A component to display the keyboard shortcuts for the application.
     import { formatShortcutParts, type Keys } from '$lib/Hotkey'
 
     export let shorcut: Keys
+    export let inline: boolean = false
 
     const separator = isMacPlatform() ? '' : '+'
 
@@ -22,7 +23,7 @@ A component to display the keyboard shortcuts for the application.
     })()
 </script>
 
-<kbd>
+<kbd class:inline={inline}>
     {#each parts as part}
         <span>{part}</span>
     {/each}
@@ -33,5 +34,13 @@ A component to display the keyboard shortcuts for the application.
         display: inline-flex;
         align-items: center;
         gap: 0.125rem;
+    }
+
+    .inline {
+      margin: 0;
+      padding: 0;
+      border: none;
+      box-shadow: none;
+      background-color: transparent;
     }
 </style>

--- a/client/web-sveltekit/src/lib/KeyboardShortcut.svelte
+++ b/client/web-sveltekit/src/lib/KeyboardShortcut.svelte
@@ -23,7 +23,7 @@ A component to display the keyboard shortcuts for the application.
     })()
 </script>
 
-<kbd class:inline={inline}>
+<kbd class:inline>
     {#each parts as part}
         <span>{part}</span>
     {/each}
@@ -37,10 +37,10 @@ A component to display the keyboard shortcuts for the application.
     }
 
     .inline {
-      margin: 0;
-      padding: 0;
-      border: none;
-      box-shadow: none;
-      background-color: transparent;
+        margin: 0;
+        padding: 0;
+        border: none;
+        box-shadow: none;
+        background-color: transparent;
     }
 </style>

--- a/client/web-sveltekit/src/lib/Popover.svelte
+++ b/client/web-sveltekit/src/lib/Popover.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
     import type { Placement } from '@floating-ui/dom'
     import type { Action } from 'svelte/action'
+    import { registerHotkey } from '$lib/Hotkey'
 
     import { popover, onClickOutside, portal } from './dom'
 
@@ -11,12 +12,25 @@
     export let showOnHover: boolean = false
     export let hoverDelay: number = 500
     export let hoverCloseDelay: number = 150
+    export let closeOnEsc: boolean = true
 
     let isOpen = false
     let trigger: HTMLElement | null
     let target: HTMLElement | undefined
     let popoverContainer: HTMLElement | null
     let delayTimer: ReturnType<typeof setTimeout>
+
+    if (closeOnEsc) {
+        registerHotkey({
+            keys: { key: 'Esc' },
+            ignoreInputFields: false,
+            handler: event => {
+                event.preventDefault()
+                close()
+                return false
+            },
+        })
+    }
 
     function toggle(open?: boolean): void {
         isOpen = open === undefined ? !isOpen : open

--- a/client/web-sveltekit/src/lib/TabPanel.svelte
+++ b/client/web-sveltekit/src/lib/TabPanel.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
-    import {getContext, onDestroy } from 'svelte'
+    import { getContext, onDestroy } from 'svelte'
     import * as uuid from 'uuid'
 
-    import type { Keys } from '$lib/Hotkey';
+    import type { Keys } from '$lib/Hotkey'
     import { type TabsContext, KEY } from './Tabs.svelte'
-    import { registerHotkey } from '$lib/Hotkey';
+    import { registerHotkey } from '$lib/Hotkey'
 
     export let title: string
     export let shortcut: Keys | undefined = undefined
@@ -33,7 +33,7 @@
         context.register({
             id: tabId,
             title,
-            shortcut
+            shortcut,
         })
     )
     $: selectedId = context.selectedTabID

--- a/client/web-sveltekit/src/lib/TabPanel.svelte
+++ b/client/web-sveltekit/src/lib/TabPanel.svelte
@@ -1,23 +1,39 @@
 <script lang="ts">
-    import { getContext, onDestroy } from 'svelte'
+    import {getContext, onDestroy } from 'svelte'
     import * as uuid from 'uuid'
 
+    import type { Keys } from '$lib/Hotkey';
     import { type TabsContext, KEY } from './Tabs.svelte'
+    import { registerHotkey } from '$lib/Hotkey';
 
     export let title: string
-    /**
-     * SVG path for the icon to display in the tab header.
-     */
-    export let icon: string | undefined = undefined
+    export let shortcut: Keys | undefined = undefined
 
-    const context = getContext<TabsContext>(KEY)
     const id = uuid.v4()
+    const context = getContext<TabsContext>(KEY)
     const tabId = `${context.id}-tab-${id}`
+
+    if (shortcut) {
+        registerHotkey({
+            keys: shortcut!,
+            allowDefault: false,
+            ignoreInputFields: false,
+            handler: event => {
+                event.preventDefault()
+
+                const currentTabIndex = context.getTabs().findIndex(tab => tab.id === tabId)
+                context.selectTab(currentTabIndex)
+
+                return false
+            },
+        })
+    }
+
     onDestroy(
         context.register({
             id: tabId,
             title,
-            icon,
+            shortcut
         })
     )
     $: selectedId = context.selectedTabID

--- a/client/web-sveltekit/src/lib/Tabs.svelte
+++ b/client/web-sveltekit/src/lib/Tabs.svelte
@@ -15,7 +15,7 @@
 </script>
 
 <script lang="ts">
-    import {createEventDispatcher, setContext} from 'svelte'
+    import { createEventDispatcher, setContext } from 'svelte'
     import { derived, writable, type Readable, type Writable, type Unsubscriber } from 'svelte/store'
     import * as uuid from 'uuid'
 
@@ -56,7 +56,7 @@
         selectTab: (index: number): void => {
             $selectedTab = $selectedTab === index && toggable ? null : index
             dispatch('select', $selectedTab)
-        }
+        },
     })
 
     function selectTab(event: { detail: number }) {

--- a/client/web-sveltekit/src/lib/Tabs.svelte
+++ b/client/web-sveltekit/src/lib/Tabs.svelte
@@ -7,13 +7,15 @@
         id: string
         selectedTabID: Readable<string | null>
         register(tab: Tab): Unsubscriber
+        getTabs: () => Tab[]
+        selectTab: (selectedTabIndex: number) => void
     }
 
     export const KEY = {}
 </script>
 
 <script lang="ts">
-    import { createEventDispatcher, setContext } from 'svelte'
+    import {createEventDispatcher, setContext} from 'svelte'
     import { derived, writable, type Readable, type Writable, type Unsubscriber } from 'svelte/store'
     import * as uuid from 'uuid'
 
@@ -50,6 +52,11 @@
                 tabs.update(tabs => tabs.filter(existingTab => existingTab.id !== tab.id))
             }
         },
+        getTabs: () => $tabs,
+        selectTab: (index: number): void => {
+            $selectedTab = $selectedTab === index && toggable ? null : index
+            dispatch('select', $selectedTab)
+        }
     })
 
     function selectTab(event: { detail: number }) {

--- a/client/web-sveltekit/src/lib/TabsHeader.svelte
+++ b/client/web-sveltekit/src/lib/TabsHeader.svelte
@@ -10,7 +10,7 @@
 
 <script lang="ts">
     import { createEventDispatcher } from 'svelte'
-    import KeyboardShortcut from '$lib/KeyboardShortcut.svelte';
+    import KeyboardShortcut from '$lib/KeyboardShortcut.svelte'
 
     export let id: string
     export let tabs: Tab[]
@@ -36,10 +36,10 @@
             role="tab"
             on:click={selectTab}
             data-tab
-            >
-                <span data-tab-title={tab.title}>
-                    {tab.title}
-                </span>
+        >
+            <span data-tab-title={tab.title}>
+                {tab.title}
+            </span>
             {#if tab.shortcut}
                 <KeyboardShortcut shorcut={tab.shortcut} />
             {/if}
@@ -94,10 +94,10 @@
             background-color: var(--secondary-2);
 
             :global(kbd) {
-              color: white;
-              box-shadow: none;
-              border-color: var(--primary);
-              background-color: var(--primary);
+                color: white;
+                box-shadow: none;
+                border-color: var(--primary);
+                background-color: var(--primary);
             }
 
             &::after {

--- a/client/web-sveltekit/src/lib/TabsHeader.svelte
+++ b/client/web-sveltekit/src/lib/TabsHeader.svelte
@@ -65,7 +65,7 @@
         flex-flow: row nowrap;
         justify-content: center;
         white-space: nowrap;
-        gap: 0.5rem;
+        gap: 0.25rem;
         position: relative;
 
         &::after {
@@ -80,15 +80,23 @@
 
         &:hover {
             color: var(--text-title);
-            background-color: var(--color-bg-2);
+            background-color: var(--secondary-2);
         }
 
         &[aria-selected='true'] {
             font-weight: 500;
             color: var(--text-title);
+            background-color: var(--secondary-2);
+
+            :global(kbd) {
+              color: white;
+              box-shadow: none;
+              border-color: var(--primary);
+              background-color: var(--primary);
+            }
 
             &::after {
-                border-color: var(--brand-secondary);
+                border-color: var(--primary);
             }
         }
 

--- a/client/web-sveltekit/src/lib/TabsHeader.svelte
+++ b/client/web-sveltekit/src/lib/TabsHeader.svelte
@@ -1,15 +1,16 @@
 <script lang="ts" context="module">
+    import type { Keys } from '$lib/Hotkey'
+
     export interface Tab {
         id: string
         title: string
-        icon?: string
+        shortcut?: Keys
     }
 </script>
 
 <script lang="ts">
     import { createEventDispatcher } from 'svelte'
-
-    import Icon from '$lib/Icon.svelte'
+    import KeyboardShortcut from '$lib/KeyboardShortcut.svelte';
 
     export let id: string
     export let tabs: Tab[]
@@ -35,10 +36,14 @@
             role="tab"
             on:click={selectTab}
             data-tab
-            >{#if tab.icon}<Icon svgPath={tab.icon} aria-hidden inline /> {/if}<span data-tab-title={tab.title}
-                >{tab.title}</span
-            ><slot name="after-title" {tab} /></button
-        >
+            >
+                <span data-tab-title={tab.title}>
+                    {tab.title}
+                </span>
+            {#if tab.shortcut}
+                <KeyboardShortcut shorcut={tab.shortcut} />
+            {/if}
+        </button>
     {/each}
 </div>
 

--- a/client/web-sveltekit/src/lib/codemirror/SearchPanelView.svelte
+++ b/client/web-sveltekit/src/lib/codemirror/SearchPanelView.svelte
@@ -27,7 +27,6 @@
      */
     export function getInput(): HTMLInputElement {
         return input
-
     }
 
     let input: HTMLInputElement

--- a/client/web-sveltekit/src/lib/fuzzyfinder/FuzzyFinder.svelte
+++ b/client/web-sveltekit/src/lib/fuzzyfinder/FuzzyFinder.svelte
@@ -51,7 +51,7 @@
 
     const client = getGraphQLClient()
     const tabs: (Tab & { source: CompletionSource<FuzzyFinderResult> })[] = [
-        { id: 'repos', title: 'Repos', shortcut: reposHotkey,  source: createRepositorySource(client) },
+        { id: 'repos', title: 'Repos', shortcut: reposHotkey, source: createRepositorySource(client) },
         { id: 'symbols', title: 'Symbols', shortcut: symbolsHotkey, source: createSymbolSource(client, () => scope) },
         { id: 'files', title: 'Files', shortcut: filesHotkey, source: createFileSource(client, () => scope) },
     ]

--- a/client/web-sveltekit/src/lib/fuzzyfinder/FuzzyFinder.svelte
+++ b/client/web-sveltekit/src/lib/fuzzyfinder/FuzzyFinder.svelte
@@ -206,7 +206,7 @@
                 </span>
             </TabsHeader>
             <Button variant="icon" on:click={() => dialog?.close()} size="sm">
-                <Icon svgPath={mdiClose} aria-label="Close" />
+                <Icon svgPath={mdiClose} aria-label="Close" inline />
             </Button>
         </header>
         <main>
@@ -284,15 +284,16 @@
 
 <style lang="scss">
     dialog {
-        background-color: var(--color-bg-1);
         width: 80vw;
         height: 80vh;
-        border: 1px solid var(--border-color);
         padding: 0;
         overflow: hidden;
+        border: 1px solid var(--border-color);
+        border-radius: var(--border-radius);
+        background-color: var(--body-bg);
 
         &::backdrop {
-            background-color: rgba(0, 0, 0, 0.3);
+            background-color: var(--modal-bg);
         }
     }
 

--- a/client/web-sveltekit/src/lib/fuzzyfinder/FuzzyFinder.svelte
+++ b/client/web-sveltekit/src/lib/fuzzyfinder/FuzzyFinder.svelte
@@ -323,6 +323,7 @@
             margin: 0;
             padding: 0;
             overflow-y: auto;
+            list-style: none;
         }
 
         [role='option'] {

--- a/client/web-sveltekit/src/lib/fuzzyfinder/FuzzyFinder.svelte
+++ b/client/web-sveltekit/src/lib/fuzzyfinder/FuzzyFinder.svelte
@@ -17,7 +17,6 @@
     import { nextSibling, onClickOutside, previousSibling } from '$lib/dom'
     import { getGraphQLClient } from '$lib/graphql'
     import Icon from '$lib/Icon.svelte'
-    import KeyboardShortcut from '$lib/KeyboardShortcut.svelte'
     import FileIcon from '$lib/repo/FileIcon.svelte'
     import CodeHostIcon from '$lib/search/CodeHostIcon.svelte'
     import EmphasizedLabel from '$lib/search/EmphasizedLabel.svelte'
@@ -52,9 +51,9 @@
 
     const client = getGraphQLClient()
     const tabs: (Tab & { source: CompletionSource<FuzzyFinderResult> })[] = [
-        { id: 'repos', title: 'Repos', source: createRepositorySource(client) },
-        { id: 'symbols', title: 'Symbols', source: createSymbolSource(client, () => scope) },
-        { id: 'files', title: 'Files', source: createFileSource(client, () => scope) },
+        { id: 'repos', title: 'Repos', shortcut: reposHotkey,  source: createRepositorySource(client) },
+        { id: 'symbols', title: 'Symbols', shortcut: symbolsHotkey, source: createSymbolSource(client, () => scope) },
+        { id: 'files', title: 'Files', shortcut: filesHotkey, source: createFileSource(client, () => scope) },
     ]
 
     function selectNext() {
@@ -194,17 +193,7 @@
                     selectedOption = 0
                     input?.focus()
                 }}
-            >
-                <span slot="after-title" let:tab>
-                    {#if tab.id === 'repos'}
-                        <KeyboardShortcut shorcut={reposHotkey} />
-                    {:else if tab.id === 'symbols'}
-                        <KeyboardShortcut shorcut={symbolsHotkey} />
-                    {:else if tab.id === 'files'}
-                        <KeyboardShortcut shorcut={filesHotkey} />
-                    {/if}
-                </span>
-            </TabsHeader>
+            />
             <Button variant="icon" on:click={() => dialog?.close()} size="sm">
                 <Icon svgPath={mdiClose} aria-label="Close" inline />
             </Button>

--- a/client/web-sveltekit/src/lib/fuzzyfinder/FuzzyFinderContainer.svelte
+++ b/client/web-sveltekit/src/lib/fuzzyfinder/FuzzyFinderContainer.svelte
@@ -39,6 +39,7 @@
             return false
         },
     })
+
     registerHotkey({
         keys: symbolsHotkey,
         ignoreInputFields: false,

--- a/client/web-sveltekit/src/lib/fuzzyfinder/FuzzyFinderContainer.svelte
+++ b/client/web-sveltekit/src/lib/fuzzyfinder/FuzzyFinderContainer.svelte
@@ -66,6 +66,16 @@
         },
     })
 
+    registerHotkey({
+        keys: { key: 'Esc' },
+        ignoreInputFields: false,
+        handler: event => {
+            event.preventDefault()
+            fuzzyFinderState.update(state => ({ ...state, open: false }))
+            return false
+        },
+    })
+
     $: if ($fuzzyFinderState.selectedTabId !== '') {
         finder?.selectTab($fuzzyFinderState.selectedTabId)
     }

--- a/client/web-sveltekit/src/lib/fuzzyfinder/FuzzyFinderContainer.svelte
+++ b/client/web-sveltekit/src/lib/fuzzyfinder/FuzzyFinderContainer.svelte
@@ -82,8 +82,9 @@
 </script>
 
 <FuzzyFinder
-    bind:this={finder}
-    {scope}
-    open={$fuzzyFinderState.open}
-    on:close={() => ($fuzzyFinderState.open = false)}
+        bind:this={finder}
+        {scope}
+        open={$fuzzyFinderState.open}
+        on:close={() => ($fuzzyFinderState.open = false)}
 />
+

--- a/client/web-sveltekit/src/lib/fuzzyfinder/FuzzyFinderContainer.svelte
+++ b/client/web-sveltekit/src/lib/fuzzyfinder/FuzzyFinderContainer.svelte
@@ -92,9 +92,8 @@
 </script>
 
 <FuzzyFinder
-        bind:this={finder}
-        {scope}
-        open={$fuzzyFinderState.open}
-        on:close={() => ($fuzzyFinderState.open = false)}
+    bind:this={finder}
+    {scope}
+    open={$fuzzyFinderState.open}
+    on:close={() => ($fuzzyFinderState.open = false)}
 />
-

--- a/client/web-sveltekit/src/lib/navigation/GlobalHeader.svelte
+++ b/client/web-sveltekit/src/lib/navigation/GlobalHeader.svelte
@@ -67,7 +67,7 @@
         {/if}
     </nav>
 
-    <Popover let:registerTrigger showOnHover>
+    <Popover let:registerTrigger showOnHover hoverDelay={100} hoverCloseDelay={50}>
         <span class="web-next-badge" use:registerTrigger>
             <Badge variant="warning">Experimental</Badge>
         </span>

--- a/client/web-sveltekit/src/lib/search/dynamicFilters/Sidebar.svelte
+++ b/client/web-sveltekit/src/lib/search/dynamicFilters/Sidebar.svelte
@@ -211,15 +211,13 @@
     }
 
     .scroll-container {
-        padding-top: 1.25rem;
-        height: 100%;
-        background-color: var(--color-bg-1);
-        overflow-y: auto;
-        box-shadow: var(--sidebar-shadow);
-
         display: flex;
         flex-direction: column;
+        height: 100%;
         gap: 1.5rem;
+        overflow-y: auto;
+        padding-top: 1.25rem;
+        background-color: var(--color-bg-1);
 
         .header {
             display: flex;

--- a/client/web-sveltekit/src/lib/wildcard/Switch.svelte
+++ b/client/web-sveltekit/src/lib/wildcard/Switch.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
-    import type { HTMLInputAttributes } from "svelte/elements"
+    import type { HTMLInputAttributes } from 'svelte/elements'
 
     type $$Props = HTMLInputAttributes
 </script>
 
-<input { ...$$restProps } type="checkbox" role="switch" on:change />
+<input {...$$restProps} type="checkbox" role="switch" on:change />
 
 <style lang="scss">
     input {
@@ -39,7 +39,7 @@
         }
 
         &::before {
-            content: "";
+            content: '';
             grid-area: track;
             inline-size: var(--thumb-size);
             block-size: var(--thumb-size);

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/+layout.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/+layout.svelte
@@ -1,5 +1,6 @@
 <script context="module" lang="ts">
     import { SVELTE_LOGGER, SVELTE_TELEMETRY_EVENTS } from '$lib/telemetry'
+    import type { Keys } from '$lib/Hotkey'
     import type { Capture as HistoryCapture } from '$lib/repo/HistoryPanel.svelte'
 
     enum TabPanels {
@@ -25,10 +26,21 @@
             return
         }
     }
+
+    const historyHotkey: Keys = {
+        key: 'alt+h',
+        mac: '⌥+h',
+    }
+
+    const referenceHotkey: Keys = {
+        key: 'alt+r',
+        mac: '⌥+r'
+    }
+
 </script>
 
 <script lang="ts">
-    import { mdiChevronDoubleLeft, mdiChevronDoubleRight, mdiHistory, mdiListBoxOutline } from '@mdi/js'
+    import { mdiChevronDoubleLeft, mdiChevronDoubleRight } from '@mdi/js'
     import { tick } from 'svelte'
 
     import { afterNavigate, goto } from '$app/navigation'
@@ -273,7 +285,7 @@
             >
                 <div class="bottom-panel">
                     <Tabs selected={selectedTab} toggable on:select={selectTab}>
-                        <TabPanel title="History" icon={mdiHistory}>
+                        <TabPanel title="History" shortcut={historyHotkey}>
                             {#key $page.params.path}
                                 <HistoryPanel
                                     bind:this={historyPanel}
@@ -285,7 +297,7 @@
                                 />
                             {/key}
                         </TabPanel>
-                        <TabPanel title="References" icon={mdiListBoxOutline}>
+                        <TabPanel title="References" shortcut={referenceHotkey}>
                             <ReferencePanel
                                 connection={references}
                                 loading={referencesLoading}

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/+layout.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/+layout.svelte
@@ -1,5 +1,6 @@
 <script context="module" lang="ts">
     import { SVELTE_LOGGER, SVELTE_TELEMETRY_EVENTS } from '$lib/telemetry'
+    import type { Capture as HistoryCapture } from '$lib/repo/HistoryPanel.svelte'
 
     enum TabPanels {
         History,
@@ -36,10 +37,12 @@
     import { openFuzzyFinder } from '$lib/fuzzyfinder/FuzzyFinderContainer.svelte'
     import { filesHotkey } from '$lib/fuzzyfinder/keys'
     import Icon from '$lib/Icon.svelte'
+    import Icon2 from '$lib/Icon2.svelte';
+    import Tooltip from '$lib/Tooltip.svelte'
     import KeyboardShortcut from '$lib/KeyboardShortcut.svelte'
     import LoadingSpinner from '$lib/LoadingSpinner.svelte'
     import { fetchSidebarFileTree } from '$lib/repo/api/tree'
-    import HistoryPanel, { type Capture as HistoryCapture } from '$lib/repo/HistoryPanel.svelte'
+    import HistoryPanel from '$lib/repo/HistoryPanel.svelte'
     import LastCommit from '$lib/repo/LastCommit.svelte'
     import TabPanel from '$lib/TabPanel.svelte'
     import Tabs from '$lib/Tabs.svelte'
@@ -204,13 +207,20 @@
                 <div class="sidebar-action-row">
                     <Button variant="secondary" outline size="sm">
                         <svelte:fragment slot="custom" let:buttonClass>
-                            <button
-                                class={`${buttonClass} search-files-button`}
-                                on:click={() => openFuzzyFinder('files')}
-                            >
-                                <span>Search files</span>
-                                <KeyboardShortcut shorcut={filesHotkey} />
-                            </button>
+                            <Tooltip tooltip={isCollapsed ? 'Open search fuzzy finder' : ''}>
+                                <button
+                                        class={`${buttonClass} search-files-button`}
+                                        on:click={() => openFuzzyFinder('files')}
+                                >
+                                    {#if isCollapsed}
+                                        <Icon2 icon={ILucideSquareSlash} inline aria-hidden />
+                                    {:else}
+                                        <span>Search files</span>
+                                        <KeyboardShortcut shorcut={filesHotkey} inline={isCollapsed} />
+                                    {/if}
+
+                                </button>
+                            </Tooltip>
                         </svelte:fragment>
                     </Button>
                 </div>
@@ -348,7 +358,15 @@
             width: 100%;
         }
 
-        .search-files-button,
+        // Hide action text and leave just icon for collapsed version
+        .search-files-button {
+          display: block;
+
+          span {
+            display: none;
+          }
+        }
+
         :global([data-repo-rev-picker-trigger]),
         .sidebar-file-tree {
             display: none;
@@ -391,12 +409,6 @@
                 flex-shrink: 1;
                 text-align: left;
             }
-
-            kbd {
-                display: flex;
-                margin: -0.1rem 0;
-                letter-spacing: 0.15rem;
-            }
         }
     }
 
@@ -435,9 +447,10 @@
         :global([data-tabs]) {
             flex: 1;
         }
+
         .last-commit {
             min-width: 0;
-            max-width: content;
+            max-width: min-content;
             margin-right: 0.5rem;
         }
     }

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/+layout.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/+layout.svelte
@@ -29,12 +29,10 @@
 
     const historyHotkey: Keys = {
         key: 'alt+h',
-        mac: '⌥+h',
     }
 
     const referenceHotkey: Keys = {
         key: 'alt+r',
-        mac: '⌥+r',
     }
 </script>
 

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/+layout.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/+layout.svelte
@@ -34,9 +34,8 @@
 
     const referenceHotkey: Keys = {
         key: 'alt+r',
-        mac: '⌥+r'
+        mac: '⌥+r',
     }
-
 </script>
 
 <script lang="ts">
@@ -49,7 +48,7 @@
     import { openFuzzyFinder } from '$lib/fuzzyfinder/FuzzyFinderContainer.svelte'
     import { filesHotkey } from '$lib/fuzzyfinder/keys'
     import Icon from '$lib/Icon.svelte'
-    import Icon2 from '$lib/Icon2.svelte';
+    import Icon2 from '$lib/Icon2.svelte'
     import Tooltip from '$lib/Tooltip.svelte'
     import KeyboardShortcut from '$lib/KeyboardShortcut.svelte'
     import LoadingSpinner from '$lib/LoadingSpinner.svelte'
@@ -221,8 +220,8 @@
                         <svelte:fragment slot="custom" let:buttonClass>
                             <Tooltip tooltip={isCollapsed ? 'Open search fuzzy finder' : ''}>
                                 <button
-                                        class={`${buttonClass} search-files-button`}
-                                        on:click={() => openFuzzyFinder('files')}
+                                    class={`${buttonClass} search-files-button`}
+                                    on:click={() => openFuzzyFinder('files')}
                                 >
                                     {#if isCollapsed}
                                         <Icon2 icon={ILucideSquareSlash} inline aria-hidden />
@@ -230,7 +229,6 @@
                                         <span>Search files</span>
                                         <KeyboardShortcut shorcut={filesHotkey} inline={isCollapsed} />
                                     {/if}
-
                                 </button>
                             </Tooltip>
                         </svelte:fragment>
@@ -372,11 +370,11 @@
 
         // Hide action text and leave just icon for collapsed version
         .search-files-button {
-          display: block;
+            display: block;
 
-          span {
-            display: none;
-          }
+            span {
+                display: none;
+            }
         }
 
         :global([data-repo-rev-picker-trigger]),

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/RepositoryRevPicker.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/RepositoryRevPicker.svelte
@@ -206,7 +206,6 @@
         max-width: 40rem;
         width: 640px;
 
-        --tabs-gap: 0.25rem;
         --align-tabs: flex-start;
 
         :global([data-tab-header]) {

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/RepositoryRevPicker.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/RepositoryRevPicker.svelte
@@ -25,7 +25,6 @@
         key: 'shift+c',
         mac: 'shift+c',
     }
-
 </script>
 
 <script lang="ts">

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/RepositoryRevPicker.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/RepositoryRevPicker.svelte
@@ -13,17 +13,14 @@
 
     const branchesHotkey: Keys = {
         key: 'shift+b',
-        mac: 'shift+b',
     }
 
     const tagsHotkey: Keys = {
         key: 'shift+t',
-        mac: 'shift+t',
     }
 
     const commitsHotkey: Keys = {
         key: 'shift+c',
-        mac: 'shift+c',
     }
 </script>
 

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/RepositoryRevPicker.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/RepositoryRevPicker.svelte
@@ -1,4 +1,5 @@
 <script context="module" lang="ts">
+    import type { Keys } from '$lib/Hotkey'
     import type { RepositoryGitRefs, RevPickerGitCommit } from './RepositoryRevPicker.gql'
 
     export type RepositoryBranches = RepositoryGitRefs['gitRefs']
@@ -9,6 +10,22 @@
 
     export type RepositoryCommits = { nodes: RevPickerGitCommit[] }
     export type RepositoryGitCommit = RevPickerGitCommit
+
+    const branchesHotkey: Keys = {
+        key: 'shift+b',
+        mac: 'shift+b',
+    }
+
+    const tagsHotkey: Keys = {
+        key: 'shift+t',
+        mac: 'shift+t',
+    }
+
+    const commitsHotkey: Keys = {
+        key: 'shift+c',
+        mac: 'shift+c',
+    }
+
 </script>
 
 <script lang="ts">
@@ -92,7 +109,7 @@
 
     <div slot="content" class="content" let:toggle>
         <Tabs>
-            <TabPanel title="Branches">
+            <TabPanel title="Branches" shortcut={branchesHotkey}>
                 <Picker
                     name="branches"
                     seeAllItemsURL={`${repoURL}/-/branches`}
@@ -119,7 +136,7 @@
                     </RepositoryRevPickerItem>
                 </Picker>
             </TabPanel>
-            <TabPanel title="Tags">
+            <TabPanel title="Tags" shortcut={tagsHotkey}>
                 <Picker
                     name="tags"
                     seeAllItemsURL={`${repoURL}/-/tags`}
@@ -138,7 +155,7 @@
                     />
                 </Picker>
             </TabPanel>
-            <TabPanel title="Commits">
+            <TabPanel title="Commits" shortcut={commitsHotkey}>
                 <Picker
                     name="commits"
                     seeAllItemsURL={`${repoURL}/-/commits`}

--- a/client/web-sveltekit/src/routes/svelte-overrides.scss
+++ b/client/web-sveltekit/src/routes/svelte-overrides.scss
@@ -27,14 +27,17 @@ label {
 }
 
 // Theme Light
-
-.theme-light {
+// Apparently ::backdrop element doesn't support CSS variable if they
+// are defined only on the root element, we have to define them for ::backdrop
+// pseudo selector as well
+.theme-light, .theme-light ::backdrop {
     // Colors
     --color-bg-1: var(--white);
     --text-body: var(--gray-08);
     --search-result-header-bg: #eef2f5;
     --line-number-color: var(--gray-06);
     --code-bg: var(--white);
+    --modal-bg: rgba(219, 226, 240, .5);;
     --code-selection-bg: rgba(231, 238, 250, 0.8);
 
     // Shadows
@@ -54,7 +57,7 @@ label {
 
 // Theme Dark
 
-.theme-dark {
+.theme-dark, .theme-dark ::backdrop {
     // Colors
     --color-bg-1: var(--gray-12);
     --text-body: var(--gray-05);
@@ -63,6 +66,7 @@ label {
     --line-number-color: var(--gray-07);
     --code-selection-bg: var(--color-bg-2);
     --code-bg: var(--gray-12);
+    --modal-bg: rgba(52, 58, 77, .5);
 
     // Shadows
     --sidebar-shadow: 0 240px 80px 0 rgba(12, 1, 19, 0.01), 0 160px 80px 0 rgba(12, 1, 19, 0.02),

--- a/client/web-sveltekit/src/routes/svelte-overrides.scss
+++ b/client/web-sveltekit/src/routes/svelte-overrides.scss
@@ -30,14 +30,15 @@ label {
 // Apparently ::backdrop element doesn't support CSS variable if they
 // are defined only on the root element, we have to define them for ::backdrop
 // pseudo selector as well
-.theme-light, .theme-light ::backdrop {
+.theme-light,
+.theme-light ::backdrop {
     // Colors
     --color-bg-1: var(--white);
     --text-body: var(--gray-08);
     --search-result-header-bg: #eef2f5;
     --line-number-color: var(--gray-06);
     --code-bg: var(--white);
-    --modal-bg: rgba(219, 226, 240, .5);;
+    --modal-bg: rgba(219, 226, 240, 0.5);
     --code-selection-bg: rgba(231, 238, 250, 0.8);
 
     // Shadows
@@ -56,8 +57,8 @@ label {
 }
 
 // Theme Dark
-
-.theme-dark, .theme-dark ::backdrop {
+.theme-dark,
+.theme-dark ::backdrop {
     // Colors
     --color-bg-1: var(--gray-12);
     --text-body: var(--gray-05);
@@ -66,7 +67,7 @@ label {
     --line-number-color: var(--gray-07);
     --code-selection-bg: var(--color-bg-2);
     --code-bg: var(--gray-12);
-    --modal-bg: rgba(52, 58, 77, .5);
+    --modal-bg: rgba(52, 58, 77, 0.5);
 
     // Shadows
     --sidebar-shadow: 0 240px 80px 0 rgba(12, 1, 19, 0.01), 0 160px 80px 0 rgba(12, 1, 19, 0.02),


### PR DESCRIPTION
Closes https://linear.app/sourcegraph/issue/SRCH-78/svelte-improve-repository-revision-picker-ui

Just a package of small fixes in different places (group them in one PR to avoid having a lot of super small PRs before the release. These fixes include

## Add Search files quick actions for collapsed file sidebar state
<img width="248" alt="Screenshot 2024-05-31 at 15 34 12" src="https://github.com/sourcegraph/sourcegraph/assets/18492575/35e5c94a-b947-430c-9183-b21b4185d7c6">


## Updates for tabs appearance 
<img width="392" alt="Screenshot 2024-05-31 at 15 34 36" src="https://github.com/sourcegraph/sourcegraph/assets/18492575/eafad8d1-b68c-4f68-889f-0710354d5224">

## Update fuzzy finder  appearance (most of the styles that we have in the react version and fixes for Safari)
<img width="1073" alt="Screenshot 2024-05-31 at 15 35 42" src="https://github.com/sourcegraph/sourcegraph/assets/18492575/5363c886-3500-4886-a051-31a166596375">

- Add keyboard support for tabs 
- Fixes opt-in/out tooltips delays
- Add close-on escape feature to fuzzy finder and popover components
- Fix sidebar filters panel shadow problem 
- Add shortcuts to repo revision popover tabs and history and references tabs





## Test plan
- Manual testing of all changes listed above

