### PR TITLE
chore(appliance): fix race condition in tests

### DIFF
--- a/internal/appliance/reconciler/blobstore_test.go
+++ b/internal/appliance/reconciler/blobstore_test.go
@@ -12,8 +12,7 @@ func (suite *ApplianceTestSuite) TestDeployBlobstore() {
 		},
 	} {
 		suite.Run(tc.name, func() {
-			namespace := suite.createConfigMap(tc.name)
-			suite.awaitReconciliation(namespace)
+			namespace := suite.createConfigMapAndAwaitReconciliation(tc.name)
 			suite.makeGoldenAssertions(namespace, tc.name)
 		})
 	}

--- a/internal/appliance/reconciler/blobstore_test.go
+++ b/internal/appliance/reconciler/blobstore_test.go
@@ -1,9 +1,5 @@
 package reconciler
 
-import (
-	"time"
-)
-
 // Simple test cases in which we want to assert that a given configmap causes a
 // certain set of resources to be deployed can go here. sg and golden fixtures
 // are in testdata/ and named after the test case name.
@@ -17,12 +13,7 @@ func (suite *ApplianceTestSuite) TestDeployBlobstore() {
 	} {
 		suite.Run(tc.name, func() {
 			namespace := suite.createConfigMap(tc.name)
-
-			// Wait for reconciliation to be finished.
-			suite.Require().Eventually(func() bool {
-				return suite.getConfigMapReconcileEventCount(namespace) > 0
-			}, time.Second*10, time.Millisecond*200)
-
+			suite.awaitReconciliation(namespace)
 			suite.makeGoldenAssertions(namespace, tc.name)
 		})
 	}

--- a/internal/appliance/reconciler/cadvisor_test.go
+++ b/internal/appliance/reconciler/cadvisor_test.go
@@ -7,8 +7,7 @@ func (suite *ApplianceTestSuite) TestDeployCadvisor() {
 		{name: "cadvisor/default"},
 	} {
 		suite.Run(tc.name, func() {
-			namespace := suite.createConfigMap(tc.name)
-			suite.awaitReconciliation(namespace)
+			namespace := suite.createConfigMapAndAwaitReconciliation(tc.name)
 			suite.makeGoldenAssertions(namespace, tc.name)
 		})
 	}

--- a/internal/appliance/reconciler/cadvisor_test.go
+++ b/internal/appliance/reconciler/cadvisor_test.go
@@ -1,7 +1,5 @@
 package reconciler
 
-import "time"
-
 func (suite *ApplianceTestSuite) TestDeployCadvisor() {
 	for _, tc := range []struct {
 		name string
@@ -10,12 +8,7 @@ func (suite *ApplianceTestSuite) TestDeployCadvisor() {
 	} {
 		suite.Run(tc.name, func() {
 			namespace := suite.createConfigMap(tc.name)
-
-			// Wait for reconciliation to be finished.
-			suite.Require().Eventually(func() bool {
-				return suite.getConfigMapReconcileEventCount(namespace) > 0
-			}, time.Second*10, time.Millisecond*200)
-
+			suite.awaitReconciliation(namespace)
 			suite.makeGoldenAssertions(namespace, tc.name)
 		})
 	}

--- a/internal/appliance/reconciler/codeintel_test.go
+++ b/internal/appliance/reconciler/codeintel_test.go
@@ -1,7 +1,5 @@
 package reconciler
 
-import "time"
-
 func (suite *ApplianceTestSuite) TestDeployCodeIntel() {
 	for _, tc := range []struct {
 		name string
@@ -10,12 +8,7 @@ func (suite *ApplianceTestSuite) TestDeployCodeIntel() {
 	} {
 		suite.Run(tc.name, func() {
 			namespace := suite.createConfigMap(tc.name)
-
-			// Wait for reconciliation to be finished.
-			suite.Require().Eventually(func() bool {
-				return suite.getConfigMapReconcileEventCount(namespace) > 0
-			}, time.Second*10, time.Millisecond*200)
-
+			suite.awaitReconciliation(namespace)
 			suite.makeGoldenAssertions(namespace, tc.name)
 		})
 	}

--- a/internal/appliance/reconciler/codeintel_test.go
+++ b/internal/appliance/reconciler/codeintel_test.go
@@ -7,8 +7,7 @@ func (suite *ApplianceTestSuite) TestDeployCodeIntel() {
 		{name: "codeintel/default"},
 	} {
 		suite.Run(tc.name, func() {
-			namespace := suite.createConfigMap(tc.name)
-			suite.awaitReconciliation(namespace)
+			namespace := suite.createConfigMapAndAwaitReconciliation(tc.name)
 			suite.makeGoldenAssertions(namespace, tc.name)
 		})
 	}

--- a/internal/appliance/reconciler/gitserver_test.go
+++ b/internal/appliance/reconciler/gitserver_test.go
@@ -1,7 +1,5 @@
 package reconciler
 
-import "time"
-
 func (suite *ApplianceTestSuite) TestDeployGitServer() {
 	for _, tc := range []struct {
 		name string
@@ -10,12 +8,7 @@ func (suite *ApplianceTestSuite) TestDeployGitServer() {
 	} {
 		suite.Run(tc.name, func() {
 			namespace := suite.createConfigMap(tc.name)
-
-			// Wait for reconciliation to be finished.
-			suite.Require().Eventually(func() bool {
-				return suite.getConfigMapReconcileEventCount(namespace) > 0
-			}, time.Second*10, time.Millisecond*200)
-
+			suite.awaitReconciliation(namespace)
 			suite.makeGoldenAssertions(namespace, tc.name)
 		})
 	}

--- a/internal/appliance/reconciler/gitserver_test.go
+++ b/internal/appliance/reconciler/gitserver_test.go
@@ -7,8 +7,7 @@ func (suite *ApplianceTestSuite) TestDeployGitServer() {
 		{name: "gitserver/default"},
 	} {
 		suite.Run(tc.name, func() {
-			namespace := suite.createConfigMap(tc.name)
-			suite.awaitReconciliation(namespace)
+			namespace := suite.createConfigMapAndAwaitReconciliation(tc.name)
 			suite.makeGoldenAssertions(namespace, tc.name)
 		})
 	}

--- a/internal/appliance/reconciler/pgsql_test.go
+++ b/internal/appliance/reconciler/pgsql_test.go
@@ -1,7 +1,5 @@
 package reconciler
 
-import "time"
-
 func (suite *ApplianceTestSuite) TestDeployPGSQL() {
 	for _, tc := range []struct {
 		name string
@@ -10,12 +8,7 @@ func (suite *ApplianceTestSuite) TestDeployPGSQL() {
 	} {
 		suite.Run(tc.name, func() {
 			namespace := suite.createConfigMap(tc.name)
-
-			// Wait for reconciliation to be finished.
-			suite.Require().Eventually(func() bool {
-				return suite.getConfigMapReconcileEventCount(namespace) > 0
-			}, time.Second*10, time.Millisecond*200)
-
+			suite.awaitReconciliation(namespace)
 			suite.makeGoldenAssertions(namespace, tc.name)
 		})
 	}

--- a/internal/appliance/reconciler/pgsql_test.go
+++ b/internal/appliance/reconciler/pgsql_test.go
@@ -7,8 +7,7 @@ func (suite *ApplianceTestSuite) TestDeployPGSQL() {
 		{name: "pgsql/default"},
 	} {
 		suite.Run(tc.name, func() {
-			namespace := suite.createConfigMap(tc.name)
-			suite.awaitReconciliation(namespace)
+			namespace := suite.createConfigMapAndAwaitReconciliation(tc.name)
 			suite.makeGoldenAssertions(namespace, tc.name)
 		})
 	}

--- a/internal/appliance/reconciler/precise_code_intel_test.go
+++ b/internal/appliance/reconciler/precise_code_intel_test.go
@@ -1,7 +1,5 @@
 package reconciler
 
-import "time"
-
 func (suite *ApplianceTestSuite) TestDeployPreciseCodeIntel() {
 	for _, tc := range []struct {
 		name string
@@ -13,12 +11,7 @@ func (suite *ApplianceTestSuite) TestDeployPreciseCodeIntel() {
 	} {
 		suite.Run(tc.name, func() {
 			namespace := suite.createConfigMap(tc.name)
-
-			// Wait for reconciliation to be finished.
-			suite.Require().Eventually(func() bool {
-				return suite.getConfigMapReconcileEventCount(namespace) > 0
-			}, time.Second*10, time.Millisecond*200)
-
+			suite.awaitReconciliation(namespace)
 			suite.makeGoldenAssertions(namespace, tc.name)
 		})
 	}

--- a/internal/appliance/reconciler/precise_code_intel_test.go
+++ b/internal/appliance/reconciler/precise_code_intel_test.go
@@ -10,8 +10,7 @@ func (suite *ApplianceTestSuite) TestDeployPreciseCodeIntel() {
 		{name: "precise-code-intel/with-replicas"},
 	} {
 		suite.Run(tc.name, func() {
-			namespace := suite.createConfigMap(tc.name)
-			suite.awaitReconciliation(namespace)
+			namespace := suite.createConfigMapAndAwaitReconciliation(tc.name)
 			suite.makeGoldenAssertions(namespace, tc.name)
 		})
 	}

--- a/internal/appliance/reconciler/prometheus_test.go
+++ b/internal/appliance/reconciler/prometheus_test.go
@@ -9,18 +9,14 @@ func (suite *ApplianceTestSuite) TestDeployPrometheus() {
 		{name: "prometheus/with-existing-configmap"},
 	} {
 		suite.Run(tc.name, func() {
-			namespace := suite.createConfigMap(tc.name)
-			suite.awaitReconciliation(namespace)
+			namespace := suite.createConfigMapAndAwaitReconciliation(tc.name)
 			suite.makeGoldenAssertions(namespace, tc.name)
 		})
 	}
 }
 
 func (suite *ApplianceTestSuite) TestNonNamespacedResourcesRemainWhenDisabled() {
-	namespace := suite.createConfigMap("prometheus/privileged")
-	suite.awaitReconciliation(namespace)
-
-	suite.updateConfigMap(namespace, "standard/everything-disabled")
-	suite.awaitReconciliation(namespace)
+	namespace := suite.createConfigMapAndAwaitReconciliation("prometheus/privileged")
+	suite.updateConfigMapAndAwaitReconciliation(namespace, "standard/everything-disabled")
 	suite.makeGoldenAssertions(namespace, "prometheus/subsequent-disable")
 }

--- a/internal/appliance/reconciler/redis_test.go
+++ b/internal/appliance/reconciler/redis_test.go
@@ -7,8 +7,7 @@ func (suite *ApplianceTestSuite) TestDeployRedis() {
 		{name: "redis/default"},
 	} {
 		suite.Run(tc.name, func() {
-			namespace := suite.createConfigMap(tc.name)
-			suite.awaitReconciliation(namespace)
+			namespace := suite.createConfigMapAndAwaitReconciliation(tc.name)
 			suite.makeGoldenAssertions(namespace, tc.name)
 		})
 	}

--- a/internal/appliance/reconciler/redis_test.go
+++ b/internal/appliance/reconciler/redis_test.go
@@ -1,7 +1,5 @@
 package reconciler
 
-import "time"
-
 func (suite *ApplianceTestSuite) TestDeployRedis() {
 	for _, tc := range []struct {
 		name string
@@ -10,12 +8,7 @@ func (suite *ApplianceTestSuite) TestDeployRedis() {
 	} {
 		suite.Run(tc.name, func() {
 			namespace := suite.createConfigMap(tc.name)
-
-			// Wait for reconciliation to be finished.
-			suite.Require().Eventually(func() bool {
-				return suite.getConfigMapReconcileEventCount(namespace) > 0
-			}, time.Second*10, time.Millisecond*200)
-
+			suite.awaitReconciliation(namespace)
 			suite.makeGoldenAssertions(namespace, tc.name)
 		})
 	}

--- a/internal/appliance/reconciler/repo_updater_test.go
+++ b/internal/appliance/reconciler/repo_updater_test.go
@@ -1,9 +1,5 @@
 package reconciler
 
-import (
-	"time"
-)
-
 func (suite *ApplianceTestSuite) TestDeployRepoUpdater() {
 	for _, tc := range []struct {
 		name string
@@ -12,12 +8,7 @@ func (suite *ApplianceTestSuite) TestDeployRepoUpdater() {
 	} {
 		suite.Run(tc.name, func() {
 			namespace := suite.createConfigMap(tc.name)
-
-			// Wait for reconciliation to be finished.
-			suite.Require().Eventually(func() bool {
-				return suite.getConfigMapReconcileEventCount(namespace) > 0
-			}, time.Second*10, time.Millisecond*200)
-
+			suite.awaitReconciliation(namespace)
 			suite.makeGoldenAssertions(namespace, tc.name)
 		})
 	}

--- a/internal/appliance/reconciler/repo_updater_test.go
+++ b/internal/appliance/reconciler/repo_updater_test.go
@@ -7,8 +7,7 @@ func (suite *ApplianceTestSuite) TestDeployRepoUpdater() {
 		{name: "repo-updater/default"},
 	} {
 		suite.Run(tc.name, func() {
-			namespace := suite.createConfigMap(tc.name)
-			suite.awaitReconciliation(namespace)
+			namespace := suite.createConfigMapAndAwaitReconciliation(tc.name)
 			suite.makeGoldenAssertions(namespace, tc.name)
 		})
 	}

--- a/internal/appliance/reconciler/standard_config_test.go
+++ b/internal/appliance/reconciler/standard_config_test.go
@@ -1,7 +1,5 @@
 package reconciler
 
-import "time"
-
 // Use this file to test features available in StandardConfig (see
 // development.md and config subpackage).
 
@@ -21,12 +19,7 @@ func (suite *ApplianceTestSuite) TestStandardFeatures() {
 	} {
 		suite.Run(tc.name, func() {
 			namespace := suite.createConfigMap(tc.name)
-
-			// Wait for reconciliation to be finished.
-			suite.Require().Eventually(func() bool {
-				return suite.getConfigMapReconcileEventCount(namespace) > 0
-			}, time.Second*10, time.Millisecond*200)
-
+			suite.awaitReconciliation(namespace)
 			suite.makeGoldenAssertions(namespace, tc.name)
 		})
 	}
@@ -36,15 +29,9 @@ func (suite *ApplianceTestSuite) TestStandardFeatures() {
 // test blocks
 func (suite *ApplianceTestSuite) TestResourcesDeletedWhenDisabled() {
 	namespace := suite.createConfigMap("blobstore/default")
-	suite.Require().Eventually(func() bool {
-		return suite.getConfigMapReconcileEventCount(namespace) > 0
-	}, time.Second*10, time.Millisecond*200)
+	suite.awaitReconciliation(namespace)
 
-	eventsSeenSoFar := suite.getConfigMapReconcileEventCount(namespace)
 	suite.updateConfigMap(namespace, "standard/everything-disabled")
-	suite.Require().Eventually(func() bool {
-		return suite.getConfigMapReconcileEventCount(namespace) > eventsSeenSoFar
-	}, time.Second*10, time.Millisecond*200)
-
+	suite.awaitReconciliation(namespace)
 	suite.makeGoldenAssertions(namespace, "standard/blobstore-subsequent-disable")
 }

--- a/internal/appliance/reconciler/standard_config_test.go
+++ b/internal/appliance/reconciler/standard_config_test.go
@@ -18,8 +18,7 @@ func (suite *ApplianceTestSuite) TestStandardFeatures() {
 		{name: "standard/symbols-with-custom-image"},
 	} {
 		suite.Run(tc.name, func() {
-			namespace := suite.createConfigMap(tc.name)
-			suite.awaitReconciliation(namespace)
+			namespace := suite.createConfigMapAndAwaitReconciliation(tc.name)
 			suite.makeGoldenAssertions(namespace, tc.name)
 		})
 	}
@@ -28,10 +27,8 @@ func (suite *ApplianceTestSuite) TestStandardFeatures() {
 // More complex test cases involving updates to the configmap can have their own
 // test blocks
 func (suite *ApplianceTestSuite) TestResourcesDeletedWhenDisabled() {
-	namespace := suite.createConfigMap("blobstore/default")
-	suite.awaitReconciliation(namespace)
+	namespace := suite.createConfigMapAndAwaitReconciliation("blobstore/default")
 
-	suite.updateConfigMap(namespace, "standard/everything-disabled")
-	suite.awaitReconciliation(namespace)
+	suite.updateConfigMapAndAwaitReconciliation(namespace, "standard/everything-disabled")
 	suite.makeGoldenAssertions(namespace, "standard/blobstore-subsequent-disable")
 }

--- a/internal/appliance/reconciler/symbols_test.go
+++ b/internal/appliance/reconciler/symbols_test.go
@@ -11,8 +11,7 @@ func (suite *ApplianceTestSuite) TestDeploySymbols() {
 		{name: "symbols/with-storage"},
 	} {
 		suite.Run(tc.name, func() {
-			namespace := suite.createConfigMap(tc.name)
-			suite.awaitReconciliation(namespace)
+			namespace := suite.createConfigMapAndAwaitReconciliation(tc.name)
 			suite.makeGoldenAssertions(namespace, tc.name)
 		})
 	}

--- a/internal/appliance/reconciler/symbols_test.go
+++ b/internal/appliance/reconciler/symbols_test.go
@@ -1,7 +1,5 @@
 package reconciler
 
-import "time"
-
 func (suite *ApplianceTestSuite) TestDeploySymbols() {
 	for _, tc := range []struct {
 		name string
@@ -14,12 +12,7 @@ func (suite *ApplianceTestSuite) TestDeploySymbols() {
 	} {
 		suite.Run(tc.name, func() {
 			namespace := suite.createConfigMap(tc.name)
-
-			// Wait for reconciliation to be finished.
-			suite.Require().Eventually(func() bool {
-				return suite.getConfigMapReconcileEventCount(namespace) > 0
-			}, time.Second*10, time.Millisecond*200)
-
+			suite.awaitReconciliation(namespace)
 			suite.makeGoldenAssertions(namespace, tc.name)
 		})
 	}

--- a/internal/appliance/reconciler/syntect_test.go
+++ b/internal/appliance/reconciler/syntect_test.go
@@ -8,8 +8,7 @@ func (suite *ApplianceTestSuite) TestDeploySyntect() {
 		{name: "syntect/with-replicas"},
 	} {
 		suite.Run(tc.name, func() {
-			namespace := suite.createConfigMap(tc.name)
-			suite.awaitReconciliation(namespace)
+			namespace := suite.createConfigMapAndAwaitReconciliation(tc.name)
 			suite.makeGoldenAssertions(namespace, tc.name)
 		})
 	}

--- a/internal/appliance/reconciler/syntect_test.go
+++ b/internal/appliance/reconciler/syntect_test.go
@@ -1,7 +1,5 @@
 package reconciler
 
-import "time"
-
 func (suite *ApplianceTestSuite) TestDeploySyntect() {
 	for _, tc := range []struct {
 		name string
@@ -11,12 +9,7 @@ func (suite *ApplianceTestSuite) TestDeploySyntect() {
 	} {
 		suite.Run(tc.name, func() {
 			namespace := suite.createConfigMap(tc.name)
-
-			// Wait for reconciliation to be finished.
-			suite.Require().Eventually(func() bool {
-				return suite.getConfigMapReconcileEventCount(namespace) > 0
-			}, time.Second*10, time.Millisecond*200)
-
+			suite.awaitReconciliation(namespace)
 			suite.makeGoldenAssertions(namespace, tc.name)
 		})
 	}


### PR DESCRIPTION
We observed a rare test flake in
TestNonNamespacedResourcesRemainWhenDisabled in which non-namespaced resources were apparently not deleted when assertions were made against golden fixtures. My theory for why this was happening, is that there was a race between the test goroutine and the reconciler running in the background.

The reconciler actually appears to emit 2 events per configmap creation. The second is probably a result of updating the currentVersion annotation at the end of the reconcile loop, which itself triggers another reconcile loop.

Our test code was waiting for the initial resources to be created by waiting for at least one reconcile event to appear. It was then waiting for only one more event. When we got unlucky, this event would be the 2nd event from the 1st configmap upload, rather than the _next_ event, from the 2nd configmap upload. If the test thread scraped all resources from kube-apiserver before the reconciler had deleted them (in response to the 2nd configmap upload in this particular test), the golden assertions would fail.

This could all be totally wrong. We only received one report of such a flake, and I was unable to reproduce it in hundreds of local runs, so sadly I haven't empirically validated this.

---

Closes https://linear.app/sourcegraph/issue/REL-121/test-failure-related-to-appliance-in-pr-adding-dependency-and

<!-- 💡 To write a useful PR description, make sure that your description covers:
- WHAT this PR is changing:
    - How was it PREVIOUSLY.
    - How it will be from NOW on.
- WHY this PR is needed.
- CONTEXT, i.e. to which initiative, project or RFC it belongs.

The structure of the description doesn't matter as much as covering these points, so use
your best judgement based on your context.
Learn how to write good pull request description: https://www.notion.so/sourcegraph/Write-a-good-pull-request-description-610a7fd3e613496eb76f450db5a49b6e?pvs=4 -->


## Test plan

This is a fix to tests.

<!-- All pull requests REQUIRE a test plan: https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles -->


## Changelog

<!--
1. Ensure your pull request title is formatted as: $type($domain): $what
2. Add bullet list items for each additional detail you want to cover (see example below)
3. You can edit this after the pull request was merged, as long as release shipping it hasn't been promoted to the public.
4. For more information, please see this how-to https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c?

Audience: TS/CSE > Customers > Teammates (in that order).

Cheat sheet: $type = chore|fix|feature $domain: source|search|ci|release|plg|cody|local|...
-->

- Fix a race condition in one package's tests.

<!--
Example:

Title: fix(search): parse quotes with the appropriate context
Changelog section:

## Changelog

- When a quote is used with regexp pattern type, then ...
- Refactored underlying code.
-->
