### PR TITLE
fix(scip-syntax): Fixes a couple CLI annoyances

### DIFF
--- a/docker-images/syntax-highlighter/crates/scip-syntax/src/index.rs
+++ b/docker-images/syntax-highlighter/crates/scip-syntax/src/index.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use anyhow::{anyhow, Context, Result};
 use clap::ValueEnum;
@@ -87,9 +87,12 @@ pub fn index_command(
         ..Default::default()
     };
 
-    let mut index_file = |filepath: &PathBuf| -> Result<()> {
+    let mut index_file = |filepath: &Path| -> Result<()> {
         let contents = std::fs::read_to_string(filepath)
             .with_context(|| format!("Failed to read file at {}", filepath.display()))?;
+        let filepath = filepath
+            .canonicalize()
+            .with_context(|| format!("Failed to canonicalize file path: {}", filepath.display()))?;
         let relative_path = filepath
             .strip_prefix(canonical_project_root.clone())
             .expect("Failed to strip project root prefix");

--- a/docker-images/syntax-highlighter/crates/scip-syntax/src/index.rs
+++ b/docker-images/syntax-highlighter/crates/scip-syntax/src/index.rs
@@ -94,7 +94,13 @@ pub fn index_command(
             .with_context(|| format!("Failed to canonicalize file path: {}", filepath.display()))?;
         let relative_path = filepath
             .strip_prefix(canonical_project_root.clone())
-            .expect("Failed to strip project root prefix");
+            .with_context(|| {
+                format!(
+                    "Failed to strip project root prefix: root={} file={}",
+                    canonical_project_root.display(),
+                    filepath.display()
+                )
+            })?;
 
         match index_content(&contents, p, &options) {
             Ok(mut document) => {

--- a/docker-images/syntax-highlighter/crates/scip-syntax/src/index.rs
+++ b/docker-images/syntax-highlighter/crates/scip-syntax/src/index.rs
@@ -89,9 +89,13 @@ pub fn index_command(
     let mut index_file = |filepath: &Path| -> Result<()> {
         let contents = std::fs::read_to_string(filepath)
             .with_context(|| format!("Failed to read file at {}", filepath.display()))?;
-        let filepath = filepath
-            .canonicalize()
-            .with_context(|| format!("Failed to canonicalize file path: {}", filepath.display()))?;
+        let filepath = if filepath.is_absolute() {
+            filepath.to_owned()
+        } else {
+            filepath.canonicalize().with_context(|| {
+                format!("Failed to canonicalize file path: {}", filepath.display())
+            })?
+        };
         let relative_path = filepath
             .strip_prefix(canonical_project_root.clone())
             .with_context(|| {

--- a/docker-images/syntax-highlighter/crates/scip-syntax/src/main.rs
+++ b/docker-images/syntax-highlighter/crates/scip-syntax/src/main.rs
@@ -1,4 +1,5 @@
 use std::path::PathBuf;
+use std::process;
 
 use clap::{Parser, Subcommand};
 use scip_syntax::index::{index_command, AnalysisMode, IndexMode, IndexOptions};
@@ -111,10 +112,17 @@ pub fn main() -> anyhow::Result<()> {
         } => {
             let index_mode = {
                 match workspace {
-                    None => IndexMode::Files { list: filenames },
+                    None => {
+                        if filenames.is_empty() {
+                            eprintln!("either specify --workspace or provide a list of files");
+                            process::exit(1)
+                        }
+                        IndexMode::Files { list: filenames }
+                    }
                     Some(location) => {
                         if !filenames.is_empty() {
-                            panic!("--workspace option cannot be combined with a list of files");
+                            eprintln!("--workspace option cannot be combined with a list of files");
+                            process::exit(1)
                         } else {
                             IndexMode::Workspace {
                                 location: location.into(),

--- a/docker-images/syntax-highlighter/crates/scip-syntax/src/main.rs
+++ b/docker-images/syntax-highlighter/crates/scip-syntax/src/main.rs
@@ -1,5 +1,4 @@
-use std::path::PathBuf;
-use std::process;
+use std::{path::PathBuf, process};
 
 use clap::{Parser, Subcommand};
 use scip_syntax::index::{index_command, AnalysisMode, IndexMode, IndexOptions};


### PR DESCRIPTION
Fixes https://linear.app/sourcegraph/issue/GRAPH-642/scip-syntax-index-fails-for-relative-workspace-path

## Test plan

Run `scip-syntax --language java --workspace .` and get an index with documents

Run `scip-syntax --language java` and get an error, rather than an empty index

## Changelog

Internal change. Implements QoL changes to the `scip-syntax` CLI