### PR TITLE
Remove echo test alert

### DIFF
--- a/doc/admin/observability/alerts.md
+++ b/doc/admin/observability/alerts.md
@@ -1484,7 +1484,6 @@ Generated query for critical alert: `max((sum by (instance, cmd) (src_gitserver_
 **Descriptions**
 
 - <span class="badge badge-warning">warning</span> gitserver: 0.02s+ echo test command duration for 30s
-- <span class="badge badge-critical">critical</span> gitserver: 1s+ echo test command duration for 1m0s
 
 **Next steps**
 
@@ -1496,8 +1495,7 @@ Generated query for critical alert: `max((sum by (instance, cmd) (src_gitserver_
 
 ```json
 "observability.silenceAlerts": [
-  "warning_gitserver_echo_command_duration_test",
-  "critical_gitserver_echo_command_duration_test"
+  "warning_gitserver_echo_command_duration_test"
 ]
 ```
 
@@ -1507,8 +1505,6 @@ Generated query for critical alert: `max((sum by (instance, cmd) (src_gitserver_
 <summary>Technical details</summary>
 
 Generated query for warning alert: `max((max(src_gitserver_echo_duration_seconds)) >= 0.02)`
-
-Generated query for critical alert: `max((max(src_gitserver_echo_duration_seconds)) >= 1)`
 
 </details>
 

--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -6435,7 +6435,7 @@ sum by (cmd) (rate(src_gitserver_exec_duration_seconds_count{instance=~`${shard:
 
 
 
-Refer to the [alerts reference](./alerts.md#gitserver-echo-command-duration-test) for 2 alerts related to this panel.
+Refer to the [alerts reference](./alerts.md#gitserver-echo-command-duration-test) for 1 alert related to this panel.
 
 To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=100040` on your Sourcegraph instance.
 

--- a/monitoring/definitions/git_server.go
+++ b/monitoring/definitions/git_server.go
@@ -266,28 +266,6 @@ func GitServer() *monitoring.Dashboard {
 					},
 					{
 						{
-							Name:        "echo_command_duration_test",
-							Description: "echo test command duration",
-							Query:       "max(src_gitserver_echo_duration_seconds)",
-							Warning:     monitoring.Alert().GreaterOrEqual(0.020).For(30 * time.Second),
-							Critical:    monitoring.Alert().GreaterOrEqual(1).For(1 * time.Minute),
-							Panel:       monitoring.Panel().LegendFormat("running commands").Unit(monitoring.Seconds),
-							Owner:       monitoring.ObservableOwnerSource,
-							Interpretation: `
-							A high value here likely indicates a problem, especially if consistently high.
-							You can query for individual commands using 'sum by (cmd)(src_gitserver_exec_running)' in Grafana ('/-/debug/grafana') to see if a specific Git Server command might be spiking in frequency.
-							On a healthy linux node, this number should be less than 5ms, ideally closer to 2ms.
-							A high process spawning overhead will affect latency of gitserver APIs.
-
-							Various factors can affect process spawning overhead, but the most common we've seen is IOPS contention on the underlying volume, or high CPU throttling.
-							`,
-							NextSteps: `
-								- **Single container deployments:** Upgrade to a [Docker Compose deployment](../deploy/docker-compose/migrate.md) which offers better scalability and resource isolation.
-								- **Kubernetes and Docker Compose:** Check that you are running a similar number of git server replicas and that their CPU/memory limits are allocated according to what is shown in the [Sourcegraph resource estimator](../deploy/resource_estimator.md).
-								- If your persistent volume is slow, you may want to provision more IOPS, usually by increasing the volume size.
-							`,
-						},
-						{
 							Name:        "repo_corrupted",
 							Description: "number of times a repo corruption has been identified",
 							Query:       `sum(rate(src_gitserver_repo_corrupted[5m]))`,

--- a/monitoring/definitions/git_server.go
+++ b/monitoring/definitions/git_server.go
@@ -266,6 +266,26 @@ func GitServer() *monitoring.Dashboard {
 					},
 					{
 						{
+							Name:        "echo_command_duration_test",
+							Description: "echo test command duration",
+							Query:       "max(src_gitserver_echo_duration_seconds)",
+							Warning:     monitoring.Alert().GreaterOrEqual(0.020).For(30 * time.Second),
+							Panel:       monitoring.Panel().LegendFormat("running commands").Unit(monitoring.Seconds),
+							Owner:       monitoring.ObservableOwnerSource,
+							Interpretation: `
+							A high value here likely indicates a problem, especially if consistently high.
+							You can query for individual commands using 'sum by (cmd)(src_gitserver_exec_running)' in Grafana ('/-/debug/grafana') to see if a specific Git Server command might be spiking in frequency.
+							On a healthy linux node, this number should be less than 5ms, ideally closer to 2ms.
+							A high process spawning overhead will affect latency of gitserver APIs.
+							Various factors can affect process spawning overhead, but the most common we've seen is IOPS contention on the underlying volume, or high CPU throttling.
+							`,
+							NextSteps: `
+								- **Single container deployments:** Upgrade to a [Docker Compose deployment](../deploy/docker-compose/migrate.md) which offers better scalability and resource isolation.
+								- **Kubernetes and Docker Compose:** Check that you are running a similar number of git server replicas and that their CPU/memory limits are allocated according to what is shown in the [Sourcegraph resource estimator](../deploy/resource_estimator.md).
+								- If your persistent volume is slow, you may want to provision more IOPS, usually by increasing the volume size.
+							`,
+						},
+						{
 							Name:        "repo_corrupted",
 							Description: "number of times a repo corruption has been identified",
 							Query:       `sum(rate(src_gitserver_repo_corrupted[5m]))`,

--- a/monitoring/definitions/git_server.go
+++ b/monitoring/definitions/git_server.go
@@ -277,6 +277,7 @@ func GitServer() *monitoring.Dashboard {
 							You can query for individual commands using 'sum by (cmd)(src_gitserver_exec_running)' in Grafana ('/-/debug/grafana') to see if a specific Git Server command might be spiking in frequency.
 							On a healthy linux node, this number should be less than 5ms, ideally closer to 2ms.
 							A high process spawning overhead will affect latency of gitserver APIs.
+
 							Various factors can affect process spawning overhead, but the most common we've seen is IOPS contention on the underlying volume, or high CPU throttling.
 							`,
 							NextSteps: `


### PR DESCRIPTION
This removes the critical alert from the 1s echo test, since it has a tendency to wake someone up in the middle of the night and turns our alerts into noise.

The warning still remains.

<!-- 💡 To write a useful PR description, make sure that your description covers:
- WHAT this PR is changing:
    - How was it PREVIOUSLY.
    - How it will be from NOW on.
- WHY this PR is needed.
- CONTEXT, i.e. to which initiative, project or RFC it belongs.

The structure of the description doesn't matter as much as covering these points, so use
your best judgement based on your context.
Learn how to write good pull request description: https://www.notion.so/sourcegraph/Write-a-good-pull-request-description-610a7fd3e613496eb76f450db5a49b6e?pvs=4 -->


## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles -->

Alert removed and docs updated.


## Changelog

<!--
1. Ensure your pull request title is formatted as: $type($domain): $what
2. Add bullet list items for each additional detail you want to cover (see example below)
3. You can edit this after the pull request was merged, as long as release shipping it hasn't been promoted to the public.
4. For more information, please see this how-to https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c?

Audience: TS/CSE > Customers > Teammates (in that order).

Cheat sheet: $type = chore|fix|feat $domain: source|search|ci|release|plg|cody|local|...
-->

<!--
Example:

Title: fix(search): parse quotes with the appropriate context
Changelog section:

## Changelog

- When a quote is used with regexp pattern type, then ...
- Refactored underlying code.
-->
