### PR TITLE
build(bazel): bump to rules_esbuild 0.16.0

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -284,6 +284,7 @@ load("@aspect_rules_esbuild//esbuild:repositories.bzl", "esbuild_register_toolch
 
 esbuild_register_toolchains(
     name = "esbuild",
+    # Note, this differs from the version noted in package.json, however we've been inadvertently building with this version for some time now so we'll stick with it and revisit.
     esbuild_version = "0.19.2",
 )
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -270,9 +270,9 @@ swc_register_toolchains(
 # rules_esbuild setup ===========================
 http_archive(
     name = "aspect_rules_esbuild",
-    sha256 = "84419868e43c714c0d909dca73039e2f25427fc04f352d2f4f7343ca33f60deb",
-    strip_prefix = "rules_esbuild-0.15.3",
-    url = "https://github.com/aspect-build/rules_esbuild/releases/download/v0.15.3/rules_esbuild-v0.15.3.tar.gz",
+    sha256 = "46aab76044f040c1c0bd97672d56324619af4913cb9e96606ec37ddd4605831d",
+    strip_prefix = "rules_esbuild-0.16.0",
+    url = "https://github.com/aspect-build/rules_esbuild/releases/download/v0.16.0/rules_esbuild-v0.16.0.tar.gz",
 )
 
 load("@aspect_rules_esbuild//esbuild:dependencies.bzl", "rules_esbuild_dependencies")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -280,11 +280,11 @@ load("@aspect_rules_esbuild//esbuild:dependencies.bzl", "rules_esbuild_dependenc
 rules_esbuild_dependencies()
 
 # Register a toolchain containing esbuild npm package and native bindings
-load("@aspect_rules_esbuild//esbuild:repositories.bzl", "LATEST_ESBUILD_VERSION", "esbuild_register_toolchains")
+load("@aspect_rules_esbuild//esbuild:repositories.bzl", "esbuild_register_toolchains")
 
 esbuild_register_toolchains(
     name = "esbuild",
-    esbuild_version = LATEST_ESBUILD_VERSION,
+    esbuild_version = "0.19.2",
 )
 
 # Go toolchain setup

--- a/client/browser/BUILD.bazel
+++ b/client/browser/BUILD.bazel
@@ -1,12 +1,12 @@
 load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 load("@aspect_bazel_lib//lib:copy_to_directory.bzl", "copy_to_directory")
-load("@aspect_rules_esbuild//esbuild:defs.bzl", "esbuild")
 load("@aspect_rules_ts//ts:defs.bzl", "ts_config")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("//client/shared/dev:build_code_intel_extensions.bzl", "build_code_intel_extensions")
 load("//client/shared/dev:generate_graphql_operations.bzl", "generate_graphql_operations")
 load("//client/shared/dev:tools.bzl", "module_style_typings")
 load("//dev:defs.bzl", "sass", "ts_project", "vitest_test")
+load("//dev:esbuild.bzl", "esbuild")
 load("//dev:eslint.bzl", "eslint_config_and_lint_root")
 
 # gazelle:js_custom_files stories src/**/*.story.tsx

--- a/client/browser/config/BUILD.bazel
+++ b/client/browser/config/BUILD.bazel
@@ -1,6 +1,6 @@
-load("//dev:defs.bzl", "ts_project")
-load("@aspect_rules_esbuild//esbuild:defs.bzl", "esbuild")
 load("@aspect_rules_js//js:defs.bzl", "js_library")
+load("//dev:defs.bzl", "ts_project")
+load("//dev:esbuild.bzl", "esbuild")
 
 # config/ does not contain a src/
 # gazelle:js_files **/*.{ts,tsx}

--- a/client/web/BUILD.bazel
+++ b/client/web/BUILD.bazel
@@ -1,4 +1,3 @@
-load("@aspect_rules_esbuild//esbuild:defs.bzl", "esbuild")
 load("@aspect_rules_js//js:defs.bzl", "js_library")
 load("@aspect_rules_ts//ts:defs.bzl", "ts_config")
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
@@ -7,7 +6,7 @@ load("@npm//:defs.bzl", "npm_link_all_packages")
 load("//client/shared/dev:generate_graphql_operations.bzl", "generate_graphql_operations")
 load("//client/shared/dev:tools.bzl", "module_style_typings")
 load("//dev:defs.bzl", "npm_package", "sass", "ts_project", "vitest_test")
-load("//dev:esbuild.bzl", "esbuild_web_app")
+load("//dev:esbuild.bzl", "esbuild", "esbuild_web_app")
 load("//dev:eslint.bzl", "eslint_config_and_lint_root")
 load("//dev:write_generated_to_source_files.bzl", "write_generated_to_source_files")
 

--- a/client/web/dev/BUILD.bazel
+++ b/client/web/dev/BUILD.bazel
@@ -1,7 +1,7 @@
-load("@aspect_rules_esbuild//esbuild:defs.bzl", "esbuild")
 load("@aspect_rules_js//js:defs.bzl", "js_library")
 load("@aspect_rules_ts//ts:defs.bzl", "ts_config")
 load("//dev:defs.bzl", "ts_project", "vitest_test")
+load("//dev:esbuild.bzl", "esbuild")
 
 # dev/ does not contain a src/
 # gazelle:js_files **/*.{ts,tsx}

--- a/dev/esbuild.bzl
+++ b/dev/esbuild.bzl
@@ -1,10 +1,16 @@
 load("@aspect_bazel_lib//lib:copy_to_directory.bzl", "copy_to_directory")
-load("@aspect_rules_esbuild//esbuild:defs.bzl", "esbuild")
+load("@aspect_rules_esbuild//esbuild:defs.bzl", _esbuild = "esbuild")
+
+def esbuild(name, **kwargs):
+    _esbuild(
+        name,
+        **kwargs
+    )
 
 def esbuild_web_app(name, **kwargs):
     bundle_name = "%s_bundle" % name
 
-    esbuild(
+    _esbuild(
         name = bundle_name,
         **kwargs
     )

--- a/dev/mocha.bzl
+++ b/dev/mocha.bzl
@@ -1,6 +1,6 @@
-load("@npm//:mocha/package_json.bzl", mocha_bin = "bin")
 load("@aspect_rules_esbuild//esbuild:defs.bzl", "esbuild")
 load("@aspect_rules_js//js:defs.bzl", "js_test")
+load("@npm//:mocha/package_json.bzl", mocha_bin = "bin")
 
 NON_BUNDLED = [
     # Dependencies loaded by mocha itself before the tests.


### PR DESCRIPTION
1.6.0 is the minimum rules_esbuild version that support bazel-lib 2.x. After this lands, I'll put up a PR to get onto bazel-lib 2.x and after that lands that unblocks upgrading to rules_oci 2 which resolves at least some caching issues with large image artifacts.

Also pins the esbuild toolchain to esbuild 0.19.2 which should be a no-op since LATEST_ESBUILD_VERSION for rules_esbuild 0.15.3 (the version currently on main) is 0.19.2.

Both @Strum355 and I tried bumping to rules_esbuild 0.17.0+ and hit build issues (with and without the sandbox plugin enabled that was added in that version) so there is work to do there to track down what changed in the ruleset that breaks this build.

## Test plan

CI

## Changelog

<!--
1. Ensure your pull request title is formatted as: $type($domain): $what
2. Add bullet list items for each additional detail you want to cover (see example below)
3. You can edit this after the pull request was merged, as long as release shipping it hasn't been promoted to the public.
4. For more information, please see this how-to https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c?

Audience: TS/CSE > Customers > Teammates (in that order).

Cheat sheet: $type = chore|fix|feat $domain: source|search|ci|release|plg|cody|local|...
-->

<!--
Example:

Title: fix(search): parse quotes with the appropriate context
Changelog section:

## Changelog

- When a quote is used with regexp pattern type, then ...
- Refactored underlying code.
-->
