### PR TITLE
feat/msp: add link to ops page in Slack channel description

### DIFF
--- a/dev/managedservicesplatform/stacks/monitoring/monitoring.go
+++ b/dev/managedservicesplatform/stacks/monitoring/monitoring.go
@@ -265,14 +265,16 @@ func NewStack(stacks *stack.Set, vars Variables) (*CrossStackOutput, error) {
 
 		var slackChannel slackconversation.Conversation
 		if channel.ProvisionChannel {
-			description := pointers.Stringf(
-				"Alerts from %s (%s) deployed on Managed Services Platform",
+			description := fmt.Sprintf("Alerts from %s (%s) deployed on Managed Services Platform.",
 				vars.Service.GetName(), vars.EnvironmentID)
+			if vars.Service.NotionPageID != nil {
+				description += fmt.Sprintf(" Operational handbook: %s", vars.Service.GetHandbookPageURL())
+			}
 			// https://registry.terraform.io/providers/pablovarela/slack/latest/docs/resources/conversation#argument-reference
 			slackChannel = slackconversation.NewConversation(stack, id.TerraformID("channel"), &slackconversation.ConversationConfig{
 				Name:             pointers.Ptr(strings.TrimPrefix(channel.Name, "#")),
-				Topic:            description,
-				Purpose:          description,
+				Topic:            &description,
+				Purpose:          &description,
 				IsPrivate:        pointers.Ptr(false),
 				PermanentMembers: pointers.Ptr(pointers.Slice([]string{mspRolloutsBotSlackUserID})),
 				// Do not kick out other users in the channel


### PR DESCRIPTION
Minor QOL improvement, when you're in the Slack channel the chances are good that you might want the ops docs at some point.

## Test plan

n/a

## Changelog

- MSP-provisioned alerts Slack channels now include a link to the service's generated operational docs for a service (go/msp-ops) in the channel description.
