### PR TITLE
Embeddings: hide site admin references

### DIFF
--- a/client/web/src/cody/isCodyEnabled.tsx
+++ b/client/web/src/cody/isCodyEnabled.tsx
@@ -10,3 +10,5 @@ export const isCodyEnabled = (): boolean => {
 }
 
 export const isSignInRequiredForCody = (): boolean => !window.context.isAuthenticatedUser
+
+export const isEmbeddingsEnabled = (): boolean => window.context?.codyEnabled && window.context?.embeddingsEnabled

--- a/client/web/src/repo/tree/TreePage.tsx
+++ b/client/web/src/repo/tree/TreePage.tsx
@@ -47,7 +47,7 @@ import type { AuthenticatedUser } from '../../auth'
 import type { BatchChangesProps } from '../../batches'
 import { RepoBatchChangesButton } from '../../batches/RepoBatchChangesButton'
 import type { CodeIntelligenceProps } from '../../codeintel'
-import { isCodyEnabled } from '../../cody/isCodyEnabled'
+import { isCodyEnabled, isEmbeddingsEnabled } from '../../cody/isCodyEnabled'
 import type { BreadcrumbSetters } from '../../components/Breadcrumbs'
 import { PageTitle } from '../../components/PageTitle'
 import type { FileCommitsResult, FileCommitsVariables, RepositoryFields } from '../../graphql-operations'
@@ -302,7 +302,7 @@ export const TreePage: FC<Props> = ({
                             </Button>
                         </Tooltip>
                     )}
-                    {window.context?.codyEnabled && window.context?.embeddingsEnabled && (
+                    {isEmbeddingsEnabled() && (
                         <Tooltip content="Embeddings">
                             <Button
                                 className="flex-shrink-0"

--- a/client/web/src/site-admin/RepositoryNode.tsx
+++ b/client/web/src/site-admin/RepositoryNode.tsx
@@ -40,6 +40,7 @@ import {
     Position,
 } from '@sourcegraph/wildcard'
 
+import { isEmbeddingsEnabled } from '../cody/isCodyEnabled'
 import type {
     RecloneRepositoryResult,
     RecloneRepositoryVariables,
@@ -227,15 +228,17 @@ export const RepositoryNode: React.FunctionComponent<React.PropsWithChildren<Rep
                                     <Icon aria-hidden={true} svgPath={mdiSearchWeb} className="mr-1" />
                                     Search indexing
                                 </MenuItem>
-                                <MenuItem
-                                    as={Button}
-                                    disabled={!repoClonedAndHealthy(node)}
-                                    onSelect={() => navigate(`/${node.name}/-/embeddings/configuration`)}
-                                    className="p-2"
-                                >
-                                    <Icon aria-hidden={true} svgPath={mdiVectorPolyline} className="mr-1" />
-                                    Embeddings
-                                </MenuItem>
+                                {isEmbeddingsEnabled() && (
+                                    <MenuItem
+                                        as={Button}
+                                        disabled={!repoClonedAndHealthy(node)}
+                                        onSelect={() => navigate(`/${node.name}/-/embeddings/configuration`)}
+                                        className="p-2"
+                                    >
+                                        <Icon aria-hidden={true} svgPath={mdiVectorPolyline} className="mr-1" />
+                                        Embeddings
+                                    </MenuItem>
+                                )}
                                 <MenuItem
                                     as={Button}
                                     disabled={!repoClonedAndHealthy(node)}

--- a/client/web/src/site-admin/SiteAdminRepositoriesContainer.tsx
+++ b/client/web/src/site-admin/SiteAdminRepositoriesContainer.tsx
@@ -6,6 +6,7 @@ import { useLocation, useNavigate } from 'react-router-dom'
 import { useQuery } from '@sourcegraph/http-client'
 import { Container, ErrorAlert, Input, LoadingSpinner, PageSwitcher, useDebounce } from '@sourcegraph/wildcard'
 
+import { isEmbeddingsEnabled } from '../cody/isCodyEnabled'
 import { EXTERNAL_SERVICE_IDS_AND_NAMES } from '../components/externalServices/backend'
 import {
     buildFilterArgs,
@@ -362,7 +363,10 @@ export const SiteAdminRepositoriesContainer: React.FunctionComponent<{ alwaysPol
                         return newValues
                     }),
             },
-            {
+        ]
+
+        if (isEmbeddingsEnabled()) {
+            items.push({
                 value: data.repositoryStats.embedded,
                 description: 'Embedded',
                 color: 'var(--body-color)',
@@ -374,8 +378,9 @@ export const SiteAdminRepositoriesContainer: React.FunctionComponent<{ alwaysPol
                         newValues.set('status', STATUS_FILTERS.Embedded)
                         return newValues
                     }),
-            },
-        ]
+            })
+        }
+
         if (data.repositoryStats.corrupted > 0) {
             items.push({
                 value: data.repositoryStats.corrupted,

--- a/client/web/src/site-admin/routes.tsx
+++ b/client/web/src/site-admin/routes.tsx
@@ -3,6 +3,7 @@ import { Navigate, useLocation } from 'react-router-dom'
 import { lazyComponent } from '@sourcegraph/shared/src/util/lazyComponent'
 import { FeedbackBadge } from '@sourcegraph/wildcard'
 
+import { isEmbeddingsEnabled } from '../cody/isCodyEnabled'
 import type { BatchSpecsPageProps } from '../enterprise/batches/BatchSpecsPage'
 import { CodeIntelConfigurationPolicyPage } from '../enterprise/codeintel/configuration/pages/CodeIntelConfigurationPolicyPage'
 import { SHOW_BUSINESS_FEATURES } from '../enterprise/dotcom/productSubscriptions/features'
@@ -192,8 +193,6 @@ const CodyConfigurationPage = lazyComponent(
     () => import('../enterprise/cody/configuration/pages/CodyConfigurationPage'),
     'CodyConfigurationPage'
 )
-
-const codyIsEnabled = (): boolean => Boolean(window.context?.codyEnabled && window.context?.embeddingsEnabled)
 
 export const otherSiteAdminRoutes: readonly SiteAdminAreaRoute[] = [
     {
@@ -494,24 +493,24 @@ export const otherSiteAdminRoutes: readonly SiteAdminAreaRoute[] = [
         exact: true,
         path: '/cody',
         render: () => <Navigate to="/site-admin/embeddings" />,
-        condition: codyIsEnabled,
+        condition: isEmbeddingsEnabled,
     },
     {
         exact: true,
         path: '/embeddings',
         render: props => <SiteAdminCodyPage {...props} telemetryRecorder={props.platformContext.telemetryRecorder} />,
-        condition: codyIsEnabled,
+        condition: isEmbeddingsEnabled,
     },
     {
         exact: true,
         path: '/embeddings/configuration',
         render: props => <CodyConfigurationPage {...props} />,
-        condition: codyIsEnabled,
+        condition: isEmbeddingsEnabled,
     },
     {
         path: '/embeddings/configuration/:id',
         render: props => <CodeIntelConfigurationPolicyPage {...props} domain="embeddings" />,
-        condition: codyIsEnabled,
+        condition: isEmbeddingsEnabled,
     },
 
     // rbac-related routes


### PR DESCRIPTION
This PR fixes a bug in the site admin UI where we showed references to
embeddings even when they were disabled in site config.

In follow-up work, we plan to remove the embeddings logic completely.

Closes https://github.com/sourcegraph/cody-issues/issues/50

## Test plan

Manually tested!

