### PR TITLE
msp/runtime: add Job runtime

### DIFF
--- a/lib/managedservicesplatform/runtime/BUILD.bazel
+++ b/lib/managedservicesplatform/runtime/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "config.go",
         "contract.go",
+        "job.go",
         "sanitycheck.go",
         "service.go",
     ],

--- a/lib/managedservicesplatform/runtime/contract/diagnostics_test.go
+++ b/lib/managedservicesplatform/runtime/contract/diagnostics_test.go
@@ -9,9 +9,10 @@ import (
 
 	"github.com/hexops/autogold/v2"
 	"github.com/sourcegraph/log/logtest"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 	"github.com/sourcegraph/sourcegraph/lib/pointers"
-	"github.com/stretchr/testify/assert"
 
 	oteltracesdk "go.opentelemetry.io/otel/sdk/trace"
 )
@@ -49,13 +50,14 @@ func TestJobExecutionCheckIn(t *testing.T) {
 				Start(context.Background(), "test")
 			t.Cleanup(func() { span.End() })
 
-			done, err := c.JobExecutionCheckIn(ctx)
+			_, done, err := c.JobExecutionCheckIn(ctx)
 			assert.NoError(t, err)
 
 			time.Sleep(100 * time.Millisecond) // emulate some work
 
 			if failed {
-				done(errors.New("failed"))
+				err := errors.New("failed")
+				done(&err)
 			} else {
 				done(nil)
 			}

--- a/lib/managedservicesplatform/runtime/contract/diagnostics_test.go
+++ b/lib/managedservicesplatform/runtime/contract/diagnostics_test.go
@@ -57,7 +57,7 @@ func TestJobExecutionCheckIn(t *testing.T) {
 
 			if failed {
 				err := errors.New("failed")
-				done(&err)
+				done(err)
 			} else {
 				done(nil)
 			}

--- a/lib/managedservicesplatform/runtime/contract/diagnostics_test.go
+++ b/lib/managedservicesplatform/runtime/contract/diagnostics_test.go
@@ -56,8 +56,7 @@ func TestJobExecutionCheckIn(t *testing.T) {
 			time.Sleep(100 * time.Millisecond) // emulate some work
 
 			if failed {
-				err := errors.New("failed")
-				done(err)
+				done(errors.New("failed"))
 			} else {
 				done(nil)
 			}

--- a/lib/managedservicesplatform/runtime/job.go
+++ b/lib/managedservicesplatform/runtime/job.go
@@ -1,0 +1,130 @@
+package runtime
+
+import (
+	"context"
+	"flag"
+	"os"
+
+	"cloud.google.com/go/profiler"
+	"github.com/sourcegraph/log"
+
+	"github.com/sourcegraph/sourcegraph/lib/managedservicesplatform/runtime/contract"
+	"github.com/sourcegraph/sourcegraph/lib/managedservicesplatform/runtime/internal/opentelemetry"
+)
+
+type Job[ConfigT any] interface {
+	contract.ServiceMetadataProvider
+	// Execute should use given configuration to perform the desired
+	// job execution.
+	Execute(
+		ctx context.Context,
+		logger log.Logger,
+		contract Contract,
+		config ConfigT,
+	) error
+}
+
+// ExecuteJob handles the entire lifecycle of the program performing a
+// job execution, and should be the only thing called in a MSP job
+// program's main package, for example:
+//
+//	runtime.ExecuteJob[example.Config](example.Job{})
+//
+// Where example.Config is your runtime.ConfigLoader implementation, and
+// example.Job is your runtime.Job implementation.
+func ExecuteJob[
+	ConfigT any,
+	LoaderT ConfigLoader[ConfigT],
+](job Job[ConfigT]) {
+	// To get around os.Exit not honoring defer we
+	// wrap the body in another function which we can safely defer inside
+	err := func() (err error) {
+		flag.Parse()
+		passSanityCheck(job)
+
+		// Resource representing the job
+		res := log.Resource{
+			Name:       job.Name(),
+			Version:    job.Version(),
+			Namespace:  "",
+			InstanceID: "",
+		}
+
+		liblog := log.Init(res, log.NewSentrySink())
+		defer liblog.Sync()
+
+		ctx := context.Background()
+
+		// startLogger should only be used within Start - jobs should
+		// create a separate top-level startLogger for their usage.
+		startLogger := log.Scoped("msp.start")
+
+		env, err := contract.ParseEnv(os.Environ())
+		if err != nil {
+			startLogger.Fatal("failed to load environment", log.Error(err))
+		}
+
+		// Initialize LoaderT implementation as non-zero *ConfigT
+		var config LoaderT = new(ConfigT)
+
+		// Load configuration variables from environment
+		config.Load(env)
+		ctr := contract.New(log.Scoped("msp.contract"), job, env)
+
+		// Fast-exit with configuration facts if requested
+		if *showHelp {
+			renderHelp(job, env)
+			return nil
+		}
+
+		// Enable Sentry error log reporting
+		sentryEnabled := ctr.Diagnostics.ConfigureSentry(liblog)
+
+		// Check for environment errors
+		if err := env.Validate(); err != nil {
+			startLogger.Fatal("environment configuration error encountered", log.Error(err))
+		}
+
+		// Initialize things dependent on configuration being loaded
+		otelCleanup, err := opentelemetry.Init(ctx, log.Scoped("msp.otel"), ctr.Diagnostics.OpenTelemetry, res)
+		if err != nil {
+			startLogger.Fatal("failed to initialize OpenTelemetry", log.Error(err))
+		}
+		defer otelCleanup()
+
+		if ctr.MSP {
+			if err := profiler.Start(profiler.Config{
+				Service:        job.Name(),
+				ServiceVersion: job.Version(),
+				// Options used in sourcegraph/sourcegraph
+				MutexProfiling: true,
+				AllocForceGC:   true,
+			}); err != nil {
+				// For now, keep this optional and don't prevent startup
+				startLogger.Error("failed to initialize profiler", log.Error(err))
+			} else {
+				startLogger.Debug("Cloud Profiler enabled")
+			}
+		}
+
+		executionID, done, err := ctr.Diagnostics.JobExecutionCheckIn(ctx)
+		if err != nil {
+			startLogger.Warn("failed to register job execution check-in", log.Error(err))
+		}
+		defer done(&err)
+
+		startLogger.Info("starting job execution",
+			log.String("job", job.Name()),
+			log.String("executionID", executionID),
+			log.Bool("msp", ctr.MSP),
+			log.Bool("sentry", sentryEnabled))
+
+		err = job.Execute(ctx, log.Scoped("job"), ctr, *config)
+		return
+	}()
+
+	if err != nil {
+		os.Exit(1)
+	}
+	os.Exit(0)
+}

--- a/lib/managedservicesplatform/runtime/job.go
+++ b/lib/managedservicesplatform/runtime/job.go
@@ -117,6 +117,8 @@ func ExecuteJob[
 	err = job.Execute(ctx, log.Scoped("job"), ctr, *config)
 	done(err)
 
+	// Logging the error is handled by `done(err)` above, so here we just exit
+	// with an appropriate exit code.
 	if err != nil {
 		os.Exit(1)
 	}

--- a/lib/managedservicesplatform/runtime/job.go
+++ b/lib/managedservicesplatform/runtime/job.go
@@ -119,8 +119,7 @@ func ExecuteJob[
 			log.Bool("msp", ctr.MSP),
 			log.Bool("sentry", sentryEnabled))
 
-		err = job.Execute(ctx, log.Scoped("job"), ctr, *config)
-		return
+		return job.Execute(ctx, log.Scoped("job"), ctr, *config)
 	}()
 
 	if err != nil {


### PR DESCRIPTION
Currently we have a Service runtime entrypoint which parses env, creates a logger, initialises telemetry, creates the MSP contract, etc. according to MSP conventions.
However we don't have the equivalent for Jobs which requires operators to set up everything manually. 
This PR remedies the situation by adding a Job entrypoint which performs similar setup to the Service entrypoint.

Closes CORE-117
## Test plan
Successfully executed a mock job in GCP using this as an entrypoint
