### PR TITLE
fix/msp: make deadlineSeconds job-level configuration, apply in timeout

### DIFF
--- a/dev/managedservicesplatform/spec/environment.go
+++ b/dev/managedservicesplatform/spec/environment.go
@@ -578,6 +578,8 @@ func (s *EnvironmentServiceHealthProbesSpec) GetTimeoutSeconds() int {
 }
 
 type EnvironmentJobSpec struct {
+	// DeadlineSeconds of each job execution, in seconds. Defaults to 300.
+	DeadlineSeconds *int `yaml:"deadlineSeconds,omitempty"`
 	// Schedule configures a cron schedule for the service.
 	//
 	// Only supported for services of 'kind: job'.
@@ -602,8 +604,6 @@ type EnvironmentJobScheduleSpec struct {
 	//
 	// Protip: use https://crontab.guru
 	Cron string `yaml:"cron"`
-	// Deadline of each attempt, in seconds.
-	Deadline *int `yaml:"deadline,omitempty"`
 }
 
 func (s *EnvironmentJobScheduleSpec) Validate() []error {


### PR DESCRIPTION
In a rushed POC of MSP jobs, I did some pretty bad copy-pasting (evidenced by all the service-specific docstrings I have removed in this PR) and made a bad configuration decision here, resulting in a few issues:

1. `schedule.deadline` is not actually applied to Cloud Run jobs, causing jobs to time out earlier than desired
2. `schedule.deadline` is not the right place to configure a deadline, because _all_ jobs need a configurable deadline, not just those with schedules. This change moves `schedule.deadline` to `deadlineSeconds`.

Closes CORE-145

## Test plan

```
$ sg msp generate gatekeeper prod
$ git diff
```

```diff                    
diff --git a/services/gatekeeper/service.yaml b/services/gatekeeper/service.yaml
index fd6a3812..ce4b02e3 100644
--- a/services/gatekeeper/service.yaml
+++ b/services/gatekeeper/service.yaml
@@ -48,4 +48,4 @@ environments:
           - "primary"
     schedule:
       cron: 0 * * * *
-      deadline: 1800 # 30 minutes
+    deadlineSeconds: 1800 # 30 minutes
diff --git a/services/gatekeeper/terraform/prod/stacks/cloudrun/cdk.tf.json b/services/gatekeeper/terraform/prod/stacks/cloudrun/cdk.tf.json
index 3c2c295e..f83b32b9 100644
--- a/services/gatekeeper/terraform/prod/stacks/cloudrun/cdk.tf.json
+++ b/services/gatekeeper/terraform/prod/stacks/cloudrun/cdk.tf.json
@@ -281,7 +281,7 @@
                   },
                   {
                     "name": "JOB_EXECUTION_DEADLINE",
-                    "value": "600s"
+                    "value": "1800s"
                   }
                 ],
                 "image": "us.gcr.io/sourcegraph-dev/abuse-ban-bot:${var.resolved_image_tag}",
@@ -302,7 +302,7 @@
               }
             ],
             "service_account": "${data.terraform_remote_state.cross-stack-reference-input-iam.outputs.cross-stack-output-google_service_accountiam-workload-accountemail}",
-            "timeout": "300s",
+            "timeout": "1800s",
             "volumes": [
             ],
             "vpc_access": {
@@ -341,7 +341,7 @@
             "uniqueId": "job_scheduler"
           }
         },
-        "attempt_deadline": "600s",
+        "attempt_deadline": "1800s",
         "depends_on": [
           "google_cloud_run_v2_job_iam_member.cloudrun_scheduler_job_invoker"
         ],
```

## Changelog

- MSP jobs: `schedule.deadline` is deprecated, use the top-level `deadlineSeconds` instead. Configured deadlines are now correctly applied as the Cloud Run job execution timeout as well.