### PR TITLE
chore/productsubscription: add metric tracking usage

### DIFF
--- a/cmd/frontend/internal/dotcom/productsubscription/BUILD.bazel
+++ b/cmd/frontend/internal/dotcom/productsubscription/BUILD.bazel
@@ -66,6 +66,8 @@ go_library(
         "@com_github_graph_gophers_graphql_go//relay",
         "@com_github_keegancsmith_sqlf//:sqlf",
         "@com_github_lib_pq//:pq",
+        "@com_github_prometheus_client_golang//prometheus",
+        "@com_github_prometheus_client_golang//prometheus/promauto",
         "@com_github_sourcegraph_log//:log",
         "@com_google_cloud_go_bigquery//:bigquery",
         "@org_golang_google_api//iterator",

--- a/cmd/frontend/internal/dotcom/productsubscription/subscriptions_graphql.go
+++ b/cmd/frontend/internal/dotcom/productsubscription/subscriptions_graphql.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/graph-gophers/graphql-go"
 	"github.com/graph-gophers/graphql-go/relay"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 
 	"github.com/sourcegraph/log"
 
@@ -21,6 +23,12 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/license"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
+
+var productSubscriptionAccess = promauto.NewCounterVec(prometheus.CounterOpts{
+	Namespace: "src",
+	Subsystem: "productsubscription",
+	Name:      "graphql_access",
+}, []string{"action"})
 
 const auditEntityProductSubscriptions = "dotcom-productsubscriptions"
 
@@ -81,6 +89,9 @@ func productSubscriptionByDBID(ctx context.Context, logger log.Logger, db databa
 			log.String("accessed_product_subscription_id", id),
 		},
 	})
+	// Track usage
+	productSubscriptionAccess.With(prometheus.Labels{"action": action}).Inc()
+
 	return &productSubscription{logger: logger, v: v, db: db}, nil
 }
 


### PR DESCRIPTION
Adds a simple metric tracking usage of `productSubscriptionByDBID`. All GraphQL resolvers in this package use this at some point (including the Cody Gateway access and licenses resolvers, which is surprising), so this is a good place to record it.

The goal is to use this to pare down traffic to this endpoint, and eventually remove it, as part of https://www.notion.so/sourcegraph/Establish-Enterprise-Portal-as-the-enterprise-integration-platform-261f0be5a4a040088eceb59c5ac4a8b3?pvs=4

## Test plan

n/a