### PR TITLE
chore: Enable traces for uploads

### DIFF
--- a/internal/uploadhandler/BUILD.bazel
+++ b/internal/uploadhandler/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
     deps = [
         "//internal/metrics",
         "//internal/observation",
+        "//internal/trace/policy",
         "//internal/uploadstore",
         "//lib/errors",
         "@com_github_aws_aws_sdk_go_v2_feature_s3_manager//:manager",

--- a/internal/uploadhandler/upload_handler_state.go
+++ b/internal/uploadhandler/upload_handler_state.go
@@ -2,8 +2,11 @@ package uploadhandler
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"strconv"
+
+	"go.opentelemetry.io/otel/attribute"
 
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
@@ -14,11 +17,26 @@ type uploadState[T any] struct {
 	numParts         int
 	uploadedParts    []int
 	multipart        bool
-	suppliedIndex    bool
+	// suppliedIndex is true if the part index was supplied in the query parameters.
+	suppliedIndex bool
+	// index is 0-based part number for multi-part uploads
 	index            int
 	done             bool
 	uncompressedSize *int64
 	metadata         T
+}
+
+func (uploadState *uploadState[T]) Attrs() []attribute.KeyValue {
+	return []attribute.KeyValue{
+		attribute.Int("uploadID", uploadState.uploadID),
+		attribute.Int("numParts", uploadState.numParts),
+		attribute.Int("numUploadedParts", len(uploadState.uploadedParts)),
+		attribute.Bool("multipart", uploadState.multipart),
+		attribute.Bool("suppliedIndex", uploadState.suppliedIndex),
+		attribute.Int("index", uploadState.index),
+		attribute.Bool("done", uploadState.done),
+		attribute.String("metadata", fmt.Sprintf("%#v", uploadState.metadata)),
+	}
 }
 
 // constructUploadState reads the query args of the given HTTP request and populates an upload state object.


### PR DESCRIPTION
Fixes [GRAPH-615](https://linear.app/sourcegraph/issue/GRAPH-615/enable-traces-for-upload-operations-by-default)

We've been getting more i/o timeout errors and similar lately.
Let's enable traces so that we have more information to go on
when investigating these kinds of errors. It might take some
rounds of iteration with adding more events etc to figure out
what exactly is going wrong.

## Test plan

Locally changed the backend to `jaeger` and performed an upload.
The trace showed up while the "sampling" was set to "selective" (not "all").

## Changelog

- Tracing is enabled for all SCIP index uploads by default