### PR TITLE
chore: Use new cmp package to simplify comparisons

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -2,6 +2,7 @@
 package api
 
 import (
+	"cmp"
 	"fmt"
 	"strings"
 	"time"
@@ -98,12 +99,12 @@ func (r ExternalRepoSpec) Equal(s *ExternalRepoSpec) bool {
 // Compare returns -1 if r < s, 0 if r == s or 1 if r > s
 func (r ExternalRepoSpec) Compare(s ExternalRepoSpec) int {
 	if r.ServiceType != s.ServiceType {
-		return cmp(r.ServiceType, s.ServiceType)
+		return cmp.Compare(r.ServiceType, s.ServiceType)
 	}
 	if r.ServiceID != s.ServiceID {
-		return cmp(r.ServiceID, s.ServiceID)
+		return cmp.Compare(r.ServiceID, s.ServiceID)
 	}
-	return cmp(r.ID, s.ID)
+	return cmp.Compare(r.ID, s.ID)
 }
 
 func (r ExternalRepoSpec) String() string {
@@ -140,17 +141,6 @@ type Settings struct {
 	AuthorUserID *int32          // the ID of the user who authored this settings value
 	Contents     string          // the raw JSON (with comments and trailing commas allowed)
 	CreatedAt    time.Time       // the date when this settings value was created
-}
-
-func cmp(a, b string) int {
-	switch {
-	case a < b:
-		return -1
-	case b < a:
-		return 1
-	default:
-		return 0
-	}
 }
 
 type SavedQueryIDSpec struct {

--- a/lib/codeintel/precise/util.go
+++ b/lib/codeintel/precise/util.go
@@ -1,6 +1,7 @@
 package precise
 
 import (
+	"cmp"
 	"sort"
 )
 
@@ -26,39 +27,19 @@ func FindRanges(ranges map[ID]RangeData, line, character int) []RangeData {
 // Returns -1 if the range A starts before range B, or starts at the same place but ends earlier.
 // Returns 0 if they're exactly equal. Returns 1 otherwise.
 func CompareLocations(a LocationData, b LocationData) int {
-	if a.StartLine < b.StartLine {
-		return -1
+	if v := cmp.Compare(a.StartLine, b.StartLine); v != 0 {
+		return v
 	}
 
-	if a.StartLine > b.StartLine {
-		return 1
+	if v := cmp.Compare(a.StartCharacter, b.StartCharacter); v != 0 {
+		return v
 	}
 
-	if a.StartCharacter < b.StartCharacter {
-		return -1
+	if v := cmp.Compare(a.EndLine, b.EndLine); v != 0 {
+		return v
 	}
 
-	if a.StartCharacter > b.StartCharacter {
-		return 1
-	}
-
-	if a.EndLine < b.EndLine {
-		return -1
-	}
-
-	if a.EndLine > b.EndLine {
-		return 1
-	}
-
-	if a.EndCharacter < b.EndCharacter {
-		return -1
-	}
-
-	if a.EndCharacter > b.EndCharacter {
-		return 1
-	}
-
-	return 0
+	return cmp.Compare(a.EndCharacter, b.EndCharacter)
 }
 
 // ComparePosition compares the range r with the position constructed from line and character.


### PR DESCRIPTION
There is also a [`cmp.Or` function](https://pkg.go.dev/cmp#Or) but since that's a function and
not a macro, it would cause all comparisons to always happen,
so we don't use that for chaining results.

## Test plan

Covered by existing tests

## Changelog