### PR TITLE
sg: speed up interrupt execution

### DIFF
--- a/dev/sg/interrupt/interrupt.go
+++ b/dev/sg/interrupt/interrupt.go
@@ -42,10 +42,17 @@ func Listen() {
 			os.Exit(1)
 		}()
 
-		// Execute all hooks
+		// Concurrently execute all hooks
+		var wg sync.WaitGroup
 		for _, h := range hooks {
-			h()
+			wg.Add(1)
+			fn := h
+			go func() {
+				fn()
+				wg.Done()
+			}()
 		}
+		wg.Wait()
 		close(closed)
 	}()
 }


### PR DESCRIPTION
Previously the interrupts where executed serially. Although _quick_ this was not quick enough! Since you if pressed `ctrl+c` rapidly not all hooks would get executed.

Hooks now get executed concurrently. In my own testing I could reliably get the orphaned process issue by just pressing `ctrl+c` twice. With this change, even pressing it very quickly - it still executed all hooks and thus all process where cleaned up.


## Test plan
Tested locally