### PR TITLE
feat(release): rename code freeze event to `branch cut` event

### DIFF
--- a/dev/sg/internal/release/calendar.go
+++ b/dev/sg/internal/release/calendar.go
@@ -25,7 +25,7 @@ import (
 
 type Event struct {
 	Name               string    `json:"name"`
-	CodeFreezeDate     time.Time `json:"codeFreezeDate"`
+	BranchCutDate      time.Time `json:"branchCutDate"`
 	MonthlyReleaseDate time.Time `json:"monthlyReleaseDate"`
 	PatchReleaseDate   time.Time `json:"patchReleaseDate"`
 }
@@ -65,12 +65,11 @@ func generateCalendarEvents(cctx *cli.Context) error {
 			continue
 		}
 
-		p.Updatef("Creating Code Freeze event for %q", e.Name)
-		codeFreezeEvt := createReleaseEvent(cc.TeamEmail, fmt.Sprintf("Code Freeze: (%s)", e.Name), e.CodeFreezeDate)
-		_, err := client.Events.Insert("primary", codeFreezeEvt).Context(cctx.Context).Do()
+		p.Updatef("Creating Branch Cut event for %q", e.Name)
+		branchCutEvt := createReleaseEvent(cc.TeamEmail, fmt.Sprintf("Branch Cut: (%s)", e.Name), e.BranchCutDate)
+		_, err := client.Events.Insert("primary", branchCutEvt).Context(cctx.Context).Do()
 		if err != nil {
 			p.Destroy()
-			fmt.Println(err.Error(), "<===")
 			return errors.Wrapf(err, "Failed to create Code Freeze event for %q", e.Name)
 		}
 

--- a/tools/release/config/calendar.jsonc
+++ b/tools/release/config/calendar.jsonc
@@ -5,31 +5,31 @@
     "events": [
         {
             "name": "March 2024 Release",
-            "codeFreezeDate": "2024-03-06T09:00:00-07:00",
+            "branchCutDate": "2024-03-06T09:00:00-07:00",
             "monthlyReleaseDate": "2024-03-08T09:00:00-07:00",
             "patchReleaseDate": "2024-03-20T09:00:00-07:00"
         },
         {
             "name": "April 2024 Release",
-            "codeFreezeDate": "2024-04-03T09:00:00-07:00",
+            "branchCutDate": "2024-04-03T09:00:00-07:00",
             "monthlyReleaseDate": "2024-04-05T09:00:00-07:00",
             "patchReleaseDate": "2024-04-22T09:00:00-07:00"
         },
         {
             "name": "May 2024 Release",
-            "codeFreezeDate": "2024-05-02T09:00:00-07:00",
+            "branchCutDate": "2024-05-02T09:00:00-07:00",
             "monthlyReleaseDate": "2024-05-06T09:00:00-07:00",
             "patchReleaseDate": "2024-05-27T09:00:00-07:00"
         },
         {
             "name": "June 2024 Release",
-            "codeFreezeDate": "2024-06-02T09:00:00-07:00",
+            "branchCutDate": "2024-06-02T09:00:00-07:00",
             "monthlyReleaseDate": "2024-06-05T09:00:00-07:00",
             "patchReleaseDate": "2024-06-20T09:00:00-07:00"
         },
         {
             "name": "July 2024 Release",
-            "codeFreezeDate": "2024-07-02T09:00:00-07:00",
+            "branchCutDate": "2024-07-02T09:00:00-07:00",
             "monthlyReleaseDate": "2024-07-05T09:00:00-07:00",
             "patchReleaseDate": "2024-07-22T09:00:00-07:00"
         }


### PR DESCRIPTION
[Slack Context](https://sourcegraph.slack.com/archives/C02E4HE42BX/p1717378098939399)

This PR renames the `Code Freeze event` sent when `sg release cal` is run to `Branch Cut`. This naming change reflects the correct action carried out during this event.

The concept of a Code Freeze doesn't exist during a release.

## Test plan

Manual testing

## Changelog

- Rename the calendar event `Code Freeze:` to `Branch Cut:`
