### PR TITLE
feat(release): allow creation of multiple patch release events

### DIFF
--- a/dev/sg/internal/release/calendar.go
+++ b/dev/sg/internal/release/calendar.go
@@ -24,10 +24,10 @@ import (
 )
 
 type Event struct {
-	Name               string    `json:"name"`
-	BranchCutDate      time.Time `json:"branchCutDate"`
-	MonthlyReleaseDate time.Time `json:"monthlyReleaseDate"`
-	PatchReleaseDate   time.Time `json:"patchReleaseDate"`
+	Name               string      `json:"name"`
+	BranchCutDate      time.Time   `json:"branchCutDate"`
+	MonthlyReleaseDate time.Time   `json:"monthlyReleaseDate"`
+	PatchReleaseDates  []time.Time `json:"patchReleaseDates"`
 }
 
 type CalendarConfig struct {
@@ -60,8 +60,18 @@ func generateCalendarEvents(cctx *cli.Context) error {
 	now := time.Now()
 	for _, e := range cc.Events {
 		p := std.Out.Pending(output.Styledf(output.StylePending, "Processing Calendar event: %q", e.Name))
-		if e.MonthlyReleaseDate.Before(now) || e.PatchReleaseDate.Before(now) {
-			p.Complete(output.Linef(output.EmojiWarning, output.StyleWarning, "Skipping event: %q because the date is in the past.", e.Name))
+
+		patchEventsToCreate := make([]time.Time, len(e.PatchReleaseDates))
+
+		for i, patchReleaseDate := range e.PatchReleaseDates {
+			if patchReleaseDate.Before(now) {
+				continue
+			}
+			patchEventsToCreate[i] = patchReleaseDate
+		}
+
+		if len(patchEventsToCreate) == 0 {
+			p.Complete(output.Linef(output.EmojiWarning, output.StyleWarning, "Skipping event: %q because there are no patch release dates for the month.", e.Name))
 			continue
 		}
 
@@ -81,12 +91,14 @@ func generateCalendarEvents(cctx *cli.Context) error {
 			return errors.Wrapf(err, "Failed to create monthly release event for %q", e.Name)
 		}
 
-		p.Updatef("Creating Patch Release event for %q", e.Name)
-		patchReleaseEvt := createReleaseEvent(cc.TeamEmail, fmt.Sprintf("Patch Release: (%s)", e.Name), e.PatchReleaseDate)
-		_, err = client.Events.Insert("primary", patchReleaseEvt).Context(cctx.Context).Do()
-		if err != nil {
-			p.Destroy()
-			return errors.Wrapf(err, "Failed to create patch release event for %q", e.Name)
+		p.Updatef("Creating Patch Release events for %q", e.Name)
+		for _, prd := range patchEventsToCreate {
+			patchReleaseEvt := createReleaseEvent(cc.TeamEmail, fmt.Sprintf("Patch Release: (%s)", e.Name), prd)
+			_, err = client.Events.Insert("primary", patchReleaseEvt).Context(cctx.Context).Do()
+			if err != nil {
+				p.Destroy()
+				return errors.Wrapf(err, "Failed to create patch release event for %q. Patch release date: %s", e.Name, prd)
+			}
 		}
 
 		p.Complete(output.Linef(output.EmojiSuccess, output.StyleSuccess, "Sent and created event: %q", e.Name))

--- a/dev/sg/internal/release/calendar.go
+++ b/dev/sg/internal/release/calendar.go
@@ -63,6 +63,11 @@ func generateCalendarEvents(cctx *cli.Context) error {
 
 		patchEventsToCreate := make([]time.Time, len(e.PatchReleaseDates))
 
+		if e.MonthlyReleaseDate.Before(now) {
+			p.Complete(output.Linef(output.EmojiWarning, output.StyleWarning, "Skipping event: %q because the monthly release date is in the past.", e.Name))
+			continue
+		}
+
 		for i, patchReleaseDate := range e.PatchReleaseDates {
 			if patchReleaseDate.Before(now) {
 				continue

--- a/tools/release/config/calendar.jsonc
+++ b/tools/release/config/calendar.jsonc
@@ -7,31 +7,31 @@
             "name": "March 2024 Release",
             "branchCutDate": "2024-03-06T09:00:00-07:00",
             "monthlyReleaseDate": "2024-03-08T09:00:00-07:00",
-            "patchReleaseDate": "2024-03-20T09:00:00-07:00"
+            "patchReleaseDates": ["2024-03-20T09:00:00-07:00"]
         },
         {
             "name": "April 2024 Release",
             "branchCutDate": "2024-04-03T09:00:00-07:00",
             "monthlyReleaseDate": "2024-04-05T09:00:00-07:00",
-            "patchReleaseDate": "2024-04-22T09:00:00-07:00"
+            "patchReleaseDates": ["2024-04-22T09:00:00-07:00"]
         },
         {
             "name": "May 2024 Release",
             "branchCutDate": "2024-05-02T09:00:00-07:00",
             "monthlyReleaseDate": "2024-05-06T09:00:00-07:00",
-            "patchReleaseDate": "2024-05-27T09:00:00-07:00"
+            "patchReleaseDates": ["2024-05-27T09:00:00-07:00"]
         },
         {
             "name": "June 2024 Release",
             "branchCutDate": "2024-06-02T09:00:00-07:00",
             "monthlyReleaseDate": "2024-06-05T09:00:00-07:00",
-            "patchReleaseDate": "2024-06-20T09:00:00-07:00"
+            "patchReleaseDates": ["2024-06-20T09:00:00-07:00"]
         },
         {
             "name": "July 2024 Release",
             "branchCutDate": "2024-07-02T09:00:00-07:00",
             "monthlyReleaseDate": "2024-07-05T09:00:00-07:00",
-            "patchReleaseDate": "2024-07-22T09:00:00-07:00"
+            "patchReleaseDates": ["2024-07-22T09:00:00-07:00"]
         }
     ]
 }

--- a/tools/release/config/calendar.jsonc
+++ b/tools/release/config/calendar.jsonc
@@ -1,25 +1,13 @@
 {
     "teamEmail": "team@sourcegraph.com",
     // these dates should always be in sync with the Sourcegraph Handbook release schedule
-    // https://handbook.sourcegraph.com/departments/engineering/dev/process/releases/#release-schedule
+    // https://www.notion.so/sourcegraph/Sourcegraph-Releases-eee2a5384b0a4555adb51b439ddde35f?pvs=4
     "events": [
         {
-            "name": "March 2024 Release",
-            "branchCutDate": "2024-03-06T09:00:00-07:00",
-            "monthlyReleaseDate": "2024-03-08T09:00:00-07:00",
-            "patchReleaseDates": ["2024-03-20T09:00:00-07:00"]
-        },
-        {
-            "name": "April 2024 Release",
-            "branchCutDate": "2024-04-03T09:00:00-07:00",
-            "monthlyReleaseDate": "2024-04-05T09:00:00-07:00",
-            "patchReleaseDates": ["2024-04-22T09:00:00-07:00"]
-        },
-        {
-            "name": "May 2024 Release",
-            "branchCutDate": "2024-05-02T09:00:00-07:00",
-            "monthlyReleaseDate": "2024-05-06T09:00:00-07:00",
-            "patchReleaseDates": ["2024-05-27T09:00:00-07:00"]
+            "name": "July 2024 Release",
+            "branchCutDate": "2024-07-02T09:00:00-07:00",
+            "monthlyReleaseDate": "2024-07-05T09:00:00-07:00",
+            "patchReleaseDates": ["2024-07-22T09:00:00-07:00"]
         },
         {
             "name": "June 2024 Release",
@@ -28,10 +16,22 @@
             "patchReleaseDates": ["2024-06-20T09:00:00-07:00"]
         },
         {
-            "name": "July 2024 Release",
-            "branchCutDate": "2024-07-02T09:00:00-07:00",
-            "monthlyReleaseDate": "2024-07-05T09:00:00-07:00",
-            "patchReleaseDates": ["2024-07-22T09:00:00-07:00"]
+            "name": "May 2024 Release",
+            "branchCutDate": "2024-05-02T09:00:00-07:00",
+            "monthlyReleaseDate": "2024-05-06T09:00:00-07:00",
+            "patchReleaseDates": ["2024-05-27T09:00:00-07:00"]
+        },
+        {
+            "name": "April 2024 Release",
+            "branchCutDate": "2024-04-03T09:00:00-07:00",
+            "monthlyReleaseDate": "2024-04-05T09:00:00-07:00",
+            "patchReleaseDates": ["2024-04-22T09:00:00-07:00"]
+        },
+        {
+            "name": "March 2024 Release",
+            "branchCutDate": "2024-03-06T09:00:00-07:00",
+            "monthlyReleaseDate": "2024-03-08T09:00:00-07:00",
+            "patchReleaseDates": ["2024-03-20T09:00:00-07:00"]
         }
     ]
 }


### PR DESCRIPTION
Before this PR, the `sg release cal` command only allowed one patch release per monthly release. This isn't always the case as sometimes, we have multiple patches in a month.

This PR updates the calendar config to allow multiple patch release events. This changes the structure of the config object to 

```json
...
{
            "name": "July 2024 Release",
            "branchCutDate": "2024-07-02T09:00:00-07:00",
            "monthlyReleaseDate": "2024-07-05T09:00:00-07:00",
            "patchReleaseDates": ["2024-07-22T09:00:00-07:00"]
}
...
```

## Test plan

Manual testing

## Changelog

- Multiple patch events can now be created with the `sg release cal` command