### PR TITLE
chore: Simplify RequestState/PositionalRequestArgs o11y code

### DIFF
--- a/internal/codeintel/codenav/request_state.go
+++ b/internal/codeintel/codenav/request_state.go
@@ -3,6 +3,8 @@ package codenav
 import (
 	"sync"
 
+	"go.opentelemetry.io/otel/attribute"
+
 	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/uploads/shared"
 	"github.com/sourcegraph/sourcegraph/internal/database"
@@ -28,6 +30,19 @@ type RequestState struct {
 	RepositoryID int
 	Commit       string
 	Path         string
+}
+
+func (r *RequestState) Attrs() []attribute.KeyValue {
+	out := []attribute.KeyValue{
+		attribute.Int("repositoryID", r.RepositoryID),
+		attribute.String("commit", r.Commit),
+		attribute.String("path", r.Path),
+	}
+	if r.dataLoader != nil {
+		uploads := r.dataLoader.uploads
+		out = append(out, attribute.Int("numUploads", len(uploads)), attribute.String("uploads", uploadIDsToString(uploads)))
+	}
+	return out
 }
 
 func NewRequestState(

--- a/internal/codeintel/codenav/service.go
+++ b/internal/codeintel/codenav/service.go
@@ -54,7 +54,8 @@ func newService(
 
 // GetHover returns the set of locations defining the symbol at the given position.
 func (s *Service) GetHover(ctx context.Context, args PositionalRequestArgs, requestState RequestState) (_ string, _ shared.Range, _ bool, err error) {
-	ctx, trace, endObservation := observeResolver(ctx, &err, s.operations.getHover, serviceObserverThreshold, observation.Args{Attrs: append(args.Attrs(), requestState.Attrs()...)})
+	ctx, trace, endObservation := observeResolver(ctx, &err, s.operations.getHover, serviceObserverThreshold,
+		observation.Args{Attrs: observation.MergeAttributes(args.Attrs(), requestState.Attrs()...)})
 	defer endObservation()
 
 	adjustedUploads, err := s.getVisibleUploads(ctx, args.Line, args.Character, requestState)
@@ -368,7 +369,7 @@ const DefinitionsLimit = 100
 
 func (s *Service) GetDiagnostics(ctx context.Context, args PositionalRequestArgs, requestState RequestState) (diagnosticsAtUploads []DiagnosticAtUpload, _ int, err error) {
 	ctx, trace, endObservation := observeResolver(ctx, &err, s.operations.getDiagnostics, serviceObserverThreshold,
-		observation.Args{Attrs: append(args.Attrs(), requestState.Attrs()...)})
+		observation.Args{Attrs: observation.MergeAttributes(args.Attrs(), requestState.Attrs()...)})
 	defer endObservation()
 
 	visibleUploads, err := s.getUploadPaths(ctx, args.Path, requestState)

--- a/internal/codeintel/codenav/service_new.go
+++ b/internal/codeintel/codenav/service_new.go
@@ -107,7 +107,7 @@ func (s *Service) gatherLocations(
 	extractor LocationExtractor,
 ) (allLocations []shared.UploadLocation, _ Cursor, err error) {
 	ctx, trace, endObservation := observeResolver(ctx, &err, operation, serviceObserverThreshold,
-		observation.Args{Attrs: append(args.Attrs(), requestState.Attrs()...)})
+		observation.Args{Attrs: observation.MergeAttributes(args.Attrs(), requestState.Attrs()...)})
 	defer endObservation()
 
 	if cursor.Phase == "" {

--- a/internal/codeintel/codenav/service_new.go
+++ b/internal/codeintel/codenav/service_new.go
@@ -106,15 +106,8 @@ func (s *Service) gatherLocations(
 	includeReferencingIndexes bool,
 	extractor LocationExtractor,
 ) (allLocations []shared.UploadLocation, _ Cursor, err error) {
-	ctx, trace, endObservation := observeResolver(ctx, &err, operation, serviceObserverThreshold, observation.Args{Attrs: []attribute.KeyValue{
-		attribute.Int("repositoryID", args.RepositoryID),
-		attribute.String("commit", args.Commit),
-		attribute.String("path", args.Path),
-		attribute.Int("numUploads", len(requestState.GetCacheUploads())),
-		attribute.String("uploads", uploadIDsToString(requestState.GetCacheUploads())),
-		attribute.Int("line", args.Line),
-		attribute.Int("character", args.Character),
-	}})
+	ctx, trace, endObservation := observeResolver(ctx, &err, operation, serviceObserverThreshold,
+		observation.Args{Attrs: append(args.Attrs(), requestState.Attrs()...)})
 	defer endObservation()
 
 	if cursor.Phase == "" {

--- a/internal/codeintel/codenav/transport/graphql/observability.go
+++ b/internal/codeintel/codenav/transport/graphql/observability.go
@@ -6,8 +6,6 @@ import (
 	"time"
 
 	"github.com/sourcegraph/log"
-	"go.opentelemetry.io/otel/attribute"
-
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/codenav"
 	"github.com/sourcegraph/sourcegraph/internal/metrics"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
@@ -94,12 +92,5 @@ func lowSlowRequest(logger log.Logger, duration time.Duration, err *error) {
 }
 
 func getObservationArgs(args codenav.PositionalRequestArgs) observation.Args {
-	return observation.Args{Attrs: []attribute.KeyValue{
-		attribute.Int("repositoryID", args.RepositoryID),
-		attribute.String("commit", args.Commit),
-		attribute.String("path", args.Path),
-		attribute.Int("line", args.Line),
-		attribute.Int("character", args.Character),
-		attribute.Int("limit", args.Limit),
-	}}
+	return observation.Args{Attrs: args.Attrs()}
 }

--- a/internal/codeintel/codenav/transport/graphql/root_resolver.go
+++ b/internal/codeintel/codenav/transport/graphql/root_resolver.go
@@ -273,11 +273,7 @@ func (r *gitBlobLSIFDataResolver) ToGitBlobLSIFData() (resolverstubs.GitBlobLSIF
 }
 
 func (r *gitBlobLSIFDataResolver) VisibleIndexes(ctx context.Context) (_ *[]resolverstubs.PreciseIndexResolver, err error) {
-	ctx, traceErrs, endObservation := r.operations.visibleIndexes.WithErrors(ctx, &err, observation.Args{Attrs: []attribute.KeyValue{
-		attribute.Int("repoID", r.requestState.RepositoryID),
-		attribute.String("commit", r.requestState.Commit),
-		attribute.String("path", r.requestState.Path),
-	}})
+	ctx, traceErrs, endObservation := r.operations.visibleIndexes.WithErrors(ctx, &err, observation.Args{Attrs: r.requestState.Attrs()})
 	defer endObservation(1, observation.Args{})
 
 	visibleUploads, err := r.codeNavSvc.VisibleUploadsForPath(ctx, r.requestState)

--- a/internal/codeintel/codenav/transport/graphql/root_resolver_definitions.go
+++ b/internal/codeintel/codenav/transport/graphql/root_resolver_definitions.go
@@ -5,8 +5,6 @@ import (
 	"strings"
 	"time"
 
-	"go.opentelemetry.io/otel/attribute"
-
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/codenav"
 	resolverstubs "github.com/sourcegraph/sourcegraph/internal/codeintel/resolvers"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
@@ -27,14 +25,7 @@ func (r *gitBlobLSIFDataResolver) Definitions(ctx context.Context, args *resolve
 		Line:      int(args.Line),
 		Character: int(args.Character),
 	}
-	ctx, _, endObservation := observeResolver(ctx, &err, r.operations.definitions, time.Second, observation.Args{Attrs: []attribute.KeyValue{
-		attribute.Int("repositoryID", requestArgs.RepositoryID),
-		attribute.String("commit", requestArgs.Commit),
-		attribute.String("path", requestArgs.Path),
-		attribute.Int("line", requestArgs.Line),
-		attribute.Int("character", requestArgs.Character),
-		attribute.Int("limit", requestArgs.Limit),
-	}})
+	ctx, _, endObservation := observeResolver(ctx, &err, r.operations.definitions, time.Second, observation.Args{Attrs: requestArgs.Attrs()})
 	defer endObservation()
 
 	def, err := r.codeNavSvc.GetDefinitions(ctx, requestArgs, r.requestState)

--- a/internal/codeintel/codenav/transport/graphql/root_resolver_ranges.go
+++ b/internal/codeintel/codenav/transport/graphql/root_resolver_ranges.go
@@ -27,13 +27,11 @@ func (r *gitBlobLSIFDataResolver) Ranges(ctx context.Context, args *resolverstub
 		},
 		Path: r.requestState.Path,
 	}
-	ctx, _, endObservation := observeResolver(ctx, &err, r.operations.ranges, time.Second, observation.Args{Attrs: []attribute.KeyValue{
-		attribute.Int("repositoryID", requestArgs.RepositoryID),
-		attribute.String("commit", requestArgs.Commit),
-		attribute.String("path", requestArgs.Path),
-		attribute.Int("startLine", int(args.StartLine)),
-		attribute.Int("endLine", int(args.EndLine)),
-	}})
+	ctx, _, endObservation := observeResolver(ctx, &err, r.operations.ranges, time.Second,
+		observation.Args{Attrs: append(requestArgs.Attrs(),
+			attribute.Int("startLine", int(args.StartLine)),
+			attribute.Int("endLine", int(args.EndLine)))},
+	)
 	defer endObservation()
 
 	if args.StartLine < 0 || args.EndLine < args.StartLine {

--- a/internal/codeintel/codenav/types.go
+++ b/internal/codeintel/codenav/types.go
@@ -3,6 +3,8 @@ package codenav
 import (
 	"strings"
 
+	"go.opentelemetry.io/otel/attribute"
+
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/codenav/shared"
 	uploadsshared "github.com/sourcegraph/sourcegraph/internal/codeintel/uploads/shared"
 	"github.com/sourcegraph/sourcegraph/lib/codeintel/precise"
@@ -54,11 +56,27 @@ type RequestArgs struct {
 	RawCursor    string
 }
 
+func (args *RequestArgs) Attrs() []attribute.KeyValue {
+	return []attribute.KeyValue{
+		attribute.Int("repositoryID", args.RepositoryID),
+		attribute.String("commit", args.Commit),
+		attribute.Int("limit", args.Limit),
+	}
+}
+
 type PositionalRequestArgs struct {
 	RequestArgs
 	Path      string
 	Line      int
 	Character int
+}
+
+func (args *PositionalRequestArgs) Attrs() []attribute.KeyValue {
+	return append(args.RequestArgs.Attrs(),
+		attribute.String("path", args.Path),
+		attribute.Int("line", args.Line),
+		attribute.Int("character", args.Character),
+	)
 }
 
 // DiagnosticAtUpload is a diagnostic from within a particular upload. The adjusted commit denotes

--- a/internal/observation/BUILD.bazel
+++ b/internal/observation/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
         "@com_github_prometheus_client_golang//prometheus",
         "@com_github_sourcegraph_log//:log",
         "@com_github_sourcegraph_log//logtest",
+        "@com_github_wk8_go_ordered_map_v2//:go-ordered-map",
         "@io_opentelemetry_go_otel//attribute",
         "@io_opentelemetry_go_otel_trace//:trace",
         "@io_opentelemetry_go_otel_trace//noop",
@@ -33,8 +34,13 @@ go_test(
     name = "observation_test",
     timeout = "short",
     srcs = [
+        "fields_test.go",
         "snakecase_test.go",
         "util_test.go",
     ],
     embed = [":observation"],
+    deps = [
+        "@com_github_stretchr_testify//require",
+        "@io_opentelemetry_go_otel//attribute",
+    ],
 )

--- a/internal/observation/fields_test.go
+++ b/internal/observation/fields_test.go
@@ -1,0 +1,37 @@
+package observation
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
+)
+
+func TestMergeAttributes(t *testing.T) {
+	type testCase struct {
+		kv1  []attribute.KeyValue
+		kv2  []attribute.KeyValue
+		want []attribute.KeyValue
+	}
+	testCases := []testCase{
+		{
+			kv1: []attribute.KeyValue{
+				attribute.Int("a", 0),
+				attribute.Int("b", 1),
+			},
+			kv2: []attribute.KeyValue{
+				attribute.Int("a", 1),
+				attribute.Int("c", 2),
+			},
+			want: []attribute.KeyValue{
+				attribute.Int("a", 1),
+				attribute.Int("b", 1),
+				attribute.Int("c", 2),
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		require.Equal(t, tc.want, MergeAttributes(tc.kv1, tc.kv2...))
+	}
+}


### PR DESCRIPTION
Moving the common observability attributes code into helper methods makes
reading the observation related code less painful.

TODO:
- [x] Add a function to de-duplicate the attributes, because the current implementation
  will end up creating a slice on seeing duplicate keys for the fields common between
  RequestState and PositionalRequestArgs.

@Strum355, do you know why we keep multiple values for the same key instead
of having overwriting semantics? You added this behavior here:
https://github.com/sourcegraph/sourcegraph/pull/29652

## Test plan

Covered by existing tests

## Changelog