### PR TITLE
gitserver: Increase default GitLongCommandTimeout

### DIFF
--- a/internal/conf/computed.go
+++ b/internal/conf/computed.go
@@ -618,7 +618,7 @@ func AuthLockout() *schema.AuthLockout {
 	return val
 }
 
-const defaultGitLongCommandTimeout = time.Hour
+const defaultGitLongCommandTimeout = 2 * time.Hour
 
 // GitLongCommandTimeout returns the maximum amount of time in seconds that a
 // long Git command (e.g. clone or remote update) is allowed to execute. If not

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -921,7 +921,7 @@
     "gitLongCommandTimeout": {
       "description": "Maximum number of seconds that a long Git command (e.g. clone or remote update) is allowed to execute. The default is 3600 seconds, or 1 hour.",
       "type": "integer",
-      "default": 3600,
+      "default": 7200,
       "group": "External services"
     },
     "gitMaxConcurrentClones": {


### PR DESCRIPTION
This has historically been set to 1 hour.
We've seen several reports of users running into the limit for clones of very large repositories, but we have seen no complaints of processes hanging for very long and clogging any queues.
So it feels sensible to me to increase the default for this value to 2h.

We might come back here later and decide that we don't really need a deadline here at all and instead hard-code a day or so to prevent infinite clogging, but let's see how far 2x gets us for now.

Test plan:

CI still passes.