### PR TITLE
Use anyhow context, bail, and ensure instead of panicking

### DIFF
--- a/docker-images/syntax-highlighter/crates/syntax-analysis/src/globals.rs
+++ b/docker-images/syntax-highlighter/crates/syntax-analysis/src/globals.rs
@@ -1,4 +1,4 @@
-use anyhow::{Context, Result};
+use anyhow::{bail, ensure, Context, Result};
 use bitvec::prelude::*;
 use protobuf::Enum;
 use scip::types::{symbol_information, Descriptor, Document, Occurrence, SymbolInformation};
@@ -174,7 +174,7 @@ pub fn parse_tree<'a>(
         for capture in m.captures {
             let capture_name = capture_names
                 .get(capture.index as usize)
-                .expect("capture indexes should always work");
+                .context("capture indexes should always work")?;
 
             if capture_name.starts_with("descriptor") {
                 descriptors.push((
@@ -188,12 +188,12 @@ pub fn parse_tree<'a>(
             }
 
             if capture_name.starts_with("scope") {
-                assert!(scope.is_none(), "declare only one scope per match");
+                ensure!(scope.is_none(), "declare only one scope per match");
                 scope = Some(capture);
             }
 
             if capture_name.starts_with("enclosing") {
-                assert!(enclosing_node.is_none(), "declare only one scope per match");
+                ensure!(enclosing_node.is_none(), "declare only one scope per match");
                 enclosing_node = Some(capture.node);
             }
 
@@ -202,7 +202,7 @@ pub fn parse_tree<'a>(
             }
 
             if capture_name.starts_with("kind") {
-                assert!(kind.is_none(), "declare only one kind per match");
+                ensure!(kind.is_none(), "declare only one kind per match");
                 kind = Some(capture_name)
             }
         }
@@ -277,7 +277,7 @@ pub fn parse_tree<'a>(
             }
             None => {
                 if local_range.is_none() {
-                    panic!("there must always be at least one descriptor (except for @local)");
+                    bail!("there must always be at least one descriptor (except for @local)");
                 }
             }
         }


### PR DESCRIPTION
I was indexing some projects and occasionally it'd fail with 

```
thread 'main' panicked at crates/syntax-analysis/src/globals.rs:191:17:
declare only one scope per match
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

With no extra information, circumventing the error handling in the levels above.

This PR uses anyhow's helpers to ensure that the errors are propagated

## Test plan

- N/A

<!-- All pull requests REQUIRE a test plan: https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles -->


