### PR TITLE
chore/msp/runtime: disable telemetry on Google Monitoring/Trace APIs

### DIFF
--- a/lib/managedservicesplatform/go.mod
+++ b/lib/managedservicesplatform/go.mod
@@ -34,6 +34,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.24.0
 	go.opentelemetry.io/otel/sdk/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
+	google.golang.org/api v0.156.0
 )
 
 require (
@@ -114,7 +115,6 @@ require (
 	golang.org/x/time v0.5.0 // indirect
 	golang.org/x/tools v0.18.0 // indirect
 	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 // indirect
-	google.golang.org/api v0.156.0 // indirect
 	google.golang.org/appengine v1.6.8 // indirect
 	google.golang.org/genproto v0.0.0-20240108191215-35c7eff3a6b1 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20240108191215-35c7eff3a6b1 // indirect

--- a/lib/managedservicesplatform/runtime/internal/opentelemetry/BUILD.bazel
+++ b/lib/managedservicesplatform/runtime/internal/opentelemetry/BUILD.bazel
@@ -38,5 +38,6 @@ go_library(
         "@io_opentelemetry_go_otel_sdk_metric//metricdata",
         "@io_opentelemetry_go_otel_trace//:trace",
         "@io_opentelemetry_go_otel_trace//embedded",
+        "@org_golang_google_api//option",
     ],
 )

--- a/lib/managedservicesplatform/runtime/internal/opentelemetry/metrics.go
+++ b/lib/managedservicesplatform/runtime/internal/opentelemetry/metrics.go
@@ -6,7 +6,6 @@ import (
 
 	gcpmetricexporter "github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/sourcegraph/log"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	otelprometheus "go.opentelemetry.io/otel/exporters/prometheus"
@@ -14,6 +13,9 @@ import (
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	"go.opentelemetry.io/otel/sdk/resource"
+	apioption "google.golang.org/api/option"
+
+	"github.com/sourcegraph/log"
 
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
@@ -25,7 +27,10 @@ func configureMetrics(_ context.Context, logger log.Logger, config Config, res *
 		// We use a push-based exporter with PeriodicReader from the metrics SDK
 		// to publish metrics to GCP.
 		exporter, err := gcpmetricexporter.New(
-			gcpmetricexporter.WithProjectID(config.GCPProjectID))
+			gcpmetricexporter.WithProjectID(config.GCPProjectID),
+			gcpmetricexporter.WithMonitoringClientOptions(
+				apioption.WithTelemetryDisabled(),
+			))
 		if err != nil {
 			return nil, errors.Wrap(err, "gcpmetricexporter.New")
 		}

--- a/lib/managedservicesplatform/runtime/internal/opentelemetry/tracing.go
+++ b/lib/managedservicesplatform/runtime/internal/opentelemetry/tracing.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/sourcegraph/log"
-
 	gcptraceexporter "github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace"
 	jaegerpropagator "go.opentelemetry.io/contrib/propagators/jaeger"
 	otpropagator "go.opentelemetry.io/contrib/propagators/ot"
@@ -19,6 +17,9 @@ import (
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/trace"
 	"go.opentelemetry.io/otel/trace/embedded"
+	apioption "google.golang.org/api/option"
+
+	"github.com/sourcegraph/log"
 
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
@@ -39,6 +40,9 @@ func configureTracing(ctx context.Context, logger log.Logger, config Config, res
 			gcptraceexporter.WithErrorHandler(otel.ErrorHandlerFunc(func(err error) {
 				logger.Warn("gcptraceexporter error", log.Error(err))
 			})),
+			gcptraceexporter.WithTraceClientOptions([]apioption.ClientOption{
+				apioption.WithTelemetryDisabled(),
+			}),
 		)
 		if err != nil {
 			return nil, errors.Wrap(err, "gcptraceexporter.New")


### PR DESCRIPTION
Right now these emit a bunch of metrics and traces _for exporting metrics and traces_ that aren't very interesting. In particular they make the GCP console trace view very annoying to use because it's just filled with a bunch of "export trace" and "export metric" traces.

This disables telemetry for both. We only care about actual failures, which we do log.

https://sourcegraph.com/github.com/googleapis/google-api-go-client/-/blob/transport/grpc/dial.go?L362-367

## Test plan

n/a