### PR TITLE
chore: Make GetDefinitions API consistent with GetReferences etc.

### DIFF
--- a/internal/codeintel/codenav/service_new.go
+++ b/internal/codeintel/codenav/service_new.go
@@ -19,17 +19,15 @@ func (s *Service) GetDefinitions(
 	ctx context.Context,
 	args PositionalRequestArgs,
 	requestState RequestState,
-) (_ []shared.UploadLocation, err error) {
-	locations, _, err := s.gatherLocations(
-		ctx, args, requestState, Cursor{},
-
+	cursor Cursor,
+) (_ []shared.UploadLocation, nextCursor Cursor, err error) {
+	return s.gatherLocations(
+		ctx, args, requestState, cursor,
 		s.operations.getDefinitions, // operation
 		"definitions",               // tableName
 		false,                       // includeReferencingIndexes
 		LocationExtractorFunc(s.lsifstore.ExtractDefinitionLocationsFromPosition),
 	)
-
-	return locations, err
 }
 
 func (s *Service) GetReferences(
@@ -40,7 +38,6 @@ func (s *Service) GetReferences(
 ) (_ []shared.UploadLocation, nextCursor Cursor, err error) {
 	return s.gatherLocations(
 		ctx, args, requestState, cursor,
-
 		s.operations.getReferences, // operation
 		"references",               // tableName
 		true,                       // includeReferencingIndexes
@@ -56,7 +53,6 @@ func (s *Service) GetImplementations(
 ) (_ []shared.UploadLocation, nextCursor Cursor, err error) {
 	return s.gatherLocations(
 		ctx, args, requestState, cursor,
-
 		s.operations.getImplementations, // operation
 		"implementations",               // tableName
 		true,                            // includeReferencingIndexes
@@ -72,7 +68,6 @@ func (s *Service) GetPrototypes(
 ) (_ []shared.UploadLocation, nextCursor Cursor, err error) {
 	return s.gatherLocations(
 		ctx, args, requestState, cursor,
-
 		s.operations.getPrototypes, // operation
 		"definitions",              // N.B.: we're looking for definitions of interfaces
 		false,                      // includeReferencingIndexes

--- a/internal/codeintel/codenav/service_new_test.go
+++ b/internal/codeintel/codenav/service_new_test.go
@@ -60,7 +60,7 @@ func TestGetDefinitions(t *testing.T) {
 			Line:      10,
 			Character: 20,
 		}
-		adjustedLocations, err := svc.GetDefinitions(context.Background(), mockRequest, mockRequestState)
+		adjustedLocations, _, err := svc.GetDefinitions(context.Background(), mockRequest, mockRequestState, Cursor{})
 		if err != nil {
 			t.Fatalf("unexpected error querying definitions: %s", err)
 		}
@@ -145,7 +145,7 @@ func TestGetDefinitions(t *testing.T) {
 			Character: 20,
 		}
 		remoteUploads := uploads2
-		adjustedLocations, err := svc.GetDefinitions(context.Background(), mockRequest, mockRequestState)
+		adjustedLocations, _, err := svc.GetDefinitions(context.Background(), mockRequest, mockRequestState, Cursor{})
 		if err != nil {
 			t.Fatalf("unexpected error querying definitions: %s", err)
 		}

--- a/internal/codeintel/codenav/transport/graphql/iface.go
+++ b/internal/codeintel/codenav/transport/graphql/iface.go
@@ -15,7 +15,7 @@ type CodeNavService interface {
 	GetReferences(ctx context.Context, args codenav.PositionalRequestArgs, requestState codenav.RequestState, cursor codenav.Cursor) (_ []shared.UploadLocation, nextCursor codenav.Cursor, err error)
 	GetImplementations(ctx context.Context, args codenav.PositionalRequestArgs, requestState codenav.RequestState, cursor codenav.Cursor) (_ []shared.UploadLocation, nextCursor codenav.Cursor, err error)
 	GetPrototypes(ctx context.Context, args codenav.PositionalRequestArgs, requestState codenav.RequestState, cursor codenav.Cursor) (_ []shared.UploadLocation, nextCursor codenav.Cursor, err error)
-	GetDefinitions(ctx context.Context, args codenav.PositionalRequestArgs, requestState codenav.RequestState) (_ []shared.UploadLocation, err error)
+	GetDefinitions(ctx context.Context, args codenav.PositionalRequestArgs, requestState codenav.RequestState, cursor codenav.Cursor) (_ []shared.UploadLocation, nextCursor codenav.Cursor, err error)
 	GetDiagnostics(ctx context.Context, args codenav.PositionalRequestArgs, requestState codenav.RequestState) (diagnosticsAtUploads []codenav.DiagnosticAtUpload, _ int, err error)
 	GetRanges(ctx context.Context, args codenav.PositionalRequestArgs, requestState codenav.RequestState, startLine, endLine int) (adjustedRanges []codenav.AdjustedCodeIntelligenceRange, err error)
 	GetStencil(ctx context.Context, args codenav.PositionalRequestArgs, requestState codenav.RequestState) (adjustedRanges []shared.Range, err error)

--- a/internal/codeintel/codenav/transport/graphql/mocks_test.go
+++ b/internal/codeintel/codenav/transport/graphql/mocks_test.go
@@ -228,7 +228,7 @@ func NewMockCodeNavService() *MockCodeNavService {
 			},
 		},
 		GetDefinitionsFunc: &CodeNavServiceGetDefinitionsFunc{
-			defaultHook: func(context.Context, codenav.PositionalRequestArgs, codenav.RequestState) (r0 []shared1.UploadLocation, r1 error) {
+			defaultHook: func(context.Context, codenav.PositionalRequestArgs, codenav.RequestState, codenav.Cursor) (r0 []shared1.UploadLocation, r1 codenav.Cursor, r2 error) {
 				return
 			},
 		},
@@ -295,7 +295,7 @@ func NewStrictMockCodeNavService() *MockCodeNavService {
 			},
 		},
 		GetDefinitionsFunc: &CodeNavServiceGetDefinitionsFunc{
-			defaultHook: func(context.Context, codenav.PositionalRequestArgs, codenav.RequestState) ([]shared1.UploadLocation, error) {
+			defaultHook: func(context.Context, codenav.PositionalRequestArgs, codenav.RequestState, codenav.Cursor) ([]shared1.UploadLocation, codenav.Cursor, error) {
 				panic("unexpected invocation of MockCodeNavService.GetDefinitions")
 			},
 		},
@@ -512,24 +512,24 @@ func (c CodeNavServiceGetClosestCompletedUploadsForBlobFuncCall) Results() []int
 // GetDefinitions method of the parent MockCodeNavService instance is
 // invoked.
 type CodeNavServiceGetDefinitionsFunc struct {
-	defaultHook func(context.Context, codenav.PositionalRequestArgs, codenav.RequestState) ([]shared1.UploadLocation, error)
-	hooks       []func(context.Context, codenav.PositionalRequestArgs, codenav.RequestState) ([]shared1.UploadLocation, error)
+	defaultHook func(context.Context, codenav.PositionalRequestArgs, codenav.RequestState, codenav.Cursor) ([]shared1.UploadLocation, codenav.Cursor, error)
+	hooks       []func(context.Context, codenav.PositionalRequestArgs, codenav.RequestState, codenav.Cursor) ([]shared1.UploadLocation, codenav.Cursor, error)
 	history     []CodeNavServiceGetDefinitionsFuncCall
 	mutex       sync.Mutex
 }
 
 // GetDefinitions delegates to the next hook function in the queue and
 // stores the parameter and result values of this invocation.
-func (m *MockCodeNavService) GetDefinitions(v0 context.Context, v1 codenav.PositionalRequestArgs, v2 codenav.RequestState) ([]shared1.UploadLocation, error) {
-	r0, r1 := m.GetDefinitionsFunc.nextHook()(v0, v1, v2)
-	m.GetDefinitionsFunc.appendCall(CodeNavServiceGetDefinitionsFuncCall{v0, v1, v2, r0, r1})
-	return r0, r1
+func (m *MockCodeNavService) GetDefinitions(v0 context.Context, v1 codenav.PositionalRequestArgs, v2 codenav.RequestState, v3 codenav.Cursor) ([]shared1.UploadLocation, codenav.Cursor, error) {
+	r0, r1, r2 := m.GetDefinitionsFunc.nextHook()(v0, v1, v2, v3)
+	m.GetDefinitionsFunc.appendCall(CodeNavServiceGetDefinitionsFuncCall{v0, v1, v2, v3, r0, r1, r2})
+	return r0, r1, r2
 }
 
 // SetDefaultHook sets function that is called when the GetDefinitions
 // method of the parent MockCodeNavService instance is invoked and the hook
 // queue is empty.
-func (f *CodeNavServiceGetDefinitionsFunc) SetDefaultHook(hook func(context.Context, codenav.PositionalRequestArgs, codenav.RequestState) ([]shared1.UploadLocation, error)) {
+func (f *CodeNavServiceGetDefinitionsFunc) SetDefaultHook(hook func(context.Context, codenav.PositionalRequestArgs, codenav.RequestState, codenav.Cursor) ([]shared1.UploadLocation, codenav.Cursor, error)) {
 	f.defaultHook = hook
 }
 
@@ -537,7 +537,7 @@ func (f *CodeNavServiceGetDefinitionsFunc) SetDefaultHook(hook func(context.Cont
 // GetDefinitions method of the parent MockCodeNavService instance invokes
 // the hook at the front of the queue and discards it. After the queue is
 // empty, the default hook function is invoked for any future action.
-func (f *CodeNavServiceGetDefinitionsFunc) PushHook(hook func(context.Context, codenav.PositionalRequestArgs, codenav.RequestState) ([]shared1.UploadLocation, error)) {
+func (f *CodeNavServiceGetDefinitionsFunc) PushHook(hook func(context.Context, codenav.PositionalRequestArgs, codenav.RequestState, codenav.Cursor) ([]shared1.UploadLocation, codenav.Cursor, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -545,20 +545,20 @@ func (f *CodeNavServiceGetDefinitionsFunc) PushHook(hook func(context.Context, c
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *CodeNavServiceGetDefinitionsFunc) SetDefaultReturn(r0 []shared1.UploadLocation, r1 error) {
-	f.SetDefaultHook(func(context.Context, codenav.PositionalRequestArgs, codenav.RequestState) ([]shared1.UploadLocation, error) {
-		return r0, r1
+func (f *CodeNavServiceGetDefinitionsFunc) SetDefaultReturn(r0 []shared1.UploadLocation, r1 codenav.Cursor, r2 error) {
+	f.SetDefaultHook(func(context.Context, codenav.PositionalRequestArgs, codenav.RequestState, codenav.Cursor) ([]shared1.UploadLocation, codenav.Cursor, error) {
+		return r0, r1, r2
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *CodeNavServiceGetDefinitionsFunc) PushReturn(r0 []shared1.UploadLocation, r1 error) {
-	f.PushHook(func(context.Context, codenav.PositionalRequestArgs, codenav.RequestState) ([]shared1.UploadLocation, error) {
-		return r0, r1
+func (f *CodeNavServiceGetDefinitionsFunc) PushReturn(r0 []shared1.UploadLocation, r1 codenav.Cursor, r2 error) {
+	f.PushHook(func(context.Context, codenav.PositionalRequestArgs, codenav.RequestState, codenav.Cursor) ([]shared1.UploadLocation, codenav.Cursor, error) {
+		return r0, r1, r2
 	})
 }
 
-func (f *CodeNavServiceGetDefinitionsFunc) nextHook() func(context.Context, codenav.PositionalRequestArgs, codenav.RequestState) ([]shared1.UploadLocation, error) {
+func (f *CodeNavServiceGetDefinitionsFunc) nextHook() func(context.Context, codenav.PositionalRequestArgs, codenav.RequestState, codenav.Cursor) ([]shared1.UploadLocation, codenav.Cursor, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -600,24 +600,30 @@ type CodeNavServiceGetDefinitionsFuncCall struct {
 	// Arg2 is the value of the 3rd argument passed to this method
 	// invocation.
 	Arg2 codenav.RequestState
+	// Arg3 is the value of the 4th argument passed to this method
+	// invocation.
+	Arg3 codenav.Cursor
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 []shared1.UploadLocation
 	// Result1 is the value of the 2nd result returned from this method
 	// invocation.
-	Result1 error
+	Result1 codenav.Cursor
+	// Result2 is the value of the 3rd result returned from this method
+	// invocation.
+	Result2 error
 }
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
 func (c CodeNavServiceGetDefinitionsFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c CodeNavServiceGetDefinitionsFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+	return []interface{}{c.Result0, c.Result1, c.Result2}
 }
 
 // CodeNavServiceGetDiagnosticsFunc describes the behavior when the

--- a/internal/codeintel/codenav/transport/graphql/root_resolver_definitions.go
+++ b/internal/codeintel/codenav/transport/graphql/root_resolver_definitions.go
@@ -37,7 +37,8 @@ func (r *gitBlobLSIFDataResolver) Definitions(ctx context.Context, args *resolve
 	}})
 	defer endObservation()
 
-	def, err := r.codeNavSvc.GetDefinitions(ctx, requestArgs, r.requestState)
+	// NOTE: We don't support pagination for definitions in the GraphQL API.
+	def, _, err := r.codeNavSvc.GetDefinitions(ctx, requestArgs, r.requestState, codenav.Cursor{})
 	if err != nil {
 		return nil, errors.Wrap(err, "codeNavSvc.GetDefinitions")
 	}


### PR DESCRIPTION
Implementing precise usages on top of the existing APIs becomes easier
if they're all of the same shape.

## Test plan

Covered by existing tests.

## Changelog