### PR TITLE
fix/enterpriseportal: fix registration of connectRPC handler options

### DIFF
--- a/cmd/enterprise-portal/internal/codyaccessservice/v1.go
+++ b/cmd/enterprise-portal/internal/codyaccessservice/v1.go
@@ -34,11 +34,16 @@ func RegisterV1(
 	dotcom DotComDB,
 	opts ...connect.HandlerOption,
 ) {
-	mux.Handle(codyaccessv1connect.NewCodyAccessServiceHandler(&handlerV1{
-		logger:     logger.Scoped("codyaccess.v1"),
-		samsClient: samsClient,
-		dotcom:     dotcom,
-	}))
+	mux.Handle(
+		codyaccessv1connect.NewCodyAccessServiceHandler(
+			&handlerV1{
+				logger:     logger.Scoped("codyaccess.v1"),
+				samsClient: samsClient,
+				dotcom:     dotcom,
+			},
+			opts...,
+		),
+	)
 }
 
 type handlerV1 struct {

--- a/cmd/enterprise-portal/internal/subscriptionsservice/v1.go
+++ b/cmd/enterprise-portal/internal/subscriptionsservice/v1.go
@@ -31,11 +31,16 @@ func RegisterV1(
 	dotcom DotComDB,
 	opts ...connect.HandlerOption,
 ) {
-	mux.Handle(subscriptionsv1connect.NewSubscriptionsServiceHandler(&handlerV1{
-		logger:     logger.Scoped("subscriptions.v1"),
-		samsClient: samsClient,
-		dotcom:     dotcom,
-	}))
+	mux.Handle(
+		subscriptionsv1connect.NewSubscriptionsServiceHandler(
+			&handlerV1{
+				logger:     logger.Scoped("subscriptions.v1"),
+				samsClient: samsClient,
+				dotcom:     dotcom,
+			},
+			opts...,
+		),
+	)
 }
 
 type handlerV1 struct {


### PR DESCRIPTION
Missed this in #63045 , we aren't actually registering our OTEL handler for Connect yet

Part of CORE-161

## Test plan
n/a