### PR TITLE
chore(codeintel): usagesForSymbol - make start/end non-optional for now

### DIFF
--- a/cmd/frontend/graphqlbackend/codeintel.codenav.graphql
+++ b/cmd/frontend/graphqlbackend/codeintel.codenav.graphql
@@ -539,12 +539,14 @@ input RangeInput {
     """
     Start position of the range (inclusive)
     """
-    start: PositionInput
+    # TODO(id: usagesForSymbol-v2) Make this input optional
+    start: PositionInput!
 
     """
     End position of the range (exclusive)
     """
-    end: PositionInput
+    # TODO(id: usagesForSymbol-v2) Make this input optional
+    end: PositionInput!
 }
 
 """
@@ -602,7 +604,7 @@ input UsagesFilter {
     an empty value will find results across the Sourcegraph instance.
     """
     repository: RepositoryFilter
-    # TODO(id: usagesForSymbols-v2)
+    # TODO(id: usagesForSymbol-v2)
     # and: [UsagesFilter!]
     # or: [UsagesFilter!]
     # path: PathFilter

--- a/internal/codeintel/resolvers/codenav.go
+++ b/internal/codeintel/resolvers/codenav.go
@@ -352,8 +352,8 @@ type RangeInput struct {
 	Repository string
 	Revision   *string
 	Path       string
-	Start      *PositionInput
-	End        *PositionInput
+	Start      PositionInput
+	End        PositionInput
 }
 
 func (r *RangeInput) Attrs() (out []attribute.KeyValue) {
@@ -362,14 +362,10 @@ func (r *RangeInput) Attrs() (out []attribute.KeyValue) {
 		out = append(out, attribute.String("range.revision", *r.Revision))
 	}
 	out = append(out, attribute.String("range.path", r.Path))
-	if r.Start != nil {
-		out = append(out, attribute.Int("range.start.line", int(r.Start.Line)))
-		out = append(out, attribute.Int("range.start.character", int(r.Start.Character)))
-	}
-	if r.End != nil {
-		out = append(out, attribute.Int("range.end.line", int(r.End.Line)))
-		out = append(out, attribute.Int("range.end.character", int(r.End.Character)))
-	}
+	out = append(out, attribute.Int("range.start.line", int(r.Start.Line)))
+	out = append(out, attribute.Int("range.start.character", int(r.Start.Character)))
+	out = append(out, attribute.Int("range.end.line", int(r.End.Line)))
+	out = append(out, attribute.Int("range.end.character", int(r.End.Character)))
 	return out
 }
 


### PR DESCRIPTION
We can add support for optional start/end later
in a backwards-compatible way. Making these non-optional
helps simplify the initial implementation.

## Test plan

Check that `sg start enterprise-codeintel` works locally.

## Changelog