### PR TITLE
chore(codeintel): Simplify map[T]struct{} logic to use Set

### DIFF
--- a/internal/codeintel/codenav/commit_cache.go
+++ b/internal/codeintel/codenav/commit_cache.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/collections"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
@@ -88,14 +89,11 @@ func (c *commitCache) ExistsBatch(ctx context.Context, commits []RepositoryCommi
 // commitsExist determines if the given commits exists in the given repositories. This method returns a
 // slice of the same size as the input slice, true indicating that the commit at the symmetric index exists.
 func (c *commitCache) commitsExist(ctx context.Context, commits []RepositoryCommit) (_ []bool, err error) {
-	repositoryIDMap := map[int]struct{}{}
+	repositoryIDSet := collections.NewSet[api.RepoID]()
 	for _, rc := range commits {
-		repositoryIDMap[rc.RepositoryID] = struct{}{}
+		repositoryIDSet.Add(api.RepoID(rc.RepositoryID))
 	}
-	repositoryIDs := make([]api.RepoID, 0, len(repositoryIDMap))
-	for repositoryID := range repositoryIDMap {
-		repositoryIDs = append(repositoryIDs, api.RepoID(repositoryID))
-	}
+	repositoryIDs := repositoryIDSet.Values()
 	repos, err := c.repoStore.GetReposSetByIDs(ctx, repositoryIDs...)
 	if err != nil {
 		return nil, err

--- a/internal/codeintel/codenav/internal/lsifstore/BUILD.bazel
+++ b/internal/codeintel/codenav/internal/lsifstore/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
         "//internal/codeintel/shared",
         "//internal/codeintel/shared/ranges",
         "//internal/codeintel/uploads/shared",
+        "//internal/collections",
         "//internal/database/basestore",
         "//internal/database/dbutil",
         "//internal/metrics",

--- a/internal/codeintel/codenav/internal/lsifstore/locations_by_position.go
+++ b/internal/codeintel/codenav/internal/lsifstore/locations_by_position.go
@@ -11,6 +11,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/codenav/shared"
+	"github.com/sourcegraph/sourcegraph/internal/collections"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/lib/codeintel/precise"
 )
@@ -273,9 +274,9 @@ func extractOccurrenceData(document *scip.Document, occurrence *scip.Occurrence)
 	var (
 		hoverText               []string
 		definitionSymbol        = occurrence.Symbol
-		referencesBySymbol      = map[string]struct{}{}
-		implementationsBySymbol = map[string]struct{}{}
-		prototypeBySymbol       = map[string]struct{}{}
+		referencesBySymbol      = collections.NewSet[string]()
+		implementationsBySymbol = collections.NewSet[string]()
+		prototypeBySymbol       = collections.NewSet[string]()
 	)
 
 	// Extract hover text and relationship data from the symbol information that
@@ -290,10 +291,10 @@ func extractOccurrenceData(document *scip.Document, occurrence *scip.Occurrence)
 				definitionSymbol = rel.Symbol
 			}
 			if rel.IsReference {
-				referencesBySymbol[rel.Symbol] = struct{}{}
+				referencesBySymbol.Add(rel.Symbol)
 			}
 			if rel.IsImplementation {
-				prototypeBySymbol[rel.Symbol] = struct{}{}
+				prototypeBySymbol.Add(rel.Symbol)
 			}
 		}
 	}
@@ -302,7 +303,7 @@ func extractOccurrenceData(document *scip.Document, occurrence *scip.Occurrence)
 		for _, rel := range sym.Relationships {
 			if rel.IsImplementation {
 				if rel.Symbol == occurrence.Symbol {
-					implementationsBySymbol[sym.Symbol] = struct{}{}
+					implementationsBySymbol.Add(sym.Symbol)
 				}
 			}
 		}
@@ -314,7 +315,7 @@ func extractOccurrenceData(document *scip.Document, occurrence *scip.Occurrence)
 	prototypes := []*scip.Range{}
 
 	// Include original symbol names for reference search below
-	referencesBySymbol[occurrence.Symbol] = struct{}{}
+	referencesBySymbol.Add(occurrence.Symbol)
 
 	// For each occurrence that references one of the definition, reference, or
 	// implementation symbol names, extract and aggregate their source positions.
@@ -328,17 +329,17 @@ func extractOccurrenceData(document *scip.Document, occurrence *scip.Occurrence)
 		}
 
 		// This occurrence references this symbol (or a sibling of it)
-		if _, ok := referencesBySymbol[occ.Symbol]; ok && !isDefinition {
+		if !isDefinition && referencesBySymbol.Has(occ.Symbol) {
 			references = append(references, scip.NewRange(occ.Range))
 		}
 
 		// This occurrence is a definition of a symbol with an implementation relationship
-		if _, ok := implementationsBySymbol[occ.Symbol]; ok && isDefinition && definitionSymbol != occ.Symbol {
+		if isDefinition && implementationsBySymbol.Has(occ.Symbol) && definitionSymbol != occ.Symbol {
 			implementations = append(implementations, scip.NewRange(occ.Range))
 		}
 
 		// This occurrence is a definition of a symbol with a prototype relationship
-		if _, ok := prototypeBySymbol[occ.Symbol]; ok && isDefinition {
+		if isDefinition && prototypeBySymbol.Has(occ.Symbol) {
 			prototypes = append(prototypes, scip.NewRange(occ.Range))
 		}
 	}
@@ -471,28 +472,25 @@ func (s *store) extractLocationsFromPosition(
 		}
 	}
 
-	return deduplicateLocations(locations), deduplicate(symbols, func(s string) string { return s }), nil
+	return deduplicateLocations(locations), deduplicateBy(symbols, func(s string) string { return s }), nil
 }
 
-func deduplicate[T any](locations []T, keyFn func(T) string) []T {
-	seen := map[string]struct{}{}
-
+func deduplicateBy[T any](locations []T, keyFn func(T) string) []T {
+	seen := collections.NewSet[string]()
 	filtered := locations[:0]
 	for _, l := range locations {
 		k := keyFn(l)
-		if _, ok := seen[k]; ok {
+		if seen.Has(k) {
 			continue
 		}
-
-		seen[k] = struct{}{}
+		seen.Add(k)
 		filtered = append(filtered, l)
 	}
-
 	return filtered
 }
 
 func deduplicateLocations(locations []shared.Location) []shared.Location {
-	return deduplicate(locations, locationKey)
+	return deduplicateBy(locations, locationKey)
 }
 
 func locationKey(l shared.Location) string {

--- a/internal/codeintel/codenav/internal/lsifstore/scan.go
+++ b/internal/codeintel/codenav/internal/lsifstore/scan.go
@@ -161,7 +161,7 @@ func (s *store) scanDeduplicatedQualifiedMonikerLocations(rows *sql.Rows, queryE
 		}
 	}
 	for i := range values {
-		values[i].Locations = deduplicate(values[i].Locations, locationDataKey)
+		values[i].Locations = deduplicateBy(values[i].Locations, locationDataKey)
 	}
 
 	return values, nil

--- a/internal/codeintel/codenav/service_new.go
+++ b/internal/codeintel/codenav/service_new.go
@@ -1,8 +1,8 @@
 package codenav
 
 import (
+	"cmp"
 	"context"
-	"sort"
 	"strings"
 
 	"github.com/sourcegraph/scip/bindings/go/scip"
@@ -493,18 +493,15 @@ func (s *Service) prepareCandidateUploads(
 		if err != nil {
 			return Cursor{}, false, err
 		}
-		idMap := make(map[int]struct{}, len(uploads)+len(cursor.VisibleUploads))
+
+		idSet := collections.NewSet[int]()
 		for _, upload := range cursor.VisibleUploads {
-			idMap[upload.UploadID] = struct{}{}
+			idSet.Add(upload.UploadID)
 		}
 		for _, upload := range uploads {
-			idMap[upload.ID] = struct{}{}
+			idSet.Add(upload.ID)
 		}
-		ids := make([]int, 0, len(idMap))
-		for id := range idMap {
-			ids = append(ids, id)
-		}
-		sort.Ints(ids)
+		ids := idSet.Sorted(cmp.Less[int])
 
 		fallback = false
 		cursor.UploadIDs = ids


### PR DESCRIPTION
We have had this type around for a while, but a bunch of code still uses
`map[T]struct{}` which makes the code harder to read.

## Test plan

Covered by existing tests

## Changelog