### PR TITLE
chore: Rename Contains to IsSupersetOf

### DIFF
--- a/internal/collections/set.go
+++ b/internal/collections/set.go
@@ -83,8 +83,8 @@ func (s Set[T]) Intersect(b Set[T]) Set[T] {
 	return Intersection(s, b)
 }
 
-// Contains returns true if s has all the elements in b.
-func (s Set[T]) Contains(b Set[T]) bool {
+// IsSupersetOf returns true if s has all the elements in b.
+func (s Set[T]) IsSupersetOf(b Set[T]) bool {
 	// do not waste time on loop if b is bigger than s
 	if len(b) > len(s) {
 		return false

--- a/internal/collections/set_test.go
+++ b/internal/collections/set_test.go
@@ -65,16 +65,16 @@ func TestSet(t *testing.T) {
 		require.Equal(t, []int{1}, s.Values())
 	})
 
-	t.Run("Contains returns true if set contains the other set", func(t *testing.T) {
-		require.True(t, a.Contains(NewSet(1, 2)))
-		require.True(t, a.Contains(NewSet(1, 2, 3)))
-		require.False(t, a.Contains(b))
+	t.Run("IsSupersetOf returns true if set contains the other set", func(t *testing.T) {
+		require.True(t, a.IsSupersetOf(NewSet(1, 2)))
+		require.True(t, a.IsSupersetOf(NewSet(1, 2, 3)))
+		require.False(t, a.IsSupersetOf(b))
 
 		// set always contains self
-		require.True(t, a.Contains(a))
+		require.True(t, a.IsSupersetOf(a))
 
 		// empty set is always contained
-		require.True(t, a.Contains(NewSet[int]()))
+		require.True(t, a.IsSupersetOf(NewSet[int]()))
 	})
 
 	t.Run("Union creates a new set with all values from both sets", func(t *testing.T) {

--- a/internal/collections/set_test.go
+++ b/internal/collections/set_test.go
@@ -70,10 +70,10 @@ func TestSet(t *testing.T) {
 		require.True(t, a.IsSupersetOf(NewSet(1, 2, 3)))
 		require.False(t, a.IsSupersetOf(b))
 
-		// set always contains self
+		// a set is a superset of itself
 		require.True(t, a.IsSupersetOf(a))
 
-		// empty set is always contained
+		// a set is always the superset of an empty set
 		require.True(t, a.IsSupersetOf(NewSet[int]()))
 	})
 


### PR DESCRIPTION
The name Contains is also commonly used for checking if a
set contains an element in other languages, so it leads to
confusing auto-complete. Additionally, IsSupersetOf sounds
more expensive, which may be the case for this operation.

## Test plan

Covered by existing tests

## Changelog