### PR TITLE
feat(sg: add `list-build` subcommand to ci

### DIFF
--- a/dev/sg/ci/BUILD.bazel
+++ b/dev/sg/ci/BUILD.bazel
@@ -25,6 +25,7 @@ go_library(
         "//lib/cliutil/exit",
         "//lib/errors",
         "//lib/output",
+        "//lib/pointers",
         "@com_github_buildkite_go_buildkite_v3//buildkite",
         "@com_github_gen2brain_beeep//:beeep",
         "@com_github_google_uuid//:uuid",

--- a/dev/sg/ci/command.go
+++ b/dev/sg/ci/command.go
@@ -80,6 +80,7 @@ sg ci build --help
 		bazelCommand,
 		statusCommand,
 		buildCommand,
+		listBuildsCommand,
 		logsCommand,
 		docsCommand,
 		openCommand,

--- a/dev/sg/ci/subcommands.go
+++ b/dev/sg/ci/subcommands.go
@@ -391,7 +391,7 @@ var listBuildsCommand = &cli.Command{
 				}
 				commit := pointers.DerefZero(b.Commit)
 				if len(commit) > 12 {
-					commit = commit[:12] + "..."
+					commit = commit[:12]
 				}
 				std.Out.WriteLine(output.Styledf(output.StyleGrey, "%-8d%-10s%-25s%-16s%s", pointers.DerefZero(b.Number), pointers.DerefZero(b.State), author, commit, pointers.DerefZero(b.WebURL)))
 			}

--- a/dev/sg/internal/bk/bk.go
+++ b/dev/sg/internal/bk/bk.go
@@ -171,6 +171,18 @@ func (c *Client) ListArtifactsByJob(ctx context.Context, pipeline string, buildN
 	return artifacts, nil
 }
 
+// ListBuilds returns a list of all the builds for a given pipeline and a given status
+func (c *Client) ListBuilds(ctx context.Context, pipeline string, status string) ([]buildkite.Build, error) {
+	builds, _, err := c.bk.Builds.ListByPipeline(BuildkiteOrg, pipeline, &buildkite.BuildsListOptions{
+		State: []string{status},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return builds, nil
+}
+
 // DownloadArtifact downloads the Buildkite artifact into the provider io.Writer
 func (c *Client) DownloadArtifact(artifact buildkite.Artifact, w io.Writer) error {
 	url := artifact.DownloadURL


### PR DESCRIPTION
Add command to list builds in various states on a pipeline. This makes it ever so slightly for ops like scenarios like finding all running builds to cancel etc.

## Test plan
Tested locally
```
go run ./dev/sg ci list-builds --state 'running'
✅ Fetched 2 builds for "sourcegraph" pipeline
Pipeline: sourcegraph
Build   Status    Author                   Commit          Link
276911  running   William Bezuidenhout     9a8cc2303bd8... https://buildkite.com/sourcegraph/sourcegraph/builds/276911
276910  running   Greg Magolan             59be5e4415ff... https://buildkite.com/sourcegraph/sourcegraph/builds/276910
```


## Changelog
- add `list-builds` subcommand to sg to list builds in various states