### PR TITLE
fix(appliance): use version for image tags

### DIFF
--- a/internal/appliance/config/BUILD.bazel
+++ b/internal/appliance/config/BUILD.bazel
@@ -21,7 +21,6 @@ go_library(
     tags = [TAG_INFRA_RELEASE],
     visibility = ["//:__subpackages__"],
     deps = [
-        "//lib/errors",
         "//lib/pointers",
         "@io_k8s_api//core/v1:core",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:meta",

--- a/internal/appliance/config/defaults.go
+++ b/internal/appliance/config/defaults.go
@@ -3,7 +3,6 @@ package config
 import (
 	"fmt"
 
-	"github.com/sourcegraph/sourcegraph/lib/errors"
 	"github.com/sourcegraph/sourcegraph/lib/pointers"
 )
 
@@ -148,41 +147,6 @@ func NewDefaultConfig() Sourcegraph {
 	}
 }
 
-// Images
-
-// Map of version to map of service to image tag
-var defaultImages = map[string]map[string]string{
-	"5.3.9104": defaultImagesForVersion_5_3_9104,
-}
-
-var defaultImagesForVersion_5_3_9104 = map[string]string{
-	"alpine":                    "alpine-3.14:5.3.2@sha256:982220e0fd8ce55a73798fa7e814a482c4807c412f054c8440c5970b610239b7",
-	"blobstore":                 "blobstore:5.3.2@sha256:d625be1eefe61cc42f94498e3c588bf212c4159c8b20c519db84eae4ff715efa",
-	"cadvisor":                  "cadvisor:5.3.2@sha256:3860cce1f7ef0278c0d785f66baf69dd2bece19610a2fd6eaa54c03095f2f105",
-	"codeinsights-db":           "codeinsights-db:5.3.2@sha256:c4a1bd3908658e1c09558a638e378e5570d5f669d27f9f867eeda25fe60cb88f",
-	"codeintel-db":              "codeintel-db:5.3.2@sha256:1e0e93661a65c832b9697048c797f9894dfb502e2e1da2b8209f0018a6632b79",
-	"gitserver":                 "gitserver:5.3.2@sha256:6c6042cf3e5f3f16de9b82e3d4ab1647f8bb924cd315245bd7a3162f5489e8c4",
-	"pgsql":                     "postgres-12-alpine:5.3.2@sha256:1e0e93661a65c832b9697048c797f9894dfb502e2e1da2b8209f0018a6632b79",
-	"pgsql-exporter":            "postgres_exporter:5.3.2@sha256:b9fa66fbcb4cc2d466487259db4ae2deacd7651dac4a9e28c9c7fc36523699d0",
-	"precise-code-intel-worker": "precise-code-intel-worker:5.3.2@sha256:6142093097f5757afe772cffd131c1be54bb77335232011254733f51ffb2d6c6",
-	"prometheus":                "prometheus:5.3.2@sha256:1b5c003fb39628f79e7655ba33f9ca119ddc4be021602ede3cc1674ef99fcdad",
-	"redis-cache":               "redis-cache:5.3.2@sha256:ed79dada4d1a2bd85fb8450dffe227283ab6ae0e7ce56dc5056fbb8202d95624",
-	"redis-exporter":            "redis_exporter:5.3.2@sha256:21a9dd9214483a42b11d58bf99e4f268f44257a4f67acd436d458797a31b7786",
-	"redis-store":               "redis-store:5.3.2@sha256:0e3270a5eb293c158093f41145810eb5a154f61a74c9a896690dfdecd1b98b39",
-	"repo-updater":              "repo-updater:5.3.2@sha256:5a414aa030c7e0922700664a43b449ee5f3fafa68834abef93988c5992c747c6",
-	"symbols":                   "symbols:5.3.2@sha256:dd7f923bdbd5dbd231b749a7483110d40d59159084477b9fff84afaf58aad98e",
-	"syntect-server":            "syntax-highlighter:5.3.2@sha256:3d16ab2a0203fea85063dcfe2e9d476540ef3274c28881dc4bbd5ca77933d8e8",
-	"worker":                    "worker:5.3.2@sha256:776168bb53a0b094f51bfec3d0d38e2938a07bb840b665b645ccf2637f0e779f",
-}
-
-func GetDefaultImage(sg *Sourcegraph, component string) (string, error) {
-	images, ok := defaultImages[sg.Spec.RequestedVersion]
-	if !ok {
-		return "", errors.Newf("no default images found for version %s", sg.Spec.RequestedVersion)
-	}
-	image, ok := images[component]
-	if !ok {
-		return "", errors.Newf("no default image found for service %s", component)
-	}
-	return fmt.Sprintf("%s/%s", sg.Spec.ImageRepository, image), nil
+func GetDefaultImage(sg *Sourcegraph, component string) string {
+	return fmt.Sprintf("%s/%s:%s", sg.Spec.ImageRepository, component, sg.Spec.RequestedVersion)
 }

--- a/internal/appliance/reconciler/blobstore.go
+++ b/internal/appliance/reconciler/blobstore.go
@@ -69,7 +69,7 @@ func (r *Reconciler) reconcileBlobstoreServices(ctx context.Context, sg *config.
 	return reconcileObject(ctx, r, sg.Spec.Blobstore, &s, &corev1.Service{}, sg, owner)
 }
 
-func buildBlobstoreDeployment(sg *config.Sourcegraph) (appsv1.Deployment, error) {
+func buildBlobstoreDeployment(sg *config.Sourcegraph) appsv1.Deployment {
 	name := "blobstore"
 
 	containerPorts := []corev1.ContainerPort{{
@@ -88,10 +88,7 @@ func buildBlobstoreDeployment(sg *config.Sourcegraph) (appsv1.Deployment, error)
 		},
 	}
 
-	defaultImage, err := config.GetDefaultImage(sg, name)
-	if err != nil {
-		return appsv1.Deployment{}, err
-	}
+	defaultImage := config.GetDefaultImage(sg, name)
 	defaultContainer := container.NewContainer(name, sg.Spec.Blobstore, config.ContainerConfig{
 		Image: defaultImage,
 		Resources: &corev1.ResourceRequirements{
@@ -137,13 +134,10 @@ func buildBlobstoreDeployment(sg *config.Sourcegraph) (appsv1.Deployment, error)
 	)
 	defaultDeployment.Spec.Template = podTemplate.Template
 
-	return defaultDeployment, nil
+	return defaultDeployment
 }
 
 func (r *Reconciler) reconcileBlobstoreDeployments(ctx context.Context, sg *config.Sourcegraph, owner client.Object) error {
-	d, err := buildBlobstoreDeployment(sg)
-	if err != nil {
-		return err
-	}
+	d := buildBlobstoreDeployment(sg)
 	return reconcileObject(ctx, r, sg.Spec.Blobstore, &d, &appsv1.Deployment{}, sg, owner)
 }

--- a/internal/appliance/reconciler/cadvisor.go
+++ b/internal/appliance/reconciler/cadvisor.go
@@ -32,10 +32,7 @@ func (r *Reconciler) reconcileCadvisorDaemonset(ctx context.Context, sg *config.
 	name := "cadvisor"
 	cfg := sg.Spec.Cadvisor
 
-	defaultImage, err := config.GetDefaultImage(sg, name)
-	if err != nil {
-		return err
-	}
+	defaultImage := config.GetDefaultImage(sg, name)
 	ctr := container.NewContainer(name, cfg, config.ContainerConfig{
 		Image: defaultImage,
 		Resources: &corev1.ResourceRequirements{

--- a/internal/appliance/reconciler/codeinsights.go
+++ b/internal/appliance/reconciler/codeinsights.go
@@ -47,10 +47,7 @@ func (r *Reconciler) reconcileCodeInsightsStatefulSet(ctx context.Context, sg *c
 	cfg := sg.Spec.CodeInsights
 	name := "codeinsights-db"
 
-	ctrImage, err := config.GetDefaultImage(sg, name)
-	if err != nil {
-		return err
-	}
+	ctrImage := config.GetDefaultImage(sg, name)
 
 	ctr := container.NewContainer("codeinsights", cfg, config.ContainerConfig{
 		Image: ctrImage,
@@ -86,11 +83,7 @@ func (r *Reconciler) reconcileCodeInsightsStatefulSet(ctx context.Context, sg *c
 		{Name: "lockdir", MountPath: "/var/run/postgresql"},
 	}
 
-	initCtrImage, err := config.GetDefaultImage(sg, "alpine")
-	if err != nil {
-		return err
-	}
-
+	initCtrImage := config.GetDefaultImage(sg, "alpine-3.14")
 	initCtr := container.NewContainer("correct-data-dir-permissions", cfg, config.ContainerConfig{
 		Image: initCtrImage,
 		Resources: &corev1.ResourceRequirements{
@@ -113,11 +106,7 @@ func (r *Reconciler) reconcileCodeInsightsStatefulSet(ctx context.Context, sg *c
 	initCtr.VolumeMounts = []corev1.VolumeMount{{Name: "disk", MountPath: "/var/lib/postgresql/data"}}
 	initCtr.Command = []string{"sh", "-c", "if [ -d /var/lib/postgresql/data/pgdata ]; then chmod 750 /var/lib/postgresql/data/pgdata; fi"}
 
-	pgExpCtrImage, err := config.GetDefaultImage(sg, "pgsql-exporter")
-	if err != nil {
-		return err
-	}
-
+	pgExpCtrImage := config.GetDefaultImage(sg, "postgres_exporter")
 	pgExpCtr := container.NewContainer("pgsql-exporter", cfg, config.ContainerConfig{
 		Image: pgExpCtrImage,
 		Resources: &corev1.ResourceRequirements{

--- a/internal/appliance/reconciler/codeintel.go
+++ b/internal/appliance/reconciler/codeintel.go
@@ -47,10 +47,7 @@ func (r *Reconciler) reconcileCodeIntelStatefulSet(ctx context.Context, sg *conf
 	cfg := sg.Spec.CodeIntel
 	name := "codeintel-db"
 
-	ctrImage, err := config.GetDefaultImage(sg, name)
-	if err != nil {
-		return err
-	}
+	ctrImage := config.GetDefaultImage(sg, name)
 
 	ctr := container.NewContainer(name, cfg, config.ContainerConfig{
 		Image: ctrImage,
@@ -105,11 +102,7 @@ func (r *Reconciler) reconcileCodeIntelStatefulSet(ctx context.Context, sg *conf
 		{Name: "lockdir", MountPath: "/var/run/postgresql"},
 	}
 
-	initCtrImage, err := config.GetDefaultImage(sg, "alpine")
-	if err != nil {
-		return err
-	}
-
+	initCtrImage := config.GetDefaultImage(sg, "alpine-3.14")
 	initCtr := container.NewContainer("correct-data-dir-permissions", cfg, config.ContainerConfig{
 		Image: initCtrImage,
 		Resources: &corev1.ResourceRequirements{
@@ -132,11 +125,7 @@ func (r *Reconciler) reconcileCodeIntelStatefulSet(ctx context.Context, sg *conf
 	initCtr.VolumeMounts = []corev1.VolumeMount{{Name: "disk", MountPath: "/data"}}
 	initCtr.Command = []string{"sh", "-c", "if [ -d /data/pgdata-12 ]; then chmod 750 /data/pgdata-12; fi"}
 
-	pgExpCtrImage, err := config.GetDefaultImage(sg, "pgsql-exporter")
-	if err != nil {
-		return err
-	}
-
+	pgExpCtrImage := config.GetDefaultImage(sg, "postgres_exporter")
 	pgExpCtr := container.NewContainer("pgsql-exporter", cfg, config.ContainerConfig{
 		Image: pgExpCtrImage,
 		Resources: &corev1.ResourceRequirements{

--- a/internal/appliance/reconciler/gitserver.go
+++ b/internal/appliance/reconciler/gitserver.go
@@ -37,10 +37,7 @@ func (r *Reconciler) reconcileGitServerStatefulSet(ctx context.Context, sg *conf
 	cfg := sg.Spec.GitServer
 	name := "gitserver"
 
-	defaultImage, err := config.GetDefaultImage(sg, name)
-	if err != nil {
-		return err
-	}
+	defaultImage := config.GetDefaultImage(sg, name)
 	ctr := container.NewContainer(name, cfg, config.ContainerConfig{
 		Image: defaultImage,
 		Resources: &corev1.ResourceRequirements{

--- a/internal/appliance/reconciler/pgsql.go
+++ b/internal/appliance/reconciler/pgsql.go
@@ -47,11 +47,7 @@ func (r *Reconciler) reconcilePGSQLStatefulSet(ctx context.Context, sg *config.S
 	cfg := sg.Spec.PGSQL
 	name := "pgsql"
 
-	ctrImage, err := config.GetDefaultImage(sg, name)
-	if err != nil {
-		return err
-	}
-
+	ctrImage := config.GetDefaultImage(sg, "postgres-12-alpine")
 	ctr := container.NewContainer(name, cfg, config.ContainerConfig{
 		Image: ctrImage,
 		Resources: &corev1.ResourceRequirements{
@@ -106,11 +102,7 @@ func (r *Reconciler) reconcilePGSQLStatefulSet(ctx context.Context, sg *config.S
 		{Name: "lockdir", MountPath: "/var/run/postgresql"},
 	}
 
-	initCtrImage, err := config.GetDefaultImage(sg, "alpine")
-	if err != nil {
-		return err
-	}
-
+	initCtrImage := config.GetDefaultImage(sg, "alpine-3.14")
 	initCtr := container.NewContainer("correct-data-dir-permissions", cfg, config.ContainerConfig{
 		Image: initCtrImage,
 		Resources: &corev1.ResourceRequirements{
@@ -133,11 +125,7 @@ func (r *Reconciler) reconcilePGSQLStatefulSet(ctx context.Context, sg *config.S
 	initCtr.VolumeMounts = []corev1.VolumeMount{{Name: "disk", MountPath: "/data"}}
 	initCtr.Command = []string{"sh", "-c", "if [ -d /data/pgdata-12 ]; then chmod 750 /data/pgdata-12; fi"}
 
-	pgExpCtrImage, err := config.GetDefaultImage(sg, "pgsql-exporter")
-	if err != nil {
-		return err
-	}
-
+	pgExpCtrImage := config.GetDefaultImage(sg, "postgres_exporter")
 	pgExpCtr := container.NewContainer("pgsql-exporter", cfg, config.ContainerConfig{
 		Image: pgExpCtrImage,
 		Resources: &corev1.ResourceRequirements{

--- a/internal/appliance/reconciler/precise_code_intel.go
+++ b/internal/appliance/reconciler/precise_code_intel.go
@@ -37,10 +37,7 @@ func (r *Reconciler) reconcilePreciseCodeIntelDeployment(ctx context.Context, sg
 	name := "precise-code-intel-worker"
 	cfg := sg.Spec.PreciseCodeIntel
 
-	defaultImage, err := config.GetDefaultImage(sg, name)
-	if err != nil {
-		return err
-	}
+	defaultImage := config.GetDefaultImage(sg, name)
 	ctr := container.NewContainer(name, cfg, config.ContainerConfig{
 		Image: defaultImage,
 		Resources: &corev1.ResourceRequirements{

--- a/internal/appliance/reconciler/prometheus.go
+++ b/internal/appliance/reconciler/prometheus.go
@@ -62,10 +62,7 @@ func (r *Reconciler) reconcilePrometheusDeployment(ctx context.Context, sg *conf
 	name := "prometheus"
 	cfg := sg.Spec.Prometheus
 
-	defaultImage, err := config.GetDefaultImage(sg, name)
-	if err != nil {
-		return err
-	}
+	defaultImage := config.GetDefaultImage(sg, name)
 	ctr := container.NewContainer(name, cfg, config.ContainerConfig{
 		Image: defaultImage,
 		Resources: &corev1.ResourceRequirements{

--- a/internal/appliance/reconciler/redis.go
+++ b/internal/appliance/reconciler/redis.go
@@ -49,10 +49,7 @@ func (r *Reconciler) reconcileRedisInstance(ctx context.Context, sg *config.Sour
 func (r *Reconciler) reconcileRedisDeployment(ctx context.Context, sg *config.Sourcegraph, owner client.Object, kind string, cfg config.RedisSpec) error {
 	name := "redis-" + kind
 
-	defaultImage, err := config.GetDefaultImage(sg, name)
-	if err != nil {
-		return err
-	}
+	defaultImage := config.GetDefaultImage(sg, name)
 	ctr := container.NewContainer(name, cfg, config.ContainerConfig{
 		Image: defaultImage,
 		Resources: &corev1.ResourceRequirements{
@@ -109,10 +106,7 @@ fi
 	ctr.SecurityContext.RunAsUser = pointers.Ptr(int64(999))
 	ctr.SecurityContext.RunAsGroup = pointers.Ptr(int64(1000))
 
-	exporterImage, err := config.GetDefaultImage(sg, "redis-exporter")
-	if err != nil {
-		return err
-	}
+	exporterImage := config.GetDefaultImage(sg, "redis_exporter")
 	exporterCtr := container.NewContainer("redis-exporter", cfg, config.ContainerConfig{
 		Image: exporterImage,
 		Resources: &corev1.ResourceRequirements{

--- a/internal/appliance/reconciler/repo_updater.go
+++ b/internal/appliance/reconciler/repo_updater.go
@@ -46,10 +46,7 @@ func (r *Reconciler) reconcileRepoUpdaterDeployment(ctx context.Context, sg *con
 	cfg := sg.Spec.RepoUpdater
 	name := "repo-updater"
 
-	defaultImage, err := config.GetDefaultImage(sg, name)
-	if err != nil {
-		return err
-	}
+	defaultImage := config.GetDefaultImage(sg, name)
 	ctr := container.NewContainer(name, cfg, config.ContainerConfig{
 		Image: defaultImage,
 		Resources: &corev1.ResourceRequirements{

--- a/internal/appliance/reconciler/symbols.go
+++ b/internal/appliance/reconciler/symbols.go
@@ -38,10 +38,7 @@ func (r *Reconciler) reconcileSymbolsStatefulSet(ctx context.Context, sg *config
 	name := "symbols"
 	cfg := sg.Spec.Symbols
 
-	defaultImage, err := config.GetDefaultImage(sg, name)
-	if err != nil {
-		return err
-	}
+	defaultImage := config.GetDefaultImage(sg, name)
 	ctr := container.NewContainer(name, cfg, config.ContainerConfig{
 		Image: defaultImage,
 		Resources: &corev1.ResourceRequirements{

--- a/internal/appliance/reconciler/syntect.go
+++ b/internal/appliance/reconciler/syntect.go
@@ -36,10 +36,7 @@ func (r *Reconciler) reconcileSyntectDeployment(ctx context.Context, sg *config.
 	name := "syntect-server"
 	cfg := sg.Spec.SyntectServer
 
-	defaultImage, err := config.GetDefaultImage(sg, name)
-	if err != nil {
-		return err
-	}
+	defaultImage := config.GetDefaultImage(sg, "syntax-highlighter")
 	ctr := container.NewContainer(name, cfg, config.ContainerConfig{
 		Image: defaultImage,
 		Resources: &corev1.ResourceRequirements{

--- a/internal/appliance/reconciler/testdata/golden-fixtures/blobstore/default.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/blobstore/default.yaml
@@ -46,7 +46,7 @@ resources:
           name: blobstore
         spec:
           containers:
-            - image: index.docker.io/sourcegraph/blobstore:5.3.2@sha256:d625be1eefe61cc42f94498e3c588bf212c4159c8b20c519db84eae4ff715efa
+            - image: index.docker.io/sourcegraph/blobstore:5.3.9104
               imagePullPolicy: IfNotPresent
               name: blobstore
               ports:

--- a/internal/appliance/reconciler/testdata/golden-fixtures/cadvisor/default.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/cadvisor/default.yaml
@@ -45,7 +45,7 @@ resources:
             - args:
                 - --store_container_labels=false
                 - --whitelisted_container_labels=io.kubernetes.container.name,io.kubernetes.pod.name,io.kubernetes.pod.namespace,io.kubernetes.pod.uid
-              image: index.docker.io/sourcegraph/cadvisor:5.3.2@sha256:3860cce1f7ef0278c0d785f66baf69dd2bece19610a2fd6eaa54c03095f2f105
+              image: index.docker.io/sourcegraph/cadvisor:5.3.9104
               imagePullPolicy: IfNotPresent
               name: cadvisor
               ports:

--- a/internal/appliance/reconciler/testdata/golden-fixtures/codeinsights/default.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/codeinsights/default.yaml
@@ -77,7 +77,7 @@ resources:
                   value: /var/lib/postgresql/data/pgdata
                 - name: POSTGRESQL_CONF_DIR
                   value: /conf
-              image: index.docker.io/sourcegraph/codeinsights-db:5.3.2@sha256:c4a1bd3908658e1c09558a638e378e5570d5f669d27f9f867eeda25fe60cb88f
+              image: index.docker.io/sourcegraph/codeinsights-db:5.3.9104
               imagePullPolicy: IfNotPresent
               name: codeinsights
               ports:
@@ -130,7 +130,7 @@ resources:
                   value: 127.0.0.1:$(DATA_SOURCE_PORT)/$(DATA_SOURCE_DB)?sslmode=disable
                 - name: PG_EXPORTER_EXTEND_QUERY_PATH
                   value: /config/code_insights_queries.yaml
-              image: index.docker.io/sourcegraph/postgres_exporter:5.3.2@sha256:b9fa66fbcb4cc2d466487259db4ae2deacd7651dac4a9e28c9c7fc36523699d0
+              image: index.docker.io/sourcegraph/postgres_exporter:5.3.9104
               imagePullPolicy: IfNotPresent
               name: pgsql-exporter
               resources:
@@ -153,7 +153,7 @@ resources:
                 - sh
                 - -c
                 - if [ -d /var/lib/postgresql/data/pgdata ]; then chmod 750 /var/lib/postgresql/data/pgdata; fi
-              image: index.docker.io/sourcegraph/alpine-3.14:5.3.2@sha256:982220e0fd8ce55a73798fa7e814a482c4807c412f054c8440c5970b610239b7
+              image: index.docker.io/sourcegraph/alpine-3.14:5.3.9104
               imagePullPolicy: IfNotPresent
               name: correct-data-dir-permissions
               resources:

--- a/internal/appliance/reconciler/testdata/golden-fixtures/codeintel/default.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/codeintel/default.yaml
@@ -73,7 +73,7 @@ resources:
                       name: codeintel-db-auth
                 - name: POSTGRES_DB
                   value: $(POSTGRES_DATABASE)
-              image: index.docker.io/sourcegraph/codeintel-db:5.3.2@sha256:1e0e93661a65c832b9697048c797f9894dfb502e2e1da2b8209f0018a6632b79
+              image: index.docker.io/sourcegraph/codeintel-db:5.3.9104
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 exec:
@@ -151,7 +151,7 @@ resources:
                   value: 127.0.0.1:$(DATA_SOURCE_PORT)/$(DATA_SOURCE_DB)?sslmode=disable
                 - name: PG_EXPORTER_EXTEND_QUERY_PATH
                   value: /config/code_intel_queries.yaml
-              image: index.docker.io/sourcegraph/postgres_exporter:5.3.2@sha256:b9fa66fbcb4cc2d466487259db4ae2deacd7651dac4a9e28c9c7fc36523699d0
+              image: index.docker.io/sourcegraph/postgres_exporter:5.3.9104
               imagePullPolicy: IfNotPresent
               name: pgsql-exporter
               resources:
@@ -174,7 +174,7 @@ resources:
                 - sh
                 - -c
                 - if [ -d /data/pgdata-12 ]; then chmod 750 /data/pgdata-12; fi
-              image: index.docker.io/sourcegraph/alpine-3.14:5.3.2@sha256:982220e0fd8ce55a73798fa7e814a482c4807c412f054c8440c5970b610239b7
+              image: index.docker.io/sourcegraph/alpine-3.14:5.3.9104
               imagePullPolicy: IfNotPresent
               name: correct-data-dir-permissions
               resources:

--- a/internal/appliance/reconciler/testdata/golden-fixtures/gitserver/default.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/gitserver/default.yaml
@@ -65,7 +65,7 @@ resources:
                       fieldPath: status.hostIP
                 - name: OTEL_EXPORTER_OTLP_ENDPOINT
                   value: http://$(OTEL_AGENT_HOST):4317
-              image: index.docker.io/sourcegraph/gitserver:5.3.2@sha256:6c6042cf3e5f3f16de9b82e3d4ab1647f8bb924cd315245bd7a3162f5489e8c4
+              image: index.docker.io/sourcegraph/gitserver:5.3.9104
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 failureThreshold: 3

--- a/internal/appliance/reconciler/testdata/golden-fixtures/pgsql/default.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/pgsql/default.yaml
@@ -73,7 +73,7 @@ resources:
                       name: pgsql-auth
                 - name: POSTGRES_DB
                   value: $(POSTGRES_DATABASE)
-              image: index.docker.io/sourcegraph/postgres-12-alpine:5.3.2@sha256:1e0e93661a65c832b9697048c797f9894dfb502e2e1da2b8209f0018a6632b79
+              image: index.docker.io/sourcegraph/postgres-12-alpine:5.3.9104
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 exec:
@@ -153,7 +153,7 @@ resources:
                   value: 127.0.0.1:$(DATA_SOURCE_PORT)/$(DATA_SOURCE_DB)?sslmode=disable
                 - name: PG_EXPORTER_EXTEND_QUERY_PATH
                   value: /config/queries.yaml
-              image: index.docker.io/sourcegraph/postgres_exporter:5.3.2@sha256:b9fa66fbcb4cc2d466487259db4ae2deacd7651dac4a9e28c9c7fc36523699d0
+              image: index.docker.io/sourcegraph/postgres_exporter:5.3.9104
               imagePullPolicy: IfNotPresent
               name: pgsql-exporter
               resources:
@@ -176,7 +176,7 @@ resources:
                 - sh
                 - -c
                 - if [ -d /data/pgdata-12 ]; then chmod 750 /data/pgdata-12; fi
-              image: index.docker.io/sourcegraph/alpine-3.14:5.3.2@sha256:982220e0fd8ce55a73798fa7e814a482c4807c412f054c8440c5970b610239b7
+              image: index.docker.io/sourcegraph/alpine-3.14:5.3.9104
               imagePullPolicy: IfNotPresent
               name: correct-data-dir-permissions
               resources:

--- a/internal/appliance/reconciler/testdata/golden-fixtures/precise-code-intel/default.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/precise-code-intel/default.yaml
@@ -61,7 +61,7 @@ resources:
                       fieldPath: status.hostIP
                 - name: OTEL_EXPORTER_OTLP_ENDPOINT
                   value: http://$(OTEL_AGENT_HOST):4317
-              image: index.docker.io/sourcegraph/precise-code-intel-worker:5.3.2@sha256:6142093097f5757afe772cffd131c1be54bb77335232011254733f51ffb2d6c6
+              image: index.docker.io/sourcegraph/precise-code-intel-worker:5.3.9104
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 failureThreshold: 3

--- a/internal/appliance/reconciler/testdata/golden-fixtures/precise-code-intel/with-blobstore.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/precise-code-intel/with-blobstore.yaml
@@ -46,7 +46,7 @@ resources:
           name: blobstore
         spec:
           containers:
-            - image: index.docker.io/sourcegraph/blobstore:5.3.2@sha256:d625be1eefe61cc42f94498e3c588bf212c4159c8b20c519db84eae4ff715efa
+            - image: index.docker.io/sourcegraph/blobstore:5.3.9104
               imagePullPolicy: IfNotPresent
               name: blobstore
               ports:
@@ -154,7 +154,7 @@ resources:
                       fieldPath: status.hostIP
                 - name: OTEL_EXPORTER_OTLP_ENDPOINT
                   value: http://$(OTEL_AGENT_HOST):4317
-              image: index.docker.io/sourcegraph/precise-code-intel-worker:5.3.2@sha256:6142093097f5757afe772cffd131c1be54bb77335232011254733f51ffb2d6c6
+              image: index.docker.io/sourcegraph/precise-code-intel-worker:5.3.9104
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 failureThreshold: 3

--- a/internal/appliance/reconciler/testdata/golden-fixtures/precise-code-intel/with-num-workers.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/precise-code-intel/with-num-workers.yaml
@@ -61,7 +61,7 @@ resources:
                       fieldPath: status.hostIP
                 - name: OTEL_EXPORTER_OTLP_ENDPOINT
                   value: http://$(OTEL_AGENT_HOST):4317
-              image: index.docker.io/sourcegraph/precise-code-intel-worker:5.3.2@sha256:6142093097f5757afe772cffd131c1be54bb77335232011254733f51ffb2d6c6
+              image: index.docker.io/sourcegraph/precise-code-intel-worker:5.3.9104
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 failureThreshold: 3

--- a/internal/appliance/reconciler/testdata/golden-fixtures/precise-code-intel/with-replicas.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/precise-code-intel/with-replicas.yaml
@@ -61,7 +61,7 @@ resources:
                       fieldPath: status.hostIP
                 - name: OTEL_EXPORTER_OTLP_ENDPOINT
                   value: http://$(OTEL_AGENT_HOST):4317
-              image: index.docker.io/sourcegraph/precise-code-intel-worker:5.3.2@sha256:6142093097f5757afe772cffd131c1be54bb77335232011254733f51ffb2d6c6
+              image: index.docker.io/sourcegraph/precise-code-intel-worker:5.3.9104
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 failureThreshold: 3

--- a/internal/appliance/reconciler/testdata/golden-fixtures/prometheus/default.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/prometheus/default.yaml
@@ -43,7 +43,7 @@ resources:
           name: prometheus
         spec:
           containers:
-            - image: index.docker.io/sourcegraph/prometheus:5.3.2@sha256:1b5c003fb39628f79e7655ba33f9ca119ddc4be021602ede3cc1674ef99fcdad
+            - image: index.docker.io/sourcegraph/prometheus:5.3.9104
               imagePullPolicy: IfNotPresent
               name: prometheus
               ports:

--- a/internal/appliance/reconciler/testdata/golden-fixtures/prometheus/privileged.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/prometheus/privileged.yaml
@@ -43,7 +43,7 @@ resources:
           name: prometheus
         spec:
           containers:
-            - image: index.docker.io/sourcegraph/prometheus:5.3.2@sha256:1b5c003fb39628f79e7655ba33f9ca119ddc4be021602ede3cc1674ef99fcdad
+            - image: index.docker.io/sourcegraph/prometheus:5.3.9104
               imagePullPolicy: IfNotPresent
               name: prometheus
               ports:

--- a/internal/appliance/reconciler/testdata/golden-fixtures/prometheus/with-existing-configmap.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/prometheus/with-existing-configmap.yaml
@@ -43,7 +43,7 @@ resources:
           name: prometheus
         spec:
           containers:
-            - image: index.docker.io/sourcegraph/prometheus:5.3.2@sha256:1b5c003fb39628f79e7655ba33f9ca119ddc4be021602ede3cc1674ef99fcdad
+            - image: index.docker.io/sourcegraph/prometheus:5.3.9104
               imagePullPolicy: IfNotPresent
               name: prometheus
               ports:

--- a/internal/appliance/reconciler/testdata/golden-fixtures/redis/default.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/redis/default.yaml
@@ -43,7 +43,7 @@ resources:
           name: redis-cache
         spec:
           containers:
-            - image: index.docker.io/sourcegraph/redis-cache:5.3.2@sha256:ed79dada4d1a2bd85fb8450dffe227283ab6ae0e7ce56dc5056fbb8202d95624
+            - image: index.docker.io/sourcegraph/redis-cache:5.3.9104
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 failureThreshold: 2
@@ -97,7 +97,7 @@ resources:
               volumeMounts:
                 - mountPath: /redis-data
                   name: redis-data
-            - image: index.docker.io/sourcegraph/redis_exporter:5.3.2@sha256:21a9dd9214483a42b11d58bf99e4f268f44257a4f67acd436d458797a31b7786
+            - image: index.docker.io/sourcegraph/redis_exporter:5.3.9104
               imagePullPolicy: IfNotPresent
               name: redis-exporter
               ports:
@@ -176,7 +176,7 @@ resources:
           name: redis-store
         spec:
           containers:
-            - image: index.docker.io/sourcegraph/redis-store:5.3.2@sha256:0e3270a5eb293c158093f41145810eb5a154f61a74c9a896690dfdecd1b98b39
+            - image: index.docker.io/sourcegraph/redis-store:5.3.9104
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 failureThreshold: 2
@@ -230,7 +230,7 @@ resources:
               volumeMounts:
                 - mountPath: /redis-data
                   name: redis-data
-            - image: index.docker.io/sourcegraph/redis_exporter:5.3.2@sha256:21a9dd9214483a42b11d58bf99e4f268f44257a4f67acd436d458797a31b7786
+            - image: index.docker.io/sourcegraph/redis_exporter:5.3.9104
               imagePullPolicy: IfNotPresent
               name: redis-exporter
               ports:

--- a/internal/appliance/reconciler/testdata/golden-fixtures/repo-updater/default.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/repo-updater/default.yaml
@@ -64,7 +64,7 @@ resources:
                       fieldPath: status.hostIP
                 - name: OTEL_EXPORTER_OTLP_ENDPOINT
                   value: http://$(OTEL_AGENT_HOST):4317
-              image: index.docker.io/sourcegraph/repo-updater:5.3.2@sha256:5a414aa030c7e0922700664a43b449ee5f3fafa68834abef93988c5992c747c6
+              image: index.docker.io/sourcegraph/repo-updater:5.3.9104
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 failureThreshold: 3

--- a/internal/appliance/reconciler/testdata/golden-fixtures/standard/blobstore-with-named-storage-class.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/standard/blobstore-with-named-storage-class.yaml
@@ -46,7 +46,7 @@ resources:
           name: blobstore
         spec:
           containers:
-            - image: index.docker.io/sourcegraph/blobstore:5.3.2@sha256:d625be1eefe61cc42f94498e3c588bf212c4159c8b20c519db84eae4ff715efa
+            - image: index.docker.io/sourcegraph/blobstore:5.3.9104
               imagePullPolicy: IfNotPresent
               name: blobstore
               ports:

--- a/internal/appliance/reconciler/testdata/golden-fixtures/standard/precise-code-intel-with-env-vars.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/standard/precise-code-intel-with-env-vars.yaml
@@ -65,7 +65,7 @@ resources:
                       fieldPath: status.hostIP
                 - name: OTEL_EXPORTER_OTLP_ENDPOINT
                   value: http://$(OTEL_AGENT_HOST):4317
-              image: index.docker.io/sourcegraph/precise-code-intel-worker:5.3.2@sha256:6142093097f5757afe772cffd131c1be54bb77335232011254733f51ffb2d6c6
+              image: index.docker.io/sourcegraph/precise-code-intel-worker:5.3.9104
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 failureThreshold: 3

--- a/internal/appliance/reconciler/testdata/golden-fixtures/standard/redis-with-storage.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/standard/redis-with-storage.yaml
@@ -43,7 +43,7 @@ resources:
           name: redis-cache
         spec:
           containers:
-            - image: index.docker.io/sourcegraph/redis-cache:5.3.2@sha256:ed79dada4d1a2bd85fb8450dffe227283ab6ae0e7ce56dc5056fbb8202d95624
+            - image: index.docker.io/sourcegraph/redis-cache:5.3.9104
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 failureThreshold: 2
@@ -97,7 +97,7 @@ resources:
               volumeMounts:
                 - mountPath: /redis-data
                   name: redis-data
-            - image: index.docker.io/sourcegraph/redis_exporter:5.3.2@sha256:21a9dd9214483a42b11d58bf99e4f268f44257a4f67acd436d458797a31b7786
+            - image: index.docker.io/sourcegraph/redis_exporter:5.3.9104
               imagePullPolicy: IfNotPresent
               name: redis-exporter
               ports:
@@ -176,7 +176,7 @@ resources:
           name: redis-store
         spec:
           containers:
-            - image: index.docker.io/sourcegraph/redis-store:5.3.2@sha256:0e3270a5eb293c158093f41145810eb5a154f61a74c9a896690dfdecd1b98b39
+            - image: index.docker.io/sourcegraph/redis-store:5.3.9104
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 failureThreshold: 2
@@ -230,7 +230,7 @@ resources:
               volumeMounts:
                 - mountPath: /redis-data
                   name: redis-data
-            - image: index.docker.io/sourcegraph/redis_exporter:5.3.2@sha256:21a9dd9214483a42b11d58bf99e4f268f44257a4f67acd436d458797a31b7786
+            - image: index.docker.io/sourcegraph/redis_exporter:5.3.9104
               imagePullPolicy: IfNotPresent
               name: redis-exporter
               ports:

--- a/internal/appliance/reconciler/testdata/golden-fixtures/standard/repo-updater-with-no-resources.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/standard/repo-updater-with-no-resources.yaml
@@ -64,7 +64,7 @@ resources:
                       fieldPath: status.hostIP
                 - name: OTEL_EXPORTER_OTLP_ENDPOINT
                   value: http://$(OTEL_AGENT_HOST):4317
-              image: index.docker.io/sourcegraph/repo-updater:5.3.2@sha256:5a414aa030c7e0922700664a43b449ee5f3fafa68834abef93988c5992c747c6
+              image: index.docker.io/sourcegraph/repo-updater:5.3.9104
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 failureThreshold: 3

--- a/internal/appliance/reconciler/testdata/golden-fixtures/standard/repo-updater-with-pod-template-config.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/standard/repo-updater-with-pod-template-config.yaml
@@ -73,7 +73,7 @@ resources:
                       fieldPath: status.hostIP
                 - name: OTEL_EXPORTER_OTLP_ENDPOINT
                   value: http://$(OTEL_AGENT_HOST):4317
-              image: index.docker.io/sourcegraph/repo-updater:5.3.2@sha256:5a414aa030c7e0922700664a43b449ee5f3fafa68834abef93988c5992c747c6
+              image: index.docker.io/sourcegraph/repo-updater:5.3.9104
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 failureThreshold: 3

--- a/internal/appliance/reconciler/testdata/golden-fixtures/standard/repo-updater-with-resources.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/standard/repo-updater-with-resources.yaml
@@ -64,7 +64,7 @@ resources:
                       fieldPath: status.hostIP
                 - name: OTEL_EXPORTER_OTLP_ENDPOINT
                   value: http://$(OTEL_AGENT_HOST):4317
-              image: index.docker.io/sourcegraph/repo-updater:5.3.2@sha256:5a414aa030c7e0922700664a43b449ee5f3fafa68834abef93988c5992c747c6
+              image: index.docker.io/sourcegraph/repo-updater:5.3.9104
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 failureThreshold: 3

--- a/internal/appliance/reconciler/testdata/golden-fixtures/standard/repo-updater-with-sa-annotations.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/standard/repo-updater-with-sa-annotations.yaml
@@ -64,7 +64,7 @@ resources:
                       fieldPath: status.hostIP
                 - name: OTEL_EXPORTER_OTLP_ENDPOINT
                   value: http://$(OTEL_AGENT_HOST):4317
-              image: index.docker.io/sourcegraph/repo-updater:5.3.2@sha256:5a414aa030c7e0922700664a43b449ee5f3fafa68834abef93988c5992c747c6
+              image: index.docker.io/sourcegraph/repo-updater:5.3.9104
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 failureThreshold: 3

--- a/internal/appliance/reconciler/testdata/golden-fixtures/symbols/default.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/symbols/default.yaml
@@ -74,7 +74,7 @@ resources:
                       fieldPath: status.hostIP
                 - name: OTEL_EXPORTER_OTLP_ENDPOINT
                   value: http://$(OTEL_AGENT_HOST):4317
-              image: index.docker.io/sourcegraph/symbols:5.3.2@sha256:dd7f923bdbd5dbd231b749a7483110d40d59159084477b9fff84afaf58aad98e
+              image: index.docker.io/sourcegraph/symbols:5.3.9104
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 failureThreshold: 3

--- a/internal/appliance/reconciler/testdata/golden-fixtures/symbols/with-storage.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/symbols/with-storage.yaml
@@ -74,7 +74,7 @@ resources:
                       fieldPath: status.hostIP
                 - name: OTEL_EXPORTER_OTLP_ENDPOINT
                   value: http://$(OTEL_AGENT_HOST):4317
-              image: index.docker.io/sourcegraph/symbols:5.3.2@sha256:dd7f923bdbd5dbd231b749a7483110d40d59159084477b9fff84afaf58aad98e
+              image: index.docker.io/sourcegraph/symbols:5.3.9104
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 failureThreshold: 3

--- a/internal/appliance/reconciler/testdata/golden-fixtures/syntect/default.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/syntect/default.yaml
@@ -46,7 +46,7 @@ resources:
           name: syntect-server
         spec:
           containers:
-            - image: index.docker.io/sourcegraph/syntax-highlighter:5.3.2@sha256:3d16ab2a0203fea85063dcfe2e9d476540ef3274c28881dc4bbd5ca77933d8e8
+            - image: index.docker.io/sourcegraph/syntax-highlighter:5.3.9104
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 failureThreshold: 3

--- a/internal/appliance/reconciler/testdata/golden-fixtures/syntect/with-replicas.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/syntect/with-replicas.yaml
@@ -46,7 +46,7 @@ resources:
           name: syntect-server
         spec:
           containers:
-            - image: index.docker.io/sourcegraph/syntax-highlighter:5.3.2@sha256:3d16ab2a0203fea85063dcfe2e9d476540ef3274c28881dc4bbd5ca77933d8e8
+            - image: index.docker.io/sourcegraph/syntax-highlighter:5.3.9104
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 failureThreshold: 3

--- a/internal/appliance/reconciler/testdata/golden-fixtures/worker/default.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/worker/default.yaml
@@ -69,7 +69,7 @@ resources:
                       fieldPath: status.hostIP
                 - name: OTEL_EXPORTER_OTLP_ENDPOINT
                   value: http://$(OTEL_AGENT_HOST):4317
-              image: index.docker.io/sourcegraph/worker:5.3.2@sha256:776168bb53a0b094f51bfec3d0d38e2938a07bb840b665b645ccf2637f0e779f
+              image: index.docker.io/sourcegraph/worker:5.3.9104
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 failureThreshold: 3

--- a/internal/appliance/reconciler/testdata/golden-fixtures/worker/with-blobstore-and-embeddings.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/worker/with-blobstore-and-embeddings.yaml
@@ -46,7 +46,7 @@ resources:
           name: blobstore
         spec:
           containers:
-            - image: index.docker.io/sourcegraph/blobstore:5.3.2@sha256:d625be1eefe61cc42f94498e3c588bf212c4159c8b20c519db84eae4ff715efa
+            - image: index.docker.io/sourcegraph/blobstore:5.3.9104
               imagePullPolicy: IfNotPresent
               name: blobstore
               ports:
@@ -166,7 +166,7 @@ resources:
                       fieldPath: status.hostIP
                 - name: OTEL_EXPORTER_OTLP_ENDPOINT
                   value: http://$(OTEL_AGENT_HOST):4317
-              image: index.docker.io/sourcegraph/worker:5.3.2@sha256:776168bb53a0b094f51bfec3d0d38e2938a07bb840b665b645ccf2637f0e779f
+              image: index.docker.io/sourcegraph/worker:5.3.9104
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 failureThreshold: 3

--- a/internal/appliance/reconciler/testdata/golden-fixtures/worker/with-blobstore.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/worker/with-blobstore.yaml
@@ -46,7 +46,7 @@ resources:
           name: blobstore
         spec:
           containers:
-            - image: index.docker.io/sourcegraph/blobstore:5.3.2@sha256:d625be1eefe61cc42f94498e3c588bf212c4159c8b20c519db84eae4ff715efa
+            - image: index.docker.io/sourcegraph/blobstore:5.3.9104
               imagePullPolicy: IfNotPresent
               name: blobstore
               ports:
@@ -162,7 +162,7 @@ resources:
                       fieldPath: status.hostIP
                 - name: OTEL_EXPORTER_OTLP_ENDPOINT
                   value: http://$(OTEL_AGENT_HOST):4317
-              image: index.docker.io/sourcegraph/worker:5.3.2@sha256:776168bb53a0b094f51bfec3d0d38e2938a07bb840b665b645ccf2637f0e779f
+              image: index.docker.io/sourcegraph/worker:5.3.9104
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 failureThreshold: 3

--- a/internal/appliance/reconciler/testdata/golden-fixtures/worker/with-replicas.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/worker/with-replicas.yaml
@@ -69,7 +69,7 @@ resources:
                       fieldPath: status.hostIP
                 - name: OTEL_EXPORTER_OTLP_ENDPOINT
                   value: http://$(OTEL_AGENT_HOST):4317
-              image: index.docker.io/sourcegraph/worker:5.3.2@sha256:776168bb53a0b094f51bfec3d0d38e2938a07bb840b665b645ccf2637f0e779f
+              image: index.docker.io/sourcegraph/worker:5.3.9104
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 failureThreshold: 3

--- a/internal/appliance/reconciler/worker.go
+++ b/internal/appliance/reconciler/worker.go
@@ -39,10 +39,7 @@ func (r *Reconciler) reconcileWorkerDeployment(ctx context.Context, sg *config.S
 	name := "worker"
 	cfg := sg.Spec.Worker
 
-	defaultImage, err := config.GetDefaultImage(sg, name)
-	if err != nil {
-		return err
-	}
+	defaultImage := config.GetDefaultImage(sg, name)
 	ctr := container.NewContainer(name, cfg, config.ContainerConfig{
 		Image: defaultImage,
 		Resources: &corev1.ResourceRequirements{


### PR DESCRIPTION
Simultaneously fix a bug in the (still unreleased) appliance and change approach to container image metadata. The appliance used to maintain a map of versions to image-tags. The only version hardcoded for the still-in-development appliance was 5.3.9104, since that was the latest at the time development started. These versions were set to 5.3.2, which is incorrect. These versions were obtained from looking at the main branch of deploy-sourcegraph-helm, instead of the relevant release branch.

The change in approach is to stop including the optional sha256 digest of the image in the appliance-generated config. We considered several approaches in
https://linear.app/sourcegraph/issue/REL-22/spike-sketch-out-how-appliance-developers-will-handle-upgrades, please see that issue for more context.

It appears simpler to statelessly determine the image tag (as being equal to the release version string) rather than add moving parts such as calling the release registry, or building a 2-phase release system to bake image checksums into the appliance once they are known post-build. These options introduce complexity and greater possibility of errors than just asking for a version.

Closes
https://linear.app/sourcegraph/issue/REL-135/appliance-knows-what-images-to-pull-for-a-given-release.

<!-- 💡 To write a useful PR description, make sure that your description covers:
- WHAT this PR is changing:
    - How was it PREVIOUSLY.
    - How it will be from NOW on.
- WHY this PR is needed.
- CONTEXT, i.e. to which initiative, project or RFC it belongs.

The structure of the description doesn't matter as much as covering these points, so use
your best judgement based on your context.
Learn how to write good pull request description: https://www.notion.so/sourcegraph/Write-a-good-pull-request-description-610a7fd3e613496eb76f450db5a49b6e?pvs=4 -->


## Test plan

Golden tests included.

<!-- All pull requests REQUIRE a test plan: https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles -->


## Changelog

<!--
1. Ensure your pull request title is formatted as: $type($domain): $what
2. Add bullet list items for each additional detail you want to cover (see example below)
3. You can edit this after the pull request was merged, as long as release shipping it hasn't been promoted to the public.
4. For more information, please see this how-to https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c?

Audience: TS/CSE > Customers > Teammates (in that order).

Cheat sheet: $type = chore|fix|feat $domain: source|search|ci|release|plg|cody|local|...
-->

<!--
Example:

Title: fix(search): parse quotes with the appropriate context
Changelog section:

## Changelog

- When a quote is used with regexp pattern type, then ...
- Refactored underlying code.
-->

- Appliance uses requested version as image tag, instead of requiring sha256 digests.
