### PR TITLE
sg: add command to fetch versions from release registry

### DIFF
--- a/dev/sg/internal/release/BUILD.bazel
+++ b/dev/sg/internal/release/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "cut.go",
         "cve.go",
         "release.go",
+        "release_registry.go",
     ],
     importpath = "github.com/sourcegraph/sourcegraph/dev/sg/internal/release",
     tags = [TAG_INFRA_RELEASE],

--- a/dev/sg/internal/release/release.go
+++ b/dev/sg/internal/release/release.go
@@ -218,6 +218,7 @@ var Command = &cli.Command{
 				},
 			},
 		},
+		registryCommand,
 	},
 }
 

--- a/dev/sg/internal/release/release_registry.go
+++ b/dev/sg/internal/release/release_registry.go
@@ -1,0 +1,129 @@
+package release
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"os"
+	"time"
+
+	"github.com/urfave/cli/v2"
+
+	"github.com/sourcegraph/sourcegraph/dev/sg/internal/category"
+	"github.com/sourcegraph/sourcegraph/dev/sg/internal/std"
+	"github.com/sourcegraph/sourcegraph/lib/output"
+)
+
+const releaseRegistryEndpoint = "https://releaseregistry.sourcegraph.com/v1/"
+
+type RegistryVersion struct {
+	ID            int32      `json:"id"`
+	Name          string     `json:"name"`
+	Public        bool       `json:"public"`
+	CreatedAt     time.Time  `json:"created_at"`
+	PromotedAt    *time.Time `json:"promoted_at"`
+	Version       string     `json:"version"`
+	GitSHA        string     `json:"git_sha"`
+	IsDevelopment bool       `json:"is_development"`
+}
+
+type releaseRegistryClient struct {
+	endpoint string
+	client   http.Client
+}
+
+func newReleaseRegistryClient(endpoint string) *releaseRegistryClient {
+	return &releaseRegistryClient{
+		endpoint: endpoint,
+		client:   http.Client{},
+	}
+}
+
+func (r *releaseRegistryClient) newRequest(method, path string) (*http.Request, error) {
+	urlPath, err := url.JoinPath(r.endpoint, path)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(method, urlPath, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/json")
+	return req, nil
+}
+
+func (r *releaseRegistryClient) ListVersions(ctx context.Context) ([]RegistryVersion, error) {
+	req, err := r.newRequest(http.MethodGet, "releases")
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := r.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	results := []RegistryVersion{}
+
+	err = json.NewDecoder(resp.Body).Decode(&results)
+	if err != nil {
+		return nil, err
+	}
+
+	return results, nil
+}
+
+var registryCommand = &cli.Command{
+	Name:      "registry",
+	Usage:     "set of commands to interact with the release registry",
+	Category:  category.Util,
+	UsageText: "sg release registry [subcommand]",
+	Subcommands: []*cli.Command{
+		{
+			Name:      "list",
+			Usage:     "list versions in the release",
+			Category:  category.Util,
+			UsageText: "sg release registry list <flags>",
+			Action:    listRegistryVersions,
+			Flags: []cli.Flag{
+				&cli.StringFlag{
+					Name:  "format",
+					Usage: "output the list of versions in 'json' or 'terminal' format",
+					Value: "terminal",
+				},
+			},
+		},
+	},
+}
+
+func listRegistryVersions(cmd *cli.Context) error {
+	client := newReleaseRegistryClient(releaseRegistryEndpoint)
+
+	out := std.NewOutput(os.Stderr, false)
+	pending := out.Pending(output.Line("", output.StylePending, "Fetching versions from the release registry..."))
+	versions, err := client.ListVersions(cmd.Context)
+	if err != nil {
+		pending.Complete(output.Linef(output.EmojiFailure, output.StyleFailure, "Failed to fetch versions from release registry"))
+		return err
+	}
+	pending.Complete(output.Linef(output.EmojiSuccess, output.StyleSuccess, "Fetched %d versions from release registry", len(versions)))
+
+	switch cmd.String("format") {
+	case "json":
+		json.NewEncoder(os.Stdout).Encode(versions)
+	default:
+		std.Out.WriteLine(output.Linef("", output.StyleBold, "%-4s%-20s%-12s%-23s%s", "ID", "Product", "Version", "Created", "SHA"))
+		for _, v := range versions {
+			productName := v.Name
+			if len(productName) > 20 {
+				productName = productName[:17] + "..."
+			}
+			std.Out.WriteLine(output.Linef("", output.StyleGrey, "%-4d%-20s%-12s%-23s%s", v.ID, productName, v.Version, v.CreatedAt.Format(time.RFC3339), v.GitSHA))
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
Added a small command to fetch a list of versions from the release registry

- Output the list of versions with some cherry picked information
- Allow one to output the list in json and since the _fancy_ stuff printed on stderr you can `sg release registry list --format json | jq '.[] | .version`

## Test plan
Tested locally
```
go run ./dev/sg release registry list
✅ Fetched 31 versions from release registry
ID  Product             Version     Created                SHA
42  docker              v5.4.4217   2024-06-01T00:06:23Z   8826b10639682f465d365f7957a0f71014135dce
41  sourcegraph         v5.4.4217   2024-05-31T23:20:01Z   21cfcfea8dcf31d2a2a9c39d67c1e154a8c0e6c9
40  sourcegraph         v5.4.3842   2024-05-29T21:04:17Z   17a5fdb1d280ffe99f352a05967dbb89a09d692e
39  k8s                 v5.4.3643   2024-05-28T19:18:40Z   322774df4f817237eb57b006a790a09090e72a24
38  docker              v5.4.3643   2024-05-28T19:17:50Z   11fb53c977c6afa247ae1d7a954446eb6fce4a89
36  helm                v5.4.3643   2024-05-28T19:08:47Z   2db46988852c5381632279238886454ba8f65ae0
35  deploy-sourcegraph  v5.4.3643   2024-05-28T19:06:15Z   41f05b684a0e6d3a22143611f48e47a598993bb0
33  sourcegraph         v5.4.3643   2024-05-28T18:59:10Z   3083588ca5a94bad8ff816c1beab3232b7777bca
```
Filtering
```
sg release registry list --format json | jq '.[] | .version'
Fetching versions from the release registry......
✅ Fetched 31 versions from release registry
"v5.4.4217"
"v5.4.4217"
"v5.4.3842"
"v5.4.3643"
````


## Changelog
- add `sg release registry list` to list versions from the release registry
