### PR TITLE
Svelte: fix editor button styling

### DIFF
--- a/client/web-sveltekit/src/lib/repo/open-in-editor/OpenInEditor.svelte
+++ b/client/web-sveltekit/src/lib/repo/open-in-editor/OpenInEditor.svelte
@@ -81,7 +81,7 @@
         {#if editor}
             <Tooltip tooltip={`Open in ${editor.name}`}>
                 <a
-                    class="action-href"
+                    class="action"
                     href={buildEditorUrl(
                         buildRepoBaseNameAndPath(repoName, externalServiceType, filePath),
                         start,
@@ -101,10 +101,10 @@
 {:else if editorSettingsErrorMessage}
     <Popover let:registerTrigger let:toggle placement="left-start">
         <Tooltip tooltip="Set your preferred editor">
-            <span use:registerTrigger on:click={() => toggle()}>
+            <button class="action" use:registerTrigger on:click={() => toggle()}>
                 <DefaultEditorIcon />
-                <span data-action-label> Editor </span>
-            </span>
+                <span data-action-label>Editor</span>
+            </button>
         </Tooltip>
         <div slot="content" class="open-in-editor-popover">
             <form on:submit={handleEditorUpdate} novalidate>
@@ -159,7 +159,9 @@
 {/if}
 
 <style lang="scss">
-    .action-href {
+    .action {
+        all: unset;
+
         display: flex;
         align-items: center;
         justify-content: center;
@@ -167,6 +169,7 @@
         color: var(--text-body);
         text-decoration: none;
         white-space: nowrap;
+        cursor: pointer;
 
         &:hover {
             color: var(--text-title);
@@ -178,10 +181,6 @@
         width: 25rem;
         padding: 1.25rem 1rem;
         background-color: var(--color-bg-1);
-    }
-
-    .form-label {
-        font-weight: 500;
     }
 
     .form-input {


### PR DESCRIPTION
The editor button would wrap before the div would overflow, causing weird wrapping. This fixes that and also makes it a proper button.

Before:
![screenshot-2024-06-04_10-23-29@2x](https://github.com/sourcegraph/sourcegraph/assets/12631702/9dc31a7a-f977-479b-84c8-d779eb4ffd0d)

After:
![screenshot-2024-06-04_10-24-22@2x](https://github.com/sourcegraph/sourcegraph/assets/12631702/63a97701-7b37-4cfa-a34a-8430f021e2d7)





## Test plan

Manual testing + screenshots above.
