### PR TITLE
Cc/svelte analytics

### DIFF
--- a/client/web-sveltekit/src/app.prod.html
+++ b/client/web-sveltekit/src/app.prod.html
@@ -1,19 +1,68 @@
 <!DOCTYPE html>
 <html lang="en">
     <head>
+        {{.Injected.HeadTop}}
         <meta charset="utf-8" />
         <meta http-equiv="x-ua-compatible" content="ie=edge" />
+        <meta name="google" content="notranslate">
         <meta http-equiv="Content-Language" content="en" />
-        <meta name="google" content="notranslate" />
         <meta name="viewport" content="width=device-width, viewport-fit=cover" />
-        <meta name="referrer" content="origin-when-cross-origin" />
+        <meta name="referrer" content="strict-origin-when-cross-origin" />
         <meta name="color-scheme" content="light dark" />
+
+        {{- with .Metadata }}
+        <meta name='description' content="{{.Description}}" />
+            {{if .ShowPreview }}
+        <meta name='twitter:title' content="{{.Title}}" />
+        <meta name='twitter:description' content="{{.Description}}" />
+        <meta property="og:type" content="website" />
+        <meta property='og:title' content="{{.Title}}" />
+        <meta property='og:description' content="{{.Description}}" />
+                {{- if .PreviewImage }}
+        <meta name='twitter:card' content='summary_large_image' />
+        <meta name="twitter:image" content="{{.PreviewImage}}" />
+        <meta property="og:image" content="{{.PreviewImage}}" />
+                {{- else }}
+        <meta name='twitter:card' content='summary' />
+                {{- end }}
+            {{- end }}
+        {{- end}}
+
         <title>{{.Title}}</title>
+
+        <!--TODO: do we need this with Svelte?-->
+        <!--{{if .Manifest.MainCSSBundlePath}}<link rel="stylesheet" href="{{assetURL .Manifest.MainCSSBundlePath}}">{{end}}-->
+
+        <link id='sourcegraph-chrome-webstore-item' rel="chrome-webstore-item" href="https://chrome.google.com/webstore/detail/dgjhfomjieaadpoljlnidmbgkdffpack">
+        <link rel="search" href="/opensearch.xml" type="application/opensearchdescription+xml" title="Sourcegraph Search">
+
+        {{- if .PreloadedAssets}}
+            {{- range .PreloadedAssets}}
+        <link rel="preload" href="{{.Href}}" as="{{.As}}" />
+            {{- end}}
+        {{- end}}
+
+        {{- if .Context.SourcegraphDotComMode }}
+        <!-- Google Tag Manager -->
+        <script ignore-csp>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+        new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+        j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.defer=true;j.src=
+        'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+        })(window,document,'script','dataLayer','GTM-TB4NLS7');</script>
+        <!-- End Google Tag Manager -->
+        <!-- Sentry -->
+        <script src='https://js.sentry-cdn.com/ae2f74442b154faf90b5ff0f7cd1c618.min.js' crossorigin="anonymous"></script>
+        <!-- Plausible -->
+        <script src="https://plausible.io/js/plausible.js" defer data-domain="sourcegraph.com"></script>
+        {{- end }}
 
         <script ignore-csp>
             window.context = {{ .Context }}
             window.pageError = {{ .Error }}
         </script>
+
+        {{.Injected.HeadBottom}}
+        <!--TODO: continue here-->
 
         %sveltekit.head%
 

--- a/client/web-sveltekit/src/app.prod.html
+++ b/client/web-sveltekit/src/app.prod.html
@@ -13,7 +13,7 @@
 
         {{- with .Metadata }}
         <meta name='description' content="{{.Description}}" />
-            {{if .ShowPreview }}
+            {{- if .ShowPreview }}
         <meta name='twitter:title' content="{{.Title}}" />
         <meta name='twitter:description' content="{{.Description}}" />
         <meta property="og:type" content="website" />

--- a/client/web-sveltekit/src/app.prod.html
+++ b/client/web-sveltekit/src/app.prod.html
@@ -1,3 +1,4 @@
+{{/* NOTE: Keep in sync with cmd/frontend/internal/app/ui/app.html */}}
 <!DOCTYPE html>
 <html lang="en">
     <head>
@@ -30,9 +31,6 @@
 
         <title>{{.Title}}</title>
 
-        <!--TODO: do we need this with Svelte?-->
-        <!--{{if .Manifest.MainCSSBundlePath}}<link rel="stylesheet" href="{{assetURL .Manifest.MainCSSBundlePath}}">{{end}}-->
-
         <link id='sourcegraph-chrome-webstore-item' rel="chrome-webstore-item" href="https://chrome.google.com/webstore/detail/dgjhfomjieaadpoljlnidmbgkdffpack">
         <link rel="search" href="/opensearch.xml" type="application/opensearchdescription+xml" title="Sourcegraph Search">
 
@@ -50,10 +48,29 @@
         'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
         })(window,document,'script','dataLayer','GTM-TB4NLS7');</script>
         <!-- End Google Tag Manager -->
+
         <!-- Sentry -->
-        <script src='https://js.sentry-cdn.com/ae2f74442b154faf90b5ff0f7cd1c618.min.js' crossorigin="anonymous"></script>
-        <!-- Plausible -->
-        <script src="https://plausible.io/js/plausible.js" defer data-domain="sourcegraph.com"></script>
+        <script ignore-csp src='https://js.sentry-cdn.com/ae2f74442b154faf90b5ff0f7cd1c618.min.js' crossorigin="anonymous"></script>
+
+        <!-- Google Search Result SearchBox -->
+        <!-- See https://developers.google.com/search/docs/advanced/structured-data/sitelinks-searchbox -->
+        <script ignore-csp type="application/ld+json">
+            {
+                "@context": "https://schema.org",
+                "@type": "WebSite",
+                "name": "Sourcegraph",
+                "url": "https://sourcegraph.com",
+                "potentialAction": {
+                    "@type": "SearchAction",
+                    "target": {
+                        "@type": "EntryPoint",
+                        "urlTemplate": "https://sourcegraph.com/search?q={search_term_string}&utm_source=google-search-result&utm_campaign=google-search-result-searchbox"
+                    },
+                    "query-input": "required name=search_term_string"
+                }
+            }
+        </script>
+        <!-- End Google Search Result SearchBox -->
         {{- end }}
 
         <script ignore-csp>
@@ -62,7 +79,6 @@
         </script>
 
         {{.Injected.HeadBottom}}
-        <!--TODO: continue here-->
 
         %sveltekit.head%
 
@@ -77,8 +93,28 @@
         </script>
     </head>
     <body data-sveltekit-preload-data data-sveltekit-preload-code="hover">
+		{{ if .Context.RedirectUnsupportedBrowser }}
+        <script ignore-csp>
+            function canRunSourceGraph(){"use strict";if("undefined"==typeof Symbol)return!1;try{eval("class Foo {}"),eval("var bar = (x) => x+1")}catch(r){return!1}return!0}
+            if (!canRunSourceGraph()) {
+                document.write("<h1 ignore-csp style=\"padding: 10px;\">It looks like Sourcegraph does not support your browser. Upgrade or install a JavaScript ES6 supported browser (<a href=\"https://www.microsoft.com/en-us/edge\">Edge</a>, <a href=\"https://www.apple.com/safari/\">Safari</a>, <a href=\"https://www.google.com/chrome/downloads\">Chrome</a>, <a href=\"https://www.mozilla.org/en-US/firefox/new/\">Firefox</a>)</h1>")
+
+                // makes everything below disabled so no crashes
+                document.write('<!--');
+            }
+        </script>
+		{{ end }}
+
+        {{.Injected.BodyTop}}
         <div style="display: contents">%sveltekit.body%</div>
+
         <noscript>
+            {{ if .Context.SourcegraphDotComMode }}
+            <!-- Google Tag Manager (noscript) -->
+            <iframe ignore-csp src="https://www.googletagmanager.com/ns.html?id=GTM-TB4NLS7" height="0" width="0" style="display:none;visibility:hidden"></iframe>
+            <!-- End Google Tag Manager (noscript) -->
+            {{ end }}
+
             <p>
                 Sourcegraph is a web-based code search and navigation tool for dev teams. Search, navigate, and review
                 code. Find answers.
@@ -89,5 +125,6 @@
             <br />
             You need to enable JavaScript to run this app.
         </noscript>
+        {{.Injected.BodyBottom}}
     </body>
 </html>

--- a/cmd/frontend/internal/app/ui/app.html
+++ b/cmd/frontend/internal/app/ui/app.html
@@ -1,3 +1,4 @@
+{{/* NOTE: Keep in sync with client/web-sveltekit/src/app.prod.html */}}
 <!doctype html>
 <html lang="en" class="base">
 


### PR DESCRIPTION
This reconciles the generated `index.html` for the Svelte webapp with what we use in the React app. In particular, it adds things like opengraph metadata, analytics scripts, opensearch metadata, Sentry (which is currently broken), and Google Tag Manager.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles -->


## Changelog

<!--
1. Ensure your pull request title is formatted as: $type($domain): $what
2. Add bullet list items for each additional detail you want to cover (see example below)
3. You can edit this after the pull request was merged, as long as release shipping it hasn't been promoted to the public.
4. For more information, please see this how-to https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c?

Audience: TS/CSE > Customers > Teammates (in that order).

Cheat sheet: $type = chore|fix|feat $domain: source|search|ci|release|plg|cody|local|...
-->

<!--
Example:

Title: fix(search): parse quotes with the appropriate context
Changelog section:

## Changelog

- When a quote is used with regexp pattern type, then ...
- Refactored underlying code.
-->
