### PR TITLE
Svelte: inject into primary `app.html`

### DIFF
--- a/client/web-sveltekit/src/app.prod.html
+++ b/client/web-sveltekit/src/app.prod.html
@@ -1,44 +1,9 @@
-<!DOCTYPE html>
-<html lang="en">
-    <head>
-        <meta charset="utf-8" />
-        <meta http-equiv="x-ua-compatible" content="ie=edge" />
-        <meta http-equiv="Content-Language" content="en" />
-        <meta name="google" content="notranslate" />
-        <meta name="viewport" content="width=device-width, viewport-fit=cover" />
-        <meta name="referrer" content="origin-when-cross-origin" />
-        <meta name="color-scheme" content="light dark" />
-        <title>{{.Title}}</title>
-
-        <script ignore-csp>
-            window.context = {{ .Context }}
-            window.pageError = {{ .Error }}
-        </script>
-
-        %sveltekit.head%
-
-        <script>
-            const userPreference = localStorage.getItem('sourcegraph-theme') || 'System'
-            const theme =
-                (userPreference === 'System' && window.matchMedia('(prefers-color-scheme: dark)').matches) ||
-                userPreference === 'Dark'
-                    ? 'theme-dark'
-                    : 'theme-light'
-            document.documentElement.classList.add(theme)
-        </script>
-    </head>
-    <body data-sveltekit-preload-data data-sveltekit-preload-code="hover">
-        <div style="display: contents">%sveltekit.body%</div>
-        <noscript>
-            <p>
-                Sourcegraph is a web-based code search and navigation tool for dev teams. Search, navigate, and review
-                code. Find answers.
-            </p>
-
-            <br />
-            <br />
-            <br />
-            You need to enable JavaScript to run this app.
-        </noscript>
-    </body>
-</html>
+<!--
+    HACK: Intentionally minimal because this is parsed in frontend which does
+    its own templating. If you change this file, ensure that you also update
+    cmd/frontend/internal/app/ui/sveltekit/sveltekit.go:loadSvelteKitInjections
+-->
+<!-- SPLIT -->
+%sveltekit.head%
+<!-- SPLIT -->
+%sveltekit.body%

--- a/client/web/dev/esbuild/server.ts
+++ b/client/web/dev/esbuild/server.ts
@@ -38,21 +38,6 @@ export const esbuildDevelopmentServer = async (
     // requests go to the upstream.
     const proxyApp = express()
 
-    if (process.env.SVELTEKIT) {
-        // Proxy requests for SvelteKit's assets to the server, not the esbuild server.
-        proxyApp.use(
-            `${assetPathPrefix}/_sk`,
-            createProxyMiddleware({
-                target: {
-                    protocol: 'http:',
-                    host: DEV_SERVER_PROXY_TARGET_ADDR.host,
-                    port: DEV_SERVER_PROXY_TARGET_ADDR.port,
-                },
-                logLevel: 'error',
-            })
-        )
-    }
-
     proxyApp.use(
         assetPathPrefix,
         createProxyMiddleware({

--- a/cmd/frontend/internal/app/ui/app.html
+++ b/cmd/frontend/internal/app/ui/app.html
@@ -28,7 +28,22 @@
 		{{end}}
 	{{end}}
 	<title>{{.Title}}</title>
-	{{if .Manifest.MainCSSBundlePath}}<link rel="stylesheet" href="{{assetURL .Manifest.MainCSSBundlePath}}">{{end}}
+
+    {{- if .Svelte.Enabled}}
+    {{.Svelte.Head}}
+    <script ignore-csp>
+        const userPreference = localStorage.getItem('sourcegraph-theme') || 'System'
+        const theme =
+            (userPreference === 'System' && window.matchMedia('(prefers-color-scheme: dark)').matches) ||
+            userPreference === 'Dark'
+                ? 'theme-dark'
+                : 'theme-light'
+        document.documentElement.classList.add(theme)
+    </script>
+    {{- else if .Manifest.MainCSSBundlePath}}
+    <link rel="stylesheet" href="{{assetURL .Manifest.MainCSSBundlePath}}">
+    {{- end}}
+
 	<link id='sourcegraph-chrome-webstore-item' rel="chrome-webstore-item" href="https://chrome.google.com/webstore/detail/dgjhfomjieaadpoljlnidmbgkdffpack">
 	<link rel="search" href="/opensearch.xml" type="application/opensearchdescription+xml" title="Sourcegraph Search">
 	{{if .PreloadedAssets}}
@@ -75,36 +90,40 @@
 	<!-- End Google Search Result SearchBox -->
 </head>
 
-<body>
-	{{ if .Context.SourcegraphDotComMode }}
-	<!-- Google Tag Manager (noscript) -->
-	<noscript><iframe ignore-csp src="https://www.googletagmanager.com/ns.html?id=GTM-TB4NLS7" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-	<!-- End Google Tag Manager (noscript) -->
-
-	{{ end }}
+<body {{if .Svelte.Enabled }}data-sveltekit-preload-data data-sveltekit-preload-code="hover"{{ end }}>
 	{{.Injected.BodyTop}}
-	<div id="root">
-		{{ if .Context.RedirectUnsupportedBrowser }}
-			 <script ignore-csp>
-				function canRunSourceGraph(){"use strict";if("undefined"==typeof Symbol)return!1;try{eval("class Foo {}"),eval("var bar = (x) => x+1")}catch(r){return!1}return!0}
-				if (!canRunSourceGraph()) {
-					document.write("<h1 ignore-csp style=\"padding: 10px;\">It looks like Sourcegraph does not support your browser. Upgrade or install a JavaScript ES6 supported browser (<a href=\"https://www.microsoft.com/en-us/edge\">Edge</a>, <a href=\"https://www.apple.com/safari/\">Safari</a>, <a href=\"https://www.google.com/chrome/downloads\">Chrome</a>, <a href=\"https://www.mozilla.org/en-US/firefox/new/\">Firefox</a>)</h1>")
 
-					// makes everything below disabled so no crashes
-					document.write('<!--');
-				}
-			</script>
-		{{ end }}
-	</div>
+    {{ if .Context.RedirectUnsupportedBrowser }}
+         <script ignore-csp>
+            function canRunSourceGraph(){"use strict";if("undefined"==typeof Symbol)return!1;try{eval("class Foo {}"),eval("var bar = (x) => x+1")}catch(r){return!1}return!0}
+            if (!canRunSourceGraph()) {
+                document.write("<h1 ignore-csp style=\"padding: 10px;\">It looks like Sourcegraph does not support your browser. Upgrade or install a JavaScript ES6 supported browser (<a href=\"https://www.microsoft.com/en-us/edge\">Edge</a>, <a href=\"https://www.apple.com/safari/\">Safari</a>, <a href=\"https://www.google.com/chrome/downloads\">Chrome</a>, <a href=\"https://www.mozilla.org/en-US/firefox/new/\">Firefox</a>)</h1>")
+
+                // makes everything below disabled so no crashes
+                document.write('<!--');
+            }
+        </script>
+    {{ end }}
+
+    {{- if .Svelte.Enabled }}
+        <div ignore-csp style="display: contents">{{ .Svelte.Body }}</div>
+    {{- else }}
+        <div id="root"></div>
+        <script src="{{assetURL .Manifest.MainJSBundlePath}}" type="module"></script>
+    {{- end }}
+
 	<noscript>
-		<p>Sourcegraph is a web-based code search and navigation tool for dev teams. Search, navigate, and review code. Find answers.</p>
+        {{ if .Context.SourcegraphDotComMode }}
+        <!-- Google Tag Manager (noscript) -->
+        <iframe ignore-csp src="https://www.googletagmanager.com/ns.html?id=GTM-TB4NLS7" height="0" width="0" style="display:none;visibility:hidden"></iframe>
+        <!-- End Google Tag Manager (noscript) -->
+        {{ end }}
 
-		<br>
-		<br>
-		<br>
-		You need to enable JavaScript to run this app.
+		<p>Sourcegraph is a web-based code search and navigation tool for dev teams. Search, navigate, and review code. Find answers.</p>
+		<br><br><br>
+        You need to enable JavaScript to run this app.
 	</noscript>
-	<script src="{{assetURL .Manifest.MainJSBundlePath}}" type="module"></script>
+
 	{{.Injected.BodyBottom}}
 </body>
 

--- a/cmd/frontend/internal/app/ui/handlers.go
+++ b/cmd/frontend/internal/app/ui/handlers.go
@@ -76,12 +76,20 @@ type PreloadedAsset struct {
 	Href string
 }
 
+type SvelteInjections struct {
+	Enabled bool
+	Head    template.HTML
+	Body    template.HTML
+}
+
 type Common struct {
 	Injected InjectedHTML
 	Metadata *Metadata
 	Context  jscontext.JSContext
 	Title    string
 	Error    *pageError
+
+	Svelte SvelteInjections
 
 	PreloadedAssets *[]PreloadedAsset
 
@@ -162,6 +170,19 @@ func newCommon(w http.ResponseWriter, r *http.Request, db database.DB, title str
 		}
 	}
 
+	var svelteInjections SvelteInjections
+	if sveltekit.Enabled(r.Context()) {
+		svelteHead, svelteBody, err := sveltekit.LoadCachedSvelteKitInjections()
+		if err != nil {
+			return nil, errors.Wrap(err, "loading svelte kit context")
+		}
+		svelteInjections = SvelteInjections{
+			Enabled: true,
+			Head:    template.HTML(svelteHead),
+			Body:    template.HTML(svelteBody),
+		}
+	}
+
 	common := &Common{
 		Injected: InjectedHTML{
 			HeadTop:    template.HTML(conf.Get().HtmlHeadTop),
@@ -178,7 +199,7 @@ func newCommon(w http.ResponseWriter, r *http.Request, db database.DB, title str
 			Description: "Sourcegraph is a web-based code search and navigation tool for dev teams. Search, navigate, and review code. Find answers.",
 			ShowPreview: r.URL.Path == "/sign-in" && r.URL.RawQuery == "returnTo=%2F",
 		},
-
+		Svelte:              svelteInjections,
 		WebBuilderDevServer: webBuilderDevServer,
 	}
 
@@ -326,10 +347,6 @@ func serveBasicPage(db database.DB, title func(c *Common, r *http.Request) strin
 			return nil // request was handled
 		}
 		common.Title = title(common, r)
-
-		if sveltekit.Enabled(r.Context()) {
-			return sveltekit.RenderTemplate(w, common)
-		}
 
 		return renderTemplate(w, "app.html", common)
 	}
@@ -482,10 +499,6 @@ func serveTree(db database.DB, title func(c *Common, r *http.Request) string) ha
 
 		common.Title = title(common, r)
 
-		if sveltekit.Enabled(r.Context()) {
-			return sveltekit.RenderTemplate(w, common)
-		}
-
 		return renderTemplate(w, "app.html", common)
 	}
 }
@@ -537,10 +550,6 @@ func serveRepoOrBlob(db database.DB, routeName string, title func(c *Common, r *
 			r.URL.RawQuery = q.Encode()
 			http.Redirect(w, r, r.URL.String(), http.StatusPermanentRedirect)
 			return nil
-		}
-
-		if sveltekit.Enabled(r.Context()) {
-			return sveltekit.RenderTemplate(w, common)
 		}
 
 		return renderTemplate(w, "app.html", common)

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -1776,37 +1776,6 @@ commandsets:
     bazelCommands:
       - cody-gateway
 
-  enterprise-bazel-sveltekit:
-    <<: *enterprise_bazel_set
-    env:
-      SVELTEKIT: true
-
-  enterprise-sveltekit:
-    <<: *enterprise_set
-    # Keep in sync with &enterprise_set.commands
-    commands:
-      - frontend
-      - worker
-      - repo-updater
-      - web
-      - web-sveltekit
-      - gitserver-0
-      - gitserver-1
-      - searcher
-      - caddy
-      - symbols
-      # TODO https://github.com/sourcegraph/devx-support/issues/537
-      # - docsite
-      - syntax-highlighter
-      - zoekt-index-0
-      - zoekt-index-1
-      - zoekt-web-0
-      - zoekt-web-1
-      - blobstore
-      - embeddings
-    env:
-      SVELTEKIT: true
-
 tests:
   # These can be run with `sg test [name]`
   backend:


### PR DESCRIPTION
This modifies our pattern for shipping a svelte-enabled HTML document by injecting the svelte-specific things into our primary `app.html` rather than trying to make `app.prod.html` match the behavior of the frontend `app.html`.

I could not figure out a "blessed" way to integrate this into the build system, so I went for the hacky way: render `app.prod.html` in a format that's easily parseable, then parse it in `frontend` and inject it into our `app.html` with the standard go template patterns.

Fixes SRCH-76

## Test plan

Manual testing with `sg start enterprise` and `sg start enterprise-sveltekit`. Manual inspection of the generated HTML and diffing against the previously generated HTML.