### PR TITLE
bazel: rules_js rc3 and remove deprecated "exclude_declarations" option

### DIFF
--- a/.aspect/bazelrc/local.bazelrc
+++ b/.aspect/bazelrc/local.bazelrc
@@ -22,9 +22,3 @@ common --remote_cache=https://storage.googleapis.com/local_bazel_remote_cache
 # Docs: https://bazel.build/reference/command-line-reference#flag--experimental_remote_cache_async
 # Appears to be quite unstable, disabling for now
 # common  --experimental_remote_cache_async
-
-
-# Disables declaration file generation from pnpm workspaces (i.e. all sub projects in client/)
-# which removes tsc from the loop of compilation.
-# Docs: https://docs.aspect.build/rulesets/aspect_rules_ts/docs/transpiler/#avoid-eager-type-checks-via-npm_package
-build --@aspect_rules_js//npm:exclude_declarations_from_npm_packages

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -35,9 +35,9 @@ http_archive(
 
 http_archive(
     name = "aspect_rules_js",
-    sha256 = "25e06ac98ce2dd44d74e728e63e1c88e707d0972db20d7e7339c8e458335b4e3",
-    strip_prefix = "rules_js-2.0.0-rc2",
-    url = "https://github.com/aspect-build/rules_js/releases/download/v2.0.0-rc2/rules_js-v2.0.0-rc2.tar.gz",
+    sha256 = "3dfccf2713288e0518c0485b65574ca66426c6e06495299abe6f5c64e3bc6314",
+    strip_prefix = "rules_js-2.0.0-rc3",
+    url = "https://github.com/aspect-build/rules_js/releases/download/v2.0.0-rc3/rules_js-v2.0.0-rc3.tar.gz",
 )
 
 http_archive(


### PR DESCRIPTION
`exclude_declarations_from_npm_packages` is not an option anymore as from the output
```
ERROR: @aspect_rules_js//npm:exclude_declarations_from_npm_packages :: Unrecognized option: @aspect_rules_js//npm:exclude_declarations_from_npm_packages
```

Also upgraded to `rc3` while diagnosing this.

Closes https://github.com/sourcegraph/devx-support/issues/1005
## Test plan
Tested locally + CI
```
sg bazel test //internal/appliance/reconciler:reconciler_test
INFO: Invocation ID: 70da4295-36f2-43a8-a71e-9b11ae489657
WARNING: Build option --modify_execution_info has changed, discarding analysis cache (this can be expensive, see https://bazel.build/advanced/performance/iteration-speed).
INFO: Analyzed target //internal/appliance/reconciler:reconciler_test (0 packages loaded, 17313 targets configured).
INFO: Found 1 test target...
Target //internal/appliance/reconciler:reconciler_test up-to-date:
  bazel-bin/internal/appliance/reconciler/reconciler_test_/reconciler_test
Aspect @@rules_rust//rust/private:rustfmt.bzl%rustfmt_aspect of //internal/appliance/reconciler:reconciler_test up-to-date (nothing to build)
Aspect @@rules_rust//rust/private:clippy.bzl%rust_clippy_aspect of //internal/appliance/reconciler:reconciler_test up-to-date (nothing to build)
INFO: Elapsed time: 1.210s, Critical Path: 0.11s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
//internal/appliance/reconciler:reconciler_test                 (cached) PASSED in 19.2s
```

## Changelog
- remove deprecated option `exclude_declarations_from_npm_packages` from local.bazelrc
- update to rc3 of rules_js