### PR TITLE
Fix Cody onboarding redirect problem

### DIFF
--- a/client/web/src/cody/onboarding/CodyOnboarding.tsx
+++ b/client/web/src/cody/onboarding/CodyOnboarding.tsx
@@ -46,8 +46,8 @@ export function CodyOnboarding({ authenticatedUser, telemetryRecorder }: CodyOnb
     const parameters = useSearchParameters()
     const enrollPro = parameters.get('pro') === 'true'
     const returnToURL = parameters.get('returnTo')
-    // Even if just the return URL contains `requestFrom=CODY`, we should treat it as a request from Cody.
-    const isCody = parameters.get('requestFrom') === 'CODY' || returnToURL?.includes('requestFrom=CODY')
+    // All calls with a `requestFrom` query param to this call or in the returnTo URL come from Cody clients.
+    const isCody = !!parameters.get('requestFrom') || !!returnToURL?.includes('requestFrom')
 
     const navigate = useNavigate()
 

--- a/client/web/src/cody/onboarding/CodyOnboarding.tsx
+++ b/client/web/src/cody/onboarding/CodyOnboarding.tsx
@@ -46,7 +46,8 @@ export function CodyOnboarding({ authenticatedUser, telemetryRecorder }: CodyOnb
     const parameters = useSearchParameters()
     const enrollPro = parameters.get('pro') === 'true'
     const returnToURL = parameters.get('returnTo')
-    const isCody = parameters.get('requestFrom') === 'CODY'
+    // Even if just the return URL contains `requestFrom=CODY`, we should treat it as a request from Cody.
+    const isCody = parameters.get('requestFrom') === 'CODY' || returnToURL?.includes('requestFrom=CODY')
 
     const navigate = useNavigate()
 


### PR DESCRIPTION
Closes https://linear.app/sourcegraph/issue/PRIME-299/unable-to-sign-into-cody-account-via-github

The problem is that in some cases, the Cody Management page (https://courcegraph.com/cody/manage) doesn't redirect requests to the `returnTo` URL passed to it.
The situation when this occurs is when the user has not completed the Cody onboarding flow in the browser they are seeing the page.

History of the bug:
- Originally, it worked, but only because of an apparently accidental, transient state in [this line](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/commit/c5c199e7e06349db85c79b5ece6e31512b4a3ff6#diff-d14b1d38e01f8217c9e449122cad5122L104) where the variable `completed` was initialized with the value of `true`.
- I made a change in December (in https://github.com/sourcegraph/sourcegraph/pull/58854) where I removed that transient state, but thus, I broke the redirect, which caused severe onboarding UX problems.
- This PR fixes the redirect again, by making the redirect decision logic consider `requestFrom=CODY` even in the return URL.

This is actually just another hack; the right solution would be for clients to propoerly pass the `request=CODY` to the Cody Management page itself, not just in the return URL. But it is what it is, this solution works with that glitch, which is a solution that works with versions of clients that are already released.

## Test plan

I've tested locally with all combinations of
- `ab-shortened-install-first-signup-flow-cody-2024-04` feature flag being on/off
- the string `requestFrom=CODY` present/not present in the return URL
- the `cody.onboarding.completed` temporary setting being `true`/`false`

## Changelog

fix(cody): redirect Cody client requests to the access token creation page in all cases