### PR TITLE
Syntactic Indexing: add TAR archive indexing mode to scip-syntax CLI

### DIFF
--- a/docker-images/syntax-highlighter/Cargo.Bazel.lock
+++ b/docker-images/syntax-highlighter/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "d746458bde59540b716b94762ce4edc4a698a1daff9a5f39cc3de34bd341767e",
+  "checksum": "3cd06aa5fd5108cee2e6e19b9e6809923b6c23e0bd51d36717b4c016dd136a8c",
   "crates": {
     "addr2line 0.20.0": {
       "name": "addr2line",

--- a/docker-images/syntax-highlighter/Cargo.Bazel.lock
+++ b/docker-images/syntax-highlighter/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "296b539d4c595a40878a6f2db34cde2485d34792507243386f1f540fee4ab337",
+  "checksum": "d746458bde59540b716b94762ce4edc4a698a1daff9a5f39cc3de34bd341767e",
   "crates": {
     "addr2line 0.20.0": {
       "name": "addr2line",
@@ -832,7 +832,7 @@
             ],
             "cfg(unix)": [
               {
-                "id": "libc 0.2.147",
+                "id": "libc 0.2.155",
                 "target": "libc"
               }
             ],
@@ -928,7 +928,7 @@
               "target": "cfg_if"
             },
             {
-              "id": "libc 0.2.147",
+              "id": "libc 0.2.155",
               "target": "libc"
             },
             {
@@ -1433,7 +1433,7 @@
           "selects": {
             "cfg(unix)": [
               {
-                "id": "libc 0.2.147",
+                "id": "libc 0.2.155",
                 "target": "libc"
               }
             ]
@@ -2092,7 +2092,7 @@
               "target": "lazy_static"
             },
             {
-              "id": "libc 0.2.147",
+              "id": "libc 0.2.155",
               "target": "libc"
             },
             {
@@ -3012,7 +3012,7 @@
             ],
             "cfg(unix)": [
               {
-                "id": "libc 0.2.147",
+                "id": "libc 0.2.155",
                 "target": "libc"
               }
             ],
@@ -3262,13 +3262,13 @@
       },
       "license": "Apache-2.0 OR MIT"
     },
-    "errno 0.3.2": {
+    "errno 0.3.9": {
       "name": "errno",
-      "version": "0.3.2",
+      "version": "0.3.9",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/errno/0.3.2/download",
-          "sha256": "6b30f669a7961ef1631673d2766cc92f52d64f7ef354d4fe0ddfd30ed52f0f4f"
+          "url": "https://static.crates.io/crates/errno/0.3.9/download",
+          "sha256": "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
         }
       },
       "targets": [
@@ -3287,111 +3287,45 @@
         "compile_data_glob": [
           "**"
         ],
+        "crate_features": {
+          "common": [
+            "std"
+          ],
+          "selects": {}
+        },
         "deps": {
           "common": [],
           "selects": {
-            "cfg(target_os = \"dragonfly\")": [
-              {
-                "id": "errno-dragonfly 0.1.2",
-                "target": "errno_dragonfly"
-              }
-            ],
             "cfg(target_os = \"hermit\")": [
               {
-                "id": "libc 0.2.147",
+                "id": "libc 0.2.155",
                 "target": "libc"
               }
             ],
             "cfg(target_os = \"wasi\")": [
               {
-                "id": "libc 0.2.147",
+                "id": "libc 0.2.155",
                 "target": "libc"
               }
             ],
             "cfg(unix)": [
               {
-                "id": "libc 0.2.147",
+                "id": "libc 0.2.155",
                 "target": "libc"
               }
             ],
             "cfg(windows)": [
               {
-                "id": "windows-sys 0.48.0",
+                "id": "windows-sys 0.52.0",
                 "target": "windows_sys"
               }
             ]
           }
         },
         "edition": "2018",
-        "version": "0.3.2"
+        "version": "0.3.9"
       },
       "license": "MIT OR Apache-2.0"
-    },
-    "errno-dragonfly 0.1.2": {
-      "name": "errno-dragonfly",
-      "version": "0.1.2",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/errno-dragonfly/0.1.2/download",
-          "sha256": "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "errno_dragonfly",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        },
-        {
-          "BuildScript": {
-            "crate_name": "build_script_build",
-            "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "errno_dragonfly",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "errno-dragonfly 0.1.2",
-              "target": "build_script_build"
-            },
-            {
-              "id": "libc 0.2.147",
-              "target": "libc"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "version": "0.1.2"
-      },
-      "build_script_attrs": {
-        "data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "cc 1.0.83",
-              "target": "cc"
-            }
-          ],
-          "selects": {}
-        }
-      },
-      "license": "MIT"
     },
     "error-code 2.3.1": {
       "name": "error-code",
@@ -3421,7 +3355,7 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.147",
+              "id": "libc 0.2.155",
               "target": "libc"
             },
             {
@@ -3436,13 +3370,13 @@
       },
       "license": "BSL-1.0"
     },
-    "fastrand 2.0.0": {
+    "fastrand 2.1.0": {
       "name": "fastrand",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/fastrand/2.0.0/download",
-          "sha256": "6999dc1837253364c2ebb0704ba97994bd874e8f195d665c50b7548f6ea92764"
+          "url": "https://static.crates.io/crates/fastrand/2.1.0/download",
+          "sha256": "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
         }
       },
       "targets": [
@@ -3470,7 +3404,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "2.0.0"
+        "version": "2.1.0"
       },
       "license": "Apache-2.0 OR MIT"
     },
@@ -3509,7 +3443,7 @@
           "selects": {
             "cfg(unix)": [
               {
-                "id": "rustix 0.38.8",
+                "id": "rustix 0.38.34",
                 "target": "rustix"
               }
             ],
@@ -3619,6 +3553,64 @@
         }
       },
       "license": "MIT OR Apache-2.0"
+    },
+    "filetime 0.2.23": {
+      "name": "filetime",
+      "version": "0.2.23",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/filetime/0.2.23/download",
+          "sha256": "1ee447700ac8aa0b2f2bd7bc4462ad686ba06baa6727ac149a2d6277f0d240fd"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "filetime",
+            "crate_root": "src/lib.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        }
+      ],
+      "library_target_name": "filetime",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "cfg-if 1.0.0",
+              "target": "cfg_if"
+            }
+          ],
+          "selects": {
+            "cfg(target_os = \"redox\")": [
+              {
+                "id": "redox_syscall 0.4.1",
+                "target": "syscall"
+              }
+            ],
+            "cfg(unix)": [
+              {
+                "id": "libc 0.2.155",
+                "target": "libc"
+              }
+            ],
+            "cfg(windows)": [
+              {
+                "id": "windows-sys 0.52.0",
+                "target": "windows_sys"
+              }
+            ]
+          }
+        },
+        "edition": "2018",
+        "version": "0.2.23"
+      },
+      "license": "MIT/Apache-2.0"
     },
     "flate2 1.0.27": {
       "name": "flate2",
@@ -4270,7 +4262,7 @@
           "selects": {
             "cfg(unix)": [
               {
-                "id": "libc 0.2.147",
+                "id": "libc 0.2.155",
                 "target": "libc"
               }
             ],
@@ -4357,7 +4349,7 @@
             ],
             "cfg(unix)": [
               {
-                "id": "libc 0.2.147",
+                "id": "libc 0.2.155",
                 "target": "libc"
               }
             ]
@@ -4719,7 +4711,7 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.147",
+              "id": "libc 0.2.155",
               "target": "libc"
             }
           ],
@@ -5478,7 +5470,7 @@
           "selects": {
             "cfg(not(any(windows, target_os = \"hermit\", target_os = \"unknown\")))": [
               {
-                "id": "rustix 0.38.8",
+                "id": "rustix 0.38.34",
                 "target": "rustix"
               }
             ],
@@ -5694,13 +5686,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "libc 0.2.147": {
+    "libc 0.2.155": {
       "name": "libc",
-      "version": "0.2.147",
+      "version": "0.2.155",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/libc/0.2.147/download",
-          "sha256": "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
+          "url": "https://static.crates.io/crates/libc/0.2.155/download",
+          "sha256": "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
         }
       },
       "targets": [
@@ -5832,14 +5824,14 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.147",
+              "id": "libc 0.2.155",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2015",
-        "version": "0.2.147"
+        "version": "0.2.155"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -5917,13 +5909,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "linux-raw-sys 0.4.5": {
+    "linux-raw-sys 0.4.14": {
       "name": "linux-raw-sys",
-      "version": "0.4.5",
+      "version": "0.4.14",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/linux-raw-sys/0.4.5/download",
-          "sha256": "57bcfdad1b858c2db7c38303a6d2ad4dfaf5eb53dfeb0910128b2c26d6158503"
+          "url": "https://static.crates.io/crates/linux-raw-sys/0.4.14/download",
+          "sha256": "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
         }
       },
       "targets": [
@@ -5950,30 +5942,50 @@
           ],
           "selects": {
             "aarch64-unknown-linux-gnu": [
-              "errno"
+              "elf",
+              "errno",
+              "std"
             ],
             "aarch64-unknown-nixos-gnu": [
-              "errno"
+              "elf",
+              "errno",
+              "std"
             ],
             "arm-unknown-linux-gnueabi": [
-              "errno"
+              "elf",
+              "errno",
+              "std"
             ],
             "armv7-unknown-linux-gnueabi": [
-              "errno"
+              "elf",
+              "errno",
+              "std"
             ],
             "i686-unknown-linux-gnu": [
-              "errno"
+              "elf",
+              "errno",
+              "std"
+            ],
+            "powerpc-unknown-linux-gnu": [
+              "std"
+            ],
+            "s390x-unknown-linux-gnu": [
+              "std"
             ],
             "x86_64-unknown-linux-gnu": [
-              "errno"
+              "elf",
+              "errno",
+              "std"
             ],
             "x86_64-unknown-nixos-gnu": [
-              "errno"
+              "elf",
+              "errno",
+              "std"
             ]
           }
         },
         "edition": "2021",
-        "version": "0.4.5"
+        "version": "0.4.14"
       },
       "license": "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT"
     },
@@ -6497,7 +6509,7 @@
           "selects": {
             "cfg(target_os = \"wasi\")": [
               {
-                "id": "libc 0.2.147",
+                "id": "libc 0.2.155",
                 "target": "libc"
               },
               {
@@ -6507,7 +6519,7 @@
             ],
             "cfg(unix)": [
               {
-                "id": "libc 0.2.147",
+                "id": "libc 0.2.155",
                 "target": "libc"
               }
             ],
@@ -6714,7 +6726,7 @@
               "target": "cfg_if"
             },
             {
-              "id": "libc 0.2.147",
+              "id": "libc 0.2.155",
               "target": "libc"
             }
           ],
@@ -6907,7 +6919,7 @@
           "selects": {
             "cfg(not(windows))": [
               {
-                "id": "libc 0.2.147",
+                "id": "libc 0.2.155",
                 "target": "libc"
               }
             ],
@@ -7082,7 +7094,7 @@
           "selects": {
             "cfg(windows)": [
               {
-                "id": "libc 0.2.147",
+                "id": "libc 0.2.155",
                 "target": "libc"
               }
             ]
@@ -7363,7 +7375,7 @@
             ],
             "cfg(unix)": [
               {
-                "id": "libc 0.2.147",
+                "id": "libc 0.2.155",
                 "target": "libc"
               }
             ],
@@ -7435,6 +7447,36 @@
         "data_glob": [
           "**"
         ]
+      },
+      "license": "MIT OR Apache-2.0"
+    },
+    "path-clean 1.0.1": {
+      "name": "path-clean",
+      "version": "1.0.1",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/path-clean/1.0.1/download",
+          "sha256": "17359afc20d7ab31fdb42bb844c8b3bb1dabd7dcf7e68428492da7f16966fcef"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "path_clean",
+            "crate_root": "src/lib.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        }
+      ],
+      "library_target_name": "path_clean",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "edition": "2015",
+        "version": "1.0.1"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -8701,7 +8743,7 @@
           "selects": {
             "cfg(unix)": [
               {
-                "id": "libc 0.2.147",
+                "id": "libc 0.2.155",
                 "target": "libc"
               }
             ]
@@ -8996,6 +9038,45 @@
         },
         "edition": "2018",
         "version": "0.3.5"
+      },
+      "license": "MIT"
+    },
+    "redox_syscall 0.4.1": {
+      "name": "redox_syscall",
+      "version": "0.4.1",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/redox_syscall/0.4.1/download",
+          "sha256": "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "syscall",
+            "crate_root": "src/lib.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        }
+      ],
+      "library_target_name": "syscall",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "bitflags 1.3.2",
+              "target": "bitflags"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "0.4.1"
       },
       "license": "MIT"
     },
@@ -9565,7 +9646,7 @@
               "target": "state"
             },
             {
-              "id": "tempfile 3.8.0",
+              "id": "tempfile 3.10.1",
               "target": "tempfile"
             },
             {
@@ -9882,13 +9963,13 @@
       },
       "license": "Apache-2.0/MIT"
     },
-    "rustix 0.38.8": {
+    "rustix 0.38.34": {
       "name": "rustix",
-      "version": "0.38.8",
+      "version": "0.38.34",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/rustix/0.38.8/download",
-          "sha256": "19ed4fa021d81c8392ce04db050a3da9a60299050b7ae1cf482d862b54a7218f"
+          "url": "https://static.crates.io/crates/rustix/0.38.34/download",
+          "sha256": "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
         }
       },
       "targets": [
@@ -9918,8 +9999,10 @@
         ],
         "crate_features": {
           "common": [
+            "alloc",
             "default",
             "libc",
+            "libc-extra-traits",
             "libc_errno",
             "std",
             "use-libc",
@@ -10050,58 +10133,58 @@
               "target": "bitflags"
             },
             {
-              "id": "rustix 0.38.8",
+              "id": "rustix 0.38.34",
               "target": "build_script_build"
             }
           ],
           "selects": {
             "cfg(all(any(target_os = \"android\", target_os = \"linux\"), any(rustix_use_libc, miri, not(all(target_os = \"linux\", target_endian = \"little\", any(target_arch = \"arm\", all(target_arch = \"aarch64\", target_pointer_width = \"64\"), target_arch = \"riscv64\", all(rustix_use_experimental_asm, target_arch = \"powerpc64\"), all(rustix_use_experimental_asm, target_arch = \"mips\"), all(rustix_use_experimental_asm, target_arch = \"mips32r6\"), all(rustix_use_experimental_asm, target_arch = \"mips64\"), all(rustix_use_experimental_asm, target_arch = \"mips64r6\"), target_arch = \"x86\", all(target_arch = \"x86_64\", target_pointer_width = \"64\")))))))": [
               {
-                "id": "linux-raw-sys 0.4.5",
+                "id": "linux-raw-sys 0.4.14",
                 "target": "linux_raw_sys"
               }
             ],
             "cfg(all(not(rustix_use_libc), not(miri), target_os = \"linux\", target_endian = \"little\", any(target_arch = \"arm\", all(target_arch = \"aarch64\", target_pointer_width = \"64\"), target_arch = \"riscv64\", all(rustix_use_experimental_asm, target_arch = \"powerpc64\"), all(rustix_use_experimental_asm, target_arch = \"mips\"), all(rustix_use_experimental_asm, target_arch = \"mips32r6\"), all(rustix_use_experimental_asm, target_arch = \"mips64\"), all(rustix_use_experimental_asm, target_arch = \"mips64r6\"), target_arch = \"x86\", all(target_arch = \"x86_64\", target_pointer_width = \"64\"))))": [
               {
-                "id": "errno 0.3.2",
+                "id": "errno 0.3.9",
                 "target": "errno",
                 "alias": "libc_errno"
               },
               {
-                "id": "libc 0.2.147",
+                "id": "libc 0.2.155",
                 "target": "libc"
               },
               {
-                "id": "linux-raw-sys 0.4.5",
+                "id": "linux-raw-sys 0.4.14",
                 "target": "linux_raw_sys"
               }
             ],
             "cfg(all(not(windows), any(rustix_use_libc, miri, not(all(target_os = \"linux\", target_endian = \"little\", any(target_arch = \"arm\", all(target_arch = \"aarch64\", target_pointer_width = \"64\"), target_arch = \"riscv64\", all(rustix_use_experimental_asm, target_arch = \"powerpc64\"), all(rustix_use_experimental_asm, target_arch = \"mips\"), all(rustix_use_experimental_asm, target_arch = \"mips32r6\"), all(rustix_use_experimental_asm, target_arch = \"mips64\"), all(rustix_use_experimental_asm, target_arch = \"mips64r6\"), target_arch = \"x86\", all(target_arch = \"x86_64\", target_pointer_width = \"64\")))))))": [
               {
-                "id": "errno 0.3.2",
+                "id": "errno 0.3.9",
                 "target": "errno",
                 "alias": "libc_errno"
               },
               {
-                "id": "libc 0.2.147",
+                "id": "libc 0.2.155",
                 "target": "libc"
               }
             ],
             "cfg(windows)": [
               {
-                "id": "errno 0.3.2",
+                "id": "errno 0.3.9",
                 "target": "errno",
                 "alias": "libc_errno"
               },
               {
-                "id": "windows-sys 0.48.0",
+                "id": "windows-sys 0.52.0",
                 "target": "windows_sys"
               }
             ]
           }
         },
         "edition": "2021",
-        "version": "0.38.8"
+        "version": "0.38.34"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -10215,7 +10298,7 @@
               "target": "fd_lock"
             },
             {
-              "id": "libc 0.2.147",
+              "id": "libc 0.2.155",
               "target": "libc"
             },
             {
@@ -10473,6 +10556,10 @@
               "target": "lazy_static"
             },
             {
+              "id": "path-clean 1.0.1",
+              "target": "path_clean"
+            },
+            {
               "id": "predicates 3.0.4",
               "target": "predicates"
             },
@@ -10497,8 +10584,21 @@
               "target": "string_interner"
             },
             {
+              "id": "tar 0.4.40",
+              "target": "tar"
+            },
+            {
               "id": "walkdir 2.3.3",
               "target": "walkdir"
+            }
+          ],
+          "selects": {}
+        },
+        "deps_dev": {
+          "common": [
+            {
+              "id": "tempfile 3.10.1",
+              "target": "tempfile"
             }
           ],
           "selects": {}
@@ -10903,7 +11003,7 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.147",
+              "id": "libc 0.2.155",
               "target": "libc"
             }
           ],
@@ -11087,7 +11187,7 @@
           "selects": {
             "cfg(unix)": [
               {
-                "id": "libc 0.2.147",
+                "id": "libc 0.2.155",
                 "target": "libc"
               }
             ],
@@ -11140,7 +11240,7 @@
           "selects": {
             "cfg(unix)": [
               {
-                "id": "libc 0.2.147",
+                "id": "libc 0.2.155",
                 "target": "libc"
               }
             ],
@@ -11769,7 +11869,7 @@
               "target": "rocket"
             },
             {
-              "id": "rustix 0.38.8",
+              "id": "rustix 0.38.34",
               "target": "rustix"
             },
             {
@@ -11847,13 +11947,70 @@
       },
       "license": "MIT"
     },
-    "tempfile 3.8.0": {
-      "name": "tempfile",
-      "version": "3.8.0",
+    "tar 0.4.40": {
+      "name": "tar",
+      "version": "0.4.40",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/tempfile/3.8.0/download",
-          "sha256": "cb94d2f3cc536af71caac6b6fcebf65860b347e7ce0cc9ebe8f70d3e521054ef"
+          "url": "https://static.crates.io/crates/tar/0.4.40/download",
+          "sha256": "b16afcea1f22891c49a00c751c7b63b2233284064f11a200fc624137c51e2ddb"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "tar",
+            "crate_root": "src/lib.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        }
+      ],
+      "library_target_name": "tar",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "default",
+            "xattr"
+          ],
+          "selects": {}
+        },
+        "deps": {
+          "common": [
+            {
+              "id": "filetime 0.2.23",
+              "target": "filetime"
+            }
+          ],
+          "selects": {
+            "cfg(unix)": [
+              {
+                "id": "libc 0.2.155",
+                "target": "libc"
+              },
+              {
+                "id": "xattr 1.3.1",
+                "target": "xattr"
+              }
+            ]
+          }
+        },
+        "edition": "2018",
+        "version": "0.4.40"
+      },
+      "license": "MIT/Apache-2.0"
+    },
+    "tempfile 3.10.1": {
+      "name": "tempfile",
+      "version": "3.10.1",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/tempfile/3.10.1/download",
+          "sha256": "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
         }
       },
       "targets": [
@@ -11879,33 +12036,27 @@
               "target": "cfg_if"
             },
             {
-              "id": "fastrand 2.0.0",
+              "id": "fastrand 2.1.0",
               "target": "fastrand"
             }
           ],
           "selects": {
             "cfg(any(unix, target_os = \"wasi\"))": [
               {
-                "id": "rustix 0.38.8",
+                "id": "rustix 0.38.34",
                 "target": "rustix"
-              }
-            ],
-            "cfg(target_os = \"redox\")": [
-              {
-                "id": "redox_syscall 0.3.5",
-                "target": "syscall"
               }
             ],
             "cfg(windows)": [
               {
-                "id": "windows-sys 0.48.0",
+                "id": "windows-sys 0.52.0",
                 "target": "windows_sys"
               }
             ]
           }
         },
-        "edition": "2018",
-        "version": "3.8.0"
+        "edition": "2021",
+        "version": "3.10.1"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -12403,7 +12554,7 @@
             ],
             "cfg(unix)": [
               {
-                "id": "libc 0.2.147",
+                "id": "libc 0.2.155",
                 "target": "libc"
               },
               {
@@ -15224,7 +15375,7 @@
           "selects": {
             "cfg(unix)": [
               {
-                "id": "libc 0.2.147",
+                "id": "libc 0.2.155",
                 "target": "libc"
               }
             ]
@@ -16086,8 +16237,6 @@
           "common": [
             "Win32",
             "Win32_Foundation",
-            "Win32_NetworkManagement",
-            "Win32_NetworkManagement_IpHelper",
             "Win32_Networking",
             "Win32_Networking_WinSock",
             "Win32_Security",
@@ -16095,8 +16244,6 @@
             "Win32_Storage_FileSystem",
             "Win32_System",
             "Win32_System_Console",
-            "Win32_System_Diagnostics",
-            "Win32_System_Diagnostics_Debug",
             "Win32_System_IO",
             "Win32_System_Pipes",
             "Win32_System_SystemServices",
@@ -16117,6 +16264,63 @@
         },
         "edition": "2018",
         "version": "0.48.0"
+      },
+      "license": "MIT OR Apache-2.0"
+    },
+    "windows-sys 0.52.0": {
+      "name": "windows-sys",
+      "version": "0.52.0",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/windows-sys/0.52.0/download",
+          "sha256": "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "windows_sys",
+            "crate_root": "src/lib.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        }
+      ],
+      "library_target_name": "windows_sys",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "Win32",
+            "Win32_Foundation",
+            "Win32_NetworkManagement",
+            "Win32_NetworkManagement_IpHelper",
+            "Win32_Networking",
+            "Win32_Networking_WinSock",
+            "Win32_Storage",
+            "Win32_Storage_FileSystem",
+            "Win32_System",
+            "Win32_System_Diagnostics",
+            "Win32_System_Diagnostics_Debug",
+            "Win32_System_Threading",
+            "default"
+          ],
+          "selects": {}
+        },
+        "deps": {
+          "common": [
+            {
+              "id": "windows-targets 0.52.5",
+              "target": "windows_targets"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.52.0"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -16304,6 +16508,89 @@
       },
       "license": "MIT OR Apache-2.0"
     },
+    "windows-targets 0.52.5": {
+      "name": "windows-targets",
+      "version": "0.52.5",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/windows-targets/0.52.5/download",
+          "sha256": "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "windows_targets",
+            "crate_root": "src/lib.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        }
+      ],
+      "library_target_name": "windows_targets",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [],
+          "selects": {
+            "aarch64-pc-windows-gnullvm": [
+              {
+                "id": "windows_aarch64_gnullvm 0.52.5",
+                "target": "windows_aarch64_gnullvm"
+              }
+            ],
+            "cfg(all(any(target_arch = \"x86_64\", target_arch = \"arm64ec\"), target_env = \"msvc\", not(windows_raw_dylib)))": [
+              {
+                "id": "windows_x86_64_msvc 0.52.5",
+                "target": "windows_x86_64_msvc"
+              }
+            ],
+            "cfg(all(target_arch = \"aarch64\", target_env = \"msvc\", not(windows_raw_dylib)))": [
+              {
+                "id": "windows_aarch64_msvc 0.52.5",
+                "target": "windows_aarch64_msvc"
+              }
+            ],
+            "cfg(all(target_arch = \"x86\", target_env = \"gnu\", not(target_abi = \"llvm\"), not(windows_raw_dylib)))": [
+              {
+                "id": "windows_i686_gnu 0.52.5",
+                "target": "windows_i686_gnu"
+              }
+            ],
+            "cfg(all(target_arch = \"x86\", target_env = \"msvc\", not(windows_raw_dylib)))": [
+              {
+                "id": "windows_i686_msvc 0.52.5",
+                "target": "windows_i686_msvc"
+              }
+            ],
+            "cfg(all(target_arch = \"x86_64\", target_env = \"gnu\", not(target_abi = \"llvm\"), not(windows_raw_dylib)))": [
+              {
+                "id": "windows_x86_64_gnu 0.52.5",
+                "target": "windows_x86_64_gnu"
+              }
+            ],
+            "i686-pc-windows-gnullvm": [
+              {
+                "id": "windows_i686_gnullvm 0.52.5",
+                "target": "windows_i686_gnullvm"
+              }
+            ],
+            "x86_64-pc-windows-gnullvm": [
+              {
+                "id": "windows_x86_64_gnullvm 0.52.5",
+                "target": "windows_x86_64_gnullvm"
+              }
+            ]
+          }
+        },
+        "edition": "2021",
+        "version": "0.52.5"
+      },
+      "license": "MIT OR Apache-2.0"
+    },
     "windows_aarch64_gnullvm 0.42.2": {
       "name": "windows_aarch64_gnullvm",
       "version": "0.42.2",
@@ -16402,6 +16689,59 @@
         },
         "edition": "2018",
         "version": "0.48.5"
+      },
+      "build_script_attrs": {
+        "data_glob": [
+          "**"
+        ]
+      },
+      "license": "MIT OR Apache-2.0"
+    },
+    "windows_aarch64_gnullvm 0.52.5": {
+      "name": "windows_aarch64_gnullvm",
+      "version": "0.52.5",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/windows_aarch64_gnullvm/0.52.5/download",
+          "sha256": "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "windows_aarch64_gnullvm",
+            "crate_root": "src/lib.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        },
+        {
+          "BuildScript": {
+            "crate_name": "build_script_build",
+            "crate_root": "build.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        }
+      ],
+      "library_target_name": "windows_aarch64_gnullvm",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "windows_aarch64_gnullvm 0.52.5",
+              "target": "build_script_build"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.52.5"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -16516,6 +16856,59 @@
       },
       "license": "MIT OR Apache-2.0"
     },
+    "windows_aarch64_msvc 0.52.5": {
+      "name": "windows_aarch64_msvc",
+      "version": "0.52.5",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/windows_aarch64_msvc/0.52.5/download",
+          "sha256": "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "windows_aarch64_msvc",
+            "crate_root": "src/lib.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        },
+        {
+          "BuildScript": {
+            "crate_name": "build_script_build",
+            "crate_root": "build.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        }
+      ],
+      "library_target_name": "windows_aarch64_msvc",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "windows_aarch64_msvc 0.52.5",
+              "target": "build_script_build"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.52.5"
+      },
+      "build_script_attrs": {
+        "data_glob": [
+          "**"
+        ]
+      },
+      "license": "MIT OR Apache-2.0"
+    },
     "windows_i686_gnu 0.42.2": {
       "name": "windows_i686_gnu",
       "version": "0.42.2",
@@ -16614,6 +17007,112 @@
         },
         "edition": "2018",
         "version": "0.48.5"
+      },
+      "build_script_attrs": {
+        "data_glob": [
+          "**"
+        ]
+      },
+      "license": "MIT OR Apache-2.0"
+    },
+    "windows_i686_gnu 0.52.5": {
+      "name": "windows_i686_gnu",
+      "version": "0.52.5",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/windows_i686_gnu/0.52.5/download",
+          "sha256": "88ba073cf16d5372720ec942a8ccbf61626074c6d4dd2e745299726ce8b89670"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "windows_i686_gnu",
+            "crate_root": "src/lib.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        },
+        {
+          "BuildScript": {
+            "crate_name": "build_script_build",
+            "crate_root": "build.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        }
+      ],
+      "library_target_name": "windows_i686_gnu",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "windows_i686_gnu 0.52.5",
+              "target": "build_script_build"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.52.5"
+      },
+      "build_script_attrs": {
+        "data_glob": [
+          "**"
+        ]
+      },
+      "license": "MIT OR Apache-2.0"
+    },
+    "windows_i686_gnullvm 0.52.5": {
+      "name": "windows_i686_gnullvm",
+      "version": "0.52.5",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/windows_i686_gnullvm/0.52.5/download",
+          "sha256": "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "windows_i686_gnullvm",
+            "crate_root": "src/lib.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        },
+        {
+          "BuildScript": {
+            "crate_name": "build_script_build",
+            "crate_root": "build.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        }
+      ],
+      "library_target_name": "windows_i686_gnullvm",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "windows_i686_gnullvm 0.52.5",
+              "target": "build_script_build"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.52.5"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -16728,6 +17227,59 @@
       },
       "license": "MIT OR Apache-2.0"
     },
+    "windows_i686_msvc 0.52.5": {
+      "name": "windows_i686_msvc",
+      "version": "0.52.5",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/windows_i686_msvc/0.52.5/download",
+          "sha256": "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "windows_i686_msvc",
+            "crate_root": "src/lib.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        },
+        {
+          "BuildScript": {
+            "crate_name": "build_script_build",
+            "crate_root": "build.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        }
+      ],
+      "library_target_name": "windows_i686_msvc",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "windows_i686_msvc 0.52.5",
+              "target": "build_script_build"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.52.5"
+      },
+      "build_script_attrs": {
+        "data_glob": [
+          "**"
+        ]
+      },
+      "license": "MIT OR Apache-2.0"
+    },
     "windows_x86_64_gnu 0.42.2": {
       "name": "windows_x86_64_gnu",
       "version": "0.42.2",
@@ -16826,6 +17378,59 @@
         },
         "edition": "2018",
         "version": "0.48.5"
+      },
+      "build_script_attrs": {
+        "data_glob": [
+          "**"
+        ]
+      },
+      "license": "MIT OR Apache-2.0"
+    },
+    "windows_x86_64_gnu 0.52.5": {
+      "name": "windows_x86_64_gnu",
+      "version": "0.52.5",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/windows_x86_64_gnu/0.52.5/download",
+          "sha256": "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "windows_x86_64_gnu",
+            "crate_root": "src/lib.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        },
+        {
+          "BuildScript": {
+            "crate_name": "build_script_build",
+            "crate_root": "build.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        }
+      ],
+      "library_target_name": "windows_x86_64_gnu",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "windows_x86_64_gnu 0.52.5",
+              "target": "build_script_build"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.52.5"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -16940,6 +17545,59 @@
       },
       "license": "MIT OR Apache-2.0"
     },
+    "windows_x86_64_gnullvm 0.52.5": {
+      "name": "windows_x86_64_gnullvm",
+      "version": "0.52.5",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/windows_x86_64_gnullvm/0.52.5/download",
+          "sha256": "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "windows_x86_64_gnullvm",
+            "crate_root": "src/lib.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        },
+        {
+          "BuildScript": {
+            "crate_name": "build_script_build",
+            "crate_root": "build.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        }
+      ],
+      "library_target_name": "windows_x86_64_gnullvm",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "windows_x86_64_gnullvm 0.52.5",
+              "target": "build_script_build"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.52.5"
+      },
+      "build_script_attrs": {
+        "data_glob": [
+          "**"
+        ]
+      },
+      "license": "MIT OR Apache-2.0"
+    },
     "windows_x86_64_msvc 0.42.2": {
       "name": "windows_x86_64_msvc",
       "version": "0.42.2",
@@ -17046,6 +17704,59 @@
       },
       "license": "MIT OR Apache-2.0"
     },
+    "windows_x86_64_msvc 0.52.5": {
+      "name": "windows_x86_64_msvc",
+      "version": "0.52.5",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/windows_x86_64_msvc/0.52.5/download",
+          "sha256": "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "windows_x86_64_msvc",
+            "crate_root": "src/lib.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        },
+        {
+          "BuildScript": {
+            "crate_name": "build_script_build",
+            "crate_root": "build.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        }
+      ],
+      "library_target_name": "windows_x86_64_msvc",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "windows_x86_64_msvc 0.52.5",
+              "target": "build_script_build"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.52.5"
+      },
+      "build_script_attrs": {
+        "data_glob": [
+          "**"
+        ]
+      },
+      "license": "MIT OR Apache-2.0"
+    },
     "winnow 0.5.14": {
       "name": "winnow",
       "version": "0.5.14",
@@ -17122,6 +17833,65 @@
         "version": "0.5.1"
       },
       "license": "MIT"
+    },
+    "xattr 1.3.1": {
+      "name": "xattr",
+      "version": "1.3.1",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/xattr/1.3.1/download",
+          "sha256": "8da84f1a25939b27f6820d92aed108f83ff920fdf11a7b19366c27c4cda81d4f"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "xattr",
+            "crate_root": "src/lib.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        }
+      ],
+      "library_target_name": "xattr",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "default",
+            "unsupported"
+          ],
+          "selects": {}
+        },
+        "deps": {
+          "common": [
+            {
+              "id": "rustix 0.38.34",
+              "target": "rustix"
+            }
+          ],
+          "selects": {
+            "cfg(any(target_os = \"freebsd\", target_os = \"netbsd\"))": [
+              {
+                "id": "libc 0.2.155",
+                "target": "libc"
+              }
+            ],
+            "cfg(target_os = \"linux\")": [
+              {
+                "id": "linux-raw-sys 0.4.14",
+                "target": "linux_raw_sys"
+              }
+            ]
+          }
+        },
+        "edition": "2021",
+        "version": "1.3.1"
+      },
+      "license": "MIT/Apache-2.0"
     },
     "yaml-rust 0.4.5": {
       "name": "yaml-rust",
@@ -17277,6 +18047,9 @@
     "armv7-unknown-linux-gnueabi": [
       "armv7-unknown-linux-gnueabi"
     ],
+    "cfg(all(any(target_arch = \"x86_64\", target_arch = \"arm64ec\"), target_env = \"msvc\", not(windows_raw_dylib)))": [
+      "x86_64-pc-windows-msvc"
+    ],
     "cfg(all(any(target_os = \"android\", target_os = \"linux\"), any(rustix_use_libc, miri, not(all(target_os = \"linux\", target_endian = \"little\", any(target_arch = \"arm\", all(target_arch = \"aarch64\", target_pointer_width = \"64\"), target_arch = \"riscv64\", all(rustix_use_experimental_asm, target_arch = \"powerpc64\"), all(rustix_use_experimental_asm, target_arch = \"mips\"), all(rustix_use_experimental_asm, target_arch = \"mips32r6\"), all(rustix_use_experimental_asm, target_arch = \"mips64\"), all(rustix_use_experimental_asm, target_arch = \"mips64r6\"), target_arch = \"x86\", all(target_arch = \"x86_64\", target_pointer_width = \"64\")))))))": [
       "aarch64-linux-android",
       "armv7-linux-androideabi",
@@ -17326,6 +18099,9 @@
     "cfg(all(target_arch = \"wasm32\", not(target_os = \"wasi\")))": [
       "wasm32-unknown-unknown"
     ],
+    "cfg(all(target_arch = \"x86\", target_env = \"gnu\", not(target_abi = \"llvm\"), not(windows_raw_dylib)))": [
+      "i686-unknown-linux-gnu"
+    ],
     "cfg(all(target_arch = \"x86\", target_env = \"gnu\", not(windows_raw_dylib)))": [
       "i686-unknown-linux-gnu"
     ],
@@ -17338,6 +18114,10 @@
     ],
     "cfg(all(target_arch = \"x86_64\", target_env = \"msvc\", not(windows_raw_dylib)))": [
       "x86_64-pc-windows-msvc"
+    ],
+    "cfg(any(target_os = \"freebsd\", target_os = \"netbsd\"))": [
+      "i686-unknown-freebsd",
+      "x86_64-unknown-freebsd"
     ],
     "cfg(any(target_os = \"linux\", target_os = \"android\", target_os = \"windows\", target_os = \"macos\", target_os = \"ios\", target_os = \"freebsd\", target_os = \"openbsd\", target_os = \"netbsd\", target_os = \"dragonfly\", target_os = \"solaris\", target_os = \"illumos\", target_os = \"fuchsia\", target_os = \"redox\", target_os = \"cloudabi\", target_os = \"haiku\", target_os = \"vxworks\", target_os = \"emscripten\", target_os = \"wasi\"))": [
       "aarch64-apple-darwin",
@@ -17621,8 +18401,18 @@
       "wasm32-unknown-unknown",
       "wasm32-wasi"
     ],
-    "cfg(target_os = \"dragonfly\")": [],
     "cfg(target_os = \"hermit\")": [],
+    "cfg(target_os = \"linux\")": [
+      "aarch64-unknown-linux-gnu",
+      "aarch64-unknown-nixos-gnu",
+      "arm-unknown-linux-gnueabi",
+      "armv7-unknown-linux-gnueabi",
+      "i686-unknown-linux-gnu",
+      "powerpc-unknown-linux-gnu",
+      "s390x-unknown-linux-gnu",
+      "x86_64-unknown-linux-gnu",
+      "x86_64-unknown-nixos-gnu"
+    ],
     "cfg(target_os = \"redox\")": [],
     "cfg(target_os = \"wasi\")": [
       "wasm32-wasi"
@@ -17672,6 +18462,7 @@
       "i686-linux-android"
     ],
     "i686-pc-windows-gnu": [],
+    "i686-pc-windows-gnullvm": [],
     "i686-pc-windows-msvc": [
       "i686-pc-windows-msvc"
     ],
@@ -17757,18 +18548,20 @@
     "lazy_static 1.4.0",
     "once_cell 1.18.0",
     "paste 1.0.14",
+    "path-clean 1.0.1",
     "predicates 3.0.4",
     "protobuf 3.2.0",
     "regex 1.9.3",
     "rocket 0.5.0-rc.3",
     "rustc-hash 1.1.0",
-    "rustix 0.38.8",
+    "rustix 0.38.34",
     "rustyline 9.1.2",
     "scip 0.3.2",
     "serde 1.0.194",
     "serde_json 1.0.99",
     "string-interner 0.14.0",
     "syntect 4.7.0",
+    "tar 0.4.40",
     "tree-sitter 0.20.10",
     "tree-sitter-c 0.20.6",
     "tree-sitter-c-sharp 0.20.0",
@@ -17797,6 +18590,7 @@
   ],
   "direct_dev_deps": [
     "criterion 0.4.0",
-    "pretty_assertions 1.4.0"
+    "pretty_assertions 1.4.0",
+    "tempfile 3.10.1"
   ]
 }

--- a/docker-images/syntax-highlighter/Cargo.lock
+++ b/docker-images/syntax-highlighter/Cargo.lock
@@ -1352,6 +1352,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
 
 [[package]]
+name = "path-clean"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17359afc20d7ab31fdb42bb844c8b3bb1dabd7dcf7e68428492da7f16966fcef"
+
+[[package]]
 name = "pear"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1908,6 +1914,7 @@ dependencies = [
  "insta",
  "lazy_static",
  "paste",
+ "path-clean",
  "predicates",
  "protobuf",
  "scip",

--- a/docker-images/syntax-highlighter/Cargo.lock
+++ b/docker-images/syntax-highlighter/Cargo.lock
@@ -625,23 +625,12 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.2"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b30f669a7961ef1631673d2766cc92f52d64f7ef354d4fe0ddfd30ed52f0f4f"
+checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
 dependencies = [
- "errno-dragonfly",
  "libc",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "errno-dragonfly"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
-dependencies = [
- "cc",
- "libc",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -683,6 +672,18 @@ dependencies = [
  "toml",
  "uncased",
  "version_check",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ee447700ac8aa0b2f2bd7bc4462ad686ba06baa6727ac149a2d6277f0d240fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall 0.4.1",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1068,9 +1069,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.147"
+version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
+checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
 name = "line-wrap"
@@ -1089,9 +1090,9 @@ checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.5"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57bcfdad1b858c2db7c38303a6d2ad4dfaf5eb53dfeb0910128b2c26d6158503"
+checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
 name = "lock_api"
@@ -1645,6 +1646,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1815,15 +1825,15 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustix"
-version = "0.38.8"
+version = "0.38.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19ed4fa021d81c8392ce04db050a3da9a60299050b7ae1cf482d862b54a7218f"
+checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
 dependencies = [
  "bitflags 2.4.0",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1905,6 +1915,7 @@ dependencies = [
  "serde_json",
  "string-interner",
  "syntax-analysis",
+ "tar",
  "tree-sitter-all-languages",
  "walkdir",
 ]
@@ -2159,6 +2170,17 @@ name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
+name = "tar"
+version = "0.4.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b16afcea1f22891c49a00c751c7b63b2233284064f11a200fc624137c51e2ddb"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
 
 [[package]]
 name = "tempfile"
@@ -2893,6 +2915,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.5",
+]
+
+[[package]]
 name = "windows-targets"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2923,6 +2954,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-targets"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.5",
+ "windows_aarch64_msvc 0.52.5",
+ "windows_i686_gnu 0.52.5",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc 0.52.5",
+ "windows_x86_64_gnu 0.52.5",
+ "windows_x86_64_gnullvm 0.52.5",
+ "windows_x86_64_msvc 0.52.5",
+]
+
+[[package]]
 name = "windows_aarch64_gnullvm"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2933,6 +2980,12 @@ name = "windows_aarch64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -2947,6 +3000,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
+
+[[package]]
 name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2957,6 +3016,18 @@ name = "windows_i686_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88ba073cf16d5372720ec942a8ccbf61626074c6d4dd2e745299726ce8b89670"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -2971,6 +3042,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2981,6 +3058,12 @@ name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -2995,6 +3078,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3005,6 +3094,12 @@ name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
 
 [[package]]
 name = "winnow"
@@ -3022,6 +3117,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
+]
+
+[[package]]
+name = "xattr"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8da84f1a25939b27f6820d92aed108f83ff920fdf11a7b19366c27c4cda81d4f"
+dependencies = [
+ "libc",
+ "linux-raw-sys",
+ "rustix",
 ]
 
 [[package]]

--- a/docker-images/syntax-highlighter/Cargo.lock
+++ b/docker-images/syntax-highlighter/Cargo.lock
@@ -645,9 +645,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6999dc1837253364c2ebb0704ba97994bd874e8f195d665c50b7548f6ea92764"
+checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
 
 [[package]]
 name = "fd-lock"
@@ -1916,6 +1916,7 @@ dependencies = [
  "string-interner",
  "syntax-analysis",
  "tar",
+ "tempfile",
  "tree-sitter-all-languages",
  "walkdir",
 ]
@@ -2184,15 +2185,14 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.8.0"
+version = "3.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb94d2f3cc536af71caac6b6fcebf65860b347e7ce0cc9ebe8f70d3e521054ef"
+checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
 dependencies = [
  "cfg-if",
  "fastrand",
- "redox_syscall 0.3.5",
  "rustix",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/docker-images/syntax-highlighter/Cargo.toml
+++ b/docker-images/syntax-highlighter/Cargo.toml
@@ -59,6 +59,7 @@ syntect = { git = "https://github.com/sourcegraph/syntect", rev = "7e02c5b4085e6
 tree-sitter = "0.20.9"
 tree-sitter-highlight = "0.20.1"
 walkdir = "2"
+path-clean = "1"
 
 scip = "0.3.2"
 protobuf = "3"

--- a/docker-images/syntax-highlighter/crates/scip-syntax/BUILD.bazel
+++ b/docker-images/syntax-highlighter/crates/scip-syntax/BUILD.bazel
@@ -94,6 +94,7 @@ rust_test(
     tags = [TAG_PLATFORM_GRAPH],
     deps = all_crate_deps(
         normal = True,
+        normal_dev = True,
     ) + [
         ":scip-syntax",
         ":scip_syntax_lib",

--- a/docker-images/syntax-highlighter/crates/scip-syntax/Cargo.toml
+++ b/docker-images/syntax-highlighter/crates/scip-syntax/Cargo.toml
@@ -30,3 +30,6 @@ tar = "0.4.40"
 
 [profile.release]
 debug=true
+
+[dev-dependencies]
+tempfile="3.10.1"

--- a/docker-images/syntax-highlighter/crates/scip-syntax/Cargo.toml
+++ b/docker-images/syntax-highlighter/crates/scip-syntax/Cargo.toml
@@ -29,8 +29,5 @@ syntax-analysis = { path = "../syntax-analysis" }
 tree-sitter-all-languages = { path = "../tree-sitter-all-languages" }
 tar = "0.4.40"
 
-[profile.release]
-debug=true
-
 [dev-dependencies]
 tempfile="3.10.1"

--- a/docker-images/syntax-highlighter/crates/scip-syntax/Cargo.toml
+++ b/docker-images/syntax-highlighter/crates/scip-syntax/Cargo.toml
@@ -23,6 +23,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 string-interner = { workspace = true }
 walkdir = { workspace = true }
+path-clean = { workspace = true }
 
 syntax-analysis = { path = "../syntax-analysis" }
 tree-sitter-all-languages = { path = "../tree-sitter-all-languages" }

--- a/docker-images/syntax-highlighter/crates/scip-syntax/Cargo.toml
+++ b/docker-images/syntax-highlighter/crates/scip-syntax/Cargo.toml
@@ -27,3 +27,6 @@ walkdir = { workspace = true }
 syntax-analysis = { path = "../syntax-analysis" }
 tree-sitter-all-languages = { path = "../tree-sitter-all-languages" }
 tar = "0.4.40"
+
+[profile.release]
+debug=true

--- a/docker-images/syntax-highlighter/crates/scip-syntax/Cargo.toml
+++ b/docker-images/syntax-highlighter/crates/scip-syntax/Cargo.toml
@@ -26,3 +26,4 @@ walkdir = { workspace = true }
 
 syntax-analysis = { path = "../syntax-analysis" }
 tree-sitter-all-languages = { path = "../tree-sitter-all-languages" }
+tar = "0.4.40"

--- a/docker-images/syntax-highlighter/crates/scip-syntax/src/index.rs
+++ b/docker-images/syntax-highlighter/crates/scip-syntax/src/index.rs
@@ -1,6 +1,7 @@
-use std::env;
 use std::{
+    env,
     fs::File,
+    io::{self, prelude::*},
     path::{Path, PathBuf},
 };
 
@@ -8,7 +9,6 @@ use anyhow::{anyhow, bail, Context, Result};
 use clap::ValueEnum;
 use path_clean;
 use scip::{types::Document, write_message_to_file};
-use std::io::{self, prelude::*};
 use syntax_analysis::{get_globals, get_locals};
 use tree_sitter_all_languages::ParserId;
 

--- a/docker-images/syntax-highlighter/crates/scip-syntax/src/index.rs
+++ b/docker-images/syntax-highlighter/crates/scip-syntax/src/index.rs
@@ -114,7 +114,12 @@ pub fn index_command(
             for filename in list {
                 let filepath = PathBuf::from(filename).canonicalize()?;
                 bar.set_message(filepath.display().to_string());
-                index_file(&filepath, parser_id, &canonical_project_root, &options)?;
+                index.documents.push(index_file(
+                    &filepath,
+                    parser_id,
+                    &canonical_project_root,
+                    &options,
+                )?);
                 bar.inc(1);
             }
 
@@ -148,12 +153,12 @@ pub fn index_command(
                 };
                 if extensions.contains(extension) {
                     bar.set_message(entry.path().display().to_string());
-                    index_file(
+                    index.documents.push(index_file(
                         &entry.into_path(),
                         parser_id,
                         &canonical_project_root,
                         &options,
-                    )?;
+                    )?);
                     bar.tick();
                 }
             }

--- a/docker-images/syntax-highlighter/crates/scip-syntax/src/index.rs
+++ b/docker-images/syntax-highlighter/crates/scip-syntax/src/index.rs
@@ -214,7 +214,7 @@ fn index_file(
             )
         })?;
 
-    match index_content(&contents, parser_id, &options) {
+    match index_content(&contents, parser_id, options) {
         Ok(mut document) => {
             document.relative_path = relative_path.display().to_string();
             Ok(document)
@@ -243,7 +243,7 @@ fn index_tar_entries<R: Read>(
         {
             match e.read_to_string(&mut contents) {
                 Ok(size) => {
-                    match index_content(&contents, parser, &options) {
+                    match index_content(&contents, parser, options) {
                         Ok(mut document) => {
                             document.relative_path = path.display().to_string();
                             documents.push(document);
@@ -278,7 +278,7 @@ fn index_tar_entries<R: Read>(
             }
 
             progress += 1;
-            spinner.set_message(format!("[{}]: {}", progress, path.display().to_string()));
+            spinner.set_message(format!("[{}]: {}", progress, path.display()));
             spinner.tick();
         }
     }

--- a/docker-images/syntax-highlighter/crates/scip-syntax/src/index.rs
+++ b/docker-images/syntax-highlighter/crates/scip-syntax/src/index.rs
@@ -46,24 +46,23 @@ impl AnalysisMode {
 }
 
 pub enum TarMode {
+    /// Data is streamed from STDIN
     Stdin,
+
+    /// Data is read from a .tar file
     File { location: PathBuf },
 }
 
 pub enum IndexMode {
     /// Index only this list of files, without checking file extensions
-    Files {
-        list: Vec<String>,
-    },
+    Files { list: Vec<String> },
     /// Discover all files that can be handled by the chosen language
     /// in the passed location (which has to be a directory)
-    Workspace {
-        location: PathBuf,
-    },
+    Workspace { location: PathBuf },
 
-    TarArchive {
-        input: TarMode,
-    },
+    /// Discover all files that can be handled by the chosen language
+    /// in either a .tar file, or from STDIN to which TAR data is streamed
+    TarArchive { input: TarMode },
 }
 
 fn make_absolute(cwd: &Path, path: &Path) -> PathBuf {

--- a/docker-images/syntax-highlighter/crates/scip-syntax/src/index.rs
+++ b/docker-images/syntax-highlighter/crates/scip-syntax/src/index.rs
@@ -26,7 +26,7 @@ pub struct IndexOptions {
     pub fail_fast: bool,
 }
 
-#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum, Debug)]
 pub enum AnalysisMode {
     /// Only extract occurrences of local definitions
     Locals,

--- a/docker-images/syntax-highlighter/crates/scip-syntax/src/index.rs
+++ b/docker-images/syntax-highlighter/crates/scip-syntax/src/index.rs
@@ -198,14 +198,14 @@ pub fn index_command(
 fn index_file(
     filepath: &Path,
     parser_id: ParserId,
-    absolute_project_root: &PathBuf,
+    absolute_project_root: &Path,
     options: &IndexOptions,
 ) -> Result<Document> {
     let contents = std::fs::read_to_string(filepath)
         .with_context(|| format!("Failed to read file at {}", filepath.display()))?;
 
     let relative_path = filepath
-        .strip_prefix(absolute_project_root.clone())
+        .strip_prefix(absolute_project_root)
         .with_context(|| {
             format!(
                 "Failed to strip project root prefix: root={} file={}",

--- a/docker-images/syntax-highlighter/crates/scip-syntax/src/index.rs
+++ b/docker-images/syntax-highlighter/crates/scip-syntax/src/index.rs
@@ -193,13 +193,20 @@ fn index_file(
     let contents = std::fs::read_to_string(filepath)
         .with_context(|| format!("Failed to read file at {}", filepath.display()))?;
 
-    let filepath = if filepath.is_absolute() {
-        filepath.to_owned()
-    } else {
-        filepath
-            .canonicalize()
-            .with_context(|| format!("Failed to canonicalize file path: {}", filepath.display()))?
-    };
+    // TODO(Anton&Christoph): revise this logic. currently uncommented version is the only one that
+    // passes tests on MacOS
+    //let filepath = if filepath.is_absolute() {
+    //    filepath.to_owned()
+    //} else {
+    //    filepath
+    //        .canonicalize()
+    //        .with_context(|| format!("Failed to canonicalize file path: {}", filepath.display()))?
+    //};
+    //
+    let filepath = filepath
+        .canonicalize()
+        .with_context(|| format!("Failed to canonicalize file path: {}", filepath.display()))?;
+    // end TODO
 
     let relative_path = filepath
         .strip_prefix(canonical_project_root.clone())

--- a/docker-images/syntax-highlighter/crates/scip-syntax/src/index.rs
+++ b/docker-images/syntax-highlighter/crates/scip-syntax/src/index.rs
@@ -1,16 +1,16 @@
+use std::env;
 use std::{
     fs::File,
     path::{Path, PathBuf},
 };
-use std::env;
 
 use anyhow::{anyhow, bail, Context, Result};
 use clap::ValueEnum;
+use path_clean;
 use scip::{types::Document, write_message_to_file};
 use std::io::{self, prelude::*};
 use syntax_analysis::{get_globals, get_locals};
 use tree_sitter_all_languages::ParserId;
-use path_clean;
 
 use crate::{
     evaluate::Evaluator,
@@ -120,7 +120,12 @@ pub fn index_command(
             for filename in list {
                 let filepath = make_absolute(&cwd, &PathBuf::from(filename));
                 bar.set_message(filepath.display().to_string());
-                index.documents.push(index_file(&filepath, parser_id, &absolute_project_root, &options)?);
+                index.documents.push(index_file(
+                    &filepath,
+                    parser_id,
+                    &absolute_project_root,
+                    &options,
+                )?);
                 bar.inc(1);
             }
 

--- a/docker-images/syntax-highlighter/crates/scip-syntax/src/io.rs
+++ b/docker-images/syntax-highlighter/crates/scip-syntax/src/io.rs
@@ -1,6 +1,6 @@
-use anyhow::{Context, Result};
 use std::{fs::File, io::BufReader, path::PathBuf};
 
+use anyhow::{Context, Result};
 use protobuf::{CodedInputStream, Message};
 
 pub fn read_index_from_file(file: &PathBuf) -> Result<scip::types::Index> {

--- a/docker-images/syntax-highlighter/crates/scip-syntax/src/io.rs
+++ b/docker-images/syntax-highlighter/crates/scip-syntax/src/io.rs
@@ -1,6 +1,6 @@
+use anyhow::{Context, Result};
 use std::{fs::File, io::BufReader, path::PathBuf};
 
-use anyhow::{Context, Result};
 use protobuf::{CodedInputStream, Message};
 
 pub fn read_index_from_file(file: &PathBuf) -> Result<scip::types::Index> {

--- a/docker-images/syntax-highlighter/crates/scip-syntax/src/main.rs
+++ b/docker-images/syntax-highlighter/crates/scip-syntax/src/main.rs
@@ -1,6 +1,7 @@
+use std::{path::PathBuf, process};
+
 use clap::{Parser, Subcommand};
 use scip_syntax::index::{index_command, AnalysisMode, IndexMode, IndexOptions};
-use std::{path::PathBuf, process};
 
 #[derive(Parser)]
 #[command(author, version, about, long_about = None)]

--- a/docker-images/syntax-highlighter/crates/scip-syntax/src/main.rs
+++ b/docker-images/syntax-highlighter/crates/scip-syntax/src/main.rs
@@ -1,6 +1,6 @@
 use clap::{Parser, Subcommand};
 use scip_syntax::index::{index_command, AnalysisMode, IndexMode, IndexOptions};
-use std::path::PathBuf;
+use std::{path::PathBuf, process};
 
 #[derive(Parser)]
 #[command(author, version, about, long_about = None)]
@@ -123,20 +123,27 @@ pub fn main() -> anyhow::Result<()> {
                             location: PathBuf::from(loc),
                         },
                     },
-                    None => {
-                        match workspace {
-                            None => IndexMode::Files { list: filenames },
-                            Some(location) => {
-                                if !filenames.is_empty() {
-                                    panic!("--workspace option cannot be combined with a list of files");
-                                } else {
-                                    IndexMode::Workspace {
-                                        location: location.into(),
-                                    }
+                    None => match workspace {
+                        None => {
+                            if filenames.is_empty() {
+                                eprintln!("either specify --workspace or provide a list of files");
+                                process::exit(1)
+                            }
+                            IndexMode::Files { list: filenames }
+                        }
+                        Some(location) => {
+                            if !filenames.is_empty() {
+                                eprintln!(
+                                    "--workspace option cannot be combined with a list of files"
+                                );
+                                process::exit(1)
+                            } else {
+                                IndexMode::Workspace {
+                                    location: location.into(),
                                 }
                             }
                         }
-                    }
+                    },
                 }
             };
 

--- a/docker-images/syntax-highlighter/crates/scip-syntax/src/main.rs
+++ b/docker-images/syntax-highlighter/crates/scip-syntax/src/main.rs
@@ -33,7 +33,7 @@ enum Commands {
         /// List of files to analyse
         filenames: Vec<String>,
 
-        /// Tar file to index
+        /// Either a path to .tar file, or "-" to read .tar data from STDIN
         #[arg(long)]
         tar: Option<String>,
 

--- a/docker-images/syntax-highlighter/crates/scip-syntax/src/main.rs
+++ b/docker-images/syntax-highlighter/crates/scip-syntax/src/main.rs
@@ -47,7 +47,6 @@ enum IndexCommand {
         /// and files will be discovered according to
         /// configured extensions for the selected language
         /// Has to be absolute path.
-        #[arg(long)]
         dir: String,
 
         #[command(flatten)]
@@ -138,7 +137,7 @@ pub fn main() -> anyhow::Result<()> {
             let result = match index1.index_command {
                 IndexCommand::Files { filenames, options } => {
                     if filenames.is_empty() {
-                        eprintln!("either specify --workspace or provide a list of files");
+                        eprintln!("List of files cannot be empty");
                         process::exit(1)
                     }
                     run_index_command(options, IndexMode::Files { list: filenames })

--- a/docker-images/syntax-highlighter/crates/scip-syntax/testdata/package-info.java
+++ b/docker-images/syntax-highlighter/crates/scip-syntax/testdata/package-info.java
@@ -1,0 +1,4 @@
+@Deprecated
+package foo.bar;
+
+class Baz {}

--- a/docker-images/syntax-highlighter/crates/scip-syntax/tests/integration_test.rs
+++ b/docker-images/syntax-highlighter/crates/scip-syntax/tests/integration_test.rs
@@ -293,7 +293,6 @@ fn create_tar(files: &HashMap<PathBuf, String>) -> Result<Vec<u8>, std::io::Erro
         ar.append(&header, bytes).unwrap();
     }
 
-    ar.finish().expect("Failed to close TAR archive");
     ar.into_inner()
 }
 

--- a/docker-images/syntax-highlighter/crates/scip-syntax/tests/integration_test.rs
+++ b/docker-images/syntax-highlighter/crates/scip-syntax/tests/integration_test.rs
@@ -5,7 +5,7 @@ use std::{
     process::{Command, Stdio},
 };
 
-use anyhow::{anyhow, Context};
+use anyhow::{anyhow, Context, Result};
 use assert_cmd::{cargo::cargo_bin, prelude::*};
 use scip::types::Document;
 use scip_syntax::{
@@ -105,7 +105,7 @@ fn java_files_indexing() {
     let output_location = out_dir.join("index.scip");
     let paths = extract_paths(&setup);
 
-    prepare(&out_dir, &setup);
+    prepare(&out_dir, &setup).unwrap();
 
     cmd.args(vec![
         "--language",
@@ -135,7 +135,7 @@ fn java_workspace_indexing() {
     let mut cmd = command("index");
     let output_location = out_dir.join("index.scip");
 
-    prepare(&out_dir, &setup);
+    prepare(&out_dir, &setup).unwrap();
 
     cmd.args(vec![
         "--workspace",
@@ -169,7 +169,7 @@ fn java_tar_file_indexing() {
     let tar_file = out_dir.join("test.tar");
     let output_location = out_dir.join("index.scip");
 
-    write_file_bytes(&tar_file, &data);
+    write_file_bytes(&tar_file, &data).unwrap();
 
     cmd.args(vec![
         "--tar",
@@ -203,7 +203,9 @@ fn java_tar_stream_indexing() {
     let tar_file = out_dir.join("test.tar");
     let output_location = out_dir.join("index.scip");
 
-    write_file_bytes(&tar_file, &data);
+    write_file_bytes(&tar_file, &data)
+        .context("Failed to write tar data")
+        .unwrap();
 
     let mut spawned = cmd
         .args(vec![
@@ -233,11 +235,13 @@ fn java_tar_stream_indexing() {
     insta::assert_snapshot!(index_snapshot);
 }
 
-fn prepare(temp: &Path, files: &HashMap<PathBuf, String>) {
+fn prepare(temp: &Path, files: &HashMap<PathBuf, String>) -> Result<()> {
     for (path, contents) in files.iter() {
         let file_path = temp.join(path);
-        write_file_string(&file_path, contents);
+        write_file_string(&file_path, contents)?;
     }
+
+    Ok(())
 }
 
 fn command(sub: &str) -> Command {
@@ -248,11 +252,11 @@ fn command(sub: &str) -> Command {
     cmd
 }
 
-fn write_file_string(path: &PathBuf, contents: &String) {
-    write_file_bytes(path, contents.as_bytes());
+fn write_file_string(path: &PathBuf, contents: &String) -> Result<()> {
+    write_file_bytes(path, contents.as_bytes())
 }
 
-fn write_file_bytes(path: &PathBuf, contents: &[u8]) {
+fn write_file_bytes(path: &PathBuf, contents: &[u8]) -> Result<()> {
     use std::io::Write;
 
     let Some(parent) = path.parent() else {
@@ -260,12 +264,14 @@ fn write_file_bytes(path: &PathBuf, contents: &[u8]) {
     };
 
     std::fs::create_dir_all(parent)
-        .expect(format!("Failed to create all parent folders for {:?}", path).as_str());
+        .with_context(|| anyhow!("Failed to create all parent folders for {:?}", path))?;
 
     let output = std::fs::File::create(path)
-        .expect(format!("Failed to open file {} for writing", path.to_str().unwrap()).as_str());
+        .with_context(|| anyhow!("Failed to open file {} for writing", path.to_str().unwrap()))?;
     let mut writer = std::io::BufWriter::new(output);
-    writer.write_all(contents).unwrap();
+    writer.write_all(contents)?;
+
+    Ok(())
 }
 
 fn tempdir() -> PathBuf {
@@ -275,7 +281,7 @@ fn tempdir() -> PathBuf {
 fn create_tar(files: &HashMap<PathBuf, String>) -> Result<Vec<u8>, std::io::Error> {
     let mut ar = Builder::new(Vec::new());
 
-    for (path, text) in files.into_iter() {
+    for (path, text) in files.iter() {
         let mut header = Header::new_gnu();
         let bytes = text.as_bytes();
 
@@ -321,9 +327,9 @@ fn extract_indexed_paths(index: &scip::types::Index) -> HashSet<String> {
         .collect()
 }
 
-fn snapshot_from_files(docs: &Vec<Document>, project_root: &Path) -> String {
+fn snapshot_from_files(docs: &[Document], project_root: &Path) -> String {
     let mut str = String::new();
-    let mut docs = docs.clone();
+    let mut docs = docs.to_owned();
     docs.sort_by_key(|doc| doc.relative_path.clone());
 
     for doc in docs {
@@ -338,18 +344,18 @@ fn snapshot_from_files(docs: &Vec<Document>, project_root: &Path) -> String {
     str
 }
 
-fn format_snapshot_document(doc: &scip::types::Document, contents: &String) -> String {
+fn format_snapshot_document(doc: &scip::types::Document, contents: &str) -> String {
     let mut str = String::new();
     str.push_str(format!("//----FILE={}\n", doc.relative_path).as_str());
-    str.push_str(&snapshot_syntax_document(&doc, &contents));
+    str.push_str(&snapshot_syntax_document(doc, contents));
     str.push_str("\n\n");
 
     str
 }
 
-fn snapshot_from_data(docs: &Vec<Document>, data: &HashMap<PathBuf, String>) -> String {
+fn snapshot_from_data(docs: &[Document], data: &HashMap<PathBuf, String>) -> String {
     let mut str = String::new();
-    let mut docs = docs.clone();
+    let mut docs = docs.to_owned();
     docs.sort_by_key(|doc| doc.relative_path.clone());
 
     for doc in docs {

--- a/docker-images/syntax-highlighter/crates/scip-syntax/tests/integration_test.rs
+++ b/docker-images/syntax-highlighter/crates/scip-syntax/tests/integration_test.rs
@@ -140,7 +140,6 @@ fn java_workspace_indexing() {
 
     cmd.args(vec![
         "workspace",
-        "--dir",
         out_dir.to_str().unwrap(),
         "--language",
         "java",

--- a/docker-images/syntax-highlighter/crates/scip-syntax/tests/integration_test.rs
+++ b/docker-images/syntax-highlighter/crates/scip-syntax/tests/integration_test.rs
@@ -108,6 +108,7 @@ fn java_files_indexing() {
     prepare(&out_dir, &setup).unwrap();
 
     cmd.args(vec![
+        "files",
         "--language",
         "java",
         "--out",
@@ -138,7 +139,8 @@ fn java_workspace_indexing() {
     prepare(&out_dir, &setup).unwrap();
 
     cmd.args(vec![
-        "--workspace",
+        "workspace",
+        "--dir",
         out_dir.to_str().unwrap(),
         "--language",
         "java",
@@ -172,7 +174,7 @@ fn java_tar_file_indexing() {
     write_file_bytes(&tar_file, &data).unwrap();
 
     cmd.args(vec![
-        "--tar",
+        "tar",
         tar_file.to_str().unwrap(),
         "--language",
         "java",
@@ -209,7 +211,7 @@ fn java_tar_stream_indexing() {
 
     let mut spawned = cmd
         .args(vec![
-            "--tar",
+            "tar",
             "-",
             "--language",
             "java",

--- a/docker-images/syntax-highlighter/crates/scip-syntax/tests/integration_test.rs
+++ b/docker-images/syntax-highlighter/crates/scip-syntax/tests/integration_test.rs
@@ -1,9 +1,8 @@
-use std::io::Write;
-use std::process::Stdio;
 use std::{
     collections::{HashMap, HashSet},
+    io::Write,
     path::{Path, PathBuf},
-    process::Command,
+    process::{Command, Stdio},
 };
 
 use anyhow::{anyhow, Context};

--- a/docker-images/syntax-highlighter/crates/scip-syntax/tests/snapshots/integration_test__java_files_indexing.snap
+++ b/docker-images/syntax-highlighter/crates/scip-syntax/tests/snapshots/integration_test__java_files_indexing.snap
@@ -1,7 +1,17 @@
 ---
 source: crates/scip-syntax/tests/integration_test.rs
-expression: dumped
+expression: index_snapshot
 ---
+//----FILE=package-info.java
+  @Deprecated
+  package foo.bar;
+//        ^^^^^^^ definition(Package) scip-ctags `foo.bar`/
+  
+  class Baz {}
+//      ^^^ definition scip-ctags `foo.bar`/Baz#
+
+
+//----FILE=src/main/java/globals.java
   package MyPackage;
 //        ^^^^^^^^^ definition(Package) scip-ctags MyPackage/
   
@@ -71,4 +81,6 @@ expression: dumped
           }
       }
   }
+
+
 

--- a/docker-images/syntax-highlighter/crates/scip-syntax/tests/snapshots/integration_test__java_tar_file_indexing.snap
+++ b/docker-images/syntax-highlighter/crates/scip-syntax/tests/snapshots/integration_test__java_tar_file_indexing.snap
@@ -1,0 +1,86 @@
+---
+source: crates/scip-syntax/tests/integration_test.rs
+expression: index_snapshot
+---
+//----FILE=package-info.java
+  @Deprecated
+  package foo.bar;
+//        ^^^^^^^ definition(Package) scip-ctags `foo.bar`/
+  
+  class Baz {}
+//      ^^^ definition scip-ctags `foo.bar`/Baz#
+
+
+//----FILE=src/main/java/globals.java
+  package MyPackage;
+//        ^^^^^^^^^ definition(Package) scip-ctags MyPackage/
+  
+  public class globals {
+//             ^^^^^^^ definition scip-ctags MyPackage/globals#
+      private static int field1;
+//                       ^^^^^^ definition scip-ctags MyPackage/globals#field1.
+      protected static int field2;
+//                         ^^^^^^ definition scip-ctags MyPackage/globals#field2.
+      public static int field3;
+//                      ^^^^^^ definition scip-ctags MyPackage/globals#field3.
+      private int field4;
+//                ^^^^^^ definition scip-ctags MyPackage/globals#field4.
+      protected int field5;
+//                  ^^^^^^ definition scip-ctags MyPackage/globals#field5.
+      public int field6;
+//               ^^^^^^ definition scip-ctags MyPackage/globals#field6.
+  
+      private static void method1() {}
+//                        ^^^^^^^ definition scip-ctags MyPackage/globals#method1().
+      protected static void method2() {}
+//                          ^^^^^^^ definition scip-ctags MyPackage/globals#method2().
+      public static void method3() {}
+//                       ^^^^^^^ definition scip-ctags MyPackage/globals#method3().
+      private void method4() {}
+//                 ^^^^^^^ definition scip-ctags MyPackage/globals#method4().
+      protected void method5() {}
+//                   ^^^^^^^ definition scip-ctags MyPackage/globals#method5().
+      public void method6() {}
+//                ^^^^^^^ definition scip-ctags MyPackage/globals#method6().
+  
+      public static final String COOLEST_STRING = "probably this one";
+//                               ^^^^^^^^^^^^^^ definition scip-ctags MyPackage/globals#COOLEST_STRING.
+  
+      public class ClassInAClass {
+//                 ^^^^^^^^^^^^^ definition scip-ctags MyPackage/globals#ClassInAClass#
+          boolean classy = true;
+//                ^^^^^^ definition scip-ctags MyPackage/globals#ClassInAClass#classy.
+  
+          public static enum Enum {
+//                           ^^^^ definition scip-ctags MyPackage/globals#ClassInAClass#Enum#
+              these,
+//            ^^^^^ definition scip-ctags MyPackage/globals#ClassInAClass#Enum#these.
+              should,
+//            ^^^^^^ definition scip-ctags MyPackage/globals#ClassInAClass#Enum#should.
+              be,
+//            ^^ definition scip-ctags MyPackage/globals#ClassInAClass#Enum#be.
+              recognized,
+//            ^^^^^^^^^^ definition scip-ctags MyPackage/globals#ClassInAClass#Enum#recognized.
+              as,
+//            ^^ definition scip-ctags MyPackage/globals#ClassInAClass#Enum#as.
+              terms
+//            ^^^^^ definition scip-ctags MyPackage/globals#ClassInAClass#Enum#terms.
+          }
+  
+          public interface Goated {
+//                         ^^^^^^ definition scip-ctags MyPackage/globals#ClassInAClass#Goated#
+              boolean withTheSauce();
+//                    ^^^^^^^^^^^^ definition scip-ctags MyPackage/globals#ClassInAClass#Goated#withTheSauce().
+          }
+  
+          public void myCoolMethod() {
+//                    ^^^^^^^^^^^^ definition scip-ctags MyPackage/globals#ClassInAClass#myCoolMethod().
+              class WhatIsGoingOn {}
+              boolean iThinkThisIsAllowedButWeDontReallyCare = true;
+//                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition local 1
+          }
+      }
+  }
+
+
+

--- a/docker-images/syntax-highlighter/crates/scip-syntax/tests/snapshots/integration_test__java_tar_stream_indexing.snap
+++ b/docker-images/syntax-highlighter/crates/scip-syntax/tests/snapshots/integration_test__java_tar_stream_indexing.snap
@@ -1,0 +1,86 @@
+---
+source: crates/scip-syntax/tests/integration_test.rs
+expression: index_snapshot
+---
+//----FILE=package-info.java
+  @Deprecated
+  package foo.bar;
+//        ^^^^^^^ definition(Package) scip-ctags `foo.bar`/
+  
+  class Baz {}
+//      ^^^ definition scip-ctags `foo.bar`/Baz#
+
+
+//----FILE=src/main/java/globals.java
+  package MyPackage;
+//        ^^^^^^^^^ definition(Package) scip-ctags MyPackage/
+  
+  public class globals {
+//             ^^^^^^^ definition scip-ctags MyPackage/globals#
+      private static int field1;
+//                       ^^^^^^ definition scip-ctags MyPackage/globals#field1.
+      protected static int field2;
+//                         ^^^^^^ definition scip-ctags MyPackage/globals#field2.
+      public static int field3;
+//                      ^^^^^^ definition scip-ctags MyPackage/globals#field3.
+      private int field4;
+//                ^^^^^^ definition scip-ctags MyPackage/globals#field4.
+      protected int field5;
+//                  ^^^^^^ definition scip-ctags MyPackage/globals#field5.
+      public int field6;
+//               ^^^^^^ definition scip-ctags MyPackage/globals#field6.
+  
+      private static void method1() {}
+//                        ^^^^^^^ definition scip-ctags MyPackage/globals#method1().
+      protected static void method2() {}
+//                          ^^^^^^^ definition scip-ctags MyPackage/globals#method2().
+      public static void method3() {}
+//                       ^^^^^^^ definition scip-ctags MyPackage/globals#method3().
+      private void method4() {}
+//                 ^^^^^^^ definition scip-ctags MyPackage/globals#method4().
+      protected void method5() {}
+//                   ^^^^^^^ definition scip-ctags MyPackage/globals#method5().
+      public void method6() {}
+//                ^^^^^^^ definition scip-ctags MyPackage/globals#method6().
+  
+      public static final String COOLEST_STRING = "probably this one";
+//                               ^^^^^^^^^^^^^^ definition scip-ctags MyPackage/globals#COOLEST_STRING.
+  
+      public class ClassInAClass {
+//                 ^^^^^^^^^^^^^ definition scip-ctags MyPackage/globals#ClassInAClass#
+          boolean classy = true;
+//                ^^^^^^ definition scip-ctags MyPackage/globals#ClassInAClass#classy.
+  
+          public static enum Enum {
+//                           ^^^^ definition scip-ctags MyPackage/globals#ClassInAClass#Enum#
+              these,
+//            ^^^^^ definition scip-ctags MyPackage/globals#ClassInAClass#Enum#these.
+              should,
+//            ^^^^^^ definition scip-ctags MyPackage/globals#ClassInAClass#Enum#should.
+              be,
+//            ^^ definition scip-ctags MyPackage/globals#ClassInAClass#Enum#be.
+              recognized,
+//            ^^^^^^^^^^ definition scip-ctags MyPackage/globals#ClassInAClass#Enum#recognized.
+              as,
+//            ^^ definition scip-ctags MyPackage/globals#ClassInAClass#Enum#as.
+              terms
+//            ^^^^^ definition scip-ctags MyPackage/globals#ClassInAClass#Enum#terms.
+          }
+  
+          public interface Goated {
+//                         ^^^^^^ definition scip-ctags MyPackage/globals#ClassInAClass#Goated#
+              boolean withTheSauce();
+//                    ^^^^^^^^^^^^ definition scip-ctags MyPackage/globals#ClassInAClass#Goated#withTheSauce().
+          }
+  
+          public void myCoolMethod() {
+//                    ^^^^^^^^^^^^ definition scip-ctags MyPackage/globals#ClassInAClass#myCoolMethod().
+              class WhatIsGoingOn {}
+              boolean iThinkThisIsAllowedButWeDontReallyCare = true;
+//                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition local 1
+          }
+      }
+  }
+
+
+

--- a/docker-images/syntax-highlighter/crates/scip-syntax/tests/snapshots/integration_test__java_workspace_indexing.snap
+++ b/docker-images/syntax-highlighter/crates/scip-syntax/tests/snapshots/integration_test__java_workspace_indexing.snap
@@ -1,0 +1,86 @@
+---
+source: crates/scip-syntax/tests/integration_test.rs
+expression: index_snapshot
+---
+//----FILE=package-info.java
+  @Deprecated
+  package foo.bar;
+//        ^^^^^^^ definition(Package) scip-ctags `foo.bar`/
+  
+  class Baz {}
+//      ^^^ definition scip-ctags `foo.bar`/Baz#
+
+
+//----FILE=src/main/java/globals.java
+  package MyPackage;
+//        ^^^^^^^^^ definition(Package) scip-ctags MyPackage/
+  
+  public class globals {
+//             ^^^^^^^ definition scip-ctags MyPackage/globals#
+      private static int field1;
+//                       ^^^^^^ definition scip-ctags MyPackage/globals#field1.
+      protected static int field2;
+//                         ^^^^^^ definition scip-ctags MyPackage/globals#field2.
+      public static int field3;
+//                      ^^^^^^ definition scip-ctags MyPackage/globals#field3.
+      private int field4;
+//                ^^^^^^ definition scip-ctags MyPackage/globals#field4.
+      protected int field5;
+//                  ^^^^^^ definition scip-ctags MyPackage/globals#field5.
+      public int field6;
+//               ^^^^^^ definition scip-ctags MyPackage/globals#field6.
+  
+      private static void method1() {}
+//                        ^^^^^^^ definition scip-ctags MyPackage/globals#method1().
+      protected static void method2() {}
+//                          ^^^^^^^ definition scip-ctags MyPackage/globals#method2().
+      public static void method3() {}
+//                       ^^^^^^^ definition scip-ctags MyPackage/globals#method3().
+      private void method4() {}
+//                 ^^^^^^^ definition scip-ctags MyPackage/globals#method4().
+      protected void method5() {}
+//                   ^^^^^^^ definition scip-ctags MyPackage/globals#method5().
+      public void method6() {}
+//                ^^^^^^^ definition scip-ctags MyPackage/globals#method6().
+  
+      public static final String COOLEST_STRING = "probably this one";
+//                               ^^^^^^^^^^^^^^ definition scip-ctags MyPackage/globals#COOLEST_STRING.
+  
+      public class ClassInAClass {
+//                 ^^^^^^^^^^^^^ definition scip-ctags MyPackage/globals#ClassInAClass#
+          boolean classy = true;
+//                ^^^^^^ definition scip-ctags MyPackage/globals#ClassInAClass#classy.
+  
+          public static enum Enum {
+//                           ^^^^ definition scip-ctags MyPackage/globals#ClassInAClass#Enum#
+              these,
+//            ^^^^^ definition scip-ctags MyPackage/globals#ClassInAClass#Enum#these.
+              should,
+//            ^^^^^^ definition scip-ctags MyPackage/globals#ClassInAClass#Enum#should.
+              be,
+//            ^^ definition scip-ctags MyPackage/globals#ClassInAClass#Enum#be.
+              recognized,
+//            ^^^^^^^^^^ definition scip-ctags MyPackage/globals#ClassInAClass#Enum#recognized.
+              as,
+//            ^^ definition scip-ctags MyPackage/globals#ClassInAClass#Enum#as.
+              terms
+//            ^^^^^ definition scip-ctags MyPackage/globals#ClassInAClass#Enum#terms.
+          }
+  
+          public interface Goated {
+//                         ^^^^^^ definition scip-ctags MyPackage/globals#ClassInAClass#Goated#
+              boolean withTheSauce();
+//                    ^^^^^^^^^^^^ definition scip-ctags MyPackage/globals#ClassInAClass#Goated#withTheSauce().
+          }
+  
+          public void myCoolMethod() {
+//                    ^^^^^^^^^^^^ definition scip-ctags MyPackage/globals#ClassInAClass#myCoolMethod().
+              class WhatIsGoingOn {}
+              boolean iThinkThisIsAllowedButWeDontReallyCare = true;
+//                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition local 1
+          }
+      }
+  }
+
+
+


### PR DESCRIPTION
Fixes GRAPH-651
Fixes GRAPH-650

New features:
- `index tar <input>` allows indexing tar archives when `input` is a file, and `stdin` when `input` is literal string `-`
- **BREAKING: Instead of flags controlling the type of input source, we now have subcommands: `index files`, `index workspace`, `index tar`**

Refactoring:
- Tests were improved, with helper functions broken down into composable pieces, and producing 1 snapshot per test, making it easier to manage
- Closures were removed from the indexing code, instead replaced with functions.
- Calls to `.unwrap` were replaced with better error handling code
- Path canonicalisation was replaced with path cleanup + absolutisation - to avoid following symlinks (which is what `canonicalize` would do)

Most of the refactoring was triggered by the changes required to add more tests.

## Test plan

- New integration tests