### PR TITLE
Initialise authProviders array in Go code

### DIFF
--- a/client/web/src/external-account-modal/ExternalAccountsModal.tsx
+++ b/client/web/src/external-account-modal/ExternalAccountsModal.tsx
@@ -28,13 +28,9 @@ export interface ExternalAccountsModalProps extends TelemetryV2Props {
 // If the active auth providers contain an auth provider that has not yet
 // been seen by the user, true is returned. Otherwise false is returned.
 const shouldShowExternalAccountsModal = (
-    activeAuthProviders: AuthProvider[] | null,
+    activeAuthProviders: AuthProvider[],
     seenAuthProviders: SeenAuthProvider[] | undefined
 ): boolean => {
-    if (activeAuthProviders === null) {
-        return false
-    }
-
     for (const activeProvider of activeAuthProviders) {
         // Skip the builtin provider
         if (activeProvider.isBuiltin) {
@@ -78,13 +74,9 @@ function userAccountConnected(authProvider: AuthProvider, userExternalAccounts: 
 }
 
 function filterAuthProviders(
-    authProviders: AuthProvider[] | null,
+    authProviders: AuthProvider[],
     userExternalAccounts: UserExternalAccount[]
 ): AuthProvider[] {
-    if (authProviders === null) {
-        return []
-    }
-
     return authProviders.filter(
         provider =>
             !provider.isBuiltin && provider.requiredForAuthz && !userAccountConnected(provider, userExternalAccounts)

--- a/client/web/src/external-account-modal/ExternalAccountsModal.tsx
+++ b/client/web/src/external-account-modal/ExternalAccountsModal.tsx
@@ -28,9 +28,13 @@ export interface ExternalAccountsModalProps extends TelemetryV2Props {
 // If the active auth providers contain an auth provider that has not yet
 // been seen by the user, true is returned. Otherwise false is returned.
 const shouldShowExternalAccountsModal = (
-    activeAuthProviders: AuthProvider[],
+    activeAuthProviders: AuthProvider[] | null,
     seenAuthProviders: SeenAuthProvider[] | undefined
 ): boolean => {
+    if (activeAuthProviders === null) {
+        return false
+    }
+
     for (const activeProvider of activeAuthProviders) {
         // Skip the builtin provider
         if (activeProvider.isBuiltin) {
@@ -74,9 +78,13 @@ function userAccountConnected(authProvider: AuthProvider, userExternalAccounts: 
 }
 
 function filterAuthProviders(
-    authProviders: AuthProvider[],
+    authProviders: AuthProvider[] | null,
     userExternalAccounts: UserExternalAccount[]
 ): AuthProvider[] {
+    if (authProviders === null) {
+        return []
+    }
+
     return authProviders.filter(
         provider =>
             !provider.isBuiltin && provider.requiredForAuthz && !userAccountConnected(provider, userExternalAccounts)

--- a/cmd/frontend/internal/app/jscontext/jscontext.go
+++ b/cmd/frontend/internal/app/jscontext/jscontext.go
@@ -297,7 +297,7 @@ func NewJSContextFromRequest(req *http.Request, db database.DB) JSContext {
 	needsSiteInit := err == nil && !siteInitialized
 
 	// Auth providers
-	var authProviders []authProviderInfo
+	authProviders := []authProviderInfo{}
 	_, authzProviders := authz.GetProviders()
 	for _, p := range providers.SortedProviders() {
 		commonConfig := providers.GetAuthProviderCommon(p)

--- a/cmd/frontend/internal/app/jscontext/jscontext.go
+++ b/cmd/frontend/internal/app/jscontext/jscontext.go
@@ -297,7 +297,7 @@ func NewJSContextFromRequest(req *http.Request, db database.DB) JSContext {
 	needsSiteInit := err == nil && !siteInitialized
 
 	// Auth providers
-	authProviders := []authProviderInfo{}
+	authProviders := []authProviderInfo{} // Explicitly initialise array, otherwise it gets marshalled to null instead of []
 	_, authzProviders := authz.GetProviders()
 	for _, p := range providers.SortedProviders() {
 		commonConfig := providers.GetAuthProviderCommon(p)


### PR DESCRIPTION
When a Sourcegraph license is expired or revoked and the instance reverts to free license, then `authz` (for permissions syncing) stops working as well. This means that there are no AuthProviders set up and the front-end code has `null` for these values.

The issue arrises from unitialised arrays in Go being marshalled as `null` instead of `[]`. This PR initialises the array explicitly, instead of relying on the empty value.

<!-- 💡 To write a useful PR description, make sure that your description covers:
- WHAT this PR is changing:
    - How was it PREVIOUSLY.
    - How it will be from NOW on.
- WHY this PR is needed.
- CONTEXT, i.e. to which initiative, project or RFC it belongs.

The structure of the description doesn't matter as much as covering these points, so use
your best judgement based on your context.
Learn how to write good pull request description: https://www.notion.so/sourcegraph/Write-a-good-pull-request-description-610a7fd3e613496eb76f450db5a49b6e?pvs=4 -->


## Test plan

Tested locally with a revoked license.

<!-- All pull requests REQUIRE a test plan: https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles -->


## Changelog

<!--
1. Ensure your pull request title is formatted as: $type($domain): $what
2. Add bullet list items for each additional detail you want to cover (see example below)
3. You can edit this after the pull request was merged, as long as release shipping it hasn't been promoted to the public.
4. For more information, please see this how-to https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c?

Audience: TS/CSE > Customers > Teammates (in that order).

Cheat sheet: $type = chore|fix|feat $domain: source|search|ci|release|plg|cody|local|...
-->

<!--
Example:

Title: fix(search): parse quotes with the appropriate context
Changelog section:

## Changelog

- When a quote is used with regexp pattern type, then ...
- Refactored underlying code.
-->
