### PR TITLE
cleanup: fix typo: scretTokenKey --> secretTokenKey

### DIFF
--- a/client/vscode/src/backend/authenticatedUser.ts
+++ b/client/vscode/src/backend/authenticatedUser.ts
@@ -5,7 +5,7 @@ import { gql } from '@sourcegraph/http-client'
 import type { AuthenticatedUser } from '@sourcegraph/shared/src/auth'
 import type { CurrentAuthStateResult, CurrentAuthStateVariables } from '@sourcegraph/shared/src/graphql-operations'
 
-import { scretTokenKey } from '../webview/platform/AuthProvider'
+import { secretTokenKey } from '../webview/platform/AuthProvider'
 
 import { requestGraphQLFromVSCode } from './requestGraphQl'
 
@@ -64,8 +64,8 @@ export function observeAuthenticatedUser(secretStorage: vscode.SecretStorage): O
     updateAuthenticatedUser()
 
     secretStorage.onDidChange(async event => {
-        if (event.key === scretTokenKey) {
-            const token = await secretStorage.get(scretTokenKey)
+        if (event.key === secretTokenKey) {
+            const token = await secretStorage.get(secretTokenKey)
             if (token) {
                 updateAuthenticatedUser()
             }

--- a/client/vscode/src/extension.ts
+++ b/client/vscode/src/extension.ts
@@ -26,7 +26,7 @@ import { LocalStorageService, SELECTED_SEARCH_CONTEXT_SPEC_KEY } from './setting
 import { watchUninstall } from './settings/uninstall'
 import { createVSCEStateMachine, type VSCEQueryState } from './state'
 import { copySourcegraphLinks, focusSearchPanel, openSourcegraphLinks, registerWebviews } from './webview/commands'
-import { scretTokenKey, SourcegraphAuthActions, SourcegraphAuthProvider } from './webview/platform/AuthProvider'
+import { secretTokenKey, SourcegraphAuthActions, SourcegraphAuthProvider } from './webview/platform/AuthProvider'
 
 /**
  * See CONTRIBUTING docs for the Architecture Diagram
@@ -37,13 +37,13 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     context.subscriptions.push(
         vscode.authentication.registerAuthenticationProvider(
             endpointSetting(),
-            scretTokenKey,
+            secretTokenKey,
             new SourcegraphAuthProvider(secretStorage)
         )
     )
     await processOldToken(secretStorage)
     const initialInstanceURL = endpointSetting()
-    const initialAccessToken = await secretStorage.get(scretTokenKey)
+    const initialAccessToken = await secretStorage.get(secretTokenKey)
     const createIfNone = initialAccessToken ? { createIfNone: true } : { createIfNone: false }
     const session = await vscode.authentication.getSession(endpointSetting(), [], createIfNone)
     const authenticatedUser = observeAuthenticatedUser(secretStorage)

--- a/client/vscode/src/settings/accessTokenSetting.ts
+++ b/client/vscode/src/settings/accessTokenSetting.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode'
 
 import { isOlderThan, observeInstanceVersionNumber } from '../backend/instanceVersion'
-import { scretTokenKey } from '../webview/platform/AuthProvider'
+import { secretTokenKey } from '../webview/platform/AuthProvider'
 
 import { endpointHostnameSetting, endpointProtocolSetting } from './endpointSetting'
 import { readConfiguration } from './readConfiguration'
@@ -10,17 +10,17 @@ import { readConfiguration } from './readConfiguration'
 export async function processOldToken(secretStorage: vscode.SecretStorage): Promise<void> {
     // Process the token that lives in user configuration
     // Move them to secrets and then remove them by setting it as undefined
-    const storageToken = await secretStorage.get(scretTokenKey)
+    const storageToken = await secretStorage.get(secretTokenKey)
     const oldToken = vscode.workspace.getConfiguration().get<string>('sourcegraph.accessToken') || ''
     if (!storageToken && oldToken.length > 8) {
-        await secretStorage.store(scretTokenKey, oldToken)
+        await secretStorage.store(secretTokenKey, oldToken)
         await removeOldAccessTokenSetting()
     }
     return
 }
 
 export async function accessTokenSetting(secretStorage: vscode.SecretStorage): Promise<string> {
-    const currentToken = await secretStorage.get(scretTokenKey)
+    const currentToken = await secretStorage.get(secretTokenKey)
     return currentToken || ''
 }
 

--- a/client/vscode/src/webview/commands.ts
+++ b/client/vscode/src/webview/commands.ts
@@ -17,7 +17,7 @@ import {
     initializeSearchPanelWebview,
     initializeSearchSidebarWebview,
 } from './initialize'
-import { scretTokenKey } from './platform/AuthProvider'
+import { secretTokenKey } from './platform/AuthProvider'
 
 // Track current active webview panel to make sure only one panel exists at a time
 let currentSearchPanel: vscode.WebviewPanel | 'initializing' | undefined
@@ -47,7 +47,7 @@ export function registerWebviews({
         // TODO: Decrypt token
         // TODO: Match returnedNonce to stored nonce
         if (token && token.length > 8) {
-            await context.secrets.store(scretTokenKey, token)
+            await context.secrets.store(secretTokenKey, token)
             await vscode.window.showInformationMessage('Token has been retreived and updated successfully')
         }
     }

--- a/client/vscode/src/webview/platform/AuthProvider.ts
+++ b/client/vscode/src/webview/platform/AuthProvider.ts
@@ -15,7 +15,7 @@ import polyfillEventSource from '@sourcegraph/shared/src/polyfills/vendor/eventS
 import { getProxyAgent } from '../../backend/fetch'
 import { endpointRequestHeadersSetting, endpointSetting, setEndpoint } from '../../settings/endpointSetting'
 
-export const scretTokenKey = 'SOURCEGRAPH_AUTH'
+export const secretTokenKey = 'SOURCEGRAPH_AUTH'
 
 class SourcegraphAuthSession implements AuthenticationSession {
     public readonly account = {
@@ -30,8 +30,8 @@ class SourcegraphAuthSession implements AuthenticationSession {
 
 export class SourcegraphAuthProvider implements AuthenticationProvider, Disposable {
     public static id = endpointSetting()
-    private static secretKey = scretTokenKey
-    public static label = scretTokenKey
+    private static secretKey = secretTokenKey
+    public static label = secretTokenKey
 
     // Kept track of token changes through out the session
     private currentToken: string | undefined
@@ -136,7 +136,7 @@ export class SourcegraphAuthActions {
 
     public async login(newtoken: string, newuri: string): Promise<void> {
         try {
-            await this.secretStorage.store(scretTokenKey, newtoken)
+            await this.secretStorage.store(secretTokenKey, newtoken)
             if (this.currentEndpoint !== newuri) {
                 await setEndpoint(newuri)
             }
@@ -147,7 +147,7 @@ export class SourcegraphAuthActions {
     }
 
     public async logout(): Promise<void> {
-        await this.secretStorage.delete(scretTokenKey)
+        await this.secretStorage.delete(secretTokenKey)
         await commands.executeCommand('workbench.action.reloadWindow')
         return
     }


### PR DESCRIPTION
This one is straightforward: changing the spelling of a variable. 

As I poked around in the vscode extension looking for what's going on with the authentication errors, the misspelling of `scretTokenKey` became difficult to ignore. So I fixed it. :-D
 
## Test plan

1. Build and run locally.
```
cd client/vscode
pmpn run build
```
2. Launch extension in VSCode: open the `Run and Debug` sidebar view in VS Code, then select `Launch VS Code Extension` from the dropdown menu. Verify expected behavior.
