### PR TITLE
security: Auto-update package lockfiles for Sourcegraph base images

### DIFF
--- a/wolfi-images/batcheshelper.lock.json
+++ b/wolfi-images/batcheshelper.lock.json
@@ -204,41 +204,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q10Rr8mXMuAm4i4SjxE7xhsgs2UME=",
+        "checksum": "Q1gTZGkWP+QO3mUqLVJth8vrDEzzU=",
         "control": {
-          "checksum": "sha1-0Rr8mXMuAm4i4SjxE7xhsgs2UME=",
-          "range": "bytes=699-1079"
+          "checksum": "sha1-gTZGkWP+QO3mUqLVJth8vrDEzzU=",
+          "range": "bytes=699-1076"
         },
         "data": {
-          "checksum": "sha256-IVV0PRiJiwz4Ov1pWU1VAHf8cM0TgwqsV3vkYEQc0mM=",
-          "range": "bytes=1080-5915633"
+          "checksum": "sha256-/IFXqeKvU0GODNsz1yPIEMcFHgABT+8rbZpSlTLo4e4=",
+          "range": "bytes=1077-5915704"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-OlnuKCVUD1RpZgK+JyGdG/NQ0R0=",
+          "checksum": "sha1-l1o5ixkyWWqqJE3FOfR0QUemJUA=",
           "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r7.apk",
-        "version": "3.3.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r9.apk",
+        "version": "3.3.0-r9"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1xZQl4rSEEOs59w1q/EhMx0+ZVxw=",
+        "checksum": "Q1jhAhggAuZnU7FFHnebGA26mq+jI=",
         "control": {
-          "checksum": "sha1-xZQl4rSEEOs59w1q/EhMx0+ZVxw=",
-          "range": "bytes=697-1082"
+          "checksum": "sha1-jhAhggAuZnU7FFHnebGA26mq+jI=",
+          "range": "bytes=695-1079"
         },
         "data": {
-          "checksum": "sha256-IfGWsH9qFzzKcdVENdnoZqPbAdejcokLcfm7Z53KnPM=",
-          "range": "bytes=1083-1197082"
+          "checksum": "sha256-XTCQYnhGSm7SkGwqV/TQMFqGajVJVYhKAidKfLb2D3Y=",
+          "range": "bytes=1080-1197081"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-CypiuHQ6EuduQ5uexXhBDv5YvvY=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-qVrfDVxubkrb5Yrd2mFTv2A0G7k=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r7.apk",
-        "version": "3.3.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r9.apk",
+        "version": "3.3.0-r9"
       },
       {
         "architecture": "x86_64",
@@ -755,22 +755,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1eaot0B2H9IOF054RKMabXG37GUk=",
+        "checksum": "Q111Aq+tDFOygcfZzOg1hQbtZw1Q4=",
         "control": {
-          "checksum": "sha1-eaot0B2H9IOF054RKMabXG37GUk=",
-          "range": "bytes=700-1143"
+          "checksum": "sha1-11Aq+tDFOygcfZzOg1hQbtZw1Q4=",
+          "range": "bytes=697-1140"
         },
         "data": {
-          "checksum": "sha256-EeuQkVe5Hl+bqWfkBaMgA1Z2Fh91f1upncBbArJu9Gw=",
-          "range": "bytes=1144-17267929"
+          "checksum": "sha256-ednk20seorMQ+xEGnt8zWpxO20xrfj7zOtAmk+XcTbA=",
+          "range": "bytes=1141-17250210"
         },
         "name": "git",
         "signature": {
-          "checksum": "sha1-yMhNFUJ+emT/s9tdLDQ8zjT2+vY=",
-          "range": "bytes=0-699"
+          "checksum": "sha1-T1C3/QmQvuJGLjPH2YyOLIM5ewE=",
+          "range": "bytes=0-696"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/git-2.45.1-r0.apk",
-        "version": "2.45.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/git-2.45.2-r0.apk",
+        "version": "2.45.2-r0"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/blobstore.lock.json
+++ b/wolfi-images/blobstore.lock.json
@@ -204,41 +204,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q10Rr8mXMuAm4i4SjxE7xhsgs2UME=",
+        "checksum": "Q1gTZGkWP+QO3mUqLVJth8vrDEzzU=",
         "control": {
-          "checksum": "sha1-0Rr8mXMuAm4i4SjxE7xhsgs2UME=",
-          "range": "bytes=699-1079"
+          "checksum": "sha1-gTZGkWP+QO3mUqLVJth8vrDEzzU=",
+          "range": "bytes=699-1076"
         },
         "data": {
-          "checksum": "sha256-IVV0PRiJiwz4Ov1pWU1VAHf8cM0TgwqsV3vkYEQc0mM=",
-          "range": "bytes=1080-5915633"
+          "checksum": "sha256-/IFXqeKvU0GODNsz1yPIEMcFHgABT+8rbZpSlTLo4e4=",
+          "range": "bytes=1077-5915704"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-OlnuKCVUD1RpZgK+JyGdG/NQ0R0=",
+          "checksum": "sha1-l1o5ixkyWWqqJE3FOfR0QUemJUA=",
           "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r7.apk",
-        "version": "3.3.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r9.apk",
+        "version": "3.3.0-r9"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1xZQl4rSEEOs59w1q/EhMx0+ZVxw=",
+        "checksum": "Q1jhAhggAuZnU7FFHnebGA26mq+jI=",
         "control": {
-          "checksum": "sha1-xZQl4rSEEOs59w1q/EhMx0+ZVxw=",
-          "range": "bytes=697-1082"
+          "checksum": "sha1-jhAhggAuZnU7FFHnebGA26mq+jI=",
+          "range": "bytes=695-1079"
         },
         "data": {
-          "checksum": "sha256-IfGWsH9qFzzKcdVENdnoZqPbAdejcokLcfm7Z53KnPM=",
-          "range": "bytes=1083-1197082"
+          "checksum": "sha256-XTCQYnhGSm7SkGwqV/TQMFqGajVJVYhKAidKfLb2D3Y=",
+          "range": "bytes=1080-1197081"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-CypiuHQ6EuduQ5uexXhBDv5YvvY=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-qVrfDVxubkrb5Yrd2mFTv2A0G7k=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r7.apk",
-        "version": "3.3.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r9.apk",
+        "version": "3.3.0-r9"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/bundled-executor.lock.json
+++ b/wolfi-images/bundled-executor.lock.json
@@ -204,41 +204,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q10Rr8mXMuAm4i4SjxE7xhsgs2UME=",
+        "checksum": "Q1gTZGkWP+QO3mUqLVJth8vrDEzzU=",
         "control": {
-          "checksum": "sha1-0Rr8mXMuAm4i4SjxE7xhsgs2UME=",
-          "range": "bytes=699-1079"
+          "checksum": "sha1-gTZGkWP+QO3mUqLVJth8vrDEzzU=",
+          "range": "bytes=699-1076"
         },
         "data": {
-          "checksum": "sha256-IVV0PRiJiwz4Ov1pWU1VAHf8cM0TgwqsV3vkYEQc0mM=",
-          "range": "bytes=1080-5915633"
+          "checksum": "sha256-/IFXqeKvU0GODNsz1yPIEMcFHgABT+8rbZpSlTLo4e4=",
+          "range": "bytes=1077-5915704"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-OlnuKCVUD1RpZgK+JyGdG/NQ0R0=",
+          "checksum": "sha1-l1o5ixkyWWqqJE3FOfR0QUemJUA=",
           "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r7.apk",
-        "version": "3.3.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r9.apk",
+        "version": "3.3.0-r9"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1xZQl4rSEEOs59w1q/EhMx0+ZVxw=",
+        "checksum": "Q1jhAhggAuZnU7FFHnebGA26mq+jI=",
         "control": {
-          "checksum": "sha1-xZQl4rSEEOs59w1q/EhMx0+ZVxw=",
-          "range": "bytes=697-1082"
+          "checksum": "sha1-jhAhggAuZnU7FFHnebGA26mq+jI=",
+          "range": "bytes=695-1079"
         },
         "data": {
-          "checksum": "sha256-IfGWsH9qFzzKcdVENdnoZqPbAdejcokLcfm7Z53KnPM=",
-          "range": "bytes=1083-1197082"
+          "checksum": "sha256-XTCQYnhGSm7SkGwqV/TQMFqGajVJVYhKAidKfLb2D3Y=",
+          "range": "bytes=1080-1197081"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-CypiuHQ6EuduQ5uexXhBDv5YvvY=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-qVrfDVxubkrb5Yrd2mFTv2A0G7k=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r7.apk",
-        "version": "3.3.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r9.apk",
+        "version": "3.3.0-r9"
       },
       {
         "architecture": "x86_64",
@@ -774,22 +774,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1eaot0B2H9IOF054RKMabXG37GUk=",
+        "checksum": "Q111Aq+tDFOygcfZzOg1hQbtZw1Q4=",
         "control": {
-          "checksum": "sha1-eaot0B2H9IOF054RKMabXG37GUk=",
-          "range": "bytes=700-1143"
+          "checksum": "sha1-11Aq+tDFOygcfZzOg1hQbtZw1Q4=",
+          "range": "bytes=697-1140"
         },
         "data": {
-          "checksum": "sha256-EeuQkVe5Hl+bqWfkBaMgA1Z2Fh91f1upncBbArJu9Gw=",
-          "range": "bytes=1144-17267929"
+          "checksum": "sha256-ednk20seorMQ+xEGnt8zWpxO20xrfj7zOtAmk+XcTbA=",
+          "range": "bytes=1141-17250210"
         },
         "name": "git",
         "signature": {
-          "checksum": "sha1-yMhNFUJ+emT/s9tdLDQ8zjT2+vY=",
-          "range": "bytes=0-699"
+          "checksum": "sha1-T1C3/QmQvuJGLjPH2YyOLIM5ewE=",
+          "range": "bytes=0-696"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/git-2.45.1-r0.apk",
-        "version": "2.45.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/git-2.45.2-r0.apk",
+        "version": "2.45.2-r0"
       },
       {
         "architecture": "x86_64",
@@ -812,22 +812,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q13aWkG70feJbLGSThmQEKqLYrGNc=",
+        "checksum": "Q19dA+Zcg8X4SxDAZMWWPEjgjeKdc=",
         "control": {
-          "checksum": "sha1-3aWkG70feJbLGSThmQEKqLYrGNc=",
-          "range": "bytes=700-1060"
+          "checksum": "sha1-9dA+Zcg8X4SxDAZMWWPEjgjeKdc=",
+          "range": "bytes=696-1056"
         },
         "data": {
-          "checksum": "sha256-ABzm09Er/gJsfvuqgWDcowvo7CXRrEpILpmatpTwWsM=",
-          "range": "bytes=1061-10428036"
+          "checksum": "sha256-yi3bDtrc3T+EVxl1H6XvaCUcp0Jl6SQOeiWDSoNP1sA=",
+          "range": "bytes=1057-10587175"
         },
         "name": "maven",
         "signature": {
-          "checksum": "sha1-exwnWPSNQTP3ePNLEk7P+bVCU00=",
-          "range": "bytes=0-699"
+          "checksum": "sha1-bNLB1Gu/o9NWJbnqMFLWY514RiY=",
+          "range": "bytes=0-695"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/maven-3.9.6-r3.apk",
-        "version": "3.9.6-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/maven-3.9.7-r0.apk",
+        "version": "3.9.7-r0"
       },
       {
         "architecture": "x86_64",
@@ -1439,22 +1439,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q14Muq4cEUd0wF85l2mWLHz+e2wqQ=",
+        "checksum": "Q1M5XGTuK0Sik/s9KP247D/TnEEd8=",
         "control": {
-          "checksum": "sha1-4Muq4cEUd0wF85l2mWLHz+e2wqQ=",
-          "range": "bytes=701-1097"
+          "checksum": "sha1-M5XGTuK0Sik/s9KP247D/TnEEd8=",
+          "range": "bytes=702-1098"
         },
         "data": {
-          "checksum": "sha256-SElvwzQZ1l/AVXyNgi19RQNbHASIOTh1hRNBl5o+Dnc=",
-          "range": "bytes=1098-10722191"
+          "checksum": "sha256-Qom1e/Jneo20yQRSp4w7cMeUXCCN4pKl0bE9f8Ep/Lk=",
+          "range": "bytes=1099-10722775"
         },
         "name": "yq",
         "signature": {
-          "checksum": "sha1-ja9bchtob57rWvzai35AaF0x2Rg=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-csGSkvlu7eVdliwEiyEgzGaqBcM=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/yq-4.44.1-r1.apk",
-        "version": "4.44.1-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/yq-4.44.1-r2.apk",
+        "version": "4.44.1-r2"
       }
     ],
     "repositories": [

--- a/wolfi-images/caddy.lock.json
+++ b/wolfi-images/caddy.lock.json
@@ -204,41 +204,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q10Rr8mXMuAm4i4SjxE7xhsgs2UME=",
+        "checksum": "Q1gTZGkWP+QO3mUqLVJth8vrDEzzU=",
         "control": {
-          "checksum": "sha1-0Rr8mXMuAm4i4SjxE7xhsgs2UME=",
-          "range": "bytes=699-1079"
+          "checksum": "sha1-gTZGkWP+QO3mUqLVJth8vrDEzzU=",
+          "range": "bytes=699-1076"
         },
         "data": {
-          "checksum": "sha256-IVV0PRiJiwz4Ov1pWU1VAHf8cM0TgwqsV3vkYEQc0mM=",
-          "range": "bytes=1080-5915633"
+          "checksum": "sha256-/IFXqeKvU0GODNsz1yPIEMcFHgABT+8rbZpSlTLo4e4=",
+          "range": "bytes=1077-5915704"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-OlnuKCVUD1RpZgK+JyGdG/NQ0R0=",
+          "checksum": "sha1-l1o5ixkyWWqqJE3FOfR0QUemJUA=",
           "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r7.apk",
-        "version": "3.3.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r9.apk",
+        "version": "3.3.0-r9"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1xZQl4rSEEOs59w1q/EhMx0+ZVxw=",
+        "checksum": "Q1jhAhggAuZnU7FFHnebGA26mq+jI=",
         "control": {
-          "checksum": "sha1-xZQl4rSEEOs59w1q/EhMx0+ZVxw=",
-          "range": "bytes=697-1082"
+          "checksum": "sha1-jhAhggAuZnU7FFHnebGA26mq+jI=",
+          "range": "bytes=695-1079"
         },
         "data": {
-          "checksum": "sha256-IfGWsH9qFzzKcdVENdnoZqPbAdejcokLcfm7Z53KnPM=",
-          "range": "bytes=1083-1197082"
+          "checksum": "sha256-XTCQYnhGSm7SkGwqV/TQMFqGajVJVYhKAidKfLb2D3Y=",
+          "range": "bytes=1080-1197081"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-CypiuHQ6EuduQ5uexXhBDv5YvvY=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-qVrfDVxubkrb5Yrd2mFTv2A0G7k=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r7.apk",
-        "version": "3.3.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r9.apk",
+        "version": "3.3.0-r9"
       },
       {
         "architecture": "x86_64",
@@ -584,22 +584,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1hmJGKUg5U62/eDsJFXTXql08W5k=",
+        "checksum": "Q1PGSGzKPMVw90aYlMlNUdARgMDfc=",
         "control": {
-          "checksum": "sha1-hmJGKUg5U62/eDsJFXTXql08W5k=",
-          "range": "bytes=695-1092"
+          "checksum": "sha1-PGSGzKPMVw90aYlMlNUdARgMDfc=",
+          "range": "bytes=701-1099"
         },
         "data": {
-          "checksum": "sha256-9mtlf5LYMHCQZQcBNv/Nhof+RDrDvqEJB3u/pFo9nXc=",
-          "range": "bytes=1093-41669227"
+          "checksum": "sha256-QjsHuaC1mVOumuyNSPOcx8mjPqaV7s/nl1z1FUQEE8w=",
+          "range": "bytes=1100-42588288"
         },
         "name": "caddy",
         "signature": {
-          "checksum": "sha1-sJwUZEAK0xlZda4GGmTA5C6d2pc=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-0lXh76iWNLGfC4EgObKUoP0CxZ4=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/caddy-2.7.6-r9.apk",
-        "version": "2.7.6-r9"
+        "url": "https://packages.wolfi.dev/os/x86_64/caddy-2.8.4-r1.apk",
+        "version": "2.8.4-r1"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/cadvisor.lock.json
+++ b/wolfi-images/cadvisor.lock.json
@@ -204,41 +204,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q10Rr8mXMuAm4i4SjxE7xhsgs2UME=",
+        "checksum": "Q1gTZGkWP+QO3mUqLVJth8vrDEzzU=",
         "control": {
-          "checksum": "sha1-0Rr8mXMuAm4i4SjxE7xhsgs2UME=",
-          "range": "bytes=699-1079"
+          "checksum": "sha1-gTZGkWP+QO3mUqLVJth8vrDEzzU=",
+          "range": "bytes=699-1076"
         },
         "data": {
-          "checksum": "sha256-IVV0PRiJiwz4Ov1pWU1VAHf8cM0TgwqsV3vkYEQc0mM=",
-          "range": "bytes=1080-5915633"
+          "checksum": "sha256-/IFXqeKvU0GODNsz1yPIEMcFHgABT+8rbZpSlTLo4e4=",
+          "range": "bytes=1077-5915704"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-OlnuKCVUD1RpZgK+JyGdG/NQ0R0=",
+          "checksum": "sha1-l1o5ixkyWWqqJE3FOfR0QUemJUA=",
           "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r7.apk",
-        "version": "3.3.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r9.apk",
+        "version": "3.3.0-r9"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1xZQl4rSEEOs59w1q/EhMx0+ZVxw=",
+        "checksum": "Q1jhAhggAuZnU7FFHnebGA26mq+jI=",
         "control": {
-          "checksum": "sha1-xZQl4rSEEOs59w1q/EhMx0+ZVxw=",
-          "range": "bytes=697-1082"
+          "checksum": "sha1-jhAhggAuZnU7FFHnebGA26mq+jI=",
+          "range": "bytes=695-1079"
         },
         "data": {
-          "checksum": "sha256-IfGWsH9qFzzKcdVENdnoZqPbAdejcokLcfm7Z53KnPM=",
-          "range": "bytes=1083-1197082"
+          "checksum": "sha256-XTCQYnhGSm7SkGwqV/TQMFqGajVJVYhKAidKfLb2D3Y=",
+          "range": "bytes=1080-1197081"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-CypiuHQ6EuduQ5uexXhBDv5YvvY=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-qVrfDVxubkrb5Yrd2mFTv2A0G7k=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r7.apk",
-        "version": "3.3.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r9.apk",
+        "version": "3.3.0-r9"
       },
       {
         "architecture": "x86_64",
@@ -584,22 +584,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1FnZKsgMBSvlDuXlEG2PaYaE8RPw=",
+        "checksum": "Q1NzeZQK7ngdKA26bAtJ64z1u7EeE=",
         "control": {
-          "checksum": "sha1-FnZKsgMBSvlDuXlEG2PaYaE8RPw=",
-          "range": "bytes=696-1122"
+          "checksum": "sha1-NzeZQK7ngdKA26bAtJ64z1u7EeE=",
+          "range": "bytes=703-1130"
         },
         "data": {
-          "checksum": "sha256-IfmaVCQGqWrW4v1+0Jjv3v2YIPwoKzWb+U1+s7g6x60=",
-          "range": "bytes=1123-37570300"
+          "checksum": "sha256-BWPJNvd3nr6y2KyENvLMnGRVXMACqV3+UD8tpwyf4KM=",
+          "range": "bytes=1131-37570849"
         },
         "name": "cadvisor",
         "signature": {
-          "checksum": "sha1-670YzcWblzXa/YXHTFdgn0yzlCY=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-KDDYQVfPIdoYnyTpxPd8JWnot+A=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/cadvisor-0.49.1-r7.apk",
-        "version": "0.49.1-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/cadvisor-0.49.1-r8.apk",
+        "version": "0.49.1-r8"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/cloud-mi2.lock.json
+++ b/wolfi-images/cloud-mi2.lock.json
@@ -204,41 +204,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q10Rr8mXMuAm4i4SjxE7xhsgs2UME=",
+        "checksum": "Q1gTZGkWP+QO3mUqLVJth8vrDEzzU=",
         "control": {
-          "checksum": "sha1-0Rr8mXMuAm4i4SjxE7xhsgs2UME=",
-          "range": "bytes=699-1079"
+          "checksum": "sha1-gTZGkWP+QO3mUqLVJth8vrDEzzU=",
+          "range": "bytes=699-1076"
         },
         "data": {
-          "checksum": "sha256-IVV0PRiJiwz4Ov1pWU1VAHf8cM0TgwqsV3vkYEQc0mM=",
-          "range": "bytes=1080-5915633"
+          "checksum": "sha256-/IFXqeKvU0GODNsz1yPIEMcFHgABT+8rbZpSlTLo4e4=",
+          "range": "bytes=1077-5915704"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-OlnuKCVUD1RpZgK+JyGdG/NQ0R0=",
+          "checksum": "sha1-l1o5ixkyWWqqJE3FOfR0QUemJUA=",
           "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r7.apk",
-        "version": "3.3.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r9.apk",
+        "version": "3.3.0-r9"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1xZQl4rSEEOs59w1q/EhMx0+ZVxw=",
+        "checksum": "Q1jhAhggAuZnU7FFHnebGA26mq+jI=",
         "control": {
-          "checksum": "sha1-xZQl4rSEEOs59w1q/EhMx0+ZVxw=",
-          "range": "bytes=697-1082"
+          "checksum": "sha1-jhAhggAuZnU7FFHnebGA26mq+jI=",
+          "range": "bytes=695-1079"
         },
         "data": {
-          "checksum": "sha256-IfGWsH9qFzzKcdVENdnoZqPbAdejcokLcfm7Z53KnPM=",
-          "range": "bytes=1083-1197082"
+          "checksum": "sha256-XTCQYnhGSm7SkGwqV/TQMFqGajVJVYhKAidKfLb2D3Y=",
+          "range": "bytes=1080-1197081"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-CypiuHQ6EuduQ5uexXhBDv5YvvY=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-qVrfDVxubkrb5Yrd2mFTv2A0G7k=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r7.apk",
-        "version": "3.3.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r9.apk",
+        "version": "3.3.0-r9"
       },
       {
         "architecture": "x86_64",
@@ -755,41 +755,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1eaot0B2H9IOF054RKMabXG37GUk=",
+        "checksum": "Q111Aq+tDFOygcfZzOg1hQbtZw1Q4=",
         "control": {
-          "checksum": "sha1-eaot0B2H9IOF054RKMabXG37GUk=",
-          "range": "bytes=700-1143"
+          "checksum": "sha1-11Aq+tDFOygcfZzOg1hQbtZw1Q4=",
+          "range": "bytes=697-1140"
         },
         "data": {
-          "checksum": "sha256-EeuQkVe5Hl+bqWfkBaMgA1Z2Fh91f1upncBbArJu9Gw=",
-          "range": "bytes=1144-17267929"
+          "checksum": "sha256-ednk20seorMQ+xEGnt8zWpxO20xrfj7zOtAmk+XcTbA=",
+          "range": "bytes=1141-17250210"
         },
         "name": "git",
         "signature": {
-          "checksum": "sha1-yMhNFUJ+emT/s9tdLDQ8zjT2+vY=",
-          "range": "bytes=0-699"
+          "checksum": "sha1-T1C3/QmQvuJGLjPH2YyOLIM5ewE=",
+          "range": "bytes=0-696"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/git-2.45.1-r0.apk",
-        "version": "2.45.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/git-2.45.2-r0.apk",
+        "version": "2.45.2-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q116m2Q5Ln3gJz05D1gRD/3AQz9+4=",
+        "checksum": "Q1KXXN9Hu7PZ0iPK7gAnYRUDcDzZs=",
         "control": {
-          "checksum": "sha1-16m2Q5Ln3gJz05D1gRD/3AQz9+4=",
-          "range": "bytes=703-1102"
+          "checksum": "sha1-KXXN9Hu7PZ0iPK7gAnYRUDcDzZs=",
+          "range": "bytes=700-1063"
         },
         "data": {
-          "checksum": "sha256-nU1+NEgt7CR9vsxeCs5Hr9tHiSAw69pxvz+m0W+N+PI=",
-          "range": "bytes=1103-11855891"
+          "checksum": "sha256-F61XBj+QV78wXrinzeVQestiQeJtCAVPWwbLWf8c98Y=",
+          "range": "bytes=1064-12733161"
         },
         "name": "git-lfs",
         "signature": {
-          "checksum": "sha1-z3BWu5hxd1KVtIrVNwIYsNsgYpc=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-U6NrIIwbHHzX/fgtB3PoNVQZOJU=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/git-lfs-3.5.1-r4.apk",
-        "version": "3.5.1-r4"
+        "url": "https://packages.wolfi.dev/os/x86_64/git-lfs-3.5.1-r6.apk",
+        "version": "3.5.1-r6"
       },
       {
         "architecture": "x86_64",
@@ -945,22 +945,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1OwTlRMXb7zHeLIAvkR9u4QSpB3g=",
+        "checksum": "Q1cqvmBqrAP2QlJV4IAn1Hs451O10=",
         "control": {
-          "checksum": "sha1-OwTlRMXb7zHeLIAvkR9u4QSpB3g=",
-          "range": "bytes=696-1054"
+          "checksum": "sha1-cqvmBqrAP2QlJV4IAn1Hs451O10=",
+          "range": "bytes=699-1057"
         },
         "data": {
-          "checksum": "sha256-OdJs5w5sVo61nZaAAmGJHi5QXRIwZfqwnauupc1JVMM=",
-          "range": "bytes=1055-8931137"
+          "checksum": "sha256-hVF8tflwY/oUUrf9jv52TwZfqyvA+nvr1OAYZDTP1QY=",
+          "range": "bytes=1058-8956887"
         },
         "name": "npm",
         "signature": {
-          "checksum": "sha1-x8/Ou0c9cx6tQEiYvZTCqfMeXZM=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-7Rr/2LbH/tpKPSaWYd3jRQUO1s0=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/npm-10.8.0-r0.apk",
-        "version": "10.8.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/npm-10.8.1-r0.apk",
+        "version": "10.8.1-r0"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/executor-kubernetes.lock.json
+++ b/wolfi-images/executor-kubernetes.lock.json
@@ -204,41 +204,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q10Rr8mXMuAm4i4SjxE7xhsgs2UME=",
+        "checksum": "Q1gTZGkWP+QO3mUqLVJth8vrDEzzU=",
         "control": {
-          "checksum": "sha1-0Rr8mXMuAm4i4SjxE7xhsgs2UME=",
-          "range": "bytes=699-1079"
+          "checksum": "sha1-gTZGkWP+QO3mUqLVJth8vrDEzzU=",
+          "range": "bytes=699-1076"
         },
         "data": {
-          "checksum": "sha256-IVV0PRiJiwz4Ov1pWU1VAHf8cM0TgwqsV3vkYEQc0mM=",
-          "range": "bytes=1080-5915633"
+          "checksum": "sha256-/IFXqeKvU0GODNsz1yPIEMcFHgABT+8rbZpSlTLo4e4=",
+          "range": "bytes=1077-5915704"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-OlnuKCVUD1RpZgK+JyGdG/NQ0R0=",
+          "checksum": "sha1-l1o5ixkyWWqqJE3FOfR0QUemJUA=",
           "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r7.apk",
-        "version": "3.3.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r9.apk",
+        "version": "3.3.0-r9"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1xZQl4rSEEOs59w1q/EhMx0+ZVxw=",
+        "checksum": "Q1jhAhggAuZnU7FFHnebGA26mq+jI=",
         "control": {
-          "checksum": "sha1-xZQl4rSEEOs59w1q/EhMx0+ZVxw=",
-          "range": "bytes=697-1082"
+          "checksum": "sha1-jhAhggAuZnU7FFHnebGA26mq+jI=",
+          "range": "bytes=695-1079"
         },
         "data": {
-          "checksum": "sha256-IfGWsH9qFzzKcdVENdnoZqPbAdejcokLcfm7Z53KnPM=",
-          "range": "bytes=1083-1197082"
+          "checksum": "sha256-XTCQYnhGSm7SkGwqV/TQMFqGajVJVYhKAidKfLb2D3Y=",
+          "range": "bytes=1080-1197081"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-CypiuHQ6EuduQ5uexXhBDv5YvvY=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-qVrfDVxubkrb5Yrd2mFTv2A0G7k=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r7.apk",
-        "version": "3.3.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r9.apk",
+        "version": "3.3.0-r9"
       },
       {
         "architecture": "x86_64",
@@ -755,22 +755,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1eaot0B2H9IOF054RKMabXG37GUk=",
+        "checksum": "Q111Aq+tDFOygcfZzOg1hQbtZw1Q4=",
         "control": {
-          "checksum": "sha1-eaot0B2H9IOF054RKMabXG37GUk=",
-          "range": "bytes=700-1143"
+          "checksum": "sha1-11Aq+tDFOygcfZzOg1hQbtZw1Q4=",
+          "range": "bytes=697-1140"
         },
         "data": {
-          "checksum": "sha256-EeuQkVe5Hl+bqWfkBaMgA1Z2Fh91f1upncBbArJu9Gw=",
-          "range": "bytes=1144-17267929"
+          "checksum": "sha256-ednk20seorMQ+xEGnt8zWpxO20xrfj7zOtAmk+XcTbA=",
+          "range": "bytes=1141-17250210"
         },
         "name": "git",
         "signature": {
-          "checksum": "sha1-yMhNFUJ+emT/s9tdLDQ8zjT2+vY=",
-          "range": "bytes=0-699"
+          "checksum": "sha1-T1C3/QmQvuJGLjPH2YyOLIM5ewE=",
+          "range": "bytes=0-696"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/git-2.45.1-r0.apk",
-        "version": "2.45.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/git-2.45.2-r0.apk",
+        "version": "2.45.2-r0"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/executor.lock.json
+++ b/wolfi-images/executor.lock.json
@@ -204,41 +204,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q10Rr8mXMuAm4i4SjxE7xhsgs2UME=",
+        "checksum": "Q1gTZGkWP+QO3mUqLVJth8vrDEzzU=",
         "control": {
-          "checksum": "sha1-0Rr8mXMuAm4i4SjxE7xhsgs2UME=",
-          "range": "bytes=699-1079"
+          "checksum": "sha1-gTZGkWP+QO3mUqLVJth8vrDEzzU=",
+          "range": "bytes=699-1076"
         },
         "data": {
-          "checksum": "sha256-IVV0PRiJiwz4Ov1pWU1VAHf8cM0TgwqsV3vkYEQc0mM=",
-          "range": "bytes=1080-5915633"
+          "checksum": "sha256-/IFXqeKvU0GODNsz1yPIEMcFHgABT+8rbZpSlTLo4e4=",
+          "range": "bytes=1077-5915704"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-OlnuKCVUD1RpZgK+JyGdG/NQ0R0=",
+          "checksum": "sha1-l1o5ixkyWWqqJE3FOfR0QUemJUA=",
           "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r7.apk",
-        "version": "3.3.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r9.apk",
+        "version": "3.3.0-r9"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1xZQl4rSEEOs59w1q/EhMx0+ZVxw=",
+        "checksum": "Q1jhAhggAuZnU7FFHnebGA26mq+jI=",
         "control": {
-          "checksum": "sha1-xZQl4rSEEOs59w1q/EhMx0+ZVxw=",
-          "range": "bytes=697-1082"
+          "checksum": "sha1-jhAhggAuZnU7FFHnebGA26mq+jI=",
+          "range": "bytes=695-1079"
         },
         "data": {
-          "checksum": "sha256-IfGWsH9qFzzKcdVENdnoZqPbAdejcokLcfm7Z53KnPM=",
-          "range": "bytes=1083-1197082"
+          "checksum": "sha256-XTCQYnhGSm7SkGwqV/TQMFqGajVJVYhKAidKfLb2D3Y=",
+          "range": "bytes=1080-1197081"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-CypiuHQ6EuduQ5uexXhBDv5YvvY=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-qVrfDVxubkrb5Yrd2mFTv2A0G7k=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r7.apk",
-        "version": "3.3.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r9.apk",
+        "version": "3.3.0-r9"
       },
       {
         "architecture": "x86_64",
@@ -793,22 +793,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1eaot0B2H9IOF054RKMabXG37GUk=",
+        "checksum": "Q111Aq+tDFOygcfZzOg1hQbtZw1Q4=",
         "control": {
-          "checksum": "sha1-eaot0B2H9IOF054RKMabXG37GUk=",
-          "range": "bytes=700-1143"
+          "checksum": "sha1-11Aq+tDFOygcfZzOg1hQbtZw1Q4=",
+          "range": "bytes=697-1140"
         },
         "data": {
-          "checksum": "sha256-EeuQkVe5Hl+bqWfkBaMgA1Z2Fh91f1upncBbArJu9Gw=",
-          "range": "bytes=1144-17267929"
+          "checksum": "sha256-ednk20seorMQ+xEGnt8zWpxO20xrfj7zOtAmk+XcTbA=",
+          "range": "bytes=1141-17250210"
         },
         "name": "git",
         "signature": {
-          "checksum": "sha1-yMhNFUJ+emT/s9tdLDQ8zjT2+vY=",
-          "range": "bytes=0-699"
+          "checksum": "sha1-T1C3/QmQvuJGLjPH2YyOLIM5ewE=",
+          "range": "bytes=0-696"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/git-2.45.1-r0.apk",
-        "version": "2.45.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/git-2.45.2-r0.apk",
+        "version": "2.45.2-r0"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/gitserver.lock.json
+++ b/wolfi-images/gitserver.lock.json
@@ -261,41 +261,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q10Rr8mXMuAm4i4SjxE7xhsgs2UME=",
+        "checksum": "Q1gTZGkWP+QO3mUqLVJth8vrDEzzU=",
         "control": {
-          "checksum": "sha1-0Rr8mXMuAm4i4SjxE7xhsgs2UME=",
-          "range": "bytes=699-1079"
+          "checksum": "sha1-gTZGkWP+QO3mUqLVJth8vrDEzzU=",
+          "range": "bytes=699-1076"
         },
         "data": {
-          "checksum": "sha256-IVV0PRiJiwz4Ov1pWU1VAHf8cM0TgwqsV3vkYEQc0mM=",
-          "range": "bytes=1080-5915633"
+          "checksum": "sha256-/IFXqeKvU0GODNsz1yPIEMcFHgABT+8rbZpSlTLo4e4=",
+          "range": "bytes=1077-5915704"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-OlnuKCVUD1RpZgK+JyGdG/NQ0R0=",
+          "checksum": "sha1-l1o5ixkyWWqqJE3FOfR0QUemJUA=",
           "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r7.apk",
-        "version": "3.3.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r9.apk",
+        "version": "3.3.0-r9"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1xZQl4rSEEOs59w1q/EhMx0+ZVxw=",
+        "checksum": "Q1jhAhggAuZnU7FFHnebGA26mq+jI=",
         "control": {
-          "checksum": "sha1-xZQl4rSEEOs59w1q/EhMx0+ZVxw=",
-          "range": "bytes=697-1082"
+          "checksum": "sha1-jhAhggAuZnU7FFHnebGA26mq+jI=",
+          "range": "bytes=695-1079"
         },
         "data": {
-          "checksum": "sha256-IfGWsH9qFzzKcdVENdnoZqPbAdejcokLcfm7Z53KnPM=",
-          "range": "bytes=1083-1197082"
+          "checksum": "sha256-XTCQYnhGSm7SkGwqV/TQMFqGajVJVYhKAidKfLb2D3Y=",
+          "range": "bytes=1080-1197081"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-CypiuHQ6EuduQ5uexXhBDv5YvvY=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-qVrfDVxubkrb5Yrd2mFTv2A0G7k=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r7.apk",
-        "version": "3.3.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r9.apk",
+        "version": "3.3.0-r9"
       },
       {
         "architecture": "x86_64",
@@ -831,79 +831,79 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1eaot0B2H9IOF054RKMabXG37GUk=",
+        "checksum": "Q111Aq+tDFOygcfZzOg1hQbtZw1Q4=",
         "control": {
-          "checksum": "sha1-eaot0B2H9IOF054RKMabXG37GUk=",
-          "range": "bytes=700-1143"
+          "checksum": "sha1-11Aq+tDFOygcfZzOg1hQbtZw1Q4=",
+          "range": "bytes=697-1140"
         },
         "data": {
-          "checksum": "sha256-EeuQkVe5Hl+bqWfkBaMgA1Z2Fh91f1upncBbArJu9Gw=",
-          "range": "bytes=1144-17267929"
+          "checksum": "sha256-ednk20seorMQ+xEGnt8zWpxO20xrfj7zOtAmk+XcTbA=",
+          "range": "bytes=1141-17250210"
         },
         "name": "git",
         "signature": {
-          "checksum": "sha1-yMhNFUJ+emT/s9tdLDQ8zjT2+vY=",
-          "range": "bytes=0-699"
+          "checksum": "sha1-T1C3/QmQvuJGLjPH2YyOLIM5ewE=",
+          "range": "bytes=0-696"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/git-2.45.1-r0.apk",
-        "version": "2.45.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/git-2.45.2-r0.apk",
+        "version": "2.45.2-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q116m2Q5Ln3gJz05D1gRD/3AQz9+4=",
+        "checksum": "Q1KXXN9Hu7PZ0iPK7gAnYRUDcDzZs=",
         "control": {
-          "checksum": "sha1-16m2Q5Ln3gJz05D1gRD/3AQz9+4=",
-          "range": "bytes=703-1102"
+          "checksum": "sha1-KXXN9Hu7PZ0iPK7gAnYRUDcDzZs=",
+          "range": "bytes=700-1063"
         },
         "data": {
-          "checksum": "sha256-nU1+NEgt7CR9vsxeCs5Hr9tHiSAw69pxvz+m0W+N+PI=",
-          "range": "bytes=1103-11855891"
+          "checksum": "sha256-F61XBj+QV78wXrinzeVQestiQeJtCAVPWwbLWf8c98Y=",
+          "range": "bytes=1064-12733161"
         },
         "name": "git-lfs",
         "signature": {
-          "checksum": "sha1-z3BWu5hxd1KVtIrVNwIYsNsgYpc=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-U6NrIIwbHHzX/fgtB3PoNVQZOJU=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/git-lfs-3.5.1-r4.apk",
-        "version": "3.5.1-r4"
+        "url": "https://packages.wolfi.dev/os/x86_64/git-lfs-3.5.1-r6.apk",
+        "version": "3.5.1-r6"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1AtyQ8BGxIy54FTCVfU4vA3dBujA=",
+        "checksum": "Q1/xjUDpfwOCMLFmAYUyXK3hbr7M8=",
         "control": {
-          "checksum": "sha1-AtyQ8BGxIy54FTCVfU4vA3dBujA=",
-          "range": "bytes=696-1105"
+          "checksum": "sha1-/xjUDpfwOCMLFmAYUyXK3hbr7M8=",
+          "range": "bytes=703-1114"
         },
         "data": {
-          "checksum": "sha256-jm7jYqIpUa8S3qayJMbb10cks4vaQbqkkl7r95+SUvc=",
-          "range": "bytes=1106-7568791"
+          "checksum": "sha256-RvBzvJt//AAv6DeDRxBbbW2UG//3UZ38sDmhcMQoRKY=",
+          "range": "bytes=1115-7560368"
         },
         "name": "git-daemon",
         "signature": {
-          "checksum": "sha1-WouI+0ZflydIMa2FK5A7CtGW7Uo=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-dHYurOENIvRxIuBAaHNAeJGQciA=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/git-daemon-2.45.1-r0.apk",
-        "version": "2.45.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/git-daemon-2.45.2-r0.apk",
+        "version": "2.45.2-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1bxdUk5Zm+DGJ1BJRhi+4lVqQC8M=",
+        "checksum": "Q1lmZVnMVaV+BuJ4Zw8v1gIkGVcNc=",
         "control": {
-          "checksum": "sha1-bxdUk5Zm+DGJ1BJRhi+4lVqQC8M=",
-          "range": "bytes=707-1078"
+          "checksum": "sha1-lmZVnMVaV+BuJ4Zw8v1gIkGVcNc=",
+          "range": "bytes=696-1069"
         },
         "data": {
-          "checksum": "sha256-n6UB0PG6Q3zvEhvY9YG0J+5fLLQy52aoHxuc/8mNhDo=",
-          "range": "bytes=1079-211589"
+          "checksum": "sha256-qHYsorfTKRzalTN5p+JzwEZ2NYXNkxiHME9MoyMfeRI=",
+          "range": "bytes=1070-212142"
         },
         "name": "git-p4",
         "signature": {
-          "checksum": "sha1-7GOnoDsQV3oKBXD6jIlMaFHpzxQ=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-eGGtsdgoIw2il+9a5ZT/t126v0c=",
+          "range": "bytes=0-695"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/git-p4-2.45.1-r0.apk",
-        "version": "2.45.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/git-p4-2.45.2-r0.apk",
+        "version": "2.45.2-r0"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/grafana.lock.json
+++ b/wolfi-images/grafana.lock.json
@@ -113,41 +113,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q10Rr8mXMuAm4i4SjxE7xhsgs2UME=",
+        "checksum": "Q1gTZGkWP+QO3mUqLVJth8vrDEzzU=",
         "control": {
-          "checksum": "sha1-0Rr8mXMuAm4i4SjxE7xhsgs2UME=",
-          "range": "bytes=699-1079"
+          "checksum": "sha1-gTZGkWP+QO3mUqLVJth8vrDEzzU=",
+          "range": "bytes=699-1076"
         },
         "data": {
-          "checksum": "sha256-IVV0PRiJiwz4Ov1pWU1VAHf8cM0TgwqsV3vkYEQc0mM=",
-          "range": "bytes=1080-5915633"
+          "checksum": "sha256-/IFXqeKvU0GODNsz1yPIEMcFHgABT+8rbZpSlTLo4e4=",
+          "range": "bytes=1077-5915704"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-OlnuKCVUD1RpZgK+JyGdG/NQ0R0=",
+          "checksum": "sha1-l1o5ixkyWWqqJE3FOfR0QUemJUA=",
           "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r7.apk",
-        "version": "3.3.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r9.apk",
+        "version": "3.3.0-r9"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1xZQl4rSEEOs59w1q/EhMx0+ZVxw=",
+        "checksum": "Q1jhAhggAuZnU7FFHnebGA26mq+jI=",
         "control": {
-          "checksum": "sha1-xZQl4rSEEOs59w1q/EhMx0+ZVxw=",
-          "range": "bytes=697-1082"
+          "checksum": "sha1-jhAhggAuZnU7FFHnebGA26mq+jI=",
+          "range": "bytes=695-1079"
         },
         "data": {
-          "checksum": "sha256-IfGWsH9qFzzKcdVENdnoZqPbAdejcokLcfm7Z53KnPM=",
-          "range": "bytes=1083-1197082"
+          "checksum": "sha256-XTCQYnhGSm7SkGwqV/TQMFqGajVJVYhKAidKfLb2D3Y=",
+          "range": "bytes=1080-1197081"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-CypiuHQ6EuduQ5uexXhBDv5YvvY=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-qVrfDVxubkrb5Yrd2mFTv2A0G7k=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r7.apk",
-        "version": "3.3.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r9.apk",
+        "version": "3.3.0-r9"
       },
       {
         "architecture": "x86_64",
@@ -531,41 +531,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1NzlLfN1k5jpK2xS5gxS0BUbK0rg=",
+        "checksum": "Q1ClRU9LEog4OgkuXujv0JpHDKDiI=",
         "control": {
-          "checksum": "sha1-NzlLfN1k5jpK2xS5gxS0BUbK0rg=",
-          "range": "bytes=698-1077"
+          "checksum": "sha1-ClRU9LEog4OgkuXujv0JpHDKDiI=",
+          "range": "bytes=703-1079"
         },
         "data": {
-          "checksum": "sha256-ZP4LZuoDPsCZ6pbQ4jkiGi0Z6SSPTQWRD0ZnxU00I64=",
-          "range": "bytes=1078-182482"
+          "checksum": "sha256-hC391qobx5DyYe6LmNA1XlgRpG5rpj6iHjAQPkK1SIk=",
+          "range": "bytes=1080-182481"
         },
         "name": "openssl-provider-legacy",
         "signature": {
-          "checksum": "sha1-ZpEyUMtKFAY1UG/VL58J72AHd2w=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-Fbc6Xmeg6vEpNQFZfdi3jb6Z/hw=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/openssl-provider-legacy-3.3.0-r7.apk",
-        "version": "3.3.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/openssl-provider-legacy-3.3.0-r9.apk",
+        "version": "3.3.0-r9"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1rK5w3i6jXlDEOJcsXmIzbJk8hWY=",
+        "checksum": "Q14cgQ7hzxZhRqXzw7CItN8b6TR0s=",
         "control": {
-          "checksum": "sha1-rK5w3i6jXlDEOJcsXmIzbJk8hWY=",
-          "range": "bytes=700-1127"
+          "checksum": "sha1-4cgQ7hzxZhRqXzw7CItN8b6TR0s=",
+          "range": "bytes=696-1122"
         },
         "data": {
-          "checksum": "sha256-F4hLB3k839A/9bWeW7SrEijgtyFQcHeoei760W+MZ44=",
-          "range": "bytes=1128-1242436"
+          "checksum": "sha256-usdB5oXIjCEBQqtiMoloXos6Fn+OyzGqbEevj/UDSLE=",
+          "range": "bytes=1123-1242435"
         },
         "name": "openssl",
         "signature": {
-          "checksum": "sha1-sMuYQwUf0O2Om8Hp/e9ulEBNwKI=",
-          "range": "bytes=0-699"
+          "checksum": "sha1-mjEQyOlQm8wq/ShCz8h/vZVZTkU=",
+          "range": "bytes=0-695"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/openssl-3.3.0-r7.apk",
-        "version": "3.3.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/openssl-3.3.0-r9.apk",
+        "version": "3.3.0-r9"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/jaeger-agent.lock.json
+++ b/wolfi-images/jaeger-agent.lock.json
@@ -204,41 +204,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q10Rr8mXMuAm4i4SjxE7xhsgs2UME=",
+        "checksum": "Q1gTZGkWP+QO3mUqLVJth8vrDEzzU=",
         "control": {
-          "checksum": "sha1-0Rr8mXMuAm4i4SjxE7xhsgs2UME=",
-          "range": "bytes=699-1079"
+          "checksum": "sha1-gTZGkWP+QO3mUqLVJth8vrDEzzU=",
+          "range": "bytes=699-1076"
         },
         "data": {
-          "checksum": "sha256-IVV0PRiJiwz4Ov1pWU1VAHf8cM0TgwqsV3vkYEQc0mM=",
-          "range": "bytes=1080-5915633"
+          "checksum": "sha256-/IFXqeKvU0GODNsz1yPIEMcFHgABT+8rbZpSlTLo4e4=",
+          "range": "bytes=1077-5915704"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-OlnuKCVUD1RpZgK+JyGdG/NQ0R0=",
+          "checksum": "sha1-l1o5ixkyWWqqJE3FOfR0QUemJUA=",
           "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r7.apk",
-        "version": "3.3.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r9.apk",
+        "version": "3.3.0-r9"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1xZQl4rSEEOs59w1q/EhMx0+ZVxw=",
+        "checksum": "Q1jhAhggAuZnU7FFHnebGA26mq+jI=",
         "control": {
-          "checksum": "sha1-xZQl4rSEEOs59w1q/EhMx0+ZVxw=",
-          "range": "bytes=697-1082"
+          "checksum": "sha1-jhAhggAuZnU7FFHnebGA26mq+jI=",
+          "range": "bytes=695-1079"
         },
         "data": {
-          "checksum": "sha256-IfGWsH9qFzzKcdVENdnoZqPbAdejcokLcfm7Z53KnPM=",
-          "range": "bytes=1083-1197082"
+          "checksum": "sha256-XTCQYnhGSm7SkGwqV/TQMFqGajVJVYhKAidKfLb2D3Y=",
+          "range": "bytes=1080-1197081"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-CypiuHQ6EuduQ5uexXhBDv5YvvY=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-qVrfDVxubkrb5Yrd2mFTv2A0G7k=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r7.apk",
-        "version": "3.3.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r9.apk",
+        "version": "3.3.0-r9"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/jaeger-all-in-one.lock.json
+++ b/wolfi-images/jaeger-all-in-one.lock.json
@@ -204,41 +204,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q10Rr8mXMuAm4i4SjxE7xhsgs2UME=",
+        "checksum": "Q1gTZGkWP+QO3mUqLVJth8vrDEzzU=",
         "control": {
-          "checksum": "sha1-0Rr8mXMuAm4i4SjxE7xhsgs2UME=",
-          "range": "bytes=699-1079"
+          "checksum": "sha1-gTZGkWP+QO3mUqLVJth8vrDEzzU=",
+          "range": "bytes=699-1076"
         },
         "data": {
-          "checksum": "sha256-IVV0PRiJiwz4Ov1pWU1VAHf8cM0TgwqsV3vkYEQc0mM=",
-          "range": "bytes=1080-5915633"
+          "checksum": "sha256-/IFXqeKvU0GODNsz1yPIEMcFHgABT+8rbZpSlTLo4e4=",
+          "range": "bytes=1077-5915704"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-OlnuKCVUD1RpZgK+JyGdG/NQ0R0=",
+          "checksum": "sha1-l1o5ixkyWWqqJE3FOfR0QUemJUA=",
           "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r7.apk",
-        "version": "3.3.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r9.apk",
+        "version": "3.3.0-r9"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1xZQl4rSEEOs59w1q/EhMx0+ZVxw=",
+        "checksum": "Q1jhAhggAuZnU7FFHnebGA26mq+jI=",
         "control": {
-          "checksum": "sha1-xZQl4rSEEOs59w1q/EhMx0+ZVxw=",
-          "range": "bytes=697-1082"
+          "checksum": "sha1-jhAhggAuZnU7FFHnebGA26mq+jI=",
+          "range": "bytes=695-1079"
         },
         "data": {
-          "checksum": "sha256-IfGWsH9qFzzKcdVENdnoZqPbAdejcokLcfm7Z53KnPM=",
-          "range": "bytes=1083-1197082"
+          "checksum": "sha256-XTCQYnhGSm7SkGwqV/TQMFqGajVJVYhKAidKfLb2D3Y=",
+          "range": "bytes=1080-1197081"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-CypiuHQ6EuduQ5uexXhBDv5YvvY=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-qVrfDVxubkrb5Yrd2mFTv2A0G7k=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r7.apk",
-        "version": "3.3.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r9.apk",
+        "version": "3.3.0-r9"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/node-exporter.lock.json
+++ b/wolfi-images/node-exporter.lock.json
@@ -204,41 +204,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q10Rr8mXMuAm4i4SjxE7xhsgs2UME=",
+        "checksum": "Q1gTZGkWP+QO3mUqLVJth8vrDEzzU=",
         "control": {
-          "checksum": "sha1-0Rr8mXMuAm4i4SjxE7xhsgs2UME=",
-          "range": "bytes=699-1079"
+          "checksum": "sha1-gTZGkWP+QO3mUqLVJth8vrDEzzU=",
+          "range": "bytes=699-1076"
         },
         "data": {
-          "checksum": "sha256-IVV0PRiJiwz4Ov1pWU1VAHf8cM0TgwqsV3vkYEQc0mM=",
-          "range": "bytes=1080-5915633"
+          "checksum": "sha256-/IFXqeKvU0GODNsz1yPIEMcFHgABT+8rbZpSlTLo4e4=",
+          "range": "bytes=1077-5915704"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-OlnuKCVUD1RpZgK+JyGdG/NQ0R0=",
+          "checksum": "sha1-l1o5ixkyWWqqJE3FOfR0QUemJUA=",
           "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r7.apk",
-        "version": "3.3.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r9.apk",
+        "version": "3.3.0-r9"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1xZQl4rSEEOs59w1q/EhMx0+ZVxw=",
+        "checksum": "Q1jhAhggAuZnU7FFHnebGA26mq+jI=",
         "control": {
-          "checksum": "sha1-xZQl4rSEEOs59w1q/EhMx0+ZVxw=",
-          "range": "bytes=697-1082"
+          "checksum": "sha1-jhAhggAuZnU7FFHnebGA26mq+jI=",
+          "range": "bytes=695-1079"
         },
         "data": {
-          "checksum": "sha256-IfGWsH9qFzzKcdVENdnoZqPbAdejcokLcfm7Z53KnPM=",
-          "range": "bytes=1083-1197082"
+          "checksum": "sha256-XTCQYnhGSm7SkGwqV/TQMFqGajVJVYhKAidKfLb2D3Y=",
+          "range": "bytes=1080-1197081"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-CypiuHQ6EuduQ5uexXhBDv5YvvY=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-qVrfDVxubkrb5Yrd2mFTv2A0G7k=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r7.apk",
-        "version": "3.3.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r9.apk",
+        "version": "3.3.0-r9"
       },
       {
         "architecture": "x86_64",
@@ -717,22 +717,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1+CrV4/7Mpj6weKDPMS4/SGyDZ/k=",
+        "checksum": "Q11MjyY75dy19jhUUc+pJ77bBmkiA=",
         "control": {
-          "checksum": "sha1-+CrV4/7Mpj6weKDPMS4/SGyDZ/k=",
-          "range": "bytes=706-1088"
+          "checksum": "sha1-1MjyY75dy19jhUUc+pJ77bBmkiA=",
+          "range": "bytes=704-1086"
         },
         "data": {
-          "checksum": "sha256-MeiYbFzYAORxCrV44mMVXgCFtUmwkp4HY5UQ1vD4uRQ=",
-          "range": "bytes=1089-15541728"
+          "checksum": "sha256-VzE/ZAEOrO6lBW21IJ6Kx4BCAaWIjuygSPZCYGwGKuk=",
+          "range": "bytes=1087-15542357"
         },
         "name": "prometheus-node-exporter",
         "signature": {
-          "checksum": "sha1-k1QW5tfgVSlm4Xwx77Y8ZOvSiAU=",
-          "range": "bytes=0-705"
+          "checksum": "sha1-m6+CIL3VlmtVXNtxUmEDLVgOC9o=",
+          "range": "bytes=0-703"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/prometheus-node-exporter-1.8.1-r0.apk",
-        "version": "1.8.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/prometheus-node-exporter-1.8.1-r1.apk",
+        "version": "1.8.1-r1"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/opentelemetry-collector.lock.json
+++ b/wolfi-images/opentelemetry-collector.lock.json
@@ -204,41 +204,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q10Rr8mXMuAm4i4SjxE7xhsgs2UME=",
+        "checksum": "Q1gTZGkWP+QO3mUqLVJth8vrDEzzU=",
         "control": {
-          "checksum": "sha1-0Rr8mXMuAm4i4SjxE7xhsgs2UME=",
-          "range": "bytes=699-1079"
+          "checksum": "sha1-gTZGkWP+QO3mUqLVJth8vrDEzzU=",
+          "range": "bytes=699-1076"
         },
         "data": {
-          "checksum": "sha256-IVV0PRiJiwz4Ov1pWU1VAHf8cM0TgwqsV3vkYEQc0mM=",
-          "range": "bytes=1080-5915633"
+          "checksum": "sha256-/IFXqeKvU0GODNsz1yPIEMcFHgABT+8rbZpSlTLo4e4=",
+          "range": "bytes=1077-5915704"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-OlnuKCVUD1RpZgK+JyGdG/NQ0R0=",
+          "checksum": "sha1-l1o5ixkyWWqqJE3FOfR0QUemJUA=",
           "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r7.apk",
-        "version": "3.3.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r9.apk",
+        "version": "3.3.0-r9"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1xZQl4rSEEOs59w1q/EhMx0+ZVxw=",
+        "checksum": "Q1jhAhggAuZnU7FFHnebGA26mq+jI=",
         "control": {
-          "checksum": "sha1-xZQl4rSEEOs59w1q/EhMx0+ZVxw=",
-          "range": "bytes=697-1082"
+          "checksum": "sha1-jhAhggAuZnU7FFHnebGA26mq+jI=",
+          "range": "bytes=695-1079"
         },
         "data": {
-          "checksum": "sha256-IfGWsH9qFzzKcdVENdnoZqPbAdejcokLcfm7Z53KnPM=",
-          "range": "bytes=1083-1197082"
+          "checksum": "sha256-XTCQYnhGSm7SkGwqV/TQMFqGajVJVYhKAidKfLb2D3Y=",
+          "range": "bytes=1080-1197081"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-CypiuHQ6EuduQ5uexXhBDv5YvvY=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-qVrfDVxubkrb5Yrd2mFTv2A0G7k=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r7.apk",
-        "version": "3.3.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r9.apk",
+        "version": "3.3.0-r9"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/postgres-exporter.lock.json
+++ b/wolfi-images/postgres-exporter.lock.json
@@ -204,41 +204,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q10Rr8mXMuAm4i4SjxE7xhsgs2UME=",
+        "checksum": "Q1gTZGkWP+QO3mUqLVJth8vrDEzzU=",
         "control": {
-          "checksum": "sha1-0Rr8mXMuAm4i4SjxE7xhsgs2UME=",
-          "range": "bytes=699-1079"
+          "checksum": "sha1-gTZGkWP+QO3mUqLVJth8vrDEzzU=",
+          "range": "bytes=699-1076"
         },
         "data": {
-          "checksum": "sha256-IVV0PRiJiwz4Ov1pWU1VAHf8cM0TgwqsV3vkYEQc0mM=",
-          "range": "bytes=1080-5915633"
+          "checksum": "sha256-/IFXqeKvU0GODNsz1yPIEMcFHgABT+8rbZpSlTLo4e4=",
+          "range": "bytes=1077-5915704"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-OlnuKCVUD1RpZgK+JyGdG/NQ0R0=",
+          "checksum": "sha1-l1o5ixkyWWqqJE3FOfR0QUemJUA=",
           "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r7.apk",
-        "version": "3.3.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r9.apk",
+        "version": "3.3.0-r9"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1xZQl4rSEEOs59w1q/EhMx0+ZVxw=",
+        "checksum": "Q1jhAhggAuZnU7FFHnebGA26mq+jI=",
         "control": {
-          "checksum": "sha1-xZQl4rSEEOs59w1q/EhMx0+ZVxw=",
-          "range": "bytes=697-1082"
+          "checksum": "sha1-jhAhggAuZnU7FFHnebGA26mq+jI=",
+          "range": "bytes=695-1079"
         },
         "data": {
-          "checksum": "sha256-IfGWsH9qFzzKcdVENdnoZqPbAdejcokLcfm7Z53KnPM=",
-          "range": "bytes=1083-1197082"
+          "checksum": "sha256-XTCQYnhGSm7SkGwqV/TQMFqGajVJVYhKAidKfLb2D3Y=",
+          "range": "bytes=1080-1197081"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-CypiuHQ6EuduQ5uexXhBDv5YvvY=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-qVrfDVxubkrb5Yrd2mFTv2A0G7k=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r7.apk",
-        "version": "3.3.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r9.apk",
+        "version": "3.3.0-r9"
       },
       {
         "architecture": "x86_64",
@@ -717,22 +717,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1XIbmz6FFXwWTUG8HhvQerKRe/jw=",
+        "checksum": "Q1ZSA3uYHgOuEdsXqsjTZQOc7JGFM=",
         "control": {
-          "checksum": "sha1-XIbmz6FFXwWTUG8HhvQerKRe/jw=",
-          "range": "bytes=696-1083"
+          "checksum": "sha1-ZSA3uYHgOuEdsXqsjTZQOc7JGFM=",
+          "range": "bytes=697-1083"
         },
         "data": {
-          "checksum": "sha256-UKgbUouSkIdCQsg8PmQTkCgdqcyvoLQgXBBnqCxbIro=",
-          "range": "bytes=1084-13096991"
+          "checksum": "sha256-U6V84QUUZHttnP8E4tXIiGqLDrqo6l+b3pSK4J2U5oI=",
+          "range": "bytes=1084-13097660"
         },
         "name": "prometheus-postgres-exporter",
         "signature": {
-          "checksum": "sha1-KOTdEh5gZtZxWaonriTl0RKGtz0=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-tYMJlKBEQpyVJBRdhmv1c/+AQfQ=",
+          "range": "bytes=0-696"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/prometheus-postgres-exporter-0.15.0-r9.apk",
-        "version": "0.15.0-r9"
+        "url": "https://packages.wolfi.dev/os/x86_64/prometheus-postgres-exporter-0.15.0-r10.apk",
+        "version": "0.15.0-r10"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/postgresql-12-codeinsights.lock.json
+++ b/wolfi-images/postgresql-12-codeinsights.lock.json
@@ -204,41 +204,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q10Rr8mXMuAm4i4SjxE7xhsgs2UME=",
+        "checksum": "Q1gTZGkWP+QO3mUqLVJth8vrDEzzU=",
         "control": {
-          "checksum": "sha1-0Rr8mXMuAm4i4SjxE7xhsgs2UME=",
-          "range": "bytes=699-1079"
+          "checksum": "sha1-gTZGkWP+QO3mUqLVJth8vrDEzzU=",
+          "range": "bytes=699-1076"
         },
         "data": {
-          "checksum": "sha256-IVV0PRiJiwz4Ov1pWU1VAHf8cM0TgwqsV3vkYEQc0mM=",
-          "range": "bytes=1080-5915633"
+          "checksum": "sha256-/IFXqeKvU0GODNsz1yPIEMcFHgABT+8rbZpSlTLo4e4=",
+          "range": "bytes=1077-5915704"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-OlnuKCVUD1RpZgK+JyGdG/NQ0R0=",
+          "checksum": "sha1-l1o5ixkyWWqqJE3FOfR0QUemJUA=",
           "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r7.apk",
-        "version": "3.3.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r9.apk",
+        "version": "3.3.0-r9"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1xZQl4rSEEOs59w1q/EhMx0+ZVxw=",
+        "checksum": "Q1jhAhggAuZnU7FFHnebGA26mq+jI=",
         "control": {
-          "checksum": "sha1-xZQl4rSEEOs59w1q/EhMx0+ZVxw=",
-          "range": "bytes=697-1082"
+          "checksum": "sha1-jhAhggAuZnU7FFHnebGA26mq+jI=",
+          "range": "bytes=695-1079"
         },
         "data": {
-          "checksum": "sha256-IfGWsH9qFzzKcdVENdnoZqPbAdejcokLcfm7Z53KnPM=",
-          "range": "bytes=1083-1197082"
+          "checksum": "sha256-XTCQYnhGSm7SkGwqV/TQMFqGajVJVYhKAidKfLb2D3Y=",
+          "range": "bytes=1080-1197081"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-CypiuHQ6EuduQ5uexXhBDv5YvvY=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-qVrfDVxubkrb5Yrd2mFTv2A0G7k=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r7.apk",
-        "version": "3.3.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r9.apk",
+        "version": "3.3.0-r9"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/postgresql-12.lock.json
+++ b/wolfi-images/postgresql-12.lock.json
@@ -204,41 +204,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q10Rr8mXMuAm4i4SjxE7xhsgs2UME=",
+        "checksum": "Q1gTZGkWP+QO3mUqLVJth8vrDEzzU=",
         "control": {
-          "checksum": "sha1-0Rr8mXMuAm4i4SjxE7xhsgs2UME=",
-          "range": "bytes=699-1079"
+          "checksum": "sha1-gTZGkWP+QO3mUqLVJth8vrDEzzU=",
+          "range": "bytes=699-1076"
         },
         "data": {
-          "checksum": "sha256-IVV0PRiJiwz4Ov1pWU1VAHf8cM0TgwqsV3vkYEQc0mM=",
-          "range": "bytes=1080-5915633"
+          "checksum": "sha256-/IFXqeKvU0GODNsz1yPIEMcFHgABT+8rbZpSlTLo4e4=",
+          "range": "bytes=1077-5915704"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-OlnuKCVUD1RpZgK+JyGdG/NQ0R0=",
+          "checksum": "sha1-l1o5ixkyWWqqJE3FOfR0QUemJUA=",
           "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r7.apk",
-        "version": "3.3.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r9.apk",
+        "version": "3.3.0-r9"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1xZQl4rSEEOs59w1q/EhMx0+ZVxw=",
+        "checksum": "Q1jhAhggAuZnU7FFHnebGA26mq+jI=",
         "control": {
-          "checksum": "sha1-xZQl4rSEEOs59w1q/EhMx0+ZVxw=",
-          "range": "bytes=697-1082"
+          "checksum": "sha1-jhAhggAuZnU7FFHnebGA26mq+jI=",
+          "range": "bytes=695-1079"
         },
         "data": {
-          "checksum": "sha256-IfGWsH9qFzzKcdVENdnoZqPbAdejcokLcfm7Z53KnPM=",
-          "range": "bytes=1083-1197082"
+          "checksum": "sha256-XTCQYnhGSm7SkGwqV/TQMFqGajVJVYhKAidKfLb2D3Y=",
+          "range": "bytes=1080-1197081"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-CypiuHQ6EuduQ5uexXhBDv5YvvY=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-qVrfDVxubkrb5Yrd2mFTv2A0G7k=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r7.apk",
-        "version": "3.3.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r9.apk",
+        "version": "3.3.0-r9"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/prometheus.lock.json
+++ b/wolfi-images/prometheus.lock.json
@@ -204,41 +204,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q10Rr8mXMuAm4i4SjxE7xhsgs2UME=",
+        "checksum": "Q1gTZGkWP+QO3mUqLVJth8vrDEzzU=",
         "control": {
-          "checksum": "sha1-0Rr8mXMuAm4i4SjxE7xhsgs2UME=",
-          "range": "bytes=699-1079"
+          "checksum": "sha1-gTZGkWP+QO3mUqLVJth8vrDEzzU=",
+          "range": "bytes=699-1076"
         },
         "data": {
-          "checksum": "sha256-IVV0PRiJiwz4Ov1pWU1VAHf8cM0TgwqsV3vkYEQc0mM=",
-          "range": "bytes=1080-5915633"
+          "checksum": "sha256-/IFXqeKvU0GODNsz1yPIEMcFHgABT+8rbZpSlTLo4e4=",
+          "range": "bytes=1077-5915704"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-OlnuKCVUD1RpZgK+JyGdG/NQ0R0=",
+          "checksum": "sha1-l1o5ixkyWWqqJE3FOfR0QUemJUA=",
           "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r7.apk",
-        "version": "3.3.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r9.apk",
+        "version": "3.3.0-r9"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1xZQl4rSEEOs59w1q/EhMx0+ZVxw=",
+        "checksum": "Q1jhAhggAuZnU7FFHnebGA26mq+jI=",
         "control": {
-          "checksum": "sha1-xZQl4rSEEOs59w1q/EhMx0+ZVxw=",
-          "range": "bytes=697-1082"
+          "checksum": "sha1-jhAhggAuZnU7FFHnebGA26mq+jI=",
+          "range": "bytes=695-1079"
         },
         "data": {
-          "checksum": "sha256-IfGWsH9qFzzKcdVENdnoZqPbAdejcokLcfm7Z53KnPM=",
-          "range": "bytes=1083-1197082"
+          "checksum": "sha256-XTCQYnhGSm7SkGwqV/TQMFqGajVJVYhKAidKfLb2D3Y=",
+          "range": "bytes=1080-1197081"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-CypiuHQ6EuduQ5uexXhBDv5YvvY=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-qVrfDVxubkrb5Yrd2mFTv2A0G7k=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r7.apk",
-        "version": "3.3.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r9.apk",
+        "version": "3.3.0-r9"
       },
       {
         "architecture": "x86_64",
@@ -736,41 +736,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1wjEh5PI4XEuZMLSqCUBZsNsp5t8=",
+        "checksum": "Q1KHnJp4dgXxm50FeWqVm7Lu2Rm3o=",
         "control": {
-          "checksum": "sha1-wjEh5PI4XEuZMLSqCUBZsNsp5t8=",
-          "range": "bytes=702-1143"
+          "checksum": "sha1-KHnJp4dgXxm50FeWqVm7Lu2Rm3o=",
+          "range": "bytes=696-1138"
         },
         "data": {
-          "checksum": "sha256-Vbe4KzKdSQ8oya/6+1+E9jHF+kEFJ9dk9E+zkaoBM7w=",
-          "range": "bytes=1144-192879162"
+          "checksum": "sha256-wWq5y1hEpcKhQ1QnvOKJHsnPxcD7/X7IEViso75B9bs=",
+          "range": "bytes=1139-192875683"
         },
         "name": "prometheus-2.52",
         "signature": {
-          "checksum": "sha1-m6xJcvKj0rNtml4eJe5VbyYfryo=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-3JjyUbZtACAX5ljsTN4qs1Qekqk=",
+          "range": "bytes=0-695"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/prometheus-2.52-2.52.0-r2.apk",
-        "version": "2.52.0-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/prometheus-2.52-2.52.0-r3.apk",
+        "version": "2.52.0-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1EFV1Q0eivNbJaIY0PhIkKyi/YpM=",
+        "checksum": "Q1mKnd8VT1t/VpToT3N7SPrMi9G7M=",
         "control": {
-          "checksum": "sha1-EFV1Q0eivNbJaIY0PhIkKyi/YpM=",
-          "range": "bytes=692-1063"
+          "checksum": "sha1-mKnd8VT1t/VpToT3N7SPrMi9G7M=",
+          "range": "bytes=704-1076"
         },
         "data": {
-          "checksum": "sha256-8+FNf75bgQE5erENZXCFxI50AnaHUvWSpI08emdqXvM=",
-          "range": "bytes=1064-57320379"
+          "checksum": "sha256-jQj6AJ1g/WJ9eLrczILo23fWFXkgfa9KdKtaFQoqSUc=",
+          "range": "bytes=1077-57321007"
         },
         "name": "prometheus-alertmanager",
         "signature": {
-          "checksum": "sha1-YMhX/dlqWFP0BQzWZPUviDQs/Yw=",
-          "range": "bytes=0-691"
+          "checksum": "sha1-ZOVjf8UJGM8EYWnakAYVMzPXaoE=",
+          "range": "bytes=0-703"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/prometheus-alertmanager-0.27.0-r5.apk",
-        "version": "0.27.0-r5"
+        "url": "https://packages.wolfi.dev/os/x86_64/prometheus-alertmanager-0.27.0-r6.apk",
+        "version": "0.27.0-r6"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/redis-exporter.lock.json
+++ b/wolfi-images/redis-exporter.lock.json
@@ -204,41 +204,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q10Rr8mXMuAm4i4SjxE7xhsgs2UME=",
+        "checksum": "Q1gTZGkWP+QO3mUqLVJth8vrDEzzU=",
         "control": {
-          "checksum": "sha1-0Rr8mXMuAm4i4SjxE7xhsgs2UME=",
-          "range": "bytes=699-1079"
+          "checksum": "sha1-gTZGkWP+QO3mUqLVJth8vrDEzzU=",
+          "range": "bytes=699-1076"
         },
         "data": {
-          "checksum": "sha256-IVV0PRiJiwz4Ov1pWU1VAHf8cM0TgwqsV3vkYEQc0mM=",
-          "range": "bytes=1080-5915633"
+          "checksum": "sha256-/IFXqeKvU0GODNsz1yPIEMcFHgABT+8rbZpSlTLo4e4=",
+          "range": "bytes=1077-5915704"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-OlnuKCVUD1RpZgK+JyGdG/NQ0R0=",
+          "checksum": "sha1-l1o5ixkyWWqqJE3FOfR0QUemJUA=",
           "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r7.apk",
-        "version": "3.3.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r9.apk",
+        "version": "3.3.0-r9"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1xZQl4rSEEOs59w1q/EhMx0+ZVxw=",
+        "checksum": "Q1jhAhggAuZnU7FFHnebGA26mq+jI=",
         "control": {
-          "checksum": "sha1-xZQl4rSEEOs59w1q/EhMx0+ZVxw=",
-          "range": "bytes=697-1082"
+          "checksum": "sha1-jhAhggAuZnU7FFHnebGA26mq+jI=",
+          "range": "bytes=695-1079"
         },
         "data": {
-          "checksum": "sha256-IfGWsH9qFzzKcdVENdnoZqPbAdejcokLcfm7Z53KnPM=",
-          "range": "bytes=1083-1197082"
+          "checksum": "sha256-XTCQYnhGSm7SkGwqV/TQMFqGajVJVYhKAidKfLb2D3Y=",
+          "range": "bytes=1080-1197081"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-CypiuHQ6EuduQ5uexXhBDv5YvvY=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-qVrfDVxubkrb5Yrd2mFTv2A0G7k=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r7.apk",
-        "version": "3.3.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r9.apk",
+        "version": "3.3.0-r9"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/redis.lock.json
+++ b/wolfi-images/redis.lock.json
@@ -204,41 +204,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q10Rr8mXMuAm4i4SjxE7xhsgs2UME=",
+        "checksum": "Q1gTZGkWP+QO3mUqLVJth8vrDEzzU=",
         "control": {
-          "checksum": "sha1-0Rr8mXMuAm4i4SjxE7xhsgs2UME=",
-          "range": "bytes=699-1079"
+          "checksum": "sha1-gTZGkWP+QO3mUqLVJth8vrDEzzU=",
+          "range": "bytes=699-1076"
         },
         "data": {
-          "checksum": "sha256-IVV0PRiJiwz4Ov1pWU1VAHf8cM0TgwqsV3vkYEQc0mM=",
-          "range": "bytes=1080-5915633"
+          "checksum": "sha256-/IFXqeKvU0GODNsz1yPIEMcFHgABT+8rbZpSlTLo4e4=",
+          "range": "bytes=1077-5915704"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-OlnuKCVUD1RpZgK+JyGdG/NQ0R0=",
+          "checksum": "sha1-l1o5ixkyWWqqJE3FOfR0QUemJUA=",
           "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r7.apk",
-        "version": "3.3.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r9.apk",
+        "version": "3.3.0-r9"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1xZQl4rSEEOs59w1q/EhMx0+ZVxw=",
+        "checksum": "Q1jhAhggAuZnU7FFHnebGA26mq+jI=",
         "control": {
-          "checksum": "sha1-xZQl4rSEEOs59w1q/EhMx0+ZVxw=",
-          "range": "bytes=697-1082"
+          "checksum": "sha1-jhAhggAuZnU7FFHnebGA26mq+jI=",
+          "range": "bytes=695-1079"
         },
         "data": {
-          "checksum": "sha256-IfGWsH9qFzzKcdVENdnoZqPbAdejcokLcfm7Z53KnPM=",
-          "range": "bytes=1083-1197082"
+          "checksum": "sha256-XTCQYnhGSm7SkGwqV/TQMFqGajVJVYhKAidKfLb2D3Y=",
+          "range": "bytes=1080-1197081"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-CypiuHQ6EuduQ5uexXhBDv5YvvY=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-qVrfDVxubkrb5Yrd2mFTv2A0G7k=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r7.apk",
-        "version": "3.3.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r9.apk",
+        "version": "3.3.0-r9"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/repo-updater.lock.json
+++ b/wolfi-images/repo-updater.lock.json
@@ -204,41 +204,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q10Rr8mXMuAm4i4SjxE7xhsgs2UME=",
+        "checksum": "Q1gTZGkWP+QO3mUqLVJth8vrDEzzU=",
         "control": {
-          "checksum": "sha1-0Rr8mXMuAm4i4SjxE7xhsgs2UME=",
-          "range": "bytes=699-1079"
+          "checksum": "sha1-gTZGkWP+QO3mUqLVJth8vrDEzzU=",
+          "range": "bytes=699-1076"
         },
         "data": {
-          "checksum": "sha256-IVV0PRiJiwz4Ov1pWU1VAHf8cM0TgwqsV3vkYEQc0mM=",
-          "range": "bytes=1080-5915633"
+          "checksum": "sha256-/IFXqeKvU0GODNsz1yPIEMcFHgABT+8rbZpSlTLo4e4=",
+          "range": "bytes=1077-5915704"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-OlnuKCVUD1RpZgK+JyGdG/NQ0R0=",
+          "checksum": "sha1-l1o5ixkyWWqqJE3FOfR0QUemJUA=",
           "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r7.apk",
-        "version": "3.3.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r9.apk",
+        "version": "3.3.0-r9"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1xZQl4rSEEOs59w1q/EhMx0+ZVxw=",
+        "checksum": "Q1jhAhggAuZnU7FFHnebGA26mq+jI=",
         "control": {
-          "checksum": "sha1-xZQl4rSEEOs59w1q/EhMx0+ZVxw=",
-          "range": "bytes=697-1082"
+          "checksum": "sha1-jhAhggAuZnU7FFHnebGA26mq+jI=",
+          "range": "bytes=695-1079"
         },
         "data": {
-          "checksum": "sha256-IfGWsH9qFzzKcdVENdnoZqPbAdejcokLcfm7Z53KnPM=",
-          "range": "bytes=1083-1197082"
+          "checksum": "sha256-XTCQYnhGSm7SkGwqV/TQMFqGajVJVYhKAidKfLb2D3Y=",
+          "range": "bytes=1080-1197081"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-CypiuHQ6EuduQ5uexXhBDv5YvvY=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-qVrfDVxubkrb5Yrd2mFTv2A0G7k=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r7.apk",
-        "version": "3.3.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r9.apk",
+        "version": "3.3.0-r9"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/search-indexer.lock.json
+++ b/wolfi-images/search-indexer.lock.json
@@ -204,41 +204,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q10Rr8mXMuAm4i4SjxE7xhsgs2UME=",
+        "checksum": "Q1gTZGkWP+QO3mUqLVJth8vrDEzzU=",
         "control": {
-          "checksum": "sha1-0Rr8mXMuAm4i4SjxE7xhsgs2UME=",
-          "range": "bytes=699-1079"
+          "checksum": "sha1-gTZGkWP+QO3mUqLVJth8vrDEzzU=",
+          "range": "bytes=699-1076"
         },
         "data": {
-          "checksum": "sha256-IVV0PRiJiwz4Ov1pWU1VAHf8cM0TgwqsV3vkYEQc0mM=",
-          "range": "bytes=1080-5915633"
+          "checksum": "sha256-/IFXqeKvU0GODNsz1yPIEMcFHgABT+8rbZpSlTLo4e4=",
+          "range": "bytes=1077-5915704"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-OlnuKCVUD1RpZgK+JyGdG/NQ0R0=",
+          "checksum": "sha1-l1o5ixkyWWqqJE3FOfR0QUemJUA=",
           "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r7.apk",
-        "version": "3.3.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r9.apk",
+        "version": "3.3.0-r9"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1xZQl4rSEEOs59w1q/EhMx0+ZVxw=",
+        "checksum": "Q1jhAhggAuZnU7FFHnebGA26mq+jI=",
         "control": {
-          "checksum": "sha1-xZQl4rSEEOs59w1q/EhMx0+ZVxw=",
-          "range": "bytes=697-1082"
+          "checksum": "sha1-jhAhggAuZnU7FFHnebGA26mq+jI=",
+          "range": "bytes=695-1079"
         },
         "data": {
-          "checksum": "sha256-IfGWsH9qFzzKcdVENdnoZqPbAdejcokLcfm7Z53KnPM=",
-          "range": "bytes=1083-1197082"
+          "checksum": "sha256-XTCQYnhGSm7SkGwqV/TQMFqGajVJVYhKAidKfLb2D3Y=",
+          "range": "bytes=1080-1197081"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-CypiuHQ6EuduQ5uexXhBDv5YvvY=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-qVrfDVxubkrb5Yrd2mFTv2A0G7k=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r7.apk",
-        "version": "3.3.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r9.apk",
+        "version": "3.3.0-r9"
       },
       {
         "architecture": "x86_64",
@@ -793,22 +793,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1eaot0B2H9IOF054RKMabXG37GUk=",
+        "checksum": "Q111Aq+tDFOygcfZzOg1hQbtZw1Q4=",
         "control": {
-          "checksum": "sha1-eaot0B2H9IOF054RKMabXG37GUk=",
-          "range": "bytes=700-1143"
+          "checksum": "sha1-11Aq+tDFOygcfZzOg1hQbtZw1Q4=",
+          "range": "bytes=697-1140"
         },
         "data": {
-          "checksum": "sha256-EeuQkVe5Hl+bqWfkBaMgA1Z2Fh91f1upncBbArJu9Gw=",
-          "range": "bytes=1144-17267929"
+          "checksum": "sha256-ednk20seorMQ+xEGnt8zWpxO20xrfj7zOtAmk+XcTbA=",
+          "range": "bytes=1141-17250210"
         },
         "name": "git",
         "signature": {
-          "checksum": "sha1-yMhNFUJ+emT/s9tdLDQ8zjT2+vY=",
-          "range": "bytes=0-699"
+          "checksum": "sha1-T1C3/QmQvuJGLjPH2YyOLIM5ewE=",
+          "range": "bytes=0-696"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/git-2.45.1-r0.apk",
-        "version": "2.45.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/git-2.45.2-r0.apk",
+        "version": "2.45.2-r0"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/searcher.lock.json
+++ b/wolfi-images/searcher.lock.json
@@ -204,41 +204,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q10Rr8mXMuAm4i4SjxE7xhsgs2UME=",
+        "checksum": "Q1gTZGkWP+QO3mUqLVJth8vrDEzzU=",
         "control": {
-          "checksum": "sha1-0Rr8mXMuAm4i4SjxE7xhsgs2UME=",
-          "range": "bytes=699-1079"
+          "checksum": "sha1-gTZGkWP+QO3mUqLVJth8vrDEzzU=",
+          "range": "bytes=699-1076"
         },
         "data": {
-          "checksum": "sha256-IVV0PRiJiwz4Ov1pWU1VAHf8cM0TgwqsV3vkYEQc0mM=",
-          "range": "bytes=1080-5915633"
+          "checksum": "sha256-/IFXqeKvU0GODNsz1yPIEMcFHgABT+8rbZpSlTLo4e4=",
+          "range": "bytes=1077-5915704"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-OlnuKCVUD1RpZgK+JyGdG/NQ0R0=",
+          "checksum": "sha1-l1o5ixkyWWqqJE3FOfR0QUemJUA=",
           "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r7.apk",
-        "version": "3.3.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r9.apk",
+        "version": "3.3.0-r9"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1xZQl4rSEEOs59w1q/EhMx0+ZVxw=",
+        "checksum": "Q1jhAhggAuZnU7FFHnebGA26mq+jI=",
         "control": {
-          "checksum": "sha1-xZQl4rSEEOs59w1q/EhMx0+ZVxw=",
-          "range": "bytes=697-1082"
+          "checksum": "sha1-jhAhggAuZnU7FFHnebGA26mq+jI=",
+          "range": "bytes=695-1079"
         },
         "data": {
-          "checksum": "sha256-IfGWsH9qFzzKcdVENdnoZqPbAdejcokLcfm7Z53KnPM=",
-          "range": "bytes=1083-1197082"
+          "checksum": "sha256-XTCQYnhGSm7SkGwqV/TQMFqGajVJVYhKAidKfLb2D3Y=",
+          "range": "bytes=1080-1197081"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-CypiuHQ6EuduQ5uexXhBDv5YvvY=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-qVrfDVxubkrb5Yrd2mFTv2A0G7k=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r7.apk",
-        "version": "3.3.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r9.apk",
+        "version": "3.3.0-r9"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/server.lock.json
+++ b/wolfi-images/server.lock.json
@@ -265,41 +265,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q10Rr8mXMuAm4i4SjxE7xhsgs2UME=",
+        "checksum": "Q1gTZGkWP+QO3mUqLVJth8vrDEzzU=",
         "control": {
-          "checksum": "sha1-0Rr8mXMuAm4i4SjxE7xhsgs2UME=",
-          "range": "bytes=699-1079"
+          "checksum": "sha1-gTZGkWP+QO3mUqLVJth8vrDEzzU=",
+          "range": "bytes=699-1076"
         },
         "data": {
-          "checksum": "sha256-IVV0PRiJiwz4Ov1pWU1VAHf8cM0TgwqsV3vkYEQc0mM=",
-          "range": "bytes=1080-5915633"
+          "checksum": "sha256-/IFXqeKvU0GODNsz1yPIEMcFHgABT+8rbZpSlTLo4e4=",
+          "range": "bytes=1077-5915704"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-OlnuKCVUD1RpZgK+JyGdG/NQ0R0=",
+          "checksum": "sha1-l1o5ixkyWWqqJE3FOfR0QUemJUA=",
           "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r7.apk",
-        "version": "3.3.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r9.apk",
+        "version": "3.3.0-r9"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1xZQl4rSEEOs59w1q/EhMx0+ZVxw=",
+        "checksum": "Q1jhAhggAuZnU7FFHnebGA26mq+jI=",
         "control": {
-          "checksum": "sha1-xZQl4rSEEOs59w1q/EhMx0+ZVxw=",
-          "range": "bytes=697-1082"
+          "checksum": "sha1-jhAhggAuZnU7FFHnebGA26mq+jI=",
+          "range": "bytes=695-1079"
         },
         "data": {
-          "checksum": "sha256-IfGWsH9qFzzKcdVENdnoZqPbAdejcokLcfm7Z53KnPM=",
-          "range": "bytes=1083-1197082"
+          "checksum": "sha256-XTCQYnhGSm7SkGwqV/TQMFqGajVJVYhKAidKfLb2D3Y=",
+          "range": "bytes=1080-1197081"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-CypiuHQ6EuduQ5uexXhBDv5YvvY=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-qVrfDVxubkrb5Yrd2mFTv2A0G7k=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r7.apk",
-        "version": "3.3.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r9.apk",
+        "version": "3.3.0-r9"
       },
       {
         "architecture": "x86_64",
@@ -949,79 +949,79 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1eaot0B2H9IOF054RKMabXG37GUk=",
+        "checksum": "Q111Aq+tDFOygcfZzOg1hQbtZw1Q4=",
         "control": {
-          "checksum": "sha1-eaot0B2H9IOF054RKMabXG37GUk=",
-          "range": "bytes=700-1143"
+          "checksum": "sha1-11Aq+tDFOygcfZzOg1hQbtZw1Q4=",
+          "range": "bytes=697-1140"
         },
         "data": {
-          "checksum": "sha256-EeuQkVe5Hl+bqWfkBaMgA1Z2Fh91f1upncBbArJu9Gw=",
-          "range": "bytes=1144-17267929"
+          "checksum": "sha256-ednk20seorMQ+xEGnt8zWpxO20xrfj7zOtAmk+XcTbA=",
+          "range": "bytes=1141-17250210"
         },
         "name": "git",
         "signature": {
-          "checksum": "sha1-yMhNFUJ+emT/s9tdLDQ8zjT2+vY=",
-          "range": "bytes=0-699"
+          "checksum": "sha1-T1C3/QmQvuJGLjPH2YyOLIM5ewE=",
+          "range": "bytes=0-696"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/git-2.45.1-r0.apk",
-        "version": "2.45.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/git-2.45.2-r0.apk",
+        "version": "2.45.2-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q116m2Q5Ln3gJz05D1gRD/3AQz9+4=",
+        "checksum": "Q1KXXN9Hu7PZ0iPK7gAnYRUDcDzZs=",
         "control": {
-          "checksum": "sha1-16m2Q5Ln3gJz05D1gRD/3AQz9+4=",
-          "range": "bytes=703-1102"
+          "checksum": "sha1-KXXN9Hu7PZ0iPK7gAnYRUDcDzZs=",
+          "range": "bytes=700-1063"
         },
         "data": {
-          "checksum": "sha256-nU1+NEgt7CR9vsxeCs5Hr9tHiSAw69pxvz+m0W+N+PI=",
-          "range": "bytes=1103-11855891"
+          "checksum": "sha256-F61XBj+QV78wXrinzeVQestiQeJtCAVPWwbLWf8c98Y=",
+          "range": "bytes=1064-12733161"
         },
         "name": "git-lfs",
         "signature": {
-          "checksum": "sha1-z3BWu5hxd1KVtIrVNwIYsNsgYpc=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-U6NrIIwbHHzX/fgtB3PoNVQZOJU=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/git-lfs-3.5.1-r4.apk",
-        "version": "3.5.1-r4"
+        "url": "https://packages.wolfi.dev/os/x86_64/git-lfs-3.5.1-r6.apk",
+        "version": "3.5.1-r6"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1AtyQ8BGxIy54FTCVfU4vA3dBujA=",
+        "checksum": "Q1/xjUDpfwOCMLFmAYUyXK3hbr7M8=",
         "control": {
-          "checksum": "sha1-AtyQ8BGxIy54FTCVfU4vA3dBujA=",
-          "range": "bytes=696-1105"
+          "checksum": "sha1-/xjUDpfwOCMLFmAYUyXK3hbr7M8=",
+          "range": "bytes=703-1114"
         },
         "data": {
-          "checksum": "sha256-jm7jYqIpUa8S3qayJMbb10cks4vaQbqkkl7r95+SUvc=",
-          "range": "bytes=1106-7568791"
+          "checksum": "sha256-RvBzvJt//AAv6DeDRxBbbW2UG//3UZ38sDmhcMQoRKY=",
+          "range": "bytes=1115-7560368"
         },
         "name": "git-daemon",
         "signature": {
-          "checksum": "sha1-WouI+0ZflydIMa2FK5A7CtGW7Uo=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-dHYurOENIvRxIuBAaHNAeJGQciA=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/git-daemon-2.45.1-r0.apk",
-        "version": "2.45.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/git-daemon-2.45.2-r0.apk",
+        "version": "2.45.2-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1bxdUk5Zm+DGJ1BJRhi+4lVqQC8M=",
+        "checksum": "Q1lmZVnMVaV+BuJ4Zw8v1gIkGVcNc=",
         "control": {
-          "checksum": "sha1-bxdUk5Zm+DGJ1BJRhi+4lVqQC8M=",
-          "range": "bytes=707-1078"
+          "checksum": "sha1-lmZVnMVaV+BuJ4Zw8v1gIkGVcNc=",
+          "range": "bytes=696-1069"
         },
         "data": {
-          "checksum": "sha256-n6UB0PG6Q3zvEhvY9YG0J+5fLLQy52aoHxuc/8mNhDo=",
-          "range": "bytes=1079-211589"
+          "checksum": "sha256-qHYsorfTKRzalTN5p+JzwEZ2NYXNkxiHME9MoyMfeRI=",
+          "range": "bytes=1070-212142"
         },
         "name": "git-p4",
         "signature": {
-          "checksum": "sha1-7GOnoDsQV3oKBXD6jIlMaFHpzxQ=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-eGGtsdgoIw2il+9a5ZT/t126v0c=",
+          "range": "bytes=0-695"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/git-p4-2.45.1-r0.apk",
-        "version": "2.45.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/git-p4-2.45.2-r0.apk",
+        "version": "2.45.2-r0"
       },
       {
         "architecture": "x86_64",
@@ -1063,41 +1063,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q191zIDDWGGmlnPpIVN5G3rE+byGo=",
+        "checksum": "Q1vrOnBo92+mGIAJquCs5EcsBJ7B0=",
         "control": {
-          "checksum": "sha1-91zIDDWGGmlnPpIVN5G3rE+byGo=",
-          "range": "bytes=702-1158"
+          "checksum": "sha1-vrOnBo92+mGIAJquCs5EcsBJ7B0=",
+          "range": "bytes=703-1156"
         },
         "data": {
-          "checksum": "sha256-W6OeWteP3G5aA4Ko3o/D17L/8HTM93vIw0SvQPbReso=",
-          "range": "bytes=1159-1349570"
+          "checksum": "sha256-5niuG91x7i55ksheox0EjKMKC+Wq+voVBUyKR2klMaQ=",
+          "range": "bytes=1157-1350198"
         },
-        "name": "nginx-stable",
+        "name": "nginx-mainline",
         "signature": {
-          "checksum": "sha1-fR0bq7hY8qNjhML4kkjR0NEffMs=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-9iEcHqqJ8e81IifZU2fa3u/ytdQ=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nginx-stable-1.26.0-r0.apk",
-        "version": "1.26.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/nginx-mainline-1.27.0-r0.apk",
+        "version": "1.27.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q172cAKkkDUKFCNimN+lEf7gxZcO8=",
+        "checksum": "Q1pnWXOjkJIlvLYT8XeY7F3IVNRn8=",
         "control": {
-          "checksum": "sha1-72cAKkkDUKFCNimN+lEf7gxZcO8=",
-          "range": "bytes=698-1094"
+          "checksum": "sha1-pnWXOjkJIlvLYT8XeY7F3IVNRn8=",
+          "range": "bytes=701-1103"
         },
         "data": {
-          "checksum": "sha256-LGjTn0CCGKvgW1cBIrzzQAaWYNfdRXiRKBa6mBLnddU=",
-          "range": "bytes=1095-61313"
+          "checksum": "sha256-zC1cJXh51Hw9sebfcIVT0+NAoj3WXEhStvH3HvFI+Sc=",
+          "range": "bytes=1104-61941"
         },
-        "name": "nginx-stable-config",
+        "name": "nginx-mainline-config",
         "signature": {
-          "checksum": "sha1-PcxbsesHLvLbanvDf0hRZQEeO9c=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-9Ox08qvmuRGHEVKXDnApxEndnpo=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nginx-stable-config-1.26.0-r0.apk",
-        "version": "1.26.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/nginx-mainline-config-1.27.0-r0.apk",
+        "version": "1.27.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -1576,60 +1576,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1wjEh5PI4XEuZMLSqCUBZsNsp5t8=",
+        "checksum": "Q1KHnJp4dgXxm50FeWqVm7Lu2Rm3o=",
         "control": {
-          "checksum": "sha1-wjEh5PI4XEuZMLSqCUBZsNsp5t8=",
-          "range": "bytes=702-1143"
+          "checksum": "sha1-KHnJp4dgXxm50FeWqVm7Lu2Rm3o=",
+          "range": "bytes=696-1138"
         },
         "data": {
-          "checksum": "sha256-Vbe4KzKdSQ8oya/6+1+E9jHF+kEFJ9dk9E+zkaoBM7w=",
-          "range": "bytes=1144-192879162"
+          "checksum": "sha256-wWq5y1hEpcKhQ1QnvOKJHsnPxcD7/X7IEViso75B9bs=",
+          "range": "bytes=1139-192875683"
         },
         "name": "prometheus-2.52",
         "signature": {
-          "checksum": "sha1-m6xJcvKj0rNtml4eJe5VbyYfryo=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-3JjyUbZtACAX5ljsTN4qs1Qekqk=",
+          "range": "bytes=0-695"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/prometheus-2.52-2.52.0-r2.apk",
-        "version": "2.52.0-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/prometheus-2.52-2.52.0-r3.apk",
+        "version": "2.52.0-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1EFV1Q0eivNbJaIY0PhIkKyi/YpM=",
+        "checksum": "Q1mKnd8VT1t/VpToT3N7SPrMi9G7M=",
         "control": {
-          "checksum": "sha1-EFV1Q0eivNbJaIY0PhIkKyi/YpM=",
-          "range": "bytes=692-1063"
+          "checksum": "sha1-mKnd8VT1t/VpToT3N7SPrMi9G7M=",
+          "range": "bytes=704-1076"
         },
         "data": {
-          "checksum": "sha256-8+FNf75bgQE5erENZXCFxI50AnaHUvWSpI08emdqXvM=",
-          "range": "bytes=1064-57320379"
+          "checksum": "sha256-jQj6AJ1g/WJ9eLrczILo23fWFXkgfa9KdKtaFQoqSUc=",
+          "range": "bytes=1077-57321007"
         },
         "name": "prometheus-alertmanager",
         "signature": {
-          "checksum": "sha1-YMhX/dlqWFP0BQzWZPUviDQs/Yw=",
-          "range": "bytes=0-691"
+          "checksum": "sha1-ZOVjf8UJGM8EYWnakAYVMzPXaoE=",
+          "range": "bytes=0-703"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/prometheus-alertmanager-0.27.0-r5.apk",
-        "version": "0.27.0-r5"
+        "url": "https://packages.wolfi.dev/os/x86_64/prometheus-alertmanager-0.27.0-r6.apk",
+        "version": "0.27.0-r6"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1XIbmz6FFXwWTUG8HhvQerKRe/jw=",
+        "checksum": "Q1ZSA3uYHgOuEdsXqsjTZQOc7JGFM=",
         "control": {
-          "checksum": "sha1-XIbmz6FFXwWTUG8HhvQerKRe/jw=",
-          "range": "bytes=696-1083"
+          "checksum": "sha1-ZSA3uYHgOuEdsXqsjTZQOc7JGFM=",
+          "range": "bytes=697-1083"
         },
         "data": {
-          "checksum": "sha256-UKgbUouSkIdCQsg8PmQTkCgdqcyvoLQgXBBnqCxbIro=",
-          "range": "bytes=1084-13096991"
+          "checksum": "sha256-U6V84QUUZHttnP8E4tXIiGqLDrqo6l+b3pSK4J2U5oI=",
+          "range": "bytes=1084-13097660"
         },
         "name": "prometheus-postgres-exporter",
         "signature": {
-          "checksum": "sha1-KOTdEh5gZtZxWaonriTl0RKGtz0=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-tYMJlKBEQpyVJBRdhmv1c/+AQfQ=",
+          "range": "bytes=0-696"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/prometheus-postgres-exporter-0.15.0-r9.apk",
-        "version": "0.15.0-r9"
+        "url": "https://packages.wolfi.dev/os/x86_64/prometheus-postgres-exporter-0.15.0-r10.apk",
+        "version": "0.15.0-r10"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/sourcegraph-base.lock.json
+++ b/wolfi-images/sourcegraph-base.lock.json
@@ -204,41 +204,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q10Rr8mXMuAm4i4SjxE7xhsgs2UME=",
+        "checksum": "Q1gTZGkWP+QO3mUqLVJth8vrDEzzU=",
         "control": {
-          "checksum": "sha1-0Rr8mXMuAm4i4SjxE7xhsgs2UME=",
-          "range": "bytes=699-1079"
+          "checksum": "sha1-gTZGkWP+QO3mUqLVJth8vrDEzzU=",
+          "range": "bytes=699-1076"
         },
         "data": {
-          "checksum": "sha256-IVV0PRiJiwz4Ov1pWU1VAHf8cM0TgwqsV3vkYEQc0mM=",
-          "range": "bytes=1080-5915633"
+          "checksum": "sha256-/IFXqeKvU0GODNsz1yPIEMcFHgABT+8rbZpSlTLo4e4=",
+          "range": "bytes=1077-5915704"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-OlnuKCVUD1RpZgK+JyGdG/NQ0R0=",
+          "checksum": "sha1-l1o5ixkyWWqqJE3FOfR0QUemJUA=",
           "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r7.apk",
-        "version": "3.3.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r9.apk",
+        "version": "3.3.0-r9"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1xZQl4rSEEOs59w1q/EhMx0+ZVxw=",
+        "checksum": "Q1jhAhggAuZnU7FFHnebGA26mq+jI=",
         "control": {
-          "checksum": "sha1-xZQl4rSEEOs59w1q/EhMx0+ZVxw=",
-          "range": "bytes=697-1082"
+          "checksum": "sha1-jhAhggAuZnU7FFHnebGA26mq+jI=",
+          "range": "bytes=695-1079"
         },
         "data": {
-          "checksum": "sha256-IfGWsH9qFzzKcdVENdnoZqPbAdejcokLcfm7Z53KnPM=",
-          "range": "bytes=1083-1197082"
+          "checksum": "sha256-XTCQYnhGSm7SkGwqV/TQMFqGajVJVYhKAidKfLb2D3Y=",
+          "range": "bytes=1080-1197081"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-CypiuHQ6EuduQ5uexXhBDv5YvvY=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-qVrfDVxubkrb5Yrd2mFTv2A0G7k=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r7.apk",
-        "version": "3.3.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r9.apk",
+        "version": "3.3.0-r9"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/sourcegraph-dev.lock.json
+++ b/wolfi-images/sourcegraph-dev.lock.json
@@ -128,41 +128,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q10Rr8mXMuAm4i4SjxE7xhsgs2UME=",
+        "checksum": "Q1gTZGkWP+QO3mUqLVJth8vrDEzzU=",
         "control": {
-          "checksum": "sha1-0Rr8mXMuAm4i4SjxE7xhsgs2UME=",
-          "range": "bytes=699-1079"
+          "checksum": "sha1-gTZGkWP+QO3mUqLVJth8vrDEzzU=",
+          "range": "bytes=699-1076"
         },
         "data": {
-          "checksum": "sha256-IVV0PRiJiwz4Ov1pWU1VAHf8cM0TgwqsV3vkYEQc0mM=",
-          "range": "bytes=1080-5915633"
+          "checksum": "sha256-/IFXqeKvU0GODNsz1yPIEMcFHgABT+8rbZpSlTLo4e4=",
+          "range": "bytes=1077-5915704"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-OlnuKCVUD1RpZgK+JyGdG/NQ0R0=",
+          "checksum": "sha1-l1o5ixkyWWqqJE3FOfR0QUemJUA=",
           "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r7.apk",
-        "version": "3.3.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r9.apk",
+        "version": "3.3.0-r9"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1xZQl4rSEEOs59w1q/EhMx0+ZVxw=",
+        "checksum": "Q1jhAhggAuZnU7FFHnebGA26mq+jI=",
         "control": {
-          "checksum": "sha1-xZQl4rSEEOs59w1q/EhMx0+ZVxw=",
-          "range": "bytes=697-1082"
+          "checksum": "sha1-jhAhggAuZnU7FFHnebGA26mq+jI=",
+          "range": "bytes=695-1079"
         },
         "data": {
-          "checksum": "sha256-IfGWsH9qFzzKcdVENdnoZqPbAdejcokLcfm7Z53KnPM=",
-          "range": "bytes=1083-1197082"
+          "checksum": "sha256-XTCQYnhGSm7SkGwqV/TQMFqGajVJVYhKAidKfLb2D3Y=",
+          "range": "bytes=1080-1197081"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-CypiuHQ6EuduQ5uexXhBDv5YvvY=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-qVrfDVxubkrb5Yrd2mFTv2A0G7k=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r7.apk",
-        "version": "3.3.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r9.apk",
+        "version": "3.3.0-r9"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/sourcegraph-template.lock.json
+++ b/wolfi-images/sourcegraph-template.lock.json
@@ -204,41 +204,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q10Rr8mXMuAm4i4SjxE7xhsgs2UME=",
+        "checksum": "Q1gTZGkWP+QO3mUqLVJth8vrDEzzU=",
         "control": {
-          "checksum": "sha1-0Rr8mXMuAm4i4SjxE7xhsgs2UME=",
-          "range": "bytes=699-1079"
+          "checksum": "sha1-gTZGkWP+QO3mUqLVJth8vrDEzzU=",
+          "range": "bytes=699-1076"
         },
         "data": {
-          "checksum": "sha256-IVV0PRiJiwz4Ov1pWU1VAHf8cM0TgwqsV3vkYEQc0mM=",
-          "range": "bytes=1080-5915633"
+          "checksum": "sha256-/IFXqeKvU0GODNsz1yPIEMcFHgABT+8rbZpSlTLo4e4=",
+          "range": "bytes=1077-5915704"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-OlnuKCVUD1RpZgK+JyGdG/NQ0R0=",
+          "checksum": "sha1-l1o5ixkyWWqqJE3FOfR0QUemJUA=",
           "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r7.apk",
-        "version": "3.3.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r9.apk",
+        "version": "3.3.0-r9"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1xZQl4rSEEOs59w1q/EhMx0+ZVxw=",
+        "checksum": "Q1jhAhggAuZnU7FFHnebGA26mq+jI=",
         "control": {
-          "checksum": "sha1-xZQl4rSEEOs59w1q/EhMx0+ZVxw=",
-          "range": "bytes=697-1082"
+          "checksum": "sha1-jhAhggAuZnU7FFHnebGA26mq+jI=",
+          "range": "bytes=695-1079"
         },
         "data": {
-          "checksum": "sha256-IfGWsH9qFzzKcdVENdnoZqPbAdejcokLcfm7Z53KnPM=",
-          "range": "bytes=1083-1197082"
+          "checksum": "sha256-XTCQYnhGSm7SkGwqV/TQMFqGajVJVYhKAidKfLb2D3Y=",
+          "range": "bytes=1080-1197081"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-CypiuHQ6EuduQ5uexXhBDv5YvvY=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-qVrfDVxubkrb5Yrd2mFTv2A0G7k=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r7.apk",
-        "version": "3.3.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r9.apk",
+        "version": "3.3.0-r9"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/symbols.lock.json
+++ b/wolfi-images/symbols.lock.json
@@ -204,41 +204,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q10Rr8mXMuAm4i4SjxE7xhsgs2UME=",
+        "checksum": "Q1gTZGkWP+QO3mUqLVJth8vrDEzzU=",
         "control": {
-          "checksum": "sha1-0Rr8mXMuAm4i4SjxE7xhsgs2UME=",
-          "range": "bytes=699-1079"
+          "checksum": "sha1-gTZGkWP+QO3mUqLVJth8vrDEzzU=",
+          "range": "bytes=699-1076"
         },
         "data": {
-          "checksum": "sha256-IVV0PRiJiwz4Ov1pWU1VAHf8cM0TgwqsV3vkYEQc0mM=",
-          "range": "bytes=1080-5915633"
+          "checksum": "sha256-/IFXqeKvU0GODNsz1yPIEMcFHgABT+8rbZpSlTLo4e4=",
+          "range": "bytes=1077-5915704"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-OlnuKCVUD1RpZgK+JyGdG/NQ0R0=",
+          "checksum": "sha1-l1o5ixkyWWqqJE3FOfR0QUemJUA=",
           "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r7.apk",
-        "version": "3.3.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r9.apk",
+        "version": "3.3.0-r9"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1xZQl4rSEEOs59w1q/EhMx0+ZVxw=",
+        "checksum": "Q1jhAhggAuZnU7FFHnebGA26mq+jI=",
         "control": {
-          "checksum": "sha1-xZQl4rSEEOs59w1q/EhMx0+ZVxw=",
-          "range": "bytes=697-1082"
+          "checksum": "sha1-jhAhggAuZnU7FFHnebGA26mq+jI=",
+          "range": "bytes=695-1079"
         },
         "data": {
-          "checksum": "sha256-IfGWsH9qFzzKcdVENdnoZqPbAdejcokLcfm7Z53KnPM=",
-          "range": "bytes=1083-1197082"
+          "checksum": "sha256-XTCQYnhGSm7SkGwqV/TQMFqGajVJVYhKAidKfLb2D3Y=",
+          "range": "bytes=1080-1197081"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-CypiuHQ6EuduQ5uexXhBDv5YvvY=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-qVrfDVxubkrb5Yrd2mFTv2A0G7k=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r7.apk",
-        "version": "3.3.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r9.apk",
+        "version": "3.3.0-r9"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/syntax-highlighter.lock.json
+++ b/wolfi-images/syntax-highlighter.lock.json
@@ -204,41 +204,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q10Rr8mXMuAm4i4SjxE7xhsgs2UME=",
+        "checksum": "Q1gTZGkWP+QO3mUqLVJth8vrDEzzU=",
         "control": {
-          "checksum": "sha1-0Rr8mXMuAm4i4SjxE7xhsgs2UME=",
-          "range": "bytes=699-1079"
+          "checksum": "sha1-gTZGkWP+QO3mUqLVJth8vrDEzzU=",
+          "range": "bytes=699-1076"
         },
         "data": {
-          "checksum": "sha256-IVV0PRiJiwz4Ov1pWU1VAHf8cM0TgwqsV3vkYEQc0mM=",
-          "range": "bytes=1080-5915633"
+          "checksum": "sha256-/IFXqeKvU0GODNsz1yPIEMcFHgABT+8rbZpSlTLo4e4=",
+          "range": "bytes=1077-5915704"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-OlnuKCVUD1RpZgK+JyGdG/NQ0R0=",
+          "checksum": "sha1-l1o5ixkyWWqqJE3FOfR0QUemJUA=",
           "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r7.apk",
-        "version": "3.3.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r9.apk",
+        "version": "3.3.0-r9"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1xZQl4rSEEOs59w1q/EhMx0+ZVxw=",
+        "checksum": "Q1jhAhggAuZnU7FFHnebGA26mq+jI=",
         "control": {
-          "checksum": "sha1-xZQl4rSEEOs59w1q/EhMx0+ZVxw=",
-          "range": "bytes=697-1082"
+          "checksum": "sha1-jhAhggAuZnU7FFHnebGA26mq+jI=",
+          "range": "bytes=695-1079"
         },
         "data": {
-          "checksum": "sha256-IfGWsH9qFzzKcdVENdnoZqPbAdejcokLcfm7Z53KnPM=",
-          "range": "bytes=1083-1197082"
+          "checksum": "sha256-XTCQYnhGSm7SkGwqV/TQMFqGajVJVYhKAidKfLb2D3Y=",
+          "range": "bytes=1080-1197081"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-CypiuHQ6EuduQ5uexXhBDv5YvvY=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-qVrfDVxubkrb5Yrd2mFTv2A0G7k=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r7.apk",
-        "version": "3.3.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r9.apk",
+        "version": "3.3.0-r9"
       },
       {
         "architecture": "x86_64",


### PR DESCRIPTION
Automatically generated PR to update package lockfiles for Sourcegraph base images.

Built from Buildkite run [#277149](https://buildkite.com/sourcegraph/sourcegraph/builds/277149).
## Test Plan
- CI build verifies image functionality