### PR TITLE
fix(Cody Gateway): add model field to Google completion request

### DIFF
--- a/internal/completions/client/google/google.go
+++ b/internal/completions/client/google/google.go
@@ -150,6 +150,7 @@ func (c *googleCompletionStreamClient) makeRequest(ctx context.Context, requestP
 	}
 
 	payload := googleRequest{
+		Model:    requestParams.Model,
 		Contents: prompt,
 		GenerationConfig: googleGenerationConfig{
 			Temperature:     requestParams.Temperature,

--- a/internal/completions/client/google/types.go
+++ b/internal/completions/client/google/types.go
@@ -9,6 +9,7 @@ type googleCompletionStreamClient struct {
 }
 
 type googleRequest struct {
+	Model            string                 `json:"model"`
 	Contents         []googleContentMessage `json:"contents"`
 	GenerationConfig googleGenerationConfig `json:"generationConfig,omitempty"`
 	SafetySettings   []googleSafetySettings `json:"safetySettings,omitempty"`


### PR DESCRIPTION
Add the missing `Model` field to the `googleRequest` struct to include the model name in the request to the Cody Gateway completion API.

This change ensures that the model name is properly included in the request, which is necessary for Cody Gateway to function correctly.


## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles -->


Verified connection to Gemini API directly works:

```sh
❯ curl -X 'POST' -d '{"messages":[{"speaker":"human","text":"Who are you?"}],"maxTokensToSample":30,"temperature":0,"stopSequences":[],"timeoutMs":5000,"stream":true}' -H 'Accept: application/json' -H 'Authorization: token $LOCAL_SG_TOKEN' -H 'Content-Type: application/json' 'https://sourcegraph.test:3443/.api/completions/stream?client-name=web'
```

Response:

```
event: completion
data: {"completion":"I","stopReason":"STOP"}

event: completion
data: {"completion":"I am a large language model, trained by Google. \n\nHere are some key","stopReason":"STOP"}

event: completion
data: {"completion":"I am a large language model, trained by Google. \n\nHere are some key things to know about me:\n\n* **I'm a","stopReason":"MAX_TOKENS"}

event: done
data: {}
```

Verified connection to Cody Gateway endpoint works:

```sh
❯ curl  -H  "Authorization: Bearer $CODY_GATEWAY_TOKEN" -H  "X-Sourcegraph-Feature: chat_completions"  -d '{"model":"gemini-1.5-flash-latest","contents":[{"parts":[{"text":"You are Cody"}],"role":"user"},{"parts":[{"text":"Ok I am Cody"}],"role":"model"},{"parts":[{"text":"What is your name?"}],"role":"user"}],"max_tokens":100}' https://cody-gateway.sourcegraph.com/v1/completions/google
```

Response:

```
data: {"candidates": [{"content": {"parts": [{"text": "As"}],"role": "model"},"finishReason": "STOP","index": 0}],"usageMetadata": {"promptTokenCount": 15,"candidatesTokenCount": 1,"totalTokenCount": 16}}
data: {"candidates": [{"content": {"parts": [{"text": " a large language model, I don't have a name in the traditional sense"}],"role": "model"},"finishReason": "STOP","index": 0,"safetyRatings": [{"category": "HARM_CATEGORY_SEXUALLY_EXPLICIT","probability": "NEGLIGIBLE"},{"category": "HARM_CATEGORY_HATE_SPEECH","probability": "NEGLIGIBLE"},{"category": "HARM_CATEGORY_HARASSMENT","probability": "NEGLIGIBLE"},{"category": "HARM_CATEGORY_DANGEROUS_CONTENT","probability": "NEGLIGIBLE"}]}],"usageMetadata": {"promptTokenCount": 15,"candidatesTokenCount": 17,"totalTokenCount": 32}}

data: {"candidates": [{"content": {"parts": [{"text": ". You can call me Cody, or any other name you like!  What"}],"role": "model"},"finishReason": "STOP","index": 0,"safetyRatings": [{"category": "HARM_CATEGORY_SEXUALLY_EXPLICIT","probability": "NEGLIGIBLE"},{"category": "HARM_CATEGORY_HATE_SPEECH","probability": "NEGLIGIBLE"},{"category": "HARM_CATEGORY_HARASSMENT","probability": "NEGLIGIBLE"},{"category": "HARM_CATEGORY_DANGEROUS_CONTENT","probability": "NEGLIGIBLE"}]}],"usageMetadata": {"promptTokenCount": 15,"candidatesTokenCount": 33,"totalTokenCount": 48}}

data: {"candidates": [{"content": {"parts": [{"text": " do you prefer? \n"}],"role": "model"},"finishReason": "STOP","index": 0,"safetyRatings": [{"category": "HARM_CATEGORY_SEXUALLY_EXPLICIT","probability": "NEGLIGIBLE"},{"category": "HARM_CATEGORY_HATE_SPEECH","probability": "NEGLIGIBLE"},{"category": "HARM_CATEGORY_HARASSMENT","probability": "NEGLIGIBLE"},{"category": "HARM_CATEGORY_DANGEROUS_CONTENT","probability": "NEGLIGIBLE"}]}],"usageMetadata": {"promptTokenCount": 15,"candidatesTokenCount": 37,"totalTokenCount": 52}}
```

curl-ing the Cody Gateway endpoint returns the correct `model` name `google/gemini-model`:

```sh
curl -X 'POST' -d '{"messages":[{"speaker":"human","text":"Who are you?"}],"maxTokensToSample":30,"temperature":0,"stopSequences":[],"timeoutMs":5000,"stream":true}' -H 'Accept: application/json' -H 'Authorization: token $LOCAL_TOKEN' -H 'Content-Type: application/json' 'https://sourcegraph.test:3443/.api/completions/stream'
```

Response:

```
data: {"error":"Sourcegraph Cody Gateway: unexpected status code 400: {\"error\":\"model \\\"google/gemini-1.5-flash-latest\\\" is not allowed, allowed: []\"}\n"}
```

### Before

curl-ing the Cody Gateway endpoint returns the following error because Model is missing, that's why model only contains the provider (`google`) name:

```sh
curl -X 'POST' -d '{"messages":[{"speaker":"human","text":"Who are you?"}],"maxTokensToSample":30,"temperature":0,"stopSequences":[],"timeoutMs":5000,"stream":true,"model":"google/gemini-1.5-pro-latest"}' -H 'Accept: application/json' -H 'Authorization: token $DOT_COM_TOKEN' -H 'Content-Type: application/json' 'https://sourcegraph.com/.api/completions/stream'
```

Response:

```
"Sourcegraph Cody Gateway: unexpected status code 400: {\"error\":\"model \\\"google/\\\" is not allowed, allowed: [google/gemini-1.5-pro-latest, google/gemini-1.5-flash-latest]\"}
```

No Changelog is required for unreleased change.