### PR TITLE
feat/sg-msp-pg: add suggestion to check msp-ops page on perms error

### DIFF
--- a/dev/sg/cloudsqlproxy/cloudsqlproxy.go
+++ b/dev/sg/cloudsqlproxy/cloudsqlproxy.go
@@ -28,13 +28,13 @@ type CloudSQLProxy struct {
 	PermissionsHelpPageURL string
 }
 
-func NewCloudSQLProxy(dbConnection string, iamUserEmail string, port int, permissionsHelpPageURL string) (*CloudSQLProxy, error) {
+func NewCloudSQLProxy(dbConnection string, iamUserEmail string, port int, permissionsHelpPageURL string) *CloudSQLProxy {
 	return &CloudSQLProxy{
 		DBInstanceConnectionName:  dbConnection,
 		ImpersonateServiceAccount: iamUserEmail,
 		Port:                      port,
 		PermissionsHelpPageURL:    permissionsHelpPageURL,
-	}, nil
+	}
 }
 
 func (p *CloudSQLProxy) Start(ctx context.Context, timeoutSeconds int) error {

--- a/dev/sg/msp/helpers.go
+++ b/dev/sg/msp/helpers.go
@@ -346,3 +346,18 @@ func sortSlice[S ~[]E, E cmp.Ordered](s S) S {
 	slices.Sort(s)
 	return s
 }
+
+// maybeAddSuggestion adds suggestions to errors that are known to be related to
+// problems that can be resolved by referring to the service Notion page. If
+// the service doesn't have one, or if the error doesn't match any known patterns,
+// the error is returned as-is.
+func maybeAddSuggestion(svc spec.ServiceSpec, err error) error {
+	if svc.NotionPageID == nil {
+		return err
+	}
+	if strings.Contains(err.Error(), "PermissionDenied") {
+		return errors.Wrapf(err, "possible permissions error, ensure you have the prerequisite Entitle grants mentioned in %s",
+			svc.GetHandbookPageURL())
+	}
+	return err
+}

--- a/dev/sg/msp/sg_msp.go
+++ b/dev/sg/msp/sg_msp.go
@@ -731,7 +731,8 @@ This command supports completions on services and environments.
 								Project: env.ProjectID,
 							})
 							if err != nil {
-								return errors.Wrap(err, "find IAM output")
+								return maybeAddSuggestion(svc.Service,
+									errors.Wrap(err, "find IAM output"))
 							}
 							std.Out.WriteAlertf("Preparing a connection with write access - proceed with caution!")
 						} else {
@@ -742,7 +743,8 @@ This command supports completions on services and environments.
 								Project: env.ProjectID,
 							})
 							if err != nil {
-								return errors.Wrap(err, "find IAM output")
+								return maybeAddSuggestion(svc.Service,
+									errors.Wrap(err, "find IAM output"))
 							}
 							std.Out.WriteSuggestionf("Preparing a connection with read-only access - for write access, use the '-write-access' flag.")
 						}
@@ -752,18 +754,18 @@ This command supports completions on services and environments.
 							Project: env.ProjectID,
 						})
 						if err != nil {
-							return errors.Wrap(err, "find Cloud Run output")
+							return maybeAddSuggestion(svc.Service,
+								errors.Wrap(err, "find Cloud Run output"))
 						}
 
 						proxyPort := c.Int("port")
-						proxy, err := cloudsqlproxy.NewCloudSQLProxy(
+						proxy := cloudsqlproxy.NewCloudSQLProxy(
 							connectionName,
 							serviceAccountEmail,
 							proxyPort,
+							// errors from proxy are already annotated with
+							// suggestions where applicable
 							svc.Service.GetHandbookPageURL())
-						if err != nil {
-							return err
-						}
 
 						for _, db := range env.Resources.PostgreSQL.Databases {
 							std.Out.WriteNoticef("Use this command to connect to database %q:", db)


### PR DESCRIPTION
I think finding the right permissions confuses people pretty often when first interacting with MSP. This adds a helper for annotating errors returned from points where we might be able to help out @DaedalusG, specifically for the situation in https://sourcegraph.slack.com/archives/C05GJPTSZCZ/p1717629546727829 😉 

## Test plan

It's a little wordy but:

```
sg msp pg connect sams prod
❌ possible permissions error, ensure you have the prerequisite Entitle grants mentioned in https://sourcegraph.notion.site/3e59b9ac3d414a5f8fb5911eed1e418a: find IAM output: gcloud: failed to access secret "iam_operator_access_service_account" from "sams-prod-ywuz": rpc error: code = PermissionDenied desc = Permission 'secretmanager.versions.access' denied for resource 'projects/sams-prod-ywuz/secrets/iam_operator_access_service_account/versions/latest' (or it may not exist).
```

## Changelog

- `sg msp pg connect` will tell you about your service's generated Notion page if you run into a permissions-looking error during command setup, where there is guidance about the required Entitle requests.