### PR TITLE
fix(release): allow release tooling to rerun finalize promotion on err

### DIFF
--- a/release.yaml
+++ b/release.yaml
@@ -6,11 +6,11 @@ meta:
 
 requirements:
   # We use wget here, because curl --fail-with-body was introduced in a version ulterior to what we can have on the CI agents.
-  - name: "wget"
-    cmd: "wget --help"
-  - name: "jq"
-    cmd: "jq --help"
-  - name: "Buidkite access token"
+  - name: 'wget'
+    cmd: 'wget --help'
+  - name: 'jq'
+    cmd: 'jq --help'
+  - name: 'Buidkite access token'
     # `write_builds` permission is all that's needed here
     # You also need to ensure you add access to the Sourcegraph organization on Buildkite.
     env: BUILDKITE_ACCESS_TOKEN
@@ -254,7 +254,7 @@ promoteToPublic:
           # we need to first fetch the branch because the repo in CI is in a detached state
           git fetch origin '+refs/heads/{{git.branch}}:refs/heads/{{git.branch}}'
           git checkout {{git.branch}}
-          git tag {{version}}
+          git tag --force {{version}}
           git push origin {{git.branch}} --tags
 
           # Annotate build
@@ -262,7 +262,7 @@ promoteToPublic:
           Promoted release is **publicly available** through a git tag at [\`{{version}}\`](https://github.com/sourcegraph/sourcegraph/tree/{{version}}).
           EOF
 
-      - name: "git:release:create"
+      - name: 'git:release:create'
         cmd: |
           tag="{{tag}}"
           version="{{version}}"


### PR DESCRIPTION
<!-- 💡 To write a useful PR description, make sure that your description covers:
- WHAT this PR is changing:
    - How was it PREVIOUSLY.
    - How it will be from NOW on.
- WHY this PR is needed.
- CONTEXT, i.e. to which initiative, project or RFC it belongs.

The structure of the description doesn't matter as much as covering these points, so use
your best judgement based on your context.
Learn how to write good pull request description: https://www.notion.so/sourcegraph/Write-a-good-pull-request-description-610a7fd3e613496eb76f450db5a49b6e?pvs=4 -->

This PR will allow us to rerun failures in the last step of a release. Currently if release promotion fails during the git:tag step of finalize promotion we can't delete the tag in the remote repo and rerun the step, this suspected to be due to caching in the pipeline. 

See: https://buildkite.com/sourcegraph/sourcegraph/builds/277241#018feb0e-6800-4148-b83c-70f27b68094d

## Test plan
untested

<!-- All pull requests REQUIRE a test plan: https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles -->


## Changelog

- add force flag in git tag during finalize release promotion

<!--
1. Ensure your pull request title is formatted as: $type($domain): $what
2. Add bullet list items for each additional detail you want to cover (see example below)
3. You can edit this after the pull request was merged, as long as release shipping it hasn't been promoted to the public.
4. For more information, please see this how-to https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c?

Audience: TS/CSE > Customers > Teammates (in that order).

Cheat sheet: $type = chore|fix|feat $domain: source|search|ci|release|plg|cody|local|...
-->

<!--
Example:

Title: fix(search): parse quotes with the appropriate context
Changelog section:

## Changelog

- When a quote is used with regexp pattern type, then ...
- Refactored underlying code.
-->

