### PR TITLE
fix(gateway): double provider in telemetry

### DIFF
--- a/cmd/cody-gateway/internal/httpapi/completions/upstream.go
+++ b/cmd/cody-gateway/internal/httpapi/completions/upstream.go
@@ -252,7 +252,7 @@ func makeUpstreamHandler[ReqT UpstreamRequest](
 						Identifier: act.ID,
 						Metadata: events.MergeMaps(requestMetadata, map[string]any{
 							codygateway.CompletionsEventFeatureMetadataField: feature,
-							"model":    fmt.Sprintf("%s/%s", upstreamName, body.GetModel()),
+							"model":    fmt.Sprintf("%s/%s", "", body.GetModel()),
 							"provider": upstreamName,
 
 							// Request metadata


### PR DESCRIPTION
On march 7, and we see "anthropic/anthropic" happen on "request blocked" events. This PR fixes that double provider logging error.

![Screenshot 2024-06-06 at 1 47 08 AM](https://github.com/sourcegraph/sourcegraph/assets/3654603/361ad568-3f12-4dd7-a100-4af701eeba91)


## Test plan

check telemetry


## Changelog

<!--
1. Ensure your pull request title is formatted as: $type($domain): $what
2. Add bullet list items for each additional detail you want to cover (see example below)
3. You can edit this after the pull request was merged, as long as release shipping it hasn't been promoted to the public.
4. For more information, please see this how-to https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c?

Audience: TS/CSE > Customers > Teammates (in that order).

Cheat sheet: $type = chore|fix|feat $domain: source|search|ci|release|plg|cody|local|...
-->

<!--
Example:

Title: fix(search): parse quotes with the appropriate context
Changelog section:

## Changelog

- When a quote is used with regexp pattern type, then ...
- Refactored underlying code.
-->
