### PR TITLE
fix(release): remove generate-notes from github release creation

### DIFF
--- a/release.yaml
+++ b/release.yaml
@@ -290,7 +290,7 @@ promoteToPublic:
             - [Release post](https://sourcegraph.com/blog/release/${month_name}-${current_year})
           EndOfText
 
-          bazel run //dev/tools:gh -- release create ${version} --latest --verify-tag -t "Sourcegraph ${tag}" --generate-notes --notes "${releasepost}"
+          bazel run //dev/tools:gh -- release create ${version} --latest --verify-tag -t "Sourcegraph ${tag}" --notes "${releasepost}"
 
       # tag is usually in the format `5.3.2`
       # while version is usually the tag prepended with a v, `v5.3.2`

--- a/release.yaml
+++ b/release.yaml
@@ -255,7 +255,8 @@ promoteToPublic:
           git fetch origin '+refs/heads/{{git.branch}}:refs/heads/{{git.branch}}'
           git checkout {{git.branch}}
           git tag --force {{version}}
-          git push origin {{git.branch}} --tags
+          # only push a single tag
+          git push origin tag {{version}}
 
           # Annotate build
           cat << EOF | buildkite-agent annotate --style info
@@ -339,7 +340,7 @@ promoteToPublic:
           chmod +x changelog
 
           pr_url=$(./changelog \
-            --github.token="$DEVX_GH_TOKEN" \
+            --github.token="$DEVX_SERVICE_GH_TOKEN" \
             update-as-pr \
             --github.repo="sourcegraph/sourcegraph" \
             --output.repo="sourcegraph/docs" \


### PR DESCRIPTION
Generate notes currently generates a changelog all the way from the tag `app-2023` ... which means the content is more than what is allowed by github - hard cap of 125000 characters.


## Test plan
CI

## Changelog
- remove `generate-notes` cli flag when promoting releases
- push only a single tag
- fix token name used in changelog generation