### PR TITLE
fix(search): Properly handle URLs with file paths that contain route segments

### DIFF
--- a/client/web-sveltekit/src/hooks.test.ts
+++ b/client/web-sveltekit/src/hooks.test.ts
@@ -1,0 +1,15 @@
+import { expect, test, describe } from 'vitest'
+
+import { getStaticSuffix_TEST_ONLY as getStaticSuffix } from '$root/client/web-sveltekit/src/hooks'
+
+describe('getStaticSuffix', () => {
+    test.each([
+        ['s1/s2', 's1/s2'],
+        ['s1/(group)/s2', 's1/s2'],
+        ['s1/[parameter]/s2', 's2'],
+        ['s1/[...rest]/s2', 's2'],
+        ['s1/[[optional]]/s2', 's2'],
+    ])('%s -> %s', (input, expected) => {
+        expect(getStaticSuffix(input.split('/')).join('/')).toBe(expected)
+    })
+})

--- a/client/web-sveltekit/src/hooks.ts
+++ b/client/web-sveltekit/src/hooks.ts
@@ -1,0 +1,103 @@
+import type { Reroute } from '@sveltejs/kit'
+
+import { type SvelteKitRoute, svelteKitRoutes } from '$lib/routes'
+
+export const reroute: Reroute = ({ url }) => {
+    return rerouteWithEncodedFilePath(url)
+}
+
+/**
+ * For SvelteKit to process repo URLs with file paths properly we have to encode the file path portion of the URL pathname.
+ *
+ * Because SvelteKit uses eager quantifiers in its route regular expressions, and because some repo routes contain two
+ * rest parameters to match the repository and the filepath, a path such as
+ * ```
+ * /repo-name/-/blob/path/-/blob/file
+ * ```
+ * would be interpreted as
+ * ```
+ * /repo-name/-/blob/path/-/blob/file
+ *  ^^^^^^^^^^^^^^^^^^^^^        ^^^^
+ *       repo               path
+ * ```
+ * instead of the desired
+ * ```
+ * /repo-name/-/blob/path/-/blob/file
+ *  ^^^^^^^^^        ^^^^^^^^^^^^^^^^
+ *    repo                path
+ * ```
+ * By URL-encoding the file path portion of the URL pathname we avoid this behavior.
+ * @param url The URL to navigate to
+ */
+function rerouteWithEncodedFilePath(url: URL): string | void {
+    for (const route of ROUTES_WITH_FILEPATH) {
+        if (route.pattern.test(url.pathname)) {
+            return route.encodeFilePath(url)
+        }
+    }
+}
+
+interface EnhancedSvelteKitRoute extends SvelteKitRoute {
+    /**
+     * Encodes the part of the URL pathname that represents a file path.
+     * @param url
+     */
+    encodeFilePath(url: URL): string
+}
+
+/**
+ * A list of routes for which the file path portion of the URL path name should be encoded.
+ */
+const ROUTES_WITH_FILEPATH: EnhancedSvelteKitRoute[] = (function () {
+    const filePathParameter = '[...path]'
+    const filePathSegment = `/${filePathParameter}`
+    const routesWithFilepath: EnhancedSvelteKitRoute[] = []
+
+    for (const route of svelteKitRoutes) {
+        // To keep the logic simple we currently only do this for routes that have the file path parameter at
+        // the end.
+        if (route.id.endsWith(filePathSegment)) {
+            const suffix = getStaticSuffix(route.id.split('/').slice(0, -1))
+            const separator = suffix.length > 0 ? `/${suffix.join('/')}/` : '/'
+            routesWithFilepath.push({
+                ...route,
+                encodeFilePath(url) {
+                    const start = url.pathname.indexOf(separator)
+                    if (start < 0) {
+                        return url.pathname
+                    }
+                    const end = start + separator.length
+                    return url.pathname.slice(0, end) + encodeURIComponent(url.pathname.slice(end))
+                },
+            })
+        }
+    }
+
+    return routesWithFilepath
+})()
+
+/**
+ * Returns all "static" route segments following from the last optional parameter till the end. Ignores groups since
+ * they are not part of URL.s
+ * Example:
+ *     Input: ['s1', '[...rest]', 's2', '(group)', 's3', 's4']
+ *     Output: ['s2', 's3', 's4']
+ * @param routeSegments The route to compute the static prefix for
+ */
+function getStaticSuffix(routeSegments: string[]): string[] {
+    const staticSegments: string[] = []
+
+    for (let i = routeSegments.length - 1; i > -1; i--) {
+        const segment = routeSegments[i]
+        if (segment[0] === '(') {
+            continue
+        }
+        if (segment[0] === '[') {
+            break
+        }
+        staticSegments.unshift(segment)
+    }
+    return staticSegments
+}
+
+export const getStaticSuffix_TEST_ONLY = getStaticSuffix

--- a/client/web-sveltekit/src/hooks.ts
+++ b/client/web-sveltekit/src/hooks.ts
@@ -37,7 +37,7 @@ function rerouteWithEncodedFilePath(url: URL): string | void {
     }
 }
 
-interface EnhancedSvelteKitRoute extends SvelteKitRoute {
+interface SvelteKitRouteWithPathEncoder extends SvelteKitRoute {
     /**
      * Encodes the part of the URL pathname that represents a file path.
      * @param url
@@ -48,10 +48,10 @@ interface EnhancedSvelteKitRoute extends SvelteKitRoute {
 /**
  * A list of routes for which the file path portion of the URL path name should be encoded.
  */
-const ROUTES_WITH_FILEPATH: EnhancedSvelteKitRoute[] = (function () {
+const ROUTES_WITH_FILEPATH: SvelteKitRouteWithPathEncoder[] = (function () {
     const filePathParameter = '[...path]'
     const filePathSegment = `/${filePathParameter}`
-    const routesWithFilepath: EnhancedSvelteKitRoute[] = []
+    const routesWithFilepath: SvelteKitRouteWithPathEncoder[] = []
 
     for (const route of svelteKitRoutes) {
         // To keep the logic simple we currently only do this for routes that have the file path parameter at

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/+layout.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/+layout.svelte
@@ -247,7 +247,7 @@
                                 {repoName}
                                 {revision}
                                 treeProvider={$fileTreeStore}
-                                selectedPath={$page.params.path ?? ''}
+                                selectedPath={data.filePath ?? ''}
                             />
                         {/if}
                     {:else}
@@ -282,7 +282,7 @@
                 <div class="bottom-panel">
                     <Tabs selected={selectedTab} toggable on:select={selectTab}>
                         <TabPanel title="History" shortcut={historyHotkey}>
-                            {#key $page.params.path}
+                            {#key data.filePath}
                                 <HistoryPanel
                                     bind:this={historyPanel}
                                     history={commitHistory}

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/+layout.ts
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/+layout.ts
@@ -24,7 +24,8 @@ const REFERENCES_PER_PAGE = 20
 export const load: LayoutLoad = async ({ parent, params }) => {
     const client = getGraphQLClient()
     const { repoName, revision = '' } = parseRepoRevision(params.repo)
-    const parentPath = params.path ? dirname(params.path) : ROOT_PATH
+    const filePath = params.path ? decodeURIComponent(params.path) : ''
+    const parentPath = filePath ? dirname(filePath) : ROOT_PATH
     const resolvedRevision = resolveRevision(parent, revision)
 
     // Prefetch the sidebar file tree for the parent path.
@@ -42,11 +43,12 @@ export const load: LayoutLoad = async ({ parent, params }) => {
 
     return {
         fileTree,
+        filePath,
         parentPath,
         lastCommit: client.query(LastCommitQuery, {
             repoName,
             revspec: revision,
-            filePath: params.path ?? '',
+            filePath,
         }),
         // Fetches the most recent commits for current blob, tree or repo root
         commitHistory: infinityQuery({
@@ -56,7 +58,7 @@ export const load: LayoutLoad = async ({ parent, params }) => {
                 resolvedRevision.then(revspec => ({
                     repoName,
                     revspec,
-                    filePath: params.path ?? '',
+                    filePath,
                     first: HISTORY_COMMITS_PER_PAGE,
                     afterCursor: null as string | null,
                 }))
@@ -103,7 +105,7 @@ export const load: LayoutLoad = async ({ parent, params }) => {
                     resolvedRevision.then(revspec => ({
                         repoName,
                         revspec,
-                        filePath: params.path ?? '',
+                        filePath,
                         first: REFERENCES_PER_PAGE,
                         // Line and character are 1-indexed, but the API expects 0-indexed
                         line: lineOrPosition.line - 1,

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/tree/[...path]/+page.ts
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/tree/[...path]/+page.ts
@@ -11,27 +11,28 @@ export const load: PageLoad = ({ parent, params }) => {
     const client = getGraphQLClient()
     const { repoName, revision = '' } = parseRepoRevision(params.repo)
     const resolvedRevision = resolveRevision(parent, revision)
+    const filePath = decodeURIComponent(params.path)
 
     const treeEntries = resolvedRevision
         .then(resolvedRevision =>
             fetchTreeEntries({
                 repoName,
                 revision: resolvedRevision,
-                filePath: params.path,
+                filePath,
                 first: null,
             })
         )
         .then(commit => commit.tree)
 
     return {
-        filePath: params.path,
+        filePath,
         treeEntries,
         treeEntriesWithCommitInfo: resolvedRevision
             .then(resolvedRevision =>
                 client.query(TreePageCommitInfoQuery, {
                     repoName,
                     revision: resolvedRevision,
-                    filePath: params.path,
+                    filePath,
                     first: null,
                 })
             )

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/-/commits/[...path]/+page.ts
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/-/commits/[...path]/+page.ts
@@ -12,7 +12,7 @@ const PAGE_SIZE = 20
 export const load: PageLoad = ({ parent, params }) => {
     const client = getGraphQLClient()
     const { repoName, revision = '' } = parseRepoRevision(params.repo)
-    const path = params.path ?? ''
+    const path = params.path ? decodeURIComponent(params.path) : ''
     const resolvedRevision = resolveRevision(parent, revision)
 
     const commitsQuery = infinityQuery({

--- a/client/web-sveltekit/src/routes/layout.spec.ts
+++ b/client/web-sveltekit/src/routes/layout.spec.ts
@@ -62,3 +62,22 @@ test('has global notifications', async ({ sg, page }) => {
     await expect(alerts.first()).toBeVisible()
     await expect(alerts).toHaveCount(4)
 })
+
+// Because of how SvelteKit routing works, having a URL with a file path that includes route segements is
+// problematic. We solve this problem by automatically encoding file paths in the URL. This test ensures
+// that this behavior works as expected.
+test('automatic file path encoding', async ({ sg, page }) => {
+    sg.mockOperations({
+        ResolveRepoRevision(variables) {
+            return {
+                repositoryRedirect: {
+                    id: '1',
+                },
+            }
+        },
+    })
+    await page.goto('/sourcegraph/sourcegraph/-/blob/app/src/routes/-/blob/page.ts')
+    // If this didn't work we would render a 'Error: Not found' page
+    await expect(page.getByRole('heading', { name: 'sourcegraph/sourcegraph' })).toBeVisible()
+    await expect(page.getByRole('heading', { name: 'Error' })).not.toBeVisible()
+})


### PR DESCRIPTION
Fixes SRCH-484. See that issue for more information about the problem.

Instead of hardcoding the routes that can contain file paths, I'm using the generated list of routes in `routes.ts` and extract any route that ends with a `[...path]` segment (which, so far at least, is used as the file path parameter).

This list is then used to hook into the routing process and encode the file path when any of the routes match. As mentioned in the `reroute` documentation, this does not affect the URL displayed in the browser. Because the file path is now URL encoded we need to decode it before we can process it further (I grepped for all occurrences of `params.path`). 

E.g. for https://sourcegraph.sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/+page.svelte

| Before | After |
|--------|--------|
| ![2024-06-06_14-07](https://github.com/sourcegraph/sourcegraph/assets/179026/5ab38533-36f5-45ab-ac00-add6570285af) | ![2024-06-06_14-08](https://github.com/sourcegraph/sourcegraph/assets/179026/ce0a9770-a701-4641-82bb-111293e2ad4a) | 

## Test plan

Manual testing, integration test.
