### PR TITLE
chore(tooling): bump Go version to 1.22.4

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,4 @@
-golang 1.22.1
+golang 1.22.4
 nodejs 20.8.1
 fd 8.6.0
 shfmt 3.5.0

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -334,7 +334,7 @@ go_rules_dependencies()
 
 go_register_toolchains(
     nogo = "@//:sg_nogo",
-    version = "1.22.1",
+    version = "1.22.4",
 )
 
 linter_dependencies()

--- a/dev/ci/images/go.mod
+++ b/dev/ci/images/go.mod
@@ -1,3 +1,3 @@
 module github.com/sourcegraph/sourcegraph/dev/ci/images
 
-go 1.22.1
+go 1.22.4

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sourcegraph/sourcegraph
 
-go 1.22.1
+go 1.22.4
 
 // Permanent replace directives
 // ============================

--- a/internal/cmd/progress-bot/go.mod
+++ b/internal/cmd/progress-bot/go.mod
@@ -2,7 +2,7 @@ module progress-bot
 
 go 1.21
 
-toolchain go1.22.1
+toolchain go1.22.4
 
 require (
 	cloud.google.com/go/storage v1.40.0

--- a/lib/go.mod
+++ b/lib/go.mod
@@ -2,7 +2,7 @@ module github.com/sourcegraph/sourcegraph/lib
 
 go 1.22
 
-toolchain go1.22.1
+toolchain go1.22.4
 
 require (
 	connectrpc.com/connect v1.16.1


### PR DESCRIPTION
Bump for @evict 

## Test plan

CI passes with no complaints

## Changelog

- Bumped version of Go used to build to 1.22.4
