### PR TITLE
sg: deny cloud ephemeral builds from main

### DIFF
--- a/dev/sg/internal/cloud/deploy_command.go
+++ b/dev/sg/internal/cloud/deploy_command.go
@@ -214,12 +214,16 @@ func deployCloudEphemeral(ctx *cli.Context) error {
 	if version == "" {
 		b, err := triggerEphemeralBuild(ctx.Context, currRepo)
 		if err != nil {
-			if err == ErrBranchOutOfSync {
+			if errors.Is(err, ErrBranchOutOfSync) {
 				std.Out.WriteWarningf(`Your branch %q is out of sync with remote.
 
 Please make sure you have either pushed or pulled the latest changes before trying again`, currRepo.Branch)
-			} else {
-				std.Out.WriteFailuref("Cannot start deployment as there was problem with the ephemeral build")
+			} else if errors.Is(err, ErrMainBranchBuild) {
+				std.Out.WriteWarningf(`Triggering Cloud Ephemeral builds from "main" is not supported.`)
+				steps := "1. create a new branch off main by running `git switch <branch-name>`\n"
+				steps += "2. push the branch to the remote by running `git push -u origin <branch-name>`\n"
+				steps += "3. trigger the build by running `sg cloud ephemeral build`\n"
+				std.Out.WriteMarkdown(fmt.Sprintf("Alternatively, if you still want to deploy \"main\" you can do:\n%s", steps))
 			}
 			return errors.Wrapf(err, "cloud ephemeral deployment failure")
 		}

--- a/dev/sg/internal/cloud/deploy_command.go
+++ b/dev/sg/internal/cloud/deploy_command.go
@@ -21,6 +21,7 @@ import (
 )
 
 var ErrDeploymentExists error = errors.New("deployment already exists")
+var ErrMainBranchBuild error = errors.New("cannot trigger a Cloud Ephemeral build for main branch")
 
 var deployEphemeralCommand = cli.Command{
 	Name:        "deploy",
@@ -130,6 +131,9 @@ func createDeploymentForVersion(ctx context.Context, email, name, version string
 }
 
 func triggerEphemeralBuild(ctx context.Context, currRepo *repo.GitRepo) (*buildkite.Build, error) {
+	if currRepo.Branch == "main" {
+		return nil, ErrMainBranchBuild
+	}
 	pending := std.Out.Pending(output.Linef("🔨", output.StylePending, "Checking if branch %q is up to date with remote branch", currRepo.Branch))
 	if isOutOfSync, err := currRepo.IsOutOfSync(ctx); err != nil {
 		pending.Complete(output.Linef(output.EmojiFailure, output.StyleFailure, "failed to check if branch is out of sync with remote branch"))


### PR DESCRIPTION
Triggering cloud ephemeral builds on main is problematic since there are a bunch of specific conditions that get triggered because the branch is `main`


## Test plan
Tested locally
`sg cloud eph build`
```
./sg cloud eph build
⚠️ Triggering Cloud Ephemeral builds from "main" is not supported.

  Alternatively, if you still want to deploy "main" you can do:

  1. create a new branch off main by running  git switch <branch-name>
  2. push the branch to the remote by running  git push -u origin <branch-name>
  3. trigger the build by running  sg cloud ephemeral build


❌ failed to trigger epehemeral build for branch: cannot trigger a Cloud Ephemeral build for main branch
```
`./sg cloud eph deploy`
```
⚠️ Triggering Cloud Ephemeral builds from "main" is not supported.

  Alternatively, if you still want to deploy "main" you can do:

  1. create a new branch off main by running  git switch <branch-name>
  2. push the branch to the remote by running  git push -u origin <branch-name>
  3. trigger the build by running  sg cloud ephemeral build


❌ cloud ephemeral deployment failure: cannot trigger a Cloud Ephemeral build for main branch

```

## Changelog
- deny cloud ephemeral deployments triggered from 'main'