### PR TITLE
fix(SCIM): don't allow SCIM users to change fields

### DIFF
--- a/cmd/frontend/graphqlbackend/user_test.go
+++ b/cmd/frontend/graphqlbackend/user_test.go
@@ -504,7 +504,7 @@ func TestUpdateUser(t *testing.T) {
 			SCIMControlled: true,
 			Username:       "alice",
 			DisplayName:    "alice-updated",
-			AvatarURL:      "http://www.example.com/alice-updated",
+			AvatarURL:      "http://www.example.com/alice.png",
 		}
 		users := dbmocks.NewMockUserStore()
 		users.GetByIDFunc.SetDefaultReturn(mockUser, nil)
@@ -520,7 +520,7 @@ func TestUpdateUser(t *testing.T) {
 			mutation {
 				updateUser(
 					user: "VXNlcjox",
-					displayName: "alice-updated"
+					displayName: "alice-changed"
 				) {
 					displayName,
 				}


### PR DESCRIPTION
Previously it was possible to use the `updateUser` mutation to change user fields for SCIM managed users. We now reject these changes if the user is SCIM managed.

<!-- 💡 To write a useful PR description, make sure that your description covers:
- WHAT this PR is changing:
    - How was it PREVIOUSLY.
    - How it will be from NOW on.
- WHY this PR is needed.
- CONTEXT, i.e. to which initiative, project or RFC it belongs.

The structure of the description doesn't matter as much as covering these points, so use
your best judgement based on your context.
Learn how to write good pull request description: https://www.notion.so/sourcegraph/Write-a-good-pull-request-description-610a7fd3e613496eb76f450db5a49b6e?pvs=4 -->


## Test plan
CI tests
<!-- All pull requests REQUIRE a test plan: https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles -->

<!--
1. Ensure your pull request title is formatted as: $type($domain): $what
2. Add bullet list items for each additional detail you want to cover (see example below)
3. You can edit this after the pull request was merged, as long as release shipping it hasn't been promoted to the public.
4. For more information, please see this how-to https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c?

Audience: TS/CSE > Customers > Teammates (in that order).

Cheat sheet: $type = chore|fix|feat $domain: source|search|ci|release|plg|cody|local|...
-->

<!--
Example:

Title: fix(search): parse quotes with the appropriate context
Changelog section:

## Changelog

- When a quote is used with regexp pattern type, then ...
- Refactored underlying code.
-->
