### PR TITLE
scim: Fix user updates when SCIM was previously enabled

### DIFF
--- a/internal/database/migration/shared/data/stitched-migration-graph.json
+++ b/internal/database/migration/shared/data/stitched-migration-graph.json
@@ -11221,6 +11221,19 @@
 				],
 				"IsCreateIndexConcurrently": false,
 				"IndexMetadata": null
+			},
+			{
+				"ID": 1717699555,
+				"Name": "Fix unique index for SCIM external account connection",
+				"UpQuery": "DROP INDEX IF EXISTS user_external_accounts_user_id_scim_service_type;\n\nCREATE UNIQUE INDEX\n    user_external_accounts_user_id_scim_service_type\nON\n    user_external_accounts (user_id, service_type)\nWHERE\n    service_type = 'scim'::text\n    AND deleted_at IS NULL;",
+				"DownQuery": "DROP INDEX IF EXISTS user_external_accounts_user_id_scim_service_type;\n\nCREATE UNIQUE INDEX\n    user_external_accounts_user_id_scim_service_type\nON\n    user_external_accounts (user_id, service_type)\nWHERE\n    service_type = 'scim'::text;",
+				"Privileged": false,
+				"NonIdempotent": false,
+				"Parents": [
+					1713958707
+				],
+				"IsCreateIndexConcurrently": false,
+				"IndexMetadata": null
 			}
 		],
 		"BoundsByRev": {
@@ -11481,7 +11494,7 @@
 			"v5.4.0": {
 				"RootID": 1648051770,
 				"LeafIDs": [
-					1713958707
+					1717699555
 				],
 				"PreCreation": false
 			}

--- a/internal/database/schema.json
+++ b/internal/database/schema.json
@@ -27638,7 +27638,7 @@
           "IsUnique": true,
           "IsExclusion": false,
           "IsDeferrable": false,
-          "IndexDefinition": "CREATE UNIQUE INDEX user_external_accounts_user_id_scim_service_type ON user_external_accounts USING btree (user_id, service_type) WHERE service_type = 'scim'::text",
+          "IndexDefinition": "CREATE UNIQUE INDEX user_external_accounts_user_id_scim_service_type ON user_external_accounts USING btree (user_id, service_type) WHERE service_type = 'scim'::text AND deleted_at IS NULL",
           "ConstraintType": "",
           "ConstraintDefinition": ""
         },

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -4215,7 +4215,7 @@ Foreign-key constraints:
 Indexes:
     "user_external_accounts_pkey" PRIMARY KEY, btree (id)
     "user_external_accounts_account" UNIQUE, btree (service_type, service_id, client_id, account_id) WHERE deleted_at IS NULL
-    "user_external_accounts_user_id_scim_service_type" UNIQUE, btree (user_id, service_type) WHERE service_type = 'scim'::text
+    "user_external_accounts_user_id_scim_service_type" UNIQUE, btree (user_id, service_type) WHERE service_type = 'scim'::text AND deleted_at IS NULL
     "user_external_accounts_user_id" btree (user_id) WHERE deleted_at IS NULL
 Foreign-key constraints:
     "user_external_accounts_user_id_fkey" FOREIGN KEY (user_id) REFERENCES users(id)

--- a/internal/users/stats.go
+++ b/internal/users/stats.go
@@ -152,7 +152,7 @@ var (
 			stats.user_last_active_at AS last_active_at,
 			users.deleted_at,
 			users.site_admin,
-            (SELECT COUNT(user_id) FROM user_external_accounts WHERE user_id=users.id AND service_type = 'scim') >= 1 AS scim_controlled,
+            (SELECT COUNT(user_id) FROM user_external_accounts WHERE user_id = users.id AND service_type = 'scim' AND deleted_at IS NULL) >= 1 AS scim_controlled,
 			COALESCE(stats.user_events_count, 0) AS events_count
 		FROM users
 			LEFT JOIN aggregated_user_statistics stats ON stats.user_id = users.id

--- a/migrations/frontend/1717699555_fix_unique_index_for_scim_external_account_connection/down.sql
+++ b/migrations/frontend/1717699555_fix_unique_index_for_scim_external_account_connection/down.sql
@@ -1,0 +1,8 @@
+DROP INDEX IF EXISTS user_external_accounts_user_id_scim_service_type;
+
+CREATE UNIQUE INDEX
+    user_external_accounts_user_id_scim_service_type
+ON
+    user_external_accounts (user_id, service_type)
+WHERE
+    service_type = 'scim'::text;

--- a/migrations/frontend/1717699555_fix_unique_index_for_scim_external_account_connection/metadata.yaml
+++ b/migrations/frontend/1717699555_fix_unique_index_for_scim_external_account_connection/metadata.yaml
@@ -1,0 +1,2 @@
+name: Fix unique index for SCIM external account connection
+parents: [1713958707]

--- a/migrations/frontend/1717699555_fix_unique_index_for_scim_external_account_connection/up.sql
+++ b/migrations/frontend/1717699555_fix_unique_index_for_scim_external_account_connection/up.sql
@@ -1,0 +1,9 @@
+DROP INDEX IF EXISTS user_external_accounts_user_id_scim_service_type;
+
+CREATE UNIQUE INDEX
+    user_external_accounts_user_id_scim_service_type
+ON
+    user_external_accounts (user_id, service_type)
+WHERE
+    service_type = 'scim'::text
+    AND deleted_at IS NULL;

--- a/migrations/frontend/squashed.sql
+++ b/migrations/frontend/squashed.sql
@@ -6377,7 +6377,7 @@ CREATE UNIQUE INDEX user_external_accounts_account ON user_external_accounts USI
 
 CREATE INDEX user_external_accounts_user_id ON user_external_accounts USING btree (user_id) WHERE (deleted_at IS NULL);
 
-CREATE UNIQUE INDEX user_external_accounts_user_id_scim_service_type ON user_external_accounts USING btree (user_id, service_type) WHERE (service_type = 'scim'::text);
+CREATE UNIQUE INDEX user_external_accounts_user_id_scim_service_type ON user_external_accounts USING btree (user_id, service_type) WHERE ((service_type = 'scim'::text) AND (deleted_at IS NULL));
 
 CREATE UNIQUE INDEX user_repo_permissions_perms_unique_idx ON user_repo_permissions USING btree (user_id, user_external_account_id, repo_id);
 


### PR DESCRIPTION
When the user external account entry for SCIM has been deleted in the past, updating the user again fails as the deleted record is found and then the insertion fails.

This PR fixes that by adjusting the unique index to only consider non-soft-deleted external accounts.

Closes SRC-383

Test plan:

Added a test suite for the DB method - it was untested before :(