### PR TITLE
fix(highlighting): Update JSX/TSX highlighting to more properly label tag  delimiters

### DIFF
--- a/client/wildcard/src/global-styles/highlight.scss
+++ b/client/wildcard/src/global-styles/highlight.scss
@@ -592,7 +592,7 @@
     .hl-typed-Tag {
         color: var(--hl-green);
     }
-    .hl-typed-TagDelimited {
+    .hl-typed-TagDelimiter {
         color: var(--hl-gray-0); // same as .hl-typed-PunctuationBracket
     }
 }
@@ -1013,7 +1013,7 @@
     .hl-typed-Tag {
         color: var(--hl-green-2);
     }
-    .hl-typed-TagDelimited {
+    .hl-typed-TagDelimiter {
         color: var(--hl-gray-2); // same as .hl-typed-PunctuationBracket
     }
 }

--- a/docker-images/syntax-highlighter/crates/syntax-analysis/queries/javascript/highlights-jsx.scm
+++ b/docker-images/syntax-highlighter/crates/syntax-analysis/queries/javascript/highlights-jsx.scm
@@ -1,7 +1,20 @@
 ;; This file inherits from javascript/highlights.scm
 ;; This file should be kept in sync with tsx/highlights.scm
 (jsx_opening_element
-  name: (identifier) @tag)
+  "<" @tag.delimiter
+  name: (identifier) @tag
+  ">" @tag.delimiter)
+
+; We need to match the tag characters individually since the version of the grammar we are using (v0.20.0) defines them that way
+; when we update to the newsest we can remove this
 (jsx_closing_element
-  name: (identifier) @tag)
+  ["<" "/"] @tag.delimiter
+  name: (identifier) @tag
+  ">" @tag.delimiter)
+
+(jsx_self_closing_element
+  "<" @tag.delimiter
+  name: (identifier) @tag
+  ["/" ">"] @tag.delimiter)
+
 (jsx_attribute (property_identifier) @tag.attribute)

--- a/docker-images/syntax-highlighter/crates/syntax-analysis/queries/javascript/highlights-jsx.scm
+++ b/docker-images/syntax-highlighter/crates/syntax-analysis/queries/javascript/highlights-jsx.scm
@@ -6,7 +6,7 @@
   ">" @tag.delimiter)
 
 ; We need to match the tag characters individually since the version of the grammar we are using (v0.20.0) defines them that way
-; when we update to the newsest we can remove this
+; when we update to the newest version we can remove this
 (jsx_closing_element
   ["<" "/"] @tag.delimiter
   name: (identifier) @tag

--- a/docker-images/syntax-highlighter/crates/syntax-analysis/queries/tsx/highlights.scm
+++ b/docker-images/syntax-highlighter/crates/syntax-analysis/queries/tsx/highlights.scm
@@ -1,7 +1,20 @@
-;; This file inherits from typescript/highlights.scm
+ ;; This file inherits from typescript/highlights.scm
 ;; This file should be kept in sync with javascript/highlights-jsx.scm
 (jsx_opening_element
-  name: (identifier) @tag)
+  "<" @tag.delimiter
+  name: (identifier) @tag
+  ">" @tag.delimiter)
+
+; We need to match the tag characters individually since the version of the grammar we are using (v0.20.2) defines them that way
+; when we update to the newest version we can remove this
 (jsx_closing_element
-  name: (identifier) @tag)
+  ["<" "/"] @tag.delimiter
+  name: (identifier) @tag
+  ">" @tag.delimiter)
+
+(jsx_self_closing_element
+  "<" @tag.delimiter
+  name: (identifier) @tag
+  ["/" ">"] @tag.delimiter)
+
 (jsx_attribute (property_identifier) @tag.attribute)

--- a/docker-images/syntax-highlighter/crates/syntax-analysis/src/highlighting/snapshots/files/react.jsx
+++ b/docker-images/syntax-highlighter/crates/syntax-analysis/src/highlighting/snapshots/files/react.jsx
@@ -2,6 +2,7 @@ const ComponentJsx = () => {
     let name = 'id'
     return (
         <div>
+            <p />
             <h1 id={name}>My Component</h1>
             {[1, 2, 3].map(item => (
                 <p key={item}>{item}</p>

--- a/docker-images/syntax-highlighter/crates/syntax-analysis/src/highlighting/snapshots/files/react.tsx
+++ b/docker-images/syntax-highlighter/crates/syntax-analysis/src/highlighting/snapshots/files/react.tsx
@@ -2,6 +2,7 @@ const Component: React.FunctionComponent<{}> = () => {
     let name = 'id'
     return (
         <div>
+            <p />
             <h1 id={name}>My Component</h1>
             {[1, 2, 3].map(item => (
                 <p key={item}>{item}</p>

--- a/docker-images/syntax-highlighter/crates/syntax-analysis/src/highlighting/snapshots/syntax_analysis__highlighting__tree_sitter__test__react.jsx.snap
+++ b/docker-images/syntax-highlighter/crates/syntax-analysis/src/highlighting/snapshots/syntax_analysis__highlighting__tree_sitter__test__react.jsx.snap
@@ -14,12 +14,24 @@ expression: "snapshot_treesitter_syntax_kinds(&document, &contents)"
       return (
 //    ^^^^^^ Keyword
           <div>
+//        ^ TagDelimiter
 //         ^^^ Tag
+//            ^ TagDelimiter
+              <p />
+//            ^ TagDelimiter
+//             ^ Tag
+//               ^ TagDelimiter
+//                ^ TagDelimiter
               <h1 id={name}>My Component</h1>
+//            ^ TagDelimiter
 //             ^^ Tag
 //                ^^ TagAttribute
 //                    ^^^^ Identifier
+//                         ^ TagDelimiter
+//                                      ^ TagDelimiter
+//                                       ^ TagDelimiter
 //                                        ^^ Tag
+//                                          ^ TagDelimiter
               {[1, 2, 3].map(item => (
 //              ^ NumericLiteral
 //                 ^ NumericLiteral
@@ -27,13 +39,21 @@ expression: "snapshot_treesitter_syntax_kinds(&document, &contents)"
 //                       ^^^ IdentifierFunction
 //                           ^^^^ Identifier
                   <p key={item}>{item}</p>
+//                ^ TagDelimiter
 //                 ^ Tag
 //                   ^^^ TagAttribute
 //                        ^^^^ Identifier
+//                             ^ TagDelimiter
 //                               ^^^^ Identifier
+//                                    ^ TagDelimiter
+//                                     ^ TagDelimiter
 //                                      ^ Tag
+//                                       ^ TagDelimiter
               ))}
           </div>
+//        ^ TagDelimiter
+//         ^ TagDelimiter
 //          ^^^ Tag
+//             ^ TagDelimiter
       )
   }

--- a/docker-images/syntax-highlighter/crates/syntax-analysis/src/highlighting/snapshots/syntax_analysis__highlighting__tree_sitter__test__react.tsx.snap
+++ b/docker-images/syntax-highlighter/crates/syntax-analysis/src/highlighting/snapshots/syntax_analysis__highlighting__tree_sitter__test__react.tsx.snap
@@ -16,12 +16,24 @@ expression: "snapshot_treesitter_syntax_kinds(&document, &contents)"
       return (
 //    ^^^^^^ Keyword
           <div>
+//        ^ TagDelimiter
 //         ^^^ Tag
+//            ^ TagDelimiter
+              <p />
+//            ^ TagDelimiter
+//             ^ Tag
+//               ^ TagDelimiter
+//                ^ TagDelimiter
               <h1 id={name}>My Component</h1>
+//            ^ TagDelimiter
 //             ^^ Tag
 //                ^^ TagAttribute
 //                    ^^^^ Identifier
+//                         ^ TagDelimiter
+//                                      ^ TagDelimiter
+//                                       ^ TagDelimiter
 //                                        ^^ Tag
+//                                          ^ TagDelimiter
               {[1, 2, 3].map(item => (
 //              ^ NumericLiteral
 //                 ^ NumericLiteral
@@ -29,14 +41,21 @@ expression: "snapshot_treesitter_syntax_kinds(&document, &contents)"
 //                       ^^^ IdentifierFunction
 //                           ^^^^ Identifier
                   <p key={item}>{item}</p>
+//                ^ TagDelimiter
 //                 ^ Tag
 //                   ^^^ TagAttribute
 //                        ^^^^ Identifier
+//                             ^ TagDelimiter
 //                               ^^^^ Identifier
+//                                    ^ TagDelimiter
+//                                     ^ TagDelimiter
 //                                      ^ Tag
+//                                       ^ TagDelimiter
               ))}
           </div>
+//        ^ TagDelimiter
+//         ^ TagDelimiter
 //          ^^^ Tag
+//             ^ TagDelimiter
       )
   }
-


### PR DESCRIPTION
Update JSX/TSX highlighting to identify tag delimiters properly. 

## Test plan

- Unit tests pass
- Inspect snap file

 
## Changelog
- Update highlighting of JSX/TSX Tags to correctly label delimiters
