### PR TITLE
Svelte: allow popovers to have external targets

### DIFF
--- a/client/web-sveltekit/src/lib/Popover.svelte
+++ b/client/web-sveltekit/src/lib/Popover.svelte
@@ -141,7 +141,6 @@
 <slot {toggle} {registerTrigger} {registerTarget} />
 {#if trigger && isOpen}
     <div
-        class="popover-container"
         use:portal
         use:onClickOutside
         use:registerPopoverContainer
@@ -160,7 +159,7 @@
 {/if}
 
 <style lang="scss">
-    .popover-container {
+    div {
         position: absolute;
         isolation: isolate;
         min-width: 10rem;

--- a/client/web-sveltekit/src/lib/Popover.svelte
+++ b/client/web-sveltekit/src/lib/Popover.svelte
@@ -51,10 +51,20 @@
 
     const registerTarget: Action<HTMLElement> = node => {
         target = node
+        return {
+            destroy() {
+                target = undefined
+            },
+        }
     }
 
     const registerTrigger: Action<HTMLElement> = node => {
         trigger = node
+        return {
+            destroy() {
+                trigger = null
+            },
+        }
     }
 
     const watchTrigger: Action<HTMLElement, HTMLElement | null> = (_node, trigger) => {

--- a/client/web-sveltekit/src/lib/Popover.svelte
+++ b/client/web-sveltekit/src/lib/Popover.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
     import type { Placement } from '@floating-ui/dom'
     import type { Action } from 'svelte/action'
+
     import { registerHotkey } from '$lib/Hotkey'
 
     import { popover, onClickOutside, portal } from './dom'
@@ -13,10 +14,10 @@
     export let hoverDelay: number = 500
     export let hoverCloseDelay: number = 150
     export let closeOnEsc: boolean = true
+    export let trigger: HTMLElement | null = null
+    export let target: HTMLElement | undefined = undefined
 
     let isOpen = false
-    let trigger: HTMLElement | null
-    let target: HTMLElement | undefined
     let popoverContainer: HTMLElement | null
     let delayTimer: ReturnType<typeof setTimeout>
 

--- a/client/web-sveltekit/src/lib/Popover.svelte
+++ b/client/web-sveltekit/src/lib/Popover.svelte
@@ -1,16 +1,17 @@
 <script lang="ts">
-    import type { Placement } from '@floating-ui/dom'
+    import type { OffsetOptions, Placement } from '@floating-ui/dom'
     import type { Action } from 'svelte/action'
 
     import { registerHotkey } from '$lib/Hotkey'
 
     import { popover, onClickOutside, portal } from './dom'
 
-    export let placement: Placement = 'bottom'
     /**
      * Show the popover when hovering over the trigger.
      */
     export let showOnHover: boolean = false
+    export let placement: Placement = 'bottom'
+    export let offset: OffsetOptions = showOnHover ? 0 : 3
     export let hoverDelay: number = 500
     export let hoverCloseDelay: number = 150
     export let closeOnEsc: boolean = true
@@ -147,7 +148,7 @@
             reference: target ?? trigger,
             options: {
                 placement,
-                offset: showOnHover ? 0 : 3,
+                offset,
                 shift: { padding: 4 },
             },
         }}

--- a/client/web-sveltekit/src/lib/TreeNode.svelte
+++ b/client/web-sveltekit/src/lib/TreeNode.svelte
@@ -99,7 +99,7 @@
                 <Icon svgPath={expanded ? mdiChevronDown : mdiChevronRight} inline />
             </Button>
         {/if}
-        <slot {entry} {expanded} toggle={toggleOpen} />
+        <slot {entry} {expanded} toggle={toggleOpen} {label} />
     </span>
     {#if expanded && children}
         {#await children}
@@ -110,7 +110,7 @@
             <ul role="group">
                 {#each treeProvider.getEntries() as entry (treeProvider.getNodeID(entry))}
                     <svelte:self {entry} {treeProvider} let:entry let:toggle let:expanded on:scope-change>
-                        <slot {entry} {toggle} {expanded} />
+                        <slot {entry} {toggle} {expanded} {label} />
                     </svelte:self>
                 {/each}
             </ul>

--- a/client/web-sveltekit/src/lib/TreeNode.svelte
+++ b/client/web-sveltekit/src/lib/TreeNode.svelte
@@ -109,7 +109,7 @@
         {:then treeProvider}
             <ul role="group">
                 {#each treeProvider.getEntries() as entry (treeProvider.getNodeID(entry))}
-                    <svelte:self {entry} {treeProvider} let:entry let:toggle let:expanded on:scope-change>
+                    <svelte:self {entry} {treeProvider} let:entry let:toggle let:expanded let:label on:scope-change>
                         <slot {entry} {toggle} {expanded} {label} />
                     </svelte:self>
                 {/each}

--- a/client/web-sveltekit/src/lib/TreeView.svelte
+++ b/client/web-sveltekit/src/lib/TreeView.svelte
@@ -245,8 +245,8 @@
 <ul role="tree" bind:this={treeRoot} on:keydown={handleKeydown} on:click={handleClick}>
     {#each entries as entry (treeProvider.getNodeID(entry))}
         <TreeNode {entry} {treeProvider} on:scope-change>
-            <svelte:fragment let:entry let:toggle let:expanded>
-                <slot {entry} {toggle} {expanded} />
+            <svelte:fragment let:entry let:toggle let:expanded let:label>
+                <slot {entry} {toggle} {expanded} {label} />
             </svelte:fragment>
             <svelte:fragment slot="error" let:error>
                 <slot name="error" {error} />

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/FileTree.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/FileTree.svelte
@@ -114,7 +114,7 @@
         on:select={event => handleSelect(event.detail)}
         on:scope-change={event => handleScopeChange(event.detail.provider)}
     >
-        <svelte:fragment let:entry let:expanded>
+        <svelte:fragment let:entry let:expanded let:label>
             {@const isRoot = entry === treeRoot}
             {#if entry === NODE_LIMIT}
                 <!-- todo: create alert component -->
@@ -124,13 +124,12 @@
                     We handle navigation via the TreeView's select event, to preserve the focus state.
                     Using a link here allows us to benefit from data preloading.
                 -->
-                <Popover let:registerTrigger placement="right-end" showOnHover>
+                <Popover trigger={label} placement="right-start" showOnHover>
                     <a
                         href={replaceRevisionInURL(entry.canonicalURL, revision)}
                         on:click|preventDefault={() => {}}
                         tabindex={-1}
                         data-go-up={isRoot ? true : undefined}
-                        use:registerTrigger
                         on:mouseover={/* Preload */ () =>
                             fetchPopoverData({ repoName, revision, filePath: entry.path })}
                     >

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/FileTree.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/FileTree.svelte
@@ -124,7 +124,7 @@
                     We handle navigation via the TreeView's select event, to preserve the focus state.
                     Using a link here allows us to benefit from data preloading.
                 -->
-                <Popover trigger={label} placement="right-start" showOnHover offset={8}>
+                <Popover trigger={label} placement="right-start" showOnHover offset={{ mainAxis: 8, crossAxis: -32 }}>
                     <a
                         href={replaceRevisionInURL(entry.canonicalURL, revision)}
                         on:click|preventDefault={() => {}}

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/FileTree.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/FileTree.svelte
@@ -124,7 +124,7 @@
                     We handle navigation via the TreeView's select event, to preserve the focus state.
                     Using a link here allows us to benefit from data preloading.
                 -->
-                <Popover trigger={label} placement="right-start" showOnHover>
+                <Popover trigger={label} placement="right-start" showOnHover offset={8}>
                     <a
                         href={replaceRevisionInURL(entry.canonicalURL, revision)}
                         on:click|preventDefault={() => {}}


### PR DESCRIPTION
This updates the `Popover` component to accept a passed-in target rather than setting the target via an action. This allows us to pass in targets not owned by the `Popover` component, which is important for things like the file tree where the logical target is a wrapper around what the consumer has access to.



## Test plan

Manually tested. [Video walkthrough](https://share.cleanshot.com/K29H6Mvw).