### PR TITLE
feat/enterprise-portal: rudimentary audit logging

### DIFF
--- a/cmd/enterprise-portal/internal/codyaccessservice/v1.go
+++ b/cmd/enterprise-portal/internal/codyaccessservice/v1.go
@@ -62,12 +62,13 @@ func (s *handlerV1) GetCodyGatewayAccess(ctx context.Context, req *connect.Reque
 
 	// 🚨 SECURITY: Require approrpiate M2M scope.
 	requiredScope := samsm2m.EnterprisePortalScope("codyaccess", scopes.ActionRead)
-	if err := samsm2m.RequireScope(ctx, logger, s.samsClient, requiredScope, req); err != nil {
+	clientAttrs, err := samsm2m.RequireScope(ctx, logger, s.samsClient, requiredScope, req)
+	if err != nil {
 		return nil, err
 	}
+	logger = logger.With(clientAttrs...)
 
 	var attr *dotcomdb.CodyGatewayAccessAttributes
-	var err error
 	switch query := req.Msg.GetQuery().(type) {
 	case *codyaccessv1.GetCodyGatewayAccessRequest_SubscriptionId:
 		if len(query.SubscriptionId) == 0 {
@@ -91,8 +92,12 @@ func (s *handlerV1) GetCodyGatewayAccess(ctx context.Context, req *connect.Reque
 		return nil, connectutil.InternalError(ctx, logger, err,
 			"failed to get Cody Gateway access attributes")
 	}
+
+	access := convertAccessAttrsToProto(attr)
+	logger.Scoped("audit").Info("GetCodyGatewayAccess",
+		log.String("accessedSubscription", access.GetSubscriptionId()))
 	return connect.NewResponse(&codyaccessv1.GetCodyGatewayAccessResponse{
-		Access: convertAccessAttrsToProto(attr),
+		Access: access,
 	}), nil
 }
 
@@ -101,9 +106,11 @@ func (s *handlerV1) ListCodyGatewayAccesses(ctx context.Context, req *connect.Re
 
 	// 🚨 SECURITY: Require approrpiate M2M scope.
 	requiredScope := samsm2m.EnterprisePortalScope("codyaccess", scopes.ActionRead)
-	if err := samsm2m.RequireScope(ctx, logger, s.samsClient, requiredScope, req); err != nil {
+	clientAttrs, err := samsm2m.RequireScope(ctx, logger, s.samsClient, requiredScope, req)
+	if err != nil {
 		return nil, err
 	}
+	logger = logger.With(clientAttrs...)
 
 	// Pagination is unimplemented: https://linear.app/sourcegraph/issue/CORE-134
 	if req.Msg.PageSize != 0 {
@@ -127,8 +134,12 @@ func (s *handlerV1) ListCodyGatewayAccesses(ctx context.Context, req *connect.Re
 		NextPageToken: "",
 		Accesses:      make([]*codyaccessv1.CodyGatewayAccess, len(attrs)),
 	}
+	accessedSubscriptions := make([]string, len(attrs))
 	for i, attr := range attrs {
 		resp.Accesses[i] = convertAccessAttrsToProto(attr)
+		accessedSubscriptions[i] = resp.Accesses[i].GetSubscriptionId()
 	}
+	logger.Scoped("audit").Info("ListCodyGatewayAccesses",
+		log.Strings("accessedSubscriptions", accessedSubscriptions))
 	return connect.NewResponse(&resp), nil
 }

--- a/cmd/enterprise-portal/internal/samsm2m/samsm2m.go
+++ b/cmd/enterprise-portal/internal/samsm2m/samsm2m.go
@@ -3,6 +3,7 @@ package samsm2m
 import (
 	"context"
 	"net/http"
+	"strings"
 
 	"connectrpc.com/connect"
 	"go.opentelemetry.io/otel"
@@ -41,7 +42,7 @@ type Request interface {
 // returned directly from a ConnectRPC implementation.
 //
 // See: go/sams-m2m
-func RequireScope(ctx context.Context, logger log.Logger, tokens TokenIntrospector, requiredScope scopes.Scope, req Request) (err error) {
+func RequireScope(ctx context.Context, logger log.Logger, tokens TokenIntrospector, requiredScope scopes.Scope, req Request) (attrs []log.Field, err error) {
 	logger = logger.Scoped("samsm2m")
 
 	var span trace.Span
@@ -59,11 +60,11 @@ func RequireScope(ctx context.Context, logger log.Logger, tokens TokenIntrospect
 		var err error
 		token, err = authbearer.ExtractBearerContents(v[0])
 		if err != nil {
-			return connect.NewError(connect.CodeUnauthenticated,
+			return nil, connect.NewError(connect.CodeUnauthenticated,
 				errors.Wrap(err, "invalid authorization header"))
 		}
 	} else {
-		return connect.NewError(connect.CodeUnauthenticated,
+		return nil, connect.NewError(connect.CodeUnauthenticated,
 			errors.New("no authorization header"))
 	}
 
@@ -72,15 +73,20 @@ func RequireScope(ctx context.Context, logger log.Logger, tokens TokenIntrospect
 	// for now until we have a concerted effort.
 	result, err := tokens.IntrospectToken(ctx, token)
 	if err != nil {
-		return connectutil.InternalError(ctx, logger, err, "unable to validate token")
+		return nil, connectutil.InternalError(ctx, logger, err, "unable to validate token")
 	}
 	span.SetAttributes(attribute.String("client_id", result.ClientID))
+	fields := []log.Field{
+		log.String("client.clientID", result.ClientID),
+		log.Time("client.tokenExpiresAt", result.ExpiresAt),
+		log.String("client.tokenScopes", strings.Join(scopes.ToStrings(result.Scopes), " ")),
+	}
 
 	// Active encapsulates whether the token is active, including expiration.
 	if !result.Active {
 		// Record detailed error in span, and return an opaque one
 		span.SetAttributes(attribute.String("full_error", "inactive token"))
-		return connect.NewError(connect.CodePermissionDenied, errors.New("permission denied"))
+		return fields, connect.NewError(connect.CodePermissionDenied, errors.New("permission denied"))
 	}
 
 	// Check for our required scope.
@@ -89,11 +95,10 @@ func RequireScope(ctx context.Context, logger log.Logger, tokens TokenIntrospect
 		err = errors.Newf("got scopes %+v, required: %+v", result.Scopes, requiredScope)
 		span.SetAttributes(attribute.String("full_error", err.Error()))
 		logger.Error("attempt to authenticate using SAMS token without required scope",
-			log.String("clientID", result.ClientID),
 			log.Error(err))
 		// Return an opaque error
-		return connect.NewError(connect.CodePermissionDenied, errors.New("insufficient scope"))
+		return fields, connect.NewError(connect.CodePermissionDenied, errors.New("insufficient scope"))
 	}
 
-	return nil
+	return fields, nil
 }

--- a/cmd/enterprise-portal/internal/samsm2m/samsm2m_test.go
+++ b/cmd/enterprise-portal/internal/samsm2m/samsm2m_test.go
@@ -96,7 +96,7 @@ func TestRequireScope(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := context.Background()
-			err := RequireScope(ctx, logtest.Scoped(t), tc.samsClient, requiredScope, request(tc.metadata))
+			_, err := RequireScope(ctx, logtest.Scoped(t), tc.samsClient, requiredScope, request(tc.metadata))
 			if tc.wantErr == nil {
 				assert.NoError(t, err)
 			} else {

--- a/cmd/enterprise-portal/internal/subscriptionsservice/BUILD.bazel
+++ b/cmd/enterprise-portal/internal/subscriptionsservice/BUILD.bazel
@@ -22,5 +22,6 @@ go_library(
         "@com_github_sourcegraph_log//:log",
         "@com_github_sourcegraph_sourcegraph_accounts_sdk_go//scopes",
         "@org_golang_google_protobuf//types/known/timestamppb",
+        "@org_golang_x_exp//maps",
     ],
 )


### PR DESCRIPTION
As we prepare to roll out https://github.com/sourcegraph/sourcegraph/pull/62934, this adds rudimentary audit logging that records the client and some session details on successful data access at the end of the RPC. The GraphQL resolvers generate an audit log on every resolver, so this maintains some parity.

I'm not sure there's a good way to generalize this better and reduce copy-pasta, open to ideas

## Test plan

n/a just logging additions