### PR TITLE
Remove references to 'rate-limits-exceeded-for-testing' feature flag

### DIFF
--- a/cmd/frontend/graphqlbackend/user.go
+++ b/cmd/frontend/graphqlbackend/user.go
@@ -516,10 +516,6 @@ func (r *schemaResolver) ChangeCodyPlan(ctx context.Context, args *changeCodyPla
 		return nil, errors.New("this feature is only available on sourcegraph.com")
 	}
 
-	if featureflag.FromContext(ctx).GetBoolOr("rate-limits-exceeded-for-testing", false) {
-		return nil, errors.New("this user is not allowed to change their plan")
-	}
-
 	userID, err := UnmarshalUserID(args.User)
 	if err != nil {
 		return nil, err

--- a/cmd/frontend/internal/httpapi/completions/limiter.go
+++ b/cmd/frontend/internal/httpapi/completions/limiter.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/sourcegraph/sourcegraph/internal/featureflag"
-
 	"github.com/gomodule/redigo/redis"
 
 	"github.com/sourcegraph/sourcegraph/internal/actor"
@@ -92,7 +90,7 @@ func (r *rateLimiter) TryAcquire(ctx context.Context) (err error) {
 	// If the usage exceeds the maximum, we return an error. Consumers can check if
 	// the error is of type RateLimitExceededError and extract additional information
 	// like the limit and the time by when they should retry.
-	if currentUsage >= limit || featureflag.FromContext(ctx).GetBoolOr("rate-limits-exceeded-for-testing", false) {
+	if currentUsage >= limit {
 		// Read TTL to compute the RetryAfter time.
 		ttl, err := rstore.TTL(key)
 		if err != nil {


### PR DESCRIPTION
See [this Slack thread](https://sourcegraph.slack.com/archives/C06062P5TS5/p1717624627412939) for some more context on this change.

Somebody pointed out that there is a Sourcegraph.com feature flag that appears to allow a user to bypass any Cody Pro rate limits that are imposed. (This was originally added in https://github.com/sourcegraph/sourcegraph/pull/58591 to facilitate testing when user limits were a new thing.)

However, at this point that capability has proven itself and so this escape hatch is no longer needed. However it sounds like this may never have worked correctly on Cody Gateway, by virtue of when feature flags get materialized, and where the specific Cody Gateway API call is made. ([Slack](https://sourcegraph.slack.com/archives/C06062P5TS5/p1717656566799539?thread_ts=1717624627.412939&cid=C06062P5TS5))

## Test plan

Relying on CI/CD.


## Changelog

<!--
1. Ensure your pull request title is formatted as: $type($domain): $what
2. Add bullet list items for each additional detail you want to cover (see example below)
3. You can edit this after the pull request was merged, as long as release shipping it hasn't been promoted to the public.
4. For more information, please see this how-to https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c?

Audience: TS/CSE > Customers > Teammates (in that order).

Cheat sheet: $type = chore|fix|feat $domain: source|search|ci|release|plg|cody|local|...
-->

<!--
Example:

Title: fix(search): parse quotes with the appropriate context
Changelog section:

## Changelog

- When a quote is used with regexp pattern type, then ...
- Refactored underlying code.
-->
