### PR TITLE
security: Auto-update package lockfiles for Sourcegraph base images

### DIFF
--- a/wolfi-images/appliance.lock.json
+++ b/wolfi-images/appliance.lock.json
@@ -109,22 +109,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Zjfs1uR/mYiortANP+EFcejW+vo=",
+        "checksum": "Q1Zi0e8Bq6WCd/6uXXjVhb8YwMD1U=",
         "control": {
-          "checksum": "sha1-Zjfs1uR/mYiortANP+EFcejW+vo=",
-          "range": "bytes=698-1085"
+          "checksum": "sha1-Zi0e8Bq6WCd/6uXXjVhb8YwMD1U=",
+          "range": "bytes=700-1073"
         },
         "data": {
-          "checksum": "sha256-BMd7TzffjbrFwdbopDPVYsX0X9XnusIMNbIf33/8kwc=",
-          "range": "bytes=1086-76881"
+          "checksum": "sha256-jMhtfqVjnhuuBO7wtNZ6RS/72sZWoKt/Moage2amlks=",
+          "range": "bytes=1074-81594"
         },
         "name": "protobuf-c",
         "signature": {
-          "checksum": "sha1-efGiXyYWsJ5P2uTkB6aXEZ3kl3o=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-kATwMKztK7nk7qbYCJPkCFp6IXc=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r4.apk",
-        "version": "1.5.0-r4"
+        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r5.apk",
+        "version": "1.5.0-r5"
       },
       {
         "architecture": "x86_64",
@@ -166,22 +166,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1wRzOx+L6MeRFtTcq2y/6ot7Cj54=",
+        "checksum": "Q1Onuac6Y+IWA7a4b8FvqX1erWDDw=",
         "control": {
-          "checksum": "sha1-wRzOx+L6MeRFtTcq2y/6ot7Cj54=",
-          "range": "bytes=699-1069"
+          "checksum": "sha1-Onuac6Y+IWA7a4b8FvqX1erWDDw=",
+          "range": "bytes=693-1048"
         },
         "data": {
-          "checksum": "sha256-gNRjwZ4XQatCYWediSVb+j8lS54CggvMC5Dn3qT84So=",
-          "range": "bytes=1070-61490"
+          "checksum": "sha256-KLtDAs3iU0oyZ/FysePG/J+1H1ofDxHXIY7xvtZhtMc=",
+          "range": "bytes=1049-61503"
         },
         "name": "libverto",
         "signature": {
-          "checksum": "sha1-kuPwakYdy5EM6sd5Ba0K0Ta8x4w=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-/IXL9S1O+MwaW7KsSzz1ywEqKFQ=",
+          "range": "bytes=0-692"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libverto-0.3.2-r3.apk",
-        "version": "0.3.2-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/libverto-0.3.2-r4.apk",
+        "version": "0.3.2-r4"
       },
       {
         "architecture": "x86_64",
@@ -204,60 +204,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q15k7skG0C5SvxLvN3uoETs1Udd9w=",
+        "checksum": "Q1Q/Zy5ovYSu2p/vVLr6DgVA1e8AQ=",
         "control": {
-          "checksum": "sha1-5k7skG0C5SvxLvN3uoETs1Udd9w=",
-          "range": "bytes=700-1064"
+          "checksum": "sha1-Q/Zy5ovYSu2p/vVLr6DgVA1e8AQ=",
+          "range": "bytes=699-1062"
         },
         "data": {
-          "checksum": "sha256-45tH8phNvEY3Z9XXaBHNviH4vfoG4E8PFsu2M/LDMRc=",
-          "range": "bytes=1065-5924167"
+          "checksum": "sha256-H3jxsw8ytOeCIR4vq17voSVhdNokXk8C1g075txH6Bs=",
+          "range": "bytes=1063-5903754"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-5z9K2exWEl9OCHnv0JLws1YSyJc=",
-          "range": "bytes=0-699"
+          "checksum": "sha1-NIl2f5OI/wSZByI8Ds1ZUfbFWyw=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.1-r1.apk",
-        "version": "3.3.1-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.1-r3.apk",
+        "version": "3.3.1-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1YHPNuN8ECvgfexdDInIcb8xsZ+4=",
+        "checksum": "Q13wGUXdZut9OOTdY5z2amUj9wXC0=",
         "control": {
-          "checksum": "sha1-YHPNuN8ECvgfexdDInIcb8xsZ+4=",
-          "range": "bytes=702-1073"
+          "checksum": "sha1-3wGUXdZut9OOTdY5z2amUj9wXC0=",
+          "range": "bytes=698-1068"
         },
         "data": {
-          "checksum": "sha256-zLu4HkXXRUtKAepPk1ijRG6kDY0FbUtKluFCbz4NL5s=",
-          "range": "bytes=1074-1197080"
+          "checksum": "sha256-mRda6+YGlOCczyIWKaHqXskTINoT1rgorHDHqAKAb7c=",
+          "range": "bytes=1069-1188955"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-9jomo+G8ixgf6HZyZaPwOGq+Mb8=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-+UdRc4U3PKw4H9OiNurHKXa5BYk=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.1-r1.apk",
-        "version": "3.3.1-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.1-r3.apk",
+        "version": "3.3.1-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1T0Wnzc742ViaBV3YvvE20lFhHWY=",
+        "checksum": "Q1p04MrHQPrXOzuV/uF290zjnltqI=",
         "control": {
-          "checksum": "sha1-T0Wnzc742ViaBV3YvvE20lFhHWY=",
-          "range": "bytes=701-1219"
+          "checksum": "sha1-p04MrHQPrXOzuV/uF290zjnltqI=",
+          "range": "bytes=704-1219"
         },
         "data": {
-          "checksum": "sha256-KlEKsw3y36AC2NnaKU/8vMb1NiRHwkOOSPi+PQaatFk=",
-          "range": "bytes=1220-2555813"
+          "checksum": "sha256-TsXeqhUGykAhjQUEAlMUSzDQBcWDkkDvReoeHCL1F6c=",
+          "range": "bytes=1220-2555814"
         },
         "name": "krb5-libs",
         "signature": {
-          "checksum": "sha1-LmtseIB7cVCHQwhmMfSaLS9k4X0=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-cPyzS38QHuNlOCQb8IPlsl2PLHQ=",
+          "range": "bytes=0-703"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/krb5-libs-1.21.2-r3.apk",
-        "version": "1.21.2-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/krb5-libs-1.21.3-r0.apk",
+        "version": "1.21.3-r0"
       },
       {
         "architecture": "x86_64",
@@ -280,60 +280,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1wzZwtLauOQfLQC7YUvZdfKxtlwQ=",
+        "checksum": "Q17uprcuQ2VFudMcWAwtP7miJmLYs=",
         "control": {
-          "checksum": "sha1-wzZwtLauOQfLQC7YUvZdfKxtlwQ=",
-          "range": "bytes=698-1085"
+          "checksum": "sha1-7uprcuQ2VFudMcWAwtP7miJmLYs=",
+          "range": "bytes=695-1067"
         },
         "data": {
-          "checksum": "sha256-TO8CAULO44s/LphhtcaFOGJB7aFldk13v1cV9ceZHww=",
-          "range": "bytes=1086-276837"
+          "checksum": "sha256-unKdPbvO2VHZ5w1t1l8mOpQuNdUGwLhofEO4weN2Mig=",
+          "range": "bytes=1068-280973"
         },
         "name": "libuv",
         "signature": {
-          "checksum": "sha1-LRiyeKmjexy8CJizLxjd6ikon1w=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-4lKldnTO71WHMZ4tbANz6i2/Ed0=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libuv-1.48.0-r2.apk",
-        "version": "1.48.0-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libuv-1.48.0-r3.apk",
+        "version": "1.48.0-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q14S6biy8fc5OGbGEJoLBM+tJOGyo=",
+        "checksum": "Q1CN6zJbOPznWUfTrb/41KT7E6dm8=",
         "control": {
-          "checksum": "sha1-4S6biy8fc5OGbGEJoLBM+tJOGyo=",
-          "range": "bytes=703-1102"
+          "checksum": "sha1-CN6zJbOPznWUfTrb/41KT7E6dm8=",
+          "range": "bytes=699-1083"
         },
         "data": {
-          "checksum": "sha256-hwjdLQYfuMAGQeONmFVo0lZKKQK1S+3PBhrI3upm5W4=",
-          "range": "bytes=1103-155304"
+          "checksum": "sha256-ybzFzoQh1yNTcd3cjt54nYsPlAxAcMUcVMxEv1JRnpQ=",
+          "range": "bytes=1084-155375"
         },
         "name": "zlib",
         "signature": {
-          "checksum": "sha1-ZuLd7kE+AGhn27o8ZqDGM5eundc=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-CPXJcCjinAXP+H8Z5tkko8ayG6E=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/zlib-1.3.1-r2.apk",
-        "version": "1.3.1-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/zlib-1.3.1-r3.apk",
+        "version": "1.3.1-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ykDkP+AmDi2VcZZ1c4q4sez/DxI=",
+        "checksum": "Q1rgbci8SRSjW7EB0NSh6ZUPJLndM=",
         "control": {
-          "checksum": "sha1-ykDkP+AmDi2VcZZ1c4q4sez/DxI=",
-          "range": "bytes=705-1079"
+          "checksum": "sha1-rgbci8SRSjW7EB0NSh6ZUPJLndM=",
+          "range": "bytes=702-1060"
         },
         "data": {
-          "checksum": "sha256-t3BrH7lWfY3to3Fu3EKAMZx29v9Hnl5seyXJzLmZ9/4=",
-          "range": "bytes=1080-251884"
+          "checksum": "sha256-tf4xbo+NP+ssiaZtC1kOKehffAZ3+d17bhgfU3/30+g=",
+          "range": "bytes=1061-256582"
         },
         "name": "libnghttp2-14",
         "signature": {
-          "checksum": "sha1-CotSXRaPLKQCBRHrgzrDOD+4w20=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-KrsJYTyUsll+EUhHekbkdZFzeig=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.62.1-r0.apk",
-        "version": "1.62.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.62.1-r1.apk",
+        "version": "1.62.1-r1"
       },
       {
         "architecture": "x86_64",
@@ -413,41 +413,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q12eWmn2tCkXxwncU6gagKM3Wd9Sk=",
+        "checksum": "Q1g2RQKAvNjlRPxWjinIRveaq7IlY=",
         "control": {
-          "checksum": "sha1-2eWmn2tCkXxwncU6gagKM3Wd9Sk=",
-          "range": "bytes=696-1169"
+          "checksum": "sha1-g2RQKAvNjlRPxWjinIRveaq7IlY=",
+          "range": "bytes=695-1154"
         },
         "data": {
-          "checksum": "sha256-IFKNdojOhml3DbWPryQuHUiV3tgTWHyqOYD1JNe9IJ4=",
-          "range": "bytes=1170-2582015"
+          "checksum": "sha256-UsQFfOTXCZBan0mxDvR+ts0NKcbv1lNijxnRxjsmZhA=",
+          "range": "bytes=1155-2566233"
         },
         "name": "nghttp2",
         "signature": {
-          "checksum": "sha1-2/9n7KbRuOkrvhYqCFR5Mblx+z8=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-SUvMhz1cc5Or5Qh4fUEvPCp0NAw=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.62.1-r0.apk",
-        "version": "1.62.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.62.1-r1.apk",
+        "version": "1.62.1-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ialksjwPWvvZW+O2ABMbbBV/KTg=",
+        "checksum": "Q1sTMGOgdbZyDKxlRAByisPMHTbpY=",
         "control": {
-          "checksum": "sha1-ialksjwPWvvZW+O2ABMbbBV/KTg=",
-          "range": "bytes=702-1074"
+          "checksum": "sha1-sTMGOgdbZyDKxlRAByisPMHTbpY=",
+          "range": "bytes=703-1060"
         },
         "data": {
-          "checksum": "sha256-+ctDr3AO9mTXovGRPWk6h2ZgfY99Toy6esjBNHtJPY4=",
-          "range": "bytes=1075-631903"
+          "checksum": "sha256-bUy0h/zxpq7iP6vrQRMftZ9nevkHTB87hSX17wz4lmM=",
+          "range": "bytes=1061-631449"
         },
         "name": "nghttp2-dev",
         "signature": {
-          "checksum": "sha1-wZGQRluFd6DL1USzeak75o5/BTc=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-fQ6aDq3Io/gdJ5s5t3M+FwED1Y0=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.62.1-r0.apk",
-        "version": "1.62.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.62.1-r1.apk",
+        "version": "1.62.1-r1"
       },
       {
         "architecture": "x86_64",
@@ -470,22 +470,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1j7mSQMMairN1V1GgXOVuQSexLuc=",
+        "checksum": "Q10AaU1ocIM4PYYNvwbml8TmpNvEA=",
         "control": {
-          "checksum": "sha1-j7mSQMMairN1V1GgXOVuQSexLuc=",
-          "range": "bytes=698-1074"
+          "checksum": "sha1-0AaU1ocIM4PYYNvwbml8TmpNvEA=",
+          "range": "bytes=706-1085"
         },
         "data": {
-          "checksum": "sha256-bhHbD8Y002DmplTAE3opQOtihownr8rl562x0pVTzsI=",
-          "range": "bytes=1075-4272651"
+          "checksum": "sha256-1YQNYASFjlP3kXX58ec8du75ij/U6O4DPAKzJAPkln0=",
+          "range": "bytes=1086-4272589"
         },
         "name": "libxml2",
         "signature": {
-          "checksum": "sha1-wRiyzFOv6Vhlt8mORziokxelzRk=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-QFjdplzGn/MiNFxMykgafr6/w6U=",
+          "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.1-r0.apk",
-        "version": "2.13.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.1-r1.apk",
+        "version": "2.13.1-r1"
       },
       {
         "architecture": "x86_64",
@@ -622,22 +622,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1fr0OtiVaD3c5nw8fy5m74hDe9PU=",
+        "checksum": "Q1BRGmQ9LZTeZqbxQ1ls69T6efViw=",
         "control": {
-          "checksum": "sha1-fr0OtiVaD3c5nw8fy5m74hDe9PU=",
-          "range": "bytes=697-1092"
+          "checksum": "sha1-BRGmQ9LZTeZqbxQ1ls69T6efViw=",
+          "range": "bytes=698-1080"
         },
         "data": {
-          "checksum": "sha256-lukjMYpGmuhBNDUbbTJMIrUWaR4rNikEnW4BgiTaLj8=",
-          "range": "bytes=1093-113872"
+          "checksum": "sha256-vtJ4WJ5M+31ZKSBYBedbrl/FrbAw8hGpPRrHC7kasOk=",
+          "range": "bytes=1081-113895"
         },
         "name": "libpsl",
         "signature": {
-          "checksum": "sha1-Lrrudgn1i1a0JhjdzeXG+exnjQA=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-DuAoiykwhu8vu1qxdEDK5oyAmf8=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libpsl-0.21.5-r2.apk",
-        "version": "0.21.5-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libpsl-0.21.5-r3.apk",
+        "version": "0.21.5-r3"
       },
       {
         "architecture": "x86_64",
@@ -755,22 +755,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q19f/3419Xa/xv9jgQ0mMYs011fBk=",
+        "checksum": "Q1mTmy64gKYi4THBqewuvYL2uUyHc=",
         "control": {
-          "checksum": "sha1-9f/3419Xa/xv9jgQ0mMYs011fBk=",
-          "range": "bytes=696-1041"
+          "checksum": "sha1-mTmy64gKYi4THBqewuvYL2uUyHc=",
+          "range": "bytes=700-1031"
         },
         "data": {
-          "checksum": "sha256-iqHASiMgiu6rIjbWGwBmmq1Zthae8BkE4QZkiVPH7Ek=",
-          "range": "bytes=1042-1888945"
+          "checksum": "sha256-p0qua2luH33oAgOcLkU9f7k+I8WnykFszVMwNahujDA=",
+          "range": "bytes=1032-1889523"
         },
         "name": "tzdata",
         "signature": {
-          "checksum": "sha1-PCC3jiXlTwrimRMXH/4RyNvccOM=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-sBf5jVLVpWj4DiXaAd/mjo0pTfk=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/tzdata-2024a-r2.apk",
-        "version": "2024a-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/tzdata-2024a-r3.apk",
+        "version": "2024a-r3"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/batcheshelper.lock.json
+++ b/wolfi-images/batcheshelper.lock.json
@@ -14,41 +14,41 @@
     "packages": [
       {
         "architecture": "x86_64",
-        "checksum": "Q1ge3SLQsJ9v2RnvIHHAP1yFyjrEU=",
+        "checksum": "Q1Ai8jWuxKZR2M2XhOpOGAoTEwnnk=",
         "control": {
-          "checksum": "sha1-ge3SLQsJ9v2RnvIHHAP1yFyjrEU=",
-          "range": "bytes=693-1040"
+          "checksum": "sha1-Ai8jWuxKZR2M2XhOpOGAoTEwnnk=",
+          "range": "bytes=705-1037"
         },
         "data": {
-          "checksum": "sha256-I0AdTdfGf4P/jwzTrLXm73l5/RNSlymEof/YZfev3xY=",
-          "range": "bytes=1041-255811"
+          "checksum": "sha256-e4UardkBVyaC49aSyrVmXNi8sSKqQl4eKYd0LxGRLA0=",
+          "range": "bytes=1038-255695"
         },
         "name": "ca-certificates-bundle",
         "signature": {
-          "checksum": "sha1-ge1eJBiQmFWAn9GapFkQpO+Rn/Y=",
-          "range": "bytes=0-692"
+          "checksum": "sha1-loRuyYQLm+atp+YteiQoj++EWIM=",
+          "range": "bytes=0-704"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20240315-r3.apk",
-        "version": "20240315-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20240315-r4.apk",
+        "version": "20240315-r4"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1bgay5kOzpmDBgqJCg7dSlawyJg0=",
+        "checksum": "Q1+GH6qRN4iy1IDt0cT0x0tin7YfI=",
         "control": {
-          "checksum": "sha1-bgay5kOzpmDBgqJCg7dSlawyJg0=",
-          "range": "bytes=703-1067"
+          "checksum": "sha1-+GH6qRN4iy1IDt0cT0x0tin7YfI=",
+          "range": "bytes=703-1051"
         },
         "data": {
-          "checksum": "sha256-f83HfRE7r2ZniH7PyPmRqcoU5NTpF+Uk4FH80QbjvBM=",
-          "range": "bytes=1068-118370"
+          "checksum": "sha256-rO0P9z2V49BSrz1A5Ap69tEappVrg5MMBjzW00rOpZc=",
+          "range": "bytes=1052-122464"
         },
         "name": "wolfi-baselayout",
         "signature": {
-          "checksum": "sha1-2hlCvYH1D7u25HkJGA75jjs/sQY=",
+          "checksum": "sha1-Ntb6VuMzDfM+frpCjKEIpDzl53I=",
           "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r11.apk",
-        "version": "20230201-r11"
+        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r12.apk",
+        "version": "20230201-r12"
       },
       {
         "architecture": "x86_64",
@@ -109,41 +109,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Zjfs1uR/mYiortANP+EFcejW+vo=",
+        "checksum": "Q1Zi0e8Bq6WCd/6uXXjVhb8YwMD1U=",
         "control": {
-          "checksum": "sha1-Zjfs1uR/mYiortANP+EFcejW+vo=",
-          "range": "bytes=698-1085"
+          "checksum": "sha1-Zi0e8Bq6WCd/6uXXjVhb8YwMD1U=",
+          "range": "bytes=700-1073"
         },
         "data": {
-          "checksum": "sha256-BMd7TzffjbrFwdbopDPVYsX0X9XnusIMNbIf33/8kwc=",
-          "range": "bytes=1086-76881"
+          "checksum": "sha256-jMhtfqVjnhuuBO7wtNZ6RS/72sZWoKt/Moage2amlks=",
+          "range": "bytes=1074-81594"
         },
         "name": "protobuf-c",
         "signature": {
-          "checksum": "sha1-efGiXyYWsJ5P2uTkB6aXEZ3kl3o=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-kATwMKztK7nk7qbYCJPkCFp6IXc=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r4.apk",
-        "version": "1.5.0-r4"
-      },
-      {
-        "architecture": "x86_64",
-        "checksum": "Q1Xf5v5uXumBgIR4d4ZxMRxdpyWlM=",
-        "control": {
-          "checksum": "sha1-Xf5v5uXumBgIR4d4ZxMRxdpyWlM=",
-          "range": "bytes=698-1078"
-        },
-        "data": {
-          "checksum": "sha256-eD7HqFCWNUBQiLq9PcWE/zPeZwkiv8hBrytI4qmfQ/8=",
-          "range": "bytes=1079-57055"
-        },
-        "name": "keyutils-libs",
-        "signature": {
-          "checksum": "sha1-V0HVgZLP7P5kNACfus3abCLCS20=",
-          "range": "bytes=0-697"
-        },
-        "url": "https://packages.wolfi.dev/os/x86_64/keyutils-libs-1.6.3-r2.apk",
-        "version": "1.6.3-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r5.apk",
+        "version": "1.5.0-r5"
       },
       {
         "architecture": "x86_64",
@@ -166,22 +147,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1wRzOx+L6MeRFtTcq2y/6ot7Cj54=",
+        "checksum": "Q1v0A2vQM5k8rQY/GpIq6xI4T0YmA=",
         "control": {
-          "checksum": "sha1-wRzOx+L6MeRFtTcq2y/6ot7Cj54=",
-          "range": "bytes=699-1069"
+          "checksum": "sha1-v0A2vQM5k8rQY/GpIq6xI4T0YmA=",
+          "range": "bytes=701-1064"
         },
         "data": {
-          "checksum": "sha256-gNRjwZ4XQatCYWediSVb+j8lS54CggvMC5Dn3qT84So=",
-          "range": "bytes=1070-61490"
+          "checksum": "sha256-uAOrkGDDc/yqt6VjIrlTEALBJG4BCI4njqZw5jQqF0o=",
+          "range": "bytes=1065-56984"
+        },
+        "name": "keyutils-libs",
+        "signature": {
+          "checksum": "sha1-32uYMH/zGBr9Jo3hiqnThlcqBcE=",
+          "range": "bytes=0-700"
+        },
+        "url": "https://packages.wolfi.dev/os/x86_64/keyutils-libs-1.6.3-r3.apk",
+        "version": "1.6.3-r3"
+      },
+      {
+        "architecture": "x86_64",
+        "checksum": "Q1Onuac6Y+IWA7a4b8FvqX1erWDDw=",
+        "control": {
+          "checksum": "sha1-Onuac6Y+IWA7a4b8FvqX1erWDDw=",
+          "range": "bytes=693-1048"
+        },
+        "data": {
+          "checksum": "sha256-KLtDAs3iU0oyZ/FysePG/J+1H1ofDxHXIY7xvtZhtMc=",
+          "range": "bytes=1049-61503"
         },
         "name": "libverto",
         "signature": {
-          "checksum": "sha1-kuPwakYdy5EM6sd5Ba0K0Ta8x4w=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-/IXL9S1O+MwaW7KsSzz1ywEqKFQ=",
+          "range": "bytes=0-692"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libverto-0.3.2-r3.apk",
-        "version": "0.3.2-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/libverto-0.3.2-r4.apk",
+        "version": "0.3.2-r4"
       },
       {
         "architecture": "x86_64",
@@ -204,60 +204,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1gTZGkWP+QO3mUqLVJth8vrDEzzU=",
+        "checksum": "Q1Q/Zy5ovYSu2p/vVLr6DgVA1e8AQ=",
         "control": {
-          "checksum": "sha1-gTZGkWP+QO3mUqLVJth8vrDEzzU=",
-          "range": "bytes=699-1076"
+          "checksum": "sha1-Q/Zy5ovYSu2p/vVLr6DgVA1e8AQ=",
+          "range": "bytes=699-1062"
         },
         "data": {
-          "checksum": "sha256-/IFXqeKvU0GODNsz1yPIEMcFHgABT+8rbZpSlTLo4e4=",
-          "range": "bytes=1077-5915704"
+          "checksum": "sha256-H3jxsw8ytOeCIR4vq17voSVhdNokXk8C1g075txH6Bs=",
+          "range": "bytes=1063-5903754"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-l1o5ixkyWWqqJE3FOfR0QUemJUA=",
+          "checksum": "sha1-NIl2f5OI/wSZByI8Ds1ZUfbFWyw=",
           "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r9.apk",
-        "version": "3.3.0-r9"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.1-r3.apk",
+        "version": "3.3.1-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1jhAhggAuZnU7FFHnebGA26mq+jI=",
+        "checksum": "Q13wGUXdZut9OOTdY5z2amUj9wXC0=",
         "control": {
-          "checksum": "sha1-jhAhggAuZnU7FFHnebGA26mq+jI=",
-          "range": "bytes=695-1079"
+          "checksum": "sha1-3wGUXdZut9OOTdY5z2amUj9wXC0=",
+          "range": "bytes=698-1068"
         },
         "data": {
-          "checksum": "sha256-XTCQYnhGSm7SkGwqV/TQMFqGajVJVYhKAidKfLb2D3Y=",
-          "range": "bytes=1080-1197081"
+          "checksum": "sha256-mRda6+YGlOCczyIWKaHqXskTINoT1rgorHDHqAKAb7c=",
+          "range": "bytes=1069-1188955"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-qVrfDVxubkrb5Yrd2mFTv2A0G7k=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-+UdRc4U3PKw4H9OiNurHKXa5BYk=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r9.apk",
-        "version": "3.3.0-r9"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.1-r3.apk",
+        "version": "3.3.1-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1BQEXaeya6QB39QLeKcB99qBNF2o=",
+        "checksum": "Q1p04MrHQPrXOzuV/uF290zjnltqI=",
         "control": {
-          "checksum": "sha1-BQEXaeya6QB39QLeKcB99qBNF2o=",
-          "range": "bytes=699-1229"
+          "checksum": "sha1-p04MrHQPrXOzuV/uF290zjnltqI=",
+          "range": "bytes=704-1219"
         },
         "data": {
-          "checksum": "sha256-ugj/qGEBzhvdX17S22Anry+biy3lcqywhGMSHLIBCvo=",
-          "range": "bytes=1230-2551676"
+          "checksum": "sha256-TsXeqhUGykAhjQUEAlMUSzDQBcWDkkDvReoeHCL1F6c=",
+          "range": "bytes=1220-2555814"
         },
         "name": "krb5-libs",
         "signature": {
-          "checksum": "sha1-oqDPmNM4EngXAGayd/BZOqJAIao=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-cPyzS38QHuNlOCQb8IPlsl2PLHQ=",
+          "range": "bytes=0-703"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/krb5-libs-1.21.2-r2.apk",
-        "version": "1.21.2-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/krb5-libs-1.21.3-r0.apk",
+        "version": "1.21.3-r0"
       },
       {
         "architecture": "x86_64",
@@ -280,60 +280,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1wzZwtLauOQfLQC7YUvZdfKxtlwQ=",
+        "checksum": "Q17uprcuQ2VFudMcWAwtP7miJmLYs=",
         "control": {
-          "checksum": "sha1-wzZwtLauOQfLQC7YUvZdfKxtlwQ=",
-          "range": "bytes=698-1085"
+          "checksum": "sha1-7uprcuQ2VFudMcWAwtP7miJmLYs=",
+          "range": "bytes=695-1067"
         },
         "data": {
-          "checksum": "sha256-TO8CAULO44s/LphhtcaFOGJB7aFldk13v1cV9ceZHww=",
-          "range": "bytes=1086-276837"
+          "checksum": "sha256-unKdPbvO2VHZ5w1t1l8mOpQuNdUGwLhofEO4weN2Mig=",
+          "range": "bytes=1068-280973"
         },
         "name": "libuv",
         "signature": {
-          "checksum": "sha1-LRiyeKmjexy8CJizLxjd6ikon1w=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-4lKldnTO71WHMZ4tbANz6i2/Ed0=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libuv-1.48.0-r2.apk",
-        "version": "1.48.0-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libuv-1.48.0-r3.apk",
+        "version": "1.48.0-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q14S6biy8fc5OGbGEJoLBM+tJOGyo=",
+        "checksum": "Q1CN6zJbOPznWUfTrb/41KT7E6dm8=",
         "control": {
-          "checksum": "sha1-4S6biy8fc5OGbGEJoLBM+tJOGyo=",
-          "range": "bytes=703-1102"
+          "checksum": "sha1-CN6zJbOPznWUfTrb/41KT7E6dm8=",
+          "range": "bytes=699-1083"
         },
         "data": {
-          "checksum": "sha256-hwjdLQYfuMAGQeONmFVo0lZKKQK1S+3PBhrI3upm5W4=",
-          "range": "bytes=1103-155304"
+          "checksum": "sha256-ybzFzoQh1yNTcd3cjt54nYsPlAxAcMUcVMxEv1JRnpQ=",
+          "range": "bytes=1084-155375"
         },
         "name": "zlib",
         "signature": {
-          "checksum": "sha1-ZuLd7kE+AGhn27o8ZqDGM5eundc=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-CPXJcCjinAXP+H8Z5tkko8ayG6E=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/zlib-1.3.1-r2.apk",
-        "version": "1.3.1-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/zlib-1.3.1-r3.apk",
+        "version": "1.3.1-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ykDkP+AmDi2VcZZ1c4q4sez/DxI=",
+        "checksum": "Q1rgbci8SRSjW7EB0NSh6ZUPJLndM=",
         "control": {
-          "checksum": "sha1-ykDkP+AmDi2VcZZ1c4q4sez/DxI=",
-          "range": "bytes=705-1079"
+          "checksum": "sha1-rgbci8SRSjW7EB0NSh6ZUPJLndM=",
+          "range": "bytes=702-1060"
         },
         "data": {
-          "checksum": "sha256-t3BrH7lWfY3to3Fu3EKAMZx29v9Hnl5seyXJzLmZ9/4=",
-          "range": "bytes=1080-251884"
+          "checksum": "sha256-tf4xbo+NP+ssiaZtC1kOKehffAZ3+d17bhgfU3/30+g=",
+          "range": "bytes=1061-256582"
         },
         "name": "libnghttp2-14",
         "signature": {
-          "checksum": "sha1-CotSXRaPLKQCBRHrgzrDOD+4w20=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-KrsJYTyUsll+EUhHekbkdZFzeig=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.62.1-r0.apk",
-        "version": "1.62.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.62.1-r1.apk",
+        "version": "1.62.1-r1"
       },
       {
         "architecture": "x86_64",
@@ -394,136 +394,136 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1DE49kWSnmqVKJdjHFYC1bLkvyb0=",
+        "checksum": "Q1R8OxpY0fGwVaIwft4wJeswF5D54=",
         "control": {
-          "checksum": "sha1-DE49kWSnmqVKJdjHFYC1bLkvyb0=",
-          "range": "bytes=697-1078"
+          "checksum": "sha1-R8OxpY0fGwVaIwft4wJeswF5D54=",
+          "range": "bytes=695-1059"
         },
         "data": {
-          "checksum": "sha256-uDg8Qc6Rnro/68Vb5ufFSkqFLGrEsbvPb0pMJNvT1zw=",
-          "range": "bytes=1079-242085"
+          "checksum": "sha256-wNc8/SBJrGHfwywAtzCsAqeUOt0IaAhqNtlbv8OiHBE=",
+          "range": "bytes=1060-242151"
         },
         "name": "c-ares",
         "signature": {
-          "checksum": "sha1-iYEm6EWQKzxkeoDm+QsRfhw8pDg=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-55/PTlEHXI3o0hx9dSVdNwQeSMg=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.29.0-r0.apk",
-        "version": "1.29.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.31.0-r0.apk",
+        "version": "1.31.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q12eWmn2tCkXxwncU6gagKM3Wd9Sk=",
+        "checksum": "Q1g2RQKAvNjlRPxWjinIRveaq7IlY=",
         "control": {
-          "checksum": "sha1-2eWmn2tCkXxwncU6gagKM3Wd9Sk=",
-          "range": "bytes=696-1169"
+          "checksum": "sha1-g2RQKAvNjlRPxWjinIRveaq7IlY=",
+          "range": "bytes=695-1154"
         },
         "data": {
-          "checksum": "sha256-IFKNdojOhml3DbWPryQuHUiV3tgTWHyqOYD1JNe9IJ4=",
-          "range": "bytes=1170-2582015"
+          "checksum": "sha256-UsQFfOTXCZBan0mxDvR+ts0NKcbv1lNijxnRxjsmZhA=",
+          "range": "bytes=1155-2566233"
         },
         "name": "nghttp2",
         "signature": {
-          "checksum": "sha1-2/9n7KbRuOkrvhYqCFR5Mblx+z8=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-SUvMhz1cc5Or5Qh4fUEvPCp0NAw=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.62.1-r0.apk",
-        "version": "1.62.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.62.1-r1.apk",
+        "version": "1.62.1-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ialksjwPWvvZW+O2ABMbbBV/KTg=",
+        "checksum": "Q1sTMGOgdbZyDKxlRAByisPMHTbpY=",
         "control": {
-          "checksum": "sha1-ialksjwPWvvZW+O2ABMbbBV/KTg=",
-          "range": "bytes=702-1074"
+          "checksum": "sha1-sTMGOgdbZyDKxlRAByisPMHTbpY=",
+          "range": "bytes=703-1060"
         },
         "data": {
-          "checksum": "sha256-+ctDr3AO9mTXovGRPWk6h2ZgfY99Toy6esjBNHtJPY4=",
-          "range": "bytes=1075-631903"
+          "checksum": "sha256-bUy0h/zxpq7iP6vrQRMftZ9nevkHTB87hSX17wz4lmM=",
+          "range": "bytes=1061-631449"
         },
         "name": "nghttp2-dev",
         "signature": {
-          "checksum": "sha1-wZGQRluFd6DL1USzeak75o5/BTc=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-fQ6aDq3Io/gdJ5s5t3M+FwED1Y0=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.62.1-r0.apk",
-        "version": "1.62.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.62.1-r1.apk",
+        "version": "1.62.1-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1MlpRL1nBMU3RgNdSZVB42/vlGME=",
+        "checksum": "Q1rD3dEbbN8s5QAIQK1I8uF1O+oSo=",
         "control": {
-          "checksum": "sha1-MlpRL1nBMU3RgNdSZVB42/vlGME=",
-          "range": "bytes=697-1164"
+          "checksum": "sha1-rD3dEbbN8s5QAIQK1I8uF1O+oSo=",
+          "range": "bytes=701-1154"
         },
         "data": {
-          "checksum": "sha256-RiEPDasBVtnThSxGqTCDvb4J7WXM9YRpJwfYZJ3JLbs=",
-          "range": "bytes=1165-2274746"
+          "checksum": "sha256-41W2IRSRALQijYojLaqAiSSN1uO7twatGn8jqEuCZUg=",
+          "range": "bytes=1155-1439872"
         },
         "name": "xz",
         "signature": {
-          "checksum": "sha1-3wMPFIUEVfkAs7QSENemZsnTLyE=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-lozWkVrKvSrd1SoM7Zv08YYG2pA=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/xz-5.4.6-r2.apk",
-        "version": "5.4.6-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/xz-5.6.2-r0.apk",
+        "version": "5.6.2-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1TS707T+cPGL7TYVHQBCJoWwHZ0E=",
+        "checksum": "Q10AaU1ocIM4PYYNvwbml8TmpNvEA=",
         "control": {
-          "checksum": "sha1-TS707T+cPGL7TYVHQBCJoWwHZ0E=",
-          "range": "bytes=706-1098"
+          "checksum": "sha1-0AaU1ocIM4PYYNvwbml8TmpNvEA=",
+          "range": "bytes=706-1085"
         },
         "data": {
-          "checksum": "sha256-x18L706Vug5qDzq13SXuN/vGdVgzrqB06dW2DdgHGR4=",
-          "range": "bytes=1099-4541967"
+          "checksum": "sha256-1YQNYASFjlP3kXX58ec8du75ij/U6O4DPAKzJAPkln0=",
+          "range": "bytes=1086-4272589"
         },
         "name": "libxml2",
         "signature": {
-          "checksum": "sha1-BYhOxDos48sN8df8LMsSpROv2aw=",
+          "checksum": "sha1-QFjdplzGn/MiNFxMykgafr6/w6U=",
           "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.12.7-r0.apk",
-        "version": "2.12.7-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.1-r1.apk",
+        "version": "2.13.1-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1wJPtj5XZtnPiVWGM5dsT+nyfWXc=",
+        "checksum": "Q1wbnfumlWEiJnVUsJBRcQjFD3U6I=",
         "control": {
-          "checksum": "sha1-wJPtj5XZtnPiVWGM5dsT+nyfWXc=",
-          "range": "bytes=705-1234"
+          "checksum": "sha1-wbnfumlWEiJnVUsJBRcQjFD3U6I=",
+          "range": "bytes=699-1222"
         },
         "data": {
-          "checksum": "sha256-sw+CjlpsjO01q6lqzXgHnniiJKn7bqOSNO6vNqdGc7I=",
-          "range": "bytes=1235-3873775"
+          "checksum": "sha256-IXMNbJjj3kTjkWVBIHVRfG3zJQY2r5Eslgh/3TpMSsE=",
+          "range": "bytes=1223-3886778"
         },
         "name": "bind-libs",
         "signature": {
-          "checksum": "sha1-9zDzmHAeu7mWpidXAatqrLZVzUs=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-JNN15IPpJ2hMsO6hFVpDYPvvX5g=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bind-libs-9.18.26-r0.apk",
-        "version": "9.18.26-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/bind-libs-9.18.27-r1.apk",
+        "version": "9.18.27-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1AxEQdi8fVcYtGc3zHTCW3OZdY2Q=",
+        "checksum": "Q1kXUOoNa2KXixxAASo1W/im1qZ7s=",
         "control": {
-          "checksum": "sha1-AxEQdi8fVcYtGc3zHTCW3OZdY2Q=",
-          "range": "bytes=694-1208"
+          "checksum": "sha1-kXUOoNa2KXixxAASo1W/im1qZ7s=",
+          "range": "bytes=702-1215"
         },
         "data": {
-          "checksum": "sha256-/dt3qJw5D9iSJ/mKkRQkhWD8R52selhpcwXyw7KLMhg=",
-          "range": "bytes=1209-879444"
+          "checksum": "sha256-HRADvfRXfYsgEjUMGM4Hd7prpIv+YWILVfovbGOkEME=",
+          "range": "bytes=1216-879975"
         },
         "name": "bind-tools",
         "signature": {
-          "checksum": "sha1-VTb0YdUzPMk8Po0p4nj0y5Jey6k=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-8WUTMUaJTaX0T9FS/c+GddL7ttY=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bind-tools-9.18.26-r0.apk",
-        "version": "9.18.26-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/bind-tools-9.18.27-r1.apk",
+        "version": "9.18.27-r1"
       },
       {
         "architecture": "x86_64",
@@ -622,60 +622,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1fr0OtiVaD3c5nw8fy5m74hDe9PU=",
+        "checksum": "Q1BRGmQ9LZTeZqbxQ1ls69T6efViw=",
         "control": {
-          "checksum": "sha1-fr0OtiVaD3c5nw8fy5m74hDe9PU=",
-          "range": "bytes=697-1092"
+          "checksum": "sha1-BRGmQ9LZTeZqbxQ1ls69T6efViw=",
+          "range": "bytes=698-1080"
         },
         "data": {
-          "checksum": "sha256-lukjMYpGmuhBNDUbbTJMIrUWaR4rNikEnW4BgiTaLj8=",
-          "range": "bytes=1093-113872"
+          "checksum": "sha256-vtJ4WJ5M+31ZKSBYBedbrl/FrbAw8hGpPRrHC7kasOk=",
+          "range": "bytes=1081-113895"
         },
         "name": "libpsl",
         "signature": {
-          "checksum": "sha1-Lrrudgn1i1a0JhjdzeXG+exnjQA=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-DuAoiykwhu8vu1qxdEDK5oyAmf8=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libpsl-0.21.5-r2.apk",
-        "version": "0.21.5-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libpsl-0.21.5-r3.apk",
+        "version": "0.21.5-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1oauHQa0YcFcEHSQWdfohfNEN4sY=",
+        "checksum": "Q11DZVpe2UYyDr/dG6BDysZhE3L48=",
         "control": {
-          "checksum": "sha1-oauHQa0YcFcEHSQWdfohfNEN4sY=",
-          "range": "bytes=698-1057"
+          "checksum": "sha1-1DZVpe2UYyDr/dG6BDysZhE3L48=",
+          "range": "bytes=707-1049"
         },
         "data": {
-          "checksum": "sha256-d95c9lpjQrpuZ1CcQ8ZZ89LAGGKcessd+hxrOQpP4LU=",
-          "range": "bytes=1058-173549"
+          "checksum": "sha256-aECfsy7giZsLNxZM0HMeF4OS2gu+ycX4DUTJXsiZRQs=",
+          "range": "bytes=1050-173585"
         },
         "name": "libbrotlicommon1",
         "signature": {
-          "checksum": "sha1-g3ufBq/tyiNP6AaOoqwItVvh7uk=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-7LXD38QwFhklZCEqyW4qIncfZV0=",
+          "range": "bytes=0-706"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlicommon1-1.1.0-r2.apk",
-        "version": "1.1.0-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlicommon1-1.1.0-r3.apk",
+        "version": "1.1.0-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q18Otq7NLoYnNMebI/1Rr/s0zdLVw=",
+        "checksum": "Q1Cgr886A8Ryzynz9pxRKsNybVuK0=",
         "control": {
-          "checksum": "sha1-8Otq7NLoYnNMebI/1Rr/s0zdLVw=",
-          "range": "bytes=705-1072"
+          "checksum": "sha1-Cgr886A8Ryzynz9pxRKsNybVuK0=",
+          "range": "bytes=694-1043"
         },
         "data": {
-          "checksum": "sha256-sR3QidR/e46PJ/3S2fxAjN/hRSSA3Ar32Nw7VshTHWg=",
-          "range": "bytes=1073-81475"
+          "checksum": "sha256-mH+MTbqpLiqgydlgE+tSDEt0Sh1/zqMvAqspV4lr+Ks=",
+          "range": "bytes=1044-81511"
         },
         "name": "libbrotlidec1",
         "signature": {
-          "checksum": "sha1-6GpZI5cBUXOvjCYG81aZZR53lMI=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-Yp4Bde9oHQCec8HM2qn6hVKgtko=",
+          "range": "bytes=0-693"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlidec1-1.1.0-r2.apk",
-        "version": "1.1.0-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlidec1-1.1.0-r3.apk",
+        "version": "1.1.0-r3"
       },
       {
         "architecture": "x86_64",
@@ -736,41 +736,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1uIKbAiTl7xWbpJXy11+HeOS/RDo=",
+        "checksum": "Q1+FlR1zI7qp3uiJm5fHTA4Hr1lSQ=",
         "control": {
-          "checksum": "sha1-uIKbAiTl7xWbpJXy11+HeOS/RDo=",
-          "range": "bytes=694-1075"
+          "checksum": "sha1-+FlR1zI7qp3uiJm5fHTA4Hr1lSQ=",
+          "range": "bytes=698-1064"
         },
         "data": {
-          "checksum": "sha256-qUT47e+MUydc5TG+6YjAi7LyDOWQeOyP5dlfnPBWRWM=",
-          "range": "bytes=1076-697425"
+          "checksum": "sha256-jx/MzLqQnCOtZqAiH6LmBTCiTD9HId1TLO3GZFDqHxQ=",
+          "range": "bytes=1065-685148"
         },
         "name": "libpcre2-8-0",
         "signature": {
-          "checksum": "sha1-T6Z2q5sW3pwjztCXPRoQKi8rfeY=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-4ZNzjpofU2aV2PzFb9SFo9ipHLE=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libpcre2-8-0-10.43-r1.apk",
-        "version": "10.43-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libpcre2-8-0-10.44-r1.apk",
+        "version": "10.44-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q111Aq+tDFOygcfZzOg1hQbtZw1Q4=",
+        "checksum": "Q1Xg04pU313NQ+1ni/3EGFESveG28=",
         "control": {
-          "checksum": "sha1-11Aq+tDFOygcfZzOg1hQbtZw1Q4=",
-          "range": "bytes=697-1140"
+          "checksum": "sha1-Xg04pU313NQ+1ni/3EGFESveG28=",
+          "range": "bytes=694-1135"
         },
         "data": {
-          "checksum": "sha256-ednk20seorMQ+xEGnt8zWpxO20xrfj7zOtAmk+XcTbA=",
-          "range": "bytes=1141-17250210"
+          "checksum": "sha256-rgB0/iCkskRu0z50yJPj5UbCkDqeT48PaLInXkivQh4=",
+          "range": "bytes=1136-17250228"
         },
         "name": "git",
         "signature": {
-          "checksum": "sha1-T1C3/QmQvuJGLjPH2YyOLIM5ewE=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-oiYirHB8Oqxgza8ivbRUYOy39i8=",
+          "range": "bytes=0-693"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/git-2.45.2-r0.apk",
-        "version": "2.45.2-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/git-2.45.2-r2.apk",
+        "version": "2.45.2-r2"
       },
       {
         "architecture": "x86_64",
@@ -812,22 +812,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q19f/3419Xa/xv9jgQ0mMYs011fBk=",
+        "checksum": "Q1mTmy64gKYi4THBqewuvYL2uUyHc=",
         "control": {
-          "checksum": "sha1-9f/3419Xa/xv9jgQ0mMYs011fBk=",
-          "range": "bytes=696-1041"
+          "checksum": "sha1-mTmy64gKYi4THBqewuvYL2uUyHc=",
+          "range": "bytes=700-1031"
         },
         "data": {
-          "checksum": "sha256-iqHASiMgiu6rIjbWGwBmmq1Zthae8BkE4QZkiVPH7Ek=",
-          "range": "bytes=1042-1888945"
+          "checksum": "sha256-p0qua2luH33oAgOcLkU9f7k+I8WnykFszVMwNahujDA=",
+          "range": "bytes=1032-1889523"
         },
         "name": "tzdata",
         "signature": {
-          "checksum": "sha1-PCC3jiXlTwrimRMXH/4RyNvccOM=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-sBf5jVLVpWj4DiXaAd/mjo0pTfk=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/tzdata-2024a-r2.apk",
-        "version": "2024a-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/tzdata-2024a-r3.apk",
+        "version": "2024a-r3"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/blobstore.lock.json
+++ b/wolfi-images/blobstore.lock.json
@@ -14,41 +14,41 @@
     "packages": [
       {
         "architecture": "x86_64",
-        "checksum": "Q1ge3SLQsJ9v2RnvIHHAP1yFyjrEU=",
+        "checksum": "Q1Ai8jWuxKZR2M2XhOpOGAoTEwnnk=",
         "control": {
-          "checksum": "sha1-ge3SLQsJ9v2RnvIHHAP1yFyjrEU=",
-          "range": "bytes=693-1040"
+          "checksum": "sha1-Ai8jWuxKZR2M2XhOpOGAoTEwnnk=",
+          "range": "bytes=705-1037"
         },
         "data": {
-          "checksum": "sha256-I0AdTdfGf4P/jwzTrLXm73l5/RNSlymEof/YZfev3xY=",
-          "range": "bytes=1041-255811"
+          "checksum": "sha256-e4UardkBVyaC49aSyrVmXNi8sSKqQl4eKYd0LxGRLA0=",
+          "range": "bytes=1038-255695"
         },
         "name": "ca-certificates-bundle",
         "signature": {
-          "checksum": "sha1-ge1eJBiQmFWAn9GapFkQpO+Rn/Y=",
-          "range": "bytes=0-692"
+          "checksum": "sha1-loRuyYQLm+atp+YteiQoj++EWIM=",
+          "range": "bytes=0-704"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20240315-r3.apk",
-        "version": "20240315-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20240315-r4.apk",
+        "version": "20240315-r4"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1bgay5kOzpmDBgqJCg7dSlawyJg0=",
+        "checksum": "Q1+GH6qRN4iy1IDt0cT0x0tin7YfI=",
         "control": {
-          "checksum": "sha1-bgay5kOzpmDBgqJCg7dSlawyJg0=",
-          "range": "bytes=703-1067"
+          "checksum": "sha1-+GH6qRN4iy1IDt0cT0x0tin7YfI=",
+          "range": "bytes=703-1051"
         },
         "data": {
-          "checksum": "sha256-f83HfRE7r2ZniH7PyPmRqcoU5NTpF+Uk4FH80QbjvBM=",
-          "range": "bytes=1068-118370"
+          "checksum": "sha256-rO0P9z2V49BSrz1A5Ap69tEappVrg5MMBjzW00rOpZc=",
+          "range": "bytes=1052-122464"
         },
         "name": "wolfi-baselayout",
         "signature": {
-          "checksum": "sha1-2hlCvYH1D7u25HkJGA75jjs/sQY=",
+          "checksum": "sha1-Ntb6VuMzDfM+frpCjKEIpDzl53I=",
           "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r11.apk",
-        "version": "20230201-r11"
+        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r12.apk",
+        "version": "20230201-r12"
       },
       {
         "architecture": "x86_64",
@@ -109,41 +109,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Zjfs1uR/mYiortANP+EFcejW+vo=",
+        "checksum": "Q1Zi0e8Bq6WCd/6uXXjVhb8YwMD1U=",
         "control": {
-          "checksum": "sha1-Zjfs1uR/mYiortANP+EFcejW+vo=",
-          "range": "bytes=698-1085"
+          "checksum": "sha1-Zi0e8Bq6WCd/6uXXjVhb8YwMD1U=",
+          "range": "bytes=700-1073"
         },
         "data": {
-          "checksum": "sha256-BMd7TzffjbrFwdbopDPVYsX0X9XnusIMNbIf33/8kwc=",
-          "range": "bytes=1086-76881"
+          "checksum": "sha256-jMhtfqVjnhuuBO7wtNZ6RS/72sZWoKt/Moage2amlks=",
+          "range": "bytes=1074-81594"
         },
         "name": "protobuf-c",
         "signature": {
-          "checksum": "sha1-efGiXyYWsJ5P2uTkB6aXEZ3kl3o=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-kATwMKztK7nk7qbYCJPkCFp6IXc=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r4.apk",
-        "version": "1.5.0-r4"
-      },
-      {
-        "architecture": "x86_64",
-        "checksum": "Q1Xf5v5uXumBgIR4d4ZxMRxdpyWlM=",
-        "control": {
-          "checksum": "sha1-Xf5v5uXumBgIR4d4ZxMRxdpyWlM=",
-          "range": "bytes=698-1078"
-        },
-        "data": {
-          "checksum": "sha256-eD7HqFCWNUBQiLq9PcWE/zPeZwkiv8hBrytI4qmfQ/8=",
-          "range": "bytes=1079-57055"
-        },
-        "name": "keyutils-libs",
-        "signature": {
-          "checksum": "sha1-V0HVgZLP7P5kNACfus3abCLCS20=",
-          "range": "bytes=0-697"
-        },
-        "url": "https://packages.wolfi.dev/os/x86_64/keyutils-libs-1.6.3-r2.apk",
-        "version": "1.6.3-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r5.apk",
+        "version": "1.5.0-r5"
       },
       {
         "architecture": "x86_64",
@@ -166,22 +147,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1wRzOx+L6MeRFtTcq2y/6ot7Cj54=",
+        "checksum": "Q1v0A2vQM5k8rQY/GpIq6xI4T0YmA=",
         "control": {
-          "checksum": "sha1-wRzOx+L6MeRFtTcq2y/6ot7Cj54=",
-          "range": "bytes=699-1069"
+          "checksum": "sha1-v0A2vQM5k8rQY/GpIq6xI4T0YmA=",
+          "range": "bytes=701-1064"
         },
         "data": {
-          "checksum": "sha256-gNRjwZ4XQatCYWediSVb+j8lS54CggvMC5Dn3qT84So=",
-          "range": "bytes=1070-61490"
+          "checksum": "sha256-uAOrkGDDc/yqt6VjIrlTEALBJG4BCI4njqZw5jQqF0o=",
+          "range": "bytes=1065-56984"
+        },
+        "name": "keyutils-libs",
+        "signature": {
+          "checksum": "sha1-32uYMH/zGBr9Jo3hiqnThlcqBcE=",
+          "range": "bytes=0-700"
+        },
+        "url": "https://packages.wolfi.dev/os/x86_64/keyutils-libs-1.6.3-r3.apk",
+        "version": "1.6.3-r3"
+      },
+      {
+        "architecture": "x86_64",
+        "checksum": "Q1Onuac6Y+IWA7a4b8FvqX1erWDDw=",
+        "control": {
+          "checksum": "sha1-Onuac6Y+IWA7a4b8FvqX1erWDDw=",
+          "range": "bytes=693-1048"
+        },
+        "data": {
+          "checksum": "sha256-KLtDAs3iU0oyZ/FysePG/J+1H1ofDxHXIY7xvtZhtMc=",
+          "range": "bytes=1049-61503"
         },
         "name": "libverto",
         "signature": {
-          "checksum": "sha1-kuPwakYdy5EM6sd5Ba0K0Ta8x4w=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-/IXL9S1O+MwaW7KsSzz1ywEqKFQ=",
+          "range": "bytes=0-692"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libverto-0.3.2-r3.apk",
-        "version": "0.3.2-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/libverto-0.3.2-r4.apk",
+        "version": "0.3.2-r4"
       },
       {
         "architecture": "x86_64",
@@ -204,60 +204,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1gTZGkWP+QO3mUqLVJth8vrDEzzU=",
+        "checksum": "Q1Q/Zy5ovYSu2p/vVLr6DgVA1e8AQ=",
         "control": {
-          "checksum": "sha1-gTZGkWP+QO3mUqLVJth8vrDEzzU=",
-          "range": "bytes=699-1076"
+          "checksum": "sha1-Q/Zy5ovYSu2p/vVLr6DgVA1e8AQ=",
+          "range": "bytes=699-1062"
         },
         "data": {
-          "checksum": "sha256-/IFXqeKvU0GODNsz1yPIEMcFHgABT+8rbZpSlTLo4e4=",
-          "range": "bytes=1077-5915704"
+          "checksum": "sha256-H3jxsw8ytOeCIR4vq17voSVhdNokXk8C1g075txH6Bs=",
+          "range": "bytes=1063-5903754"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-l1o5ixkyWWqqJE3FOfR0QUemJUA=",
+          "checksum": "sha1-NIl2f5OI/wSZByI8Ds1ZUfbFWyw=",
           "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r9.apk",
-        "version": "3.3.0-r9"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.1-r3.apk",
+        "version": "3.3.1-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1jhAhggAuZnU7FFHnebGA26mq+jI=",
+        "checksum": "Q13wGUXdZut9OOTdY5z2amUj9wXC0=",
         "control": {
-          "checksum": "sha1-jhAhggAuZnU7FFHnebGA26mq+jI=",
-          "range": "bytes=695-1079"
+          "checksum": "sha1-3wGUXdZut9OOTdY5z2amUj9wXC0=",
+          "range": "bytes=698-1068"
         },
         "data": {
-          "checksum": "sha256-XTCQYnhGSm7SkGwqV/TQMFqGajVJVYhKAidKfLb2D3Y=",
-          "range": "bytes=1080-1197081"
+          "checksum": "sha256-mRda6+YGlOCczyIWKaHqXskTINoT1rgorHDHqAKAb7c=",
+          "range": "bytes=1069-1188955"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-qVrfDVxubkrb5Yrd2mFTv2A0G7k=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-+UdRc4U3PKw4H9OiNurHKXa5BYk=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r9.apk",
-        "version": "3.3.0-r9"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.1-r3.apk",
+        "version": "3.3.1-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1BQEXaeya6QB39QLeKcB99qBNF2o=",
+        "checksum": "Q1p04MrHQPrXOzuV/uF290zjnltqI=",
         "control": {
-          "checksum": "sha1-BQEXaeya6QB39QLeKcB99qBNF2o=",
-          "range": "bytes=699-1229"
+          "checksum": "sha1-p04MrHQPrXOzuV/uF290zjnltqI=",
+          "range": "bytes=704-1219"
         },
         "data": {
-          "checksum": "sha256-ugj/qGEBzhvdX17S22Anry+biy3lcqywhGMSHLIBCvo=",
-          "range": "bytes=1230-2551676"
+          "checksum": "sha256-TsXeqhUGykAhjQUEAlMUSzDQBcWDkkDvReoeHCL1F6c=",
+          "range": "bytes=1220-2555814"
         },
         "name": "krb5-libs",
         "signature": {
-          "checksum": "sha1-oqDPmNM4EngXAGayd/BZOqJAIao=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-cPyzS38QHuNlOCQb8IPlsl2PLHQ=",
+          "range": "bytes=0-703"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/krb5-libs-1.21.2-r2.apk",
-        "version": "1.21.2-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/krb5-libs-1.21.3-r0.apk",
+        "version": "1.21.3-r0"
       },
       {
         "architecture": "x86_64",
@@ -280,60 +280,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1wzZwtLauOQfLQC7YUvZdfKxtlwQ=",
+        "checksum": "Q17uprcuQ2VFudMcWAwtP7miJmLYs=",
         "control": {
-          "checksum": "sha1-wzZwtLauOQfLQC7YUvZdfKxtlwQ=",
-          "range": "bytes=698-1085"
+          "checksum": "sha1-7uprcuQ2VFudMcWAwtP7miJmLYs=",
+          "range": "bytes=695-1067"
         },
         "data": {
-          "checksum": "sha256-TO8CAULO44s/LphhtcaFOGJB7aFldk13v1cV9ceZHww=",
-          "range": "bytes=1086-276837"
+          "checksum": "sha256-unKdPbvO2VHZ5w1t1l8mOpQuNdUGwLhofEO4weN2Mig=",
+          "range": "bytes=1068-280973"
         },
         "name": "libuv",
         "signature": {
-          "checksum": "sha1-LRiyeKmjexy8CJizLxjd6ikon1w=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-4lKldnTO71WHMZ4tbANz6i2/Ed0=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libuv-1.48.0-r2.apk",
-        "version": "1.48.0-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libuv-1.48.0-r3.apk",
+        "version": "1.48.0-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q14S6biy8fc5OGbGEJoLBM+tJOGyo=",
+        "checksum": "Q1CN6zJbOPznWUfTrb/41KT7E6dm8=",
         "control": {
-          "checksum": "sha1-4S6biy8fc5OGbGEJoLBM+tJOGyo=",
-          "range": "bytes=703-1102"
+          "checksum": "sha1-CN6zJbOPznWUfTrb/41KT7E6dm8=",
+          "range": "bytes=699-1083"
         },
         "data": {
-          "checksum": "sha256-hwjdLQYfuMAGQeONmFVo0lZKKQK1S+3PBhrI3upm5W4=",
-          "range": "bytes=1103-155304"
+          "checksum": "sha256-ybzFzoQh1yNTcd3cjt54nYsPlAxAcMUcVMxEv1JRnpQ=",
+          "range": "bytes=1084-155375"
         },
         "name": "zlib",
         "signature": {
-          "checksum": "sha1-ZuLd7kE+AGhn27o8ZqDGM5eundc=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-CPXJcCjinAXP+H8Z5tkko8ayG6E=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/zlib-1.3.1-r2.apk",
-        "version": "1.3.1-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/zlib-1.3.1-r3.apk",
+        "version": "1.3.1-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ykDkP+AmDi2VcZZ1c4q4sez/DxI=",
+        "checksum": "Q1rgbci8SRSjW7EB0NSh6ZUPJLndM=",
         "control": {
-          "checksum": "sha1-ykDkP+AmDi2VcZZ1c4q4sez/DxI=",
-          "range": "bytes=705-1079"
+          "checksum": "sha1-rgbci8SRSjW7EB0NSh6ZUPJLndM=",
+          "range": "bytes=702-1060"
         },
         "data": {
-          "checksum": "sha256-t3BrH7lWfY3to3Fu3EKAMZx29v9Hnl5seyXJzLmZ9/4=",
-          "range": "bytes=1080-251884"
+          "checksum": "sha256-tf4xbo+NP+ssiaZtC1kOKehffAZ3+d17bhgfU3/30+g=",
+          "range": "bytes=1061-256582"
         },
         "name": "libnghttp2-14",
         "signature": {
-          "checksum": "sha1-CotSXRaPLKQCBRHrgzrDOD+4w20=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-KrsJYTyUsll+EUhHekbkdZFzeig=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.62.1-r0.apk",
-        "version": "1.62.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.62.1-r1.apk",
+        "version": "1.62.1-r1"
       },
       {
         "architecture": "x86_64",
@@ -394,136 +394,136 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1DE49kWSnmqVKJdjHFYC1bLkvyb0=",
+        "checksum": "Q1R8OxpY0fGwVaIwft4wJeswF5D54=",
         "control": {
-          "checksum": "sha1-DE49kWSnmqVKJdjHFYC1bLkvyb0=",
-          "range": "bytes=697-1078"
+          "checksum": "sha1-R8OxpY0fGwVaIwft4wJeswF5D54=",
+          "range": "bytes=695-1059"
         },
         "data": {
-          "checksum": "sha256-uDg8Qc6Rnro/68Vb5ufFSkqFLGrEsbvPb0pMJNvT1zw=",
-          "range": "bytes=1079-242085"
+          "checksum": "sha256-wNc8/SBJrGHfwywAtzCsAqeUOt0IaAhqNtlbv8OiHBE=",
+          "range": "bytes=1060-242151"
         },
         "name": "c-ares",
         "signature": {
-          "checksum": "sha1-iYEm6EWQKzxkeoDm+QsRfhw8pDg=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-55/PTlEHXI3o0hx9dSVdNwQeSMg=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.29.0-r0.apk",
-        "version": "1.29.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.31.0-r0.apk",
+        "version": "1.31.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q12eWmn2tCkXxwncU6gagKM3Wd9Sk=",
+        "checksum": "Q1g2RQKAvNjlRPxWjinIRveaq7IlY=",
         "control": {
-          "checksum": "sha1-2eWmn2tCkXxwncU6gagKM3Wd9Sk=",
-          "range": "bytes=696-1169"
+          "checksum": "sha1-g2RQKAvNjlRPxWjinIRveaq7IlY=",
+          "range": "bytes=695-1154"
         },
         "data": {
-          "checksum": "sha256-IFKNdojOhml3DbWPryQuHUiV3tgTWHyqOYD1JNe9IJ4=",
-          "range": "bytes=1170-2582015"
+          "checksum": "sha256-UsQFfOTXCZBan0mxDvR+ts0NKcbv1lNijxnRxjsmZhA=",
+          "range": "bytes=1155-2566233"
         },
         "name": "nghttp2",
         "signature": {
-          "checksum": "sha1-2/9n7KbRuOkrvhYqCFR5Mblx+z8=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-SUvMhz1cc5Or5Qh4fUEvPCp0NAw=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.62.1-r0.apk",
-        "version": "1.62.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.62.1-r1.apk",
+        "version": "1.62.1-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ialksjwPWvvZW+O2ABMbbBV/KTg=",
+        "checksum": "Q1sTMGOgdbZyDKxlRAByisPMHTbpY=",
         "control": {
-          "checksum": "sha1-ialksjwPWvvZW+O2ABMbbBV/KTg=",
-          "range": "bytes=702-1074"
+          "checksum": "sha1-sTMGOgdbZyDKxlRAByisPMHTbpY=",
+          "range": "bytes=703-1060"
         },
         "data": {
-          "checksum": "sha256-+ctDr3AO9mTXovGRPWk6h2ZgfY99Toy6esjBNHtJPY4=",
-          "range": "bytes=1075-631903"
+          "checksum": "sha256-bUy0h/zxpq7iP6vrQRMftZ9nevkHTB87hSX17wz4lmM=",
+          "range": "bytes=1061-631449"
         },
         "name": "nghttp2-dev",
         "signature": {
-          "checksum": "sha1-wZGQRluFd6DL1USzeak75o5/BTc=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-fQ6aDq3Io/gdJ5s5t3M+FwED1Y0=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.62.1-r0.apk",
-        "version": "1.62.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.62.1-r1.apk",
+        "version": "1.62.1-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1MlpRL1nBMU3RgNdSZVB42/vlGME=",
+        "checksum": "Q1rD3dEbbN8s5QAIQK1I8uF1O+oSo=",
         "control": {
-          "checksum": "sha1-MlpRL1nBMU3RgNdSZVB42/vlGME=",
-          "range": "bytes=697-1164"
+          "checksum": "sha1-rD3dEbbN8s5QAIQK1I8uF1O+oSo=",
+          "range": "bytes=701-1154"
         },
         "data": {
-          "checksum": "sha256-RiEPDasBVtnThSxGqTCDvb4J7WXM9YRpJwfYZJ3JLbs=",
-          "range": "bytes=1165-2274746"
+          "checksum": "sha256-41W2IRSRALQijYojLaqAiSSN1uO7twatGn8jqEuCZUg=",
+          "range": "bytes=1155-1439872"
         },
         "name": "xz",
         "signature": {
-          "checksum": "sha1-3wMPFIUEVfkAs7QSENemZsnTLyE=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-lozWkVrKvSrd1SoM7Zv08YYG2pA=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/xz-5.4.6-r2.apk",
-        "version": "5.4.6-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/xz-5.6.2-r0.apk",
+        "version": "5.6.2-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1TS707T+cPGL7TYVHQBCJoWwHZ0E=",
+        "checksum": "Q10AaU1ocIM4PYYNvwbml8TmpNvEA=",
         "control": {
-          "checksum": "sha1-TS707T+cPGL7TYVHQBCJoWwHZ0E=",
-          "range": "bytes=706-1098"
+          "checksum": "sha1-0AaU1ocIM4PYYNvwbml8TmpNvEA=",
+          "range": "bytes=706-1085"
         },
         "data": {
-          "checksum": "sha256-x18L706Vug5qDzq13SXuN/vGdVgzrqB06dW2DdgHGR4=",
-          "range": "bytes=1099-4541967"
+          "checksum": "sha256-1YQNYASFjlP3kXX58ec8du75ij/U6O4DPAKzJAPkln0=",
+          "range": "bytes=1086-4272589"
         },
         "name": "libxml2",
         "signature": {
-          "checksum": "sha1-BYhOxDos48sN8df8LMsSpROv2aw=",
+          "checksum": "sha1-QFjdplzGn/MiNFxMykgafr6/w6U=",
           "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.12.7-r0.apk",
-        "version": "2.12.7-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.1-r1.apk",
+        "version": "2.13.1-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1wJPtj5XZtnPiVWGM5dsT+nyfWXc=",
+        "checksum": "Q1wbnfumlWEiJnVUsJBRcQjFD3U6I=",
         "control": {
-          "checksum": "sha1-wJPtj5XZtnPiVWGM5dsT+nyfWXc=",
-          "range": "bytes=705-1234"
+          "checksum": "sha1-wbnfumlWEiJnVUsJBRcQjFD3U6I=",
+          "range": "bytes=699-1222"
         },
         "data": {
-          "checksum": "sha256-sw+CjlpsjO01q6lqzXgHnniiJKn7bqOSNO6vNqdGc7I=",
-          "range": "bytes=1235-3873775"
+          "checksum": "sha256-IXMNbJjj3kTjkWVBIHVRfG3zJQY2r5Eslgh/3TpMSsE=",
+          "range": "bytes=1223-3886778"
         },
         "name": "bind-libs",
         "signature": {
-          "checksum": "sha1-9zDzmHAeu7mWpidXAatqrLZVzUs=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-JNN15IPpJ2hMsO6hFVpDYPvvX5g=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bind-libs-9.18.26-r0.apk",
-        "version": "9.18.26-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/bind-libs-9.18.27-r1.apk",
+        "version": "9.18.27-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1AxEQdi8fVcYtGc3zHTCW3OZdY2Q=",
+        "checksum": "Q1kXUOoNa2KXixxAASo1W/im1qZ7s=",
         "control": {
-          "checksum": "sha1-AxEQdi8fVcYtGc3zHTCW3OZdY2Q=",
-          "range": "bytes=694-1208"
+          "checksum": "sha1-kXUOoNa2KXixxAASo1W/im1qZ7s=",
+          "range": "bytes=702-1215"
         },
         "data": {
-          "checksum": "sha256-/dt3qJw5D9iSJ/mKkRQkhWD8R52selhpcwXyw7KLMhg=",
-          "range": "bytes=1209-879444"
+          "checksum": "sha256-HRADvfRXfYsgEjUMGM4Hd7prpIv+YWILVfovbGOkEME=",
+          "range": "bytes=1216-879975"
         },
         "name": "bind-tools",
         "signature": {
-          "checksum": "sha1-VTb0YdUzPMk8Po0p4nj0y5Jey6k=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-8WUTMUaJTaX0T9FS/c+GddL7ttY=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bind-tools-9.18.26-r0.apk",
-        "version": "9.18.26-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/bind-tools-9.18.27-r1.apk",
+        "version": "9.18.27-r1"
       },
       {
         "architecture": "x86_64",
@@ -622,60 +622,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1fr0OtiVaD3c5nw8fy5m74hDe9PU=",
+        "checksum": "Q1BRGmQ9LZTeZqbxQ1ls69T6efViw=",
         "control": {
-          "checksum": "sha1-fr0OtiVaD3c5nw8fy5m74hDe9PU=",
-          "range": "bytes=697-1092"
+          "checksum": "sha1-BRGmQ9LZTeZqbxQ1ls69T6efViw=",
+          "range": "bytes=698-1080"
         },
         "data": {
-          "checksum": "sha256-lukjMYpGmuhBNDUbbTJMIrUWaR4rNikEnW4BgiTaLj8=",
-          "range": "bytes=1093-113872"
+          "checksum": "sha256-vtJ4WJ5M+31ZKSBYBedbrl/FrbAw8hGpPRrHC7kasOk=",
+          "range": "bytes=1081-113895"
         },
         "name": "libpsl",
         "signature": {
-          "checksum": "sha1-Lrrudgn1i1a0JhjdzeXG+exnjQA=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-DuAoiykwhu8vu1qxdEDK5oyAmf8=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libpsl-0.21.5-r2.apk",
-        "version": "0.21.5-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libpsl-0.21.5-r3.apk",
+        "version": "0.21.5-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1oauHQa0YcFcEHSQWdfohfNEN4sY=",
+        "checksum": "Q11DZVpe2UYyDr/dG6BDysZhE3L48=",
         "control": {
-          "checksum": "sha1-oauHQa0YcFcEHSQWdfohfNEN4sY=",
-          "range": "bytes=698-1057"
+          "checksum": "sha1-1DZVpe2UYyDr/dG6BDysZhE3L48=",
+          "range": "bytes=707-1049"
         },
         "data": {
-          "checksum": "sha256-d95c9lpjQrpuZ1CcQ8ZZ89LAGGKcessd+hxrOQpP4LU=",
-          "range": "bytes=1058-173549"
+          "checksum": "sha256-aECfsy7giZsLNxZM0HMeF4OS2gu+ycX4DUTJXsiZRQs=",
+          "range": "bytes=1050-173585"
         },
         "name": "libbrotlicommon1",
         "signature": {
-          "checksum": "sha1-g3ufBq/tyiNP6AaOoqwItVvh7uk=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-7LXD38QwFhklZCEqyW4qIncfZV0=",
+          "range": "bytes=0-706"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlicommon1-1.1.0-r2.apk",
-        "version": "1.1.0-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlicommon1-1.1.0-r3.apk",
+        "version": "1.1.0-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q18Otq7NLoYnNMebI/1Rr/s0zdLVw=",
+        "checksum": "Q1Cgr886A8Ryzynz9pxRKsNybVuK0=",
         "control": {
-          "checksum": "sha1-8Otq7NLoYnNMebI/1Rr/s0zdLVw=",
-          "range": "bytes=705-1072"
+          "checksum": "sha1-Cgr886A8Ryzynz9pxRKsNybVuK0=",
+          "range": "bytes=694-1043"
         },
         "data": {
-          "checksum": "sha256-sR3QidR/e46PJ/3S2fxAjN/hRSSA3Ar32Nw7VshTHWg=",
-          "range": "bytes=1073-81475"
+          "checksum": "sha256-mH+MTbqpLiqgydlgE+tSDEt0Sh1/zqMvAqspV4lr+Ks=",
+          "range": "bytes=1044-81511"
         },
         "name": "libbrotlidec1",
         "signature": {
-          "checksum": "sha1-6GpZI5cBUXOvjCYG81aZZR53lMI=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-Yp4Bde9oHQCec8HM2qn6hVKgtko=",
+          "range": "bytes=0-693"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlidec1-1.1.0-r2.apk",
-        "version": "1.1.0-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlidec1-1.1.0-r3.apk",
+        "version": "1.1.0-r3"
       },
       {
         "architecture": "x86_64",
@@ -774,22 +774,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1EeC4oJcNGILol2exjVmAmCeKe3Y=",
+        "checksum": "Q1G/AwDwdfNwNdSm/t6Sqght8DOpI=",
         "control": {
-          "checksum": "sha1-EeC4oJcNGILol2exjVmAmCeKe3Y=",
-          "range": "bytes=698-1076"
+          "checksum": "sha1-G/AwDwdfNwNdSm/t6Sqght8DOpI=",
+          "range": "bytes=696-1061"
         },
         "data": {
-          "checksum": "sha256-jG5+Qk19KNjypflTSwO2gF+f/zqWbtjjhuzSO3maxf8=",
-          "range": "bytes=1077-109053"
+          "checksum": "sha256-5ypXRnqcv42v+Xt59TOt/lTM3huvyCrCDpeER423auk=",
+          "range": "bytes=1062-113624"
         },
         "name": "libbz2-1",
         "signature": {
-          "checksum": "sha1-800rFtecn2FKQ9uM95GkfwOMvnQ=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-riGFRNbF0tAWYE9PlBEuTbcGkTQ=",
+          "range": "bytes=0-695"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libbz2-1-1.0.8-r7.apk",
-        "version": "1.0.8-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libbz2-1-1.0.8-r8.apk",
+        "version": "1.0.8-r8"
       },
       {
         "architecture": "x86_64",
@@ -907,22 +907,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1sBp15UoB9iDd/xOOx13CSHRTZnA=",
+        "checksum": "Q1b1fkDQZR7BtOZFyaQCnquuKyU8c=",
         "control": {
-          "checksum": "sha1-sBp15UoB9iDd/xOOx13CSHRTZnA=",
-          "range": "bytes=695-1072"
+          "checksum": "sha1-b1fkDQZR7BtOZFyaQCnquuKyU8c=",
+          "range": "bytes=697-1059"
         },
         "data": {
-          "checksum": "sha256-pSuWnCmt6INeWQul5MdUqxgoJ5B7FTEtCfyvg5H+WrA=",
-          "range": "bytes=1073-84740"
+          "checksum": "sha256-g6aBpzXAR79pmyFfBOmkTYKPEVMdAYC7akIKD6h6mHM=",
+          "range": "bytes=1060-84760"
         },
         "name": "libffi",
         "signature": {
-          "checksum": "sha1-kabxjRZlgSfO5ocH7PkbBtqFyus=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-xik2kwwu8Ryo+2igE3vEQ430rP0=",
+          "range": "bytes=0-696"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libffi-3.4.6-r2.apk",
-        "version": "3.4.6-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libffi-3.4.6-r3.apk",
+        "version": "3.4.6-r3"
       },
       {
         "architecture": "x86_64",
@@ -964,22 +964,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1FaSuo5kLpGzOlCXAmVtdoeTE9KY=",
+        "checksum": "Q1fnaWc3899x9dK4z4iTFNOeM6MI0=",
         "control": {
-          "checksum": "sha1-FaSuo5kLpGzOlCXAmVtdoeTE9KY=",
-          "range": "bytes=699-1146"
+          "checksum": "sha1-fnaWc3899x9dK4z4iTFNOeM6MI0=",
+          "range": "bytes=702-1132"
         },
         "data": {
-          "checksum": "sha256-yT+SLCTF2RGijQmytiBOuD/ZmYIeILT21+D12xRVzrQ=",
-          "range": "bytes=1147-373555"
+          "checksum": "sha256-rhtsl8eIgOKIHSa3VsedIEj1sA3xRi83jc3fhTjIQLw=",
+          "range": "bytes=1133-377535"
         },
         "name": "ca-certificates",
         "signature": {
-          "checksum": "sha1-AKpkACT5QAimOprekpt14cLs7Pw=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-I1wWFlIzyXu0g5mcgMo/iyW3Mhw=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-20240315-r3.apk",
-        "version": "20240315-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-20240315-r4.apk",
+        "version": "20240315-r4"
       },
       {
         "architecture": "x86_64",
@@ -1116,22 +1116,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q19f/3419Xa/xv9jgQ0mMYs011fBk=",
+        "checksum": "Q1mTmy64gKYi4THBqewuvYL2uUyHc=",
         "control": {
-          "checksum": "sha1-9f/3419Xa/xv9jgQ0mMYs011fBk=",
-          "range": "bytes=696-1041"
+          "checksum": "sha1-mTmy64gKYi4THBqewuvYL2uUyHc=",
+          "range": "bytes=700-1031"
         },
         "data": {
-          "checksum": "sha256-iqHASiMgiu6rIjbWGwBmmq1Zthae8BkE4QZkiVPH7Ek=",
-          "range": "bytes=1042-1888945"
+          "checksum": "sha256-p0qua2luH33oAgOcLkU9f7k+I8WnykFszVMwNahujDA=",
+          "range": "bytes=1032-1889523"
         },
         "name": "tzdata",
         "signature": {
-          "checksum": "sha1-PCC3jiXlTwrimRMXH/4RyNvccOM=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-sBf5jVLVpWj4DiXaAd/mjo0pTfk=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/tzdata-2024a-r2.apk",
-        "version": "2024a-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/tzdata-2024a-r3.apk",
+        "version": "2024a-r3"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/bundled-executor.lock.json
+++ b/wolfi-images/bundled-executor.lock.json
@@ -14,41 +14,41 @@
     "packages": [
       {
         "architecture": "x86_64",
-        "checksum": "Q1ge3SLQsJ9v2RnvIHHAP1yFyjrEU=",
+        "checksum": "Q1Ai8jWuxKZR2M2XhOpOGAoTEwnnk=",
         "control": {
-          "checksum": "sha1-ge3SLQsJ9v2RnvIHHAP1yFyjrEU=",
-          "range": "bytes=693-1040"
+          "checksum": "sha1-Ai8jWuxKZR2M2XhOpOGAoTEwnnk=",
+          "range": "bytes=705-1037"
         },
         "data": {
-          "checksum": "sha256-I0AdTdfGf4P/jwzTrLXm73l5/RNSlymEof/YZfev3xY=",
-          "range": "bytes=1041-255811"
+          "checksum": "sha256-e4UardkBVyaC49aSyrVmXNi8sSKqQl4eKYd0LxGRLA0=",
+          "range": "bytes=1038-255695"
         },
         "name": "ca-certificates-bundle",
         "signature": {
-          "checksum": "sha1-ge1eJBiQmFWAn9GapFkQpO+Rn/Y=",
-          "range": "bytes=0-692"
+          "checksum": "sha1-loRuyYQLm+atp+YteiQoj++EWIM=",
+          "range": "bytes=0-704"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20240315-r3.apk",
-        "version": "20240315-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20240315-r4.apk",
+        "version": "20240315-r4"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1bgay5kOzpmDBgqJCg7dSlawyJg0=",
+        "checksum": "Q1+GH6qRN4iy1IDt0cT0x0tin7YfI=",
         "control": {
-          "checksum": "sha1-bgay5kOzpmDBgqJCg7dSlawyJg0=",
-          "range": "bytes=703-1067"
+          "checksum": "sha1-+GH6qRN4iy1IDt0cT0x0tin7YfI=",
+          "range": "bytes=703-1051"
         },
         "data": {
-          "checksum": "sha256-f83HfRE7r2ZniH7PyPmRqcoU5NTpF+Uk4FH80QbjvBM=",
-          "range": "bytes=1068-118370"
+          "checksum": "sha256-rO0P9z2V49BSrz1A5Ap69tEappVrg5MMBjzW00rOpZc=",
+          "range": "bytes=1052-122464"
         },
         "name": "wolfi-baselayout",
         "signature": {
-          "checksum": "sha1-2hlCvYH1D7u25HkJGA75jjs/sQY=",
+          "checksum": "sha1-Ntb6VuMzDfM+frpCjKEIpDzl53I=",
           "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r11.apk",
-        "version": "20230201-r11"
+        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r12.apk",
+        "version": "20230201-r12"
       },
       {
         "architecture": "x86_64",
@@ -109,41 +109,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Zjfs1uR/mYiortANP+EFcejW+vo=",
+        "checksum": "Q1Zi0e8Bq6WCd/6uXXjVhb8YwMD1U=",
         "control": {
-          "checksum": "sha1-Zjfs1uR/mYiortANP+EFcejW+vo=",
-          "range": "bytes=698-1085"
+          "checksum": "sha1-Zi0e8Bq6WCd/6uXXjVhb8YwMD1U=",
+          "range": "bytes=700-1073"
         },
         "data": {
-          "checksum": "sha256-BMd7TzffjbrFwdbopDPVYsX0X9XnusIMNbIf33/8kwc=",
-          "range": "bytes=1086-76881"
+          "checksum": "sha256-jMhtfqVjnhuuBO7wtNZ6RS/72sZWoKt/Moage2amlks=",
+          "range": "bytes=1074-81594"
         },
         "name": "protobuf-c",
         "signature": {
-          "checksum": "sha1-efGiXyYWsJ5P2uTkB6aXEZ3kl3o=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-kATwMKztK7nk7qbYCJPkCFp6IXc=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r4.apk",
-        "version": "1.5.0-r4"
-      },
-      {
-        "architecture": "x86_64",
-        "checksum": "Q1Xf5v5uXumBgIR4d4ZxMRxdpyWlM=",
-        "control": {
-          "checksum": "sha1-Xf5v5uXumBgIR4d4ZxMRxdpyWlM=",
-          "range": "bytes=698-1078"
-        },
-        "data": {
-          "checksum": "sha256-eD7HqFCWNUBQiLq9PcWE/zPeZwkiv8hBrytI4qmfQ/8=",
-          "range": "bytes=1079-57055"
-        },
-        "name": "keyutils-libs",
-        "signature": {
-          "checksum": "sha1-V0HVgZLP7P5kNACfus3abCLCS20=",
-          "range": "bytes=0-697"
-        },
-        "url": "https://packages.wolfi.dev/os/x86_64/keyutils-libs-1.6.3-r2.apk",
-        "version": "1.6.3-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r5.apk",
+        "version": "1.5.0-r5"
       },
       {
         "architecture": "x86_64",
@@ -166,22 +147,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1wRzOx+L6MeRFtTcq2y/6ot7Cj54=",
+        "checksum": "Q1v0A2vQM5k8rQY/GpIq6xI4T0YmA=",
         "control": {
-          "checksum": "sha1-wRzOx+L6MeRFtTcq2y/6ot7Cj54=",
-          "range": "bytes=699-1069"
+          "checksum": "sha1-v0A2vQM5k8rQY/GpIq6xI4T0YmA=",
+          "range": "bytes=701-1064"
         },
         "data": {
-          "checksum": "sha256-gNRjwZ4XQatCYWediSVb+j8lS54CggvMC5Dn3qT84So=",
-          "range": "bytes=1070-61490"
+          "checksum": "sha256-uAOrkGDDc/yqt6VjIrlTEALBJG4BCI4njqZw5jQqF0o=",
+          "range": "bytes=1065-56984"
+        },
+        "name": "keyutils-libs",
+        "signature": {
+          "checksum": "sha1-32uYMH/zGBr9Jo3hiqnThlcqBcE=",
+          "range": "bytes=0-700"
+        },
+        "url": "https://packages.wolfi.dev/os/x86_64/keyutils-libs-1.6.3-r3.apk",
+        "version": "1.6.3-r3"
+      },
+      {
+        "architecture": "x86_64",
+        "checksum": "Q1Onuac6Y+IWA7a4b8FvqX1erWDDw=",
+        "control": {
+          "checksum": "sha1-Onuac6Y+IWA7a4b8FvqX1erWDDw=",
+          "range": "bytes=693-1048"
+        },
+        "data": {
+          "checksum": "sha256-KLtDAs3iU0oyZ/FysePG/J+1H1ofDxHXIY7xvtZhtMc=",
+          "range": "bytes=1049-61503"
         },
         "name": "libverto",
         "signature": {
-          "checksum": "sha1-kuPwakYdy5EM6sd5Ba0K0Ta8x4w=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-/IXL9S1O+MwaW7KsSzz1ywEqKFQ=",
+          "range": "bytes=0-692"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libverto-0.3.2-r3.apk",
-        "version": "0.3.2-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/libverto-0.3.2-r4.apk",
+        "version": "0.3.2-r4"
       },
       {
         "architecture": "x86_64",
@@ -204,60 +204,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1gTZGkWP+QO3mUqLVJth8vrDEzzU=",
+        "checksum": "Q1Q/Zy5ovYSu2p/vVLr6DgVA1e8AQ=",
         "control": {
-          "checksum": "sha1-gTZGkWP+QO3mUqLVJth8vrDEzzU=",
-          "range": "bytes=699-1076"
+          "checksum": "sha1-Q/Zy5ovYSu2p/vVLr6DgVA1e8AQ=",
+          "range": "bytes=699-1062"
         },
         "data": {
-          "checksum": "sha256-/IFXqeKvU0GODNsz1yPIEMcFHgABT+8rbZpSlTLo4e4=",
-          "range": "bytes=1077-5915704"
+          "checksum": "sha256-H3jxsw8ytOeCIR4vq17voSVhdNokXk8C1g075txH6Bs=",
+          "range": "bytes=1063-5903754"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-l1o5ixkyWWqqJE3FOfR0QUemJUA=",
+          "checksum": "sha1-NIl2f5OI/wSZByI8Ds1ZUfbFWyw=",
           "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r9.apk",
-        "version": "3.3.0-r9"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.1-r3.apk",
+        "version": "3.3.1-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1jhAhggAuZnU7FFHnebGA26mq+jI=",
+        "checksum": "Q13wGUXdZut9OOTdY5z2amUj9wXC0=",
         "control": {
-          "checksum": "sha1-jhAhggAuZnU7FFHnebGA26mq+jI=",
-          "range": "bytes=695-1079"
+          "checksum": "sha1-3wGUXdZut9OOTdY5z2amUj9wXC0=",
+          "range": "bytes=698-1068"
         },
         "data": {
-          "checksum": "sha256-XTCQYnhGSm7SkGwqV/TQMFqGajVJVYhKAidKfLb2D3Y=",
-          "range": "bytes=1080-1197081"
+          "checksum": "sha256-mRda6+YGlOCczyIWKaHqXskTINoT1rgorHDHqAKAb7c=",
+          "range": "bytes=1069-1188955"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-qVrfDVxubkrb5Yrd2mFTv2A0G7k=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-+UdRc4U3PKw4H9OiNurHKXa5BYk=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r9.apk",
-        "version": "3.3.0-r9"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.1-r3.apk",
+        "version": "3.3.1-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1BQEXaeya6QB39QLeKcB99qBNF2o=",
+        "checksum": "Q1p04MrHQPrXOzuV/uF290zjnltqI=",
         "control": {
-          "checksum": "sha1-BQEXaeya6QB39QLeKcB99qBNF2o=",
-          "range": "bytes=699-1229"
+          "checksum": "sha1-p04MrHQPrXOzuV/uF290zjnltqI=",
+          "range": "bytes=704-1219"
         },
         "data": {
-          "checksum": "sha256-ugj/qGEBzhvdX17S22Anry+biy3lcqywhGMSHLIBCvo=",
-          "range": "bytes=1230-2551676"
+          "checksum": "sha256-TsXeqhUGykAhjQUEAlMUSzDQBcWDkkDvReoeHCL1F6c=",
+          "range": "bytes=1220-2555814"
         },
         "name": "krb5-libs",
         "signature": {
-          "checksum": "sha1-oqDPmNM4EngXAGayd/BZOqJAIao=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-cPyzS38QHuNlOCQb8IPlsl2PLHQ=",
+          "range": "bytes=0-703"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/krb5-libs-1.21.2-r2.apk",
-        "version": "1.21.2-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/krb5-libs-1.21.3-r0.apk",
+        "version": "1.21.3-r0"
       },
       {
         "architecture": "x86_64",
@@ -280,60 +280,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1wzZwtLauOQfLQC7YUvZdfKxtlwQ=",
+        "checksum": "Q17uprcuQ2VFudMcWAwtP7miJmLYs=",
         "control": {
-          "checksum": "sha1-wzZwtLauOQfLQC7YUvZdfKxtlwQ=",
-          "range": "bytes=698-1085"
+          "checksum": "sha1-7uprcuQ2VFudMcWAwtP7miJmLYs=",
+          "range": "bytes=695-1067"
         },
         "data": {
-          "checksum": "sha256-TO8CAULO44s/LphhtcaFOGJB7aFldk13v1cV9ceZHww=",
-          "range": "bytes=1086-276837"
+          "checksum": "sha256-unKdPbvO2VHZ5w1t1l8mOpQuNdUGwLhofEO4weN2Mig=",
+          "range": "bytes=1068-280973"
         },
         "name": "libuv",
         "signature": {
-          "checksum": "sha1-LRiyeKmjexy8CJizLxjd6ikon1w=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-4lKldnTO71WHMZ4tbANz6i2/Ed0=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libuv-1.48.0-r2.apk",
-        "version": "1.48.0-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libuv-1.48.0-r3.apk",
+        "version": "1.48.0-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q14S6biy8fc5OGbGEJoLBM+tJOGyo=",
+        "checksum": "Q1CN6zJbOPznWUfTrb/41KT7E6dm8=",
         "control": {
-          "checksum": "sha1-4S6biy8fc5OGbGEJoLBM+tJOGyo=",
-          "range": "bytes=703-1102"
+          "checksum": "sha1-CN6zJbOPznWUfTrb/41KT7E6dm8=",
+          "range": "bytes=699-1083"
         },
         "data": {
-          "checksum": "sha256-hwjdLQYfuMAGQeONmFVo0lZKKQK1S+3PBhrI3upm5W4=",
-          "range": "bytes=1103-155304"
+          "checksum": "sha256-ybzFzoQh1yNTcd3cjt54nYsPlAxAcMUcVMxEv1JRnpQ=",
+          "range": "bytes=1084-155375"
         },
         "name": "zlib",
         "signature": {
-          "checksum": "sha1-ZuLd7kE+AGhn27o8ZqDGM5eundc=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-CPXJcCjinAXP+H8Z5tkko8ayG6E=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/zlib-1.3.1-r2.apk",
-        "version": "1.3.1-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/zlib-1.3.1-r3.apk",
+        "version": "1.3.1-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ykDkP+AmDi2VcZZ1c4q4sez/DxI=",
+        "checksum": "Q1rgbci8SRSjW7EB0NSh6ZUPJLndM=",
         "control": {
-          "checksum": "sha1-ykDkP+AmDi2VcZZ1c4q4sez/DxI=",
-          "range": "bytes=705-1079"
+          "checksum": "sha1-rgbci8SRSjW7EB0NSh6ZUPJLndM=",
+          "range": "bytes=702-1060"
         },
         "data": {
-          "checksum": "sha256-t3BrH7lWfY3to3Fu3EKAMZx29v9Hnl5seyXJzLmZ9/4=",
-          "range": "bytes=1080-251884"
+          "checksum": "sha256-tf4xbo+NP+ssiaZtC1kOKehffAZ3+d17bhgfU3/30+g=",
+          "range": "bytes=1061-256582"
         },
         "name": "libnghttp2-14",
         "signature": {
-          "checksum": "sha1-CotSXRaPLKQCBRHrgzrDOD+4w20=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-KrsJYTyUsll+EUhHekbkdZFzeig=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.62.1-r0.apk",
-        "version": "1.62.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.62.1-r1.apk",
+        "version": "1.62.1-r1"
       },
       {
         "architecture": "x86_64",
@@ -394,136 +394,136 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1DE49kWSnmqVKJdjHFYC1bLkvyb0=",
+        "checksum": "Q1R8OxpY0fGwVaIwft4wJeswF5D54=",
         "control": {
-          "checksum": "sha1-DE49kWSnmqVKJdjHFYC1bLkvyb0=",
-          "range": "bytes=697-1078"
+          "checksum": "sha1-R8OxpY0fGwVaIwft4wJeswF5D54=",
+          "range": "bytes=695-1059"
         },
         "data": {
-          "checksum": "sha256-uDg8Qc6Rnro/68Vb5ufFSkqFLGrEsbvPb0pMJNvT1zw=",
-          "range": "bytes=1079-242085"
+          "checksum": "sha256-wNc8/SBJrGHfwywAtzCsAqeUOt0IaAhqNtlbv8OiHBE=",
+          "range": "bytes=1060-242151"
         },
         "name": "c-ares",
         "signature": {
-          "checksum": "sha1-iYEm6EWQKzxkeoDm+QsRfhw8pDg=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-55/PTlEHXI3o0hx9dSVdNwQeSMg=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.29.0-r0.apk",
-        "version": "1.29.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.31.0-r0.apk",
+        "version": "1.31.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q12eWmn2tCkXxwncU6gagKM3Wd9Sk=",
+        "checksum": "Q1g2RQKAvNjlRPxWjinIRveaq7IlY=",
         "control": {
-          "checksum": "sha1-2eWmn2tCkXxwncU6gagKM3Wd9Sk=",
-          "range": "bytes=696-1169"
+          "checksum": "sha1-g2RQKAvNjlRPxWjinIRveaq7IlY=",
+          "range": "bytes=695-1154"
         },
         "data": {
-          "checksum": "sha256-IFKNdojOhml3DbWPryQuHUiV3tgTWHyqOYD1JNe9IJ4=",
-          "range": "bytes=1170-2582015"
+          "checksum": "sha256-UsQFfOTXCZBan0mxDvR+ts0NKcbv1lNijxnRxjsmZhA=",
+          "range": "bytes=1155-2566233"
         },
         "name": "nghttp2",
         "signature": {
-          "checksum": "sha1-2/9n7KbRuOkrvhYqCFR5Mblx+z8=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-SUvMhz1cc5Or5Qh4fUEvPCp0NAw=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.62.1-r0.apk",
-        "version": "1.62.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.62.1-r1.apk",
+        "version": "1.62.1-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ialksjwPWvvZW+O2ABMbbBV/KTg=",
+        "checksum": "Q1sTMGOgdbZyDKxlRAByisPMHTbpY=",
         "control": {
-          "checksum": "sha1-ialksjwPWvvZW+O2ABMbbBV/KTg=",
-          "range": "bytes=702-1074"
+          "checksum": "sha1-sTMGOgdbZyDKxlRAByisPMHTbpY=",
+          "range": "bytes=703-1060"
         },
         "data": {
-          "checksum": "sha256-+ctDr3AO9mTXovGRPWk6h2ZgfY99Toy6esjBNHtJPY4=",
-          "range": "bytes=1075-631903"
+          "checksum": "sha256-bUy0h/zxpq7iP6vrQRMftZ9nevkHTB87hSX17wz4lmM=",
+          "range": "bytes=1061-631449"
         },
         "name": "nghttp2-dev",
         "signature": {
-          "checksum": "sha1-wZGQRluFd6DL1USzeak75o5/BTc=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-fQ6aDq3Io/gdJ5s5t3M+FwED1Y0=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.62.1-r0.apk",
-        "version": "1.62.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.62.1-r1.apk",
+        "version": "1.62.1-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1MlpRL1nBMU3RgNdSZVB42/vlGME=",
+        "checksum": "Q1rD3dEbbN8s5QAIQK1I8uF1O+oSo=",
         "control": {
-          "checksum": "sha1-MlpRL1nBMU3RgNdSZVB42/vlGME=",
-          "range": "bytes=697-1164"
+          "checksum": "sha1-rD3dEbbN8s5QAIQK1I8uF1O+oSo=",
+          "range": "bytes=701-1154"
         },
         "data": {
-          "checksum": "sha256-RiEPDasBVtnThSxGqTCDvb4J7WXM9YRpJwfYZJ3JLbs=",
-          "range": "bytes=1165-2274746"
+          "checksum": "sha256-41W2IRSRALQijYojLaqAiSSN1uO7twatGn8jqEuCZUg=",
+          "range": "bytes=1155-1439872"
         },
         "name": "xz",
         "signature": {
-          "checksum": "sha1-3wMPFIUEVfkAs7QSENemZsnTLyE=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-lozWkVrKvSrd1SoM7Zv08YYG2pA=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/xz-5.4.6-r2.apk",
-        "version": "5.4.6-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/xz-5.6.2-r0.apk",
+        "version": "5.6.2-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1TS707T+cPGL7TYVHQBCJoWwHZ0E=",
+        "checksum": "Q10AaU1ocIM4PYYNvwbml8TmpNvEA=",
         "control": {
-          "checksum": "sha1-TS707T+cPGL7TYVHQBCJoWwHZ0E=",
-          "range": "bytes=706-1098"
+          "checksum": "sha1-0AaU1ocIM4PYYNvwbml8TmpNvEA=",
+          "range": "bytes=706-1085"
         },
         "data": {
-          "checksum": "sha256-x18L706Vug5qDzq13SXuN/vGdVgzrqB06dW2DdgHGR4=",
-          "range": "bytes=1099-4541967"
+          "checksum": "sha256-1YQNYASFjlP3kXX58ec8du75ij/U6O4DPAKzJAPkln0=",
+          "range": "bytes=1086-4272589"
         },
         "name": "libxml2",
         "signature": {
-          "checksum": "sha1-BYhOxDos48sN8df8LMsSpROv2aw=",
+          "checksum": "sha1-QFjdplzGn/MiNFxMykgafr6/w6U=",
           "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.12.7-r0.apk",
-        "version": "2.12.7-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.1-r1.apk",
+        "version": "2.13.1-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1wJPtj5XZtnPiVWGM5dsT+nyfWXc=",
+        "checksum": "Q1wbnfumlWEiJnVUsJBRcQjFD3U6I=",
         "control": {
-          "checksum": "sha1-wJPtj5XZtnPiVWGM5dsT+nyfWXc=",
-          "range": "bytes=705-1234"
+          "checksum": "sha1-wbnfumlWEiJnVUsJBRcQjFD3U6I=",
+          "range": "bytes=699-1222"
         },
         "data": {
-          "checksum": "sha256-sw+CjlpsjO01q6lqzXgHnniiJKn7bqOSNO6vNqdGc7I=",
-          "range": "bytes=1235-3873775"
+          "checksum": "sha256-IXMNbJjj3kTjkWVBIHVRfG3zJQY2r5Eslgh/3TpMSsE=",
+          "range": "bytes=1223-3886778"
         },
         "name": "bind-libs",
         "signature": {
-          "checksum": "sha1-9zDzmHAeu7mWpidXAatqrLZVzUs=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-JNN15IPpJ2hMsO6hFVpDYPvvX5g=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bind-libs-9.18.26-r0.apk",
-        "version": "9.18.26-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/bind-libs-9.18.27-r1.apk",
+        "version": "9.18.27-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1AxEQdi8fVcYtGc3zHTCW3OZdY2Q=",
+        "checksum": "Q1kXUOoNa2KXixxAASo1W/im1qZ7s=",
         "control": {
-          "checksum": "sha1-AxEQdi8fVcYtGc3zHTCW3OZdY2Q=",
-          "range": "bytes=694-1208"
+          "checksum": "sha1-kXUOoNa2KXixxAASo1W/im1qZ7s=",
+          "range": "bytes=702-1215"
         },
         "data": {
-          "checksum": "sha256-/dt3qJw5D9iSJ/mKkRQkhWD8R52selhpcwXyw7KLMhg=",
-          "range": "bytes=1209-879444"
+          "checksum": "sha256-HRADvfRXfYsgEjUMGM4Hd7prpIv+YWILVfovbGOkEME=",
+          "range": "bytes=1216-879975"
         },
         "name": "bind-tools",
         "signature": {
-          "checksum": "sha1-VTb0YdUzPMk8Po0p4nj0y5Jey6k=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-8WUTMUaJTaX0T9FS/c+GddL7ttY=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bind-tools-9.18.26-r0.apk",
-        "version": "9.18.26-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/bind-tools-9.18.27-r1.apk",
+        "version": "9.18.27-r1"
       },
       {
         "architecture": "x86_64",
@@ -584,22 +584,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1FaSuo5kLpGzOlCXAmVtdoeTE9KY=",
+        "checksum": "Q1fnaWc3899x9dK4z4iTFNOeM6MI0=",
         "control": {
-          "checksum": "sha1-FaSuo5kLpGzOlCXAmVtdoeTE9KY=",
-          "range": "bytes=699-1146"
+          "checksum": "sha1-fnaWc3899x9dK4z4iTFNOeM6MI0=",
+          "range": "bytes=702-1132"
         },
         "data": {
-          "checksum": "sha256-yT+SLCTF2RGijQmytiBOuD/ZmYIeILT21+D12xRVzrQ=",
-          "range": "bytes=1147-373555"
+          "checksum": "sha256-rhtsl8eIgOKIHSa3VsedIEj1sA3xRi83jc3fhTjIQLw=",
+          "range": "bytes=1133-377535"
         },
         "name": "ca-certificates",
         "signature": {
-          "checksum": "sha1-AKpkACT5QAimOprekpt14cLs7Pw=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-I1wWFlIzyXu0g5mcgMo/iyW3Mhw=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-20240315-r3.apk",
-        "version": "20240315-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-20240315-r4.apk",
+        "version": "20240315-r4"
       },
       {
         "architecture": "x86_64",
@@ -641,60 +641,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1fr0OtiVaD3c5nw8fy5m74hDe9PU=",
+        "checksum": "Q1BRGmQ9LZTeZqbxQ1ls69T6efViw=",
         "control": {
-          "checksum": "sha1-fr0OtiVaD3c5nw8fy5m74hDe9PU=",
-          "range": "bytes=697-1092"
+          "checksum": "sha1-BRGmQ9LZTeZqbxQ1ls69T6efViw=",
+          "range": "bytes=698-1080"
         },
         "data": {
-          "checksum": "sha256-lukjMYpGmuhBNDUbbTJMIrUWaR4rNikEnW4BgiTaLj8=",
-          "range": "bytes=1093-113872"
+          "checksum": "sha256-vtJ4WJ5M+31ZKSBYBedbrl/FrbAw8hGpPRrHC7kasOk=",
+          "range": "bytes=1081-113895"
         },
         "name": "libpsl",
         "signature": {
-          "checksum": "sha1-Lrrudgn1i1a0JhjdzeXG+exnjQA=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-DuAoiykwhu8vu1qxdEDK5oyAmf8=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libpsl-0.21.5-r2.apk",
-        "version": "0.21.5-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libpsl-0.21.5-r3.apk",
+        "version": "0.21.5-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1oauHQa0YcFcEHSQWdfohfNEN4sY=",
+        "checksum": "Q11DZVpe2UYyDr/dG6BDysZhE3L48=",
         "control": {
-          "checksum": "sha1-oauHQa0YcFcEHSQWdfohfNEN4sY=",
-          "range": "bytes=698-1057"
+          "checksum": "sha1-1DZVpe2UYyDr/dG6BDysZhE3L48=",
+          "range": "bytes=707-1049"
         },
         "data": {
-          "checksum": "sha256-d95c9lpjQrpuZ1CcQ8ZZ89LAGGKcessd+hxrOQpP4LU=",
-          "range": "bytes=1058-173549"
+          "checksum": "sha256-aECfsy7giZsLNxZM0HMeF4OS2gu+ycX4DUTJXsiZRQs=",
+          "range": "bytes=1050-173585"
         },
         "name": "libbrotlicommon1",
         "signature": {
-          "checksum": "sha1-g3ufBq/tyiNP6AaOoqwItVvh7uk=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-7LXD38QwFhklZCEqyW4qIncfZV0=",
+          "range": "bytes=0-706"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlicommon1-1.1.0-r2.apk",
-        "version": "1.1.0-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlicommon1-1.1.0-r3.apk",
+        "version": "1.1.0-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q18Otq7NLoYnNMebI/1Rr/s0zdLVw=",
+        "checksum": "Q1Cgr886A8Ryzynz9pxRKsNybVuK0=",
         "control": {
-          "checksum": "sha1-8Otq7NLoYnNMebI/1Rr/s0zdLVw=",
-          "range": "bytes=705-1072"
+          "checksum": "sha1-Cgr886A8Ryzynz9pxRKsNybVuK0=",
+          "range": "bytes=694-1043"
         },
         "data": {
-          "checksum": "sha256-sR3QidR/e46PJ/3S2fxAjN/hRSSA3Ar32Nw7VshTHWg=",
-          "range": "bytes=1073-81475"
+          "checksum": "sha256-mH+MTbqpLiqgydlgE+tSDEt0Sh1/zqMvAqspV4lr+Ks=",
+          "range": "bytes=1044-81511"
         },
         "name": "libbrotlidec1",
         "signature": {
-          "checksum": "sha1-6GpZI5cBUXOvjCYG81aZZR53lMI=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-Yp4Bde9oHQCec8HM2qn6hVKgtko=",
+          "range": "bytes=0-693"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlidec1-1.1.0-r2.apk",
-        "version": "1.1.0-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlidec1-1.1.0-r3.apk",
+        "version": "1.1.0-r3"
       },
       {
         "architecture": "x86_64",
@@ -755,41 +755,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1uIKbAiTl7xWbpJXy11+HeOS/RDo=",
+        "checksum": "Q1+FlR1zI7qp3uiJm5fHTA4Hr1lSQ=",
         "control": {
-          "checksum": "sha1-uIKbAiTl7xWbpJXy11+HeOS/RDo=",
-          "range": "bytes=694-1075"
+          "checksum": "sha1-+FlR1zI7qp3uiJm5fHTA4Hr1lSQ=",
+          "range": "bytes=698-1064"
         },
         "data": {
-          "checksum": "sha256-qUT47e+MUydc5TG+6YjAi7LyDOWQeOyP5dlfnPBWRWM=",
-          "range": "bytes=1076-697425"
+          "checksum": "sha256-jx/MzLqQnCOtZqAiH6LmBTCiTD9HId1TLO3GZFDqHxQ=",
+          "range": "bytes=1065-685148"
         },
         "name": "libpcre2-8-0",
         "signature": {
-          "checksum": "sha1-T6Z2q5sW3pwjztCXPRoQKi8rfeY=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-4ZNzjpofU2aV2PzFb9SFo9ipHLE=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libpcre2-8-0-10.43-r1.apk",
-        "version": "10.43-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libpcre2-8-0-10.44-r1.apk",
+        "version": "10.44-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q111Aq+tDFOygcfZzOg1hQbtZw1Q4=",
+        "checksum": "Q1Xg04pU313NQ+1ni/3EGFESveG28=",
         "control": {
-          "checksum": "sha1-11Aq+tDFOygcfZzOg1hQbtZw1Q4=",
-          "range": "bytes=697-1140"
+          "checksum": "sha1-Xg04pU313NQ+1ni/3EGFESveG28=",
+          "range": "bytes=694-1135"
         },
         "data": {
-          "checksum": "sha256-ednk20seorMQ+xEGnt8zWpxO20xrfj7zOtAmk+XcTbA=",
-          "range": "bytes=1141-17250210"
+          "checksum": "sha256-rgB0/iCkskRu0z50yJPj5UbCkDqeT48PaLInXkivQh4=",
+          "range": "bytes=1136-17250228"
         },
         "name": "git",
         "signature": {
-          "checksum": "sha1-T1C3/QmQvuJGLjPH2YyOLIM5ewE=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-oiYirHB8Oqxgza8ivbRUYOy39i8=",
+          "range": "bytes=0-693"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/git-2.45.2-r0.apk",
-        "version": "2.45.2-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/git-2.45.2-r2.apk",
+        "version": "2.45.2-r2"
       },
       {
         "architecture": "x86_64",
@@ -812,22 +812,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q19dA+Zcg8X4SxDAZMWWPEjgjeKdc=",
+        "checksum": "Q182nzbWYdZj/iC4pasN1vKY7BbBY=",
         "control": {
-          "checksum": "sha1-9dA+Zcg8X4SxDAZMWWPEjgjeKdc=",
-          "range": "bytes=696-1056"
+          "checksum": "sha1-82nzbWYdZj/iC4pasN1vKY7BbBY=",
+          "range": "bytes=702-1050"
         },
         "data": {
-          "checksum": "sha256-yi3bDtrc3T+EVxl1H6XvaCUcp0Jl6SQOeiWDSoNP1sA=",
-          "range": "bytes=1057-10587175"
+          "checksum": "sha256-9zZvxXERuAXeg75D9BI6R+2cfAZn7ecs/AZp64liKQM=",
+          "range": "bytes=1051-10040238"
         },
         "name": "maven",
         "signature": {
-          "checksum": "sha1-bNLB1Gu/o9NWJbnqMFLWY514RiY=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-sNtWRTd4lLWbI+WokfA/lvKuVVo=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/maven-3.9.7-r0.apk",
-        "version": "3.9.7-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/maven-3.9.8-r0.apk",
+        "version": "3.9.8-r0"
       },
       {
         "architecture": "x86_64",
@@ -850,22 +850,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1EeC4oJcNGILol2exjVmAmCeKe3Y=",
+        "checksum": "Q1G/AwDwdfNwNdSm/t6Sqght8DOpI=",
         "control": {
-          "checksum": "sha1-EeC4oJcNGILol2exjVmAmCeKe3Y=",
-          "range": "bytes=698-1076"
+          "checksum": "sha1-G/AwDwdfNwNdSm/t6Sqght8DOpI=",
+          "range": "bytes=696-1061"
         },
         "data": {
-          "checksum": "sha256-jG5+Qk19KNjypflTSwO2gF+f/zqWbtjjhuzSO3maxf8=",
-          "range": "bytes=1077-109053"
+          "checksum": "sha256-5ypXRnqcv42v+Xt59TOt/lTM3huvyCrCDpeER423auk=",
+          "range": "bytes=1062-113624"
         },
         "name": "libbz2-1",
         "signature": {
-          "checksum": "sha1-800rFtecn2FKQ9uM95GkfwOMvnQ=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-riGFRNbF0tAWYE9PlBEuTbcGkTQ=",
+          "range": "bytes=0-695"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libbz2-1-1.0.8-r7.apk",
-        "version": "1.0.8-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libbz2-1-1.0.8-r8.apk",
+        "version": "1.0.8-r8"
       },
       {
         "architecture": "x86_64",
@@ -964,22 +964,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1sBp15UoB9iDd/xOOx13CSHRTZnA=",
+        "checksum": "Q1b1fkDQZR7BtOZFyaQCnquuKyU8c=",
         "control": {
-          "checksum": "sha1-sBp15UoB9iDd/xOOx13CSHRTZnA=",
-          "range": "bytes=695-1072"
+          "checksum": "sha1-b1fkDQZR7BtOZFyaQCnquuKyU8c=",
+          "range": "bytes=697-1059"
         },
         "data": {
-          "checksum": "sha256-pSuWnCmt6INeWQul5MdUqxgoJ5B7FTEtCfyvg5H+WrA=",
-          "range": "bytes=1073-84740"
+          "checksum": "sha256-g6aBpzXAR79pmyFfBOmkTYKPEVMdAYC7akIKD6h6mHM=",
+          "range": "bytes=1060-84760"
         },
         "name": "libffi",
         "signature": {
-          "checksum": "sha1-kabxjRZlgSfO5ocH7PkbBtqFyus=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-xik2kwwu8Ryo+2igE3vEQ430rP0=",
+          "range": "bytes=0-696"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libffi-3.4.6-r2.apk",
-        "version": "3.4.6-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libffi-3.4.6-r3.apk",
+        "version": "3.4.6-r3"
       },
       {
         "architecture": "x86_64",
@@ -1192,22 +1192,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Xou3FauSnsDlv/GSiADD5//sbLU=",
+        "checksum": "Q10pJtceZTY/GaOtTkhXrHyRg/4us=",
         "control": {
-          "checksum": "sha1-Xou3FauSnsDlv/GSiADD5//sbLU=",
-          "range": "bytes=701-1087"
+          "checksum": "sha1-0pJtceZTY/GaOtTkhXrHyRg/4us=",
+          "range": "bytes=698-1072"
         },
         "data": {
-          "checksum": "sha256-pb3t+dcRqtb+NKcRaX+WpCmgwmCys/1yj9ZEv00dz6o=",
-          "range": "bytes=1088-1101261"
+          "checksum": "sha256-p32sgOSmN27pL84lhBFuVJ77C3zL/HSJpCa+dBqx/0Y=",
+          "range": "bytes=1073-1101764"
         },
         "name": "readline",
         "signature": {
-          "checksum": "sha1-UM8oioixvqY+MAGWmuqxp169zNk=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-a8RmW9zjTrKAkoKJP5kERPY1CeI=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/readline-8.2-r6.apk",
-        "version": "8.2-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/readline-8.2-r7.apk",
+        "version": "8.2-r7"
       },
       {
         "architecture": "x86_64",
@@ -1230,79 +1230,117 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1dSuRtBPomtGv2me2POZQiR51lJE=",
+        "checksum": "Q1a6z011zqFp2z1JCXtKZA+NDNaZM=",
         "control": {
-          "checksum": "sha1-dSuRtBPomtGv2me2POZQiR51lJE=",
-          "range": "bytes=700-1214"
+          "checksum": "sha1-a6z011zqFp2z1JCXtKZA+NDNaZM=",
+          "range": "bytes=700-1201"
         },
         "data": {
-          "checksum": "sha256-ZGhXZHXVdTTijpXtoRbXzHVsQ5bFnkjjY/LVgy+5Wm4=",
-          "range": "bytes=1215-40423596"
+          "checksum": "sha256-3blIe0IpHxnfbUhz4WrMWZb2cKlOYBr1bffuuxBVk2s=",
+          "range": "bytes=1202-40471072"
         },
         "name": "python-3.12-base",
         "signature": {
-          "checksum": "sha1-n2GGplQgEEHbAOL1wxJ7zdm2KDs=",
+          "checksum": "sha1-zABDPtPAGmVdJmPpIJpvPFzpu0k=",
           "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/python-3.12-base-3.12.3-r3.apk",
-        "version": "3.12.3-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/python-3.12-base-3.12.4-r1.apk",
+        "version": "3.12.4-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Jps1axE/oWBY4VZrdX7R4bEsaOM=",
+        "checksum": "Q1Pj5PZI3fgc9lNDNdTTb1joPrjhE=",
         "control": {
-          "checksum": "sha1-Jps1axE/oWBY4VZrdX7R4bEsaOM=",
-          "range": "bytes=700-1076"
+          "checksum": "sha1-Pj5PZI3fgc9lNDNdTTb1joPrjhE=",
+          "range": "bytes=704-1059"
         },
         "data": {
-          "checksum": "sha256-RvypSTb54kyTUweZeMAt6rXJSKendPCi0e7Qtg3U9wQ=",
-          "range": "bytes=1077-42729"
+          "checksum": "sha256-7MRuDZOEFQ5WNyh4d23pLgseGiXl+8IeZLH02QAAaXM=",
+          "range": "bytes=1060-297814"
         },
-        "name": "python-3.12",
+        "name": "py3.12-flit-core",
         "signature": {
-          "checksum": "sha1-0tQ4gaI3k39mmmjsylobay/tq8Y=",
-          "range": "bytes=0-699"
+          "checksum": "sha1-LnvYxMBDb5EdACbaX8T9Hty/Lnc=",
+          "range": "bytes=0-703"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/python-3.12-3.12.3-r3.apk",
-        "version": "3.12.3-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/py3.12-flit-core-3.9.0-r2.apk",
+        "version": "3.9.0-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Gor3JUs9zjABTUdZkxu5om/Ixhg=",
+        "checksum": "Q1j+Qxn4qwORrfXr0pkQKENYAJqo0=",
         "control": {
-          "checksum": "sha1-Gor3JUs9zjABTUdZkxu5om/Ixhg=",
-          "range": "bytes=698-1104"
+          "checksum": "sha1-j+Qxn4qwORrfXr0pkQKENYAJqo0=",
+          "range": "bytes=700-1074"
         },
         "data": {
-          "checksum": "sha256-N2xQ0UU/ODKzG2SWzE1GhydZAUhO/uVxU0cfQPuA9a0=",
-          "range": "bytes=1105-6527987"
+          "checksum": "sha256-p2z0o9bhigV/yoZAck/M6QjCKRYLvNrViRt615Olc3k=",
+          "range": "bytes=1075-6690059"
         },
         "name": "py3.12-setuptools",
         "signature": {
-          "checksum": "sha1-9RW+pUU7ihDW41QUmYo3TABmZ6s=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-BAfOowj9atVLZDo2nm8XoBQ5bQo=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/py3.12-setuptools-70.0.0-r0.apk",
-        "version": "70.0.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/py3.12-setuptools-70.1.1-r1.apk",
+        "version": "70.1.1-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1+cos+39hkqiOHpNDDQJd59Mzg0A=",
+        "checksum": "Q1jcGRQarIsLr8mdYzf2GP7eRIhak=",
         "control": {
-          "checksum": "sha1-+cos+39hkqiOHpNDDQJd59Mzg0A=",
-          "range": "bytes=698-1115"
+          "checksum": "sha1-jcGRQarIsLr8mdYzf2GP7eRIhak=",
+          "range": "bytes=698-1090"
         },
         "data": {
-          "checksum": "sha256-nYTip9D9wUNfyUS52rDtt+xQJqpDr20VnF27mnPJ0Qw=",
-          "range": "bytes=1116-14379261"
+          "checksum": "sha256-Aaz7A2/NS1VmDZ+x/HuBKXdEQYAZjyJFWRnImqD7Ih0=",
+          "range": "bytes=1091-11409283"
+        },
+        "name": "py3.12-pip-base",
+        "signature": {
+          "checksum": "sha1-LZSoowKk3DtT7DEvEeJn7V1RT1s=",
+          "range": "bytes=0-697"
+        },
+        "url": "https://packages.wolfi.dev/os/x86_64/py3.12-pip-base-24.1.1-r0.apk",
+        "version": "24.1.1-r0"
+      },
+      {
+        "architecture": "x86_64",
+        "checksum": "Q1zzil7wXlx7KyR4/c7AkAepkVNOc=",
+        "control": {
+          "checksum": "sha1-zzil7wXlx7KyR4/c7AkAepkVNOc=",
+          "range": "bytes=698-1103"
+        },
+        "data": {
+          "checksum": "sha256-/baopsKdhGeMlVDpNAXQ/Wr7Dqe8o0Ms05Dn8vn3JsA=",
+          "range": "bytes=1104-30867"
         },
         "name": "py3.12-pip",
         "signature": {
-          "checksum": "sha1-2tenNpZKIKKE34SmCRoxmX4F3bg=",
+          "checksum": "sha1-PDt1UH3nhWeFFz5ilfp5lYzfvMw=",
           "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/py3.12-pip-24.0-r2.apk",
-        "version": "24.0-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/py3.12-pip-24.1.1-r0.apk",
+        "version": "24.1.1-r0"
+      },
+      {
+        "architecture": "x86_64",
+        "checksum": "Q1URKL5KNXKIM0igX3gWtsaAQinog=",
+        "control": {
+          "checksum": "sha1-URKL5KNXKIM0igX3gWtsaAQinog=",
+          "range": "bytes=701-1059"
+        },
+        "data": {
+          "checksum": "sha256-7rAjW9fn3i3sNJnhTa5zqRD9I/0JkjlNHLsxCswOZBU=",
+          "range": "bytes=1060-42767"
+        },
+        "name": "python-3.12",
+        "signature": {
+          "checksum": "sha1-NmSoZl1PXBTBFANq2LBz9dX+bbo=",
+          "range": "bytes=0-700"
+        },
+        "url": "https://packages.wolfi.dev/os/x86_64/python-3.12-3.12.4-r1.apk",
+        "version": "3.12.4-r1"
       },
       {
         "architecture": "x86_64",
@@ -1325,22 +1363,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q19f/3419Xa/xv9jgQ0mMYs011fBk=",
+        "checksum": "Q1mTmy64gKYi4THBqewuvYL2uUyHc=",
         "control": {
-          "checksum": "sha1-9f/3419Xa/xv9jgQ0mMYs011fBk=",
-          "range": "bytes=696-1041"
+          "checksum": "sha1-mTmy64gKYi4THBqewuvYL2uUyHc=",
+          "range": "bytes=700-1031"
         },
         "data": {
-          "checksum": "sha256-iqHASiMgiu6rIjbWGwBmmq1Zthae8BkE4QZkiVPH7Ek=",
-          "range": "bytes=1042-1888945"
+          "checksum": "sha256-p0qua2luH33oAgOcLkU9f7k+I8WnykFszVMwNahujDA=",
+          "range": "bytes=1032-1889523"
         },
         "name": "tzdata",
         "signature": {
-          "checksum": "sha1-PCC3jiXlTwrimRMXH/4RyNvccOM=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-sBf5jVLVpWj4DiXaAd/mjo0pTfk=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/tzdata-2024a-r2.apk",
-        "version": "2024a-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/tzdata-2024a-r3.apk",
+        "version": "2024a-r3"
       },
       {
         "architecture": "x86_64",
@@ -1363,60 +1401,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1dddUZ+5FL0QIyEDf0OGy2wj8Svs=",
+        "checksum": "Q1ICMLmx9XiN02gWP7VDgljQEw/aE=",
         "control": {
-          "checksum": "sha1-dddUZ+5FL0QIyEDf0OGy2wj8Svs=",
-          "range": "bytes=702-1134"
+          "checksum": "sha1-ICMLmx9XiN02gWP7VDgljQEw/aE=",
+          "range": "bytes=700-1115"
         },
         "data": {
-          "checksum": "sha256-gB6hk8ptHU832g9esnLkdjk+TSvy4O/+M2sBGE2GOHc=",
-          "range": "bytes=1135-472076"
-        },
-        "name": "libgpg-error",
-        "signature": {
-          "checksum": "sha1-iCdEhd6pXn4NYtkVxamRKxAs/ds=",
-          "range": "bytes=0-701"
-        },
-        "url": "https://packages.wolfi.dev/os/x86_64/libgpg-error-1.49-r1.apk",
-        "version": "1.49-r1"
-      },
-      {
-        "architecture": "x86_64",
-        "checksum": "Q1+/OgQyPeLbB+Nia52b7bTW90nAI=",
-        "control": {
-          "checksum": "sha1-+/OgQyPeLbB+Nia52b7bTW90nAI=",
-          "range": "bytes=701-1161"
-        },
-        "data": {
-          "checksum": "sha256-RyPXm/2XBro+J+Km7qSg36779/NKGoCQ3bl8y8hRyuA=",
-          "range": "bytes=1162-1889892"
-        },
-        "name": "libgcrypt",
-        "signature": {
-          "checksum": "sha1-cZCJW0hrYiz/w+wilD3mIzKexZg=",
-          "range": "bytes=0-700"
-        },
-        "url": "https://packages.wolfi.dev/os/x86_64/libgcrypt-1.10.3-r2.apk",
-        "version": "1.10.3-r2"
-      },
-      {
-        "architecture": "x86_64",
-        "checksum": "Q1Ld/Kl2RpUnUq51OY2huRw/6YesA=",
-        "control": {
-          "checksum": "sha1-Ld/Kl2RpUnUq51OY2huRw/6YesA=",
-          "range": "bytes=697-1147"
-        },
-        "data": {
-          "checksum": "sha256-lYyvZHI3Fb03MXWoTqbsnFT3RqwJjgD6l+TfQEYWQ08=",
-          "range": "bytes=1148-1115130"
+          "checksum": "sha256-oca0wmxt4WsIt8ewErEndJ1L0umSFFqGuX0eKmwhLKA=",
+          "range": "bytes=1116-1105656"
         },
         "name": "libxslt",
         "signature": {
-          "checksum": "sha1-ASa9FmXRGuwxSeHg4TsMxxaDMpA=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-KqSVkzLzQCpeMAXPEr4kuzRZJPo=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxslt-1.1.39-r2.apk",
-        "version": "1.1.39-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxslt-1.1.41-r1.apk",
+        "version": "1.1.41-r1"
       },
       {
         "architecture": "x86_64",
@@ -1439,22 +1439,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1M5XGTuK0Sik/s9KP247D/TnEEd8=",
+        "checksum": "Q1POMkB+OGZU68Oyy1bPHttaBWrKQ=",
         "control": {
-          "checksum": "sha1-M5XGTuK0Sik/s9KP247D/TnEEd8=",
-          "range": "bytes=702-1098"
+          "checksum": "sha1-POMkB+OGZU68Oyy1bPHttaBWrKQ=",
+          "range": "bytes=702-1082"
         },
         "data": {
-          "checksum": "sha256-Qom1e/Jneo20yQRSp4w7cMeUXCCN4pKl0bE9f8Ep/Lk=",
-          "range": "bytes=1099-10722775"
+          "checksum": "sha256-2wD/1bLmSgMNDa3dm9wx0831vCi3zcZYCDxIHeoKHAo=",
+          "range": "bytes=1083-10722853"
         },
         "name": "yq",
         "signature": {
-          "checksum": "sha1-csGSkvlu7eVdliwEiyEgzGaqBcM=",
+          "checksum": "sha1-Db9wFCBDYnYkT73rwdOa8SiS+pw=",
           "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/yq-4.44.1-r2.apk",
-        "version": "4.44.1-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/yq-4.44.2-r0.apk",
+        "version": "4.44.2-r0"
       }
     ],
     "repositories": [

--- a/wolfi-images/caddy.lock.json
+++ b/wolfi-images/caddy.lock.json
@@ -14,41 +14,41 @@
     "packages": [
       {
         "architecture": "x86_64",
-        "checksum": "Q1ge3SLQsJ9v2RnvIHHAP1yFyjrEU=",
+        "checksum": "Q1Ai8jWuxKZR2M2XhOpOGAoTEwnnk=",
         "control": {
-          "checksum": "sha1-ge3SLQsJ9v2RnvIHHAP1yFyjrEU=",
-          "range": "bytes=693-1040"
+          "checksum": "sha1-Ai8jWuxKZR2M2XhOpOGAoTEwnnk=",
+          "range": "bytes=705-1037"
         },
         "data": {
-          "checksum": "sha256-I0AdTdfGf4P/jwzTrLXm73l5/RNSlymEof/YZfev3xY=",
-          "range": "bytes=1041-255811"
+          "checksum": "sha256-e4UardkBVyaC49aSyrVmXNi8sSKqQl4eKYd0LxGRLA0=",
+          "range": "bytes=1038-255695"
         },
         "name": "ca-certificates-bundle",
         "signature": {
-          "checksum": "sha1-ge1eJBiQmFWAn9GapFkQpO+Rn/Y=",
-          "range": "bytes=0-692"
+          "checksum": "sha1-loRuyYQLm+atp+YteiQoj++EWIM=",
+          "range": "bytes=0-704"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20240315-r3.apk",
-        "version": "20240315-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20240315-r4.apk",
+        "version": "20240315-r4"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1bgay5kOzpmDBgqJCg7dSlawyJg0=",
+        "checksum": "Q1+GH6qRN4iy1IDt0cT0x0tin7YfI=",
         "control": {
-          "checksum": "sha1-bgay5kOzpmDBgqJCg7dSlawyJg0=",
-          "range": "bytes=703-1067"
+          "checksum": "sha1-+GH6qRN4iy1IDt0cT0x0tin7YfI=",
+          "range": "bytes=703-1051"
         },
         "data": {
-          "checksum": "sha256-f83HfRE7r2ZniH7PyPmRqcoU5NTpF+Uk4FH80QbjvBM=",
-          "range": "bytes=1068-118370"
+          "checksum": "sha256-rO0P9z2V49BSrz1A5Ap69tEappVrg5MMBjzW00rOpZc=",
+          "range": "bytes=1052-122464"
         },
         "name": "wolfi-baselayout",
         "signature": {
-          "checksum": "sha1-2hlCvYH1D7u25HkJGA75jjs/sQY=",
+          "checksum": "sha1-Ntb6VuMzDfM+frpCjKEIpDzl53I=",
           "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r11.apk",
-        "version": "20230201-r11"
+        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r12.apk",
+        "version": "20230201-r12"
       },
       {
         "architecture": "x86_64",
@@ -109,41 +109,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Zjfs1uR/mYiortANP+EFcejW+vo=",
+        "checksum": "Q1Zi0e8Bq6WCd/6uXXjVhb8YwMD1U=",
         "control": {
-          "checksum": "sha1-Zjfs1uR/mYiortANP+EFcejW+vo=",
-          "range": "bytes=698-1085"
+          "checksum": "sha1-Zi0e8Bq6WCd/6uXXjVhb8YwMD1U=",
+          "range": "bytes=700-1073"
         },
         "data": {
-          "checksum": "sha256-BMd7TzffjbrFwdbopDPVYsX0X9XnusIMNbIf33/8kwc=",
-          "range": "bytes=1086-76881"
+          "checksum": "sha256-jMhtfqVjnhuuBO7wtNZ6RS/72sZWoKt/Moage2amlks=",
+          "range": "bytes=1074-81594"
         },
         "name": "protobuf-c",
         "signature": {
-          "checksum": "sha1-efGiXyYWsJ5P2uTkB6aXEZ3kl3o=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-kATwMKztK7nk7qbYCJPkCFp6IXc=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r4.apk",
-        "version": "1.5.0-r4"
-      },
-      {
-        "architecture": "x86_64",
-        "checksum": "Q1Xf5v5uXumBgIR4d4ZxMRxdpyWlM=",
-        "control": {
-          "checksum": "sha1-Xf5v5uXumBgIR4d4ZxMRxdpyWlM=",
-          "range": "bytes=698-1078"
-        },
-        "data": {
-          "checksum": "sha256-eD7HqFCWNUBQiLq9PcWE/zPeZwkiv8hBrytI4qmfQ/8=",
-          "range": "bytes=1079-57055"
-        },
-        "name": "keyutils-libs",
-        "signature": {
-          "checksum": "sha1-V0HVgZLP7P5kNACfus3abCLCS20=",
-          "range": "bytes=0-697"
-        },
-        "url": "https://packages.wolfi.dev/os/x86_64/keyutils-libs-1.6.3-r2.apk",
-        "version": "1.6.3-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r5.apk",
+        "version": "1.5.0-r5"
       },
       {
         "architecture": "x86_64",
@@ -166,22 +147,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1wRzOx+L6MeRFtTcq2y/6ot7Cj54=",
+        "checksum": "Q1v0A2vQM5k8rQY/GpIq6xI4T0YmA=",
         "control": {
-          "checksum": "sha1-wRzOx+L6MeRFtTcq2y/6ot7Cj54=",
-          "range": "bytes=699-1069"
+          "checksum": "sha1-v0A2vQM5k8rQY/GpIq6xI4T0YmA=",
+          "range": "bytes=701-1064"
         },
         "data": {
-          "checksum": "sha256-gNRjwZ4XQatCYWediSVb+j8lS54CggvMC5Dn3qT84So=",
-          "range": "bytes=1070-61490"
+          "checksum": "sha256-uAOrkGDDc/yqt6VjIrlTEALBJG4BCI4njqZw5jQqF0o=",
+          "range": "bytes=1065-56984"
+        },
+        "name": "keyutils-libs",
+        "signature": {
+          "checksum": "sha1-32uYMH/zGBr9Jo3hiqnThlcqBcE=",
+          "range": "bytes=0-700"
+        },
+        "url": "https://packages.wolfi.dev/os/x86_64/keyutils-libs-1.6.3-r3.apk",
+        "version": "1.6.3-r3"
+      },
+      {
+        "architecture": "x86_64",
+        "checksum": "Q1Onuac6Y+IWA7a4b8FvqX1erWDDw=",
+        "control": {
+          "checksum": "sha1-Onuac6Y+IWA7a4b8FvqX1erWDDw=",
+          "range": "bytes=693-1048"
+        },
+        "data": {
+          "checksum": "sha256-KLtDAs3iU0oyZ/FysePG/J+1H1ofDxHXIY7xvtZhtMc=",
+          "range": "bytes=1049-61503"
         },
         "name": "libverto",
         "signature": {
-          "checksum": "sha1-kuPwakYdy5EM6sd5Ba0K0Ta8x4w=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-/IXL9S1O+MwaW7KsSzz1ywEqKFQ=",
+          "range": "bytes=0-692"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libverto-0.3.2-r3.apk",
-        "version": "0.3.2-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/libverto-0.3.2-r4.apk",
+        "version": "0.3.2-r4"
       },
       {
         "architecture": "x86_64",
@@ -204,60 +204,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1gTZGkWP+QO3mUqLVJth8vrDEzzU=",
+        "checksum": "Q1Q/Zy5ovYSu2p/vVLr6DgVA1e8AQ=",
         "control": {
-          "checksum": "sha1-gTZGkWP+QO3mUqLVJth8vrDEzzU=",
-          "range": "bytes=699-1076"
+          "checksum": "sha1-Q/Zy5ovYSu2p/vVLr6DgVA1e8AQ=",
+          "range": "bytes=699-1062"
         },
         "data": {
-          "checksum": "sha256-/IFXqeKvU0GODNsz1yPIEMcFHgABT+8rbZpSlTLo4e4=",
-          "range": "bytes=1077-5915704"
+          "checksum": "sha256-H3jxsw8ytOeCIR4vq17voSVhdNokXk8C1g075txH6Bs=",
+          "range": "bytes=1063-5903754"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-l1o5ixkyWWqqJE3FOfR0QUemJUA=",
+          "checksum": "sha1-NIl2f5OI/wSZByI8Ds1ZUfbFWyw=",
           "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r9.apk",
-        "version": "3.3.0-r9"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.1-r3.apk",
+        "version": "3.3.1-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1jhAhggAuZnU7FFHnebGA26mq+jI=",
+        "checksum": "Q13wGUXdZut9OOTdY5z2amUj9wXC0=",
         "control": {
-          "checksum": "sha1-jhAhggAuZnU7FFHnebGA26mq+jI=",
-          "range": "bytes=695-1079"
+          "checksum": "sha1-3wGUXdZut9OOTdY5z2amUj9wXC0=",
+          "range": "bytes=698-1068"
         },
         "data": {
-          "checksum": "sha256-XTCQYnhGSm7SkGwqV/TQMFqGajVJVYhKAidKfLb2D3Y=",
-          "range": "bytes=1080-1197081"
+          "checksum": "sha256-mRda6+YGlOCczyIWKaHqXskTINoT1rgorHDHqAKAb7c=",
+          "range": "bytes=1069-1188955"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-qVrfDVxubkrb5Yrd2mFTv2A0G7k=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-+UdRc4U3PKw4H9OiNurHKXa5BYk=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r9.apk",
-        "version": "3.3.0-r9"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.1-r3.apk",
+        "version": "3.3.1-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1BQEXaeya6QB39QLeKcB99qBNF2o=",
+        "checksum": "Q1p04MrHQPrXOzuV/uF290zjnltqI=",
         "control": {
-          "checksum": "sha1-BQEXaeya6QB39QLeKcB99qBNF2o=",
-          "range": "bytes=699-1229"
+          "checksum": "sha1-p04MrHQPrXOzuV/uF290zjnltqI=",
+          "range": "bytes=704-1219"
         },
         "data": {
-          "checksum": "sha256-ugj/qGEBzhvdX17S22Anry+biy3lcqywhGMSHLIBCvo=",
-          "range": "bytes=1230-2551676"
+          "checksum": "sha256-TsXeqhUGykAhjQUEAlMUSzDQBcWDkkDvReoeHCL1F6c=",
+          "range": "bytes=1220-2555814"
         },
         "name": "krb5-libs",
         "signature": {
-          "checksum": "sha1-oqDPmNM4EngXAGayd/BZOqJAIao=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-cPyzS38QHuNlOCQb8IPlsl2PLHQ=",
+          "range": "bytes=0-703"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/krb5-libs-1.21.2-r2.apk",
-        "version": "1.21.2-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/krb5-libs-1.21.3-r0.apk",
+        "version": "1.21.3-r0"
       },
       {
         "architecture": "x86_64",
@@ -280,60 +280,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1wzZwtLauOQfLQC7YUvZdfKxtlwQ=",
+        "checksum": "Q17uprcuQ2VFudMcWAwtP7miJmLYs=",
         "control": {
-          "checksum": "sha1-wzZwtLauOQfLQC7YUvZdfKxtlwQ=",
-          "range": "bytes=698-1085"
+          "checksum": "sha1-7uprcuQ2VFudMcWAwtP7miJmLYs=",
+          "range": "bytes=695-1067"
         },
         "data": {
-          "checksum": "sha256-TO8CAULO44s/LphhtcaFOGJB7aFldk13v1cV9ceZHww=",
-          "range": "bytes=1086-276837"
+          "checksum": "sha256-unKdPbvO2VHZ5w1t1l8mOpQuNdUGwLhofEO4weN2Mig=",
+          "range": "bytes=1068-280973"
         },
         "name": "libuv",
         "signature": {
-          "checksum": "sha1-LRiyeKmjexy8CJizLxjd6ikon1w=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-4lKldnTO71WHMZ4tbANz6i2/Ed0=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libuv-1.48.0-r2.apk",
-        "version": "1.48.0-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libuv-1.48.0-r3.apk",
+        "version": "1.48.0-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q14S6biy8fc5OGbGEJoLBM+tJOGyo=",
+        "checksum": "Q1CN6zJbOPznWUfTrb/41KT7E6dm8=",
         "control": {
-          "checksum": "sha1-4S6biy8fc5OGbGEJoLBM+tJOGyo=",
-          "range": "bytes=703-1102"
+          "checksum": "sha1-CN6zJbOPznWUfTrb/41KT7E6dm8=",
+          "range": "bytes=699-1083"
         },
         "data": {
-          "checksum": "sha256-hwjdLQYfuMAGQeONmFVo0lZKKQK1S+3PBhrI3upm5W4=",
-          "range": "bytes=1103-155304"
+          "checksum": "sha256-ybzFzoQh1yNTcd3cjt54nYsPlAxAcMUcVMxEv1JRnpQ=",
+          "range": "bytes=1084-155375"
         },
         "name": "zlib",
         "signature": {
-          "checksum": "sha1-ZuLd7kE+AGhn27o8ZqDGM5eundc=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-CPXJcCjinAXP+H8Z5tkko8ayG6E=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/zlib-1.3.1-r2.apk",
-        "version": "1.3.1-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/zlib-1.3.1-r3.apk",
+        "version": "1.3.1-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ykDkP+AmDi2VcZZ1c4q4sez/DxI=",
+        "checksum": "Q1rgbci8SRSjW7EB0NSh6ZUPJLndM=",
         "control": {
-          "checksum": "sha1-ykDkP+AmDi2VcZZ1c4q4sez/DxI=",
-          "range": "bytes=705-1079"
+          "checksum": "sha1-rgbci8SRSjW7EB0NSh6ZUPJLndM=",
+          "range": "bytes=702-1060"
         },
         "data": {
-          "checksum": "sha256-t3BrH7lWfY3to3Fu3EKAMZx29v9Hnl5seyXJzLmZ9/4=",
-          "range": "bytes=1080-251884"
+          "checksum": "sha256-tf4xbo+NP+ssiaZtC1kOKehffAZ3+d17bhgfU3/30+g=",
+          "range": "bytes=1061-256582"
         },
         "name": "libnghttp2-14",
         "signature": {
-          "checksum": "sha1-CotSXRaPLKQCBRHrgzrDOD+4w20=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-KrsJYTyUsll+EUhHekbkdZFzeig=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.62.1-r0.apk",
-        "version": "1.62.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.62.1-r1.apk",
+        "version": "1.62.1-r1"
       },
       {
         "architecture": "x86_64",
@@ -394,136 +394,136 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1DE49kWSnmqVKJdjHFYC1bLkvyb0=",
+        "checksum": "Q1R8OxpY0fGwVaIwft4wJeswF5D54=",
         "control": {
-          "checksum": "sha1-DE49kWSnmqVKJdjHFYC1bLkvyb0=",
-          "range": "bytes=697-1078"
+          "checksum": "sha1-R8OxpY0fGwVaIwft4wJeswF5D54=",
+          "range": "bytes=695-1059"
         },
         "data": {
-          "checksum": "sha256-uDg8Qc6Rnro/68Vb5ufFSkqFLGrEsbvPb0pMJNvT1zw=",
-          "range": "bytes=1079-242085"
+          "checksum": "sha256-wNc8/SBJrGHfwywAtzCsAqeUOt0IaAhqNtlbv8OiHBE=",
+          "range": "bytes=1060-242151"
         },
         "name": "c-ares",
         "signature": {
-          "checksum": "sha1-iYEm6EWQKzxkeoDm+QsRfhw8pDg=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-55/PTlEHXI3o0hx9dSVdNwQeSMg=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.29.0-r0.apk",
-        "version": "1.29.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.31.0-r0.apk",
+        "version": "1.31.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q12eWmn2tCkXxwncU6gagKM3Wd9Sk=",
+        "checksum": "Q1g2RQKAvNjlRPxWjinIRveaq7IlY=",
         "control": {
-          "checksum": "sha1-2eWmn2tCkXxwncU6gagKM3Wd9Sk=",
-          "range": "bytes=696-1169"
+          "checksum": "sha1-g2RQKAvNjlRPxWjinIRveaq7IlY=",
+          "range": "bytes=695-1154"
         },
         "data": {
-          "checksum": "sha256-IFKNdojOhml3DbWPryQuHUiV3tgTWHyqOYD1JNe9IJ4=",
-          "range": "bytes=1170-2582015"
+          "checksum": "sha256-UsQFfOTXCZBan0mxDvR+ts0NKcbv1lNijxnRxjsmZhA=",
+          "range": "bytes=1155-2566233"
         },
         "name": "nghttp2",
         "signature": {
-          "checksum": "sha1-2/9n7KbRuOkrvhYqCFR5Mblx+z8=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-SUvMhz1cc5Or5Qh4fUEvPCp0NAw=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.62.1-r0.apk",
-        "version": "1.62.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.62.1-r1.apk",
+        "version": "1.62.1-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ialksjwPWvvZW+O2ABMbbBV/KTg=",
+        "checksum": "Q1sTMGOgdbZyDKxlRAByisPMHTbpY=",
         "control": {
-          "checksum": "sha1-ialksjwPWvvZW+O2ABMbbBV/KTg=",
-          "range": "bytes=702-1074"
+          "checksum": "sha1-sTMGOgdbZyDKxlRAByisPMHTbpY=",
+          "range": "bytes=703-1060"
         },
         "data": {
-          "checksum": "sha256-+ctDr3AO9mTXovGRPWk6h2ZgfY99Toy6esjBNHtJPY4=",
-          "range": "bytes=1075-631903"
+          "checksum": "sha256-bUy0h/zxpq7iP6vrQRMftZ9nevkHTB87hSX17wz4lmM=",
+          "range": "bytes=1061-631449"
         },
         "name": "nghttp2-dev",
         "signature": {
-          "checksum": "sha1-wZGQRluFd6DL1USzeak75o5/BTc=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-fQ6aDq3Io/gdJ5s5t3M+FwED1Y0=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.62.1-r0.apk",
-        "version": "1.62.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.62.1-r1.apk",
+        "version": "1.62.1-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1MlpRL1nBMU3RgNdSZVB42/vlGME=",
+        "checksum": "Q1rD3dEbbN8s5QAIQK1I8uF1O+oSo=",
         "control": {
-          "checksum": "sha1-MlpRL1nBMU3RgNdSZVB42/vlGME=",
-          "range": "bytes=697-1164"
+          "checksum": "sha1-rD3dEbbN8s5QAIQK1I8uF1O+oSo=",
+          "range": "bytes=701-1154"
         },
         "data": {
-          "checksum": "sha256-RiEPDasBVtnThSxGqTCDvb4J7WXM9YRpJwfYZJ3JLbs=",
-          "range": "bytes=1165-2274746"
+          "checksum": "sha256-41W2IRSRALQijYojLaqAiSSN1uO7twatGn8jqEuCZUg=",
+          "range": "bytes=1155-1439872"
         },
         "name": "xz",
         "signature": {
-          "checksum": "sha1-3wMPFIUEVfkAs7QSENemZsnTLyE=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-lozWkVrKvSrd1SoM7Zv08YYG2pA=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/xz-5.4.6-r2.apk",
-        "version": "5.4.6-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/xz-5.6.2-r0.apk",
+        "version": "5.6.2-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1TS707T+cPGL7TYVHQBCJoWwHZ0E=",
+        "checksum": "Q10AaU1ocIM4PYYNvwbml8TmpNvEA=",
         "control": {
-          "checksum": "sha1-TS707T+cPGL7TYVHQBCJoWwHZ0E=",
-          "range": "bytes=706-1098"
+          "checksum": "sha1-0AaU1ocIM4PYYNvwbml8TmpNvEA=",
+          "range": "bytes=706-1085"
         },
         "data": {
-          "checksum": "sha256-x18L706Vug5qDzq13SXuN/vGdVgzrqB06dW2DdgHGR4=",
-          "range": "bytes=1099-4541967"
+          "checksum": "sha256-1YQNYASFjlP3kXX58ec8du75ij/U6O4DPAKzJAPkln0=",
+          "range": "bytes=1086-4272589"
         },
         "name": "libxml2",
         "signature": {
-          "checksum": "sha1-BYhOxDos48sN8df8LMsSpROv2aw=",
+          "checksum": "sha1-QFjdplzGn/MiNFxMykgafr6/w6U=",
           "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.12.7-r0.apk",
-        "version": "2.12.7-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.1-r1.apk",
+        "version": "2.13.1-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1wJPtj5XZtnPiVWGM5dsT+nyfWXc=",
+        "checksum": "Q1wbnfumlWEiJnVUsJBRcQjFD3U6I=",
         "control": {
-          "checksum": "sha1-wJPtj5XZtnPiVWGM5dsT+nyfWXc=",
-          "range": "bytes=705-1234"
+          "checksum": "sha1-wbnfumlWEiJnVUsJBRcQjFD3U6I=",
+          "range": "bytes=699-1222"
         },
         "data": {
-          "checksum": "sha256-sw+CjlpsjO01q6lqzXgHnniiJKn7bqOSNO6vNqdGc7I=",
-          "range": "bytes=1235-3873775"
+          "checksum": "sha256-IXMNbJjj3kTjkWVBIHVRfG3zJQY2r5Eslgh/3TpMSsE=",
+          "range": "bytes=1223-3886778"
         },
         "name": "bind-libs",
         "signature": {
-          "checksum": "sha1-9zDzmHAeu7mWpidXAatqrLZVzUs=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-JNN15IPpJ2hMsO6hFVpDYPvvX5g=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bind-libs-9.18.26-r0.apk",
-        "version": "9.18.26-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/bind-libs-9.18.27-r1.apk",
+        "version": "9.18.27-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1AxEQdi8fVcYtGc3zHTCW3OZdY2Q=",
+        "checksum": "Q1kXUOoNa2KXixxAASo1W/im1qZ7s=",
         "control": {
-          "checksum": "sha1-AxEQdi8fVcYtGc3zHTCW3OZdY2Q=",
-          "range": "bytes=694-1208"
+          "checksum": "sha1-kXUOoNa2KXixxAASo1W/im1qZ7s=",
+          "range": "bytes=702-1215"
         },
         "data": {
-          "checksum": "sha256-/dt3qJw5D9iSJ/mKkRQkhWD8R52selhpcwXyw7KLMhg=",
-          "range": "bytes=1209-879444"
+          "checksum": "sha256-HRADvfRXfYsgEjUMGM4Hd7prpIv+YWILVfovbGOkEME=",
+          "range": "bytes=1216-879975"
         },
         "name": "bind-tools",
         "signature": {
-          "checksum": "sha1-VTb0YdUzPMk8Po0p4nj0y5Jey6k=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-8WUTMUaJTaX0T9FS/c+GddL7ttY=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bind-tools-9.18.26-r0.apk",
-        "version": "9.18.26-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/bind-tools-9.18.27-r1.apk",
+        "version": "9.18.27-r1"
       },
       {
         "architecture": "x86_64",
@@ -641,60 +641,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1fr0OtiVaD3c5nw8fy5m74hDe9PU=",
+        "checksum": "Q1BRGmQ9LZTeZqbxQ1ls69T6efViw=",
         "control": {
-          "checksum": "sha1-fr0OtiVaD3c5nw8fy5m74hDe9PU=",
-          "range": "bytes=697-1092"
+          "checksum": "sha1-BRGmQ9LZTeZqbxQ1ls69T6efViw=",
+          "range": "bytes=698-1080"
         },
         "data": {
-          "checksum": "sha256-lukjMYpGmuhBNDUbbTJMIrUWaR4rNikEnW4BgiTaLj8=",
-          "range": "bytes=1093-113872"
+          "checksum": "sha256-vtJ4WJ5M+31ZKSBYBedbrl/FrbAw8hGpPRrHC7kasOk=",
+          "range": "bytes=1081-113895"
         },
         "name": "libpsl",
         "signature": {
-          "checksum": "sha1-Lrrudgn1i1a0JhjdzeXG+exnjQA=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-DuAoiykwhu8vu1qxdEDK5oyAmf8=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libpsl-0.21.5-r2.apk",
-        "version": "0.21.5-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libpsl-0.21.5-r3.apk",
+        "version": "0.21.5-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1oauHQa0YcFcEHSQWdfohfNEN4sY=",
+        "checksum": "Q11DZVpe2UYyDr/dG6BDysZhE3L48=",
         "control": {
-          "checksum": "sha1-oauHQa0YcFcEHSQWdfohfNEN4sY=",
-          "range": "bytes=698-1057"
+          "checksum": "sha1-1DZVpe2UYyDr/dG6BDysZhE3L48=",
+          "range": "bytes=707-1049"
         },
         "data": {
-          "checksum": "sha256-d95c9lpjQrpuZ1CcQ8ZZ89LAGGKcessd+hxrOQpP4LU=",
-          "range": "bytes=1058-173549"
+          "checksum": "sha256-aECfsy7giZsLNxZM0HMeF4OS2gu+ycX4DUTJXsiZRQs=",
+          "range": "bytes=1050-173585"
         },
         "name": "libbrotlicommon1",
         "signature": {
-          "checksum": "sha1-g3ufBq/tyiNP6AaOoqwItVvh7uk=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-7LXD38QwFhklZCEqyW4qIncfZV0=",
+          "range": "bytes=0-706"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlicommon1-1.1.0-r2.apk",
-        "version": "1.1.0-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlicommon1-1.1.0-r3.apk",
+        "version": "1.1.0-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q18Otq7NLoYnNMebI/1Rr/s0zdLVw=",
+        "checksum": "Q1Cgr886A8Ryzynz9pxRKsNybVuK0=",
         "control": {
-          "checksum": "sha1-8Otq7NLoYnNMebI/1Rr/s0zdLVw=",
-          "range": "bytes=705-1072"
+          "checksum": "sha1-Cgr886A8Ryzynz9pxRKsNybVuK0=",
+          "range": "bytes=694-1043"
         },
         "data": {
-          "checksum": "sha256-sR3QidR/e46PJ/3S2fxAjN/hRSSA3Ar32Nw7VshTHWg=",
-          "range": "bytes=1073-81475"
+          "checksum": "sha256-mH+MTbqpLiqgydlgE+tSDEt0Sh1/zqMvAqspV4lr+Ks=",
+          "range": "bytes=1044-81511"
         },
         "name": "libbrotlidec1",
         "signature": {
-          "checksum": "sha1-6GpZI5cBUXOvjCYG81aZZR53lMI=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-Yp4Bde9oHQCec8HM2qn6hVKgtko=",
+          "range": "bytes=0-693"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlidec1-1.1.0-r2.apk",
-        "version": "1.1.0-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlidec1-1.1.0-r3.apk",
+        "version": "1.1.0-r3"
       },
       {
         "architecture": "x86_64",
@@ -736,22 +736,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1oApoc3nWXtAsLDJdmq9a4Cc4Y3s=",
+        "checksum": "Q11HU6P62pLu2HOf6M5PsI0a9uzws=",
         "control": {
-          "checksum": "sha1-oApoc3nWXtAsLDJdmq9a4Cc4Y3s=",
-          "range": "bytes=699-1113"
+          "checksum": "sha1-1HU6P62pLu2HOf6M5PsI0a9uzws=",
+          "range": "bytes=702-1103"
         },
         "data": {
-          "checksum": "sha256-haJY4QjwFbTR3vpKjU//xcSx/qYViZEIOLqHgZEsqRk=",
-          "range": "bytes=1114-108047"
+          "checksum": "sha256-rzsuMWkBJ/RPHj7GO4lVXk2c8MtIt2ZpjY/z6TEqmrk=",
+          "range": "bytes=1104-104454"
         },
         "name": "libcap",
         "signature": {
-          "checksum": "sha1-HnNeht4rRtGNhyP0n3IHd5BWy6k=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-JGtkpfiwCDjeRgaXlIW7QaedOk4=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcap-2.70-r0.apk",
-        "version": "2.70-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcap-2.70-r1.apk",
+        "version": "2.70-r1"
       },
       {
         "architecture": "x86_64",
@@ -774,22 +774,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q19f/3419Xa/xv9jgQ0mMYs011fBk=",
+        "checksum": "Q1mTmy64gKYi4THBqewuvYL2uUyHc=",
         "control": {
-          "checksum": "sha1-9f/3419Xa/xv9jgQ0mMYs011fBk=",
-          "range": "bytes=696-1041"
+          "checksum": "sha1-mTmy64gKYi4THBqewuvYL2uUyHc=",
+          "range": "bytes=700-1031"
         },
         "data": {
-          "checksum": "sha256-iqHASiMgiu6rIjbWGwBmmq1Zthae8BkE4QZkiVPH7Ek=",
-          "range": "bytes=1042-1888945"
+          "checksum": "sha256-p0qua2luH33oAgOcLkU9f7k+I8WnykFszVMwNahujDA=",
+          "range": "bytes=1032-1889523"
         },
         "name": "tzdata",
         "signature": {
-          "checksum": "sha1-PCC3jiXlTwrimRMXH/4RyNvccOM=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-sBf5jVLVpWj4DiXaAd/mjo0pTfk=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/tzdata-2024a-r2.apk",
-        "version": "2024a-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/tzdata-2024a-r3.apk",
+        "version": "2024a-r3"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/cadvisor.lock.json
+++ b/wolfi-images/cadvisor.lock.json
@@ -14,41 +14,41 @@
     "packages": [
       {
         "architecture": "x86_64",
-        "checksum": "Q1ge3SLQsJ9v2RnvIHHAP1yFyjrEU=",
+        "checksum": "Q1Ai8jWuxKZR2M2XhOpOGAoTEwnnk=",
         "control": {
-          "checksum": "sha1-ge3SLQsJ9v2RnvIHHAP1yFyjrEU=",
-          "range": "bytes=693-1040"
+          "checksum": "sha1-Ai8jWuxKZR2M2XhOpOGAoTEwnnk=",
+          "range": "bytes=705-1037"
         },
         "data": {
-          "checksum": "sha256-I0AdTdfGf4P/jwzTrLXm73l5/RNSlymEof/YZfev3xY=",
-          "range": "bytes=1041-255811"
+          "checksum": "sha256-e4UardkBVyaC49aSyrVmXNi8sSKqQl4eKYd0LxGRLA0=",
+          "range": "bytes=1038-255695"
         },
         "name": "ca-certificates-bundle",
         "signature": {
-          "checksum": "sha1-ge1eJBiQmFWAn9GapFkQpO+Rn/Y=",
-          "range": "bytes=0-692"
+          "checksum": "sha1-loRuyYQLm+atp+YteiQoj++EWIM=",
+          "range": "bytes=0-704"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20240315-r3.apk",
-        "version": "20240315-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20240315-r4.apk",
+        "version": "20240315-r4"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1bgay5kOzpmDBgqJCg7dSlawyJg0=",
+        "checksum": "Q1+GH6qRN4iy1IDt0cT0x0tin7YfI=",
         "control": {
-          "checksum": "sha1-bgay5kOzpmDBgqJCg7dSlawyJg0=",
-          "range": "bytes=703-1067"
+          "checksum": "sha1-+GH6qRN4iy1IDt0cT0x0tin7YfI=",
+          "range": "bytes=703-1051"
         },
         "data": {
-          "checksum": "sha256-f83HfRE7r2ZniH7PyPmRqcoU5NTpF+Uk4FH80QbjvBM=",
-          "range": "bytes=1068-118370"
+          "checksum": "sha256-rO0P9z2V49BSrz1A5Ap69tEappVrg5MMBjzW00rOpZc=",
+          "range": "bytes=1052-122464"
         },
         "name": "wolfi-baselayout",
         "signature": {
-          "checksum": "sha1-2hlCvYH1D7u25HkJGA75jjs/sQY=",
+          "checksum": "sha1-Ntb6VuMzDfM+frpCjKEIpDzl53I=",
           "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r11.apk",
-        "version": "20230201-r11"
+        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r12.apk",
+        "version": "20230201-r12"
       },
       {
         "architecture": "x86_64",
@@ -109,41 +109,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Zjfs1uR/mYiortANP+EFcejW+vo=",
+        "checksum": "Q1Zi0e8Bq6WCd/6uXXjVhb8YwMD1U=",
         "control": {
-          "checksum": "sha1-Zjfs1uR/mYiortANP+EFcejW+vo=",
-          "range": "bytes=698-1085"
+          "checksum": "sha1-Zi0e8Bq6WCd/6uXXjVhb8YwMD1U=",
+          "range": "bytes=700-1073"
         },
         "data": {
-          "checksum": "sha256-BMd7TzffjbrFwdbopDPVYsX0X9XnusIMNbIf33/8kwc=",
-          "range": "bytes=1086-76881"
+          "checksum": "sha256-jMhtfqVjnhuuBO7wtNZ6RS/72sZWoKt/Moage2amlks=",
+          "range": "bytes=1074-81594"
         },
         "name": "protobuf-c",
         "signature": {
-          "checksum": "sha1-efGiXyYWsJ5P2uTkB6aXEZ3kl3o=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-kATwMKztK7nk7qbYCJPkCFp6IXc=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r4.apk",
-        "version": "1.5.0-r4"
-      },
-      {
-        "architecture": "x86_64",
-        "checksum": "Q1Xf5v5uXumBgIR4d4ZxMRxdpyWlM=",
-        "control": {
-          "checksum": "sha1-Xf5v5uXumBgIR4d4ZxMRxdpyWlM=",
-          "range": "bytes=698-1078"
-        },
-        "data": {
-          "checksum": "sha256-eD7HqFCWNUBQiLq9PcWE/zPeZwkiv8hBrytI4qmfQ/8=",
-          "range": "bytes=1079-57055"
-        },
-        "name": "keyutils-libs",
-        "signature": {
-          "checksum": "sha1-V0HVgZLP7P5kNACfus3abCLCS20=",
-          "range": "bytes=0-697"
-        },
-        "url": "https://packages.wolfi.dev/os/x86_64/keyutils-libs-1.6.3-r2.apk",
-        "version": "1.6.3-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r5.apk",
+        "version": "1.5.0-r5"
       },
       {
         "architecture": "x86_64",
@@ -166,22 +147,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1wRzOx+L6MeRFtTcq2y/6ot7Cj54=",
+        "checksum": "Q1v0A2vQM5k8rQY/GpIq6xI4T0YmA=",
         "control": {
-          "checksum": "sha1-wRzOx+L6MeRFtTcq2y/6ot7Cj54=",
-          "range": "bytes=699-1069"
+          "checksum": "sha1-v0A2vQM5k8rQY/GpIq6xI4T0YmA=",
+          "range": "bytes=701-1064"
         },
         "data": {
-          "checksum": "sha256-gNRjwZ4XQatCYWediSVb+j8lS54CggvMC5Dn3qT84So=",
-          "range": "bytes=1070-61490"
+          "checksum": "sha256-uAOrkGDDc/yqt6VjIrlTEALBJG4BCI4njqZw5jQqF0o=",
+          "range": "bytes=1065-56984"
+        },
+        "name": "keyutils-libs",
+        "signature": {
+          "checksum": "sha1-32uYMH/zGBr9Jo3hiqnThlcqBcE=",
+          "range": "bytes=0-700"
+        },
+        "url": "https://packages.wolfi.dev/os/x86_64/keyutils-libs-1.6.3-r3.apk",
+        "version": "1.6.3-r3"
+      },
+      {
+        "architecture": "x86_64",
+        "checksum": "Q1Onuac6Y+IWA7a4b8FvqX1erWDDw=",
+        "control": {
+          "checksum": "sha1-Onuac6Y+IWA7a4b8FvqX1erWDDw=",
+          "range": "bytes=693-1048"
+        },
+        "data": {
+          "checksum": "sha256-KLtDAs3iU0oyZ/FysePG/J+1H1ofDxHXIY7xvtZhtMc=",
+          "range": "bytes=1049-61503"
         },
         "name": "libverto",
         "signature": {
-          "checksum": "sha1-kuPwakYdy5EM6sd5Ba0K0Ta8x4w=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-/IXL9S1O+MwaW7KsSzz1ywEqKFQ=",
+          "range": "bytes=0-692"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libverto-0.3.2-r3.apk",
-        "version": "0.3.2-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/libverto-0.3.2-r4.apk",
+        "version": "0.3.2-r4"
       },
       {
         "architecture": "x86_64",
@@ -204,60 +204,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1gTZGkWP+QO3mUqLVJth8vrDEzzU=",
+        "checksum": "Q1Q/Zy5ovYSu2p/vVLr6DgVA1e8AQ=",
         "control": {
-          "checksum": "sha1-gTZGkWP+QO3mUqLVJth8vrDEzzU=",
-          "range": "bytes=699-1076"
+          "checksum": "sha1-Q/Zy5ovYSu2p/vVLr6DgVA1e8AQ=",
+          "range": "bytes=699-1062"
         },
         "data": {
-          "checksum": "sha256-/IFXqeKvU0GODNsz1yPIEMcFHgABT+8rbZpSlTLo4e4=",
-          "range": "bytes=1077-5915704"
+          "checksum": "sha256-H3jxsw8ytOeCIR4vq17voSVhdNokXk8C1g075txH6Bs=",
+          "range": "bytes=1063-5903754"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-l1o5ixkyWWqqJE3FOfR0QUemJUA=",
+          "checksum": "sha1-NIl2f5OI/wSZByI8Ds1ZUfbFWyw=",
           "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r9.apk",
-        "version": "3.3.0-r9"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.1-r3.apk",
+        "version": "3.3.1-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1jhAhggAuZnU7FFHnebGA26mq+jI=",
+        "checksum": "Q13wGUXdZut9OOTdY5z2amUj9wXC0=",
         "control": {
-          "checksum": "sha1-jhAhggAuZnU7FFHnebGA26mq+jI=",
-          "range": "bytes=695-1079"
+          "checksum": "sha1-3wGUXdZut9OOTdY5z2amUj9wXC0=",
+          "range": "bytes=698-1068"
         },
         "data": {
-          "checksum": "sha256-XTCQYnhGSm7SkGwqV/TQMFqGajVJVYhKAidKfLb2D3Y=",
-          "range": "bytes=1080-1197081"
+          "checksum": "sha256-mRda6+YGlOCczyIWKaHqXskTINoT1rgorHDHqAKAb7c=",
+          "range": "bytes=1069-1188955"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-qVrfDVxubkrb5Yrd2mFTv2A0G7k=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-+UdRc4U3PKw4H9OiNurHKXa5BYk=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r9.apk",
-        "version": "3.3.0-r9"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.1-r3.apk",
+        "version": "3.3.1-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1BQEXaeya6QB39QLeKcB99qBNF2o=",
+        "checksum": "Q1p04MrHQPrXOzuV/uF290zjnltqI=",
         "control": {
-          "checksum": "sha1-BQEXaeya6QB39QLeKcB99qBNF2o=",
-          "range": "bytes=699-1229"
+          "checksum": "sha1-p04MrHQPrXOzuV/uF290zjnltqI=",
+          "range": "bytes=704-1219"
         },
         "data": {
-          "checksum": "sha256-ugj/qGEBzhvdX17S22Anry+biy3lcqywhGMSHLIBCvo=",
-          "range": "bytes=1230-2551676"
+          "checksum": "sha256-TsXeqhUGykAhjQUEAlMUSzDQBcWDkkDvReoeHCL1F6c=",
+          "range": "bytes=1220-2555814"
         },
         "name": "krb5-libs",
         "signature": {
-          "checksum": "sha1-oqDPmNM4EngXAGayd/BZOqJAIao=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-cPyzS38QHuNlOCQb8IPlsl2PLHQ=",
+          "range": "bytes=0-703"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/krb5-libs-1.21.2-r2.apk",
-        "version": "1.21.2-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/krb5-libs-1.21.3-r0.apk",
+        "version": "1.21.3-r0"
       },
       {
         "architecture": "x86_64",
@@ -280,60 +280,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1wzZwtLauOQfLQC7YUvZdfKxtlwQ=",
+        "checksum": "Q17uprcuQ2VFudMcWAwtP7miJmLYs=",
         "control": {
-          "checksum": "sha1-wzZwtLauOQfLQC7YUvZdfKxtlwQ=",
-          "range": "bytes=698-1085"
+          "checksum": "sha1-7uprcuQ2VFudMcWAwtP7miJmLYs=",
+          "range": "bytes=695-1067"
         },
         "data": {
-          "checksum": "sha256-TO8CAULO44s/LphhtcaFOGJB7aFldk13v1cV9ceZHww=",
-          "range": "bytes=1086-276837"
+          "checksum": "sha256-unKdPbvO2VHZ5w1t1l8mOpQuNdUGwLhofEO4weN2Mig=",
+          "range": "bytes=1068-280973"
         },
         "name": "libuv",
         "signature": {
-          "checksum": "sha1-LRiyeKmjexy8CJizLxjd6ikon1w=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-4lKldnTO71WHMZ4tbANz6i2/Ed0=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libuv-1.48.0-r2.apk",
-        "version": "1.48.0-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libuv-1.48.0-r3.apk",
+        "version": "1.48.0-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q14S6biy8fc5OGbGEJoLBM+tJOGyo=",
+        "checksum": "Q1CN6zJbOPznWUfTrb/41KT7E6dm8=",
         "control": {
-          "checksum": "sha1-4S6biy8fc5OGbGEJoLBM+tJOGyo=",
-          "range": "bytes=703-1102"
+          "checksum": "sha1-CN6zJbOPznWUfTrb/41KT7E6dm8=",
+          "range": "bytes=699-1083"
         },
         "data": {
-          "checksum": "sha256-hwjdLQYfuMAGQeONmFVo0lZKKQK1S+3PBhrI3upm5W4=",
-          "range": "bytes=1103-155304"
+          "checksum": "sha256-ybzFzoQh1yNTcd3cjt54nYsPlAxAcMUcVMxEv1JRnpQ=",
+          "range": "bytes=1084-155375"
         },
         "name": "zlib",
         "signature": {
-          "checksum": "sha1-ZuLd7kE+AGhn27o8ZqDGM5eundc=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-CPXJcCjinAXP+H8Z5tkko8ayG6E=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/zlib-1.3.1-r2.apk",
-        "version": "1.3.1-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/zlib-1.3.1-r3.apk",
+        "version": "1.3.1-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ykDkP+AmDi2VcZZ1c4q4sez/DxI=",
+        "checksum": "Q1rgbci8SRSjW7EB0NSh6ZUPJLndM=",
         "control": {
-          "checksum": "sha1-ykDkP+AmDi2VcZZ1c4q4sez/DxI=",
-          "range": "bytes=705-1079"
+          "checksum": "sha1-rgbci8SRSjW7EB0NSh6ZUPJLndM=",
+          "range": "bytes=702-1060"
         },
         "data": {
-          "checksum": "sha256-t3BrH7lWfY3to3Fu3EKAMZx29v9Hnl5seyXJzLmZ9/4=",
-          "range": "bytes=1080-251884"
+          "checksum": "sha256-tf4xbo+NP+ssiaZtC1kOKehffAZ3+d17bhgfU3/30+g=",
+          "range": "bytes=1061-256582"
         },
         "name": "libnghttp2-14",
         "signature": {
-          "checksum": "sha1-CotSXRaPLKQCBRHrgzrDOD+4w20=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-KrsJYTyUsll+EUhHekbkdZFzeig=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.62.1-r0.apk",
-        "version": "1.62.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.62.1-r1.apk",
+        "version": "1.62.1-r1"
       },
       {
         "architecture": "x86_64",
@@ -394,136 +394,136 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1DE49kWSnmqVKJdjHFYC1bLkvyb0=",
+        "checksum": "Q1R8OxpY0fGwVaIwft4wJeswF5D54=",
         "control": {
-          "checksum": "sha1-DE49kWSnmqVKJdjHFYC1bLkvyb0=",
-          "range": "bytes=697-1078"
+          "checksum": "sha1-R8OxpY0fGwVaIwft4wJeswF5D54=",
+          "range": "bytes=695-1059"
         },
         "data": {
-          "checksum": "sha256-uDg8Qc6Rnro/68Vb5ufFSkqFLGrEsbvPb0pMJNvT1zw=",
-          "range": "bytes=1079-242085"
+          "checksum": "sha256-wNc8/SBJrGHfwywAtzCsAqeUOt0IaAhqNtlbv8OiHBE=",
+          "range": "bytes=1060-242151"
         },
         "name": "c-ares",
         "signature": {
-          "checksum": "sha1-iYEm6EWQKzxkeoDm+QsRfhw8pDg=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-55/PTlEHXI3o0hx9dSVdNwQeSMg=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.29.0-r0.apk",
-        "version": "1.29.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.31.0-r0.apk",
+        "version": "1.31.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q12eWmn2tCkXxwncU6gagKM3Wd9Sk=",
+        "checksum": "Q1g2RQKAvNjlRPxWjinIRveaq7IlY=",
         "control": {
-          "checksum": "sha1-2eWmn2tCkXxwncU6gagKM3Wd9Sk=",
-          "range": "bytes=696-1169"
+          "checksum": "sha1-g2RQKAvNjlRPxWjinIRveaq7IlY=",
+          "range": "bytes=695-1154"
         },
         "data": {
-          "checksum": "sha256-IFKNdojOhml3DbWPryQuHUiV3tgTWHyqOYD1JNe9IJ4=",
-          "range": "bytes=1170-2582015"
+          "checksum": "sha256-UsQFfOTXCZBan0mxDvR+ts0NKcbv1lNijxnRxjsmZhA=",
+          "range": "bytes=1155-2566233"
         },
         "name": "nghttp2",
         "signature": {
-          "checksum": "sha1-2/9n7KbRuOkrvhYqCFR5Mblx+z8=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-SUvMhz1cc5Or5Qh4fUEvPCp0NAw=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.62.1-r0.apk",
-        "version": "1.62.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.62.1-r1.apk",
+        "version": "1.62.1-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ialksjwPWvvZW+O2ABMbbBV/KTg=",
+        "checksum": "Q1sTMGOgdbZyDKxlRAByisPMHTbpY=",
         "control": {
-          "checksum": "sha1-ialksjwPWvvZW+O2ABMbbBV/KTg=",
-          "range": "bytes=702-1074"
+          "checksum": "sha1-sTMGOgdbZyDKxlRAByisPMHTbpY=",
+          "range": "bytes=703-1060"
         },
         "data": {
-          "checksum": "sha256-+ctDr3AO9mTXovGRPWk6h2ZgfY99Toy6esjBNHtJPY4=",
-          "range": "bytes=1075-631903"
+          "checksum": "sha256-bUy0h/zxpq7iP6vrQRMftZ9nevkHTB87hSX17wz4lmM=",
+          "range": "bytes=1061-631449"
         },
         "name": "nghttp2-dev",
         "signature": {
-          "checksum": "sha1-wZGQRluFd6DL1USzeak75o5/BTc=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-fQ6aDq3Io/gdJ5s5t3M+FwED1Y0=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.62.1-r0.apk",
-        "version": "1.62.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.62.1-r1.apk",
+        "version": "1.62.1-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1MlpRL1nBMU3RgNdSZVB42/vlGME=",
+        "checksum": "Q1rD3dEbbN8s5QAIQK1I8uF1O+oSo=",
         "control": {
-          "checksum": "sha1-MlpRL1nBMU3RgNdSZVB42/vlGME=",
-          "range": "bytes=697-1164"
+          "checksum": "sha1-rD3dEbbN8s5QAIQK1I8uF1O+oSo=",
+          "range": "bytes=701-1154"
         },
         "data": {
-          "checksum": "sha256-RiEPDasBVtnThSxGqTCDvb4J7WXM9YRpJwfYZJ3JLbs=",
-          "range": "bytes=1165-2274746"
+          "checksum": "sha256-41W2IRSRALQijYojLaqAiSSN1uO7twatGn8jqEuCZUg=",
+          "range": "bytes=1155-1439872"
         },
         "name": "xz",
         "signature": {
-          "checksum": "sha1-3wMPFIUEVfkAs7QSENemZsnTLyE=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-lozWkVrKvSrd1SoM7Zv08YYG2pA=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/xz-5.4.6-r2.apk",
-        "version": "5.4.6-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/xz-5.6.2-r0.apk",
+        "version": "5.6.2-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1TS707T+cPGL7TYVHQBCJoWwHZ0E=",
+        "checksum": "Q10AaU1ocIM4PYYNvwbml8TmpNvEA=",
         "control": {
-          "checksum": "sha1-TS707T+cPGL7TYVHQBCJoWwHZ0E=",
-          "range": "bytes=706-1098"
+          "checksum": "sha1-0AaU1ocIM4PYYNvwbml8TmpNvEA=",
+          "range": "bytes=706-1085"
         },
         "data": {
-          "checksum": "sha256-x18L706Vug5qDzq13SXuN/vGdVgzrqB06dW2DdgHGR4=",
-          "range": "bytes=1099-4541967"
+          "checksum": "sha256-1YQNYASFjlP3kXX58ec8du75ij/U6O4DPAKzJAPkln0=",
+          "range": "bytes=1086-4272589"
         },
         "name": "libxml2",
         "signature": {
-          "checksum": "sha1-BYhOxDos48sN8df8LMsSpROv2aw=",
+          "checksum": "sha1-QFjdplzGn/MiNFxMykgafr6/w6U=",
           "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.12.7-r0.apk",
-        "version": "2.12.7-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.1-r1.apk",
+        "version": "2.13.1-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1wJPtj5XZtnPiVWGM5dsT+nyfWXc=",
+        "checksum": "Q1wbnfumlWEiJnVUsJBRcQjFD3U6I=",
         "control": {
-          "checksum": "sha1-wJPtj5XZtnPiVWGM5dsT+nyfWXc=",
-          "range": "bytes=705-1234"
+          "checksum": "sha1-wbnfumlWEiJnVUsJBRcQjFD3U6I=",
+          "range": "bytes=699-1222"
         },
         "data": {
-          "checksum": "sha256-sw+CjlpsjO01q6lqzXgHnniiJKn7bqOSNO6vNqdGc7I=",
-          "range": "bytes=1235-3873775"
+          "checksum": "sha256-IXMNbJjj3kTjkWVBIHVRfG3zJQY2r5Eslgh/3TpMSsE=",
+          "range": "bytes=1223-3886778"
         },
         "name": "bind-libs",
         "signature": {
-          "checksum": "sha1-9zDzmHAeu7mWpidXAatqrLZVzUs=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-JNN15IPpJ2hMsO6hFVpDYPvvX5g=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bind-libs-9.18.26-r0.apk",
-        "version": "9.18.26-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/bind-libs-9.18.27-r1.apk",
+        "version": "9.18.27-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1AxEQdi8fVcYtGc3zHTCW3OZdY2Q=",
+        "checksum": "Q1kXUOoNa2KXixxAASo1W/im1qZ7s=",
         "control": {
-          "checksum": "sha1-AxEQdi8fVcYtGc3zHTCW3OZdY2Q=",
-          "range": "bytes=694-1208"
+          "checksum": "sha1-kXUOoNa2KXixxAASo1W/im1qZ7s=",
+          "range": "bytes=702-1215"
         },
         "data": {
-          "checksum": "sha256-/dt3qJw5D9iSJ/mKkRQkhWD8R52selhpcwXyw7KLMhg=",
-          "range": "bytes=1209-879444"
+          "checksum": "sha256-HRADvfRXfYsgEjUMGM4Hd7prpIv+YWILVfovbGOkEME=",
+          "range": "bytes=1216-879975"
         },
         "name": "bind-tools",
         "signature": {
-          "checksum": "sha1-VTb0YdUzPMk8Po0p4nj0y5Jey6k=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-8WUTMUaJTaX0T9FS/c+GddL7ttY=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bind-tools-9.18.26-r0.apk",
-        "version": "9.18.26-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/bind-tools-9.18.27-r1.apk",
+        "version": "9.18.27-r1"
       },
       {
         "architecture": "x86_64",
@@ -641,60 +641,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1fr0OtiVaD3c5nw8fy5m74hDe9PU=",
+        "checksum": "Q1BRGmQ9LZTeZqbxQ1ls69T6efViw=",
         "control": {
-          "checksum": "sha1-fr0OtiVaD3c5nw8fy5m74hDe9PU=",
-          "range": "bytes=697-1092"
+          "checksum": "sha1-BRGmQ9LZTeZqbxQ1ls69T6efViw=",
+          "range": "bytes=698-1080"
         },
         "data": {
-          "checksum": "sha256-lukjMYpGmuhBNDUbbTJMIrUWaR4rNikEnW4BgiTaLj8=",
-          "range": "bytes=1093-113872"
+          "checksum": "sha256-vtJ4WJ5M+31ZKSBYBedbrl/FrbAw8hGpPRrHC7kasOk=",
+          "range": "bytes=1081-113895"
         },
         "name": "libpsl",
         "signature": {
-          "checksum": "sha1-Lrrudgn1i1a0JhjdzeXG+exnjQA=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-DuAoiykwhu8vu1qxdEDK5oyAmf8=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libpsl-0.21.5-r2.apk",
-        "version": "0.21.5-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libpsl-0.21.5-r3.apk",
+        "version": "0.21.5-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1oauHQa0YcFcEHSQWdfohfNEN4sY=",
+        "checksum": "Q11DZVpe2UYyDr/dG6BDysZhE3L48=",
         "control": {
-          "checksum": "sha1-oauHQa0YcFcEHSQWdfohfNEN4sY=",
-          "range": "bytes=698-1057"
+          "checksum": "sha1-1DZVpe2UYyDr/dG6BDysZhE3L48=",
+          "range": "bytes=707-1049"
         },
         "data": {
-          "checksum": "sha256-d95c9lpjQrpuZ1CcQ8ZZ89LAGGKcessd+hxrOQpP4LU=",
-          "range": "bytes=1058-173549"
+          "checksum": "sha256-aECfsy7giZsLNxZM0HMeF4OS2gu+ycX4DUTJXsiZRQs=",
+          "range": "bytes=1050-173585"
         },
         "name": "libbrotlicommon1",
         "signature": {
-          "checksum": "sha1-g3ufBq/tyiNP6AaOoqwItVvh7uk=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-7LXD38QwFhklZCEqyW4qIncfZV0=",
+          "range": "bytes=0-706"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlicommon1-1.1.0-r2.apk",
-        "version": "1.1.0-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlicommon1-1.1.0-r3.apk",
+        "version": "1.1.0-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q18Otq7NLoYnNMebI/1Rr/s0zdLVw=",
+        "checksum": "Q1Cgr886A8Ryzynz9pxRKsNybVuK0=",
         "control": {
-          "checksum": "sha1-8Otq7NLoYnNMebI/1Rr/s0zdLVw=",
-          "range": "bytes=705-1072"
+          "checksum": "sha1-Cgr886A8Ryzynz9pxRKsNybVuK0=",
+          "range": "bytes=694-1043"
         },
         "data": {
-          "checksum": "sha256-sR3QidR/e46PJ/3S2fxAjN/hRSSA3Ar32Nw7VshTHWg=",
-          "range": "bytes=1073-81475"
+          "checksum": "sha256-mH+MTbqpLiqgydlgE+tSDEt0Sh1/zqMvAqspV4lr+Ks=",
+          "range": "bytes=1044-81511"
         },
         "name": "libbrotlidec1",
         "signature": {
-          "checksum": "sha1-6GpZI5cBUXOvjCYG81aZZR53lMI=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-Yp4Bde9oHQCec8HM2qn6hVKgtko=",
+          "range": "bytes=0-693"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlidec1-1.1.0-r2.apk",
-        "version": "1.1.0-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlidec1-1.1.0-r3.apk",
+        "version": "1.1.0-r3"
       },
       {
         "architecture": "x86_64",
@@ -774,22 +774,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q19f/3419Xa/xv9jgQ0mMYs011fBk=",
+        "checksum": "Q1mTmy64gKYi4THBqewuvYL2uUyHc=",
         "control": {
-          "checksum": "sha1-9f/3419Xa/xv9jgQ0mMYs011fBk=",
-          "range": "bytes=696-1041"
+          "checksum": "sha1-mTmy64gKYi4THBqewuvYL2uUyHc=",
+          "range": "bytes=700-1031"
         },
         "data": {
-          "checksum": "sha256-iqHASiMgiu6rIjbWGwBmmq1Zthae8BkE4QZkiVPH7Ek=",
-          "range": "bytes=1042-1888945"
+          "checksum": "sha256-p0qua2luH33oAgOcLkU9f7k+I8WnykFszVMwNahujDA=",
+          "range": "bytes=1032-1889523"
         },
         "name": "tzdata",
         "signature": {
-          "checksum": "sha1-PCC3jiXlTwrimRMXH/4RyNvccOM=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-sBf5jVLVpWj4DiXaAd/mjo0pTfk=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/tzdata-2024a-r2.apk",
-        "version": "2024a-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/tzdata-2024a-r3.apk",
+        "version": "2024a-r3"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/cloud-mi2.lock.json
+++ b/wolfi-images/cloud-mi2.lock.json
@@ -14,41 +14,41 @@
     "packages": [
       {
         "architecture": "x86_64",
-        "checksum": "Q1ge3SLQsJ9v2RnvIHHAP1yFyjrEU=",
+        "checksum": "Q1Ai8jWuxKZR2M2XhOpOGAoTEwnnk=",
         "control": {
-          "checksum": "sha1-ge3SLQsJ9v2RnvIHHAP1yFyjrEU=",
-          "range": "bytes=693-1040"
+          "checksum": "sha1-Ai8jWuxKZR2M2XhOpOGAoTEwnnk=",
+          "range": "bytes=705-1037"
         },
         "data": {
-          "checksum": "sha256-I0AdTdfGf4P/jwzTrLXm73l5/RNSlymEof/YZfev3xY=",
-          "range": "bytes=1041-255811"
+          "checksum": "sha256-e4UardkBVyaC49aSyrVmXNi8sSKqQl4eKYd0LxGRLA0=",
+          "range": "bytes=1038-255695"
         },
         "name": "ca-certificates-bundle",
         "signature": {
-          "checksum": "sha1-ge1eJBiQmFWAn9GapFkQpO+Rn/Y=",
-          "range": "bytes=0-692"
+          "checksum": "sha1-loRuyYQLm+atp+YteiQoj++EWIM=",
+          "range": "bytes=0-704"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20240315-r3.apk",
-        "version": "20240315-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20240315-r4.apk",
+        "version": "20240315-r4"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1bgay5kOzpmDBgqJCg7dSlawyJg0=",
+        "checksum": "Q1+GH6qRN4iy1IDt0cT0x0tin7YfI=",
         "control": {
-          "checksum": "sha1-bgay5kOzpmDBgqJCg7dSlawyJg0=",
-          "range": "bytes=703-1067"
+          "checksum": "sha1-+GH6qRN4iy1IDt0cT0x0tin7YfI=",
+          "range": "bytes=703-1051"
         },
         "data": {
-          "checksum": "sha256-f83HfRE7r2ZniH7PyPmRqcoU5NTpF+Uk4FH80QbjvBM=",
-          "range": "bytes=1068-118370"
+          "checksum": "sha256-rO0P9z2V49BSrz1A5Ap69tEappVrg5MMBjzW00rOpZc=",
+          "range": "bytes=1052-122464"
         },
         "name": "wolfi-baselayout",
         "signature": {
-          "checksum": "sha1-2hlCvYH1D7u25HkJGA75jjs/sQY=",
+          "checksum": "sha1-Ntb6VuMzDfM+frpCjKEIpDzl53I=",
           "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r11.apk",
-        "version": "20230201-r11"
+        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r12.apk",
+        "version": "20230201-r12"
       },
       {
         "architecture": "x86_64",
@@ -109,41 +109,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Zjfs1uR/mYiortANP+EFcejW+vo=",
+        "checksum": "Q1Zi0e8Bq6WCd/6uXXjVhb8YwMD1U=",
         "control": {
-          "checksum": "sha1-Zjfs1uR/mYiortANP+EFcejW+vo=",
-          "range": "bytes=698-1085"
+          "checksum": "sha1-Zi0e8Bq6WCd/6uXXjVhb8YwMD1U=",
+          "range": "bytes=700-1073"
         },
         "data": {
-          "checksum": "sha256-BMd7TzffjbrFwdbopDPVYsX0X9XnusIMNbIf33/8kwc=",
-          "range": "bytes=1086-76881"
+          "checksum": "sha256-jMhtfqVjnhuuBO7wtNZ6RS/72sZWoKt/Moage2amlks=",
+          "range": "bytes=1074-81594"
         },
         "name": "protobuf-c",
         "signature": {
-          "checksum": "sha1-efGiXyYWsJ5P2uTkB6aXEZ3kl3o=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-kATwMKztK7nk7qbYCJPkCFp6IXc=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r4.apk",
-        "version": "1.5.0-r4"
-      },
-      {
-        "architecture": "x86_64",
-        "checksum": "Q1Xf5v5uXumBgIR4d4ZxMRxdpyWlM=",
-        "control": {
-          "checksum": "sha1-Xf5v5uXumBgIR4d4ZxMRxdpyWlM=",
-          "range": "bytes=698-1078"
-        },
-        "data": {
-          "checksum": "sha256-eD7HqFCWNUBQiLq9PcWE/zPeZwkiv8hBrytI4qmfQ/8=",
-          "range": "bytes=1079-57055"
-        },
-        "name": "keyutils-libs",
-        "signature": {
-          "checksum": "sha1-V0HVgZLP7P5kNACfus3abCLCS20=",
-          "range": "bytes=0-697"
-        },
-        "url": "https://packages.wolfi.dev/os/x86_64/keyutils-libs-1.6.3-r2.apk",
-        "version": "1.6.3-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r5.apk",
+        "version": "1.5.0-r5"
       },
       {
         "architecture": "x86_64",
@@ -166,22 +147,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1wRzOx+L6MeRFtTcq2y/6ot7Cj54=",
+        "checksum": "Q1v0A2vQM5k8rQY/GpIq6xI4T0YmA=",
         "control": {
-          "checksum": "sha1-wRzOx+L6MeRFtTcq2y/6ot7Cj54=",
-          "range": "bytes=699-1069"
+          "checksum": "sha1-v0A2vQM5k8rQY/GpIq6xI4T0YmA=",
+          "range": "bytes=701-1064"
         },
         "data": {
-          "checksum": "sha256-gNRjwZ4XQatCYWediSVb+j8lS54CggvMC5Dn3qT84So=",
-          "range": "bytes=1070-61490"
+          "checksum": "sha256-uAOrkGDDc/yqt6VjIrlTEALBJG4BCI4njqZw5jQqF0o=",
+          "range": "bytes=1065-56984"
+        },
+        "name": "keyutils-libs",
+        "signature": {
+          "checksum": "sha1-32uYMH/zGBr9Jo3hiqnThlcqBcE=",
+          "range": "bytes=0-700"
+        },
+        "url": "https://packages.wolfi.dev/os/x86_64/keyutils-libs-1.6.3-r3.apk",
+        "version": "1.6.3-r3"
+      },
+      {
+        "architecture": "x86_64",
+        "checksum": "Q1Onuac6Y+IWA7a4b8FvqX1erWDDw=",
+        "control": {
+          "checksum": "sha1-Onuac6Y+IWA7a4b8FvqX1erWDDw=",
+          "range": "bytes=693-1048"
+        },
+        "data": {
+          "checksum": "sha256-KLtDAs3iU0oyZ/FysePG/J+1H1ofDxHXIY7xvtZhtMc=",
+          "range": "bytes=1049-61503"
         },
         "name": "libverto",
         "signature": {
-          "checksum": "sha1-kuPwakYdy5EM6sd5Ba0K0Ta8x4w=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-/IXL9S1O+MwaW7KsSzz1ywEqKFQ=",
+          "range": "bytes=0-692"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libverto-0.3.2-r3.apk",
-        "version": "0.3.2-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/libverto-0.3.2-r4.apk",
+        "version": "0.3.2-r4"
       },
       {
         "architecture": "x86_64",
@@ -204,60 +204,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1gTZGkWP+QO3mUqLVJth8vrDEzzU=",
+        "checksum": "Q1Q/Zy5ovYSu2p/vVLr6DgVA1e8AQ=",
         "control": {
-          "checksum": "sha1-gTZGkWP+QO3mUqLVJth8vrDEzzU=",
-          "range": "bytes=699-1076"
+          "checksum": "sha1-Q/Zy5ovYSu2p/vVLr6DgVA1e8AQ=",
+          "range": "bytes=699-1062"
         },
         "data": {
-          "checksum": "sha256-/IFXqeKvU0GODNsz1yPIEMcFHgABT+8rbZpSlTLo4e4=",
-          "range": "bytes=1077-5915704"
+          "checksum": "sha256-H3jxsw8ytOeCIR4vq17voSVhdNokXk8C1g075txH6Bs=",
+          "range": "bytes=1063-5903754"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-l1o5ixkyWWqqJE3FOfR0QUemJUA=",
+          "checksum": "sha1-NIl2f5OI/wSZByI8Ds1ZUfbFWyw=",
           "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r9.apk",
-        "version": "3.3.0-r9"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.1-r3.apk",
+        "version": "3.3.1-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1jhAhggAuZnU7FFHnebGA26mq+jI=",
+        "checksum": "Q13wGUXdZut9OOTdY5z2amUj9wXC0=",
         "control": {
-          "checksum": "sha1-jhAhggAuZnU7FFHnebGA26mq+jI=",
-          "range": "bytes=695-1079"
+          "checksum": "sha1-3wGUXdZut9OOTdY5z2amUj9wXC0=",
+          "range": "bytes=698-1068"
         },
         "data": {
-          "checksum": "sha256-XTCQYnhGSm7SkGwqV/TQMFqGajVJVYhKAidKfLb2D3Y=",
-          "range": "bytes=1080-1197081"
+          "checksum": "sha256-mRda6+YGlOCczyIWKaHqXskTINoT1rgorHDHqAKAb7c=",
+          "range": "bytes=1069-1188955"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-qVrfDVxubkrb5Yrd2mFTv2A0G7k=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-+UdRc4U3PKw4H9OiNurHKXa5BYk=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r9.apk",
-        "version": "3.3.0-r9"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.1-r3.apk",
+        "version": "3.3.1-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1BQEXaeya6QB39QLeKcB99qBNF2o=",
+        "checksum": "Q1p04MrHQPrXOzuV/uF290zjnltqI=",
         "control": {
-          "checksum": "sha1-BQEXaeya6QB39QLeKcB99qBNF2o=",
-          "range": "bytes=699-1229"
+          "checksum": "sha1-p04MrHQPrXOzuV/uF290zjnltqI=",
+          "range": "bytes=704-1219"
         },
         "data": {
-          "checksum": "sha256-ugj/qGEBzhvdX17S22Anry+biy3lcqywhGMSHLIBCvo=",
-          "range": "bytes=1230-2551676"
+          "checksum": "sha256-TsXeqhUGykAhjQUEAlMUSzDQBcWDkkDvReoeHCL1F6c=",
+          "range": "bytes=1220-2555814"
         },
         "name": "krb5-libs",
         "signature": {
-          "checksum": "sha1-oqDPmNM4EngXAGayd/BZOqJAIao=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-cPyzS38QHuNlOCQb8IPlsl2PLHQ=",
+          "range": "bytes=0-703"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/krb5-libs-1.21.2-r2.apk",
-        "version": "1.21.2-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/krb5-libs-1.21.3-r0.apk",
+        "version": "1.21.3-r0"
       },
       {
         "architecture": "x86_64",
@@ -280,60 +280,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1wzZwtLauOQfLQC7YUvZdfKxtlwQ=",
+        "checksum": "Q17uprcuQ2VFudMcWAwtP7miJmLYs=",
         "control": {
-          "checksum": "sha1-wzZwtLauOQfLQC7YUvZdfKxtlwQ=",
-          "range": "bytes=698-1085"
+          "checksum": "sha1-7uprcuQ2VFudMcWAwtP7miJmLYs=",
+          "range": "bytes=695-1067"
         },
         "data": {
-          "checksum": "sha256-TO8CAULO44s/LphhtcaFOGJB7aFldk13v1cV9ceZHww=",
-          "range": "bytes=1086-276837"
+          "checksum": "sha256-unKdPbvO2VHZ5w1t1l8mOpQuNdUGwLhofEO4weN2Mig=",
+          "range": "bytes=1068-280973"
         },
         "name": "libuv",
         "signature": {
-          "checksum": "sha1-LRiyeKmjexy8CJizLxjd6ikon1w=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-4lKldnTO71WHMZ4tbANz6i2/Ed0=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libuv-1.48.0-r2.apk",
-        "version": "1.48.0-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libuv-1.48.0-r3.apk",
+        "version": "1.48.0-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q14S6biy8fc5OGbGEJoLBM+tJOGyo=",
+        "checksum": "Q1CN6zJbOPznWUfTrb/41KT7E6dm8=",
         "control": {
-          "checksum": "sha1-4S6biy8fc5OGbGEJoLBM+tJOGyo=",
-          "range": "bytes=703-1102"
+          "checksum": "sha1-CN6zJbOPznWUfTrb/41KT7E6dm8=",
+          "range": "bytes=699-1083"
         },
         "data": {
-          "checksum": "sha256-hwjdLQYfuMAGQeONmFVo0lZKKQK1S+3PBhrI3upm5W4=",
-          "range": "bytes=1103-155304"
+          "checksum": "sha256-ybzFzoQh1yNTcd3cjt54nYsPlAxAcMUcVMxEv1JRnpQ=",
+          "range": "bytes=1084-155375"
         },
         "name": "zlib",
         "signature": {
-          "checksum": "sha1-ZuLd7kE+AGhn27o8ZqDGM5eundc=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-CPXJcCjinAXP+H8Z5tkko8ayG6E=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/zlib-1.3.1-r2.apk",
-        "version": "1.3.1-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/zlib-1.3.1-r3.apk",
+        "version": "1.3.1-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ykDkP+AmDi2VcZZ1c4q4sez/DxI=",
+        "checksum": "Q1rgbci8SRSjW7EB0NSh6ZUPJLndM=",
         "control": {
-          "checksum": "sha1-ykDkP+AmDi2VcZZ1c4q4sez/DxI=",
-          "range": "bytes=705-1079"
+          "checksum": "sha1-rgbci8SRSjW7EB0NSh6ZUPJLndM=",
+          "range": "bytes=702-1060"
         },
         "data": {
-          "checksum": "sha256-t3BrH7lWfY3to3Fu3EKAMZx29v9Hnl5seyXJzLmZ9/4=",
-          "range": "bytes=1080-251884"
+          "checksum": "sha256-tf4xbo+NP+ssiaZtC1kOKehffAZ3+d17bhgfU3/30+g=",
+          "range": "bytes=1061-256582"
         },
         "name": "libnghttp2-14",
         "signature": {
-          "checksum": "sha1-CotSXRaPLKQCBRHrgzrDOD+4w20=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-KrsJYTyUsll+EUhHekbkdZFzeig=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.62.1-r0.apk",
-        "version": "1.62.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.62.1-r1.apk",
+        "version": "1.62.1-r1"
       },
       {
         "architecture": "x86_64",
@@ -394,136 +394,136 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1DE49kWSnmqVKJdjHFYC1bLkvyb0=",
+        "checksum": "Q1R8OxpY0fGwVaIwft4wJeswF5D54=",
         "control": {
-          "checksum": "sha1-DE49kWSnmqVKJdjHFYC1bLkvyb0=",
-          "range": "bytes=697-1078"
+          "checksum": "sha1-R8OxpY0fGwVaIwft4wJeswF5D54=",
+          "range": "bytes=695-1059"
         },
         "data": {
-          "checksum": "sha256-uDg8Qc6Rnro/68Vb5ufFSkqFLGrEsbvPb0pMJNvT1zw=",
-          "range": "bytes=1079-242085"
+          "checksum": "sha256-wNc8/SBJrGHfwywAtzCsAqeUOt0IaAhqNtlbv8OiHBE=",
+          "range": "bytes=1060-242151"
         },
         "name": "c-ares",
         "signature": {
-          "checksum": "sha1-iYEm6EWQKzxkeoDm+QsRfhw8pDg=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-55/PTlEHXI3o0hx9dSVdNwQeSMg=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.29.0-r0.apk",
-        "version": "1.29.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.31.0-r0.apk",
+        "version": "1.31.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q12eWmn2tCkXxwncU6gagKM3Wd9Sk=",
+        "checksum": "Q1g2RQKAvNjlRPxWjinIRveaq7IlY=",
         "control": {
-          "checksum": "sha1-2eWmn2tCkXxwncU6gagKM3Wd9Sk=",
-          "range": "bytes=696-1169"
+          "checksum": "sha1-g2RQKAvNjlRPxWjinIRveaq7IlY=",
+          "range": "bytes=695-1154"
         },
         "data": {
-          "checksum": "sha256-IFKNdojOhml3DbWPryQuHUiV3tgTWHyqOYD1JNe9IJ4=",
-          "range": "bytes=1170-2582015"
+          "checksum": "sha256-UsQFfOTXCZBan0mxDvR+ts0NKcbv1lNijxnRxjsmZhA=",
+          "range": "bytes=1155-2566233"
         },
         "name": "nghttp2",
         "signature": {
-          "checksum": "sha1-2/9n7KbRuOkrvhYqCFR5Mblx+z8=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-SUvMhz1cc5Or5Qh4fUEvPCp0NAw=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.62.1-r0.apk",
-        "version": "1.62.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.62.1-r1.apk",
+        "version": "1.62.1-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ialksjwPWvvZW+O2ABMbbBV/KTg=",
+        "checksum": "Q1sTMGOgdbZyDKxlRAByisPMHTbpY=",
         "control": {
-          "checksum": "sha1-ialksjwPWvvZW+O2ABMbbBV/KTg=",
-          "range": "bytes=702-1074"
+          "checksum": "sha1-sTMGOgdbZyDKxlRAByisPMHTbpY=",
+          "range": "bytes=703-1060"
         },
         "data": {
-          "checksum": "sha256-+ctDr3AO9mTXovGRPWk6h2ZgfY99Toy6esjBNHtJPY4=",
-          "range": "bytes=1075-631903"
+          "checksum": "sha256-bUy0h/zxpq7iP6vrQRMftZ9nevkHTB87hSX17wz4lmM=",
+          "range": "bytes=1061-631449"
         },
         "name": "nghttp2-dev",
         "signature": {
-          "checksum": "sha1-wZGQRluFd6DL1USzeak75o5/BTc=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-fQ6aDq3Io/gdJ5s5t3M+FwED1Y0=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.62.1-r0.apk",
-        "version": "1.62.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.62.1-r1.apk",
+        "version": "1.62.1-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1MlpRL1nBMU3RgNdSZVB42/vlGME=",
+        "checksum": "Q1rD3dEbbN8s5QAIQK1I8uF1O+oSo=",
         "control": {
-          "checksum": "sha1-MlpRL1nBMU3RgNdSZVB42/vlGME=",
-          "range": "bytes=697-1164"
+          "checksum": "sha1-rD3dEbbN8s5QAIQK1I8uF1O+oSo=",
+          "range": "bytes=701-1154"
         },
         "data": {
-          "checksum": "sha256-RiEPDasBVtnThSxGqTCDvb4J7WXM9YRpJwfYZJ3JLbs=",
-          "range": "bytes=1165-2274746"
+          "checksum": "sha256-41W2IRSRALQijYojLaqAiSSN1uO7twatGn8jqEuCZUg=",
+          "range": "bytes=1155-1439872"
         },
         "name": "xz",
         "signature": {
-          "checksum": "sha1-3wMPFIUEVfkAs7QSENemZsnTLyE=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-lozWkVrKvSrd1SoM7Zv08YYG2pA=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/xz-5.4.6-r2.apk",
-        "version": "5.4.6-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/xz-5.6.2-r0.apk",
+        "version": "5.6.2-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1TS707T+cPGL7TYVHQBCJoWwHZ0E=",
+        "checksum": "Q10AaU1ocIM4PYYNvwbml8TmpNvEA=",
         "control": {
-          "checksum": "sha1-TS707T+cPGL7TYVHQBCJoWwHZ0E=",
-          "range": "bytes=706-1098"
+          "checksum": "sha1-0AaU1ocIM4PYYNvwbml8TmpNvEA=",
+          "range": "bytes=706-1085"
         },
         "data": {
-          "checksum": "sha256-x18L706Vug5qDzq13SXuN/vGdVgzrqB06dW2DdgHGR4=",
-          "range": "bytes=1099-4541967"
+          "checksum": "sha256-1YQNYASFjlP3kXX58ec8du75ij/U6O4DPAKzJAPkln0=",
+          "range": "bytes=1086-4272589"
         },
         "name": "libxml2",
         "signature": {
-          "checksum": "sha1-BYhOxDos48sN8df8LMsSpROv2aw=",
+          "checksum": "sha1-QFjdplzGn/MiNFxMykgafr6/w6U=",
           "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.12.7-r0.apk",
-        "version": "2.12.7-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.1-r1.apk",
+        "version": "2.13.1-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1wJPtj5XZtnPiVWGM5dsT+nyfWXc=",
+        "checksum": "Q1wbnfumlWEiJnVUsJBRcQjFD3U6I=",
         "control": {
-          "checksum": "sha1-wJPtj5XZtnPiVWGM5dsT+nyfWXc=",
-          "range": "bytes=705-1234"
+          "checksum": "sha1-wbnfumlWEiJnVUsJBRcQjFD3U6I=",
+          "range": "bytes=699-1222"
         },
         "data": {
-          "checksum": "sha256-sw+CjlpsjO01q6lqzXgHnniiJKn7bqOSNO6vNqdGc7I=",
-          "range": "bytes=1235-3873775"
+          "checksum": "sha256-IXMNbJjj3kTjkWVBIHVRfG3zJQY2r5Eslgh/3TpMSsE=",
+          "range": "bytes=1223-3886778"
         },
         "name": "bind-libs",
         "signature": {
-          "checksum": "sha1-9zDzmHAeu7mWpidXAatqrLZVzUs=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-JNN15IPpJ2hMsO6hFVpDYPvvX5g=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bind-libs-9.18.26-r0.apk",
-        "version": "9.18.26-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/bind-libs-9.18.27-r1.apk",
+        "version": "9.18.27-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1AxEQdi8fVcYtGc3zHTCW3OZdY2Q=",
+        "checksum": "Q1kXUOoNa2KXixxAASo1W/im1qZ7s=",
         "control": {
-          "checksum": "sha1-AxEQdi8fVcYtGc3zHTCW3OZdY2Q=",
-          "range": "bytes=694-1208"
+          "checksum": "sha1-kXUOoNa2KXixxAASo1W/im1qZ7s=",
+          "range": "bytes=702-1215"
         },
         "data": {
-          "checksum": "sha256-/dt3qJw5D9iSJ/mKkRQkhWD8R52selhpcwXyw7KLMhg=",
-          "range": "bytes=1209-879444"
+          "checksum": "sha256-HRADvfRXfYsgEjUMGM4Hd7prpIv+YWILVfovbGOkEME=",
+          "range": "bytes=1216-879975"
         },
         "name": "bind-tools",
         "signature": {
-          "checksum": "sha1-VTb0YdUzPMk8Po0p4nj0y5Jey6k=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-8WUTMUaJTaX0T9FS/c+GddL7ttY=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bind-tools-9.18.26-r0.apk",
-        "version": "9.18.26-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/bind-tools-9.18.27-r1.apk",
+        "version": "9.18.27-r1"
       },
       {
         "architecture": "x86_64",
@@ -622,60 +622,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1fr0OtiVaD3c5nw8fy5m74hDe9PU=",
+        "checksum": "Q1BRGmQ9LZTeZqbxQ1ls69T6efViw=",
         "control": {
-          "checksum": "sha1-fr0OtiVaD3c5nw8fy5m74hDe9PU=",
-          "range": "bytes=697-1092"
+          "checksum": "sha1-BRGmQ9LZTeZqbxQ1ls69T6efViw=",
+          "range": "bytes=698-1080"
         },
         "data": {
-          "checksum": "sha256-lukjMYpGmuhBNDUbbTJMIrUWaR4rNikEnW4BgiTaLj8=",
-          "range": "bytes=1093-113872"
+          "checksum": "sha256-vtJ4WJ5M+31ZKSBYBedbrl/FrbAw8hGpPRrHC7kasOk=",
+          "range": "bytes=1081-113895"
         },
         "name": "libpsl",
         "signature": {
-          "checksum": "sha1-Lrrudgn1i1a0JhjdzeXG+exnjQA=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-DuAoiykwhu8vu1qxdEDK5oyAmf8=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libpsl-0.21.5-r2.apk",
-        "version": "0.21.5-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libpsl-0.21.5-r3.apk",
+        "version": "0.21.5-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1oauHQa0YcFcEHSQWdfohfNEN4sY=",
+        "checksum": "Q11DZVpe2UYyDr/dG6BDysZhE3L48=",
         "control": {
-          "checksum": "sha1-oauHQa0YcFcEHSQWdfohfNEN4sY=",
-          "range": "bytes=698-1057"
+          "checksum": "sha1-1DZVpe2UYyDr/dG6BDysZhE3L48=",
+          "range": "bytes=707-1049"
         },
         "data": {
-          "checksum": "sha256-d95c9lpjQrpuZ1CcQ8ZZ89LAGGKcessd+hxrOQpP4LU=",
-          "range": "bytes=1058-173549"
+          "checksum": "sha256-aECfsy7giZsLNxZM0HMeF4OS2gu+ycX4DUTJXsiZRQs=",
+          "range": "bytes=1050-173585"
         },
         "name": "libbrotlicommon1",
         "signature": {
-          "checksum": "sha1-g3ufBq/tyiNP6AaOoqwItVvh7uk=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-7LXD38QwFhklZCEqyW4qIncfZV0=",
+          "range": "bytes=0-706"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlicommon1-1.1.0-r2.apk",
-        "version": "1.1.0-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlicommon1-1.1.0-r3.apk",
+        "version": "1.1.0-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q18Otq7NLoYnNMebI/1Rr/s0zdLVw=",
+        "checksum": "Q1Cgr886A8Ryzynz9pxRKsNybVuK0=",
         "control": {
-          "checksum": "sha1-8Otq7NLoYnNMebI/1Rr/s0zdLVw=",
-          "range": "bytes=705-1072"
+          "checksum": "sha1-Cgr886A8Ryzynz9pxRKsNybVuK0=",
+          "range": "bytes=694-1043"
         },
         "data": {
-          "checksum": "sha256-sR3QidR/e46PJ/3S2fxAjN/hRSSA3Ar32Nw7VshTHWg=",
-          "range": "bytes=1073-81475"
+          "checksum": "sha256-mH+MTbqpLiqgydlgE+tSDEt0Sh1/zqMvAqspV4lr+Ks=",
+          "range": "bytes=1044-81511"
         },
         "name": "libbrotlidec1",
         "signature": {
-          "checksum": "sha1-6GpZI5cBUXOvjCYG81aZZR53lMI=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-Yp4Bde9oHQCec8HM2qn6hVKgtko=",
+          "range": "bytes=0-693"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlidec1-1.1.0-r2.apk",
-        "version": "1.1.0-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlidec1-1.1.0-r3.apk",
+        "version": "1.1.0-r3"
       },
       {
         "architecture": "x86_64",
@@ -736,41 +736,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1uIKbAiTl7xWbpJXy11+HeOS/RDo=",
+        "checksum": "Q1+FlR1zI7qp3uiJm5fHTA4Hr1lSQ=",
         "control": {
-          "checksum": "sha1-uIKbAiTl7xWbpJXy11+HeOS/RDo=",
-          "range": "bytes=694-1075"
+          "checksum": "sha1-+FlR1zI7qp3uiJm5fHTA4Hr1lSQ=",
+          "range": "bytes=698-1064"
         },
         "data": {
-          "checksum": "sha256-qUT47e+MUydc5TG+6YjAi7LyDOWQeOyP5dlfnPBWRWM=",
-          "range": "bytes=1076-697425"
+          "checksum": "sha256-jx/MzLqQnCOtZqAiH6LmBTCiTD9HId1TLO3GZFDqHxQ=",
+          "range": "bytes=1065-685148"
         },
         "name": "libpcre2-8-0",
         "signature": {
-          "checksum": "sha1-T6Z2q5sW3pwjztCXPRoQKi8rfeY=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-4ZNzjpofU2aV2PzFb9SFo9ipHLE=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libpcre2-8-0-10.43-r1.apk",
-        "version": "10.43-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libpcre2-8-0-10.44-r1.apk",
+        "version": "10.44-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q111Aq+tDFOygcfZzOg1hQbtZw1Q4=",
+        "checksum": "Q1Xg04pU313NQ+1ni/3EGFESveG28=",
         "control": {
-          "checksum": "sha1-11Aq+tDFOygcfZzOg1hQbtZw1Q4=",
-          "range": "bytes=697-1140"
+          "checksum": "sha1-Xg04pU313NQ+1ni/3EGFESveG28=",
+          "range": "bytes=694-1135"
         },
         "data": {
-          "checksum": "sha256-ednk20seorMQ+xEGnt8zWpxO20xrfj7zOtAmk+XcTbA=",
-          "range": "bytes=1141-17250210"
+          "checksum": "sha256-rgB0/iCkskRu0z50yJPj5UbCkDqeT48PaLInXkivQh4=",
+          "range": "bytes=1136-17250228"
         },
         "name": "git",
         "signature": {
-          "checksum": "sha1-T1C3/QmQvuJGLjPH2YyOLIM5ewE=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-oiYirHB8Oqxgza8ivbRUYOy39i8=",
+          "range": "bytes=0-693"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/git-2.45.2-r0.apk",
-        "version": "2.45.2-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/git-2.45.2-r2.apk",
+        "version": "2.45.2-r2"
       },
       {
         "architecture": "x86_64",
@@ -926,22 +926,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1xaO01yr0uPrZYKCxdxfm7vtrnew=",
+        "checksum": "Q15hWu/tpXSQUbvPRQPettOWMEsE0=",
         "control": {
-          "checksum": "sha1-xaO01yr0uPrZYKCxdxfm7vtrnew=",
-          "range": "bytes=700-1072"
+          "checksum": "sha1-5hWu/tpXSQUbvPRQPettOWMEsE0=",
+          "range": "bytes=698-1052"
         },
         "data": {
-          "checksum": "sha256-nPcSlOR7Eo5m/pcnhDqTL9EUExMZogcK7fnmX+1rsWo=",
-          "range": "bytes=1073-626291"
+          "checksum": "sha256-EZolknQx9ASVh5ggtn8iTwLo53WysPjVcX1D07P2yXw=",
+          "range": "bytes=1053-626327"
         },
         "name": "libbrotlienc1",
         "signature": {
-          "checksum": "sha1-A8nnGDvAdzsN8uuSAU6VTmX1d5k=",
-          "range": "bytes=0-699"
+          "checksum": "sha1-MRUowULmWNyCH6OslieGlPeJN3Y=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlienc1-1.1.0-r2.apk",
-        "version": "1.1.0-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlienc1-1.1.0-r3.apk",
+        "version": "1.1.0-r3"
       },
       {
         "architecture": "x86_64",
@@ -1021,22 +1021,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q19f/3419Xa/xv9jgQ0mMYs011fBk=",
+        "checksum": "Q1mTmy64gKYi4THBqewuvYL2uUyHc=",
         "control": {
-          "checksum": "sha1-9f/3419Xa/xv9jgQ0mMYs011fBk=",
-          "range": "bytes=696-1041"
+          "checksum": "sha1-mTmy64gKYi4THBqewuvYL2uUyHc=",
+          "range": "bytes=700-1031"
         },
         "data": {
-          "checksum": "sha256-iqHASiMgiu6rIjbWGwBmmq1Zthae8BkE4QZkiVPH7Ek=",
-          "range": "bytes=1042-1888945"
+          "checksum": "sha256-p0qua2luH33oAgOcLkU9f7k+I8WnykFszVMwNahujDA=",
+          "range": "bytes=1032-1889523"
         },
         "name": "tzdata",
         "signature": {
-          "checksum": "sha1-PCC3jiXlTwrimRMXH/4RyNvccOM=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-sBf5jVLVpWj4DiXaAd/mjo0pTfk=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/tzdata-2024a-r2.apk",
-        "version": "2024a-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/tzdata-2024a-r3.apk",
+        "version": "2024a-r3"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/executor-kubernetes.lock.json
+++ b/wolfi-images/executor-kubernetes.lock.json
@@ -14,41 +14,41 @@
     "packages": [
       {
         "architecture": "x86_64",
-        "checksum": "Q1ge3SLQsJ9v2RnvIHHAP1yFyjrEU=",
+        "checksum": "Q1Ai8jWuxKZR2M2XhOpOGAoTEwnnk=",
         "control": {
-          "checksum": "sha1-ge3SLQsJ9v2RnvIHHAP1yFyjrEU=",
-          "range": "bytes=693-1040"
+          "checksum": "sha1-Ai8jWuxKZR2M2XhOpOGAoTEwnnk=",
+          "range": "bytes=705-1037"
         },
         "data": {
-          "checksum": "sha256-I0AdTdfGf4P/jwzTrLXm73l5/RNSlymEof/YZfev3xY=",
-          "range": "bytes=1041-255811"
+          "checksum": "sha256-e4UardkBVyaC49aSyrVmXNi8sSKqQl4eKYd0LxGRLA0=",
+          "range": "bytes=1038-255695"
         },
         "name": "ca-certificates-bundle",
         "signature": {
-          "checksum": "sha1-ge1eJBiQmFWAn9GapFkQpO+Rn/Y=",
-          "range": "bytes=0-692"
+          "checksum": "sha1-loRuyYQLm+atp+YteiQoj++EWIM=",
+          "range": "bytes=0-704"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20240315-r3.apk",
-        "version": "20240315-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20240315-r4.apk",
+        "version": "20240315-r4"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1bgay5kOzpmDBgqJCg7dSlawyJg0=",
+        "checksum": "Q1+GH6qRN4iy1IDt0cT0x0tin7YfI=",
         "control": {
-          "checksum": "sha1-bgay5kOzpmDBgqJCg7dSlawyJg0=",
-          "range": "bytes=703-1067"
+          "checksum": "sha1-+GH6qRN4iy1IDt0cT0x0tin7YfI=",
+          "range": "bytes=703-1051"
         },
         "data": {
-          "checksum": "sha256-f83HfRE7r2ZniH7PyPmRqcoU5NTpF+Uk4FH80QbjvBM=",
-          "range": "bytes=1068-118370"
+          "checksum": "sha256-rO0P9z2V49BSrz1A5Ap69tEappVrg5MMBjzW00rOpZc=",
+          "range": "bytes=1052-122464"
         },
         "name": "wolfi-baselayout",
         "signature": {
-          "checksum": "sha1-2hlCvYH1D7u25HkJGA75jjs/sQY=",
+          "checksum": "sha1-Ntb6VuMzDfM+frpCjKEIpDzl53I=",
           "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r11.apk",
-        "version": "20230201-r11"
+        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r12.apk",
+        "version": "20230201-r12"
       },
       {
         "architecture": "x86_64",
@@ -109,41 +109,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Zjfs1uR/mYiortANP+EFcejW+vo=",
+        "checksum": "Q1Zi0e8Bq6WCd/6uXXjVhb8YwMD1U=",
         "control": {
-          "checksum": "sha1-Zjfs1uR/mYiortANP+EFcejW+vo=",
-          "range": "bytes=698-1085"
+          "checksum": "sha1-Zi0e8Bq6WCd/6uXXjVhb8YwMD1U=",
+          "range": "bytes=700-1073"
         },
         "data": {
-          "checksum": "sha256-BMd7TzffjbrFwdbopDPVYsX0X9XnusIMNbIf33/8kwc=",
-          "range": "bytes=1086-76881"
+          "checksum": "sha256-jMhtfqVjnhuuBO7wtNZ6RS/72sZWoKt/Moage2amlks=",
+          "range": "bytes=1074-81594"
         },
         "name": "protobuf-c",
         "signature": {
-          "checksum": "sha1-efGiXyYWsJ5P2uTkB6aXEZ3kl3o=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-kATwMKztK7nk7qbYCJPkCFp6IXc=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r4.apk",
-        "version": "1.5.0-r4"
-      },
-      {
-        "architecture": "x86_64",
-        "checksum": "Q1Xf5v5uXumBgIR4d4ZxMRxdpyWlM=",
-        "control": {
-          "checksum": "sha1-Xf5v5uXumBgIR4d4ZxMRxdpyWlM=",
-          "range": "bytes=698-1078"
-        },
-        "data": {
-          "checksum": "sha256-eD7HqFCWNUBQiLq9PcWE/zPeZwkiv8hBrytI4qmfQ/8=",
-          "range": "bytes=1079-57055"
-        },
-        "name": "keyutils-libs",
-        "signature": {
-          "checksum": "sha1-V0HVgZLP7P5kNACfus3abCLCS20=",
-          "range": "bytes=0-697"
-        },
-        "url": "https://packages.wolfi.dev/os/x86_64/keyutils-libs-1.6.3-r2.apk",
-        "version": "1.6.3-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r5.apk",
+        "version": "1.5.0-r5"
       },
       {
         "architecture": "x86_64",
@@ -166,22 +147,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1wRzOx+L6MeRFtTcq2y/6ot7Cj54=",
+        "checksum": "Q1v0A2vQM5k8rQY/GpIq6xI4T0YmA=",
         "control": {
-          "checksum": "sha1-wRzOx+L6MeRFtTcq2y/6ot7Cj54=",
-          "range": "bytes=699-1069"
+          "checksum": "sha1-v0A2vQM5k8rQY/GpIq6xI4T0YmA=",
+          "range": "bytes=701-1064"
         },
         "data": {
-          "checksum": "sha256-gNRjwZ4XQatCYWediSVb+j8lS54CggvMC5Dn3qT84So=",
-          "range": "bytes=1070-61490"
+          "checksum": "sha256-uAOrkGDDc/yqt6VjIrlTEALBJG4BCI4njqZw5jQqF0o=",
+          "range": "bytes=1065-56984"
+        },
+        "name": "keyutils-libs",
+        "signature": {
+          "checksum": "sha1-32uYMH/zGBr9Jo3hiqnThlcqBcE=",
+          "range": "bytes=0-700"
+        },
+        "url": "https://packages.wolfi.dev/os/x86_64/keyutils-libs-1.6.3-r3.apk",
+        "version": "1.6.3-r3"
+      },
+      {
+        "architecture": "x86_64",
+        "checksum": "Q1Onuac6Y+IWA7a4b8FvqX1erWDDw=",
+        "control": {
+          "checksum": "sha1-Onuac6Y+IWA7a4b8FvqX1erWDDw=",
+          "range": "bytes=693-1048"
+        },
+        "data": {
+          "checksum": "sha256-KLtDAs3iU0oyZ/FysePG/J+1H1ofDxHXIY7xvtZhtMc=",
+          "range": "bytes=1049-61503"
         },
         "name": "libverto",
         "signature": {
-          "checksum": "sha1-kuPwakYdy5EM6sd5Ba0K0Ta8x4w=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-/IXL9S1O+MwaW7KsSzz1ywEqKFQ=",
+          "range": "bytes=0-692"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libverto-0.3.2-r3.apk",
-        "version": "0.3.2-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/libverto-0.3.2-r4.apk",
+        "version": "0.3.2-r4"
       },
       {
         "architecture": "x86_64",
@@ -204,60 +204,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1gTZGkWP+QO3mUqLVJth8vrDEzzU=",
+        "checksum": "Q1Q/Zy5ovYSu2p/vVLr6DgVA1e8AQ=",
         "control": {
-          "checksum": "sha1-gTZGkWP+QO3mUqLVJth8vrDEzzU=",
-          "range": "bytes=699-1076"
+          "checksum": "sha1-Q/Zy5ovYSu2p/vVLr6DgVA1e8AQ=",
+          "range": "bytes=699-1062"
         },
         "data": {
-          "checksum": "sha256-/IFXqeKvU0GODNsz1yPIEMcFHgABT+8rbZpSlTLo4e4=",
-          "range": "bytes=1077-5915704"
+          "checksum": "sha256-H3jxsw8ytOeCIR4vq17voSVhdNokXk8C1g075txH6Bs=",
+          "range": "bytes=1063-5903754"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-l1o5ixkyWWqqJE3FOfR0QUemJUA=",
+          "checksum": "sha1-NIl2f5OI/wSZByI8Ds1ZUfbFWyw=",
           "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r9.apk",
-        "version": "3.3.0-r9"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.1-r3.apk",
+        "version": "3.3.1-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1jhAhggAuZnU7FFHnebGA26mq+jI=",
+        "checksum": "Q13wGUXdZut9OOTdY5z2amUj9wXC0=",
         "control": {
-          "checksum": "sha1-jhAhggAuZnU7FFHnebGA26mq+jI=",
-          "range": "bytes=695-1079"
+          "checksum": "sha1-3wGUXdZut9OOTdY5z2amUj9wXC0=",
+          "range": "bytes=698-1068"
         },
         "data": {
-          "checksum": "sha256-XTCQYnhGSm7SkGwqV/TQMFqGajVJVYhKAidKfLb2D3Y=",
-          "range": "bytes=1080-1197081"
+          "checksum": "sha256-mRda6+YGlOCczyIWKaHqXskTINoT1rgorHDHqAKAb7c=",
+          "range": "bytes=1069-1188955"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-qVrfDVxubkrb5Yrd2mFTv2A0G7k=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-+UdRc4U3PKw4H9OiNurHKXa5BYk=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r9.apk",
-        "version": "3.3.0-r9"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.1-r3.apk",
+        "version": "3.3.1-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1BQEXaeya6QB39QLeKcB99qBNF2o=",
+        "checksum": "Q1p04MrHQPrXOzuV/uF290zjnltqI=",
         "control": {
-          "checksum": "sha1-BQEXaeya6QB39QLeKcB99qBNF2o=",
-          "range": "bytes=699-1229"
+          "checksum": "sha1-p04MrHQPrXOzuV/uF290zjnltqI=",
+          "range": "bytes=704-1219"
         },
         "data": {
-          "checksum": "sha256-ugj/qGEBzhvdX17S22Anry+biy3lcqywhGMSHLIBCvo=",
-          "range": "bytes=1230-2551676"
+          "checksum": "sha256-TsXeqhUGykAhjQUEAlMUSzDQBcWDkkDvReoeHCL1F6c=",
+          "range": "bytes=1220-2555814"
         },
         "name": "krb5-libs",
         "signature": {
-          "checksum": "sha1-oqDPmNM4EngXAGayd/BZOqJAIao=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-cPyzS38QHuNlOCQb8IPlsl2PLHQ=",
+          "range": "bytes=0-703"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/krb5-libs-1.21.2-r2.apk",
-        "version": "1.21.2-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/krb5-libs-1.21.3-r0.apk",
+        "version": "1.21.3-r0"
       },
       {
         "architecture": "x86_64",
@@ -280,60 +280,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1wzZwtLauOQfLQC7YUvZdfKxtlwQ=",
+        "checksum": "Q17uprcuQ2VFudMcWAwtP7miJmLYs=",
         "control": {
-          "checksum": "sha1-wzZwtLauOQfLQC7YUvZdfKxtlwQ=",
-          "range": "bytes=698-1085"
+          "checksum": "sha1-7uprcuQ2VFudMcWAwtP7miJmLYs=",
+          "range": "bytes=695-1067"
         },
         "data": {
-          "checksum": "sha256-TO8CAULO44s/LphhtcaFOGJB7aFldk13v1cV9ceZHww=",
-          "range": "bytes=1086-276837"
+          "checksum": "sha256-unKdPbvO2VHZ5w1t1l8mOpQuNdUGwLhofEO4weN2Mig=",
+          "range": "bytes=1068-280973"
         },
         "name": "libuv",
         "signature": {
-          "checksum": "sha1-LRiyeKmjexy8CJizLxjd6ikon1w=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-4lKldnTO71WHMZ4tbANz6i2/Ed0=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libuv-1.48.0-r2.apk",
-        "version": "1.48.0-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libuv-1.48.0-r3.apk",
+        "version": "1.48.0-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q14S6biy8fc5OGbGEJoLBM+tJOGyo=",
+        "checksum": "Q1CN6zJbOPznWUfTrb/41KT7E6dm8=",
         "control": {
-          "checksum": "sha1-4S6biy8fc5OGbGEJoLBM+tJOGyo=",
-          "range": "bytes=703-1102"
+          "checksum": "sha1-CN6zJbOPznWUfTrb/41KT7E6dm8=",
+          "range": "bytes=699-1083"
         },
         "data": {
-          "checksum": "sha256-hwjdLQYfuMAGQeONmFVo0lZKKQK1S+3PBhrI3upm5W4=",
-          "range": "bytes=1103-155304"
+          "checksum": "sha256-ybzFzoQh1yNTcd3cjt54nYsPlAxAcMUcVMxEv1JRnpQ=",
+          "range": "bytes=1084-155375"
         },
         "name": "zlib",
         "signature": {
-          "checksum": "sha1-ZuLd7kE+AGhn27o8ZqDGM5eundc=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-CPXJcCjinAXP+H8Z5tkko8ayG6E=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/zlib-1.3.1-r2.apk",
-        "version": "1.3.1-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/zlib-1.3.1-r3.apk",
+        "version": "1.3.1-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ykDkP+AmDi2VcZZ1c4q4sez/DxI=",
+        "checksum": "Q1rgbci8SRSjW7EB0NSh6ZUPJLndM=",
         "control": {
-          "checksum": "sha1-ykDkP+AmDi2VcZZ1c4q4sez/DxI=",
-          "range": "bytes=705-1079"
+          "checksum": "sha1-rgbci8SRSjW7EB0NSh6ZUPJLndM=",
+          "range": "bytes=702-1060"
         },
         "data": {
-          "checksum": "sha256-t3BrH7lWfY3to3Fu3EKAMZx29v9Hnl5seyXJzLmZ9/4=",
-          "range": "bytes=1080-251884"
+          "checksum": "sha256-tf4xbo+NP+ssiaZtC1kOKehffAZ3+d17bhgfU3/30+g=",
+          "range": "bytes=1061-256582"
         },
         "name": "libnghttp2-14",
         "signature": {
-          "checksum": "sha1-CotSXRaPLKQCBRHrgzrDOD+4w20=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-KrsJYTyUsll+EUhHekbkdZFzeig=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.62.1-r0.apk",
-        "version": "1.62.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.62.1-r1.apk",
+        "version": "1.62.1-r1"
       },
       {
         "architecture": "x86_64",
@@ -394,136 +394,136 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1DE49kWSnmqVKJdjHFYC1bLkvyb0=",
+        "checksum": "Q1R8OxpY0fGwVaIwft4wJeswF5D54=",
         "control": {
-          "checksum": "sha1-DE49kWSnmqVKJdjHFYC1bLkvyb0=",
-          "range": "bytes=697-1078"
+          "checksum": "sha1-R8OxpY0fGwVaIwft4wJeswF5D54=",
+          "range": "bytes=695-1059"
         },
         "data": {
-          "checksum": "sha256-uDg8Qc6Rnro/68Vb5ufFSkqFLGrEsbvPb0pMJNvT1zw=",
-          "range": "bytes=1079-242085"
+          "checksum": "sha256-wNc8/SBJrGHfwywAtzCsAqeUOt0IaAhqNtlbv8OiHBE=",
+          "range": "bytes=1060-242151"
         },
         "name": "c-ares",
         "signature": {
-          "checksum": "sha1-iYEm6EWQKzxkeoDm+QsRfhw8pDg=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-55/PTlEHXI3o0hx9dSVdNwQeSMg=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.29.0-r0.apk",
-        "version": "1.29.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.31.0-r0.apk",
+        "version": "1.31.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q12eWmn2tCkXxwncU6gagKM3Wd9Sk=",
+        "checksum": "Q1g2RQKAvNjlRPxWjinIRveaq7IlY=",
         "control": {
-          "checksum": "sha1-2eWmn2tCkXxwncU6gagKM3Wd9Sk=",
-          "range": "bytes=696-1169"
+          "checksum": "sha1-g2RQKAvNjlRPxWjinIRveaq7IlY=",
+          "range": "bytes=695-1154"
         },
         "data": {
-          "checksum": "sha256-IFKNdojOhml3DbWPryQuHUiV3tgTWHyqOYD1JNe9IJ4=",
-          "range": "bytes=1170-2582015"
+          "checksum": "sha256-UsQFfOTXCZBan0mxDvR+ts0NKcbv1lNijxnRxjsmZhA=",
+          "range": "bytes=1155-2566233"
         },
         "name": "nghttp2",
         "signature": {
-          "checksum": "sha1-2/9n7KbRuOkrvhYqCFR5Mblx+z8=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-SUvMhz1cc5Or5Qh4fUEvPCp0NAw=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.62.1-r0.apk",
-        "version": "1.62.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.62.1-r1.apk",
+        "version": "1.62.1-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ialksjwPWvvZW+O2ABMbbBV/KTg=",
+        "checksum": "Q1sTMGOgdbZyDKxlRAByisPMHTbpY=",
         "control": {
-          "checksum": "sha1-ialksjwPWvvZW+O2ABMbbBV/KTg=",
-          "range": "bytes=702-1074"
+          "checksum": "sha1-sTMGOgdbZyDKxlRAByisPMHTbpY=",
+          "range": "bytes=703-1060"
         },
         "data": {
-          "checksum": "sha256-+ctDr3AO9mTXovGRPWk6h2ZgfY99Toy6esjBNHtJPY4=",
-          "range": "bytes=1075-631903"
+          "checksum": "sha256-bUy0h/zxpq7iP6vrQRMftZ9nevkHTB87hSX17wz4lmM=",
+          "range": "bytes=1061-631449"
         },
         "name": "nghttp2-dev",
         "signature": {
-          "checksum": "sha1-wZGQRluFd6DL1USzeak75o5/BTc=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-fQ6aDq3Io/gdJ5s5t3M+FwED1Y0=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.62.1-r0.apk",
-        "version": "1.62.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.62.1-r1.apk",
+        "version": "1.62.1-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1MlpRL1nBMU3RgNdSZVB42/vlGME=",
+        "checksum": "Q1rD3dEbbN8s5QAIQK1I8uF1O+oSo=",
         "control": {
-          "checksum": "sha1-MlpRL1nBMU3RgNdSZVB42/vlGME=",
-          "range": "bytes=697-1164"
+          "checksum": "sha1-rD3dEbbN8s5QAIQK1I8uF1O+oSo=",
+          "range": "bytes=701-1154"
         },
         "data": {
-          "checksum": "sha256-RiEPDasBVtnThSxGqTCDvb4J7WXM9YRpJwfYZJ3JLbs=",
-          "range": "bytes=1165-2274746"
+          "checksum": "sha256-41W2IRSRALQijYojLaqAiSSN1uO7twatGn8jqEuCZUg=",
+          "range": "bytes=1155-1439872"
         },
         "name": "xz",
         "signature": {
-          "checksum": "sha1-3wMPFIUEVfkAs7QSENemZsnTLyE=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-lozWkVrKvSrd1SoM7Zv08YYG2pA=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/xz-5.4.6-r2.apk",
-        "version": "5.4.6-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/xz-5.6.2-r0.apk",
+        "version": "5.6.2-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1TS707T+cPGL7TYVHQBCJoWwHZ0E=",
+        "checksum": "Q10AaU1ocIM4PYYNvwbml8TmpNvEA=",
         "control": {
-          "checksum": "sha1-TS707T+cPGL7TYVHQBCJoWwHZ0E=",
-          "range": "bytes=706-1098"
+          "checksum": "sha1-0AaU1ocIM4PYYNvwbml8TmpNvEA=",
+          "range": "bytes=706-1085"
         },
         "data": {
-          "checksum": "sha256-x18L706Vug5qDzq13SXuN/vGdVgzrqB06dW2DdgHGR4=",
-          "range": "bytes=1099-4541967"
+          "checksum": "sha256-1YQNYASFjlP3kXX58ec8du75ij/U6O4DPAKzJAPkln0=",
+          "range": "bytes=1086-4272589"
         },
         "name": "libxml2",
         "signature": {
-          "checksum": "sha1-BYhOxDos48sN8df8LMsSpROv2aw=",
+          "checksum": "sha1-QFjdplzGn/MiNFxMykgafr6/w6U=",
           "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.12.7-r0.apk",
-        "version": "2.12.7-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.1-r1.apk",
+        "version": "2.13.1-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1wJPtj5XZtnPiVWGM5dsT+nyfWXc=",
+        "checksum": "Q1wbnfumlWEiJnVUsJBRcQjFD3U6I=",
         "control": {
-          "checksum": "sha1-wJPtj5XZtnPiVWGM5dsT+nyfWXc=",
-          "range": "bytes=705-1234"
+          "checksum": "sha1-wbnfumlWEiJnVUsJBRcQjFD3U6I=",
+          "range": "bytes=699-1222"
         },
         "data": {
-          "checksum": "sha256-sw+CjlpsjO01q6lqzXgHnniiJKn7bqOSNO6vNqdGc7I=",
-          "range": "bytes=1235-3873775"
+          "checksum": "sha256-IXMNbJjj3kTjkWVBIHVRfG3zJQY2r5Eslgh/3TpMSsE=",
+          "range": "bytes=1223-3886778"
         },
         "name": "bind-libs",
         "signature": {
-          "checksum": "sha1-9zDzmHAeu7mWpidXAatqrLZVzUs=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-JNN15IPpJ2hMsO6hFVpDYPvvX5g=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bind-libs-9.18.26-r0.apk",
-        "version": "9.18.26-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/bind-libs-9.18.27-r1.apk",
+        "version": "9.18.27-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1AxEQdi8fVcYtGc3zHTCW3OZdY2Q=",
+        "checksum": "Q1kXUOoNa2KXixxAASo1W/im1qZ7s=",
         "control": {
-          "checksum": "sha1-AxEQdi8fVcYtGc3zHTCW3OZdY2Q=",
-          "range": "bytes=694-1208"
+          "checksum": "sha1-kXUOoNa2KXixxAASo1W/im1qZ7s=",
+          "range": "bytes=702-1215"
         },
         "data": {
-          "checksum": "sha256-/dt3qJw5D9iSJ/mKkRQkhWD8R52selhpcwXyw7KLMhg=",
-          "range": "bytes=1209-879444"
+          "checksum": "sha256-HRADvfRXfYsgEjUMGM4Hd7prpIv+YWILVfovbGOkEME=",
+          "range": "bytes=1216-879975"
         },
         "name": "bind-tools",
         "signature": {
-          "checksum": "sha1-VTb0YdUzPMk8Po0p4nj0y5Jey6k=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-8WUTMUaJTaX0T9FS/c+GddL7ttY=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bind-tools-9.18.26-r0.apk",
-        "version": "9.18.26-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/bind-tools-9.18.27-r1.apk",
+        "version": "9.18.27-r1"
       },
       {
         "architecture": "x86_64",
@@ -622,60 +622,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1fr0OtiVaD3c5nw8fy5m74hDe9PU=",
+        "checksum": "Q1BRGmQ9LZTeZqbxQ1ls69T6efViw=",
         "control": {
-          "checksum": "sha1-fr0OtiVaD3c5nw8fy5m74hDe9PU=",
-          "range": "bytes=697-1092"
+          "checksum": "sha1-BRGmQ9LZTeZqbxQ1ls69T6efViw=",
+          "range": "bytes=698-1080"
         },
         "data": {
-          "checksum": "sha256-lukjMYpGmuhBNDUbbTJMIrUWaR4rNikEnW4BgiTaLj8=",
-          "range": "bytes=1093-113872"
+          "checksum": "sha256-vtJ4WJ5M+31ZKSBYBedbrl/FrbAw8hGpPRrHC7kasOk=",
+          "range": "bytes=1081-113895"
         },
         "name": "libpsl",
         "signature": {
-          "checksum": "sha1-Lrrudgn1i1a0JhjdzeXG+exnjQA=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-DuAoiykwhu8vu1qxdEDK5oyAmf8=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libpsl-0.21.5-r2.apk",
-        "version": "0.21.5-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libpsl-0.21.5-r3.apk",
+        "version": "0.21.5-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1oauHQa0YcFcEHSQWdfohfNEN4sY=",
+        "checksum": "Q11DZVpe2UYyDr/dG6BDysZhE3L48=",
         "control": {
-          "checksum": "sha1-oauHQa0YcFcEHSQWdfohfNEN4sY=",
-          "range": "bytes=698-1057"
+          "checksum": "sha1-1DZVpe2UYyDr/dG6BDysZhE3L48=",
+          "range": "bytes=707-1049"
         },
         "data": {
-          "checksum": "sha256-d95c9lpjQrpuZ1CcQ8ZZ89LAGGKcessd+hxrOQpP4LU=",
-          "range": "bytes=1058-173549"
+          "checksum": "sha256-aECfsy7giZsLNxZM0HMeF4OS2gu+ycX4DUTJXsiZRQs=",
+          "range": "bytes=1050-173585"
         },
         "name": "libbrotlicommon1",
         "signature": {
-          "checksum": "sha1-g3ufBq/tyiNP6AaOoqwItVvh7uk=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-7LXD38QwFhklZCEqyW4qIncfZV0=",
+          "range": "bytes=0-706"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlicommon1-1.1.0-r2.apk",
-        "version": "1.1.0-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlicommon1-1.1.0-r3.apk",
+        "version": "1.1.0-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q18Otq7NLoYnNMebI/1Rr/s0zdLVw=",
+        "checksum": "Q1Cgr886A8Ryzynz9pxRKsNybVuK0=",
         "control": {
-          "checksum": "sha1-8Otq7NLoYnNMebI/1Rr/s0zdLVw=",
-          "range": "bytes=705-1072"
+          "checksum": "sha1-Cgr886A8Ryzynz9pxRKsNybVuK0=",
+          "range": "bytes=694-1043"
         },
         "data": {
-          "checksum": "sha256-sR3QidR/e46PJ/3S2fxAjN/hRSSA3Ar32Nw7VshTHWg=",
-          "range": "bytes=1073-81475"
+          "checksum": "sha256-mH+MTbqpLiqgydlgE+tSDEt0Sh1/zqMvAqspV4lr+Ks=",
+          "range": "bytes=1044-81511"
         },
         "name": "libbrotlidec1",
         "signature": {
-          "checksum": "sha1-6GpZI5cBUXOvjCYG81aZZR53lMI=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-Yp4Bde9oHQCec8HM2qn6hVKgtko=",
+          "range": "bytes=0-693"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlidec1-1.1.0-r2.apk",
-        "version": "1.1.0-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlidec1-1.1.0-r3.apk",
+        "version": "1.1.0-r3"
       },
       {
         "architecture": "x86_64",
@@ -736,41 +736,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1uIKbAiTl7xWbpJXy11+HeOS/RDo=",
+        "checksum": "Q1+FlR1zI7qp3uiJm5fHTA4Hr1lSQ=",
         "control": {
-          "checksum": "sha1-uIKbAiTl7xWbpJXy11+HeOS/RDo=",
-          "range": "bytes=694-1075"
+          "checksum": "sha1-+FlR1zI7qp3uiJm5fHTA4Hr1lSQ=",
+          "range": "bytes=698-1064"
         },
         "data": {
-          "checksum": "sha256-qUT47e+MUydc5TG+6YjAi7LyDOWQeOyP5dlfnPBWRWM=",
-          "range": "bytes=1076-697425"
+          "checksum": "sha256-jx/MzLqQnCOtZqAiH6LmBTCiTD9HId1TLO3GZFDqHxQ=",
+          "range": "bytes=1065-685148"
         },
         "name": "libpcre2-8-0",
         "signature": {
-          "checksum": "sha1-T6Z2q5sW3pwjztCXPRoQKi8rfeY=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-4ZNzjpofU2aV2PzFb9SFo9ipHLE=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libpcre2-8-0-10.43-r1.apk",
-        "version": "10.43-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libpcre2-8-0-10.44-r1.apk",
+        "version": "10.44-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q111Aq+tDFOygcfZzOg1hQbtZw1Q4=",
+        "checksum": "Q1Xg04pU313NQ+1ni/3EGFESveG28=",
         "control": {
-          "checksum": "sha1-11Aq+tDFOygcfZzOg1hQbtZw1Q4=",
-          "range": "bytes=697-1140"
+          "checksum": "sha1-Xg04pU313NQ+1ni/3EGFESveG28=",
+          "range": "bytes=694-1135"
         },
         "data": {
-          "checksum": "sha256-ednk20seorMQ+xEGnt8zWpxO20xrfj7zOtAmk+XcTbA=",
-          "range": "bytes=1141-17250210"
+          "checksum": "sha256-rgB0/iCkskRu0z50yJPj5UbCkDqeT48PaLInXkivQh4=",
+          "range": "bytes=1136-17250228"
         },
         "name": "git",
         "signature": {
-          "checksum": "sha1-T1C3/QmQvuJGLjPH2YyOLIM5ewE=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-oiYirHB8Oqxgza8ivbRUYOy39i8=",
+          "range": "bytes=0-693"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/git-2.45.2-r0.apk",
-        "version": "2.45.2-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/git-2.45.2-r2.apk",
+        "version": "2.45.2-r2"
       },
       {
         "architecture": "x86_64",
@@ -812,22 +812,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q19f/3419Xa/xv9jgQ0mMYs011fBk=",
+        "checksum": "Q1mTmy64gKYi4THBqewuvYL2uUyHc=",
         "control": {
-          "checksum": "sha1-9f/3419Xa/xv9jgQ0mMYs011fBk=",
-          "range": "bytes=696-1041"
+          "checksum": "sha1-mTmy64gKYi4THBqewuvYL2uUyHc=",
+          "range": "bytes=700-1031"
         },
         "data": {
-          "checksum": "sha256-iqHASiMgiu6rIjbWGwBmmq1Zthae8BkE4QZkiVPH7Ek=",
-          "range": "bytes=1042-1888945"
+          "checksum": "sha256-p0qua2luH33oAgOcLkU9f7k+I8WnykFszVMwNahujDA=",
+          "range": "bytes=1032-1889523"
         },
         "name": "tzdata",
         "signature": {
-          "checksum": "sha1-PCC3jiXlTwrimRMXH/4RyNvccOM=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-sBf5jVLVpWj4DiXaAd/mjo0pTfk=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/tzdata-2024a-r2.apk",
-        "version": "2024a-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/tzdata-2024a-r3.apk",
+        "version": "2024a-r3"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/executor.lock.json
+++ b/wolfi-images/executor.lock.json
@@ -14,41 +14,41 @@
     "packages": [
       {
         "architecture": "x86_64",
-        "checksum": "Q1ge3SLQsJ9v2RnvIHHAP1yFyjrEU=",
+        "checksum": "Q1Ai8jWuxKZR2M2XhOpOGAoTEwnnk=",
         "control": {
-          "checksum": "sha1-ge3SLQsJ9v2RnvIHHAP1yFyjrEU=",
-          "range": "bytes=693-1040"
+          "checksum": "sha1-Ai8jWuxKZR2M2XhOpOGAoTEwnnk=",
+          "range": "bytes=705-1037"
         },
         "data": {
-          "checksum": "sha256-I0AdTdfGf4P/jwzTrLXm73l5/RNSlymEof/YZfev3xY=",
-          "range": "bytes=1041-255811"
+          "checksum": "sha256-e4UardkBVyaC49aSyrVmXNi8sSKqQl4eKYd0LxGRLA0=",
+          "range": "bytes=1038-255695"
         },
         "name": "ca-certificates-bundle",
         "signature": {
-          "checksum": "sha1-ge1eJBiQmFWAn9GapFkQpO+Rn/Y=",
-          "range": "bytes=0-692"
+          "checksum": "sha1-loRuyYQLm+atp+YteiQoj++EWIM=",
+          "range": "bytes=0-704"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20240315-r3.apk",
-        "version": "20240315-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20240315-r4.apk",
+        "version": "20240315-r4"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1bgay5kOzpmDBgqJCg7dSlawyJg0=",
+        "checksum": "Q1+GH6qRN4iy1IDt0cT0x0tin7YfI=",
         "control": {
-          "checksum": "sha1-bgay5kOzpmDBgqJCg7dSlawyJg0=",
-          "range": "bytes=703-1067"
+          "checksum": "sha1-+GH6qRN4iy1IDt0cT0x0tin7YfI=",
+          "range": "bytes=703-1051"
         },
         "data": {
-          "checksum": "sha256-f83HfRE7r2ZniH7PyPmRqcoU5NTpF+Uk4FH80QbjvBM=",
-          "range": "bytes=1068-118370"
+          "checksum": "sha256-rO0P9z2V49BSrz1A5Ap69tEappVrg5MMBjzW00rOpZc=",
+          "range": "bytes=1052-122464"
         },
         "name": "wolfi-baselayout",
         "signature": {
-          "checksum": "sha1-2hlCvYH1D7u25HkJGA75jjs/sQY=",
+          "checksum": "sha1-Ntb6VuMzDfM+frpCjKEIpDzl53I=",
           "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r11.apk",
-        "version": "20230201-r11"
+        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r12.apk",
+        "version": "20230201-r12"
       },
       {
         "architecture": "x86_64",
@@ -109,41 +109,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Zjfs1uR/mYiortANP+EFcejW+vo=",
+        "checksum": "Q1Zi0e8Bq6WCd/6uXXjVhb8YwMD1U=",
         "control": {
-          "checksum": "sha1-Zjfs1uR/mYiortANP+EFcejW+vo=",
-          "range": "bytes=698-1085"
+          "checksum": "sha1-Zi0e8Bq6WCd/6uXXjVhb8YwMD1U=",
+          "range": "bytes=700-1073"
         },
         "data": {
-          "checksum": "sha256-BMd7TzffjbrFwdbopDPVYsX0X9XnusIMNbIf33/8kwc=",
-          "range": "bytes=1086-76881"
+          "checksum": "sha256-jMhtfqVjnhuuBO7wtNZ6RS/72sZWoKt/Moage2amlks=",
+          "range": "bytes=1074-81594"
         },
         "name": "protobuf-c",
         "signature": {
-          "checksum": "sha1-efGiXyYWsJ5P2uTkB6aXEZ3kl3o=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-kATwMKztK7nk7qbYCJPkCFp6IXc=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r4.apk",
-        "version": "1.5.0-r4"
-      },
-      {
-        "architecture": "x86_64",
-        "checksum": "Q1Xf5v5uXumBgIR4d4ZxMRxdpyWlM=",
-        "control": {
-          "checksum": "sha1-Xf5v5uXumBgIR4d4ZxMRxdpyWlM=",
-          "range": "bytes=698-1078"
-        },
-        "data": {
-          "checksum": "sha256-eD7HqFCWNUBQiLq9PcWE/zPeZwkiv8hBrytI4qmfQ/8=",
-          "range": "bytes=1079-57055"
-        },
-        "name": "keyutils-libs",
-        "signature": {
-          "checksum": "sha1-V0HVgZLP7P5kNACfus3abCLCS20=",
-          "range": "bytes=0-697"
-        },
-        "url": "https://packages.wolfi.dev/os/x86_64/keyutils-libs-1.6.3-r2.apk",
-        "version": "1.6.3-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r5.apk",
+        "version": "1.5.0-r5"
       },
       {
         "architecture": "x86_64",
@@ -166,22 +147,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1wRzOx+L6MeRFtTcq2y/6ot7Cj54=",
+        "checksum": "Q1v0A2vQM5k8rQY/GpIq6xI4T0YmA=",
         "control": {
-          "checksum": "sha1-wRzOx+L6MeRFtTcq2y/6ot7Cj54=",
-          "range": "bytes=699-1069"
+          "checksum": "sha1-v0A2vQM5k8rQY/GpIq6xI4T0YmA=",
+          "range": "bytes=701-1064"
         },
         "data": {
-          "checksum": "sha256-gNRjwZ4XQatCYWediSVb+j8lS54CggvMC5Dn3qT84So=",
-          "range": "bytes=1070-61490"
+          "checksum": "sha256-uAOrkGDDc/yqt6VjIrlTEALBJG4BCI4njqZw5jQqF0o=",
+          "range": "bytes=1065-56984"
+        },
+        "name": "keyutils-libs",
+        "signature": {
+          "checksum": "sha1-32uYMH/zGBr9Jo3hiqnThlcqBcE=",
+          "range": "bytes=0-700"
+        },
+        "url": "https://packages.wolfi.dev/os/x86_64/keyutils-libs-1.6.3-r3.apk",
+        "version": "1.6.3-r3"
+      },
+      {
+        "architecture": "x86_64",
+        "checksum": "Q1Onuac6Y+IWA7a4b8FvqX1erWDDw=",
+        "control": {
+          "checksum": "sha1-Onuac6Y+IWA7a4b8FvqX1erWDDw=",
+          "range": "bytes=693-1048"
+        },
+        "data": {
+          "checksum": "sha256-KLtDAs3iU0oyZ/FysePG/J+1H1ofDxHXIY7xvtZhtMc=",
+          "range": "bytes=1049-61503"
         },
         "name": "libverto",
         "signature": {
-          "checksum": "sha1-kuPwakYdy5EM6sd5Ba0K0Ta8x4w=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-/IXL9S1O+MwaW7KsSzz1ywEqKFQ=",
+          "range": "bytes=0-692"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libverto-0.3.2-r3.apk",
-        "version": "0.3.2-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/libverto-0.3.2-r4.apk",
+        "version": "0.3.2-r4"
       },
       {
         "architecture": "x86_64",
@@ -204,60 +204,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1gTZGkWP+QO3mUqLVJth8vrDEzzU=",
+        "checksum": "Q1Q/Zy5ovYSu2p/vVLr6DgVA1e8AQ=",
         "control": {
-          "checksum": "sha1-gTZGkWP+QO3mUqLVJth8vrDEzzU=",
-          "range": "bytes=699-1076"
+          "checksum": "sha1-Q/Zy5ovYSu2p/vVLr6DgVA1e8AQ=",
+          "range": "bytes=699-1062"
         },
         "data": {
-          "checksum": "sha256-/IFXqeKvU0GODNsz1yPIEMcFHgABT+8rbZpSlTLo4e4=",
-          "range": "bytes=1077-5915704"
+          "checksum": "sha256-H3jxsw8ytOeCIR4vq17voSVhdNokXk8C1g075txH6Bs=",
+          "range": "bytes=1063-5903754"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-l1o5ixkyWWqqJE3FOfR0QUemJUA=",
+          "checksum": "sha1-NIl2f5OI/wSZByI8Ds1ZUfbFWyw=",
           "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r9.apk",
-        "version": "3.3.0-r9"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.1-r3.apk",
+        "version": "3.3.1-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1jhAhggAuZnU7FFHnebGA26mq+jI=",
+        "checksum": "Q13wGUXdZut9OOTdY5z2amUj9wXC0=",
         "control": {
-          "checksum": "sha1-jhAhggAuZnU7FFHnebGA26mq+jI=",
-          "range": "bytes=695-1079"
+          "checksum": "sha1-3wGUXdZut9OOTdY5z2amUj9wXC0=",
+          "range": "bytes=698-1068"
         },
         "data": {
-          "checksum": "sha256-XTCQYnhGSm7SkGwqV/TQMFqGajVJVYhKAidKfLb2D3Y=",
-          "range": "bytes=1080-1197081"
+          "checksum": "sha256-mRda6+YGlOCczyIWKaHqXskTINoT1rgorHDHqAKAb7c=",
+          "range": "bytes=1069-1188955"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-qVrfDVxubkrb5Yrd2mFTv2A0G7k=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-+UdRc4U3PKw4H9OiNurHKXa5BYk=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r9.apk",
-        "version": "3.3.0-r9"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.1-r3.apk",
+        "version": "3.3.1-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1BQEXaeya6QB39QLeKcB99qBNF2o=",
+        "checksum": "Q1p04MrHQPrXOzuV/uF290zjnltqI=",
         "control": {
-          "checksum": "sha1-BQEXaeya6QB39QLeKcB99qBNF2o=",
-          "range": "bytes=699-1229"
+          "checksum": "sha1-p04MrHQPrXOzuV/uF290zjnltqI=",
+          "range": "bytes=704-1219"
         },
         "data": {
-          "checksum": "sha256-ugj/qGEBzhvdX17S22Anry+biy3lcqywhGMSHLIBCvo=",
-          "range": "bytes=1230-2551676"
+          "checksum": "sha256-TsXeqhUGykAhjQUEAlMUSzDQBcWDkkDvReoeHCL1F6c=",
+          "range": "bytes=1220-2555814"
         },
         "name": "krb5-libs",
         "signature": {
-          "checksum": "sha1-oqDPmNM4EngXAGayd/BZOqJAIao=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-cPyzS38QHuNlOCQb8IPlsl2PLHQ=",
+          "range": "bytes=0-703"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/krb5-libs-1.21.2-r2.apk",
-        "version": "1.21.2-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/krb5-libs-1.21.3-r0.apk",
+        "version": "1.21.3-r0"
       },
       {
         "architecture": "x86_64",
@@ -280,60 +280,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1wzZwtLauOQfLQC7YUvZdfKxtlwQ=",
+        "checksum": "Q17uprcuQ2VFudMcWAwtP7miJmLYs=",
         "control": {
-          "checksum": "sha1-wzZwtLauOQfLQC7YUvZdfKxtlwQ=",
-          "range": "bytes=698-1085"
+          "checksum": "sha1-7uprcuQ2VFudMcWAwtP7miJmLYs=",
+          "range": "bytes=695-1067"
         },
         "data": {
-          "checksum": "sha256-TO8CAULO44s/LphhtcaFOGJB7aFldk13v1cV9ceZHww=",
-          "range": "bytes=1086-276837"
+          "checksum": "sha256-unKdPbvO2VHZ5w1t1l8mOpQuNdUGwLhofEO4weN2Mig=",
+          "range": "bytes=1068-280973"
         },
         "name": "libuv",
         "signature": {
-          "checksum": "sha1-LRiyeKmjexy8CJizLxjd6ikon1w=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-4lKldnTO71WHMZ4tbANz6i2/Ed0=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libuv-1.48.0-r2.apk",
-        "version": "1.48.0-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libuv-1.48.0-r3.apk",
+        "version": "1.48.0-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q14S6biy8fc5OGbGEJoLBM+tJOGyo=",
+        "checksum": "Q1CN6zJbOPznWUfTrb/41KT7E6dm8=",
         "control": {
-          "checksum": "sha1-4S6biy8fc5OGbGEJoLBM+tJOGyo=",
-          "range": "bytes=703-1102"
+          "checksum": "sha1-CN6zJbOPznWUfTrb/41KT7E6dm8=",
+          "range": "bytes=699-1083"
         },
         "data": {
-          "checksum": "sha256-hwjdLQYfuMAGQeONmFVo0lZKKQK1S+3PBhrI3upm5W4=",
-          "range": "bytes=1103-155304"
+          "checksum": "sha256-ybzFzoQh1yNTcd3cjt54nYsPlAxAcMUcVMxEv1JRnpQ=",
+          "range": "bytes=1084-155375"
         },
         "name": "zlib",
         "signature": {
-          "checksum": "sha1-ZuLd7kE+AGhn27o8ZqDGM5eundc=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-CPXJcCjinAXP+H8Z5tkko8ayG6E=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/zlib-1.3.1-r2.apk",
-        "version": "1.3.1-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/zlib-1.3.1-r3.apk",
+        "version": "1.3.1-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ykDkP+AmDi2VcZZ1c4q4sez/DxI=",
+        "checksum": "Q1rgbci8SRSjW7EB0NSh6ZUPJLndM=",
         "control": {
-          "checksum": "sha1-ykDkP+AmDi2VcZZ1c4q4sez/DxI=",
-          "range": "bytes=705-1079"
+          "checksum": "sha1-rgbci8SRSjW7EB0NSh6ZUPJLndM=",
+          "range": "bytes=702-1060"
         },
         "data": {
-          "checksum": "sha256-t3BrH7lWfY3to3Fu3EKAMZx29v9Hnl5seyXJzLmZ9/4=",
-          "range": "bytes=1080-251884"
+          "checksum": "sha256-tf4xbo+NP+ssiaZtC1kOKehffAZ3+d17bhgfU3/30+g=",
+          "range": "bytes=1061-256582"
         },
         "name": "libnghttp2-14",
         "signature": {
-          "checksum": "sha1-CotSXRaPLKQCBRHrgzrDOD+4w20=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-KrsJYTyUsll+EUhHekbkdZFzeig=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.62.1-r0.apk",
-        "version": "1.62.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.62.1-r1.apk",
+        "version": "1.62.1-r1"
       },
       {
         "architecture": "x86_64",
@@ -394,136 +394,136 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1DE49kWSnmqVKJdjHFYC1bLkvyb0=",
+        "checksum": "Q1R8OxpY0fGwVaIwft4wJeswF5D54=",
         "control": {
-          "checksum": "sha1-DE49kWSnmqVKJdjHFYC1bLkvyb0=",
-          "range": "bytes=697-1078"
+          "checksum": "sha1-R8OxpY0fGwVaIwft4wJeswF5D54=",
+          "range": "bytes=695-1059"
         },
         "data": {
-          "checksum": "sha256-uDg8Qc6Rnro/68Vb5ufFSkqFLGrEsbvPb0pMJNvT1zw=",
-          "range": "bytes=1079-242085"
+          "checksum": "sha256-wNc8/SBJrGHfwywAtzCsAqeUOt0IaAhqNtlbv8OiHBE=",
+          "range": "bytes=1060-242151"
         },
         "name": "c-ares",
         "signature": {
-          "checksum": "sha1-iYEm6EWQKzxkeoDm+QsRfhw8pDg=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-55/PTlEHXI3o0hx9dSVdNwQeSMg=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.29.0-r0.apk",
-        "version": "1.29.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.31.0-r0.apk",
+        "version": "1.31.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q12eWmn2tCkXxwncU6gagKM3Wd9Sk=",
+        "checksum": "Q1g2RQKAvNjlRPxWjinIRveaq7IlY=",
         "control": {
-          "checksum": "sha1-2eWmn2tCkXxwncU6gagKM3Wd9Sk=",
-          "range": "bytes=696-1169"
+          "checksum": "sha1-g2RQKAvNjlRPxWjinIRveaq7IlY=",
+          "range": "bytes=695-1154"
         },
         "data": {
-          "checksum": "sha256-IFKNdojOhml3DbWPryQuHUiV3tgTWHyqOYD1JNe9IJ4=",
-          "range": "bytes=1170-2582015"
+          "checksum": "sha256-UsQFfOTXCZBan0mxDvR+ts0NKcbv1lNijxnRxjsmZhA=",
+          "range": "bytes=1155-2566233"
         },
         "name": "nghttp2",
         "signature": {
-          "checksum": "sha1-2/9n7KbRuOkrvhYqCFR5Mblx+z8=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-SUvMhz1cc5Or5Qh4fUEvPCp0NAw=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.62.1-r0.apk",
-        "version": "1.62.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.62.1-r1.apk",
+        "version": "1.62.1-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ialksjwPWvvZW+O2ABMbbBV/KTg=",
+        "checksum": "Q1sTMGOgdbZyDKxlRAByisPMHTbpY=",
         "control": {
-          "checksum": "sha1-ialksjwPWvvZW+O2ABMbbBV/KTg=",
-          "range": "bytes=702-1074"
+          "checksum": "sha1-sTMGOgdbZyDKxlRAByisPMHTbpY=",
+          "range": "bytes=703-1060"
         },
         "data": {
-          "checksum": "sha256-+ctDr3AO9mTXovGRPWk6h2ZgfY99Toy6esjBNHtJPY4=",
-          "range": "bytes=1075-631903"
+          "checksum": "sha256-bUy0h/zxpq7iP6vrQRMftZ9nevkHTB87hSX17wz4lmM=",
+          "range": "bytes=1061-631449"
         },
         "name": "nghttp2-dev",
         "signature": {
-          "checksum": "sha1-wZGQRluFd6DL1USzeak75o5/BTc=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-fQ6aDq3Io/gdJ5s5t3M+FwED1Y0=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.62.1-r0.apk",
-        "version": "1.62.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.62.1-r1.apk",
+        "version": "1.62.1-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1MlpRL1nBMU3RgNdSZVB42/vlGME=",
+        "checksum": "Q1rD3dEbbN8s5QAIQK1I8uF1O+oSo=",
         "control": {
-          "checksum": "sha1-MlpRL1nBMU3RgNdSZVB42/vlGME=",
-          "range": "bytes=697-1164"
+          "checksum": "sha1-rD3dEbbN8s5QAIQK1I8uF1O+oSo=",
+          "range": "bytes=701-1154"
         },
         "data": {
-          "checksum": "sha256-RiEPDasBVtnThSxGqTCDvb4J7WXM9YRpJwfYZJ3JLbs=",
-          "range": "bytes=1165-2274746"
+          "checksum": "sha256-41W2IRSRALQijYojLaqAiSSN1uO7twatGn8jqEuCZUg=",
+          "range": "bytes=1155-1439872"
         },
         "name": "xz",
         "signature": {
-          "checksum": "sha1-3wMPFIUEVfkAs7QSENemZsnTLyE=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-lozWkVrKvSrd1SoM7Zv08YYG2pA=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/xz-5.4.6-r2.apk",
-        "version": "5.4.6-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/xz-5.6.2-r0.apk",
+        "version": "5.6.2-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1TS707T+cPGL7TYVHQBCJoWwHZ0E=",
+        "checksum": "Q10AaU1ocIM4PYYNvwbml8TmpNvEA=",
         "control": {
-          "checksum": "sha1-TS707T+cPGL7TYVHQBCJoWwHZ0E=",
-          "range": "bytes=706-1098"
+          "checksum": "sha1-0AaU1ocIM4PYYNvwbml8TmpNvEA=",
+          "range": "bytes=706-1085"
         },
         "data": {
-          "checksum": "sha256-x18L706Vug5qDzq13SXuN/vGdVgzrqB06dW2DdgHGR4=",
-          "range": "bytes=1099-4541967"
+          "checksum": "sha256-1YQNYASFjlP3kXX58ec8du75ij/U6O4DPAKzJAPkln0=",
+          "range": "bytes=1086-4272589"
         },
         "name": "libxml2",
         "signature": {
-          "checksum": "sha1-BYhOxDos48sN8df8LMsSpROv2aw=",
+          "checksum": "sha1-QFjdplzGn/MiNFxMykgafr6/w6U=",
           "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.12.7-r0.apk",
-        "version": "2.12.7-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.1-r1.apk",
+        "version": "2.13.1-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1wJPtj5XZtnPiVWGM5dsT+nyfWXc=",
+        "checksum": "Q1wbnfumlWEiJnVUsJBRcQjFD3U6I=",
         "control": {
-          "checksum": "sha1-wJPtj5XZtnPiVWGM5dsT+nyfWXc=",
-          "range": "bytes=705-1234"
+          "checksum": "sha1-wbnfumlWEiJnVUsJBRcQjFD3U6I=",
+          "range": "bytes=699-1222"
         },
         "data": {
-          "checksum": "sha256-sw+CjlpsjO01q6lqzXgHnniiJKn7bqOSNO6vNqdGc7I=",
-          "range": "bytes=1235-3873775"
+          "checksum": "sha256-IXMNbJjj3kTjkWVBIHVRfG3zJQY2r5Eslgh/3TpMSsE=",
+          "range": "bytes=1223-3886778"
         },
         "name": "bind-libs",
         "signature": {
-          "checksum": "sha1-9zDzmHAeu7mWpidXAatqrLZVzUs=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-JNN15IPpJ2hMsO6hFVpDYPvvX5g=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bind-libs-9.18.26-r0.apk",
-        "version": "9.18.26-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/bind-libs-9.18.27-r1.apk",
+        "version": "9.18.27-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1AxEQdi8fVcYtGc3zHTCW3OZdY2Q=",
+        "checksum": "Q1kXUOoNa2KXixxAASo1W/im1qZ7s=",
         "control": {
-          "checksum": "sha1-AxEQdi8fVcYtGc3zHTCW3OZdY2Q=",
-          "range": "bytes=694-1208"
+          "checksum": "sha1-kXUOoNa2KXixxAASo1W/im1qZ7s=",
+          "range": "bytes=702-1215"
         },
         "data": {
-          "checksum": "sha256-/dt3qJw5D9iSJ/mKkRQkhWD8R52selhpcwXyw7KLMhg=",
-          "range": "bytes=1209-879444"
+          "checksum": "sha256-HRADvfRXfYsgEjUMGM4Hd7prpIv+YWILVfovbGOkEME=",
+          "range": "bytes=1216-879975"
         },
         "name": "bind-tools",
         "signature": {
-          "checksum": "sha1-VTb0YdUzPMk8Po0p4nj0y5Jey6k=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-8WUTMUaJTaX0T9FS/c+GddL7ttY=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bind-tools-9.18.26-r0.apk",
-        "version": "9.18.26-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/bind-tools-9.18.27-r1.apk",
+        "version": "9.18.27-r1"
       },
       {
         "architecture": "x86_64",
@@ -584,22 +584,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1FaSuo5kLpGzOlCXAmVtdoeTE9KY=",
+        "checksum": "Q1fnaWc3899x9dK4z4iTFNOeM6MI0=",
         "control": {
-          "checksum": "sha1-FaSuo5kLpGzOlCXAmVtdoeTE9KY=",
-          "range": "bytes=699-1146"
+          "checksum": "sha1-fnaWc3899x9dK4z4iTFNOeM6MI0=",
+          "range": "bytes=702-1132"
         },
         "data": {
-          "checksum": "sha256-yT+SLCTF2RGijQmytiBOuD/ZmYIeILT21+D12xRVzrQ=",
-          "range": "bytes=1147-373555"
+          "checksum": "sha256-rhtsl8eIgOKIHSa3VsedIEj1sA3xRi83jc3fhTjIQLw=",
+          "range": "bytes=1133-377535"
         },
         "name": "ca-certificates",
         "signature": {
-          "checksum": "sha1-AKpkACT5QAimOprekpt14cLs7Pw=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-I1wWFlIzyXu0g5mcgMo/iyW3Mhw=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-20240315-r3.apk",
-        "version": "20240315-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-20240315-r4.apk",
+        "version": "20240315-r4"
       },
       {
         "architecture": "x86_64",
@@ -641,60 +641,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1fr0OtiVaD3c5nw8fy5m74hDe9PU=",
+        "checksum": "Q1BRGmQ9LZTeZqbxQ1ls69T6efViw=",
         "control": {
-          "checksum": "sha1-fr0OtiVaD3c5nw8fy5m74hDe9PU=",
-          "range": "bytes=697-1092"
+          "checksum": "sha1-BRGmQ9LZTeZqbxQ1ls69T6efViw=",
+          "range": "bytes=698-1080"
         },
         "data": {
-          "checksum": "sha256-lukjMYpGmuhBNDUbbTJMIrUWaR4rNikEnW4BgiTaLj8=",
-          "range": "bytes=1093-113872"
+          "checksum": "sha256-vtJ4WJ5M+31ZKSBYBedbrl/FrbAw8hGpPRrHC7kasOk=",
+          "range": "bytes=1081-113895"
         },
         "name": "libpsl",
         "signature": {
-          "checksum": "sha1-Lrrudgn1i1a0JhjdzeXG+exnjQA=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-DuAoiykwhu8vu1qxdEDK5oyAmf8=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libpsl-0.21.5-r2.apk",
-        "version": "0.21.5-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libpsl-0.21.5-r3.apk",
+        "version": "0.21.5-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1oauHQa0YcFcEHSQWdfohfNEN4sY=",
+        "checksum": "Q11DZVpe2UYyDr/dG6BDysZhE3L48=",
         "control": {
-          "checksum": "sha1-oauHQa0YcFcEHSQWdfohfNEN4sY=",
-          "range": "bytes=698-1057"
+          "checksum": "sha1-1DZVpe2UYyDr/dG6BDysZhE3L48=",
+          "range": "bytes=707-1049"
         },
         "data": {
-          "checksum": "sha256-d95c9lpjQrpuZ1CcQ8ZZ89LAGGKcessd+hxrOQpP4LU=",
-          "range": "bytes=1058-173549"
+          "checksum": "sha256-aECfsy7giZsLNxZM0HMeF4OS2gu+ycX4DUTJXsiZRQs=",
+          "range": "bytes=1050-173585"
         },
         "name": "libbrotlicommon1",
         "signature": {
-          "checksum": "sha1-g3ufBq/tyiNP6AaOoqwItVvh7uk=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-7LXD38QwFhklZCEqyW4qIncfZV0=",
+          "range": "bytes=0-706"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlicommon1-1.1.0-r2.apk",
-        "version": "1.1.0-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlicommon1-1.1.0-r3.apk",
+        "version": "1.1.0-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q18Otq7NLoYnNMebI/1Rr/s0zdLVw=",
+        "checksum": "Q1Cgr886A8Ryzynz9pxRKsNybVuK0=",
         "control": {
-          "checksum": "sha1-8Otq7NLoYnNMebI/1Rr/s0zdLVw=",
-          "range": "bytes=705-1072"
+          "checksum": "sha1-Cgr886A8Ryzynz9pxRKsNybVuK0=",
+          "range": "bytes=694-1043"
         },
         "data": {
-          "checksum": "sha256-sR3QidR/e46PJ/3S2fxAjN/hRSSA3Ar32Nw7VshTHWg=",
-          "range": "bytes=1073-81475"
+          "checksum": "sha256-mH+MTbqpLiqgydlgE+tSDEt0Sh1/zqMvAqspV4lr+Ks=",
+          "range": "bytes=1044-81511"
         },
         "name": "libbrotlidec1",
         "signature": {
-          "checksum": "sha1-6GpZI5cBUXOvjCYG81aZZR53lMI=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-Yp4Bde9oHQCec8HM2qn6hVKgtko=",
+          "range": "bytes=0-693"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlidec1-1.1.0-r2.apk",
-        "version": "1.1.0-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlidec1-1.1.0-r3.apk",
+        "version": "1.1.0-r3"
       },
       {
         "architecture": "x86_64",
@@ -774,41 +774,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1uIKbAiTl7xWbpJXy11+HeOS/RDo=",
+        "checksum": "Q1+FlR1zI7qp3uiJm5fHTA4Hr1lSQ=",
         "control": {
-          "checksum": "sha1-uIKbAiTl7xWbpJXy11+HeOS/RDo=",
-          "range": "bytes=694-1075"
+          "checksum": "sha1-+FlR1zI7qp3uiJm5fHTA4Hr1lSQ=",
+          "range": "bytes=698-1064"
         },
         "data": {
-          "checksum": "sha256-qUT47e+MUydc5TG+6YjAi7LyDOWQeOyP5dlfnPBWRWM=",
-          "range": "bytes=1076-697425"
+          "checksum": "sha256-jx/MzLqQnCOtZqAiH6LmBTCiTD9HId1TLO3GZFDqHxQ=",
+          "range": "bytes=1065-685148"
         },
         "name": "libpcre2-8-0",
         "signature": {
-          "checksum": "sha1-T6Z2q5sW3pwjztCXPRoQKi8rfeY=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-4ZNzjpofU2aV2PzFb9SFo9ipHLE=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libpcre2-8-0-10.43-r1.apk",
-        "version": "10.43-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libpcre2-8-0-10.44-r1.apk",
+        "version": "10.44-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q111Aq+tDFOygcfZzOg1hQbtZw1Q4=",
+        "checksum": "Q1Xg04pU313NQ+1ni/3EGFESveG28=",
         "control": {
-          "checksum": "sha1-11Aq+tDFOygcfZzOg1hQbtZw1Q4=",
-          "range": "bytes=697-1140"
+          "checksum": "sha1-Xg04pU313NQ+1ni/3EGFESveG28=",
+          "range": "bytes=694-1135"
         },
         "data": {
-          "checksum": "sha256-ednk20seorMQ+xEGnt8zWpxO20xrfj7zOtAmk+XcTbA=",
-          "range": "bytes=1141-17250210"
+          "checksum": "sha256-rgB0/iCkskRu0z50yJPj5UbCkDqeT48PaLInXkivQh4=",
+          "range": "bytes=1136-17250228"
         },
         "name": "git",
         "signature": {
-          "checksum": "sha1-T1C3/QmQvuJGLjPH2YyOLIM5ewE=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-oiYirHB8Oqxgza8ivbRUYOy39i8=",
+          "range": "bytes=0-693"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/git-2.45.2-r0.apk",
-        "version": "2.45.2-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/git-2.45.2-r2.apk",
+        "version": "2.45.2-r2"
       },
       {
         "architecture": "x86_64",
@@ -850,22 +850,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q19f/3419Xa/xv9jgQ0mMYs011fBk=",
+        "checksum": "Q1mTmy64gKYi4THBqewuvYL2uUyHc=",
         "control": {
-          "checksum": "sha1-9f/3419Xa/xv9jgQ0mMYs011fBk=",
-          "range": "bytes=696-1041"
+          "checksum": "sha1-mTmy64gKYi4THBqewuvYL2uUyHc=",
+          "range": "bytes=700-1031"
         },
         "data": {
-          "checksum": "sha256-iqHASiMgiu6rIjbWGwBmmq1Zthae8BkE4QZkiVPH7Ek=",
-          "range": "bytes=1042-1888945"
+          "checksum": "sha256-p0qua2luH33oAgOcLkU9f7k+I8WnykFszVMwNahujDA=",
+          "range": "bytes=1032-1889523"
         },
         "name": "tzdata",
         "signature": {
-          "checksum": "sha1-PCC3jiXlTwrimRMXH/4RyNvccOM=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-sBf5jVLVpWj4DiXaAd/mjo0pTfk=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/tzdata-2024a-r2.apk",
-        "version": "2024a-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/tzdata-2024a-r3.apk",
+        "version": "2024a-r3"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/gitserver.lock.json
+++ b/wolfi-images/gitserver.lock.json
@@ -33,41 +33,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ge3SLQsJ9v2RnvIHHAP1yFyjrEU=",
+        "checksum": "Q1Ai8jWuxKZR2M2XhOpOGAoTEwnnk=",
         "control": {
-          "checksum": "sha1-ge3SLQsJ9v2RnvIHHAP1yFyjrEU=",
-          "range": "bytes=693-1040"
+          "checksum": "sha1-Ai8jWuxKZR2M2XhOpOGAoTEwnnk=",
+          "range": "bytes=705-1037"
         },
         "data": {
-          "checksum": "sha256-I0AdTdfGf4P/jwzTrLXm73l5/RNSlymEof/YZfev3xY=",
-          "range": "bytes=1041-255811"
+          "checksum": "sha256-e4UardkBVyaC49aSyrVmXNi8sSKqQl4eKYd0LxGRLA0=",
+          "range": "bytes=1038-255695"
         },
         "name": "ca-certificates-bundle",
         "signature": {
-          "checksum": "sha1-ge1eJBiQmFWAn9GapFkQpO+Rn/Y=",
-          "range": "bytes=0-692"
+          "checksum": "sha1-loRuyYQLm+atp+YteiQoj++EWIM=",
+          "range": "bytes=0-704"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20240315-r3.apk",
-        "version": "20240315-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20240315-r4.apk",
+        "version": "20240315-r4"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1bgay5kOzpmDBgqJCg7dSlawyJg0=",
+        "checksum": "Q1+GH6qRN4iy1IDt0cT0x0tin7YfI=",
         "control": {
-          "checksum": "sha1-bgay5kOzpmDBgqJCg7dSlawyJg0=",
-          "range": "bytes=703-1067"
+          "checksum": "sha1-+GH6qRN4iy1IDt0cT0x0tin7YfI=",
+          "range": "bytes=703-1051"
         },
         "data": {
-          "checksum": "sha256-f83HfRE7r2ZniH7PyPmRqcoU5NTpF+Uk4FH80QbjvBM=",
-          "range": "bytes=1068-118370"
+          "checksum": "sha256-rO0P9z2V49BSrz1A5Ap69tEappVrg5MMBjzW00rOpZc=",
+          "range": "bytes=1052-122464"
         },
         "name": "wolfi-baselayout",
         "signature": {
-          "checksum": "sha1-2hlCvYH1D7u25HkJGA75jjs/sQY=",
+          "checksum": "sha1-Ntb6VuMzDfM+frpCjKEIpDzl53I=",
           "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r11.apk",
-        "version": "20230201-r11"
+        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r12.apk",
+        "version": "20230201-r12"
       },
       {
         "architecture": "x86_64",
@@ -147,60 +147,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ZMGiMSnjbScBstPVaw5qQfkNI+M=",
+        "checksum": "Q1w2/J0nDU8aA/f0HxunA5N19L1gw=",
         "control": {
-          "checksum": "sha1-ZMGiMSnjbScBstPVaw5qQfkNI+M=",
-          "range": "bytes=697-1097"
+          "checksum": "sha1-w2/J0nDU8aA/f0HxunA5N19L1gw=",
+          "range": "bytes=702-1086"
         },
         "data": {
-          "checksum": "sha256-XN2CeOJxCHWCgGpwTUkm5UOFKFz/eRpd7AReq4CqiOk=",
-          "range": "bytes=1098-1436391"
+          "checksum": "sha256-/2i+TNHbkrOsjrx7WHrrloXc6gcoyfyGrUHdBljYM+o=",
+          "range": "bytes=1087-1440232"
         },
         "name": "bash",
         "signature": {
-          "checksum": "sha1-t7/nmubimPIaw21oj0WlXgqY90E=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-tnYcLxCgV8srkBsTl4c/f6m11vQ=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bash-5.2.21-r4.apk",
-        "version": "5.2.21-r4"
+        "url": "https://packages.wolfi.dev/os/x86_64/bash-5.2.21-r5.apk",
+        "version": "5.2.21-r5"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Zjfs1uR/mYiortANP+EFcejW+vo=",
+        "checksum": "Q1Zi0e8Bq6WCd/6uXXjVhb8YwMD1U=",
         "control": {
-          "checksum": "sha1-Zjfs1uR/mYiortANP+EFcejW+vo=",
-          "range": "bytes=698-1085"
+          "checksum": "sha1-Zi0e8Bq6WCd/6uXXjVhb8YwMD1U=",
+          "range": "bytes=700-1073"
         },
         "data": {
-          "checksum": "sha256-BMd7TzffjbrFwdbopDPVYsX0X9XnusIMNbIf33/8kwc=",
-          "range": "bytes=1086-76881"
+          "checksum": "sha256-jMhtfqVjnhuuBO7wtNZ6RS/72sZWoKt/Moage2amlks=",
+          "range": "bytes=1074-81594"
         },
         "name": "protobuf-c",
         "signature": {
-          "checksum": "sha1-efGiXyYWsJ5P2uTkB6aXEZ3kl3o=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-kATwMKztK7nk7qbYCJPkCFp6IXc=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r4.apk",
-        "version": "1.5.0-r4"
-      },
-      {
-        "architecture": "x86_64",
-        "checksum": "Q1Xf5v5uXumBgIR4d4ZxMRxdpyWlM=",
-        "control": {
-          "checksum": "sha1-Xf5v5uXumBgIR4d4ZxMRxdpyWlM=",
-          "range": "bytes=698-1078"
-        },
-        "data": {
-          "checksum": "sha256-eD7HqFCWNUBQiLq9PcWE/zPeZwkiv8hBrytI4qmfQ/8=",
-          "range": "bytes=1079-57055"
-        },
-        "name": "keyutils-libs",
-        "signature": {
-          "checksum": "sha1-V0HVgZLP7P5kNACfus3abCLCS20=",
-          "range": "bytes=0-697"
-        },
-        "url": "https://packages.wolfi.dev/os/x86_64/keyutils-libs-1.6.3-r2.apk",
-        "version": "1.6.3-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r5.apk",
+        "version": "1.5.0-r5"
       },
       {
         "architecture": "x86_64",
@@ -223,22 +204,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1wRzOx+L6MeRFtTcq2y/6ot7Cj54=",
+        "checksum": "Q1v0A2vQM5k8rQY/GpIq6xI4T0YmA=",
         "control": {
-          "checksum": "sha1-wRzOx+L6MeRFtTcq2y/6ot7Cj54=",
-          "range": "bytes=699-1069"
+          "checksum": "sha1-v0A2vQM5k8rQY/GpIq6xI4T0YmA=",
+          "range": "bytes=701-1064"
         },
         "data": {
-          "checksum": "sha256-gNRjwZ4XQatCYWediSVb+j8lS54CggvMC5Dn3qT84So=",
-          "range": "bytes=1070-61490"
+          "checksum": "sha256-uAOrkGDDc/yqt6VjIrlTEALBJG4BCI4njqZw5jQqF0o=",
+          "range": "bytes=1065-56984"
+        },
+        "name": "keyutils-libs",
+        "signature": {
+          "checksum": "sha1-32uYMH/zGBr9Jo3hiqnThlcqBcE=",
+          "range": "bytes=0-700"
+        },
+        "url": "https://packages.wolfi.dev/os/x86_64/keyutils-libs-1.6.3-r3.apk",
+        "version": "1.6.3-r3"
+      },
+      {
+        "architecture": "x86_64",
+        "checksum": "Q1Onuac6Y+IWA7a4b8FvqX1erWDDw=",
+        "control": {
+          "checksum": "sha1-Onuac6Y+IWA7a4b8FvqX1erWDDw=",
+          "range": "bytes=693-1048"
+        },
+        "data": {
+          "checksum": "sha256-KLtDAs3iU0oyZ/FysePG/J+1H1ofDxHXIY7xvtZhtMc=",
+          "range": "bytes=1049-61503"
         },
         "name": "libverto",
         "signature": {
-          "checksum": "sha1-kuPwakYdy5EM6sd5Ba0K0Ta8x4w=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-/IXL9S1O+MwaW7KsSzz1ywEqKFQ=",
+          "range": "bytes=0-692"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libverto-0.3.2-r3.apk",
-        "version": "0.3.2-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/libverto-0.3.2-r4.apk",
+        "version": "0.3.2-r4"
       },
       {
         "architecture": "x86_64",
@@ -261,60 +261,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1gTZGkWP+QO3mUqLVJth8vrDEzzU=",
+        "checksum": "Q1Q/Zy5ovYSu2p/vVLr6DgVA1e8AQ=",
         "control": {
-          "checksum": "sha1-gTZGkWP+QO3mUqLVJth8vrDEzzU=",
-          "range": "bytes=699-1076"
+          "checksum": "sha1-Q/Zy5ovYSu2p/vVLr6DgVA1e8AQ=",
+          "range": "bytes=699-1062"
         },
         "data": {
-          "checksum": "sha256-/IFXqeKvU0GODNsz1yPIEMcFHgABT+8rbZpSlTLo4e4=",
-          "range": "bytes=1077-5915704"
+          "checksum": "sha256-H3jxsw8ytOeCIR4vq17voSVhdNokXk8C1g075txH6Bs=",
+          "range": "bytes=1063-5903754"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-l1o5ixkyWWqqJE3FOfR0QUemJUA=",
+          "checksum": "sha1-NIl2f5OI/wSZByI8Ds1ZUfbFWyw=",
           "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r9.apk",
-        "version": "3.3.0-r9"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.1-r3.apk",
+        "version": "3.3.1-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1jhAhggAuZnU7FFHnebGA26mq+jI=",
+        "checksum": "Q13wGUXdZut9OOTdY5z2amUj9wXC0=",
         "control": {
-          "checksum": "sha1-jhAhggAuZnU7FFHnebGA26mq+jI=",
-          "range": "bytes=695-1079"
+          "checksum": "sha1-3wGUXdZut9OOTdY5z2amUj9wXC0=",
+          "range": "bytes=698-1068"
         },
         "data": {
-          "checksum": "sha256-XTCQYnhGSm7SkGwqV/TQMFqGajVJVYhKAidKfLb2D3Y=",
-          "range": "bytes=1080-1197081"
+          "checksum": "sha256-mRda6+YGlOCczyIWKaHqXskTINoT1rgorHDHqAKAb7c=",
+          "range": "bytes=1069-1188955"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-qVrfDVxubkrb5Yrd2mFTv2A0G7k=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-+UdRc4U3PKw4H9OiNurHKXa5BYk=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r9.apk",
-        "version": "3.3.0-r9"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.1-r3.apk",
+        "version": "3.3.1-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1BQEXaeya6QB39QLeKcB99qBNF2o=",
+        "checksum": "Q1p04MrHQPrXOzuV/uF290zjnltqI=",
         "control": {
-          "checksum": "sha1-BQEXaeya6QB39QLeKcB99qBNF2o=",
-          "range": "bytes=699-1229"
+          "checksum": "sha1-p04MrHQPrXOzuV/uF290zjnltqI=",
+          "range": "bytes=704-1219"
         },
         "data": {
-          "checksum": "sha256-ugj/qGEBzhvdX17S22Anry+biy3lcqywhGMSHLIBCvo=",
-          "range": "bytes=1230-2551676"
+          "checksum": "sha256-TsXeqhUGykAhjQUEAlMUSzDQBcWDkkDvReoeHCL1F6c=",
+          "range": "bytes=1220-2555814"
         },
         "name": "krb5-libs",
         "signature": {
-          "checksum": "sha1-oqDPmNM4EngXAGayd/BZOqJAIao=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-cPyzS38QHuNlOCQb8IPlsl2PLHQ=",
+          "range": "bytes=0-703"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/krb5-libs-1.21.2-r2.apk",
-        "version": "1.21.2-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/krb5-libs-1.21.3-r0.apk",
+        "version": "1.21.3-r0"
       },
       {
         "architecture": "x86_64",
@@ -337,60 +337,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1wzZwtLauOQfLQC7YUvZdfKxtlwQ=",
+        "checksum": "Q17uprcuQ2VFudMcWAwtP7miJmLYs=",
         "control": {
-          "checksum": "sha1-wzZwtLauOQfLQC7YUvZdfKxtlwQ=",
-          "range": "bytes=698-1085"
+          "checksum": "sha1-7uprcuQ2VFudMcWAwtP7miJmLYs=",
+          "range": "bytes=695-1067"
         },
         "data": {
-          "checksum": "sha256-TO8CAULO44s/LphhtcaFOGJB7aFldk13v1cV9ceZHww=",
-          "range": "bytes=1086-276837"
+          "checksum": "sha256-unKdPbvO2VHZ5w1t1l8mOpQuNdUGwLhofEO4weN2Mig=",
+          "range": "bytes=1068-280973"
         },
         "name": "libuv",
         "signature": {
-          "checksum": "sha1-LRiyeKmjexy8CJizLxjd6ikon1w=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-4lKldnTO71WHMZ4tbANz6i2/Ed0=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libuv-1.48.0-r2.apk",
-        "version": "1.48.0-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libuv-1.48.0-r3.apk",
+        "version": "1.48.0-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q14S6biy8fc5OGbGEJoLBM+tJOGyo=",
+        "checksum": "Q1CN6zJbOPznWUfTrb/41KT7E6dm8=",
         "control": {
-          "checksum": "sha1-4S6biy8fc5OGbGEJoLBM+tJOGyo=",
-          "range": "bytes=703-1102"
+          "checksum": "sha1-CN6zJbOPznWUfTrb/41KT7E6dm8=",
+          "range": "bytes=699-1083"
         },
         "data": {
-          "checksum": "sha256-hwjdLQYfuMAGQeONmFVo0lZKKQK1S+3PBhrI3upm5W4=",
-          "range": "bytes=1103-155304"
+          "checksum": "sha256-ybzFzoQh1yNTcd3cjt54nYsPlAxAcMUcVMxEv1JRnpQ=",
+          "range": "bytes=1084-155375"
         },
         "name": "zlib",
         "signature": {
-          "checksum": "sha1-ZuLd7kE+AGhn27o8ZqDGM5eundc=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-CPXJcCjinAXP+H8Z5tkko8ayG6E=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/zlib-1.3.1-r2.apk",
-        "version": "1.3.1-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/zlib-1.3.1-r3.apk",
+        "version": "1.3.1-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ykDkP+AmDi2VcZZ1c4q4sez/DxI=",
+        "checksum": "Q1rgbci8SRSjW7EB0NSh6ZUPJLndM=",
         "control": {
-          "checksum": "sha1-ykDkP+AmDi2VcZZ1c4q4sez/DxI=",
-          "range": "bytes=705-1079"
+          "checksum": "sha1-rgbci8SRSjW7EB0NSh6ZUPJLndM=",
+          "range": "bytes=702-1060"
         },
         "data": {
-          "checksum": "sha256-t3BrH7lWfY3to3Fu3EKAMZx29v9Hnl5seyXJzLmZ9/4=",
-          "range": "bytes=1080-251884"
+          "checksum": "sha256-tf4xbo+NP+ssiaZtC1kOKehffAZ3+d17bhgfU3/30+g=",
+          "range": "bytes=1061-256582"
         },
         "name": "libnghttp2-14",
         "signature": {
-          "checksum": "sha1-CotSXRaPLKQCBRHrgzrDOD+4w20=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-KrsJYTyUsll+EUhHekbkdZFzeig=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.62.1-r0.apk",
-        "version": "1.62.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.62.1-r1.apk",
+        "version": "1.62.1-r1"
       },
       {
         "architecture": "x86_64",
@@ -451,136 +451,136 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1DE49kWSnmqVKJdjHFYC1bLkvyb0=",
+        "checksum": "Q1R8OxpY0fGwVaIwft4wJeswF5D54=",
         "control": {
-          "checksum": "sha1-DE49kWSnmqVKJdjHFYC1bLkvyb0=",
-          "range": "bytes=697-1078"
+          "checksum": "sha1-R8OxpY0fGwVaIwft4wJeswF5D54=",
+          "range": "bytes=695-1059"
         },
         "data": {
-          "checksum": "sha256-uDg8Qc6Rnro/68Vb5ufFSkqFLGrEsbvPb0pMJNvT1zw=",
-          "range": "bytes=1079-242085"
+          "checksum": "sha256-wNc8/SBJrGHfwywAtzCsAqeUOt0IaAhqNtlbv8OiHBE=",
+          "range": "bytes=1060-242151"
         },
         "name": "c-ares",
         "signature": {
-          "checksum": "sha1-iYEm6EWQKzxkeoDm+QsRfhw8pDg=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-55/PTlEHXI3o0hx9dSVdNwQeSMg=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.29.0-r0.apk",
-        "version": "1.29.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.31.0-r0.apk",
+        "version": "1.31.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q12eWmn2tCkXxwncU6gagKM3Wd9Sk=",
+        "checksum": "Q1g2RQKAvNjlRPxWjinIRveaq7IlY=",
         "control": {
-          "checksum": "sha1-2eWmn2tCkXxwncU6gagKM3Wd9Sk=",
-          "range": "bytes=696-1169"
+          "checksum": "sha1-g2RQKAvNjlRPxWjinIRveaq7IlY=",
+          "range": "bytes=695-1154"
         },
         "data": {
-          "checksum": "sha256-IFKNdojOhml3DbWPryQuHUiV3tgTWHyqOYD1JNe9IJ4=",
-          "range": "bytes=1170-2582015"
+          "checksum": "sha256-UsQFfOTXCZBan0mxDvR+ts0NKcbv1lNijxnRxjsmZhA=",
+          "range": "bytes=1155-2566233"
         },
         "name": "nghttp2",
         "signature": {
-          "checksum": "sha1-2/9n7KbRuOkrvhYqCFR5Mblx+z8=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-SUvMhz1cc5Or5Qh4fUEvPCp0NAw=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.62.1-r0.apk",
-        "version": "1.62.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.62.1-r1.apk",
+        "version": "1.62.1-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ialksjwPWvvZW+O2ABMbbBV/KTg=",
+        "checksum": "Q1sTMGOgdbZyDKxlRAByisPMHTbpY=",
         "control": {
-          "checksum": "sha1-ialksjwPWvvZW+O2ABMbbBV/KTg=",
-          "range": "bytes=702-1074"
+          "checksum": "sha1-sTMGOgdbZyDKxlRAByisPMHTbpY=",
+          "range": "bytes=703-1060"
         },
         "data": {
-          "checksum": "sha256-+ctDr3AO9mTXovGRPWk6h2ZgfY99Toy6esjBNHtJPY4=",
-          "range": "bytes=1075-631903"
+          "checksum": "sha256-bUy0h/zxpq7iP6vrQRMftZ9nevkHTB87hSX17wz4lmM=",
+          "range": "bytes=1061-631449"
         },
         "name": "nghttp2-dev",
         "signature": {
-          "checksum": "sha1-wZGQRluFd6DL1USzeak75o5/BTc=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-fQ6aDq3Io/gdJ5s5t3M+FwED1Y0=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.62.1-r0.apk",
-        "version": "1.62.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.62.1-r1.apk",
+        "version": "1.62.1-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1MlpRL1nBMU3RgNdSZVB42/vlGME=",
+        "checksum": "Q1rD3dEbbN8s5QAIQK1I8uF1O+oSo=",
         "control": {
-          "checksum": "sha1-MlpRL1nBMU3RgNdSZVB42/vlGME=",
-          "range": "bytes=697-1164"
+          "checksum": "sha1-rD3dEbbN8s5QAIQK1I8uF1O+oSo=",
+          "range": "bytes=701-1154"
         },
         "data": {
-          "checksum": "sha256-RiEPDasBVtnThSxGqTCDvb4J7WXM9YRpJwfYZJ3JLbs=",
-          "range": "bytes=1165-2274746"
+          "checksum": "sha256-41W2IRSRALQijYojLaqAiSSN1uO7twatGn8jqEuCZUg=",
+          "range": "bytes=1155-1439872"
         },
         "name": "xz",
         "signature": {
-          "checksum": "sha1-3wMPFIUEVfkAs7QSENemZsnTLyE=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-lozWkVrKvSrd1SoM7Zv08YYG2pA=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/xz-5.4.6-r2.apk",
-        "version": "5.4.6-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/xz-5.6.2-r0.apk",
+        "version": "5.6.2-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1TS707T+cPGL7TYVHQBCJoWwHZ0E=",
+        "checksum": "Q10AaU1ocIM4PYYNvwbml8TmpNvEA=",
         "control": {
-          "checksum": "sha1-TS707T+cPGL7TYVHQBCJoWwHZ0E=",
-          "range": "bytes=706-1098"
+          "checksum": "sha1-0AaU1ocIM4PYYNvwbml8TmpNvEA=",
+          "range": "bytes=706-1085"
         },
         "data": {
-          "checksum": "sha256-x18L706Vug5qDzq13SXuN/vGdVgzrqB06dW2DdgHGR4=",
-          "range": "bytes=1099-4541967"
+          "checksum": "sha256-1YQNYASFjlP3kXX58ec8du75ij/U6O4DPAKzJAPkln0=",
+          "range": "bytes=1086-4272589"
         },
         "name": "libxml2",
         "signature": {
-          "checksum": "sha1-BYhOxDos48sN8df8LMsSpROv2aw=",
+          "checksum": "sha1-QFjdplzGn/MiNFxMykgafr6/w6U=",
           "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.12.7-r0.apk",
-        "version": "2.12.7-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.1-r1.apk",
+        "version": "2.13.1-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1wJPtj5XZtnPiVWGM5dsT+nyfWXc=",
+        "checksum": "Q1wbnfumlWEiJnVUsJBRcQjFD3U6I=",
         "control": {
-          "checksum": "sha1-wJPtj5XZtnPiVWGM5dsT+nyfWXc=",
-          "range": "bytes=705-1234"
+          "checksum": "sha1-wbnfumlWEiJnVUsJBRcQjFD3U6I=",
+          "range": "bytes=699-1222"
         },
         "data": {
-          "checksum": "sha256-sw+CjlpsjO01q6lqzXgHnniiJKn7bqOSNO6vNqdGc7I=",
-          "range": "bytes=1235-3873775"
+          "checksum": "sha256-IXMNbJjj3kTjkWVBIHVRfG3zJQY2r5Eslgh/3TpMSsE=",
+          "range": "bytes=1223-3886778"
         },
         "name": "bind-libs",
         "signature": {
-          "checksum": "sha1-9zDzmHAeu7mWpidXAatqrLZVzUs=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-JNN15IPpJ2hMsO6hFVpDYPvvX5g=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bind-libs-9.18.26-r0.apk",
-        "version": "9.18.26-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/bind-libs-9.18.27-r1.apk",
+        "version": "9.18.27-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1AxEQdi8fVcYtGc3zHTCW3OZdY2Q=",
+        "checksum": "Q1kXUOoNa2KXixxAASo1W/im1qZ7s=",
         "control": {
-          "checksum": "sha1-AxEQdi8fVcYtGc3zHTCW3OZdY2Q=",
-          "range": "bytes=694-1208"
+          "checksum": "sha1-kXUOoNa2KXixxAASo1W/im1qZ7s=",
+          "range": "bytes=702-1215"
         },
         "data": {
-          "checksum": "sha256-/dt3qJw5D9iSJ/mKkRQkhWD8R52selhpcwXyw7KLMhg=",
-          "range": "bytes=1209-879444"
+          "checksum": "sha256-HRADvfRXfYsgEjUMGM4Hd7prpIv+YWILVfovbGOkEME=",
+          "range": "bytes=1216-879975"
         },
         "name": "bind-tools",
         "signature": {
-          "checksum": "sha1-VTb0YdUzPMk8Po0p4nj0y5Jey6k=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-8WUTMUaJTaX0T9FS/c+GddL7ttY=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bind-tools-9.18.26-r0.apk",
-        "version": "9.18.26-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/bind-tools-9.18.27-r1.apk",
+        "version": "9.18.27-r1"
       },
       {
         "architecture": "x86_64",
@@ -698,60 +698,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1fr0OtiVaD3c5nw8fy5m74hDe9PU=",
+        "checksum": "Q1BRGmQ9LZTeZqbxQ1ls69T6efViw=",
         "control": {
-          "checksum": "sha1-fr0OtiVaD3c5nw8fy5m74hDe9PU=",
-          "range": "bytes=697-1092"
+          "checksum": "sha1-BRGmQ9LZTeZqbxQ1ls69T6efViw=",
+          "range": "bytes=698-1080"
         },
         "data": {
-          "checksum": "sha256-lukjMYpGmuhBNDUbbTJMIrUWaR4rNikEnW4BgiTaLj8=",
-          "range": "bytes=1093-113872"
+          "checksum": "sha256-vtJ4WJ5M+31ZKSBYBedbrl/FrbAw8hGpPRrHC7kasOk=",
+          "range": "bytes=1081-113895"
         },
         "name": "libpsl",
         "signature": {
-          "checksum": "sha1-Lrrudgn1i1a0JhjdzeXG+exnjQA=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-DuAoiykwhu8vu1qxdEDK5oyAmf8=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libpsl-0.21.5-r2.apk",
-        "version": "0.21.5-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libpsl-0.21.5-r3.apk",
+        "version": "0.21.5-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1oauHQa0YcFcEHSQWdfohfNEN4sY=",
+        "checksum": "Q11DZVpe2UYyDr/dG6BDysZhE3L48=",
         "control": {
-          "checksum": "sha1-oauHQa0YcFcEHSQWdfohfNEN4sY=",
-          "range": "bytes=698-1057"
+          "checksum": "sha1-1DZVpe2UYyDr/dG6BDysZhE3L48=",
+          "range": "bytes=707-1049"
         },
         "data": {
-          "checksum": "sha256-d95c9lpjQrpuZ1CcQ8ZZ89LAGGKcessd+hxrOQpP4LU=",
-          "range": "bytes=1058-173549"
+          "checksum": "sha256-aECfsy7giZsLNxZM0HMeF4OS2gu+ycX4DUTJXsiZRQs=",
+          "range": "bytes=1050-173585"
         },
         "name": "libbrotlicommon1",
         "signature": {
-          "checksum": "sha1-g3ufBq/tyiNP6AaOoqwItVvh7uk=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-7LXD38QwFhklZCEqyW4qIncfZV0=",
+          "range": "bytes=0-706"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlicommon1-1.1.0-r2.apk",
-        "version": "1.1.0-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlicommon1-1.1.0-r3.apk",
+        "version": "1.1.0-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q18Otq7NLoYnNMebI/1Rr/s0zdLVw=",
+        "checksum": "Q1Cgr886A8Ryzynz9pxRKsNybVuK0=",
         "control": {
-          "checksum": "sha1-8Otq7NLoYnNMebI/1Rr/s0zdLVw=",
-          "range": "bytes=705-1072"
+          "checksum": "sha1-Cgr886A8Ryzynz9pxRKsNybVuK0=",
+          "range": "bytes=694-1043"
         },
         "data": {
-          "checksum": "sha256-sR3QidR/e46PJ/3S2fxAjN/hRSSA3Ar32Nw7VshTHWg=",
-          "range": "bytes=1073-81475"
+          "checksum": "sha256-mH+MTbqpLiqgydlgE+tSDEt0Sh1/zqMvAqspV4lr+Ks=",
+          "range": "bytes=1044-81511"
         },
         "name": "libbrotlidec1",
         "signature": {
-          "checksum": "sha1-6GpZI5cBUXOvjCYG81aZZR53lMI=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-Yp4Bde9oHQCec8HM2qn6hVKgtko=",
+          "range": "bytes=0-693"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlidec1-1.1.0-r2.apk",
-        "version": "1.1.0-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlidec1-1.1.0-r3.apk",
+        "version": "1.1.0-r3"
       },
       {
         "architecture": "x86_64",
@@ -812,41 +812,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1uIKbAiTl7xWbpJXy11+HeOS/RDo=",
+        "checksum": "Q1+FlR1zI7qp3uiJm5fHTA4Hr1lSQ=",
         "control": {
-          "checksum": "sha1-uIKbAiTl7xWbpJXy11+HeOS/RDo=",
-          "range": "bytes=694-1075"
+          "checksum": "sha1-+FlR1zI7qp3uiJm5fHTA4Hr1lSQ=",
+          "range": "bytes=698-1064"
         },
         "data": {
-          "checksum": "sha256-qUT47e+MUydc5TG+6YjAi7LyDOWQeOyP5dlfnPBWRWM=",
-          "range": "bytes=1076-697425"
+          "checksum": "sha256-jx/MzLqQnCOtZqAiH6LmBTCiTD9HId1TLO3GZFDqHxQ=",
+          "range": "bytes=1065-685148"
         },
         "name": "libpcre2-8-0",
         "signature": {
-          "checksum": "sha1-T6Z2q5sW3pwjztCXPRoQKi8rfeY=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-4ZNzjpofU2aV2PzFb9SFo9ipHLE=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libpcre2-8-0-10.43-r1.apk",
-        "version": "10.43-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libpcre2-8-0-10.44-r1.apk",
+        "version": "10.44-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q111Aq+tDFOygcfZzOg1hQbtZw1Q4=",
+        "checksum": "Q1Xg04pU313NQ+1ni/3EGFESveG28=",
         "control": {
-          "checksum": "sha1-11Aq+tDFOygcfZzOg1hQbtZw1Q4=",
-          "range": "bytes=697-1140"
+          "checksum": "sha1-Xg04pU313NQ+1ni/3EGFESveG28=",
+          "range": "bytes=694-1135"
         },
         "data": {
-          "checksum": "sha256-ednk20seorMQ+xEGnt8zWpxO20xrfj7zOtAmk+XcTbA=",
-          "range": "bytes=1141-17250210"
+          "checksum": "sha256-rgB0/iCkskRu0z50yJPj5UbCkDqeT48PaLInXkivQh4=",
+          "range": "bytes=1136-17250228"
         },
         "name": "git",
         "signature": {
-          "checksum": "sha1-T1C3/QmQvuJGLjPH2YyOLIM5ewE=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-oiYirHB8Oqxgza8ivbRUYOy39i8=",
+          "range": "bytes=0-693"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/git-2.45.2-r0.apk",
-        "version": "2.45.2-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/git-2.45.2-r2.apk",
+        "version": "2.45.2-r2"
       },
       {
         "architecture": "x86_64",
@@ -869,41 +869,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1/xjUDpfwOCMLFmAYUyXK3hbr7M8=",
+        "checksum": "Q1yJyrwOSL5j/c75p1ZWXww23qWyw=",
         "control": {
-          "checksum": "sha1-/xjUDpfwOCMLFmAYUyXK3hbr7M8=",
-          "range": "bytes=703-1114"
+          "checksum": "sha1-yJyrwOSL5j/c75p1ZWXww23qWyw=",
+          "range": "bytes=696-1092"
         },
         "data": {
-          "checksum": "sha256-RvBzvJt//AAv6DeDRxBbbW2UG//3UZ38sDmhcMQoRKY=",
-          "range": "bytes=1115-7560368"
+          "checksum": "sha256-aGdAd0PplDBTW6tyKKTA/Q5yovpzZ+IYuoLBrPxcgqY=",
+          "range": "bytes=1093-7560386"
         },
         "name": "git-daemon",
         "signature": {
-          "checksum": "sha1-dHYurOENIvRxIuBAaHNAeJGQciA=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-pf55N3sBcf0jZRjNnGgDsnaNvF4=",
+          "range": "bytes=0-695"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/git-daemon-2.45.2-r0.apk",
-        "version": "2.45.2-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/git-daemon-2.45.2-r2.apk",
+        "version": "2.45.2-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1lmZVnMVaV+BuJ4Zw8v1gIkGVcNc=",
+        "checksum": "Q1HtAJTveKgYfSNwcyhAKJO8Q38TI=",
         "control": {
-          "checksum": "sha1-lmZVnMVaV+BuJ4Zw8v1gIkGVcNc=",
-          "range": "bytes=696-1069"
+          "checksum": "sha1-HtAJTveKgYfSNwcyhAKJO8Q38TI=",
+          "range": "bytes=699-1057"
         },
         "data": {
-          "checksum": "sha256-qHYsorfTKRzalTN5p+JzwEZ2NYXNkxiHME9MoyMfeRI=",
-          "range": "bytes=1070-212142"
+          "checksum": "sha256-G5w+Y8O79PdpMBZ/KtsRs2mNVs7hjjoaEyB4a4+A8LU=",
+          "range": "bytes=1058-212160"
         },
         "name": "git-p4",
         "signature": {
-          "checksum": "sha1-eGGtsdgoIw2il+9a5ZT/t126v0c=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-7cdrBfVvX+ZNJnJhvO21XG5Z69M=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/git-p4-2.45.2-r0.apk",
-        "version": "2.45.2-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/git-p4-2.45.2-r2.apk",
+        "version": "2.45.2-r2"
       },
       {
         "architecture": "x86_64",
@@ -945,22 +945,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1gVS2hViR+aAQXAlw4s/5CvQBxy8=",
+        "checksum": "Q1Hf1ZqgmpLdGq0pcrMGQLx+YVW30=",
         "control": {
-          "checksum": "sha1-gVS2hViR+aAQXAlw4s/5CvQBxy8=",
-          "range": "bytes=699-1129"
+          "checksum": "sha1-Hf1ZqgmpLdGq0pcrMGQLx+YVW30=",
+          "range": "bytes=705-1121"
         },
         "data": {
-          "checksum": "sha256-ebXJXNAa0wCctDQAiIs0biAL9KgvayQCWHJbWhJwm9U=",
-          "range": "bytes=1130-3146675"
+          "checksum": "sha256-IYdYuA3crFIox4q1U8Hezl/CbJTAC8O39UH63SyW95k=",
+          "range": "bytes=1122-3076780"
         },
         "name": "openssh-client",
         "signature": {
-          "checksum": "sha1-TV5xWmTqQw4glScJ2YEiQz728ns=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-hx9IdDW+uTR72mUA/LIasTK5KHk=",
+          "range": "bytes=0-704"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/openssh-client-9.7_p1-r1.apk",
-        "version": "9.7_p1-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/openssh-client-9.8_p1-r1.apk",
+        "version": "9.8_p1-r1"
       },
       {
         "architecture": "x86_64",
@@ -1002,25 +1002,6 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1EeC4oJcNGILol2exjVmAmCeKe3Y=",
-        "control": {
-          "checksum": "sha1-EeC4oJcNGILol2exjVmAmCeKe3Y=",
-          "range": "bytes=698-1076"
-        },
-        "data": {
-          "checksum": "sha256-jG5+Qk19KNjypflTSwO2gF+f/zqWbtjjhuzSO3maxf8=",
-          "range": "bytes=1077-109053"
-        },
-        "name": "libbz2-1",
-        "signature": {
-          "checksum": "sha1-800rFtecn2FKQ9uM95GkfwOMvnQ=",
-          "range": "bytes=0-697"
-        },
-        "url": "https://packages.wolfi.dev/os/x86_64/libbz2-1-1.0.8-r7.apk",
-        "version": "1.0.8-r7"
-      },
-      {
-        "architecture": "x86_64",
         "checksum": "Q1rJFbJnZtmlBGIqrPwJQNcrfS4bE=",
         "control": {
           "checksum": "sha1-rJFbJnZtmlBGIqrPwJQNcrfS4bE=",
@@ -1037,6 +1018,25 @@
         },
         "url": "https://packages.wolfi.dev/os/x86_64/mpdecimal-4.0.0-r2.apk",
         "version": "4.0.0-r2"
+      },
+      {
+        "architecture": "x86_64",
+        "checksum": "Q1G/AwDwdfNwNdSm/t6Sqght8DOpI=",
+        "control": {
+          "checksum": "sha1-G/AwDwdfNwNdSm/t6Sqght8DOpI=",
+          "range": "bytes=696-1061"
+        },
+        "data": {
+          "checksum": "sha256-5ypXRnqcv42v+Xt59TOt/lTM3huvyCrCDpeER423auk=",
+          "range": "bytes=1062-113624"
+        },
+        "name": "libbz2-1",
+        "signature": {
+          "checksum": "sha1-riGFRNbF0tAWYE9PlBEuTbcGkTQ=",
+          "range": "bytes=0-695"
+        },
+        "url": "https://packages.wolfi.dev/os/x86_64/libbz2-1-1.0.8-r8.apk",
+        "version": "1.0.8-r8"
       },
       {
         "architecture": "x86_64",
@@ -1059,41 +1059,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Xou3FauSnsDlv/GSiADD5//sbLU=",
+        "checksum": "Q10pJtceZTY/GaOtTkhXrHyRg/4us=",
         "control": {
-          "checksum": "sha1-Xou3FauSnsDlv/GSiADD5//sbLU=",
-          "range": "bytes=701-1087"
+          "checksum": "sha1-0pJtceZTY/GaOtTkhXrHyRg/4us=",
+          "range": "bytes=698-1072"
         },
         "data": {
-          "checksum": "sha256-pb3t+dcRqtb+NKcRaX+WpCmgwmCys/1yj9ZEv00dz6o=",
-          "range": "bytes=1088-1101261"
+          "checksum": "sha256-p32sgOSmN27pL84lhBFuVJ77C3zL/HSJpCa+dBqx/0Y=",
+          "range": "bytes=1073-1101764"
         },
         "name": "readline",
         "signature": {
-          "checksum": "sha1-UM8oioixvqY+MAGWmuqxp169zNk=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-a8RmW9zjTrKAkoKJP5kERPY1CeI=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/readline-8.2-r6.apk",
-        "version": "8.2-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/readline-8.2-r7.apk",
+        "version": "8.2-r7"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1sBp15UoB9iDd/xOOx13CSHRTZnA=",
+        "checksum": "Q1b1fkDQZR7BtOZFyaQCnquuKyU8c=",
         "control": {
-          "checksum": "sha1-sBp15UoB9iDd/xOOx13CSHRTZnA=",
-          "range": "bytes=695-1072"
+          "checksum": "sha1-b1fkDQZR7BtOZFyaQCnquuKyU8c=",
+          "range": "bytes=697-1059"
         },
         "data": {
-          "checksum": "sha256-pSuWnCmt6INeWQul5MdUqxgoJ5B7FTEtCfyvg5H+WrA=",
-          "range": "bytes=1073-84740"
+          "checksum": "sha256-g6aBpzXAR79pmyFfBOmkTYKPEVMdAYC7akIKD6h6mHM=",
+          "range": "bytes=1060-84760"
         },
         "name": "libffi",
         "signature": {
-          "checksum": "sha1-kabxjRZlgSfO5ocH7PkbBtqFyus=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-xik2kwwu8Ryo+2igE3vEQ430rP0=",
+          "range": "bytes=0-696"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libffi-3.4.6-r2.apk",
-        "version": "3.4.6-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libffi-3.4.6-r3.apk",
+        "version": "3.4.6-r3"
       },
       {
         "architecture": "x86_64",
@@ -1116,41 +1116,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1dSuRtBPomtGv2me2POZQiR51lJE=",
+        "checksum": "Q1a6z011zqFp2z1JCXtKZA+NDNaZM=",
         "control": {
-          "checksum": "sha1-dSuRtBPomtGv2me2POZQiR51lJE=",
-          "range": "bytes=700-1214"
+          "checksum": "sha1-a6z011zqFp2z1JCXtKZA+NDNaZM=",
+          "range": "bytes=700-1201"
         },
         "data": {
-          "checksum": "sha256-ZGhXZHXVdTTijpXtoRbXzHVsQ5bFnkjjY/LVgy+5Wm4=",
-          "range": "bytes=1215-40423596"
+          "checksum": "sha256-3blIe0IpHxnfbUhz4WrMWZb2cKlOYBr1bffuuxBVk2s=",
+          "range": "bytes=1202-40471072"
         },
         "name": "python-3.12-base",
         "signature": {
-          "checksum": "sha1-n2GGplQgEEHbAOL1wxJ7zdm2KDs=",
+          "checksum": "sha1-zABDPtPAGmVdJmPpIJpvPFzpu0k=",
           "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/python-3.12-base-3.12.3-r3.apk",
-        "version": "3.12.3-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/python-3.12-base-3.12.4-r1.apk",
+        "version": "3.12.4-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Jps1axE/oWBY4VZrdX7R4bEsaOM=",
+        "checksum": "Q1URKL5KNXKIM0igX3gWtsaAQinog=",
         "control": {
-          "checksum": "sha1-Jps1axE/oWBY4VZrdX7R4bEsaOM=",
-          "range": "bytes=700-1076"
+          "checksum": "sha1-URKL5KNXKIM0igX3gWtsaAQinog=",
+          "range": "bytes=701-1059"
         },
         "data": {
-          "checksum": "sha256-RvypSTb54kyTUweZeMAt6rXJSKendPCi0e7Qtg3U9wQ=",
-          "range": "bytes=1077-42729"
+          "checksum": "sha256-7rAjW9fn3i3sNJnhTa5zqRD9I/0JkjlNHLsxCswOZBU=",
+          "range": "bytes=1060-42767"
         },
         "name": "python-3.12",
         "signature": {
-          "checksum": "sha1-0tQ4gaI3k39mmmjsylobay/tq8Y=",
-          "range": "bytes=0-699"
+          "checksum": "sha1-NmSoZl1PXBTBFANq2LBz9dX+bbo=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/python-3.12-3.12.3-r3.apk",
-        "version": "3.12.3-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/python-3.12-3.12.4-r1.apk",
+        "version": "3.12.4-r1"
       },
       {
         "architecture": "x86_64",
@@ -1173,22 +1173,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q19f/3419Xa/xv9jgQ0mMYs011fBk=",
+        "checksum": "Q1mTmy64gKYi4THBqewuvYL2uUyHc=",
         "control": {
-          "checksum": "sha1-9f/3419Xa/xv9jgQ0mMYs011fBk=",
-          "range": "bytes=696-1041"
+          "checksum": "sha1-mTmy64gKYi4THBqewuvYL2uUyHc=",
+          "range": "bytes=700-1031"
         },
         "data": {
-          "checksum": "sha256-iqHASiMgiu6rIjbWGwBmmq1Zthae8BkE4QZkiVPH7Ek=",
-          "range": "bytes=1042-1888945"
+          "checksum": "sha256-p0qua2luH33oAgOcLkU9f7k+I8WnykFszVMwNahujDA=",
+          "range": "bytes=1032-1889523"
         },
         "name": "tzdata",
         "signature": {
-          "checksum": "sha1-PCC3jiXlTwrimRMXH/4RyNvccOM=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-sBf5jVLVpWj4DiXaAd/mjo0pTfk=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/tzdata-2024a-r2.apk",
-        "version": "2024a-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/tzdata-2024a-r3.apk",
+        "version": "2024a-r3"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/grafana.lock.json
+++ b/wolfi-images/grafana.lock.json
@@ -18,41 +18,41 @@
     "packages": [
       {
         "architecture": "x86_64",
-        "checksum": "Q1ge3SLQsJ9v2RnvIHHAP1yFyjrEU=",
+        "checksum": "Q1Ai8jWuxKZR2M2XhOpOGAoTEwnnk=",
         "control": {
-          "checksum": "sha1-ge3SLQsJ9v2RnvIHHAP1yFyjrEU=",
-          "range": "bytes=693-1040"
+          "checksum": "sha1-Ai8jWuxKZR2M2XhOpOGAoTEwnnk=",
+          "range": "bytes=705-1037"
         },
         "data": {
-          "checksum": "sha256-I0AdTdfGf4P/jwzTrLXm73l5/RNSlymEof/YZfev3xY=",
-          "range": "bytes=1041-255811"
+          "checksum": "sha256-e4UardkBVyaC49aSyrVmXNi8sSKqQl4eKYd0LxGRLA0=",
+          "range": "bytes=1038-255695"
         },
         "name": "ca-certificates-bundle",
         "signature": {
-          "checksum": "sha1-ge1eJBiQmFWAn9GapFkQpO+Rn/Y=",
-          "range": "bytes=0-692"
+          "checksum": "sha1-loRuyYQLm+atp+YteiQoj++EWIM=",
+          "range": "bytes=0-704"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20240315-r3.apk",
-        "version": "20240315-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20240315-r4.apk",
+        "version": "20240315-r4"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1bgay5kOzpmDBgqJCg7dSlawyJg0=",
+        "checksum": "Q1+GH6qRN4iy1IDt0cT0x0tin7YfI=",
         "control": {
-          "checksum": "sha1-bgay5kOzpmDBgqJCg7dSlawyJg0=",
-          "range": "bytes=703-1067"
+          "checksum": "sha1-+GH6qRN4iy1IDt0cT0x0tin7YfI=",
+          "range": "bytes=703-1051"
         },
         "data": {
-          "checksum": "sha256-f83HfRE7r2ZniH7PyPmRqcoU5NTpF+Uk4FH80QbjvBM=",
-          "range": "bytes=1068-118370"
+          "checksum": "sha256-rO0P9z2V49BSrz1A5Ap69tEappVrg5MMBjzW00rOpZc=",
+          "range": "bytes=1052-122464"
         },
         "name": "wolfi-baselayout",
         "signature": {
-          "checksum": "sha1-2hlCvYH1D7u25HkJGA75jjs/sQY=",
+          "checksum": "sha1-Ntb6VuMzDfM+frpCjKEIpDzl53I=",
           "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r11.apk",
-        "version": "20230201-r11"
+        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r12.apk",
+        "version": "20230201-r12"
       },
       {
         "architecture": "x86_64",
@@ -113,79 +113,79 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1gTZGkWP+QO3mUqLVJth8vrDEzzU=",
+        "checksum": "Q1Q/Zy5ovYSu2p/vVLr6DgVA1e8AQ=",
         "control": {
-          "checksum": "sha1-gTZGkWP+QO3mUqLVJth8vrDEzzU=",
-          "range": "bytes=699-1076"
+          "checksum": "sha1-Q/Zy5ovYSu2p/vVLr6DgVA1e8AQ=",
+          "range": "bytes=699-1062"
         },
         "data": {
-          "checksum": "sha256-/IFXqeKvU0GODNsz1yPIEMcFHgABT+8rbZpSlTLo4e4=",
-          "range": "bytes=1077-5915704"
+          "checksum": "sha256-H3jxsw8ytOeCIR4vq17voSVhdNokXk8C1g075txH6Bs=",
+          "range": "bytes=1063-5903754"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-l1o5ixkyWWqqJE3FOfR0QUemJUA=",
+          "checksum": "sha1-NIl2f5OI/wSZByI8Ds1ZUfbFWyw=",
           "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r9.apk",
-        "version": "3.3.0-r9"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.1-r3.apk",
+        "version": "3.3.1-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1jhAhggAuZnU7FFHnebGA26mq+jI=",
+        "checksum": "Q13wGUXdZut9OOTdY5z2amUj9wXC0=",
         "control": {
-          "checksum": "sha1-jhAhggAuZnU7FFHnebGA26mq+jI=",
-          "range": "bytes=695-1079"
+          "checksum": "sha1-3wGUXdZut9OOTdY5z2amUj9wXC0=",
+          "range": "bytes=698-1068"
         },
         "data": {
-          "checksum": "sha256-XTCQYnhGSm7SkGwqV/TQMFqGajVJVYhKAidKfLb2D3Y=",
-          "range": "bytes=1080-1197081"
+          "checksum": "sha256-mRda6+YGlOCczyIWKaHqXskTINoT1rgorHDHqAKAb7c=",
+          "range": "bytes=1069-1188955"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-qVrfDVxubkrb5Yrd2mFTv2A0G7k=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-+UdRc4U3PKw4H9OiNurHKXa5BYk=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r9.apk",
-        "version": "3.3.0-r9"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.1-r3.apk",
+        "version": "3.3.1-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q14S6biy8fc5OGbGEJoLBM+tJOGyo=",
+        "checksum": "Q1CN6zJbOPznWUfTrb/41KT7E6dm8=",
         "control": {
-          "checksum": "sha1-4S6biy8fc5OGbGEJoLBM+tJOGyo=",
-          "range": "bytes=703-1102"
+          "checksum": "sha1-CN6zJbOPznWUfTrb/41KT7E6dm8=",
+          "range": "bytes=699-1083"
         },
         "data": {
-          "checksum": "sha256-hwjdLQYfuMAGQeONmFVo0lZKKQK1S+3PBhrI3upm5W4=",
-          "range": "bytes=1103-155304"
+          "checksum": "sha256-ybzFzoQh1yNTcd3cjt54nYsPlAxAcMUcVMxEv1JRnpQ=",
+          "range": "bytes=1084-155375"
         },
         "name": "zlib",
         "signature": {
-          "checksum": "sha1-ZuLd7kE+AGhn27o8ZqDGM5eundc=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-CPXJcCjinAXP+H8Z5tkko8ayG6E=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/zlib-1.3.1-r2.apk",
-        "version": "1.3.1-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/zlib-1.3.1-r3.apk",
+        "version": "1.3.1-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1/ZtLqMp9dtWuV9olMeXUvOfI/FI=",
+        "checksum": "Q1d6KWlsyysrLbDnqZNOxD3yXQArs=",
         "control": {
-          "checksum": "sha1-/ZtLqMp9dtWuV9olMeXUvOfI/FI=",
-          "range": "bytes=704-1153"
+          "checksum": "sha1-d6KWlsyysrLbDnqZNOxD3yXQArs=",
+          "range": "bytes=700-1135"
         },
         "data": {
-          "checksum": "sha256-FGmENq5TGFJ2tuz1jnVDNdjZ0+LmcEtSVerH1GV25yg=",
-          "range": "bytes=1154-476294"
+          "checksum": "sha256-PxwHUjByuYsDLfP2+E4x8ywCE2Lkk9mzYgRm2w4ayNk=",
+          "range": "bytes=1136-483558"
         },
         "name": "apk-tools",
         "signature": {
-          "checksum": "sha1-DnGH3b7h/Oox1jTrbHz7l3H7Pj8=",
-          "range": "bytes=0-703"
+          "checksum": "sha1-Nl2iLupTvBTyTCbDrH5VNbBvqsY=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/apk-tools-2.14.1-r2.apk",
-        "version": "2.14.1-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/apk-tools-2.14.4-r0.apk",
+        "version": "2.14.4-r0"
       },
       {
         "architecture": "x86_64",
@@ -322,22 +322,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ZMGiMSnjbScBstPVaw5qQfkNI+M=",
+        "checksum": "Q1w2/J0nDU8aA/f0HxunA5N19L1gw=",
         "control": {
-          "checksum": "sha1-ZMGiMSnjbScBstPVaw5qQfkNI+M=",
-          "range": "bytes=697-1097"
+          "checksum": "sha1-w2/J0nDU8aA/f0HxunA5N19L1gw=",
+          "range": "bytes=702-1086"
         },
         "data": {
-          "checksum": "sha256-XN2CeOJxCHWCgGpwTUkm5UOFKFz/eRpd7AReq4CqiOk=",
-          "range": "bytes=1098-1436391"
+          "checksum": "sha256-/2i+TNHbkrOsjrx7WHrrloXc6gcoyfyGrUHdBljYM+o=",
+          "range": "bytes=1087-1440232"
         },
         "name": "bash",
         "signature": {
-          "checksum": "sha1-t7/nmubimPIaw21oj0WlXgqY90E=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-tnYcLxCgV8srkBsTl4c/f6m11vQ=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bash-5.2.21-r4.apk",
-        "version": "5.2.21-r4"
+        "url": "https://packages.wolfi.dev/os/x86_64/bash-5.2.21-r5.apk",
+        "version": "5.2.21-r5"
       },
       {
         "architecture": "x86_64",
@@ -398,25 +398,6 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Xf5v5uXumBgIR4d4ZxMRxdpyWlM=",
-        "control": {
-          "checksum": "sha1-Xf5v5uXumBgIR4d4ZxMRxdpyWlM=",
-          "range": "bytes=698-1078"
-        },
-        "data": {
-          "checksum": "sha256-eD7HqFCWNUBQiLq9PcWE/zPeZwkiv8hBrytI4qmfQ/8=",
-          "range": "bytes=1079-57055"
-        },
-        "name": "keyutils-libs",
-        "signature": {
-          "checksum": "sha1-V0HVgZLP7P5kNACfus3abCLCS20=",
-          "range": "bytes=0-697"
-        },
-        "url": "https://packages.wolfi.dev/os/x86_64/keyutils-libs-1.6.3-r2.apk",
-        "version": "1.6.3-r2"
-      },
-      {
-        "architecture": "x86_64",
         "checksum": "Q144JvgxJGCpXrE6GLHwSuuttlkxs=",
         "control": {
           "checksum": "sha1-44JvgxJGCpXrE6GLHwSuuttlkxs=",
@@ -436,60 +417,79 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1wRzOx+L6MeRFtTcq2y/6ot7Cj54=",
+        "checksum": "Q1v0A2vQM5k8rQY/GpIq6xI4T0YmA=",
         "control": {
-          "checksum": "sha1-wRzOx+L6MeRFtTcq2y/6ot7Cj54=",
-          "range": "bytes=699-1069"
+          "checksum": "sha1-v0A2vQM5k8rQY/GpIq6xI4T0YmA=",
+          "range": "bytes=701-1064"
         },
         "data": {
-          "checksum": "sha256-gNRjwZ4XQatCYWediSVb+j8lS54CggvMC5Dn3qT84So=",
-          "range": "bytes=1070-61490"
+          "checksum": "sha256-uAOrkGDDc/yqt6VjIrlTEALBJG4BCI4njqZw5jQqF0o=",
+          "range": "bytes=1065-56984"
+        },
+        "name": "keyutils-libs",
+        "signature": {
+          "checksum": "sha1-32uYMH/zGBr9Jo3hiqnThlcqBcE=",
+          "range": "bytes=0-700"
+        },
+        "url": "https://packages.wolfi.dev/os/x86_64/keyutils-libs-1.6.3-r3.apk",
+        "version": "1.6.3-r3"
+      },
+      {
+        "architecture": "x86_64",
+        "checksum": "Q1Onuac6Y+IWA7a4b8FvqX1erWDDw=",
+        "control": {
+          "checksum": "sha1-Onuac6Y+IWA7a4b8FvqX1erWDDw=",
+          "range": "bytes=693-1048"
+        },
+        "data": {
+          "checksum": "sha256-KLtDAs3iU0oyZ/FysePG/J+1H1ofDxHXIY7xvtZhtMc=",
+          "range": "bytes=1049-61503"
         },
         "name": "libverto",
         "signature": {
-          "checksum": "sha1-kuPwakYdy5EM6sd5Ba0K0Ta8x4w=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-/IXL9S1O+MwaW7KsSzz1ywEqKFQ=",
+          "range": "bytes=0-692"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libverto-0.3.2-r3.apk",
-        "version": "0.3.2-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/libverto-0.3.2-r4.apk",
+        "version": "0.3.2-r4"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1BQEXaeya6QB39QLeKcB99qBNF2o=",
+        "checksum": "Q1p04MrHQPrXOzuV/uF290zjnltqI=",
         "control": {
-          "checksum": "sha1-BQEXaeya6QB39QLeKcB99qBNF2o=",
-          "range": "bytes=699-1229"
+          "checksum": "sha1-p04MrHQPrXOzuV/uF290zjnltqI=",
+          "range": "bytes=704-1219"
         },
         "data": {
-          "checksum": "sha256-ugj/qGEBzhvdX17S22Anry+biy3lcqywhGMSHLIBCvo=",
-          "range": "bytes=1230-2551676"
+          "checksum": "sha256-TsXeqhUGykAhjQUEAlMUSzDQBcWDkkDvReoeHCL1F6c=",
+          "range": "bytes=1220-2555814"
         },
         "name": "krb5-libs",
         "signature": {
-          "checksum": "sha1-oqDPmNM4EngXAGayd/BZOqJAIao=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-cPyzS38QHuNlOCQb8IPlsl2PLHQ=",
+          "range": "bytes=0-703"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/krb5-libs-1.21.2-r2.apk",
-        "version": "1.21.2-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/krb5-libs-1.21.3-r0.apk",
+        "version": "1.21.3-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Xyb3xjazh4u+aojIHFeTDzoIH2Q=",
+        "checksum": "Q1c6/lf6LU9erys1HqwwDoGRGGAPM=",
         "control": {
-          "checksum": "sha1-Xyb3xjazh4u+aojIHFeTDzoIH2Q=",
-          "range": "bytes=700-1243"
+          "checksum": "sha1-c6/lf6LU9erys1HqwwDoGRGGAPM=",
+          "range": "bytes=699-1226"
         },
         "data": {
-          "checksum": "sha256-k6fT5NwnRSEd9OGhlaITV3Di+cl9b9eURl2xfOL0MBE=",
-          "range": "bytes=1244-469029"
+          "checksum": "sha256-gAUAWH3XnDeiZqiCiHmjfMJNCkVoHpl7Mx/1w+atipo=",
+          "range": "bytes=1227-473167"
         },
         "name": "krb5",
         "signature": {
-          "checksum": "sha1-mpJobiFVJHTcBszjd+9kSlnzT2Q=",
-          "range": "bytes=0-699"
+          "checksum": "sha1-0zh0aQvgqqwqplX2HA2ZyRuZj6o=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/krb5-1.21.2-r2.apk",
-        "version": "1.21.2-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/krb5-1.21.3-r0.apk",
+        "version": "1.21.3-r0"
       },
       {
         "architecture": "x86_64",
@@ -531,60 +531,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ClRU9LEog4OgkuXujv0JpHDKDiI=",
+        "checksum": "Q13r+1JUdz32rNPARV9THvg4bpllM=",
         "control": {
-          "checksum": "sha1-ClRU9LEog4OgkuXujv0JpHDKDiI=",
-          "range": "bytes=703-1079"
+          "checksum": "sha1-3r+1JUdz32rNPARV9THvg4bpllM=",
+          "range": "bytes=698-1061"
         },
         "data": {
-          "checksum": "sha256-hC391qobx5DyYe6LmNA1XlgRpG5rpj6iHjAQPkK1SIk=",
-          "range": "bytes=1080-182481"
+          "checksum": "sha256-apnA3TGfV7N2B1Xp5R/yjglx9HRGqoqHYVPGfGhCXo8=",
+          "range": "bytes=1062-178451"
         },
         "name": "openssl-provider-legacy",
         "signature": {
-          "checksum": "sha1-Fbc6Xmeg6vEpNQFZfdi3jb6Z/hw=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-oLy1zTY/WbDdrqnIe3/rrpxj0VU=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/openssl-provider-legacy-3.3.0-r9.apk",
-        "version": "3.3.0-r9"
+        "url": "https://packages.wolfi.dev/os/x86_64/openssl-provider-legacy-3.3.1-r3.apk",
+        "version": "3.3.1-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q14cgQ7hzxZhRqXzw7CItN8b6TR0s=",
+        "checksum": "Q1/eKBTceqDR6fZQVoeOdWfx1SXRo=",
         "control": {
-          "checksum": "sha1-4cgQ7hzxZhRqXzw7CItN8b6TR0s=",
-          "range": "bytes=696-1122"
+          "checksum": "sha1-/eKBTceqDR6fZQVoeOdWfx1SXRo=",
+          "range": "bytes=705-1115"
         },
         "data": {
-          "checksum": "sha256-usdB5oXIjCEBQqtiMoloXos6Fn+OyzGqbEevj/UDSLE=",
-          "range": "bytes=1123-1242435"
+          "checksum": "sha256-H1aqjZjk79mgvrhp5QLK7ew5xYqT8P9VG5m8KXk3PJU=",
+          "range": "bytes=1116-1242637"
         },
         "name": "openssl",
         "signature": {
-          "checksum": "sha1-mjEQyOlQm8wq/ShCz8h/vZVZTkU=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-xYyQE6nodg8z47TyfnvFe7auA0M=",
+          "range": "bytes=0-704"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/openssl-3.3.0-r9.apk",
-        "version": "3.3.0-r9"
+        "url": "https://packages.wolfi.dev/os/x86_64/openssl-3.3.1-r3.apk",
+        "version": "3.3.1-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q19f/3419Xa/xv9jgQ0mMYs011fBk=",
+        "checksum": "Q1mTmy64gKYi4THBqewuvYL2uUyHc=",
         "control": {
-          "checksum": "sha1-9f/3419Xa/xv9jgQ0mMYs011fBk=",
-          "range": "bytes=696-1041"
+          "checksum": "sha1-mTmy64gKYi4THBqewuvYL2uUyHc=",
+          "range": "bytes=700-1031"
         },
         "data": {
-          "checksum": "sha256-iqHASiMgiu6rIjbWGwBmmq1Zthae8BkE4QZkiVPH7Ek=",
-          "range": "bytes=1042-1888945"
+          "checksum": "sha256-p0qua2luH33oAgOcLkU9f7k+I8WnykFszVMwNahujDA=",
+          "range": "bytes=1032-1889523"
         },
         "name": "tzdata",
         "signature": {
-          "checksum": "sha1-PCC3jiXlTwrimRMXH/4RyNvccOM=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-sBf5jVLVpWj4DiXaAd/mjo0pTfk=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/tzdata-2024a-r2.apk",
-        "version": "2024a-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/tzdata-2024a-r3.apk",
+        "version": "2024a-r3"
       }
     ],
     "repositories": [

--- a/wolfi-images/jaeger-agent.lock.json
+++ b/wolfi-images/jaeger-agent.lock.json
@@ -14,41 +14,41 @@
     "packages": [
       {
         "architecture": "x86_64",
-        "checksum": "Q1ge3SLQsJ9v2RnvIHHAP1yFyjrEU=",
+        "checksum": "Q1Ai8jWuxKZR2M2XhOpOGAoTEwnnk=",
         "control": {
-          "checksum": "sha1-ge3SLQsJ9v2RnvIHHAP1yFyjrEU=",
-          "range": "bytes=693-1040"
+          "checksum": "sha1-Ai8jWuxKZR2M2XhOpOGAoTEwnnk=",
+          "range": "bytes=705-1037"
         },
         "data": {
-          "checksum": "sha256-I0AdTdfGf4P/jwzTrLXm73l5/RNSlymEof/YZfev3xY=",
-          "range": "bytes=1041-255811"
+          "checksum": "sha256-e4UardkBVyaC49aSyrVmXNi8sSKqQl4eKYd0LxGRLA0=",
+          "range": "bytes=1038-255695"
         },
         "name": "ca-certificates-bundle",
         "signature": {
-          "checksum": "sha1-ge1eJBiQmFWAn9GapFkQpO+Rn/Y=",
-          "range": "bytes=0-692"
+          "checksum": "sha1-loRuyYQLm+atp+YteiQoj++EWIM=",
+          "range": "bytes=0-704"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20240315-r3.apk",
-        "version": "20240315-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20240315-r4.apk",
+        "version": "20240315-r4"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1bgay5kOzpmDBgqJCg7dSlawyJg0=",
+        "checksum": "Q1+GH6qRN4iy1IDt0cT0x0tin7YfI=",
         "control": {
-          "checksum": "sha1-bgay5kOzpmDBgqJCg7dSlawyJg0=",
-          "range": "bytes=703-1067"
+          "checksum": "sha1-+GH6qRN4iy1IDt0cT0x0tin7YfI=",
+          "range": "bytes=703-1051"
         },
         "data": {
-          "checksum": "sha256-f83HfRE7r2ZniH7PyPmRqcoU5NTpF+Uk4FH80QbjvBM=",
-          "range": "bytes=1068-118370"
+          "checksum": "sha256-rO0P9z2V49BSrz1A5Ap69tEappVrg5MMBjzW00rOpZc=",
+          "range": "bytes=1052-122464"
         },
         "name": "wolfi-baselayout",
         "signature": {
-          "checksum": "sha1-2hlCvYH1D7u25HkJGA75jjs/sQY=",
+          "checksum": "sha1-Ntb6VuMzDfM+frpCjKEIpDzl53I=",
           "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r11.apk",
-        "version": "20230201-r11"
+        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r12.apk",
+        "version": "20230201-r12"
       },
       {
         "architecture": "x86_64",
@@ -109,41 +109,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Zjfs1uR/mYiortANP+EFcejW+vo=",
+        "checksum": "Q1Zi0e8Bq6WCd/6uXXjVhb8YwMD1U=",
         "control": {
-          "checksum": "sha1-Zjfs1uR/mYiortANP+EFcejW+vo=",
-          "range": "bytes=698-1085"
+          "checksum": "sha1-Zi0e8Bq6WCd/6uXXjVhb8YwMD1U=",
+          "range": "bytes=700-1073"
         },
         "data": {
-          "checksum": "sha256-BMd7TzffjbrFwdbopDPVYsX0X9XnusIMNbIf33/8kwc=",
-          "range": "bytes=1086-76881"
+          "checksum": "sha256-jMhtfqVjnhuuBO7wtNZ6RS/72sZWoKt/Moage2amlks=",
+          "range": "bytes=1074-81594"
         },
         "name": "protobuf-c",
         "signature": {
-          "checksum": "sha1-efGiXyYWsJ5P2uTkB6aXEZ3kl3o=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-kATwMKztK7nk7qbYCJPkCFp6IXc=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r4.apk",
-        "version": "1.5.0-r4"
-      },
-      {
-        "architecture": "x86_64",
-        "checksum": "Q1Xf5v5uXumBgIR4d4ZxMRxdpyWlM=",
-        "control": {
-          "checksum": "sha1-Xf5v5uXumBgIR4d4ZxMRxdpyWlM=",
-          "range": "bytes=698-1078"
-        },
-        "data": {
-          "checksum": "sha256-eD7HqFCWNUBQiLq9PcWE/zPeZwkiv8hBrytI4qmfQ/8=",
-          "range": "bytes=1079-57055"
-        },
-        "name": "keyutils-libs",
-        "signature": {
-          "checksum": "sha1-V0HVgZLP7P5kNACfus3abCLCS20=",
-          "range": "bytes=0-697"
-        },
-        "url": "https://packages.wolfi.dev/os/x86_64/keyutils-libs-1.6.3-r2.apk",
-        "version": "1.6.3-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r5.apk",
+        "version": "1.5.0-r5"
       },
       {
         "architecture": "x86_64",
@@ -166,22 +147,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1wRzOx+L6MeRFtTcq2y/6ot7Cj54=",
+        "checksum": "Q1v0A2vQM5k8rQY/GpIq6xI4T0YmA=",
         "control": {
-          "checksum": "sha1-wRzOx+L6MeRFtTcq2y/6ot7Cj54=",
-          "range": "bytes=699-1069"
+          "checksum": "sha1-v0A2vQM5k8rQY/GpIq6xI4T0YmA=",
+          "range": "bytes=701-1064"
         },
         "data": {
-          "checksum": "sha256-gNRjwZ4XQatCYWediSVb+j8lS54CggvMC5Dn3qT84So=",
-          "range": "bytes=1070-61490"
+          "checksum": "sha256-uAOrkGDDc/yqt6VjIrlTEALBJG4BCI4njqZw5jQqF0o=",
+          "range": "bytes=1065-56984"
+        },
+        "name": "keyutils-libs",
+        "signature": {
+          "checksum": "sha1-32uYMH/zGBr9Jo3hiqnThlcqBcE=",
+          "range": "bytes=0-700"
+        },
+        "url": "https://packages.wolfi.dev/os/x86_64/keyutils-libs-1.6.3-r3.apk",
+        "version": "1.6.3-r3"
+      },
+      {
+        "architecture": "x86_64",
+        "checksum": "Q1Onuac6Y+IWA7a4b8FvqX1erWDDw=",
+        "control": {
+          "checksum": "sha1-Onuac6Y+IWA7a4b8FvqX1erWDDw=",
+          "range": "bytes=693-1048"
+        },
+        "data": {
+          "checksum": "sha256-KLtDAs3iU0oyZ/FysePG/J+1H1ofDxHXIY7xvtZhtMc=",
+          "range": "bytes=1049-61503"
         },
         "name": "libverto",
         "signature": {
-          "checksum": "sha1-kuPwakYdy5EM6sd5Ba0K0Ta8x4w=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-/IXL9S1O+MwaW7KsSzz1ywEqKFQ=",
+          "range": "bytes=0-692"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libverto-0.3.2-r3.apk",
-        "version": "0.3.2-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/libverto-0.3.2-r4.apk",
+        "version": "0.3.2-r4"
       },
       {
         "architecture": "x86_64",
@@ -204,60 +204,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1gTZGkWP+QO3mUqLVJth8vrDEzzU=",
+        "checksum": "Q1Q/Zy5ovYSu2p/vVLr6DgVA1e8AQ=",
         "control": {
-          "checksum": "sha1-gTZGkWP+QO3mUqLVJth8vrDEzzU=",
-          "range": "bytes=699-1076"
+          "checksum": "sha1-Q/Zy5ovYSu2p/vVLr6DgVA1e8AQ=",
+          "range": "bytes=699-1062"
         },
         "data": {
-          "checksum": "sha256-/IFXqeKvU0GODNsz1yPIEMcFHgABT+8rbZpSlTLo4e4=",
-          "range": "bytes=1077-5915704"
+          "checksum": "sha256-H3jxsw8ytOeCIR4vq17voSVhdNokXk8C1g075txH6Bs=",
+          "range": "bytes=1063-5903754"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-l1o5ixkyWWqqJE3FOfR0QUemJUA=",
+          "checksum": "sha1-NIl2f5OI/wSZByI8Ds1ZUfbFWyw=",
           "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r9.apk",
-        "version": "3.3.0-r9"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.1-r3.apk",
+        "version": "3.3.1-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1jhAhggAuZnU7FFHnebGA26mq+jI=",
+        "checksum": "Q13wGUXdZut9OOTdY5z2amUj9wXC0=",
         "control": {
-          "checksum": "sha1-jhAhggAuZnU7FFHnebGA26mq+jI=",
-          "range": "bytes=695-1079"
+          "checksum": "sha1-3wGUXdZut9OOTdY5z2amUj9wXC0=",
+          "range": "bytes=698-1068"
         },
         "data": {
-          "checksum": "sha256-XTCQYnhGSm7SkGwqV/TQMFqGajVJVYhKAidKfLb2D3Y=",
-          "range": "bytes=1080-1197081"
+          "checksum": "sha256-mRda6+YGlOCczyIWKaHqXskTINoT1rgorHDHqAKAb7c=",
+          "range": "bytes=1069-1188955"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-qVrfDVxubkrb5Yrd2mFTv2A0G7k=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-+UdRc4U3PKw4H9OiNurHKXa5BYk=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r9.apk",
-        "version": "3.3.0-r9"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.1-r3.apk",
+        "version": "3.3.1-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1BQEXaeya6QB39QLeKcB99qBNF2o=",
+        "checksum": "Q1p04MrHQPrXOzuV/uF290zjnltqI=",
         "control": {
-          "checksum": "sha1-BQEXaeya6QB39QLeKcB99qBNF2o=",
-          "range": "bytes=699-1229"
+          "checksum": "sha1-p04MrHQPrXOzuV/uF290zjnltqI=",
+          "range": "bytes=704-1219"
         },
         "data": {
-          "checksum": "sha256-ugj/qGEBzhvdX17S22Anry+biy3lcqywhGMSHLIBCvo=",
-          "range": "bytes=1230-2551676"
+          "checksum": "sha256-TsXeqhUGykAhjQUEAlMUSzDQBcWDkkDvReoeHCL1F6c=",
+          "range": "bytes=1220-2555814"
         },
         "name": "krb5-libs",
         "signature": {
-          "checksum": "sha1-oqDPmNM4EngXAGayd/BZOqJAIao=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-cPyzS38QHuNlOCQb8IPlsl2PLHQ=",
+          "range": "bytes=0-703"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/krb5-libs-1.21.2-r2.apk",
-        "version": "1.21.2-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/krb5-libs-1.21.3-r0.apk",
+        "version": "1.21.3-r0"
       },
       {
         "architecture": "x86_64",
@@ -280,60 +280,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1wzZwtLauOQfLQC7YUvZdfKxtlwQ=",
+        "checksum": "Q17uprcuQ2VFudMcWAwtP7miJmLYs=",
         "control": {
-          "checksum": "sha1-wzZwtLauOQfLQC7YUvZdfKxtlwQ=",
-          "range": "bytes=698-1085"
+          "checksum": "sha1-7uprcuQ2VFudMcWAwtP7miJmLYs=",
+          "range": "bytes=695-1067"
         },
         "data": {
-          "checksum": "sha256-TO8CAULO44s/LphhtcaFOGJB7aFldk13v1cV9ceZHww=",
-          "range": "bytes=1086-276837"
+          "checksum": "sha256-unKdPbvO2VHZ5w1t1l8mOpQuNdUGwLhofEO4weN2Mig=",
+          "range": "bytes=1068-280973"
         },
         "name": "libuv",
         "signature": {
-          "checksum": "sha1-LRiyeKmjexy8CJizLxjd6ikon1w=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-4lKldnTO71WHMZ4tbANz6i2/Ed0=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libuv-1.48.0-r2.apk",
-        "version": "1.48.0-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libuv-1.48.0-r3.apk",
+        "version": "1.48.0-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q14S6biy8fc5OGbGEJoLBM+tJOGyo=",
+        "checksum": "Q1CN6zJbOPznWUfTrb/41KT7E6dm8=",
         "control": {
-          "checksum": "sha1-4S6biy8fc5OGbGEJoLBM+tJOGyo=",
-          "range": "bytes=703-1102"
+          "checksum": "sha1-CN6zJbOPznWUfTrb/41KT7E6dm8=",
+          "range": "bytes=699-1083"
         },
         "data": {
-          "checksum": "sha256-hwjdLQYfuMAGQeONmFVo0lZKKQK1S+3PBhrI3upm5W4=",
-          "range": "bytes=1103-155304"
+          "checksum": "sha256-ybzFzoQh1yNTcd3cjt54nYsPlAxAcMUcVMxEv1JRnpQ=",
+          "range": "bytes=1084-155375"
         },
         "name": "zlib",
         "signature": {
-          "checksum": "sha1-ZuLd7kE+AGhn27o8ZqDGM5eundc=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-CPXJcCjinAXP+H8Z5tkko8ayG6E=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/zlib-1.3.1-r2.apk",
-        "version": "1.3.1-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/zlib-1.3.1-r3.apk",
+        "version": "1.3.1-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ykDkP+AmDi2VcZZ1c4q4sez/DxI=",
+        "checksum": "Q1rgbci8SRSjW7EB0NSh6ZUPJLndM=",
         "control": {
-          "checksum": "sha1-ykDkP+AmDi2VcZZ1c4q4sez/DxI=",
-          "range": "bytes=705-1079"
+          "checksum": "sha1-rgbci8SRSjW7EB0NSh6ZUPJLndM=",
+          "range": "bytes=702-1060"
         },
         "data": {
-          "checksum": "sha256-t3BrH7lWfY3to3Fu3EKAMZx29v9Hnl5seyXJzLmZ9/4=",
-          "range": "bytes=1080-251884"
+          "checksum": "sha256-tf4xbo+NP+ssiaZtC1kOKehffAZ3+d17bhgfU3/30+g=",
+          "range": "bytes=1061-256582"
         },
         "name": "libnghttp2-14",
         "signature": {
-          "checksum": "sha1-CotSXRaPLKQCBRHrgzrDOD+4w20=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-KrsJYTyUsll+EUhHekbkdZFzeig=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.62.1-r0.apk",
-        "version": "1.62.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.62.1-r1.apk",
+        "version": "1.62.1-r1"
       },
       {
         "architecture": "x86_64",
@@ -394,136 +394,136 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1DE49kWSnmqVKJdjHFYC1bLkvyb0=",
+        "checksum": "Q1R8OxpY0fGwVaIwft4wJeswF5D54=",
         "control": {
-          "checksum": "sha1-DE49kWSnmqVKJdjHFYC1bLkvyb0=",
-          "range": "bytes=697-1078"
+          "checksum": "sha1-R8OxpY0fGwVaIwft4wJeswF5D54=",
+          "range": "bytes=695-1059"
         },
         "data": {
-          "checksum": "sha256-uDg8Qc6Rnro/68Vb5ufFSkqFLGrEsbvPb0pMJNvT1zw=",
-          "range": "bytes=1079-242085"
+          "checksum": "sha256-wNc8/SBJrGHfwywAtzCsAqeUOt0IaAhqNtlbv8OiHBE=",
+          "range": "bytes=1060-242151"
         },
         "name": "c-ares",
         "signature": {
-          "checksum": "sha1-iYEm6EWQKzxkeoDm+QsRfhw8pDg=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-55/PTlEHXI3o0hx9dSVdNwQeSMg=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.29.0-r0.apk",
-        "version": "1.29.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.31.0-r0.apk",
+        "version": "1.31.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q12eWmn2tCkXxwncU6gagKM3Wd9Sk=",
+        "checksum": "Q1g2RQKAvNjlRPxWjinIRveaq7IlY=",
         "control": {
-          "checksum": "sha1-2eWmn2tCkXxwncU6gagKM3Wd9Sk=",
-          "range": "bytes=696-1169"
+          "checksum": "sha1-g2RQKAvNjlRPxWjinIRveaq7IlY=",
+          "range": "bytes=695-1154"
         },
         "data": {
-          "checksum": "sha256-IFKNdojOhml3DbWPryQuHUiV3tgTWHyqOYD1JNe9IJ4=",
-          "range": "bytes=1170-2582015"
+          "checksum": "sha256-UsQFfOTXCZBan0mxDvR+ts0NKcbv1lNijxnRxjsmZhA=",
+          "range": "bytes=1155-2566233"
         },
         "name": "nghttp2",
         "signature": {
-          "checksum": "sha1-2/9n7KbRuOkrvhYqCFR5Mblx+z8=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-SUvMhz1cc5Or5Qh4fUEvPCp0NAw=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.62.1-r0.apk",
-        "version": "1.62.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.62.1-r1.apk",
+        "version": "1.62.1-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ialksjwPWvvZW+O2ABMbbBV/KTg=",
+        "checksum": "Q1sTMGOgdbZyDKxlRAByisPMHTbpY=",
         "control": {
-          "checksum": "sha1-ialksjwPWvvZW+O2ABMbbBV/KTg=",
-          "range": "bytes=702-1074"
+          "checksum": "sha1-sTMGOgdbZyDKxlRAByisPMHTbpY=",
+          "range": "bytes=703-1060"
         },
         "data": {
-          "checksum": "sha256-+ctDr3AO9mTXovGRPWk6h2ZgfY99Toy6esjBNHtJPY4=",
-          "range": "bytes=1075-631903"
+          "checksum": "sha256-bUy0h/zxpq7iP6vrQRMftZ9nevkHTB87hSX17wz4lmM=",
+          "range": "bytes=1061-631449"
         },
         "name": "nghttp2-dev",
         "signature": {
-          "checksum": "sha1-wZGQRluFd6DL1USzeak75o5/BTc=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-fQ6aDq3Io/gdJ5s5t3M+FwED1Y0=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.62.1-r0.apk",
-        "version": "1.62.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.62.1-r1.apk",
+        "version": "1.62.1-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1MlpRL1nBMU3RgNdSZVB42/vlGME=",
+        "checksum": "Q1rD3dEbbN8s5QAIQK1I8uF1O+oSo=",
         "control": {
-          "checksum": "sha1-MlpRL1nBMU3RgNdSZVB42/vlGME=",
-          "range": "bytes=697-1164"
+          "checksum": "sha1-rD3dEbbN8s5QAIQK1I8uF1O+oSo=",
+          "range": "bytes=701-1154"
         },
         "data": {
-          "checksum": "sha256-RiEPDasBVtnThSxGqTCDvb4J7WXM9YRpJwfYZJ3JLbs=",
-          "range": "bytes=1165-2274746"
+          "checksum": "sha256-41W2IRSRALQijYojLaqAiSSN1uO7twatGn8jqEuCZUg=",
+          "range": "bytes=1155-1439872"
         },
         "name": "xz",
         "signature": {
-          "checksum": "sha1-3wMPFIUEVfkAs7QSENemZsnTLyE=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-lozWkVrKvSrd1SoM7Zv08YYG2pA=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/xz-5.4.6-r2.apk",
-        "version": "5.4.6-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/xz-5.6.2-r0.apk",
+        "version": "5.6.2-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1TS707T+cPGL7TYVHQBCJoWwHZ0E=",
+        "checksum": "Q10AaU1ocIM4PYYNvwbml8TmpNvEA=",
         "control": {
-          "checksum": "sha1-TS707T+cPGL7TYVHQBCJoWwHZ0E=",
-          "range": "bytes=706-1098"
+          "checksum": "sha1-0AaU1ocIM4PYYNvwbml8TmpNvEA=",
+          "range": "bytes=706-1085"
         },
         "data": {
-          "checksum": "sha256-x18L706Vug5qDzq13SXuN/vGdVgzrqB06dW2DdgHGR4=",
-          "range": "bytes=1099-4541967"
+          "checksum": "sha256-1YQNYASFjlP3kXX58ec8du75ij/U6O4DPAKzJAPkln0=",
+          "range": "bytes=1086-4272589"
         },
         "name": "libxml2",
         "signature": {
-          "checksum": "sha1-BYhOxDos48sN8df8LMsSpROv2aw=",
+          "checksum": "sha1-QFjdplzGn/MiNFxMykgafr6/w6U=",
           "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.12.7-r0.apk",
-        "version": "2.12.7-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.1-r1.apk",
+        "version": "2.13.1-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1wJPtj5XZtnPiVWGM5dsT+nyfWXc=",
+        "checksum": "Q1wbnfumlWEiJnVUsJBRcQjFD3U6I=",
         "control": {
-          "checksum": "sha1-wJPtj5XZtnPiVWGM5dsT+nyfWXc=",
-          "range": "bytes=705-1234"
+          "checksum": "sha1-wbnfumlWEiJnVUsJBRcQjFD3U6I=",
+          "range": "bytes=699-1222"
         },
         "data": {
-          "checksum": "sha256-sw+CjlpsjO01q6lqzXgHnniiJKn7bqOSNO6vNqdGc7I=",
-          "range": "bytes=1235-3873775"
+          "checksum": "sha256-IXMNbJjj3kTjkWVBIHVRfG3zJQY2r5Eslgh/3TpMSsE=",
+          "range": "bytes=1223-3886778"
         },
         "name": "bind-libs",
         "signature": {
-          "checksum": "sha1-9zDzmHAeu7mWpidXAatqrLZVzUs=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-JNN15IPpJ2hMsO6hFVpDYPvvX5g=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bind-libs-9.18.26-r0.apk",
-        "version": "9.18.26-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/bind-libs-9.18.27-r1.apk",
+        "version": "9.18.27-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1AxEQdi8fVcYtGc3zHTCW3OZdY2Q=",
+        "checksum": "Q1kXUOoNa2KXixxAASo1W/im1qZ7s=",
         "control": {
-          "checksum": "sha1-AxEQdi8fVcYtGc3zHTCW3OZdY2Q=",
-          "range": "bytes=694-1208"
+          "checksum": "sha1-kXUOoNa2KXixxAASo1W/im1qZ7s=",
+          "range": "bytes=702-1215"
         },
         "data": {
-          "checksum": "sha256-/dt3qJw5D9iSJ/mKkRQkhWD8R52selhpcwXyw7KLMhg=",
-          "range": "bytes=1209-879444"
+          "checksum": "sha256-HRADvfRXfYsgEjUMGM4Hd7prpIv+YWILVfovbGOkEME=",
+          "range": "bytes=1216-879975"
         },
         "name": "bind-tools",
         "signature": {
-          "checksum": "sha1-VTb0YdUzPMk8Po0p4nj0y5Jey6k=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-8WUTMUaJTaX0T9FS/c+GddL7ttY=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bind-tools-9.18.26-r0.apk",
-        "version": "9.18.26-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/bind-tools-9.18.27-r1.apk",
+        "version": "9.18.27-r1"
       },
       {
         "architecture": "x86_64",
@@ -622,60 +622,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1fr0OtiVaD3c5nw8fy5m74hDe9PU=",
+        "checksum": "Q1BRGmQ9LZTeZqbxQ1ls69T6efViw=",
         "control": {
-          "checksum": "sha1-fr0OtiVaD3c5nw8fy5m74hDe9PU=",
-          "range": "bytes=697-1092"
+          "checksum": "sha1-BRGmQ9LZTeZqbxQ1ls69T6efViw=",
+          "range": "bytes=698-1080"
         },
         "data": {
-          "checksum": "sha256-lukjMYpGmuhBNDUbbTJMIrUWaR4rNikEnW4BgiTaLj8=",
-          "range": "bytes=1093-113872"
+          "checksum": "sha256-vtJ4WJ5M+31ZKSBYBedbrl/FrbAw8hGpPRrHC7kasOk=",
+          "range": "bytes=1081-113895"
         },
         "name": "libpsl",
         "signature": {
-          "checksum": "sha1-Lrrudgn1i1a0JhjdzeXG+exnjQA=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-DuAoiykwhu8vu1qxdEDK5oyAmf8=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libpsl-0.21.5-r2.apk",
-        "version": "0.21.5-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libpsl-0.21.5-r3.apk",
+        "version": "0.21.5-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1oauHQa0YcFcEHSQWdfohfNEN4sY=",
+        "checksum": "Q11DZVpe2UYyDr/dG6BDysZhE3L48=",
         "control": {
-          "checksum": "sha1-oauHQa0YcFcEHSQWdfohfNEN4sY=",
-          "range": "bytes=698-1057"
+          "checksum": "sha1-1DZVpe2UYyDr/dG6BDysZhE3L48=",
+          "range": "bytes=707-1049"
         },
         "data": {
-          "checksum": "sha256-d95c9lpjQrpuZ1CcQ8ZZ89LAGGKcessd+hxrOQpP4LU=",
-          "range": "bytes=1058-173549"
+          "checksum": "sha256-aECfsy7giZsLNxZM0HMeF4OS2gu+ycX4DUTJXsiZRQs=",
+          "range": "bytes=1050-173585"
         },
         "name": "libbrotlicommon1",
         "signature": {
-          "checksum": "sha1-g3ufBq/tyiNP6AaOoqwItVvh7uk=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-7LXD38QwFhklZCEqyW4qIncfZV0=",
+          "range": "bytes=0-706"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlicommon1-1.1.0-r2.apk",
-        "version": "1.1.0-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlicommon1-1.1.0-r3.apk",
+        "version": "1.1.0-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q18Otq7NLoYnNMebI/1Rr/s0zdLVw=",
+        "checksum": "Q1Cgr886A8Ryzynz9pxRKsNybVuK0=",
         "control": {
-          "checksum": "sha1-8Otq7NLoYnNMebI/1Rr/s0zdLVw=",
-          "range": "bytes=705-1072"
+          "checksum": "sha1-Cgr886A8Ryzynz9pxRKsNybVuK0=",
+          "range": "bytes=694-1043"
         },
         "data": {
-          "checksum": "sha256-sR3QidR/e46PJ/3S2fxAjN/hRSSA3Ar32Nw7VshTHWg=",
-          "range": "bytes=1073-81475"
+          "checksum": "sha256-mH+MTbqpLiqgydlgE+tSDEt0Sh1/zqMvAqspV4lr+Ks=",
+          "range": "bytes=1044-81511"
         },
         "name": "libbrotlidec1",
         "signature": {
-          "checksum": "sha1-6GpZI5cBUXOvjCYG81aZZR53lMI=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-Yp4Bde9oHQCec8HM2qn6hVKgtko=",
+          "range": "bytes=0-693"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlidec1-1.1.0-r2.apk",
-        "version": "1.1.0-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlidec1-1.1.0-r3.apk",
+        "version": "1.1.0-r3"
       },
       {
         "architecture": "x86_64",
@@ -774,22 +774,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q19f/3419Xa/xv9jgQ0mMYs011fBk=",
+        "checksum": "Q1mTmy64gKYi4THBqewuvYL2uUyHc=",
         "control": {
-          "checksum": "sha1-9f/3419Xa/xv9jgQ0mMYs011fBk=",
-          "range": "bytes=696-1041"
+          "checksum": "sha1-mTmy64gKYi4THBqewuvYL2uUyHc=",
+          "range": "bytes=700-1031"
         },
         "data": {
-          "checksum": "sha256-iqHASiMgiu6rIjbWGwBmmq1Zthae8BkE4QZkiVPH7Ek=",
-          "range": "bytes=1042-1888945"
+          "checksum": "sha256-p0qua2luH33oAgOcLkU9f7k+I8WnykFszVMwNahujDA=",
+          "range": "bytes=1032-1889523"
         },
         "name": "tzdata",
         "signature": {
-          "checksum": "sha1-PCC3jiXlTwrimRMXH/4RyNvccOM=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-sBf5jVLVpWj4DiXaAd/mjo0pTfk=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/tzdata-2024a-r2.apk",
-        "version": "2024a-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/tzdata-2024a-r3.apk",
+        "version": "2024a-r3"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/jaeger-all-in-one.lock.json
+++ b/wolfi-images/jaeger-all-in-one.lock.json
@@ -14,41 +14,41 @@
     "packages": [
       {
         "architecture": "x86_64",
-        "checksum": "Q1ge3SLQsJ9v2RnvIHHAP1yFyjrEU=",
+        "checksum": "Q1Ai8jWuxKZR2M2XhOpOGAoTEwnnk=",
         "control": {
-          "checksum": "sha1-ge3SLQsJ9v2RnvIHHAP1yFyjrEU=",
-          "range": "bytes=693-1040"
+          "checksum": "sha1-Ai8jWuxKZR2M2XhOpOGAoTEwnnk=",
+          "range": "bytes=705-1037"
         },
         "data": {
-          "checksum": "sha256-I0AdTdfGf4P/jwzTrLXm73l5/RNSlymEof/YZfev3xY=",
-          "range": "bytes=1041-255811"
+          "checksum": "sha256-e4UardkBVyaC49aSyrVmXNi8sSKqQl4eKYd0LxGRLA0=",
+          "range": "bytes=1038-255695"
         },
         "name": "ca-certificates-bundle",
         "signature": {
-          "checksum": "sha1-ge1eJBiQmFWAn9GapFkQpO+Rn/Y=",
-          "range": "bytes=0-692"
+          "checksum": "sha1-loRuyYQLm+atp+YteiQoj++EWIM=",
+          "range": "bytes=0-704"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20240315-r3.apk",
-        "version": "20240315-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20240315-r4.apk",
+        "version": "20240315-r4"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1bgay5kOzpmDBgqJCg7dSlawyJg0=",
+        "checksum": "Q1+GH6qRN4iy1IDt0cT0x0tin7YfI=",
         "control": {
-          "checksum": "sha1-bgay5kOzpmDBgqJCg7dSlawyJg0=",
-          "range": "bytes=703-1067"
+          "checksum": "sha1-+GH6qRN4iy1IDt0cT0x0tin7YfI=",
+          "range": "bytes=703-1051"
         },
         "data": {
-          "checksum": "sha256-f83HfRE7r2ZniH7PyPmRqcoU5NTpF+Uk4FH80QbjvBM=",
-          "range": "bytes=1068-118370"
+          "checksum": "sha256-rO0P9z2V49BSrz1A5Ap69tEappVrg5MMBjzW00rOpZc=",
+          "range": "bytes=1052-122464"
         },
         "name": "wolfi-baselayout",
         "signature": {
-          "checksum": "sha1-2hlCvYH1D7u25HkJGA75jjs/sQY=",
+          "checksum": "sha1-Ntb6VuMzDfM+frpCjKEIpDzl53I=",
           "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r11.apk",
-        "version": "20230201-r11"
+        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r12.apk",
+        "version": "20230201-r12"
       },
       {
         "architecture": "x86_64",
@@ -109,41 +109,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Zjfs1uR/mYiortANP+EFcejW+vo=",
+        "checksum": "Q1Zi0e8Bq6WCd/6uXXjVhb8YwMD1U=",
         "control": {
-          "checksum": "sha1-Zjfs1uR/mYiortANP+EFcejW+vo=",
-          "range": "bytes=698-1085"
+          "checksum": "sha1-Zi0e8Bq6WCd/6uXXjVhb8YwMD1U=",
+          "range": "bytes=700-1073"
         },
         "data": {
-          "checksum": "sha256-BMd7TzffjbrFwdbopDPVYsX0X9XnusIMNbIf33/8kwc=",
-          "range": "bytes=1086-76881"
+          "checksum": "sha256-jMhtfqVjnhuuBO7wtNZ6RS/72sZWoKt/Moage2amlks=",
+          "range": "bytes=1074-81594"
         },
         "name": "protobuf-c",
         "signature": {
-          "checksum": "sha1-efGiXyYWsJ5P2uTkB6aXEZ3kl3o=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-kATwMKztK7nk7qbYCJPkCFp6IXc=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r4.apk",
-        "version": "1.5.0-r4"
-      },
-      {
-        "architecture": "x86_64",
-        "checksum": "Q1Xf5v5uXumBgIR4d4ZxMRxdpyWlM=",
-        "control": {
-          "checksum": "sha1-Xf5v5uXumBgIR4d4ZxMRxdpyWlM=",
-          "range": "bytes=698-1078"
-        },
-        "data": {
-          "checksum": "sha256-eD7HqFCWNUBQiLq9PcWE/zPeZwkiv8hBrytI4qmfQ/8=",
-          "range": "bytes=1079-57055"
-        },
-        "name": "keyutils-libs",
-        "signature": {
-          "checksum": "sha1-V0HVgZLP7P5kNACfus3abCLCS20=",
-          "range": "bytes=0-697"
-        },
-        "url": "https://packages.wolfi.dev/os/x86_64/keyutils-libs-1.6.3-r2.apk",
-        "version": "1.6.3-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r5.apk",
+        "version": "1.5.0-r5"
       },
       {
         "architecture": "x86_64",
@@ -166,22 +147,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1wRzOx+L6MeRFtTcq2y/6ot7Cj54=",
+        "checksum": "Q1v0A2vQM5k8rQY/GpIq6xI4T0YmA=",
         "control": {
-          "checksum": "sha1-wRzOx+L6MeRFtTcq2y/6ot7Cj54=",
-          "range": "bytes=699-1069"
+          "checksum": "sha1-v0A2vQM5k8rQY/GpIq6xI4T0YmA=",
+          "range": "bytes=701-1064"
         },
         "data": {
-          "checksum": "sha256-gNRjwZ4XQatCYWediSVb+j8lS54CggvMC5Dn3qT84So=",
-          "range": "bytes=1070-61490"
+          "checksum": "sha256-uAOrkGDDc/yqt6VjIrlTEALBJG4BCI4njqZw5jQqF0o=",
+          "range": "bytes=1065-56984"
+        },
+        "name": "keyutils-libs",
+        "signature": {
+          "checksum": "sha1-32uYMH/zGBr9Jo3hiqnThlcqBcE=",
+          "range": "bytes=0-700"
+        },
+        "url": "https://packages.wolfi.dev/os/x86_64/keyutils-libs-1.6.3-r3.apk",
+        "version": "1.6.3-r3"
+      },
+      {
+        "architecture": "x86_64",
+        "checksum": "Q1Onuac6Y+IWA7a4b8FvqX1erWDDw=",
+        "control": {
+          "checksum": "sha1-Onuac6Y+IWA7a4b8FvqX1erWDDw=",
+          "range": "bytes=693-1048"
+        },
+        "data": {
+          "checksum": "sha256-KLtDAs3iU0oyZ/FysePG/J+1H1ofDxHXIY7xvtZhtMc=",
+          "range": "bytes=1049-61503"
         },
         "name": "libverto",
         "signature": {
-          "checksum": "sha1-kuPwakYdy5EM6sd5Ba0K0Ta8x4w=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-/IXL9S1O+MwaW7KsSzz1ywEqKFQ=",
+          "range": "bytes=0-692"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libverto-0.3.2-r3.apk",
-        "version": "0.3.2-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/libverto-0.3.2-r4.apk",
+        "version": "0.3.2-r4"
       },
       {
         "architecture": "x86_64",
@@ -204,60 +204,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1gTZGkWP+QO3mUqLVJth8vrDEzzU=",
+        "checksum": "Q1Q/Zy5ovYSu2p/vVLr6DgVA1e8AQ=",
         "control": {
-          "checksum": "sha1-gTZGkWP+QO3mUqLVJth8vrDEzzU=",
-          "range": "bytes=699-1076"
+          "checksum": "sha1-Q/Zy5ovYSu2p/vVLr6DgVA1e8AQ=",
+          "range": "bytes=699-1062"
         },
         "data": {
-          "checksum": "sha256-/IFXqeKvU0GODNsz1yPIEMcFHgABT+8rbZpSlTLo4e4=",
-          "range": "bytes=1077-5915704"
+          "checksum": "sha256-H3jxsw8ytOeCIR4vq17voSVhdNokXk8C1g075txH6Bs=",
+          "range": "bytes=1063-5903754"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-l1o5ixkyWWqqJE3FOfR0QUemJUA=",
+          "checksum": "sha1-NIl2f5OI/wSZByI8Ds1ZUfbFWyw=",
           "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r9.apk",
-        "version": "3.3.0-r9"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.1-r3.apk",
+        "version": "3.3.1-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1jhAhggAuZnU7FFHnebGA26mq+jI=",
+        "checksum": "Q13wGUXdZut9OOTdY5z2amUj9wXC0=",
         "control": {
-          "checksum": "sha1-jhAhggAuZnU7FFHnebGA26mq+jI=",
-          "range": "bytes=695-1079"
+          "checksum": "sha1-3wGUXdZut9OOTdY5z2amUj9wXC0=",
+          "range": "bytes=698-1068"
         },
         "data": {
-          "checksum": "sha256-XTCQYnhGSm7SkGwqV/TQMFqGajVJVYhKAidKfLb2D3Y=",
-          "range": "bytes=1080-1197081"
+          "checksum": "sha256-mRda6+YGlOCczyIWKaHqXskTINoT1rgorHDHqAKAb7c=",
+          "range": "bytes=1069-1188955"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-qVrfDVxubkrb5Yrd2mFTv2A0G7k=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-+UdRc4U3PKw4H9OiNurHKXa5BYk=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r9.apk",
-        "version": "3.3.0-r9"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.1-r3.apk",
+        "version": "3.3.1-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1BQEXaeya6QB39QLeKcB99qBNF2o=",
+        "checksum": "Q1p04MrHQPrXOzuV/uF290zjnltqI=",
         "control": {
-          "checksum": "sha1-BQEXaeya6QB39QLeKcB99qBNF2o=",
-          "range": "bytes=699-1229"
+          "checksum": "sha1-p04MrHQPrXOzuV/uF290zjnltqI=",
+          "range": "bytes=704-1219"
         },
         "data": {
-          "checksum": "sha256-ugj/qGEBzhvdX17S22Anry+biy3lcqywhGMSHLIBCvo=",
-          "range": "bytes=1230-2551676"
+          "checksum": "sha256-TsXeqhUGykAhjQUEAlMUSzDQBcWDkkDvReoeHCL1F6c=",
+          "range": "bytes=1220-2555814"
         },
         "name": "krb5-libs",
         "signature": {
-          "checksum": "sha1-oqDPmNM4EngXAGayd/BZOqJAIao=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-cPyzS38QHuNlOCQb8IPlsl2PLHQ=",
+          "range": "bytes=0-703"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/krb5-libs-1.21.2-r2.apk",
-        "version": "1.21.2-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/krb5-libs-1.21.3-r0.apk",
+        "version": "1.21.3-r0"
       },
       {
         "architecture": "x86_64",
@@ -280,60 +280,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1wzZwtLauOQfLQC7YUvZdfKxtlwQ=",
+        "checksum": "Q17uprcuQ2VFudMcWAwtP7miJmLYs=",
         "control": {
-          "checksum": "sha1-wzZwtLauOQfLQC7YUvZdfKxtlwQ=",
-          "range": "bytes=698-1085"
+          "checksum": "sha1-7uprcuQ2VFudMcWAwtP7miJmLYs=",
+          "range": "bytes=695-1067"
         },
         "data": {
-          "checksum": "sha256-TO8CAULO44s/LphhtcaFOGJB7aFldk13v1cV9ceZHww=",
-          "range": "bytes=1086-276837"
+          "checksum": "sha256-unKdPbvO2VHZ5w1t1l8mOpQuNdUGwLhofEO4weN2Mig=",
+          "range": "bytes=1068-280973"
         },
         "name": "libuv",
         "signature": {
-          "checksum": "sha1-LRiyeKmjexy8CJizLxjd6ikon1w=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-4lKldnTO71WHMZ4tbANz6i2/Ed0=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libuv-1.48.0-r2.apk",
-        "version": "1.48.0-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libuv-1.48.0-r3.apk",
+        "version": "1.48.0-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q14S6biy8fc5OGbGEJoLBM+tJOGyo=",
+        "checksum": "Q1CN6zJbOPznWUfTrb/41KT7E6dm8=",
         "control": {
-          "checksum": "sha1-4S6biy8fc5OGbGEJoLBM+tJOGyo=",
-          "range": "bytes=703-1102"
+          "checksum": "sha1-CN6zJbOPznWUfTrb/41KT7E6dm8=",
+          "range": "bytes=699-1083"
         },
         "data": {
-          "checksum": "sha256-hwjdLQYfuMAGQeONmFVo0lZKKQK1S+3PBhrI3upm5W4=",
-          "range": "bytes=1103-155304"
+          "checksum": "sha256-ybzFzoQh1yNTcd3cjt54nYsPlAxAcMUcVMxEv1JRnpQ=",
+          "range": "bytes=1084-155375"
         },
         "name": "zlib",
         "signature": {
-          "checksum": "sha1-ZuLd7kE+AGhn27o8ZqDGM5eundc=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-CPXJcCjinAXP+H8Z5tkko8ayG6E=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/zlib-1.3.1-r2.apk",
-        "version": "1.3.1-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/zlib-1.3.1-r3.apk",
+        "version": "1.3.1-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ykDkP+AmDi2VcZZ1c4q4sez/DxI=",
+        "checksum": "Q1rgbci8SRSjW7EB0NSh6ZUPJLndM=",
         "control": {
-          "checksum": "sha1-ykDkP+AmDi2VcZZ1c4q4sez/DxI=",
-          "range": "bytes=705-1079"
+          "checksum": "sha1-rgbci8SRSjW7EB0NSh6ZUPJLndM=",
+          "range": "bytes=702-1060"
         },
         "data": {
-          "checksum": "sha256-t3BrH7lWfY3to3Fu3EKAMZx29v9Hnl5seyXJzLmZ9/4=",
-          "range": "bytes=1080-251884"
+          "checksum": "sha256-tf4xbo+NP+ssiaZtC1kOKehffAZ3+d17bhgfU3/30+g=",
+          "range": "bytes=1061-256582"
         },
         "name": "libnghttp2-14",
         "signature": {
-          "checksum": "sha1-CotSXRaPLKQCBRHrgzrDOD+4w20=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-KrsJYTyUsll+EUhHekbkdZFzeig=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.62.1-r0.apk",
-        "version": "1.62.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.62.1-r1.apk",
+        "version": "1.62.1-r1"
       },
       {
         "architecture": "x86_64",
@@ -394,136 +394,136 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1DE49kWSnmqVKJdjHFYC1bLkvyb0=",
+        "checksum": "Q1R8OxpY0fGwVaIwft4wJeswF5D54=",
         "control": {
-          "checksum": "sha1-DE49kWSnmqVKJdjHFYC1bLkvyb0=",
-          "range": "bytes=697-1078"
+          "checksum": "sha1-R8OxpY0fGwVaIwft4wJeswF5D54=",
+          "range": "bytes=695-1059"
         },
         "data": {
-          "checksum": "sha256-uDg8Qc6Rnro/68Vb5ufFSkqFLGrEsbvPb0pMJNvT1zw=",
-          "range": "bytes=1079-242085"
+          "checksum": "sha256-wNc8/SBJrGHfwywAtzCsAqeUOt0IaAhqNtlbv8OiHBE=",
+          "range": "bytes=1060-242151"
         },
         "name": "c-ares",
         "signature": {
-          "checksum": "sha1-iYEm6EWQKzxkeoDm+QsRfhw8pDg=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-55/PTlEHXI3o0hx9dSVdNwQeSMg=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.29.0-r0.apk",
-        "version": "1.29.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.31.0-r0.apk",
+        "version": "1.31.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q12eWmn2tCkXxwncU6gagKM3Wd9Sk=",
+        "checksum": "Q1g2RQKAvNjlRPxWjinIRveaq7IlY=",
         "control": {
-          "checksum": "sha1-2eWmn2tCkXxwncU6gagKM3Wd9Sk=",
-          "range": "bytes=696-1169"
+          "checksum": "sha1-g2RQKAvNjlRPxWjinIRveaq7IlY=",
+          "range": "bytes=695-1154"
         },
         "data": {
-          "checksum": "sha256-IFKNdojOhml3DbWPryQuHUiV3tgTWHyqOYD1JNe9IJ4=",
-          "range": "bytes=1170-2582015"
+          "checksum": "sha256-UsQFfOTXCZBan0mxDvR+ts0NKcbv1lNijxnRxjsmZhA=",
+          "range": "bytes=1155-2566233"
         },
         "name": "nghttp2",
         "signature": {
-          "checksum": "sha1-2/9n7KbRuOkrvhYqCFR5Mblx+z8=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-SUvMhz1cc5Or5Qh4fUEvPCp0NAw=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.62.1-r0.apk",
-        "version": "1.62.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.62.1-r1.apk",
+        "version": "1.62.1-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ialksjwPWvvZW+O2ABMbbBV/KTg=",
+        "checksum": "Q1sTMGOgdbZyDKxlRAByisPMHTbpY=",
         "control": {
-          "checksum": "sha1-ialksjwPWvvZW+O2ABMbbBV/KTg=",
-          "range": "bytes=702-1074"
+          "checksum": "sha1-sTMGOgdbZyDKxlRAByisPMHTbpY=",
+          "range": "bytes=703-1060"
         },
         "data": {
-          "checksum": "sha256-+ctDr3AO9mTXovGRPWk6h2ZgfY99Toy6esjBNHtJPY4=",
-          "range": "bytes=1075-631903"
+          "checksum": "sha256-bUy0h/zxpq7iP6vrQRMftZ9nevkHTB87hSX17wz4lmM=",
+          "range": "bytes=1061-631449"
         },
         "name": "nghttp2-dev",
         "signature": {
-          "checksum": "sha1-wZGQRluFd6DL1USzeak75o5/BTc=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-fQ6aDq3Io/gdJ5s5t3M+FwED1Y0=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.62.1-r0.apk",
-        "version": "1.62.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.62.1-r1.apk",
+        "version": "1.62.1-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1MlpRL1nBMU3RgNdSZVB42/vlGME=",
+        "checksum": "Q1rD3dEbbN8s5QAIQK1I8uF1O+oSo=",
         "control": {
-          "checksum": "sha1-MlpRL1nBMU3RgNdSZVB42/vlGME=",
-          "range": "bytes=697-1164"
+          "checksum": "sha1-rD3dEbbN8s5QAIQK1I8uF1O+oSo=",
+          "range": "bytes=701-1154"
         },
         "data": {
-          "checksum": "sha256-RiEPDasBVtnThSxGqTCDvb4J7WXM9YRpJwfYZJ3JLbs=",
-          "range": "bytes=1165-2274746"
+          "checksum": "sha256-41W2IRSRALQijYojLaqAiSSN1uO7twatGn8jqEuCZUg=",
+          "range": "bytes=1155-1439872"
         },
         "name": "xz",
         "signature": {
-          "checksum": "sha1-3wMPFIUEVfkAs7QSENemZsnTLyE=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-lozWkVrKvSrd1SoM7Zv08YYG2pA=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/xz-5.4.6-r2.apk",
-        "version": "5.4.6-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/xz-5.6.2-r0.apk",
+        "version": "5.6.2-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1TS707T+cPGL7TYVHQBCJoWwHZ0E=",
+        "checksum": "Q10AaU1ocIM4PYYNvwbml8TmpNvEA=",
         "control": {
-          "checksum": "sha1-TS707T+cPGL7TYVHQBCJoWwHZ0E=",
-          "range": "bytes=706-1098"
+          "checksum": "sha1-0AaU1ocIM4PYYNvwbml8TmpNvEA=",
+          "range": "bytes=706-1085"
         },
         "data": {
-          "checksum": "sha256-x18L706Vug5qDzq13SXuN/vGdVgzrqB06dW2DdgHGR4=",
-          "range": "bytes=1099-4541967"
+          "checksum": "sha256-1YQNYASFjlP3kXX58ec8du75ij/U6O4DPAKzJAPkln0=",
+          "range": "bytes=1086-4272589"
         },
         "name": "libxml2",
         "signature": {
-          "checksum": "sha1-BYhOxDos48sN8df8LMsSpROv2aw=",
+          "checksum": "sha1-QFjdplzGn/MiNFxMykgafr6/w6U=",
           "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.12.7-r0.apk",
-        "version": "2.12.7-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.1-r1.apk",
+        "version": "2.13.1-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1wJPtj5XZtnPiVWGM5dsT+nyfWXc=",
+        "checksum": "Q1wbnfumlWEiJnVUsJBRcQjFD3U6I=",
         "control": {
-          "checksum": "sha1-wJPtj5XZtnPiVWGM5dsT+nyfWXc=",
-          "range": "bytes=705-1234"
+          "checksum": "sha1-wbnfumlWEiJnVUsJBRcQjFD3U6I=",
+          "range": "bytes=699-1222"
         },
         "data": {
-          "checksum": "sha256-sw+CjlpsjO01q6lqzXgHnniiJKn7bqOSNO6vNqdGc7I=",
-          "range": "bytes=1235-3873775"
+          "checksum": "sha256-IXMNbJjj3kTjkWVBIHVRfG3zJQY2r5Eslgh/3TpMSsE=",
+          "range": "bytes=1223-3886778"
         },
         "name": "bind-libs",
         "signature": {
-          "checksum": "sha1-9zDzmHAeu7mWpidXAatqrLZVzUs=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-JNN15IPpJ2hMsO6hFVpDYPvvX5g=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bind-libs-9.18.26-r0.apk",
-        "version": "9.18.26-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/bind-libs-9.18.27-r1.apk",
+        "version": "9.18.27-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1AxEQdi8fVcYtGc3zHTCW3OZdY2Q=",
+        "checksum": "Q1kXUOoNa2KXixxAASo1W/im1qZ7s=",
         "control": {
-          "checksum": "sha1-AxEQdi8fVcYtGc3zHTCW3OZdY2Q=",
-          "range": "bytes=694-1208"
+          "checksum": "sha1-kXUOoNa2KXixxAASo1W/im1qZ7s=",
+          "range": "bytes=702-1215"
         },
         "data": {
-          "checksum": "sha256-/dt3qJw5D9iSJ/mKkRQkhWD8R52selhpcwXyw7KLMhg=",
-          "range": "bytes=1209-879444"
+          "checksum": "sha256-HRADvfRXfYsgEjUMGM4Hd7prpIv+YWILVfovbGOkEME=",
+          "range": "bytes=1216-879975"
         },
         "name": "bind-tools",
         "signature": {
-          "checksum": "sha1-VTb0YdUzPMk8Po0p4nj0y5Jey6k=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-8WUTMUaJTaX0T9FS/c+GddL7ttY=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bind-tools-9.18.26-r0.apk",
-        "version": "9.18.26-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/bind-tools-9.18.27-r1.apk",
+        "version": "9.18.27-r1"
       },
       {
         "architecture": "x86_64",
@@ -622,60 +622,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1fr0OtiVaD3c5nw8fy5m74hDe9PU=",
+        "checksum": "Q1BRGmQ9LZTeZqbxQ1ls69T6efViw=",
         "control": {
-          "checksum": "sha1-fr0OtiVaD3c5nw8fy5m74hDe9PU=",
-          "range": "bytes=697-1092"
+          "checksum": "sha1-BRGmQ9LZTeZqbxQ1ls69T6efViw=",
+          "range": "bytes=698-1080"
         },
         "data": {
-          "checksum": "sha256-lukjMYpGmuhBNDUbbTJMIrUWaR4rNikEnW4BgiTaLj8=",
-          "range": "bytes=1093-113872"
+          "checksum": "sha256-vtJ4WJ5M+31ZKSBYBedbrl/FrbAw8hGpPRrHC7kasOk=",
+          "range": "bytes=1081-113895"
         },
         "name": "libpsl",
         "signature": {
-          "checksum": "sha1-Lrrudgn1i1a0JhjdzeXG+exnjQA=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-DuAoiykwhu8vu1qxdEDK5oyAmf8=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libpsl-0.21.5-r2.apk",
-        "version": "0.21.5-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libpsl-0.21.5-r3.apk",
+        "version": "0.21.5-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1oauHQa0YcFcEHSQWdfohfNEN4sY=",
+        "checksum": "Q11DZVpe2UYyDr/dG6BDysZhE3L48=",
         "control": {
-          "checksum": "sha1-oauHQa0YcFcEHSQWdfohfNEN4sY=",
-          "range": "bytes=698-1057"
+          "checksum": "sha1-1DZVpe2UYyDr/dG6BDysZhE3L48=",
+          "range": "bytes=707-1049"
         },
         "data": {
-          "checksum": "sha256-d95c9lpjQrpuZ1CcQ8ZZ89LAGGKcessd+hxrOQpP4LU=",
-          "range": "bytes=1058-173549"
+          "checksum": "sha256-aECfsy7giZsLNxZM0HMeF4OS2gu+ycX4DUTJXsiZRQs=",
+          "range": "bytes=1050-173585"
         },
         "name": "libbrotlicommon1",
         "signature": {
-          "checksum": "sha1-g3ufBq/tyiNP6AaOoqwItVvh7uk=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-7LXD38QwFhklZCEqyW4qIncfZV0=",
+          "range": "bytes=0-706"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlicommon1-1.1.0-r2.apk",
-        "version": "1.1.0-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlicommon1-1.1.0-r3.apk",
+        "version": "1.1.0-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q18Otq7NLoYnNMebI/1Rr/s0zdLVw=",
+        "checksum": "Q1Cgr886A8Ryzynz9pxRKsNybVuK0=",
         "control": {
-          "checksum": "sha1-8Otq7NLoYnNMebI/1Rr/s0zdLVw=",
-          "range": "bytes=705-1072"
+          "checksum": "sha1-Cgr886A8Ryzynz9pxRKsNybVuK0=",
+          "range": "bytes=694-1043"
         },
         "data": {
-          "checksum": "sha256-sR3QidR/e46PJ/3S2fxAjN/hRSSA3Ar32Nw7VshTHWg=",
-          "range": "bytes=1073-81475"
+          "checksum": "sha256-mH+MTbqpLiqgydlgE+tSDEt0Sh1/zqMvAqspV4lr+Ks=",
+          "range": "bytes=1044-81511"
         },
         "name": "libbrotlidec1",
         "signature": {
-          "checksum": "sha1-6GpZI5cBUXOvjCYG81aZZR53lMI=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-Yp4Bde9oHQCec8HM2qn6hVKgtko=",
+          "range": "bytes=0-693"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlidec1-1.1.0-r2.apk",
-        "version": "1.1.0-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlidec1-1.1.0-r3.apk",
+        "version": "1.1.0-r3"
       },
       {
         "architecture": "x86_64",
@@ -774,22 +774,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q19f/3419Xa/xv9jgQ0mMYs011fBk=",
+        "checksum": "Q1mTmy64gKYi4THBqewuvYL2uUyHc=",
         "control": {
-          "checksum": "sha1-9f/3419Xa/xv9jgQ0mMYs011fBk=",
-          "range": "bytes=696-1041"
+          "checksum": "sha1-mTmy64gKYi4THBqewuvYL2uUyHc=",
+          "range": "bytes=700-1031"
         },
         "data": {
-          "checksum": "sha256-iqHASiMgiu6rIjbWGwBmmq1Zthae8BkE4QZkiVPH7Ek=",
-          "range": "bytes=1042-1888945"
+          "checksum": "sha256-p0qua2luH33oAgOcLkU9f7k+I8WnykFszVMwNahujDA=",
+          "range": "bytes=1032-1889523"
         },
         "name": "tzdata",
         "signature": {
-          "checksum": "sha1-PCC3jiXlTwrimRMXH/4RyNvccOM=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-sBf5jVLVpWj4DiXaAd/mjo0pTfk=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/tzdata-2024a-r2.apk",
-        "version": "2024a-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/tzdata-2024a-r3.apk",
+        "version": "2024a-r3"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/node-exporter.lock.json
+++ b/wolfi-images/node-exporter.lock.json
@@ -14,41 +14,41 @@
     "packages": [
       {
         "architecture": "x86_64",
-        "checksum": "Q1ge3SLQsJ9v2RnvIHHAP1yFyjrEU=",
+        "checksum": "Q1Ai8jWuxKZR2M2XhOpOGAoTEwnnk=",
         "control": {
-          "checksum": "sha1-ge3SLQsJ9v2RnvIHHAP1yFyjrEU=",
-          "range": "bytes=693-1040"
+          "checksum": "sha1-Ai8jWuxKZR2M2XhOpOGAoTEwnnk=",
+          "range": "bytes=705-1037"
         },
         "data": {
-          "checksum": "sha256-I0AdTdfGf4P/jwzTrLXm73l5/RNSlymEof/YZfev3xY=",
-          "range": "bytes=1041-255811"
+          "checksum": "sha256-e4UardkBVyaC49aSyrVmXNi8sSKqQl4eKYd0LxGRLA0=",
+          "range": "bytes=1038-255695"
         },
         "name": "ca-certificates-bundle",
         "signature": {
-          "checksum": "sha1-ge1eJBiQmFWAn9GapFkQpO+Rn/Y=",
-          "range": "bytes=0-692"
+          "checksum": "sha1-loRuyYQLm+atp+YteiQoj++EWIM=",
+          "range": "bytes=0-704"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20240315-r3.apk",
-        "version": "20240315-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20240315-r4.apk",
+        "version": "20240315-r4"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1bgay5kOzpmDBgqJCg7dSlawyJg0=",
+        "checksum": "Q1+GH6qRN4iy1IDt0cT0x0tin7YfI=",
         "control": {
-          "checksum": "sha1-bgay5kOzpmDBgqJCg7dSlawyJg0=",
-          "range": "bytes=703-1067"
+          "checksum": "sha1-+GH6qRN4iy1IDt0cT0x0tin7YfI=",
+          "range": "bytes=703-1051"
         },
         "data": {
-          "checksum": "sha256-f83HfRE7r2ZniH7PyPmRqcoU5NTpF+Uk4FH80QbjvBM=",
-          "range": "bytes=1068-118370"
+          "checksum": "sha256-rO0P9z2V49BSrz1A5Ap69tEappVrg5MMBjzW00rOpZc=",
+          "range": "bytes=1052-122464"
         },
         "name": "wolfi-baselayout",
         "signature": {
-          "checksum": "sha1-2hlCvYH1D7u25HkJGA75jjs/sQY=",
+          "checksum": "sha1-Ntb6VuMzDfM+frpCjKEIpDzl53I=",
           "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r11.apk",
-        "version": "20230201-r11"
+        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r12.apk",
+        "version": "20230201-r12"
       },
       {
         "architecture": "x86_64",
@@ -109,41 +109,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Zjfs1uR/mYiortANP+EFcejW+vo=",
+        "checksum": "Q1Zi0e8Bq6WCd/6uXXjVhb8YwMD1U=",
         "control": {
-          "checksum": "sha1-Zjfs1uR/mYiortANP+EFcejW+vo=",
-          "range": "bytes=698-1085"
+          "checksum": "sha1-Zi0e8Bq6WCd/6uXXjVhb8YwMD1U=",
+          "range": "bytes=700-1073"
         },
         "data": {
-          "checksum": "sha256-BMd7TzffjbrFwdbopDPVYsX0X9XnusIMNbIf33/8kwc=",
-          "range": "bytes=1086-76881"
+          "checksum": "sha256-jMhtfqVjnhuuBO7wtNZ6RS/72sZWoKt/Moage2amlks=",
+          "range": "bytes=1074-81594"
         },
         "name": "protobuf-c",
         "signature": {
-          "checksum": "sha1-efGiXyYWsJ5P2uTkB6aXEZ3kl3o=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-kATwMKztK7nk7qbYCJPkCFp6IXc=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r4.apk",
-        "version": "1.5.0-r4"
-      },
-      {
-        "architecture": "x86_64",
-        "checksum": "Q1Xf5v5uXumBgIR4d4ZxMRxdpyWlM=",
-        "control": {
-          "checksum": "sha1-Xf5v5uXumBgIR4d4ZxMRxdpyWlM=",
-          "range": "bytes=698-1078"
-        },
-        "data": {
-          "checksum": "sha256-eD7HqFCWNUBQiLq9PcWE/zPeZwkiv8hBrytI4qmfQ/8=",
-          "range": "bytes=1079-57055"
-        },
-        "name": "keyutils-libs",
-        "signature": {
-          "checksum": "sha1-V0HVgZLP7P5kNACfus3abCLCS20=",
-          "range": "bytes=0-697"
-        },
-        "url": "https://packages.wolfi.dev/os/x86_64/keyutils-libs-1.6.3-r2.apk",
-        "version": "1.6.3-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r5.apk",
+        "version": "1.5.0-r5"
       },
       {
         "architecture": "x86_64",
@@ -166,22 +147,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1wRzOx+L6MeRFtTcq2y/6ot7Cj54=",
+        "checksum": "Q1v0A2vQM5k8rQY/GpIq6xI4T0YmA=",
         "control": {
-          "checksum": "sha1-wRzOx+L6MeRFtTcq2y/6ot7Cj54=",
-          "range": "bytes=699-1069"
+          "checksum": "sha1-v0A2vQM5k8rQY/GpIq6xI4T0YmA=",
+          "range": "bytes=701-1064"
         },
         "data": {
-          "checksum": "sha256-gNRjwZ4XQatCYWediSVb+j8lS54CggvMC5Dn3qT84So=",
-          "range": "bytes=1070-61490"
+          "checksum": "sha256-uAOrkGDDc/yqt6VjIrlTEALBJG4BCI4njqZw5jQqF0o=",
+          "range": "bytes=1065-56984"
+        },
+        "name": "keyutils-libs",
+        "signature": {
+          "checksum": "sha1-32uYMH/zGBr9Jo3hiqnThlcqBcE=",
+          "range": "bytes=0-700"
+        },
+        "url": "https://packages.wolfi.dev/os/x86_64/keyutils-libs-1.6.3-r3.apk",
+        "version": "1.6.3-r3"
+      },
+      {
+        "architecture": "x86_64",
+        "checksum": "Q1Onuac6Y+IWA7a4b8FvqX1erWDDw=",
+        "control": {
+          "checksum": "sha1-Onuac6Y+IWA7a4b8FvqX1erWDDw=",
+          "range": "bytes=693-1048"
+        },
+        "data": {
+          "checksum": "sha256-KLtDAs3iU0oyZ/FysePG/J+1H1ofDxHXIY7xvtZhtMc=",
+          "range": "bytes=1049-61503"
         },
         "name": "libverto",
         "signature": {
-          "checksum": "sha1-kuPwakYdy5EM6sd5Ba0K0Ta8x4w=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-/IXL9S1O+MwaW7KsSzz1ywEqKFQ=",
+          "range": "bytes=0-692"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libverto-0.3.2-r3.apk",
-        "version": "0.3.2-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/libverto-0.3.2-r4.apk",
+        "version": "0.3.2-r4"
       },
       {
         "architecture": "x86_64",
@@ -204,60 +204,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1gTZGkWP+QO3mUqLVJth8vrDEzzU=",
+        "checksum": "Q1Q/Zy5ovYSu2p/vVLr6DgVA1e8AQ=",
         "control": {
-          "checksum": "sha1-gTZGkWP+QO3mUqLVJth8vrDEzzU=",
-          "range": "bytes=699-1076"
+          "checksum": "sha1-Q/Zy5ovYSu2p/vVLr6DgVA1e8AQ=",
+          "range": "bytes=699-1062"
         },
         "data": {
-          "checksum": "sha256-/IFXqeKvU0GODNsz1yPIEMcFHgABT+8rbZpSlTLo4e4=",
-          "range": "bytes=1077-5915704"
+          "checksum": "sha256-H3jxsw8ytOeCIR4vq17voSVhdNokXk8C1g075txH6Bs=",
+          "range": "bytes=1063-5903754"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-l1o5ixkyWWqqJE3FOfR0QUemJUA=",
+          "checksum": "sha1-NIl2f5OI/wSZByI8Ds1ZUfbFWyw=",
           "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r9.apk",
-        "version": "3.3.0-r9"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.1-r3.apk",
+        "version": "3.3.1-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1jhAhggAuZnU7FFHnebGA26mq+jI=",
+        "checksum": "Q13wGUXdZut9OOTdY5z2amUj9wXC0=",
         "control": {
-          "checksum": "sha1-jhAhggAuZnU7FFHnebGA26mq+jI=",
-          "range": "bytes=695-1079"
+          "checksum": "sha1-3wGUXdZut9OOTdY5z2amUj9wXC0=",
+          "range": "bytes=698-1068"
         },
         "data": {
-          "checksum": "sha256-XTCQYnhGSm7SkGwqV/TQMFqGajVJVYhKAidKfLb2D3Y=",
-          "range": "bytes=1080-1197081"
+          "checksum": "sha256-mRda6+YGlOCczyIWKaHqXskTINoT1rgorHDHqAKAb7c=",
+          "range": "bytes=1069-1188955"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-qVrfDVxubkrb5Yrd2mFTv2A0G7k=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-+UdRc4U3PKw4H9OiNurHKXa5BYk=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r9.apk",
-        "version": "3.3.0-r9"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.1-r3.apk",
+        "version": "3.3.1-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1BQEXaeya6QB39QLeKcB99qBNF2o=",
+        "checksum": "Q1p04MrHQPrXOzuV/uF290zjnltqI=",
         "control": {
-          "checksum": "sha1-BQEXaeya6QB39QLeKcB99qBNF2o=",
-          "range": "bytes=699-1229"
+          "checksum": "sha1-p04MrHQPrXOzuV/uF290zjnltqI=",
+          "range": "bytes=704-1219"
         },
         "data": {
-          "checksum": "sha256-ugj/qGEBzhvdX17S22Anry+biy3lcqywhGMSHLIBCvo=",
-          "range": "bytes=1230-2551676"
+          "checksum": "sha256-TsXeqhUGykAhjQUEAlMUSzDQBcWDkkDvReoeHCL1F6c=",
+          "range": "bytes=1220-2555814"
         },
         "name": "krb5-libs",
         "signature": {
-          "checksum": "sha1-oqDPmNM4EngXAGayd/BZOqJAIao=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-cPyzS38QHuNlOCQb8IPlsl2PLHQ=",
+          "range": "bytes=0-703"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/krb5-libs-1.21.2-r2.apk",
-        "version": "1.21.2-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/krb5-libs-1.21.3-r0.apk",
+        "version": "1.21.3-r0"
       },
       {
         "architecture": "x86_64",
@@ -280,60 +280,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1wzZwtLauOQfLQC7YUvZdfKxtlwQ=",
+        "checksum": "Q17uprcuQ2VFudMcWAwtP7miJmLYs=",
         "control": {
-          "checksum": "sha1-wzZwtLauOQfLQC7YUvZdfKxtlwQ=",
-          "range": "bytes=698-1085"
+          "checksum": "sha1-7uprcuQ2VFudMcWAwtP7miJmLYs=",
+          "range": "bytes=695-1067"
         },
         "data": {
-          "checksum": "sha256-TO8CAULO44s/LphhtcaFOGJB7aFldk13v1cV9ceZHww=",
-          "range": "bytes=1086-276837"
+          "checksum": "sha256-unKdPbvO2VHZ5w1t1l8mOpQuNdUGwLhofEO4weN2Mig=",
+          "range": "bytes=1068-280973"
         },
         "name": "libuv",
         "signature": {
-          "checksum": "sha1-LRiyeKmjexy8CJizLxjd6ikon1w=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-4lKldnTO71WHMZ4tbANz6i2/Ed0=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libuv-1.48.0-r2.apk",
-        "version": "1.48.0-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libuv-1.48.0-r3.apk",
+        "version": "1.48.0-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q14S6biy8fc5OGbGEJoLBM+tJOGyo=",
+        "checksum": "Q1CN6zJbOPznWUfTrb/41KT7E6dm8=",
         "control": {
-          "checksum": "sha1-4S6biy8fc5OGbGEJoLBM+tJOGyo=",
-          "range": "bytes=703-1102"
+          "checksum": "sha1-CN6zJbOPznWUfTrb/41KT7E6dm8=",
+          "range": "bytes=699-1083"
         },
         "data": {
-          "checksum": "sha256-hwjdLQYfuMAGQeONmFVo0lZKKQK1S+3PBhrI3upm5W4=",
-          "range": "bytes=1103-155304"
+          "checksum": "sha256-ybzFzoQh1yNTcd3cjt54nYsPlAxAcMUcVMxEv1JRnpQ=",
+          "range": "bytes=1084-155375"
         },
         "name": "zlib",
         "signature": {
-          "checksum": "sha1-ZuLd7kE+AGhn27o8ZqDGM5eundc=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-CPXJcCjinAXP+H8Z5tkko8ayG6E=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/zlib-1.3.1-r2.apk",
-        "version": "1.3.1-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/zlib-1.3.1-r3.apk",
+        "version": "1.3.1-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ykDkP+AmDi2VcZZ1c4q4sez/DxI=",
+        "checksum": "Q1rgbci8SRSjW7EB0NSh6ZUPJLndM=",
         "control": {
-          "checksum": "sha1-ykDkP+AmDi2VcZZ1c4q4sez/DxI=",
-          "range": "bytes=705-1079"
+          "checksum": "sha1-rgbci8SRSjW7EB0NSh6ZUPJLndM=",
+          "range": "bytes=702-1060"
         },
         "data": {
-          "checksum": "sha256-t3BrH7lWfY3to3Fu3EKAMZx29v9Hnl5seyXJzLmZ9/4=",
-          "range": "bytes=1080-251884"
+          "checksum": "sha256-tf4xbo+NP+ssiaZtC1kOKehffAZ3+d17bhgfU3/30+g=",
+          "range": "bytes=1061-256582"
         },
         "name": "libnghttp2-14",
         "signature": {
-          "checksum": "sha1-CotSXRaPLKQCBRHrgzrDOD+4w20=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-KrsJYTyUsll+EUhHekbkdZFzeig=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.62.1-r0.apk",
-        "version": "1.62.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.62.1-r1.apk",
+        "version": "1.62.1-r1"
       },
       {
         "architecture": "x86_64",
@@ -394,136 +394,136 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1DE49kWSnmqVKJdjHFYC1bLkvyb0=",
+        "checksum": "Q1R8OxpY0fGwVaIwft4wJeswF5D54=",
         "control": {
-          "checksum": "sha1-DE49kWSnmqVKJdjHFYC1bLkvyb0=",
-          "range": "bytes=697-1078"
+          "checksum": "sha1-R8OxpY0fGwVaIwft4wJeswF5D54=",
+          "range": "bytes=695-1059"
         },
         "data": {
-          "checksum": "sha256-uDg8Qc6Rnro/68Vb5ufFSkqFLGrEsbvPb0pMJNvT1zw=",
-          "range": "bytes=1079-242085"
+          "checksum": "sha256-wNc8/SBJrGHfwywAtzCsAqeUOt0IaAhqNtlbv8OiHBE=",
+          "range": "bytes=1060-242151"
         },
         "name": "c-ares",
         "signature": {
-          "checksum": "sha1-iYEm6EWQKzxkeoDm+QsRfhw8pDg=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-55/PTlEHXI3o0hx9dSVdNwQeSMg=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.29.0-r0.apk",
-        "version": "1.29.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.31.0-r0.apk",
+        "version": "1.31.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q12eWmn2tCkXxwncU6gagKM3Wd9Sk=",
+        "checksum": "Q1g2RQKAvNjlRPxWjinIRveaq7IlY=",
         "control": {
-          "checksum": "sha1-2eWmn2tCkXxwncU6gagKM3Wd9Sk=",
-          "range": "bytes=696-1169"
+          "checksum": "sha1-g2RQKAvNjlRPxWjinIRveaq7IlY=",
+          "range": "bytes=695-1154"
         },
         "data": {
-          "checksum": "sha256-IFKNdojOhml3DbWPryQuHUiV3tgTWHyqOYD1JNe9IJ4=",
-          "range": "bytes=1170-2582015"
+          "checksum": "sha256-UsQFfOTXCZBan0mxDvR+ts0NKcbv1lNijxnRxjsmZhA=",
+          "range": "bytes=1155-2566233"
         },
         "name": "nghttp2",
         "signature": {
-          "checksum": "sha1-2/9n7KbRuOkrvhYqCFR5Mblx+z8=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-SUvMhz1cc5Or5Qh4fUEvPCp0NAw=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.62.1-r0.apk",
-        "version": "1.62.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.62.1-r1.apk",
+        "version": "1.62.1-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ialksjwPWvvZW+O2ABMbbBV/KTg=",
+        "checksum": "Q1sTMGOgdbZyDKxlRAByisPMHTbpY=",
         "control": {
-          "checksum": "sha1-ialksjwPWvvZW+O2ABMbbBV/KTg=",
-          "range": "bytes=702-1074"
+          "checksum": "sha1-sTMGOgdbZyDKxlRAByisPMHTbpY=",
+          "range": "bytes=703-1060"
         },
         "data": {
-          "checksum": "sha256-+ctDr3AO9mTXovGRPWk6h2ZgfY99Toy6esjBNHtJPY4=",
-          "range": "bytes=1075-631903"
+          "checksum": "sha256-bUy0h/zxpq7iP6vrQRMftZ9nevkHTB87hSX17wz4lmM=",
+          "range": "bytes=1061-631449"
         },
         "name": "nghttp2-dev",
         "signature": {
-          "checksum": "sha1-wZGQRluFd6DL1USzeak75o5/BTc=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-fQ6aDq3Io/gdJ5s5t3M+FwED1Y0=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.62.1-r0.apk",
-        "version": "1.62.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.62.1-r1.apk",
+        "version": "1.62.1-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1MlpRL1nBMU3RgNdSZVB42/vlGME=",
+        "checksum": "Q1rD3dEbbN8s5QAIQK1I8uF1O+oSo=",
         "control": {
-          "checksum": "sha1-MlpRL1nBMU3RgNdSZVB42/vlGME=",
-          "range": "bytes=697-1164"
+          "checksum": "sha1-rD3dEbbN8s5QAIQK1I8uF1O+oSo=",
+          "range": "bytes=701-1154"
         },
         "data": {
-          "checksum": "sha256-RiEPDasBVtnThSxGqTCDvb4J7WXM9YRpJwfYZJ3JLbs=",
-          "range": "bytes=1165-2274746"
+          "checksum": "sha256-41W2IRSRALQijYojLaqAiSSN1uO7twatGn8jqEuCZUg=",
+          "range": "bytes=1155-1439872"
         },
         "name": "xz",
         "signature": {
-          "checksum": "sha1-3wMPFIUEVfkAs7QSENemZsnTLyE=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-lozWkVrKvSrd1SoM7Zv08YYG2pA=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/xz-5.4.6-r2.apk",
-        "version": "5.4.6-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/xz-5.6.2-r0.apk",
+        "version": "5.6.2-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1TS707T+cPGL7TYVHQBCJoWwHZ0E=",
+        "checksum": "Q10AaU1ocIM4PYYNvwbml8TmpNvEA=",
         "control": {
-          "checksum": "sha1-TS707T+cPGL7TYVHQBCJoWwHZ0E=",
-          "range": "bytes=706-1098"
+          "checksum": "sha1-0AaU1ocIM4PYYNvwbml8TmpNvEA=",
+          "range": "bytes=706-1085"
         },
         "data": {
-          "checksum": "sha256-x18L706Vug5qDzq13SXuN/vGdVgzrqB06dW2DdgHGR4=",
-          "range": "bytes=1099-4541967"
+          "checksum": "sha256-1YQNYASFjlP3kXX58ec8du75ij/U6O4DPAKzJAPkln0=",
+          "range": "bytes=1086-4272589"
         },
         "name": "libxml2",
         "signature": {
-          "checksum": "sha1-BYhOxDos48sN8df8LMsSpROv2aw=",
+          "checksum": "sha1-QFjdplzGn/MiNFxMykgafr6/w6U=",
           "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.12.7-r0.apk",
-        "version": "2.12.7-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.1-r1.apk",
+        "version": "2.13.1-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1wJPtj5XZtnPiVWGM5dsT+nyfWXc=",
+        "checksum": "Q1wbnfumlWEiJnVUsJBRcQjFD3U6I=",
         "control": {
-          "checksum": "sha1-wJPtj5XZtnPiVWGM5dsT+nyfWXc=",
-          "range": "bytes=705-1234"
+          "checksum": "sha1-wbnfumlWEiJnVUsJBRcQjFD3U6I=",
+          "range": "bytes=699-1222"
         },
         "data": {
-          "checksum": "sha256-sw+CjlpsjO01q6lqzXgHnniiJKn7bqOSNO6vNqdGc7I=",
-          "range": "bytes=1235-3873775"
+          "checksum": "sha256-IXMNbJjj3kTjkWVBIHVRfG3zJQY2r5Eslgh/3TpMSsE=",
+          "range": "bytes=1223-3886778"
         },
         "name": "bind-libs",
         "signature": {
-          "checksum": "sha1-9zDzmHAeu7mWpidXAatqrLZVzUs=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-JNN15IPpJ2hMsO6hFVpDYPvvX5g=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bind-libs-9.18.26-r0.apk",
-        "version": "9.18.26-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/bind-libs-9.18.27-r1.apk",
+        "version": "9.18.27-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1AxEQdi8fVcYtGc3zHTCW3OZdY2Q=",
+        "checksum": "Q1kXUOoNa2KXixxAASo1W/im1qZ7s=",
         "control": {
-          "checksum": "sha1-AxEQdi8fVcYtGc3zHTCW3OZdY2Q=",
-          "range": "bytes=694-1208"
+          "checksum": "sha1-kXUOoNa2KXixxAASo1W/im1qZ7s=",
+          "range": "bytes=702-1215"
         },
         "data": {
-          "checksum": "sha256-/dt3qJw5D9iSJ/mKkRQkhWD8R52selhpcwXyw7KLMhg=",
-          "range": "bytes=1209-879444"
+          "checksum": "sha256-HRADvfRXfYsgEjUMGM4Hd7prpIv+YWILVfovbGOkEME=",
+          "range": "bytes=1216-879975"
         },
         "name": "bind-tools",
         "signature": {
-          "checksum": "sha1-VTb0YdUzPMk8Po0p4nj0y5Jey6k=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-8WUTMUaJTaX0T9FS/c+GddL7ttY=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bind-tools-9.18.26-r0.apk",
-        "version": "9.18.26-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/bind-tools-9.18.27-r1.apk",
+        "version": "9.18.27-r1"
       },
       {
         "architecture": "x86_64",
@@ -622,60 +622,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1fr0OtiVaD3c5nw8fy5m74hDe9PU=",
+        "checksum": "Q1BRGmQ9LZTeZqbxQ1ls69T6efViw=",
         "control": {
-          "checksum": "sha1-fr0OtiVaD3c5nw8fy5m74hDe9PU=",
-          "range": "bytes=697-1092"
+          "checksum": "sha1-BRGmQ9LZTeZqbxQ1ls69T6efViw=",
+          "range": "bytes=698-1080"
         },
         "data": {
-          "checksum": "sha256-lukjMYpGmuhBNDUbbTJMIrUWaR4rNikEnW4BgiTaLj8=",
-          "range": "bytes=1093-113872"
+          "checksum": "sha256-vtJ4WJ5M+31ZKSBYBedbrl/FrbAw8hGpPRrHC7kasOk=",
+          "range": "bytes=1081-113895"
         },
         "name": "libpsl",
         "signature": {
-          "checksum": "sha1-Lrrudgn1i1a0JhjdzeXG+exnjQA=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-DuAoiykwhu8vu1qxdEDK5oyAmf8=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libpsl-0.21.5-r2.apk",
-        "version": "0.21.5-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libpsl-0.21.5-r3.apk",
+        "version": "0.21.5-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1oauHQa0YcFcEHSQWdfohfNEN4sY=",
+        "checksum": "Q11DZVpe2UYyDr/dG6BDysZhE3L48=",
         "control": {
-          "checksum": "sha1-oauHQa0YcFcEHSQWdfohfNEN4sY=",
-          "range": "bytes=698-1057"
+          "checksum": "sha1-1DZVpe2UYyDr/dG6BDysZhE3L48=",
+          "range": "bytes=707-1049"
         },
         "data": {
-          "checksum": "sha256-d95c9lpjQrpuZ1CcQ8ZZ89LAGGKcessd+hxrOQpP4LU=",
-          "range": "bytes=1058-173549"
+          "checksum": "sha256-aECfsy7giZsLNxZM0HMeF4OS2gu+ycX4DUTJXsiZRQs=",
+          "range": "bytes=1050-173585"
         },
         "name": "libbrotlicommon1",
         "signature": {
-          "checksum": "sha1-g3ufBq/tyiNP6AaOoqwItVvh7uk=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-7LXD38QwFhklZCEqyW4qIncfZV0=",
+          "range": "bytes=0-706"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlicommon1-1.1.0-r2.apk",
-        "version": "1.1.0-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlicommon1-1.1.0-r3.apk",
+        "version": "1.1.0-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q18Otq7NLoYnNMebI/1Rr/s0zdLVw=",
+        "checksum": "Q1Cgr886A8Ryzynz9pxRKsNybVuK0=",
         "control": {
-          "checksum": "sha1-8Otq7NLoYnNMebI/1Rr/s0zdLVw=",
-          "range": "bytes=705-1072"
+          "checksum": "sha1-Cgr886A8Ryzynz9pxRKsNybVuK0=",
+          "range": "bytes=694-1043"
         },
         "data": {
-          "checksum": "sha256-sR3QidR/e46PJ/3S2fxAjN/hRSSA3Ar32Nw7VshTHWg=",
-          "range": "bytes=1073-81475"
+          "checksum": "sha256-mH+MTbqpLiqgydlgE+tSDEt0Sh1/zqMvAqspV4lr+Ks=",
+          "range": "bytes=1044-81511"
         },
         "name": "libbrotlidec1",
         "signature": {
-          "checksum": "sha1-6GpZI5cBUXOvjCYG81aZZR53lMI=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-Yp4Bde9oHQCec8HM2qn6hVKgtko=",
+          "range": "bytes=0-693"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlidec1-1.1.0-r2.apk",
-        "version": "1.1.0-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlidec1-1.1.0-r3.apk",
+        "version": "1.1.0-r3"
       },
       {
         "architecture": "x86_64",
@@ -736,22 +736,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q19f/3419Xa/xv9jgQ0mMYs011fBk=",
+        "checksum": "Q1mTmy64gKYi4THBqewuvYL2uUyHc=",
         "control": {
-          "checksum": "sha1-9f/3419Xa/xv9jgQ0mMYs011fBk=",
-          "range": "bytes=696-1041"
+          "checksum": "sha1-mTmy64gKYi4THBqewuvYL2uUyHc=",
+          "range": "bytes=700-1031"
         },
         "data": {
-          "checksum": "sha256-iqHASiMgiu6rIjbWGwBmmq1Zthae8BkE4QZkiVPH7Ek=",
-          "range": "bytes=1042-1888945"
+          "checksum": "sha256-p0qua2luH33oAgOcLkU9f7k+I8WnykFszVMwNahujDA=",
+          "range": "bytes=1032-1889523"
         },
         "name": "tzdata",
         "signature": {
-          "checksum": "sha1-PCC3jiXlTwrimRMXH/4RyNvccOM=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-sBf5jVLVpWj4DiXaAd/mjo0pTfk=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/tzdata-2024a-r2.apk",
-        "version": "2024a-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/tzdata-2024a-r3.apk",
+        "version": "2024a-r3"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/opentelemetry-collector.lock.json
+++ b/wolfi-images/opentelemetry-collector.lock.json
@@ -14,41 +14,41 @@
     "packages": [
       {
         "architecture": "x86_64",
-        "checksum": "Q1ge3SLQsJ9v2RnvIHHAP1yFyjrEU=",
+        "checksum": "Q1Ai8jWuxKZR2M2XhOpOGAoTEwnnk=",
         "control": {
-          "checksum": "sha1-ge3SLQsJ9v2RnvIHHAP1yFyjrEU=",
-          "range": "bytes=693-1040"
+          "checksum": "sha1-Ai8jWuxKZR2M2XhOpOGAoTEwnnk=",
+          "range": "bytes=705-1037"
         },
         "data": {
-          "checksum": "sha256-I0AdTdfGf4P/jwzTrLXm73l5/RNSlymEof/YZfev3xY=",
-          "range": "bytes=1041-255811"
+          "checksum": "sha256-e4UardkBVyaC49aSyrVmXNi8sSKqQl4eKYd0LxGRLA0=",
+          "range": "bytes=1038-255695"
         },
         "name": "ca-certificates-bundle",
         "signature": {
-          "checksum": "sha1-ge1eJBiQmFWAn9GapFkQpO+Rn/Y=",
-          "range": "bytes=0-692"
+          "checksum": "sha1-loRuyYQLm+atp+YteiQoj++EWIM=",
+          "range": "bytes=0-704"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20240315-r3.apk",
-        "version": "20240315-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20240315-r4.apk",
+        "version": "20240315-r4"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1bgay5kOzpmDBgqJCg7dSlawyJg0=",
+        "checksum": "Q1+GH6qRN4iy1IDt0cT0x0tin7YfI=",
         "control": {
-          "checksum": "sha1-bgay5kOzpmDBgqJCg7dSlawyJg0=",
-          "range": "bytes=703-1067"
+          "checksum": "sha1-+GH6qRN4iy1IDt0cT0x0tin7YfI=",
+          "range": "bytes=703-1051"
         },
         "data": {
-          "checksum": "sha256-f83HfRE7r2ZniH7PyPmRqcoU5NTpF+Uk4FH80QbjvBM=",
-          "range": "bytes=1068-118370"
+          "checksum": "sha256-rO0P9z2V49BSrz1A5Ap69tEappVrg5MMBjzW00rOpZc=",
+          "range": "bytes=1052-122464"
         },
         "name": "wolfi-baselayout",
         "signature": {
-          "checksum": "sha1-2hlCvYH1D7u25HkJGA75jjs/sQY=",
+          "checksum": "sha1-Ntb6VuMzDfM+frpCjKEIpDzl53I=",
           "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r11.apk",
-        "version": "20230201-r11"
+        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r12.apk",
+        "version": "20230201-r12"
       },
       {
         "architecture": "x86_64",
@@ -109,41 +109,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Zjfs1uR/mYiortANP+EFcejW+vo=",
+        "checksum": "Q1Zi0e8Bq6WCd/6uXXjVhb8YwMD1U=",
         "control": {
-          "checksum": "sha1-Zjfs1uR/mYiortANP+EFcejW+vo=",
-          "range": "bytes=698-1085"
+          "checksum": "sha1-Zi0e8Bq6WCd/6uXXjVhb8YwMD1U=",
+          "range": "bytes=700-1073"
         },
         "data": {
-          "checksum": "sha256-BMd7TzffjbrFwdbopDPVYsX0X9XnusIMNbIf33/8kwc=",
-          "range": "bytes=1086-76881"
+          "checksum": "sha256-jMhtfqVjnhuuBO7wtNZ6RS/72sZWoKt/Moage2amlks=",
+          "range": "bytes=1074-81594"
         },
         "name": "protobuf-c",
         "signature": {
-          "checksum": "sha1-efGiXyYWsJ5P2uTkB6aXEZ3kl3o=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-kATwMKztK7nk7qbYCJPkCFp6IXc=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r4.apk",
-        "version": "1.5.0-r4"
-      },
-      {
-        "architecture": "x86_64",
-        "checksum": "Q1Xf5v5uXumBgIR4d4ZxMRxdpyWlM=",
-        "control": {
-          "checksum": "sha1-Xf5v5uXumBgIR4d4ZxMRxdpyWlM=",
-          "range": "bytes=698-1078"
-        },
-        "data": {
-          "checksum": "sha256-eD7HqFCWNUBQiLq9PcWE/zPeZwkiv8hBrytI4qmfQ/8=",
-          "range": "bytes=1079-57055"
-        },
-        "name": "keyutils-libs",
-        "signature": {
-          "checksum": "sha1-V0HVgZLP7P5kNACfus3abCLCS20=",
-          "range": "bytes=0-697"
-        },
-        "url": "https://packages.wolfi.dev/os/x86_64/keyutils-libs-1.6.3-r2.apk",
-        "version": "1.6.3-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r5.apk",
+        "version": "1.5.0-r5"
       },
       {
         "architecture": "x86_64",
@@ -166,22 +147,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1wRzOx+L6MeRFtTcq2y/6ot7Cj54=",
+        "checksum": "Q1v0A2vQM5k8rQY/GpIq6xI4T0YmA=",
         "control": {
-          "checksum": "sha1-wRzOx+L6MeRFtTcq2y/6ot7Cj54=",
-          "range": "bytes=699-1069"
+          "checksum": "sha1-v0A2vQM5k8rQY/GpIq6xI4T0YmA=",
+          "range": "bytes=701-1064"
         },
         "data": {
-          "checksum": "sha256-gNRjwZ4XQatCYWediSVb+j8lS54CggvMC5Dn3qT84So=",
-          "range": "bytes=1070-61490"
+          "checksum": "sha256-uAOrkGDDc/yqt6VjIrlTEALBJG4BCI4njqZw5jQqF0o=",
+          "range": "bytes=1065-56984"
+        },
+        "name": "keyutils-libs",
+        "signature": {
+          "checksum": "sha1-32uYMH/zGBr9Jo3hiqnThlcqBcE=",
+          "range": "bytes=0-700"
+        },
+        "url": "https://packages.wolfi.dev/os/x86_64/keyutils-libs-1.6.3-r3.apk",
+        "version": "1.6.3-r3"
+      },
+      {
+        "architecture": "x86_64",
+        "checksum": "Q1Onuac6Y+IWA7a4b8FvqX1erWDDw=",
+        "control": {
+          "checksum": "sha1-Onuac6Y+IWA7a4b8FvqX1erWDDw=",
+          "range": "bytes=693-1048"
+        },
+        "data": {
+          "checksum": "sha256-KLtDAs3iU0oyZ/FysePG/J+1H1ofDxHXIY7xvtZhtMc=",
+          "range": "bytes=1049-61503"
         },
         "name": "libverto",
         "signature": {
-          "checksum": "sha1-kuPwakYdy5EM6sd5Ba0K0Ta8x4w=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-/IXL9S1O+MwaW7KsSzz1ywEqKFQ=",
+          "range": "bytes=0-692"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libverto-0.3.2-r3.apk",
-        "version": "0.3.2-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/libverto-0.3.2-r4.apk",
+        "version": "0.3.2-r4"
       },
       {
         "architecture": "x86_64",
@@ -204,60 +204,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1gTZGkWP+QO3mUqLVJth8vrDEzzU=",
+        "checksum": "Q1Q/Zy5ovYSu2p/vVLr6DgVA1e8AQ=",
         "control": {
-          "checksum": "sha1-gTZGkWP+QO3mUqLVJth8vrDEzzU=",
-          "range": "bytes=699-1076"
+          "checksum": "sha1-Q/Zy5ovYSu2p/vVLr6DgVA1e8AQ=",
+          "range": "bytes=699-1062"
         },
         "data": {
-          "checksum": "sha256-/IFXqeKvU0GODNsz1yPIEMcFHgABT+8rbZpSlTLo4e4=",
-          "range": "bytes=1077-5915704"
+          "checksum": "sha256-H3jxsw8ytOeCIR4vq17voSVhdNokXk8C1g075txH6Bs=",
+          "range": "bytes=1063-5903754"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-l1o5ixkyWWqqJE3FOfR0QUemJUA=",
+          "checksum": "sha1-NIl2f5OI/wSZByI8Ds1ZUfbFWyw=",
           "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r9.apk",
-        "version": "3.3.0-r9"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.1-r3.apk",
+        "version": "3.3.1-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1jhAhggAuZnU7FFHnebGA26mq+jI=",
+        "checksum": "Q13wGUXdZut9OOTdY5z2amUj9wXC0=",
         "control": {
-          "checksum": "sha1-jhAhggAuZnU7FFHnebGA26mq+jI=",
-          "range": "bytes=695-1079"
+          "checksum": "sha1-3wGUXdZut9OOTdY5z2amUj9wXC0=",
+          "range": "bytes=698-1068"
         },
         "data": {
-          "checksum": "sha256-XTCQYnhGSm7SkGwqV/TQMFqGajVJVYhKAidKfLb2D3Y=",
-          "range": "bytes=1080-1197081"
+          "checksum": "sha256-mRda6+YGlOCczyIWKaHqXskTINoT1rgorHDHqAKAb7c=",
+          "range": "bytes=1069-1188955"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-qVrfDVxubkrb5Yrd2mFTv2A0G7k=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-+UdRc4U3PKw4H9OiNurHKXa5BYk=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r9.apk",
-        "version": "3.3.0-r9"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.1-r3.apk",
+        "version": "3.3.1-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1BQEXaeya6QB39QLeKcB99qBNF2o=",
+        "checksum": "Q1p04MrHQPrXOzuV/uF290zjnltqI=",
         "control": {
-          "checksum": "sha1-BQEXaeya6QB39QLeKcB99qBNF2o=",
-          "range": "bytes=699-1229"
+          "checksum": "sha1-p04MrHQPrXOzuV/uF290zjnltqI=",
+          "range": "bytes=704-1219"
         },
         "data": {
-          "checksum": "sha256-ugj/qGEBzhvdX17S22Anry+biy3lcqywhGMSHLIBCvo=",
-          "range": "bytes=1230-2551676"
+          "checksum": "sha256-TsXeqhUGykAhjQUEAlMUSzDQBcWDkkDvReoeHCL1F6c=",
+          "range": "bytes=1220-2555814"
         },
         "name": "krb5-libs",
         "signature": {
-          "checksum": "sha1-oqDPmNM4EngXAGayd/BZOqJAIao=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-cPyzS38QHuNlOCQb8IPlsl2PLHQ=",
+          "range": "bytes=0-703"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/krb5-libs-1.21.2-r2.apk",
-        "version": "1.21.2-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/krb5-libs-1.21.3-r0.apk",
+        "version": "1.21.3-r0"
       },
       {
         "architecture": "x86_64",
@@ -280,60 +280,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1wzZwtLauOQfLQC7YUvZdfKxtlwQ=",
+        "checksum": "Q17uprcuQ2VFudMcWAwtP7miJmLYs=",
         "control": {
-          "checksum": "sha1-wzZwtLauOQfLQC7YUvZdfKxtlwQ=",
-          "range": "bytes=698-1085"
+          "checksum": "sha1-7uprcuQ2VFudMcWAwtP7miJmLYs=",
+          "range": "bytes=695-1067"
         },
         "data": {
-          "checksum": "sha256-TO8CAULO44s/LphhtcaFOGJB7aFldk13v1cV9ceZHww=",
-          "range": "bytes=1086-276837"
+          "checksum": "sha256-unKdPbvO2VHZ5w1t1l8mOpQuNdUGwLhofEO4weN2Mig=",
+          "range": "bytes=1068-280973"
         },
         "name": "libuv",
         "signature": {
-          "checksum": "sha1-LRiyeKmjexy8CJizLxjd6ikon1w=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-4lKldnTO71WHMZ4tbANz6i2/Ed0=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libuv-1.48.0-r2.apk",
-        "version": "1.48.0-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libuv-1.48.0-r3.apk",
+        "version": "1.48.0-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q14S6biy8fc5OGbGEJoLBM+tJOGyo=",
+        "checksum": "Q1CN6zJbOPznWUfTrb/41KT7E6dm8=",
         "control": {
-          "checksum": "sha1-4S6biy8fc5OGbGEJoLBM+tJOGyo=",
-          "range": "bytes=703-1102"
+          "checksum": "sha1-CN6zJbOPznWUfTrb/41KT7E6dm8=",
+          "range": "bytes=699-1083"
         },
         "data": {
-          "checksum": "sha256-hwjdLQYfuMAGQeONmFVo0lZKKQK1S+3PBhrI3upm5W4=",
-          "range": "bytes=1103-155304"
+          "checksum": "sha256-ybzFzoQh1yNTcd3cjt54nYsPlAxAcMUcVMxEv1JRnpQ=",
+          "range": "bytes=1084-155375"
         },
         "name": "zlib",
         "signature": {
-          "checksum": "sha1-ZuLd7kE+AGhn27o8ZqDGM5eundc=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-CPXJcCjinAXP+H8Z5tkko8ayG6E=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/zlib-1.3.1-r2.apk",
-        "version": "1.3.1-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/zlib-1.3.1-r3.apk",
+        "version": "1.3.1-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ykDkP+AmDi2VcZZ1c4q4sez/DxI=",
+        "checksum": "Q1rgbci8SRSjW7EB0NSh6ZUPJLndM=",
         "control": {
-          "checksum": "sha1-ykDkP+AmDi2VcZZ1c4q4sez/DxI=",
-          "range": "bytes=705-1079"
+          "checksum": "sha1-rgbci8SRSjW7EB0NSh6ZUPJLndM=",
+          "range": "bytes=702-1060"
         },
         "data": {
-          "checksum": "sha256-t3BrH7lWfY3to3Fu3EKAMZx29v9Hnl5seyXJzLmZ9/4=",
-          "range": "bytes=1080-251884"
+          "checksum": "sha256-tf4xbo+NP+ssiaZtC1kOKehffAZ3+d17bhgfU3/30+g=",
+          "range": "bytes=1061-256582"
         },
         "name": "libnghttp2-14",
         "signature": {
-          "checksum": "sha1-CotSXRaPLKQCBRHrgzrDOD+4w20=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-KrsJYTyUsll+EUhHekbkdZFzeig=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.62.1-r0.apk",
-        "version": "1.62.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.62.1-r1.apk",
+        "version": "1.62.1-r1"
       },
       {
         "architecture": "x86_64",
@@ -394,136 +394,136 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1DE49kWSnmqVKJdjHFYC1bLkvyb0=",
+        "checksum": "Q1R8OxpY0fGwVaIwft4wJeswF5D54=",
         "control": {
-          "checksum": "sha1-DE49kWSnmqVKJdjHFYC1bLkvyb0=",
-          "range": "bytes=697-1078"
+          "checksum": "sha1-R8OxpY0fGwVaIwft4wJeswF5D54=",
+          "range": "bytes=695-1059"
         },
         "data": {
-          "checksum": "sha256-uDg8Qc6Rnro/68Vb5ufFSkqFLGrEsbvPb0pMJNvT1zw=",
-          "range": "bytes=1079-242085"
+          "checksum": "sha256-wNc8/SBJrGHfwywAtzCsAqeUOt0IaAhqNtlbv8OiHBE=",
+          "range": "bytes=1060-242151"
         },
         "name": "c-ares",
         "signature": {
-          "checksum": "sha1-iYEm6EWQKzxkeoDm+QsRfhw8pDg=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-55/PTlEHXI3o0hx9dSVdNwQeSMg=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.29.0-r0.apk",
-        "version": "1.29.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.31.0-r0.apk",
+        "version": "1.31.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q12eWmn2tCkXxwncU6gagKM3Wd9Sk=",
+        "checksum": "Q1g2RQKAvNjlRPxWjinIRveaq7IlY=",
         "control": {
-          "checksum": "sha1-2eWmn2tCkXxwncU6gagKM3Wd9Sk=",
-          "range": "bytes=696-1169"
+          "checksum": "sha1-g2RQKAvNjlRPxWjinIRveaq7IlY=",
+          "range": "bytes=695-1154"
         },
         "data": {
-          "checksum": "sha256-IFKNdojOhml3DbWPryQuHUiV3tgTWHyqOYD1JNe9IJ4=",
-          "range": "bytes=1170-2582015"
+          "checksum": "sha256-UsQFfOTXCZBan0mxDvR+ts0NKcbv1lNijxnRxjsmZhA=",
+          "range": "bytes=1155-2566233"
         },
         "name": "nghttp2",
         "signature": {
-          "checksum": "sha1-2/9n7KbRuOkrvhYqCFR5Mblx+z8=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-SUvMhz1cc5Or5Qh4fUEvPCp0NAw=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.62.1-r0.apk",
-        "version": "1.62.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.62.1-r1.apk",
+        "version": "1.62.1-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ialksjwPWvvZW+O2ABMbbBV/KTg=",
+        "checksum": "Q1sTMGOgdbZyDKxlRAByisPMHTbpY=",
         "control": {
-          "checksum": "sha1-ialksjwPWvvZW+O2ABMbbBV/KTg=",
-          "range": "bytes=702-1074"
+          "checksum": "sha1-sTMGOgdbZyDKxlRAByisPMHTbpY=",
+          "range": "bytes=703-1060"
         },
         "data": {
-          "checksum": "sha256-+ctDr3AO9mTXovGRPWk6h2ZgfY99Toy6esjBNHtJPY4=",
-          "range": "bytes=1075-631903"
+          "checksum": "sha256-bUy0h/zxpq7iP6vrQRMftZ9nevkHTB87hSX17wz4lmM=",
+          "range": "bytes=1061-631449"
         },
         "name": "nghttp2-dev",
         "signature": {
-          "checksum": "sha1-wZGQRluFd6DL1USzeak75o5/BTc=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-fQ6aDq3Io/gdJ5s5t3M+FwED1Y0=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.62.1-r0.apk",
-        "version": "1.62.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.62.1-r1.apk",
+        "version": "1.62.1-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1MlpRL1nBMU3RgNdSZVB42/vlGME=",
+        "checksum": "Q1rD3dEbbN8s5QAIQK1I8uF1O+oSo=",
         "control": {
-          "checksum": "sha1-MlpRL1nBMU3RgNdSZVB42/vlGME=",
-          "range": "bytes=697-1164"
+          "checksum": "sha1-rD3dEbbN8s5QAIQK1I8uF1O+oSo=",
+          "range": "bytes=701-1154"
         },
         "data": {
-          "checksum": "sha256-RiEPDasBVtnThSxGqTCDvb4J7WXM9YRpJwfYZJ3JLbs=",
-          "range": "bytes=1165-2274746"
+          "checksum": "sha256-41W2IRSRALQijYojLaqAiSSN1uO7twatGn8jqEuCZUg=",
+          "range": "bytes=1155-1439872"
         },
         "name": "xz",
         "signature": {
-          "checksum": "sha1-3wMPFIUEVfkAs7QSENemZsnTLyE=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-lozWkVrKvSrd1SoM7Zv08YYG2pA=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/xz-5.4.6-r2.apk",
-        "version": "5.4.6-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/xz-5.6.2-r0.apk",
+        "version": "5.6.2-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1TS707T+cPGL7TYVHQBCJoWwHZ0E=",
+        "checksum": "Q10AaU1ocIM4PYYNvwbml8TmpNvEA=",
         "control": {
-          "checksum": "sha1-TS707T+cPGL7TYVHQBCJoWwHZ0E=",
-          "range": "bytes=706-1098"
+          "checksum": "sha1-0AaU1ocIM4PYYNvwbml8TmpNvEA=",
+          "range": "bytes=706-1085"
         },
         "data": {
-          "checksum": "sha256-x18L706Vug5qDzq13SXuN/vGdVgzrqB06dW2DdgHGR4=",
-          "range": "bytes=1099-4541967"
+          "checksum": "sha256-1YQNYASFjlP3kXX58ec8du75ij/U6O4DPAKzJAPkln0=",
+          "range": "bytes=1086-4272589"
         },
         "name": "libxml2",
         "signature": {
-          "checksum": "sha1-BYhOxDos48sN8df8LMsSpROv2aw=",
+          "checksum": "sha1-QFjdplzGn/MiNFxMykgafr6/w6U=",
           "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.12.7-r0.apk",
-        "version": "2.12.7-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.1-r1.apk",
+        "version": "2.13.1-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1wJPtj5XZtnPiVWGM5dsT+nyfWXc=",
+        "checksum": "Q1wbnfumlWEiJnVUsJBRcQjFD3U6I=",
         "control": {
-          "checksum": "sha1-wJPtj5XZtnPiVWGM5dsT+nyfWXc=",
-          "range": "bytes=705-1234"
+          "checksum": "sha1-wbnfumlWEiJnVUsJBRcQjFD3U6I=",
+          "range": "bytes=699-1222"
         },
         "data": {
-          "checksum": "sha256-sw+CjlpsjO01q6lqzXgHnniiJKn7bqOSNO6vNqdGc7I=",
-          "range": "bytes=1235-3873775"
+          "checksum": "sha256-IXMNbJjj3kTjkWVBIHVRfG3zJQY2r5Eslgh/3TpMSsE=",
+          "range": "bytes=1223-3886778"
         },
         "name": "bind-libs",
         "signature": {
-          "checksum": "sha1-9zDzmHAeu7mWpidXAatqrLZVzUs=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-JNN15IPpJ2hMsO6hFVpDYPvvX5g=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bind-libs-9.18.26-r0.apk",
-        "version": "9.18.26-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/bind-libs-9.18.27-r1.apk",
+        "version": "9.18.27-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1AxEQdi8fVcYtGc3zHTCW3OZdY2Q=",
+        "checksum": "Q1kXUOoNa2KXixxAASo1W/im1qZ7s=",
         "control": {
-          "checksum": "sha1-AxEQdi8fVcYtGc3zHTCW3OZdY2Q=",
-          "range": "bytes=694-1208"
+          "checksum": "sha1-kXUOoNa2KXixxAASo1W/im1qZ7s=",
+          "range": "bytes=702-1215"
         },
         "data": {
-          "checksum": "sha256-/dt3qJw5D9iSJ/mKkRQkhWD8R52selhpcwXyw7KLMhg=",
-          "range": "bytes=1209-879444"
+          "checksum": "sha256-HRADvfRXfYsgEjUMGM4Hd7prpIv+YWILVfovbGOkEME=",
+          "range": "bytes=1216-879975"
         },
         "name": "bind-tools",
         "signature": {
-          "checksum": "sha1-VTb0YdUzPMk8Po0p4nj0y5Jey6k=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-8WUTMUaJTaX0T9FS/c+GddL7ttY=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bind-tools-9.18.26-r0.apk",
-        "version": "9.18.26-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/bind-tools-9.18.27-r1.apk",
+        "version": "9.18.27-r1"
       },
       {
         "architecture": "x86_64",
@@ -622,60 +622,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1fr0OtiVaD3c5nw8fy5m74hDe9PU=",
+        "checksum": "Q1BRGmQ9LZTeZqbxQ1ls69T6efViw=",
         "control": {
-          "checksum": "sha1-fr0OtiVaD3c5nw8fy5m74hDe9PU=",
-          "range": "bytes=697-1092"
+          "checksum": "sha1-BRGmQ9LZTeZqbxQ1ls69T6efViw=",
+          "range": "bytes=698-1080"
         },
         "data": {
-          "checksum": "sha256-lukjMYpGmuhBNDUbbTJMIrUWaR4rNikEnW4BgiTaLj8=",
-          "range": "bytes=1093-113872"
+          "checksum": "sha256-vtJ4WJ5M+31ZKSBYBedbrl/FrbAw8hGpPRrHC7kasOk=",
+          "range": "bytes=1081-113895"
         },
         "name": "libpsl",
         "signature": {
-          "checksum": "sha1-Lrrudgn1i1a0JhjdzeXG+exnjQA=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-DuAoiykwhu8vu1qxdEDK5oyAmf8=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libpsl-0.21.5-r2.apk",
-        "version": "0.21.5-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libpsl-0.21.5-r3.apk",
+        "version": "0.21.5-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1oauHQa0YcFcEHSQWdfohfNEN4sY=",
+        "checksum": "Q11DZVpe2UYyDr/dG6BDysZhE3L48=",
         "control": {
-          "checksum": "sha1-oauHQa0YcFcEHSQWdfohfNEN4sY=",
-          "range": "bytes=698-1057"
+          "checksum": "sha1-1DZVpe2UYyDr/dG6BDysZhE3L48=",
+          "range": "bytes=707-1049"
         },
         "data": {
-          "checksum": "sha256-d95c9lpjQrpuZ1CcQ8ZZ89LAGGKcessd+hxrOQpP4LU=",
-          "range": "bytes=1058-173549"
+          "checksum": "sha256-aECfsy7giZsLNxZM0HMeF4OS2gu+ycX4DUTJXsiZRQs=",
+          "range": "bytes=1050-173585"
         },
         "name": "libbrotlicommon1",
         "signature": {
-          "checksum": "sha1-g3ufBq/tyiNP6AaOoqwItVvh7uk=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-7LXD38QwFhklZCEqyW4qIncfZV0=",
+          "range": "bytes=0-706"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlicommon1-1.1.0-r2.apk",
-        "version": "1.1.0-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlicommon1-1.1.0-r3.apk",
+        "version": "1.1.0-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q18Otq7NLoYnNMebI/1Rr/s0zdLVw=",
+        "checksum": "Q1Cgr886A8Ryzynz9pxRKsNybVuK0=",
         "control": {
-          "checksum": "sha1-8Otq7NLoYnNMebI/1Rr/s0zdLVw=",
-          "range": "bytes=705-1072"
+          "checksum": "sha1-Cgr886A8Ryzynz9pxRKsNybVuK0=",
+          "range": "bytes=694-1043"
         },
         "data": {
-          "checksum": "sha256-sR3QidR/e46PJ/3S2fxAjN/hRSSA3Ar32Nw7VshTHWg=",
-          "range": "bytes=1073-81475"
+          "checksum": "sha256-mH+MTbqpLiqgydlgE+tSDEt0Sh1/zqMvAqspV4lr+Ks=",
+          "range": "bytes=1044-81511"
         },
         "name": "libbrotlidec1",
         "signature": {
-          "checksum": "sha1-6GpZI5cBUXOvjCYG81aZZR53lMI=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-Yp4Bde9oHQCec8HM2qn6hVKgtko=",
+          "range": "bytes=0-693"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlidec1-1.1.0-r2.apk",
-        "version": "1.1.0-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlidec1-1.1.0-r3.apk",
+        "version": "1.1.0-r3"
       },
       {
         "architecture": "x86_64",
@@ -774,22 +774,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q19f/3419Xa/xv9jgQ0mMYs011fBk=",
+        "checksum": "Q1mTmy64gKYi4THBqewuvYL2uUyHc=",
         "control": {
-          "checksum": "sha1-9f/3419Xa/xv9jgQ0mMYs011fBk=",
-          "range": "bytes=696-1041"
+          "checksum": "sha1-mTmy64gKYi4THBqewuvYL2uUyHc=",
+          "range": "bytes=700-1031"
         },
         "data": {
-          "checksum": "sha256-iqHASiMgiu6rIjbWGwBmmq1Zthae8BkE4QZkiVPH7Ek=",
-          "range": "bytes=1042-1888945"
+          "checksum": "sha256-p0qua2luH33oAgOcLkU9f7k+I8WnykFszVMwNahujDA=",
+          "range": "bytes=1032-1889523"
         },
         "name": "tzdata",
         "signature": {
-          "checksum": "sha1-PCC3jiXlTwrimRMXH/4RyNvccOM=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-sBf5jVLVpWj4DiXaAd/mjo0pTfk=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/tzdata-2024a-r2.apk",
-        "version": "2024a-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/tzdata-2024a-r3.apk",
+        "version": "2024a-r3"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/postgres-exporter.lock.json
+++ b/wolfi-images/postgres-exporter.lock.json
@@ -14,41 +14,41 @@
     "packages": [
       {
         "architecture": "x86_64",
-        "checksum": "Q1ge3SLQsJ9v2RnvIHHAP1yFyjrEU=",
+        "checksum": "Q1Ai8jWuxKZR2M2XhOpOGAoTEwnnk=",
         "control": {
-          "checksum": "sha1-ge3SLQsJ9v2RnvIHHAP1yFyjrEU=",
-          "range": "bytes=693-1040"
+          "checksum": "sha1-Ai8jWuxKZR2M2XhOpOGAoTEwnnk=",
+          "range": "bytes=705-1037"
         },
         "data": {
-          "checksum": "sha256-I0AdTdfGf4P/jwzTrLXm73l5/RNSlymEof/YZfev3xY=",
-          "range": "bytes=1041-255811"
+          "checksum": "sha256-e4UardkBVyaC49aSyrVmXNi8sSKqQl4eKYd0LxGRLA0=",
+          "range": "bytes=1038-255695"
         },
         "name": "ca-certificates-bundle",
         "signature": {
-          "checksum": "sha1-ge1eJBiQmFWAn9GapFkQpO+Rn/Y=",
-          "range": "bytes=0-692"
+          "checksum": "sha1-loRuyYQLm+atp+YteiQoj++EWIM=",
+          "range": "bytes=0-704"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20240315-r3.apk",
-        "version": "20240315-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20240315-r4.apk",
+        "version": "20240315-r4"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1bgay5kOzpmDBgqJCg7dSlawyJg0=",
+        "checksum": "Q1+GH6qRN4iy1IDt0cT0x0tin7YfI=",
         "control": {
-          "checksum": "sha1-bgay5kOzpmDBgqJCg7dSlawyJg0=",
-          "range": "bytes=703-1067"
+          "checksum": "sha1-+GH6qRN4iy1IDt0cT0x0tin7YfI=",
+          "range": "bytes=703-1051"
         },
         "data": {
-          "checksum": "sha256-f83HfRE7r2ZniH7PyPmRqcoU5NTpF+Uk4FH80QbjvBM=",
-          "range": "bytes=1068-118370"
+          "checksum": "sha256-rO0P9z2V49BSrz1A5Ap69tEappVrg5MMBjzW00rOpZc=",
+          "range": "bytes=1052-122464"
         },
         "name": "wolfi-baselayout",
         "signature": {
-          "checksum": "sha1-2hlCvYH1D7u25HkJGA75jjs/sQY=",
+          "checksum": "sha1-Ntb6VuMzDfM+frpCjKEIpDzl53I=",
           "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r11.apk",
-        "version": "20230201-r11"
+        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r12.apk",
+        "version": "20230201-r12"
       },
       {
         "architecture": "x86_64",
@@ -109,41 +109,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Zjfs1uR/mYiortANP+EFcejW+vo=",
+        "checksum": "Q1Zi0e8Bq6WCd/6uXXjVhb8YwMD1U=",
         "control": {
-          "checksum": "sha1-Zjfs1uR/mYiortANP+EFcejW+vo=",
-          "range": "bytes=698-1085"
+          "checksum": "sha1-Zi0e8Bq6WCd/6uXXjVhb8YwMD1U=",
+          "range": "bytes=700-1073"
         },
         "data": {
-          "checksum": "sha256-BMd7TzffjbrFwdbopDPVYsX0X9XnusIMNbIf33/8kwc=",
-          "range": "bytes=1086-76881"
+          "checksum": "sha256-jMhtfqVjnhuuBO7wtNZ6RS/72sZWoKt/Moage2amlks=",
+          "range": "bytes=1074-81594"
         },
         "name": "protobuf-c",
         "signature": {
-          "checksum": "sha1-efGiXyYWsJ5P2uTkB6aXEZ3kl3o=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-kATwMKztK7nk7qbYCJPkCFp6IXc=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r4.apk",
-        "version": "1.5.0-r4"
-      },
-      {
-        "architecture": "x86_64",
-        "checksum": "Q1Xf5v5uXumBgIR4d4ZxMRxdpyWlM=",
-        "control": {
-          "checksum": "sha1-Xf5v5uXumBgIR4d4ZxMRxdpyWlM=",
-          "range": "bytes=698-1078"
-        },
-        "data": {
-          "checksum": "sha256-eD7HqFCWNUBQiLq9PcWE/zPeZwkiv8hBrytI4qmfQ/8=",
-          "range": "bytes=1079-57055"
-        },
-        "name": "keyutils-libs",
-        "signature": {
-          "checksum": "sha1-V0HVgZLP7P5kNACfus3abCLCS20=",
-          "range": "bytes=0-697"
-        },
-        "url": "https://packages.wolfi.dev/os/x86_64/keyutils-libs-1.6.3-r2.apk",
-        "version": "1.6.3-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r5.apk",
+        "version": "1.5.0-r5"
       },
       {
         "architecture": "x86_64",
@@ -166,22 +147,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1wRzOx+L6MeRFtTcq2y/6ot7Cj54=",
+        "checksum": "Q1v0A2vQM5k8rQY/GpIq6xI4T0YmA=",
         "control": {
-          "checksum": "sha1-wRzOx+L6MeRFtTcq2y/6ot7Cj54=",
-          "range": "bytes=699-1069"
+          "checksum": "sha1-v0A2vQM5k8rQY/GpIq6xI4T0YmA=",
+          "range": "bytes=701-1064"
         },
         "data": {
-          "checksum": "sha256-gNRjwZ4XQatCYWediSVb+j8lS54CggvMC5Dn3qT84So=",
-          "range": "bytes=1070-61490"
+          "checksum": "sha256-uAOrkGDDc/yqt6VjIrlTEALBJG4BCI4njqZw5jQqF0o=",
+          "range": "bytes=1065-56984"
+        },
+        "name": "keyutils-libs",
+        "signature": {
+          "checksum": "sha1-32uYMH/zGBr9Jo3hiqnThlcqBcE=",
+          "range": "bytes=0-700"
+        },
+        "url": "https://packages.wolfi.dev/os/x86_64/keyutils-libs-1.6.3-r3.apk",
+        "version": "1.6.3-r3"
+      },
+      {
+        "architecture": "x86_64",
+        "checksum": "Q1Onuac6Y+IWA7a4b8FvqX1erWDDw=",
+        "control": {
+          "checksum": "sha1-Onuac6Y+IWA7a4b8FvqX1erWDDw=",
+          "range": "bytes=693-1048"
+        },
+        "data": {
+          "checksum": "sha256-KLtDAs3iU0oyZ/FysePG/J+1H1ofDxHXIY7xvtZhtMc=",
+          "range": "bytes=1049-61503"
         },
         "name": "libverto",
         "signature": {
-          "checksum": "sha1-kuPwakYdy5EM6sd5Ba0K0Ta8x4w=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-/IXL9S1O+MwaW7KsSzz1ywEqKFQ=",
+          "range": "bytes=0-692"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libverto-0.3.2-r3.apk",
-        "version": "0.3.2-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/libverto-0.3.2-r4.apk",
+        "version": "0.3.2-r4"
       },
       {
         "architecture": "x86_64",
@@ -204,60 +204,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1gTZGkWP+QO3mUqLVJth8vrDEzzU=",
+        "checksum": "Q1Q/Zy5ovYSu2p/vVLr6DgVA1e8AQ=",
         "control": {
-          "checksum": "sha1-gTZGkWP+QO3mUqLVJth8vrDEzzU=",
-          "range": "bytes=699-1076"
+          "checksum": "sha1-Q/Zy5ovYSu2p/vVLr6DgVA1e8AQ=",
+          "range": "bytes=699-1062"
         },
         "data": {
-          "checksum": "sha256-/IFXqeKvU0GODNsz1yPIEMcFHgABT+8rbZpSlTLo4e4=",
-          "range": "bytes=1077-5915704"
+          "checksum": "sha256-H3jxsw8ytOeCIR4vq17voSVhdNokXk8C1g075txH6Bs=",
+          "range": "bytes=1063-5903754"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-l1o5ixkyWWqqJE3FOfR0QUemJUA=",
+          "checksum": "sha1-NIl2f5OI/wSZByI8Ds1ZUfbFWyw=",
           "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r9.apk",
-        "version": "3.3.0-r9"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.1-r3.apk",
+        "version": "3.3.1-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1jhAhggAuZnU7FFHnebGA26mq+jI=",
+        "checksum": "Q13wGUXdZut9OOTdY5z2amUj9wXC0=",
         "control": {
-          "checksum": "sha1-jhAhggAuZnU7FFHnebGA26mq+jI=",
-          "range": "bytes=695-1079"
+          "checksum": "sha1-3wGUXdZut9OOTdY5z2amUj9wXC0=",
+          "range": "bytes=698-1068"
         },
         "data": {
-          "checksum": "sha256-XTCQYnhGSm7SkGwqV/TQMFqGajVJVYhKAidKfLb2D3Y=",
-          "range": "bytes=1080-1197081"
+          "checksum": "sha256-mRda6+YGlOCczyIWKaHqXskTINoT1rgorHDHqAKAb7c=",
+          "range": "bytes=1069-1188955"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-qVrfDVxubkrb5Yrd2mFTv2A0G7k=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-+UdRc4U3PKw4H9OiNurHKXa5BYk=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r9.apk",
-        "version": "3.3.0-r9"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.1-r3.apk",
+        "version": "3.3.1-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1BQEXaeya6QB39QLeKcB99qBNF2o=",
+        "checksum": "Q1p04MrHQPrXOzuV/uF290zjnltqI=",
         "control": {
-          "checksum": "sha1-BQEXaeya6QB39QLeKcB99qBNF2o=",
-          "range": "bytes=699-1229"
+          "checksum": "sha1-p04MrHQPrXOzuV/uF290zjnltqI=",
+          "range": "bytes=704-1219"
         },
         "data": {
-          "checksum": "sha256-ugj/qGEBzhvdX17S22Anry+biy3lcqywhGMSHLIBCvo=",
-          "range": "bytes=1230-2551676"
+          "checksum": "sha256-TsXeqhUGykAhjQUEAlMUSzDQBcWDkkDvReoeHCL1F6c=",
+          "range": "bytes=1220-2555814"
         },
         "name": "krb5-libs",
         "signature": {
-          "checksum": "sha1-oqDPmNM4EngXAGayd/BZOqJAIao=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-cPyzS38QHuNlOCQb8IPlsl2PLHQ=",
+          "range": "bytes=0-703"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/krb5-libs-1.21.2-r2.apk",
-        "version": "1.21.2-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/krb5-libs-1.21.3-r0.apk",
+        "version": "1.21.3-r0"
       },
       {
         "architecture": "x86_64",
@@ -280,60 +280,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1wzZwtLauOQfLQC7YUvZdfKxtlwQ=",
+        "checksum": "Q17uprcuQ2VFudMcWAwtP7miJmLYs=",
         "control": {
-          "checksum": "sha1-wzZwtLauOQfLQC7YUvZdfKxtlwQ=",
-          "range": "bytes=698-1085"
+          "checksum": "sha1-7uprcuQ2VFudMcWAwtP7miJmLYs=",
+          "range": "bytes=695-1067"
         },
         "data": {
-          "checksum": "sha256-TO8CAULO44s/LphhtcaFOGJB7aFldk13v1cV9ceZHww=",
-          "range": "bytes=1086-276837"
+          "checksum": "sha256-unKdPbvO2VHZ5w1t1l8mOpQuNdUGwLhofEO4weN2Mig=",
+          "range": "bytes=1068-280973"
         },
         "name": "libuv",
         "signature": {
-          "checksum": "sha1-LRiyeKmjexy8CJizLxjd6ikon1w=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-4lKldnTO71WHMZ4tbANz6i2/Ed0=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libuv-1.48.0-r2.apk",
-        "version": "1.48.0-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libuv-1.48.0-r3.apk",
+        "version": "1.48.0-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q14S6biy8fc5OGbGEJoLBM+tJOGyo=",
+        "checksum": "Q1CN6zJbOPznWUfTrb/41KT7E6dm8=",
         "control": {
-          "checksum": "sha1-4S6biy8fc5OGbGEJoLBM+tJOGyo=",
-          "range": "bytes=703-1102"
+          "checksum": "sha1-CN6zJbOPznWUfTrb/41KT7E6dm8=",
+          "range": "bytes=699-1083"
         },
         "data": {
-          "checksum": "sha256-hwjdLQYfuMAGQeONmFVo0lZKKQK1S+3PBhrI3upm5W4=",
-          "range": "bytes=1103-155304"
+          "checksum": "sha256-ybzFzoQh1yNTcd3cjt54nYsPlAxAcMUcVMxEv1JRnpQ=",
+          "range": "bytes=1084-155375"
         },
         "name": "zlib",
         "signature": {
-          "checksum": "sha1-ZuLd7kE+AGhn27o8ZqDGM5eundc=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-CPXJcCjinAXP+H8Z5tkko8ayG6E=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/zlib-1.3.1-r2.apk",
-        "version": "1.3.1-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/zlib-1.3.1-r3.apk",
+        "version": "1.3.1-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ykDkP+AmDi2VcZZ1c4q4sez/DxI=",
+        "checksum": "Q1rgbci8SRSjW7EB0NSh6ZUPJLndM=",
         "control": {
-          "checksum": "sha1-ykDkP+AmDi2VcZZ1c4q4sez/DxI=",
-          "range": "bytes=705-1079"
+          "checksum": "sha1-rgbci8SRSjW7EB0NSh6ZUPJLndM=",
+          "range": "bytes=702-1060"
         },
         "data": {
-          "checksum": "sha256-t3BrH7lWfY3to3Fu3EKAMZx29v9Hnl5seyXJzLmZ9/4=",
-          "range": "bytes=1080-251884"
+          "checksum": "sha256-tf4xbo+NP+ssiaZtC1kOKehffAZ3+d17bhgfU3/30+g=",
+          "range": "bytes=1061-256582"
         },
         "name": "libnghttp2-14",
         "signature": {
-          "checksum": "sha1-CotSXRaPLKQCBRHrgzrDOD+4w20=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-KrsJYTyUsll+EUhHekbkdZFzeig=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.62.1-r0.apk",
-        "version": "1.62.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.62.1-r1.apk",
+        "version": "1.62.1-r1"
       },
       {
         "architecture": "x86_64",
@@ -394,136 +394,136 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1DE49kWSnmqVKJdjHFYC1bLkvyb0=",
+        "checksum": "Q1R8OxpY0fGwVaIwft4wJeswF5D54=",
         "control": {
-          "checksum": "sha1-DE49kWSnmqVKJdjHFYC1bLkvyb0=",
-          "range": "bytes=697-1078"
+          "checksum": "sha1-R8OxpY0fGwVaIwft4wJeswF5D54=",
+          "range": "bytes=695-1059"
         },
         "data": {
-          "checksum": "sha256-uDg8Qc6Rnro/68Vb5ufFSkqFLGrEsbvPb0pMJNvT1zw=",
-          "range": "bytes=1079-242085"
+          "checksum": "sha256-wNc8/SBJrGHfwywAtzCsAqeUOt0IaAhqNtlbv8OiHBE=",
+          "range": "bytes=1060-242151"
         },
         "name": "c-ares",
         "signature": {
-          "checksum": "sha1-iYEm6EWQKzxkeoDm+QsRfhw8pDg=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-55/PTlEHXI3o0hx9dSVdNwQeSMg=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.29.0-r0.apk",
-        "version": "1.29.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.31.0-r0.apk",
+        "version": "1.31.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q12eWmn2tCkXxwncU6gagKM3Wd9Sk=",
+        "checksum": "Q1g2RQKAvNjlRPxWjinIRveaq7IlY=",
         "control": {
-          "checksum": "sha1-2eWmn2tCkXxwncU6gagKM3Wd9Sk=",
-          "range": "bytes=696-1169"
+          "checksum": "sha1-g2RQKAvNjlRPxWjinIRveaq7IlY=",
+          "range": "bytes=695-1154"
         },
         "data": {
-          "checksum": "sha256-IFKNdojOhml3DbWPryQuHUiV3tgTWHyqOYD1JNe9IJ4=",
-          "range": "bytes=1170-2582015"
+          "checksum": "sha256-UsQFfOTXCZBan0mxDvR+ts0NKcbv1lNijxnRxjsmZhA=",
+          "range": "bytes=1155-2566233"
         },
         "name": "nghttp2",
         "signature": {
-          "checksum": "sha1-2/9n7KbRuOkrvhYqCFR5Mblx+z8=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-SUvMhz1cc5Or5Qh4fUEvPCp0NAw=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.62.1-r0.apk",
-        "version": "1.62.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.62.1-r1.apk",
+        "version": "1.62.1-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ialksjwPWvvZW+O2ABMbbBV/KTg=",
+        "checksum": "Q1sTMGOgdbZyDKxlRAByisPMHTbpY=",
         "control": {
-          "checksum": "sha1-ialksjwPWvvZW+O2ABMbbBV/KTg=",
-          "range": "bytes=702-1074"
+          "checksum": "sha1-sTMGOgdbZyDKxlRAByisPMHTbpY=",
+          "range": "bytes=703-1060"
         },
         "data": {
-          "checksum": "sha256-+ctDr3AO9mTXovGRPWk6h2ZgfY99Toy6esjBNHtJPY4=",
-          "range": "bytes=1075-631903"
+          "checksum": "sha256-bUy0h/zxpq7iP6vrQRMftZ9nevkHTB87hSX17wz4lmM=",
+          "range": "bytes=1061-631449"
         },
         "name": "nghttp2-dev",
         "signature": {
-          "checksum": "sha1-wZGQRluFd6DL1USzeak75o5/BTc=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-fQ6aDq3Io/gdJ5s5t3M+FwED1Y0=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.62.1-r0.apk",
-        "version": "1.62.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.62.1-r1.apk",
+        "version": "1.62.1-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1MlpRL1nBMU3RgNdSZVB42/vlGME=",
+        "checksum": "Q1rD3dEbbN8s5QAIQK1I8uF1O+oSo=",
         "control": {
-          "checksum": "sha1-MlpRL1nBMU3RgNdSZVB42/vlGME=",
-          "range": "bytes=697-1164"
+          "checksum": "sha1-rD3dEbbN8s5QAIQK1I8uF1O+oSo=",
+          "range": "bytes=701-1154"
         },
         "data": {
-          "checksum": "sha256-RiEPDasBVtnThSxGqTCDvb4J7WXM9YRpJwfYZJ3JLbs=",
-          "range": "bytes=1165-2274746"
+          "checksum": "sha256-41W2IRSRALQijYojLaqAiSSN1uO7twatGn8jqEuCZUg=",
+          "range": "bytes=1155-1439872"
         },
         "name": "xz",
         "signature": {
-          "checksum": "sha1-3wMPFIUEVfkAs7QSENemZsnTLyE=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-lozWkVrKvSrd1SoM7Zv08YYG2pA=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/xz-5.4.6-r2.apk",
-        "version": "5.4.6-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/xz-5.6.2-r0.apk",
+        "version": "5.6.2-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1TS707T+cPGL7TYVHQBCJoWwHZ0E=",
+        "checksum": "Q10AaU1ocIM4PYYNvwbml8TmpNvEA=",
         "control": {
-          "checksum": "sha1-TS707T+cPGL7TYVHQBCJoWwHZ0E=",
-          "range": "bytes=706-1098"
+          "checksum": "sha1-0AaU1ocIM4PYYNvwbml8TmpNvEA=",
+          "range": "bytes=706-1085"
         },
         "data": {
-          "checksum": "sha256-x18L706Vug5qDzq13SXuN/vGdVgzrqB06dW2DdgHGR4=",
-          "range": "bytes=1099-4541967"
+          "checksum": "sha256-1YQNYASFjlP3kXX58ec8du75ij/U6O4DPAKzJAPkln0=",
+          "range": "bytes=1086-4272589"
         },
         "name": "libxml2",
         "signature": {
-          "checksum": "sha1-BYhOxDos48sN8df8LMsSpROv2aw=",
+          "checksum": "sha1-QFjdplzGn/MiNFxMykgafr6/w6U=",
           "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.12.7-r0.apk",
-        "version": "2.12.7-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.1-r1.apk",
+        "version": "2.13.1-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1wJPtj5XZtnPiVWGM5dsT+nyfWXc=",
+        "checksum": "Q1wbnfumlWEiJnVUsJBRcQjFD3U6I=",
         "control": {
-          "checksum": "sha1-wJPtj5XZtnPiVWGM5dsT+nyfWXc=",
-          "range": "bytes=705-1234"
+          "checksum": "sha1-wbnfumlWEiJnVUsJBRcQjFD3U6I=",
+          "range": "bytes=699-1222"
         },
         "data": {
-          "checksum": "sha256-sw+CjlpsjO01q6lqzXgHnniiJKn7bqOSNO6vNqdGc7I=",
-          "range": "bytes=1235-3873775"
+          "checksum": "sha256-IXMNbJjj3kTjkWVBIHVRfG3zJQY2r5Eslgh/3TpMSsE=",
+          "range": "bytes=1223-3886778"
         },
         "name": "bind-libs",
         "signature": {
-          "checksum": "sha1-9zDzmHAeu7mWpidXAatqrLZVzUs=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-JNN15IPpJ2hMsO6hFVpDYPvvX5g=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bind-libs-9.18.26-r0.apk",
-        "version": "9.18.26-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/bind-libs-9.18.27-r1.apk",
+        "version": "9.18.27-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1AxEQdi8fVcYtGc3zHTCW3OZdY2Q=",
+        "checksum": "Q1kXUOoNa2KXixxAASo1W/im1qZ7s=",
         "control": {
-          "checksum": "sha1-AxEQdi8fVcYtGc3zHTCW3OZdY2Q=",
-          "range": "bytes=694-1208"
+          "checksum": "sha1-kXUOoNa2KXixxAASo1W/im1qZ7s=",
+          "range": "bytes=702-1215"
         },
         "data": {
-          "checksum": "sha256-/dt3qJw5D9iSJ/mKkRQkhWD8R52selhpcwXyw7KLMhg=",
-          "range": "bytes=1209-879444"
+          "checksum": "sha256-HRADvfRXfYsgEjUMGM4Hd7prpIv+YWILVfovbGOkEME=",
+          "range": "bytes=1216-879975"
         },
         "name": "bind-tools",
         "signature": {
-          "checksum": "sha1-VTb0YdUzPMk8Po0p4nj0y5Jey6k=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-8WUTMUaJTaX0T9FS/c+GddL7ttY=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bind-tools-9.18.26-r0.apk",
-        "version": "9.18.26-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/bind-tools-9.18.27-r1.apk",
+        "version": "9.18.27-r1"
       },
       {
         "architecture": "x86_64",
@@ -622,60 +622,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1fr0OtiVaD3c5nw8fy5m74hDe9PU=",
+        "checksum": "Q1BRGmQ9LZTeZqbxQ1ls69T6efViw=",
         "control": {
-          "checksum": "sha1-fr0OtiVaD3c5nw8fy5m74hDe9PU=",
-          "range": "bytes=697-1092"
+          "checksum": "sha1-BRGmQ9LZTeZqbxQ1ls69T6efViw=",
+          "range": "bytes=698-1080"
         },
         "data": {
-          "checksum": "sha256-lukjMYpGmuhBNDUbbTJMIrUWaR4rNikEnW4BgiTaLj8=",
-          "range": "bytes=1093-113872"
+          "checksum": "sha256-vtJ4WJ5M+31ZKSBYBedbrl/FrbAw8hGpPRrHC7kasOk=",
+          "range": "bytes=1081-113895"
         },
         "name": "libpsl",
         "signature": {
-          "checksum": "sha1-Lrrudgn1i1a0JhjdzeXG+exnjQA=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-DuAoiykwhu8vu1qxdEDK5oyAmf8=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libpsl-0.21.5-r2.apk",
-        "version": "0.21.5-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libpsl-0.21.5-r3.apk",
+        "version": "0.21.5-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1oauHQa0YcFcEHSQWdfohfNEN4sY=",
+        "checksum": "Q11DZVpe2UYyDr/dG6BDysZhE3L48=",
         "control": {
-          "checksum": "sha1-oauHQa0YcFcEHSQWdfohfNEN4sY=",
-          "range": "bytes=698-1057"
+          "checksum": "sha1-1DZVpe2UYyDr/dG6BDysZhE3L48=",
+          "range": "bytes=707-1049"
         },
         "data": {
-          "checksum": "sha256-d95c9lpjQrpuZ1CcQ8ZZ89LAGGKcessd+hxrOQpP4LU=",
-          "range": "bytes=1058-173549"
+          "checksum": "sha256-aECfsy7giZsLNxZM0HMeF4OS2gu+ycX4DUTJXsiZRQs=",
+          "range": "bytes=1050-173585"
         },
         "name": "libbrotlicommon1",
         "signature": {
-          "checksum": "sha1-g3ufBq/tyiNP6AaOoqwItVvh7uk=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-7LXD38QwFhklZCEqyW4qIncfZV0=",
+          "range": "bytes=0-706"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlicommon1-1.1.0-r2.apk",
-        "version": "1.1.0-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlicommon1-1.1.0-r3.apk",
+        "version": "1.1.0-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q18Otq7NLoYnNMebI/1Rr/s0zdLVw=",
+        "checksum": "Q1Cgr886A8Ryzynz9pxRKsNybVuK0=",
         "control": {
-          "checksum": "sha1-8Otq7NLoYnNMebI/1Rr/s0zdLVw=",
-          "range": "bytes=705-1072"
+          "checksum": "sha1-Cgr886A8Ryzynz9pxRKsNybVuK0=",
+          "range": "bytes=694-1043"
         },
         "data": {
-          "checksum": "sha256-sR3QidR/e46PJ/3S2fxAjN/hRSSA3Ar32Nw7VshTHWg=",
-          "range": "bytes=1073-81475"
+          "checksum": "sha256-mH+MTbqpLiqgydlgE+tSDEt0Sh1/zqMvAqspV4lr+Ks=",
+          "range": "bytes=1044-81511"
         },
         "name": "libbrotlidec1",
         "signature": {
-          "checksum": "sha1-6GpZI5cBUXOvjCYG81aZZR53lMI=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-Yp4Bde9oHQCec8HM2qn6hVKgtko=",
+          "range": "bytes=0-693"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlidec1-1.1.0-r2.apk",
-        "version": "1.1.0-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlidec1-1.1.0-r3.apk",
+        "version": "1.1.0-r3"
       },
       {
         "architecture": "x86_64",
@@ -736,22 +736,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q19f/3419Xa/xv9jgQ0mMYs011fBk=",
+        "checksum": "Q1mTmy64gKYi4THBqewuvYL2uUyHc=",
         "control": {
-          "checksum": "sha1-9f/3419Xa/xv9jgQ0mMYs011fBk=",
-          "range": "bytes=696-1041"
+          "checksum": "sha1-mTmy64gKYi4THBqewuvYL2uUyHc=",
+          "range": "bytes=700-1031"
         },
         "data": {
-          "checksum": "sha256-iqHASiMgiu6rIjbWGwBmmq1Zthae8BkE4QZkiVPH7Ek=",
-          "range": "bytes=1042-1888945"
+          "checksum": "sha256-p0qua2luH33oAgOcLkU9f7k+I8WnykFszVMwNahujDA=",
+          "range": "bytes=1032-1889523"
         },
         "name": "tzdata",
         "signature": {
-          "checksum": "sha1-PCC3jiXlTwrimRMXH/4RyNvccOM=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-sBf5jVLVpWj4DiXaAd/mjo0pTfk=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/tzdata-2024a-r2.apk",
-        "version": "2024a-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/tzdata-2024a-r3.apk",
+        "version": "2024a-r3"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/postgresql-12-codeinsights.lock.json
+++ b/wolfi-images/postgresql-12-codeinsights.lock.json
@@ -14,41 +14,41 @@
     "packages": [
       {
         "architecture": "x86_64",
-        "checksum": "Q1ge3SLQsJ9v2RnvIHHAP1yFyjrEU=",
+        "checksum": "Q1Ai8jWuxKZR2M2XhOpOGAoTEwnnk=",
         "control": {
-          "checksum": "sha1-ge3SLQsJ9v2RnvIHHAP1yFyjrEU=",
-          "range": "bytes=693-1040"
+          "checksum": "sha1-Ai8jWuxKZR2M2XhOpOGAoTEwnnk=",
+          "range": "bytes=705-1037"
         },
         "data": {
-          "checksum": "sha256-I0AdTdfGf4P/jwzTrLXm73l5/RNSlymEof/YZfev3xY=",
-          "range": "bytes=1041-255811"
+          "checksum": "sha256-e4UardkBVyaC49aSyrVmXNi8sSKqQl4eKYd0LxGRLA0=",
+          "range": "bytes=1038-255695"
         },
         "name": "ca-certificates-bundle",
         "signature": {
-          "checksum": "sha1-ge1eJBiQmFWAn9GapFkQpO+Rn/Y=",
-          "range": "bytes=0-692"
+          "checksum": "sha1-loRuyYQLm+atp+YteiQoj++EWIM=",
+          "range": "bytes=0-704"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20240315-r3.apk",
-        "version": "20240315-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20240315-r4.apk",
+        "version": "20240315-r4"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1bgay5kOzpmDBgqJCg7dSlawyJg0=",
+        "checksum": "Q1+GH6qRN4iy1IDt0cT0x0tin7YfI=",
         "control": {
-          "checksum": "sha1-bgay5kOzpmDBgqJCg7dSlawyJg0=",
-          "range": "bytes=703-1067"
+          "checksum": "sha1-+GH6qRN4iy1IDt0cT0x0tin7YfI=",
+          "range": "bytes=703-1051"
         },
         "data": {
-          "checksum": "sha256-f83HfRE7r2ZniH7PyPmRqcoU5NTpF+Uk4FH80QbjvBM=",
-          "range": "bytes=1068-118370"
+          "checksum": "sha256-rO0P9z2V49BSrz1A5Ap69tEappVrg5MMBjzW00rOpZc=",
+          "range": "bytes=1052-122464"
         },
         "name": "wolfi-baselayout",
         "signature": {
-          "checksum": "sha1-2hlCvYH1D7u25HkJGA75jjs/sQY=",
+          "checksum": "sha1-Ntb6VuMzDfM+frpCjKEIpDzl53I=",
           "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r11.apk",
-        "version": "20230201-r11"
+        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r12.apk",
+        "version": "20230201-r12"
       },
       {
         "architecture": "x86_64",
@@ -109,41 +109,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Zjfs1uR/mYiortANP+EFcejW+vo=",
+        "checksum": "Q1Zi0e8Bq6WCd/6uXXjVhb8YwMD1U=",
         "control": {
-          "checksum": "sha1-Zjfs1uR/mYiortANP+EFcejW+vo=",
-          "range": "bytes=698-1085"
+          "checksum": "sha1-Zi0e8Bq6WCd/6uXXjVhb8YwMD1U=",
+          "range": "bytes=700-1073"
         },
         "data": {
-          "checksum": "sha256-BMd7TzffjbrFwdbopDPVYsX0X9XnusIMNbIf33/8kwc=",
-          "range": "bytes=1086-76881"
+          "checksum": "sha256-jMhtfqVjnhuuBO7wtNZ6RS/72sZWoKt/Moage2amlks=",
+          "range": "bytes=1074-81594"
         },
         "name": "protobuf-c",
         "signature": {
-          "checksum": "sha1-efGiXyYWsJ5P2uTkB6aXEZ3kl3o=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-kATwMKztK7nk7qbYCJPkCFp6IXc=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r4.apk",
-        "version": "1.5.0-r4"
-      },
-      {
-        "architecture": "x86_64",
-        "checksum": "Q1Xf5v5uXumBgIR4d4ZxMRxdpyWlM=",
-        "control": {
-          "checksum": "sha1-Xf5v5uXumBgIR4d4ZxMRxdpyWlM=",
-          "range": "bytes=698-1078"
-        },
-        "data": {
-          "checksum": "sha256-eD7HqFCWNUBQiLq9PcWE/zPeZwkiv8hBrytI4qmfQ/8=",
-          "range": "bytes=1079-57055"
-        },
-        "name": "keyutils-libs",
-        "signature": {
-          "checksum": "sha1-V0HVgZLP7P5kNACfus3abCLCS20=",
-          "range": "bytes=0-697"
-        },
-        "url": "https://packages.wolfi.dev/os/x86_64/keyutils-libs-1.6.3-r2.apk",
-        "version": "1.6.3-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r5.apk",
+        "version": "1.5.0-r5"
       },
       {
         "architecture": "x86_64",
@@ -166,22 +147,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1wRzOx+L6MeRFtTcq2y/6ot7Cj54=",
+        "checksum": "Q1v0A2vQM5k8rQY/GpIq6xI4T0YmA=",
         "control": {
-          "checksum": "sha1-wRzOx+L6MeRFtTcq2y/6ot7Cj54=",
-          "range": "bytes=699-1069"
+          "checksum": "sha1-v0A2vQM5k8rQY/GpIq6xI4T0YmA=",
+          "range": "bytes=701-1064"
         },
         "data": {
-          "checksum": "sha256-gNRjwZ4XQatCYWediSVb+j8lS54CggvMC5Dn3qT84So=",
-          "range": "bytes=1070-61490"
+          "checksum": "sha256-uAOrkGDDc/yqt6VjIrlTEALBJG4BCI4njqZw5jQqF0o=",
+          "range": "bytes=1065-56984"
+        },
+        "name": "keyutils-libs",
+        "signature": {
+          "checksum": "sha1-32uYMH/zGBr9Jo3hiqnThlcqBcE=",
+          "range": "bytes=0-700"
+        },
+        "url": "https://packages.wolfi.dev/os/x86_64/keyutils-libs-1.6.3-r3.apk",
+        "version": "1.6.3-r3"
+      },
+      {
+        "architecture": "x86_64",
+        "checksum": "Q1Onuac6Y+IWA7a4b8FvqX1erWDDw=",
+        "control": {
+          "checksum": "sha1-Onuac6Y+IWA7a4b8FvqX1erWDDw=",
+          "range": "bytes=693-1048"
+        },
+        "data": {
+          "checksum": "sha256-KLtDAs3iU0oyZ/FysePG/J+1H1ofDxHXIY7xvtZhtMc=",
+          "range": "bytes=1049-61503"
         },
         "name": "libverto",
         "signature": {
-          "checksum": "sha1-kuPwakYdy5EM6sd5Ba0K0Ta8x4w=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-/IXL9S1O+MwaW7KsSzz1ywEqKFQ=",
+          "range": "bytes=0-692"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libverto-0.3.2-r3.apk",
-        "version": "0.3.2-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/libverto-0.3.2-r4.apk",
+        "version": "0.3.2-r4"
       },
       {
         "architecture": "x86_64",
@@ -204,60 +204,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1gTZGkWP+QO3mUqLVJth8vrDEzzU=",
+        "checksum": "Q1Q/Zy5ovYSu2p/vVLr6DgVA1e8AQ=",
         "control": {
-          "checksum": "sha1-gTZGkWP+QO3mUqLVJth8vrDEzzU=",
-          "range": "bytes=699-1076"
+          "checksum": "sha1-Q/Zy5ovYSu2p/vVLr6DgVA1e8AQ=",
+          "range": "bytes=699-1062"
         },
         "data": {
-          "checksum": "sha256-/IFXqeKvU0GODNsz1yPIEMcFHgABT+8rbZpSlTLo4e4=",
-          "range": "bytes=1077-5915704"
+          "checksum": "sha256-H3jxsw8ytOeCIR4vq17voSVhdNokXk8C1g075txH6Bs=",
+          "range": "bytes=1063-5903754"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-l1o5ixkyWWqqJE3FOfR0QUemJUA=",
+          "checksum": "sha1-NIl2f5OI/wSZByI8Ds1ZUfbFWyw=",
           "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r9.apk",
-        "version": "3.3.0-r9"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.1-r3.apk",
+        "version": "3.3.1-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1jhAhggAuZnU7FFHnebGA26mq+jI=",
+        "checksum": "Q13wGUXdZut9OOTdY5z2amUj9wXC0=",
         "control": {
-          "checksum": "sha1-jhAhggAuZnU7FFHnebGA26mq+jI=",
-          "range": "bytes=695-1079"
+          "checksum": "sha1-3wGUXdZut9OOTdY5z2amUj9wXC0=",
+          "range": "bytes=698-1068"
         },
         "data": {
-          "checksum": "sha256-XTCQYnhGSm7SkGwqV/TQMFqGajVJVYhKAidKfLb2D3Y=",
-          "range": "bytes=1080-1197081"
+          "checksum": "sha256-mRda6+YGlOCczyIWKaHqXskTINoT1rgorHDHqAKAb7c=",
+          "range": "bytes=1069-1188955"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-qVrfDVxubkrb5Yrd2mFTv2A0G7k=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-+UdRc4U3PKw4H9OiNurHKXa5BYk=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r9.apk",
-        "version": "3.3.0-r9"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.1-r3.apk",
+        "version": "3.3.1-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1BQEXaeya6QB39QLeKcB99qBNF2o=",
+        "checksum": "Q1p04MrHQPrXOzuV/uF290zjnltqI=",
         "control": {
-          "checksum": "sha1-BQEXaeya6QB39QLeKcB99qBNF2o=",
-          "range": "bytes=699-1229"
+          "checksum": "sha1-p04MrHQPrXOzuV/uF290zjnltqI=",
+          "range": "bytes=704-1219"
         },
         "data": {
-          "checksum": "sha256-ugj/qGEBzhvdX17S22Anry+biy3lcqywhGMSHLIBCvo=",
-          "range": "bytes=1230-2551676"
+          "checksum": "sha256-TsXeqhUGykAhjQUEAlMUSzDQBcWDkkDvReoeHCL1F6c=",
+          "range": "bytes=1220-2555814"
         },
         "name": "krb5-libs",
         "signature": {
-          "checksum": "sha1-oqDPmNM4EngXAGayd/BZOqJAIao=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-cPyzS38QHuNlOCQb8IPlsl2PLHQ=",
+          "range": "bytes=0-703"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/krb5-libs-1.21.2-r2.apk",
-        "version": "1.21.2-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/krb5-libs-1.21.3-r0.apk",
+        "version": "1.21.3-r0"
       },
       {
         "architecture": "x86_64",
@@ -280,60 +280,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1wzZwtLauOQfLQC7YUvZdfKxtlwQ=",
+        "checksum": "Q17uprcuQ2VFudMcWAwtP7miJmLYs=",
         "control": {
-          "checksum": "sha1-wzZwtLauOQfLQC7YUvZdfKxtlwQ=",
-          "range": "bytes=698-1085"
+          "checksum": "sha1-7uprcuQ2VFudMcWAwtP7miJmLYs=",
+          "range": "bytes=695-1067"
         },
         "data": {
-          "checksum": "sha256-TO8CAULO44s/LphhtcaFOGJB7aFldk13v1cV9ceZHww=",
-          "range": "bytes=1086-276837"
+          "checksum": "sha256-unKdPbvO2VHZ5w1t1l8mOpQuNdUGwLhofEO4weN2Mig=",
+          "range": "bytes=1068-280973"
         },
         "name": "libuv",
         "signature": {
-          "checksum": "sha1-LRiyeKmjexy8CJizLxjd6ikon1w=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-4lKldnTO71WHMZ4tbANz6i2/Ed0=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libuv-1.48.0-r2.apk",
-        "version": "1.48.0-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libuv-1.48.0-r3.apk",
+        "version": "1.48.0-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q14S6biy8fc5OGbGEJoLBM+tJOGyo=",
+        "checksum": "Q1CN6zJbOPznWUfTrb/41KT7E6dm8=",
         "control": {
-          "checksum": "sha1-4S6biy8fc5OGbGEJoLBM+tJOGyo=",
-          "range": "bytes=703-1102"
+          "checksum": "sha1-CN6zJbOPznWUfTrb/41KT7E6dm8=",
+          "range": "bytes=699-1083"
         },
         "data": {
-          "checksum": "sha256-hwjdLQYfuMAGQeONmFVo0lZKKQK1S+3PBhrI3upm5W4=",
-          "range": "bytes=1103-155304"
+          "checksum": "sha256-ybzFzoQh1yNTcd3cjt54nYsPlAxAcMUcVMxEv1JRnpQ=",
+          "range": "bytes=1084-155375"
         },
         "name": "zlib",
         "signature": {
-          "checksum": "sha1-ZuLd7kE+AGhn27o8ZqDGM5eundc=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-CPXJcCjinAXP+H8Z5tkko8ayG6E=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/zlib-1.3.1-r2.apk",
-        "version": "1.3.1-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/zlib-1.3.1-r3.apk",
+        "version": "1.3.1-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ykDkP+AmDi2VcZZ1c4q4sez/DxI=",
+        "checksum": "Q1rgbci8SRSjW7EB0NSh6ZUPJLndM=",
         "control": {
-          "checksum": "sha1-ykDkP+AmDi2VcZZ1c4q4sez/DxI=",
-          "range": "bytes=705-1079"
+          "checksum": "sha1-rgbci8SRSjW7EB0NSh6ZUPJLndM=",
+          "range": "bytes=702-1060"
         },
         "data": {
-          "checksum": "sha256-t3BrH7lWfY3to3Fu3EKAMZx29v9Hnl5seyXJzLmZ9/4=",
-          "range": "bytes=1080-251884"
+          "checksum": "sha256-tf4xbo+NP+ssiaZtC1kOKehffAZ3+d17bhgfU3/30+g=",
+          "range": "bytes=1061-256582"
         },
         "name": "libnghttp2-14",
         "signature": {
-          "checksum": "sha1-CotSXRaPLKQCBRHrgzrDOD+4w20=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-KrsJYTyUsll+EUhHekbkdZFzeig=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.62.1-r0.apk",
-        "version": "1.62.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.62.1-r1.apk",
+        "version": "1.62.1-r1"
       },
       {
         "architecture": "x86_64",
@@ -394,136 +394,136 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1DE49kWSnmqVKJdjHFYC1bLkvyb0=",
+        "checksum": "Q1R8OxpY0fGwVaIwft4wJeswF5D54=",
         "control": {
-          "checksum": "sha1-DE49kWSnmqVKJdjHFYC1bLkvyb0=",
-          "range": "bytes=697-1078"
+          "checksum": "sha1-R8OxpY0fGwVaIwft4wJeswF5D54=",
+          "range": "bytes=695-1059"
         },
         "data": {
-          "checksum": "sha256-uDg8Qc6Rnro/68Vb5ufFSkqFLGrEsbvPb0pMJNvT1zw=",
-          "range": "bytes=1079-242085"
+          "checksum": "sha256-wNc8/SBJrGHfwywAtzCsAqeUOt0IaAhqNtlbv8OiHBE=",
+          "range": "bytes=1060-242151"
         },
         "name": "c-ares",
         "signature": {
-          "checksum": "sha1-iYEm6EWQKzxkeoDm+QsRfhw8pDg=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-55/PTlEHXI3o0hx9dSVdNwQeSMg=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.29.0-r0.apk",
-        "version": "1.29.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.31.0-r0.apk",
+        "version": "1.31.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q12eWmn2tCkXxwncU6gagKM3Wd9Sk=",
+        "checksum": "Q1g2RQKAvNjlRPxWjinIRveaq7IlY=",
         "control": {
-          "checksum": "sha1-2eWmn2tCkXxwncU6gagKM3Wd9Sk=",
-          "range": "bytes=696-1169"
+          "checksum": "sha1-g2RQKAvNjlRPxWjinIRveaq7IlY=",
+          "range": "bytes=695-1154"
         },
         "data": {
-          "checksum": "sha256-IFKNdojOhml3DbWPryQuHUiV3tgTWHyqOYD1JNe9IJ4=",
-          "range": "bytes=1170-2582015"
+          "checksum": "sha256-UsQFfOTXCZBan0mxDvR+ts0NKcbv1lNijxnRxjsmZhA=",
+          "range": "bytes=1155-2566233"
         },
         "name": "nghttp2",
         "signature": {
-          "checksum": "sha1-2/9n7KbRuOkrvhYqCFR5Mblx+z8=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-SUvMhz1cc5Or5Qh4fUEvPCp0NAw=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.62.1-r0.apk",
-        "version": "1.62.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.62.1-r1.apk",
+        "version": "1.62.1-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ialksjwPWvvZW+O2ABMbbBV/KTg=",
+        "checksum": "Q1sTMGOgdbZyDKxlRAByisPMHTbpY=",
         "control": {
-          "checksum": "sha1-ialksjwPWvvZW+O2ABMbbBV/KTg=",
-          "range": "bytes=702-1074"
+          "checksum": "sha1-sTMGOgdbZyDKxlRAByisPMHTbpY=",
+          "range": "bytes=703-1060"
         },
         "data": {
-          "checksum": "sha256-+ctDr3AO9mTXovGRPWk6h2ZgfY99Toy6esjBNHtJPY4=",
-          "range": "bytes=1075-631903"
+          "checksum": "sha256-bUy0h/zxpq7iP6vrQRMftZ9nevkHTB87hSX17wz4lmM=",
+          "range": "bytes=1061-631449"
         },
         "name": "nghttp2-dev",
         "signature": {
-          "checksum": "sha1-wZGQRluFd6DL1USzeak75o5/BTc=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-fQ6aDq3Io/gdJ5s5t3M+FwED1Y0=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.62.1-r0.apk",
-        "version": "1.62.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.62.1-r1.apk",
+        "version": "1.62.1-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1MlpRL1nBMU3RgNdSZVB42/vlGME=",
+        "checksum": "Q1rD3dEbbN8s5QAIQK1I8uF1O+oSo=",
         "control": {
-          "checksum": "sha1-MlpRL1nBMU3RgNdSZVB42/vlGME=",
-          "range": "bytes=697-1164"
+          "checksum": "sha1-rD3dEbbN8s5QAIQK1I8uF1O+oSo=",
+          "range": "bytes=701-1154"
         },
         "data": {
-          "checksum": "sha256-RiEPDasBVtnThSxGqTCDvb4J7WXM9YRpJwfYZJ3JLbs=",
-          "range": "bytes=1165-2274746"
+          "checksum": "sha256-41W2IRSRALQijYojLaqAiSSN1uO7twatGn8jqEuCZUg=",
+          "range": "bytes=1155-1439872"
         },
         "name": "xz",
         "signature": {
-          "checksum": "sha1-3wMPFIUEVfkAs7QSENemZsnTLyE=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-lozWkVrKvSrd1SoM7Zv08YYG2pA=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/xz-5.4.6-r2.apk",
-        "version": "5.4.6-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/xz-5.6.2-r0.apk",
+        "version": "5.6.2-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1TS707T+cPGL7TYVHQBCJoWwHZ0E=",
+        "checksum": "Q10AaU1ocIM4PYYNvwbml8TmpNvEA=",
         "control": {
-          "checksum": "sha1-TS707T+cPGL7TYVHQBCJoWwHZ0E=",
-          "range": "bytes=706-1098"
+          "checksum": "sha1-0AaU1ocIM4PYYNvwbml8TmpNvEA=",
+          "range": "bytes=706-1085"
         },
         "data": {
-          "checksum": "sha256-x18L706Vug5qDzq13SXuN/vGdVgzrqB06dW2DdgHGR4=",
-          "range": "bytes=1099-4541967"
+          "checksum": "sha256-1YQNYASFjlP3kXX58ec8du75ij/U6O4DPAKzJAPkln0=",
+          "range": "bytes=1086-4272589"
         },
         "name": "libxml2",
         "signature": {
-          "checksum": "sha1-BYhOxDos48sN8df8LMsSpROv2aw=",
+          "checksum": "sha1-QFjdplzGn/MiNFxMykgafr6/w6U=",
           "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.12.7-r0.apk",
-        "version": "2.12.7-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.1-r1.apk",
+        "version": "2.13.1-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1wJPtj5XZtnPiVWGM5dsT+nyfWXc=",
+        "checksum": "Q1wbnfumlWEiJnVUsJBRcQjFD3U6I=",
         "control": {
-          "checksum": "sha1-wJPtj5XZtnPiVWGM5dsT+nyfWXc=",
-          "range": "bytes=705-1234"
+          "checksum": "sha1-wbnfumlWEiJnVUsJBRcQjFD3U6I=",
+          "range": "bytes=699-1222"
         },
         "data": {
-          "checksum": "sha256-sw+CjlpsjO01q6lqzXgHnniiJKn7bqOSNO6vNqdGc7I=",
-          "range": "bytes=1235-3873775"
+          "checksum": "sha256-IXMNbJjj3kTjkWVBIHVRfG3zJQY2r5Eslgh/3TpMSsE=",
+          "range": "bytes=1223-3886778"
         },
         "name": "bind-libs",
         "signature": {
-          "checksum": "sha1-9zDzmHAeu7mWpidXAatqrLZVzUs=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-JNN15IPpJ2hMsO6hFVpDYPvvX5g=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bind-libs-9.18.26-r0.apk",
-        "version": "9.18.26-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/bind-libs-9.18.27-r1.apk",
+        "version": "9.18.27-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1AxEQdi8fVcYtGc3zHTCW3OZdY2Q=",
+        "checksum": "Q1kXUOoNa2KXixxAASo1W/im1qZ7s=",
         "control": {
-          "checksum": "sha1-AxEQdi8fVcYtGc3zHTCW3OZdY2Q=",
-          "range": "bytes=694-1208"
+          "checksum": "sha1-kXUOoNa2KXixxAASo1W/im1qZ7s=",
+          "range": "bytes=702-1215"
         },
         "data": {
-          "checksum": "sha256-/dt3qJw5D9iSJ/mKkRQkhWD8R52selhpcwXyw7KLMhg=",
-          "range": "bytes=1209-879444"
+          "checksum": "sha256-HRADvfRXfYsgEjUMGM4Hd7prpIv+YWILVfovbGOkEME=",
+          "range": "bytes=1216-879975"
         },
         "name": "bind-tools",
         "signature": {
-          "checksum": "sha1-VTb0YdUzPMk8Po0p4nj0y5Jey6k=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-8WUTMUaJTaX0T9FS/c+GddL7ttY=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bind-tools-9.18.26-r0.apk",
-        "version": "9.18.26-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/bind-tools-9.18.27-r1.apk",
+        "version": "9.18.27-r1"
       },
       {
         "architecture": "x86_64",
@@ -622,60 +622,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1fr0OtiVaD3c5nw8fy5m74hDe9PU=",
+        "checksum": "Q1BRGmQ9LZTeZqbxQ1ls69T6efViw=",
         "control": {
-          "checksum": "sha1-fr0OtiVaD3c5nw8fy5m74hDe9PU=",
-          "range": "bytes=697-1092"
+          "checksum": "sha1-BRGmQ9LZTeZqbxQ1ls69T6efViw=",
+          "range": "bytes=698-1080"
         },
         "data": {
-          "checksum": "sha256-lukjMYpGmuhBNDUbbTJMIrUWaR4rNikEnW4BgiTaLj8=",
-          "range": "bytes=1093-113872"
+          "checksum": "sha256-vtJ4WJ5M+31ZKSBYBedbrl/FrbAw8hGpPRrHC7kasOk=",
+          "range": "bytes=1081-113895"
         },
         "name": "libpsl",
         "signature": {
-          "checksum": "sha1-Lrrudgn1i1a0JhjdzeXG+exnjQA=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-DuAoiykwhu8vu1qxdEDK5oyAmf8=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libpsl-0.21.5-r2.apk",
-        "version": "0.21.5-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libpsl-0.21.5-r3.apk",
+        "version": "0.21.5-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1oauHQa0YcFcEHSQWdfohfNEN4sY=",
+        "checksum": "Q11DZVpe2UYyDr/dG6BDysZhE3L48=",
         "control": {
-          "checksum": "sha1-oauHQa0YcFcEHSQWdfohfNEN4sY=",
-          "range": "bytes=698-1057"
+          "checksum": "sha1-1DZVpe2UYyDr/dG6BDysZhE3L48=",
+          "range": "bytes=707-1049"
         },
         "data": {
-          "checksum": "sha256-d95c9lpjQrpuZ1CcQ8ZZ89LAGGKcessd+hxrOQpP4LU=",
-          "range": "bytes=1058-173549"
+          "checksum": "sha256-aECfsy7giZsLNxZM0HMeF4OS2gu+ycX4DUTJXsiZRQs=",
+          "range": "bytes=1050-173585"
         },
         "name": "libbrotlicommon1",
         "signature": {
-          "checksum": "sha1-g3ufBq/tyiNP6AaOoqwItVvh7uk=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-7LXD38QwFhklZCEqyW4qIncfZV0=",
+          "range": "bytes=0-706"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlicommon1-1.1.0-r2.apk",
-        "version": "1.1.0-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlicommon1-1.1.0-r3.apk",
+        "version": "1.1.0-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q18Otq7NLoYnNMebI/1Rr/s0zdLVw=",
+        "checksum": "Q1Cgr886A8Ryzynz9pxRKsNybVuK0=",
         "control": {
-          "checksum": "sha1-8Otq7NLoYnNMebI/1Rr/s0zdLVw=",
-          "range": "bytes=705-1072"
+          "checksum": "sha1-Cgr886A8Ryzynz9pxRKsNybVuK0=",
+          "range": "bytes=694-1043"
         },
         "data": {
-          "checksum": "sha256-sR3QidR/e46PJ/3S2fxAjN/hRSSA3Ar32Nw7VshTHWg=",
-          "range": "bytes=1073-81475"
+          "checksum": "sha256-mH+MTbqpLiqgydlgE+tSDEt0Sh1/zqMvAqspV4lr+Ks=",
+          "range": "bytes=1044-81511"
         },
         "name": "libbrotlidec1",
         "signature": {
-          "checksum": "sha1-6GpZI5cBUXOvjCYG81aZZR53lMI=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-Yp4Bde9oHQCec8HM2qn6hVKgtko=",
+          "range": "bytes=0-693"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlidec1-1.1.0-r2.apk",
-        "version": "1.1.0-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlidec1-1.1.0-r3.apk",
+        "version": "1.1.0-r3"
       },
       {
         "architecture": "x86_64",
@@ -850,22 +850,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1GrI3roTx+zrOBnGfqb4bM1OYj6I=",
+        "checksum": "Q1pFBna33iXNWoxlANBI0dibfvT94=",
         "control": {
-          "checksum": "sha1-GrI3roTx+zrOBnGfqb4bM1OYj6I=",
-          "range": "bytes=702-1139"
+          "checksum": "sha1-pFBna33iXNWoxlANBI0dibfvT94=",
+          "range": "bytes=706-1129"
         },
         "data": {
-          "checksum": "sha256-DB4T1Bo94kP9/NuGNv0Vi0KzSaINmPY0hpICRStIKSE=",
-          "range": "bytes=1140-66640"
+          "checksum": "sha256-jsPjzi/shXYlr0zayGvJ82SSPVs4ew/DIy3L1hiuqdE=",
+          "range": "bytes=1130-66950"
         },
         "name": "libuuid",
         "signature": {
-          "checksum": "sha1-xVMkIcRSdv+/WzAYI6KvKvyW9WU=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-nVANm2v8k7qILW+g+xjNgr7yqQY=",
+          "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libuuid-2.39.3-r4.apk",
-        "version": "2.39.3-r4"
+        "url": "https://packages.wolfi.dev/os/x86_64/libuuid-2.40.1-r1.apk",
+        "version": "2.40.1-r1"
       },
       {
         "architecture": "x86_64",
@@ -907,22 +907,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ZMGiMSnjbScBstPVaw5qQfkNI+M=",
+        "checksum": "Q1w2/J0nDU8aA/f0HxunA5N19L1gw=",
         "control": {
-          "checksum": "sha1-ZMGiMSnjbScBstPVaw5qQfkNI+M=",
-          "range": "bytes=697-1097"
+          "checksum": "sha1-w2/J0nDU8aA/f0HxunA5N19L1gw=",
+          "range": "bytes=702-1086"
         },
         "data": {
-          "checksum": "sha256-XN2CeOJxCHWCgGpwTUkm5UOFKFz/eRpd7AReq4CqiOk=",
-          "range": "bytes=1098-1436391"
+          "checksum": "sha256-/2i+TNHbkrOsjrx7WHrrloXc6gcoyfyGrUHdBljYM+o=",
+          "range": "bytes=1087-1440232"
         },
         "name": "bash",
         "signature": {
-          "checksum": "sha1-t7/nmubimPIaw21oj0WlXgqY90E=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-tnYcLxCgV8srkBsTl4c/f6m11vQ=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bash-5.2.21-r4.apk",
-        "version": "5.2.21-r4"
+        "url": "https://packages.wolfi.dev/os/x86_64/bash-5.2.21-r5.apk",
+        "version": "5.2.21-r5"
       },
       {
         "architecture": "x86_64",
@@ -945,22 +945,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q19f/3419Xa/xv9jgQ0mMYs011fBk=",
+        "checksum": "Q1mTmy64gKYi4THBqewuvYL2uUyHc=",
         "control": {
-          "checksum": "sha1-9f/3419Xa/xv9jgQ0mMYs011fBk=",
-          "range": "bytes=696-1041"
+          "checksum": "sha1-mTmy64gKYi4THBqewuvYL2uUyHc=",
+          "range": "bytes=700-1031"
         },
         "data": {
-          "checksum": "sha256-iqHASiMgiu6rIjbWGwBmmq1Zthae8BkE4QZkiVPH7Ek=",
-          "range": "bytes=1042-1888945"
+          "checksum": "sha256-p0qua2luH33oAgOcLkU9f7k+I8WnykFszVMwNahujDA=",
+          "range": "bytes=1032-1889523"
         },
         "name": "tzdata",
         "signature": {
-          "checksum": "sha1-PCC3jiXlTwrimRMXH/4RyNvccOM=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-sBf5jVLVpWj4DiXaAd/mjo0pTfk=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/tzdata-2024a-r2.apk",
-        "version": "2024a-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/tzdata-2024a-r3.apk",
+        "version": "2024a-r3"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/postgresql-12.lock.json
+++ b/wolfi-images/postgresql-12.lock.json
@@ -14,41 +14,41 @@
     "packages": [
       {
         "architecture": "x86_64",
-        "checksum": "Q1ge3SLQsJ9v2RnvIHHAP1yFyjrEU=",
+        "checksum": "Q1Ai8jWuxKZR2M2XhOpOGAoTEwnnk=",
         "control": {
-          "checksum": "sha1-ge3SLQsJ9v2RnvIHHAP1yFyjrEU=",
-          "range": "bytes=693-1040"
+          "checksum": "sha1-Ai8jWuxKZR2M2XhOpOGAoTEwnnk=",
+          "range": "bytes=705-1037"
         },
         "data": {
-          "checksum": "sha256-I0AdTdfGf4P/jwzTrLXm73l5/RNSlymEof/YZfev3xY=",
-          "range": "bytes=1041-255811"
+          "checksum": "sha256-e4UardkBVyaC49aSyrVmXNi8sSKqQl4eKYd0LxGRLA0=",
+          "range": "bytes=1038-255695"
         },
         "name": "ca-certificates-bundle",
         "signature": {
-          "checksum": "sha1-ge1eJBiQmFWAn9GapFkQpO+Rn/Y=",
-          "range": "bytes=0-692"
+          "checksum": "sha1-loRuyYQLm+atp+YteiQoj++EWIM=",
+          "range": "bytes=0-704"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20240315-r3.apk",
-        "version": "20240315-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20240315-r4.apk",
+        "version": "20240315-r4"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1bgay5kOzpmDBgqJCg7dSlawyJg0=",
+        "checksum": "Q1+GH6qRN4iy1IDt0cT0x0tin7YfI=",
         "control": {
-          "checksum": "sha1-bgay5kOzpmDBgqJCg7dSlawyJg0=",
-          "range": "bytes=703-1067"
+          "checksum": "sha1-+GH6qRN4iy1IDt0cT0x0tin7YfI=",
+          "range": "bytes=703-1051"
         },
         "data": {
-          "checksum": "sha256-f83HfRE7r2ZniH7PyPmRqcoU5NTpF+Uk4FH80QbjvBM=",
-          "range": "bytes=1068-118370"
+          "checksum": "sha256-rO0P9z2V49BSrz1A5Ap69tEappVrg5MMBjzW00rOpZc=",
+          "range": "bytes=1052-122464"
         },
         "name": "wolfi-baselayout",
         "signature": {
-          "checksum": "sha1-2hlCvYH1D7u25HkJGA75jjs/sQY=",
+          "checksum": "sha1-Ntb6VuMzDfM+frpCjKEIpDzl53I=",
           "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r11.apk",
-        "version": "20230201-r11"
+        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r12.apk",
+        "version": "20230201-r12"
       },
       {
         "architecture": "x86_64",
@@ -109,41 +109,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Zjfs1uR/mYiortANP+EFcejW+vo=",
+        "checksum": "Q1Zi0e8Bq6WCd/6uXXjVhb8YwMD1U=",
         "control": {
-          "checksum": "sha1-Zjfs1uR/mYiortANP+EFcejW+vo=",
-          "range": "bytes=698-1085"
+          "checksum": "sha1-Zi0e8Bq6WCd/6uXXjVhb8YwMD1U=",
+          "range": "bytes=700-1073"
         },
         "data": {
-          "checksum": "sha256-BMd7TzffjbrFwdbopDPVYsX0X9XnusIMNbIf33/8kwc=",
-          "range": "bytes=1086-76881"
+          "checksum": "sha256-jMhtfqVjnhuuBO7wtNZ6RS/72sZWoKt/Moage2amlks=",
+          "range": "bytes=1074-81594"
         },
         "name": "protobuf-c",
         "signature": {
-          "checksum": "sha1-efGiXyYWsJ5P2uTkB6aXEZ3kl3o=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-kATwMKztK7nk7qbYCJPkCFp6IXc=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r4.apk",
-        "version": "1.5.0-r4"
-      },
-      {
-        "architecture": "x86_64",
-        "checksum": "Q1Xf5v5uXumBgIR4d4ZxMRxdpyWlM=",
-        "control": {
-          "checksum": "sha1-Xf5v5uXumBgIR4d4ZxMRxdpyWlM=",
-          "range": "bytes=698-1078"
-        },
-        "data": {
-          "checksum": "sha256-eD7HqFCWNUBQiLq9PcWE/zPeZwkiv8hBrytI4qmfQ/8=",
-          "range": "bytes=1079-57055"
-        },
-        "name": "keyutils-libs",
-        "signature": {
-          "checksum": "sha1-V0HVgZLP7P5kNACfus3abCLCS20=",
-          "range": "bytes=0-697"
-        },
-        "url": "https://packages.wolfi.dev/os/x86_64/keyutils-libs-1.6.3-r2.apk",
-        "version": "1.6.3-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r5.apk",
+        "version": "1.5.0-r5"
       },
       {
         "architecture": "x86_64",
@@ -166,22 +147,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1wRzOx+L6MeRFtTcq2y/6ot7Cj54=",
+        "checksum": "Q1v0A2vQM5k8rQY/GpIq6xI4T0YmA=",
         "control": {
-          "checksum": "sha1-wRzOx+L6MeRFtTcq2y/6ot7Cj54=",
-          "range": "bytes=699-1069"
+          "checksum": "sha1-v0A2vQM5k8rQY/GpIq6xI4T0YmA=",
+          "range": "bytes=701-1064"
         },
         "data": {
-          "checksum": "sha256-gNRjwZ4XQatCYWediSVb+j8lS54CggvMC5Dn3qT84So=",
-          "range": "bytes=1070-61490"
+          "checksum": "sha256-uAOrkGDDc/yqt6VjIrlTEALBJG4BCI4njqZw5jQqF0o=",
+          "range": "bytes=1065-56984"
+        },
+        "name": "keyutils-libs",
+        "signature": {
+          "checksum": "sha1-32uYMH/zGBr9Jo3hiqnThlcqBcE=",
+          "range": "bytes=0-700"
+        },
+        "url": "https://packages.wolfi.dev/os/x86_64/keyutils-libs-1.6.3-r3.apk",
+        "version": "1.6.3-r3"
+      },
+      {
+        "architecture": "x86_64",
+        "checksum": "Q1Onuac6Y+IWA7a4b8FvqX1erWDDw=",
+        "control": {
+          "checksum": "sha1-Onuac6Y+IWA7a4b8FvqX1erWDDw=",
+          "range": "bytes=693-1048"
+        },
+        "data": {
+          "checksum": "sha256-KLtDAs3iU0oyZ/FysePG/J+1H1ofDxHXIY7xvtZhtMc=",
+          "range": "bytes=1049-61503"
         },
         "name": "libverto",
         "signature": {
-          "checksum": "sha1-kuPwakYdy5EM6sd5Ba0K0Ta8x4w=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-/IXL9S1O+MwaW7KsSzz1ywEqKFQ=",
+          "range": "bytes=0-692"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libverto-0.3.2-r3.apk",
-        "version": "0.3.2-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/libverto-0.3.2-r4.apk",
+        "version": "0.3.2-r4"
       },
       {
         "architecture": "x86_64",
@@ -204,60 +204,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1gTZGkWP+QO3mUqLVJth8vrDEzzU=",
+        "checksum": "Q1Q/Zy5ovYSu2p/vVLr6DgVA1e8AQ=",
         "control": {
-          "checksum": "sha1-gTZGkWP+QO3mUqLVJth8vrDEzzU=",
-          "range": "bytes=699-1076"
+          "checksum": "sha1-Q/Zy5ovYSu2p/vVLr6DgVA1e8AQ=",
+          "range": "bytes=699-1062"
         },
         "data": {
-          "checksum": "sha256-/IFXqeKvU0GODNsz1yPIEMcFHgABT+8rbZpSlTLo4e4=",
-          "range": "bytes=1077-5915704"
+          "checksum": "sha256-H3jxsw8ytOeCIR4vq17voSVhdNokXk8C1g075txH6Bs=",
+          "range": "bytes=1063-5903754"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-l1o5ixkyWWqqJE3FOfR0QUemJUA=",
+          "checksum": "sha1-NIl2f5OI/wSZByI8Ds1ZUfbFWyw=",
           "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r9.apk",
-        "version": "3.3.0-r9"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.1-r3.apk",
+        "version": "3.3.1-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1jhAhggAuZnU7FFHnebGA26mq+jI=",
+        "checksum": "Q13wGUXdZut9OOTdY5z2amUj9wXC0=",
         "control": {
-          "checksum": "sha1-jhAhggAuZnU7FFHnebGA26mq+jI=",
-          "range": "bytes=695-1079"
+          "checksum": "sha1-3wGUXdZut9OOTdY5z2amUj9wXC0=",
+          "range": "bytes=698-1068"
         },
         "data": {
-          "checksum": "sha256-XTCQYnhGSm7SkGwqV/TQMFqGajVJVYhKAidKfLb2D3Y=",
-          "range": "bytes=1080-1197081"
+          "checksum": "sha256-mRda6+YGlOCczyIWKaHqXskTINoT1rgorHDHqAKAb7c=",
+          "range": "bytes=1069-1188955"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-qVrfDVxubkrb5Yrd2mFTv2A0G7k=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-+UdRc4U3PKw4H9OiNurHKXa5BYk=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r9.apk",
-        "version": "3.3.0-r9"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.1-r3.apk",
+        "version": "3.3.1-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1BQEXaeya6QB39QLeKcB99qBNF2o=",
+        "checksum": "Q1p04MrHQPrXOzuV/uF290zjnltqI=",
         "control": {
-          "checksum": "sha1-BQEXaeya6QB39QLeKcB99qBNF2o=",
-          "range": "bytes=699-1229"
+          "checksum": "sha1-p04MrHQPrXOzuV/uF290zjnltqI=",
+          "range": "bytes=704-1219"
         },
         "data": {
-          "checksum": "sha256-ugj/qGEBzhvdX17S22Anry+biy3lcqywhGMSHLIBCvo=",
-          "range": "bytes=1230-2551676"
+          "checksum": "sha256-TsXeqhUGykAhjQUEAlMUSzDQBcWDkkDvReoeHCL1F6c=",
+          "range": "bytes=1220-2555814"
         },
         "name": "krb5-libs",
         "signature": {
-          "checksum": "sha1-oqDPmNM4EngXAGayd/BZOqJAIao=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-cPyzS38QHuNlOCQb8IPlsl2PLHQ=",
+          "range": "bytes=0-703"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/krb5-libs-1.21.2-r2.apk",
-        "version": "1.21.2-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/krb5-libs-1.21.3-r0.apk",
+        "version": "1.21.3-r0"
       },
       {
         "architecture": "x86_64",
@@ -280,60 +280,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1wzZwtLauOQfLQC7YUvZdfKxtlwQ=",
+        "checksum": "Q17uprcuQ2VFudMcWAwtP7miJmLYs=",
         "control": {
-          "checksum": "sha1-wzZwtLauOQfLQC7YUvZdfKxtlwQ=",
-          "range": "bytes=698-1085"
+          "checksum": "sha1-7uprcuQ2VFudMcWAwtP7miJmLYs=",
+          "range": "bytes=695-1067"
         },
         "data": {
-          "checksum": "sha256-TO8CAULO44s/LphhtcaFOGJB7aFldk13v1cV9ceZHww=",
-          "range": "bytes=1086-276837"
+          "checksum": "sha256-unKdPbvO2VHZ5w1t1l8mOpQuNdUGwLhofEO4weN2Mig=",
+          "range": "bytes=1068-280973"
         },
         "name": "libuv",
         "signature": {
-          "checksum": "sha1-LRiyeKmjexy8CJizLxjd6ikon1w=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-4lKldnTO71WHMZ4tbANz6i2/Ed0=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libuv-1.48.0-r2.apk",
-        "version": "1.48.0-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libuv-1.48.0-r3.apk",
+        "version": "1.48.0-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q14S6biy8fc5OGbGEJoLBM+tJOGyo=",
+        "checksum": "Q1CN6zJbOPznWUfTrb/41KT7E6dm8=",
         "control": {
-          "checksum": "sha1-4S6biy8fc5OGbGEJoLBM+tJOGyo=",
-          "range": "bytes=703-1102"
+          "checksum": "sha1-CN6zJbOPznWUfTrb/41KT7E6dm8=",
+          "range": "bytes=699-1083"
         },
         "data": {
-          "checksum": "sha256-hwjdLQYfuMAGQeONmFVo0lZKKQK1S+3PBhrI3upm5W4=",
-          "range": "bytes=1103-155304"
+          "checksum": "sha256-ybzFzoQh1yNTcd3cjt54nYsPlAxAcMUcVMxEv1JRnpQ=",
+          "range": "bytes=1084-155375"
         },
         "name": "zlib",
         "signature": {
-          "checksum": "sha1-ZuLd7kE+AGhn27o8ZqDGM5eundc=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-CPXJcCjinAXP+H8Z5tkko8ayG6E=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/zlib-1.3.1-r2.apk",
-        "version": "1.3.1-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/zlib-1.3.1-r3.apk",
+        "version": "1.3.1-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ykDkP+AmDi2VcZZ1c4q4sez/DxI=",
+        "checksum": "Q1rgbci8SRSjW7EB0NSh6ZUPJLndM=",
         "control": {
-          "checksum": "sha1-ykDkP+AmDi2VcZZ1c4q4sez/DxI=",
-          "range": "bytes=705-1079"
+          "checksum": "sha1-rgbci8SRSjW7EB0NSh6ZUPJLndM=",
+          "range": "bytes=702-1060"
         },
         "data": {
-          "checksum": "sha256-t3BrH7lWfY3to3Fu3EKAMZx29v9Hnl5seyXJzLmZ9/4=",
-          "range": "bytes=1080-251884"
+          "checksum": "sha256-tf4xbo+NP+ssiaZtC1kOKehffAZ3+d17bhgfU3/30+g=",
+          "range": "bytes=1061-256582"
         },
         "name": "libnghttp2-14",
         "signature": {
-          "checksum": "sha1-CotSXRaPLKQCBRHrgzrDOD+4w20=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-KrsJYTyUsll+EUhHekbkdZFzeig=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.62.1-r0.apk",
-        "version": "1.62.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.62.1-r1.apk",
+        "version": "1.62.1-r1"
       },
       {
         "architecture": "x86_64",
@@ -394,136 +394,136 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1DE49kWSnmqVKJdjHFYC1bLkvyb0=",
+        "checksum": "Q1R8OxpY0fGwVaIwft4wJeswF5D54=",
         "control": {
-          "checksum": "sha1-DE49kWSnmqVKJdjHFYC1bLkvyb0=",
-          "range": "bytes=697-1078"
+          "checksum": "sha1-R8OxpY0fGwVaIwft4wJeswF5D54=",
+          "range": "bytes=695-1059"
         },
         "data": {
-          "checksum": "sha256-uDg8Qc6Rnro/68Vb5ufFSkqFLGrEsbvPb0pMJNvT1zw=",
-          "range": "bytes=1079-242085"
+          "checksum": "sha256-wNc8/SBJrGHfwywAtzCsAqeUOt0IaAhqNtlbv8OiHBE=",
+          "range": "bytes=1060-242151"
         },
         "name": "c-ares",
         "signature": {
-          "checksum": "sha1-iYEm6EWQKzxkeoDm+QsRfhw8pDg=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-55/PTlEHXI3o0hx9dSVdNwQeSMg=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.29.0-r0.apk",
-        "version": "1.29.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.31.0-r0.apk",
+        "version": "1.31.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q12eWmn2tCkXxwncU6gagKM3Wd9Sk=",
+        "checksum": "Q1g2RQKAvNjlRPxWjinIRveaq7IlY=",
         "control": {
-          "checksum": "sha1-2eWmn2tCkXxwncU6gagKM3Wd9Sk=",
-          "range": "bytes=696-1169"
+          "checksum": "sha1-g2RQKAvNjlRPxWjinIRveaq7IlY=",
+          "range": "bytes=695-1154"
         },
         "data": {
-          "checksum": "sha256-IFKNdojOhml3DbWPryQuHUiV3tgTWHyqOYD1JNe9IJ4=",
-          "range": "bytes=1170-2582015"
+          "checksum": "sha256-UsQFfOTXCZBan0mxDvR+ts0NKcbv1lNijxnRxjsmZhA=",
+          "range": "bytes=1155-2566233"
         },
         "name": "nghttp2",
         "signature": {
-          "checksum": "sha1-2/9n7KbRuOkrvhYqCFR5Mblx+z8=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-SUvMhz1cc5Or5Qh4fUEvPCp0NAw=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.62.1-r0.apk",
-        "version": "1.62.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.62.1-r1.apk",
+        "version": "1.62.1-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ialksjwPWvvZW+O2ABMbbBV/KTg=",
+        "checksum": "Q1sTMGOgdbZyDKxlRAByisPMHTbpY=",
         "control": {
-          "checksum": "sha1-ialksjwPWvvZW+O2ABMbbBV/KTg=",
-          "range": "bytes=702-1074"
+          "checksum": "sha1-sTMGOgdbZyDKxlRAByisPMHTbpY=",
+          "range": "bytes=703-1060"
         },
         "data": {
-          "checksum": "sha256-+ctDr3AO9mTXovGRPWk6h2ZgfY99Toy6esjBNHtJPY4=",
-          "range": "bytes=1075-631903"
+          "checksum": "sha256-bUy0h/zxpq7iP6vrQRMftZ9nevkHTB87hSX17wz4lmM=",
+          "range": "bytes=1061-631449"
         },
         "name": "nghttp2-dev",
         "signature": {
-          "checksum": "sha1-wZGQRluFd6DL1USzeak75o5/BTc=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-fQ6aDq3Io/gdJ5s5t3M+FwED1Y0=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.62.1-r0.apk",
-        "version": "1.62.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.62.1-r1.apk",
+        "version": "1.62.1-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1MlpRL1nBMU3RgNdSZVB42/vlGME=",
+        "checksum": "Q1rD3dEbbN8s5QAIQK1I8uF1O+oSo=",
         "control": {
-          "checksum": "sha1-MlpRL1nBMU3RgNdSZVB42/vlGME=",
-          "range": "bytes=697-1164"
+          "checksum": "sha1-rD3dEbbN8s5QAIQK1I8uF1O+oSo=",
+          "range": "bytes=701-1154"
         },
         "data": {
-          "checksum": "sha256-RiEPDasBVtnThSxGqTCDvb4J7WXM9YRpJwfYZJ3JLbs=",
-          "range": "bytes=1165-2274746"
+          "checksum": "sha256-41W2IRSRALQijYojLaqAiSSN1uO7twatGn8jqEuCZUg=",
+          "range": "bytes=1155-1439872"
         },
         "name": "xz",
         "signature": {
-          "checksum": "sha1-3wMPFIUEVfkAs7QSENemZsnTLyE=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-lozWkVrKvSrd1SoM7Zv08YYG2pA=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/xz-5.4.6-r2.apk",
-        "version": "5.4.6-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/xz-5.6.2-r0.apk",
+        "version": "5.6.2-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1TS707T+cPGL7TYVHQBCJoWwHZ0E=",
+        "checksum": "Q10AaU1ocIM4PYYNvwbml8TmpNvEA=",
         "control": {
-          "checksum": "sha1-TS707T+cPGL7TYVHQBCJoWwHZ0E=",
-          "range": "bytes=706-1098"
+          "checksum": "sha1-0AaU1ocIM4PYYNvwbml8TmpNvEA=",
+          "range": "bytes=706-1085"
         },
         "data": {
-          "checksum": "sha256-x18L706Vug5qDzq13SXuN/vGdVgzrqB06dW2DdgHGR4=",
-          "range": "bytes=1099-4541967"
+          "checksum": "sha256-1YQNYASFjlP3kXX58ec8du75ij/U6O4DPAKzJAPkln0=",
+          "range": "bytes=1086-4272589"
         },
         "name": "libxml2",
         "signature": {
-          "checksum": "sha1-BYhOxDos48sN8df8LMsSpROv2aw=",
+          "checksum": "sha1-QFjdplzGn/MiNFxMykgafr6/w6U=",
           "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.12.7-r0.apk",
-        "version": "2.12.7-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.1-r1.apk",
+        "version": "2.13.1-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1wJPtj5XZtnPiVWGM5dsT+nyfWXc=",
+        "checksum": "Q1wbnfumlWEiJnVUsJBRcQjFD3U6I=",
         "control": {
-          "checksum": "sha1-wJPtj5XZtnPiVWGM5dsT+nyfWXc=",
-          "range": "bytes=705-1234"
+          "checksum": "sha1-wbnfumlWEiJnVUsJBRcQjFD3U6I=",
+          "range": "bytes=699-1222"
         },
         "data": {
-          "checksum": "sha256-sw+CjlpsjO01q6lqzXgHnniiJKn7bqOSNO6vNqdGc7I=",
-          "range": "bytes=1235-3873775"
+          "checksum": "sha256-IXMNbJjj3kTjkWVBIHVRfG3zJQY2r5Eslgh/3TpMSsE=",
+          "range": "bytes=1223-3886778"
         },
         "name": "bind-libs",
         "signature": {
-          "checksum": "sha1-9zDzmHAeu7mWpidXAatqrLZVzUs=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-JNN15IPpJ2hMsO6hFVpDYPvvX5g=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bind-libs-9.18.26-r0.apk",
-        "version": "9.18.26-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/bind-libs-9.18.27-r1.apk",
+        "version": "9.18.27-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1AxEQdi8fVcYtGc3zHTCW3OZdY2Q=",
+        "checksum": "Q1kXUOoNa2KXixxAASo1W/im1qZ7s=",
         "control": {
-          "checksum": "sha1-AxEQdi8fVcYtGc3zHTCW3OZdY2Q=",
-          "range": "bytes=694-1208"
+          "checksum": "sha1-kXUOoNa2KXixxAASo1W/im1qZ7s=",
+          "range": "bytes=702-1215"
         },
         "data": {
-          "checksum": "sha256-/dt3qJw5D9iSJ/mKkRQkhWD8R52selhpcwXyw7KLMhg=",
-          "range": "bytes=1209-879444"
+          "checksum": "sha256-HRADvfRXfYsgEjUMGM4Hd7prpIv+YWILVfovbGOkEME=",
+          "range": "bytes=1216-879975"
         },
         "name": "bind-tools",
         "signature": {
-          "checksum": "sha1-VTb0YdUzPMk8Po0p4nj0y5Jey6k=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-8WUTMUaJTaX0T9FS/c+GddL7ttY=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bind-tools-9.18.26-r0.apk",
-        "version": "9.18.26-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/bind-tools-9.18.27-r1.apk",
+        "version": "9.18.27-r1"
       },
       {
         "architecture": "x86_64",
@@ -622,60 +622,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1fr0OtiVaD3c5nw8fy5m74hDe9PU=",
+        "checksum": "Q1BRGmQ9LZTeZqbxQ1ls69T6efViw=",
         "control": {
-          "checksum": "sha1-fr0OtiVaD3c5nw8fy5m74hDe9PU=",
-          "range": "bytes=697-1092"
+          "checksum": "sha1-BRGmQ9LZTeZqbxQ1ls69T6efViw=",
+          "range": "bytes=698-1080"
         },
         "data": {
-          "checksum": "sha256-lukjMYpGmuhBNDUbbTJMIrUWaR4rNikEnW4BgiTaLj8=",
-          "range": "bytes=1093-113872"
+          "checksum": "sha256-vtJ4WJ5M+31ZKSBYBedbrl/FrbAw8hGpPRrHC7kasOk=",
+          "range": "bytes=1081-113895"
         },
         "name": "libpsl",
         "signature": {
-          "checksum": "sha1-Lrrudgn1i1a0JhjdzeXG+exnjQA=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-DuAoiykwhu8vu1qxdEDK5oyAmf8=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libpsl-0.21.5-r2.apk",
-        "version": "0.21.5-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libpsl-0.21.5-r3.apk",
+        "version": "0.21.5-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1oauHQa0YcFcEHSQWdfohfNEN4sY=",
+        "checksum": "Q11DZVpe2UYyDr/dG6BDysZhE3L48=",
         "control": {
-          "checksum": "sha1-oauHQa0YcFcEHSQWdfohfNEN4sY=",
-          "range": "bytes=698-1057"
+          "checksum": "sha1-1DZVpe2UYyDr/dG6BDysZhE3L48=",
+          "range": "bytes=707-1049"
         },
         "data": {
-          "checksum": "sha256-d95c9lpjQrpuZ1CcQ8ZZ89LAGGKcessd+hxrOQpP4LU=",
-          "range": "bytes=1058-173549"
+          "checksum": "sha256-aECfsy7giZsLNxZM0HMeF4OS2gu+ycX4DUTJXsiZRQs=",
+          "range": "bytes=1050-173585"
         },
         "name": "libbrotlicommon1",
         "signature": {
-          "checksum": "sha1-g3ufBq/tyiNP6AaOoqwItVvh7uk=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-7LXD38QwFhklZCEqyW4qIncfZV0=",
+          "range": "bytes=0-706"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlicommon1-1.1.0-r2.apk",
-        "version": "1.1.0-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlicommon1-1.1.0-r3.apk",
+        "version": "1.1.0-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q18Otq7NLoYnNMebI/1Rr/s0zdLVw=",
+        "checksum": "Q1Cgr886A8Ryzynz9pxRKsNybVuK0=",
         "control": {
-          "checksum": "sha1-8Otq7NLoYnNMebI/1Rr/s0zdLVw=",
-          "range": "bytes=705-1072"
+          "checksum": "sha1-Cgr886A8Ryzynz9pxRKsNybVuK0=",
+          "range": "bytes=694-1043"
         },
         "data": {
-          "checksum": "sha256-sR3QidR/e46PJ/3S2fxAjN/hRSSA3Ar32Nw7VshTHWg=",
-          "range": "bytes=1073-81475"
+          "checksum": "sha256-mH+MTbqpLiqgydlgE+tSDEt0Sh1/zqMvAqspV4lr+Ks=",
+          "range": "bytes=1044-81511"
         },
         "name": "libbrotlidec1",
         "signature": {
-          "checksum": "sha1-6GpZI5cBUXOvjCYG81aZZR53lMI=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-Yp4Bde9oHQCec8HM2qn6hVKgtko=",
+          "range": "bytes=0-693"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlidec1-1.1.0-r2.apk",
-        "version": "1.1.0-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlidec1-1.1.0-r3.apk",
+        "version": "1.1.0-r3"
       },
       {
         "architecture": "x86_64",
@@ -850,22 +850,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1GrI3roTx+zrOBnGfqb4bM1OYj6I=",
+        "checksum": "Q1pFBna33iXNWoxlANBI0dibfvT94=",
         "control": {
-          "checksum": "sha1-GrI3roTx+zrOBnGfqb4bM1OYj6I=",
-          "range": "bytes=702-1139"
+          "checksum": "sha1-pFBna33iXNWoxlANBI0dibfvT94=",
+          "range": "bytes=706-1129"
         },
         "data": {
-          "checksum": "sha256-DB4T1Bo94kP9/NuGNv0Vi0KzSaINmPY0hpICRStIKSE=",
-          "range": "bytes=1140-66640"
+          "checksum": "sha256-jsPjzi/shXYlr0zayGvJ82SSPVs4ew/DIy3L1hiuqdE=",
+          "range": "bytes=1130-66950"
         },
         "name": "libuuid",
         "signature": {
-          "checksum": "sha1-xVMkIcRSdv+/WzAYI6KvKvyW9WU=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-nVANm2v8k7qILW+g+xjNgr7yqQY=",
+          "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libuuid-2.39.3-r4.apk",
-        "version": "2.39.3-r4"
+        "url": "https://packages.wolfi.dev/os/x86_64/libuuid-2.40.1-r1.apk",
+        "version": "2.40.1-r1"
       },
       {
         "architecture": "x86_64",
@@ -907,22 +907,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ZMGiMSnjbScBstPVaw5qQfkNI+M=",
+        "checksum": "Q1w2/J0nDU8aA/f0HxunA5N19L1gw=",
         "control": {
-          "checksum": "sha1-ZMGiMSnjbScBstPVaw5qQfkNI+M=",
-          "range": "bytes=697-1097"
+          "checksum": "sha1-w2/J0nDU8aA/f0HxunA5N19L1gw=",
+          "range": "bytes=702-1086"
         },
         "data": {
-          "checksum": "sha256-XN2CeOJxCHWCgGpwTUkm5UOFKFz/eRpd7AReq4CqiOk=",
-          "range": "bytes=1098-1436391"
+          "checksum": "sha256-/2i+TNHbkrOsjrx7WHrrloXc6gcoyfyGrUHdBljYM+o=",
+          "range": "bytes=1087-1440232"
         },
         "name": "bash",
         "signature": {
-          "checksum": "sha1-t7/nmubimPIaw21oj0WlXgqY90E=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-tnYcLxCgV8srkBsTl4c/f6m11vQ=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bash-5.2.21-r4.apk",
-        "version": "5.2.21-r4"
+        "url": "https://packages.wolfi.dev/os/x86_64/bash-5.2.21-r5.apk",
+        "version": "5.2.21-r5"
       },
       {
         "architecture": "x86_64",
@@ -945,22 +945,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q19f/3419Xa/xv9jgQ0mMYs011fBk=",
+        "checksum": "Q1mTmy64gKYi4THBqewuvYL2uUyHc=",
         "control": {
-          "checksum": "sha1-9f/3419Xa/xv9jgQ0mMYs011fBk=",
-          "range": "bytes=696-1041"
+          "checksum": "sha1-mTmy64gKYi4THBqewuvYL2uUyHc=",
+          "range": "bytes=700-1031"
         },
         "data": {
-          "checksum": "sha256-iqHASiMgiu6rIjbWGwBmmq1Zthae8BkE4QZkiVPH7Ek=",
-          "range": "bytes=1042-1888945"
+          "checksum": "sha256-p0qua2luH33oAgOcLkU9f7k+I8WnykFszVMwNahujDA=",
+          "range": "bytes=1032-1889523"
         },
         "name": "tzdata",
         "signature": {
-          "checksum": "sha1-PCC3jiXlTwrimRMXH/4RyNvccOM=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-sBf5jVLVpWj4DiXaAd/mjo0pTfk=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/tzdata-2024a-r2.apk",
-        "version": "2024a-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/tzdata-2024a-r3.apk",
+        "version": "2024a-r3"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/prometheus.lock.json
+++ b/wolfi-images/prometheus.lock.json
@@ -14,41 +14,41 @@
     "packages": [
       {
         "architecture": "x86_64",
-        "checksum": "Q1ge3SLQsJ9v2RnvIHHAP1yFyjrEU=",
+        "checksum": "Q1Ai8jWuxKZR2M2XhOpOGAoTEwnnk=",
         "control": {
-          "checksum": "sha1-ge3SLQsJ9v2RnvIHHAP1yFyjrEU=",
-          "range": "bytes=693-1040"
+          "checksum": "sha1-Ai8jWuxKZR2M2XhOpOGAoTEwnnk=",
+          "range": "bytes=705-1037"
         },
         "data": {
-          "checksum": "sha256-I0AdTdfGf4P/jwzTrLXm73l5/RNSlymEof/YZfev3xY=",
-          "range": "bytes=1041-255811"
+          "checksum": "sha256-e4UardkBVyaC49aSyrVmXNi8sSKqQl4eKYd0LxGRLA0=",
+          "range": "bytes=1038-255695"
         },
         "name": "ca-certificates-bundle",
         "signature": {
-          "checksum": "sha1-ge1eJBiQmFWAn9GapFkQpO+Rn/Y=",
-          "range": "bytes=0-692"
+          "checksum": "sha1-loRuyYQLm+atp+YteiQoj++EWIM=",
+          "range": "bytes=0-704"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20240315-r3.apk",
-        "version": "20240315-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20240315-r4.apk",
+        "version": "20240315-r4"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1bgay5kOzpmDBgqJCg7dSlawyJg0=",
+        "checksum": "Q1+GH6qRN4iy1IDt0cT0x0tin7YfI=",
         "control": {
-          "checksum": "sha1-bgay5kOzpmDBgqJCg7dSlawyJg0=",
-          "range": "bytes=703-1067"
+          "checksum": "sha1-+GH6qRN4iy1IDt0cT0x0tin7YfI=",
+          "range": "bytes=703-1051"
         },
         "data": {
-          "checksum": "sha256-f83HfRE7r2ZniH7PyPmRqcoU5NTpF+Uk4FH80QbjvBM=",
-          "range": "bytes=1068-118370"
+          "checksum": "sha256-rO0P9z2V49BSrz1A5Ap69tEappVrg5MMBjzW00rOpZc=",
+          "range": "bytes=1052-122464"
         },
         "name": "wolfi-baselayout",
         "signature": {
-          "checksum": "sha1-2hlCvYH1D7u25HkJGA75jjs/sQY=",
+          "checksum": "sha1-Ntb6VuMzDfM+frpCjKEIpDzl53I=",
           "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r11.apk",
-        "version": "20230201-r11"
+        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r12.apk",
+        "version": "20230201-r12"
       },
       {
         "architecture": "x86_64",
@@ -109,41 +109,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Zjfs1uR/mYiortANP+EFcejW+vo=",
+        "checksum": "Q1Zi0e8Bq6WCd/6uXXjVhb8YwMD1U=",
         "control": {
-          "checksum": "sha1-Zjfs1uR/mYiortANP+EFcejW+vo=",
-          "range": "bytes=698-1085"
+          "checksum": "sha1-Zi0e8Bq6WCd/6uXXjVhb8YwMD1U=",
+          "range": "bytes=700-1073"
         },
         "data": {
-          "checksum": "sha256-BMd7TzffjbrFwdbopDPVYsX0X9XnusIMNbIf33/8kwc=",
-          "range": "bytes=1086-76881"
+          "checksum": "sha256-jMhtfqVjnhuuBO7wtNZ6RS/72sZWoKt/Moage2amlks=",
+          "range": "bytes=1074-81594"
         },
         "name": "protobuf-c",
         "signature": {
-          "checksum": "sha1-efGiXyYWsJ5P2uTkB6aXEZ3kl3o=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-kATwMKztK7nk7qbYCJPkCFp6IXc=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r4.apk",
-        "version": "1.5.0-r4"
-      },
-      {
-        "architecture": "x86_64",
-        "checksum": "Q1Xf5v5uXumBgIR4d4ZxMRxdpyWlM=",
-        "control": {
-          "checksum": "sha1-Xf5v5uXumBgIR4d4ZxMRxdpyWlM=",
-          "range": "bytes=698-1078"
-        },
-        "data": {
-          "checksum": "sha256-eD7HqFCWNUBQiLq9PcWE/zPeZwkiv8hBrytI4qmfQ/8=",
-          "range": "bytes=1079-57055"
-        },
-        "name": "keyutils-libs",
-        "signature": {
-          "checksum": "sha1-V0HVgZLP7P5kNACfus3abCLCS20=",
-          "range": "bytes=0-697"
-        },
-        "url": "https://packages.wolfi.dev/os/x86_64/keyutils-libs-1.6.3-r2.apk",
-        "version": "1.6.3-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r5.apk",
+        "version": "1.5.0-r5"
       },
       {
         "architecture": "x86_64",
@@ -166,22 +147,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1wRzOx+L6MeRFtTcq2y/6ot7Cj54=",
+        "checksum": "Q1v0A2vQM5k8rQY/GpIq6xI4T0YmA=",
         "control": {
-          "checksum": "sha1-wRzOx+L6MeRFtTcq2y/6ot7Cj54=",
-          "range": "bytes=699-1069"
+          "checksum": "sha1-v0A2vQM5k8rQY/GpIq6xI4T0YmA=",
+          "range": "bytes=701-1064"
         },
         "data": {
-          "checksum": "sha256-gNRjwZ4XQatCYWediSVb+j8lS54CggvMC5Dn3qT84So=",
-          "range": "bytes=1070-61490"
+          "checksum": "sha256-uAOrkGDDc/yqt6VjIrlTEALBJG4BCI4njqZw5jQqF0o=",
+          "range": "bytes=1065-56984"
+        },
+        "name": "keyutils-libs",
+        "signature": {
+          "checksum": "sha1-32uYMH/zGBr9Jo3hiqnThlcqBcE=",
+          "range": "bytes=0-700"
+        },
+        "url": "https://packages.wolfi.dev/os/x86_64/keyutils-libs-1.6.3-r3.apk",
+        "version": "1.6.3-r3"
+      },
+      {
+        "architecture": "x86_64",
+        "checksum": "Q1Onuac6Y+IWA7a4b8FvqX1erWDDw=",
+        "control": {
+          "checksum": "sha1-Onuac6Y+IWA7a4b8FvqX1erWDDw=",
+          "range": "bytes=693-1048"
+        },
+        "data": {
+          "checksum": "sha256-KLtDAs3iU0oyZ/FysePG/J+1H1ofDxHXIY7xvtZhtMc=",
+          "range": "bytes=1049-61503"
         },
         "name": "libverto",
         "signature": {
-          "checksum": "sha1-kuPwakYdy5EM6sd5Ba0K0Ta8x4w=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-/IXL9S1O+MwaW7KsSzz1ywEqKFQ=",
+          "range": "bytes=0-692"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libverto-0.3.2-r3.apk",
-        "version": "0.3.2-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/libverto-0.3.2-r4.apk",
+        "version": "0.3.2-r4"
       },
       {
         "architecture": "x86_64",
@@ -204,60 +204,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1gTZGkWP+QO3mUqLVJth8vrDEzzU=",
+        "checksum": "Q1Q/Zy5ovYSu2p/vVLr6DgVA1e8AQ=",
         "control": {
-          "checksum": "sha1-gTZGkWP+QO3mUqLVJth8vrDEzzU=",
-          "range": "bytes=699-1076"
+          "checksum": "sha1-Q/Zy5ovYSu2p/vVLr6DgVA1e8AQ=",
+          "range": "bytes=699-1062"
         },
         "data": {
-          "checksum": "sha256-/IFXqeKvU0GODNsz1yPIEMcFHgABT+8rbZpSlTLo4e4=",
-          "range": "bytes=1077-5915704"
+          "checksum": "sha256-H3jxsw8ytOeCIR4vq17voSVhdNokXk8C1g075txH6Bs=",
+          "range": "bytes=1063-5903754"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-l1o5ixkyWWqqJE3FOfR0QUemJUA=",
+          "checksum": "sha1-NIl2f5OI/wSZByI8Ds1ZUfbFWyw=",
           "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r9.apk",
-        "version": "3.3.0-r9"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.1-r3.apk",
+        "version": "3.3.1-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1jhAhggAuZnU7FFHnebGA26mq+jI=",
+        "checksum": "Q13wGUXdZut9OOTdY5z2amUj9wXC0=",
         "control": {
-          "checksum": "sha1-jhAhggAuZnU7FFHnebGA26mq+jI=",
-          "range": "bytes=695-1079"
+          "checksum": "sha1-3wGUXdZut9OOTdY5z2amUj9wXC0=",
+          "range": "bytes=698-1068"
         },
         "data": {
-          "checksum": "sha256-XTCQYnhGSm7SkGwqV/TQMFqGajVJVYhKAidKfLb2D3Y=",
-          "range": "bytes=1080-1197081"
+          "checksum": "sha256-mRda6+YGlOCczyIWKaHqXskTINoT1rgorHDHqAKAb7c=",
+          "range": "bytes=1069-1188955"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-qVrfDVxubkrb5Yrd2mFTv2A0G7k=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-+UdRc4U3PKw4H9OiNurHKXa5BYk=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r9.apk",
-        "version": "3.3.0-r9"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.1-r3.apk",
+        "version": "3.3.1-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1BQEXaeya6QB39QLeKcB99qBNF2o=",
+        "checksum": "Q1p04MrHQPrXOzuV/uF290zjnltqI=",
         "control": {
-          "checksum": "sha1-BQEXaeya6QB39QLeKcB99qBNF2o=",
-          "range": "bytes=699-1229"
+          "checksum": "sha1-p04MrHQPrXOzuV/uF290zjnltqI=",
+          "range": "bytes=704-1219"
         },
         "data": {
-          "checksum": "sha256-ugj/qGEBzhvdX17S22Anry+biy3lcqywhGMSHLIBCvo=",
-          "range": "bytes=1230-2551676"
+          "checksum": "sha256-TsXeqhUGykAhjQUEAlMUSzDQBcWDkkDvReoeHCL1F6c=",
+          "range": "bytes=1220-2555814"
         },
         "name": "krb5-libs",
         "signature": {
-          "checksum": "sha1-oqDPmNM4EngXAGayd/BZOqJAIao=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-cPyzS38QHuNlOCQb8IPlsl2PLHQ=",
+          "range": "bytes=0-703"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/krb5-libs-1.21.2-r2.apk",
-        "version": "1.21.2-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/krb5-libs-1.21.3-r0.apk",
+        "version": "1.21.3-r0"
       },
       {
         "architecture": "x86_64",
@@ -280,60 +280,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1wzZwtLauOQfLQC7YUvZdfKxtlwQ=",
+        "checksum": "Q17uprcuQ2VFudMcWAwtP7miJmLYs=",
         "control": {
-          "checksum": "sha1-wzZwtLauOQfLQC7YUvZdfKxtlwQ=",
-          "range": "bytes=698-1085"
+          "checksum": "sha1-7uprcuQ2VFudMcWAwtP7miJmLYs=",
+          "range": "bytes=695-1067"
         },
         "data": {
-          "checksum": "sha256-TO8CAULO44s/LphhtcaFOGJB7aFldk13v1cV9ceZHww=",
-          "range": "bytes=1086-276837"
+          "checksum": "sha256-unKdPbvO2VHZ5w1t1l8mOpQuNdUGwLhofEO4weN2Mig=",
+          "range": "bytes=1068-280973"
         },
         "name": "libuv",
         "signature": {
-          "checksum": "sha1-LRiyeKmjexy8CJizLxjd6ikon1w=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-4lKldnTO71WHMZ4tbANz6i2/Ed0=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libuv-1.48.0-r2.apk",
-        "version": "1.48.0-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libuv-1.48.0-r3.apk",
+        "version": "1.48.0-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q14S6biy8fc5OGbGEJoLBM+tJOGyo=",
+        "checksum": "Q1CN6zJbOPznWUfTrb/41KT7E6dm8=",
         "control": {
-          "checksum": "sha1-4S6biy8fc5OGbGEJoLBM+tJOGyo=",
-          "range": "bytes=703-1102"
+          "checksum": "sha1-CN6zJbOPznWUfTrb/41KT7E6dm8=",
+          "range": "bytes=699-1083"
         },
         "data": {
-          "checksum": "sha256-hwjdLQYfuMAGQeONmFVo0lZKKQK1S+3PBhrI3upm5W4=",
-          "range": "bytes=1103-155304"
+          "checksum": "sha256-ybzFzoQh1yNTcd3cjt54nYsPlAxAcMUcVMxEv1JRnpQ=",
+          "range": "bytes=1084-155375"
         },
         "name": "zlib",
         "signature": {
-          "checksum": "sha1-ZuLd7kE+AGhn27o8ZqDGM5eundc=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-CPXJcCjinAXP+H8Z5tkko8ayG6E=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/zlib-1.3.1-r2.apk",
-        "version": "1.3.1-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/zlib-1.3.1-r3.apk",
+        "version": "1.3.1-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ykDkP+AmDi2VcZZ1c4q4sez/DxI=",
+        "checksum": "Q1rgbci8SRSjW7EB0NSh6ZUPJLndM=",
         "control": {
-          "checksum": "sha1-ykDkP+AmDi2VcZZ1c4q4sez/DxI=",
-          "range": "bytes=705-1079"
+          "checksum": "sha1-rgbci8SRSjW7EB0NSh6ZUPJLndM=",
+          "range": "bytes=702-1060"
         },
         "data": {
-          "checksum": "sha256-t3BrH7lWfY3to3Fu3EKAMZx29v9Hnl5seyXJzLmZ9/4=",
-          "range": "bytes=1080-251884"
+          "checksum": "sha256-tf4xbo+NP+ssiaZtC1kOKehffAZ3+d17bhgfU3/30+g=",
+          "range": "bytes=1061-256582"
         },
         "name": "libnghttp2-14",
         "signature": {
-          "checksum": "sha1-CotSXRaPLKQCBRHrgzrDOD+4w20=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-KrsJYTyUsll+EUhHekbkdZFzeig=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.62.1-r0.apk",
-        "version": "1.62.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.62.1-r1.apk",
+        "version": "1.62.1-r1"
       },
       {
         "architecture": "x86_64",
@@ -394,136 +394,136 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1DE49kWSnmqVKJdjHFYC1bLkvyb0=",
+        "checksum": "Q1R8OxpY0fGwVaIwft4wJeswF5D54=",
         "control": {
-          "checksum": "sha1-DE49kWSnmqVKJdjHFYC1bLkvyb0=",
-          "range": "bytes=697-1078"
+          "checksum": "sha1-R8OxpY0fGwVaIwft4wJeswF5D54=",
+          "range": "bytes=695-1059"
         },
         "data": {
-          "checksum": "sha256-uDg8Qc6Rnro/68Vb5ufFSkqFLGrEsbvPb0pMJNvT1zw=",
-          "range": "bytes=1079-242085"
+          "checksum": "sha256-wNc8/SBJrGHfwywAtzCsAqeUOt0IaAhqNtlbv8OiHBE=",
+          "range": "bytes=1060-242151"
         },
         "name": "c-ares",
         "signature": {
-          "checksum": "sha1-iYEm6EWQKzxkeoDm+QsRfhw8pDg=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-55/PTlEHXI3o0hx9dSVdNwQeSMg=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.29.0-r0.apk",
-        "version": "1.29.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.31.0-r0.apk",
+        "version": "1.31.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q12eWmn2tCkXxwncU6gagKM3Wd9Sk=",
+        "checksum": "Q1g2RQKAvNjlRPxWjinIRveaq7IlY=",
         "control": {
-          "checksum": "sha1-2eWmn2tCkXxwncU6gagKM3Wd9Sk=",
-          "range": "bytes=696-1169"
+          "checksum": "sha1-g2RQKAvNjlRPxWjinIRveaq7IlY=",
+          "range": "bytes=695-1154"
         },
         "data": {
-          "checksum": "sha256-IFKNdojOhml3DbWPryQuHUiV3tgTWHyqOYD1JNe9IJ4=",
-          "range": "bytes=1170-2582015"
+          "checksum": "sha256-UsQFfOTXCZBan0mxDvR+ts0NKcbv1lNijxnRxjsmZhA=",
+          "range": "bytes=1155-2566233"
         },
         "name": "nghttp2",
         "signature": {
-          "checksum": "sha1-2/9n7KbRuOkrvhYqCFR5Mblx+z8=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-SUvMhz1cc5Or5Qh4fUEvPCp0NAw=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.62.1-r0.apk",
-        "version": "1.62.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.62.1-r1.apk",
+        "version": "1.62.1-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ialksjwPWvvZW+O2ABMbbBV/KTg=",
+        "checksum": "Q1sTMGOgdbZyDKxlRAByisPMHTbpY=",
         "control": {
-          "checksum": "sha1-ialksjwPWvvZW+O2ABMbbBV/KTg=",
-          "range": "bytes=702-1074"
+          "checksum": "sha1-sTMGOgdbZyDKxlRAByisPMHTbpY=",
+          "range": "bytes=703-1060"
         },
         "data": {
-          "checksum": "sha256-+ctDr3AO9mTXovGRPWk6h2ZgfY99Toy6esjBNHtJPY4=",
-          "range": "bytes=1075-631903"
+          "checksum": "sha256-bUy0h/zxpq7iP6vrQRMftZ9nevkHTB87hSX17wz4lmM=",
+          "range": "bytes=1061-631449"
         },
         "name": "nghttp2-dev",
         "signature": {
-          "checksum": "sha1-wZGQRluFd6DL1USzeak75o5/BTc=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-fQ6aDq3Io/gdJ5s5t3M+FwED1Y0=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.62.1-r0.apk",
-        "version": "1.62.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.62.1-r1.apk",
+        "version": "1.62.1-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1MlpRL1nBMU3RgNdSZVB42/vlGME=",
+        "checksum": "Q1rD3dEbbN8s5QAIQK1I8uF1O+oSo=",
         "control": {
-          "checksum": "sha1-MlpRL1nBMU3RgNdSZVB42/vlGME=",
-          "range": "bytes=697-1164"
+          "checksum": "sha1-rD3dEbbN8s5QAIQK1I8uF1O+oSo=",
+          "range": "bytes=701-1154"
         },
         "data": {
-          "checksum": "sha256-RiEPDasBVtnThSxGqTCDvb4J7WXM9YRpJwfYZJ3JLbs=",
-          "range": "bytes=1165-2274746"
+          "checksum": "sha256-41W2IRSRALQijYojLaqAiSSN1uO7twatGn8jqEuCZUg=",
+          "range": "bytes=1155-1439872"
         },
         "name": "xz",
         "signature": {
-          "checksum": "sha1-3wMPFIUEVfkAs7QSENemZsnTLyE=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-lozWkVrKvSrd1SoM7Zv08YYG2pA=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/xz-5.4.6-r2.apk",
-        "version": "5.4.6-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/xz-5.6.2-r0.apk",
+        "version": "5.6.2-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1TS707T+cPGL7TYVHQBCJoWwHZ0E=",
+        "checksum": "Q10AaU1ocIM4PYYNvwbml8TmpNvEA=",
         "control": {
-          "checksum": "sha1-TS707T+cPGL7TYVHQBCJoWwHZ0E=",
-          "range": "bytes=706-1098"
+          "checksum": "sha1-0AaU1ocIM4PYYNvwbml8TmpNvEA=",
+          "range": "bytes=706-1085"
         },
         "data": {
-          "checksum": "sha256-x18L706Vug5qDzq13SXuN/vGdVgzrqB06dW2DdgHGR4=",
-          "range": "bytes=1099-4541967"
+          "checksum": "sha256-1YQNYASFjlP3kXX58ec8du75ij/U6O4DPAKzJAPkln0=",
+          "range": "bytes=1086-4272589"
         },
         "name": "libxml2",
         "signature": {
-          "checksum": "sha1-BYhOxDos48sN8df8LMsSpROv2aw=",
+          "checksum": "sha1-QFjdplzGn/MiNFxMykgafr6/w6U=",
           "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.12.7-r0.apk",
-        "version": "2.12.7-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.1-r1.apk",
+        "version": "2.13.1-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1wJPtj5XZtnPiVWGM5dsT+nyfWXc=",
+        "checksum": "Q1wbnfumlWEiJnVUsJBRcQjFD3U6I=",
         "control": {
-          "checksum": "sha1-wJPtj5XZtnPiVWGM5dsT+nyfWXc=",
-          "range": "bytes=705-1234"
+          "checksum": "sha1-wbnfumlWEiJnVUsJBRcQjFD3U6I=",
+          "range": "bytes=699-1222"
         },
         "data": {
-          "checksum": "sha256-sw+CjlpsjO01q6lqzXgHnniiJKn7bqOSNO6vNqdGc7I=",
-          "range": "bytes=1235-3873775"
+          "checksum": "sha256-IXMNbJjj3kTjkWVBIHVRfG3zJQY2r5Eslgh/3TpMSsE=",
+          "range": "bytes=1223-3886778"
         },
         "name": "bind-libs",
         "signature": {
-          "checksum": "sha1-9zDzmHAeu7mWpidXAatqrLZVzUs=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-JNN15IPpJ2hMsO6hFVpDYPvvX5g=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bind-libs-9.18.26-r0.apk",
-        "version": "9.18.26-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/bind-libs-9.18.27-r1.apk",
+        "version": "9.18.27-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1AxEQdi8fVcYtGc3zHTCW3OZdY2Q=",
+        "checksum": "Q1kXUOoNa2KXixxAASo1W/im1qZ7s=",
         "control": {
-          "checksum": "sha1-AxEQdi8fVcYtGc3zHTCW3OZdY2Q=",
-          "range": "bytes=694-1208"
+          "checksum": "sha1-kXUOoNa2KXixxAASo1W/im1qZ7s=",
+          "range": "bytes=702-1215"
         },
         "data": {
-          "checksum": "sha256-/dt3qJw5D9iSJ/mKkRQkhWD8R52selhpcwXyw7KLMhg=",
-          "range": "bytes=1209-879444"
+          "checksum": "sha256-HRADvfRXfYsgEjUMGM4Hd7prpIv+YWILVfovbGOkEME=",
+          "range": "bytes=1216-879975"
         },
         "name": "bind-tools",
         "signature": {
-          "checksum": "sha1-VTb0YdUzPMk8Po0p4nj0y5Jey6k=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-8WUTMUaJTaX0T9FS/c+GddL7ttY=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bind-tools-9.18.26-r0.apk",
-        "version": "9.18.26-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/bind-tools-9.18.27-r1.apk",
+        "version": "9.18.27-r1"
       },
       {
         "architecture": "x86_64",
@@ -622,60 +622,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1fr0OtiVaD3c5nw8fy5m74hDe9PU=",
+        "checksum": "Q1BRGmQ9LZTeZqbxQ1ls69T6efViw=",
         "control": {
-          "checksum": "sha1-fr0OtiVaD3c5nw8fy5m74hDe9PU=",
-          "range": "bytes=697-1092"
+          "checksum": "sha1-BRGmQ9LZTeZqbxQ1ls69T6efViw=",
+          "range": "bytes=698-1080"
         },
         "data": {
-          "checksum": "sha256-lukjMYpGmuhBNDUbbTJMIrUWaR4rNikEnW4BgiTaLj8=",
-          "range": "bytes=1093-113872"
+          "checksum": "sha256-vtJ4WJ5M+31ZKSBYBedbrl/FrbAw8hGpPRrHC7kasOk=",
+          "range": "bytes=1081-113895"
         },
         "name": "libpsl",
         "signature": {
-          "checksum": "sha1-Lrrudgn1i1a0JhjdzeXG+exnjQA=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-DuAoiykwhu8vu1qxdEDK5oyAmf8=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libpsl-0.21.5-r2.apk",
-        "version": "0.21.5-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libpsl-0.21.5-r3.apk",
+        "version": "0.21.5-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1oauHQa0YcFcEHSQWdfohfNEN4sY=",
+        "checksum": "Q11DZVpe2UYyDr/dG6BDysZhE3L48=",
         "control": {
-          "checksum": "sha1-oauHQa0YcFcEHSQWdfohfNEN4sY=",
-          "range": "bytes=698-1057"
+          "checksum": "sha1-1DZVpe2UYyDr/dG6BDysZhE3L48=",
+          "range": "bytes=707-1049"
         },
         "data": {
-          "checksum": "sha256-d95c9lpjQrpuZ1CcQ8ZZ89LAGGKcessd+hxrOQpP4LU=",
-          "range": "bytes=1058-173549"
+          "checksum": "sha256-aECfsy7giZsLNxZM0HMeF4OS2gu+ycX4DUTJXsiZRQs=",
+          "range": "bytes=1050-173585"
         },
         "name": "libbrotlicommon1",
         "signature": {
-          "checksum": "sha1-g3ufBq/tyiNP6AaOoqwItVvh7uk=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-7LXD38QwFhklZCEqyW4qIncfZV0=",
+          "range": "bytes=0-706"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlicommon1-1.1.0-r2.apk",
-        "version": "1.1.0-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlicommon1-1.1.0-r3.apk",
+        "version": "1.1.0-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q18Otq7NLoYnNMebI/1Rr/s0zdLVw=",
+        "checksum": "Q1Cgr886A8Ryzynz9pxRKsNybVuK0=",
         "control": {
-          "checksum": "sha1-8Otq7NLoYnNMebI/1Rr/s0zdLVw=",
-          "range": "bytes=705-1072"
+          "checksum": "sha1-Cgr886A8Ryzynz9pxRKsNybVuK0=",
+          "range": "bytes=694-1043"
         },
         "data": {
-          "checksum": "sha256-sR3QidR/e46PJ/3S2fxAjN/hRSSA3Ar32Nw7VshTHWg=",
-          "range": "bytes=1073-81475"
+          "checksum": "sha256-mH+MTbqpLiqgydlgE+tSDEt0Sh1/zqMvAqspV4lr+Ks=",
+          "range": "bytes=1044-81511"
         },
         "name": "libbrotlidec1",
         "signature": {
-          "checksum": "sha1-6GpZI5cBUXOvjCYG81aZZR53lMI=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-Yp4Bde9oHQCec8HM2qn6hVKgtko=",
+          "range": "bytes=0-693"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlidec1-1.1.0-r2.apk",
-        "version": "1.1.0-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlidec1-1.1.0-r3.apk",
+        "version": "1.1.0-r3"
       },
       {
         "architecture": "x86_64",
@@ -736,22 +736,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1KHnJp4dgXxm50FeWqVm7Lu2Rm3o=",
+        "checksum": "Q1K7zkV+ytg2NfGl9Sq0L07g7m3t8=",
         "control": {
-          "checksum": "sha1-KHnJp4dgXxm50FeWqVm7Lu2Rm3o=",
-          "range": "bytes=696-1138"
+          "checksum": "sha1-K7zkV+ytg2NfGl9Sq0L07g7m3t8=",
+          "range": "bytes=703-1134"
         },
         "data": {
-          "checksum": "sha256-wWq5y1hEpcKhQ1QnvOKJHsnPxcD7/X7IEViso75B9bs=",
-          "range": "bytes=1139-192875683"
+          "checksum": "sha256-R8lBnMUORssXrz1Ph1NoBz+/StjHKbjVjNDDtSvb0Zs=",
+          "range": "bytes=1135-191882402"
         },
-        "name": "prometheus-2.52",
+        "name": "prometheus-2.53",
         "signature": {
-          "checksum": "sha1-3JjyUbZtACAX5ljsTN4qs1Qekqk=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-LHetuVjR91DCOcHkyTC91kBA3vY=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/prometheus-2.52-2.52.0-r3.apk",
-        "version": "2.52.0-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/prometheus-2.53-2.53.0-r2.apk",
+        "version": "2.53.0-r2"
       },
       {
         "architecture": "x86_64",
@@ -793,22 +793,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q19f/3419Xa/xv9jgQ0mMYs011fBk=",
+        "checksum": "Q1mTmy64gKYi4THBqewuvYL2uUyHc=",
         "control": {
-          "checksum": "sha1-9f/3419Xa/xv9jgQ0mMYs011fBk=",
-          "range": "bytes=696-1041"
+          "checksum": "sha1-mTmy64gKYi4THBqewuvYL2uUyHc=",
+          "range": "bytes=700-1031"
         },
         "data": {
-          "checksum": "sha256-iqHASiMgiu6rIjbWGwBmmq1Zthae8BkE4QZkiVPH7Ek=",
-          "range": "bytes=1042-1888945"
+          "checksum": "sha256-p0qua2luH33oAgOcLkU9f7k+I8WnykFszVMwNahujDA=",
+          "range": "bytes=1032-1889523"
         },
         "name": "tzdata",
         "signature": {
-          "checksum": "sha1-PCC3jiXlTwrimRMXH/4RyNvccOM=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-sBf5jVLVpWj4DiXaAd/mjo0pTfk=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/tzdata-2024a-r2.apk",
-        "version": "2024a-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/tzdata-2024a-r3.apk",
+        "version": "2024a-r3"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/redis-exporter.lock.json
+++ b/wolfi-images/redis-exporter.lock.json
@@ -14,41 +14,41 @@
     "packages": [
       {
         "architecture": "x86_64",
-        "checksum": "Q1ge3SLQsJ9v2RnvIHHAP1yFyjrEU=",
+        "checksum": "Q1Ai8jWuxKZR2M2XhOpOGAoTEwnnk=",
         "control": {
-          "checksum": "sha1-ge3SLQsJ9v2RnvIHHAP1yFyjrEU=",
-          "range": "bytes=693-1040"
+          "checksum": "sha1-Ai8jWuxKZR2M2XhOpOGAoTEwnnk=",
+          "range": "bytes=705-1037"
         },
         "data": {
-          "checksum": "sha256-I0AdTdfGf4P/jwzTrLXm73l5/RNSlymEof/YZfev3xY=",
-          "range": "bytes=1041-255811"
+          "checksum": "sha256-e4UardkBVyaC49aSyrVmXNi8sSKqQl4eKYd0LxGRLA0=",
+          "range": "bytes=1038-255695"
         },
         "name": "ca-certificates-bundle",
         "signature": {
-          "checksum": "sha1-ge1eJBiQmFWAn9GapFkQpO+Rn/Y=",
-          "range": "bytes=0-692"
+          "checksum": "sha1-loRuyYQLm+atp+YteiQoj++EWIM=",
+          "range": "bytes=0-704"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20240315-r3.apk",
-        "version": "20240315-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20240315-r4.apk",
+        "version": "20240315-r4"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1bgay5kOzpmDBgqJCg7dSlawyJg0=",
+        "checksum": "Q1+GH6qRN4iy1IDt0cT0x0tin7YfI=",
         "control": {
-          "checksum": "sha1-bgay5kOzpmDBgqJCg7dSlawyJg0=",
-          "range": "bytes=703-1067"
+          "checksum": "sha1-+GH6qRN4iy1IDt0cT0x0tin7YfI=",
+          "range": "bytes=703-1051"
         },
         "data": {
-          "checksum": "sha256-f83HfRE7r2ZniH7PyPmRqcoU5NTpF+Uk4FH80QbjvBM=",
-          "range": "bytes=1068-118370"
+          "checksum": "sha256-rO0P9z2V49BSrz1A5Ap69tEappVrg5MMBjzW00rOpZc=",
+          "range": "bytes=1052-122464"
         },
         "name": "wolfi-baselayout",
         "signature": {
-          "checksum": "sha1-2hlCvYH1D7u25HkJGA75jjs/sQY=",
+          "checksum": "sha1-Ntb6VuMzDfM+frpCjKEIpDzl53I=",
           "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r11.apk",
-        "version": "20230201-r11"
+        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r12.apk",
+        "version": "20230201-r12"
       },
       {
         "architecture": "x86_64",
@@ -109,41 +109,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Zjfs1uR/mYiortANP+EFcejW+vo=",
+        "checksum": "Q1Zi0e8Bq6WCd/6uXXjVhb8YwMD1U=",
         "control": {
-          "checksum": "sha1-Zjfs1uR/mYiortANP+EFcejW+vo=",
-          "range": "bytes=698-1085"
+          "checksum": "sha1-Zi0e8Bq6WCd/6uXXjVhb8YwMD1U=",
+          "range": "bytes=700-1073"
         },
         "data": {
-          "checksum": "sha256-BMd7TzffjbrFwdbopDPVYsX0X9XnusIMNbIf33/8kwc=",
-          "range": "bytes=1086-76881"
+          "checksum": "sha256-jMhtfqVjnhuuBO7wtNZ6RS/72sZWoKt/Moage2amlks=",
+          "range": "bytes=1074-81594"
         },
         "name": "protobuf-c",
         "signature": {
-          "checksum": "sha1-efGiXyYWsJ5P2uTkB6aXEZ3kl3o=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-kATwMKztK7nk7qbYCJPkCFp6IXc=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r4.apk",
-        "version": "1.5.0-r4"
-      },
-      {
-        "architecture": "x86_64",
-        "checksum": "Q1Xf5v5uXumBgIR4d4ZxMRxdpyWlM=",
-        "control": {
-          "checksum": "sha1-Xf5v5uXumBgIR4d4ZxMRxdpyWlM=",
-          "range": "bytes=698-1078"
-        },
-        "data": {
-          "checksum": "sha256-eD7HqFCWNUBQiLq9PcWE/zPeZwkiv8hBrytI4qmfQ/8=",
-          "range": "bytes=1079-57055"
-        },
-        "name": "keyutils-libs",
-        "signature": {
-          "checksum": "sha1-V0HVgZLP7P5kNACfus3abCLCS20=",
-          "range": "bytes=0-697"
-        },
-        "url": "https://packages.wolfi.dev/os/x86_64/keyutils-libs-1.6.3-r2.apk",
-        "version": "1.6.3-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r5.apk",
+        "version": "1.5.0-r5"
       },
       {
         "architecture": "x86_64",
@@ -166,22 +147,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1wRzOx+L6MeRFtTcq2y/6ot7Cj54=",
+        "checksum": "Q1v0A2vQM5k8rQY/GpIq6xI4T0YmA=",
         "control": {
-          "checksum": "sha1-wRzOx+L6MeRFtTcq2y/6ot7Cj54=",
-          "range": "bytes=699-1069"
+          "checksum": "sha1-v0A2vQM5k8rQY/GpIq6xI4T0YmA=",
+          "range": "bytes=701-1064"
         },
         "data": {
-          "checksum": "sha256-gNRjwZ4XQatCYWediSVb+j8lS54CggvMC5Dn3qT84So=",
-          "range": "bytes=1070-61490"
+          "checksum": "sha256-uAOrkGDDc/yqt6VjIrlTEALBJG4BCI4njqZw5jQqF0o=",
+          "range": "bytes=1065-56984"
+        },
+        "name": "keyutils-libs",
+        "signature": {
+          "checksum": "sha1-32uYMH/zGBr9Jo3hiqnThlcqBcE=",
+          "range": "bytes=0-700"
+        },
+        "url": "https://packages.wolfi.dev/os/x86_64/keyutils-libs-1.6.3-r3.apk",
+        "version": "1.6.3-r3"
+      },
+      {
+        "architecture": "x86_64",
+        "checksum": "Q1Onuac6Y+IWA7a4b8FvqX1erWDDw=",
+        "control": {
+          "checksum": "sha1-Onuac6Y+IWA7a4b8FvqX1erWDDw=",
+          "range": "bytes=693-1048"
+        },
+        "data": {
+          "checksum": "sha256-KLtDAs3iU0oyZ/FysePG/J+1H1ofDxHXIY7xvtZhtMc=",
+          "range": "bytes=1049-61503"
         },
         "name": "libverto",
         "signature": {
-          "checksum": "sha1-kuPwakYdy5EM6sd5Ba0K0Ta8x4w=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-/IXL9S1O+MwaW7KsSzz1ywEqKFQ=",
+          "range": "bytes=0-692"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libverto-0.3.2-r3.apk",
-        "version": "0.3.2-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/libverto-0.3.2-r4.apk",
+        "version": "0.3.2-r4"
       },
       {
         "architecture": "x86_64",
@@ -204,60 +204,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1gTZGkWP+QO3mUqLVJth8vrDEzzU=",
+        "checksum": "Q1Q/Zy5ovYSu2p/vVLr6DgVA1e8AQ=",
         "control": {
-          "checksum": "sha1-gTZGkWP+QO3mUqLVJth8vrDEzzU=",
-          "range": "bytes=699-1076"
+          "checksum": "sha1-Q/Zy5ovYSu2p/vVLr6DgVA1e8AQ=",
+          "range": "bytes=699-1062"
         },
         "data": {
-          "checksum": "sha256-/IFXqeKvU0GODNsz1yPIEMcFHgABT+8rbZpSlTLo4e4=",
-          "range": "bytes=1077-5915704"
+          "checksum": "sha256-H3jxsw8ytOeCIR4vq17voSVhdNokXk8C1g075txH6Bs=",
+          "range": "bytes=1063-5903754"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-l1o5ixkyWWqqJE3FOfR0QUemJUA=",
+          "checksum": "sha1-NIl2f5OI/wSZByI8Ds1ZUfbFWyw=",
           "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r9.apk",
-        "version": "3.3.0-r9"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.1-r3.apk",
+        "version": "3.3.1-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1jhAhggAuZnU7FFHnebGA26mq+jI=",
+        "checksum": "Q13wGUXdZut9OOTdY5z2amUj9wXC0=",
         "control": {
-          "checksum": "sha1-jhAhggAuZnU7FFHnebGA26mq+jI=",
-          "range": "bytes=695-1079"
+          "checksum": "sha1-3wGUXdZut9OOTdY5z2amUj9wXC0=",
+          "range": "bytes=698-1068"
         },
         "data": {
-          "checksum": "sha256-XTCQYnhGSm7SkGwqV/TQMFqGajVJVYhKAidKfLb2D3Y=",
-          "range": "bytes=1080-1197081"
+          "checksum": "sha256-mRda6+YGlOCczyIWKaHqXskTINoT1rgorHDHqAKAb7c=",
+          "range": "bytes=1069-1188955"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-qVrfDVxubkrb5Yrd2mFTv2A0G7k=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-+UdRc4U3PKw4H9OiNurHKXa5BYk=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r9.apk",
-        "version": "3.3.0-r9"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.1-r3.apk",
+        "version": "3.3.1-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1BQEXaeya6QB39QLeKcB99qBNF2o=",
+        "checksum": "Q1p04MrHQPrXOzuV/uF290zjnltqI=",
         "control": {
-          "checksum": "sha1-BQEXaeya6QB39QLeKcB99qBNF2o=",
-          "range": "bytes=699-1229"
+          "checksum": "sha1-p04MrHQPrXOzuV/uF290zjnltqI=",
+          "range": "bytes=704-1219"
         },
         "data": {
-          "checksum": "sha256-ugj/qGEBzhvdX17S22Anry+biy3lcqywhGMSHLIBCvo=",
-          "range": "bytes=1230-2551676"
+          "checksum": "sha256-TsXeqhUGykAhjQUEAlMUSzDQBcWDkkDvReoeHCL1F6c=",
+          "range": "bytes=1220-2555814"
         },
         "name": "krb5-libs",
         "signature": {
-          "checksum": "sha1-oqDPmNM4EngXAGayd/BZOqJAIao=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-cPyzS38QHuNlOCQb8IPlsl2PLHQ=",
+          "range": "bytes=0-703"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/krb5-libs-1.21.2-r2.apk",
-        "version": "1.21.2-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/krb5-libs-1.21.3-r0.apk",
+        "version": "1.21.3-r0"
       },
       {
         "architecture": "x86_64",
@@ -280,60 +280,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1wzZwtLauOQfLQC7YUvZdfKxtlwQ=",
+        "checksum": "Q17uprcuQ2VFudMcWAwtP7miJmLYs=",
         "control": {
-          "checksum": "sha1-wzZwtLauOQfLQC7YUvZdfKxtlwQ=",
-          "range": "bytes=698-1085"
+          "checksum": "sha1-7uprcuQ2VFudMcWAwtP7miJmLYs=",
+          "range": "bytes=695-1067"
         },
         "data": {
-          "checksum": "sha256-TO8CAULO44s/LphhtcaFOGJB7aFldk13v1cV9ceZHww=",
-          "range": "bytes=1086-276837"
+          "checksum": "sha256-unKdPbvO2VHZ5w1t1l8mOpQuNdUGwLhofEO4weN2Mig=",
+          "range": "bytes=1068-280973"
         },
         "name": "libuv",
         "signature": {
-          "checksum": "sha1-LRiyeKmjexy8CJizLxjd6ikon1w=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-4lKldnTO71WHMZ4tbANz6i2/Ed0=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libuv-1.48.0-r2.apk",
-        "version": "1.48.0-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libuv-1.48.0-r3.apk",
+        "version": "1.48.0-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q14S6biy8fc5OGbGEJoLBM+tJOGyo=",
+        "checksum": "Q1CN6zJbOPznWUfTrb/41KT7E6dm8=",
         "control": {
-          "checksum": "sha1-4S6biy8fc5OGbGEJoLBM+tJOGyo=",
-          "range": "bytes=703-1102"
+          "checksum": "sha1-CN6zJbOPznWUfTrb/41KT7E6dm8=",
+          "range": "bytes=699-1083"
         },
         "data": {
-          "checksum": "sha256-hwjdLQYfuMAGQeONmFVo0lZKKQK1S+3PBhrI3upm5W4=",
-          "range": "bytes=1103-155304"
+          "checksum": "sha256-ybzFzoQh1yNTcd3cjt54nYsPlAxAcMUcVMxEv1JRnpQ=",
+          "range": "bytes=1084-155375"
         },
         "name": "zlib",
         "signature": {
-          "checksum": "sha1-ZuLd7kE+AGhn27o8ZqDGM5eundc=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-CPXJcCjinAXP+H8Z5tkko8ayG6E=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/zlib-1.3.1-r2.apk",
-        "version": "1.3.1-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/zlib-1.3.1-r3.apk",
+        "version": "1.3.1-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ykDkP+AmDi2VcZZ1c4q4sez/DxI=",
+        "checksum": "Q1rgbci8SRSjW7EB0NSh6ZUPJLndM=",
         "control": {
-          "checksum": "sha1-ykDkP+AmDi2VcZZ1c4q4sez/DxI=",
-          "range": "bytes=705-1079"
+          "checksum": "sha1-rgbci8SRSjW7EB0NSh6ZUPJLndM=",
+          "range": "bytes=702-1060"
         },
         "data": {
-          "checksum": "sha256-t3BrH7lWfY3to3Fu3EKAMZx29v9Hnl5seyXJzLmZ9/4=",
-          "range": "bytes=1080-251884"
+          "checksum": "sha256-tf4xbo+NP+ssiaZtC1kOKehffAZ3+d17bhgfU3/30+g=",
+          "range": "bytes=1061-256582"
         },
         "name": "libnghttp2-14",
         "signature": {
-          "checksum": "sha1-CotSXRaPLKQCBRHrgzrDOD+4w20=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-KrsJYTyUsll+EUhHekbkdZFzeig=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.62.1-r0.apk",
-        "version": "1.62.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.62.1-r1.apk",
+        "version": "1.62.1-r1"
       },
       {
         "architecture": "x86_64",
@@ -394,136 +394,136 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1DE49kWSnmqVKJdjHFYC1bLkvyb0=",
+        "checksum": "Q1R8OxpY0fGwVaIwft4wJeswF5D54=",
         "control": {
-          "checksum": "sha1-DE49kWSnmqVKJdjHFYC1bLkvyb0=",
-          "range": "bytes=697-1078"
+          "checksum": "sha1-R8OxpY0fGwVaIwft4wJeswF5D54=",
+          "range": "bytes=695-1059"
         },
         "data": {
-          "checksum": "sha256-uDg8Qc6Rnro/68Vb5ufFSkqFLGrEsbvPb0pMJNvT1zw=",
-          "range": "bytes=1079-242085"
+          "checksum": "sha256-wNc8/SBJrGHfwywAtzCsAqeUOt0IaAhqNtlbv8OiHBE=",
+          "range": "bytes=1060-242151"
         },
         "name": "c-ares",
         "signature": {
-          "checksum": "sha1-iYEm6EWQKzxkeoDm+QsRfhw8pDg=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-55/PTlEHXI3o0hx9dSVdNwQeSMg=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.29.0-r0.apk",
-        "version": "1.29.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.31.0-r0.apk",
+        "version": "1.31.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q12eWmn2tCkXxwncU6gagKM3Wd9Sk=",
+        "checksum": "Q1g2RQKAvNjlRPxWjinIRveaq7IlY=",
         "control": {
-          "checksum": "sha1-2eWmn2tCkXxwncU6gagKM3Wd9Sk=",
-          "range": "bytes=696-1169"
+          "checksum": "sha1-g2RQKAvNjlRPxWjinIRveaq7IlY=",
+          "range": "bytes=695-1154"
         },
         "data": {
-          "checksum": "sha256-IFKNdojOhml3DbWPryQuHUiV3tgTWHyqOYD1JNe9IJ4=",
-          "range": "bytes=1170-2582015"
+          "checksum": "sha256-UsQFfOTXCZBan0mxDvR+ts0NKcbv1lNijxnRxjsmZhA=",
+          "range": "bytes=1155-2566233"
         },
         "name": "nghttp2",
         "signature": {
-          "checksum": "sha1-2/9n7KbRuOkrvhYqCFR5Mblx+z8=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-SUvMhz1cc5Or5Qh4fUEvPCp0NAw=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.62.1-r0.apk",
-        "version": "1.62.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.62.1-r1.apk",
+        "version": "1.62.1-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ialksjwPWvvZW+O2ABMbbBV/KTg=",
+        "checksum": "Q1sTMGOgdbZyDKxlRAByisPMHTbpY=",
         "control": {
-          "checksum": "sha1-ialksjwPWvvZW+O2ABMbbBV/KTg=",
-          "range": "bytes=702-1074"
+          "checksum": "sha1-sTMGOgdbZyDKxlRAByisPMHTbpY=",
+          "range": "bytes=703-1060"
         },
         "data": {
-          "checksum": "sha256-+ctDr3AO9mTXovGRPWk6h2ZgfY99Toy6esjBNHtJPY4=",
-          "range": "bytes=1075-631903"
+          "checksum": "sha256-bUy0h/zxpq7iP6vrQRMftZ9nevkHTB87hSX17wz4lmM=",
+          "range": "bytes=1061-631449"
         },
         "name": "nghttp2-dev",
         "signature": {
-          "checksum": "sha1-wZGQRluFd6DL1USzeak75o5/BTc=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-fQ6aDq3Io/gdJ5s5t3M+FwED1Y0=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.62.1-r0.apk",
-        "version": "1.62.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.62.1-r1.apk",
+        "version": "1.62.1-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1MlpRL1nBMU3RgNdSZVB42/vlGME=",
+        "checksum": "Q1rD3dEbbN8s5QAIQK1I8uF1O+oSo=",
         "control": {
-          "checksum": "sha1-MlpRL1nBMU3RgNdSZVB42/vlGME=",
-          "range": "bytes=697-1164"
+          "checksum": "sha1-rD3dEbbN8s5QAIQK1I8uF1O+oSo=",
+          "range": "bytes=701-1154"
         },
         "data": {
-          "checksum": "sha256-RiEPDasBVtnThSxGqTCDvb4J7WXM9YRpJwfYZJ3JLbs=",
-          "range": "bytes=1165-2274746"
+          "checksum": "sha256-41W2IRSRALQijYojLaqAiSSN1uO7twatGn8jqEuCZUg=",
+          "range": "bytes=1155-1439872"
         },
         "name": "xz",
         "signature": {
-          "checksum": "sha1-3wMPFIUEVfkAs7QSENemZsnTLyE=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-lozWkVrKvSrd1SoM7Zv08YYG2pA=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/xz-5.4.6-r2.apk",
-        "version": "5.4.6-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/xz-5.6.2-r0.apk",
+        "version": "5.6.2-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1TS707T+cPGL7TYVHQBCJoWwHZ0E=",
+        "checksum": "Q10AaU1ocIM4PYYNvwbml8TmpNvEA=",
         "control": {
-          "checksum": "sha1-TS707T+cPGL7TYVHQBCJoWwHZ0E=",
-          "range": "bytes=706-1098"
+          "checksum": "sha1-0AaU1ocIM4PYYNvwbml8TmpNvEA=",
+          "range": "bytes=706-1085"
         },
         "data": {
-          "checksum": "sha256-x18L706Vug5qDzq13SXuN/vGdVgzrqB06dW2DdgHGR4=",
-          "range": "bytes=1099-4541967"
+          "checksum": "sha256-1YQNYASFjlP3kXX58ec8du75ij/U6O4DPAKzJAPkln0=",
+          "range": "bytes=1086-4272589"
         },
         "name": "libxml2",
         "signature": {
-          "checksum": "sha1-BYhOxDos48sN8df8LMsSpROv2aw=",
+          "checksum": "sha1-QFjdplzGn/MiNFxMykgafr6/w6U=",
           "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.12.7-r0.apk",
-        "version": "2.12.7-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.1-r1.apk",
+        "version": "2.13.1-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1wJPtj5XZtnPiVWGM5dsT+nyfWXc=",
+        "checksum": "Q1wbnfumlWEiJnVUsJBRcQjFD3U6I=",
         "control": {
-          "checksum": "sha1-wJPtj5XZtnPiVWGM5dsT+nyfWXc=",
-          "range": "bytes=705-1234"
+          "checksum": "sha1-wbnfumlWEiJnVUsJBRcQjFD3U6I=",
+          "range": "bytes=699-1222"
         },
         "data": {
-          "checksum": "sha256-sw+CjlpsjO01q6lqzXgHnniiJKn7bqOSNO6vNqdGc7I=",
-          "range": "bytes=1235-3873775"
+          "checksum": "sha256-IXMNbJjj3kTjkWVBIHVRfG3zJQY2r5Eslgh/3TpMSsE=",
+          "range": "bytes=1223-3886778"
         },
         "name": "bind-libs",
         "signature": {
-          "checksum": "sha1-9zDzmHAeu7mWpidXAatqrLZVzUs=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-JNN15IPpJ2hMsO6hFVpDYPvvX5g=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bind-libs-9.18.26-r0.apk",
-        "version": "9.18.26-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/bind-libs-9.18.27-r1.apk",
+        "version": "9.18.27-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1AxEQdi8fVcYtGc3zHTCW3OZdY2Q=",
+        "checksum": "Q1kXUOoNa2KXixxAASo1W/im1qZ7s=",
         "control": {
-          "checksum": "sha1-AxEQdi8fVcYtGc3zHTCW3OZdY2Q=",
-          "range": "bytes=694-1208"
+          "checksum": "sha1-kXUOoNa2KXixxAASo1W/im1qZ7s=",
+          "range": "bytes=702-1215"
         },
         "data": {
-          "checksum": "sha256-/dt3qJw5D9iSJ/mKkRQkhWD8R52selhpcwXyw7KLMhg=",
-          "range": "bytes=1209-879444"
+          "checksum": "sha256-HRADvfRXfYsgEjUMGM4Hd7prpIv+YWILVfovbGOkEME=",
+          "range": "bytes=1216-879975"
         },
         "name": "bind-tools",
         "signature": {
-          "checksum": "sha1-VTb0YdUzPMk8Po0p4nj0y5Jey6k=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-8WUTMUaJTaX0T9FS/c+GddL7ttY=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bind-tools-9.18.26-r0.apk",
-        "version": "9.18.26-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/bind-tools-9.18.27-r1.apk",
+        "version": "9.18.27-r1"
       },
       {
         "architecture": "x86_64",
@@ -622,60 +622,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1fr0OtiVaD3c5nw8fy5m74hDe9PU=",
+        "checksum": "Q1BRGmQ9LZTeZqbxQ1ls69T6efViw=",
         "control": {
-          "checksum": "sha1-fr0OtiVaD3c5nw8fy5m74hDe9PU=",
-          "range": "bytes=697-1092"
+          "checksum": "sha1-BRGmQ9LZTeZqbxQ1ls69T6efViw=",
+          "range": "bytes=698-1080"
         },
         "data": {
-          "checksum": "sha256-lukjMYpGmuhBNDUbbTJMIrUWaR4rNikEnW4BgiTaLj8=",
-          "range": "bytes=1093-113872"
+          "checksum": "sha256-vtJ4WJ5M+31ZKSBYBedbrl/FrbAw8hGpPRrHC7kasOk=",
+          "range": "bytes=1081-113895"
         },
         "name": "libpsl",
         "signature": {
-          "checksum": "sha1-Lrrudgn1i1a0JhjdzeXG+exnjQA=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-DuAoiykwhu8vu1qxdEDK5oyAmf8=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libpsl-0.21.5-r2.apk",
-        "version": "0.21.5-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libpsl-0.21.5-r3.apk",
+        "version": "0.21.5-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1oauHQa0YcFcEHSQWdfohfNEN4sY=",
+        "checksum": "Q11DZVpe2UYyDr/dG6BDysZhE3L48=",
         "control": {
-          "checksum": "sha1-oauHQa0YcFcEHSQWdfohfNEN4sY=",
-          "range": "bytes=698-1057"
+          "checksum": "sha1-1DZVpe2UYyDr/dG6BDysZhE3L48=",
+          "range": "bytes=707-1049"
         },
         "data": {
-          "checksum": "sha256-d95c9lpjQrpuZ1CcQ8ZZ89LAGGKcessd+hxrOQpP4LU=",
-          "range": "bytes=1058-173549"
+          "checksum": "sha256-aECfsy7giZsLNxZM0HMeF4OS2gu+ycX4DUTJXsiZRQs=",
+          "range": "bytes=1050-173585"
         },
         "name": "libbrotlicommon1",
         "signature": {
-          "checksum": "sha1-g3ufBq/tyiNP6AaOoqwItVvh7uk=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-7LXD38QwFhklZCEqyW4qIncfZV0=",
+          "range": "bytes=0-706"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlicommon1-1.1.0-r2.apk",
-        "version": "1.1.0-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlicommon1-1.1.0-r3.apk",
+        "version": "1.1.0-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q18Otq7NLoYnNMebI/1Rr/s0zdLVw=",
+        "checksum": "Q1Cgr886A8Ryzynz9pxRKsNybVuK0=",
         "control": {
-          "checksum": "sha1-8Otq7NLoYnNMebI/1Rr/s0zdLVw=",
-          "range": "bytes=705-1072"
+          "checksum": "sha1-Cgr886A8Ryzynz9pxRKsNybVuK0=",
+          "range": "bytes=694-1043"
         },
         "data": {
-          "checksum": "sha256-sR3QidR/e46PJ/3S2fxAjN/hRSSA3Ar32Nw7VshTHWg=",
-          "range": "bytes=1073-81475"
+          "checksum": "sha256-mH+MTbqpLiqgydlgE+tSDEt0Sh1/zqMvAqspV4lr+Ks=",
+          "range": "bytes=1044-81511"
         },
         "name": "libbrotlidec1",
         "signature": {
-          "checksum": "sha1-6GpZI5cBUXOvjCYG81aZZR53lMI=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-Yp4Bde9oHQCec8HM2qn6hVKgtko=",
+          "range": "bytes=0-693"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlidec1-1.1.0-r2.apk",
-        "version": "1.1.0-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlidec1-1.1.0-r3.apk",
+        "version": "1.1.0-r3"
       },
       {
         "architecture": "x86_64",
@@ -774,22 +774,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q19f/3419Xa/xv9jgQ0mMYs011fBk=",
+        "checksum": "Q1mTmy64gKYi4THBqewuvYL2uUyHc=",
         "control": {
-          "checksum": "sha1-9f/3419Xa/xv9jgQ0mMYs011fBk=",
-          "range": "bytes=696-1041"
+          "checksum": "sha1-mTmy64gKYi4THBqewuvYL2uUyHc=",
+          "range": "bytes=700-1031"
         },
         "data": {
-          "checksum": "sha256-iqHASiMgiu6rIjbWGwBmmq1Zthae8BkE4QZkiVPH7Ek=",
-          "range": "bytes=1042-1888945"
+          "checksum": "sha256-p0qua2luH33oAgOcLkU9f7k+I8WnykFszVMwNahujDA=",
+          "range": "bytes=1032-1889523"
         },
         "name": "tzdata",
         "signature": {
-          "checksum": "sha1-PCC3jiXlTwrimRMXH/4RyNvccOM=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-sBf5jVLVpWj4DiXaAd/mjo0pTfk=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/tzdata-2024a-r2.apk",
-        "version": "2024a-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/tzdata-2024a-r3.apk",
+        "version": "2024a-r3"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/redis.lock.json
+++ b/wolfi-images/redis.lock.json
@@ -14,41 +14,41 @@
     "packages": [
       {
         "architecture": "x86_64",
-        "checksum": "Q1ge3SLQsJ9v2RnvIHHAP1yFyjrEU=",
+        "checksum": "Q1Ai8jWuxKZR2M2XhOpOGAoTEwnnk=",
         "control": {
-          "checksum": "sha1-ge3SLQsJ9v2RnvIHHAP1yFyjrEU=",
-          "range": "bytes=693-1040"
+          "checksum": "sha1-Ai8jWuxKZR2M2XhOpOGAoTEwnnk=",
+          "range": "bytes=705-1037"
         },
         "data": {
-          "checksum": "sha256-I0AdTdfGf4P/jwzTrLXm73l5/RNSlymEof/YZfev3xY=",
-          "range": "bytes=1041-255811"
+          "checksum": "sha256-e4UardkBVyaC49aSyrVmXNi8sSKqQl4eKYd0LxGRLA0=",
+          "range": "bytes=1038-255695"
         },
         "name": "ca-certificates-bundle",
         "signature": {
-          "checksum": "sha1-ge1eJBiQmFWAn9GapFkQpO+Rn/Y=",
-          "range": "bytes=0-692"
+          "checksum": "sha1-loRuyYQLm+atp+YteiQoj++EWIM=",
+          "range": "bytes=0-704"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20240315-r3.apk",
-        "version": "20240315-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20240315-r4.apk",
+        "version": "20240315-r4"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1bgay5kOzpmDBgqJCg7dSlawyJg0=",
+        "checksum": "Q1+GH6qRN4iy1IDt0cT0x0tin7YfI=",
         "control": {
-          "checksum": "sha1-bgay5kOzpmDBgqJCg7dSlawyJg0=",
-          "range": "bytes=703-1067"
+          "checksum": "sha1-+GH6qRN4iy1IDt0cT0x0tin7YfI=",
+          "range": "bytes=703-1051"
         },
         "data": {
-          "checksum": "sha256-f83HfRE7r2ZniH7PyPmRqcoU5NTpF+Uk4FH80QbjvBM=",
-          "range": "bytes=1068-118370"
+          "checksum": "sha256-rO0P9z2V49BSrz1A5Ap69tEappVrg5MMBjzW00rOpZc=",
+          "range": "bytes=1052-122464"
         },
         "name": "wolfi-baselayout",
         "signature": {
-          "checksum": "sha1-2hlCvYH1D7u25HkJGA75jjs/sQY=",
+          "checksum": "sha1-Ntb6VuMzDfM+frpCjKEIpDzl53I=",
           "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r11.apk",
-        "version": "20230201-r11"
+        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r12.apk",
+        "version": "20230201-r12"
       },
       {
         "architecture": "x86_64",
@@ -109,41 +109,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Zjfs1uR/mYiortANP+EFcejW+vo=",
+        "checksum": "Q1Zi0e8Bq6WCd/6uXXjVhb8YwMD1U=",
         "control": {
-          "checksum": "sha1-Zjfs1uR/mYiortANP+EFcejW+vo=",
-          "range": "bytes=698-1085"
+          "checksum": "sha1-Zi0e8Bq6WCd/6uXXjVhb8YwMD1U=",
+          "range": "bytes=700-1073"
         },
         "data": {
-          "checksum": "sha256-BMd7TzffjbrFwdbopDPVYsX0X9XnusIMNbIf33/8kwc=",
-          "range": "bytes=1086-76881"
+          "checksum": "sha256-jMhtfqVjnhuuBO7wtNZ6RS/72sZWoKt/Moage2amlks=",
+          "range": "bytes=1074-81594"
         },
         "name": "protobuf-c",
         "signature": {
-          "checksum": "sha1-efGiXyYWsJ5P2uTkB6aXEZ3kl3o=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-kATwMKztK7nk7qbYCJPkCFp6IXc=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r4.apk",
-        "version": "1.5.0-r4"
-      },
-      {
-        "architecture": "x86_64",
-        "checksum": "Q1Xf5v5uXumBgIR4d4ZxMRxdpyWlM=",
-        "control": {
-          "checksum": "sha1-Xf5v5uXumBgIR4d4ZxMRxdpyWlM=",
-          "range": "bytes=698-1078"
-        },
-        "data": {
-          "checksum": "sha256-eD7HqFCWNUBQiLq9PcWE/zPeZwkiv8hBrytI4qmfQ/8=",
-          "range": "bytes=1079-57055"
-        },
-        "name": "keyutils-libs",
-        "signature": {
-          "checksum": "sha1-V0HVgZLP7P5kNACfus3abCLCS20=",
-          "range": "bytes=0-697"
-        },
-        "url": "https://packages.wolfi.dev/os/x86_64/keyutils-libs-1.6.3-r2.apk",
-        "version": "1.6.3-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r5.apk",
+        "version": "1.5.0-r5"
       },
       {
         "architecture": "x86_64",
@@ -166,22 +147,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1wRzOx+L6MeRFtTcq2y/6ot7Cj54=",
+        "checksum": "Q1v0A2vQM5k8rQY/GpIq6xI4T0YmA=",
         "control": {
-          "checksum": "sha1-wRzOx+L6MeRFtTcq2y/6ot7Cj54=",
-          "range": "bytes=699-1069"
+          "checksum": "sha1-v0A2vQM5k8rQY/GpIq6xI4T0YmA=",
+          "range": "bytes=701-1064"
         },
         "data": {
-          "checksum": "sha256-gNRjwZ4XQatCYWediSVb+j8lS54CggvMC5Dn3qT84So=",
-          "range": "bytes=1070-61490"
+          "checksum": "sha256-uAOrkGDDc/yqt6VjIrlTEALBJG4BCI4njqZw5jQqF0o=",
+          "range": "bytes=1065-56984"
+        },
+        "name": "keyutils-libs",
+        "signature": {
+          "checksum": "sha1-32uYMH/zGBr9Jo3hiqnThlcqBcE=",
+          "range": "bytes=0-700"
+        },
+        "url": "https://packages.wolfi.dev/os/x86_64/keyutils-libs-1.6.3-r3.apk",
+        "version": "1.6.3-r3"
+      },
+      {
+        "architecture": "x86_64",
+        "checksum": "Q1Onuac6Y+IWA7a4b8FvqX1erWDDw=",
+        "control": {
+          "checksum": "sha1-Onuac6Y+IWA7a4b8FvqX1erWDDw=",
+          "range": "bytes=693-1048"
+        },
+        "data": {
+          "checksum": "sha256-KLtDAs3iU0oyZ/FysePG/J+1H1ofDxHXIY7xvtZhtMc=",
+          "range": "bytes=1049-61503"
         },
         "name": "libverto",
         "signature": {
-          "checksum": "sha1-kuPwakYdy5EM6sd5Ba0K0Ta8x4w=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-/IXL9S1O+MwaW7KsSzz1ywEqKFQ=",
+          "range": "bytes=0-692"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libverto-0.3.2-r3.apk",
-        "version": "0.3.2-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/libverto-0.3.2-r4.apk",
+        "version": "0.3.2-r4"
       },
       {
         "architecture": "x86_64",
@@ -204,60 +204,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1gTZGkWP+QO3mUqLVJth8vrDEzzU=",
+        "checksum": "Q1Q/Zy5ovYSu2p/vVLr6DgVA1e8AQ=",
         "control": {
-          "checksum": "sha1-gTZGkWP+QO3mUqLVJth8vrDEzzU=",
-          "range": "bytes=699-1076"
+          "checksum": "sha1-Q/Zy5ovYSu2p/vVLr6DgVA1e8AQ=",
+          "range": "bytes=699-1062"
         },
         "data": {
-          "checksum": "sha256-/IFXqeKvU0GODNsz1yPIEMcFHgABT+8rbZpSlTLo4e4=",
-          "range": "bytes=1077-5915704"
+          "checksum": "sha256-H3jxsw8ytOeCIR4vq17voSVhdNokXk8C1g075txH6Bs=",
+          "range": "bytes=1063-5903754"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-l1o5ixkyWWqqJE3FOfR0QUemJUA=",
+          "checksum": "sha1-NIl2f5OI/wSZByI8Ds1ZUfbFWyw=",
           "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r9.apk",
-        "version": "3.3.0-r9"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.1-r3.apk",
+        "version": "3.3.1-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1jhAhggAuZnU7FFHnebGA26mq+jI=",
+        "checksum": "Q13wGUXdZut9OOTdY5z2amUj9wXC0=",
         "control": {
-          "checksum": "sha1-jhAhggAuZnU7FFHnebGA26mq+jI=",
-          "range": "bytes=695-1079"
+          "checksum": "sha1-3wGUXdZut9OOTdY5z2amUj9wXC0=",
+          "range": "bytes=698-1068"
         },
         "data": {
-          "checksum": "sha256-XTCQYnhGSm7SkGwqV/TQMFqGajVJVYhKAidKfLb2D3Y=",
-          "range": "bytes=1080-1197081"
+          "checksum": "sha256-mRda6+YGlOCczyIWKaHqXskTINoT1rgorHDHqAKAb7c=",
+          "range": "bytes=1069-1188955"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-qVrfDVxubkrb5Yrd2mFTv2A0G7k=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-+UdRc4U3PKw4H9OiNurHKXa5BYk=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r9.apk",
-        "version": "3.3.0-r9"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.1-r3.apk",
+        "version": "3.3.1-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1BQEXaeya6QB39QLeKcB99qBNF2o=",
+        "checksum": "Q1p04MrHQPrXOzuV/uF290zjnltqI=",
         "control": {
-          "checksum": "sha1-BQEXaeya6QB39QLeKcB99qBNF2o=",
-          "range": "bytes=699-1229"
+          "checksum": "sha1-p04MrHQPrXOzuV/uF290zjnltqI=",
+          "range": "bytes=704-1219"
         },
         "data": {
-          "checksum": "sha256-ugj/qGEBzhvdX17S22Anry+biy3lcqywhGMSHLIBCvo=",
-          "range": "bytes=1230-2551676"
+          "checksum": "sha256-TsXeqhUGykAhjQUEAlMUSzDQBcWDkkDvReoeHCL1F6c=",
+          "range": "bytes=1220-2555814"
         },
         "name": "krb5-libs",
         "signature": {
-          "checksum": "sha1-oqDPmNM4EngXAGayd/BZOqJAIao=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-cPyzS38QHuNlOCQb8IPlsl2PLHQ=",
+          "range": "bytes=0-703"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/krb5-libs-1.21.2-r2.apk",
-        "version": "1.21.2-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/krb5-libs-1.21.3-r0.apk",
+        "version": "1.21.3-r0"
       },
       {
         "architecture": "x86_64",
@@ -280,60 +280,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1wzZwtLauOQfLQC7YUvZdfKxtlwQ=",
+        "checksum": "Q17uprcuQ2VFudMcWAwtP7miJmLYs=",
         "control": {
-          "checksum": "sha1-wzZwtLauOQfLQC7YUvZdfKxtlwQ=",
-          "range": "bytes=698-1085"
+          "checksum": "sha1-7uprcuQ2VFudMcWAwtP7miJmLYs=",
+          "range": "bytes=695-1067"
         },
         "data": {
-          "checksum": "sha256-TO8CAULO44s/LphhtcaFOGJB7aFldk13v1cV9ceZHww=",
-          "range": "bytes=1086-276837"
+          "checksum": "sha256-unKdPbvO2VHZ5w1t1l8mOpQuNdUGwLhofEO4weN2Mig=",
+          "range": "bytes=1068-280973"
         },
         "name": "libuv",
         "signature": {
-          "checksum": "sha1-LRiyeKmjexy8CJizLxjd6ikon1w=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-4lKldnTO71WHMZ4tbANz6i2/Ed0=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libuv-1.48.0-r2.apk",
-        "version": "1.48.0-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libuv-1.48.0-r3.apk",
+        "version": "1.48.0-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q14S6biy8fc5OGbGEJoLBM+tJOGyo=",
+        "checksum": "Q1CN6zJbOPznWUfTrb/41KT7E6dm8=",
         "control": {
-          "checksum": "sha1-4S6biy8fc5OGbGEJoLBM+tJOGyo=",
-          "range": "bytes=703-1102"
+          "checksum": "sha1-CN6zJbOPznWUfTrb/41KT7E6dm8=",
+          "range": "bytes=699-1083"
         },
         "data": {
-          "checksum": "sha256-hwjdLQYfuMAGQeONmFVo0lZKKQK1S+3PBhrI3upm5W4=",
-          "range": "bytes=1103-155304"
+          "checksum": "sha256-ybzFzoQh1yNTcd3cjt54nYsPlAxAcMUcVMxEv1JRnpQ=",
+          "range": "bytes=1084-155375"
         },
         "name": "zlib",
         "signature": {
-          "checksum": "sha1-ZuLd7kE+AGhn27o8ZqDGM5eundc=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-CPXJcCjinAXP+H8Z5tkko8ayG6E=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/zlib-1.3.1-r2.apk",
-        "version": "1.3.1-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/zlib-1.3.1-r3.apk",
+        "version": "1.3.1-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ykDkP+AmDi2VcZZ1c4q4sez/DxI=",
+        "checksum": "Q1rgbci8SRSjW7EB0NSh6ZUPJLndM=",
         "control": {
-          "checksum": "sha1-ykDkP+AmDi2VcZZ1c4q4sez/DxI=",
-          "range": "bytes=705-1079"
+          "checksum": "sha1-rgbci8SRSjW7EB0NSh6ZUPJLndM=",
+          "range": "bytes=702-1060"
         },
         "data": {
-          "checksum": "sha256-t3BrH7lWfY3to3Fu3EKAMZx29v9Hnl5seyXJzLmZ9/4=",
-          "range": "bytes=1080-251884"
+          "checksum": "sha256-tf4xbo+NP+ssiaZtC1kOKehffAZ3+d17bhgfU3/30+g=",
+          "range": "bytes=1061-256582"
         },
         "name": "libnghttp2-14",
         "signature": {
-          "checksum": "sha1-CotSXRaPLKQCBRHrgzrDOD+4w20=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-KrsJYTyUsll+EUhHekbkdZFzeig=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.62.1-r0.apk",
-        "version": "1.62.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.62.1-r1.apk",
+        "version": "1.62.1-r1"
       },
       {
         "architecture": "x86_64",
@@ -394,136 +394,136 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1DE49kWSnmqVKJdjHFYC1bLkvyb0=",
+        "checksum": "Q1R8OxpY0fGwVaIwft4wJeswF5D54=",
         "control": {
-          "checksum": "sha1-DE49kWSnmqVKJdjHFYC1bLkvyb0=",
-          "range": "bytes=697-1078"
+          "checksum": "sha1-R8OxpY0fGwVaIwft4wJeswF5D54=",
+          "range": "bytes=695-1059"
         },
         "data": {
-          "checksum": "sha256-uDg8Qc6Rnro/68Vb5ufFSkqFLGrEsbvPb0pMJNvT1zw=",
-          "range": "bytes=1079-242085"
+          "checksum": "sha256-wNc8/SBJrGHfwywAtzCsAqeUOt0IaAhqNtlbv8OiHBE=",
+          "range": "bytes=1060-242151"
         },
         "name": "c-ares",
         "signature": {
-          "checksum": "sha1-iYEm6EWQKzxkeoDm+QsRfhw8pDg=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-55/PTlEHXI3o0hx9dSVdNwQeSMg=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.29.0-r0.apk",
-        "version": "1.29.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.31.0-r0.apk",
+        "version": "1.31.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q12eWmn2tCkXxwncU6gagKM3Wd9Sk=",
+        "checksum": "Q1g2RQKAvNjlRPxWjinIRveaq7IlY=",
         "control": {
-          "checksum": "sha1-2eWmn2tCkXxwncU6gagKM3Wd9Sk=",
-          "range": "bytes=696-1169"
+          "checksum": "sha1-g2RQKAvNjlRPxWjinIRveaq7IlY=",
+          "range": "bytes=695-1154"
         },
         "data": {
-          "checksum": "sha256-IFKNdojOhml3DbWPryQuHUiV3tgTWHyqOYD1JNe9IJ4=",
-          "range": "bytes=1170-2582015"
+          "checksum": "sha256-UsQFfOTXCZBan0mxDvR+ts0NKcbv1lNijxnRxjsmZhA=",
+          "range": "bytes=1155-2566233"
         },
         "name": "nghttp2",
         "signature": {
-          "checksum": "sha1-2/9n7KbRuOkrvhYqCFR5Mblx+z8=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-SUvMhz1cc5Or5Qh4fUEvPCp0NAw=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.62.1-r0.apk",
-        "version": "1.62.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.62.1-r1.apk",
+        "version": "1.62.1-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ialksjwPWvvZW+O2ABMbbBV/KTg=",
+        "checksum": "Q1sTMGOgdbZyDKxlRAByisPMHTbpY=",
         "control": {
-          "checksum": "sha1-ialksjwPWvvZW+O2ABMbbBV/KTg=",
-          "range": "bytes=702-1074"
+          "checksum": "sha1-sTMGOgdbZyDKxlRAByisPMHTbpY=",
+          "range": "bytes=703-1060"
         },
         "data": {
-          "checksum": "sha256-+ctDr3AO9mTXovGRPWk6h2ZgfY99Toy6esjBNHtJPY4=",
-          "range": "bytes=1075-631903"
+          "checksum": "sha256-bUy0h/zxpq7iP6vrQRMftZ9nevkHTB87hSX17wz4lmM=",
+          "range": "bytes=1061-631449"
         },
         "name": "nghttp2-dev",
         "signature": {
-          "checksum": "sha1-wZGQRluFd6DL1USzeak75o5/BTc=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-fQ6aDq3Io/gdJ5s5t3M+FwED1Y0=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.62.1-r0.apk",
-        "version": "1.62.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.62.1-r1.apk",
+        "version": "1.62.1-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1MlpRL1nBMU3RgNdSZVB42/vlGME=",
+        "checksum": "Q1rD3dEbbN8s5QAIQK1I8uF1O+oSo=",
         "control": {
-          "checksum": "sha1-MlpRL1nBMU3RgNdSZVB42/vlGME=",
-          "range": "bytes=697-1164"
+          "checksum": "sha1-rD3dEbbN8s5QAIQK1I8uF1O+oSo=",
+          "range": "bytes=701-1154"
         },
         "data": {
-          "checksum": "sha256-RiEPDasBVtnThSxGqTCDvb4J7WXM9YRpJwfYZJ3JLbs=",
-          "range": "bytes=1165-2274746"
+          "checksum": "sha256-41W2IRSRALQijYojLaqAiSSN1uO7twatGn8jqEuCZUg=",
+          "range": "bytes=1155-1439872"
         },
         "name": "xz",
         "signature": {
-          "checksum": "sha1-3wMPFIUEVfkAs7QSENemZsnTLyE=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-lozWkVrKvSrd1SoM7Zv08YYG2pA=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/xz-5.4.6-r2.apk",
-        "version": "5.4.6-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/xz-5.6.2-r0.apk",
+        "version": "5.6.2-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1TS707T+cPGL7TYVHQBCJoWwHZ0E=",
+        "checksum": "Q10AaU1ocIM4PYYNvwbml8TmpNvEA=",
         "control": {
-          "checksum": "sha1-TS707T+cPGL7TYVHQBCJoWwHZ0E=",
-          "range": "bytes=706-1098"
+          "checksum": "sha1-0AaU1ocIM4PYYNvwbml8TmpNvEA=",
+          "range": "bytes=706-1085"
         },
         "data": {
-          "checksum": "sha256-x18L706Vug5qDzq13SXuN/vGdVgzrqB06dW2DdgHGR4=",
-          "range": "bytes=1099-4541967"
+          "checksum": "sha256-1YQNYASFjlP3kXX58ec8du75ij/U6O4DPAKzJAPkln0=",
+          "range": "bytes=1086-4272589"
         },
         "name": "libxml2",
         "signature": {
-          "checksum": "sha1-BYhOxDos48sN8df8LMsSpROv2aw=",
+          "checksum": "sha1-QFjdplzGn/MiNFxMykgafr6/w6U=",
           "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.12.7-r0.apk",
-        "version": "2.12.7-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.1-r1.apk",
+        "version": "2.13.1-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1wJPtj5XZtnPiVWGM5dsT+nyfWXc=",
+        "checksum": "Q1wbnfumlWEiJnVUsJBRcQjFD3U6I=",
         "control": {
-          "checksum": "sha1-wJPtj5XZtnPiVWGM5dsT+nyfWXc=",
-          "range": "bytes=705-1234"
+          "checksum": "sha1-wbnfumlWEiJnVUsJBRcQjFD3U6I=",
+          "range": "bytes=699-1222"
         },
         "data": {
-          "checksum": "sha256-sw+CjlpsjO01q6lqzXgHnniiJKn7bqOSNO6vNqdGc7I=",
-          "range": "bytes=1235-3873775"
+          "checksum": "sha256-IXMNbJjj3kTjkWVBIHVRfG3zJQY2r5Eslgh/3TpMSsE=",
+          "range": "bytes=1223-3886778"
         },
         "name": "bind-libs",
         "signature": {
-          "checksum": "sha1-9zDzmHAeu7mWpidXAatqrLZVzUs=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-JNN15IPpJ2hMsO6hFVpDYPvvX5g=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bind-libs-9.18.26-r0.apk",
-        "version": "9.18.26-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/bind-libs-9.18.27-r1.apk",
+        "version": "9.18.27-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1AxEQdi8fVcYtGc3zHTCW3OZdY2Q=",
+        "checksum": "Q1kXUOoNa2KXixxAASo1W/im1qZ7s=",
         "control": {
-          "checksum": "sha1-AxEQdi8fVcYtGc3zHTCW3OZdY2Q=",
-          "range": "bytes=694-1208"
+          "checksum": "sha1-kXUOoNa2KXixxAASo1W/im1qZ7s=",
+          "range": "bytes=702-1215"
         },
         "data": {
-          "checksum": "sha256-/dt3qJw5D9iSJ/mKkRQkhWD8R52selhpcwXyw7KLMhg=",
-          "range": "bytes=1209-879444"
+          "checksum": "sha256-HRADvfRXfYsgEjUMGM4Hd7prpIv+YWILVfovbGOkEME=",
+          "range": "bytes=1216-879975"
         },
         "name": "bind-tools",
         "signature": {
-          "checksum": "sha1-VTb0YdUzPMk8Po0p4nj0y5Jey6k=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-8WUTMUaJTaX0T9FS/c+GddL7ttY=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bind-tools-9.18.26-r0.apk",
-        "version": "9.18.26-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/bind-tools-9.18.27-r1.apk",
+        "version": "9.18.27-r1"
       },
       {
         "architecture": "x86_64",
@@ -622,60 +622,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1fr0OtiVaD3c5nw8fy5m74hDe9PU=",
+        "checksum": "Q1BRGmQ9LZTeZqbxQ1ls69T6efViw=",
         "control": {
-          "checksum": "sha1-fr0OtiVaD3c5nw8fy5m74hDe9PU=",
-          "range": "bytes=697-1092"
+          "checksum": "sha1-BRGmQ9LZTeZqbxQ1ls69T6efViw=",
+          "range": "bytes=698-1080"
         },
         "data": {
-          "checksum": "sha256-lukjMYpGmuhBNDUbbTJMIrUWaR4rNikEnW4BgiTaLj8=",
-          "range": "bytes=1093-113872"
+          "checksum": "sha256-vtJ4WJ5M+31ZKSBYBedbrl/FrbAw8hGpPRrHC7kasOk=",
+          "range": "bytes=1081-113895"
         },
         "name": "libpsl",
         "signature": {
-          "checksum": "sha1-Lrrudgn1i1a0JhjdzeXG+exnjQA=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-DuAoiykwhu8vu1qxdEDK5oyAmf8=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libpsl-0.21.5-r2.apk",
-        "version": "0.21.5-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libpsl-0.21.5-r3.apk",
+        "version": "0.21.5-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1oauHQa0YcFcEHSQWdfohfNEN4sY=",
+        "checksum": "Q11DZVpe2UYyDr/dG6BDysZhE3L48=",
         "control": {
-          "checksum": "sha1-oauHQa0YcFcEHSQWdfohfNEN4sY=",
-          "range": "bytes=698-1057"
+          "checksum": "sha1-1DZVpe2UYyDr/dG6BDysZhE3L48=",
+          "range": "bytes=707-1049"
         },
         "data": {
-          "checksum": "sha256-d95c9lpjQrpuZ1CcQ8ZZ89LAGGKcessd+hxrOQpP4LU=",
-          "range": "bytes=1058-173549"
+          "checksum": "sha256-aECfsy7giZsLNxZM0HMeF4OS2gu+ycX4DUTJXsiZRQs=",
+          "range": "bytes=1050-173585"
         },
         "name": "libbrotlicommon1",
         "signature": {
-          "checksum": "sha1-g3ufBq/tyiNP6AaOoqwItVvh7uk=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-7LXD38QwFhklZCEqyW4qIncfZV0=",
+          "range": "bytes=0-706"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlicommon1-1.1.0-r2.apk",
-        "version": "1.1.0-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlicommon1-1.1.0-r3.apk",
+        "version": "1.1.0-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q18Otq7NLoYnNMebI/1Rr/s0zdLVw=",
+        "checksum": "Q1Cgr886A8Ryzynz9pxRKsNybVuK0=",
         "control": {
-          "checksum": "sha1-8Otq7NLoYnNMebI/1Rr/s0zdLVw=",
-          "range": "bytes=705-1072"
+          "checksum": "sha1-Cgr886A8Ryzynz9pxRKsNybVuK0=",
+          "range": "bytes=694-1043"
         },
         "data": {
-          "checksum": "sha256-sR3QidR/e46PJ/3S2fxAjN/hRSSA3Ar32Nw7VshTHWg=",
-          "range": "bytes=1073-81475"
+          "checksum": "sha256-mH+MTbqpLiqgydlgE+tSDEt0Sh1/zqMvAqspV4lr+Ks=",
+          "range": "bytes=1044-81511"
         },
         "name": "libbrotlidec1",
         "signature": {
-          "checksum": "sha1-6GpZI5cBUXOvjCYG81aZZR53lMI=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-Yp4Bde9oHQCec8HM2qn6hVKgtko=",
+          "range": "bytes=0-693"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlidec1-1.1.0-r2.apk",
-        "version": "1.1.0-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlidec1-1.1.0-r3.apk",
+        "version": "1.1.0-r3"
       },
       {
         "architecture": "x86_64",
@@ -774,22 +774,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ZMGiMSnjbScBstPVaw5qQfkNI+M=",
+        "checksum": "Q1w2/J0nDU8aA/f0HxunA5N19L1gw=",
         "control": {
-          "checksum": "sha1-ZMGiMSnjbScBstPVaw5qQfkNI+M=",
-          "range": "bytes=697-1097"
+          "checksum": "sha1-w2/J0nDU8aA/f0HxunA5N19L1gw=",
+          "range": "bytes=702-1086"
         },
         "data": {
-          "checksum": "sha256-XN2CeOJxCHWCgGpwTUkm5UOFKFz/eRpd7AReq4CqiOk=",
-          "range": "bytes=1098-1436391"
+          "checksum": "sha256-/2i+TNHbkrOsjrx7WHrrloXc6gcoyfyGrUHdBljYM+o=",
+          "range": "bytes=1087-1440232"
         },
         "name": "bash",
         "signature": {
-          "checksum": "sha1-t7/nmubimPIaw21oj0WlXgqY90E=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-tnYcLxCgV8srkBsTl4c/f6m11vQ=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bash-5.2.21-r4.apk",
-        "version": "5.2.21-r4"
+        "url": "https://packages.wolfi.dev/os/x86_64/bash-5.2.21-r5.apk",
+        "version": "5.2.21-r5"
       },
       {
         "architecture": "x86_64",
@@ -869,22 +869,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q19f/3419Xa/xv9jgQ0mMYs011fBk=",
+        "checksum": "Q1mTmy64gKYi4THBqewuvYL2uUyHc=",
         "control": {
-          "checksum": "sha1-9f/3419Xa/xv9jgQ0mMYs011fBk=",
-          "range": "bytes=696-1041"
+          "checksum": "sha1-mTmy64gKYi4THBqewuvYL2uUyHc=",
+          "range": "bytes=700-1031"
         },
         "data": {
-          "checksum": "sha256-iqHASiMgiu6rIjbWGwBmmq1Zthae8BkE4QZkiVPH7Ek=",
-          "range": "bytes=1042-1888945"
+          "checksum": "sha256-p0qua2luH33oAgOcLkU9f7k+I8WnykFszVMwNahujDA=",
+          "range": "bytes=1032-1889523"
         },
         "name": "tzdata",
         "signature": {
-          "checksum": "sha1-PCC3jiXlTwrimRMXH/4RyNvccOM=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-sBf5jVLVpWj4DiXaAd/mjo0pTfk=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/tzdata-2024a-r2.apk",
-        "version": "2024a-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/tzdata-2024a-r3.apk",
+        "version": "2024a-r3"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/repo-updater.lock.json
+++ b/wolfi-images/repo-updater.lock.json
@@ -14,41 +14,41 @@
     "packages": [
       {
         "architecture": "x86_64",
-        "checksum": "Q1ge3SLQsJ9v2RnvIHHAP1yFyjrEU=",
+        "checksum": "Q1Ai8jWuxKZR2M2XhOpOGAoTEwnnk=",
         "control": {
-          "checksum": "sha1-ge3SLQsJ9v2RnvIHHAP1yFyjrEU=",
-          "range": "bytes=693-1040"
+          "checksum": "sha1-Ai8jWuxKZR2M2XhOpOGAoTEwnnk=",
+          "range": "bytes=705-1037"
         },
         "data": {
-          "checksum": "sha256-I0AdTdfGf4P/jwzTrLXm73l5/RNSlymEof/YZfev3xY=",
-          "range": "bytes=1041-255811"
+          "checksum": "sha256-e4UardkBVyaC49aSyrVmXNi8sSKqQl4eKYd0LxGRLA0=",
+          "range": "bytes=1038-255695"
         },
         "name": "ca-certificates-bundle",
         "signature": {
-          "checksum": "sha1-ge1eJBiQmFWAn9GapFkQpO+Rn/Y=",
-          "range": "bytes=0-692"
+          "checksum": "sha1-loRuyYQLm+atp+YteiQoj++EWIM=",
+          "range": "bytes=0-704"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20240315-r3.apk",
-        "version": "20240315-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20240315-r4.apk",
+        "version": "20240315-r4"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1bgay5kOzpmDBgqJCg7dSlawyJg0=",
+        "checksum": "Q1+GH6qRN4iy1IDt0cT0x0tin7YfI=",
         "control": {
-          "checksum": "sha1-bgay5kOzpmDBgqJCg7dSlawyJg0=",
-          "range": "bytes=703-1067"
+          "checksum": "sha1-+GH6qRN4iy1IDt0cT0x0tin7YfI=",
+          "range": "bytes=703-1051"
         },
         "data": {
-          "checksum": "sha256-f83HfRE7r2ZniH7PyPmRqcoU5NTpF+Uk4FH80QbjvBM=",
-          "range": "bytes=1068-118370"
+          "checksum": "sha256-rO0P9z2V49BSrz1A5Ap69tEappVrg5MMBjzW00rOpZc=",
+          "range": "bytes=1052-122464"
         },
         "name": "wolfi-baselayout",
         "signature": {
-          "checksum": "sha1-2hlCvYH1D7u25HkJGA75jjs/sQY=",
+          "checksum": "sha1-Ntb6VuMzDfM+frpCjKEIpDzl53I=",
           "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r11.apk",
-        "version": "20230201-r11"
+        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r12.apk",
+        "version": "20230201-r12"
       },
       {
         "architecture": "x86_64",
@@ -109,41 +109,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Zjfs1uR/mYiortANP+EFcejW+vo=",
+        "checksum": "Q1Zi0e8Bq6WCd/6uXXjVhb8YwMD1U=",
         "control": {
-          "checksum": "sha1-Zjfs1uR/mYiortANP+EFcejW+vo=",
-          "range": "bytes=698-1085"
+          "checksum": "sha1-Zi0e8Bq6WCd/6uXXjVhb8YwMD1U=",
+          "range": "bytes=700-1073"
         },
         "data": {
-          "checksum": "sha256-BMd7TzffjbrFwdbopDPVYsX0X9XnusIMNbIf33/8kwc=",
-          "range": "bytes=1086-76881"
+          "checksum": "sha256-jMhtfqVjnhuuBO7wtNZ6RS/72sZWoKt/Moage2amlks=",
+          "range": "bytes=1074-81594"
         },
         "name": "protobuf-c",
         "signature": {
-          "checksum": "sha1-efGiXyYWsJ5P2uTkB6aXEZ3kl3o=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-kATwMKztK7nk7qbYCJPkCFp6IXc=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r4.apk",
-        "version": "1.5.0-r4"
-      },
-      {
-        "architecture": "x86_64",
-        "checksum": "Q1Xf5v5uXumBgIR4d4ZxMRxdpyWlM=",
-        "control": {
-          "checksum": "sha1-Xf5v5uXumBgIR4d4ZxMRxdpyWlM=",
-          "range": "bytes=698-1078"
-        },
-        "data": {
-          "checksum": "sha256-eD7HqFCWNUBQiLq9PcWE/zPeZwkiv8hBrytI4qmfQ/8=",
-          "range": "bytes=1079-57055"
-        },
-        "name": "keyutils-libs",
-        "signature": {
-          "checksum": "sha1-V0HVgZLP7P5kNACfus3abCLCS20=",
-          "range": "bytes=0-697"
-        },
-        "url": "https://packages.wolfi.dev/os/x86_64/keyutils-libs-1.6.3-r2.apk",
-        "version": "1.6.3-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r5.apk",
+        "version": "1.5.0-r5"
       },
       {
         "architecture": "x86_64",
@@ -166,22 +147,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1wRzOx+L6MeRFtTcq2y/6ot7Cj54=",
+        "checksum": "Q1v0A2vQM5k8rQY/GpIq6xI4T0YmA=",
         "control": {
-          "checksum": "sha1-wRzOx+L6MeRFtTcq2y/6ot7Cj54=",
-          "range": "bytes=699-1069"
+          "checksum": "sha1-v0A2vQM5k8rQY/GpIq6xI4T0YmA=",
+          "range": "bytes=701-1064"
         },
         "data": {
-          "checksum": "sha256-gNRjwZ4XQatCYWediSVb+j8lS54CggvMC5Dn3qT84So=",
-          "range": "bytes=1070-61490"
+          "checksum": "sha256-uAOrkGDDc/yqt6VjIrlTEALBJG4BCI4njqZw5jQqF0o=",
+          "range": "bytes=1065-56984"
+        },
+        "name": "keyutils-libs",
+        "signature": {
+          "checksum": "sha1-32uYMH/zGBr9Jo3hiqnThlcqBcE=",
+          "range": "bytes=0-700"
+        },
+        "url": "https://packages.wolfi.dev/os/x86_64/keyutils-libs-1.6.3-r3.apk",
+        "version": "1.6.3-r3"
+      },
+      {
+        "architecture": "x86_64",
+        "checksum": "Q1Onuac6Y+IWA7a4b8FvqX1erWDDw=",
+        "control": {
+          "checksum": "sha1-Onuac6Y+IWA7a4b8FvqX1erWDDw=",
+          "range": "bytes=693-1048"
+        },
+        "data": {
+          "checksum": "sha256-KLtDAs3iU0oyZ/FysePG/J+1H1ofDxHXIY7xvtZhtMc=",
+          "range": "bytes=1049-61503"
         },
         "name": "libverto",
         "signature": {
-          "checksum": "sha1-kuPwakYdy5EM6sd5Ba0K0Ta8x4w=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-/IXL9S1O+MwaW7KsSzz1ywEqKFQ=",
+          "range": "bytes=0-692"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libverto-0.3.2-r3.apk",
-        "version": "0.3.2-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/libverto-0.3.2-r4.apk",
+        "version": "0.3.2-r4"
       },
       {
         "architecture": "x86_64",
@@ -204,60 +204,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1gTZGkWP+QO3mUqLVJth8vrDEzzU=",
+        "checksum": "Q1Q/Zy5ovYSu2p/vVLr6DgVA1e8AQ=",
         "control": {
-          "checksum": "sha1-gTZGkWP+QO3mUqLVJth8vrDEzzU=",
-          "range": "bytes=699-1076"
+          "checksum": "sha1-Q/Zy5ovYSu2p/vVLr6DgVA1e8AQ=",
+          "range": "bytes=699-1062"
         },
         "data": {
-          "checksum": "sha256-/IFXqeKvU0GODNsz1yPIEMcFHgABT+8rbZpSlTLo4e4=",
-          "range": "bytes=1077-5915704"
+          "checksum": "sha256-H3jxsw8ytOeCIR4vq17voSVhdNokXk8C1g075txH6Bs=",
+          "range": "bytes=1063-5903754"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-l1o5ixkyWWqqJE3FOfR0QUemJUA=",
+          "checksum": "sha1-NIl2f5OI/wSZByI8Ds1ZUfbFWyw=",
           "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r9.apk",
-        "version": "3.3.0-r9"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.1-r3.apk",
+        "version": "3.3.1-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1jhAhggAuZnU7FFHnebGA26mq+jI=",
+        "checksum": "Q13wGUXdZut9OOTdY5z2amUj9wXC0=",
         "control": {
-          "checksum": "sha1-jhAhggAuZnU7FFHnebGA26mq+jI=",
-          "range": "bytes=695-1079"
+          "checksum": "sha1-3wGUXdZut9OOTdY5z2amUj9wXC0=",
+          "range": "bytes=698-1068"
         },
         "data": {
-          "checksum": "sha256-XTCQYnhGSm7SkGwqV/TQMFqGajVJVYhKAidKfLb2D3Y=",
-          "range": "bytes=1080-1197081"
+          "checksum": "sha256-mRda6+YGlOCczyIWKaHqXskTINoT1rgorHDHqAKAb7c=",
+          "range": "bytes=1069-1188955"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-qVrfDVxubkrb5Yrd2mFTv2A0G7k=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-+UdRc4U3PKw4H9OiNurHKXa5BYk=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r9.apk",
-        "version": "3.3.0-r9"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.1-r3.apk",
+        "version": "3.3.1-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1BQEXaeya6QB39QLeKcB99qBNF2o=",
+        "checksum": "Q1p04MrHQPrXOzuV/uF290zjnltqI=",
         "control": {
-          "checksum": "sha1-BQEXaeya6QB39QLeKcB99qBNF2o=",
-          "range": "bytes=699-1229"
+          "checksum": "sha1-p04MrHQPrXOzuV/uF290zjnltqI=",
+          "range": "bytes=704-1219"
         },
         "data": {
-          "checksum": "sha256-ugj/qGEBzhvdX17S22Anry+biy3lcqywhGMSHLIBCvo=",
-          "range": "bytes=1230-2551676"
+          "checksum": "sha256-TsXeqhUGykAhjQUEAlMUSzDQBcWDkkDvReoeHCL1F6c=",
+          "range": "bytes=1220-2555814"
         },
         "name": "krb5-libs",
         "signature": {
-          "checksum": "sha1-oqDPmNM4EngXAGayd/BZOqJAIao=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-cPyzS38QHuNlOCQb8IPlsl2PLHQ=",
+          "range": "bytes=0-703"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/krb5-libs-1.21.2-r2.apk",
-        "version": "1.21.2-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/krb5-libs-1.21.3-r0.apk",
+        "version": "1.21.3-r0"
       },
       {
         "architecture": "x86_64",
@@ -280,60 +280,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1wzZwtLauOQfLQC7YUvZdfKxtlwQ=",
+        "checksum": "Q17uprcuQ2VFudMcWAwtP7miJmLYs=",
         "control": {
-          "checksum": "sha1-wzZwtLauOQfLQC7YUvZdfKxtlwQ=",
-          "range": "bytes=698-1085"
+          "checksum": "sha1-7uprcuQ2VFudMcWAwtP7miJmLYs=",
+          "range": "bytes=695-1067"
         },
         "data": {
-          "checksum": "sha256-TO8CAULO44s/LphhtcaFOGJB7aFldk13v1cV9ceZHww=",
-          "range": "bytes=1086-276837"
+          "checksum": "sha256-unKdPbvO2VHZ5w1t1l8mOpQuNdUGwLhofEO4weN2Mig=",
+          "range": "bytes=1068-280973"
         },
         "name": "libuv",
         "signature": {
-          "checksum": "sha1-LRiyeKmjexy8CJizLxjd6ikon1w=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-4lKldnTO71WHMZ4tbANz6i2/Ed0=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libuv-1.48.0-r2.apk",
-        "version": "1.48.0-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libuv-1.48.0-r3.apk",
+        "version": "1.48.0-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q14S6biy8fc5OGbGEJoLBM+tJOGyo=",
+        "checksum": "Q1CN6zJbOPznWUfTrb/41KT7E6dm8=",
         "control": {
-          "checksum": "sha1-4S6biy8fc5OGbGEJoLBM+tJOGyo=",
-          "range": "bytes=703-1102"
+          "checksum": "sha1-CN6zJbOPznWUfTrb/41KT7E6dm8=",
+          "range": "bytes=699-1083"
         },
         "data": {
-          "checksum": "sha256-hwjdLQYfuMAGQeONmFVo0lZKKQK1S+3PBhrI3upm5W4=",
-          "range": "bytes=1103-155304"
+          "checksum": "sha256-ybzFzoQh1yNTcd3cjt54nYsPlAxAcMUcVMxEv1JRnpQ=",
+          "range": "bytes=1084-155375"
         },
         "name": "zlib",
         "signature": {
-          "checksum": "sha1-ZuLd7kE+AGhn27o8ZqDGM5eundc=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-CPXJcCjinAXP+H8Z5tkko8ayG6E=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/zlib-1.3.1-r2.apk",
-        "version": "1.3.1-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/zlib-1.3.1-r3.apk",
+        "version": "1.3.1-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ykDkP+AmDi2VcZZ1c4q4sez/DxI=",
+        "checksum": "Q1rgbci8SRSjW7EB0NSh6ZUPJLndM=",
         "control": {
-          "checksum": "sha1-ykDkP+AmDi2VcZZ1c4q4sez/DxI=",
-          "range": "bytes=705-1079"
+          "checksum": "sha1-rgbci8SRSjW7EB0NSh6ZUPJLndM=",
+          "range": "bytes=702-1060"
         },
         "data": {
-          "checksum": "sha256-t3BrH7lWfY3to3Fu3EKAMZx29v9Hnl5seyXJzLmZ9/4=",
-          "range": "bytes=1080-251884"
+          "checksum": "sha256-tf4xbo+NP+ssiaZtC1kOKehffAZ3+d17bhgfU3/30+g=",
+          "range": "bytes=1061-256582"
         },
         "name": "libnghttp2-14",
         "signature": {
-          "checksum": "sha1-CotSXRaPLKQCBRHrgzrDOD+4w20=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-KrsJYTyUsll+EUhHekbkdZFzeig=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.62.1-r0.apk",
-        "version": "1.62.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.62.1-r1.apk",
+        "version": "1.62.1-r1"
       },
       {
         "architecture": "x86_64",
@@ -394,136 +394,136 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1DE49kWSnmqVKJdjHFYC1bLkvyb0=",
+        "checksum": "Q1R8OxpY0fGwVaIwft4wJeswF5D54=",
         "control": {
-          "checksum": "sha1-DE49kWSnmqVKJdjHFYC1bLkvyb0=",
-          "range": "bytes=697-1078"
+          "checksum": "sha1-R8OxpY0fGwVaIwft4wJeswF5D54=",
+          "range": "bytes=695-1059"
         },
         "data": {
-          "checksum": "sha256-uDg8Qc6Rnro/68Vb5ufFSkqFLGrEsbvPb0pMJNvT1zw=",
-          "range": "bytes=1079-242085"
+          "checksum": "sha256-wNc8/SBJrGHfwywAtzCsAqeUOt0IaAhqNtlbv8OiHBE=",
+          "range": "bytes=1060-242151"
         },
         "name": "c-ares",
         "signature": {
-          "checksum": "sha1-iYEm6EWQKzxkeoDm+QsRfhw8pDg=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-55/PTlEHXI3o0hx9dSVdNwQeSMg=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.29.0-r0.apk",
-        "version": "1.29.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.31.0-r0.apk",
+        "version": "1.31.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q12eWmn2tCkXxwncU6gagKM3Wd9Sk=",
+        "checksum": "Q1g2RQKAvNjlRPxWjinIRveaq7IlY=",
         "control": {
-          "checksum": "sha1-2eWmn2tCkXxwncU6gagKM3Wd9Sk=",
-          "range": "bytes=696-1169"
+          "checksum": "sha1-g2RQKAvNjlRPxWjinIRveaq7IlY=",
+          "range": "bytes=695-1154"
         },
         "data": {
-          "checksum": "sha256-IFKNdojOhml3DbWPryQuHUiV3tgTWHyqOYD1JNe9IJ4=",
-          "range": "bytes=1170-2582015"
+          "checksum": "sha256-UsQFfOTXCZBan0mxDvR+ts0NKcbv1lNijxnRxjsmZhA=",
+          "range": "bytes=1155-2566233"
         },
         "name": "nghttp2",
         "signature": {
-          "checksum": "sha1-2/9n7KbRuOkrvhYqCFR5Mblx+z8=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-SUvMhz1cc5Or5Qh4fUEvPCp0NAw=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.62.1-r0.apk",
-        "version": "1.62.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.62.1-r1.apk",
+        "version": "1.62.1-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ialksjwPWvvZW+O2ABMbbBV/KTg=",
+        "checksum": "Q1sTMGOgdbZyDKxlRAByisPMHTbpY=",
         "control": {
-          "checksum": "sha1-ialksjwPWvvZW+O2ABMbbBV/KTg=",
-          "range": "bytes=702-1074"
+          "checksum": "sha1-sTMGOgdbZyDKxlRAByisPMHTbpY=",
+          "range": "bytes=703-1060"
         },
         "data": {
-          "checksum": "sha256-+ctDr3AO9mTXovGRPWk6h2ZgfY99Toy6esjBNHtJPY4=",
-          "range": "bytes=1075-631903"
+          "checksum": "sha256-bUy0h/zxpq7iP6vrQRMftZ9nevkHTB87hSX17wz4lmM=",
+          "range": "bytes=1061-631449"
         },
         "name": "nghttp2-dev",
         "signature": {
-          "checksum": "sha1-wZGQRluFd6DL1USzeak75o5/BTc=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-fQ6aDq3Io/gdJ5s5t3M+FwED1Y0=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.62.1-r0.apk",
-        "version": "1.62.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.62.1-r1.apk",
+        "version": "1.62.1-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1MlpRL1nBMU3RgNdSZVB42/vlGME=",
+        "checksum": "Q1rD3dEbbN8s5QAIQK1I8uF1O+oSo=",
         "control": {
-          "checksum": "sha1-MlpRL1nBMU3RgNdSZVB42/vlGME=",
-          "range": "bytes=697-1164"
+          "checksum": "sha1-rD3dEbbN8s5QAIQK1I8uF1O+oSo=",
+          "range": "bytes=701-1154"
         },
         "data": {
-          "checksum": "sha256-RiEPDasBVtnThSxGqTCDvb4J7WXM9YRpJwfYZJ3JLbs=",
-          "range": "bytes=1165-2274746"
+          "checksum": "sha256-41W2IRSRALQijYojLaqAiSSN1uO7twatGn8jqEuCZUg=",
+          "range": "bytes=1155-1439872"
         },
         "name": "xz",
         "signature": {
-          "checksum": "sha1-3wMPFIUEVfkAs7QSENemZsnTLyE=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-lozWkVrKvSrd1SoM7Zv08YYG2pA=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/xz-5.4.6-r2.apk",
-        "version": "5.4.6-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/xz-5.6.2-r0.apk",
+        "version": "5.6.2-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1TS707T+cPGL7TYVHQBCJoWwHZ0E=",
+        "checksum": "Q10AaU1ocIM4PYYNvwbml8TmpNvEA=",
         "control": {
-          "checksum": "sha1-TS707T+cPGL7TYVHQBCJoWwHZ0E=",
-          "range": "bytes=706-1098"
+          "checksum": "sha1-0AaU1ocIM4PYYNvwbml8TmpNvEA=",
+          "range": "bytes=706-1085"
         },
         "data": {
-          "checksum": "sha256-x18L706Vug5qDzq13SXuN/vGdVgzrqB06dW2DdgHGR4=",
-          "range": "bytes=1099-4541967"
+          "checksum": "sha256-1YQNYASFjlP3kXX58ec8du75ij/U6O4DPAKzJAPkln0=",
+          "range": "bytes=1086-4272589"
         },
         "name": "libxml2",
         "signature": {
-          "checksum": "sha1-BYhOxDos48sN8df8LMsSpROv2aw=",
+          "checksum": "sha1-QFjdplzGn/MiNFxMykgafr6/w6U=",
           "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.12.7-r0.apk",
-        "version": "2.12.7-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.1-r1.apk",
+        "version": "2.13.1-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1wJPtj5XZtnPiVWGM5dsT+nyfWXc=",
+        "checksum": "Q1wbnfumlWEiJnVUsJBRcQjFD3U6I=",
         "control": {
-          "checksum": "sha1-wJPtj5XZtnPiVWGM5dsT+nyfWXc=",
-          "range": "bytes=705-1234"
+          "checksum": "sha1-wbnfumlWEiJnVUsJBRcQjFD3U6I=",
+          "range": "bytes=699-1222"
         },
         "data": {
-          "checksum": "sha256-sw+CjlpsjO01q6lqzXgHnniiJKn7bqOSNO6vNqdGc7I=",
-          "range": "bytes=1235-3873775"
+          "checksum": "sha256-IXMNbJjj3kTjkWVBIHVRfG3zJQY2r5Eslgh/3TpMSsE=",
+          "range": "bytes=1223-3886778"
         },
         "name": "bind-libs",
         "signature": {
-          "checksum": "sha1-9zDzmHAeu7mWpidXAatqrLZVzUs=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-JNN15IPpJ2hMsO6hFVpDYPvvX5g=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bind-libs-9.18.26-r0.apk",
-        "version": "9.18.26-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/bind-libs-9.18.27-r1.apk",
+        "version": "9.18.27-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1AxEQdi8fVcYtGc3zHTCW3OZdY2Q=",
+        "checksum": "Q1kXUOoNa2KXixxAASo1W/im1qZ7s=",
         "control": {
-          "checksum": "sha1-AxEQdi8fVcYtGc3zHTCW3OZdY2Q=",
-          "range": "bytes=694-1208"
+          "checksum": "sha1-kXUOoNa2KXixxAASo1W/im1qZ7s=",
+          "range": "bytes=702-1215"
         },
         "data": {
-          "checksum": "sha256-/dt3qJw5D9iSJ/mKkRQkhWD8R52selhpcwXyw7KLMhg=",
-          "range": "bytes=1209-879444"
+          "checksum": "sha256-HRADvfRXfYsgEjUMGM4Hd7prpIv+YWILVfovbGOkEME=",
+          "range": "bytes=1216-879975"
         },
         "name": "bind-tools",
         "signature": {
-          "checksum": "sha1-VTb0YdUzPMk8Po0p4nj0y5Jey6k=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-8WUTMUaJTaX0T9FS/c+GddL7ttY=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bind-tools-9.18.26-r0.apk",
-        "version": "9.18.26-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/bind-tools-9.18.27-r1.apk",
+        "version": "9.18.27-r1"
       },
       {
         "architecture": "x86_64",
@@ -641,60 +641,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1fr0OtiVaD3c5nw8fy5m74hDe9PU=",
+        "checksum": "Q1BRGmQ9LZTeZqbxQ1ls69T6efViw=",
         "control": {
-          "checksum": "sha1-fr0OtiVaD3c5nw8fy5m74hDe9PU=",
-          "range": "bytes=697-1092"
+          "checksum": "sha1-BRGmQ9LZTeZqbxQ1ls69T6efViw=",
+          "range": "bytes=698-1080"
         },
         "data": {
-          "checksum": "sha256-lukjMYpGmuhBNDUbbTJMIrUWaR4rNikEnW4BgiTaLj8=",
-          "range": "bytes=1093-113872"
+          "checksum": "sha256-vtJ4WJ5M+31ZKSBYBedbrl/FrbAw8hGpPRrHC7kasOk=",
+          "range": "bytes=1081-113895"
         },
         "name": "libpsl",
         "signature": {
-          "checksum": "sha1-Lrrudgn1i1a0JhjdzeXG+exnjQA=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-DuAoiykwhu8vu1qxdEDK5oyAmf8=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libpsl-0.21.5-r2.apk",
-        "version": "0.21.5-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libpsl-0.21.5-r3.apk",
+        "version": "0.21.5-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1oauHQa0YcFcEHSQWdfohfNEN4sY=",
+        "checksum": "Q11DZVpe2UYyDr/dG6BDysZhE3L48=",
         "control": {
-          "checksum": "sha1-oauHQa0YcFcEHSQWdfohfNEN4sY=",
-          "range": "bytes=698-1057"
+          "checksum": "sha1-1DZVpe2UYyDr/dG6BDysZhE3L48=",
+          "range": "bytes=707-1049"
         },
         "data": {
-          "checksum": "sha256-d95c9lpjQrpuZ1CcQ8ZZ89LAGGKcessd+hxrOQpP4LU=",
-          "range": "bytes=1058-173549"
+          "checksum": "sha256-aECfsy7giZsLNxZM0HMeF4OS2gu+ycX4DUTJXsiZRQs=",
+          "range": "bytes=1050-173585"
         },
         "name": "libbrotlicommon1",
         "signature": {
-          "checksum": "sha1-g3ufBq/tyiNP6AaOoqwItVvh7uk=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-7LXD38QwFhklZCEqyW4qIncfZV0=",
+          "range": "bytes=0-706"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlicommon1-1.1.0-r2.apk",
-        "version": "1.1.0-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlicommon1-1.1.0-r3.apk",
+        "version": "1.1.0-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q18Otq7NLoYnNMebI/1Rr/s0zdLVw=",
+        "checksum": "Q1Cgr886A8Ryzynz9pxRKsNybVuK0=",
         "control": {
-          "checksum": "sha1-8Otq7NLoYnNMebI/1Rr/s0zdLVw=",
-          "range": "bytes=705-1072"
+          "checksum": "sha1-Cgr886A8Ryzynz9pxRKsNybVuK0=",
+          "range": "bytes=694-1043"
         },
         "data": {
-          "checksum": "sha256-sR3QidR/e46PJ/3S2fxAjN/hRSSA3Ar32Nw7VshTHWg=",
-          "range": "bytes=1073-81475"
+          "checksum": "sha256-mH+MTbqpLiqgydlgE+tSDEt0Sh1/zqMvAqspV4lr+Ks=",
+          "range": "bytes=1044-81511"
         },
         "name": "libbrotlidec1",
         "signature": {
-          "checksum": "sha1-6GpZI5cBUXOvjCYG81aZZR53lMI=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-Yp4Bde9oHQCec8HM2qn6hVKgtko=",
+          "range": "bytes=0-693"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlidec1-1.1.0-r2.apk",
-        "version": "1.1.0-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlidec1-1.1.0-r3.apk",
+        "version": "1.1.0-r3"
       },
       {
         "architecture": "x86_64",
@@ -774,22 +774,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q19f/3419Xa/xv9jgQ0mMYs011fBk=",
+        "checksum": "Q1mTmy64gKYi4THBqewuvYL2uUyHc=",
         "control": {
-          "checksum": "sha1-9f/3419Xa/xv9jgQ0mMYs011fBk=",
-          "range": "bytes=696-1041"
+          "checksum": "sha1-mTmy64gKYi4THBqewuvYL2uUyHc=",
+          "range": "bytes=700-1031"
         },
         "data": {
-          "checksum": "sha256-iqHASiMgiu6rIjbWGwBmmq1Zthae8BkE4QZkiVPH7Ek=",
-          "range": "bytes=1042-1888945"
+          "checksum": "sha256-p0qua2luH33oAgOcLkU9f7k+I8WnykFszVMwNahujDA=",
+          "range": "bytes=1032-1889523"
         },
         "name": "tzdata",
         "signature": {
-          "checksum": "sha1-PCC3jiXlTwrimRMXH/4RyNvccOM=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-sBf5jVLVpWj4DiXaAd/mjo0pTfk=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/tzdata-2024a-r2.apk",
-        "version": "2024a-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/tzdata-2024a-r3.apk",
+        "version": "2024a-r3"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/search-indexer.lock.json
+++ b/wolfi-images/search-indexer.lock.json
@@ -14,41 +14,41 @@
     "packages": [
       {
         "architecture": "x86_64",
-        "checksum": "Q1ge3SLQsJ9v2RnvIHHAP1yFyjrEU=",
+        "checksum": "Q1Ai8jWuxKZR2M2XhOpOGAoTEwnnk=",
         "control": {
-          "checksum": "sha1-ge3SLQsJ9v2RnvIHHAP1yFyjrEU=",
-          "range": "bytes=693-1040"
+          "checksum": "sha1-Ai8jWuxKZR2M2XhOpOGAoTEwnnk=",
+          "range": "bytes=705-1037"
         },
         "data": {
-          "checksum": "sha256-I0AdTdfGf4P/jwzTrLXm73l5/RNSlymEof/YZfev3xY=",
-          "range": "bytes=1041-255811"
+          "checksum": "sha256-e4UardkBVyaC49aSyrVmXNi8sSKqQl4eKYd0LxGRLA0=",
+          "range": "bytes=1038-255695"
         },
         "name": "ca-certificates-bundle",
         "signature": {
-          "checksum": "sha1-ge1eJBiQmFWAn9GapFkQpO+Rn/Y=",
-          "range": "bytes=0-692"
+          "checksum": "sha1-loRuyYQLm+atp+YteiQoj++EWIM=",
+          "range": "bytes=0-704"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20240315-r3.apk",
-        "version": "20240315-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20240315-r4.apk",
+        "version": "20240315-r4"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1bgay5kOzpmDBgqJCg7dSlawyJg0=",
+        "checksum": "Q1+GH6qRN4iy1IDt0cT0x0tin7YfI=",
         "control": {
-          "checksum": "sha1-bgay5kOzpmDBgqJCg7dSlawyJg0=",
-          "range": "bytes=703-1067"
+          "checksum": "sha1-+GH6qRN4iy1IDt0cT0x0tin7YfI=",
+          "range": "bytes=703-1051"
         },
         "data": {
-          "checksum": "sha256-f83HfRE7r2ZniH7PyPmRqcoU5NTpF+Uk4FH80QbjvBM=",
-          "range": "bytes=1068-118370"
+          "checksum": "sha256-rO0P9z2V49BSrz1A5Ap69tEappVrg5MMBjzW00rOpZc=",
+          "range": "bytes=1052-122464"
         },
         "name": "wolfi-baselayout",
         "signature": {
-          "checksum": "sha1-2hlCvYH1D7u25HkJGA75jjs/sQY=",
+          "checksum": "sha1-Ntb6VuMzDfM+frpCjKEIpDzl53I=",
           "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r11.apk",
-        "version": "20230201-r11"
+        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r12.apk",
+        "version": "20230201-r12"
       },
       {
         "architecture": "x86_64",
@@ -109,41 +109,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Zjfs1uR/mYiortANP+EFcejW+vo=",
+        "checksum": "Q1Zi0e8Bq6WCd/6uXXjVhb8YwMD1U=",
         "control": {
-          "checksum": "sha1-Zjfs1uR/mYiortANP+EFcejW+vo=",
-          "range": "bytes=698-1085"
+          "checksum": "sha1-Zi0e8Bq6WCd/6uXXjVhb8YwMD1U=",
+          "range": "bytes=700-1073"
         },
         "data": {
-          "checksum": "sha256-BMd7TzffjbrFwdbopDPVYsX0X9XnusIMNbIf33/8kwc=",
-          "range": "bytes=1086-76881"
+          "checksum": "sha256-jMhtfqVjnhuuBO7wtNZ6RS/72sZWoKt/Moage2amlks=",
+          "range": "bytes=1074-81594"
         },
         "name": "protobuf-c",
         "signature": {
-          "checksum": "sha1-efGiXyYWsJ5P2uTkB6aXEZ3kl3o=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-kATwMKztK7nk7qbYCJPkCFp6IXc=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r4.apk",
-        "version": "1.5.0-r4"
-      },
-      {
-        "architecture": "x86_64",
-        "checksum": "Q1Xf5v5uXumBgIR4d4ZxMRxdpyWlM=",
-        "control": {
-          "checksum": "sha1-Xf5v5uXumBgIR4d4ZxMRxdpyWlM=",
-          "range": "bytes=698-1078"
-        },
-        "data": {
-          "checksum": "sha256-eD7HqFCWNUBQiLq9PcWE/zPeZwkiv8hBrytI4qmfQ/8=",
-          "range": "bytes=1079-57055"
-        },
-        "name": "keyutils-libs",
-        "signature": {
-          "checksum": "sha1-V0HVgZLP7P5kNACfus3abCLCS20=",
-          "range": "bytes=0-697"
-        },
-        "url": "https://packages.wolfi.dev/os/x86_64/keyutils-libs-1.6.3-r2.apk",
-        "version": "1.6.3-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r5.apk",
+        "version": "1.5.0-r5"
       },
       {
         "architecture": "x86_64",
@@ -166,22 +147,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1wRzOx+L6MeRFtTcq2y/6ot7Cj54=",
+        "checksum": "Q1v0A2vQM5k8rQY/GpIq6xI4T0YmA=",
         "control": {
-          "checksum": "sha1-wRzOx+L6MeRFtTcq2y/6ot7Cj54=",
-          "range": "bytes=699-1069"
+          "checksum": "sha1-v0A2vQM5k8rQY/GpIq6xI4T0YmA=",
+          "range": "bytes=701-1064"
         },
         "data": {
-          "checksum": "sha256-gNRjwZ4XQatCYWediSVb+j8lS54CggvMC5Dn3qT84So=",
-          "range": "bytes=1070-61490"
+          "checksum": "sha256-uAOrkGDDc/yqt6VjIrlTEALBJG4BCI4njqZw5jQqF0o=",
+          "range": "bytes=1065-56984"
+        },
+        "name": "keyutils-libs",
+        "signature": {
+          "checksum": "sha1-32uYMH/zGBr9Jo3hiqnThlcqBcE=",
+          "range": "bytes=0-700"
+        },
+        "url": "https://packages.wolfi.dev/os/x86_64/keyutils-libs-1.6.3-r3.apk",
+        "version": "1.6.3-r3"
+      },
+      {
+        "architecture": "x86_64",
+        "checksum": "Q1Onuac6Y+IWA7a4b8FvqX1erWDDw=",
+        "control": {
+          "checksum": "sha1-Onuac6Y+IWA7a4b8FvqX1erWDDw=",
+          "range": "bytes=693-1048"
+        },
+        "data": {
+          "checksum": "sha256-KLtDAs3iU0oyZ/FysePG/J+1H1ofDxHXIY7xvtZhtMc=",
+          "range": "bytes=1049-61503"
         },
         "name": "libverto",
         "signature": {
-          "checksum": "sha1-kuPwakYdy5EM6sd5Ba0K0Ta8x4w=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-/IXL9S1O+MwaW7KsSzz1ywEqKFQ=",
+          "range": "bytes=0-692"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libverto-0.3.2-r3.apk",
-        "version": "0.3.2-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/libverto-0.3.2-r4.apk",
+        "version": "0.3.2-r4"
       },
       {
         "architecture": "x86_64",
@@ -204,60 +204,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1gTZGkWP+QO3mUqLVJth8vrDEzzU=",
+        "checksum": "Q1Q/Zy5ovYSu2p/vVLr6DgVA1e8AQ=",
         "control": {
-          "checksum": "sha1-gTZGkWP+QO3mUqLVJth8vrDEzzU=",
-          "range": "bytes=699-1076"
+          "checksum": "sha1-Q/Zy5ovYSu2p/vVLr6DgVA1e8AQ=",
+          "range": "bytes=699-1062"
         },
         "data": {
-          "checksum": "sha256-/IFXqeKvU0GODNsz1yPIEMcFHgABT+8rbZpSlTLo4e4=",
-          "range": "bytes=1077-5915704"
+          "checksum": "sha256-H3jxsw8ytOeCIR4vq17voSVhdNokXk8C1g075txH6Bs=",
+          "range": "bytes=1063-5903754"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-l1o5ixkyWWqqJE3FOfR0QUemJUA=",
+          "checksum": "sha1-NIl2f5OI/wSZByI8Ds1ZUfbFWyw=",
           "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r9.apk",
-        "version": "3.3.0-r9"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.1-r3.apk",
+        "version": "3.3.1-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1jhAhggAuZnU7FFHnebGA26mq+jI=",
+        "checksum": "Q13wGUXdZut9OOTdY5z2amUj9wXC0=",
         "control": {
-          "checksum": "sha1-jhAhggAuZnU7FFHnebGA26mq+jI=",
-          "range": "bytes=695-1079"
+          "checksum": "sha1-3wGUXdZut9OOTdY5z2amUj9wXC0=",
+          "range": "bytes=698-1068"
         },
         "data": {
-          "checksum": "sha256-XTCQYnhGSm7SkGwqV/TQMFqGajVJVYhKAidKfLb2D3Y=",
-          "range": "bytes=1080-1197081"
+          "checksum": "sha256-mRda6+YGlOCczyIWKaHqXskTINoT1rgorHDHqAKAb7c=",
+          "range": "bytes=1069-1188955"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-qVrfDVxubkrb5Yrd2mFTv2A0G7k=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-+UdRc4U3PKw4H9OiNurHKXa5BYk=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r9.apk",
-        "version": "3.3.0-r9"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.1-r3.apk",
+        "version": "3.3.1-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1BQEXaeya6QB39QLeKcB99qBNF2o=",
+        "checksum": "Q1p04MrHQPrXOzuV/uF290zjnltqI=",
         "control": {
-          "checksum": "sha1-BQEXaeya6QB39QLeKcB99qBNF2o=",
-          "range": "bytes=699-1229"
+          "checksum": "sha1-p04MrHQPrXOzuV/uF290zjnltqI=",
+          "range": "bytes=704-1219"
         },
         "data": {
-          "checksum": "sha256-ugj/qGEBzhvdX17S22Anry+biy3lcqywhGMSHLIBCvo=",
-          "range": "bytes=1230-2551676"
+          "checksum": "sha256-TsXeqhUGykAhjQUEAlMUSzDQBcWDkkDvReoeHCL1F6c=",
+          "range": "bytes=1220-2555814"
         },
         "name": "krb5-libs",
         "signature": {
-          "checksum": "sha1-oqDPmNM4EngXAGayd/BZOqJAIao=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-cPyzS38QHuNlOCQb8IPlsl2PLHQ=",
+          "range": "bytes=0-703"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/krb5-libs-1.21.2-r2.apk",
-        "version": "1.21.2-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/krb5-libs-1.21.3-r0.apk",
+        "version": "1.21.3-r0"
       },
       {
         "architecture": "x86_64",
@@ -280,60 +280,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1wzZwtLauOQfLQC7YUvZdfKxtlwQ=",
+        "checksum": "Q17uprcuQ2VFudMcWAwtP7miJmLYs=",
         "control": {
-          "checksum": "sha1-wzZwtLauOQfLQC7YUvZdfKxtlwQ=",
-          "range": "bytes=698-1085"
+          "checksum": "sha1-7uprcuQ2VFudMcWAwtP7miJmLYs=",
+          "range": "bytes=695-1067"
         },
         "data": {
-          "checksum": "sha256-TO8CAULO44s/LphhtcaFOGJB7aFldk13v1cV9ceZHww=",
-          "range": "bytes=1086-276837"
+          "checksum": "sha256-unKdPbvO2VHZ5w1t1l8mOpQuNdUGwLhofEO4weN2Mig=",
+          "range": "bytes=1068-280973"
         },
         "name": "libuv",
         "signature": {
-          "checksum": "sha1-LRiyeKmjexy8CJizLxjd6ikon1w=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-4lKldnTO71WHMZ4tbANz6i2/Ed0=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libuv-1.48.0-r2.apk",
-        "version": "1.48.0-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libuv-1.48.0-r3.apk",
+        "version": "1.48.0-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q14S6biy8fc5OGbGEJoLBM+tJOGyo=",
+        "checksum": "Q1CN6zJbOPznWUfTrb/41KT7E6dm8=",
         "control": {
-          "checksum": "sha1-4S6biy8fc5OGbGEJoLBM+tJOGyo=",
-          "range": "bytes=703-1102"
+          "checksum": "sha1-CN6zJbOPznWUfTrb/41KT7E6dm8=",
+          "range": "bytes=699-1083"
         },
         "data": {
-          "checksum": "sha256-hwjdLQYfuMAGQeONmFVo0lZKKQK1S+3PBhrI3upm5W4=",
-          "range": "bytes=1103-155304"
+          "checksum": "sha256-ybzFzoQh1yNTcd3cjt54nYsPlAxAcMUcVMxEv1JRnpQ=",
+          "range": "bytes=1084-155375"
         },
         "name": "zlib",
         "signature": {
-          "checksum": "sha1-ZuLd7kE+AGhn27o8ZqDGM5eundc=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-CPXJcCjinAXP+H8Z5tkko8ayG6E=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/zlib-1.3.1-r2.apk",
-        "version": "1.3.1-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/zlib-1.3.1-r3.apk",
+        "version": "1.3.1-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ykDkP+AmDi2VcZZ1c4q4sez/DxI=",
+        "checksum": "Q1rgbci8SRSjW7EB0NSh6ZUPJLndM=",
         "control": {
-          "checksum": "sha1-ykDkP+AmDi2VcZZ1c4q4sez/DxI=",
-          "range": "bytes=705-1079"
+          "checksum": "sha1-rgbci8SRSjW7EB0NSh6ZUPJLndM=",
+          "range": "bytes=702-1060"
         },
         "data": {
-          "checksum": "sha256-t3BrH7lWfY3to3Fu3EKAMZx29v9Hnl5seyXJzLmZ9/4=",
-          "range": "bytes=1080-251884"
+          "checksum": "sha256-tf4xbo+NP+ssiaZtC1kOKehffAZ3+d17bhgfU3/30+g=",
+          "range": "bytes=1061-256582"
         },
         "name": "libnghttp2-14",
         "signature": {
-          "checksum": "sha1-CotSXRaPLKQCBRHrgzrDOD+4w20=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-KrsJYTyUsll+EUhHekbkdZFzeig=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.62.1-r0.apk",
-        "version": "1.62.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.62.1-r1.apk",
+        "version": "1.62.1-r1"
       },
       {
         "architecture": "x86_64",
@@ -394,136 +394,136 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1DE49kWSnmqVKJdjHFYC1bLkvyb0=",
+        "checksum": "Q1R8OxpY0fGwVaIwft4wJeswF5D54=",
         "control": {
-          "checksum": "sha1-DE49kWSnmqVKJdjHFYC1bLkvyb0=",
-          "range": "bytes=697-1078"
+          "checksum": "sha1-R8OxpY0fGwVaIwft4wJeswF5D54=",
+          "range": "bytes=695-1059"
         },
         "data": {
-          "checksum": "sha256-uDg8Qc6Rnro/68Vb5ufFSkqFLGrEsbvPb0pMJNvT1zw=",
-          "range": "bytes=1079-242085"
+          "checksum": "sha256-wNc8/SBJrGHfwywAtzCsAqeUOt0IaAhqNtlbv8OiHBE=",
+          "range": "bytes=1060-242151"
         },
         "name": "c-ares",
         "signature": {
-          "checksum": "sha1-iYEm6EWQKzxkeoDm+QsRfhw8pDg=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-55/PTlEHXI3o0hx9dSVdNwQeSMg=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.29.0-r0.apk",
-        "version": "1.29.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.31.0-r0.apk",
+        "version": "1.31.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q12eWmn2tCkXxwncU6gagKM3Wd9Sk=",
+        "checksum": "Q1g2RQKAvNjlRPxWjinIRveaq7IlY=",
         "control": {
-          "checksum": "sha1-2eWmn2tCkXxwncU6gagKM3Wd9Sk=",
-          "range": "bytes=696-1169"
+          "checksum": "sha1-g2RQKAvNjlRPxWjinIRveaq7IlY=",
+          "range": "bytes=695-1154"
         },
         "data": {
-          "checksum": "sha256-IFKNdojOhml3DbWPryQuHUiV3tgTWHyqOYD1JNe9IJ4=",
-          "range": "bytes=1170-2582015"
+          "checksum": "sha256-UsQFfOTXCZBan0mxDvR+ts0NKcbv1lNijxnRxjsmZhA=",
+          "range": "bytes=1155-2566233"
         },
         "name": "nghttp2",
         "signature": {
-          "checksum": "sha1-2/9n7KbRuOkrvhYqCFR5Mblx+z8=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-SUvMhz1cc5Or5Qh4fUEvPCp0NAw=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.62.1-r0.apk",
-        "version": "1.62.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.62.1-r1.apk",
+        "version": "1.62.1-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ialksjwPWvvZW+O2ABMbbBV/KTg=",
+        "checksum": "Q1sTMGOgdbZyDKxlRAByisPMHTbpY=",
         "control": {
-          "checksum": "sha1-ialksjwPWvvZW+O2ABMbbBV/KTg=",
-          "range": "bytes=702-1074"
+          "checksum": "sha1-sTMGOgdbZyDKxlRAByisPMHTbpY=",
+          "range": "bytes=703-1060"
         },
         "data": {
-          "checksum": "sha256-+ctDr3AO9mTXovGRPWk6h2ZgfY99Toy6esjBNHtJPY4=",
-          "range": "bytes=1075-631903"
+          "checksum": "sha256-bUy0h/zxpq7iP6vrQRMftZ9nevkHTB87hSX17wz4lmM=",
+          "range": "bytes=1061-631449"
         },
         "name": "nghttp2-dev",
         "signature": {
-          "checksum": "sha1-wZGQRluFd6DL1USzeak75o5/BTc=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-fQ6aDq3Io/gdJ5s5t3M+FwED1Y0=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.62.1-r0.apk",
-        "version": "1.62.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.62.1-r1.apk",
+        "version": "1.62.1-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1MlpRL1nBMU3RgNdSZVB42/vlGME=",
+        "checksum": "Q1rD3dEbbN8s5QAIQK1I8uF1O+oSo=",
         "control": {
-          "checksum": "sha1-MlpRL1nBMU3RgNdSZVB42/vlGME=",
-          "range": "bytes=697-1164"
+          "checksum": "sha1-rD3dEbbN8s5QAIQK1I8uF1O+oSo=",
+          "range": "bytes=701-1154"
         },
         "data": {
-          "checksum": "sha256-RiEPDasBVtnThSxGqTCDvb4J7WXM9YRpJwfYZJ3JLbs=",
-          "range": "bytes=1165-2274746"
+          "checksum": "sha256-41W2IRSRALQijYojLaqAiSSN1uO7twatGn8jqEuCZUg=",
+          "range": "bytes=1155-1439872"
         },
         "name": "xz",
         "signature": {
-          "checksum": "sha1-3wMPFIUEVfkAs7QSENemZsnTLyE=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-lozWkVrKvSrd1SoM7Zv08YYG2pA=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/xz-5.4.6-r2.apk",
-        "version": "5.4.6-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/xz-5.6.2-r0.apk",
+        "version": "5.6.2-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1TS707T+cPGL7TYVHQBCJoWwHZ0E=",
+        "checksum": "Q10AaU1ocIM4PYYNvwbml8TmpNvEA=",
         "control": {
-          "checksum": "sha1-TS707T+cPGL7TYVHQBCJoWwHZ0E=",
-          "range": "bytes=706-1098"
+          "checksum": "sha1-0AaU1ocIM4PYYNvwbml8TmpNvEA=",
+          "range": "bytes=706-1085"
         },
         "data": {
-          "checksum": "sha256-x18L706Vug5qDzq13SXuN/vGdVgzrqB06dW2DdgHGR4=",
-          "range": "bytes=1099-4541967"
+          "checksum": "sha256-1YQNYASFjlP3kXX58ec8du75ij/U6O4DPAKzJAPkln0=",
+          "range": "bytes=1086-4272589"
         },
         "name": "libxml2",
         "signature": {
-          "checksum": "sha1-BYhOxDos48sN8df8LMsSpROv2aw=",
+          "checksum": "sha1-QFjdplzGn/MiNFxMykgafr6/w6U=",
           "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.12.7-r0.apk",
-        "version": "2.12.7-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.1-r1.apk",
+        "version": "2.13.1-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1wJPtj5XZtnPiVWGM5dsT+nyfWXc=",
+        "checksum": "Q1wbnfumlWEiJnVUsJBRcQjFD3U6I=",
         "control": {
-          "checksum": "sha1-wJPtj5XZtnPiVWGM5dsT+nyfWXc=",
-          "range": "bytes=705-1234"
+          "checksum": "sha1-wbnfumlWEiJnVUsJBRcQjFD3U6I=",
+          "range": "bytes=699-1222"
         },
         "data": {
-          "checksum": "sha256-sw+CjlpsjO01q6lqzXgHnniiJKn7bqOSNO6vNqdGc7I=",
-          "range": "bytes=1235-3873775"
+          "checksum": "sha256-IXMNbJjj3kTjkWVBIHVRfG3zJQY2r5Eslgh/3TpMSsE=",
+          "range": "bytes=1223-3886778"
         },
         "name": "bind-libs",
         "signature": {
-          "checksum": "sha1-9zDzmHAeu7mWpidXAatqrLZVzUs=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-JNN15IPpJ2hMsO6hFVpDYPvvX5g=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bind-libs-9.18.26-r0.apk",
-        "version": "9.18.26-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/bind-libs-9.18.27-r1.apk",
+        "version": "9.18.27-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1AxEQdi8fVcYtGc3zHTCW3OZdY2Q=",
+        "checksum": "Q1kXUOoNa2KXixxAASo1W/im1qZ7s=",
         "control": {
-          "checksum": "sha1-AxEQdi8fVcYtGc3zHTCW3OZdY2Q=",
-          "range": "bytes=694-1208"
+          "checksum": "sha1-kXUOoNa2KXixxAASo1W/im1qZ7s=",
+          "range": "bytes=702-1215"
         },
         "data": {
-          "checksum": "sha256-/dt3qJw5D9iSJ/mKkRQkhWD8R52selhpcwXyw7KLMhg=",
-          "range": "bytes=1209-879444"
+          "checksum": "sha256-HRADvfRXfYsgEjUMGM4Hd7prpIv+YWILVfovbGOkEME=",
+          "range": "bytes=1216-879975"
         },
         "name": "bind-tools",
         "signature": {
-          "checksum": "sha1-VTb0YdUzPMk8Po0p4nj0y5Jey6k=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-8WUTMUaJTaX0T9FS/c+GddL7ttY=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bind-tools-9.18.26-r0.apk",
-        "version": "9.18.26-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/bind-tools-9.18.27-r1.apk",
+        "version": "9.18.27-r1"
       },
       {
         "architecture": "x86_64",
@@ -584,22 +584,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1XvuhvUSvcah2GSDqXjzZ3s2gxP0=",
+        "checksum": "Q18GWimtzBPBcoLLvO1qkSUgU8lnY=",
         "control": {
-          "checksum": "sha1-XvuhvUSvcah2GSDqXjzZ3s2gxP0=",
-          "range": "bytes=704-1059"
+          "checksum": "sha1-8GWimtzBPBcoLLvO1qkSUgU8lnY=",
+          "range": "bytes=703-1059"
         },
         "data": {
-          "checksum": "sha256-5El7qY7swpzsMszBT3d1Qml1POftfwUyQg65MopTlQY=",
-          "range": "bytes=1060-103661"
+          "checksum": "sha256-gbfqvYRPtP/Psse3jpUh1M2btMStrDYp7S8S5KKk1gc=",
+          "range": "bytes=1060-99122"
         },
         "name": "jansson",
         "signature": {
-          "checksum": "sha1-S1w/d1pn3Z/Md0gX/qJN+cZZ1uw=",
-          "range": "bytes=0-703"
+          "checksum": "sha1-7T/ORwcPkbnmMZiRs2mQ7MVjTBY=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/jansson-2.14-r1.apk",
-        "version": "2.14-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/jansson-2.14-r2.apk",
+        "version": "2.14-r2"
       },
       {
         "architecture": "x86_64",
@@ -660,60 +660,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1fr0OtiVaD3c5nw8fy5m74hDe9PU=",
+        "checksum": "Q1BRGmQ9LZTeZqbxQ1ls69T6efViw=",
         "control": {
-          "checksum": "sha1-fr0OtiVaD3c5nw8fy5m74hDe9PU=",
-          "range": "bytes=697-1092"
+          "checksum": "sha1-BRGmQ9LZTeZqbxQ1ls69T6efViw=",
+          "range": "bytes=698-1080"
         },
         "data": {
-          "checksum": "sha256-lukjMYpGmuhBNDUbbTJMIrUWaR4rNikEnW4BgiTaLj8=",
-          "range": "bytes=1093-113872"
+          "checksum": "sha256-vtJ4WJ5M+31ZKSBYBedbrl/FrbAw8hGpPRrHC7kasOk=",
+          "range": "bytes=1081-113895"
         },
         "name": "libpsl",
         "signature": {
-          "checksum": "sha1-Lrrudgn1i1a0JhjdzeXG+exnjQA=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-DuAoiykwhu8vu1qxdEDK5oyAmf8=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libpsl-0.21.5-r2.apk",
-        "version": "0.21.5-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libpsl-0.21.5-r3.apk",
+        "version": "0.21.5-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1oauHQa0YcFcEHSQWdfohfNEN4sY=",
+        "checksum": "Q11DZVpe2UYyDr/dG6BDysZhE3L48=",
         "control": {
-          "checksum": "sha1-oauHQa0YcFcEHSQWdfohfNEN4sY=",
-          "range": "bytes=698-1057"
+          "checksum": "sha1-1DZVpe2UYyDr/dG6BDysZhE3L48=",
+          "range": "bytes=707-1049"
         },
         "data": {
-          "checksum": "sha256-d95c9lpjQrpuZ1CcQ8ZZ89LAGGKcessd+hxrOQpP4LU=",
-          "range": "bytes=1058-173549"
+          "checksum": "sha256-aECfsy7giZsLNxZM0HMeF4OS2gu+ycX4DUTJXsiZRQs=",
+          "range": "bytes=1050-173585"
         },
         "name": "libbrotlicommon1",
         "signature": {
-          "checksum": "sha1-g3ufBq/tyiNP6AaOoqwItVvh7uk=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-7LXD38QwFhklZCEqyW4qIncfZV0=",
+          "range": "bytes=0-706"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlicommon1-1.1.0-r2.apk",
-        "version": "1.1.0-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlicommon1-1.1.0-r3.apk",
+        "version": "1.1.0-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q18Otq7NLoYnNMebI/1Rr/s0zdLVw=",
+        "checksum": "Q1Cgr886A8Ryzynz9pxRKsNybVuK0=",
         "control": {
-          "checksum": "sha1-8Otq7NLoYnNMebI/1Rr/s0zdLVw=",
-          "range": "bytes=705-1072"
+          "checksum": "sha1-Cgr886A8Ryzynz9pxRKsNybVuK0=",
+          "range": "bytes=694-1043"
         },
         "data": {
-          "checksum": "sha256-sR3QidR/e46PJ/3S2fxAjN/hRSSA3Ar32Nw7VshTHWg=",
-          "range": "bytes=1073-81475"
+          "checksum": "sha256-mH+MTbqpLiqgydlgE+tSDEt0Sh1/zqMvAqspV4lr+Ks=",
+          "range": "bytes=1044-81511"
         },
         "name": "libbrotlidec1",
         "signature": {
-          "checksum": "sha1-6GpZI5cBUXOvjCYG81aZZR53lMI=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-Yp4Bde9oHQCec8HM2qn6hVKgtko=",
+          "range": "bytes=0-693"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlidec1-1.1.0-r2.apk",
-        "version": "1.1.0-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlidec1-1.1.0-r3.apk",
+        "version": "1.1.0-r3"
       },
       {
         "architecture": "x86_64",
@@ -774,41 +774,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1uIKbAiTl7xWbpJXy11+HeOS/RDo=",
+        "checksum": "Q1+FlR1zI7qp3uiJm5fHTA4Hr1lSQ=",
         "control": {
-          "checksum": "sha1-uIKbAiTl7xWbpJXy11+HeOS/RDo=",
-          "range": "bytes=694-1075"
+          "checksum": "sha1-+FlR1zI7qp3uiJm5fHTA4Hr1lSQ=",
+          "range": "bytes=698-1064"
         },
         "data": {
-          "checksum": "sha256-qUT47e+MUydc5TG+6YjAi7LyDOWQeOyP5dlfnPBWRWM=",
-          "range": "bytes=1076-697425"
+          "checksum": "sha256-jx/MzLqQnCOtZqAiH6LmBTCiTD9HId1TLO3GZFDqHxQ=",
+          "range": "bytes=1065-685148"
         },
         "name": "libpcre2-8-0",
         "signature": {
-          "checksum": "sha1-T6Z2q5sW3pwjztCXPRoQKi8rfeY=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-4ZNzjpofU2aV2PzFb9SFo9ipHLE=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libpcre2-8-0-10.43-r1.apk",
-        "version": "10.43-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libpcre2-8-0-10.44-r1.apk",
+        "version": "10.44-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q111Aq+tDFOygcfZzOg1hQbtZw1Q4=",
+        "checksum": "Q1Xg04pU313NQ+1ni/3EGFESveG28=",
         "control": {
-          "checksum": "sha1-11Aq+tDFOygcfZzOg1hQbtZw1Q4=",
-          "range": "bytes=697-1140"
+          "checksum": "sha1-Xg04pU313NQ+1ni/3EGFESveG28=",
+          "range": "bytes=694-1135"
         },
         "data": {
-          "checksum": "sha256-ednk20seorMQ+xEGnt8zWpxO20xrfj7zOtAmk+XcTbA=",
-          "range": "bytes=1141-17250210"
+          "checksum": "sha256-rgB0/iCkskRu0z50yJPj5UbCkDqeT48PaLInXkivQh4=",
+          "range": "bytes=1136-17250228"
         },
         "name": "git",
         "signature": {
-          "checksum": "sha1-T1C3/QmQvuJGLjPH2YyOLIM5ewE=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-oiYirHB8Oqxgza8ivbRUYOy39i8=",
+          "range": "bytes=0-693"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/git-2.45.2-r0.apk",
-        "version": "2.45.2-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/git-2.45.2-r2.apk",
+        "version": "2.45.2-r2"
       },
       {
         "architecture": "x86_64",
@@ -850,22 +850,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q19f/3419Xa/xv9jgQ0mMYs011fBk=",
+        "checksum": "Q1mTmy64gKYi4THBqewuvYL2uUyHc=",
         "control": {
-          "checksum": "sha1-9f/3419Xa/xv9jgQ0mMYs011fBk=",
-          "range": "bytes=696-1041"
+          "checksum": "sha1-mTmy64gKYi4THBqewuvYL2uUyHc=",
+          "range": "bytes=700-1031"
         },
         "data": {
-          "checksum": "sha256-iqHASiMgiu6rIjbWGwBmmq1Zthae8BkE4QZkiVPH7Ek=",
-          "range": "bytes=1042-1888945"
+          "checksum": "sha256-p0qua2luH33oAgOcLkU9f7k+I8WnykFszVMwNahujDA=",
+          "range": "bytes=1032-1889523"
         },
         "name": "tzdata",
         "signature": {
-          "checksum": "sha1-PCC3jiXlTwrimRMXH/4RyNvccOM=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-sBf5jVLVpWj4DiXaAd/mjo0pTfk=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/tzdata-2024a-r2.apk",
-        "version": "2024a-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/tzdata-2024a-r3.apk",
+        "version": "2024a-r3"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/searcher.lock.json
+++ b/wolfi-images/searcher.lock.json
@@ -14,41 +14,41 @@
     "packages": [
       {
         "architecture": "x86_64",
-        "checksum": "Q1ge3SLQsJ9v2RnvIHHAP1yFyjrEU=",
+        "checksum": "Q1Ai8jWuxKZR2M2XhOpOGAoTEwnnk=",
         "control": {
-          "checksum": "sha1-ge3SLQsJ9v2RnvIHHAP1yFyjrEU=",
-          "range": "bytes=693-1040"
+          "checksum": "sha1-Ai8jWuxKZR2M2XhOpOGAoTEwnnk=",
+          "range": "bytes=705-1037"
         },
         "data": {
-          "checksum": "sha256-I0AdTdfGf4P/jwzTrLXm73l5/RNSlymEof/YZfev3xY=",
-          "range": "bytes=1041-255811"
+          "checksum": "sha256-e4UardkBVyaC49aSyrVmXNi8sSKqQl4eKYd0LxGRLA0=",
+          "range": "bytes=1038-255695"
         },
         "name": "ca-certificates-bundle",
         "signature": {
-          "checksum": "sha1-ge1eJBiQmFWAn9GapFkQpO+Rn/Y=",
-          "range": "bytes=0-692"
+          "checksum": "sha1-loRuyYQLm+atp+YteiQoj++EWIM=",
+          "range": "bytes=0-704"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20240315-r3.apk",
-        "version": "20240315-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20240315-r4.apk",
+        "version": "20240315-r4"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1bgay5kOzpmDBgqJCg7dSlawyJg0=",
+        "checksum": "Q1+GH6qRN4iy1IDt0cT0x0tin7YfI=",
         "control": {
-          "checksum": "sha1-bgay5kOzpmDBgqJCg7dSlawyJg0=",
-          "range": "bytes=703-1067"
+          "checksum": "sha1-+GH6qRN4iy1IDt0cT0x0tin7YfI=",
+          "range": "bytes=703-1051"
         },
         "data": {
-          "checksum": "sha256-f83HfRE7r2ZniH7PyPmRqcoU5NTpF+Uk4FH80QbjvBM=",
-          "range": "bytes=1068-118370"
+          "checksum": "sha256-rO0P9z2V49BSrz1A5Ap69tEappVrg5MMBjzW00rOpZc=",
+          "range": "bytes=1052-122464"
         },
         "name": "wolfi-baselayout",
         "signature": {
-          "checksum": "sha1-2hlCvYH1D7u25HkJGA75jjs/sQY=",
+          "checksum": "sha1-Ntb6VuMzDfM+frpCjKEIpDzl53I=",
           "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r11.apk",
-        "version": "20230201-r11"
+        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r12.apk",
+        "version": "20230201-r12"
       },
       {
         "architecture": "x86_64",
@@ -109,41 +109,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Zjfs1uR/mYiortANP+EFcejW+vo=",
+        "checksum": "Q1Zi0e8Bq6WCd/6uXXjVhb8YwMD1U=",
         "control": {
-          "checksum": "sha1-Zjfs1uR/mYiortANP+EFcejW+vo=",
-          "range": "bytes=698-1085"
+          "checksum": "sha1-Zi0e8Bq6WCd/6uXXjVhb8YwMD1U=",
+          "range": "bytes=700-1073"
         },
         "data": {
-          "checksum": "sha256-BMd7TzffjbrFwdbopDPVYsX0X9XnusIMNbIf33/8kwc=",
-          "range": "bytes=1086-76881"
+          "checksum": "sha256-jMhtfqVjnhuuBO7wtNZ6RS/72sZWoKt/Moage2amlks=",
+          "range": "bytes=1074-81594"
         },
         "name": "protobuf-c",
         "signature": {
-          "checksum": "sha1-efGiXyYWsJ5P2uTkB6aXEZ3kl3o=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-kATwMKztK7nk7qbYCJPkCFp6IXc=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r4.apk",
-        "version": "1.5.0-r4"
-      },
-      {
-        "architecture": "x86_64",
-        "checksum": "Q1Xf5v5uXumBgIR4d4ZxMRxdpyWlM=",
-        "control": {
-          "checksum": "sha1-Xf5v5uXumBgIR4d4ZxMRxdpyWlM=",
-          "range": "bytes=698-1078"
-        },
-        "data": {
-          "checksum": "sha256-eD7HqFCWNUBQiLq9PcWE/zPeZwkiv8hBrytI4qmfQ/8=",
-          "range": "bytes=1079-57055"
-        },
-        "name": "keyutils-libs",
-        "signature": {
-          "checksum": "sha1-V0HVgZLP7P5kNACfus3abCLCS20=",
-          "range": "bytes=0-697"
-        },
-        "url": "https://packages.wolfi.dev/os/x86_64/keyutils-libs-1.6.3-r2.apk",
-        "version": "1.6.3-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r5.apk",
+        "version": "1.5.0-r5"
       },
       {
         "architecture": "x86_64",
@@ -166,22 +147,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1wRzOx+L6MeRFtTcq2y/6ot7Cj54=",
+        "checksum": "Q1v0A2vQM5k8rQY/GpIq6xI4T0YmA=",
         "control": {
-          "checksum": "sha1-wRzOx+L6MeRFtTcq2y/6ot7Cj54=",
-          "range": "bytes=699-1069"
+          "checksum": "sha1-v0A2vQM5k8rQY/GpIq6xI4T0YmA=",
+          "range": "bytes=701-1064"
         },
         "data": {
-          "checksum": "sha256-gNRjwZ4XQatCYWediSVb+j8lS54CggvMC5Dn3qT84So=",
-          "range": "bytes=1070-61490"
+          "checksum": "sha256-uAOrkGDDc/yqt6VjIrlTEALBJG4BCI4njqZw5jQqF0o=",
+          "range": "bytes=1065-56984"
+        },
+        "name": "keyutils-libs",
+        "signature": {
+          "checksum": "sha1-32uYMH/zGBr9Jo3hiqnThlcqBcE=",
+          "range": "bytes=0-700"
+        },
+        "url": "https://packages.wolfi.dev/os/x86_64/keyutils-libs-1.6.3-r3.apk",
+        "version": "1.6.3-r3"
+      },
+      {
+        "architecture": "x86_64",
+        "checksum": "Q1Onuac6Y+IWA7a4b8FvqX1erWDDw=",
+        "control": {
+          "checksum": "sha1-Onuac6Y+IWA7a4b8FvqX1erWDDw=",
+          "range": "bytes=693-1048"
+        },
+        "data": {
+          "checksum": "sha256-KLtDAs3iU0oyZ/FysePG/J+1H1ofDxHXIY7xvtZhtMc=",
+          "range": "bytes=1049-61503"
         },
         "name": "libverto",
         "signature": {
-          "checksum": "sha1-kuPwakYdy5EM6sd5Ba0K0Ta8x4w=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-/IXL9S1O+MwaW7KsSzz1ywEqKFQ=",
+          "range": "bytes=0-692"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libverto-0.3.2-r3.apk",
-        "version": "0.3.2-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/libverto-0.3.2-r4.apk",
+        "version": "0.3.2-r4"
       },
       {
         "architecture": "x86_64",
@@ -204,60 +204,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1gTZGkWP+QO3mUqLVJth8vrDEzzU=",
+        "checksum": "Q1Q/Zy5ovYSu2p/vVLr6DgVA1e8AQ=",
         "control": {
-          "checksum": "sha1-gTZGkWP+QO3mUqLVJth8vrDEzzU=",
-          "range": "bytes=699-1076"
+          "checksum": "sha1-Q/Zy5ovYSu2p/vVLr6DgVA1e8AQ=",
+          "range": "bytes=699-1062"
         },
         "data": {
-          "checksum": "sha256-/IFXqeKvU0GODNsz1yPIEMcFHgABT+8rbZpSlTLo4e4=",
-          "range": "bytes=1077-5915704"
+          "checksum": "sha256-H3jxsw8ytOeCIR4vq17voSVhdNokXk8C1g075txH6Bs=",
+          "range": "bytes=1063-5903754"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-l1o5ixkyWWqqJE3FOfR0QUemJUA=",
+          "checksum": "sha1-NIl2f5OI/wSZByI8Ds1ZUfbFWyw=",
           "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r9.apk",
-        "version": "3.3.0-r9"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.1-r3.apk",
+        "version": "3.3.1-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1jhAhggAuZnU7FFHnebGA26mq+jI=",
+        "checksum": "Q13wGUXdZut9OOTdY5z2amUj9wXC0=",
         "control": {
-          "checksum": "sha1-jhAhggAuZnU7FFHnebGA26mq+jI=",
-          "range": "bytes=695-1079"
+          "checksum": "sha1-3wGUXdZut9OOTdY5z2amUj9wXC0=",
+          "range": "bytes=698-1068"
         },
         "data": {
-          "checksum": "sha256-XTCQYnhGSm7SkGwqV/TQMFqGajVJVYhKAidKfLb2D3Y=",
-          "range": "bytes=1080-1197081"
+          "checksum": "sha256-mRda6+YGlOCczyIWKaHqXskTINoT1rgorHDHqAKAb7c=",
+          "range": "bytes=1069-1188955"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-qVrfDVxubkrb5Yrd2mFTv2A0G7k=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-+UdRc4U3PKw4H9OiNurHKXa5BYk=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r9.apk",
-        "version": "3.3.0-r9"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.1-r3.apk",
+        "version": "3.3.1-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1BQEXaeya6QB39QLeKcB99qBNF2o=",
+        "checksum": "Q1p04MrHQPrXOzuV/uF290zjnltqI=",
         "control": {
-          "checksum": "sha1-BQEXaeya6QB39QLeKcB99qBNF2o=",
-          "range": "bytes=699-1229"
+          "checksum": "sha1-p04MrHQPrXOzuV/uF290zjnltqI=",
+          "range": "bytes=704-1219"
         },
         "data": {
-          "checksum": "sha256-ugj/qGEBzhvdX17S22Anry+biy3lcqywhGMSHLIBCvo=",
-          "range": "bytes=1230-2551676"
+          "checksum": "sha256-TsXeqhUGykAhjQUEAlMUSzDQBcWDkkDvReoeHCL1F6c=",
+          "range": "bytes=1220-2555814"
         },
         "name": "krb5-libs",
         "signature": {
-          "checksum": "sha1-oqDPmNM4EngXAGayd/BZOqJAIao=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-cPyzS38QHuNlOCQb8IPlsl2PLHQ=",
+          "range": "bytes=0-703"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/krb5-libs-1.21.2-r2.apk",
-        "version": "1.21.2-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/krb5-libs-1.21.3-r0.apk",
+        "version": "1.21.3-r0"
       },
       {
         "architecture": "x86_64",
@@ -280,60 +280,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1wzZwtLauOQfLQC7YUvZdfKxtlwQ=",
+        "checksum": "Q17uprcuQ2VFudMcWAwtP7miJmLYs=",
         "control": {
-          "checksum": "sha1-wzZwtLauOQfLQC7YUvZdfKxtlwQ=",
-          "range": "bytes=698-1085"
+          "checksum": "sha1-7uprcuQ2VFudMcWAwtP7miJmLYs=",
+          "range": "bytes=695-1067"
         },
         "data": {
-          "checksum": "sha256-TO8CAULO44s/LphhtcaFOGJB7aFldk13v1cV9ceZHww=",
-          "range": "bytes=1086-276837"
+          "checksum": "sha256-unKdPbvO2VHZ5w1t1l8mOpQuNdUGwLhofEO4weN2Mig=",
+          "range": "bytes=1068-280973"
         },
         "name": "libuv",
         "signature": {
-          "checksum": "sha1-LRiyeKmjexy8CJizLxjd6ikon1w=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-4lKldnTO71WHMZ4tbANz6i2/Ed0=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libuv-1.48.0-r2.apk",
-        "version": "1.48.0-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libuv-1.48.0-r3.apk",
+        "version": "1.48.0-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q14S6biy8fc5OGbGEJoLBM+tJOGyo=",
+        "checksum": "Q1CN6zJbOPznWUfTrb/41KT7E6dm8=",
         "control": {
-          "checksum": "sha1-4S6biy8fc5OGbGEJoLBM+tJOGyo=",
-          "range": "bytes=703-1102"
+          "checksum": "sha1-CN6zJbOPznWUfTrb/41KT7E6dm8=",
+          "range": "bytes=699-1083"
         },
         "data": {
-          "checksum": "sha256-hwjdLQYfuMAGQeONmFVo0lZKKQK1S+3PBhrI3upm5W4=",
-          "range": "bytes=1103-155304"
+          "checksum": "sha256-ybzFzoQh1yNTcd3cjt54nYsPlAxAcMUcVMxEv1JRnpQ=",
+          "range": "bytes=1084-155375"
         },
         "name": "zlib",
         "signature": {
-          "checksum": "sha1-ZuLd7kE+AGhn27o8ZqDGM5eundc=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-CPXJcCjinAXP+H8Z5tkko8ayG6E=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/zlib-1.3.1-r2.apk",
-        "version": "1.3.1-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/zlib-1.3.1-r3.apk",
+        "version": "1.3.1-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ykDkP+AmDi2VcZZ1c4q4sez/DxI=",
+        "checksum": "Q1rgbci8SRSjW7EB0NSh6ZUPJLndM=",
         "control": {
-          "checksum": "sha1-ykDkP+AmDi2VcZZ1c4q4sez/DxI=",
-          "range": "bytes=705-1079"
+          "checksum": "sha1-rgbci8SRSjW7EB0NSh6ZUPJLndM=",
+          "range": "bytes=702-1060"
         },
         "data": {
-          "checksum": "sha256-t3BrH7lWfY3to3Fu3EKAMZx29v9Hnl5seyXJzLmZ9/4=",
-          "range": "bytes=1080-251884"
+          "checksum": "sha256-tf4xbo+NP+ssiaZtC1kOKehffAZ3+d17bhgfU3/30+g=",
+          "range": "bytes=1061-256582"
         },
         "name": "libnghttp2-14",
         "signature": {
-          "checksum": "sha1-CotSXRaPLKQCBRHrgzrDOD+4w20=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-KrsJYTyUsll+EUhHekbkdZFzeig=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.62.1-r0.apk",
-        "version": "1.62.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.62.1-r1.apk",
+        "version": "1.62.1-r1"
       },
       {
         "architecture": "x86_64",
@@ -394,136 +394,136 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1DE49kWSnmqVKJdjHFYC1bLkvyb0=",
+        "checksum": "Q1R8OxpY0fGwVaIwft4wJeswF5D54=",
         "control": {
-          "checksum": "sha1-DE49kWSnmqVKJdjHFYC1bLkvyb0=",
-          "range": "bytes=697-1078"
+          "checksum": "sha1-R8OxpY0fGwVaIwft4wJeswF5D54=",
+          "range": "bytes=695-1059"
         },
         "data": {
-          "checksum": "sha256-uDg8Qc6Rnro/68Vb5ufFSkqFLGrEsbvPb0pMJNvT1zw=",
-          "range": "bytes=1079-242085"
+          "checksum": "sha256-wNc8/SBJrGHfwywAtzCsAqeUOt0IaAhqNtlbv8OiHBE=",
+          "range": "bytes=1060-242151"
         },
         "name": "c-ares",
         "signature": {
-          "checksum": "sha1-iYEm6EWQKzxkeoDm+QsRfhw8pDg=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-55/PTlEHXI3o0hx9dSVdNwQeSMg=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.29.0-r0.apk",
-        "version": "1.29.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.31.0-r0.apk",
+        "version": "1.31.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q12eWmn2tCkXxwncU6gagKM3Wd9Sk=",
+        "checksum": "Q1g2RQKAvNjlRPxWjinIRveaq7IlY=",
         "control": {
-          "checksum": "sha1-2eWmn2tCkXxwncU6gagKM3Wd9Sk=",
-          "range": "bytes=696-1169"
+          "checksum": "sha1-g2RQKAvNjlRPxWjinIRveaq7IlY=",
+          "range": "bytes=695-1154"
         },
         "data": {
-          "checksum": "sha256-IFKNdojOhml3DbWPryQuHUiV3tgTWHyqOYD1JNe9IJ4=",
-          "range": "bytes=1170-2582015"
+          "checksum": "sha256-UsQFfOTXCZBan0mxDvR+ts0NKcbv1lNijxnRxjsmZhA=",
+          "range": "bytes=1155-2566233"
         },
         "name": "nghttp2",
         "signature": {
-          "checksum": "sha1-2/9n7KbRuOkrvhYqCFR5Mblx+z8=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-SUvMhz1cc5Or5Qh4fUEvPCp0NAw=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.62.1-r0.apk",
-        "version": "1.62.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.62.1-r1.apk",
+        "version": "1.62.1-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ialksjwPWvvZW+O2ABMbbBV/KTg=",
+        "checksum": "Q1sTMGOgdbZyDKxlRAByisPMHTbpY=",
         "control": {
-          "checksum": "sha1-ialksjwPWvvZW+O2ABMbbBV/KTg=",
-          "range": "bytes=702-1074"
+          "checksum": "sha1-sTMGOgdbZyDKxlRAByisPMHTbpY=",
+          "range": "bytes=703-1060"
         },
         "data": {
-          "checksum": "sha256-+ctDr3AO9mTXovGRPWk6h2ZgfY99Toy6esjBNHtJPY4=",
-          "range": "bytes=1075-631903"
+          "checksum": "sha256-bUy0h/zxpq7iP6vrQRMftZ9nevkHTB87hSX17wz4lmM=",
+          "range": "bytes=1061-631449"
         },
         "name": "nghttp2-dev",
         "signature": {
-          "checksum": "sha1-wZGQRluFd6DL1USzeak75o5/BTc=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-fQ6aDq3Io/gdJ5s5t3M+FwED1Y0=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.62.1-r0.apk",
-        "version": "1.62.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.62.1-r1.apk",
+        "version": "1.62.1-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1MlpRL1nBMU3RgNdSZVB42/vlGME=",
+        "checksum": "Q1rD3dEbbN8s5QAIQK1I8uF1O+oSo=",
         "control": {
-          "checksum": "sha1-MlpRL1nBMU3RgNdSZVB42/vlGME=",
-          "range": "bytes=697-1164"
+          "checksum": "sha1-rD3dEbbN8s5QAIQK1I8uF1O+oSo=",
+          "range": "bytes=701-1154"
         },
         "data": {
-          "checksum": "sha256-RiEPDasBVtnThSxGqTCDvb4J7WXM9YRpJwfYZJ3JLbs=",
-          "range": "bytes=1165-2274746"
+          "checksum": "sha256-41W2IRSRALQijYojLaqAiSSN1uO7twatGn8jqEuCZUg=",
+          "range": "bytes=1155-1439872"
         },
         "name": "xz",
         "signature": {
-          "checksum": "sha1-3wMPFIUEVfkAs7QSENemZsnTLyE=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-lozWkVrKvSrd1SoM7Zv08YYG2pA=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/xz-5.4.6-r2.apk",
-        "version": "5.4.6-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/xz-5.6.2-r0.apk",
+        "version": "5.6.2-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1TS707T+cPGL7TYVHQBCJoWwHZ0E=",
+        "checksum": "Q10AaU1ocIM4PYYNvwbml8TmpNvEA=",
         "control": {
-          "checksum": "sha1-TS707T+cPGL7TYVHQBCJoWwHZ0E=",
-          "range": "bytes=706-1098"
+          "checksum": "sha1-0AaU1ocIM4PYYNvwbml8TmpNvEA=",
+          "range": "bytes=706-1085"
         },
         "data": {
-          "checksum": "sha256-x18L706Vug5qDzq13SXuN/vGdVgzrqB06dW2DdgHGR4=",
-          "range": "bytes=1099-4541967"
+          "checksum": "sha256-1YQNYASFjlP3kXX58ec8du75ij/U6O4DPAKzJAPkln0=",
+          "range": "bytes=1086-4272589"
         },
         "name": "libxml2",
         "signature": {
-          "checksum": "sha1-BYhOxDos48sN8df8LMsSpROv2aw=",
+          "checksum": "sha1-QFjdplzGn/MiNFxMykgafr6/w6U=",
           "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.12.7-r0.apk",
-        "version": "2.12.7-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.1-r1.apk",
+        "version": "2.13.1-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1wJPtj5XZtnPiVWGM5dsT+nyfWXc=",
+        "checksum": "Q1wbnfumlWEiJnVUsJBRcQjFD3U6I=",
         "control": {
-          "checksum": "sha1-wJPtj5XZtnPiVWGM5dsT+nyfWXc=",
-          "range": "bytes=705-1234"
+          "checksum": "sha1-wbnfumlWEiJnVUsJBRcQjFD3U6I=",
+          "range": "bytes=699-1222"
         },
         "data": {
-          "checksum": "sha256-sw+CjlpsjO01q6lqzXgHnniiJKn7bqOSNO6vNqdGc7I=",
-          "range": "bytes=1235-3873775"
+          "checksum": "sha256-IXMNbJjj3kTjkWVBIHVRfG3zJQY2r5Eslgh/3TpMSsE=",
+          "range": "bytes=1223-3886778"
         },
         "name": "bind-libs",
         "signature": {
-          "checksum": "sha1-9zDzmHAeu7mWpidXAatqrLZVzUs=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-JNN15IPpJ2hMsO6hFVpDYPvvX5g=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bind-libs-9.18.26-r0.apk",
-        "version": "9.18.26-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/bind-libs-9.18.27-r1.apk",
+        "version": "9.18.27-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1AxEQdi8fVcYtGc3zHTCW3OZdY2Q=",
+        "checksum": "Q1kXUOoNa2KXixxAASo1W/im1qZ7s=",
         "control": {
-          "checksum": "sha1-AxEQdi8fVcYtGc3zHTCW3OZdY2Q=",
-          "range": "bytes=694-1208"
+          "checksum": "sha1-kXUOoNa2KXixxAASo1W/im1qZ7s=",
+          "range": "bytes=702-1215"
         },
         "data": {
-          "checksum": "sha256-/dt3qJw5D9iSJ/mKkRQkhWD8R52selhpcwXyw7KLMhg=",
-          "range": "bytes=1209-879444"
+          "checksum": "sha256-HRADvfRXfYsgEjUMGM4Hd7prpIv+YWILVfovbGOkEME=",
+          "range": "bytes=1216-879975"
         },
         "name": "bind-tools",
         "signature": {
-          "checksum": "sha1-VTb0YdUzPMk8Po0p4nj0y5Jey6k=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-8WUTMUaJTaX0T9FS/c+GddL7ttY=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bind-tools-9.18.26-r0.apk",
-        "version": "9.18.26-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/bind-tools-9.18.27-r1.apk",
+        "version": "9.18.27-r1"
       },
       {
         "architecture": "x86_64",
@@ -679,60 +679,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1fr0OtiVaD3c5nw8fy5m74hDe9PU=",
+        "checksum": "Q1BRGmQ9LZTeZqbxQ1ls69T6efViw=",
         "control": {
-          "checksum": "sha1-fr0OtiVaD3c5nw8fy5m74hDe9PU=",
-          "range": "bytes=697-1092"
+          "checksum": "sha1-BRGmQ9LZTeZqbxQ1ls69T6efViw=",
+          "range": "bytes=698-1080"
         },
         "data": {
-          "checksum": "sha256-lukjMYpGmuhBNDUbbTJMIrUWaR4rNikEnW4BgiTaLj8=",
-          "range": "bytes=1093-113872"
+          "checksum": "sha256-vtJ4WJ5M+31ZKSBYBedbrl/FrbAw8hGpPRrHC7kasOk=",
+          "range": "bytes=1081-113895"
         },
         "name": "libpsl",
         "signature": {
-          "checksum": "sha1-Lrrudgn1i1a0JhjdzeXG+exnjQA=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-DuAoiykwhu8vu1qxdEDK5oyAmf8=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libpsl-0.21.5-r2.apk",
-        "version": "0.21.5-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libpsl-0.21.5-r3.apk",
+        "version": "0.21.5-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1oauHQa0YcFcEHSQWdfohfNEN4sY=",
+        "checksum": "Q11DZVpe2UYyDr/dG6BDysZhE3L48=",
         "control": {
-          "checksum": "sha1-oauHQa0YcFcEHSQWdfohfNEN4sY=",
-          "range": "bytes=698-1057"
+          "checksum": "sha1-1DZVpe2UYyDr/dG6BDysZhE3L48=",
+          "range": "bytes=707-1049"
         },
         "data": {
-          "checksum": "sha256-d95c9lpjQrpuZ1CcQ8ZZ89LAGGKcessd+hxrOQpP4LU=",
-          "range": "bytes=1058-173549"
+          "checksum": "sha256-aECfsy7giZsLNxZM0HMeF4OS2gu+ycX4DUTJXsiZRQs=",
+          "range": "bytes=1050-173585"
         },
         "name": "libbrotlicommon1",
         "signature": {
-          "checksum": "sha1-g3ufBq/tyiNP6AaOoqwItVvh7uk=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-7LXD38QwFhklZCEqyW4qIncfZV0=",
+          "range": "bytes=0-706"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlicommon1-1.1.0-r2.apk",
-        "version": "1.1.0-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlicommon1-1.1.0-r3.apk",
+        "version": "1.1.0-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q18Otq7NLoYnNMebI/1Rr/s0zdLVw=",
+        "checksum": "Q1Cgr886A8Ryzynz9pxRKsNybVuK0=",
         "control": {
-          "checksum": "sha1-8Otq7NLoYnNMebI/1Rr/s0zdLVw=",
-          "range": "bytes=705-1072"
+          "checksum": "sha1-Cgr886A8Ryzynz9pxRKsNybVuK0=",
+          "range": "bytes=694-1043"
         },
         "data": {
-          "checksum": "sha256-sR3QidR/e46PJ/3S2fxAjN/hRSSA3Ar32Nw7VshTHWg=",
-          "range": "bytes=1073-81475"
+          "checksum": "sha256-mH+MTbqpLiqgydlgE+tSDEt0Sh1/zqMvAqspV4lr+Ks=",
+          "range": "bytes=1044-81511"
         },
         "name": "libbrotlidec1",
         "signature": {
-          "checksum": "sha1-6GpZI5cBUXOvjCYG81aZZR53lMI=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-Yp4Bde9oHQCec8HM2qn6hVKgtko=",
+          "range": "bytes=0-693"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlidec1-1.1.0-r2.apk",
-        "version": "1.1.0-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlidec1-1.1.0-r3.apk",
+        "version": "1.1.0-r3"
       },
       {
         "architecture": "x86_64",
@@ -812,22 +812,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q19f/3419Xa/xv9jgQ0mMYs011fBk=",
+        "checksum": "Q1mTmy64gKYi4THBqewuvYL2uUyHc=",
         "control": {
-          "checksum": "sha1-9f/3419Xa/xv9jgQ0mMYs011fBk=",
-          "range": "bytes=696-1041"
+          "checksum": "sha1-mTmy64gKYi4THBqewuvYL2uUyHc=",
+          "range": "bytes=700-1031"
         },
         "data": {
-          "checksum": "sha256-iqHASiMgiu6rIjbWGwBmmq1Zthae8BkE4QZkiVPH7Ek=",
-          "range": "bytes=1042-1888945"
+          "checksum": "sha256-p0qua2luH33oAgOcLkU9f7k+I8WnykFszVMwNahujDA=",
+          "range": "bytes=1032-1889523"
         },
         "name": "tzdata",
         "signature": {
-          "checksum": "sha1-PCC3jiXlTwrimRMXH/4RyNvccOM=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-sBf5jVLVpWj4DiXaAd/mjo0pTfk=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/tzdata-2024a-r2.apk",
-        "version": "2024a-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/tzdata-2024a-r3.apk",
+        "version": "2024a-r3"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/server.lock.json
+++ b/wolfi-images/server.lock.json
@@ -37,41 +37,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ge3SLQsJ9v2RnvIHHAP1yFyjrEU=",
+        "checksum": "Q1Ai8jWuxKZR2M2XhOpOGAoTEwnnk=",
         "control": {
-          "checksum": "sha1-ge3SLQsJ9v2RnvIHHAP1yFyjrEU=",
-          "range": "bytes=693-1040"
+          "checksum": "sha1-Ai8jWuxKZR2M2XhOpOGAoTEwnnk=",
+          "range": "bytes=705-1037"
         },
         "data": {
-          "checksum": "sha256-I0AdTdfGf4P/jwzTrLXm73l5/RNSlymEof/YZfev3xY=",
-          "range": "bytes=1041-255811"
+          "checksum": "sha256-e4UardkBVyaC49aSyrVmXNi8sSKqQl4eKYd0LxGRLA0=",
+          "range": "bytes=1038-255695"
         },
         "name": "ca-certificates-bundle",
         "signature": {
-          "checksum": "sha1-ge1eJBiQmFWAn9GapFkQpO+Rn/Y=",
-          "range": "bytes=0-692"
+          "checksum": "sha1-loRuyYQLm+atp+YteiQoj++EWIM=",
+          "range": "bytes=0-704"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20240315-r3.apk",
-        "version": "20240315-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20240315-r4.apk",
+        "version": "20240315-r4"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1bgay5kOzpmDBgqJCg7dSlawyJg0=",
+        "checksum": "Q1+GH6qRN4iy1IDt0cT0x0tin7YfI=",
         "control": {
-          "checksum": "sha1-bgay5kOzpmDBgqJCg7dSlawyJg0=",
-          "range": "bytes=703-1067"
+          "checksum": "sha1-+GH6qRN4iy1IDt0cT0x0tin7YfI=",
+          "range": "bytes=703-1051"
         },
         "data": {
-          "checksum": "sha256-f83HfRE7r2ZniH7PyPmRqcoU5NTpF+Uk4FH80QbjvBM=",
-          "range": "bytes=1068-118370"
+          "checksum": "sha256-rO0P9z2V49BSrz1A5Ap69tEappVrg5MMBjzW00rOpZc=",
+          "range": "bytes=1052-122464"
         },
         "name": "wolfi-baselayout",
         "signature": {
-          "checksum": "sha1-2hlCvYH1D7u25HkJGA75jjs/sQY=",
+          "checksum": "sha1-Ntb6VuMzDfM+frpCjKEIpDzl53I=",
           "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r11.apk",
-        "version": "20230201-r11"
+        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r12.apk",
+        "version": "20230201-r12"
       },
       {
         "architecture": "x86_64",
@@ -151,60 +151,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ZMGiMSnjbScBstPVaw5qQfkNI+M=",
+        "checksum": "Q1w2/J0nDU8aA/f0HxunA5N19L1gw=",
         "control": {
-          "checksum": "sha1-ZMGiMSnjbScBstPVaw5qQfkNI+M=",
-          "range": "bytes=697-1097"
+          "checksum": "sha1-w2/J0nDU8aA/f0HxunA5N19L1gw=",
+          "range": "bytes=702-1086"
         },
         "data": {
-          "checksum": "sha256-XN2CeOJxCHWCgGpwTUkm5UOFKFz/eRpd7AReq4CqiOk=",
-          "range": "bytes=1098-1436391"
+          "checksum": "sha256-/2i+TNHbkrOsjrx7WHrrloXc6gcoyfyGrUHdBljYM+o=",
+          "range": "bytes=1087-1440232"
         },
         "name": "bash",
         "signature": {
-          "checksum": "sha1-t7/nmubimPIaw21oj0WlXgqY90E=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-tnYcLxCgV8srkBsTl4c/f6m11vQ=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bash-5.2.21-r4.apk",
-        "version": "5.2.21-r4"
+        "url": "https://packages.wolfi.dev/os/x86_64/bash-5.2.21-r5.apk",
+        "version": "5.2.21-r5"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Zjfs1uR/mYiortANP+EFcejW+vo=",
+        "checksum": "Q1Zi0e8Bq6WCd/6uXXjVhb8YwMD1U=",
         "control": {
-          "checksum": "sha1-Zjfs1uR/mYiortANP+EFcejW+vo=",
-          "range": "bytes=698-1085"
+          "checksum": "sha1-Zi0e8Bq6WCd/6uXXjVhb8YwMD1U=",
+          "range": "bytes=700-1073"
         },
         "data": {
-          "checksum": "sha256-BMd7TzffjbrFwdbopDPVYsX0X9XnusIMNbIf33/8kwc=",
-          "range": "bytes=1086-76881"
+          "checksum": "sha256-jMhtfqVjnhuuBO7wtNZ6RS/72sZWoKt/Moage2amlks=",
+          "range": "bytes=1074-81594"
         },
         "name": "protobuf-c",
         "signature": {
-          "checksum": "sha1-efGiXyYWsJ5P2uTkB6aXEZ3kl3o=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-kATwMKztK7nk7qbYCJPkCFp6IXc=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r4.apk",
-        "version": "1.5.0-r4"
-      },
-      {
-        "architecture": "x86_64",
-        "checksum": "Q1Xf5v5uXumBgIR4d4ZxMRxdpyWlM=",
-        "control": {
-          "checksum": "sha1-Xf5v5uXumBgIR4d4ZxMRxdpyWlM=",
-          "range": "bytes=698-1078"
-        },
-        "data": {
-          "checksum": "sha256-eD7HqFCWNUBQiLq9PcWE/zPeZwkiv8hBrytI4qmfQ/8=",
-          "range": "bytes=1079-57055"
-        },
-        "name": "keyutils-libs",
-        "signature": {
-          "checksum": "sha1-V0HVgZLP7P5kNACfus3abCLCS20=",
-          "range": "bytes=0-697"
-        },
-        "url": "https://packages.wolfi.dev/os/x86_64/keyutils-libs-1.6.3-r2.apk",
-        "version": "1.6.3-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r5.apk",
+        "version": "1.5.0-r5"
       },
       {
         "architecture": "x86_64",
@@ -227,22 +208,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1wRzOx+L6MeRFtTcq2y/6ot7Cj54=",
+        "checksum": "Q1v0A2vQM5k8rQY/GpIq6xI4T0YmA=",
         "control": {
-          "checksum": "sha1-wRzOx+L6MeRFtTcq2y/6ot7Cj54=",
-          "range": "bytes=699-1069"
+          "checksum": "sha1-v0A2vQM5k8rQY/GpIq6xI4T0YmA=",
+          "range": "bytes=701-1064"
         },
         "data": {
-          "checksum": "sha256-gNRjwZ4XQatCYWediSVb+j8lS54CggvMC5Dn3qT84So=",
-          "range": "bytes=1070-61490"
+          "checksum": "sha256-uAOrkGDDc/yqt6VjIrlTEALBJG4BCI4njqZw5jQqF0o=",
+          "range": "bytes=1065-56984"
+        },
+        "name": "keyutils-libs",
+        "signature": {
+          "checksum": "sha1-32uYMH/zGBr9Jo3hiqnThlcqBcE=",
+          "range": "bytes=0-700"
+        },
+        "url": "https://packages.wolfi.dev/os/x86_64/keyutils-libs-1.6.3-r3.apk",
+        "version": "1.6.3-r3"
+      },
+      {
+        "architecture": "x86_64",
+        "checksum": "Q1Onuac6Y+IWA7a4b8FvqX1erWDDw=",
+        "control": {
+          "checksum": "sha1-Onuac6Y+IWA7a4b8FvqX1erWDDw=",
+          "range": "bytes=693-1048"
+        },
+        "data": {
+          "checksum": "sha256-KLtDAs3iU0oyZ/FysePG/J+1H1ofDxHXIY7xvtZhtMc=",
+          "range": "bytes=1049-61503"
         },
         "name": "libverto",
         "signature": {
-          "checksum": "sha1-kuPwakYdy5EM6sd5Ba0K0Ta8x4w=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-/IXL9S1O+MwaW7KsSzz1ywEqKFQ=",
+          "range": "bytes=0-692"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libverto-0.3.2-r3.apk",
-        "version": "0.3.2-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/libverto-0.3.2-r4.apk",
+        "version": "0.3.2-r4"
       },
       {
         "architecture": "x86_64",
@@ -265,60 +265,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1gTZGkWP+QO3mUqLVJth8vrDEzzU=",
+        "checksum": "Q1Q/Zy5ovYSu2p/vVLr6DgVA1e8AQ=",
         "control": {
-          "checksum": "sha1-gTZGkWP+QO3mUqLVJth8vrDEzzU=",
-          "range": "bytes=699-1076"
+          "checksum": "sha1-Q/Zy5ovYSu2p/vVLr6DgVA1e8AQ=",
+          "range": "bytes=699-1062"
         },
         "data": {
-          "checksum": "sha256-/IFXqeKvU0GODNsz1yPIEMcFHgABT+8rbZpSlTLo4e4=",
-          "range": "bytes=1077-5915704"
+          "checksum": "sha256-H3jxsw8ytOeCIR4vq17voSVhdNokXk8C1g075txH6Bs=",
+          "range": "bytes=1063-5903754"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-l1o5ixkyWWqqJE3FOfR0QUemJUA=",
+          "checksum": "sha1-NIl2f5OI/wSZByI8Ds1ZUfbFWyw=",
           "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r9.apk",
-        "version": "3.3.0-r9"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.1-r3.apk",
+        "version": "3.3.1-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1jhAhggAuZnU7FFHnebGA26mq+jI=",
+        "checksum": "Q13wGUXdZut9OOTdY5z2amUj9wXC0=",
         "control": {
-          "checksum": "sha1-jhAhggAuZnU7FFHnebGA26mq+jI=",
-          "range": "bytes=695-1079"
+          "checksum": "sha1-3wGUXdZut9OOTdY5z2amUj9wXC0=",
+          "range": "bytes=698-1068"
         },
         "data": {
-          "checksum": "sha256-XTCQYnhGSm7SkGwqV/TQMFqGajVJVYhKAidKfLb2D3Y=",
-          "range": "bytes=1080-1197081"
+          "checksum": "sha256-mRda6+YGlOCczyIWKaHqXskTINoT1rgorHDHqAKAb7c=",
+          "range": "bytes=1069-1188955"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-qVrfDVxubkrb5Yrd2mFTv2A0G7k=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-+UdRc4U3PKw4H9OiNurHKXa5BYk=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r9.apk",
-        "version": "3.3.0-r9"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.1-r3.apk",
+        "version": "3.3.1-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1BQEXaeya6QB39QLeKcB99qBNF2o=",
+        "checksum": "Q1p04MrHQPrXOzuV/uF290zjnltqI=",
         "control": {
-          "checksum": "sha1-BQEXaeya6QB39QLeKcB99qBNF2o=",
-          "range": "bytes=699-1229"
+          "checksum": "sha1-p04MrHQPrXOzuV/uF290zjnltqI=",
+          "range": "bytes=704-1219"
         },
         "data": {
-          "checksum": "sha256-ugj/qGEBzhvdX17S22Anry+biy3lcqywhGMSHLIBCvo=",
-          "range": "bytes=1230-2551676"
+          "checksum": "sha256-TsXeqhUGykAhjQUEAlMUSzDQBcWDkkDvReoeHCL1F6c=",
+          "range": "bytes=1220-2555814"
         },
         "name": "krb5-libs",
         "signature": {
-          "checksum": "sha1-oqDPmNM4EngXAGayd/BZOqJAIao=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-cPyzS38QHuNlOCQb8IPlsl2PLHQ=",
+          "range": "bytes=0-703"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/krb5-libs-1.21.2-r2.apk",
-        "version": "1.21.2-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/krb5-libs-1.21.3-r0.apk",
+        "version": "1.21.3-r0"
       },
       {
         "architecture": "x86_64",
@@ -341,60 +341,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1wzZwtLauOQfLQC7YUvZdfKxtlwQ=",
+        "checksum": "Q17uprcuQ2VFudMcWAwtP7miJmLYs=",
         "control": {
-          "checksum": "sha1-wzZwtLauOQfLQC7YUvZdfKxtlwQ=",
-          "range": "bytes=698-1085"
+          "checksum": "sha1-7uprcuQ2VFudMcWAwtP7miJmLYs=",
+          "range": "bytes=695-1067"
         },
         "data": {
-          "checksum": "sha256-TO8CAULO44s/LphhtcaFOGJB7aFldk13v1cV9ceZHww=",
-          "range": "bytes=1086-276837"
+          "checksum": "sha256-unKdPbvO2VHZ5w1t1l8mOpQuNdUGwLhofEO4weN2Mig=",
+          "range": "bytes=1068-280973"
         },
         "name": "libuv",
         "signature": {
-          "checksum": "sha1-LRiyeKmjexy8CJizLxjd6ikon1w=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-4lKldnTO71WHMZ4tbANz6i2/Ed0=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libuv-1.48.0-r2.apk",
-        "version": "1.48.0-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libuv-1.48.0-r3.apk",
+        "version": "1.48.0-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q14S6biy8fc5OGbGEJoLBM+tJOGyo=",
+        "checksum": "Q1CN6zJbOPznWUfTrb/41KT7E6dm8=",
         "control": {
-          "checksum": "sha1-4S6biy8fc5OGbGEJoLBM+tJOGyo=",
-          "range": "bytes=703-1102"
+          "checksum": "sha1-CN6zJbOPznWUfTrb/41KT7E6dm8=",
+          "range": "bytes=699-1083"
         },
         "data": {
-          "checksum": "sha256-hwjdLQYfuMAGQeONmFVo0lZKKQK1S+3PBhrI3upm5W4=",
-          "range": "bytes=1103-155304"
+          "checksum": "sha256-ybzFzoQh1yNTcd3cjt54nYsPlAxAcMUcVMxEv1JRnpQ=",
+          "range": "bytes=1084-155375"
         },
         "name": "zlib",
         "signature": {
-          "checksum": "sha1-ZuLd7kE+AGhn27o8ZqDGM5eundc=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-CPXJcCjinAXP+H8Z5tkko8ayG6E=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/zlib-1.3.1-r2.apk",
-        "version": "1.3.1-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/zlib-1.3.1-r3.apk",
+        "version": "1.3.1-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ykDkP+AmDi2VcZZ1c4q4sez/DxI=",
+        "checksum": "Q1rgbci8SRSjW7EB0NSh6ZUPJLndM=",
         "control": {
-          "checksum": "sha1-ykDkP+AmDi2VcZZ1c4q4sez/DxI=",
-          "range": "bytes=705-1079"
+          "checksum": "sha1-rgbci8SRSjW7EB0NSh6ZUPJLndM=",
+          "range": "bytes=702-1060"
         },
         "data": {
-          "checksum": "sha256-t3BrH7lWfY3to3Fu3EKAMZx29v9Hnl5seyXJzLmZ9/4=",
-          "range": "bytes=1080-251884"
+          "checksum": "sha256-tf4xbo+NP+ssiaZtC1kOKehffAZ3+d17bhgfU3/30+g=",
+          "range": "bytes=1061-256582"
         },
         "name": "libnghttp2-14",
         "signature": {
-          "checksum": "sha1-CotSXRaPLKQCBRHrgzrDOD+4w20=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-KrsJYTyUsll+EUhHekbkdZFzeig=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.62.1-r0.apk",
-        "version": "1.62.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.62.1-r1.apk",
+        "version": "1.62.1-r1"
       },
       {
         "architecture": "x86_64",
@@ -455,136 +455,136 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1DE49kWSnmqVKJdjHFYC1bLkvyb0=",
+        "checksum": "Q1R8OxpY0fGwVaIwft4wJeswF5D54=",
         "control": {
-          "checksum": "sha1-DE49kWSnmqVKJdjHFYC1bLkvyb0=",
-          "range": "bytes=697-1078"
+          "checksum": "sha1-R8OxpY0fGwVaIwft4wJeswF5D54=",
+          "range": "bytes=695-1059"
         },
         "data": {
-          "checksum": "sha256-uDg8Qc6Rnro/68Vb5ufFSkqFLGrEsbvPb0pMJNvT1zw=",
-          "range": "bytes=1079-242085"
+          "checksum": "sha256-wNc8/SBJrGHfwywAtzCsAqeUOt0IaAhqNtlbv8OiHBE=",
+          "range": "bytes=1060-242151"
         },
         "name": "c-ares",
         "signature": {
-          "checksum": "sha1-iYEm6EWQKzxkeoDm+QsRfhw8pDg=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-55/PTlEHXI3o0hx9dSVdNwQeSMg=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.29.0-r0.apk",
-        "version": "1.29.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.31.0-r0.apk",
+        "version": "1.31.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q12eWmn2tCkXxwncU6gagKM3Wd9Sk=",
+        "checksum": "Q1g2RQKAvNjlRPxWjinIRveaq7IlY=",
         "control": {
-          "checksum": "sha1-2eWmn2tCkXxwncU6gagKM3Wd9Sk=",
-          "range": "bytes=696-1169"
+          "checksum": "sha1-g2RQKAvNjlRPxWjinIRveaq7IlY=",
+          "range": "bytes=695-1154"
         },
         "data": {
-          "checksum": "sha256-IFKNdojOhml3DbWPryQuHUiV3tgTWHyqOYD1JNe9IJ4=",
-          "range": "bytes=1170-2582015"
+          "checksum": "sha256-UsQFfOTXCZBan0mxDvR+ts0NKcbv1lNijxnRxjsmZhA=",
+          "range": "bytes=1155-2566233"
         },
         "name": "nghttp2",
         "signature": {
-          "checksum": "sha1-2/9n7KbRuOkrvhYqCFR5Mblx+z8=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-SUvMhz1cc5Or5Qh4fUEvPCp0NAw=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.62.1-r0.apk",
-        "version": "1.62.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.62.1-r1.apk",
+        "version": "1.62.1-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ialksjwPWvvZW+O2ABMbbBV/KTg=",
+        "checksum": "Q1sTMGOgdbZyDKxlRAByisPMHTbpY=",
         "control": {
-          "checksum": "sha1-ialksjwPWvvZW+O2ABMbbBV/KTg=",
-          "range": "bytes=702-1074"
+          "checksum": "sha1-sTMGOgdbZyDKxlRAByisPMHTbpY=",
+          "range": "bytes=703-1060"
         },
         "data": {
-          "checksum": "sha256-+ctDr3AO9mTXovGRPWk6h2ZgfY99Toy6esjBNHtJPY4=",
-          "range": "bytes=1075-631903"
+          "checksum": "sha256-bUy0h/zxpq7iP6vrQRMftZ9nevkHTB87hSX17wz4lmM=",
+          "range": "bytes=1061-631449"
         },
         "name": "nghttp2-dev",
         "signature": {
-          "checksum": "sha1-wZGQRluFd6DL1USzeak75o5/BTc=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-fQ6aDq3Io/gdJ5s5t3M+FwED1Y0=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.62.1-r0.apk",
-        "version": "1.62.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.62.1-r1.apk",
+        "version": "1.62.1-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1MlpRL1nBMU3RgNdSZVB42/vlGME=",
+        "checksum": "Q1rD3dEbbN8s5QAIQK1I8uF1O+oSo=",
         "control": {
-          "checksum": "sha1-MlpRL1nBMU3RgNdSZVB42/vlGME=",
-          "range": "bytes=697-1164"
+          "checksum": "sha1-rD3dEbbN8s5QAIQK1I8uF1O+oSo=",
+          "range": "bytes=701-1154"
         },
         "data": {
-          "checksum": "sha256-RiEPDasBVtnThSxGqTCDvb4J7WXM9YRpJwfYZJ3JLbs=",
-          "range": "bytes=1165-2274746"
+          "checksum": "sha256-41W2IRSRALQijYojLaqAiSSN1uO7twatGn8jqEuCZUg=",
+          "range": "bytes=1155-1439872"
         },
         "name": "xz",
         "signature": {
-          "checksum": "sha1-3wMPFIUEVfkAs7QSENemZsnTLyE=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-lozWkVrKvSrd1SoM7Zv08YYG2pA=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/xz-5.4.6-r2.apk",
-        "version": "5.4.6-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/xz-5.6.2-r0.apk",
+        "version": "5.6.2-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1TS707T+cPGL7TYVHQBCJoWwHZ0E=",
+        "checksum": "Q10AaU1ocIM4PYYNvwbml8TmpNvEA=",
         "control": {
-          "checksum": "sha1-TS707T+cPGL7TYVHQBCJoWwHZ0E=",
-          "range": "bytes=706-1098"
+          "checksum": "sha1-0AaU1ocIM4PYYNvwbml8TmpNvEA=",
+          "range": "bytes=706-1085"
         },
         "data": {
-          "checksum": "sha256-x18L706Vug5qDzq13SXuN/vGdVgzrqB06dW2DdgHGR4=",
-          "range": "bytes=1099-4541967"
+          "checksum": "sha256-1YQNYASFjlP3kXX58ec8du75ij/U6O4DPAKzJAPkln0=",
+          "range": "bytes=1086-4272589"
         },
         "name": "libxml2",
         "signature": {
-          "checksum": "sha1-BYhOxDos48sN8df8LMsSpROv2aw=",
+          "checksum": "sha1-QFjdplzGn/MiNFxMykgafr6/w6U=",
           "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.12.7-r0.apk",
-        "version": "2.12.7-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.1-r1.apk",
+        "version": "2.13.1-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1wJPtj5XZtnPiVWGM5dsT+nyfWXc=",
+        "checksum": "Q1wbnfumlWEiJnVUsJBRcQjFD3U6I=",
         "control": {
-          "checksum": "sha1-wJPtj5XZtnPiVWGM5dsT+nyfWXc=",
-          "range": "bytes=705-1234"
+          "checksum": "sha1-wbnfumlWEiJnVUsJBRcQjFD3U6I=",
+          "range": "bytes=699-1222"
         },
         "data": {
-          "checksum": "sha256-sw+CjlpsjO01q6lqzXgHnniiJKn7bqOSNO6vNqdGc7I=",
-          "range": "bytes=1235-3873775"
+          "checksum": "sha256-IXMNbJjj3kTjkWVBIHVRfG3zJQY2r5Eslgh/3TpMSsE=",
+          "range": "bytes=1223-3886778"
         },
         "name": "bind-libs",
         "signature": {
-          "checksum": "sha1-9zDzmHAeu7mWpidXAatqrLZVzUs=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-JNN15IPpJ2hMsO6hFVpDYPvvX5g=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bind-libs-9.18.26-r0.apk",
-        "version": "9.18.26-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/bind-libs-9.18.27-r1.apk",
+        "version": "9.18.27-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1AxEQdi8fVcYtGc3zHTCW3OZdY2Q=",
+        "checksum": "Q1kXUOoNa2KXixxAASo1W/im1qZ7s=",
         "control": {
-          "checksum": "sha1-AxEQdi8fVcYtGc3zHTCW3OZdY2Q=",
-          "range": "bytes=694-1208"
+          "checksum": "sha1-kXUOoNa2KXixxAASo1W/im1qZ7s=",
+          "range": "bytes=702-1215"
         },
         "data": {
-          "checksum": "sha256-/dt3qJw5D9iSJ/mKkRQkhWD8R52selhpcwXyw7KLMhg=",
-          "range": "bytes=1209-879444"
+          "checksum": "sha256-HRADvfRXfYsgEjUMGM4Hd7prpIv+YWILVfovbGOkEME=",
+          "range": "bytes=1216-879975"
         },
         "name": "bind-tools",
         "signature": {
-          "checksum": "sha1-VTb0YdUzPMk8Po0p4nj0y5Jey6k=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-8WUTMUaJTaX0T9FS/c+GddL7ttY=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bind-tools-9.18.26-r0.apk",
-        "version": "9.18.26-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/bind-tools-9.18.27-r1.apk",
+        "version": "9.18.27-r1"
       },
       {
         "architecture": "x86_64",
@@ -645,22 +645,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1FaSuo5kLpGzOlCXAmVtdoeTE9KY=",
+        "checksum": "Q1fnaWc3899x9dK4z4iTFNOeM6MI0=",
         "control": {
-          "checksum": "sha1-FaSuo5kLpGzOlCXAmVtdoeTE9KY=",
-          "range": "bytes=699-1146"
+          "checksum": "sha1-fnaWc3899x9dK4z4iTFNOeM6MI0=",
+          "range": "bytes=702-1132"
         },
         "data": {
-          "checksum": "sha256-yT+SLCTF2RGijQmytiBOuD/ZmYIeILT21+D12xRVzrQ=",
-          "range": "bytes=1147-373555"
+          "checksum": "sha256-rhtsl8eIgOKIHSa3VsedIEj1sA3xRi83jc3fhTjIQLw=",
+          "range": "bytes=1133-377535"
         },
         "name": "ca-certificates",
         "signature": {
-          "checksum": "sha1-AKpkACT5QAimOprekpt14cLs7Pw=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-I1wWFlIzyXu0g5mcgMo/iyW3Mhw=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-20240315-r3.apk",
-        "version": "20240315-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-20240315-r4.apk",
+        "version": "20240315-r4"
       },
       {
         "architecture": "x86_64",
@@ -740,22 +740,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1XvuhvUSvcah2GSDqXjzZ3s2gxP0=",
+        "checksum": "Q18GWimtzBPBcoLLvO1qkSUgU8lnY=",
         "control": {
-          "checksum": "sha1-XvuhvUSvcah2GSDqXjzZ3s2gxP0=",
-          "range": "bytes=704-1059"
+          "checksum": "sha1-8GWimtzBPBcoLLvO1qkSUgU8lnY=",
+          "range": "bytes=703-1059"
         },
         "data": {
-          "checksum": "sha256-5El7qY7swpzsMszBT3d1Qml1POftfwUyQg65MopTlQY=",
-          "range": "bytes=1060-103661"
+          "checksum": "sha256-gbfqvYRPtP/Psse3jpUh1M2btMStrDYp7S8S5KKk1gc=",
+          "range": "bytes=1060-99122"
         },
         "name": "jansson",
         "signature": {
-          "checksum": "sha1-S1w/d1pn3Z/Md0gX/qJN+cZZ1uw=",
-          "range": "bytes=0-703"
+          "checksum": "sha1-7T/ORwcPkbnmMZiRs2mQ7MVjTBY=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/jansson-2.14-r1.apk",
-        "version": "2.14-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/jansson-2.14-r2.apk",
+        "version": "2.14-r2"
       },
       {
         "architecture": "x86_64",
@@ -816,60 +816,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1fr0OtiVaD3c5nw8fy5m74hDe9PU=",
+        "checksum": "Q1BRGmQ9LZTeZqbxQ1ls69T6efViw=",
         "control": {
-          "checksum": "sha1-fr0OtiVaD3c5nw8fy5m74hDe9PU=",
-          "range": "bytes=697-1092"
+          "checksum": "sha1-BRGmQ9LZTeZqbxQ1ls69T6efViw=",
+          "range": "bytes=698-1080"
         },
         "data": {
-          "checksum": "sha256-lukjMYpGmuhBNDUbbTJMIrUWaR4rNikEnW4BgiTaLj8=",
-          "range": "bytes=1093-113872"
+          "checksum": "sha256-vtJ4WJ5M+31ZKSBYBedbrl/FrbAw8hGpPRrHC7kasOk=",
+          "range": "bytes=1081-113895"
         },
         "name": "libpsl",
         "signature": {
-          "checksum": "sha1-Lrrudgn1i1a0JhjdzeXG+exnjQA=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-DuAoiykwhu8vu1qxdEDK5oyAmf8=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libpsl-0.21.5-r2.apk",
-        "version": "0.21.5-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libpsl-0.21.5-r3.apk",
+        "version": "0.21.5-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1oauHQa0YcFcEHSQWdfohfNEN4sY=",
+        "checksum": "Q11DZVpe2UYyDr/dG6BDysZhE3L48=",
         "control": {
-          "checksum": "sha1-oauHQa0YcFcEHSQWdfohfNEN4sY=",
-          "range": "bytes=698-1057"
+          "checksum": "sha1-1DZVpe2UYyDr/dG6BDysZhE3L48=",
+          "range": "bytes=707-1049"
         },
         "data": {
-          "checksum": "sha256-d95c9lpjQrpuZ1CcQ8ZZ89LAGGKcessd+hxrOQpP4LU=",
-          "range": "bytes=1058-173549"
+          "checksum": "sha256-aECfsy7giZsLNxZM0HMeF4OS2gu+ycX4DUTJXsiZRQs=",
+          "range": "bytes=1050-173585"
         },
         "name": "libbrotlicommon1",
         "signature": {
-          "checksum": "sha1-g3ufBq/tyiNP6AaOoqwItVvh7uk=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-7LXD38QwFhklZCEqyW4qIncfZV0=",
+          "range": "bytes=0-706"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlicommon1-1.1.0-r2.apk",
-        "version": "1.1.0-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlicommon1-1.1.0-r3.apk",
+        "version": "1.1.0-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q18Otq7NLoYnNMebI/1Rr/s0zdLVw=",
+        "checksum": "Q1Cgr886A8Ryzynz9pxRKsNybVuK0=",
         "control": {
-          "checksum": "sha1-8Otq7NLoYnNMebI/1Rr/s0zdLVw=",
-          "range": "bytes=705-1072"
+          "checksum": "sha1-Cgr886A8Ryzynz9pxRKsNybVuK0=",
+          "range": "bytes=694-1043"
         },
         "data": {
-          "checksum": "sha256-sR3QidR/e46PJ/3S2fxAjN/hRSSA3Ar32Nw7VshTHWg=",
-          "range": "bytes=1073-81475"
+          "checksum": "sha256-mH+MTbqpLiqgydlgE+tSDEt0Sh1/zqMvAqspV4lr+Ks=",
+          "range": "bytes=1044-81511"
         },
         "name": "libbrotlidec1",
         "signature": {
-          "checksum": "sha1-6GpZI5cBUXOvjCYG81aZZR53lMI=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-Yp4Bde9oHQCec8HM2qn6hVKgtko=",
+          "range": "bytes=0-693"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlidec1-1.1.0-r2.apk",
-        "version": "1.1.0-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlidec1-1.1.0-r3.apk",
+        "version": "1.1.0-r3"
       },
       {
         "architecture": "x86_64",
@@ -930,41 +930,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1uIKbAiTl7xWbpJXy11+HeOS/RDo=",
+        "checksum": "Q1+FlR1zI7qp3uiJm5fHTA4Hr1lSQ=",
         "control": {
-          "checksum": "sha1-uIKbAiTl7xWbpJXy11+HeOS/RDo=",
-          "range": "bytes=694-1075"
+          "checksum": "sha1-+FlR1zI7qp3uiJm5fHTA4Hr1lSQ=",
+          "range": "bytes=698-1064"
         },
         "data": {
-          "checksum": "sha256-qUT47e+MUydc5TG+6YjAi7LyDOWQeOyP5dlfnPBWRWM=",
-          "range": "bytes=1076-697425"
+          "checksum": "sha256-jx/MzLqQnCOtZqAiH6LmBTCiTD9HId1TLO3GZFDqHxQ=",
+          "range": "bytes=1065-685148"
         },
         "name": "libpcre2-8-0",
         "signature": {
-          "checksum": "sha1-T6Z2q5sW3pwjztCXPRoQKi8rfeY=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-4ZNzjpofU2aV2PzFb9SFo9ipHLE=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libpcre2-8-0-10.43-r1.apk",
-        "version": "10.43-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libpcre2-8-0-10.44-r1.apk",
+        "version": "10.44-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q111Aq+tDFOygcfZzOg1hQbtZw1Q4=",
+        "checksum": "Q1Xg04pU313NQ+1ni/3EGFESveG28=",
         "control": {
-          "checksum": "sha1-11Aq+tDFOygcfZzOg1hQbtZw1Q4=",
-          "range": "bytes=697-1140"
+          "checksum": "sha1-Xg04pU313NQ+1ni/3EGFESveG28=",
+          "range": "bytes=694-1135"
         },
         "data": {
-          "checksum": "sha256-ednk20seorMQ+xEGnt8zWpxO20xrfj7zOtAmk+XcTbA=",
-          "range": "bytes=1141-17250210"
+          "checksum": "sha256-rgB0/iCkskRu0z50yJPj5UbCkDqeT48PaLInXkivQh4=",
+          "range": "bytes=1136-17250228"
         },
         "name": "git",
         "signature": {
-          "checksum": "sha1-T1C3/QmQvuJGLjPH2YyOLIM5ewE=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-oiYirHB8Oqxgza8ivbRUYOy39i8=",
+          "range": "bytes=0-693"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/git-2.45.2-r0.apk",
-        "version": "2.45.2-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/git-2.45.2-r2.apk",
+        "version": "2.45.2-r2"
       },
       {
         "architecture": "x86_64",
@@ -987,41 +987,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1/xjUDpfwOCMLFmAYUyXK3hbr7M8=",
+        "checksum": "Q1yJyrwOSL5j/c75p1ZWXww23qWyw=",
         "control": {
-          "checksum": "sha1-/xjUDpfwOCMLFmAYUyXK3hbr7M8=",
-          "range": "bytes=703-1114"
+          "checksum": "sha1-yJyrwOSL5j/c75p1ZWXww23qWyw=",
+          "range": "bytes=696-1092"
         },
         "data": {
-          "checksum": "sha256-RvBzvJt//AAv6DeDRxBbbW2UG//3UZ38sDmhcMQoRKY=",
-          "range": "bytes=1115-7560368"
+          "checksum": "sha256-aGdAd0PplDBTW6tyKKTA/Q5yovpzZ+IYuoLBrPxcgqY=",
+          "range": "bytes=1093-7560386"
         },
         "name": "git-daemon",
         "signature": {
-          "checksum": "sha1-dHYurOENIvRxIuBAaHNAeJGQciA=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-pf55N3sBcf0jZRjNnGgDsnaNvF4=",
+          "range": "bytes=0-695"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/git-daemon-2.45.2-r0.apk",
-        "version": "2.45.2-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/git-daemon-2.45.2-r2.apk",
+        "version": "2.45.2-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1lmZVnMVaV+BuJ4Zw8v1gIkGVcNc=",
+        "checksum": "Q1HtAJTveKgYfSNwcyhAKJO8Q38TI=",
         "control": {
-          "checksum": "sha1-lmZVnMVaV+BuJ4Zw8v1gIkGVcNc=",
-          "range": "bytes=696-1069"
+          "checksum": "sha1-HtAJTveKgYfSNwcyhAKJO8Q38TI=",
+          "range": "bytes=699-1057"
         },
         "data": {
-          "checksum": "sha256-qHYsorfTKRzalTN5p+JzwEZ2NYXNkxiHME9MoyMfeRI=",
-          "range": "bytes=1070-212142"
+          "checksum": "sha256-G5w+Y8O79PdpMBZ/KtsRs2mNVs7hjjoaEyB4a4+A8LU=",
+          "range": "bytes=1058-212160"
         },
         "name": "git-p4",
         "signature": {
-          "checksum": "sha1-eGGtsdgoIw2il+9a5ZT/t126v0c=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-7cdrBfVvX+ZNJnJhvO21XG5Z69M=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/git-p4-2.45.2-r0.apk",
-        "version": "2.45.2-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/git-p4-2.45.2-r2.apk",
+        "version": "2.45.2-r2"
       },
       {
         "architecture": "x86_64",
@@ -1063,41 +1063,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1vrOnBo92+mGIAJquCs5EcsBJ7B0=",
+        "checksum": "Q1ilPHja4OgIE4Ghwn3Lem3el24a8=",
         "control": {
-          "checksum": "sha1-vrOnBo92+mGIAJquCs5EcsBJ7B0=",
-          "range": "bytes=703-1156"
+          "checksum": "sha1-ilPHja4OgIE4Ghwn3Lem3el24a8=",
+          "range": "bytes=704-1144"
         },
         "data": {
-          "checksum": "sha256-5niuG91x7i55ksheox0EjKMKC+Wq+voVBUyKR2klMaQ=",
-          "range": "bytes=1157-1350198"
+          "checksum": "sha256-YE6EOIZDlX8wyqrwatqEuMJ8PqP9oPYzoQXirqTeiQ8=",
+          "range": "bytes=1145-1341997"
         },
         "name": "nginx-mainline",
         "signature": {
-          "checksum": "sha1-9iEcHqqJ8e81IifZU2fa3u/ytdQ=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-1JZ7s+meE/vHPSZDidXATGecqts=",
+          "range": "bytes=0-703"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nginx-mainline-1.27.0-r0.apk",
-        "version": "1.27.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/nginx-mainline-1.27.0-r5.apk",
+        "version": "1.27.0-r5"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1pnWXOjkJIlvLYT8XeY7F3IVNRn8=",
+        "checksum": "Q16khvLSvBTIM/9zdpX5Xi0z/5fzY=",
         "control": {
-          "checksum": "sha1-pnWXOjkJIlvLYT8XeY7F3IVNRn8=",
-          "range": "bytes=701-1103"
+          "checksum": "sha1-6khvLSvBTIM/9zdpX5Xi0z/5fzY=",
+          "range": "bytes=702-1087"
         },
         "data": {
-          "checksum": "sha256-zC1cJXh51Hw9sebfcIVT0+NAoj3WXEhStvH3HvFI+Sc=",
-          "range": "bytes=1104-61941"
+          "checksum": "sha256-KTW8s77J6Gl2Buzp3IAJyKbFCW5MUdyV69KfS+Fhcns=",
+          "range": "bytes=1088-61932"
         },
         "name": "nginx-mainline-config",
         "signature": {
-          "checksum": "sha1-9Ox08qvmuRGHEVKXDnApxEndnpo=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-8+knAPPIU4yKuPZE0a2oqYp8hnA=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nginx-mainline-config-1.27.0-r0.apk",
-        "version": "1.27.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/nginx-mainline-config-1.27.0-r5.apk",
+        "version": "1.27.0-r5"
       },
       {
         "architecture": "x86_64",
@@ -1120,22 +1120,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1EeC4oJcNGILol2exjVmAmCeKe3Y=",
+        "checksum": "Q1G/AwDwdfNwNdSm/t6Sqght8DOpI=",
         "control": {
-          "checksum": "sha1-EeC4oJcNGILol2exjVmAmCeKe3Y=",
-          "range": "bytes=698-1076"
+          "checksum": "sha1-G/AwDwdfNwNdSm/t6Sqght8DOpI=",
+          "range": "bytes=696-1061"
         },
         "data": {
-          "checksum": "sha256-jG5+Qk19KNjypflTSwO2gF+f/zqWbtjjhuzSO3maxf8=",
-          "range": "bytes=1077-109053"
+          "checksum": "sha256-5ypXRnqcv42v+Xt59TOt/lTM3huvyCrCDpeER423auk=",
+          "range": "bytes=1062-113624"
         },
         "name": "libbz2-1",
         "signature": {
-          "checksum": "sha1-800rFtecn2FKQ9uM95GkfwOMvnQ=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-riGFRNbF0tAWYE9PlBEuTbcGkTQ=",
+          "range": "bytes=0-695"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libbz2-1-1.0.8-r7.apk",
-        "version": "1.0.8-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libbz2-1-1.0.8-r8.apk",
+        "version": "1.0.8-r8"
       },
       {
         "architecture": "x86_64",
@@ -1234,22 +1234,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1sBp15UoB9iDd/xOOx13CSHRTZnA=",
+        "checksum": "Q1b1fkDQZR7BtOZFyaQCnquuKyU8c=",
         "control": {
-          "checksum": "sha1-sBp15UoB9iDd/xOOx13CSHRTZnA=",
-          "range": "bytes=695-1072"
+          "checksum": "sha1-b1fkDQZR7BtOZFyaQCnquuKyU8c=",
+          "range": "bytes=697-1059"
         },
         "data": {
-          "checksum": "sha256-pSuWnCmt6INeWQul5MdUqxgoJ5B7FTEtCfyvg5H+WrA=",
-          "range": "bytes=1073-84740"
+          "checksum": "sha256-g6aBpzXAR79pmyFfBOmkTYKPEVMdAYC7akIKD6h6mHM=",
+          "range": "bytes=1060-84760"
         },
         "name": "libffi",
         "signature": {
-          "checksum": "sha1-kabxjRZlgSfO5ocH7PkbBtqFyus=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-xik2kwwu8Ryo+2igE3vEQ430rP0=",
+          "range": "bytes=0-696"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libffi-3.4.6-r2.apk",
-        "version": "3.4.6-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libffi-3.4.6-r3.apk",
+        "version": "3.4.6-r3"
       },
       {
         "architecture": "x86_64",
@@ -1405,22 +1405,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1gVS2hViR+aAQXAlw4s/5CvQBxy8=",
+        "checksum": "Q1Hf1ZqgmpLdGq0pcrMGQLx+YVW30=",
         "control": {
-          "checksum": "sha1-gVS2hViR+aAQXAlw4s/5CvQBxy8=",
-          "range": "bytes=699-1129"
+          "checksum": "sha1-Hf1ZqgmpLdGq0pcrMGQLx+YVW30=",
+          "range": "bytes=705-1121"
         },
         "data": {
-          "checksum": "sha256-ebXJXNAa0wCctDQAiIs0biAL9KgvayQCWHJbWhJwm9U=",
-          "range": "bytes=1130-3146675"
+          "checksum": "sha256-IYdYuA3crFIox4q1U8Hezl/CbJTAC8O39UH63SyW95k=",
+          "range": "bytes=1122-3076780"
         },
         "name": "openssh-client",
         "signature": {
-          "checksum": "sha1-TV5xWmTqQw4glScJ2YEiQz728ns=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-hx9IdDW+uTR72mUA/LIasTK5KHk=",
+          "range": "bytes=0-704"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/openssh-client-9.7_p1-r1.apk",
-        "version": "9.7_p1-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/openssh-client-9.8_p1-r1.apk",
+        "version": "9.8_p1-r1"
       },
       {
         "architecture": "x86_64",
@@ -1538,22 +1538,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1GrI3roTx+zrOBnGfqb4bM1OYj6I=",
+        "checksum": "Q1pFBna33iXNWoxlANBI0dibfvT94=",
         "control": {
-          "checksum": "sha1-GrI3roTx+zrOBnGfqb4bM1OYj6I=",
-          "range": "bytes=702-1139"
+          "checksum": "sha1-pFBna33iXNWoxlANBI0dibfvT94=",
+          "range": "bytes=706-1129"
         },
         "data": {
-          "checksum": "sha256-DB4T1Bo94kP9/NuGNv0Vi0KzSaINmPY0hpICRStIKSE=",
-          "range": "bytes=1140-66640"
+          "checksum": "sha256-jsPjzi/shXYlr0zayGvJ82SSPVs4ew/DIy3L1hiuqdE=",
+          "range": "bytes=1130-66950"
         },
         "name": "libuuid",
         "signature": {
-          "checksum": "sha1-xVMkIcRSdv+/WzAYI6KvKvyW9WU=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-nVANm2v8k7qILW+g+xjNgr7yqQY=",
+          "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libuuid-2.39.3-r4.apk",
-        "version": "2.39.3-r4"
+        "url": "https://packages.wolfi.dev/os/x86_64/libuuid-2.40.1-r1.apk",
+        "version": "2.40.1-r1"
       },
       {
         "architecture": "x86_64",
@@ -1576,22 +1576,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1KHnJp4dgXxm50FeWqVm7Lu2Rm3o=",
+        "checksum": "Q1K7zkV+ytg2NfGl9Sq0L07g7m3t8=",
         "control": {
-          "checksum": "sha1-KHnJp4dgXxm50FeWqVm7Lu2Rm3o=",
-          "range": "bytes=696-1138"
+          "checksum": "sha1-K7zkV+ytg2NfGl9Sq0L07g7m3t8=",
+          "range": "bytes=703-1134"
         },
         "data": {
-          "checksum": "sha256-wWq5y1hEpcKhQ1QnvOKJHsnPxcD7/X7IEViso75B9bs=",
-          "range": "bytes=1139-192875683"
+          "checksum": "sha256-R8lBnMUORssXrz1Ph1NoBz+/StjHKbjVjNDDtSvb0Zs=",
+          "range": "bytes=1135-191882402"
         },
-        "name": "prometheus-2.52",
+        "name": "prometheus-2.53",
         "signature": {
-          "checksum": "sha1-3JjyUbZtACAX5ljsTN4qs1Qekqk=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-LHetuVjR91DCOcHkyTC91kBA3vY=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/prometheus-2.52-2.52.0-r3.apk",
-        "version": "2.52.0-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/prometheus-2.53-2.53.0-r2.apk",
+        "version": "2.53.0-r2"
       },
       {
         "architecture": "x86_64",
@@ -1671,60 +1671,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Xou3FauSnsDlv/GSiADD5//sbLU=",
+        "checksum": "Q10pJtceZTY/GaOtTkhXrHyRg/4us=",
         "control": {
-          "checksum": "sha1-Xou3FauSnsDlv/GSiADD5//sbLU=",
-          "range": "bytes=701-1087"
+          "checksum": "sha1-0pJtceZTY/GaOtTkhXrHyRg/4us=",
+          "range": "bytes=698-1072"
         },
         "data": {
-          "checksum": "sha256-pb3t+dcRqtb+NKcRaX+WpCmgwmCys/1yj9ZEv00dz6o=",
-          "range": "bytes=1088-1101261"
+          "checksum": "sha256-p32sgOSmN27pL84lhBFuVJ77C3zL/HSJpCa+dBqx/0Y=",
+          "range": "bytes=1073-1101764"
         },
         "name": "readline",
         "signature": {
-          "checksum": "sha1-UM8oioixvqY+MAGWmuqxp169zNk=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-a8RmW9zjTrKAkoKJP5kERPY1CeI=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/readline-8.2-r6.apk",
-        "version": "8.2-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/readline-8.2-r7.apk",
+        "version": "8.2-r7"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1dSuRtBPomtGv2me2POZQiR51lJE=",
+        "checksum": "Q1a6z011zqFp2z1JCXtKZA+NDNaZM=",
         "control": {
-          "checksum": "sha1-dSuRtBPomtGv2me2POZQiR51lJE=",
-          "range": "bytes=700-1214"
+          "checksum": "sha1-a6z011zqFp2z1JCXtKZA+NDNaZM=",
+          "range": "bytes=700-1201"
         },
         "data": {
-          "checksum": "sha256-ZGhXZHXVdTTijpXtoRbXzHVsQ5bFnkjjY/LVgy+5Wm4=",
-          "range": "bytes=1215-40423596"
+          "checksum": "sha256-3blIe0IpHxnfbUhz4WrMWZb2cKlOYBr1bffuuxBVk2s=",
+          "range": "bytes=1202-40471072"
         },
         "name": "python-3.12-base",
         "signature": {
-          "checksum": "sha1-n2GGplQgEEHbAOL1wxJ7zdm2KDs=",
+          "checksum": "sha1-zABDPtPAGmVdJmPpIJpvPFzpu0k=",
           "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/python-3.12-base-3.12.3-r3.apk",
-        "version": "3.12.3-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/python-3.12-base-3.12.4-r1.apk",
+        "version": "3.12.4-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Jps1axE/oWBY4VZrdX7R4bEsaOM=",
+        "checksum": "Q1URKL5KNXKIM0igX3gWtsaAQinog=",
         "control": {
-          "checksum": "sha1-Jps1axE/oWBY4VZrdX7R4bEsaOM=",
-          "range": "bytes=700-1076"
+          "checksum": "sha1-URKL5KNXKIM0igX3gWtsaAQinog=",
+          "range": "bytes=701-1059"
         },
         "data": {
-          "checksum": "sha256-RvypSTb54kyTUweZeMAt6rXJSKendPCi0e7Qtg3U9wQ=",
-          "range": "bytes=1077-42729"
+          "checksum": "sha256-7rAjW9fn3i3sNJnhTa5zqRD9I/0JkjlNHLsxCswOZBU=",
+          "range": "bytes=1060-42767"
         },
         "name": "python-3.12",
         "signature": {
-          "checksum": "sha1-0tQ4gaI3k39mmmjsylobay/tq8Y=",
-          "range": "bytes=0-699"
+          "checksum": "sha1-NmSoZl1PXBTBFANq2LBz9dX+bbo=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/python-3.12-3.12.3-r3.apk",
-        "version": "3.12.3-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/python-3.12-3.12.4-r1.apk",
+        "version": "3.12.4-r1"
       },
       {
         "architecture": "x86_64",
@@ -1842,22 +1842,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q19f/3419Xa/xv9jgQ0mMYs011fBk=",
+        "checksum": "Q1mTmy64gKYi4THBqewuvYL2uUyHc=",
         "control": {
-          "checksum": "sha1-9f/3419Xa/xv9jgQ0mMYs011fBk=",
-          "range": "bytes=696-1041"
+          "checksum": "sha1-mTmy64gKYi4THBqewuvYL2uUyHc=",
+          "range": "bytes=700-1031"
         },
         "data": {
-          "checksum": "sha256-iqHASiMgiu6rIjbWGwBmmq1Zthae8BkE4QZkiVPH7Ek=",
-          "range": "bytes=1042-1888945"
+          "checksum": "sha256-p0qua2luH33oAgOcLkU9f7k+I8WnykFszVMwNahujDA=",
+          "range": "bytes=1032-1889523"
         },
         "name": "tzdata",
         "signature": {
-          "checksum": "sha1-PCC3jiXlTwrimRMXH/4RyNvccOM=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-sBf5jVLVpWj4DiXaAd/mjo0pTfk=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/tzdata-2024a-r2.apk",
-        "version": "2024a-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/tzdata-2024a-r3.apk",
+        "version": "2024a-r3"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/sourcegraph-base.lock.json
+++ b/wolfi-images/sourcegraph-base.lock.json
@@ -14,41 +14,41 @@
     "packages": [
       {
         "architecture": "x86_64",
-        "checksum": "Q1ge3SLQsJ9v2RnvIHHAP1yFyjrEU=",
+        "checksum": "Q1Ai8jWuxKZR2M2XhOpOGAoTEwnnk=",
         "control": {
-          "checksum": "sha1-ge3SLQsJ9v2RnvIHHAP1yFyjrEU=",
-          "range": "bytes=693-1040"
+          "checksum": "sha1-Ai8jWuxKZR2M2XhOpOGAoTEwnnk=",
+          "range": "bytes=705-1037"
         },
         "data": {
-          "checksum": "sha256-I0AdTdfGf4P/jwzTrLXm73l5/RNSlymEof/YZfev3xY=",
-          "range": "bytes=1041-255811"
+          "checksum": "sha256-e4UardkBVyaC49aSyrVmXNi8sSKqQl4eKYd0LxGRLA0=",
+          "range": "bytes=1038-255695"
         },
         "name": "ca-certificates-bundle",
         "signature": {
-          "checksum": "sha1-ge1eJBiQmFWAn9GapFkQpO+Rn/Y=",
-          "range": "bytes=0-692"
+          "checksum": "sha1-loRuyYQLm+atp+YteiQoj++EWIM=",
+          "range": "bytes=0-704"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20240315-r3.apk",
-        "version": "20240315-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20240315-r4.apk",
+        "version": "20240315-r4"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1bgay5kOzpmDBgqJCg7dSlawyJg0=",
+        "checksum": "Q1+GH6qRN4iy1IDt0cT0x0tin7YfI=",
         "control": {
-          "checksum": "sha1-bgay5kOzpmDBgqJCg7dSlawyJg0=",
-          "range": "bytes=703-1067"
+          "checksum": "sha1-+GH6qRN4iy1IDt0cT0x0tin7YfI=",
+          "range": "bytes=703-1051"
         },
         "data": {
-          "checksum": "sha256-f83HfRE7r2ZniH7PyPmRqcoU5NTpF+Uk4FH80QbjvBM=",
-          "range": "bytes=1068-118370"
+          "checksum": "sha256-rO0P9z2V49BSrz1A5Ap69tEappVrg5MMBjzW00rOpZc=",
+          "range": "bytes=1052-122464"
         },
         "name": "wolfi-baselayout",
         "signature": {
-          "checksum": "sha1-2hlCvYH1D7u25HkJGA75jjs/sQY=",
+          "checksum": "sha1-Ntb6VuMzDfM+frpCjKEIpDzl53I=",
           "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r11.apk",
-        "version": "20230201-r11"
+        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r12.apk",
+        "version": "20230201-r12"
       },
       {
         "architecture": "x86_64",
@@ -109,41 +109,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Zjfs1uR/mYiortANP+EFcejW+vo=",
+        "checksum": "Q1Zi0e8Bq6WCd/6uXXjVhb8YwMD1U=",
         "control": {
-          "checksum": "sha1-Zjfs1uR/mYiortANP+EFcejW+vo=",
-          "range": "bytes=698-1085"
+          "checksum": "sha1-Zi0e8Bq6WCd/6uXXjVhb8YwMD1U=",
+          "range": "bytes=700-1073"
         },
         "data": {
-          "checksum": "sha256-BMd7TzffjbrFwdbopDPVYsX0X9XnusIMNbIf33/8kwc=",
-          "range": "bytes=1086-76881"
+          "checksum": "sha256-jMhtfqVjnhuuBO7wtNZ6RS/72sZWoKt/Moage2amlks=",
+          "range": "bytes=1074-81594"
         },
         "name": "protobuf-c",
         "signature": {
-          "checksum": "sha1-efGiXyYWsJ5P2uTkB6aXEZ3kl3o=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-kATwMKztK7nk7qbYCJPkCFp6IXc=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r4.apk",
-        "version": "1.5.0-r4"
-      },
-      {
-        "architecture": "x86_64",
-        "checksum": "Q1Xf5v5uXumBgIR4d4ZxMRxdpyWlM=",
-        "control": {
-          "checksum": "sha1-Xf5v5uXumBgIR4d4ZxMRxdpyWlM=",
-          "range": "bytes=698-1078"
-        },
-        "data": {
-          "checksum": "sha256-eD7HqFCWNUBQiLq9PcWE/zPeZwkiv8hBrytI4qmfQ/8=",
-          "range": "bytes=1079-57055"
-        },
-        "name": "keyutils-libs",
-        "signature": {
-          "checksum": "sha1-V0HVgZLP7P5kNACfus3abCLCS20=",
-          "range": "bytes=0-697"
-        },
-        "url": "https://packages.wolfi.dev/os/x86_64/keyutils-libs-1.6.3-r2.apk",
-        "version": "1.6.3-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r5.apk",
+        "version": "1.5.0-r5"
       },
       {
         "architecture": "x86_64",
@@ -166,22 +147,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1wRzOx+L6MeRFtTcq2y/6ot7Cj54=",
+        "checksum": "Q1v0A2vQM5k8rQY/GpIq6xI4T0YmA=",
         "control": {
-          "checksum": "sha1-wRzOx+L6MeRFtTcq2y/6ot7Cj54=",
-          "range": "bytes=699-1069"
+          "checksum": "sha1-v0A2vQM5k8rQY/GpIq6xI4T0YmA=",
+          "range": "bytes=701-1064"
         },
         "data": {
-          "checksum": "sha256-gNRjwZ4XQatCYWediSVb+j8lS54CggvMC5Dn3qT84So=",
-          "range": "bytes=1070-61490"
+          "checksum": "sha256-uAOrkGDDc/yqt6VjIrlTEALBJG4BCI4njqZw5jQqF0o=",
+          "range": "bytes=1065-56984"
+        },
+        "name": "keyutils-libs",
+        "signature": {
+          "checksum": "sha1-32uYMH/zGBr9Jo3hiqnThlcqBcE=",
+          "range": "bytes=0-700"
+        },
+        "url": "https://packages.wolfi.dev/os/x86_64/keyutils-libs-1.6.3-r3.apk",
+        "version": "1.6.3-r3"
+      },
+      {
+        "architecture": "x86_64",
+        "checksum": "Q1Onuac6Y+IWA7a4b8FvqX1erWDDw=",
+        "control": {
+          "checksum": "sha1-Onuac6Y+IWA7a4b8FvqX1erWDDw=",
+          "range": "bytes=693-1048"
+        },
+        "data": {
+          "checksum": "sha256-KLtDAs3iU0oyZ/FysePG/J+1H1ofDxHXIY7xvtZhtMc=",
+          "range": "bytes=1049-61503"
         },
         "name": "libverto",
         "signature": {
-          "checksum": "sha1-kuPwakYdy5EM6sd5Ba0K0Ta8x4w=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-/IXL9S1O+MwaW7KsSzz1ywEqKFQ=",
+          "range": "bytes=0-692"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libverto-0.3.2-r3.apk",
-        "version": "0.3.2-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/libverto-0.3.2-r4.apk",
+        "version": "0.3.2-r4"
       },
       {
         "architecture": "x86_64",
@@ -204,60 +204,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1gTZGkWP+QO3mUqLVJth8vrDEzzU=",
+        "checksum": "Q1Q/Zy5ovYSu2p/vVLr6DgVA1e8AQ=",
         "control": {
-          "checksum": "sha1-gTZGkWP+QO3mUqLVJth8vrDEzzU=",
-          "range": "bytes=699-1076"
+          "checksum": "sha1-Q/Zy5ovYSu2p/vVLr6DgVA1e8AQ=",
+          "range": "bytes=699-1062"
         },
         "data": {
-          "checksum": "sha256-/IFXqeKvU0GODNsz1yPIEMcFHgABT+8rbZpSlTLo4e4=",
-          "range": "bytes=1077-5915704"
+          "checksum": "sha256-H3jxsw8ytOeCIR4vq17voSVhdNokXk8C1g075txH6Bs=",
+          "range": "bytes=1063-5903754"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-l1o5ixkyWWqqJE3FOfR0QUemJUA=",
+          "checksum": "sha1-NIl2f5OI/wSZByI8Ds1ZUfbFWyw=",
           "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r9.apk",
-        "version": "3.3.0-r9"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.1-r3.apk",
+        "version": "3.3.1-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1jhAhggAuZnU7FFHnebGA26mq+jI=",
+        "checksum": "Q13wGUXdZut9OOTdY5z2amUj9wXC0=",
         "control": {
-          "checksum": "sha1-jhAhggAuZnU7FFHnebGA26mq+jI=",
-          "range": "bytes=695-1079"
+          "checksum": "sha1-3wGUXdZut9OOTdY5z2amUj9wXC0=",
+          "range": "bytes=698-1068"
         },
         "data": {
-          "checksum": "sha256-XTCQYnhGSm7SkGwqV/TQMFqGajVJVYhKAidKfLb2D3Y=",
-          "range": "bytes=1080-1197081"
+          "checksum": "sha256-mRda6+YGlOCczyIWKaHqXskTINoT1rgorHDHqAKAb7c=",
+          "range": "bytes=1069-1188955"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-qVrfDVxubkrb5Yrd2mFTv2A0G7k=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-+UdRc4U3PKw4H9OiNurHKXa5BYk=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r9.apk",
-        "version": "3.3.0-r9"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.1-r3.apk",
+        "version": "3.3.1-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1BQEXaeya6QB39QLeKcB99qBNF2o=",
+        "checksum": "Q1p04MrHQPrXOzuV/uF290zjnltqI=",
         "control": {
-          "checksum": "sha1-BQEXaeya6QB39QLeKcB99qBNF2o=",
-          "range": "bytes=699-1229"
+          "checksum": "sha1-p04MrHQPrXOzuV/uF290zjnltqI=",
+          "range": "bytes=704-1219"
         },
         "data": {
-          "checksum": "sha256-ugj/qGEBzhvdX17S22Anry+biy3lcqywhGMSHLIBCvo=",
-          "range": "bytes=1230-2551676"
+          "checksum": "sha256-TsXeqhUGykAhjQUEAlMUSzDQBcWDkkDvReoeHCL1F6c=",
+          "range": "bytes=1220-2555814"
         },
         "name": "krb5-libs",
         "signature": {
-          "checksum": "sha1-oqDPmNM4EngXAGayd/BZOqJAIao=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-cPyzS38QHuNlOCQb8IPlsl2PLHQ=",
+          "range": "bytes=0-703"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/krb5-libs-1.21.2-r2.apk",
-        "version": "1.21.2-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/krb5-libs-1.21.3-r0.apk",
+        "version": "1.21.3-r0"
       },
       {
         "architecture": "x86_64",
@@ -280,60 +280,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1wzZwtLauOQfLQC7YUvZdfKxtlwQ=",
+        "checksum": "Q17uprcuQ2VFudMcWAwtP7miJmLYs=",
         "control": {
-          "checksum": "sha1-wzZwtLauOQfLQC7YUvZdfKxtlwQ=",
-          "range": "bytes=698-1085"
+          "checksum": "sha1-7uprcuQ2VFudMcWAwtP7miJmLYs=",
+          "range": "bytes=695-1067"
         },
         "data": {
-          "checksum": "sha256-TO8CAULO44s/LphhtcaFOGJB7aFldk13v1cV9ceZHww=",
-          "range": "bytes=1086-276837"
+          "checksum": "sha256-unKdPbvO2VHZ5w1t1l8mOpQuNdUGwLhofEO4weN2Mig=",
+          "range": "bytes=1068-280973"
         },
         "name": "libuv",
         "signature": {
-          "checksum": "sha1-LRiyeKmjexy8CJizLxjd6ikon1w=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-4lKldnTO71WHMZ4tbANz6i2/Ed0=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libuv-1.48.0-r2.apk",
-        "version": "1.48.0-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libuv-1.48.0-r3.apk",
+        "version": "1.48.0-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q14S6biy8fc5OGbGEJoLBM+tJOGyo=",
+        "checksum": "Q1CN6zJbOPznWUfTrb/41KT7E6dm8=",
         "control": {
-          "checksum": "sha1-4S6biy8fc5OGbGEJoLBM+tJOGyo=",
-          "range": "bytes=703-1102"
+          "checksum": "sha1-CN6zJbOPznWUfTrb/41KT7E6dm8=",
+          "range": "bytes=699-1083"
         },
         "data": {
-          "checksum": "sha256-hwjdLQYfuMAGQeONmFVo0lZKKQK1S+3PBhrI3upm5W4=",
-          "range": "bytes=1103-155304"
+          "checksum": "sha256-ybzFzoQh1yNTcd3cjt54nYsPlAxAcMUcVMxEv1JRnpQ=",
+          "range": "bytes=1084-155375"
         },
         "name": "zlib",
         "signature": {
-          "checksum": "sha1-ZuLd7kE+AGhn27o8ZqDGM5eundc=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-CPXJcCjinAXP+H8Z5tkko8ayG6E=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/zlib-1.3.1-r2.apk",
-        "version": "1.3.1-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/zlib-1.3.1-r3.apk",
+        "version": "1.3.1-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ykDkP+AmDi2VcZZ1c4q4sez/DxI=",
+        "checksum": "Q1rgbci8SRSjW7EB0NSh6ZUPJLndM=",
         "control": {
-          "checksum": "sha1-ykDkP+AmDi2VcZZ1c4q4sez/DxI=",
-          "range": "bytes=705-1079"
+          "checksum": "sha1-rgbci8SRSjW7EB0NSh6ZUPJLndM=",
+          "range": "bytes=702-1060"
         },
         "data": {
-          "checksum": "sha256-t3BrH7lWfY3to3Fu3EKAMZx29v9Hnl5seyXJzLmZ9/4=",
-          "range": "bytes=1080-251884"
+          "checksum": "sha256-tf4xbo+NP+ssiaZtC1kOKehffAZ3+d17bhgfU3/30+g=",
+          "range": "bytes=1061-256582"
         },
         "name": "libnghttp2-14",
         "signature": {
-          "checksum": "sha1-CotSXRaPLKQCBRHrgzrDOD+4w20=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-KrsJYTyUsll+EUhHekbkdZFzeig=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.62.1-r0.apk",
-        "version": "1.62.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.62.1-r1.apk",
+        "version": "1.62.1-r1"
       },
       {
         "architecture": "x86_64",
@@ -394,136 +394,136 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1DE49kWSnmqVKJdjHFYC1bLkvyb0=",
+        "checksum": "Q1R8OxpY0fGwVaIwft4wJeswF5D54=",
         "control": {
-          "checksum": "sha1-DE49kWSnmqVKJdjHFYC1bLkvyb0=",
-          "range": "bytes=697-1078"
+          "checksum": "sha1-R8OxpY0fGwVaIwft4wJeswF5D54=",
+          "range": "bytes=695-1059"
         },
         "data": {
-          "checksum": "sha256-uDg8Qc6Rnro/68Vb5ufFSkqFLGrEsbvPb0pMJNvT1zw=",
-          "range": "bytes=1079-242085"
+          "checksum": "sha256-wNc8/SBJrGHfwywAtzCsAqeUOt0IaAhqNtlbv8OiHBE=",
+          "range": "bytes=1060-242151"
         },
         "name": "c-ares",
         "signature": {
-          "checksum": "sha1-iYEm6EWQKzxkeoDm+QsRfhw8pDg=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-55/PTlEHXI3o0hx9dSVdNwQeSMg=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.29.0-r0.apk",
-        "version": "1.29.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.31.0-r0.apk",
+        "version": "1.31.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q12eWmn2tCkXxwncU6gagKM3Wd9Sk=",
+        "checksum": "Q1g2RQKAvNjlRPxWjinIRveaq7IlY=",
         "control": {
-          "checksum": "sha1-2eWmn2tCkXxwncU6gagKM3Wd9Sk=",
-          "range": "bytes=696-1169"
+          "checksum": "sha1-g2RQKAvNjlRPxWjinIRveaq7IlY=",
+          "range": "bytes=695-1154"
         },
         "data": {
-          "checksum": "sha256-IFKNdojOhml3DbWPryQuHUiV3tgTWHyqOYD1JNe9IJ4=",
-          "range": "bytes=1170-2582015"
+          "checksum": "sha256-UsQFfOTXCZBan0mxDvR+ts0NKcbv1lNijxnRxjsmZhA=",
+          "range": "bytes=1155-2566233"
         },
         "name": "nghttp2",
         "signature": {
-          "checksum": "sha1-2/9n7KbRuOkrvhYqCFR5Mblx+z8=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-SUvMhz1cc5Or5Qh4fUEvPCp0NAw=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.62.1-r0.apk",
-        "version": "1.62.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.62.1-r1.apk",
+        "version": "1.62.1-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ialksjwPWvvZW+O2ABMbbBV/KTg=",
+        "checksum": "Q1sTMGOgdbZyDKxlRAByisPMHTbpY=",
         "control": {
-          "checksum": "sha1-ialksjwPWvvZW+O2ABMbbBV/KTg=",
-          "range": "bytes=702-1074"
+          "checksum": "sha1-sTMGOgdbZyDKxlRAByisPMHTbpY=",
+          "range": "bytes=703-1060"
         },
         "data": {
-          "checksum": "sha256-+ctDr3AO9mTXovGRPWk6h2ZgfY99Toy6esjBNHtJPY4=",
-          "range": "bytes=1075-631903"
+          "checksum": "sha256-bUy0h/zxpq7iP6vrQRMftZ9nevkHTB87hSX17wz4lmM=",
+          "range": "bytes=1061-631449"
         },
         "name": "nghttp2-dev",
         "signature": {
-          "checksum": "sha1-wZGQRluFd6DL1USzeak75o5/BTc=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-fQ6aDq3Io/gdJ5s5t3M+FwED1Y0=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.62.1-r0.apk",
-        "version": "1.62.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.62.1-r1.apk",
+        "version": "1.62.1-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1MlpRL1nBMU3RgNdSZVB42/vlGME=",
+        "checksum": "Q1rD3dEbbN8s5QAIQK1I8uF1O+oSo=",
         "control": {
-          "checksum": "sha1-MlpRL1nBMU3RgNdSZVB42/vlGME=",
-          "range": "bytes=697-1164"
+          "checksum": "sha1-rD3dEbbN8s5QAIQK1I8uF1O+oSo=",
+          "range": "bytes=701-1154"
         },
         "data": {
-          "checksum": "sha256-RiEPDasBVtnThSxGqTCDvb4J7WXM9YRpJwfYZJ3JLbs=",
-          "range": "bytes=1165-2274746"
+          "checksum": "sha256-41W2IRSRALQijYojLaqAiSSN1uO7twatGn8jqEuCZUg=",
+          "range": "bytes=1155-1439872"
         },
         "name": "xz",
         "signature": {
-          "checksum": "sha1-3wMPFIUEVfkAs7QSENemZsnTLyE=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-lozWkVrKvSrd1SoM7Zv08YYG2pA=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/xz-5.4.6-r2.apk",
-        "version": "5.4.6-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/xz-5.6.2-r0.apk",
+        "version": "5.6.2-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1TS707T+cPGL7TYVHQBCJoWwHZ0E=",
+        "checksum": "Q10AaU1ocIM4PYYNvwbml8TmpNvEA=",
         "control": {
-          "checksum": "sha1-TS707T+cPGL7TYVHQBCJoWwHZ0E=",
-          "range": "bytes=706-1098"
+          "checksum": "sha1-0AaU1ocIM4PYYNvwbml8TmpNvEA=",
+          "range": "bytes=706-1085"
         },
         "data": {
-          "checksum": "sha256-x18L706Vug5qDzq13SXuN/vGdVgzrqB06dW2DdgHGR4=",
-          "range": "bytes=1099-4541967"
+          "checksum": "sha256-1YQNYASFjlP3kXX58ec8du75ij/U6O4DPAKzJAPkln0=",
+          "range": "bytes=1086-4272589"
         },
         "name": "libxml2",
         "signature": {
-          "checksum": "sha1-BYhOxDos48sN8df8LMsSpROv2aw=",
+          "checksum": "sha1-QFjdplzGn/MiNFxMykgafr6/w6U=",
           "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.12.7-r0.apk",
-        "version": "2.12.7-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.1-r1.apk",
+        "version": "2.13.1-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1wJPtj5XZtnPiVWGM5dsT+nyfWXc=",
+        "checksum": "Q1wbnfumlWEiJnVUsJBRcQjFD3U6I=",
         "control": {
-          "checksum": "sha1-wJPtj5XZtnPiVWGM5dsT+nyfWXc=",
-          "range": "bytes=705-1234"
+          "checksum": "sha1-wbnfumlWEiJnVUsJBRcQjFD3U6I=",
+          "range": "bytes=699-1222"
         },
         "data": {
-          "checksum": "sha256-sw+CjlpsjO01q6lqzXgHnniiJKn7bqOSNO6vNqdGc7I=",
-          "range": "bytes=1235-3873775"
+          "checksum": "sha256-IXMNbJjj3kTjkWVBIHVRfG3zJQY2r5Eslgh/3TpMSsE=",
+          "range": "bytes=1223-3886778"
         },
         "name": "bind-libs",
         "signature": {
-          "checksum": "sha1-9zDzmHAeu7mWpidXAatqrLZVzUs=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-JNN15IPpJ2hMsO6hFVpDYPvvX5g=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bind-libs-9.18.26-r0.apk",
-        "version": "9.18.26-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/bind-libs-9.18.27-r1.apk",
+        "version": "9.18.27-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1AxEQdi8fVcYtGc3zHTCW3OZdY2Q=",
+        "checksum": "Q1kXUOoNa2KXixxAASo1W/im1qZ7s=",
         "control": {
-          "checksum": "sha1-AxEQdi8fVcYtGc3zHTCW3OZdY2Q=",
-          "range": "bytes=694-1208"
+          "checksum": "sha1-kXUOoNa2KXixxAASo1W/im1qZ7s=",
+          "range": "bytes=702-1215"
         },
         "data": {
-          "checksum": "sha256-/dt3qJw5D9iSJ/mKkRQkhWD8R52selhpcwXyw7KLMhg=",
-          "range": "bytes=1209-879444"
+          "checksum": "sha256-HRADvfRXfYsgEjUMGM4Hd7prpIv+YWILVfovbGOkEME=",
+          "range": "bytes=1216-879975"
         },
         "name": "bind-tools",
         "signature": {
-          "checksum": "sha1-VTb0YdUzPMk8Po0p4nj0y5Jey6k=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-8WUTMUaJTaX0T9FS/c+GddL7ttY=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bind-tools-9.18.26-r0.apk",
-        "version": "9.18.26-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/bind-tools-9.18.27-r1.apk",
+        "version": "9.18.27-r1"
       },
       {
         "architecture": "x86_64",
@@ -622,60 +622,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1fr0OtiVaD3c5nw8fy5m74hDe9PU=",
+        "checksum": "Q1BRGmQ9LZTeZqbxQ1ls69T6efViw=",
         "control": {
-          "checksum": "sha1-fr0OtiVaD3c5nw8fy5m74hDe9PU=",
-          "range": "bytes=697-1092"
+          "checksum": "sha1-BRGmQ9LZTeZqbxQ1ls69T6efViw=",
+          "range": "bytes=698-1080"
         },
         "data": {
-          "checksum": "sha256-lukjMYpGmuhBNDUbbTJMIrUWaR4rNikEnW4BgiTaLj8=",
-          "range": "bytes=1093-113872"
+          "checksum": "sha256-vtJ4WJ5M+31ZKSBYBedbrl/FrbAw8hGpPRrHC7kasOk=",
+          "range": "bytes=1081-113895"
         },
         "name": "libpsl",
         "signature": {
-          "checksum": "sha1-Lrrudgn1i1a0JhjdzeXG+exnjQA=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-DuAoiykwhu8vu1qxdEDK5oyAmf8=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libpsl-0.21.5-r2.apk",
-        "version": "0.21.5-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libpsl-0.21.5-r3.apk",
+        "version": "0.21.5-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1oauHQa0YcFcEHSQWdfohfNEN4sY=",
+        "checksum": "Q11DZVpe2UYyDr/dG6BDysZhE3L48=",
         "control": {
-          "checksum": "sha1-oauHQa0YcFcEHSQWdfohfNEN4sY=",
-          "range": "bytes=698-1057"
+          "checksum": "sha1-1DZVpe2UYyDr/dG6BDysZhE3L48=",
+          "range": "bytes=707-1049"
         },
         "data": {
-          "checksum": "sha256-d95c9lpjQrpuZ1CcQ8ZZ89LAGGKcessd+hxrOQpP4LU=",
-          "range": "bytes=1058-173549"
+          "checksum": "sha256-aECfsy7giZsLNxZM0HMeF4OS2gu+ycX4DUTJXsiZRQs=",
+          "range": "bytes=1050-173585"
         },
         "name": "libbrotlicommon1",
         "signature": {
-          "checksum": "sha1-g3ufBq/tyiNP6AaOoqwItVvh7uk=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-7LXD38QwFhklZCEqyW4qIncfZV0=",
+          "range": "bytes=0-706"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlicommon1-1.1.0-r2.apk",
-        "version": "1.1.0-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlicommon1-1.1.0-r3.apk",
+        "version": "1.1.0-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q18Otq7NLoYnNMebI/1Rr/s0zdLVw=",
+        "checksum": "Q1Cgr886A8Ryzynz9pxRKsNybVuK0=",
         "control": {
-          "checksum": "sha1-8Otq7NLoYnNMebI/1Rr/s0zdLVw=",
-          "range": "bytes=705-1072"
+          "checksum": "sha1-Cgr886A8Ryzynz9pxRKsNybVuK0=",
+          "range": "bytes=694-1043"
         },
         "data": {
-          "checksum": "sha256-sR3QidR/e46PJ/3S2fxAjN/hRSSA3Ar32Nw7VshTHWg=",
-          "range": "bytes=1073-81475"
+          "checksum": "sha256-mH+MTbqpLiqgydlgE+tSDEt0Sh1/zqMvAqspV4lr+Ks=",
+          "range": "bytes=1044-81511"
         },
         "name": "libbrotlidec1",
         "signature": {
-          "checksum": "sha1-6GpZI5cBUXOvjCYG81aZZR53lMI=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-Yp4Bde9oHQCec8HM2qn6hVKgtko=",
+          "range": "bytes=0-693"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlidec1-1.1.0-r2.apk",
-        "version": "1.1.0-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlidec1-1.1.0-r3.apk",
+        "version": "1.1.0-r3"
       },
       {
         "architecture": "x86_64",
@@ -755,22 +755,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q19f/3419Xa/xv9jgQ0mMYs011fBk=",
+        "checksum": "Q1mTmy64gKYi4THBqewuvYL2uUyHc=",
         "control": {
-          "checksum": "sha1-9f/3419Xa/xv9jgQ0mMYs011fBk=",
-          "range": "bytes=696-1041"
+          "checksum": "sha1-mTmy64gKYi4THBqewuvYL2uUyHc=",
+          "range": "bytes=700-1031"
         },
         "data": {
-          "checksum": "sha256-iqHASiMgiu6rIjbWGwBmmq1Zthae8BkE4QZkiVPH7Ek=",
-          "range": "bytes=1042-1888945"
+          "checksum": "sha256-p0qua2luH33oAgOcLkU9f7k+I8WnykFszVMwNahujDA=",
+          "range": "bytes=1032-1889523"
         },
         "name": "tzdata",
         "signature": {
-          "checksum": "sha1-PCC3jiXlTwrimRMXH/4RyNvccOM=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-sBf5jVLVpWj4DiXaAd/mjo0pTfk=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/tzdata-2024a-r2.apk",
-        "version": "2024a-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/tzdata-2024a-r3.apk",
+        "version": "2024a-r3"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/sourcegraph-dev.lock.json
+++ b/wolfi-images/sourcegraph-dev.lock.json
@@ -14,41 +14,41 @@
     "packages": [
       {
         "architecture": "x86_64",
-        "checksum": "Q1ge3SLQsJ9v2RnvIHHAP1yFyjrEU=",
+        "checksum": "Q1Ai8jWuxKZR2M2XhOpOGAoTEwnnk=",
         "control": {
-          "checksum": "sha1-ge3SLQsJ9v2RnvIHHAP1yFyjrEU=",
-          "range": "bytes=693-1040"
+          "checksum": "sha1-Ai8jWuxKZR2M2XhOpOGAoTEwnnk=",
+          "range": "bytes=705-1037"
         },
         "data": {
-          "checksum": "sha256-I0AdTdfGf4P/jwzTrLXm73l5/RNSlymEof/YZfev3xY=",
-          "range": "bytes=1041-255811"
+          "checksum": "sha256-e4UardkBVyaC49aSyrVmXNi8sSKqQl4eKYd0LxGRLA0=",
+          "range": "bytes=1038-255695"
         },
         "name": "ca-certificates-bundle",
         "signature": {
-          "checksum": "sha1-ge1eJBiQmFWAn9GapFkQpO+Rn/Y=",
-          "range": "bytes=0-692"
+          "checksum": "sha1-loRuyYQLm+atp+YteiQoj++EWIM=",
+          "range": "bytes=0-704"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20240315-r3.apk",
-        "version": "20240315-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20240315-r4.apk",
+        "version": "20240315-r4"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1bgay5kOzpmDBgqJCg7dSlawyJg0=",
+        "checksum": "Q1+GH6qRN4iy1IDt0cT0x0tin7YfI=",
         "control": {
-          "checksum": "sha1-bgay5kOzpmDBgqJCg7dSlawyJg0=",
-          "range": "bytes=703-1067"
+          "checksum": "sha1-+GH6qRN4iy1IDt0cT0x0tin7YfI=",
+          "range": "bytes=703-1051"
         },
         "data": {
-          "checksum": "sha256-f83HfRE7r2ZniH7PyPmRqcoU5NTpF+Uk4FH80QbjvBM=",
-          "range": "bytes=1068-118370"
+          "checksum": "sha256-rO0P9z2V49BSrz1A5Ap69tEappVrg5MMBjzW00rOpZc=",
+          "range": "bytes=1052-122464"
         },
         "name": "wolfi-baselayout",
         "signature": {
-          "checksum": "sha1-2hlCvYH1D7u25HkJGA75jjs/sQY=",
+          "checksum": "sha1-Ntb6VuMzDfM+frpCjKEIpDzl53I=",
           "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r11.apk",
-        "version": "20230201-r11"
+        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r12.apk",
+        "version": "20230201-r12"
       },
       {
         "architecture": "x86_64",
@@ -109,117 +109,98 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q14S6biy8fc5OGbGEJoLBM+tJOGyo=",
+        "checksum": "Q1CN6zJbOPznWUfTrb/41KT7E6dm8=",
         "control": {
-          "checksum": "sha1-4S6biy8fc5OGbGEJoLBM+tJOGyo=",
-          "range": "bytes=703-1102"
+          "checksum": "sha1-CN6zJbOPznWUfTrb/41KT7E6dm8=",
+          "range": "bytes=699-1083"
         },
         "data": {
-          "checksum": "sha256-hwjdLQYfuMAGQeONmFVo0lZKKQK1S+3PBhrI3upm5W4=",
-          "range": "bytes=1103-155304"
+          "checksum": "sha256-ybzFzoQh1yNTcd3cjt54nYsPlAxAcMUcVMxEv1JRnpQ=",
+          "range": "bytes=1084-155375"
         },
         "name": "zlib",
         "signature": {
-          "checksum": "sha1-ZuLd7kE+AGhn27o8ZqDGM5eundc=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-CPXJcCjinAXP+H8Z5tkko8ayG6E=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/zlib-1.3.1-r2.apk",
-        "version": "1.3.1-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/zlib-1.3.1-r3.apk",
+        "version": "1.3.1-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1gTZGkWP+QO3mUqLVJth8vrDEzzU=",
+        "checksum": "Q1Q/Zy5ovYSu2p/vVLr6DgVA1e8AQ=",
         "control": {
-          "checksum": "sha1-gTZGkWP+QO3mUqLVJth8vrDEzzU=",
-          "range": "bytes=699-1076"
+          "checksum": "sha1-Q/Zy5ovYSu2p/vVLr6DgVA1e8AQ=",
+          "range": "bytes=699-1062"
         },
         "data": {
-          "checksum": "sha256-/IFXqeKvU0GODNsz1yPIEMcFHgABT+8rbZpSlTLo4e4=",
-          "range": "bytes=1077-5915704"
+          "checksum": "sha256-H3jxsw8ytOeCIR4vq17voSVhdNokXk8C1g075txH6Bs=",
+          "range": "bytes=1063-5903754"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-l1o5ixkyWWqqJE3FOfR0QUemJUA=",
+          "checksum": "sha1-NIl2f5OI/wSZByI8Ds1ZUfbFWyw=",
           "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r9.apk",
-        "version": "3.3.0-r9"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.1-r3.apk",
+        "version": "3.3.1-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1jhAhggAuZnU7FFHnebGA26mq+jI=",
+        "checksum": "Q13wGUXdZut9OOTdY5z2amUj9wXC0=",
         "control": {
-          "checksum": "sha1-jhAhggAuZnU7FFHnebGA26mq+jI=",
-          "range": "bytes=695-1079"
+          "checksum": "sha1-3wGUXdZut9OOTdY5z2amUj9wXC0=",
+          "range": "bytes=698-1068"
         },
         "data": {
-          "checksum": "sha256-XTCQYnhGSm7SkGwqV/TQMFqGajVJVYhKAidKfLb2D3Y=",
-          "range": "bytes=1080-1197081"
+          "checksum": "sha256-mRda6+YGlOCczyIWKaHqXskTINoT1rgorHDHqAKAb7c=",
+          "range": "bytes=1069-1188955"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-qVrfDVxubkrb5Yrd2mFTv2A0G7k=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-+UdRc4U3PKw4H9OiNurHKXa5BYk=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r9.apk",
-        "version": "3.3.0-r9"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.1-r3.apk",
+        "version": "3.3.1-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1/ZtLqMp9dtWuV9olMeXUvOfI/FI=",
+        "checksum": "Q1d6KWlsyysrLbDnqZNOxD3yXQArs=",
         "control": {
-          "checksum": "sha1-/ZtLqMp9dtWuV9olMeXUvOfI/FI=",
-          "range": "bytes=704-1153"
+          "checksum": "sha1-d6KWlsyysrLbDnqZNOxD3yXQArs=",
+          "range": "bytes=700-1135"
         },
         "data": {
-          "checksum": "sha256-FGmENq5TGFJ2tuz1jnVDNdjZ0+LmcEtSVerH1GV25yg=",
-          "range": "bytes=1154-476294"
+          "checksum": "sha256-PxwHUjByuYsDLfP2+E4x8ywCE2Lkk9mzYgRm2w4ayNk=",
+          "range": "bytes=1136-483558"
         },
         "name": "apk-tools",
         "signature": {
-          "checksum": "sha1-DnGH3b7h/Oox1jTrbHz7l3H7Pj8=",
-          "range": "bytes=0-703"
+          "checksum": "sha1-Nl2iLupTvBTyTCbDrH5VNbBvqsY=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/apk-tools-2.14.1-r2.apk",
-        "version": "2.14.1-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/apk-tools-2.14.4-r0.apk",
+        "version": "2.14.4-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Zjfs1uR/mYiortANP+EFcejW+vo=",
+        "checksum": "Q1Zi0e8Bq6WCd/6uXXjVhb8YwMD1U=",
         "control": {
-          "checksum": "sha1-Zjfs1uR/mYiortANP+EFcejW+vo=",
-          "range": "bytes=698-1085"
+          "checksum": "sha1-Zi0e8Bq6WCd/6uXXjVhb8YwMD1U=",
+          "range": "bytes=700-1073"
         },
         "data": {
-          "checksum": "sha256-BMd7TzffjbrFwdbopDPVYsX0X9XnusIMNbIf33/8kwc=",
-          "range": "bytes=1086-76881"
+          "checksum": "sha256-jMhtfqVjnhuuBO7wtNZ6RS/72sZWoKt/Moage2amlks=",
+          "range": "bytes=1074-81594"
         },
         "name": "protobuf-c",
         "signature": {
-          "checksum": "sha1-efGiXyYWsJ5P2uTkB6aXEZ3kl3o=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-kATwMKztK7nk7qbYCJPkCFp6IXc=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r4.apk",
-        "version": "1.5.0-r4"
-      },
-      {
-        "architecture": "x86_64",
-        "checksum": "Q1Xf5v5uXumBgIR4d4ZxMRxdpyWlM=",
-        "control": {
-          "checksum": "sha1-Xf5v5uXumBgIR4d4ZxMRxdpyWlM=",
-          "range": "bytes=698-1078"
-        },
-        "data": {
-          "checksum": "sha256-eD7HqFCWNUBQiLq9PcWE/zPeZwkiv8hBrytI4qmfQ/8=",
-          "range": "bytes=1079-57055"
-        },
-        "name": "keyutils-libs",
-        "signature": {
-          "checksum": "sha1-V0HVgZLP7P5kNACfus3abCLCS20=",
-          "range": "bytes=0-697"
-        },
-        "url": "https://packages.wolfi.dev/os/x86_64/keyutils-libs-1.6.3-r2.apk",
-        "version": "1.6.3-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r5.apk",
+        "version": "1.5.0-r5"
       },
       {
         "architecture": "x86_64",
@@ -242,22 +223,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1wRzOx+L6MeRFtTcq2y/6ot7Cj54=",
+        "checksum": "Q1v0A2vQM5k8rQY/GpIq6xI4T0YmA=",
         "control": {
-          "checksum": "sha1-wRzOx+L6MeRFtTcq2y/6ot7Cj54=",
-          "range": "bytes=699-1069"
+          "checksum": "sha1-v0A2vQM5k8rQY/GpIq6xI4T0YmA=",
+          "range": "bytes=701-1064"
         },
         "data": {
-          "checksum": "sha256-gNRjwZ4XQatCYWediSVb+j8lS54CggvMC5Dn3qT84So=",
-          "range": "bytes=1070-61490"
+          "checksum": "sha256-uAOrkGDDc/yqt6VjIrlTEALBJG4BCI4njqZw5jQqF0o=",
+          "range": "bytes=1065-56984"
+        },
+        "name": "keyutils-libs",
+        "signature": {
+          "checksum": "sha1-32uYMH/zGBr9Jo3hiqnThlcqBcE=",
+          "range": "bytes=0-700"
+        },
+        "url": "https://packages.wolfi.dev/os/x86_64/keyutils-libs-1.6.3-r3.apk",
+        "version": "1.6.3-r3"
+      },
+      {
+        "architecture": "x86_64",
+        "checksum": "Q1Onuac6Y+IWA7a4b8FvqX1erWDDw=",
+        "control": {
+          "checksum": "sha1-Onuac6Y+IWA7a4b8FvqX1erWDDw=",
+          "range": "bytes=693-1048"
+        },
+        "data": {
+          "checksum": "sha256-KLtDAs3iU0oyZ/FysePG/J+1H1ofDxHXIY7xvtZhtMc=",
+          "range": "bytes=1049-61503"
         },
         "name": "libverto",
         "signature": {
-          "checksum": "sha1-kuPwakYdy5EM6sd5Ba0K0Ta8x4w=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-/IXL9S1O+MwaW7KsSzz1ywEqKFQ=",
+          "range": "bytes=0-692"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libverto-0.3.2-r3.apk",
-        "version": "0.3.2-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/libverto-0.3.2-r4.apk",
+        "version": "0.3.2-r4"
       },
       {
         "architecture": "x86_64",
@@ -280,22 +280,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1BQEXaeya6QB39QLeKcB99qBNF2o=",
+        "checksum": "Q1p04MrHQPrXOzuV/uF290zjnltqI=",
         "control": {
-          "checksum": "sha1-BQEXaeya6QB39QLeKcB99qBNF2o=",
-          "range": "bytes=699-1229"
+          "checksum": "sha1-p04MrHQPrXOzuV/uF290zjnltqI=",
+          "range": "bytes=704-1219"
         },
         "data": {
-          "checksum": "sha256-ugj/qGEBzhvdX17S22Anry+biy3lcqywhGMSHLIBCvo=",
-          "range": "bytes=1230-2551676"
+          "checksum": "sha256-TsXeqhUGykAhjQUEAlMUSzDQBcWDkkDvReoeHCL1F6c=",
+          "range": "bytes=1220-2555814"
         },
         "name": "krb5-libs",
         "signature": {
-          "checksum": "sha1-oqDPmNM4EngXAGayd/BZOqJAIao=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-cPyzS38QHuNlOCQb8IPlsl2PLHQ=",
+          "range": "bytes=0-703"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/krb5-libs-1.21.2-r2.apk",
-        "version": "1.21.2-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/krb5-libs-1.21.3-r0.apk",
+        "version": "1.21.3-r0"
       },
       {
         "architecture": "x86_64",
@@ -318,41 +318,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1wzZwtLauOQfLQC7YUvZdfKxtlwQ=",
+        "checksum": "Q17uprcuQ2VFudMcWAwtP7miJmLYs=",
         "control": {
-          "checksum": "sha1-wzZwtLauOQfLQC7YUvZdfKxtlwQ=",
-          "range": "bytes=698-1085"
+          "checksum": "sha1-7uprcuQ2VFudMcWAwtP7miJmLYs=",
+          "range": "bytes=695-1067"
         },
         "data": {
-          "checksum": "sha256-TO8CAULO44s/LphhtcaFOGJB7aFldk13v1cV9ceZHww=",
-          "range": "bytes=1086-276837"
+          "checksum": "sha256-unKdPbvO2VHZ5w1t1l8mOpQuNdUGwLhofEO4weN2Mig=",
+          "range": "bytes=1068-280973"
         },
         "name": "libuv",
         "signature": {
-          "checksum": "sha1-LRiyeKmjexy8CJizLxjd6ikon1w=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-4lKldnTO71WHMZ4tbANz6i2/Ed0=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libuv-1.48.0-r2.apk",
-        "version": "1.48.0-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libuv-1.48.0-r3.apk",
+        "version": "1.48.0-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ykDkP+AmDi2VcZZ1c4q4sez/DxI=",
+        "checksum": "Q1rgbci8SRSjW7EB0NSh6ZUPJLndM=",
         "control": {
-          "checksum": "sha1-ykDkP+AmDi2VcZZ1c4q4sez/DxI=",
-          "range": "bytes=705-1079"
+          "checksum": "sha1-rgbci8SRSjW7EB0NSh6ZUPJLndM=",
+          "range": "bytes=702-1060"
         },
         "data": {
-          "checksum": "sha256-t3BrH7lWfY3to3Fu3EKAMZx29v9Hnl5seyXJzLmZ9/4=",
-          "range": "bytes=1080-251884"
+          "checksum": "sha256-tf4xbo+NP+ssiaZtC1kOKehffAZ3+d17bhgfU3/30+g=",
+          "range": "bytes=1061-256582"
         },
         "name": "libnghttp2-14",
         "signature": {
-          "checksum": "sha1-CotSXRaPLKQCBRHrgzrDOD+4w20=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-KrsJYTyUsll+EUhHekbkdZFzeig=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.62.1-r0.apk",
-        "version": "1.62.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.62.1-r1.apk",
+        "version": "1.62.1-r1"
       },
       {
         "architecture": "x86_64",
@@ -413,136 +413,136 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1DE49kWSnmqVKJdjHFYC1bLkvyb0=",
+        "checksum": "Q1R8OxpY0fGwVaIwft4wJeswF5D54=",
         "control": {
-          "checksum": "sha1-DE49kWSnmqVKJdjHFYC1bLkvyb0=",
-          "range": "bytes=697-1078"
+          "checksum": "sha1-R8OxpY0fGwVaIwft4wJeswF5D54=",
+          "range": "bytes=695-1059"
         },
         "data": {
-          "checksum": "sha256-uDg8Qc6Rnro/68Vb5ufFSkqFLGrEsbvPb0pMJNvT1zw=",
-          "range": "bytes=1079-242085"
+          "checksum": "sha256-wNc8/SBJrGHfwywAtzCsAqeUOt0IaAhqNtlbv8OiHBE=",
+          "range": "bytes=1060-242151"
         },
         "name": "c-ares",
         "signature": {
-          "checksum": "sha1-iYEm6EWQKzxkeoDm+QsRfhw8pDg=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-55/PTlEHXI3o0hx9dSVdNwQeSMg=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.29.0-r0.apk",
-        "version": "1.29.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.31.0-r0.apk",
+        "version": "1.31.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q12eWmn2tCkXxwncU6gagKM3Wd9Sk=",
+        "checksum": "Q1g2RQKAvNjlRPxWjinIRveaq7IlY=",
         "control": {
-          "checksum": "sha1-2eWmn2tCkXxwncU6gagKM3Wd9Sk=",
-          "range": "bytes=696-1169"
+          "checksum": "sha1-g2RQKAvNjlRPxWjinIRveaq7IlY=",
+          "range": "bytes=695-1154"
         },
         "data": {
-          "checksum": "sha256-IFKNdojOhml3DbWPryQuHUiV3tgTWHyqOYD1JNe9IJ4=",
-          "range": "bytes=1170-2582015"
+          "checksum": "sha256-UsQFfOTXCZBan0mxDvR+ts0NKcbv1lNijxnRxjsmZhA=",
+          "range": "bytes=1155-2566233"
         },
         "name": "nghttp2",
         "signature": {
-          "checksum": "sha1-2/9n7KbRuOkrvhYqCFR5Mblx+z8=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-SUvMhz1cc5Or5Qh4fUEvPCp0NAw=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.62.1-r0.apk",
-        "version": "1.62.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.62.1-r1.apk",
+        "version": "1.62.1-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ialksjwPWvvZW+O2ABMbbBV/KTg=",
+        "checksum": "Q1sTMGOgdbZyDKxlRAByisPMHTbpY=",
         "control": {
-          "checksum": "sha1-ialksjwPWvvZW+O2ABMbbBV/KTg=",
-          "range": "bytes=702-1074"
+          "checksum": "sha1-sTMGOgdbZyDKxlRAByisPMHTbpY=",
+          "range": "bytes=703-1060"
         },
         "data": {
-          "checksum": "sha256-+ctDr3AO9mTXovGRPWk6h2ZgfY99Toy6esjBNHtJPY4=",
-          "range": "bytes=1075-631903"
+          "checksum": "sha256-bUy0h/zxpq7iP6vrQRMftZ9nevkHTB87hSX17wz4lmM=",
+          "range": "bytes=1061-631449"
         },
         "name": "nghttp2-dev",
         "signature": {
-          "checksum": "sha1-wZGQRluFd6DL1USzeak75o5/BTc=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-fQ6aDq3Io/gdJ5s5t3M+FwED1Y0=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.62.1-r0.apk",
-        "version": "1.62.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.62.1-r1.apk",
+        "version": "1.62.1-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1MlpRL1nBMU3RgNdSZVB42/vlGME=",
+        "checksum": "Q1rD3dEbbN8s5QAIQK1I8uF1O+oSo=",
         "control": {
-          "checksum": "sha1-MlpRL1nBMU3RgNdSZVB42/vlGME=",
-          "range": "bytes=697-1164"
+          "checksum": "sha1-rD3dEbbN8s5QAIQK1I8uF1O+oSo=",
+          "range": "bytes=701-1154"
         },
         "data": {
-          "checksum": "sha256-RiEPDasBVtnThSxGqTCDvb4J7WXM9YRpJwfYZJ3JLbs=",
-          "range": "bytes=1165-2274746"
+          "checksum": "sha256-41W2IRSRALQijYojLaqAiSSN1uO7twatGn8jqEuCZUg=",
+          "range": "bytes=1155-1439872"
         },
         "name": "xz",
         "signature": {
-          "checksum": "sha1-3wMPFIUEVfkAs7QSENemZsnTLyE=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-lozWkVrKvSrd1SoM7Zv08YYG2pA=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/xz-5.4.6-r2.apk",
-        "version": "5.4.6-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/xz-5.6.2-r0.apk",
+        "version": "5.6.2-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1TS707T+cPGL7TYVHQBCJoWwHZ0E=",
+        "checksum": "Q10AaU1ocIM4PYYNvwbml8TmpNvEA=",
         "control": {
-          "checksum": "sha1-TS707T+cPGL7TYVHQBCJoWwHZ0E=",
-          "range": "bytes=706-1098"
+          "checksum": "sha1-0AaU1ocIM4PYYNvwbml8TmpNvEA=",
+          "range": "bytes=706-1085"
         },
         "data": {
-          "checksum": "sha256-x18L706Vug5qDzq13SXuN/vGdVgzrqB06dW2DdgHGR4=",
-          "range": "bytes=1099-4541967"
+          "checksum": "sha256-1YQNYASFjlP3kXX58ec8du75ij/U6O4DPAKzJAPkln0=",
+          "range": "bytes=1086-4272589"
         },
         "name": "libxml2",
         "signature": {
-          "checksum": "sha1-BYhOxDos48sN8df8LMsSpROv2aw=",
+          "checksum": "sha1-QFjdplzGn/MiNFxMykgafr6/w6U=",
           "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.12.7-r0.apk",
-        "version": "2.12.7-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.1-r1.apk",
+        "version": "2.13.1-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1wJPtj5XZtnPiVWGM5dsT+nyfWXc=",
+        "checksum": "Q1wbnfumlWEiJnVUsJBRcQjFD3U6I=",
         "control": {
-          "checksum": "sha1-wJPtj5XZtnPiVWGM5dsT+nyfWXc=",
-          "range": "bytes=705-1234"
+          "checksum": "sha1-wbnfumlWEiJnVUsJBRcQjFD3U6I=",
+          "range": "bytes=699-1222"
         },
         "data": {
-          "checksum": "sha256-sw+CjlpsjO01q6lqzXgHnniiJKn7bqOSNO6vNqdGc7I=",
-          "range": "bytes=1235-3873775"
+          "checksum": "sha256-IXMNbJjj3kTjkWVBIHVRfG3zJQY2r5Eslgh/3TpMSsE=",
+          "range": "bytes=1223-3886778"
         },
         "name": "bind-libs",
         "signature": {
-          "checksum": "sha1-9zDzmHAeu7mWpidXAatqrLZVzUs=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-JNN15IPpJ2hMsO6hFVpDYPvvX5g=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bind-libs-9.18.26-r0.apk",
-        "version": "9.18.26-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/bind-libs-9.18.27-r1.apk",
+        "version": "9.18.27-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1AxEQdi8fVcYtGc3zHTCW3OZdY2Q=",
+        "checksum": "Q1kXUOoNa2KXixxAASo1W/im1qZ7s=",
         "control": {
-          "checksum": "sha1-AxEQdi8fVcYtGc3zHTCW3OZdY2Q=",
-          "range": "bytes=694-1208"
+          "checksum": "sha1-kXUOoNa2KXixxAASo1W/im1qZ7s=",
+          "range": "bytes=702-1215"
         },
         "data": {
-          "checksum": "sha256-/dt3qJw5D9iSJ/mKkRQkhWD8R52selhpcwXyw7KLMhg=",
-          "range": "bytes=1209-879444"
+          "checksum": "sha256-HRADvfRXfYsgEjUMGM4Hd7prpIv+YWILVfovbGOkEME=",
+          "range": "bytes=1216-879975"
         },
         "name": "bind-tools",
         "signature": {
-          "checksum": "sha1-VTb0YdUzPMk8Po0p4nj0y5Jey6k=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-8WUTMUaJTaX0T9FS/c+GddL7ttY=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bind-tools-9.18.26-r0.apk",
-        "version": "9.18.26-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/bind-tools-9.18.27-r1.apk",
+        "version": "9.18.27-r1"
       },
       {
         "architecture": "x86_64",
@@ -641,60 +641,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1fr0OtiVaD3c5nw8fy5m74hDe9PU=",
+        "checksum": "Q1BRGmQ9LZTeZqbxQ1ls69T6efViw=",
         "control": {
-          "checksum": "sha1-fr0OtiVaD3c5nw8fy5m74hDe9PU=",
-          "range": "bytes=697-1092"
+          "checksum": "sha1-BRGmQ9LZTeZqbxQ1ls69T6efViw=",
+          "range": "bytes=698-1080"
         },
         "data": {
-          "checksum": "sha256-lukjMYpGmuhBNDUbbTJMIrUWaR4rNikEnW4BgiTaLj8=",
-          "range": "bytes=1093-113872"
+          "checksum": "sha256-vtJ4WJ5M+31ZKSBYBedbrl/FrbAw8hGpPRrHC7kasOk=",
+          "range": "bytes=1081-113895"
         },
         "name": "libpsl",
         "signature": {
-          "checksum": "sha1-Lrrudgn1i1a0JhjdzeXG+exnjQA=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-DuAoiykwhu8vu1qxdEDK5oyAmf8=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libpsl-0.21.5-r2.apk",
-        "version": "0.21.5-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libpsl-0.21.5-r3.apk",
+        "version": "0.21.5-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1oauHQa0YcFcEHSQWdfohfNEN4sY=",
+        "checksum": "Q11DZVpe2UYyDr/dG6BDysZhE3L48=",
         "control": {
-          "checksum": "sha1-oauHQa0YcFcEHSQWdfohfNEN4sY=",
-          "range": "bytes=698-1057"
+          "checksum": "sha1-1DZVpe2UYyDr/dG6BDysZhE3L48=",
+          "range": "bytes=707-1049"
         },
         "data": {
-          "checksum": "sha256-d95c9lpjQrpuZ1CcQ8ZZ89LAGGKcessd+hxrOQpP4LU=",
-          "range": "bytes=1058-173549"
+          "checksum": "sha256-aECfsy7giZsLNxZM0HMeF4OS2gu+ycX4DUTJXsiZRQs=",
+          "range": "bytes=1050-173585"
         },
         "name": "libbrotlicommon1",
         "signature": {
-          "checksum": "sha1-g3ufBq/tyiNP6AaOoqwItVvh7uk=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-7LXD38QwFhklZCEqyW4qIncfZV0=",
+          "range": "bytes=0-706"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlicommon1-1.1.0-r2.apk",
-        "version": "1.1.0-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlicommon1-1.1.0-r3.apk",
+        "version": "1.1.0-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q18Otq7NLoYnNMebI/1Rr/s0zdLVw=",
+        "checksum": "Q1Cgr886A8Ryzynz9pxRKsNybVuK0=",
         "control": {
-          "checksum": "sha1-8Otq7NLoYnNMebI/1Rr/s0zdLVw=",
-          "range": "bytes=705-1072"
+          "checksum": "sha1-Cgr886A8Ryzynz9pxRKsNybVuK0=",
+          "range": "bytes=694-1043"
         },
         "data": {
-          "checksum": "sha256-sR3QidR/e46PJ/3S2fxAjN/hRSSA3Ar32Nw7VshTHWg=",
-          "range": "bytes=1073-81475"
+          "checksum": "sha256-mH+MTbqpLiqgydlgE+tSDEt0Sh1/zqMvAqspV4lr+Ks=",
+          "range": "bytes=1044-81511"
         },
         "name": "libbrotlidec1",
         "signature": {
-          "checksum": "sha1-6GpZI5cBUXOvjCYG81aZZR53lMI=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-Yp4Bde9oHQCec8HM2qn6hVKgtko=",
+          "range": "bytes=0-693"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlidec1-1.1.0-r2.apk",
-        "version": "1.1.0-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlidec1-1.1.0-r3.apk",
+        "version": "1.1.0-r3"
       },
       {
         "architecture": "x86_64",
@@ -774,22 +774,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q19f/3419Xa/xv9jgQ0mMYs011fBk=",
+        "checksum": "Q1mTmy64gKYi4THBqewuvYL2uUyHc=",
         "control": {
-          "checksum": "sha1-9f/3419Xa/xv9jgQ0mMYs011fBk=",
-          "range": "bytes=696-1041"
+          "checksum": "sha1-mTmy64gKYi4THBqewuvYL2uUyHc=",
+          "range": "bytes=700-1031"
         },
         "data": {
-          "checksum": "sha256-iqHASiMgiu6rIjbWGwBmmq1Zthae8BkE4QZkiVPH7Ek=",
-          "range": "bytes=1042-1888945"
+          "checksum": "sha256-p0qua2luH33oAgOcLkU9f7k+I8WnykFszVMwNahujDA=",
+          "range": "bytes=1032-1889523"
         },
         "name": "tzdata",
         "signature": {
-          "checksum": "sha1-PCC3jiXlTwrimRMXH/4RyNvccOM=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-sBf5jVLVpWj4DiXaAd/mjo0pTfk=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/tzdata-2024a-r2.apk",
-        "version": "2024a-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/tzdata-2024a-r3.apk",
+        "version": "2024a-r3"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/sourcegraph-template.lock.json
+++ b/wolfi-images/sourcegraph-template.lock.json
@@ -14,41 +14,41 @@
     "packages": [
       {
         "architecture": "x86_64",
-        "checksum": "Q1ge3SLQsJ9v2RnvIHHAP1yFyjrEU=",
+        "checksum": "Q1Ai8jWuxKZR2M2XhOpOGAoTEwnnk=",
         "control": {
-          "checksum": "sha1-ge3SLQsJ9v2RnvIHHAP1yFyjrEU=",
-          "range": "bytes=693-1040"
+          "checksum": "sha1-Ai8jWuxKZR2M2XhOpOGAoTEwnnk=",
+          "range": "bytes=705-1037"
         },
         "data": {
-          "checksum": "sha256-I0AdTdfGf4P/jwzTrLXm73l5/RNSlymEof/YZfev3xY=",
-          "range": "bytes=1041-255811"
+          "checksum": "sha256-e4UardkBVyaC49aSyrVmXNi8sSKqQl4eKYd0LxGRLA0=",
+          "range": "bytes=1038-255695"
         },
         "name": "ca-certificates-bundle",
         "signature": {
-          "checksum": "sha1-ge1eJBiQmFWAn9GapFkQpO+Rn/Y=",
-          "range": "bytes=0-692"
+          "checksum": "sha1-loRuyYQLm+atp+YteiQoj++EWIM=",
+          "range": "bytes=0-704"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20240315-r3.apk",
-        "version": "20240315-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20240315-r4.apk",
+        "version": "20240315-r4"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1bgay5kOzpmDBgqJCg7dSlawyJg0=",
+        "checksum": "Q1+GH6qRN4iy1IDt0cT0x0tin7YfI=",
         "control": {
-          "checksum": "sha1-bgay5kOzpmDBgqJCg7dSlawyJg0=",
-          "range": "bytes=703-1067"
+          "checksum": "sha1-+GH6qRN4iy1IDt0cT0x0tin7YfI=",
+          "range": "bytes=703-1051"
         },
         "data": {
-          "checksum": "sha256-f83HfRE7r2ZniH7PyPmRqcoU5NTpF+Uk4FH80QbjvBM=",
-          "range": "bytes=1068-118370"
+          "checksum": "sha256-rO0P9z2V49BSrz1A5Ap69tEappVrg5MMBjzW00rOpZc=",
+          "range": "bytes=1052-122464"
         },
         "name": "wolfi-baselayout",
         "signature": {
-          "checksum": "sha1-2hlCvYH1D7u25HkJGA75jjs/sQY=",
+          "checksum": "sha1-Ntb6VuMzDfM+frpCjKEIpDzl53I=",
           "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r11.apk",
-        "version": "20230201-r11"
+        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r12.apk",
+        "version": "20230201-r12"
       },
       {
         "architecture": "x86_64",
@@ -109,41 +109,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Zjfs1uR/mYiortANP+EFcejW+vo=",
+        "checksum": "Q1Zi0e8Bq6WCd/6uXXjVhb8YwMD1U=",
         "control": {
-          "checksum": "sha1-Zjfs1uR/mYiortANP+EFcejW+vo=",
-          "range": "bytes=698-1085"
+          "checksum": "sha1-Zi0e8Bq6WCd/6uXXjVhb8YwMD1U=",
+          "range": "bytes=700-1073"
         },
         "data": {
-          "checksum": "sha256-BMd7TzffjbrFwdbopDPVYsX0X9XnusIMNbIf33/8kwc=",
-          "range": "bytes=1086-76881"
+          "checksum": "sha256-jMhtfqVjnhuuBO7wtNZ6RS/72sZWoKt/Moage2amlks=",
+          "range": "bytes=1074-81594"
         },
         "name": "protobuf-c",
         "signature": {
-          "checksum": "sha1-efGiXyYWsJ5P2uTkB6aXEZ3kl3o=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-kATwMKztK7nk7qbYCJPkCFp6IXc=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r4.apk",
-        "version": "1.5.0-r4"
-      },
-      {
-        "architecture": "x86_64",
-        "checksum": "Q1Xf5v5uXumBgIR4d4ZxMRxdpyWlM=",
-        "control": {
-          "checksum": "sha1-Xf5v5uXumBgIR4d4ZxMRxdpyWlM=",
-          "range": "bytes=698-1078"
-        },
-        "data": {
-          "checksum": "sha256-eD7HqFCWNUBQiLq9PcWE/zPeZwkiv8hBrytI4qmfQ/8=",
-          "range": "bytes=1079-57055"
-        },
-        "name": "keyutils-libs",
-        "signature": {
-          "checksum": "sha1-V0HVgZLP7P5kNACfus3abCLCS20=",
-          "range": "bytes=0-697"
-        },
-        "url": "https://packages.wolfi.dev/os/x86_64/keyutils-libs-1.6.3-r2.apk",
-        "version": "1.6.3-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r5.apk",
+        "version": "1.5.0-r5"
       },
       {
         "architecture": "x86_64",
@@ -166,22 +147,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1wRzOx+L6MeRFtTcq2y/6ot7Cj54=",
+        "checksum": "Q1v0A2vQM5k8rQY/GpIq6xI4T0YmA=",
         "control": {
-          "checksum": "sha1-wRzOx+L6MeRFtTcq2y/6ot7Cj54=",
-          "range": "bytes=699-1069"
+          "checksum": "sha1-v0A2vQM5k8rQY/GpIq6xI4T0YmA=",
+          "range": "bytes=701-1064"
         },
         "data": {
-          "checksum": "sha256-gNRjwZ4XQatCYWediSVb+j8lS54CggvMC5Dn3qT84So=",
-          "range": "bytes=1070-61490"
+          "checksum": "sha256-uAOrkGDDc/yqt6VjIrlTEALBJG4BCI4njqZw5jQqF0o=",
+          "range": "bytes=1065-56984"
+        },
+        "name": "keyutils-libs",
+        "signature": {
+          "checksum": "sha1-32uYMH/zGBr9Jo3hiqnThlcqBcE=",
+          "range": "bytes=0-700"
+        },
+        "url": "https://packages.wolfi.dev/os/x86_64/keyutils-libs-1.6.3-r3.apk",
+        "version": "1.6.3-r3"
+      },
+      {
+        "architecture": "x86_64",
+        "checksum": "Q1Onuac6Y+IWA7a4b8FvqX1erWDDw=",
+        "control": {
+          "checksum": "sha1-Onuac6Y+IWA7a4b8FvqX1erWDDw=",
+          "range": "bytes=693-1048"
+        },
+        "data": {
+          "checksum": "sha256-KLtDAs3iU0oyZ/FysePG/J+1H1ofDxHXIY7xvtZhtMc=",
+          "range": "bytes=1049-61503"
         },
         "name": "libverto",
         "signature": {
-          "checksum": "sha1-kuPwakYdy5EM6sd5Ba0K0Ta8x4w=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-/IXL9S1O+MwaW7KsSzz1ywEqKFQ=",
+          "range": "bytes=0-692"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libverto-0.3.2-r3.apk",
-        "version": "0.3.2-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/libverto-0.3.2-r4.apk",
+        "version": "0.3.2-r4"
       },
       {
         "architecture": "x86_64",
@@ -204,60 +204,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1gTZGkWP+QO3mUqLVJth8vrDEzzU=",
+        "checksum": "Q1Q/Zy5ovYSu2p/vVLr6DgVA1e8AQ=",
         "control": {
-          "checksum": "sha1-gTZGkWP+QO3mUqLVJth8vrDEzzU=",
-          "range": "bytes=699-1076"
+          "checksum": "sha1-Q/Zy5ovYSu2p/vVLr6DgVA1e8AQ=",
+          "range": "bytes=699-1062"
         },
         "data": {
-          "checksum": "sha256-/IFXqeKvU0GODNsz1yPIEMcFHgABT+8rbZpSlTLo4e4=",
-          "range": "bytes=1077-5915704"
+          "checksum": "sha256-H3jxsw8ytOeCIR4vq17voSVhdNokXk8C1g075txH6Bs=",
+          "range": "bytes=1063-5903754"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-l1o5ixkyWWqqJE3FOfR0QUemJUA=",
+          "checksum": "sha1-NIl2f5OI/wSZByI8Ds1ZUfbFWyw=",
           "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r9.apk",
-        "version": "3.3.0-r9"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.1-r3.apk",
+        "version": "3.3.1-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1jhAhggAuZnU7FFHnebGA26mq+jI=",
+        "checksum": "Q13wGUXdZut9OOTdY5z2amUj9wXC0=",
         "control": {
-          "checksum": "sha1-jhAhggAuZnU7FFHnebGA26mq+jI=",
-          "range": "bytes=695-1079"
+          "checksum": "sha1-3wGUXdZut9OOTdY5z2amUj9wXC0=",
+          "range": "bytes=698-1068"
         },
         "data": {
-          "checksum": "sha256-XTCQYnhGSm7SkGwqV/TQMFqGajVJVYhKAidKfLb2D3Y=",
-          "range": "bytes=1080-1197081"
+          "checksum": "sha256-mRda6+YGlOCczyIWKaHqXskTINoT1rgorHDHqAKAb7c=",
+          "range": "bytes=1069-1188955"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-qVrfDVxubkrb5Yrd2mFTv2A0G7k=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-+UdRc4U3PKw4H9OiNurHKXa5BYk=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r9.apk",
-        "version": "3.3.0-r9"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.1-r3.apk",
+        "version": "3.3.1-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1BQEXaeya6QB39QLeKcB99qBNF2o=",
+        "checksum": "Q1p04MrHQPrXOzuV/uF290zjnltqI=",
         "control": {
-          "checksum": "sha1-BQEXaeya6QB39QLeKcB99qBNF2o=",
-          "range": "bytes=699-1229"
+          "checksum": "sha1-p04MrHQPrXOzuV/uF290zjnltqI=",
+          "range": "bytes=704-1219"
         },
         "data": {
-          "checksum": "sha256-ugj/qGEBzhvdX17S22Anry+biy3lcqywhGMSHLIBCvo=",
-          "range": "bytes=1230-2551676"
+          "checksum": "sha256-TsXeqhUGykAhjQUEAlMUSzDQBcWDkkDvReoeHCL1F6c=",
+          "range": "bytes=1220-2555814"
         },
         "name": "krb5-libs",
         "signature": {
-          "checksum": "sha1-oqDPmNM4EngXAGayd/BZOqJAIao=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-cPyzS38QHuNlOCQb8IPlsl2PLHQ=",
+          "range": "bytes=0-703"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/krb5-libs-1.21.2-r2.apk",
-        "version": "1.21.2-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/krb5-libs-1.21.3-r0.apk",
+        "version": "1.21.3-r0"
       },
       {
         "architecture": "x86_64",
@@ -280,60 +280,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1wzZwtLauOQfLQC7YUvZdfKxtlwQ=",
+        "checksum": "Q17uprcuQ2VFudMcWAwtP7miJmLYs=",
         "control": {
-          "checksum": "sha1-wzZwtLauOQfLQC7YUvZdfKxtlwQ=",
-          "range": "bytes=698-1085"
+          "checksum": "sha1-7uprcuQ2VFudMcWAwtP7miJmLYs=",
+          "range": "bytes=695-1067"
         },
         "data": {
-          "checksum": "sha256-TO8CAULO44s/LphhtcaFOGJB7aFldk13v1cV9ceZHww=",
-          "range": "bytes=1086-276837"
+          "checksum": "sha256-unKdPbvO2VHZ5w1t1l8mOpQuNdUGwLhofEO4weN2Mig=",
+          "range": "bytes=1068-280973"
         },
         "name": "libuv",
         "signature": {
-          "checksum": "sha1-LRiyeKmjexy8CJizLxjd6ikon1w=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-4lKldnTO71WHMZ4tbANz6i2/Ed0=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libuv-1.48.0-r2.apk",
-        "version": "1.48.0-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libuv-1.48.0-r3.apk",
+        "version": "1.48.0-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q14S6biy8fc5OGbGEJoLBM+tJOGyo=",
+        "checksum": "Q1CN6zJbOPznWUfTrb/41KT7E6dm8=",
         "control": {
-          "checksum": "sha1-4S6biy8fc5OGbGEJoLBM+tJOGyo=",
-          "range": "bytes=703-1102"
+          "checksum": "sha1-CN6zJbOPznWUfTrb/41KT7E6dm8=",
+          "range": "bytes=699-1083"
         },
         "data": {
-          "checksum": "sha256-hwjdLQYfuMAGQeONmFVo0lZKKQK1S+3PBhrI3upm5W4=",
-          "range": "bytes=1103-155304"
+          "checksum": "sha256-ybzFzoQh1yNTcd3cjt54nYsPlAxAcMUcVMxEv1JRnpQ=",
+          "range": "bytes=1084-155375"
         },
         "name": "zlib",
         "signature": {
-          "checksum": "sha1-ZuLd7kE+AGhn27o8ZqDGM5eundc=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-CPXJcCjinAXP+H8Z5tkko8ayG6E=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/zlib-1.3.1-r2.apk",
-        "version": "1.3.1-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/zlib-1.3.1-r3.apk",
+        "version": "1.3.1-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ykDkP+AmDi2VcZZ1c4q4sez/DxI=",
+        "checksum": "Q1rgbci8SRSjW7EB0NSh6ZUPJLndM=",
         "control": {
-          "checksum": "sha1-ykDkP+AmDi2VcZZ1c4q4sez/DxI=",
-          "range": "bytes=705-1079"
+          "checksum": "sha1-rgbci8SRSjW7EB0NSh6ZUPJLndM=",
+          "range": "bytes=702-1060"
         },
         "data": {
-          "checksum": "sha256-t3BrH7lWfY3to3Fu3EKAMZx29v9Hnl5seyXJzLmZ9/4=",
-          "range": "bytes=1080-251884"
+          "checksum": "sha256-tf4xbo+NP+ssiaZtC1kOKehffAZ3+d17bhgfU3/30+g=",
+          "range": "bytes=1061-256582"
         },
         "name": "libnghttp2-14",
         "signature": {
-          "checksum": "sha1-CotSXRaPLKQCBRHrgzrDOD+4w20=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-KrsJYTyUsll+EUhHekbkdZFzeig=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.62.1-r0.apk",
-        "version": "1.62.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.62.1-r1.apk",
+        "version": "1.62.1-r1"
       },
       {
         "architecture": "x86_64",
@@ -394,136 +394,136 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1DE49kWSnmqVKJdjHFYC1bLkvyb0=",
+        "checksum": "Q1R8OxpY0fGwVaIwft4wJeswF5D54=",
         "control": {
-          "checksum": "sha1-DE49kWSnmqVKJdjHFYC1bLkvyb0=",
-          "range": "bytes=697-1078"
+          "checksum": "sha1-R8OxpY0fGwVaIwft4wJeswF5D54=",
+          "range": "bytes=695-1059"
         },
         "data": {
-          "checksum": "sha256-uDg8Qc6Rnro/68Vb5ufFSkqFLGrEsbvPb0pMJNvT1zw=",
-          "range": "bytes=1079-242085"
+          "checksum": "sha256-wNc8/SBJrGHfwywAtzCsAqeUOt0IaAhqNtlbv8OiHBE=",
+          "range": "bytes=1060-242151"
         },
         "name": "c-ares",
         "signature": {
-          "checksum": "sha1-iYEm6EWQKzxkeoDm+QsRfhw8pDg=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-55/PTlEHXI3o0hx9dSVdNwQeSMg=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.29.0-r0.apk",
-        "version": "1.29.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.31.0-r0.apk",
+        "version": "1.31.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q12eWmn2tCkXxwncU6gagKM3Wd9Sk=",
+        "checksum": "Q1g2RQKAvNjlRPxWjinIRveaq7IlY=",
         "control": {
-          "checksum": "sha1-2eWmn2tCkXxwncU6gagKM3Wd9Sk=",
-          "range": "bytes=696-1169"
+          "checksum": "sha1-g2RQKAvNjlRPxWjinIRveaq7IlY=",
+          "range": "bytes=695-1154"
         },
         "data": {
-          "checksum": "sha256-IFKNdojOhml3DbWPryQuHUiV3tgTWHyqOYD1JNe9IJ4=",
-          "range": "bytes=1170-2582015"
+          "checksum": "sha256-UsQFfOTXCZBan0mxDvR+ts0NKcbv1lNijxnRxjsmZhA=",
+          "range": "bytes=1155-2566233"
         },
         "name": "nghttp2",
         "signature": {
-          "checksum": "sha1-2/9n7KbRuOkrvhYqCFR5Mblx+z8=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-SUvMhz1cc5Or5Qh4fUEvPCp0NAw=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.62.1-r0.apk",
-        "version": "1.62.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.62.1-r1.apk",
+        "version": "1.62.1-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ialksjwPWvvZW+O2ABMbbBV/KTg=",
+        "checksum": "Q1sTMGOgdbZyDKxlRAByisPMHTbpY=",
         "control": {
-          "checksum": "sha1-ialksjwPWvvZW+O2ABMbbBV/KTg=",
-          "range": "bytes=702-1074"
+          "checksum": "sha1-sTMGOgdbZyDKxlRAByisPMHTbpY=",
+          "range": "bytes=703-1060"
         },
         "data": {
-          "checksum": "sha256-+ctDr3AO9mTXovGRPWk6h2ZgfY99Toy6esjBNHtJPY4=",
-          "range": "bytes=1075-631903"
+          "checksum": "sha256-bUy0h/zxpq7iP6vrQRMftZ9nevkHTB87hSX17wz4lmM=",
+          "range": "bytes=1061-631449"
         },
         "name": "nghttp2-dev",
         "signature": {
-          "checksum": "sha1-wZGQRluFd6DL1USzeak75o5/BTc=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-fQ6aDq3Io/gdJ5s5t3M+FwED1Y0=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.62.1-r0.apk",
-        "version": "1.62.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.62.1-r1.apk",
+        "version": "1.62.1-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1MlpRL1nBMU3RgNdSZVB42/vlGME=",
+        "checksum": "Q1rD3dEbbN8s5QAIQK1I8uF1O+oSo=",
         "control": {
-          "checksum": "sha1-MlpRL1nBMU3RgNdSZVB42/vlGME=",
-          "range": "bytes=697-1164"
+          "checksum": "sha1-rD3dEbbN8s5QAIQK1I8uF1O+oSo=",
+          "range": "bytes=701-1154"
         },
         "data": {
-          "checksum": "sha256-RiEPDasBVtnThSxGqTCDvb4J7WXM9YRpJwfYZJ3JLbs=",
-          "range": "bytes=1165-2274746"
+          "checksum": "sha256-41W2IRSRALQijYojLaqAiSSN1uO7twatGn8jqEuCZUg=",
+          "range": "bytes=1155-1439872"
         },
         "name": "xz",
         "signature": {
-          "checksum": "sha1-3wMPFIUEVfkAs7QSENemZsnTLyE=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-lozWkVrKvSrd1SoM7Zv08YYG2pA=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/xz-5.4.6-r2.apk",
-        "version": "5.4.6-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/xz-5.6.2-r0.apk",
+        "version": "5.6.2-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1TS707T+cPGL7TYVHQBCJoWwHZ0E=",
+        "checksum": "Q10AaU1ocIM4PYYNvwbml8TmpNvEA=",
         "control": {
-          "checksum": "sha1-TS707T+cPGL7TYVHQBCJoWwHZ0E=",
-          "range": "bytes=706-1098"
+          "checksum": "sha1-0AaU1ocIM4PYYNvwbml8TmpNvEA=",
+          "range": "bytes=706-1085"
         },
         "data": {
-          "checksum": "sha256-x18L706Vug5qDzq13SXuN/vGdVgzrqB06dW2DdgHGR4=",
-          "range": "bytes=1099-4541967"
+          "checksum": "sha256-1YQNYASFjlP3kXX58ec8du75ij/U6O4DPAKzJAPkln0=",
+          "range": "bytes=1086-4272589"
         },
         "name": "libxml2",
         "signature": {
-          "checksum": "sha1-BYhOxDos48sN8df8LMsSpROv2aw=",
+          "checksum": "sha1-QFjdplzGn/MiNFxMykgafr6/w6U=",
           "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.12.7-r0.apk",
-        "version": "2.12.7-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.1-r1.apk",
+        "version": "2.13.1-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1wJPtj5XZtnPiVWGM5dsT+nyfWXc=",
+        "checksum": "Q1wbnfumlWEiJnVUsJBRcQjFD3U6I=",
         "control": {
-          "checksum": "sha1-wJPtj5XZtnPiVWGM5dsT+nyfWXc=",
-          "range": "bytes=705-1234"
+          "checksum": "sha1-wbnfumlWEiJnVUsJBRcQjFD3U6I=",
+          "range": "bytes=699-1222"
         },
         "data": {
-          "checksum": "sha256-sw+CjlpsjO01q6lqzXgHnniiJKn7bqOSNO6vNqdGc7I=",
-          "range": "bytes=1235-3873775"
+          "checksum": "sha256-IXMNbJjj3kTjkWVBIHVRfG3zJQY2r5Eslgh/3TpMSsE=",
+          "range": "bytes=1223-3886778"
         },
         "name": "bind-libs",
         "signature": {
-          "checksum": "sha1-9zDzmHAeu7mWpidXAatqrLZVzUs=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-JNN15IPpJ2hMsO6hFVpDYPvvX5g=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bind-libs-9.18.26-r0.apk",
-        "version": "9.18.26-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/bind-libs-9.18.27-r1.apk",
+        "version": "9.18.27-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1AxEQdi8fVcYtGc3zHTCW3OZdY2Q=",
+        "checksum": "Q1kXUOoNa2KXixxAASo1W/im1qZ7s=",
         "control": {
-          "checksum": "sha1-AxEQdi8fVcYtGc3zHTCW3OZdY2Q=",
-          "range": "bytes=694-1208"
+          "checksum": "sha1-kXUOoNa2KXixxAASo1W/im1qZ7s=",
+          "range": "bytes=702-1215"
         },
         "data": {
-          "checksum": "sha256-/dt3qJw5D9iSJ/mKkRQkhWD8R52selhpcwXyw7KLMhg=",
-          "range": "bytes=1209-879444"
+          "checksum": "sha256-HRADvfRXfYsgEjUMGM4Hd7prpIv+YWILVfovbGOkEME=",
+          "range": "bytes=1216-879975"
         },
         "name": "bind-tools",
         "signature": {
-          "checksum": "sha1-VTb0YdUzPMk8Po0p4nj0y5Jey6k=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-8WUTMUaJTaX0T9FS/c+GddL7ttY=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bind-tools-9.18.26-r0.apk",
-        "version": "9.18.26-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/bind-tools-9.18.27-r1.apk",
+        "version": "9.18.27-r1"
       },
       {
         "architecture": "x86_64",
@@ -622,60 +622,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1fr0OtiVaD3c5nw8fy5m74hDe9PU=",
+        "checksum": "Q1BRGmQ9LZTeZqbxQ1ls69T6efViw=",
         "control": {
-          "checksum": "sha1-fr0OtiVaD3c5nw8fy5m74hDe9PU=",
-          "range": "bytes=697-1092"
+          "checksum": "sha1-BRGmQ9LZTeZqbxQ1ls69T6efViw=",
+          "range": "bytes=698-1080"
         },
         "data": {
-          "checksum": "sha256-lukjMYpGmuhBNDUbbTJMIrUWaR4rNikEnW4BgiTaLj8=",
-          "range": "bytes=1093-113872"
+          "checksum": "sha256-vtJ4WJ5M+31ZKSBYBedbrl/FrbAw8hGpPRrHC7kasOk=",
+          "range": "bytes=1081-113895"
         },
         "name": "libpsl",
         "signature": {
-          "checksum": "sha1-Lrrudgn1i1a0JhjdzeXG+exnjQA=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-DuAoiykwhu8vu1qxdEDK5oyAmf8=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libpsl-0.21.5-r2.apk",
-        "version": "0.21.5-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libpsl-0.21.5-r3.apk",
+        "version": "0.21.5-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1oauHQa0YcFcEHSQWdfohfNEN4sY=",
+        "checksum": "Q11DZVpe2UYyDr/dG6BDysZhE3L48=",
         "control": {
-          "checksum": "sha1-oauHQa0YcFcEHSQWdfohfNEN4sY=",
-          "range": "bytes=698-1057"
+          "checksum": "sha1-1DZVpe2UYyDr/dG6BDysZhE3L48=",
+          "range": "bytes=707-1049"
         },
         "data": {
-          "checksum": "sha256-d95c9lpjQrpuZ1CcQ8ZZ89LAGGKcessd+hxrOQpP4LU=",
-          "range": "bytes=1058-173549"
+          "checksum": "sha256-aECfsy7giZsLNxZM0HMeF4OS2gu+ycX4DUTJXsiZRQs=",
+          "range": "bytes=1050-173585"
         },
         "name": "libbrotlicommon1",
         "signature": {
-          "checksum": "sha1-g3ufBq/tyiNP6AaOoqwItVvh7uk=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-7LXD38QwFhklZCEqyW4qIncfZV0=",
+          "range": "bytes=0-706"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlicommon1-1.1.0-r2.apk",
-        "version": "1.1.0-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlicommon1-1.1.0-r3.apk",
+        "version": "1.1.0-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q18Otq7NLoYnNMebI/1Rr/s0zdLVw=",
+        "checksum": "Q1Cgr886A8Ryzynz9pxRKsNybVuK0=",
         "control": {
-          "checksum": "sha1-8Otq7NLoYnNMebI/1Rr/s0zdLVw=",
-          "range": "bytes=705-1072"
+          "checksum": "sha1-Cgr886A8Ryzynz9pxRKsNybVuK0=",
+          "range": "bytes=694-1043"
         },
         "data": {
-          "checksum": "sha256-sR3QidR/e46PJ/3S2fxAjN/hRSSA3Ar32Nw7VshTHWg=",
-          "range": "bytes=1073-81475"
+          "checksum": "sha256-mH+MTbqpLiqgydlgE+tSDEt0Sh1/zqMvAqspV4lr+Ks=",
+          "range": "bytes=1044-81511"
         },
         "name": "libbrotlidec1",
         "signature": {
-          "checksum": "sha1-6GpZI5cBUXOvjCYG81aZZR53lMI=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-Yp4Bde9oHQCec8HM2qn6hVKgtko=",
+          "range": "bytes=0-693"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlidec1-1.1.0-r2.apk",
-        "version": "1.1.0-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlidec1-1.1.0-r3.apk",
+        "version": "1.1.0-r3"
       },
       {
         "architecture": "x86_64",
@@ -717,22 +717,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q19f/3419Xa/xv9jgQ0mMYs011fBk=",
+        "checksum": "Q1mTmy64gKYi4THBqewuvYL2uUyHc=",
         "control": {
-          "checksum": "sha1-9f/3419Xa/xv9jgQ0mMYs011fBk=",
-          "range": "bytes=696-1041"
+          "checksum": "sha1-mTmy64gKYi4THBqewuvYL2uUyHc=",
+          "range": "bytes=700-1031"
         },
         "data": {
-          "checksum": "sha256-iqHASiMgiu6rIjbWGwBmmq1Zthae8BkE4QZkiVPH7Ek=",
-          "range": "bytes=1042-1888945"
+          "checksum": "sha256-p0qua2luH33oAgOcLkU9f7k+I8WnykFszVMwNahujDA=",
+          "range": "bytes=1032-1889523"
         },
         "name": "tzdata",
         "signature": {
-          "checksum": "sha1-PCC3jiXlTwrimRMXH/4RyNvccOM=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-sBf5jVLVpWj4DiXaAd/mjo0pTfk=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/tzdata-2024a-r2.apk",
-        "version": "2024a-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/tzdata-2024a-r3.apk",
+        "version": "2024a-r3"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/symbols.lock.json
+++ b/wolfi-images/symbols.lock.json
@@ -14,41 +14,41 @@
     "packages": [
       {
         "architecture": "x86_64",
-        "checksum": "Q1ge3SLQsJ9v2RnvIHHAP1yFyjrEU=",
+        "checksum": "Q1Ai8jWuxKZR2M2XhOpOGAoTEwnnk=",
         "control": {
-          "checksum": "sha1-ge3SLQsJ9v2RnvIHHAP1yFyjrEU=",
-          "range": "bytes=693-1040"
+          "checksum": "sha1-Ai8jWuxKZR2M2XhOpOGAoTEwnnk=",
+          "range": "bytes=705-1037"
         },
         "data": {
-          "checksum": "sha256-I0AdTdfGf4P/jwzTrLXm73l5/RNSlymEof/YZfev3xY=",
-          "range": "bytes=1041-255811"
+          "checksum": "sha256-e4UardkBVyaC49aSyrVmXNi8sSKqQl4eKYd0LxGRLA0=",
+          "range": "bytes=1038-255695"
         },
         "name": "ca-certificates-bundle",
         "signature": {
-          "checksum": "sha1-ge1eJBiQmFWAn9GapFkQpO+Rn/Y=",
-          "range": "bytes=0-692"
+          "checksum": "sha1-loRuyYQLm+atp+YteiQoj++EWIM=",
+          "range": "bytes=0-704"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20240315-r3.apk",
-        "version": "20240315-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20240315-r4.apk",
+        "version": "20240315-r4"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1bgay5kOzpmDBgqJCg7dSlawyJg0=",
+        "checksum": "Q1+GH6qRN4iy1IDt0cT0x0tin7YfI=",
         "control": {
-          "checksum": "sha1-bgay5kOzpmDBgqJCg7dSlawyJg0=",
-          "range": "bytes=703-1067"
+          "checksum": "sha1-+GH6qRN4iy1IDt0cT0x0tin7YfI=",
+          "range": "bytes=703-1051"
         },
         "data": {
-          "checksum": "sha256-f83HfRE7r2ZniH7PyPmRqcoU5NTpF+Uk4FH80QbjvBM=",
-          "range": "bytes=1068-118370"
+          "checksum": "sha256-rO0P9z2V49BSrz1A5Ap69tEappVrg5MMBjzW00rOpZc=",
+          "range": "bytes=1052-122464"
         },
         "name": "wolfi-baselayout",
         "signature": {
-          "checksum": "sha1-2hlCvYH1D7u25HkJGA75jjs/sQY=",
+          "checksum": "sha1-Ntb6VuMzDfM+frpCjKEIpDzl53I=",
           "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r11.apk",
-        "version": "20230201-r11"
+        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r12.apk",
+        "version": "20230201-r12"
       },
       {
         "architecture": "x86_64",
@@ -109,41 +109,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Zjfs1uR/mYiortANP+EFcejW+vo=",
+        "checksum": "Q1Zi0e8Bq6WCd/6uXXjVhb8YwMD1U=",
         "control": {
-          "checksum": "sha1-Zjfs1uR/mYiortANP+EFcejW+vo=",
-          "range": "bytes=698-1085"
+          "checksum": "sha1-Zi0e8Bq6WCd/6uXXjVhb8YwMD1U=",
+          "range": "bytes=700-1073"
         },
         "data": {
-          "checksum": "sha256-BMd7TzffjbrFwdbopDPVYsX0X9XnusIMNbIf33/8kwc=",
-          "range": "bytes=1086-76881"
+          "checksum": "sha256-jMhtfqVjnhuuBO7wtNZ6RS/72sZWoKt/Moage2amlks=",
+          "range": "bytes=1074-81594"
         },
         "name": "protobuf-c",
         "signature": {
-          "checksum": "sha1-efGiXyYWsJ5P2uTkB6aXEZ3kl3o=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-kATwMKztK7nk7qbYCJPkCFp6IXc=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r4.apk",
-        "version": "1.5.0-r4"
-      },
-      {
-        "architecture": "x86_64",
-        "checksum": "Q1Xf5v5uXumBgIR4d4ZxMRxdpyWlM=",
-        "control": {
-          "checksum": "sha1-Xf5v5uXumBgIR4d4ZxMRxdpyWlM=",
-          "range": "bytes=698-1078"
-        },
-        "data": {
-          "checksum": "sha256-eD7HqFCWNUBQiLq9PcWE/zPeZwkiv8hBrytI4qmfQ/8=",
-          "range": "bytes=1079-57055"
-        },
-        "name": "keyutils-libs",
-        "signature": {
-          "checksum": "sha1-V0HVgZLP7P5kNACfus3abCLCS20=",
-          "range": "bytes=0-697"
-        },
-        "url": "https://packages.wolfi.dev/os/x86_64/keyutils-libs-1.6.3-r2.apk",
-        "version": "1.6.3-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r5.apk",
+        "version": "1.5.0-r5"
       },
       {
         "architecture": "x86_64",
@@ -166,22 +147,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1wRzOx+L6MeRFtTcq2y/6ot7Cj54=",
+        "checksum": "Q1v0A2vQM5k8rQY/GpIq6xI4T0YmA=",
         "control": {
-          "checksum": "sha1-wRzOx+L6MeRFtTcq2y/6ot7Cj54=",
-          "range": "bytes=699-1069"
+          "checksum": "sha1-v0A2vQM5k8rQY/GpIq6xI4T0YmA=",
+          "range": "bytes=701-1064"
         },
         "data": {
-          "checksum": "sha256-gNRjwZ4XQatCYWediSVb+j8lS54CggvMC5Dn3qT84So=",
-          "range": "bytes=1070-61490"
+          "checksum": "sha256-uAOrkGDDc/yqt6VjIrlTEALBJG4BCI4njqZw5jQqF0o=",
+          "range": "bytes=1065-56984"
+        },
+        "name": "keyutils-libs",
+        "signature": {
+          "checksum": "sha1-32uYMH/zGBr9Jo3hiqnThlcqBcE=",
+          "range": "bytes=0-700"
+        },
+        "url": "https://packages.wolfi.dev/os/x86_64/keyutils-libs-1.6.3-r3.apk",
+        "version": "1.6.3-r3"
+      },
+      {
+        "architecture": "x86_64",
+        "checksum": "Q1Onuac6Y+IWA7a4b8FvqX1erWDDw=",
+        "control": {
+          "checksum": "sha1-Onuac6Y+IWA7a4b8FvqX1erWDDw=",
+          "range": "bytes=693-1048"
+        },
+        "data": {
+          "checksum": "sha256-KLtDAs3iU0oyZ/FysePG/J+1H1ofDxHXIY7xvtZhtMc=",
+          "range": "bytes=1049-61503"
         },
         "name": "libverto",
         "signature": {
-          "checksum": "sha1-kuPwakYdy5EM6sd5Ba0K0Ta8x4w=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-/IXL9S1O+MwaW7KsSzz1ywEqKFQ=",
+          "range": "bytes=0-692"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libverto-0.3.2-r3.apk",
-        "version": "0.3.2-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/libverto-0.3.2-r4.apk",
+        "version": "0.3.2-r4"
       },
       {
         "architecture": "x86_64",
@@ -204,60 +204,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1gTZGkWP+QO3mUqLVJth8vrDEzzU=",
+        "checksum": "Q1Q/Zy5ovYSu2p/vVLr6DgVA1e8AQ=",
         "control": {
-          "checksum": "sha1-gTZGkWP+QO3mUqLVJth8vrDEzzU=",
-          "range": "bytes=699-1076"
+          "checksum": "sha1-Q/Zy5ovYSu2p/vVLr6DgVA1e8AQ=",
+          "range": "bytes=699-1062"
         },
         "data": {
-          "checksum": "sha256-/IFXqeKvU0GODNsz1yPIEMcFHgABT+8rbZpSlTLo4e4=",
-          "range": "bytes=1077-5915704"
+          "checksum": "sha256-H3jxsw8ytOeCIR4vq17voSVhdNokXk8C1g075txH6Bs=",
+          "range": "bytes=1063-5903754"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-l1o5ixkyWWqqJE3FOfR0QUemJUA=",
+          "checksum": "sha1-NIl2f5OI/wSZByI8Ds1ZUfbFWyw=",
           "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r9.apk",
-        "version": "3.3.0-r9"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.1-r3.apk",
+        "version": "3.3.1-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1jhAhggAuZnU7FFHnebGA26mq+jI=",
+        "checksum": "Q13wGUXdZut9OOTdY5z2amUj9wXC0=",
         "control": {
-          "checksum": "sha1-jhAhggAuZnU7FFHnebGA26mq+jI=",
-          "range": "bytes=695-1079"
+          "checksum": "sha1-3wGUXdZut9OOTdY5z2amUj9wXC0=",
+          "range": "bytes=698-1068"
         },
         "data": {
-          "checksum": "sha256-XTCQYnhGSm7SkGwqV/TQMFqGajVJVYhKAidKfLb2D3Y=",
-          "range": "bytes=1080-1197081"
+          "checksum": "sha256-mRda6+YGlOCczyIWKaHqXskTINoT1rgorHDHqAKAb7c=",
+          "range": "bytes=1069-1188955"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-qVrfDVxubkrb5Yrd2mFTv2A0G7k=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-+UdRc4U3PKw4H9OiNurHKXa5BYk=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r9.apk",
-        "version": "3.3.0-r9"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.1-r3.apk",
+        "version": "3.3.1-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1BQEXaeya6QB39QLeKcB99qBNF2o=",
+        "checksum": "Q1p04MrHQPrXOzuV/uF290zjnltqI=",
         "control": {
-          "checksum": "sha1-BQEXaeya6QB39QLeKcB99qBNF2o=",
-          "range": "bytes=699-1229"
+          "checksum": "sha1-p04MrHQPrXOzuV/uF290zjnltqI=",
+          "range": "bytes=704-1219"
         },
         "data": {
-          "checksum": "sha256-ugj/qGEBzhvdX17S22Anry+biy3lcqywhGMSHLIBCvo=",
-          "range": "bytes=1230-2551676"
+          "checksum": "sha256-TsXeqhUGykAhjQUEAlMUSzDQBcWDkkDvReoeHCL1F6c=",
+          "range": "bytes=1220-2555814"
         },
         "name": "krb5-libs",
         "signature": {
-          "checksum": "sha1-oqDPmNM4EngXAGayd/BZOqJAIao=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-cPyzS38QHuNlOCQb8IPlsl2PLHQ=",
+          "range": "bytes=0-703"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/krb5-libs-1.21.2-r2.apk",
-        "version": "1.21.2-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/krb5-libs-1.21.3-r0.apk",
+        "version": "1.21.3-r0"
       },
       {
         "architecture": "x86_64",
@@ -280,60 +280,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1wzZwtLauOQfLQC7YUvZdfKxtlwQ=",
+        "checksum": "Q17uprcuQ2VFudMcWAwtP7miJmLYs=",
         "control": {
-          "checksum": "sha1-wzZwtLauOQfLQC7YUvZdfKxtlwQ=",
-          "range": "bytes=698-1085"
+          "checksum": "sha1-7uprcuQ2VFudMcWAwtP7miJmLYs=",
+          "range": "bytes=695-1067"
         },
         "data": {
-          "checksum": "sha256-TO8CAULO44s/LphhtcaFOGJB7aFldk13v1cV9ceZHww=",
-          "range": "bytes=1086-276837"
+          "checksum": "sha256-unKdPbvO2VHZ5w1t1l8mOpQuNdUGwLhofEO4weN2Mig=",
+          "range": "bytes=1068-280973"
         },
         "name": "libuv",
         "signature": {
-          "checksum": "sha1-LRiyeKmjexy8CJizLxjd6ikon1w=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-4lKldnTO71WHMZ4tbANz6i2/Ed0=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libuv-1.48.0-r2.apk",
-        "version": "1.48.0-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libuv-1.48.0-r3.apk",
+        "version": "1.48.0-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q14S6biy8fc5OGbGEJoLBM+tJOGyo=",
+        "checksum": "Q1CN6zJbOPznWUfTrb/41KT7E6dm8=",
         "control": {
-          "checksum": "sha1-4S6biy8fc5OGbGEJoLBM+tJOGyo=",
-          "range": "bytes=703-1102"
+          "checksum": "sha1-CN6zJbOPznWUfTrb/41KT7E6dm8=",
+          "range": "bytes=699-1083"
         },
         "data": {
-          "checksum": "sha256-hwjdLQYfuMAGQeONmFVo0lZKKQK1S+3PBhrI3upm5W4=",
-          "range": "bytes=1103-155304"
+          "checksum": "sha256-ybzFzoQh1yNTcd3cjt54nYsPlAxAcMUcVMxEv1JRnpQ=",
+          "range": "bytes=1084-155375"
         },
         "name": "zlib",
         "signature": {
-          "checksum": "sha1-ZuLd7kE+AGhn27o8ZqDGM5eundc=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-CPXJcCjinAXP+H8Z5tkko8ayG6E=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/zlib-1.3.1-r2.apk",
-        "version": "1.3.1-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/zlib-1.3.1-r3.apk",
+        "version": "1.3.1-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ykDkP+AmDi2VcZZ1c4q4sez/DxI=",
+        "checksum": "Q1rgbci8SRSjW7EB0NSh6ZUPJLndM=",
         "control": {
-          "checksum": "sha1-ykDkP+AmDi2VcZZ1c4q4sez/DxI=",
-          "range": "bytes=705-1079"
+          "checksum": "sha1-rgbci8SRSjW7EB0NSh6ZUPJLndM=",
+          "range": "bytes=702-1060"
         },
         "data": {
-          "checksum": "sha256-t3BrH7lWfY3to3Fu3EKAMZx29v9Hnl5seyXJzLmZ9/4=",
-          "range": "bytes=1080-251884"
+          "checksum": "sha256-tf4xbo+NP+ssiaZtC1kOKehffAZ3+d17bhgfU3/30+g=",
+          "range": "bytes=1061-256582"
         },
         "name": "libnghttp2-14",
         "signature": {
-          "checksum": "sha1-CotSXRaPLKQCBRHrgzrDOD+4w20=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-KrsJYTyUsll+EUhHekbkdZFzeig=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.62.1-r0.apk",
-        "version": "1.62.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.62.1-r1.apk",
+        "version": "1.62.1-r1"
       },
       {
         "architecture": "x86_64",
@@ -394,136 +394,136 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1DE49kWSnmqVKJdjHFYC1bLkvyb0=",
+        "checksum": "Q1R8OxpY0fGwVaIwft4wJeswF5D54=",
         "control": {
-          "checksum": "sha1-DE49kWSnmqVKJdjHFYC1bLkvyb0=",
-          "range": "bytes=697-1078"
+          "checksum": "sha1-R8OxpY0fGwVaIwft4wJeswF5D54=",
+          "range": "bytes=695-1059"
         },
         "data": {
-          "checksum": "sha256-uDg8Qc6Rnro/68Vb5ufFSkqFLGrEsbvPb0pMJNvT1zw=",
-          "range": "bytes=1079-242085"
+          "checksum": "sha256-wNc8/SBJrGHfwywAtzCsAqeUOt0IaAhqNtlbv8OiHBE=",
+          "range": "bytes=1060-242151"
         },
         "name": "c-ares",
         "signature": {
-          "checksum": "sha1-iYEm6EWQKzxkeoDm+QsRfhw8pDg=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-55/PTlEHXI3o0hx9dSVdNwQeSMg=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.29.0-r0.apk",
-        "version": "1.29.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.31.0-r0.apk",
+        "version": "1.31.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q12eWmn2tCkXxwncU6gagKM3Wd9Sk=",
+        "checksum": "Q1g2RQKAvNjlRPxWjinIRveaq7IlY=",
         "control": {
-          "checksum": "sha1-2eWmn2tCkXxwncU6gagKM3Wd9Sk=",
-          "range": "bytes=696-1169"
+          "checksum": "sha1-g2RQKAvNjlRPxWjinIRveaq7IlY=",
+          "range": "bytes=695-1154"
         },
         "data": {
-          "checksum": "sha256-IFKNdojOhml3DbWPryQuHUiV3tgTWHyqOYD1JNe9IJ4=",
-          "range": "bytes=1170-2582015"
+          "checksum": "sha256-UsQFfOTXCZBan0mxDvR+ts0NKcbv1lNijxnRxjsmZhA=",
+          "range": "bytes=1155-2566233"
         },
         "name": "nghttp2",
         "signature": {
-          "checksum": "sha1-2/9n7KbRuOkrvhYqCFR5Mblx+z8=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-SUvMhz1cc5Or5Qh4fUEvPCp0NAw=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.62.1-r0.apk",
-        "version": "1.62.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.62.1-r1.apk",
+        "version": "1.62.1-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ialksjwPWvvZW+O2ABMbbBV/KTg=",
+        "checksum": "Q1sTMGOgdbZyDKxlRAByisPMHTbpY=",
         "control": {
-          "checksum": "sha1-ialksjwPWvvZW+O2ABMbbBV/KTg=",
-          "range": "bytes=702-1074"
+          "checksum": "sha1-sTMGOgdbZyDKxlRAByisPMHTbpY=",
+          "range": "bytes=703-1060"
         },
         "data": {
-          "checksum": "sha256-+ctDr3AO9mTXovGRPWk6h2ZgfY99Toy6esjBNHtJPY4=",
-          "range": "bytes=1075-631903"
+          "checksum": "sha256-bUy0h/zxpq7iP6vrQRMftZ9nevkHTB87hSX17wz4lmM=",
+          "range": "bytes=1061-631449"
         },
         "name": "nghttp2-dev",
         "signature": {
-          "checksum": "sha1-wZGQRluFd6DL1USzeak75o5/BTc=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-fQ6aDq3Io/gdJ5s5t3M+FwED1Y0=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.62.1-r0.apk",
-        "version": "1.62.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.62.1-r1.apk",
+        "version": "1.62.1-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1MlpRL1nBMU3RgNdSZVB42/vlGME=",
+        "checksum": "Q1rD3dEbbN8s5QAIQK1I8uF1O+oSo=",
         "control": {
-          "checksum": "sha1-MlpRL1nBMU3RgNdSZVB42/vlGME=",
-          "range": "bytes=697-1164"
+          "checksum": "sha1-rD3dEbbN8s5QAIQK1I8uF1O+oSo=",
+          "range": "bytes=701-1154"
         },
         "data": {
-          "checksum": "sha256-RiEPDasBVtnThSxGqTCDvb4J7WXM9YRpJwfYZJ3JLbs=",
-          "range": "bytes=1165-2274746"
+          "checksum": "sha256-41W2IRSRALQijYojLaqAiSSN1uO7twatGn8jqEuCZUg=",
+          "range": "bytes=1155-1439872"
         },
         "name": "xz",
         "signature": {
-          "checksum": "sha1-3wMPFIUEVfkAs7QSENemZsnTLyE=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-lozWkVrKvSrd1SoM7Zv08YYG2pA=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/xz-5.4.6-r2.apk",
-        "version": "5.4.6-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/xz-5.6.2-r0.apk",
+        "version": "5.6.2-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1TS707T+cPGL7TYVHQBCJoWwHZ0E=",
+        "checksum": "Q10AaU1ocIM4PYYNvwbml8TmpNvEA=",
         "control": {
-          "checksum": "sha1-TS707T+cPGL7TYVHQBCJoWwHZ0E=",
-          "range": "bytes=706-1098"
+          "checksum": "sha1-0AaU1ocIM4PYYNvwbml8TmpNvEA=",
+          "range": "bytes=706-1085"
         },
         "data": {
-          "checksum": "sha256-x18L706Vug5qDzq13SXuN/vGdVgzrqB06dW2DdgHGR4=",
-          "range": "bytes=1099-4541967"
+          "checksum": "sha256-1YQNYASFjlP3kXX58ec8du75ij/U6O4DPAKzJAPkln0=",
+          "range": "bytes=1086-4272589"
         },
         "name": "libxml2",
         "signature": {
-          "checksum": "sha1-BYhOxDos48sN8df8LMsSpROv2aw=",
+          "checksum": "sha1-QFjdplzGn/MiNFxMykgafr6/w6U=",
           "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.12.7-r0.apk",
-        "version": "2.12.7-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.1-r1.apk",
+        "version": "2.13.1-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1wJPtj5XZtnPiVWGM5dsT+nyfWXc=",
+        "checksum": "Q1wbnfumlWEiJnVUsJBRcQjFD3U6I=",
         "control": {
-          "checksum": "sha1-wJPtj5XZtnPiVWGM5dsT+nyfWXc=",
-          "range": "bytes=705-1234"
+          "checksum": "sha1-wbnfumlWEiJnVUsJBRcQjFD3U6I=",
+          "range": "bytes=699-1222"
         },
         "data": {
-          "checksum": "sha256-sw+CjlpsjO01q6lqzXgHnniiJKn7bqOSNO6vNqdGc7I=",
-          "range": "bytes=1235-3873775"
+          "checksum": "sha256-IXMNbJjj3kTjkWVBIHVRfG3zJQY2r5Eslgh/3TpMSsE=",
+          "range": "bytes=1223-3886778"
         },
         "name": "bind-libs",
         "signature": {
-          "checksum": "sha1-9zDzmHAeu7mWpidXAatqrLZVzUs=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-JNN15IPpJ2hMsO6hFVpDYPvvX5g=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bind-libs-9.18.26-r0.apk",
-        "version": "9.18.26-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/bind-libs-9.18.27-r1.apk",
+        "version": "9.18.27-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1AxEQdi8fVcYtGc3zHTCW3OZdY2Q=",
+        "checksum": "Q1kXUOoNa2KXixxAASo1W/im1qZ7s=",
         "control": {
-          "checksum": "sha1-AxEQdi8fVcYtGc3zHTCW3OZdY2Q=",
-          "range": "bytes=694-1208"
+          "checksum": "sha1-kXUOoNa2KXixxAASo1W/im1qZ7s=",
+          "range": "bytes=702-1215"
         },
         "data": {
-          "checksum": "sha256-/dt3qJw5D9iSJ/mKkRQkhWD8R52selhpcwXyw7KLMhg=",
-          "range": "bytes=1209-879444"
+          "checksum": "sha256-HRADvfRXfYsgEjUMGM4Hd7prpIv+YWILVfovbGOkEME=",
+          "range": "bytes=1216-879975"
         },
         "name": "bind-tools",
         "signature": {
-          "checksum": "sha1-VTb0YdUzPMk8Po0p4nj0y5Jey6k=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-8WUTMUaJTaX0T9FS/c+GddL7ttY=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bind-tools-9.18.26-r0.apk",
-        "version": "9.18.26-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/bind-tools-9.18.27-r1.apk",
+        "version": "9.18.27-r1"
       },
       {
         "architecture": "x86_64",
@@ -584,41 +584,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1FaSuo5kLpGzOlCXAmVtdoeTE9KY=",
+        "checksum": "Q1fnaWc3899x9dK4z4iTFNOeM6MI0=",
         "control": {
-          "checksum": "sha1-FaSuo5kLpGzOlCXAmVtdoeTE9KY=",
-          "range": "bytes=699-1146"
+          "checksum": "sha1-fnaWc3899x9dK4z4iTFNOeM6MI0=",
+          "range": "bytes=702-1132"
         },
         "data": {
-          "checksum": "sha256-yT+SLCTF2RGijQmytiBOuD/ZmYIeILT21+D12xRVzrQ=",
-          "range": "bytes=1147-373555"
+          "checksum": "sha256-rhtsl8eIgOKIHSa3VsedIEj1sA3xRi83jc3fhTjIQLw=",
+          "range": "bytes=1133-377535"
         },
         "name": "ca-certificates",
         "signature": {
-          "checksum": "sha1-AKpkACT5QAimOprekpt14cLs7Pw=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-I1wWFlIzyXu0g5mcgMo/iyW3Mhw=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-20240315-r3.apk",
-        "version": "20240315-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-20240315-r4.apk",
+        "version": "20240315-r4"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1XvuhvUSvcah2GSDqXjzZ3s2gxP0=",
+        "checksum": "Q18GWimtzBPBcoLLvO1qkSUgU8lnY=",
         "control": {
-          "checksum": "sha1-XvuhvUSvcah2GSDqXjzZ3s2gxP0=",
-          "range": "bytes=704-1059"
+          "checksum": "sha1-8GWimtzBPBcoLLvO1qkSUgU8lnY=",
+          "range": "bytes=703-1059"
         },
         "data": {
-          "checksum": "sha256-5El7qY7swpzsMszBT3d1Qml1POftfwUyQg65MopTlQY=",
-          "range": "bytes=1060-103661"
+          "checksum": "sha256-gbfqvYRPtP/Psse3jpUh1M2btMStrDYp7S8S5KKk1gc=",
+          "range": "bytes=1060-99122"
         },
         "name": "jansson",
         "signature": {
-          "checksum": "sha1-S1w/d1pn3Z/Md0gX/qJN+cZZ1uw=",
-          "range": "bytes=0-703"
+          "checksum": "sha1-7T/ORwcPkbnmMZiRs2mQ7MVjTBY=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/jansson-2.14-r1.apk",
-        "version": "2.14-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/jansson-2.14-r2.apk",
+        "version": "2.14-r2"
       },
       {
         "architecture": "x86_64",
@@ -679,60 +679,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1fr0OtiVaD3c5nw8fy5m74hDe9PU=",
+        "checksum": "Q1BRGmQ9LZTeZqbxQ1ls69T6efViw=",
         "control": {
-          "checksum": "sha1-fr0OtiVaD3c5nw8fy5m74hDe9PU=",
-          "range": "bytes=697-1092"
+          "checksum": "sha1-BRGmQ9LZTeZqbxQ1ls69T6efViw=",
+          "range": "bytes=698-1080"
         },
         "data": {
-          "checksum": "sha256-lukjMYpGmuhBNDUbbTJMIrUWaR4rNikEnW4BgiTaLj8=",
-          "range": "bytes=1093-113872"
+          "checksum": "sha256-vtJ4WJ5M+31ZKSBYBedbrl/FrbAw8hGpPRrHC7kasOk=",
+          "range": "bytes=1081-113895"
         },
         "name": "libpsl",
         "signature": {
-          "checksum": "sha1-Lrrudgn1i1a0JhjdzeXG+exnjQA=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-DuAoiykwhu8vu1qxdEDK5oyAmf8=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libpsl-0.21.5-r2.apk",
-        "version": "0.21.5-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libpsl-0.21.5-r3.apk",
+        "version": "0.21.5-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1oauHQa0YcFcEHSQWdfohfNEN4sY=",
+        "checksum": "Q11DZVpe2UYyDr/dG6BDysZhE3L48=",
         "control": {
-          "checksum": "sha1-oauHQa0YcFcEHSQWdfohfNEN4sY=",
-          "range": "bytes=698-1057"
+          "checksum": "sha1-1DZVpe2UYyDr/dG6BDysZhE3L48=",
+          "range": "bytes=707-1049"
         },
         "data": {
-          "checksum": "sha256-d95c9lpjQrpuZ1CcQ8ZZ89LAGGKcessd+hxrOQpP4LU=",
-          "range": "bytes=1058-173549"
+          "checksum": "sha256-aECfsy7giZsLNxZM0HMeF4OS2gu+ycX4DUTJXsiZRQs=",
+          "range": "bytes=1050-173585"
         },
         "name": "libbrotlicommon1",
         "signature": {
-          "checksum": "sha1-g3ufBq/tyiNP6AaOoqwItVvh7uk=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-7LXD38QwFhklZCEqyW4qIncfZV0=",
+          "range": "bytes=0-706"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlicommon1-1.1.0-r2.apk",
-        "version": "1.1.0-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlicommon1-1.1.0-r3.apk",
+        "version": "1.1.0-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q18Otq7NLoYnNMebI/1Rr/s0zdLVw=",
+        "checksum": "Q1Cgr886A8Ryzynz9pxRKsNybVuK0=",
         "control": {
-          "checksum": "sha1-8Otq7NLoYnNMebI/1Rr/s0zdLVw=",
-          "range": "bytes=705-1072"
+          "checksum": "sha1-Cgr886A8Ryzynz9pxRKsNybVuK0=",
+          "range": "bytes=694-1043"
         },
         "data": {
-          "checksum": "sha256-sR3QidR/e46PJ/3S2fxAjN/hRSSA3Ar32Nw7VshTHWg=",
-          "range": "bytes=1073-81475"
+          "checksum": "sha256-mH+MTbqpLiqgydlgE+tSDEt0Sh1/zqMvAqspV4lr+Ks=",
+          "range": "bytes=1044-81511"
         },
         "name": "libbrotlidec1",
         "signature": {
-          "checksum": "sha1-6GpZI5cBUXOvjCYG81aZZR53lMI=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-Yp4Bde9oHQCec8HM2qn6hVKgtko=",
+          "range": "bytes=0-693"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlidec1-1.1.0-r2.apk",
-        "version": "1.1.0-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlidec1-1.1.0-r3.apk",
+        "version": "1.1.0-r3"
       },
       {
         "architecture": "x86_64",
@@ -812,22 +812,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q19f/3419Xa/xv9jgQ0mMYs011fBk=",
+        "checksum": "Q1mTmy64gKYi4THBqewuvYL2uUyHc=",
         "control": {
-          "checksum": "sha1-9f/3419Xa/xv9jgQ0mMYs011fBk=",
-          "range": "bytes=696-1041"
+          "checksum": "sha1-mTmy64gKYi4THBqewuvYL2uUyHc=",
+          "range": "bytes=700-1031"
         },
         "data": {
-          "checksum": "sha256-iqHASiMgiu6rIjbWGwBmmq1Zthae8BkE4QZkiVPH7Ek=",
-          "range": "bytes=1042-1888945"
+          "checksum": "sha256-p0qua2luH33oAgOcLkU9f7k+I8WnykFszVMwNahujDA=",
+          "range": "bytes=1032-1889523"
         },
         "name": "tzdata",
         "signature": {
-          "checksum": "sha1-PCC3jiXlTwrimRMXH/4RyNvccOM=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-sBf5jVLVpWj4DiXaAd/mjo0pTfk=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/tzdata-2024a-r2.apk",
-        "version": "2024a-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/tzdata-2024a-r3.apk",
+        "version": "2024a-r3"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/syntax-highlighter.lock.json
+++ b/wolfi-images/syntax-highlighter.lock.json
@@ -14,41 +14,41 @@
     "packages": [
       {
         "architecture": "x86_64",
-        "checksum": "Q1ge3SLQsJ9v2RnvIHHAP1yFyjrEU=",
+        "checksum": "Q1Ai8jWuxKZR2M2XhOpOGAoTEwnnk=",
         "control": {
-          "checksum": "sha1-ge3SLQsJ9v2RnvIHHAP1yFyjrEU=",
-          "range": "bytes=693-1040"
+          "checksum": "sha1-Ai8jWuxKZR2M2XhOpOGAoTEwnnk=",
+          "range": "bytes=705-1037"
         },
         "data": {
-          "checksum": "sha256-I0AdTdfGf4P/jwzTrLXm73l5/RNSlymEof/YZfev3xY=",
-          "range": "bytes=1041-255811"
+          "checksum": "sha256-e4UardkBVyaC49aSyrVmXNi8sSKqQl4eKYd0LxGRLA0=",
+          "range": "bytes=1038-255695"
         },
         "name": "ca-certificates-bundle",
         "signature": {
-          "checksum": "sha1-ge1eJBiQmFWAn9GapFkQpO+Rn/Y=",
-          "range": "bytes=0-692"
+          "checksum": "sha1-loRuyYQLm+atp+YteiQoj++EWIM=",
+          "range": "bytes=0-704"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20240315-r3.apk",
-        "version": "20240315-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20240315-r4.apk",
+        "version": "20240315-r4"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1bgay5kOzpmDBgqJCg7dSlawyJg0=",
+        "checksum": "Q1+GH6qRN4iy1IDt0cT0x0tin7YfI=",
         "control": {
-          "checksum": "sha1-bgay5kOzpmDBgqJCg7dSlawyJg0=",
-          "range": "bytes=703-1067"
+          "checksum": "sha1-+GH6qRN4iy1IDt0cT0x0tin7YfI=",
+          "range": "bytes=703-1051"
         },
         "data": {
-          "checksum": "sha256-f83HfRE7r2ZniH7PyPmRqcoU5NTpF+Uk4FH80QbjvBM=",
-          "range": "bytes=1068-118370"
+          "checksum": "sha256-rO0P9z2V49BSrz1A5Ap69tEappVrg5MMBjzW00rOpZc=",
+          "range": "bytes=1052-122464"
         },
         "name": "wolfi-baselayout",
         "signature": {
-          "checksum": "sha1-2hlCvYH1D7u25HkJGA75jjs/sQY=",
+          "checksum": "sha1-Ntb6VuMzDfM+frpCjKEIpDzl53I=",
           "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r11.apk",
-        "version": "20230201-r11"
+        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r12.apk",
+        "version": "20230201-r12"
       },
       {
         "architecture": "x86_64",
@@ -109,41 +109,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Zjfs1uR/mYiortANP+EFcejW+vo=",
+        "checksum": "Q1Zi0e8Bq6WCd/6uXXjVhb8YwMD1U=",
         "control": {
-          "checksum": "sha1-Zjfs1uR/mYiortANP+EFcejW+vo=",
-          "range": "bytes=698-1085"
+          "checksum": "sha1-Zi0e8Bq6WCd/6uXXjVhb8YwMD1U=",
+          "range": "bytes=700-1073"
         },
         "data": {
-          "checksum": "sha256-BMd7TzffjbrFwdbopDPVYsX0X9XnusIMNbIf33/8kwc=",
-          "range": "bytes=1086-76881"
+          "checksum": "sha256-jMhtfqVjnhuuBO7wtNZ6RS/72sZWoKt/Moage2amlks=",
+          "range": "bytes=1074-81594"
         },
         "name": "protobuf-c",
         "signature": {
-          "checksum": "sha1-efGiXyYWsJ5P2uTkB6aXEZ3kl3o=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-kATwMKztK7nk7qbYCJPkCFp6IXc=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r4.apk",
-        "version": "1.5.0-r4"
-      },
-      {
-        "architecture": "x86_64",
-        "checksum": "Q1Xf5v5uXumBgIR4d4ZxMRxdpyWlM=",
-        "control": {
-          "checksum": "sha1-Xf5v5uXumBgIR4d4ZxMRxdpyWlM=",
-          "range": "bytes=698-1078"
-        },
-        "data": {
-          "checksum": "sha256-eD7HqFCWNUBQiLq9PcWE/zPeZwkiv8hBrytI4qmfQ/8=",
-          "range": "bytes=1079-57055"
-        },
-        "name": "keyutils-libs",
-        "signature": {
-          "checksum": "sha1-V0HVgZLP7P5kNACfus3abCLCS20=",
-          "range": "bytes=0-697"
-        },
-        "url": "https://packages.wolfi.dev/os/x86_64/keyutils-libs-1.6.3-r2.apk",
-        "version": "1.6.3-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r5.apk",
+        "version": "1.5.0-r5"
       },
       {
         "architecture": "x86_64",
@@ -166,22 +147,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1wRzOx+L6MeRFtTcq2y/6ot7Cj54=",
+        "checksum": "Q1v0A2vQM5k8rQY/GpIq6xI4T0YmA=",
         "control": {
-          "checksum": "sha1-wRzOx+L6MeRFtTcq2y/6ot7Cj54=",
-          "range": "bytes=699-1069"
+          "checksum": "sha1-v0A2vQM5k8rQY/GpIq6xI4T0YmA=",
+          "range": "bytes=701-1064"
         },
         "data": {
-          "checksum": "sha256-gNRjwZ4XQatCYWediSVb+j8lS54CggvMC5Dn3qT84So=",
-          "range": "bytes=1070-61490"
+          "checksum": "sha256-uAOrkGDDc/yqt6VjIrlTEALBJG4BCI4njqZw5jQqF0o=",
+          "range": "bytes=1065-56984"
+        },
+        "name": "keyutils-libs",
+        "signature": {
+          "checksum": "sha1-32uYMH/zGBr9Jo3hiqnThlcqBcE=",
+          "range": "bytes=0-700"
+        },
+        "url": "https://packages.wolfi.dev/os/x86_64/keyutils-libs-1.6.3-r3.apk",
+        "version": "1.6.3-r3"
+      },
+      {
+        "architecture": "x86_64",
+        "checksum": "Q1Onuac6Y+IWA7a4b8FvqX1erWDDw=",
+        "control": {
+          "checksum": "sha1-Onuac6Y+IWA7a4b8FvqX1erWDDw=",
+          "range": "bytes=693-1048"
+        },
+        "data": {
+          "checksum": "sha256-KLtDAs3iU0oyZ/FysePG/J+1H1ofDxHXIY7xvtZhtMc=",
+          "range": "bytes=1049-61503"
         },
         "name": "libverto",
         "signature": {
-          "checksum": "sha1-kuPwakYdy5EM6sd5Ba0K0Ta8x4w=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-/IXL9S1O+MwaW7KsSzz1ywEqKFQ=",
+          "range": "bytes=0-692"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libverto-0.3.2-r3.apk",
-        "version": "0.3.2-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/libverto-0.3.2-r4.apk",
+        "version": "0.3.2-r4"
       },
       {
         "architecture": "x86_64",
@@ -204,60 +204,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1gTZGkWP+QO3mUqLVJth8vrDEzzU=",
+        "checksum": "Q1Q/Zy5ovYSu2p/vVLr6DgVA1e8AQ=",
         "control": {
-          "checksum": "sha1-gTZGkWP+QO3mUqLVJth8vrDEzzU=",
-          "range": "bytes=699-1076"
+          "checksum": "sha1-Q/Zy5ovYSu2p/vVLr6DgVA1e8AQ=",
+          "range": "bytes=699-1062"
         },
         "data": {
-          "checksum": "sha256-/IFXqeKvU0GODNsz1yPIEMcFHgABT+8rbZpSlTLo4e4=",
-          "range": "bytes=1077-5915704"
+          "checksum": "sha256-H3jxsw8ytOeCIR4vq17voSVhdNokXk8C1g075txH6Bs=",
+          "range": "bytes=1063-5903754"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-l1o5ixkyWWqqJE3FOfR0QUemJUA=",
+          "checksum": "sha1-NIl2f5OI/wSZByI8Ds1ZUfbFWyw=",
           "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r9.apk",
-        "version": "3.3.0-r9"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.1-r3.apk",
+        "version": "3.3.1-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1jhAhggAuZnU7FFHnebGA26mq+jI=",
+        "checksum": "Q13wGUXdZut9OOTdY5z2amUj9wXC0=",
         "control": {
-          "checksum": "sha1-jhAhggAuZnU7FFHnebGA26mq+jI=",
-          "range": "bytes=695-1079"
+          "checksum": "sha1-3wGUXdZut9OOTdY5z2amUj9wXC0=",
+          "range": "bytes=698-1068"
         },
         "data": {
-          "checksum": "sha256-XTCQYnhGSm7SkGwqV/TQMFqGajVJVYhKAidKfLb2D3Y=",
-          "range": "bytes=1080-1197081"
+          "checksum": "sha256-mRda6+YGlOCczyIWKaHqXskTINoT1rgorHDHqAKAb7c=",
+          "range": "bytes=1069-1188955"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-qVrfDVxubkrb5Yrd2mFTv2A0G7k=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-+UdRc4U3PKw4H9OiNurHKXa5BYk=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r9.apk",
-        "version": "3.3.0-r9"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.1-r3.apk",
+        "version": "3.3.1-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1BQEXaeya6QB39QLeKcB99qBNF2o=",
+        "checksum": "Q1p04MrHQPrXOzuV/uF290zjnltqI=",
         "control": {
-          "checksum": "sha1-BQEXaeya6QB39QLeKcB99qBNF2o=",
-          "range": "bytes=699-1229"
+          "checksum": "sha1-p04MrHQPrXOzuV/uF290zjnltqI=",
+          "range": "bytes=704-1219"
         },
         "data": {
-          "checksum": "sha256-ugj/qGEBzhvdX17S22Anry+biy3lcqywhGMSHLIBCvo=",
-          "range": "bytes=1230-2551676"
+          "checksum": "sha256-TsXeqhUGykAhjQUEAlMUSzDQBcWDkkDvReoeHCL1F6c=",
+          "range": "bytes=1220-2555814"
         },
         "name": "krb5-libs",
         "signature": {
-          "checksum": "sha1-oqDPmNM4EngXAGayd/BZOqJAIao=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-cPyzS38QHuNlOCQb8IPlsl2PLHQ=",
+          "range": "bytes=0-703"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/krb5-libs-1.21.2-r2.apk",
-        "version": "1.21.2-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/krb5-libs-1.21.3-r0.apk",
+        "version": "1.21.3-r0"
       },
       {
         "architecture": "x86_64",
@@ -280,60 +280,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1wzZwtLauOQfLQC7YUvZdfKxtlwQ=",
+        "checksum": "Q17uprcuQ2VFudMcWAwtP7miJmLYs=",
         "control": {
-          "checksum": "sha1-wzZwtLauOQfLQC7YUvZdfKxtlwQ=",
-          "range": "bytes=698-1085"
+          "checksum": "sha1-7uprcuQ2VFudMcWAwtP7miJmLYs=",
+          "range": "bytes=695-1067"
         },
         "data": {
-          "checksum": "sha256-TO8CAULO44s/LphhtcaFOGJB7aFldk13v1cV9ceZHww=",
-          "range": "bytes=1086-276837"
+          "checksum": "sha256-unKdPbvO2VHZ5w1t1l8mOpQuNdUGwLhofEO4weN2Mig=",
+          "range": "bytes=1068-280973"
         },
         "name": "libuv",
         "signature": {
-          "checksum": "sha1-LRiyeKmjexy8CJizLxjd6ikon1w=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-4lKldnTO71WHMZ4tbANz6i2/Ed0=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libuv-1.48.0-r2.apk",
-        "version": "1.48.0-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libuv-1.48.0-r3.apk",
+        "version": "1.48.0-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q14S6biy8fc5OGbGEJoLBM+tJOGyo=",
+        "checksum": "Q1CN6zJbOPznWUfTrb/41KT7E6dm8=",
         "control": {
-          "checksum": "sha1-4S6biy8fc5OGbGEJoLBM+tJOGyo=",
-          "range": "bytes=703-1102"
+          "checksum": "sha1-CN6zJbOPznWUfTrb/41KT7E6dm8=",
+          "range": "bytes=699-1083"
         },
         "data": {
-          "checksum": "sha256-hwjdLQYfuMAGQeONmFVo0lZKKQK1S+3PBhrI3upm5W4=",
-          "range": "bytes=1103-155304"
+          "checksum": "sha256-ybzFzoQh1yNTcd3cjt54nYsPlAxAcMUcVMxEv1JRnpQ=",
+          "range": "bytes=1084-155375"
         },
         "name": "zlib",
         "signature": {
-          "checksum": "sha1-ZuLd7kE+AGhn27o8ZqDGM5eundc=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-CPXJcCjinAXP+H8Z5tkko8ayG6E=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/zlib-1.3.1-r2.apk",
-        "version": "1.3.1-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/zlib-1.3.1-r3.apk",
+        "version": "1.3.1-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ykDkP+AmDi2VcZZ1c4q4sez/DxI=",
+        "checksum": "Q1rgbci8SRSjW7EB0NSh6ZUPJLndM=",
         "control": {
-          "checksum": "sha1-ykDkP+AmDi2VcZZ1c4q4sez/DxI=",
-          "range": "bytes=705-1079"
+          "checksum": "sha1-rgbci8SRSjW7EB0NSh6ZUPJLndM=",
+          "range": "bytes=702-1060"
         },
         "data": {
-          "checksum": "sha256-t3BrH7lWfY3to3Fu3EKAMZx29v9Hnl5seyXJzLmZ9/4=",
-          "range": "bytes=1080-251884"
+          "checksum": "sha256-tf4xbo+NP+ssiaZtC1kOKehffAZ3+d17bhgfU3/30+g=",
+          "range": "bytes=1061-256582"
         },
         "name": "libnghttp2-14",
         "signature": {
-          "checksum": "sha1-CotSXRaPLKQCBRHrgzrDOD+4w20=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-KrsJYTyUsll+EUhHekbkdZFzeig=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.62.1-r0.apk",
-        "version": "1.62.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.62.1-r1.apk",
+        "version": "1.62.1-r1"
       },
       {
         "architecture": "x86_64",
@@ -394,136 +394,136 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1DE49kWSnmqVKJdjHFYC1bLkvyb0=",
+        "checksum": "Q1R8OxpY0fGwVaIwft4wJeswF5D54=",
         "control": {
-          "checksum": "sha1-DE49kWSnmqVKJdjHFYC1bLkvyb0=",
-          "range": "bytes=697-1078"
+          "checksum": "sha1-R8OxpY0fGwVaIwft4wJeswF5D54=",
+          "range": "bytes=695-1059"
         },
         "data": {
-          "checksum": "sha256-uDg8Qc6Rnro/68Vb5ufFSkqFLGrEsbvPb0pMJNvT1zw=",
-          "range": "bytes=1079-242085"
+          "checksum": "sha256-wNc8/SBJrGHfwywAtzCsAqeUOt0IaAhqNtlbv8OiHBE=",
+          "range": "bytes=1060-242151"
         },
         "name": "c-ares",
         "signature": {
-          "checksum": "sha1-iYEm6EWQKzxkeoDm+QsRfhw8pDg=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-55/PTlEHXI3o0hx9dSVdNwQeSMg=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.29.0-r0.apk",
-        "version": "1.29.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.31.0-r0.apk",
+        "version": "1.31.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q12eWmn2tCkXxwncU6gagKM3Wd9Sk=",
+        "checksum": "Q1g2RQKAvNjlRPxWjinIRveaq7IlY=",
         "control": {
-          "checksum": "sha1-2eWmn2tCkXxwncU6gagKM3Wd9Sk=",
-          "range": "bytes=696-1169"
+          "checksum": "sha1-g2RQKAvNjlRPxWjinIRveaq7IlY=",
+          "range": "bytes=695-1154"
         },
         "data": {
-          "checksum": "sha256-IFKNdojOhml3DbWPryQuHUiV3tgTWHyqOYD1JNe9IJ4=",
-          "range": "bytes=1170-2582015"
+          "checksum": "sha256-UsQFfOTXCZBan0mxDvR+ts0NKcbv1lNijxnRxjsmZhA=",
+          "range": "bytes=1155-2566233"
         },
         "name": "nghttp2",
         "signature": {
-          "checksum": "sha1-2/9n7KbRuOkrvhYqCFR5Mblx+z8=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-SUvMhz1cc5Or5Qh4fUEvPCp0NAw=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.62.1-r0.apk",
-        "version": "1.62.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.62.1-r1.apk",
+        "version": "1.62.1-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ialksjwPWvvZW+O2ABMbbBV/KTg=",
+        "checksum": "Q1sTMGOgdbZyDKxlRAByisPMHTbpY=",
         "control": {
-          "checksum": "sha1-ialksjwPWvvZW+O2ABMbbBV/KTg=",
-          "range": "bytes=702-1074"
+          "checksum": "sha1-sTMGOgdbZyDKxlRAByisPMHTbpY=",
+          "range": "bytes=703-1060"
         },
         "data": {
-          "checksum": "sha256-+ctDr3AO9mTXovGRPWk6h2ZgfY99Toy6esjBNHtJPY4=",
-          "range": "bytes=1075-631903"
+          "checksum": "sha256-bUy0h/zxpq7iP6vrQRMftZ9nevkHTB87hSX17wz4lmM=",
+          "range": "bytes=1061-631449"
         },
         "name": "nghttp2-dev",
         "signature": {
-          "checksum": "sha1-wZGQRluFd6DL1USzeak75o5/BTc=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-fQ6aDq3Io/gdJ5s5t3M+FwED1Y0=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.62.1-r0.apk",
-        "version": "1.62.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.62.1-r1.apk",
+        "version": "1.62.1-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1MlpRL1nBMU3RgNdSZVB42/vlGME=",
+        "checksum": "Q1rD3dEbbN8s5QAIQK1I8uF1O+oSo=",
         "control": {
-          "checksum": "sha1-MlpRL1nBMU3RgNdSZVB42/vlGME=",
-          "range": "bytes=697-1164"
+          "checksum": "sha1-rD3dEbbN8s5QAIQK1I8uF1O+oSo=",
+          "range": "bytes=701-1154"
         },
         "data": {
-          "checksum": "sha256-RiEPDasBVtnThSxGqTCDvb4J7WXM9YRpJwfYZJ3JLbs=",
-          "range": "bytes=1165-2274746"
+          "checksum": "sha256-41W2IRSRALQijYojLaqAiSSN1uO7twatGn8jqEuCZUg=",
+          "range": "bytes=1155-1439872"
         },
         "name": "xz",
         "signature": {
-          "checksum": "sha1-3wMPFIUEVfkAs7QSENemZsnTLyE=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-lozWkVrKvSrd1SoM7Zv08YYG2pA=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/xz-5.4.6-r2.apk",
-        "version": "5.4.6-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/xz-5.6.2-r0.apk",
+        "version": "5.6.2-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1TS707T+cPGL7TYVHQBCJoWwHZ0E=",
+        "checksum": "Q10AaU1ocIM4PYYNvwbml8TmpNvEA=",
         "control": {
-          "checksum": "sha1-TS707T+cPGL7TYVHQBCJoWwHZ0E=",
-          "range": "bytes=706-1098"
+          "checksum": "sha1-0AaU1ocIM4PYYNvwbml8TmpNvEA=",
+          "range": "bytes=706-1085"
         },
         "data": {
-          "checksum": "sha256-x18L706Vug5qDzq13SXuN/vGdVgzrqB06dW2DdgHGR4=",
-          "range": "bytes=1099-4541967"
+          "checksum": "sha256-1YQNYASFjlP3kXX58ec8du75ij/U6O4DPAKzJAPkln0=",
+          "range": "bytes=1086-4272589"
         },
         "name": "libxml2",
         "signature": {
-          "checksum": "sha1-BYhOxDos48sN8df8LMsSpROv2aw=",
+          "checksum": "sha1-QFjdplzGn/MiNFxMykgafr6/w6U=",
           "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.12.7-r0.apk",
-        "version": "2.12.7-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.1-r1.apk",
+        "version": "2.13.1-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1wJPtj5XZtnPiVWGM5dsT+nyfWXc=",
+        "checksum": "Q1wbnfumlWEiJnVUsJBRcQjFD3U6I=",
         "control": {
-          "checksum": "sha1-wJPtj5XZtnPiVWGM5dsT+nyfWXc=",
-          "range": "bytes=705-1234"
+          "checksum": "sha1-wbnfumlWEiJnVUsJBRcQjFD3U6I=",
+          "range": "bytes=699-1222"
         },
         "data": {
-          "checksum": "sha256-sw+CjlpsjO01q6lqzXgHnniiJKn7bqOSNO6vNqdGc7I=",
-          "range": "bytes=1235-3873775"
+          "checksum": "sha256-IXMNbJjj3kTjkWVBIHVRfG3zJQY2r5Eslgh/3TpMSsE=",
+          "range": "bytes=1223-3886778"
         },
         "name": "bind-libs",
         "signature": {
-          "checksum": "sha1-9zDzmHAeu7mWpidXAatqrLZVzUs=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-JNN15IPpJ2hMsO6hFVpDYPvvX5g=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bind-libs-9.18.26-r0.apk",
-        "version": "9.18.26-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/bind-libs-9.18.27-r1.apk",
+        "version": "9.18.27-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1AxEQdi8fVcYtGc3zHTCW3OZdY2Q=",
+        "checksum": "Q1kXUOoNa2KXixxAASo1W/im1qZ7s=",
         "control": {
-          "checksum": "sha1-AxEQdi8fVcYtGc3zHTCW3OZdY2Q=",
-          "range": "bytes=694-1208"
+          "checksum": "sha1-kXUOoNa2KXixxAASo1W/im1qZ7s=",
+          "range": "bytes=702-1215"
         },
         "data": {
-          "checksum": "sha256-/dt3qJw5D9iSJ/mKkRQkhWD8R52selhpcwXyw7KLMhg=",
-          "range": "bytes=1209-879444"
+          "checksum": "sha256-HRADvfRXfYsgEjUMGM4Hd7prpIv+YWILVfovbGOkEME=",
+          "range": "bytes=1216-879975"
         },
         "name": "bind-tools",
         "signature": {
-          "checksum": "sha1-VTb0YdUzPMk8Po0p4nj0y5Jey6k=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-8WUTMUaJTaX0T9FS/c+GddL7ttY=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bind-tools-9.18.26-r0.apk",
-        "version": "9.18.26-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/bind-tools-9.18.27-r1.apk",
+        "version": "9.18.27-r1"
       },
       {
         "architecture": "x86_64",
@@ -622,60 +622,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1fr0OtiVaD3c5nw8fy5m74hDe9PU=",
+        "checksum": "Q1BRGmQ9LZTeZqbxQ1ls69T6efViw=",
         "control": {
-          "checksum": "sha1-fr0OtiVaD3c5nw8fy5m74hDe9PU=",
-          "range": "bytes=697-1092"
+          "checksum": "sha1-BRGmQ9LZTeZqbxQ1ls69T6efViw=",
+          "range": "bytes=698-1080"
         },
         "data": {
-          "checksum": "sha256-lukjMYpGmuhBNDUbbTJMIrUWaR4rNikEnW4BgiTaLj8=",
-          "range": "bytes=1093-113872"
+          "checksum": "sha256-vtJ4WJ5M+31ZKSBYBedbrl/FrbAw8hGpPRrHC7kasOk=",
+          "range": "bytes=1081-113895"
         },
         "name": "libpsl",
         "signature": {
-          "checksum": "sha1-Lrrudgn1i1a0JhjdzeXG+exnjQA=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-DuAoiykwhu8vu1qxdEDK5oyAmf8=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libpsl-0.21.5-r2.apk",
-        "version": "0.21.5-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libpsl-0.21.5-r3.apk",
+        "version": "0.21.5-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1oauHQa0YcFcEHSQWdfohfNEN4sY=",
+        "checksum": "Q11DZVpe2UYyDr/dG6BDysZhE3L48=",
         "control": {
-          "checksum": "sha1-oauHQa0YcFcEHSQWdfohfNEN4sY=",
-          "range": "bytes=698-1057"
+          "checksum": "sha1-1DZVpe2UYyDr/dG6BDysZhE3L48=",
+          "range": "bytes=707-1049"
         },
         "data": {
-          "checksum": "sha256-d95c9lpjQrpuZ1CcQ8ZZ89LAGGKcessd+hxrOQpP4LU=",
-          "range": "bytes=1058-173549"
+          "checksum": "sha256-aECfsy7giZsLNxZM0HMeF4OS2gu+ycX4DUTJXsiZRQs=",
+          "range": "bytes=1050-173585"
         },
         "name": "libbrotlicommon1",
         "signature": {
-          "checksum": "sha1-g3ufBq/tyiNP6AaOoqwItVvh7uk=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-7LXD38QwFhklZCEqyW4qIncfZV0=",
+          "range": "bytes=0-706"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlicommon1-1.1.0-r2.apk",
-        "version": "1.1.0-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlicommon1-1.1.0-r3.apk",
+        "version": "1.1.0-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q18Otq7NLoYnNMebI/1Rr/s0zdLVw=",
+        "checksum": "Q1Cgr886A8Ryzynz9pxRKsNybVuK0=",
         "control": {
-          "checksum": "sha1-8Otq7NLoYnNMebI/1Rr/s0zdLVw=",
-          "range": "bytes=705-1072"
+          "checksum": "sha1-Cgr886A8Ryzynz9pxRKsNybVuK0=",
+          "range": "bytes=694-1043"
         },
         "data": {
-          "checksum": "sha256-sR3QidR/e46PJ/3S2fxAjN/hRSSA3Ar32Nw7VshTHWg=",
-          "range": "bytes=1073-81475"
+          "checksum": "sha256-mH+MTbqpLiqgydlgE+tSDEt0Sh1/zqMvAqspV4lr+Ks=",
+          "range": "bytes=1044-81511"
         },
         "name": "libbrotlidec1",
         "signature": {
-          "checksum": "sha1-6GpZI5cBUXOvjCYG81aZZR53lMI=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-Yp4Bde9oHQCec8HM2qn6hVKgtko=",
+          "range": "bytes=0-693"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlidec1-1.1.0-r2.apk",
-        "version": "1.1.0-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlidec1-1.1.0-r3.apk",
+        "version": "1.1.0-r3"
       },
       {
         "architecture": "x86_64",
@@ -774,22 +774,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q19f/3419Xa/xv9jgQ0mMYs011fBk=",
+        "checksum": "Q1mTmy64gKYi4THBqewuvYL2uUyHc=",
         "control": {
-          "checksum": "sha1-9f/3419Xa/xv9jgQ0mMYs011fBk=",
-          "range": "bytes=696-1041"
+          "checksum": "sha1-mTmy64gKYi4THBqewuvYL2uUyHc=",
+          "range": "bytes=700-1031"
         },
         "data": {
-          "checksum": "sha256-iqHASiMgiu6rIjbWGwBmmq1Zthae8BkE4QZkiVPH7Ek=",
-          "range": "bytes=1042-1888945"
+          "checksum": "sha256-p0qua2luH33oAgOcLkU9f7k+I8WnykFszVMwNahujDA=",
+          "range": "bytes=1032-1889523"
         },
         "name": "tzdata",
         "signature": {
-          "checksum": "sha1-PCC3jiXlTwrimRMXH/4RyNvccOM=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-sBf5jVLVpWj4DiXaAd/mjo0pTfk=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/tzdata-2024a-r2.apk",
-        "version": "2024a-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/tzdata-2024a-r3.apk",
+        "version": "2024a-r3"
       },
       {
         "architecture": "x86_64",


### PR DESCRIPTION
Automatically generated PR to update package lockfiles for Sourcegraph base images.

Built from Buildkite run [#280656](https://buildkite.com/sourcegraph/sourcegraph/builds/280656).
## Test Plan
- CI build verifies image functionality