### PR TITLE
gitserver: Remove comment about error checking

### DIFF
--- a/cmd/gitserver/internal/server_grpc.go
+++ b/cmd/gitserver/internal/server_grpc.go
@@ -201,7 +201,6 @@ func (gs *grpcServer) Archive(req *proto.ArchiveRequest, ss proto.GitserverServi
 		}
 
 		gs.svc.LogIfCorrupt(ctx, repoName, err)
-		// TODO: Better error checking.
 		return err
 	}
 	defer r.Close()
@@ -682,7 +681,6 @@ func (gs *grpcServer) MergeBase(ctx context.Context, req *proto.MergeBaseRequest
 		}
 
 		gs.svc.LogIfCorrupt(ctx, repoName, err)
-		// TODO: Better error checking.
 		return nil, err
 	}
 
@@ -729,7 +727,6 @@ func (gs *grpcServer) GetCommit(ctx context.Context, req *proto.GetCommitRequest
 			return nil, s.Err()
 		}
 		gs.svc.LogIfCorrupt(ctx, repoName, err)
-		// TODO: Better error checking.
 		return nil, err
 	}
 
@@ -811,7 +808,6 @@ func (gs *grpcServer) Blame(req *proto.BlameRequest, ss proto.GitserverService_B
 			return s.Err()
 		}
 		gs.svc.LogIfCorrupt(ctx, repoName, err)
-		// TODO: Better error checking.
 		return err
 	}
 	defer r.Close()
@@ -857,7 +853,6 @@ func (gs *grpcServer) DefaultBranch(ctx context.Context, req *proto.DefaultBranc
 	refName, err := backend.SymbolicRefHead(ctx, req.GetShortRef())
 	if err != nil {
 		gs.svc.LogIfCorrupt(ctx, repoName, err)
-		// TODO: Better error checking.
 		return nil, err
 	}
 
@@ -940,7 +935,6 @@ func (gs *grpcServer) ReadFile(req *proto.ReadFileRequest, ss proto.GitserverSer
 			return s.Err()
 		}
 		gs.svc.LogIfCorrupt(ctx, repoName, err)
-		// TODO: Better error checking.
 		return err
 	}
 	defer r.Close()
@@ -1002,7 +996,6 @@ func (gs *grpcServer) ResolveRevision(ctx context.Context, req *proto.ResolveRev
 		}
 
 		gs.svc.LogIfCorrupt(ctx, repoName, err)
-		// TODO: Better error checking.
 		return nil, err
 	}
 
@@ -1092,7 +1085,6 @@ func (gs *grpcServer) ListRefs(req *proto.ListRefsRequest, ss proto.GitserverSer
 	it, err := backend.ListRefs(ss.Context(), opt)
 	if err != nil {
 		gs.svc.LogIfCorrupt(ss.Context(), repoName, err)
-		// TODO: Better error checking.
 		return err
 	}
 
@@ -1199,7 +1191,6 @@ func (gs *grpcServer) RawDiff(req *proto.RawDiffRequest, ss proto.GitserverServi
 			return s.Err()
 		}
 		gs.svc.LogIfCorrupt(ctx, repoName, err)
-		// TODO: Better error checking.
 		return err
 	}
 	defer r.Close()
@@ -1252,7 +1243,6 @@ func (gs *grpcServer) ContributorCounts(ctx context.Context, req *proto.Contribu
 		}
 
 		gs.svc.LogIfCorrupt(ctx, repoName, err)
-		// TODO: Better error checking.
 		return nil, err
 	}
 


### PR DESCRIPTION
I think we do a decent job now, and most errors are properly converted with very few unknown errors returned, so I don't think this TODO is needed anymore.

Test plan:

CI passes after removal of comments.