### PR TITLE
release: never use build number in image family

### DIFF
--- a/cmd/executor/docker-mirror/_ami.build.sh
+++ b/cmd/executor/docker-mirror/_ami.build.sh
@@ -19,11 +19,7 @@ GCP_PROJECT="aspect-dev"
 "$gcloud" secrets versions access latest --secret=e2e-builder-sa-key --quiet --project="$GCP_PROJECT" >"workdir/builder-sa-key.json"
 
 ## Setting up packer
-export PKR_VAR_name
-PKR_VAR_name="${IMAGE_FAMILY}"
-if [ "${RELEASE_INTERNAL:-}" == "true" ]; then
-  PKR_VAR_name="${PKR_VAR_name}-${BUILDKITE_BUILD_NUMBER}"
-fi
+export PKR_VAR_name="${IMAGE_FAMILY}-${BUILDKITE_BUILD_NUMBER}"
 export PKR_VAR_image_family="${IMAGE_FAMILY}"
 export PKR_VAR_tagged_release="${EXECUTOR_IS_TAGGED_RELEASE}"
 export PKR_VAR_aws_access_key=${AWS_EXECUTOR_AMI_ACCESS_KEY}

--- a/cmd/executor/docker-mirror/_ami.push.sh
+++ b/cmd/executor/docker-mirror/_ami.push.sh
@@ -9,10 +9,7 @@ export AWS_ACCESS_KEY_ID="${AWS_EXECUTOR_AMI_ACCESS_KEY}"
 export AWS_SECRET_ACCESS_KEY="${AWS_EXECUTOR_AMI_SECRET_KEY}"
 
 # Point to GCP boot disk image/AMI built by build.sh script
-NAME="${IMAGE_FAMILY}"
-if [ "${RELEASE_INTERNAL:-}" == "true" ]; then
-  NAME="${NAME}-${BUILDKITE_BUILD_NUMBER}"
-fi
+NAME="${IMAGE_FAMILY}-${BUILDKITE_BUILD_NUMBER}"
 GOOGLE_IMAGE_NAME="${NAME}"
 
 # Mark GCP boot disk as released and make it usable outside of Sourcegraph.

--- a/cmd/executor/vm-image/_ami.build.sh
+++ b/cmd/executor/vm-image/_ami.build.sh
@@ -33,11 +33,7 @@ docker save --output workdir/executor-vm.tar "sourcegraph/executor-vm:$VERSION"
 GCP_PROJECT="aspect-dev"
 "$gcloud" secrets versions access latest --secret=e2e-builder-sa-key --quiet --project="$GCP_PROJECT" >"workdir/builder-sa-key.json"
 
-export PKR_VAR_name
-PKR_VAR_name="${IMAGE_FAMILY}"
-if [ "${RELEASE_INTERNAL:-}" == "true" ]; then
-  PKR_VAR_name="${PKR_VAR_name}-${BUILDKITE_BUILD_NUMBER}"
-fi
+export PKR_VAR_name="${IMAGE_FAMILY}-${BUILDKITE_BUILD_NUMBER}"
 export PKR_VAR_image_family="${IMAGE_FAMILY}"
 export PKR_VAR_tagged_release="${EXECUTOR_IS_TAGGED_RELEASE}"
 export PKR_VAR_version="${VERSION}"

--- a/cmd/executor/vm-image/_ami.push.sh
+++ b/cmd/executor/vm-image/_ami.push.sh
@@ -24,11 +24,7 @@ export AWS_ACCESS_KEY_ID="${AWS_EXECUTOR_AMI_ACCESS_KEY}"
 export AWS_SECRET_ACCESS_KEY="${AWS_EXECUTOR_AMI_SECRET_KEY}"
 
 # Point to GCP boot disk image/AMI built by //cmd/executor/vm-image:ami.build
-NAME="${IMAGE_FAMILY}"
-if [ "${RELEASE_INTERNAL:-}" == "true" ]; then
-  NAME="${NAME}-${BUILDKITE_BUILD_NUMBER}"
-fi
-
+NAME="${IMAGE_FAMILY}-${BUILDKITE_BUILD_NUMBER}"
 GOOGLE_IMAGE_NAME="${NAME}"
 
 # Mark GCP boot disk as released and make it usable outside of Sourcegraph.

--- a/dev/ci/internal/ci/executor_operations.go
+++ b/dev/ci/internal/ci/executor_operations.go
@@ -124,7 +124,7 @@ func executorDockerMirrorImageFamilyForConfig(c Config) string {
 		if err != nil {
 			panic("cannot parse version")
 		}
-		imageFamily = fmt.Sprintf("sourcegraph-executors-internal-docker-mirror-%d-%d-%d", ver.Major(), ver.Minor(), ver.Patch())
+		imageFamily = fmt.Sprintf("sourcegraph-executors-internal-docker-mirror-%d-%d", ver.Major(), ver.Minor())
 	}
 	return imageFamily
 }
@@ -146,7 +146,7 @@ func executorImageFamilyForConfig(c Config) string {
 		if err != nil {
 			panic("cannot parse version")
 		}
-		imageFamily = fmt.Sprintf("sourcegraph-executors-internal-%d-%d-%d", ver.Major(), ver.Minor(), ver.Patch())
+		imageFamily = fmt.Sprintf("sourcegraph-executors-internal-%d-%d", ver.Major(), ver.Minor())
 	}
 	return imageFamily
 }


### PR DESCRIPTION
the executor image and docker mirror image should now follow the following naming convention:

Image family: `sourcegraph-executors-[nightly|internal|'']-<MAJOR>-<MINOR>`
Image name: `sourcegraph-executor-[nightly|internal|'']-<MAJOR>-<MINOR>-<BUILD_NUMBER>`

example:
Image family: `sourcegraph-executors-5-4`
Image name: `sourcegraph-executor-5-4-277666`

## What happens during releases and _not_ releases?
#### Nightly
**`nightly` suffix**
Image family: `sourcegraph-executors-nightly-<MAJOR>-<MINOR>`
Image name: `sourcegraph-executor-nightly-<MAJOR>-<MINOR>-<BUILD_NUMBER>`
#### Internal
**`internal` suffix**
Image family: `sourcegraph-executors-internal-<MAJOR>-<MINOR>`
Image name: `sourcegraph-executor-internal-<MAJOR>-<MINOR>-<BUILD_NUMBER>`
#### Public / Promote to public

** No suffix **

Image family: `sourcegraph-executors-<MAJOR>-<MINOR>`
Image name: `sourcegraph-executor-<MAJOR>-<MINOR>-<BUILD_NUMBER>`

>  [!IMPORTANT]
> Should we keep the imagine name stable at `sourcegraph-executor-<MAJOR>-<MINOR>-<BUILD_NUMBER>`
> and only change the family name? 
>
> **Why?**
>
> The Image family dictates the collection of images and that changes each major minor and or release phase so there is really no use in changing the image name too, except at a glance you can see from the name what image family it belongs to?
## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles -->


## Changelog

<!--
1. Ensure your pull request title is formatted as: $type($domain): $what
2. Add bullet list items for each additional detail you want to cover (see example below)
3. You can edit this after the pull request was merged, as long as release shipping it hasn't been promoted to the public.
4. For more information, please see this how-to https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c?

Audience: TS/CSE > Customers > Teammates (in that order).

Cheat sheet: $type = chore|fix|feat $domain: source|search|ci|release|plg|cody|local|...
-->

<!--
Example:

Title: fix(search): parse quotes with the appropriate context
Changelog section:

## Changelog

- When a quote is used with regexp pattern type, then ...
- Refactored underlying code.
-->
