### PR TITLE
feat/enterprise-portal: return all attributes, even when access is disabled

### DIFF
--- a/cmd/enterprise-portal/internal/codyaccessservice/BUILD.bazel
+++ b/cmd/enterprise-portal/internal/codyaccessservice/BUILD.bazel
@@ -1,3 +1,4 @@
+load("//dev:go_defs.bzl", "go_test")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
@@ -22,5 +23,16 @@ go_library(
         "@com_github_sourcegraph_log//:log",
         "@com_github_sourcegraph_sourcegraph_accounts_sdk_go//scopes",
         "@org_golang_google_protobuf//types/known/durationpb",
+    ],
+)
+
+go_test(
+    name = "codyaccessservice_test",
+    srcs = ["adapters_test.go"],
+    embed = [":codyaccessservice"],
+    deps = [
+        "//cmd/enterprise-portal/internal/dotcomdb",
+        "@com_github_hexops_autogold_v2//:autogold",
+        "@com_github_stretchr_testify//assert",
     ],
 )

--- a/cmd/enterprise-portal/internal/codyaccessservice/adapters.go
+++ b/cmd/enterprise-portal/internal/codyaccessservice/adapters.go
@@ -12,15 +12,9 @@ func convertAccessAttrsToProto(attrs *dotcomdb.CodyGatewayAccessAttributes) *cod
 	// Provide ID in prefixed format.
 	subscriptionID := subscriptionsv1.EnterpriseSubscriptionIDPrefix + attrs.SubscriptionID
 
-	// If not enabled, return a minimal response.
-	if !attrs.CodyGatewayEnabled {
-		return &codyaccessv1.CodyGatewayAccess{
-			SubscriptionId: subscriptionID,
-			Enabled:        false,
-		}
-	}
-
-	// If enabled, return the full response.
+	// Always try to return the full response, since even when disabled, some
+	// features may be allowed via Cody Gateway (notably attributions). This
+	// also allows Cody Gateway to cache the state of actors that are disabled.
 	limits := attrs.EvaluateRateLimits()
 	return &codyaccessv1.CodyGatewayAccess{
 		SubscriptionId:          subscriptionID,

--- a/cmd/enterprise-portal/internal/codyaccessservice/adapters_test.go
+++ b/cmd/enterprise-portal/internal/codyaccessservice/adapters_test.go
@@ -1,0 +1,36 @@
+package codyaccessservice
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hexops/autogold/v2"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/sourcegraph/sourcegraph/cmd/enterprise-portal/internal/dotcomdb"
+)
+
+func TestConvertAccessAttrsToProto(t *testing.T) {
+	t.Run("zero value", func(t *testing.T) {
+		proto := convertAccessAttrsToProto(&dotcomdb.CodyGatewayAccessAttributes{})
+		assert.False(t, proto.Enabled)
+	})
+
+	t.Run("disabled returns access tokens", func(t *testing.T) {
+		proto := convertAccessAttrsToProto(&dotcomdb.CodyGatewayAccessAttributes{
+			CodyGatewayEnabled: false,
+			LicenseKeyHashes:   [][]byte{[]byte("abc"), []byte("efg")},
+		})
+		assert.False(t, proto.Enabled)
+		// NOTE: These are not real access tokens
+		autogold.Expect([]string{`token:"slk_616263"`, `token:"slk_656667"`}).Equal(t, toStrings(proto.GetAccessTokens()))
+	})
+}
+
+func toStrings[T fmt.Stringer](stringers []T) []string {
+	strs := make([]string, len(stringers))
+	for i, s := range stringers {
+		strs[i] = s.String()
+	}
+	return strs
+}

--- a/cmd/enterprise-portal/internal/codyaccessservice/adapters_test.go
+++ b/cmd/enterprise-portal/internal/codyaccessservice/adapters_test.go
@@ -24,6 +24,24 @@ func TestConvertAccessAttrsToProto(t *testing.T) {
 		assert.False(t, proto.Enabled)
 		// NOTE: These are not real access tokens
 		autogold.Expect([]string{`token:"slk_616263"`, `token:"slk_656667"`}).Equal(t, toStrings(proto.GetAccessTokens()))
+		// Returns nil rate limits
+		assert.Nil(t, proto.ChatCompletionsRateLimit)
+		assert.Nil(t, proto.CodeCompletionsRateLimit)
+		assert.Nil(t, proto.EmbeddingsRateLimit)
+	})
+
+	t.Run("enabled returns everything", func(t *testing.T) {
+		proto := convertAccessAttrsToProto(&dotcomdb.CodyGatewayAccessAttributes{
+			CodyGatewayEnabled: true,
+			LicenseKeyHashes:   [][]byte{[]byte("abc"), []byte("efg")},
+		})
+		assert.True(t, proto.Enabled)
+		// NOTE: These are not real access tokens
+		autogold.Expect([]string{`token:"slk_616263"`, `token:"slk_656667"`}).Equal(t, toStrings(proto.GetAccessTokens()))
+		// Returns non-nil rate limits
+		assert.NotNil(t, proto.ChatCompletionsRateLimit)
+		assert.NotNil(t, proto.CodeCompletionsRateLimit)
+		assert.NotNil(t, proto.EmbeddingsRateLimit)
 	})
 }
 


### PR DESCRIPTION
I was doing a more in-depth, final check between the state of sync in dotcom and in Enterprise Portal, and found a discrepancy: we only return attributes if access is enabled, but there are Cody Gateway features that are enabled _even if Cody Gateway access is disabled_. This was also called out in https://github.com/sourcegraph/sourcegraph/pull/62934#discussion_r1625142452

See my comment in CORE-98 here: https://linear.app/sourcegraph/issue/CORE-98/enterprise-portal-use-portal-from-cody-gateway#comment-80991a40

## Test plan

Basic unit test to make sure the constructor doesn't blow up on any nil fields