### PR TITLE
fix/enterprise-portal: ignore empty hashes for Cody Gateway access tokens

### DIFF
--- a/cmd/enterprise-portal/internal/codyaccessservice/adapters.go
+++ b/cmd/enterprise-portal/internal/codyaccessservice/adapters.go
@@ -39,6 +39,10 @@ func convertAccessAttrsToProto(attrs *dotcomdb.CodyGatewayAccessAttributes) *cod
 		// This is always provided, even if access is disabled
 		AccessTokens: func() []*codyaccessv1.CodyGatewayAccessToken {
 			accessTokens := attrs.GenerateAccessTokens()
+			if len(accessTokens) == 0 {
+				return []*codyaccessv1.CodyGatewayAccessToken{}
+			}
+
 			results := make([]*codyaccessv1.CodyGatewayAccessToken, len(accessTokens))
 			for i, token := range accessTokens {
 				results[i] = &codyaccessv1.CodyGatewayAccessToken{

--- a/cmd/enterprise-portal/internal/codyaccessservice/adapters_test.go
+++ b/cmd/enterprise-portal/internal/codyaccessservice/adapters_test.go
@@ -30,6 +30,15 @@ func TestConvertAccessAttrsToProto(t *testing.T) {
 		assert.Nil(t, proto.EmbeddingsRateLimit)
 	})
 
+	t.Run("enabled with empty access token", func(t *testing.T) {
+		proto := convertAccessAttrsToProto(&dotcomdb.CodyGatewayAccessAttributes{
+			CodyGatewayEnabled: true,
+			LicenseKeyHashes:   [][]byte{[]byte(""), nil},
+		})
+		assert.True(t, proto.Enabled)
+		assert.Empty(t, proto.GetAccessTokens())
+	})
+
 	t.Run("enabled returns everything", func(t *testing.T) {
 		proto := convertAccessAttrsToProto(&dotcomdb.CodyGatewayAccessAttributes{
 			CodyGatewayEnabled: true,

--- a/cmd/enterprise-portal/internal/dotcomdb/dotcomdb.go
+++ b/cmd/enterprise-portal/internal/dotcomdb/dotcomdb.go
@@ -147,10 +147,13 @@ func (c CodyGatewayAccessAttributes) EvaluateRateLimits() CodyGatewayRateLimits 
 }
 
 func (c CodyGatewayAccessAttributes) GenerateAccessTokens() []string {
-	accessTokens := make([]string, len(c.LicenseKeyHashes))
-	for i, t := range c.LicenseKeyHashes {
+	accessTokens := make([]string, 0, len(c.LicenseKeyHashes))
+	for _, t := range c.LicenseKeyHashes {
+		if len(t) == 0 { // query can return empty hashes, ignore these
+			continue
+		}
 		// See license.GenerateLicenseKeyBasedAccessToken
-		accessTokens[i] = license.LicenseKeyBasedAccessTokenPrefix + hex.EncodeToString(t)
+		accessTokens = append(accessTokens, license.LicenseKeyBasedAccessTokenPrefix+hex.EncodeToString(t))
 	}
 	return accessTokens
 }


### PR DESCRIPTION
Quick fix in prep for rollout of https://github.com/sourcegraph/sourcegraph/pull/62934 - see https://linear.app/sourcegraph/issue/CORE-98/enterprise-portal-use-portal-from-cody-gateway#comment-1d627e80

## Test plan

Unit test