### PR TITLE
feat/msp/runtime: PG_QUERY_LOGGING=true for local dev query logging

### DIFF
--- a/lib/managedservicesplatform/runtime/contract/BUILD.bazel
+++ b/lib/managedservicesplatform/runtime/contract/BUILD.bazel
@@ -21,6 +21,7 @@ go_library(
         "//lib/pointers",
         "@com_github_getsentry_sentry_go//:sentry-go",
         "@com_github_google_uuid//:uuid",
+        "@com_github_jackc_pgx_v5//:pgx",
         "@com_github_jackc_pgx_v5//pgxpool",
         "@com_github_jackc_pgx_v5//stdlib",
         "@com_github_prometheus_client_golang//prometheus/promhttp",

--- a/lib/managedservicesplatform/runtime/contract/contract.go
+++ b/lib/managedservicesplatform/runtime/contract/contract.go
@@ -130,7 +130,7 @@ func New(logger log.Logger, service ServiceMetadataProvider, env *Env) Contract 
 		ExternalDNSName: env.GetOptional("EXTERNAL_DNS_NAME", "external DNS name provisioned for the service"),
 		RedisEndpoint:   env.GetOptional("REDIS_ENDPOINT", "full Redis address, including any prerequisite authentication"),
 
-		PostgreSQL: loadPostgreSQLContract(env),
+		PostgreSQL: loadPostgreSQLContract(env, isMSP),
 		BigQuery:   loadBigQueryContract(env),
 
 		Diagnostics: loadDiagnosticsContract(logger, env, defaultGCPProjectID, internal, isMSP),

--- a/lib/managedservicesplatform/runtime/contract/postgresql.go
+++ b/lib/managedservicesplatform/runtime/contract/postgresql.go
@@ -4,11 +4,16 @@ import (
 	"bytes"
 	"context"
 	"database/sql"
+	"encoding/json"
+	"fmt"
 	"text/template"
 
 	"cloud.google.com/go/cloudsqlconn"
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/jackc/pgx/v5/stdlib"
+
+	"github.com/sourcegraph/log"
 
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 	"github.com/sourcegraph/sourcegraph/lib/managedservicesplatform/cloudsql"
@@ -16,19 +21,31 @@ import (
 
 type postgreSQLContract struct {
 	customDSNTemplate *string
+	logQueries        bool
 
 	instanceConnectionName *string
 	instanceConnectionUser *string
 }
 
-func loadPostgreSQLContract(env *Env) postgreSQLContract {
-	return postgreSQLContract{
+func loadPostgreSQLContract(env *Env, isMSP bool) postgreSQLContract {
+	c := postgreSQLContract{
 		customDSNTemplate: env.GetOptional("PGDSN",
-			"custom PostgreSQL DSN with templatized database, e.g. 'user=foo database={{ .Database }}'"),
+			"Local dev only: custom PostgreSQL DSN with templatized database, e.g. 'user=foo database={{ .Database }}'"),
+		logQueries: env.GetBool("PG_QUERY_LOGGING", "false",
+			"Local dev only: dump all queries to log output"),
 
 		instanceConnectionName: env.GetOptional("PGINSTANCE", "Cloud SQL instance connection name"),
 		instanceConnectionUser: env.GetOptional("PGUSER", "Cloud SQL user"),
 	}
+
+	if isMSP && c.customDSNTemplate != nil {
+		env.AddError(errors.New("PGDSN is not allowed with MSP=true"))
+	}
+	if isMSP && c.logQueries {
+		env.AddError(errors.New("PG_QUERY_LOGGING=true is not allowed with MSP=true"))
+	}
+
+	return c
 }
 
 // Configured indicates if a PostgreSQL instance is configured for use. It does
@@ -45,7 +62,7 @@ func (c postgreSQLContract) Configured() bool {
 // variable.
 func (c postgreSQLContract) OpenDatabase(ctx context.Context, database string) (*sql.DB, error) {
 	if c.customDSNTemplate != nil {
-		config, err := parseCustomDSNTemplateConnConfig(*c.customDSNTemplate, database)
+		config, err := parseCustomDSNTemplateConnConfig(*c.customDSNTemplate, database, c.logQueries)
 		if err != nil {
 			return nil, err
 		}
@@ -65,7 +82,7 @@ func (c postgreSQLContract) OpenDatabase(ctx context.Context, database string) (
 // variable.
 func (c postgreSQLContract) GetConnectionPool(ctx context.Context, database string) (*pgxpool.Pool, error) {
 	if c.customDSNTemplate != nil {
-		config, err := parseCustomDSNTemplateConnConfig(*c.customDSNTemplate, database)
+		config, err := parseCustomDSNTemplateConnConfig(*c.customDSNTemplate, database, c.logQueries)
 		if err != nil {
 			return nil, err
 		}
@@ -86,7 +103,7 @@ func (c postgreSQLContract) getCloudSQLConnConfig(database string) cloudsql.Conn
 	}
 }
 
-func parseCustomDSNTemplateConnConfig(customDSNTemplate, database string) (*pgxpool.Config, error) {
+func parseCustomDSNTemplateConnConfig(customDSNTemplate, database string, logQueries bool) (*pgxpool.Config, error) {
 	tmpl, err := template.New("PGDSN").Parse(customDSNTemplate)
 	if err != nil {
 		return nil, errors.Wrap(err, "PGDSN is not a valid template")
@@ -99,5 +116,63 @@ func parseCustomDSNTemplateConnConfig(customDSNTemplate, database string) (*pgxp
 	if err != nil {
 		return nil, errors.Wrap(err, "rendered PGDSN is invalid")
 	}
+
+	if logQueries {
+		logger := log.Scoped(fmt.Sprintf("pgx.devtracer.%s", database))
+		logger.Warn("enabling query logging")
+		config.ConnConfig.Tracer = pgxLocalDevTracer{
+			// Just use new root-scoped logger here, as this is local dev, so we
+			// don't worry too much about scope propagation.
+			logger: logger,
+		}
+	}
+
 	return config, nil
+}
+
+// pgxLocalDevTracer implements various pgx tracing hooks for dumping diagnostics
+// in local dev. DO NOT USE OUTSIDE LOCAL DEV.
+type pgxLocalDevTracer struct {
+	logger log.Logger
+}
+
+// Select tracing hooks we want to implement.
+var (
+	_ pgx.QueryTracer   = pgxLocalDevTracer{}
+	_ pgx.ConnectTracer = pgxLocalDevTracer{}
+	// Future:
+	// _ pgx.BatchTracer    = pgxTracer{}
+	// _ pgx.CopyFromTracer = pgxTracer{}
+	// _ pgx.PrepareTracer  = pgxTracer{}
+)
+
+// TraceQueryStart is called at the beginning of Query, QueryRow, and Exec calls. The returned context is used for the
+// rest of the call and will be passed to TraceQueryEnd.
+func (t pgxLocalDevTracer) TraceQueryStart(ctx context.Context, _ *pgx.Conn, data pgx.TraceQueryStartData) context.Context {
+	var args []string
+	for _, arg := range data.Args {
+		data, _ := json.Marshal(arg)
+		args = append(args, string(data))
+	}
+	t.logger.Debug(fmt.Sprintf("pgx.QueryStart\n---\n%s\n---\n", data.SQL),
+		log.Strings("args", args))
+	return ctx
+}
+
+func (t pgxLocalDevTracer) TraceQueryEnd(ctx context.Context, _ *pgx.Conn, data pgx.TraceQueryEndData) {
+	t.logger.Debug("pgx.QueryEnd", log.String("commandTag",
+		data.CommandTag.String()),
+		log.Error(data.Err))
+}
+
+func (t pgxLocalDevTracer) TraceConnectStart(ctx context.Context, data pgx.TraceConnectStartData) context.Context {
+	t.logger.Debug("pgx.ConnectStart",
+		log.String("database", data.ConnConfig.Database),
+		log.String("instance", fmt.Sprintf("%s:%d", data.ConnConfig.Host, data.ConnConfig.Port)),
+		log.String("user", data.ConnConfig.User))
+	return ctx
+}
+
+func (t pgxLocalDevTracer) TraceConnectEnd(ctx context.Context, data pgx.TraceConnectEndData) {
+	t.logger.Debug("pgx.ConnectEnd", log.Error(data.Err))
 }


### PR DESCRIPTION
Closes https://linear.app/sourcegraph/issue/CORE-168

## Test plan

```
[enterprise-...l] DEBUG pgx.devtracer.enterprise-portal contract/postgresql.go:157 pgx.QueryStart
[enterprise-...l] ---
[enterprise-...l] SELECT count(*) FROM pg_indexes WHERE tablename = $1 AND indexname = $2 AND schemaname = CURRENT_SCHEMA()
[enterprise-...l] ---
[enterprise-...l]  {"args": ["{\"1082\":1,\"1114\":1,\"1184\":1,\"16\":1,\"17\":1,\"20\":1,\"21\":1,\"23\":1,\"26\":1,\"28\":1,\"29\":1,\"700\":1,\"701\":1}", "\"permissions\"", "\"idx_permissions_namespace\""]}
[enterprise-...l] DEBUG pgx.devtracer.enterprise-portal contract/postgresql.go:163 pgx.QueryEnd {"commandTag": "SELECT 1", "error": "<nil>"}
[enterprise-...l] DEBUG pgx.devtracer.enterprise-portal contract/postgresql.go:157 pgx.QueryStart
[enterprise-...l] ---
[enterprise-...l] SELECT count(*) FROM pg_indexes WHERE tablename = $1 AND indexname = $2 AND schemaname = CURRENT_SCHEMA()
[enterprise-...l] ---
[enterprise-...l]  {"args": ["{\"1082\":1,\"1114\":1,\"1184\":1,\"16\":1,\"17\":1,\"20\":1,\"21\":1,\"23\":1,\"26\":1,\"28\":1,\"29\":1,\"700\":1,\"701\":1}", "\"permissions\"", "\"idx_permissions_subject\""]}
```

## Changelog

- MSP runtime users can now set `PG_QUERY_LOGGING=true` to dump queries and arguments from database interactions at `DEBUG` level in local dev.