### PR TITLE
bug(release): change order of release finalization operations

### DIFF
--- a/release.yaml
+++ b/release.yaml
@@ -231,22 +231,6 @@ promoteToPublic:
           fi
   finalize:
     steps:
-      - name: 'Promote on release registry'
-        cmd: |
-          echo "Promoting sourcegraph/sourcegraph {{version}} release on release registry"
-          body=$(wget --content-on-error -O- --header="Content-Type: application/json" --header="Authorization: ${RELEASE_REGISTRY_TOKEN}" --post-data '' "https://releaseregistry.sourcegraph.com/v1/releases/sourcegraph/{{version}}/promote")
-          exit_code=$?
-
-          if [ $exit_code != 0 ]; then
-            echo "❌ Failed to promote release on release registry, got:"
-            echo "--- raw body ---"
-            echo $body
-            echo "--- raw body ---"
-            exit $exit_code
-          else
-            echo "Release promoted, see:"
-            echo $body
-          fi
       - name: 'git:tag'
         cmd: |
           set -eu
@@ -293,6 +277,24 @@ promoteToPublic:
           EndOfText
 
           bazel run //dev/tools:gh -- release create ${version} --latest --verify-tag -t "Sourcegraph ${tag}" --notes "${releasepost}"
+
+      # A release promoted to public in the release registry cannot be repromoted unless the publi is manually set to FALSE.
+      - name: 'Promote on release registry'
+        cmd: |
+          echo "Promoting sourcegraph/sourcegraph {{version}} release on release registry"
+          body=$(wget --content-on-error -O- --header="Content-Type: application/json" --header="Authorization: ${RELEASE_REGISTRY_TOKEN}" --post-data '' "https://releaseregistry.sourcegraph.com/v1/releases/sourcegraph/{{version}}/promote")
+          exit_code=$?
+
+          if [ $exit_code != 0 ]; then
+            echo "❌ Failed to promote release on release registry, got:"
+            echo "--- raw body ---"
+            echo $body
+            echo "--- raw body ---"
+            exit $exit_code
+          else
+            echo "Release promoted, see:"
+            echo $body
+          fi
 
       # tag is usually in the format `5.3.2`
       # while version is usually the tag prepended with a v, `v5.3.2`

--- a/release.yaml
+++ b/release.yaml
@@ -278,24 +278,6 @@ promoteToPublic:
 
           bazel run //dev/tools:gh -- release create ${version} --latest --verify-tag -t "Sourcegraph ${tag}" --notes "${releasepost}"
 
-      # A release promoted to public in the release registry cannot be repromoted unless the publi is manually set to FALSE.
-      - name: 'Promote on release registry'
-        cmd: |
-          echo "Promoting sourcegraph/sourcegraph {{version}} release on release registry"
-          body=$(wget --content-on-error -O- --header="Content-Type: application/json" --header="Authorization: ${RELEASE_REGISTRY_TOKEN}" --post-data '' "https://releaseregistry.sourcegraph.com/v1/releases/sourcegraph/{{version}}/promote")
-          exit_code=$?
-
-          if [ $exit_code != 0 ]; then
-            echo "❌ Failed to promote release on release registry, got:"
-            echo "--- raw body ---"
-            echo $body
-            echo "--- raw body ---"
-            exit $exit_code
-          else
-            echo "Release promoted, see:"
-            echo $body
-          fi
-
       # tag is usually in the format `5.3.2`
       # while version is usually the tag prepended with a v, `v5.3.2`
       - name: 'Slack notification (#announce-engineering, #team-cloud-ops)'
@@ -357,3 +339,21 @@ promoteToPublic:
           cat << EOF | buildkite-agent annotate --style info
           Succesfully submitted [changelog pull request for {{version}}]($pr_url)
           EOF
+
+      # A release promoted to public in the release registry cannot be repromoted unless `public` is manually set to FALSE.
+      - name: 'Promote on release registry'
+        cmd: |
+          echo "Promoting sourcegraph/sourcegraph {{version}} release on release registry"
+          body=$(wget --content-on-error -O- --header="Content-Type: application/json" --header="Authorization: ${RELEASE_REGISTRY_TOKEN}" --post-data '' "https://releaseregistry.sourcegraph.com/v1/releases/sourcegraph/{{version}}/promote")
+          exit_code=$?
+
+          if [ $exit_code != 0 ]; then
+            echo "❌ Failed to promote release on release registry, got:"
+            echo "--- raw body ---"
+            echo $body
+            echo "--- raw body ---"
+            exit $exit_code
+          else
+            echo "Release promoted, see:"
+            echo $body
+          fi


### PR DESCRIPTION
<!-- 💡 To write a useful PR description, make sure that your description covers:
- WHAT this PR is changing:
    - How was it PREVIOUSLY.
    - How it will be from NOW on.
- WHY this PR is needed.
- CONTEXT, i.e. to which initiative, project or RFC it belongs.

The structure of the description doesn't matter as much as covering these points, so use
your best judgement based on your context.
Learn how to write good pull request description: https://www.notion.so/sourcegraph/Write-a-good-pull-request-description-610a7fd3e613496eb76f450db5a49b6e?pvs=4 -->

This PR moves the buildkite step which sets `public = true` for a release in the release registry during the `promoteToPublic:finalize` step in the pipeline generated by `sg release promote-to-publc --version=X.X.X` 

This is because we currently don't want this step to be run on a release thats already been made public: https://github.com/sourcegraph/releaseregistry/issues/12

Note this operation isn't totally last and the internal slack message generation and changelog generation steps could still fail after this. 

## Test plan

Not yet tested

<!-- All pull requests REQUIRE a test plan: https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles -->


## Changelog

<!--
1. Ensure your pull request title is formatted as: $type($domain): $what
2. Add bullet list items for each additional detail you want to cover (see example below)
3. You can edit this after the pull request was merged, as long as release shipping it hasn't been promoted to the public.
4. For more information, please see this how-to https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c?

Audience: TS/CSE > Customers > Teammates (in that order).

Cheat sheet: $type = chore|fix|feat $domain: source|search|ci|release|plg|cody|local|...
-->

<!--
Example:

Title: fix(search): parse quotes with the appropriate context
Changelog section:

## Changelog

- When a quote is used with regexp pattern type, then ...
- Refactored underlying code.
-->
