### PR TITLE
Cody Gateway: handle streams with trailing newline in Gemini response

### DIFF
--- a/cmd/cody-gateway/internal/httpapi/completions/google.go
+++ b/cmd/cody-gateway/internal/httpapi/completions/google.go
@@ -191,13 +191,18 @@ func parseGoogleTokenUsage(r io.Reader, logger log.Logger) (promptTokens int, co
 	scanner.Buffer(make([]byte, 0, 4096), maxPayloadSize)
 	scanner.Split(bufio.ScanLines)
 
-	var lastLine []byte
+	var lastNonEmptyLine []byte
+
+	// Find the last non-empty line in the stream.
 	for scanner.Scan() {
-		lastLine = scanner.Bytes()
+		line := scanner.Bytes()
+		if len(bytes.TrimSpace(line)) > 0 {
+			lastNonEmptyLine = line
+		}
 	}
 
-	if bytes.HasPrefix(bytes.TrimSpace(lastLine), []byte("data: ")) {
-		event := lastLine[5:]
+	if bytes.HasPrefix(bytes.TrimSpace(lastNonEmptyLine), []byte("data: ")) {
+		event := lastNonEmptyLine[5:]
 		var res googleResponse
 		if err := json.NewDecoder(bytes.NewReader(event)).Decode(&res); err != nil {
 			logger.Error("failed to parse Google response as JSON", log.Error(err))

--- a/cmd/cody-gateway/internal/httpapi/completions/google_test.go
+++ b/cmd/cody-gateway/internal/httpapi/completions/google_test.go
@@ -32,7 +32,9 @@ data: {"candidates": [{"content": {"parts": [{"text": "\n  for i in range(n-1):\
 
 data: {"candidates": [{"content": {"parts": [{"text": " range(n-i-1):\n      if list1[j] \u003e list1[j+1]:\n        list1[j], list"}],"role": "model"},"finishReason": "STOP","index": 0,"safetyRatings": [{"category": "HARM_CATEGORY_SEXUALLY_EXPLICIT","probability": "NEGLIGIBLE"},{"category": "HARM_CATEGORY_HATE_SPEECH","probability": "NEGLIGIBLE"},{"category": "HARM_CATEGORY_HARASSMENT","probability": "NEGLIGIBLE"},{"category": "HARM_CATEGORY_DANGEROUS_CONTENT","probability": "NEGLIGIBLE"}]}],"usageMetadata": {"promptTokenCount": 21,"candidatesTokenCount": 63,"totalTokenCount": 84}}
 
-data: {"candidates": [{"content": {"parts": [{"text": "1[j+1] = list1[j+1], list1[j]\n  return list1\n"}],"role": "model"},"finishReason": "STOP","index": 0,"safetyRatings": [{"category": "HARM_CATEGORY_SEXUALLY_EXPLICIT","probability": "NEGLIGIBLE"},{"category": "HARM_CATEGORY_HATE_SPEECH","probability": "NEGLIGIBLE"},{"category": "HARM_CATEGORY_HARASSMENT","probability": "NEGLIGIBLE"},{"category": "HARM_CATEGORY_DANGEROUS_CONTENT","probability": "NEGLIGIBLE"}],"citationMetadata": {"citationSources": [{"startIndex": 1,"endIndex": 185,"uri": "https://github.com/Feng080412/Searches-and-sorts","license": ""}]}}],"usageMetadata": {"promptTokenCount": 21,"candidatesTokenCount": 87,"totalTokenCount": 108}}`
+data: {"candidates": [{"content": {"parts": [{"text": "1[j+1] = list1[j+1], list1[j]\n  return list1\n"}],"role": "model"},"finishReason": "STOP","index": 0,"safetyRatings": [{"category": "HARM_CATEGORY_SEXUALLY_EXPLICIT","probability": "NEGLIGIBLE"},{"category": "HARM_CATEGORY_HATE_SPEECH","probability": "NEGLIGIBLE"},{"category": "HARM_CATEGORY_HARASSMENT","probability": "NEGLIGIBLE"},{"category": "HARM_CATEGORY_DANGEROUS_CONTENT","probability": "NEGLIGIBLE"}],"citationMetadata": {"citationSources": [{"startIndex": 1,"endIndex": 185,"uri": "https://github.com/Feng080412/Searches-and-sorts","license": ""}]}}],"usageMetadata": {"promptTokenCount": 21,"candidatesTokenCount": 87,"totalTokenCount": 108}}
+
+`
 
 func TestParseGoogleTokenUsage(t *testing.T) {
 	tests := []struct {
@@ -108,6 +110,26 @@ data: {"usageMetadata": {"promptTokenCount": 10, "candidatesTokenCount": 20}}`,
 			input:   `data: {"usageMetadata": {"promptTokenCount": 10`,
 			want:    nil,
 			wantErr: true,
+		},
+		{
+			name: "stream ends with new line",
+			input: `data: {"candidates": [{"content": {"parts": [{"text": "The"}],"role": "model"},"finishReason": "STOP","index": 0}],"usageMetadata": {"promptTokenCount": 59,"candidatesTokenCount": 1,"totalTokenCount": 60}}
+
+data: {"candidates": [{"content": {"parts": [{"text": " cobblestone streets of the sleepy village of St. Martin were silent, save for"}],"role": "model"},"finishReason": "STOP","index": 0,"safetyRatings": [{"category": "HARM_CATEGORY_SEXUALLY_EXPLICIT","probability": "NEGLIGIBLE"},{"category": "HARM_CATEGORY_HATE_SPEECH","probability": "NEGLIGIBLE"},{"category": "HARM_CATEGORY_HARASSMENT","probability": "NEGLIGIBLE"},{"category": "HARM_CATEGORY_DANGEROUS_CONTENT","probability": "NEGLIGIBLE"}]}],"usageMetadata": {"promptTokenCount": 59,"candidatesTokenCount": 17,"totalTokenCount": 76}}
+
+data: {"candidates": [{"content": {"parts": [{"text": " the rhythmic clinking of Marguerite's wooden clogs as she trudged towards the"}],"role": "model"},"finishReason": "STOP","index": 0,"safetyRatings": [{"category": "HARM_CATEGORY_SEXUALLY_EXPLICIT","probability": "LOW"},{"category": "HARM_CATEGORY_HATE_SPEECH","probability": "NEGLIGIBLE"},{"category": "HARM_CATEGORY_HARASSMENT","probability": "NEGLIGIBLE"},{"category": "HARM_CATEGORY_DANGEROUS_CONTENT","probability": "NEGLIGIBLE"}]}],"usageMetadata": {"promptTokenCount": 59,"candidatesTokenCount": 33,"totalTokenCount": 92}}
+
+data: {"candidates": [{"content": {"parts": [{"text": " market square. \n"}],"role": "model"},"finishReason": "STOP","index": 0,"safetyRatings": [{"category": "HARM_CATEGORY_SEXUALLY_EXPLICIT","probability": "NEGLIGIBLE"},{"category": "HARM_CATEGORY_HATE_SPEECH","probability": "NEGLIGIBLE"},{"category": "HARM_CATEGORY_HARASSMENT","probability": "NEGLIGIBLE"},{"category": "HARM_CATEGORY_DANGEROUS_CONTENT","probability": "NEGLIGIBLE"}]}],"usageMetadata": {"promptTokenCount": 59,"candidatesTokenCount": 36,"totalTokenCount": 95}}
+
+`,
+			want: &googleResponse{
+				UsageMetadata: googleUsage{
+					PromptTokenCount:     59,
+					CompletionTokenCount: 36,
+					TotalTokenCount:      0,
+				},
+			},
+			wantErr: false,
 		},
 	}
 


### PR DESCRIPTION
CONTEXT: https://sourcegraph.slack.com/archives/C05ABRRGB0B/p1717790701356599

Fix an issue where a valid Gemini response ends with new lines, causing a false alert.

![image](https://github.com/sourcegraph/sourcegraph/assets/68532117/6b69ff2e-b88e-435b-a50e-27eaa5e31bf9)

Issue: We are seeing `*errutil.leafError: no Google response found` in Sentry complaining  when I run a command or chat in VS Code using google as provider.

Cause: Currently the code (added my me) would skip to the last line of the stream response and determine if the response is valid or not, which could be an issue because the stream API could ends the response with an empty new line, where our current logic would fail.

Changes included in this PR:

- Modify `parseGoogleTokenUsage` function to find the last non-empty line in the stream, to handle cases where the stream ends with a newline
- Add a test case to cover the scenario where the stream ends with a newline

This change modifies the behavior of the `parseGoogleTokenUsage` function to handle streams with trailing newlines, which would fail even if the response is valid because Gemini adds a new line to the end of their stream.

<!-- 💡 To write a useful PR description, make sure that your description covers:
- WHAT this PR is changing:
    - How was it PREVIOUSLY.
    - How it will be from NOW on.
- WHY this PR is needed.
- CONTEXT, i.e. to which initiative, project or RFC it belongs.

The structure of the description doesn't matter as much as covering these points, so use
your best judgement based on your context.
Learn how to write good pull request description: https://www.notion.so/sourcegraph/Write-a-good-pull-request-description-610a7fd3e613496eb76f450db5a49b6e?pvs=4 -->


## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles -->

Make a curl command to the Gemini streaming API to confirm the response ends with a new line:

![image](https://github.com/sourcegraph/sourcegraph/assets/68532117/c0ff0c4a-40dd-4d49-91d3-1b9f01f5c2b9)

```sh
curl https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:streamGenerateContent\?alt=sse\&key\=$GOOGLE_API_KEY \
    -H 'Content-Type: application/json' \
    -X POST \
    -d '{
      "contents": [
        {"role":"user",
         "parts":[{
           "text": "Write the first line of a story about a magic backpack."}]},
        {"role": "model",
         "parts":[{
           "text": "In the bustling city of Meadow brook, lived a young girl named Sophie. She was a bright and curious soul with an imaginative mind."}]},
        {"role": "user",
         "parts":[{
           "text": "Can you set it in a quiet village in 1600s France?"}]},
      ]
    }' 2> /dev/null
```

Copied the response to the test file and confirmed our current test would fail with the same error message:

![image](https://github.com/sourcegraph/sourcegraph/assets/68532117/0485d38f-0d3c-40de-b641-a679b16fd1f4)

This is now handled by the newly added test with the actually stream response returned by calling the Gemini API.


## Changelog

<!--
1. Ensure your pull request title is formatted as: $type($domain): $what
2. Add bullet list items for each additional detail you want to cover (see example below)
3. You can edit this after the pull request was merged, as long as release shipping it hasn't been promoted to the public.
4. For more information, please see this how-to https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c?

Audience: TS/CSE > Customers > Teammates (in that order).

Cheat sheet: $type = chore|fix|feat $domain: source|search|ci|release|plg|cody|local|...
-->

<!--
Example:

Title: fix(search): parse quotes with the appropriate context
Changelog section:

## Changelog

- When a quote is used with regexp pattern type, then ...
- Refactored underlying code.
-->
