### PR TITLE
fix(search/svelte): Hide diff view when closing bottom panel

### DIFF
--- a/client/web-sveltekit/package.json
+++ b/client/web-sveltekit/package.json
@@ -11,7 +11,7 @@
     "preview": "vite preview",
     "install:browsers": "playwright install",
     "test": "playwright test",
-    "test:dev": "PORT=5173 playwright test --ui",
+    "test:dev": "DISABLE_APP_ASSETS_MOCKING=true PORT=5173 playwright test --ui",
     "test:svelte": "vitest --run",
     "sync": "svelte-kit sync",
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/+layout.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/+layout.svelte
@@ -138,13 +138,11 @@
         }
     })
 
-    async function selectTab(event: { detail: number | null }) {
+    function selectTab(event: { detail: number | null }) {
         trackHistoryPanelTabAction(selectedTab, event.detail)
 
         if (event.detail === null) {
-            const url = new URL($page.url)
-            url.searchParams.delete('rev')
-            await goto(url, { replaceState: true, keepFocus: true, noScroll: true })
+            handleBottomPanelCollapse().catch(() => {})
         }
         selectedTab = event.detail
     }
@@ -155,7 +153,13 @@
         }
     }
 
-    function handleBottomPanelCollapse() {
+    async function handleBottomPanelCollapse() {
+        // Removing the URL parameter causes the diff view to close
+        if ($page.url.searchParams.has('rev')) {
+            const url = new URL($page.url)
+            url.searchParams.delete('rev')
+            await goto(url, { replaceState: true, keepFocus: true, noScroll: true })
+        }
         selectedTab = null
     }
 

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/page.spec.ts
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/page.spec.ts
@@ -248,7 +248,10 @@ test('history panel', async ({ page, sg }) => {
     await expect(page.getByText('Test commit')).toBeHidden()
 })
 
-test('file popover', async ({ page, sg }) => {
+test('file popover', async ({ page, sg }, testInfo) => {
+    // Test needs more time to teardown
+    test.setTimeout(testInfo.timeout * 3000)
+
     await page.goto(`/${repoName}`)
 
     // Open the sidebar


### PR DESCRIPTION
Closes SRCH-496

#63128 added a dedicated button for closing the bottom panel but clicking the button didn't cause the diff view to close. This commit fixes that.

## Test plan

Manual testing.

