### PR TITLE
enterprise-portal: temporarily disable local DB migrate

### DIFF
--- a/cmd/enterprise-portal/internal/database/migrate.go
+++ b/cmd/enterprise-portal/internal/database/migrate.go
@@ -25,7 +25,8 @@ import (
 // the given version.
 func maybeMigrate(ctx context.Context, logger log.Logger, contract runtime.Contract, redisClient *redis.Client, currentVersion string) (err error) {
 	// TODO(jchen): We need to figure otu a way to make local dev more seamless.
-	// Until then, only run migrations in MSP.
+	// Until then, only run migrations in MSP. See
+	// https://linear.app/sourcegraph/issue/CORE-176/enterprise-portal-do-not-require-a-separate-database-in-local-dev
 	if !contract.MSP {
 		return nil
 	}

--- a/cmd/enterprise-portal/internal/database/migrate.go
+++ b/cmd/enterprise-portal/internal/database/migrate.go
@@ -24,6 +24,12 @@ import (
 // maybeMigrate runs the auto-migration for the database when needed based on
 // the given version.
 func maybeMigrate(ctx context.Context, logger log.Logger, contract runtime.Contract, redisClient *redis.Client, currentVersion string) (err error) {
+	// TODO(jchen): We need to figure otu a way to make local dev more seamless.
+	// Until then, only run migrations in MSP.
+	if !contract.MSP {
+		return nil
+	}
+
 	ctx, span := databaseTracer.Start(
 		ctx,
 		"database.maybeMigrate",


### PR DESCRIPTION
Part of CORE-176

Reported in https://sourcegraph.slack.com/archives/C04MYFW01NV/p1718019777829589, let's disable DB migrate to prevent more people hitting into this.


## Test plan

`sg run enterprise-portal` starts without a local database named `enterprise-portal`.
