### PR TITLE
SSC: Fix "Make admin" and "Revoke admin" button actions

### DIFF
--- a/client/web/src/cody/team/TeamMemberList.tsx
+++ b/client/web/src/cody/team/TeamMemberList.tsx
@@ -68,7 +68,7 @@ export const TeamMemberList: FunctionComponent<TeamMemberListProps> = ({
                 })
 
                 try {
-                    const response = await requestSSC(`/team/current/members/${accountId}?newRole=${newRole}`, 'PATCH')
+                    const response = await requestSSC(`/team/current/members`, 'PATCH', {updateMemberRole: {accountId, teamRole: newRole}})
                     if (!response.ok) {
                         setLoading(false)
                         setActionResult({

--- a/client/web/src/cody/team/TeamMemberList.tsx
+++ b/client/web/src/cody/team/TeamMemberList.tsx
@@ -68,7 +68,9 @@ export const TeamMemberList: FunctionComponent<TeamMemberListProps> = ({
                 })
 
                 try {
-                    const response = await requestSSC(`/team/current/members`, 'PATCH', {updateMemberRole: {accountId, teamRole: newRole}})
+                    const response = await requestSSC('/team/current/members', 'PATCH', {
+                        updateMemberRole: { accountId, teamRole: newRole },
+                    })
                     if (!response.ok) {
                         setLoading(false)
                         setActionResult({


### PR DESCRIPTION
Before this PR, the "Make admin" and "Revoke admin" button actions failed with an error.

Now they both work.

## Test plan

Tested both buttons, they work as they should:

![CleanShot 2024-06-10 at 16 27 32@2x](https://github.com/sourcegraph/sourcegraph/assets/2552265/74e20124-2ed6-4201-aafe-7c5a74d977c4)

(Note: the design is to be tweaked)

## Changelog

fix(plg): fixed "Make admin" and "Revoke admin" button actions