### PR TITLE
SSC: Fix checkout links

### DIFF
--- a/client/web/src/cody/subscription/CodySubscriptionPage.tsx
+++ b/client/web/src/cody/subscription/CodySubscriptionPage.tsx
@@ -237,7 +237,7 @@ export const CodySubscriptionPage: React.FunctionComponent<CodySubscriptionPageP
                                         </Button>
                                         <Link
                                             className="text-center"
-                                            to={'/cody/manage/subscription/new'}
+                                            to="/cody/manage/subscription/new"
                                             target="_blank"
                                             rel="noreferrer noopener"
                                             onClick={event => {

--- a/client/web/src/cody/subscription/CodySubscriptionPage.tsx
+++ b/client/web/src/cody/subscription/CodySubscriptionPage.tsx
@@ -227,7 +227,10 @@ export const CodySubscriptionPage: React.FunctionComponent<CodySubscriptionPageP
                                                 // We add ?team=1 to the URL to indicate that the user is creating a team.
                                                 // We can use this info to initialize the UI differently,
                                                 // or even display an entirely different UI.
-                                                const url = new URL('/cody/manage/subscription/new', window.location.origin)
+                                                const url = new URL(
+                                                    '/cody/manage/subscription/new',
+                                                    window.location.origin
+                                                )
                                                 url.searchParams.append('team', '1')
                                                 window.location.href = url.toString()
                                             }}

--- a/client/web/src/cody/subscription/CodySubscriptionPage.tsx
+++ b/client/web/src/cody/subscription/CodySubscriptionPage.tsx
@@ -227,7 +227,7 @@ export const CodySubscriptionPage: React.FunctionComponent<CodySubscriptionPageP
                                                 // We add ?team=1 to the URL to indicate that the user is creating a team.
                                                 // We can use this info to initialize the UI differently,
                                                 // or even display an entirely different UI.
-                                                const url = new URL(manageSubscriptionRedirectURL)
+                                                const url = new URL('/cody/manage/subscription/new', window.location.origin)
                                                 url.searchParams.append('team', '1')
                                                 window.location.href = url.toString()
                                             }}
@@ -237,7 +237,7 @@ export const CodySubscriptionPage: React.FunctionComponent<CodySubscriptionPageP
                                         </Button>
                                         <Link
                                             className="text-center"
-                                            to={manageSubscriptionRedirectURL}
+                                            to={'/cody/manage/subscription/new'}
                                             target="_blank"
                                             rel="noreferrer noopener"
                                             onClick={event => {
@@ -245,7 +245,7 @@ export const CodySubscriptionPage: React.FunctionComponent<CodySubscriptionPageP
                                                 telemetryRecorder.recordEvent('cody.planSelection', 'click', {
                                                     metadata: { tier: 1, team: 0 },
                                                 })
-                                                window.location.href = manageSubscriptionRedirectURL
+                                                navigate('/cody/manage/subscription/new')
                                             }}
                                         >
                                             Upgrade yourself to Pro


### PR DESCRIPTION
The "Create team" and "Upgrade to Pro" links currently point to the old SSC site.

![CleanShot 2024-06-10 at 16 39 44@2x](https://github.com/sourcegraph/sourcegraph/assets/2552265/f6ed070b-e41c-41c7-88e5-fc440270140f)

This PR makes both of them point to the new PLG checkout experience, behind the feature flag.

## Test plan

Tested it manually, both buttons work now as they should

## Changelog

fix(plg): make upgrade links point to the right pages for Teams & Invites