### PR TITLE
[Svelte]: Fix standard click-based popover flow

### DIFF
--- a/client/web-sveltekit/src/lib/Popover.svelte
+++ b/client/web-sveltekit/src/lib/Popover.svelte
@@ -40,7 +40,10 @@
 
     function close(): void {
         clearTimeout(delayTimer)
-        toggle(false)
+
+        if (isOpen) {
+            toggle(false)
+        }
     }
 
     function handleClickOutside(event: { detail: HTMLElement }): void {
@@ -105,8 +108,8 @@
     // unwatch the old trigger and watch the new trigger.
     let oldTrigger: HTMLElement | null
     $: {
-        oldTrigger && unwatchTrigger(oldTrigger)
-        trigger && watchTrigger(trigger)
+        oldTrigger && showOnHover && unwatchTrigger(oldTrigger)
+        trigger && showOnHover && watchTrigger(trigger)
         oldTrigger = trigger
     }
 

--- a/client/web-sveltekit/src/lib/Popover.svelte
+++ b/client/web-sveltekit/src/lib/Popover.svelte
@@ -40,10 +40,7 @@
 
     function close(): void {
         clearTimeout(delayTimer)
-
-        if (isOpen) {
-            toggle(false)
-        }
+        toggle(false)
     }
 
     function handleClickOutside(event: { detail: HTMLElement }): void {


### PR DESCRIPTION
Closes [SRCH-504](https://linear.app/sourcegraph/issue/SRCH-504/popover-click-triggers-are-no-longer-working-properly) 

It seems that this problem was caused by slipped-out showOnHover check for hover-based trigger event listeners 

## Test plan 
Manual testing