### PR TITLE
context: detect if README is required

### DIFF
--- a/internal/search/codycontext/query_parser.go
+++ b/internal/search/codycontext/query_parser.go
@@ -197,7 +197,7 @@ func isLikelySymbol(pattern string) bool {
 
 // matches project names such as "github.com/sourcegraph/sourcegraph or
 // golang/go", but doesn't match file paths with extensions.
-var projectRegex = regexp.MustCompile(`.*/[a-zA-Z0-9_-]+(?:\.?([?!\s]|$))`)
+var projectRegex = regexp.MustCompile(`([a-zA-Z0-9_-]+/[a-zA-Z0-9_-]+)(?:\.?([?!\s]|$))`)
 
 func maybeContainsProjectName(input string) bool {
 	return projectRegex.MatchString(input)

--- a/internal/search/codycontext/query_parser.go
+++ b/internal/search/codycontext/query_parser.go
@@ -195,14 +195,6 @@ func isLikelySymbol(pattern string) bool {
 	return strings.Contains(pattern, "_") || camelCaseRegexp.MatchString(pattern)
 }
 
-// matches project names such as "github.com/sourcegraph/sourcegraph or
-// golang/go", but doesn't match file paths with extensions.
-var projectRegex = regexp.MustCompile(`([a-zA-Z0-9_-]+/[a-zA-Z0-9_-]+)(?:\.?([?!\s]|$))`)
-
-func maybeContainsProjectName(input string) bool {
-	return projectRegex.MatchString(input)
-}
-
 var projectSignifiers = []string{
 	"code",
 	"codebase",
@@ -242,7 +234,7 @@ func needsReadmeContext(input string) bool {
 		}
 	}
 
-	return maybeContainsProjectName(input)
+	return false
 }
 
 const (

--- a/internal/search/codycontext/query_parser.go
+++ b/internal/search/codycontext/query_parser.go
@@ -197,7 +197,7 @@ func isLikelySymbol(pattern string) bool {
 
 // matches project names such as "github.com/sourcegraph/sourcegraph or
 // golang/go", but doesn't match file paths with extensions.
-var projectRegex = regexp.MustCompile(`.*/[^/.]+(?:\.?([?!\s]|$))`)
+var projectRegex = regexp.MustCompile(`.*/[a-zA-Z0-9_-]+(?:\.?([?!\s]|$))`)
 
 func maybeContainsProjectName(input string) bool {
 	return projectRegex.MatchString(input)
@@ -242,11 +242,7 @@ func needsReadmeContext(input string) bool {
 		}
 	}
 
-	if maybeContainsProjectName(input) {
-		return true
-	}
-
-	return false
+	return maybeContainsProjectName(input)
 }
 
 const (

--- a/internal/search/codycontext/query_parser_test.go
+++ b/internal/search/codycontext/query_parser_test.go
@@ -152,22 +152,56 @@ func TestFindSymbols(t *testing.T) {
 	}
 }
 
-func TestExtractEntities(t *testing.T) {
+func TestExpandQuery(t *testing.T) {
 	cases := []struct {
 		queryString string
 		want        []string
 	}{
 		{
 			queryString: "What does this repo do?",
-			want:        []string{entityReadme},
+			want:        []string{kwReadme},
 		},
 		{
 			queryString: "Describe my code",
-			want:        []string{entityReadme},
+			want:        []string{kwReadme},
 		},
 		{
 			queryString: "What does github.com/sourcegraph/zoekt do?",
-			want:        []string{entityReadme},
+			want:        []string{kwReadme},
+		},
+		{
+			queryString: "what does batch-change-buddy/jtest do?",
+			want:        []string{kwReadme},
+		},
+		// Punctuation
+		{
+			queryString: "describe sourcegraph/zoekt",
+			want:        []string{kwReadme},
+		},
+		{
+			queryString: "describe sourcegraph/zoekt.",
+			want:        []string{kwReadme},
+		},
+		{
+			queryString: "describe sourcegraph/zoekt. Details please!",
+			want:        []string{kwReadme},
+		},
+		{
+			queryString: "describe sourcegraph/zoekt!",
+			want:        []string{kwReadme},
+		},
+		// Negative tests
+		{
+			queryString: "what does cmd/update.sh do?",
+			want:        nil,
+		},
+		{
+			queryString: "what does update.sh do?",
+			want:        nil,
+		},
+		{
+			queryString: "explain update.sh",
+			want:        nil,
 		},
 		{
 			queryString: "What is the meaning of life?",
@@ -181,7 +215,7 @@ func TestExtractEntities(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.queryString, func(t *testing.T) {
-			got := extractEntities(c.queryString)
+			got := expandQuery(c.queryString)
 			require.Equal(t, c.want, got)
 		})
 	}

--- a/internal/search/codycontext/query_parser_test.go
+++ b/internal/search/codycontext/query_parser_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/hexops/autogold/v2"
+	"github.com/stretchr/testify/require"
 
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
 )
@@ -147,6 +148,41 @@ func TestFindSymbols(t *testing.T) {
 			if got := findSymbols(tt.patterns); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("findSymbols() = %v, want %v", got, tt.want)
 			}
+		})
+	}
+}
+
+func TestExtractEntities(t *testing.T) {
+	cases := []struct {
+		queryString string
+		want        []string
+	}{
+		{
+			queryString: "What does this repo do?",
+			want:        []string{entityReadme},
+		},
+		{
+			queryString: "Describe my code",
+			want:        []string{entityReadme},
+		},
+		{
+			queryString: "What does github.com/sourcegraph/zoekt do?",
+			want:        []string{entityReadme},
+		},
+		{
+			queryString: "What is the meaning of life?",
+			want:        nil,
+		},
+		{
+			queryString: "Where is my code?",
+			want:        nil,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.queryString, func(t *testing.T) {
+			got := extractEntities(c.queryString)
+			require.Equal(t, c.want, got)
 		})
 	}
 }

--- a/internal/search/codycontext/query_parser_test.go
+++ b/internal/search/codycontext/query_parser_test.go
@@ -166,28 +166,7 @@ func TestExpandQuery(t *testing.T) {
 			want:        []string{kwReadme},
 		},
 		{
-			queryString: "What does github.com/sourcegraph/zoekt do?",
-			want:        []string{kwReadme},
-		},
-		{
-			queryString: "what does batch-change-buddy/jtest do?",
-			want:        []string{kwReadme},
-		},
-		// Punctuation
-		{
-			queryString: "describe sourcegraph/zoekt",
-			want:        []string{kwReadme},
-		},
-		{
-			queryString: "describe sourcegraph/zoekt.",
-			want:        []string{kwReadme},
-		},
-		{
-			queryString: "describe sourcegraph/zoekt. Details please!",
-			want:        []string{kwReadme},
-		},
-		{
-			queryString: "describe sourcegraph/zoekt!",
+			queryString: "Explain what this project is about",
 			want:        []string{kwReadme},
 		},
 		// Negative tests

--- a/internal/search/job/jobutil/job_test.go
+++ b/internal/search/job/jobutil/job_test.go
@@ -1142,7 +1142,7 @@ func TestNewPlanJob(t *testing.T) {
     (originalQuery . )
     (patternType . codycontext)
     (CODYCONTEXTSEARCH
-      (patterns . [symf readme])
+      (patterns . [readme symf])
       (codeCount . 12)
       (textCount . 3))))
 `),

--- a/internal/search/job/jobutil/job_test.go
+++ b/internal/search/job/jobutil/job_test.go
@@ -1113,7 +1113,7 @@ func TestNewPlanJob(t *testing.T) {
 `),
 		},
 		{
-			query:      `context:global repo:sourcegraph/.* what's going on'? lang:go`,
+			query:      `context:global repo:sourcegraph/.* are all things possible? lang:go`,
 			protocol:   search.Streaming,
 			searchType: query.SearchTypeCodyContext,
 			want: autogold.Expect(`
@@ -1142,7 +1142,7 @@ func TestNewPlanJob(t *testing.T) {
     (originalQuery . )
     (patternType . codycontext)
     (CODYCONTEXTSEARCH
-      (patterns . [symf])
+      (patterns . [symf readme])
       (codeCount . 12)
       (textCount . 3))))
 `),


### PR DESCRIPTION
This adds a thin layer to expand a query with keywords which are not explicitly mentioned. As a first application, we detect if a README should be returned. See /vscode/src/chat/chat-view/context.ts for how a similar logic is implemented in the client.


Test plan:
- new and updated unit tests
- Cody web client: I tested the "what does this codebase do?" for `sourcegraph/sourcegraph` and `sourcegraph/zoekt` as selected context. For Zoekt we return `/README.md` in the top 3, which leads to a good answer. The Sourcegraph repo has many README files and our ranking ranks other README files higher, for example if they contain the string "README", which leads to a vague answer.

Addresses SPLF-94