### PR TITLE
sg: cloud eph - set max deployment name

### DIFF
--- a/dev/sg/internal/cloud/deploy_command.go
+++ b/dev/sg/internal/cloud/deploy_command.go
@@ -190,8 +190,9 @@ func determineDeploymentName(originalName, version, email, branch string) string
 		deploymentName = branch
 	}
 
-	return sanitizeInstanceName(deploymentName)
-
+	deploymentName = sanitizeInstanceName(deploymentName)
+	// names can only be max 30 chars
+	return deploymentName[:min(30, len(deploymentName))]
 }
 
 func deployCloudEphemeral(ctx *cli.Context) error {

--- a/dev/sg/internal/cloud/deploy_command.go
+++ b/dev/sg/internal/cloud/deploy_command.go
@@ -246,6 +246,9 @@ Please make sure you have either pushed or pulled the latest changes before tryi
 
 	// note we do not use the version here, we use ORIGINAL version, since it if it is given we create a different deployment name
 	deploymentName := determineDeploymentName(ctx.String("name"), ctx.String("version"), email, currRepo.Branch)
+	if ctx.String("name") != "" && ctx.String("name") != deploymentName {
+		std.Out.WriteNoticef("Your deployment name has been truncated to be %q", deploymentName)
+	}
 	err = createDeploymentForVersion(ctx.Context, email, deploymentName, version)
 	if err != nil {
 		if errors.Is(err, ErrDeploymentExists) {

--- a/dev/sg/internal/cloud/upgrade_command.go
+++ b/dev/sg/internal/cloud/upgrade_command.go
@@ -90,12 +90,14 @@ func upgradeCloudEphemeral(ctx *cli.Context) error {
 	if err != nil {
 		return errors.Wrap(err, "failed to determine current branch")
 	}
-	// if a version is specified we do not build anything and just trigger the cloud deployment
 	email, err := GetGCloudAccount(ctx.Context)
 	if err != nil {
 		return err
 	}
 	deploymentName := determineDeploymentName(ctx.String("name"), version, email, currentBranch)
+	if ctx.String("name") != "" && ctx.String("name") != deploymentName {
+		std.Out.WriteNoticef("Your deployment name has been truncated to be %q", deploymentName)
+	}
 
 	err = upgradeDeploymentForVersion(ctx.Context, email, deploymentName, version)
 	if err != nil {


### PR DESCRIPTION
Encountered this error while doing my demo
```
{"SeverityText":"ERROR","Timestamp":1718110348252114099,"InstrumentationScope":"mi2.instance.create","Caller":"mi2/instance.go:478","Function":"main.glob..func26","Body":"new instance validation failed: slug (displayName) must be between 4 to 30 characters. Allowed characters are: lowercase letters, numbers, hyphen. Current: christoph-resolve-syntactic-symbol-at-request-range","Resource":{"service.name":"mi2","service.version":"2024-06-11-09-50-
```
So now we limit it to 30 chars and print a notice to inform the user that it has been truncated

## Test plan
Tested locally
```
go run ./dev/sg cloud eph deploy --name 'christoph-resolve-syntactic-symbol-at-request-range_277899_2024-06-11_5.4-f04d3b973a19' --version 'christoph-resolve-syntactic-symbol-at-request-range_277899_2024-06-11_5.4-f04d3b973a19'
✅ Version "christoph-resolve-syntactic-symbol-at-request-range_277899_2024-06-11_5.4-f04d3b973a19" found in Cloud ephemeral registry
👉 Your deployment name has been truncated to be "christoph-resolve-syntactic-sy"
```

## Changelog
- sg - set a max length for cloud ephemeral deployment names