### PR TITLE
fix/internal/memcmd: fix goroutine leak in linux observer

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -316,6 +316,7 @@ require (
 	go.opentelemetry.io/collector/config/configtelemetry v0.92.0
 	go.opentelemetry.io/collector/config/configtls v0.92.0
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0
+	go.uber.org/goleak v1.3.0
 	google.golang.org/genproto/googleapis/api v0.0.0-20240318140521-94a12d6c2237
 	gorm.io/driver/postgres v1.5.7
 	gorm.io/gorm v1.25.7-0.20240204074919-46816ad31dde
@@ -436,7 +437,6 @@ require (
 	go.opentelemetry.io/collector/extension v0.92.0 // indirect
 	go.opentelemetry.io/collector/extension/auth v0.92.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.0.1 // indirect
-	go.uber.org/goleak v1.3.0 // indirect
 	golang.org/x/image v0.14.0 // indirect
 	golang.org/x/lint v0.0.0-20210508222113-6edffad5e616 // indirect
 	golang.org/x/tools/go/vcs v0.1.0-deprecated // indirect

--- a/internal/memcmd/BUILD.bazel
+++ b/internal/memcmd/BUILD.bazel
@@ -48,6 +48,7 @@ go_test(
             "@com_github_dustin_go_humanize//:go-humanize",
             "@com_github_google_go_cmp//cmp",
             "@com_github_sourcegraph_conc//pool",
+            "@org_uber_go_goleak//:goleak",
         ],
         "@io_bazel_rules_go//go/platform:darwin": [
             "//internal/bytesize",
@@ -65,6 +66,7 @@ go_test(
             "@com_github_dustin_go_humanize//:go-humanize",
             "@com_github_google_go_cmp//cmp",
             "@com_github_sourcegraph_conc//pool",
+            "@org_uber_go_goleak//:goleak",
         ],
         "//conditions:default": [],
     }),

--- a/internal/memcmd/observer_linux_test.go
+++ b/internal/memcmd/observer_linux_test.go
@@ -15,12 +15,15 @@ import (
 	"github.com/dustin/go-humanize"
 	"github.com/google/go-cmp/cmp"
 	"github.com/sourcegraph/conc/pool"
+	"go.uber.org/goleak"
 
 	"github.com/sourcegraph/sourcegraph/internal/bytesize"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 func TestObserverIntegration(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
 	cmd := allocatingGoProgram(t, 250*1024*1024) // 250 MB
 
 	var buf bytes.Buffer
@@ -59,6 +62,8 @@ func TestObserverIntegration(t *testing.T) {
 }
 
 func TestConvertESRCH(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
 	tests := []struct {
 		name     string
 		err      error
@@ -144,6 +149,8 @@ func TestConvertESRCH(t *testing.T) {
 }
 
 func TestMemoryUsageForPidAndChildren(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
 	ctx := context.Background()
 
 	var spyRSSCalls []int
@@ -205,6 +212,8 @@ func TestMemoryUsageForPidAndChildren(t *testing.T) {
 }
 
 func TestMaxMemoryUsageErrorObserverNotStarted(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
 	cmd := allocatingGoProgram(t, 50*1024*1024) // 50 MB
 	err := cmd.Start()
 	if err != nil {
@@ -265,6 +274,8 @@ func BenchmarkLinuxObservationApproaches(b *testing.B) {
 }
 
 func benchFunc(b *testing.B, observerInterval time.Duration) {
+	defer goleak.VerifyNone(b)
+
 	for range b.N {
 		workerPool := pool.New().WithErrors()
 


### PR DESCRIPTION
There was a goroutine leak in the Linux observation logic. 

https://github.com/sourcegraph/sourcegraph/blob/add4baa455ef86d60b59f7c0182839a7bb2a9e18/internal/memcmd/observer_linux.go#L122-L141

In observe, it was possible for the goroutine that produces collection events on a channel to block forever. If we exit early from the function, it was still possible for the channel to be full (because the consumer exited early), which causes the producer goroutine to block forever since there is no room in the channel. 

This PR fixes this issue by adding a `defer` statement that ensures that collection channel is drained before we exit - thus fixing the leak.



## Test plan

Added goroutine leak dector to linux tests - now see them pass.

## Changelog 

A goroutine leak in the experimental linux memory observation logic has been fixed. 
