### PR TITLE
feat/gitserver: don't log memoryObservation error if it occured due to context cancellation

### DIFF
--- a/internal/memcmd/BUILD.bazel
+++ b/internal/memcmd/BUILD.bazel
@@ -48,6 +48,7 @@ go_test(
             "@com_github_dustin_go_humanize//:go-humanize",
             "@com_github_google_go_cmp//cmp",
             "@com_github_sourcegraph_conc//pool",
+            "@com_github_stretchr_testify//require",
             "@org_uber_go_goleak//:goleak",
         ],
         "@io_bazel_rules_go//go/platform:darwin": [
@@ -66,6 +67,7 @@ go_test(
             "@com_github_dustin_go_humanize//:go-humanize",
             "@com_github_google_go_cmp//cmp",
             "@com_github_sourcegraph_conc//pool",
+            "@com_github_stretchr_testify//require",
             "@org_uber_go_goleak//:goleak",
         ],
         "//conditions:default": [],

--- a/internal/memcmd/observer_linux_test.go
+++ b/internal/memcmd/observer_linux_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/dustin/go-humanize"
 	"github.com/google/go-cmp/cmp"
 	"github.com/sourcegraph/conc/pool"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 
 	"github.com/sourcegraph/sourcegraph/internal/bytesize"
@@ -59,6 +60,34 @@ func TestObserverIntegration(t *testing.T) {
 	if !(memoryLow < memoryUsage && memoryUsage < memoryHigh) {
 		t.Fatalf("memory usage is not in the expected range (low: %s, high: %s): %s", humanize.Bytes(uint64(memoryLow)), humanize.Bytes(uint64(memoryHigh)), humanize.Bytes(uint64(memoryUsage)))
 	}
+}
+func TestErrorMaybeCausedByExplicitStop(t *testing.T) {
+	t.Run("normal context cancellation error", func(t *testing.T) {
+		explicitlyStopped := make(chan struct{})
+
+		require.False(t, errMaybeCausedByExplicitStop(context.Canceled, explicitlyStopped))
+	})
+
+	t.Run("explicit stop", func(t *testing.T) {
+		explicitlyStopped := make(chan struct{})
+		close(explicitlyStopped)
+
+		require.True(t, errMaybeCausedByExplicitStop(context.Canceled, explicitlyStopped))
+	})
+
+	t.Run("stopped, but not cancellation error", func(t *testing.T) {
+		explicitlyStopped := make(chan struct{})
+		close(explicitlyStopped)
+
+		require.False(t, errMaybeCausedByExplicitStop(errors.New("some error"), explicitlyStopped))
+	})
+
+	t.Run("nil error", func(t *testing.T) {
+		explicitlyStopped := make(chan struct{})
+		close(explicitlyStopped)
+
+		require.False(t, errMaybeCausedByExplicitStop(nil, explicitlyStopped))
+	})
 }
 
 func TestConvertESRCH(t *testing.T) {


### PR DESCRIPTION
This PR changes the behavior of the git cli commands to ignore errors from the memory observer if they occurred due to cancellation. Such errors are expected if the user cancels the request, and so there is no reason to generate logspam.

## Test plan

Existing CI tests

This PR only reduces logspam, and as such doesn't need extensive new unit tests.


## Changelog

- Reduce logspam in the gitserver command functionality by ignoring memory observation errors if they occurred due to external context cancellation.