### PR TITLE
feat/gitserver: don't log memoryObservation error if it occured b/c context cancellation

### DIFF
--- a/cmd/gitserver/internal/git/gitcli/command.go
+++ b/cmd/gitserver/internal/git/gitcli/command.go
@@ -313,9 +313,12 @@ func (rc *cmdReader) trace() {
 		sysUsage = *s
 	}
 
-	memUsage, err := rc.memoryObserver.MaxMemoryUsage()
-	if err != nil {
-		rc.logger.Warn("failed to get max memory usage", log.Error(err))
+	memUsage, memoryError := rc.memoryObserver.MaxMemoryUsage()
+	if memoryError != nil {
+		if !(errors.IsContextCanceled(memoryError) && errors.IsContextCanceled(rc.ctx.Err())) {
+			// If the context was canceled, we don't log the error as it's expected.
+			rc.logger.Warn("failed to get max memory usage", log.Error(memoryError))
+		}
 	}
 
 	isSlow := duration > shortGitCommandSlow(rc.cmd.Unwrap().Args)


### PR DESCRIPTION
This PR changes the behavior of the git cli commands to ignore errors from the memory observer if they occurred due to cancellation. Such errors are expected if the user cancels the request, and so there is no reason to generate logspam.

## Test plan

Existing CI tests

This PR only reduces logspam, and as such doesn't need extensive new unit tests.


## Changelog

- Reduce logspam in the gitserver command functionality by ignoring memory observation errors if they occurred due to external context cancellation.