### PR TITLE
fix/internal/memcmd: close the explicit stop channel before cancelling context

### DIFF
--- a/internal/memcmd/observer_linux.go
+++ b/internal/memcmd/observer_linux.go
@@ -115,8 +115,8 @@ func (l *linuxObserver) Start() {
 
 func (l *linuxObserver) Stop() {
 	l.stopOnce.Do(func() {
-		l.cancelFunc()
 		close(l.explicitlyStopped)
+		l.cancelFunc()
 	})
 }
 


### PR DESCRIPTION
This PR tweaks the logic in the linux memory observer that skips over context cancellation errors that occur when we deliberately stop the observer.

https://github.com/sourcegraph/sourcegraph/blob/553b5c55ac60986a3b8d3a1a0ba8b3118f94731b/internal/memcmd/observer_linux.go#L156-L172

Before it was possible for the above code to run after the context was cancelled, but before the explicitlyStopped channel was closed. This would cause the function to incorrectly keep the context cancellation error.

Now, we make sure to close the channel _before_ canceling the context in Stop - thus fixing the above issue. 



## Test plan

Existing unit tests (you can't really test a race condition like this).


## Changelog

This PR fixes a logspam bug in the linux memory observer that was due to do slightly faulty synchronizzation logic.  