### PR TITLE
feat/gitserver: avoid logspam from deadline exceeded memory tracking errors

### DIFF
--- a/cmd/gitserver/internal/git/gitcli/command.go
+++ b/cmd/gitserver/internal/git/gitcli/command.go
@@ -315,7 +315,7 @@ func (rc *cmdReader) trace() {
 
 	memUsage, memoryError := rc.memoryObserver.MaxMemoryUsage()
 	if memoryError != nil {
-		if !(errors.IsContextCanceled(memoryError) && errors.IsContextCanceled(rc.ctx.Err())) {
+		if !(isContextErr(memoryError) && isContextErr(rc.ctx.Err())) {
 			// If the context was canceled, we don't log the error as it's expected.
 			rc.logger.Warn("failed to get max memory usage", log.Error(memoryError))
 		}
@@ -550,4 +550,8 @@ func HoneySampleRate(cmd string, actor *actor.Actor) uint {
 	default:
 		return 8
 	}
+}
+
+func isContextErr(err error) bool {
+	return errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
 }

--- a/cmd/gitserver/internal/git/gitcli/command_test.go
+++ b/cmd/gitserver/internal/git/gitcli/command_test.go
@@ -1,6 +1,7 @@
 package gitcli
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -9,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/sourcegraph/sourcegraph/cmd/gitserver/internal/common"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 func TestMarkRepoMaybeCorrupt(t *testing.T) {
@@ -49,4 +51,45 @@ func getFileMtime(path string) (time.Time, error) {
 		return time.Time{}, err
 	}
 	return info.ModTime(), nil
+}
+
+func TestIsContextErr(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "context canceled",
+			err:      context.Canceled,
+			expected: true,
+		},
+		{
+			name:     "context deadline exceeded",
+			err:      context.DeadlineExceeded,
+			expected: true,
+		},
+		{
+			name:     "other error",
+			err:      errors.New("some other error"),
+			expected: false,
+		},
+		{
+			name:     "multi error",
+			err:      errors.Append(errors.New("foo bar"), context.Canceled),
+			expected: true,
+		},
+		{
+			name:     "nil error",
+			err:      nil,
+			expected: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual := isContextErr(test.err)
+			require.Equal(t, test.expected, actual)
+		})
+	}
 }


### PR DESCRIPTION
This PR tweaks the logic in the gitserver new command logic to avoid printing errors from the memory observer if the context error is deadline exceeded.


## Test plan

Unit tests

## Changelog

- In the gitserver new command logic, logspam from the memory observer when the context error is deadline exceeded will no longer occur.