### PR TITLE
Codenav: use new occurrences API for symbol definitions

### DIFF
--- a/client/shared/src/codeintel/scip.ts
+++ b/client/shared/src/codeintel/scip.ts
@@ -33,7 +33,7 @@ export enum SymbolRole {
 }
 
 export class Position implements sourcegraph.Position {
-    constructor(public readonly line: number, public readonly character: number) { }
+    constructor(public readonly line: number, public readonly character: number) {}
 
     /** @returns this position with incremented line/character values */
     public withIncrementedValues(): Position {
@@ -85,7 +85,7 @@ export class Position implements sourcegraph.Position {
 }
 
 export class Range {
-    constructor(public readonly start: Position, public readonly end: Position) { }
+    constructor(public readonly start: Position, public readonly end: Position) {}
     public static fromNumbers(startLine: number, startCharacter: number, endLine: number, endCharacter: number): Range {
         return new Range(new Position(startLine, startCharacter), new Position(endLine, endCharacter))
     }
@@ -145,7 +145,7 @@ export class Occurrence {
         public readonly kind?: SyntaxKind,
         public readonly symbol?: string,
         public readonly symbolRoles?: number
-    ) { }
+    ) {}
 
     public withStartPosition(newStartPosition: Position): Occurrence {
         return this.withRange(this.range.withStart(newStartPosition))
@@ -163,9 +163,9 @@ export class Occurrence {
             // Handle 3 vs 4 length meaning different things
             occ.range.length === 3
                 ? // 3 means same row
-                new Position(occ.range[0], occ.range[2])
+                  new Position(occ.range[0], occ.range[2])
                 : // 4 means could be different rows
-                new Position(occ.range[2], occ.range[3])
+                  new Position(occ.range[2], occ.range[3])
         )
 
         return new Occurrence(range, occ.syntaxKind, occ.symbol, occ.symbolRoles)

--- a/client/shared/src/codeintel/scip.ts
+++ b/client/shared/src/codeintel/scip.ts
@@ -33,7 +33,7 @@ export enum SymbolRole {
 }
 
 export class Position implements sourcegraph.Position {
-    constructor(public readonly line: number, public readonly character: number) {}
+    constructor(public readonly line: number, public readonly character: number) { }
 
     /** @returns this position with incremented line/character values */
     public withIncrementedValues(): Position {
@@ -85,7 +85,7 @@ export class Position implements sourcegraph.Position {
 }
 
 export class Range {
-    constructor(public readonly start: Position, public readonly end: Position) {}
+    constructor(public readonly start: Position, public readonly end: Position) { }
     public static fromNumbers(startLine: number, startCharacter: number, endLine: number, endCharacter: number): Range {
         return new Range(new Position(startLine, startCharacter), new Position(endLine, endCharacter))
     }
@@ -145,7 +145,7 @@ export class Occurrence {
         public readonly kind?: SyntaxKind,
         public readonly symbol?: string,
         public readonly symbolRoles?: number
-    ) {}
+    ) { }
 
     public withStartPosition(newStartPosition: Position): Occurrence {
         return this.withRange(this.range.withStart(newStartPosition))
@@ -163,9 +163,9 @@ export class Occurrence {
             // Handle 3 vs 4 length meaning different things
             occ.range.length === 3
                 ? // 3 means same row
-                  new Position(occ.range[0], occ.range[2])
+                new Position(occ.range[0], occ.range[2])
                 : // 4 means could be different rows
-                  new Position(occ.range[2], occ.range[3])
+                new Position(occ.range[2], occ.range[3])
         )
 
         return new Occurrence(range, occ.syntaxKind, occ.symbol, occ.symbolRoles)
@@ -180,7 +180,7 @@ export class Occurrence {
 // non-overlapping occurrences.  The most narrow occurrence "wins", meaning that
 // when two ranges overlap, we pick the syntax kind of the occurrence with the
 // shortest distance between start/end.
-function nonOverlappingOccurrences(occurrences: Occurrence[]): Occurrence[] {
+export function nonOverlappingOccurrences(occurrences: Occurrence[]): Occurrence[] {
     // NOTE: we can't guarantee that the occurrences are sorted from the server
     // or after splitting multiline occurrences into single-line occurrences.
     const stack: Occurrence[] = occurrences.sort((a, b) => a.range.compare(b.range)).reverse()

--- a/client/shared/src/codeintel/scip.ts
+++ b/client/shared/src/codeintel/scip.ts
@@ -20,8 +20,20 @@ export interface JsonOccurrence {
     symbolRoles?: number
 }
 
+// Copied from https://github.com/sourcegraph/scip/blob/62966697fbeaccaaf87dab3870c85048d801ca68/scip.proto#L500
+export enum SymbolRole {
+    Unspecified = 0,
+    Definition = 1,
+    Import = 2,
+    WriteAccess = 4,
+    ReadAccess = 8,
+    Generated = 16,
+    Test = 32,
+    ForwardDefinition = 64,
+}
+
 export class Position implements sourcegraph.Position {
-    constructor(public readonly line: number, public readonly character: number) {}
+    constructor(public readonly line: number, public readonly character: number) { }
 
     /** @returns this position with incremented line/character values */
     public withIncrementedValues(): Position {
@@ -73,7 +85,7 @@ export class Position implements sourcegraph.Position {
 }
 
 export class Range {
-    constructor(public readonly start: Position, public readonly end: Position) {}
+    constructor(public readonly start: Position, public readonly end: Position) { }
     public static fromNumbers(startLine: number, startCharacter: number, endLine: number, endCharacter: number): Range {
         return new Range(new Position(startLine, startCharacter), new Position(endLine, endCharacter))
     }
@@ -133,7 +145,7 @@ export class Occurrence {
         public readonly kind?: SyntaxKind,
         public readonly symbol?: string,
         public readonly symbolRoles?: number
-    ) {}
+    ) { }
 
     public withStartPosition(newStartPosition: Position): Occurrence {
         return this.withRange(this.range.withStart(newStartPosition))
@@ -151,9 +163,9 @@ export class Occurrence {
             // Handle 3 vs 4 length meaning different things
             occ.range.length === 3
                 ? // 3 means same row
-                  new Position(occ.range[0], occ.range[2])
+                new Position(occ.range[0], occ.range[2])
                 : // 4 means could be different rows
-                  new Position(occ.range[2], occ.range[3])
+                new Position(occ.range[2], occ.range[3])
         )
 
         return new Occurrence(range, occ.syntaxKind, occ.symbol, occ.symbolRoles)

--- a/client/web-sveltekit/src/lib/CodeMirrorBlob.svelte
+++ b/client/web-sveltekit/src/lib/CodeMirrorBlob.svelte
@@ -129,8 +129,10 @@
     import { EditorView } from '@codemirror/view'
     import { createEventDispatcher, onMount } from 'svelte'
 
-    import { Occurrence, Range as SCIPRange, Position } from '@sourcegraph/shared/src/codeintel/scip'
-    import { codeGraphData as codeGraphDataFacet } from '@sourcegraph/web/src/repo/blob/codemirror/codeintel/occurrences'
+    import {
+        codeGraphData as codeGraphDataFacet,
+        type CodeGraphData,
+    } from '@sourcegraph/web/src/repo/blob/codemirror/codeintel/occurrences'
 
     import { browser } from '$app/environment'
     import { goto } from '$app/navigation'
@@ -164,7 +166,6 @@
         type ScrollSnapshot,
         getScrollSnapshot as getScrollSnapshot_internal,
     } from './codemirror/utils'
-    import type { CodeGraphData } from './graphql-types'
     import { registerHotkey } from './Hotkey'
     import { goToDefinition, openImplementations, openReferences } from './repo/blob'
     import { createLocalWritable } from './stores'
@@ -255,24 +256,7 @@
         : null
     $: lineWrapping = wrapLines ? EditorView.lineWrapping : null
     $: syntaxHighlighting = highlights ? syntaxHighlight.of({ content: blobInfo.content, lsif: highlights }) : null
-    $: codeGraph = codeGraphDataFacet.of(
-        codeGraphData?.map(datum => ({
-            provenance: datum.provenance,
-            occurrences:
-                datum.occurrences?.nodes.map(
-                    occ =>
-                        new Occurrence(
-                            new SCIPRange(
-                                new Position(occ.range.start.line, occ.range.start.character),
-                                new Position(occ.range.end.line, occ.range.end.character)
-                            ),
-                            undefined,
-                            occ.symbol ?? undefined,
-                            undefined // TODO: how to convert to numberic roles?
-                        )
-                ) ?? [],
-        })) ?? []
-    )
+    $: codeGraph = codeGraphDataFacet.of(codeGraphData)
     $: staticHighlightExtension = staticHighlights(staticHighlightRanges)
     $: searchExtension = search({
         overrideBrowserFindInPageShortcut: $useFileSearch,

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/+page.ts
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/+page.ts
@@ -158,11 +158,11 @@ async function loadFileView({ parent, params, url }: PageLoadEvent) {
         // We can ignore the error because if the revision doesn't exist, other queries will fail as well
         revisionOverride: revisionOverride
             ? await client
-                .query(BlobFileViewCommitQuery_revisionOverride, {
-                    repoName,
-                    revspec: revisionOverride,
-                })
-                .then(result => result.data?.repository?.commit)
+                  .query(BlobFileViewCommitQuery_revisionOverride, {
+                      repoName,
+                      revspec: revisionOverride,
+                  })
+                  .then(result => result.data?.repository?.commit)
             : null,
         externalServiceType: parent()
             .then(({ resolvedRevision }) => resolvedRevision.repo?.externalRepository?.serviceType)

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/+page.ts
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/+page.ts
@@ -12,6 +12,7 @@ import type { PageLoad, PageLoadEvent } from './$types'
 import {
     BlobDiffViewCommitQuery,
     BlobFileViewBlobQuery,
+    BlobFileViewCodeGraphDataQuery,
     BlobFileViewCommitQuery_revisionOverride,
     BlobFileViewHighlightedFileQuery,
 } from './page.gql'
@@ -95,6 +96,15 @@ async function loadFileView({ parent, params, url }: PageLoadEvent) {
                 })
             )
             .then(mapOrThrow(result => result.data?.repository?.commit?.blob?.highlight ?? null)),
+        codeGraphData: resolvedRevision
+            .then(resolvedRevision =>
+                client.query(BlobFileViewCodeGraphDataQuery, {
+                    repoName,
+                    revspec: resolvedRevision,
+                    path: filePath,
+                })
+            )
+            .then(mapOrThrow(result => result.data?.repository?.commit?.blob?.codeGraphData ?? null)),
         // We can ignore the error because if the revision doesn't exist, other queries will fail as well
         revisionOverride: revisionOverride
             ? await client

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/+page.ts
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/+page.ts
@@ -193,9 +193,14 @@ async function loadFileView({ parent, params, url }: PageLoadEvent) {
                 })
             )
             .then(mapOrThrow(result => result.data?.repository?.commit?.blob?.highlight ?? null)),
-        codeGraphData: resolvedRevision.then(resolvedRevision =>
-            fetchCodeGraphData(client, repoName, resolvedRevision, filePath)
-        ),
+        codeGraphData: resolvedRevision.then(async resolvedRevision => {
+            console.log((await parent()).settings.experimentalFeatures)
+            if ((await parent()).settings.experimentalFeatures?.enablePreciseOccurrences ?? false) {
+                return fetchCodeGraphData(client, repoName, resolvedRevision, filePath)
+            } else {
+                return []
+            }
+        }),
         // We can ignore the error because if the revision doesn't exist, other queries will fail as well
         revisionOverride: revisionOverride
             ? await client

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/+page.ts
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/+page.ts
@@ -1,9 +1,12 @@
 import { BehaviorSubject, concatMap, from, map } from 'rxjs'
 
+import { Occurrence, Range, Position, SymbolRole } from '@sourcegraph/shared/src/codeintel/scip'
 import { type BlameHunkData, fetchBlameHunksMemoized } from '@sourcegraph/web/src/repo/blame/shared'
+import type { CodeGraphData } from '@sourcegraph/web/src/repo/blob/codemirror/codeintel/occurrences'
 
 import { SourcegraphURL } from '$lib/common'
-import { getGraphQLClient, mapOrThrow } from '$lib/graphql'
+import { getGraphQLClient, mapOrThrow, type GraphQLClient } from '$lib/graphql'
+import { SymbolRole as GraphQLSymbolRole } from '$lib/graphql-types'
 import { resolveRevision } from '$lib/repo/utils'
 import { parseRepoRevision } from '$lib/shared'
 import { assertNonNullable } from '$lib/utils'
@@ -38,6 +41,57 @@ function loadDiffView({ params, url }: PageLoadEvent) {
             })
             .then(mapOrThrow(result => result.data?.repository?.commit ?? null)),
     }
+}
+
+async function fetchCodeGraphData(
+    client: GraphQLClient,
+    repoName: string,
+    resolvedRevision: string,
+    path: string
+): Promise<CodeGraphData[]> {
+    const response = await client.query(BlobFileViewCodeGraphDataQuery, {
+        repoName,
+        revspec: resolvedRevision,
+        path,
+    })
+
+    const rawCodeGraphData = response.data?.repository?.commit?.blob?.codeGraphData
+    if (!rawCodeGraphData) {
+        return []
+    }
+
+    function translateRole(graphQLRole: GraphQLSymbolRole): SymbolRole {
+        switch (graphQLRole) {
+            case GraphQLSymbolRole.DEFINITION:
+                return SymbolRole.Definition
+            case GraphQLSymbolRole.REFERENCE:
+                // TODO: is this correct?
+                return SymbolRole.Import
+            case GraphQLSymbolRole.FORWARD_DEFINITION:
+                return SymbolRole.ForwardDefinition
+            default:
+                return SymbolRole.Unspecified
+        }
+    }
+
+    return (
+        rawCodeGraphData.map(datum => ({
+            provenance: datum.provenance,
+            occurrences:
+                datum.occurrences?.nodes.map(
+                    occ =>
+                        new Occurrence(
+                            new Range(
+                                new Position(occ.range.start.line, occ.range.start.character),
+                                new Position(occ.range.end.line, occ.range.end.character)
+                            ),
+                            undefined,
+                            occ.symbol ?? undefined,
+                            occ.roles?.map(translateRole).reduce((acc, role) => acc | role, 0)
+                        )
+                ) ?? [],
+        })) ?? []
+    )
 }
 
 async function loadFileView({ parent, params, url }: PageLoadEvent) {
@@ -96,23 +150,17 @@ async function loadFileView({ parent, params, url }: PageLoadEvent) {
                 })
             )
             .then(mapOrThrow(result => result.data?.repository?.commit?.blob?.highlight ?? null)),
-        codeGraphData: resolvedRevision
-            .then(resolvedRevision =>
-                client.query(BlobFileViewCodeGraphDataQuery, {
-                    repoName,
-                    revspec: resolvedRevision,
-                    path: filePath,
-                })
-            )
-            .then(mapOrThrow(result => result.data?.repository?.commit?.blob?.codeGraphData ?? null)),
+        codeGraphData: resolvedRevision.then(resolvedRevision =>
+            fetchCodeGraphData(client, repoName, resolvedRevision, filePath)
+        ),
         // We can ignore the error because if the revision doesn't exist, other queries will fail as well
         revisionOverride: revisionOverride
             ? await client
-                  .query(BlobFileViewCommitQuery_revisionOverride, {
-                      repoName,
-                      revspec: revisionOverride,
-                  })
-                  .then(result => result.data?.repository?.commit)
+                .query(BlobFileViewCommitQuery_revisionOverride, {
+                    repoName,
+                    revspec: revisionOverride,
+                })
+                .then(result => result.data?.repository?.commit)
             : null,
         externalServiceType: parent()
             .then(({ resolvedRevision }) => resolvedRevision.repo?.externalRepository?.serviceType)

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/+page.ts
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/+page.ts
@@ -77,6 +77,8 @@ async function fetchCodeGraphData(
     return (
         rawCodeGraphData.map(datum => ({
             provenance: datum.provenance,
+            toolInfo: datum.toolInfo,
+            commit: datum.commit,
             occurrences:
                 datum.occurrences?.nodes.map(
                     occ =>

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/+page.ts
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/+page.ts
@@ -168,11 +168,11 @@ async function loadFileView({ parent, params, url }: PageLoadEvent) {
         // We can ignore the error because if the revision doesn't exist, other queries will fail as well
         revisionOverride: revisionOverride
             ? await client
-                .query(BlobFileViewCommitQuery_revisionOverride, {
-                    repoName,
-                    revspec: revisionOverride,
-                })
-                .then(result => result.data?.repository?.commit)
+                  .query(BlobFileViewCommitQuery_revisionOverride, {
+                      repoName,
+                      revspec: revisionOverride,
+                  })
+                  .then(result => result.data?.repository?.commit)
             : null,
         externalServiceType: parent()
             .then(({ resolvedRevision }) => resolvedRevision.repo?.externalRepository?.serviceType)

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/FileView.gql
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/FileView.gql
@@ -7,6 +7,7 @@ fragment FileViewGitBlob on GitBlob {
     totalLines
     byteSize
 
+
     ...OpenInCodeHostAction
     ...FileIcon_GitBlob
 }
@@ -29,4 +30,24 @@ fragment FileView_ResolvedRevision on Repository {
 fragment FileViewCommit on GitCommit {
     canonicalURL
     abbreviatedOID
+}
+
+fragment FileViewCodeGraphData on CodeGraphData {
+        # TODO(camdencheek): does it actually make sense to paginate here?
+        occurrences(first: 10000) {
+            nodes {
+                symbol
+                range {
+                   start {
+                       line
+                       character
+                   }
+                   end {
+                       line
+                       character
+                   }
+                }
+                roles
+            }
+        }
 }

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/FileView.gql
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/FileView.gql
@@ -42,7 +42,7 @@ fragment FileViewCodeGraphData on CodeGraphData {
     # TODO: I do not think it is possible to use this pagination correctly.
     # We would need a GraphQL ID on the CodeGraphData node to request followup pages
     # for that element of the codeGraphData list
-    occurrences(first: 10000) {
+    occurrences(first: 50000) {
         nodes {
             symbol
             range {

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/FileView.gql
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/FileView.gql
@@ -33,7 +33,16 @@ fragment FileViewCommit on GitCommit {
 }
 
 fragment FileViewCodeGraphData on CodeGraphData {
-        # TODO(camdencheek): does it actually make sense to paginate here?
+        provenance
+        commit
+        toolInfo {
+            name
+            version
+        }
+
+        # TODO: I do not think it is possible to use this pagination correctly.
+        # We would need a GraphQL ID on the CodeGraphData node to request followup pages
+        # for that element of the codeGraphData list
         occurrences(first: 10000) {
             nodes {
                 symbol

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/FileView.gql
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/FileView.gql
@@ -7,7 +7,6 @@ fragment FileViewGitBlob on GitBlob {
     totalLines
     byteSize
 
-
     ...OpenInCodeHostAction
     ...FileIcon_GitBlob
 }
@@ -33,30 +32,30 @@ fragment FileViewCommit on GitCommit {
 }
 
 fragment FileViewCodeGraphData on CodeGraphData {
-        provenance
-        commit
-        toolInfo {
-            name
-            version
-        }
+    provenance
+    commit
+    toolInfo {
+        name
+        version
+    }
 
-        # TODO: I do not think it is possible to use this pagination correctly.
-        # We would need a GraphQL ID on the CodeGraphData node to request followup pages
-        # for that element of the codeGraphData list
-        occurrences(first: 10000) {
-            nodes {
-                symbol
-                range {
-                   start {
-                       line
-                       character
-                   }
-                   end {
-                       line
-                       character
-                   }
+    # TODO: I do not think it is possible to use this pagination correctly.
+    # We would need a GraphQL ID on the CodeGraphData node to request followup pages
+    # for that element of the codeGraphData list
+    occurrences(first: 10000) {
+        nodes {
+            symbol
+            range {
+                start {
+                    line
+                    character
                 }
-                roles
+                end {
+                    line
+                    character
+                }
             }
+            roles
         }
+    }
 }

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/FileView.gql
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/FileView.gql
@@ -32,6 +32,7 @@ fragment FileViewCommit on GitCommit {
 }
 
 fragment FileViewCodeGraphData on CodeGraphData {
+    id
     provenance
     commit
     toolInfo {
@@ -39,23 +40,28 @@ fragment FileViewCodeGraphData on CodeGraphData {
         version
     }
 
-    # TODO: I do not think it is possible to use this pagination correctly.
-    # We would need a GraphQL ID on the CodeGraphData node to request followup pages
-    # for that element of the codeGraphData list
-    occurrences(first: 50000) {
+    occurrences(first: 10000) {
         nodes {
-            symbol
-            range {
-                start {
-                    line
-                    character
-                }
-                end {
-                    line
-                    character
-                }
-            }
-            roles
+            ...FileViewOccurrence
+        }
+        pageInfo {
+            endCursor
+            hasNextPage
         }
     }
+}
+
+fragment FileViewOccurrence on SCIPOccurrence {
+    symbol
+        range {
+            start {
+                line
+                    character
+            }
+            end {
+                line
+                    character
+            }
+        }
+    roles
 }

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/FileView.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/FileView.svelte
@@ -29,7 +29,7 @@
     import markdownStyles from '$lib/wildcard/Markdown.module.scss'
 
     import type { PageData } from './$types'
-    import { FileViewGitBlob, FileViewHighlightedFile } from './FileView.gql'
+    import { FileViewGitBlob, FileViewHighlightedFile, FileViewCodeGraphData } from './FileView.gql'
     import FileViewModeSwitcher from './FileViewModeSwitcher.svelte'
     import OpenInCodeHostAction from './OpenInCodeHostAction.svelte'
     import { CodeViewMode, toCodeViewMode } from './util'
@@ -49,9 +49,11 @@
     const lineWrap = writable<boolean>(false)
     const blobLoader = createPromiseStore<Awaited<PageData['blob']>>()
     const highlightsLoader = createPromiseStore<Awaited<PageData['highlights']>>()
+    const codeGraphDataLoader = createPromiseStore<Awaited<PageData['codeGraphData']>>()
 
     let blob: FileViewGitBlob | null = null
     let highlights: FileViewHighlightedFile | null = null
+    let codeGraphData: FileViewCodeGraphData | null = null
     let cmblob: CodeMirrorBlob | null = null
     let initialScrollPosition: ScrollSnapshot | null = null
     let selectedPosition: LineOrPositionOrRange | null = null
@@ -67,12 +69,14 @@
     } = data)
     $: blobLoader.set(data.blob)
     $: highlightsLoader.set(data.highlights)
+    $: codeGraphDataLoader.set(data.codeGraphData)
 
     $: if (!$blobLoader.pending) {
         // Only update highlights and position after the file content has been loaded.
         // While the file content is loading we show the previous file content.
         blob = $blobLoader.value ?? null
         highlights = $highlightsLoader.pending ? null : $highlightsLoader.value ?? null
+        codeGraphData = $codeGraphDataLoader.pending ? null : $codeGraphDataLoader.value ?? null
         selectedPosition = data.lineOrPosition
     }
     $: fileLoadingError = !$blobLoader.pending && $blobLoader.error
@@ -268,6 +272,7 @@
                     filePath,
                 }}
                 highlights={highlights?.lsif ?? ''}
+                {codeGraphData}
                 showBlame={showBlameView}
                 blameData={$blameData}
                 wrapLines={$lineWrap}

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/FileView.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/FileView.svelte
@@ -30,7 +30,7 @@
     import markdownStyles from '$lib/wildcard/Markdown.module.scss'
 
     import type { PageData } from './$types'
-    import { FileViewGitBlob, FileViewHighlightedFile, FileViewCodeGraphData } from './FileView.gql'
+    import { FileViewGitBlob, FileViewHighlightedFile } from './FileView.gql'
     import FileViewModeSwitcher from './FileViewModeSwitcher.svelte'
     import OpenInCodeHostAction from './OpenInCodeHostAction.svelte'
     import { CodeViewMode, toCodeViewMode } from './util'

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/FileView.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/FileView.svelte
@@ -8,6 +8,7 @@
     import { writable } from 'svelte/store'
 
     import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
+    import type { CodeGraphData } from '@sourcegraph/web/src/repo/blob/codemirror/codeintel/occurrences'
 
     import { goto, preloadData, afterNavigate } from '$app/navigation'
     import { page } from '$app/stores'
@@ -53,7 +54,7 @@
 
     let blob: FileViewGitBlob | null = null
     let highlights: FileViewHighlightedFile | null = null
-    let codeGraphData: FileViewCodeGraphData | null = null
+    let codeGraphData: CodeGraphData[] | null = null
     let cmblob: CodeMirrorBlob | null = null
     let initialScrollPosition: ScrollSnapshot | null = null
     let selectedPosition: LineOrPositionOrRange | null = null
@@ -272,7 +273,7 @@
                     filePath,
                 }}
                 highlights={highlights?.lsif ?? ''}
-                {codeGraphData}
+                codeGraphData={codeGraphData ?? undefined}
                 showBlame={showBlameView}
                 blameData={$blameData}
                 wrapLines={$lineWrap}

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/page.gql
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/page.gql
@@ -48,6 +48,24 @@ query BlobFileViewHighlightedFileQuery(
     }
 }
 
+query BlobFileViewCodeGraphDataQuery(
+    $repoName: String!
+    $revspec: String!
+    $path: String!
+) {
+    repository(name: $repoName) {
+        id
+        commit(rev: $revspec) {
+            id
+            blob(path: $path) {
+                codeGraphData {
+                    ...FileViewCodeGraphData
+                }
+            }
+        }
+    }
+}
+
 query BlobFileViewCommitQuery_revisionOverride($repoName: String!, $revspec: String!) {
     repository(name: $repoName) {
         commit(rev: $revspec) {

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/page.gql
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/page.gql
@@ -48,11 +48,7 @@ query BlobFileViewHighlightedFileQuery(
     }
 }
 
-query BlobFileViewCodeGraphDataQuery(
-    $repoName: String!
-    $revspec: String!
-    $path: String!
-) {
+query BlobFileViewCodeGraphDataQuery($repoName: String!, $revspec: String!, $path: String!) {
     repository(name: $repoName) {
         id
         commit(rev: $revspec) {

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/page.gql
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/page.gql
@@ -62,6 +62,22 @@ query BlobFileViewCodeGraphDataQuery($repoName: String!, $revspec: String!, $pat
     }
 }
 
+query BlobViewCodeGraphDataNextPage($codeGraphDataID: ID!, $after: String!) {
+    node(id: $codeGraphDataID) {
+        ...on CodeGraphData {
+            occurrences(first: 10000, after: $after){
+                nodes {
+                    ...FileViewOccurrence
+                }
+                pageInfo {
+                    endCursor
+                    hasNextPage
+                }
+            }
+        }
+    }
+}
+
 query BlobFileViewCommitQuery_revisionOverride($repoName: String!, $revspec: String!) {
     repository(name: $repoName) {
         commit(rev: $revspec) {

--- a/client/web/BUILD.bazel
+++ b/client/web/BUILD.bazel
@@ -1291,6 +1291,7 @@ ts_project(
         "src/repo/blob/codemirror/codeintel/hover.ts",
         "src/repo/blob/codemirror/codeintel/keybindings.ts",
         "src/repo/blob/codemirror/codeintel/modifier-key.ts",
+        "src/repo/blob/codemirror/codeintel/occurrences.ts",
         "src/repo/blob/codemirror/codeintel/pin.ts",
         "src/repo/blob/codemirror/codeintel/token-selection.ts",
         "src/repo/blob/codemirror/codeintel/tooltips.ts",

--- a/client/web/src/repo/blob/codemirror/codeintel/api.ts
+++ b/client/web/src/repo/blob/codemirror/codeintel/api.ts
@@ -250,7 +250,6 @@ export class CodeIntelAPIAdapter {
 
     public getHoverTooltip(state: EditorState, offset: number): Promise<(Tooltip & { end: number }) | null> {
         const { occurrence, range } = this.findOccurrenceAt(offset, state)
-        console.log({ occurrence, range })
         if (!occurrence || !range) {
             return Promise.resolve(null)
         }

--- a/client/web/src/repo/blob/codemirror/codeintel/api.ts
+++ b/client/web/src/repo/blob/codemirror/codeintel/api.ts
@@ -21,8 +21,7 @@ import type { WebHoverOverlayProps } from '../../../../components/WebHoverOverla
 import { syntaxHighlight } from '../highlight'
 import {
     contains,
-    isInteractiveOccurrence,
-    occurrenceAt,
+    interactiveOccurrenceAt,
     positionAtCmPosition,
     rangeToCmSelection,
     closestOccurrenceByCharacter,
@@ -138,10 +137,7 @@ export class CodeIntelAPIAdapter {
             return fromCache
         }
 
-        let occurrence = occurrenceAt(state, offset) ?? null
-        if (occurrence && !isInteractiveOccurrence(occurrence)) {
-            occurrence = null
-        }
+        const occurrence = interactiveOccurrenceAt(state, offset) ?? null
         const range = occurrence ? rangeToCmSelection(state.doc, occurrence.range) : null
         for (let i = range?.from ?? offset, to = range?.to ?? offset; i <= to; i++) {
             this.occurrenceCache.set(offset, { occurrence, range })

--- a/client/web/src/repo/blob/codemirror/codeintel/api.ts
+++ b/client/web/src/repo/blob/codemirror/codeintel/api.ts
@@ -49,11 +49,11 @@ export interface Location {
 
 export type Definition =
     | {
-          type: 'at-definition' | 'single' | 'multiple'
-          readonly destination: Location
-          readonly from: Location
-          occurrence: Occurrence
-      }
+        type: 'at-definition' | 'single' | 'multiple'
+        readonly destination: Location
+        readonly from: Location
+        occurrence: Occurrence
+    }
     | { type: 'none'; occurrence: Occurrence }
 
 export interface GoToDefinitionOptions {
@@ -250,6 +250,7 @@ export class CodeIntelAPIAdapter {
 
     public getHoverTooltip(state: EditorState, offset: number): Promise<(Tooltip & { end: number }) | null> {
         const { occurrence, range } = this.findOccurrenceAt(offset, state)
+        console.log({ occurrence, range })
         if (!occurrence || !range) {
             return Promise.resolve(null)
         }
@@ -271,9 +272,9 @@ export class CodeIntelAPIAdapter {
                     result === null || result === undefined || result.contents.length === 0
                         ? ''
                         : result.contents
-                              .map(({ value }) => value)
-                              .join('\n\n----\n\n')
-                              .trimEnd()
+                            .map(({ value }) => value)
+                            .join('\n\n----\n\n')
+                            .trimEnd()
                 const precise = isPrecise(result)
                 if (!precise && markdownContents.length > 0 && !isInteractiveOccurrence(occurrence)) {
                     return null
@@ -283,30 +284,30 @@ export class CodeIntelAPIAdapter {
                 }
                 return markdownContents
                     ? {
-                          pos: range.from,
-                          end: range.to,
-                          above: true,
-                          create: view =>
-                              this.config.createTooltipView({
-                                  view,
-                                  token: occurrence.range.withIncrementedValues(),
-                                  hovercardData: this.getHoverActions(view, occurrence, precise).pipe(
-                                      map(actions => ({
-                                          actionsOrError: actions,
-                                          hoverOrError: {
-                                              range: occurrence.range,
-                                              aggregatedBadges: result?.aggregatedBadges,
-                                              contents: [
-                                                  {
-                                                      value: markdownContents,
-                                                      kind: MarkupKind.Markdown,
-                                                  },
-                                              ],
-                                          },
-                                      }))
-                                  ),
-                              }),
-                      }
+                        pos: range.from,
+                        end: range.to,
+                        above: true,
+                        create: view =>
+                            this.config.createTooltipView({
+                                view,
+                                token: occurrence.range.withIncrementedValues(),
+                                hovercardData: this.getHoverActions(view, occurrence, precise).pipe(
+                                    map(actions => ({
+                                        actionsOrError: actions,
+                                        hoverOrError: {
+                                            range: occurrence.range,
+                                            aggregatedBadges: result?.aggregatedBadges,
+                                            contents: [
+                                                {
+                                                    value: markdownContents,
+                                                    kind: MarkupKind.Markdown,
+                                                },
+                                            ],
+                                        },
+                                    }))
+                                ),
+                            }),
+                    }
                     : null
             })
 

--- a/client/web/src/repo/blob/codemirror/codeintel/api.ts
+++ b/client/web/src/repo/blob/codemirror/codeintel/api.ts
@@ -49,11 +49,11 @@ export interface Location {
 
 export type Definition =
     | {
-        type: 'at-definition' | 'single' | 'multiple'
-        readonly destination: Location
-        readonly from: Location
-        occurrence: Occurrence
-    }
+          type: 'at-definition' | 'single' | 'multiple'
+          readonly destination: Location
+          readonly from: Location
+          occurrence: Occurrence
+      }
     | { type: 'none'; occurrence: Occurrence }
 
 export interface GoToDefinitionOptions {
@@ -272,9 +272,9 @@ export class CodeIntelAPIAdapter {
                     result === null || result === undefined || result.contents.length === 0
                         ? ''
                         : result.contents
-                            .map(({ value }) => value)
-                            .join('\n\n----\n\n')
-                            .trimEnd()
+                              .map(({ value }) => value)
+                              .join('\n\n----\n\n')
+                              .trimEnd()
                 const precise = isPrecise(result)
                 if (!precise && markdownContents.length > 0 && !isInteractiveOccurrence(occurrence)) {
                     return null
@@ -284,30 +284,30 @@ export class CodeIntelAPIAdapter {
                 }
                 return markdownContents
                     ? {
-                        pos: range.from,
-                        end: range.to,
-                        above: true,
-                        create: view =>
-                            this.config.createTooltipView({
-                                view,
-                                token: occurrence.range.withIncrementedValues(),
-                                hovercardData: this.getHoverActions(view, occurrence, precise).pipe(
-                                    map(actions => ({
-                                        actionsOrError: actions,
-                                        hoverOrError: {
-                                            range: occurrence.range,
-                                            aggregatedBadges: result?.aggregatedBadges,
-                                            contents: [
-                                                {
-                                                    value: markdownContents,
-                                                    kind: MarkupKind.Markdown,
-                                                },
-                                            ],
-                                        },
-                                    }))
-                                ),
-                            }),
-                    }
+                          pos: range.from,
+                          end: range.to,
+                          above: true,
+                          create: view =>
+                              this.config.createTooltipView({
+                                  view,
+                                  token: occurrence.range.withIncrementedValues(),
+                                  hovercardData: this.getHoverActions(view, occurrence, precise).pipe(
+                                      map(actions => ({
+                                          actionsOrError: actions,
+                                          hoverOrError: {
+                                              range: occurrence.range,
+                                              aggregatedBadges: result?.aggregatedBadges,
+                                              contents: [
+                                                  {
+                                                      value: markdownContents,
+                                                      kind: MarkupKind.Markdown,
+                                                  },
+                                              ],
+                                          },
+                                      }))
+                                  ),
+                              }),
+                      }
                     : null
             })
 

--- a/client/web/src/repo/blob/codemirror/codeintel/api.ts
+++ b/client/web/src/repo/blob/codemirror/codeintel/api.ts
@@ -271,10 +271,7 @@ export class CodeIntelAPIAdapter {
                               .join('\n\n----\n\n')
                               .trimEnd()
                 const precise = isPrecise(result)
-                if (!precise && markdownContents.length > 0 && !isInteractiveOccurrence(occurrence)) {
-                    return null
-                }
-                if (markdownContents === '' && isInteractiveOccurrence(occurrence)) {
+                if (markdownContents === '') {
                     markdownContents = 'No hover information available'
                 }
                 return markdownContents

--- a/client/web/src/repo/blob/codemirror/codeintel/occurrences.ts
+++ b/client/web/src/repo/blob/codemirror/codeintel/occurrences.ts
@@ -1,5 +1,3 @@
-// TODO: document that this is the new way to do things
-
 import { Facet } from '@codemirror/state'
 
 import { Occurrence } from '@sourcegraph/shared/src/codeintel/scip'
@@ -11,8 +9,11 @@ export interface CodeGraphData {
         name: string | null
         version: string | null
     } | null
-    // Guaranteed to be sorted by range
+    // The raw occurrences as returned by the API
     occurrences: Occurrence[]
+    // The same as occurrences, but flattened so there are no overlapping
+    // ranges.
+    nonOverlappingOccurrences: Occurrence[]
 }
 
 export const codeGraphData = Facet.define<CodeGraphData[], CodeGraphData[]>({

--- a/client/web/src/repo/blob/codemirror/codeintel/occurrences.ts
+++ b/client/web/src/repo/blob/codemirror/codeintel/occurrences.ts
@@ -6,10 +6,11 @@ import { Occurrence } from '@sourcegraph/shared/src/codeintel/scip'
 
 export interface CodeGraphData {
     provenance: string
-    toolInfo?: {
-        name?: string
-        version?: string
-    }
+    commit: string
+    toolInfo: {
+        name: string | null
+        version: string | null
+    } | null
     // Guaranteed to be sorted by range
     occurrences: Occurrence[]
 }

--- a/client/web/src/repo/blob/codemirror/codeintel/occurrences.ts
+++ b/client/web/src/repo/blob/codemirror/codeintel/occurrences.ts
@@ -16,7 +16,10 @@ export interface CodeGraphData {
     nonOverlappingOccurrences: Occurrence[]
 }
 
+// A facet that contains the precise code graph data from the occurrences API.
+// It just retains the most recent contribution. At some point, we should
+// probably extend this to be able to accept contributions from multiple
+// sources.
 export const codeGraphData = Facet.define<CodeGraphData[], CodeGraphData[]>({
-    static: true,
     combine: values => values[0] ?? [],
 })

--- a/client/web/src/repo/blob/codemirror/codeintel/occurrences.ts
+++ b/client/web/src/repo/blob/codemirror/codeintel/occurrences.ts
@@ -9,10 +9,10 @@ export interface CodeGraphData {
         name: string | null
         version: string | null
     } | null
-    // The raw occurrences as returned by the API
+    // The raw occurrences as returned by the API. Guaranteed to be sorted.
     occurrences: Occurrence[]
     // The same as occurrences, but flattened so there are no overlapping
-    // ranges.
+    // ranges. Guaranteed to be sorted.
     nonOverlappingOccurrences: Occurrence[]
 }
 

--- a/client/web/src/repo/blob/codemirror/codeintel/occurrences.ts
+++ b/client/web/src/repo/blob/codemirror/codeintel/occurrences.ts
@@ -5,13 +5,16 @@ import { Facet } from '@codemirror/state'
 import { Occurrence } from '@sourcegraph/shared/src/codeintel/scip'
 
 export interface CodeGraphData {
-    // TODO: add other relevant information here?
     provenance: string
+    toolInfo?: {
+        name?: string
+        version?: string
+    }
+    // Guaranteed to be sorted by range
     occurrences: Occurrence[]
 }
 
 export const codeGraphData = Facet.define<CodeGraphData[], CodeGraphData[]>({
     static: true,
-    // TODO: generate an index for efficient lookups
-    combine: values => values[0],
+    combine: values => values[0] ?? [],
 })

--- a/client/web/src/repo/blob/codemirror/codeintel/occurrences.ts
+++ b/client/web/src/repo/blob/codemirror/codeintel/occurrences.ts
@@ -1,0 +1,17 @@
+// TODO: document that this is the new way to do things
+
+import { Facet } from '@codemirror/state'
+
+import { Occurrence } from '@sourcegraph/shared/src/codeintel/scip'
+
+export interface CodeGraphData {
+    // TODO: add other relevant information here?
+    provenance: string
+    occurrences: Occurrence[]
+}
+
+export const codeGraphData = Facet.define<CodeGraphData[], CodeGraphData[]>({
+    static: true,
+    // TODO: generate an index for efficient lookups
+    combine: values => values[0],
+})

--- a/client/web/src/repo/blob/codemirror/occurrence-utils.ts
+++ b/client/web/src/repo/blob/codemirror/occurrence-utils.ts
@@ -28,9 +28,6 @@ const INTERACTIVE_OCCURRENCE_KINDS = new Set([
 ])
 
 export const isInteractiveOccurrence = (occurrence: Occurrence): boolean => {
-    if (occurrence.symbolRoles !== undefined && occurrence.symbolRoles > 0) {
-        return true
-    }
     if (!occurrence.kind) {
         return false
     }
@@ -38,7 +35,7 @@ export const isInteractiveOccurrence = (occurrence: Occurrence): boolean => {
     return INTERACTIVE_OCCURRENCE_KINDS.has(occurrence.kind)
 }
 
-export function occurrenceAt(state: EditorState, offset: number): Occurrence | undefined {
+export function interactiveOccurrenceAt(state: EditorState, offset: number): Occurrence | undefined {
     const position = positionAtCmPosition(state.doc, offset)
 
     // First we try to get an occurrence from the occurrences API
@@ -49,13 +46,18 @@ export function occurrenceAt(state: EditorState, offset: number): Occurrence | u
 
     // Next we try to get an occurrence from syntax highlighting data.
     const fromHighlighting = highlightingOccurrenceAtPosition(state, position)
-    if (fromHighlighting) {
+    if (fromHighlighting && isInteractiveOccurrence(fromHighlighting)) {
         return fromHighlighting
     }
 
     // If the syntax highlighting data is incomplete then we fallback to a
     // heursitic to infer the occurrence.
-    return inferOccurrenceAtOffset(state, offset)
+    const fromWords = inferOccurrenceAtOffset(state, offset)
+    if (fromWords && isInteractiveOccurrence(fromWords)) {
+        return fromWords
+    }
+
+    return undefined
 }
 
 // Returns the occurrence at this position based on syntax highlighting data.

--- a/client/web/src/repo/blob/codemirror/occurrence-utils.ts
+++ b/client/web/src/repo/blob/codemirror/occurrence-utils.ts
@@ -1,13 +1,7 @@
 import { EditorSelection, type Text, type EditorState, type SelectionRange } from '@codemirror/state'
 
 import type { Range } from '@sourcegraph/extension-api-types'
-import {
-    Occurrence,
-    Position,
-    Range as ScipRange,
-    SymbolRole,
-    SyntaxKind,
-} from '@sourcegraph/shared/src/codeintel/scip'
+import { Occurrence, Position, Range as ScipRange, SyntaxKind } from '@sourcegraph/shared/src/codeintel/scip'
 
 import { CodeGraphData, codeGraphData } from './codeintel/occurrences'
 import { type HighlightIndex, syntaxHighlight } from './highlight'
@@ -33,13 +27,8 @@ const INTERACTIVE_OCCURRENCE_KINDS = new Set([
 ])
 
 export const isInteractiveOccurrence = (occurrence: Occurrence): boolean => {
-    if (occurrence.symbolRoles) {
-        // TODO: is this actually correct?
-        return (
-            (occurrence.symbolRoles &
-                (SymbolRole.Definition | SymbolRole.Import | SymbolRole.ReadAccess | SymbolRole.WriteAccess)) >
-            0
-        )
+    if (occurrence.symbolRoles !== undefined && occurrence.symbolRoles > 0) {
+        return true
     }
     if (!occurrence.kind) {
         return false

--- a/client/web/src/repo/blob/codemirror/occurrence-utils.ts
+++ b/client/web/src/repo/blob/codemirror/occurrence-utils.ts
@@ -1,4 +1,5 @@
 import { EditorSelection, type Text, type EditorState, type SelectionRange } from '@codemirror/state'
+import { sortedIndexBy } from 'lodash'
 
 import type { Range } from '@sourcegraph/extension-api-types'
 import { Occurrence, Position, Range as ScipRange, SyntaxKind } from '@sourcegraph/shared/src/codeintel/scip'
@@ -81,11 +82,13 @@ function highlightingOccurrenceAtPosition(state: EditorState, position: Position
 // TODO: document
 function scipOccurrenceAtPosition(data: CodeGraphData[], position: Position): Occurrence | undefined {
     for (const datum of data) {
-        for (const occurrence of datum.occurrences) {
-            if (occurrence.range.contains(position)) {
-                return occurrence
+        sortedIndexBy<Occurrence | Position>(datum.nonOverlappingOccurrences, position, (occOrPosition): Position => {
+            if (occOrPosition instanceof Position) {
+                return occOrPosition
+            } else {
+                return occOrPosition.range.start
             }
-        }
+        })
     }
     return undefined
 }

--- a/client/web/src/repo/blob/codemirror/occurrence-utils.ts
+++ b/client/web/src/repo/blob/codemirror/occurrence-utils.ts
@@ -85,7 +85,8 @@ function scipOccurrenceAtPosition(data: CodeGraphData[], position: Position): Oc
             const mid = Math.floor((low + high) / 2)
             if (arr[mid].range.contains(position)) {
                 return arr[mid]
-            } else if (arr[mid].range.end.compare(position) < 0) {
+            }
+            if (arr[mid].range.end.compare(position) < 0) {
                 low = mid + 1
             } else {
                 high = mid

--- a/client/web/src/repo/blob/codemirror/occurrence-utils.ts
+++ b/client/web/src/repo/blob/codemirror/occurrence-utils.ts
@@ -79,16 +79,28 @@ function highlightingOccurrenceAtPosition(state: EditorState, position: Position
     return undefined
 }
 
-// TODO: document
+// Returns the occurrence at this position based on data from the GraphQL occurrences API.
 function scipOccurrenceAtPosition(data: CodeGraphData[], position: Position): Occurrence | undefined {
     for (const datum of data) {
-        sortedIndexBy<Occurrence | Position>(datum.nonOverlappingOccurrences, position, (occOrPosition): Position => {
-            if (occOrPosition instanceof Position) {
-                return occOrPosition
-            } else {
-                return occOrPosition.range.start
+        const idx = sortedIndexBy<Occurrence | Position>(
+            datum.nonOverlappingOccurrences,
+            position,
+            (occOrPosition): Position => {
+                // Note: sortedIndexBy expects the array and the target element
+                // to have the same type, but we have a position and not an
+                // occurrence. The transform func is used for both the array
+                // elements and the target element, so we switch on the type
+                // here.
+                if (occOrPosition instanceof Position) {
+                    return occOrPosition
+                } else {
+                    return occOrPosition.range.start
+                }
             }
-        })
+        )
+        if (datum.nonOverlappingOccurrences[idx].range.contains(position)) {
+            return datum.nonOverlappingOccurrences[idx]
+        }
     }
     return undefined
 }

--- a/client/web/src/repo/blob/codemirror/occurrence-utils.ts
+++ b/client/web/src/repo/blob/codemirror/occurrence-utils.ts
@@ -26,7 +26,7 @@ const INTERACTIVE_OCCURRENCE_KINDS = new Set([
     SyntaxKind.IdentifierAttribute,
 ])
 
-function isInteractiveOccurrence(occurrence: Occurrence): boolean {
+const isInteractiveOccurrence = (occurrence: Occurrence): boolean => {
     if (!occurrence.kind) {
         return false
     }

--- a/client/web/src/repo/blob/codemirror/occurrence-utils.ts
+++ b/client/web/src/repo/blob/codemirror/occurrence-utils.ts
@@ -1,7 +1,13 @@
 import { EditorSelection, type Text, type EditorState, type SelectionRange } from '@codemirror/state'
 
 import type { Range } from '@sourcegraph/extension-api-types'
-import { Occurrence, Position, Range as ScipRange, SyntaxKind } from '@sourcegraph/shared/src/codeintel/scip'
+import {
+    Occurrence,
+    Position,
+    Range as ScipRange,
+    SymbolRole,
+    SyntaxKind,
+} from '@sourcegraph/shared/src/codeintel/scip'
 
 import { codeGraphData } from './codeintel/occurrences'
 import { type HighlightIndex, syntaxHighlight } from './highlight'
@@ -27,6 +33,14 @@ const INTERACTIVE_OCCURRENCE_KINDS = new Set([
 ])
 
 export const isInteractiveOccurrence = (occurrence: Occurrence): boolean => {
+    if (occurrence.symbolRoles) {
+        // TODO: is this actually correct?
+        return (
+            (occurrence.symbolRoles &
+                (SymbolRole.Definition | SymbolRole.Import | SymbolRole.ReadAccess | SymbolRole.WriteAccess)) >
+            0
+        )
+    }
     if (!occurrence.kind) {
         return false
     }
@@ -77,9 +91,11 @@ function highlightingOccurrenceAtPosition(state: EditorState, offset: number): O
 function scipOccurrenceAtPosition(state: EditorState, offset: number): Occurrence | undefined {
     const position = positionAtCmPosition(state.doc, offset)
     const data = state.facet(codeGraphData)
+    console.log(data)
     for (const datum of data) {
         for (const occurrence of datum.occurrences) {
             if (occurrence.range.contains(position)) {
+                console.log({ occurrence })
                 return occurrence
             }
         }

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -2543,6 +2543,8 @@ type SettingsExperimentalFeatures struct {
 	EnableLazyBlobSyntaxHighlighting *bool `json:"enableLazyBlobSyntaxHighlighting,omitempty"`
 	// EnableLazyFileResultSyntaxHighlighting description: Fetch un-highlighted file result contents to render immediately, decorate with syntax highlighting once loaded.
 	EnableLazyFileResultSyntaxHighlighting *bool `json:"enableLazyFileResultSyntaxHighlighting,omitempty"`
+	// EnablePreciseOccurrences description: Enable the new precise occurrences API, which can provide more accurate hovers for some languages.
+	EnablePreciseOccurrences bool `json:"enablePreciseOccurrences,omitempty"`
 	// EnableSearchFilePrefetch description: Pre-fetch plaintext file revisions from search results on hover/focus.
 	EnableSearchFilePrefetch *bool `json:"enableSearchFilePrefetch,omitempty"`
 	// EnableSidebarFilePrefetch description: Pre-fetch plaintext file revisions from sidebar on hover/focus.
@@ -2625,6 +2627,7 @@ func (v *SettingsExperimentalFeatures) UnmarshalJSON(data []byte) error {
 	delete(m, "codeMonitoringWebHooks")
 	delete(m, "enableLazyBlobSyntaxHighlighting")
 	delete(m, "enableLazyFileResultSyntaxHighlighting")
+	delete(m, "enablePreciseOccurrences")
 	delete(m, "enableSearchFilePrefetch")
 	delete(m, "enableSidebarFilePrefetch")
 	delete(m, "fuzzyFinder")

--- a/schema/settings.schema.json
+++ b/schema/settings.schema.json
@@ -227,6 +227,11 @@
           "description": "Whether to enable the 'keyword search' language improvement",
           "type": "boolean",
           "default": true
+        },
+        "enablePreciseOccurrences": {
+          "description": "Enable the new precise occurrences API, which can provide more accurate hovers for some languages.",
+          "type": "boolean",
+          "default": true
         }
       },
       "group": "Experimental"


### PR DESCRIPTION
This integrates the new occurrences API into the Svelte webapp. This fixes a number of issues where the syntax highlighting data is not an accurate way to determine hoverable tokens.

(In the Svelte app only:)
Fixes SRCH-582
Fixes SRCH-162 (validated)
Fixes SRCH-299 (validated)
Fixes SRCH-223 (not validated -- do we know of any groovy repos we have with precise indexing set up?)

Missing any?

# Test plan

A bunch of manual testing that the files referenced in those issues now use the data from the occurrences API to provide more accurate hoverable token info. Once release tests are live, I plan to make a few end-to-end tests for all this. I attempted to make a playwright integration test for the hover ranges, but it turns out that it's quite difficult to target a specific text range in playwright. I've added it to my list for our next pairing time.
