### PR TITLE
chore: Add GitBlobResolver and GitTreeResolver for readability

### DIFF
--- a/cmd/frontend/graphqlbackend/batches.go
+++ b/cmd/frontend/graphqlbackend/batches.go
@@ -715,7 +715,7 @@ type BatchWorkspaceFileResolver interface {
 	Highlight(ctx context.Context, args *HighlightArgs) (*HighlightedFileResolver, error)
 	Languages() ([]string, error)
 
-	ToGitBlob() (*GitTreeEntryResolver, bool)
+	ToGitBlob() (*GitBlobResolver, bool)
 	ToVirtualFile() (*VirtualFileResolver, bool)
 	ToBatchSpecWorkspaceFile() (BatchWorkspaceFileResolver, bool)
 }

--- a/cmd/frontend/graphqlbackend/file.go
+++ b/cmd/frontend/graphqlbackend/file.go
@@ -26,7 +26,7 @@ type FileResolver interface {
 	Highlight(ctx context.Context, args *HighlightArgs) (*HighlightedFileResolver, error)
 	Languages(ctx context.Context) ([]string, error)
 
-	ToGitBlob() (*GitTreeEntryResolver, bool)
+	ToGitBlob() (*GitBlobResolver, bool)
 	ToVirtualFile() (*VirtualFileResolver, bool)
 	ToBatchSpecWorkspaceFile() (BatchWorkspaceFileResolver, bool)
 }

--- a/cmd/frontend/graphqlbackend/git_tree_entry.go
+++ b/cmd/frontend/graphqlbackend/git_tree_entry.go
@@ -53,6 +53,26 @@ type GitTreeEntryResolver struct {
 	stat fs.FileInfo
 }
 
+// GitBlobResolver is a thin wrapper around GitTreeEntryResolver for readability.
+//
+// We embed GitTreeEntryResolver to avoid needing to forward method implementations.
+//
+// Since most of the logic is shared between GitBlobResolver and GitTreeResolver,
+// prefer adding new functionality on GitTreeEntryResolver directly.
+type GitBlobResolver struct {
+	*GitTreeEntryResolver
+}
+
+// GitTreeResolver is a thin wrapper around GitTreeEntryResolver for readability.
+//
+// We embed GitTreeEntryResolver to avoid needing to forward method implementations.
+//
+// Since most of the logic is shared between GitBlobResolver and GitTreeResolver,
+// prefer adding new functionality on GitTreeEntryResolver directly.
+type GitTreeResolver struct {
+	*GitTreeEntryResolver
+}
+
 type GitTreeEntryResolverOpts struct {
 	Commit *GitCommitResolver
 	Stat   fs.FileInfo
@@ -75,8 +95,13 @@ func NewGitTreeEntryResolver(db database.DB, gitserverClient gitserver.Client, o
 func (r *GitTreeEntryResolver) Path() string { return r.stat.Name() }
 func (r *GitTreeEntryResolver) Name() string { return path.Base(r.stat.Name()) }
 
-func (r *GitTreeEntryResolver) ToGitTree() (*GitTreeEntryResolver, bool) { return r, r.IsDirectory() }
-func (r *GitTreeEntryResolver) ToGitBlob() (*GitTreeEntryResolver, bool) { return r, !r.IsDirectory() }
+func (r *GitTreeEntryResolver) ToGitTree() (*GitTreeResolver, bool) {
+	return &GitTreeResolver{r}, r.IsDirectory()
+}
+
+func (r *GitTreeEntryResolver) ToGitBlob() (*GitBlobResolver, bool) {
+	return &GitBlobResolver{r}, !r.IsDirectory()
+}
 
 func (r *GitTreeEntryResolver) ToVirtualFile() (*VirtualFileResolver, bool) { return nil, false }
 func (r *GitTreeEntryResolver) ToBatchSpecWorkspaceFile() (BatchWorkspaceFileResolver, bool) {

--- a/cmd/frontend/graphqlbackend/repository_comparison_test.go
+++ b/cmd/frontend/graphqlbackend/repository_comparison_test.go
@@ -1097,7 +1097,7 @@ func (d *dummyFileResolver) Languages(ctx context.Context) ([]string, error) {
 	})
 }
 
-func (d *dummyFileResolver) ToGitBlob() (*GitTreeEntryResolver, bool) {
+func (d *dummyFileResolver) ToGitBlob() (*GitBlobResolver, bool) {
 	return nil, false
 }
 

--- a/cmd/frontend/graphqlbackend/virtual_file.go
+++ b/cmd/frontend/graphqlbackend/virtual_file.go
@@ -45,7 +45,7 @@ func (r *VirtualFileResolver) Path() string      { return r.stat.Name() }
 func (r *VirtualFileResolver) Name() string      { return path.Base(r.stat.Name()) }
 func (r *VirtualFileResolver) IsDirectory() bool { return r.stat.Mode().IsDir() }
 
-func (r *VirtualFileResolver) ToGitBlob() (*GitTreeEntryResolver, bool)    { return nil, false }
+func (r *VirtualFileResolver) ToGitBlob() (*GitBlobResolver, bool)         { return nil, false }
 func (r *VirtualFileResolver) ToVirtualFile() (*VirtualFileResolver, bool) { return r, true }
 func (r *VirtualFileResolver) ToBatchSpecWorkspaceFile() (BatchWorkspaceFileResolver, bool) {
 	return nil, false

--- a/cmd/frontend/internal/batches/resolvers/batch_spec_workspace_file.go
+++ b/cmd/frontend/internal/batches/resolvers/batch_spec_workspace_file.go
@@ -140,7 +140,7 @@ func (r *batchSpecWorkspaceFileResolver) Highlight(ctx context.Context, args *gr
 	return vfr.Highlight(ctx, args)
 }
 
-func (r *batchSpecWorkspaceFileResolver) ToGitBlob() (*graphqlbackend.GitTreeEntryResolver, bool) {
+func (r *batchSpecWorkspaceFileResolver) ToGitBlob() (*graphqlbackend.GitBlobResolver, bool) {
 	return nil, false
 }
 

--- a/cmd/frontend/internal/batches/resolvers/batch_spec_workspace_file_test.go
+++ b/cmd/frontend/internal/batches/resolvers/batch_spec_workspace_file_test.go
@@ -61,7 +61,7 @@ func (m *mockFileResolver) Highlight(ctx context.Context, highlightArgs *graphql
 	return nil, args.Error(1)
 }
 
-func (m *mockFileResolver) ToGitBlob() (*graphqlbackend.GitTreeEntryResolver, bool) {
+func (m *mockFileResolver) ToGitBlob() (*graphqlbackend.GitBlobResolver, bool) {
 	return nil, false
 }
 func (m *mockFileResolver) ToVirtualFile() (*graphqlbackend.VirtualFileResolver, bool) {

--- a/internal/codeintel/resolvers/git.go
+++ b/internal/codeintel/resolvers/git.go
@@ -1,3 +1,8 @@
+// Package resolvers contains slimmed down copies of some of
+// the resolvers in the jumbo graphqlbackend package.
+//
+// Ideally, we would not have these duplicate copies at all,
+// so avoid adding new functionality here.
 package resolvers
 
 import (
@@ -54,6 +59,20 @@ type GitTreeEntryResolver interface {
 	Name() string
 	URL() string
 	Content(ctx context.Context, args *GitTreeContentPageArgs) (string, error)
+}
+
+// GitBlobResolver is a thin wrapper around GitTreeEntryResolver for readability.
+//
+// By embedding GitTreeEntryResolver, we enable seamless conversion between the interfaces.
+type GitBlobResolver interface {
+	GitTreeEntryResolver
+}
+
+// GitTreeResolver is a thin wrapper around GitTreeEntryResolver for readability.
+//
+// By embedding GitTreeEntryResolver, we enable seamless conversion between the interfaces.
+type GitTreeResolver interface {
+	GitTreeEntryResolver
 }
 
 type GitTreeContentPageArgs struct {

--- a/internal/codeintel/shared/resolvers/gitresolvers/tree_entry.go
+++ b/internal/codeintel/shared/resolvers/gitresolvers/tree_entry.go
@@ -42,14 +42,14 @@ func NewGitTreeEntryResolver(commit resolvers.GitCommitResolver, path string, is
 	}
 }
 
-func (r *treeEntryResolver) Repository() resolvers.RepositoryResolver          { return r.commit.Repository() }
-func (r *treeEntryResolver) Commit() resolvers.GitCommitResolver               { return r.commit }
-func (r *treeEntryResolver) Path() string                                      { return r.path }
-func (r *treeEntryResolver) Name() string                                      { return stdpath.Base(r.path) }
-func (r *treeEntryResolver) URL() string                                       { return r.commit.URI() + r.uriSuffix }
-func (r *treeEntryResolver) RecordID() string                                  { return r.path }
-func (r *treeEntryResolver) ToGitTree() (resolvers.GitTreeEntryResolver, bool) { return r, r.isDir }
-func (r *treeEntryResolver) ToGitBlob() (resolvers.GitTreeEntryResolver, bool) { return r, !r.isDir }
+func (r *treeEntryResolver) Repository() resolvers.RepositoryResolver     { return r.commit.Repository() }
+func (r *treeEntryResolver) Commit() resolvers.GitCommitResolver          { return r.commit }
+func (r *treeEntryResolver) Path() string                                 { return r.path }
+func (r *treeEntryResolver) Name() string                                 { return stdpath.Base(r.path) }
+func (r *treeEntryResolver) URL() string                                  { return r.commit.URI() + r.uriSuffix }
+func (r *treeEntryResolver) RecordID() string                             { return r.path }
+func (r *treeEntryResolver) ToGitTree() (resolvers.GitBlobResolver, bool) { return r, r.isDir }
+func (r *treeEntryResolver) ToGitBlob() (resolvers.GitTreeResolver, bool) { return r, !r.isDir }
 
 func (r *treeEntryResolver) Content(ctx context.Context, args *resolvers.GitTreeContentPageArgs) (string, error) {
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)


### PR DESCRIPTION
In our backend, we mostly follow the convention that type names
for the resolvers match up with the types in the GraphQL API,
with the extra `Resolver` suffix. However, this is broken by the
`GitTreeEntryResolver` where there were no types called
`GitBlobResolver` or `GitTreeResolver`, since all functionality
was implemented on top of `GitTreeEntryResolver`.

Since Go supports implicit method forwarding for embedded structs,
I think we can improve the code consistency & readability by adding
these two stub resolver types.

As struct embedding is not a super common pattern, I've explicitly
mentioned that in the doc comments for `GitBlobResolver` and
`GitTreeResolver`.

## Test plan

Should be covered by existing tests.

## Changelog