### PR TITLE
chore: Remove dead code for Rust crates

### DIFF
--- a/internal/codeintel/codenav/transport/graphql/BUILD.bazel
+++ b/internal/codeintel/codenav/transport/graphql/BUILD.bazel
@@ -36,7 +36,6 @@ go_library(
         "//internal/codeintel/uploads/shared",
         "//internal/codeintel/uploads/transport/graphql",
         "//internal/database",
-        "//internal/dotcom",
         "//internal/gitserver",
         "//internal/metrics",
         "//internal/observation",

--- a/internal/codeintel/codenav/transport/graphql/root_resolver.go
+++ b/internal/codeintel/codenav/transport/graphql/root_resolver.go
@@ -3,7 +3,6 @@ package graphql
 import (
 	"context"
 	"fmt"
-	"strings"
 	"sync"
 
 	orderedmap "github.com/wk8/go-ordered-map/v2"
@@ -19,7 +18,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/uploads/shared"
 	uploadsgraphql "github.com/sourcegraph/sourcegraph/internal/codeintel/uploads/transport/graphql"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/dotcom"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
@@ -83,15 +81,6 @@ func (r *rootResolver) GitBlobLSIFData(ctx context.Context, args *resolverstubs.
 
 	uploads, err := r.svc.GetClosestCompletedUploadsForBlob(ctx, opts)
 	if err != nil || len(uploads) == 0 {
-		return nil, err
-	}
-
-	if len(uploads) == 0 {
-		// If we're on sourcegraph.com and it's a rust package repo, index it on-demand
-		if dotcom.SourcegraphDotComMode() && strings.HasPrefix(string(args.Repo.Name), "crates/") {
-			err = r.autoindexingSvc.QueueRepoRev(ctx, int(args.Repo.ID), string(args.Commit))
-		}
-
 		return nil, err
 	}
 


### PR DESCRIPTION
The function already has an earlier exit if `len(uploads) == 0`,
and packages have been removed/disabled.

## Test plan

n/a

## Changelog