### PR TITLE
chore(search/svelte): Remove dependencies on barrel files to speed up dev build

### DIFF
--- a/client/web-sveltekit/src/lib/search/resultsIndicator/ProgressMessage.svelte
+++ b/client/web-sveltekit/src/lib/search/resultsIndicator/ProgressMessage.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
-    import { getProgressText } from '@sourcegraph/branded'
-
+    import { getProgressText } from '$lib/branded'
     import type { Progress } from '$lib/shared'
 
     export let state: 'error' | 'loading' | 'complete'

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/+layout.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/+layout.svelte
@@ -2,8 +2,6 @@
     import { mdiAccount, mdiCodeTags, mdiCog, mdiHistory, mdiSourceBranch, mdiSourceCommit, mdiTag } from '@mdi/js'
     import { writable } from 'svelte/store'
 
-    import { getButtonClassName } from '@sourcegraph/wildcard'
-
     import { page } from '$app/stores'
     import { sizeToFit } from '$lib/dom'
     import Icon2 from '$lib/Icon2.svelte'
@@ -17,6 +15,7 @@
     import { default as TabsHeader } from '$lib/TabsHeader.svelte'
     import { TELEMETRY_RECORDER } from '$lib/telemetry'
     import { DropdownMenu, MenuLink } from '$lib/wildcard'
+    import { getButtonClassName } from '$lib/wildcard/Button'
 
     import type { LayoutData } from './$types'
 


### PR DESCRIPTION
Fixes srch-516

Using vite's inspect plugin I found out that we are importing a lot of unnecessary components again, including `@sourcegraph/wildcard` and `@sourcegraph/branded`:


By removing those dependencies we speed up the development build significantly.

| Before | After |
|--------|--------|
| ![2024-06-12_17-24](https://github.com/sourcegraph/sourcegraph/assets/179026/1d3935af-6dcf-4e35-9d0c-f8a2439e3757) | ![2024-06-12_17-40](https://github.com/sourcegraph/sourcegraph/assets/179026/ca5978f2-5109-4e37-91ea-16c96902511d) | 
| ![2024-06-12_17-27](https://github.com/sourcegraph/sourcegraph/assets/179026/fce354d6-01ca-4f93-9049-bdb7611e1231) | ![2024-06-12_17-39](https://github.com/sourcegraph/sourcegraph/assets/179026/f511a17a-c660-4423-bdba-133d43896e17) |


## Test plan

`pnpm build`