### PR TITLE
refactor: upgrade to rules_oci 2.0

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -106,9 +106,9 @@ http_archive(
 # Container rules
 http_archive(
     name = "rules_oci",
-    sha256 = "647f4c6fd092dc7a86a7f79892d4b1b7f1de288bdb4829ca38f74fd430fcd2fe",
-    strip_prefix = "rules_oci-1.7.6",
-    url = "https://github.com/bazel-contrib/rules_oci/releases/download/v1.7.6/rules_oci-v1.7.6.tar.gz",
+    sha256 = "e96d70faa4bace3e09fdb1d7d1441b838920f491588889ff9a7e2615afca5799",
+    strip_prefix = "rules_oci-2.0.0-alpha2",
+    url = "https://github.com/bazel-contrib/rules_oci/releases/download/v2.0.0-alpha2/rules_oci-v2.0.0-alpha2.tar.gz",
 )
 
 http_archive(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -106,9 +106,9 @@ http_archive(
 # Container rules
 http_archive(
     name = "rules_oci",
-    sha256 = "e96d70faa4bace3e09fdb1d7d1441b838920f491588889ff9a7e2615afca5799",
-    strip_prefix = "rules_oci-2.0.0-alpha2",
-    url = "https://github.com/bazel-contrib/rules_oci/releases/download/v2.0.0-alpha2/rules_oci-v2.0.0-alpha2.tar.gz",
+    sha256 = "02df4efc5c7431904a927c1947fc7b6e2eda838b038b15bdf9a15918e7d6c04b",
+    strip_prefix = "rules_oci-2.0.0-alpha4",
+    url = "https://github.com/bazel-contrib/rules_oci/releases/download/v2.0.0-alpha4/rules_oci-v2.0.0-alpha4.tar.gz",
 )
 
 http_archive(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -399,15 +399,9 @@ load("@rules_oci//oci:dependencies.bzl", "rules_oci_dependencies")
 
 rules_oci_dependencies()
 
-load("@rules_oci//oci:repositories.bzl", "LATEST_CRANE_VERSION", "oci_register_toolchains")
+load("@rules_oci//oci:repositories.bzl", "oci_register_toolchains")
 
-oci_register_toolchains(
-    name = "oci",
-    crane_version = LATEST_CRANE_VERSION,
-    # Uncommenting the zot toolchain will cause it to be used instead of crane for some tasks.
-    # Note that it does not support docker-format images.
-    # zot_version = LATEST_ZOT_VERSION,
-)
+oci_register_toolchains(name = "oci")
 
 # Optional, for oci_tarball rule
 load("@rules_pkg//:deps.bzl", "rules_pkg_dependencies")

--- a/doc/dev/background-information/bazel/containers.md
+++ b/doc/dev/background-information/bazel/containers.md
@@ -154,11 +154,8 @@ We can now build this image _locally_ and run those tests as well.
 Example:
 
 ```
-# Create a tarball that can be loaded in Docker of the worker service:
-bazel build //cmd/worker:image_tarball
-
-# Load the image in Docker:
-docker load --input $(bazel cquery //cmd/worker:image_tarball  --output=files)
+# Create and load a tarball that can be loaded in Docker of the worker service:
+bazel run //cmd/worker:image_tarball
 
 # Run the container structure tests
 bazel test //cmd/worker:image_test

--- a/doc/dev/background-information/bazel/faq.md
+++ b/doc/dev/background-information/bazel/faq.md
@@ -55,11 +55,8 @@ Our containers are only built for `linux/amd64`, therefore we need to cross-comp
 Example:
 
 ```
-# Create a tarball that can be loaded in Docker of the worker service:
-bazel build //cmd/worker:image_tarball
-
-# Load the image in Docker:
-docker load --input $(bazel cquery //cmd/worker:image_tarball  --output=files)
+# Create and load a tarball that can be loaded in Docker of the worker service:
+bazel run //cmd/worker:image_tarball
 ```
 
 You can also use the same configuration flag to run the container tests on MacOS:

--- a/doc/dev/background-information/sg/index.md
+++ b/doc/dev/background-information/sg/index.md
@@ -186,8 +186,7 @@ env:
 commands:
   gitserver:
     install: |
-      bazel build //cmd/gitserver:image_tarball && \
-      docker load --input $(bazel cquery //cmd/gitserver:image_tarball --output=files)
+      bazel run //cmd/gitserver:image_tarball
   gitserver-0:
     cmd: |
       docker inspect gitserver-${GITSERVER_INDEX} >/dev/null 2>&1 && docker stop gitserver-${GITSERVER_INDEX}

--- a/docker-images/syntax-highlighter/crates/scip-syntax/BUILD.bazel
+++ b/docker-images/syntax-highlighter/crates/scip-syntax/BUILD.bazel
@@ -105,22 +105,31 @@ oci_image(
     base = "@scip-java",
 )
 
+# TODO: this is expensive as whole has to be uploaded to the remote cache
+# Instead call the executable script created by oci_tarball to load the image
+# to daemon.
 oci_tarball(
     name = "scip_java_image_tarball",
     image = ":scip_java_image",
     repo_tags = ["scip-java:tmp"],
 )
 
+filegroup(
+    name = "scip_java_image_tarball_tar",
+    srcs = [":scip_java_image_tarball"],
+    output_group = "tarball",
+)
+
 genrule(
     name = "java_groundtruth_scip",
     srcs = [
         "testdata/scip-index.sh",
-        ":scip_java_image_tarball",
+        ":scip_java_image_tarball_tar",
     ] + glob(["testdata/java/**"]),
     outs = ["index-java.scip"],
     cmd = """\
     $(location testdata/scip-index.sh) \
-        $(location :scip_java_image_tarball) \
+        $(location :scip_java_image_tarball_tar) \
         scip-java:tmp \
         $(location testdata/java/build.gradle) \
         'scip-java index' \

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -759,8 +759,7 @@ commands:
     # Nothing to run for this, we just want to re-run the install script every time.
     cmd: exit 0
     install: |
-      bazel build //cmd/batcheshelper:image_tarball
-      docker load --input $(bazel cquery //cmd/batcheshelper:image_tarball --output=files)
+      bazel run //cmd/batcheshelper:image_tarball
     env:
       IMAGE: batcheshelper:candidate
       # TODO: This is required but should only be set on M1 Macs.
@@ -851,8 +850,7 @@ commands:
       mkdir -p "${GRAFANA_DISK}"
       mkdir -p "$(dirname ${GRAFANA_LOG_FILE})"
       docker inspect $CONTAINER >/dev/null 2>&1 && docker rm -f $CONTAINER
-      bazel build //docker-images/grafana:image_tarball
-      docker load --input $(bazel cquery //docker-images/grafana:image_tarball --output=files)
+      bazel run //docker-images/grafana:image_tarball
     env:
       GRAFANA_DISK: $HOME/.sourcegraph-dev/data/grafana
       # Log file location: since we log outside of the Docker container, we should
@@ -909,8 +907,7 @@ commands:
 
       cp ${PROM_TARGETS} "${CONFIG_DIR}"/prometheus_targets.yml
 
-      bazel build //docker-images/prometheus:image_tarball
-      docker load --input $(bazel cquery //docker-images/prometheus:image_tarball --output=files)
+      bazel run //docker-images/prometheus:image_tarball
     env:
       PROMETHEUS_DISK: $HOME/.sourcegraph-dev/data/prometheus
       # See comment above for `grafana`
@@ -966,8 +963,7 @@ commands:
         "${IMAGE}"
     install: |
       docker inspect $CONTAINER >/dev/null 2>&1 && docker rm -f $CONTAINER
-      bazel build //docker-images/postgres_exporter:image_tarball
-      docker load --input $(bazel cquery //docker-images/postgres_exporter:image_tarball --output=files)
+      bazel run //docker-images/postgres_exporter:image_tarball
     env:
       IMAGE: postgres-exporter:candidate
       CONTAINER: postgres_exporter
@@ -981,8 +977,7 @@ commands:
 
   otel-collector:
     install: |
-      bazel build //docker-images/opentelemetry-collector:image_tarball
-      docker load --input $(bazel cquery //docker-images/opentelemetry-collector:image_tarball --output=files)
+      bazel run //docker-images/opentelemetry-collector:image_tarball
     description: OpenTelemetry collector
     cmd: |
       JAEGER_HOST='host.docker.internal'


### PR DESCRIPTION
Follow up https://github.com/sourcegraph/sourcegraph/pull/63085

Redo of: https://github.com/sourcegraph/sourcegraph/pull/63111

rules_oci 2.0 brings a lot of performance improvement around oci_image and oci_pull, which will benefit sourcegraph. It will also make RBE faster and have less load on remote cache. 

However, 2.0 makes some breaking changes like 

- oci_tarball's default output is no longer a tarball
- oci_image no longer compresses layers that are uncompressed, somebody has to make sure all `pkg_tar` targets have a `compression` attribute set to compress it beforehand. 
- there is no curl fallback, but this is fine for sourcegraph as it already uses bazel 7.1.

I checked all targets that use oci_tarball as much as i could to make sure nothing depends on the default tarball output of oci_tarball. there was one target which used the default output which i put a TODO for somebody else (somebody who is more on top of the repo) to tackle later. 

## Test plan

I am assuming that the repo has enough tests to catch potential problems on CI.  Also somebody who knows the repo better should double check my changes. 