### PR TITLE
fix(search): Copy text from read-only code host configuration input

### DIFF
--- a/client/web/src/components/externalServices/ExternalServicePage.module.scss
+++ b/client/web/src/components/externalServices/ExternalServicePage.module.scss
@@ -1,7 +1,7 @@
 .external-service-page {
     // hide cursor and bracket match in monaco editor
     div[data-editor='monaco'] {
-        textarea,
+        :global(.cursors-layer),
         canvas,
         :global(.cdr.bracket-match) {
             display: none;


### PR DESCRIPTION
PR #49682 made some CSS changes to hide the caret as well as bracket matching for this input. I assume that seeing those in a read-only input was confusing.

However, hiding the textarea element also breaks copying the input's value. Instead of hiding the textarea, we are now hiding the visiual representation of the caret.

A noteable difference in behavior now is that it's possible to focus the input via tab, but there is no visual indiciation that the editor has focus (since we hide the caret, as before).


## Test plan

Manual tested on https://sourcegraph.test:3443/site-admin/external-services/RXh0ZXJuYWxTZXJ2aWNlOjky