### PR TITLE
fix(plg): Fix "Remove team member" feature

### DIFF
--- a/client/web/src/cody/team/TeamMemberList.tsx
+++ b/client/web/src/cody/team/TeamMemberList.tsx
@@ -147,7 +147,9 @@ export const TeamMemberList: FunctionComponent<TeamMemberListProps> = ({
                 setLoading(true)
                 telemetryRecorder.recordEvent('cody.team.removeMember', 'click', { privateMetadata: { teamId } })
 
-                const response = await requestSSC(`/team/current/members/${accountId}`, 'DELETE')
+                const response = await requestSSC('/team/current/members', 'PATCH', {
+                    removeMember: { accountId, teamRole: 'member' },
+                })
                 if (!response.ok) {
                     setLoading(false)
                     setActionResult({


### PR DESCRIPTION
The "Remove" button on the `/cody/team/manage` page didn't remove the user.
Turns out we made the wrong API call. Not sure if the state before this PR was a total hallucination or if it worked well with an earlier, WIP version of the API. But this PR fixes it in any case.

- **Note:** we still don't have a confirmation modal or similar for this action, though. Created https://github.com/sourcegraph/sourcegraph/issues/63240 to track this potential issue.

## Test plan

Did manual QA, it removes users nicely.