### PR TITLE
Svelte: use Roboto Mono as monospace font

### DIFF
--- a/client/web-sveltekit/BUILD.bazel
+++ b/client/web-sveltekit/BUILD.bazel
@@ -92,6 +92,7 @@ BUILD_DEPS = [
     ":node_modules/@sourcegraph/client-api",
     ":node_modules/@sourcegraph/common",
     ":node_modules/@fontsource-variable/inter",
+    ":node_modules/@fontsource-variable/roboto-mono",
     ":node_modules/@sourcegraph/http-client",
     ":node_modules/@sourcegraph/shared",
     ":node_modules/@sourcegraph/web",

--- a/client/web-sveltekit/package.json
+++ b/client/web-sveltekit/package.json
@@ -78,6 +78,7 @@
   "dependencies": {
     "@floating-ui/dom": "^1.6.3",
     "@fontsource-variable/inter": "^5.0.18",
+    "@fontsource-variable/roboto-mono": "^5.0.19",
     "@melt-ui/svelte": "^0.76.0",
     "@sentry/sveltekit": "^8.7.0",
     "@sourcegraph/branded": "workspace:*",

--- a/client/web-sveltekit/src/routes/+layout.svelte
+++ b/client/web-sveltekit/src/routes/+layout.svelte
@@ -10,6 +10,7 @@
     import { isLightTheme, setAppContext } from '$lib/stores'
     import { createTemporarySettingsStorage } from '$lib/temporarySettings'
 
+    import '@fontsource-variable/roboto-mono'
     import '@fontsource-variable/inter'
     import './styles.scss'
 

--- a/client/web-sveltekit/src/routes/svelte-overrides.scss
+++ b/client/web-sveltekit/src/routes/svelte-overrides.scss
@@ -12,6 +12,8 @@ h6 {
 
 body {
     --font-family-base: 'Inter Variable', sans-serif;
+    --monospace-font-family: 'Roboto Mono Variable', monospace;
+    --code-font-family: var(--monospace-font-family);
     --font-size-base: 0.9375rem;
     --font-size-small: 0.875rem;
     --font-size-tiny: 0.8125rem;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1554,6 +1554,9 @@ importers:
       '@fontsource-variable/inter':
         specifier: ^5.0.18
         version: 5.0.18
+      '@fontsource-variable/roboto-mono':
+        specifier: ^5.0.19
+        version: 5.0.19
       '@melt-ui/svelte':
         specifier: ^0.76.0
         version: 0.76.0(svelte@4.1.1)
@@ -4209,6 +4212,10 @@ packages:
 
   /@fontsource-variable/inter@5.0.18:
     resolution: {integrity: sha512-rJzSrtJ3b7djiGFvRuTe6stDfbYJGhdQSfn2SI2WfXviee7Er0yKAHE5u7FU7OWVQQQ1x3+cxdmx9NdiAkcrcA==}
+    dev: false
+
+  /@fontsource-variable/roboto-mono@5.0.19:
+    resolution: {integrity: sha512-EGHx+Av6qNZf1XUM69eE1dwG3vtZHTpRETlkgt9BoRcN0T9xG+Boo/TzznmhI40CLI1zwBjmglEIu2qNI462Vw==}
     dev: false
 
   /@gql2ts/from-query@1.9.0(graphql@14.7.0):


### PR DESCRIPTION
This adds Roboto Mono as the default monospace font for the Svelte webapp. Previously, we were nominally using SF Mono, but that is not installed by default and we were not fetching it, so the figma designs looked different than what was being rendered in the web app. This uses FontSource packages for the font for easy self-hosting (no external requests).

Fixes SRCH-445

## Test plan

Manually tested that code is rendered with Roboto Mono. The font weighs ~30KB