### PR TITLE
chore: Add binary search function that returns range

### DIFF
--- a/internal/collections/slice_utils.go
+++ b/internal/collections/slice_utils.go
@@ -30,7 +30,7 @@ func SplitIntoChunks[T any](slice []T, size int) ([][]T, error) {
 
 type HalfOpenRange struct {
 	Start int // Start is inclusive
-	End   int // End is exclusive
+	End   int // End is exclusive, End >= Start
 }
 
 func (r HalfOpenRange) IsEmpty() bool {

--- a/internal/collections/slice_utils.go
+++ b/internal/collections/slice_utils.go
@@ -2,6 +2,7 @@ package collections
 
 import (
 	"golang.org/x/exp/constraints"
+	"slices"
 
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
@@ -25,4 +26,24 @@ func SplitIntoChunks[T any](slice []T, size int) ([][]T, error) {
 		chunks[i] = slice[i*size : maxIndex]
 	}
 	return chunks, nil
+}
+
+type HalfOpenRange struct {
+	Start int // Start is inclusive
+	End   int // End is exclusive
+}
+
+func BinarySearchRangeFunc[S ~[]E, E, T any](x S, target T, cmp func(E, T) int) (HalfOpenRange, bool) {
+	insertIndex, found := slices.BinarySearchFunc(x, target, cmp)
+	if !found {
+		return HalfOpenRange{insertIndex, insertIndex + 1}, false
+	}
+	start := insertIndex
+	for ; start >= 0 && cmp(x[start], target) == 0; start-- {
+	}
+	start += 1
+	end := insertIndex
+	for ; end < len(x) && cmp(x[end], target) == 0; end++ {
+	}
+	return HalfOpenRange{Start: start, End: end}, true
 }

--- a/internal/collections/slice_utils_test.go
+++ b/internal/collections/slice_utils_test.go
@@ -80,11 +80,11 @@ func Test_SplitIntoChunks(t *testing.T) {
 
 func TestBinarySearchRangeFunc(t *testing.T) {
 	t.Run("returns the range of elements that are equal to the target", func(t *testing.T) {
-		got, ok := BinarySearchRangeFunc([]int{1, 2, 2, 2, 3, 4, 5, 6, 7, 8, 9}, 2, func(x, y int) int {
+		got := BinarySearchRangeFunc([]int{1, 2, 2, 2, 3, 4, 5, 6, 7, 8, 9}, 2, func(x, y int) int {
 			return x - y
 		})
 		want := HalfOpenRange{Start: 1, End: 4}
-		if ok && got != want {
+		if got != want {
 			t.Errorf("got %v, want %v", got, want)
 		}
 	})
@@ -94,7 +94,8 @@ func TestBinarySearchRangeFunc(t *testing.T) {
 		slices.Sort(s)
 		cmpFunc := stdcmp.Compare[int]
 		target := rapid.IntRange(0, 10).Draw(t, "target")
-		got, binarySearchFound := BinarySearchRangeFunc(s, target, cmpFunc)
+		got := BinarySearchRangeFunc(s, target, cmpFunc)
+		binarySearchFound := !got.IsEmpty()
 		expected, linearSearchFound := linearSearchRangeFunc(s, target, cmpFunc)
 		if binarySearchFound != linearSearchFound {
 			t.Errorf("BinarySearchRangeFunc returned %v, but linearSearchRangeFunc returned %v", binarySearchFound, linearSearchFound)

--- a/internal/collections/slice_utils_test.go
+++ b/internal/collections/slice_utils_test.go
@@ -1,6 +1,9 @@
 package collections
 
 import (
+	stdcmp "cmp"
+	"pgregory.net/rapid"
+	"slices"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -73,4 +76,52 @@ func Test_SplitIntoChunks(t *testing.T) {
 			t.Errorf("got %v, want %v", got, want)
 		}
 	})
+}
+
+func TestBinarySearchRangeFunc(t *testing.T) {
+	t.Run("returns the range of elements that are equal to the target", func(t *testing.T) {
+		got, ok := BinarySearchRangeFunc([]int{1, 2, 2, 2, 3, 4, 5, 6, 7, 8, 9}, 2, func(x, y int) int {
+			return x - y
+		})
+		want := HalfOpenRange{Start: 1, End: 4}
+		if ok && got != want {
+			t.Errorf("got %v, want %v", got, want)
+		}
+	})
+
+	rapid.Check(t, func(t *rapid.T) {
+		s := rapid.SliceOfN(rapid.IntRange(0, 10), 0, 10).Draw(t, "slice")
+		slices.Sort(s)
+		cmpFunc := stdcmp.Compare[int]
+		target := rapid.IntRange(0, 10).Draw(t, "target")
+		got, binarySearchFound := BinarySearchRangeFunc(s, target, cmpFunc)
+		expected, linearSearchFound := linearSearchRangeFunc(s, target, cmpFunc)
+		if binarySearchFound != linearSearchFound {
+			t.Errorf("BinarySearchRangeFunc returned %v, but linearSearchRangeFunc returned %v", binarySearchFound, linearSearchFound)
+		}
+		if binarySearchFound && got != expected {
+			t.Errorf("BinarySearchRangeFunc returned %v, but linearSearchRangeFunc returned %v", got, expected)
+		}
+	})
+}
+
+func linearSearchRangeFunc[S ~[]E, E, T any](x S, target T, cmp func(E, T) int) (HalfOpenRange, bool) {
+	start := -1
+	end := -1
+	found := false
+	for i, e := range x {
+		if cmp(e, target) == 0 {
+			if !found {
+				found = true
+				start = i
+				end = i + 1
+			} else {
+				end = i + 1
+			}
+		}
+	}
+	if found {
+		return HalfOpenRange{Start: start, End: end}, true
+	}
+	return HalfOpenRange{}, false
 }


### PR DESCRIPTION
This is useful for comparing SCIP occurrences with search ranges.

## Test plan

Added unit test and property-based test

## Changelog