### PR TITLE
chore: Move deduplicateBy to collections package

### DIFF
--- a/internal/codeintel/codenav/internal/lsifstore/locations_by_position.go
+++ b/internal/codeintel/codenav/internal/lsifstore/locations_by_position.go
@@ -472,25 +472,11 @@ func (s *store) extractLocationsFromPosition(
 		}
 	}
 
-	return deduplicateLocations(locations), deduplicateBy(symbols, func(s string) string { return s }), nil
-}
-
-func deduplicateBy[T any](locations []T, keyFn func(T) string) []T {
-	seen := collections.NewSet[string]()
-	filtered := locations[:0]
-	for _, l := range locations {
-		k := keyFn(l)
-		if seen.Has(k) {
-			continue
-		}
-		seen.Add(k)
-		filtered = append(filtered, l)
-	}
-	return filtered
+	return deduplicateLocations(locations), collections.DeduplicateBy(symbols, func(s string) string { return s }), nil
 }
 
 func deduplicateLocations(locations []shared.Location) []shared.Location {
-	return deduplicateBy(locations, locationKey)
+	return collections.DeduplicateBy(locations, locationKey)
 }
 
 func locationKey(l shared.Location) string {

--- a/internal/codeintel/codenav/internal/lsifstore/scan.go
+++ b/internal/codeintel/codenav/internal/lsifstore/scan.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/shared/ranges"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/uploads/shared"
+	"github.com/sourcegraph/sourcegraph/internal/collections"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/lib/codeintel/precise"
 )
@@ -161,7 +162,7 @@ func (s *store) scanDeduplicatedQualifiedMonikerLocations(rows *sql.Rows, queryE
 		}
 	}
 	for i := range values {
-		values[i].Locations = deduplicateBy(values[i].Locations, locationDataKey)
+		values[i].Locations = collections.DeduplicateBy(values[i].Locations, locationDataKey)
 	}
 
 	return values, nil

--- a/internal/collections/BUILD.bazel
+++ b/internal/collections/BUILD.bazel
@@ -23,10 +23,12 @@ go_test(
         "set_test.go",
         "slice_utils_test.go",
     ],
+    data = glob(["testdata/**"]),
     embed = [":collections"],
     deps = [
         "@com_github_google_go_cmp//cmp",
         "@com_github_grafana_regexp//:regexp",
         "@com_github_stretchr_testify//require",
+        "@net_pgregory_rapid//:rapid",
     ],
 )

--- a/internal/collections/set.go
+++ b/internal/collections/set.go
@@ -142,3 +142,17 @@ func Intersection[T comparable](a, b Set[T]) Set[T] {
 
 	return itrsc
 }
+
+func DeduplicateBy[T any, K comparable](xs []T, keyFn func(T) K) []T {
+	seen := NewSet[K]()
+	filtered := xs[:0]
+	for _, x := range xs {
+		k := keyFn(x)
+		if seen.Has(k) {
+			continue
+		}
+		seen.Add(k)
+		filtered = append(filtered, x)
+	}
+	return filtered
+}

--- a/internal/collections/set_test.go
+++ b/internal/collections/set_test.go
@@ -2,6 +2,8 @@ package collections
 
 import (
 	"cmp"
+	"pgregory.net/rapid"
+	"slices"
 	"testing"
 
 	"github.com/grafana/regexp"
@@ -124,5 +126,22 @@ func TestSet(t *testing.T) {
 
 		// empty set
 		require.Equal(t, "Set[]", NewSet[int]().String())
+	})
+}
+
+func TestDeduplicateBy(t *testing.T) {
+	t.Run("Deduplicates values by key", func(t *testing.T) {
+		got := DeduplicateBy([]int{1, 7, 8, 15}, func(i int) int { return i % 7 })
+		slices.Sort(got)
+		want := []int{1, 7}
+		require.Equal(t, want, got)
+	})
+
+	rapid.Check(t, func(t *rapid.T) {
+		slice := rapid.SliceOfN(rapid.IntRange(0, 10), 0, 10).Draw(t, "slice")
+		viaSet := NewSet(slice...).Sorted(cmp.Less[int])
+		viaDedupe := DeduplicateBy(slice, func(i int) int { return i })
+		slices.Sort(viaDedupe)
+		require.Equal(t, viaSet, viaDedupe)
 	})
 }


### PR DESCRIPTION
It's a bit weird that this was in the codeintel package.

## Test plan

Added new tests

## Changelog