### PR TITLE
Chore: disable flaky tests

### DIFF
--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/page.spec.ts
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/page.spec.ts
@@ -181,7 +181,8 @@ test.describe('file header', () => {
         )
     })
 
-    test('dropdown menu', async ({ page }) => {
+    // Disabled because flaky in CI
+    test.fixme('dropdown menu', async ({ page }) => {
         await page.goto(url)
 
         async function openDropdown() {

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/-/stats/contributors/page.spec.ts
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/-/stats/contributors/page.spec.ts
@@ -56,7 +56,8 @@ test.beforeEach(async ({ sg }) => {
     })
 })
 
-test('paginate contributors', async ({ page }) => {
+// Disabled because flaky in CI
+test.fixme('paginate contributors', async ({ page }) => {
     await page.goto(url)
     await expect(page.getByRole('row')).toHaveCount(5)
 


### PR DESCRIPTION
Of the last 10 failures, only two tests were flaking. This disables those tests until we can figure out why they were flaking.

## Test plan

CI passes with no flakes
