### PR TITLE
fix(svelte): scrolling search input

### DIFF
--- a/client/web-sveltekit/src/lib/search/input/SearchInput.svelte
+++ b/client/web-sveltekit/src/lib/search/input/SearchInput.svelte
@@ -86,6 +86,7 @@
             },
             '.cm-scroller': {
                 overflowX: 'hidden',
+                lineHeight: '1.6',
             },
             '.cm-content': {
                 paddingLeft: '0.25rem',


### PR DESCRIPTION
Fixes SRCH-541

Reported [here](https://sourcegraph.slack.com/archives/C05EA9KQUTA/p1718328910576659)

The bug:

https://github.com/sourcegraph/sourcegraph/assets/12631702/78d69be1-e594-4551-b3cb-fdb6fcadbd2e

With the change in font, the minimum line-height to fit that font has also increased. 1.6 seemed to do the job.

I'm a little concerned about other places this might be a problem, but for now just doing the easy thing to make it feel less broken.

## Test plan

The input no longer scrolls and there is no change to the height of the element as a whole.
