### PR TITLE
chore: Simplify location uniquing

### DIFF
--- a/internal/codeintel/codenav/internal/lsifstore/locations_by_position.go
+++ b/internal/codeintel/codenav/internal/lsifstore/locations_by_position.go
@@ -354,22 +354,12 @@ func (s *store) extractLocationsFromPosition(
 		}
 	}
 
-	return deduplicateLocations(locations), collections.DeduplicateBy(symbols, func(s string) string { return s }), nil
+	// We only need to unique by the range, since all location objects share the same path and uploadID.
+	return collections.DeduplicateBy(locations, uniqueByRange), collections.Deduplicate(symbols), nil
 }
 
-func deduplicateLocations(locations []shared.Location) []shared.Location {
-	return collections.DeduplicateBy(locations, locationKey)
-}
-
-func locationKey(l shared.Location) string {
-	return fmt.Sprintf("%d:%s:%d:%d:%d:%d",
-		l.UploadID,
-		l.Path,
-		l.Range.Start.Line,
-		l.Range.Start.Character,
-		l.Range.End.Line,
-		l.Range.End.Character,
-	)
+func uniqueByRange(l shared.Location) [4]int {
+	return [4]int{l.Range.Start.Line, l.Range.Start.Character, l.Range.End.Character}
 }
 
 //

--- a/internal/codeintel/codenav/internal/lsifstore/locations_by_position.go
+++ b/internal/codeintel/codenav/internal/lsifstore/locations_by_position.go
@@ -354,7 +354,7 @@ func (s *store) extractLocationsFromPosition(
 		}
 	}
 
-	// We only need to unique by the range, since all location objects share the same path and uploadID.
+	// We only need to deduplicate by the range, since all location objects share the same path and uploadID.
 	return collections.DeduplicateBy(locations, uniqueByRange), collections.Deduplicate(symbols), nil
 }
 

--- a/internal/collections/set.go
+++ b/internal/collections/set.go
@@ -156,3 +156,18 @@ func DeduplicateBy[T any, K comparable](xs []T, keyFn func(T) K) []T {
 	}
 	return filtered
 }
+
+// Deduplicate modifies the argument slice in-place,
+// and maintains ordering unlike NewSet(...).Values().
+func Deduplicate[T comparable](xs []T) []T {
+	seen := NewSet[T]()
+	filtered := xs[:0]
+	for _, x := range xs {
+		if seen.Has(x) {
+			continue
+		}
+		seen.Add(x)
+		filtered = append(filtered, x)
+	}
+	return filtered
+}


### PR DESCRIPTION
The code earlier constructing the locations attaches the same
uploadID and path to all of them, so trying to use those while 
uniquing is wasteful. Let's stop doing that.

## Test plan

Covered by existing tests

## Changelog