### PR TITLE
fix(search): Better diagnostic message for invalid and incomplete select: filter value

### DIFF
--- a/client/branded/src/search-ui/input/codemirror/token-info.ts
+++ b/client/branded/src/search-ui/input/codemirror/token-info.ts
@@ -107,7 +107,13 @@ export function tokenInfo(): Extension {
                         return null
                     }
 
-                    return getTokensTooltipInformation(state.facet(decoratedTokens), position)
+                    const tooltipInformation = getTokensTooltipInformation(state.facet(decoratedTokens), position)
+
+                    // Do not show tooltips with empty content
+                    if (!tooltipInformation?.value) {
+                        return null
+                    }
+                    return tooltipInformation
                 }),
 
                 EditorView.decorations.compute([field, tooltipInformationFacet, 'selection'], state => {

--- a/client/shared/src/search/query/selectFilter.ts
+++ b/client/shared/src/search/query/selectFilter.ts
@@ -92,6 +92,12 @@ export const selectorCompletion = (value: Literal | undefined): string[] => {
     if (value.value.endsWith('.') || value.value.split('.').length > 1 || kinds.has(value.value)) {
         // Resolve completions to greater depth for `foo.` if the value is `foo.` or `foo.bar`.
         const kind = value.value.split('.')[0]
+
+        // Return top-level selectors if the selector prefix is not known.
+        if (!kinds.has(kind)) {
+            return selectDiscreteValues(SELECTORS, 0)
+        }
+
         return selectDiscreteValues(
             SELECTORS.filter(value => value.name === kind),
             2


### PR DESCRIPTION
Fixes srch-362

When the select filter value ends with a `.` *and* does not have a valid "top-level" value, e.g. `select:diff.` then the diagnostic message doesn't show a list of valid values. This commit fixes that.
Additionally it won't show an empty tooltip anymore when we don't have information for the hovered token.

| Before | After |
|--------|--------|
| ![2024-06-14_13-53](https://github.com/sourcegraph/sourcegraph/assets/179026/40a1d42a-74ba-4d51-891c-b8db96c49f0f) | ![2024-06-14_13-54](https://github.com/sourcegraph/sourcegraph/assets/179026/5963deb2-1823-4f7d-9793-9a4671ab1069) | 

(notice the separator in the popover in the first screenshot)

This affects both the React and the Svelte app.


## Test plan

Manual testing.

## Changelog

- Show useful valid values when an invalid `select:` value is entered
- Do not render empty hover tooltips
