### PR TITLE
Filters candidate matches against syntactic SCIP documents

### DIFF
--- a/internal/codeintel/codenav/BUILD.bazel
+++ b/internal/codeintel/codenav/BUILD.bazel
@@ -47,6 +47,7 @@ go_library(
         "@com_github_sourcegraph_go_diff//diff",
         "@com_github_sourcegraph_log//:log",
         "@com_github_sourcegraph_scip//bindings/go/scip",
+        "@com_github_wk8_go_ordered_map_v2//:go-ordered-map",
         "@io_opentelemetry_go_otel//attribute",
     ],
 )

--- a/internal/codeintel/codenav/service.go
+++ b/internal/codeintel/codenav/service.go
@@ -1022,7 +1022,7 @@ func (s *Service) getSyntacticSymbolsAtRange(
 
 	// TODO: Adjust symbolRange based on revision vs syntacticUpload.Commit
 
-	symbols = make([]*scip.Symbol, 0)
+	symbols = []*scip.Symbol{}
 	var parseFail *scip.Occurrence = nil
 
 	// FIXME(issue: GRAPH-674): Properly handle different text encodings here.
@@ -1056,7 +1056,7 @@ func (s *Service) findSyntacticMatchesForCandidateFile(
 	filePath string,
 	candidateFile candidateFile,
 ) []SyntacticMatch {
-	results := make([]SyntacticMatch, 0)
+	results := []SyntacticMatch{}
 
 	document, docErr := s.SCIPDocument(ctx, uploadId, filePath)
 	if docErr != nil {

--- a/internal/codeintel/codenav/service.go
+++ b/internal/codeintel/codenav/service.go
@@ -997,7 +997,7 @@ func (s *Service) getSyntacticUpload(ctx context.Context, trace observation.Trac
 // (some broken invariant internally, network issue etc.)
 // If this function doesn't error, the returned slice is guaranteed to be non-empty
 //
-// NOTE(id: single-syntactic-upload): This function returns the uploadId in because we're
+// NOTE(id: single-syntactic-upload): This function returns the uploadID because we're
 // making the assumption that there'll only be a single syntactic upload at the root
 // directory for a particular commit.
 func (s *Service) getSyntacticSymbolsAtRange(
@@ -1007,7 +1007,7 @@ func (s *Service) getSyntacticSymbolsAtRange(
 	commit api.CommitID,
 	path string,
 	symbolRange scip.Range,
-) (symbols []*scip.Symbol, uploadId int, err *SyntacticUsagesError) {
+) (symbols []*scip.Symbol, uploadID int, err *SyntacticUsagesError) {
 	syntacticUpload, err := s.getSyntacticUpload(ctx, trace, repo, commit, path)
 	if err != nil {
 		return nil, 0, err
@@ -1053,13 +1053,13 @@ func (s *Service) getSyntacticSymbolsAtRange(
 
 func (s *Service) findSyntacticMatchesForCandidateFile(
 	ctx context.Context,
-	uploadId int,
+	uploadID int,
 	filePath string,
 	candidateFile candidateFile,
 ) ([]SyntacticMatch, *SyntacticUsagesError) {
 	results := []SyntacticMatch{}
 
-	document, docErr := s.SCIPDocument(ctx, uploadId, filePath)
+	document, docErr := s.SCIPDocument(ctx, uploadID, filePath)
 	if docErr != nil {
 		return nil, &SyntacticUsagesError{
 			Code:            SU_NoSyntacticIndex,
@@ -1108,7 +1108,7 @@ func (s *Service) SyntacticUsages(
 	}})
 	defer endObservation(1, observation.Args{})
 
-	symbolsAtRange, uploadId, err := s.getSyntacticSymbolsAtRange(ctx, trace, repo, commit, path, symbolRange)
+	symbolsAtRange, uploadID, err := s.getSyntacticSymbolsAtRange(ctx, trace, repo, commit, path, symbolRange)
 	if err != nil {
 		return nil, err
 	}
@@ -1145,7 +1145,7 @@ func (s *Service) SyntacticUsages(
 	for pair := candidateMatches.Oldest(); pair != nil; pair = pair.Next() {
 		// We're assuming the upload we found earlier contains the relevant SCIP document
 		// see NOTE(id: single-syntactic-upload)
-		syntacticMatches, err := s.findSyntacticMatchesForCandidateFile(ctx, uploadId, pair.Key, pair.Value)
+		syntacticMatches, err := s.findSyntacticMatchesForCandidateFile(ctx, uploadID, pair.Key, pair.Value)
 		if err != nil {
 			// TODO: Errors that are not "no index found in the DB" should be reported
 			// TODO: Track metrics about how often this happens (GRAPH-693)

--- a/internal/codeintel/codenav/service.go
+++ b/internal/codeintel/codenav/service.go
@@ -995,6 +995,10 @@ func (s *Service) getSyntacticUpload(ctx context.Context, repo types.Repo, commi
 // in a syntactic upload. If this function returns an error you should most likely
 // log and handle it instead of rethrowing, as this could fail for a myriad of reasons
 // (some broken invariant internally, network issue etc.)
+//
+// NOTE(id: single-syntactic-upload): This function returns the uploadId in because we're
+// making the assumption that there'll only be a single syntactic upload at the root
+// directory for a particular commit.
 func (s *Service) getSyntacticSymbolsAtRange(
 	ctx context.Context,
 	repo types.Repo,
@@ -1134,6 +1138,8 @@ func (s *Service) SyntacticUsages(
 	results := make([][]SyntacticMatch, candidateMatches.Len())
 
 	for pair := candidateMatches.Oldest(); pair != nil; pair = pair.Next() {
+		// We're assuming the upload we found earlier contains the relevant SCIP document
+		// see NOTE(id: single-syntactic-upload)
 		syntacticMatches := s.findSyntacticMatchesForCandidateFile(ctx, uploadId, pair.Key, pair.Value)
 		results = append(results, syntacticMatches)
 	}

--- a/internal/codeintel/codenav/service.go
+++ b/internal/codeintel/codenav/service.go
@@ -1128,7 +1128,7 @@ func (s *Service) SyntacticUsages(
 		}
 	}
 
-	candidateMatches, matchCount, searchErr := findCandidateOccurrencesViaSearch(
+	candidateMatches, searchErr := findCandidateOccurrencesViaSearch(
 		ctx, s.searchClient, trace,
 		repo, commit, searchSymbol, langs[0],
 	)
@@ -1138,7 +1138,6 @@ func (s *Service) SyntacticUsages(
 			UnderlyingError: searchErr,
 		}
 	}
-	trace.AddEvent("findCandidateOccurrencesViaSearch", attribute.Int("matchCount", matchCount))
 
 	results := make([][]SyntacticMatch, candidateMatches.Len())
 

--- a/internal/codeintel/codenav/service.go
+++ b/internal/codeintel/codenav/service.go
@@ -995,6 +995,7 @@ func (s *Service) getSyntacticUpload(ctx context.Context, trace observation.Trac
 // in a syntactic upload. If this function returns an error you should most likely
 // log and handle it instead of rethrowing, as this could fail for a myriad of reasons
 // (some broken invariant internally, network issue etc.)
+// If this function doesn't error, the returned slice is guaranteed to be non-empty
 //
 // NOTE(id: single-syntactic-upload): This function returns the uploadId in because we're
 // making the assumption that there'll only be a single syntactic upload at the root

--- a/internal/codeintel/codenav/service.go
+++ b/internal/codeintel/codenav/service.go
@@ -1039,6 +1039,14 @@ func (s *Service) getSyntacticSymbolsAtRange(
 		trace.Warn("getSyntacticSymbolsAtRange: Failed to parse symbol", log.String("symbol", parseFail.Symbol))
 	}
 
+	if len(symbols) == 0 {
+		trace.Warn("getSyntacticSymbolsAtRange: No symbols found at requested range")
+		return nil, 0, &SyntacticUsagesError{
+			Code:            SU_NoSymbolAtRequestedRange,
+			UnderlyingError: nil,
+		}
+	}
+
 	return symbols, syntacticUpload.ID, nil
 }
 
@@ -1101,13 +1109,6 @@ func (s *Service) SyntacticUsages(
 		return nil, err
 	}
 
-	if len(symbolsAtRange) == 0 {
-		s.logger.Warn("getSyntacticSymbolsAtRange: No symbols found at requested range")
-		return nil, &SyntacticUsagesError{
-			Code:            SU_NoSymbolAtRequestedRange,
-			UnderlyingError: nil,
-		}
-	}
 	// Overlapping symbolsAtRange should lead to the same display name, but be scored separately.
 	// (Meaning we just need a single Searcher/Zoekt search)
 	searchSymbol := symbolsAtRange[0]

--- a/internal/codeintel/codenav/service.go
+++ b/internal/codeintel/codenav/service.go
@@ -1125,7 +1125,7 @@ func (s *Service) SyntacticUsages(
 	}
 	trace.AddEvent("findCandidateOccurrencesViaSearch", attribute.Int("matchCount", matchCount))
 
-	results := make([][]SyntacticMatch, 0)
+	results := make([][]SyntacticMatch, len(candidateMatches))
 	for filePath, file := range candidateMatches {
 		syntacticMatches := s.findSyntacticMatchesForCandidateFile(ctx, uploadId, filePath, file)
 		results = append(results, syntacticMatches)

--- a/internal/codeintel/codenav/service.go
+++ b/internal/codeintel/codenav/service.go
@@ -1125,9 +1125,10 @@ func (s *Service) SyntacticUsages(
 	}
 	trace.AddEvent("findCandidateOccurrencesViaSearch", attribute.Int("matchCount", matchCount))
 
-	results := make([][]SyntacticMatch, len(candidateMatches))
-	for filePath, file := range candidateMatches {
-		syntacticMatches := s.findSyntacticMatchesForCandidateFile(ctx, uploadId, filePath, file)
+	results := make([][]SyntacticMatch, candidateMatches.Len())
+
+	for pair := candidateMatches.Oldest(); pair != nil; pair = pair.Next() {
+		syntacticMatches := s.findSyntacticMatchesForCandidateFile(ctx, uploadId, pair.Key, pair.Value)
 		results = append(results, syntacticMatches)
 	}
 	return slices.Concat(results...), nil

--- a/internal/codeintel/codenav/service.go
+++ b/internal/codeintel/codenav/service.go
@@ -1050,12 +1050,16 @@ func (s *Service) findSyntacticMatchesForCandidateFile(
 		return results
 	}
 
+	// TODO: We can optimize this further by continuously slicing the occurrences array
+	// as both these arrays are sorted
 	for _, candidateRange := range candidateFile.matches {
 		for _, occ := range findOccurrencesWithEqualRange(document.Occurrences, candidateRange) {
-			results = append(results, SyntacticMatch{
-				Path:       filePath,
-				Occurrence: occ,
-			})
+			if !scip.IsLocalSymbol(occ.Symbol) {
+				results = append(results, SyntacticMatch{
+					Path:       filePath,
+					Occurrence: occ,
+				})
+			}
 		}
 	}
 

--- a/internal/codeintel/codenav/service.go
+++ b/internal/codeintel/codenav/service.go
@@ -1126,7 +1126,7 @@ func (s *Service) SyntacticUsages(
 	}
 
 	candidateMatches, matchCount, searchErr := findCandidateOccurrencesViaSearch(
-		ctx, s.searchClient, s.logger, trace,
+		ctx, s.searchClient, trace,
 		repo, commit, searchSymbol, langs[0],
 	)
 	if searchErr != nil {

--- a/internal/codeintel/codenav/service.go
+++ b/internal/codeintel/codenav/service.go
@@ -980,12 +980,14 @@ func (s *Service) getSyntacticUpload(ctx context.Context, repo types.Repo, commi
 		}
 	}
 
-	s.logger.Warn(
-		"Multiple syntactic uploads found, picking the first one",
-		log.String("repo", repo.URI),
-		log.String("commit", commit.Short()),
-		log.String("path", path),
-	)
+	if len(uploads) > 1 {
+		s.logger.Warn(
+			"Multiple syntactic uploads found, picking the first one",
+			log.String("repo", repo.URI),
+			log.String("commit", commit.Short()),
+			log.String("path", path),
+		)
+	}
 	return uploads[0], nil
 }
 

--- a/internal/codeintel/codenav/syntactic.go
+++ b/internal/codeintel/codenav/syntactic.go
@@ -43,8 +43,10 @@ func findCandidateOccurrencesViaSearch(
 		return nil, 0, errors.Errorf("can't find occurrences for locals via search")
 	}
 	// TODO: This should be dependent on the number of requested usages, with a configured global limit
-	countLimit := 500
-	searchQuery := fmt.Sprintf("type:file repo:%s rev:%s language:%s count:%d %s", repoName, string(commit), language, countLimit, identifier)
+	countLimit := 1000
+	searchQuery := fmt.Sprintf("type:file repo:%s rev:%s language:%s count:%d case:yes /\\b%s\\b/", repoName, string(commit), language, countLimit, identifier)
+
+	logger.Info("Running query", log.String("q", searchQuery))
 
 	plan, err := client.Plan(ctx, "V3", &patternType, searchQuery, search.Precise, search.Streaming, &contextLines)
 	if err != nil {

--- a/internal/codeintel/codenav/syntactic.go
+++ b/internal/codeintel/codenav/syntactic.go
@@ -113,12 +113,8 @@ func findCandidateOccurrencesViaSearch(
 }
 
 func nameFromSymbol(symbol *scip.Symbol) (string, bool) {
-	if len(symbol.Descriptors) > 0 {
-		if symbol.Descriptors[0].Suffix == scip.Descriptor_Local {
-			return "", false
-		}
-		return symbol.Descriptors[len(symbol.Descriptors)-1].Name, true
-	} else {
+	if len(symbol.Descriptors) == 0 || symbol.Descriptors[0].Suffix == scip.Descriptor_Local {
 		return "", false
 	}
+	return symbol.Descriptors[len(symbol.Descriptors)-1].Name, true
 }

--- a/internal/codeintel/codenav/syntactic.go
+++ b/internal/codeintel/codenav/syntactic.go
@@ -3,11 +3,9 @@ package codenav
 import (
 	"context"
 	"fmt"
-	orderedmap "github.com/wk8/go-ordered-map/v2"
-	"strings"
-
 	"github.com/sourcegraph/log"
 	"github.com/sourcegraph/scip/bindings/go/scip"
+	orderedmap "github.com/wk8/go-ordered-map/v2"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/search"
@@ -114,7 +112,7 @@ func findCandidateOccurrencesViaSearch(
 
 func nameFromSymbol(symbol *scip.Symbol) (string, bool) {
 	if len(symbol.Descriptors) > 0 {
-		if strings.HasSuffix(symbol.Descriptors[0].Name, "local") {
+		if symbol.Descriptors[0].Suffix == scip.Descriptor_Local {
 			return "", false
 		}
 		return symbol.Descriptors[len(symbol.Descriptors)-1].Name, true

--- a/internal/codeintel/codenav/syntactic.go
+++ b/internal/codeintel/codenav/syntactic.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/sourcegraph/log"
 	"github.com/sourcegraph/scip/bindings/go/scip"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
 	orderedmap "github.com/wk8/go-ordered-map/v2"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
@@ -27,6 +28,7 @@ func findCandidateOccurrencesViaSearch(
 	ctx context.Context,
 	client searchclient.SearchClient,
 	logger log.Logger,
+	trace observation.TraceLogger,
 	repo types.Repo,
 	commit api.CommitID,
 	symbol *scip.Symbol,
@@ -46,7 +48,7 @@ func findCandidateOccurrencesViaSearch(
 	countLimit := 1000
 	searchQuery := fmt.Sprintf("type:file repo:%s rev:%s language:%s count:%d case:yes /\\b%s\\b/", repoName, string(commit), language, countLimit, identifier)
 
-	logger.Info("Running query", log.String("q", searchQuery))
+	trace.Info("Running query", log.String("q", searchQuery))
 
 	plan, err := client.Plan(ctx, "V3", &patternType, searchQuery, search.Precise, search.Streaming, &contextLines)
 	if err != nil {

--- a/internal/codeintel/codenav/transport/graphql/iface.go
+++ b/internal/codeintel/codenav/transport/graphql/iface.go
@@ -27,7 +27,7 @@ type CodeNavService interface {
 	VisibleUploadsForPath(ctx context.Context, requestState codenav.RequestState) ([]uploadsshared.CompletedUpload, error)
 	SnapshotForDocument(ctx context.Context, repositoryID int, commit, path string, uploadID int) (data []shared.SnapshotData, err error)
 	SCIPDocument(ctx context.Context, uploadID int, path string) (*scip.Document, error)
-	SyntacticUsages(ctx context.Context, repo types.Repo, commit api.CommitID, path string, symbolRange scip.Range) ([]struct{}, *codenav.SyntacticUsagesError)
+	SyntacticUsages(ctx context.Context, repo types.Repo, commit api.CommitID, path string, symbolRange scip.Range) ([]codenav.SyntacticMatch, *codenav.SyntacticUsagesError)
 }
 
 type AutoIndexingService interface {

--- a/internal/codeintel/codenav/transport/graphql/mocks_test.go
+++ b/internal/codeintel/codenav/transport/graphql/mocks_test.go
@@ -283,7 +283,7 @@ func NewMockCodeNavService() *MockCodeNavService {
 			},
 		},
 		SyntacticUsagesFunc: &CodeNavServiceSyntacticUsagesFunc{
-			defaultHook: func(context.Context, types.Repo, api.CommitID, string, scip.Range) (r0 []struct{}, r1 *codenav.SyntacticUsagesError) {
+			defaultHook: func(context.Context, types.Repo, api.CommitID, string, scip.Range) (r0 []codenav.SyntacticMatch, r1 *codenav.SyntacticUsagesError) {
 				return
 			},
 		},
@@ -355,7 +355,7 @@ func NewStrictMockCodeNavService() *MockCodeNavService {
 			},
 		},
 		SyntacticUsagesFunc: &CodeNavServiceSyntacticUsagesFunc{
-			defaultHook: func(context.Context, types.Repo, api.CommitID, string, scip.Range) ([]struct{}, *codenav.SyntacticUsagesError) {
+			defaultHook: func(context.Context, types.Repo, api.CommitID, string, scip.Range) ([]codenav.SyntacticMatch, *codenav.SyntacticUsagesError) {
 				panic("unexpected invocation of MockCodeNavService.SyntacticUsages")
 			},
 		},
@@ -1695,15 +1695,15 @@ func (c CodeNavServiceSnapshotForDocumentFuncCall) Results() []interface{} {
 // SyntacticUsages method of the parent MockCodeNavService instance is
 // invoked.
 type CodeNavServiceSyntacticUsagesFunc struct {
-	defaultHook func(context.Context, types.Repo, api.CommitID, string, scip.Range) ([]struct{}, *codenav.SyntacticUsagesError)
-	hooks       []func(context.Context, types.Repo, api.CommitID, string, scip.Range) ([]struct{}, *codenav.SyntacticUsagesError)
+	defaultHook func(context.Context, types.Repo, api.CommitID, string, scip.Range) ([]codenav.SyntacticMatch, *codenav.SyntacticUsagesError)
+	hooks       []func(context.Context, types.Repo, api.CommitID, string, scip.Range) ([]codenav.SyntacticMatch, *codenav.SyntacticUsagesError)
 	history     []CodeNavServiceSyntacticUsagesFuncCall
 	mutex       sync.Mutex
 }
 
 // SyntacticUsages delegates to the next hook function in the queue and
 // stores the parameter and result values of this invocation.
-func (m *MockCodeNavService) SyntacticUsages(v0 context.Context, v1 types.Repo, v2 api.CommitID, v3 string, v4 scip.Range) ([]struct{}, *codenav.SyntacticUsagesError) {
+func (m *MockCodeNavService) SyntacticUsages(v0 context.Context, v1 types.Repo, v2 api.CommitID, v3 string, v4 scip.Range) ([]codenav.SyntacticMatch, *codenav.SyntacticUsagesError) {
 	r0, r1 := m.SyntacticUsagesFunc.nextHook()(v0, v1, v2, v3, v4)
 	m.SyntacticUsagesFunc.appendCall(CodeNavServiceSyntacticUsagesFuncCall{v0, v1, v2, v3, v4, r0, r1})
 	return r0, r1
@@ -1712,7 +1712,7 @@ func (m *MockCodeNavService) SyntacticUsages(v0 context.Context, v1 types.Repo, 
 // SetDefaultHook sets function that is called when the SyntacticUsages
 // method of the parent MockCodeNavService instance is invoked and the hook
 // queue is empty.
-func (f *CodeNavServiceSyntacticUsagesFunc) SetDefaultHook(hook func(context.Context, types.Repo, api.CommitID, string, scip.Range) ([]struct{}, *codenav.SyntacticUsagesError)) {
+func (f *CodeNavServiceSyntacticUsagesFunc) SetDefaultHook(hook func(context.Context, types.Repo, api.CommitID, string, scip.Range) ([]codenav.SyntacticMatch, *codenav.SyntacticUsagesError)) {
 	f.defaultHook = hook
 }
 
@@ -1720,7 +1720,7 @@ func (f *CodeNavServiceSyntacticUsagesFunc) SetDefaultHook(hook func(context.Con
 // SyntacticUsages method of the parent MockCodeNavService instance invokes
 // the hook at the front of the queue and discards it. After the queue is
 // empty, the default hook function is invoked for any future action.
-func (f *CodeNavServiceSyntacticUsagesFunc) PushHook(hook func(context.Context, types.Repo, api.CommitID, string, scip.Range) ([]struct{}, *codenav.SyntacticUsagesError)) {
+func (f *CodeNavServiceSyntacticUsagesFunc) PushHook(hook func(context.Context, types.Repo, api.CommitID, string, scip.Range) ([]codenav.SyntacticMatch, *codenav.SyntacticUsagesError)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -1728,20 +1728,20 @@ func (f *CodeNavServiceSyntacticUsagesFunc) PushHook(hook func(context.Context, 
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *CodeNavServiceSyntacticUsagesFunc) SetDefaultReturn(r0 []struct{}, r1 *codenav.SyntacticUsagesError) {
-	f.SetDefaultHook(func(context.Context, types.Repo, api.CommitID, string, scip.Range) ([]struct{}, *codenav.SyntacticUsagesError) {
+func (f *CodeNavServiceSyntacticUsagesFunc) SetDefaultReturn(r0 []codenav.SyntacticMatch, r1 *codenav.SyntacticUsagesError) {
+	f.SetDefaultHook(func(context.Context, types.Repo, api.CommitID, string, scip.Range) ([]codenav.SyntacticMatch, *codenav.SyntacticUsagesError) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *CodeNavServiceSyntacticUsagesFunc) PushReturn(r0 []struct{}, r1 *codenav.SyntacticUsagesError) {
-	f.PushHook(func(context.Context, types.Repo, api.CommitID, string, scip.Range) ([]struct{}, *codenav.SyntacticUsagesError) {
+func (f *CodeNavServiceSyntacticUsagesFunc) PushReturn(r0 []codenav.SyntacticMatch, r1 *codenav.SyntacticUsagesError) {
+	f.PushHook(func(context.Context, types.Repo, api.CommitID, string, scip.Range) ([]codenav.SyntacticMatch, *codenav.SyntacticUsagesError) {
 		return r0, r1
 	})
 }
 
-func (f *CodeNavServiceSyntacticUsagesFunc) nextHook() func(context.Context, types.Repo, api.CommitID, string, scip.Range) ([]struct{}, *codenav.SyntacticUsagesError) {
+func (f *CodeNavServiceSyntacticUsagesFunc) nextHook() func(context.Context, types.Repo, api.CommitID, string, scip.Range) ([]codenav.SyntacticMatch, *codenav.SyntacticUsagesError) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -1792,7 +1792,7 @@ type CodeNavServiceSyntacticUsagesFuncCall struct {
 	Arg4 scip.Range
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 []struct{}
+	Result0 []codenav.SyntacticMatch
 	// Result1 is the value of the 2nd result returned from this method
 	// invocation.
 	Result1 *codenav.SyntacticUsagesError


### PR DESCRIPTION
Closes https://linear.app/sourcegraph/issue/GRAPH-657/fetch-and-filter-scip-documents-based-on-candidate-files

## Test plan

Currently only testable via the site-admin API console