### PR TITLE
chore: Add specialized function for sorting primitive sets

### DIFF
--- a/cmd/worker/internal/permissions/BUILD.bazel
+++ b/cmd/worker/internal/permissions/BUILD.bazel
@@ -65,6 +65,7 @@ go_test(
         "//internal/api",
         "//internal/auth",
         "//internal/authz",
+        "//internal/collections",
         "//internal/conf",
         "//internal/database",
         "//internal/database/dbmocks",

--- a/cmd/worker/internal/permissions/bitbucket_projects_test.go
+++ b/cmd/worker/internal/permissions/bitbucket_projects_test.go
@@ -1,7 +1,6 @@
 package permissions
 
 import (
-	"cmp"
 	"context"
 	"encoding/json"
 	"slices"
@@ -13,6 +12,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
+	"github.com/sourcegraph/sourcegraph/internal/collections"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbmocks"
@@ -183,7 +183,7 @@ func TestSetPermissionsForUsers(t *testing.T) {
 
 			err := perms.LoadUserPendingPermissions(ctx, userPerms)
 			require.NoError(t, err)
-			require.Equal(t, []int32{1, 2}, userPerms.IDs.Sorted(cmp.Less[int32]))
+			require.Equal(t, []int32{1, 2}, collections.SortedSetValues(userPerms.IDs))
 		}
 	}
 

--- a/internal/authz/perms.go
+++ b/internal/authz/perms.go
@@ -1,7 +1,6 @@
 package authz
 
 import (
-	"cmp"
 	"fmt"
 	"strings"
 	"time"
@@ -200,7 +199,7 @@ type UserPendingPermissions struct {
 
 // GenerateSortedIDsSlice returns a sorted slice of the IDs set.
 func (p *UserPendingPermissions) GenerateSortedIDsSlice() []int32 {
-	return p.IDs.Sorted(cmp.Less[int32])
+	return collections.SortedSetValues(p.IDs)
 }
 
 func (p *UserPendingPermissions) Attrs() []attribute.KeyValue {

--- a/internal/codeintel/codenav/service_new.go
+++ b/internal/codeintel/codenav/service_new.go
@@ -1,7 +1,6 @@
 package codenav
 
 import (
-	"cmp"
 	"context"
 	"strings"
 
@@ -341,7 +340,7 @@ func (s *Service) gatherLocalLocations(
 	}
 
 	// re-assign mutable cursor scope to response cursor
-	cursor.SymbolNames = allSymbolNames.Sorted(compareStrings)
+	cursor.SymbolNames = collections.SortedSetValues(allSymbolNames)
 	cursor.SkipPathsByUploadID = skipPathsByUploadID
 
 	return allLocations, cursor, nil
@@ -496,7 +495,7 @@ func (s *Service) prepareCandidateUploads(
 		for _, upload := range uploads {
 			idSet.Add(upload.ID)
 		}
-		ids := idSet.Sorted(cmp.Less[int])
+		ids := collections.SortedSetValues(idSet)
 
 		fallback = false
 		cursor.UploadIDs = ids

--- a/internal/collections/set.go
+++ b/internal/collections/set.go
@@ -1,10 +1,10 @@
 package collections
 
 import (
+	"cmp"
 	"fmt"
-	"sort"
-
 	"golang.org/x/exp/maps"
+	"slices"
 )
 
 // Set is a set (collection of unique elements) implemented as a map.
@@ -48,20 +48,26 @@ func (s Set[T]) Values() []T {
 	return maps.Keys(s)
 }
 
-// Sorted returns the values of the set in sorted order using the given
+// SortedFunc returns the values of the set in sorted order using the given
 // comparator function.
 //
-// The comparator function should return true if the first argument is less than
-// the second, and false otherwise.
+// The comparator should return -1 / 0 / +1 based on comparison,
+// similar to cmp.Compare.
 //
-// Example:
-//
-//	s.Sorted(func(a, b int) bool { return a < b })
-func (s Set[T]) Sorted(comparator func(a, b T) bool) []T {
+// Prefer SortedSetValues for primitive types.
+func (s Set[T]) SortedFunc(comparator func(a, b T) int) []T {
 	vals := s.Values()
-	sort.Slice(vals, func(i, j int) bool {
-		return comparator(vals[i], vals[j])
-	})
+	slices.SortFunc(vals, comparator)
+	return vals
+}
+
+// SortedSetValues is equivalent to SortedFunc(s, cmp.Compare).
+//
+// Ideally, this would be a method on Set[T], but Go does not allow
+// adding constraints to type parameters in methods.
+func SortedSetValues[T cmp.Ordered](s Set[T]) []T {
+	vals := s.Values()
+	slices.Sort(vals)
 	return vals
 }
 


### PR DESCRIPTION
The most common case is sorting primitives, so add a specialized
function for that which doesn't require passing in a comparator explicitly.

## Test plan

Updated existing tests

## Changelog