### PR TITLE
fix(svelte): Add trailing slash to group and directory suggestions

### DIFF
--- a/client/web-sveltekit/src/lib/search/codemirror/suggestions.ts
+++ b/client/web-sveltekit/src/lib/search/codemirror/suggestions.ts
@@ -82,8 +82,11 @@ export function createScopeSuggestions(options: ScopeSuggestionsOptions): Extens
             const options: Option[] = []
 
             {
-                const group = dirname(repoName)
+                let group = dirname(repoName)
                 if (group !== '.') {
+                    if (!group.endsWith('/')) {
+                        group += '/'
+                    }
                     const option = createFilterSuggestion(
                         FilterType.repo,
                         `^${escapeRegExp(group)}`,
@@ -119,6 +122,9 @@ export function createScopeSuggestions(options: ScopeSuggestionsOptions): Extens
             const options: Option[] = []
 
             if (directoryPath && directoryPath !== '.') {
+                if (!directoryPath.endsWith('/')) {
+                    directoryPath += '/'
+                }
                 const option = createFilterSuggestion(
                     FilterType.file,
                     `^${escapeRegExp(directoryPath)}`,


### PR DESCRIPTION
This PR appends a trailing slash to org and directory suggestions so that we don't search in repos or directories that are a prefix of the current org/directory.

## Test plan

Manual testing.
