### PR TITLE
PLG: encode URL search params

### DIFF
--- a/client/web/src/cody/management/api/react-query/callCodyProApi.ts
+++ b/client/web/src/cody/management/api/react-query/callCodyProApi.ts
@@ -31,9 +31,13 @@ const buildRequestInit = ({ headers = {}, ...init }: RequestInit): RequestInit =
 const signOutAndRedirectToSignIn = async (): Promise<void> => {
     const response = await fetch('/-/sign-out', buildRequestInit({ method: 'GET' }))
     if (response.ok) {
-        window.location.href = `/sign-in?returnTo=${window.location.pathname + window.location.search}`
+        window.location.href = `/sign-in?returnTo=${
+            window.location.pathname + encodeURIComponent(window.location.search)
+        }`
     }
 }
+
+window.signOutAndRedirectToSignIn = signOutAndRedirectToSignIn
 
 // Important: This function has the side effect of logging the user out and redirecting them
 // to the sign-in page with the current page as the return URL if they are not authenticated.

--- a/client/web/src/cody/management/api/react-query/callCodyProApi.ts
+++ b/client/web/src/cody/management/api/react-query/callCodyProApi.ts
@@ -37,8 +37,6 @@ const signOutAndRedirectToSignIn = async (): Promise<void> => {
     }
 }
 
-window.signOutAndRedirectToSignIn = signOutAndRedirectToSignIn
-
 // Important: This function has the side effect of logging the user out and redirecting them
 // to the sign-in page with the current page as the return URL if they are not authenticated.
 export const callCodyProApi = async (call: Call<unknown>): Promise<Response> => {


### PR DESCRIPTION
Fixes bug intorduced in https://github.com/sourcegraph/sourcegraph/pull/63231

Encode the URL search params added to `returnTo` search param value.

Previously the search param value hasn't been encoded resulting in URLs with broken search params , e.g. *"/sign-in?returnTo=/cody/manage?teamID=1&inviteID=2"* (note the second "?" making the search params invalid). 



<!-- 💡 To write a useful PR description, make sure that your description covers:
- WHAT this PR is changing:
    - How was it PREVIOUSLY.
    - How it will be from NOW on.
- WHY this PR is needed.
- CONTEXT, i.e. to which initiative, project or RFC it belongs.

The structure of the description doesn't matter as much as covering these points, so use
your best judgement based on your context.
Learn how to write good pull request description: https://www.notion.so/sourcegraph/Write-a-good-pull-request-description-610a7fd3e613496eb76f450db5a49b6e?pvs=4 -->


## Test plan
- CI
- Tested manually:
   - Make `signOutAndRedirectToSignIn` available in the window object, e.g. `window.signOutAndRedirectToSignIn = signOutAndRedirectToSignIn` in the *client/web/src/cody/management/api/react-query/callCodyProApi.ts*
   - On "/cody/manage" page (any page works actually) ensure that a few search params are added to the URL
   - call `signOutAndRedirectToSignIn` in the browser console
   - ensure you have been sign out, signed back in and the search params are still in the URL
<!-- All pull requests REQUIRE a test plan: https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles -->


## Changelog

<!--
1. Ensure your pull request title is formatted as: $type($domain): $what
2. Add bullet list items for each additional detail you want to cover (see example below)
3. You can edit this after the pull request was merged, as long as release shipping it hasn't been promoted to the public.
4. For more information, please see this how-to https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c?

Audience: TS/CSE > Customers > Teammates (in that order).

Cheat sheet: $type = chore|fix|feat $domain: source|search|ci|release|plg|cody|local|...
-->

<!--
Example:

Title: fix(search): parse quotes with the appropriate context
Changelog section:

## Changelog

- When a quote is used with regexp pattern type, then ...
- Refactored underlying code.
-->
