### PR TITLE
fix(ci): remove broken glob

### DIFF
--- a/client/web/BUILD.bazel
+++ b/client/web/BUILD.bazel
@@ -144,7 +144,7 @@ filegroup(
 
 ts_project(
     name = "web_lib",
-    srcs = glob(["!src/playwright/*.spec.ts"]) + [
+    srcs = [
         "src/Index.tsx",
         "src/LegacyLayout.tsx",
         "src/LegacyRouteContext.tsx",


### PR DESCRIPTION
A glob that doesn't match any files got introduced in https://github.com/sourcegraph/sourcegraph/commit/4077b3ec22dad1c93675fd3e33336a35019bac00#diff-f7c1ab1acb5e753bccdd4b092b0098fa58855899e8764b68829ada2ba9cea760R147 which appears to confuse Gazelle, leading to `sg bazel configure` not updating ts files. 

Fixes https://github.com/sourcegraph/devx-support/issues/1029


## Test plan

Locally tested: 

1. Dropped the offending glob 
2. rm'ed `client/web/src/cody/subscription/subscriptionSummary.ts` 
3. `sg bazel configure` 
4. Observed the build file being updated accordingly. 

<!-- All pull requests REQUIRE a test plan: https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles -->


## Changelog

<!--
1. Ensure your pull request title is formatted as: $type($domain): $what
5. Add bullet list items for each additional detail you want to cover (see example below)
6. You can edit this after the pull request was merged, as long as release shipping it hasn't been promoted to the public.
7. For more information, please see this how-to https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c?

Audience: TS/CSE > Customers > Teammates (in that order).

Cheat sheet: $type = chore|fix|feat $domain: source|search|ci|release|plg|cody|local|...
-->

<!--
Example:

Title: fix(search): parse quotes with the appropriate context
Changelog section:

## Changelog

- When a quote is used with regexp pattern type, then ...
- Refactored underlying code.
-->
