### PR TITLE
adding deepseek and lang specific mixtral for completions ab experiment

### DIFF
--- a/cmd/cody-gateway/internal/httpapi/completions/fireworks.go
+++ b/cmd/cody-gateway/internal/httpapi/completions/fireworks.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/sourcegraph/log"
+
 	"github.com/sourcegraph/sourcegraph/cmd/cody-gateway/shared/config"
 
 	"github.com/sourcegraph/sourcegraph/internal/completions/client/fireworks"
@@ -243,18 +244,15 @@ func pickStarCoderModel(model string, config config.FireworksConfig) string {
 
 func pickFineTunedModel(model string, language string) string {
 	switch model {
-	// 1. Fine-tuned models Mixtral variant
-	case fireworks.FineTunedFIMVariant1:
-		return fireworks.FineTunedMixtralAll
-
-	// 2. Fine-tuned model Language specific mixtral variant
-	case fireworks.FineTunedFIMVariant2:
+	case fireworks.FineTunedFIMLangSpecificMixtral:
 		{
 			switch language {
 			case "typescript", "typescriptreact":
 				return fireworks.FineTunedMixtralTypescript
 			case "javascript":
 				return fireworks.FineTunedMixtralJavascript
+			case "javascriptreact":
+				return fireworks.FineTunedMixtralJsx
 			case "php":
 				return fireworks.FineTunedMixtralPhp
 			case "python":
@@ -263,27 +261,9 @@ func pickFineTunedModel(model string, language string) string {
 				return fireworks.FineTunedMixtralAll
 			}
 		}
-	case fireworks.FineTunedFIMVariant3:
-		return fireworks.FineTunedLlamaAll
-	case fireworks.FineTunedFIMVariant4:
-		{
-			switch language {
-			case "typescript", "typescriptreact":
-				return fireworks.FineTunedLlamaTypescript
-			case "javascript":
-				return fireworks.FineTunedLlamaJavascript
-			case "php":
-				return fireworks.FineTunedLlamaPhp
-			case "python":
-				return fireworks.FineTunedLlamaPython
-			default:
-				return fireworks.FineTunedLlamaAll
-			}
-		}
 	default:
 		return model
 	}
-
 }
 
 // Picks a model based on a specific percentage split. If the percent value is 0, the

--- a/cmd/cody-gateway/shared/config/config.go
+++ b/cmd/cody-gateway/shared/config/config.go
@@ -293,6 +293,8 @@ func (c *Config) Load() {
 			// Deprecated model strings
 			"accounts/fireworks/models/starcoder-3b-w8a16",
 			"accounts/fireworks/models/starcoder-1b-w8a16",
+			fireworks.DeepseekCoder1p3b,
+			fireworks.DeepseekCoder7b,
 		}, fireworks.FineTunedLlamaModelVariants, fireworks.FineTunedMixtralModelVariants), ","),
 		"Fireworks models that can be used."))
 	if c.Fireworks.AccessToken != "" && len(c.Fireworks.AllowedModels) == 0 {

--- a/cmd/frontend/internal/dotcom/productsubscription/codygateway_dotcom_user.go
+++ b/cmd/frontend/internal/dotcom/productsubscription/codygateway_dotcom_user.go
@@ -337,7 +337,9 @@ var allCodeCompletionModels = slices.Concat([]string{"anthropic/" + anthropic.Cl
 	"fireworks/starcoder",
 	"fireworks/" + fireworks.Llama213bCode,
 	"fireworks/" + fireworks.StarcoderTwo15b,
-	"fireworks/" + fireworks.StarcoderTwo7b},
+	"fireworks/" + fireworks.StarcoderTwo7b,
+	"fireworks/" + fireworks.DeepseekCoder1p3b,
+	"fireworks/" + fireworks.DeepseekCoder7b},
 	prefix("fireworks/", fireworks.FineTunedMixtralModelVariants),
 	prefix("fireworks/", fireworks.FineTunedLlamaModelVariants))
 

--- a/cmd/frontend/internal/httpapi/completions/codecompletion.go
+++ b/cmd/frontend/internal/httpapi/completions/codecompletion.go
@@ -62,6 +62,9 @@ func allowedCustomModel(model string) string {
 		"fireworks/" + fireworks.FineTunedFIMVariant2,
 		"fireworks/" + fireworks.FineTunedFIMVariant3,
 		"fireworks/" + fireworks.FineTunedFIMVariant4,
+		"fireworks/" + fireworks.FineTunedFIMLangSpecificMixtral,
+		"fireworks/" + fireworks.DeepseekCoder1p3b,
+		"fireworks/" + fireworks.DeepseekCoder7b,
 		"anthropic/claude-instant-1.2",
 		"anthropic/claude-3-haiku-20240307",
 		// Deprecated model identifiers

--- a/internal/completions/client/fireworks/fireworks.go
+++ b/internal/completions/client/fireworks/fireworks.go
@@ -33,19 +33,23 @@ const Llama370bInstruct = "accounts/fireworks/models/llama-v3-70b-instruct"
 const Mistral7bInstruct = "accounts/fireworks/models/mistral-7b-instruct-4k"
 const Mixtral8x7bInstruct = "accounts/fireworks/models/mixtral-8x7b-instruct"
 const Mixtral8x22Instruct = "accounts/fireworks/models/mixtral-8x22b-instruct"
+const DeepseekCoder1p3b = "accounts/sourcegraph/models/custom-deepseek-1p3b-base-hf-version"
+const DeepseekCoder7b = "accounts/sourcegraph/models/deepseek-coder-7b-base"
 
 const FineTunedFIMVariant1 = "fim-fine-tuned-model-variant-1"
 const FineTunedFIMVariant2 = "fim-fine-tuned-model-variant-2"
 const FineTunedFIMVariant3 = "fim-fine-tuned-model-variant-3"
 const FineTunedFIMVariant4 = "fim-fine-tuned-model-variant-4"
+const FineTunedFIMLangSpecificMixtral = "fim-lang-specific-model-mixtral"
 
-const FineTunedMixtralTypescript = "accounts/sourcegraph/models/typescript-context-aware-fim-mixtral-8x7b-instruct-v0-1-e-1"
-const FineTunedMixtralJavascript = "accounts/sourcegraph/models/javascript-context-aware-fim-mixtral-8x7b-instruct-v0-1-e-1"
-const FineTunedMixtralPhp = "accounts/sourcegraph/models/php-context-aware-fim-mixtral-8x7b-instruct-v0-1-e-1"
-const FineTunedMixtralPython = "accounts/sourcegraph/models/python-context-aware-fim-mixtral-8x7b-instruct-v0-1-e-1"
+const FineTunedMixtralTypescript = "accounts/sourcegraph/models/finetuned-fim-lang-typescript-model-mixtral-8x7b"
+const FineTunedMixtralJavascript = "accounts/sourcegraph/models/finetuned-fim-lang-javascript-model-mixtral-8x7b"
+const FineTunedMixtralPhp = "accounts/sourcegraph/models/finetuned-fim-lang-php-model-mixtral-8x7b"
+const FineTunedMixtralPython = "accounts/sourcegraph/models/finetuned-fim-lang-python-model-mixtral-8x7b"
+const FineTunedMixtralJsx = "accounts/sourcegraph/models/finetuned-fim-lang-jsx-model-mixtral-8x7b"
 const FineTunedMixtralAll = "accounts/sourcegraph/models/finetuned-fim-lang-all-model-mixtral-8x7b"
 
-var FineTunedMixtralModelVariants = []string{FineTunedMixtralTypescript, FineTunedMixtralJavascript, FineTunedMixtralPhp, FineTunedMixtralPython, FineTunedMixtralAll}
+var FineTunedMixtralModelVariants = []string{FineTunedMixtralTypescript, FineTunedMixtralJavascript, FineTunedMixtralPhp, FineTunedMixtralPython, FineTunedMixtralAll, FineTunedMixtralJsx, FineTunedFIMLangSpecificMixtral}
 
 const FineTunedLlamaTypescript = "accounts/sourcegraph/models/lang-typescript-context-fim-meta-llama-3-8b-instruct-e-1"
 const FineTunedLlamaJavascript = "accounts/sourcegraph/models/lang-javascript-context-fim-meta-llama-3-8b-instruct-e-1"


### PR DESCRIPTION
## Context
1. Adds support for deepseek-coder model and updated Mixtral finetuned-FIM models identifiers hosted on Fireworks. 
2. Client side pull request: https://github.com/sourcegraph/cody/pull/4577

## Test plan
```
curl -vS -X POST http://localhost:9992/v1/completions/fireworks -H 'Authorization: bearer <SGD_TOKEN>' -d '{"stream":false,"max_tokens":50, "model": "accounts/sourcegraph/models/deepseek-coder-7b-base", "stop_sequences": ["\n\n"], "prompt": "const value = ", "stream":false}' -H 'X-sourcegraph-feature: code_completions'
```

```
curl -vS -X POST http://localhost:9992/v1/completions/fireworks -H 'Authorization: bearer <SGD_TOKEN>' -d '{"stream":false,"max_tokens":50, "model": "accounts/sourcegraph/models/custom-deepseek-1p3b-base-hf-version", "stop_sequences": ["\n\n"], "prompt": "const value = ", "stream":false}' -H 'X-sourcegraph-feature: code_completions'
```

```
curl -vS -X POST http://localhost:9992/v1/completions/fireworks -H 'Authorization: bearer <SGD_TOKEN>' -d '{"stream":false,"max_tokens":50, "model": "fim-lang-specific-model-mixtral", "stop_sequences": ["\n\n"], "prompt": "const value = ", "stream":false}' -H 'X-sourcegraph-feature: code_completions'
```

