### PR TITLE
Wraps up syntactic usages in resolvers

### DIFF
--- a/internal/codeintel/codenav/transport/graphql/root_resolver.go
+++ b/internal/codeintel/codenav/transport/graphql/root_resolver.go
@@ -229,6 +229,18 @@ func (r *rootResolver) UsagesForSymbol(ctx context.Context, unresolvedArgs *reso
 
 			}
 		}
+
+		usageResolvers := []resolverstubs.UsageResolver{}
+		for _, result := range results {
+			usageResolvers = append(usageResolvers, NewSyntacticUsageResolver(result, args.Repo, args.CommitID))
+		}
+		if len(usageResolvers) != 0 {
+			return &usageConnectionResolver{
+				nodes:    usageResolvers,
+				pageInfo: resolverstubs.NewSimplePageInfo(false),
+			}, nil
+		}
+
 		numSyntacticResults = len(results)
 		remainingCount = remainingCount - numSyntacticResults
 	}

--- a/internal/codeintel/codenav/transport/graphql/root_resolver_usages.go
+++ b/internal/codeintel/codenav/transport/graphql/root_resolver_usages.go
@@ -2,37 +2,59 @@ package graphql
 
 import (
 	"context"
+
+	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/codeintel/codenav"
+	"github.com/sourcegraph/sourcegraph/internal/codeintel/codenav/shared"
 	resolverstubs "github.com/sourcegraph/sourcegraph/internal/codeintel/resolvers"
+	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
 type usageConnectionResolver struct {
+	nodes    []resolverstubs.UsageResolver
+	pageInfo resolverstubs.PageInfo
 }
 
 var _ resolverstubs.UsageConnectionResolver = &usageConnectionResolver{}
 
 func (u *usageConnectionResolver) Nodes(ctx context.Context) ([]resolverstubs.UsageResolver, error) {
-	//TODO implement me
-	panic("implement me")
+	return u.nodes, nil
 }
 
 func (u *usageConnectionResolver) PageInfo() resolverstubs.PageInfo {
-	//TODO implement me
-	panic("implement me")
+	return u.pageInfo
 }
 
 type usageResolver struct {
+	symbol     resolverstubs.SymbolInformationResolver
+	usageRange resolverstubs.UsageRangeResolver
 }
 
 var _ resolverstubs.UsageResolver = &usageResolver{}
 
+func NewSyntacticUsageResolver(usage codenav.SyntacticMatch, repository types.Repo, revision api.CommitID) resolverstubs.UsageResolver {
+	return &usageResolver{
+		symbol: &symbolInformationResolver{
+			name:       usage.Occurrence.Symbol,
+			provenance: resolverstubs.ProvenanceSyntactic,
+		},
+		usageRange: &usageRangeResolver{
+			repository: repository,
+			revision:   revision,
+			path:       usage.Path,
+			rx: &rangeResolver{
+				lspRange: convertRange(shared.TranslateRange(usage.Range())),
+			},
+		},
+	}
+}
+
 func (u *usageResolver) Symbol(ctx context.Context) (resolverstubs.SymbolInformationResolver, error) {
-	//TODO implement me
-	panic("implement me")
+	return u.symbol, nil
 }
 
 func (u *usageResolver) UsageRange(ctx context.Context) (resolverstubs.UsageRangeResolver, error) {
-	//TODO implement me
-	panic("implement me")
+	return u.usageRange, nil
 }
 
 func (u *usageResolver) SurroundingContent(_ context.Context, args *struct {
@@ -47,13 +69,14 @@ func (u *usageResolver) UsageKind() resolverstubs.SymbolUsageKind {
 }
 
 type symbolInformationResolver struct {
+	name       string
+	provenance resolverstubs.CodeGraphDataProvenance
 }
 
 var _ resolverstubs.SymbolInformationResolver = &symbolInformationResolver{}
 
 func (s *symbolInformationResolver) Name() (string, error) {
-	//TODO implement me
-	panic("implement me")
+	return s.name, nil
 }
 
 func (s *symbolInformationResolver) Documentation() (*[]string, error) {
@@ -62,8 +85,7 @@ func (s *symbolInformationResolver) Documentation() (*[]string, error) {
 }
 
 func (s *symbolInformationResolver) Provenance() (resolverstubs.CodeGraphDataProvenance, error) {
-	//TODO implement me
-	panic("implement me")
+	return s.provenance, nil
 }
 
 func (s *symbolInformationResolver) DataSource() *string {
@@ -71,26 +93,27 @@ func (s *symbolInformationResolver) DataSource() *string {
 	panic("implement me")
 }
 
-type usageRangeResolver struct{}
+type usageRangeResolver struct {
+	repository types.Repo
+	revision   api.CommitID
+	path       string
+	rx         *rangeResolver
+}
 
 var _ resolverstubs.UsageRangeResolver = &usageRangeResolver{}
 
 func (u *usageRangeResolver) Repository() string {
-	//TODO implement me
-	panic("implement me")
+	return string(u.repository.Name)
 }
 
 func (u *usageRangeResolver) Revision() string {
-	//TODO implement me
-	panic("implement me")
+	return string(u.revision)
 }
 
 func (u *usageRangeResolver) Path() string {
-	//TODO implement me
-	panic("implement me")
+	return u.path
 }
 
 func (u *usageRangeResolver) Range() resolverstubs.RangeResolver {
-	//TODO implement me
-	panic("implement me")
+	return u.rx
 }

--- a/internal/codeintel/codenav/transport/graphql/root_resolver_usages.go
+++ b/internal/codeintel/codenav/transport/graphql/root_resolver_usages.go
@@ -3,6 +3,8 @@ package graphql
 import (
 	"context"
 
+	"github.com/sourcegraph/scip/bindings/go/scip"
+
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/codenav"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/codenav/shared"
@@ -42,9 +44,7 @@ func NewSyntacticUsageResolver(usage codenav.SyntacticMatch, repository types.Re
 			repository: repository,
 			revision:   revision,
 			path:       usage.Path,
-			rx: &rangeResolver{
-				lspRange: convertRange(shared.TranslateRange(usage.Range())),
-			},
+			range_:     usage.Range(),
 		},
 	}
 }
@@ -97,7 +97,7 @@ type usageRangeResolver struct {
 	repository types.Repo
 	revision   api.CommitID
 	path       string
-	rx         *rangeResolver
+	range_     scip.Range
 }
 
 var _ resolverstubs.UsageRangeResolver = &usageRangeResolver{}
@@ -115,5 +115,7 @@ func (u *usageRangeResolver) Path() string {
 }
 
 func (u *usageRangeResolver) Range() resolverstubs.RangeResolver {
-	return u.rx
+	return &rangeResolver{
+		lspRange: convertRange(shared.TranslateRange(u.range_)),
+	}
 }

--- a/internal/codeintel/codenav/transport/graphql/root_resolver_usages.go
+++ b/internal/codeintel/codenav/transport/graphql/root_resolver_usages.go
@@ -29,17 +29,25 @@ func (u *usageConnectionResolver) PageInfo() resolverstubs.PageInfo {
 
 type usageResolver struct {
 	symbol     resolverstubs.SymbolInformationResolver
+	kind       resolverstubs.SymbolUsageKind
 	usageRange resolverstubs.UsageRangeResolver
 }
 
 var _ resolverstubs.UsageResolver = &usageResolver{}
 
 func NewSyntacticUsageResolver(usage codenav.SyntacticMatch, repository types.Repo, revision api.CommitID) resolverstubs.UsageResolver {
+	var kind resolverstubs.SymbolUsageKind
+	if scip.SymbolRole_Definition.Matches(usage.Occurrence) {
+		kind = resolverstubs.UsageKindDefinition
+	} else {
+		kind = resolverstubs.UsageKindReference
+	}
 	return &usageResolver{
 		symbol: &symbolInformationResolver{
 			name:       usage.Occurrence.Symbol,
 			provenance: resolverstubs.ProvenanceSyntactic,
 		},
+		kind: kind,
 		usageRange: &usageRangeResolver{
 			repository: repository,
 			revision:   revision,
@@ -65,7 +73,7 @@ func (u *usageResolver) SurroundingContent(_ context.Context, args *struct {
 }
 
 func (u *usageResolver) UsageKind() resolverstubs.SymbolUsageKind {
-	panic("implement me")
+	return u.kind
 }
 
 type symbolInformationResolver struct {


### PR DESCRIPTION
Fixes https://linear.app/sourcegraph/issue/GRAPH-667/wrap-up-usage-results-in-graphql-resolvers

This allows us to actually return syntactic usages from the occurrences API. It does not implement pagination yet, but I think _that_ PR will be nicer to review after this one landed.

Requires #63268

## Test plan

Running queries against the site-admin api console
