### PR TITLE
fix(plg): Fix redirect on the Cody Management page in an edge case

### DIFF
--- a/client/web/src/cody/onboarding/CodyOnboarding.tsx
+++ b/client/web/src/cody/onboarding/CodyOnboarding.tsx
@@ -52,10 +52,10 @@ export function CodyOnboarding({ authenticatedUser, telemetryRecorder }: CodyOnb
     const navigate = useNavigate()
 
     useEffect(() => {
-        if (completed && returnToURL) {
+        if (returnToURL && (!(signUpFlowStatus === 'loaded' && !signUpFlowEnabled) || completed)) {
             navigate(returnToURL)
         }
-    }, [completed, returnToURL, navigate])
+    }, [completed, returnToURL, navigate, signUpFlowStatus, signUpFlowEnabled])
 
     useEffect(() => {
         if (signUpFlowStatus === 'loaded' && signUpFlowEnabled && isCody) {


### PR DESCRIPTION
I'm stuck on the `/cody/manage` page when trying to sign in to Cody in VS Code.

- I'm redirected to https://sourcegraph.com/.auth/openidconnect/login
- Then to https://sourcegraph.com/post-sign-up
- Then to https://sourcegraph.com/cody-manage, but then I'm stuck:

<img src="https://github.com/sourcegraph/sourcegraph/assets/2552265/489cd8c0-62d6-4f06-b154-cb257ed5378d" alt="Screenshot" />

It's because I haven't completed the onboarding but onboarding is not enabled on my account.

I think it only affects me because I did testing before, but it might also happen to real uses if we mass-disable onboarding.

## Test plan

Tested manually.