### PR TITLE
Svelte: fix sidebar icon alignment

### DIFF
--- a/client/web-sveltekit/src/lib/search/dynamicFilters/Section.svelte
+++ b/client/web-sveltekit/src/lib/search/dynamicFilters/Section.svelte
@@ -32,15 +32,7 @@
             {#each limitedItems as item}
                 <li>
                     <slot name="item" {item}>
-                        {#if $$slots.label}
-                            <SectionItem {item} {onFilterSelect}>
-                                <svelte:fragment slot="label" let:label let:value>
-                                    <slot name="label" {label} {value} />
-                                </svelte:fragment>
-                            </SectionItem>
-                        {:else}
-                            <SectionItem {item} {onFilterSelect} />
-                        {/if}
+                        <SectionItem {item} {onFilterSelect} />
                     </slot>
                 </li>
             {/each}

--- a/client/web-sveltekit/src/lib/search/dynamicFilters/SectionItem.svelte
+++ b/client/web-sveltekit/src/lib/search/dynamicFilters/SectionItem.svelte
@@ -14,6 +14,7 @@
     class:selected={item.selected}
     on:click={() => onFilterSelect(item.kind)}
 >
+    <slot name="icon" />
     <span class="label">
         <slot name="label" label={item.label} value={item.value}>
             {item.label}
@@ -38,7 +39,7 @@
         border-radius: var(--border-radius);
         color: inherit;
         white-space: nowrap;
-        gap: 0.25rem;
+        gap: 0.5rem;
 
         padding: 0.25rem 0.5rem;
         margin: 0;

--- a/client/web-sveltekit/src/lib/search/dynamicFilters/Sidebar.svelte
+++ b/client/web-sveltekit/src/lib/search/dynamicFilters/Sidebar.svelte
@@ -97,13 +97,9 @@
 
         {#if !queryHasTypeFilter(searchQuery)}
             <Section items={typeFilters} title="By type" showAll onFilterSelect={handleFilterSelect}>
-                <svelte:fragment slot="item" let:item>
-                    <SectionItem {item}>
-                        <svelte:fragment slot="icon">
-                            <Icon icon={typeFilterIcons[item.label]} inline />
-                        </svelte:fragment>
-                    </SectionItem>
-                </svelte:fragment>
+                <SectionItem slot="item" let:item {item}>
+                    <Icon slot="icon" icon={typeFilterIcons[item.label]} inline />
+                </SectionItem>
             </Section>
         {/if}
 
@@ -117,12 +113,8 @@
                 <Popover showOnHover let:registerTrigger placement="right-start">
                     <div use:registerTrigger>
                         <SectionItem {item}>
-                            <svelte:fragment slot="icon">
-                                <CodeHostIcon disableTooltip repository={item.label} />
-                            </svelte:fragment>
-                            <svelte:fragment slot="label" let:label>
-                                <span>{displayRepoName(label)}</span>
-                            </svelte:fragment>
+                            <CodeHostIcon slot="icon" disableTooltip repository={item.label} />
+                            <span slot="label" let:label>{displayRepoName(label)}</span>
                         </SectionItem>
                     </div>
                     <svelte:fragment slot="content">
@@ -141,10 +133,8 @@
             filterPlaceholder="Filter languages"
             onFilterSelect={handleFilterSelect}
         >
-            <SectionItem {item} slot="item" let:item>
-                <svelte:fragment slot="icon">
-                    <LanguageIcon language={item.label} inline />
-                </svelte:fragment>
+            <SectionItem slot="item" let:item {item}>
+                <LanguageIcon slot="icon" language={item.label} inline />
             </SectionItem>
         </Section>
         <Section
@@ -153,12 +143,9 @@
             filterPlaceholder="Filter symbol types"
             onFilterSelect={handleFilterSelect}
         >
-            <svelte:fragment slot="label" let:label>
-                <div class="symbol-label">
-                    <SymbolKindIcon symbolKind={label.toUpperCase()} />
-                    {label}
-                </div>
-            </svelte:fragment>
+            <SectionItem slot="item" let:item {item}>
+                <SymbolKindIcon slot="icon" symbolKind={item.label.toUpperCase()} />
+            </SectionItem>
         </Section>
         <Section
             items={groupedFilters.author}
@@ -167,10 +154,12 @@
             onFilterSelect={handleFilterSelect}
         />
         <Section items={groupedFilters['commit date']} title="By commit date" onFilterSelect={handleFilterSelect}>
-            <span class="commit-date-label" slot="label" let:label let:value>
-                {label}
-                <small><pre>{value}</pre></small>
-            </span>
+            <SectionItem slot="item" let:item {item}>
+                <span class="commit-date-label" slot="label">
+                    {item.label}
+                    <small><pre>{item.value}</pre></small>
+                </span>
+            </SectionItem>
         </Section>
         <Section items={groupedFilters.file} title="By file" showAll onFilterSelect={handleFilterSelect} />
         <Section items={groupedFilters.utility} title="Utility" showAll onFilterSelect={handleFilterSelect} />
@@ -237,12 +226,6 @@
             fill: none !important;
             --icon-color: var(--body-color);
         }
-    }
-
-    .symbol-label {
-        display: flex;
-        align-items: center;
-        gap: 0.5rem;
     }
 
     pre {

--- a/client/web-sveltekit/src/lib/search/dynamicFilters/Sidebar.svelte
+++ b/client/web-sveltekit/src/lib/search/dynamicFilters/Sidebar.svelte
@@ -97,9 +97,12 @@
 
         {#if !queryHasTypeFilter(searchQuery)}
             <Section items={typeFilters} title="By type" showAll onFilterSelect={handleFilterSelect}>
-                <svelte:fragment slot="label" let:label>
-                    <Icon icon={typeFilterIcons[label]} inline aria-hidden="true" />&nbsp;
-                    {label}
+                <svelte:fragment slot="item" let:item>
+                    <SectionItem {item}>
+                        <svelte:fragment slot="icon">
+                            <Icon icon={typeFilterIcons[item.label]} inline />
+                        </svelte:fragment>
+                    </SectionItem>
                 </svelte:fragment>
             </Section>
         {/if}
@@ -114,8 +117,10 @@
                 <Popover showOnHover let:registerTrigger placement="right-start">
                     <div use:registerTrigger>
                         <SectionItem {item}>
+                            <svelte:fragment slot="icon">
+                                <CodeHostIcon disableTooltip repository={item.label} />
+                            </svelte:fragment>
                             <svelte:fragment slot="label" let:label>
-                                <CodeHostIcon disableTooltip repository={label} />
                                 <span>{displayRepoName(label)}</span>
                             </svelte:fragment>
                         </SectionItem>
@@ -136,10 +141,11 @@
             filterPlaceholder="Filter languages"
             onFilterSelect={handleFilterSelect}
         >
-            <svelte:fragment slot="label" let:label>
-                <LanguageIcon language={label} inline />&nbsp;
-                {label}
-            </svelte:fragment>
+            <SectionItem {item} slot="item" let:item>
+                <svelte:fragment slot="icon">
+                    <LanguageIcon language={item.label} inline />
+                </svelte:fragment>
+            </SectionItem>
         </Section>
         <Section
             items={groupedFilters['symbol type']}


### PR DESCRIPTION
This fixes the alignment of the icons in the dynamic filters sidebar by mvoing the icon out of the `label` span and directly under the section item flexbox. I did this by creating an `icon` slot, which also allowed me to simplify a bunch of other complex slot interactions.

Contributes to SRCH-531

## Test plan

Manually visually inspected each of the types of section items.
