### PR TITLE
fix/graphql/database: make count of failed user permissions syncs ignore soft deleted users

### DIFF
--- a/internal/database/permission_sync_jobs_test.go
+++ b/internal/database/permission_sync_jobs_test.go
@@ -904,6 +904,30 @@ func TestPermissionSyncJobs_CountUsersWithFailingSyncJob(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, int32(2), count, "wrong count")
 	})
+
+	t.Run("Should not count jobs with a deleted user", func(t *testing.T) {
+		cleanupSyncJobs(t, db, ctx)
+		tmpUser, err := usersStore.Create(ctx, NewUser{Username: "test-user-tmp"})
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			_ = usersStore.HardDelete(ctx, tmpUser.ID) // Ensure we clean up after ourselves.
+		})
+
+		createSyncJob(t, store, ctx, tmpUser.ID, 0) // id = 1
+		finishSyncJobWithFailure(t, db, ctx, 1, clock.Now().Add(-1*time.Hour))
+
+		count, err := store.CountUsersWithFailingSyncJob(ctx)
+		require.NoError(t, err)
+		require.Equal(t, int32(1), count, "wrong count")
+
+		// Delete tmpUser
+		err = usersStore.Delete(ctx, tmpUser.ID)
+		require.NoError(t, err)
+
+		count, err = store.CountUsersWithFailingSyncJob(ctx)
+		require.NoError(t, err)
+		require.Equal(t, int32(0), count, "wrong count")
+	})
 }
 
 func TestPermissionSyncJobs_CountReposWithFailingSyncJob(t *testing.T) {


### PR DESCRIPTION
This PR changes the query that powers the "failed user sync count" on the permissions center to now properly ignore soft-deleted users. The admin can't take any action to remedy this, so there is no point in displaying it.


![Screenshot 2024-06-17 at 12.52.08 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/5VKJ5spRdhDRvKQ0TTIe/6ef49bc9-fc65-4ef9-a58e-f2a66ff87e31.png)


## Test plan

Unit tests

## Changelog 

- The failed user permission sync count on the permission dashboard now properly ignores syncs from deleted users (which is the expected behavior).
