### PR TITLE
fix/graphql/database: fix repo permission sync count to ignore soft deleted repositories

### DIFF
--- a/internal/database/permission_sync_jobs.go
+++ b/internal/database/permission_sync_jobs.go
@@ -722,7 +722,8 @@ FROM
   JOIN users ON users.id = latest_user_sync_jobs.user_id
 WHERE
   latest_user_sync_jobs.state = 'failed'
-  AND users.deleted_at IS NULL; -- exclude jobs from soft-deleted users (hard deleted users are taken care of by the CASCADE foreign key constraint)
+  AND users.deleted_at IS NULL;
+-- exclude jobs from soft-deleted users (hard deleted users are taken care of by the CASCADE foreign key constraint)
 `
 
 // CountUsersWithFailingSyncJob returns count of users with LATEST sync job failing.
@@ -735,16 +736,29 @@ func (s *permissionSyncJobStore) CountUsersWithFailingSyncJob(ctx context.Contex
 }
 
 const countReposWithFailingSyncJobsQuery = `
-SELECT COUNT(*)
-FROM (
-  SELECT DISTINCT ON (repository_id) id, state
-  FROM permission_sync_jobs
+WITH latest_repo_sync_jobs AS (
+  SELECT
+    DISTINCT ON (repository_id) repository_id,
+    id,
+    state
+  FROM
+    permission_sync_jobs
   WHERE
-	repository_id is NOT NULL
-	AND state IN ('completed', 'failed')
-  ORDER BY repository_id, finished_at DESC
-) AS tmp
-WHERE state = 'failed';
+    repository_id is NOT NULL
+    AND state IN ('completed', 'failed')
+  ORDER BY
+    repository_id,
+    finished_at DESC
+)
+SELECT
+  COUNT(*)
+FROM
+  latest_repo_sync_jobs
+  JOIN repo ON repo.id = latest_repo_sync_jobs.repository_id
+WHERE
+  latest_repo_sync_jobs.state = 'failed'
+  AND repo.deleted_at IS NULL;
+-- exclude jobs from soft-deleted repos (hard deleted repos are taken care of by the CASCADE foreign key constraint)
 `
 
 // CountReposWithFailingSyncJob returns count of repos with LATEST sync job failing.


### PR DESCRIPTION
This PR changes the query that powers the "failed repository sync count" on the permissions center to now properly ignore soft-deleted repositories. The admin can't take any action to remedy this, so there is no point in displaying it.

![Screenshot 2024-06-17 at 12.55.19 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/5VKJ5spRdhDRvKQ0TTIe/ca554b82-c663-421b-8208-5f8c52a1c6ab.png)



## Test plan

Unit tests

## Changelog 

- The failed repository permission sync count on the permission dashboard now properly ignores syncs from deleted repository (which is the expected behavior).
