### PR TITLE
feature/internal/database: add test to ensure that not found errors fulfiill errcode.NotFound

### DIFF
--- a/internal/database/repos_test.go
+++ b/internal/database/repos_test.go
@@ -2942,6 +2942,15 @@ func TestListSourcegraphDotComIndexableRepos(t *testing.T) {
 	}
 }
 
+func TestRepoNotFoundFulfillsNotFound(t *testing.T) {
+	err := &RepoNotFoundErr{
+		ID:         api.RepoID(1),
+		Name:       api.RepoName("github.com/foo/bar"),
+		HashedName: api.RepoHashedName("github.com/foo/bar"),
+	}
+	require.True(t, errcode.IsNotFound(err))
+}
+
 func TestRepoStore_Metadata(t *testing.T) {
 	if testing.Short() {
 		t.Skip()

--- a/internal/database/users_test.go
+++ b/internal/database/users_test.go
@@ -1400,6 +1400,11 @@ func TestUsers_CreateCancelAccessRequest(t *testing.T) {
 	assert.Equal(t, updated.Status, types.AccessRequestStatusCanceled)
 }
 
+func TestUserNotFoundFulfillsNotFound(t *testing.T) {
+	err := NewUserNotFoundError(123)
+	require.True(t, errcode.IsNotFound(err))
+}
+
 func normalizeUsers(users []*types.User) []*types.User {
 	for _, u := range users {
 		u.CreatedAt = u.CreatedAt.Local().Round(time.Second)


### PR DESCRIPTION
This is a small change that ensures that the user/repository not found error types fulfill the errcode.NotFound interface. This is a building block for https://app.graphite.dev//github/pr/sourcegraph/sourcegraph/63302

## Test plan

Unit tests

## Changelog

- Added unit tests to ensure that the database userNotFound and RepositoryNotFound error types fulfuill the errcode.NotFound interface. 
