### PR TITLE
Context: simplify file chunk conversion

### DIFF
--- a/cmd/frontend/internal/codycontext/context.go
+++ b/cmd/frontend/internal/codycontext/context.go
@@ -315,7 +315,7 @@ func (c *CodyContextClient) getKeywordContext(ctx context.Context, args GetConte
 
 		for _, res := range e.Results {
 			if fm, ok := res.(*result.FileMatch); ok {
-				collected = append(collected, fileMatchToContextMatches(fm)...)
+				collected = append(collected, fileMatchToContextMatch(fm))
 			}
 		}
 	})
@@ -345,16 +345,16 @@ func addLimitsAndFilter(plan *search.Inputs, filter fileMatcher, args GetContext
 	plan.Features.CodyFileMatcher = filter
 }
 
-func fileMatchToContextMatches(fm *result.FileMatch) []FileChunkContext {
+func fileMatchToContextMatch(fm *result.FileMatch) FileChunkContext {
 	if len(fm.ChunkMatches) == 0 {
-		// If this is a filename-only match, we return the first 20 lines of the file.
-		return []FileChunkContext{{
+		// If this is a filename-only match, return a single chunk at the start of the file
+		return FileChunkContext{
 			RepoName:  fm.Repo.Name,
 			RepoID:    fm.Repo.ID,
 			CommitID:  fm.CommitID,
 			Path:      fm.Path,
 			StartLine: 0,
-		}}
+		}
 	}
 
 	// To provide some context variety, we just use the top-ranked
@@ -363,11 +363,11 @@ func fileMatchToContextMatches(fm *result.FileMatch) []FileChunkContext {
 	// 5 lines of leading context, clamped to zero
 	startLine := max(0, fm.ChunkMatches[0].ContentStart.Line-5)
 
-	return []FileChunkContext{{
+	return FileChunkContext{
 		RepoName:  fm.Repo.Name,
 		RepoID:    fm.Repo.ID,
 		CommitID:  fm.CommitID,
 		Path:      fm.Path,
 		StartLine: startLine,
-	}}
+	}
 }

--- a/cmd/frontend/internal/codycontext/context_test.go
+++ b/cmd/frontend/internal/codycontext/context_test.go
@@ -12,7 +12,7 @@ import (
 func TestFileMatchToContextMatches(t *testing.T) {
 	cases := []struct {
 		fileMatch *result.FileMatch
-		want      []FileChunkContext
+		want      FileChunkContext
 	}{
 		{
 			// No chunk matches returns first 20 lines
@@ -27,13 +27,13 @@ func TestFileMatchToContextMatches(t *testing.T) {
 				},
 				ChunkMatches: nil,
 			},
-			want: []FileChunkContext{{
+			want: FileChunkContext{
 				RepoName:  "repo",
 				RepoID:    1,
 				CommitID:  "abc123",
 				Path:      "main.go",
 				StartLine: 0,
-			}},
+			},
 		},
 		{
 			// With chunk match returns context around first chunk
@@ -54,18 +54,18 @@ func TestFileMatchToContextMatches(t *testing.T) {
 					ContentStart: result.Location{Line: 37, Column: 10},
 				}},
 			},
-			want: []FileChunkContext{{
+			want: FileChunkContext{
 				RepoName:  "repo",
 				RepoID:    1,
 				CommitID:  "abc123",
 				Path:      "main.go",
 				StartLine: 85,
-			}},
+			},
 		},
 	}
 
 	for _, tc := range cases {
-		got := fileMatchToContextMatches(tc.fileMatch)
+		got := fileMatchToContextMatch(tc.fileMatch)
 		if diff := cmp.Diff(tc.want, got); diff != "" {
 			t.Errorf("mismatch (-want +got):\n%s", diff)
 		}


### PR DESCRIPTION
Tiny refactor that makes it clear we only return one `FileChunkContext` per file match.

## Test plan

Covered by existing tests