### PR TITLE
fix/frontend/graphql: log and add trace events for all non-not-found errors that occur when fetching permission syncs

### DIFF
--- a/cmd/frontend/internal/authz/resolvers/BUILD.bazel
+++ b/cmd/frontend/internal/authz/resolvers/BUILD.bazel
@@ -31,6 +31,7 @@ go_library(
         "//internal/gqlutil",
         "//internal/licensing",
         "//internal/observation",
+        "//internal/trace",
         "//internal/types",
         "//lib/errors",
         "//lib/pointers",

--- a/cmd/frontend/internal/authz/resolvers/permissions_sync_jobs_test.go
+++ b/cmd/frontend/internal/authz/resolvers/permissions_sync_jobs_test.go
@@ -2,14 +2,18 @@ package resolvers
 
 import (
 	"context"
+	"strings"
 	"testing"
+
+	"github.com/sourcegraph/log/logtest"
+	"github.com/stretchr/testify/require"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbmocks"
 	"github.com/sourcegraph/sourcegraph/internal/types"
-	"github.com/stretchr/testify/require"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 func TestPermissionSyncJobsResolver(t *testing.T) {
@@ -24,8 +28,9 @@ func TestPermissionSyncJobsResolver(t *testing.T) {
 		jobsStore.ListFunc.SetDefaultReturn([]*database.PermissionSyncJob{}, nil)
 
 		db.PermissionSyncJobsFunc.SetDefaultReturn(jobsStore)
+		logger := logtest.NoOp(t)
 
-		resolver, err := NewPermissionsSyncJobsResolver(db, graphqlbackend.ListPermissionsSyncJobsArgs{ConnectionResolverArgs: args})
+		resolver, err := NewPermissionsSyncJobsResolver(logger, db, graphqlbackend.ListPermissionsSyncJobsArgs{ConnectionResolverArgs: args})
 		require.NoError(t, err)
 		jobs, err := resolver.Nodes(ctx)
 		require.NoError(t, err)
@@ -42,12 +47,207 @@ func TestPermissionSyncJobsResolver(t *testing.T) {
 
 		db.PermissionSyncJobsFunc.SetDefaultReturn(jobsStore)
 		db.ReposFunc.SetDefaultReturn(repoStore)
+		logger := logtest.NoOp(t)
 
-		resolver, err := NewPermissionsSyncJobsResolver(db, graphqlbackend.ListPermissionsSyncJobsArgs{ConnectionResolverArgs: args})
+		resolver, err := NewPermissionsSyncJobsResolver(logger, db, graphqlbackend.ListPermissionsSyncJobsArgs{ConnectionResolverArgs: args})
 		require.NoError(t, err)
 		jobs, err := resolver.Nodes(ctx)
 		require.NoError(t, err)
 		require.Len(t, jobs, 1)
 		require.Equal(t, marshalPermissionsSyncJobID(1), jobs[0].ID())
 	})
+
+	t.Run("logs non-not-found errors", func(t *testing.T) {
+		t.Run("repository error", func(t *testing.T) {
+			// Create a mock database
+			db := dbmocks.NewMockDB()
+
+			// Create a mock permissions sync job store
+			jobStore := dbmocks.NewMockPermissionSyncJobStore()
+
+			// Set up the expectations for the job store
+			job := &database.PermissionSyncJob{ID: 1, RepositoryID: 1}
+			jobStore.ListFunc.SetDefaultReturn([]*database.PermissionSyncJob{job}, nil)
+
+			db.PermissionSyncJobsFunc.SetDefaultReturn(jobStore)
+
+			unexpectedError := errors.New("this is a test error")
+
+			reposStore := dbmocks.NewMockRepoStore()
+			reposStore.GetFunc.SetDefaultReturn(nil, unexpectedError)
+			db.ReposFunc.SetDefaultReturn(reposStore)
+
+			logger, dumpLogs := logtest.Captured(t)
+			// Create a permissions sync job connection store
+			resolver, err := NewPermissionsSyncJobsResolver(logger, db, graphqlbackend.ListPermissionsSyncJobsArgs{ConnectionResolverArgs: args})
+			require.NoError(t, err)
+
+			nodes, err := resolver.Nodes(ctx)
+			require.NoError(t, err) // Assert that no error is returned
+			require.Equal(t, 0, len(nodes))
+
+			// Assert that the error is logged
+			logEntries := dumpLogs()
+			var foundLogEntry bool
+			for _, entry := range logEntries {
+				errText, ok := entry.Fields["error"].(string)
+
+				if ok && strings.Contains(errText, unexpectedError.Error()) {
+					foundLogEntry = true
+					break
+				}
+			}
+
+			require.True(t, foundLogEntry, "Expected log entry not found")
+		})
+
+		t.Run("user error", func(t *testing.T) {
+			// Create a mock database
+			db := dbmocks.NewMockDB()
+
+			// Create a mock permissions sync job store
+			jobStore := dbmocks.NewMockPermissionSyncJobStore()
+
+			// Set up the expectations for the job store
+			job := &database.PermissionSyncJob{ID: 1, UserID: 1}
+			jobStore.ListFunc.SetDefaultReturn([]*database.PermissionSyncJob{job}, nil)
+
+			db.PermissionSyncJobsFunc.SetDefaultReturn(jobStore)
+
+			unexpectedError := errors.New("this is a test error")
+
+			userStore := dbmocks.NewMockUserStore()
+			userStore.GetByIDFunc.SetDefaultReturn(nil, unexpectedError)
+			db.UsersFunc.SetDefaultReturn(userStore)
+
+			logger, dumpLogs := logtest.Captured(t)
+			// Create a permissions sync job connection store
+			resolver, err := NewPermissionsSyncJobsResolver(logger, db, graphqlbackend.ListPermissionsSyncJobsArgs{ConnectionResolverArgs: args})
+			require.NoError(t, err)
+
+			nodes, err := resolver.Nodes(ctx)
+			require.NoError(t, err)
+			require.Equal(t, 0, len(nodes))
+
+			// Assert that the error is logged
+			logEntries := dumpLogs()
+			var foundLogEntry bool
+			for _, entry := range logEntries {
+				errText, ok := entry.Fields["error"].(string)
+
+				if ok && strings.Contains(errText, unexpectedError.Error()) {
+					foundLogEntry = true
+					break
+				}
+			}
+
+			require.True(t, foundLogEntry, "Expected log entry not found")
+		})
+	})
+
+	t.Run("skips over not found errors", func(t *testing.T) {
+		t.Run("repository error", func(t *testing.T) {
+
+			// Create a mock
+			db := dbmocks.NewMockDB()
+
+			// Create a mock permissions sync job store
+			jobStore := dbmocks.NewMockPermissionSyncJobStore()
+
+			// Set up the expectations for the job store
+			job := &database.PermissionSyncJob{ID: 1, RepositoryID: 1}
+			jobStore.ListFunc.SetDefaultReturn([]*database.PermissionSyncJob{job}, nil)
+
+			db.PermissionSyncJobsFunc.SetDefaultReturn(jobStore)
+
+			notFoundError := testNotFoundError{}
+
+			repoStore := dbmocks.NewMockRepoStore()
+			repoStore.GetFunc.SetDefaultReturn(nil, notFoundError)
+			db.ReposFunc.SetDefaultReturn(repoStore)
+
+			logger, dumpLogs := logtest.Captured(t)
+			// Create a permissions sync job connection store
+			resolver, err := NewPermissionsSyncJobsResolver(logger, db, graphqlbackend.ListPermissionsSyncJobsArgs{ConnectionResolverArgs: args})
+			require.NoError(t, err)
+
+			nodes, err := resolver.Nodes(ctx)
+			require.NoError(t, err) // Assert that no error is returned
+			require.Equal(t, 0, len(nodes))
+
+			foundError := false
+			for _, entry := range dumpLogs() {
+				if strings.Contains(entry.Message, notFoundError.Error()) {
+					foundError = true
+					break
+				}
+
+				errText, ok := entry.Fields["error"].(string)
+				if ok && strings.Contains(errText, notFoundError.Error()) {
+					foundError = true
+					break
+				}
+			}
+
+			require.False(t, foundError, "Unexpected error found in logs")
+		})
+
+		t.Run("user error", func(t *testing.T) {
+
+			// Create a mock
+			db := dbmocks.NewMockDB()
+
+			// Create a mock permissions sync job store
+			jobStore := dbmocks.NewMockPermissionSyncJobStore()
+
+			// Set up the expectations for the job store
+			job := &database.PermissionSyncJob{ID: 1, RepositoryID: 1}
+			jobStore.ListFunc.SetDefaultReturn([]*database.PermissionSyncJob{job}, nil)
+
+			db.PermissionSyncJobsFunc.SetDefaultReturn(jobStore)
+
+			notFoundError := testNotFoundError{}
+
+			userStore := dbmocks.NewMockRepoStore()
+			userStore.GetFunc.SetDefaultReturn(nil, notFoundError)
+			db.ReposFunc.SetDefaultReturn(userStore)
+
+			logger, dumpLogs := logtest.Captured(t)
+			// Create a permissions sync job connection store
+			resolver, err := NewPermissionsSyncJobsResolver(logger, db, graphqlbackend.ListPermissionsSyncJobsArgs{ConnectionResolverArgs: args})
+			require.NoError(t, err)
+
+			nodes, err := resolver.Nodes(ctx)
+			require.NoError(t, err) // Assert that no error is returned
+			require.Equal(t, 0, len(nodes))
+
+			foundError := false
+			for _, entry := range dumpLogs() {
+				if strings.Contains(entry.Message, notFoundError.Error()) {
+					foundError = true
+					break
+				}
+
+				errText, ok := entry.Fields["error"].(string)
+				if ok && strings.Contains(errText, notFoundError.Error()) {
+					foundError = true
+					break
+				}
+			}
+
+			require.False(t, foundError, "Unexpected error found in logs")
+		})
+	})
 }
+
+type testNotFoundError struct{}
+
+func (testNotFoundError) NotFound() bool {
+	return true
+}
+
+func (testNotFoundError) Error() string {
+	return "this is a test not found error"
+}
+
+var _ error = testNotFoundError{}

--- a/cmd/frontend/internal/authz/resolvers/resolver.go
+++ b/cmd/frontend/internal/authz/resolvers/resolver.go
@@ -663,7 +663,7 @@ func (r *Resolver) PermissionsSyncJobs(ctx context.Context, args graphqlbackend.
 		return nil, err
 	}
 
-	return NewPermissionsSyncJobsResolver(r.db, args)
+	return NewPermissionsSyncJobsResolver(r.logger, r.db, args)
 }
 
 func (r *Resolver) PermissionsSyncingStats(ctx context.Context) (graphqlbackend.PermissionsSyncingStatsResolver, error) {

--- a/cmd/frontend/internal/authz/resolvers/resolver_test.go
+++ b/cmd/frontend/internal/authz/resolvers/resolver_test.go
@@ -2018,7 +2018,8 @@ func TestResolverPermissionsSyncJobs(t *testing.T) {
 		db := dbmocks.NewStrictMockDB()
 		db.UsersFunc.SetDefaultReturn(users)
 
-		r := &Resolver{db: db}
+		logger := logtest.NoOp(t)
+		r := &Resolver{logger: logger, db: db}
 
 		ctx := actor.WithActor(context.Background(), &actor.Actor{UID: 1})
 		userID := graphqlbackend.MarshalUserID(1)
@@ -2035,7 +2036,8 @@ func TestResolverPermissionsSyncJobs(t *testing.T) {
 		db := dbmocks.NewStrictMockDB()
 		db.UsersFunc.SetDefaultReturn(users)
 
-		r := &Resolver{db: db}
+		logger := logtest.NoOp(t)
+		r := &Resolver{logger: logger, db: db}
 
 		ctx := actor.WithActor(context.Background(), &actor.Actor{UID: 1})
 		userID := graphqlbackend.MarshalUserID(2)
@@ -2052,7 +2054,8 @@ func TestResolverPermissionsSyncJobs(t *testing.T) {
 		db := dbmocks.NewStrictMockDB()
 		db.UsersFunc.SetDefaultReturn(users)
 
-		r := &Resolver{db: db}
+		logger := logtest.NoOp(t)
+		r := &Resolver{logger: logger, db: db}
 
 		ctx := actor.WithActor(context.Background(), &actor.Actor{UID: 1})
 		userID := graphqlbackend.MarshalUserID(2)
@@ -2133,7 +2136,9 @@ func TestResolverPermissionsSyncJobs(t *testing.T) {
 	db.ReposFunc.SetDefaultReturn(repoStore)
 
 	// Creating a resolver and validating GraphQL schema.
-	r := &Resolver{db: db}
+	logger := logtest.NoOp(t)
+	r := &Resolver{logger: logger, db: db}
+
 	parsedSchema, err := graphqlbackend.NewSchemaWithAuthzResolver(db, r)
 	if err != nil {
 		t.Fatal(err)
@@ -2378,7 +2383,9 @@ func TestResolverPermissionsSyncJobsFiltering(t *testing.T) {
 	db.ReposFunc.SetDefaultReturn(repoStore)
 
 	// Creating a resolver and validating GraphQL schema.
-	r := &Resolver{db: db}
+	logger := logtest.NoOp(t)
+	r := &Resolver{logger: logger, db: db}
+
 	parsedSchema, err := graphqlbackend.NewSchemaWithAuthzResolver(db, r)
 	if err != nil {
 		t.Fatal(err)
@@ -2547,7 +2554,8 @@ func TestResolverPermissionsSyncJobsSearching(t *testing.T) {
 	db.ReposFunc.SetDefaultReturn(repoStore)
 
 	// Creating a resolver and validating GraphQL schema.
-	r := &Resolver{db: db}
+	logger := logtest.NoOp(t)
+	r := &Resolver{logger: logger, db: db}
 	parsedSchema, err := graphqlbackend.NewSchemaWithAuthzResolver(db, r)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Closes https://linear.app/sourcegraph/issue/SRC-421/customer-reported-an-issue-with-user-permissions-stats

This PR ensures that any non not-found errors that occur when fetching permission sync jobs are logged and added as error events in the trace. Before, these errors were silently swallowed which makes things exceptionally hard to debug.

This PR only changes the monitoring around this query - **it doesn't change the underlying behavior.**

**Note**: I spent a while reading up on how to communicate partial errors in our graphql API, but it seems like there isn't a clear consensus. 
- https://github.com/graph-gophers/graphql-go/issues/414
- https://spec.graphql.org/October2021/#sel-HAHlBNJDPEBAAADFBU-_D

According to the above, it seems like ideally we should be returning `null` in the graphQL for permission sync jobs that have an error. However, when I tried to do this I begain seeing nil panics all over the place. It's hard for me to know if the underlying library supports this or if we are just holding it wrong. 😥 

## Test plan

Unit tests

## Changelog

- Our graphqlAPI now logs and traces any non-not-found errors that occur when fetching permission sync jobs (as opposed to being silently swallowed). 