### PR TITLE
Add logging for Google LLM request path

### DIFF
--- a/internal/completions/client/client.go
+++ b/internal/completions/client/client.go
@@ -25,14 +25,14 @@ func Get(
 	provider conftypes.CompletionsProviderName,
 	accessToken string,
 ) (types.CompletionsClient, error) {
-	client, err := getBasic(endpoint, provider, accessToken)
+	client, err := getBasic(logger, endpoint, provider, accessToken)
 	if err != nil {
 		return nil, err
 	}
 	return newObservedClient(logger, events, client), nil
 }
 
-func getBasic(endpoint string, provider conftypes.CompletionsProviderName, accessToken string) (types.CompletionsClient, error) {
+func getBasic(logger log.Logger, endpoint string, provider conftypes.CompletionsProviderName, accessToken string) (types.CompletionsClient, error) {
 	tokenManager := tokenusage.NewManager()
 	switch provider {
 	case conftypes.CompletionsProviderNameAnthropic:
@@ -44,7 +44,7 @@ func getBasic(endpoint string, provider conftypes.CompletionsProviderName, acces
 	case conftypes.CompletionsProviderNameGoogle:
 		return google.NewClient(httpcli.UncachedExternalDoer, endpoint, accessToken), nil
 	case conftypes.CompletionsProviderNameSourcegraph:
-		return codygateway.NewClient(httpcli.CodyGatewayDoer, endpoint, accessToken, *tokenManager)
+		return codygateway.NewClient(logger, httpcli.CodyGatewayDoer, endpoint, accessToken, *tokenManager)
 	case conftypes.CompletionsProviderNameFireworks:
 		return fireworks.NewClient(httpcli.UncachedExternalDoer, endpoint, accessToken), nil
 	case conftypes.CompletionsProviderNameAWSBedrock:


### PR DESCRIPTION
We recently saw that _all_ Google-routed LLM requests were getting flagged by Cody Gateway. After looking through the code, there is an easy explanation for this... but looking at the tracing data, everything appears to be working correctly. Somehow between the "Sourcegraph.com receiving the completion request" and when "Cody Gateway checks the request's info" the `MaxTokensToSample` / `GenerationConfig.MaxOutputTokens` value is getting changed.

https://github.com/sourcegraph/abuse-ban-bot/issues/32

This PR just adds some logging to various pieces along the codepath to hopefully help narrow down where exactly things are going off the rails.

Worth nothing is that we haven't been able to reproduce this locally, so it's possible that this is some unexpected interaction with the `CustomProviderSiteConfiguration` and Sourcegraph.com... but carefully looking through the code didn't turn up any places where that could happen.

## Test plan

CI/CD