### PR TITLE
fix(cody-gateway): Fix Google flagging configuration

### DIFF
--- a/cmd/cody-gateway/internal/httpapi/completions/flagging.go
+++ b/cmd/cody-gateway/internal/httpapi/completions/flagging.go
@@ -70,6 +70,13 @@ type flaggingResult struct {
 // as the goal isn't for 100% accuracy - isFlaggedRequest should catch obvious abuse patterns, and let other backend
 // systems do a more thorough review async.
 func isFlaggedRequest(tk tokenizer.Tokenizer, r flaggingRequest, cfg flaggingConfig) (*flaggingResult, error) {
+	// Verify that we were given a legitimate flaggingConfig. Blocking all requests is
+	// kinda lame. But failing loudly is preferable to banning users because 100% of their
+	// requests get flagged.
+	if cfg.MaxTokensToSampleFlaggingLimit == 0 || cfg.ResponseTokenBlockingLimit == 0 {
+		return nil, errors.New("flaggingConfig object is invalid")
+	}
+
 	var reasons []string
 	prompt := strings.ToLower(r.FlattenedPrompt)
 

--- a/cmd/cody-gateway/internal/httpapi/completions/google.go
+++ b/cmd/cody-gateway/internal/httpapi/completions/google.go
@@ -32,10 +32,7 @@ func NewGoogleHandler(baseLogger log.Logger, eventLogger events.Logger, rs limit
 		httpClient,
 		string(conftypes.CompletionsProviderNameGoogle),
 		config.AllowedModels,
-		&GoogleHandlerMethods{
-			config: config,
-			logger: baseLogger,
-		},
+		&GoogleHandlerMethods{config: config},
 		promptRecorder,
 		upstreamConfig,
 	)
@@ -43,7 +40,6 @@ func NewGoogleHandler(baseLogger log.Logger, eventLogger events.Logger, rs limit
 
 type GoogleHandlerMethods struct {
 	config config.GoogleConfig
-	logger log.Logger
 }
 
 func (r googleRequest) ShouldStream() bool {

--- a/cmd/cody-gateway/shared/config/config.go
+++ b/cmd/cody-gateway/shared/config/config.go
@@ -320,6 +320,10 @@ func (c *Config) Load() {
 		c.AddError(errors.New("must provide allowed models for Google"))
 	}
 
+	// Load configuration settings specific to how we flag Google-routed requests.
+	// HACK: Same as the comment on OpenAI or Fireworks, re: only using one env var prefix.
+	c.loadFlaggingConfig(&c.Google.FlaggingConfig, "CODY_GATEWAY_ANTHROPIC")
+
 	defaultEmbeddingModels := strings.Join([]string{
 		string(embeddings.ModelNameOpenAIAda),
 		string(embeddings.ModelNameSourcegraphSTMultiQA),


### PR DESCRIPTION
We recently noticed that 100% of all LLM requests routed to Google-provided LLMs were getting flagged, and for the same reasons ["high_max_tokens_to_sample","blocked_phrase"].

After FAR, FAR more head scratching than I care to admit to. I realized the problem: that we were never actually initializing the `Google.FlaggingConfig` settings. So when we were inspecting Gemini requests for potential abuse, we were comparing them against the zero-state for `flaggingConfig`. i.e. does this prompt have a higher `MaxTokensToSample` than 0?

🤦 Super easy mistake to make. We now confirm that _something_ is in the `flaggingConfig` before assuming it is legitimate.

Fixes https://github.com/sourcegraph/abuse-ban-bot/issues/32.

## Test plan

CI/CD