### PR TITLE
fix(svelte): Reference panel width

### DIFF
--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/+layout.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/+layout.svelte
@@ -473,6 +473,7 @@
 
         :global([data-tabs]) {
             flex: 1;
+            min-width: 0;
         }
 
         .last-commit {


### PR DESCRIPTION
When the reference panel preview opens, the bottom panel extends beyond its boundaries and ist partially hidden. Allowing it to shrink past it's content width fixes it.

| Before | Header |
|--------|--------|
| ![2024-06-18_11-22](https://github.com/sourcegraph/sourcegraph/assets/179026/33224c07-946e-4662-bba3-1ce5cf35d834)| ![2024-06-18_11-23](https://github.com/sourcegraph/sourcegraph/assets/179026/3d976506-23e4-4e53-8c8f-e82d189960d9) | 

## Test plan

Manual testing