### PR TITLE
syntax-highlighter: Use camino to make handling utf8 paths nicer

### DIFF
--- a/docker-images/syntax-highlighter/Cargo.Bazel.lock
+++ b/docker-images/syntax-highlighter/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "af874a7a007e7b8e861e3203be252436ede369e33b1819397b3428b27f7df960",
+  "checksum": "31748fbba83a1f037f24462114667576f5abb10cf202f1ae7b083d6c48c5c1f1",
   "crates": {
     "addr2line 0.20.0": {
       "name": "addr2line",
@@ -1372,6 +1372,59 @@
         "version": "1.4.0"
       },
       "license": "MIT"
+    },
+    "camino 1.1.7": {
+      "name": "camino",
+      "version": "1.1.7",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/camino/1.1.7/download",
+          "sha256": "e0ec6b951b160caa93cc0c7b209e5a3bff7aae9062213451ac99493cd844c239"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "camino",
+            "crate_root": "src/lib.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        },
+        {
+          "BuildScript": {
+            "crate_name": "build_script_build",
+            "crate_root": "build.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        }
+      ],
+      "library_target_name": "camino",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "camino 1.1.7",
+              "target": "build_script_build"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "1.1.7"
+      },
+      "build_script_attrs": {
+        "data_glob": [
+          "**"
+        ]
+      },
+      "license": "MIT OR Apache-2.0"
     },
     "cast 0.3.0": {
       "name": "cast",
@@ -10536,6 +10589,10 @@
               "target": "assert_cmd"
             },
             {
+              "id": "camino 1.1.7",
+              "target": "camino"
+            },
+            {
               "id": "clap 4.3.23",
               "target": "clap"
             },
@@ -11595,6 +11652,10 @@
             {
               "id": "bitvec 1.0.1",
               "target": "bitvec"
+            },
+            {
+              "id": "camino 1.1.7",
+              "target": "camino"
             },
             {
               "id": "clap 4.3.23",
@@ -18679,6 +18740,7 @@
     "assert_cmd 2.0.12",
     "base64 0.13.1",
     "bitvec 1.0.1",
+    "camino 1.1.7",
     "clap 4.3.23",
     "colored 2.0.4",
     "futures 0.3.28",

--- a/docker-images/syntax-highlighter/Cargo.lock
+++ b/docker-images/syntax-highlighter/Cargo.lock
@@ -259,6 +259,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 
 [[package]]
+name = "camino"
+version = "1.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0ec6b951b160caa93cc0c7b209e5a3bff7aae9062213451ac99493cd844c239"
+
+[[package]]
 name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1908,6 +1914,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
+ "camino",
  "clap 4.3.23",
  "colored",
  "indicatif",
@@ -2104,6 +2111,7 @@ dependencies = [
  "anyhow",
  "base64 0.13.1",
  "bitvec",
+ "camino",
  "clap 4.3.23",
  "id-arena",
  "if_chain",

--- a/docker-images/syntax-highlighter/Cargo.toml
+++ b/docker-images/syntax-highlighter/Cargo.toml
@@ -60,6 +60,7 @@ tree-sitter = "0.20.9"
 tree-sitter-highlight = "0.20.1"
 walkdir = "2"
 path-clean = "1"
+camino = "1.1"
 
 scip = "0.3.2"
 protobuf = "3"

--- a/docker-images/syntax-highlighter/crates/scip-syntax/Cargo.toml
+++ b/docker-images/syntax-highlighter/crates/scip-syntax/Cargo.toml
@@ -24,6 +24,7 @@ serde_json = { workspace = true }
 string-interner = { workspace = true }
 walkdir = { workspace = true }
 path-clean = { workspace = true }
+camino = { workspace = true }
 
 syntax-analysis = { path = "../syntax-analysis" }
 tree-sitter-all-languages = { path = "../tree-sitter-all-languages" }

--- a/docker-images/syntax-highlighter/crates/scip-syntax/src/evaluate.rs
+++ b/docker-images/syntax-highlighter/crates/scip-syntax/src/evaluate.rs
@@ -4,10 +4,10 @@
 use std::{
     collections::{HashMap, HashSet},
     marker::PhantomData,
-    path::PathBuf,
 };
 
 use anyhow::*;
+use camino::Utf8Path;
 use colored::{ColoredString, Colorize};
 use scip::types::Index;
 use serde::Serializer;
@@ -17,8 +17,8 @@ use syntax_analysis::range::Range;
 use crate::{io::read_index_from_file, progress::*};
 
 pub fn evaluate_command(
-    candidate: PathBuf,
-    ground_truth: PathBuf,
+    candidate: &Utf8Path,
+    ground_truth: &Utf8Path,
     evaluation_output_options: EvaluationOutputOptions,
 ) -> Result<()> {
     Evaluator::default()
@@ -416,12 +416,12 @@ pub struct Evaluator {
 impl Evaluator {
     pub fn evaluate_files<'e>(
         &'e mut self,
-        candidate: PathBuf,
-        ground_truth: PathBuf,
+        candidate: &Utf8Path,
+        ground_truth: &Utf8Path,
     ) -> Result<EvaluationResult<'e>> {
         self.evaluate_indexes(
-            &read_index_from_file(&candidate)?,
-            &read_index_from_file(&ground_truth)?,
+            &read_index_from_file(candidate)?,
+            &read_index_from_file(ground_truth)?,
         )
     }
 

--- a/docker-images/syntax-highlighter/crates/scip-syntax/src/io.rs
+++ b/docker-images/syntax-highlighter/crates/scip-syntax/src/io.rs
@@ -1,14 +1,13 @@
-use std::{fs::File, io::BufReader, path::PathBuf};
+use std::{fs::File, io::BufReader};
 
 use anyhow::{Context, Result};
+use camino::Utf8Path;
 use protobuf::{CodedInputStream, Message};
 
-pub fn read_index_from_file(file: &PathBuf) -> Result<scip::types::Index> {
+pub fn read_index_from_file(file: &Utf8Path) -> Result<scip::types::Index> {
     let mut candidate_idx = scip::types::Index::new();
-    let candidate_f = File::open(file).context(format!(
-        "when trying to read an index from {}",
-        file.display()
-    ))?;
+    let candidate_f =
+        File::open(file).context(format!("when trying to read an index from {file}"))?;
 
     let mut reader = BufReader::new(candidate_f);
     let mut cis = CodedInputStream::from_buf_read(&mut reader);

--- a/docker-images/syntax-highlighter/crates/scip-syntax/src/main.rs
+++ b/docker-images/syntax-highlighter/crates/scip-syntax/src/main.rs
@@ -1,5 +1,6 @@
-use std::{path::PathBuf, process};
+use std::process;
 
+use camino::{Utf8Path, Utf8PathBuf};
 use clap::{Parser, Subcommand};
 use scip_syntax::index::{index_command, AnalysisMode, IndexMode, IndexOptions, TarMode};
 
@@ -162,7 +163,7 @@ pub fn main() -> anyhow::Result<()> {
                             options,
                             IndexMode::TarArchive {
                                 input: TarMode::File {
-                                    location: PathBuf::from(tar),
+                                    location: Utf8PathBuf::from(tar),
                                 },
                             },
                         )
@@ -182,8 +183,8 @@ pub fn main() -> anyhow::Result<()> {
             print_false_negatives,
             disable_colors,
         } => scip_syntax::evaluate::evaluate_command(
-            PathBuf::from(candidate),
-            PathBuf::from(ground_truth),
+            Utf8Path::new(&candidate),
+            Utf8Path::new(&ground_truth),
             scip_syntax::evaluate::EvaluationOutputOptions {
                 print_mapping,
                 print_true_positives,
@@ -200,9 +201,9 @@ fn run_index_command(options: IndexCommandOptions, mode: IndexMode) -> anyhow::R
     index_command(
         options.language,
         mode,
-        PathBuf::from(options.out),
-        PathBuf::from(options.project_root),
-        options.evaluate.map(PathBuf::from),
+        Utf8Path::new(&options.out),
+        Utf8Path::new(&options.project_root),
+        options.evaluate.map(Utf8PathBuf::from),
         IndexOptions {
             analysis_mode: options.mode,
             fail_fast: options.fail_fast,

--- a/docker-images/syntax-highlighter/crates/syntax-analysis/Cargo.toml
+++ b/docker-images/syntax-highlighter/crates/syntax-analysis/Cargo.toml
@@ -19,6 +19,7 @@ syntect.workspace = true
 tree-sitter.workspace = true
 tree-sitter-highlight.workspace = true
 walkdir.workspace = true
+camino.workspace = true
 
 tree-sitter-all-languages = { path = "../tree-sitter-all-languages" }
 


### PR DESCRIPTION
Fixes https://linear.app/sourcegraph/issue/GRAPH-688/refactor-syntax-highlighter-to-use-the-camino-library

We're already codifying and assuming that paths are utf8 only in a bunch of places. This library let's us make the utf8 check up-front and then not have to recheck over and over again.

## Test plan

This should purely be a refactoring, so all existing tests should continue to pass