### PR TITLE
chore(ci): disable renovate

### DIFF
--- a/doc/dev/background-information/renovate.md
+++ b/doc/dev/background-information/renovate.md
@@ -1,6 +1,6 @@
 # Renovate dependency updades
 
-We use Renovate to automatically create pull requests to update dependendies.
+We use Renovate to automatically create pull requests to update dependendies in some repositories.
 Renovate is [configured](https://github.com/sourcegraph/renovate-config/blob/master/renovate.json#L5) to create these in the first week of each month.
 
 It will ask teams to review these dependency updates, depending on code ownership.

--- a/renovate.json
+++ b/renovate.json
@@ -1,15 +1,4 @@
 {
   "$schema": "http://json.schemastore.org/renovate",
-  "extends": ["github>sourcegraph/renovate-config"],
-  "semanticCommits": "disabled",
-  "rebaseWhen": "never",
-  "prBodyNotes": ["Test plan: CI should pass with updated dependencies."],
-  "dependencyDashboardApproval": true,
-  "packageRules": [
-    {
-      "matchDepTypes": ["engines"],
-      "matchPackageNames": ["node"],
-      "rangeStrategy": "bump"
-    }
-  ]
+  "enabled": false
 }


### PR DESCRIPTION
We haven't been using it _at all_ in this repo, and its just causing unnecessary CI builds

## Test plan

N/A 


## Changelog
