### PR TITLE
Minor: update license wording

### DIFF
--- a/client/web-sveltekit/src/lib/global-notifications/GlobalNotifications.svelte
+++ b/client/web-sveltekit/src/lib/global-notifications/GlobalNotifications.svelte
@@ -1,6 +1,7 @@
 <script lang="ts" context="module">
-    import { AlertType } from '$lib/graphql-types'
     import { formatDistanceStrict, isAfter } from 'date-fns'
+
+    import { AlertType } from '$lib/graphql-types'
 
     type PossibleAlertVariation = 'info' | 'warning' | 'danger'
 
@@ -33,13 +34,13 @@
 </script>
 
 <script lang="ts">
-    import { settings } from '$lib/stores'
-
-    import { Markdown } from '$lib/wildcard'
-    import DismissibleAlert from './DismissibleAlert.svelte'
-
-    import type { GlobalNotifications } from './GlobalNotifications.gql'
     import { differenceInDays, parseISO } from 'date-fns'
+
+    import { settings } from '$lib/stores'
+    import { Markdown } from '$lib/wildcard'
+
+    import DismissibleAlert from './DismissibleAlert.svelte'
+    import type { GlobalNotifications } from './GlobalNotifications.gql'
 
     export let globalAlerts: GlobalNotifications
 
@@ -93,7 +94,7 @@
 
     {#if globalAlerts.productSubscription.license && daysLeft <= 7}
         <DismissibleAlert variant="warning" partialStorageKey={`licenseExpiring.${daysLeft}`}>
-            Your Sourcegraph license&nbsp;
+            The license for this Sourcegraph instance&nbsp;
             {isProductLicenseExpired(expiresAt)
                 ? 'expired ' + formatRelativeExpirationDate(expiresAt) // 'Expired two months ago'
                 : 'will expire in ' + formatDistanceStrict(expiresAt, Date.now())}.&nbsp;

--- a/client/web/src/site/LicenseExpirationAlert.tsx
+++ b/client/web/src/site/LicenseExpirationAlert.tsx
@@ -41,7 +41,7 @@ export const LicenseExpirationAlert: React.FunctionComponent<React.PropsWithChil
             variant="warning"
             className={classNames('align-items-center', className)}
         >
-            Your Sourcegraph license{' '}
+            The license for this Sourcegraph instance{' '}
             {
                 isProductLicenseExpired(expiresAt)
                     ? 'expired ' + formatRelativeExpirationDate(expiresAt) // 'Expired two months ago'

--- a/client/web/src/site/__snapshots__/LicenseExpirationAlert.test.tsx.snap
+++ b/client/web/src/site/__snapshots__/LicenseExpirationAlert.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`LicenseExpirationAlert > expired 1`] = `
     <div
       class="content"
     >
-      Your Sourcegraph license expired 3 months ago. 
+      The license for this Sourcegraph instance expired 3 months ago. 
       <a
         class="anchorLink site-alert__link"
         href="/site-admin/license"
@@ -66,7 +66,7 @@ exports[`LicenseExpirationAlert > expiring soon 1`] = `
     <div
       class="content"
     >
-      Your Sourcegraph license will expire in 3 days. 
+      The license for this Sourcegraph instance will expire in 3 days. 
       <a
         class="anchorLink site-alert__link"
         href="/site-admin/license"


### PR DESCRIPTION
In response to some customer feedback that multiple users thought this meant their user's license was expiring, this updates the wording to clarify that it's the sourcegraph instance license that's expiring.

Fixes SRCH-513

## Test plan

N/A