### PR TITLE
Svelte: repo header followups

### DIFF
--- a/client/web-sveltekit/src/routes/[...repo=reporev]/RepoMenu.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/RepoMenu.svelte
@@ -19,7 +19,7 @@
     export let externalServiceKind: string | undefined
 </script>
 
-<DropdownMenu triggerButtonClass={getButtonClassName({ variant: 'text' })}>
+<DropdownMenu triggerButtonClass="{getButtonClassName({ variant: 'text' })} triggerButton">
     <svelte:fragment slot="trigger">
         <div class="trigger">
             <CodeHostIcon repository={repoName} codeHost={externalServiceKind} />
@@ -72,6 +72,9 @@
 </DropdownMenu>
 
 <style lang="scss">
+    :global(.triggerButton) {
+        border-radius: 0;
+    }
     .trigger {
         --icon-color: currentColor;
 

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/RepoMenu.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/RepoMenu.svelte
@@ -119,7 +119,8 @@
 
         display: grid;
         gap: 0.25rem;
-        grid-template-columns: 1fr 1rem;
+        align-items: center;
+        grid-template-columns: 1fr min-content;
         grid-template-rows: min-content min-content;
 
         small {
@@ -131,19 +132,15 @@
         div.repo-name {
             grid-column: 1;
             grid-row: 2;
-
             display: flex;
-            gap: 0.5em;
+            gap: 0.5rem;
             align-items: center;
         }
 
         div.external-link-icon {
             grid-column: 2;
             grid-row: 1 / span 2;
-
-            display: flex;
-            gap: 0.5em;
-            align-items: center;
+            --icon-size: 1rem;
         }
     }
 </style>

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/RepoMenu.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/RepoMenu.svelte
@@ -62,9 +62,12 @@
                         View on code host
                     {/if}
                 </small>
-                <div>
+                <div class="repo-name">
                     <CodeHostIcon repository={repoName} codeHost={externalServiceKind} />
                     <span>{displayRepoName}</span>
+                </div>
+                <div class="external-link-icon">
+                    <Icon icon={ILucideExternalLink} aria-hidden />
                 </div>
             </div>
         </MenuLink>
@@ -114,15 +117,30 @@
     .code-host-item {
         --icon-color: currentColor;
 
-        display: flex;
-        flex-direction: column;
+        display: grid;
         gap: 0.25rem;
+        grid-template-columns: 1fr 1rem;
+        grid-template-rows: min-content min-content;
 
         small {
             color: var(--text-muted);
+            grid-column: 1;
+            grid-row: 1;
         }
 
-        div {
+        div.repo-name {
+            grid-column: 1;
+            grid-row: 2;
+
+            display: flex;
+            gap: 0.5em;
+            align-items: center;
+        }
+
+        div.external-link-icon {
+            grid-column: 2;
+            grid-row: 1 / span 2;
+
             display: flex;
             gap: 0.5em;
             align-items: center;


### PR DESCRIPTION
Two followups from implementing the repo menu:
1) Remove the rounded corners from the trigger button to match the rest of the header
2) Add an external link icon to the code host link

![screenshot-2024-06-18_12-57-05@2x](https://github.com/sourcegraph/sourcegraph/assets/12631702/a83c222e-10c7-4a57-aa3e-1b2516611383)
![screenshot-2024-06-18_12-59-48@2x](https://github.com/sourcegraph/sourcegraph/assets/12631702/b0a7f638-acee-4224-a136-2fb6e52f183e)


## Test plan

Visual testing