### PR TITLE
Search: surface pattern type in query input

### DIFF
--- a/client/web/src/integration/search-aggregation.test.ts
+++ b/client/web/src/integration/search-aggregation.test.ts
@@ -307,7 +307,7 @@ describe('Search aggregation', () => {
             const origQuery = 'context:global insights('
 
             await driver.page.goto(
-                `${driver.sourcegraphBaseUrl}/search?q=${encodeURIComponent(origQuery)}&patternType=literal`
+                `${driver.sourcegraphBaseUrl}/search?q=${encodeURIComponent(origQuery)}&patternType=keyword`
             )
 
             await driver.page.evaluate(() => {

--- a/client/web/src/search/index.test.ts
+++ b/client/web/src/search/index.test.ts
@@ -138,29 +138,6 @@ describe('search/index', () => {
             searchMode: SearchMode.Precise,
         })
     })
-
-    test('parseSearchURL preserves literal search compatibility', () => {
-        expect(parseSearchURL('q=/a literal pattern/&patternType=literal')).toStrictEqual({
-            query: 'content:"/a literal pattern/"',
-            patternType: SearchPatternType.standard,
-            caseSensitive: false,
-            searchMode: SearchMode.Precise,
-        })
-
-        expect(parseSearchURL('q=not /a literal pattern/&patternType=literal')).toStrictEqual({
-            query: 'not content:"/a literal pattern/"',
-            patternType: SearchPatternType.standard,
-            caseSensitive: false,
-            searchMode: SearchMode.Precise,
-        })
-
-        expect(parseSearchURL('q=un.*touched&patternType=literal')).toStrictEqual({
-            query: 'un.*touched',
-            patternType: SearchPatternType.standard,
-            caseSensitive: false,
-            searchMode: SearchMode.Precise,
-        })
-    })
 })
 
 describe('repoFilterForRepoRevision escapes values with spaces', () => {

--- a/client/web/src/stores/navbarSearchQueryState.test.ts
+++ b/client/web/src/stores/navbarSearchQueryState.test.ts
@@ -95,6 +95,16 @@ describe('navbar query state', () => {
 
             expect(useNavbarQueryState.getState().searchPatternType).toBe(SearchPatternType.keyword)
         })
+
+        it('should add patterntype to query if not keyword or regexp', () => {
+            setQueryStateFromURL(parseSearchURL('q=hello!&patternType=keyword'))
+            expect(useNavbarQueryState.getState().queryState.query).toBe('hello!')
+            expect(useNavbarQueryState.getState().searchPatternType).toBe(SearchPatternType.keyword)
+
+            setQueryStateFromURL(parseSearchURL('q=hello!!&patternType=standard'))
+            expect(useNavbarQueryState.getState().queryState.query).toBe('hello!! patterntype:standard')
+            expect(useNavbarQueryState.getState().searchPatternType).toBe(SearchPatternType.standard)
+        })
     })
 
     describe('state initialization precedence', () => {

--- a/client/web/src/stores/navbarSearchQueryState.ts
+++ b/client/web/src/stores/navbarSearchQueryState.ts
@@ -13,6 +13,7 @@ import {
     InitialParametersSource,
     SearchMode,
 } from '@sourcegraph/shared/src/search'
+import { FilterType } from '@sourcegraph/shared/src/search/query/filters'
 import type { Settings, SettingsCascadeOrError } from '@sourcegraph/shared/src/settings/settings'
 import { buildSearchURLQuery } from '@sourcegraph/shared/src/util/url'
 
@@ -108,8 +109,14 @@ export function setQueryStateFromURL(parsedSearchURL: ParsedSearchURL, query = p
         // Only update flags if the URL contains a search query.
         newState.parametersSource = InitialParametersSource.URL
         newState.searchCaseSensitivity = parsedSearchURL.caseSensitive
-        if (parsedSearchURL.patternType !== undefined) {
-            newState.searchPatternType = parsedSearchURL.patternType
+
+        const parsedPatternType = parsedSearchURL.patternType
+        if (parsedPatternType !== undefined) {
+            newState.searchPatternType = parsedPatternType
+            // Only keyword and regexp are represented in the UI, so surface other patterntypes in the query input.
+            if (parsedPatternType !== SearchPatternType.regexp && parsedPatternType !== SearchPatternType.keyword) {
+                query += ' ' + FilterType.patterntype + ':' + parsedPatternType
+            }
         }
         newState.queryState = { query }
         newState.searchQueryFromURL = parsedSearchURL.query

--- a/client/web/src/stores/navbarSearchQueryState.ts
+++ b/client/web/src/stores/navbarSearchQueryState.ts
@@ -120,7 +120,6 @@ export function setQueryStateFromURL(parsedSearchURL: ParsedSearchURL, query = p
             newState.searchPatternType = parsedPatternType
             // Only keyword, regexp, and structural are represented in the UI. For other pattern types, we make
             // sure to surface them in the query input itself.
-            // pattern types in the query input itself.
             if (implicitPatternTypes.has(parsedPatternType)) {
                 query += ` ${FilterType.patterntype}:${parsedPatternType}`
             }

--- a/client/web/src/stores/navbarSearchQueryState.ts
+++ b/client/web/src/stores/navbarSearchQueryState.ts
@@ -121,8 +121,8 @@ export function setQueryStateFromURL(parsedSearchURL: ParsedSearchURL, query = p
         const parsedPatternType = parsedSearchURL.patternType
         if (parsedPatternType !== undefined) {
             newState.searchPatternType = parsedPatternType
-            // Only keyword, regexp, and structural are represented in the UI. For other pattern types, we make sure to
-            //  surface them in the query input itself. This includes invalid patterntypes, which should display an error.
+            // Only keyword, regexp, and structural are represented in the UI. For other pattern types, we make
+            // sure to surface them in the query input itself.
             if (!explicitPatternTypes.has(parsedPatternType)) {
                 query = `${query} ${FilterType.patterntype}:${parsedPatternType}`
             }


### PR DESCRIPTION
We plan to remove the 'Keyword Search' toggle as part of bringing the feature
to GA. Once the toggle is removed, the search UX will only represent `keyword`
(the default pattern type) and `regexp` (through the regex toggle), with no
visual indication for other pattern types. So if a user clicks on a link using
`patterntype:standard`, the search will just behave differently, without any
indication in the UX as to why.

This PR surfaces the `patterntype` filter in the search bar whenever it's not
`keyword` or `regexp`. That way, users can see an old pattern type is being
used and understand why the search behavior may be different.

Relates to SPLF-68

## Test plan

Added unit tests, manually tested search bar behavior with different pattern
types.