### PR TITLE
fix(svelte): Properly scope global CSS selector

### DIFF
--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/-/tags/+page.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/-/tags/+page.svelte
@@ -100,6 +100,12 @@
             display: flex;
             flex-direction: column;
         }
+
+        form,
+        div,
+        :global([data-scroller]) {
+            padding: 1rem;
+        }
     }
 
     form {
@@ -109,12 +115,6 @@
         :global([data-input-container]) {
             flex: 1;
         }
-    }
-
-    form,
-    div,
-    :global([data-scroller]) {
-        padding: 1rem;
     }
 
     form,


### PR DESCRIPTION
The tags page contains a `:global` selector at the root level, which affects all elements that match the selector, even those not part of the page.
`:global` selectors always need to be scoped one way or the other.

## Test plan

Code inspection, trivial change.
