### PR TITLE
code monitors: respect default pattern type

### DIFF
--- a/client/branded/src/search-ui/input/CodeMirrorQueryInput.tsx
+++ b/client/branded/src/search-ui/input/CodeMirrorQueryInput.tsx
@@ -22,10 +22,10 @@ import { queryDiagnostic } from './codemirror/diagnostics'
 import { HISTORY_USER_EVENT, searchHistory as searchHistoryFacet } from './codemirror/history'
 import { useMutableValue, useOnValueChanged, useUpdateInputFromQueryState } from './codemirror/react'
 import { tokenInfo } from './codemirror/token-info'
+import { filterDecoration } from './experimental/codemirror/syntax-highlighting'
 import type { QueryInputProps } from './QueryInput'
 
 import styles from './CodeMirrorQueryInput.module.scss'
-import {filterDecoration} from './experimental/codemirror/syntax-highlighting'
 
 export interface CodeMirrorQueryInputFacadeProps extends QueryInputProps {
     readOnly?: boolean
@@ -212,7 +212,10 @@ export const CodeMirrorMonacoFacade: React.FunctionComponent<CodeMirrorQueryInpu
         ])
     )
 
-    const extensions = useMemo(() => [autocompletion, dynamicExtensions], [autocompletion, dynamicExtensions])
+    const extensions = useMemo(
+        () => [filterDecoration, autocompletion, dynamicExtensions],
+        [autocompletion, dynamicExtensions]
+    )
 
     // Always focus the editor on 'selectedSearchContextSpec' change
     useOnValueChanged(selectedSearchContextSpec, () => {

--- a/client/branded/src/search-ui/input/CodeMirrorQueryInput.tsx
+++ b/client/branded/src/search-ui/input/CodeMirrorQueryInput.tsx
@@ -25,6 +25,7 @@ import { tokenInfo } from './codemirror/token-info'
 import type { QueryInputProps } from './QueryInput'
 
 import styles from './CodeMirrorQueryInput.module.scss'
+import {filterDecoration} from './experimental/codemirror/syntax-highlighting'
 
 export interface CodeMirrorQueryInputFacadeProps extends QueryInputProps {
     readOnly?: boolean

--- a/client/branded/src/search-ui/input/codemirror/parsedQuery.ts
+++ b/client/branded/src/search-ui/input/codemirror/parsedQuery.ts
@@ -3,7 +3,7 @@ import { type EditorState, type Extension, Facet, StateEffect, StateField } from
 import { SearchPatternType } from '@sourcegraph/shared/src/graphql-operations'
 import { decorate, type DecoratedToken } from '@sourcegraph/shared/src/search/query/decoratedToken'
 import { type ParseResult, parseSearchQuery, type Node } from '@sourcegraph/shared/src/search/query/parser'
-import { scanSearchQuery } from '@sourcegraph/shared/src/search/query/scanner'
+import { detectPatternType, scanSearchQuery } from '@sourcegraph/shared/src/search/query/scanner'
 import type { Filter, Token } from '@sourcegraph/shared/src/search/query/token'
 
 export interface QueryTokens {
@@ -74,12 +74,14 @@ export function parseInputAsQuery(initialParseOptions: ParseOptions): Extension 
             // recomputed whenever one of those values changes.
             return queryTokens.compute(['doc', parseOptions], state => {
                 const textDocument = state.sliceDoc()
-                const { patternType, interpretComments } = state.field(parseOptions)
+                const options = state.field(parseOptions)
                 if (!textDocument) {
-                    return { patternType, tokens: [] }
+                    return { patternType: options.patternType, tokens: [] }
                 }
 
-                const result = scanSearchQuery(textDocument, interpretComments, patternType)
+                const patternType = detectPatternType(textDocument) || options.patternType
+                const result = scanSearchQuery(textDocument, options.interpretComments, patternType)
+
                 return {
                     patternType,
                     tokens: result.type === 'success' ? result.term : [],

--- a/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.tsx
@@ -8,12 +8,12 @@ import { LazyQueryInput } from '@sourcegraph/branded'
 import type { QueryState } from '@sourcegraph/shared/src/search'
 import { FilterType, resolveFilter, validateFilter } from '@sourcegraph/shared/src/search/query/filters'
 import { scanSearchQuery } from '@sourcegraph/shared/src/search/query/scanner'
+import { useSettingsCascade } from '@sourcegraph/shared/src/settings/settings'
 import { buildSearchURLQuery } from '@sourcegraph/shared/src/util/url'
 import { Button, Card, Checkbox, Code, H3, Icon, Link, Tooltip } from '@sourcegraph/wildcard'
-import { useSettingsCascade } from '@sourcegraph/shared/src/settings/settings'
 
-import { defaultPatternTypeFromSettings } from '../../../util/settings'
 import { SearchPatternType } from '../../../graphql-operations'
+import { defaultPatternTypeFromSettings } from '../../../util/settings'
 
 import styles from './FormTriggerArea.module.scss'
 
@@ -32,7 +32,8 @@ interface TriggerAreaProps {
 const isDiffOrCommit = (value: string): boolean => value === 'diff' || value === 'commit'
 
 // Code monitors don't support pattern type "structural"
-const isValidPatternType = (value: string): boolean => value === 'keyword' || value === 'standard' || value === 'literal' || value === 'regexp'
+const isValidPatternType = (value: string): boolean =>
+    value === 'keyword' || value === 'standard' || value === 'literal' || value === 'regexp'
 
 const ValidQueryChecklistItem: React.FunctionComponent<
     React.PropsWithChildren<{
@@ -183,7 +184,8 @@ export const FormTriggerArea: React.FunctionComponent<React.PropsWithChildren<Tr
         setHasValidPatternTypeFilter(hasValidPatternTypeFilter)
     }, [queryState.query])
 
-    let defaultPatternType: SearchPatternType = defaultPatternTypeFromSettings(useSettingsCascade()) || SearchPatternType.keyword
+    const defaultPatternType: SearchPatternType =
+        defaultPatternTypeFromSettings(useSettingsCascade()) || SearchPatternType.keyword
 
     const completeForm: React.FormEventHandler = useCallback(
         event => {
@@ -269,7 +271,8 @@ export const FormTriggerArea: React.FunctionComponent<React.PropsWithChildren<Tr
                                     hint={`Code monitors support keyword, standard, literal and regex search. The default is ${defaultPatternType}`}
                                     dataTestid="patterntype-checkbox"
                                 >
-                                    Is <Code>patternType:keyword</Code>, <Code>standard</Code>, <Code>literal</Code> or <Code>regexp</Code>
+                                    Is <Code>patternType:keyword</Code>, <Code>standard</Code>, <Code>literal</Code> or{' '}
+                                    <Code>regexp</Code>
                                 </ValidQueryChecklistItem>
                             </li>
                             <li>

--- a/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.tsx
@@ -184,8 +184,7 @@ export const FormTriggerArea: React.FunctionComponent<React.PropsWithChildren<Tr
         setHasValidPatternTypeFilter(hasValidPatternTypeFilter)
     }, [queryState.query])
 
-    const defaultPatternType: SearchPatternType =
-        defaultPatternTypeFromSettings(useSettingsCascade()) || SearchPatternType.keyword
+    const defaultPatternType: SearchPatternType = defaultPatternTypeFromSettings(useSettingsCascade())
 
     const completeForm: React.FormEventHandler = useCallback(
         event => {


### PR DESCRIPTION
This is part of the Keyword Search GA project (see background below). 

The core change is that we use the default pattern type consistently for the query input field and preview. Before, we hardcoded `literal` as the default and used `standard` for previews. 

This is does not affect existing code monitors.

Other fixes:
- show suggestions that were previously hidden
- highlight keyword queries correctly

<img width="1088" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/26413131/1f8213c7-a801-4880-8fcc-d09753152266">


Background:
- "keyword" will soon be the new default pattern type
- the default pattern type can be overridden in the user/global settings
- query fields in all of our products should respect the default

Test Plan:
- The unit test is currently "skipped" with the following comment
```
// TODO: these tests trigger an error with CodeMirror, complaining about being
// loaded twice, see https://github.com/uiwjs/react-codemirror/issues/506
```
- Manual testing:
  - I created several code monitors with and without pattern type and checked in the DB that the correct pattern type was appended. 
  - I configured a new default pattern type in my user settings and verified that the setting changes the default pattern type for code monitors. 

Co-authored-by: Felix Kling <felix@felix-kling.de>