### PR TITLE
fix(svelte): History suggestions should show immediately when clicking the history button

### DIFF
--- a/client/web-sveltekit/src/lib/search/input/SearchInput.svelte
+++ b/client/web-sveltekit/src/lib/search/input/SearchInput.svelte
@@ -225,6 +225,9 @@
         if (editor) {
             setMode(editor, currentMode => (currentMode === 'History' ? null : 'History'))
             editor.focus()
+            // This ensures that history suggestions are shown after the button was pressed,
+            // before the user has interacted with the input in any other way.
+            userHasInteracted = true
         }
     }
 </script>


### PR DESCRIPTION
Fixes srch-545

We are hiding suggestions until the user has interacted with the input (e.g. by clicking or typing), but, as it is not, it does not include clicking on the history button.

This commit changes that.


## Test plan

Manual testing. Clicking the history button without having interacted with the search input in any other way will now show history suggestions and focus in the input.