### PR TITLE
chore(local): simplify 'sg db' inline help

### DIFF
--- a/dev/sg/sg_db.go
+++ b/dev/sg/sg_db.go
@@ -48,29 +48,15 @@ var (
 
 	dbCommand = &cli.Command{
 		Name:  "db",
-		Usage: "Interact with local Sourcegraph databases for development",
-		UsageText: `
-# Delete test databases
-sg db delete-test-dbs
+		Usage: "Interact with local Sourcegraph databases for development purposes",
+		UsageText: `# Create the the default site-admin user with a default token, i.e. it's always going to be
+# username: sourcegraph, pw: sourcegraph, token spg_local_f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0
+sg db default-site-admin
 
-# Reset the Sourcegraph 'frontend' database
+# Reset the database entirely
 sg db reset-pg
 
-# Reset the 'frontend' and 'codeintel' databases
-sg db reset-pg -db=frontend,codeintel
-
-# Reset all databases ('frontend', 'codeintel', 'codeinsights')
-sg db reset-pg -db=all
-
-# Reset the redis database
-sg db reset-redis
-
-# Create a site-admin user whose email and password are foo@sourcegraph.com and sourcegraph.
-sg db add-user -username=foo
-
-# Create an access token for the user created above.
-sg db add-access-token -username=foo
-`,
+# ... (see below)`,
 		Category: category.Dev,
 		Subcommands: []*cli.Command{
 			{


### PR DESCRIPTION
Follow-up to https://github.com/sourcegraph/sourcegraph/pull/63320 as I noticed that the `UsageText` didn't include `sg db default-site-admin`. Additionally, it was quite verbose without providing much info, so I just dropped it in favour of highlighting notable commands.

Before: 

```
NAME:
   sg db - Interact with local Sourcegraph databases for development

USAGE:
   
   # Delete test databases
   sg db delete-test-dbs

   # Reset the Sourcegraph 'frontend' database
   sg db reset-pg

   # Reset the 'frontend' and 'codeintel' databases
   sg db reset-pg -db=frontend,codeintel

   # Reset all databases ('frontend', 'codeintel', 'codeinsights')
   sg db reset-pg -db=all

   # Reset the redis database
   sg db reset-redis

   # Create a site-admin user whose email and password are foo@sourcegraph.com and sourcegraph.
   sg db add-user -username=foo

   # Create an access token for the user created above.
   sg db add-access-token -username=foo


COMMANDS:
   delete-test-dbs                Drops all databases that have the prefix `sourcegraph-test-`
   reset-pg                       Drops, recreates and migrates the specified Sourcegraph database
   reset-redis                    Drops, recreates and migrates the specified Sourcegraph Redis database
   update-user-external-services  Manually update a user's external services
   add-user                       Create an admin sourcegraph user
   add-access-token               Create a sourcegraph access token
   help, h                        Shows a list of commands or help for one command

OPTIONS:
   --help, -h  show help
```

After: 

```
NAME:
   sg db - Interact with local Sourcegraph databases for development purposes

USAGE:
   # Create the the default site-admin user with a default token, i.e. it's always going to be
   # username: sourcegraph, pw: sourcegraph, token spg_local_f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0
   sg db default-site-admin

   # Reset the database entirely
   sg db reset-pg

   # ... (see below)

COMMANDS:
   delete-test-dbs                Drops all databases that have the prefix `sourcegraph-test-`
   reset-pg                       Drops, recreates and migrates the specified Sourcegraph database
   reset-redis                    Drops, recreates and migrates the specified Sourcegraph Redis database
   update-user-external-services  Manually update a user's external services
   add-user                       Create an admin sourcegraph user
   add-access-token               Create a sourcegraph access token
   default-site-admin             Create a predefined site-admin user with a preset access token
   help, h                        Shows a list of commands or help for one command

OPTIONS:
   --help, -h  show help
```

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles -->

CI + local 

## Changelog

<!--
1. Ensure your pull request title is formatted as: $type($domain): $what
2. Add bullet list items for each additional detail you want to cover (see example below)
3. You can edit this after the pull request was merged, as long as release shipping it hasn't been promoted to the public.
4. For more information, please see this how-to https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c?

Audience: TS/CSE > Customers > Teammates (in that order).

Cheat sheet: $type = chore|fix|feat $domain: source|search|ci|release|plg|cody|local|...
-->

<!--
Example:

Title: fix(search): parse quotes with the appropriate context
Changelog section:

## Changelog

- When a quote is used with regexp pattern type, then ...
- Refactored underlying code.
-->
