### PR TITLE
fix(appliance): target configured namespace

### DIFF
--- a/cmd/appliance/shared/config.go
+++ b/cmd/appliance/shared/config.go
@@ -6,7 +6,6 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/util/homedir"
-	"sigs.k8s.io/controller-runtime/pkg/cache"
 
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
@@ -41,7 +40,7 @@ func (c *Config) Load() {
 	c.metrics.secure = c.GetBool("APPLIANCE_METRICS_SECURE", "false", "Appliance metrics server uses https.")
 	c.grpc.addr = c.Get("APPLIANCE_GRPC_ADDR", ":9000", "Appliance gRPC address.")
 	c.http.addr = c.Get("APPLIANCE_HTTP_ADDR", ":8080", "Appliance http address.")
-	c.namespace = c.Get("APPLIANCE_NAMESPACE", cache.AllNamespaces, "Namespace to monitor. Defaults to all.")
+	c.namespace = c.Get("APPLIANCE_NAMESPACE", "default", "Namespace to monitor.")
 }
 
 func (c *Config) Validate() error {

--- a/cmd/appliance/shared/shared.go
+++ b/cmd/appliance/shared/shared.go
@@ -42,7 +42,7 @@ func Start(ctx context.Context, observationCtx *observation.Context, ready servi
 		return err
 	}
 
-	app := appliance.NewAppliance(k8sClient, logger)
+	app := appliance.NewAppliance(k8sClient, config.namespace, logger)
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Logger: logr,

--- a/internal/appliance/html.go
+++ b/internal/appliance/html.go
@@ -69,7 +69,7 @@ func (a *Appliance) postSetupHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	// TODO validate user input
 
-	_, err = a.CreateConfigMap(r.Context(), "sourcegraph-appliance", "default") //TODO namespace
+	_, err = a.CreateConfigMap(r.Context(), "sourcegraph-appliance")
 	if err != nil {
 		a.logger.Error("failed to create configMap sourcegraph-appliance", log.Error(err))
 		// Handle err


### PR DESCRIPTION
Change default to "default", rather than all namespaces. Before, this config element was only used to tell the reconciler which namespaces to monitor for ConfigMaps.

Now, we repurpose it to tell the appliance frontend which namespace to _create_ the configmap in, so "all" makes no sense.

Follow-on to https://github.com/sourcegraph/sourcegraph/pull/63291.

<!-- 💡 To write a useful PR description, make sure that your description covers:
- WHAT this PR is changing:
    - How was it PREVIOUSLY.
    - How it will be from NOW on.
- WHY this PR is needed.
- CONTEXT, i.e. to which initiative, project or RFC it belongs.

The structure of the description doesn't matter as much as covering these points, so use
your best judgement based on your context.
Learn how to write good pull request description: https://www.notion.so/sourcegraph/Write-a-good-pull-request-description-610a7fd3e613496eb76f450db5a49b6e?pvs=4 -->


## Test plan

Manual only, there are no automated tests for the frontend... yet. I deployed SG with and without APPLIANCE_NAMESPACE set, and it targeted the namespace as expected.

<!-- All pull requests REQUIRE a test plan: https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles -->


## Changelog

<!--
1. Ensure your pull request title is formatted as: $type($domain): $what
2. Add bullet list items for each additional detail you want to cover (see example below)
3. You can edit this after the pull request was merged, as long as release shipping it hasn't been promoted to the public.
4. For more information, please see this how-to https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c?

Audience: TS/CSE > Customers > Teammates (in that order).

Cheat sheet: $type = chore|fix|feat $domain: source|search|ci|release|plg|cody|local|...
-->

<!--
Example:

Title: fix(search): parse quotes with the appropriate context
Changelog section:

## Changelog

- When a quote is used with regexp pattern type, then ...
- Refactored underlying code.
-->
