### PR TITLE
chore(svelte): Update fuzzy finder designs

### DIFF
--- a/client/web-sveltekit/src/lib/KeyboardShortcut.svelte
+++ b/client/web-sveltekit/src/lib/KeyboardShortcut.svelte
@@ -52,12 +52,11 @@ A component to display the keyboard shortcuts for the application.
         line-height: 1;
 
         background-color: var(--secondary-4);
-        color: var(--text-muted);
+        color: var(--text-body);
 
         // When inside a selected container, show the selected variant
         :global([aria-selected='true']) & {
-            color: white;
-            background-color: var(--primary);
+            color: var(--primary);
         }
     }
 </style>

--- a/client/web-sveltekit/src/lib/TabsHeader.svelte
+++ b/client/web-sveltekit/src/lib/TabsHeader.svelte
@@ -77,7 +77,7 @@
         align-items: center;
         min-height: 2rem;
         padding: 0.25rem 0.75rem;
-        color: var(--text-body);
+        color: var(--text-muted);
         display: inline-flex;
         flex-flow: row nowrap;
         justify-content: center;
@@ -95,6 +95,8 @@
         }
 
         &:hover {
+            --icon-color: currentColor;
+
             color: var(--text-title);
             background-color: var(--secondary-2);
         }
@@ -102,9 +104,7 @@
         &[aria-selected='true'] {
             --icon-color: currentColor;
 
-            font-weight: 500;
-            color: var(--text-title);
-            background-color: var(--secondary-2);
+            color: var(--primary);
 
             &::after {
                 border-color: var(--primary);
@@ -119,10 +119,16 @@
             &::before {
                 content: attr(data-tab-title);
                 display: block;
-                font-weight: 500;
                 height: 0;
                 visibility: hidden;
             }
+        }
+
+        &[aria-selected='true'] span,
+        span::before {
+            // Hidden rendering of the bold tab title to prevent
+            // shifting when the tab is selected.
+            font-weight: 500;
         }
     }
 </style>

--- a/client/web-sveltekit/src/lib/common.ts
+++ b/client/web-sveltekit/src/lib/common.ts
@@ -18,6 +18,7 @@ export {
     isLinuxPlatform,
     getPlatform,
 } from '@sourcegraph/common/src/util/browserDetection'
+export { dirname, basename } from '@sourcegraph/common/src/util/path'
 
 let highlightingLoaded = false
 

--- a/client/web-sveltekit/src/lib/fuzzyfinder/FuzzyFinder.svelte
+++ b/client/web-sveltekit/src/lib/fuzzyfinder/FuzzyFinder.svelte
@@ -405,11 +405,14 @@
         }
 
         .close {
-            color: var(--icon-color);
             position: fixed;
             right: 2rem;
             background-color: var(--color-bg-1);
             border-radius: 50%;
+
+            &:hover {
+                background-color: var(--color-bg-2);
+            }
         }
     }
 </style>

--- a/client/web-sveltekit/src/lib/fuzzyfinder/FuzzyFinder.svelte
+++ b/client/web-sveltekit/src/lib/fuzzyfinder/FuzzyFinder.svelte
@@ -296,7 +296,6 @@
         overflow: hidden;
         border: 1px solid var(--border-color);
         background-color: var(--color-bg-1);
-        margin-top: 2rem;
 
         box-shadow: var(--fuzzy-finder-shadow);
 
@@ -361,6 +360,10 @@
 
             .icon {
                 grid-area: icon;
+
+                // Centers the icon vertically
+                display: flex;
+                align-items: center;
             }
 
             .label {

--- a/client/web-sveltekit/src/routes/svelte-overrides.scss
+++ b/client/web-sveltekit/src/routes/svelte-overrides.scss
@@ -44,7 +44,6 @@ label {
     --code-bg: var(--white);
     --modal-bg: rgba(219, 226, 240, 0.5);
     --code-selection-bg: rgba(231, 238, 250, 0.8);
-
     --fuzzy-finder-backdrop: rgba(255, 255, 255, 0.96);
 
     // Shadows
@@ -60,9 +59,9 @@ label {
         0 -18px 11px 0 rgba(1, 6, 12, 0.02), 0 -8px 8px 0 rgba(1, 6, 12, 0.03), 0 -2px 4px 0 rgba(1, 6, 12, 0.04);
     --popover-shadow: 0 174px 49px 0 rgba(0, 0, 0, 0), 0 112px 45px 0 rgba(0, 0, 0, 0.01),
         0 63px 38px 0 rgba(0, 0, 0, 0.02), 0 28px 28px 0 rgba(0, 0, 0, 0.03), 0 7px 15px 0 rgba(0, 0, 0, 0.04);
-    --fuzzy-finder-shadow: 0px 186px 52px 0px rgba(0, 0, 0, 0), 0px 119px 48px 0px rgba(0, 0, 0, 0.01),
-        0px 67px 40px 0px rgba(0, 0, 0, 0.02), 0px 30px 30px 0px rgba(0, 0, 0, 0.03),
-        0px 7px 16px 0px rgba(0, 0, 0, 0.04);
+    --fuzzy-finder-shadow: 0 186px 52px 0 rgba(0, 0, 0, 0), 0 119px 48px 0 rgba(0, 0, 0, 0.01),
+        0 67px 40px 0 rgba(0, 0, 0, 0.02), 0 30px 30px 0 rgba(0, 0, 0, 0.03),
+        0 7px 16px 0 rgba(0, 0, 0, 0.04);
 }
 
 // Theme Dark
@@ -77,7 +76,6 @@ label {
     --code-selection-bg: var(--color-bg-2);
     --code-bg: var(--gray-12);
     --modal-bg: rgba(52, 58, 77, 0.5);
-
     --fuzzy-finder-backdrop: rgba(20, 23, 31, 0.96);
 
     // Shadows
@@ -93,7 +91,7 @@ label {
         0 -16px 8px 0 rgba(0, 0, 0, 0.08), 0 -8px 4px 0 rgba(0, 0, 0, 0.16), 0 -2px 4px 0 rgba(0, 0, 0, 0.32);
     --popover-shadow: 0 174px 49px 0 rgba(0, 0, 0, 0.01), 0 112px 45px 0 rgba(0, 0, 0, 0.05),
         0 63px 38px 0 rgba(0, 0, 0, 0.16), 0 28px 28px 0 rgba(0, 0, 0, 0.27), 0 7px 15px 0 rgba(0, 0, 0, 0.31);
-    --fuzzy-finder-shadow: 0px 186px 52px 0px rgba(0, 0, 0, 0.01), 0px 119px 48px 0px rgba(0, 0, 0, 0.03),
-        0px 67px 40px 0px rgba(0, 0, 0, 0.06), 0px 30px 30px 0px rgba(0, 0, 0, 0.12),
-        0px 7px 16px 0px rgba(0, 0, 0, 0.24);
+    --fuzzy-finder-shadow: 0 186px 52px 0 rgba(0, 0, 0, 0.01), 0 119px 48px 0 rgba(0, 0, 0, 0.03),
+        0 67px 40px 0 rgba(0, 0, 0, 0.06), 0 30px 30px 0 rgba(0, 0, 0, 0.12),
+        0 7px 16px 0 rgba(0, 0, 0, 0.24);
 }

--- a/client/web-sveltekit/src/routes/svelte-overrides.scss
+++ b/client/web-sveltekit/src/routes/svelte-overrides.scss
@@ -60,8 +60,7 @@ label {
     --popover-shadow: 0 174px 49px 0 rgba(0, 0, 0, 0), 0 112px 45px 0 rgba(0, 0, 0, 0.01),
         0 63px 38px 0 rgba(0, 0, 0, 0.02), 0 28px 28px 0 rgba(0, 0, 0, 0.03), 0 7px 15px 0 rgba(0, 0, 0, 0.04);
     --fuzzy-finder-shadow: 0 186px 52px 0 rgba(0, 0, 0, 0), 0 119px 48px 0 rgba(0, 0, 0, 0.01),
-        0 67px 40px 0 rgba(0, 0, 0, 0.02), 0 30px 30px 0 rgba(0, 0, 0, 0.03),
-        0 7px 16px 0 rgba(0, 0, 0, 0.04);
+        0 67px 40px 0 rgba(0, 0, 0, 0.02), 0 30px 30px 0 rgba(0, 0, 0, 0.03), 0 7px 16px 0 rgba(0, 0, 0, 0.04);
 }
 
 // Theme Dark
@@ -92,6 +91,5 @@ label {
     --popover-shadow: 0 174px 49px 0 rgba(0, 0, 0, 0.01), 0 112px 45px 0 rgba(0, 0, 0, 0.05),
         0 63px 38px 0 rgba(0, 0, 0, 0.16), 0 28px 28px 0 rgba(0, 0, 0, 0.27), 0 7px 15px 0 rgba(0, 0, 0, 0.31);
     --fuzzy-finder-shadow: 0 186px 52px 0 rgba(0, 0, 0, 0.01), 0 119px 48px 0 rgba(0, 0, 0, 0.03),
-        0 67px 40px 0 rgba(0, 0, 0, 0.06), 0 30px 30px 0 rgba(0, 0, 0, 0.12),
-        0 7px 16px 0 rgba(0, 0, 0, 0.24);
+        0 67px 40px 0 rgba(0, 0, 0, 0.06), 0 30px 30px 0 rgba(0, 0, 0, 0.12), 0 7px 16px 0 rgba(0, 0, 0, 0.24);
 }

--- a/client/web-sveltekit/src/routes/svelte-overrides.scss
+++ b/client/web-sveltekit/src/routes/svelte-overrides.scss
@@ -16,6 +16,7 @@ body {
     --code-font-family: var(--monospace-font-family);
     --font-size-base: 0.9375rem;
     --font-size-small: 0.875rem;
+    --font-size-extra-small: 0.6875rem;
     --font-size-tiny: 0.8125rem;
     --code-font-size: 13px;
     --border-radius: 4px;
@@ -44,6 +45,8 @@ label {
     --modal-bg: rgba(219, 226, 240, 0.5);
     --code-selection-bg: rgba(231, 238, 250, 0.8);
 
+    --fuzzy-finder-backdrop: rgba(255, 255, 255, 0.96);
+
     // Shadows
     --sidebar-shadow: 0 79px 22px 0 rgba(30, 4, 47, 0), 0 51px 20px 0 rgba(30, 4, 47, 0.01),
         0 29px 17px 0 rgba(30, 4, 47, 0.02), 0 13px 13px 0 rgba(30, 4, 47, 0.03), 0 3px 7px 0 rgba(30, 4, 47, 0.04);
@@ -57,6 +60,9 @@ label {
         0 -18px 11px 0 rgba(1, 6, 12, 0.02), 0 -8px 8px 0 rgba(1, 6, 12, 0.03), 0 -2px 4px 0 rgba(1, 6, 12, 0.04);
     --popover-shadow: 0 174px 49px 0 rgba(0, 0, 0, 0), 0 112px 45px 0 rgba(0, 0, 0, 0.01),
         0 63px 38px 0 rgba(0, 0, 0, 0.02), 0 28px 28px 0 rgba(0, 0, 0, 0.03), 0 7px 15px 0 rgba(0, 0, 0, 0.04);
+    --fuzzy-finder-shadow: 0px 186px 52px 0px rgba(0, 0, 0, 0), 0px 119px 48px 0px rgba(0, 0, 0, 0.01),
+        0px 67px 40px 0px rgba(0, 0, 0, 0.02), 0px 30px 30px 0px rgba(0, 0, 0, 0.03),
+        0px 7px 16px 0px rgba(0, 0, 0, 0.04);
 }
 
 // Theme Dark
@@ -72,6 +78,8 @@ label {
     --code-bg: var(--gray-12);
     --modal-bg: rgba(52, 58, 77, 0.5);
 
+    --fuzzy-finder-backdrop: rgba(20, 23, 31, 0.96);
+
     // Shadows
     --sidebar-shadow: 0 240px 80px 0 rgba(12, 1, 19, 0.01), 0 160px 80px 0 rgba(12, 1, 19, 0.02),
         0 120px 60px 0 rgba(12, 1, 19, 0.08), 0 48px 24px 0 rgba(12, 1, 19, 0.16), 0 12px 28px 0 rgba(12, 1, 19, 0.24);
@@ -85,4 +93,7 @@ label {
         0 -16px 8px 0 rgba(0, 0, 0, 0.08), 0 -8px 4px 0 rgba(0, 0, 0, 0.16), 0 -2px 4px 0 rgba(0, 0, 0, 0.32);
     --popover-shadow: 0 174px 49px 0 rgba(0, 0, 0, 0.01), 0 112px 45px 0 rgba(0, 0, 0, 0.05),
         0 63px 38px 0 rgba(0, 0, 0, 0.16), 0 28px 28px 0 rgba(0, 0, 0, 0.27), 0 7px 15px 0 rgba(0, 0, 0, 0.31);
+    --fuzzy-finder-shadow: 0px 186px 52px 0px rgba(0, 0, 0, 0.01), 0px 119px 48px 0px rgba(0, 0, 0, 0.03),
+        0px 67px 40px 0px rgba(0, 0, 0, 0.06), 0px 30px 30px 0px rgba(0, 0, 0, 0.12),
+        0px 7px 16px 0px rgba(0, 0, 0, 0.24);
 }


### PR DESCRIPTION
Closes srch-458

This implements the new fuzzy finder design, specifically:

- Backdrop and dropshadow
- Border radius
- Tab header (affects all tab headers)
- Options

Note 1: Some aspects of the options UI (such as how paths are rendered and highlighted), and the "footer" depend on how the highlighted parts are computed. This will change when the local matching and ranking logic is removed and will be updated when that happens.

Note 2: The symbol icon coloring was broken by #63288 and will be fixed in a separate PR.

| Panel | Before | After |
|--------|--------|--------|
| Repo (light) | ![2024-06-19_21-04](https://github.com/sourcegraph/sourcegraph/assets/179026/9fe0eae8-2ed5-4a93-917c-ec65a0c4b1ca) | ![2024-06-19_21-03](https://github.com/sourcegraph/sourcegraph/assets/179026/76f09568-0247-4a03-8dc6-c94d03c7bc68) |
| Repo (dark) | ![2024-06-19_21-05](https://github.com/sourcegraph/sourcegraph/assets/179026/8698571c-e268-4b01-88d7-b04f673ebd05) | ![2024-06-19_21-04_1](https://github.com/sourcegraph/sourcegraph/assets/179026/b6ef7deb-af33-4046-a8ec-10ace734cb30) |
| Symbol (light) | ![2024-06-19_21-05_2](https://github.com/sourcegraph/sourcegraph/assets/179026/9208a978-3934-4be2-9d0f-19302bda2d46) | ![2024-06-19_21-06_2](https://github.com/sourcegraph/sourcegraph/assets/179026/20fcf606-bc88-42ba-b0cc-b15f6b671af2) | 
| Symbol (dark) | ![2024-06-19_21-05_1](https://github.com/sourcegraph/sourcegraph/assets/179026/81ab9b17-4272-4c26-a347-135c6feb9bd0) | ![2024-06-19_21-07](https://github.com/sourcegraph/sourcegraph/assets/179026/21ad5385-5c07-4b89-a0dc-ea4fb5a4a532) |
| File (light) | ![2024-06-19_21-06](https://github.com/sourcegraph/sourcegraph/assets/179026/266665a2-3535-4762-a127-f19a786ff56b) | ![2024-06-19_21-07_1](https://github.com/sourcegraph/sourcegraph/assets/179026/d07fae5e-4b88-4cd5-9cf5-220511e112df) |
| File (dark) | ![2024-06-19_21-06_1](https://github.com/sourcegraph/sourcegraph/assets/179026/6b9c3f7e-29de-4376-a940-3d0d287e9c92) | ![2024-06-19_21-07_2](https://github.com/sourcegraph/sourcegraph/assets/179026/fa7eae53-aaf7-4812-9259-c2af8401e06d) | 



## Test plan

Manual testing


## Changelog

<!--
1. Ensure your pull request title is formatted as: $type($domain): $what
2. Add bullet list items for each additional detail you want to cover (see example below)
3. You can edit this after the pull request was merged, as long as release shipping it hasn't been promoted to the public.
4. For more information, please see this how-to https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c?

Audience: TS/CSE > Customers > Teammates (in that order).

Cheat sheet: $type = chore|fix|feat $domain: source|search|ci|release|plg|cody|local|...
-->

<!--
Example:

Title: fix(search): parse quotes with the appropriate context
Changelog section:

## Changelog

- When a quote is used with regexp pattern type, then ...
- Refactored underlying code.
-->
