### PR TITLE
fix(svelte): Use correct symbol icon color

### DIFF
--- a/client/web-sveltekit/src/lib/search/SymbolKindIcon.svelte
+++ b/client/web-sveltekit/src/lib/search/SymbolKindIcon.svelte
@@ -86,7 +86,7 @@
 
         // TODO(@taiyab): incorporate these colors into the semantic colors
 
-        --icon-color: var(--text-muted);
+        --icon-color: currentColor;
 
         :global(.theme-light) & {
             &.module {


### PR DESCRIPTION
Fixes srch-601

| Before | After |
|--------|--------|
| ![2024-06-19_21-15](https://github.com/sourcegraph/sourcegraph/assets/179026/2e3efa8a-826f-455a-a55c-055b6f82920e) | ![2024-06-19_21-15_1](https://github.com/sourcegraph/sourcegraph/assets/179026/cf93f744-d3f3-49e6-8593-dc28ecb43587) | 

## Test plan

Visual inspection

