### PR TITLE
refactor(cody): Reshape the `CompletionsClient` interface

### DIFF
--- a/cmd/cody-gateway/internal/httpapi/embeddings/metadata.go
+++ b/cmd/cody-gateway/internal/httpapi/embeddings/metadata.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/sourcegraph/conc/iter"
 	"github.com/sourcegraph/log"
+
 	"github.com/sourcegraph/sourcegraph/internal/codygateway"
 	"github.com/sourcegraph/sourcegraph/internal/completions/client/fireworks"
 	"github.com/sourcegraph/sourcegraph/internal/completions/types"
@@ -35,8 +36,10 @@ Return your response in text format. Each entry name should be followed by a new
 Respond with nothing else, only the entry names and the documentation. Code: ` +
 		"```\n" + *input + "\n```"
 
-	resp, err := c.completionsClient.Complete(c.ctx, types.CompletionsFeatureChat, types.CompletionsVersionLegacy,
-		types.CompletionRequestParameters{
+	compRequest := types.CompletionRequest{
+		Feature: types.CompletionsFeatureChat,
+		Version: types.CompletionsVersionLegacy,
+		Parameters: types.CompletionRequestParameters{
 			Messages: []types.Message{{
 				Speaker: "user",
 				Text:    promptText,
@@ -45,7 +48,9 @@ Respond with nothing else, only the entry names and the documentation. Code: ` +
 			Temperature:       0,
 			TopP:              1,
 			Model:             fireworks.Llama38bInstruct,
-		}, c.logger)
+		},
+	}
+	resp, err := c.completionsClient.Complete(c.ctx, c.logger, compRequest)
 
 	if err != nil {
 		return "", err

--- a/cmd/frontend/internal/completions/resolvers/resolver.go
+++ b/cmd/frontend/internal/completions/resolvers/resolver.go
@@ -74,13 +74,17 @@ func (c *completionsResolver) Completions(ctx context.Context, args graphqlbacke
 		return "", err
 	}
 
-	// GraphQL API is considered a legacy API
-	version := types.CompletionsVersionLegacy
-
 	params := convertParams(args)
 	// No way to configure the model through the request, we hard code to chat.
 	params.Model = chatModel
-	resp, err := client.Complete(ctx, types.CompletionsFeatureChat, version, params, c.logger)
+
+	request := types.CompletionRequest{
+		Feature: types.CompletionsFeatureChat,
+		// GraphQL API is considered a legacy API.
+		Version:    types.CompletionsVersionLegacy,
+		Parameters: params,
+	}
+	resp, err := client.Complete(ctx, c.logger, request)
 	if err != nil {
 		return "", errors.Wrap(err, "client.Complete")
 	}

--- a/internal/completions/client/anthropic/BUILD.bazel
+++ b/internal/completions/client/anthropic/BUILD.bazel
@@ -33,6 +33,7 @@ go_test(
     deps = [
         "//internal/completions/tokenusage",
         "//internal/completions/types",
+        "//lib/pointers",
         "@com_github_hexops_autogold_v2//:autogold",
         "@com_github_sourcegraph_log//:log",
         "@com_github_stretchr_testify//assert",

--- a/internal/completions/client/anthropic/anthropic.go
+++ b/internal/completions/client/anthropic/anthropic.go
@@ -43,11 +43,13 @@ type anthropicClient struct {
 
 func (a *anthropicClient) Complete(
 	ctx context.Context,
-	feature types.CompletionsFeature,
-	version types.CompletionsVersion,
-	requestParams types.CompletionRequestParameters,
 	logger log.Logger,
-) (*types.CompletionResponse, error) {
+	request types.CompletionRequest) (*types.CompletionResponse, error) {
+
+	feature := request.Feature
+	version := request.Version
+	requestParams := request.Parameters
+
 	resp, err := a.makeRequest(ctx, requestParams, version, false)
 	if err != nil {
 		return nil, err
@@ -78,12 +80,14 @@ func (a *anthropicClient) Complete(
 
 func (a *anthropicClient) Stream(
 	ctx context.Context,
-	feature types.CompletionsFeature,
-	version types.CompletionsVersion,
-	requestParams types.CompletionRequestParameters,
-	sendEvent types.SendCompletionEvent,
 	logger log.Logger,
-) error {
+	request types.CompletionRequest,
+	sendEvent types.SendCompletionEvent) error {
+
+	feature := request.Feature
+	version := request.Version
+	requestParams := request.Parameters
+
 	resp, err := a.makeRequest(ctx, requestParams, version, true)
 	if err != nil {
 		return err

--- a/internal/completions/client/awsbedrock/bedrock.go
+++ b/internal/completions/client/awsbedrock/bedrock.go
@@ -49,11 +49,13 @@ type awsBedrockAnthropicCompletionStreamClient struct {
 
 func (c *awsBedrockAnthropicCompletionStreamClient) Complete(
 	ctx context.Context,
-	feature types.CompletionsFeature,
-	version types.CompletionsVersion,
-	requestParams types.CompletionRequestParameters,
 	logger log.Logger,
-) (*types.CompletionResponse, error) {
+	request types.CompletionRequest) (*types.CompletionResponse, error) {
+
+	feature := request.Feature
+	version := request.Version
+	requestParams := request.Parameters
+
 	resp, err := c.makeRequest(ctx, requestParams, version, false)
 	if err != nil {
 		return nil, errors.Wrap(err, "making request")
@@ -82,12 +84,14 @@ func (c *awsBedrockAnthropicCompletionStreamClient) Complete(
 
 func (a *awsBedrockAnthropicCompletionStreamClient) Stream(
 	ctx context.Context,
-	feature types.CompletionsFeature,
-	version types.CompletionsVersion,
-	requestParams types.CompletionRequestParameters,
-	sendEvent types.SendCompletionEvent,
 	logger log.Logger,
-) error {
+	request types.CompletionRequest,
+	sendEvent types.SendCompletionEvent) error {
+
+	feature := request.Feature
+	version := request.Version
+	requestParams := request.Parameters
+
 	resp, err := a.makeRequest(ctx, requestParams, version, true)
 	if err != nil {
 		return errors.Wrap(err, "making request")

--- a/internal/completions/client/azureopenai/openai.go
+++ b/internal/completions/client/azureopenai/openai.go
@@ -129,11 +129,10 @@ type azureCompletionClient struct {
 
 func (c *azureCompletionClient) Complete(
 	ctx context.Context,
-	feature types.CompletionsFeature,
-	_ types.CompletionsVersion,
-	requestParams types.CompletionRequestParameters,
 	log log.Logger,
-) (*types.CompletionResponse, error) {
+	request types.CompletionRequest) (*types.CompletionResponse, error) {
+	feature := request.Feature
+	requestParams := request.Parameters
 
 	switch feature {
 	case types.CompletionsFeatureCode:
@@ -189,12 +188,13 @@ func completeChat(
 
 func (c *azureCompletionClient) Stream(
 	ctx context.Context,
-	feature types.CompletionsFeature,
-	_ types.CompletionsVersion,
-	requestParams types.CompletionRequestParameters,
-	sendEvent types.SendCompletionEvent,
 	log log.Logger,
+	request types.CompletionRequest,
+	sendEvent types.SendCompletionEvent,
 ) error {
+	feature := request.Feature
+	requestParams := request.Parameters
+
 	switch feature {
 	case types.CompletionsFeatureCode:
 		return streamAutocomplete(ctx, c.client, requestParams, sendEvent, log)

--- a/internal/completions/client/azureopenai/openai_test.go
+++ b/internal/completions/client/azureopenai/openai_test.go
@@ -79,9 +79,16 @@ func TestErrStatusNotOK(t *testing.T) {
 	})
 	tokenManager := tokenusage.NewManager()
 	mockClient, _ := NewClient(getAzureAPIClient, "", "", *tokenManager)
+
+	compRequest := types.CompletionRequest{
+		Feature:    types.CompletionsFeatureChat,
+		Version:    types.CompletionsVersionLegacy,
+		Parameters: types.CompletionRequestParameters{},
+	}
+
 	t.Run("Complete", func(t *testing.T) {
 		logger := log.Scoped("completions")
-		resp, err := mockClient.Complete(context.Background(), types.CompletionsFeatureChat, types.CompletionsVersionLegacy, types.CompletionRequestParameters{}, logger)
+		resp, err := mockClient.Complete(context.Background(), logger, compRequest)
 		require.Error(t, err)
 		assert.Nil(t, resp)
 
@@ -92,7 +99,8 @@ func TestErrStatusNotOK(t *testing.T) {
 
 	t.Run("Stream", func(t *testing.T) {
 		logger := log.Scoped("completions")
-		err := mockClient.Stream(context.Background(), types.CompletionsFeatureChat, types.CompletionsVersionLegacy, types.CompletionRequestParameters{}, func(event types.CompletionResponse) error { return nil }, logger)
+		sendEventFn := func(event types.CompletionResponse) error { return nil }
+		err := mockClient.Stream(context.Background(), logger, compRequest, sendEventFn)
 		require.Error(t, err)
 
 		autogold.Expect("AzureOpenAI: unexpected status code 429: too many requests").Equal(t, err.Error())
@@ -118,9 +126,16 @@ func TestGenericErr(t *testing.T) {
 	})
 	tokenManager := tokenusage.NewManager()
 	mockClient, _ := NewClient(getAzureAPIClient, "", "", *tokenManager)
+
+	compRequest := types.CompletionRequest{
+		Feature:    types.CompletionsFeatureChat,
+		Version:    types.CompletionsVersionLegacy,
+		Parameters: types.CompletionRequestParameters{},
+	}
+
 	t.Run("Complete", func(t *testing.T) {
 		logger := log.Scoped("completions")
-		resp, err := mockClient.Complete(context.Background(), types.CompletionsFeatureChat, types.CompletionsVersionLegacy, types.CompletionRequestParameters{}, logger)
+		resp, err := mockClient.Complete(context.Background(), logger, compRequest)
 		require.Error(t, err)
 		assert.Nil(t, resp)
 
@@ -131,7 +146,8 @@ func TestGenericErr(t *testing.T) {
 
 	t.Run("Stream", func(t *testing.T) {
 		logger := log.Scoped("completions")
-		err := mockClient.Stream(context.Background(), types.CompletionsFeatureChat, types.CompletionsVersionLegacy, types.CompletionRequestParameters{}, func(event types.CompletionResponse) error { return nil }, logger)
+		sendEventFn := func(event types.CompletionResponse) error { return nil }
+		err := mockClient.Stream(context.Background(), logger, compRequest, sendEventFn)
 		require.Error(t, err)
 
 		autogold.Expect("error").Equal(t, err.Error())

--- a/internal/completions/client/codygateway/codygateway.go
+++ b/internal/completions/client/codygateway/codygateway.go
@@ -46,20 +46,23 @@ type codyGatewayClient struct {
 	tokenizer   tokenusage.Manager
 }
 
-func (c *codyGatewayClient) Stream(ctx context.Context, feature types.CompletionsFeature, version types.CompletionsVersion, requestParams types.CompletionRequestParameters, sendEvent types.SendCompletionEvent, logger log.Logger) error {
-	cc, err := c.clientForParams(feature, &requestParams)
+func (c *codyGatewayClient) Stream(
+	ctx context.Context, logger log.Logger, request types.CompletionRequest, sendEvent types.SendCompletionEvent) error {
+	cc, err := c.clientForParams(request.Feature, &request.Parameters)
 	if err != nil {
 		return err
 	}
-	return overwriteErrSource(cc.Stream(ctx, feature, version, requestParams, sendEvent, logger))
+
+	err = cc.Stream(ctx, logger, request, sendEvent)
+	return overwriteErrSource(err)
 }
 
-func (c *codyGatewayClient) Complete(ctx context.Context, feature types.CompletionsFeature, version types.CompletionsVersion, requestParams types.CompletionRequestParameters, logger log.Logger) (*types.CompletionResponse, error) {
-	cc, err := c.clientForParams(feature, &requestParams)
+func (c *codyGatewayClient) Complete(ctx context.Context, logger log.Logger, request types.CompletionRequest) (*types.CompletionResponse, error) {
+	cc, err := c.clientForParams(request.Feature, &request.Parameters)
 	if err != nil {
 		return nil, err
 	}
-	resp, err := cc.Complete(ctx, feature, version, requestParams, logger)
+	resp, err := cc.Complete(ctx, logger, request)
 	return resp, overwriteErrSource(err)
 }
 

--- a/internal/completions/client/fireworks/fireworks.go
+++ b/internal/completions/client/fireworks/fireworks.go
@@ -75,11 +75,11 @@ type fireworksClient struct {
 
 func (c *fireworksClient) Complete(
 	ctx context.Context,
-	feature types.CompletionsFeature,
-	_ types.CompletionsVersion,
-	requestParams types.CompletionRequestParameters,
 	logger log.Logger,
-) (*types.CompletionResponse, error) {
+	request types.CompletionRequest) (*types.CompletionResponse, error) {
+	feature := request.Feature
+	requestParams := request.Parameters
+
 	resp, err := c.makeRequest(ctx, feature, requestParams, false)
 	if err != nil {
 		return nil, err
@@ -114,12 +114,11 @@ func (c *fireworksClient) Complete(
 
 func (c *fireworksClient) Stream(
 	ctx context.Context,
-	feature types.CompletionsFeature,
-	_ types.CompletionsVersion,
-	requestParams types.CompletionRequestParameters,
-	sendEvent types.SendCompletionEvent,
 	logger log.Logger,
-) error {
+	request types.CompletionRequest,
+	sendEvent types.SendCompletionEvent) error {
+	feature := request.Feature
+	requestParams := request.Parameters
 	logprobsInclude := uint8(0)
 	requestParams.Logprobs = &logprobsInclude
 

--- a/internal/completions/client/fireworks/fireworks_test.go
+++ b/internal/completions/client/fireworks/fireworks_test.go
@@ -33,9 +33,19 @@ func TestErrStatusNotOK(t *testing.T) {
 		},
 	}, "", "")
 
+	compRequest := types.CompletionRequest{
+		Feature: types.CompletionsFeatureCode,
+		Version: types.CompletionsVersionLegacy,
+		Parameters: types.CompletionRequestParameters{
+			Messages: []types.Message{
+				{Text: "Hey"},
+			},
+		},
+	}
+
 	t.Run("Complete", func(t *testing.T) {
 		logger := log.Scoped("completions")
-		resp, err := mockClient.Complete(context.Background(), types.CompletionsFeatureCode, types.CompletionsVersionLegacy, types.CompletionRequestParameters{Messages: []types.Message{{Text: "Hey"}}}, logger)
+		resp, err := mockClient.Complete(context.Background(), logger, compRequest)
 		require.Error(t, err)
 		assert.Nil(t, resp)
 
@@ -46,7 +56,8 @@ func TestErrStatusNotOK(t *testing.T) {
 
 	t.Run("Stream", func(t *testing.T) {
 		logger := log.Scoped("completions")
-		err := mockClient.Stream(context.Background(), types.CompletionsFeatureCode, types.CompletionsVersionLegacy, types.CompletionRequestParameters{Messages: []types.Message{{Text: "Hey"}}}, func(event types.CompletionResponse) error { return nil }, logger)
+		sendEventFn := func(event types.CompletionResponse) error { return nil }
+		err := mockClient.Stream(context.Background(), logger, compRequest, sendEventFn)
 		require.Error(t, err)
 
 		autogold.Expect("Fireworks: unexpected status code 429: oh no, please slow down!").Equal(t, err.Error())

--- a/internal/completions/client/google/google.go
+++ b/internal/completions/client/google/google.go
@@ -26,11 +26,9 @@ func NewClient(cli httpcli.Doer, endpoint, accessToken string, viaGateway bool) 
 
 func (c *googleCompletionStreamClient) Complete(
 	ctx context.Context,
-	feature types.CompletionsFeature,
-	_ types.CompletionsVersion,
-	requestParams types.CompletionRequestParameters,
 	logger log.Logger,
-) (*types.CompletionResponse, error) {
+	request types.CompletionRequest) (*types.CompletionResponse, error) {
+	requestParams := request.Parameters
 	resp, err := c.makeRequest(ctx, requestParams, false)
 	if err != nil {
 		return nil, err
@@ -62,12 +60,11 @@ func (c *googleCompletionStreamClient) Complete(
 
 func (c *googleCompletionStreamClient) Stream(
 	ctx context.Context,
-	feature types.CompletionsFeature,
-	_ types.CompletionsVersion,
-	requestParams types.CompletionRequestParameters,
-	sendEvent types.SendCompletionEvent,
 	logger log.Logger,
-) error {
+	request types.CompletionRequest,
+	sendEvent types.SendCompletionEvent) error {
+	requestParams := request.Parameters
+
 	resp, err := c.makeRequest(ctx, requestParams, true)
 	if err != nil {
 		return err

--- a/internal/completions/client/google/google_test.go
+++ b/internal/completions/client/google/google_test.go
@@ -33,9 +33,15 @@ func TestErrStatusNotOK(t *testing.T) {
 		},
 	}, "", "", false)
 
+	compRequest := types.CompletionRequest{
+		Feature:    types.CompletionsFeatureChat,
+		Version:    types.CompletionsVersionLegacy,
+		Parameters: types.CompletionRequestParameters{},
+	}
+
 	t.Run("Complete", func(t *testing.T) {
 		logger := log.Scoped("completions")
-		resp, err := mockClient.Complete(context.Background(), types.CompletionsFeatureChat, types.CompletionsVersionLegacy, types.CompletionRequestParameters{}, logger)
+		resp, err := mockClient.Complete(context.Background(), logger, compRequest)
 		require.Error(t, err)
 		assert.Nil(t, resp)
 
@@ -46,7 +52,8 @@ func TestErrStatusNotOK(t *testing.T) {
 
 	t.Run("Stream", func(t *testing.T) {
 		logger := log.Scoped("completions")
-		err := mockClient.Stream(context.Background(), types.CompletionsFeatureChat, types.CompletionsVersionLegacy, types.CompletionRequestParameters{}, func(event types.CompletionResponse) error { return nil }, logger)
+		sendEventFn := func(event types.CompletionResponse) error { return nil }
+		err := mockClient.Stream(context.Background(), logger, compRequest, sendEventFn)
 		require.Error(t, err)
 
 		autogold.Expect("Google: unexpected status code 429: oh no, please slow down!").Equal(t, err.Error())

--- a/internal/completions/client/openai/openai.go
+++ b/internal/completions/client/openai/openai.go
@@ -35,11 +35,11 @@ type openAIChatCompletionStreamClient struct {
 
 func (c *openAIChatCompletionStreamClient) Complete(
 	ctx context.Context,
-	feature types.CompletionsFeature,
-	_ types.CompletionsVersion,
-	requestParams types.CompletionRequestParameters,
 	logger log.Logger,
-) (*types.CompletionResponse, error) {
+	request types.CompletionRequest) (*types.CompletionResponse, error) {
+	feature := request.Feature
+	requestParams := request.Parameters
+
 	var resp *http.Response
 	var err error
 	defer (func() {
@@ -67,7 +67,12 @@ func (c *openAIChatCompletionStreamClient) Complete(
 		// Empty response.
 		return &types.CompletionResponse{}, nil
 	}
-	err = c.tokenManager.UpdateTokenCountsFromModelUsage(response.Usage.PromptTokens, response.Usage.CompletionTokens, tokenizer.OpenAIModel+"/"+requestParams.Model, string(feature), tokenusage.OpenAI)
+	err = c.tokenManager.UpdateTokenCountsFromModelUsage(
+		response.Usage.PromptTokens,
+		response.Usage.CompletionTokens,
+		tokenizer.OpenAIModel+"/"+requestParams.Model,
+		string(feature),
+		tokenusage.OpenAI)
 	if err != nil {
 		logger.Warn("Failed to count tokens with the token manager %w ", log.Error(err))
 	}
@@ -79,12 +84,12 @@ func (c *openAIChatCompletionStreamClient) Complete(
 
 func (c *openAIChatCompletionStreamClient) Stream(
 	ctx context.Context,
-	feature types.CompletionsFeature,
-	_ types.CompletionsVersion,
-	requestParams types.CompletionRequestParameters,
-	sendEvent types.SendCompletionEvent,
 	logger log.Logger,
-) error {
+	request types.CompletionRequest,
+	sendEvent types.SendCompletionEvent) error {
+	feature := request.Feature
+	requestParams := request.Parameters
+
 	var resp *http.Response
 	var err error
 

--- a/internal/completions/client/openai/openai_test.go
+++ b/internal/completions/client/openai/openai_test.go
@@ -35,9 +35,15 @@ func TestErrStatusNotOK(t *testing.T) {
 		},
 	}, "", "", *tokenManager)
 
+	compRequest := types.CompletionRequest{
+		Feature:    types.CompletionsFeatureChat,
+		Version:    types.CompletionsVersionLegacy,
+		Parameters: types.CompletionRequestParameters{},
+	}
+
 	t.Run("Complete", func(t *testing.T) {
 		logger := log.Scoped("completions")
-		resp, err := mockClient.Complete(context.Background(), types.CompletionsFeatureChat, types.CompletionsVersionLegacy, types.CompletionRequestParameters{}, logger)
+		resp, err := mockClient.Complete(context.Background(), logger, compRequest)
 		require.Error(t, err)
 		assert.Nil(t, resp)
 
@@ -48,7 +54,8 @@ func TestErrStatusNotOK(t *testing.T) {
 
 	t.Run("Stream", func(t *testing.T) {
 		logger := log.Scoped("completions")
-		err := mockClient.Stream(context.Background(), types.CompletionsFeatureChat, types.CompletionsVersionLegacy, types.CompletionRequestParameters{}, func(event types.CompletionResponse) error { return nil }, logger)
+		sendEventFn := func(event types.CompletionResponse) error { return nil }
+		err := mockClient.Stream(context.Background(), logger, compRequest, sendEventFn)
 		require.Error(t, err)
 
 		autogold.Expect("OpenAI: unexpected status code 429: oh no, please slow down!").Equal(t, err.Error())

--- a/internal/completions/types/types.go
+++ b/internal/completions/types/types.go
@@ -188,13 +188,19 @@ const (
 	CodyClientJetbrains CodyClientName = "jetbrains"
 )
 
+type CompletionRequest struct {
+	Feature    CompletionsFeature
+	Version    CompletionsVersion
+	Parameters CompletionRequestParameters
+}
+
 type CompletionsClient interface {
 	// Stream executions a completions request, streaming results to the callback.
 	// Callers should check for ErrStatusNotOK and handle the error appropriately.
-	Stream(context.Context, CompletionsFeature, CompletionsVersion, CompletionRequestParameters, SendCompletionEvent, log.Logger) error
+	Stream(context.Context, log.Logger, CompletionRequest, SendCompletionEvent) error
 	// Complete executions a completions request until done. Callers should check
 	// for ErrStatusNotOK and handle the error appropriately.
-	Complete(context.Context, CompletionsFeature, CompletionsVersion, CompletionRequestParameters, log.Logger) (*CompletionResponse, error)
+	Complete(context.Context, log.Logger, CompletionRequest) (*CompletionResponse, error)
 }
 
 func ConvertFromLegacyMessages(messages []Message) []Message {


### PR DESCRIPTION
This PR refactors the `CompletionsClient` interface, and all the corresponding call sites. There is no functional change, beyond bundling several function parameters into a new type.

See `internal/completions/types/types.go`. But the gist is this putting 3x parameters into a single `CompletionRequest` type.

```diff
	Complete(
            context.Context,
            log.Logger
-           CompletionsFeature,
-           CompletionsVersion,
-           CompletionRequestParameters
+           CompletionRequest
        ) (*CompletionResponse, error)
```

## Why?

As part of reworking the codepath between receiving a completion request, dispatching it to the right `CompletionsClient` implementation, and serving the request, I need some "hooks" to inject new information.

In a future PR I plan on adding a `*ServerSideModelConfig` as another field to the `CompletionRequest`, so that when the `CompletionClient`'s implementation is trying to serve that request it has any additional data it needs. (For example, the AWS Bedrock provisioned capacity ARN, etc.)

## Test plan

Updated existing tests, relying on CI/CD for any other issues.

## Changelog

NA, just some under the hood refactoring that shouldn't impact any functionality.