### PR TITLE
Refactor the 'getModel' callbacks into their own file

### DIFF
--- a/cmd/cody-gateway/internal/httpapi/embeddings/metadata.go
+++ b/cmd/cody-gateway/internal/httpapi/embeddings/metadata.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/sourcegraph/conc/iter"
 	"github.com/sourcegraph/log"
+
 	"github.com/sourcegraph/sourcegraph/internal/codygateway"
 	"github.com/sourcegraph/sourcegraph/internal/completions/client/fireworks"
 	"github.com/sourcegraph/sourcegraph/internal/completions/types"
@@ -35,8 +36,10 @@ Return your response in text format. Each entry name should be followed by a new
 Respond with nothing else, only the entry names and the documentation. Code: ` +
 		"```\n" + *input + "\n```"
 
-	resp, err := c.completionsClient.Complete(c.ctx, types.CompletionsFeatureChat, types.CompletionsVersionLegacy,
-		types.CompletionRequestParameters{
+	compRequest := types.CompletionRequest{
+		Feature: types.CompletionsFeatureChat,
+		Version: types.CompletionsVersionLegacy,
+		Parameters: types.CompletionRequestParameters{
 			Messages: []types.Message{{
 				Speaker: "user",
 				Text:    promptText,
@@ -45,7 +48,9 @@ Respond with nothing else, only the entry names and the documentation. Code: ` +
 			Temperature:       0,
 			TopP:              1,
 			Model:             fireworks.Llama38bInstruct,
-		}, c.logger)
+		},
+	}
+	resp, err := c.completionsClient.Complete(c.ctx, c.logger, compRequest)
 
 	if err != nil {
 		return "", err

--- a/cmd/frontend/internal/completions/resolvers/resolver.go
+++ b/cmd/frontend/internal/completions/resolvers/resolver.go
@@ -74,13 +74,17 @@ func (c *completionsResolver) Completions(ctx context.Context, args graphqlbacke
 		return "", err
 	}
 
-	// GraphQL API is considered a legacy API
-	version := types.CompletionsVersionLegacy
-
 	params := convertParams(args)
 	// No way to configure the model through the request, we hard code to chat.
 	params.Model = chatModel
-	resp, err := client.Complete(ctx, types.CompletionsFeatureChat, version, params, c.logger)
+
+	request := types.CompletionRequest{
+		Feature: types.CompletionsFeatureChat,
+		// GraphQL API is considered a legacy API.
+		Version:    types.CompletionsVersionLegacy,
+		Parameters: params,
+	}
+	resp, err := client.Complete(ctx, c.logger, request)
 	if err != nil {
 		return "", errors.Wrap(err, "client.Complete")
 	}

--- a/cmd/frontend/internal/httpapi/completions/BUILD.bazel
+++ b/cmd/frontend/internal/httpapi/completions/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     srcs = [
         "chat.go",
         "codecompletion.go",
+        "get_model.go",
         "handler.go",
         "limiter.go",
         "observability.go",

--- a/cmd/frontend/internal/httpapi/completions/chat.go
+++ b/cmd/frontend/internal/httpapi/completions/chat.go
@@ -5,17 +5,9 @@ import (
 
 	"net/http"
 
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/cody"
-	sgactor "github.com/sourcegraph/sourcegraph/internal/actor"
-	"github.com/sourcegraph/sourcegraph/internal/dotcom"
-
 	"github.com/sourcegraph/log"
 
-	"github.com/sourcegraph/sourcegraph/internal/completions/client/anthropic"
-	"github.com/sourcegraph/sourcegraph/internal/completions/client/fireworks"
-	"github.com/sourcegraph/sourcegraph/internal/completions/client/google"
 	"github.com/sourcegraph/sourcegraph/internal/completions/types"
-	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/redispool"
 	"github.com/sourcegraph/sourcegraph/internal/telemetry/telemetryrecorder"
@@ -43,79 +35,5 @@ func NewChatCompletionsStreamHandler(logger log.Logger, db database.DB) http.Han
 		types.CompletionsFeatureChat,
 		rl,
 		"chat",
-		func(ctx context.Context, requestParams types.CodyCompletionRequestParameters, c *conftypes.CompletionsConfig) (string, error) {
-			// Allow a number of additional models on Dotcom
-			if dotcom.SourcegraphDotComMode() {
-				actor := sgactor.FromContext(ctx)
-				user, err := actor.User(ctx, db.Users())
-				if err != nil {
-					return "", err
-				}
-
-				subscription, err := cody.SubscriptionForUser(ctx, db, *user)
-				if err != nil {
-					return "", err
-				}
-
-				if isAllowedCustomChatModel(requestParams.Model, subscription.ApplyProRateLimits) {
-					return requestParams.Model, nil
-				}
-			}
-			// No user defined models for now.
-			if requestParams.Fast {
-				return c.FastChatModel, nil
-			}
-			return c.ChatModel, nil
-		},
-	)
-}
-
-// We only allow dotcom clients to select a custom chat model and maintain an allowlist for which
-// custom values we support
-func isAllowedCustomChatModel(model string, isProUser bool) bool {
-	// When updating these two lists, make sure you also update `allowedModels` in codygateway_dotcom_user.go.
-	if isProUser {
-		switch model {
-		case
-			"anthropic/" + anthropic.Claude3Haiku,
-			"anthropic/" + anthropic.Claude3Sonnet,
-			"anthropic/" + anthropic.Claude3Opus,
-			"fireworks/" + fireworks.Mixtral8x7bInstruct,
-			"fireworks/" + fireworks.Mixtral8x22Instruct,
-			"openai/gpt-3.5-turbo",
-			"openai/gpt-4o",
-			"openai/gpt-4-turbo",
-			"openai/gpt-4-turbo-preview",
-			"google/" + google.Gemini15FlashLatest,
-			"google/" + google.Gemini15ProLatest,
-			"google/" + google.GeminiProLatest,
-			"google/" + google.Gemini15Flash,
-			"google/" + google.Gemini15Pro,
-			"google/" + google.GeminiPro,
-
-			// Remove after the Claude 3 rollout is complete
-			"anthropic/claude-2",
-			"anthropic/claude-2.0",
-			"anthropic/claude-2.1",
-			"anthropic/claude-instant-1.2-cyan",
-			"anthropic/claude-instant-1.2",
-			"anthropic/claude-instant-v1",
-			"anthropic/claude-instant-1":
-			return true
-		}
-	} else {
-		switch model {
-		case
-			"anthropic/" + anthropic.Claude3Haiku,
-			"anthropic/" + anthropic.Claude3Sonnet,
-			// Remove after the Claude 3 rollout is complete
-			"anthropic/claude-2",
-			"anthropic/claude-2.0",
-			"anthropic/claude-instant-v1",
-			"anthropic/claude-instant-1":
-			return true
-		}
-	}
-
-	return false
+		getChatModelFn(db))
 }

--- a/cmd/frontend/internal/httpapi/completions/codecompletion.go
+++ b/cmd/frontend/internal/httpapi/completions/codecompletion.go
@@ -1,20 +1,15 @@
 package completions
 
 import (
-	"context"
 	"net/http"
 
 	"github.com/sourcegraph/log"
 
-	"github.com/sourcegraph/sourcegraph/internal/completions/client/fireworks"
-	"github.com/sourcegraph/sourcegraph/internal/completions/client/google"
 	"github.com/sourcegraph/sourcegraph/internal/completions/types"
-	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/guardrails"
 	"github.com/sourcegraph/sourcegraph/internal/redispool"
 	"github.com/sourcegraph/sourcegraph/internal/telemetry/telemetryrecorder"
-	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 // NewCodeCompletionsHandler is an http handler which sends back code completion results.
@@ -31,54 +26,5 @@ func NewCodeCompletionsHandler(logger log.Logger, db database.DB, test guardrail
 		types.CompletionsFeatureCode,
 		rl,
 		"code",
-		func(_ context.Context, requestParams types.CodyCompletionRequestParameters, c *conftypes.CompletionsConfig) (string, error) {
-			customModel := allowedCustomModel(requestParams.Model)
-			if customModel != "" {
-				return customModel, nil
-			}
-			if requestParams.Model != "" {
-				return "", errors.Newf("Unsupported code completion model %q", requestParams.Model)
-			}
-			return c.CompletionModel, nil
-		},
-	)
-}
-
-func allowedCustomModel(model string) string {
-	switch model {
-	case "fireworks/starcoder",
-		"fireworks/starcoder-16b",
-		"fireworks/starcoder-7b",
-		"fireworks/starcoder2-15b",
-		"fireworks/starcoder2-7b",
-		"fireworks/" + fireworks.Starcoder16b,
-		"fireworks/" + fireworks.Starcoder7b,
-		"fireworks/" + fireworks.Llama27bCode,
-		"fireworks/" + fireworks.Llama213bCode,
-		"fireworks/" + fireworks.Llama213bCodeInstruct,
-		"fireworks/" + fireworks.Llama234bCodeInstruct,
-		"fireworks/" + fireworks.Mistral7bInstruct,
-		"fireworks/" + fireworks.FineTunedFIMVariant1,
-		"fireworks/" + fireworks.FineTunedFIMVariant2,
-		"fireworks/" + fireworks.FineTunedFIMVariant3,
-		"fireworks/" + fireworks.FineTunedFIMVariant4,
-		"fireworks/" + fireworks.FineTunedFIMLangSpecificMixtral,
-		"fireworks/" + fireworks.DeepseekCoder1p3b,
-		"fireworks/" + fireworks.DeepseekCoder7b,
-		"anthropic/claude-instant-1.2",
-		"anthropic/claude-3-haiku-20240307",
-		// Deprecated model identifiers
-		"anthropic/claude-instant-v1",
-		"anthropic/claude-instant-1",
-		"anthropic/claude-instant-1.2-cyan",
-		"google/" + google.Gemini15Flash,
-		"google/" + google.GeminiPro,
-		"fireworks/accounts/sourcegraph/models/starcoder-7b",
-		"fireworks/accounts/sourcegraph/models/starcoder-16b",
-		"fireworks/accounts/fireworks/models/starcoder-3b-w8a16",
-		"fireworks/accounts/fireworks/models/starcoder-1b-w8a16":
-		return model
-	}
-
-	return ""
+		getCodeCompletionModelFn())
 }

--- a/cmd/frontend/internal/httpapi/completions/get_model.go
+++ b/cmd/frontend/internal/httpapi/completions/get_model.go
@@ -1,0 +1,155 @@
+package completions
+
+import (
+	"context"
+
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/cody"
+	sgactor "github.com/sourcegraph/sourcegraph/internal/actor"
+	"github.com/sourcegraph/sourcegraph/internal/dotcom"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+
+	"github.com/sourcegraph/sourcegraph/internal/completions/client/anthropic"
+	"github.com/sourcegraph/sourcegraph/internal/completions/client/fireworks"
+	"github.com/sourcegraph/sourcegraph/internal/completions/client/google"
+	"github.com/sourcegraph/sourcegraph/internal/completions/types"
+	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+)
+
+// getModelFn is the thunk used to return the LLM model we should use for processing
+// the supplied completion request. Depending on the incomming request, site config,
+// feature used, etc. it could be any number of things.
+type getModelFn func(ctx context.Context, requestParams types.CodyCompletionRequestParameters, c *conftypes.CompletionsConfig) (string, error)
+
+func getCodeCompletionModelFn() getModelFn {
+	return func(_ context.Context, requestParams types.CodyCompletionRequestParameters, c *conftypes.CompletionsConfig) (string, error) {
+		// For code completions, we only allow certain models to be used.
+		// (Regardless of if the user is on Cody Free, Pro, or Enterprise.)
+		if requestParams.Model != "" {
+			if isAllowedCodeCompletionModel(requestParams.Model) {
+				return requestParams.Model, nil
+			}
+			return "", errors.Newf("unsupported code completion model %q", requestParams.Model)
+		}
+		return c.CompletionModel, nil
+	}
+}
+
+func getChatModelFn(db database.DB) getModelFn {
+	return func(ctx context.Context, requestParams types.CodyCompletionRequestParameters, c *conftypes.CompletionsConfig) (string, error) {
+		// If running on dotcom, i.e. using Cody Free/Cody Pro, then a number
+		// of models are available depending on the caller's subscription status.
+		if dotcom.SourcegraphDotComMode() {
+			actor := sgactor.FromContext(ctx)
+			user, err := actor.User(ctx, db.Users())
+			if err != nil {
+				return "", err
+			}
+
+			subscription, err := cody.SubscriptionForUser(ctx, db, *user)
+			if err != nil {
+				return "", err
+			}
+
+			if isAllowedCustomChatModel(requestParams.Model, subscription.ApplyProRateLimits) {
+				return requestParams.Model, nil
+			}
+		}
+
+		// For any other Sourcegraph instance, i.e. using Cody Enterprise,
+		// we just use the configured "chat" or "fastChat" model.
+		if requestParams.Fast {
+			return c.FastChatModel, nil
+		}
+		return c.ChatModel, nil
+	}
+}
+
+func isAllowedCodeCompletionModel(model string) bool {
+	switch model {
+	case "fireworks/starcoder",
+		"fireworks/starcoder-16b",
+		"fireworks/starcoder-7b",
+		"fireworks/starcoder2-15b",
+		"fireworks/starcoder2-7b",
+		"fireworks/" + fireworks.Starcoder16b,
+		"fireworks/" + fireworks.Starcoder7b,
+		"fireworks/" + fireworks.Llama27bCode,
+		"fireworks/" + fireworks.Llama213bCode,
+		"fireworks/" + fireworks.Llama213bCodeInstruct,
+		"fireworks/" + fireworks.Llama234bCodeInstruct,
+		"fireworks/" + fireworks.Mistral7bInstruct,
+		"fireworks/" + fireworks.FineTunedFIMVariant1,
+		"fireworks/" + fireworks.FineTunedFIMVariant2,
+		"fireworks/" + fireworks.FineTunedFIMVariant3,
+		"fireworks/" + fireworks.FineTunedFIMVariant4,
+		"fireworks/" + fireworks.FineTunedFIMLangSpecificMixtral,
+		"fireworks/" + fireworks.DeepseekCoder1p3b,
+		"fireworks/" + fireworks.DeepseekCoder7b,
+		"anthropic/claude-instant-1.2",
+		"anthropic/claude-3-haiku-20240307",
+		// Deprecated model identifiers
+		"anthropic/claude-instant-v1",
+		"anthropic/claude-instant-1",
+		"anthropic/claude-instant-1.2-cyan",
+		"google/" + google.Gemini15Flash,
+		"google/" + google.GeminiPro,
+		"fireworks/accounts/sourcegraph/models/starcoder-7b",
+		"fireworks/accounts/sourcegraph/models/starcoder-16b",
+		"fireworks/accounts/fireworks/models/starcoder-3b-w8a16",
+		"fireworks/accounts/fireworks/models/starcoder-1b-w8a16":
+		return true
+	}
+
+	return false
+}
+
+// We only allow dotcom clients to select a custom chat model and maintain an allowlist for which
+// custom values we support
+func isAllowedCustomChatModel(model string, isProUser bool) bool {
+	// When updating these two lists, make sure you also update `allowedModels` in codygateway_dotcom_user.go.
+	if isProUser {
+		switch model {
+		case
+			"anthropic/" + anthropic.Claude3Haiku,
+			"anthropic/" + anthropic.Claude3Sonnet,
+			"anthropic/" + anthropic.Claude3Opus,
+			"fireworks/" + fireworks.Mixtral8x7bInstruct,
+			"fireworks/" + fireworks.Mixtral8x22Instruct,
+			"openai/gpt-3.5-turbo",
+			"openai/gpt-4o",
+			"openai/gpt-4-turbo",
+			"openai/gpt-4-turbo-preview",
+			"google/" + google.Gemini15FlashLatest,
+			"google/" + google.Gemini15ProLatest,
+			"google/" + google.GeminiProLatest,
+			"google/" + google.Gemini15Flash,
+			"google/" + google.Gemini15Pro,
+			"google/" + google.GeminiPro,
+
+			// Remove after the Claude 3 rollout is complete
+			"anthropic/claude-2",
+			"anthropic/claude-2.0",
+			"anthropic/claude-2.1",
+			"anthropic/claude-instant-1.2-cyan",
+			"anthropic/claude-instant-1.2",
+			"anthropic/claude-instant-v1",
+			"anthropic/claude-instant-1":
+			return true
+		}
+	} else {
+		switch model {
+		case
+			"anthropic/" + anthropic.Claude3Haiku,
+			"anthropic/" + anthropic.Claude3Sonnet,
+			// Remove after the Claude 3 rollout is complete
+			"anthropic/claude-2",
+			"anthropic/claude-2.0",
+			"anthropic/claude-instant-v1",
+			"anthropic/claude-instant-1":
+			return true
+		}
+	}
+
+	return false
+}

--- a/cmd/frontend/internal/httpapi/completions/handler.go
+++ b/cmd/frontend/internal/httpapi/completions/handler.go
@@ -115,8 +115,10 @@ func newCompletionsHandler(
 		requestParams.Model, err = getModel(ctx, requestParams, completionsConfig)
 		requestParams.User = completionsConfig.User
 		if err != nil {
-			logger.Error("error fetching model", log.Error(err))
-			http.Error(w, "Internal Server Error", http.StatusBadRequest)
+			// NOTE: We return the raw error to the user assuming that it contains relevant
+			// user-facing diagnostic information, and doesn't leak any internal details.
+			logger.Info("error fetching model", log.Error(err))
+			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
 

--- a/cmd/frontend/internal/httpapi/completions/handler.go
+++ b/cmd/frontend/internal/httpapi/completions/handler.go
@@ -115,7 +115,8 @@ func newCompletionsHandler(
 		requestParams.Model, err = getModel(ctx, requestParams, completionsConfig)
 		requestParams.User = completionsConfig.User
 		if err != nil {
-			http.Error(w, err.Error(), http.StatusBadRequest)
+			logger.Error("error fetching model", log.Error(err))
+			http.Error(w, "Internal Server Error", http.StatusBadRequest)
 			return
 		}
 

--- a/internal/completions/client/anthropic/BUILD.bazel
+++ b/internal/completions/client/anthropic/BUILD.bazel
@@ -33,6 +33,7 @@ go_test(
     deps = [
         "//internal/completions/tokenusage",
         "//internal/completions/types",
+        "//lib/pointers",
         "@com_github_hexops_autogold_v2//:autogold",
         "@com_github_sourcegraph_log//:log",
         "@com_github_stretchr_testify//assert",

--- a/internal/completions/client/anthropic/anthropic.go
+++ b/internal/completions/client/anthropic/anthropic.go
@@ -43,11 +43,13 @@ type anthropicClient struct {
 
 func (a *anthropicClient) Complete(
 	ctx context.Context,
-	feature types.CompletionsFeature,
-	version types.CompletionsVersion,
-	requestParams types.CompletionRequestParameters,
 	logger log.Logger,
-) (*types.CompletionResponse, error) {
+	request types.CompletionRequest) (*types.CompletionResponse, error) {
+
+	feature := request.Feature
+	version := request.Version
+	requestParams := request.Parameters
+
 	resp, err := a.makeRequest(ctx, requestParams, version, false)
 	if err != nil {
 		return nil, err
@@ -78,12 +80,14 @@ func (a *anthropicClient) Complete(
 
 func (a *anthropicClient) Stream(
 	ctx context.Context,
-	feature types.CompletionsFeature,
-	version types.CompletionsVersion,
-	requestParams types.CompletionRequestParameters,
-	sendEvent types.SendCompletionEvent,
 	logger log.Logger,
-) error {
+	request types.CompletionRequest,
+	sendEvent types.SendCompletionEvent) error {
+
+	feature := request.Feature
+	version := request.Version
+	requestParams := request.Parameters
+
 	resp, err := a.makeRequest(ctx, requestParams, version, true)
 	if err != nil {
 		return err

--- a/internal/completions/client/awsbedrock/bedrock.go
+++ b/internal/completions/client/awsbedrock/bedrock.go
@@ -49,11 +49,13 @@ type awsBedrockAnthropicCompletionStreamClient struct {
 
 func (c *awsBedrockAnthropicCompletionStreamClient) Complete(
 	ctx context.Context,
-	feature types.CompletionsFeature,
-	version types.CompletionsVersion,
-	requestParams types.CompletionRequestParameters,
 	logger log.Logger,
-) (*types.CompletionResponse, error) {
+	request types.CompletionRequest) (*types.CompletionResponse, error) {
+
+	feature := request.Feature
+	version := request.Version
+	requestParams := request.Parameters
+
 	resp, err := c.makeRequest(ctx, requestParams, version, false)
 	if err != nil {
 		return nil, errors.Wrap(err, "making request")
@@ -82,12 +84,14 @@ func (c *awsBedrockAnthropicCompletionStreamClient) Complete(
 
 func (a *awsBedrockAnthropicCompletionStreamClient) Stream(
 	ctx context.Context,
-	feature types.CompletionsFeature,
-	version types.CompletionsVersion,
-	requestParams types.CompletionRequestParameters,
-	sendEvent types.SendCompletionEvent,
 	logger log.Logger,
-) error {
+	request types.CompletionRequest,
+	sendEvent types.SendCompletionEvent) error {
+
+	feature := request.Feature
+	version := request.Version
+	requestParams := request.Parameters
+
 	resp, err := a.makeRequest(ctx, requestParams, version, true)
 	if err != nil {
 		return errors.Wrap(err, "making request")

--- a/internal/completions/client/azureopenai/openai.go
+++ b/internal/completions/client/azureopenai/openai.go
@@ -129,11 +129,10 @@ type azureCompletionClient struct {
 
 func (c *azureCompletionClient) Complete(
 	ctx context.Context,
-	feature types.CompletionsFeature,
-	_ types.CompletionsVersion,
-	requestParams types.CompletionRequestParameters,
 	log log.Logger,
-) (*types.CompletionResponse, error) {
+	request types.CompletionRequest) (*types.CompletionResponse, error) {
+	feature := request.Feature
+	requestParams := request.Parameters
 
 	switch feature {
 	case types.CompletionsFeatureCode:
@@ -189,12 +188,13 @@ func completeChat(
 
 func (c *azureCompletionClient) Stream(
 	ctx context.Context,
-	feature types.CompletionsFeature,
-	_ types.CompletionsVersion,
-	requestParams types.CompletionRequestParameters,
-	sendEvent types.SendCompletionEvent,
 	log log.Logger,
+	request types.CompletionRequest,
+	sendEvent types.SendCompletionEvent,
 ) error {
+	feature := request.Feature
+	requestParams := request.Parameters
+
 	switch feature {
 	case types.CompletionsFeatureCode:
 		return streamAutocomplete(ctx, c.client, requestParams, sendEvent, log)

--- a/internal/completions/client/azureopenai/openai_test.go
+++ b/internal/completions/client/azureopenai/openai_test.go
@@ -79,9 +79,16 @@ func TestErrStatusNotOK(t *testing.T) {
 	})
 	tokenManager := tokenusage.NewManager()
 	mockClient, _ := NewClient(getAzureAPIClient, "", "", *tokenManager)
+
+	compRequest := types.CompletionRequest{
+		Feature:    types.CompletionsFeatureChat,
+		Version:    types.CompletionsVersionLegacy,
+		Parameters: types.CompletionRequestParameters{},
+	}
+
 	t.Run("Complete", func(t *testing.T) {
 		logger := log.Scoped("completions")
-		resp, err := mockClient.Complete(context.Background(), types.CompletionsFeatureChat, types.CompletionsVersionLegacy, types.CompletionRequestParameters{}, logger)
+		resp, err := mockClient.Complete(context.Background(), logger, compRequest)
 		require.Error(t, err)
 		assert.Nil(t, resp)
 
@@ -92,7 +99,8 @@ func TestErrStatusNotOK(t *testing.T) {
 
 	t.Run("Stream", func(t *testing.T) {
 		logger := log.Scoped("completions")
-		err := mockClient.Stream(context.Background(), types.CompletionsFeatureChat, types.CompletionsVersionLegacy, types.CompletionRequestParameters{}, func(event types.CompletionResponse) error { return nil }, logger)
+		sendEventFn := func(event types.CompletionResponse) error { return nil }
+		err := mockClient.Stream(context.Background(), logger, compRequest, sendEventFn)
 		require.Error(t, err)
 
 		autogold.Expect("AzureOpenAI: unexpected status code 429: too many requests").Equal(t, err.Error())
@@ -118,9 +126,16 @@ func TestGenericErr(t *testing.T) {
 	})
 	tokenManager := tokenusage.NewManager()
 	mockClient, _ := NewClient(getAzureAPIClient, "", "", *tokenManager)
+
+	compRequest := types.CompletionRequest{
+		Feature:    types.CompletionsFeatureChat,
+		Version:    types.CompletionsVersionLegacy,
+		Parameters: types.CompletionRequestParameters{},
+	}
+
 	t.Run("Complete", func(t *testing.T) {
 		logger := log.Scoped("completions")
-		resp, err := mockClient.Complete(context.Background(), types.CompletionsFeatureChat, types.CompletionsVersionLegacy, types.CompletionRequestParameters{}, logger)
+		resp, err := mockClient.Complete(context.Background(), logger, compRequest)
 		require.Error(t, err)
 		assert.Nil(t, resp)
 
@@ -131,7 +146,8 @@ func TestGenericErr(t *testing.T) {
 
 	t.Run("Stream", func(t *testing.T) {
 		logger := log.Scoped("completions")
-		err := mockClient.Stream(context.Background(), types.CompletionsFeatureChat, types.CompletionsVersionLegacy, types.CompletionRequestParameters{}, func(event types.CompletionResponse) error { return nil }, logger)
+		sendEventFn := func(event types.CompletionResponse) error { return nil }
+		err := mockClient.Stream(context.Background(), logger, compRequest, sendEventFn)
 		require.Error(t, err)
 
 		autogold.Expect("error").Equal(t, err.Error())

--- a/internal/completions/client/codygateway/codygateway.go
+++ b/internal/completions/client/codygateway/codygateway.go
@@ -46,20 +46,23 @@ type codyGatewayClient struct {
 	tokenizer   tokenusage.Manager
 }
 
-func (c *codyGatewayClient) Stream(ctx context.Context, feature types.CompletionsFeature, version types.CompletionsVersion, requestParams types.CompletionRequestParameters, sendEvent types.SendCompletionEvent, logger log.Logger) error {
-	cc, err := c.clientForParams(feature, &requestParams)
+func (c *codyGatewayClient) Stream(
+	ctx context.Context, logger log.Logger, request types.CompletionRequest, sendEvent types.SendCompletionEvent) error {
+	cc, err := c.clientForParams(request.Feature, &request.Parameters)
 	if err != nil {
 		return err
 	}
-	return overwriteErrSource(cc.Stream(ctx, feature, version, requestParams, sendEvent, logger))
+
+	err = cc.Stream(ctx, logger, request, sendEvent)
+	return overwriteErrSource(err)
 }
 
-func (c *codyGatewayClient) Complete(ctx context.Context, feature types.CompletionsFeature, version types.CompletionsVersion, requestParams types.CompletionRequestParameters, logger log.Logger) (*types.CompletionResponse, error) {
-	cc, err := c.clientForParams(feature, &requestParams)
+func (c *codyGatewayClient) Complete(ctx context.Context, logger log.Logger, request types.CompletionRequest) (*types.CompletionResponse, error) {
+	cc, err := c.clientForParams(request.Feature, &request.Parameters)
 	if err != nil {
 		return nil, err
 	}
-	resp, err := cc.Complete(ctx, feature, version, requestParams, logger)
+	resp, err := cc.Complete(ctx, logger, request)
 	return resp, overwriteErrSource(err)
 }
 

--- a/internal/completions/client/fireworks/fireworks.go
+++ b/internal/completions/client/fireworks/fireworks.go
@@ -75,11 +75,11 @@ type fireworksClient struct {
 
 func (c *fireworksClient) Complete(
 	ctx context.Context,
-	feature types.CompletionsFeature,
-	_ types.CompletionsVersion,
-	requestParams types.CompletionRequestParameters,
 	logger log.Logger,
-) (*types.CompletionResponse, error) {
+	request types.CompletionRequest) (*types.CompletionResponse, error) {
+	feature := request.Feature
+	requestParams := request.Parameters
+
 	resp, err := c.makeRequest(ctx, feature, requestParams, false)
 	if err != nil {
 		return nil, err
@@ -114,12 +114,11 @@ func (c *fireworksClient) Complete(
 
 func (c *fireworksClient) Stream(
 	ctx context.Context,
-	feature types.CompletionsFeature,
-	_ types.CompletionsVersion,
-	requestParams types.CompletionRequestParameters,
-	sendEvent types.SendCompletionEvent,
 	logger log.Logger,
-) error {
+	request types.CompletionRequest,
+	sendEvent types.SendCompletionEvent) error {
+	feature := request.Feature
+	requestParams := request.Parameters
 	logprobsInclude := uint8(0)
 	requestParams.Logprobs = &logprobsInclude
 

--- a/internal/completions/client/fireworks/fireworks_test.go
+++ b/internal/completions/client/fireworks/fireworks_test.go
@@ -33,9 +33,19 @@ func TestErrStatusNotOK(t *testing.T) {
 		},
 	}, "", "")
 
+	compRequest := types.CompletionRequest{
+		Feature: types.CompletionsFeatureCode,
+		Version: types.CompletionsVersionLegacy,
+		Parameters: types.CompletionRequestParameters{
+			Messages: []types.Message{
+				{Text: "Hey"},
+			},
+		},
+	}
+
 	t.Run("Complete", func(t *testing.T) {
 		logger := log.Scoped("completions")
-		resp, err := mockClient.Complete(context.Background(), types.CompletionsFeatureCode, types.CompletionsVersionLegacy, types.CompletionRequestParameters{Messages: []types.Message{{Text: "Hey"}}}, logger)
+		resp, err := mockClient.Complete(context.Background(), logger, compRequest)
 		require.Error(t, err)
 		assert.Nil(t, resp)
 
@@ -46,7 +56,8 @@ func TestErrStatusNotOK(t *testing.T) {
 
 	t.Run("Stream", func(t *testing.T) {
 		logger := log.Scoped("completions")
-		err := mockClient.Stream(context.Background(), types.CompletionsFeatureCode, types.CompletionsVersionLegacy, types.CompletionRequestParameters{Messages: []types.Message{{Text: "Hey"}}}, func(event types.CompletionResponse) error { return nil }, logger)
+		sendEventFn := func(event types.CompletionResponse) error { return nil }
+		err := mockClient.Stream(context.Background(), logger, compRequest, sendEventFn)
 		require.Error(t, err)
 
 		autogold.Expect("Fireworks: unexpected status code 429: oh no, please slow down!").Equal(t, err.Error())

--- a/internal/completions/client/google/google.go
+++ b/internal/completions/client/google/google.go
@@ -26,11 +26,9 @@ func NewClient(cli httpcli.Doer, endpoint, accessToken string, viaGateway bool) 
 
 func (c *googleCompletionStreamClient) Complete(
 	ctx context.Context,
-	feature types.CompletionsFeature,
-	_ types.CompletionsVersion,
-	requestParams types.CompletionRequestParameters,
 	logger log.Logger,
-) (*types.CompletionResponse, error) {
+	request types.CompletionRequest) (*types.CompletionResponse, error) {
+	requestParams := request.Parameters
 	resp, err := c.makeRequest(ctx, requestParams, false)
 	if err != nil {
 		return nil, err
@@ -62,12 +60,11 @@ func (c *googleCompletionStreamClient) Complete(
 
 func (c *googleCompletionStreamClient) Stream(
 	ctx context.Context,
-	feature types.CompletionsFeature,
-	_ types.CompletionsVersion,
-	requestParams types.CompletionRequestParameters,
-	sendEvent types.SendCompletionEvent,
 	logger log.Logger,
-) error {
+	request types.CompletionRequest,
+	sendEvent types.SendCompletionEvent) error {
+	requestParams := request.Parameters
+
 	resp, err := c.makeRequest(ctx, requestParams, true)
 	if err != nil {
 		return err

--- a/internal/completions/client/google/google_test.go
+++ b/internal/completions/client/google/google_test.go
@@ -33,9 +33,15 @@ func TestErrStatusNotOK(t *testing.T) {
 		},
 	}, "", "", false)
 
+	compRequest := types.CompletionRequest{
+		Feature:    types.CompletionsFeatureChat,
+		Version:    types.CompletionsVersionLegacy,
+		Parameters: types.CompletionRequestParameters{},
+	}
+
 	t.Run("Complete", func(t *testing.T) {
 		logger := log.Scoped("completions")
-		resp, err := mockClient.Complete(context.Background(), types.CompletionsFeatureChat, types.CompletionsVersionLegacy, types.CompletionRequestParameters{}, logger)
+		resp, err := mockClient.Complete(context.Background(), logger, compRequest)
 		require.Error(t, err)
 		assert.Nil(t, resp)
 
@@ -46,7 +52,8 @@ func TestErrStatusNotOK(t *testing.T) {
 
 	t.Run("Stream", func(t *testing.T) {
 		logger := log.Scoped("completions")
-		err := mockClient.Stream(context.Background(), types.CompletionsFeatureChat, types.CompletionsVersionLegacy, types.CompletionRequestParameters{}, func(event types.CompletionResponse) error { return nil }, logger)
+		sendEventFn := func(event types.CompletionResponse) error { return nil }
+		err := mockClient.Stream(context.Background(), logger, compRequest, sendEventFn)
 		require.Error(t, err)
 
 		autogold.Expect("Google: unexpected status code 429: oh no, please slow down!").Equal(t, err.Error())

--- a/internal/completions/client/openai/openai.go
+++ b/internal/completions/client/openai/openai.go
@@ -35,11 +35,11 @@ type openAIChatCompletionStreamClient struct {
 
 func (c *openAIChatCompletionStreamClient) Complete(
 	ctx context.Context,
-	feature types.CompletionsFeature,
-	_ types.CompletionsVersion,
-	requestParams types.CompletionRequestParameters,
 	logger log.Logger,
-) (*types.CompletionResponse, error) {
+	request types.CompletionRequest) (*types.CompletionResponse, error) {
+	feature := request.Feature
+	requestParams := request.Parameters
+
 	var resp *http.Response
 	var err error
 	defer (func() {
@@ -67,7 +67,12 @@ func (c *openAIChatCompletionStreamClient) Complete(
 		// Empty response.
 		return &types.CompletionResponse{}, nil
 	}
-	err = c.tokenManager.UpdateTokenCountsFromModelUsage(response.Usage.PromptTokens, response.Usage.CompletionTokens, tokenizer.OpenAIModel+"/"+requestParams.Model, string(feature), tokenusage.OpenAI)
+	err = c.tokenManager.UpdateTokenCountsFromModelUsage(
+		response.Usage.PromptTokens,
+		response.Usage.CompletionTokens,
+		tokenizer.OpenAIModel+"/"+requestParams.Model,
+		string(feature),
+		tokenusage.OpenAI)
 	if err != nil {
 		logger.Warn("Failed to count tokens with the token manager %w ", log.Error(err))
 	}
@@ -79,12 +84,12 @@ func (c *openAIChatCompletionStreamClient) Complete(
 
 func (c *openAIChatCompletionStreamClient) Stream(
 	ctx context.Context,
-	feature types.CompletionsFeature,
-	_ types.CompletionsVersion,
-	requestParams types.CompletionRequestParameters,
-	sendEvent types.SendCompletionEvent,
 	logger log.Logger,
-) error {
+	request types.CompletionRequest,
+	sendEvent types.SendCompletionEvent) error {
+	feature := request.Feature
+	requestParams := request.Parameters
+
 	var resp *http.Response
 	var err error
 

--- a/internal/completions/client/openai/openai_test.go
+++ b/internal/completions/client/openai/openai_test.go
@@ -35,9 +35,15 @@ func TestErrStatusNotOK(t *testing.T) {
 		},
 	}, "", "", *tokenManager)
 
+	compRequest := types.CompletionRequest{
+		Feature:    types.CompletionsFeatureChat,
+		Version:    types.CompletionsVersionLegacy,
+		Parameters: types.CompletionRequestParameters{},
+	}
+
 	t.Run("Complete", func(t *testing.T) {
 		logger := log.Scoped("completions")
-		resp, err := mockClient.Complete(context.Background(), types.CompletionsFeatureChat, types.CompletionsVersionLegacy, types.CompletionRequestParameters{}, logger)
+		resp, err := mockClient.Complete(context.Background(), logger, compRequest)
 		require.Error(t, err)
 		assert.Nil(t, resp)
 
@@ -48,7 +54,8 @@ func TestErrStatusNotOK(t *testing.T) {
 
 	t.Run("Stream", func(t *testing.T) {
 		logger := log.Scoped("completions")
-		err := mockClient.Stream(context.Background(), types.CompletionsFeatureChat, types.CompletionsVersionLegacy, types.CompletionRequestParameters{}, func(event types.CompletionResponse) error { return nil }, logger)
+		sendEventFn := func(event types.CompletionResponse) error { return nil }
+		err := mockClient.Stream(context.Background(), logger, compRequest, sendEventFn)
 		require.Error(t, err)
 
 		autogold.Expect("OpenAI: unexpected status code 429: oh no, please slow down!").Equal(t, err.Error())

--- a/internal/completions/types/types.go
+++ b/internal/completions/types/types.go
@@ -188,13 +188,19 @@ const (
 	CodyClientJetbrains CodyClientName = "jetbrains"
 )
 
+type CompletionRequest struct {
+	Feature    CompletionsFeature
+	Version    CompletionsVersion
+	Parameters CompletionRequestParameters
+}
+
 type CompletionsClient interface {
 	// Stream executions a completions request, streaming results to the callback.
 	// Callers should check for ErrStatusNotOK and handle the error appropriately.
-	Stream(context.Context, CompletionsFeature, CompletionsVersion, CompletionRequestParameters, SendCompletionEvent, log.Logger) error
+	Stream(context.Context, log.Logger, CompletionRequest, SendCompletionEvent) error
 	// Complete executions a completions request until done. Callers should check
 	// for ErrStatusNotOK and handle the error appropriately.
-	Complete(context.Context, CompletionsFeature, CompletionsVersion, CompletionRequestParameters, log.Logger) (*CompletionResponse, error)
+	Complete(context.Context, log.Logger, CompletionRequest) (*CompletionResponse, error)
 }
 
 func ConvertFromLegacyMessages(messages []Message) []Message {


### PR DESCRIPTION
Minor refactoring to the `cmd/frontend/internal/completions` package.

When we call `newCompletionsHandler` one of the parameters is a function named `getModel`. This is called to determine which LLM model should be use to respond to the incoming completion request. And we have two implementations of this function, one for code completions and another for chats.

This PR just moves the logic for those two implementations into their own file (`get_model.go`), along with a couple of functions for which they were the only caller.

There were two minor functionality changes I made, which I'll call out in comments on this PR.

## Why?

As we rework how LLM models and associated configuration flows throughout the backend, updating these functions will be a bit easier if they are pulled out like this rather than being defined inline like they are today.

Also, pretty much any place in the codebase where we have hard-coded an LLM model is "on notice" and should instead be driven entirely by some sort of global configuration file. (Since this is one of the key problems server-side LLM config is trying to solve.)

## Test plan

NA, no functional changes. Relying on CI/CD and linter.

## Changelog

NA