### PR TITLE
fix/msp/postgresqlroles: wait for databases to be provisioned

### DIFF
--- a/dev/managedservicesplatform/internal/resource/cloudsql/cloudsql.go
+++ b/dev/managedservicesplatform/internal/resource/cloudsql/cloudsql.go
@@ -34,6 +34,9 @@ type Output struct {
 	// OperatorAccessUser is the SQL user corresponding to the operator access
 	// service account.
 	OperatorAccessUser sqluser.SqlUser
+	// Databases created in the Cloud SQL instance, used for resources that
+	// depend on database creation.
+	Databases []cdktf.ITerraformDependable
 }
 
 type Config struct {
@@ -209,6 +212,7 @@ func New(scope constructs.Construct, id resourceid.ID, config Config) (*Output, 
 			instance, config.WorkloadIdentity, databaseResources),
 		OperatorAccessUser: newSqlUserForIdentity(scope, id.TerraformID("operator_access_service_account_user"),
 			instance, config.OperatorAccessIdentity, databaseResources),
+		Databases: databaseResources,
 	}, nil
 }
 

--- a/dev/managedservicesplatform/internal/resource/postgresqlroles/postgresqlroles.go
+++ b/dev/managedservicesplatform/internal/resource/postgresqlroles/postgresqlroles.go
@@ -59,7 +59,8 @@ func New(scope constructs.Construct, id resourceid.ID, config Config) (*Output, 
 	// Operator access: grant restricted read-only permissions, based on
 	// https://github.com/sourcegraph/deploy-sourcegraph-managed/blob/ded74a806bb6d1925cb894a8755ed52db7585a4f/modules/terraform-managed-instance-new/sql.tf#L153-L179
 	for _, db := range config.Databases {
-		_ = grant.NewGrant(scope, id.Group(db).TerraformID("operator_access_service_account_connect_grant"), &grant.GrantConfig{
+		id := id.Group(db)
+		_ = grant.NewGrant(scope, id.TerraformID("operator_access_service_account_connect_grant"), &grant.GrantConfig{
 			Provider:   pgProvider,
 			Database:   &db,
 			Role:       config.CloudSQL.OperatorAccessUser.Name(),
@@ -67,8 +68,9 @@ func New(scope constructs.Construct, id resourceid.ID, config Config) (*Output, 
 			Privileges: pointers.Ptr(pointers.Slice([]string{
 				"CONNECT",
 			})),
+			DependsOn: &config.CloudSQL.Databases,
 		})
-		_ = grant.NewGrant(scope, id.Group(db).TerraformID("operator_access_service_account_table_grant"), &grant.GrantConfig{
+		_ = grant.NewGrant(scope, id.TerraformID("operator_access_service_account_table_grant"), &grant.GrantConfig{
 			Provider: pgProvider,
 			Database: &db,
 			Role:     config.CloudSQL.OperatorAccessUser.Name(),
@@ -80,6 +82,7 @@ func New(scope constructs.Construct, id resourceid.ID, config Config) (*Output, 
 			Privileges: pointers.Ptr(pointers.Slice([]string{
 				"SELECT",
 			})),
+			DependsOn: &config.CloudSQL.Databases,
 		})
 	}
 


### PR DESCRIPTION
Wait for databases to be provisioned before granting database-specific roles to the operator access user. 

## Test plan

Re-apply fixed https://sourcegraph.slack.com/archives/C05E2LHPQLX/p1718850688397579, indicating a race condition on database creation. Diff looks good:

```diff
@@ -1447,10 +1472,15 @@
             "path": "cloudrun/cloudrun-postgresqlroles-msp_iam-operator_access_service_account_table_grant",
             "uniqueId": "cloudrun-postgresqlroles-msp_iam-operator_access_service_account_table_grant"
           }
         },
         "database": "msp_iam",
+        "depends_on": [
+          "google_sql_database.postgresql-database-enterprise-portal",
+          "google_sql_database.postgresql-database-enterprise_portal",
+          "google_sql_database.postgresql-database-msp_iam"
+        ],
         "object_type": "table",
         "objects": [
         ],
         "privileges": [
           "SELECT"
```

## Changelog

- MSP Cloud SQL: Fix race condition between database creation and role grants for the read-only operator access user