### PR TITLE
Split apart dotcom env vars

### DIFF
--- a/cmd/frontend/backend/repos.go
+++ b/cmd/frontend/backend/repos.go
@@ -3,10 +3,11 @@ package backend
 import (
 	"context"
 	"fmt"
-	"github.com/sourcegraph/sourcegraph/internal/env"
 	"net/http"
 	"strconv"
 	"time"
+
+	"github.com/sourcegraph/sourcegraph/internal/env"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -96,9 +97,8 @@ func (s *repos) GetByName(ctx context.Context, name api.RepoName) (_ *types.Repo
 		return nil, err
 	}
 
-	if errcode.IsNotFound(err) && !dotcom.SourcegraphDotComMode() {
-		// The repo doesn't exist and we're not on sourcegraph.com, we should not lazy
-		// clone it.
+	if errcode.IsNotFound(err) && !dotcom.LazilySyncsIndefinitelyManyRepositories() {
+		// The repo doesn't exist and we should not lazy clone it.
 		return nil, err
 	}
 
@@ -242,7 +242,7 @@ func (s *repos) ListIndexable(ctx context.Context) (repos []types.MinimalRepo, e
 		done()
 	}()
 
-	if dotcom.SourcegraphDotComMode() {
+	if dotcom.LazilySyncsIndefinitelyManyRepositories() {
 		return s.cache.List(ctx)
 	}
 

--- a/cmd/frontend/backend/user_emails.go
+++ b/cmd/frontend/backend/user_emails.go
@@ -528,10 +528,10 @@ func checkEmailAbuse(ctx context.Context, db database.DB, userID int32) (abused 
 			return true, "too many existing unverified email addresses", nil
 		}
 	}
-	if dotcom.SourcegraphDotComMode() {
-		// Abuse prevention check 3: Set a quota on Sourcegraph.com users to prevent abuse.
+	if dotcom.IsAbusePreventionEnabled() {
+		// Abuse prevention check 3: Set a quota to prevent abuse.
 		//
-		// There is no quota for on-prem instances because we assume they can trust their users
+		// There is no quota by default because we assume most instances can trust their users
 		// to not abuse adding emails.
 		//
 		// TODO(sqs): This reuses the "invite quota", which is really just a number that counts

--- a/cmd/frontend/enterprise/enterprise.go
+++ b/cmd/frontend/enterprise/enterprise.go
@@ -13,7 +13,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/types"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/dotcom"
 )
 
 // Services is a bag of HTTP handlers and factory functions that are registered by the
@@ -143,12 +142,6 @@ func (e *emptyWebhookHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 	makeNotFoundHandler(e.name)
 }
 
-type ErrBatchChangesDisabledDotcom struct{}
-
-func (e ErrBatchChangesDisabledDotcom) Error() string {
-	return "batch changes is not available on Sourcegraph.com; use Sourcegraph Cloud or self-hosted instead"
-}
-
 type ErrBatchChangesDisabled struct{}
 
 func (e ErrBatchChangesDisabled) Error() string {
@@ -166,11 +159,6 @@ func (e ErrBatchChangesDisabledForUser) Error() string {
 func BatchChangesEnabledForSite() error {
 	if !conf.BatchChangesEnabled() {
 		return ErrBatchChangesDisabled{}
-	}
-
-	// Batch Changes are disabled on sourcegraph.com
-	if dotcom.SourcegraphDotComMode() {
-		return ErrBatchChangesDisabledDotcom{}
 	}
 
 	return nil

--- a/cmd/frontend/graphqlbackend/access_tokens.go
+++ b/cmd/frontend/graphqlbackend/access_tokens.go
@@ -29,12 +29,6 @@ type createAccessTokenInput struct {
 }
 
 func (r *schemaResolver) CreateAccessToken(ctx context.Context, args *createAccessTokenInput) (*createAccessTokenResult, error) {
-	// 🚨 SECURITY: Creating access tokens for any user by site admins is not
-	// allowed on Sourcegraph.com. This check is mostly the defense for a
-	// misconfiguration of the site configuration.
-	if dotcom.SourcegraphDotComMode() && conf.AccessTokensAllow() == conf.AccessTokensAdmin {
-		return nil, errors.Errorf("access token configuration value %q is disabled on Sourcegraph.com", conf.AccessTokensAllow())
-	}
 
 	userID, err := UnmarshalUserID(args.User)
 	if err != nil {
@@ -56,6 +50,16 @@ func (r *schemaResolver) CreateAccessToken(ctx context.Context, args *createAcce
 		if err := auth.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
 			return nil, errors.New("Access token creation has been restricted to admin users. Contact an admin user to create a new access token.")
 		}
+
+		// 🚨 SECURITY: Creating access tokens for other users by site admins is not allowed on
+		// Sourcegraph.com. This check is mostly the defense for a misconfiguration of the site
+		// configuration.
+		if dotcom.SourcegraphDotComMode() {
+			if err := auth.CheckSameUser(ctx, userID); err != nil {
+				return nil, errors.New("access token creation for other users is disabled on Sourcegraph.com")
+			}
+		}
+
 	case conf.AccessTokensNone:
 	default:
 		return nil, errors.New("Access token creation is disabled. Contact an admin user to enable.")

--- a/cmd/frontend/graphqlbackend/external_account.go
+++ b/cmd/frontend/graphqlbackend/external_account.go
@@ -58,8 +58,8 @@ func (r *externalAccountResolver) AccountID() string   { return r.account.Accoun
 
 // TEMPORARY: This resolver is temporary to help us debug the #inc-284-plg-users-paying-for-and-being-billed-for-pro-without-being-upgrade.
 func (r *externalAccountResolver) CodySubscription(ctx context.Context) (*CodySubscriptionResolver, error) {
-	if !dotcom.SourcegraphDotComMode() {
-		return nil, errors.New("this feature is only available on sourcegraph.com")
+	if !dotcom.ProvidesCodySelfServe() {
+		return nil, errors.New("this feature is only available on Cody self-serve")
 	}
 
 	if r.account.ServiceType != "openidconnect" || r.account.ServiceID != ssc.GetSAMSServiceID() {

--- a/cmd/frontend/graphqlbackend/git_tree_entry.go
+++ b/cmd/frontend/graphqlbackend/git_tree_entry.go
@@ -24,7 +24,6 @@ import (
 	resolverstubs "github.com/sourcegraph/sourcegraph/internal/codeintel/resolvers"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/dotcom"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 	"github.com/sourcegraph/sourcegraph/internal/gosyntect"
@@ -281,13 +280,11 @@ func (r *GitTreeEntryResolver) Highlight(ctx context.Context, args *HighlightArg
 	}
 
 	// special handling in dotcom to prevent syntax highlighting large lock files
-	if dotcom.SourcegraphDotComMode() {
-		for _, f := range syntaxHighlightFileBlocklist {
-			if strings.HasSuffix(r.Path(), f) {
-				// this will force the content to be returned as plaintext
-				// without hitting the syntax highlighter
-				args.Format = string(gosyntect.FormatHTMLPlaintext)
-			}
+	for _, f := range syntaxHighlightFileBlocklist {
+		if strings.HasSuffix(r.Path(), f) {
+			// this will force the content to be returned as plaintext
+			// without hitting the syntax highlighter
+			args.Format = string(gosyntect.FormatHTMLPlaintext)
 		}
 	}
 

--- a/cmd/frontend/graphqlbackend/org_invitations.go
+++ b/cmd/frontend/graphqlbackend/org_invitations.go
@@ -355,9 +355,7 @@ func createInvitationJWT(orgID int32, invitationID int64, senderID int32, expiry
 // respond to the invitation. Callers should check conf.CanSendEmail() if they want to return a nice
 // error if sending email is not enabled.
 func sendOrgInvitationNotification(ctx context.Context, db database.DB, org *types.Org, sender *types.User, recipientEmail string, invitationURL string, expiryTime time.Time) error {
-	if dotcom.SourcegraphDotComMode() {
-		// Basic abuse prevention for Sourcegraph.com.
-
+	if dotcom.IsAbusePreventionEnabled() {
 		// Only allow email-verified users to send invites.
 		if _, senderEmailVerified, err := db.UserEmails().GetPrimaryEmail(ctx, sender.ID); err != nil {
 			return err

--- a/cmd/frontend/graphqlbackend/person.go
+++ b/cmd/frontend/graphqlbackend/person.go
@@ -7,12 +7,13 @@ import (
 	"sync"
 	"unicode"
 
+	"golang.org/x/text/unicode/norm"
+
 	"github.com/sourcegraph/sourcegraph/internal/auth"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/dotcom"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
 	"github.com/sourcegraph/sourcegraph/internal/types"
-	"golang.org/x/text/unicode/norm"
 )
 
 type PersonResolver struct {
@@ -92,7 +93,7 @@ func unicodeToAscii(input string) string {
 }
 
 func (r *PersonResolver) Email(ctx context.Context) (string, error) {
-	if !dotcom.SourcegraphDotComMode() {
+	if !dotcom.IsAbusePreventionEnabled() {
 		return r.email, nil
 	}
 

--- a/cmd/frontend/graphqlbackend/repositories.go
+++ b/cmd/frontend/graphqlbackend/repositories.go
@@ -216,8 +216,7 @@ func (s *repositoriesConnectionStore) ComputeTotal(ctx context.Context) (int32, 
 		return 0, nil
 	}
 
-	// Counting repositories is slow on Sourcegraph.com. Don't wait very long for an exact count.
-	if dotcom.SourcegraphDotComMode() {
+	if dotcom.LazilySyncsIndefinitelyManyRepositories() {
 		return 0, nil
 	}
 

--- a/cmd/frontend/graphqlbackend/site.go
+++ b/cmd/frontend/graphqlbackend/site.go
@@ -608,8 +608,8 @@ func (r *siteResolver) PerUserCodeCompletionsQuota() *int32 {
 }
 
 func (r *siteResolver) RequiresVerifiedEmailForCody(ctx context.Context) bool {
-	// We only require this on dotcom
-	if !dotcom.SourcegraphDotComMode() {
+	// We only require a verified email to prevent abuse.
+	if !dotcom.IsAbusePreventionEnabled() {
 		return false
 	}
 

--- a/cmd/frontend/graphqlbackend/user.go
+++ b/cmd/frontend/graphqlbackend/user.go
@@ -791,9 +791,9 @@ func (r *UserResolver) BatchChangesCodeHosts(ctx context.Context, args *ListBatc
 }
 
 func (r *UserResolver) Roles(ctx context.Context, args *ListRoleArgs) (*graphqlutil.ConnectionResolver[RoleResolver], error) {
-	// 🚨 SECURITY: In dotcom mode, only allow site admins to check roles.
-	if dotcom.SourcegraphDotComMode() && auth.CheckCurrentUserIsSiteAdmin(ctx, r.db) != nil {
-		return nil, errors.New("unauthorized")
+	// 🚨 SECURITY: Only allow site admins or the user to check the user's roles.
+	if err := auth.CheckSiteAdminOrSameUser(ctx, r.db, r.user.ID); err != nil {
+		return nil, err
 	}
 	userID := r.user.ID
 	connectionStore := &roleConnectionStore{

--- a/cmd/frontend/graphqlbackend/user.go
+++ b/cmd/frontend/graphqlbackend/user.go
@@ -49,9 +49,8 @@ func (r *schemaResolver) User(
 		user, err = r.db.Users().GetByID(ctx, *args.DatabaseID)
 
 	case args.Email != nil:
-		// 🚨 SECURITY: Only site admins are allowed to look up by email address on
-		// Sourcegraph.com, for user privacy reasons.
-		if dotcom.SourcegraphDotComMode() {
+		if dotcom.IsUserAndOrgProfileDataPrivate() {
+			// 🚨 SECURITY: Only site admins are allowed to look up by email address in this mode for user privacy reasons.
 			if err := auth.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
 				return nil, err
 			}

--- a/cmd/frontend/graphqlbackend/user_emails.go
+++ b/cmd/frontend/graphqlbackend/user_emails.go
@@ -26,8 +26,8 @@ func (r *UserResolver) HasVerifiedEmail(ctx context.Context) (bool, error) {
 
 func (r *UserResolver) Emails(ctx context.Context) ([]*userEmailResolver, error) {
 	// 🚨 SECURITY: Only the authenticated user and site admins can list user's
-	// emails on Sourcegraph.com.
-	if dotcom.SourcegraphDotComMode() {
+	// emails on multi-tenant instances.
+	if !dotcom.IsUserAndOrgProfileDataPrivate() {
 		if err := auth.CheckSiteAdminOrSameUser(ctx, r.db, r.user.ID); err != nil {
 			return nil, err
 		}
@@ -52,10 +52,9 @@ func (r *UserResolver) Emails(ctx context.Context) ([]*userEmailResolver, error)
 }
 
 func (r *UserResolver) PrimaryEmail(ctx context.Context) (*userEmailResolver, error) {
-	// 🚨 SECURITY: Only the authenticated user and site admins can list user's
-	// emails on Sourcegraph.com. We don't return an error, but not showing the email
-	// either.
-	if dotcom.SourcegraphDotComMode() {
+	// 🚨 SECURITY: Only the authenticated user and site admins can list the user's emails on
+	// multi-tenant instances. We don't return an error, but we don't show the email either.
+	if !dotcom.IsUserAndOrgProfileDataPrivate() {
 		if err := auth.CheckSiteAdminOrSameUser(ctx, r.db, r.user.ID); err != nil {
 			return nil, nil
 		}

--- a/cmd/frontend/graphqlbackend/user_usage_stats.go
+++ b/cmd/frontend/graphqlbackend/user_usage_stats.go
@@ -185,11 +185,6 @@ func (r *schemaResolver) LogEvents(ctx context.Context, args *EventBatch) (*Empt
 				})
 		}
 
-		// On Sourcegraph.com only, log a HubSpot event indicating when the user clicks button to downloads Cody App.
-		if dotcom.SourcegraphDotComMode() && args.Event == "DownloadApp" && userID != 0 && userPrimaryEmail != "" {
-			hubspotutil.SyncUser(userPrimaryEmail, hubspotutil.AppDownloadButtonClickedEventID, &hubspot.ContactProperties{})
-		}
-
 		argumentPayload, err := decode(args.Argument)
 		if err != nil {
 			return nil, err

--- a/cmd/frontend/graphqlbackend/user_usage_stats.go
+++ b/cmd/frontend/graphqlbackend/user_usage_stats.go
@@ -344,7 +344,7 @@ func (r *schemaResolver) SubmitCodySurvey(ctx context.Context, args *struct {
 	IsForWork     bool
 	IsForPersonal bool
 }) (*EmptyResponse, error) {
-	if !dotcom.SourcegraphDotComMode() {
+	if !dotcom.ProvidesCodySelfServe() {
 		return nil, errors.New("Cody survey is not supported outside sourcegraph.com")
 	}
 

--- a/cmd/frontend/graphqlbackend/user_usage_stats.go
+++ b/cmd/frontend/graphqlbackend/user_usage_stats.go
@@ -26,10 +26,8 @@ import (
 )
 
 func (r *UserResolver) UsageStatistics(ctx context.Context) (*userUsageStatisticsResolver, error) {
-	if dotcom.SourcegraphDotComMode() {
-		if err := auth.CheckSiteAdminOrSameUser(ctx, r.db, r.user.ID); err != nil {
-			return nil, err
-		}
+	if err := auth.CheckSiteAdminOrSameUser(ctx, r.db, r.user.ID); err != nil {
+		return nil, err
 	}
 
 	stats, err := usagestats.GetByUserID(ctx, r.db, r.user.ID)

--- a/cmd/frontend/graphqlbackend/users.go
+++ b/cmd/frontend/graphqlbackend/users.go
@@ -143,8 +143,8 @@ func (r *userConnectionResolver) PageInfo(ctx context.Context) (*graphqlutil.Pag
 }
 
 func checkMembersAccess(ctx context.Context, db database.DB) error {
-	// 🚨 SECURITY: Only site admins can list users on sourcegraph.com.
-	if dotcom.SourcegraphDotComMode() {
+	if dotcom.IsUserAndOrgProfileDataPrivate() {
+		// 🚨 SECURITY: Only site admins can list users in this mode.
 		if err := auth.CheckCurrentUserIsSiteAdmin(ctx, db); err != nil {
 			return err
 		}

--- a/cmd/frontend/hubspot/hubspotutil/hubspotutil.go
+++ b/cmd/frontend/hubspot/hubspotutil/hubspotutil.go
@@ -45,9 +45,6 @@ var CodyClientInstalledEventID = "000018021981"
 // CodyClientInstalledV3EventID is the HubSpot ID for the new event which support custom properties.
 var CodyClientInstalledV3EventID = "pe2762526_codyinstall"
 
-// AppDownloadButtonClickedEventID is the HubSpot Event ID for when a user clicks on a button to download Cody App.
-var AppDownloadButtonClickedEventID = "000019179879"
-
 var client *hubspot.Client
 
 // HasAPIKey returns true if a HubspotAPI key is present. A subset of requests require a HubSpot API key.

--- a/cmd/frontend/internal/batches/resolvers/errors.go
+++ b/cmd/frontend/internal/batches/resolvers/errors.go
@@ -60,12 +60,6 @@ func (e ErrBatchChangesOverLimit) Extensions() map[string]any {
 	return map[string]any{"code": "ErrBatchChangesOverLimit"}
 }
 
-type ErrBatchChangesDisabledDotcom struct{ error }
-
-func (e ErrBatchChangesDisabledDotcom) Extensions() map[string]any {
-	return map[string]any{"code": "ErrBatchChangesDisabledDotcom"}
-}
-
 type ErrEnsureBatchChangeFailed struct{}
 
 func (e ErrEnsureBatchChangeFailed) Error() string {

--- a/internal/auth/site_admin.go
+++ b/internal/auth/site_admin.go
@@ -12,7 +12,7 @@ import (
 )
 
 var ErrMustBeSiteAdmin = errors.New("must be site admin")
-var ErrMustBeSiteAdminOrSameUser = &InsufficientAuthorizationError{"must be authenticated as the authorized user or site admin"}
+var ErrMustBeSiteAdminOrSameUser = &InsufficientAuthorizationError{"must be authenticated as the user or be a site admin"}
 
 // CheckCurrentUserIsSiteAdmin returns an error if the current user is NOT a site admin.
 func CheckCurrentUserIsSiteAdmin(ctx context.Context, db database.DB) error {

--- a/internal/authz/header.go
+++ b/internal/authz/header.go
@@ -54,7 +54,7 @@ func ParseAuthorizationHeader(headerValue string) (token, sudoUser string, err e
 		}
 	}
 
-	if dotcom.SourcegraphDotComMode() && scheme == SchemeTokenSudo {
+	if !dotcom.SiteAdminCanViewAllUserData() && scheme == SchemeTokenSudo {
 		return "", "", errors.New("use of access tokens with sudo scope is disabled")
 	}
 

--- a/internal/authz/register.go
+++ b/internal/authz/register.go
@@ -3,7 +3,6 @@ package authz
 import (
 	"sync"
 
-	"github.com/sourcegraph/sourcegraph/internal/dotcom"
 	"github.com/sourcegraph/sourcegraph/internal/testutil"
 )
 
@@ -34,12 +33,6 @@ func SetProviders(authzAllowByDefault bool, z []Provider) {
 
 	authzProviders = z
 	allowAccessByDefault = authzAllowByDefault
-
-	// 🚨 SECURITY: We do not want to allow access by default by any means on
-	// dotcom.
-	if dotcom.SourcegraphDotComMode() {
-		allowAccessByDefault = false
-	}
 
 	authzProvidersReadyOnce.Do(func() {
 		close(authzProvidersReady)

--- a/internal/conf/computed.go
+++ b/internal/conf/computed.go
@@ -14,6 +14,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/conf/confdefaults"
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	"github.com/sourcegraph/sourcegraph/internal/conf/deploy"
+	"github.com/sourcegraph/sourcegraph/internal/dotcom"
 	"github.com/sourcegraph/sourcegraph/internal/hashutil"
 	"github.com/sourcegraph/sourcegraph/internal/license"
 	srccli "github.com/sourcegraph/sourcegraph/internal/src-cli"
@@ -164,6 +165,10 @@ func UpdateChannel() string {
 }
 
 func BatchChangesEnabled() bool {
+	if dotcom.SourcegraphDotComMode() {
+		// Batch Changes is always disabled on dotcom.
+		return false
+	}
 	if enabled := Get().BatchChangesEnabled; enabled != nil {
 		return *enabled
 	}

--- a/internal/dotcom/dotcom.go
+++ b/internal/dotcom/dotcom.go
@@ -15,6 +15,57 @@ func SourcegraphDotComMode() bool {
 	return sourcegraphDotComMode
 }
 
+// ProvidesCodySelfServe is true if this instance provides Cody self-serve (PLG) user and team
+// management.
+//
+// This is currently equivalent to `SourcegraphDotComMode()`;  i.e., it is enabled on
+// Sourcegraph.com and no other instances.
+func ProvidesCodySelfServe() bool {
+	return SourcegraphDotComMode()
+}
+
+// IsAbusePreventionEnabled is whether abuse prevention is enabled.
+//
+// This is currently equivalent to `SourcegraphDotComMode()`;  i.e., it is enabled on
+// Sourcegraph.com and no other instances.
+func IsAbusePreventionEnabled() bool {
+	return SourcegraphDotComMode()
+}
+
+// IsUserAndOrgProfileDataPrivate is whether user and organization profile and membership data is
+// private.
+//
+//   - If private (true), for example, organization membership is only visible to
+//     members of the organization.
+//   - If not private (false), for example, user's email addresses, committer email addresses,
+//     organization membership, etc., are visible to all users. Sensitive data (such as
+//     user credentials and user/org settings) is treated as private.
+//
+// This is currently equivalent to `SourcegraphDotComMode()`; i.e., it is enabled on Sourcegraph.com
+// and no other instances.
+func IsUserAndOrgProfileDataPrivate() bool {
+	return SourcegraphDotComMode()
+}
+
+// SiteAdminCanViewAllUserData is whether the instance's site admin can view all user data,
+// including sensitive user data.
+//
+// This is currently equivalent to `!SourcegraphDotComMode()`; i.e., it is DISABLED on Sourcegraph.com
+// and enabled on all other instances.
+func SiteAdminCanViewAllUserData() bool {
+	return !SourcegraphDotComMode()
+}
+
+// LazilySyncsIndefinitelyManyRepositories is true if the instance has a very large and indefinite
+// number of synced repositories, such as on Sourcegraph.com where we sync repositories from
+// GitHub.com.
+//
+// This is currently equivalent to `SourcegraphDotComMode()`; i.e., it is enabled on Sourcegraph.com
+// and no other instances.
+func LazilySyncsIndefinitelyManyRepositories() bool {
+	return SourcegraphDotComMode()
+}
+
 type TB interface {
 	Cleanup(func())
 }

--- a/internal/search/repos/repos.go
+++ b/internal/search/repos/repos.go
@@ -22,7 +22,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/dotcom"
 	"github.com/sourcegraph/sourcegraph/internal/endpoint"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
@@ -1117,7 +1116,7 @@ func findPatternRevs(includePatterns []query.ParsedRepoFilter) (outputPatterns [
 }
 
 func optimizeRepoPatternWithHeuristics(repoPattern string) string {
-	if dotcom.SourcegraphDotComMode() && (strings.HasPrefix(repoPattern, "github.com") || strings.HasPrefix(repoPattern, `github\.com`)) {
+	if strings.HasPrefix(repoPattern, "github.com/") || strings.HasPrefix(repoPattern, `github\.com/`) {
 		repoPattern = "^" + repoPattern
 	}
 	// Optimization: make the "." in "github.com" a literal dot

--- a/internal/search/searchcontexts/search_contexts.go
+++ b/internal/search/searchcontexts/search_contexts.go
@@ -80,7 +80,7 @@ func ResolveSearchContextSpec(ctx context.Context, db database.DB, searchContext
 
 		// Only member of the organization can use search contexts under the
 		// organization namespace on Sourcegraph Cloud.
-		if dotcom.SourcegraphDotComMode() && namespace.Organization > 0 {
+		if dotcom.IsUserAndOrgProfileDataPrivate() && namespace.Organization > 0 {
 			_, err = db.OrgMembers().GetByOrgIDAndUserID(ctx, namespace.Organization, actor.FromContext(ctx).UID)
 			if err != nil {
 				if errcode.IsNotFound(err) {

--- a/internal/suspiciousnames/names.go
+++ b/internal/suspiciousnames/names.go
@@ -18,7 +18,7 @@ import (
 // 🚨 SECURITY: This is not foolproof; users may choose a name like `secur1ty` that might be
 // confused with a name like "security", or they might find another synonym that we didn't think of.
 func CheckNameAllowedForUserOrOrganization(desiredName string) error {
-	if dotcom.SourcegraphDotComMode() && isSuspicious(desiredName) {
+	if dotcom.IsAbusePreventionEnabled() && isSuspicious(desiredName) {
 		return errors.Errorf("rejected suspicious name %q", desiredName)
 	}
 	return nil


### PR DESCRIPTION
Currently we use `dotcom.SourcegraphDotComMode()` to alter behavior in ~135 places in the code.

I have heard from many people that this amount of special-casing is daunting and prevents them from feeling confident about dotcom, and I agree and understand why. So, I went through and started to categorize the different reasons for special-casing dotcom, using my historical knowledge of why we did things in certain ways:

- ProvidesCodySelfServe - Cody PLG endpoints
- IsAbusePreventionEnabled - rate limits, etc.
- IsUserAndOrgProfileDataPrivate - whether to expose user/committer emails and org membership
- SiteAdminCanViewAllUserData - whether site admins can assume other user identities and view all user data
- LazilySyncsIndefinitelyManyRepositories - whether we're syncing against the github.com universe
- (and there are probably a few more that I haven't yet carved out)

This work is not complete, but it starts to bring some order to the special-casing, suggests ways we could start to reduce it, and helps us make progress on multi-tenancy.

## Test plan

TODO

## Changelog

TODO