### PR TITLE
chore: remove obsolete tracking code for Cody App downloads

### DIFF
--- a/cmd/frontend/graphqlbackend/user_usage_stats.go
+++ b/cmd/frontend/graphqlbackend/user_usage_stats.go
@@ -187,11 +187,6 @@ func (r *schemaResolver) LogEvents(ctx context.Context, args *EventBatch) (*Empt
 				})
 		}
 
-		// On Sourcegraph.com only, log a HubSpot event indicating when the user clicks button to downloads Cody App.
-		if dotcom.SourcegraphDotComMode() && args.Event == "DownloadApp" && userID != 0 && userPrimaryEmail != "" {
-			hubspotutil.SyncUser(userPrimaryEmail, hubspotutil.AppDownloadButtonClickedEventID, &hubspot.ContactProperties{})
-		}
-
 		argumentPayload, err := decode(args.Argument)
 		if err != nil {
 			return nil, err

--- a/cmd/frontend/hubspot/hubspotutil/hubspotutil.go
+++ b/cmd/frontend/hubspot/hubspotutil/hubspotutil.go
@@ -45,9 +45,6 @@ var CodyClientInstalledEventID = "000018021981"
 // CodyClientInstalledV3EventID is the HubSpot ID for the new event which support custom properties.
 var CodyClientInstalledV3EventID = "pe2762526_codyinstall"
 
-// AppDownloadButtonClickedEventID is the HubSpot Event ID for when a user clicks on a button to download Cody App.
-var AppDownloadButtonClickedEventID = "000019179879"
-
 var client *hubspot.Client
 
 // HasAPIKey returns true if a HubspotAPI key is present. A subset of requests require a HubSpot API key.


### PR DESCRIPTION
Cody App was removed in June 2023 and is no longer in use.


## Test plan

CI