### PR TITLE
fix(api): only allow a user or site admin to view that user's usage stats

### DIFF
--- a/cmd/frontend/graphqlbackend/user_usage_stats.go
+++ b/cmd/frontend/graphqlbackend/user_usage_stats.go
@@ -26,10 +26,8 @@ import (
 )
 
 func (r *UserResolver) UsageStatistics(ctx context.Context) (*userUsageStatisticsResolver, error) {
-	if dotcom.SourcegraphDotComMode() {
-		if err := auth.CheckSiteAdminOrSameUser(ctx, r.db, r.user.ID); err != nil {
-			return nil, err
-		}
+	if err := auth.CheckSiteAdminOrSameUser(ctx, r.db, r.user.ID); err != nil {
+		return nil, err
 	}
 
 	stats, err := usagestats.GetByUserID(ctx, r.db, r.user.ID)

--- a/cmd/frontend/graphqlbackend/user_usage_stats_test.go
+++ b/cmd/frontend/graphqlbackend/user_usage_stats_test.go
@@ -1,8 +1,10 @@
 package graphqlbackend
 
 import (
+	"context"
 	"testing"
 
+	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbmocks"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/internal/usagestats"
@@ -47,6 +49,7 @@ func TestUser_UsageStatistics(t *testing.T) {
 					}
 				}
 			`,
+			Context: actor.WithActor(context.Background(), &actor.Actor{UID: 1}),
 		},
 	})
 }


### PR DESCRIPTION
Previously, all users were allowed to view a user's usage stats. This is an admin feature and it is not needed nor desirable for other users to be able to view a user's usage stats.


## Test plan

CI