### PR TITLE
allow repo access by default on dotcom

### DIFF
--- a/internal/authz/register.go
+++ b/internal/authz/register.go
@@ -3,7 +3,6 @@ package authz
 import (
 	"sync"
 
-	"github.com/sourcegraph/sourcegraph/internal/dotcom"
 	"github.com/sourcegraph/sourcegraph/internal/testutil"
 )
 
@@ -34,12 +33,6 @@ func SetProviders(authzAllowByDefault bool, z []Provider) {
 
 	authzProviders = z
 	allowAccessByDefault = authzAllowByDefault
-
-	// 🚨 SECURITY: We do not want to allow access by default by any means on
-	// dotcom.
-	if dotcom.SourcegraphDotComMode() {
-		allowAccessByDefault = false
-	}
 
 	authzProvidersReadyOnce.Do(func() {
 		close(authzProvidersReady)


### PR DESCRIPTION
Sourcegraph.com only has public repos, so it is safe to allow access to all repositories by all users.

This now-deleted code was originally added in https://github.com/sourcegraph/sourcegraph/pull/26345 to support private repositories on dotcom. We do not currently support private repositories on dotcom anymore, and when we do add back that feature, we can figure out how best to do it and will benefit from fewer special-cases for dotcom.

## Test plan

CI