### PR TITLE
chore: centralize logic for disabling Batch Changes on dotcom

### DIFF
--- a/cmd/frontend/enterprise/BUILD.bazel
+++ b/cmd/frontend/enterprise/BUILD.bazel
@@ -13,6 +13,5 @@ go_library(
         "//internal/codeintel/types",
         "//internal/conf",
         "//internal/database",
-        "//internal/dotcom",
     ],
 )

--- a/cmd/frontend/enterprise/enterprise.go
+++ b/cmd/frontend/enterprise/enterprise.go
@@ -13,7 +13,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/types"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/dotcom"
 )
 
 // Services is a bag of HTTP handlers and factory functions that are registered by the
@@ -143,12 +142,6 @@ func (e *emptyWebhookHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 	makeNotFoundHandler(e.name)
 }
 
-type ErrBatchChangesDisabledDotcom struct{}
-
-func (e ErrBatchChangesDisabledDotcom) Error() string {
-	return "batch changes is not available on Sourcegraph.com; use Sourcegraph Cloud or self-hosted instead"
-}
-
 type ErrBatchChangesDisabled struct{}
 
 func (e ErrBatchChangesDisabled) Error() string {
@@ -166,11 +159,6 @@ func (e ErrBatchChangesDisabledForUser) Error() string {
 func BatchChangesEnabledForSite() error {
 	if !conf.BatchChangesEnabled() {
 		return ErrBatchChangesDisabled{}
-	}
-
-	// Batch Changes are disabled on sourcegraph.com
-	if dotcom.SourcegraphDotComMode() {
-		return ErrBatchChangesDisabledDotcom{}
 	}
 
 	return nil

--- a/cmd/frontend/internal/batches/resolvers/errors.go
+++ b/cmd/frontend/internal/batches/resolvers/errors.go
@@ -60,12 +60,6 @@ func (e ErrBatchChangesOverLimit) Extensions() map[string]any {
 	return map[string]any{"code": "ErrBatchChangesOverLimit"}
 }
 
-type ErrBatchChangesDisabledDotcom struct{ error }
-
-func (e ErrBatchChangesDisabledDotcom) Extensions() map[string]any {
-	return map[string]any{"code": "ErrBatchChangesDisabledDotcom"}
-}
-
 type ErrEnsureBatchChangeFailed struct{}
 
 func (e ErrEnsureBatchChangeFailed) Error() string {

--- a/internal/conf/computed.go
+++ b/internal/conf/computed.go
@@ -14,6 +14,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/conf/confdefaults"
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	"github.com/sourcegraph/sourcegraph/internal/conf/deploy"
+	"github.com/sourcegraph/sourcegraph/internal/dotcom"
 	"github.com/sourcegraph/sourcegraph/internal/hashutil"
 	"github.com/sourcegraph/sourcegraph/internal/license"
 	srccli "github.com/sourcegraph/sourcegraph/internal/src-cli"
@@ -164,6 +165,10 @@ func UpdateChannel() string {
 }
 
 func BatchChangesEnabled() bool {
+	if dotcom.SourcegraphDotComMode() {
+		// Batch Changes is always disabled on dotcom.
+		return false
+	}
 	if enabled := Get().BatchChangesEnabled; enabled != nil {
 		return *enabled
 	}


### PR DESCRIPTION
This is how it's done for Code Insights as well.

## Test plan

CI