### PR TITLE
nix: use go1.22.4

### DIFF
--- a/dev/nix/go_1_22.nix
+++ b/dev/nix/go_1_22.nix
@@ -1,0 +1,9 @@
+{ pkgs, fetchurl }:
+pkgs.go_1_22.overrideAttrs rec {
+  # PLEASE UPDATE THE SHA512 BELOW OR NOTIFY ONE OF THE NIX USERS BEFORE MERGING A CHANGE TO THESE FILES
+  version = "1.22.4";
+  src = fetchurl {
+    url = "https://go.dev/dl/go${version}.src.tar.gz";
+    hash = "sha256-/tcgZ45yinyjC6jR3tHKr+J9FgKPqwIyuLqOIgCPt4Q=";
+  };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -26,7 +26,7 @@
       (system:
         let
           pkgs = nixpkgs.legacyPackages.${system};
-          pkgsShell = import nixpkgs { inherit system; overlays = with self.overlays; [ nodejs-20_x bazel_7 ]; };
+          pkgsShell = import nixpkgs { inherit system; overlays = with self.overlays; [ nodejs-20_x bazel_7 go_1_22 ]; };
           pkgsBins = nixpkgs-stable.legacyPackages.${system};
           pkgsAll = import nixpkgs { inherit system; overlays = builtins.attrValues self.overlays; };
           pkgsX = xcompileTargets.${system} or null;
@@ -47,6 +47,7 @@
               # tzdata fails to build on pkgsStatic, and pkgsMusl isnt supported on macos
               tzdata = if pkgs.hostPlatform.isMacOS then pkgs.tzdata else pkgs.pkgsMusl.tzdata;
             };
+            go_1_22 = pkgs.callPackage ./dev/nix/go_1_22.nix { };
           };
 
           # We use pkgsShell (not pkgsAll) intentionally to avoid doing extra work of
@@ -63,6 +64,7 @@
         p4-fusion = final: prev: { p4-fusion = self.packages.${prev.system}.p4-fusion; };
         bazel_7 = final: prev: { bazel_7 = self.packages.${prev.system}.bazel_7; };
         pg-utils = final: prev: { pg-utils = self.packages.${prev.system}.pg-utils; };
+        go_1_22 = final: prev: { go_1_22 = self.packages.${prev.system}.go_1_22; };
       };
     };
 }


### PR DESCRIPTION
Tired of seeing the go toolchain being easier to use than nix.

Test Plan: nix develop on linux amd64 and macbook arm64 followed by running "go test ./internal/search" working. Also confirming that "go env GOROOT" points into the nix store.
