### PR TITLE
feat(plg): Tweak invite co-workers flow

### DIFF
--- a/client/web/src/cody/management/CodyManagementPage.tsx
+++ b/client/web/src/cody/management/CodyManagementPage.tsx
@@ -88,7 +88,7 @@ export const CodyManagementPage: React.FunctionComponent<CodyManagementPageProps
         }
     }, [data, navigate])
 
-    const getTeamInviteButton = useCallback(() => {
+    const getTeamInviteButton = () => {
         const isSoloUser = subscriptionSummaryQueryResult?.data?.teamMaxMembers === 1
         const hasFreeSeats = subscriptionSummaryQueryResult?.data
             ? subscriptionSummaryQueryResult.data.teamMaxMembers >
@@ -96,12 +96,17 @@ export const CodyManagementPage: React.FunctionComponent<CodyManagementPageProps
             : false
         const targetUrl = hasFreeSeats ? '/cody/team/manage' : '/cody/manage/subscription/new?addSeats=1'
         const label = isSoloUser || hasFreeSeats ? 'Invite co-workers' : 'Add seats'
+
+        if (!subscriptionSummaryQueryResult?.data) {
+            return null
+        }
+
         return (
             <Button as={Link} to={targetUrl} variant="success" className="text-nowrap">
                 <Icon aria-hidden={true} svgPath={mdiPlusThick} /> {label}
             </Button>
         )
-    }, [subscriptionSummaryQueryResult?.data])
+    }
 
     const onClickUpgradeToProCTA = useCallback(() => {
         telemetryRecorder.recordEvent('cody.management.upgradeToProCTA', 'click')

--- a/client/web/src/cody/management/CodyManagementPage.tsx
+++ b/client/web/src/cody/management/CodyManagementPage.tsx
@@ -90,17 +90,17 @@ export const CodyManagementPage: React.FunctionComponent<CodyManagementPageProps
 
     const getTeamInviteButton = useCallback(() => {
         const isSoloUser = subscriptionSummaryQueryResult?.data?.teamMaxMembers === 1
-        const hasFreeSeats = subscriptionSummaryQueryResult?.data ? subscriptionSummaryQueryResult.data.teamMaxMembers > subscriptionSummaryQueryResult.data.teamCurrentMembers : false
-        const targetUrl= hasFreeSeats ? '/cody/team/manage' : '/cody/manage/subscription/new?addSeats=1'
-        const label = (isSoloUser || hasFreeSeats) ? 'Invite co-workers' : 'Add seats'
-        return <Button
-            as={Link}
-            to={targetUrl}
-            variant="success"
-            className="text-nowrap"
-        >
-            <Icon aria-hidden={true} svgPath={mdiPlusThick} /> {label}
-        </Button>
+        const hasFreeSeats = subscriptionSummaryQueryResult?.data
+            ? subscriptionSummaryQueryResult.data.teamMaxMembers >
+              subscriptionSummaryQueryResult.data.teamCurrentMembers
+            : false
+        const targetUrl = hasFreeSeats ? '/cody/team/manage' : '/cody/manage/subscription/new?addSeats=1'
+        const label = isSoloUser || hasFreeSeats ? 'Invite co-workers' : 'Add seats'
+        return (
+            <Button as={Link} to={targetUrl} variant="success" className="text-nowrap">
+                <Icon aria-hidden={true} svgPath={mdiPlusThick} /> {label}
+            </Button>
+        )
     }, [subscriptionSummaryQueryResult?.data])
 
     const onClickUpgradeToProCTA = useCallback(() => {
@@ -136,13 +136,7 @@ export const CodyManagementPage: React.FunctionComponent<CodyManagementPageProps
                 )}
                 <PageHeader
                     className="mb-4 mt-4"
-                    actions={
-                        isAdmin && (
-                            <div className="d-flex">
-                                {getTeamInviteButton()}
-                            </div>
-                        )
-                    }
+                    actions={isAdmin && <div className="d-flex">{getTeamInviteButton()}</div>}
                 >
                     <PageHeader.Heading as="h2" styleAs="h1">
                         <div className="d-inline-flex align-items-center">

--- a/client/web/src/cody/management/CodyManagementPage.tsx
+++ b/client/web/src/cody/management/CodyManagementPage.tsx
@@ -88,7 +88,7 @@ export const CodyManagementPage: React.FunctionComponent<CodyManagementPageProps
         }
     }, [data, navigate])
 
-    const getTeamInviteButton = () => {
+    const getTeamInviteButton = (): JSX.Element | null => {
         const isSoloUser = subscriptionSummaryQueryResult?.data?.teamMaxMembers === 1
         const hasFreeSeats = subscriptionSummaryQueryResult?.data
             ? subscriptionSummaryQueryResult.data.teamMaxMembers >

--- a/client/web/src/cody/management/CodyManagementPage.tsx
+++ b/client/web/src/cody/management/CodyManagementPage.tsx
@@ -88,6 +88,21 @@ export const CodyManagementPage: React.FunctionComponent<CodyManagementPageProps
         }
     }, [data, navigate])
 
+    const getTeamInviteButton = useCallback(() => {
+        const isSoloUser = subscriptionSummaryQueryResult?.data?.teamMaxMembers === 1
+        const hasFreeSeats = subscriptionSummaryQueryResult?.data ? subscriptionSummaryQueryResult.data.teamMaxMembers > subscriptionSummaryQueryResult.data.teamCurrentMembers : false
+        const targetUrl= hasFreeSeats ? '/cody/team/manage' : '/cody/manage/subscription/new?addSeats=1'
+        const label = (isSoloUser || hasFreeSeats) ? 'Invite co-workers' : 'Add seats'
+        return <Button
+            as={Link}
+            to={targetUrl}
+            variant="success"
+            className="text-nowrap"
+        >
+            <Icon aria-hidden={true} svgPath={mdiPlusThick} /> {label}
+        </Button>
+    }, [subscriptionSummaryQueryResult?.data])
+
     const onClickUpgradeToProCTA = useCallback(() => {
         telemetryRecorder.recordEvent('cody.management.upgradeToProCTA', 'click')
     }, [telemetryRecorder])
@@ -124,14 +139,7 @@ export const CodyManagementPage: React.FunctionComponent<CodyManagementPageProps
                     actions={
                         isAdmin && (
                             <div className="d-flex">
-                                <Button
-                                    as={Link}
-                                    to="/cody/manage/subscription/new?addSeats=1"
-                                    variant="success"
-                                    className="text-nowrap"
-                                >
-                                    <Icon aria-hidden={true} svgPath={mdiPlusThick} /> Invite co-workers
-                                </Button>
+                                {getTeamInviteButton()}
                             </div>
                         )
                     }

--- a/client/web/src/cody/management/subscription/new/NewCodyProSubscriptionPage.tsx
+++ b/client/web/src/cody/management/subscription/new/NewCodyProSubscriptionPage.tsx
@@ -48,8 +48,8 @@ const AuthenticatedNewCodyProSubscriptionPage: FunctionComponent<NewCodyProSubsc
     telemetryRecorder,
 }) => {
     const [urlSearchParams] = useSearchParams()
-    const isTeam = parseInt(urlSearchParams.get('seats') || '', 10) > 1
     const addSeats = !!urlSearchParams.get('addSeats')
+    const isTeam = addSeats || parseInt(urlSearchParams.get('seats') || '', 10) > 1
 
     const stripeElementsOptions = useBillingAddressStripeElementsOptions()
 


### PR DESCRIPTION
The "Invite co-workers" flow was not up to spec.

This PR fixes it to match this spec:

* If you are a team of size seats = 1, then "Invite coworkers" should take you to the add seats page because you won't be able to invite anyone until you add seats
* If you are a team of size seats = N, and have M invited/accepted users where M < N, then you should see [this](https://www.google.com/url?q=https://www.figma.com/design/FMSdn1oKccJRHQPgf7053o?node-id%3D4143-5059%23845917232&sa=D&source=docs&ust=1718872555659671&usg=AOvVaw3vf3t-_T4rB5sWM-_kWWzE)
* If you are a team of size seats = N and have N invited/accepted users, then you should see [this](https://www.google.com/url?q=https://www.figma.com/design/FMSdn1oKccJRHQPgf7053o?node-id%3D5573-15751%23845918007&sa=D&source=docs&ust=1718872555659752&usg=AOvVaw3OVrhof_2iwQVX5Ser7zz9)

## Test plan

Here is a [1-min Loom](https://www.loom.com/share/ba4c565677db4096bd87d5c238c48a0c) where I went through all cases.