### PR TITLE
chore(ci): build oci_push targets before invoking them

### DIFF
--- a/dev/ci/push_all.sh
+++ b/dev/ci/push_all.sh
@@ -167,6 +167,16 @@ honeyvent=$(bazel "${bazelrc[@]}" build //dev/tools:honeyvent 2>/dev/null && baz
 
 images=$(bazel "${bazelrc[@]}" query 'kind("oci_push rule", //...)')
 
+echo "--- :bazel::docker: Building oci_push targets"
+bazel \
+  "${bazelrc[@]}" \
+  build \
+  "${images[*]}" \
+  --stamp \
+  --workspace_status_command=./dev/bazel_stamp_vars.sh
+
+echo "--- :bash: Generating jobfile"
+
 job_file=$(mktemp)
 # shellcheck disable=SC2064
 trap "rm -rf $job_file" EXIT
@@ -184,6 +194,7 @@ for target in ${images[@]}; do
 done
 
 echo "--- :bash: Generated jobfile"
+
 cat "$job_file"
 
 echo "--- :bazel::docker: Pushing images..."


### PR DESCRIPTION
Today, we use gnu `parallel` to parallelize running `bazel run` on oci_push targets. Bazel cli holds an exclusive lock on the server while building, but releases the lock once it runs the excutable of a runnable target. By building the oci_push targets (and their closures) as part of `bazel build`, we can parallelize building instead of only one oci_push closure at a time, and then there should be minimal bazel server lock when we `bazel run` in parallel.

It's important we get the flags the same for `bazel build` _and_ `bazel run`, hence stamp in both cases

## Test plan

Awaiting a main dry-run


## Changelog

