### PR TITLE
chore: Add doc comment for DiffOptions.Paths

### DIFF
--- a/internal/gitserver/client.go
+++ b/internal/gitserver/client.go
@@ -318,6 +318,10 @@ type DiffOptions struct {
 	// For a nice visual explanation of ".." vs "...", see https://stackoverflow.com/a/46345364/2682729
 	RangeType string
 
+	// Paths specifies the paths to filter for during diffing.
+	//
+	// NOTE: Rename detection does not work if only the old path or the new path
+	// is specified in this slice.
 	Paths []string
 }
 


### PR DESCRIPTION
Was confused on reading some of our code, which is not
setting this value in the way that is expected when attempting
to handle range re-mapping for precise code nav.

## Test plan

Not sure if we need a test for this, I just tested with `git diff A..B -- <path>` locally.

## Changelog