### PR TITLE
feat(plg): require confirmation before removing user or revoking admin

### DIFF
--- a/client/web/src/cody/management/subscription/manage/SubscriptionDetails.module.scss
+++ b/client/web/src/cody/management/subscription/manage/SubscriptionDetails.module.scss
@@ -7,12 +7,3 @@
     font-size: 1rem;
     font-weight: 600;
 }
-
-.bold {
-    font-weight: 700;
-}
-
-.button-container {
-    justify-content: end;
-    gap: 0.5rem;
-}

--- a/client/web/src/cody/management/subscription/manage/SubscriptionDetails.tsx
+++ b/client/web/src/cody/management/subscription/manage/SubscriptionDetails.tsx
@@ -111,15 +111,14 @@ export const SubscriptionDetails: React.FC<SubscriptionDetailsProps> = props => 
                                         Canceling your subscription now means that you won't be able to use Cody with
                                         Pro features after {humanizeDate(props.subscription.currentPeriodEnd)}.
                                     </Text>
-                                    <Text className={classNames('mt-4 mb-0', styles.bold)}>
-                                        Do you want to proceed?
-                                    </Text>
+                                    <Text className="mt-4 mb-0 font-bold">Do you want to proceed?</Text>
                                 </div>
-                                <div className={classNames('d-flex mt-4', styles.buttonContainer)}>
+                                <div className="d-flex mt-4 justify-content-end">
                                     <Button
                                         variant="secondary"
                                         outline={true}
                                         onClick={() => setIsConfirmationModalVisible(false)}
+                                        className="mr-3"
                                     >
                                         No, I've changed my mind
                                     </Button>


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/63240

Adds a confirmation modal before revoking admin or removing user.

<!-- 💡 To write a useful PR description, make sure that your description covers:
- WHAT this PR is changing:
    - How was it PREVIOUSLY.
    - How it will be from NOW on.
- WHY this PR is needed.
- CONTEXT, i.e. to which initiative, project or RFC it belongs.

The structure of the description doesn't matter as much as covering these points, so use
your best judgement based on your context.
Learn how to write good pull request description: https://www.notion.so/sourcegraph/Write-a-good-pull-request-description-610a7fd3e613496eb76f450db5a49b6e?pvs=4 -->


## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles -->


## Changelog

<!--
1. Ensure your pull request title is formatted as: $type($domain): $what
2. Add bullet list items for each additional detail you want to cover (see example below)
3. You can edit this after the pull request was merged, as long as release shipping it hasn't been promoted to the public.
4. For more information, please see this how-to https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c?

Audience: TS/CSE > Customers > Teammates (in that order).

Cheat sheet: $type = chore|fix|feat $domain: source|search|ci|release|plg|cody|local|...
-->

<!--
Example:

Title: fix(search): parse quotes with the appropriate context
Changelog section:

## Changelog

- When a quote is used with regexp pattern type, then ...
- Refactored underlying code.
-->
