### PR TITLE
chore: Refactor and document GitTreeTranslator

### DIFF
--- a/internal/codeintel/codenav/gittree_translator.go
+++ b/internal/codeintel/codenav/gittree_translator.go
@@ -10,7 +10,6 @@ import (
 	"github.com/sourcegraph/go-diff/diff"
 
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/codenav/shared"
-	"github.com/sourcegraph/sourcegraph/internal/codeintel/core"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	sgtypes "github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
@@ -19,39 +18,41 @@ import (
 // GitTreeTranslator translates a position within a git tree at a source commit into the
 // equivalent position in a target commit. The git tree translator instance carries
 // along with it the source commit.
+//
+// NOTE(id: codenav-file-rename-detection) At the moment, this code cannot handle positions/ranges
+// going from one file to another (notice that the return values don't contain any updated
+// path), because there is no way in gitserver to get rename detection without requesting
+// a diff of the full repo (which may be quite large).
+//
+// Additionally, it's not clear if reusing the Document at path P1 in an older commit,
+// at a different path P2 in a newer commit is even reliably useful, since symbol names
+// may change based on the file name or directory name depending on the language.
 type GitTreeTranslator interface {
-	// GetTargetCommitPathFromSourcePath translates the given path from the source commit into the given target
-	// commit. If revese is true, then the source and target commits are swapped.
-	GetTargetCommitPathFromSourcePath(ctx context.Context, commit, path string, reverse bool) (string, bool, error)
-	// AdjustPath
-
 	// GetTargetCommitPositionFromSourcePosition translates the given position from the source commit into the given
 	// target commit. The target commit's path and position are returned, along with a boolean flag
-	// indicating that the translation was successful. If revese is true, then the source and
+	// indicating that the translation was successful. If reverse is true, then the source and
 	// target commits are swapped.
-	GetTargetCommitPositionFromSourcePosition(ctx context.Context, commit string, px shared.Position, reverse bool) (string, shared.Position, bool, error)
-	// AdjustPosition
+	GetTargetCommitPositionFromSourcePosition(ctx context.Context, commit string, path string, px shared.Position, reverse bool) (shared.Position, bool, error)
 
 	// GetTargetCommitRangeFromSourceRange translates the given range from the source commit into the given target
-	// commit. The target commit's path and range are returned, along with a boolean flag indicating
-	// that the translation was successful. If revese is true, then the source and target commits
+	// commit. The target commit's range is returned, along with a boolean flag indicating
+	// that the translation was successful. If reverse is true, then the source and target commits
 	// are swapped.
-	GetTargetCommitRangeFromSourceRange(ctx context.Context, commit, path string, rx shared.Range, reverse bool) (string, shared.Range, bool, error)
+	GetTargetCommitRangeFromSourceRange(ctx context.Context, commit string, path string, rx shared.Range, reverse bool) (shared.Range, bool, error)
 }
 
 type gitTreeTranslator struct {
-	client           gitserver.Client
-	localRequestArgs *requestArgs
-	hunkCache        HunkCache
+	client    gitserver.Client
+	base      *translationBase
+	hunkCache HunkCache
 }
 
-type requestArgs struct {
+type translationBase struct {
 	repo   *sgtypes.Repo
 	commit string
-	path   core.RepoRelPath
 }
 
-func (r *requestArgs) GetRepoID() int {
+func (r *translationBase) GetRepoID() int {
 	return int(r.repo.ID)
 }
 
@@ -76,47 +77,40 @@ func NewHunkCache(size int) (HunkCache, error) {
 }
 
 // NewGitTreeTranslator creates a new GitTreeTranslator with the given repository and source commit.
-func NewGitTreeTranslator(client gitserver.Client, args *requestArgs, hunkCache HunkCache) GitTreeTranslator {
+func NewGitTreeTranslator(client gitserver.Client, args *translationBase, hunkCache HunkCache) GitTreeTranslator {
 	return &gitTreeTranslator{
-		client:           client,
-		hunkCache:        hunkCache,
-		localRequestArgs: args,
+		client:    client,
+		hunkCache: hunkCache,
+		base:      args,
 	}
-}
-
-// GetTargetCommitPathFromSourcePath translates the given path from the source commit into the given target
-// commit. If revese is true, then the source and target commits are swapped.
-func (g *gitTreeTranslator) GetTargetCommitPathFromSourcePath(ctx context.Context, commit, path string, reverse bool) (string, bool, error) {
-	return path, true, nil
 }
 
 // GetTargetCommitPositionFromSourcePosition translates the given position from the source commit into the given
-// target commit. The target commit path and position are returned, along with a boolean flag
-// indicating that the translation was successful. If revese is true, then the source and
+// target commit. The target commit position is returned, along with a boolean flag
+// indicating that the translation was successful. If reverse is true, then the source and
 // target commits are swapped.
-// TODO: No todo just letting me know that I updated path just on this one. Need to do it like that.
-func (g *gitTreeTranslator) GetTargetCommitPositionFromSourcePosition(ctx context.Context, commit string, px shared.Position, reverse bool) (string, shared.Position, bool, error) {
-	hunks, err := g.readCachedHunks(ctx, g.localRequestArgs.repo, g.localRequestArgs.commit, commit, g.localRequestArgs.path.RawValue(), reverse)
+func (g *gitTreeTranslator) GetTargetCommitPositionFromSourcePosition(ctx context.Context, commit string, path string, px shared.Position, reverse bool) (shared.Position, bool, error) {
+	hunks, err := g.readCachedHunks(ctx, g.base.repo, g.base.commit, commit, path, reverse)
 	if err != nil {
-		return "", shared.Position{}, false, err
+		return shared.Position{}, false, err
 	}
 
 	commitPosition, ok := translatePosition(hunks, px)
-	return g.localRequestArgs.path.RawValue(), commitPosition, ok, nil
+	return commitPosition, ok, nil
 }
 
 // GetTargetCommitRangeFromSourceRange translates the given range from the source commit into the given target
-// commit. The target commit path and range are returned, along with a boolean flag indicating
-// that the translation was successful. If revese is true, then the source and target commits
+// commit. The target commit range is returned, along with a boolean flag indicating
+// that the translation was successful. If reverse is true, then the source and target commits
 // are swapped.
-func (g *gitTreeTranslator) GetTargetCommitRangeFromSourceRange(ctx context.Context, commit, path string, rx shared.Range, reverse bool) (string, shared.Range, bool, error) {
-	hunks, err := g.readCachedHunks(ctx, g.localRequestArgs.repo, g.localRequestArgs.commit, commit, path, reverse)
+func (g *gitTreeTranslator) GetTargetCommitRangeFromSourceRange(ctx context.Context, commit string, path string, rx shared.Range, reverse bool) (shared.Range, bool, error) {
+	hunks, err := g.readCachedHunks(ctx, g.base.repo, g.base.commit, commit, path, reverse)
 	if err != nil {
-		return "", shared.Range{}, false, err
+		return shared.Range{}, false, err
 	}
 
 	commitRange, ok := translateRange(hunks, rx)
-	return path, commitRange, ok, nil
+	return commitRange, ok, nil
 }
 
 // readCachedHunks returns a position-ordered slice of changes (additions or deletions) of

--- a/internal/codeintel/codenav/gittree_translator.go
+++ b/internal/codeintel/codenav/gittree_translator.go
@@ -94,11 +94,11 @@ func NewHunkCache(size int) (HunkCache, error) {
 }
 
 // NewGitTreeTranslator creates a new GitTreeTranslator with the given repository and source commit.
-func NewGitTreeTranslator(client gitserver.Client, args *translationBase, hunkCache HunkCache) GitTreeTranslator {
+func NewGitTreeTranslator(client gitserver.Client, base *translationBase, hunkCache HunkCache) GitTreeTranslator {
 	return &gitTreeTranslator{
 		client:    client,
 		hunkCache: hunkCache,
-		base:      args,
+		base:      base,
 	}
 }
 

--- a/internal/codeintel/codenav/gittree_translator_test.go
+++ b/internal/codeintel/codenav/gittree_translator_test.go
@@ -12,38 +12,18 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/codenav/shared"
-	"github.com/sourcegraph/sourcegraph/internal/codeintel/core"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	sgtypes "github.com/sourcegraph/sourcegraph/internal/types"
 )
 
-var mockRequestArgs = requestArgs{
+var mockTranslationBase = translationBase{
 	repo:   &sgtypes.Repo{ID: 50},
 	commit: "deadbeef1",
-	path:   core.NewRepoRelPathUnchecked("foo/bar.go"),
-}
-
-func TestGetTargetCommitPathFromSourcePath(t *testing.T) {
-	client := gitserver.NewMockClient()
-
-	args := &mockRequestArgs
-	adjuster := NewGitTreeTranslator(client, args, nil)
-	path, ok, err := adjuster.GetTargetCommitPathFromSourcePath(context.Background(), "deadbeef2", args.path.RawValue(), false)
-	if err != nil {
-		t.Fatalf("unexpected error: %s", err)
-	}
-
-	if !ok {
-		t.Errorf("expected translation to succeed")
-	}
-	if path != "foo/bar.go" {
-		t.Errorf("unexpected path. want=%s have=%s", "foo/bar.go", path)
-	}
 }
 
 func TestGetTargetCommitPositionFromSourcePosition(t *testing.T) {
 	client := gitserver.NewMockClientWithExecReader(nil, func(_ context.Context, _ api.RepoName, args []string) (reader io.ReadCloser, err error) {
-		expectedArgs := []string{"diff", "--find-renames", "--full-index", "--inter-hunk-context=3", "--no-prefix", "deadbeef1..deadbeef2", "--", mockRequestArgs.path.RawValue()}
+		expectedArgs := []string{"diff", "--find-renames", "--full-index", "--inter-hunk-context=3", "--no-prefix", "deadbeef1..deadbeef2", "--", "foo/bar.go"}
 		if diff := cmp.Diff(expectedArgs, args); diff != "" {
 			t.Errorf("unexpected exec reader args (-want +got):\n%s", diff)
 		}
@@ -53,18 +33,15 @@ func TestGetTargetCommitPositionFromSourcePosition(t *testing.T) {
 
 	posIn := shared.Position{Line: 302, Character: 15}
 
-	args := &mockRequestArgs
+	args := &mockTranslationBase
 	adjuster := NewGitTreeTranslator(client, args, nil)
-	path, posOut, ok, err := adjuster.GetTargetCommitPositionFromSourcePosition(context.Background(), "deadbeef2", posIn, false)
+	posOut, ok, err := adjuster.GetTargetCommitPositionFromSourcePosition(context.Background(), "deadbeef2", "foo/bar.go", posIn, false)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
 
 	if !ok {
 		t.Errorf("expected translation to succeed")
-	}
-	if path != "foo/bar.go" {
-		t.Errorf("unexpected path. want=%s have=%s", "foo/bar.go", path)
 	}
 
 	expectedPos := shared.Position{Line: 294, Character: 15}
@@ -80,18 +57,15 @@ func TestGetTargetCommitPositionFromSourcePositionEmptyDiff(t *testing.T) {
 
 	posIn := shared.Position{Line: 10, Character: 15}
 
-	args := &mockRequestArgs
+	args := &mockTranslationBase
 	adjuster := NewGitTreeTranslator(client, args, nil)
-	path, posOut, ok, err := adjuster.GetTargetCommitPositionFromSourcePosition(context.Background(), "deadbeef2", posIn, false)
+	posOut, ok, err := adjuster.GetTargetCommitPositionFromSourcePosition(context.Background(), "deadbeef2", "foo/bar.go", posIn, false)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
 
 	if !ok {
 		t.Errorf("expected translation to succeed")
-	}
-	if path != "foo/bar.go" {
-		t.Errorf("unexpected path. want=%s have=%s", "foo/bar.go", path)
 	}
 	if diff := cmp.Diff(posOut, posIn); diff != "" {
 		t.Errorf("unexpected position (-want +got):\n%s", diff)
@@ -100,7 +74,7 @@ func TestGetTargetCommitPositionFromSourcePositionEmptyDiff(t *testing.T) {
 
 func TestGetTargetCommitPositionFromSourcePositionReverse(t *testing.T) {
 	client := gitserver.NewMockClientWithExecReader(nil, func(_ context.Context, _ api.RepoName, args []string) (reader io.ReadCloser, err error) {
-		expectedArgs := []string{"diff", "--find-renames", "--full-index", "--inter-hunk-context=3", "--no-prefix", "deadbeef2..deadbeef1", "--", mockRequestArgs.path.RawValue()}
+		expectedArgs := []string{"diff", "--find-renames", "--full-index", "--inter-hunk-context=3", "--no-prefix", "deadbeef2..deadbeef1", "--", "foo/bar.go"}
 		if diff := cmp.Diff(expectedArgs, args); diff != "" {
 			t.Errorf("unexpected exec reader args (-want +got):\n%s", diff)
 		}
@@ -110,18 +84,15 @@ func TestGetTargetCommitPositionFromSourcePositionReverse(t *testing.T) {
 
 	posIn := shared.Position{Line: 302, Character: 15}
 
-	args := &mockRequestArgs
+	args := &mockTranslationBase
 	adjuster := NewGitTreeTranslator(client, args, nil)
-	path, posOut, ok, err := adjuster.GetTargetCommitPositionFromSourcePosition(context.Background(), "deadbeef2", posIn, true)
+	posOut, ok, err := adjuster.GetTargetCommitPositionFromSourcePosition(context.Background(), "deadbeef2", "foo/bar.go", posIn, true)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
 
 	if !ok {
 		t.Errorf("expected translation to succeed")
-	}
-	if path != "foo/bar.go" {
-		t.Errorf("unexpected path. want=%s have=%s", "foo/bar.go", path)
 	}
 
 	expectedPos := shared.Position{Line: 294, Character: 15}
@@ -132,7 +103,7 @@ func TestGetTargetCommitPositionFromSourcePositionReverse(t *testing.T) {
 
 func TestGetTargetCommitRangeFromSourceRange(t *testing.T) {
 	client := gitserver.NewMockClientWithExecReader(nil, func(_ context.Context, _ api.RepoName, args []string) (reader io.ReadCloser, err error) {
-		expectedArgs := []string{"diff", "--find-renames", "--full-index", "--inter-hunk-context=3", "--no-prefix", "deadbeef1..deadbeef2", "--", mockRequestArgs.path.RawValue()}
+		expectedArgs := []string{"diff", "--find-renames", "--full-index", "--inter-hunk-context=3", "--no-prefix", "deadbeef1..deadbeef2", "--", "foo/bar.go"}
 		if diff := cmp.Diff(expectedArgs, args); diff != "" {
 			t.Errorf("unexpected exec reader args (-want +got):\n%s", diff)
 		}
@@ -145,18 +116,15 @@ func TestGetTargetCommitRangeFromSourceRange(t *testing.T) {
 		End:   shared.Position{Line: 305, Character: 20},
 	}
 
-	args := &mockRequestArgs
+	args := &mockTranslationBase
 	adjuster := NewGitTreeTranslator(client, args, nil)
-	path, rOut, ok, err := adjuster.GetTargetCommitRangeFromSourceRange(context.Background(), "deadbeef2", mockRequestArgs.path.RawValue(), rIn, false)
+	rOut, ok, err := adjuster.GetTargetCommitRangeFromSourceRange(context.Background(), "deadbeef2", "foo/bar.go", rIn, false)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
 
 	if !ok {
 		t.Errorf("expected translation to succeed")
-	}
-	if path != "foo/bar.go" {
-		t.Errorf("unexpected path. want=%s have=%s", "foo/bar.go", path)
 	}
 
 	expectedRange := shared.Range{
@@ -178,18 +146,15 @@ func TestGetTargetCommitRangeFromSourceRangeEmptyDiff(t *testing.T) {
 		End:   shared.Position{Line: 305, Character: 20},
 	}
 
-	args := &mockRequestArgs
+	args := &mockTranslationBase
 	adjuster := NewGitTreeTranslator(client, args, nil)
-	path, rOut, ok, err := adjuster.GetTargetCommitRangeFromSourceRange(context.Background(), "deadbeef2", mockRequestArgs.path.RawValue(), rIn, false)
+	rOut, ok, err := adjuster.GetTargetCommitRangeFromSourceRange(context.Background(), "deadbeef2", "foo/bar.go", rIn, false)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
 
 	if !ok {
 		t.Errorf("expected translation to succeed")
-	}
-	if path != "foo/bar.go" {
-		t.Errorf("unexpected path. want=%s have=%s", "foo/bar.go", path)
 	}
 	if diff := cmp.Diff(rOut, rIn); diff != "" {
 		t.Errorf("unexpected position (-want +got):\n%s", diff)
@@ -198,7 +163,7 @@ func TestGetTargetCommitRangeFromSourceRangeEmptyDiff(t *testing.T) {
 
 func TestGetTargetCommitRangeFromSourceRangeReverse(t *testing.T) {
 	client := gitserver.NewMockClientWithExecReader(nil, func(_ context.Context, _ api.RepoName, args []string) (reader io.ReadCloser, err error) {
-		expectedArgs := []string{"diff", "--find-renames", "--full-index", "--inter-hunk-context=3", "--no-prefix", "deadbeef2..deadbeef1", "--", mockRequestArgs.path.RawValue()}
+		expectedArgs := []string{"diff", "--find-renames", "--full-index", "--inter-hunk-context=3", "--no-prefix", "deadbeef2..deadbeef1", "--", "foo/bar.go"}
 		if diff := cmp.Diff(expectedArgs, args); diff != "" {
 			t.Errorf("unexpected exec reader args (-want +got):\n%s", diff)
 		}
@@ -211,18 +176,14 @@ func TestGetTargetCommitRangeFromSourceRangeReverse(t *testing.T) {
 		End:   shared.Position{Line: 305, Character: 20},
 	}
 
-	args := &mockRequestArgs
+	args := &mockTranslationBase
 	adjuster := NewGitTreeTranslator(client, args, nil)
-	path, rOut, ok, err := adjuster.GetTargetCommitRangeFromSourceRange(context.Background(), "deadbeef2", args.path.RawValue(), rIn, true)
+	rOut, ok, err := adjuster.GetTargetCommitRangeFromSourceRange(context.Background(), "deadbeef2", "foo/bar.go", rIn, true)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
-
 	if !ok {
 		t.Errorf("expected translation to succeed")
-	}
-	if path != "foo/bar.go" {
-		t.Errorf("unexpected path. want=%s have=%s", "foo/bar.go", path)
 	}
 
 	expectedRange := shared.Range{

--- a/internal/codeintel/codenav/mocks_test.go
+++ b/internal/codeintel/codenav/mocks_test.go
@@ -1926,10 +1926,6 @@ func (c LsifStoreSCIPDocumentFuncCall) Results() []interface{} {
 // github.com/sourcegraph/sourcegraph/internal/codeintel/codenav) used for
 // unit testing.
 type MockGitTreeTranslator struct {
-	// GetTargetCommitPathFromSourcePathFunc is an instance of a mock
-	// function object controlling the behavior of the method
-	// GetTargetCommitPathFromSourcePath.
-	GetTargetCommitPathFromSourcePathFunc *GitTreeTranslatorGetTargetCommitPathFromSourcePathFunc
 	// GetTargetCommitPositionFromSourcePositionFunc is an instance of a
 	// mock function object controlling the behavior of the method
 	// GetTargetCommitPositionFromSourcePosition.
@@ -1945,18 +1941,13 @@ type MockGitTreeTranslator struct {
 // overwritten.
 func NewMockGitTreeTranslator() *MockGitTreeTranslator {
 	return &MockGitTreeTranslator{
-		GetTargetCommitPathFromSourcePathFunc: &GitTreeTranslatorGetTargetCommitPathFromSourcePathFunc{
-			defaultHook: func(context.Context, string, string, bool) (r0 string, r1 bool, r2 error) {
-				return
-			},
-		},
 		GetTargetCommitPositionFromSourcePositionFunc: &GitTreeTranslatorGetTargetCommitPositionFromSourcePositionFunc{
-			defaultHook: func(context.Context, string, shared.Position, bool) (r0 string, r1 shared.Position, r2 bool, r3 error) {
+			defaultHook: func(context.Context, string, string, shared.Position, bool) (r0 shared.Position, r1 bool, r2 error) {
 				return
 			},
 		},
 		GetTargetCommitRangeFromSourceRangeFunc: &GitTreeTranslatorGetTargetCommitRangeFromSourceRangeFunc{
-			defaultHook: func(context.Context, string, string, shared.Range, bool) (r0 string, r1 shared.Range, r2 bool, r3 error) {
+			defaultHook: func(context.Context, string, string, shared.Range, bool) (r0 shared.Range, r1 bool, r2 error) {
 				return
 			},
 		},
@@ -1968,18 +1959,13 @@ func NewMockGitTreeTranslator() *MockGitTreeTranslator {
 // overwritten.
 func NewStrictMockGitTreeTranslator() *MockGitTreeTranslator {
 	return &MockGitTreeTranslator{
-		GetTargetCommitPathFromSourcePathFunc: &GitTreeTranslatorGetTargetCommitPathFromSourcePathFunc{
-			defaultHook: func(context.Context, string, string, bool) (string, bool, error) {
-				panic("unexpected invocation of MockGitTreeTranslator.GetTargetCommitPathFromSourcePath")
-			},
-		},
 		GetTargetCommitPositionFromSourcePositionFunc: &GitTreeTranslatorGetTargetCommitPositionFromSourcePositionFunc{
-			defaultHook: func(context.Context, string, shared.Position, bool) (string, shared.Position, bool, error) {
+			defaultHook: func(context.Context, string, string, shared.Position, bool) (shared.Position, bool, error) {
 				panic("unexpected invocation of MockGitTreeTranslator.GetTargetCommitPositionFromSourcePosition")
 			},
 		},
 		GetTargetCommitRangeFromSourceRangeFunc: &GitTreeTranslatorGetTargetCommitRangeFromSourceRangeFunc{
-			defaultHook: func(context.Context, string, string, shared.Range, bool) (string, shared.Range, bool, error) {
+			defaultHook: func(context.Context, string, string, shared.Range, bool) (shared.Range, bool, error) {
 				panic("unexpected invocation of MockGitTreeTranslator.GetTargetCommitRangeFromSourceRange")
 			},
 		},
@@ -1991,9 +1977,6 @@ func NewStrictMockGitTreeTranslator() *MockGitTreeTranslator {
 // implementation, unless overwritten.
 func NewMockGitTreeTranslatorFrom(i GitTreeTranslator) *MockGitTreeTranslator {
 	return &MockGitTreeTranslator{
-		GetTargetCommitPathFromSourcePathFunc: &GitTreeTranslatorGetTargetCommitPathFromSourcePathFunc{
-			defaultHook: i.GetTargetCommitPathFromSourcePath,
-		},
 		GetTargetCommitPositionFromSourcePositionFunc: &GitTreeTranslatorGetTargetCommitPositionFromSourcePositionFunc{
 			defaultHook: i.GetTargetCommitPositionFromSourcePosition,
 		},
@@ -2003,133 +1986,12 @@ func NewMockGitTreeTranslatorFrom(i GitTreeTranslator) *MockGitTreeTranslator {
 	}
 }
 
-// GitTreeTranslatorGetTargetCommitPathFromSourcePathFunc describes the
-// behavior when the GetTargetCommitPathFromSourcePath method of the parent
-// MockGitTreeTranslator instance is invoked.
-type GitTreeTranslatorGetTargetCommitPathFromSourcePathFunc struct {
-	defaultHook func(context.Context, string, string, bool) (string, bool, error)
-	hooks       []func(context.Context, string, string, bool) (string, bool, error)
-	history     []GitTreeTranslatorGetTargetCommitPathFromSourcePathFuncCall
-	mutex       sync.Mutex
-}
-
-// GetTargetCommitPathFromSourcePath delegates to the next hook function in
-// the queue and stores the parameter and result values of this invocation.
-func (m *MockGitTreeTranslator) GetTargetCommitPathFromSourcePath(v0 context.Context, v1 string, v2 string, v3 bool) (string, bool, error) {
-	r0, r1, r2 := m.GetTargetCommitPathFromSourcePathFunc.nextHook()(v0, v1, v2, v3)
-	m.GetTargetCommitPathFromSourcePathFunc.appendCall(GitTreeTranslatorGetTargetCommitPathFromSourcePathFuncCall{v0, v1, v2, v3, r0, r1, r2})
-	return r0, r1, r2
-}
-
-// SetDefaultHook sets function that is called when the
-// GetTargetCommitPathFromSourcePath method of the parent
-// MockGitTreeTranslator instance is invoked and the hook queue is empty.
-func (f *GitTreeTranslatorGetTargetCommitPathFromSourcePathFunc) SetDefaultHook(hook func(context.Context, string, string, bool) (string, bool, error)) {
-	f.defaultHook = hook
-}
-
-// PushHook adds a function to the end of hook queue. Each invocation of the
-// GetTargetCommitPathFromSourcePath method of the parent
-// MockGitTreeTranslator instance invokes the hook at the front of the queue
-// and discards it. After the queue is empty, the default hook function is
-// invoked for any future action.
-func (f *GitTreeTranslatorGetTargetCommitPathFromSourcePathFunc) PushHook(hook func(context.Context, string, string, bool) (string, bool, error)) {
-	f.mutex.Lock()
-	f.hooks = append(f.hooks, hook)
-	f.mutex.Unlock()
-}
-
-// SetDefaultReturn calls SetDefaultHook with a function that returns the
-// given values.
-func (f *GitTreeTranslatorGetTargetCommitPathFromSourcePathFunc) SetDefaultReturn(r0 string, r1 bool, r2 error) {
-	f.SetDefaultHook(func(context.Context, string, string, bool) (string, bool, error) {
-		return r0, r1, r2
-	})
-}
-
-// PushReturn calls PushHook with a function that returns the given values.
-func (f *GitTreeTranslatorGetTargetCommitPathFromSourcePathFunc) PushReturn(r0 string, r1 bool, r2 error) {
-	f.PushHook(func(context.Context, string, string, bool) (string, bool, error) {
-		return r0, r1, r2
-	})
-}
-
-func (f *GitTreeTranslatorGetTargetCommitPathFromSourcePathFunc) nextHook() func(context.Context, string, string, bool) (string, bool, error) {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-
-	if len(f.hooks) == 0 {
-		return f.defaultHook
-	}
-
-	hook := f.hooks[0]
-	f.hooks = f.hooks[1:]
-	return hook
-}
-
-func (f *GitTreeTranslatorGetTargetCommitPathFromSourcePathFunc) appendCall(r0 GitTreeTranslatorGetTargetCommitPathFromSourcePathFuncCall) {
-	f.mutex.Lock()
-	f.history = append(f.history, r0)
-	f.mutex.Unlock()
-}
-
-// History returns a sequence of
-// GitTreeTranslatorGetTargetCommitPathFromSourcePathFuncCall objects
-// describing the invocations of this function.
-func (f *GitTreeTranslatorGetTargetCommitPathFromSourcePathFunc) History() []GitTreeTranslatorGetTargetCommitPathFromSourcePathFuncCall {
-	f.mutex.Lock()
-	history := make([]GitTreeTranslatorGetTargetCommitPathFromSourcePathFuncCall, len(f.history))
-	copy(history, f.history)
-	f.mutex.Unlock()
-
-	return history
-}
-
-// GitTreeTranslatorGetTargetCommitPathFromSourcePathFuncCall is an object
-// that describes an invocation of method GetTargetCommitPathFromSourcePath
-// on an instance of MockGitTreeTranslator.
-type GitTreeTranslatorGetTargetCommitPathFromSourcePathFuncCall struct {
-	// Arg0 is the value of the 1st argument passed to this method
-	// invocation.
-	Arg0 context.Context
-	// Arg1 is the value of the 2nd argument passed to this method
-	// invocation.
-	Arg1 string
-	// Arg2 is the value of the 3rd argument passed to this method
-	// invocation.
-	Arg2 string
-	// Arg3 is the value of the 4th argument passed to this method
-	// invocation.
-	Arg3 bool
-	// Result0 is the value of the 1st result returned from this method
-	// invocation.
-	Result0 string
-	// Result1 is the value of the 2nd result returned from this method
-	// invocation.
-	Result1 bool
-	// Result2 is the value of the 3rd result returned from this method
-	// invocation.
-	Result2 error
-}
-
-// Args returns an interface slice containing the arguments of this
-// invocation.
-func (c GitTreeTranslatorGetTargetCommitPathFromSourcePathFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3}
-}
-
-// Results returns an interface slice containing the results of this
-// invocation.
-func (c GitTreeTranslatorGetTargetCommitPathFromSourcePathFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1, c.Result2}
-}
-
 // GitTreeTranslatorGetTargetCommitPositionFromSourcePositionFunc describes
 // the behavior when the GetTargetCommitPositionFromSourcePosition method of
 // the parent MockGitTreeTranslator instance is invoked.
 type GitTreeTranslatorGetTargetCommitPositionFromSourcePositionFunc struct {
-	defaultHook func(context.Context, string, shared.Position, bool) (string, shared.Position, bool, error)
-	hooks       []func(context.Context, string, shared.Position, bool) (string, shared.Position, bool, error)
+	defaultHook func(context.Context, string, string, shared.Position, bool) (shared.Position, bool, error)
+	hooks       []func(context.Context, string, string, shared.Position, bool) (shared.Position, bool, error)
 	history     []GitTreeTranslatorGetTargetCommitPositionFromSourcePositionFuncCall
 	mutex       sync.Mutex
 }
@@ -2137,16 +1999,16 @@ type GitTreeTranslatorGetTargetCommitPositionFromSourcePositionFunc struct {
 // GetTargetCommitPositionFromSourcePosition delegates to the next hook
 // function in the queue and stores the parameter and result values of this
 // invocation.
-func (m *MockGitTreeTranslator) GetTargetCommitPositionFromSourcePosition(v0 context.Context, v1 string, v2 shared.Position, v3 bool) (string, shared.Position, bool, error) {
-	r0, r1, r2, r3 := m.GetTargetCommitPositionFromSourcePositionFunc.nextHook()(v0, v1, v2, v3)
-	m.GetTargetCommitPositionFromSourcePositionFunc.appendCall(GitTreeTranslatorGetTargetCommitPositionFromSourcePositionFuncCall{v0, v1, v2, v3, r0, r1, r2, r3})
-	return r0, r1, r2, r3
+func (m *MockGitTreeTranslator) GetTargetCommitPositionFromSourcePosition(v0 context.Context, v1 string, v2 string, v3 shared.Position, v4 bool) (shared.Position, bool, error) {
+	r0, r1, r2 := m.GetTargetCommitPositionFromSourcePositionFunc.nextHook()(v0, v1, v2, v3, v4)
+	m.GetTargetCommitPositionFromSourcePositionFunc.appendCall(GitTreeTranslatorGetTargetCommitPositionFromSourcePositionFuncCall{v0, v1, v2, v3, v4, r0, r1, r2})
+	return r0, r1, r2
 }
 
 // SetDefaultHook sets function that is called when the
 // GetTargetCommitPositionFromSourcePosition method of the parent
 // MockGitTreeTranslator instance is invoked and the hook queue is empty.
-func (f *GitTreeTranslatorGetTargetCommitPositionFromSourcePositionFunc) SetDefaultHook(hook func(context.Context, string, shared.Position, bool) (string, shared.Position, bool, error)) {
+func (f *GitTreeTranslatorGetTargetCommitPositionFromSourcePositionFunc) SetDefaultHook(hook func(context.Context, string, string, shared.Position, bool) (shared.Position, bool, error)) {
 	f.defaultHook = hook
 }
 
@@ -2155,7 +2017,7 @@ func (f *GitTreeTranslatorGetTargetCommitPositionFromSourcePositionFunc) SetDefa
 // MockGitTreeTranslator instance invokes the hook at the front of the queue
 // and discards it. After the queue is empty, the default hook function is
 // invoked for any future action.
-func (f *GitTreeTranslatorGetTargetCommitPositionFromSourcePositionFunc) PushHook(hook func(context.Context, string, shared.Position, bool) (string, shared.Position, bool, error)) {
+func (f *GitTreeTranslatorGetTargetCommitPositionFromSourcePositionFunc) PushHook(hook func(context.Context, string, string, shared.Position, bool) (shared.Position, bool, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -2163,20 +2025,20 @@ func (f *GitTreeTranslatorGetTargetCommitPositionFromSourcePositionFunc) PushHoo
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *GitTreeTranslatorGetTargetCommitPositionFromSourcePositionFunc) SetDefaultReturn(r0 string, r1 shared.Position, r2 bool, r3 error) {
-	f.SetDefaultHook(func(context.Context, string, shared.Position, bool) (string, shared.Position, bool, error) {
-		return r0, r1, r2, r3
+func (f *GitTreeTranslatorGetTargetCommitPositionFromSourcePositionFunc) SetDefaultReturn(r0 shared.Position, r1 bool, r2 error) {
+	f.SetDefaultHook(func(context.Context, string, string, shared.Position, bool) (shared.Position, bool, error) {
+		return r0, r1, r2
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *GitTreeTranslatorGetTargetCommitPositionFromSourcePositionFunc) PushReturn(r0 string, r1 shared.Position, r2 bool, r3 error) {
-	f.PushHook(func(context.Context, string, shared.Position, bool) (string, shared.Position, bool, error) {
-		return r0, r1, r2, r3
+func (f *GitTreeTranslatorGetTargetCommitPositionFromSourcePositionFunc) PushReturn(r0 shared.Position, r1 bool, r2 error) {
+	f.PushHook(func(context.Context, string, string, shared.Position, bool) (shared.Position, bool, error) {
+		return r0, r1, r2
 	})
 }
 
-func (f *GitTreeTranslatorGetTargetCommitPositionFromSourcePositionFunc) nextHook() func(context.Context, string, shared.Position, bool) (string, shared.Position, bool, error) {
+func (f *GitTreeTranslatorGetTargetCommitPositionFromSourcePositionFunc) nextHook() func(context.Context, string, string, shared.Position, bool) (shared.Position, bool, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -2220,42 +2082,42 @@ type GitTreeTranslatorGetTargetCommitPositionFromSourcePositionFuncCall struct {
 	Arg1 string
 	// Arg2 is the value of the 3rd argument passed to this method
 	// invocation.
-	Arg2 shared.Position
+	Arg2 string
 	// Arg3 is the value of the 4th argument passed to this method
 	// invocation.
-	Arg3 bool
+	Arg3 shared.Position
+	// Arg4 is the value of the 5th argument passed to this method
+	// invocation.
+	Arg4 bool
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 string
+	Result0 shared.Position
 	// Result1 is the value of the 2nd result returned from this method
 	// invocation.
-	Result1 shared.Position
+	Result1 bool
 	// Result2 is the value of the 3rd result returned from this method
 	// invocation.
-	Result2 bool
-	// Result3 is the value of the 4th result returned from this method
-	// invocation.
-	Result3 error
+	Result2 error
 }
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
 func (c GitTreeTranslatorGetTargetCommitPositionFromSourcePositionFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3}
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c GitTreeTranslatorGetTargetCommitPositionFromSourcePositionFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1, c.Result2, c.Result3}
+	return []interface{}{c.Result0, c.Result1, c.Result2}
 }
 
 // GitTreeTranslatorGetTargetCommitRangeFromSourceRangeFunc describes the
 // behavior when the GetTargetCommitRangeFromSourceRange method of the
 // parent MockGitTreeTranslator instance is invoked.
 type GitTreeTranslatorGetTargetCommitRangeFromSourceRangeFunc struct {
-	defaultHook func(context.Context, string, string, shared.Range, bool) (string, shared.Range, bool, error)
-	hooks       []func(context.Context, string, string, shared.Range, bool) (string, shared.Range, bool, error)
+	defaultHook func(context.Context, string, string, shared.Range, bool) (shared.Range, bool, error)
+	hooks       []func(context.Context, string, string, shared.Range, bool) (shared.Range, bool, error)
 	history     []GitTreeTranslatorGetTargetCommitRangeFromSourceRangeFuncCall
 	mutex       sync.Mutex
 }
@@ -2263,16 +2125,16 @@ type GitTreeTranslatorGetTargetCommitRangeFromSourceRangeFunc struct {
 // GetTargetCommitRangeFromSourceRange delegates to the next hook function
 // in the queue and stores the parameter and result values of this
 // invocation.
-func (m *MockGitTreeTranslator) GetTargetCommitRangeFromSourceRange(v0 context.Context, v1 string, v2 string, v3 shared.Range, v4 bool) (string, shared.Range, bool, error) {
-	r0, r1, r2, r3 := m.GetTargetCommitRangeFromSourceRangeFunc.nextHook()(v0, v1, v2, v3, v4)
-	m.GetTargetCommitRangeFromSourceRangeFunc.appendCall(GitTreeTranslatorGetTargetCommitRangeFromSourceRangeFuncCall{v0, v1, v2, v3, v4, r0, r1, r2, r3})
-	return r0, r1, r2, r3
+func (m *MockGitTreeTranslator) GetTargetCommitRangeFromSourceRange(v0 context.Context, v1 string, v2 string, v3 shared.Range, v4 bool) (shared.Range, bool, error) {
+	r0, r1, r2 := m.GetTargetCommitRangeFromSourceRangeFunc.nextHook()(v0, v1, v2, v3, v4)
+	m.GetTargetCommitRangeFromSourceRangeFunc.appendCall(GitTreeTranslatorGetTargetCommitRangeFromSourceRangeFuncCall{v0, v1, v2, v3, v4, r0, r1, r2})
+	return r0, r1, r2
 }
 
 // SetDefaultHook sets function that is called when the
 // GetTargetCommitRangeFromSourceRange method of the parent
 // MockGitTreeTranslator instance is invoked and the hook queue is empty.
-func (f *GitTreeTranslatorGetTargetCommitRangeFromSourceRangeFunc) SetDefaultHook(hook func(context.Context, string, string, shared.Range, bool) (string, shared.Range, bool, error)) {
+func (f *GitTreeTranslatorGetTargetCommitRangeFromSourceRangeFunc) SetDefaultHook(hook func(context.Context, string, string, shared.Range, bool) (shared.Range, bool, error)) {
 	f.defaultHook = hook
 }
 
@@ -2281,7 +2143,7 @@ func (f *GitTreeTranslatorGetTargetCommitRangeFromSourceRangeFunc) SetDefaultHoo
 // MockGitTreeTranslator instance invokes the hook at the front of the queue
 // and discards it. After the queue is empty, the default hook function is
 // invoked for any future action.
-func (f *GitTreeTranslatorGetTargetCommitRangeFromSourceRangeFunc) PushHook(hook func(context.Context, string, string, shared.Range, bool) (string, shared.Range, bool, error)) {
+func (f *GitTreeTranslatorGetTargetCommitRangeFromSourceRangeFunc) PushHook(hook func(context.Context, string, string, shared.Range, bool) (shared.Range, bool, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -2289,20 +2151,20 @@ func (f *GitTreeTranslatorGetTargetCommitRangeFromSourceRangeFunc) PushHook(hook
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *GitTreeTranslatorGetTargetCommitRangeFromSourceRangeFunc) SetDefaultReturn(r0 string, r1 shared.Range, r2 bool, r3 error) {
-	f.SetDefaultHook(func(context.Context, string, string, shared.Range, bool) (string, shared.Range, bool, error) {
-		return r0, r1, r2, r3
+func (f *GitTreeTranslatorGetTargetCommitRangeFromSourceRangeFunc) SetDefaultReturn(r0 shared.Range, r1 bool, r2 error) {
+	f.SetDefaultHook(func(context.Context, string, string, shared.Range, bool) (shared.Range, bool, error) {
+		return r0, r1, r2
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *GitTreeTranslatorGetTargetCommitRangeFromSourceRangeFunc) PushReturn(r0 string, r1 shared.Range, r2 bool, r3 error) {
-	f.PushHook(func(context.Context, string, string, shared.Range, bool) (string, shared.Range, bool, error) {
-		return r0, r1, r2, r3
+func (f *GitTreeTranslatorGetTargetCommitRangeFromSourceRangeFunc) PushReturn(r0 shared.Range, r1 bool, r2 error) {
+	f.PushHook(func(context.Context, string, string, shared.Range, bool) (shared.Range, bool, error) {
+		return r0, r1, r2
 	})
 }
 
-func (f *GitTreeTranslatorGetTargetCommitRangeFromSourceRangeFunc) nextHook() func(context.Context, string, string, shared.Range, bool) (string, shared.Range, bool, error) {
+func (f *GitTreeTranslatorGetTargetCommitRangeFromSourceRangeFunc) nextHook() func(context.Context, string, string, shared.Range, bool) (shared.Range, bool, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -2355,16 +2217,13 @@ type GitTreeTranslatorGetTargetCommitRangeFromSourceRangeFuncCall struct {
 	Arg4 bool
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 string
+	Result0 shared.Range
 	// Result1 is the value of the 2nd result returned from this method
 	// invocation.
-	Result1 shared.Range
+	Result1 bool
 	// Result2 is the value of the 3rd result returned from this method
 	// invocation.
-	Result2 bool
-	// Result3 is the value of the 4th result returned from this method
-	// invocation.
-	Result3 error
+	Result2 error
 }
 
 // Args returns an interface slice containing the arguments of this
@@ -2376,7 +2235,7 @@ func (c GitTreeTranslatorGetTargetCommitRangeFromSourceRangeFuncCall) Args() []i
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c GitTreeTranslatorGetTargetCommitRangeFromSourceRangeFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1, c.Result2, c.Result3}
+	return []interface{}{c.Result0, c.Result1, c.Result2}
 }
 
 // MockUploadService is a mock implementation of the UploadService interface

--- a/internal/codeintel/codenav/request_state.go
+++ b/internal/codeintel/codenav/request_state.go
@@ -65,7 +65,7 @@ func NewRequestState(
 	}
 	r.SetUploadsDataLoader(uploads)
 	r.SetAuthChecker(authChecker)
-	r.SetLocalGitTreeTranslator(gitserverClient, repo, commit, path, hunkCache)
+	r.SetLocalGitTreeTranslator(gitserverClient, repo, commit, hunkCache)
 	r.SetLocalCommitCache(repoStore, gitserverClient)
 	r.SetMaximumIndexesPerMonikerSearch(maxIndexes)
 
@@ -95,11 +95,10 @@ func (r *RequestState) SetUploadsDataLoader(uploads []shared.CompletedUpload) {
 	}
 }
 
-func (r *RequestState) SetLocalGitTreeTranslator(client gitserver.Client, repo *sgTypes.Repo, commit string, path core.RepoRelPath, hunkCache HunkCache) {
-	args := &requestArgs{
+func (r *RequestState) SetLocalGitTreeTranslator(client gitserver.Client, repo *sgTypes.Repo, commit string, hunkCache HunkCache) {
+	args := &translationBase{
 		repo:   repo,
 		commit: commit,
-		path:   path,
 	}
 
 	r.GitTreeTranslator = NewGitTreeTranslator(client, args, hunkCache)

--- a/internal/codeintel/codenav/service_definitions_test.go
+++ b/internal/codeintel/codenav/service_definitions_test.go
@@ -8,14 +8,11 @@ import (
 
 func mockedGitTreeTranslator() GitTreeTranslator {
 	mockPositionAdjuster := NewMockGitTreeTranslator()
-	mockPositionAdjuster.GetTargetCommitPathFromSourcePathFunc.SetDefaultHook(func(ctx context.Context, commit string, path string, _ bool) (string, bool, error) {
-		return commit, true, nil
+	mockPositionAdjuster.GetTargetCommitPositionFromSourcePositionFunc.SetDefaultHook(func(ctx context.Context, commit string, path string, pos shared.Position, _ bool) (shared.Position, bool, error) {
+		return pos, true, nil
 	})
-	mockPositionAdjuster.GetTargetCommitPositionFromSourcePositionFunc.SetDefaultHook(func(ctx context.Context, commit string, pos shared.Position, _ bool) (string, shared.Position, bool, error) {
-		return commit, pos, true, nil
-	})
-	mockPositionAdjuster.GetTargetCommitRangeFromSourceRangeFunc.SetDefaultHook(func(ctx context.Context, commit string, path string, rx shared.Range, _ bool) (string, shared.Range, bool, error) {
-		return commit, rx, true, nil
+	mockPositionAdjuster.GetTargetCommitRangeFromSourceRangeFunc.SetDefaultHook(func(ctx context.Context, commit string, path string, rx shared.Range, _ bool) (shared.Range, bool, error) {
+		return rx, true, nil
 	})
 
 	return mockPositionAdjuster

--- a/internal/codeintel/codenav/service_diagnostics_test.go
+++ b/internal/codeintel/codenav/service_diagnostics_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/sourcegraph/log"
+	"github.com/sourcegraph/scip/bindings/go/scip"
 
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
@@ -37,7 +38,7 @@ func TestDiagnostics(t *testing.T) {
 	// Set up request state
 	mockRequestState := RequestState{}
 	mockRequestState.SetLocalCommitCache(mockRepoStore, mockGitserverClient)
-	mockRequestState.SetLocalGitTreeTranslator(mockGitserverClient, &sgtypes.Repo{}, mockCommit, mockPath, hunkCache)
+	mockRequestState.SetLocalGitTreeTranslator(mockGitserverClient, &sgtypes.Repo{}, mockCommit, hunkCache)
 	uploads := []uploadsshared.CompletedUpload{
 		{ID: 50, Commit: "deadbeef", Root: "sub1/"},
 		{ID: 51, Commit: "deadbeef", Root: "sub2/"},
@@ -56,6 +57,9 @@ func TestDiagnostics(t *testing.T) {
 	mockLsifStore.GetDiagnosticsFunc.PushReturn(diagnostics[0:1], 1, nil)
 	mockLsifStore.GetDiagnosticsFunc.PushReturn(diagnostics[1:4], 3, nil)
 	mockLsifStore.GetDiagnosticsFunc.PushReturn(diagnostics[4:], 26, nil)
+
+	// Update this when TODO(id: check-path-multiple-uploads-api) is addressed.
+	mockLsifStore.SCIPDocumentFunc.SetDefaultReturn(&scip.Document{}, nil)
 
 	mockRequest := PositionalRequestArgs{
 		RequestArgs: RequestArgs{
@@ -111,7 +115,7 @@ func TestDiagnosticsWithSubRepoPermissions(t *testing.T) {
 	// Set up request state
 	mockRequestState := RequestState{}
 	mockRequestState.SetLocalCommitCache(mockRepoStore, mockGitserverClient)
-	mockRequestState.SetLocalGitTreeTranslator(mockGitserverClient, &sgtypes.Repo{}, mockCommit, mockPath, hunkCache)
+	mockRequestState.SetLocalGitTreeTranslator(mockGitserverClient, &sgtypes.Repo{}, mockCommit, hunkCache)
 	uploads := []uploadsshared.CompletedUpload{
 		{ID: 50, Commit: "deadbeef", Root: "sub1/"},
 		{ID: 51, Commit: "deadbeef", Root: "sub2/"},
@@ -143,6 +147,9 @@ func TestDiagnosticsWithSubRepoPermissions(t *testing.T) {
 	mockLsifStore.GetDiagnosticsFunc.PushReturn(diagnostics[0:1], 1, nil)
 	mockLsifStore.GetDiagnosticsFunc.PushReturn(diagnostics[1:4], 3, nil)
 	mockLsifStore.GetDiagnosticsFunc.PushReturn(diagnostics[4:], 26, nil)
+
+	// Update this when TODO(id: check-path-multiple-uploads-api) is addressed.
+	mockLsifStore.SCIPDocumentFunc.SetDefaultReturn(&scip.Document{}, nil)
 
 	ctx := actor.WithActor(context.Background(), &actor.Actor{UID: 1})
 	mockRequest := PositionalRequestArgs{

--- a/internal/codeintel/codenav/service_hover_test.go
+++ b/internal/codeintel/codenav/service_hover_test.go
@@ -34,7 +34,7 @@ func TestHover(t *testing.T) {
 	// Set up request state
 	mockRequestState := RequestState{}
 	mockRequestState.SetLocalCommitCache(mockRepoStore, mockGitserverClient)
-	mockRequestState.SetLocalGitTreeTranslator(mockGitserverClient, &sgtypes.Repo{ID: 42}, mockCommit, mockPath, hunkCache)
+	mockRequestState.SetLocalGitTreeTranslator(mockGitserverClient, &sgtypes.Repo{ID: 42}, mockCommit, hunkCache)
 	uploads := []uploadsshared.CompletedUpload{
 		{ID: 50, Commit: "deadbeef", Root: "sub1/"},
 		{ID: 51, Commit: "deadbeef", Root: "sub2/"},
@@ -91,7 +91,7 @@ func TestHoverRemote(t *testing.T) {
 	// Set up request state
 	mockRequestState := RequestState{}
 	mockRequestState.SetLocalCommitCache(mockRepoStore, mockGitserverClient)
-	mockRequestState.SetLocalGitTreeTranslator(mockGitserverClient, &sgtypes.Repo{ID: 42}, mockCommit, mockPath, hunkCache)
+	mockRequestState.SetLocalGitTreeTranslator(mockGitserverClient, &sgtypes.Repo{ID: 42}, mockCommit, hunkCache)
 	uploads := []uploadsshared.CompletedUpload{
 		{ID: 50, Commit: "deadbeef"},
 	}

--- a/internal/codeintel/codenav/service_new_test.go
+++ b/internal/codeintel/codenav/service_new_test.go
@@ -35,7 +35,7 @@ func TestGetDefinitions(t *testing.T) {
 		mockRequestState := RequestState{}
 		mockRequestState.SetLocalCommitCache(mockRepoStore, mockGitserverClient)
 
-		mockRequestState.SetLocalGitTreeTranslator(mockGitserverClient, &sgtypes.Repo{}, mockCommit, mockPath, hunkCache)
+		mockRequestState.SetLocalGitTreeTranslator(mockGitserverClient, &sgtypes.Repo{}, mockCommit, hunkCache)
 		uploads := []uploadsshared.CompletedUpload{
 			{ID: 50, Commit: mockCommit, Root: "sub1/"},
 			{ID: 51, Commit: mockCommit, Root: "sub2/"},
@@ -95,7 +95,7 @@ func TestGetDefinitions(t *testing.T) {
 		// Set up request state
 		mockRequestState := RequestState{}
 		mockRequestState.SetLocalCommitCache(mockRepoStore, mockGitserverClient)
-		mockRequestState.SetLocalGitTreeTranslator(mockGitserverClient, &sgtypes.Repo{ID: 42}, mockCommit, mockPath, hunkCache)
+		mockRequestState.SetLocalGitTreeTranslator(mockGitserverClient, &sgtypes.Repo{ID: 42}, mockCommit, hunkCache)
 		mockRequestState.GitTreeTranslator = mockedGitTreeTranslator()
 		uploads1 := []uploadsshared.CompletedUpload{
 			{ID: 50, Commit: "deadbeef", Root: "sub1/"},
@@ -218,7 +218,7 @@ func TestGetReferences(t *testing.T) {
 		// Set up request state
 		mockRequestState := RequestState{}
 		mockRequestState.SetLocalCommitCache(mockRepoStore, mockGitserverClient)
-		mockRequestState.SetLocalGitTreeTranslator(mockGitserverClient, &sgtypes.Repo{}, mockCommit, mockPath, hunkCache)
+		mockRequestState.SetLocalGitTreeTranslator(mockGitserverClient, &sgtypes.Repo{}, mockCommit, hunkCache)
 		uploads := []uploadsshared.CompletedUpload{
 			{ID: 50, Commit: "deadbeef", Root: "sub1/"},
 			{ID: 51, Commit: "deadbeef", Root: "sub2/"},
@@ -284,7 +284,7 @@ func TestGetReferences(t *testing.T) {
 		// Set up request state
 		mockRequestState := RequestState{}
 		mockRequestState.SetLocalCommitCache(mockRepoStore, mockGitserverClient)
-		mockRequestState.SetLocalGitTreeTranslator(mockGitserverClient, &sgtypes.Repo{}, mockCommit, mockPath, hunkCache)
+		mockRequestState.SetLocalGitTreeTranslator(mockGitserverClient, &sgtypes.Repo{}, mockCommit, hunkCache)
 		uploads := []uploadsshared.CompletedUpload{
 			{ID: 50, Commit: "deadbeef", Root: "sub1/"},
 			{ID: 51, Commit: "deadbeef", Root: "sub2/"},
@@ -466,7 +466,7 @@ func TestGetImplementations(t *testing.T) {
 		// Set up request state
 		mockRequestState := RequestState{}
 		mockRequestState.SetLocalCommitCache(mockRepoStore, mockGitserverClient)
-		mockRequestState.SetLocalGitTreeTranslator(mockGitserverClient, &sgtypes.Repo{}, mockCommit, mockPath, hunkCache)
+		mockRequestState.SetLocalGitTreeTranslator(mockGitserverClient, &sgtypes.Repo{}, mockCommit, hunkCache)
 
 		// Empty result set (prevents nil pointer as scanner is always non-nil)
 		mockUploadSvc.GetUploadIDsWithReferencesFunc.PushReturn([]int{}, 0, 0, nil)

--- a/internal/codeintel/codenav/service_ranges_test.go
+++ b/internal/codeintel/codenav/service_ranges_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/sourcegraph/log"
+	"github.com/sourcegraph/scip/bindings/go/scip"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/codenav/shared"
@@ -51,13 +52,16 @@ func TestRanges(t *testing.T) {
 	mockSearchClient := client.NewMockSearchClient()
 	hunkCache, _ := NewHunkCache(50)
 
+	// Update this when TODO(id: check-path-multiple-uploads-api) is addressed.
+	mockLsifStore.SCIPDocumentFunc.SetDefaultReturn(&scip.Document{}, nil)
+
 	// Init service
 	svc := newService(observation.TestContextTB(t), mockRepoStore, mockLsifStore, mockUploadSvc, mockGitserverClient, mockSearchClient, log.NoOp())
 
 	// Set up request state
 	mockRequestState := RequestState{}
 	mockRequestState.SetLocalCommitCache(mockRepoStore, mockGitserverClient)
-	mockRequestState.SetLocalGitTreeTranslator(mockGitserverClient, &sgtypes.Repo{}, mockCommit, mockPath, hunkCache)
+	mockRequestState.SetLocalGitTreeTranslator(mockGitserverClient, &sgtypes.Repo{}, mockCommit, hunkCache)
 	uploads := []uploadsshared.CompletedUpload{
 		{ID: 50, Commit: "deadbeef1", Root: "sub1/", RepositoryID: 42},
 		{ID: 51, Commit: "deadbeef1", Root: "sub2/", RepositoryID: 42},

--- a/internal/codeintel/codenav/service_stencil_test.go
+++ b/internal/codeintel/codenav/service_stencil_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/sourcegraph/log"
+	"github.com/sourcegraph/scip/bindings/go/scip"
 
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/codenav/shared"
 	uploadsshared "github.com/sourcegraph/sourcegraph/internal/codeintel/uploads/shared"
@@ -24,13 +25,16 @@ func TestStencil(t *testing.T) {
 	mockSearchClient := client.NewMockSearchClient()
 	hunkCache, _ := NewHunkCache(50)
 
+	// Update this when TODO(id: check-path-multiple-uploads-api) is addressed.
+	mockLsifStore.SCIPDocumentFunc.SetDefaultReturn(&scip.Document{}, nil)
+
 	// Init service
 	svc := newService(observation.TestContextTB(t), mockRepoStore, mockLsifStore, mockUploadSvc, mockGitserverClient, mockSearchClient, log.NoOp())
 
 	// Set up request state
 	mockRequestState := RequestState{}
 	mockRequestState.SetLocalCommitCache(mockRepoStore, mockGitserverClient)
-	mockRequestState.SetLocalGitTreeTranslator(mockGitserverClient, &sgtypes.Repo{}, mockCommit, mockPath, hunkCache)
+	mockRequestState.SetLocalGitTreeTranslator(mockGitserverClient, &sgtypes.Repo{}, mockCommit, hunkCache)
 	uploads := []uploadsshared.CompletedUpload{
 		{ID: 50, Commit: "deadbeef", Root: "sub1/"},
 		{ID: 51, Commit: "deadbeef", Root: "sub2/"},
@@ -83,13 +87,16 @@ func TestStencilWithDuplicateRanges(t *testing.T) {
 	mockSearchClient := client.NewMockSearchClient()
 	hunkCache, _ := NewHunkCache(50)
 
+	// Update this when TODO(id: check-path-multiple-uploads-api) is addressed.
+	mockLsifStore.SCIPDocumentFunc.SetDefaultReturn(&scip.Document{}, nil)
+
 	// Init service
 	svc := newService(observation.TestContextTB(t), mockRepoStore, mockLsifStore, mockUploadSvc, mockGitserverClient, mockSearchClient, log.NoOp())
 
 	// Set up request state
 	mockRequestState := RequestState{}
 	mockRequestState.SetLocalCommitCache(mockRepoStore, mockGitserverClient)
-	mockRequestState.SetLocalGitTreeTranslator(mockGitserverClient, &sgtypes.Repo{}, mockCommit, mockPath, hunkCache)
+	mockRequestState.SetLocalGitTreeTranslator(mockGitserverClient, &sgtypes.Repo{}, mockCommit, hunkCache)
 	uploads := []uploadsshared.CompletedUpload{
 		{ID: 50, Commit: "deadbeef", Root: "sub1/"},
 		{ID: 51, Commit: "deadbeef", Root: "sub2/"},

--- a/internal/codeintel/codenav/transport/graphql/root_resolver_test.go
+++ b/internal/codeintel/codenav/transport/graphql/root_resolver_test.go
@@ -37,6 +37,9 @@ var repoRelPath = core.NewRepoRelPathUnchecked
 func TestRanges(t *testing.T) {
 	mockCodeNavService := NewMockCodeNavService()
 
+	// Update this when TODO(id: check-path-multiple-uploads-api) is addressed.
+	mockCodeNavService.SCIPDocumentFunc.SetDefaultReturn(&scip.Document{}, nil)
+
 	mockRequestState := codenav.RequestState{
 		RepositoryID: 1,
 		Commit:       "deadbeef1",


### PR DESCRIPTION
Previously, the code had several problems:

- There was code which seemed like it was handling path renames across
  commits, but it was just a no-op. It was not documented why it was
  implemented that way.
- The Position adjustment API and Range adjustment APIs were inconsistent.
- The Position and Range adjustment APIs suggested that they could
  handle file renames, but they don't/cannot.
- The mocking logic was just returning wrong outputs (commits
  instead of paths in one place).

This patch documents the rationale behind the lack of rename handling,
as well as adds a slow-but-correct form of Document checking.

## Test plan

Covered by existing tests? 🤷🏽

## Changelog