### PR TITLE
chore(ci): use --script_path to improve push_all.sh parallelism

### DIFF
--- a/dev/ci/push_all.sh
+++ b/dev/ci/push_all.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -eux
+set -eu
 
 # echo "~~~ :aspect: :stethoscope: Agent Health check"
 # /etc/aspect/workflows/bin/agent_health_check
@@ -74,7 +74,7 @@ function create_push_command() {
       --workspace_status_command=./dev/bazel_stamp_vars.sh
 
     # echo the target here so we can extract it later to show per-target timing from gnu parallel
-    echo "echo $target && $cmd $tags_args --repository ${registry}/${repository} && $(echo_append_annotation "$repository" "$registry" "${tags_args[@]}")"
+    echo "$cmd $tags_args --repository ${registry}/${repository} && $(echo_append_annotation "$repository" "$registry" "${tags_args[@]}") # $target"
   done
 }
 

--- a/dev/ci/push_all.sh
+++ b/dev/ci/push_all.sh
@@ -61,7 +61,7 @@ function create_push_command() {
 
   for i in "${!registries[@]}"; do
     registry="${registries[$i]}"
-    etarget="$(echo "$target" | sed 's/\///g')"
+    etarget="$(echo "$target" | sed 's/\//_/g')"
     cmd="$runscriptdir/${etarget}_$i.sh"
 
     bazel \


### PR DESCRIPTION
Today, we use gnu parallel to parallelize running bazel run on oci_push targets. We get a lot of logspam around the bazel exclusive lock due to parallel invocations of `bazel run`. We can use [--script_path](https://bazel.build/reference/command-line-reference#flag--script_path) to emit a script which emulates the behaviour of `bazel run` and then invoke those scripts in parallel instead to avoid the lock, hopefully shaving a bit of time off :crossed_fingers: 

## Test plan

Insert main dry-run here


## Changelog

