### PR TITLE
chore(batch-changes): remove visibility options from create batch changes page

### DIFF
--- a/client/web/src/enterprise/batches/create/ConfigurationForm.tsx
+++ b/client/web/src/enterprise/batches/create/ConfigurationForm.tsx
@@ -1,13 +1,12 @@
 import React, { useCallback, useState } from 'react'
 
-import { mdiInformationOutline, mdiLock } from '@mdi/js'
 import classNames from 'classnames'
 import { noop } from 'lodash'
 import { useNavigate, useLocation } from 'react-router-dom'
 
 import { useMutation } from '@sourcegraph/http-client'
 import type { UserSettingFields, OrgSettingFields } from '@sourcegraph/shared/src/graphql-operations'
-import { Alert, Button, Container, Icon, Input, RadioButton, Tooltip, ErrorAlert, Form } from '@sourcegraph/wildcard'
+import { Alert, Button, Container, Input, ErrorAlert, Form } from '@sourcegraph/wildcard'
 
 import type { AuthenticatedUser } from '../../../auth'
 import type {
@@ -206,42 +205,6 @@ export const ConfigurationForm: React.FunctionComponent<React.PropsWithChildren<
                         </span>
                     </small>
                 )}
-                <hr className="my-3" aria-hidden={true} />
-                <strong className="d-block mb-2">
-                    Visibility
-                    <Tooltip content="Coming soon">
-                        <Icon
-                            aria-label="Private batch changes coming soon"
-                            className="ml-1"
-                            svgPath={mdiInformationOutline}
-                        />
-                    </Tooltip>
-                </strong>
-                <div className="form-group mb-1" aria-hidden={true}>
-                    <RadioButton
-                        name="visibility"
-                        value="public"
-                        className="mr-2"
-                        checked={true}
-                        disabled={true}
-                        label="Public"
-                        aria-label="Public"
-                    />
-                </div>
-                <div className="form-group mb-0" aria-hidden={true}>
-                    <RadioButton
-                        name="visibility"
-                        value="private"
-                        className="mr-2 mb-0"
-                        disabled={true}
-                        label={
-                            <>
-                                Private <Icon aria-hidden={true} className="text-warning" svgPath={mdiLock} />
-                            </>
-                        }
-                        aria-label="Private"
-                    />
-                </div>
             </Container>
 
             {!isReadOnly && (


### PR DESCRIPTION
Closes SRCH-534

> “Visibility” on the [create batch changes page](https://sourcegraph.sourcegraph.com/batch-changes/create) has been in [coming-soon limbo](https://www.notion.so/sourcegraph/Product-features-that-are-in-a-worrying-limbo-state-customer-GTM-feedback-ff3dbf0fa6714259b8628aa29d58c395?pvs=4#c9ffd448af444188873e989a7b7f13a0) for a long time.

> We will remove “coming soon” and the "private" option. We will not ship this enhancement in FY25. 

> (We will connect batch changes to chat/search workflows in the unified product, which will make it accessible to a lot more devs compared to today. This will entail a rethinking of the entire “create batch change” flow and many other things that will benefit customers and users by addressing the #1 feedback about batch changes (that it’s too complex to use). That is why we do not want to invest in enhancing the permissions system for batch changes right now.)

![CleanShot 2024-06-20 at 15 33 25@2x](https://github.com/sourcegraph/sourcegraph/assets/25608335/51f40abe-9c1c-4a32-b5cd-ca5eeb90eb46)

## Test plan

When you visit the [create batch changes page](https://sourcegraph.sourcegraph.com/batch-changes/create), the visibility options shouldn't exist anymore.


## Changelog

- remove visibility options from create batch change page
