### PR TITLE
Svelte: Make the byline in the fuzzy finder items bigger

### DIFF
--- a/client/web-sveltekit/src/lib/fuzzyfinder/FuzzyFinder.svelte
+++ b/client/web-sveltekit/src/lib/fuzzyfinder/FuzzyFinder.svelte
@@ -373,7 +373,7 @@
             .info {
                 grid-area: info;
                 color: var(--text-muted);
-                font-size: var(--font-size-extra-small);
+                font-size: var(--font-size-small);
 
                 &.mono {
                     font-family: var(--code-font-family);


### PR DESCRIPTION
Tiny change to increase font-size of byline on the items in the fuzzy finder.

## Before
<img width="1304" alt="CleanShot 2024-06-20 at 18 19 30@2x" src="https://github.com/sourcegraph/sourcegraph/assets/5337876/8af80041-d64a-4cae-b717-a807b37081e6">

## After 
<img width="1337" alt="CleanShot 2024-06-20 at 18 20 53@2x" src="https://github.com/sourcegraph/sourcegraph/assets/5337876/53725e1e-2ebd-4b2c-be4d-ca9fa7fb00cb">


## Test plan
Manually tested locally.