### PR TITLE
fix(client): restore paths for extension bundles

### DIFF
--- a/client/web/dist/BUILD.bazel
+++ b/client/web/dist/BUILD.bazel
@@ -34,6 +34,10 @@ copy_to_directory(
         "client/web/bundle": "",
         "client/web-sveltekit/build": "",
         "client/web/dist/img": "img",
+        # We need to ensure we're keeping the old names, so older extensions are still working if ran against a newer Sourcegraph instance
+        "client/browser/integration-assets/extension/js/nativeIntegration.main.bundle.js": "extension/scripts/integration.bundle.js",
+        "client/browser/integration-assets/extension/js/phabricatorNativeIntegration.main.bundle.js": "extension/scripts/phabricator.bundle.js",
+        "client/browser/integration-assets/extension/js/extensionHostWorker.bundle.js": "extension/scripts/extensionHostWorker.bundle.js",
         "client/browser/integration-assets": "",
     },
 )


### PR DESCRIPTION
When moving to ESBuild, the filenames for extension bundles changed, which led to broken bitbucket plugins for example. 

See [discussion](https://sourcegraph.slack.com/archives/C04MYFW01NV/p1718902092493689)


## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles -->

Inspected the relevant target to see the paths in their proper location. 


## Changelog

<!--
1. Ensure your pull request title is formatted as: $type($domain): $what
2. Add bullet list items for each additional detail you want to cover (see example below)
3. You can edit this after the pull request was merged, as long as release shipping it hasn't been promoted to the public.
4. For more information, please see this how-to https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c?

Audience: TS/CSE > Customers > Teammates (in that order).

Cheat sheet: $type = chore|fix|feat $domain: source|search|ci|release|plg|cody|local|...
-->

<!--
Example:

Title: fix(search): parse quotes with the appropriate context
Changelog section:

## Changelog

- When a quote is used with regexp pattern type, then ...
- Refactored underlying code.
-->
