### PR TITLE
fix/enterpriseportal: ListEnterpriseSubscriptions fixes

### DIFF
--- a/cmd/enterprise-portal/internal/database/subscriptions.go
+++ b/cmd/enterprise-portal/internal/database/subscriptions.go
@@ -42,8 +42,9 @@ type ListEnterpriseSubscriptionsOptions struct {
 	IDs []string
 	// InstanceDomains is a list of instance domains to filter by.
 	InstanceDomains []string
-	// OnlyArchived indicates whether to only list archived subscriptions.
-	OnlyArchived bool
+	// IsArchived indicates whether to only list archived subscriptions, or only
+	// non-archived subscriptions.
+	IsArchived bool
 	// PageSize is the maximum number of subscriptions to return.
 	PageSize int
 }

--- a/cmd/enterprise-portal/internal/dotcomdb/dotcomdb.go
+++ b/cmd/enterprise-portal/internal/dotcomdb/dotcomdb.go
@@ -464,17 +464,30 @@ type SubscriptionAttributes struct {
 	ArchivedAt *time.Time
 }
 
+type ListEnterpriseSubscriptionsOptions struct {
+	SubscriptionIDs []string
+	IsArchived      bool
+}
+
 // ListEnterpriseSubscriptions returns a list of enterprise subscription
 // attributes with the given IDs. It silently ignores any non-existent
 // subscription IDs. The caller should check the length of the returned slice to
 // ensure all requested subscriptions were found.
-func (r *Reader) ListEnterpriseSubscriptions(ctx context.Context, subscriptionIDs ...string) ([]*SubscriptionAttributes, error) {
-	if len(subscriptionIDs) == 0 {
-		return []*SubscriptionAttributes{}, nil
+//
+// If no IDs are given, it returns all subscriptions.
+func (r *Reader) ListEnterpriseSubscriptions(ctx context.Context, opts ListEnterpriseSubscriptionsOptions) ([]*SubscriptionAttributes, error) {
+	query := `SELECT id, created_at, archived_at FROM product_subscriptions WHERE true`
+	namedArgs := pgx.NamedArgs{}
+	if len(opts.SubscriptionIDs) > 0 {
+		query += "\nAND id = ANY(@ids)"
+		namedArgs["ids"] = opts.SubscriptionIDs
+	}
+	if opts.IsArchived {
+		query += "\nAND archived_at IS NOT NULL"
+	} else {
+		query += "\nAND archived_at IS NULL"
 	}
 
-	query := `SELECT id, created_at, archived_at FROM product_subscriptions WHERE id = ANY(@ids)`
-	namedArgs := pgx.NamedArgs{"ids": subscriptionIDs}
 	rows, err := r.db.Query(ctx, query, namedArgs)
 	if err != nil {
 		return nil, errors.Wrap(err, "query subscription attributes")

--- a/cmd/enterprise-portal/internal/dotcomdb/dotcomdb_test.go
+++ b/cmd/enterprise-portal/internal/dotcomdb/dotcomdb_test.go
@@ -74,6 +74,7 @@ type mockedData struct {
 	targetSubscriptionID  string
 	accessTokens          []string
 	createdLicenses       int
+	createdSubscriptions  int
 	archivedSubscriptions int
 }
 
@@ -92,6 +93,7 @@ func setupDBAndInsertMockLicense(t *testing.T, dotcomdb database.DB, info licens
 		require.NoError(t, err)
 		sub, err := subscriptionsdb.Create(ctx, u.ID, u.Username)
 		require.NoError(t, err)
+		result.createdSubscriptions += 1
 		_, err = licensesdb.Create(ctx, sub, t.Name()+"-barbaz", 2, license.Info{
 			CreatedAt: info.CreatedAt,
 			ExpiresAt: info.ExpiresAt,
@@ -108,6 +110,7 @@ func setupDBAndInsertMockLicense(t *testing.T, dotcomdb database.DB, info licens
 		require.NoError(t, err)
 		sub, err := subscriptionsdb.Create(ctx, u.ID, u.Username)
 		require.NoError(t, err)
+		result.createdSubscriptions += 1
 		_, err = licensesdb.Create(ctx, sub, t.Name()+"-archived", 2, license.Info{
 			CreatedAt: info.CreatedAt,
 			ExpiresAt: info.ExpiresAt,
@@ -127,6 +130,7 @@ func setupDBAndInsertMockLicense(t *testing.T, dotcomdb database.DB, info licens
 		require.NoError(t, err)
 		sub, err := subscriptionsdb.Create(ctx, u.ID, u.Username)
 		require.NoError(t, err)
+		result.createdSubscriptions += 1
 		_, err = licensesdb.Create(ctx, sub, t.Name()+"-not-dev", 2, license.Info{
 			CreatedAt: info.CreatedAt,
 			ExpiresAt: info.ExpiresAt,
@@ -140,6 +144,7 @@ func setupDBAndInsertMockLicense(t *testing.T, dotcomdb database.DB, info licens
 	require.NoError(t, err)
 	subid, err := subscriptionsdb.Create(ctx, u.ID, u.Username)
 	require.NoError(t, err)
+	result.createdSubscriptions += 1
 	result.targetSubscriptionID = subid
 	// Insert a rubbish license first, CreatedAt is not used (creation time is
 	// inferred from insert time) so we need to do this first
@@ -171,6 +176,7 @@ func setupDBAndInsertMockLicense(t *testing.T, dotcomdb database.DB, info licens
 		require.NoError(t, err)
 		sub, err := subscriptionsdb.Create(ctx, u.ID, u.Username)
 		require.NoError(t, err)
+		result.createdSubscriptions += 1
 		_, err = licensesdb.Create(ctx, sub, t.Name()+"-foobar", 2, license.Info{
 			CreatedAt: info.CreatedAt,
 			ExpiresAt: info.ExpiresAt,
@@ -457,4 +463,29 @@ func TestListEnterpriseSubscriptionLicenses(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestListEnterpriseSubscriptions(t *testing.T) {
+	db, dotcomreader := newTestDotcomReader(t)
+	info := license.Info{
+		ExpiresAt: time.Now().Add(30 * time.Minute),
+		UserCount: 321,
+		Tags:      []string{licensing.PlanEnterprise1.Tag(), licensing.DevTag},
+	}
+	mock := setupDBAndInsertMockLicense(t, db, info, nil)
+
+	// Just a simple sanity test
+	ss, err := dotcomreader.ListEnterpriseSubscriptions(
+		context.Background(),
+		dotcomdb.ListEnterpriseSubscriptionsOptions{})
+	require.NoError(t, err)
+	assert.Len(t, ss, mock.createdSubscriptions-mock.archivedSubscriptions)
+	var found bool
+	for _, s := range ss {
+		if s.ID == mock.targetSubscriptionID {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found)
 }

--- a/cmd/enterprise-portal/internal/subscriptionsservice/BUILD.bazel
+++ b/cmd/enterprise-portal/internal/subscriptionsservice/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "//cmd/enterprise-portal/internal/database",
         "//cmd/enterprise-portal/internal/dotcomdb",
         "//cmd/enterprise-portal/internal/samsm2m",
+        "//internal/collections",
         "//internal/trace",
         "//lib/enterpriseportal/subscriptions/v1:subscriptions",
         "//lib/enterpriseportal/subscriptions/v1/v1connect",

--- a/cmd/enterprise-portal/internal/subscriptionsservice/adapters.go
+++ b/cmd/enterprise-portal/internal/subscriptionsservice/adapters.go
@@ -47,6 +47,12 @@ func convertLicenseAttrsToProto(attrs *dotcomdb.LicenseAttributes) *subscription
 }
 
 func convertSubscriptionToProto(subscription *database.Subscription, attrs *dotcomdb.SubscriptionAttributes) *subscriptionsv1.EnterpriseSubscription {
+	// Dotcom equivalent missing is surprising, but let's not panic just yet
+	if attrs == nil {
+		attrs = &dotcomdb.SubscriptionAttributes{
+			ID: subscription.ID,
+		}
+	}
 	conds := []*subscriptionsv1.EnterpriseSubscriptionCondition{
 		{
 			Status:             subscriptionsv1.EnterpriseSubscriptionCondition_STATUS_CREATED,

--- a/cmd/enterprise-portal/internal/subscriptionsservice/mocks_test.go
+++ b/cmd/enterprise-portal/internal/subscriptionsservice/mocks_test.go
@@ -91,7 +91,7 @@ func NewMockStoreV1() *MockStoreV1 {
 			},
 		},
 		ListDotcomEnterpriseSubscriptionsFunc: &StoreV1ListDotcomEnterpriseSubscriptionsFunc{
-			defaultHook: func(context.Context, ...string) (r0 []*dotcomdb.SubscriptionAttributes, r1 error) {
+			defaultHook: func(context.Context, dotcomdb.ListEnterpriseSubscriptionsOptions) (r0 []*dotcomdb.SubscriptionAttributes, r1 error) {
 				return
 			},
 		},
@@ -143,7 +143,7 @@ func NewStrictMockStoreV1() *MockStoreV1 {
 			},
 		},
 		ListDotcomEnterpriseSubscriptionsFunc: &StoreV1ListDotcomEnterpriseSubscriptionsFunc{
-			defaultHook: func(context.Context, ...string) ([]*dotcomdb.SubscriptionAttributes, error) {
+			defaultHook: func(context.Context, dotcomdb.ListEnterpriseSubscriptionsOptions) ([]*dotcomdb.SubscriptionAttributes, error) {
 				panic("unexpected invocation of MockStoreV1.ListDotcomEnterpriseSubscriptions")
 			},
 		},
@@ -849,16 +849,16 @@ func (c StoreV1ListDotcomEnterpriseSubscriptionLicensesFuncCall) Results() []int
 // the ListDotcomEnterpriseSubscriptions method of the parent MockStoreV1
 // instance is invoked.
 type StoreV1ListDotcomEnterpriseSubscriptionsFunc struct {
-	defaultHook func(context.Context, ...string) ([]*dotcomdb.SubscriptionAttributes, error)
-	hooks       []func(context.Context, ...string) ([]*dotcomdb.SubscriptionAttributes, error)
+	defaultHook func(context.Context, dotcomdb.ListEnterpriseSubscriptionsOptions) ([]*dotcomdb.SubscriptionAttributes, error)
+	hooks       []func(context.Context, dotcomdb.ListEnterpriseSubscriptionsOptions) ([]*dotcomdb.SubscriptionAttributes, error)
 	history     []StoreV1ListDotcomEnterpriseSubscriptionsFuncCall
 	mutex       sync.Mutex
 }
 
 // ListDotcomEnterpriseSubscriptions delegates to the next hook function in
 // the queue and stores the parameter and result values of this invocation.
-func (m *MockStoreV1) ListDotcomEnterpriseSubscriptions(v0 context.Context, v1 ...string) ([]*dotcomdb.SubscriptionAttributes, error) {
-	r0, r1 := m.ListDotcomEnterpriseSubscriptionsFunc.nextHook()(v0, v1...)
+func (m *MockStoreV1) ListDotcomEnterpriseSubscriptions(v0 context.Context, v1 dotcomdb.ListEnterpriseSubscriptionsOptions) ([]*dotcomdb.SubscriptionAttributes, error) {
+	r0, r1 := m.ListDotcomEnterpriseSubscriptionsFunc.nextHook()(v0, v1)
 	m.ListDotcomEnterpriseSubscriptionsFunc.appendCall(StoreV1ListDotcomEnterpriseSubscriptionsFuncCall{v0, v1, r0, r1})
 	return r0, r1
 }
@@ -866,7 +866,7 @@ func (m *MockStoreV1) ListDotcomEnterpriseSubscriptions(v0 context.Context, v1 .
 // SetDefaultHook sets function that is called when the
 // ListDotcomEnterpriseSubscriptions method of the parent MockStoreV1
 // instance is invoked and the hook queue is empty.
-func (f *StoreV1ListDotcomEnterpriseSubscriptionsFunc) SetDefaultHook(hook func(context.Context, ...string) ([]*dotcomdb.SubscriptionAttributes, error)) {
+func (f *StoreV1ListDotcomEnterpriseSubscriptionsFunc) SetDefaultHook(hook func(context.Context, dotcomdb.ListEnterpriseSubscriptionsOptions) ([]*dotcomdb.SubscriptionAttributes, error)) {
 	f.defaultHook = hook
 }
 
@@ -875,7 +875,7 @@ func (f *StoreV1ListDotcomEnterpriseSubscriptionsFunc) SetDefaultHook(hook func(
 // instance invokes the hook at the front of the queue and discards it.
 // After the queue is empty, the default hook function is invoked for any
 // future action.
-func (f *StoreV1ListDotcomEnterpriseSubscriptionsFunc) PushHook(hook func(context.Context, ...string) ([]*dotcomdb.SubscriptionAttributes, error)) {
+func (f *StoreV1ListDotcomEnterpriseSubscriptionsFunc) PushHook(hook func(context.Context, dotcomdb.ListEnterpriseSubscriptionsOptions) ([]*dotcomdb.SubscriptionAttributes, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -884,19 +884,19 @@ func (f *StoreV1ListDotcomEnterpriseSubscriptionsFunc) PushHook(hook func(contex
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
 func (f *StoreV1ListDotcomEnterpriseSubscriptionsFunc) SetDefaultReturn(r0 []*dotcomdb.SubscriptionAttributes, r1 error) {
-	f.SetDefaultHook(func(context.Context, ...string) ([]*dotcomdb.SubscriptionAttributes, error) {
+	f.SetDefaultHook(func(context.Context, dotcomdb.ListEnterpriseSubscriptionsOptions) ([]*dotcomdb.SubscriptionAttributes, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
 func (f *StoreV1ListDotcomEnterpriseSubscriptionsFunc) PushReturn(r0 []*dotcomdb.SubscriptionAttributes, r1 error) {
-	f.PushHook(func(context.Context, ...string) ([]*dotcomdb.SubscriptionAttributes, error) {
+	f.PushHook(func(context.Context, dotcomdb.ListEnterpriseSubscriptionsOptions) ([]*dotcomdb.SubscriptionAttributes, error) {
 		return r0, r1
 	})
 }
 
-func (f *StoreV1ListDotcomEnterpriseSubscriptionsFunc) nextHook() func(context.Context, ...string) ([]*dotcomdb.SubscriptionAttributes, error) {
+func (f *StoreV1ListDotcomEnterpriseSubscriptionsFunc) nextHook() func(context.Context, dotcomdb.ListEnterpriseSubscriptionsOptions) ([]*dotcomdb.SubscriptionAttributes, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -934,9 +934,9 @@ type StoreV1ListDotcomEnterpriseSubscriptionsFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
 	Arg0 context.Context
-	// Arg1 is a slice containing the values of the variadic arguments
-	// passed to this method invocation.
-	Arg1 []string
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 dotcomdb.ListEnterpriseSubscriptionsOptions
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 []*dotcomdb.SubscriptionAttributes
@@ -946,16 +946,9 @@ type StoreV1ListDotcomEnterpriseSubscriptionsFuncCall struct {
 }
 
 // Args returns an interface slice containing the arguments of this
-// invocation. The variadic slice argument is flattened in this array such
-// that one positional argument and three variadic arguments would result in
-// a slice of four, not two.
+// invocation.
 func (c StoreV1ListDotcomEnterpriseSubscriptionsFuncCall) Args() []interface{} {
-	trailing := []interface{}{}
-	for _, val := range c.Arg1 {
-		trailing = append(trailing, val)
-	}
-
-	return append([]interface{}{c.Arg0}, trailing...)
+	return []interface{}{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this

--- a/cmd/enterprise-portal/internal/subscriptionsservice/v1.go
+++ b/cmd/enterprise-portal/internal/subscriptionsservice/v1.go
@@ -7,9 +7,10 @@ import (
 
 	"connectrpc.com/connect"
 	"github.com/sourcegraph/log"
+	"golang.org/x/exp/maps"
+
 	sams "github.com/sourcegraph/sourcegraph-accounts-sdk-go"
 	"github.com/sourcegraph/sourcegraph-accounts-sdk-go/scopes"
-	"golang.org/x/exp/maps"
 
 	subscriptionsv1 "github.com/sourcegraph/sourcegraph/lib/enterpriseportal/subscriptions/v1"
 	subscriptionsv1connect "github.com/sourcegraph/sourcegraph/lib/enterpriseportal/subscriptions/v1/v1connect"
@@ -20,6 +21,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/enterprise-portal/internal/database"
 	"github.com/sourcegraph/sourcegraph/cmd/enterprise-portal/internal/dotcomdb"
 	"github.com/sourcegraph/sourcegraph/cmd/enterprise-portal/internal/samsm2m"
+	"github.com/sourcegraph/sourcegraph/internal/collections"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 )
 
@@ -71,12 +73,8 @@ func (s *handlerV1) ListEnterpriseSubscriptions(ctx context.Context, req *connec
 
 	// Validate and process filters.
 	filters := req.Msg.GetFilters()
-	if len(filters) == 0 {
-		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("at least one filter is required"))
-	}
-
-	onlyArchived := false
-	subscriptionIDs := make([]string, 0, len(filters))
+	isArchived := false
+	subscriptionIDs := make(collections.Set[string], len(filters))
 	var iamListObjectOptions *iam.ListObjectsOptions
 	for _, filter := range filters {
 		switch f := filter.GetFilter().(type) {
@@ -87,12 +85,10 @@ func (s *handlerV1) ListEnterpriseSubscriptions(ctx context.Context, req *connec
 					errors.New(`invalid filter: "subscription_id" provided but is empty`),
 				)
 			}
-			subscriptionIDs = append(
-				subscriptionIDs,
-				strings.TrimPrefix(f.SubscriptionId, subscriptionsv1.EnterpriseSubscriptionIDPrefix),
-			)
+			subscriptionIDs.Add(
+				strings.TrimPrefix(f.SubscriptionId, subscriptionsv1.EnterpriseSubscriptionIDPrefix))
 		case *subscriptionsv1.ListEnterpriseSubscriptionsFilter_IsArchived:
-			onlyArchived = f.IsArchived
+			isArchived = f.IsArchived
 		case *subscriptionsv1.ListEnterpriseSubscriptionsFilter_Permission:
 			if f.Permission == nil {
 				return nil, connect.NewError(
@@ -130,34 +126,41 @@ func (s *handlerV1) ListEnterpriseSubscriptions(ctx context.Context, req *connec
 		}
 	}
 
-	// When requested, overwrite subscription IDs with those that have the required
-	// permissions. This makes logical sense because even if a subscription ID is
-	// provided, because it may not be accessible by the subject (and thus be
-	// excluded from the response).
+	// When requested, evaluate the list of subscriptions that match the
+	// filtered permission.
 	if iamListObjectOptions != nil {
 		// Object IDs are in the form of `subscription_cody_analytics:<subscriptionID>`.
 		objectIDs, err := s.store.IAMListObjects(ctx, *iamListObjectOptions)
 		if err != nil {
 			return nil, connectutil.InternalError(ctx, logger, err, "list subscriptions from IAM")
 		}
-		// 🚨 SECURITY: If permissions are used as filter, but we found no results, we
-		// should directly return an empty response to not mistaken as list all.
-		if len(objectIDs) == 0 {
-			return connect.NewResponse(&subscriptionsv1.ListEnterpriseSubscriptionsResponse{}), nil
+		allowedSubscriptionIDs := make(collections.Set[string], len(objectIDs))
+		for _, objectID := range objectIDs {
+			allowedSubscriptionIDs.Add(strings.TrimPrefix(objectID, "subscription_cody_analytics:"))
 		}
 
-		subscriptionIDs = make([]string, 0, len(objectIDs))
-		for _, objectID := range objectIDs {
-			subscriptionIDs = append(subscriptionIDs, strings.TrimPrefix(objectID, "subscription_cody_analytics:"))
+		if !subscriptionIDs.IsEmpty() {
+			// If subscription IDs were provided, we only want to return the
+			// subscriptions that are part of the provided IDs.
+			subscriptionIDs = collections.Intersection(subscriptionIDs, allowedSubscriptionIDs)
+		} else {
+			// Otherwise, only return the allowed subscriptions.
+			subscriptionIDs = allowedSubscriptionIDs
+		}
+
+		// 🚨 SECURITY: If permissions are used as filter, but we found no results, we
+		// should directly return an empty response to not mistaken as list all.
+		if len(subscriptionIDs) == 0 {
+			return connect.NewResponse(&subscriptionsv1.ListEnterpriseSubscriptionsResponse{}), nil
 		}
 	}
 
 	subscriptions, err := s.store.ListEnterpriseSubscriptions(
 		ctx,
 		database.ListEnterpriseSubscriptionsOptions{
-			IDs:          subscriptionIDs,
-			OnlyArchived: onlyArchived,
-			PageSize:     int(req.Msg.GetPageSize()),
+			IDs:        subscriptionIDs.Values(),
+			IsArchived: isArchived,
+			PageSize:   int(req.Msg.GetPageSize()),
 		},
 	)
 	if err != nil {
@@ -165,7 +168,10 @@ func (s *handlerV1) ListEnterpriseSubscriptions(ctx context.Context, req *connec
 	}
 
 	// List from dotcom DB and merge attributes.
-	dotcomSubscriptions, err := s.store.ListDotcomEnterpriseSubscriptions(ctx, subscriptionIDs...)
+	dotcomSubscriptions, err := s.store.ListDotcomEnterpriseSubscriptions(ctx, dotcomdb.ListEnterpriseSubscriptionsOptions{
+		SubscriptionIDs: subscriptionIDs.Values(),
+		IsArchived:      isArchived,
+	})
 	if err != nil {
 		return nil, connectutil.InternalError(ctx, logger, err, "list subscriptions from dotcom DB")
 	}
@@ -174,11 +180,23 @@ func (s *handlerV1) ListEnterpriseSubscriptions(ctx context.Context, req *connec
 		dotcomSubscriptionsSet[s.ID] = s
 	}
 
+	// Add the "real" subscriptions we already track to the results
 	respSubscriptions := make([]*subscriptionsv1.EnterpriseSubscription, 0, len(subscriptions))
 	for _, s := range subscriptions {
 		respSubscriptions = append(
 			respSubscriptions,
 			convertSubscriptionToProto(s, dotcomSubscriptionsSet[s.ID]),
+		)
+		delete(dotcomSubscriptionsSet, s.ID)
+	}
+
+	// Add any remaining dotcom subscriptions to the results set
+	for _, s := range dotcomSubscriptionsSet {
+		respSubscriptions = append(
+			respSubscriptions,
+			convertSubscriptionToProto(&database.Subscription{
+				ID: subscriptionsv1.EnterpriseSubscriptionIDPrefix + s.ID,
+			}, s),
 		)
 	}
 
@@ -295,7 +313,9 @@ func (s *handlerV1) UpdateEnterpriseSubscription(ctx context.Context, req *conne
 	}
 
 	// Double check with the dotcom DB that the subscription ID is valid.
-	subscriptionAttrs, err := s.store.ListDotcomEnterpriseSubscriptions(ctx, subscriptionID)
+	subscriptionAttrs, err := s.store.ListDotcomEnterpriseSubscriptions(ctx, dotcomdb.ListEnterpriseSubscriptionsOptions{
+		SubscriptionIDs: []string{subscriptionID},
+	})
 	if err != nil {
 		return nil, connectutil.InternalError(ctx, logger, err, "get dotcom enterprise subscription")
 	} else if len(subscriptionAttrs) != 1 {
@@ -374,7 +394,9 @@ func (s *handlerV1) UpdateEnterpriseSubscriptionMembership(ctx context.Context, 
 
 	if subscriptionID != "" {
 		// Double check with the dotcom DB that the subscription ID is valid.
-		subscriptionAttrs, err := s.store.ListDotcomEnterpriseSubscriptions(ctx, subscriptionID)
+		subscriptionAttrs, err := s.store.ListDotcomEnterpriseSubscriptions(ctx, dotcomdb.ListEnterpriseSubscriptionsOptions{
+			SubscriptionIDs: []string{subscriptionID},
+		})
 		if err != nil {
 			return nil, connectutil.InternalError(ctx, logger, err, "get dotcom enterprise subscription")
 		} else if len(subscriptionAttrs) != 1 {

--- a/cmd/enterprise-portal/internal/subscriptionsservice/v1_store.go
+++ b/cmd/enterprise-portal/internal/subscriptionsservice/v1_store.go
@@ -32,7 +32,9 @@ type StoreV1 interface {
 	// attributes with the given IDs from dotcom DB. It silently ignores any
 	// non-existent subscription IDs. The caller should check the length of the
 	// returned slice to ensure all requested subscriptions were found.
-	ListDotcomEnterpriseSubscriptions(ctx context.Context, subscriptionIDs ...string) ([]*dotcomdb.SubscriptionAttributes, error)
+	//
+	// If no IDs are provided, it returns all subscriptions.
+	ListDotcomEnterpriseSubscriptions(ctx context.Context, opts dotcomdb.ListEnterpriseSubscriptionsOptions) ([]*dotcomdb.SubscriptionAttributes, error)
 
 	// IntrospectSAMSToken takes a SAMS access token and returns relevant metadata.
 	//
@@ -91,8 +93,8 @@ func (s *storeV1) ListDotcomEnterpriseSubscriptionLicenses(ctx context.Context, 
 	return s.dotcomDB.ListEnterpriseSubscriptionLicenses(ctx, filters, limit)
 }
 
-func (s *storeV1) ListDotcomEnterpriseSubscriptions(ctx context.Context, subscriptionIDs ...string) ([]*dotcomdb.SubscriptionAttributes, error) {
-	return s.dotcomDB.ListEnterpriseSubscriptions(ctx, subscriptionIDs...)
+func (s *storeV1) ListDotcomEnterpriseSubscriptions(ctx context.Context, opts dotcomdb.ListEnterpriseSubscriptionsOptions) ([]*dotcomdb.SubscriptionAttributes, error) {
+	return s.dotcomDB.ListEnterpriseSubscriptions(ctx, opts)
 }
 
 func (s *storeV1) IntrospectSAMSToken(ctx context.Context, token string) (*sams.IntrospectTokenResponse, error) {


### PR DESCRIPTION
Follow-ups to https://github.com/sourcegraph/sourcegraph/pull/63173 I'm running into while working on CORE-169:

1. Intersect permission-allowed subscriptions, instead of always overwriting. I think this is probably desired behaviour, to still allow filtering by subscriptions. If no subscriptions are explicitly listed, _then_ the allowed subscriptions become the set of subscriptions to list.
   1. If a permissions filter is used and the resulting subscription set is empty, we fast-exit with empty result
2. If no subscription list is provided, list all subscriptions. This is safe because permission filter has special fast-path above
3. Fix "is archived" support

## Test plan

Tests, and a manual check - with `sg start dotcom`, exchange for a token:

```sh
sg sams create-client-token \
        -sams https://accounts.sgdev.org \
        -s 'enterprise_portal::subscription::read' \
        -s 'enterprise_portal::codyaccess::read'
```

Query for subscriptions without filters:

```sh
curl --header "Content-Type: application/json" --header 'authorization: bearer sams_at_...' --data '{}' http://localhost:6081/enterpriseportal.subscriptions.v1.SubscriptionsService/ListEnterpriseSubscriptions | jq
```

All subscriptions I have locally get returned ✅ 