### PR TITLE
feat(appliance): local developer mode

### DIFF
--- a/internal/appliance/appliance.go
+++ b/internal/appliance/appliance.go
@@ -21,7 +21,7 @@ type Appliance struct {
 	client                 client.Client
 	namespace              string
 	status                 Status
-	sourcegraph            config.Sourcegraph
+	sourcegraph            *config.Sourcegraph
 	releaseRegistryClient  *releaseregistry.Client
 	latestSupportedVersion string
 	logger                 log.Logger
@@ -58,7 +58,7 @@ func NewAppliance(
 		latestSupportedVersion: latestSupportedVersion,
 		namespace:              namespace,
 		status:                 StatusSetup,
-		sourcegraph:            config.Sourcegraph{},
+		sourcegraph:            &config.Sourcegraph{},
 		logger:                 logger,
 	}
 }

--- a/internal/appliance/config/BUILD.bazel
+++ b/internal/appliance/config/BUILD.bazel
@@ -32,5 +32,9 @@ go_test(
     srcs = ["dev_mode_test.go"],
     embed = [":config"],
     tags = [TAG_INFRA_RELEASE],
-    deps = ["@com_github_stretchr_testify//assert"],
+    deps = [
+        "@com_github_stretchr_testify//assert",
+        "@io_k8s_api//core/v1:core",
+        "@io_k8s_apimachinery//pkg/api/resource",
+    ],
 )

--- a/internal/appliance/config/dev_mode.go
+++ b/internal/appliance/config/dev_mode.go
@@ -1,22 +1,41 @@
 package config
 
-func SetLocalDevMode(sg *Sourcegraph) {
+func (sg *Sourcegraph) SetLocalDevMode() {
 	sg.Spec.Blobstore.ContainerConfig = setBestEffortQOSOnContainer(sg.Spec.Blobstore.ContainerConfig, "blobstore")
+	sg.Spec.Cadvisor.ContainerConfig = setBestEffortQOSOnContainer(sg.Spec.Cadvisor.ContainerConfig, "cadvisor")
+
+	sg.Spec.CodeInsights.ContainerConfig = setBestEffortQOSOnContainer(sg.Spec.CodeInsights.ContainerConfig, "correct-data-dir-permissions")
+	sg.Spec.CodeInsights.ContainerConfig = setBestEffortQOSOnContainer(sg.Spec.CodeInsights.ContainerConfig, "codeinsights")
+	sg.Spec.CodeInsights.ContainerConfig = setBestEffortQOSOnContainer(sg.Spec.CodeInsights.ContainerConfig, "pgsql-exporter")
+
+	sg.Spec.CodeIntel.ContainerConfig = setBestEffortQOSOnContainer(sg.Spec.CodeIntel.ContainerConfig, "correct-data-dir-permissions")
+	sg.Spec.CodeIntel.ContainerConfig = setBestEffortQOSOnContainer(sg.Spec.CodeIntel.ContainerConfig, "codeintel-db")
+	sg.Spec.CodeIntel.ContainerConfig = setBestEffortQOSOnContainer(sg.Spec.CodeIntel.ContainerConfig, "pgsql-exporter")
+
+	sg.Spec.Frontend.ContainerConfig = setBestEffortQOSOnContainer(sg.Spec.Frontend.ContainerConfig, "frontend")
+	sg.Spec.Frontend.ContainerConfig = setBestEffortQOSOnContainer(sg.Spec.Frontend.ContainerConfig, "migrator")
+
 	sg.Spec.GitServer.ContainerConfig = setBestEffortQOSOnContainer(sg.Spec.GitServer.ContainerConfig, "gitserver")
+
+	sg.Spec.IndexedSearch.ContainerConfig = setBestEffortQOSOnContainer(sg.Spec.IndexedSearch.ContainerConfig, "zoekt-webserver")
+	sg.Spec.IndexedSearch.ContainerConfig = setBestEffortQOSOnContainer(sg.Spec.IndexedSearch.ContainerConfig, "zoekt-indexserver")
 
 	sg.Spec.PGSQL.ContainerConfig = setBestEffortQOSOnContainer(sg.Spec.PGSQL.ContainerConfig, "correct-data-dir-permissions")
 	sg.Spec.PGSQL.ContainerConfig = setBestEffortQOSOnContainer(sg.Spec.PGSQL.ContainerConfig, "pgsql")
 	sg.Spec.PGSQL.ContainerConfig = setBestEffortQOSOnContainer(sg.Spec.PGSQL.ContainerConfig, "pgsql-exporter")
+
+	sg.Spec.PreciseCodeIntel.ContainerConfig = setBestEffortQOSOnContainer(sg.Spec.PreciseCodeIntel.ContainerConfig, "precise-code-intel-worker")
+	sg.Spec.Prometheus.ContainerConfig = setBestEffortQOSOnContainer(sg.Spec.Prometheus.ContainerConfig, "prometheus")
+	sg.Spec.RepoUpdater.ContainerConfig = setBestEffortQOSOnContainer(sg.Spec.RepoUpdater.ContainerConfig, "repo-updater")
 
 	sg.Spec.RedisCache.ContainerConfig = setBestEffortQOSOnContainer(sg.Spec.RedisCache.ContainerConfig, "redis-cache")
 	sg.Spec.RedisCache.ContainerConfig = setBestEffortQOSOnContainer(sg.Spec.RedisCache.ContainerConfig, "redis-exporter")
 	sg.Spec.RedisStore.ContainerConfig = setBestEffortQOSOnContainer(sg.Spec.RedisStore.ContainerConfig, "redis-store")
 	sg.Spec.RedisStore.ContainerConfig = setBestEffortQOSOnContainer(sg.Spec.RedisStore.ContainerConfig, "redis-exporter")
 
-	sg.Spec.PreciseCodeIntel.ContainerConfig = setBestEffortQOSOnContainer(sg.Spec.PreciseCodeIntel.ContainerConfig, "precise-code-intel-worker")
 	sg.Spec.Symbols.ContainerConfig = setBestEffortQOSOnContainer(sg.Spec.Symbols.ContainerConfig, "symbols")
 	sg.Spec.SyntectServer.ContainerConfig = setBestEffortQOSOnContainer(sg.Spec.SyntectServer.ContainerConfig, "syntect-server")
-	sg.Spec.RepoUpdater.ContainerConfig = setBestEffortQOSOnContainer(sg.Spec.RepoUpdater.ContainerConfig, "repo-updater")
+	sg.Spec.Worker.ContainerConfig = setBestEffortQOSOnContainer(sg.Spec.Worker.ContainerConfig, "worker")
 }
 
 func setBestEffortQOSOnContainer(ctrConfigs map[string]ContainerConfig, container string) map[string]ContainerConfig {
@@ -25,7 +44,6 @@ func setBestEffortQOSOnContainer(ctrConfigs map[string]ContainerConfig, containe
 	}
 	ctrConfig := ctrConfigs[container]
 	ctrConfig.BestEffortQOS = true
-	ctrConfig.Resources = nil
 	ctrConfigs[container] = ctrConfig
 	return ctrConfigs
 }

--- a/internal/appliance/config/dev_mode_test.go
+++ b/internal/appliance/config/dev_mode_test.go
@@ -4,19 +4,21 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 func TestSetLocalDevMode_CreatesContainerConfigWhereNoneExistedBefore(t *testing.T) {
-	sg := Sourcegraph{}
+	sg := &Sourcegraph{}
 
-	SetLocalDevMode(&sg)
+	sg.SetLocalDevMode()
 	assert.Equal(t, sg.Spec.Blobstore.ContainerConfig, map[string]ContainerConfig{
 		"blobstore": {BestEffortQOS: true},
 	})
 }
 
 func TestSetLocalDevMode_PreservesContainerConfigOtherThanBestEffortQOS(t *testing.T) {
-	sg := Sourcegraph{
+	sg := &Sourcegraph{
 		Spec: SourcegraphSpec{
 			Blobstore: BlobstoreSpec{
 				StandardConfig: StandardConfig{
@@ -25,6 +27,18 @@ func TestSetLocalDevMode_PreservesContainerConfigOtherThanBestEffortQOS(t *testi
 							EnvVars: map[string]string{
 								"foo": "bar",
 							},
+							Resources: &corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:              resource.MustParse("2"),
+									corev1.ResourceMemory:           resource.MustParse("2G"),
+									corev1.ResourceEphemeralStorage: resource.MustParse("4Gi"),
+								},
+								Limits: corev1.ResourceList{
+									corev1.ResourceCPU:              resource.MustParse("2"),
+									corev1.ResourceMemory:           resource.MustParse("4G"),
+									corev1.ResourceEphemeralStorage: resource.MustParse("8Gi"),
+								},
+							},
 						},
 					},
 				},
@@ -32,12 +46,34 @@ func TestSetLocalDevMode_PreservesContainerConfigOtherThanBestEffortQOS(t *testi
 		},
 	}
 
-	SetLocalDevMode(&sg)
+	sg.SetLocalDevMode()
 	assert.Equal(t, sg.Spec.Blobstore.ContainerConfig, map[string]ContainerConfig{
 		"blobstore": {
 			BestEffortQOS: true,
 			EnvVars: map[string]string{
 				"foo": "bar",
+			},
+
+			// We really do want to preserve the resources block, if its already
+			// set, for one reason: in case the admin has overriden
+			// ephemeral-resources. Dev mode only affects CPU and memory, but
+			// this is implemented in
+			// internal/k8s/resource/container/container.go, not here. We set
+			// the BestEffortQOS flag to influence the behavior in that file.
+			// While this is admittedly a bit of a confusing leaky abstraction,
+			// the golden tests should catch any regressions in the interactions
+			// between these 2 bits of code.
+			Resources: &corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:              resource.MustParse("2"),
+					corev1.ResourceMemory:           resource.MustParse("2G"),
+					corev1.ResourceEphemeralStorage: resource.MustParse("4Gi"),
+				},
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:              resource.MustParse("2"),
+					corev1.ResourceMemory:           resource.MustParse("4G"),
+					corev1.ResourceEphemeralStorage: resource.MustParse("8Gi"),
+				},
 			},
 		},
 	})

--- a/internal/appliance/config/spec.go
+++ b/internal/appliance/config/spec.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -98,11 +97,6 @@ type PGSQLSpec struct {
 
 	// DatabaseConnection allows for custom database connection details.
 	DatabaseConnection *DatabaseConnectionSpec `json:"database,omitempty"`
-}
-
-type PostgresExporterSpec struct {
-	// Resources allows for custom resource limits and requests.
-	Resources *corev1.ResourceList `json:"resources,omitempty"`
 }
 
 type PreciseCodeIntelSpec struct {
@@ -231,9 +225,6 @@ type SourcegraphSpec struct {
 
 	// PGSQL defines the desired state of the PostgreSQL database.
 	PGSQL PGSQLSpec `json:"pgsql,omitempty"`
-
-	// PostgresExporter defines the desired state of the Postgres exporter service.
-	PostgresExporter PostgresExporterSpec `json:"postgresExporter,omitempty"`
 
 	// PreciseCodeIntel defines the desired state of the Precise Code Intel service.
 	PreciseCodeIntel PreciseCodeIntelSpec `json:"preciseCodeIntel,omitempty"`

--- a/internal/appliance/dev/integrationtest/integration_test.go
+++ b/internal/appliance/dev/integrationtest/integration_test.go
@@ -66,10 +66,10 @@ func srcValidate(t *testing.T, namespace string) {
 }
 
 func createConfigMap(t *testing.T, namespace string, k8sClient *kubernetes.Clientset, cfg config.SourcegraphSpec) {
-	sg := config.Sourcegraph{
+	sg := &config.Sourcegraph{
 		Spec: cfg,
 	}
-	config.SetLocalDevMode(&sg)
+	sg.SetLocalDevMode()
 	cfgBytes, err := yaml.Marshal(sg)
 	require.NoError(t, err)
 	cfgMap := configmap.NewConfigMap("sg", namespace)

--- a/internal/appliance/html.go
+++ b/internal/appliance/html.go
@@ -16,6 +16,7 @@ import (
 
 const (
 	templateSetup = "web/template/setup.gohtml"
+	formValueOn   = "on"
 )
 
 var (
@@ -84,7 +85,7 @@ func (a *Appliance) postSetupHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	a.sourcegraph.Spec.RequestedVersion = r.FormValue("version")
-	if r.FormValue("external_database") == "yes" {
+	if r.FormValue("external_database") == formValueOn {
 		a.sourcegraph.Spec.PGSQL.DatabaseConnection = &config.DatabaseConnectionSpec{
 			Host:     r.FormValue("pgsqlDBHost"),
 			Port:     r.FormValue("pgsqlDBPort"),
@@ -108,6 +109,10 @@ func (a *Appliance) postSetupHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	// TODO validate user input
+
+	if r.FormValue("dev_mode") == formValueOn {
+		a.sourcegraph.SetLocalDevMode()
+	}
 
 	_, err = a.CreateConfigMap(r.Context(), "sourcegraph-appliance")
 	if err != nil {

--- a/internal/appliance/reconciler/codeintel.go
+++ b/internal/appliance/reconciler/codeintel.go
@@ -227,6 +227,6 @@ func (r *Reconciler) reconcileCodeIntelService(ctx context.Context, sg *config.S
 
 func (r *Reconciler) reconcileCodeIntelServiceAccount(ctx context.Context, sg *config.Sourcegraph, owner client.Object) error {
 	cfg := sg.Spec.CodeIntel
-	sa := serviceaccount.NewServiceAccount("codeintel", sg.Namespace, cfg)
+	sa := serviceaccount.NewServiceAccount("codeintel-db", sg.Namespace, cfg)
 	return reconcileObject(ctx, r, sg.Spec.CodeIntel, &sa, &corev1.ServiceAccount{}, sg, owner)
 }

--- a/internal/appliance/reconciler/gitserver.go
+++ b/internal/appliance/reconciler/gitserver.go
@@ -67,8 +67,6 @@ func (r *Reconciler) reconcileGitServerStatefulSet(ctx context.Context, sg *conf
 				Port: intstr.FromString("rpc"),
 			},
 		},
-		TimeoutSeconds:      5,
-		InitialDelaySeconds: 5,
 	}
 
 	ctr.VolumeMounts = []corev1.VolumeMount{

--- a/internal/appliance/reconciler/indexed_search.go
+++ b/internal/appliance/reconciler/indexed_search.go
@@ -40,7 +40,7 @@ func (r *Reconciler) reconcileIndexedSearcherStatefulSet(ctx context.Context, sg
 	cfg := sg.Spec.IndexedSearch
 
 	webServer := container.NewContainer("zoekt-webserver", cfg, config.ContainerConfig{
-		Image: config.GetDefaultImage(sg, name),
+		Image: config.GetDefaultImage(sg, "indexed-searcher"),
 		Resources: &corev1.ResourceRequirements{
 			Requests: corev1.ResourceList{
 				corev1.ResourceCPU:    resource.MustParse("500m"),

--- a/internal/appliance/reconciler/standard_config_test.go
+++ b/internal/appliance/reconciler/standard_config_test.go
@@ -8,6 +8,7 @@ func (suite *ApplianceTestSuite) TestStandardFeatures() {
 		name string
 	}{
 		{name: "standard/blobstore-with-named-storage-class"},
+		{name: "standard/frontend-with-no-cpu-memory-resources"},
 		{name: "standard/precise-code-intel-with-env-vars"},
 		{name: "standard/redis-with-multiple-custom-images"},
 		{name: "standard/redis-with-storage"},

--- a/internal/appliance/reconciler/testdata/golden-fixtures/codeintel/default.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/codeintel/default.yaml
@@ -435,7 +435,7 @@ resources:
       creationTimestamp: "2024-04-19T00:00:00Z"
       labels:
         deploy: sourcegraph
-      name: codeintel
+      name: codeintel-db
       namespace: NORMALIZED_FOR_TESTING
       ownerReferences:
         - apiVersion: v1

--- a/internal/appliance/reconciler/testdata/golden-fixtures/gitserver/default.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/gitserver/default.yaml
@@ -69,12 +69,11 @@ resources:
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 failureThreshold: 3
-                initialDelaySeconds: 5
                 periodSeconds: 10
                 successThreshold: 1
                 tcpSocket:
                   port: rpc
-                timeoutSeconds: 5
+                timeoutSeconds: 1
               name: gitserver
               ports:
                 - containerPort: 3178

--- a/internal/appliance/reconciler/testdata/golden-fixtures/indexed-search/default.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/indexed-search/default.yaml
@@ -55,7 +55,7 @@ resources:
                   value: http://$(OTEL_AGENT_HOST):4317
                 - name: OPENTELEMETRY_DISABLED
                   value: "false"
-              image: index.docker.io/sourcegraph/indexed-search:5.3.9104
+              image: index.docker.io/sourcegraph/indexed-searcher:5.3.9104
               imagePullPolicy: IfNotPresent
               name: zoekt-webserver
               ports:

--- a/internal/appliance/reconciler/testdata/golden-fixtures/indexed-search/with-replicas.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/indexed-search/with-replicas.yaml
@@ -55,7 +55,7 @@ resources:
                   value: http://$(OTEL_AGENT_HOST):4317
                 - name: OPENTELEMETRY_DISABLED
                   value: "false"
-              image: index.docker.io/sourcegraph/indexed-search:5.3.9104
+              image: index.docker.io/sourcegraph/indexed-searcher:5.3.9104
               imagePullPolicy: IfNotPresent
               name: zoekt-webserver
               ports:

--- a/internal/appliance/reconciler/testdata/golden-fixtures/standard/frontend-with-no-cpu-memory-resources.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/standard/frontend-with-no-cpu-memory-resources.yaml
@@ -1,0 +1,537 @@
+resources:
+  - apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      annotations:
+        appliance.sourcegraph.com/configHash: e9e0837cc01eaabff90d9772835de8fbf79f814f32b58b2bac75ef8bfbc1d93d
+      creationTimestamp: "2024-04-19T00:00:00Z"
+      generation: 1
+      labels:
+        app.kubernetes.io/component: sourcegraph-frontend
+        app.kubernetes.io/name: sourcegraph
+        app.kubernetes.io/version: 5.3.9104
+        deploy: sourcegraph
+      name: sourcegraph-frontend
+      namespace: NORMALIZED_FOR_TESTING
+      ownerReferences:
+        - apiVersion: v1
+          blockOwnerDeletion: true
+          controller: true
+          kind: ConfigMap
+          name: sg
+          uid: NORMALIZED_FOR_TESTING
+      resourceVersion: NORMALIZED_FOR_TESTING
+      uid: NORMALIZED_FOR_TESTING
+    spec:
+      minReadySeconds: 10
+      progressDeadlineSeconds: 600
+      replicas: 2
+      revisionHistoryLimit: 10
+      selector:
+        matchLabels:
+          app: sourcegraph-frontend
+      strategy:
+        rollingUpdate:
+          maxSurge: 2
+          maxUnavailable: 0
+        type: RollingUpdate
+      template:
+        metadata:
+          annotations:
+            kubectl.kubernetes.io/default-container: sourcegraph-frontend
+          creationTimestamp: null
+          labels:
+            app: sourcegraph-frontend
+            deploy: sourcegraph
+          name: sourcegraph-frontend
+        spec:
+          containers:
+            - args:
+                - serve
+              env:
+                - name: DEPLOY_TYPE
+                  value: appliance
+                - name: PGDATABASE
+                  valueFrom:
+                    secretKeyRef:
+                      key: database
+                      name: pgsql-auth
+                - name: PGHOST
+                  valueFrom:
+                    secretKeyRef:
+                      key: host
+                      name: pgsql-auth
+                - name: PGPASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      key: password
+                      name: pgsql-auth
+                - name: PGPORT
+                  valueFrom:
+                    secretKeyRef:
+                      key: port
+                      name: pgsql-auth
+                - name: PGUSER
+                  valueFrom:
+                    secretKeyRef:
+                      key: user
+                      name: pgsql-auth
+                - name: CODEINTEL_PGDATABASE
+                  valueFrom:
+                    secretKeyRef:
+                      key: database
+                      name: codeintel-db-auth
+                - name: CODEINTEL_PGHOST
+                  valueFrom:
+                    secretKeyRef:
+                      key: host
+                      name: codeintel-db-auth
+                - name: CODEINTEL_PGPASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      key: password
+                      name: codeintel-db-auth
+                - name: CODEINTEL_PGPORT
+                  valueFrom:
+                    secretKeyRef:
+                      key: port
+                      name: codeintel-db-auth
+                - name: CODEINTEL_PGUSER
+                  valueFrom:
+                    secretKeyRef:
+                      key: user
+                      name: codeintel-db-auth
+                - name: CODEINSIGHTS_PGDATABASE
+                  valueFrom:
+                    secretKeyRef:
+                      key: database
+                      name: codeinsights-db-auth
+                - name: CODEINSIGHTS_PGHOST
+                  valueFrom:
+                    secretKeyRef:
+                      key: host
+                      name: codeinsights-db-auth
+                - name: CODEINSIGHTS_PGPASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      key: password
+                      name: codeinsights-db-auth
+                - name: CODEINSIGHTS_PGPORT
+                  valueFrom:
+                    secretKeyRef:
+                      key: port
+                      name: codeinsights-db-auth
+                - name: CODEINSIGHTS_PGUSER
+                  valueFrom:
+                    secretKeyRef:
+                      key: user
+                      name: codeinsights-db-auth
+                - name: REDIS_CACHE_ENDPOINT
+                  valueFrom:
+                    secretKeyRef:
+                      key: endpoint
+                      name: redis-cache
+                - name: REDIS_STORE_ENDPOINT
+                  valueFrom:
+                    secretKeyRef:
+                      key: endpoint
+                      name: redis-store
+                - name: OTEL_AGENT_HOST
+                  valueFrom:
+                    fieldRef:
+                      apiVersion: v1
+                      fieldPath: status.hostIP
+                - name: OTEL_EXPORTER_OTLP_ENDPOINT
+                  value: http://$(OTEL_AGENT_HOST):4317
+              image: index.docker.io/sourcegraph/frontend:5.3.9104
+              imagePullPolicy: IfNotPresent
+              livenessProbe:
+                failureThreshold: 3
+                httpGet:
+                  path: /healthz
+                  port: debug
+                  scheme: HTTP
+                initialDelaySeconds: 300
+                periodSeconds: 10
+                successThreshold: 1
+                timeoutSeconds: 5
+              name: frontend
+              ports:
+                - containerPort: 3080
+                  name: http
+                  protocol: TCP
+                - containerPort: 3090
+                  name: http-internal
+                  protocol: TCP
+                - containerPort: 6060
+                  name: debug
+                  protocol: TCP
+              readinessProbe:
+                failureThreshold: 3
+                httpGet:
+                  path: /ready
+                  port: debug
+                  scheme: HTTP
+                periodSeconds: 5
+                successThreshold: 1
+                timeoutSeconds: 5
+              resources:
+                limits:
+                  ephemeral-storage: 8Gi
+                requests:
+                  ephemeral-storage: 4Gi
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                runAsGroup: 101
+                runAsUser: 100
+              terminationMessagePath: /dev/termination-log
+              terminationMessagePolicy: FallbackToLogsOnError
+              volumeMounts:
+                - mountPath: /home/sourcegraph
+                  name: home-dir
+          dnsPolicy: ClusterFirst
+          initContainers:
+            - args:
+                - up
+              env:
+                - name: DEPLOY_TYPE
+                  value: appliance
+                - name: PGDATABASE
+                  valueFrom:
+                    secretKeyRef:
+                      key: database
+                      name: pgsql-auth
+                - name: PGHOST
+                  valueFrom:
+                    secretKeyRef:
+                      key: host
+                      name: pgsql-auth
+                - name: PGPASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      key: password
+                      name: pgsql-auth
+                - name: PGPORT
+                  valueFrom:
+                    secretKeyRef:
+                      key: port
+                      name: pgsql-auth
+                - name: PGUSER
+                  valueFrom:
+                    secretKeyRef:
+                      key: user
+                      name: pgsql-auth
+                - name: CODEINTEL_PGDATABASE
+                  valueFrom:
+                    secretKeyRef:
+                      key: database
+                      name: codeintel-db-auth
+                - name: CODEINTEL_PGHOST
+                  valueFrom:
+                    secretKeyRef:
+                      key: host
+                      name: codeintel-db-auth
+                - name: CODEINTEL_PGPASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      key: password
+                      name: codeintel-db-auth
+                - name: CODEINTEL_PGPORT
+                  valueFrom:
+                    secretKeyRef:
+                      key: port
+                      name: codeintel-db-auth
+                - name: CODEINTEL_PGUSER
+                  valueFrom:
+                    secretKeyRef:
+                      key: user
+                      name: codeintel-db-auth
+                - name: CODEINSIGHTS_PGDATABASE
+                  valueFrom:
+                    secretKeyRef:
+                      key: database
+                      name: codeinsights-db-auth
+                - name: CODEINSIGHTS_PGHOST
+                  valueFrom:
+                    secretKeyRef:
+                      key: host
+                      name: codeinsights-db-auth
+                - name: CODEINSIGHTS_PGPASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      key: password
+                      name: codeinsights-db-auth
+                - name: CODEINSIGHTS_PGPORT
+                  valueFrom:
+                    secretKeyRef:
+                      key: port
+                      name: codeinsights-db-auth
+                - name: CODEINSIGHTS_PGUSER
+                  valueFrom:
+                    secretKeyRef:
+                      key: user
+                      name: codeinsights-db-auth
+              image: index.docker.io/sourcegraph/migrator:5.3.9104
+              imagePullPolicy: IfNotPresent
+              name: migrator
+              resources: {}
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                runAsGroup: 101
+                runAsUser: 100
+              terminationMessagePath: /dev/termination-log
+              terminationMessagePolicy: FallbackToLogsOnError
+          restartPolicy: Always
+          schedulerName: default-scheduler
+          securityContext:
+            fsGroup: 101
+            fsGroupChangePolicy: OnRootMismatch
+            runAsGroup: 101
+            runAsUser: 100
+          serviceAccount: sourcegraph-frontend
+          serviceAccountName: sourcegraph-frontend
+          terminationGracePeriodSeconds: 30
+          volumes:
+            - emptyDir: {}
+              name: home-dir
+    status: {}
+  - apiVersion: v1
+    data:
+      spec: |
+        spec:
+          requestedVersion: "5.3.9104"
+
+          blobstore:
+            disabled: true
+
+          codeInsights:
+            disabled: true
+
+          codeIntel:
+            disabled: true
+
+          frontend:
+            containerConfig:
+              frontend:
+                bestEffortQOS: true
+              migrator:
+                bestEffortQOS: true
+
+          gitServer:
+            disabled: true
+
+          indexedSearch:
+            disabled: true
+
+          openTelemetry:
+            disabled: true
+
+          pgsql:
+            disabled: true
+
+          postgresExporter:
+            disabled: true
+
+          preciseCodeIntel:
+            disabled: true
+
+          redisCache:
+            disabled: true
+
+          redisStore:
+            disabled: true
+
+          repoUpdater:
+            disabled: true
+
+          searcher:
+            disabled: true
+
+          symbols:
+            disabled: true
+
+          syntectServer:
+            disabled: true
+
+          worker:
+            disabled: true
+
+          prometheus:
+            disabled: true
+    kind: ConfigMap
+    metadata:
+      annotations:
+        appliance.sourcegraph.com/currentVersion: 5.3.9104
+        appliance.sourcegraph.com/managed: "true"
+      creationTimestamp: "2024-04-19T00:00:00Z"
+      name: sg
+      namespace: NORMALIZED_FOR_TESTING
+      resourceVersion: NORMALIZED_FOR_TESTING
+      uid: NORMALIZED_FOR_TESTING
+  - apiVersion: rbac.authorization.k8s.io/v1
+    kind: Role
+    metadata:
+      annotations:
+        appliance.sourcegraph.com/configHash: e9e0837cc01eaabff90d9772835de8fbf79f814f32b58b2bac75ef8bfbc1d93d
+      creationTimestamp: "2024-04-19T00:00:00Z"
+      labels:
+        deploy: sourcegraph
+      name: sourcegraph-frontend
+      namespace: NORMALIZED_FOR_TESTING
+      ownerReferences:
+        - apiVersion: v1
+          blockOwnerDeletion: true
+          controller: true
+          kind: ConfigMap
+          name: sg
+          uid: NORMALIZED_FOR_TESTING
+      resourceVersion: NORMALIZED_FOR_TESTING
+      uid: NORMALIZED_FOR_TESTING
+    rules:
+      - apiGroups:
+          - ""
+        resources:
+          - endpoints
+          - services
+        verbs:
+          - get
+          - list
+          - watch
+      - apiGroups:
+          - apps
+        resources:
+          - statefulsets
+        verbs:
+          - get
+          - list
+          - watch
+  - apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      annotations:
+        appliance.sourcegraph.com/configHash: e9e0837cc01eaabff90d9772835de8fbf79f814f32b58b2bac75ef8bfbc1d93d
+      creationTimestamp: "2024-04-19T00:00:00Z"
+      labels:
+        deploy: sourcegraph
+      name: sourcegraph-frontend
+      namespace: NORMALIZED_FOR_TESTING
+      ownerReferences:
+        - apiVersion: v1
+          blockOwnerDeletion: true
+          controller: true
+          kind: ConfigMap
+          name: sg
+          uid: NORMALIZED_FOR_TESTING
+      resourceVersion: NORMALIZED_FOR_TESTING
+      uid: NORMALIZED_FOR_TESTING
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: Role
+      name: sourcegraph-frontend
+    subjects:
+      - kind: ServiceAccount
+        name: sourcegraph-frontend
+        namespace: NORMALIZED_FOR_TESTING
+  - apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      annotations:
+        appliance.sourcegraph.com/configHash: e9e0837cc01eaabff90d9772835de8fbf79f814f32b58b2bac75ef8bfbc1d93d
+      creationTimestamp: "2024-04-19T00:00:00Z"
+      labels:
+        deploy: sourcegraph
+      name: sourcegraph-frontend
+      namespace: NORMALIZED_FOR_TESTING
+      ownerReferences:
+        - apiVersion: v1
+          blockOwnerDeletion: true
+          controller: true
+          kind: ConfigMap
+          name: sg
+          uid: NORMALIZED_FOR_TESTING
+      resourceVersion: NORMALIZED_FOR_TESTING
+      uid: NORMALIZED_FOR_TESTING
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      annotations:
+        appliance.sourcegraph.com/configHash: e9e0837cc01eaabff90d9772835de8fbf79f814f32b58b2bac75ef8bfbc1d93d
+        prometheus.io/port: "6060"
+        sourcegraph.prometheus/scrape: "true"
+      creationTimestamp: "2024-04-19T00:00:00Z"
+      labels:
+        app: sourcegraph-frontend
+        app.kubernetes.io/component: sourcegraph-frontend
+        deploy: sourcegraph
+      name: sourcegraph-frontend
+      namespace: NORMALIZED_FOR_TESTING
+      ownerReferences:
+        - apiVersion: v1
+          blockOwnerDeletion: true
+          controller: true
+          kind: ConfigMap
+          name: sg
+          uid: NORMALIZED_FOR_TESTING
+      resourceVersion: NORMALIZED_FOR_TESTING
+      uid: NORMALIZED_FOR_TESTING
+    spec:
+      clusterIP: NORMALIZED_FOR_TESTING
+      clusterIPs:
+        - NORMALIZED_FOR_TESTING
+      internalTrafficPolicy: Cluster
+      ipFamilies:
+        - IPv4
+      ipFamilyPolicy: SingleStack
+      ports:
+        - name: http
+          port: 30080
+          protocol: TCP
+          targetPort: http
+      selector:
+        app: sourcegraph-frontend
+      sessionAffinity: None
+      type: ClusterIP
+    status:
+      loadBalancer: {}
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      annotations:
+        appliance.sourcegraph.com/configHash: e9e0837cc01eaabff90d9772835de8fbf79f814f32b58b2bac75ef8bfbc1d93d
+      creationTimestamp: "2024-04-19T00:00:00Z"
+      labels:
+        app: sourcegraph-frontend-internal
+        app.kubernetes.io/component: sourcegraph-frontend-internal
+        deploy: sourcegraph
+      name: sourcegraph-frontend-internal
+      namespace: NORMALIZED_FOR_TESTING
+      ownerReferences:
+        - apiVersion: v1
+          blockOwnerDeletion: true
+          controller: true
+          kind: ConfigMap
+          name: sg
+          uid: NORMALIZED_FOR_TESTING
+      resourceVersion: NORMALIZED_FOR_TESTING
+      uid: NORMALIZED_FOR_TESTING
+    spec:
+      clusterIP: NORMALIZED_FOR_TESTING
+      clusterIPs:
+        - NORMALIZED_FOR_TESTING
+      internalTrafficPolicy: Cluster
+      ipFamilies:
+        - IPv4
+      ipFamilyPolicy: SingleStack
+      ports:
+        - name: http-internal
+          port: 80
+          protocol: TCP
+          targetPort: http-internal
+      selector:
+        app: sourcegraph-frontend
+      sessionAffinity: None
+      type: ClusterIP
+    status:
+      loadBalancer: {}

--- a/internal/appliance/reconciler/testdata/sg/standard/frontend-with-no-cpu-memory-resources.yaml
+++ b/internal/appliance/reconciler/testdata/sg/standard/frontend-with-no-cpu-memory-resources.yaml
@@ -1,0 +1,60 @@
+spec:
+  requestedVersion: "5.3.9104"
+
+  blobstore:
+    disabled: true
+
+  codeInsights:
+    disabled: true
+
+  codeIntel:
+    disabled: true
+
+  frontend:
+    containerConfig:
+      frontend:
+        bestEffortQOS: true
+      migrator:
+        bestEffortQOS: true
+
+  gitServer:
+    disabled: true
+
+  indexedSearch:
+    disabled: true
+
+  openTelemetry:
+    disabled: true
+
+  pgsql:
+    disabled: true
+
+  postgresExporter:
+    disabled: true
+
+  preciseCodeIntel:
+    disabled: true
+
+  redisCache:
+    disabled: true
+
+  redisStore:
+    disabled: true
+
+  repoUpdater:
+    disabled: true
+
+  searcher:
+    disabled: true
+
+  symbols:
+    disabled: true
+
+  syntectServer:
+    disabled: true
+
+  worker:
+    disabled: true
+
+  prometheus:
+    disabled: true

--- a/internal/appliance/web/template/setup.gohtml
+++ b/internal/appliance/web/template/setup.gohtml
@@ -141,6 +141,18 @@
 
         </div>
     </div>
+    <div class="row">
+       <div class="col">
+           <label for="dev_mode" class="fw-bold">Developer mode</label>
+           <p>Would you like to run in development mode (No resource requests/limits)?</p>
+       </div>
+        <div class="col">
+            <div class="form-switch mb-3">
+                <input class="form-check-input" data-bs-toggle="collapse" type="checkbox" id="dev_mode" name="dev_mode">
+                <label class="form-check-label" for="dev_mode">Use dev mode</label>
+            </div>
+        </div>
+    </div>
     <button type="submit" class="btn btn-primary">Start Setup</button>
 </form>
 

--- a/internal/k8s/resource/container/container.go
+++ b/internal/k8s/resource/container/container.go
@@ -34,7 +34,11 @@ func NewContainer(name string, cfg config.StandardComponent, defaults config.Con
 			ctr.Env = append(ctr.Env, newSortedEnvVars(ctrConfig.EnvVars)...)
 
 			if ctrConfig.BestEffortQOS {
-				ctr.Resources = corev1.ResourceRequirements{}
+				// Preserve ephemeral-storage
+				delete(ctr.Resources.Requests, corev1.ResourceCPU)
+				delete(ctr.Resources.Requests, corev1.ResourceMemory)
+				delete(ctr.Resources.Limits, corev1.ResourceCPU)
+				delete(ctr.Resources.Limits, corev1.ResourceMemory)
 			} else if ctrConfig.Resources != nil {
 				ctr.Resources = *ctrConfig.Resources
 			}


### PR DESCRIPTION
**feat(appliance): local developer mode**

- Expose a toggle in the web UI to enable dev mode
- dev mode is currently defined as: no container resource
  requests/limits



**fix(appliance): fix misconfigurations to 2 services**

Gitserver: the configured probe timeouts were too aggressive.
Indexed-search: the image name was wrong

Both of these were drift from Helm that we didn't catch. Luckily the
appliance is still pre-release!

---

Closes https://linear.app/sourcegraph/issue/REL-199/populate-accurate-list-of-versions-to-install

~Draft until base branch merged, but should be reviewable independently~

## Test plan

The behavior of the dev mode toggle is unit tested and golden tests cover its integration with the reconcile loop.

<!-- All pull requests REQUIRE a test plan: https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles -->


## Changelog

- Local developer mode for appliance config authors.

<!--
1. Ensure your pull request title is formatted as: $type($domain): $what
2. Add bullet list items for each additional detail you want to cover (see example below)
3. You can edit this after the pull request was merged, as long as release shipping it hasn't been promoted to the public.
4. For more information, please see this how-to https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c?

Audience: TS/CSE > Customers > Teammates (in that order).

Cheat sheet: $type = chore|fix|feat $domain: source|search|ci|release|plg|cody|local|...
-->

<!--
Example:

Title: fix(search): parse quotes with the appropriate context
Changelog section:

## Changelog

- When a quote is used with regexp pattern type, then ...
- Refactored underlying code.
-->
