### PR TITLE
Remove old intent API

### DIFF
--- a/cmd/frontend/graphqlbackend/cody_context.go
+++ b/cmd/frontend/graphqlbackend/cody_context.go
@@ -8,7 +8,6 @@ import (
 
 type CodyContextResolver interface {
 	GetCodyContext(ctx context.Context, args GetContextArgs) ([]ContextResultResolver, error)
-	GetCodyIntent(ctx context.Context, args GetIntentArgs) (IntentResolver, error)
 	ChatIntent(ctx context.Context, args ChatIntentArgs) (IntentResolver, error)
 }
 

--- a/cmd/frontend/graphqlbackend/cody_context.go
+++ b/cmd/frontend/graphqlbackend/cody_context.go
@@ -9,6 +9,7 @@ import (
 type CodyContextResolver interface {
 	GetCodyContext(ctx context.Context, args GetContextArgs) ([]ContextResultResolver, error)
 	GetCodyIntent(ctx context.Context, args GetIntentArgs) (IntentResolver, error)
+	ChatIntent(ctx context.Context, args ChatIntentArgs) (IntentResolver, error)
 }
 
 type GetContextArgs struct {
@@ -19,6 +20,10 @@ type GetContextArgs struct {
 }
 
 type GetIntentArgs struct {
+	Query string
+}
+
+type ChatIntentArgs struct {
 	Query string
 }
 

--- a/cmd/frontend/graphqlbackend/cody_context.graphql
+++ b/cmd/frontend/graphqlbackend/cody_context.graphql
@@ -21,7 +21,7 @@ extend type Query {
         textResultsCount: Int!
     ): [CodyContextResult!]!
     """
-    EXPERIMENTAL: Detect intent for a given Cody query.
+    DEPRECATED: use chatIntent. This will be deleted in a future release.
     """
     getCodyIntent(
         """
@@ -29,6 +29,16 @@ extend type Query {
         """
         query: String!
     ): CodyIntentResponse!
+
+    """
+    EXPERIMENTAL: Detect intent for a given Cody chat query.
+    """
+    chatIntent(
+        """
+        A natural language query string.
+        """
+        query: String!
+    ): ChatIntentResponse!
 }
 
 """
@@ -64,6 +74,20 @@ type FileChunkContext {
 EXPERIMENTAL: A response from Cody intent detection API.
 """
 type CodyIntentResponse {
+    """
+    Intent that was detected
+    """
+    intent: String!
+    """
+    Confidence score as assigned by the intent detection model
+    """
+    score: Float!
+}
+
+"""
+EXPERIMENTAL: A response from Cody Chat intent detection API.
+"""
+type ChatIntentResponse {
     """
     Intent that was detected
     """

--- a/cmd/frontend/graphqlbackend/cody_context.graphql
+++ b/cmd/frontend/graphqlbackend/cody_context.graphql
@@ -20,15 +20,6 @@ extend type Query {
         """
         textResultsCount: Int!
     ): [CodyContextResult!]!
-    """
-    DEPRECATED: use chatIntent. This will be deleted in a future release.
-    """
-    getCodyIntent(
-        """
-        A natural language query string.
-        """
-        query: String!
-    ): CodyIntentResponse!
 
     """
     EXPERIMENTAL: Detect intent for a given Cody chat query.
@@ -68,20 +59,6 @@ type FileChunkContext {
     The relevant content of the file from start line to end line.
     """
     chunkContent: String!
-}
-
-"""
-EXPERIMENTAL: A response from Cody intent detection API.
-"""
-type CodyIntentResponse {
-    """
-    Intent that was detected
-    """
-    intent: String!
-    """
-    Confidence score as assigned by the intent detection model
-    """
-    score: Float!
 }
 
 """

--- a/cmd/frontend/internal/context/resolvers/context.go
+++ b/cmd/frontend/internal/context/resolvers/context.go
@@ -81,9 +81,14 @@ func (r *Resolver) GetCodyContext(ctx context.Context, args graphqlbackend.GetCo
 	})
 }
 
-// GetCodyIntent is a quick-and-dirty way to expose our intent detection model to Cody clients.
-// Yes, it does things that should not be done in production code - for now it is just a proof of concept for demos.
+// GetCodyIntent is deprecated: use ChatIntent instead.
 func (r *Resolver) GetCodyIntent(ctx context.Context, args graphqlbackend.GetIntentArgs) (graphqlbackend.IntentResolver, error) {
+	return r.ChatIntent(ctx, graphqlbackend.ChatIntentArgs{Query: args.Query})
+}
+
+// ChatIntent is a quick-and-dirty way to expose our intent detection model to Cody clients.
+// Yes, it does things that should not be done in production code - for now it is just a proof of concept for demos.
+func (r *Resolver) ChatIntent(ctx context.Context, args graphqlbackend.ChatIntentArgs) (graphqlbackend.IntentResolver, error) {
 	if !dotcom.SourcegraphDotComMode() {
 		return nil, errors.New("this feature is only available on sourcegraph.com")
 	}
@@ -118,7 +123,7 @@ func (r *Resolver) GetCodyIntent(ctx context.Context, args graphqlbackend.GetInt
 	if err != nil {
 		return nil, err
 	}
-	return &getIntentResponse{intent: intentResponse.Intent, score: intentResponse.Score}, nil
+	return &chatIntentResponse{intent: intentResponse.Intent, score: intentResponse.Score}, nil
 }
 
 type intentApiRequest struct {
@@ -130,15 +135,15 @@ type intentApiResponse struct {
 	Score  float64 `json:"score"`
 }
 
-type getIntentResponse struct {
+type chatIntentResponse struct {
 	intent string
 	score  float64
 }
 
-func (r *getIntentResponse) Intent() string {
+func (r *chatIntentResponse) Intent() string {
 	return r.intent
 }
-func (r *getIntentResponse) Score() float64 {
+func (r *chatIntentResponse) Score() float64 {
 	return r.score
 }
 

--- a/cmd/frontend/internal/context/resolvers/context.go
+++ b/cmd/frontend/internal/context/resolvers/context.go
@@ -81,11 +81,6 @@ func (r *Resolver) GetCodyContext(ctx context.Context, args graphqlbackend.GetCo
 	})
 }
 
-// GetCodyIntent is deprecated: use ChatIntent instead.
-func (r *Resolver) GetCodyIntent(ctx context.Context, args graphqlbackend.GetIntentArgs) (graphqlbackend.IntentResolver, error) {
-	return r.ChatIntent(ctx, graphqlbackend.ChatIntentArgs{Query: args.Query})
-}
-
 // ChatIntent is a quick-and-dirty way to expose our intent detection model to Cody clients.
 // Yes, it does things that should not be done in production code - for now it is just a proof of concept for demos.
 func (r *Resolver) ChatIntent(ctx context.Context, args graphqlbackend.ChatIntentArgs) (graphqlbackend.IntentResolver, error) {


### PR DESCRIPTION
This removes the old name of Intent API (once clients have been removed).


## Test plan
- tested locally


## Changelog

<!--
1. Ensure your pull request title is formatted as: $type($domain): $what
2. Add bullet list items for each additional detail you want to cover (see example below)
3. You can edit this after the pull request was merged, as long as release shipping it hasn't been promoted to the public.
4. For more information, please see this how-to https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c?

Audience: TS/CSE > Customers > Teammates (in that order).

Cheat sheet: $type = chore|fix|feat $domain: source|search|ci|release|plg|cody|local|...
-->

<!--
Example:

Title: fix(search): parse quotes with the appropriate context
Changelog section:

## Changelog

- When a quote is used with regexp pattern type, then ...
- Refactored underlying code.
-->
