### PR TITLE
chore(bazel): bump rules_js to address permissions denied warning

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -35,9 +35,9 @@ http_archive(
 
 http_archive(
     name = "aspect_rules_js",
-    sha256 = "3dfccf2713288e0518c0485b65574ca66426c6e06495299abe6f5c64e3bc6314",
-    strip_prefix = "rules_js-2.0.0-rc3",
-    url = "https://github.com/aspect-build/rules_js/releases/download/v2.0.0-rc3/rules_js-v2.0.0-rc3.tar.gz",
+    sha256 = "3bad4ab669d4d38d0d137275b946a46ce6f8f17fecc6c7affba64966a9054246",
+    strip_prefix = "rules_js-2.0.0-rc5",
+    url = "https://github.com/aspect-build/rules_js/releases/download/v2.0.0-rc5/rules_js-v2.0.0-rc5.tar.gz",
 )
 
 http_archive(
@@ -197,7 +197,7 @@ rules_js_dependencies()
 
 load("@aspect_rules_js//js:toolchains.bzl", "rules_js_register_toolchains")
 
-rules_js_register_toolchains(node_version = "20.8.0")
+rules_js_register_toolchains(node_version = "20.8.1")
 
 # rules_js npm setup ============================
 load("@aspect_rules_js//npm:repositories.bzl", "npm_translate_lock")


### PR DESCRIPTION
Previously we were having soft-warnings around permissions in badly made npm packages
```
(21:31:30) WARNING: Remote Cache: /mnt/ephemeral/output/__main__/execroot/__main__/bazel-out/k8-fastbuild/bin/node_modules/.aspect_rules_js/its-fine@1.1.1_react_18.1.0/node_modules/its-fine/src/index.tsx (Permission denied)
```
When trying to enable compact execution log, this becomes a hard fail
```
(14:44:58) ERROR: /mnt/ephemeral/workdir/sourcegraph/sourcegraph/BUILD.bazel:33:22: Extracting npm package its-fine@1.1.1_react_18.1.0 failed: IOException while logging spawn: /mnt/ephemeral/output/__main__/execroot/__main__/bazel-out/k8-fastbuild/bin/node_modules/.aspect_rules_js/its-fine@1.1.1_react_18.1.0/node_modules/its-fine/dist/index.cjs (Permission denied)
```
This bump should fix that

## Test plan

CI still builds successfully


## Changelog

