### PR TITLE
chore(ci): emit compact executon log in CI

### DIFF
--- a/.aspect/bazelrc/ci.sourcegraph.bazelrc
+++ b/.aspect/bazelrc/ci.sourcegraph.bazelrc
@@ -59,6 +59,8 @@ test --build_event_binary_file_path_conversion=false
 test --build_event_binary_file_upload_mode=wait_for_upload_complete
 test --build_event_publish_all_actions=true
 
+common --experimental_execution_log_compact_file=execution_log.zstd
+
 # These likely perform faster locally than the overhead of pulling/pushing from/to the remote cache,
 # as well as being able to reduce how much we push to the cache
 common --modify_execution_info=CopyDirectory=+no-remote,CopyToDirectory=+no-remote,CopyFile=+no-remote

--- a/.aspect/workflows/config.yaml
+++ b/.aspect/workflows/config.yaml
@@ -26,6 +26,7 @@ tasks:
         - -//testing/...
       artifact_paths:
         - build_event_log.bin
+        - execution_log.zstd
   - test:
       name: Integration/E2E
       targets:
@@ -36,6 +37,7 @@ tasks:
         - //testing:codeintel_integration_test
       artifact_paths:
         - build_event_log.bin
+        - execution_log.zstd
   - delivery:
       auto_deliver: true
       icon: 'ship'

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /bazel-*
 .bazelrc-nix
 build_event_log.bin
+execution_log.zstd
 
 # Vim
 *.swp

--- a/dev/ci/internal/ci/images_operations.go
+++ b/dev/ci/internal/ci/images_operations.go
@@ -132,7 +132,7 @@ func bazelPushImagesCmd(c Config, isCandidate bool, opts ...bk.StepOpt) func(*bk
 				bk.Env("PROD_REGISTRY", prodRegistry),
 				bk.Env("ADDITIONAL_PROD_REGISTRIES", additionalProdRegistry),
 				bk.Cmd(bazelStampedCmd(fmt.Sprintf(`build $$(bazel --bazelrc=%s --bazelrc=.aspect/bazelrc/ci.sourcegraph.bazelrc query 'kind("oci_push rule", //...)')`, bazelRC))),
-				bk.ArtifactPaths("build_event_log.bin"),
+				bk.ArtifactPaths("build_event_log.bin", "execution_log.zstd"),
 				bk.AnnotatedCmd(
 					"./dev/ci/push_all.sh",
 					bk.AnnotatedCmdOpts{


### PR DESCRIPTION
Second attempt at https://github.com/sourcegraph/sourcegraph/pull/61760, we can start using these to dig into action cache misses etc

## Test plan

CI passes green


## Changelog

