### PR TITLE
Add language ID to private metadata for v2 codeintel events (for in p…

### DIFF
--- a/client/shared/src/codeintel/legacy-extensions/telemetry.ts
+++ b/client/shared/src/codeintel/legacy-extensions/telemetry.ts
@@ -77,7 +77,7 @@ export class TelemetryEmitter {
                 },
                 privateMetadata: {
                     languageId: this.languageID,
-                }
+                },
             })
         } catch {
             // Older version of Sourcegraph may have not registered this

--- a/client/shared/src/codeintel/legacy-extensions/telemetry.ts
+++ b/client/shared/src/codeintel/legacy-extensions/telemetry.ts
@@ -75,6 +75,9 @@ export class TelemetryEmitter {
                     durationMs: this.elapsed(),
                     repositoryId: this.repoID,
                 },
+                privateMetadata: {
+                    languageId: this.languageID,
+                }
             })
         } catch {
             // Older version of Sourcegraph may have not registered this


### PR DESCRIPTION
…orduct analytics)

As part of the v1 -> v2 telemetry transition, in product analytics ("IPA") aka admin analytics pages need to all be updated as well.

The codeintel IPA page shows codeintel actions by language. We aren't capturing this metadata for v2 events. This PR adds it to private metadata (since this is only needed on the instance itself).


## Test plan

CI
