### PR TITLE
chore (analytics): update in-product (admin) analytics to use v2 telemetry instead of the deprecated v1

### DIFF
--- a/internal/adminanalytics/codeinsights.go
+++ b/internal/adminanalytics/codeinsights.go
@@ -20,7 +20,7 @@ func (c *CodeInsights) InsightHovers() (*AnalyticsFetcher, error) {
 	nodesQuery, summaryQuery, err := makeEventLogsQueries(
 		c.DateRange,
 		c.Grouping,
-		[]string{"InsightHover"},
+		[]string{"insight.hover"},
 	)
 	if err != nil {
 		return nil, err
@@ -43,7 +43,7 @@ func (c *CodeInsights) InsightDataPointClicks() (*AnalyticsFetcher, error) {
 	nodesQuery, summaryQuery, err := makeEventLogsQueries(
 		c.DateRange,
 		c.Grouping,
-		[]string{"InsightDataPointClick"},
+		[]string{"insight.dataPoint.click"},
 	)
 	if err != nil {
 		return nil, err

--- a/internal/adminanalytics/codeintel.go
+++ b/internal/adminanalytics/codeintel.go
@@ -17,7 +17,7 @@ type CodeIntel struct {
 }
 
 func (s *CodeIntel) ReferenceClicks() (*AnalyticsFetcher, error) {
-	nodesQuery, summaryQuery, err := makeEventLogsQueries(s.DateRange, s.Grouping, []string{"findReferences"})
+	nodesQuery, summaryQuery, err := makeEventLogsQueries(s.DateRange, s.Grouping, []string{"blob.findReferences.executed"})
 	if err != nil {
 		return nil, err
 	}
@@ -34,7 +34,7 @@ func (s *CodeIntel) ReferenceClicks() (*AnalyticsFetcher, error) {
 }
 
 func (s *CodeIntel) DefinitionClicks() (*AnalyticsFetcher, error) {
-	nodesQuery, summaryQuery, err := makeEventLogsQueries(s.DateRange, s.Grouping, []string{"goToDefinition.preloaded", "goToDefinition"})
+	nodesQuery, summaryQuery, err := makeEventLogsQueries(s.DateRange, s.Grouping, []string{"blob.goToDefinition.preloaded.executed", "blob.goToDefinition.executed"})
 	if err != nil {
 		return nil, err
 	}
@@ -51,8 +51,8 @@ func (s *CodeIntel) DefinitionClicks() (*AnalyticsFetcher, error) {
 }
 
 func (s *CodeIntel) InAppEvents() (*AnalyticsFetcher, error) {
-	sourceCond := sqlf.Sprintf("source = 'WEB'")
-	nodesQuery, summaryQuery, err := makeEventLogsQueries(s.DateRange, s.Grouping, []string{"goToDefinition.preloaded", "goToDefinition", "findReferences"}, sourceCond)
+	sourceCond := sqlf.Sprintf("source = 'server.web'")
+	nodesQuery, summaryQuery, err := makeEventLogsQueries(s.DateRange, s.Grouping, []string{"blob.goToDefinition.preloaded.executed", "blob.goToDefinition.executed", "blob.findReferences.executed"}, sourceCond)
 	if err != nil {
 		return nil, err
 	}
@@ -69,8 +69,8 @@ func (s *CodeIntel) InAppEvents() (*AnalyticsFetcher, error) {
 }
 
 func (s *CodeIntel) CodeHostEvents() (*AnalyticsFetcher, error) {
-	sourceCond := sqlf.Sprintf("source = 'CODEHOSTINTEGRATION'")
-	nodesQuery, summaryQuery, err := makeEventLogsQueries(s.DateRange, s.Grouping, []string{"goToDefinition.preloaded", "goToDefinition", "findReferences"}, sourceCond)
+	sourceCond := sqlf.Sprintf("source != 'server.web'")
+	nodesQuery, summaryQuery, err := makeEventLogsQueries(s.DateRange, s.Grouping, []strin{"blob.goToDefinition.preloaded.executed", "blob.goToDefinition.executed", "blob.findReferences.executed"}, sourceCond)
 	if err != nil {
 		return nil, err
 	}
@@ -88,10 +88,10 @@ func (s *CodeIntel) CodeHostEvents() (*AnalyticsFetcher, error) {
 
 func (s *CodeIntel) SearchBasedEvents() (*AnalyticsFetcher, error) {
 	nodesQuery, summaryQuery, err := makeEventLogsQueries(s.DateRange, s.Grouping, []string{
-		"codeintel.searchDefinitions",
-		"codeintel.searchDefinitions.xrepo",
-		"codeintel.searchReferences",
-		"codeintel.searchReferences.xrepo",
+		"blob.codeintel.searchDefinitions",
+		"blob.codeintel.searchDefinitions.xrepo",
+		"blob.codeintel.searchReferences",
+		"blob.codeintel.searchReferences.xrepo",
 	})
 	if err != nil {
 		return nil, err
@@ -110,10 +110,10 @@ func (s *CodeIntel) SearchBasedEvents() (*AnalyticsFetcher, error) {
 
 func (s *CodeIntel) PreciseEvents() (*AnalyticsFetcher, error) {
 	nodesQuery, summaryQuery, err := makeEventLogsQueries(s.DateRange, s.Grouping, []string{
-		"codeintel.lsifDefinitions",
-		"codeintel.lsifDefinitions.xrepo",
-		"codeintel.lsifReferences",
-		"codeintel.lsifReferences.xrepo",
+		"blob.codeintel.lsifDefinitions",
+		"blob.codeintel.lsifDefinitions.xrepo",
+		"blob.codeintel.lsifReferences",
+		"blob.codeintel.lsifReferences.xrepo",
 	})
 	if err != nil {
 		return nil, err
@@ -132,10 +132,10 @@ func (s *CodeIntel) PreciseEvents() (*AnalyticsFetcher, error) {
 
 func (s *CodeIntel) CrossRepoEvents() (*AnalyticsFetcher, error) {
 	nodesQuery, summaryQuery, err := makeEventLogsQueries(s.DateRange, s.Grouping, []string{
-		"codeintel.searchDefinitions.xrepo",
-		"codeintel.searchReferences.xrepo",
-		"codeintel.lsifDefinitions.xrepo",
-		"codeintel.lsifReferences.xrepo",
+		"blob.codeintel.searchDefinitions.xrepo",
+		"blob.codeintel.searchReferences.xrepo",
+		"blob.codeintel.lsifDefinitions.xrepo",
+		"blob.codeintel.lsifReferences.xrepo",
 	})
 	if err != nil {
 		return nil, err

--- a/internal/adminanalytics/codeintelbylanguage.go
+++ b/internal/adminanalytics/codeintelbylanguage.go
@@ -41,14 +41,14 @@ func GetCodeIntelByLanguage(ctx context.Context, db database.DB, cache bool, dat
 			WHERE
 				timestamp BETWEEN $1 AND $2 AND
 				name IN (
-					'codeintel.searchDefinitions',
-					'codeintel.searchDefinitions.xrepo',
-					'codeintel.searchReferences',
-					'codeintel.searchReferences.xrepo',
-					'codeintel.lsifDefinitions',
-					'codeintel.lsifDefinitions.xrepo',
-					'codeintel.lsifReferences',
-					'codeintel.lsifReferences.xrepo'
+					'blob.codeintel.searchDefinitions',
+					'blob.codeintel.searchDefinitions.xrepo',
+					'blob.codeintel.searchReferences',
+					'blob.codeintel.searchReferences.xrepo',
+					'blob.codeintel.lsifDefinitions',
+					'blob.codeintel.lsifDefinitions.xrepo',
+					'blob.codeintel.lsifReferences',
+					'blob.codeintel.lsifReferences.xrepo'
 				)
 		) sub
 		GROUP BY language, precision;

--- a/internal/adminanalytics/codeinteltoprepositories.go
+++ b/internal/adminanalytics/codeinteltoprepositories.go
@@ -45,23 +45,23 @@ func GetCodeIntelTopRepositories(ctx context.Context, db database.DB, cache bool
 			SELECT *
 			FROM (
 				SELECT
-					(argument->>'repositoryId')::int AS repo_id,
+					(public_argument->>'repositoryId')::int AS repo_id,
 					(argument->>'languageId')::text AS lang,
 					(
 						CASE
-						WHEN name = 'codeintel.lsifDefinitions.xrepo'                                      THEN 'crossRepo'
-						WHEN name = 'codeintel.lsifDefinitions'                                            THEN 'precise'
-						WHEN name = 'codeintel.lsifReferences.xrepo'                                       THEN 'crossRepo'
-						WHEN name = 'codeintel.lsifReferences'                                             THEN 'precise'
-						WHEN name = 'codeintel.searchDefinitions.xrepo'                                    THEN 'crossRepo'
-						WHEN name = 'codeintel.searchReferences.xrepo'                                     THEN 'crossRepo'
-						WHEN name = 'findReferences'                    AND source = 'CODEHOSTINTEGRATION' THEN 'codeHost'
-						WHEN name = 'findReferences'                    AND source = 'WEB'                 THEN 'inApp'
-						WHEN name = 'goToDefinition.preloaded'          AND source = 'CODEHOSTINTEGRATION' THEN 'codeHost'
-						WHEN name = 'goToDefinition.preloaded'          AND source = 'WEB'                 THEN 'inApp'
-						WHEN name = 'goToDefinition'                    AND source = 'CODEHOSTINTEGRATION' THEN 'codeHost'
-						WHEN name = 'goToDefinition'                    AND source = 'WEB'                 THEN 'inApp'
-						WHEN name = 'codeintel.searchDefinitions'                                          THEN 'inApp'
+						WHEN name = 'blob.codeintel.lsifDefinitions.xrepo'                              THEN 'crossRepo'
+						WHEN name = 'blob.codeintel.lsifDefinitions'                                    THEN 'precise'
+						WHEN name = 'blob.codeintel.lsifReferences.xrepo'                               THEN 'crossRepo'
+						WHEN name = 'blob.codeintel.lsifReferences'                                     THEN 'precise'
+						WHEN name = 'blob.codeintel.searchDefinitions.xrepo'                            THEN 'crossRepo'
+						WHEN name = 'blob.codeintel.searchReferences.xrepo'                             THEN 'crossRepo'
+						WHEN name = 'blob.findReferences.executed'           AND source != 'server.web' THEN 'codeHost'
+						WHEN name = 'blob.findReferences.executed'           AND source = 'server.web'  THEN 'inApp'
+						WHEN name = 'blob.goToDefinition.preloaded.executed' AND source != 'server.web' THEN 'codeHost'
+						WHEN name = 'blob.goToDefinition.preloaded.executed' AND source = 'server.web'  THEN 'inApp'
+						WHEN name = 'blob.goToDefinition.executed'           AND source != 'server.web' THEN 'codeHost'
+						WHEN name = 'blob.goToDefinition.executed'           AND source = 'server.web'  THEN 'inApp'
+						WHEN name = 'blob.codeintel.searchDefinitions'                                  THEN 'inApp'
 						ELSE NULL
 						END
 					) AS kind,
@@ -83,11 +83,11 @@ func GetCodeIntelTopRepositories(ctx context.Context, db database.DB, cache bool
 			kind,
 			(
 				CASE
-				WHEN name = 'codeintel.lsifDefinitions.xrepo' THEN 'precise'
-				WHEN name = 'codeintel.lsifDefinitions'       THEN 'precise'
-				WHEN name = 'codeintel.lsifHover'             THEN 'precise'
-				WHEN name = 'codeintel.lsifReferences.xrepo'  THEN 'precise'
-				WHEN name = 'codeintel.lsifReferences'        THEN 'precise'
+				WHEN name = 'blob.codeintel.lsifDefinitions.xrepo' THEN 'precise'
+				WHEN name = 'blob.codeintel.lsifDefinitions'       THEN 'precise'
+				WHEN name = 'blob.codeintel.lsifHover'             THEN 'precise'
+				WHEN name = 'blob.codeintel.lsifReferences.xrepo'  THEN 'precise'
+				WHEN name = 'blob.codeintel.lsifReferences'        THEN 'precise'
 				ELSE                                               'search-based'
 				END
 			) AS precision,

--- a/internal/adminanalytics/notebooks.go
+++ b/internal/adminanalytics/notebooks.go
@@ -15,7 +15,7 @@ type Notebooks struct {
 }
 
 func (s *Notebooks) Creations() (*AnalyticsFetcher, error) {
-	nodesQuery, summaryQuery, err := makeEventLogsQueries(s.DateRange, s.Grouping, []string{"SearchNotebookCreated"})
+	nodesQuery, summaryQuery, err := makeEventLogsQueries(s.DateRange, s.Grouping, []string{"notebook.create"})
 	if err != nil {
 		return nil, err
 	}
@@ -32,7 +32,7 @@ func (s *Notebooks) Creations() (*AnalyticsFetcher, error) {
 }
 
 func (s *Notebooks) Views() (*AnalyticsFetcher, error) {
-	nodesQuery, summaryQuery, err := makeEventLogsQueries(s.DateRange, s.Grouping, []string{"SearchNotebookPageViewed"})
+	nodesQuery, summaryQuery, err := makeEventLogsQueries(s.DateRange, s.Grouping, []string{"notebook.view"})
 	if err != nil {
 		return nil, err
 	}
@@ -50,8 +50,8 @@ func (s *Notebooks) Views() (*AnalyticsFetcher, error) {
 
 func (s *Notebooks) BlockRuns() (*AnalyticsFetcher, error) {
 	nodesQuery, summaryQuery, err := makeEventLogsQueries(s.DateRange, s.Grouping, []string{
-		"SearchNotebookRunAllBlocks",
-		"SearchNotebookRunBlock",
+		"notebook.blocks.runAll",
+		"notebook.block.run",
 	})
 	if err != nil {
 		return nil, err

--- a/internal/adminanalytics/search.go
+++ b/internal/adminanalytics/search.go
@@ -15,7 +15,7 @@ type Search struct {
 }
 
 func (s *Search) Searches() (*AnalyticsFetcher, error) {
-	nodesQuery, summaryQuery, err := makeEventLogsQueries(s.DateRange, s.Grouping, []string{"SearchResultsQueried"})
+	nodesQuery, summaryQuery, err := makeEventLogsQueries(s.DateRange, s.Grouping, []string{"search.results.query"})
 	if err != nil {
 		return nil, err
 	}
@@ -32,7 +32,7 @@ func (s *Search) Searches() (*AnalyticsFetcher, error) {
 }
 
 func (s *Search) ResultClicks() (*AnalyticsFetcher, error) {
-	nodesQuery, summaryQuery, err := makeEventLogsQueries(s.DateRange, s.Grouping, []string{"SearchResultClicked"})
+	nodesQuery, summaryQuery, err := makeEventLogsQueries(s.DateRange, s.Grouping, []string{"search.result.area.click"})
 	if err != nil {
 		return nil, err
 	}
@@ -48,7 +48,7 @@ func (s *Search) ResultClicks() (*AnalyticsFetcher, error) {
 }
 
 func (s *Search) FileViews() (*AnalyticsFetcher, error) {
-	nodesQuery, summaryQuery, err := makeEventLogsQueries(s.DateRange, s.Grouping, []string{"ViewBlob"})
+	nodesQuery, summaryQuery, err := makeEventLogsQueries(s.DateRange, s.Grouping, []string{"blob.view", "repo.blob.view"})
 	if err != nil {
 		return nil, err
 	}
@@ -66,11 +66,8 @@ func (s *Search) FileViews() (*AnalyticsFetcher, error) {
 
 func (s *Search) FileOpens() (*AnalyticsFetcher, error) {
 	nodesQuery, summaryQuery, err := makeEventLogsQueries(s.DateRange, s.Grouping, []string{
-		"GoToCodeHostClicked",
-		"vscode.open.file",
-		"openInAtom.open.file",
-		"openineditor.open.file",
-		"openInWebstorm.open.file",
+		"repo.goToCodeHost.click",
+		"blob.openInEditor.click",
 	})
 	if err != nil {
 		return nil, err
@@ -88,7 +85,7 @@ func (s *Search) FileOpens() (*AnalyticsFetcher, error) {
 }
 
 func (s *Search) CodeCopied() (*AnalyticsFetcher, error) {
-	nodesQuery, summaryQuery, err := makeEventLogsQueries(s.DateRange, s.Grouping, []string{"CodeCopied"})
+	nodesQuery, summaryQuery, err := makeEventLogsQueries(s.DateRange, s.Grouping, []string{"code.copy", "repo.blob.code.copy", "notebook.code.copy"})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR converts most in-product analytics (aka admin analytics) pages to use v2 telemetry results instead of v1. This is an essential step on the path to retiring v1.

I'd love to get this merged sooner rather than later, though it will take time. Several steps remain in closing out the IPA section, including:

* Adding v2 telemetry to browser extensions and the non-Cody editor extensions (for the /analytics/extensions page to be updated).
* [Adding language ID for codeintel events](https://github.com/sourcegraph/sourcegraph/pull/63421).
* Adding (and validating) v2 telemetry in the new svelte webapp. Several parts of this IPA code will have to change to support that.
* Waiting 93 days to merge for v2 telemetry to fully populate. We provide 3 months of history in IPA, and since v1 and v2 are living side by side for now, we can't just take a simple sum of the event counts—we have to record at least 3 months of v2 telemetry before changing over for the charts to not look empty. I think it's acceptable to wait until 7/31 to merge given that will be roughly the three month anniversary of the largest set of changes going live (and the extra time for releasing, upgrading, etc. will fill in the stragglers)

## Test plan

* Tested locally to ensure it runs without error.
* All queries that populate these charts were tested directly against a duplicate of the S2 `event_logs` table. While not all counts matched _exactly_, variances were immaterial. 
* CI.

## Changelog
