### PR TITLE
chore(batch-changes): remove beta badge from batch changes

### DIFF
--- a/client/web/src/enterprise/batches/batch-spec/header/BatchChangeHeader.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/header/BatchChangeHeader.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 import classNames from 'classnames'
 
-import { PageHeader, FeedbackBadge } from '@sourcegraph/wildcard'
+import { PageHeader } from '@sourcegraph/wildcard'
 
 import { BatchChangesIcon } from '../../../../batches/icons'
 
@@ -22,7 +22,6 @@ export const BatchChangeHeader: React.FC<BatchChangeHeaderProps> = ({ className,
     <PageHeader
         className={classNames('flex-1 pb-2', styles.header, className)}
         description={description || 'Run and manage large-scale changes across many repositories.'}
-        annotation={<FeedbackBadge status="beta" feedback={{ mailto: 'support@sourcegraph.com' }} />}
     >
         <PageHeader.Heading as="h2" styleAs="h1">
             <PageHeader.Breadcrumb icon={BatchChangesIcon} />


### PR DESCRIPTION
Closes SRCH-609

This removes the Beta badge from SSBC pages.

![CleanShot 2024-06-21 at 22 09 25@2x](https://github.com/sourcegraph/sourcegraph/assets/25608335/a3ce2202-dd5e-4193-b878-62e6687b0a9d)

![CleanShot 2024-06-21 at 22 09 20@2x](https://github.com/sourcegraph/sourcegraph/assets/25608335/37c85e43-0305-436c-874b-d5b98a23f14d)


## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles -->

Accessing Batch Changes shouldn't display the Beta badge label anymore.


## Changelog

- Remove Beta badge from Batch Changes pages.
