### PR TITLE
chore/enterpriseportal: split database package

### DIFF
--- a/cmd/enterprise-portal/internal/database/BUILD.bazel
+++ b/cmd/enterprise-portal/internal/database/BUILD.bazel
@@ -1,4 +1,3 @@
-load("//dev:go_defs.bzl", "go_test")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
@@ -6,11 +5,12 @@ go_library(
     srcs = [
         "database.go",
         "migrate.go",
-        "subscriptions.go",
     ],
     importpath = "github.com/sourcegraph/sourcegraph/cmd/enterprise-portal/internal/database",
     visibility = ["//cmd/enterprise-portal:__subpackages__"],
     deps = [
+        "//cmd/enterprise-portal/internal/database/internal/tables",
+        "//cmd/enterprise-portal/internal/database/subscriptions",
         "//lib/errors",
         "//lib/managedservicesplatform/runtime",
         "//lib/redislock",
@@ -21,35 +21,10 @@ go_library(
         "@io_gorm_driver_postgres//:postgres",
         "@io_gorm_gorm//:gorm",
         "@io_gorm_gorm//logger",
-        "@io_gorm_gorm//schema",
         "@io_gorm_plugin_opentelemetry//tracing",
         "@io_opentelemetry_go_otel//:otel",
         "@io_opentelemetry_go_otel//attribute",
         "@io_opentelemetry_go_otel//codes",
         "@io_opentelemetry_go_otel_trace//:trace",
-    ],
-)
-
-go_test(
-    name = "database_test",
-    srcs = [
-        "main_test.go",
-        "subscriptions_test.go",
-    ],
-    embed = [":database"],
-    tags = [
-        # Test requires localhost database
-        "requires-network",
-    ],
-    deps = [
-        "//internal/database/dbtest",
-        "@com_github_google_uuid//:uuid",
-        "@com_github_jackc_pgx_v5//:pgx",
-        "@com_github_jackc_pgx_v5//pgxpool",
-        "@com_github_stretchr_testify//assert",
-        "@com_github_stretchr_testify//require",
-        "@io_gorm_driver_postgres//:postgres",
-        "@io_gorm_gorm//:gorm",
-        "@io_gorm_gorm//schema",
     ],
 )

--- a/cmd/enterprise-portal/internal/database/BUILD.bazel
+++ b/cmd/enterprise-portal/internal/database/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
         "migrate.go",
     ],
     importpath = "github.com/sourcegraph/sourcegraph/cmd/enterprise-portal/internal/database",
+    tags = [TAG_INFRA_CORESERVICES],
     visibility = ["//cmd/enterprise-portal:__subpackages__"],
     deps = [
         "//cmd/enterprise-portal/internal/database/internal/tables",

--- a/cmd/enterprise-portal/internal/database/database.go
+++ b/cmd/enterprise-portal/internal/database/database.go
@@ -9,10 +9,11 @@ import (
 	"github.com/redis/go-redis/v9"
 	"github.com/sourcegraph/log"
 	"go.opentelemetry.io/otel"
-	"gorm.io/gorm/schema"
 
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 	"github.com/sourcegraph/sourcegraph/lib/managedservicesplatform/runtime"
+
+	"github.com/sourcegraph/sourcegraph/cmd/enterprise-portal/internal/database/subscriptions"
 )
 
 var databaseTracer = otel.Tracer("enterprise-portal/internal/database")
@@ -22,13 +23,8 @@ type DB struct {
 	db *pgxpool.Pool
 }
 
-func (db *DB) Subscriptions() *SubscriptionsStore {
-	return newSubscriptionsStore(db.db)
-}
-
-// ⚠️ WARNING: This list is meant to be read-only.
-var allTables = []schema.Tabler{
-	&Subscription{},
+func (db *DB) Subscriptions() *subscriptions.Store {
+	return subscriptions.NewStore(db.db)
 }
 
 func databaseName(msp bool) string {

--- a/cmd/enterprise-portal/internal/database/databasetest/BUILD.bazel
+++ b/cmd/enterprise-portal/internal/database/databasetest/BUILD.bazel
@@ -1,0 +1,16 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "databasetest",
+    srcs = ["databasetest.go"],
+    importpath = "github.com/sourcegraph/sourcegraph/cmd/enterprise-portal/internal/database/databasetest",
+    visibility = ["//cmd/enterprise-portal:__subpackages__"],
+    deps = [
+        "//internal/database/dbtest",
+        "@com_github_jackc_pgx_v5//pgxpool",
+        "@com_github_stretchr_testify//require",
+        "@io_gorm_driver_postgres//:postgres",
+        "@io_gorm_gorm//:gorm",
+        "@io_gorm_gorm//schema",
+    ],
+)

--- a/cmd/enterprise-portal/internal/database/databasetest/BUILD.bazel
+++ b/cmd/enterprise-portal/internal/database/databasetest/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "databasetest",
     srcs = ["databasetest.go"],
     importpath = "github.com/sourcegraph/sourcegraph/cmd/enterprise-portal/internal/database/databasetest",
+    tags = [TAG_INFRA_CORESERVICES],
     visibility = ["//cmd/enterprise-portal:__subpackages__"],
     deps = [
         "//internal/database/dbtest",

--- a/cmd/enterprise-portal/internal/database/internal/tables/BUILD.bazel
+++ b/cmd/enterprise-portal/internal/database/internal/tables/BUILD.bazel
@@ -1,0 +1,12 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "tables",
+    srcs = ["tables.go"],
+    importpath = "github.com/sourcegraph/sourcegraph/cmd/enterprise-portal/internal/database/internal/tables",
+    visibility = ["//cmd/enterprise-portal:__subpackages__"],
+    deps = [
+        "//cmd/enterprise-portal/internal/database/subscriptions",
+        "@io_gorm_gorm//schema",
+    ],
+)

--- a/cmd/enterprise-portal/internal/database/internal/tables/BUILD.bazel
+++ b/cmd/enterprise-portal/internal/database/internal/tables/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "tables",
     srcs = ["tables.go"],
     importpath = "github.com/sourcegraph/sourcegraph/cmd/enterprise-portal/internal/database/internal/tables",
+    tags = [TAG_INFRA_CORESERVICES],
     visibility = ["//cmd/enterprise-portal:__subpackages__"],
     deps = [
         "//cmd/enterprise-portal/internal/database/subscriptions",

--- a/cmd/enterprise-portal/internal/database/internal/tables/tables.go
+++ b/cmd/enterprise-portal/internal/database/internal/tables/tables.go
@@ -1,0 +1,14 @@
+package tables
+
+import (
+	"gorm.io/gorm/schema"
+
+	"github.com/sourcegraph/sourcegraph/cmd/enterprise-portal/internal/database/subscriptions"
+)
+
+// ⚠️ WARNING: This list is meant to be read-only.
+func AllTables() []schema.Tabler {
+	return []schema.Tabler{
+		&subscriptions.Subscription{},
+	}
+}

--- a/cmd/enterprise-portal/internal/database/internal/tables/tables.go
+++ b/cmd/enterprise-portal/internal/database/internal/tables/tables.go
@@ -6,8 +6,10 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/enterprise-portal/internal/database/subscriptions"
 )
 
+// All tables provisioned for the Enterprise Portal database are defined here.
+//
 // ⚠️ WARNING: This list is meant to be read-only.
-func AllTables() []schema.Tabler {
+func All() []schema.Tabler {
 	return []schema.Tabler{
 		&subscriptions.Subscription{},
 	}

--- a/cmd/enterprise-portal/internal/database/migrate.go
+++ b/cmd/enterprise-portal/internal/database/migrate.go
@@ -19,6 +19,8 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 	"github.com/sourcegraph/sourcegraph/lib/managedservicesplatform/runtime"
 	"github.com/sourcegraph/sourcegraph/lib/redislock"
+
+	"github.com/sourcegraph/sourcegraph/cmd/enterprise-portal/internal/database/internal/tables"
 )
 
 // maybeMigrate runs the auto-migration for the database when needed based on
@@ -96,7 +98,7 @@ func maybeMigrate(ctx context.Context, logger log.Logger, contract runtime.Contr
 				Logger: gormlogger.Default.LogMode(gormlogger.Warn),
 			})
 			// Auto-migrate database table definitions.
-			for _, table := range allTables {
+			for _, table := range tables.AllTables() {
 				err := sess.AutoMigrate(table)
 				if err != nil {
 					return errors.Wrapf(err, "auto migrating table for %s", errors.Safe(fmt.Sprintf("%T", table)))

--- a/cmd/enterprise-portal/internal/database/migrate.go
+++ b/cmd/enterprise-portal/internal/database/migrate.go
@@ -98,7 +98,7 @@ func maybeMigrate(ctx context.Context, logger log.Logger, contract runtime.Contr
 				Logger: gormlogger.Default.LogMode(gormlogger.Warn),
 			})
 			// Auto-migrate database table definitions.
-			for _, table := range tables.AllTables() {
+			for _, table := range tables.All() {
 				err := sess.AutoMigrate(table)
 				if err != nil {
 					return errors.Wrapf(err, "auto migrating table for %s", errors.Safe(fmt.Sprintf("%T", table)))

--- a/cmd/enterprise-portal/internal/database/subscriptions/BUILD.bazel
+++ b/cmd/enterprise-portal/internal/database/subscriptions/BUILD.bazel
@@ -1,0 +1,28 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("//dev:go_defs.bzl", "go_test")
+
+go_library(
+    name = "subscriptions",
+    srcs = ["subscriptions.go"],
+    importpath = "github.com/sourcegraph/sourcegraph/cmd/enterprise-portal/internal/database/subscriptions",
+    visibility = ["//cmd/enterprise-portal:__subpackages__"],
+    deps = [
+        "//lib/errors",
+        "@com_github_jackc_pgx_v5//:pgx",
+        "@com_github_jackc_pgx_v5//pgxpool",
+    ],
+)
+
+go_test(
+    name = "subscriptions_test",
+    srcs = ["subscriptions_test.go"],
+    deps = [
+        ":subscriptions",
+        "//cmd/enterprise-portal/internal/database/databasetest",
+        "//cmd/enterprise-portal/internal/database/internal/tables",
+        "@com_github_google_uuid//:uuid",
+        "@com_github_jackc_pgx_v5//:pgx",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/cmd/enterprise-portal/internal/database/subscriptions/BUILD.bazel
+++ b/cmd/enterprise-portal/internal/database/subscriptions/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     name = "subscriptions",
     srcs = ["subscriptions.go"],
     importpath = "github.com/sourcegraph/sourcegraph/cmd/enterprise-portal/internal/database/subscriptions",
+    tags = [TAG_INFRA_CORESERVICES],
     visibility = ["//cmd/enterprise-portal:__subpackages__"],
     deps = [
         "//lib/errors",
@@ -16,6 +17,10 @@ go_library(
 go_test(
     name = "subscriptions_test",
     srcs = ["subscriptions_test.go"],
+    tags = [
+        TAG_INFRA_CORESERVICES,
+        "requires-network",
+    ],
     deps = [
         ":subscriptions",
         "//cmd/enterprise-portal/internal/database/databasetest",

--- a/cmd/enterprise-portal/internal/database/subscriptions/subscriptions_test.go
+++ b/cmd/enterprise-portal/internal/database/subscriptions/subscriptions_test.go
@@ -18,7 +18,7 @@ func TestSubscriptionsStore(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	db := databasetest.NewTestDB(t, "enterprise-portal", "SubscriptionsStore", tables.AllTables()...)
+	db := databasetest.NewTestDB(t, "enterprise-portal", "SubscriptionsStore", tables.All()...)
 
 	for _, tc := range []struct {
 		name string
@@ -29,7 +29,7 @@ func TestSubscriptionsStore(t *testing.T) {
 		{"Get", SubscriptionsStoreGet},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			databasetest.ClearTablesAfterTest(t, db, tables.AllTables()...)
+			databasetest.ClearTablesAfterTest(t, db, tables.All()...)
 			tc.test(t, ctx, subscriptions.NewStore(db))
 		})
 		if t.Failed() {

--- a/cmd/enterprise-portal/internal/database/subscriptions/subscriptions_test.go
+++ b/cmd/enterprise-portal/internal/database/subscriptions/subscriptions_test.go
@@ -1,4 +1,4 @@
-package database
+package subscriptions_test
 
 import (
 	"context"
@@ -8,28 +8,29 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/sourcegraph/sourcegraph/cmd/enterprise-portal/internal/database/databasetest"
+	"github.com/sourcegraph/sourcegraph/cmd/enterprise-portal/internal/database/internal/tables"
+	"github.com/sourcegraph/sourcegraph/cmd/enterprise-portal/internal/database/subscriptions"
 )
 
 func TestSubscriptionsStore(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	db := newSubscriptionsStore(newTestDB(t, "enterprise-portal", "SubscriptionsStore", allTables...))
+	db := databasetest.NewTestDB(t, "enterprise-portal", "SubscriptionsStore", tables.AllTables()...)
 
 	for _, tc := range []struct {
 		name string
-		test func(t *testing.T, ctx context.Context, s *SubscriptionsStore)
+		test func(t *testing.T, ctx context.Context, s *subscriptions.Store)
 	}{
 		{"List", SubscriptionsStoreList},
 		{"Upsert", SubscriptionsStoreUpsert},
 		{"Get", SubscriptionsStoreGet},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			t.Cleanup(func() {
-				err := clearTables(t, db.db, allTables...)
-				require.NoError(t, err)
-			})
-			tc.test(t, ctx, db)
+			databasetest.ClearTablesAfterTest(t, db, tables.AllTables()...)
+			tc.test(t, ctx, subscriptions.NewStore(db))
 		})
 		if t.Failed() {
 			break
@@ -37,76 +38,76 @@ func TestSubscriptionsStore(t *testing.T) {
 	}
 }
 
-func SubscriptionsStoreList(t *testing.T, ctx context.Context, s *SubscriptionsStore) {
+func SubscriptionsStoreList(t *testing.T, ctx context.Context, s *subscriptions.Store) {
 	// Create test records.
 	s1, err := s.Upsert(
 		ctx,
 		uuid.New().String(),
-		UpsertSubscriptionOptions{InstanceDomain: "s1.sourcegraph.com"},
+		subscriptions.UpsertSubscriptionOptions{InstanceDomain: "s1.sourcegraph.com"},
 	)
 	require.NoError(t, err)
 	s2, err := s.Upsert(
 		ctx,
 		uuid.New().String(),
-		UpsertSubscriptionOptions{InstanceDomain: "s2.sourcegraph.com"},
+		subscriptions.UpsertSubscriptionOptions{InstanceDomain: "s2.sourcegraph.com"},
 	)
 	require.NoError(t, err)
 	_, err = s.Upsert(
 		ctx,
 		uuid.New().String(),
-		UpsertSubscriptionOptions{InstanceDomain: "s3.sourcegraph.com"},
+		subscriptions.UpsertSubscriptionOptions{InstanceDomain: "s3.sourcegraph.com"},
 	)
 	require.NoError(t, err)
 
 	t.Run("list by IDs", func(t *testing.T) {
-		subscriptions, err := s.List(ctx, ListEnterpriseSubscriptionsOptions{IDs: []string{s1.ID, s2.ID}})
+		ss, err := s.List(ctx, subscriptions.ListEnterpriseSubscriptionsOptions{IDs: []string{s1.ID, s2.ID}})
 		require.NoError(t, err)
-		require.Len(t, subscriptions, 2)
-		assert.Equal(t, s1.ID, subscriptions[0].ID)
-		assert.Equal(t, s2.ID, subscriptions[1].ID)
+		require.Len(t, ss, 2)
+		assert.Equal(t, s1.ID, ss[0].ID)
+		assert.Equal(t, s2.ID, ss[1].ID)
 
 		t.Run("no match", func(t *testing.T) {
-			subscriptions, err = s.List(ctx, ListEnterpriseSubscriptionsOptions{IDs: []string{"1234"}})
+			ss, err = s.List(ctx, subscriptions.ListEnterpriseSubscriptionsOptions{IDs: []string{"1234"}})
 			require.NoError(t, err)
-			require.Len(t, subscriptions, 0)
+			require.Len(t, ss, 0)
 		})
 	})
 
 	t.Run("list by instance domains", func(t *testing.T) {
-		subscriptions, err := s.List(ctx, ListEnterpriseSubscriptionsOptions{
+		ss, err := s.List(ctx, subscriptions.ListEnterpriseSubscriptionsOptions{
 			InstanceDomains: []string{s1.InstanceDomain, s2.InstanceDomain}},
 		)
 		require.NoError(t, err)
-		require.Len(t, subscriptions, 2)
-		assert.Equal(t, s1.ID, subscriptions[0].ID)
-		assert.Equal(t, s2.ID, subscriptions[1].ID)
+		require.Len(t, ss, 2)
+		assert.Equal(t, s1.ID, ss[0].ID)
+		assert.Equal(t, s2.ID, ss[1].ID)
 
 		t.Run("no match", func(t *testing.T) {
-			subscriptions, err = s.List(ctx, ListEnterpriseSubscriptionsOptions{InstanceDomains: []string{"1234"}})
+			ss, err = s.List(ctx, subscriptions.ListEnterpriseSubscriptionsOptions{InstanceDomains: []string{"1234"}})
 			require.NoError(t, err)
-			require.Len(t, subscriptions, 0)
+			require.Len(t, ss, 0)
 		})
 	})
 
 	t.Run("list with page size", func(t *testing.T) {
-		subscriptions, err := s.List(
+		ss, err := s.List(
 			ctx,
-			ListEnterpriseSubscriptionsOptions{
+			subscriptions.ListEnterpriseSubscriptionsOptions{
 				IDs:      []string{s1.ID, s2.ID}, // Two matching but only of them will be returned.
 				PageSize: 1,
 			},
 		)
 		require.NoError(t, err)
-		assert.Len(t, subscriptions, 1)
+		assert.Len(t, ss, 1)
 	})
 }
 
-func SubscriptionsStoreUpsert(t *testing.T, ctx context.Context, s *SubscriptionsStore) {
+func SubscriptionsStoreUpsert(t *testing.T, ctx context.Context, s *subscriptions.Store) {
 	// Create initial test record.
 	s1, err := s.Upsert(
 		ctx,
 		uuid.New().String(),
-		UpsertSubscriptionOptions{InstanceDomain: "s1.sourcegraph.com"},
+		subscriptions.UpsertSubscriptionOptions{InstanceDomain: "s1.sourcegraph.com"},
 	)
 	require.NoError(t, err)
 
@@ -116,30 +117,30 @@ func SubscriptionsStoreUpsert(t *testing.T, ctx context.Context, s *Subscription
 	assert.Equal(t, s1.InstanceDomain, got.InstanceDomain)
 
 	t.Run("noop", func(t *testing.T) {
-		got, err = s.Upsert(ctx, s1.ID, UpsertSubscriptionOptions{})
+		got, err = s.Upsert(ctx, s1.ID, subscriptions.UpsertSubscriptionOptions{})
 		require.NoError(t, err)
 		assert.Equal(t, s1.InstanceDomain, got.InstanceDomain)
 	})
 
 	t.Run("update", func(t *testing.T) {
-		got, err = s.Upsert(ctx, s1.ID, UpsertSubscriptionOptions{InstanceDomain: "s1-new.sourcegraph.com"})
+		got, err = s.Upsert(ctx, s1.ID, subscriptions.UpsertSubscriptionOptions{InstanceDomain: "s1-new.sourcegraph.com"})
 		require.NoError(t, err)
 		assert.Equal(t, "s1-new.sourcegraph.com", got.InstanceDomain)
 	})
 
 	t.Run("force update", func(t *testing.T) {
-		got, err = s.Upsert(ctx, s1.ID, UpsertSubscriptionOptions{ForceUpdate: true})
+		got, err = s.Upsert(ctx, s1.ID, subscriptions.UpsertSubscriptionOptions{ForceUpdate: true})
 		require.NoError(t, err)
 		assert.Empty(t, got.InstanceDomain)
 	})
 }
 
-func SubscriptionsStoreGet(t *testing.T, ctx context.Context, s *SubscriptionsStore) {
+func SubscriptionsStoreGet(t *testing.T, ctx context.Context, s *subscriptions.Store) {
 	// Create initial test record.
 	s1, err := s.Upsert(
 		ctx,
 		uuid.New().String(),
-		UpsertSubscriptionOptions{InstanceDomain: "s1.sourcegraph.com"},
+		subscriptions.UpsertSubscriptionOptions{InstanceDomain: "s1.sourcegraph.com"},
 	)
 	require.NoError(t, err)
 

--- a/cmd/enterprise-portal/internal/subscriptionsservice/BUILD.bazel
+++ b/cmd/enterprise-portal/internal/subscriptionsservice/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
     deps = [
         "//cmd/enterprise-portal/internal/connectutil",
         "//cmd/enterprise-portal/internal/database",
+        "//cmd/enterprise-portal/internal/database/subscriptions",
         "//cmd/enterprise-portal/internal/dotcomdb",
         "//cmd/enterprise-portal/internal/samsm2m",
         "//internal/collections",
@@ -42,7 +43,7 @@ go_test(
     ],
     embed = [":subscriptionsservice"],
     deps = [
-        "//cmd/enterprise-portal/internal/database",
+        "//cmd/enterprise-portal/internal/database/subscriptions",
         "//cmd/enterprise-portal/internal/dotcomdb",
         "//cmd/enterprise-portal/internal/samsm2m",
         "//lib/enterpriseportal/subscriptions/v1:subscriptions",

--- a/cmd/enterprise-portal/internal/subscriptionsservice/adapters.go
+++ b/cmd/enterprise-portal/internal/subscriptionsservice/adapters.go
@@ -3,7 +3,7 @@ package subscriptionsservice
 import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 
-	"github.com/sourcegraph/sourcegraph/cmd/enterprise-portal/internal/database"
+	"github.com/sourcegraph/sourcegraph/cmd/enterprise-portal/internal/database/subscriptions"
 	"github.com/sourcegraph/sourcegraph/cmd/enterprise-portal/internal/dotcomdb"
 	subscriptionsv1 "github.com/sourcegraph/sourcegraph/lib/enterpriseportal/subscriptions/v1"
 	"github.com/sourcegraph/sourcegraph/lib/managedservicesplatform/iam"
@@ -46,7 +46,7 @@ func convertLicenseAttrsToProto(attrs *dotcomdb.LicenseAttributes) *subscription
 	}
 }
 
-func convertSubscriptionToProto(subscription *database.Subscription, attrs *dotcomdb.SubscriptionAttributes) *subscriptionsv1.EnterpriseSubscription {
+func convertSubscriptionToProto(subscription *subscriptions.Subscription, attrs *dotcomdb.SubscriptionAttributes) *subscriptionsv1.EnterpriseSubscription {
 	// Dotcom equivalent missing is surprising, but let's not panic just yet
 	if attrs == nil {
 		attrs = &dotcomdb.SubscriptionAttributes{

--- a/cmd/enterprise-portal/internal/subscriptionsservice/mocks_test.go
+++ b/cmd/enterprise-portal/internal/subscriptionsservice/mocks_test.go
@@ -12,7 +12,7 @@ import (
 
 	sourcegraphaccountssdkgo "github.com/sourcegraph/sourcegraph-accounts-sdk-go"
 	v1 "github.com/sourcegraph/sourcegraph-accounts-sdk-go/clients/v1"
-	database "github.com/sourcegraph/sourcegraph/cmd/enterprise-portal/internal/database"
+	subscriptions "github.com/sourcegraph/sourcegraph/cmd/enterprise-portal/internal/database/subscriptions"
 	dotcomdb "github.com/sourcegraph/sourcegraph/cmd/enterprise-portal/internal/dotcomdb"
 	v11 "github.com/sourcegraph/sourcegraph/lib/enterpriseportal/subscriptions/v1"
 	iam "github.com/sourcegraph/sourcegraph/lib/managedservicesplatform/iam"
@@ -96,12 +96,12 @@ func NewMockStoreV1() *MockStoreV1 {
 			},
 		},
 		ListEnterpriseSubscriptionsFunc: &StoreV1ListEnterpriseSubscriptionsFunc{
-			defaultHook: func(context.Context, database.ListEnterpriseSubscriptionsOptions) (r0 []*database.Subscription, r1 error) {
+			defaultHook: func(context.Context, subscriptions.ListEnterpriseSubscriptionsOptions) (r0 []*subscriptions.Subscription, r1 error) {
 				return
 			},
 		},
 		UpsertEnterpriseSubscriptionFunc: &StoreV1UpsertEnterpriseSubscriptionFunc{
-			defaultHook: func(context.Context, string, database.UpsertSubscriptionOptions) (r0 *database.Subscription, r1 error) {
+			defaultHook: func(context.Context, string, subscriptions.UpsertSubscriptionOptions) (r0 *subscriptions.Subscription, r1 error) {
 				return
 			},
 		},
@@ -148,12 +148,12 @@ func NewStrictMockStoreV1() *MockStoreV1 {
 			},
 		},
 		ListEnterpriseSubscriptionsFunc: &StoreV1ListEnterpriseSubscriptionsFunc{
-			defaultHook: func(context.Context, database.ListEnterpriseSubscriptionsOptions) ([]*database.Subscription, error) {
+			defaultHook: func(context.Context, subscriptions.ListEnterpriseSubscriptionsOptions) ([]*subscriptions.Subscription, error) {
 				panic("unexpected invocation of MockStoreV1.ListEnterpriseSubscriptions")
 			},
 		},
 		UpsertEnterpriseSubscriptionFunc: &StoreV1UpsertEnterpriseSubscriptionFunc{
-			defaultHook: func(context.Context, string, database.UpsertSubscriptionOptions) (*database.Subscription, error) {
+			defaultHook: func(context.Context, string, subscriptions.UpsertSubscriptionOptions) (*subscriptions.Subscription, error) {
 				panic("unexpected invocation of MockStoreV1.UpsertEnterpriseSubscription")
 			},
 		},
@@ -961,15 +961,15 @@ func (c StoreV1ListDotcomEnterpriseSubscriptionsFuncCall) Results() []interface{
 // ListEnterpriseSubscriptions method of the parent MockStoreV1 instance is
 // invoked.
 type StoreV1ListEnterpriseSubscriptionsFunc struct {
-	defaultHook func(context.Context, database.ListEnterpriseSubscriptionsOptions) ([]*database.Subscription, error)
-	hooks       []func(context.Context, database.ListEnterpriseSubscriptionsOptions) ([]*database.Subscription, error)
+	defaultHook func(context.Context, subscriptions.ListEnterpriseSubscriptionsOptions) ([]*subscriptions.Subscription, error)
+	hooks       []func(context.Context, subscriptions.ListEnterpriseSubscriptionsOptions) ([]*subscriptions.Subscription, error)
 	history     []StoreV1ListEnterpriseSubscriptionsFuncCall
 	mutex       sync.Mutex
 }
 
 // ListEnterpriseSubscriptions delegates to the next hook function in the
 // queue and stores the parameter and result values of this invocation.
-func (m *MockStoreV1) ListEnterpriseSubscriptions(v0 context.Context, v1 database.ListEnterpriseSubscriptionsOptions) ([]*database.Subscription, error) {
+func (m *MockStoreV1) ListEnterpriseSubscriptions(v0 context.Context, v1 subscriptions.ListEnterpriseSubscriptionsOptions) ([]*subscriptions.Subscription, error) {
 	r0, r1 := m.ListEnterpriseSubscriptionsFunc.nextHook()(v0, v1)
 	m.ListEnterpriseSubscriptionsFunc.appendCall(StoreV1ListEnterpriseSubscriptionsFuncCall{v0, v1, r0, r1})
 	return r0, r1
@@ -978,7 +978,7 @@ func (m *MockStoreV1) ListEnterpriseSubscriptions(v0 context.Context, v1 databas
 // SetDefaultHook sets function that is called when the
 // ListEnterpriseSubscriptions method of the parent MockStoreV1 instance is
 // invoked and the hook queue is empty.
-func (f *StoreV1ListEnterpriseSubscriptionsFunc) SetDefaultHook(hook func(context.Context, database.ListEnterpriseSubscriptionsOptions) ([]*database.Subscription, error)) {
+func (f *StoreV1ListEnterpriseSubscriptionsFunc) SetDefaultHook(hook func(context.Context, subscriptions.ListEnterpriseSubscriptionsOptions) ([]*subscriptions.Subscription, error)) {
 	f.defaultHook = hook
 }
 
@@ -987,7 +987,7 @@ func (f *StoreV1ListEnterpriseSubscriptionsFunc) SetDefaultHook(hook func(contex
 // invokes the hook at the front of the queue and discards it. After the
 // queue is empty, the default hook function is invoked for any future
 // action.
-func (f *StoreV1ListEnterpriseSubscriptionsFunc) PushHook(hook func(context.Context, database.ListEnterpriseSubscriptionsOptions) ([]*database.Subscription, error)) {
+func (f *StoreV1ListEnterpriseSubscriptionsFunc) PushHook(hook func(context.Context, subscriptions.ListEnterpriseSubscriptionsOptions) ([]*subscriptions.Subscription, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -995,20 +995,20 @@ func (f *StoreV1ListEnterpriseSubscriptionsFunc) PushHook(hook func(context.Cont
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *StoreV1ListEnterpriseSubscriptionsFunc) SetDefaultReturn(r0 []*database.Subscription, r1 error) {
-	f.SetDefaultHook(func(context.Context, database.ListEnterpriseSubscriptionsOptions) ([]*database.Subscription, error) {
+func (f *StoreV1ListEnterpriseSubscriptionsFunc) SetDefaultReturn(r0 []*subscriptions.Subscription, r1 error) {
+	f.SetDefaultHook(func(context.Context, subscriptions.ListEnterpriseSubscriptionsOptions) ([]*subscriptions.Subscription, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *StoreV1ListEnterpriseSubscriptionsFunc) PushReturn(r0 []*database.Subscription, r1 error) {
-	f.PushHook(func(context.Context, database.ListEnterpriseSubscriptionsOptions) ([]*database.Subscription, error) {
+func (f *StoreV1ListEnterpriseSubscriptionsFunc) PushReturn(r0 []*subscriptions.Subscription, r1 error) {
+	f.PushHook(func(context.Context, subscriptions.ListEnterpriseSubscriptionsOptions) ([]*subscriptions.Subscription, error) {
 		return r0, r1
 	})
 }
 
-func (f *StoreV1ListEnterpriseSubscriptionsFunc) nextHook() func(context.Context, database.ListEnterpriseSubscriptionsOptions) ([]*database.Subscription, error) {
+func (f *StoreV1ListEnterpriseSubscriptionsFunc) nextHook() func(context.Context, subscriptions.ListEnterpriseSubscriptionsOptions) ([]*subscriptions.Subscription, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -1047,10 +1047,10 @@ type StoreV1ListEnterpriseSubscriptionsFuncCall struct {
 	Arg0 context.Context
 	// Arg1 is the value of the 2nd argument passed to this method
 	// invocation.
-	Arg1 database.ListEnterpriseSubscriptionsOptions
+	Arg1 subscriptions.ListEnterpriseSubscriptionsOptions
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 []*database.Subscription
+	Result0 []*subscriptions.Subscription
 	// Result1 is the value of the 2nd result returned from this method
 	// invocation.
 	Result1 error
@@ -1072,15 +1072,15 @@ func (c StoreV1ListEnterpriseSubscriptionsFuncCall) Results() []interface{} {
 // UpsertEnterpriseSubscription method of the parent MockStoreV1 instance is
 // invoked.
 type StoreV1UpsertEnterpriseSubscriptionFunc struct {
-	defaultHook func(context.Context, string, database.UpsertSubscriptionOptions) (*database.Subscription, error)
-	hooks       []func(context.Context, string, database.UpsertSubscriptionOptions) (*database.Subscription, error)
+	defaultHook func(context.Context, string, subscriptions.UpsertSubscriptionOptions) (*subscriptions.Subscription, error)
+	hooks       []func(context.Context, string, subscriptions.UpsertSubscriptionOptions) (*subscriptions.Subscription, error)
 	history     []StoreV1UpsertEnterpriseSubscriptionFuncCall
 	mutex       sync.Mutex
 }
 
 // UpsertEnterpriseSubscription delegates to the next hook function in the
 // queue and stores the parameter and result values of this invocation.
-func (m *MockStoreV1) UpsertEnterpriseSubscription(v0 context.Context, v1 string, v2 database.UpsertSubscriptionOptions) (*database.Subscription, error) {
+func (m *MockStoreV1) UpsertEnterpriseSubscription(v0 context.Context, v1 string, v2 subscriptions.UpsertSubscriptionOptions) (*subscriptions.Subscription, error) {
 	r0, r1 := m.UpsertEnterpriseSubscriptionFunc.nextHook()(v0, v1, v2)
 	m.UpsertEnterpriseSubscriptionFunc.appendCall(StoreV1UpsertEnterpriseSubscriptionFuncCall{v0, v1, v2, r0, r1})
 	return r0, r1
@@ -1089,7 +1089,7 @@ func (m *MockStoreV1) UpsertEnterpriseSubscription(v0 context.Context, v1 string
 // SetDefaultHook sets function that is called when the
 // UpsertEnterpriseSubscription method of the parent MockStoreV1 instance is
 // invoked and the hook queue is empty.
-func (f *StoreV1UpsertEnterpriseSubscriptionFunc) SetDefaultHook(hook func(context.Context, string, database.UpsertSubscriptionOptions) (*database.Subscription, error)) {
+func (f *StoreV1UpsertEnterpriseSubscriptionFunc) SetDefaultHook(hook func(context.Context, string, subscriptions.UpsertSubscriptionOptions) (*subscriptions.Subscription, error)) {
 	f.defaultHook = hook
 }
 
@@ -1098,7 +1098,7 @@ func (f *StoreV1UpsertEnterpriseSubscriptionFunc) SetDefaultHook(hook func(conte
 // invokes the hook at the front of the queue and discards it. After the
 // queue is empty, the default hook function is invoked for any future
 // action.
-func (f *StoreV1UpsertEnterpriseSubscriptionFunc) PushHook(hook func(context.Context, string, database.UpsertSubscriptionOptions) (*database.Subscription, error)) {
+func (f *StoreV1UpsertEnterpriseSubscriptionFunc) PushHook(hook func(context.Context, string, subscriptions.UpsertSubscriptionOptions) (*subscriptions.Subscription, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -1106,20 +1106,20 @@ func (f *StoreV1UpsertEnterpriseSubscriptionFunc) PushHook(hook func(context.Con
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *StoreV1UpsertEnterpriseSubscriptionFunc) SetDefaultReturn(r0 *database.Subscription, r1 error) {
-	f.SetDefaultHook(func(context.Context, string, database.UpsertSubscriptionOptions) (*database.Subscription, error) {
+func (f *StoreV1UpsertEnterpriseSubscriptionFunc) SetDefaultReturn(r0 *subscriptions.Subscription, r1 error) {
+	f.SetDefaultHook(func(context.Context, string, subscriptions.UpsertSubscriptionOptions) (*subscriptions.Subscription, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *StoreV1UpsertEnterpriseSubscriptionFunc) PushReturn(r0 *database.Subscription, r1 error) {
-	f.PushHook(func(context.Context, string, database.UpsertSubscriptionOptions) (*database.Subscription, error) {
+func (f *StoreV1UpsertEnterpriseSubscriptionFunc) PushReturn(r0 *subscriptions.Subscription, r1 error) {
+	f.PushHook(func(context.Context, string, subscriptions.UpsertSubscriptionOptions) (*subscriptions.Subscription, error) {
 		return r0, r1
 	})
 }
 
-func (f *StoreV1UpsertEnterpriseSubscriptionFunc) nextHook() func(context.Context, string, database.UpsertSubscriptionOptions) (*database.Subscription, error) {
+func (f *StoreV1UpsertEnterpriseSubscriptionFunc) nextHook() func(context.Context, string, subscriptions.UpsertSubscriptionOptions) (*subscriptions.Subscription, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -1161,10 +1161,10 @@ type StoreV1UpsertEnterpriseSubscriptionFuncCall struct {
 	Arg1 string
 	// Arg2 is the value of the 3rd argument passed to this method
 	// invocation.
-	Arg2 database.UpsertSubscriptionOptions
+	Arg2 subscriptions.UpsertSubscriptionOptions
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 *database.Subscription
+	Result0 *subscriptions.Subscription
 	// Result1 is the value of the 2nd result returned from this method
 	// invocation.
 	Result1 error

--- a/cmd/enterprise-portal/internal/subscriptionsservice/v1_store.go
+++ b/cmd/enterprise-portal/internal/subscriptionsservice/v1_store.go
@@ -7,6 +7,7 @@ import (
 	clientsv1 "github.com/sourcegraph/sourcegraph-accounts-sdk-go/clients/v1"
 
 	"github.com/sourcegraph/sourcegraph/cmd/enterprise-portal/internal/database"
+	"github.com/sourcegraph/sourcegraph/cmd/enterprise-portal/internal/database/subscriptions"
 	"github.com/sourcegraph/sourcegraph/cmd/enterprise-portal/internal/dotcomdb"
 	subscriptionsv1 "github.com/sourcegraph/sourcegraph/lib/enterpriseportal/subscriptions/v1"
 	"github.com/sourcegraph/sourcegraph/lib/managedservicesplatform/iam"
@@ -18,10 +19,10 @@ import (
 type StoreV1 interface {
 	// UpsertEnterpriseSubscription upserts a enterprise subscription record based
 	// on the given options.
-	UpsertEnterpriseSubscription(ctx context.Context, subscriptionID string, opts database.UpsertSubscriptionOptions) (*database.Subscription, error)
+	UpsertEnterpriseSubscription(ctx context.Context, subscriptionID string, opts subscriptions.UpsertSubscriptionOptions) (*subscriptions.Subscription, error)
 	// ListEnterpriseSubscriptions returns a list of enterprise subscriptions based
 	// on the given options.
-	ListEnterpriseSubscriptions(ctx context.Context, opts database.ListEnterpriseSubscriptionsOptions) ([]*database.Subscription, error)
+	ListEnterpriseSubscriptions(ctx context.Context, opts subscriptions.ListEnterpriseSubscriptionsOptions) ([]*subscriptions.Subscription, error)
 
 	// ListDotcomEnterpriseSubscriptionLicenses returns a list of enterprise
 	// subscription license attributes with the given filters. It silently ignores
@@ -81,11 +82,11 @@ func NewStoreV1(opts NewStoreV1Options) StoreV1 {
 	}
 }
 
-func (s *storeV1) UpsertEnterpriseSubscription(ctx context.Context, subscriptionID string, opts database.UpsertSubscriptionOptions) (*database.Subscription, error) {
+func (s *storeV1) UpsertEnterpriseSubscription(ctx context.Context, subscriptionID string, opts subscriptions.UpsertSubscriptionOptions) (*subscriptions.Subscription, error) {
 	return s.db.Subscriptions().Upsert(ctx, subscriptionID, opts)
 }
 
-func (s *storeV1) ListEnterpriseSubscriptions(ctx context.Context, opts database.ListEnterpriseSubscriptionsOptions) ([]*database.Subscription, error) {
+func (s *storeV1) ListEnterpriseSubscriptions(ctx context.Context, opts subscriptions.ListEnterpriseSubscriptionsOptions) ([]*subscriptions.Subscription, error) {
 	return s.db.Subscriptions().List(ctx, opts)
 }
 

--- a/cmd/enterprise-portal/internal/subscriptionsservice/v1_test.go
+++ b/cmd/enterprise-portal/internal/subscriptionsservice/v1_test.go
@@ -14,7 +14,7 @@ import (
 	sams "github.com/sourcegraph/sourcegraph-accounts-sdk-go"
 	"github.com/sourcegraph/sourcegraph-accounts-sdk-go/scopes"
 
-	"github.com/sourcegraph/sourcegraph/cmd/enterprise-portal/internal/database"
+	"github.com/sourcegraph/sourcegraph/cmd/enterprise-portal/internal/database/subscriptions"
 	"github.com/sourcegraph/sourcegraph/cmd/enterprise-portal/internal/dotcomdb"
 	"github.com/sourcegraph/sourcegraph/cmd/enterprise-portal/internal/samsm2m"
 	subscriptionsv1 "github.com/sourcegraph/sourcegraph/lib/enterpriseportal/subscriptions/v1"
@@ -87,10 +87,10 @@ func TestHandlerV1_ListEnterpriseSubscriptions(t *testing.T) {
 		req.Header().Add("Authorization", "Bearer foolmeifyoucan")
 
 		h := newTestHandlerV1()
-		h.mockStore.ListEnterpriseSubscriptionsFunc.SetDefaultHook(func(_ context.Context, opts database.ListEnterpriseSubscriptionsOptions) ([]*database.Subscription, error) {
+		h.mockStore.ListEnterpriseSubscriptionsFunc.SetDefaultHook(func(_ context.Context, opts subscriptions.ListEnterpriseSubscriptionsOptions) ([]*subscriptions.Subscription, error) {
 			require.Len(t, opts.IDs, 1)
 			assert.Equal(t, "80ca12e2-54b4-448c-a61a-390b1a9c1224", opts.IDs[0])
-			return []*database.Subscription{}, nil
+			return []*subscriptions.Subscription{}, nil
 		})
 		_, err := h.ListEnterpriseSubscriptions(ctx, req)
 		require.NoError(t, err)
@@ -113,10 +113,10 @@ func TestHandlerV1_ListEnterpriseSubscriptions(t *testing.T) {
 
 		h := newTestHandlerV1()
 		h.mockStore.IAMListObjectsFunc.SetDefaultReturn([]string{"subscription_cody_analytics:80ca12e2-54b4-448c-a61a-390b1a9c1224"}, nil)
-		h.mockStore.ListEnterpriseSubscriptionsFunc.SetDefaultHook(func(_ context.Context, opts database.ListEnterpriseSubscriptionsOptions) ([]*database.Subscription, error) {
+		h.mockStore.ListEnterpriseSubscriptionsFunc.SetDefaultHook(func(_ context.Context, opts subscriptions.ListEnterpriseSubscriptionsOptions) ([]*subscriptions.Subscription, error) {
 			require.Len(t, opts.IDs, 1)
 			assert.Equal(t, "80ca12e2-54b4-448c-a61a-390b1a9c1224", opts.IDs[0])
-			return []*database.Subscription{}, nil
+			return []*subscriptions.Subscription{}, nil
 		})
 		_, err := h.ListEnterpriseSubscriptions(ctx, req)
 		require.NoError(t, err)
@@ -142,10 +142,10 @@ func TestHandlerV1_ListEnterpriseSubscriptions(t *testing.T) {
 
 		h := newTestHandlerV1()
 		h.mockStore.IAMListObjectsFunc.SetDefaultReturn([]string{"subscription_cody_analytics:a-different-subscription-id"}, nil)
-		h.mockStore.ListEnterpriseSubscriptionsFunc.SetDefaultHook(func(_ context.Context, opts database.ListEnterpriseSubscriptionsOptions) ([]*database.Subscription, error) {
+		h.mockStore.ListEnterpriseSubscriptionsFunc.SetDefaultHook(func(_ context.Context, opts subscriptions.ListEnterpriseSubscriptionsOptions) ([]*subscriptions.Subscription, error) {
 			require.Len(t, opts.IDs, 1)
 			assert.Equal(t, "a-different-subscription-id", opts.IDs[0])
-			return []*database.Subscription{}, nil
+			return []*subscriptions.Subscription{}, nil
 		})
 		resp, err := h.ListEnterpriseSubscriptions(ctx, req)
 		require.NoError(t, err)
@@ -172,10 +172,10 @@ func TestHandlerV1_ListEnterpriseSubscriptions(t *testing.T) {
 
 		h := newTestHandlerV1()
 		h.mockStore.IAMListObjectsFunc.SetDefaultReturn([]string{"subscription_cody_analytics:" + subscriptionID}, nil)
-		h.mockStore.ListEnterpriseSubscriptionsFunc.SetDefaultHook(func(_ context.Context, opts database.ListEnterpriseSubscriptionsOptions) ([]*database.Subscription, error) {
+		h.mockStore.ListEnterpriseSubscriptionsFunc.SetDefaultHook(func(_ context.Context, opts subscriptions.ListEnterpriseSubscriptionsOptions) ([]*subscriptions.Subscription, error) {
 			require.Len(t, opts.IDs, 1)
 			assert.Equal(t, subscriptionID, opts.IDs[0])
-			return []*database.Subscription{{ID: opts.IDs[0]}}, nil
+			return []*subscriptions.Subscription{{ID: opts.IDs[0]}}, nil
 		})
 		resp, err := h.ListEnterpriseSubscriptions(ctx, req)
 		require.NoError(t, err)
@@ -214,8 +214,8 @@ func TestHandlerV1_ListEnterpriseSubscriptions(t *testing.T) {
 		req.Header().Add("Authorization", "Bearer foolmeifyoucan")
 
 		h := newTestHandlerV1()
-		h.mockStore.ListEnterpriseSubscriptionsFunc.SetDefaultHook(func(_ context.Context, opts database.ListEnterpriseSubscriptionsOptions) ([]*database.Subscription, error) {
-			return []*database.Subscription{}, nil
+		h.mockStore.ListEnterpriseSubscriptionsFunc.SetDefaultHook(func(_ context.Context, opts subscriptions.ListEnterpriseSubscriptionsOptions) ([]*subscriptions.Subscription, error) {
+			return []*subscriptions.Subscription{}, nil
 		})
 		h.mockStore.ListDotcomEnterpriseSubscriptionsFunc.SetDefaultHook(func(_ context.Context, opts dotcomdb.ListEnterpriseSubscriptionsOptions) ([]*dotcomdb.SubscriptionAttributes, error) {
 			assert.Empty(t, opts.SubscriptionIDs)
@@ -248,10 +248,10 @@ func TestHandlerV1_UpdateEnterpriseSubscription(t *testing.T) {
 
 		h := newTestHandlerV1()
 		h.mockStore.ListDotcomEnterpriseSubscriptionsFunc.SetDefaultReturn([]*dotcomdb.SubscriptionAttributes{{ID: "80ca12e2-54b4-448c-a61a-390b1a9c1224"}}, nil)
-		h.mockStore.UpsertEnterpriseSubscriptionFunc.SetDefaultHook(func(_ context.Context, _ string, opts database.UpsertSubscriptionOptions) (*database.Subscription, error) {
+		h.mockStore.UpsertEnterpriseSubscriptionFunc.SetDefaultHook(func(_ context.Context, _ string, opts subscriptions.UpsertSubscriptionOptions) (*subscriptions.Subscription, error) {
 			assert.NotEmpty(t, opts.InstanceDomain)
 			assert.False(t, opts.ForceUpdate)
-			return &database.Subscription{}, nil
+			return &subscriptions.Subscription{}, nil
 		})
 		_, err := h.UpdateEnterpriseSubscription(ctx, req)
 		require.NoError(t, err)
@@ -270,10 +270,10 @@ func TestHandlerV1_UpdateEnterpriseSubscription(t *testing.T) {
 
 		h := newTestHandlerV1()
 		h.mockStore.ListDotcomEnterpriseSubscriptionsFunc.SetDefaultReturn([]*dotcomdb.SubscriptionAttributes{{ID: "80ca12e2-54b4-448c-a61a-390b1a9c1224"}}, nil)
-		h.mockStore.UpsertEnterpriseSubscriptionFunc.SetDefaultHook(func(_ context.Context, _ string, opts database.UpsertSubscriptionOptions) (*database.Subscription, error) {
+		h.mockStore.UpsertEnterpriseSubscriptionFunc.SetDefaultHook(func(_ context.Context, _ string, opts subscriptions.UpsertSubscriptionOptions) (*subscriptions.Subscription, error) {
 			assert.NotEmpty(t, opts.InstanceDomain)
 			assert.False(t, opts.ForceUpdate)
-			return &database.Subscription{}, nil
+			return &subscriptions.Subscription{}, nil
 		})
 		_, err := h.UpdateEnterpriseSubscription(ctx, req)
 		require.NoError(t, err)
@@ -292,10 +292,10 @@ func TestHandlerV1_UpdateEnterpriseSubscription(t *testing.T) {
 
 		h := newTestHandlerV1()
 		h.mockStore.ListDotcomEnterpriseSubscriptionsFunc.SetDefaultReturn([]*dotcomdb.SubscriptionAttributes{{ID: "80ca12e2-54b4-448c-a61a-390b1a9c1224"}}, nil)
-		h.mockStore.UpsertEnterpriseSubscriptionFunc.SetDefaultHook(func(_ context.Context, _ string, opts database.UpsertSubscriptionOptions) (*database.Subscription, error) {
+		h.mockStore.UpsertEnterpriseSubscriptionFunc.SetDefaultHook(func(_ context.Context, _ string, opts subscriptions.UpsertSubscriptionOptions) (*subscriptions.Subscription, error) {
 			assert.Empty(t, opts.InstanceDomain)
 			assert.True(t, opts.ForceUpdate)
-			return &database.Subscription{}, nil
+			return &subscriptions.Subscription{}, nil
 		})
 		_, err := h.UpdateEnterpriseSubscription(ctx, req)
 		require.NoError(t, err)
@@ -313,10 +313,10 @@ func TestHandlerV1_UpdateEnterpriseSubscription(t *testing.T) {
 
 		h := newTestHandlerV1()
 		h.mockStore.ListDotcomEnterpriseSubscriptionsFunc.SetDefaultReturn([]*dotcomdb.SubscriptionAttributes{{ID: "80ca12e2-54b4-448c-a61a-390b1a9c1224"}}, nil)
-		h.mockStore.UpsertEnterpriseSubscriptionFunc.SetDefaultHook(func(_ context.Context, _ string, opts database.UpsertSubscriptionOptions) (*database.Subscription, error) {
+		h.mockStore.UpsertEnterpriseSubscriptionFunc.SetDefaultHook(func(_ context.Context, _ string, opts subscriptions.UpsertSubscriptionOptions) (*subscriptions.Subscription, error) {
 			assert.Empty(t, opts.InstanceDomain)
 			assert.False(t, opts.ForceUpdate)
-			return &database.Subscription{}, nil
+			return &subscriptions.Subscription{}, nil
 		})
 		_, err := h.UpdateEnterpriseSubscription(ctx, req)
 		require.NoError(t, err)
@@ -358,7 +358,7 @@ func TestHandlerV1_UpdateEnterpriseSubscriptionMembership(t *testing.T) {
 		req.Header().Add("Authorization", "Bearer foolmeifyoucan")
 
 		h := newTestHandlerV1()
-		h.mockStore.ListEnterpriseSubscriptionsFunc.SetDefaultReturn([]*database.Subscription{{ID: "80ca12e2-54b4-448c-a61a-390b1a9c1224"}}, nil)
+		h.mockStore.ListEnterpriseSubscriptionsFunc.SetDefaultReturn([]*subscriptions.Subscription{{ID: "80ca12e2-54b4-448c-a61a-390b1a9c1224"}}, nil)
 		h.mockStore.IAMWriteFunc.SetDefaultHook(func(_ context.Context, opts iam.WriteOptions) error {
 			assert.Len(t, opts.Writes, 2)
 			return nil


### PR DESCRIPTION
As we set up to introduce more tables to Enterprise Portal, I think it'll be more sustainable for things to get their own subpackages. No real code changes, just moving things around.

## Test plan

CI