### PR TITLE
chore/enterpriseportal: properly close DB handle

### DIFF
--- a/cmd/enterprise-portal/internal/database/BUILD.bazel
+++ b/cmd/enterprise-portal/internal/database/BUILD.bazel
@@ -15,7 +15,6 @@ go_library(
         "//lib/errors",
         "//lib/managedservicesplatform/runtime",
         "//lib/redislock",
-        "@com_github_jackc_pgx_v5//:pgx",
         "@com_github_jackc_pgx_v5//pgxpool",
         "@com_github_redis_go_redis_v9//:go-redis",
         "@com_github_sourcegraph_log//:log",

--- a/cmd/enterprise-portal/internal/database/database.go
+++ b/cmd/enterprise-portal/internal/database/database.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"os"
 
-	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/redis/go-redis/v9"
 	"github.com/sourcegraph/log"
@@ -52,27 +51,8 @@ func NewHandle(ctx context.Context, logger log.Logger, contract runtime.Contract
 	return &DB{db: pool}, nil
 }
 
-// transaction executes the given function within a transaction. If the function
-// returns an error, the transaction will be rolled back.
-func transaction(ctx context.Context, db *pgxpool.Pool, fn func(tx pgx.Tx) error) (err error) {
-	tx, err := db.Begin(ctx)
-	if err != nil {
-		return errors.Wrap(err, "begin")
-	}
-	defer func() {
-		rollbackErr := tx.Rollback(ctx)
-		// Only return the rollback error if there is no other error.
-		if err == nil {
-			err = errors.Wrap(rollbackErr, "rollback")
-		}
-	}()
-
-	if err = fn(tx); err != nil {
-		return err
-	}
-
-	if err = tx.Commit(ctx); err != nil {
-		return errors.Wrap(err, "commit")
-	}
-	return nil
+// Close closes all connections in the pool and rejects future Acquire calls.
+// Blocks until all connections are returned to pool and closed.
+func (db *DB) Close() {
+	db.db.Close()
 }


### PR DESCRIPTION
Adds a clean shutdown for our primary DB handle, and removes some unused code.

## Test plan

`sg run enterprise-portal` and stop it