### PR TITLE
"Cody" in navbar not "Cody AI"

### DIFF
--- a/client/web-sveltekit/src/routes/navigation.ts
+++ b/client/web-sveltekit/src/routes/navigation.ts
@@ -43,7 +43,7 @@ export const mainNavigation: (NavigationMenu | NavigationEntry)[] = [
         },
     },
     {
-        label: 'Cody AI',
+        label: 'Cody',
         icon: ISgCody,
         href: '/cody',
         isCurrent(this: NavigationMenu, page) {
@@ -82,7 +82,7 @@ export const dotcomMainNavigation: (NavigationMenu | NavigationEntry)[] = [
         href: '/search',
     },
     {
-        label: 'Cody AI',
+        label: 'Cody',
         icon: ISgCody,
         href: '/cody',
         children: [

--- a/client/web/src/nav/GlobalNavbar.tsx
+++ b/client/web/src/nav/GlobalNavbar.tsx
@@ -367,7 +367,7 @@ export const InlineNavigationPanel: FC<InlineNavigationPanelProps> = props => {
     const codyNavigation = hideCodyDropdown ? (
         <NavItem icon={() => <CodyLogoWrapper />} key="cody">
             <NavLink variant={navLinkVariant} to={disableCodyFeatures ? PageRoutes.Cody : PageRoutes.CodyChat}>
-                Cody AI
+                Cody
             </NavLink>
         </NavItem>
     ) : (
@@ -376,7 +376,7 @@ export const InlineNavigationPanel: FC<InlineNavigationPanelProps> = props => {
             toggleItem={{
                 path: isSourcegraphDotCom ? CodyProRoutes.Manage : PageRoutes.Cody,
                 icon: () => <CodyLogoWrapper />,
-                content: 'Cody AI',
+                content: 'Cody',
                 variant: navLinkVariant,
             }}
             routeMatch={routeMatch}

--- a/client/web/src/nav/__snapshots__/GlobalNavbar.test.tsx.snap
+++ b/client/web/src/nav/__snapshots__/GlobalNavbar.test.tsx.snap
@@ -114,7 +114,7 @@ exports[`GlobalNavbar > code search only license 1`] = `
               <span
                 class="text iconIncluded"
               >
-                Cody AI
+                Cody
               </span>
             </span>
           </a>
@@ -260,7 +260,7 @@ exports[`GlobalNavbar > cody only license 1`] = `
               <span
                 class="text iconIncluded"
               >
-                Cody AI
+                Cody
               </span>
             </span>
           </a>
@@ -406,7 +406,7 @@ exports[`GlobalNavbar > default 1`] = `
               <span
                 class="text iconIncluded"
               >
-                Cody AI
+                Cody
               </span>
             </span>
           </a>

--- a/client/web/src/nav/new-global-navigation/NewGlobalNavigationBar.tsx
+++ b/client/web/src/nav/new-global-navigation/NewGlobalNavigationBar.tsx
@@ -378,7 +378,7 @@ const SidebarNavigation: FC<SidebarNavigationProps> = props => {
                     </li>
 
                     <NavItemLink url={PageRoutes.Cody} icon={CodyLogo} onClick={handleNavigationClick}>
-                        Cody AI
+                        Cody
                     </NavItemLink>
 
                     {authenticatedUser && (


### PR DESCRIPTION
The name of the product is "Cody", not "Cody AI". Also, "AI" just looks dumb and hype-y.


## Test plan

View the navbar and ensure it reads "Cody" not "Cody AI".

## Changelog

- In the navbar, Cody is now just "Cody" not "Cody AI".