### PR TITLE
test(cody): Add unit tests for the Completions API

### DIFF
--- a/cmd/frontend/internal/httpapi/completions/BUILD.bazel
+++ b/cmd/frontend/internal/httpapi/completions/BUILD.bazel
@@ -51,15 +51,31 @@ go_library(
 
 go_test(
     name = "completions_test",
-    srcs = ["handler_test.go"],
+    srcs = [
+        "entconfig_anthropic_test.go",
+        "entconfig_base_test.go",
+        "get_model_test.go",
+        "handler_test.go",
+    ],
     embed = [":completions"],
     tags = [TAG_CODY_CORE],
     deps = [
+        "//internal/actor",
         "//internal/completions/types",
         "//internal/conf",
+        "//internal/conf/conftypes",
         "//internal/database/dbmocks",
         "//internal/featureflag",
+        "//internal/httpcli",
+        "//internal/licensing",
+        "//internal/rcache",
+        "//internal/telemetry",
+        "//internal/telemetry/telemetrytest",
+        "//lib/errors",
+        "//lib/pointers",
         "//schema",
+        "@com_github_sourcegraph_log//logtest",
+        "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/cmd/frontend/internal/httpapi/completions/BUILD.bazel
+++ b/cmd/frontend/internal/httpapi/completions/BUILD.bazel
@@ -58,7 +58,11 @@ go_test(
         "handler_test.go",
     ],
     embed = [":completions"],
-    tags = [TAG_CODY_CORE],
+    tags = [
+        TAG_CODY_CORE,
+        # Test indirectly localhost Redis.
+        "requires-network",
+    ],
     deps = [
         "//internal/actor",
         "//internal/completions/types",

--- a/cmd/frontend/internal/httpapi/completions/entconfig_anthropic_test.go
+++ b/cmd/frontend/internal/httpapi/completions/entconfig_anthropic_test.go
@@ -1,0 +1,188 @@
+package completions
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/sourcegraph/sourcegraph/internal/completions/types"
+	"github.com/sourcegraph/sourcegraph/lib/pointers"
+	"github.com/sourcegraph/sourcegraph/schema"
+)
+
+func testAPIProviderAnthropic(t *testing.T, infra *apiProviderTestInfra) {
+	// validAnthropicRequestData bundles the messages sent between major
+	// components of the Completions API.
+	type validAnthropicRequestData struct {
+		// InitialCompletionRequest is the request sent by the user to the
+		// Sourcegraph instance.
+		InitialCompletionRequest types.CodyCompletionRequestParameters
+
+		// OutboundAnthropicRequest is the data sent from this Sourcegraph
+		// instance to the API Provider (e.g. Anthropic, Cody Gateway, AWS
+		// Bedrock, etc.)
+		OutboundAnthropicRequest map[string]any
+
+		// InboundAnthropicRequest is the response from the API Provider
+		// to the Sourcegraph instance.
+		InboundAnthropicRequest map[string]any
+	}
+
+	// getValidTestData returns a valid set of request data.
+	getValidTestData := func() validAnthropicRequestData {
+		initialCompletionRequest := types.CodyCompletionRequestParameters{
+			CompletionRequestParameters: types.CompletionRequestParameters{
+				Messages: []types.Message{
+					{
+						Speaker: "human",
+						Text:    "please make this code better",
+					},
+				},
+				Stream: pointers.Ptr(false),
+			},
+		}
+
+		// Anthropic-specific request object we expect to see sent to Cody Gateway.
+		// See `anthropicRequestParameters`.
+		outboundAnthropicRequest := map[string]any{
+			"model": "claude-2.0",
+			"messages": []map[string]any{
+				{
+					"role": "user",
+					"content": []map[string]any{
+						{
+							"type": "text",
+							"text": "please make this code better",
+						},
+					},
+				},
+			},
+		}
+
+		// Stock response we would receive from Anthropic.
+		//
+		// The expected output is found also defined in the Anthropic completion provider codebase,
+		// as `anthropicNonStreamingResponse`.` But it's easier to keep those types unexported.
+		inboundAnthropicRequest := map[string]any{
+			"content": []map[string]string{
+				{
+					"speak": "user",
+					"text":  "you should totally rewrite it in Rust!",
+				},
+			},
+			"usage": map[string]int{
+				"input_token":   100,
+				"output_tokens": 200,
+			},
+			"stop_reason": "max_tokens",
+		}
+
+		return validAnthropicRequestData{
+			InitialCompletionRequest: initialCompletionRequest,
+			OutboundAnthropicRequest: outboundAnthropicRequest,
+			InboundAnthropicRequest:  inboundAnthropicRequest,
+		}
+	}
+
+	t.Run("WithDefaultConfig", func(t *testing.T) {
+		infra.SetSiteConfig(schema.SiteConfiguration{
+			CodyEnabled:                  pointers.Ptr(true),
+			CodyPermissions:              pointers.Ptr(false),
+			CodyRestrictUsersFeatureFlag: pointers.Ptr(false),
+
+			// LicenseKey is required in order to use Cody, but other than
+			// that we don't provide any "completions" configuration.
+			// This will default to Anthropic models.
+			LicenseKey:  "license-key",
+			Completions: nil,
+		})
+
+		// Confirm that the default configuration `Completions: nil` will use
+		// Cody Gateway as the LLM API Provider for the Anthropic models.
+		t.Run("ViaCodyGateway", func(t *testing.T) {
+			// The Model isn't included in the CompletionRequestParameters, so we have the getModelFn callback
+			// return claude-2. The Site Configuration will then route this to Cody Gateway (and not BYOK Anthropic),
+			// and we sanity check the request to Cody Gateway matches what is expected, and we serve a valid response.
+			infra.PushGetModelResult("anthropic/claude-2", nil)
+
+			// Generate some basic test data and confirm that the completions handler
+			// code works as expected.
+			testData := getValidTestData()
+
+			// Register our hook to verify Cody Gateway got called with
+			// the requested data.
+			infra.AssertCodyGatewayReceivesRequestWithResponse(
+				t, assertLLMRequestOptions{
+					WantRequestPath: "/v1/completions/anthropic-messages",
+					WantRequestObj:  &testData.OutboundAnthropicRequest,
+					OutResponseObj:  &testData.InboundAnthropicRequest,
+				})
+
+			status, responseBody := infra.CallChatCompletionAPI(t, testData.InitialCompletionRequest)
+
+			assert.Equal(t, http.StatusOK, status)
+			infra.AssertCompletionsResponse(t, responseBody, types.CompletionResponse{
+				Completion: "you should totally rewrite it in Rust!",
+				StopReason: "max_tokens",
+				Logprobs:   nil,
+			})
+		})
+	})
+
+	t.Run("ViaBYOK", func(t *testing.T) {
+		const (
+			anthropicAPIKeyInConfig      = "secret-api-key"
+			anthropicAPIEndpointInConfig = "https://byok.anthropic.com/path/from/config"
+			chatModelInConfig            = "anthropic/claude-3-opus"
+			codeModelInConfig            = "anthropic/claude-3-haiku"
+		)
+
+		infra.SetSiteConfig(schema.SiteConfiguration{
+			CodyEnabled:                  pointers.Ptr(true),
+			CodyPermissions:              pointers.Ptr(false),
+			CodyRestrictUsersFeatureFlag: pointers.Ptr(false),
+
+			// LicenseKey is required in order to use Cody.
+			LicenseKey: "license-key",
+			Completions: &schema.Completions{
+				Provider:    "anthropic",
+				AccessToken: anthropicAPIKeyInConfig,
+				Endpoint:    anthropicAPIEndpointInConfig,
+
+				ChatModel:       chatModelInConfig,
+				CompletionModel: codeModelInConfig,
+			},
+		})
+
+		t.Run("ChatModel", func(t *testing.T) {
+			// Start with the stock test data, but customize it to reflect
+			// what we expect to see based on the site configuration.
+			testData := getValidTestData()
+			testData.OutboundAnthropicRequest["model"] = "anthropic/claude-3-opus"
+
+			// Register our hook to verify Cody Gateway got called with
+			// the requested data.
+			infra.AssertGenericExternalAPIRequestWithResponse(
+				t, assertLLMRequestOptions{
+					WantRequestPath: "/path/from/config",
+					WantRequestObj:  &testData.OutboundAnthropicRequest,
+					OutResponseObj:  &testData.InboundAnthropicRequest,
+					WantHeaders: map[string]string{
+						// Yes, Anthropic's API uses "X-Api-Key" rather than the "Authorization" header. 🤷
+						"X-Api-Key": anthropicAPIKeyInConfig,
+					},
+				})
+
+			infra.PushGetModelResult(chatModelInConfig, nil)
+			status, responseBody := infra.CallChatCompletionAPI(t, testData.InitialCompletionRequest)
+
+			assert.Equal(t, http.StatusOK, status)
+			infra.AssertCompletionsResponse(t, responseBody, types.CompletionResponse{
+				Completion: "you should totally rewrite it in Rust!",
+				StopReason: "max_tokens",
+				Logprobs:   nil,
+			})
+		})
+	})
+}

--- a/cmd/frontend/internal/httpapi/completions/entconfig_base_test.go
+++ b/cmd/frontend/internal/httpapi/completions/entconfig_base_test.go
@@ -1,0 +1,416 @@
+package completions
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/sourcegraph/log/logtest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sourcegraph/sourcegraph/internal/actor"
+	"github.com/sourcegraph/sourcegraph/internal/completions/types"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbmocks"
+	"github.com/sourcegraph/sourcegraph/internal/httpcli"
+	"github.com/sourcegraph/sourcegraph/internal/licensing"
+	"github.com/sourcegraph/sourcegraph/internal/rcache"
+	"github.com/sourcegraph/sourcegraph/internal/telemetry"
+	"github.com/sourcegraph/sourcegraph/internal/telemetry/telemetrytest"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"github.com/sourcegraph/sourcegraph/lib/pointers"
+	"github.com/sourcegraph/sourcegraph/schema"
+)
+
+type mockRateLimiter struct{}
+
+func (*mockRateLimiter) TryAcquire(ctx context.Context) error {
+	return nil
+}
+
+// Mock of the httpcli.Doer interface.
+type mockDoer struct {
+	do func(*http.Request) (*http.Response, error)
+}
+
+func (c *mockDoer) Do(r *http.Request) (*http.Response, error) {
+	return c.do(r)
+}
+
+// apiProviderTestInfra bundles the various mocks and things necessary for
+// running an API provider test.
+type apiProviderTestInfra struct {
+	// Don't use these directly. Tests should just use the exported fields and functions.
+	chatCompletionHandler http.Handler
+	codeCompletionHandler http.Handler
+	mockGetModelFn        *mockGetModelFn
+}
+
+// PushGetModelResult sets what gets returned on the next call to getModelFn, which is invoked
+// on every HTTP request to the completions endpoint. So you'll always need to call this before
+// invoking the completions API.
+func (ti *apiProviderTestInfra) PushGetModelResult(model string, err error) {
+	ti.mockGetModelFn.PushResult(model, err)
+}
+
+func (ti *apiProviderTestInfra) SetSiteConfig(siteConfig schema.SiteConfiguration) {
+	conf.Mock(&conf.Unified{
+		SiteConfiguration: siteConfig,
+	})
+}
+
+func (ti *apiProviderTestInfra) CallChatCompletionAPI(t *testing.T, reqObj types.CodyCompletionRequestParameters) (int, string) {
+	return ti.makeCompletionRequest(t, ti.chatCompletionHandler, reqObj)
+}
+func (ti *apiProviderTestInfra) CallCodeCompletionAPI(t *testing.T, reqObj types.CodyCompletionRequestParameters) (int, string) {
+	return ti.makeCompletionRequest(t, ti.codeCompletionHandler, reqObj)
+}
+
+// Issues an HTTP request to the given HTTP handler with the supplied payload. Returns the HTTP status and response body.
+func (ti *apiProviderTestInfra) makeCompletionRequest(t *testing.T, handler http.Handler, reqObj types.CodyCompletionRequestParameters) (int, string) {
+	t.Helper()
+
+	// Convert the request into JSON.
+	reqBody, err := json.Marshal(reqObj)
+	require.NoError(t, err)
+
+	// Build the request.
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/cody/completions/handler/api",
+		strings.NewReader(string(reqBody)))
+
+	mockUser := actor.FromMockUser(1337)
+	ctx := actor.WithActor(context.Background(), mockUser)
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+
+	// Make the request
+	handler.ServeHTTP(w, req)
+	resp := w.Result()
+	respBody, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	return resp.StatusCode, string(respBody)
+}
+
+// AssertCompletionsResponse verifies that the JSON text matches the supplied
+// CompletionResponse object.
+func (ti *apiProviderTestInfra) AssertCompletionsResponse(t *testing.T, rawResponseJSON string, wantResponse types.CompletionResponse) {
+	t.Helper()
+
+	var gotResponse types.CompletionResponse
+	err := json.Unmarshal([]byte(rawResponseJSON), &gotResponse)
+	require.NoError(t, err, "error unmarshalling JSON, full response:\n%s", rawResponseJSON)
+
+	assert.Equal(t, wantResponse, gotResponse)
+}
+
+type assertLLMRequestOptions struct {
+	// WantRequestObj is what we expect the outbound HTTP request's JSON body
+	// to be equal to. Required.
+	WantRequestObj any
+	// OutResponseObj is serialized to JSON and sent to the caller, i.e. our
+	// LLM API Provider which is making the API request. Required.
+	OutResponseObj any
+
+	// WantRequestPath is the URL Path we expect in the outbound HTTP request.
+	// No check is done if empty.
+	WantRequestPath string
+
+	// WantHeaders are HTTP header key/value pairs that must be present.
+	WantHeaders map[string]string
+}
+
+// See comment on `assertDoerReceivesRequestAndSendResponse`.
+func (ti *apiProviderTestInfra) AssertCodyGatewayReceivesRequestWithResponse(
+	t *testing.T, opts assertLLMRequestOptions) {
+	initialDoer := httpcli.CodyGatewayDoer
+	t.Cleanup(func() {
+		httpcli.CodyGatewayDoer = initialDoer
+	})
+	httpcli.CodyGatewayDoer = &mockDoer{
+		do: func(r *http.Request) (*http.Response, error) {
+			return ti.assertDoerReceivesRequestAndSendResponse(t, r, opts)
+		},
+	}
+}
+
+// See comment on `assertDoerReceivesRequestAndSendResponse`.
+func (ti *apiProviderTestInfra) AssertGenericExternalAPIRequestWithResponse(
+	t *testing.T, opts assertLLMRequestOptions) {
+	initialDoer := httpcli.UncachedExternalDoer
+	t.Logf("Saving initialDoer which was %v", initialDoer)
+	t.Cleanup(func() {
+		t.Logf("Resetting initialDoer for generic external %v", initialDoer)
+		httpcli.UncachedExternalDoer = initialDoer
+	})
+	httpcli.UncachedExternalDoer = &mockDoer{
+		do: func(r *http.Request) (*http.Response, error) {
+			return ti.assertDoerReceivesRequestAndSendResponse(t, r, opts)
+		},
+	}
+	t.Logf("Replaced initialDoer for generic external to %v", httpcli.UncachedExternalDoer)
+}
+
+// assertDoerReceivesRequestAndSendResponse is an http.HandlerFunc that we hook into
+// the httpcli.Doer's used for sending LLM API requests.
+//
+// This HTTP handler will verify that the HTTP request being sent matches what is expected.
+// e.g. that the outbound URL path and that the HTTP request's body (as unmarshalled
+// JSON) matches the provided values.
+//
+// The handler then returns a generic 200 OK response, with the the JSON response body
+// matching the respObj.
+func (ti *apiProviderTestInfra) assertDoerReceivesRequestAndSendResponse(
+	t *testing.T, r *http.Request, opts assertLLMRequestOptions) (*http.Response, error) {
+	t.Helper()
+
+	// Verify aspects of the request metadata.
+	if opts.WantRequestPath != "" {
+		assert.Equal(t, opts.WantRequestPath, r.URL.Path)
+	}
+	for header, wantValue := range opts.WantHeaders {
+		assert.Equal(t, wantValue, r.Header.Get(header), "all request headers: %+v", r.Header)
+	}
+
+	// We don't know what the actual type of the request object is, and even
+	// if we did, verifying it matches the incomming JSON isn't straight forward.
+	// So we just marshall each to a generic `map[string]any` and compare the two.
+	var wantReqPayload map[string]any
+	reqObjJSON, err := json.Marshal(opts.WantRequestObj)
+	require.NoError(t, err)
+	err = json.Unmarshal(reqObjJSON, &wantReqPayload)
+	require.NoError(t, err)
+	require.True(t, len(wantReqPayload) > 0, "req object was empty? JSON `%s`", string(reqObjJSON))
+
+	var gotReqPayload map[string]any
+	reqBodyJSON, err := io.ReadAll(r.Body)
+	require.NoError(t, err)
+	err = json.Unmarshal(reqBodyJSON, &gotReqPayload)
+	require.NoError(t, err)
+
+	// Compare the incomming HTTP request matches what we expect.
+	assert.EqualValues(t, wantReqPayload, gotReqPayload,
+		"Comparing the raw vs. expected payloads:\nWant: %s\nGot : %s",
+		string(reqObjJSON), string(reqBodyJSON))
+
+	respObjJSON, err := json.Marshal(opts.OutResponseObj)
+	require.NoError(t, err)
+
+	respBodyReadCloser := io.NopCloser(strings.NewReader(string(respObjJSON)))
+	okResponse := &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       respBodyReadCloser,
+	}
+	return okResponse, nil
+}
+
+// TestAPIProviders is the big deal, it calls into specific implemntations.
+// To cut down on the boilerplate, they inject various things.
+func TestAPIProviders(t *testing.T) {
+	// Configure all the mocks necessary for testing completion handlers.
+	initialMockCheck := licensing.MockCheckFeature
+	licensing.MockCheckFeature = func(licensing.Feature) error {
+		return nil // Don't fail when checking if Cody is enabled.
+	}
+	t.Cleanup(func() { licensing.MockCheckFeature = initialMockCheck })
+	t.Cleanup(func() { conf.Mock(nil) })
+
+	// Set up mocks.
+	logger := logtest.NoOp(t)
+	mockDB := dbmocks.NewMockDB()
+
+	mockGetModelFn := mockGetModelFn{}
+	eventRecorder := telemetry.NewEventRecorder(telemetrytest.NewMockEventsStore())
+
+	// No idea, but the TokenManager assumes that it has access to Redis.
+	rcache.SetupForTest(t)
+
+	// Create the HTTP handlers.
+	chatCompletionHandler := newCompletionsHandler(
+		logger,
+		mockDB,
+		nil, // database.UserStore
+		nil, // database.AccessTokenStore
+		eventRecorder,
+		nil, // guardrails.AttributionTest
+		types.CompletionsFeatureChat,
+		&mockRateLimiter{},
+		"trace-family",
+		mockGetModelFn.ToFunc())
+	codeCompletionHandler := newCompletionsHandler(
+		logger,
+		mockDB,
+		nil, // database.UserStore
+		nil, // database.AccessTokenStore
+		eventRecorder,
+		nil, // guardrails.AttributionTest
+		types.CompletionsFeatureCode,
+		&mockRateLimiter{},
+		"trace-family",
+		mockGetModelFn.ToFunc())
+
+	// Bundle into a test infra object, for convenience.
+	testInfra := apiProviderTestInfra{
+		chatCompletionHandler: chatCompletionHandler,
+		codeCompletionHandler: codeCompletionHandler,
+		mockGetModelFn:        &mockGetModelFn,
+	}
+
+	// Run the set of tests using that infra.
+	testSuites := []struct {
+		Name   string
+		TestFn func(t *testing.T, infra *apiProviderTestInfra)
+	}{
+		{"BasicConfigChecks", testBasicConfiguration},
+		{"APIProviderAnthropic", testAPIProviderAnthropic},
+	}
+	for _, testSuite := range testSuites {
+		t.Run(testSuite.Name, func(t *testing.T) {
+			testSuite.TestFn(t, &testInfra)
+		})
+	}
+}
+
+func testBasicConfiguration(t *testing.T, infra *apiProviderTestInfra) {
+	t.Run("Errors", func(t *testing.T) {
+		t.Run("CodyNotEnabled", func(t *testing.T) {
+			infra.SetSiteConfig(schema.SiteConfiguration{})
+
+			{
+				status, respBody := infra.CallChatCompletionAPI(t, types.CodyCompletionRequestParameters{})
+				assert.Equal(t, http.StatusUnauthorized, status)
+				assert.Equal(t, "cody is not enabled: cody is disabled\n", respBody)
+			}
+			{
+				status, respBody := infra.CallCodeCompletionAPI(t, types.CodyCompletionRequestParameters{})
+				assert.Equal(t, http.StatusUnauthorized, status)
+				assert.Equal(t, "cody is not enabled: cody is disabled\n", respBody)
+			}
+		})
+
+		t.Run("NoCompletionsConfig", func(t *testing.T) {
+			infra.SetSiteConfig(schema.SiteConfiguration{
+				CodyEnabled:                  pointers.Ptr(true),
+				CodyPermissions:              pointers.Ptr(false),
+				CodyRestrictUsersFeatureFlag: pointers.Ptr(false),
+
+				Completions: nil,
+			})
+
+			t.Run("Complete", func(t *testing.T) {
+				status, respBody := infra.CallChatCompletionAPI(t, types.CodyCompletionRequestParameters{
+					CompletionRequestParameters: types.CompletionRequestParameters{
+						Stream: pointers.Ptr(true),
+					},
+				})
+				assert.Equal(t, http.StatusInternalServerError, status)
+				assert.Equal(t, "completions are not configured or disabled\n", respBody)
+			})
+			t.Run("Streaming", func(t *testing.T) {
+				status, respBody := infra.CallCodeCompletionAPI(t, types.CodyCompletionRequestParameters{
+					CompletionRequestParameters: types.CompletionRequestParameters{
+						Stream: pointers.Ptr(true),
+					},
+				})
+				assert.Equal(t, http.StatusInternalServerError, status)
+				assert.Equal(t, "completions are not configured or disabled\n", respBody)
+			})
+		})
+	})
+
+	t.Run("WithDefaultModels", func(t *testing.T) {
+		// Set the site configuration to have Cody enabled (from the previous test,
+		// we were just missing the LicenseKey) but do not specify any completions.
+		infra.SetSiteConfig(schema.SiteConfiguration{
+			CodyEnabled:                  pointers.Ptr(true),
+			CodyPermissions:              pointers.Ptr(false),
+			CodyRestrictUsersFeatureFlag: pointers.Ptr(false),
+
+			// LicenseKey is required in order to use Cody.
+			LicenseKey:  "license-key",
+			Completions: nil,
+		})
+
+		t.Run("ConfirmDefaultsSet", func(t *testing.T) {
+			modelConfig := conf.GetCompletionsConfig(conf.Get().SiteConfiguration)
+
+			assert.Equal(t, "anthropic/claude-3-sonnet-20240229", modelConfig.ChatModel)
+			assert.Equal(t, "fireworks/starcoder", modelConfig.CompletionModel)
+			assert.Equal(t, "anthropic/claude-3-haiku-20240307", modelConfig.FastChatModel)
+
+			assert.Greater(t, modelConfig.ChatModelMaxTokens, 3000)
+			assert.Greater(t, modelConfig.CompletionModelMaxTokens, 3000)
+			assert.Greater(t, modelConfig.FastChatModelMaxTokens, 3000)
+		})
+
+		// When the call to getModelFn -- how the HTTP endpoint knows which model to
+		// use for serving the request -- returns an error, we serve it directly to
+		// the end user. As usually these contain user-facing messages.
+		t.Run("ErrorGettingModel", func(t *testing.T) {
+			t.Run("Sync", func(t *testing.T) {
+				infra.PushGetModelResult("NA", errors.New("error-from-getModelFn"))
+				status, respBody := infra.CallChatCompletionAPI(t, types.CodyCompletionRequestParameters{
+					CompletionRequestParameters: types.CompletionRequestParameters{
+						Stream: pointers.Ptr(false),
+					},
+				})
+				assert.Equal(t, http.StatusBadRequest, status)
+				assert.Equal(t, "error-from-getModelFn\n", respBody)
+			})
+			t.Run("Streaming", func(t *testing.T) {
+				infra.PushGetModelResult("NA", errors.New("error-from-getModelFn"))
+				status, respBody := infra.CallChatCompletionAPI(t, types.CodyCompletionRequestParameters{
+					CompletionRequestParameters: types.CompletionRequestParameters{
+						Stream: pointers.Ptr(false),
+					},
+				})
+				assert.Equal(t, http.StatusBadRequest, status)
+				assert.Equal(t, "error-from-getModelFn\n", respBody)
+			})
+		})
+
+		t.Run("ErrorOnUnknownModel", func(t *testing.T) {
+			// Cody Gateway will reject the model with a different error name if it is sent something
+			// without any slashes.
+			t.Run("InvalidModelFormat", func(t *testing.T) {
+				infra.PushGetModelResult("model-name-no-slashes", nil)
+				status, respBody := infra.CallCodeCompletionAPI(t, types.CodyCompletionRequestParameters{})
+				assert.Equal(t, http.StatusInternalServerError, status)
+				assert.Equal(t,
+					"no provider provided in model model-name-no-slashes - a model in the format '$PROVIDER/$MODEL_NAME' is expected",
+					respBody)
+			})
+
+			// In these tests, we resolve the request to use an unknown model.
+			// The error originates from Cody Gateway which is serving a 400.
+			// BUG: We serve these as 500s on our side, but they should be 4xx.
+			t.Run("Sync", func(t *testing.T) {
+				infra.PushGetModelResult("acmeco/llm-tron-9k", nil)
+				status, respBody := infra.CallCodeCompletionAPI(t, types.CodyCompletionRequestParameters{
+					CompletionRequestParameters: types.CompletionRequestParameters{
+						Stream: pointers.Ptr(false),
+					},
+				})
+				assert.Equal(t, http.StatusInternalServerError, status)
+				assert.Equal(t, "no client known for upstream provider acmeco", respBody)
+			})
+			t.Run("Streaming", func(t *testing.T) {
+				infra.PushGetModelResult("acmeco/llm-tron-9k", nil)
+				status, respBody := infra.CallCodeCompletionAPI(t, types.CodyCompletionRequestParameters{
+					CompletionRequestParameters: types.CompletionRequestParameters{
+						// If nil, defaults to streaming.
+					},
+				})
+				assert.Equal(t, http.StatusInternalServerError, status)
+				assert.Equal(t, "no client known for upstream provider acmeco", respBody)
+			})
+		})
+	})
+}

--- a/cmd/frontend/internal/httpapi/completions/get_model.go
+++ b/cmd/frontend/internal/httpapi/completions/get_model.go
@@ -31,6 +31,11 @@ func getCodeCompletionModelFn() getModelFn {
 			}
 			return "", errors.Newf("unsupported code completion model %q", requestParams.Model)
 		}
+		// The caller will probably return a 4xx if Cody isn't available on the Sourcegraph
+		// instance before calling getModel.
+		if c == nil {
+			return "", errors.New("no completions config available")
+		}
 		return c.CompletionModel, nil
 	}
 }
@@ -58,6 +63,7 @@ func getChatModelFn(db database.DB) getModelFn {
 
 		// For any other Sourcegraph instance, i.e. using Cody Enterprise,
 		// we just use the configured "chat" or "fastChat" model.
+		// TODO(PRIME-283): Enable LLM model selection Cody Enterprise users.
 		if requestParams.Fast {
 			return c.FastChatModel, nil
 		}

--- a/cmd/frontend/internal/httpapi/completions/get_model_test.go
+++ b/cmd/frontend/internal/httpapi/completions/get_model_test.go
@@ -1,0 +1,158 @@
+package completions
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sourcegraph/sourcegraph/internal/completions/types"
+	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbmocks"
+)
+
+// getModelResult is a mock implementation of the getModelFn, one of the parameters
+// to newCompletionsHandler.
+type getModelResult struct {
+	Model string
+	Err   error
+}
+
+type mockGetModelFn struct {
+	results []getModelResult
+}
+
+func (m *mockGetModelFn) PushResult(model string, err error) {
+	result := getModelResult{
+		Model: model,
+		Err:   err,
+	}
+	m.results = append(m.results, result)
+}
+
+func (m *mockGetModelFn) ToFunc() func(context.Context, types.CodyCompletionRequestParameters, *conftypes.CompletionsConfig) (string, error) {
+	return func(context.Context, types.CodyCompletionRequestParameters, *conftypes.CompletionsConfig) (string, error) {
+		if len(m.results) == 0 {
+			panic("no call registered to getModels")
+		}
+		v := m.results[0]
+		m.results = m.results[1:]
+		return v.Model, v.Err
+	}
+}
+
+func TestGetCodeCompletionsModelFn(t *testing.T) {
+	ctx := context.Background()
+
+	validCompletionsConfig := conftypes.CompletionsConfig{
+		ChatModel:       "chat-model-in-config",
+		CompletionModel: "code-model-in-config",
+		FastChatModel:   "fast-chat-model-in-config",
+	}
+
+	getModelFn := getCodeCompletionModelFn()
+
+	t.Run("ErrorUnsupportedModel", func(t *testing.T) {
+
+		reqParams := types.CodyCompletionRequestParameters{
+			CompletionRequestParameters: types.CompletionRequestParameters{
+				Model: "model-the-user-requested",
+			},
+		}
+		_, err := getModelFn(ctx, reqParams, nil /* completionsConfig */)
+		require.ErrorContains(t, err, `unsupported code completion model "model-the-user-requested"`)
+
+		_, err2 := getModelFn(ctx, reqParams, &validCompletionsConfig)
+		require.ErrorContains(t, err2, `unsupported code completion model "model-the-user-requested"`)
+	})
+
+	t.Run("OverrideSiteConfig", func(t *testing.T) {
+		reqParams := types.CodyCompletionRequestParameters{
+			// BUG: This is inconsistent with how user-requested models work for "chats", which
+			// totally ignore user preferences. Here we _always_ honor the user's preference.
+			//
+			// We should reject requests to use models the calling user cannot access, or are not
+			// available to the current "Cody Pro Subscription" or "Cody Enterprise config".
+			CompletionRequestParameters: types.CompletionRequestParameters{
+				Model: "google/gemini-pro",
+			},
+		}
+		model, err := getModelFn(ctx, reqParams, nil)
+		require.NoError(t, err)
+		assert.Equal(t, "google/gemini-pro", model)
+	})
+
+	t.Run("Default", func(t *testing.T) {
+		// For these tests, the Model field in the request body isn't set.
+		t.Run("NoSiteConfig", func(t *testing.T) {
+			reqParams := types.CodyCompletionRequestParameters{}
+			_, err := getModelFn(ctx, reqParams, nil)
+			assert.ErrorContains(t, err, "no completions config available")
+		})
+		t.Run("WithSiteConfig", func(t *testing.T) {
+			reqParams := types.CodyCompletionRequestParameters{}
+			model, err := getModelFn(ctx, reqParams, &validCompletionsConfig)
+			require.NoError(t, err)
+			assert.Equal(t, "code-model-in-config", model)
+		})
+	})
+}
+
+func TestGetChatModelFn(t *testing.T) {
+	ctx := context.Background()
+	mockDB := dbmocks.NewMockDB()
+
+	validCompletionsConfig := conftypes.CompletionsConfig{
+		ChatModel:       "chat-model-in-config",
+		CompletionModel: "code-model-in-config",
+		FastChatModel:   "fast-chat-model-in-config",
+	}
+
+	t.Run("IgnoreRequestUseConfig", func(t *testing.T) {
+		t.Run("Chat", func(t *testing.T) {
+			getModelFn := getChatModelFn(mockDB)
+
+			reqParams := types.CodyCompletionRequestParameters{
+				CompletionRequestParameters: types.CompletionRequestParameters{
+					// For Cody Enterprise, this is totally ignored. Currently, only
+					// Cody Pro users can configure the chat model used.
+					// TODO(PRIME-283): Enable LLM model selection Cody Enterprise users.
+					Model: "model-the-user-requested",
+				},
+			}
+			model, err := getModelFn(ctx, reqParams, &validCompletionsConfig)
+
+			require.NoError(t, err)
+			assert.Equal(t, "chat-model-in-config", model)
+		})
+
+		t.Run("FastChat", func(t *testing.T) {
+			getModelFn := getChatModelFn(mockDB)
+
+			reqParams := types.CodyCompletionRequestParameters{
+				CompletionRequestParameters: types.CompletionRequestParameters{
+					// For Cody Enterprise, this is totally ignored. Currently, only
+					// Cody Pro users can configure the chat model used.
+					// TODO(PRIME-283): Enable LLM model selection Cody Enterprise users.
+					Model: "model-the-user-requested",
+				},
+				// .. but again, for "fast" chats.
+				Fast: true,
+			}
+			compConfig := conftypes.CompletionsConfig{
+				ChatModel:       "chat-model-in-config",
+				CompletionModel: "code-model-in-config",
+				FastChatModel:   "fast-chat-model-in-config",
+			}
+			model, err := getModelFn(ctx, reqParams, &compConfig)
+
+			require.NoError(t, err)
+			assert.Equal(t, "fast-chat-model-in-config", model)
+		})
+	})
+
+	// TODO(PRIME-283): As part of enabling model selection for Cody Enterprise users,
+	// add more tests for the Cody Pro path as well. Where we only allow certain models
+	// based on the calling user's subscription status, etc.
+}

--- a/cmd/frontend/internal/httpapi/completions/handler.go
+++ b/cmd/frontend/internal/httpapi/completions/handler.go
@@ -59,13 +59,13 @@ func newCompletionsHandler(
 	feature types.CompletionsFeature,
 	rl RateLimiter,
 	traceFamily string,
-	getModel func(context.Context, types.CodyCompletionRequestParameters, *conftypes.CompletionsConfig) (string, error),
+	getModel getModelFn,
 ) http.Handler {
 	responseHandler := newSwitchingResponseHandler(logger, db, feature)
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != "POST" {
-			http.Error(w, fmt.Sprintf("unsupported method %s", r.Method), http.StatusMethodNotAllowed)
+			http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
 			return
 		}
 
@@ -73,7 +73,8 @@ func newCompletionsHandler(
 		defer cancel()
 
 		if isEnabled, reason := cody.IsCodyEnabled(ctx, db); !isEnabled {
-			http.Error(w, fmt.Sprintf("cody is not enabled: %s", reason), http.StatusUnauthorized)
+			errResponse := fmt.Sprintf("cody is not enabled: %s", reason)
+			http.Error(w, errResponse, http.StatusUnauthorized)
 			return
 		}
 
@@ -99,11 +100,14 @@ func newCompletionsHandler(
 		isDotcom := dotcom.SourcegraphDotComMode()
 		if !isDotcom {
 			if err := checkClientCodyIgnoreCompatibility(ctx, db, r); err != nil {
+				logger.Info("rejecting request due to CodyIngore compat", log.Error(err))
 				http.Error(w, err.Error(), err.statusCode)
 				return
 			}
 		}
 
+		// We don't perform any sort of validation. So we would silently accept a totally bogus
+		// JSON payload. And just have a zero-value CompletionRequestParameters, e.g. no prompt.
 		var requestParams types.CodyCompletionRequestParameters
 		if err := json.NewDecoder(r.Body).Decode(&requestParams); err != nil {
 			http.Error(w, "could not decode request body", http.StatusBadRequest)
@@ -245,6 +249,9 @@ func newSwitchingResponseHandler(logger log.Logger, db database.DB, feature type
 func newStreamingResponseHandler(logger log.Logger, db database.DB, feature types.CompletionsFeature) func(ctx context.Context, requestParams types.CompletionRequestParameters, version types.CompletionsVersion, cc types.CompletionsClient, w http.ResponseWriter, userStore database.UserStore, test guardrails.AttributionTest) {
 	return func(ctx context.Context, requestParams types.CompletionRequestParameters, version types.CompletionsVersion, cc types.CompletionsClient, w http.ResponseWriter, userStore database.UserStore, test guardrails.AttributionTest) {
 		var eventWriter = sync.OnceValue[*streamhttp.Writer](func() *streamhttp.Writer {
+			// NOTE: The HTTP response defaults to 200 if not set explicitly before writing the response.
+			// This means that this function will never serve a non-OK response. (Which makes sense, since
+			// we don't know ahead of time if some later SSE event will fail.
 			eventWriter, err := streamhttp.NewWriter(w)
 			if err != nil {
 				http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/internal/completions/client/anthropic/prompt.go
+++ b/internal/completions/client/anthropic/prompt.go
@@ -35,7 +35,7 @@ func toAnthropicMessages(messages []types.Message) ([]anthropicMessage, error) {
 		case types.HUMAN_MESSAGE_SPEAKER:
 			anthropicRole = "user"
 		default:
-			return nil, errors.Errorf("unexpected role: %s", text)
+			return nil, errors.Errorf("unexpected role: %s", speaker)
 		}
 
 		if text == "" {

--- a/internal/completions/client/awsbedrock/bedrock.go
+++ b/internal/completions/client/awsbedrock/bedrock.go
@@ -427,7 +427,7 @@ func toAnthropicMessages(messages []types.Message) ([]bedrockAnthropicMessage, e
 		case types.HUMAN_MESSAGE_SPEAKER:
 			anthropicRole = "user"
 		default:
-			return nil, errors.Errorf("unexpected role: %s", text)
+			return nil, errors.Errorf("unexpected role: %s", speaker)
 		}
 
 		if text == "" {

--- a/internal/completions/client/google/prompt.go
+++ b/internal/completions/client/google/prompt.go
@@ -35,7 +35,7 @@ func getAnthropicPrompt(messages []types.Message) ([]anthropicMessage, string, e
 		case types.HUMAN_MESSAGE_SPEAKER:
 			anthropicRole = "user"
 		default:
-			return nil, "", errors.Errorf("unexpected role: %s", message.Text)
+			return nil, "", errors.Errorf("unexpected role: %s", message.Speaker)
 		}
 
 		// Trim whitespace from the message text if it's the last message


### PR DESCRIPTION
The [Server-side Cody Model Selection](https://linear.app/sourcegraph/project/server-side-cody-model-selection-cca47c48da6d) project requires refactoring a lot of how the Completions API endpoint works for the Sourcegraph backend. It will need to update any place where we interact with the site config as it relates to LLMs, or any time we figure out which models can-or-can-not be used.

In order to safely land those refactoring without breaking existing users, who will be using the "older config format", we need tests. LOTS and LOTS of tests.

This PR adds the necessary infrastructure for writing unit tests against the Completions API, and adds a few basic ones for the Anthropic API provider. I wouldn't say it's as easy as we'd like to write these tests, but at least now it is _possible_. And we can further streamline things from here.

## Overview

The bulk of functionality is in `entconfig_base_test.go`. That file contains some basic unit tests for how the enterprise configuration data is loaded, and provides the mocks and test infrastructure.

The crux of which is the `apiProviderTestInfra` struct. It will bundle mocks and the HTTP handlers to test, and provides high-level methods for invoking the completion API.

```go
type apiProviderTestInfra struct {}

func (ti *apiProviderTestInfra) PushGetModelResult(model string, err error)
func (ti *apiProviderTestInfra) SetSiteConfig(siteConfig schema.SiteConfiguration)
func (ti *apiProviderTestInfra) CallChatCompletionAPI(t *testing.T, reqObj types.CodyCompletionRequestParameters) (int, string)
func (ti *apiProviderTestInfra) CallCodeCompletionAPI(t *testing.T, reqObj types.CodyCompletionRequestParameters) (int, string)
func (ti *apiProviderTestInfra) AssertCompletionsResponse(t *testing.T, rawResponseJSON string, wantResponse types.CompletionResponse)
```

What gets trick however, is how we actually hook into the implementation details of the completions API endpoint. You see, the user makes an HTTP request to the Sourcegraph instance. But we then figure out which LLM model to use, and then build an HTTP request to send to the specific LLM API Provider.

So the test infrastructure allows you to mock out that "middle part". The `AssertCodyGatewayReceivesRequestWithResponse`/`AssertGenericExternalAPIRequestWithResponse` functions will:

1. Verify that the Sourcegraph instance is making an API call to the LLM provider that matches the format we expect. (e.g. using the correct Anthropic API request, etc.)
2. The outbound HTTP request looks like it should, that it contains the right authorization headers, URL path, etc. (e.g. is it using the API key from the site config?)
3. Finally, it returns the HTTP response from the API provider. (i.e. whatever Anthropic or Cody Gateway would have returned.)

```go
type assertLLMRequestOptions struct {
	// WantRequestObj is what we expect the outbound HTTP request's JSON body
	// to be equal to. Required.
	WantRequestObj any
	// OutResponseObj is serialized to JSON and sent to the caller, i.e. our
	// LLM API Provider which is making the API request. Required.
	OutResponseObj any

	// WantRequestPath is the URL Path we expect in the outbound HTTP request.
	// No check is done if empty.
	WantRequestPath string

	// WantHeaders are HTTP header key/value pairs that must be present.
	WantHeaders map[string]string
}
func (ti *apiProviderTestInfra) AssertCodyGatewayReceivesRequestWithResponse(
	t *testing.T, opts assertLLMRequestOptions)
func (ti *apiProviderTestInfra) AssertGenericExternalAPIRequestWithResponse(
	t *testing.T, opts assertLLMRequestOptions)
```

Unfortunately it's super gnarly because we aren't really exposing the API data types from the API providers in a useful way. (e.g. perhaps we should just use the standard Anthropic Golang API client library.) So generating the test data relies on a lot of `map[string]any` to make it easier to construct arbitrary data types that can serialize to JSON the way that we need them to.

Anyways, with all of this test infrastructure in-place, you can write API provider tests like the following. Here's one such test from `entconfig_anthropic_test.go` which confirms that various aspects of the site-configuration are honored correctly when configured to use BYOK mode.

I've added "ℹ️ comments" to highlight some of the tricker parts.


```go
t.Run("ViaBYOK", func(t *testing.T) {
		const (
			anthropicAPIKeyInConfig      = "secret-api-key"
			anthropicAPIEndpointInConfig = "https://byok.anthropic.com/path/from/config"
			chatModelInConfig            = "anthropic/claude-3-opus"
			codeModelInConfig            = "anthropic/claude-3-haiku"
		)

		infra.SetSiteConfig(schema.SiteConfiguration{
			CodyEnabled:                  pointers.Ptr(true),
			CodyPermissions:              pointers.Ptr(false),
			CodyRestrictUsersFeatureFlag: pointers.Ptr(false),

			// LicenseKey is required in order to use Cody.
			LicenseKey: "license-key",
			Completions: &schema.Completions{
				Provider:    "anthropic",
				AccessToken: anthropicAPIKeyInConfig,
				Endpoint:    anthropicAPIEndpointInConfig,

				ChatModel:       chatModelInConfig,
				CompletionModel: codeModelInConfig,
			},
		})

		t.Run("ChatModel", func(t *testing.T) {
			// ℹ️ Generating the "wantAnthropicRequest" and "outAnthropicResponse"
			// data is super-tedious. So we instead have a single function
			// that returns "a valid set", that we then customize.
			// So here, we just update the model we expect to see in the API
			// call to Anthropic.

			// Start with the stock test data, but customize it to reflect
			// what we expect to see based on the site configuration.
			testData := getValidTestData()
			testData.OutboundAnthropicRequest["model"] = "anthropic/claude-3-opus"

			// Register our hook to verify Cody Gateway got called with
			// the requested data.
			infra.AssertGenericExternalAPIRequestWithResponse(
				t, assertLLMRequestOptions{
					WantRequestPath: "/path/from/config",
					WantRequestObj:  &testData.OutboundAnthropicRequest,
					OutResponseObj:  &testData.InboundAnthropicRequest,
					WantHeaders: map[string]string{
						// Yes, Anthropic's API uses "X-Api-Key" rather than the "Authorization" header. 🤷
						"X-Api-Key": anthropicAPIKeyInConfig,
					},
				})

			// ℹ️ This `PushGetModelResult` is just a quirk of how the code
			// under test works. We mock out the `getModelFn` that is invoked
			// to resolve the _actual_ LLM model to use. (And not necessarily
			// use the one from the HTTP request.)
			infra.PushGetModelResult(chatModelInConfig, nil)

			status, responseBody := infra.CallChatCompletionAPI(t, testData.InitialCompletionRequest)

			assert.Equal(t, http.StatusOK, status)
			infra.AssertCompletionsResponse(t, responseBody, types.CompletionResponse{
				// ℹ️ The "totally rewrite it in Rust!" is coming from the
				// fake Anthropic response, from `getValidTestData`.
				Completion: "you should totally rewrite it in Rust!",
				StopReason: "max_tokens",
				Logprobs:   nil,
			})
		})
	})
```

## Next steps

Once this gets checked-in, my plan is to carefully add new unit tests for the existing functionality before DISMANTLING the code to write through an entirely different site configuration object. 🤞 this will allow me to do so in such a way that I can confirm my changes won't alter any existing Sourcegraph instances that are using the older configuration format.

## Test plan

Adds more tests.

## Changelog

NA. Just trivial changes and adding more tests.
