### PR TITLE
support fast, simple `sg start single-program-experimental-blame-sqs` for local dev

### DIFF
--- a/cmd/appliance/main.go
+++ b/cmd/appliance/main.go
@@ -8,5 +8,5 @@ import (
 
 func main() {
 	sanitycheck.Pass()
-	svcmain.SingleServiceMainWithoutConf(shared.Service, svcmain.OutOfBandConfiguration{})
+	svcmain.SingleServiceMainWithoutConf(shared.Service, nil, svcmain.OutOfBandConfiguration{})
 }

--- a/cmd/cody-gateway/main.go
+++ b/cmd/cody-gateway/main.go
@@ -15,7 +15,7 @@ var sentryDSN = env.Get("CODY_GATEWAY_SENTRY_DSN", "", "Sentry DSN")
 
 func main() {
 	sanitycheck.Pass()
-	svcmain.SingleServiceMainWithoutConf(shared.Service, svcmain.OutOfBandConfiguration{
+	svcmain.SingleServiceMainWithoutConf(shared.Service, nil, svcmain.OutOfBandConfiguration{
 		Logging: func() conf.LogSinksSource {
 			if sentryDSN == "" {
 				return nil

--- a/cmd/frontend/BUILD.bazel
+++ b/cmd/frontend/BUILD.bazel
@@ -10,13 +10,8 @@ go_library(
     importpath = "github.com/sourcegraph/sourcegraph/cmd/frontend",
     visibility = ["//visibility:private"],
     deps = [
-        "//client/web/dist",
         "//cmd/frontend/shared",
-        "//internal/conf",
         "//internal/sanitycheck",
-        "//internal/service/svcmain",
-        "//internal/tracer",
-        "//ui/assets",
     ],
 )
 

--- a/cmd/frontend/main.go
+++ b/cmd/frontend/main.go
@@ -2,27 +2,11 @@
 package main
 
 import (
-	"os"
-
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/shared"
-	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/sanitycheck"
-	"github.com/sourcegraph/sourcegraph/internal/service/svcmain"
-	"github.com/sourcegraph/sourcegraph/internal/tracer"
-	"github.com/sourcegraph/sourcegraph/ui/assets"
-
-	_ "github.com/sourcegraph/sourcegraph/client/web/dist" // use assets
 )
 
 func main() {
 	sanitycheck.Pass()
-	if os.Getenv("WEB_BUILDER_DEV_SERVER") == "1" {
-		assets.UseDevAssetsProvider()
-	}
-	svcmain.SingleServiceMainWithoutConf(shared.Service, svcmain.OutOfBandConfiguration{
-		// use a switchable config here so we can switch it out for a proper conf client
-		// once we can use it after autoupgrading
-		Logging: conf.NewLogsSinksSource(shared.SwitchableSiteConfig()),
-		Tracing: tracer.ConfConfigurationSource{WatchableSiteConfig: shared.SwitchableSiteConfig()},
-	})
+	shared.FrontendMain(nil)
 }

--- a/cmd/frontend/shared/BUILD.bazel
+++ b/cmd/frontend/shared/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
     importpath = "github.com/sourcegraph/sourcegraph/cmd/frontend/shared",
     visibility = ["//visibility:public"],
     deps = [
+        "//client/web/dist",
         "//cmd/frontend/enterprise",
         "//cmd/frontend/internal/auth",
         "//cmd/frontend/internal/authz",
@@ -51,7 +52,10 @@ go_library(
         "//internal/observation",
         "//internal/oobmigration/migrations/register",
         "//internal/service",
+        "//internal/service/svcmain",
+        "//internal/tracer",
         "//schema",
+        "//ui/assets",
         "@com_github_sourcegraph_log//:log",
     ],
 )

--- a/cmd/frontend/shared/shared.go
+++ b/cmd/frontend/shared/shared.go
@@ -129,7 +129,7 @@ func mustInitializeCodeIntelDB(logger log.Logger) codeintelshared.CodeIntelDB {
 	return codeintelshared.NewCodeIntelDB(logger, db)
 }
 
-func SwitchableSiteConfig() conftypes.WatchableSiteConfig {
+func switchableSiteConfig() conftypes.WatchableSiteConfig {
 	confClient := conf.DefaultClient()
 	switchable := &switchingSiteConfig{
 		watchers:            make([]func(), 0),

--- a/cmd/sourcegraph/BUILD.bazel
+++ b/cmd/sourcegraph/BUILD.bazel
@@ -1,0 +1,23 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "sourcegraph_lib",
+    srcs = ["main.go"],
+    importpath = "github.com/sourcegraph/sourcegraph/cmd/sourcegraph",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//cmd/frontend/shared",
+        "//cmd/gitserver/shared",
+        "//cmd/repo-updater/shared",
+        "//cmd/searcher/shared",
+        "//cmd/worker/shared",
+        "//internal/sanitycheck",
+        "//internal/service",
+    ],
+)
+
+go_binary(
+    name = "sourcegraph",
+    embed = [":sourcegraph_lib"],
+    visibility = ["//visibility:public"],
+)

--- a/cmd/sourcegraph/README.md
+++ b/cmd/sourcegraph/README.md
@@ -1,0 +1,7 @@
+# Single-program distribution (dev only)
+
+Run `sg start single-program-experimental-blame-sqs` to run Sourcegraph locally with some services. This can be faster than `sg start`, which runs more services and compiles/runs them each individually.
+
+Use at your own risk, and blame @sqs if this has any problems.
+
+**Status:** only for local dev

--- a/cmd/sourcegraph/main.go
+++ b/cmd/sourcegraph/main.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"github.com/sourcegraph/sourcegraph/internal/sanitycheck"
+	"github.com/sourcegraph/sourcegraph/internal/service"
+
+	frontend_shared "github.com/sourcegraph/sourcegraph/cmd/frontend/shared"
+	gitserver_shared "github.com/sourcegraph/sourcegraph/cmd/gitserver/shared"
+	repoupdater_shared "github.com/sourcegraph/sourcegraph/cmd/repo-updater/shared"
+	searcher_shared "github.com/sourcegraph/sourcegraph/cmd/searcher/shared"
+	worker_shared "github.com/sourcegraph/sourcegraph/cmd/worker/shared"
+)
+
+func main() {
+	sanitycheck.Pass()
+
+	// Other services to run (in addition to `frontend`).
+	otherServices := []service.Service{
+		gitserver_shared.Service,
+		repoupdater_shared.Service,
+		searcher_shared.Service,
+		worker_shared.Service,
+	}
+
+	frontend_shared.FrontendMain(otherServices)
+}

--- a/dev/linters/dbconn/dbconn.go
+++ b/dev/linters/dbconn/dbconn.go
@@ -26,6 +26,7 @@ func (*importsDbConn) AFact() {}
 var allowedToImport = []string{
 	"github.com/sourcegraph/sourcegraph/cmd/embeddings",
 	"github.com/sourcegraph/sourcegraph/cmd/frontend",
+	"github.com/sourcegraph/sourcegraph/cmd/sourcegraph",
 	"github.com/sourcegraph/sourcegraph/cmd/gitserver",
 	"github.com/sourcegraph/sourcegraph/cmd/migrator",
 	// Transitively depends on updatecheck package which imports but does not use DB

--- a/internal/conf/deploy/deploytype.go
+++ b/internal/conf/deploy/deploytype.go
@@ -20,13 +20,8 @@ const (
 
 var mock string
 
-var forceType string // force a deploy type (can be injected with `go build -ldflags "-X ..."`)
-
 // Type tells the deployment type.
 func Type() string {
-	if forceType != "" {
-		return forceType
-	}
 	if mock != "" {
 		return mock
 	}

--- a/internal/repos/observability.go
+++ b/internal/repos/observability.go
@@ -171,9 +171,9 @@ func (sm StoreMetrics) MustRegister(r prometheus.Registerer) {
 		sm.GetExternalService,
 		sm.SetClonedRepos,
 	} {
-		r.MustRegister(om.Count)
-		r.MustRegister(om.Duration)
-		r.MustRegister(om.Errors)
+		metrics.MustRegisterIgnoreDuplicate(r, om.Count)
+		metrics.MustRegisterIgnoreDuplicate(r, om.Duration)
+		metrics.MustRegisterIgnoreDuplicate(r, om.Errors)
 	}
 }
 

--- a/internal/service/svcmain/svcmain.go
+++ b/internal/service/svcmain/svcmain.go
@@ -29,20 +29,8 @@ import (
 // If your service cannot access site configuration, use SingleServiceMainWithoutConf
 // instead.
 func SingleServiceMain(svc sgservice.Service) {
-	liblog := log.Init(log.Resource{
-		Name:       env.MyName,
-		Version:    version.Version(),
-		InstanceID: hostname.Get(),
-	},
-		// Experimental: DevX is observing how sampling affects the errors signal.
-		log.NewSentrySinkWith(
-			log.SentrySink{
-				ClientOptions: sentry.ClientOptions{SampleRate: 0.2},
-			},
-		),
-	)
-	logger := log.Scoped("sourcegraph")
-	run(liblog, logger, svc, nil)
+	liblog, logger := newLogger()
+	run(liblog, logger, []sgservice.Service{svc}, nil)
 }
 
 // OutOfBandConfiguration declares additional configuration that happens continuously,
@@ -60,7 +48,12 @@ type OutOfBandConfiguration struct {
 // service WITHOUT site configuration enabled by default. This is only useful for services
 // that are not part of the core Sourcegraph deployment, such as executors and managed
 // services. Use with care!
-func SingleServiceMainWithoutConf(svc sgservice.Service, oobConfig OutOfBandConfiguration) {
+func SingleServiceMainWithoutConf(svc sgservice.Service, otherServices []sgservice.Service, oobConfig OutOfBandConfiguration) {
+	liblog, logger := newLogger()
+	run(liblog, logger, append([]sgservice.Service{svc}, otherServices...), &oobConfig)
+}
+
+func newLogger() (*log.PostInitCallbacks, log.Logger) {
 	liblog := log.Init(log.Resource{
 		Name:       env.MyName,
 		Version:    version.Version(),
@@ -74,13 +67,13 @@ func SingleServiceMainWithoutConf(svc sgservice.Service, oobConfig OutOfBandConf
 		),
 	)
 	logger := log.Scoped("sourcegraph")
-	run(liblog, logger, svc, &oobConfig)
+	return liblog, logger
 }
 
 func run(
 	liblog *log.PostInitCallbacks,
 	logger log.Logger,
-	service sgservice.Service,
+	services []sgservice.Service,
 	// If nil, will use site config
 	oobConfig *OutOfBandConfiguration,
 ) {
@@ -108,38 +101,75 @@ func run(
 
 	profiler.Init(logger)
 
-	obctx := observation.ContextWithLogger(log.Scoped(service.Name()), observation.NewContext(logger))
+	obctx := observation.NewContext(logger)
 	ctx := context.Background()
 
-	// Run the service Configure func before env vars are locked.
-	serviceConfig, debugserverEndpoints := service.Configure()
+	allReady := make(chan struct{})
 
-	// Validate the service's configuration.
+	// Run the services' Configure funcs before env vars are locked.
+	var (
+		serviceConfigs          = make([]env.Config, len(services))
+		allDebugserverEndpoints []debugserver.Endpoint
+	)
+	for i, s := range services {
+		var debugserverEndpoints []debugserver.Endpoint
+		serviceConfigs[i], debugserverEndpoints = s.Configure()
+		allDebugserverEndpoints = append(allDebugserverEndpoints, debugserverEndpoints...)
+	}
+
+	// Validate each service's configuration.
 	//
 	// This cannot be done for executor, see the executorcmd package for details.
-	if serviceConfig != nil {
-		if err := serviceConfig.Validate(); err != nil {
-			logger.Fatal("invalid configuration", log.String("service", service.Name()), log.Error(err))
+	for i, c := range serviceConfigs {
+		if c == nil {
+			continue
+		}
+		if err := c.Validate(); err != nil {
+			logger.Fatal("invalid configuration", log.String("service", services[i].Name()), log.Error(err))
 		}
 	}
 
 	env.Lock()
 	env.HandleHelpFlag()
 
-	// Start the debug server. The ready boolean state it publishes will become true when
-	// the service reports ready.
-	ready := make(chan struct{})
-	go debugserver.NewServerRoutine(ready, debugserverEndpoints...).Start()
+	// Start the debug server. The ready boolean state it publishes will become true when *all*
+	// services report ready.
+	var allReadyWG sync.WaitGroup
+	var allDoneWG sync.WaitGroup
+	go debugserver.NewServerRoutine(allReady, allDebugserverEndpoints...).Start()
 
-	readyFunc := sync.OnceFunc(func() {
-		close(ready)
-	})
+	// Start the services.
+	for i := range services {
+		service := services[i]
+		serviceConfig := serviceConfigs[i]
+		allReadyWG.Add(1)
+		allDoneWG.Add(1)
+		go func() {
+			// TODO(sqs): TODO(single-binary): Consider using the goroutine package and/or the errgroup package to report
+			// errors and listen to signals to initiate cleanup in a consistent way across all
+			// services.
+			obctx := observation.ContextWithLogger(log.Scoped(service.Name()), obctx)
 
-	// Start the service.
-	// TODO: It's not clear or enforced but all the service.Start calls block until the service is completed
-	// This should be made explicit or refactored to accept to done channel or function in addition to ready.
-	err := service.Start(ctx, obctx, readyFunc, serviceConfig)
-	if err != nil {
-		logger.Fatal("failed to start service", log.String("service", service.Name()), log.Error(err))
+			// ensure ready is only called once and always call it.
+			ready := sync.OnceFunc(allReadyWG.Done)
+			defer ready()
+
+			// TODO: It's not clear or enforced but all the service.Start calls block until the service is completed
+			// This should be made explicit or refactored to accept to done channel or function in addition to ready.
+			err := service.Start(ctx, obctx, ready, serviceConfig)
+			allDoneWG.Done()
+			if err != nil {
+				logger.Fatal("failed to start service", log.String("service", service.Name()), log.Error(err))
+			}
+		}()
 	}
+
+	// Pass along the signal to the debugserver that all started services are ready.
+	go func() {
+		allReadyWG.Wait()
+		close(allReady)
+	}()
+
+	// wait for all services to stop
+	allDoneWG.Wait()
 }

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -1040,6 +1040,34 @@ commands:
     cmd: pnpm --filter @sourcegraph/browser dev
     install: pnpm install
 
+  sourcegraph:
+    description: Single-program distribution (dev only)
+    cmd: |
+      export SOURCEGRAPH_LICENSE_GENERATION_KEY=$(cat ../dev-private/enterprise/dev/test-license-generation-key.pem)
+      .bin/sourcegraph
+    install: |
+      if [ -n "$DELVE" ]; then
+        export GCFLAGS='all=-N -l'
+      fi
+      go build -buildvcs=false -gcflags="$GCFLAGS" -o .bin/sourcegraph github.com/sourcegraph/sourcegraph/cmd/sourcegraph
+    checkBinary: .bin/sourcegraph
+    env:
+      CONFIGURATION_MODE: server
+      SITE_CONFIG_FILE: '../dev-private/enterprise/dev/site-config.json'
+      SITE_CONFIG_ESCAPE_HATCH_PATH: '$HOME/.sourcegraph/site-config.json'
+      EXTSVC_CONFIG_FILE: ../dev-private/enterprise/dev/external-services-config.json
+      WEB_BUILDER_DEV_SERVER: 1
+      INDEXED_SEARCH_SERVERS:
+      GITSERVER_ADDR: 127.0.0.1:3178
+      GITSERVER_EXTERNAL_ADDR: 127.0.0.1:3178
+      SRC_GIT_SERVERS: 127.0.0.1:3178
+      SRC_DISABLE_OOBMIGRATION_VALIDATION: 1
+    watch:
+      - cmd
+      - internal
+      - lib
+      - schema
+
 bazelCommands:
   blobstore:
     target: //cmd/blobstore
@@ -1781,19 +1809,20 @@ commandsets:
       - otel-collector
       - jaeger
 
-  single-program:
+  # NOTE: This is an experimental way of running a subset of Sourcegraph. See
+  # cmd/sourcegraph/README.md.
+  single-program-experimental-blame-sqs:
     checks:
       - git
       - dev-private
+      - redis
     commands:
       - sourcegraph
       - web
       - caddy
     env:
-      DISABLE_CODE_INSIGHTS: false
-      PRECISE_CODE_INTEL_UPLOAD_AWS_ENDPOINT: http://localhost:49000
-      EMBEDDINGS_UPLOAD_AWS_ENDPOINT: http://localhost:49000
-      USE_EMBEDDED_POSTGRESQL: false
+      # Faster builds in local dev.
+      DEV_WEB_BUILDER_NO_SPLITTING: 1
 
   cody-gateway:
     checks:


### PR DESCRIPTION
This makes it easier to run Sourcegraph in local dev by compiling a few key services (frontend, searcher, repo-updater, gitserver, and worker) into a single Go binary and running that.

Compared to `sg start` (which compiles and runs ~10 services), it's faster to start up (by ~10% or a few seconds), takes a lot less memory and CPU when running, has less log noise, and rebuilds faster. It is slower to recompile for changes just to `frontend` because it needs to link in more code on each recompile, but it's faster for most other Go changes that require recompilation of multiple services.

This is only intended for local dev as a convenience. There may be different behavior in this mode that could result in problems when your code runs in the normal deployment. Usually our e2e tests should catch this, but to be safe, you should run in the usual mode if you are making sensitive cross-service changes.

Partially reverts "svcmain: Simplify service setup (#61903)" (commit 95410322925a4d78883290e01095086d11239877).


## Test plan

Existing tests cover any regressions to existing behavior. This new behavior is for local dev only.