### PR TITLE
chore(batch-changes): remove beta badge from Batch Changes page

### DIFF
--- a/client/web/src/enterprise/batches/batch-spec/header/BatchChangeHeader.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/header/BatchChangeHeader.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 import classNames from 'classnames'
 
-import { PageHeader, FeedbackBadge } from '@sourcegraph/wildcard'
+import { PageHeader } from '@sourcegraph/wildcard'
 
 import { BatchChangesIcon } from '../../../../batches/icons'
 
@@ -22,7 +22,6 @@ export const BatchChangeHeader: React.FC<BatchChangeHeaderProps> = ({ className,
     <PageHeader
         className={classNames('flex-1 pb-2', styles.header, className)}
         description={description || 'Run and manage large-scale changes across many repositories.'}
-        annotation={<FeedbackBadge status="beta" feedback={{ mailto: 'support@sourcegraph.com' }} />}
     >
         <PageHeader.Heading as="h2" styleAs="h1">
             <PageHeader.Breadcrumb icon={BatchChangesIcon} />


### PR DESCRIPTION
This PR removes the Beta badge from the Batch Changes pages. SSBC has been in Beta for sometime and this doesn't reflect the true status of the product.

![CleanShot 2024-06-24 at 11 06 22@2x](https://github.com/sourcegraph/sourcegraph/assets/25608335/fa102b9b-d53a-44c2-b93e-4c400985a4e2)


## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles -->

Navigate to the `/batch-changes/create` page and the Beta badge shouldn't be there.


## Changelog

- the Beta badge is now removed from Batch Changes 
