### PR TITLE
scip-syntax: adds strict SCIP symbol parsing and formatting

### DIFF
--- a/docker-images/syntax-highlighter/Cargo.Bazel.lock
+++ b/docker-images/syntax-highlighter/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "16af7384c373f405b14982ed18dfb8fd320f4c727086dc073cd004d1316c351d",
+  "checksum": "29abc93382c22b38f87c9f8db7894be1e88ba39e3e45b46fd61a08be146a87e5",
   "crates": {
     "addr2line 0.20.0": {
       "name": "addr2line",
@@ -6479,6 +6479,42 @@
       },
       "license": "MIT OR Apache-2.0"
     },
+    "minimal-lexical 0.2.1": {
+      "name": "minimal-lexical",
+      "version": "0.2.1",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/minimal-lexical/0.2.1/download",
+          "sha256": "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "minimal_lexical",
+            "crate_root": "src/lib.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        }
+      ],
+      "library_target_name": "minimal_lexical",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "std"
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "0.2.1"
+      },
+      "license": "MIT/Apache-2.0"
+    },
     "miniz_oxide 0.7.1": {
       "name": "miniz_oxide",
       "version": "0.7.1",
@@ -6794,6 +6830,57 @@
         },
         "edition": "2018",
         "version": "0.23.2"
+      },
+      "license": "MIT"
+    },
+    "nom 7.1.3": {
+      "name": "nom",
+      "version": "7.1.3",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/nom/7.1.3/download",
+          "sha256": "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "nom",
+            "crate_root": "src/lib.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        }
+      ],
+      "library_target_name": "nom",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "alloc",
+            "default",
+            "std"
+          ],
+          "selects": {}
+        },
+        "deps": {
+          "common": [
+            {
+              "id": "memchr 2.5.0",
+              "target": "memchr"
+            },
+            {
+              "id": "minimal-lexical 0.2.1",
+              "target": "minimal_lexical"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "7.1.3"
       },
       "license": "MIT"
     },
@@ -10613,6 +10700,10 @@
               "target": "lazy_static"
             },
             {
+              "id": "nom 7.1.3",
+              "target": "nom"
+            },
+            {
               "id": "path-clean 1.0.1",
               "target": "path_clean"
             },
@@ -10657,6 +10748,10 @@
         },
         "deps_dev": {
           "common": [
+            {
+              "id": "criterion 0.4.0",
+              "target": "criterion"
+            },
             {
               "id": "tempfile 3.10.1",
               "target": "tempfile"
@@ -18756,6 +18851,7 @@
     "insta 1.34.0",
     "itertools 0.10.5",
     "lazy_static 1.4.0",
+    "nom 7.1.3",
     "once_cell 1.18.0",
     "paste 1.0.14",
     "path-clean 1.0.1",

--- a/docker-images/syntax-highlighter/Cargo.lock
+++ b/docker-images/syntax-highlighter/Cargo.lock
@@ -1933,6 +1933,7 @@ dependencies = [
  "camino",
  "clap 4.3.23",
  "colored",
+ "criterion",
  "indicatif",
  "insta",
  "lazy_static",

--- a/docker-images/syntax-highlighter/Cargo.lock
+++ b/docker-images/syntax-highlighter/Cargo.lock
@@ -1171,6 +1171,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1230,6 +1236,16 @@ dependencies = [
  "cfg-if",
  "libc",
  "memoffset 0.6.5",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -1920,6 +1936,7 @@ dependencies = [
  "indicatif",
  "insta",
  "lazy_static",
+ "nom",
  "paste",
  "path-clean",
  "predicates",

--- a/docker-images/syntax-highlighter/Cargo.toml
+++ b/docker-images/syntax-highlighter/Cargo.toml
@@ -61,6 +61,7 @@ tree-sitter-highlight = "0.20.1"
 walkdir = "2"
 path-clean = "1"
 camino = "1.1"
+nom = "7.1.3"
 
 scip = "0.3.2"
 protobuf = "3"

--- a/docker-images/syntax-highlighter/crates/scip-syntax/BUILD.bazel
+++ b/docker-images/syntax-highlighter/crates/scip-syntax/BUILD.bazel
@@ -28,9 +28,7 @@ WORKSPACE_DEPS = [
 rust_library(
     name = "scip_syntax_lib",
     srcs = glob(
-        [
-            "src/*.rs",
-        ],
+        ["src/**/*.rs"],
         allow_empty = False,
         exclude = ["src/main.rs"],
     ),
@@ -49,7 +47,11 @@ rust_library(
 rust_test(
     name = "unit_test",
     size = "small",
-    srcs = glob(["src/*.rs"]),
+    srcs = glob(
+        ["src/**/*.rs"],
+        allow_empty = False,
+        exclude = ["src/main.rs"],
+    ),
     proc_macro_deps = all_crate_deps(
         proc_macro = True,
     ),
@@ -68,7 +70,11 @@ rust_test(
 rust_test(
     name = "integration_test",
     size = "small",
-    srcs = glob(["tests/*.rs"]),
+    srcs = glob(
+        ["src/**/*.rs"],
+        allow_empty = False,
+        exclude = ["src/main.rs"],
+    ),
     compile_data = glob(
         [
             "testdata/**",

--- a/docker-images/syntax-highlighter/crates/scip-syntax/Cargo.toml
+++ b/docker-images/syntax-highlighter/crates/scip-syntax/Cargo.toml
@@ -26,6 +26,7 @@ walkdir = { workspace = true }
 path-clean = { workspace = true }
 camino = { workspace = true }
 tree-sitter = { workspace = true }
+nom = { workspace = true }
 
 syntax-analysis = { path = "../syntax-analysis" }
 tree-sitter-all-languages = { path = "../tree-sitter-all-languages" }

--- a/docker-images/syntax-highlighter/crates/scip-syntax/Cargo.toml
+++ b/docker-images/syntax-highlighter/crates/scip-syntax/Cargo.toml
@@ -6,6 +6,10 @@ edition = "2021"
 [[bin]]
 name = "scip-syntax"
 
+[[bench]]
+name = "symbol_parsing"
+harness = false
+
 [dependencies]
 assert_cmd = "2.0.12"
 predicates = "3.0.4"
@@ -34,3 +38,4 @@ tar = "0.4.40"
 
 [dev-dependencies]
 tempfile="3.10.1"
+criterion = { version = "0.4", features = ["html_reports"] }

--- a/docker-images/syntax-highlighter/crates/scip-syntax/benches/symbol_parsing.rs
+++ b/docker-images/syntax-highlighter/crates/scip-syntax/benches/symbol_parsing.rs
@@ -1,0 +1,47 @@
+use camino::Utf8Path;
+use criterion::{criterion_group, criterion_main, Criterion};
+use scip_syntax::{io::read_index_from_file, scip_strict};
+
+fn parse_symbols(symbols: &[&str]) {
+    for symbol in symbols {
+        scip::symbol::parse_symbol(symbol).unwrap();
+    }
+}
+
+fn parse_symbols_v2(symbols: &[&str]) {
+    for symbol in symbols {
+        scip_strict::Symbol::parse(&symbol).unwrap();
+    }
+}
+
+fn symbols_from_index(path: &str) -> impl Iterator<Item = String> {
+    let index = read_index_from_file(Utf8Path::new(path))
+    .unwrap();
+    index
+        .documents
+        .into_iter()
+        .flat_map(|document| {
+            document
+                .occurrences
+                .into_iter()
+                .map(|occurrence| occurrence.symbol)
+        })
+}
+
+fn bench_symbol_parsing(c: &mut Criterion) {
+    // let all_symbols: Vec<String> = symbols_from_index("~/work/scip-indices/spring-framework-syntactic.scip").collect();
+    let all_symbols: Vec<String> = symbols_from_index("/Users/creek/work/scip-indices/chromium-1.scip").collect();
+    let symbol_count = all_symbols.len();
+    let n = 10_000;
+    let symbols: Vec<&str> = all_symbols.iter().step_by(symbol_count / n).map(|s| s.as_str()).collect();
+    let mut group = c.benchmark_group("symbol parsing");
+    group.bench_function("parse", |b| {
+        b.iter(|| parse_symbols(&symbols))
+    });
+    group.bench_function("parse_v2", |b| {
+        b.iter(|| parse_symbols_v2(&symbols))
+    });
+}
+
+criterion_group!(benches, bench_symbol_parsing);
+criterion_main!(benches);

--- a/docker-images/syntax-highlighter/crates/scip-syntax/src/evaluate.rs
+++ b/docker-images/syntax-highlighter/crates/scip-syntax/src/evaluate.rs
@@ -736,7 +736,7 @@ impl SymbolFormatter {
             return sym;
         };
         symbol.package = scip_strict::Package::default();
-        return self.make_symbol_id(&symbol.to_string());
+        self.make_symbol_id(&symbol.to_string())
     }
 }
 

--- a/docker-images/syntax-highlighter/crates/scip-syntax/src/evaluate.rs
+++ b/docker-images/syntax-highlighter/crates/scip-syntax/src/evaluate.rs
@@ -13,9 +13,8 @@ use scip::types::Index;
 use serde::Serializer;
 use string_interner::{symbol::SymbolU32, StringInterner, Symbol};
 use syntax_analysis::range::Range;
-use crate::scip_strict;
 
-use crate::{io::read_index_from_file, progress::*};
+use crate::{io::read_index_from_file, progress::*, scip_strict};
 
 pub fn evaluate_command(
     candidate: &Utf8Path,
@@ -732,11 +731,12 @@ impl SymbolFormatter {
 
     fn try_strip_package_details<T: Copy>(&mut self, sym: SymbolId<T>) -> SymbolId<T> {
         let s = self.display_symbol(sym);
-        let Result::Ok(scip_strict::Symbol::NonLocal(mut symbol)) = scip_strict::Symbol::parse(s) else {
-            return sym
+        let Result::Ok(scip_strict::Symbol::NonLocal(mut symbol)) = scip_strict::Symbol::parse(s)
+        else {
+            return sym;
         };
         symbol.package = scip_strict::Package::default();
-        return self.make_symbol_id(&symbol.to_string())
+        return self.make_symbol_id(&symbol.to_string());
     }
 }
 

--- a/docker-images/syntax-highlighter/crates/scip-syntax/src/lib.rs
+++ b/docker-images/syntax-highlighter/crates/scip-syntax/src/lib.rs
@@ -2,4 +2,4 @@ pub mod evaluate;
 pub mod index;
 pub mod io;
 pub mod progress;
-mod scip_strict;
+pub mod scip_strict;

--- a/docker-images/syntax-highlighter/crates/scip-syntax/src/lib.rs
+++ b/docker-images/syntax-highlighter/crates/scip-syntax/src/lib.rs
@@ -2,3 +2,4 @@ pub mod evaluate;
 pub mod index;
 pub mod io;
 pub mod progress;
+mod scip_strict;

--- a/docker-images/syntax-highlighter/crates/scip-syntax/src/scip_strict.rs
+++ b/docker-images/syntax-highlighter/crates/scip-syntax/src/scip_strict.rs
@@ -1,0 +1,147 @@
+use std::borrow::Cow;
+
+mod format;
+mod parse;
+
+#[derive(Debug, PartialEq, Eq, Hash)]
+pub enum Symbol<'a> {
+    Local {
+        local_id: &'a str,
+    },
+    NonLocal(NonLocalSymbol<'a>),
+}
+
+impl Symbol<'_> {
+    pub fn parse(raw: &str) -> Result<Symbol, String> {
+        parse::parse_symbol(raw)
+    }
+
+    pub fn is_local(&self) -> bool {
+        matches!(self, Symbol::Local { .. })
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Hash)]
+pub struct NonLocalSymbol<'a> {
+    pub scheme: Scheme<'a>,
+    pub package: Package<'a>,
+    pub descriptors: Vec<Descriptor<'a>>,
+}
+
+#[derive(Debug, PartialEq, Eq, Hash, Default)]
+pub struct Scheme<'a>(Cow<'a, str>);
+
+impl Scheme<'_> {
+    pub fn new(s: &str) -> Scheme {
+        Scheme(s.into())
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Hash)]
+pub struct Package<'a> {
+    manager: Cow<'a, str>,
+    package_name: Cow<'a, str>,
+    version: Cow<'a, str>,
+}
+
+impl Default for Package<'_> {
+    fn default() -> Self {
+        Self::new(None, None, None)
+    }
+}
+
+impl Package<'_> {
+    pub fn new<'a>(
+        manager: Option<&'a str>,
+        package_name: Option<&'a str>,
+        version: Option<&'a str>,
+    ) -> Package<'a> {
+        Package {
+            manager: manager.unwrap_or(".").into(),
+            package_name: package_name.unwrap_or(".").into(),
+            version: version.unwrap_or(".").into(),
+        }
+    }
+    pub fn manager(&self) -> Option<&str> {
+        let manager = self.manager.as_ref();
+        if manager == "." {
+            None
+        } else {
+            Some(manager)
+        }
+    }
+    pub fn package_name(&self) -> Option<&str> {
+        let package_name = self.package_name.as_ref();
+        if package_name == "." {
+            None
+        } else {
+            Some(package_name)
+        }
+    }
+    pub fn version(&self) -> Option<&str> {
+        let version = self.version.as_ref();
+        if version == "." {
+            None
+        } else {
+            Some(version)
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Hash)]
+pub enum Descriptor<'a> {
+    Namespace(Cow<'a, str>),
+    Type(Cow<'a, str>),
+    Term(Cow<'a, str>),
+    Meta(Cow<'a, str>),
+    Macro(Cow<'a, str>),
+    Method {
+        name: Cow<'a, str>,
+        disambiguator: &'a str,
+    },
+    TypeParameter(Cow<'a, str>),
+    Parameter(Cow<'a, str>),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_works() {
+        assert_eq!(
+            Symbol::parse("scip-java . . . Dude#lol!waow.")
+                .unwrap()
+                .to_string(),
+            "scip-java . . . Dude#lol!waow."
+        );
+        assert_eq!(
+            Symbol::parse("scip  java . . . Dude#lol!waow.")
+                .unwrap()
+                .to_string(),
+            "scip  java . . . Dude#lol!waow."
+        );
+        assert_eq!(
+            Symbol::parse("scip  java . . . `Dude```#`lol`!waow.")
+                .unwrap()
+                .to_string(),
+            "scip  java . . . `Dude```#lol!waow."
+        );
+        assert_eq!(Symbol::parse("local 1").unwrap().to_string(), "local 1");
+        assert_eq!(
+            Symbol::parse("rust-analyzer cargo test_rust_dependency 0.1.0 println!")
+                .unwrap()
+                .to_string(),
+            "rust-analyzer cargo test_rust_dependency 0.1.0 println!"
+        );
+        assert_eq!(
+            Symbol::NonLocal(NonLocalSymbol {
+                scheme: Default::default(),
+                package: Default::default(),
+                descriptors: vec![Descriptor::Type("hi".into())]
+            })
+            .to_string(),
+            " . . . hi#"
+        );
+    }
+}

--- a/docker-images/syntax-highlighter/crates/scip-syntax/src/scip_strict.rs
+++ b/docker-images/syntax-highlighter/crates/scip-syntax/src/scip_strict.rs
@@ -1,5 +1,6 @@
 use std::borrow::Cow;
 
+mod context_error;
 mod format;
 mod parse;
 

--- a/docker-images/syntax-highlighter/crates/scip-syntax/src/scip_strict.rs
+++ b/docker-images/syntax-highlighter/crates/scip-syntax/src/scip_strict.rs
@@ -5,9 +5,7 @@ mod parse;
 
 #[derive(Debug, PartialEq, Eq, Hash)]
 pub enum Symbol<'a> {
-    Local {
-        local_id: &'a str,
-    },
+    Local { local_id: &'a str },
     NonLocal(NonLocalSymbol<'a>),
 }
 
@@ -97,51 +95,8 @@ pub enum Descriptor<'a> {
     Macro(Cow<'a, str>),
     Method {
         name: Cow<'a, str>,
-        disambiguator: &'a str,
+        disambiguator: Option<&'a str>,
     },
     TypeParameter(Cow<'a, str>),
     Parameter(Cow<'a, str>),
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn it_works() {
-        assert_eq!(
-            Symbol::parse("scip-java . . . Dude#lol!waow.")
-                .unwrap()
-                .to_string(),
-            "scip-java . . . Dude#lol!waow."
-        );
-        assert_eq!(
-            Symbol::parse("scip  java . . . Dude#lol!waow.")
-                .unwrap()
-                .to_string(),
-            "scip  java . . . Dude#lol!waow."
-        );
-        assert_eq!(
-            Symbol::parse("scip  java . . . `Dude```#`lol`!waow.")
-                .unwrap()
-                .to_string(),
-            "scip  java . . . `Dude```#lol!waow."
-        );
-        assert_eq!(Symbol::parse("local 1").unwrap().to_string(), "local 1");
-        assert_eq!(
-            Symbol::parse("rust-analyzer cargo test_rust_dependency 0.1.0 println!")
-                .unwrap()
-                .to_string(),
-            "rust-analyzer cargo test_rust_dependency 0.1.0 println!"
-        );
-        assert_eq!(
-            Symbol::NonLocal(NonLocalSymbol {
-                scheme: Default::default(),
-                package: Default::default(),
-                descriptors: vec![Descriptor::Type("hi".into())]
-            })
-            .to_string(),
-            " . . . hi#"
-        );
-    }
 }

--- a/docker-images/syntax-highlighter/crates/scip-syntax/src/scip_strict/context_error.rs
+++ b/docker-images/syntax-highlighter/crates/scip-syntax/src/scip_strict/context_error.rs
@@ -1,0 +1,49 @@
+use std::fmt;
+
+use nom::error::{ContextError, ErrorKind, FromExternalError, ParseError};
+
+/// default error type, only contains the error's location and code
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CtxError<I> {
+    /// position of the error in the input data
+    pub input: I,
+    /// contextual error message
+    pub context: &'static str,
+}
+
+impl<I> ParseError<I> for CtxError<I> {
+    fn from_error_kind(input: I, _kind: ErrorKind) -> Self {
+        CtxError {
+            input,
+            context: "no context set yet",
+        }
+    }
+
+    fn append(_: I, _: ErrorKind, other: Self) -> Self {
+        other
+    }
+}
+
+impl<I> ContextError<I> for CtxError<I> {
+    fn add_context(_input: I, context: &'static str, mut other: Self) -> Self {
+        other.context = context;
+        other
+    }
+}
+
+impl<I, E> FromExternalError<I, E> for CtxError<I> {
+    /// Create a new error from an input position and an external error
+    fn from_external_error(input: I, _kind: ErrorKind, _e: E) -> Self {
+        CtxError {
+            input,
+            context: "no context set yet",
+        }
+    }
+}
+
+/// The Display implementation allows the std::error::Error implementation
+impl<I: fmt::Display> fmt::Display for CtxError<I> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "error '{}' at: {}", self.context, self.input)
+    }
+}

--- a/docker-images/syntax-highlighter/crates/scip-syntax/src/scip_strict/format.rs
+++ b/docker-images/syntax-highlighter/crates/scip-syntax/src/scip_strict/format.rs
@@ -1,0 +1,131 @@
+use super::{parse, Descriptor, NonLocalSymbol, Package, Scheme, Symbol};
+use std::borrow::Cow;
+use std::fmt;
+use std::fmt::Write;
+
+pub struct SymbolFormatOptions {
+    pub include_scheme: bool,
+    pub include_package_manager: bool,
+    pub include_package_name: bool,
+    pub include_package_version: bool,
+    pub include_descriptor: bool,
+}
+
+impl SymbolFormatOptions {
+    fn default() -> SymbolFormatOptions {
+        SymbolFormatOptions {
+            include_scheme: true,
+            include_package_manager: true,
+            include_package_name: true,
+            include_package_version: true,
+            include_descriptor: true,
+        }
+    }
+}
+
+pub fn format_symbol_with(symbol: &Symbol, options: SymbolFormatOptions) -> String {
+    let mut buf = String::new();
+    match symbol {
+        Symbol::Local { local_id } => write!(&mut buf, "local {local_id}").unwrap(),
+        Symbol::NonLocal (NonLocalSymbol {
+            scheme,
+            package,
+            descriptors,
+        }) => {
+            if options.include_scheme {
+                write!(&mut buf, "{scheme} ").unwrap()
+            }
+            if options.include_package_manager {
+                write!(&mut buf, "{} ", package.manager).unwrap()
+            }
+            if options.include_package_name {
+                write!(&mut buf, "{} ", package.package_name).unwrap()
+            }
+            if options.include_package_version {
+                write!(&mut buf, "{} ", package.version).unwrap()
+            }
+            if options.include_descriptor {
+                for descriptor in descriptors {
+                    write!(&mut buf, "{descriptor}").unwrap()
+                }
+            }
+        }
+    }
+
+    if buf.ends_with(' ') {
+        buf.pop();
+    }
+
+    buf
+}
+
+impl fmt::Display for Symbol<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Symbol::NonLocal(non_local) => non_local.fmt(f),
+            Symbol::Local { local_id } => write!(f, "local {}", local_id),
+        }
+    }
+}
+
+impl fmt::Display for NonLocalSymbol<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                write!(f, "{} {} ", self.scheme, self.package)?;
+                for descriptor in &self.descriptors {
+                    write!(f, "{}", descriptor)?;
+                }
+                Ok(())
+    }
+}
+
+impl fmt::Display for Scheme<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", escape_space_terminated(&self.0))
+    }
+}
+
+impl fmt::Display for Package<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "{} {} {}",
+            escape_space_terminated(&self.manager),
+            escape_space_terminated(&self.package_name),
+            escape_space_terminated(&self.version),
+        )
+    }
+}
+
+impl fmt::Display for Descriptor<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Descriptor::Namespace(name) => write!(f, "{}/", escape_name(name)),
+            Descriptor::Type(name) => write!(f, "{}#", escape_name(name)),
+            Descriptor::Term(name) => write!(f, "{}.", escape_name(name)),
+            Descriptor::Meta(name) => write!(f, "{}:", escape_name(name)),
+            Descriptor::Macro(name) => write!(f, "{}!", escape_name(name)),
+            Descriptor::Method {
+                name,
+                disambiguator,
+            } => write!(f, "{}({}).", escape_name(name), disambiguator),
+            Descriptor::TypeParameter(name) => write!(f, "[{}]", escape_name(name)),
+            Descriptor::Parameter(name) => write!(f, "({})", escape_name(name)),
+        }
+    }
+}
+
+fn escape_name<'a>(name: &'a Cow<'a, str>) -> Cow<'a, str> {
+    if name.chars().all(parse::is_simple_identifier_char) {
+        name.as_ref().into()
+    } else {
+        format!("`{}`", name.replace('`', "``")).into()
+    }
+}
+
+fn escape_space_terminated<'a>(s: &'a Cow<'a, str>) -> Cow<'a, str> {
+    if s.contains(' ') {
+        s.replace(' ', "  ").into()
+    } else {
+        s.as_ref().into()
+    }
+}

--- a/docker-images/syntax-highlighter/crates/scip-syntax/src/scip_strict/format.rs
+++ b/docker-images/syntax-highlighter/crates/scip-syntax/src/scip_strict/format.rs
@@ -1,63 +1,6 @@
+use std::{borrow::Cow, fmt};
+
 use super::{parse, Descriptor, NonLocalSymbol, Package, Scheme, Symbol};
-use std::borrow::Cow;
-use std::fmt;
-use std::fmt::Write;
-
-pub struct SymbolFormatOptions {
-    pub include_scheme: bool,
-    pub include_package_manager: bool,
-    pub include_package_name: bool,
-    pub include_package_version: bool,
-    pub include_descriptor: bool,
-}
-
-impl SymbolFormatOptions {
-    fn default() -> SymbolFormatOptions {
-        SymbolFormatOptions {
-            include_scheme: true,
-            include_package_manager: true,
-            include_package_name: true,
-            include_package_version: true,
-            include_descriptor: true,
-        }
-    }
-}
-
-pub fn format_symbol_with(symbol: &Symbol, options: SymbolFormatOptions) -> String {
-    let mut buf = String::new();
-    match symbol {
-        Symbol::Local { local_id } => write!(&mut buf, "local {local_id}").unwrap(),
-        Symbol::NonLocal(NonLocalSymbol {
-            scheme,
-            package,
-            descriptors,
-        }) => {
-            if options.include_scheme {
-                write!(&mut buf, "{scheme} ").unwrap()
-            }
-            if options.include_package_manager {
-                write!(&mut buf, "{} ", package.manager).unwrap()
-            }
-            if options.include_package_name {
-                write!(&mut buf, "{} ", package.package_name).unwrap()
-            }
-            if options.include_package_version {
-                write!(&mut buf, "{} ", package.version).unwrap()
-            }
-            if options.include_descriptor {
-                for descriptor in descriptors {
-                    write!(&mut buf, "{descriptor}").unwrap()
-                }
-            }
-        }
-    }
-
-    if buf.ends_with(' ') {
-        buf.pop();
-    }
-
-    buf
-}
 
 impl fmt::Display for Symbol<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -107,7 +50,12 @@ impl fmt::Display for Descriptor<'_> {
             Descriptor::Method {
                 name,
                 disambiguator,
-            } => write!(f, "{}({}).", escape_name(name), disambiguator),
+            } => write!(
+                f,
+                "{}({}).",
+                escape_name(name),
+                disambiguator.unwrap_or_default()
+            ),
             Descriptor::TypeParameter(name) => write!(f, "[{}]", escape_name(name)),
             Descriptor::Parameter(name) => write!(f, "({})", escape_name(name)),
         }

--- a/docker-images/syntax-highlighter/crates/scip-syntax/src/scip_strict/format.rs
+++ b/docker-images/syntax-highlighter/crates/scip-syntax/src/scip_strict/format.rs
@@ -27,7 +27,7 @@ pub fn format_symbol_with(symbol: &Symbol, options: SymbolFormatOptions) -> Stri
     let mut buf = String::new();
     match symbol {
         Symbol::Local { local_id } => write!(&mut buf, "local {local_id}").unwrap(),
-        Symbol::NonLocal (NonLocalSymbol {
+        Symbol::NonLocal(NonLocalSymbol {
             scheme,
             package,
             descriptors,
@@ -70,11 +70,11 @@ impl fmt::Display for Symbol<'_> {
 
 impl fmt::Display for NonLocalSymbol<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-                write!(f, "{} {} ", self.scheme, self.package)?;
-                for descriptor in &self.descriptors {
-                    write!(f, "{}", descriptor)?;
-                }
-                Ok(())
+        write!(f, "{} {} ", self.scheme, self.package)?;
+        for descriptor in &self.descriptors {
+            write!(f, "{}", descriptor)?;
+        }
+        Ok(())
     }
 }
 

--- a/docker-images/syntax-highlighter/crates/scip-syntax/src/scip_strict/parse.rs
+++ b/docker-images/syntax-highlighter/crates/scip-syntax/src/scip_strict/parse.rs
@@ -109,7 +109,7 @@ fn parse_name(input: &str) -> PResult<'_, Cow<'_, str>> {
 }
 
 pub fn is_simple_identifier_char(c: char) -> bool {
-    c.is_alphanumeric() || c == '_' || c == '+' || c == '-' || c == '$'
+    c.is_ascii_alphanumeric() || c == '_' || c == '+' || c == '-' || c == '$'
 }
 
 fn parse_simple_identifier_str(input: &str) -> PResult<'_, &str> {

--- a/docker-images/syntax-highlighter/crates/scip-syntax/src/scip_strict/parse.rs
+++ b/docker-images/syntax-highlighter/crates/scip-syntax/src/scip_strict/parse.rs
@@ -1,0 +1,159 @@
+use super::{Descriptor, NonLocalSymbol, Package, Scheme, Symbol};
+use nom::branch::alt;
+use nom::bytes::complete::{tag, take_while1};
+use nom::character::complete::char;
+use nom::combinator::{cut, eof, fail};
+use nom::error::{context, convert_error, VerboseError};
+use nom::multi::many1;
+use nom::sequence::{delimited, preceded, tuple};
+use nom::{Finish, IResult, Parser};
+use std::borrow::Cow;
+
+pub(super) fn parse_symbol(input: &str) -> Result<Symbol<'_>, String> {
+    match parse_symbol_inner(input).finish() {
+        Ok((_, symbol)) => Ok(symbol),
+        Err(err) => Err(format!(
+            "Invalid symbol: '{input}'\n{}",
+            convert_error(input, err)
+        )),
+    }
+}
+
+type PResult<'a, A> = IResult<&'a str, A, VerboseError<&'a str>>;
+
+fn parse_symbol_inner(input: &str) -> PResult<'_, Symbol<'_>> {
+    let (input, symbol) = alt((parse_local_symbol, parse_nonlocal_symbol))(input)?;
+    eof(input)?;
+    Ok((input, symbol))
+}
+
+fn parse_local_symbol(input: &str) -> PResult<'_, Symbol<'_>> {
+    preceded(tag("local "), parse_simple_identifier_str)
+        .map(|local_id| Symbol::Local { local_id })
+        .parse(input)
+}
+
+fn parse_nonlocal_symbol(input: &str) -> PResult<'_, Symbol<'_>> {
+    tuple((
+        parse_space_terminated,
+        parse_package,
+        many1(parse_descriptor),
+    ))
+    .map(|(scheme, package, descriptors)| Symbol::NonLocal (NonLocalSymbol {
+        scheme: Scheme(scheme),
+        package,
+        descriptors,
+    }))
+    .parse(input)
+}
+
+fn parse_package(input: &str) -> PResult<'_, Package> {
+    tuple((
+        parse_space_terminated,
+        parse_space_terminated,
+        parse_space_terminated,
+    ))
+    .map(|(manager, package_name, version)| Package {
+        manager,
+        package_name,
+        version,
+    })
+    .parse(input)
+}
+
+fn parse_descriptor(input: &str) -> PResult<'_, Descriptor> {
+    alt((
+        parse_parameter_descriptor,
+        parse_type_parameter_descriptor,
+        parse_named_descriptor,
+    ))(input)
+}
+
+fn parse_type_parameter_descriptor(input: &str) -> PResult<'_, Descriptor> {
+    delimited(char('['), parse_name, char(']'))
+        .map(Descriptor::TypeParameter)
+        .parse(input)
+}
+
+fn parse_parameter_descriptor(input: &str) -> PResult<'_, Descriptor> {
+    delimited(char('('), parse_name, char(')'))
+        .map(Descriptor::Parameter)
+        .parse(input)
+}
+
+fn parse_named_descriptor(input: &str) -> PResult<'_, Descriptor> {
+    let (input, name) = parse_name(input)?;
+    match input.chars().next() {
+        Some('/') => Ok((&input[1..], Descriptor::Namespace(name))),
+        Some('#') => Ok((&input[1..], Descriptor::Type(name))),
+        Some('.') => Ok((&input[1..], Descriptor::Term(name))),
+        Some(':') => Ok((&input[1..], Descriptor::Meta(name))),
+        Some('!') => Ok((&input[1..], Descriptor::Macro(name))),
+        Some('(') => {
+            let (input, disambiguator) = parse_simple_identifier_str(&input[1..])?;
+            let (input, _) = tag(").")(input)?;
+            Ok((
+                input,
+                Descriptor::Method {
+                    name,
+                    disambiguator,
+                },
+            ))
+        }
+        _ => context("Missing descriptor suffix", cut(fail))(input),
+    }
+}
+
+fn parse_name(input: &str) -> PResult<'_, Cow<'_, str>> {
+    alt((parse_escaped_identifier, parse_simple_identifier))(input)
+}
+
+pub fn is_simple_identifier_char(c: char) -> bool {
+    c.is_alphanumeric() || c == '_' || c == '+' || c == '-' || c == '$'
+}
+
+fn parse_simple_identifier_str(input: &str) -> PResult<'_, &str> {
+    take_while1(is_simple_identifier_char)(input)
+}
+
+fn parse_simple_identifier(input: &str) -> PResult<'_, Cow<'_, str>> {
+    parse_simple_identifier_str.map(Cow::Borrowed).parse(input)
+}
+
+fn parse_escaped_identifier(input: &str) -> PResult<'_, Cow<'_, str>> {
+    let (input, _) = char('`')(input)?;
+    let (input, name) = parse_terminated(input, '`')?;
+    let (input, _) = char('`')(input)?;
+    Ok((input, name))
+}
+
+fn parse_space_terminated(input: &str) -> PResult<'_, Cow<'_, str>> {
+    let (input, terminated) = parse_terminated(input, ' ')?;
+    let (input, _) = char(' ')(input)?;
+    Ok((input, terminated))
+}
+
+fn parse_terminated(input: &str, terminator: char) -> PResult<'_, Cow<'_, str>> {
+    let terminator_len = terminator.len_utf8();
+    let mut needs_escape = false;
+    let mut current = input;
+    while let Some(offset) = current.find(terminator) {
+        let (_, rest) = current.split_at(offset + terminator_len);
+        if rest.starts_with(terminator) {
+            needs_escape = true;
+            current = &rest[terminator_len..];
+        } else {
+            let (raw, rest) = input.split_at(input.len() - rest.len() - terminator_len);
+            let escaped = if needs_escape {
+                Cow::Owned(raw.replace(
+                    &format!("{terminator}{terminator}"),
+                    &terminator.to_string(),
+                ))
+            } else {
+                Cow::Borrowed(raw)
+            };
+            return Ok((rest, escaped));
+        }
+    }
+    context("Missing terminator", cut(fail))(current)
+}


### PR DESCRIPTION
Adds strict and performant symbol parsing/formatting for `scip-syntax`.

Parsing is "zero" allocation when the symbol does not contain escapes. (Technically it does allocate a Vec to hold the descriptors)

Final benchmark numbers:
```
symbol parsing/parse_v1/10000 [19.158 ms 19.231 ms 19.306 ms]
symbol parsing/parse_v1/100000 [252.10 ms 252.48 ms 252.86 ms]
symbol parsing/parse_v1/1000000 [2.9972 s 3.0033 s 3.0094 s]

symbol parsing/parse_v2/10000 [1.1307 ms 1.1357 ms 1.1413 ms]
symbol parsing/parse_v2/100000 [15.645 ms 15.670 ms 15.697 ms]
symbol parsing/parse_v2/1000000 [191.80 ms 192.11 ms 192.44 ms]
```

## Test plan

Some basic unit tests. Verified manually that it produces the same symbols as the existing parser for all of chromium.scip