### PR TITLE
fix(svelte): Properly rounded corner for file view hover cards

### DIFF
--- a/client/web-sveltekit/src/lib/CodeMirrorBlob.svelte
+++ b/client/web-sveltekit/src/lib/CodeMirrorBlob.svelte
@@ -92,6 +92,8 @@
         },
         '.cm-tooltip': {
             border: 'none',
+            // For nice rounded corners in hover cards
+            borderRadius: 'var(--border-radius)',
         },
     })
 


### PR DESCRIPTION
| Before | After |
|--------|--------|
| ![2024-06-24_17-21_1](https://github.com/sourcegraph/sourcegraph/assets/179026/cdca567c-ed88-461d-8c95-ded3e04a6ec3) | ![2024-06-24_17-21](https://github.com/sourcegraph/sourcegraph/assets/179026/46354fce-0dfa-4c84-aa15-a45b5a01692e) | 

(note the corners)

## Test plan

Visual inspection
