### PR TITLE
chore(ci): emit compact executon log in CI for test + build commands only

### DIFF
--- a/.aspect/bazelrc/ci.sourcegraph.bazelrc
+++ b/.aspect/bazelrc/ci.sourcegraph.bazelrc
@@ -59,7 +59,8 @@ test --build_event_binary_file_path_conversion=false
 test --build_event_binary_file_upload_mode=wait_for_upload_complete
 test --build_event_publish_all_actions=true
 
-common --experimental_execution_log_compact_file=execution_log.zstd
+build --experimental_execution_log_compact_file=execution_log.zstd
+test --experimental_execution_log_compact_file=execution_log.zstd
 
 # These likely perform faster locally than the overhead of pulling/pushing from/to the remote cache,
 # as well as being able to reduce how much we push to the cache


### PR DESCRIPTION
The "Delivery Manifest" bazel commands messing stuff up again :pensive: 

## Test plan

CI 


## Changelog

