### PR TITLE
feat/enterpriseportal: use UUID type for subscription ID

### DIFF
--- a/cmd/enterprise-portal/internal/database/subscriptions/subscriptions.go
+++ b/cmd/enterprise-portal/internal/database/subscriptions/subscriptions.go
@@ -13,8 +13,8 @@ import (
 
 // Subscription is an Enterprise subscription record.
 type Subscription struct {
-	// ID is the prefixed UUID-format identifier for the subscription.
-	ID string `gorm:"primaryKey"`
+	// ID is the internal (unprefixed) UUID-format identifier for the subscription.
+	ID string `gorm:"type:uuid;primaryKey"`
 	// InstanceDomain is the instance domain associated with the subscription, e.g.
 	// "acme.sourcegraphcloud.com".
 	InstanceDomain string `gorm:"unique"`

--- a/cmd/enterprise-portal/internal/database/subscriptions/subscriptions_test.go
+++ b/cmd/enterprise-portal/internal/database/subscriptions/subscriptions_test.go
@@ -67,7 +67,9 @@ func SubscriptionsStoreList(t *testing.T, ctx context.Context, s *subscriptions.
 		assert.Equal(t, s2.ID, ss[1].ID)
 
 		t.Run("no match", func(t *testing.T) {
-			ss, err = s.List(ctx, subscriptions.ListEnterpriseSubscriptionsOptions{IDs: []string{"1234"}})
+			ss, err = s.List(ctx, subscriptions.ListEnterpriseSubscriptionsOptions{
+				IDs: []string{uuid.Must(uuid.NewV7()).String()},
+			})
 			require.NoError(t, err)
 			require.Len(t, ss, 0)
 		})
@@ -83,7 +85,9 @@ func SubscriptionsStoreList(t *testing.T, ctx context.Context, s *subscriptions.
 		assert.Equal(t, s2.ID, ss[1].ID)
 
 		t.Run("no match", func(t *testing.T) {
-			ss, err = s.List(ctx, subscriptions.ListEnterpriseSubscriptionsOptions{InstanceDomains: []string{"1234"}})
+			ss, err = s.List(ctx, subscriptions.ListEnterpriseSubscriptionsOptions{
+				InstanceDomains: []string{"1234"},
+			})
 			require.NoError(t, err)
 			require.Len(t, ss, 0)
 		})


### PR DESCRIPTION
We were aligned on using non-prefixed UUIDs internally, only prefixing them for external consumption. This lets us use the native UUID type.

Part of https://linear.app/sourcegraph/issue/CORE-155

## Test plan

CI, `sg run enterprise-portal`

`select * from enterprise_portal_subscriptions;` on dev shows we are using the non-prefixed UUDs only. Manual migration, since it doesn't seem like GORM can do this for you:

```
ALTER TABLE enterprise_portal_subscriptions ALTER COLUMN id TYPE uuid USING id::uuid;
```

Checked that data is intact.