### PR TITLE
feat/enterpriseportal: initialize subscriptions tables

### DIFF
--- a/cmd/enterprise-portal/internal/database/databasetest/databasetest.go
+++ b/cmd/enterprise-portal/internal/database/databasetest/databasetest.go
@@ -37,7 +37,7 @@ func NewTestDB(t testing.TB, system, suite string, tables ...schema.Tabler) *pgx
 	_, err = sqlDB.Exec(fmt.Sprintf("DROP DATABASE IF EXISTS %q", dbName))
 	require.NoError(t, err)
 
-	_, err = sqlDB.Exec(fmt.Sprintf("CREATE DATABASE %q WITH ENCODING=UTF8", dbName))
+	_, err = sqlDB.Exec(fmt.Sprintf("CREATE DATABASE %q TEMPLATE template0", dbName))
 	require.NoError(t, err)
 
 	// Swap out the database name to be the test suite database in the DSN.

--- a/cmd/enterprise-portal/internal/database/databasetest/databasetest.go
+++ b/cmd/enterprise-portal/internal/database/databasetest/databasetest.go
@@ -20,8 +20,6 @@ import (
 // NewTestDB creates a new test database and initializes the given list of
 // tables for the suite. The test database is dropped after testing is completed
 // unless failed.
-//
-// Future: Move to a shared package when more than Enterprise Portal uses it.
 func NewTestDB(t testing.TB, system, suite string, tables ...schema.Tabler) *pgxpool.Pool {
 	if testing.Short() {
 		t.Skip("skipping DB test since -short specified")
@@ -39,7 +37,7 @@ func NewTestDB(t testing.TB, system, suite string, tables ...schema.Tabler) *pgx
 	_, err = sqlDB.Exec(fmt.Sprintf("DROP DATABASE IF EXISTS %q", dbName))
 	require.NoError(t, err)
 
-	_, err = sqlDB.Exec(fmt.Sprintf("CREATE DATABASE %q", dbName))
+	_, err = sqlDB.Exec(fmt.Sprintf("CREATE DATABASE %q WITH ENCODING=UTF8", dbName))
 	require.NoError(t, err)
 
 	// Swap out the database name to be the test suite database in the DSN.
@@ -95,8 +93,6 @@ func NewTestDB(t testing.TB, system, suite string, tables ...schema.Tabler) *pgx
 // ClearTablesAfterTest removes all rows from the list of tables in the original
 // order as a t.Cleanup hook. It uses soft-deletion when available and skips
 // deletion when the test suite failed.
-//
-// Future: Move to a shared package when more than Enterprise Portal uses it.
 func ClearTablesAfterTest(t *testing.T, db *pgxpool.Pool, tables ...schema.Tabler) {
 	t.Cleanup(func() {
 		if t.Failed() {

--- a/cmd/enterprise-portal/internal/database/databasetest/databasetest.go
+++ b/cmd/enterprise-portal/internal/database/databasetest/databasetest.go
@@ -37,7 +37,7 @@ func NewTestDB(t testing.TB, system, suite string, tables ...schema.Tabler) *pgx
 	_, err = sqlDB.Exec(fmt.Sprintf("DROP DATABASE IF EXISTS %q", dbName))
 	require.NoError(t, err)
 
-	_, err = sqlDB.Exec(fmt.Sprintf("CREATE DATABASE %q TEMPLATE template0", dbName))
+	_, err = sqlDB.Exec(fmt.Sprintf("CREATE DATABASE %q TEMPLATE template0 ENCODING 'UTF8'", dbName))
 	require.NoError(t, err)
 
 	// Swap out the database name to be the test suite database in the DSN.

--- a/cmd/enterprise-portal/internal/database/internal/tables/tables.go
+++ b/cmd/enterprise-portal/internal/database/internal/tables/tables.go
@@ -12,5 +12,6 @@ import (
 func All() []schema.Tabler {
 	return []schema.Tabler{
 		&subscriptions.Subscription{},
+		&subscriptions.SubscriptionCondition{},
 	}
 }

--- a/cmd/enterprise-portal/internal/database/subscriptions/BUILD.bazel
+++ b/cmd/enterprise-portal/internal/database/subscriptions/BUILD.bazel
@@ -3,7 +3,10 @@ load("//dev:go_defs.bzl", "go_test")
 
 go_library(
     name = "subscriptions",
-    srcs = ["subscriptions.go"],
+    srcs = [
+        "subscriptions.go",
+        "subscriptions_conditions.go",
+    ],
     importpath = "github.com/sourcegraph/sourcegraph/cmd/enterprise-portal/internal/database/subscriptions",
     tags = [TAG_INFRA_CORESERVICES],
     visibility = ["//cmd/enterprise-portal:__subpackages__"],

--- a/cmd/enterprise-portal/internal/database/subscriptions/subscriptions.go
+++ b/cmd/enterprise-portal/internal/database/subscriptions/subscriptions.go
@@ -27,7 +27,7 @@ type Subscription struct {
 	// DisplayName is the human-friendly name of this subscription, e.g. "Acme, Inc."
 	//
 	// It must be unique across all currently un-archived subscriptions.
-	DisplayName string `gorm:"size:256;not null;uniqueIndex:,where:archived_at IS NULL;default:'Unnamed subscription'"`
+	DisplayName string `gorm:"size:256;not null;uniqueIndex:,where:archived_at IS NULL AND display_name != 'Unnamed subscription';default:'Unnamed subscription'"`
 
 	// Timestamps representing the latest timestamps of key conditions related
 	// to this subscription.

--- a/cmd/enterprise-portal/internal/database/subscriptions/subscriptions.go
+++ b/cmd/enterprise-portal/internal/database/subscriptions/subscriptions.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -16,8 +17,30 @@ type Subscription struct {
 	// ID is the internal (unprefixed) UUID-format identifier for the subscription.
 	ID string `gorm:"type:uuid;primaryKey"`
 	// InstanceDomain is the instance domain associated with the subscription, e.g.
-	// "acme.sourcegraphcloud.com".
-	InstanceDomain string `gorm:"unique"`
+	// "acme.sourcegraphcloud.com". This is set explicitly.
+	//
+	// It must be unique across all currently un-archived subscriptions.
+	InstanceDomain string `gorm:"uniqueIndex:,where:archived_at IS NULL"`
+
+	// WARNING: The below fields are not yet used in production.
+
+	// DisplayName is the human-friendly name of this subscription, e.g. "Acme, Inc."
+	//
+	// It must be unique across all currently un-archived subscriptions.
+	DisplayName string `gorm:"size:256;not null;uniqueIndex:,where:archived_at IS NULL;default:'Unnamed subscription'"`
+
+	// Timestamps representing the latest timestamps of key conditions related
+	// to this subscription.
+	//
+	// Condition transition details are tracked in 'enterprise_portal_subscription_conditions'.
+	CreatedAt  time.Time  `gorm:"not null;default:current_timestamp"`
+	UpdatedAt  time.Time  `gorm:"not null;default:current_timestamp"`
+	ArchivedAt *time.Time // Null indicates the subscription is not archived.
+
+	// SalesforceSubscriptionID associated with this Enterprise subscription.
+	SalesforceSubscriptionID *string
+	// SalesforceOpportunityID associated with this Enterprise subscription.
+	SalesforceOpportunityID *string
 }
 
 func (s *Subscription) TableName() string {

--- a/cmd/enterprise-portal/internal/database/subscriptions/subscriptions_conditions.go
+++ b/cmd/enterprise-portal/internal/database/subscriptions/subscriptions_conditions.go
@@ -1,0 +1,26 @@
+package subscriptions
+
+import (
+	"time"
+)
+
+// Subscription is an Enterprise subscription condition record.
+type SubscriptionCondition struct {
+	// ⚠️ DO NOT USE: This field is only used for creating foreign key constraint.
+	Subscription *Subscription `gorm:"foreignKey:SubscriptionID"`
+
+	// SubscriptionID is the internal unprefixed UUID of the related subscription.
+	SubscriptionID string `gorm:"type:uuid;not null"`
+	// Status is the type of status corresponding to this condition, corresponding
+	// to the API 'EnterpriseSubscriptionCondition.Status'.
+	Status string `gorm:"not null"`
+	// Message is a human-readable message associated with the condition.
+	Message *string `gorm:"size:256"`
+	// TransitionTime is the time at which the condition was created, i.e. when
+	// the subscription transitioned into this status.
+	TransitionTime time.Time `gorm:"not null;default:current_timestamp"`
+}
+
+func (s *SubscriptionCondition) TableName() string {
+	return "enterprise_portal_subscription_conditions"
+}


### PR DESCRIPTION
The idea is to have a table of conditions which track reasons etc for major changes to a subscription. These aren't critical - important state still gets a subscription table time field for querying - but should match.

Closes https://linear.app/sourcegraph/issue/CORE-155

## Test plan

Apply https://github.com/sourcegraph/sourcegraph/pull/63452, then `sg run enterprise-portal`