### PR TITLE
feat/enterpriseportal: init licenses tables

### DIFF
--- a/cmd/enterprise-portal/internal/database/internal/tables/tables.go
+++ b/cmd/enterprise-portal/internal/database/internal/tables/tables.go
@@ -13,5 +13,7 @@ func All() []schema.Tabler {
 	return []schema.Tabler{
 		&subscriptions.Subscription{},
 		&subscriptions.SubscriptionCondition{},
+		&subscriptions.SubscriptionLicense{},
+		&subscriptions.SubscriptionLicenseCondition{},
 	}
 }

--- a/cmd/enterprise-portal/internal/database/subscriptions/BUILD.bazel
+++ b/cmd/enterprise-portal/internal/database/subscriptions/BUILD.bazel
@@ -4,6 +4,8 @@ load("//dev:go_defs.bzl", "go_test")
 go_library(
     name = "subscriptions",
     srcs = [
+        "license_conditions.go",
+        "licenses.go",
         "subscriptions.go",
         "subscriptions_conditions.go",
     ],
@@ -12,6 +14,7 @@ go_library(
     visibility = ["//cmd/enterprise-portal:__subpackages__"],
     deps = [
         "//lib/errors",
+        "@com_github_jackc_pgtype//:pgtype",
         "@com_github_jackc_pgx_v5//:pgx",
         "@com_github_jackc_pgx_v5//pgxpool",
     ],

--- a/cmd/enterprise-portal/internal/database/subscriptions/license_conditions.go
+++ b/cmd/enterprise-portal/internal/database/subscriptions/license_conditions.go
@@ -1,0 +1,23 @@
+package subscriptions
+
+import "time"
+
+type SubscriptionLicenseCondition struct {
+	// ⚠️ DO NOT USE: This field is only used for creating foreign key constraint.
+	License *SubscriptionLicense `gorm:"foreignKey:LicenseID"`
+
+	// SubscriptionID is the internal unprefixed UUID of the related license.
+	LicenseID string `gorm:"type:uuid;not null"`
+	// Status is the type of status corresponding to this condition, corresponding
+	// to the API 'EnterpriseSubscriptionLicenseCondition.Status'.
+	Status string `gorm:"not null"`
+	// Message is a human-readable message associated with the condition.
+	Message *string `gorm:"size:256"`
+	// TransitionTime is the time at which the condition was created, i.e. when
+	// the license transitioned into this status.
+	TransitionTime time.Time `gorm:"not null;default:current_timestamp"`
+}
+
+func (s *SubscriptionLicenseCondition) TableName() string {
+	return "enterprise_portal_subscription_license_conditions"
+}

--- a/cmd/enterprise-portal/internal/database/subscriptions/licenses.go
+++ b/cmd/enterprise-portal/internal/database/subscriptions/licenses.go
@@ -1,0 +1,40 @@
+package subscriptions
+
+import (
+	"time"
+
+	"github.com/jackc/pgtype"
+)
+
+type SubscriptionLicense struct {
+	// ⚠️ DO NOT USE: This field is only used for creating foreign key constraint.
+	Subscription *Subscription `gorm:"foreignKey:SubscriptionID"`
+
+	// SubscriptionID is the internal unprefixed UUID of the related subscription.
+	SubscriptionID string `gorm:"type:uuid;not null"`
+	// ID is the internal unprefixed UUID of this license.
+	ID string `gorm:"type:uuid;primaryKey"`
+
+	// Timestamps representing the latest timestamps of key conditions related
+	// to this subscription.
+	//
+	// Condition transition details are tracked in 'enterprise_portal_subscription_license_conditions'.
+	CreatedAt time.Time  `gorm:"not null;default:current_timestamp"`
+	ExpiresAt time.Time  `gorm:"not null"` // All license types should be time-bound.
+	RevokedAt *time.Time // Null indicates the licnese is not revoked.
+
+	// LicenseKind is the kind of license stored in LicenseData, corresponding
+	// to the API 'EnterpriseSubscriptionLicenseType'.
+	LicenseKind string `gorm:"not null"`
+	// LicenseData is the license data stored in JSON format. It is read-only
+	// and generally never queried in conditions - properties that are should
+	// be stored at the subscription or license level.
+	//
+	// Value shapes correspond to API types appropriate for each
+	// 'EnterpriseSubscriptionLicenseType'.
+	LicenseData pgtype.JSONB `gorm:"type:jsonb"`
+}
+
+func (s *SubscriptionLicense) TableName() string {
+	return "enterprise_portal_subscription_licenses"
+}

--- a/cmd/enterprise-portal/internal/database/subscriptions/licenses.go
+++ b/cmd/enterprise-portal/internal/database/subscriptions/licenses.go
@@ -20,7 +20,6 @@ type SubscriptionLicense struct {
 	//
 	// Condition transition details are tracked in 'enterprise_portal_subscription_license_conditions'.
 	CreatedAt time.Time  `gorm:"not null;default:current_timestamp"`
-	ExpiresAt time.Time  `gorm:"not null"` // All license types should be time-bound.
 	RevokedAt *time.Time // Null indicates the licnese is not revoked.
 
 	// LicenseKind is the kind of license stored in LicenseData, corresponding


### PR DESCRIPTION
Closes https://linear.app/sourcegraph/issue/CORE-157

Potentially controversial decision: storing license data (the JSON data encoded into license keys, and the license key itself) in JSONB. The data in there isn't (and shouldn't be) interesting to query on - they're only used in the context of a single license, so you would never use it as conditions. The only one that might be useful is "license key substring" for parity with what we have today, but that's an internal-only use case and shouldn't be in the hotpath for anything super performance sensitive.

Conditions table is similar to the one introduced in https://github.com/sourcegraph/sourcegraph/pull/63453

## Test plan

CI