### PR TITLE
chore/enterpriseportal: propagate context to migration database context

### DIFF
--- a/cmd/enterprise-portal/internal/database/migrate.go
+++ b/cmd/enterprise-portal/internal/database/migrate.go
@@ -98,7 +98,8 @@ func maybeMigrate(ctx context.Context, logger log.Logger, contract runtime.Contr
 
 			// Create a session that ignore debug logging.
 			sess := conn.Session(&gorm.Session{
-				Logger: gormlogger.Default.LogMode(gormlogger.Warn),
+				Context: ctx,
+				Logger:  gormlogger.Default.LogMode(gormlogger.Warn),
 			})
 			// Auto-migrate database table definitions.
 			for _, table := range tables.All() {

--- a/cmd/enterprise-portal/internal/database/migrate.go
+++ b/cmd/enterprise-portal/internal/database/migrate.go
@@ -79,7 +79,7 @@ func maybeMigrate(ctx context.Context, logger log.Logger, contract runtime.Contr
 		fmt.Sprintf("%s:auto-migrate", dbName),
 		15*time.Second,
 		func() error {
-			ctx := context.WithoutCancel(ctx)
+			ctx := context.WithoutCancel(ctx) // do not interrupt once we start
 			span.AddEvent("lock.acquired")
 
 			versionKey := fmt.Sprintf("%s:db_version", dbName)

--- a/lib/managedservicesplatform/iam/database.go
+++ b/lib/managedservicesplatform/iam/database.go
@@ -70,6 +70,7 @@ func migrateAndReconcile(ctx context.Context, logger log.Logger, sqlDB *sql.DB, 
 		fmt.Sprintf("%s:auto-migrate", databaseName),
 		15*time.Second,
 		func() error {
+			ctx := context.WithoutCancel(ctx) // do not interrupt once we start
 			span.AddEvent("lock.acquired")
 
 			// Create a session that ignore debug logging.

--- a/lib/managedservicesplatform/iam/database.go
+++ b/lib/managedservicesplatform/iam/database.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"time"
 
-	openfga_migrations "github.com/openfga/openfga/assets"
+	openfga_assets "github.com/openfga/openfga/assets"
 	"github.com/pressly/goose/v3"
 	"github.com/redis/go-redis/v9"
 	"github.com/sourcegraph/log"
@@ -57,7 +57,7 @@ func migrateAndReconcile(ctx context.Context, logger log.Logger, sqlDB *sql.DB, 
 		return nil, errors.Wrap(err, "open connection")
 	}
 
-	goose.SetBaseFS(openfga_migrations.EmbedMigrations)
+	goose.SetBaseFS(openfga_assets.EmbedMigrations)
 	goose.SetLogger(&gooseLoggerShim{Logger: logger})
 	currentVersion, err := goose.GetDBVersionContext(ctx, sqlDB)
 	if err != nil {
@@ -95,7 +95,7 @@ func migrateAndReconcile(ctx context.Context, logger log.Logger, sqlDB *sql.DB, 
 			err = goose.UpContext(
 				ctx,
 				sqlDB,
-				openfga_migrations.PostgresMigrationDir,
+				openfga_assets.PostgresMigrationDir,
 			)
 			if err != nil {
 				return errors.Wrap(err, "run OpenFGA migrations")

--- a/lib/managedservicesplatform/iam/database.go
+++ b/lib/managedservicesplatform/iam/database.go
@@ -74,7 +74,8 @@ func migrateAndReconcile(ctx context.Context, logger log.Logger, sqlDB *sql.DB, 
 
 			// Create a session that ignore debug logging.
 			sess := conn.Session(&gorm.Session{
-				Logger: gormlogger.Default.LogMode(gormlogger.Warn),
+				Context: ctx,
+				Logger:  gormlogger.Default.LogMode(gormlogger.Warn),
 			})
 			// Auto-migrate database table definitions.
 			for _, table := range []any{&metadata{}} {


### PR DESCRIPTION
Follow-up to #63448 - we now get Redis spans, but not the database operations that happen throughout a migration. Maybe this will do the thing?

## Test plan

n/a