### PR TITLE
feat/enterpriseportal: init Cody Gateway Access table

### DIFF
--- a/cmd/enterprise-portal/internal/database/codyaccess/BUILD.bazel
+++ b/cmd/enterprise-portal/internal/database/codyaccess/BUILD.bazel
@@ -1,0 +1,9 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "codyaccess",
+    srcs = ["codygateway.go"],
+    importpath = "github.com/sourcegraph/sourcegraph/cmd/enterprise-portal/internal/database/codyaccess",
+    visibility = ["//cmd/enterprise-portal:__subpackages__"],
+    deps = ["//cmd/enterprise-portal/internal/database/subscriptions"],
+)

--- a/cmd/enterprise-portal/internal/database/codyaccess/codygateway.go
+++ b/cmd/enterprise-portal/internal/database/codyaccess/codygateway.go
@@ -26,5 +26,5 @@ type CodyGatewayAccess struct {
 }
 
 func (s *CodyGatewayAccess) TableName() string {
-	return "codyaccess_cody_gateway_access"
+	return "enterprise_portal_cody_gateway_access"
 }

--- a/cmd/enterprise-portal/internal/database/codyaccess/codygateway.go
+++ b/cmd/enterprise-portal/internal/database/codyaccess/codygateway.go
@@ -1,0 +1,30 @@
+package codyaccess
+
+import "github.com/sourcegraph/sourcegraph/cmd/enterprise-portal/internal/database/subscriptions"
+
+type CodyGatewayAccess struct {
+	// ⚠️ DO NOT USE: This field is only used for creating foreign key constraint.
+	Subscription *subscriptions.Subscription `gorm:"foreignKey:SubscriptionID"`
+
+	// SubscriptionID is the internal unprefixed UUID of the related subscription.
+	SubscriptionID string `gorm:"type:uuid;not null;unique"`
+
+	// Whether or not a subscription has Cody Gateway access enabled.
+	Enabled bool `gorm:"not null"`
+
+	// chat_completions_rate_limit
+	ChatCompletionsRateLimit                int64 `gorm:"type:bigint;not null"`
+	ChatCompletionsRateLimitIntervalSeconds int   `gorm:"not null"`
+
+	// code_completions_rate_limit
+	CodeCompletionsRateLimit                int64 `gorm:"type:bigint;not null"`
+	CodeCompletionsRateLimitIntervalSeconds int   `gorm:"not null"`
+
+	// embeddings_rate_limit
+	EmbeddingsRateLimit                int64 `gorm:"type:bigint;not null"`
+	EmbeddingsRateLimitIntervalSeconds int   `gorm:"not null"`
+}
+
+func (s *CodyGatewayAccess) TableName() string {
+	return "codyaccess_cody_gateway_access"
+}

--- a/cmd/enterprise-portal/internal/database/internal/tables/BUILD.bazel
+++ b/cmd/enterprise-portal/internal/database/internal/tables/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     tags = [TAG_INFRA_CORESERVICES],
     visibility = ["//cmd/enterprise-portal:__subpackages__"],
     deps = [
+        "//cmd/enterprise-portal/internal/database/codyaccess",
         "//cmd/enterprise-portal/internal/database/subscriptions",
         "@io_gorm_gorm//schema",
     ],

--- a/cmd/enterprise-portal/internal/database/internal/tables/tables.go
+++ b/cmd/enterprise-portal/internal/database/internal/tables/tables.go
@@ -3,6 +3,7 @@ package tables
 import (
 	"gorm.io/gorm/schema"
 
+	"github.com/sourcegraph/sourcegraph/cmd/enterprise-portal/internal/database/codyaccess"
 	"github.com/sourcegraph/sourcegraph/cmd/enterprise-portal/internal/database/subscriptions"
 )
 
@@ -15,5 +16,7 @@ func All() []schema.Tabler {
 		&subscriptions.SubscriptionCondition{},
 		&subscriptions.SubscriptionLicense{},
 		&subscriptions.SubscriptionLicenseCondition{},
+
+		&codyaccess.CodyGatewayAccess{},
 	}
 }


### PR DESCRIPTION
Closes https://linear.app/sourcegraph/issue/CORE-159

I opted to prefix this table name with `codyaccess` instead of `enterprise_portal`, to reflect that it's a different component that owns this table.

## Test plan

CI