### PR TITLE
Search-based usages for new codenav API

### DIFF
--- a/cmd/frontend/graphqlbackend/codeintel.codenav.graphql
+++ b/cmd/frontend/graphqlbackend/codeintel.codenav.graphql
@@ -699,7 +699,19 @@ type Usage {
     """
     Information about the symbol itself.
     """
-    symbol: SymbolInformation!
+    symbol: SymbolInformation
+
+    """
+    Coarse-grained information about the data source.
+    """
+    provenance: CodeGraphDataProvenance!
+
+    """
+    Opaque fine-grained information describing the data source.
+    Provided only for debugging.
+    This field should be ignored when checking structural equality.
+    """
+    dataSource: String
 
     """
     Information about where this usage is located.
@@ -891,18 +903,6 @@ type SymbolInformation {
     is no appropriate hover documentation to display.
     """
     documentation: [String!]
-
-    """
-    Coarse-grained information about the data source.
-    """
-    provenance: CodeGraphDataProvenance!
-
-    """
-    Opaque fine-grained information describing the data source.
-    Provided only for debugging.
-    This field should be ignored when checking structural equality.
-    """
-    dataSource: String
 }
 
 """

--- a/internal/codeintel/codenav/observability.go
+++ b/internal/codeintel/codenav/observability.go
@@ -24,6 +24,7 @@ type operations struct {
 	snapshotForDocument               *observation.Operation
 	visibleUploadsForPath             *observation.Operation
 	syntacticUsages                   *observation.Operation
+	searchBasedUsages                 *observation.Operation
 }
 
 var m = new(metrics.SingletonREDMetrics)
@@ -59,6 +60,7 @@ func newOperations(observationCtx *observation.Context) *operations {
 		snapshotForDocument:               op("SnapshotForDocument"),
 		visibleUploadsForPath:             op("VisibleUploadsForPath"),
 		syntacticUsages:                   op("SyntacticUsages"),
+		searchBasedUsages:                 op("SearchBasedUsages"),
 	}
 }
 

--- a/internal/codeintel/codenav/transport/graphql/iface.go
+++ b/internal/codeintel/codenav/transport/graphql/iface.go
@@ -28,7 +28,7 @@ type CodeNavService interface {
 	VisibleUploadsForPath(ctx context.Context, requestState codenav.RequestState) ([]uploadsshared.CompletedUpload, error)
 	SnapshotForDocument(ctx context.Context, repositoryID int, commit string, path core.RepoRelPath, uploadID int) (data []shared.SnapshotData, err error)
 	SCIPDocument(ctx context.Context, uploadID int, path core.RepoRelPath) (*scip.Document, error)
-	SyntacticUsages(ctx context.Context, repo types.Repo, commit api.CommitID, path core.RepoRelPath, symbolRange scip.Range) (codenav.SyntacticUsagesResult, *codenav.SyntacticUsagesError)
+	SyntacticUsages(ctx context.Context, repo types.Repo, commit api.CommitID, path core.RepoRelPath, symbolRange scip.Range) (codenav.SyntacticUsagesResult, codenav.PreviousSyntacticSearch, *codenav.SyntacticUsagesError)
 	SearchBasedUsages(ctx context.Context, repo types.Repo, commit api.CommitID, path core.RepoRelPath, symbolRange scip.Range, previous codenav.PreviousSyntacticSearch) ([]codenav.SearchBasedMatch, error)
 }
 

--- a/internal/codeintel/codenav/transport/graphql/iface.go
+++ b/internal/codeintel/codenav/transport/graphql/iface.go
@@ -5,12 +5,10 @@ import (
 
 	"github.com/sourcegraph/scip/bindings/go/scip"
 
-	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/codenav"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/codenav/shared"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/core"
 	uploadsshared "github.com/sourcegraph/sourcegraph/internal/codeintel/uploads/shared"
-	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
 type CodeNavService interface {
@@ -28,8 +26,8 @@ type CodeNavService interface {
 	VisibleUploadsForPath(ctx context.Context, requestState codenav.RequestState) ([]uploadsshared.CompletedUpload, error)
 	SnapshotForDocument(ctx context.Context, repositoryID int, commit string, path core.RepoRelPath, uploadID int) (data []shared.SnapshotData, err error)
 	SCIPDocument(ctx context.Context, uploadID int, path core.RepoRelPath) (*scip.Document, error)
-	SyntacticUsages(ctx context.Context, repo types.Repo, commit api.CommitID, path core.RepoRelPath, symbolRange scip.Range) (codenav.SyntacticUsagesResult, *codenav.PreviousSyntacticSearch, *codenav.SyntacticUsagesError)
-	SearchBasedUsages(ctx context.Context, repo types.Repo, commit api.CommitID, path core.RepoRelPath, symbolRange scip.Range, previous *codenav.PreviousSyntacticSearch) ([]codenav.SearchBasedMatch, error)
+	SyntacticUsages(ctx context.Context, args codenav.UsagesForSymbolArgs) (codenav.SyntacticUsagesResult, *codenav.PreviousSyntacticSearch, *codenav.SyntacticUsagesError)
+	SearchBasedUsages(ctx context.Context, args codenav.UsagesForSymbolArgs, previous *codenav.PreviousSyntacticSearch) ([]codenav.SearchBasedMatch, error)
 }
 
 type AutoIndexingService interface {

--- a/internal/codeintel/codenav/transport/graphql/iface.go
+++ b/internal/codeintel/codenav/transport/graphql/iface.go
@@ -28,7 +28,8 @@ type CodeNavService interface {
 	VisibleUploadsForPath(ctx context.Context, requestState codenav.RequestState) ([]uploadsshared.CompletedUpload, error)
 	SnapshotForDocument(ctx context.Context, repositoryID int, commit string, path core.RepoRelPath, uploadID int) (data []shared.SnapshotData, err error)
 	SCIPDocument(ctx context.Context, uploadID int, path core.RepoRelPath) (*scip.Document, error)
-	SyntacticUsages(ctx context.Context, repo types.Repo, commit api.CommitID, path core.RepoRelPath, symbolRange scip.Range) ([]codenav.SyntacticMatch, *codenav.SyntacticUsagesError)
+	SyntacticUsages(ctx context.Context, repo types.Repo, commit api.CommitID, path core.RepoRelPath, symbolRange scip.Range) (codenav.SyntacticUsagesResult, *codenav.SyntacticUsagesError)
+	SearchBasedUsages(ctx context.Context, repo types.Repo, commit api.CommitID, path core.RepoRelPath, symbolRange scip.Range, previous codenav.PreviousSyntacticSearch) ([]codenav.SearchBasedMatch, error)
 }
 
 type AutoIndexingService interface {

--- a/internal/codeintel/codenav/transport/graphql/iface.go
+++ b/internal/codeintel/codenav/transport/graphql/iface.go
@@ -28,8 +28,8 @@ type CodeNavService interface {
 	VisibleUploadsForPath(ctx context.Context, requestState codenav.RequestState) ([]uploadsshared.CompletedUpload, error)
 	SnapshotForDocument(ctx context.Context, repositoryID int, commit string, path core.RepoRelPath, uploadID int) (data []shared.SnapshotData, err error)
 	SCIPDocument(ctx context.Context, uploadID int, path core.RepoRelPath) (*scip.Document, error)
-	SyntacticUsages(ctx context.Context, repo types.Repo, commit api.CommitID, path core.RepoRelPath, symbolRange scip.Range) (codenav.SyntacticUsagesResult, codenav.PreviousSyntacticSearch, *codenav.SyntacticUsagesError)
-	SearchBasedUsages(ctx context.Context, repo types.Repo, commit api.CommitID, path core.RepoRelPath, symbolRange scip.Range, previous codenav.PreviousSyntacticSearch) ([]codenav.SearchBasedMatch, error)
+	SyntacticUsages(ctx context.Context, repo types.Repo, commit api.CommitID, path core.RepoRelPath, symbolRange scip.Range) (codenav.SyntacticUsagesResult, *codenav.PreviousSyntacticSearch, *codenav.SyntacticUsagesError)
+	SearchBasedUsages(ctx context.Context, repo types.Repo, commit api.CommitID, path core.RepoRelPath, symbolRange scip.Range, previous *codenav.PreviousSyntacticSearch) ([]codenav.SearchBasedMatch, error)
 }
 
 type AutoIndexingService interface {

--- a/internal/codeintel/codenav/transport/graphql/mocks_test.go
+++ b/internal/codeintel/codenav/transport/graphql/mocks_test.go
@@ -292,7 +292,7 @@ func NewMockCodeNavService() *MockCodeNavService {
 			},
 		},
 		SyntacticUsagesFunc: &CodeNavServiceSyntacticUsagesFunc{
-			defaultHook: func(context.Context, types.Repo, api.CommitID, core.RepoRelPath, scip.Range) (r0 codenav.SyntacticUsagesResult, r1 *codenav.SyntacticUsagesError) {
+			defaultHook: func(context.Context, types.Repo, api.CommitID, core.RepoRelPath, scip.Range) (r0 codenav.SyntacticUsagesResult, r1 codenav.PreviousSyntacticSearch, r2 *codenav.SyntacticUsagesError) {
 				return
 			},
 		},
@@ -369,7 +369,7 @@ func NewStrictMockCodeNavService() *MockCodeNavService {
 			},
 		},
 		SyntacticUsagesFunc: &CodeNavServiceSyntacticUsagesFunc{
-			defaultHook: func(context.Context, types.Repo, api.CommitID, core.RepoRelPath, scip.Range) (codenav.SyntacticUsagesResult, *codenav.SyntacticUsagesError) {
+			defaultHook: func(context.Context, types.Repo, api.CommitID, core.RepoRelPath, scip.Range) (codenav.SyntacticUsagesResult, codenav.PreviousSyntacticSearch, *codenav.SyntacticUsagesError) {
 				panic("unexpected invocation of MockCodeNavService.SyntacticUsages")
 			},
 		},
@@ -1835,24 +1835,24 @@ func (c CodeNavServiceSnapshotForDocumentFuncCall) Results() []interface{} {
 // SyntacticUsages method of the parent MockCodeNavService instance is
 // invoked.
 type CodeNavServiceSyntacticUsagesFunc struct {
-	defaultHook func(context.Context, types.Repo, api.CommitID, core.RepoRelPath, scip.Range) (codenav.SyntacticUsagesResult, *codenav.SyntacticUsagesError)
-	hooks       []func(context.Context, types.Repo, api.CommitID, core.RepoRelPath, scip.Range) (codenav.SyntacticUsagesResult, *codenav.SyntacticUsagesError)
+	defaultHook func(context.Context, types.Repo, api.CommitID, core.RepoRelPath, scip.Range) (codenav.SyntacticUsagesResult, codenav.PreviousSyntacticSearch, *codenav.SyntacticUsagesError)
+	hooks       []func(context.Context, types.Repo, api.CommitID, core.RepoRelPath, scip.Range) (codenav.SyntacticUsagesResult, codenav.PreviousSyntacticSearch, *codenav.SyntacticUsagesError)
 	history     []CodeNavServiceSyntacticUsagesFuncCall
 	mutex       sync.Mutex
 }
 
 // SyntacticUsages delegates to the next hook function in the queue and
 // stores the parameter and result values of this invocation.
-func (m *MockCodeNavService) SyntacticUsages(v0 context.Context, v1 types.Repo, v2 api.CommitID, v3 core.RepoRelPath, v4 scip.Range) (codenav.SyntacticUsagesResult, *codenav.SyntacticUsagesError) {
-	r0, r1 := m.SyntacticUsagesFunc.nextHook()(v0, v1, v2, v3, v4)
-	m.SyntacticUsagesFunc.appendCall(CodeNavServiceSyntacticUsagesFuncCall{v0, v1, v2, v3, v4, r0, r1})
-	return r0, r1
+func (m *MockCodeNavService) SyntacticUsages(v0 context.Context, v1 types.Repo, v2 api.CommitID, v3 core.RepoRelPath, v4 scip.Range) (codenav.SyntacticUsagesResult, codenav.PreviousSyntacticSearch, *codenav.SyntacticUsagesError) {
+	r0, r1, r2 := m.SyntacticUsagesFunc.nextHook()(v0, v1, v2, v3, v4)
+	m.SyntacticUsagesFunc.appendCall(CodeNavServiceSyntacticUsagesFuncCall{v0, v1, v2, v3, v4, r0, r1, r2})
+	return r0, r1, r2
 }
 
 // SetDefaultHook sets function that is called when the SyntacticUsages
 // method of the parent MockCodeNavService instance is invoked and the hook
 // queue is empty.
-func (f *CodeNavServiceSyntacticUsagesFunc) SetDefaultHook(hook func(context.Context, types.Repo, api.CommitID, core.RepoRelPath, scip.Range) (codenav.SyntacticUsagesResult, *codenav.SyntacticUsagesError)) {
+func (f *CodeNavServiceSyntacticUsagesFunc) SetDefaultHook(hook func(context.Context, types.Repo, api.CommitID, core.RepoRelPath, scip.Range) (codenav.SyntacticUsagesResult, codenav.PreviousSyntacticSearch, *codenav.SyntacticUsagesError)) {
 	f.defaultHook = hook
 }
 
@@ -1860,7 +1860,7 @@ func (f *CodeNavServiceSyntacticUsagesFunc) SetDefaultHook(hook func(context.Con
 // SyntacticUsages method of the parent MockCodeNavService instance invokes
 // the hook at the front of the queue and discards it. After the queue is
 // empty, the default hook function is invoked for any future action.
-func (f *CodeNavServiceSyntacticUsagesFunc) PushHook(hook func(context.Context, types.Repo, api.CommitID, core.RepoRelPath, scip.Range) (codenav.SyntacticUsagesResult, *codenav.SyntacticUsagesError)) {
+func (f *CodeNavServiceSyntacticUsagesFunc) PushHook(hook func(context.Context, types.Repo, api.CommitID, core.RepoRelPath, scip.Range) (codenav.SyntacticUsagesResult, codenav.PreviousSyntacticSearch, *codenav.SyntacticUsagesError)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -1868,20 +1868,20 @@ func (f *CodeNavServiceSyntacticUsagesFunc) PushHook(hook func(context.Context, 
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *CodeNavServiceSyntacticUsagesFunc) SetDefaultReturn(r0 codenav.SyntacticUsagesResult, r1 *codenav.SyntacticUsagesError) {
-	f.SetDefaultHook(func(context.Context, types.Repo, api.CommitID, core.RepoRelPath, scip.Range) (codenav.SyntacticUsagesResult, *codenav.SyntacticUsagesError) {
-		return r0, r1
+func (f *CodeNavServiceSyntacticUsagesFunc) SetDefaultReturn(r0 codenav.SyntacticUsagesResult, r1 codenav.PreviousSyntacticSearch, r2 *codenav.SyntacticUsagesError) {
+	f.SetDefaultHook(func(context.Context, types.Repo, api.CommitID, core.RepoRelPath, scip.Range) (codenav.SyntacticUsagesResult, codenav.PreviousSyntacticSearch, *codenav.SyntacticUsagesError) {
+		return r0, r1, r2
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *CodeNavServiceSyntacticUsagesFunc) PushReturn(r0 codenav.SyntacticUsagesResult, r1 *codenav.SyntacticUsagesError) {
-	f.PushHook(func(context.Context, types.Repo, api.CommitID, core.RepoRelPath, scip.Range) (codenav.SyntacticUsagesResult, *codenav.SyntacticUsagesError) {
-		return r0, r1
+func (f *CodeNavServiceSyntacticUsagesFunc) PushReturn(r0 codenav.SyntacticUsagesResult, r1 codenav.PreviousSyntacticSearch, r2 *codenav.SyntacticUsagesError) {
+	f.PushHook(func(context.Context, types.Repo, api.CommitID, core.RepoRelPath, scip.Range) (codenav.SyntacticUsagesResult, codenav.PreviousSyntacticSearch, *codenav.SyntacticUsagesError) {
+		return r0, r1, r2
 	})
 }
 
-func (f *CodeNavServiceSyntacticUsagesFunc) nextHook() func(context.Context, types.Repo, api.CommitID, core.RepoRelPath, scip.Range) (codenav.SyntacticUsagesResult, *codenav.SyntacticUsagesError) {
+func (f *CodeNavServiceSyntacticUsagesFunc) nextHook() func(context.Context, types.Repo, api.CommitID, core.RepoRelPath, scip.Range) (codenav.SyntacticUsagesResult, codenav.PreviousSyntacticSearch, *codenav.SyntacticUsagesError) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -1935,7 +1935,10 @@ type CodeNavServiceSyntacticUsagesFuncCall struct {
 	Result0 codenav.SyntacticUsagesResult
 	// Result1 is the value of the 2nd result returned from this method
 	// invocation.
-	Result1 *codenav.SyntacticUsagesError
+	Result1 codenav.PreviousSyntacticSearch
+	// Result2 is the value of the 3rd result returned from this method
+	// invocation.
+	Result2 *codenav.SyntacticUsagesError
 }
 
 // Args returns an interface slice containing the arguments of this
@@ -1947,7 +1950,7 @@ func (c CodeNavServiceSyntacticUsagesFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c CodeNavServiceSyntacticUsagesFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+	return []interface{}{c.Result0, c.Result1, c.Result2}
 }
 
 // CodeNavServiceVisibleUploadsForPathFunc describes the behavior when the

--- a/internal/codeintel/codenav/transport/graphql/mocks_test.go
+++ b/internal/codeintel/codenav/transport/graphql/mocks_test.go
@@ -213,6 +213,9 @@ type MockCodeNavService struct {
 	// SCIPDocumentFunc is an instance of a mock function object controlling
 	// the behavior of the method SCIPDocument.
 	SCIPDocumentFunc *CodeNavServiceSCIPDocumentFunc
+	// SearchBasedUsagesFunc is an instance of a mock function object
+	// controlling the behavior of the method SearchBasedUsages.
+	SearchBasedUsagesFunc *CodeNavServiceSearchBasedUsagesFunc
 	// SnapshotForDocumentFunc is an instance of a mock function object
 	// controlling the behavior of the method SnapshotForDocument.
 	SnapshotForDocumentFunc *CodeNavServiceSnapshotForDocumentFunc
@@ -278,13 +281,18 @@ func NewMockCodeNavService() *MockCodeNavService {
 				return
 			},
 		},
+		SearchBasedUsagesFunc: &CodeNavServiceSearchBasedUsagesFunc{
+			defaultHook: func(context.Context, types.Repo, api.CommitID, core.RepoRelPath, scip.Range, codenav.PreviousSyntacticSearch) (r0 []codenav.SearchBasedMatch, r1 error) {
+				return
+			},
+		},
 		SnapshotForDocumentFunc: &CodeNavServiceSnapshotForDocumentFunc{
 			defaultHook: func(context.Context, int, string, core.RepoRelPath, int) (r0 []shared1.SnapshotData, r1 error) {
 				return
 			},
 		},
 		SyntacticUsagesFunc: &CodeNavServiceSyntacticUsagesFunc{
-			defaultHook: func(context.Context, types.Repo, api.CommitID, core.RepoRelPath, scip.Range) (r0 []codenav.SyntacticMatch, r1 *codenav.SyntacticUsagesError) {
+			defaultHook: func(context.Context, types.Repo, api.CommitID, core.RepoRelPath, scip.Range) (r0 codenav.SyntacticUsagesResult, r1 *codenav.SyntacticUsagesError) {
 				return
 			},
 		},
@@ -350,13 +358,18 @@ func NewStrictMockCodeNavService() *MockCodeNavService {
 				panic("unexpected invocation of MockCodeNavService.SCIPDocument")
 			},
 		},
+		SearchBasedUsagesFunc: &CodeNavServiceSearchBasedUsagesFunc{
+			defaultHook: func(context.Context, types.Repo, api.CommitID, core.RepoRelPath, scip.Range, codenav.PreviousSyntacticSearch) ([]codenav.SearchBasedMatch, error) {
+				panic("unexpected invocation of MockCodeNavService.SearchBasedUsages")
+			},
+		},
 		SnapshotForDocumentFunc: &CodeNavServiceSnapshotForDocumentFunc{
 			defaultHook: func(context.Context, int, string, core.RepoRelPath, int) ([]shared1.SnapshotData, error) {
 				panic("unexpected invocation of MockCodeNavService.SnapshotForDocument")
 			},
 		},
 		SyntacticUsagesFunc: &CodeNavServiceSyntacticUsagesFunc{
-			defaultHook: func(context.Context, types.Repo, api.CommitID, core.RepoRelPath, scip.Range) ([]codenav.SyntacticMatch, *codenav.SyntacticUsagesError) {
+			defaultHook: func(context.Context, types.Repo, api.CommitID, core.RepoRelPath, scip.Range) (codenav.SyntacticUsagesResult, *codenav.SyntacticUsagesError) {
 				panic("unexpected invocation of MockCodeNavService.SyntacticUsages")
 			},
 		},
@@ -402,6 +415,9 @@ func NewMockCodeNavServiceFrom(i CodeNavService) *MockCodeNavService {
 		},
 		SCIPDocumentFunc: &CodeNavServiceSCIPDocumentFunc{
 			defaultHook: i.SCIPDocument,
+		},
+		SearchBasedUsagesFunc: &CodeNavServiceSearchBasedUsagesFunc{
+			defaultHook: i.SearchBasedUsages,
 		},
 		SnapshotForDocumentFunc: &CodeNavServiceSnapshotForDocumentFunc{
 			defaultHook: i.SnapshotForDocument,
@@ -1572,6 +1588,129 @@ func (c CodeNavServiceSCIPDocumentFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 
+// CodeNavServiceSearchBasedUsagesFunc describes the behavior when the
+// SearchBasedUsages method of the parent MockCodeNavService instance is
+// invoked.
+type CodeNavServiceSearchBasedUsagesFunc struct {
+	defaultHook func(context.Context, types.Repo, api.CommitID, core.RepoRelPath, scip.Range, codenav.PreviousSyntacticSearch) ([]codenav.SearchBasedMatch, error)
+	hooks       []func(context.Context, types.Repo, api.CommitID, core.RepoRelPath, scip.Range, codenav.PreviousSyntacticSearch) ([]codenav.SearchBasedMatch, error)
+	history     []CodeNavServiceSearchBasedUsagesFuncCall
+	mutex       sync.Mutex
+}
+
+// SearchBasedUsages delegates to the next hook function in the queue and
+// stores the parameter and result values of this invocation.
+func (m *MockCodeNavService) SearchBasedUsages(v0 context.Context, v1 types.Repo, v2 api.CommitID, v3 core.RepoRelPath, v4 scip.Range, v5 codenav.PreviousSyntacticSearch) ([]codenav.SearchBasedMatch, error) {
+	r0, r1 := m.SearchBasedUsagesFunc.nextHook()(v0, v1, v2, v3, v4, v5)
+	m.SearchBasedUsagesFunc.appendCall(CodeNavServiceSearchBasedUsagesFuncCall{v0, v1, v2, v3, v4, v5, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the SearchBasedUsages
+// method of the parent MockCodeNavService instance is invoked and the hook
+// queue is empty.
+func (f *CodeNavServiceSearchBasedUsagesFunc) SetDefaultHook(hook func(context.Context, types.Repo, api.CommitID, core.RepoRelPath, scip.Range, codenav.PreviousSyntacticSearch) ([]codenav.SearchBasedMatch, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// SearchBasedUsages method of the parent MockCodeNavService instance
+// invokes the hook at the front of the queue and discards it. After the
+// queue is empty, the default hook function is invoked for any future
+// action.
+func (f *CodeNavServiceSearchBasedUsagesFunc) PushHook(hook func(context.Context, types.Repo, api.CommitID, core.RepoRelPath, scip.Range, codenav.PreviousSyntacticSearch) ([]codenav.SearchBasedMatch, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *CodeNavServiceSearchBasedUsagesFunc) SetDefaultReturn(r0 []codenav.SearchBasedMatch, r1 error) {
+	f.SetDefaultHook(func(context.Context, types.Repo, api.CommitID, core.RepoRelPath, scip.Range, codenav.PreviousSyntacticSearch) ([]codenav.SearchBasedMatch, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *CodeNavServiceSearchBasedUsagesFunc) PushReturn(r0 []codenav.SearchBasedMatch, r1 error) {
+	f.PushHook(func(context.Context, types.Repo, api.CommitID, core.RepoRelPath, scip.Range, codenav.PreviousSyntacticSearch) ([]codenav.SearchBasedMatch, error) {
+		return r0, r1
+	})
+}
+
+func (f *CodeNavServiceSearchBasedUsagesFunc) nextHook() func(context.Context, types.Repo, api.CommitID, core.RepoRelPath, scip.Range, codenav.PreviousSyntacticSearch) ([]codenav.SearchBasedMatch, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *CodeNavServiceSearchBasedUsagesFunc) appendCall(r0 CodeNavServiceSearchBasedUsagesFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of CodeNavServiceSearchBasedUsagesFuncCall
+// objects describing the invocations of this function.
+func (f *CodeNavServiceSearchBasedUsagesFunc) History() []CodeNavServiceSearchBasedUsagesFuncCall {
+	f.mutex.Lock()
+	history := make([]CodeNavServiceSearchBasedUsagesFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// CodeNavServiceSearchBasedUsagesFuncCall is an object that describes an
+// invocation of method SearchBasedUsages on an instance of
+// MockCodeNavService.
+type CodeNavServiceSearchBasedUsagesFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 types.Repo
+	// Arg2 is the value of the 3rd argument passed to this method
+	// invocation.
+	Arg2 api.CommitID
+	// Arg3 is the value of the 4th argument passed to this method
+	// invocation.
+	Arg3 core.RepoRelPath
+	// Arg4 is the value of the 5th argument passed to this method
+	// invocation.
+	Arg4 scip.Range
+	// Arg5 is the value of the 6th argument passed to this method
+	// invocation.
+	Arg5 codenav.PreviousSyntacticSearch
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 []codenav.SearchBasedMatch
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c CodeNavServiceSearchBasedUsagesFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4, c.Arg5}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c CodeNavServiceSearchBasedUsagesFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
+}
+
 // CodeNavServiceSnapshotForDocumentFunc describes the behavior when the
 // SnapshotForDocument method of the parent MockCodeNavService instance is
 // invoked.
@@ -1696,15 +1835,15 @@ func (c CodeNavServiceSnapshotForDocumentFuncCall) Results() []interface{} {
 // SyntacticUsages method of the parent MockCodeNavService instance is
 // invoked.
 type CodeNavServiceSyntacticUsagesFunc struct {
-	defaultHook func(context.Context, types.Repo, api.CommitID, core.RepoRelPath, scip.Range) ([]codenav.SyntacticMatch, *codenav.SyntacticUsagesError)
-	hooks       []func(context.Context, types.Repo, api.CommitID, core.RepoRelPath, scip.Range) ([]codenav.SyntacticMatch, *codenav.SyntacticUsagesError)
+	defaultHook func(context.Context, types.Repo, api.CommitID, core.RepoRelPath, scip.Range) (codenav.SyntacticUsagesResult, *codenav.SyntacticUsagesError)
+	hooks       []func(context.Context, types.Repo, api.CommitID, core.RepoRelPath, scip.Range) (codenav.SyntacticUsagesResult, *codenav.SyntacticUsagesError)
 	history     []CodeNavServiceSyntacticUsagesFuncCall
 	mutex       sync.Mutex
 }
 
 // SyntacticUsages delegates to the next hook function in the queue and
 // stores the parameter and result values of this invocation.
-func (m *MockCodeNavService) SyntacticUsages(v0 context.Context, v1 types.Repo, v2 api.CommitID, v3 core.RepoRelPath, v4 scip.Range) ([]codenav.SyntacticMatch, *codenav.SyntacticUsagesError) {
+func (m *MockCodeNavService) SyntacticUsages(v0 context.Context, v1 types.Repo, v2 api.CommitID, v3 core.RepoRelPath, v4 scip.Range) (codenav.SyntacticUsagesResult, *codenav.SyntacticUsagesError) {
 	r0, r1 := m.SyntacticUsagesFunc.nextHook()(v0, v1, v2, v3, v4)
 	m.SyntacticUsagesFunc.appendCall(CodeNavServiceSyntacticUsagesFuncCall{v0, v1, v2, v3, v4, r0, r1})
 	return r0, r1
@@ -1713,7 +1852,7 @@ func (m *MockCodeNavService) SyntacticUsages(v0 context.Context, v1 types.Repo, 
 // SetDefaultHook sets function that is called when the SyntacticUsages
 // method of the parent MockCodeNavService instance is invoked and the hook
 // queue is empty.
-func (f *CodeNavServiceSyntacticUsagesFunc) SetDefaultHook(hook func(context.Context, types.Repo, api.CommitID, core.RepoRelPath, scip.Range) ([]codenav.SyntacticMatch, *codenav.SyntacticUsagesError)) {
+func (f *CodeNavServiceSyntacticUsagesFunc) SetDefaultHook(hook func(context.Context, types.Repo, api.CommitID, core.RepoRelPath, scip.Range) (codenav.SyntacticUsagesResult, *codenav.SyntacticUsagesError)) {
 	f.defaultHook = hook
 }
 
@@ -1721,7 +1860,7 @@ func (f *CodeNavServiceSyntacticUsagesFunc) SetDefaultHook(hook func(context.Con
 // SyntacticUsages method of the parent MockCodeNavService instance invokes
 // the hook at the front of the queue and discards it. After the queue is
 // empty, the default hook function is invoked for any future action.
-func (f *CodeNavServiceSyntacticUsagesFunc) PushHook(hook func(context.Context, types.Repo, api.CommitID, core.RepoRelPath, scip.Range) ([]codenav.SyntacticMatch, *codenav.SyntacticUsagesError)) {
+func (f *CodeNavServiceSyntacticUsagesFunc) PushHook(hook func(context.Context, types.Repo, api.CommitID, core.RepoRelPath, scip.Range) (codenav.SyntacticUsagesResult, *codenav.SyntacticUsagesError)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -1729,20 +1868,20 @@ func (f *CodeNavServiceSyntacticUsagesFunc) PushHook(hook func(context.Context, 
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *CodeNavServiceSyntacticUsagesFunc) SetDefaultReturn(r0 []codenav.SyntacticMatch, r1 *codenav.SyntacticUsagesError) {
-	f.SetDefaultHook(func(context.Context, types.Repo, api.CommitID, core.RepoRelPath, scip.Range) ([]codenav.SyntacticMatch, *codenav.SyntacticUsagesError) {
+func (f *CodeNavServiceSyntacticUsagesFunc) SetDefaultReturn(r0 codenav.SyntacticUsagesResult, r1 *codenav.SyntacticUsagesError) {
+	f.SetDefaultHook(func(context.Context, types.Repo, api.CommitID, core.RepoRelPath, scip.Range) (codenav.SyntacticUsagesResult, *codenav.SyntacticUsagesError) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *CodeNavServiceSyntacticUsagesFunc) PushReturn(r0 []codenav.SyntacticMatch, r1 *codenav.SyntacticUsagesError) {
-	f.PushHook(func(context.Context, types.Repo, api.CommitID, core.RepoRelPath, scip.Range) ([]codenav.SyntacticMatch, *codenav.SyntacticUsagesError) {
+func (f *CodeNavServiceSyntacticUsagesFunc) PushReturn(r0 codenav.SyntacticUsagesResult, r1 *codenav.SyntacticUsagesError) {
+	f.PushHook(func(context.Context, types.Repo, api.CommitID, core.RepoRelPath, scip.Range) (codenav.SyntacticUsagesResult, *codenav.SyntacticUsagesError) {
 		return r0, r1
 	})
 }
 
-func (f *CodeNavServiceSyntacticUsagesFunc) nextHook() func(context.Context, types.Repo, api.CommitID, core.RepoRelPath, scip.Range) ([]codenav.SyntacticMatch, *codenav.SyntacticUsagesError) {
+func (f *CodeNavServiceSyntacticUsagesFunc) nextHook() func(context.Context, types.Repo, api.CommitID, core.RepoRelPath, scip.Range) (codenav.SyntacticUsagesResult, *codenav.SyntacticUsagesError) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -1793,7 +1932,7 @@ type CodeNavServiceSyntacticUsagesFuncCall struct {
 	Arg4 scip.Range
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 []codenav.SyntacticMatch
+	Result0 codenav.SyntacticUsagesResult
 	// Result1 is the value of the 2nd result returned from this method
 	// invocation.
 	Result1 *codenav.SyntacticUsagesError

--- a/internal/codeintel/codenav/transport/graphql/mocks_test.go
+++ b/internal/codeintel/codenav/transport/graphql/mocks_test.go
@@ -282,7 +282,7 @@ func NewMockCodeNavService() *MockCodeNavService {
 			},
 		},
 		SearchBasedUsagesFunc: &CodeNavServiceSearchBasedUsagesFunc{
-			defaultHook: func(context.Context, types.Repo, api.CommitID, core.RepoRelPath, scip.Range, codenav.PreviousSyntacticSearch) (r0 []codenav.SearchBasedMatch, r1 error) {
+			defaultHook: func(context.Context, types.Repo, api.CommitID, core.RepoRelPath, scip.Range, *codenav.PreviousSyntacticSearch) (r0 []codenav.SearchBasedMatch, r1 error) {
 				return
 			},
 		},
@@ -292,7 +292,7 @@ func NewMockCodeNavService() *MockCodeNavService {
 			},
 		},
 		SyntacticUsagesFunc: &CodeNavServiceSyntacticUsagesFunc{
-			defaultHook: func(context.Context, types.Repo, api.CommitID, core.RepoRelPath, scip.Range) (r0 codenav.SyntacticUsagesResult, r1 codenav.PreviousSyntacticSearch, r2 *codenav.SyntacticUsagesError) {
+			defaultHook: func(context.Context, types.Repo, api.CommitID, core.RepoRelPath, scip.Range) (r0 codenav.SyntacticUsagesResult, r1 *codenav.PreviousSyntacticSearch, r2 *codenav.SyntacticUsagesError) {
 				return
 			},
 		},
@@ -359,7 +359,7 @@ func NewStrictMockCodeNavService() *MockCodeNavService {
 			},
 		},
 		SearchBasedUsagesFunc: &CodeNavServiceSearchBasedUsagesFunc{
-			defaultHook: func(context.Context, types.Repo, api.CommitID, core.RepoRelPath, scip.Range, codenav.PreviousSyntacticSearch) ([]codenav.SearchBasedMatch, error) {
+			defaultHook: func(context.Context, types.Repo, api.CommitID, core.RepoRelPath, scip.Range, *codenav.PreviousSyntacticSearch) ([]codenav.SearchBasedMatch, error) {
 				panic("unexpected invocation of MockCodeNavService.SearchBasedUsages")
 			},
 		},
@@ -369,7 +369,7 @@ func NewStrictMockCodeNavService() *MockCodeNavService {
 			},
 		},
 		SyntacticUsagesFunc: &CodeNavServiceSyntacticUsagesFunc{
-			defaultHook: func(context.Context, types.Repo, api.CommitID, core.RepoRelPath, scip.Range) (codenav.SyntacticUsagesResult, codenav.PreviousSyntacticSearch, *codenav.SyntacticUsagesError) {
+			defaultHook: func(context.Context, types.Repo, api.CommitID, core.RepoRelPath, scip.Range) (codenav.SyntacticUsagesResult, *codenav.PreviousSyntacticSearch, *codenav.SyntacticUsagesError) {
 				panic("unexpected invocation of MockCodeNavService.SyntacticUsages")
 			},
 		},
@@ -1592,15 +1592,15 @@ func (c CodeNavServiceSCIPDocumentFuncCall) Results() []interface{} {
 // SearchBasedUsages method of the parent MockCodeNavService instance is
 // invoked.
 type CodeNavServiceSearchBasedUsagesFunc struct {
-	defaultHook func(context.Context, types.Repo, api.CommitID, core.RepoRelPath, scip.Range, codenav.PreviousSyntacticSearch) ([]codenav.SearchBasedMatch, error)
-	hooks       []func(context.Context, types.Repo, api.CommitID, core.RepoRelPath, scip.Range, codenav.PreviousSyntacticSearch) ([]codenav.SearchBasedMatch, error)
+	defaultHook func(context.Context, types.Repo, api.CommitID, core.RepoRelPath, scip.Range, *codenav.PreviousSyntacticSearch) ([]codenav.SearchBasedMatch, error)
+	hooks       []func(context.Context, types.Repo, api.CommitID, core.RepoRelPath, scip.Range, *codenav.PreviousSyntacticSearch) ([]codenav.SearchBasedMatch, error)
 	history     []CodeNavServiceSearchBasedUsagesFuncCall
 	mutex       sync.Mutex
 }
 
 // SearchBasedUsages delegates to the next hook function in the queue and
 // stores the parameter and result values of this invocation.
-func (m *MockCodeNavService) SearchBasedUsages(v0 context.Context, v1 types.Repo, v2 api.CommitID, v3 core.RepoRelPath, v4 scip.Range, v5 codenav.PreviousSyntacticSearch) ([]codenav.SearchBasedMatch, error) {
+func (m *MockCodeNavService) SearchBasedUsages(v0 context.Context, v1 types.Repo, v2 api.CommitID, v3 core.RepoRelPath, v4 scip.Range, v5 *codenav.PreviousSyntacticSearch) ([]codenav.SearchBasedMatch, error) {
 	r0, r1 := m.SearchBasedUsagesFunc.nextHook()(v0, v1, v2, v3, v4, v5)
 	m.SearchBasedUsagesFunc.appendCall(CodeNavServiceSearchBasedUsagesFuncCall{v0, v1, v2, v3, v4, v5, r0, r1})
 	return r0, r1
@@ -1609,7 +1609,7 @@ func (m *MockCodeNavService) SearchBasedUsages(v0 context.Context, v1 types.Repo
 // SetDefaultHook sets function that is called when the SearchBasedUsages
 // method of the parent MockCodeNavService instance is invoked and the hook
 // queue is empty.
-func (f *CodeNavServiceSearchBasedUsagesFunc) SetDefaultHook(hook func(context.Context, types.Repo, api.CommitID, core.RepoRelPath, scip.Range, codenav.PreviousSyntacticSearch) ([]codenav.SearchBasedMatch, error)) {
+func (f *CodeNavServiceSearchBasedUsagesFunc) SetDefaultHook(hook func(context.Context, types.Repo, api.CommitID, core.RepoRelPath, scip.Range, *codenav.PreviousSyntacticSearch) ([]codenav.SearchBasedMatch, error)) {
 	f.defaultHook = hook
 }
 
@@ -1618,7 +1618,7 @@ func (f *CodeNavServiceSearchBasedUsagesFunc) SetDefaultHook(hook func(context.C
 // invokes the hook at the front of the queue and discards it. After the
 // queue is empty, the default hook function is invoked for any future
 // action.
-func (f *CodeNavServiceSearchBasedUsagesFunc) PushHook(hook func(context.Context, types.Repo, api.CommitID, core.RepoRelPath, scip.Range, codenav.PreviousSyntacticSearch) ([]codenav.SearchBasedMatch, error)) {
+func (f *CodeNavServiceSearchBasedUsagesFunc) PushHook(hook func(context.Context, types.Repo, api.CommitID, core.RepoRelPath, scip.Range, *codenav.PreviousSyntacticSearch) ([]codenav.SearchBasedMatch, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -1627,19 +1627,19 @@ func (f *CodeNavServiceSearchBasedUsagesFunc) PushHook(hook func(context.Context
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
 func (f *CodeNavServiceSearchBasedUsagesFunc) SetDefaultReturn(r0 []codenav.SearchBasedMatch, r1 error) {
-	f.SetDefaultHook(func(context.Context, types.Repo, api.CommitID, core.RepoRelPath, scip.Range, codenav.PreviousSyntacticSearch) ([]codenav.SearchBasedMatch, error) {
+	f.SetDefaultHook(func(context.Context, types.Repo, api.CommitID, core.RepoRelPath, scip.Range, *codenav.PreviousSyntacticSearch) ([]codenav.SearchBasedMatch, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
 func (f *CodeNavServiceSearchBasedUsagesFunc) PushReturn(r0 []codenav.SearchBasedMatch, r1 error) {
-	f.PushHook(func(context.Context, types.Repo, api.CommitID, core.RepoRelPath, scip.Range, codenav.PreviousSyntacticSearch) ([]codenav.SearchBasedMatch, error) {
+	f.PushHook(func(context.Context, types.Repo, api.CommitID, core.RepoRelPath, scip.Range, *codenav.PreviousSyntacticSearch) ([]codenav.SearchBasedMatch, error) {
 		return r0, r1
 	})
 }
 
-func (f *CodeNavServiceSearchBasedUsagesFunc) nextHook() func(context.Context, types.Repo, api.CommitID, core.RepoRelPath, scip.Range, codenav.PreviousSyntacticSearch) ([]codenav.SearchBasedMatch, error) {
+func (f *CodeNavServiceSearchBasedUsagesFunc) nextHook() func(context.Context, types.Repo, api.CommitID, core.RepoRelPath, scip.Range, *codenav.PreviousSyntacticSearch) ([]codenav.SearchBasedMatch, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -1690,7 +1690,7 @@ type CodeNavServiceSearchBasedUsagesFuncCall struct {
 	Arg4 scip.Range
 	// Arg5 is the value of the 6th argument passed to this method
 	// invocation.
-	Arg5 codenav.PreviousSyntacticSearch
+	Arg5 *codenav.PreviousSyntacticSearch
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 []codenav.SearchBasedMatch
@@ -1835,15 +1835,15 @@ func (c CodeNavServiceSnapshotForDocumentFuncCall) Results() []interface{} {
 // SyntacticUsages method of the parent MockCodeNavService instance is
 // invoked.
 type CodeNavServiceSyntacticUsagesFunc struct {
-	defaultHook func(context.Context, types.Repo, api.CommitID, core.RepoRelPath, scip.Range) (codenav.SyntacticUsagesResult, codenav.PreviousSyntacticSearch, *codenav.SyntacticUsagesError)
-	hooks       []func(context.Context, types.Repo, api.CommitID, core.RepoRelPath, scip.Range) (codenav.SyntacticUsagesResult, codenav.PreviousSyntacticSearch, *codenav.SyntacticUsagesError)
+	defaultHook func(context.Context, types.Repo, api.CommitID, core.RepoRelPath, scip.Range) (codenav.SyntacticUsagesResult, *codenav.PreviousSyntacticSearch, *codenav.SyntacticUsagesError)
+	hooks       []func(context.Context, types.Repo, api.CommitID, core.RepoRelPath, scip.Range) (codenav.SyntacticUsagesResult, *codenav.PreviousSyntacticSearch, *codenav.SyntacticUsagesError)
 	history     []CodeNavServiceSyntacticUsagesFuncCall
 	mutex       sync.Mutex
 }
 
 // SyntacticUsages delegates to the next hook function in the queue and
 // stores the parameter and result values of this invocation.
-func (m *MockCodeNavService) SyntacticUsages(v0 context.Context, v1 types.Repo, v2 api.CommitID, v3 core.RepoRelPath, v4 scip.Range) (codenav.SyntacticUsagesResult, codenav.PreviousSyntacticSearch, *codenav.SyntacticUsagesError) {
+func (m *MockCodeNavService) SyntacticUsages(v0 context.Context, v1 types.Repo, v2 api.CommitID, v3 core.RepoRelPath, v4 scip.Range) (codenav.SyntacticUsagesResult, *codenav.PreviousSyntacticSearch, *codenav.SyntacticUsagesError) {
 	r0, r1, r2 := m.SyntacticUsagesFunc.nextHook()(v0, v1, v2, v3, v4)
 	m.SyntacticUsagesFunc.appendCall(CodeNavServiceSyntacticUsagesFuncCall{v0, v1, v2, v3, v4, r0, r1, r2})
 	return r0, r1, r2
@@ -1852,7 +1852,7 @@ func (m *MockCodeNavService) SyntacticUsages(v0 context.Context, v1 types.Repo, 
 // SetDefaultHook sets function that is called when the SyntacticUsages
 // method of the parent MockCodeNavService instance is invoked and the hook
 // queue is empty.
-func (f *CodeNavServiceSyntacticUsagesFunc) SetDefaultHook(hook func(context.Context, types.Repo, api.CommitID, core.RepoRelPath, scip.Range) (codenav.SyntacticUsagesResult, codenav.PreviousSyntacticSearch, *codenav.SyntacticUsagesError)) {
+func (f *CodeNavServiceSyntacticUsagesFunc) SetDefaultHook(hook func(context.Context, types.Repo, api.CommitID, core.RepoRelPath, scip.Range) (codenav.SyntacticUsagesResult, *codenav.PreviousSyntacticSearch, *codenav.SyntacticUsagesError)) {
 	f.defaultHook = hook
 }
 
@@ -1860,7 +1860,7 @@ func (f *CodeNavServiceSyntacticUsagesFunc) SetDefaultHook(hook func(context.Con
 // SyntacticUsages method of the parent MockCodeNavService instance invokes
 // the hook at the front of the queue and discards it. After the queue is
 // empty, the default hook function is invoked for any future action.
-func (f *CodeNavServiceSyntacticUsagesFunc) PushHook(hook func(context.Context, types.Repo, api.CommitID, core.RepoRelPath, scip.Range) (codenav.SyntacticUsagesResult, codenav.PreviousSyntacticSearch, *codenav.SyntacticUsagesError)) {
+func (f *CodeNavServiceSyntacticUsagesFunc) PushHook(hook func(context.Context, types.Repo, api.CommitID, core.RepoRelPath, scip.Range) (codenav.SyntacticUsagesResult, *codenav.PreviousSyntacticSearch, *codenav.SyntacticUsagesError)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -1868,20 +1868,20 @@ func (f *CodeNavServiceSyntacticUsagesFunc) PushHook(hook func(context.Context, 
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *CodeNavServiceSyntacticUsagesFunc) SetDefaultReturn(r0 codenav.SyntacticUsagesResult, r1 codenav.PreviousSyntacticSearch, r2 *codenav.SyntacticUsagesError) {
-	f.SetDefaultHook(func(context.Context, types.Repo, api.CommitID, core.RepoRelPath, scip.Range) (codenav.SyntacticUsagesResult, codenav.PreviousSyntacticSearch, *codenav.SyntacticUsagesError) {
+func (f *CodeNavServiceSyntacticUsagesFunc) SetDefaultReturn(r0 codenav.SyntacticUsagesResult, r1 *codenav.PreviousSyntacticSearch, r2 *codenav.SyntacticUsagesError) {
+	f.SetDefaultHook(func(context.Context, types.Repo, api.CommitID, core.RepoRelPath, scip.Range) (codenav.SyntacticUsagesResult, *codenav.PreviousSyntacticSearch, *codenav.SyntacticUsagesError) {
 		return r0, r1, r2
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *CodeNavServiceSyntacticUsagesFunc) PushReturn(r0 codenav.SyntacticUsagesResult, r1 codenav.PreviousSyntacticSearch, r2 *codenav.SyntacticUsagesError) {
-	f.PushHook(func(context.Context, types.Repo, api.CommitID, core.RepoRelPath, scip.Range) (codenav.SyntacticUsagesResult, codenav.PreviousSyntacticSearch, *codenav.SyntacticUsagesError) {
+func (f *CodeNavServiceSyntacticUsagesFunc) PushReturn(r0 codenav.SyntacticUsagesResult, r1 *codenav.PreviousSyntacticSearch, r2 *codenav.SyntacticUsagesError) {
+	f.PushHook(func(context.Context, types.Repo, api.CommitID, core.RepoRelPath, scip.Range) (codenav.SyntacticUsagesResult, *codenav.PreviousSyntacticSearch, *codenav.SyntacticUsagesError) {
 		return r0, r1, r2
 	})
 }
 
-func (f *CodeNavServiceSyntacticUsagesFunc) nextHook() func(context.Context, types.Repo, api.CommitID, core.RepoRelPath, scip.Range) (codenav.SyntacticUsagesResult, codenav.PreviousSyntacticSearch, *codenav.SyntacticUsagesError) {
+func (f *CodeNavServiceSyntacticUsagesFunc) nextHook() func(context.Context, types.Repo, api.CommitID, core.RepoRelPath, scip.Range) (codenav.SyntacticUsagesResult, *codenav.PreviousSyntacticSearch, *codenav.SyntacticUsagesError) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -1935,7 +1935,7 @@ type CodeNavServiceSyntacticUsagesFuncCall struct {
 	Result0 codenav.SyntacticUsagesResult
 	// Result1 is the value of the 2nd result returned from this method
 	// invocation.
-	Result1 codenav.PreviousSyntacticSearch
+	Result1 *codenav.PreviousSyntacticSearch
 	// Result2 is the value of the 3rd result returned from this method
 	// invocation.
 	Result2 *codenav.SyntacticUsagesError

--- a/internal/codeintel/codenav/transport/graphql/root_resolver.go
+++ b/internal/codeintel/codenav/transport/graphql/root_resolver.go
@@ -216,9 +216,15 @@ func (r *rootResolver) UsagesForSymbol(ctx context.Context, unresolvedArgs *reso
 		remainingCount = remainingCount - numPreciseResults
 	}
 
+	usagesForSymbolArgs := codenav.UsagesForSymbolArgs{
+		Repo:        args.Repo,
+		Commit:      args.CommitID,
+		Path:        args.Path,
+		SymbolRange: args.Range,
+	}
 	var previousSyntacticSearch *codenav.PreviousSyntacticSearch
 	if remainingCount > 0 && provsForSCIPData.Syntactic {
-		syntacticResult, prevSearch, err := r.svc.SyntacticUsages(ctx, args.Repo, args.CommitID, args.Path, args.Range)
+		syntacticResult, prevSearch, err := r.svc.SyntacticUsages(ctx, usagesForSymbolArgs)
 		if err != nil {
 			switch err.Code {
 			case codenav.SU_Fatal:
@@ -241,7 +247,7 @@ func (r *rootResolver) UsagesForSymbol(ctx context.Context, unresolvedArgs *reso
 	}
 
 	if remainingCount > 0 && provsForSCIPData.SearchBased {
-		results, err := r.svc.SearchBasedUsages(ctx, args.Repo, args.CommitID, args.Path, args.Range, previousSyntacticSearch)
+		results, err := r.svc.SearchBasedUsages(ctx, usagesForSymbolArgs, previousSyntacticSearch)
 		if err != nil {
 			// We only want to fail the request on an error here if we didn't get any precise or syntactic results before
 			if len(usageResolvers) == 0 {

--- a/internal/codeintel/codenav/transport/graphql/root_resolver.go
+++ b/internal/codeintel/codenav/transport/graphql/root_resolver.go
@@ -209,15 +209,16 @@ func (r *rootResolver) UsagesForSymbol(ctx context.Context, unresolvedArgs *reso
 	}
 	remainingCount := int(args.RemainingCount)
 	provsForSCIPData := args.Symbol.ProvenancesForSCIPData()
+	usageResolvers := []resolverstubs.UsageResolver{}
 
 	if provsForSCIPData.Precise {
 		// Attempt to get up to remainingCount precise results.
 		remainingCount = remainingCount - numPreciseResults
 	}
 
+	previousSyntacticSearch := codenav.PreviousSyntacticSearch{}
 	if remainingCount > 0 && provsForSCIPData.Syntactic {
-		// Attempt to get up to remainingCount syntactic results.
-		results, err := r.svc.SyntacticUsages(ctx, args.Repo, args.CommitID, args.Path, args.Range)
+		syntacticResult, err := r.svc.SyntacticUsages(ctx, args.Repo, args.CommitID, args.Path, args.Range)
 		if err != nil {
 			switch err.Code {
 			case codenav.SU_Fatal:
@@ -228,28 +229,44 @@ func (r *rootResolver) UsagesForSymbol(ctx context.Context, unresolvedArgs *reso
 			default:
 				// None of these errors should cause the whole request to fail
 				// TODO: We might want to log some of them in the future
+			}
+		} else {
+			for _, result := range syntacticResult.Matches {
+				usageResolvers = append(usageResolvers, NewSyntacticUsageResolver(result, args.Repo, args.CommitID))
+			}
+			numSyntacticResults = len(syntacticResult.Matches)
+			remainingCount = remainingCount - numSyntacticResults
 
+			previousSyntacticSearch = codenav.PreviousSyntacticSearch{
+				Found:      true,
+				UploadID:   syntacticResult.UploadID,
+				SymbolName: syntacticResult.SymbolName,
 			}
 		}
-
-		usageResolvers := []resolverstubs.UsageResolver{}
-		for _, result := range results {
-			usageResolvers = append(usageResolvers, NewSyntacticUsageResolver(result, args.Repo, args.CommitID))
-		}
-		if len(usageResolvers) != 0 {
-			return &usageConnectionResolver{
-				nodes:    usageResolvers,
-				pageInfo: resolverstubs.NewSimplePageInfo(false),
-			}, nil
-		}
-
-		numSyntacticResults = len(results)
-		remainingCount = remainingCount - numSyntacticResults
 	}
 
 	if remainingCount > 0 && provsForSCIPData.SearchBased {
-		// Attempt to get up to remainingCount search-based results.
-		_ = "shut up nogo linter complaining about empty branch"
+		results, err := r.svc.SearchBasedUsages(ctx, args.Repo, args.CommitID, args.Path, args.Range, previousSyntacticSearch)
+		if err != nil {
+			// We only want to fail the request on an error here if we didn't get any precise or syntactic results before
+			if len(usageResolvers) == 0 {
+				return nil, err
+			} else {
+				// TODO: We might want to log some of these errors in the future
+				_ = "shut up nogo linter"
+			}
+		} else {
+			for _, result := range results {
+				usageResolvers = append(usageResolvers, NewSearchBasedUsageResolver(result, args.Repo, args.CommitID))
+			}
+		}
+	}
+
+	if len(usageResolvers) != 0 {
+		return &usageConnectionResolver{
+			nodes:    usageResolvers,
+			pageInfo: resolverstubs.NewSimplePageInfo(false),
+		}, nil
 	}
 
 	return nil, errors.New("Not implemented yet")

--- a/internal/codeintel/codenav/transport/graphql/root_resolver.go
+++ b/internal/codeintel/codenav/transport/graphql/root_resolver.go
@@ -216,9 +216,9 @@ func (r *rootResolver) UsagesForSymbol(ctx context.Context, unresolvedArgs *reso
 		remainingCount = remainingCount - numPreciseResults
 	}
 
-	previousSyntacticSearch := codenav.PreviousSyntacticSearch{}
+	var previousSyntacticSearch codenav.PreviousSyntacticSearch
 	if remainingCount > 0 && provsForSCIPData.Syntactic {
-		syntacticResult, err := r.svc.SyntacticUsages(ctx, args.Repo, args.CommitID, args.Path, args.Range)
+		syntacticResult, prevSearch, err := r.svc.SyntacticUsages(ctx, args.Repo, args.CommitID, args.Path, args.Range)
 		if err != nil {
 			switch err.Code {
 			case codenav.SU_Fatal:
@@ -236,12 +236,7 @@ func (r *rootResolver) UsagesForSymbol(ctx context.Context, unresolvedArgs *reso
 			}
 			numSyntacticResults = len(syntacticResult.Matches)
 			remainingCount = remainingCount - numSyntacticResults
-
-			previousSyntacticSearch = codenav.PreviousSyntacticSearch{
-				Found:      true,
-				UploadID:   syntacticResult.UploadID,
-				SymbolName: syntacticResult.SymbolName,
-			}
+			previousSyntacticSearch = prevSearch
 		}
 	}
 

--- a/internal/codeintel/codenav/transport/graphql/root_resolver.go
+++ b/internal/codeintel/codenav/transport/graphql/root_resolver.go
@@ -216,7 +216,7 @@ func (r *rootResolver) UsagesForSymbol(ctx context.Context, unresolvedArgs *reso
 		remainingCount = remainingCount - numPreciseResults
 	}
 
-	var previousSyntacticSearch codenav.PreviousSyntacticSearch
+	var previousSyntacticSearch *codenav.PreviousSyntacticSearch
 	if remainingCount > 0 && provsForSCIPData.Syntactic {
 		syntacticResult, prevSearch, err := r.svc.SyntacticUsages(ctx, args.Repo, args.CommitID, args.Path, args.Range)
 		if err != nil {

--- a/internal/codeintel/codenav/transport/graphql/root_resolver_usages.go
+++ b/internal/codeintel/codenav/transport/graphql/root_resolver_usages.go
@@ -69,7 +69,7 @@ func NewSearchBasedUsageResolver(usage codenav.SearchBasedMatch, repository type
 			repository: repository,
 			revision:   revision,
 			path:       usage.Path,
-			range_:     usage.Range(),
+			range_:     usage.Range,
 		},
 	}
 }

--- a/internal/codeintel/codenav/transport/graphql/root_resolver_usages.go
+++ b/internal/codeintel/codenav/transport/graphql/root_resolver_usages.go
@@ -58,6 +58,21 @@ func NewSyntacticUsageResolver(usage codenav.SyntacticMatch, repository types.Re
 		},
 	}
 }
+func NewSearchBasedUsageResolver(usage codenav.SearchBasedMatch, repository types.Repo, revision api.CommitID) resolverstubs.UsageResolver {
+	// TODO: We can figure out if something is a definition via symbol search
+	kind := resolverstubs.UsageKindReference
+	return &usageResolver{
+		symbol:     nil,
+		provenance: resolverstubs.ProvenanceSearchBased,
+		kind:       kind,
+		usageRange: &usageRangeResolver{
+			repository: repository,
+			revision:   revision,
+			path:       usage.Path,
+			range_:     usage.Range(),
+		},
+	}
+}
 
 func (u *usageResolver) Symbol(ctx context.Context) (resolverstubs.SymbolInformationResolver, error) {
 	if u.symbol == nil {

--- a/internal/codeintel/codenav/transport/graphql/root_resolver_usages.go
+++ b/internal/codeintel/codenav/transport/graphql/root_resolver_usages.go
@@ -29,7 +29,8 @@ func (u *usageConnectionResolver) PageInfo() resolverstubs.PageInfo {
 }
 
 type usageResolver struct {
-	symbol     resolverstubs.SymbolInformationResolver
+	symbol     *symbolInformationResolver
+	provenance resolverstubs.CodeGraphDataProvenance
 	kind       resolverstubs.SymbolUsageKind
 	usageRange resolverstubs.UsageRangeResolver
 }
@@ -45,10 +46,10 @@ func NewSyntacticUsageResolver(usage codenav.SyntacticMatch, repository types.Re
 	}
 	return &usageResolver{
 		symbol: &symbolInformationResolver{
-			name:       usage.Occurrence.Symbol,
-			provenance: resolverstubs.ProvenanceSyntactic,
+			name: usage.Occurrence.Symbol,
 		},
-		kind: kind,
+		provenance: resolverstubs.ProvenanceSyntactic,
+		kind:       kind,
 		usageRange: &usageRangeResolver{
 			repository: repository,
 			revision:   revision,
@@ -59,7 +60,20 @@ func NewSyntacticUsageResolver(usage codenav.SyntacticMatch, repository types.Re
 }
 
 func (u *usageResolver) Symbol(ctx context.Context) (resolverstubs.SymbolInformationResolver, error) {
+	if u.symbol == nil {
+		// NOTE: if I try to directly return u.symbol, I get a panic in the resolver.
+		return nil, nil
+	}
 	return u.symbol, nil
+}
+
+func (u *usageResolver) Provenance(ctx context.Context) (resolverstubs.CodeGraphDataProvenance, error) {
+	return u.provenance, nil
+}
+
+func (u *usageResolver) DataSource() *string {
+	//TODO implement me
+	panic("implement me")
 }
 
 func (u *usageResolver) UsageRange(ctx context.Context) (resolverstubs.UsageRangeResolver, error) {
@@ -78,8 +92,7 @@ func (u *usageResolver) UsageKind() resolverstubs.SymbolUsageKind {
 }
 
 type symbolInformationResolver struct {
-	name       string
-	provenance resolverstubs.CodeGraphDataProvenance
+	name string
 }
 
 var _ resolverstubs.SymbolInformationResolver = &symbolInformationResolver{}
@@ -89,15 +102,6 @@ func (s *symbolInformationResolver) Name() (string, error) {
 }
 
 func (s *symbolInformationResolver) Documentation() (*[]string, error) {
-	//TODO implement me
-	panic("implement me")
-}
-
-func (s *symbolInformationResolver) Provenance() (resolverstubs.CodeGraphDataProvenance, error) {
-	return s.provenance, nil
-}
-
-func (s *symbolInformationResolver) DataSource() *string {
 	//TODO implement me
 	panic("implement me")
 }

--- a/internal/codeintel/codenav/transport/graphql/root_resolver_usages.go
+++ b/internal/codeintel/codenav/transport/graphql/root_resolver_usages.go
@@ -88,6 +88,7 @@ func (u *usageResolver) Provenance(ctx context.Context) (resolverstubs.CodeGraph
 
 func (u *usageResolver) DataSource() *string {
 	//TODO implement me
+	// NOTE: For search-based usages it would be good to return if this usage was found via Zoekt or Searcher
 	panic("implement me")
 }
 

--- a/internal/codeintel/resolvers/codenav.go
+++ b/internal/codeintel/resolvers/codenav.go
@@ -617,6 +617,8 @@ type UsageConnectionResolver = PagedConnectionResolver[UsageResolver]
 
 type UsageResolver interface {
 	Symbol(context.Context) (SymbolInformationResolver, error)
+	Provenance(context.Context) (CodeGraphDataProvenance, error)
+	DataSource() *string
 	UsageRange(context.Context) (UsageRangeResolver, error)
 	SurroundingContent(_ context.Context, args *struct {
 		*SurroundingLines `json:"surroundingLines"`
@@ -627,8 +629,6 @@ type UsageResolver interface {
 type SymbolInformationResolver interface {
 	Name() (string, error)
 	Documentation() (*[]string, error)
-	Provenance() (CodeGraphDataProvenance, error)
-	DataSource() *string
 }
 
 type UsageRangeResolver interface {


### PR DESCRIPTION
Closes https://linear.app/sourcegraph/issue/GRAPH-703/syntactic-filtered-search-based-usages

This initial implementation adds search-based usages for the new codenav API.

I'll work on a follow-up PR(https://github.com/sourcegraph/sourcegraph/pull/63509) to get us to feature parity with the current search-based implementation. https://linear.app/sourcegraph/issue/GRAPH-712/determine-usage-kind-for-search-based-usages-by-running-symbol-search

Additionally I've added an implementation note for when I work on pagination next cycle here: https://linear.app/sourcegraph/issue/GRAPH-696/implement-pagination-for-syntactic-and-search-based-usages

## Test plan

Using the API console
