### PR TITLE
chore(code-search): disable codemonitoring dotcom (jscontext)

### DIFF
--- a/cmd/frontend/internal/app/jscontext/jscontext.go
+++ b/cmd/frontend/internal/app/jscontext/jscontext.go
@@ -372,6 +372,8 @@ func NewJSContextFromRequest(req *http.Request, db database.DB) JSContext {
 
 	codyEnabled, _ := cody.IsCodyEnabled(ctx, db)
 
+	isDotComMode := dotcom.SourcegraphDotComMode()
+
 	// 🚨 SECURITY: This struct is sent to all users regardless of whether or
 	// not they are logged in, for example on an auth.public=false private
 	// server. Including secret fields here is OK if it is based on the user's
@@ -401,7 +403,7 @@ func NewJSContextFromRequest(req *http.Request, db database.DB) JSContext {
 		NeedServerRestart: globals.ConfigurationServerFrontendOnly.NeedServerRestart(),
 		DeployType:        deploy.Type(),
 
-		SourcegraphDotComMode: dotcom.SourcegraphDotComMode(),
+		SourcegraphDotComMode: isDotComMode,
 
 		BillingPublishableKey: BillingPublishableKey,
 
@@ -443,10 +445,11 @@ func NewJSContextFromRequest(req *http.Request, db database.DB) JSContext {
 
 		// This used to be hardcoded configuration on the frontend.
 		// https://sourcegraph.sourcegraph.com/github.com/sourcegraph/sourcegraph@ec5cc97a11c3f78743388b85b9ae0f1bc5d43932/-/blob/client/web/src/enterprise/EnterpriseWebApp.tsx?L63-71
-		CodeIntelligenceEnabled:  true,
-		SearchContextsEnabled:    true,
-		NotebooksEnabled:         true,
-		CodeMonitoringEnabled:    true,
+		CodeIntelligenceEnabled: true,
+		SearchContextsEnabled:   true,
+		NotebooksEnabled:        true,
+		// Code monitoring should be disabled on DotCom.
+		CodeMonitoringEnabled:    !isDotComMode,
 		SearchAggregationEnabled: true,
 		OwnEnabled:               true,
 


### PR DESCRIPTION
[Slack Context](https://sourcegraph.slack.com/archives/C07KZF47K/p1719302853433329)

We have code monitoring disabled on Dotcom, however in jscontext, it's not disabled, this PR fixes that.

## Test plan

Starting a Sourcegraph instance in Dotcom mode, should result in `window.context. codeMonitoringEnabled` set to `false`.


## Changelog

