### PR TITLE
chore(appliance): extract layout template

### DIFF
--- a/internal/appliance/BUILD.bazel
+++ b/internal/appliance/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
         "web/static/css/bootstrap.min.css",
         "web/static/css/custom.css",
         "web/static/script/bootstrap.bundle.min.js",
+        "web/template/layout.gohtml",
     ],
     importpath = "github.com/sourcegraph/sourcegraph/internal/appliance",
     visibility = ["//:__subpackages__"],

--- a/internal/appliance/web/template/layout.gohtml
+++ b/internal/appliance/web/template/layout.gohtml
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="icon" type="image/svg+xml" href="/static/img/favicon.png" />
+    <link rel="stylesheet" type="text/css" href="/static/css/bootstrap.min.css">
+    <link rel="stylesheet" type="text/css" href="/static/css/custom.css">
+    <script src="/static/script/htmx.min.js"></script>
+    <script src="/static/script/bootstrap.bundle.min.js"></script>
+    <title>{{ block "title" . }}{{ end }}</title>
+</head>
+
+<body hx-boost="true" class="container">
+{{ block "content" . }}{{ end }}
+</body>
+</html>

--- a/internal/appliance/web/template/setup.gohtml
+++ b/internal/appliance/web/template/setup.gohtml
@@ -1,17 +1,8 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="icon" type="image/svg+xml" href="/static/img/favicon.png" />
-    <link rel="stylesheet" type="text/css" href="/static/css/bootstrap.min.css">
-    <link rel="stylesheet" type="text/css" href="/static/css/custom.css">
-    <script src="/static/script/htmx.min.js"></script>
-    <script src="/static/script/bootstrap.bundle.min.js"></script>
-    <title>Sourcegraph Appliance - Setup</title>
-</head>
+{{ template "layout.gohtml" }}
 
-<body hx-boost="true" class="container">
+{{ define "title" }}Sourcegraph Appliance - Setup{{ end }}
+
+{{- define "content" }}
 <h1>Sourcegraph Appliance Setup</h1>
 
 <form action="/appliance/setup" method="post">
@@ -155,6 +146,4 @@
     </div>
     <button type="submit" class="btn btn-primary">Start Setup</button>
 </form>
-
-</body>
-</html>
+{{- end }}


### PR DESCRIPTION
To avoid duplication of common elements from page to page.

In preparation for introducing some more pages, it made sense to extract a layout.

Relates to https://linear.app/sourcegraph/issue/REL-20/maintenance-ui-admin-must-configure-initial-password-on-first-boot but does not close it.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles -->


Manual only - we don't have automated tests for the appliance UI, yet.

## Changelog

<!--
1. Ensure your pull request title is formatted as: $type($domain): $what
2. Add bullet list items for each additional detail you want to cover (see example below)
3. You can edit this after the pull request was merged, as long as release shipping it hasn't been promoted to the public.
4. For more information, please see this how-to https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c?

Audience: TS/CSE > Customers > Teammates (in that order).

Cheat sheet: $type = chore|fix|feat $domain: source|search|ci|release|plg|cody|local|...
-->

<!--
Example:

Title: fix(search): parse quotes with the appropriate context
Changelog section:

## Changelog

- When a quote is used with regexp pattern type, then ...
- Refactored underlying code.
-->
