### PR TITLE
chore(bazel): don't stamp yq rule for wolfi base images

### DIFF
--- a/wolfi-images/defs.bzl
+++ b/wolfi-images/defs.bzl
@@ -14,6 +14,7 @@ def wolfi_base(name = "wolfi", target = None):
             "//wolfi-images:sourcegraph-template.yaml",
         ],
         visibility = ["//visibility:private"],
+        stamp = 0,
     )
 
     apko_image(


### PR DESCRIPTION
While staring at execution logs locally I noticed that the stamp files stable-status.txt and volatile-status.txt were inputs to targets such as `//wolfi-images/sourcegraph-base:wolfi_config`, causing these `yq` targets to be executed every time `--stamp` changes or stable stamp vars change. I don't know how this interacts with BwoB. Will ask in the Bazel slack for clarification https://bazelbuild.slack.com/archives/CA31HN1T3/p1719324079626239


## Test plan

`bazel build` on an oci_image target works fine, confirmed by CI


## Changelog
