### PR TITLE
chore(bazel): add client/backstage-frontend to bazelignore

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -46,6 +46,7 @@ client/storybook/storybook-static
 client/plugin-backstage/node_modules
 client/app-shell/node_modules
 client/backstage-backend/node_modules
+client/backstage-frontend/node_modules
 client/cody/node_modules
 client/cody-agent/node_modules
 client/cody-cli/node_modules


### PR DESCRIPTION
Addresses the following error that was missed due to not happening to me locally, see original: https://github.com/sourcegraph/sourcegraph/pull/59638
```
ERROR: Traceback (most recent call last):
        File "/Users/will/code/sourcegraph/client/backstage-frontend/node_modules/@sourcegraph/build-config/BUILD.bazel", line 9, column 22, in <toplevel>
                npm_link_all_packages(name = "node_modules")
        File "/private/var/tmp/_bazel_will/dcc801c077cac507d08c05a871989466/external/npm/defs.bzl", line 3214, column 13, in npm_link_all_packages
                fail(msg)
Error in fail: The npm_link_all_packages() macro loaded from @npm//:defs.bzl and called in bazel package 'client/backstage-frontend/node_modules/@sourcegraph/build-config' may only be called in bazel packages that correspond to the pnpm root package or pnpm workspace projects. Projects are discovered from the pnpm-lock.yaml and may be missing if the lockfile is out of date. Root package: '', pnpm workspace projects: '', 'client/branded', 'client/browser', 'client/build-config', 'client/client-api', 'client/codeintellify', 'client/cody-shared', 'client/cody-ui', 'client/common', 'client/eslint-plugin-wildcard', 'client/extension-api', 'client/extension-api-types', 'client/http-client', 'client/jetbrains', 'client/observability-client', 'client/observability-server', 'client/shared', 'client/storybook', 'client/template-parser', 'client/testing', 'client/vscode', 'client/web', 'client/web-sveltekit', 'client/wildcard', 'schema'
```


## Test plan

@willdollman 

## Changelog

