### PR TITLE
Svelte: add debug view for code intel occurrences

### DIFF
--- a/client/web-sveltekit/src/lib/shared.ts
+++ b/client/web-sveltekit/src/lib/shared.ts
@@ -79,7 +79,7 @@ export { fetchStreamSuggestions } from '@sourcegraph/shared/src/search/suggestio
 export { QueryChangeSource, type QueryState } from '@sourcegraph/shared/src/search/helpers'
 export { migrateLocalStorageToTemporarySettings } from '@sourcegraph/shared/src/settings/temporary/migrateLocalStorageToTemporarySettings'
 export type { TemporarySettings } from '@sourcegraph/shared/src/settings/temporary/TemporarySettings'
-export { SyntaxKind } from '@sourcegraph/shared/src/codeintel/scip'
+export { SyntaxKind, Occurrence } from '@sourcegraph/shared/src/codeintel/scip'
 export { shortcutDisplayName } from '@sourcegraph/shared/src/keyboardShortcuts'
 export { createCodeIntelAPI, type CodeIntelAPI } from '@sourcegraph/shared/src/codeintel/api'
 export { getModeFromPath } from '@sourcegraph/shared/src/languages'

--- a/client/web-sveltekit/src/lib/web.ts
+++ b/client/web-sveltekit/src/lib/web.ts
@@ -9,6 +9,13 @@ export { syntaxHighlight } from '@sourcegraph/web/src/repo/blob/codemirror/highl
 export { linkify } from '@sourcegraph/web/src/repo/blob/codemirror/links'
 export { createCodeIntelExtension } from '@sourcegraph/web/src/repo/blob/codemirror/codeintel/extension'
 export type { TooltipViewOptions } from '@sourcegraph/web/src/repo/blob/codemirror/codeintel/api'
+export { debugOccurrences } from '@sourcegraph/web/src/repo/blob/codemirror/codeintel/debugOccurrences'
+export {
+    codeGraphData,
+    type CodeGraphData,
+    type IndexedCodeGraphData,
+} from '@sourcegraph/web/src/repo/blob/codemirror/codeintel/occurrences'
+
 export { positionToOffset, locationToURL } from '@sourcegraph/web/src/repo/blob/codemirror/utils'
 export { lockFirstVisibleLine } from '@sourcegraph/web/src/repo/blob/codemirror/lock-line'
 export { syncSelection } from '@sourcegraph/web/src/repo/blob/codemirror/codeintel/token-selection'

--- a/client/web-sveltekit/src/lib/wildcard/menu/MenuRadioGroup.svelte
+++ b/client/web-sveltekit/src/lib/wildcard/menu/MenuRadioGroup.svelte
@@ -1,7 +1,13 @@
 <script lang="ts">
+    import type { HTMLAttributes } from 'svelte/elements'
     import type { Writable } from 'svelte/store'
 
     import { getContext } from './DropdownMenu.svelte'
+
+    type $$Props = {
+        values: string[]
+        value: Writable<string>
+    } & HTMLAttributes<HTMLDivElement>
 
     export let values: string[]
     export let value: Writable<string>
@@ -14,20 +20,22 @@
     })
 </script>
 
-<div {...$radioGroup} use:radioGroup>
+<div {...$radioGroup} {...$$restProps} use:radioGroup>
     {#each values as value}
         {@const checked = $isChecked(value)}
-        <div class="item" {...$radioItem({ value })} use:radioItem>
-            <input type="radio" {value} {checked} />&nbsp
-            <slot {value} {checked}>
-                {value}
-            </slot>
+        <div {...$radioItem({ value })} use:radioItem>
+            <input type="radio" {checked} aria-hidden="true" /><!--
+            --><span>
+                <slot {value} {checked}>
+                    {value}
+                </slot>
+            </span>
         </div>
     {/each}
 </div>
 
 <style lang="scss">
     span {
-        float: right;
+        margin-left: 0.5rem;
     }
 </style>

--- a/client/web-sveltekit/src/lib/wildcard/menu/MenuRadioGroup.svelte
+++ b/client/web-sveltekit/src/lib/wildcard/menu/MenuRadioGroup.svelte
@@ -1,8 +1,6 @@
 <script lang="ts">
     import type { Writable } from 'svelte/store'
 
-    import Icon from '$lib/Icon.svelte'
-
     import { getContext } from './DropdownMenu.svelte'
 
     export let values: string[]
@@ -20,14 +18,10 @@
     {#each values as value}
         {@const checked = $isChecked(value)}
         <div class="item" {...$radioItem({ value })} use:radioItem>
+            <input type="radio" {value} {checked} />&nbsp
             <slot {value} {checked}>
                 {value}
             </slot>
-            {#if checked}
-                <span>
-                    <Icon icon={ILucideCheck} inline aria-hidden />
-                </span>
-            {/if}
         </div>
     {/each}
 </div>

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/FileView.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/FileView.svelte
@@ -24,7 +24,7 @@
     import OpenInEditor from '$lib/repo/open-in-editor/OpenInEditor.svelte'
     import Permalink from '$lib/repo/Permalink.svelte'
     import { createCodeIntelAPI, replaceRevisionInURL } from '$lib/shared'
-    import { isLightTheme, settings, user } from '$lib/stores'
+    import { isLightTheme, settings } from '$lib/stores'
     import { TELEMETRY_RECORDER } from '$lib/telemetry'
     import { createPromiseStore, formatBytes } from '$lib/utils'
     import { Alert, Badge, MenuButton, MenuLink } from '$lib/wildcard'
@@ -109,7 +109,9 @@
               })
             : null
 
-    $: codeGraphDataCommitHashes = $user?.siteAdmin ? codeGraphData?.map(datum => datum.commit.slice(0, 7)) : undefined
+    $: codeGraphDataCommitHashes = data.user?.siteAdmin
+        ? codeGraphData?.map(datum => datum.commit.slice(0, 7))
+        : undefined
     $: codeGraphDataDebugOptions = codeGraphDataCommitHashes ? ['None', ...codeGraphDataCommitHashes] : undefined
     const selectedCodeGraphDataDebugOption = writable<string>('None')
     $: selectedCodeGraphDataOccurrences = codeGraphData?.find(datum =>

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/FileView.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/FileView.svelte
@@ -199,9 +199,9 @@
             {#if codeGraphDataDebugOptions !== undefined}
                 <MenuSeparator />
                 {@const labelID = `label-${uuid.v4()}`}
-                <label for={labelID}>Code intelligence preview</label>
+                <h6 id={labelID}>Code intelligence preview</h6>
                 <MenuRadioGroup
-                    id={labelID}
+                    aria-labelledby={labelID}
                     values={codeGraphDataDebugOptions}
                     value={selectedCodeGraphDataDebugOption}
                 >
@@ -387,7 +387,7 @@
         margin-left: auto;
     }
 
-    label {
+    h6 {
         padding: var(--dropdown-item-padding);
         margin: 0;
         font-size: 0.75rem;

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/FileView.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/FileView.svelte
@@ -6,6 +6,7 @@
     import { capitalize } from 'lodash'
     import { from } from 'rxjs'
     import { writable } from 'svelte/store'
+    import * as uuid from 'uuid'
 
     import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
     import type { CodeGraphData } from '@sourcegraph/web/src/repo/blob/codemirror/codeintel/occurrences'
@@ -195,8 +196,13 @@
             </MenuButton>
             {#if codeGraphDataDebugOptions !== undefined}
                 <MenuSeparator />
-                <h6>Code intelligence preview</h6>
-                <MenuRadioGroup values={codeGraphDataDebugOptions} value={selectedCodeGraphDataDebugOption}>
+                {@const labelID = `label-${uuid.v4()}`}
+                <label for={labelID}>Code intelligence preview</label>
+                <MenuRadioGroup
+                    id={labelID}
+                    values={codeGraphDataDebugOptions}
+                    value={selectedCodeGraphDataDebugOption}
+                >
                     <svelte:fragment let:value>
                         {#if value === 'None'}
                             None
@@ -379,7 +385,7 @@
         margin-left: auto;
     }
 
-    h6 {
+    label {
         padding: var(--dropdown-item-padding);
         margin: 0;
         font-size: 0.75rem;

--- a/client/web/BUILD.bazel
+++ b/client/web/BUILD.bazel
@@ -1284,6 +1284,7 @@ ts_project(
         "src/repo/blob/codemirror/blame-decorations.ts",
         "src/repo/blob/codemirror/code-folding.tsx",
         "src/repo/blob/codemirror/codeintel/api.ts",
+        "src/repo/blob/codemirror/codeintel/debugOccurrences.ts",
         "src/repo/blob/codemirror/codeintel/decorations.ts",
         "src/repo/blob/codemirror/codeintel/definition.ts",
         "src/repo/blob/codemirror/codeintel/document-highlights.ts",

--- a/client/web/src/repo/blob/codemirror/codeintel/debugOccurrences.ts
+++ b/client/web/src/repo/blob/codemirror/codeintel/debugOccurrences.ts
@@ -1,0 +1,61 @@
+import { Facet, StateField, Transaction, countColumn } from '@codemirror/state'
+import { Decoration, DecorationSet, EditorView, WidgetType } from '@codemirror/view'
+
+import { Occurrence, SymbolRole } from '@sourcegraph/shared/src/codeintel/scip'
+
+class DebugOccurrencesWidget extends WidgetType {
+    constructor(private occurrence: Occurrence) {
+        super()
+    }
+
+    public toDOM(view: EditorView): HTMLElement {
+        const div = document.createElement('div')
+        div.style.color = 'grey'
+        // Calculate the visual offset of the range. This is not the same as start character
+        // because tabs take up multiple spaces visually.
+        const content = view.state.doc.line(this.occurrence.range.start.line + 1).text
+        const spaceCount = countColumn(
+            content,
+            view.state.tabSize,
+            Math.min(this.occurrence.range.start.character, content.length)
+        )
+        const spaces = ' '.repeat(spaceCount)
+        const arrows = '^'.repeat(this.occurrence.range.end.character - this.occurrence.range.start.character)
+        const type = (this.occurrence.symbolRoles ?? 0) & SymbolRole.Definition ? 'definition' : 'reference'
+        const symbolName = this.occurrence.symbol ?? ''
+        div.innerText = `${spaces}${arrows} ${type} ${symbolName}`
+        return div
+    }
+}
+
+export const debugOccurrencesDecorations = StateField.define<DecorationSet>({
+    create() {
+        return Decoration.none
+    },
+    update(oldDecorations: DecorationSet, tr: Transaction): DecorationSet {
+        const oldOccurrences = tr.startState.facet(debugOccurrences)
+        const newOccurrences = tr.state.facet(debugOccurrences)
+        if (Object.is(newOccurrences, oldOccurrences)) {
+            return oldDecorations
+        }
+        return Decoration.set(
+            newOccurrences.map(occ => {
+                // Place the block at the end of the line so it doesn't split the line
+                const rangeStart = tr.state.doc.line(occ.range.start.line + 1).to + 1
+                return Decoration.widget({
+                    widget: new DebugOccurrencesWidget(occ),
+                    block: true,
+                }).range(rangeStart, rangeStart)
+            }),
+            true // TODO(camdencheek): we can usually guarantee this is sorted, but I'd rather use a type for that
+        )
+    },
+    provide: f => EditorView.decorations.from(f),
+})
+
+export const debugOccurrences = Facet.define<Occurrence[], Occurrence[]>({
+    combine(input: readonly Occurrence[][]): Occurrence[] {
+        return input[0] ?? []
+    },
+    enables: () => debugOccurrencesDecorations,
+})


### PR DESCRIPTION
This implements the debug view for code intel ranges. Since we're doing work here, it's very useful to be able scan the info while exploratory testing and debugging.

Stacked on https://github.com/sourcegraph/sourcegraph/pull/63473

Note that this does _not_ use the snapshot API. After #63473, everything uses occurrences, so rather than rely on another API request, the only argument to the debug extension is a set of occurrences. This is particularly nice because it would be very easy to do things like:
- Show the occurrences as calculated from syntax highlighting data
- Show the occurrences before and after we make them non-overlapping

Fixes [an open issue that I cannot find]

## Test plan

https://github.com/sourcegraph/sourcegraph/assets/12631702/7a38af22-5361-47d1-a002-b538082f15aa


