### PR TITLE
Chore: fix repo stars alignment

### DIFF
--- a/client/web-sveltekit/src/lib/repo/RepoPopover/RepoPopover.svelte
+++ b/client/web-sveltekit/src/lib/repo/RepoPopover/RepoPopover.svelte
@@ -84,7 +84,7 @@
     {/if}
 
     <div class="footer">
-        <RepoStars repoStars={data.stars} small />
+        <RepoStars repoStars={data.stars} />
     </div>
 </div>
 
@@ -198,7 +198,7 @@
     .footer {
         display: flex;
         color: var(--text-muted);
-        align-items: center;
         justify-content: flex-end;
+        font-size: var(--font-size-tiny);
     }
 </style>

--- a/client/web-sveltekit/src/lib/repo/RepoStars.svelte
+++ b/client/web-sveltekit/src/lib/repo/RepoStars.svelte
@@ -3,14 +3,17 @@
     import Icon from '$lib/Icon.svelte'
 
     export let repoStars: number
-    export let small = false
 </script>
 
-<span>
+<div>
     <Icon inline icon={ILucideStar} aria-label="Repository stars" />
-    {#if small}
-        <small>&nbsp;{formatRepositoryStarCount(repoStars)}</small>
-    {:else}
-        &nbsp;{formatRepositoryStarCount(repoStars)}
-    {/if}
-</span>
+    {formatRepositoryStarCount(repoStars)}
+</div>
+
+<style lang="scss">
+    div {
+        display: flex;
+        align-items: center;
+        gap: 0.25em;
+    }
+</style>


### PR DESCRIPTION
This is the only one I know of that's left from SRCH-551, so saying this fixes SRCH-551.

# Test plan

Before:
![screenshot-2024-06-25_16-32-46@2x](https://github.com/sourcegraph/sourcegraph/assets/12631702/ce78fb11-57f2-4811-98e2-5f244906e442)

After:
![screenshot-2024-06-25_16-32-38@2x](https://github.com/sourcegraph/sourcegraph/assets/12631702/4421a78c-2758-41ed-8dbc-568d8e6565fd)
