### PR TITLE
omit go:embed of big assets from `sg start single-program-experimental-blame-sqs`

### DIFF
--- a/cmd/frontend/BUILD.bazel
+++ b/cmd/frontend/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
     importpath = "github.com/sourcegraph/sourcegraph/cmd/frontend",
     visibility = ["//visibility:private"],
     deps = [
+        "//client/web/dist",
         "//cmd/frontend/shared",
         "//internal/sanitycheck",
     ],

--- a/cmd/frontend/main.go
+++ b/cmd/frontend/main.go
@@ -4,6 +4,8 @@ package main
 import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/shared"
 	"github.com/sourcegraph/sourcegraph/internal/sanitycheck"
+
+	_ "github.com/sourcegraph/sourcegraph/client/web/dist" // use assets
 )
 
 func main() {

--- a/cmd/frontend/shared/BUILD.bazel
+++ b/cmd/frontend/shared/BUILD.bazel
@@ -10,7 +10,6 @@ go_library(
     importpath = "github.com/sourcegraph/sourcegraph/cmd/frontend/shared",
     visibility = ["//visibility:public"],
     deps = [
-        "//client/web/dist",
         "//cmd/frontend/enterprise",
         "//cmd/frontend/internal/auth",
         "//cmd/frontend/internal/authz",

--- a/cmd/frontend/shared/service.go
+++ b/cmd/frontend/shared/service.go
@@ -18,7 +18,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/tracer"
 	"github.com/sourcegraph/sourcegraph/ui/assets"
 
-	_ "github.com/sourcegraph/sourcegraph/client/web/dist" // use assets
 	_ "github.com/sourcegraph/sourcegraph/cmd/frontend/internal/registry"
 	_ "github.com/sourcegraph/sourcegraph/cmd/frontend/registry/api"
 )


### PR DESCRIPTION
This cuts building `./cmd/sourcegraph` from ~60s to ~6s when using `sg start single-program-experimental-blame-sqs` (which is dev only and never needs bundled assets).


## Test plan

n/a, dev experimental only