### PR TITLE
fix chopped-off tooltips in code monitor query input

### DIFF
--- a/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.module.scss
+++ b/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.module.scss
@@ -43,8 +43,8 @@
         height: calc(1rem + 0.5rem * 2 + 1px * 2); /* 1rem for text, 0.5rem vertical padding, 1px border */
         display: flex;
         align-items: center;
-        flex-grow: 1;
-        overflow: hidden;
+        flex-grow: 0;
+        min-width: 0;
 
         &:focus-within {
             border: 1px solid var(--input-focus-border-color);


### PR DESCRIPTION
The tooltips for autocomplete and diagnostics in the code monitor query editor were being chopped off due to an `overflow: hidden`. Now they show up.

Before (note the tiny vertical border that is part of the tooltip above the text):

<img width="402" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/1976/94523c8c-8e4b-4168-8675-8716b25d4b60">



After:
<img width="622" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/1976/9bc4c4f1-ec1c-4172-a4d2-1518bd0bde91">


## Test plan

Hover over a diagnostic at https://sourcegraph.test:3443/code-monitoring/new and confirm the tooltip shows.

## Changelog

- Fixed an issue when creating or editing a code monitor that obscured helpful tooltips in the query editor.