### PR TITLE
remove beta labels for code monitoring Slack notifs & logs

### DIFF
--- a/client/web/src/enterprise/code-monitoring/CodeMonitoringPage.tsx
+++ b/client/web/src/enterprise/code-monitoring/CodeMonitoringPage.tsx
@@ -1,8 +1,8 @@
-import React, { useMemo, useEffect, useState, useLayoutEffect, useCallback } from 'react'
+import React, { useCallback, useEffect, useLayoutEffect, useMemo, useState } from 'react'
 
 import { mdiPlus } from '@mdi/js'
 import classNames from 'classnames'
-import { type Location, useNavigate, useLocation, type NavigateFunction } from 'react-router-dom'
+import { useLocation, useNavigate, type Location, type NavigateFunction } from 'react-router-dom'
 import { of } from 'rxjs'
 import { catchError, map } from 'rxjs/operators'
 
@@ -11,24 +11,15 @@ import type { Settings } from '@sourcegraph/shared/src/schema/settings.schema'
 import type { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
 import type { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import { EVENT_LOGGER } from '@sourcegraph/shared/src/telemetry/web/eventLogger'
-import {
-    PageHeader,
-    LoadingSpinner,
-    useObservable,
-    Button,
-    Link,
-    ProductStatusBadge,
-    Icon,
-    ButtonLink,
-} from '@sourcegraph/wildcard'
+import { Button, ButtonLink, Icon, Link, LoadingSpinner, PageHeader, useObservable } from '@sourcegraph/wildcard'
 
 import type { AuthenticatedUser } from '../../auth'
 import { CodeMonitoringLogo } from '../../code-monitoring/CodeMonitoringLogo'
 import { PageTitle } from '../../components/PageTitle'
 
 import {
-    fetchUserCodeMonitors as _fetchUserCodeMonitors,
     fetchCodeMonitors as _fetchCodeMonitors,
+    fetchUserCodeMonitors as _fetchUserCodeMonitors,
     toggleCodeMonitorEnabled as _toggleCodeMonitorEnabled,
 } from './backend'
 import { CodeMonitoringGettingStarted } from './CodeMonitoringGettingStarted'
@@ -205,10 +196,7 @@ export const CodeMonitoringPage: React.FunctionComponent<React.PropsWithChildren
                                         }}
                                         className={classNames('nav-link', isActive && 'active')}
                                     >
-                                        <span>
-                                            {title}
-                                            {tab === 'logs' && <ProductStatusBadge status="beta" className="ml-2" />}
-                                        </span>
+                                        <span>{title}</span>
                                     </ButtonLink>
                                 </div>
                             ))}

--- a/client/web/src/enterprise/code-monitoring/components/__snapshots__/FormActionArea.test.tsx.snap
+++ b/client/web/src/enterprise/code-monitoring/components/__snapshots__/FormActionArea.test.tsx.snap
@@ -177,20 +177,7 @@ exports[`FormActionArea > Error is shown if code monitor has empty description 1
           class="font-weight-bold cardLink"
         >
           <div>
-            Send Slack message to channel 
-            <span
-              style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
-            >
-              This feature is currently in beta
-            </span>
-            <span
-              aria-hidden="true"
-              class="badge info productStatusBadge ml-1 mb-1"
-              status="beta"
-            >
-              beta
-            </span>
-             
+            Send Slack message to channel
           </div>
         </div>
         <span

--- a/client/web/src/enterprise/code-monitoring/components/actions/SlackWebhookAction.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/actions/SlackWebhookAction.tsx
@@ -3,7 +3,7 @@ import React, { useCallback, useMemo, useState } from 'react'
 import { gql, useMutation } from '@apollo/client'
 import { noop } from 'lodash'
 
-import { Alert, Input, Link, ProductStatusBadge, Label } from '@sourcegraph/wildcard'
+import { Alert, Input, Label, Link } from '@sourcegraph/wildcard'
 
 import type { SendTestSlackWebhookResult, SendTestSlackWebhookVariables } from '../../../../graphql-operations'
 import type { ActionProps } from '../FormActionArea'
@@ -101,11 +101,7 @@ export const SlackWebhookAction: React.FunctionComponent<React.PropsWithChildren
 
     return (
         <ActionEditor
-            title={
-                <div>
-                    Send Slack message to channel <ProductStatusBadge className="ml-1 mb-1" status="beta" />{' '}
-                </div>
-            }
+            title={<div>Send Slack message to channel</div>}
             subtitle="Post to a specified Slack channel. Requires webhook configuration."
             idName="slack-webhook"
             disabled={disabled}


### PR DESCRIPTION
These features have passed the steps needed to take them out of beta. They have been feature-complete and in widespread use for more than a year with no outstanding issues, and they work well.

- https://linear.app/sourcegraph/project/slack-notifications-ga-code-monitoring-7dbb9fa13f62
- https://linear.app/sourcegraph/issue/SRCH-533/remove-beta-label-from-code-monitor-logs-tab

Closes https://linear.app/sourcegraph/issue/SRCH-533/remove-beta-label-from-code-monitor-logs-tab



## Test plan

Create a new code monitor with a Slack notif. Ensure it works e2e by pushing a commit that matches and watching it show up in Slack (https://sourcegraph.slack.com/archives/C68386Z5Z/p1719357942294309).


## Changelog

- Code monitoring Slack notifications, previously in beta, are now GA. This feature lets you post matching code changes to a Slack channel.
- Code monitoring logs, previously in beta, are now GA. This feature lets you see the status of and activity related to code monitors to troubleshoot issues with finding results and performing configured actions.