### PR TITLE
feat/dotcom: show subscription UUID in Enterprise Portal format

### DIFF
--- a/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminProductSubscriptionNode.tsx
+++ b/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminProductSubscriptionNode.tsx
@@ -8,6 +8,8 @@ import { AccountName } from '../../../dotcom/productSubscriptions/AccountName'
 import { ProductSubscriptionLabel } from '../../../dotcom/productSubscriptions/ProductSubscriptionLabel'
 import { ProductLicenseTags } from '../../../productSubscription/ProductLicenseTags'
 
+import { enterprisePortalID } from './utils'
+
 export const SiteAdminProductSubscriptionNodeHeader: React.FunctionComponent<React.PropsWithChildren<unknown>> = () => (
     <thead>
         <tr>
@@ -31,9 +33,9 @@ export const SiteAdminProductSubscriptionNode: React.FunctionComponent<
     React.PropsWithChildren<SiteAdminProductSubscriptionNodeProps>
 > = ({ node }) => (
     <tr>
-        <td className="text-nowrap">
+        <td>
             <LinkOrSpan to={node.urlForSiteAdmin} className="mr-3">
-                {node.name}
+                {enterprisePortalID(node.uuid)}
             </LinkOrSpan>
         </td>
         <td className="w-100">

--- a/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminProductSubscriptionPage.tsx
+++ b/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminProductSubscriptionPage.tsx
@@ -38,7 +38,7 @@ import {
 import { CodyServicesSection } from './CodyServicesSection'
 import { SiteAdminGenerateProductLicenseForSubscriptionForm } from './SiteAdminGenerateProductLicenseForSubscriptionForm'
 import { SiteAdminProductLicenseNode } from './SiteAdminProductLicenseNode'
-import { accessTokenPath, errorForPath } from './utils'
+import { accessTokenPath, errorForPath, enterprisePortalID } from './utils'
 
 interface Props extends TelemetryV2Props {}
 
@@ -130,7 +130,7 @@ export const SiteAdminProductSubscriptionPage: React.FunctionComponent<React.Pro
                     headingElement="h2"
                     path={[
                         { text: 'Enterprise subscriptions', to: '/site-admin/dotcom/product/subscriptions' },
-                        { text: productSubscription.name },
+                        { text: enterprisePortalID(subscriptionUUID) },
                     ]}
                     description={
                         <span className="text-muted">
@@ -152,7 +152,7 @@ export const SiteAdminProductSubscriptionPage: React.FunctionComponent<React.Pro
                         <tbody>
                             <tr>
                                 <th className="text-nowrap">ID</th>
-                                <td className="w-100">{productSubscription.name}</td>
+                                <td className="w-100">{enterprisePortalID(subscriptionUUID)}</td>
                             </tr>
                             <tr>
                                 <th className="text-nowrap">Current Plan</th>

--- a/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/utils.ts
+++ b/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/utils.ts
@@ -42,3 +42,11 @@ export function errorForPath(error: ApolloError | undefined, path: (string | num
 export const accessTokenPath = ['dotcom', 'productSubscription', 'currentSourcegraphAccessToken']
 
 export const numberFormatter = new Intl.NumberFormat()
+
+/**
+ * Prefixes the ID with subscriptionsv1.EnterpriseSubscriptionIDPrefix to get
+ * the Enterprise Portal external subscription UUID format.
+ */
+export function enterprisePortalID(id: string): string {
+    return `es_${id}`
+}


### PR DESCRIPTION
The current "name" thing is not used anywhere for subscriptions - all internal capabilities and APIs depend use the UUID, and Enterprise Portal will use the UUID as well.

This change replaces all name/IDs with the UUID, prefixed in Enterprise Portal format, as we prepare to launch Enterprise Portal in more places (such as Cody Analytics: https://linear.app/sourcegraph/issue/CORE-101). This is particularly relevant for Cody Analytics so I can document how to find the UUID in a way that isn't "get it from the URL".

It's not super beautiful in the subscriptions list, but as we progress on the migration to Enterprise Portal I plan to replace the ID in the list with "Display name", which is a first-class citizen in Enterprise Portal.

## Test plan

<img width="953" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/23356519/30c4ae6b-e50b-485c-a2c8-e4ab6445fc01">

![image](https://github.com/sourcegraph/sourcegraph/assets/23356519/cca8e6d1-2e20-4954-8f72-7694ad1d8bfa)
