### PR TITLE
cloud: add feature flags to show no edit warning

### DIFF
--- a/client/web/src/featureFlags/featureFlags.ts
+++ b/client/web/src/featureFlags/featureFlags.ts
@@ -28,6 +28,7 @@ export const FEATURE_FLAGS = [
     'search-debug',
     'signup-survey-enabled',
     'sourcegraph-operator-site-admin-hide-maintenance',
+    'sourcegraph-cloud-managed-feature-flags-warning-shown',
     'ab-shortened-install-first-signup-flow-cody-2024-04',
 ] as const
 

--- a/client/web/src/site-admin/SiteAdminFeatureFlagsPage.tsx
+++ b/client/web/src/site-admin/SiteAdminFeatureFlagsPage.tsx
@@ -9,10 +9,11 @@ import { asError, type ErrorLike, isErrorLike, pluralize } from '@sourcegraph/co
 import { aggregateStreamingSearch, type ContentMatch, LATEST_VERSION } from '@sourcegraph/shared/src/search/stream'
 import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
-import { Link, PageHeader, Container, Code, H3, Text, Icon, Tooltip, ButtonLink } from '@sourcegraph/wildcard'
+import { Link, PageHeader, Container, Code, H3, Text, Icon, Tooltip, ButtonLink, Alert } from '@sourcegraph/wildcard'
 
 import { FilteredConnection, type FilteredConnectionFilter } from '../components/FilteredConnection'
 import { PageTitle } from '../components/PageTitle'
+import { useFeatureFlag } from '../featureFlags/useFeatureFlag'
 import { type FeatureFlagFields, SearchPatternType } from '../graphql-operations'
 
 import { fetchFeatureFlags as defaultFetchFeatureFlags } from './backend'
@@ -189,6 +190,10 @@ export const SiteAdminFeatureFlagsPage: React.FunctionComponent<
         [featureFlagsOrErrorsObservable]
     )
 
+    const [isSourcegraphCloudManagedFeatureFlagsWarningShown] = useFeatureFlag(
+        'sourcegraph-cloud-managed-feature-flags-warning-shown'
+    )
+
     useEffect(() => telemetryRecorder.recordEvent('admin.featureFlags', 'view'), [telemetryRecorder])
 
     return (
@@ -216,6 +221,13 @@ export const SiteAdminFeatureFlagsPage: React.FunctionComponent<
                     </ButtonLink>
                 }
             />
+
+            {isSourcegraphCloudManagedFeatureFlagsWarningShown && (
+                <Alert variant="warning">
+                    Feature flag settings are managed by Sourcegraph and will be overridden by updates. Contact support
+                    for help.
+                </Alert>
+            )}
 
             <Container>
                 <FilteredConnection<FeatureFlagAndReferences, {}>


### PR DESCRIPTION
ref CLO-380

on Cloud, customer changes to feature flags are overridden by our automation. let's add a warning message to avoid suprises.

## Test plan

![CleanShot 2024-06-25 at 19 56 04](https://github.com/sourcegraph/sourcegraph/assets/8373004/ebe18608-929d-4d92-92e9-188b6637371c)

