### PR TITLE
fix: Check (uploadID, path) pairs in bulk

### DIFF
--- a/internal/codeintel/codenav/BUILD.bazel
+++ b/internal/codeintel/codenav/BUILD.bazel
@@ -45,6 +45,7 @@ go_library(
         "//lib/codeintel/precise",
         "//lib/errors",
         "@com_github_dgraph_io_ristretto//:ristretto",
+        "@com_github_life4_genesis//slices",
         "@com_github_sourcegraph_go_diff//diff",
         "@com_github_sourcegraph_log//:log",
         "@com_github_sourcegraph_scip//bindings/go/scip",

--- a/internal/codeintel/codenav/internal/lsifstore/BUILD.bazel
+++ b/internal/codeintel/codenav/internal/lsifstore/BUILD.bazel
@@ -43,6 +43,7 @@ go_test(
     srcs = [
         "document_metadata_test.go",
         "locations_by_position_test.go",
+        "lsifstore_documents_test.go",
         "metadata_by_position_test.go",
         "symbols_by_position_test.go",
     ],
@@ -63,5 +64,6 @@ go_test(
         "@com_github_google_go_cmp//cmp",
         "@com_github_sourcegraph_log//logtest",
         "@com_github_sourcegraph_scip//bindings/go/scip",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/internal/codeintel/codenav/internal/lsifstore/document_metadata.go
+++ b/internal/codeintel/codenav/internal/lsifstore/document_metadata.go
@@ -10,35 +10,8 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/codenav/shared"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/core"
-	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 )
-
-// GetPathExists determines if the path exists in the database.
-func (s *store) GetPathExists(ctx context.Context, bundleID int, path core.UploadRelPath) (_ bool, err error) {
-	ctx, _, endObservation := s.operations.getPathExists.With(ctx, &err, observation.Args{Attrs: []attribute.KeyValue{
-		attribute.Int("bundleID", bundleID),
-		attribute.String("path", path.RawValue()),
-	}})
-	defer endObservation(1, observation.Args{})
-
-	exists, _, err := basestore.ScanFirstBool(s.db.Query(ctx, sqlf.Sprintf(
-		existsQuery,
-		bundleID,
-		path.RawValue(),
-	)))
-	return exists, err
-}
-
-const existsQuery = `
-SELECT EXISTS (
-	SELECT 1
-	FROM codeintel_scip_document_lookup sid
-	WHERE
-		sid.upload_id = %s AND
-		sid.document_path = %s
-)
-`
 
 // Stencil returns all ranges within a single document.
 func (s *store) GetStencil(ctx context.Context, bundleID int, path core.UploadRelPath) (_ []shared.Range, err error) {

--- a/internal/codeintel/codenav/internal/lsifstore/document_metadata_test.go
+++ b/internal/codeintel/codenav/internal/lsifstore/document_metadata_test.go
@@ -12,30 +12,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/core"
 )
 
-func TestDatabaseExists(t *testing.T) {
-	store := populateTestStore(t)
-
-	testCases := []struct {
-		uploadID int
-		path     string
-		expected bool
-	}{
-		// SCIP
-		{testSCIPUploadID, "template/src/lsif/api.ts", true},
-		{testSCIPUploadID, "template/src/lsif/util.ts", true},
-		{testSCIPUploadID, "missing.ts", false},
-	}
-
-	for _, testCase := range testCases {
-		if exists, err := store.GetPathExists(context.Background(), testCase.uploadID,
-			core.NewUploadRelPathUnchecked(testCase.path)); err != nil {
-			t.Fatalf("unexpected error %s", err)
-		} else if exists != testCase.expected {
-			t.Errorf("unexpected exists result for %s. want=%v have=%v", testCase.path, testCase.expected, exists)
-		}
-	}
-}
-
 func TestStencil(t *testing.T) {
 	testCases := []struct {
 		name           string

--- a/internal/codeintel/codenav/internal/lsifstore/lsifstore_documents.go
+++ b/internal/codeintel/codenav/internal/lsifstore/lsifstore_documents.go
@@ -63,12 +63,12 @@ func (s *store) FindDocumentIDs(ctx context.Context, uploadIDToLookupPath map[in
 		return nil, nil
 	}
 
-	queries := []*sqlf.Query{}
+	searchTuples := []*sqlf.Query{}
 	for uploadID, path := range uploadIDToLookupPath {
-		queries = append(queries, sqlf.Sprintf("(%d, %s)", uploadID, path.RawValue()))
+		searchTuples = append(searchTuples, sqlf.Sprintf("(%d, %s)", uploadID, path.RawValue()))
 	}
 
-	finalQuery := sqlf.Sprintf(findDocumentIDsQuery, sqlf.Join(queries, ","))
+	finalQuery := sqlf.Sprintf(findDocumentIDsQuery, sqlf.Join(searchTuples, ","))
 	type idPair struct {
 		uploadID   int32
 		documentID int64

--- a/internal/codeintel/codenav/internal/lsifstore/lsifstore_documents_test.go
+++ b/internal/codeintel/codenav/internal/lsifstore/lsifstore_documents_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestDatabaseFindDocumentIDs(t *testing.T) {
 	store := populateTestStore(t)
-	const nonExistentUploadID = math.MaxInt
+	const nonExistentUploadID = math.MaxInt32
 
 	testCases := []struct {
 		uploadID int

--- a/internal/codeintel/codenav/internal/lsifstore/lsifstore_documents_test.go
+++ b/internal/codeintel/codenav/internal/lsifstore/lsifstore_documents_test.go
@@ -1,0 +1,38 @@
+package lsifstore
+
+import (
+	"context"
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/sourcegraph/sourcegraph/internal/codeintel/core"
+)
+
+func TestDatabaseFindDocumentIDs(t *testing.T) {
+	store := populateTestStore(t)
+	const nonExistentUploadID = math.MaxInt
+
+	testCases := []struct {
+		uploadID int
+		path     string
+		expected bool
+	}{
+		// SCIP
+		{testSCIPUploadID, "template/src/lsif/api.ts", true},
+		{testSCIPUploadID, "template/src/lsif/util.ts", true},
+		{testSCIPUploadID, "missing.ts", false},
+		{nonExistentUploadID, "template/src/lsif/util.ts", false},
+	}
+
+	for _, tc := range testCases {
+		// TODO: Ideally, we would do some bulk tests here, but somewhat blocked on:
+		// https://linear.app/sourcegraph/issue/GRAPH-707/make-lsifstore-tests-more-easily-customizable
+		input := map[int]core.UploadRelPath{tc.uploadID: core.NewUploadRelPathUnchecked(tc.path)}
+		docIDsMap, err := store.FindDocumentIDs(context.Background(), input)
+		require.NoError(t, err)
+		_, found := docIDsMap[tc.uploadID]
+		require.Equalf(t, tc.expected, found, "path: %v", tc.path)
+	}
+}

--- a/internal/codeintel/codenav/internal/lsifstore/lsifstore_documents_test.go
+++ b/internal/codeintel/codenav/internal/lsifstore/lsifstore_documents_test.go
@@ -19,7 +19,6 @@ func TestDatabaseFindDocumentIDs(t *testing.T) {
 		path     string
 		expected bool
 	}{
-		// SCIP
 		{testSCIPUploadID, "template/src/lsif/api.ts", true},
 		{testSCIPUploadID, "template/src/lsif/util.ts", true},
 		{testSCIPUploadID, "missing.ts", false},

--- a/internal/codeintel/codenav/internal/lsifstore/observability.go
+++ b/internal/codeintel/codenav/internal/lsifstore/observability.go
@@ -21,6 +21,7 @@ type operations struct {
 	getHover                   *observation.Operation
 	getDiagnostics             *observation.Operation
 	scipDocument               *observation.Operation
+	findDocumentIDs            *observation.Operation
 }
 
 var m = new(metrics.SingletonREDMetrics)
@@ -57,5 +58,6 @@ func newOperations(observationCtx *observation.Context) *operations {
 		getHover:                   op("GetHover"),
 		getDiagnostics:             op("GetDiagnostics"),
 		scipDocument:               op("SCIPDocument"),
+		findDocumentIDs:            op("FindDocumentIDs"),
 	}
 }

--- a/internal/codeintel/codenav/internal/lsifstore/store.go
+++ b/internal/codeintel/codenav/internal/lsifstore/store.go
@@ -14,8 +14,14 @@ import (
 )
 
 type LsifStore interface {
+	// Multi-upload data
+
+	// FindDocumentIDs checks one path per upload, and returns the document IDs
+	// for those paths. If needed, we could generalize this to allow multiple paths
+	// per uploadID.
+	FindDocumentIDs(ctx context.Context, uploadIDToLookupPath map[int]core.UploadRelPath) (uploadIDToDocumentID map[int]int, _ error)
+
 	// Whole-document data
-	GetPathExists(ctx context.Context, bundleID int, path core.UploadRelPath) (bool, error)
 	GetStencil(ctx context.Context, bundleID int, path core.UploadRelPath) ([]shared.Range, error)
 	GetRanges(ctx context.Context, bundleID int, path core.UploadRelPath, startLine, endLine int) ([]shared.CodeIntelligenceRange, error)
 	SCIPDocument(ctx context.Context, uploadID int, path core.UploadRelPath) (_ *scip.Document, err error)

--- a/internal/codeintel/codenav/mocks_test.go
+++ b/internal/codeintel/codenav/mocks_test.go
@@ -39,6 +39,9 @@ type MockLsifStore struct {
 	// function object controlling the behavior of the method
 	// ExtractReferenceLocationsFromPosition.
 	ExtractReferenceLocationsFromPositionFunc *LsifStoreExtractReferenceLocationsFromPositionFunc
+	// FindDocumentIDsFunc is an instance of a mock function object
+	// controlling the behavior of the method FindDocumentIDs.
+	FindDocumentIDsFunc *LsifStoreFindDocumentIDsFunc
 	// GetBulkMonikerLocationsFunc is an instance of a mock function object
 	// controlling the behavior of the method GetBulkMonikerLocations.
 	GetBulkMonikerLocationsFunc *LsifStoreGetBulkMonikerLocationsFunc
@@ -58,9 +61,6 @@ type MockLsifStore struct {
 	// GetPackageInformationFunc is an instance of a mock function object
 	// controlling the behavior of the method GetPackageInformation.
 	GetPackageInformationFunc *LsifStoreGetPackageInformationFunc
-	// GetPathExistsFunc is an instance of a mock function object
-	// controlling the behavior of the method GetPathExists.
-	GetPathExistsFunc *LsifStoreGetPathExistsFunc
 	// GetRangesFunc is an instance of a mock function object controlling
 	// the behavior of the method GetRanges.
 	GetRangesFunc *LsifStoreGetRangesFunc
@@ -96,6 +96,11 @@ func NewMockLsifStore() *MockLsifStore {
 				return
 			},
 		},
+		FindDocumentIDsFunc: &LsifStoreFindDocumentIDsFunc{
+			defaultHook: func(context.Context, map[int]core.UploadRelPath) (r0 map[int]int, r1 error) {
+				return
+			},
+		},
 		GetBulkMonikerLocationsFunc: &LsifStoreGetBulkMonikerLocationsFunc{
 			defaultHook: func(context.Context, string, []int, []precise.MonikerData, int, int) (r0 []shared.Location, r1 int, r2 error) {
 				return
@@ -123,11 +128,6 @@ func NewMockLsifStore() *MockLsifStore {
 		},
 		GetPackageInformationFunc: &LsifStoreGetPackageInformationFunc{
 			defaultHook: func(context.Context, int, string) (r0 precise.PackageInformationData, r1 bool, r2 error) {
-				return
-			},
-		},
-		GetPathExistsFunc: &LsifStoreGetPathExistsFunc{
-			defaultHook: func(context.Context, int, core.UploadRelPath) (r0 bool, r1 error) {
 				return
 			},
 		},
@@ -173,6 +173,11 @@ func NewStrictMockLsifStore() *MockLsifStore {
 				panic("unexpected invocation of MockLsifStore.ExtractReferenceLocationsFromPosition")
 			},
 		},
+		FindDocumentIDsFunc: &LsifStoreFindDocumentIDsFunc{
+			defaultHook: func(context.Context, map[int]core.UploadRelPath) (map[int]int, error) {
+				panic("unexpected invocation of MockLsifStore.FindDocumentIDs")
+			},
+		},
 		GetBulkMonikerLocationsFunc: &LsifStoreGetBulkMonikerLocationsFunc{
 			defaultHook: func(context.Context, string, []int, []precise.MonikerData, int, int) ([]shared.Location, int, error) {
 				panic("unexpected invocation of MockLsifStore.GetBulkMonikerLocations")
@@ -201,11 +206,6 @@ func NewStrictMockLsifStore() *MockLsifStore {
 		GetPackageInformationFunc: &LsifStoreGetPackageInformationFunc{
 			defaultHook: func(context.Context, int, string) (precise.PackageInformationData, bool, error) {
 				panic("unexpected invocation of MockLsifStore.GetPackageInformation")
-			},
-		},
-		GetPathExistsFunc: &LsifStoreGetPathExistsFunc{
-			defaultHook: func(context.Context, int, core.UploadRelPath) (bool, error) {
-				panic("unexpected invocation of MockLsifStore.GetPathExists")
 			},
 		},
 		GetRangesFunc: &LsifStoreGetRangesFunc{
@@ -242,6 +242,9 @@ func NewMockLsifStoreFrom(i lsifstore.LsifStore) *MockLsifStore {
 		ExtractReferenceLocationsFromPositionFunc: &LsifStoreExtractReferenceLocationsFromPositionFunc{
 			defaultHook: i.ExtractReferenceLocationsFromPosition,
 		},
+		FindDocumentIDsFunc: &LsifStoreFindDocumentIDsFunc{
+			defaultHook: i.FindDocumentIDs,
+		},
 		GetBulkMonikerLocationsFunc: &LsifStoreGetBulkMonikerLocationsFunc{
 			defaultHook: i.GetBulkMonikerLocations,
 		},
@@ -259,9 +262,6 @@ func NewMockLsifStoreFrom(i lsifstore.LsifStore) *MockLsifStore {
 		},
 		GetPackageInformationFunc: &LsifStoreGetPackageInformationFunc{
 			defaultHook: i.GetPackageInformation,
-		},
-		GetPathExistsFunc: &LsifStoreGetPathExistsFunc{
-			defaultHook: i.GetPathExists,
 		},
 		GetRangesFunc: &LsifStoreGetRangesFunc{
 			defaultHook: i.GetRanges,
@@ -738,6 +738,114 @@ func (c LsifStoreExtractReferenceLocationsFromPositionFuncCall) Args() []interfa
 // invocation.
 func (c LsifStoreExtractReferenceLocationsFromPositionFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1, c.Result2}
+}
+
+// LsifStoreFindDocumentIDsFunc describes the behavior when the
+// FindDocumentIDs method of the parent MockLsifStore instance is invoked.
+type LsifStoreFindDocumentIDsFunc struct {
+	defaultHook func(context.Context, map[int]core.UploadRelPath) (map[int]int, error)
+	hooks       []func(context.Context, map[int]core.UploadRelPath) (map[int]int, error)
+	history     []LsifStoreFindDocumentIDsFuncCall
+	mutex       sync.Mutex
+}
+
+// FindDocumentIDs delegates to the next hook function in the queue and
+// stores the parameter and result values of this invocation.
+func (m *MockLsifStore) FindDocumentIDs(v0 context.Context, v1 map[int]core.UploadRelPath) (map[int]int, error) {
+	r0, r1 := m.FindDocumentIDsFunc.nextHook()(v0, v1)
+	m.FindDocumentIDsFunc.appendCall(LsifStoreFindDocumentIDsFuncCall{v0, v1, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the FindDocumentIDs
+// method of the parent MockLsifStore instance is invoked and the hook queue
+// is empty.
+func (f *LsifStoreFindDocumentIDsFunc) SetDefaultHook(hook func(context.Context, map[int]core.UploadRelPath) (map[int]int, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// FindDocumentIDs method of the parent MockLsifStore instance invokes the
+// hook at the front of the queue and discards it. After the queue is empty,
+// the default hook function is invoked for any future action.
+func (f *LsifStoreFindDocumentIDsFunc) PushHook(hook func(context.Context, map[int]core.UploadRelPath) (map[int]int, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *LsifStoreFindDocumentIDsFunc) SetDefaultReturn(r0 map[int]int, r1 error) {
+	f.SetDefaultHook(func(context.Context, map[int]core.UploadRelPath) (map[int]int, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *LsifStoreFindDocumentIDsFunc) PushReturn(r0 map[int]int, r1 error) {
+	f.PushHook(func(context.Context, map[int]core.UploadRelPath) (map[int]int, error) {
+		return r0, r1
+	})
+}
+
+func (f *LsifStoreFindDocumentIDsFunc) nextHook() func(context.Context, map[int]core.UploadRelPath) (map[int]int, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *LsifStoreFindDocumentIDsFunc) appendCall(r0 LsifStoreFindDocumentIDsFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of LsifStoreFindDocumentIDsFuncCall objects
+// describing the invocations of this function.
+func (f *LsifStoreFindDocumentIDsFunc) History() []LsifStoreFindDocumentIDsFuncCall {
+	f.mutex.Lock()
+	history := make([]LsifStoreFindDocumentIDsFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// LsifStoreFindDocumentIDsFuncCall is an object that describes an
+// invocation of method FindDocumentIDs on an instance of MockLsifStore.
+type LsifStoreFindDocumentIDsFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 map[int]core.UploadRelPath
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 map[int]int
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c LsifStoreFindDocumentIDsFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c LsifStoreFindDocumentIDsFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
 }
 
 // LsifStoreGetBulkMonikerLocationsFunc describes the behavior when the
@@ -1471,117 +1579,6 @@ func (c LsifStoreGetPackageInformationFuncCall) Args() []interface{} {
 // invocation.
 func (c LsifStoreGetPackageInformationFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1, c.Result2}
-}
-
-// LsifStoreGetPathExistsFunc describes the behavior when the GetPathExists
-// method of the parent MockLsifStore instance is invoked.
-type LsifStoreGetPathExistsFunc struct {
-	defaultHook func(context.Context, int, core.UploadRelPath) (bool, error)
-	hooks       []func(context.Context, int, core.UploadRelPath) (bool, error)
-	history     []LsifStoreGetPathExistsFuncCall
-	mutex       sync.Mutex
-}
-
-// GetPathExists delegates to the next hook function in the queue and stores
-// the parameter and result values of this invocation.
-func (m *MockLsifStore) GetPathExists(v0 context.Context, v1 int, v2 core.UploadRelPath) (bool, error) {
-	r0, r1 := m.GetPathExistsFunc.nextHook()(v0, v1, v2)
-	m.GetPathExistsFunc.appendCall(LsifStoreGetPathExistsFuncCall{v0, v1, v2, r0, r1})
-	return r0, r1
-}
-
-// SetDefaultHook sets function that is called when the GetPathExists method
-// of the parent MockLsifStore instance is invoked and the hook queue is
-// empty.
-func (f *LsifStoreGetPathExistsFunc) SetDefaultHook(hook func(context.Context, int, core.UploadRelPath) (bool, error)) {
-	f.defaultHook = hook
-}
-
-// PushHook adds a function to the end of hook queue. Each invocation of the
-// GetPathExists method of the parent MockLsifStore instance invokes the
-// hook at the front of the queue and discards it. After the queue is empty,
-// the default hook function is invoked for any future action.
-func (f *LsifStoreGetPathExistsFunc) PushHook(hook func(context.Context, int, core.UploadRelPath) (bool, error)) {
-	f.mutex.Lock()
-	f.hooks = append(f.hooks, hook)
-	f.mutex.Unlock()
-}
-
-// SetDefaultReturn calls SetDefaultHook with a function that returns the
-// given values.
-func (f *LsifStoreGetPathExistsFunc) SetDefaultReturn(r0 bool, r1 error) {
-	f.SetDefaultHook(func(context.Context, int, core.UploadRelPath) (bool, error) {
-		return r0, r1
-	})
-}
-
-// PushReturn calls PushHook with a function that returns the given values.
-func (f *LsifStoreGetPathExistsFunc) PushReturn(r0 bool, r1 error) {
-	f.PushHook(func(context.Context, int, core.UploadRelPath) (bool, error) {
-		return r0, r1
-	})
-}
-
-func (f *LsifStoreGetPathExistsFunc) nextHook() func(context.Context, int, core.UploadRelPath) (bool, error) {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-
-	if len(f.hooks) == 0 {
-		return f.defaultHook
-	}
-
-	hook := f.hooks[0]
-	f.hooks = f.hooks[1:]
-	return hook
-}
-
-func (f *LsifStoreGetPathExistsFunc) appendCall(r0 LsifStoreGetPathExistsFuncCall) {
-	f.mutex.Lock()
-	f.history = append(f.history, r0)
-	f.mutex.Unlock()
-}
-
-// History returns a sequence of LsifStoreGetPathExistsFuncCall objects
-// describing the invocations of this function.
-func (f *LsifStoreGetPathExistsFunc) History() []LsifStoreGetPathExistsFuncCall {
-	f.mutex.Lock()
-	history := make([]LsifStoreGetPathExistsFuncCall, len(f.history))
-	copy(history, f.history)
-	f.mutex.Unlock()
-
-	return history
-}
-
-// LsifStoreGetPathExistsFuncCall is an object that describes an invocation
-// of method GetPathExists on an instance of MockLsifStore.
-type LsifStoreGetPathExistsFuncCall struct {
-	// Arg0 is the value of the 1st argument passed to this method
-	// invocation.
-	Arg0 context.Context
-	// Arg1 is the value of the 2nd argument passed to this method
-	// invocation.
-	Arg1 int
-	// Arg2 is the value of the 3rd argument passed to this method
-	// invocation.
-	Arg2 core.UploadRelPath
-	// Result0 is the value of the 1st result returned from this method
-	// invocation.
-	Result0 bool
-	// Result1 is the value of the 2nd result returned from this method
-	// invocation.
-	Result1 error
-}
-
-// Args returns an interface slice containing the arguments of this
-// invocation.
-func (c LsifStoreGetPathExistsFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
-}
-
-// Results returns an interface slice containing the results of this
-// invocation.
-func (c LsifStoreGetPathExistsFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
 }
 
 // LsifStoreGetRangesFunc describes the behavior when the GetRanges method

--- a/internal/codeintel/codenav/service.go
+++ b/internal/codeintel/codenav/service.go
@@ -9,6 +9,7 @@ import (
 	"slices"
 	"strings"
 
+	genslices "github.com/life4/genesis/slices"
 	"github.com/sourcegraph/log"
 	"github.com/sourcegraph/scip/bindings/go/scip"
 	"go.opentelemetry.io/otel/attribute"
@@ -291,7 +292,7 @@ func (s *Service) getUploadLocations(ctx context.Context, args RequestArgs, requ
 // the requested commit. If the translation fails, then the original commit and range are used as the
 // commit and range of the adjusted location and a false flag is returned.
 func (s *Service) getUploadLocation(ctx context.Context, args RequestArgs, requestState RequestState, upload uploadsshared.CompletedUpload, location shared.Location) (shared.UploadLocation, bool, error) {
-	repoRootRelPath := core.NewRepoRelPath(&upload, location.Path)
+	repoRootRelPath := core.NewRepoRelPath(upload, location.Path)
 	adjustedCommit, adjustedRange, ok, err := s.getSourceRange(ctx, args, requestState, upload.RepositoryID, upload.Commit, repoRootRelPath, location.Range)
 	if err != nil {
 		return shared.UploadLocation{}, ok, err
@@ -514,31 +515,21 @@ func (s *Service) filterCachedUploadsContainingPath(ctx context.Context, request
 	//          we can't detect this easily.
 	// 2. The upload is for the same commit. In this case, we can be confident that the
 	//    path exists in the upload (otherwise we wouldn't have cached it).
-	//
-	// For a simplistic implementation here, just loop over the upload IDs and check
-	// if the document exists.
 	cachedUploads := requestState.GetCacheUploads()
-	filteredUploads := make([]visibleUpload, 0, len(cachedUploads))
-	for _, upload := range cachedUploads {
-		visibleUpload := visibleUpload{
-			Upload:                upload,
-			TargetPath:            path,
-			TargetPathWithoutRoot: core.NewUploadRelPath(&upload, path),
-		}
-		if upload.Commit == requestState.Commit && path == requestState.Path {
-			filteredUploads = append(filteredUploads, visibleUpload)
-			continue
-		}
-		// TODO(id: check-path-multiple-uploads-api): We could optimize this to a single DB query
-		// instead of a loop along with a bunch of deserialization.
-		if doc, err := s.SCIPDocument(ctx, upload.ID, path); err == nil && doc != nil {
-			// Be pessimistic, ignoring the upload for all errors, not just some
-			// DocumentNotFound or MalformedDocument cases.
-			filteredUploads = append(filteredUploads, visibleUpload)
-			continue
-		}
+
+	filteredUploads, err := filterUploadsImpl(ctx, s.lsifstore, cachedUploads, path,
+		/*skipDBCheck*/ func(upload uploadsshared.CompletedUpload) bool {
+			// See NOTE(id: path-based-upload-filtering)
+			return upload.Commit == requestState.Commit && path == requestState.Path
+		})
+	if err != nil {
+		s.logger.Warn("FindDocumentIDs failed", log.Error(err))
 	}
-	return filteredUploads
+
+	return genslices.Map(filteredUploads, func(u uploadsshared.CompletedUpload) visibleUpload {
+		uploadRelPath := core.NewUploadRelPath(&u, path)
+		return visibleUpload{Upload: u, TargetPath: path, TargetPathWithoutRoot: uploadRelPath}
+	})
 }
 
 func (s *Service) GetRanges(ctx context.Context, args PositionalRequestArgs, requestState RequestState, startLine, endLine int) (adjustedRanges []AdjustedCodeIntelligenceRange, err error) {
@@ -718,31 +709,73 @@ func filterUploadsWithCommits(ctx context.Context, commitCache CommitCache, uplo
 	return filtered, nil
 }
 
+type firstPassResult[U any] struct {
+	skipDBCheck bool
+	upload      U
+} // Go doesn't allow type definitions in generic functions
+
+// filterUploadsImpl returns the uploads in 'candidates' containing 'path'.
+//
+// This is done by consulting the codeintel_scip_document_lookup table
+// in a single query.
+//
+// The skipDBCheck function avoids consulting the database for certain uploads.
+//
+// The order of the returned slice matches the order of candidates.
+func filterUploadsImpl[U core.UploadLike](
+	ctx context.Context,
+	lsifstore lsifstore.LsifStore,
+	candidates []U,
+	path core.RepoRelPath,
+	skipDBCheck func(upload U) bool,
+) ([]U, error) {
+	// Being careful about maintaining determinism here by only
+	// iterating based on order in cachedUploads.
+	results := []firstPassResult[U]{}
+	lookupPaths := map[int]core.UploadRelPath{}
+	for _, upload := range candidates {
+		uploadRelPath := core.NewUploadRelPath(upload, path)
+		results = append(results, firstPassResult[U]{skipDBCheck: skipDBCheck(upload), upload: upload})
+		// We don't have to worry about over-writing because even if an
+		// upload with the same ID is present multiple times, different
+		// copies will have the same Root, so uploadRelPath will be identical.
+		lookupPaths[upload.GetID()] = uploadRelPath
+	}
+
+	foundDocIds, findDocumentIDsErr := lsifstore.FindDocumentIDs(ctx, lookupPaths)
+	// delay emitting the error, return partial results as much as possible
+	if foundDocIds == nil {
+		foundDocIds = map[int]int{}
+	}
+
+	filteredUploads := genslices.MapFilter(results, func(res firstPassResult[U]) (U, bool) {
+		if !res.skipDBCheck {
+			return res.upload, true
+		}
+		_, found := foundDocIds[res.upload.GetID()]
+		return res.upload, found
+	})
+
+	return filteredUploads, findDocumentIDsErr
+}
+
 func filterUploadsWithPaths(
 	ctx context.Context,
 	lsifstore lsifstore.LsifStore,
 	opts uploadsshared.UploadMatchingOptions,
 	candidates []uploadsshared.CompletedUpload,
 ) ([]uploadsshared.CompletedUpload, error) {
-	filtered := make([]uploadsshared.CompletedUpload, 0, len(candidates))
-	for _, candidate := range candidates {
+	return filterUploadsImpl(ctx, lsifstore, candidates, opts.Path /*skipDBCheck*/, func(upload uploadsshared.CompletedUpload) bool {
 		switch opts.RootToPathMatching {
 		case uploadsshared.RootMustEnclosePath:
-			// TODO - this breaks if the file was renamed in git diff
-			path := core.NewUploadRelPath(&candidate, opts.Path)
-			pathExists, err := lsifstore.GetPathExists(ctx, candidate.ID, path)
-			if err != nil {
-				return nil, errors.Wrap(err, "lsifStore.Exists")
-			}
-			if !pathExists {
-				continue
-			}
+			return false
 		case uploadsshared.RootEnclosesPathOrPathEnclosesRoot:
 			// TODO(efritz) - ensure there's a valid document path for this condition as well
+			return true
+		default:
+			panic("Unhandled case for RootToPathMatching")
 		}
-		filtered = append(filtered, candidate)
-	}
-	return filtered, nil
+	})
 }
 
 func copyUploads(uploads []uploadsshared.CompletedUpload) []uploadsshared.CompletedUpload {
@@ -791,7 +824,7 @@ func (s *Service) getVisibleUpload(ctx context.Context, line, character int, upl
 		Upload:                upload,
 		TargetPath:            r.Path,
 		TargetPosition:        targetPosition,
-		TargetPathWithoutRoot: core.NewUploadRelPath(&upload, r.Path),
+		TargetPathWithoutRoot: core.NewUploadRelPath(upload, r.Path),
 	}, true, nil
 }
 
@@ -819,7 +852,7 @@ func (s *Service) SnapshotForDocument(ctx context.Context, repositoryID int, com
 
 	upload := uploads[0]
 
-	document, err := s.lsifstore.SCIPDocument(ctx, upload.ID, core.NewUploadRelPath(&upload, path))
+	document, err := s.lsifstore.SCIPDocument(ctx, upload.ID, core.NewUploadRelPath(upload, path))
 	if err != nil || document == nil {
 		return nil, err
 	}

--- a/internal/codeintel/codenav/service.go
+++ b/internal/codeintel/codenav/service.go
@@ -719,12 +719,15 @@ type firstPassResult[U any] struct {
 // This is done by consulting the codeintel_scip_document_lookup table
 // in a single query.
 //
-// The skipDBCheck function avoids consulting the database for certain uploads.
-// If the return value is true, then the upload is included in the output slice.
-// Otherwise, the upload is included in the output slice iff the database
-// contains the (uploadID, path) pair.
+// Params:
+//   - If skipDBCheck returns true, then the upload is included in the output slice.
+//     Otherwise, the upload is included in the output slice iff the database
+//     contains the (uploadID, path) pair.
 //
-// The order of the returned slice matches the order of candidates.
+// Post-conditions:
+//   - The order of the returned slice matches the order of candidates.
+//   - Even if there is an error consulting the database, the candidates for
+//     which skipDBCheck was true will be included in the returned slice.
 func filterUploadsImpl[U core.UploadLike](
 	ctx context.Context,
 	lsifstore lsifstore.LsifStore,

--- a/internal/codeintel/codenav/service.go
+++ b/internal/codeintel/codenav/service.go
@@ -749,7 +749,7 @@ func filterUploadsImpl[U core.UploadLike](
 	}
 
 	filteredUploads := genslices.MapFilter(results, func(res firstPassResult[U]) (U, bool) {
-		if !res.skipDBCheck {
+		if res.skipDBCheck {
 			return res.upload, true
 		}
 		_, found := foundDocIds[res.upload.GetID()]
@@ -765,17 +765,19 @@ func filterUploadsWithPaths(
 	opts uploadsshared.UploadMatchingOptions,
 	candidates []uploadsshared.CompletedUpload,
 ) ([]uploadsshared.CompletedUpload, error) {
-	return filterUploadsImpl(ctx, lsifstore, candidates, opts.Path /*skipDBCheck*/, func(upload uploadsshared.CompletedUpload) bool {
-		switch opts.RootToPathMatching {
-		case uploadsshared.RootMustEnclosePath:
-			return false
-		case uploadsshared.RootEnclosesPathOrPathEnclosesRoot:
-			// TODO(efritz) - ensure there's a valid document path for this condition as well
-			return true
-		default:
-			panic("Unhandled case for RootToPathMatching")
-		}
-	})
+	return filterUploadsImpl(ctx, lsifstore, candidates, opts.Path,
+		/* skipDBCheck */
+		func(upload uploadsshared.CompletedUpload) bool {
+			switch opts.RootToPathMatching {
+			case uploadsshared.RootMustEnclosePath:
+				return false
+			case uploadsshared.RootEnclosesPathOrPathEnclosesRoot:
+				// TODO(efritz) - ensure there's a valid document path for this condition as well
+				return true
+			default:
+				panic("Unhandled case for RootToPathMatching")
+			}
+		})
 }
 
 func copyUploads(uploads []uploadsshared.CompletedUpload) []uploadsshared.CompletedUpload {

--- a/internal/codeintel/codenav/service_diagnostics_test.go
+++ b/internal/codeintel/codenav/service_diagnostics_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/sourcegraph/log"
-	"github.com/sourcegraph/scip/bindings/go/scip"
 
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
@@ -58,8 +57,7 @@ func TestDiagnostics(t *testing.T) {
 	mockLsifStore.GetDiagnosticsFunc.PushReturn(diagnostics[1:4], 3, nil)
 	mockLsifStore.GetDiagnosticsFunc.PushReturn(diagnostics[4:], 26, nil)
 
-	// Update this when TODO(id: check-path-multiple-uploads-api) is addressed.
-	mockLsifStore.SCIPDocumentFunc.SetDefaultReturn(&scip.Document{}, nil)
+	mockLsifStore.FindDocumentIDsFunc.SetDefaultHook(findDocumentIDsFuncAllowAny())
 
 	mockRequest := PositionalRequestArgs{
 		RequestArgs: RequestArgs{
@@ -148,8 +146,7 @@ func TestDiagnosticsWithSubRepoPermissions(t *testing.T) {
 	mockLsifStore.GetDiagnosticsFunc.PushReturn(diagnostics[1:4], 3, nil)
 	mockLsifStore.GetDiagnosticsFunc.PushReturn(diagnostics[4:], 26, nil)
 
-	// Update this when TODO(id: check-path-multiple-uploads-api) is addressed.
-	mockLsifStore.SCIPDocumentFunc.SetDefaultReturn(&scip.Document{}, nil)
+	mockLsifStore.FindDocumentIDsFunc.SetDefaultHook(findDocumentIDsFuncAllowAny())
 
 	ctx := actor.WithActor(context.Background(), &actor.Actor{UID: 1})
 	mockRequest := PositionalRequestArgs{

--- a/internal/codeintel/codenav/service_ranges_test.go
+++ b/internal/codeintel/codenav/service_ranges_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/sourcegraph/log"
-	"github.com/sourcegraph/scip/bindings/go/scip"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/codenav/shared"
@@ -52,8 +51,7 @@ func TestRanges(t *testing.T) {
 	mockSearchClient := client.NewMockSearchClient()
 	hunkCache, _ := NewHunkCache(50)
 
-	// Update this when TODO(id: check-path-multiple-uploads-api) is addressed.
-	mockLsifStore.SCIPDocumentFunc.SetDefaultReturn(&scip.Document{}, nil)
+	mockLsifStore.FindDocumentIDsFunc.SetDefaultHook(findDocumentIDsFuncAllowAny())
 
 	// Init service
 	svc := newService(observation.TestContextTB(t), mockRepoStore, mockLsifStore, mockUploadSvc, mockGitserverClient, mockSearchClient, log.NoOp())

--- a/internal/codeintel/codenav/service_stencil_test.go
+++ b/internal/codeintel/codenav/service_stencil_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/sourcegraph/log"
-	"github.com/sourcegraph/scip/bindings/go/scip"
 
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/codenav/shared"
 	uploadsshared "github.com/sourcegraph/sourcegraph/internal/codeintel/uploads/shared"
@@ -25,8 +24,7 @@ func TestStencil(t *testing.T) {
 	mockSearchClient := client.NewMockSearchClient()
 	hunkCache, _ := NewHunkCache(50)
 
-	// Update this when TODO(id: check-path-multiple-uploads-api) is addressed.
-	mockLsifStore.SCIPDocumentFunc.SetDefaultReturn(&scip.Document{}, nil)
+	mockLsifStore.FindDocumentIDsFunc.SetDefaultHook(findDocumentIDsFuncAllowAny())
 
 	// Init service
 	svc := newService(observation.TestContextTB(t), mockRepoStore, mockLsifStore, mockUploadSvc, mockGitserverClient, mockSearchClient, log.NoOp())
@@ -87,8 +85,7 @@ func TestStencilWithDuplicateRanges(t *testing.T) {
 	mockSearchClient := client.NewMockSearchClient()
 	hunkCache, _ := NewHunkCache(50)
 
-	// Update this when TODO(id: check-path-multiple-uploads-api) is addressed.
-	mockLsifStore.SCIPDocumentFunc.SetDefaultReturn(&scip.Document{}, nil)
+	mockLsifStore.FindDocumentIDsFunc.SetDefaultHook(findDocumentIDsFuncAllowAny())
 
 	// Init service
 	svc := newService(observation.TestContextTB(t), mockRepoStore, mockLsifStore, mockUploadSvc, mockGitserverClient, mockSearchClient, log.NoOp())

--- a/internal/codeintel/codenav/shared/types.go
+++ b/internal/codeintel/codenav/shared/types.go
@@ -26,7 +26,7 @@ type Diagnostic[PathType any] struct {
 func AdjustDiagnostic(d Diagnostic[core.UploadRelPath], upload shared.CompletedUpload) Diagnostic[core.RepoRelPath] {
 	return Diagnostic[core.RepoRelPath]{
 		UploadID:       d.UploadID,
-		Path:           core.NewRepoRelPath(&upload, d.Path),
+		Path:           core.NewRepoRelPath(upload, d.Path),
 		DiagnosticData: d.DiagnosticData,
 	}
 }

--- a/internal/codeintel/codenav/transport/graphql/root_resolver_test.go
+++ b/internal/codeintel/codenav/transport/graphql/root_resolver_test.go
@@ -37,9 +37,6 @@ var repoRelPath = core.NewRepoRelPathUnchecked
 func TestRanges(t *testing.T) {
 	mockCodeNavService := NewMockCodeNavService()
 
-	// Update this when TODO(id: check-path-multiple-uploads-api) is addressed.
-	mockCodeNavService.SCIPDocumentFunc.SetDefaultReturn(&scip.Document{}, nil)
-
 	mockRequestState := codenav.RequestState{
 		RepositoryID: 1,
 		Commit:       "deadbeef1",

--- a/internal/codeintel/uploads/shared/types.go
+++ b/internal/codeintel/uploads/shared/types.go
@@ -103,13 +103,13 @@ type CompletedUpload struct {
 	AssociatedIndexID *int       `json:"associatedIndex"`
 }
 
-var _ core.UploadLike = &CompletedUpload{}
+var _ core.UploadLike = CompletedUpload{}
 
-func (u *CompletedUpload) GetID() int {
+func (u CompletedUpload) GetID() int {
 	return u.ID
 }
 
-func (u *CompletedUpload) GetRoot() string {
+func (u CompletedUpload) GetRoot() string {
 	return u.Root
 }
 


### PR DESCRIPTION
Fixes https://linear.app/sourcegraph/issue/GRAPH-700

Previously, there were two code paths which were checking if certain
upload IDs containing a specific repo-relative path. One was using the
better GetPathExists API, the another one that I recently added was
much more stupid, it was deserializing the full SCIP Document.

However, using `GetPathExists` in a loop is also not great; we should
push the loop into the database. This patch replaces both of those usage
sites with a single function that handles bulk filtering, and replaces
the `GetPathExists` lsifstore method with `FindDocumentIDs`.

Q: Why are we returning document IDs if the caller doesn't need them?
A: Getting the document ID is essentially "free", so I thought it would be
better to return a mapping instead of a set.

However, I didn't generalize the API to support multiple paths within
the same upload, as that would complicate the method signature somewhat.
(the argument and return types would be both `collections.Set[Pair[int, UploadRelPath]]`).

I'm open to changing the method to work with sets instead and renaming
it to `CheckPathsExist`.

## Test plan

Modified GetPathExists test to use the new FindDocumentIDs API.

## Changelog