### PR TITLE
search: remove "lucky" from default pattern types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Providing an access token via the [`SRC_ACCESS_TOKEN`](https://sourcegraph.com/docs/cli/how-tos/creating_an_access_token) environment variable is now mandatory for uploading SCIP indexes using [src-cli](https://sourcegraph.com/docs/cli). [#62573](https://github.com/sourcegraph/sourcegraph/pull/62573)
 - Fixed several conditions that could cause a repository being incorrectly marked as modified during code host syncing. For these cases, unnecessary git fetches were triggered. [#62837](https://github.com/sourcegraph/sourcegraph/pull/62837)
 - Fixed usernames getting random suffixes added during SCIM provisioning. [#63122](https://github.com/sourcegraph/sourcegraph/pull/63122)
+- Removed experimental pattern type "lucky" from the list of supported default pattern types. []()
 
 ## 5.4.2198
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Providing an access token via the [`SRC_ACCESS_TOKEN`](https://sourcegraph.com/docs/cli/how-tos/creating_an_access_token) environment variable is now mandatory for uploading SCIP indexes using [src-cli](https://sourcegraph.com/docs/cli). [#62573](https://github.com/sourcegraph/sourcegraph/pull/62573)
 - Fixed several conditions that could cause a repository being incorrectly marked as modified during code host syncing. For these cases, unnecessary git fetches were triggered. [#62837](https://github.com/sourcegraph/sourcegraph/pull/62837)
 - Fixed usernames getting random suffixes added during SCIM provisioning. [#63122](https://github.com/sourcegraph/sourcegraph/pull/63122)
-- Removed experimental pattern type "lucky" from the list of supported default pattern types. []()
+- Removed experimental pattern type "lucky" from the list of supported default pattern types. [#63486](https://github.com/sourcegraph/sourcegraph/pull/63486)
 
 ## 5.4.2198
 

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -2446,7 +2446,7 @@ type Settings struct {
 	SearchDefaultCaseSensitive bool `json:"search.defaultCaseSensitive,omitempty"`
 	// SearchDefaultMode description: Defines default properties for search behavior. The default is `smart`, which provides query assistance that automatically runs alternative queries when appropriate. When `precise`, search behavior strictly searches for the precise meaning of the query.
 	SearchDefaultMode string `json:"search.defaultMode,omitempty"`
-	// SearchDefaultPatternType description: The default pattern type that search queries will be intepreted as. `lucky` is an experimental mode that will interpret the query in multiple ways.
+	// SearchDefaultPatternType description: The default pattern type that search queries will be interpreted as.
 	SearchDefaultPatternType string `json:"search.defaultPatternType,omitempty"`
 	// SearchDisplayLimit description: The number of results we send down during a search. Note: this is different to the count: in the query. The search will continue once we hit displayLimit and updated filters and statistics will continue to stream down. Defaults to 1500.
 	SearchDisplayLimit *int `json:"search.displayLimit,omitempty"`

--- a/schema/settings.schema.json
+++ b/schema/settings.schema.json
@@ -398,9 +398,9 @@
       "pattern": "precise|smart"
     },
     "search.defaultPatternType": {
-      "description": "The default pattern type that search queries will be intepreted as. `lucky` is an experimental mode that will interpret the query in multiple ways.",
+      "description": "The default pattern type that search queries will be interpreted as.",
       "type": "string",
-      "pattern": "standard|literal|regexp|lucky|keyword|codycontext"
+      "pattern": "standard|literal|regexp|keyword|codycontext"
     },
     "search.defaultCaseSensitive": {
       "description": "Whether query patterns are treated case sensitively. Patterns are case insensitive by default.",


### PR DESCRIPTION
"lucky" was an experimental pattern type we added about 2 years ago. Judging from the git history and the current code, it was at some point replaced by "smart search" and "search mode", which we also plan to remove soon.

See https://github.com/sourcegraph/sourcegraph/pull/43140 for more context

Test plan:
CI