### PR TITLE
saved searches: use default pattern type

### DIFF
--- a/client/web/BUILD.bazel
+++ b/client/web/BUILD.bazel
@@ -1992,6 +1992,7 @@ ts_project(
         "src/repo/releases/RepositoryReleasesTagsPage.test.tsx",
         "src/repo/tree/TreePage.test.tsx",
         "src/repo/utils.test.ts",
+        "src/savedSearches/SavedSearchForm.test.tsx",
         "src/search/helpers.test.tsx",
         "src/search/index.test.ts",
         "src/search/input/recentSearches.test.ts",

--- a/client/web/src/savedSearches/SavedSearchForm.test.tsx
+++ b/client/web/src/savedSearches/SavedSearchForm.test.tsx
@@ -1,0 +1,48 @@
+import { describe, test, expect, vi } from 'vitest'
+
+import { LazyQueryInput } from '@sourcegraph/branded'
+import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
+import { renderWithBrandedContext } from '@sourcegraph/wildcard/src/testing'
+
+import { SearchPatternType } from '../graphql-operations'
+
+import { SavedSearchForm } from './SavedSearchForm'
+
+const DEFAULT_PATTERN_TYPE = SearchPatternType.regexp
+
+describe('SavedSearchForm', () => {
+    test('renders LazyQueryInput with the default patternType', () => {
+        vi.mock('@sourcegraph/branded', () => ({
+            LazyQueryInput: vi.fn(() => null),
+        }))
+        vi.mock('../util/settings', () => ({
+            defaultPatternTypeFromSettings: () => DEFAULT_PATTERN_TYPE,
+        }))
+
+        renderWithBrandedContext(
+            <SavedSearchForm
+                isSourcegraphDotCom={false}
+                submitLabel="Submit"
+                title="Title"
+                defaultValues={{}}
+                authenticatedUser={null}
+                onSubmit={() => {}}
+                loading={false}
+                error={null}
+                namespace={{
+                    __typename: 'User',
+                    id: '',
+                    url: '',
+                }}
+                telemetryRecorder={noOpTelemetryRecorder}
+            />
+        )
+
+        expect(LazyQueryInput).toHaveBeenCalledWith(
+            expect.objectContaining({
+                patternType: DEFAULT_PATTERN_TYPE,
+            }),
+            expect.anything()
+        )
+    })
+})

--- a/client/web/src/savedSearches/SavedSearchForm.tsx
+++ b/client/web/src/savedSearches/SavedSearchForm.tsx
@@ -26,6 +26,8 @@ import { type Scalars, SearchPatternType } from '../graphql-operations'
 import type { NamespaceProps } from '../namespaces'
 
 import styles from './SavedSearchForm.module.scss'
+import { defaultPatternTypeFromSettings } from '../util/settings'
+import { useSettingsCascade } from '@sourcegraph/shared/src/settings/settings'
 
 export interface SavedQueryFields {
     id: Scalars['ID']
@@ -95,6 +97,8 @@ export const SavedSearchForm: React.FunctionComponent<React.PropsWithChildren<Sa
 
     const [queryState, setQueryState] = useState<QueryState>({ query: query || '' })
 
+    const defaultPatternType: SearchPatternType = defaultPatternTypeFromSettings(useSettingsCascade())
+
     useEffect(() => {
         setValues(values => ({ ...values, query: queryState.query }))
     }, [queryState.query])
@@ -123,7 +127,7 @@ export const SavedSearchForm: React.FunctionComponent<React.PropsWithChildren<Sa
 
                         <LazyQueryInput
                             className={classNames('form-control', styles.queryInput)}
-                            patternType={SearchPatternType.standard}
+                            patternType={defaultPatternType}
                             isSourcegraphDotCom={props.isSourcegraphDotCom}
                             caseSensitive={false}
                             queryState={queryState}

--- a/client/web/src/savedSearches/SavedSearchForm.tsx
+++ b/client/web/src/savedSearches/SavedSearchForm.tsx
@@ -5,6 +5,7 @@ import type { Omit } from 'utility-types'
 
 import { LazyQueryInput } from '@sourcegraph/branded'
 import type { QueryState } from '@sourcegraph/shared/src/search'
+import { useSettingsCascade } from '@sourcegraph/shared/src/settings/settings'
 import {
     Container,
     PageHeader,
@@ -24,10 +25,9 @@ import type { AuthenticatedUser } from '../auth'
 import { PageTitle } from '../components/PageTitle'
 import { type Scalars, SearchPatternType } from '../graphql-operations'
 import type { NamespaceProps } from '../namespaces'
+import { defaultPatternTypeFromSettings } from '../util/settings'
 
 import styles from './SavedSearchForm.module.scss'
-import { defaultPatternTypeFromSettings } from '../util/settings'
-import { useSettingsCascade } from '@sourcegraph/shared/src/settings/settings'
 
 export interface SavedQueryFields {
     id: Scalars['ID']


### PR DESCRIPTION
This is part of the Keyword GA Project.

Instead of hardcoding the pattern type to "standard" we use the default pattern type. This really only affects highlighting, because users are already forced to explicity state a pattern type by the GraphQL API.

Test plan:
I tested the following workflows:

1. Creating a saved search from search results page
2. Creating a saved search from the user menu
3. Editing an existing saved search after the default patternType had changed



