### PR TITLE
Fix azure completions api

### DIFF
--- a/cmd/frontend/internal/httpapi/completions/handler.go
+++ b/cmd/frontend/internal/httpapi/completions/handler.go
@@ -120,6 +120,7 @@ func newCompletionsHandler(
 		requestParams.User = completionsConfig.User
 		requestParams.AzureChatModel = completionsConfig.AzureChatModel
 		requestParams.AzureCompletionModel = completionsConfig.AzureCompletionModel
+		requestParams.AzureUseDeprecatedCompletionsAPIForOldModels = completionsConfig.AzureUseDeprecatedCompletionsAPIForOldModels
 		if err != nil {
 			// NOTE: We return the raw error to the user assuming that it contains relevant
 			// user-facing diagnostic information, and doesn't leak any internal details.

--- a/internal/completions/types/types.go
+++ b/internal/completions/types/types.go
@@ -55,19 +55,20 @@ type CompletionRequestParameters struct {
 	// Prompt exists only for backwards compatibility. Do not use it in new
 	// implementations. It will be removed once we are reasonably sure 99%
 	// of VSCode extension installations are upgraded to a new Cody version.
-	Prompt               string    `json:"prompt"`
-	Messages             []Message `json:"messages"`
-	MaxTokensToSample    int       `json:"maxTokensToSample,omitempty"`
-	Temperature          float32   `json:"temperature,omitempty"`
-	StopSequences        []string  `json:"stopSequences,omitempty"`
-	TopK                 int       `json:"topK,omitempty"`
-	TopP                 float32   `json:"topP,omitempty"`
-	Model                string    `json:"model,omitempty"`
-	Stream               *bool     `json:"stream,omitempty"`
-	Logprobs             *uint8    `json:"logprobs"`
-	User                 string    `json:"user,omitempty"`
-	AzureChatModel       string    `json:"azureChatModel,omitempty"`
-	AzureCompletionModel string    `json:"azureCompletionModel,omitempty"`
+	Prompt                                       string    `json:"prompt"`
+	Messages                                     []Message `json:"messages"`
+	MaxTokensToSample                            int       `json:"maxTokensToSample,omitempty"`
+	Temperature                                  float32   `json:"temperature,omitempty"`
+	StopSequences                                []string  `json:"stopSequences,omitempty"`
+	TopK                                         int       `json:"topK,omitempty"`
+	TopP                                         float32   `json:"topP,omitempty"`
+	Model                                        string    `json:"model,omitempty"`
+	Stream                                       *bool     `json:"stream,omitempty"`
+	Logprobs                                     *uint8    `json:"logprobs"`
+	User                                         string    `json:"user,omitempty"`
+	AzureChatModel                               string    `json:"azureChatModel,omitempty"`
+	AzureCompletionModel                         string    `json:"azureCompletionModel,omitempty"`
+	AzureUseDeprecatedCompletionsAPIForOldModels bool      `json:"azureUseDeprecatedCompletionsAPIForOldModels,omitempty"`
 }
 
 // IsStream returns whether a streaming response is requested. For backwards

--- a/internal/conf/computed.go
+++ b/internal/conf/computed.go
@@ -932,13 +932,14 @@ func GetCompletionsConfig(siteConfig schema.SiteConfiguration) (c *conftypes.Com
 	}
 
 	computedConfig := &conftypes.CompletionsConfig{
-		Provider:                         conftypes.CompletionsProviderName(completionsConfig.Provider),
-		AccessToken:                      completionsConfig.AccessToken,
-		ChatModel:                        completionsConfig.ChatModel,
-		ChatModelMaxTokens:               completionsConfig.ChatModelMaxTokens,
-		SmartContextWindow:               completionsConfig.SmartContextWindow,
-		FastChatModel:                    completionsConfig.FastChatModel,
-		FastChatModelMaxTokens:           completionsConfig.FastChatModelMaxTokens,
+		Provider:               conftypes.CompletionsProviderName(completionsConfig.Provider),
+		AccessToken:            completionsConfig.AccessToken,
+		ChatModel:              completionsConfig.ChatModel,
+		ChatModelMaxTokens:     completionsConfig.ChatModelMaxTokens,
+		SmartContextWindow:     completionsConfig.SmartContextWindow,
+		FastChatModel:          completionsConfig.FastChatModel,
+		FastChatModelMaxTokens: completionsConfig.FastChatModelMaxTokens,
+		AzureUseDeprecatedCompletionsAPIForOldModels: completionsConfig.AzureUseDeprecatedCompletionsAPIForOldModels,
 		CompletionModel:                  completionsConfig.CompletionModel,
 		CompletionModelMaxTokens:         completionsConfig.CompletionModelMaxTokens,
 		Endpoint:                         completionsConfig.Endpoint,

--- a/internal/conf/conftypes/consts.go
+++ b/internal/conf/conftypes/consts.go
@@ -14,8 +14,9 @@ type CompletionsConfig struct {
 	CompletionModel          string
 	CompletionModelMaxTokens int
 
-	AzureCompletionModel string
-	AzureChatModel       string
+	AzureCompletionModel                         string
+	AzureChatModel                               string
+	AzureUseDeprecatedCompletionsAPIForOldModels bool
 
 	AccessToken                                            string
 	Provider                                               CompletionsProviderName

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -668,6 +668,8 @@ type Completions struct {
 	AzureChatModel string `json:"azureChatModel,omitempty"`
 	// AzureCompletionModel description: Optional: Specify the Azure OpenAI model name for chat completions. This is only needed when you want to count tokens associated with your azure model
 	AzureCompletionModel string `json:"azureCompletionModel,omitempty"`
+	// AzureUseDeprecatedCompletionsAPIForOldModels description: Enables the use of the older completions API for select Azure OpenAI models.
+	AzureUseDeprecatedCompletionsAPIForOldModels bool `json:"azureUseDeprecatedCompletionsAPIForOldModels,omitempty"`
 	// ChatModel description: The model used for chat completions. If using the default provider 'sourcegraph', a reasonable default model will be set.
 	//  NOTE: The Anthropic messages API does not support model names like claude-2 or claude-instant-1 where only the major version is specified as they are retired. We recommend using a specific model identifier as specified here https://docs.anthropic.com/claude/docs/models-overview#model-comparison
 	ChatModel string `json:"chatModel,omitempty"`

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -2890,6 +2890,11 @@
             "enum": ["claude-2", "claude-instant-1"]
           }
         },
+        "azureUseDeprecatedCompletionsAPIForOldModels": {
+          "description": "Enables the use of the older completions API for select Azure OpenAI models.",
+          "type": "boolean",
+          "default": false
+        },
         "fastChatModelMaxTokens": {
           "description": "The maximum number of tokens to use as client when talking to fastChatModel. If not set, clients need to set their own limit.",
           "type": "integer"


### PR DESCRIPTION
[Linear Issue 
](https://linear.app/sourcegraph/issue/CODY-2586/fix-completions-models-api-for-azure-to-use-the-right-model-with-the)

The purpose of this PR is to make a backwords compatible solution such that the completions logic in our codebase for azure supports both the completions API(which is old) and also supports the chat/completions API which is new. This way we can use models from both of them with autocomplete. 

NOTe: Since we can't figure out which model we are using because azure has the deployment name instead of model name and because of that we can't decide which API to use for which model we try with both of the APIs and then the API that works is cached for that model and then we used the cached API logic to choose the api to make subsequent completion calls this way we can choose either of the APIs and not have added latency with completions.  


## Test plan
I used the azure keys to try out different deployment models that we have both with the old and the new api. 
Old API -> Completions (gpt-3.5-turbo-instruct, gpt-3.5-turbo(301), gpt-3.5-turbo(613))
New API -> Chat Completions(gpt-3.5-turbo(301), gpt-4o, gpt-3.5-turbo(613), gpt-3.5-turbo-16k)

NOTE both of the set of models work seamless with this PR.


<!-- REQUIRED; info at https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles -->

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
