### PR TITLE
Enable new Cody Web by default

### DIFF
--- a/client/shared/src/settings/settings.tsx
+++ b/client/shared/src/settings/settings.tsx
@@ -311,6 +311,7 @@ const defaultFeatures: SettingsExperimentalFeatures = {
     isInitialized: true,
     searchQueryInput: 'v2',
     newSearchResultFiltersPanel: true,
+    newCodyWeb: true,
 }
 
 /**


### PR DESCRIPTION

This PR turns on the new Cody Web by default for everyone. It's still possible to opt-out to the old Cody Web with `"newCodyWeb": false` in your experimental features in settings.

I forgot that the dot com instance seeds its global settings and site configuration from files and 
doesn't allow us to override specific settings there; 

## Test plan
- Check that the new Cody Web client is available to you without any feature flag by default 