### PR TITLE
Svelte: improve contrast for file tree guide line

### DIFF
--- a/client/web-sveltekit/src/lib/TreeNode.svelte
+++ b/client/web-sveltekit/src/lib/TreeNode.svelte
@@ -178,10 +178,10 @@
         &::before {
             position: absolute;
             content: '';
-            border-left: 1px solid var(--border-color);
+            border-left: 1px solid var(--secondary);
             height: 100%;
             transform: translateX(
-                calc(var(--tree-node-nested-level) * #{$shiftWidth} + var(--icon-inline-size) * 1.5 + #{$gap} + 1px)
+                calc(var(--tree-node-nested-level) * #{$shiftWidth} + var(--icon-inline-size) * 1.5 + #{$gap} + 2px)
             );
             z-index: 1;
         }


### PR DESCRIPTION
Bumped it up to `--secondary`. Also fixed the visual centering against the new lucide chevrons.

Fixes SRCH-485

# Test plan
![screenshot-2024-06-26_12-45-46@2x](https://github.com/sourcegraph/sourcegraph/assets/12631702/d477ff67-6da8-4c9a-b140-9193552eac0f)
![screenshot-2024-06-26_12-44-16@2x](https://github.com/sourcegraph/sourcegraph/assets/12631702/0919c250-945c-4ca5-9349-3261dc2d72c4)
