### PR TITLE
fix/internal/observation: make ErrCollector type threadsafe

### DIFF
--- a/dev/rockskipintegration/main_test.go
+++ b/dev/rockskipintegration/main_test.go
@@ -30,8 +30,6 @@ import (
 )
 
 func TestRockskipIntegration(t *testing.T) {
-	t.Skip("This test is having data race and needs to be fixed. See https://github.com/sourcegraph/sourcegraph/issues/63360")
-
 	gs, _ := gitserverintegration.NewTestGitserverWithRepos(t, map[api.RepoName]string{
 		"github.com/sourcegraph/rockskiptest": gitserverintegration.RepoWithCommands(t,
 			"echo '# Title' > README.md",


### PR DESCRIPTION
Closes https://linear.app/sourcegraph/issue/SRC-410/race-in-gitserver-observability

This PR adds a mutex to the internal/observation.ErrCollector type that makes it safe to use across multiple goroutines. 

(This could quite easily happen, as the FinishFunc's OnCancel method runs the logic that accesses/modifies ErrReporter in a separate goroutine:)

https://github.com/sourcegraph/sourcegraph/blob/fa46a26f7a7d3d13833cc7917aaee42d1c94eff9/internal/observation/observation.go#L156-L170

## Test plan

CI now passes and doesn't report race conditions


## Changelog

- Fixed a threadsafety issue in the internal/observation.ErrCollector type