### PR TITLE
Fix initial context for Cody Web on the repository page

### DIFF
--- a/client/web/src/cody/sidebar/new-cody-sidebar/NewCodySidebarWebChat.tsx
+++ b/client/web/src/cody/sidebar/new-cody-sidebar/NewCodySidebarWebChat.tsx
@@ -35,7 +35,7 @@ export const NewCodySidebarWebChat: FC<NewCodySidebarWebChatProps> = memo(functi
     const contextInfo = useMemo(
         () => ({
             repositories: [repository],
-            fileURL: `/${filePath}`,
+            fileURL: filePath ? `/${filePath}` : undefined,
         }),
         [repository, filePath]
     )


### PR DESCRIPTION
Closes https://linear.app/sourcegraph/issue/SRCH-620/cody-web-has-incorrect-initial-context-on-blank-repository-page

## Test plan
- Go to the repository root and open cody web, it should has only repository as initial context

<!-- REQUIRED; info at https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles -->

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
