### PR TITLE
Cody Web: Fix Cody page for signed out users

### DIFF
--- a/client/web/src/cody/chat/CodyChatPage.tsx
+++ b/client/web/src/cody/chat/CodyChatPage.tsx
@@ -27,7 +27,9 @@ export const CodyChatPage: FC<CodyChatPageProps> = props => {
     // cody extension.
     const newCodyWeb = useExperimentalFeatures(features => features.newCodyWeb)
 
-    return newCodyWeb ? (
+    // Load new cody web only for authorized users, fallback on old cody web
+    // for better non-logged-in user experience.
+    return newCodyWeb && authenticatedUser !== null ? (
         <LazyNewCodyChatPage isSourcegraphDotCom={isSourcegraphDotCom} />
     ) : (
         <OldCodyChatPage


### PR DESCRIPTION
The New Cody Web client doesn't work for non-auth users, we should never render 
new Cody web client for signed-out users and show cody landing page instead.

## Test plan
- Run local instance and sign out 
- Check that Cody Web page shows the welcome landing page 

