### PR TITLE
cloud: update feature flag warning severity

### DIFF
--- a/client/web/src/site-admin/SiteAdminFeatureFlagsPage.tsx
+++ b/client/web/src/site-admin/SiteAdminFeatureFlagsPage.tsx
@@ -223,7 +223,7 @@ export const SiteAdminFeatureFlagsPage: React.FunctionComponent<
             />
 
             {isSourcegraphCloudManagedFeatureFlagsWarningShown && (
-                <Alert variant="warning">
+                <Alert variant="info">
                     Feature flag settings are managed by Sourcegraph and will be overridden by updates. Contact support
                     for help.
                 </Alert>


### PR DESCRIPTION
follow up https://github.com/sourcegraph/sourcegraph/pull/63484

got feedback from teammates that it shouldn't be `warning` but `info`

warning usually indicates something is wrong, this is not the case.

<!-- PR description tips: https://www.notion.so/sourcegraph/Write-a-good-pull-request-description-610a7fd3e613496eb76f450db5a49b6e -->

## Test plan

<!-- REQUIRED; info at https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles -->

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->

n/a