### PR TITLE
WIP modelconfig service component

### DIFF
--- a/cmd/frontend/internal/httpapi/BUILD.bazel
+++ b/cmd/frontend/internal/httpapi/BUILD.bazel
@@ -30,6 +30,7 @@ go_library(
         "//cmd/frontend/internal/handlerutil",
         "//cmd/frontend/internal/httpapi/releasecache",
         "//cmd/frontend/internal/httpapi/webhookhandlers",
+        "//cmd/frontend/internal/modelconfig",
         "//cmd/frontend/internal/routevar",
         "//cmd/frontend/internal/search",
         "//cmd/frontend/internal/ssc",

--- a/cmd/frontend/internal/httpapi/httpapi.go
+++ b/cmd/frontend/internal/httpapi/httpapi.go
@@ -25,6 +25,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/handlerutil"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/httpapi/releasecache"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/httpapi/webhookhandlers"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/modelconfig"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/routevar"
 	frontendsearch "github.com/sourcegraph/sourcegraph/cmd/frontend/internal/search"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/ssc"
@@ -172,6 +173,10 @@ func NewHandler(
 
 	m.Path("/completions/stream").Methods("POST").Handler(handlers.NewChatCompletionsStreamHandler())
 	m.Path("/completions/code").Methods("POST").Handler(handlers.NewCodeCompletionsHandler())
+
+	// HTTP endpoints related to LLM model configuration.
+	modelConfigHandlers := modelconfig.NewHandlers(db, logger)
+	m.Path("/supported-llms").Methods("GET").HandlerFunc(modelConfigHandlers.GetSupportedModelsHandler)
 
 	if dotcom.SourcegraphDotComMode() {
 		m.Path("/license/check").Methods("POST").Name("dotcom.license.check").Handler(handlers.NewDotcomLicenseCheckHandler())

--- a/cmd/frontend/internal/modelconfig/BUILD.bazel
+++ b/cmd/frontend/internal/modelconfig/BUILD.bazel
@@ -1,0 +1,44 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("//dev:go_defs.bzl", "go_test")
+
+go_library(
+    name = "modelconfig",
+    srcs = [
+        "builder.go",
+        "httpapi.go",
+        "init.go",
+        "service.go",
+    ],
+    importpath = "github.com/sourcegraph/sourcegraph/cmd/frontend/internal/modelconfig",
+    visibility = ["//cmd/frontend:__subpackages__"],
+    deps = [
+        "//cmd/frontend/enterprise",
+        "//cmd/frontend/internal/auth",
+        "//cmd/frontend/internal/registry",
+        "//internal/actor",
+        "//internal/codeintel",
+        "//internal/conf",
+        "//internal/conf/conftypes",
+        "//internal/database",
+        "//internal/modelconfig",
+        "//internal/modelconfig/embedded",
+        "//internal/modelconfig/types",
+        "//internal/observation",
+        "//lib/errors",
+        "//schema",
+        "@com_github_sourcegraph_log//:log",
+    ],
+)
+
+go_test(
+    name = "modelconfig_test",
+    srcs = ["builder_test.go"],
+    embed = [":modelconfig"],
+    deps = [
+        "//internal/modelconfig/embedded",
+        "//internal/modelconfig/types",
+        "//schema",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/cmd/frontend/internal/modelconfig/builder.go
+++ b/cmd/frontend/internal/modelconfig/builder.go
@@ -1,0 +1,218 @@
+package modelconfig
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/sourcegraph/sourcegraph/internal/modelconfig"
+	"github.com/sourcegraph/sourcegraph/internal/modelconfig/types"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+// builder implements the logic for constructing the Sourcegraph instance's
+// LLM model configuration data, based on various configuration settings and available
+// data.
+type builder struct {
+	// staticData is what is embedded into this binary, known at build-time.
+	staticData *types.ModelConfiguration
+
+	// codyGatewayData is what we have recently obtained by checking Cody Gateway
+	// for any recent updates.
+	//
+	// TODO(chrsmith): This aspect is not yet implemented, and this field will
+	// always be nil.
+	codyGatewayData *types.ModelConfiguration
+
+	// siteConfigData is the data that is defined in the site configuration.
+	// This is in a slightly different format to be more expressive than what
+	// is provided by Cody Gateway or embedded in the binary.
+	siteConfigData *types.SiteModelConfiguration
+}
+
+// build merges all of the model configuration data together, presenting it in
+// its final form to be consumed by the Sourcegraph instance and passed onto its
+// clients.
+func (b *builder) build() (*types.ModelConfiguration, error) {
+	if b.staticData == nil {
+		return nil, errors.New("no static data available")
+	}
+	baseConfig := b.staticData
+
+	// If we have newer data from Cody Gateway, use that instead of what is
+	// baked into our codebase.
+	if b.codyGatewayData != nil {
+		baseConfig = b.codyGatewayData
+	}
+
+	// If the old config data is provided, then ignore the baseConfig entirely.
+	// Since otherwise it would be a breaking change to include all of the Cody LLM Models.
+
+	// Interpret site configuration.
+
+	// If no site configuration data is supplied, then just use Sourcegraph
+	// supplied data.
+	if b.siteConfigData == nil {
+		return deepCopy(baseConfig)
+	}
+	// But if we are using site config data, ensure it is valid.
+	if vErr := modelconfig.ValidateSiteConfig(b.siteConfigData); vErr != nil {
+		return nil, errors.Wrap(vErr, "invalid site configuration")
+	}
+
+	outConfig, err := applySiteConfig(baseConfig, b.siteConfigData)
+	if err != nil {
+		return nil, errors.Wrap(err, "applying site config")
+	}
+
+	return outConfig, nil
+}
+
+// applySiteConfig returns the LLM Model configuration after applying the Sourcegraph admin supplied site config overrides.
+// Will mutate the provided `baseConfig` in-place, and return the same value.
+func applySiteConfig(baseConfig *types.ModelConfiguration, siteConfig *types.SiteModelConfiguration) (*types.ModelConfiguration, error) {
+	if baseConfig == nil || siteConfig == nil {
+		return nil, errors.New("baseConfig or siteConfig nil")
+	}
+
+	// If the admin has explicitly disabled the Sourcegraph-supplied data, zero out the base config.
+	sgModelConfig := siteConfig.SourcegraphModelConfig
+	if sgModelConfig == nil {
+		baseConfig = &types.ModelConfiguration{
+			Revision:      "-",
+			SchemaVersion: types.CurrentModelSchemaVersion,
+		}
+	} else {
+		// Apply any model filters.
+		if modelFilters := sgModelConfig.ModelFilters; modelFilters != nil {
+			var filteredModels []types.Model
+			for _, baseConfigModel := range baseConfig.Models {
+				// Category filter.
+				if modelFilters.CategoryFilter != nil {
+					if !slices.Contains(modelFilters.CategoryFilter, string(baseConfigModel.Category)) {
+						continue
+					}
+				}
+
+				// Allow list. If not specified, include all models.
+				// Otherwise, only include those that match.
+				if len(modelFilters.Allow) > 0 {
+					if !filterListMatches(baseConfigModel.ModelRef, modelFilters.Allow) {
+						continue
+					}
+				}
+				// Deny list. Exclude all matches.
+				if len(modelFilters.Deny) > 0 {
+					if filterListMatches(baseConfigModel.ModelRef, modelFilters.Deny) {
+						continue
+					}
+				}
+
+				filteredModels = append(filteredModels, baseConfigModel)
+			}
+			baseConfig.Models = filteredModels
+		}
+	}
+
+	for _, providerOverride := range siteConfig.ProviderOverrides {
+		var providerToOverride *types.Provider
+		// Lookup the provider this configuration is for.
+		for i := range baseConfig.Providers {
+			if baseConfig.Providers[i].ID == providerOverride.ID {
+				providerToOverride = &baseConfig.Providers[i]
+				break
+			}
+		}
+
+		// The site configuration has an override for a provider that
+		// isn't in the base config. So it must entirely come from the
+		// site configuration.
+		if providerToOverride == nil {
+			providerToOverride = &types.Provider{
+				ID:               providerOverride.ID,
+				DisplayName:      fmt.Sprintf("Provider %q", providerOverride.ID),
+				ServerSideConfig: providerOverride.ServerSideConfig,
+			}
+			baseConfig.Providers = append(baseConfig.Providers, *providerToOverride)
+		}
+		providerToOverride.ServerSideConfig = providerOverride.ServerSideConfig
+	}
+
+	// Model Overrides
+	for _, modelOverride := range siteConfig.ModelOverrides {
+		var modelToOverride *types.Model
+		// Lookup the model this configuration is for.
+		for i := range baseConfig.Models {
+			if baseConfig.Models[i].ModelRef == modelOverride.ModelRef {
+				modelToOverride = &baseConfig.Models[i]
+				break
+			}
+		}
+
+		// The site configuration has an override for a model that
+		// isn't in the base config. So it must entirely come from the
+		// site configuration.
+		if modelToOverride == nil {
+			modelToOverride = &types.Model{
+				ModelRef: modelOverride.ModelRef,
+			}
+
+			// TODO: We need to apply DefaultModelConfig from the ProviderOverride,
+			// if one is supplied.
+
+			baseConfig.Models = append(baseConfig.Models, *modelToOverride)
+		}
+	}
+
+	if siteConfig.DefaultModels != nil {
+		baseConfig.DefaultModels = *siteConfig.DefaultModels
+	}
+
+	return baseConfig, nil
+}
+
+// filterListMatches returns whether or not any of the patterns match the supplied
+// mref. Assumes the supplied patterns are well-formed. Any asterisks can only be
+// in the first or last character of the pattern.
+func filterListMatches(mref types.ModelRef, patterns []string) bool {
+	s := string(mref)
+	for _, pattern := range patterns {
+		if pattern == "*" {
+			return true
+		}
+
+		pLen := len(pattern)
+		if pLen < 3 {
+			continue // Invalid pattern.
+		}
+		hasLeadingAsterisk := pattern[0] == '*'
+		hasTrailingAsterisk := pattern[pLen-1] == '*'
+
+		// e.g. "*latest"
+		if hasLeadingAsterisk && !hasTrailingAsterisk {
+			if strings.HasSuffix(s, pattern[1:]) {
+				return true
+			}
+		}
+		// e.g. "openai::*"
+		if !hasLeadingAsterisk && hasTrailingAsterisk {
+			if strings.HasPrefix(s, pattern[:pLen-1]) {
+				return true
+			}
+		}
+		// e.g. "anthropic::2023-06-01::claude-3-sonnet"
+		if !hasLeadingAsterisk && !hasTrailingAsterisk {
+			if s == pattern {
+				return true
+			}
+		}
+		// e.g. "*gpt*"
+		if hasLeadingAsterisk && hasTrailingAsterisk {
+			if strings.Contains(s, pattern[1:pLen-1]) {
+				return true
+			}
+		}
+	}
+
+	return false
+}

--- a/cmd/frontend/internal/modelconfig/builder_test.go
+++ b/cmd/frontend/internal/modelconfig/builder_test.go
@@ -1,0 +1,144 @@
+package modelconfig
+
+import (
+	"testing"
+
+	"github.com/sourcegraph/sourcegraph/internal/modelconfig/embedded"
+	"github.com/sourcegraph/sourcegraph/internal/modelconfig/types"
+	"github.com/sourcegraph/sourcegraph/schema"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFilterListMatches(t *testing.T) {
+	const geminiMRef = "google::v1::gemini-1.5-pro-latest"
+
+	tests := []struct {
+		MRef    string
+		Pattern string
+		Want    bool
+	}{
+		{
+			MRef:    geminiMRef,
+			Pattern: "google*",
+			Want:    true,
+		},
+		{
+			MRef:    geminiMRef,
+			Pattern: "google::v1::*",
+			Want:    true,
+		},
+		{
+			MRef:    geminiMRef,
+			Pattern: "*",
+			Want:    true,
+		},
+		{
+			MRef:    geminiMRef,
+			Pattern: "*v1*",
+			Want:    true,
+		},
+		{
+			MRef:    geminiMRef,
+			Pattern: "*::gemini-1.5-pro-latest",
+			Want:    true,
+		},
+		{
+			MRef:    geminiMRef,
+			Pattern: "*::gpt-4o",
+			Want:    false,
+		},
+
+		// Negative tests.
+		{
+			MRef:    geminiMRef,
+			Pattern: "*::gpt-4o",
+			Want:    false,
+		},
+		{
+			MRef:    geminiMRef,
+			Pattern: "*::v2::*",
+			Want:    false,
+		},
+		{
+			MRef:    geminiMRef,
+			Pattern: "google::v1::gemini-1.5-pro", // Doesn't end with "-latest"
+			Want:    false,
+		},
+		{
+			MRef:    geminiMRef,
+			Pattern: "anthropic*",
+			Want:    false,
+		},
+	}
+
+	for _, test := range tests {
+		got := filterListMatches(types.ModelRef(test.MRef), []string{test.Pattern})
+		assert.Equal(t, test.Want, got, "mref: %q\npattern: %q", test.MRef, test.Pattern)
+	}
+}
+
+func TestModelConfigBuilder(t *testing.T) {
+	t.Run("NoOverrides", func(t *testing.T) {
+		baseConfig, err := embedded.GetCodyGatewayModelConfig()
+		require.NoError(t, err)
+
+		siteConfig := types.SiteModelConfiguration{
+			// Keep non-nil, but leave everything else zeroed out.
+			SourcegraphModelConfig: &types.SourcegraphModelConfig{},
+			ProviderOverrides:      nil,
+			ModelOverrides:         nil,
+		}
+
+		result, err := applySiteConfig(baseConfig, &siteConfig)
+		require.NoError(t, err)
+
+		// We need to refetch the base config, since baseConfig will be
+		// modified as a side-effect of calling applySiteConfig.
+		refetchedBaseConfig, err := embedded.GetCodyGatewayModelConfig()
+		require.NoError(t, err)
+
+		require.EqualValues(t, *refetchedBaseConfig, *result)
+	})
+
+	t.Run("LegacyCompletionsConfig", func(t *testing.T) {
+		// Load the LLM model configuration expressed via the "completions" config.
+		siteConfig := convertLegacyCompletionsConfig(&schema.Completions{
+			Provider:        "aws-bedrock",
+			ChatModel:       "anthropic.claude-3-opus-20240229-v1:0",
+			CompletionModel: "anthropic.claude-instant-v1",
+			// FastChatMode is not set.
+
+			AccessToken: "secret",
+			Endpoint:    "https://example.com",
+		})
+
+		// BUG: Need to confirm the awkward syntax for AWS Bedrock, see:
+		// https://sourcegraph.com/docs/cody/clients/enable-cody-enterprise#use-amazon-bedrock-aws
+		// "completionModel": "anthropic.claude-instant-v1"
+
+		baseConfig, err := embedded.GetCodyGatewayModelConfig()
+		require.NoError(t, err)
+
+		outConfig, err := applySiteConfig(baseConfig, siteConfig)
+		require.NoError(t, err)
+
+		require.Equal(t, 1, len(outConfig.Providers))
+		provider := outConfig.Providers[0]
+		assert.EqualValues(t, "aws-bedrock", string(provider.ID))
+		assert.NotNil(t, provider.ServerSideConfig)
+
+		serverSideConfig := provider.ServerSideConfig
+		require.NotNil(t, serverSideConfig)
+		require.NotNil(t, serverSideConfig.GenericProvider)
+		assert.Equal(t, "secret", serverSideConfig.GenericProvider.AccessToken)
+		assert.Equal(t, "https://example.com", serverSideConfig.GenericProvider.Endpoint)
+
+		// Default models.
+		defModels := outConfig.DefaultModels
+		assert.EqualValues(t, "anthropic.claude-3-opus-20240229-v1:0", defModels.Chat)
+		assert.EqualValues(t, "", defModels.FastChat)
+		assert.EqualValues(t, "anthropic.claude-instant-v1", defModels.CodeCompletion)
+	})
+}

--- a/cmd/frontend/internal/modelconfig/httpapi.go
+++ b/cmd/frontend/internal/modelconfig/httpapi.go
@@ -1,0 +1,62 @@
+package modelconfig
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/sourcegraph/log"
+
+	"github.com/sourcegraph/sourcegraph/internal/actor"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	modelconfigSDK "github.com/sourcegraph/sourcegraph/internal/modelconfig"
+)
+
+// HTTP handlers for interacting with this Sourcegraph instance's
+// LLM Model configuration. These handlers perform auth checks.
+type HTTPHandlers struct {
+	db     database.DB
+	logger log.Logger
+}
+
+func NewHandlers(db database.DB, logger log.Logger) *HTTPHandlers {
+	return &HTTPHandlers{
+		db:     db,
+		logger: logger,
+	}
+}
+
+// GetSupportedModelsHandler returns the current Sourcegraph instance's LLM model configuration
+// data as JSON. Requires that the calling user is an authenticated.
+func (h *HTTPHandlers) GetSupportedModelsHandler(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	h.logger.Info("fetching supported LLMs")
+
+	// Auth check.
+	callingActor := actor.FromContext(ctx)
+	if callingActor == nil || !callingActor.IsAuthenticated() {
+		h.logger.Warn("unauthenticated user requesting model config")
+		http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
+		return
+	}
+
+	modelConfigSvc := Get()
+	currentConfig, err := modelConfigSvc.Get()
+	if err != nil {
+		h.logger.Error("fetching current model configuration", log.Error(err))
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		return
+	}
+
+	// SECURITY: It's critical that we do not serve any server-side configuration data
+	// to the client, as it contains sensitive data like access tokens.
+	modelconfigSDK.RedactServerSideConfig(currentConfig)
+
+	rawJSON, err := json.MarshalIndent(currentConfig, "", "    ")
+	if err != nil {
+		h.logger.Error("marshalling configuration", log.Error(err))
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		return
+	}
+	http.Error(w, string(rawJSON), http.StatusOK)
+}

--- a/cmd/frontend/internal/modelconfig/init.go
+++ b/cmd/frontend/internal/modelconfig/init.go
@@ -1,0 +1,131 @@
+package modelconfig
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+
+	"github.com/sourcegraph/log"
+
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/enterprise"
+	_ "github.com/sourcegraph/sourcegraph/cmd/frontend/internal/auth"
+	_ "github.com/sourcegraph/sourcegraph/cmd/frontend/internal/registry"
+	"github.com/sourcegraph/sourcegraph/internal/codeintel"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/modelconfig/embedded"
+	"github.com/sourcegraph/sourcegraph/internal/modelconfig/types"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"github.com/sourcegraph/sourcegraph/schema"
+)
+
+// Init is the initalization function wired into the `frontend` application startup.
+// This registers the necessary watchers and hooks so that the `Service` can always
+// have an up-to-date view of this Sourcegraph instance's configuration data.
+func Init(
+	ctx context.Context,
+	observationCtx *observation.Context,
+	db database.DB,
+	codeIntelServices codeintel.Services,
+	initialConf conftypes.UnifiedWatchable,
+	enterpriseServices *enterprise.Services,
+) error {
+	// Ensure that we only regsiter this once.
+	if singletonConfigService != nil {
+		return errors.New("the Init function has already been called")
+	}
+
+	logger := log.Scoped("modelconfig")
+
+	initialSiteConfig := initialConf.SiteConfig()
+	// If Cody isn't enabled on startup, we don't bother registering anything. (Because there is no need to.)
+	if codyEnabled := initialSiteConfig.CodyEnabled; codyEnabled == nil || *codyEnabled == false {
+		logger.Info("Cody is not enabled, not registering ModelConfigService")
+		return nil
+	}
+
+	// The base model configuration data is what is embedded in this binary.
+	staticModelConfig, err := embedded.GetCodyGatewayModelConfig()
+	if err != nil {
+		return errors.New("embedded model data is missing or corrupt")
+	}
+
+	// Load the newer form of LLM model configuration data.
+	siteModelConfig, err := loadModelConfigFromSiteConfig(initialSiteConfig)
+	if err != nil {
+		// BUG: This might be incorrect. If the service cannot start up because of bad site
+		// configuration, then it also means that there is no way for an admin to fix the
+		// problem. So this might require some thought.
+		return errors.New("error loading configuration data via site config")
+	}
+
+	// Now build the initial view of the Sourcegraph instance's model configuration using this data.
+	configBuilder := builder{
+		staticData:      staticModelConfig,
+		codyGatewayData: nil,
+		siteConfigData:  siteModelConfig,
+	}
+	initialConfig, err := configBuilder.build()
+	if err != nil {
+		return errors.Wrap(err, "building initial model configuration")
+	}
+
+	// Register the initial singletonConfigService.
+	initialConfigSvc := service{
+		currentConfig: initialConfig,
+	}
+	singletonConfigService = &initialConfigSvc
+
+	// Register a watcher to pull in updates whenever the site config changes.
+	conf.Watch(func() {
+		logger.Info("site config updated, recalculating model configuration")
+
+		latestSiteConfig := conf.Get().SiteConfiguration
+		latestModelConfig, err := loadModelConfigFromSiteConfig(latestSiteConfig)
+		if err != nil {
+			logger.Error("error loading model configuration via site config", log.Error(err))
+			return
+		}
+
+		// Update and rebuild the LLM model configuration.
+		//
+		// BUG: We currently don't need a mutex on `configBuilder` because there
+		// is only one writer (this callback). But when we wire up the Cody Gateway
+		// polling, we'll need to address that. Perhaps as a "<-chan configUpdate"
+		configBuilder.siteConfigData = latestModelConfig
+		updatedConfig, err := configBuilder.build()
+		if err != nil {
+			logger.Error("error regenerating model config based on site config update", log.Error(err))
+			return
+		}
+
+		singletonConfigService.set(updatedConfig)
+	})
+
+	// TODO(chrsmith): When the enhanced model configuration data is available, if configured to do so
+	// we will spawn a background job that will poll Cody Gateway for any updated model information. This
+	// will be tricky, because we want to honor any dynamic changes to the site config. e.g. the `conf.Watch`
+	// callback needs to be able to stop/restart/update the way the poller works in response to changes.
+	return nil
+}
+
+func loadModelConfigFromSiteConfig(siteConfig schema.SiteConfiguration) (*types.SiteModelConfiguration, error) {
+	// TODO(chrsmith): Encode this in the site.schema.json. Until then, we use a glorious hack
+	// to pull this from an environment variable if possible.
+	if fauxConfigJSON := os.Getenv("HACK_FAUX_MODELSOURCES_CONFIG_JSON"); fauxConfigJSON == "" {
+		// If no "newer style" model configuration data was specified, fall back to converting
+		// any settings from Sourcegraph v5.3 and prior. i.e. the "completions" object.
+		//
+		// TODO(chrsmith): When we wire up the new model schema, specifying both forms should be an error.
+		return convertLegacyCompletionsConfig(siteConfig.Completions), nil
+	} else {
+		// Otherwise, parse the env var and use that as the siteModelConfig.
+		var siteModelConfig types.SiteModelConfiguration
+		if err := json.Unmarshal([]byte(fauxConfigJSON), &siteModelConfig); err != nil {
+			return nil, errors.Wrap(err, "unmarshalling config data from 'HACK_FAUX_MODELSOURCES_CONFIG_JSON'")
+		}
+		return &siteModelConfig, nil
+	}
+}

--- a/cmd/frontend/internal/modelconfig/service.go
+++ b/cmd/frontend/internal/modelconfig/service.go
@@ -1,0 +1,174 @@
+package modelconfig
+
+import (
+	"encoding/json"
+	"fmt"
+	"sync"
+
+	"github.com/sourcegraph/sourcegraph/internal/modelconfig/types"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"github.com/sourcegraph/sourcegraph/schema"
+)
+
+// Service is the system-wide component for obtaining the set of
+// LLM models the current Sourcegraph instance is configured to use.
+//
+// You can obtain the global, package-level instance of this interface by
+// calling the Get() method. It is safe for concurrent reads.
+//
+// Updating the system's model configuration is done by updating the Site
+// Configuration. The implementation of the Service will listen
+// for configuration changes and update the ModelConfiguration object in-
+// memory as appropriate.
+type Service interface {
+	// Get returns the current model configuration for this Sourcegraph instance.
+	// Callers should not modify the returned data, and treat it as if it were
+	// immutable.
+	Get() (*types.ModelConfiguration, error)
+}
+
+// Global instance of the model config service. We don't initialize via
+// a sync.Once because we ensure Init cannot be called twice, and assume it
+// will not be called concurrently.
+var singletonConfigService *service
+
+// Get returns the singleton ModelConfigService.
+//
+// This requires that the Init function has been called before hand, which
+// is typically done on application startup.
+func Get() Service {
+	if singletonConfigService == nil {
+		panic("ModelConfigService not initialized. Init not called.")
+	}
+	return singletonConfigService
+}
+
+// service implements the Service interface, and exposes a thread-safe `set` method
+// for updating the current configuration.
+type service struct {
+	// currentConfig is the "source of truth" for this Sg instance's model configuration.
+	currentConfig   *types.ModelConfiguration
+	currentConfigMu sync.RWMutex
+}
+
+func (svc *service) Get() (*types.ModelConfiguration, error) {
+	svc.currentConfigMu.RLock()
+	defer svc.currentConfigMu.RUnlock()
+
+	// Create a deep copy of the current configuration, so callers can operate on
+	// older versions without worrying about data races or other types of errors.
+	cfgCopy, err := deepCopy(svc.currentConfig)
+	if err != nil {
+		return nil, err
+	}
+	return cfgCopy, nil
+}
+
+// set updates the set.currentConfig to the supplied value. It is assumped that
+// the Service will "own" the pointer, and the caller will no longer modify it.
+func (svc *service) set(newConfig *types.ModelConfiguration) {
+	// Block until the lock is available.
+	svc.currentConfigMu.Lock()
+	defer svc.currentConfigMu.Unlock()
+
+	svc.currentConfig = newConfig
+}
+
+// deepCopy returns a deep copy of the entire ModelConfiguration data structure.
+func deepCopy(source *types.ModelConfiguration) (*types.ModelConfiguration, error) {
+	// Rather than manage all the boiler plage by hand, or resorting to reflection
+	// we just round-trip the configuration data through JSON.
+	//
+	// This means that ALL fields in the types package MUST be exported, since
+	// unexported fields will silently be dropped by JSON marshalling. But that's
+	// not a problem in-practice.
+	bytes, err := json.Marshal(source)
+	if err != nil {
+		return nil, errors.Wrap(err, "marshalling source config")
+	}
+
+	var cfgCopy types.ModelConfiguration
+	if err = json.Unmarshal(bytes, &cfgCopy); err != nil {
+		return nil, errors.Wrap(err, "unmarshalling source config")
+	}
+
+	return &cfgCopy, nil
+}
+
+func convertLegacyCompletionsConfig(completionsCfg *schema.Completions) *types.SiteModelConfiguration {
+	if completionsCfg == nil {
+		return nil
+	}
+
+	chatModelRef := fmt.Sprintf("%s/unknown/%s", completionsCfg.Provider, completionsCfg.ChatModel)
+	fastModelRef := fmt.Sprintf("%s/unknown/%s", completionsCfg.Provider, completionsCfg.FastChatModel)
+	autocompleteModelRef := fmt.Sprintf("%s/unknown/%s", completionsCfg.Provider, completionsCfg.CompletionModel)
+
+	baseConfig := types.SiteModelConfiguration{
+		// Don't use any Sourcegraph-supplied model information.
+		SourcegraphModelConfig: nil,
+
+		ProviderOverrides: []types.ProviderOverride{
+			{
+				ID:               types.ProviderID(completionsCfg.Provider),
+				ClientSideConfig: nil,
+				ServerSideConfig: &types.ServerSideProviderConfig{
+					GenericProvider: &types.GenericProviderConfig{
+						AccessToken: completionsCfg.AccessToken,
+						Endpoint:    completionsCfg.Endpoint,
+					},
+				},
+
+				DefaultModelConfig: &types.DefaultModelConfig{
+					Capabilities: []types.ModelCapability{
+						types.ModelCapabilityAutocomplete,
+						types.ModelCapabilityChat,
+					},
+					Category: types.ModelCategoryBalanced,
+					Status:   types.ModelStatusStable,
+					Tier:     types.ModelTierEnterprise,
+				},
+			},
+		},
+
+		ModelOverrides: []types.ModelOverride{
+			{
+				ModelRef:    types.ModelRef(chatModelRef),
+				DisplayName: completionsCfg.ChatModel,
+				ModelName:   completionsCfg.ChatModel,
+
+				ContextWindow: types.ContextWindow{
+					MaxInputTokens:  completionsCfg.ChatModelMaxTokens,
+					MaxOutputTokens: 4000,
+				},
+			},
+			{
+				ModelRef:    types.ModelRef(fastModelRef),
+				DisplayName: completionsCfg.FastChatModel,
+				ModelName:   completionsCfg.FastChatModel,
+
+				ContextWindow: types.ContextWindow{
+					MaxInputTokens:  completionsCfg.FastChatModelMaxTokens,
+					MaxOutputTokens: 4000,
+				},
+			},
+			{
+				ModelRef:    types.ModelRef(autocompleteModelRef),
+				DisplayName: completionsCfg.CompletionModel,
+				ModelName:   completionsCfg.CompletionModel,
+
+				ContextWindow: types.ContextWindow{
+					MaxInputTokens:  completionsCfg.CompletionModelMaxTokens,
+					MaxOutputTokens: 4000,
+				},
+			},
+		},
+
+		DefaultModels: &types.DefaultModels{
+			Chat:           types.ModelRef(completionsCfg.ChatModel),
+			CodeCompletion: types.ModelRef(completionsCfg.CompletionModel),
+			FastChat:       types.ModelRef(completionsCfg.FastChatModel),
+		},
+	}
+	return &baseConfig
+}

--- a/cmd/frontend/shared/BUILD.bazel
+++ b/cmd/frontend/shared/BUILD.bazel
@@ -29,6 +29,7 @@ go_library(
         "//cmd/frontend/internal/guardrails",
         "//cmd/frontend/internal/insights",
         "//cmd/frontend/internal/licensing/init",
+        "//cmd/frontend/internal/modelconfig",
         "//cmd/frontend/internal/notebooks",
         "//cmd/frontend/internal/own",
         "//cmd/frontend/internal/rbac",

--- a/cmd/frontend/shared/shared.go
+++ b/cmd/frontend/shared/shared.go
@@ -12,6 +12,18 @@ import (
 
 	"github.com/sourcegraph/log"
 
+	// sourcegraph/internal
+	"github.com/sourcegraph/sourcegraph/internal/codeintel"
+	codeintelshared "github.com/sourcegraph/sourcegraph/internal/codeintel/shared"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	connections "github.com/sourcegraph/sourcegraph/internal/database/connections/live"
+	"github.com/sourcegraph/sourcegraph/internal/httpcli"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
+	"github.com/sourcegraph/sourcegraph/schema"
+
+	// sourcegraph/cmd/frontend/internal
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/enterprise"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/auth"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/authz"
@@ -30,6 +42,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/guardrails"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/insights"
 	licensing "github.com/sourcegraph/sourcegraph/cmd/frontend/internal/licensing/init"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/modelconfig"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/notebooks"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/own"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/rbac"
@@ -39,15 +52,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/search"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/searchcontexts"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/telemetry"
-	"github.com/sourcegraph/sourcegraph/internal/codeintel"
-	codeintelshared "github.com/sourcegraph/sourcegraph/internal/codeintel/shared"
-	"github.com/sourcegraph/sourcegraph/internal/conf"
-	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
-	"github.com/sourcegraph/sourcegraph/internal/database"
-	connections "github.com/sourcegraph/sourcegraph/internal/database/connections/live"
-	"github.com/sourcegraph/sourcegraph/internal/httpcli"
-	"github.com/sourcegraph/sourcegraph/internal/observation"
-	"github.com/sourcegraph/sourcegraph/schema"
 )
 
 type EnterpriseInitializer = func(context.Context, *observation.Context, database.DB, codeintel.Services, conftypes.UnifiedWatchable, *enterprise.Services) error
@@ -66,6 +70,7 @@ var initFunctions = map[string]EnterpriseInitializer{
 	"guardrails":     guardrails.Init,
 	"insights":       insights.Init,
 	"licensing":      licensing.Init,
+	"modelconfig":    modelconfig.Init,
 	"notebooks":      notebooks.Init,
 	"own":            own.Init,
 	"rbac":           rbac.Init,

--- a/internal/modelconfig/BUILD.bazel
+++ b/internal/modelconfig/BUILD.bazel
@@ -3,7 +3,10 @@ load("//dev:go_defs.bzl", "go_test")
 
 go_library(
     name = "modelconfig",
-    srcs = ["validation.go"],
+    srcs = [
+        "util.go",
+        "validation.go",
+    ],
     importpath = "github.com/sourcegraph/sourcegraph/internal/modelconfig",
     visibility = ["//:__subpackages__"],
     deps = [
@@ -15,7 +18,10 @@ go_library(
 
 go_test(
     name = "modelconfig_test",
-    srcs = ["validation_test.go"],
+    srcs = [
+        "until_test.go",
+        "validation_test.go",
+    ],
     embed = [":modelconfig"],
     deps = [
         "//internal/modelconfig/embedded",

--- a/internal/modelconfig/types/BUILD.bazel
+++ b/internal/modelconfig/types/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
         "model.go",
         "provider.go",
         "refs.go",
+        "site_config.go",
     ],
     importpath = "github.com/sourcegraph/sourcegraph/internal/modelconfig/types",
     visibility = ["//:__subpackages__"],

--- a/internal/modelconfig/types/configuration.go
+++ b/internal/modelconfig/types/configuration.go
@@ -37,9 +37,22 @@ type AzureOpenAIProviderConfig struct {
 	Endpoint string `json:"endpoint"`
 }
 
+// GenericProvider is the generic format that older Sourcegraph instances used.
+//
+// Try to avoid using this where possible, and instead rely on the more specific
+// types like `AzureOpenAIProviderConfig`. Even if they only contain the same fields.
+// This allows us to more gracefully migrate customers forward as the API providers
+// and associated API clients evolve. e.g. giving us the possibility of providing
+// defaults for any missing configuration settings that get added later.
+type GenericProviderConfig struct {
+	AccessToken string `json:"accessToken"`
+	Endpoint    string `json:"endpoint"`
+}
+
 type ServerSideProviderConfig struct {
-	AWSBedrock  *AWSBedrockProviderConfig  `json:"awsBedrock"`
-	AzureOpenAI *AzureOpenAIProviderConfig `json:"azureOpenAi"`
+	AWSBedrock      *AWSBedrockProviderConfig  `json:"awsBedrock,omitempty"`
+	AzureOpenAI     *AzureOpenAIProviderConfig `json:"azureOpenAi,omitempty"`
+	GenericProvider *GenericProviderConfig     `json:"genericProviderConfig,omitempty"`
 }
 
 // ========================================================

--- a/internal/modelconfig/types/documents.go
+++ b/internal/modelconfig/types/documents.go
@@ -19,3 +19,89 @@ type ModelConfiguration struct {
 
 	DefaultModels DefaultModels `json:"defaultModels"`
 }
+
+// SiteModelConfiguration is the data type that is encoded into the site configuration schema,
+// and in `site.schema.json`.
+type SiteModelConfiguration struct {
+	// SourcegraphModelConfig is the configuration for Sourcegraph-supplied LLM data.
+	// We will provide reasonable defaults for all of all the fields in this. If set to
+	// nil, the Sourcegraph instance will not have _any_ LLM models available by default.
+	// And will only have admin-defined providers and models.
+	SourcegraphModelConfig *SourcegraphModelConfig `json:"sourcegraph"`
+
+	// ProviderOverrides is the section where the Sourcegraph admin configures LLM providers.
+	// (Since the "default provider" information essentially means "use Cody Gateway".) So
+	// by supplying configuration data here is how BYOK or BYOLLM is configured.
+	//
+	// e.g. the following configuration will use the user-supplied API key and endpoint for
+	// all OpenAI-supplied LLM models. And use AWS Bedrock and its associated config for
+	// all Anthropic. models.
+	//
+	// ```
+	// "providerOverrides": [
+	//     {
+	//          "id": "openai",
+	//          "serverSideConfig": {
+	//              "openaiCompatible": {
+	//                  "accessToken": "secret",
+	//                  "endpoint": "https://llm-models-r-us.com/"
+	//              }
+	//          }
+	//      },
+	//      {
+	//          "id": "anthropic",
+	//          "serverSideConfig": {
+	// 	            "awsBedrockConfig": {
+	// 		            "region": "us-west-2",
+	//                  "accessKeyId": "AK...",
+	//                  "secretAccessKey": "...",
+	//                  "sessionToken": "..."
+	//              }
+	// 	        },
+	//          "defaultModelConfig": {
+	//              "clientSideConfig": { ... }
+	//          }
+	//      }
+	// ]
+	// ```
+	//
+	// NOTE: With this approach it's possible to supply an invalid configuration. For
+	// example, the ProviderID could be "google" but providing configuration information
+	// for routing those requests to Azure AI, which may not serve any Google models.
+	//
+	// BUG: With this appraoch, it is all-or-nothing when using admin-supplied provider
+	// data. So you couldn't have "only some" Anthropic models routed to AWS Bedrock,
+	// but all the rest get sent to Cody Gateway.
+	ProviderOverrides []ProviderOverride `json:"providerOverrides"`
+
+	// ModelOverrides will either "overwrite" or "add-to" the list of models supplied
+	// by Sourcegraph.
+	//
+	// If the ModelRef matches a model supplied from Sourcegraph, any non-empty settings
+	// will overwrite the Sourcegraph-supplied defaults. e.g. the following will use an
+	// expanded context window from what Sourcegraph supplied:
+	//
+	// ```
+	// "modelOverrides": [
+	//     ...
+	//     {
+	//         "modelRef": "anthropic::2023-06-01::claude-3-sonnet",
+	//         "contextWindow": {
+	//		       "maxInputTokens": 200000,
+	//	           "maxOutputTokens": 20000
+	//         }
+	//     }
+	//     ...
+	// ]
+	// ```
+	//
+	// If the ModelRef is unknown (e.g. the Sourcegraph-supplied model was removed
+	// via the SourcegraphModelConfig's deny list.) In that case, all model settings
+	// need to be supplied, either explicitly or by the provider's DefaultModelConfig.
+	ModelOverrides []ModelOverride `json:"modelOverrides"`
+
+	// DefaultModels to use. If unset, fall back to the default models from the
+	// Sourcegraph-supplied configuration data. Otherwise, will fallback to any
+	// any model that supports the required capabilities.
+	DefaultModels *DefaultModels `json:"defaultModels"`
+}

--- a/internal/modelconfig/types/model.go
+++ b/internal/modelconfig/types/model.go
@@ -40,6 +40,8 @@ const (
 )
 
 type Model struct {
+	// BUG? Why don't we just remove this since ID is already encoded in the ModelRef
+	// So it's redundant?
 	ID       ModelID  `json:"modelId"`
 	ModelRef ModelRef `json:"modelRef"`
 

--- a/internal/modelconfig/types/site_config.go
+++ b/internal/modelconfig/types/site_config.go
@@ -1,0 +1,84 @@
+package types
+
+type ModelFilters struct {
+	// CategoryFilter will constrain LLM models to just those supplied in this slice.
+	// e.g. "stable", "beta" will mean that all "experimental" models will be omitted.
+	CategoryFilter []string `json:"categoryFilter"`
+
+	// If provided, only the models matching the supplied ModelReferences will be made
+	// available. Wildcards are allowed, but this does not support arbitrary regular
+	// expressions.
+	//
+	// e.g. [ "anthropic::*", "openai::2024-02-01::*" ] would include all Anthropic-
+	// supplied models and models using a particular API Version of OpenAI.
+	Allow []string `json:"allow"`
+	// Deny will remove any models whose ModelReference matches the supplied string.
+	// e.g. [ "*gpt*" ] will remove any LLMs that have "gpt" anywhere in the mref.
+	Deny []string `json:"deny"`
+}
+
+// SourcegraphModelConfig is how we represent the configuration of Sourcegraph-supplied
+// LLM models to the Sourcegraph instance.
+type SourcegraphModelConfig struct {
+
+	// PollingInterval is the frequency by which this instance should poll Cody Gateway
+	// for an updated list of LLM models. e.g. "6h" or "1d". Or "never" to disable this
+	// capability entirely.
+	PollingInterval *string `json:"pollingInterval"`
+	// Endpoint is the Cody Gateway URL that will be polled in order to pick up new
+	// LLM models as they are released..
+	Endpoint *string `json:"endpoint"`
+
+	// ModelFilters provide a way for the Sourcegraph admin to constrain the set of
+	// LLM models made available, e.g. to only "stable" models. Or those from
+	// particular providers.
+	ModelFilters *ModelFilters `json:"modelFilters"`
+}
+
+// DefaultModelConfig is the model configuration that is applied to every LLM model
+// for a given provider. This allows Sourcegraph admins to set common configuration
+// settings once.
+type DefaultModelConfig struct {
+	// The fields here are a subset of those defined on `Model`
+
+	Capabilities []ModelCapability `json:"capabilities"`
+	Category     ModelCategory     `json:"category"`
+	Status       ModelStatus       `json:"status"`
+	Tier         ModelTier         `json:"tier"`
+
+	ContextWindow ContextWindow `json:"contextWindow"`
+
+	ClientSideConfig *ClientSideModelConfig `json:"clientSideConfig,omitempty"`
+	ServerSideConfig *ServerSideModelConfig `json:"serverSideConfig,omitempty"`
+}
+
+// ProviderOverride is how a Sourcegraph admin would describe a `Provider` within
+// the site-configuration.
+type ProviderOverride struct {
+	ID ProviderID `json:"id"`
+
+	ClientSideConfig *ClientSideProviderConfig `json:"clientSideConfig,omitempty"`
+	ServerSideConfig *ServerSideProviderConfig `json:"serverSideConfig,omitempty"`
+
+	DefaultModelConfig *DefaultModelConfig `json:"defaultModelConfig"`
+}
+
+// ModelOverride is how a Sourcegraph admin would describe a `Model` with the
+// the site-configuration. This will either overwrite the existing set of model
+// fields, or add an entirely new model.
+type ModelOverride struct {
+	ModelRef ModelRef `json:"modelRef"`
+
+	DisplayName string `json:"displayName"`
+	ModelName   string `json:"string"`
+
+	Capabilities []ModelCapability `json:"capabilities"`
+	Category     ModelCategory     `json:"category"`
+	Status       ModelStatus       `json:"status"`
+	Tier         ModelTier         `json:"tier"`
+
+	ContextWindow ContextWindow `json:"contextWindow"`
+
+	ClientSideConfig *ClientSideModelConfig `json:"clientSideConfig,omitempty"`
+	ServerSideConfig *ServerSideModelConfig `json:"serverSideConfig,omitempty"`
+}

--- a/internal/modelconfig/until_test.go
+++ b/internal/modelconfig/until_test.go
@@ -1,0 +1,50 @@
+package modelconfig
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/sourcegraph/sourcegraph/internal/modelconfig/types"
+)
+
+func TestRedactServerSideConfig(t *testing.T) {
+	testCfg := types.ModelConfiguration{
+		Providers: []types.Provider{
+			{
+				ID: "test-provider-1",
+				ServerSideConfig: &types.ServerSideProviderConfig{
+					AWSBedrock: &types.AWSBedrockProviderConfig{
+						AccessToken: "top-secret",
+					},
+				},
+			},
+			{
+				ID: "test-provider-2",
+				ServerSideConfig: &types.ServerSideProviderConfig{
+					AzureOpenAI: &types.AzureOpenAIProviderConfig{
+						AccessToken: "top-secret",
+					},
+				},
+			},
+		},
+		Models: []types.Model{
+			{
+				ServerSideConfig: &types.ServerSideModelConfig{
+					AWSBedrockProvisionedCapacity: &types.AwsBedrockProvisionedCapacity{
+						ARN: "secret-arn",
+					},
+				},
+			},
+		},
+	}
+
+	RedactServerSideConfig(&testCfg)
+
+	for _, provider := range testCfg.Providers {
+		assert.Nil(t, provider.ServerSideConfig)
+	}
+	for _, model := range testCfg.Models {
+		assert.Nil(t, model.ServerSideConfig)
+	}
+}

--- a/internal/modelconfig/util.go
+++ b/internal/modelconfig/util.go
@@ -1,0 +1,14 @@
+package modelconfig
+
+import "github.com/sourcegraph/sourcegraph/internal/modelconfig/types"
+
+// RedactServerSideConfig modifies the provided ModelConfiguration data in-place to remove
+// all server-side configuration data.
+func RedactServerSideConfig(doc *types.ModelConfiguration) {
+	for i := range doc.Providers {
+		doc.Providers[i].ServerSideConfig = nil
+	}
+	for i := range doc.Models {
+		doc.Models[i].ServerSideConfig = nil
+	}
+}

--- a/internal/modelconfig/validation.go
+++ b/internal/modelconfig/validation.go
@@ -68,6 +68,11 @@ func validateModel(m types.Model) error {
 		return errors.New("id format")
 	}
 
+	// Require that the ModelID matches the supplied ModelRef.
+	if !strings.HasSuffix(string(m.ModelRef), "::"+string(m.ID)) {
+		return errors.New("id does not match modelref")
+	}
+
 	if err := validateModelRef(m.ModelRef); err != nil {
 		return errors.Wrap(err, "modelref")
 	}
@@ -83,5 +88,27 @@ func validateModel(m types.Model) error {
 	// We intentionally do not validate any of the enum metadata fields, because
 	// older Sourcegraph instances wouldn't be able to recognize any newer values.
 
+	return nil
+}
+
+// ValidateSiteConfig validates that the site configuration data expressed is valid.
+func ValidateSiteConfig(doc *types.SiteModelConfiguration) error {
+	// TODO: Verify Sourcegraph
+	// - Endpoint is a valid URL.
+	// - PollingInterval is a valid duration, or "never".
+	// - ModelFilters.CategoryFilter only contains valid categories.
+	// - The strings in the Allow/Deny lists are reasonable, e.g. do not
+	//   contain any whitespaces, more than six colons, etc.
+	// - The Allow/Deny list wildcard strings are well-formed: they may
+	//   only contain an asterisk as the first and/or last character.
+
+	// TODO: Verify ProviderOverrides
+	// - No ProviderIDs are duplicated.
+
+	// TODO: Verify ModelOverrides
+	// - Every model must have a ModelRef. All other fields are optional.
+	// - No ModelRefs are duplicated.
+	// - Every ModelOverride for a ProviderOverrided must have a ModelRef that is
+	//   prefixed by the "${ProviderID}::".
 	return nil
 }

--- a/internal/modelconfig/validation_test.go
+++ b/internal/modelconfig/validation_test.go
@@ -64,6 +64,11 @@ func TestValidationMethods(t *testing.T) {
 				"didn't get expected validation error for mref %q", test.MRef)
 		}
 	})
+
+	t.Run("ValidateModel", func(t *testing.T) {
+		// TODO: Verify error if the model ID doesn't match the model ref.
+		// "id does not match modelref"
+	})
 }
 
 // Confirm that the model data currently in the repo is well-formed and valid.


### PR DESCRIPTION
This PR is a WIP. I'll split this into several smaller ones once I've gotten everything tested and sussed out.

## The sweet, sweet details

This PR introduces a new `frontend/internal/modelconfig` package that exposes a new `Service` interface. It is patterned after the `conf` package, so as needed you can fetch the Sourcegraph instance's current LLM config data via `modelconfig.Get()`.

The `Service` is implemented by in the `init.go` file, which initializes the global variable and keeps it updated as the Sourcegraph instance's site configuration changes.

The way that it exposes LLM model configuration is done via a `builder` type, in `builder.go`. This is where all the gnarly logic that isn't quite finished yet goes.

We combine the "site configuration data", with any "base configuration data" that is embedded in the binary or fetched from Cody Gateway.

I introduced a bunch of data types to contain the new configuration format in the site configuration. It's a little different than what we discussed earlier, because I assume we won't be able to represent it in the `site.schema.json` wouldn't be able to express the way we planned. (But I haven't looked at that part yet, so feel free to rework the types to be easier to express in the site config.)