### PR TITLE
fix Cody nav link for unauthed dotcom users

### DIFF
--- a/client/web/src/LegacyRouteContext.tsx
+++ b/client/web/src/LegacyRouteContext.tsx
@@ -90,7 +90,7 @@ export interface LegacyLayoutRouteContext
         StaticLegacyRouteContext {}
 
 interface LegacyRouteProps {
-    render: (props: LegacyLayoutRouteContext) => JSX.Element
+    render: (props: LegacyLayoutRouteContext) => JSX.Element | null
     condition?: (props: LegacyLayoutRouteContext) => boolean
 }
 

--- a/client/web/src/cody/codyRoutes.tsx
+++ b/client/web/src/cody/codyRoutes.tsx
@@ -14,6 +14,8 @@ const CodySwitchAccountPage = lazyComponent(
 )
 const CodyDashboardPage = lazyComponent(() => import('./dashboard/CodyDashboardPage'), 'CodyDashboardPage')
 
+export const CODY_MARKETING_PAGE_URL = 'https://sourcegraph.com/cody'
+
 /**
  * Use {@link codyProRoutes} for Cody PLG routes.
  */
@@ -22,12 +24,13 @@ export const codyRoutes: RouteObject[] = [
         path: PageRoutes.CodyRedirectToMarketingOrDashboard,
         element: (
             <LegacyRoute
-                render={({ isSourcegraphDotCom }) => (
-                    <Navigate
-                        to={isSourcegraphDotCom ? 'https://sourcegraph.com/cody' : PageRoutes.CodyDashboard}
-                        replace={true}
-                    />
-                )}
+                render={({ isSourcegraphDotCom }) => {
+                    if (isSourcegraphDotCom) {
+                        window.location.href = CODY_MARKETING_PAGE_URL
+                        return null
+                    }
+                    return <Navigate to={PageRoutes.CodyDashboard} replace={true} />
+                }}
                 condition={() => window.context?.codyEnabledOnInstance}
             />
         ),

--- a/client/web/src/nav/GlobalNavbar.test.tsx
+++ b/client/web/src/nav/GlobalNavbar.test.tsx
@@ -83,7 +83,7 @@ describe('GlobalNavbar', () => {
         )
         expect(describeNavBar(baseElement)).toEqual<NavBarTestDescription>({
             codyItemType: 'link',
-            codyItemLink: '/cody',
+            codyItemLink: 'https://sourcegraph.com/cody',
         })
     })
 
@@ -151,7 +151,7 @@ describe('GlobalNavbar', () => {
                 <GlobalNavbar {...PROPS} />
             </MockedTestProvider>
         )
-        expect(baseElement.querySelector('a[href^="/cody"]')).toBeNull()
+        expect(baseElement.querySelector('a[href*="cody"]')).toBeNull()
         expect(describeNavBar(baseElement)).toEqual<NavBarTestDescription>({ codyItemType: 'none' })
     })
 })
@@ -174,7 +174,7 @@ function describeNavBar(baseElement: HTMLElement): NavBarTestDescription {
         }
     }
 
-    const item = baseElement.querySelector<HTMLAnchorElement>('a[href^="/cody"]')
+    const item = baseElement.querySelector<HTMLAnchorElement>('a[href*="cody"]')
     return item
         ? {
               codyItemType: 'link',

--- a/client/web/src/nav/GlobalNavbar.tsx
+++ b/client/web/src/nav/GlobalNavbar.tsx
@@ -30,6 +30,7 @@ import type { BatchChangesProps } from '../batches'
 import { BatchChangesNavItem } from '../batches/BatchChangesNavItem'
 import type { CodeMonitoringProps } from '../codeMonitoring'
 import { CodyProRoutes } from '../cody/codyProRoutes'
+import { CODY_MARKETING_PAGE_URL } from '../cody/codyRoutes'
 import { CodyLogo } from '../cody/components/CodyLogo'
 import { BrandLogo } from '../components/branding/BrandLogo'
 import { useFuzzyFinderFeatureFlags } from '../components/fuzzyFinder/FuzzyFinderFeatureFlag'
@@ -360,7 +361,7 @@ export const InlineNavigationPanel: FC<InlineNavigationPanelProps> = props => {
         <NavItem icon={() => <CodyLogoWrapper />} key="cody">
             <NavLink
                 variant={navLinkVariant}
-                to={isSourcegraphDotCom ? PageRoutes.CodyRedirectToMarketingOrDashboard : PageRoutes.CodyDashboard}
+                to={isSourcegraphDotCom ? CODY_MARKETING_PAGE_URL : PageRoutes.CodyDashboard}
             >
                 Cody
             </NavLink>

--- a/client/web/src/nav/new-global-navigation/NewGlobalNavigationBar.test.tsx
+++ b/client/web/src/nav/new-global-navigation/NewGlobalNavigationBar.test.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 
-import { AuthenticatedUser } from '@sourcegraph/shared/src/auth'
+import type { AuthenticatedUser } from '@sourcegraph/shared/src/auth'
 import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
 import { renderWithBrandedContext } from '@sourcegraph/wildcard/src/testing'
 
@@ -68,7 +68,7 @@ describe('NewGlobalNavigationBar', () => {
         )
         const sidebarElement = baseElement.querySelector<HTMLElement>('[data-reach-dialog-overlay]')!
         expect(describeNavBarSideMenu(sidebarElement)).toEqual<NavBarTestDescription>({
-            codyItems: ['Cody /cody'],
+            codyItems: ['Cody https://sourcegraph.com/cody'],
         })
     })
 
@@ -137,7 +137,7 @@ describe('NewGlobalNavigationBar', () => {
             </MockedTestProvider>
         )
         const sidebarElement = baseElement.querySelector<HTMLElement>('[data-reach-dialog-overlay]')!
-        expect(sidebarElement.querySelector('a[href*="/cody"]')).toBeNull()
+        expect(sidebarElement.querySelector('a[href*="cody"]')).toBeNull()
         expect(describeNavBarSideMenu(sidebarElement)).toEqual<NavBarTestDescription>({ codyItems: [] })
     })
 })
@@ -148,7 +148,7 @@ interface NavBarTestDescription {
 
 function describeNavBarSideMenu(sidebarElement: HTMLElement): NavBarTestDescription {
     return {
-        codyItems: Array.from(sidebarElement.querySelectorAll<HTMLAnchorElement>('a[href^="/cody"]')).map(
+        codyItems: Array.from(sidebarElement.querySelectorAll<HTMLAnchorElement>('a[href*="cody"]')).map(
             a => `${a.textContent?.trim() ?? ''} ${a.getAttribute('href') ?? ''}`
         ),
     }

--- a/client/web/src/nav/new-global-navigation/NewGlobalNavigationBar.tsx
+++ b/client/web/src/nav/new-global-navigation/NewGlobalNavigationBar.tsx
@@ -18,6 +18,7 @@ import { Button, ButtonLink, Icon, Link, Modal, ProductStatusBadge, Text } from 
 import type { AuthenticatedUser } from '../../auth'
 import { BatchChangesIconNav } from '../../batches/icons'
 import { CodyProRoutes } from '../../cody/codyProRoutes'
+import { CODY_MARKETING_PAGE_URL } from '../../cody/codyRoutes'
 import { CodyLogo } from '../../cody/components/CodyLogo'
 import { BrandLogo } from '../../components/branding/BrandLogo'
 import { DeveloperSettingsGlobalNavItem } from '../../devsettings/DeveloperSettingsGlobalNavItem'
@@ -391,7 +392,7 @@ const SidebarNavigation: FC<SidebarNavigationProps> = props => {
                                 isSourcegraphDotCom
                                     ? window.context.codyEnabledForCurrentUser
                                         ? CodyProRoutes.Manage
-                                        : PageRoutes.CodyRedirectToMarketingOrDashboard
+                                        : CODY_MARKETING_PAGE_URL
                                     : PageRoutes.CodyDashboard
                             }
                             icon={CodyLogo}


### PR DESCRIPTION
Previously, this took users to `https://sourcegraph.com/https://sourcegraph.com/cody`, which was because it used `<Navigate />` incorrectly. Now it correctly takes you to https://sourcegraph.com/cody.


## Test plan

Test locally in dotcom mode