### PR TITLE
make Cody and Code Search global navbar items one-click

### DIFF
--- a/client/web/src/integration/nav.test.ts
+++ b/client/web/src/integration/nav.test.ts
@@ -1,22 +1,22 @@
 import { subDays } from 'date-fns'
 import expect from 'expect'
-import { describe, test, before, afterEach, beforeEach, after } from 'mocha'
+import { after, afterEach, before, beforeEach, describe, test } from 'mocha'
 
 import { encodeURIPathComponent } from '@sourcegraph/common'
 import type { SharedGraphQlOperations } from '@sourcegraph/shared/src/graphql-operations'
 import { mixedSearchStreamEvents } from '@sourcegraph/shared/src/search/integration/streaming-search-mocks'
-import { type Driver, createDriverForTest } from '@sourcegraph/shared/src/testing/driver'
+import { createDriverForTest, type Driver } from '@sourcegraph/shared/src/testing/driver'
 import { afterEachSaveScreenshotIfFailed } from '@sourcegraph/shared/src/testing/screenshotReporter'
 
 import type { NotebookFields, WebGraphQlOperations } from '../graphql-operations'
 
-import { type WebIntegrationTestContext, createWebIntegrationTestContext } from './context'
+import { createWebIntegrationTestContext, type WebIntegrationTestContext } from './context'
 import {
-    createResolveRepoRevisionResult,
-    createFileExternalLinksResult,
     createBlobContentResult,
-    createTreeEntriesResult,
+    createFileExternalLinksResult,
     createFileNamesResult,
+    createResolveRepoRevisionResult,
+    createTreeEntriesResult,
 } from './graphQlResponseHelpers'
 import { commonWebGraphQlResults } from './graphQlResults'
 import { createEditorAPI, removeContextFromQuery } from './utils'
@@ -106,68 +106,6 @@ describe('GlobalNavbar', () => {
             expect(removeContextFromQuery((await input.getValue()) ?? '')).toStrictEqual(
                 'repo:^github\\.com/sourcegraph/sourcegraph$ file:^README\\.md'
             )
-        })
-    })
-
-    describe('Code Search Dropdown', () => {
-        test('is highlighted on search page', async () => {
-            await driver.page.goto(driver.sourcegraphBaseUrl + '/search?q=test&patternType=regexp')
-            await driver.page.waitForSelector('[data-test-id="/search"]')
-            await driver.page.waitForSelector('[data-test-active="true"]')
-
-            const active = await driver.page.evaluate(() =>
-                document.querySelector('[data-test-id="/search"]')?.getAttribute('data-test-active')
-            )
-
-            expect(active).toEqual('true')
-        })
-
-        test('is highlighted on repo page', async () => {
-            await driver.page.goto(driver.sourcegraphBaseUrl + '/github.com/sourcegraph/sourcegraph')
-            await driver.page.waitForSelector('[data-test-id="/search"]')
-            await driver.page.waitForSelector('[data-test-active="true"]')
-
-            const active = await driver.page.evaluate(() =>
-                document.querySelector('[data-test-id="/search"]')?.getAttribute('data-test-active')
-            )
-
-            expect(active).toEqual('true')
-        })
-
-        test('is highlighted on repo file page', async () => {
-            await driver.page.goto(driver.sourcegraphBaseUrl + '/github.com/sourcegraph/sourcegraph/-/blob/README.md')
-            await driver.page.waitForSelector('[data-test-id="/search"]')
-            await driver.page.waitForSelector('[data-test-active="true"]')
-
-            const active = await driver.page.evaluate(() =>
-                document.querySelector('[data-test-id="/search"]')?.getAttribute('data-test-active')
-            )
-
-            expect(active).toEqual('true')
-        })
-
-        test('is highlighted on notebook page', async () => {
-            await driver.page.goto(driver.sourcegraphBaseUrl + '/notebooks/id')
-            await driver.page.waitForSelector('[data-test-id="/search"]')
-            await driver.page.waitForSelector('[data-test-active="true"]')
-
-            const active = await driver.page.evaluate(() =>
-                document.querySelector('[data-test-id="/search"]')?.getAttribute('data-test-active')
-            )
-
-            expect(active).toEqual('true')
-        })
-
-        test('is not highlighted on insights page', async () => {
-            await driver.page.goto(driver.sourcegraphBaseUrl + '/insights/id')
-            await driver.page.waitForSelector('[data-test-id="/search"]')
-            await driver.page.waitForSelector('[data-test-active="false"]')
-
-            const active = await driver.page.evaluate(() =>
-                document.querySelector('[data-test-id="/search"]')?.getAttribute('data-test-active')
-            )
-
-            expect(active).toEqual('false')
         })
     })
 })

--- a/client/web/src/nav/GlobalNavbar.test.tsx
+++ b/client/web/src/nav/GlobalNavbar.test.tsx
@@ -39,7 +39,6 @@ const PROPS: React.ComponentProps<typeof GlobalNavbar> = {
     codeMonitoringEnabled: true,
     ownEnabled: true,
     showFeedbackModal: () => undefined,
-    __testing__isOpen: true,
 }
 
 describe('GlobalNavbar', () => {
@@ -68,8 +67,8 @@ describe('GlobalNavbar', () => {
             </MockedTestProvider>
         )
         expect(describeNavBar(baseElement)).toEqual<NavBarTestDescription>({
-            codyItemType: 'dropdown',
-            codyDropdownItems: ['Dashboard /cody/dashboard', 'Web Chat /cody/chat'],
+            codyItemType: 'link',
+            codyItemLink: 'Cody /cody/chat',
         })
     })
 
@@ -82,7 +81,7 @@ describe('GlobalNavbar', () => {
         )
         expect(describeNavBar(baseElement)).toEqual<NavBarTestDescription>({
             codyItemType: 'link',
-            codyItemLink: 'https://sourcegraph.com/cody',
+            codyItemLink: 'Cody https://sourcegraph.com/cody',
         })
     })
 
@@ -93,8 +92,8 @@ describe('GlobalNavbar', () => {
             </MockedTestProvider>
         )
         expect(describeNavBar(baseElement)).toEqual<NavBarTestDescription>({
-            codyItemType: 'dropdown',
-            codyDropdownItems: ['Dashboard /cody/manage', 'Web Chat /cody/chat'],
+            codyItemType: 'link',
+            codyItemLink: 'Cody /cody/chat',
         })
     })
 
@@ -106,8 +105,8 @@ describe('GlobalNavbar', () => {
             </MockedTestProvider>
         )
         expect(describeNavBar(baseElement)).toEqual<NavBarTestDescription>({
-            codyItemType: 'dropdown',
-            codyDropdownItems: ['Dashboard /cody/dashboard', 'Web Chat /cody/chat'],
+            codyItemType: 'link',
+            codyItemLink: 'Cody /cody/chat',
         })
     })
 
@@ -120,7 +119,7 @@ describe('GlobalNavbar', () => {
         )
         expect(describeNavBar(baseElement)).toEqual<NavBarTestDescription>({
             codyItemType: 'link',
-            codyItemLink: '/cody/dashboard',
+            codyItemLink: 'Cody /cody/dashboard',
         })
     })
 
@@ -135,8 +134,8 @@ describe('GlobalNavbar', () => {
             </MockedTestProvider>
         )
         expect(describeNavBar(baseElement)).toEqual<NavBarTestDescription>({
-            codyItemType: 'dropdown',
-            codyDropdownItems: ['Dashboard /cody/dashboard', 'Web Chat /cody/chat'],
+            codyItemType: 'link',
+            codyItemLink: 'BrandLogo /cody/chat',
         })
     })
 
@@ -156,28 +155,16 @@ describe('GlobalNavbar', () => {
 })
 
 interface NavBarTestDescription {
-    codyItemType: 'none' | 'link' | 'dropdown'
+    codyItemType: 'none' | 'link'
     codyItemLink?: string
-    codyDropdownItems?: string[]
 }
 
 function describeNavBar(baseElement: HTMLElement): NavBarTestDescription {
-    const dropdownButton = baseElement.querySelector('button[aria-label="Show cody menu"]')
-    if (dropdownButton) {
-        const popover = baseElement.querySelector('[data-reach-menu-popover]')!
-        return {
-            codyItemType: 'dropdown',
-            codyDropdownItems: [...popover.querySelectorAll('a')].map(
-                item => `${item.textContent ?? ''} ${item.getAttribute('href') ?? ''}`
-            ),
-        }
-    }
-
     const item = baseElement.querySelector<HTMLAnchorElement>('a[href*="cody"]')
     return item
         ? {
               codyItemType: 'link',
-              codyItemLink: item?.getAttribute('href') ?? '',
+              codyItemLink: `${item.textContent} ${item.getAttribute('href') ?? ''}`,
           }
         : { codyItemType: 'none' }
 }

--- a/client/web/src/nav/NavBar/NavBar.tsx
+++ b/client/web/src/nav/NavBar/NavBar.tsx
@@ -51,7 +51,7 @@ export interface NavLinkProps extends NavItemProps, Pick<LinkProps, 'to'> {
 }
 
 export const NavBar = forwardRef(function NavBar({ children, logo }, reference): JSX.Element {
-    const logoUrl = window.context?.codeSearchEnabledOnInstance ? PageRoutes.Search : PageRoutes.Cody
+    const logoUrl = window.context?.codeSearchEnabledOnInstance ? PageRoutes.Search : PageRoutes.CodyChat
     return (
         <nav aria-label="Main" className={navBarStyles.navbar} ref={reference}>
             {logo && (

--- a/client/web/src/nav/NavBar/NavDropdown.tsx
+++ b/client/web/src/nav/NavBar/NavDropdown.tsx
@@ -26,28 +26,19 @@ interface NavDropdownProps {
         /** Alternative path to match against if item is active */
         altPath?: string
     } & Pick<NavLinkProps, 'variant'>
-    /**
-     * The first item in the dropdown menu that serves as the "home" item. It uses the path from the
-     * toggleItem.
-     */
-    homeItem?: Omit<NavDropdownItem, 'path'>
     /** Items to display in the dropdown */
     items: NavDropdownItem[]
     /** A current react router route match */
     routeMatch?: string
     /** The name of the dropdown to use for accessible labels */
     name: string
-
-    __testing__isOpen?: boolean
 }
 
 export const NavDropdown: React.FunctionComponent<React.PropsWithChildren<NavDropdownProps>> = ({
     toggleItem,
-    homeItem: homeItem,
     items,
     routeMatch,
     name,
-    __testing__isOpen,
 }) => {
     const location = useLocation()
     const isItemSelected = useMemo(
@@ -104,16 +95,7 @@ export const NavDropdown: React.FunctionComponent<React.PropsWithChildren<NavDro
                                     </MenuButton>
                                 </div>
 
-                                <MenuList
-                                    className={styles.menuList}
-                                    targetPadding={EMPTY_RECTANGLE}
-                                    isOpen={__testing__isOpen}
-                                >
-                                    {homeItem && (
-                                        <MenuLink as={Link} key={toggleItem.path} to={toggleItem.path}>
-                                            {homeItem.content}
-                                        </MenuLink>
-                                    )}
+                                <MenuList className={styles.menuList} targetPadding={EMPTY_RECTANGLE}>
                                     {items.map(item => (
                                         <MenuLink as={Link} key={item.path} to={item.path} target={item.target}>
                                             {item.content}

--- a/client/web/src/nav/UserNavItem.test.tsx
+++ b/client/web/src/nav/UserNavItem.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { MemoryRouter } from 'react-router-dom'
 import sinon from 'sinon'
-import { afterAll, beforeAll, describe, expect, test } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } from 'vitest'
 
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
@@ -12,6 +12,16 @@ import { renderWithBrandedContext } from '@sourcegraph/wildcard/src/testing'
 import { UserNavItem, type UserNavItemProps } from './UserNavItem'
 
 describe('UserNavItem', () => {
+    const origCodyEnabledForCurrentUser = window.context?.codyEnabledForCurrentUser ?? true
+    const reset = () => {
+        if (!window.context) {
+            window.context = {} as any
+        }
+        window.context.codyEnabledForCurrentUser = origCodyEnabledForCurrentUser
+    }
+    beforeEach(reset)
+    afterEach(reset)
+
     beforeAll(() => {
         setLinkComponent(RouterLink)
     })

--- a/client/web/src/nav/UserNavItem.tsx
+++ b/client/web/src/nav/UserNavItem.tsx
@@ -9,8 +9,11 @@ import { useKeyboardShortcut } from '@sourcegraph/shared/src/keyboardShortcuts/u
 import { Shortcut } from '@sourcegraph/shared/src/react-shortcuts'
 import { useExperimentalFeatures } from '@sourcegraph/shared/src/settings/settings'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
-import { useTheme, ThemeSetting } from '@sourcegraph/shared/src/theme'
+import { ThemeSetting, useTheme } from '@sourcegraph/shared/src/theme'
 import {
+    AnchorLink,
+    Icon,
+    Link,
     Menu,
     MenuButton,
     MenuDivider,
@@ -18,14 +21,13 @@ import {
     MenuItem,
     MenuLink,
     MenuList,
-    Link,
     Position,
-    AnchorLink,
     Select,
-    Icon,
 } from '@sourcegraph/wildcard'
 
 import type { AuthenticatedUser } from '../auth'
+import { CodyProRoutes } from '../cody/codyProRoutes'
+import { PageRoutes } from '../routes.constants'
 import { enableDevSettings, isSourcegraphDev, useDeveloperSettings } from '../stores'
 
 import { useNewSearchNavigation } from './new-global-navigation'
@@ -134,10 +136,18 @@ export const UserNavItem: FC<UserNavItemProps> = props => {
                             <MenuLink as={Link} to={authenticatedUser.settingsURL!}>
                                 Settings
                             </MenuLink>
+                            {window.context.codyEnabledForCurrentUser && (
+                                <MenuLink
+                                    as={Link}
+                                    to={isSourcegraphDotCom ? CodyProRoutes.Manage : PageRoutes.CodyDashboard}
+                                >
+                                    Cody dashboard
+                                </MenuLink>
+                            )}
                             <MenuLink as={Link} to={`/users/${props.authenticatedUser.username}/searches`}>
                                 Saved searches
                             </MenuLink>
-                            {!isSourcegraphDotCom && (
+                            {!isSourcegraphDotCom && window.context.ownEnabled && (
                                 <MenuLink as={Link} to="/teams">
                                     Teams
                                 </MenuLink>

--- a/client/web/src/nav/new-global-navigation/NewGlobalNavigationBar.module.scss
+++ b/client/web/src/nav/new-global-navigation/NewGlobalNavigationBar.module.scss
@@ -157,6 +157,18 @@
     }
 }
 
+.nav-group-title {
+    font-size: 0.8rem;
+    text-transform: uppercase;
+    font-weight: bold;
+    opacity: 0.6;
+    padding: 0.375rem 0.75rem;
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+    user-select: none;
+}
+
 .nav-link {
     display: flex;
     flex-wrap: wrap;

--- a/client/web/src/nav/new-global-navigation/NewGlobalNavigationBar.test.tsx
+++ b/client/web/src/nav/new-global-navigation/NewGlobalNavigationBar.test.tsx
@@ -54,7 +54,7 @@ describe('NewGlobalNavigationBar', () => {
         )
         const sidebarElement = baseElement.querySelector<HTMLElement>('[data-reach-dialog-overlay]')!
         expect(describeNavBarSideMenu(sidebarElement)).toEqual<NavBarTestDescription>({
-            codyItems: ['Cody /cody/dashboard', 'Web Chat /cody/chat'],
+            codyItems: ['Cody /cody/chat'],
         })
     })
 
@@ -79,7 +79,7 @@ describe('NewGlobalNavigationBar', () => {
         )
         const sidebarElement = baseElement.querySelector<HTMLElement>('[data-reach-dialog-overlay]')!
         expect(describeNavBarSideMenu(sidebarElement)).toEqual<NavBarTestDescription>({
-            codyItems: ['Cody /cody/manage', 'Web Chat /cody/chat'],
+            codyItems: ['Cody /cody/chat'],
         })
     })
 
@@ -92,7 +92,7 @@ describe('NewGlobalNavigationBar', () => {
         )
         const sidebarElement = baseElement.querySelector<HTMLElement>('[data-reach-dialog-overlay]')!
         expect(describeNavBarSideMenu(sidebarElement)).toEqual<NavBarTestDescription>({
-            codyItems: ['Cody /cody/dashboard', 'Web Chat /cody/chat'],
+            codyItems: ['Cody /cody/chat'],
         })
     })
 
@@ -121,7 +121,7 @@ describe('NewGlobalNavigationBar', () => {
         )
         const sidebarElement = baseElement.querySelector<HTMLElement>('[data-reach-dialog-overlay]')!
         expect(describeNavBarSideMenu(sidebarElement)).toEqual<NavBarTestDescription>({
-            codyItems: ['Cody /cody/dashboard', 'Web Chat /cody/chat'],
+            codyItems: ['Cody /cody/chat'],
         })
     })
 

--- a/client/web/src/nav/new-global-navigation/NewGlobalNavigationBar.tsx
+++ b/client/web/src/nav/new-global-navigation/NewGlobalNavigationBar.tsx
@@ -4,6 +4,7 @@ import { mdiClose, mdiMenu } from '@mdi/js'
 import classNames from 'classnames'
 import BarChartIcon from 'mdi-react/BarChartIcon'
 import MagnifyIcon from 'mdi-react/MagnifyIcon'
+import ToolsIcon from 'mdi-react/ToolsIcon'
 import { NavLink, useLocation, useNavigate, useSearchParams, type RouteObject } from 'react-router-dom'
 import shallow from 'zustand/shallow'
 
@@ -13,12 +14,10 @@ import type { SearchQueryState, SubmitSearchParameters } from '@sourcegraph/shar
 import type { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { useIsLightTheme } from '@sourcegraph/shared/src/theme'
-import { Button, ButtonLink, Icon, Link, Modal, ProductStatusBadge, Text } from '@sourcegraph/wildcard'
+import { Button, ButtonLink, Icon, Link, Modal, Text } from '@sourcegraph/wildcard'
 
 import type { AuthenticatedUser } from '../../auth'
 import { BatchChangesIconNav } from '../../batches/icons'
-import { CodyProRoutes } from '../../cody/codyProRoutes'
-import { CODY_MARKETING_PAGE_URL } from '../../cody/codyRoutes'
 import { CodyLogo } from '../../cody/components/CodyLogo'
 import { BrandLogo } from '../../components/branding/BrandLogo'
 import { DeveloperSettingsGlobalNavItem } from '../../devsettings/DeveloperSettingsGlobalNavItem'
@@ -28,7 +27,7 @@ import { PageRoutes } from '../../routes.constants'
 import { isSearchJobsEnabled } from '../../search-jobs/utility'
 import { LazyV2SearchInput } from '../../search/input/LazyV2SearchInput'
 import { setSearchCaseSensitivity, setSearchMode, setSearchPatternType, useNavbarQueryState } from '../../stores'
-import { InlineNavigationPanel } from '../GlobalNavbar'
+import { InlineNavigationPanel, linkForCodyNavItem } from '../GlobalNavbar'
 import { UserNavItem } from '../UserNavItem'
 
 import styles from './NewGlobalNavigationBar.module.scss'
@@ -352,62 +351,18 @@ const SidebarNavigation: FC<SidebarNavigationProps> = props => {
 
             <nav className={styles.sidebarNavigationNav}>
                 <ul className={styles.sidebarNavigationList}>
-                    <li className={classNames(styles.navItem, styles.navItemNested)}>
-                        <Button
-                            as={Link}
-                            to={PageRoutes.Search}
-                            className={styles.navLink}
-                            onClick={handleNavigationClick}
-                        >
-                            <Icon as={MagnifyIcon} className={styles.icon} aria-hidden={true} /> Code Search
-                        </Button>
-
-                        <ul className={classNames(styles.sidebarNavigationList, styles.sidebarNavigationListNested)}>
-                            {showSearchContext && (
-                                <NavItemLink url={PageRoutes.Contexts} onClick={handleNavigationClick}>
-                                    Context
-                                </NavItemLink>
-                            )}
-                            {showSearchNotebook && (
-                                <NavItemLink url={PageRoutes.Notebooks} onClick={handleNavigationClick}>
-                                    Notebooks
-                                </NavItemLink>
-                            )}
-                            {showCodeMonitoring && (
-                                <NavItemLink url="/code-monitoring" onClick={handleNavigationClick}>
-                                    Code Monitoring
-                                </NavItemLink>
-                            )}
-                            {showSearchJobs && (
-                                <NavItemLink url={PageRoutes.SearchJobs} onClick={handleNavigationClick}>
-                                    Search Jobs <ProductStatusBadge className="ml-2" status="beta" />
-                                </NavItemLink>
-                            )}
-                        </ul>
-                    </li>
+                    <NavItemLink url={PageRoutes.Search} icon={MagnifyIcon} onClick={handleNavigationClick}>
+                        Code Search
+                    </NavItemLink>
 
                     {window.context?.codyEnabledOnInstance && (
                         <NavItemLink
-                            url={
-                                isSourcegraphDotCom
-                                    ? window.context.codyEnabledForCurrentUser
-                                        ? CodyProRoutes.Manage
-                                        : CODY_MARKETING_PAGE_URL
-                                    : PageRoutes.CodyDashboard
-                            }
+                            url={linkForCodyNavItem(isSourcegraphDotCom)}
                             icon={CodyLogo}
                             onClick={handleNavigationClick}
                         >
                             Cody
                         </NavItemLink>
-                    )}
-
-                    {window.context?.codyEnabledForCurrentUser && (
-                        <ul className={classNames(styles.sidebarNavigationList, styles.sidebarNavigationListNested)}>
-                            <NavItemLink url={PageRoutes.CodyChat} onClick={handleNavigationClick}>
-                                Web Chat
-                            </NavItemLink>
-                        </ul>
                     )}
 
                     {showBatchChanges && (
@@ -420,6 +375,43 @@ const SidebarNavigation: FC<SidebarNavigationProps> = props => {
                         <NavItemLink url="/insights" icon={BarChartIcon} onClick={handleNavigationClick}>
                             Insights
                         </NavItemLink>
+                    )}
+
+                    {(showSearchContext ||
+                        showSearchNotebook ||
+                        showCodeMonitoring ||
+                        showBatchChanges ||
+                        showCodeInsights) && (
+                        <li className={classNames(styles.navItem, styles.navItemNested)}>
+                            <span className={styles.navGroupTitle}>
+                                <Icon as={ToolsIcon} className={styles.icon} aria-hidden={true} /> Tools
+                            </span>
+
+                            <ul
+                                className={classNames(styles.sidebarNavigationList, styles.sidebarNavigationListNested)}
+                            >
+                                {showSearchContext && (
+                                    <NavItemLink url={PageRoutes.Contexts} onClick={handleNavigationClick}>
+                                        Contexts
+                                    </NavItemLink>
+                                )}
+                                {showSearchNotebook && (
+                                    <NavItemLink url={PageRoutes.Notebooks} onClick={handleNavigationClick}>
+                                        Notebooks
+                                    </NavItemLink>
+                                )}
+                                {showCodeMonitoring && (
+                                    <NavItemLink url="/code-monitoring" onClick={handleNavigationClick}>
+                                        Code Monitoring
+                                    </NavItemLink>
+                                )}
+                                {showSearchJobs && (
+                                    <NavItemLink url={PageRoutes.SearchJobs} onClick={handleNavigationClick}>
+                                        Search Jobs
+                                    </NavItemLink>
+                                )}
+                            </ul>
+                        </li>
                     )}
 
                     {isSourcegraphDotCom && (

--- a/client/web/src/routes.constants.ts
+++ b/client/web/src/routes.constants.ts
@@ -34,7 +34,6 @@ export enum PageRoutes {
     Notebook = '/notebooks/:id',
     Notebooks = '/notebooks',
     SearchNotebook = '/search/notebook',
-    Cody = '/cody',
     CodyDashboard = '/cody/dashboard',
     CodyRedirectToMarketingOrDashboard = '/cody',
     CodyChat = '/cody/chat',


### PR DESCRIPTION
I found it annoying that it took 2 clicks to go to Cody chat: click **Cody** in the global navbar, then click **Web Chat**. Users rarely will visit their dashboard, and that's associated with their user anyway, so it should be under their user. Same 2-click annoyance applies to going to Code Search.

Moves some other links:

- Contexts, Search Jobs, Code Monitors, Notebooks --> moved to "Tools" global navbar item
- Cody dashboard --> moved to user nav item (in top right)

![image](https://github.com/sourcegraph/sourcegraph/assets/1976/6b87ad4a-cb8a-4706-8954-f79e588803cd)
![image](https://github.com/sourcegraph/sourcegraph/assets/1976/b971c2f2-5965-4cd9-b8ac-17dc0ff9921d)
![image](https://github.com/sourcegraph/sourcegraph/assets/1976/933865d9-105f-406f-b88e-62e370896cfd)


## Test plan

With minimize nav on and off, and with all states of dotcom and user-has-Cody-enabled, ensure matches expectations. The expectations are codified in the tests/

## Changelog

- Code Search and Cody now are one-click links in the global navbar. Other features are in the new "Tools" menu: search contexts, code monitors, search jobs, and notebooks. Your Cody dashboard is linked from your user menu (in the top right).