### PR TITLE
fix(sg): reduce max interrupt count and os.Exit always

### DIFF
--- a/dev/sg/interrupt/interrupt.go
+++ b/dev/sg/interrupt/interrupt.go
@@ -111,7 +111,11 @@ func Listen() {
 		// Closing this channel should make the interrupt counting goroutine exit
 		close(interrupt)
 		// All the hooks have finished executing - anything left we force exiting by doing an os.Exit here
-		os.Exit(1)
+		if os.Getenv("SG_INTERRUPT_DEBUG") == "1" {
+			std.Out.WriteWarningf("SG_INTERRUPT_DEBUG is set to 1 - not doing os.Exit")
+		} else {
+			os.Exit(1)
+		}
 	}()
 }
 

--- a/dev/sg/interrupt/interrupt.go
+++ b/dev/sg/interrupt/interrupt.go
@@ -111,7 +111,7 @@ func Listen() {
 		// Closing this channel should make the interrupt counting goroutine exit
 		close(interrupt)
 		// All the hooks have finished executing - anything left we force exiting by doing an os.Exit here
-		os.Exit(0)
+		os.Exit(1)
 	}()
 }
 

--- a/dev/sg/interrupt/interrupt.go
+++ b/dev/sg/interrupt/interrupt.go
@@ -93,7 +93,7 @@ func Listen() {
 			for range interrupt {
 				count++
 				if count >= MaxInterruptCount {
-					std.Out.WriteWarningf("Ok. Loads of interrupts received - exiting immediately.")
+					std.Out.WriteWarningf("Max interrupts received - exiting immediately.")
 					os.Exit(1)
 				}
 			}
@@ -108,7 +108,7 @@ func Listen() {
 		if err != nil {
 			std.Out.WriteWarningf("context failure executing hooks: %s", err)
 		}
-		// Closing this channel should make the interrupt counting gorounting exit
+		// Closing this channel should make the interrupt counting goroutine exit
 		close(interrupt)
 		// All the hooks have finished executing - anything left we force exiting by doing an os.Exit here
 		os.Exit(0)


### PR DESCRIPTION
* Once all the hooks have finished we now os.Exit ensuring anything else non-process related quits.
* Reduce max interrupt count from 5 -> 2. Restoring what it was previously. This might lead to dangling processes.

[Issue](https://linear.app/sourcegraph/issue/DINF-74/sg-address-sg-hanging-around-after-ctrlc)
<!-- PR description tips: https://www.notion.so/sourcegraph/Write-a-good-pull-request-description-610a7fd3e613496eb76f450db5a49b6e -->

## Test plan
Tested locally
<!-- REQUIRED; info at https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles -->

## Changelog
* sg - Always os.Exit once shutdown hooks have completed
* sg - Reduce max intterupt count from 5 to 2 to hard exit
