### PR TITLE
fix(batch-changes): remove leading and trailing spaces from batch changes credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-Hello wortld!
-
 <p align="center">
 <a href="https://sourcegraph.com/" target="_blank">
 <picture>

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+Hello wortld!
+
 <p align="center">
 <a href="https://sourcegraph.com/" target="_blank">
 <picture>

--- a/cmd/frontend/internal/batches/resolvers/resolver.go
+++ b/cmd/frontend/internal/batches/resolvers/resolver.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 
@@ -1117,15 +1118,16 @@ func (r *Resolver) CreateBatchChangesCredential(ctx context.Context, args *graph
 		return nil, errors.New("invalid external service kind")
 	}
 
-	if args.Credential == "" {
+	trimmedCredential := strings.TrimSpace(args.Credential)
+	if trimmedCredential == "" {
 		return nil, errors.New("empty credential not allowed")
 	}
 
 	if userID != 0 {
-		return r.createBatchChangesUserCredential(ctx, args.ExternalServiceURL, extsvc.KindToType(kind), userID, args.Credential, args.Username)
+		return r.createBatchChangesUserCredential(ctx, args.ExternalServiceURL, extsvc.KindToType(kind), userID, trimmedCredential, args.Username)
 	}
 
-	return r.createBatchChangesSiteCredential(ctx, args.ExternalServiceURL, extsvc.KindToType(kind), args.Credential, args.Username)
+	return r.createBatchChangesSiteCredential(ctx, args.ExternalServiceURL, extsvc.KindToType(kind), trimmedCredential, args.Username)
 }
 
 func (r *Resolver) createBatchChangesUserCredential(ctx context.Context, externalServiceURL, externalServiceType string, userID int32, credential string, username *string) (graphqlbackend.BatchChangesCredentialResolver, error) {


### PR DESCRIPTION
@jamesmcnamara  reported a number of 401s when using a PAT that had access to the repositories affected by a Batch Change. I spent some hours looking into this and was amazed by what I found.

That error was happening because there was a leading whitespace in the token in 1password and apparently the github credential validator doesn't care about whitespaces however when this token is being used to push a change, it becomes a problem because the URL now looks like this:

```
https://%20ghp_....@github.com/sourcegraph-testing/markdowns
```

And that's what was calling your failing batch changes with the devx token. I'll push a fix to correct this.

## Test plan

* Manual testing
* Added a credential with whitespaces and confirmed that the spaces were correctly removed.

## Changelog

- Whitespaces in Batch Changes credentials are trimmed before being saved to the database, this prevents 401 errors when using the token to construct an authenticated push URL.