### PR TITLE
fix(search): VSCode Search extension: bring back matched lines in search results. 

### DIFF
--- a/client/branded/src/search-ui/components/FileContentSearchResult.test.tsx
+++ b/client/branded/src/search-ui/components/FileContentSearchResult.test.tsx
@@ -37,6 +37,7 @@ describe('FileContentSearchResult', () => {
         expect(getByTestId(container, 'result-container')).toBeVisible()
         expect(getAllByTestId(container, 'result-container').length).toBe(1)
         expect(getAllByTestId(container, 'file-search-result').length).toBe(1)
+        expect(getAllByTestId(container, 'file-match-children').length).toBe(1)
     })
 
     // TODO: add test that the collapse shows if there are too many results

--- a/client/branded/src/search-ui/components/FileContentSearchResult.tsx
+++ b/client/branded/src/search-ui/components/FileContentSearchResult.tsx
@@ -21,6 +21,7 @@ import {
     getFileMatchUrl,
     getRepositoryUrl,
     getRevision,
+    type LineMatch,
 } from '@sourcegraph/shared/src/search/stream'
 import { useSettings, type SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
 import type { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
@@ -112,10 +113,7 @@ export const FileContentSearchResult: React.FunctionComponent<React.PropsWithChi
 
     const contextLines = useMemo(() => settings?.['search.contextLines'] ?? 1, [settings])
 
-    const unhighlightedGroups: MatchGroup[] = useMemo(
-        () => reranker(result.chunkMatches?.map(chunkToMatchGroup) ?? []),
-        [result, reranker]
-    )
+    const unhighlightedGroups: MatchGroup[] = useMemo(() => reranker(matchesToMatchGroups(result)), [result, reranker])
 
     const [expandedGroups, setExpandedGroups] = useState(unhighlightedGroups)
     const collapsedGroups = truncateGroups(expandedGroups, 5, contextLines)
@@ -299,6 +297,12 @@ function countHighlightRanges(groups: MatchGroup[]): number {
     return groups.reduce((count, group) => count + group.matches.length, 0)
 }
 
+function matchesToMatchGroups(result: ContentMatch): MatchGroup[] {
+    return [
+        ...(result.lineMatches?.map(lineToMatchGroup) ?? []),
+        ...(result.chunkMatches?.map(chunkToMatchGroup) ?? []),
+    ]
+}
 function chunkToMatchGroup(chunk: ChunkMatch): MatchGroup {
     const matches = chunk.ranges.map(range => ({
         startLine: range.start.line,
@@ -313,5 +317,21 @@ function chunkToMatchGroup(chunk: ChunkMatch): MatchGroup {
         matches,
         startLine: chunk.contentStart.line,
         endLine: chunk.contentStart.line + plaintextLines.length,
+    }
+}
+
+function lineToMatchGroup(line: LineMatch): MatchGroup {
+    const matches = line.offsetAndLengths.map(offsetAndLength => ({
+        startLine: line.lineNumber,
+        startCharacter: offsetAndLength[0],
+        endLine: line.lineNumber,
+        endCharacter: offsetAndLength[0] + offsetAndLength[1],
+    }))
+    return {
+        plaintextLines: [line.line],
+        highlightedHTMLRows: undefined, // populated lazily
+        matches,
+        startLine: line.lineNumber,
+        endLine: line.lineNumber + 1, // the matches support `endLine` == `startLine`, but MatchGroup requires `endLine` > `startLine`
     }
 }


### PR DESCRIPTION
Due to changes in the code base, the search extension code when run from `main` shows file names only in the search results page - no matches in the files. This is a regression from the behavior in the deployed extension.

Deployed extension:
<img width="1504" alt="Screenshot 2024-06-27 at 10 04 37" src="https://github.com/sourcegraph/sourcegraph/assets/129280/edd97903-d03f-4612-98c8-c8f286f0cb3b">

Running from `main`:
<img width="1502" alt="Screenshot 2024-06-27 at 10 11 17" src="https://github.com/sourcegraph/sourcegraph/assets/129280/d7aefcfe-3a25-4486-9fa6-a5e6bc7c6a8e">

Turns out the reason is because some shared code expects chunk matches, while the search queries were all returning line matches.

Added support for line matches in the shared code, and then fixed an issue with the search results display not keeping up with `MatchGroups`.

## Test plan
Build and run locally.

### Build
```
git switch peterguy/vscode-bring-back-matched-lines-in-search-results
cd client/vscode
pnpm run build
```
### Run
- Launch extension in VSCode: open the `Run and Debug` sidebar view in VS Code, then select `Launch VS Code Extension` from the dropdown menu.
- Run a search using the search bar.
- See that the results contain matched lines in the files and not just a list of file names. Compare to the currently-deployed extension - the search results should look generally the same.
