### PR TITLE
Bump `cody-web-experimental` package version

### DIFF
--- a/package.json
+++ b/package.json
@@ -333,7 +333,7 @@
     "bloomfilter": "^0.0.18",
     "buffer": "^6.0.3",
     "classnames": "^2.2.6",
-    "cody-web-experimental": "^0.1.3",
+    "cody-web-experimental": "^0.1.4",
     "comlink": "^4.3.0",
     "copy-to-clipboard": "^3.3.1",
     "core-js": "^3.8.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -206,8 +206,8 @@ importers:
         specifier: ^2.2.6
         version: 2.3.2
       cody-web-experimental:
-        specifier: ^0.1.3
-        version: 0.1.3
+        specifier: ^0.1.4
+        version: 0.1.4
       comlink:
         specifier: ^4.3.0
         version: 4.3.0
@@ -14533,8 +14533,8 @@ packages:
     resolution: {integrity: sha512-19Jox5sAKpusTDgqgKB5dawPpQcY+ipQK7xoEI+MVucEF9qqFaXpeqY1KaoyGBso/wHQoDa4HMMxMjdsS3Zzzw==}
     dev: false
 
-  /cody-web-experimental@0.1.3:
-    resolution: {integrity: sha512-StObdyhhSzB1nZtoXsp54C+bWSLySouNFT+CUsQeIfYpi1dP02UItqgIbyKFinNmq+EWIh7pJJzYcyhFIKdzJA==}
+  /cody-web-experimental@0.1.4:
+    resolution: {integrity: sha512-5WE+ZWfbNhXJxvJeCFfyJPHNaPZKEdJAGoFa7sSXoxdeUEN62YGIs5DmpCOEmSCzX0cQm+35GWRWoV28HI/0jg==}
     dev: false
 
   /color-convert@1.9.3:


### PR DESCRIPTION
Fixes [SRCH-627](https://linear.app/sourcegraph/issue/SRCH-627/cody-web-includes-false-code-context-preamble-is-unusable-for-many) 

`cody-web-experimental` 0.1.4 includes fixes for the including intro preamble when we have and when we don't have initial context for the cody chat, [commit with fix](https://github.com/sourcegraph/cody/pull/4605/commits/a0f1c8bdfa5e3aa2c71b024e3bf7d96f62ddaadd)
## Test plan
- Check that in blob UI Cody's chat constantly has context based on the repository which is currently open 
- Check that in Cody Chat standalone page chat has no predefined context and therefore builds prompt without any preamble (so it can answer generic questions properly)

<!-- REQUIRED; info at https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles -->

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
