### PR TITLE
sg/msp: generate github action subscription matrix dynamically

### DIFF
--- a/dev/sg/msp/sg_msp.go
+++ b/dev/sg/msp/sg_msp.go
@@ -1198,47 +1198,53 @@ This command supports completions on services and environments.
 			},
 		},
 		{
-			Name:  "subscription-matrix",
-			Usage: "Generate dynamic GitHub Action matrix for subscription deployment",
-			Action: func(ctx *cli.Context) error {
-				services, err := msprepo.ListServices()
-				if err != nil {
-					return err
-				}
-
-				type serviceInfo struct {
-					ID       string `json:"id"`
-					Env      string `json:"env"`
-					Category string `json:"category"`
-				}
-
-				type matrix struct {
-					Service []serviceInfo `json:"service"`
-				}
-				var outputServices matrix
-				for _, s := range services {
-					svc, err := spec.Open(msprepo.ServiceYAMLPath(s))
-					if err != nil {
-						return err
-					}
-					for _, e := range svc.Environments {
-						if e.Deploy.Type == spec.EnvironmentDeployTypeSubscription {
-							outputServices.Service = append(outputServices.Service, serviceInfo{
-								ID:       s,
-								Env:      e.ID,
-								Category: string(e.Category),
-							})
+			Name:   "gh-actions",
+			Hidden: true,
+			Subcommands: []*cli.Command{
+				{
+					Name:  "subscription-matrix",
+					Usage: "Generate dynamic GitHub Action matrix for subscription deployment",
+					Action: func(ctx *cli.Context) error {
+						services, err := msprepo.ListServices()
+						if err != nil {
+							return err
 						}
-					}
-				}
 
-				json, err := json.Marshal(outputServices)
-				if err != nil {
-					return err
-				}
-				std.Out.Write(string(json))
+						type serviceInfo struct {
+							ID       string `json:"id"`
+							Env      string `json:"env"`
+							Category string `json:"category"`
+						}
 
-				return nil
+						type matrix struct {
+							Service []serviceInfo `json:"service"`
+						}
+						var outputServices matrix
+						for _, s := range services {
+							svc, err := spec.Open(msprepo.ServiceYAMLPath(s))
+							if err != nil {
+								return err
+							}
+							for _, e := range svc.Environments {
+								if e.Deploy.Type == spec.EnvironmentDeployTypeSubscription {
+									outputServices.Service = append(outputServices.Service, serviceInfo{
+										ID:       s,
+										Env:      e.ID,
+										Category: string(e.Category),
+									})
+								}
+							}
+						}
+
+						json, err := json.Marshal(outputServices)
+						if err != nil {
+							return err
+						}
+						std.Out.Write(string(json))
+
+						return nil
+					},
+				},
 			},
 		},
 	},

--- a/dev/sg/msp/sg_msp.go
+++ b/dev/sg/msp/sg_msp.go
@@ -1200,6 +1200,7 @@ This command supports completions on services and environments.
 		{
 			Name:   "gh-actions",
 			Hidden: true,
+			Usage:  "Helper commands for GitHub Actions",
 			Subcommands: []*cli.Command{
 				{
 					Name:  "subscription-matrix",


### PR DESCRIPTION
Currently the matrix is hardcoded in the msp repo. 
Service operators can forget to add or remove their service from the list.

GitHub supports dynamically generating the matrix from a previous jobs output ([example](https://josh-ops.com/posts/github-actions-dynamic-matrix/))
This PR adds an `sg msp subscription-matrix` command which will generate the matrix we need

Part of CORE-202

## Test plan
Output
```
{"service":[{"id":"cloud-ops","env":"prod","category":"internal"},{"id":"gatekeeper","env":"prod","category":"internal"},{"id":"linearhooks","env":"prod","category":"internal"}]}
```
