### PR TITLE
fix/sg: fix 'sg enterprise' per-command flags

### DIFF
--- a/dev/sg/enterprise/sg_enterprise.go
+++ b/dev/sg/enterprise/sg_enterprise.go
@@ -39,10 +39,12 @@ var (
 	scopeWriteSubscriptionsPermissions = scopes.ToScope(scopes.ServiceEnterprisePortal, "permission.subscription", scopes.ActionWrite)
 )
 
-var clientFlags = append(samsflags.ClientCredentials(), &cli.StringFlag{
-	Name:  "enterprise-portal-server",
-	Usage: "The URL of the Enterprise Portal server to use (defaults to the appropriate one for SG_SAMS_SERVER_URL)",
-})
+func clientFlags() []cli.Flag {
+	return append(samsflags.ClientCredentials(), &cli.StringFlag{
+		Name:  "enterprise-portal-server",
+		Usage: "The URL of the Enterprise Portal server to use (defaults to the appropriate one for SG_SAMS_SERVER_URL)",
+	})
+}
 
 func newSubscriptionsClient(c *cli.Context, ss ...scopes.Scope) subscriptionsv1connect.SubscriptionsServiceClient {
 	ctx := c.Context
@@ -94,8 +96,8 @@ func resolveUserReference(ctx context.Context, users *sams.UsersServiceV1, userR
 var Command = &cli.Command{
 	Name:     "enterprise",
 	Category: category.Company,
-	Usage:    "Manage Sourcegraph Enterprise subscriptions in Enterprise Portal",
-	Description: `TODO
+	Usage:    "[EXPERIMENTAL] Manage Sourcegraph Enterprise subscriptions in Enterprise Portal",
+	Description: `[EXPERIMENTAL] See https://www.notion.so/sourcegraph/Sourcegraph-Enterprise-Portal-EP-c6311818978547beb981bd2a593c6acf?pvs=4
 
 Please reach out to #discuss-core-services for assistance if you have any questions!`,
 	Subcommands: []*cli.Command{{
@@ -105,7 +107,7 @@ Please reach out to #discuss-core-services for assistance if you have any questi
 			Name:      "list",
 			Usage:     "List subscriptions",
 			ArgsUsage: "[subscription IDs...]",
-			Flags: append(clientFlags,
+			Flags: append(clientFlags(),
 				&cli.StringFlag{
 					Name:  "member.cody-analytics-viewer",
 					Usage: "Member with Cody Analytics viewer permission to filter for (email or SAMS user ID)",
@@ -176,7 +178,7 @@ Please reach out to #discuss-core-services for assistance if you have any questi
 				Name:      "list",
 				Usage:     "List licenses for all or specified subscriptions",
 				ArgsUsage: "[subscription IDs...]",
-				Flags:     clientFlags,
+				Flags:     clientFlags(),
 				Action: func(c *cli.Context) error {
 					client := newSubscriptionsClient(c, scopeReadSubscriptions)
 					req := &subscriptionsv1.ListEnterpriseSubscriptionLicensesRequest{
@@ -222,7 +224,7 @@ Please reach out to #discuss-core-services for assistance if you have any questi
 			Name:      "set-instance-domain",
 			Usage:     "Assign an instance domain to a subscription",
 			ArgsUsage: "<subscription ID> <instance domain>",
-			Flags: append(clientFlags,
+			Flags: append(clientFlags(),
 				&cli.BoolFlag{
 					Name:  "auto-approve",
 					Usage: "Skip confirmation prompts",
@@ -282,7 +284,7 @@ Please reach out to #discuss-core-services for assistance if you have any questi
 			Usage:       "Update or assign membership to a subscription for one or more SAMS users",
 			Description: "Only one of --subscription-id or --subscription-instance-domain needs to be specified.",
 			ArgsUsage:   "<SAMS account email or ID...>",
-			Flags: append(clientFlags,
+			Flags: append(clientFlags(),
 				&cli.StringFlag{
 					Name:  "subscription-id",
 					Usage: "ID of the subscription to assign membership to",


### PR DESCRIPTION
Using `append` on a variable, then sharing that variable, surprisingly seems to cause nondeterministic behaviour in the flags. This makes the shared flag set a function so that each command gets its own set to append to.

This is causing some flags to show up as non-existent in automation.

## Test plan

`sg enterprise subscription list -h` now has the correct flags