### PR TITLE
link to Cody chat on the web from the Cody manage page

### DIFF
--- a/client/web/src/cody/chat/new-chat/NewCodyChatPage.tsx
+++ b/client/web/src/cody/chat/new-chat/NewCodyChatPage.tsx
@@ -26,7 +26,7 @@ export const NewCodyChatPage: FC<NewCodyChatPageProps> = props => {
 
     return (
         <Page className={styles.root}>
-            <PageTitle title="Cody Web Chat" />
+            <PageTitle title="Cody Chat" />
 
             <CodyPageHeader isSourcegraphDotCom={isSourcegraphDotCom} className={styles.pageHeader} />
 

--- a/client/web/src/cody/management/CodyManagementPage.tsx
+++ b/client/web/src/cody/management/CodyManagementPage.tsx
@@ -209,7 +209,7 @@ export const CodyManagementPage: React.FunctionComponent<CodyManagementPageProps
                 />
             </div>
 
-            <H3 className="mt-3 text-muted">Use Cody in...</H3>
+            <H3 className="mt-3 text-muted">Use Cody...</H3>
             <div className={classNames('border bg-1 mb-2', styles.container)}>
                 <CodyEditorsAndClients telemetryRecorder={telemetryRecorder} />
             </div>

--- a/client/web/src/cody/management/UseCodyInEditorSection.tsx
+++ b/client/web/src/cody/management/UseCodyInEditorSection.tsx
@@ -4,7 +4,9 @@ import { mdiOpenInNew } from '@mdi/js'
 import classNames from 'classnames'
 
 import type { TelemetryRecorder, TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
-import { Badge, ButtonLink, H3, Icon, Link, LinkOrSpan, Text } from '@sourcegraph/wildcard'
+import { Badge, ButtonLink, H3, Icon, Link, LinkOrSpan, SourcegraphIcon, Text } from '@sourcegraph/wildcard'
+
+import { PageRoutes } from '../../routes.constants'
 
 import styles from './CodyManagementPage.module.scss'
 
@@ -26,15 +28,18 @@ const EditorInstructions: React.FunctionComponent<
     <div className={classNames('d-flex flex-column px-3', className)}>
         {/* eslint-disable-next-line react/forbid-dom-props */}
         <div className="d-flex my-3 align-items-center" style={{ minHeight: `${EDITOR_ICON_HEIGHT}px` }}>
-            {editor.icon && (
-                <img
-                    alt={editor.name}
-                    src={`https://storage.googleapis.com/sourcegraph-assets/ideIcons/ideIcon${editor.icon}.svg`}
-                    width={EDITOR_ICON_HEIGHT}
-                    height={EDITOR_ICON_HEIGHT}
-                    className="mr-3"
-                />
-            )}
+            {editor.icon &&
+                (typeof editor.icon === 'string' ? (
+                    <img
+                        alt={editor.name}
+                        src={`https://storage.googleapis.com/sourcegraph-assets/ideIcons/ideIcon${editor.icon}.svg`}
+                        width={EDITOR_ICON_HEIGHT}
+                        height={EDITOR_ICON_HEIGHT}
+                        className="mr-3"
+                    />
+                ) : (
+                    <editor.icon className="mr-3" />
+                ))}
             <H3 className="mb-0 font-weight-normal">{editor.name}</H3>
         </div>
         {editor.instructions && <editor.instructions telemetryRecorder={telemetryRecorder} />}
@@ -43,7 +48,7 @@ const EditorInstructions: React.FunctionComponent<
 
 interface EditorInstructionsTile {
     /** Refers to gs://sourcegraph-assets/ideIcons/ideIcon${icon}.svg. */
-    icon?: string
+    icon?: string | React.ComponentType<{ className?: string }>
 
     name: string
     instructions?: React.FunctionComponent<{
@@ -141,6 +146,31 @@ const EDITOR_INSTRUCTIONS: EditorInstructionsTile[] = [
         ),
     },
     {
+        icon: ({ className }) => (
+            <SourcegraphIcon className={className} width={EDITOR_ICON_HEIGHT} height={EDITOR_ICON_HEIGHT} />
+        ),
+        name: 'Web',
+        instructions: ({ telemetryRecorder }) => (
+            <div className="d-flex flex-column flex-gap-2 align-items-start">
+                <ButtonLink
+                    variant="primary"
+                    to={PageRoutes.CodyChat}
+                    onClick={() => {
+                        telemetryRecorder.recordEvent('cody.editorExtensionsInstructions', 'clickWebChat', {
+                            metadata: { chrome: 1 },
+                        })
+                    }}
+                >
+                    Chat with Cody on the web
+                </ButtonLink>
+                <Text className="text-muted small mt-2">
+                    ...or open the <strong>Cody</strong> sidebar when viewing a repository, directory, or code file on
+                    Sourcegraph.
+                </Text>
+            </div>
+        ),
+    },
+    {
         name: 'Other editors & clients',
         instructions: ({ telemetryRecorder }) => (
             <ul className="d-flex flex-column flex-gap-2 align-items-start list-unstyled">
@@ -177,12 +207,6 @@ const OTHER_CLIENTS: {
     telemetryMetadataKey: string
     releaseStage?: 'Experimental' | 'Coming soon'
 }[] = [
-    {
-        name: 'Cody Web',
-        url: 'https://sourcegraph.com/docs/cody/clients/cody-with-sourcegraph',
-        telemetryMetadataKey: 'web',
-        releaseStage: 'Experimental',
-    },
     {
         name: 'Neovim',
         url: 'https://github.com/sourcegraph/sg.nvim#setup',

--- a/client/web/src/cody/sidebar/new-cody-sidebar/NewCodySidebar.tsx
+++ b/client/web/src/cody/sidebar/new-cody-sidebar/NewCodySidebar.tsx
@@ -4,7 +4,7 @@ import { mdiClose } from '@mdi/js'
 
 import { CodyLogo } from '@sourcegraph/cody-ui'
 import { lazyComponent } from '@sourcegraph/shared/src/util/lazyComponent'
-import { Button, Icon, Badge, LoadingSpinner, H4, Alert } from '@sourcegraph/wildcard'
+import { Alert, Badge, Button, H4, Icon, LoadingSpinner } from '@sourcegraph/wildcard'
 
 import styles from './NewCodySidebar.module.scss'
 
@@ -30,7 +30,7 @@ export const NewCodySidebar: FC<NewCodySidebarProps> = props => {
             <div className={styles.header}>
                 <div className="d-flex flex-shrink-0 align-items-center">
                     <CodyLogo />
-                    Cody Web
+                    Cody
                     <div className="ml-2">
                         <Badge variant="info">Experimental</Badge>
                     </div>
@@ -54,8 +54,8 @@ export const NewCodySidebar: FC<NewCodySidebarProps> = props => {
 
             {!isAuthorized && (
                 <Alert variant="info" className="m-3">
-                    <H4>Cody Web is only available to signed-in users</H4>
-                    Sign in to get access to use Cody Web
+                    <H4>Cody is only available to signed-in users</H4>
+                    Sign in to get access to use Cody
                 </Alert>
             )}
         </div>

--- a/client/web/src/repo/cody/AskCodyButton.module.scss
+++ b/client/web/src/repo/cody/AskCodyButton.module.scss
@@ -1,9 +1,7 @@
 .cody-button {
-    padding: 0.1rem 0.15rem 0.1rem 0.15rem;
+    padding: 0.1rem 0.45rem 0.1rem 0.15rem;
     display: flex;
     height: fit-content;
-    // stylelint-disable-next-line declaration-property-unit-allowed-list
-    width: 90px;
     align-items: center;
     justify-content: center;
     border: 1px solid var(--border-color-2);

--- a/client/web/src/repo/cody/AskCodyButton.tsx
+++ b/client/web/src/repo/cody/AskCodyButton.tsx
@@ -8,7 +8,7 @@ export function AskCodyButton({ onClick }: { onClick: () => void }): JSX.Element
         <div className="d-flex align-items-center">
             <Tooltip content="Open Cody" placement="bottom">
                 <Button className={styles.codyButton} onClick={onClick}>
-                    <AskCodyIcon iconColor="#A112FF" /> Ask Cody
+                    <AskCodyIcon iconColor="#A112FF" /> Cody
                 </Button>
             </Tooltip>
         </div>


### PR DESCRIPTION
Improves the Cody PLG management page to have a more prominent link to Cody Web. Also renames `Ask Cody` to `Cody` for simplicity.

Closes https://linear.app/sourcegraph/issue/PRIME-396/improve-web-chat-link-on-cody-manage-page

<img width="1226" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/1976/8f74f8f6-c5b8-41f1-abb6-2da5e02a25aa">


## Test plan

View in dotcom mode and ensure section looks nice