### PR TITLE
scip-syntax: implements parallel processing for workspace and tar commands

### DIFF
--- a/docker-images/syntax-highlighter/Cargo.Bazel.lock
+++ b/docker-images/syntax-highlighter/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "29abc93382c22b38f87c9f8db7894be1e88ba39e3e45b46fd61a08be146a87e5",
+  "checksum": "c1b7491fb92c7a323a1f0f8dfea0827ffdd308b84238d989ba48701a52f9c789",
   "crates": {
     "addr2line 0.20.0": {
       "name": "addr2line",
@@ -2394,7 +2394,7 @@
               "target": "plotters"
             },
             {
-              "id": "rayon 1.7.0",
+              "id": "rayon 1.10.0",
               "target": "rayon"
             },
             {
@@ -2476,57 +2476,6 @@
         "version": "0.5.0"
       },
       "license": "MIT/Apache-2.0"
-    },
-    "crossbeam-channel 0.5.8": {
-      "name": "crossbeam-channel",
-      "version": "0.5.8",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/crossbeam-channel/0.5.8/download",
-          "sha256": "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "crossbeam_channel",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "crossbeam_channel",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "crossbeam-utils",
-            "default",
-            "std"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "cfg-if 1.0.0",
-              "target": "cfg_if"
-            },
-            {
-              "id": "crossbeam-utils 0.8.16",
-              "target": "crossbeam_utils"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "version": "0.5.8"
-      },
-      "license": "MIT OR Apache-2.0"
     },
     "crossbeam-deque 0.8.3": {
       "name": "crossbeam-deque",
@@ -8990,13 +8939,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "rayon 1.7.0": {
+    "rayon 1.10.0": {
       "name": "rayon",
-      "version": "1.7.0",
+      "version": "1.10.0",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/rayon/1.7.0/download",
-          "sha256": "1d2df5196e37bcc87abebc0053e20787d73847bb33134a69841207dd0a47f03b"
+          "url": "https://static.crates.io/crates/rayon/1.10.0/download",
+          "sha256": "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
         }
       },
       "targets": [
@@ -9022,24 +8971,24 @@
               "target": "either"
             },
             {
-              "id": "rayon-core 1.11.0",
+              "id": "rayon-core 1.12.1",
               "target": "rayon_core"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "1.7.0"
+        "version": "1.10.0"
       },
       "license": "MIT OR Apache-2.0"
     },
-    "rayon-core 1.11.0": {
+    "rayon-core 1.12.1": {
       "name": "rayon-core",
-      "version": "1.11.0",
+      "version": "1.12.1",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/rayon-core/1.11.0/download",
-          "sha256": "4b8f95bd6966f5c87776639160a66bd8ab9895d9d4ab01ddba9fc60661aebe8d"
+          "url": "https://static.crates.io/crates/rayon-core/1.12.1/download",
+          "sha256": "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
         }
       },
       "targets": [
@@ -9070,10 +9019,6 @@
         "deps": {
           "common": [
             {
-              "id": "crossbeam-channel 0.5.8",
-              "target": "crossbeam_channel"
-            },
-            {
               "id": "crossbeam-deque 0.8.3",
               "target": "crossbeam_deque"
             },
@@ -9082,18 +9027,14 @@
               "target": "crossbeam_utils"
             },
             {
-              "id": "num_cpus 1.16.0",
-              "target": "num_cpus"
-            },
-            {
-              "id": "rayon-core 1.11.0",
+              "id": "rayon-core 1.12.1",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "1.11.0"
+        "version": "1.12.1"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -10714,6 +10655,10 @@
             {
               "id": "protobuf 3.2.0",
               "target": "protobuf"
+            },
+            {
+              "id": "rayon 1.10.0",
+              "target": "rayon"
             },
             {
               "id": "scip 0.3.2",
@@ -18857,6 +18802,7 @@
     "path-clean 1.0.1",
     "predicates 3.0.4",
     "protobuf 3.2.0",
+    "rayon 1.10.0",
     "regex 1.9.3",
     "rocket 0.5.0-rc.3",
     "rustc-hash 1.1.0",

--- a/docker-images/syntax-highlighter/Cargo.Bazel.lock
+++ b/docker-images/syntax-highlighter/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "c1b7491fb92c7a323a1f0f8dfea0827ffdd308b84238d989ba48701a52f9c789",
+  "checksum": "ff2c36de653530e0525fa93207bfa1381d434f2e99df6b8a198b57143537b4b6",
   "crates": {
     "addr2line 0.20.0": {
       "name": "addr2line",
@@ -10677,7 +10677,7 @@
               "target": "string_interner"
             },
             {
-              "id": "tar 0.4.40",
+              "id": "tar 0.4.41",
               "target": "tar"
             },
             {
@@ -12052,13 +12052,13 @@
       },
       "license": "MIT"
     },
-    "tar 0.4.40": {
+    "tar 0.4.41": {
       "name": "tar",
-      "version": "0.4.40",
+      "version": "0.4.41",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/tar/0.4.40/download",
-          "sha256": "b16afcea1f22891c49a00c751c7b63b2233284064f11a200fc624137c51e2ddb"
+          "url": "https://static.crates.io/crates/tar/0.4.41/download",
+          "sha256": "cb797dad5fb5b76fcf519e702f4a589483b5ef06567f160c392832c1f5e44909"
         }
       },
       "targets": [
@@ -12104,10 +12104,10 @@
             ]
           }
         },
-        "edition": "2018",
-        "version": "0.4.40"
+        "edition": "2021",
+        "version": "0.4.41"
       },
-      "license": "MIT/Apache-2.0"
+      "license": "MIT OR Apache-2.0"
     },
     "tempfile 3.10.1": {
       "name": "tempfile",
@@ -18813,7 +18813,7 @@
     "serde_json 1.0.99",
     "string-interner 0.14.0",
     "syntect 4.7.0",
-    "tar 0.4.40",
+    "tar 0.4.41",
     "tree-sitter 0.20.10",
     "tree-sitter-c 0.20.6",
     "tree-sitter-c-sharp 0.20.0",

--- a/docker-images/syntax-highlighter/Cargo.lock
+++ b/docker-images/syntax-highlighter/Cargo.lock
@@ -2197,9 +2197,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tar"
-version = "0.4.40"
+version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b16afcea1f22891c49a00c751c7b63b2233284064f11a200fc624137c51e2ddb"
+checksum = "cb797dad5fb5b76fcf519e702f4a589483b5ef06567f160c392832c1f5e44909"
 dependencies = [
  "filetime",
  "libc",

--- a/docker-images/syntax-highlighter/Cargo.lock
+++ b/docker-images/syntax-highlighter/Cargo.lock
@@ -473,16 +473,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-channel"
-version = "0.5.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
-dependencies = [
- "cfg-if",
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-deque"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1635,9 +1625,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.7.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d2df5196e37bcc87abebc0053e20787d73847bb33134a69841207dd0a47f03b"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
 dependencies = [
  "either",
  "rayon-core",
@@ -1645,14 +1635,12 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.11.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b8f95bd6966f5c87776639160a66bd8ab9895d9d4ab01ddba9fc60661aebe8d"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
 dependencies = [
- "crossbeam-channel",
  "crossbeam-deque",
  "crossbeam-utils",
- "num_cpus",
 ]
 
 [[package]]
@@ -1942,6 +1930,7 @@ dependencies = [
  "path-clean",
  "predicates",
  "protobuf",
+ "rayon",
  "scip",
  "serde",
  "serde_json",

--- a/docker-images/syntax-highlighter/Cargo.toml
+++ b/docker-images/syntax-highlighter/Cargo.toml
@@ -62,6 +62,7 @@ walkdir = "2"
 path-clean = "1"
 camino = "1.1"
 nom = "7.1.3"
+rayon = "1.10.0"
 
 scip = "0.3.2"
 protobuf = "3"

--- a/docker-images/syntax-highlighter/crates/scip-syntax/Cargo.toml
+++ b/docker-images/syntax-highlighter/crates/scip-syntax/Cargo.toml
@@ -31,6 +31,7 @@ path-clean = { workspace = true }
 camino = { workspace = true }
 tree-sitter = { workspace = true }
 nom = { workspace = true }
+rayon = { workspace = true }
 
 syntax-analysis = { path = "../syntax-analysis" }
 tree-sitter-all-languages = { path = "../tree-sitter-all-languages" }

--- a/docker-images/syntax-highlighter/crates/scip-syntax/src/index.rs
+++ b/docker-images/syntax-highlighter/crates/scip-syntax/src/index.rs
@@ -3,7 +3,7 @@ use std::{
     collections::{hash_map::Entry, HashMap},
     env,
     fs::File,
-    io::{self, prelude::*},
+    io::{self, Read},
     sync::atomic::{AtomicU32, Ordering},
 };
 
@@ -247,7 +247,7 @@ fn index_tar<R: Read + Send + 'static>(
     let spinner = create_spinner();
     // We need to move reading the archive off the main thread, because it can only be done synchronously
     let (rx, reader_thread_id) = {
-        let (tx, rx) = std::sync::mpsc::channel();
+        let (tx, rx) = std::sync::mpsc::sync_channel(rayon::current_num_threads() * 2);
         let thread_id = std::thread::spawn(move || -> Result<()> {
             let mut ar: tar::Archive<_> = tar::Archive::new(reader);
             let entries = ar.entries()?;

--- a/docker-images/syntax-highlighter/crates/scip-syntax/src/main.rs
+++ b/docker-images/syntax-highlighter/crates/scip-syntax/src/main.rs
@@ -34,9 +34,9 @@ struct IndexCommandOptions {
     #[arg(short, long, default_value = "./")]
     project_root: String,
 
-    /// Number of worker threads to use, defaults to number of logical cores
-    #[arg(short = 'j')]
-    worker_count: Option<NonZeroUsize>,
+    /// Number of jobs to run in parallel, defaults to number of logical cores
+    #[arg(short, long)]
+    jobs: Option<NonZeroUsize>,
 
     /// Evaluate the build index against an index from a file
     #[arg(long)]
@@ -208,7 +208,7 @@ fn run_index_command(options: IndexCommandOptions, mode: IndexMode) -> anyhow::R
         Utf8Path::new(&options.out),
         Utf8Path::new(&options.project_root),
         options.evaluate.map(Utf8PathBuf::from),
-        options.worker_count,
+        options.jobs,
         IndexOptions {
             analysis_mode: options.mode,
             fail_fast: options.fail_fast,

--- a/docker-images/syntax-highlighter/crates/scip-syntax/src/main.rs
+++ b/docker-images/syntax-highlighter/crates/scip-syntax/src/main.rs
@@ -1,5 +1,4 @@
-use std::num::NonZeroUsize;
-use std::process;
+use std::{num::NonZeroUsize, process};
 
 use anyhow::Context;
 use camino::{Utf8Path, Utf8PathBuf};
@@ -37,7 +36,7 @@ struct IndexCommandOptions {
     project_root: String,
 
     /// Number of worker threads to use, defaults to number of logical cores
-    #[arg(short='j')]
+    #[arg(short = 'j')]
     worker_count: Option<NonZeroUsize>,
 
     /// Evaluate the build index against an index from a file
@@ -208,7 +207,9 @@ fn run_index_command(options: IndexCommandOptions, mode: IndexMode) -> anyhow::R
         rayon::ThreadPoolBuilder::new()
             .num_threads(worker_count.get())
             .build_global()
-            .context("Failed to initialize global thread_pool, did you call 'run_index_command' twice?")?;
+            .context(
+                "Failed to initialize global thread_pool, did you call 'run_index_command' twice?",
+            )?;
     }
 
     index_command(

--- a/docker-images/syntax-highlighter/crates/scip-syntax/src/main.rs
+++ b/docker-images/syntax-highlighter/crates/scip-syntax/src/main.rs
@@ -1,6 +1,5 @@
 use std::{num::NonZeroUsize, process};
 
-use anyhow::Context;
 use camino::{Utf8Path, Utf8PathBuf};
 use clap::{Parser, Subcommand};
 use scip_syntax::index::{index_command, AnalysisMode, IndexMode, IndexOptions, TarMode};
@@ -203,21 +202,13 @@ pub fn main() -> anyhow::Result<()> {
 }
 
 fn run_index_command(options: IndexCommandOptions, mode: IndexMode) -> anyhow::Result<()> {
-    if let Some(worker_count) = options.worker_count {
-        rayon::ThreadPoolBuilder::new()
-            .num_threads(worker_count.get())
-            .build_global()
-            .context(
-                "Failed to initialize global thread_pool, did you call 'run_index_command' twice?",
-            )?;
-    }
-
     index_command(
         options.language,
         mode,
         Utf8Path::new(&options.out),
         Utf8Path::new(&options.project_root),
         options.evaluate.map(Utf8PathBuf::from),
+        options.worker_count,
         IndexOptions {
             analysis_mode: options.mode,
             fail_fast: options.fail_fast,

--- a/docker-images/syntax-highlighter/crates/scip-syntax/src/main.rs
+++ b/docker-images/syntax-highlighter/crates/scip-syntax/src/main.rs
@@ -171,7 +171,7 @@ pub fn main() -> anyhow::Result<()> {
                 }
             };
 
-            result.unwrap()
+            result?
         }
 
         Commands::ScipEvaluate {

--- a/docker-images/syntax-highlighter/crates/scip-syntax/tests/integration_test.rs
+++ b/docker-images/syntax-highlighter/crates/scip-syntax/tests/integration_test.rs
@@ -72,6 +72,7 @@ fn java_e2e_evaluation() {
         &candidate,
         &dir,
         None,
+        None,
         IndexOptions {
             analysis_mode: AnalysisMode::Full,
             fail_fast: true,


### PR DESCRIPTION
Closes https://linear.app/sourcegraph/issue/GRAPH-694/process-documents-in-parallel-in-scip-syntax

Parallelizes syntactic indexing by splitting the different indexing modes into job producers and then consuming them from a pool of workers using the `rayon` library.

`scip-syntax` will use the maximum available parallelism by default. The `-j/--jobs` argument can be used to control the number of worker threads.

Benchmarking on `spring-project/spring-framework`:
```
spring-framework on main
❯ hyperfine -L num_threads 1,4,8,10  'git archive HEAD | scip-syntax index tar - -j {num_threads} -l java' 'scip-syntax index workspace ${PWD} -l java -j {num_threads}'
Benchmark 1: git archive HEAD | scip-syntax index tar - -j 1 -l java
  Time (mean ± σ):      7.171 s ±  0.195 s    [User: 7.165 s, System: 0.149 s]
  Range (min … max):    7.047 s …  7.714 s    10 runs

Benchmark 2: scip-syntax index workspace ${PWD} -l java -j 1
  Time (mean ± σ):      7.100 s ±  0.061 s    [User: 6.965 s, System: 0.381 s]
  Range (min … max):    6.983 s …  7.184 s    10 runs

Benchmark 3: git archive HEAD | scip-syntax index tar - -j 4 -l java
  Time (mean ± σ):      1.927 s ±  0.044 s    [User: 7.366 s, System: 0.144 s]
  Range (min … max):    1.884 s …  2.034 s    10 runs

Benchmark 4: scip-syntax index workspace ${PWD} -l java -j 4
  Time (mean ± σ):      1.884 s ±  0.029 s    [User: 7.110 s, System: 0.342 s]
  Range (min … max):    1.855 s …  1.960 s    10 runs

Benchmark 5: git archive HEAD | scip-syntax index tar - -j 8 -l java
  Time (mean ± σ):      1.040 s ±  0.015 s    [User: 7.594 s, System: 0.162 s]
  Range (min … max):    1.025 s …  1.078 s    10 runs

Benchmark 6: scip-syntax index workspace ${PWD} -l java -j 8
  Time (mean ± σ):      1.010 s ±  0.007 s    [User: 7.275 s, System: 0.490 s]
  Range (min … max):    1.001 s …  1.023 s    10 runs

Benchmark 7: git archive HEAD | scip-syntax index tar - -j 10 -l java
  Time (mean ± σ):     962.7 ms ±   2.8 ms    [User: 8510.0 ms, System: 167.0 ms]
  Range (min … max):   959.0 ms … 966.7 ms    10 runs

Benchmark 8: scip-syntax index workspace ${PWD} -l java -j 10
  Time (mean ± σ):     935.7 ms ±   3.6 ms    [User: 8171.8 ms, System: 490.2 ms]
  Range (min … max):   930.9 ms … 943.5 ms    10 runs
```

Comparison against `main`:

```
spring-framework on  main [?]
❯ hyperfine 'git archive HEAD | scip-syntax index tar - -l java -o main.scip' 'git archive HEAD | scip-syntax-par index tar - -l java -o par.scip'
Benchmark 1: git archive HEAD | scip-syntax index tar - -l java -o main.scip
  Time (mean ± σ):      6.969 s ±  0.214 s    [User: 6.896 s, System: 0.096 s]
  Range (min … max):    6.806 s …  7.444 s    10 runs

Benchmark 2: git archive HEAD | scip-syntax-par index tar - -l java -o par.scip
  Time (mean ± σ):     974.7 ms ± 182.5 ms    [User: 9022.8 ms, System: 167.5 ms]
  Range (min … max):   907.1 ms … 1493.8 ms    10 runs

Summary
  git archive HEAD | scip-syntax-par index tar - -l java -o par.scip ran
    7.15 ± 1.36 times faster than git archive HEAD | scip-syntax index tar - -l java -o main.scip

spring-framework on  main [?]
❯ scip-syntax scip-evaluate --ground-truth main.scip --candidate par.scip
{"precision_percent":"100.0","recall_percent":"100.0","true_positives":"569982.0","false_positives":"0.0","false_negatives":"0.0"}
```

## Test plan

Compare the output of `scip-syntax` from `main` against the output of this branch with `scip-syntax scip-evaluate`