### PR TITLE
fetch User.id to suppress GraphQL cache warning

### DIFF
--- a/client/web/src/integration/profile.test.ts
+++ b/client/web/src/integration/profile.test.ts
@@ -132,6 +132,7 @@ describe('User Different Settings Page', () => {
             ...commonWebGraphQlResults,
             UserExternalAccountsWithAccountData: () => ({
                 user: {
+                    id: 'u1',
                     __typename: 'User',
                     externalAccounts: {
                         __typename: 'ExternalAccountConnection',

--- a/client/web/src/user/settings/backend.tsx
+++ b/client/web/src/user/settings/backend.tsx
@@ -48,6 +48,7 @@ export const userExternalAccountFragment = gql`
 export const USER_EXTERNAL_ACCOUNTS = gql`
     query UserExternalAccountsWithAccountData($username: String!) {
         user(username: $username) {
+            id
             externalAccounts {
                 nodes {
                     id


### PR DESCRIPTION
Fixes `Cache data may be lost when replacing the user field of a Query object. ...`


## Test plan

n/a