### PR TITLE
fix(search): Token decoration in keyword-enabled query input

### DIFF
--- a/client/branded/src/search-ui/input/CodeMirrorQueryInput.tsx
+++ b/client/branded/src/search-ui/input/CodeMirrorQueryInput.tsx
@@ -17,7 +17,6 @@ import { isInputElement } from '@sourcegraph/shared/src/util/dom'
 
 import { BaseCodeMirrorQueryInput, type BaseCodeMirrorQueryInputProps } from './BaseCodeMirrorQueryInput'
 import { createDefaultSuggestions, placeholder as placeholderExtension } from './codemirror'
-import { decorateActiveFilter, filterPlaceholder } from './codemirror/active-filter'
 import { queryDiagnostic } from './codemirror/diagnostics'
 import { HISTORY_USER_EVENT, searchHistory as searchHistoryFacet } from './codemirror/history'
 import { useMutableValue, useOnValueChanged, useUpdateInputFromQueryState } from './codemirror/react'
@@ -212,10 +211,7 @@ export const CodeMirrorMonacoFacade: React.FunctionComponent<CodeMirrorQueryInpu
         ])
     )
 
-    const extensions = useMemo(
-        () => [filterDecoration, autocompletion, dynamicExtensions],
-        [autocompletion, dynamicExtensions]
-    )
+    const extensions = useMemo(() => [autocompletion, dynamicExtensions], [autocompletion, dynamicExtensions])
 
     // Always focus the editor on 'selectedSearchContextSpec' change
     useOnValueChanged(selectedSearchContextSpec, () => {
@@ -265,7 +261,7 @@ const staticExtension: Extension = [
     // The precedence of these extensions needs to be decreased
     // explicitly, otherwise the diagnostic indicators will be
     // hidden behind the highlight background color
-    Prec.low([tokenInfo(), decorateActiveFilter, filterPlaceholder]),
+    Prec.low([tokenInfo(), filterDecoration]),
 ]
 
 /**

--- a/client/web/src/savedSearches/SavedSearchForm.module.scss
+++ b/client/web/src/savedSearches/SavedSearchForm.module.scss
@@ -12,6 +12,10 @@
     align-items: center;
     cursor: text;
 
+    :global(.cm-editor) {
+        flex: 1;
+    }
+
     &:focus-within {
         border: 1px solid var(--input-focus-border-color);
         box-shadow: var(--search-box-focus-box-shadow);


### PR DESCRIPTION
Fixes srch-646

This commit fixes how tokens are decorated in the query input. The "chip" style needs to have lower presedence than the syntax highlighting so that it doesn't get split across the individual parts of e.g. a repo filter.

This commit also removes the activeFilter extension. It was conflicting a bit with the filter decoration. This should be fine since it wasn't used for quite a while in the main search input either.

I also noticed an issue with the size of the CodeMirror input in the saved searches form. I couldn't enter any query actually because the input was too "narrow". Adding `flex:1` fixes that.


## Test plan

Manual testing.

![2024-06-28_13-12](https://github.com/sourcegraph/sourcegraph/assets/179026/4aff056c-2a18-4a41-9033-94d642c0858b)
