### PR TITLE
fix(sg/bazel-do): use ci.sourcegraph.bazelrc with bazel-do

### DIFF
--- a/dev/ci/internal/ci/bazel_helpers.go
+++ b/dev/ci/internal/ci/bazel_helpers.go
@@ -32,6 +32,7 @@ func bazelCmd(args ...string) string {
 		genBazelRC,
 		"bazel",
 		fmt.Sprintf("--bazelrc=%s", bazelrc),
+		fmt.Sprintf("--bazelrc=%s", ".aspect/bazelrc/ci.sourcegraph.bazelrc"),
 	}
 	Cmd := append(pre, args...)
 	return strings.Join(Cmd, " ")


### PR DESCRIPTION
Without `ci.sourcegraph.bazelrc` the bazel environment won't have the right credentials to access the db. This adds the rc to the bazel-do invocation.

For context - the `ci.sourcegraph.bazelrc` contains this following
```
# Needed for DB in CI
common --test_env=PGUSER=postgres
common --test_env=PGPASSWORD=postgres
common --test_env=PGSSLMODE=disable
common --test_env=PGDATABASE=postgres
```

## Test plan
https://buildkite.com/sourcegraph/sourcegraph/builds/280332#01905ef3-1fce-4d76-bf5b-0530dc434cff
<!-- REQUIRED; info at https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles -->

## Changelog
* sg - ensure bazel-do invocations use the ci sourcegraph bazelrc
