### PR TITLE
fix(svelte): Reference layout shift while loading data

### DIFF
--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/ReferencePanel.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/ReferencePanel.svelte
@@ -42,9 +42,10 @@
 
     $: previewURL = selectedLocation ? getPreviewURL(selectedLocation) : null
     $: locations = connection ? unique(connection.nodes) : []
+    $: isEmpty = locations.length === 0
 </script>
 
-<div class="root" class:loading>
+<div class="root">
     <PanelGroup id="references">
         <Panel id="references-list">
             <Scroller margin={600} on:more>
@@ -76,9 +77,9 @@
                         </li>
                     {/each}
                 </ul>
-                {#if loading}
+                <div class="loader" class:empty={isEmpty}>
                     <LoadingSpinner center />
-                {/if}
+                </div>
             </Scroller>
         </Panel>
         {#if previewURL}
@@ -93,10 +94,6 @@
 <style lang="scss">
     .root {
         height: 100%;
-
-        &.loading {
-            padding: 1rem;
-        }
 
         :global([data-panel-id='reference-panel-preview']) {
             z-index: 0;
@@ -130,6 +127,7 @@
         }
     }
 
+    ul:not(:empty) + .loader,
     li + li {
         border-top: 1px solid var(--border-color);
     }
@@ -155,5 +153,9 @@
     .range {
         color: var(--oc-violet-6);
         text-align: left;
+    }
+
+    .loader {
+        padding: 1rem;
     }
 </style>

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/ReferencePanel.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/ReferencePanel.svelte
@@ -42,7 +42,6 @@
 
     $: previewURL = selectedLocation ? getPreviewURL(selectedLocation) : null
     $: locations = connection ? unique(connection.nodes) : []
-    $: isEmpty = locations.length === 0
 </script>
 
 <div class="root">
@@ -77,9 +76,9 @@
                         </li>
                     {/each}
                 </ul>
-                <div class="loader" class:empty={isEmpty}>
-                    <LoadingSpinner center />
-                </div>
+                {#if loading}
+                    <div class="loader"><LoadingSpinner center /></div>
+                {/if}
             </Scroller>
         </Panel>
         {#if previewURL}

--- a/client/web-sveltekit/vite.config.ts
+++ b/client/web-sveltekit/vite.config.ts
@@ -81,7 +81,7 @@ export default defineConfig(({ mode }) => {
                 // instance.
                 '^(/sign-in|/.assets|/-|/.api|/search/stream|/users|/notebooks|/insights|/batch-changes)|/-/(raw|compare|own|code-graph|batch-changes|settings)(/|$)':
                     {
-                        target: process.env.SOURCEGRAPH_API_URL || 'https://sourcegraph.com',
+                        target: process.env.SOURCEGRAPH_API_URL || 'https://sourcegraph.sourcegraph.com',
                         changeOrigin: true,
                         secure: false,
                     },


### PR DESCRIPTION
This commit fixes an issue with layout shifting while loading data in the reference. The class/style was incorrectly applied causing additional padding to be added while data was loading. This commit fixes that and

- adds a divider between the last list item and the loader
- changes the default proxy to be S2. Dotcom didn't make sense anymore now that `pnpm dev:dotcom` does that explicitly.

## Test plan

Manual testing
