### PR TITLE
fix(batch-changes): fix zero division error resulting in wrong stats computaion

### DIFF
--- a/cmd/frontend/internal/batches/resolvers/changesets_stats.go
+++ b/cmd/frontend/internal/batches/resolvers/changesets_stats.go
@@ -65,6 +65,12 @@ func (r *changesetsStatsResolver) PercentComplete() int32 {
 	mergedAndClosed := float32(r.stats.Merged + r.stats.Closed)
 	// We don't count archived or deleted changesets when computing `percentComplete`.
 	noOfIncludedChangesets := float32(r.stats.Total - r.stats.Archived - r.stats.Deleted)
+
+	// To prevent an zero division, we check if the denominator is 0, if it is we return early.
+	// Usually this happens when all the changesets belonging to a batch change are archived or deleted.
+	if noOfIncludedChangesets == 0 {
+		return 100
+	}
 	return int32((mergedAndClosed / noOfIncludedChangesets) * 100)
 }
 

--- a/cmd/frontend/internal/batches/resolvers/changesets_stats_test.go
+++ b/cmd/frontend/internal/batches/resolvers/changesets_stats_test.go
@@ -68,4 +68,23 @@ func TestChangesetsStatsResolver(t *testing.T) {
 		require.Equal(t, r.IsCompleted(), false)
 		require.Equal(t, r.PercentComplete(), int32(22))
 	})
+
+	t.Run("all archived changeset", func(t *testing.T) {
+		stats := btypes.ChangesetsStats{
+			CommonChangesetsStats: btypes.CommonChangesetsStats{
+				Unpublished: 0,
+				Draft:       0,
+				Open:        0,
+				Merged:      0,
+				Closed:      0,
+				Total:       4,
+			},
+			Deleted:  2,
+			Archived: 2,
+		}
+
+		r := changesetsStatsResolver{stats: stats}
+		require.Equal(t, r.IsCompleted(), true)
+		require.Equal(t, r.PercentComplete(), int32(100))
+	})
 }


### PR DESCRIPTION
Closes [SRCH-636](https://linear.app/sourcegraph/issue/SRCH-636/batch-changes-overflow-when-calculating-percent-complete)

## Test plan

Added unit tests

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
