### PR TITLE
fix/enterpriseportal: forcibly run gorm-incompatible migration in local dev

### DIFF
--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -417,6 +417,9 @@ commands:
       go build -gcflags="$GCFLAGS" -o .bin/enterprise-portal github.com/sourcegraph/sourcegraph/cmd/enterprise-portal
       # Ensure the "msp_iam" database exists (PostgreSQL has no "IF NOT EXISTS" option).
       createdb -h $PGHOST -p $PGPORT -U $PGUSER msp_iam || true
+      # HACK: Forcibly handle a migration that GORM doesn't seem to handle right
+      psql -h $PGHOST -p $PGPORT -U $PGUSER -d $PGDATABASE \
+        -c 'ALTER TABLE enterprise_portal_subscriptions ALTER COLUMN id TYPE uuid USING id::uuid;' || true
     checkBinary: .bin/enterprise-portal
     env:
       PORT: '6081'


### PR DESCRIPTION
As titled - in deployments we ran this by hand already. We use `|| true` to make the forced migration non-blocking if it fails in case it just works, though in local testing it seems that command is idempotent anyway

See https://github.com/sourcegraph/devx-support/issues/1070

## Test plan

```
sg run enterprise-portal
```

```
sql -d sourcegraph -c 'ALTER TABLE enterprise_portal_subscriptions ALTER COLUMN id TYPE uuid USING id::uuid;'
```