### PR TITLE
(chore)analytics: consistent naming of web code copied events

### DIFF
--- a/client/branded/src/search-ui/components/FileMatchChildren.tsx
+++ b/client/branded/src/search-ui/components/FileMatchChildren.tsx
@@ -48,7 +48,9 @@ export const FileMatchChildren: React.FunctionComponent<React.PropsWithChildren<
 
     const logEventOnCopy = useCallback(() => {
         telemetryService.log(...codeCopiedEvent('search-result'))
-        telemetryRecorder.recordEvent('code', 'copy', { metadata: { page: V2CodyCopyPageTypes['search-result'] } })
+        telemetryRecorder.recordEvent('search.result.code', 'copy', {
+            metadata: { page: V2CodyCopyPageTypes['search-result'] },
+        })
     }, [telemetryService, telemetryRecorder])
 
     return (

--- a/client/branded/src/search-ui/components/SymbolSearchResult.tsx
+++ b/client/branded/src/search-ui/components/SymbolSearchResult.tsx
@@ -84,7 +84,9 @@ export const SymbolSearchResult: React.FunctionComponent<SymbolSearchResultProps
 
     const logEventOnCopy = useCallback(() => {
         telemetryService.log(...codeCopiedEvent('search-result'))
-        telemetryRecorder.recordEvent('code', 'copy', { metadata: { page: V2CodyCopyPageTypes['search-result'] } })
+        telemetryRecorder.recordEvent('search.result.code', 'copy', {
+            metadata: { page: V2CodyCopyPageTypes['search-result'] },
+        })
     }, [telemetryService, telemetryRecorder])
 
     const [hasBeenVisible, setHasBeenVisible] = useState(false)

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/FileView.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/FileView.svelte
@@ -118,7 +118,7 @@
     }
 
     function handleCopy(): void {
-        TELEMETRY_RECORDER.recordEvent('repo.blob', 'copy')
+        TELEMETRY_RECORDER.recordEvent('blob.code', 'copy')
     }
 
     function onViewModeChange(event: CustomEvent<CodeViewMode>): void {

--- a/client/web-sveltekit/src/routes/search/SearchResults.svelte
+++ b/client/web-sveltekit/src/routes/search/SearchResults.svelte
@@ -129,7 +129,7 @@
     }
 
     function handleResultCopy(): void {
-        TELEMETRY_RECORDER.recordEvent('search.result.area', 'copy')
+        TELEMETRY_RECORDER.recordEvent('search.result.code', 'copy')
     }
 
     function handleSearchResultClick(index: number): void {

--- a/client/web/src/repo/blob/CodeMirrorBlob.tsx
+++ b/client/web/src/repo/blob/CodeMirrorBlob.tsx
@@ -504,7 +504,7 @@ export const CodeMirrorBlob: React.FunctionComponent<BlobProps> = props => {
 
     const logEventOnCopy = useCallback(() => {
         telemetryService.log(...codeCopiedEvent('blob-view'))
-        telemetryRecorder.recordEvent('repo.blob.code', 'copy')
+        telemetryRecorder.recordEvent('blob.code', 'copy')
     }, [telemetryService, telemetryRecorder])
 
     return (


### PR DESCRIPTION
Consistent naming of all code copied events. Prompted by a discussion in Slack: https://sourcegraph.slack.com/archives/C05BGNBEPKL/p1719562715227509

## Test plan

CI

## Changelog
