### PR TITLE
fix(search): VSCode Search extension: hide file preview link

### DIFF
--- a/client/branded/src/search-ui/components/FileContentSearchResult.tsx
+++ b/client/branded/src/search-ui/components/FileContentSearchResult.tsx
@@ -81,6 +81,13 @@ interface Props extends SettingsCascadeProps, TelemetryProps, TelemetryV2Props {
     openInNewTab?: boolean
 
     index: number
+
+    /**
+     * Don't display the file preview button in the VSCode extension.
+     * Expose this prop to allow the VSCode extension to hide the button.
+     * Name it "hide" in an attempt to communicate that hiding is a special case.
+     */
+    hideFilePreviewButton?: boolean
 }
 
 const BY_LINE_RANKING = 'by-line-number'
@@ -99,6 +106,7 @@ export const FileContentSearchResult: React.FunctionComponent<React.PropsWithChi
     telemetryRecorder,
     fetchHighlightedFileLineRanges,
     onSelect,
+    hideFilePreviewButton = false, // hiding the file preview button is a special case for the VSCode extension; we normally want it shown.
 }) => {
     const repoAtRevisionURL = getRepositoryUrl(result.repository, result.branches)
     const revisionDisplayName = getRevision(result.branches, result.commit)
@@ -242,11 +250,13 @@ export const FileContentSearchResult: React.FunctionComponent<React.PropsWithChi
             rankingDebug={result.debug}
             repoLastFetched={result.repoLastFetched}
             actions={
-                <SearchResultPreviewButton
-                    result={result}
-                    telemetryService={telemetryService}
-                    telemetryRecorder={telemetryRecorder}
-                />
+                !hideFilePreviewButton ? (
+                    <SearchResultPreviewButton
+                        result={result}
+                        telemetryService={telemetryService}
+                        telemetryRecorder={telemetryRecorder}
+                    />
+                ) : undefined
             }
         >
             <VisibilitySensor

--- a/client/branded/src/search-ui/components/FilePathSearchResult.tsx
+++ b/client/branded/src/search-ui/components/FilePathSearchResult.tsx
@@ -20,6 +20,12 @@ export interface FilePathSearchResult extends SettingsCascadeProps {
     onSelect: () => void
     containerClassName?: string
     index: number
+    /**
+     * Don't display the file preview button in the VSCode extension.
+     * Expose this prop to allow the VSCode extension to hide the button.
+     * Name it "hide" in an attempt to communicate that hiding is a special case.
+     */
+    hideFilePreviewButton?: boolean
 }
 
 export const FilePathSearchResult: FC<FilePathSearchResult & TelemetryProps & TelemetryV2Props> = ({
@@ -31,6 +37,7 @@ export const FilePathSearchResult: FC<FilePathSearchResult & TelemetryProps & Te
     telemetryService,
     telemetryRecorder,
     settingsCascade,
+    hideFilePreviewButton = false, // hiding the file preview button is a special case for the VSCode extension; we normally want it shown.
 }) => {
     const repoAtRevisionURL = getRepositoryUrl(result.repository, result.branches)
     const revisionDisplayName = getRevision(result.branches, result.commit)
@@ -72,11 +79,13 @@ export const FilePathSearchResult: FC<FilePathSearchResult & TelemetryProps & Te
             className={classNames(resultStyles.copyButtonContainer, containerClassName)}
             repoLastFetched={result.repoLastFetched}
             actions={
-                <SearchResultPreviewButton
-                    result={result}
-                    telemetryService={telemetryService}
-                    telemetryRecorder={telemetryRecorder}
-                />
+                !hideFilePreviewButton ? (
+                    <SearchResultPreviewButton
+                        result={result}
+                        telemetryService={telemetryService}
+                        telemetryRecorder={telemetryRecorder}
+                    />
+                ) : undefined
             }
         />
     )

--- a/client/branded/src/search-ui/results/StreamingSearchResultsList.tsx
+++ b/client/branded/src/search-ui/results/StreamingSearchResultsList.tsx
@@ -267,6 +267,7 @@ export const StreamingSearchResultsList: React.FunctionComponent<
             enableRepositoryMetadata,
             buildSearchURLQueryFromQueryState,
             logSearchResultClicked,
+            hideFilePreviewButton,
         ]
     )
 

--- a/client/branded/src/search-ui/results/StreamingSearchResultsList.tsx
+++ b/client/branded/src/search-ui/results/StreamingSearchResultsList.tsx
@@ -91,6 +91,11 @@ export interface StreamingSearchResultsListProps
 
     enableRepositoryMetadata?: boolean
     className?: string
+
+    /**
+     * Hide the file preview button in `FileContentSearchResult` and `FilePathSearchResult`
+     */
+    hideFilePreviewButton?: boolean
 }
 
 export const StreamingSearchResultsList: React.FunctionComponent<
@@ -118,6 +123,7 @@ export const StreamingSearchResultsList: React.FunctionComponent<
     enableRepositoryMetadata,
     queryExamplesPatternType = SearchPatternType.standard,
     className,
+    hideFilePreviewButton = false,
 }) => {
     const resultsNumber = results?.results.length || 0
     const { itemsToShow, handleBottomHit } = useItemsToShow(executedQuery, resultsNumber)
@@ -154,6 +160,7 @@ export const StreamingSearchResultsList: React.FunctionComponent<
                                         settingsCascade={settingsCascade}
                                         openInNewTab={openMatchesInNewTab}
                                         containerClassName={resultClassName}
+                                        hideFilePreviewButton={hideFilePreviewButton}
                                     />
                                 )}
                                 {result.type === 'symbol' && (
@@ -180,6 +187,7 @@ export const StreamingSearchResultsList: React.FunctionComponent<
                                         telemetryService={telemetryService}
                                         telemetryRecorder={telemetryRecorder}
                                         settingsCascade={settingsCascade}
+                                        hideFilePreviewButton={hideFilePreviewButton}
                                     />
                                 )}
                             </PrefetchableFile>

--- a/client/vscode/src/webview/search-panel/SearchResultsView.tsx
+++ b/client/vscode/src/webview/search-panel/SearchResultsView.tsx
@@ -393,6 +393,8 @@ export const SearchResultsView: React.FunctionComponent<React.PropsWithChildren<
                             resultClassName="mr-0"
                             showQueryExamplesOnNoResultsPage={true}
                             selectedSearchContextSpec={context.selectedSearchContextSpec}
+                            // The VSCode extension does not support file preview, so turn that off in the search results.
+                            hideFilePreviewButton={true}
                         />
                     </MatchHandlersContext.Provider>
                 </div>


### PR DESCRIPTION
The VSCode Search extension does not support file preview, so hide it from the search results when the search originates from the VSCode Search extension.

Example showing the file preview links (before this PR):
<img width="1511" alt="Screenshot 2024-06-28 at 09 42 26" src="https://github.com/sourcegraph/sourcegraph/assets/129280/552cef26-9109-487a-96dd-0789d758c074">

Example without the file preview links (after this PR):
<img width="1511" alt="Screenshot 2024-06-28 at 09 43 46" src="https://github.com/sourcegraph/sourcegraph/assets/129280/c53a1c8e-c27e-4958-808b-e5469745d182">

## Test plan

### Automated tests still pass
Including visual and functional tests of the file preview functionality.

### Build and run locally

#### Build
```
git switch peterguy/vscode-hide-preview-file-link
cd client/vscode
pnpm run build
```
#### Run
- Launch extension in VSCode: open the `Run and Debug` sidebar view in VS Code, then select `Launch VS Code Extension` from the dropdown menu.
- Run a search using the search bar.
- See that the file preview link 

### Check that the file preview link exists in the web app
The web app uses the branded components also, so run `sg start` or `sg start web-standalone`, do a search and see that the file preview link still exists.
If you want to be an over-achiever, you can edit `client/branded/src/search-ui/results/StreamingSearchResultsList.tsx`, changing `hideFilePreviewButton = false,` to `hideFilePreviewButton = true,` and reload the search results to see that the file preview link disappears.
