### PR TITLE
fix(search): VSCode Search extension: hide file preview link

### DIFF
--- a/client/vscode/scripts/build.ts
+++ b/client/vscode/scripts/build.ts
@@ -117,6 +117,18 @@ export async function build(): Promise<void> {
                     './CommitSearchResult': require.resolve('../src/webview/search-panel/alias/CommitSearchResult'),
                     './SymbolSearchResult': require.resolve('../src/webview/search-panel/alias/SymbolSearchResult'),
                     './FileMatchChildren': require.resolve('../src/webview/search-panel/alias/FileMatchChildren'),
+                    // The VSCode Search extension should not display the file preview link on search results.
+                    // Rather than controlling the display of the file preview links by modifying shared components
+                    // in `branded` and drilling props from the vscode code to those shared components,
+                    // clone the affected shared components (FileContentSearchResult and FilePathSearchResult)
+                    // and remove the `SearchResultPreviewButton` from the cloned files.
+                    // This approach is legitimate only because the VSCode Search extension has a limited lifespan at this point
+                    // (it will be merged with Cody in the near future), so the added overhead of keeping track of duplicate code
+                    // (and _finding_ that duplicated code) will be limited.
+                    './FileContentSearchResult': require.resolve(
+                        '../src/webview/search-panel/alias/FileContentSearchResult'
+                    ),
+                    './FilePathSearchResult': require.resolve('../src/webview/search-panel/alias/FilePathSearchResult'),
                     './RepoFileLink': require.resolve('../src/webview/search-panel/alias/RepoFileLink'),
                     '../documentation/ModalVideo': require.resolve('../src/webview/search-panel/alias/ModalVideo'),
                 }),

--- a/client/vscode/src/webview/search-panel/alias/FileContentSearchResult.tsx
+++ b/client/vscode/src/webview/search-panel/alias/FileContentSearchResult.tsx
@@ -1,0 +1,328 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+
+import { mdiChevronDown, mdiChevronUp } from '@mdi/js'
+import classNames from 'classnames'
+import VisibilitySensor from 'react-visibility-sensor'
+import type { Observable } from 'rxjs'
+import { catchError } from 'rxjs/operators'
+
+import { CopyPathAction } from '@sourcegraph/branded/src/search-ui/components/CopyPathAction'
+import styles from '@sourcegraph/branded/src/search-ui/components/FileContentSearchResult.module.scss'
+import { ResultContainer } from '@sourcegraph/branded/src/search-ui/components/ResultContainer'
+import resultStyles from '@sourcegraph/branded/src/search-ui/components/ResultContainer.module.scss'
+import { asError, isErrorLike, pluralize } from '@sourcegraph/common'
+import type { FetchFileParameters } from '@sourcegraph/shared/src/backend/file'
+import {
+    type MatchGroup,
+    rankByLine,
+    rankPassthrough,
+    truncateGroups,
+} from '@sourcegraph/shared/src/components/ranking/PerFileResultRanking'
+import { HighlightResponseFormat } from '@sourcegraph/shared/src/graphql-operations'
+import {
+    type ContentMatch,
+    type ChunkMatch,
+    getFileMatchUrl,
+    getRepositoryUrl,
+    getRevision,
+    type LineMatch,
+} from '@sourcegraph/shared/src/search/stream'
+import { useSettings, type SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
+import type { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
+import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
+import { Icon } from '@sourcegraph/wildcard'
+
+import { FileMatchChildren } from './FileMatchChildren'
+import { RepoFileLink } from './RepoFileLink'
+
+const DEFAULT_VISIBILITY_OFFSET = { bottom: -500 }
+
+interface Props extends SettingsCascadeProps, TelemetryProps, TelemetryV2Props {
+    /**
+     * The file match search result.
+     */
+    result: ContentMatch
+
+    /**
+     * Formatted repository name to be displayed in repository link. If not
+     * provided, the default format will be displayed.
+     */
+    repoDisplayName?: string
+
+    /**
+     * Called when the file's search result is selected.
+     */
+    onSelect: () => void
+
+    /**
+     * Whether this file should be rendered as expanded by default.
+     */
+    defaultExpanded: boolean
+
+    /**
+     * Whether or not to show all matches for this file, or only a subset.
+     */
+    showAllMatches: boolean
+
+    allExpanded?: boolean
+
+    fetchHighlightedFileLineRanges: (parameters: FetchFileParameters, force?: boolean) => Observable<string[][]>
+
+    /**
+     * CSS class name to be applied to the ResultContainer Component
+     */
+    containerClassName?: string
+
+    /**
+     * Clicking on a match opens the link in a new tab.
+     */
+    openInNewTab?: boolean
+
+    index: number
+}
+
+const BY_LINE_RANKING = 'by-line-number'
+
+export const FileContentSearchResult: React.FunctionComponent<React.PropsWithChildren<Props>> = ({
+    containerClassName,
+    result,
+    settingsCascade,
+    index,
+    repoDisplayName,
+    defaultExpanded,
+    allExpanded,
+    showAllMatches,
+    openInNewTab,
+    telemetryService,
+    telemetryRecorder,
+    fetchHighlightedFileLineRanges,
+    onSelect,
+}) => {
+    const repoAtRevisionURL = getRepositoryUrl(result.repository, result.branches)
+    const revisionDisplayName = getRevision(result.branches, result.commit)
+
+    const settings = useSettings()
+    const reranker = useMemo(() => {
+        if (settings?.experimentalFeatures?.clientSearchResultRanking === BY_LINE_RANKING) {
+            return rankByLine
+        }
+        return rankPassthrough
+    }, [settings])
+
+    const contextLines = useMemo(() => settings?.['search.contextLines'] ?? 1, [settings])
+
+    const unhighlightedGroups: MatchGroup[] = useMemo(() => reranker(matchesToMatchGroups(result)), [result, reranker])
+
+    const [expandedGroups, setExpandedGroups] = useState(unhighlightedGroups)
+    const collapsedGroups = truncateGroups(expandedGroups, 5, contextLines)
+
+    const [hasBeenVisible, setHasBeenVisible] = useState(false)
+    const onVisible = useCallback(() => {
+        if (hasBeenVisible) {
+            return
+        }
+        setHasBeenVisible(true)
+
+        // This file contains some large lines, avoid stressing
+        // syntax-highlighter and the browser.
+        if (result.chunkMatches?.some(chunk => chunk.contentTruncated)) {
+            return
+        }
+
+        const subscription = fetchHighlightedFileLineRanges(
+            {
+                repoName: result.repository,
+                commitID: result.commit || '',
+                filePath: result.path,
+                disableTimeout: false,
+                format: HighlightResponseFormat.HTML_HIGHLIGHT,
+                // Explicitly narrow the object otherwise we'll send a bunch of extra data in the request.
+                ranges: unhighlightedGroups.map(({ startLine, endLine }) => ({ startLine, endLine })),
+            },
+            false
+        )
+            .pipe(catchError(error => [asError(error)]))
+            .subscribe(res => {
+                if (!isErrorLike(res)) {
+                    setExpandedGroups(
+                        unhighlightedGroups.map((group, i) => ({
+                            ...group,
+                            highlightedHTMLRows: res[i],
+                        }))
+                    )
+                }
+            })
+        return () => subscription.unsubscribe()
+    }, [result, unhighlightedGroups, hasBeenVisible, fetchHighlightedFileLineRanges])
+
+    const expandedHighlightCount = countHighlightRanges(expandedGroups)
+    const collapsedHighlightCount = countHighlightRanges(collapsedGroups)
+
+    const hiddenMatchesCount = expandedHighlightCount - collapsedHighlightCount
+    const collapsible = !showAllMatches && expandedHighlightCount > collapsedHighlightCount
+
+    const [expanded, setExpanded] = useState(allExpanded || defaultExpanded)
+    useEffect(() => setExpanded(allExpanded || defaultExpanded), [allExpanded, defaultExpanded])
+
+    const rootRef = useRef<HTMLDivElement>(null)
+    const toggle = useCallback((): void => {
+        if (collapsible) {
+            setExpanded(expanded => !expanded)
+        }
+
+        // Scroll back to top of result when collapsing
+        if (expanded) {
+            setTimeout(() => {
+                const reducedMotion = !window.matchMedia('(prefers-reduced-motion: no-preference)').matches
+                rootRef.current?.scrollIntoView({ block: 'nearest', behavior: reducedMotion ? 'auto' : 'smooth' })
+            }, 0)
+        }
+    }, [collapsible, expanded])
+
+    const title = (
+        <>
+            <span className="d-flex align-items-center">
+                <RepoFileLink
+                    repoName={result.repository}
+                    repoURL={repoAtRevisionURL}
+                    filePath={result.path}
+                    pathMatchRanges={result.pathMatches ?? []}
+                    fileURL={getFileMatchUrl(result)}
+                    repoDisplayName={
+                        repoDisplayName
+                            ? `${repoDisplayName}${revisionDisplayName ? `@${revisionDisplayName}` : ''}`
+                            : undefined
+                    }
+                    className={resultStyles.titleInner}
+                />
+                <CopyPathAction
+                    className={resultStyles.copyButton}
+                    filePath={result.path}
+                    telemetryService={telemetryService}
+                    telemetryRecorder={telemetryRecorder}
+                />
+            </span>
+        </>
+    )
+
+    useEffect(() => {
+        const ref = rootRef.current
+        if (!ref) {
+            return
+        }
+
+        const expand = (): void => setExpanded(true)
+        const collapse = (): void => setExpanded(false)
+        const toggle = (): void => setExpanded(expanded => !expanded)
+
+        // Custom events triggered by search results keyboard navigation (from the useSearchResultsKeyboardNavigation hook).
+        ref.addEventListener('expandSearchResultsGroup', expand)
+        ref.addEventListener('collapseSearchResultsGroup', collapse)
+        ref.addEventListener('toggleSearchResultsGroup', toggle)
+
+        return () => {
+            ref.removeEventListener('expandSearchResultsGroup', expand)
+            ref.removeEventListener('collapseSearchResultsGroup', collapse)
+            ref.removeEventListener('toggleSearchResultsGroup', toggle)
+        }
+    }, [rootRef, setExpanded])
+
+    return (
+        <ResultContainer
+            ref={rootRef}
+            index={index}
+            title={title}
+            resultType={result.type}
+            onResultClicked={onSelect}
+            repoName={result.repository}
+            repoStars={result.repoStars}
+            className={classNames(resultStyles.copyButtonContainer, containerClassName)}
+            rankingDebug={result.debug}
+            repoLastFetched={result.repoLastFetched}
+        >
+            <VisibilitySensor
+                onChange={(visible: boolean) => visible && onVisible()}
+                partialVisibility={true}
+                offset={DEFAULT_VISIBILITY_OFFSET}
+            >
+                <div data-testid="file-search-result" data-expanded={expanded}>
+                    <FileMatchChildren
+                        result={result}
+                        grouped={expanded ? expandedGroups : collapsedGroups}
+                        settingsCascade={settingsCascade}
+                        telemetryService={telemetryService}
+                        telemetryRecorder={telemetryRecorder}
+                        openInNewTab={openInNewTab}
+                    />
+                    {collapsible && (
+                        <button
+                            type="button"
+                            className={classNames(
+                                styles.toggleMatchesButton,
+                                resultStyles.focusableBlock,
+                                resultStyles.clickable,
+                                expanded && styles.toggleMatchesButtonExpanded
+                            )}
+                            onClick={toggle}
+                            data-testid="toggle-matches-container"
+                        >
+                            <Icon aria-hidden={true} svgPath={expanded ? mdiChevronUp : mdiChevronDown} />
+                            <span className={styles.toggleMatchesButtonText}>
+                                {expanded
+                                    ? 'Show less'
+                                    : `Show ${hiddenMatchesCount} more ${pluralize(
+                                          'match',
+                                          hiddenMatchesCount,
+                                          'matches'
+                                      )}`}
+                            </span>
+                        </button>
+                    )}
+                </div>
+            </VisibilitySensor>
+        </ResultContainer>
+    )
+}
+
+function countHighlightRanges(groups: MatchGroup[]): number {
+    return groups.reduce((count, group) => count + group.matches.length, 0)
+}
+
+function matchesToMatchGroups(result: ContentMatch): MatchGroup[] {
+    return [
+        ...(result.lineMatches?.map(lineToMatchGroup) ?? []),
+        ...(result.chunkMatches?.map(chunkToMatchGroup) ?? []),
+    ]
+}
+function chunkToMatchGroup(chunk: ChunkMatch): MatchGroup {
+    const matches = chunk.ranges.map(range => ({
+        startLine: range.start.line,
+        startCharacter: range.start.column,
+        endLine: range.end.line,
+        endCharacter: range.end.column,
+    }))
+    const plaintextLines = chunk.content.replace(/\r?\n$/, '').split(/\r?\n/)
+    return {
+        plaintextLines,
+        highlightedHTMLRows: undefined, // populated lazily
+        matches,
+        startLine: chunk.contentStart.line,
+        endLine: chunk.contentStart.line + plaintextLines.length,
+    }
+}
+
+function lineToMatchGroup(line: LineMatch): MatchGroup {
+    const matches = line.offsetAndLengths.map(offsetAndLength => ({
+        startLine: line.lineNumber,
+        startCharacter: offsetAndLength[0],
+        endLine: line.lineNumber,
+        endCharacter: offsetAndLength[0] + offsetAndLength[1],
+    }))
+    return {
+        plaintextLines: [line.line],
+        highlightedHTMLRows: undefined, // populated lazily
+        matches,
+        startLine: line.lineNumber,
+        endLine: line.lineNumber + 1, // the matches support `endLine` == `startLine`, but MatchGroup requires `endLine` > `startLine`
+    }
+}

--- a/client/vscode/src/webview/search-panel/alias/FilePathSearchResult.tsx
+++ b/client/vscode/src/webview/search-panel/alias/FilePathSearchResult.tsx
@@ -1,0 +1,74 @@
+import React, { type FC } from 'react'
+
+import classNames from 'classnames'
+
+import { CopyPathAction } from '@sourcegraph/branded/src/search-ui/components/CopyPathAction'
+import { ResultContainer } from '@sourcegraph/branded/src/search-ui/components/ResultContainer'
+import resultStyles from '@sourcegraph/branded/src/search-ui/components/ResultContainer.module.scss'
+import { getFileMatchUrl, getRepositoryUrl, getRevision, type PathMatch } from '@sourcegraph/shared/src/search/stream'
+import type { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
+import type { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
+import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
+
+import { RepoFileLink } from './RepoFileLink'
+
+export interface FilePathSearchResult extends SettingsCascadeProps {
+    result: PathMatch
+    repoDisplayName: string
+    onSelect: () => void
+    containerClassName?: string
+    index: number
+}
+
+export const FilePathSearchResult: FC<FilePathSearchResult & TelemetryProps & TelemetryV2Props> = ({
+    result,
+    repoDisplayName,
+    onSelect,
+    containerClassName,
+    index,
+    telemetryService,
+    telemetryRecorder,
+    settingsCascade,
+}) => {
+    const repoAtRevisionURL = getRepositoryUrl(result.repository, result.branches)
+    const revisionDisplayName = getRevision(result.branches, result.commit)
+
+    const title = (
+        <span className="d-flex align-items-center">
+            <RepoFileLink
+                repoName={result.repository}
+                repoURL={repoAtRevisionURL}
+                filePath={result.path}
+                pathMatchRanges={result.pathMatches ?? []}
+                fileURL={getFileMatchUrl(result)}
+                repoDisplayName={
+                    repoDisplayName
+                        ? `${repoDisplayName}${revisionDisplayName ? `@${revisionDisplayName}` : ''}`
+                        : undefined
+                }
+                className={resultStyles.titleInner}
+                isKeyboardSelectable={true}
+            />
+            <CopyPathAction
+                filePath={result.path}
+                className={resultStyles.copyButton}
+                telemetryService={telemetryService}
+                telemetryRecorder={telemetryRecorder}
+            />
+        </span>
+    )
+
+    return (
+        <ResultContainer
+            index={index}
+            title={title}
+            resultType={result.type}
+            onResultClicked={onSelect}
+            repoName={result.repository}
+            repoStars={result.repoStars}
+            rankingDebug={result.debug}
+            className={classNames(resultStyles.copyButtonContainer, containerClassName)}
+            repoLastFetched={result.repoLastFetched}
+        />
+    )
+}


### PR DESCRIPTION
The VSCode Search extension does not support file preview, so hide it from the search results when the search originates from the VSCode Search extension.

Example showing the file preview links (before this PR):
<img width="1511" alt="Screenshot 2024-06-28 at 09 42 26" src="https://github.com/sourcegraph/sourcegraph/assets/129280/552cef26-9109-487a-96dd-0789d758c074">

Example without the file preview links (after this PR):
<img width="1511" alt="Screenshot 2024-06-28 at 09 43 46" src="https://github.com/sourcegraph/sourcegraph/assets/129280/c53a1c8e-c27e-4958-808b-e5469745d182">

## Test plan

### Automated tests still pass
Including visual and functional tests of the file preview functionality.

### Build and run locally

#### Build
```
git switch peterguy/vscode-hide-preview-file-link
cd client/vscode
pnpm run build
```
#### Run
- Launch extension in VSCode: open the `Run and Debug` sidebar view in VS Code, then select `Launch VS Code Extension` from the dropdown menu.
- Run a content search using the search bar.
- See that the file preview link is not shown.
- Modify the search, adding `type:path`.
- See that the file preview link is not shown.
- Run other types of searches, like `type:commit` and verify expected behavior - this change should not affect any other type of search.
