### PR TITLE
chore(search): VSCode Search extension: Remove signup link for sourcegraph.com

### DIFF
--- a/client/vscode/src/webview/sidebars/auth/AuthSidebarView.tsx
+++ b/client/vscode/src/webview/sidebars/auth/AuthSidebarView.tsx
@@ -144,11 +144,6 @@ export const AuthSidebarView: React.FunctionComponent<React.PropsWithChildren<Au
         // If successful, update setting. This form will no longer be rendered
     }
 
-    const onSignUpClick = (): void => {
-        setHasAccount(true)
-        platformContext.telemetryService.log('VSCESidebarCreateAccount')
-    }
-
     if (state === 'success') {
         // This form should no longer be rendered as the extension context
         // will be invalidated. We should show a notification that the accessToken
@@ -168,25 +163,6 @@ export const AuthSidebarView: React.FunctionComponent<React.PropsWithChildren<Au
     if (!hasAccount && !accessToken) {
         return renderCommon(
             <>
-                <Text className={classNames(styles.ctaParagraph)}>
-                    Create an account to search across your private repositories and access advanced features: search
-                    multiple repositories & commit history, monitor code changes, save searches, and more.
-                </Text>
-                <div>
-                    <Link to={signUpURL} className={styles.ctaLink}>
-                        <VSCodeButton
-                            onClick={onSignUpClick}
-                            className={classNames(
-                                'my-1 p-0',
-                                styles.ctaButton,
-                                styles.ctaButtonWrapperWithContextBelow
-                            )}
-                            autofocus={false}
-                        >
-                            Create an account
-                        </VSCodeButton>
-                    </Link>
-                </div>
                 <VSCodeLink className="my-0" onClick={() => setHasAccount(true)}>
                     Have an account?
                 </VSCodeLink>
@@ -216,24 +192,6 @@ export const AuthSidebarView: React.FunctionComponent<React.PropsWithChildren<Au
                 </a>{' '}
                 for a video guide on how to create an access token.
             </Text>
-            {/* ---------- UNRELEASED FEATURE ---------- */}
-            {isSourcegraphDotCom && authenticatedUser?.displayName === 'sourcegraph' && (
-                <Text className={classNames(styles.ctaParagraph)}>
-                    <Link to={isSourcegraphDotCom} className={styles.ctaLink}>
-                        <VSCodeButton
-                            onClick={onSignUpClick}
-                            className={classNames(
-                                'my-1 p-0',
-                                styles.ctaButton,
-                                styles.ctaButtonWrapperWithContextBelow
-                            )}
-                            autofocus={false}
-                        >
-                            Continue in browser
-                        </VSCodeButton>
-                    </Link>
-                </Text>
-            )}
             <Text className={classNames(styles.ctaButtonWrapperWithContextBelow)}>
                 <Input
                     inputClassName={classNames('input', styles.ctaInput)}
@@ -286,11 +244,6 @@ export const AuthSidebarView: React.FunctionComponent<React.PropsWithChildren<Au
             <Text className="my-0">
                 <VSCodeLink onClick={() => onInstanceTypeChange()}>
                     {!usePrivateInstance ? 'Need to connect to a private instance?' : 'Not a private instance user?'}
-                </VSCodeLink>
-            </Text>
-            <Text className="my-0">
-                <VSCodeLink href={signUpURL} onClick={onSignUpClick}>
-                    Create an account
                 </VSCodeLink>
             </Text>
         </>

--- a/client/vscode/src/webview/sidebars/auth/AuthSidebarView.tsx
+++ b/client/vscode/src/webview/sidebars/auth/AuthSidebarView.tsx
@@ -5,14 +5,11 @@ import classNames from 'classnames'
 
 import { currentAuthStateQuery } from '@sourcegraph/shared/src/auth'
 import type { CurrentAuthStateResult, CurrentAuthStateVariables } from '@sourcegraph/shared/src/graphql-operations'
-import { Alert, Text, Link, Input, H5, Form } from '@sourcegraph/wildcard'
+import { Alert, Text, Input, H5, Form } from '@sourcegraph/wildcard'
 
 import {
     VSCE_LINK_DOTCOM,
     VSCE_LINK_MARKETPLACE,
-    VSCE_LINK_AUTH,
-    VSCE_LINK_TOKEN_CALLBACK,
-    VSCE_LINK_TOKEN_CALLBACK_TEST,
     VSCE_LINK_USER_DOCS,
     VSCE_SIDEBAR_PARAMS,
 } from '../../../common/links'
@@ -37,22 +34,11 @@ export const AuthSidebarView: React.FunctionComponent<React.PropsWithChildren<Au
     const [state, setState] = useState<'initial' | 'validating' | 'success' | 'failure'>('initial')
     const [hasAccount, setHasAccount] = useState(authenticatedUser?.username !== undefined)
     const [usePrivateInstance, setUsePrivateInstance] = useState(true)
-    const signUpURL = VSCE_LINK_AUTH('sign-up')
     const instanceHostname = useMemo(() => new URL(instanceURL).hostname, [instanceURL])
     const [hostname, setHostname] = useState(instanceHostname)
     const [accessToken, setAccessToken] = useState<string | undefined>('initial')
     const [endpointUrl, setEndpointUrl] = useState(instanceURL)
     const sourcegraphDotCom = 'https://www.sourcegraph.com'
-    const isSourcegraphDotCom = useMemo(() => {
-        const hostname = new URL(instanceURL).hostname
-        if (hostname === 'sourcegraph.com' || hostname === 'www.sourcegraph.com') {
-            return VSCE_LINK_TOKEN_CALLBACK
-        }
-        if (hostname === 'sourcegraph.test') {
-            return VSCE_LINK_TOKEN_CALLBACK_TEST
-        }
-        return null
-    }, [instanceURL])
 
     useEffect(() => {
         // Get access token from setting


### PR DESCRIPTION
De-cluttering the authentication options for the VSCE. Private code is no longer hosted on sourcegraph.com, so it's confusing to be directed there.

Addresses (at least partially) #45757
## Test plan

### Build and run locally

#### Build
```
git switch peterguy/vscode-address-confusing-auth-ux
cd client/vscode
pnpm build
```
#### Run
- Launch extension in VSCode: open the `Run and Debug` sidebar view in VS Code, then select `Launch VS Code Extension` from the dropdown menu.
- See that the "Create an account" links are missing from the sidebar

## Changelog

- Remove links to create an account on sourcegraph.com because it no longer hosts private code.