### PR TITLE
chore(search): VSCode Search extension: Remove url and token from configuration

### DIFF
--- a/client/vscode/package.json
+++ b/client/vscode/package.json
@@ -110,19 +110,6 @@
       "type": "object",
       "title": "Sourcegraph extension configuration",
       "properties": {
-        "sourcegraph.url": {
-          "type": [
-            "string"
-          ],
-          "default": "https://sourcegraph.com",
-          "description": "The base URL of the Sourcegraph instance to use."
-        },
-        "sourcegraph.accessToken": {
-          "type": [
-            null
-          ],
-          "description": "[Depreciated after v2.2.12] The access token to query the Sourcegraph API. Create a new access token at ${SOURCEGRAPH_URL}/users/<sourcegraph-username>/settings/tokens. Unless you are using a private instance of Sourcegraph, then ${SOURCEGRAPH_URL} is https://sourcegraph.com."
-        },
         "sourcegraph.remoteUrlReplacements": {
           "type": [
             "object"


### PR DESCRIPTION
They are no longer used from settings.json, so they should not appear in the settings.

## BEFORE
<img width="927" alt="BEFORE" src="https://github.com/sourcegraph/sourcegraph/assets/129280/60f7f4ae-078c-41a0-b6db-eadab17e10db">

## AFTER
<img width="983" alt="AFTER" src="https://github.com/sourcegraph/sourcegraph/assets/129280/92d9e5ff-ac9f-479b-8277-03b4fcfba88b">

## Test plan

### Build and run locally

#### Build
```
git switch peterguy/vscode-remove-url-and-token-from-config
cd client/vscode
pnpm build
```
#### Run
- Launch extension in VSCode: open the `Run and Debug` sidebar view in VS Code, then select `Launch VS Code Extension` from the dropdown menu.
- Navigate to the Settings page (Code --> Settings... or cmd + , on macOS), search for "sourcegraph" and verify that the access token and url are no longer present in the results.

## Changelog

- Remove access token and URL from extension settings because they are managed in the extension now.
