### PR TITLE
Add clarification for externalURL in site config

### DIFF
--- a/internal/conf/confdefaults/confdefaults.go
+++ b/internal/conf/confdefaults/confdefaults.go
@@ -34,10 +34,15 @@ var DevAndTesting = conftypes.RawUnified{
 // single-container instances of Sourcegraph.
 var DockerContainer = conftypes.RawUnified{
 	Site: `{
-	// The externally accessible URL for Sourcegraph (i.e., what you type into your browser)
+	// The externally accessible URL for this Sourcegraph instance.
+	// i.e. the address you enter in your browser's address bar.
 	// This is required to be configured for Sourcegraph to work correctly.
+	// Only root URLs are allowed.
+	// Note: When configured to the recommended https:// users will not be able to log in using http://
 	// "externalURL": "https://sourcegraph.example.com",
-
+	//
+	//
+	// The authentication providers to use for identifying and signing in users.
 	"auth.providers": [
 		{
 			"type": "builtin",
@@ -51,16 +56,17 @@ var DockerContainer = conftypes.RawUnified{
 // applied to Kubernetes, Docker Compose, and pure Docker instances of Sourcegraph.
 var KubernetesOrDockerComposeOrPureDocker = conftypes.RawUnified{
 	Site: `{
-	// The externally accessible URL for Sourcegraph (i.e., what you type into your browser)
+	// The externally accessible URL for this Sourcegraph instance.
+	// i.e. the address you enter in your browser's address bar.
 	// This is required to be configured for Sourcegraph to work correctly.
+	// Only root URLs are allowed.
+	// Note: When configured to the recommended https:// users will not be able to log in using http://
 	// "externalURL": "https://sourcegraph.example.com",
-
-	// The authentication provider to use for identifying and signing in users.
-	// Only one entry is supported.
 	//
-	// The builtin auth provider with signup disallowed (shown below) means that
+	//
+	// The authentication providers to use for identifying and signing in users.
+	// The builtin auth provider with signup disallowed (default) means that
 	// after the initial site admin signs in, all other users must be invited.
-	//
 	// Other providers are documented at https://sourcegraph.com/docs/admin/auth.
 	"auth.providers": [
 		{

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -1731,7 +1731,7 @@
       }
     },
     "externalURL": {
-      "description": "The externally accessible URL for Sourcegraph (i.e., what you type into your browser). Previously called `appURL`. Only root URLs are allowed.",
+      "description": "The externally accessible URL for this Sourcegraph instance (i.e. the address you enter in your browser's address bar). Only root URLs are allowed. \n\nNote: when configured to the recommended https:// users will not be able to log in using http://",
       "type": "string",
       "examples": ["https://sourcegraph.example.com"]
     },

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -1731,7 +1731,7 @@
       }
     },
     "externalURL": {
-      "description": "The externally accessible URL for this Sourcegraph instance (i.e. the address you enter in your browser's address bar). Only root URLs are allowed. \n\nNote: when configured to the recommended https:// users will not be able to log in using http://",
+      "description": "The externally accessible URL for this Sourcegraph instance. \n\ni.e. the address you enter in your browser's address bar. \n\nThis is required to be configured for Sourcegraph to work correctly. \n\nOnly root URLs are allowed. \n\nNote: When configured to the recommended https:// users will not be able to log in using http://",
       "type": "string",
       "examples": ["https://sourcegraph.example.com"]
     },


### PR DESCRIPTION
<!-- PR description tips: https://www.notion.so/sourcegraph/Write-a-good-pull-request-description-610a7fd3e613496eb76f450db5a49b6e -->
Clarifying the comments for the `externalURL` site config to prevent admins from configuring an https:// URL when port 443 is not open to their instance, thus locking themselves out of their instance.

https://linear.app/sourcegraph/issue/PS-17/add-clarification-to-site-admin-tooltip-for-externalurl-config 

## Test plan
<!-- REQUIRED; info at https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles -->
Verified in sg cloud eph deployment 

## Changelog
<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->