### PR TITLE
chore: preserve format imposed by bazel

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -76,5 +76,4 @@
   "rust-analyzer.linkedProjects": [
     "docker-images/syntax-highlighter/Cargo.toml"
   ],
-  "sourcegraph.accessToken": null
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -73,5 +73,8 @@
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
   "cody.codebase": "github.com/sourcegraph/sourcegraph",
-  "rust-analyzer.linkedProjects": ["docker-images/syntax-highlighter/Cargo.toml"]
+  "rust-analyzer.linkedProjects": [
+    "docker-images/syntax-highlighter/Cargo.toml"
+  ],
+  "sourcegraph.accessToken": null
 }


### PR DESCRIPTION
Running `bazel build --output_groups=+types //client/vscode:vscode_typings` caused a format change to `.vscode/settings.json`. The contents of the file are the same; just an entry is now wrapped.

<!-- PR description tips: https://www.notion.so/sourcegraph/Write-a-good-pull-request-description-610a7fd3e613496eb76f450db5a49b6e -->

## Test plan

Shouldn't be any needed. Maybe ensure vscode settings work?
