### PR TITLE
perf(scip-syntax): uses the same parse tree for globals and locals

### DIFF
--- a/docker-images/syntax-highlighter/Cargo.Bazel.lock
+++ b/docker-images/syntax-highlighter/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "31748fbba83a1f037f24462114667576f5abb10cf202f1ae7b083d6c48c5c1f1",
+  "checksum": "16af7384c373f405b14982ed18dfb8fd320f4c727086dc073cd004d1316c351d",
   "crates": {
     "addr2line 0.20.0": {
       "name": "addr2line",
@@ -10643,6 +10643,10 @@
             {
               "id": "tar 0.4.40",
               "target": "tar"
+            },
+            {
+              "id": "tree-sitter 0.20.10",
+              "target": "tree_sitter"
             },
             {
               "id": "walkdir 2.3.3",

--- a/docker-images/syntax-highlighter/Cargo.lock
+++ b/docker-images/syntax-highlighter/Cargo.lock
@@ -1931,6 +1931,7 @@ dependencies = [
  "syntax-analysis",
  "tar",
  "tempfile",
+ "tree-sitter",
  "tree-sitter-all-languages",
  "walkdir",
 ]

--- a/docker-images/syntax-highlighter/crates/scip-syntax/Cargo.toml
+++ b/docker-images/syntax-highlighter/crates/scip-syntax/Cargo.toml
@@ -25,6 +25,7 @@ string-interner = { workspace = true }
 walkdir = { workspace = true }
 path-clean = { workspace = true }
 camino = { workspace = true }
+tree-sitter = { workspace = true }
 
 syntax-analysis = { path = "../syntax-analysis" }
 tree-sitter-all-languages = { path = "../tree-sitter-all-languages" }

--- a/docker-images/syntax-highlighter/crates/scip-syntax/src/index.rs
+++ b/docker-images/syntax-highlighter/crates/scip-syntax/src/index.rs
@@ -1,4 +1,6 @@
 use std::{
+    cell::RefCell,
+    collections::HashMap,
     env,
     fs::File,
     io::{self, prelude::*},
@@ -9,7 +11,12 @@ use camino::{Utf8Path, Utf8PathBuf};
 use clap::ValueEnum;
 use path_clean;
 use scip::{types::Document, write_message_to_file};
-use syntax_analysis::{get_globals, get_locals};
+use syntax_analysis::{
+    globals,
+    languages::{get_local_configuration, get_tag_configuration},
+    locals,
+};
+use tree_sitter;
 use tree_sitter_all_languages::ParserId;
 
 use crate::{
@@ -272,20 +279,39 @@ fn index_tar_entries<R: Read>(
     Ok(documents)
 }
 
-fn index_content(contents: &str, parser: ParserId, options: &IndexOptions) -> Result<Document> {
-    let mut document: Document;
+thread_local! {
+    // We only want to initialize one parser per language per thread
+    static PARSERS: RefCell<HashMap<ParserId, tree_sitter::Parser>> = RefCell::new(HashMap::new());
+}
 
-    if options.analysis_mode.globals() {
-        let (mut scope, hint) = get_globals(parser, contents)?;
-        document = scope.into_document(hint, vec![]);
-    } else {
-        document = Document::new();
-    }
+fn index_content(contents: &str, parser_id: ParserId, options: &IndexOptions) -> Result<Document> {
+    PARSERS.with_borrow_mut(|parsers| {
+        let parser = parsers
+            .entry(parser_id)
+            .and_modify(|p| {
+                // Tree-sitter parsing is stateful, so reset the parser state explicitly
+                p.reset()
+            })
+            .or_insert_with(|| parser_id.get_parser());
+        let tree = parser
+            .parse(contents.as_bytes(), None)
+            .ok_or(anyhow!("Failed to parse when indexing content"))?;
 
-    if options.analysis_mode.locals() {
-        let occurrences = get_locals(parser, contents)?;
-        document.occurrences.extend(occurrences)
-    }
+        let mut document = if options.analysis_mode.globals() {
+            let tag_config = get_tag_configuration(parser_id)
+                .ok_or_else(|| anyhow!("No tag configuration for language: {parser_id:?}"))?;
+            let (mut scope, hint) = globals::parse_tree(tag_config, &tree, contents)?;
+            scope.into_document(hint, vec![])
+        } else {
+            Document::new()
+        };
 
-    Ok(document)
+        if options.analysis_mode.locals() {
+            let config = get_local_configuration(parser_id)
+                .ok_or_else(|| anyhow!("No local configuration for language: {parser_id:?}"))?;
+            let occurrences = locals::find_locals(config, &tree, contents)?;
+            document.occurrences.extend(occurrences)
+        }
+        Ok(document)
+    })
 }

--- a/docker-images/syntax-highlighter/crates/tree-sitter-all-languages/src/lib.rs
+++ b/docker-images/syntax-highlighter/crates/tree-sitter-all-languages/src/lib.rs
@@ -66,6 +66,12 @@ impl ParserId {
         }
     }
 
+    pub fn get_parser(self) -> tree_sitter::Parser {
+        let mut parser = tree_sitter::Parser::new();
+        parser.set_language(self.language()).expect("Error assigning language to parser, likely a version mismatch between compiled grammar and tree-sitter library.");
+        parser
+    }
+
     pub fn from_name(name: &str) -> Option<Self> {
         match name {
             "c" => Some(ParserId::C),


### PR DESCRIPTION
Closes https://linear.app/sourcegraph/issue/GRAPH-718/dont-parse-every-file-twice-in-scip-syntax

While working on parallel scip-syntax I noticed we're re-parsing every file for both globals and locals generation. This PR makes it so we use the same parse tree for both. I've also made it so we don't re-initialize the language parsers for every file. The thread-local-storage aspect of this matters after merging #63536 

## Test plan

```
spring-framework on main [?]
❯ hyperfine --warmup 1 'git archive HEAD | scip-syntax-main index tar - -l java -o main.scip' 'git archive HEAD | scip-syntax index tar - -l java -o single-parse.scip'
Benchmark 1: git archive HEAD | scip-syntax-main index tar - -l java -o main.scip
  Time (mean ± σ):      6.894 s ±  0.033 s    [User: 6.877 s, System: 0.093 s]
  Range (min … max):    6.814 s …  6.921 s    10 runs

Benchmark 2: git archive HEAD | scip-syntax index tar - -l java -o single-parse.scip
  Time (mean ± σ):      4.675 s ±  0.008 s    [User: 4.693 s, System: 0.084 s]
  Range (min … max):    4.663 s …  4.688 s    10 runs

Summary
  git archive HEAD | scip-syntax index tar - -l java -o single-parse.scip ran
    1.47 ± 0.01 times faster than git archive HEAD | scip-syntax-main index tar - -l java -o main.scip

spring-framework on  main [?]
❯ scip-syntax scip-evaluate --ground-truth main.scip --candidate single-parse.scip
{"precision_percent":"100.0","recall_percent":"100.0","true_positives":"569982.0","false_positives":"0.0","false_negatives":"0.0"}
```
