### PR TITLE
chore: Add feature flag for new SCIP-based GraphQL APIs

### DIFF
--- a/internal/conf/computed.go
+++ b/internal/conf/computed.go
@@ -1356,3 +1356,13 @@ func Branding() *schema.Branding {
 	}
 	return br
 }
+
+func SCIPBasedAPIsEnabled() bool {
+	siteConfig := SiteConfig()
+	expt := siteConfig.ExperimentalFeatures
+	if expt == nil || expt.ScipBasedAPIs == nil {
+		// NOTE(id: scip-based-apis-feature-flag): Keep this in sync with site.schema.json
+		return true
+	}
+	return *expt.ScipBasedAPIs
+}

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1029,6 +1029,8 @@ type ExperimentalFeatures struct {
 	RubyPackages string `json:"rubyPackages,omitempty"`
 	// RustPackages description: Allow adding Rust package code host connections
 	RustPackages string `json:"rustPackages,omitempty"`
+	// ScipBasedAPIs description: Enable usage of new CodeGraph and usagesForSymbol APIs
+	ScipBasedAPIs *bool `json:"scipBasedAPIs,omitempty"`
 	// SearchIndexBranches description: A map from repository name to a list of extra revs (branch, ref, tag, commit sha, etc) to index for a repository. We always index the default branch ("HEAD") and revisions in version contexts. This allows specifying additional revisions. Sourcegraph can index up to 64 branches per repository.
 	SearchIndexBranches map[string][]string `json:"search.index.branches,omitempty"`
 	// SearchIndexQueryContexts description: Enables indexing of revisions of repos matching any query defined in search contexts.
@@ -1103,6 +1105,7 @@ func (v *ExperimentalFeatures) UnmarshalJSON(data []byte) error {
 	delete(m, "rateLimitAnonymous")
 	delete(m, "rubyPackages")
 	delete(m, "rustPackages")
+	delete(m, "scipBasedAPIs")
 	delete(m, "search.index.branches")
 	delete(m, "search.index.query.contexts")
 	delete(m, "search.index.revisions")

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -175,6 +175,15 @@
       "type": "object",
       "additionalProperties": true,
       "properties": {
+        "scipBasedAPIs": {
+          "description": "Enable usage of new CodeGraph and usagesForSymbol APIs",
+          "type": "boolean",
+          "default": true,
+          "_comment": "Keep default 'true' above in sync with NOTE(id: scip-based-apis-feature-flag)",
+          "!go": {
+            "pointer": true
+          }
+        },
         "codyContextIgnore": {
           "description": "Enabled filtering of remote Cody context based on repositories ./cody/ignore file",
           "type": "boolean",


### PR DESCRIPTION
Makes partial progress towards https://linear.app/sourcegraph/issue/GRAPH-721

After this, I'll make necessary changes to the various configs to enable this feature flag
for dev, S2 and Sourcegraph.com. After that, I'll change the default to be `false`.

## Test plan

- [ ] Manually test that using `experimentalFeatures.scipBasedAPIs` can turn the feature on/off

## Changelog
