### PR TITLE
make `<Label>` element focus & select at end to match native label behavior

### DIFF
--- a/client/wildcard/src/components/Typography/Label/Label.tsx
+++ b/client/wildcard/src/components/Typography/Label/Label.tsx
@@ -54,7 +54,13 @@ export const Label = React.forwardRef((props, reference) => {
 
         // Resolve label's labellable control with aria-labelledby
         // See https://github.com/sourcegraph/sourcegraph/pull/44676#pullrequestreview-1188749383
-        document.querySelector<HTMLElement>(`[aria-labelledby="${event.currentTarget.id}"]`)?.focus()
+        const labelID = event.currentTarget.id
+        if (labelID) {
+            const control = document.querySelector<HTMLElement>(`[aria-labelledby="${event.currentTarget.id}"]`)
+            if (control) {
+                focusAndSelectEnd(control)
+            }
+        }
         onClick?.(event)
     }
 
@@ -72,3 +78,21 @@ export const Label = React.forwardRef((props, reference) => {
         </Component>
     )
 }) as ForwardReferenceComponent<'label', LabelProps>
+
+function focusAndSelectEnd(element: HTMLElement): void {
+    element.focus()
+
+    if (element.isContentEditable) {
+        // Focusing a contenteditable element (unlike a native input element) will put the cursor at
+        // the start by default, which is not usually the desired behavior.
+        const range = document.createRange()
+        range.selectNodeContents(element)
+        range.collapse(false)
+
+        const selection = window.getSelection()
+        if (selection) {
+            selection.removeAllRanges()
+            selection.addRange(range)
+        }
+    }
+}


### PR DESCRIPTION
When our custom `<Label>` element is labelling a contenteditable element (like a CodeMirror editor), it previously just called `element.focus()`. This focused the element but put the cursor at the start. The native and expected behavior of `<label for="...">` is to focus and put the cursor at the end.

Also fix an issue where this code path would be followed even if the label had no ID, which could result in it erroneously selecting an element with an empty `aria-labelledby` attribute.

## Test plan

In the create/update saved search form, click on the label and ensure it focuses at the end of the CodeMirror component.