### PR TITLE
fix bug preventing site admins from directly adding org members when email.smtp was set

### DIFF
--- a/cmd/frontend/graphqlbackend/org.go
+++ b/cmd/frontend/graphqlbackend/org.go
@@ -440,7 +440,7 @@ func (r *schemaResolver) AddUserToOrganization(ctx context.Context, args *struct
 		return nil, err
 	}
 
-	userToInvite, _, err := getUserToInviteToOrganization(ctx, r.db, args.Username, orgID)
+	userToInvite, err := r.db.Users().GetByUsername(ctx, args.Username)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Fixes https://linear.app/sourcegraph/issue/SRCH-655/site-admins-cant-add-users-wo-verified-emails-to-orgs-if-email-sending


## Test plan

As a site admin on a site with `email.smtp` configured in site config, try inviting a user who lacks a verified email directly. Confirm that it succeeds and does not error out due to not having a verified email.

## Changelog

- Fixed a bug where site admins could not directly add users to an organization if (1) email sending was configured for the instance and (2) the user had no verified email address.