### PR TITLE
cosmetic improvements to OrgSettingsMemberPage, UserEmail

### DIFF
--- a/client/web/src/org/settings/members/OrgSettingsMembersPage.tsx
+++ b/client/web/src/org/settings/members/OrgSettingsMembersPage.tsx
@@ -8,15 +8,16 @@ import { useMutation } from '@sourcegraph/http-client'
 import { UserAvatar } from '@sourcegraph/shared/src/components/UserAvatar'
 import { EVENT_LOGGER } from '@sourcegraph/shared/src/telemetry/web/eventLogger'
 import {
-    Container,
-    PageHeader,
+    Alert,
     Button,
+    Container,
+    ErrorAlert,
     Input,
     Link,
     LoadingSpinner,
-    Alert,
-    ErrorAlert,
+    PageHeader,
     PageSwitcher,
+    Text,
     Tooltip,
     useDebounce,
 } from '@sourcegraph/wildcard'
@@ -26,9 +27,9 @@ import { usePageSwitcherPagination } from '../../../components/FilteredConnectio
 import { PageTitle } from '../../../components/PageTitle'
 import type {
     OrgAreaOrganizationFields,
+    OrganizationMemberNode,
     OrganizationSettingsMembersResult,
     OrganizationSettingsMembersVariables,
-    OrganizationMemberNode,
     RemoveUserFromOrganizationResult,
     RemoveUserFromOrganizationVariables,
 } from '../../../graphql-operations'
@@ -104,21 +105,17 @@ const UserNode: React.FunctionComponent<UserNodeProps> = ({
                         )}
                     </div>
                 </div>
-                <div className="flex-1 d-flex align-items-center justify-content-between">
-                    <div className="flex-1">
-                        {authenticatedUser && org.viewerCanAdminister && (
-                            <Button
-                                className="site-admin-detail-list__action test-remove-org-member"
-                                onClick={remove}
-                                disabled={loading}
-                                variant="secondary"
-                                size="sm"
-                            >
-                                {isSelf ? 'Leave organization' : 'Remove from organization'}
-                            </Button>
-                        )}
-                    </div>
-                </div>
+                {authenticatedUser && org.viewerCanAdminister && (
+                    <Button
+                        className="site-admin-detail-list__action test-remove-org-member"
+                        onClick={remove}
+                        disabled={loading}
+                        variant="secondary"
+                        size="sm"
+                    >
+                        {isSelf ? 'Leave organization' : 'Remove from organization'}
+                    </Button>
+                )}
             </div>
             {error && <ErrorAlert className="mt-2" error={error} />}
         </li>
@@ -246,19 +243,13 @@ export const OrgSettingsMembersPage: React.FunctionComponent<Props> = ({
                 ) : null}
                 {loading && <LoadingSpinner />}
                 {error && <ErrorAlert className="mb-3" error={error} />}
+
+                {totalCount > 0 && (
+                    <Text>
+                        {`${totalCount} ${debouncedSearchQuery ? 'matching' : ''} ${pluralize('member', totalCount)}`}
+                    </Text>
+                )}
                 <ul className="list-group list-group-flush test-org-members mt-4">
-                    {totalCount > 0 && (
-                        <li className="d-flex mb-2 align-items-center justify-content-between">
-                            <strong className="flex-1">
-                                {`${totalCount} ${pluralize('person', totalCount, 'people')} in the ${
-                                    org.name
-                                } organization`}
-                            </strong>
-                            <div className="flex-1 d-flex align-items-center justify-content-between">
-                                <strong>Action</strong>
-                            </div>
-                        </li>
-                    )}
                     {(connection?.nodes || []).map(node => (
                         <UserNode
                             key={node.id}

--- a/client/web/src/user/settings/emails/UserEmail.module.scss
+++ b/client/web/src/user/settings/emails/UserEmail.module.scss
@@ -1,3 +1,0 @@
-.dot {
-    color: var(--border-color);
-}

--- a/client/web/src/user/settings/emails/UserEmail.tsx
+++ b/client/web/src/user/settings/emails/UserEmail.tsx
@@ -1,4 +1,4 @@
-import { type FunctionComponent, useState, useCallback } from 'react'
+import { useCallback, useState, type FunctionComponent } from 'react'
 
 import { lastValueFrom } from 'rxjs'
 
@@ -18,8 +18,6 @@ import type {
     SetUserEmailVerifiedVariables,
     UserEmailsResult,
 } from '../../../graphql-operations'
-
-import styles from './UserEmail.module.scss'
 
 interface Props extends TelemetryV2Props {
     user: string
@@ -165,7 +163,7 @@ export const UserEmail: FunctionComponent<React.PropsWithChildren<Props>> = ({
     return (
         <>
             <div className="d-flex align-items-center justify-content-between">
-                <div className="d-flex align-items-center">
+                <div className="d-flex align-items-center flex-gap-2">
                     <span className="mr-2">{email}</span>
                     {/*
                         a11y-ignore
@@ -173,51 +171,34 @@ export const UserEmail: FunctionComponent<React.PropsWithChildren<Props>> = ({
                         GitHub issue: https://github.com/sourcegraph/sourcegraph/issues/33343
                     */}
                     {verified && (
-                        <Badge variant="success" className="mr-1 a11y-ignore">
+                        <Badge variant="success" className="a11y-ignore">
                             Verified
                         </Badge>
                     )}
-                    {!verified && !verificationPending && (
-                        <Badge variant="secondary" className="mr-1">
-                            Not verified
-                        </Badge>
-                    )}
-                    {isPrimary && (
-                        <Badge variant="primary" className="mr-1">
-                            Primary
-                        </Badge>
-                    )}
-                    {!verified && verificationPending && (
-                        <span>
-                            <span className={styles.dot}>&bull;&nbsp;</span>
-                            <Button
-                                className="p-0"
-                                onClick={resendEmail}
-                                disabled={isLoading || disableControls}
-                                variant="link"
-                            >
-                                Resend verification email
-                            </Button>
-                        </span>
-                    )}
+                    {!verified && !verificationPending && <Badge variant="secondary">Not verified</Badge>}
+                    {isPrimary && <Badge variant="primary">Primary</Badge>}
                 </div>
-                <div className="d-flex align-items-center">
+                <div className="d-flex align-items-center flex-gap-2">
+                    {!verified && verificationPending && (
+                        <Button onClick={resendEmail} disabled={isLoading || disableControls} variant="secondary">
+                            Resend verification email
+                        </Button>
+                    )}
                     {viewerCanManuallyVerify && (
                         <Button
-                            className="p-0"
                             onClick={() => updateEmailVerification(!verified)}
                             disabled={isLoading || disableControls}
-                            variant="link"
+                            variant="secondary"
                         >
                             {verified ? 'Mark as unverified' : 'Mark as verified'}
                         </Button>
-                    )}{' '}
+                    )}
                     {!isPrimary && (
                         <Button
-                            className="text-danger p-0"
                             onClick={removeEmail}
                             disabled={isLoading || disableControls}
-                            variant="link"
+                            variant="danger"
+                            outline={true}
                         >
                             Remove
                         </Button>


### PR DESCRIPTION
- The buttons for resending the verification email, manually verifying a user's email, and removing a user's email were incorrectly styled and had no padding.
- The org members page had weird columns where a column that only ever had a single button took 50% of the width.


## Test plan

View these pages and ensure they look nicer.

## Changelog

- Minor cosmetic improvements to the pages for managing organization members and user email addresses.