### PR TITLE
suppress ResizeObserver type error

### DIFF
--- a/client/testing/src/mockResizeObserver.ts
+++ b/client/testing/src/mockResizeObserver.ts
@@ -2,6 +2,8 @@ import ResizeObserver from 'resize-observer-polyfill'
 import { vi } from 'vitest'
 
 if ('ResizeObserver' in window === false) {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
     window.ResizeObserver = ResizeObserver
 }
 


### PR DESCRIPTION
I was getting a weird TypeScript type error on a clean build.

```
$ pnpm -C client/web run build-ts
../testing/src/mockResizeObserver.ts:5:12 - error TS2339: Property 'ResizeObserver' does not exist on type 'never'.
```

Type-checking adds no value here anyway, and this is low risk to ignore.


## Test plan

CI