### PR TITLE
chore: Simplify path trimming logic in perm checking

### DIFF
--- a/internal/authz/subrepoperms/sub_repo_perms.go
+++ b/internal/authz/subrepoperms/sub_repo_perms.go
@@ -302,19 +302,13 @@ func (s *SubRepoPermsClient) getCompiledRules(ctx context.Context, userID int32)
 				// around this we add an extra rule to cover this case.
 				if strings.HasPrefix(rule, "/**/") {
 					trimmed := rule
-					for {
-						trimmed = strings.TrimPrefix(trimmed, "/**")
-						if strings.HasPrefix(trimmed, "/**/") {
-							// Keep trimming
-							continue
-						}
-						g, err := glob.Compile(trimmed, '/')
-						if err != nil {
-							return nil, errors.Wrap(err, "building include matcher")
-						}
-						paths = append(paths, path{globPath: g, exclusion: exclusion, original: trimmed})
-						break
+					for ; strings.HasPrefix(trimmed, "/**/"); trimmed = strings.TrimPrefix(trimmed, "/**") {
 					}
+					g, err := glob.Compile(trimmed, '/')
+					if err != nil {
+						return nil, errors.Wrap(err, "building include matcher")
+					}
+					paths = append(paths, path{globPath: g, exclusion: exclusion, original: trimmed})
 				}
 
 				// We should include all directories above an include rule so that we can browse


### PR DESCRIPTION
Randomly stumbled across this code, figured I could simplify the loop a bit.

## Test plan

Should be covered by existing tests?

## Changelog