### PR TITLE
chore: Set scipBasedAPIs to off by default

### DIFF
--- a/internal/conf/computed.go
+++ b/internal/conf/computed.go
@@ -1365,7 +1365,7 @@ func SCIPBasedAPIsEnabled() bool {
 	expt := siteConfig.ExperimentalFeatures
 	if expt == nil || expt.ScipBasedAPIs == nil {
 		// NOTE(id: scip-based-apis-feature-flag): Keep this in sync with site.schema.json
-		return true
+		return false
 	}
 	return *expt.ScipBasedAPIs
 }

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -178,8 +178,8 @@
         "scipBasedAPIs": {
           "description": "Enable usage of new CodeGraph and usagesForSymbol APIs",
           "type": "boolean",
-          "default": true,
-          "_comment": "Keep default 'true' above in sync with NOTE(id: scip-based-apis-feature-flag)",
+          "default": false,
+          "_comment": "Keep default above in sync with NOTE(id: scip-based-apis-feature-flag)",
           "!go": {
             "pointer": true
           }


### PR DESCRIPTION
To be merged after https://github.com/sourcegraph/deploy-sourcegraph-cloud/pull/18661 and https://github.com/sourcegraph/cloud/pull/11273.

Closes https://linear.app/sourcegraph/issue/GRAPH-721/introduce-feature-flag-for-scip-oriented-apis

## Test plan

n/a

## Changelog