### PR TITLE
Marks search-based usages as definitions or references

### DIFF
--- a/internal/codeintel/codenav/service.go
+++ b/internal/codeintel/codenav/service.go
@@ -1220,10 +1220,13 @@ func (s *Service) SyntacticUsages(
 			UnderlyingError: errors.New("can't find syntactic occurrences for locals via search"),
 		}
 	}
-	candidateMatches, searchErr := findCandidateOccurrencesViaSearch(
-		ctx, s.searchClient, trace,
-		args.Repo, args.Commit, symbolName, language,
-	)
+	searchCoords := searchArgs{
+		repo:       args.Repo.Name,
+		commit:     args.Commit,
+		identifier: symbolName,
+		language:   language,
+	}
+	candidateMatches, searchErr := findCandidateOccurrencesViaSearch(ctx, trace, s.searchClient, searchCoords)
 	if searchErr != nil {
 		return SyntacticUsagesResult{}, nil, &SyntacticUsagesError{
 			Code:            SU_FailedToSearch,
@@ -1338,11 +1341,17 @@ func (s *Service) SearchBasedUsages(
 		}
 	}
 
-	candidateMatches, err := findCandidateOccurrencesViaSearch(ctx, s.searchClient, trace, args.Repo, args.Commit, symbolName, language)
+	searchCoords := searchArgs{
+		repo:       args.Repo.Name,
+		commit:     args.Commit,
+		identifier: symbolName,
+		language:   language,
+	}
+	candidateMatches, err := findCandidateOccurrencesViaSearch(ctx, trace, s.searchClient, searchCoords)
 	if err != nil {
 		return nil, err
 	}
-	candidateSymbols, err := symbolSearch(ctx, s.searchClient, trace, args.Repo, symbolName, language)
+	candidateSymbols, err := symbolSearch(ctx, trace, s.searchClient, searchCoords)
 	if err != nil {
 		trace.Warn("Failed to run symbol search, will not mark any search-based usages as definitions", log.Error(err))
 	}

--- a/internal/codeintel/codenav/syntactic.go
+++ b/internal/codeintel/codenav/syntactic.go
@@ -21,7 +21,6 @@ import (
 	searchclient "github.com/sourcegraph/sourcegraph/internal/search/client"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
 	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
-	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
@@ -30,45 +29,37 @@ type candidateFile struct {
 	didSearchEntireFile bool         // Or did we hit the search count limit?
 }
 
+type searchArgs struct {
+	repo       api.RepoName
+	commit     api.CommitID
+	identifier string
+	language   string
+}
+
 // findCandidateOccurrencesViaSearch calls out to Searcher/Zoekt to find candidate occurrences of the given symbol.
 // It returns a map of file paths to candidate ranges.
 func findCandidateOccurrencesViaSearch(
 	ctx context.Context,
-	client searchclient.SearchClient,
 	trace observation.TraceLogger,
-	repo types.Repo,
-	commit api.CommitID,
-	identifier string,
-	language string,
+	client searchclient.SearchClient,
+	args searchArgs,
 ) (orderedmap.OrderedMap[core.RepoRelPath, candidateFile], error) {
-	if identifier == "" {
+	if args.identifier == "" {
 		return *orderedmap.New[core.RepoRelPath, candidateFile](), nil
 	}
-	var contextLines int32 = 0
-	patternType := "standard"
-	repoName := fmt.Sprintf("^%s$", repo.Name)
 	resultMap := *orderedmap.New[core.RepoRelPath, candidateFile]()
-	// TODO: This should be dependent on the number of requested usages, with a configured global limit
-	countLimit := 1000
-	searchQuery := fmt.Sprintf("type:file repo:%s rev:%s language:%s count:%d case:yes /\\b%s\\b/", repoName, string(commit), language, countLimit, identifier)
-
-	trace.Info("Running query", log.String("q", searchQuery))
-
-	plan, err := client.Plan(ctx, "V3", &patternType, searchQuery, search.Precise, search.Streaming, &contextLines)
+	// TODO: countLimit should be dependent on the number of requested usages, with a configured global limit
+	// For now we're matching the current web app with 500
+	searchResults, err := executeQuery(ctx, client, trace, args, "file", 500, 0)
 	if err != nil {
 		return resultMap, err
 	}
-	stream := streaming.NewAggregatingStream()
-	_, err = client.Execute(ctx, stream, plan)
-	if err != nil {
-		return resultMap, err
-	}
+
 	nonFileMatches := 0
 	inconsistentFilepaths := 0
 	duplicatedFilepaths := collections.NewSet[string]()
 	matchCount := 0
-
-	for _, streamResult := range stream.Results {
+	for _, streamResult := range searchResults {
 		fileMatch, ok := streamResult.(*result.FileMatch)
 		if !ok {
 			nonFileMatches += 1
@@ -111,7 +102,7 @@ func findCandidateOccurrencesViaSearch(
 	trace.AddEvent("findCandidateOccurrencesViaSearch", attribute.Int("matchCount", matchCount))
 
 	if !duplicatedFilepaths.IsEmpty() {
-		trace.Warn("Saw the duplicate file paths in search results", log.String("paths", duplicatedFilepaths.String()))
+		trace.Warn("Saw duplicate file paths in search results", log.String("paths", duplicatedFilepaths.String()))
 	}
 	if nonFileMatches != 0 {
 		trace.Warn("Saw non file match in search results. The `type:file` on the query should guarantee this")
@@ -149,35 +140,22 @@ func (s *symbolSearchResult) Contains(path core.RepoRelPath, range_ scip.Range) 
 
 func symbolSearch(
 	ctx context.Context,
-	client searchclient.SearchClient,
 	trace observation.TraceLogger,
-	repo types.Repo,
-	identifier string,
-	language string,
+	client searchclient.SearchClient,
+	args searchArgs,
 ) (symbolSearchResult, error) {
-	if identifier == "" {
+	if args.identifier == "" {
 		return symbolSearchResult{}, nil
 	}
-	var contextLines int32 = 0
-	patternType := "standard"
-	repoName := fmt.Sprintf("^%s$", repo.Name)
 	// Using the same limit as the current web app
-	countLimit := 50
-	symbolQuery := fmt.Sprintf("type:symbol repo:%s lang:%s count:%d case:yes /\\b%s\\b/", repoName, language, countLimit, identifier)
+	searchResults, err := executeQuery(ctx, client, trace, args, "symbol", 50, 0)
+	if err != nil {
+		return symbolSearchResult{}, err
+	}
 
-	plan, err := client.Plan(ctx, "V3", &patternType, symbolQuery, search.Precise, search.Streaming, &contextLines)
-	if err != nil {
-		return symbolSearchResult{}, err
-	}
-	stream := streaming.NewAggregatingStream()
-	_, err = client.Execute(ctx, stream, plan)
-	if err != nil {
-		return symbolSearchResult{}, err
-	}
 	matchCount := 0
-
 	resultMap := *orderedmap.New[core.RepoRelPath, []symbolData]()
-	for _, streamResult := range stream.Results {
+	for _, streamResult := range searchResults {
 		fileMatch, ok := streamResult.(*result.FileMatch)
 		if !ok {
 			continue
@@ -206,6 +184,39 @@ func symbolSearch(
 	trace.AddEvent("symbolSearch", attribute.Int("matchCount", matchCount))
 
 	return symbolSearchResult{resultMap}, nil
+}
+
+func buildQuery(args searchArgs, queryType string, countLimit int) string {
+	repoName := fmt.Sprintf("^%s$", args.repo)
+	wordBoundaryIdentifier := fmt.Sprintf("/\\b%s\\b/", args.identifier)
+	return fmt.Sprintf(
+		"case:yes type:%s repo:%s rev:%s language:%s count:%d %s",
+		queryType, repoName, string(args.commit), args.language, countLimit, wordBoundaryIdentifier)
+}
+
+func executeQuery(
+	ctx context.Context,
+	client searchclient.SearchClient,
+	trace observation.TraceLogger,
+	args searchArgs,
+	queryType string,
+	countLimit int,
+	surroundingLines int,
+) (result.Matches, error) {
+	searchQuery := buildQuery(args, queryType, countLimit)
+	patternType := "standard"
+	contextLines := int32(surroundingLines)
+	plan, err := client.Plan(ctx, "V3", &patternType, searchQuery, search.Precise, search.Streaming, &contextLines)
+	if err != nil {
+		return nil, err
+	}
+	trace.Info("Running query", log.String("query", searchQuery))
+	stream := streaming.NewAggregatingStream()
+	_, err = client.Execute(ctx, stream, plan)
+	if err != nil {
+		return nil, err
+	}
+	return stream.Results, nil
 }
 
 func nameFromGlobalSymbol(symbol *scip.Symbol) (string, bool) {

--- a/internal/codeintel/codenav/transport/graphql/root_resolver_usages.go
+++ b/internal/codeintel/codenav/transport/graphql/root_resolver_usages.go
@@ -59,8 +59,12 @@ func NewSyntacticUsageResolver(usage codenav.SyntacticMatch, repository types.Re
 	}
 }
 func NewSearchBasedUsageResolver(usage codenav.SearchBasedMatch, repository types.Repo, revision api.CommitID) resolverstubs.UsageResolver {
-	// TODO: We can figure out if something is a definition via symbol search
-	kind := resolverstubs.UsageKindReference
+	var kind resolverstubs.SymbolUsageKind
+	if usage.IsDefinition {
+		kind = resolverstubs.UsageKindDefinition
+	} else {
+		kind = resolverstubs.UsageKindReference
+	}
 	return &usageResolver{
 		symbol:     nil,
 		provenance: resolverstubs.ProvenanceSearchBased,


### PR DESCRIPTION
Closes https://linear.app/sourcegraph/issue/GRAPH-712/determine-usage-kind-for-search-based-usages-by-running-symbol-search

We do this by running a type:symbol search and marking all overlapping results as definitions

## Test plan

Here's an [example query to run in the API console](https://sourcegraph.test:3443/api/console#%7B%22query%22%3A%22query%20%7B%5Cn%20%20usagesForSymbol(range%3A%20%7B%5Cn%20%20%20%20repository%3A%20%5C%22github.com%2Fsourcegraph-testing%2Fpinned-zoekt%5C%22%5Cn%20%20%20%20path%3A%20%5C%22matchtree.go%5C%22%5Cn%20%20%20%20revision%3A%20%5C%22ab1b8f09199ea7a731fd80876fc5b0f376ff6882%5C%22%5Cn%20%20%20%20start%3A%20%7B%5Cn%20%20%20%20%20%20line%3A%20268%2C%5Cn%20%20%20%20%20%20character%3A%2032%5Cn%20%20%20%20%7D%2C%20end%3A%20%7B%5Cn%20%20%20%20%20%20line%3A%20268%5Ct%2C%5Cn%20%20%20%20%20%20character%3A%2039%5Cn%20%20%20%20%7D%5Cn%20%20%7D)%20%7B%5Cn%20%20%20%20nodes%20%7B%5Cn%20%20%20%20%20%20usageRange%20%7B%5Cn%20%20%20%20%20%20%20%20repository%2C%5Cn%20%20%20%20%20%20%20%20revision%2C%5Cn%20%20%20%20%20%20%20%20path%2C%5Cn%20%20%20%20%20%20%20%20range%20%7B%5Cn%20%20%20%20%20%20%20%20%20%20start%20%7B%5Cn%20%20%20%20%20%20%20%20%20%20%20%20line%2C%5Cn%20%20%20%20%20%20%20%20%20%20%20%20character%5Cn%20%20%20%20%20%20%20%20%20%20%7D%5Cn%20%20%20%20%20%20%20%20%20%20end%20%7B%5Cn%20%20%20%20%20%20%20%20%20%20%20%20line%2C%5Cn%20%20%20%20%20%20%20%20%20%20%20%20character%5Cn%20%20%20%20%20%20%20%20%20%20%7D%5Cn%20%20%20%20%20%20%20%20%7D%5Cn%20%20%20%20%20%20%7D%5Cn%20%20%20%20%20%20usageKind%5Cn%20%20%20%20%20%20provenance%5Cn%20%20%20%20%7D%5Cn%20%20%7D%5Cn%7D%5Cn%22%7D)