### PR TITLE
insights: persist patternType in db

### DIFF
--- a/client/web/BUILD.bazel
+++ b/client/web/BUILD.bazel
@@ -1925,6 +1925,7 @@ ts_project(
         "src/enterprise/code-monitoring/components/actions/WebhookAction.test.tsx",
         "src/enterprise/codeintel/configuration/components/inference-form/auto-index-to-schema.test.tsx",
         "src/enterprise/insights/components/creation-ui/code-insight-time-step-picker/get-interval-descrtiption-text/get-interval-description.text.test.ts",
+        "src/enterprise/insights/components/creation-ui/form-series/components/form-series-input/get-pattern-type-filter.test.ts",
         "src/enterprise/insights/hooks/use-parallel-requests/use-prallel-requests.test.ts",
         "src/enterprise/insights/pages/CodeInsightsRootPage.test.tsx",
         "src/enterprise/insights/pages/dashboards/dashboard-view/DashboardsContentPage.test.tsx",

--- a/client/web/src/enterprise/insights/components/creation-ui/form-series/components/form-series-input/get-pattern-type-filter.test.ts
+++ b/client/web/src/enterprise/insights/components/creation-ui/form-series/components/form-series-input/get-pattern-type-filter.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from 'vitest'
+
+import { SearchPatternType } from '@sourcegraph/shared/src/graphql-operations'
+
+import { getQueryPatternTypeFilter } from './get-pattern-type-filter'
+
+describe('getQueryPatternTypeFilter', () => {
+    const defaultPatternType = SearchPatternType.keyword
+
+    test('returns defaultPatternType when query does not contain patterntype filter', () => {
+        const query = 'test query'
+        const result = getQueryPatternTypeFilter(query, defaultPatternType)
+        expect(result).toBe(defaultPatternType)
+    })
+
+    test('returns correct patternType when query contains patterntype filter', () => {
+        const query = 'patterntype:regexp'
+        const result = getQueryPatternTypeFilter(query, defaultPatternType)
+        expect(result).toBe(SearchPatternType.regexp)
+    })
+
+    test('returns defaultPatternType when query contains unknown patterntype filter', () => {
+        const query = 'patterntype:unknown'
+        const result = getQueryPatternTypeFilter(query, defaultPatternType)
+        expect(result).toBe(defaultPatternType)
+    })
+})

--- a/client/web/src/enterprise/insights/components/creation-ui/form-series/components/form-series-input/get-pattern-type-filter.ts
+++ b/client/web/src/enterprise/insights/components/creation-ui/form-series/components/form-series-input/get-pattern-type-filter.ts
@@ -6,7 +6,7 @@ import { FilterKind, findFilter } from '@sourcegraph/shared/src/search/query/que
  * Returns pattern type filter value if it's represented in the query string,
  * otherwise returns default value for patternType filter - literal
  */
-export function getQueryPatternTypeFilter(query: string): SearchPatternType {
+export function getQueryPatternTypeFilter(query: string, defaultPatternType: SearchPatternType): SearchPatternType {
     const patternType = findFilter(query, FilterType.patterntype, FilterKind.Global)
 
     if (patternType?.value) {
@@ -23,11 +23,14 @@ export function getQueryPatternTypeFilter(query: string): SearchPatternType {
             case SearchPatternType.standard: {
                 return SearchPatternType.standard
             }
+            case SearchPatternType.keyword: {
+                return SearchPatternType.keyword
+            }
             default: {
-                return SearchPatternType.standard
+                return defaultPatternType
             }
         }
     }
 
-    return SearchPatternType.literal
+    return defaultPatternType
 }

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/BackendInsight.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/BackendInsight.tsx
@@ -6,12 +6,14 @@ import { useMergeRefs } from 'use-callback-ref'
 
 import { isDefined } from '@sourcegraph/common'
 import { useQuery } from '@sourcegraph/http-client'
+import { useSettingsCascade } from '@sourcegraph/shared/src/settings/settings'
 import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Link, useDebounce, useDeepMemo, Text } from '@sourcegraph/wildcard'
 
 import type { GetInsightViewResult, GetInsightViewVariables } from '../../../../../../graphql-operations'
 import { useSeriesToggle } from '../../../../../../insights/utils/use-series-toggle'
+import { defaultPatternTypeFromSettings } from '../../../../../../util/settings'
 import {
     type BackendInsight,
     CodeInsightsBackendContext,
@@ -88,14 +90,16 @@ export const BackendInsightView = forwardRef<HTMLElement, BackendInsightProps>((
         }
     )
 
+    const defaultPatternType = defaultPatternTypeFromSettings(useSettingsCascade())
+
     const insightData = useMemo(() => {
         if (!data) {
             return
         }
 
         const node = data.insightViews.nodes[0]
-        return isDefined(node) ? createBackendInsightData({ ...insight, filters }, node) : undefined
-    }, [data, filters, insight])
+        return isDefined(node) ? createBackendInsightData({ ...insight, filters }, node, defaultPatternType) : undefined
+    }, [data, filters, insight, defaultPatternType])
 
     // Reset item selection items on every data change
     useLayoutEffect(

--- a/client/web/src/enterprise/insights/core/backend/gql-backend/methods/get-backend-insight-data/deserializators.ts
+++ b/client/web/src/enterprise/insights/core/backend/gql-backend/methods/get-backend-insight-data/deserializators.ts
@@ -1,11 +1,16 @@
 import type { InsightDataNode } from '../../../../../../../graphql-operations'
+import { SearchPatternType } from '../../../../../../../graphql-operations'
 import { type BackendInsight, isComputeInsight, isCaptureGroupInsight } from '../../../../types'
 import { InsightContentType } from '../../../../types/insight/common'
 import type { BackendInsightData } from '../../../code-insights-backend-types'
 import { createComputeCategoricalChart } from '../../../utils/create-categorical-content'
 import { createLineChartContent } from '../../../utils/create-line-chart-content'
 
-export const createBackendInsightData = (insight: BackendInsight, response: InsightDataNode): BackendInsightData => {
+export const createBackendInsightData = (
+    insight: BackendInsight,
+    response: InsightDataNode,
+    defaultPatternType: SearchPatternType
+): BackendInsightData => {
     const seriesData = response.dataSeries
     const isFetchingHistoricalData = seriesData.some(({ status: { isLoadingData } }) => isLoadingData)
     const isAllSeriesErrored =
@@ -29,7 +34,7 @@ export const createBackendInsightData = (insight: BackendInsight, response: Insi
             isFetchingHistoricalData,
             data: {
                 type: InsightContentType.Series,
-                series: createLineChartContent({ insight, seriesData, showError: false }),
+                series: createLineChartContent({ insight, seriesData, showError: false, defaultPatternType }),
             },
         }
     }
@@ -41,7 +46,7 @@ export const createBackendInsightData = (insight: BackendInsight, response: Insi
         isFetchingHistoricalData,
         data: {
             type: InsightContentType.Series,
-            series: createLineChartContent({ insight, seriesData, showError: true }),
+            series: createLineChartContent({ insight, seriesData, showError: true, defaultPatternType }),
         },
     }
 }

--- a/client/web/src/enterprise/insights/core/backend/utils/create-line-chart-content.ts
+++ b/client/web/src/enterprise/insights/core/backend/utils/create-line-chart-content.ts
@@ -13,6 +13,7 @@ interface LineChartContentInput {
     insight: BackendInsight
     seriesData: InsightDataSeries[]
     showError: boolean
+    defaultPatternType: SearchPatternType
 }
 
 /**
@@ -32,7 +33,7 @@ export function createLineChartContent(input: LineChartContentInput): BackendIns
         data: line.points.map(point => ({
             dateTime: new Date(point.dateTime),
             value: point.value,
-            link: generateLinkURL(point.pointInTimeQuery),
+            link: generateLinkURL(point.pointInTimeQuery, input.defaultPatternType),
         })),
         name: seriesDefinitionMap[line.seriesId]?.name ?? line.label,
         color: seriesDefinitionMap[line.seriesId]?.stroke,
@@ -47,9 +48,9 @@ export function createLineChartContent(input: LineChartContentInput): BackendIns
  */
 export type InsightDataSeriesData = Pick<InsightDataSeries, 'seriesId' | 'label' | 'points'>
 
-export function generateLinkURL(query: string | null): string | undefined {
+export function generateLinkURL(query: string | null, defaultPatternType: SearchPatternType): string | undefined {
     if (query) {
-        const searchQueryParameter = buildSearchURLQuery(query, SearchPatternType.literal, false)
+        const searchQueryParameter = buildSearchURLQuery(query, defaultPatternType, false)
         return `${window.location.origin}${PageRoutes.Search}?${searchQueryParameter}`
     }
 

--- a/client/web/src/enterprise/insights/pages/insights/creation/capture-group/components/search-query-checks/SearchQueryChecks.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/capture-group/components/search-query-checks/SearchQueryChecks.tsx
@@ -33,7 +33,8 @@ export const SearchQueryChecks: FC<SearchQueryChecksProps> = ({ checks }) => (
             errorMessage="shouldn't contain 'keyword', 'literal', or 'structural' patterntype"
             valid={checks?.isValidPatternType}
         >
-            Does not contain a <Code>patternType:keyword</Code>, <Code>literal</Code>, or <Code>structural</Code>{' '}
+            Does not contain a <Code>patternType:keyword</Code>, <Code>standard</Code>, <Code>literal</Code>, or{' '}
+            <Code>structural</Code>{' '}
         </CheckListItem>
         <CheckListItem errorMessage="shouldn't contain repo filter" valid={checks?.isNotRepo}>
             Does not contain <Code>repo:</Code> filter

--- a/client/web/src/enterprise/insights/pages/insights/creation/capture-group/utils/search-query-validator.ts
+++ b/client/web/src/enterprise/insights/pages/insights/creation/capture-group/utils/search-query-validator.ts
@@ -38,6 +38,7 @@ export const searchQueryValidator = (value: string | undefined): Checks => {
                 resolveFilter(filter.field.value)?.type === FilterType.patterntype &&
                 (filter.value?.value === 'literal' ||
                     filter.value?.value === 'structural' ||
+                    filter.value?.value === 'standard' ||
                     filter.value?.value === 'keyword')
         )
 

--- a/client/web/src/enterprise/insights/pages/insights/insight/components/standalone-backend-insight/StandaloneBackendInsight.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/insight/components/standalone-backend-insight/StandaloneBackendInsight.tsx
@@ -5,6 +5,7 @@ import { useNavigate } from 'react-router-dom'
 import { lastValueFrom } from 'rxjs'
 
 import { useQuery } from '@sourcegraph/http-client'
+import { useSettingsCascade } from '@sourcegraph/shared/src/settings/settings'
 import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Card, CardBody, useDebounce, useDeepMemo, type FormChangeEvent } from '@sourcegraph/wildcard'
@@ -16,6 +17,7 @@ import type {
     SeriesDisplayOptionsInput,
 } from '../../../../../../../graphql-operations'
 import { useSeriesToggle } from '../../../../../../../insights/utils/use-series-toggle'
+import { defaultPatternTypeFromSettings } from '../../../../../../../util/settings'
 import { InsightCard, InsightCardHeader, InsightCardLoading } from '../../../../../components'
 import {
     DrillDownInsightFilters,
@@ -95,6 +97,8 @@ export const StandaloneBackendInsight: React.FunctionComponent<StandaloneBackend
         }
     )
 
+    const defaultPatternType = defaultPatternTypeFromSettings(useSettingsCascade())
+
     const insightData = useMemo(() => {
         const node = data?.insightViews.nodes[0]
 
@@ -102,12 +106,12 @@ export const StandaloneBackendInsight: React.FunctionComponent<StandaloneBackend
             stopPolling()
             return
         }
-        const parsedData = createBackendInsightData({ ...insight, filters }, node)
+        const parsedData = createBackendInsightData({ ...insight, filters }, node, defaultPatternType)
         if (!parsedData.isFetchingHistoricalData) {
             stopPolling()
         }
         return parsedData
-    }, [data, filters, insight, stopPolling])
+    }, [data, filters, insight, stopPolling, defaultPatternType])
 
     const { trackMouseLeave, trackMouseEnter, trackDatumClicks } = useCodeInsightViewPings({
         telemetryService,

--- a/client/web/src/enterprise/insights/pages/landing/getting-started/components/dynamic-code-insight-example/DynamicCodeInsightExample.tsx
+++ b/client/web/src/enterprise/insights/pages/landing/getting-started/components/dynamic-code-insight-example/DynamicCodeInsightExample.tsx
@@ -5,6 +5,7 @@ import classNames from 'classnames'
 import { noop } from 'rxjs'
 
 import { gql, useQuery } from '@sourcegraph/http-client'
+import { useSettingsCascade } from '@sourcegraph/shared/src/settings/settings'
 import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import {
@@ -22,6 +23,8 @@ import {
 } from '@sourcegraph/wildcard'
 
 import type { GetExampleRepositoryResult, GetExampleRepositoryVariables } from '../../../../../../../graphql-operations'
+import { SearchPatternType } from '../../../../../../../graphql-operations'
+import { defaultPatternTypeFromSettings } from '../../../../../../../util/settings'
 import { InsightQueryInput, RepositoriesField, insightRepositoriesValidator } from '../../../../../components'
 import { getQueryPatternTypeFilter } from '../../../../insights/creation/search-insight'
 import { CodeInsightsDescription } from '../code-insights-description/CodeInsightsDescription'
@@ -106,6 +109,8 @@ export const DynamicCodeInsightExample: FC<DynamicCodeInsightExampleProps> = pro
 
     const { status: repositoryStatus, ...repositoryProps } = getDefaultInputProps(repositories)
 
+    const defaultPatternType: SearchPatternType = defaultPatternTypeFromSettings(useSettingsCascade())
+
     return (
         <Card {...otherProps} className={classNames(styles.wrapper, otherProps.className)}>
             {/* eslint-disable-next-line react/forbid-elements */}
@@ -125,7 +130,7 @@ export const DynamicCodeInsightExample: FC<DynamicCodeInsightExampleProps> = pro
                     as={InsightQueryInput}
                     repoQuery={null}
                     repositories={repositories.input.value}
-                    patternType={getQueryPatternTypeFilter(query.input.value)}
+                    patternType={getQueryPatternTypeFilter(query.input.value, defaultPatternType)}
                     placeholder="Example: patternType:regexp const\s\w+:\s(React\.)?FunctionComponent"
                     {...getDefaultInputProps(query)}
                     className="mt-3 mb-0"

--- a/internal/database/migration/shared/data/stitched-migration-graph.json
+++ b/internal/database/migration/shared/data/stitched-migration-graph.json
@@ -692,6 +692,19 @@
 				],
 				"IsCreateIndexConcurrently": false,
 				"IndexMetadata": null
+			},
+			{
+				"ID": 1719914228,
+				"Name": "insight_series_modify_query",
+				"UpQuery": "ALTER TABLE insight_series ADD COLUMN IF NOT EXISTS query_old TEXT;\nUPDATE insight_series SET query_old = query;\n\n-- prefix query with patternType:standard if there is no patterntype: in the query\nUPDATE insight_series\nSET query = 'patterntype:standard ' || query\nWHERE query NOT ILIKE '%patterntype:%'\n  -- exclude empty queries, which are created by language stats insights\n  AND query != '';\n\nCOMMENT ON COLUMN insight_series.query_old IS 'Backup for migration. Remove with release 5.6 or later.';",
+				"DownQuery": "DO\n$$\n    BEGIN\n        -- Check if column 'query_old' exists\n        IF EXISTS (SELECT 1\n                   FROM information_schema.columns\n                   WHERE table_name = 'insight_series' AND column_name = 'query_old') THEN\n            -- Update the 'query' column with values from 'query_old'\n            UPDATE insight_series SET query = query_old;\n            ALTER TABLE insight_series DROP COLUMN query_old;\n        END IF;\n    END\n$$;",
+				"Privileged": false,
+				"NonIdempotent": false,
+				"Parents": [
+					1679051112
+				],
+				"IsCreateIndexConcurrently": false,
+				"IndexMetadata": null
 			}
 		],
 		"BoundsByRev": {
@@ -930,7 +943,7 @@
 			"v5.4.0": {
 				"RootID": 1000000027,
 				"LeafIDs": [
-					1679051112
+					1719914228
 				],
 				"PreCreation": false
 			}

--- a/internal/database/schema.codeinsights.json
+++ b/internal/database/schema.codeinsights.json
@@ -945,6 +945,19 @@
           "Comment": "Query string that generates this series"
         },
         {
+          "Name": "query_old",
+          "Index": 24,
+          "TypeName": "text",
+          "IsNullable": true,
+          "Default": "",
+          "CharacterMaximumLength": 0,
+          "IsIdentity": false,
+          "IdentityGeneration": "",
+          "IsGenerated": "NEVER",
+          "GenerationExpression": "",
+          "Comment": "Backup for migration. Remove with release 5.6 or later."
+        },
+        {
           "Name": "repositories",
           "Index": 12,
           "TypeName": "text[]",

--- a/internal/database/schema.codeinsights.md
+++ b/internal/database/schema.codeinsights.md
@@ -137,6 +137,7 @@ Foreign-key constraints:
  backfill_completed_at         | timestamp without time zone |           |          | 
  supports_augmentation         | boolean                     |           | not null | true
  repository_criteria           | text                        |           |          | 
+ query_old                     | text                        |           |          | 
 Indexes:
     "insight_series_pkey" PRIMARY KEY, btree (id)
     "insight_series_series_id_unique_idx" UNIQUE, btree (series_id)
@@ -171,6 +172,8 @@ Data series that comprise code insights.
 **oldest_historical_at**: Timestamp representing the oldest point of which this series is backfilled.
 
 **query**: Query string that generates this series
+
+**query_old**: Backup for migration. Remove with release 5.6 or later.
 
 **repository_criteria**: The search criteria used to determine the repositories that are included in this series.
 

--- a/migrations/codeinsights/1719914228_insight_series_modify_query/down.sql
+++ b/migrations/codeinsights/1719914228_insight_series_modify_query/down.sql
@@ -1,0 +1,13 @@
+DO
+$$
+    BEGIN
+        -- Check if column 'query_old' exists
+        IF EXISTS (SELECT 1
+                   FROM information_schema.columns
+                   WHERE table_name = 'insight_series' AND column_name = 'query_old') THEN
+            -- Update the 'query' column with values from 'query_old'
+            UPDATE insight_series SET query = query_old;
+            ALTER TABLE insight_series DROP COLUMN query_old;
+        END IF;
+    END
+$$;

--- a/migrations/codeinsights/1719914228_insight_series_modify_query/metadata.yaml
+++ b/migrations/codeinsights/1719914228_insight_series_modify_query/metadata.yaml
@@ -1,0 +1,2 @@
+name: insight_series_modify_query
+parents: [1679051112]

--- a/migrations/codeinsights/1719914228_insight_series_modify_query/up.sql
+++ b/migrations/codeinsights/1719914228_insight_series_modify_query/up.sql
@@ -1,0 +1,11 @@
+ALTER TABLE insight_series ADD COLUMN IF NOT EXISTS query_old TEXT;
+UPDATE insight_series SET query_old = query;
+
+-- prefix query with patternType:standard if there is no patterntype: in the query
+UPDATE insight_series
+SET query = 'patterntype:standard ' || query
+WHERE query NOT ILIKE '%patterntype:%'
+  -- exclude empty queries, which are created by language stats insights
+  AND query != '';
+
+COMMENT ON COLUMN insight_series.query_old IS 'Backup for migration. Remove with release 5.6 or later.';

--- a/migrations/codeinsights/squashed.sql
+++ b/migrations/codeinsights/squashed.sql
@@ -147,7 +147,8 @@ CREATE TABLE insight_series (
     needs_migration boolean,
     backfill_completed_at timestamp without time zone,
     supports_augmentation boolean DEFAULT true NOT NULL,
-    repository_criteria text
+    repository_criteria text,
+    query_old text
 );
 
 COMMENT ON TABLE insight_series IS 'Data series that comprise code insights.';
@@ -173,6 +174,8 @@ COMMENT ON COLUMN insight_series.generation_method IS 'Specifies the execution m
 COMMENT ON COLUMN insight_series.just_in_time IS 'Specifies if the series should be resolved just in time at query time, or recorded in background processing.';
 
 COMMENT ON COLUMN insight_series.repository_criteria IS 'The search criteria used to determine the repositories that are included in this series.';
+
+COMMENT ON COLUMN insight_series.query_old IS 'Backup for migration. Remove with release 5.6 or later.';
 
 CREATE TABLE insight_series_backfill (
     id integer NOT NULL,


### PR DESCRIPTION
This PR refactors insights to support the upcoming Keyword Search GA.

New insights are always persisted with `patternType:`.

Queries of existing insights are updated with `patternType:standard <query>` if they don't already specify a pattern type. This reflects the current default of the Stream API and thus, merely makes the pattern type explicit. 

Notes:
- The Insights UI has a lot of query input fields, but there are only 2 fields which allow the user to freely specify a pattern type: the interactive insight on the landing page and the query input field in the "Track Changes" creation form.

Test plan:
- new unit test
- existing tests pass without changes
- manual testing:
  - I created a couple of insights and checked that the pattern type is persisted in the db. 
  - I experimented with different default pattern types.
  - I tested the workflow to create an insight from the search results page.
  - I created a "language" insights and ran the migration to make sure we don't set pattern type in those cases.

