### PR TITLE
Cody context: fix an issue with anchoring repo names

### DIFF
--- a/cmd/frontend/internal/codycontext/context.go
+++ b/cmd/frontend/internal/codycontext/context.go
@@ -279,10 +279,10 @@ func (c *CodyContextClient) getKeywordContext(ctx context.Context, args GetConte
 	// the job structs directly.
 	regexEscapedRepoNames := make([]string, len(args.Repos))
 	for i, repo := range args.Repos {
-		regexEscapedRepoNames[i] = regexp.QuoteMeta(string(repo.Name))
+		regexEscapedRepoNames[i] = fmt.Sprintf("^%s$", regexp.QuoteMeta(string(repo.Name)))
 	}
 
-	keywordQuery := fmt.Sprintf(`repo:^%s$ %s %s`, query.UnionRegExps(regexEscapedRepoNames), getKeywordContextExcludeFilePathsQuery(), args.Query)
+	keywordQuery := fmt.Sprintf(`repo:%s %s %s`, query.UnionRegExps(regexEscapedRepoNames), getKeywordContextExcludeFilePathsQuery(), args.Query)
 
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()

--- a/cmd/frontend/internal/codycontext/context_test.go
+++ b/cmd/frontend/internal/codycontext/context_test.go
@@ -1,9 +1,11 @@
 package codycontext
 
 import (
+	"regexp"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
 
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
 	"github.com/sourcegraph/sourcegraph/internal/types"
@@ -70,4 +72,14 @@ func TestFileMatchToContextMatches(t *testing.T) {
 			t.Errorf("mismatch (-want +got):\n%s", diff)
 		}
 	}
+}
+
+func TestReposAsRegexp(t *testing.T) {
+	t.Run("SRCH-658", func(t *testing.T) {
+		repos := []types.RepoIDName{{Name: "github.com/sourcegraph/docs"}, {Name: "github.com/sourcegraph/docs"}}
+		pattern := reposAsRegexp(repos)
+		re := regexp.MustCompile(pattern)
+		require.True(t, re.MatchString("github.com/sourcegraph/docs"))
+		require.False(t, re.MatchString("github.com/sourcegraph/docsite"))
+	})
 }


### PR DESCRIPTION
Fixes SRCH-658

This fixes an issue with anchoring repos in the keyword search query used for cody context. 

Previously, we would use a `repo:` pattern like `repo:^(?:a)|(?:b)$`. However, the union operator binds loosely, so this is interpreted as matching `(^a)|(b$)` rather than `^(a|b)$`. 

This fixes the pattern so we add the anchors to every repo name. Alternatively, we could modify the behavior of `UnionRegExp`, but that seemed riskier. 

## Test plan

Quick manual test that context for `github.com/sourcegraph/docs` does not return any files from `github.com/sourcegraph/docsite`

## Changelog

- Fixes a bug that caused context to be fetched for Cody from irrelevant repos