### PR TITLE
Search: restore snippets to filters sidebar

### DIFF
--- a/client/branded/src/search-ui/results/filters/NewSearchFilters.tsx
+++ b/client/branded/src/search-ui/results/filters/NewSearchFilters.tsx
@@ -8,6 +8,7 @@ import { scanSearchQuery, succeedScan } from '@sourcegraph/shared/src/search/que
 import type { Filter as QueryFilter } from '@sourcegraph/shared/src/search/query/token'
 import { omitFilter } from '@sourcegraph/shared/src/search/query/transformer'
 import { TELEMETRY_FILTER_TYPES, type Filter } from '@sourcegraph/shared/src/search/stream'
+import { useSettings } from '@sourcegraph/shared/src/settings/settings'
 import type { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Button, H1, H3, Icon, Tooltip } from '@sourcegraph/wildcard'
@@ -19,7 +20,6 @@ import {
     repoFilter,
     SearchDynamicFilter,
     symbolFilter,
-    utilityFilter,
 } from './components/dynamic-filter/SearchDynamicFilter'
 import { SearchFilterSkeleton } from './components/filter-skeleton/SearchFilterSkeleton'
 import { FilterTypeList } from './components/filter-type-list/FilterTypeList'
@@ -92,7 +92,7 @@ export const NewSearchFilters: FC<NewSearchFiltersProps> = ({
     )
 
     const handleFilterChange = useCallback(
-        (filterKind: Filter['kind'], filters: URLQueryFilter[]) => {
+        (filterKind: FilterKind, filters: URLQueryFilter[]) => {
             setSelectedFilters(filters)
             telemetryService.log('SearchFiltersSelectFilter', { filterKind }, { filterKind })
             telemetryRecorder.recordEvent('search.filters', 'select', {
@@ -111,6 +111,17 @@ export const NewSearchFilters: FC<NewSearchFiltersProps> = ({
     const onAddFilterToQuery = (filter: string): void => {
         onQueryChange(`${query} ${filter}`)
     }
+
+    const settings = useSettings()
+    const snippetFilters = settings?.['search.scopes']?.map(
+        (scope): Filter => ({
+            label: scope.name,
+            value: scope.value,
+            count: 0,
+            exhaustive: true,
+            kind: 'snippet' as any,
+        })
+    )
 
     return (
         <div className={styles.scrollWrapper}>
@@ -204,11 +215,11 @@ export const NewSearchFilters: FC<NewSearchFiltersProps> = ({
                 />
 
                 <SearchDynamicFilter
-                    title="Utility"
-                    filterKind={FilterKind.Utility}
-                    filters={filters}
+                    title="Snippets"
+                    filterKind={FilterKind.Snippet}
+                    filters={snippetFilters}
                     selectedFilters={selectedFilters}
-                    renderItem={utilityFilter}
+                    renderItem={commitDateFilter}
                     onSelectedFilterChange={handleFilterChange}
                     onAddFilterToQuery={onAddFilterToQuery}
                 />
@@ -300,7 +311,7 @@ const SyntheticCountFilter: FC<SyntheticCountFilterProps> = props => {
         return []
     }, [query])
 
-    const handleCountAllFilter = (filterKind: Filter['kind'], countFilters: URLQueryFilter[]): void => {
+    const handleCountAllFilter = (filterKind: FilterKind, countFilters: URLQueryFilter[]): void => {
         telemetryService.log('SearchFiltersSelectFilter', { filterKind }, { filterKind })
         telemetryRecorder.recordEvent('search.filters', 'select', {
             metadata: { filterKind: TELEMETRY_FILTER_TYPES[filterKind] },
@@ -323,7 +334,7 @@ const SyntheticCountFilter: FC<SyntheticCountFilterProps> = props => {
 
     return (
         <SearchDynamicFilter
-            filterKind={FilterKind.Count as any}
+            filterKind={FilterKind.Count}
             filters={STATIC_COUNT_FILTER}
             selectedFilters={selectedCountFilter}
             renderItem={commitDateFilter}

--- a/client/branded/src/search-ui/results/filters/components/dynamic-filter/SearchDynamicFilter.tsx
+++ b/client/branded/src/search-ui/results/filters/components/dynamic-filter/SearchDynamicFilter.tsx
@@ -13,6 +13,7 @@ import { Button, Icon, H2, H4, Input, LanguageIcon, Code, Tooltip } from '@sourc
 import { codeHostIcon } from '../../../../components'
 import { SyntaxHighlightedSearchQuery } from '../../../../components/SyntaxHighlightedSearchQuery'
 import type { URLQueryFilter } from '../../hooks'
+import { FilterKind } from '../../types'
 import { DynamicFilterBadge } from '../DynamicFilterBadge'
 
 import styles from './SearchDynamicFilter.module.scss'
@@ -28,7 +29,7 @@ interface SearchDynamicFilterProps {
      * Specifies which type filter we want to render in this particular
      * filter section, it could be lang filter, repo filter, or file filters.
      */
-    filterKind: Filter['kind']
+    filterKind: FilterKind
 
     /**
      * The set of filters that are selected. This is the state that is stored
@@ -48,7 +49,7 @@ interface SearchDynamicFilterProps {
      * It's called whenever user changes (pick/reset) any filters in the filter panel.
      * @param nextQuery
      */
-    onSelectedFilterChange: (filterKind: Filter['kind'], filters: URLQueryFilter[]) => void
+    onSelectedFilterChange: (filterKind: FilterKind, filters: URLQueryFilter[]) => void
 
     onAddFilterToQuery: (newFilter: string) => void
 }
@@ -221,7 +222,7 @@ const DynamicFilterItem: FC<DynamicFilterItemProps> = props => {
     )
 }
 
-function filterForSearchTerm(input: string, filterKind: Filter['kind']): string | null {
+function filterForSearchTerm(input: string, filterKind: FilterKind): string | null {
     switch (filterKind) {
         case 'repo': {
             return `repo:${maybeQuoteString(input)}`

--- a/client/branded/src/search-ui/results/filters/types.ts
+++ b/client/branded/src/search-ui/results/filters/types.ts
@@ -10,6 +10,7 @@ export enum FilterKind {
     // Synthetic filters, lives only on the client
     Count = 'count',
     Type = 'type',
+    Snippet = 'snippet',
 }
 
 export const DYNAMIC_FILTER_KINDS = [

--- a/client/shared/src/search/stream.ts
+++ b/client/shared/src/search/stream.ts
@@ -246,17 +246,17 @@ export interface Skipped {
      * - display :: we hit the display limit, so we stopped sending results from the backend.
      */
     reason:
-        | 'document-match-limit'
-        | 'shard-match-limit'
-        | 'repository-limit'
-        | 'shard-timedout'
-        | 'repository-cloning'
-        | 'repository-missing'
-        | 'repository-fork'
-        | 'backend-missing'
-        | 'excluded-archive'
-        | 'display'
-        | 'error'
+    | 'document-match-limit'
+    | 'shard-match-limit'
+    | 'repository-limit'
+    | 'shard-timedout'
+    | 'repository-cloning'
+    | 'repository-missing'
+    | 'repository-fork'
+    | 'backend-missing'
+    | 'excluded-archive'
+    | 'display'
+    | 'error'
     /**
      * A short message. eg 1,200 timed out.
      */
@@ -284,7 +284,7 @@ export interface Filter {
     kind: 'file' | 'repo' | 'lang' | 'utility' | 'author' | 'commit date' | 'symbol type' | 'type'
 }
 
-export const TELEMETRY_FILTER_TYPES: { [key in Filter['kind'] | 'snippet']: number } = {
+export const TELEMETRY_FILTER_TYPES = {
     file: 1,
     repo: 2,
     lang: 3,
@@ -294,6 +294,7 @@ export const TELEMETRY_FILTER_TYPES: { [key in Filter['kind'] | 'snippet']: numb
     'symbol type': 7,
     type: 8,
     snippet: 9,
+    count: 10,
 }
 
 export type SmartSearchAlertKind = 'smart-search-additional-results' | 'smart-search-pure-results'

--- a/client/shared/src/search/stream.ts
+++ b/client/shared/src/search/stream.ts
@@ -284,7 +284,7 @@ export interface Filter {
     kind: 'file' | 'repo' | 'lang' | 'utility' | 'author' | 'commit date' | 'symbol type' | 'type'
 }
 
-export const TELEMETRY_FILTER_TYPES: { [key in Filter['kind']]: number } = {
+export const TELEMETRY_FILTER_TYPES: { [key in Filter['kind'] | 'snippet']: number } = {
     file: 1,
     repo: 2,
     lang: 3,
@@ -293,6 +293,7 @@ export const TELEMETRY_FILTER_TYPES: { [key in Filter['kind']]: number } = {
     'commit date': 6,
     'symbol type': 7,
     type: 8,
+    snippet: 9,
 }
 
 export type SmartSearchAlertKind = 'smart-search-additional-results' | 'smart-search-pure-results'

--- a/client/shared/src/search/stream.ts
+++ b/client/shared/src/search/stream.ts
@@ -246,17 +246,17 @@ export interface Skipped {
      * - display :: we hit the display limit, so we stopped sending results from the backend.
      */
     reason:
-    | 'document-match-limit'
-    | 'shard-match-limit'
-    | 'repository-limit'
-    | 'shard-timedout'
-    | 'repository-cloning'
-    | 'repository-missing'
-    | 'repository-fork'
-    | 'backend-missing'
-    | 'excluded-archive'
-    | 'display'
-    | 'error'
+        | 'document-match-limit'
+        | 'shard-match-limit'
+        | 'repository-limit'
+        | 'shard-timedout'
+        | 'repository-cloning'
+        | 'repository-missing'
+        | 'repository-fork'
+        | 'backend-missing'
+        | 'excluded-archive'
+        | 'display'
+        | 'error'
     /**
      * A short message. eg 1,200 timed out.
      */

--- a/client/web-sveltekit/src/lib/search/dynamicFilters/CountBadge.svelte
+++ b/client/web-sveltekit/src/lib/search/dynamicFilters/CountBadge.svelte
@@ -15,28 +15,14 @@
     import Tooltip from '$lib/Tooltip.svelte'
     import { Badge } from '$lib/wildcard'
 
-    export let count: number | undefined
+    export let count: number
     export let exhaustive: boolean
 </script>
 
-{#if count !== undefined}
-    <span>
-        {#if exhaustive}
-            <Badge variant="secondary">{count}</Badge>
-        {:else}
-            <Tooltip placement="right" tooltip="At least {count} {pluralize('result', count)} match this filter.">
-                <Badge variant="secondary">{roundCount(count)}+</Badge>
-            </Tooltip>
-        {/if}
-    </span>
+{#if exhaustive}
+    <Badge variant="secondary">{count}</Badge>
+{:else}
+    <Tooltip placement="right" tooltip="At least {count} {pluralize('result', count)} match this filter.">
+        <Badge variant="secondary">{roundCount(count)}+</Badge>
+    </Tooltip>
 {/if}
-
-<style lang="scss">
-    span {
-        display: contents;
-        :global(span) {
-            background-color: var(--secondary-2);
-            color: var(--text-body);
-        }
-    }
-</style>

--- a/client/web-sveltekit/src/lib/search/dynamicFilters/Section.svelte
+++ b/client/web-sveltekit/src/lib/search/dynamicFilters/Section.svelte
@@ -1,10 +1,11 @@
 <script lang="ts">
+    import type { ComponentProps } from 'svelte'
+
     import { Button } from '$lib/wildcard'
 
-    import type { SectionItemData } from './index.ts'
     import SectionItem from './SectionItem.svelte'
 
-    export let items: SectionItemData[]
+    export let items: ComponentProps<SectionItem>[]
     export let title: string
     export let filterPlaceholder: string = ''
     export let showAll: boolean = false
@@ -32,7 +33,7 @@
             {#each limitedItems as item}
                 <li>
                     <slot name="item" {item}>
-                        <SectionItem {item} {onFilterSelect} />
+                        <SectionItem {...item} {onFilterSelect} />
                     </slot>
                 </li>
             {/each}

--- a/client/web-sveltekit/src/lib/search/dynamicFilters/Section.svelte
+++ b/client/web-sveltekit/src/lib/search/dynamicFilters/Section.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import type { ComponentProps } from 'svelte'
+    import { createEventDispatcher, type ComponentProps } from 'svelte'
 
     import { Button } from '$lib/wildcard'
 
@@ -9,7 +9,6 @@
     export let title: string
     export let filterPlaceholder: string = ''
     export let showAll: boolean = false
-    export let onFilterSelect: (kind: SectionItem['kind']) => void = () => {}
 
     let filterText = ''
     $: processedFilterText = filterText.trim().toLowerCase()
@@ -21,6 +20,8 @@
     let showMore = false
     $: showCount = showAll ? items.length : showMore ? 10 : 5
     $: limitedItems = filteredItems.slice(0, showCount)
+
+    const dispatch = createEventDispatcher<{ 'item-click': string }>()
 </script>
 
 {#if items.length > 0}
@@ -33,7 +34,7 @@
             {#each limitedItems as item}
                 <li>
                     <slot name="item" {item}>
-                        <SectionItem {...item} {onFilterSelect} />
+                        <SectionItem {...item} on:click={ev => dispatch('item-click', ev.detail)} />
                     </slot>
                 </li>
             {/each}

--- a/client/web-sveltekit/src/lib/search/dynamicFilters/Section.svelte
+++ b/client/web-sveltekit/src/lib/search/dynamicFilters/Section.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { createEventDispatcher, type ComponentProps } from 'svelte'
+    import type { ComponentProps } from 'svelte'
 
     import { Button } from '$lib/wildcard'
 
@@ -20,8 +20,6 @@
     let showMore = false
     $: showCount = showAll ? items.length : showMore ? 10 : 5
     $: limitedItems = filteredItems.slice(0, showCount)
-
-    const dispatch = createEventDispatcher<{ 'item-click': string }>()
 </script>
 
 {#if items.length > 0}
@@ -34,7 +32,7 @@
             {#each limitedItems as item}
                 <li>
                     <slot name="item" {item}>
-                        <SectionItem {...item} on:click={ev => dispatch('item-click', ev.detail)} />
+                        <SectionItem {...item} on:select />
                     </slot>
                 </li>
             {/each}

--- a/client/web-sveltekit/src/lib/search/dynamicFilters/SectionItem.svelte
+++ b/client/web-sveltekit/src/lib/search/dynamicFilters/SectionItem.svelte
@@ -11,11 +11,11 @@
     export let count: ComponentProps<CountBadge> | undefined = undefined
     export let selected: boolean
 
-    const dispatch = createEventDispatcher<{ select: {} }>()
+    const dispatch = createEventDispatcher<{ select: { label: string; value: string } }>()
 </script>
 
 <!-- TODO: a11y. This should expose the aria selected state and use the proper roles -->
-<a href={href.toString()} class:selected on:click={() => dispatch('select', {})}>
+<a href={href.toString()} class:selected on:click={() => dispatch('select', { label, value })}>
     <slot name="icon" />
     <span class="label">
         <slot name="label" {label} {value}>

--- a/client/web-sveltekit/src/lib/search/dynamicFilters/SectionItem.svelte
+++ b/client/web-sveltekit/src/lib/search/dynamicFilters/SectionItem.svelte
@@ -22,9 +22,7 @@
     </span>
     <CountBadge count={item.count} exhaustive={item.exhaustive} />
     {#if item.selected}
-        <span class="close">
-            <Icon icon={ILucideX} inline aria-hidden />
-        </span>
+        <Icon icon={ILucideX} inline aria-hidden />
     {/if}
 </a>
 
@@ -73,10 +71,6 @@
             .label {
                 color: var(--light-text);
             }
-        }
-
-        .close {
-            flex-shrink: 0;
         }
     }
 </style>

--- a/client/web-sveltekit/src/lib/search/dynamicFilters/SectionItem.svelte
+++ b/client/web-sveltekit/src/lib/search/dynamicFilters/SectionItem.svelte
@@ -1,27 +1,36 @@
 <script lang="ts">
+    import type { ComponentProps } from 'svelte'
+
     import { page } from '$app/stores'
     import Icon from '$lib/Icon.svelte'
 
     import CountBadge from './CountBadge.svelte'
-    import { updateFilterInURL, type SectionItemData } from './index'
+    import { updateFilterInURL } from './index'
 
-    export let item: SectionItemData
-    export let onFilterSelect: (kind: SectionItemData['kind']) => void = () => {}
+    export let label: string
+    export let value: string
+    export let kind: string
+    export let count: ComponentProps<CountBadge> | undefined = undefined
+    export let selected: boolean
+
+    export let onFilterSelect: (kind: string) => void = () => {}
 </script>
 
 <a
-    href={updateFilterInURL($page.url, item, item.selected).toString()}
-    class:selected={item.selected}
-    on:click={() => onFilterSelect(item.kind)}
+    href={updateFilterInURL($page.url, { kind, label, value }, selected).toString()}
+    class:selected
+    on:click={() => onFilterSelect(kind)}
 >
     <slot name="icon" />
     <span class="label">
-        <slot name="label" label={item.label} value={item.value}>
-            {item.label}
+        <slot name="label" {label} {value}>
+            {label}
         </slot>
     </span>
-    <CountBadge count={item.count} exhaustive={item.exhaustive} />
-    {#if item.selected}
+    {#if count}
+        <CountBadge {...count} />
+    {/if}
+    {#if selected}
         <Icon icon={ILucideX} inline aria-hidden />
     {/if}
 </a>

--- a/client/web-sveltekit/src/lib/search/dynamicFilters/SectionItem.svelte
+++ b/client/web-sveltekit/src/lib/search/dynamicFilters/SectionItem.svelte
@@ -16,6 +16,7 @@
     export let onFilterSelect: (kind: string) => void = () => {}
 </script>
 
+<!-- TODO: a11y. This should expose the aria selected state and use the proper roles -->
 <a
     href={updateFilterInURL($page.url, { kind, label, value }, selected).toString()}
     class:selected

--- a/client/web-sveltekit/src/lib/search/dynamicFilters/SectionItem.svelte
+++ b/client/web-sveltekit/src/lib/search/dynamicFilters/SectionItem.svelte
@@ -11,11 +11,11 @@
     export let count: ComponentProps<CountBadge> | undefined = undefined
     export let selected: boolean
 
-    const dispatch = createEventDispatcher<{ click: string }>()
+    const dispatch = createEventDispatcher<{ select: {} }>()
 </script>
 
 <!-- TODO: a11y. This should expose the aria selected state and use the proper roles -->
-<a href={href.toString()} class:selected on:click={() => dispatch('click', label)}>
+<a href={href.toString()} class:selected on:click={() => dispatch('select', {})}>
     <slot name="icon" />
     <span class="label">
         <slot name="label" {label} {value}>

--- a/client/web-sveltekit/src/lib/search/dynamicFilters/SectionItem.svelte
+++ b/client/web-sveltekit/src/lib/search/dynamicFilters/SectionItem.svelte
@@ -1,27 +1,21 @@
 <script lang="ts">
-    import type { ComponentProps } from 'svelte'
+    import { createEventDispatcher, type ComponentProps } from 'svelte'
 
-    import { page } from '$app/stores'
     import Icon from '$lib/Icon.svelte'
 
     import CountBadge from './CountBadge.svelte'
-    import { updateFilterInURL } from './index'
 
     export let label: string
     export let value: string
-    export let kind: string
+    export let href: URL
     export let count: ComponentProps<CountBadge> | undefined = undefined
     export let selected: boolean
 
-    export let onFilterSelect: (kind: string) => void = () => {}
+    const dispatch = createEventDispatcher<{ click: string }>()
 </script>
 
 <!-- TODO: a11y. This should expose the aria selected state and use the proper roles -->
-<a
-    href={updateFilterInURL($page.url, { kind, label, value }, selected).toString()}
-    class:selected
-    on:click={() => onFilterSelect(kind)}
->
+<a href={href.toString()} class:selected on:click={() => dispatch('click', label)}>
     <slot name="icon" />
     <span class="label">
         <slot name="label" {label} {value}>

--- a/client/web-sveltekit/src/lib/search/dynamicFilters/Sidebar.svelte
+++ b/client/web-sveltekit/src/lib/search/dynamicFilters/Sidebar.svelte
@@ -22,18 +22,23 @@
 
     type SectionKind = typeof sectionKinds[number]
 
+    // A statically-defined filter
     type StaticFilter = {
         label: string
         value: string
     }
 
+    // A selected filter
     type SelectedFilter = StaticFilter
 
+    // A filter sourced from the stream API
     type StreamFilter = StaticFilter & {
         count: number
         exhaustive: boolean
     }
 
+    // Everything needed to render a SectionItem except the href, which
+    // can be calculated from the current URL and the other props.
     type MergedFilter = Omit<ComponentProps<SectionItem>, 'href'>
 
     const typeFilterIcons: Record<string, IconComponent> = {

--- a/client/web-sveltekit/src/lib/search/dynamicFilters/Sidebar.svelte
+++ b/client/web-sveltekit/src/lib/search/dynamicFilters/Sidebar.svelte
@@ -273,10 +273,8 @@
     {#if selectedFilters.length > 0}
         <div class="move-button">
             <Button variant="secondary" display="block" outline on:click={() => goto(moveFiltersToQuery($page.url))}>
-                <svelte:fragment>
-                    Move filters to query&nbsp;
-                    <Icon icon={ILucideCornerRightDown} aria-hidden inline />
-                </svelte:fragment>
+                Move filters to query&nbsp;
+                <Icon icon={ILucideCornerRightDown} aria-hidden inline />
             </Button>
         </div>
     {/if}

--- a/client/web-sveltekit/src/lib/search/dynamicFilters/Sidebar.svelte
+++ b/client/web-sveltekit/src/lib/search/dynamicFilters/Sidebar.svelte
@@ -54,6 +54,7 @@
         { label: 'Diffs', value: 'type:diff' },
     ]
 
+    // mergeFilterSources merges the filters of a shared kind from different sources.
     function mergeFilterSources(
         staticFilters: readonly StaticFilter[],
         selectedFilters: readonly SelectedFilter[],
@@ -66,6 +67,7 @@
             count: undefined,
         }))
 
+        // Then merge in the selected filters
         for (const selectedFilter of selectedFilters) {
             const found = merged.find(filter => filter.label === selectedFilter.label)
             if (found !== undefined) {
@@ -81,6 +83,7 @@
             }
         }
 
+        // Finally, merge in the filters from the search stream
         for (const streamFilter of streamFilters) {
             const found = merged.find(filter => filter.label === streamFilter.label)
             if (found !== undefined) {

--- a/client/web-sveltekit/src/lib/search/dynamicFilters/Sidebar.svelte
+++ b/client/web-sveltekit/src/lib/search/dynamicFilters/Sidebar.svelte
@@ -244,10 +244,10 @@
         />
         <Section items={sectionItems['commit date']} title="By commit date">
             <SectionItem slot="item" let:item {...item} on:select={() => handleFilterSelect('commit date')}>
-                <span class="commit-date-label" slot="label">
+                <svelte:fragment slot="label">
                     {item.label}
                     <small><pre>{item.value}</pre></small>
-                </span>
+                </svelte:fragment>
             </SectionItem>
         </Section>
         <Section items={sectionItems.file} title="By file" showAll on:select={() => handleFilterSelect('file')} />
@@ -255,10 +255,10 @@
 
         <Section items={sectionItems.snippet} title="Snippets">
             <SectionItem slot="item" let:item {...item} on:select={() => handleFilterSelect('snippet')}>
-                <span class="commit-date-label" slot="label">
+                <svelte:fragment slot="label">
                     {item.label}
                     <small><pre>{item.value}</pre></small>
-                </span>
+                </svelte:fragment>
             </SectionItem>
         </Section>
 

--- a/client/web-sveltekit/src/lib/search/dynamicFilters/Sidebar.svelte
+++ b/client/web-sveltekit/src/lib/search/dynamicFilters/Sidebar.svelte
@@ -277,6 +277,15 @@
             on:item-click={() => handleFilterSelect('utility')}
         />
 
+        <Section items={sectionItems.snippet} title="Snippets" on:item-click={() => handleFilterSelect('snippet')}>
+            <SectionItem slot="item" let:item {...item}>
+                <span class="commit-date-label" slot="label">
+                    {item.label}
+                    <small><pre>{item.value}</pre></small>
+                </span>
+            </SectionItem>
+        </Section>
+
         {#if state === 'loading'}
             <LoadingSkeleton />
         {/if}

--- a/client/web-sveltekit/src/lib/search/dynamicFilters/Sidebar.svelte
+++ b/client/web-sveltekit/src/lib/search/dynamicFilters/Sidebar.svelte
@@ -200,23 +200,18 @@
         </div>
 
         {#if !queryHasTypeFilter(searchQuery)}
-            <Section items={sectionItems.type} title="By type" showAll on:item-click={() => handleFilterSelect('type')}>
-                <SectionItem slot="item" let:item {...item}>
+            <Section items={sectionItems.type} title="By type" showAll>
+                <SectionItem slot="item" let:item {...item} on:select={() => handleFilterSelect('type')}>
                     <Icon slot="icon" icon={typeFilterIcons[item.label]} inline />
                 </SectionItem>
             </Section>
         {/if}
 
-        <Section
-            items={sectionItems.repo}
-            title="By repository"
-            filterPlaceholder="Filter repositories"
-            on:item-click={() => handleFilterSelect('repo')}
-        >
+        <Section items={sectionItems.repo} title="By repository" filterPlaceholder="Filter repositories">
             <svelte:fragment slot="item" let:item>
                 <Popover showOnHover let:registerTrigger placement="right-start">
                     <div use:registerTrigger>
-                        <SectionItem {...item}>
+                        <SectionItem {...item} on:select={() => handleFilterSelect('repo')}>
                             <CodeHostIcon slot="icon" disableTooltip repository={item.label} />
                             <span slot="label">{displayRepoName(item.label)}</span>
                         </SectionItem>
@@ -231,23 +226,13 @@
                 </Popover>
             </svelte:fragment>
         </Section>
-        <Section
-            items={sectionItems.lang}
-            title="By language"
-            filterPlaceholder="Filter languages"
-            on:item-click={() => handleFilterSelect('lang')}
-        >
-            <SectionItem slot="item" let:item {...item}>
+        <Section items={sectionItems.lang} title="By language" filterPlaceholder="Filter languages">
+            <SectionItem slot="item" let:item {...item} on:select={() => handleFilterSelect('lang')}>
                 <LanguageIcon slot="icon" language={item.label} inline />
             </SectionItem>
         </Section>
-        <Section
-            items={sectionItems['symbol type']}
-            title="By symbol type"
-            filterPlaceholder="Filter symbol types"
-            on:item-click={() => handleFilterSelect('symbol type')}
-        >
-            <SectionItem slot="item" let:item {...item}>
+        <Section items={sectionItems['symbol type']} title="By symbol type" filterPlaceholder="Filter symbol types">
+            <SectionItem slot="item" let:item {...item} on:select={() => handleFilterSelect('symbol type')}>
                 <SymbolKindIcon slot="icon" symbolKind={item.label.toUpperCase()} />
             </SectionItem>
         </Section>
@@ -255,30 +240,21 @@
             items={sectionItems.author}
             title="By author"
             filterPlaceholder="Filter authors"
-            on:item-click={() => handleFilterSelect('author')}
+            on:select={() => handleFilterSelect('author')}
         />
-        <Section
-            items={sectionItems['commit date']}
-            title="By commit date"
-            on:item-click={() => handleFilterSelect('commit date')}
-        >
-            <SectionItem slot="item" let:item {...item}>
+        <Section items={sectionItems['commit date']} title="By commit date">
+            <SectionItem slot="item" let:item {...item} on:select={() => handleFilterSelect('commit date')}>
                 <span class="commit-date-label" slot="label">
                     {item.label}
                     <small><pre>{item.value}</pre></small>
                 </span>
             </SectionItem>
         </Section>
-        <Section items={sectionItems.file} title="By file" showAll on:item-click={() => handleFilterSelect('file')} />
-        <Section
-            items={sectionItems.utility}
-            title="Utility"
-            showAll
-            on:item-click={() => handleFilterSelect('utility')}
-        />
+        <Section items={sectionItems.file} title="By file" showAll on:select={() => handleFilterSelect('file')} />
+        <Section items={sectionItems.utility} title="Utility" showAll on:select={() => handleFilterSelect('utility')} />
 
-        <Section items={sectionItems.snippet} title="Snippets" on:item-click={() => handleFilterSelect('snippet')}>
-            <SectionItem slot="item" let:item {...item}>
+        <Section items={sectionItems.snippet} title="Snippets">
+            <SectionItem slot="item" let:item {...item} on:select={() => handleFilterSelect('snippet')}>
                 <span class="commit-date-label" slot="label">
                     {item.label}
                     <small><pre>{item.value}</pre></small>

--- a/client/web-sveltekit/src/lib/search/dynamicFilters/index.ts
+++ b/client/web-sveltekit/src/lib/search/dynamicFilters/index.ts
@@ -1,14 +1,7 @@
 import type { Filter } from '@sourcegraph/shared/src/search/stream'
 
-import type { IconComponent } from '$lib/Icon.svelte'
-
 import { parseExtendedSearchURL } from '..'
 import { SearchCachePolicy, setCachePolicyInURL } from '../state'
-
-export type SectionItemData = Omit<Filter, 'count'> & {
-    count?: Filter['count']
-    selected: boolean
-}
 
 /**
  * URLQueryFilter is the subset of a filter that is stored in the URL query
@@ -16,7 +9,11 @@ export type SectionItemData = Omit<Filter, 'count'> & {
  * necessary to render the selected filter before the backend streams back
  * any filters.
  */
-export type URLQueryFilter = Pick<Filter, 'kind' | 'label' | 'value'>
+export type URLQueryFilter = {
+    kind: string
+    label: string
+    value: string
+}
 
 const DYNAMIC_FILTER_URL_QUERY_KEY = 'df'
 
@@ -81,52 +78,3 @@ export const staticTypeFilters: URLQueryFilter[] = [
     { kind: 'type', label: 'Commits', value: 'type:commit' },
     { kind: 'type', label: 'Diffs', value: 'type:diff' },
 ]
-
-export const typeFilterIcons: Record<string, IconComponent> = {
-    Code: ILucideBraces,
-    Repositories: ILucideGitFork,
-    Paths: ILucideFile,
-    Symbols: ILucideSquareFunction,
-    Commits: ILucideGitCommitVertical,
-    Diffs: ILucideDiff,
-}
-
-export type FilterGroups = Record<Filter['kind'], SectionItemData[]>
-
-export function groupFilters(streamFilters: Filter[], selectedFilters: URLQueryFilter[]): FilterGroups {
-    const groupedFilters: FilterGroups = {
-        type: [],
-        repo: [],
-        lang: [],
-        utility: [],
-        author: [],
-        file: [],
-        'commit date': [],
-        'symbol type': [],
-    }
-    for (const selectedFilter of selectedFilters) {
-        const streamFilter = streamFilters.find(
-            streamFilter => streamFilter.kind === selectedFilter.kind && streamFilter.value === selectedFilter.value
-        )
-        groupedFilters[selectedFilter.kind].push({
-            value: selectedFilter.value,
-            label: selectedFilter.label,
-            kind: selectedFilter.kind,
-            selected: true,
-            // Use count and exhaustiveness from the stream filter if it exists
-            count: streamFilter?.count,
-            exhaustive: streamFilter?.exhaustive || false,
-        })
-    }
-    for (const filter of streamFilters) {
-        if (groupedFilters[filter.kind].some(existingFilter => existingFilter.value === filter.value)) {
-            // Skip any filters that were already added by the seleced loop above
-            continue
-        }
-        groupedFilters[filter.kind].push({
-            ...filter,
-            selected: false,
-        })
-    }
-    return groupedFilters
-}

--- a/client/web-sveltekit/src/lib/search/dynamicFilters/index.ts
+++ b/client/web-sveltekit/src/lib/search/dynamicFilters/index.ts
@@ -69,12 +69,3 @@ export function resetFilters(url: URL): URL {
 export function filtersFromParams(params: URLSearchParams): URLQueryFilter[] {
     return params.getAll(DYNAMIC_FILTER_URL_QUERY_KEY).map(deserializeURLFilter)
 }
-
-export const staticTypeFilters: URLQueryFilter[] = [
-    { kind: 'type', label: 'Code', value: 'type:file' },
-    { kind: 'type', label: 'Repositories', value: 'type:repo' },
-    { kind: 'type', label: 'Paths', value: 'type:path' },
-    { kind: 'type', label: 'Symbols', value: 'type:symbol' },
-    { kind: 'type', label: 'Commits', value: 'type:commit' },
-    { kind: 'type', label: 'Diffs', value: 'type:diff' },
-]

--- a/client/web-sveltekit/src/lib/search/dynamicFilters/index.ts
+++ b/client/web-sveltekit/src/lib/search/dynamicFilters/index.ts
@@ -9,7 +9,11 @@ import { SearchCachePolicy, setCachePolicyInURL } from '../state'
  * necessary to render the selected filter before the backend streams back
  * any filters.
  */
-export type URLQueryFilter = Pick<Filter, 'kind' | 'label' | 'value'>
+export type URLQueryFilter = {
+    kind: string
+    label: string
+    value: string
+}
 
 const DYNAMIC_FILTER_URL_QUERY_KEY = 'df'
 

--- a/client/web-sveltekit/src/lib/search/dynamicFilters/index.ts
+++ b/client/web-sveltekit/src/lib/search/dynamicFilters/index.ts
@@ -1,4 +1,4 @@
-import type { Filter } from '@sourcegraph/shared/src/search/stream'
+import type { Filter } from '$lib/shared'
 
 import { parseExtendedSearchURL } from '..'
 import { SearchCachePolicy, setCachePolicyInURL } from '../state'
@@ -9,11 +9,7 @@ import { SearchCachePolicy, setCachePolicyInURL } from '../state'
  * necessary to render the selected filter before the backend streams back
  * any filters.
  */
-export type URLQueryFilter = {
-    kind: string
-    label: string
-    value: string
-}
+export type URLQueryFilter = Pick<Filter, 'kind' | 'label' | 'value'>
 
 const DYNAMIC_FILTER_URL_QUERY_KEY = 'df'
 

--- a/client/web-sveltekit/src/lib/wildcard/Badge.module.scss
+++ b/client/web-sveltekit/src/lib/wildcard/Badge.module.scss
@@ -52,9 +52,9 @@
 }
 
 .secondary {
-    --badge-base: var(--secondary);
-    --badge-light: var(--secondary-2);
-    --badge-dark: var(--secondary-3);
+    --badge-base: var(--secondary-2);
+    --badge-light: var(--secondary-3);
+    --badge-dark: var(--secondary-4);
     --badge-text: var(--body-color);
 }
 

--- a/client/web-sveltekit/src/routes/search/page.spec.ts
+++ b/client/web-sveltekit/src/routes/search/page.spec.ts
@@ -277,7 +277,7 @@ test.describe('search filters', async () => {
         await stream.close()
 
         for (const typeFilter of ['Code', 'Repositories', 'Paths', 'Symbols', 'Commits', 'Diffs']) {
-            expect(page.getByRole('link', { name: typeFilter })).toBeVisible()
+            await expect(page.getByRole('link', { name: typeFilter })).toBeVisible()
         }
     })
 
@@ -304,7 +304,7 @@ test.describe('search filters', async () => {
         )
         await stream.close()
 
-        page.getByRole('link', { name: 'Test snippet' }).click()
+        await page.getByRole('link', { name: 'Test snippet' }).click()
         await page.waitForURL(/Test\+snippet/)
     })
 })

--- a/client/web-sveltekit/src/routes/search/page.spec.ts
+++ b/client/web-sveltekit/src/routes/search/page.spec.ts
@@ -260,3 +260,51 @@ test.describe('search results', async () => {
         await expect(alert).toBeVisible()
     })
 })
+
+test.describe('search filters', async () => {
+    test('type filters are always visible', async ({ page, sg }) => {
+        const stream = await sg.mockSearchStream()
+        await page.goto('/search?q=test')
+        await page.getByRole('heading', { name: 'Filter results' }).waitFor()
+        await stream.publish(
+            {
+                type: 'matches',
+                data: [chunkMatch],
+            },
+            createProgressEvent(),
+            createDoneEvent()
+        )
+        await stream.close()
+
+        for (const typeFilter of ['Code', 'Repositories', 'Paths', 'Symbols', 'Commits', 'Diffs']) {
+            expect(page.getByRole('link', { name: typeFilter })).toBeVisible()
+        }
+    })
+
+    test('snippets are shown', async ({ page, sg }) => {
+        sg.mockOperations({
+            Init: () => ({
+                currentUser: null,
+                viewerSettings: {
+                    final: '{"search.scopes":[{"name":"Test snippet", "value": "repo:testsnippet"}]}',
+                },
+            }),
+        })
+
+        const stream = await sg.mockSearchStream()
+        await page.goto('/search?q=test')
+        await page.getByRole('heading', { name: 'Filter results' }).waitFor()
+        await stream.publish(
+            {
+                type: 'matches',
+                data: [chunkMatch],
+            },
+            createProgressEvent(),
+            createDoneEvent()
+        )
+        await stream.close()
+
+        page.getByRole('link', { name: 'Test snippet' }).click()
+        await page.waitForURL(/Test\+snippet/)
+    })
+})


### PR DESCRIPTION
This adds snippets back to the search sidebar, which got missed when it was redesigned.

This includes some refactoring of the Svelte version to account for filter types that do not match 1:1 with the backend types. We initially tried to tie them tightly with the backend types so the backend is the source of truth, but I think we want to have the ability to introduce client-side-only filters, which we already sorta hackily do with the `type:` filters. And it's even more hacky with the `count:` filter in the React webapp (which doesn't look like it was ever implemented in the Svelte version).

In the React app, I made the minimum changes to get this working (no associated refactoring). 

Fixes SRCH-580

## Test plan

Added a couple of simple playwright tests. Manually tested that:
- Snippets in settings show up in the sidebar
- Clicking them filters your results with that snippet
- Clicking them again unfilters your results
- Moving to query works
- The correct telemetry events are generated

<!-- REQUIRED; info at https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles -->

## Changelog

- Restores search snippets in the search sidebar
