### PR TITLE
fix(svelte): Fix unplugin icons usage in storybook

### DIFF
--- a/client/web-sveltekit/.storybook/main.ts
+++ b/client/web-sveltekit/.storybook/main.ts
@@ -1,4 +1,25 @@
 import type { StorybookConfig } from '@storybook/sveltekit'
+import type { InlineConfig, Plugin } from 'vite'
+
+// See https://github.com/storybookjs/storybook/issues/20562
+const workaroundSvelteDocgenPluginConflictWithUnpluginIcons = (config: InlineConfig) => {
+    if (!config.plugins) return config
+
+    const [_internalPlugins, ...userPlugins] = config.plugins as Plugin[]
+    const docgenPlugin = userPlugins.find(plugin => plugin.name === 'storybook:svelte-docgen-plugin')
+    if (docgenPlugin) {
+        const origTransform = docgenPlugin.transform
+        const newTransform: typeof origTransform = (code, id, options) => {
+            if (id.startsWith('~icons/')) {
+                return
+            }
+            return (origTransform as Function)?.call(docgenPlugin, code, id, options)
+        }
+        docgenPlugin.transform = newTransform
+        docgenPlugin.enforce = 'post'
+    }
+    return config
+}
 
 const config: StorybookConfig = {
     stories: ['../src/**/*.mdx', '../src/**/*.stories.svelte'],
@@ -10,6 +31,9 @@ const config: StorybookConfig = {
     staticDirs: ['../static'],
     docs: {
         autodocs: false,
+    },
+    viteFinal(config) {
+        return workaroundSvelteDocgenPluginConflictWithUnpluginIcons(config)
     },
     core: {
         disableTelemetry: true,


### PR DESCRIPTION
Using unplugin icons with storybook results in build failures. This is a workaround I found in an issue about it.
![2024-07-02_12-26](https://github.com/sourcegraph/sourcegraph/assets/179026/1413f26b-f03d-42ac-86af-0411cc693cc6)


## Test plan

`pnpm storybook` works.
