### PR TITLE
chore: Use api.RepoID and api.CommitID in more places

### DIFF
--- a/internal/codeintel/codenav/commit_cache.go
+++ b/internal/codeintel/codenav/commit_cache.go
@@ -16,26 +16,26 @@ import (
 
 type CommitCache interface {
 	ExistsBatch(ctx context.Context, commits []RepositoryCommit) ([]bool, error)
-	SetResolvableCommit(repositoryID int, commit string)
+	SetResolvableCommit(repositoryID api.RepoID, commit api.CommitID)
 }
 
 type RepositoryCommit struct {
-	RepositoryID int
-	Commit       string
+	RepositoryID api.RepoID
+	Commit       api.CommitID
 }
 
 type commitCache struct {
 	repoStore       database.RepoStore
 	gitserverClient gitserver.Client
 	mutex           sync.RWMutex
-	cache           map[int]map[string]bool
+	cache           map[api.RepoID]map[api.CommitID]bool
 }
 
 func NewCommitCache(repoStore database.RepoStore, client gitserver.Client) CommitCache {
 	return &commitCache{
 		repoStore:       repoStore,
 		gitserverClient: client,
-		cache:           map[int]map[string]bool{},
+		cache:           map[api.RepoID]map[api.CommitID]bool{},
 	}
 }
 
@@ -91,16 +91,16 @@ func (c *commitCache) ExistsBatch(ctx context.Context, commits []RepositoryCommi
 func (c *commitCache) commitsExist(ctx context.Context, commits []RepositoryCommit) (_ []bool, err error) {
 	repositoryIDSet := collections.NewSet[api.RepoID]()
 	for _, rc := range commits {
-		repositoryIDSet.Add(api.RepoID(rc.RepositoryID))
+		repositoryIDSet.Add(rc.RepositoryID)
 	}
 	repositoryIDs := repositoryIDSet.Values()
 	repos, err := c.repoStore.GetReposSetByIDs(ctx, repositoryIDs...)
 	if err != nil {
 		return nil, err
 	}
-	repositoryNames := make(map[int]api.RepoName, len(repos))
+	repositoryNames := make(map[api.RepoID]api.RepoName, len(repos))
 	for _, v := range repos {
-		repositoryNames[int(v.ID)] = v.Name
+		repositoryNames[v.ID] = v.Name
 	}
 
 	// Build the batch request to send to gitserver. Because we only add repo/commit
@@ -108,9 +108,9 @@ func (c *commitCache) commitsExist(ctx context.Context, commits []RepositoryComm
 	// unresolvable repo. We also ensure that we only represent each repo/commit pair
 	// ONCE in the input slice.
 
-	repoCommits := make([]repoCommit, 0, len(commits))    // input to CommitsExist
-	indexMapping := make(map[int]int, len(commits))       // map commits[i] to relevant repoCommits[i]
-	commitsRepresentedInInput := map[int]map[string]int{} // used to populate index mapping
+	repoCommits := make([]repoCommit, 0, len(commits))                 // input to CommitsExist
+	indexMapping := make(map[int]int, len(commits))                    // map commits[i] to relevant repoCommits[i]
+	commitsRepresentedInInput := map[api.RepoID]map[api.CommitID]int{} // used to populate index mapping
 
 	for i, rc := range commits {
 		repoName, ok := repositoryNames[rc.RepositoryID]
@@ -123,7 +123,7 @@ func (c *commitCache) commitsExist(ctx context.Context, commits []RepositoryComm
 
 		// Ensure our second-level mapping exists
 		if _, ok := commitsRepresentedInInput[rc.RepositoryID]; !ok {
-			commitsRepresentedInInput[rc.RepositoryID] = map[string]int{}
+			commitsRepresentedInInput[rc.RepositoryID] = map[api.CommitID]int{}
 		}
 
 		if n, ok := commitsRepresentedInInput[rc.RepositoryID][rc.Commit]; ok {
@@ -138,7 +138,7 @@ func (c *commitCache) commitsExist(ctx context.Context, commits []RepositoryComm
 
 			repoCommits = append(repoCommits, repoCommit{
 				repoName: repoName,
-				commitID: api.CommitID(rc.Commit),
+				commitID: rc.Commit,
 			})
 		}
 	}
@@ -175,11 +175,11 @@ type repoCommit struct {
 }
 
 // set marks the given repository and commit as valid and resolvable by gitserver.
-func (c *commitCache) SetResolvableCommit(repositoryID int, commit string) {
+func (c *commitCache) SetResolvableCommit(repositoryID api.RepoID, commit api.CommitID) {
 	c.setInternal(repositoryID, commit, true)
 }
 
-func (c *commitCache) getInternal(repositoryID int, commit string) (bool, bool) {
+func (c *commitCache) getInternal(repositoryID api.RepoID, commit api.CommitID) (bool, bool) {
 	c.mutex.RLock()
 	defer c.mutex.RUnlock()
 
@@ -192,12 +192,12 @@ func (c *commitCache) getInternal(repositoryID int, commit string) (bool, bool) 
 	return false, false
 }
 
-func (c *commitCache) setInternal(repositoryID int, commit string, exists bool) {
+func (c *commitCache) setInternal(repositoryID api.RepoID, commit api.CommitID, exists bool) {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 
 	if _, ok := c.cache[repositoryID]; !ok {
-		c.cache[repositoryID] = map[string]bool{}
+		c.cache[repositoryID] = map[api.CommitID]bool{}
 	}
 
 	c.cache[repositoryID][commit] = exists

--- a/internal/codeintel/codenav/gittree_translator.go
+++ b/internal/codeintel/codenav/gittree_translator.go
@@ -9,6 +9,7 @@ import (
 	"github.com/dgraph-io/ristretto"
 	"github.com/sourcegraph/go-diff/diff"
 
+	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/codenav/shared"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	sgtypes "github.com/sourcegraph/sourcegraph/internal/types"
@@ -66,7 +67,7 @@ type gitTreeTranslator struct {
 // of the commit field and pass that as a parameter for increased clarity at call-sites.
 type translationBase struct {
 	repo   *sgtypes.Repo
-	commit string
+	commit api.CommitID
 }
 
 func (r *translationBase) GetRepoID() int {
@@ -107,7 +108,7 @@ func NewGitTreeTranslator(client gitserver.Client, base *translationBase, hunkCa
 // indicating that the translation was successful. If reverse is true, then the source and
 // target commits are swapped.
 func (g *gitTreeTranslator) GetTargetCommitPositionFromSourcePosition(ctx context.Context, commit string, path string, px shared.Position, reverse bool) (shared.Position, bool, error) {
-	hunks, err := g.readCachedHunks(ctx, g.base.repo, g.base.commit, commit, path, reverse)
+	hunks, err := g.readCachedHunks(ctx, g.base.repo, string(g.base.commit), commit, path, reverse)
 	if err != nil {
 		return shared.Position{}, false, err
 	}
@@ -121,7 +122,7 @@ func (g *gitTreeTranslator) GetTargetCommitPositionFromSourcePosition(ctx contex
 // that the translation was successful. If reverse is true, then the source and target commits
 // are swapped.
 func (g *gitTreeTranslator) GetTargetCommitRangeFromSourceRange(ctx context.Context, commit string, path string, rx shared.Range, reverse bool) (shared.Range, bool, error) {
-	hunks, err := g.readCachedHunks(ctx, g.base.repo, g.base.commit, commit, path, reverse)
+	hunks, err := g.readCachedHunks(ctx, g.base.repo, string(g.base.commit), commit, path, reverse)
 	if err != nil {
 		return shared.Range{}, false, err
 	}

--- a/internal/codeintel/codenav/request_state.go
+++ b/internal/codeintel/codenav/request_state.go
@@ -5,6 +5,7 @@ import (
 
 	"go.opentelemetry.io/otel/attribute"
 
+	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/core"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/uploads/shared"
@@ -28,15 +29,15 @@ type RequestState struct {
 
 	authChecker authz.SubRepoPermissionChecker
 
-	RepositoryID int
-	Commit       string
+	RepositoryID api.RepoID
+	Commit       api.CommitID
 	Path         core.RepoRelPath
 }
 
 func (r *RequestState) Attrs() []attribute.KeyValue {
 	out := []attribute.KeyValue{
-		attribute.Int("repositoryID", r.RepositoryID),
-		attribute.String("commit", r.Commit),
+		attribute.Int("repositoryID", int(r.RepositoryID)),
+		attribute.String("commit", string(r.Commit)),
 		attribute.String("path", r.Path.RawValue()),
 	}
 	if r.dataLoader != nil {
@@ -52,14 +53,14 @@ func NewRequestState(
 	authChecker authz.SubRepoPermissionChecker,
 	gitserverClient gitserver.Client,
 	repo *sgTypes.Repo,
-	commit string,
+	commit api.CommitID,
 	path core.RepoRelPath,
 	maxIndexes int,
 	hunkCache HunkCache,
 ) RequestState {
 	r := &RequestState{
 		// repoStore:    repoStore,
-		RepositoryID: int(repo.ID),
+		RepositoryID: repo.ID,
 		Commit:       commit,
 		Path:         path,
 	}
@@ -95,7 +96,7 @@ func (r *RequestState) SetUploadsDataLoader(uploads []shared.CompletedUpload) {
 	}
 }
 
-func (r *RequestState) SetLocalGitTreeTranslator(client gitserver.Client, repo *sgTypes.Repo, commit string, hunkCache HunkCache) {
+func (r *RequestState) SetLocalGitTreeTranslator(client gitserver.Client, repo *sgTypes.Repo, commit api.CommitID, hunkCache HunkCache) {
 	args := &translationBase{
 		repo:   repo,
 		commit: commit,

--- a/internal/codeintel/codenav/service.go
+++ b/internal/codeintel/codenav/service.go
@@ -310,7 +310,7 @@ func (s *Service) getUploadLocation(ctx context.Context, args RequestArgs, reque
 // commit. If the translation fails, then the original commit and range are returned along with a false-valued
 // flag.
 func (s *Service) getSourceRange(ctx context.Context, args RequestArgs, requestState RequestState, repositoryID int, commit string, path core.RepoRelPath, rng shared.Range) (string, shared.Range, bool, error) {
-	if repositoryID != args.RepositoryID {
+	if repositoryID != int(args.RepositoryID) {
 		// No diffs between distinct repositories
 		return commit, rng, true, nil
 	}
@@ -318,7 +318,7 @@ func (s *Service) getSourceRange(ctx context.Context, args RequestArgs, requestS
 	if sourceRange, ok, err := requestState.GitTreeTranslator.GetTargetCommitRangeFromSourceRange(ctx, commit, path.RawValue(), rng, true); err != nil {
 		return "", shared.Range{}, false, errors.Wrap(err, "gitTreeTranslator.GetTargetCommitRangeFromSourceRange")
 	} else if ok {
-		return args.Commit, sourceRange, true, nil
+		return string(args.Commit), sourceRange, true, nil
 	}
 
 	return commit, rng, false, nil
@@ -520,7 +520,7 @@ func (s *Service) filterCachedUploadsContainingPath(ctx context.Context, trace o
 	filteredUploads, err := filterUploadsImpl(ctx, s.lsifstore, cachedUploads, path,
 		/*skipDBCheck*/ func(upload uploadsshared.CompletedUpload) bool {
 			// See NOTE(id: path-based-upload-filtering)
-			return upload.Commit == requestState.Commit && path == requestState.Path
+			return api.CommitID(upload.Commit) == requestState.Commit && path == requestState.Path
 		})
 	if err != nil {
 		trace.Warn("FindDocumentIDs failed", log.Error(err))
@@ -690,8 +690,8 @@ func filterUploadsWithCommits(ctx context.Context, commitCache CommitCache, uplo
 	rcs := make([]RepositoryCommit, 0, len(uploads))
 	for _, upload := range uploads {
 		rcs = append(rcs, RepositoryCommit{
-			RepositoryID: upload.RepositoryID,
-			Commit:       upload.Commit,
+			RepositoryID: api.RepoID(upload.RepositoryID),
+			Commit:       api.CommitID(upload.Commit),
 		})
 	}
 	exists, err := commitCache.ExistsBatch(ctx, rcs)
@@ -840,10 +840,10 @@ func (s *Service) getVisibleUpload(ctx context.Context, line, character int, upl
 	}, true, nil
 }
 
-func (s *Service) SnapshotForDocument(ctx context.Context, repositoryID int, commit string, path core.RepoRelPath, uploadID int) (data []shared.SnapshotData, err error) {
+func (s *Service) SnapshotForDocument(ctx context.Context, repositoryID int, commit api.CommitID, path core.RepoRelPath, uploadID int) (data []shared.SnapshotData, err error) {
 	ctx, _, endObservation := s.operations.snapshotForDocument.With(ctx, &err, observation.Args{Attrs: []attribute.KeyValue{
 		attribute.Int("repoID", repositoryID),
-		attribute.String("commit", commit),
+		attribute.String("commit", string(commit)),
 		attribute.String("path", path.RawValue()),
 		attribute.Int("uploadID", uploadID),
 	}})
@@ -1036,8 +1036,8 @@ func (e SyntacticUsagesError) Error() string {
 
 func (s *Service) getSyntacticUpload(ctx context.Context, trace observation.TraceLogger, args UsagesForSymbolArgs) (uploadsshared.CompletedUpload, *SyntacticUsagesError) {
 	uploads, err := s.GetClosestCompletedUploadsForBlob(ctx, uploadsshared.UploadMatchingOptions{
-		RepositoryID:       int(args.Repo.ID),
-		Commit:             string(args.Commit),
+		RepositoryID:       args.Repo.ID,
+		Commit:             args.Commit,
 		Indexer:            uploadsshared.SyntacticIndexer,
 		Path:               args.Path,
 		RootToPathMatching: uploadsshared.RootMustEnclosePath,

--- a/internal/codeintel/codenav/service.go
+++ b/internal/codeintel/codenav/service.go
@@ -840,9 +840,9 @@ func (s *Service) getVisibleUpload(ctx context.Context, line, character int, upl
 	}, true, nil
 }
 
-func (s *Service) SnapshotForDocument(ctx context.Context, repositoryID int, commit api.CommitID, path core.RepoRelPath, uploadID int) (data []shared.SnapshotData, err error) {
+func (s *Service) SnapshotForDocument(ctx context.Context, repositoryID api.RepoID, commit api.CommitID, path core.RepoRelPath, uploadID int) (data []shared.SnapshotData, err error) {
 	ctx, _, endObservation := s.operations.snapshotForDocument.With(ctx, &err, observation.Args{Attrs: []attribute.KeyValue{
-		attribute.Int("repoID", repositoryID),
+		attribute.Int("repoID", int(repositoryID)),
 		attribute.String("commit", string(commit)),
 		attribute.String("path", path.RawValue()),
 		attribute.Int("uploadID", uploadID),

--- a/internal/codeintel/codenav/service_new.go
+++ b/internal/codeintel/codenav/service_new.go
@@ -517,8 +517,8 @@ func (s *Service) prepareCandidateUploads(
 				ctx,
 				monikers,
 				cursor.DefinitionIDs,
-				args.RepositoryID,
-				args.Commit,
+				int(args.RepositoryID),
+				string(args.Commit),
 				requestState.maximumIndexesPerMonikerSearch, // limit
 				cursor.RemoteUploadOffset,                   // offset
 			)

--- a/internal/codeintel/codenav/service_new_test.go
+++ b/internal/codeintel/codenav/service_new_test.go
@@ -36,6 +36,18 @@ func TestGetDefinitions(t *testing.T) {
 		mockRequestState.SetLocalCommitCache(mockRepoStore, mockGitserverClient)
 
 		mockRequestState.SetLocalGitTreeTranslator(mockGitserverClient, &sgtypes.Repo{}, mockCommit, hunkCache)
+		mockRequest := PositionalRequestArgs{
+			RequestArgs: RequestArgs{
+				RepositoryID: 51,
+				Commit:       mockCommit,
+				Limit:        50,
+			},
+			Path:      mockPath,
+			Line:      10,
+			Character: 20,
+		}
+		mockCommit := string(mockCommit)
+
 		uploads := []uploadsshared.CompletedUpload{
 			{ID: 50, Commit: mockCommit, Root: "sub1/"},
 			{ID: 51, Commit: mockCommit, Root: "sub2/"},
@@ -53,16 +65,6 @@ func TestGetDefinitions(t *testing.T) {
 		}
 		mockLsifStore.ExtractDefinitionLocationsFromPositionFunc.PushReturn(locations, nil, nil)
 
-		mockRequest := PositionalRequestArgs{
-			RequestArgs: RequestArgs{
-				RepositoryID: 51,
-				Commit:       mockCommit,
-				Limit:        50,
-			},
-			Path:      mockPath,
-			Line:      10,
-			Character: 20,
-		}
 		adjustedLocations, _, err := svc.GetDefinitions(context.Background(), mockRequest, mockRequestState, Cursor{})
 		if err != nil {
 			t.Fatalf("unexpected error querying definitions: %s", err)

--- a/internal/codeintel/codenav/service_references_test.go
+++ b/internal/codeintel/codenav/service_references_test.go
@@ -1,6 +1,7 @@
 package codenav
 
 import (
+	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/codenav/shared"
 )
 
@@ -13,5 +14,5 @@ var (
 	testRange6 = shared.Range{Start: shared.Position{Line: 16, Character: 26}, End: shared.Position{Line: 36, Character: 46}}
 
 	mockPath   = repoRelPath("s1/main.go")
-	mockCommit = "deadbeef"
+	mockCommit = api.CommitID("deadbeef")
 )

--- a/internal/codeintel/codenav/transport/graphql/iface.go
+++ b/internal/codeintel/codenav/transport/graphql/iface.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/sourcegraph/scip/bindings/go/scip"
 
+	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/codenav"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/codenav/shared"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/core"
@@ -24,7 +25,7 @@ type CodeNavService interface {
 	// see NOTE(id: closest-uploads-postcondition).
 	GetClosestCompletedUploadsForBlob(context.Context, uploadsshared.UploadMatchingOptions) (_ []uploadsshared.CompletedUpload, err error)
 	VisibleUploadsForPath(ctx context.Context, requestState codenav.RequestState) ([]uploadsshared.CompletedUpload, error)
-	SnapshotForDocument(ctx context.Context, repositoryID int, commit string, path core.RepoRelPath, uploadID int) (data []shared.SnapshotData, err error)
+	SnapshotForDocument(ctx context.Context, repositoryID api.RepoID, commit api.CommitID, path core.RepoRelPath, uploadID int) (data []shared.SnapshotData, err error)
 	SCIPDocument(ctx context.Context, uploadID int, path core.RepoRelPath) (*scip.Document, error)
 	SyntacticUsages(ctx context.Context, args codenav.UsagesForSymbolArgs) (codenav.SyntacticUsagesResult, *codenav.PreviousSyntacticSearch, *codenav.SyntacticUsagesError)
 	SearchBasedUsages(ctx context.Context, args codenav.UsagesForSymbolArgs, previous *codenav.PreviousSyntacticSearch) ([]codenav.SearchBasedMatch, error)

--- a/internal/codeintel/codenav/transport/graphql/iface.go
+++ b/internal/codeintel/codenav/transport/graphql/iface.go
@@ -31,6 +31,8 @@ type CodeNavService interface {
 	SearchBasedUsages(ctx context.Context, args codenav.UsagesForSymbolArgs, previous *codenav.PreviousSyntacticSearch) ([]codenav.SearchBasedMatch, error)
 }
 
+var _ CodeNavService = &codenav.Service{}
+
 type AutoIndexingService interface {
 	QueueRepoRev(ctx context.Context, repositoryID int, rev string) error
 }

--- a/internal/codeintel/codenav/transport/graphql/mocks_test.go
+++ b/internal/codeintel/codenav/transport/graphql/mocks_test.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 
 	scip "github.com/sourcegraph/scip/bindings/go/scip"
+	api "github.com/sourcegraph/sourcegraph/internal/api"
 	codenav "github.com/sourcegraph/sourcegraph/internal/codeintel/codenav"
 	shared1 "github.com/sourcegraph/sourcegraph/internal/codeintel/codenav/shared"
 	core "github.com/sourcegraph/sourcegraph/internal/codeintel/core"
@@ -285,7 +286,7 @@ func NewMockCodeNavService() *MockCodeNavService {
 			},
 		},
 		SnapshotForDocumentFunc: &CodeNavServiceSnapshotForDocumentFunc{
-			defaultHook: func(context.Context, int, string, core.RepoRelPath, int) (r0 []shared1.SnapshotData, r1 error) {
+			defaultHook: func(context.Context, api.RepoID, api.CommitID, core.RepoRelPath, int) (r0 []shared1.SnapshotData, r1 error) {
 				return
 			},
 		},
@@ -362,7 +363,7 @@ func NewStrictMockCodeNavService() *MockCodeNavService {
 			},
 		},
 		SnapshotForDocumentFunc: &CodeNavServiceSnapshotForDocumentFunc{
-			defaultHook: func(context.Context, int, string, core.RepoRelPath, int) ([]shared1.SnapshotData, error) {
+			defaultHook: func(context.Context, api.RepoID, api.CommitID, core.RepoRelPath, int) ([]shared1.SnapshotData, error) {
 				panic("unexpected invocation of MockCodeNavService.SnapshotForDocument")
 			},
 		},
@@ -1704,15 +1705,15 @@ func (c CodeNavServiceSearchBasedUsagesFuncCall) Results() []interface{} {
 // SnapshotForDocument method of the parent MockCodeNavService instance is
 // invoked.
 type CodeNavServiceSnapshotForDocumentFunc struct {
-	defaultHook func(context.Context, int, string, core.RepoRelPath, int) ([]shared1.SnapshotData, error)
-	hooks       []func(context.Context, int, string, core.RepoRelPath, int) ([]shared1.SnapshotData, error)
+	defaultHook func(context.Context, api.RepoID, api.CommitID, core.RepoRelPath, int) ([]shared1.SnapshotData, error)
+	hooks       []func(context.Context, api.RepoID, api.CommitID, core.RepoRelPath, int) ([]shared1.SnapshotData, error)
 	history     []CodeNavServiceSnapshotForDocumentFuncCall
 	mutex       sync.Mutex
 }
 
 // SnapshotForDocument delegates to the next hook function in the queue and
 // stores the parameter and result values of this invocation.
-func (m *MockCodeNavService) SnapshotForDocument(v0 context.Context, v1 int, v2 string, v3 core.RepoRelPath, v4 int) ([]shared1.SnapshotData, error) {
+func (m *MockCodeNavService) SnapshotForDocument(v0 context.Context, v1 api.RepoID, v2 api.CommitID, v3 core.RepoRelPath, v4 int) ([]shared1.SnapshotData, error) {
 	r0, r1 := m.SnapshotForDocumentFunc.nextHook()(v0, v1, v2, v3, v4)
 	m.SnapshotForDocumentFunc.appendCall(CodeNavServiceSnapshotForDocumentFuncCall{v0, v1, v2, v3, v4, r0, r1})
 	return r0, r1
@@ -1721,7 +1722,7 @@ func (m *MockCodeNavService) SnapshotForDocument(v0 context.Context, v1 int, v2 
 // SetDefaultHook sets function that is called when the SnapshotForDocument
 // method of the parent MockCodeNavService instance is invoked and the hook
 // queue is empty.
-func (f *CodeNavServiceSnapshotForDocumentFunc) SetDefaultHook(hook func(context.Context, int, string, core.RepoRelPath, int) ([]shared1.SnapshotData, error)) {
+func (f *CodeNavServiceSnapshotForDocumentFunc) SetDefaultHook(hook func(context.Context, api.RepoID, api.CommitID, core.RepoRelPath, int) ([]shared1.SnapshotData, error)) {
 	f.defaultHook = hook
 }
 
@@ -1730,7 +1731,7 @@ func (f *CodeNavServiceSnapshotForDocumentFunc) SetDefaultHook(hook func(context
 // invokes the hook at the front of the queue and discards it. After the
 // queue is empty, the default hook function is invoked for any future
 // action.
-func (f *CodeNavServiceSnapshotForDocumentFunc) PushHook(hook func(context.Context, int, string, core.RepoRelPath, int) ([]shared1.SnapshotData, error)) {
+func (f *CodeNavServiceSnapshotForDocumentFunc) PushHook(hook func(context.Context, api.RepoID, api.CommitID, core.RepoRelPath, int) ([]shared1.SnapshotData, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -1739,19 +1740,19 @@ func (f *CodeNavServiceSnapshotForDocumentFunc) PushHook(hook func(context.Conte
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
 func (f *CodeNavServiceSnapshotForDocumentFunc) SetDefaultReturn(r0 []shared1.SnapshotData, r1 error) {
-	f.SetDefaultHook(func(context.Context, int, string, core.RepoRelPath, int) ([]shared1.SnapshotData, error) {
+	f.SetDefaultHook(func(context.Context, api.RepoID, api.CommitID, core.RepoRelPath, int) ([]shared1.SnapshotData, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
 func (f *CodeNavServiceSnapshotForDocumentFunc) PushReturn(r0 []shared1.SnapshotData, r1 error) {
-	f.PushHook(func(context.Context, int, string, core.RepoRelPath, int) ([]shared1.SnapshotData, error) {
+	f.PushHook(func(context.Context, api.RepoID, api.CommitID, core.RepoRelPath, int) ([]shared1.SnapshotData, error) {
 		return r0, r1
 	})
 }
 
-func (f *CodeNavServiceSnapshotForDocumentFunc) nextHook() func(context.Context, int, string, core.RepoRelPath, int) ([]shared1.SnapshotData, error) {
+func (f *CodeNavServiceSnapshotForDocumentFunc) nextHook() func(context.Context, api.RepoID, api.CommitID, core.RepoRelPath, int) ([]shared1.SnapshotData, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -1790,10 +1791,10 @@ type CodeNavServiceSnapshotForDocumentFuncCall struct {
 	Arg0 context.Context
 	// Arg1 is the value of the 2nd argument passed to this method
 	// invocation.
-	Arg1 int
+	Arg1 api.RepoID
 	// Arg2 is the value of the 3rd argument passed to this method
 	// invocation.
-	Arg2 string
+	Arg2 api.CommitID
 	// Arg3 is the value of the 4th argument passed to this method
 	// invocation.
 	Arg3 core.RepoRelPath

--- a/internal/codeintel/codenav/transport/graphql/root_resolver.go
+++ b/internal/codeintel/codenav/transport/graphql/root_resolver.go
@@ -95,7 +95,7 @@ func (r *rootResolver) GitBlobLSIFData(ctx context.Context, args *resolverstubs.
 		authz.DefaultSubRepoPermsChecker,
 		r.gitserverClient,
 		args.Repo,
-		string(args.Commit),
+		args.Commit,
 		// OK to use Unchecked function based on contract of GraphQL API
 		core.NewRepoRelPathUnchecked(args.Path),
 		r.maximumIndexesPerMonikerSearch,
@@ -127,8 +127,8 @@ func (r *rootResolver) CodeGraphData(ctx context.Context, opts *resolverstubs.Co
 			indexer = shared.SyntacticIndexer
 		}
 		uploads, err := r.svc.GetClosestCompletedUploadsForBlob(ctx, shared.UploadMatchingOptions{
-			RepositoryID:       int(opts.Repo.ID),
-			Commit:             string(opts.Commit),
+			RepositoryID:       opts.Repo.ID,
+			Commit:             opts.Commit,
 			Path:               opts.Path,
 			RootToPathMatching: shared.RootMustEnclosePath,
 			Indexer:            indexer,

--- a/internal/codeintel/codenav/types.go
+++ b/internal/codeintel/codenav/types.go
@@ -5,6 +5,7 @@ import (
 
 	"go.opentelemetry.io/otel/attribute"
 
+	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/codenav/shared"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/core"
 	uploadsshared "github.com/sourcegraph/sourcegraph/internal/codeintel/uploads/shared"
@@ -51,16 +52,16 @@ func (s *qualifiedMonikerSet) add(qualifiedMoniker precise.QualifiedMonikerData)
 }
 
 type RequestArgs struct {
-	RepositoryID int
-	Commit       string
+	RepositoryID api.RepoID
+	Commit       api.CommitID
 	Limit        int
 	RawCursor    string
 }
 
 func (args *RequestArgs) Attrs() []attribute.KeyValue {
 	return []attribute.KeyValue{
-		attribute.Int("repositoryID", args.RepositoryID),
-		attribute.String("commit", args.Commit),
+		attribute.Int("repositoryID", int(args.RepositoryID)),
+		attribute.String("commit", string(args.Commit)),
 		attribute.Int("limit", args.Limit),
 	}
 }

--- a/internal/codeintel/resolvers/codenav.go
+++ b/internal/codeintel/resolvers/codenav.go
@@ -53,8 +53,8 @@ func (a *GitBlobLSIFDataArgs) Options() shared.UploadMatchingOptions {
 		matching = shared.RootEnclosesPathOrPathEnclosesRoot
 	}
 	return shared.UploadMatchingOptions{
-		RepositoryID: int(a.Repo.ID),
-		Commit:       string(a.Commit),
+		RepositoryID: a.Repo.ID,
+		Commit:       a.Commit,
 		// OK to use Unchecked method since we expect a repo-root relative
 		// path from the GraphQL API arguments; upload root relative paths
 		// are largely an implementation detail.

--- a/internal/codeintel/uploads/internal/background/backfiller/mocks_test.go
+++ b/internal/codeintel/uploads/internal/background/backfiller/mocks_test.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 	"time"
 
+	api "github.com/sourcegraph/sourcegraph/internal/api"
 	commitgraph "github.com/sourcegraph/sourcegraph/internal/codeintel/uploads/internal/commitgraph"
 	store "github.com/sourcegraph/sourcegraph/internal/codeintel/uploads/internal/store"
 	shared "github.com/sourcegraph/sourcegraph/internal/codeintel/uploads/shared"
@@ -425,12 +426,12 @@ func NewMockStore() *MockStore {
 			},
 		},
 		HasCommitFunc: &StoreHasCommitFunc{
-			defaultHook: func(context.Context, int, string) (r0 bool, r1 error) {
+			defaultHook: func(context.Context, api.RepoID, api.CommitID) (r0 bool, r1 error) {
 				return
 			},
 		},
 		HasRepositoryFunc: &StoreHasRepositoryFunc{
-			defaultHook: func(context.Context, int) (r0 bool, r1 error) {
+			defaultHook: func(context.Context, api.RepoID) (r0 bool, r1 error) {
 				return
 			},
 		},
@@ -752,12 +753,12 @@ func NewStrictMockStore() *MockStore {
 			},
 		},
 		HasCommitFunc: &StoreHasCommitFunc{
-			defaultHook: func(context.Context, int, string) (bool, error) {
+			defaultHook: func(context.Context, api.RepoID, api.CommitID) (bool, error) {
 				panic("unexpected invocation of MockStore.HasCommit")
 			},
 		},
 		HasRepositoryFunc: &StoreHasRepositoryFunc{
-			defaultHook: func(context.Context, int) (bool, error) {
+			defaultHook: func(context.Context, api.RepoID) (bool, error) {
 				panic("unexpected invocation of MockStore.HasRepository")
 			},
 		},
@@ -5131,15 +5132,15 @@ func (c StoreHardDeleteUploadsByIDsFuncCall) Results() []interface{} {
 // StoreHasCommitFunc describes the behavior when the HasCommit method of
 // the parent MockStore instance is invoked.
 type StoreHasCommitFunc struct {
-	defaultHook func(context.Context, int, string) (bool, error)
-	hooks       []func(context.Context, int, string) (bool, error)
+	defaultHook func(context.Context, api.RepoID, api.CommitID) (bool, error)
+	hooks       []func(context.Context, api.RepoID, api.CommitID) (bool, error)
 	history     []StoreHasCommitFuncCall
 	mutex       sync.Mutex
 }
 
 // HasCommit delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockStore) HasCommit(v0 context.Context, v1 int, v2 string) (bool, error) {
+func (m *MockStore) HasCommit(v0 context.Context, v1 api.RepoID, v2 api.CommitID) (bool, error) {
 	r0, r1 := m.HasCommitFunc.nextHook()(v0, v1, v2)
 	m.HasCommitFunc.appendCall(StoreHasCommitFuncCall{v0, v1, v2, r0, r1})
 	return r0, r1
@@ -5147,7 +5148,7 @@ func (m *MockStore) HasCommit(v0 context.Context, v1 int, v2 string) (bool, erro
 
 // SetDefaultHook sets function that is called when the HasCommit method of
 // the parent MockStore instance is invoked and the hook queue is empty.
-func (f *StoreHasCommitFunc) SetDefaultHook(hook func(context.Context, int, string) (bool, error)) {
+func (f *StoreHasCommitFunc) SetDefaultHook(hook func(context.Context, api.RepoID, api.CommitID) (bool, error)) {
 	f.defaultHook = hook
 }
 
@@ -5155,7 +5156,7 @@ func (f *StoreHasCommitFunc) SetDefaultHook(hook func(context.Context, int, stri
 // HasCommit method of the parent MockStore instance invokes the hook at the
 // front of the queue and discards it. After the queue is empty, the default
 // hook function is invoked for any future action.
-func (f *StoreHasCommitFunc) PushHook(hook func(context.Context, int, string) (bool, error)) {
+func (f *StoreHasCommitFunc) PushHook(hook func(context.Context, api.RepoID, api.CommitID) (bool, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -5164,19 +5165,19 @@ func (f *StoreHasCommitFunc) PushHook(hook func(context.Context, int, string) (b
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
 func (f *StoreHasCommitFunc) SetDefaultReturn(r0 bool, r1 error) {
-	f.SetDefaultHook(func(context.Context, int, string) (bool, error) {
+	f.SetDefaultHook(func(context.Context, api.RepoID, api.CommitID) (bool, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
 func (f *StoreHasCommitFunc) PushReturn(r0 bool, r1 error) {
-	f.PushHook(func(context.Context, int, string) (bool, error) {
+	f.PushHook(func(context.Context, api.RepoID, api.CommitID) (bool, error) {
 		return r0, r1
 	})
 }
 
-func (f *StoreHasCommitFunc) nextHook() func(context.Context, int, string) (bool, error) {
+func (f *StoreHasCommitFunc) nextHook() func(context.Context, api.RepoID, api.CommitID) (bool, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -5214,10 +5215,10 @@ type StoreHasCommitFuncCall struct {
 	Arg0 context.Context
 	// Arg1 is the value of the 2nd argument passed to this method
 	// invocation.
-	Arg1 int
+	Arg1 api.RepoID
 	// Arg2 is the value of the 3rd argument passed to this method
 	// invocation.
-	Arg2 string
+	Arg2 api.CommitID
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 bool
@@ -5241,15 +5242,15 @@ func (c StoreHasCommitFuncCall) Results() []interface{} {
 // StoreHasRepositoryFunc describes the behavior when the HasRepository
 // method of the parent MockStore instance is invoked.
 type StoreHasRepositoryFunc struct {
-	defaultHook func(context.Context, int) (bool, error)
-	hooks       []func(context.Context, int) (bool, error)
+	defaultHook func(context.Context, api.RepoID) (bool, error)
+	hooks       []func(context.Context, api.RepoID) (bool, error)
 	history     []StoreHasRepositoryFuncCall
 	mutex       sync.Mutex
 }
 
 // HasRepository delegates to the next hook function in the queue and stores
 // the parameter and result values of this invocation.
-func (m *MockStore) HasRepository(v0 context.Context, v1 int) (bool, error) {
+func (m *MockStore) HasRepository(v0 context.Context, v1 api.RepoID) (bool, error) {
 	r0, r1 := m.HasRepositoryFunc.nextHook()(v0, v1)
 	m.HasRepositoryFunc.appendCall(StoreHasRepositoryFuncCall{v0, v1, r0, r1})
 	return r0, r1
@@ -5257,7 +5258,7 @@ func (m *MockStore) HasRepository(v0 context.Context, v1 int) (bool, error) {
 
 // SetDefaultHook sets function that is called when the HasRepository method
 // of the parent MockStore instance is invoked and the hook queue is empty.
-func (f *StoreHasRepositoryFunc) SetDefaultHook(hook func(context.Context, int) (bool, error)) {
+func (f *StoreHasRepositoryFunc) SetDefaultHook(hook func(context.Context, api.RepoID) (bool, error)) {
 	f.defaultHook = hook
 }
 
@@ -5265,7 +5266,7 @@ func (f *StoreHasRepositoryFunc) SetDefaultHook(hook func(context.Context, int) 
 // HasRepository method of the parent MockStore instance invokes the hook at
 // the front of the queue and discards it. After the queue is empty, the
 // default hook function is invoked for any future action.
-func (f *StoreHasRepositoryFunc) PushHook(hook func(context.Context, int) (bool, error)) {
+func (f *StoreHasRepositoryFunc) PushHook(hook func(context.Context, api.RepoID) (bool, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -5274,19 +5275,19 @@ func (f *StoreHasRepositoryFunc) PushHook(hook func(context.Context, int) (bool,
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
 func (f *StoreHasRepositoryFunc) SetDefaultReturn(r0 bool, r1 error) {
-	f.SetDefaultHook(func(context.Context, int) (bool, error) {
+	f.SetDefaultHook(func(context.Context, api.RepoID) (bool, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
 func (f *StoreHasRepositoryFunc) PushReturn(r0 bool, r1 error) {
-	f.PushHook(func(context.Context, int) (bool, error) {
+	f.PushHook(func(context.Context, api.RepoID) (bool, error) {
 		return r0, r1
 	})
 }
 
-func (f *StoreHasRepositoryFunc) nextHook() func(context.Context, int) (bool, error) {
+func (f *StoreHasRepositoryFunc) nextHook() func(context.Context, api.RepoID) (bool, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -5324,7 +5325,7 @@ type StoreHasRepositoryFuncCall struct {
 	Arg0 context.Context
 	// Arg1 is the value of the 2nd argument passed to this method
 	// invocation.
-	Arg1 int
+	Arg1 api.RepoID
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 bool

--- a/internal/codeintel/uploads/internal/background/expirer/mocks_test.go
+++ b/internal/codeintel/uploads/internal/background/expirer/mocks_test.go
@@ -769,12 +769,12 @@ func NewMockStore() *MockStore {
 			},
 		},
 		HasCommitFunc: &StoreHasCommitFunc{
-			defaultHook: func(context.Context, int, string) (r0 bool, r1 error) {
+			defaultHook: func(context.Context, api.RepoID, api.CommitID) (r0 bool, r1 error) {
 				return
 			},
 		},
 		HasRepositoryFunc: &StoreHasRepositoryFunc{
-			defaultHook: func(context.Context, int) (r0 bool, r1 error) {
+			defaultHook: func(context.Context, api.RepoID) (r0 bool, r1 error) {
 				return
 			},
 		},
@@ -1096,12 +1096,12 @@ func NewStrictMockStore() *MockStore {
 			},
 		},
 		HasCommitFunc: &StoreHasCommitFunc{
-			defaultHook: func(context.Context, int, string) (bool, error) {
+			defaultHook: func(context.Context, api.RepoID, api.CommitID) (bool, error) {
 				panic("unexpected invocation of MockStore.HasCommit")
 			},
 		},
 		HasRepositoryFunc: &StoreHasRepositoryFunc{
-			defaultHook: func(context.Context, int) (bool, error) {
+			defaultHook: func(context.Context, api.RepoID) (bool, error) {
 				panic("unexpected invocation of MockStore.HasRepository")
 			},
 		},
@@ -5475,15 +5475,15 @@ func (c StoreHardDeleteUploadsByIDsFuncCall) Results() []interface{} {
 // StoreHasCommitFunc describes the behavior when the HasCommit method of
 // the parent MockStore instance is invoked.
 type StoreHasCommitFunc struct {
-	defaultHook func(context.Context, int, string) (bool, error)
-	hooks       []func(context.Context, int, string) (bool, error)
+	defaultHook func(context.Context, api.RepoID, api.CommitID) (bool, error)
+	hooks       []func(context.Context, api.RepoID, api.CommitID) (bool, error)
 	history     []StoreHasCommitFuncCall
 	mutex       sync.Mutex
 }
 
 // HasCommit delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockStore) HasCommit(v0 context.Context, v1 int, v2 string) (bool, error) {
+func (m *MockStore) HasCommit(v0 context.Context, v1 api.RepoID, v2 api.CommitID) (bool, error) {
 	r0, r1 := m.HasCommitFunc.nextHook()(v0, v1, v2)
 	m.HasCommitFunc.appendCall(StoreHasCommitFuncCall{v0, v1, v2, r0, r1})
 	return r0, r1
@@ -5491,7 +5491,7 @@ func (m *MockStore) HasCommit(v0 context.Context, v1 int, v2 string) (bool, erro
 
 // SetDefaultHook sets function that is called when the HasCommit method of
 // the parent MockStore instance is invoked and the hook queue is empty.
-func (f *StoreHasCommitFunc) SetDefaultHook(hook func(context.Context, int, string) (bool, error)) {
+func (f *StoreHasCommitFunc) SetDefaultHook(hook func(context.Context, api.RepoID, api.CommitID) (bool, error)) {
 	f.defaultHook = hook
 }
 
@@ -5499,7 +5499,7 @@ func (f *StoreHasCommitFunc) SetDefaultHook(hook func(context.Context, int, stri
 // HasCommit method of the parent MockStore instance invokes the hook at the
 // front of the queue and discards it. After the queue is empty, the default
 // hook function is invoked for any future action.
-func (f *StoreHasCommitFunc) PushHook(hook func(context.Context, int, string) (bool, error)) {
+func (f *StoreHasCommitFunc) PushHook(hook func(context.Context, api.RepoID, api.CommitID) (bool, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -5508,19 +5508,19 @@ func (f *StoreHasCommitFunc) PushHook(hook func(context.Context, int, string) (b
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
 func (f *StoreHasCommitFunc) SetDefaultReturn(r0 bool, r1 error) {
-	f.SetDefaultHook(func(context.Context, int, string) (bool, error) {
+	f.SetDefaultHook(func(context.Context, api.RepoID, api.CommitID) (bool, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
 func (f *StoreHasCommitFunc) PushReturn(r0 bool, r1 error) {
-	f.PushHook(func(context.Context, int, string) (bool, error) {
+	f.PushHook(func(context.Context, api.RepoID, api.CommitID) (bool, error) {
 		return r0, r1
 	})
 }
 
-func (f *StoreHasCommitFunc) nextHook() func(context.Context, int, string) (bool, error) {
+func (f *StoreHasCommitFunc) nextHook() func(context.Context, api.RepoID, api.CommitID) (bool, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -5558,10 +5558,10 @@ type StoreHasCommitFuncCall struct {
 	Arg0 context.Context
 	// Arg1 is the value of the 2nd argument passed to this method
 	// invocation.
-	Arg1 int
+	Arg1 api.RepoID
 	// Arg2 is the value of the 3rd argument passed to this method
 	// invocation.
-	Arg2 string
+	Arg2 api.CommitID
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 bool
@@ -5585,15 +5585,15 @@ func (c StoreHasCommitFuncCall) Results() []interface{} {
 // StoreHasRepositoryFunc describes the behavior when the HasRepository
 // method of the parent MockStore instance is invoked.
 type StoreHasRepositoryFunc struct {
-	defaultHook func(context.Context, int) (bool, error)
-	hooks       []func(context.Context, int) (bool, error)
+	defaultHook func(context.Context, api.RepoID) (bool, error)
+	hooks       []func(context.Context, api.RepoID) (bool, error)
 	history     []StoreHasRepositoryFuncCall
 	mutex       sync.Mutex
 }
 
 // HasRepository delegates to the next hook function in the queue and stores
 // the parameter and result values of this invocation.
-func (m *MockStore) HasRepository(v0 context.Context, v1 int) (bool, error) {
+func (m *MockStore) HasRepository(v0 context.Context, v1 api.RepoID) (bool, error) {
 	r0, r1 := m.HasRepositoryFunc.nextHook()(v0, v1)
 	m.HasRepositoryFunc.appendCall(StoreHasRepositoryFuncCall{v0, v1, r0, r1})
 	return r0, r1
@@ -5601,7 +5601,7 @@ func (m *MockStore) HasRepository(v0 context.Context, v1 int) (bool, error) {
 
 // SetDefaultHook sets function that is called when the HasRepository method
 // of the parent MockStore instance is invoked and the hook queue is empty.
-func (f *StoreHasRepositoryFunc) SetDefaultHook(hook func(context.Context, int) (bool, error)) {
+func (f *StoreHasRepositoryFunc) SetDefaultHook(hook func(context.Context, api.RepoID) (bool, error)) {
 	f.defaultHook = hook
 }
 
@@ -5609,7 +5609,7 @@ func (f *StoreHasRepositoryFunc) SetDefaultHook(hook func(context.Context, int) 
 // HasRepository method of the parent MockStore instance invokes the hook at
 // the front of the queue and discards it. After the queue is empty, the
 // default hook function is invoked for any future action.
-func (f *StoreHasRepositoryFunc) PushHook(hook func(context.Context, int) (bool, error)) {
+func (f *StoreHasRepositoryFunc) PushHook(hook func(context.Context, api.RepoID) (bool, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -5618,19 +5618,19 @@ func (f *StoreHasRepositoryFunc) PushHook(hook func(context.Context, int) (bool,
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
 func (f *StoreHasRepositoryFunc) SetDefaultReturn(r0 bool, r1 error) {
-	f.SetDefaultHook(func(context.Context, int) (bool, error) {
+	f.SetDefaultHook(func(context.Context, api.RepoID) (bool, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
 func (f *StoreHasRepositoryFunc) PushReturn(r0 bool, r1 error) {
-	f.PushHook(func(context.Context, int) (bool, error) {
+	f.PushHook(func(context.Context, api.RepoID) (bool, error) {
 		return r0, r1
 	})
 }
 
-func (f *StoreHasRepositoryFunc) nextHook() func(context.Context, int) (bool, error) {
+func (f *StoreHasRepositoryFunc) nextHook() func(context.Context, api.RepoID) (bool, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -5668,7 +5668,7 @@ type StoreHasRepositoryFuncCall struct {
 	Arg0 context.Context
 	// Arg1 is the value of the 2nd argument passed to this method
 	// invocation.
-	Arg1 int
+	Arg1 api.RepoID
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 bool

--- a/internal/codeintel/uploads/internal/background/processor/mocks_test.go
+++ b/internal/codeintel/uploads/internal/background/processor/mocks_test.go
@@ -583,12 +583,12 @@ func NewMockStore() *MockStore {
 			},
 		},
 		HasCommitFunc: &StoreHasCommitFunc{
-			defaultHook: func(context.Context, int, string) (r0 bool, r1 error) {
+			defaultHook: func(context.Context, api.RepoID, api.CommitID) (r0 bool, r1 error) {
 				return
 			},
 		},
 		HasRepositoryFunc: &StoreHasRepositoryFunc{
-			defaultHook: func(context.Context, int) (r0 bool, r1 error) {
+			defaultHook: func(context.Context, api.RepoID) (r0 bool, r1 error) {
 				return
 			},
 		},
@@ -910,12 +910,12 @@ func NewStrictMockStore() *MockStore {
 			},
 		},
 		HasCommitFunc: &StoreHasCommitFunc{
-			defaultHook: func(context.Context, int, string) (bool, error) {
+			defaultHook: func(context.Context, api.RepoID, api.CommitID) (bool, error) {
 				panic("unexpected invocation of MockStore.HasCommit")
 			},
 		},
 		HasRepositoryFunc: &StoreHasRepositoryFunc{
-			defaultHook: func(context.Context, int) (bool, error) {
+			defaultHook: func(context.Context, api.RepoID) (bool, error) {
 				panic("unexpected invocation of MockStore.HasRepository")
 			},
 		},
@@ -5289,15 +5289,15 @@ func (c StoreHardDeleteUploadsByIDsFuncCall) Results() []interface{} {
 // StoreHasCommitFunc describes the behavior when the HasCommit method of
 // the parent MockStore instance is invoked.
 type StoreHasCommitFunc struct {
-	defaultHook func(context.Context, int, string) (bool, error)
-	hooks       []func(context.Context, int, string) (bool, error)
+	defaultHook func(context.Context, api.RepoID, api.CommitID) (bool, error)
+	hooks       []func(context.Context, api.RepoID, api.CommitID) (bool, error)
 	history     []StoreHasCommitFuncCall
 	mutex       sync.Mutex
 }
 
 // HasCommit delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockStore) HasCommit(v0 context.Context, v1 int, v2 string) (bool, error) {
+func (m *MockStore) HasCommit(v0 context.Context, v1 api.RepoID, v2 api.CommitID) (bool, error) {
 	r0, r1 := m.HasCommitFunc.nextHook()(v0, v1, v2)
 	m.HasCommitFunc.appendCall(StoreHasCommitFuncCall{v0, v1, v2, r0, r1})
 	return r0, r1
@@ -5305,7 +5305,7 @@ func (m *MockStore) HasCommit(v0 context.Context, v1 int, v2 string) (bool, erro
 
 // SetDefaultHook sets function that is called when the HasCommit method of
 // the parent MockStore instance is invoked and the hook queue is empty.
-func (f *StoreHasCommitFunc) SetDefaultHook(hook func(context.Context, int, string) (bool, error)) {
+func (f *StoreHasCommitFunc) SetDefaultHook(hook func(context.Context, api.RepoID, api.CommitID) (bool, error)) {
 	f.defaultHook = hook
 }
 
@@ -5313,7 +5313,7 @@ func (f *StoreHasCommitFunc) SetDefaultHook(hook func(context.Context, int, stri
 // HasCommit method of the parent MockStore instance invokes the hook at the
 // front of the queue and discards it. After the queue is empty, the default
 // hook function is invoked for any future action.
-func (f *StoreHasCommitFunc) PushHook(hook func(context.Context, int, string) (bool, error)) {
+func (f *StoreHasCommitFunc) PushHook(hook func(context.Context, api.RepoID, api.CommitID) (bool, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -5322,19 +5322,19 @@ func (f *StoreHasCommitFunc) PushHook(hook func(context.Context, int, string) (b
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
 func (f *StoreHasCommitFunc) SetDefaultReturn(r0 bool, r1 error) {
-	f.SetDefaultHook(func(context.Context, int, string) (bool, error) {
+	f.SetDefaultHook(func(context.Context, api.RepoID, api.CommitID) (bool, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
 func (f *StoreHasCommitFunc) PushReturn(r0 bool, r1 error) {
-	f.PushHook(func(context.Context, int, string) (bool, error) {
+	f.PushHook(func(context.Context, api.RepoID, api.CommitID) (bool, error) {
 		return r0, r1
 	})
 }
 
-func (f *StoreHasCommitFunc) nextHook() func(context.Context, int, string) (bool, error) {
+func (f *StoreHasCommitFunc) nextHook() func(context.Context, api.RepoID, api.CommitID) (bool, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -5372,10 +5372,10 @@ type StoreHasCommitFuncCall struct {
 	Arg0 context.Context
 	// Arg1 is the value of the 2nd argument passed to this method
 	// invocation.
-	Arg1 int
+	Arg1 api.RepoID
 	// Arg2 is the value of the 3rd argument passed to this method
 	// invocation.
-	Arg2 string
+	Arg2 api.CommitID
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 bool
@@ -5399,15 +5399,15 @@ func (c StoreHasCommitFuncCall) Results() []interface{} {
 // StoreHasRepositoryFunc describes the behavior when the HasRepository
 // method of the parent MockStore instance is invoked.
 type StoreHasRepositoryFunc struct {
-	defaultHook func(context.Context, int) (bool, error)
-	hooks       []func(context.Context, int) (bool, error)
+	defaultHook func(context.Context, api.RepoID) (bool, error)
+	hooks       []func(context.Context, api.RepoID) (bool, error)
 	history     []StoreHasRepositoryFuncCall
 	mutex       sync.Mutex
 }
 
 // HasRepository delegates to the next hook function in the queue and stores
 // the parameter and result values of this invocation.
-func (m *MockStore) HasRepository(v0 context.Context, v1 int) (bool, error) {
+func (m *MockStore) HasRepository(v0 context.Context, v1 api.RepoID) (bool, error) {
 	r0, r1 := m.HasRepositoryFunc.nextHook()(v0, v1)
 	m.HasRepositoryFunc.appendCall(StoreHasRepositoryFuncCall{v0, v1, r0, r1})
 	return r0, r1
@@ -5415,7 +5415,7 @@ func (m *MockStore) HasRepository(v0 context.Context, v1 int) (bool, error) {
 
 // SetDefaultHook sets function that is called when the HasRepository method
 // of the parent MockStore instance is invoked and the hook queue is empty.
-func (f *StoreHasRepositoryFunc) SetDefaultHook(hook func(context.Context, int) (bool, error)) {
+func (f *StoreHasRepositoryFunc) SetDefaultHook(hook func(context.Context, api.RepoID) (bool, error)) {
 	f.defaultHook = hook
 }
 
@@ -5423,7 +5423,7 @@ func (f *StoreHasRepositoryFunc) SetDefaultHook(hook func(context.Context, int) 
 // HasRepository method of the parent MockStore instance invokes the hook at
 // the front of the queue and discards it. After the queue is empty, the
 // default hook function is invoked for any future action.
-func (f *StoreHasRepositoryFunc) PushHook(hook func(context.Context, int) (bool, error)) {
+func (f *StoreHasRepositoryFunc) PushHook(hook func(context.Context, api.RepoID) (bool, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -5432,19 +5432,19 @@ func (f *StoreHasRepositoryFunc) PushHook(hook func(context.Context, int) (bool,
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
 func (f *StoreHasRepositoryFunc) SetDefaultReturn(r0 bool, r1 error) {
-	f.SetDefaultHook(func(context.Context, int) (bool, error) {
+	f.SetDefaultHook(func(context.Context, api.RepoID) (bool, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
 func (f *StoreHasRepositoryFunc) PushReturn(r0 bool, r1 error) {
-	f.PushHook(func(context.Context, int) (bool, error) {
+	f.PushHook(func(context.Context, api.RepoID) (bool, error) {
 		return r0, r1
 	})
 }
 
-func (f *StoreHasRepositoryFunc) nextHook() func(context.Context, int) (bool, error) {
+func (f *StoreHasRepositoryFunc) nextHook() func(context.Context, api.RepoID) (bool, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -5482,7 +5482,7 @@ type StoreHasRepositoryFuncCall struct {
 	Arg0 context.Context
 	// Arg1 is the value of the 2nd argument passed to this method
 	// invocation.
-	Arg1 int
+	Arg1 api.RepoID
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 bool

--- a/internal/codeintel/uploads/internal/store/commitgraph.go
+++ b/internal/codeintel/uploads/internal/store/commitgraph.go
@@ -300,7 +300,7 @@ func (s *store) FindClosestCompletedUploads(ctx context.Context, opts shared.Upl
 
 	conds := makeFindClosestProcessUploadsConditions(opts)
 	// TODO(id: completed-state-check) Make sure we only return uploads with state = 'completed' here
-	query := sqlf.Sprintf(findClosestCompletedUploadsQuery, makeVisibleUploadsQuery(opts.RepositoryID, opts.Commit), sqlf.Join(conds, " AND "))
+	query := sqlf.Sprintf(findClosestCompletedUploadsQuery, makeVisibleUploadsQuery(int(opts.RepositoryID), string(opts.Commit)), sqlf.Join(conds, " AND "))
 
 	uploads, err := scanCompletedUploads(s.db.Query(ctx, query))
 	if err != nil {

--- a/internal/codeintel/uploads/internal/store/commitgraph_test.go
+++ b/internal/codeintel/uploads/internal/store/commitgraph_test.go
@@ -1295,7 +1295,7 @@ func (t *FindClosestCompletedUploadsTestCase) uploadMatchingOptions() shared.Upl
 	if !t.rootMustEnclosePath {
 		matching = shared.RootEnclosesPathOrPathEnclosesRoot
 	}
-	return shared.UploadMatchingOptions{50, t.commit, core.NewRepoRelPathUnchecked(t.file), matching, t.indexer}
+	return shared.UploadMatchingOptions{50, api.CommitID(t.commit), core.NewRepoRelPathUnchecked(t.file), matching, t.indexer}
 }
 
 func testFindClosestCompletedUploads(t *testing.T, store Store, testCases []FindClosestCompletedUploadsTestCase) {

--- a/internal/codeintel/uploads/internal/store/misc.go
+++ b/internal/codeintel/uploads/internal/store/misc.go
@@ -6,19 +6,20 @@ import (
 	"github.com/keegancsmith/sqlf"
 	"go.opentelemetry.io/otel/attribute"
 
+	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 )
 
 // HasRepository determines if there is LSIF data for the given repository.
-func (s *store) HasRepository(ctx context.Context, repositoryID int) (_ bool, err error) {
+func (s *store) HasRepository(ctx context.Context, repositoryID api.RepoID) (_ bool, err error) {
 	ctx, _, endObservation := s.operations.hasRepository.With(ctx, &err, observation.Args{Attrs: []attribute.KeyValue{
-		attribute.Int("repositoryID", repositoryID),
+		attribute.Int("repositoryID", int(repositoryID)),
 	}})
 	defer endObservation(1, observation.Args{})
 
-	_, found, err := basestore.ScanFirstInt(s.db.Query(ctx, sqlf.Sprintf(hasRepositoryQuery, repositoryID)))
+	_, found, err := basestore.ScanFirstInt(s.db.Query(ctx, sqlf.Sprintf(hasRepositoryQuery, int(repositoryID))))
 	return found, err
 }
 
@@ -27,10 +28,10 @@ SELECT 1 FROM lsif_uploads WHERE state NOT IN ('deleted', 'deleting') AND reposi
 `
 
 // HasCommit determines if the given commit is known for the given repository.
-func (s *store) HasCommit(ctx context.Context, repositoryID int, commit string) (_ bool, err error) {
+func (s *store) HasCommit(ctx context.Context, repositoryID api.RepoID, commit api.CommitID) (_ bool, err error) {
 	ctx, _, endObservation := s.operations.hasCommit.With(ctx, &err, observation.Args{Attrs: []attribute.KeyValue{
-		attribute.Int("repositoryID", repositoryID),
-		attribute.String("commit", commit),
+		attribute.Int("repositoryID", int(repositoryID)),
+		attribute.String("commit", string(commit)),
 	}})
 	defer endObservation(1, observation.Args{})
 

--- a/internal/codeintel/uploads/internal/store/misc_test.go
+++ b/internal/codeintel/uploads/internal/store/misc_test.go
@@ -36,7 +36,7 @@ func TestHasRepository(t *testing.T) {
 		name := fmt.Sprintf("repositoryID=%d", testCase.repositoryID)
 
 		t.Run(name, func(t *testing.T) {
-			exists, err := store.HasRepository(context.Background(), testCase.repositoryID)
+			exists, err := store.HasRepository(context.Background(), api.RepoID(testCase.repositoryID))
 			if err != nil {
 				t.Fatalf("unexpected error checking if repository exists: %s", err)
 			}
@@ -70,7 +70,7 @@ func TestHasCommit(t *testing.T) {
 		name := fmt.Sprintf("repositoryID=%d commit=%s", testCase.repositoryID, testCase.commit)
 
 		t.Run(name, func(t *testing.T) {
-			exists, err := store.HasCommit(context.Background(), testCase.repositoryID, testCase.commit)
+			exists, err := store.HasCommit(context.Background(), api.RepoID(testCase.repositoryID), api.CommitID(testCase.commit))
 			if err != nil {
 				t.Fatalf("unexpected error checking if commit exists: %s", err)
 			}

--- a/internal/codeintel/uploads/internal/store/store.go
+++ b/internal/codeintel/uploads/internal/store/store.go
@@ -6,6 +6,7 @@ import (
 
 	logger "github.com/sourcegraph/log"
 
+	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/uploads/internal/commitgraph"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/uploads/shared"
 	"github.com/sourcegraph/sourcegraph/internal/database"
@@ -102,8 +103,8 @@ type Store interface {
 	ProcessSourcedCommits(ctx context.Context, minimumTimeSinceLastCheck time.Duration, commitResolverMaximumCommitLag time.Duration, limit int, f func(ctx context.Context, repositoryID int, repositoryName, commit string) (bool, error), now time.Time) (int, int, error)
 
 	// Misc
-	HasRepository(ctx context.Context, repositoryID int) (bool, error)
-	HasCommit(ctx context.Context, repositoryID int, commit string) (bool, error)
+	HasRepository(ctx context.Context, repositoryID api.RepoID) (bool, error)
+	HasCommit(ctx context.Context, repositoryID api.RepoID, commit api.CommitID) (bool, error)
 	InsertDependencySyncingJob(ctx context.Context, uploadID int) (int, error)
 }
 

--- a/internal/codeintel/uploads/mocks_test.go
+++ b/internal/codeintel/uploads/mocks_test.go
@@ -432,12 +432,12 @@ func NewMockStore() *MockStore {
 			},
 		},
 		HasCommitFunc: &StoreHasCommitFunc{
-			defaultHook: func(context.Context, int, string) (r0 bool, r1 error) {
+			defaultHook: func(context.Context, api.RepoID, api.CommitID) (r0 bool, r1 error) {
 				return
 			},
 		},
 		HasRepositoryFunc: &StoreHasRepositoryFunc{
-			defaultHook: func(context.Context, int) (r0 bool, r1 error) {
+			defaultHook: func(context.Context, api.RepoID) (r0 bool, r1 error) {
 				return
 			},
 		},
@@ -759,12 +759,12 @@ func NewStrictMockStore() *MockStore {
 			},
 		},
 		HasCommitFunc: &StoreHasCommitFunc{
-			defaultHook: func(context.Context, int, string) (bool, error) {
+			defaultHook: func(context.Context, api.RepoID, api.CommitID) (bool, error) {
 				panic("unexpected invocation of MockStore.HasCommit")
 			},
 		},
 		HasRepositoryFunc: &StoreHasRepositoryFunc{
-			defaultHook: func(context.Context, int) (bool, error) {
+			defaultHook: func(context.Context, api.RepoID) (bool, error) {
 				panic("unexpected invocation of MockStore.HasRepository")
 			},
 		},
@@ -5138,15 +5138,15 @@ func (c StoreHardDeleteUploadsByIDsFuncCall) Results() []interface{} {
 // StoreHasCommitFunc describes the behavior when the HasCommit method of
 // the parent MockStore instance is invoked.
 type StoreHasCommitFunc struct {
-	defaultHook func(context.Context, int, string) (bool, error)
-	hooks       []func(context.Context, int, string) (bool, error)
+	defaultHook func(context.Context, api.RepoID, api.CommitID) (bool, error)
+	hooks       []func(context.Context, api.RepoID, api.CommitID) (bool, error)
 	history     []StoreHasCommitFuncCall
 	mutex       sync.Mutex
 }
 
 // HasCommit delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockStore) HasCommit(v0 context.Context, v1 int, v2 string) (bool, error) {
+func (m *MockStore) HasCommit(v0 context.Context, v1 api.RepoID, v2 api.CommitID) (bool, error) {
 	r0, r1 := m.HasCommitFunc.nextHook()(v0, v1, v2)
 	m.HasCommitFunc.appendCall(StoreHasCommitFuncCall{v0, v1, v2, r0, r1})
 	return r0, r1
@@ -5154,7 +5154,7 @@ func (m *MockStore) HasCommit(v0 context.Context, v1 int, v2 string) (bool, erro
 
 // SetDefaultHook sets function that is called when the HasCommit method of
 // the parent MockStore instance is invoked and the hook queue is empty.
-func (f *StoreHasCommitFunc) SetDefaultHook(hook func(context.Context, int, string) (bool, error)) {
+func (f *StoreHasCommitFunc) SetDefaultHook(hook func(context.Context, api.RepoID, api.CommitID) (bool, error)) {
 	f.defaultHook = hook
 }
 
@@ -5162,7 +5162,7 @@ func (f *StoreHasCommitFunc) SetDefaultHook(hook func(context.Context, int, stri
 // HasCommit method of the parent MockStore instance invokes the hook at the
 // front of the queue and discards it. After the queue is empty, the default
 // hook function is invoked for any future action.
-func (f *StoreHasCommitFunc) PushHook(hook func(context.Context, int, string) (bool, error)) {
+func (f *StoreHasCommitFunc) PushHook(hook func(context.Context, api.RepoID, api.CommitID) (bool, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -5171,19 +5171,19 @@ func (f *StoreHasCommitFunc) PushHook(hook func(context.Context, int, string) (b
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
 func (f *StoreHasCommitFunc) SetDefaultReturn(r0 bool, r1 error) {
-	f.SetDefaultHook(func(context.Context, int, string) (bool, error) {
+	f.SetDefaultHook(func(context.Context, api.RepoID, api.CommitID) (bool, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
 func (f *StoreHasCommitFunc) PushReturn(r0 bool, r1 error) {
-	f.PushHook(func(context.Context, int, string) (bool, error) {
+	f.PushHook(func(context.Context, api.RepoID, api.CommitID) (bool, error) {
 		return r0, r1
 	})
 }
 
-func (f *StoreHasCommitFunc) nextHook() func(context.Context, int, string) (bool, error) {
+func (f *StoreHasCommitFunc) nextHook() func(context.Context, api.RepoID, api.CommitID) (bool, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -5221,10 +5221,10 @@ type StoreHasCommitFuncCall struct {
 	Arg0 context.Context
 	// Arg1 is the value of the 2nd argument passed to this method
 	// invocation.
-	Arg1 int
+	Arg1 api.RepoID
 	// Arg2 is the value of the 3rd argument passed to this method
 	// invocation.
-	Arg2 string
+	Arg2 api.CommitID
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 bool
@@ -5248,15 +5248,15 @@ func (c StoreHasCommitFuncCall) Results() []interface{} {
 // StoreHasRepositoryFunc describes the behavior when the HasRepository
 // method of the parent MockStore instance is invoked.
 type StoreHasRepositoryFunc struct {
-	defaultHook func(context.Context, int) (bool, error)
-	hooks       []func(context.Context, int) (bool, error)
+	defaultHook func(context.Context, api.RepoID) (bool, error)
+	hooks       []func(context.Context, api.RepoID) (bool, error)
 	history     []StoreHasRepositoryFuncCall
 	mutex       sync.Mutex
 }
 
 // HasRepository delegates to the next hook function in the queue and stores
 // the parameter and result values of this invocation.
-func (m *MockStore) HasRepository(v0 context.Context, v1 int) (bool, error) {
+func (m *MockStore) HasRepository(v0 context.Context, v1 api.RepoID) (bool, error) {
 	r0, r1 := m.HasRepositoryFunc.nextHook()(v0, v1)
 	m.HasRepositoryFunc.appendCall(StoreHasRepositoryFuncCall{v0, v1, r0, r1})
 	return r0, r1
@@ -5264,7 +5264,7 @@ func (m *MockStore) HasRepository(v0 context.Context, v1 int) (bool, error) {
 
 // SetDefaultHook sets function that is called when the HasRepository method
 // of the parent MockStore instance is invoked and the hook queue is empty.
-func (f *StoreHasRepositoryFunc) SetDefaultHook(hook func(context.Context, int) (bool, error)) {
+func (f *StoreHasRepositoryFunc) SetDefaultHook(hook func(context.Context, api.RepoID) (bool, error)) {
 	f.defaultHook = hook
 }
 
@@ -5272,7 +5272,7 @@ func (f *StoreHasRepositoryFunc) SetDefaultHook(hook func(context.Context, int) 
 // HasRepository method of the parent MockStore instance invokes the hook at
 // the front of the queue and discards it. After the queue is empty, the
 // default hook function is invoked for any future action.
-func (f *StoreHasRepositoryFunc) PushHook(hook func(context.Context, int) (bool, error)) {
+func (f *StoreHasRepositoryFunc) PushHook(hook func(context.Context, api.RepoID) (bool, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -5281,19 +5281,19 @@ func (f *StoreHasRepositoryFunc) PushHook(hook func(context.Context, int) (bool,
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
 func (f *StoreHasRepositoryFunc) SetDefaultReturn(r0 bool, r1 error) {
-	f.SetDefaultHook(func(context.Context, int) (bool, error) {
+	f.SetDefaultHook(func(context.Context, api.RepoID) (bool, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
 func (f *StoreHasRepositoryFunc) PushReturn(r0 bool, r1 error) {
-	f.PushHook(func(context.Context, int) (bool, error) {
+	f.PushHook(func(context.Context, api.RepoID) (bool, error) {
 		return r0, r1
 	})
 }
 
-func (f *StoreHasRepositoryFunc) nextHook() func(context.Context, int) (bool, error) {
+func (f *StoreHasRepositoryFunc) nextHook() func(context.Context, api.RepoID) (bool, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -5331,7 +5331,7 @@ type StoreHasRepositoryFuncCall struct {
 	Arg0 context.Context
 	// Arg1 is the value of the 2nd argument passed to this method
 	// invocation.
-	Arg1 int
+	Arg1 api.RepoID
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 bool

--- a/internal/codeintel/uploads/service.go
+++ b/internal/codeintel/uploads/service.go
@@ -142,7 +142,7 @@ func (s *Service) InferClosestUploads(ctx context.Context, opts shared.UploadMat
 	// graph as dirty so it's updated for subsequent requests.
 
 	commits, err := s.gitserverClient.Commits(ctx, repo.Name, gitserver.CommitsOptions{
-		Ranges: []string{opts.Commit},
+		Ranges: []string{string(opts.Commit)},
 		N:      numAncestors,
 		Order:  gitserver.CommitsOrderTopoDate,
 	})
@@ -157,7 +157,7 @@ func (s *Service) InferClosestUploads(ctx context.Context, opts shared.UploadMat
 		return nil, errors.Wrap(err, "dbstore.FindClosestCompletedUploadsFromGraphFragment")
 	}
 
-	if err := s.store.SetRepositoryAsDirty(ctx, opts.RepositoryID); err != nil {
+	if err := s.store.SetRepositoryAsDirty(ctx, int(opts.RepositoryID)); err != nil {
 		return nil, errors.Wrap(err, "dbstore.MarkRepositoryAsDirty")
 	}
 

--- a/internal/codeintel/uploads/shared/BUILD.bazel
+++ b/internal/codeintel/uploads/shared/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
     tags = [TAG_PLATFORM_GRAPH],
     visibility = ["//:__subpackages__"],
     deps = [
+        "//internal/api",
         "//internal/codeintel/core",
         "//internal/executor",
         "//lib/codeintel/autoindex/config",

--- a/internal/codeintel/uploads/shared/types.go
+++ b/internal/codeintel/uploads/shared/types.go
@@ -8,6 +8,7 @@ import (
 
 	"go.opentelemetry.io/otel/attribute"
 
+	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/core"
 	"github.com/sourcegraph/sourcegraph/internal/executor"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
@@ -85,7 +86,7 @@ func (u Upload) SizeStats() UploadSizeStats {
 // The State must be 'completed', see TODO(id: completed-state-check).
 type CompletedUpload struct {
 	ID                int        `json:"id"`
-	Commit            string     `json:"commit"`
+	Commit            string     `json:"commit"` // TODO: This type ought to be api.CommitID
 	Root              string     `json:"root"`
 	VisibleAtTip      bool       `json:"visibleAtTip"`
 	UploadedAt        time.Time  `json:"uploadedAt"`
@@ -96,7 +97,7 @@ type CompletedUpload struct {
 	ProcessAfter      *time.Time `json:"processAfter"`
 	NumResets         int        `json:"numResets"`
 	NumFailures       int        `json:"numFailures"`
-	RepositoryID      int        `json:"repositoryId"`
+	RepositoryID      int        `json:"repositoryId"` // TODO: This type ought to be api.RepoID, but that is 32-bit
 	RepositoryName    string     `json:"repositoryName"`
 	Indexer           string     `json:"indexer"`
 	IndexerVersion    string     `json:"indexerVersion"`
@@ -354,8 +355,8 @@ type UploadsWithRepositoryNamespace struct {
 }
 
 type UploadMatchingOptions struct {
-	RepositoryID int
-	Commit       string
+	RepositoryID api.RepoID
+	Commit       api.CommitID
 	Path         core.RepoRelPath
 	// RootToPathMatching describes how the root for which a SCIP index was uploaded
 	// should be matched to the provided Path for a file or directory
@@ -375,8 +376,8 @@ type UploadMatchingOptions struct {
 
 func (u *UploadMatchingOptions) Attrs() []attribute.KeyValue {
 	return []attribute.KeyValue{
-		attribute.Int("repositoryID", u.RepositoryID),
-		attribute.String("commit", u.Commit),
+		attribute.Int("repositoryID", int(u.RepositoryID)),
+		attribute.String("commit", string(u.Commit)),
 		attribute.String("path", u.Path.RawValue()),
 		attribute.String("rootToPathMatching", string(u.RootToPathMatching)),
 		attribute.String("indexer", u.Indexer),


### PR DESCRIPTION
This reduces the chances for confusion with other ints/strings flying around.

## Test plan

Covered by existing tests.

## Changelog