### PR TITLE
fix(ci): panic using correct err

### DIFF
--- a/dev/ci/internal/ci/config.go
+++ b/dev/ci/internal/ci/config.go
@@ -99,7 +99,7 @@ func NewConfig(now time.Time) Config {
 	} else {
 		out, giterr := exec.Command("git", "rev-parse", "HEAD").Output()
 		if giterr != nil {
-			panic(err)
+			panic(giterr)
 		}
 
 		commit = strings.TrimSpace(string(out))


### PR DESCRIPTION
It was panicing using the wrong error value

## Test plan
CI
## Changelog
* ci - use correct err value to panic on