### PR TITLE
Trivial additions

### DIFF
--- a/internal/modelconfig/types/site_config.go
+++ b/internal/modelconfig/types/site_config.go
@@ -55,7 +55,8 @@ type DefaultModelConfig struct {
 // ProviderOverride is how a Sourcegraph admin would describe a `Provider` within
 // the site-configuration.
 type ProviderOverride struct {
-	ID ProviderID `json:"id"`
+	ID          ProviderID `json:"id"`
+	DisplayName string     `json:"displayName"`
 
 	ClientSideConfig *ClientSideProviderConfig `json:"clientSideConfig,omitempty"`
 	ServerSideConfig *ServerSideProviderConfig `json:"serverSideConfig,omitempty"`


### PR DESCRIPTION
Couple of trivial changes I teased out of some stacked PRs.

- There were a couple of codepaths where we returned a non-200 in the Completions API but didn't have any logging statements.
- Adds the `ProviderOverride::DisplayName` field. This will allow Sourcegraph admins who provide custom providers the ability to give them friendly names. (So that this information is available so it can be more useful than the raw ID.)

Re: `ProviderOverride.DisplayName`, I don't expect this to be a required field. Or even used very often. But when debugging things, it seemed more helpful than just the opaque provider string like `anthropic-via-sourcegraph` or `anthropic-via-aws-bedrock`.

## Test plan

NA

## Changelog

NA