### PR TITLE
feat(cody): Expose Sg modelconfig data via HTTP REST API

### DIFF
--- a/cmd/frontend/internal/httpapi/BUILD.bazel
+++ b/cmd/frontend/internal/httpapi/BUILD.bazel
@@ -30,6 +30,7 @@ go_library(
         "//cmd/frontend/internal/handlerutil",
         "//cmd/frontend/internal/httpapi/releasecache",
         "//cmd/frontend/internal/httpapi/webhookhandlers",
+        "//cmd/frontend/internal/modelconfig",
         "//cmd/frontend/internal/routevar",
         "//cmd/frontend/internal/search",
         "//cmd/frontend/internal/ssc",

--- a/cmd/frontend/internal/httpapi/httpapi.go
+++ b/cmd/frontend/internal/httpapi/httpapi.go
@@ -25,6 +25,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/handlerutil"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/httpapi/releasecache"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/httpapi/webhookhandlers"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/modelconfig"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/routevar"
 	frontendsearch "github.com/sourcegraph/sourcegraph/cmd/frontend/internal/search"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/ssc"
@@ -172,6 +173,10 @@ func NewHandler(
 
 	m.Path("/completions/stream").Methods("POST").Handler(handlers.NewChatCompletionsStreamHandler())
 	m.Path("/completions/code").Methods("POST").Handler(handlers.NewCodeCompletionsHandler())
+
+	// HTTP endpoints related to LLM model configuration.
+	modelConfigHandlers := modelconfig.NewHandlers(db, logger)
+	m.Path("/modelconfig/supported-models.json").Methods("GET").HandlerFunc(modelConfigHandlers.GetSupportedModelsHandler)
 
 	if dotcom.SourcegraphDotComMode() {
 		m.Path("/license/check").Methods("POST").Name("dotcom.license.check").Handler(handlers.NewDotcomLicenseCheckHandler())

--- a/cmd/frontend/internal/modelconfig/BUILD.bazel
+++ b/cmd/frontend/internal/modelconfig/BUILD.bazel
@@ -4,22 +4,37 @@ load("//dev:go_defs.bzl", "go_test")
 go_library(
     name = "modelconfig",
     srcs = [
+        "builder.go",
+        "httpapi.go",
+        "init.go",
+        "service.go",
         "siteconfig_completions.go",
         "util.go",
     ],
     importpath = "github.com/sourcegraph/sourcegraph/cmd/frontend/internal/modelconfig",
     visibility = ["//cmd/frontend:__subpackages__"],
     deps = [
+        "//cmd/frontend/enterprise",
+        "//cmd/frontend/internal/auth",
+        "//cmd/frontend/internal/registry",
+        "//internal/actor",
+        "//internal/codeintel",
+        "//internal/conf",
         "//internal/conf/conftypes",
+        "//internal/database",
         "//internal/modelconfig",
+        "//internal/modelconfig/embedded",
         "//internal/modelconfig/types",
+        "//internal/observation",
         "//lib/errors",
+        "@com_github_sourcegraph_log//:log",
     ],
 )
 
 go_test(
     name = "modelconfig_test",
     srcs = [
+        "builder_test.go",
         "siteconfig_completions_test.go",
         "util_test.go",
     ],
@@ -28,6 +43,7 @@ go_test(
         "//internal/conf",
         "//internal/conf/conftypes",
         "//internal/licensing",
+        "//internal/modelconfig",
         "//internal/modelconfig/embedded",
         "//internal/modelconfig/types",
         "//lib/pointers",

--- a/cmd/frontend/internal/modelconfig/builder.go
+++ b/cmd/frontend/internal/modelconfig/builder.go
@@ -1,0 +1,289 @@
+package modelconfig
+
+import (
+	"fmt"
+	"slices"
+
+	"github.com/sourcegraph/sourcegraph/internal/modelconfig"
+	"github.com/sourcegraph/sourcegraph/internal/modelconfig/types"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+// builder implements the logic for constructing the Sourcegraph instance's
+// LLM model configuration data, based on various configuration settings and available
+// data.
+type builder struct {
+	// staticData is what is embedded into this binary, known at build-time.
+	staticData *types.ModelConfiguration
+
+	// codyGatewayData is what we have recently obtained by checking Cody Gateway
+	// for any recent updates.
+	//
+	// TODO(PRIME-290): Implement this capability. Currently NYI.
+	codyGatewayData *types.ModelConfiguration
+
+	// siteConfigData is the data that is defined in the site configuration.
+	// This is in a slightly different format to be more expressive than what
+	// is provided by Cody Gateway or embedded in the binary.
+	siteConfigData *types.SiteModelConfiguration
+}
+
+// build merges all of the model configuration data together, presenting it in
+// its final form to be consumed by the Sourcegraph instance and passed onto its
+// clients.
+func (b *builder) build() (*types.ModelConfiguration, error) {
+	if b.staticData == nil {
+		return nil, errors.New("no static data available")
+	}
+	baseConfig := b.staticData
+
+	// If we have newer data from Cody Gateway, use that instead of what is
+	// baked into our codebase.
+	if b.codyGatewayData != nil {
+		baseConfig = b.codyGatewayData
+	}
+
+	// Interpret site configuration.
+
+	// If no site configuration data is supplied, then just use Sourcegraph
+	// supplied data.
+	if b.siteConfigData == nil {
+		return deepCopy(baseConfig)
+	}
+	// But if we are using site config data, ensure it is valid before appying.
+	if vErr := modelconfig.ValidateSiteConfig(b.siteConfigData); vErr != nil {
+		return nil, errors.Wrap(vErr, "invalid site configuration")
+	}
+
+	outConfig, err := applySiteConfig(baseConfig, b.siteConfigData)
+	if err != nil {
+		return nil, errors.Wrap(err, "applying site config")
+	}
+
+	return outConfig, nil
+}
+
+// applySiteConfig returns the LLM Model configuration after applying the Sourcegraph admin supplied site config overrides.
+func applySiteConfig(baseConfig *types.ModelConfiguration, siteConfig *types.SiteModelConfiguration) (*types.ModelConfiguration, error) {
+	if baseConfig == nil || siteConfig == nil {
+		return nil, errors.New("baseConfig or siteConfig nil")
+	}
+
+	// We initialize the merged configuration data in-place.
+	var mergedConfig *types.ModelConfiguration
+
+	// If the admin has explicitly disabled the Sourcegraph-supplied data, zero out the base config.
+	if sgModelConfig := siteConfig.SourcegraphModelConfig; sgModelConfig == nil {
+		mergedConfig = &types.ModelConfiguration{
+			Revision:      "-",
+			SchemaVersion: types.CurrentModelSchemaVersion,
+
+			// No Models or Providers.
+			Providers: nil,
+			Models:    nil,
+
+			// Don't provide any DefaultModels either.
+			//
+			// These instead need to come from the siteConfig, or be inferred from
+			// the models available.
+			DefaultModels: types.DefaultModels{},
+		}
+	} else {
+		// Apply any model filters from the base configuration. We start with copying the base config
+		// so we can just mutate it in-memory.
+		mergedConfig, err := deepCopy(baseConfig)
+		if err != nil {
+			return nil, errors.New("copying base config")
+		}
+
+		// Apply any admin-defined model filters.
+		if modelFilters := sgModelConfig.ModelFilters; modelFilters != nil {
+			var filteredModels []types.Model
+			for _, baseConfigModel := range mergedConfig.Models {
+				// Status filter.
+				if modelFilters.StatusFilter != nil {
+					if !slices.Contains(modelFilters.StatusFilter, string(baseConfigModel.Category)) {
+						continue
+					}
+				}
+
+				// Allow list. If not specified, include all models. Otherwise, ONLY include the model
+				// IFF it matches one of the allow rules.
+				if len(modelFilters.Allow) > 0 {
+					if !filterListMatches(baseConfigModel.ModelRef, modelFilters.Allow) {
+						continue
+					}
+				}
+				// Deny list. Filter the model if it matches any deny rules.
+				if len(modelFilters.Deny) > 0 {
+					if filterListMatches(baseConfigModel.ModelRef, modelFilters.Deny) {
+						continue
+					}
+				}
+
+				filteredModels = append(filteredModels, baseConfigModel)
+			}
+
+			// Replace the base config models with the filtered set.
+			mergedConfig.Models = filteredModels
+		}
+	}
+
+	// Apply any ProviderOverrides from the site configuration to the mergedConfig object.
+	providerOverrideLookup := map[types.ProviderID]*types.ProviderOverride{}
+	for i := range siteConfig.ProviderOverrides {
+		providerOverride := &siteConfig.ProviderOverrides[i]
+		providerOverrideLookup[providerOverride.ID] = providerOverride
+
+		// Lookup the provider this configuration is for.
+		var providerToOverride *types.Provider
+		for i := range mergedConfig.Providers {
+			if mergedConfig.Providers[i].ID == providerOverride.ID {
+				providerToOverride = &mergedConfig.Providers[i]
+				break
+			}
+		}
+
+		// The site configuration has an override for a provider that
+		// isn't in the base config. So it is "new" and defined exclusively
+		// in the site configuration.
+		if providerToOverride == nil {
+
+			displayName := providerOverride.DisplayName
+			if displayName == "" {
+				displayName = fmt.Sprintf("Provider %q", providerOverride.ID)
+			}
+			providerToOverride = &types.Provider{
+				ID:               providerOverride.ID,
+				DisplayName:      displayName,
+				ClientSideConfig: providerOverride.ClientSideConfig,
+				ServerSideConfig: providerOverride.ServerSideConfig,
+			}
+			mergedConfig.Providers = append(mergedConfig.Providers, *providerToOverride)
+		}
+
+		// Blow away the provider*TO*override's configuration with the
+		// provider override defined in the site config.
+		providerToOverride.ClientSideConfig = providerOverride.ClientSideConfig
+		providerToOverride.ServerSideConfig = providerOverride.ServerSideConfig
+	}
+
+	// Apply Model Overrides. Since we need to apply any ProviderOverride.DefaultModelConfig,
+	// we just build a lookup and add any entries to the mergedConfig.Models. We can actually
+	// set their fields later.
+	modelOverrideLookup := map[types.ModelRef]*types.ModelOverride{}
+	for i := range siteConfig.ModelOverrides {
+		modelOverride := &siteConfig.ModelOverrides[i]
+		modelOverrideLookup[modelOverride.ModelRef] = modelOverride
+	}
+
+	// Now loop through all baseConfig models, and apply the override or provider defaults.
+	for i := range mergedConfig.Models {
+		mod := &mergedConfig.Models[i]
+
+		// If this model is associated with one of the ProviderOverrides, then fetch
+		// its DefaultModelConfig.
+		var providerDefaultModelConfig *types.DefaultModelConfig
+		modelProviderID := mod.ModelRef.ProviderID()
+		if providerOverride := providerOverrideLookup[modelProviderID]; providerOverride != nil {
+			providerDefaultModelConfig = providerOverride.DefaultModelConfig
+		}
+
+		// Apply the Provider's DefaultModelConfig, if applicable. (Is no-op if DefaultModelConfig is nil.)
+		if err := modelconfig.ApplyDefaultModelConfiguration(mod, providerDefaultModelConfig); err != nil {
+			return nil, errors.Wrapf(err, "applying provider default model config (%q)", modelProviderID)
+		}
+
+		// Next, apply any specific ModelOverride data for that model.
+		if modelOverride := modelOverrideLookup[mod.ModelRef]; modelOverride != nil {
+			if err := modelconfig.ApplyModelOverride(mod, *modelOverride); err != nil {
+				return nil, errors.Wrapf(err, "applying model override (%q)", mod.ModelRef)
+			}
+
+			// Remove the key from the modelOverrideLookup, see below.
+			delete(modelOverrideLookup, mod.ModelRef)
+		}
+	}
+
+	// If there are remaining keys in `modelOverrideLookup` means that the are for a ModelRef that
+	// was NOT found in the base configuration. So in that case we add those as "entirely new" models
+	// that were only defined in the site config, and wasn't referenced in the base config.
+	for _, modelOverride := range modelOverrideLookup {
+		newModelRef := modelOverride.ModelRef
+		newModel := &types.Model{
+			ModelRef: newModelRef,
+			// This isn't to provide a "default" so much as it is just to
+			// ensure the model will work.
+			ContextWindow: types.ContextWindow{
+				MaxInputTokens:  4_000,
+				MaxOutputTokens: 4_000,
+			},
+		}
+
+		// Lookup and apply the model's provider's DefaultModelConfig, if applicable.
+		modelProviderID := newModelRef.ProviderID()
+		if providerOverride := providerOverrideLookup[modelProviderID]; providerOverride != nil {
+			providerDefaultModelConfig := providerOverride.DefaultModelConfig
+
+			err := modelconfig.ApplyDefaultModelConfiguration(newModel, providerDefaultModelConfig)
+			if err != nil {
+				return nil, errors.Wrapf(err, "applying default provider config (%q)", modelProviderID)
+			}
+		}
+
+		// Apply the ModelOverride from the site config to the new Model object we are building.
+		if err := modelconfig.ApplyModelOverride(newModel, *modelOverride); err != nil {
+			return nil, errors.Wrapf(err, "applying model override (%q)", newModelRef)
+		}
+
+		mergedConfig.Models = append(mergedConfig.Models, *newModel)
+	}
+
+	// Use the DefaultModels from the site config. Otherwise, we need to pick something randomly
+	// to ensure they are at least defined.
+	if siteConfig.DefaultModels != nil {
+		mergedConfig.DefaultModels.Chat = siteConfig.DefaultModels.Chat
+		mergedConfig.DefaultModels.CodeCompletion = siteConfig.DefaultModels.CodeCompletion
+		mergedConfig.DefaultModels.FastChat = siteConfig.DefaultModels.FastChat
+	} else {
+		getModelMatchingCategory := func(wantCategories ...types.ModelCategory) *types.ModelRef {
+			for _, model := range mergedConfig.Models {
+				for _, wantCategory := range wantCategories {
+					if model.Category == wantCategory {
+						return &model.ModelRef
+					}
+				}
+			}
+			return nil
+		}
+		// Infer the default models to used based on category. This is probably not going to lead to great
+		// results. But :shrug: it's better than just crash looping because the config is under-specified.
+		if mergedConfig.DefaultModels.Chat == "" {
+			validModel := getModelMatchingCategory(types.ModelCategoryAccuracy, types.ModelCategoryBalanced)
+			if validModel == nil {
+				return nil, errors.New("no suitable model found for Chat")
+			}
+			mergedConfig.DefaultModels.Chat = *validModel
+		}
+		if mergedConfig.DefaultModels.FastChat == "" {
+			validModel := getModelMatchingCategory(types.ModelCategorySpeed, types.ModelCategoryBalanced)
+			if validModel == nil {
+				return nil, errors.New("no suitable model found for FastChat")
+			}
+			mergedConfig.DefaultModels.FastChat = *validModel
+		}
+		if mergedConfig.DefaultModels.CodeCompletion == "" {
+			validModel := getModelMatchingCategory(types.ModelCategorySpeed, types.ModelCategoryBalanced)
+			if validModel == nil {
+				return nil, errors.New("no suitable model found for Chat")
+			}
+			mergedConfig.DefaultModels.CodeCompletion = *validModel
+		}
+	}
+
+	// Validate the resulting configuration.
+	if err := modelconfig.ValidateModelConfig(mergedConfig); err != nil {
+		return nil, errors.Wrap(err, "result of application was invalid configuration")
+	}
+	return mergedConfig, nil
+}

--- a/cmd/frontend/internal/modelconfig/builder.go
+++ b/cmd/frontend/internal/modelconfig/builder.go
@@ -254,6 +254,19 @@ func applySiteConfig(baseConfig *types.ModelConfiguration, siteConfig *types.Sit
 		getModelWithRequirements := func(
 			wantCapability types.ModelCapability, wantCategories ...types.ModelCategory) *types.ModelRef {
 			for _, model := range mergedConfig.Models {
+				// Check if the model can be used for that purpose.
+				var hasCapability bool
+				for _, gotCapability := range model.Capabilities {
+					if gotCapability == wantCapability {
+						hasCapability = true
+						break
+					}
+				}
+				if !hasCapability {
+					return nil
+				}
+
+				// Check if the model has a matching category.
 				for _, wantCategory := range wantCategories {
 					if model.Category == wantCategory {
 						return &model.ModelRef

--- a/cmd/frontend/internal/modelconfig/builder_test.go
+++ b/cmd/frontend/internal/modelconfig/builder_test.go
@@ -1,0 +1,166 @@
+package modelconfig
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/sourcegraph/sourcegraph/schema"
+
+	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
+	"github.com/sourcegraph/sourcegraph/internal/licensing"
+	"github.com/sourcegraph/sourcegraph/internal/modelconfig/embedded"
+	"github.com/sourcegraph/sourcegraph/internal/modelconfig/types"
+	"github.com/sourcegraph/sourcegraph/lib/pointers"
+
+	modelconfigSDK "github.com/sourcegraph/sourcegraph/internal/modelconfig"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// verifyProviderByID will lookup the Provider from the ModelConfig and call the supplied function.
+// If the provider isn't found, will report an error.
+func verifyProviderByID(t *testing.T, cfg *types.ModelConfiguration, id string, fn func(t *testing.T, p types.Provider)) {
+	t.Helper()
+	t.Run(fmt.Sprintf("Provider=%s", id), func(t *testing.T) {
+		for _, provider := range cfg.Providers {
+			if provider.ID == types.ProviderID(id) {
+				fn(t, provider)
+				return
+			}
+		}
+
+		t.Errorf("no provider with ID %q found", id)
+	})
+}
+
+// verifyModelByMRef will lookup the Model from the ModelConfig and call the supplied function.
+// If the model isn't found, will report an error.
+func verifyModelByMRef(t *testing.T, cfg *types.ModelConfiguration, id string, fn func(t *testing.T, p types.Model)) {
+	t.Helper()
+	t.Run(fmt.Sprintf("Model=%s", id), func(t *testing.T) {
+		var ranTest bool
+		for _, model := range cfg.Models {
+			if model.ModelRef == types.ModelRef(id) {
+				if ranTest {
+					t.Errorf("two models were found with the same ID %q", id)
+				}
+				fn(t, model)
+				return
+			}
+		}
+
+		t.Errorf("no model with ID %q found", id)
+	})
+}
+
+func TestModelConfigBuilder(t *testing.T) {
+	// Mock out the licensing check confirming Cody is enabled.
+	initialMockCheck := licensing.MockCheckFeature
+	licensing.MockCheckFeature = func(licensing.Feature) error {
+		return nil // Don't fail when checking if Cody is enabled.
+	}
+	t.Cleanup(func() { licensing.MockCheckFeature = initialMockCheck })
+	t.Cleanup(func() { conf.Mock(nil) })
+
+	// setSiteCompletionsConfig sets site configuration data
+	// to enable Cody Enterprise, and have the supplied completions
+	// data.
+	setSiteCompletionsConfig := func(userSuppliedCompConfig schema.Completions) *conftypes.CompletionsConfig {
+		fauxSiteConfig := schema.SiteConfiguration{
+			CodyEnabled:                  pointers.Ptr(true),
+			CodyPermissions:              pointers.Ptr(false),
+			CodyRestrictUsersFeatureFlag: pointers.Ptr(false),
+			LicenseKey:                   "license-key",
+
+			Completions: &userSuppliedCompConfig,
+		}
+		return conf.GetCompletionsConfig(fauxSiteConfig)
+	}
+
+	type testData struct {
+		codyGatewayConfig     *types.ModelConfiguration
+		SiteCompletionsConfig schema.Completions
+	}
+
+	// verifyCanBuildModelConfig builds the types.ModelConfiguration based on the supplied data.
+	// Will abort the test if any invalid configuration data is produced.
+	verifyCanBuildModelConfig := func(t *testing.T, testData testData) *types.ModelConfiguration {
+		baseConfig, err := embedded.GetCodyGatewayModelConfig()
+		require.NoError(t, err)
+		require.NoError(t, modelconfigSDK.ValidateModelConfig(baseConfig), "baseConfig is invalid!")
+
+		// First round-trip the completions config through the `conf` package,
+		// so that various hard-coded defualts from `conf/computed.go` get applied.
+		// (Otherwise we'd test combinations that would never be possible in prod.)
+		completionsConfig := setSiteCompletionsConfig(testData.SiteCompletionsConfig)
+
+		// TODO: We are assuming that the SiteModelConfiguration ONLY comes from the
+		// "completions" section of the site config. In the future, we'll add a new
+		// format in the site configuration so users can express the SiteModelConfiguration
+		// data structure directly. (Since it is more flexible than the completions config
+		// that is available today.)
+		siteConfigData, err := convertCompletionsConfig(completionsConfig)
+		require.NoError(t, err)
+
+		b := builder{
+			staticData:      baseConfig,
+			codyGatewayData: testData.codyGatewayConfig,
+			siteConfigData:  siteConfigData,
+		}
+		result, err := b.build()
+		require.NoError(t, err)
+		require.NoError(t, modelconfigSDK.ValidateModelConfig(result), "produced ModelConfiguration was invalid")
+
+		return result
+	}
+
+	// Provide the bare minimum of site configuration data. This will enable Cody Pro
+	// and return the conftypes.CompletionsConfig as a types.ModelConfiguration.
+	t.Run("NoOverrides", func(t *testing.T) {
+		cfg := verifyCanBuildModelConfig(t, testData{})
+		assert.Equal(t, 2, len(cfg.Providers), "providers: %v", cfg.Providers)
+		assert.Equal(t, 3, len(cfg.Models), "models: %v", cfg.Models)
+
+		// Verify Providers are configured as expected.
+		verifyProviderByID(t, cfg, "anthropic", func(t *testing.T, prov types.Provider) {
+			require.NotNil(t, prov.ServerSideConfig)
+			// Use the "sourcegraph" LLM API provider under the hood.
+			require.NotNil(t, prov.ServerSideConfig.SourcegraphProvider)
+			require.Nil(t, prov.ServerSideConfig.GenericProvider)
+		})
+		verifyProviderByID(t, cfg, "fireworks", func(t *testing.T, prov types.Provider) {
+			require.NotNil(t, prov.ServerSideConfig)
+			// Use the "sourcegraph" LLM API provider under the hood.
+			require.NotNil(t, prov.ServerSideConfig.SourcegraphProvider)
+			require.Nil(t, prov.ServerSideConfig.GenericProvider)
+		})
+
+		// Verify DefaultModels.
+		assert.Equal(t, types.DefaultModels{
+			Chat:           types.ModelRef("anthropic::unknown::claude-3-sonnet-20240229"),
+			CodeCompletion: types.ModelRef("fireworks::unknown::starcoder"),
+			FastChat:       types.ModelRef("anthropic::unknown::claude-3-haiku-20240307"),
+		}, cfg.DefaultModels)
+
+		// Verify Models are configured as expected.
+		verifyModelByMRef(t, cfg, "anthropic::unknown::claude-3-haiku-20240307", func(t *testing.T, model types.Model) {
+			// The MaxInputTokens can be specified via the site config.
+			assert.Equal(t, 12_000, model.ContextWindow.MaxInputTokens)
+			assert.Equal(t, 4_000, model.ContextWindow.MaxOutputTokens)
+		})
+
+		verifyModelByMRef(t, cfg, "anthropic::unknown::claude-3-sonnet-20240229", func(t *testing.T, model types.Model) {
+			// The MaxInputTokens can be specified via the site config.
+			assert.Equal(t, 12_000, model.ContextWindow.MaxInputTokens)
+			assert.Equal(t, 4_000, model.ContextWindow.MaxOutputTokens)
+		})
+
+		verifyModelByMRef(t, cfg, "fireworks::unknown::starcoder", func(t *testing.T, model types.Model) {
+			// The MaxInputTokens can be specified via the site config.
+			assert.Equal(t, 9_000, model.ContextWindow.MaxInputTokens)
+			assert.Equal(t, 4_000, model.ContextWindow.MaxOutputTokens)
+		})
+	})
+}

--- a/cmd/frontend/internal/modelconfig/httpapi.go
+++ b/cmd/frontend/internal/modelconfig/httpapi.go
@@ -1,0 +1,68 @@
+package modelconfig
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/sourcegraph/log"
+
+	"github.com/sourcegraph/sourcegraph/internal/actor"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+
+	modelconfigSDK "github.com/sourcegraph/sourcegraph/internal/modelconfig"
+)
+
+// HTTP handlers for interacting with this Sourcegraph instance's
+// LLM Model configuration. These handlers perform auth checks.
+type HTTPHandlers struct {
+	db     database.DB
+	logger log.Logger
+}
+
+func NewHandlers(db database.DB, logger log.Logger) *HTTPHandlers {
+	return &HTTPHandlers{
+		db:     db,
+		logger: logger,
+	}
+}
+
+// GetSupportedModelsHandler returns the current Sourcegraph instance's LLM model configuration
+// data as JSON. Requires that the calling user is an authenticated.
+func (h *HTTPHandlers) GetSupportedModelsHandler(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	h.logger.Info("fetching supported LLMs")
+
+	// Auth check.
+	callingActor := actor.FromContext(ctx)
+	if callingActor == nil || !callingActor.IsAuthenticated() {
+		h.logger.Warn("unauthenticated user requesting model config")
+		http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
+		return
+	}
+
+	modelConfigSvc := Get()
+	currentConfig, err := modelConfigSvc.Get()
+	if err != nil {
+		h.logger.Error("fetching current model configuration", log.Error(err))
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		return
+	}
+	h.logger.Info(
+		"current configuration stats",
+		log.String("revision", currentConfig.Revision),
+		log.Int("providers", len(currentConfig.Providers)),
+		log.Int("models", len(currentConfig.Models)))
+
+	// SECURITY: It's critical that we do not serve any server-side configuration data
+	// to the client, as it contains sensitive data like access tokens.
+	modelconfigSDK.RedactServerSideConfig(currentConfig)
+
+	rawJSON, err := json.MarshalIndent(currentConfig, "", "    ")
+	if err != nil {
+		h.logger.Error("marshalling configuration", log.Error(err))
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		return
+	}
+	http.Error(w, string(rawJSON), http.StatusOK)
+}

--- a/cmd/frontend/internal/modelconfig/init.go
+++ b/cmd/frontend/internal/modelconfig/init.go
@@ -1,0 +1,126 @@
+package modelconfig
+
+import (
+	"context"
+
+	"github.com/sourcegraph/log"
+
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/enterprise"
+	_ "github.com/sourcegraph/sourcegraph/cmd/frontend/internal/auth"
+	_ "github.com/sourcegraph/sourcegraph/cmd/frontend/internal/registry"
+	"github.com/sourcegraph/sourcegraph/internal/codeintel"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/modelconfig/embedded"
+	"github.com/sourcegraph/sourcegraph/internal/modelconfig/types"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+// Init is the initalization function wired into the `frontend` application startup.
+// This registers the necessary watchers and hooks so that the `Service` can always
+// have an up-to-date view of this Sourcegraph instance's configuration data.
+func Init(
+	ctx context.Context,
+	observationCtx *observation.Context,
+	db database.DB,
+	codeIntelServices codeintel.Services,
+	initialConf conftypes.UnifiedWatchable,
+	enterpriseServices *enterprise.Services,
+) error {
+	// Ensure that we only regsiter this once.
+	if singletonConfigService != nil {
+		return errors.New("the Init function has already been called")
+	}
+
+	logger := log.Scoped("modelconfig")
+
+	initialSiteConfig := initialConf.SiteConfig()
+	// If Cody isn't enabled on startup, we don't bother registering anything.
+	// Because there is no need to.
+	if codyEnabled := initialSiteConfig.CodyEnabled; codyEnabled == nil || *codyEnabled == false {
+		logger.Info("Cody is not enabled, not registering ModelConfigService")
+		return nil
+	}
+
+	// The base model configuration data is what is embedded in this binary.
+	staticModelConfig, err := embedded.GetCodyGatewayModelConfig()
+	if err != nil {
+		return errors.New("embedded model data is missing or corrupt")
+	}
+
+	// TODO(chrsmith): Load the newer form of LLM model configuration data. For now, we just
+	// load the older-stype completions configuration data if available.
+	var siteModelConfig *types.SiteModelConfiguration
+	if compConfig := conf.GetCompletionsConfig(initialSiteConfig); compConfig == nil {
+		logger.Info("ignoring site modelconfig data, completions config not set")
+	} else {
+		logger.Info("converting completions configuration data", log.String("apiProvider", string(compConfig.Provider)))
+		siteModelConfig, err = convertCompletionsConfig(compConfig)
+		if err != nil {
+			logger.Error("error loading LLM model configuration data via site config", log.Error(err))
+			return errors.Wrap(err, "converting completions config")
+		}
+	}
+
+	// Now build the initial view of the Sourcegraph instance's model configuration using this data.
+	configBuilder := builder{
+		staticData:      staticModelConfig,
+		codyGatewayData: nil,
+		siteConfigData:  siteModelConfig,
+	}
+	initialConfig, err := configBuilder.build()
+	if err != nil {
+		return errors.Wrap(err, "building initial model configuration")
+	}
+
+	// Register the initial singletonConfigService.
+	initialConfigSvc := service{
+		currentConfig: initialConfig,
+	}
+	singletonConfigService = &initialConfigSvc
+
+	// Register a watcher to pull in updates whenever the site config changes.
+	conf.Watch(func() {
+		logger.Info("site config updated, recalculating model configuration")
+
+		latestSiteConfig := conf.Get().SiteConfiguration
+
+		// TODO(chrsmith): Load the newer form of LLM model configuration data. For now, we just
+		// load the older-stype completions configuration data if available.
+		var latestSiteModelConfiguration *types.SiteModelConfiguration
+		if compConfig := conf.GetCompletionsConfig(latestSiteConfig); compConfig != nil {
+			latestSiteModelConfiguration, err = convertCompletionsConfig(compConfig)
+			if err != nil {
+				// BUG: If the site configuration data is somehow bad, we silently ignore
+				// the changes. This is bad, because there is no signal to the Sourcegraph
+				// admin that their configuration is invalid. Hopefully we can put the necessary
+				// validation logic inside the site configuration validation checks, so
+				// that they will be prevented from saving invalid config data.
+				logger.Error("errror loading updated site configuration", log.Error(err))
+				latestSiteModelConfiguration = nil
+			}
+		}
+
+		// Update and rebuild the LLM model configuration.
+		//
+		// NOTE: We currently don't need a mutex on `configBuilder` because there
+		// is only one writer (this callback). But when we wire up the Cody Gateway
+		// polling, we'll need to address that.
+		configBuilder.siteConfigData = latestSiteModelConfiguration
+		updatedConfig, err := configBuilder.build()
+		if err != nil {
+			logger.Error("error regenerating model config based on site config update", log.Error(err))
+			return
+		}
+
+		singletonConfigService.set(updatedConfig)
+	})
+
+	// TODO(chrsmith): When the enhanced model configuration data is available, if configured to do so
+	// we will spawn a background job that will poll Cody Gateway for any updated model information. This
+	// will be tricky, because we want to honor any dynamic changes to the site config. e.g. the `conf.Watch`
+	// callback needs to be able to stop/restart/update the way the poller works in response to changes.
+	return nil
+}

--- a/cmd/frontend/internal/modelconfig/init.go
+++ b/cmd/frontend/internal/modelconfig/init.go
@@ -39,7 +39,7 @@ func Init(
 	initialSiteConfig := initialConf.SiteConfig()
 	// If Cody isn't enabled on startup, we don't bother registering anything.
 	// Because there is no need to.
-	if codyEnabled := initialSiteConfig.CodyEnabled; codyEnabled == nil || *codyEnabled == false {
+	if codyEnabled := initialSiteConfig.CodyEnabled; codyEnabled == nil || !*codyEnabled {
 		logger.Info("Cody is not enabled, not registering ModelConfigService")
 		return nil
 	}

--- a/cmd/frontend/internal/modelconfig/service.go
+++ b/cmd/frontend/internal/modelconfig/service.go
@@ -1,0 +1,71 @@
+package modelconfig
+
+import (
+	"sync"
+
+	"github.com/sourcegraph/sourcegraph/internal/modelconfig/types"
+)
+
+// Service is the system-wide component for obtaining the set of
+// LLM models the current Sourcegraph instance is configured to use.
+//
+// You can obtain the global, package-level instance of this interface by
+// calling the Get() method. It is safe for concurrent reads.
+//
+// Updating the system's model configuration is done by updating the Site
+// Configuration. The implementation of the Service will listen
+// for configuration changes and update the ModelConfiguration object in-
+// memory as appropriate.
+type Service interface {
+	// Get returns the current model configuration for this Sourcegraph instance.
+	// Callers should not modify the returned data, and treat it as if it were
+	// immutable.
+	Get() (*types.ModelConfiguration, error)
+}
+
+// Global instance of the model config service. We don't initialize via
+// a sync.Once because we ensure Init cannot be called twice, and assume it
+// will not be called concurrently.
+var singletonConfigService *service
+
+// Get returns the singleton ModelConfigService.
+//
+// This requires that the Init function has been called before hand, which
+// is typically done on application startup.
+func Get() Service {
+	if singletonConfigService == nil {
+		panic("ModelConfigService not initialized. Init not called.")
+	}
+	return singletonConfigService
+}
+
+// service implements the Service interface, and exposes a thread-safe `set` method
+// for updating the current configuration.
+type service struct {
+	// currentConfig is the "source of truth" for this Sg instance's model configuration.
+	currentConfig   *types.ModelConfiguration
+	currentConfigMu sync.RWMutex
+}
+
+func (svc *service) Get() (*types.ModelConfiguration, error) {
+	svc.currentConfigMu.RLock()
+	defer svc.currentConfigMu.RUnlock()
+
+	// Create a deep copy of the current configuration, so callers can operate on
+	// older versions without worrying about data races or other types of errors.
+	cfgCopy, err := deepCopy(svc.currentConfig)
+	if err != nil {
+		return nil, err
+	}
+	return cfgCopy, nil
+}
+
+// set updates the set.currentConfig to the supplied value. It is assumped that
+// the Service will "own" the pointer, and the caller will no longer modify it.
+func (svc *service) set(newConfig *types.ModelConfiguration) {
+	// Block until the lock is available.
+	svc.currentConfigMu.Lock()
+	defer svc.currentConfigMu.Unlock()
+
+	svc.currentConfig = newConfig
+}

--- a/cmd/frontend/shared/BUILD.bazel
+++ b/cmd/frontend/shared/BUILD.bazel
@@ -29,6 +29,7 @@ go_library(
         "//cmd/frontend/internal/guardrails",
         "//cmd/frontend/internal/insights",
         "//cmd/frontend/internal/licensing/init",
+        "//cmd/frontend/internal/modelconfig",
         "//cmd/frontend/internal/notebooks",
         "//cmd/frontend/internal/own",
         "//cmd/frontend/internal/rbac",

--- a/cmd/frontend/shared/shared.go
+++ b/cmd/frontend/shared/shared.go
@@ -12,6 +12,18 @@ import (
 
 	"github.com/sourcegraph/log"
 
+	// sourcegraph/internal
+	"github.com/sourcegraph/sourcegraph/internal/codeintel"
+	codeintelshared "github.com/sourcegraph/sourcegraph/internal/codeintel/shared"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	connections "github.com/sourcegraph/sourcegraph/internal/database/connections/live"
+	"github.com/sourcegraph/sourcegraph/internal/httpcli"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
+	"github.com/sourcegraph/sourcegraph/schema"
+
+	// sourcegraph/cmd/frontend/internal
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/enterprise"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/auth"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/authz"
@@ -30,6 +42,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/guardrails"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/insights"
 	licensing "github.com/sourcegraph/sourcegraph/cmd/frontend/internal/licensing/init"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/modelconfig"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/notebooks"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/own"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/rbac"
@@ -39,15 +52,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/search"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/searchcontexts"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/telemetry"
-	"github.com/sourcegraph/sourcegraph/internal/codeintel"
-	codeintelshared "github.com/sourcegraph/sourcegraph/internal/codeintel/shared"
-	"github.com/sourcegraph/sourcegraph/internal/conf"
-	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
-	"github.com/sourcegraph/sourcegraph/internal/database"
-	connections "github.com/sourcegraph/sourcegraph/internal/database/connections/live"
-	"github.com/sourcegraph/sourcegraph/internal/httpcli"
-	"github.com/sourcegraph/sourcegraph/internal/observation"
-	"github.com/sourcegraph/sourcegraph/schema"
 )
 
 type EnterpriseInitializer = func(context.Context, *observation.Context, database.DB, codeintel.Services, conftypes.UnifiedWatchable, *enterprise.Services) error
@@ -66,6 +70,7 @@ var initFunctions = map[string]EnterpriseInitializer{
 	"guardrails":     guardrails.Init,
 	"insights":       insights.Init,
 	"licensing":      licensing.Init,
+	"modelconfig":    modelconfig.Init,
 	"notebooks":      notebooks.Init,
 	"own":            own.Init,
 	"rbac":           rbac.Init,

--- a/internal/modelconfig/types/site_config.go
+++ b/internal/modelconfig/types/site_config.go
@@ -55,7 +55,8 @@ type DefaultModelConfig struct {
 // ProviderOverride is how a Sourcegraph admin would describe a `Provider` within
 // the site-configuration.
 type ProviderOverride struct {
-	ID ProviderID `json:"id"`
+	ID          ProviderID `json:"id"`
+	DisplayName string     `json:"displayName"`
 
 	ClientSideConfig *ClientSideProviderConfig `json:"clientSideConfig,omitempty"`
 	ServerSideConfig *ServerSideProviderConfig `json:"serverSideConfig,omitempty"`


### PR DESCRIPTION
This PR exposes a new HTTP endpoint from the `frontend` that will return the LLM models currently supported by the Sourcegraph instance. (Or a 500 if Cody isn't enabled or not configured correctly.)

This endpoint will be used by Cody clients in order to fetch LLM models dynamically, so that new LLM models can automatically be picked up as they are available from Cody Gateway. The underlying data structures will also make it easier for the Sourcegraph instance to configure arbitrary LLM providers, customize model settings, etc.

```zsh
curl \
    -H "Authorization: token ${SG_LOCALHOST_TOKEN}" \
    https://sourcegraph.test:3443/.api/modelconfig/supported-models.json 
```

## Overview

This PR is the latest (long) series of steps for enabling arbitrary LLM model configuration in the Sourcegraph backend. This PR introduces three new components into the `cmd/frontend/internal/modelconfig` package:

### `builder.go`, `builder_test.go`

The `builder struct` is the logic for how we generate the LLM model configuration data based on the current site configuration, what is embedded in the Sourcegraph binary, and later, what we obtain from Cody Gateway.

This is essentially how we apply things like the "model allow/deny list" or "provider/model overrides" that will later be available in the Sourcegraph site configuration.

For now, some of this functionality is inert. As there is no way for you to actually specify the type of configuration data that the `builder` supports. (e.g. you cannot specify the "LLM model allow or deny list", or fetch models from Cody Gateway.)

So realistically, with this PR the only thing it is doing is just converting a (`internal/modelconfig/types`) `SiteModelConfiguration` into a `ModelConfiguration` object. (Which was added in https://github.com/sourcegraph/sourcegraph/pull/63533.)

### `init.go`, `service.go`

Next is the `Service interface`, which is a new global service that can be used anywhere within the `frontend` binary to fetch the current LLM configuration data.

This will be used later to allow the Completions API endpoints to look up various provider and LLM configuration data.

`init.go` supplies an initialization function to the Sourcegraph machinery, and then it goes about loading the LLM model configuration data and exposing it in a singleton object. Part of this is also registering a "site configuration watcher", so that we will automatically pick up on any changes to the site configuration that may impact the LLM model configuration.

### `httpapi.go`

Finally, we expose a `HTTPHandlers struct` that contains a single `http.HandlerFunc` that will serve the HTTP response.

My intention is to later add more endpoints, such as a way for Site admins to easily `curl` the full configuration information. Or surface diagnostic-type information about available models.

## Next Steps

With this piece, we now expose a view of the Sourcegraph instance's currently supported LLM models. However, the existing completions API stilly reads the site configuration directly. (And does not use the newer, and more flexible `modelconfig` package.)

So the next step to continue wiring this up is to refactor the `frontend/internal/completions` and `internal/completions` packages to rely on the "newer style" configuration data. (Which 🤞 is faithfully reproducing the current site configuration data.)

The end result should be a no-op, but will allow us to no longer rely on hard-coded LLM model names anywhere in the codebase. And instead we can just rely on the model configuration data.

## Test plan

Added new unit tests. Verified things worked manually. And looked through existing unit tests for other components to sanity check some of the assumptions made in newer code.

## Changelog

Sourcegraph instances how expose an HTTP endpoint that authenticated users can call to get a list of LLM models supported by the Sourcegraph instance. In the future this will be used to allow Cody users to select the LLM model dynamically, based on what is currently available.

