### PR TITLE
fix/cody-gateway: use keepalive/idle timeout options for Enterprise Portal

### DIFF
--- a/cmd/cody-gateway/internal/actor/productsubscription/enterpriseportal/BUILD.bazel
+++ b/cmd/cody-gateway/internal/actor/productsubscription/enterpriseportal/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
         "//lib/errors",
         "@com_github_sourcegraph_log//:log",
         "@org_golang_google_grpc//:go_default_library",
+        "@org_golang_google_grpc//keepalive",
         "@org_golang_x_oauth2//:oauth2",
     ],
 )


### PR DESCRIPTION
See https://linear.app/sourcegraph/issue/CORE-203 - it seems the default keepalive and idle options are quite aggressive about keeping idle connections around without verifying them. This change tries to configure some options to ensure idle connections aren't retained for a long time.

## Test plan

`sg start cody-gateway` with `CODY_GATEWAY_ENTERPRISE_PORTAL_URL: https://enterprise-portal.sgdev.org:443` in override

```
[   cody-gateway] INFO cody-gateway.sources.worker.handler actor/source.go:154 Completed sync {"TraceId": "b30602af4f6f3269ed438c86ca37edcc", "SpanId": "154e7f8114b27cab", "handle.timeout": "2m0s", "source": "dotcom-product-subscriptions", "sync_duration": "800.20575ms", "seen": 161}
[   cody-gateway] INFO cody-gateway.sources.worker.handler actor/source.go:165 All sources synced {"TraceId": "b30602af4f6f3269ed438c86ca37edcc", "SpanId": "8f226cc9f0159b70", "handle.timeout": "2m0s"}
```