### PR TITLE
security: Auto-update package lockfiles for Sourcegraph base images

### DIFF
--- a/wolfi-images/appliance.lock.json
+++ b/wolfi-images/appliance.lock.json
@@ -14,117 +14,117 @@
     "packages": [
       {
         "architecture": "x86_64",
-        "checksum": "Q1Ai8jWuxKZR2M2XhOpOGAoTEwnnk=",
+        "checksum": "Q1WR9MGKU+cJh6dJFEXnr3zU1qsMM=",
         "control": {
-          "checksum": "sha1-Ai8jWuxKZR2M2XhOpOGAoTEwnnk=",
-          "range": "bytes=705-1037"
+          "checksum": "sha1-WR9MGKU+cJh6dJFEXnr3zU1qsMM=",
+          "range": "bytes=705-1034"
         },
         "data": {
-          "checksum": "sha256-e4UardkBVyaC49aSyrVmXNi8sSKqQl4eKYd0LxGRLA0=",
-          "range": "bytes=1038-255695"
+          "checksum": "sha256-EkOhtSivoLErXsK2J9ri39thkwb2kJGYHVou4n6dMKA=",
+          "range": "bytes=1035-254654"
         },
         "name": "ca-certificates-bundle",
         "signature": {
-          "checksum": "sha1-loRuyYQLm+atp+YteiQoj++EWIM=",
+          "checksum": "sha1-WL9vKv1nPIeaUQI4O0DiY9RdSHE=",
           "range": "bytes=0-704"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20240315-r4.apk",
-        "version": "20240315-r4"
+        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20240705-r0.apk",
+        "version": "20240705-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1+GH6qRN4iy1IDt0cT0x0tin7YfI=",
+        "checksum": "Q1KmG1L67f+/TnVGcnIcLfWRF/K2g=",
         "control": {
-          "checksum": "sha1-+GH6qRN4iy1IDt0cT0x0tin7YfI=",
-          "range": "bytes=703-1051"
+          "checksum": "sha1-KmG1L67f+/TnVGcnIcLfWRF/K2g=",
+          "range": "bytes=702-1051"
         },
         "data": {
-          "checksum": "sha256-rO0P9z2V49BSrz1A5Ap69tEappVrg5MMBjzW00rOpZc=",
-          "range": "bytes=1052-122464"
+          "checksum": "sha256-2YIxYc/Quit+Kri2qS8p6XvL7taAmOYJU/1Z8RNQ+88=",
+          "range": "bytes=1052-122509"
         },
         "name": "wolfi-baselayout",
         "signature": {
-          "checksum": "sha1-Ntb6VuMzDfM+frpCjKEIpDzl53I=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-VVyPrknEtqCPym5lfhVEuIhfkKg=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r12.apk",
-        "version": "20230201-r12"
+        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r13.apk",
+        "version": "20230201-r13"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q17rD4cKGW3uVSJw02PFiYR719t/Y=",
+        "checksum": "Q1ASyaCJL2Zyz4uAKpPPlx1Sd40yo=",
         "control": {
-          "checksum": "sha1-7rD4cKGW3uVSJw02PFiYR719t/Y=",
-          "range": "bytes=697-1108"
+          "checksum": "sha1-ASyaCJL2Zyz4uAKpPPlx1Sd40yo=",
+          "range": "bytes=706-1101"
         },
         "data": {
-          "checksum": "sha256-GvSViXbvUD0BdV2A+IzVJni2DjLvyM+j14hM29DcsYg=",
-          "range": "bytes=1109-268391"
+          "checksum": "sha256-KoaUrlV3QZ4ATGvKgOmZ1C8Rb/tHK3zEiCTGDrxxc/I=",
+          "range": "bytes=1102-272818"
         },
         "name": "ld-linux",
         "signature": {
-          "checksum": "sha1-nRIFect8o/LOUIEvN17AsrI07dg=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-DBrLE0fWPMyB5/0kAtNlIK6viCU=",
+          "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1/A0wNjkLqqBhe0jFr2D9SKcDNq8=",
+        "checksum": "Q10iHLABsXtuH2JyExQ2IIxH1NUCI=",
         "control": {
-          "checksum": "sha1-/A0wNjkLqqBhe0jFr2D9SKcDNq8=",
-          "range": "bytes=696-1054"
+          "checksum": "sha1-0iHLABsXtuH2JyExQ2IIxH1NUCI=",
+          "range": "bytes=698-1041"
         },
         "data": {
-          "checksum": "sha256-GT22MF6hR+Tj4el5xk2QEwNWig5JRoOrZ60Lecz+lok=",
-          "range": "bytes=1055-408851"
+          "checksum": "sha256-A3RF8XLSIePkapCnvEridXa2N7nheKNT1kTKDqZlGdI=",
+          "range": "bytes=1042-408849"
         },
         "name": "glibc-locale-posix",
         "signature": {
-          "checksum": "sha1-9uPIvcOCeZbPiR7+MLDB4tkJlHo=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-QqrJFnJmyPeT66hUk3O7NxaWY8I=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1YLxq+Z9/+aFnCwvgV7acVLT4QFA=",
+        "checksum": "Q1JYf1zI1zVi/S9sMI32guk6ptuRQ=",
         "control": {
-          "checksum": "sha1-YLxq+Z9/+aFnCwvgV7acVLT4QFA=",
-          "range": "bytes=701-1330"
+          "checksum": "sha1-JYf1zI1zVi/S9sMI32guk6ptuRQ=",
+          "range": "bytes=701-1308"
         },
         "data": {
-          "checksum": "sha256-9s5RNfAJ3GVt7a/fFUaew5MfYYUkvL/6FMvsEfD95jY=",
-          "range": "bytes=1331-5862057"
+          "checksum": "sha256-ioC8korS2nJpJvoS6He+mKkDsgVLcMxiEuYLsAB9M7U=",
+          "range": "bytes=1309-5959239"
         },
         "name": "glibc",
         "signature": {
-          "checksum": "sha1-Kvfb+I/1PCfiBTjoaU4ezZa0b+8=",
+          "checksum": "sha1-3TP2+cHjCEBrIFluCdTmr2oJA1s=",
           "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Zi0e8Bq6WCd/6uXXjVhb8YwMD1U=",
+        "checksum": "Q1WAlPh7UNBV+RHfBixVB5P9F9Mp8=",
         "control": {
-          "checksum": "sha1-Zi0e8Bq6WCd/6uXXjVhb8YwMD1U=",
-          "range": "bytes=700-1073"
+          "checksum": "sha1-WAlPh7UNBV+RHfBixVB5P9F9Mp8=",
+          "range": "bytes=700-1074"
         },
         "data": {
-          "checksum": "sha256-jMhtfqVjnhuuBO7wtNZ6RS/72sZWoKt/Moage2amlks=",
-          "range": "bytes=1074-81594"
+          "checksum": "sha256-i6uEFvUEbJ4YzgNSV58aObIdU608mjbCVPwyF57ZeQQ=",
+          "range": "bytes=1075-81593"
         },
         "name": "protobuf-c",
         "signature": {
-          "checksum": "sha1-kATwMKztK7nk7qbYCJPkCFp6IXc=",
+          "checksum": "sha1-47zwDXmhcWiVtTYCjq4sFld8wHQ=",
           "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r5.apk",
-        "version": "1.5.0-r5"
+        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r6.apk",
+        "version": "1.5.0-r6"
       },
       {
         "architecture": "x86_64",
@@ -204,41 +204,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Q/Zy5ovYSu2p/vVLr6DgVA1e8AQ=",
+        "checksum": "Q1a5wJzZI7k9o4F8hHFpfuqAUIH5Q=",
         "control": {
-          "checksum": "sha1-Q/Zy5ovYSu2p/vVLr6DgVA1e8AQ=",
-          "range": "bytes=699-1062"
+          "checksum": "sha1-a5wJzZI7k9o4F8hHFpfuqAUIH5Q=",
+          "range": "bytes=710-1075"
         },
         "data": {
-          "checksum": "sha256-H3jxsw8ytOeCIR4vq17voSVhdNokXk8C1g075txH6Bs=",
-          "range": "bytes=1063-5903754"
+          "checksum": "sha256-2p1UC4F4Odfxup/J/nyzujYRGaxGVjBOBWoc0aajClI=",
+          "range": "bytes=1076-5903889"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-NIl2f5OI/wSZByI8Ds1ZUfbFWyw=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-SOFoklqXtH38i1PcI3G/cPdRFtY=",
+          "range": "bytes=0-709"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.1-r3.apk",
-        "version": "3.3.1-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.1-r4.apk",
+        "version": "3.3.1-r4"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q13wGUXdZut9OOTdY5z2amUj9wXC0=",
+        "checksum": "Q1gb2VyLOsGV7xUiHBT0Ypt64rw6Y=",
         "control": {
-          "checksum": "sha1-3wGUXdZut9OOTdY5z2amUj9wXC0=",
-          "range": "bytes=698-1068"
+          "checksum": "sha1-gb2VyLOsGV7xUiHBT0Ypt64rw6Y=",
+          "range": "bytes=702-1071"
         },
         "data": {
-          "checksum": "sha256-mRda6+YGlOCczyIWKaHqXskTINoT1rgorHDHqAKAb7c=",
-          "range": "bytes=1069-1188955"
+          "checksum": "sha256-h2tz/aFB2n8SFdBFde5foQm1ru+8JUcGp+trUeA2ZlQ=",
+          "range": "bytes=1072-1188954"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-+UdRc4U3PKw4H9OiNurHKXa5BYk=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-w6U2Pb1Y90u1iBFc/sHg2xn6Qmo=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.1-r3.apk",
-        "version": "3.3.1-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.1-r4.apk",
+        "version": "3.3.1-r4"
       },
       {
         "architecture": "x86_64",
@@ -356,60 +356,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1gfqHM/7r3rXX1HqC163slTPP46o=",
+        "checksum": "Q1DLAp18ebMscosnQ4TfTivIzgtCY=",
         "control": {
-          "checksum": "sha1-gfqHM/7r3rXX1HqC163slTPP46o=",
-          "range": "bytes=704-1101"
+          "checksum": "sha1-DLAp18ebMscosnQ4TfTivIzgtCY=",
+          "range": "bytes=698-1079"
         },
         "data": {
-          "checksum": "sha256-OR7ikvfUYp78EsP0I2kuwqqAcy05jw9tr7JVQ6jTnGQ=",
-          "range": "bytes=1102-185433"
+          "checksum": "sha256-eiBdqqECWnULWGe/Gnd6iv/7h56A4xR2qw+5toY5Gaw=",
+          "range": "bytes=1080-185559"
         },
         "name": "libgcc",
         "signature": {
-          "checksum": "sha1-Il4pyVzI6eqNd/f4bsKeakpB5DI=",
-          "range": "bytes=0-703"
+          "checksum": "sha1-qVj9laNeBIwRxP+8ehB+fXftJrw=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.2.0-r7.apk",
-        "version": "13.2.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r0.apk",
+        "version": "13.3.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1c+lykdx+yHoqsrQmQLHMV7waR1Q=",
+        "checksum": "Q1p9aaHhpB2Ud0URrcIrVRAujMw+o=",
         "control": {
-          "checksum": "sha1-c+lykdx+yHoqsrQmQLHMV7waR1Q=",
-          "range": "bytes=701-1119"
+          "checksum": "sha1-p9aaHhpB2Ud0URrcIrVRAujMw+o=",
+          "range": "bytes=696-1097"
         },
         "data": {
-          "checksum": "sha256-CuZi2C5g0vUnz4PNH8jIWV+EBdVMvHr+sNKFYTSnQZk=",
-          "range": "bytes=1120-3155369"
+          "checksum": "sha256-rGMnyLiGEDCEVgqA1oXMf28QHuWHAaPzYrLeDzQ3WOU=",
+          "range": "bytes=1098-3155519"
         },
         "name": "libstdc++",
         "signature": {
-          "checksum": "sha1-7l8MLj8aCcdqta/0sR+0PscBsD4=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-lge2XoAsgvp8U6ZBgT52N2xNQAw=",
+          "range": "bytes=0-695"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.2.0-r7.apk",
-        "version": "13.2.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r0.apk",
+        "version": "13.3.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1R8OxpY0fGwVaIwft4wJeswF5D54=",
+        "checksum": "Q1DUpLMidX5HbXUAFV8y3Imyt+Ank=",
         "control": {
-          "checksum": "sha1-R8OxpY0fGwVaIwft4wJeswF5D54=",
-          "range": "bytes=695-1059"
+          "checksum": "sha1-DUpLMidX5HbXUAFV8y3Imyt+Ank=",
+          "range": "bytes=698-1063"
         },
         "data": {
-          "checksum": "sha256-wNc8/SBJrGHfwywAtzCsAqeUOt0IaAhqNtlbv8OiHBE=",
-          "range": "bytes=1060-242151"
+          "checksum": "sha256-ZUDWWOBnxl5xi3b5HQCHaiYqKDSrnVpJQgavWpn1duc=",
+          "range": "bytes=1064-255810"
         },
         "name": "c-ares",
         "signature": {
-          "checksum": "sha1-55/PTlEHXI3o0hx9dSVdNwQeSMg=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-0AXk7b/B1baNADDg/NSocbW//pw=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.31.0-r0.apk",
-        "version": "1.31.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.32.1-r0.apk",
+        "version": "1.32.1-r0"
       },
       {
         "architecture": "x86_64",
@@ -470,22 +470,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q10AaU1ocIM4PYYNvwbml8TmpNvEA=",
+        "checksum": "Q1ORn/60iAvLcAgApXYoZzM6o0XSs=",
         "control": {
-          "checksum": "sha1-0AaU1ocIM4PYYNvwbml8TmpNvEA=",
-          "range": "bytes=706-1085"
+          "checksum": "sha1-ORn/60iAvLcAgApXYoZzM6o0XSs=",
+          "range": "bytes=703-1081"
         },
         "data": {
-          "checksum": "sha256-1YQNYASFjlP3kXX58ec8du75ij/U6O4DPAKzJAPkln0=",
-          "range": "bytes=1086-4272589"
+          "checksum": "sha256-Ya2Dn1VNYB21ZBD/jBCSx3SxZuJloJET5xkjX0s3Vt8=",
+          "range": "bytes=1082-4272708"
         },
         "name": "libxml2",
         "signature": {
-          "checksum": "sha1-QFjdplzGn/MiNFxMykgafr6/w6U=",
-          "range": "bytes=0-705"
+          "checksum": "sha1-s5jaTwJdla4k4KK0KEk7AYbgdqs=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.1-r1.apk",
-        "version": "2.13.1-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.2-r0.apk",
+        "version": "2.13.2-r0"
       },
       {
         "architecture": "x86_64",
@@ -546,22 +546,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1+0xClEzF5nhyNPUeGFhC++ElQmg=",
+        "checksum": "Q1u+fF2xg98dT0poYklte5HHMg/Kk=",
         "control": {
-          "checksum": "sha1-+0xClEzF5nhyNPUeGFhC++ElQmg=",
-          "range": "bytes=701-1107"
+          "checksum": "sha1-u+fF2xg98dT0poYklte5HHMg/Kk=",
+          "range": "bytes=701-1090"
         },
         "data": {
-          "checksum": "sha256-81V5R7T08up/3BwfuAG25Rq7KkB1MvALVCaogCpW500=",
-          "range": "bytes=1108-22181"
+          "checksum": "sha256-9e+i7LwSg7oAUU33f0r7A4Mc2suaK95iNU5BKaTSXac=",
+          "range": "bytes=1091-22179"
         },
         "name": "libcrypt1",
         "signature": {
-          "checksum": "sha1-k+7JfhPi5KOQ+6Nqk3oAfTbtOVM=",
+          "checksum": "sha1-EWBUcJqCJTOYJq1H0/kkO+m6W3E=",
           "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/batcheshelper.lock.json
+++ b/wolfi-images/batcheshelper.lock.json
@@ -14,117 +14,117 @@
     "packages": [
       {
         "architecture": "x86_64",
-        "checksum": "Q1Ai8jWuxKZR2M2XhOpOGAoTEwnnk=",
+        "checksum": "Q1WR9MGKU+cJh6dJFEXnr3zU1qsMM=",
         "control": {
-          "checksum": "sha1-Ai8jWuxKZR2M2XhOpOGAoTEwnnk=",
-          "range": "bytes=705-1037"
+          "checksum": "sha1-WR9MGKU+cJh6dJFEXnr3zU1qsMM=",
+          "range": "bytes=705-1034"
         },
         "data": {
-          "checksum": "sha256-e4UardkBVyaC49aSyrVmXNi8sSKqQl4eKYd0LxGRLA0=",
-          "range": "bytes=1038-255695"
+          "checksum": "sha256-EkOhtSivoLErXsK2J9ri39thkwb2kJGYHVou4n6dMKA=",
+          "range": "bytes=1035-254654"
         },
         "name": "ca-certificates-bundle",
         "signature": {
-          "checksum": "sha1-loRuyYQLm+atp+YteiQoj++EWIM=",
+          "checksum": "sha1-WL9vKv1nPIeaUQI4O0DiY9RdSHE=",
           "range": "bytes=0-704"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20240315-r4.apk",
-        "version": "20240315-r4"
+        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20240705-r0.apk",
+        "version": "20240705-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1+GH6qRN4iy1IDt0cT0x0tin7YfI=",
+        "checksum": "Q1KmG1L67f+/TnVGcnIcLfWRF/K2g=",
         "control": {
-          "checksum": "sha1-+GH6qRN4iy1IDt0cT0x0tin7YfI=",
-          "range": "bytes=703-1051"
+          "checksum": "sha1-KmG1L67f+/TnVGcnIcLfWRF/K2g=",
+          "range": "bytes=702-1051"
         },
         "data": {
-          "checksum": "sha256-rO0P9z2V49BSrz1A5Ap69tEappVrg5MMBjzW00rOpZc=",
-          "range": "bytes=1052-122464"
+          "checksum": "sha256-2YIxYc/Quit+Kri2qS8p6XvL7taAmOYJU/1Z8RNQ+88=",
+          "range": "bytes=1052-122509"
         },
         "name": "wolfi-baselayout",
         "signature": {
-          "checksum": "sha1-Ntb6VuMzDfM+frpCjKEIpDzl53I=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-VVyPrknEtqCPym5lfhVEuIhfkKg=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r12.apk",
-        "version": "20230201-r12"
+        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r13.apk",
+        "version": "20230201-r13"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q17rD4cKGW3uVSJw02PFiYR719t/Y=",
+        "checksum": "Q1ASyaCJL2Zyz4uAKpPPlx1Sd40yo=",
         "control": {
-          "checksum": "sha1-7rD4cKGW3uVSJw02PFiYR719t/Y=",
-          "range": "bytes=697-1108"
+          "checksum": "sha1-ASyaCJL2Zyz4uAKpPPlx1Sd40yo=",
+          "range": "bytes=706-1101"
         },
         "data": {
-          "checksum": "sha256-GvSViXbvUD0BdV2A+IzVJni2DjLvyM+j14hM29DcsYg=",
-          "range": "bytes=1109-268391"
+          "checksum": "sha256-KoaUrlV3QZ4ATGvKgOmZ1C8Rb/tHK3zEiCTGDrxxc/I=",
+          "range": "bytes=1102-272818"
         },
         "name": "ld-linux",
         "signature": {
-          "checksum": "sha1-nRIFect8o/LOUIEvN17AsrI07dg=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-DBrLE0fWPMyB5/0kAtNlIK6viCU=",
+          "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1/A0wNjkLqqBhe0jFr2D9SKcDNq8=",
+        "checksum": "Q10iHLABsXtuH2JyExQ2IIxH1NUCI=",
         "control": {
-          "checksum": "sha1-/A0wNjkLqqBhe0jFr2D9SKcDNq8=",
-          "range": "bytes=696-1054"
+          "checksum": "sha1-0iHLABsXtuH2JyExQ2IIxH1NUCI=",
+          "range": "bytes=698-1041"
         },
         "data": {
-          "checksum": "sha256-GT22MF6hR+Tj4el5xk2QEwNWig5JRoOrZ60Lecz+lok=",
-          "range": "bytes=1055-408851"
+          "checksum": "sha256-A3RF8XLSIePkapCnvEridXa2N7nheKNT1kTKDqZlGdI=",
+          "range": "bytes=1042-408849"
         },
         "name": "glibc-locale-posix",
         "signature": {
-          "checksum": "sha1-9uPIvcOCeZbPiR7+MLDB4tkJlHo=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-QqrJFnJmyPeT66hUk3O7NxaWY8I=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1YLxq+Z9/+aFnCwvgV7acVLT4QFA=",
+        "checksum": "Q1JYf1zI1zVi/S9sMI32guk6ptuRQ=",
         "control": {
-          "checksum": "sha1-YLxq+Z9/+aFnCwvgV7acVLT4QFA=",
-          "range": "bytes=701-1330"
+          "checksum": "sha1-JYf1zI1zVi/S9sMI32guk6ptuRQ=",
+          "range": "bytes=701-1308"
         },
         "data": {
-          "checksum": "sha256-9s5RNfAJ3GVt7a/fFUaew5MfYYUkvL/6FMvsEfD95jY=",
-          "range": "bytes=1331-5862057"
+          "checksum": "sha256-ioC8korS2nJpJvoS6He+mKkDsgVLcMxiEuYLsAB9M7U=",
+          "range": "bytes=1309-5959239"
         },
         "name": "glibc",
         "signature": {
-          "checksum": "sha1-Kvfb+I/1PCfiBTjoaU4ezZa0b+8=",
+          "checksum": "sha1-3TP2+cHjCEBrIFluCdTmr2oJA1s=",
           "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Zi0e8Bq6WCd/6uXXjVhb8YwMD1U=",
+        "checksum": "Q1WAlPh7UNBV+RHfBixVB5P9F9Mp8=",
         "control": {
-          "checksum": "sha1-Zi0e8Bq6WCd/6uXXjVhb8YwMD1U=",
-          "range": "bytes=700-1073"
+          "checksum": "sha1-WAlPh7UNBV+RHfBixVB5P9F9Mp8=",
+          "range": "bytes=700-1074"
         },
         "data": {
-          "checksum": "sha256-jMhtfqVjnhuuBO7wtNZ6RS/72sZWoKt/Moage2amlks=",
-          "range": "bytes=1074-81594"
+          "checksum": "sha256-i6uEFvUEbJ4YzgNSV58aObIdU608mjbCVPwyF57ZeQQ=",
+          "range": "bytes=1075-81593"
         },
         "name": "protobuf-c",
         "signature": {
-          "checksum": "sha1-kATwMKztK7nk7qbYCJPkCFp6IXc=",
+          "checksum": "sha1-47zwDXmhcWiVtTYCjq4sFld8wHQ=",
           "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r5.apk",
-        "version": "1.5.0-r5"
+        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r6.apk",
+        "version": "1.5.0-r6"
       },
       {
         "architecture": "x86_64",
@@ -204,41 +204,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Q/Zy5ovYSu2p/vVLr6DgVA1e8AQ=",
+        "checksum": "Q1a5wJzZI7k9o4F8hHFpfuqAUIH5Q=",
         "control": {
-          "checksum": "sha1-Q/Zy5ovYSu2p/vVLr6DgVA1e8AQ=",
-          "range": "bytes=699-1062"
+          "checksum": "sha1-a5wJzZI7k9o4F8hHFpfuqAUIH5Q=",
+          "range": "bytes=710-1075"
         },
         "data": {
-          "checksum": "sha256-H3jxsw8ytOeCIR4vq17voSVhdNokXk8C1g075txH6Bs=",
-          "range": "bytes=1063-5903754"
+          "checksum": "sha256-2p1UC4F4Odfxup/J/nyzujYRGaxGVjBOBWoc0aajClI=",
+          "range": "bytes=1076-5903889"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-NIl2f5OI/wSZByI8Ds1ZUfbFWyw=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-SOFoklqXtH38i1PcI3G/cPdRFtY=",
+          "range": "bytes=0-709"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.1-r3.apk",
-        "version": "3.3.1-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.1-r4.apk",
+        "version": "3.3.1-r4"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q13wGUXdZut9OOTdY5z2amUj9wXC0=",
+        "checksum": "Q1gb2VyLOsGV7xUiHBT0Ypt64rw6Y=",
         "control": {
-          "checksum": "sha1-3wGUXdZut9OOTdY5z2amUj9wXC0=",
-          "range": "bytes=698-1068"
+          "checksum": "sha1-gb2VyLOsGV7xUiHBT0Ypt64rw6Y=",
+          "range": "bytes=702-1071"
         },
         "data": {
-          "checksum": "sha256-mRda6+YGlOCczyIWKaHqXskTINoT1rgorHDHqAKAb7c=",
-          "range": "bytes=1069-1188955"
+          "checksum": "sha256-h2tz/aFB2n8SFdBFde5foQm1ru+8JUcGp+trUeA2ZlQ=",
+          "range": "bytes=1072-1188954"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-+UdRc4U3PKw4H9OiNurHKXa5BYk=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-w6U2Pb1Y90u1iBFc/sHg2xn6Qmo=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.1-r3.apk",
-        "version": "3.3.1-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.1-r4.apk",
+        "version": "3.3.1-r4"
       },
       {
         "architecture": "x86_64",
@@ -356,60 +356,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1gfqHM/7r3rXX1HqC163slTPP46o=",
+        "checksum": "Q1DLAp18ebMscosnQ4TfTivIzgtCY=",
         "control": {
-          "checksum": "sha1-gfqHM/7r3rXX1HqC163slTPP46o=",
-          "range": "bytes=704-1101"
+          "checksum": "sha1-DLAp18ebMscosnQ4TfTivIzgtCY=",
+          "range": "bytes=698-1079"
         },
         "data": {
-          "checksum": "sha256-OR7ikvfUYp78EsP0I2kuwqqAcy05jw9tr7JVQ6jTnGQ=",
-          "range": "bytes=1102-185433"
+          "checksum": "sha256-eiBdqqECWnULWGe/Gnd6iv/7h56A4xR2qw+5toY5Gaw=",
+          "range": "bytes=1080-185559"
         },
         "name": "libgcc",
         "signature": {
-          "checksum": "sha1-Il4pyVzI6eqNd/f4bsKeakpB5DI=",
-          "range": "bytes=0-703"
+          "checksum": "sha1-qVj9laNeBIwRxP+8ehB+fXftJrw=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.2.0-r7.apk",
-        "version": "13.2.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r0.apk",
+        "version": "13.3.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1c+lykdx+yHoqsrQmQLHMV7waR1Q=",
+        "checksum": "Q1p9aaHhpB2Ud0URrcIrVRAujMw+o=",
         "control": {
-          "checksum": "sha1-c+lykdx+yHoqsrQmQLHMV7waR1Q=",
-          "range": "bytes=701-1119"
+          "checksum": "sha1-p9aaHhpB2Ud0URrcIrVRAujMw+o=",
+          "range": "bytes=696-1097"
         },
         "data": {
-          "checksum": "sha256-CuZi2C5g0vUnz4PNH8jIWV+EBdVMvHr+sNKFYTSnQZk=",
-          "range": "bytes=1120-3155369"
+          "checksum": "sha256-rGMnyLiGEDCEVgqA1oXMf28QHuWHAaPzYrLeDzQ3WOU=",
+          "range": "bytes=1098-3155519"
         },
         "name": "libstdc++",
         "signature": {
-          "checksum": "sha1-7l8MLj8aCcdqta/0sR+0PscBsD4=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-lge2XoAsgvp8U6ZBgT52N2xNQAw=",
+          "range": "bytes=0-695"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.2.0-r7.apk",
-        "version": "13.2.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r0.apk",
+        "version": "13.3.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1R8OxpY0fGwVaIwft4wJeswF5D54=",
+        "checksum": "Q1DUpLMidX5HbXUAFV8y3Imyt+Ank=",
         "control": {
-          "checksum": "sha1-R8OxpY0fGwVaIwft4wJeswF5D54=",
-          "range": "bytes=695-1059"
+          "checksum": "sha1-DUpLMidX5HbXUAFV8y3Imyt+Ank=",
+          "range": "bytes=698-1063"
         },
         "data": {
-          "checksum": "sha256-wNc8/SBJrGHfwywAtzCsAqeUOt0IaAhqNtlbv8OiHBE=",
-          "range": "bytes=1060-242151"
+          "checksum": "sha256-ZUDWWOBnxl5xi3b5HQCHaiYqKDSrnVpJQgavWpn1duc=",
+          "range": "bytes=1064-255810"
         },
         "name": "c-ares",
         "signature": {
-          "checksum": "sha1-55/PTlEHXI3o0hx9dSVdNwQeSMg=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-0AXk7b/B1baNADDg/NSocbW//pw=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.31.0-r0.apk",
-        "version": "1.31.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.32.1-r0.apk",
+        "version": "1.32.1-r0"
       },
       {
         "architecture": "x86_64",
@@ -470,22 +470,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q10AaU1ocIM4PYYNvwbml8TmpNvEA=",
+        "checksum": "Q1ORn/60iAvLcAgApXYoZzM6o0XSs=",
         "control": {
-          "checksum": "sha1-0AaU1ocIM4PYYNvwbml8TmpNvEA=",
-          "range": "bytes=706-1085"
+          "checksum": "sha1-ORn/60iAvLcAgApXYoZzM6o0XSs=",
+          "range": "bytes=703-1081"
         },
         "data": {
-          "checksum": "sha256-1YQNYASFjlP3kXX58ec8du75ij/U6O4DPAKzJAPkln0=",
-          "range": "bytes=1086-4272589"
+          "checksum": "sha256-Ya2Dn1VNYB21ZBD/jBCSx3SxZuJloJET5xkjX0s3Vt8=",
+          "range": "bytes=1082-4272708"
         },
         "name": "libxml2",
         "signature": {
-          "checksum": "sha1-QFjdplzGn/MiNFxMykgafr6/w6U=",
-          "range": "bytes=0-705"
+          "checksum": "sha1-s5jaTwJdla4k4KK0KEk7AYbgdqs=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.1-r1.apk",
-        "version": "2.13.1-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.2-r0.apk",
+        "version": "2.13.2-r0"
       },
       {
         "architecture": "x86_64",
@@ -546,22 +546,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1+0xClEzF5nhyNPUeGFhC++ElQmg=",
+        "checksum": "Q1u+fF2xg98dT0poYklte5HHMg/Kk=",
         "control": {
-          "checksum": "sha1-+0xClEzF5nhyNPUeGFhC++ElQmg=",
-          "range": "bytes=701-1107"
+          "checksum": "sha1-u+fF2xg98dT0poYklte5HHMg/Kk=",
+          "range": "bytes=701-1090"
         },
         "data": {
-          "checksum": "sha256-81V5R7T08up/3BwfuAG25Rq7KkB1MvALVCaogCpW500=",
-          "range": "bytes=1108-22181"
+          "checksum": "sha256-9e+i7LwSg7oAUU33f0r7A4Mc2suaK95iNU5BKaTSXac=",
+          "range": "bytes=1091-22179"
         },
         "name": "libcrypt1",
         "signature": {
-          "checksum": "sha1-k+7JfhPi5KOQ+6Nqk3oAfTbtOVM=",
+          "checksum": "sha1-EWBUcJqCJTOYJq1H0/kkO+m6W3E=",
           "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/blobstore.lock.json
+++ b/wolfi-images/blobstore.lock.json
@@ -14,117 +14,117 @@
     "packages": [
       {
         "architecture": "x86_64",
-        "checksum": "Q1Ai8jWuxKZR2M2XhOpOGAoTEwnnk=",
+        "checksum": "Q1WR9MGKU+cJh6dJFEXnr3zU1qsMM=",
         "control": {
-          "checksum": "sha1-Ai8jWuxKZR2M2XhOpOGAoTEwnnk=",
-          "range": "bytes=705-1037"
+          "checksum": "sha1-WR9MGKU+cJh6dJFEXnr3zU1qsMM=",
+          "range": "bytes=705-1034"
         },
         "data": {
-          "checksum": "sha256-e4UardkBVyaC49aSyrVmXNi8sSKqQl4eKYd0LxGRLA0=",
-          "range": "bytes=1038-255695"
+          "checksum": "sha256-EkOhtSivoLErXsK2J9ri39thkwb2kJGYHVou4n6dMKA=",
+          "range": "bytes=1035-254654"
         },
         "name": "ca-certificates-bundle",
         "signature": {
-          "checksum": "sha1-loRuyYQLm+atp+YteiQoj++EWIM=",
+          "checksum": "sha1-WL9vKv1nPIeaUQI4O0DiY9RdSHE=",
           "range": "bytes=0-704"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20240315-r4.apk",
-        "version": "20240315-r4"
+        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20240705-r0.apk",
+        "version": "20240705-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1+GH6qRN4iy1IDt0cT0x0tin7YfI=",
+        "checksum": "Q1KmG1L67f+/TnVGcnIcLfWRF/K2g=",
         "control": {
-          "checksum": "sha1-+GH6qRN4iy1IDt0cT0x0tin7YfI=",
-          "range": "bytes=703-1051"
+          "checksum": "sha1-KmG1L67f+/TnVGcnIcLfWRF/K2g=",
+          "range": "bytes=702-1051"
         },
         "data": {
-          "checksum": "sha256-rO0P9z2V49BSrz1A5Ap69tEappVrg5MMBjzW00rOpZc=",
-          "range": "bytes=1052-122464"
+          "checksum": "sha256-2YIxYc/Quit+Kri2qS8p6XvL7taAmOYJU/1Z8RNQ+88=",
+          "range": "bytes=1052-122509"
         },
         "name": "wolfi-baselayout",
         "signature": {
-          "checksum": "sha1-Ntb6VuMzDfM+frpCjKEIpDzl53I=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-VVyPrknEtqCPym5lfhVEuIhfkKg=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r12.apk",
-        "version": "20230201-r12"
+        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r13.apk",
+        "version": "20230201-r13"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q17rD4cKGW3uVSJw02PFiYR719t/Y=",
+        "checksum": "Q1ASyaCJL2Zyz4uAKpPPlx1Sd40yo=",
         "control": {
-          "checksum": "sha1-7rD4cKGW3uVSJw02PFiYR719t/Y=",
-          "range": "bytes=697-1108"
+          "checksum": "sha1-ASyaCJL2Zyz4uAKpPPlx1Sd40yo=",
+          "range": "bytes=706-1101"
         },
         "data": {
-          "checksum": "sha256-GvSViXbvUD0BdV2A+IzVJni2DjLvyM+j14hM29DcsYg=",
-          "range": "bytes=1109-268391"
+          "checksum": "sha256-KoaUrlV3QZ4ATGvKgOmZ1C8Rb/tHK3zEiCTGDrxxc/I=",
+          "range": "bytes=1102-272818"
         },
         "name": "ld-linux",
         "signature": {
-          "checksum": "sha1-nRIFect8o/LOUIEvN17AsrI07dg=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-DBrLE0fWPMyB5/0kAtNlIK6viCU=",
+          "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1/A0wNjkLqqBhe0jFr2D9SKcDNq8=",
+        "checksum": "Q10iHLABsXtuH2JyExQ2IIxH1NUCI=",
         "control": {
-          "checksum": "sha1-/A0wNjkLqqBhe0jFr2D9SKcDNq8=",
-          "range": "bytes=696-1054"
+          "checksum": "sha1-0iHLABsXtuH2JyExQ2IIxH1NUCI=",
+          "range": "bytes=698-1041"
         },
         "data": {
-          "checksum": "sha256-GT22MF6hR+Tj4el5xk2QEwNWig5JRoOrZ60Lecz+lok=",
-          "range": "bytes=1055-408851"
+          "checksum": "sha256-A3RF8XLSIePkapCnvEridXa2N7nheKNT1kTKDqZlGdI=",
+          "range": "bytes=1042-408849"
         },
         "name": "glibc-locale-posix",
         "signature": {
-          "checksum": "sha1-9uPIvcOCeZbPiR7+MLDB4tkJlHo=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-QqrJFnJmyPeT66hUk3O7NxaWY8I=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1YLxq+Z9/+aFnCwvgV7acVLT4QFA=",
+        "checksum": "Q1JYf1zI1zVi/S9sMI32guk6ptuRQ=",
         "control": {
-          "checksum": "sha1-YLxq+Z9/+aFnCwvgV7acVLT4QFA=",
-          "range": "bytes=701-1330"
+          "checksum": "sha1-JYf1zI1zVi/S9sMI32guk6ptuRQ=",
+          "range": "bytes=701-1308"
         },
         "data": {
-          "checksum": "sha256-9s5RNfAJ3GVt7a/fFUaew5MfYYUkvL/6FMvsEfD95jY=",
-          "range": "bytes=1331-5862057"
+          "checksum": "sha256-ioC8korS2nJpJvoS6He+mKkDsgVLcMxiEuYLsAB9M7U=",
+          "range": "bytes=1309-5959239"
         },
         "name": "glibc",
         "signature": {
-          "checksum": "sha1-Kvfb+I/1PCfiBTjoaU4ezZa0b+8=",
+          "checksum": "sha1-3TP2+cHjCEBrIFluCdTmr2oJA1s=",
           "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Zi0e8Bq6WCd/6uXXjVhb8YwMD1U=",
+        "checksum": "Q1WAlPh7UNBV+RHfBixVB5P9F9Mp8=",
         "control": {
-          "checksum": "sha1-Zi0e8Bq6WCd/6uXXjVhb8YwMD1U=",
-          "range": "bytes=700-1073"
+          "checksum": "sha1-WAlPh7UNBV+RHfBixVB5P9F9Mp8=",
+          "range": "bytes=700-1074"
         },
         "data": {
-          "checksum": "sha256-jMhtfqVjnhuuBO7wtNZ6RS/72sZWoKt/Moage2amlks=",
-          "range": "bytes=1074-81594"
+          "checksum": "sha256-i6uEFvUEbJ4YzgNSV58aObIdU608mjbCVPwyF57ZeQQ=",
+          "range": "bytes=1075-81593"
         },
         "name": "protobuf-c",
         "signature": {
-          "checksum": "sha1-kATwMKztK7nk7qbYCJPkCFp6IXc=",
+          "checksum": "sha1-47zwDXmhcWiVtTYCjq4sFld8wHQ=",
           "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r5.apk",
-        "version": "1.5.0-r5"
+        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r6.apk",
+        "version": "1.5.0-r6"
       },
       {
         "architecture": "x86_64",
@@ -204,41 +204,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Q/Zy5ovYSu2p/vVLr6DgVA1e8AQ=",
+        "checksum": "Q1a5wJzZI7k9o4F8hHFpfuqAUIH5Q=",
         "control": {
-          "checksum": "sha1-Q/Zy5ovYSu2p/vVLr6DgVA1e8AQ=",
-          "range": "bytes=699-1062"
+          "checksum": "sha1-a5wJzZI7k9o4F8hHFpfuqAUIH5Q=",
+          "range": "bytes=710-1075"
         },
         "data": {
-          "checksum": "sha256-H3jxsw8ytOeCIR4vq17voSVhdNokXk8C1g075txH6Bs=",
-          "range": "bytes=1063-5903754"
+          "checksum": "sha256-2p1UC4F4Odfxup/J/nyzujYRGaxGVjBOBWoc0aajClI=",
+          "range": "bytes=1076-5903889"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-NIl2f5OI/wSZByI8Ds1ZUfbFWyw=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-SOFoklqXtH38i1PcI3G/cPdRFtY=",
+          "range": "bytes=0-709"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.1-r3.apk",
-        "version": "3.3.1-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.1-r4.apk",
+        "version": "3.3.1-r4"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q13wGUXdZut9OOTdY5z2amUj9wXC0=",
+        "checksum": "Q1gb2VyLOsGV7xUiHBT0Ypt64rw6Y=",
         "control": {
-          "checksum": "sha1-3wGUXdZut9OOTdY5z2amUj9wXC0=",
-          "range": "bytes=698-1068"
+          "checksum": "sha1-gb2VyLOsGV7xUiHBT0Ypt64rw6Y=",
+          "range": "bytes=702-1071"
         },
         "data": {
-          "checksum": "sha256-mRda6+YGlOCczyIWKaHqXskTINoT1rgorHDHqAKAb7c=",
-          "range": "bytes=1069-1188955"
+          "checksum": "sha256-h2tz/aFB2n8SFdBFde5foQm1ru+8JUcGp+trUeA2ZlQ=",
+          "range": "bytes=1072-1188954"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-+UdRc4U3PKw4H9OiNurHKXa5BYk=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-w6U2Pb1Y90u1iBFc/sHg2xn6Qmo=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.1-r3.apk",
-        "version": "3.3.1-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.1-r4.apk",
+        "version": "3.3.1-r4"
       },
       {
         "architecture": "x86_64",
@@ -356,60 +356,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1gfqHM/7r3rXX1HqC163slTPP46o=",
+        "checksum": "Q1DLAp18ebMscosnQ4TfTivIzgtCY=",
         "control": {
-          "checksum": "sha1-gfqHM/7r3rXX1HqC163slTPP46o=",
-          "range": "bytes=704-1101"
+          "checksum": "sha1-DLAp18ebMscosnQ4TfTivIzgtCY=",
+          "range": "bytes=698-1079"
         },
         "data": {
-          "checksum": "sha256-OR7ikvfUYp78EsP0I2kuwqqAcy05jw9tr7JVQ6jTnGQ=",
-          "range": "bytes=1102-185433"
+          "checksum": "sha256-eiBdqqECWnULWGe/Gnd6iv/7h56A4xR2qw+5toY5Gaw=",
+          "range": "bytes=1080-185559"
         },
         "name": "libgcc",
         "signature": {
-          "checksum": "sha1-Il4pyVzI6eqNd/f4bsKeakpB5DI=",
-          "range": "bytes=0-703"
+          "checksum": "sha1-qVj9laNeBIwRxP+8ehB+fXftJrw=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.2.0-r7.apk",
-        "version": "13.2.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r0.apk",
+        "version": "13.3.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1c+lykdx+yHoqsrQmQLHMV7waR1Q=",
+        "checksum": "Q1p9aaHhpB2Ud0URrcIrVRAujMw+o=",
         "control": {
-          "checksum": "sha1-c+lykdx+yHoqsrQmQLHMV7waR1Q=",
-          "range": "bytes=701-1119"
+          "checksum": "sha1-p9aaHhpB2Ud0URrcIrVRAujMw+o=",
+          "range": "bytes=696-1097"
         },
         "data": {
-          "checksum": "sha256-CuZi2C5g0vUnz4PNH8jIWV+EBdVMvHr+sNKFYTSnQZk=",
-          "range": "bytes=1120-3155369"
+          "checksum": "sha256-rGMnyLiGEDCEVgqA1oXMf28QHuWHAaPzYrLeDzQ3WOU=",
+          "range": "bytes=1098-3155519"
         },
         "name": "libstdc++",
         "signature": {
-          "checksum": "sha1-7l8MLj8aCcdqta/0sR+0PscBsD4=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-lge2XoAsgvp8U6ZBgT52N2xNQAw=",
+          "range": "bytes=0-695"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.2.0-r7.apk",
-        "version": "13.2.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r0.apk",
+        "version": "13.3.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1R8OxpY0fGwVaIwft4wJeswF5D54=",
+        "checksum": "Q1DUpLMidX5HbXUAFV8y3Imyt+Ank=",
         "control": {
-          "checksum": "sha1-R8OxpY0fGwVaIwft4wJeswF5D54=",
-          "range": "bytes=695-1059"
+          "checksum": "sha1-DUpLMidX5HbXUAFV8y3Imyt+Ank=",
+          "range": "bytes=698-1063"
         },
         "data": {
-          "checksum": "sha256-wNc8/SBJrGHfwywAtzCsAqeUOt0IaAhqNtlbv8OiHBE=",
-          "range": "bytes=1060-242151"
+          "checksum": "sha256-ZUDWWOBnxl5xi3b5HQCHaiYqKDSrnVpJQgavWpn1duc=",
+          "range": "bytes=1064-255810"
         },
         "name": "c-ares",
         "signature": {
-          "checksum": "sha1-55/PTlEHXI3o0hx9dSVdNwQeSMg=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-0AXk7b/B1baNADDg/NSocbW//pw=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.31.0-r0.apk",
-        "version": "1.31.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.32.1-r0.apk",
+        "version": "1.32.1-r0"
       },
       {
         "architecture": "x86_64",
@@ -470,22 +470,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q10AaU1ocIM4PYYNvwbml8TmpNvEA=",
+        "checksum": "Q1ORn/60iAvLcAgApXYoZzM6o0XSs=",
         "control": {
-          "checksum": "sha1-0AaU1ocIM4PYYNvwbml8TmpNvEA=",
-          "range": "bytes=706-1085"
+          "checksum": "sha1-ORn/60iAvLcAgApXYoZzM6o0XSs=",
+          "range": "bytes=703-1081"
         },
         "data": {
-          "checksum": "sha256-1YQNYASFjlP3kXX58ec8du75ij/U6O4DPAKzJAPkln0=",
-          "range": "bytes=1086-4272589"
+          "checksum": "sha256-Ya2Dn1VNYB21ZBD/jBCSx3SxZuJloJET5xkjX0s3Vt8=",
+          "range": "bytes=1082-4272708"
         },
         "name": "libxml2",
         "signature": {
-          "checksum": "sha1-QFjdplzGn/MiNFxMykgafr6/w6U=",
-          "range": "bytes=0-705"
+          "checksum": "sha1-s5jaTwJdla4k4KK0KEk7AYbgdqs=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.1-r1.apk",
-        "version": "2.13.1-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.2-r0.apk",
+        "version": "2.13.2-r0"
       },
       {
         "architecture": "x86_64",
@@ -546,22 +546,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1+0xClEzF5nhyNPUeGFhC++ElQmg=",
+        "checksum": "Q1u+fF2xg98dT0poYklte5HHMg/Kk=",
         "control": {
-          "checksum": "sha1-+0xClEzF5nhyNPUeGFhC++ElQmg=",
-          "range": "bytes=701-1107"
+          "checksum": "sha1-u+fF2xg98dT0poYklte5HHMg/Kk=",
+          "range": "bytes=701-1090"
         },
         "data": {
-          "checksum": "sha256-81V5R7T08up/3BwfuAG25Rq7KkB1MvALVCaogCpW500=",
-          "range": "bytes=1108-22181"
+          "checksum": "sha256-9e+i7LwSg7oAUU33f0r7A4Mc2suaK95iNU5BKaTSXac=",
+          "range": "bytes=1091-22179"
         },
         "name": "libcrypt1",
         "signature": {
-          "checksum": "sha1-k+7JfhPi5KOQ+6Nqk3oAfTbtOVM=",
+          "checksum": "sha1-EWBUcJqCJTOYJq1H0/kkO+m6W3E=",
           "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",
@@ -926,60 +926,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q159N4eiyaOIItDmaNcUwCEzopOQ0=",
+        "checksum": "Q1Xe6Mab0L6pI1cl1KoyHFFh22EnM=",
         "control": {
-          "checksum": "sha1-59N4eiyaOIItDmaNcUwCEzopOQ0=",
-          "range": "bytes=697-1137"
+          "checksum": "sha1-Xe6Mab0L6pI1cl1KoyHFFh22EnM=",
+          "range": "bytes=699-1127"
         },
         "data": {
-          "checksum": "sha256-YAYeT4S1TlekdgUVFi3Bqt8NUj3sBV1IIKCFkSzDQEM=",
-          "range": "bytes=1138-2550161"
+          "checksum": "sha256-xDHa35D2QjyjAX61JkPzSjbxYP8j+jVdZUolSCqc4Hw=",
+          "range": "bytes=1128-2571512"
         },
         "name": "p11-kit",
         "signature": {
-          "checksum": "sha1-u73VVE8Z2YCPfvy/7dGl9L5WE58=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-xeLkdL2Y2geUmjgmxvBrzYQPJ+A=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/p11-kit-0.25.3-r3.apk",
-        "version": "0.25.3-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/p11-kit-0.25.5-r0.apk",
+        "version": "0.25.5-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1u0Mde9gv6i/Mh7HcW3LtIyfIz2g=",
+        "checksum": "Q1Z6A8qRFoM2Og4D2fJ4qE2pugYo8=",
         "control": {
-          "checksum": "sha1-u0Mde9gv6i/Mh7HcW3LtIyfIz2g=",
-          "range": "bytes=705-1125"
+          "checksum": "sha1-Z6A8qRFoM2Og4D2fJ4qE2pugYo8=",
+          "range": "bytes=704-1108"
         },
         "data": {
-          "checksum": "sha256-cH7wwh2J0IPekB/ODuWjSHpU3pyarrG/XhTdTd3GZ2U=",
-          "range": "bytes=1126-575277"
+          "checksum": "sha256-JYA0kZGsjcz+sYUzzEM2mwcb1T3v/HJNfWMcVMCJE2k=",
+          "range": "bytes=1109-575276"
         },
         "name": "p11-kit-trust",
         "signature": {
-          "checksum": "sha1-BkatHr3xbv9kp95kv5bigMa8HrA=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-R4wCRm0VpFbrL0LTd4MQDOUQy7c=",
+          "range": "bytes=0-703"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/p11-kit-trust-0.25.3-r3.apk",
-        "version": "0.25.3-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/p11-kit-trust-0.25.5-r0.apk",
+        "version": "0.25.5-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1fnaWc3899x9dK4z4iTFNOeM6MI0=",
+        "checksum": "Q1yStY7gve/r3+nnaV+ul/l4zmwpU=",
         "control": {
-          "checksum": "sha1-fnaWc3899x9dK4z4iTFNOeM6MI0=",
-          "range": "bytes=702-1132"
+          "checksum": "sha1-yStY7gve/r3+nnaV+ul/l4zmwpU=",
+          "range": "bytes=699-1128"
         },
         "data": {
-          "checksum": "sha256-rhtsl8eIgOKIHSa3VsedIEj1sA3xRi83jc3fhTjIQLw=",
-          "range": "bytes=1133-377535"
+          "checksum": "sha256-1d/7CyMhSR2oDbLJtN12D1pYniEuQIptX78kAs2ZI14=",
+          "range": "bytes=1129-376508"
         },
         "name": "ca-certificates",
         "signature": {
-          "checksum": "sha1-I1wWFlIzyXu0g5mcgMo/iyW3Mhw=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-EIHhUeKgg6x/sc6JooVgTCBIgOg=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-20240315-r4.apk",
-        "version": "20240315-r4"
+        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-20240705-r0.apk",
+        "version": "20240705-r0"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/bundled-executor.lock.json
+++ b/wolfi-images/bundled-executor.lock.json
@@ -14,117 +14,117 @@
     "packages": [
       {
         "architecture": "x86_64",
-        "checksum": "Q1Ai8jWuxKZR2M2XhOpOGAoTEwnnk=",
+        "checksum": "Q1WR9MGKU+cJh6dJFEXnr3zU1qsMM=",
         "control": {
-          "checksum": "sha1-Ai8jWuxKZR2M2XhOpOGAoTEwnnk=",
-          "range": "bytes=705-1037"
+          "checksum": "sha1-WR9MGKU+cJh6dJFEXnr3zU1qsMM=",
+          "range": "bytes=705-1034"
         },
         "data": {
-          "checksum": "sha256-e4UardkBVyaC49aSyrVmXNi8sSKqQl4eKYd0LxGRLA0=",
-          "range": "bytes=1038-255695"
+          "checksum": "sha256-EkOhtSivoLErXsK2J9ri39thkwb2kJGYHVou4n6dMKA=",
+          "range": "bytes=1035-254654"
         },
         "name": "ca-certificates-bundle",
         "signature": {
-          "checksum": "sha1-loRuyYQLm+atp+YteiQoj++EWIM=",
+          "checksum": "sha1-WL9vKv1nPIeaUQI4O0DiY9RdSHE=",
           "range": "bytes=0-704"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20240315-r4.apk",
-        "version": "20240315-r4"
+        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20240705-r0.apk",
+        "version": "20240705-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1+GH6qRN4iy1IDt0cT0x0tin7YfI=",
+        "checksum": "Q1KmG1L67f+/TnVGcnIcLfWRF/K2g=",
         "control": {
-          "checksum": "sha1-+GH6qRN4iy1IDt0cT0x0tin7YfI=",
-          "range": "bytes=703-1051"
+          "checksum": "sha1-KmG1L67f+/TnVGcnIcLfWRF/K2g=",
+          "range": "bytes=702-1051"
         },
         "data": {
-          "checksum": "sha256-rO0P9z2V49BSrz1A5Ap69tEappVrg5MMBjzW00rOpZc=",
-          "range": "bytes=1052-122464"
+          "checksum": "sha256-2YIxYc/Quit+Kri2qS8p6XvL7taAmOYJU/1Z8RNQ+88=",
+          "range": "bytes=1052-122509"
         },
         "name": "wolfi-baselayout",
         "signature": {
-          "checksum": "sha1-Ntb6VuMzDfM+frpCjKEIpDzl53I=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-VVyPrknEtqCPym5lfhVEuIhfkKg=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r12.apk",
-        "version": "20230201-r12"
+        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r13.apk",
+        "version": "20230201-r13"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q17rD4cKGW3uVSJw02PFiYR719t/Y=",
+        "checksum": "Q1ASyaCJL2Zyz4uAKpPPlx1Sd40yo=",
         "control": {
-          "checksum": "sha1-7rD4cKGW3uVSJw02PFiYR719t/Y=",
-          "range": "bytes=697-1108"
+          "checksum": "sha1-ASyaCJL2Zyz4uAKpPPlx1Sd40yo=",
+          "range": "bytes=706-1101"
         },
         "data": {
-          "checksum": "sha256-GvSViXbvUD0BdV2A+IzVJni2DjLvyM+j14hM29DcsYg=",
-          "range": "bytes=1109-268391"
+          "checksum": "sha256-KoaUrlV3QZ4ATGvKgOmZ1C8Rb/tHK3zEiCTGDrxxc/I=",
+          "range": "bytes=1102-272818"
         },
         "name": "ld-linux",
         "signature": {
-          "checksum": "sha1-nRIFect8o/LOUIEvN17AsrI07dg=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-DBrLE0fWPMyB5/0kAtNlIK6viCU=",
+          "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1/A0wNjkLqqBhe0jFr2D9SKcDNq8=",
+        "checksum": "Q10iHLABsXtuH2JyExQ2IIxH1NUCI=",
         "control": {
-          "checksum": "sha1-/A0wNjkLqqBhe0jFr2D9SKcDNq8=",
-          "range": "bytes=696-1054"
+          "checksum": "sha1-0iHLABsXtuH2JyExQ2IIxH1NUCI=",
+          "range": "bytes=698-1041"
         },
         "data": {
-          "checksum": "sha256-GT22MF6hR+Tj4el5xk2QEwNWig5JRoOrZ60Lecz+lok=",
-          "range": "bytes=1055-408851"
+          "checksum": "sha256-A3RF8XLSIePkapCnvEridXa2N7nheKNT1kTKDqZlGdI=",
+          "range": "bytes=1042-408849"
         },
         "name": "glibc-locale-posix",
         "signature": {
-          "checksum": "sha1-9uPIvcOCeZbPiR7+MLDB4tkJlHo=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-QqrJFnJmyPeT66hUk3O7NxaWY8I=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1YLxq+Z9/+aFnCwvgV7acVLT4QFA=",
+        "checksum": "Q1JYf1zI1zVi/S9sMI32guk6ptuRQ=",
         "control": {
-          "checksum": "sha1-YLxq+Z9/+aFnCwvgV7acVLT4QFA=",
-          "range": "bytes=701-1330"
+          "checksum": "sha1-JYf1zI1zVi/S9sMI32guk6ptuRQ=",
+          "range": "bytes=701-1308"
         },
         "data": {
-          "checksum": "sha256-9s5RNfAJ3GVt7a/fFUaew5MfYYUkvL/6FMvsEfD95jY=",
-          "range": "bytes=1331-5862057"
+          "checksum": "sha256-ioC8korS2nJpJvoS6He+mKkDsgVLcMxiEuYLsAB9M7U=",
+          "range": "bytes=1309-5959239"
         },
         "name": "glibc",
         "signature": {
-          "checksum": "sha1-Kvfb+I/1PCfiBTjoaU4ezZa0b+8=",
+          "checksum": "sha1-3TP2+cHjCEBrIFluCdTmr2oJA1s=",
           "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Zi0e8Bq6WCd/6uXXjVhb8YwMD1U=",
+        "checksum": "Q1WAlPh7UNBV+RHfBixVB5P9F9Mp8=",
         "control": {
-          "checksum": "sha1-Zi0e8Bq6WCd/6uXXjVhb8YwMD1U=",
-          "range": "bytes=700-1073"
+          "checksum": "sha1-WAlPh7UNBV+RHfBixVB5P9F9Mp8=",
+          "range": "bytes=700-1074"
         },
         "data": {
-          "checksum": "sha256-jMhtfqVjnhuuBO7wtNZ6RS/72sZWoKt/Moage2amlks=",
-          "range": "bytes=1074-81594"
+          "checksum": "sha256-i6uEFvUEbJ4YzgNSV58aObIdU608mjbCVPwyF57ZeQQ=",
+          "range": "bytes=1075-81593"
         },
         "name": "protobuf-c",
         "signature": {
-          "checksum": "sha1-kATwMKztK7nk7qbYCJPkCFp6IXc=",
+          "checksum": "sha1-47zwDXmhcWiVtTYCjq4sFld8wHQ=",
           "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r5.apk",
-        "version": "1.5.0-r5"
+        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r6.apk",
+        "version": "1.5.0-r6"
       },
       {
         "architecture": "x86_64",
@@ -204,41 +204,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Q/Zy5ovYSu2p/vVLr6DgVA1e8AQ=",
+        "checksum": "Q1a5wJzZI7k9o4F8hHFpfuqAUIH5Q=",
         "control": {
-          "checksum": "sha1-Q/Zy5ovYSu2p/vVLr6DgVA1e8AQ=",
-          "range": "bytes=699-1062"
+          "checksum": "sha1-a5wJzZI7k9o4F8hHFpfuqAUIH5Q=",
+          "range": "bytes=710-1075"
         },
         "data": {
-          "checksum": "sha256-H3jxsw8ytOeCIR4vq17voSVhdNokXk8C1g075txH6Bs=",
-          "range": "bytes=1063-5903754"
+          "checksum": "sha256-2p1UC4F4Odfxup/J/nyzujYRGaxGVjBOBWoc0aajClI=",
+          "range": "bytes=1076-5903889"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-NIl2f5OI/wSZByI8Ds1ZUfbFWyw=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-SOFoklqXtH38i1PcI3G/cPdRFtY=",
+          "range": "bytes=0-709"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.1-r3.apk",
-        "version": "3.3.1-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.1-r4.apk",
+        "version": "3.3.1-r4"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q13wGUXdZut9OOTdY5z2amUj9wXC0=",
+        "checksum": "Q1gb2VyLOsGV7xUiHBT0Ypt64rw6Y=",
         "control": {
-          "checksum": "sha1-3wGUXdZut9OOTdY5z2amUj9wXC0=",
-          "range": "bytes=698-1068"
+          "checksum": "sha1-gb2VyLOsGV7xUiHBT0Ypt64rw6Y=",
+          "range": "bytes=702-1071"
         },
         "data": {
-          "checksum": "sha256-mRda6+YGlOCczyIWKaHqXskTINoT1rgorHDHqAKAb7c=",
-          "range": "bytes=1069-1188955"
+          "checksum": "sha256-h2tz/aFB2n8SFdBFde5foQm1ru+8JUcGp+trUeA2ZlQ=",
+          "range": "bytes=1072-1188954"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-+UdRc4U3PKw4H9OiNurHKXa5BYk=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-w6U2Pb1Y90u1iBFc/sHg2xn6Qmo=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.1-r3.apk",
-        "version": "3.3.1-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.1-r4.apk",
+        "version": "3.3.1-r4"
       },
       {
         "architecture": "x86_64",
@@ -356,60 +356,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1gfqHM/7r3rXX1HqC163slTPP46o=",
+        "checksum": "Q1DLAp18ebMscosnQ4TfTivIzgtCY=",
         "control": {
-          "checksum": "sha1-gfqHM/7r3rXX1HqC163slTPP46o=",
-          "range": "bytes=704-1101"
+          "checksum": "sha1-DLAp18ebMscosnQ4TfTivIzgtCY=",
+          "range": "bytes=698-1079"
         },
         "data": {
-          "checksum": "sha256-OR7ikvfUYp78EsP0I2kuwqqAcy05jw9tr7JVQ6jTnGQ=",
-          "range": "bytes=1102-185433"
+          "checksum": "sha256-eiBdqqECWnULWGe/Gnd6iv/7h56A4xR2qw+5toY5Gaw=",
+          "range": "bytes=1080-185559"
         },
         "name": "libgcc",
         "signature": {
-          "checksum": "sha1-Il4pyVzI6eqNd/f4bsKeakpB5DI=",
-          "range": "bytes=0-703"
+          "checksum": "sha1-qVj9laNeBIwRxP+8ehB+fXftJrw=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.2.0-r7.apk",
-        "version": "13.2.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r0.apk",
+        "version": "13.3.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1c+lykdx+yHoqsrQmQLHMV7waR1Q=",
+        "checksum": "Q1p9aaHhpB2Ud0URrcIrVRAujMw+o=",
         "control": {
-          "checksum": "sha1-c+lykdx+yHoqsrQmQLHMV7waR1Q=",
-          "range": "bytes=701-1119"
+          "checksum": "sha1-p9aaHhpB2Ud0URrcIrVRAujMw+o=",
+          "range": "bytes=696-1097"
         },
         "data": {
-          "checksum": "sha256-CuZi2C5g0vUnz4PNH8jIWV+EBdVMvHr+sNKFYTSnQZk=",
-          "range": "bytes=1120-3155369"
+          "checksum": "sha256-rGMnyLiGEDCEVgqA1oXMf28QHuWHAaPzYrLeDzQ3WOU=",
+          "range": "bytes=1098-3155519"
         },
         "name": "libstdc++",
         "signature": {
-          "checksum": "sha1-7l8MLj8aCcdqta/0sR+0PscBsD4=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-lge2XoAsgvp8U6ZBgT52N2xNQAw=",
+          "range": "bytes=0-695"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.2.0-r7.apk",
-        "version": "13.2.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r0.apk",
+        "version": "13.3.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1R8OxpY0fGwVaIwft4wJeswF5D54=",
+        "checksum": "Q1DUpLMidX5HbXUAFV8y3Imyt+Ank=",
         "control": {
-          "checksum": "sha1-R8OxpY0fGwVaIwft4wJeswF5D54=",
-          "range": "bytes=695-1059"
+          "checksum": "sha1-DUpLMidX5HbXUAFV8y3Imyt+Ank=",
+          "range": "bytes=698-1063"
         },
         "data": {
-          "checksum": "sha256-wNc8/SBJrGHfwywAtzCsAqeUOt0IaAhqNtlbv8OiHBE=",
-          "range": "bytes=1060-242151"
+          "checksum": "sha256-ZUDWWOBnxl5xi3b5HQCHaiYqKDSrnVpJQgavWpn1duc=",
+          "range": "bytes=1064-255810"
         },
         "name": "c-ares",
         "signature": {
-          "checksum": "sha1-55/PTlEHXI3o0hx9dSVdNwQeSMg=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-0AXk7b/B1baNADDg/NSocbW//pw=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.31.0-r0.apk",
-        "version": "1.31.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.32.1-r0.apk",
+        "version": "1.32.1-r0"
       },
       {
         "architecture": "x86_64",
@@ -470,22 +470,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q10AaU1ocIM4PYYNvwbml8TmpNvEA=",
+        "checksum": "Q1ORn/60iAvLcAgApXYoZzM6o0XSs=",
         "control": {
-          "checksum": "sha1-0AaU1ocIM4PYYNvwbml8TmpNvEA=",
-          "range": "bytes=706-1085"
+          "checksum": "sha1-ORn/60iAvLcAgApXYoZzM6o0XSs=",
+          "range": "bytes=703-1081"
         },
         "data": {
-          "checksum": "sha256-1YQNYASFjlP3kXX58ec8du75ij/U6O4DPAKzJAPkln0=",
-          "range": "bytes=1086-4272589"
+          "checksum": "sha256-Ya2Dn1VNYB21ZBD/jBCSx3SxZuJloJET5xkjX0s3Vt8=",
+          "range": "bytes=1082-4272708"
         },
         "name": "libxml2",
         "signature": {
-          "checksum": "sha1-QFjdplzGn/MiNFxMykgafr6/w6U=",
-          "range": "bytes=0-705"
+          "checksum": "sha1-s5jaTwJdla4k4KK0KEk7AYbgdqs=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.1-r1.apk",
-        "version": "2.13.1-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.2-r0.apk",
+        "version": "2.13.2-r0"
       },
       {
         "architecture": "x86_64",
@@ -546,22 +546,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1+0xClEzF5nhyNPUeGFhC++ElQmg=",
+        "checksum": "Q1u+fF2xg98dT0poYklte5HHMg/Kk=",
         "control": {
-          "checksum": "sha1-+0xClEzF5nhyNPUeGFhC++ElQmg=",
-          "range": "bytes=701-1107"
+          "checksum": "sha1-u+fF2xg98dT0poYklte5HHMg/Kk=",
+          "range": "bytes=701-1090"
         },
         "data": {
-          "checksum": "sha256-81V5R7T08up/3BwfuAG25Rq7KkB1MvALVCaogCpW500=",
-          "range": "bytes=1108-22181"
+          "checksum": "sha256-9e+i7LwSg7oAUU33f0r7A4Mc2suaK95iNU5BKaTSXac=",
+          "range": "bytes=1091-22179"
         },
         "name": "libcrypt1",
         "signature": {
-          "checksum": "sha1-k+7JfhPi5KOQ+6Nqk3oAfTbtOVM=",
+          "checksum": "sha1-EWBUcJqCJTOYJq1H0/kkO+m6W3E=",
           "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",
@@ -584,22 +584,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1fnaWc3899x9dK4z4iTFNOeM6MI0=",
+        "checksum": "Q1yStY7gve/r3+nnaV+ul/l4zmwpU=",
         "control": {
-          "checksum": "sha1-fnaWc3899x9dK4z4iTFNOeM6MI0=",
-          "range": "bytes=702-1132"
+          "checksum": "sha1-yStY7gve/r3+nnaV+ul/l4zmwpU=",
+          "range": "bytes=699-1128"
         },
         "data": {
-          "checksum": "sha256-rhtsl8eIgOKIHSa3VsedIEj1sA3xRi83jc3fhTjIQLw=",
-          "range": "bytes=1133-377535"
+          "checksum": "sha256-1d/7CyMhSR2oDbLJtN12D1pYniEuQIptX78kAs2ZI14=",
+          "range": "bytes=1129-376508"
         },
         "name": "ca-certificates",
         "signature": {
-          "checksum": "sha1-I1wWFlIzyXu0g5mcgMo/iyW3Mhw=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-EIHhUeKgg6x/sc6JooVgTCBIgOg=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-20240315-r4.apk",
-        "version": "20240315-r4"
+        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-20240705-r0.apk",
+        "version": "20240705-r0"
       },
       {
         "architecture": "x86_64",
@@ -983,41 +983,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q159N4eiyaOIItDmaNcUwCEzopOQ0=",
+        "checksum": "Q1Xe6Mab0L6pI1cl1KoyHFFh22EnM=",
         "control": {
-          "checksum": "sha1-59N4eiyaOIItDmaNcUwCEzopOQ0=",
-          "range": "bytes=697-1137"
+          "checksum": "sha1-Xe6Mab0L6pI1cl1KoyHFFh22EnM=",
+          "range": "bytes=699-1127"
         },
         "data": {
-          "checksum": "sha256-YAYeT4S1TlekdgUVFi3Bqt8NUj3sBV1IIKCFkSzDQEM=",
-          "range": "bytes=1138-2550161"
+          "checksum": "sha256-xDHa35D2QjyjAX61JkPzSjbxYP8j+jVdZUolSCqc4Hw=",
+          "range": "bytes=1128-2571512"
         },
         "name": "p11-kit",
         "signature": {
-          "checksum": "sha1-u73VVE8Z2YCPfvy/7dGl9L5WE58=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-xeLkdL2Y2geUmjgmxvBrzYQPJ+A=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/p11-kit-0.25.3-r3.apk",
-        "version": "0.25.3-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/p11-kit-0.25.5-r0.apk",
+        "version": "0.25.5-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1u0Mde9gv6i/Mh7HcW3LtIyfIz2g=",
+        "checksum": "Q1Z6A8qRFoM2Og4D2fJ4qE2pugYo8=",
         "control": {
-          "checksum": "sha1-u0Mde9gv6i/Mh7HcW3LtIyfIz2g=",
-          "range": "bytes=705-1125"
+          "checksum": "sha1-Z6A8qRFoM2Og4D2fJ4qE2pugYo8=",
+          "range": "bytes=704-1108"
         },
         "data": {
-          "checksum": "sha256-cH7wwh2J0IPekB/ODuWjSHpU3pyarrG/XhTdTd3GZ2U=",
-          "range": "bytes=1126-575277"
+          "checksum": "sha256-JYA0kZGsjcz+sYUzzEM2mwcb1T3v/HJNfWMcVMCJE2k=",
+          "range": "bytes=1109-575276"
         },
         "name": "p11-kit-trust",
         "signature": {
-          "checksum": "sha1-BkatHr3xbv9kp95kv5bigMa8HrA=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-R4wCRm0VpFbrL0LTd4MQDOUQy7c=",
+          "range": "bytes=0-703"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/p11-kit-trust-0.25.3-r3.apk",
-        "version": "0.25.3-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/p11-kit-trust-0.25.5-r0.apk",
+        "version": "0.25.5-r0"
       },
       {
         "architecture": "x86_64",
@@ -1135,60 +1135,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ibJSAAe0yAmeC3Sp9K+672q3eKg=",
+        "checksum": "Q15bwVoaq1Noe1m3R1UrRBlJGLGSM=",
         "control": {
-          "checksum": "sha1-ibJSAAe0yAmeC3Sp9K+672q3eKg=",
-          "range": "bytes=704-1060"
+          "checksum": "sha1-5bwVoaq1Noe1m3R1UrRBlJGLGSM=",
+          "range": "bytes=702-1043"
         },
         "data": {
-          "checksum": "sha256-Qdx821f7/tO71EyPPGGyuTZlK4If05eUDqMkGTNYzdw=",
-          "range": "bytes=1061-603623"
+          "checksum": "sha256-RUfH3pZt5PBG2RCxX2qGzc0JK+BWQ3BfabP8B3Zjkyo=",
+          "range": "bytes=1044-605796"
         },
         "name": "ncurses-terminfo-base",
         "signature": {
-          "checksum": "sha1-hFLJnjW3MeXzjutUUaMVz+pq774=",
-          "range": "bytes=0-703"
+          "checksum": "sha1-qOe+XIaqWDBfRGrODGmvZj+PGs8=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ncurses-terminfo-base-6.4_p20231125-r3.apk",
-        "version": "6.4_p20231125-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/ncurses-terminfo-base-6.5_p20240629-r0.apk",
+        "version": "6.5_p20240629-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ggdVedzys8c0/DPbL/8uVM0IeHM=",
+        "checksum": "Q1UbEaadDhtuSAInuPjntJMZefM4U=",
         "control": {
-          "checksum": "sha1-ggdVedzys8c0/DPbL/8uVM0IeHM=",
-          "range": "bytes=697-1165"
+          "checksum": "sha1-UbEaadDhtuSAInuPjntJMZefM4U=",
+          "range": "bytes=698-1152"
         },
         "data": {
-          "checksum": "sha256-7NLgBuaKCCXSTXXEZ48mE9pTOgyoOY6yHLR2cW0LdGM=",
-          "range": "bytes=1166-1048223"
+          "checksum": "sha256-gkm/MRL/YRxHkRROZEW/TSWGC7r+ZAqogwd0Umio3LU=",
+          "range": "bytes=1153-1065345"
         },
         "name": "ncurses",
         "signature": {
-          "checksum": "sha1-50wXsiR3GgiiLwsWICdXEagYHRE=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-NLFv0xzWR8uGe+4SFVz9mAZDn/k=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ncurses-6.4_p20231125-r3.apk",
-        "version": "6.4_p20231125-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/ncurses-6.5_p20240629-r0.apk",
+        "version": "6.5_p20240629-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q19lUpYPaVnv70kshfW0v/13XTNXc=",
+        "checksum": "Q1PHgnhvSy0SxqgLQc4V4dtaQ6sUo=",
         "control": {
-          "checksum": "sha1-9lUpYPaVnv70kshfW0v/13XTNXc=",
-          "range": "bytes=697-1146"
+          "checksum": "sha1-PHgnhvSy0SxqgLQc4V4dtaQ6sUo=",
+          "range": "bytes=699-1133"
         },
         "data": {
-          "checksum": "sha256-9Gn07toI1MChIgfXnxaTJQ6cH9BEG2bHmq2cYNSO9cU=",
-          "range": "bytes=1147-996427"
+          "checksum": "sha256-azs/Gn4jbpFwPIosLxAIQK9cuIRi/a4HWD9kOzi2whE=",
+          "range": "bytes=1134-1124576"
         },
         "name": "gdbm",
         "signature": {
-          "checksum": "sha1-iBmI2lW1dZcunxPMZXI29oayzBQ=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-62Pf1vhZGGdtLkZwFXpTAb7xiG0=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/gdbm-1.23-r6.apk",
-        "version": "1.23-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/gdbm-1.24-r0.apk",
+        "version": "1.24-r0"
       },
       {
         "architecture": "x86_64",
@@ -1268,60 +1268,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1j+Qxn4qwORrfXr0pkQKENYAJqo0=",
+        "checksum": "Q1NquwUqjJVn+RoszVjwvyMQj7rnw=",
         "control": {
-          "checksum": "sha1-j+Qxn4qwORrfXr0pkQKENYAJqo0=",
-          "range": "bytes=700-1074"
+          "checksum": "sha1-NquwUqjJVn+RoszVjwvyMQj7rnw=",
+          "range": "bytes=702-1077"
         },
         "data": {
-          "checksum": "sha256-p2z0o9bhigV/yoZAck/M6QjCKRYLvNrViRt615Olc3k=",
-          "range": "bytes=1075-6690059"
+          "checksum": "sha256-IPUd613079ZujgZOJry0j7GmxVwQxVLCXT+4CSmv4Qs=",
+          "range": "bytes=1078-7049609"
         },
         "name": "py3.12-setuptools",
         "signature": {
-          "checksum": "sha1-BAfOowj9atVLZDo2nm8XoBQ5bQo=",
-          "range": "bytes=0-699"
+          "checksum": "sha1-zZuhQTy9T+3RBGIYXdb1hGdSTOg=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/py3.12-setuptools-70.1.1-r1.apk",
-        "version": "70.1.1-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/py3.12-setuptools-70.3.0-r0.apk",
+        "version": "70.3.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1jcGRQarIsLr8mdYzf2GP7eRIhak=",
+        "checksum": "Q1BDPrZm/6hQZxp/gQMaJ5Mo9w9xI=",
         "control": {
-          "checksum": "sha1-jcGRQarIsLr8mdYzf2GP7eRIhak=",
-          "range": "bytes=698-1090"
+          "checksum": "sha1-BDPrZm/6hQZxp/gQMaJ5Mo9w9xI=",
+          "range": "bytes=707-1095"
         },
         "data": {
-          "checksum": "sha256-Aaz7A2/NS1VmDZ+x/HuBKXdEQYAZjyJFWRnImqD7Ih0=",
-          "range": "bytes=1091-11409283"
+          "checksum": "sha256-UDWAX+y+rceu3uKCVISvmZbG/RZ2jeTfAp6USOASipY=",
+          "range": "bytes=1096-11410069"
         },
         "name": "py3.12-pip-base",
         "signature": {
-          "checksum": "sha1-LZSoowKk3DtT7DEvEeJn7V1RT1s=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-QJSsFWlZUT681eOmnE86K5zY964=",
+          "range": "bytes=0-706"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/py3.12-pip-base-24.1.1-r0.apk",
-        "version": "24.1.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/py3.12-pip-base-24.1.2-r0.apk",
+        "version": "24.1.2-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1zzil7wXlx7KyR4/c7AkAepkVNOc=",
+        "checksum": "Q1wdaDK+LP3jGDtEW1s7O6mZeWpCg=",
         "control": {
-          "checksum": "sha1-zzil7wXlx7KyR4/c7AkAepkVNOc=",
-          "range": "bytes=698-1103"
+          "checksum": "sha1-wdaDK+LP3jGDtEW1s7O6mZeWpCg=",
+          "range": "bytes=698-1102"
         },
         "data": {
-          "checksum": "sha256-/baopsKdhGeMlVDpNAXQ/Wr7Dqe8o0Ms05Dn8vn3JsA=",
-          "range": "bytes=1104-30867"
+          "checksum": "sha256-J5N8o+3301AgN7kIom6mRV8UEybFTYcohYq6hDEC9Ys=",
+          "range": "bytes=1103-30866"
         },
         "name": "py3.12-pip",
         "signature": {
-          "checksum": "sha1-PDt1UH3nhWeFFz5ilfp5lYzfvMw=",
+          "checksum": "sha1-iB7RXmkTID2j/3l1J2xOCWjvASI=",
           "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/py3.12-pip-24.1.1-r0.apk",
-        "version": "24.1.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/py3.12-pip-24.1.2-r0.apk",
+        "version": "24.1.2-r0"
       },
       {
         "architecture": "x86_64",
@@ -1401,22 +1401,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ICMLmx9XiN02gWP7VDgljQEw/aE=",
+        "checksum": "Q1qAUv8EOKgGekpn4RPg1AJ8JniWg=",
         "control": {
-          "checksum": "sha1-ICMLmx9XiN02gWP7VDgljQEw/aE=",
-          "range": "bytes=700-1115"
+          "checksum": "sha1-qAUv8EOKgGekpn4RPg1AJ8JniWg=",
+          "range": "bytes=705-1121"
         },
         "data": {
-          "checksum": "sha256-oca0wmxt4WsIt8ewErEndJ1L0umSFFqGuX0eKmwhLKA=",
-          "range": "bytes=1116-1105656"
+          "checksum": "sha256-gzOMTZy3XWBPsozhqgwJAHKTQa5GuDsu4wuYOU9mxZc=",
+          "range": "bytes=1122-1105395"
         },
         "name": "libxslt",
         "signature": {
-          "checksum": "sha1-KqSVkzLzQCpeMAXPEr4kuzRZJPo=",
-          "range": "bytes=0-699"
+          "checksum": "sha1-yOtbVtsuWEAbnGKaVNSrEEAfd48=",
+          "range": "bytes=0-704"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxslt-1.1.41-r1.apk",
-        "version": "1.1.41-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxslt-1.1.42-r0.apk",
+        "version": "1.1.42-r0"
       },
       {
         "architecture": "x86_64",
@@ -1439,22 +1439,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1POMkB+OGZU68Oyy1bPHttaBWrKQ=",
+        "checksum": "Q1OE9Tcv5FRM2R59X1GeBqhBSjO2c=",
         "control": {
-          "checksum": "sha1-POMkB+OGZU68Oyy1bPHttaBWrKQ=",
-          "range": "bytes=702-1082"
+          "checksum": "sha1-OE9Tcv5FRM2R59X1GeBqhBSjO2c=",
+          "range": "bytes=701-1083"
         },
         "data": {
-          "checksum": "sha256-2wD/1bLmSgMNDa3dm9wx0831vCi3zcZYCDxIHeoKHAo=",
-          "range": "bytes=1083-10722853"
+          "checksum": "sha256-G20U3AWP68ABai8Co/Yw7FURY39/cGwhZlAe2G0C1cM=",
+          "range": "bytes=1084-10723002"
         },
         "name": "yq",
         "signature": {
-          "checksum": "sha1-Db9wFCBDYnYkT73rwdOa8SiS+pw=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-pLMmu1lquvuF098yf/9+Vbk33YU=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/yq-4.44.2-r0.apk",
-        "version": "4.44.2-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/yq-4.44.2-r1.apk",
+        "version": "4.44.2-r1"
       }
     ],
     "repositories": [

--- a/wolfi-images/caddy.lock.json
+++ b/wolfi-images/caddy.lock.json
@@ -14,117 +14,117 @@
     "packages": [
       {
         "architecture": "x86_64",
-        "checksum": "Q1Ai8jWuxKZR2M2XhOpOGAoTEwnnk=",
+        "checksum": "Q1WR9MGKU+cJh6dJFEXnr3zU1qsMM=",
         "control": {
-          "checksum": "sha1-Ai8jWuxKZR2M2XhOpOGAoTEwnnk=",
-          "range": "bytes=705-1037"
+          "checksum": "sha1-WR9MGKU+cJh6dJFEXnr3zU1qsMM=",
+          "range": "bytes=705-1034"
         },
         "data": {
-          "checksum": "sha256-e4UardkBVyaC49aSyrVmXNi8sSKqQl4eKYd0LxGRLA0=",
-          "range": "bytes=1038-255695"
+          "checksum": "sha256-EkOhtSivoLErXsK2J9ri39thkwb2kJGYHVou4n6dMKA=",
+          "range": "bytes=1035-254654"
         },
         "name": "ca-certificates-bundle",
         "signature": {
-          "checksum": "sha1-loRuyYQLm+atp+YteiQoj++EWIM=",
+          "checksum": "sha1-WL9vKv1nPIeaUQI4O0DiY9RdSHE=",
           "range": "bytes=0-704"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20240315-r4.apk",
-        "version": "20240315-r4"
+        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20240705-r0.apk",
+        "version": "20240705-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1+GH6qRN4iy1IDt0cT0x0tin7YfI=",
+        "checksum": "Q1KmG1L67f+/TnVGcnIcLfWRF/K2g=",
         "control": {
-          "checksum": "sha1-+GH6qRN4iy1IDt0cT0x0tin7YfI=",
-          "range": "bytes=703-1051"
+          "checksum": "sha1-KmG1L67f+/TnVGcnIcLfWRF/K2g=",
+          "range": "bytes=702-1051"
         },
         "data": {
-          "checksum": "sha256-rO0P9z2V49BSrz1A5Ap69tEappVrg5MMBjzW00rOpZc=",
-          "range": "bytes=1052-122464"
+          "checksum": "sha256-2YIxYc/Quit+Kri2qS8p6XvL7taAmOYJU/1Z8RNQ+88=",
+          "range": "bytes=1052-122509"
         },
         "name": "wolfi-baselayout",
         "signature": {
-          "checksum": "sha1-Ntb6VuMzDfM+frpCjKEIpDzl53I=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-VVyPrknEtqCPym5lfhVEuIhfkKg=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r12.apk",
-        "version": "20230201-r12"
+        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r13.apk",
+        "version": "20230201-r13"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q17rD4cKGW3uVSJw02PFiYR719t/Y=",
+        "checksum": "Q1ASyaCJL2Zyz4uAKpPPlx1Sd40yo=",
         "control": {
-          "checksum": "sha1-7rD4cKGW3uVSJw02PFiYR719t/Y=",
-          "range": "bytes=697-1108"
+          "checksum": "sha1-ASyaCJL2Zyz4uAKpPPlx1Sd40yo=",
+          "range": "bytes=706-1101"
         },
         "data": {
-          "checksum": "sha256-GvSViXbvUD0BdV2A+IzVJni2DjLvyM+j14hM29DcsYg=",
-          "range": "bytes=1109-268391"
+          "checksum": "sha256-KoaUrlV3QZ4ATGvKgOmZ1C8Rb/tHK3zEiCTGDrxxc/I=",
+          "range": "bytes=1102-272818"
         },
         "name": "ld-linux",
         "signature": {
-          "checksum": "sha1-nRIFect8o/LOUIEvN17AsrI07dg=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-DBrLE0fWPMyB5/0kAtNlIK6viCU=",
+          "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1/A0wNjkLqqBhe0jFr2D9SKcDNq8=",
+        "checksum": "Q10iHLABsXtuH2JyExQ2IIxH1NUCI=",
         "control": {
-          "checksum": "sha1-/A0wNjkLqqBhe0jFr2D9SKcDNq8=",
-          "range": "bytes=696-1054"
+          "checksum": "sha1-0iHLABsXtuH2JyExQ2IIxH1NUCI=",
+          "range": "bytes=698-1041"
         },
         "data": {
-          "checksum": "sha256-GT22MF6hR+Tj4el5xk2QEwNWig5JRoOrZ60Lecz+lok=",
-          "range": "bytes=1055-408851"
+          "checksum": "sha256-A3RF8XLSIePkapCnvEridXa2N7nheKNT1kTKDqZlGdI=",
+          "range": "bytes=1042-408849"
         },
         "name": "glibc-locale-posix",
         "signature": {
-          "checksum": "sha1-9uPIvcOCeZbPiR7+MLDB4tkJlHo=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-QqrJFnJmyPeT66hUk3O7NxaWY8I=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1YLxq+Z9/+aFnCwvgV7acVLT4QFA=",
+        "checksum": "Q1JYf1zI1zVi/S9sMI32guk6ptuRQ=",
         "control": {
-          "checksum": "sha1-YLxq+Z9/+aFnCwvgV7acVLT4QFA=",
-          "range": "bytes=701-1330"
+          "checksum": "sha1-JYf1zI1zVi/S9sMI32guk6ptuRQ=",
+          "range": "bytes=701-1308"
         },
         "data": {
-          "checksum": "sha256-9s5RNfAJ3GVt7a/fFUaew5MfYYUkvL/6FMvsEfD95jY=",
-          "range": "bytes=1331-5862057"
+          "checksum": "sha256-ioC8korS2nJpJvoS6He+mKkDsgVLcMxiEuYLsAB9M7U=",
+          "range": "bytes=1309-5959239"
         },
         "name": "glibc",
         "signature": {
-          "checksum": "sha1-Kvfb+I/1PCfiBTjoaU4ezZa0b+8=",
+          "checksum": "sha1-3TP2+cHjCEBrIFluCdTmr2oJA1s=",
           "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Zi0e8Bq6WCd/6uXXjVhb8YwMD1U=",
+        "checksum": "Q1WAlPh7UNBV+RHfBixVB5P9F9Mp8=",
         "control": {
-          "checksum": "sha1-Zi0e8Bq6WCd/6uXXjVhb8YwMD1U=",
-          "range": "bytes=700-1073"
+          "checksum": "sha1-WAlPh7UNBV+RHfBixVB5P9F9Mp8=",
+          "range": "bytes=700-1074"
         },
         "data": {
-          "checksum": "sha256-jMhtfqVjnhuuBO7wtNZ6RS/72sZWoKt/Moage2amlks=",
-          "range": "bytes=1074-81594"
+          "checksum": "sha256-i6uEFvUEbJ4YzgNSV58aObIdU608mjbCVPwyF57ZeQQ=",
+          "range": "bytes=1075-81593"
         },
         "name": "protobuf-c",
         "signature": {
-          "checksum": "sha1-kATwMKztK7nk7qbYCJPkCFp6IXc=",
+          "checksum": "sha1-47zwDXmhcWiVtTYCjq4sFld8wHQ=",
           "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r5.apk",
-        "version": "1.5.0-r5"
+        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r6.apk",
+        "version": "1.5.0-r6"
       },
       {
         "architecture": "x86_64",
@@ -204,41 +204,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Q/Zy5ovYSu2p/vVLr6DgVA1e8AQ=",
+        "checksum": "Q1a5wJzZI7k9o4F8hHFpfuqAUIH5Q=",
         "control": {
-          "checksum": "sha1-Q/Zy5ovYSu2p/vVLr6DgVA1e8AQ=",
-          "range": "bytes=699-1062"
+          "checksum": "sha1-a5wJzZI7k9o4F8hHFpfuqAUIH5Q=",
+          "range": "bytes=710-1075"
         },
         "data": {
-          "checksum": "sha256-H3jxsw8ytOeCIR4vq17voSVhdNokXk8C1g075txH6Bs=",
-          "range": "bytes=1063-5903754"
+          "checksum": "sha256-2p1UC4F4Odfxup/J/nyzujYRGaxGVjBOBWoc0aajClI=",
+          "range": "bytes=1076-5903889"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-NIl2f5OI/wSZByI8Ds1ZUfbFWyw=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-SOFoklqXtH38i1PcI3G/cPdRFtY=",
+          "range": "bytes=0-709"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.1-r3.apk",
-        "version": "3.3.1-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.1-r4.apk",
+        "version": "3.3.1-r4"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q13wGUXdZut9OOTdY5z2amUj9wXC0=",
+        "checksum": "Q1gb2VyLOsGV7xUiHBT0Ypt64rw6Y=",
         "control": {
-          "checksum": "sha1-3wGUXdZut9OOTdY5z2amUj9wXC0=",
-          "range": "bytes=698-1068"
+          "checksum": "sha1-gb2VyLOsGV7xUiHBT0Ypt64rw6Y=",
+          "range": "bytes=702-1071"
         },
         "data": {
-          "checksum": "sha256-mRda6+YGlOCczyIWKaHqXskTINoT1rgorHDHqAKAb7c=",
-          "range": "bytes=1069-1188955"
+          "checksum": "sha256-h2tz/aFB2n8SFdBFde5foQm1ru+8JUcGp+trUeA2ZlQ=",
+          "range": "bytes=1072-1188954"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-+UdRc4U3PKw4H9OiNurHKXa5BYk=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-w6U2Pb1Y90u1iBFc/sHg2xn6Qmo=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.1-r3.apk",
-        "version": "3.3.1-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.1-r4.apk",
+        "version": "3.3.1-r4"
       },
       {
         "architecture": "x86_64",
@@ -356,60 +356,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1gfqHM/7r3rXX1HqC163slTPP46o=",
+        "checksum": "Q1DLAp18ebMscosnQ4TfTivIzgtCY=",
         "control": {
-          "checksum": "sha1-gfqHM/7r3rXX1HqC163slTPP46o=",
-          "range": "bytes=704-1101"
+          "checksum": "sha1-DLAp18ebMscosnQ4TfTivIzgtCY=",
+          "range": "bytes=698-1079"
         },
         "data": {
-          "checksum": "sha256-OR7ikvfUYp78EsP0I2kuwqqAcy05jw9tr7JVQ6jTnGQ=",
-          "range": "bytes=1102-185433"
+          "checksum": "sha256-eiBdqqECWnULWGe/Gnd6iv/7h56A4xR2qw+5toY5Gaw=",
+          "range": "bytes=1080-185559"
         },
         "name": "libgcc",
         "signature": {
-          "checksum": "sha1-Il4pyVzI6eqNd/f4bsKeakpB5DI=",
-          "range": "bytes=0-703"
+          "checksum": "sha1-qVj9laNeBIwRxP+8ehB+fXftJrw=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.2.0-r7.apk",
-        "version": "13.2.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r0.apk",
+        "version": "13.3.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1c+lykdx+yHoqsrQmQLHMV7waR1Q=",
+        "checksum": "Q1p9aaHhpB2Ud0URrcIrVRAujMw+o=",
         "control": {
-          "checksum": "sha1-c+lykdx+yHoqsrQmQLHMV7waR1Q=",
-          "range": "bytes=701-1119"
+          "checksum": "sha1-p9aaHhpB2Ud0URrcIrVRAujMw+o=",
+          "range": "bytes=696-1097"
         },
         "data": {
-          "checksum": "sha256-CuZi2C5g0vUnz4PNH8jIWV+EBdVMvHr+sNKFYTSnQZk=",
-          "range": "bytes=1120-3155369"
+          "checksum": "sha256-rGMnyLiGEDCEVgqA1oXMf28QHuWHAaPzYrLeDzQ3WOU=",
+          "range": "bytes=1098-3155519"
         },
         "name": "libstdc++",
         "signature": {
-          "checksum": "sha1-7l8MLj8aCcdqta/0sR+0PscBsD4=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-lge2XoAsgvp8U6ZBgT52N2xNQAw=",
+          "range": "bytes=0-695"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.2.0-r7.apk",
-        "version": "13.2.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r0.apk",
+        "version": "13.3.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1R8OxpY0fGwVaIwft4wJeswF5D54=",
+        "checksum": "Q1DUpLMidX5HbXUAFV8y3Imyt+Ank=",
         "control": {
-          "checksum": "sha1-R8OxpY0fGwVaIwft4wJeswF5D54=",
-          "range": "bytes=695-1059"
+          "checksum": "sha1-DUpLMidX5HbXUAFV8y3Imyt+Ank=",
+          "range": "bytes=698-1063"
         },
         "data": {
-          "checksum": "sha256-wNc8/SBJrGHfwywAtzCsAqeUOt0IaAhqNtlbv8OiHBE=",
-          "range": "bytes=1060-242151"
+          "checksum": "sha256-ZUDWWOBnxl5xi3b5HQCHaiYqKDSrnVpJQgavWpn1duc=",
+          "range": "bytes=1064-255810"
         },
         "name": "c-ares",
         "signature": {
-          "checksum": "sha1-55/PTlEHXI3o0hx9dSVdNwQeSMg=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-0AXk7b/B1baNADDg/NSocbW//pw=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.31.0-r0.apk",
-        "version": "1.31.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.32.1-r0.apk",
+        "version": "1.32.1-r0"
       },
       {
         "architecture": "x86_64",
@@ -470,22 +470,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q10AaU1ocIM4PYYNvwbml8TmpNvEA=",
+        "checksum": "Q1ORn/60iAvLcAgApXYoZzM6o0XSs=",
         "control": {
-          "checksum": "sha1-0AaU1ocIM4PYYNvwbml8TmpNvEA=",
-          "range": "bytes=706-1085"
+          "checksum": "sha1-ORn/60iAvLcAgApXYoZzM6o0XSs=",
+          "range": "bytes=703-1081"
         },
         "data": {
-          "checksum": "sha256-1YQNYASFjlP3kXX58ec8du75ij/U6O4DPAKzJAPkln0=",
-          "range": "bytes=1086-4272589"
+          "checksum": "sha256-Ya2Dn1VNYB21ZBD/jBCSx3SxZuJloJET5xkjX0s3Vt8=",
+          "range": "bytes=1082-4272708"
         },
         "name": "libxml2",
         "signature": {
-          "checksum": "sha1-QFjdplzGn/MiNFxMykgafr6/w6U=",
-          "range": "bytes=0-705"
+          "checksum": "sha1-s5jaTwJdla4k4KK0KEk7AYbgdqs=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.1-r1.apk",
-        "version": "2.13.1-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.2-r0.apk",
+        "version": "2.13.2-r0"
       },
       {
         "architecture": "x86_64",
@@ -546,22 +546,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1+0xClEzF5nhyNPUeGFhC++ElQmg=",
+        "checksum": "Q1u+fF2xg98dT0poYklte5HHMg/Kk=",
         "control": {
-          "checksum": "sha1-+0xClEzF5nhyNPUeGFhC++ElQmg=",
-          "range": "bytes=701-1107"
+          "checksum": "sha1-u+fF2xg98dT0poYklte5HHMg/Kk=",
+          "range": "bytes=701-1090"
         },
         "data": {
-          "checksum": "sha256-81V5R7T08up/3BwfuAG25Rq7KkB1MvALVCaogCpW500=",
-          "range": "bytes=1108-22181"
+          "checksum": "sha256-9e+i7LwSg7oAUU33f0r7A4Mc2suaK95iNU5BKaTSXac=",
+          "range": "bytes=1091-22179"
         },
         "name": "libcrypt1",
         "signature": {
-          "checksum": "sha1-k+7JfhPi5KOQ+6Nqk3oAfTbtOVM=",
+          "checksum": "sha1-EWBUcJqCJTOYJq1H0/kkO+m6W3E=",
           "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",
@@ -584,22 +584,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1PGSGzKPMVw90aYlMlNUdARgMDfc=",
+        "checksum": "Q1hB4bh/iEdsn9qLpCJUCFix+7mgM=",
         "control": {
-          "checksum": "sha1-PGSGzKPMVw90aYlMlNUdARgMDfc=",
-          "range": "bytes=701-1099"
+          "checksum": "sha1-hB4bh/iEdsn9qLpCJUCFix+7mgM=",
+          "range": "bytes=696-1079"
         },
         "data": {
-          "checksum": "sha256-QjsHuaC1mVOumuyNSPOcx8mjPqaV7s/nl1z1FUQEE8w=",
-          "range": "bytes=1100-42588288"
+          "checksum": "sha256-/lijqtQR3b/u7s8t/SU60R66T2L4ipW57W27LlZmiH8=",
+          "range": "bytes=1080-42588435"
         },
         "name": "caddy",
         "signature": {
-          "checksum": "sha1-0lXh76iWNLGfC4EgObKUoP0CxZ4=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-E6Ho7lrC0XkzvNWwp5TayimgiOY=",
+          "range": "bytes=0-695"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/caddy-2.8.4-r1.apk",
-        "version": "2.8.4-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/caddy-2.8.4-r2.apk",
+        "version": "2.8.4-r2"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/cadvisor.lock.json
+++ b/wolfi-images/cadvisor.lock.json
@@ -14,117 +14,117 @@
     "packages": [
       {
         "architecture": "x86_64",
-        "checksum": "Q1Ai8jWuxKZR2M2XhOpOGAoTEwnnk=",
+        "checksum": "Q1WR9MGKU+cJh6dJFEXnr3zU1qsMM=",
         "control": {
-          "checksum": "sha1-Ai8jWuxKZR2M2XhOpOGAoTEwnnk=",
-          "range": "bytes=705-1037"
+          "checksum": "sha1-WR9MGKU+cJh6dJFEXnr3zU1qsMM=",
+          "range": "bytes=705-1034"
         },
         "data": {
-          "checksum": "sha256-e4UardkBVyaC49aSyrVmXNi8sSKqQl4eKYd0LxGRLA0=",
-          "range": "bytes=1038-255695"
+          "checksum": "sha256-EkOhtSivoLErXsK2J9ri39thkwb2kJGYHVou4n6dMKA=",
+          "range": "bytes=1035-254654"
         },
         "name": "ca-certificates-bundle",
         "signature": {
-          "checksum": "sha1-loRuyYQLm+atp+YteiQoj++EWIM=",
+          "checksum": "sha1-WL9vKv1nPIeaUQI4O0DiY9RdSHE=",
           "range": "bytes=0-704"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20240315-r4.apk",
-        "version": "20240315-r4"
+        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20240705-r0.apk",
+        "version": "20240705-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1+GH6qRN4iy1IDt0cT0x0tin7YfI=",
+        "checksum": "Q1KmG1L67f+/TnVGcnIcLfWRF/K2g=",
         "control": {
-          "checksum": "sha1-+GH6qRN4iy1IDt0cT0x0tin7YfI=",
-          "range": "bytes=703-1051"
+          "checksum": "sha1-KmG1L67f+/TnVGcnIcLfWRF/K2g=",
+          "range": "bytes=702-1051"
         },
         "data": {
-          "checksum": "sha256-rO0P9z2V49BSrz1A5Ap69tEappVrg5MMBjzW00rOpZc=",
-          "range": "bytes=1052-122464"
+          "checksum": "sha256-2YIxYc/Quit+Kri2qS8p6XvL7taAmOYJU/1Z8RNQ+88=",
+          "range": "bytes=1052-122509"
         },
         "name": "wolfi-baselayout",
         "signature": {
-          "checksum": "sha1-Ntb6VuMzDfM+frpCjKEIpDzl53I=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-VVyPrknEtqCPym5lfhVEuIhfkKg=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r12.apk",
-        "version": "20230201-r12"
+        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r13.apk",
+        "version": "20230201-r13"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q17rD4cKGW3uVSJw02PFiYR719t/Y=",
+        "checksum": "Q1ASyaCJL2Zyz4uAKpPPlx1Sd40yo=",
         "control": {
-          "checksum": "sha1-7rD4cKGW3uVSJw02PFiYR719t/Y=",
-          "range": "bytes=697-1108"
+          "checksum": "sha1-ASyaCJL2Zyz4uAKpPPlx1Sd40yo=",
+          "range": "bytes=706-1101"
         },
         "data": {
-          "checksum": "sha256-GvSViXbvUD0BdV2A+IzVJni2DjLvyM+j14hM29DcsYg=",
-          "range": "bytes=1109-268391"
+          "checksum": "sha256-KoaUrlV3QZ4ATGvKgOmZ1C8Rb/tHK3zEiCTGDrxxc/I=",
+          "range": "bytes=1102-272818"
         },
         "name": "ld-linux",
         "signature": {
-          "checksum": "sha1-nRIFect8o/LOUIEvN17AsrI07dg=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-DBrLE0fWPMyB5/0kAtNlIK6viCU=",
+          "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1/A0wNjkLqqBhe0jFr2D9SKcDNq8=",
+        "checksum": "Q10iHLABsXtuH2JyExQ2IIxH1NUCI=",
         "control": {
-          "checksum": "sha1-/A0wNjkLqqBhe0jFr2D9SKcDNq8=",
-          "range": "bytes=696-1054"
+          "checksum": "sha1-0iHLABsXtuH2JyExQ2IIxH1NUCI=",
+          "range": "bytes=698-1041"
         },
         "data": {
-          "checksum": "sha256-GT22MF6hR+Tj4el5xk2QEwNWig5JRoOrZ60Lecz+lok=",
-          "range": "bytes=1055-408851"
+          "checksum": "sha256-A3RF8XLSIePkapCnvEridXa2N7nheKNT1kTKDqZlGdI=",
+          "range": "bytes=1042-408849"
         },
         "name": "glibc-locale-posix",
         "signature": {
-          "checksum": "sha1-9uPIvcOCeZbPiR7+MLDB4tkJlHo=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-QqrJFnJmyPeT66hUk3O7NxaWY8I=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1YLxq+Z9/+aFnCwvgV7acVLT4QFA=",
+        "checksum": "Q1JYf1zI1zVi/S9sMI32guk6ptuRQ=",
         "control": {
-          "checksum": "sha1-YLxq+Z9/+aFnCwvgV7acVLT4QFA=",
-          "range": "bytes=701-1330"
+          "checksum": "sha1-JYf1zI1zVi/S9sMI32guk6ptuRQ=",
+          "range": "bytes=701-1308"
         },
         "data": {
-          "checksum": "sha256-9s5RNfAJ3GVt7a/fFUaew5MfYYUkvL/6FMvsEfD95jY=",
-          "range": "bytes=1331-5862057"
+          "checksum": "sha256-ioC8korS2nJpJvoS6He+mKkDsgVLcMxiEuYLsAB9M7U=",
+          "range": "bytes=1309-5959239"
         },
         "name": "glibc",
         "signature": {
-          "checksum": "sha1-Kvfb+I/1PCfiBTjoaU4ezZa0b+8=",
+          "checksum": "sha1-3TP2+cHjCEBrIFluCdTmr2oJA1s=",
           "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Zi0e8Bq6WCd/6uXXjVhb8YwMD1U=",
+        "checksum": "Q1WAlPh7UNBV+RHfBixVB5P9F9Mp8=",
         "control": {
-          "checksum": "sha1-Zi0e8Bq6WCd/6uXXjVhb8YwMD1U=",
-          "range": "bytes=700-1073"
+          "checksum": "sha1-WAlPh7UNBV+RHfBixVB5P9F9Mp8=",
+          "range": "bytes=700-1074"
         },
         "data": {
-          "checksum": "sha256-jMhtfqVjnhuuBO7wtNZ6RS/72sZWoKt/Moage2amlks=",
-          "range": "bytes=1074-81594"
+          "checksum": "sha256-i6uEFvUEbJ4YzgNSV58aObIdU608mjbCVPwyF57ZeQQ=",
+          "range": "bytes=1075-81593"
         },
         "name": "protobuf-c",
         "signature": {
-          "checksum": "sha1-kATwMKztK7nk7qbYCJPkCFp6IXc=",
+          "checksum": "sha1-47zwDXmhcWiVtTYCjq4sFld8wHQ=",
           "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r5.apk",
-        "version": "1.5.0-r5"
+        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r6.apk",
+        "version": "1.5.0-r6"
       },
       {
         "architecture": "x86_64",
@@ -204,41 +204,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Q/Zy5ovYSu2p/vVLr6DgVA1e8AQ=",
+        "checksum": "Q1a5wJzZI7k9o4F8hHFpfuqAUIH5Q=",
         "control": {
-          "checksum": "sha1-Q/Zy5ovYSu2p/vVLr6DgVA1e8AQ=",
-          "range": "bytes=699-1062"
+          "checksum": "sha1-a5wJzZI7k9o4F8hHFpfuqAUIH5Q=",
+          "range": "bytes=710-1075"
         },
         "data": {
-          "checksum": "sha256-H3jxsw8ytOeCIR4vq17voSVhdNokXk8C1g075txH6Bs=",
-          "range": "bytes=1063-5903754"
+          "checksum": "sha256-2p1UC4F4Odfxup/J/nyzujYRGaxGVjBOBWoc0aajClI=",
+          "range": "bytes=1076-5903889"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-NIl2f5OI/wSZByI8Ds1ZUfbFWyw=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-SOFoklqXtH38i1PcI3G/cPdRFtY=",
+          "range": "bytes=0-709"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.1-r3.apk",
-        "version": "3.3.1-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.1-r4.apk",
+        "version": "3.3.1-r4"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q13wGUXdZut9OOTdY5z2amUj9wXC0=",
+        "checksum": "Q1gb2VyLOsGV7xUiHBT0Ypt64rw6Y=",
         "control": {
-          "checksum": "sha1-3wGUXdZut9OOTdY5z2amUj9wXC0=",
-          "range": "bytes=698-1068"
+          "checksum": "sha1-gb2VyLOsGV7xUiHBT0Ypt64rw6Y=",
+          "range": "bytes=702-1071"
         },
         "data": {
-          "checksum": "sha256-mRda6+YGlOCczyIWKaHqXskTINoT1rgorHDHqAKAb7c=",
-          "range": "bytes=1069-1188955"
+          "checksum": "sha256-h2tz/aFB2n8SFdBFde5foQm1ru+8JUcGp+trUeA2ZlQ=",
+          "range": "bytes=1072-1188954"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-+UdRc4U3PKw4H9OiNurHKXa5BYk=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-w6U2Pb1Y90u1iBFc/sHg2xn6Qmo=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.1-r3.apk",
-        "version": "3.3.1-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.1-r4.apk",
+        "version": "3.3.1-r4"
       },
       {
         "architecture": "x86_64",
@@ -356,60 +356,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1gfqHM/7r3rXX1HqC163slTPP46o=",
+        "checksum": "Q1DLAp18ebMscosnQ4TfTivIzgtCY=",
         "control": {
-          "checksum": "sha1-gfqHM/7r3rXX1HqC163slTPP46o=",
-          "range": "bytes=704-1101"
+          "checksum": "sha1-DLAp18ebMscosnQ4TfTivIzgtCY=",
+          "range": "bytes=698-1079"
         },
         "data": {
-          "checksum": "sha256-OR7ikvfUYp78EsP0I2kuwqqAcy05jw9tr7JVQ6jTnGQ=",
-          "range": "bytes=1102-185433"
+          "checksum": "sha256-eiBdqqECWnULWGe/Gnd6iv/7h56A4xR2qw+5toY5Gaw=",
+          "range": "bytes=1080-185559"
         },
         "name": "libgcc",
         "signature": {
-          "checksum": "sha1-Il4pyVzI6eqNd/f4bsKeakpB5DI=",
-          "range": "bytes=0-703"
+          "checksum": "sha1-qVj9laNeBIwRxP+8ehB+fXftJrw=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.2.0-r7.apk",
-        "version": "13.2.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r0.apk",
+        "version": "13.3.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1c+lykdx+yHoqsrQmQLHMV7waR1Q=",
+        "checksum": "Q1p9aaHhpB2Ud0URrcIrVRAujMw+o=",
         "control": {
-          "checksum": "sha1-c+lykdx+yHoqsrQmQLHMV7waR1Q=",
-          "range": "bytes=701-1119"
+          "checksum": "sha1-p9aaHhpB2Ud0URrcIrVRAujMw+o=",
+          "range": "bytes=696-1097"
         },
         "data": {
-          "checksum": "sha256-CuZi2C5g0vUnz4PNH8jIWV+EBdVMvHr+sNKFYTSnQZk=",
-          "range": "bytes=1120-3155369"
+          "checksum": "sha256-rGMnyLiGEDCEVgqA1oXMf28QHuWHAaPzYrLeDzQ3WOU=",
+          "range": "bytes=1098-3155519"
         },
         "name": "libstdc++",
         "signature": {
-          "checksum": "sha1-7l8MLj8aCcdqta/0sR+0PscBsD4=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-lge2XoAsgvp8U6ZBgT52N2xNQAw=",
+          "range": "bytes=0-695"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.2.0-r7.apk",
-        "version": "13.2.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r0.apk",
+        "version": "13.3.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1R8OxpY0fGwVaIwft4wJeswF5D54=",
+        "checksum": "Q1DUpLMidX5HbXUAFV8y3Imyt+Ank=",
         "control": {
-          "checksum": "sha1-R8OxpY0fGwVaIwft4wJeswF5D54=",
-          "range": "bytes=695-1059"
+          "checksum": "sha1-DUpLMidX5HbXUAFV8y3Imyt+Ank=",
+          "range": "bytes=698-1063"
         },
         "data": {
-          "checksum": "sha256-wNc8/SBJrGHfwywAtzCsAqeUOt0IaAhqNtlbv8OiHBE=",
-          "range": "bytes=1060-242151"
+          "checksum": "sha256-ZUDWWOBnxl5xi3b5HQCHaiYqKDSrnVpJQgavWpn1duc=",
+          "range": "bytes=1064-255810"
         },
         "name": "c-ares",
         "signature": {
-          "checksum": "sha1-55/PTlEHXI3o0hx9dSVdNwQeSMg=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-0AXk7b/B1baNADDg/NSocbW//pw=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.31.0-r0.apk",
-        "version": "1.31.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.32.1-r0.apk",
+        "version": "1.32.1-r0"
       },
       {
         "architecture": "x86_64",
@@ -470,22 +470,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q10AaU1ocIM4PYYNvwbml8TmpNvEA=",
+        "checksum": "Q1ORn/60iAvLcAgApXYoZzM6o0XSs=",
         "control": {
-          "checksum": "sha1-0AaU1ocIM4PYYNvwbml8TmpNvEA=",
-          "range": "bytes=706-1085"
+          "checksum": "sha1-ORn/60iAvLcAgApXYoZzM6o0XSs=",
+          "range": "bytes=703-1081"
         },
         "data": {
-          "checksum": "sha256-1YQNYASFjlP3kXX58ec8du75ij/U6O4DPAKzJAPkln0=",
-          "range": "bytes=1086-4272589"
+          "checksum": "sha256-Ya2Dn1VNYB21ZBD/jBCSx3SxZuJloJET5xkjX0s3Vt8=",
+          "range": "bytes=1082-4272708"
         },
         "name": "libxml2",
         "signature": {
-          "checksum": "sha1-QFjdplzGn/MiNFxMykgafr6/w6U=",
-          "range": "bytes=0-705"
+          "checksum": "sha1-s5jaTwJdla4k4KK0KEk7AYbgdqs=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.1-r1.apk",
-        "version": "2.13.1-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.2-r0.apk",
+        "version": "2.13.2-r0"
       },
       {
         "architecture": "x86_64",
@@ -546,22 +546,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1+0xClEzF5nhyNPUeGFhC++ElQmg=",
+        "checksum": "Q1u+fF2xg98dT0poYklte5HHMg/Kk=",
         "control": {
-          "checksum": "sha1-+0xClEzF5nhyNPUeGFhC++ElQmg=",
-          "range": "bytes=701-1107"
+          "checksum": "sha1-u+fF2xg98dT0poYklte5HHMg/Kk=",
+          "range": "bytes=701-1090"
         },
         "data": {
-          "checksum": "sha256-81V5R7T08up/3BwfuAG25Rq7KkB1MvALVCaogCpW500=",
-          "range": "bytes=1108-22181"
+          "checksum": "sha256-9e+i7LwSg7oAUU33f0r7A4Mc2suaK95iNU5BKaTSXac=",
+          "range": "bytes=1091-22179"
         },
         "name": "libcrypt1",
         "signature": {
-          "checksum": "sha1-k+7JfhPi5KOQ+6Nqk3oAfTbtOVM=",
+          "checksum": "sha1-EWBUcJqCJTOYJq1H0/kkO+m6W3E=",
           "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",
@@ -584,22 +584,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1NzeZQK7ngdKA26bAtJ64z1u7EeE=",
+        "checksum": "Q1ftAlNBj/KqipupXuWtYyimr7/Kk=",
         "control": {
-          "checksum": "sha1-NzeZQK7ngdKA26bAtJ64z1u7EeE=",
-          "range": "bytes=703-1130"
+          "checksum": "sha1-ftAlNBj/KqipupXuWtYyimr7/Kk=",
+          "range": "bytes=695-1108"
         },
         "data": {
-          "checksum": "sha256-BWPJNvd3nr6y2KyENvLMnGRVXMACqV3+UD8tpwyf4KM=",
-          "range": "bytes=1131-37570849"
+          "checksum": "sha256-M5rjCF4ontjzVR94JsspxxCFfy6kUN25FKk4HzVymwg=",
+          "range": "bytes=1109-37571004"
         },
         "name": "cadvisor",
         "signature": {
-          "checksum": "sha1-KDDYQVfPIdoYnyTpxPd8JWnot+A=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-a/cGo8hqjfZNIKL0o48D7ooRjZA=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/cadvisor-0.49.1-r8.apk",
-        "version": "0.49.1-r8"
+        "url": "https://packages.wolfi.dev/os/x86_64/cadvisor-0.49.1-r9.apk",
+        "version": "0.49.1-r9"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/cloud-mi2.lock.json
+++ b/wolfi-images/cloud-mi2.lock.json
@@ -14,117 +14,117 @@
     "packages": [
       {
         "architecture": "x86_64",
-        "checksum": "Q1Ai8jWuxKZR2M2XhOpOGAoTEwnnk=",
+        "checksum": "Q1WR9MGKU+cJh6dJFEXnr3zU1qsMM=",
         "control": {
-          "checksum": "sha1-Ai8jWuxKZR2M2XhOpOGAoTEwnnk=",
-          "range": "bytes=705-1037"
+          "checksum": "sha1-WR9MGKU+cJh6dJFEXnr3zU1qsMM=",
+          "range": "bytes=705-1034"
         },
         "data": {
-          "checksum": "sha256-e4UardkBVyaC49aSyrVmXNi8sSKqQl4eKYd0LxGRLA0=",
-          "range": "bytes=1038-255695"
+          "checksum": "sha256-EkOhtSivoLErXsK2J9ri39thkwb2kJGYHVou4n6dMKA=",
+          "range": "bytes=1035-254654"
         },
         "name": "ca-certificates-bundle",
         "signature": {
-          "checksum": "sha1-loRuyYQLm+atp+YteiQoj++EWIM=",
+          "checksum": "sha1-WL9vKv1nPIeaUQI4O0DiY9RdSHE=",
           "range": "bytes=0-704"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20240315-r4.apk",
-        "version": "20240315-r4"
+        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20240705-r0.apk",
+        "version": "20240705-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1+GH6qRN4iy1IDt0cT0x0tin7YfI=",
+        "checksum": "Q1KmG1L67f+/TnVGcnIcLfWRF/K2g=",
         "control": {
-          "checksum": "sha1-+GH6qRN4iy1IDt0cT0x0tin7YfI=",
-          "range": "bytes=703-1051"
+          "checksum": "sha1-KmG1L67f+/TnVGcnIcLfWRF/K2g=",
+          "range": "bytes=702-1051"
         },
         "data": {
-          "checksum": "sha256-rO0P9z2V49BSrz1A5Ap69tEappVrg5MMBjzW00rOpZc=",
-          "range": "bytes=1052-122464"
+          "checksum": "sha256-2YIxYc/Quit+Kri2qS8p6XvL7taAmOYJU/1Z8RNQ+88=",
+          "range": "bytes=1052-122509"
         },
         "name": "wolfi-baselayout",
         "signature": {
-          "checksum": "sha1-Ntb6VuMzDfM+frpCjKEIpDzl53I=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-VVyPrknEtqCPym5lfhVEuIhfkKg=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r12.apk",
-        "version": "20230201-r12"
+        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r13.apk",
+        "version": "20230201-r13"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q17rD4cKGW3uVSJw02PFiYR719t/Y=",
+        "checksum": "Q1ASyaCJL2Zyz4uAKpPPlx1Sd40yo=",
         "control": {
-          "checksum": "sha1-7rD4cKGW3uVSJw02PFiYR719t/Y=",
-          "range": "bytes=697-1108"
+          "checksum": "sha1-ASyaCJL2Zyz4uAKpPPlx1Sd40yo=",
+          "range": "bytes=706-1101"
         },
         "data": {
-          "checksum": "sha256-GvSViXbvUD0BdV2A+IzVJni2DjLvyM+j14hM29DcsYg=",
-          "range": "bytes=1109-268391"
+          "checksum": "sha256-KoaUrlV3QZ4ATGvKgOmZ1C8Rb/tHK3zEiCTGDrxxc/I=",
+          "range": "bytes=1102-272818"
         },
         "name": "ld-linux",
         "signature": {
-          "checksum": "sha1-nRIFect8o/LOUIEvN17AsrI07dg=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-DBrLE0fWPMyB5/0kAtNlIK6viCU=",
+          "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1/A0wNjkLqqBhe0jFr2D9SKcDNq8=",
+        "checksum": "Q10iHLABsXtuH2JyExQ2IIxH1NUCI=",
         "control": {
-          "checksum": "sha1-/A0wNjkLqqBhe0jFr2D9SKcDNq8=",
-          "range": "bytes=696-1054"
+          "checksum": "sha1-0iHLABsXtuH2JyExQ2IIxH1NUCI=",
+          "range": "bytes=698-1041"
         },
         "data": {
-          "checksum": "sha256-GT22MF6hR+Tj4el5xk2QEwNWig5JRoOrZ60Lecz+lok=",
-          "range": "bytes=1055-408851"
+          "checksum": "sha256-A3RF8XLSIePkapCnvEridXa2N7nheKNT1kTKDqZlGdI=",
+          "range": "bytes=1042-408849"
         },
         "name": "glibc-locale-posix",
         "signature": {
-          "checksum": "sha1-9uPIvcOCeZbPiR7+MLDB4tkJlHo=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-QqrJFnJmyPeT66hUk3O7NxaWY8I=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1YLxq+Z9/+aFnCwvgV7acVLT4QFA=",
+        "checksum": "Q1JYf1zI1zVi/S9sMI32guk6ptuRQ=",
         "control": {
-          "checksum": "sha1-YLxq+Z9/+aFnCwvgV7acVLT4QFA=",
-          "range": "bytes=701-1330"
+          "checksum": "sha1-JYf1zI1zVi/S9sMI32guk6ptuRQ=",
+          "range": "bytes=701-1308"
         },
         "data": {
-          "checksum": "sha256-9s5RNfAJ3GVt7a/fFUaew5MfYYUkvL/6FMvsEfD95jY=",
-          "range": "bytes=1331-5862057"
+          "checksum": "sha256-ioC8korS2nJpJvoS6He+mKkDsgVLcMxiEuYLsAB9M7U=",
+          "range": "bytes=1309-5959239"
         },
         "name": "glibc",
         "signature": {
-          "checksum": "sha1-Kvfb+I/1PCfiBTjoaU4ezZa0b+8=",
+          "checksum": "sha1-3TP2+cHjCEBrIFluCdTmr2oJA1s=",
           "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Zi0e8Bq6WCd/6uXXjVhb8YwMD1U=",
+        "checksum": "Q1WAlPh7UNBV+RHfBixVB5P9F9Mp8=",
         "control": {
-          "checksum": "sha1-Zi0e8Bq6WCd/6uXXjVhb8YwMD1U=",
-          "range": "bytes=700-1073"
+          "checksum": "sha1-WAlPh7UNBV+RHfBixVB5P9F9Mp8=",
+          "range": "bytes=700-1074"
         },
         "data": {
-          "checksum": "sha256-jMhtfqVjnhuuBO7wtNZ6RS/72sZWoKt/Moage2amlks=",
-          "range": "bytes=1074-81594"
+          "checksum": "sha256-i6uEFvUEbJ4YzgNSV58aObIdU608mjbCVPwyF57ZeQQ=",
+          "range": "bytes=1075-81593"
         },
         "name": "protobuf-c",
         "signature": {
-          "checksum": "sha1-kATwMKztK7nk7qbYCJPkCFp6IXc=",
+          "checksum": "sha1-47zwDXmhcWiVtTYCjq4sFld8wHQ=",
           "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r5.apk",
-        "version": "1.5.0-r5"
+        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r6.apk",
+        "version": "1.5.0-r6"
       },
       {
         "architecture": "x86_64",
@@ -204,41 +204,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Q/Zy5ovYSu2p/vVLr6DgVA1e8AQ=",
+        "checksum": "Q1a5wJzZI7k9o4F8hHFpfuqAUIH5Q=",
         "control": {
-          "checksum": "sha1-Q/Zy5ovYSu2p/vVLr6DgVA1e8AQ=",
-          "range": "bytes=699-1062"
+          "checksum": "sha1-a5wJzZI7k9o4F8hHFpfuqAUIH5Q=",
+          "range": "bytes=710-1075"
         },
         "data": {
-          "checksum": "sha256-H3jxsw8ytOeCIR4vq17voSVhdNokXk8C1g075txH6Bs=",
-          "range": "bytes=1063-5903754"
+          "checksum": "sha256-2p1UC4F4Odfxup/J/nyzujYRGaxGVjBOBWoc0aajClI=",
+          "range": "bytes=1076-5903889"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-NIl2f5OI/wSZByI8Ds1ZUfbFWyw=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-SOFoklqXtH38i1PcI3G/cPdRFtY=",
+          "range": "bytes=0-709"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.1-r3.apk",
-        "version": "3.3.1-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.1-r4.apk",
+        "version": "3.3.1-r4"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q13wGUXdZut9OOTdY5z2amUj9wXC0=",
+        "checksum": "Q1gb2VyLOsGV7xUiHBT0Ypt64rw6Y=",
         "control": {
-          "checksum": "sha1-3wGUXdZut9OOTdY5z2amUj9wXC0=",
-          "range": "bytes=698-1068"
+          "checksum": "sha1-gb2VyLOsGV7xUiHBT0Ypt64rw6Y=",
+          "range": "bytes=702-1071"
         },
         "data": {
-          "checksum": "sha256-mRda6+YGlOCczyIWKaHqXskTINoT1rgorHDHqAKAb7c=",
-          "range": "bytes=1069-1188955"
+          "checksum": "sha256-h2tz/aFB2n8SFdBFde5foQm1ru+8JUcGp+trUeA2ZlQ=",
+          "range": "bytes=1072-1188954"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-+UdRc4U3PKw4H9OiNurHKXa5BYk=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-w6U2Pb1Y90u1iBFc/sHg2xn6Qmo=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.1-r3.apk",
-        "version": "3.3.1-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.1-r4.apk",
+        "version": "3.3.1-r4"
       },
       {
         "architecture": "x86_64",
@@ -356,60 +356,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1gfqHM/7r3rXX1HqC163slTPP46o=",
+        "checksum": "Q1DLAp18ebMscosnQ4TfTivIzgtCY=",
         "control": {
-          "checksum": "sha1-gfqHM/7r3rXX1HqC163slTPP46o=",
-          "range": "bytes=704-1101"
+          "checksum": "sha1-DLAp18ebMscosnQ4TfTivIzgtCY=",
+          "range": "bytes=698-1079"
         },
         "data": {
-          "checksum": "sha256-OR7ikvfUYp78EsP0I2kuwqqAcy05jw9tr7JVQ6jTnGQ=",
-          "range": "bytes=1102-185433"
+          "checksum": "sha256-eiBdqqECWnULWGe/Gnd6iv/7h56A4xR2qw+5toY5Gaw=",
+          "range": "bytes=1080-185559"
         },
         "name": "libgcc",
         "signature": {
-          "checksum": "sha1-Il4pyVzI6eqNd/f4bsKeakpB5DI=",
-          "range": "bytes=0-703"
+          "checksum": "sha1-qVj9laNeBIwRxP+8ehB+fXftJrw=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.2.0-r7.apk",
-        "version": "13.2.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r0.apk",
+        "version": "13.3.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1c+lykdx+yHoqsrQmQLHMV7waR1Q=",
+        "checksum": "Q1p9aaHhpB2Ud0URrcIrVRAujMw+o=",
         "control": {
-          "checksum": "sha1-c+lykdx+yHoqsrQmQLHMV7waR1Q=",
-          "range": "bytes=701-1119"
+          "checksum": "sha1-p9aaHhpB2Ud0URrcIrVRAujMw+o=",
+          "range": "bytes=696-1097"
         },
         "data": {
-          "checksum": "sha256-CuZi2C5g0vUnz4PNH8jIWV+EBdVMvHr+sNKFYTSnQZk=",
-          "range": "bytes=1120-3155369"
+          "checksum": "sha256-rGMnyLiGEDCEVgqA1oXMf28QHuWHAaPzYrLeDzQ3WOU=",
+          "range": "bytes=1098-3155519"
         },
         "name": "libstdc++",
         "signature": {
-          "checksum": "sha1-7l8MLj8aCcdqta/0sR+0PscBsD4=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-lge2XoAsgvp8U6ZBgT52N2xNQAw=",
+          "range": "bytes=0-695"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.2.0-r7.apk",
-        "version": "13.2.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r0.apk",
+        "version": "13.3.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1R8OxpY0fGwVaIwft4wJeswF5D54=",
+        "checksum": "Q1DUpLMidX5HbXUAFV8y3Imyt+Ank=",
         "control": {
-          "checksum": "sha1-R8OxpY0fGwVaIwft4wJeswF5D54=",
-          "range": "bytes=695-1059"
+          "checksum": "sha1-DUpLMidX5HbXUAFV8y3Imyt+Ank=",
+          "range": "bytes=698-1063"
         },
         "data": {
-          "checksum": "sha256-wNc8/SBJrGHfwywAtzCsAqeUOt0IaAhqNtlbv8OiHBE=",
-          "range": "bytes=1060-242151"
+          "checksum": "sha256-ZUDWWOBnxl5xi3b5HQCHaiYqKDSrnVpJQgavWpn1duc=",
+          "range": "bytes=1064-255810"
         },
         "name": "c-ares",
         "signature": {
-          "checksum": "sha1-55/PTlEHXI3o0hx9dSVdNwQeSMg=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-0AXk7b/B1baNADDg/NSocbW//pw=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.31.0-r0.apk",
-        "version": "1.31.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.32.1-r0.apk",
+        "version": "1.32.1-r0"
       },
       {
         "architecture": "x86_64",
@@ -470,22 +470,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q10AaU1ocIM4PYYNvwbml8TmpNvEA=",
+        "checksum": "Q1ORn/60iAvLcAgApXYoZzM6o0XSs=",
         "control": {
-          "checksum": "sha1-0AaU1ocIM4PYYNvwbml8TmpNvEA=",
-          "range": "bytes=706-1085"
+          "checksum": "sha1-ORn/60iAvLcAgApXYoZzM6o0XSs=",
+          "range": "bytes=703-1081"
         },
         "data": {
-          "checksum": "sha256-1YQNYASFjlP3kXX58ec8du75ij/U6O4DPAKzJAPkln0=",
-          "range": "bytes=1086-4272589"
+          "checksum": "sha256-Ya2Dn1VNYB21ZBD/jBCSx3SxZuJloJET5xkjX0s3Vt8=",
+          "range": "bytes=1082-4272708"
         },
         "name": "libxml2",
         "signature": {
-          "checksum": "sha1-QFjdplzGn/MiNFxMykgafr6/w6U=",
-          "range": "bytes=0-705"
+          "checksum": "sha1-s5jaTwJdla4k4KK0KEk7AYbgdqs=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.1-r1.apk",
-        "version": "2.13.1-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.2-r0.apk",
+        "version": "2.13.2-r0"
       },
       {
         "architecture": "x86_64",
@@ -546,22 +546,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1+0xClEzF5nhyNPUeGFhC++ElQmg=",
+        "checksum": "Q1u+fF2xg98dT0poYklte5HHMg/Kk=",
         "control": {
-          "checksum": "sha1-+0xClEzF5nhyNPUeGFhC++ElQmg=",
-          "range": "bytes=701-1107"
+          "checksum": "sha1-u+fF2xg98dT0poYklte5HHMg/Kk=",
+          "range": "bytes=701-1090"
         },
         "data": {
-          "checksum": "sha256-81V5R7T08up/3BwfuAG25Rq7KkB1MvALVCaogCpW500=",
-          "range": "bytes=1108-22181"
+          "checksum": "sha256-9e+i7LwSg7oAUU33f0r7A4Mc2suaK95iNU5BKaTSXac=",
+          "range": "bytes=1091-22179"
         },
         "name": "libcrypt1",
         "signature": {
-          "checksum": "sha1-k+7JfhPi5KOQ+6Nqk3oAfTbtOVM=",
+          "checksum": "sha1-EWBUcJqCJTOYJq1H0/kkO+m6W3E=",
           "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",
@@ -774,22 +774,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1KXXN9Hu7PZ0iPK7gAnYRUDcDzZs=",
+        "checksum": "Q1VJwVzi86yWcTj5PHY01vdoetpZQ=",
         "control": {
-          "checksum": "sha1-KXXN9Hu7PZ0iPK7gAnYRUDcDzZs=",
-          "range": "bytes=700-1063"
+          "checksum": "sha1-VJwVzi86yWcTj5PHY01vdoetpZQ=",
+          "range": "bytes=710-1058"
         },
         "data": {
-          "checksum": "sha256-F61XBj+QV78wXrinzeVQestiQeJtCAVPWwbLWf8c98Y=",
-          "range": "bytes=1064-12733161"
+          "checksum": "sha256-kBMNCuqgebDS1M9EjrUO3wqJ2laPKu/oE0YI/4szp4M=",
+          "range": "bytes=1059-12733185"
         },
         "name": "git-lfs",
         "signature": {
-          "checksum": "sha1-U6NrIIwbHHzX/fgtB3PoNVQZOJU=",
-          "range": "bytes=0-699"
+          "checksum": "sha1-RgfxUCV6GAC4fDsAvBAZ6AWoGFM=",
+          "range": "bytes=0-709"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/git-lfs-3.5.1-r6.apk",
-        "version": "3.5.1-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/git-lfs-3.5.1-r7.apk",
+        "version": "3.5.1-r7"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/executor-kubernetes.lock.json
+++ b/wolfi-images/executor-kubernetes.lock.json
@@ -14,117 +14,117 @@
     "packages": [
       {
         "architecture": "x86_64",
-        "checksum": "Q1Ai8jWuxKZR2M2XhOpOGAoTEwnnk=",
+        "checksum": "Q1WR9MGKU+cJh6dJFEXnr3zU1qsMM=",
         "control": {
-          "checksum": "sha1-Ai8jWuxKZR2M2XhOpOGAoTEwnnk=",
-          "range": "bytes=705-1037"
+          "checksum": "sha1-WR9MGKU+cJh6dJFEXnr3zU1qsMM=",
+          "range": "bytes=705-1034"
         },
         "data": {
-          "checksum": "sha256-e4UardkBVyaC49aSyrVmXNi8sSKqQl4eKYd0LxGRLA0=",
-          "range": "bytes=1038-255695"
+          "checksum": "sha256-EkOhtSivoLErXsK2J9ri39thkwb2kJGYHVou4n6dMKA=",
+          "range": "bytes=1035-254654"
         },
         "name": "ca-certificates-bundle",
         "signature": {
-          "checksum": "sha1-loRuyYQLm+atp+YteiQoj++EWIM=",
+          "checksum": "sha1-WL9vKv1nPIeaUQI4O0DiY9RdSHE=",
           "range": "bytes=0-704"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20240315-r4.apk",
-        "version": "20240315-r4"
+        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20240705-r0.apk",
+        "version": "20240705-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1+GH6qRN4iy1IDt0cT0x0tin7YfI=",
+        "checksum": "Q1KmG1L67f+/TnVGcnIcLfWRF/K2g=",
         "control": {
-          "checksum": "sha1-+GH6qRN4iy1IDt0cT0x0tin7YfI=",
-          "range": "bytes=703-1051"
+          "checksum": "sha1-KmG1L67f+/TnVGcnIcLfWRF/K2g=",
+          "range": "bytes=702-1051"
         },
         "data": {
-          "checksum": "sha256-rO0P9z2V49BSrz1A5Ap69tEappVrg5MMBjzW00rOpZc=",
-          "range": "bytes=1052-122464"
+          "checksum": "sha256-2YIxYc/Quit+Kri2qS8p6XvL7taAmOYJU/1Z8RNQ+88=",
+          "range": "bytes=1052-122509"
         },
         "name": "wolfi-baselayout",
         "signature": {
-          "checksum": "sha1-Ntb6VuMzDfM+frpCjKEIpDzl53I=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-VVyPrknEtqCPym5lfhVEuIhfkKg=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r12.apk",
-        "version": "20230201-r12"
+        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r13.apk",
+        "version": "20230201-r13"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q17rD4cKGW3uVSJw02PFiYR719t/Y=",
+        "checksum": "Q1ASyaCJL2Zyz4uAKpPPlx1Sd40yo=",
         "control": {
-          "checksum": "sha1-7rD4cKGW3uVSJw02PFiYR719t/Y=",
-          "range": "bytes=697-1108"
+          "checksum": "sha1-ASyaCJL2Zyz4uAKpPPlx1Sd40yo=",
+          "range": "bytes=706-1101"
         },
         "data": {
-          "checksum": "sha256-GvSViXbvUD0BdV2A+IzVJni2DjLvyM+j14hM29DcsYg=",
-          "range": "bytes=1109-268391"
+          "checksum": "sha256-KoaUrlV3QZ4ATGvKgOmZ1C8Rb/tHK3zEiCTGDrxxc/I=",
+          "range": "bytes=1102-272818"
         },
         "name": "ld-linux",
         "signature": {
-          "checksum": "sha1-nRIFect8o/LOUIEvN17AsrI07dg=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-DBrLE0fWPMyB5/0kAtNlIK6viCU=",
+          "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1/A0wNjkLqqBhe0jFr2D9SKcDNq8=",
+        "checksum": "Q10iHLABsXtuH2JyExQ2IIxH1NUCI=",
         "control": {
-          "checksum": "sha1-/A0wNjkLqqBhe0jFr2D9SKcDNq8=",
-          "range": "bytes=696-1054"
+          "checksum": "sha1-0iHLABsXtuH2JyExQ2IIxH1NUCI=",
+          "range": "bytes=698-1041"
         },
         "data": {
-          "checksum": "sha256-GT22MF6hR+Tj4el5xk2QEwNWig5JRoOrZ60Lecz+lok=",
-          "range": "bytes=1055-408851"
+          "checksum": "sha256-A3RF8XLSIePkapCnvEridXa2N7nheKNT1kTKDqZlGdI=",
+          "range": "bytes=1042-408849"
         },
         "name": "glibc-locale-posix",
         "signature": {
-          "checksum": "sha1-9uPIvcOCeZbPiR7+MLDB4tkJlHo=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-QqrJFnJmyPeT66hUk3O7NxaWY8I=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1YLxq+Z9/+aFnCwvgV7acVLT4QFA=",
+        "checksum": "Q1JYf1zI1zVi/S9sMI32guk6ptuRQ=",
         "control": {
-          "checksum": "sha1-YLxq+Z9/+aFnCwvgV7acVLT4QFA=",
-          "range": "bytes=701-1330"
+          "checksum": "sha1-JYf1zI1zVi/S9sMI32guk6ptuRQ=",
+          "range": "bytes=701-1308"
         },
         "data": {
-          "checksum": "sha256-9s5RNfAJ3GVt7a/fFUaew5MfYYUkvL/6FMvsEfD95jY=",
-          "range": "bytes=1331-5862057"
+          "checksum": "sha256-ioC8korS2nJpJvoS6He+mKkDsgVLcMxiEuYLsAB9M7U=",
+          "range": "bytes=1309-5959239"
         },
         "name": "glibc",
         "signature": {
-          "checksum": "sha1-Kvfb+I/1PCfiBTjoaU4ezZa0b+8=",
+          "checksum": "sha1-3TP2+cHjCEBrIFluCdTmr2oJA1s=",
           "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Zi0e8Bq6WCd/6uXXjVhb8YwMD1U=",
+        "checksum": "Q1WAlPh7UNBV+RHfBixVB5P9F9Mp8=",
         "control": {
-          "checksum": "sha1-Zi0e8Bq6WCd/6uXXjVhb8YwMD1U=",
-          "range": "bytes=700-1073"
+          "checksum": "sha1-WAlPh7UNBV+RHfBixVB5P9F9Mp8=",
+          "range": "bytes=700-1074"
         },
         "data": {
-          "checksum": "sha256-jMhtfqVjnhuuBO7wtNZ6RS/72sZWoKt/Moage2amlks=",
-          "range": "bytes=1074-81594"
+          "checksum": "sha256-i6uEFvUEbJ4YzgNSV58aObIdU608mjbCVPwyF57ZeQQ=",
+          "range": "bytes=1075-81593"
         },
         "name": "protobuf-c",
         "signature": {
-          "checksum": "sha1-kATwMKztK7nk7qbYCJPkCFp6IXc=",
+          "checksum": "sha1-47zwDXmhcWiVtTYCjq4sFld8wHQ=",
           "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r5.apk",
-        "version": "1.5.0-r5"
+        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r6.apk",
+        "version": "1.5.0-r6"
       },
       {
         "architecture": "x86_64",
@@ -204,41 +204,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Q/Zy5ovYSu2p/vVLr6DgVA1e8AQ=",
+        "checksum": "Q1a5wJzZI7k9o4F8hHFpfuqAUIH5Q=",
         "control": {
-          "checksum": "sha1-Q/Zy5ovYSu2p/vVLr6DgVA1e8AQ=",
-          "range": "bytes=699-1062"
+          "checksum": "sha1-a5wJzZI7k9o4F8hHFpfuqAUIH5Q=",
+          "range": "bytes=710-1075"
         },
         "data": {
-          "checksum": "sha256-H3jxsw8ytOeCIR4vq17voSVhdNokXk8C1g075txH6Bs=",
-          "range": "bytes=1063-5903754"
+          "checksum": "sha256-2p1UC4F4Odfxup/J/nyzujYRGaxGVjBOBWoc0aajClI=",
+          "range": "bytes=1076-5903889"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-NIl2f5OI/wSZByI8Ds1ZUfbFWyw=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-SOFoklqXtH38i1PcI3G/cPdRFtY=",
+          "range": "bytes=0-709"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.1-r3.apk",
-        "version": "3.3.1-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.1-r4.apk",
+        "version": "3.3.1-r4"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q13wGUXdZut9OOTdY5z2amUj9wXC0=",
+        "checksum": "Q1gb2VyLOsGV7xUiHBT0Ypt64rw6Y=",
         "control": {
-          "checksum": "sha1-3wGUXdZut9OOTdY5z2amUj9wXC0=",
-          "range": "bytes=698-1068"
+          "checksum": "sha1-gb2VyLOsGV7xUiHBT0Ypt64rw6Y=",
+          "range": "bytes=702-1071"
         },
         "data": {
-          "checksum": "sha256-mRda6+YGlOCczyIWKaHqXskTINoT1rgorHDHqAKAb7c=",
-          "range": "bytes=1069-1188955"
+          "checksum": "sha256-h2tz/aFB2n8SFdBFde5foQm1ru+8JUcGp+trUeA2ZlQ=",
+          "range": "bytes=1072-1188954"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-+UdRc4U3PKw4H9OiNurHKXa5BYk=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-w6U2Pb1Y90u1iBFc/sHg2xn6Qmo=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.1-r3.apk",
-        "version": "3.3.1-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.1-r4.apk",
+        "version": "3.3.1-r4"
       },
       {
         "architecture": "x86_64",
@@ -356,60 +356,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1gfqHM/7r3rXX1HqC163slTPP46o=",
+        "checksum": "Q1DLAp18ebMscosnQ4TfTivIzgtCY=",
         "control": {
-          "checksum": "sha1-gfqHM/7r3rXX1HqC163slTPP46o=",
-          "range": "bytes=704-1101"
+          "checksum": "sha1-DLAp18ebMscosnQ4TfTivIzgtCY=",
+          "range": "bytes=698-1079"
         },
         "data": {
-          "checksum": "sha256-OR7ikvfUYp78EsP0I2kuwqqAcy05jw9tr7JVQ6jTnGQ=",
-          "range": "bytes=1102-185433"
+          "checksum": "sha256-eiBdqqECWnULWGe/Gnd6iv/7h56A4xR2qw+5toY5Gaw=",
+          "range": "bytes=1080-185559"
         },
         "name": "libgcc",
         "signature": {
-          "checksum": "sha1-Il4pyVzI6eqNd/f4bsKeakpB5DI=",
-          "range": "bytes=0-703"
+          "checksum": "sha1-qVj9laNeBIwRxP+8ehB+fXftJrw=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.2.0-r7.apk",
-        "version": "13.2.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r0.apk",
+        "version": "13.3.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1c+lykdx+yHoqsrQmQLHMV7waR1Q=",
+        "checksum": "Q1p9aaHhpB2Ud0URrcIrVRAujMw+o=",
         "control": {
-          "checksum": "sha1-c+lykdx+yHoqsrQmQLHMV7waR1Q=",
-          "range": "bytes=701-1119"
+          "checksum": "sha1-p9aaHhpB2Ud0URrcIrVRAujMw+o=",
+          "range": "bytes=696-1097"
         },
         "data": {
-          "checksum": "sha256-CuZi2C5g0vUnz4PNH8jIWV+EBdVMvHr+sNKFYTSnQZk=",
-          "range": "bytes=1120-3155369"
+          "checksum": "sha256-rGMnyLiGEDCEVgqA1oXMf28QHuWHAaPzYrLeDzQ3WOU=",
+          "range": "bytes=1098-3155519"
         },
         "name": "libstdc++",
         "signature": {
-          "checksum": "sha1-7l8MLj8aCcdqta/0sR+0PscBsD4=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-lge2XoAsgvp8U6ZBgT52N2xNQAw=",
+          "range": "bytes=0-695"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.2.0-r7.apk",
-        "version": "13.2.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r0.apk",
+        "version": "13.3.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1R8OxpY0fGwVaIwft4wJeswF5D54=",
+        "checksum": "Q1DUpLMidX5HbXUAFV8y3Imyt+Ank=",
         "control": {
-          "checksum": "sha1-R8OxpY0fGwVaIwft4wJeswF5D54=",
-          "range": "bytes=695-1059"
+          "checksum": "sha1-DUpLMidX5HbXUAFV8y3Imyt+Ank=",
+          "range": "bytes=698-1063"
         },
         "data": {
-          "checksum": "sha256-wNc8/SBJrGHfwywAtzCsAqeUOt0IaAhqNtlbv8OiHBE=",
-          "range": "bytes=1060-242151"
+          "checksum": "sha256-ZUDWWOBnxl5xi3b5HQCHaiYqKDSrnVpJQgavWpn1duc=",
+          "range": "bytes=1064-255810"
         },
         "name": "c-ares",
         "signature": {
-          "checksum": "sha1-55/PTlEHXI3o0hx9dSVdNwQeSMg=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-0AXk7b/B1baNADDg/NSocbW//pw=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.31.0-r0.apk",
-        "version": "1.31.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.32.1-r0.apk",
+        "version": "1.32.1-r0"
       },
       {
         "architecture": "x86_64",
@@ -470,22 +470,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q10AaU1ocIM4PYYNvwbml8TmpNvEA=",
+        "checksum": "Q1ORn/60iAvLcAgApXYoZzM6o0XSs=",
         "control": {
-          "checksum": "sha1-0AaU1ocIM4PYYNvwbml8TmpNvEA=",
-          "range": "bytes=706-1085"
+          "checksum": "sha1-ORn/60iAvLcAgApXYoZzM6o0XSs=",
+          "range": "bytes=703-1081"
         },
         "data": {
-          "checksum": "sha256-1YQNYASFjlP3kXX58ec8du75ij/U6O4DPAKzJAPkln0=",
-          "range": "bytes=1086-4272589"
+          "checksum": "sha256-Ya2Dn1VNYB21ZBD/jBCSx3SxZuJloJET5xkjX0s3Vt8=",
+          "range": "bytes=1082-4272708"
         },
         "name": "libxml2",
         "signature": {
-          "checksum": "sha1-QFjdplzGn/MiNFxMykgafr6/w6U=",
-          "range": "bytes=0-705"
+          "checksum": "sha1-s5jaTwJdla4k4KK0KEk7AYbgdqs=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.1-r1.apk",
-        "version": "2.13.1-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.2-r0.apk",
+        "version": "2.13.2-r0"
       },
       {
         "architecture": "x86_64",
@@ -546,22 +546,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1+0xClEzF5nhyNPUeGFhC++ElQmg=",
+        "checksum": "Q1u+fF2xg98dT0poYklte5HHMg/Kk=",
         "control": {
-          "checksum": "sha1-+0xClEzF5nhyNPUeGFhC++ElQmg=",
-          "range": "bytes=701-1107"
+          "checksum": "sha1-u+fF2xg98dT0poYklte5HHMg/Kk=",
+          "range": "bytes=701-1090"
         },
         "data": {
-          "checksum": "sha256-81V5R7T08up/3BwfuAG25Rq7KkB1MvALVCaogCpW500=",
-          "range": "bytes=1108-22181"
+          "checksum": "sha256-9e+i7LwSg7oAUU33f0r7A4Mc2suaK95iNU5BKaTSXac=",
+          "range": "bytes=1091-22179"
         },
         "name": "libcrypt1",
         "signature": {
-          "checksum": "sha1-k+7JfhPi5KOQ+6Nqk3oAfTbtOVM=",
+          "checksum": "sha1-EWBUcJqCJTOYJq1H0/kkO+m6W3E=",
           "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/executor.lock.json
+++ b/wolfi-images/executor.lock.json
@@ -14,117 +14,117 @@
     "packages": [
       {
         "architecture": "x86_64",
-        "checksum": "Q1Ai8jWuxKZR2M2XhOpOGAoTEwnnk=",
+        "checksum": "Q1WR9MGKU+cJh6dJFEXnr3zU1qsMM=",
         "control": {
-          "checksum": "sha1-Ai8jWuxKZR2M2XhOpOGAoTEwnnk=",
-          "range": "bytes=705-1037"
+          "checksum": "sha1-WR9MGKU+cJh6dJFEXnr3zU1qsMM=",
+          "range": "bytes=705-1034"
         },
         "data": {
-          "checksum": "sha256-e4UardkBVyaC49aSyrVmXNi8sSKqQl4eKYd0LxGRLA0=",
-          "range": "bytes=1038-255695"
+          "checksum": "sha256-EkOhtSivoLErXsK2J9ri39thkwb2kJGYHVou4n6dMKA=",
+          "range": "bytes=1035-254654"
         },
         "name": "ca-certificates-bundle",
         "signature": {
-          "checksum": "sha1-loRuyYQLm+atp+YteiQoj++EWIM=",
+          "checksum": "sha1-WL9vKv1nPIeaUQI4O0DiY9RdSHE=",
           "range": "bytes=0-704"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20240315-r4.apk",
-        "version": "20240315-r4"
+        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20240705-r0.apk",
+        "version": "20240705-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1+GH6qRN4iy1IDt0cT0x0tin7YfI=",
+        "checksum": "Q1KmG1L67f+/TnVGcnIcLfWRF/K2g=",
         "control": {
-          "checksum": "sha1-+GH6qRN4iy1IDt0cT0x0tin7YfI=",
-          "range": "bytes=703-1051"
+          "checksum": "sha1-KmG1L67f+/TnVGcnIcLfWRF/K2g=",
+          "range": "bytes=702-1051"
         },
         "data": {
-          "checksum": "sha256-rO0P9z2V49BSrz1A5Ap69tEappVrg5MMBjzW00rOpZc=",
-          "range": "bytes=1052-122464"
+          "checksum": "sha256-2YIxYc/Quit+Kri2qS8p6XvL7taAmOYJU/1Z8RNQ+88=",
+          "range": "bytes=1052-122509"
         },
         "name": "wolfi-baselayout",
         "signature": {
-          "checksum": "sha1-Ntb6VuMzDfM+frpCjKEIpDzl53I=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-VVyPrknEtqCPym5lfhVEuIhfkKg=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r12.apk",
-        "version": "20230201-r12"
+        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r13.apk",
+        "version": "20230201-r13"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q17rD4cKGW3uVSJw02PFiYR719t/Y=",
+        "checksum": "Q1ASyaCJL2Zyz4uAKpPPlx1Sd40yo=",
         "control": {
-          "checksum": "sha1-7rD4cKGW3uVSJw02PFiYR719t/Y=",
-          "range": "bytes=697-1108"
+          "checksum": "sha1-ASyaCJL2Zyz4uAKpPPlx1Sd40yo=",
+          "range": "bytes=706-1101"
         },
         "data": {
-          "checksum": "sha256-GvSViXbvUD0BdV2A+IzVJni2DjLvyM+j14hM29DcsYg=",
-          "range": "bytes=1109-268391"
+          "checksum": "sha256-KoaUrlV3QZ4ATGvKgOmZ1C8Rb/tHK3zEiCTGDrxxc/I=",
+          "range": "bytes=1102-272818"
         },
         "name": "ld-linux",
         "signature": {
-          "checksum": "sha1-nRIFect8o/LOUIEvN17AsrI07dg=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-DBrLE0fWPMyB5/0kAtNlIK6viCU=",
+          "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1/A0wNjkLqqBhe0jFr2D9SKcDNq8=",
+        "checksum": "Q10iHLABsXtuH2JyExQ2IIxH1NUCI=",
         "control": {
-          "checksum": "sha1-/A0wNjkLqqBhe0jFr2D9SKcDNq8=",
-          "range": "bytes=696-1054"
+          "checksum": "sha1-0iHLABsXtuH2JyExQ2IIxH1NUCI=",
+          "range": "bytes=698-1041"
         },
         "data": {
-          "checksum": "sha256-GT22MF6hR+Tj4el5xk2QEwNWig5JRoOrZ60Lecz+lok=",
-          "range": "bytes=1055-408851"
+          "checksum": "sha256-A3RF8XLSIePkapCnvEridXa2N7nheKNT1kTKDqZlGdI=",
+          "range": "bytes=1042-408849"
         },
         "name": "glibc-locale-posix",
         "signature": {
-          "checksum": "sha1-9uPIvcOCeZbPiR7+MLDB4tkJlHo=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-QqrJFnJmyPeT66hUk3O7NxaWY8I=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1YLxq+Z9/+aFnCwvgV7acVLT4QFA=",
+        "checksum": "Q1JYf1zI1zVi/S9sMI32guk6ptuRQ=",
         "control": {
-          "checksum": "sha1-YLxq+Z9/+aFnCwvgV7acVLT4QFA=",
-          "range": "bytes=701-1330"
+          "checksum": "sha1-JYf1zI1zVi/S9sMI32guk6ptuRQ=",
+          "range": "bytes=701-1308"
         },
         "data": {
-          "checksum": "sha256-9s5RNfAJ3GVt7a/fFUaew5MfYYUkvL/6FMvsEfD95jY=",
-          "range": "bytes=1331-5862057"
+          "checksum": "sha256-ioC8korS2nJpJvoS6He+mKkDsgVLcMxiEuYLsAB9M7U=",
+          "range": "bytes=1309-5959239"
         },
         "name": "glibc",
         "signature": {
-          "checksum": "sha1-Kvfb+I/1PCfiBTjoaU4ezZa0b+8=",
+          "checksum": "sha1-3TP2+cHjCEBrIFluCdTmr2oJA1s=",
           "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Zi0e8Bq6WCd/6uXXjVhb8YwMD1U=",
+        "checksum": "Q1WAlPh7UNBV+RHfBixVB5P9F9Mp8=",
         "control": {
-          "checksum": "sha1-Zi0e8Bq6WCd/6uXXjVhb8YwMD1U=",
-          "range": "bytes=700-1073"
+          "checksum": "sha1-WAlPh7UNBV+RHfBixVB5P9F9Mp8=",
+          "range": "bytes=700-1074"
         },
         "data": {
-          "checksum": "sha256-jMhtfqVjnhuuBO7wtNZ6RS/72sZWoKt/Moage2amlks=",
-          "range": "bytes=1074-81594"
+          "checksum": "sha256-i6uEFvUEbJ4YzgNSV58aObIdU608mjbCVPwyF57ZeQQ=",
+          "range": "bytes=1075-81593"
         },
         "name": "protobuf-c",
         "signature": {
-          "checksum": "sha1-kATwMKztK7nk7qbYCJPkCFp6IXc=",
+          "checksum": "sha1-47zwDXmhcWiVtTYCjq4sFld8wHQ=",
           "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r5.apk",
-        "version": "1.5.0-r5"
+        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r6.apk",
+        "version": "1.5.0-r6"
       },
       {
         "architecture": "x86_64",
@@ -204,41 +204,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Q/Zy5ovYSu2p/vVLr6DgVA1e8AQ=",
+        "checksum": "Q1a5wJzZI7k9o4F8hHFpfuqAUIH5Q=",
         "control": {
-          "checksum": "sha1-Q/Zy5ovYSu2p/vVLr6DgVA1e8AQ=",
-          "range": "bytes=699-1062"
+          "checksum": "sha1-a5wJzZI7k9o4F8hHFpfuqAUIH5Q=",
+          "range": "bytes=710-1075"
         },
         "data": {
-          "checksum": "sha256-H3jxsw8ytOeCIR4vq17voSVhdNokXk8C1g075txH6Bs=",
-          "range": "bytes=1063-5903754"
+          "checksum": "sha256-2p1UC4F4Odfxup/J/nyzujYRGaxGVjBOBWoc0aajClI=",
+          "range": "bytes=1076-5903889"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-NIl2f5OI/wSZByI8Ds1ZUfbFWyw=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-SOFoklqXtH38i1PcI3G/cPdRFtY=",
+          "range": "bytes=0-709"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.1-r3.apk",
-        "version": "3.3.1-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.1-r4.apk",
+        "version": "3.3.1-r4"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q13wGUXdZut9OOTdY5z2amUj9wXC0=",
+        "checksum": "Q1gb2VyLOsGV7xUiHBT0Ypt64rw6Y=",
         "control": {
-          "checksum": "sha1-3wGUXdZut9OOTdY5z2amUj9wXC0=",
-          "range": "bytes=698-1068"
+          "checksum": "sha1-gb2VyLOsGV7xUiHBT0Ypt64rw6Y=",
+          "range": "bytes=702-1071"
         },
         "data": {
-          "checksum": "sha256-mRda6+YGlOCczyIWKaHqXskTINoT1rgorHDHqAKAb7c=",
-          "range": "bytes=1069-1188955"
+          "checksum": "sha256-h2tz/aFB2n8SFdBFde5foQm1ru+8JUcGp+trUeA2ZlQ=",
+          "range": "bytes=1072-1188954"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-+UdRc4U3PKw4H9OiNurHKXa5BYk=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-w6U2Pb1Y90u1iBFc/sHg2xn6Qmo=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.1-r3.apk",
-        "version": "3.3.1-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.1-r4.apk",
+        "version": "3.3.1-r4"
       },
       {
         "architecture": "x86_64",
@@ -356,60 +356,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1gfqHM/7r3rXX1HqC163slTPP46o=",
+        "checksum": "Q1DLAp18ebMscosnQ4TfTivIzgtCY=",
         "control": {
-          "checksum": "sha1-gfqHM/7r3rXX1HqC163slTPP46o=",
-          "range": "bytes=704-1101"
+          "checksum": "sha1-DLAp18ebMscosnQ4TfTivIzgtCY=",
+          "range": "bytes=698-1079"
         },
         "data": {
-          "checksum": "sha256-OR7ikvfUYp78EsP0I2kuwqqAcy05jw9tr7JVQ6jTnGQ=",
-          "range": "bytes=1102-185433"
+          "checksum": "sha256-eiBdqqECWnULWGe/Gnd6iv/7h56A4xR2qw+5toY5Gaw=",
+          "range": "bytes=1080-185559"
         },
         "name": "libgcc",
         "signature": {
-          "checksum": "sha1-Il4pyVzI6eqNd/f4bsKeakpB5DI=",
-          "range": "bytes=0-703"
+          "checksum": "sha1-qVj9laNeBIwRxP+8ehB+fXftJrw=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.2.0-r7.apk",
-        "version": "13.2.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r0.apk",
+        "version": "13.3.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1c+lykdx+yHoqsrQmQLHMV7waR1Q=",
+        "checksum": "Q1p9aaHhpB2Ud0URrcIrVRAujMw+o=",
         "control": {
-          "checksum": "sha1-c+lykdx+yHoqsrQmQLHMV7waR1Q=",
-          "range": "bytes=701-1119"
+          "checksum": "sha1-p9aaHhpB2Ud0URrcIrVRAujMw+o=",
+          "range": "bytes=696-1097"
         },
         "data": {
-          "checksum": "sha256-CuZi2C5g0vUnz4PNH8jIWV+EBdVMvHr+sNKFYTSnQZk=",
-          "range": "bytes=1120-3155369"
+          "checksum": "sha256-rGMnyLiGEDCEVgqA1oXMf28QHuWHAaPzYrLeDzQ3WOU=",
+          "range": "bytes=1098-3155519"
         },
         "name": "libstdc++",
         "signature": {
-          "checksum": "sha1-7l8MLj8aCcdqta/0sR+0PscBsD4=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-lge2XoAsgvp8U6ZBgT52N2xNQAw=",
+          "range": "bytes=0-695"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.2.0-r7.apk",
-        "version": "13.2.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r0.apk",
+        "version": "13.3.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1R8OxpY0fGwVaIwft4wJeswF5D54=",
+        "checksum": "Q1DUpLMidX5HbXUAFV8y3Imyt+Ank=",
         "control": {
-          "checksum": "sha1-R8OxpY0fGwVaIwft4wJeswF5D54=",
-          "range": "bytes=695-1059"
+          "checksum": "sha1-DUpLMidX5HbXUAFV8y3Imyt+Ank=",
+          "range": "bytes=698-1063"
         },
         "data": {
-          "checksum": "sha256-wNc8/SBJrGHfwywAtzCsAqeUOt0IaAhqNtlbv8OiHBE=",
-          "range": "bytes=1060-242151"
+          "checksum": "sha256-ZUDWWOBnxl5xi3b5HQCHaiYqKDSrnVpJQgavWpn1duc=",
+          "range": "bytes=1064-255810"
         },
         "name": "c-ares",
         "signature": {
-          "checksum": "sha1-55/PTlEHXI3o0hx9dSVdNwQeSMg=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-0AXk7b/B1baNADDg/NSocbW//pw=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.31.0-r0.apk",
-        "version": "1.31.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.32.1-r0.apk",
+        "version": "1.32.1-r0"
       },
       {
         "architecture": "x86_64",
@@ -470,22 +470,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q10AaU1ocIM4PYYNvwbml8TmpNvEA=",
+        "checksum": "Q1ORn/60iAvLcAgApXYoZzM6o0XSs=",
         "control": {
-          "checksum": "sha1-0AaU1ocIM4PYYNvwbml8TmpNvEA=",
-          "range": "bytes=706-1085"
+          "checksum": "sha1-ORn/60iAvLcAgApXYoZzM6o0XSs=",
+          "range": "bytes=703-1081"
         },
         "data": {
-          "checksum": "sha256-1YQNYASFjlP3kXX58ec8du75ij/U6O4DPAKzJAPkln0=",
-          "range": "bytes=1086-4272589"
+          "checksum": "sha256-Ya2Dn1VNYB21ZBD/jBCSx3SxZuJloJET5xkjX0s3Vt8=",
+          "range": "bytes=1082-4272708"
         },
         "name": "libxml2",
         "signature": {
-          "checksum": "sha1-QFjdplzGn/MiNFxMykgafr6/w6U=",
-          "range": "bytes=0-705"
+          "checksum": "sha1-s5jaTwJdla4k4KK0KEk7AYbgdqs=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.1-r1.apk",
-        "version": "2.13.1-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.2-r0.apk",
+        "version": "2.13.2-r0"
       },
       {
         "architecture": "x86_64",
@@ -546,22 +546,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1+0xClEzF5nhyNPUeGFhC++ElQmg=",
+        "checksum": "Q1u+fF2xg98dT0poYklte5HHMg/Kk=",
         "control": {
-          "checksum": "sha1-+0xClEzF5nhyNPUeGFhC++ElQmg=",
-          "range": "bytes=701-1107"
+          "checksum": "sha1-u+fF2xg98dT0poYklte5HHMg/Kk=",
+          "range": "bytes=701-1090"
         },
         "data": {
-          "checksum": "sha256-81V5R7T08up/3BwfuAG25Rq7KkB1MvALVCaogCpW500=",
-          "range": "bytes=1108-22181"
+          "checksum": "sha256-9e+i7LwSg7oAUU33f0r7A4Mc2suaK95iNU5BKaTSXac=",
+          "range": "bytes=1091-22179"
         },
         "name": "libcrypt1",
         "signature": {
-          "checksum": "sha1-k+7JfhPi5KOQ+6Nqk3oAfTbtOVM=",
+          "checksum": "sha1-EWBUcJqCJTOYJq1H0/kkO+m6W3E=",
           "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",
@@ -584,22 +584,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1fnaWc3899x9dK4z4iTFNOeM6MI0=",
+        "checksum": "Q1yStY7gve/r3+nnaV+ul/l4zmwpU=",
         "control": {
-          "checksum": "sha1-fnaWc3899x9dK4z4iTFNOeM6MI0=",
-          "range": "bytes=702-1132"
+          "checksum": "sha1-yStY7gve/r3+nnaV+ul/l4zmwpU=",
+          "range": "bytes=699-1128"
         },
         "data": {
-          "checksum": "sha256-rhtsl8eIgOKIHSa3VsedIEj1sA3xRi83jc3fhTjIQLw=",
-          "range": "bytes=1133-377535"
+          "checksum": "sha256-1d/7CyMhSR2oDbLJtN12D1pYniEuQIptX78kAs2ZI14=",
+          "range": "bytes=1129-376508"
         },
         "name": "ca-certificates",
         "signature": {
-          "checksum": "sha1-I1wWFlIzyXu0g5mcgMo/iyW3Mhw=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-EIHhUeKgg6x/sc6JooVgTCBIgOg=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-20240315-r4.apk",
-        "version": "20240315-r4"
+        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-20240705-r0.apk",
+        "version": "20240705-r0"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/gitserver.lock.json
+++ b/wolfi-images/gitserver.lock.json
@@ -14,136 +14,136 @@
     "packages": [
       {
         "architecture": "x86_64",
-        "checksum": "Q1ibJSAAe0yAmeC3Sp9K+672q3eKg=",
+        "checksum": "Q15bwVoaq1Noe1m3R1UrRBlJGLGSM=",
         "control": {
-          "checksum": "sha1-ibJSAAe0yAmeC3Sp9K+672q3eKg=",
-          "range": "bytes=704-1060"
+          "checksum": "sha1-5bwVoaq1Noe1m3R1UrRBlJGLGSM=",
+          "range": "bytes=702-1043"
         },
         "data": {
-          "checksum": "sha256-Qdx821f7/tO71EyPPGGyuTZlK4If05eUDqMkGTNYzdw=",
-          "range": "bytes=1061-603623"
+          "checksum": "sha256-RUfH3pZt5PBG2RCxX2qGzc0JK+BWQ3BfabP8B3Zjkyo=",
+          "range": "bytes=1044-605796"
         },
         "name": "ncurses-terminfo-base",
         "signature": {
-          "checksum": "sha1-hFLJnjW3MeXzjutUUaMVz+pq774=",
-          "range": "bytes=0-703"
+          "checksum": "sha1-qOe+XIaqWDBfRGrODGmvZj+PGs8=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ncurses-terminfo-base-6.4_p20231125-r3.apk",
-        "version": "6.4_p20231125-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/ncurses-terminfo-base-6.5_p20240629-r0.apk",
+        "version": "6.5_p20240629-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Ai8jWuxKZR2M2XhOpOGAoTEwnnk=",
+        "checksum": "Q1WR9MGKU+cJh6dJFEXnr3zU1qsMM=",
         "control": {
-          "checksum": "sha1-Ai8jWuxKZR2M2XhOpOGAoTEwnnk=",
-          "range": "bytes=705-1037"
+          "checksum": "sha1-WR9MGKU+cJh6dJFEXnr3zU1qsMM=",
+          "range": "bytes=705-1034"
         },
         "data": {
-          "checksum": "sha256-e4UardkBVyaC49aSyrVmXNi8sSKqQl4eKYd0LxGRLA0=",
-          "range": "bytes=1038-255695"
+          "checksum": "sha256-EkOhtSivoLErXsK2J9ri39thkwb2kJGYHVou4n6dMKA=",
+          "range": "bytes=1035-254654"
         },
         "name": "ca-certificates-bundle",
         "signature": {
-          "checksum": "sha1-loRuyYQLm+atp+YteiQoj++EWIM=",
+          "checksum": "sha1-WL9vKv1nPIeaUQI4O0DiY9RdSHE=",
           "range": "bytes=0-704"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20240315-r4.apk",
-        "version": "20240315-r4"
+        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20240705-r0.apk",
+        "version": "20240705-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1+GH6qRN4iy1IDt0cT0x0tin7YfI=",
+        "checksum": "Q1KmG1L67f+/TnVGcnIcLfWRF/K2g=",
         "control": {
-          "checksum": "sha1-+GH6qRN4iy1IDt0cT0x0tin7YfI=",
-          "range": "bytes=703-1051"
+          "checksum": "sha1-KmG1L67f+/TnVGcnIcLfWRF/K2g=",
+          "range": "bytes=702-1051"
         },
         "data": {
-          "checksum": "sha256-rO0P9z2V49BSrz1A5Ap69tEappVrg5MMBjzW00rOpZc=",
-          "range": "bytes=1052-122464"
+          "checksum": "sha256-2YIxYc/Quit+Kri2qS8p6XvL7taAmOYJU/1Z8RNQ+88=",
+          "range": "bytes=1052-122509"
         },
         "name": "wolfi-baselayout",
         "signature": {
-          "checksum": "sha1-Ntb6VuMzDfM+frpCjKEIpDzl53I=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-VVyPrknEtqCPym5lfhVEuIhfkKg=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r12.apk",
-        "version": "20230201-r12"
+        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r13.apk",
+        "version": "20230201-r13"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q17rD4cKGW3uVSJw02PFiYR719t/Y=",
+        "checksum": "Q1ASyaCJL2Zyz4uAKpPPlx1Sd40yo=",
         "control": {
-          "checksum": "sha1-7rD4cKGW3uVSJw02PFiYR719t/Y=",
-          "range": "bytes=697-1108"
+          "checksum": "sha1-ASyaCJL2Zyz4uAKpPPlx1Sd40yo=",
+          "range": "bytes=706-1101"
         },
         "data": {
-          "checksum": "sha256-GvSViXbvUD0BdV2A+IzVJni2DjLvyM+j14hM29DcsYg=",
-          "range": "bytes=1109-268391"
+          "checksum": "sha256-KoaUrlV3QZ4ATGvKgOmZ1C8Rb/tHK3zEiCTGDrxxc/I=",
+          "range": "bytes=1102-272818"
         },
         "name": "ld-linux",
         "signature": {
-          "checksum": "sha1-nRIFect8o/LOUIEvN17AsrI07dg=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-DBrLE0fWPMyB5/0kAtNlIK6viCU=",
+          "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1/A0wNjkLqqBhe0jFr2D9SKcDNq8=",
+        "checksum": "Q10iHLABsXtuH2JyExQ2IIxH1NUCI=",
         "control": {
-          "checksum": "sha1-/A0wNjkLqqBhe0jFr2D9SKcDNq8=",
-          "range": "bytes=696-1054"
+          "checksum": "sha1-0iHLABsXtuH2JyExQ2IIxH1NUCI=",
+          "range": "bytes=698-1041"
         },
         "data": {
-          "checksum": "sha256-GT22MF6hR+Tj4el5xk2QEwNWig5JRoOrZ60Lecz+lok=",
-          "range": "bytes=1055-408851"
+          "checksum": "sha256-A3RF8XLSIePkapCnvEridXa2N7nheKNT1kTKDqZlGdI=",
+          "range": "bytes=1042-408849"
         },
         "name": "glibc-locale-posix",
         "signature": {
-          "checksum": "sha1-9uPIvcOCeZbPiR7+MLDB4tkJlHo=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-QqrJFnJmyPeT66hUk3O7NxaWY8I=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1YLxq+Z9/+aFnCwvgV7acVLT4QFA=",
+        "checksum": "Q1JYf1zI1zVi/S9sMI32guk6ptuRQ=",
         "control": {
-          "checksum": "sha1-YLxq+Z9/+aFnCwvgV7acVLT4QFA=",
-          "range": "bytes=701-1330"
+          "checksum": "sha1-JYf1zI1zVi/S9sMI32guk6ptuRQ=",
+          "range": "bytes=701-1308"
         },
         "data": {
-          "checksum": "sha256-9s5RNfAJ3GVt7a/fFUaew5MfYYUkvL/6FMvsEfD95jY=",
-          "range": "bytes=1331-5862057"
+          "checksum": "sha256-ioC8korS2nJpJvoS6He+mKkDsgVLcMxiEuYLsAB9M7U=",
+          "range": "bytes=1309-5959239"
         },
         "name": "glibc",
         "signature": {
-          "checksum": "sha1-Kvfb+I/1PCfiBTjoaU4ezZa0b+8=",
+          "checksum": "sha1-3TP2+cHjCEBrIFluCdTmr2oJA1s=",
           "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ggdVedzys8c0/DPbL/8uVM0IeHM=",
+        "checksum": "Q1UbEaadDhtuSAInuPjntJMZefM4U=",
         "control": {
-          "checksum": "sha1-ggdVedzys8c0/DPbL/8uVM0IeHM=",
-          "range": "bytes=697-1165"
+          "checksum": "sha1-UbEaadDhtuSAInuPjntJMZefM4U=",
+          "range": "bytes=698-1152"
         },
         "data": {
-          "checksum": "sha256-7NLgBuaKCCXSTXXEZ48mE9pTOgyoOY6yHLR2cW0LdGM=",
-          "range": "bytes=1166-1048223"
+          "checksum": "sha256-gkm/MRL/YRxHkRROZEW/TSWGC7r+ZAqogwd0Umio3LU=",
+          "range": "bytes=1153-1065345"
         },
         "name": "ncurses",
         "signature": {
-          "checksum": "sha1-50wXsiR3GgiiLwsWICdXEagYHRE=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-NLFv0xzWR8uGe+4SFVz9mAZDn/k=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ncurses-6.4_p20231125-r3.apk",
-        "version": "6.4_p20231125-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/ncurses-6.5_p20240629-r0.apk",
+        "version": "6.5_p20240629-r0"
       },
       {
         "architecture": "x86_64",
@@ -166,22 +166,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Zi0e8Bq6WCd/6uXXjVhb8YwMD1U=",
+        "checksum": "Q1WAlPh7UNBV+RHfBixVB5P9F9Mp8=",
         "control": {
-          "checksum": "sha1-Zi0e8Bq6WCd/6uXXjVhb8YwMD1U=",
-          "range": "bytes=700-1073"
+          "checksum": "sha1-WAlPh7UNBV+RHfBixVB5P9F9Mp8=",
+          "range": "bytes=700-1074"
         },
         "data": {
-          "checksum": "sha256-jMhtfqVjnhuuBO7wtNZ6RS/72sZWoKt/Moage2amlks=",
-          "range": "bytes=1074-81594"
+          "checksum": "sha256-i6uEFvUEbJ4YzgNSV58aObIdU608mjbCVPwyF57ZeQQ=",
+          "range": "bytes=1075-81593"
         },
         "name": "protobuf-c",
         "signature": {
-          "checksum": "sha1-kATwMKztK7nk7qbYCJPkCFp6IXc=",
+          "checksum": "sha1-47zwDXmhcWiVtTYCjq4sFld8wHQ=",
           "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r5.apk",
-        "version": "1.5.0-r5"
+        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r6.apk",
+        "version": "1.5.0-r6"
       },
       {
         "architecture": "x86_64",
@@ -261,41 +261,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Q/Zy5ovYSu2p/vVLr6DgVA1e8AQ=",
+        "checksum": "Q1a5wJzZI7k9o4F8hHFpfuqAUIH5Q=",
         "control": {
-          "checksum": "sha1-Q/Zy5ovYSu2p/vVLr6DgVA1e8AQ=",
-          "range": "bytes=699-1062"
+          "checksum": "sha1-a5wJzZI7k9o4F8hHFpfuqAUIH5Q=",
+          "range": "bytes=710-1075"
         },
         "data": {
-          "checksum": "sha256-H3jxsw8ytOeCIR4vq17voSVhdNokXk8C1g075txH6Bs=",
-          "range": "bytes=1063-5903754"
+          "checksum": "sha256-2p1UC4F4Odfxup/J/nyzujYRGaxGVjBOBWoc0aajClI=",
+          "range": "bytes=1076-5903889"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-NIl2f5OI/wSZByI8Ds1ZUfbFWyw=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-SOFoklqXtH38i1PcI3G/cPdRFtY=",
+          "range": "bytes=0-709"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.1-r3.apk",
-        "version": "3.3.1-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.1-r4.apk",
+        "version": "3.3.1-r4"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q13wGUXdZut9OOTdY5z2amUj9wXC0=",
+        "checksum": "Q1gb2VyLOsGV7xUiHBT0Ypt64rw6Y=",
         "control": {
-          "checksum": "sha1-3wGUXdZut9OOTdY5z2amUj9wXC0=",
-          "range": "bytes=698-1068"
+          "checksum": "sha1-gb2VyLOsGV7xUiHBT0Ypt64rw6Y=",
+          "range": "bytes=702-1071"
         },
         "data": {
-          "checksum": "sha256-mRda6+YGlOCczyIWKaHqXskTINoT1rgorHDHqAKAb7c=",
-          "range": "bytes=1069-1188955"
+          "checksum": "sha256-h2tz/aFB2n8SFdBFde5foQm1ru+8JUcGp+trUeA2ZlQ=",
+          "range": "bytes=1072-1188954"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-+UdRc4U3PKw4H9OiNurHKXa5BYk=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-w6U2Pb1Y90u1iBFc/sHg2xn6Qmo=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.1-r3.apk",
-        "version": "3.3.1-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.1-r4.apk",
+        "version": "3.3.1-r4"
       },
       {
         "architecture": "x86_64",
@@ -413,60 +413,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1gfqHM/7r3rXX1HqC163slTPP46o=",
+        "checksum": "Q1DLAp18ebMscosnQ4TfTivIzgtCY=",
         "control": {
-          "checksum": "sha1-gfqHM/7r3rXX1HqC163slTPP46o=",
-          "range": "bytes=704-1101"
+          "checksum": "sha1-DLAp18ebMscosnQ4TfTivIzgtCY=",
+          "range": "bytes=698-1079"
         },
         "data": {
-          "checksum": "sha256-OR7ikvfUYp78EsP0I2kuwqqAcy05jw9tr7JVQ6jTnGQ=",
-          "range": "bytes=1102-185433"
+          "checksum": "sha256-eiBdqqECWnULWGe/Gnd6iv/7h56A4xR2qw+5toY5Gaw=",
+          "range": "bytes=1080-185559"
         },
         "name": "libgcc",
         "signature": {
-          "checksum": "sha1-Il4pyVzI6eqNd/f4bsKeakpB5DI=",
-          "range": "bytes=0-703"
+          "checksum": "sha1-qVj9laNeBIwRxP+8ehB+fXftJrw=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.2.0-r7.apk",
-        "version": "13.2.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r0.apk",
+        "version": "13.3.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1c+lykdx+yHoqsrQmQLHMV7waR1Q=",
+        "checksum": "Q1p9aaHhpB2Ud0URrcIrVRAujMw+o=",
         "control": {
-          "checksum": "sha1-c+lykdx+yHoqsrQmQLHMV7waR1Q=",
-          "range": "bytes=701-1119"
+          "checksum": "sha1-p9aaHhpB2Ud0URrcIrVRAujMw+o=",
+          "range": "bytes=696-1097"
         },
         "data": {
-          "checksum": "sha256-CuZi2C5g0vUnz4PNH8jIWV+EBdVMvHr+sNKFYTSnQZk=",
-          "range": "bytes=1120-3155369"
+          "checksum": "sha256-rGMnyLiGEDCEVgqA1oXMf28QHuWHAaPzYrLeDzQ3WOU=",
+          "range": "bytes=1098-3155519"
         },
         "name": "libstdc++",
         "signature": {
-          "checksum": "sha1-7l8MLj8aCcdqta/0sR+0PscBsD4=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-lge2XoAsgvp8U6ZBgT52N2xNQAw=",
+          "range": "bytes=0-695"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.2.0-r7.apk",
-        "version": "13.2.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r0.apk",
+        "version": "13.3.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1R8OxpY0fGwVaIwft4wJeswF5D54=",
+        "checksum": "Q1DUpLMidX5HbXUAFV8y3Imyt+Ank=",
         "control": {
-          "checksum": "sha1-R8OxpY0fGwVaIwft4wJeswF5D54=",
-          "range": "bytes=695-1059"
+          "checksum": "sha1-DUpLMidX5HbXUAFV8y3Imyt+Ank=",
+          "range": "bytes=698-1063"
         },
         "data": {
-          "checksum": "sha256-wNc8/SBJrGHfwywAtzCsAqeUOt0IaAhqNtlbv8OiHBE=",
-          "range": "bytes=1060-242151"
+          "checksum": "sha256-ZUDWWOBnxl5xi3b5HQCHaiYqKDSrnVpJQgavWpn1duc=",
+          "range": "bytes=1064-255810"
         },
         "name": "c-ares",
         "signature": {
-          "checksum": "sha1-55/PTlEHXI3o0hx9dSVdNwQeSMg=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-0AXk7b/B1baNADDg/NSocbW//pw=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.31.0-r0.apk",
-        "version": "1.31.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.32.1-r0.apk",
+        "version": "1.32.1-r0"
       },
       {
         "architecture": "x86_64",
@@ -527,22 +527,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q10AaU1ocIM4PYYNvwbml8TmpNvEA=",
+        "checksum": "Q1ORn/60iAvLcAgApXYoZzM6o0XSs=",
         "control": {
-          "checksum": "sha1-0AaU1ocIM4PYYNvwbml8TmpNvEA=",
-          "range": "bytes=706-1085"
+          "checksum": "sha1-ORn/60iAvLcAgApXYoZzM6o0XSs=",
+          "range": "bytes=703-1081"
         },
         "data": {
-          "checksum": "sha256-1YQNYASFjlP3kXX58ec8du75ij/U6O4DPAKzJAPkln0=",
-          "range": "bytes=1086-4272589"
+          "checksum": "sha256-Ya2Dn1VNYB21ZBD/jBCSx3SxZuJloJET5xkjX0s3Vt8=",
+          "range": "bytes=1082-4272708"
         },
         "name": "libxml2",
         "signature": {
-          "checksum": "sha1-QFjdplzGn/MiNFxMykgafr6/w6U=",
-          "range": "bytes=0-705"
+          "checksum": "sha1-s5jaTwJdla4k4KK0KEk7AYbgdqs=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.1-r1.apk",
-        "version": "2.13.1-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.2-r0.apk",
+        "version": "2.13.2-r0"
       },
       {
         "architecture": "x86_64",
@@ -603,22 +603,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1+0xClEzF5nhyNPUeGFhC++ElQmg=",
+        "checksum": "Q1u+fF2xg98dT0poYklte5HHMg/Kk=",
         "control": {
-          "checksum": "sha1-+0xClEzF5nhyNPUeGFhC++ElQmg=",
-          "range": "bytes=701-1107"
+          "checksum": "sha1-u+fF2xg98dT0poYklte5HHMg/Kk=",
+          "range": "bytes=701-1090"
         },
         "data": {
-          "checksum": "sha256-81V5R7T08up/3BwfuAG25Rq7KkB1MvALVCaogCpW500=",
-          "range": "bytes=1108-22181"
+          "checksum": "sha256-9e+i7LwSg7oAUU33f0r7A4Mc2suaK95iNU5BKaTSXac=",
+          "range": "bytes=1091-22179"
         },
         "name": "libcrypt1",
         "signature": {
-          "checksum": "sha1-k+7JfhPi5KOQ+6Nqk3oAfTbtOVM=",
+          "checksum": "sha1-EWBUcJqCJTOYJq1H0/kkO+m6W3E=",
           "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",
@@ -850,22 +850,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1KXXN9Hu7PZ0iPK7gAnYRUDcDzZs=",
+        "checksum": "Q1VJwVzi86yWcTj5PHY01vdoetpZQ=",
         "control": {
-          "checksum": "sha1-KXXN9Hu7PZ0iPK7gAnYRUDcDzZs=",
-          "range": "bytes=700-1063"
+          "checksum": "sha1-VJwVzi86yWcTj5PHY01vdoetpZQ=",
+          "range": "bytes=710-1058"
         },
         "data": {
-          "checksum": "sha256-F61XBj+QV78wXrinzeVQestiQeJtCAVPWwbLWf8c98Y=",
-          "range": "bytes=1064-12733161"
+          "checksum": "sha256-kBMNCuqgebDS1M9EjrUO3wqJ2laPKu/oE0YI/4szp4M=",
+          "range": "bytes=1059-12733185"
         },
         "name": "git-lfs",
         "signature": {
-          "checksum": "sha1-U6NrIIwbHHzX/fgtB3PoNVQZOJU=",
-          "range": "bytes=0-699"
+          "checksum": "sha1-RgfxUCV6GAC4fDsAvBAZ6AWoGFM=",
+          "range": "bytes=0-709"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/git-lfs-3.5.1-r6.apk",
-        "version": "3.5.1-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/git-lfs-3.5.1-r7.apk",
+        "version": "3.5.1-r7"
       },
       {
         "architecture": "x86_64",
@@ -1040,22 +1040,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q19lUpYPaVnv70kshfW0v/13XTNXc=",
+        "checksum": "Q1PHgnhvSy0SxqgLQc4V4dtaQ6sUo=",
         "control": {
-          "checksum": "sha1-9lUpYPaVnv70kshfW0v/13XTNXc=",
-          "range": "bytes=697-1146"
+          "checksum": "sha1-PHgnhvSy0SxqgLQc4V4dtaQ6sUo=",
+          "range": "bytes=699-1133"
         },
         "data": {
-          "checksum": "sha256-9Gn07toI1MChIgfXnxaTJQ6cH9BEG2bHmq2cYNSO9cU=",
-          "range": "bytes=1147-996427"
+          "checksum": "sha256-azs/Gn4jbpFwPIosLxAIQK9cuIRi/a4HWD9kOzi2whE=",
+          "range": "bytes=1134-1124576"
         },
         "name": "gdbm",
         "signature": {
-          "checksum": "sha1-iBmI2lW1dZcunxPMZXI29oayzBQ=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-62Pf1vhZGGdtLkZwFXpTAb7xiG0=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/gdbm-1.23-r6.apk",
-        "version": "1.23-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/gdbm-1.24-r0.apk",
+        "version": "1.24-r0"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/grafana.lock.json
+++ b/wolfi-images/grafana.lock.json
@@ -18,136 +18,136 @@
     "packages": [
       {
         "architecture": "x86_64",
-        "checksum": "Q1Ai8jWuxKZR2M2XhOpOGAoTEwnnk=",
+        "checksum": "Q1WR9MGKU+cJh6dJFEXnr3zU1qsMM=",
         "control": {
-          "checksum": "sha1-Ai8jWuxKZR2M2XhOpOGAoTEwnnk=",
-          "range": "bytes=705-1037"
+          "checksum": "sha1-WR9MGKU+cJh6dJFEXnr3zU1qsMM=",
+          "range": "bytes=705-1034"
         },
         "data": {
-          "checksum": "sha256-e4UardkBVyaC49aSyrVmXNi8sSKqQl4eKYd0LxGRLA0=",
-          "range": "bytes=1038-255695"
+          "checksum": "sha256-EkOhtSivoLErXsK2J9ri39thkwb2kJGYHVou4n6dMKA=",
+          "range": "bytes=1035-254654"
         },
         "name": "ca-certificates-bundle",
         "signature": {
-          "checksum": "sha1-loRuyYQLm+atp+YteiQoj++EWIM=",
+          "checksum": "sha1-WL9vKv1nPIeaUQI4O0DiY9RdSHE=",
           "range": "bytes=0-704"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20240315-r4.apk",
-        "version": "20240315-r4"
+        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20240705-r0.apk",
+        "version": "20240705-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1+GH6qRN4iy1IDt0cT0x0tin7YfI=",
+        "checksum": "Q1KmG1L67f+/TnVGcnIcLfWRF/K2g=",
         "control": {
-          "checksum": "sha1-+GH6qRN4iy1IDt0cT0x0tin7YfI=",
-          "range": "bytes=703-1051"
+          "checksum": "sha1-KmG1L67f+/TnVGcnIcLfWRF/K2g=",
+          "range": "bytes=702-1051"
         },
         "data": {
-          "checksum": "sha256-rO0P9z2V49BSrz1A5Ap69tEappVrg5MMBjzW00rOpZc=",
-          "range": "bytes=1052-122464"
+          "checksum": "sha256-2YIxYc/Quit+Kri2qS8p6XvL7taAmOYJU/1Z8RNQ+88=",
+          "range": "bytes=1052-122509"
         },
         "name": "wolfi-baselayout",
         "signature": {
-          "checksum": "sha1-Ntb6VuMzDfM+frpCjKEIpDzl53I=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-VVyPrknEtqCPym5lfhVEuIhfkKg=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r12.apk",
-        "version": "20230201-r12"
+        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r13.apk",
+        "version": "20230201-r13"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q17rD4cKGW3uVSJw02PFiYR719t/Y=",
+        "checksum": "Q1ASyaCJL2Zyz4uAKpPPlx1Sd40yo=",
         "control": {
-          "checksum": "sha1-7rD4cKGW3uVSJw02PFiYR719t/Y=",
-          "range": "bytes=697-1108"
+          "checksum": "sha1-ASyaCJL2Zyz4uAKpPPlx1Sd40yo=",
+          "range": "bytes=706-1101"
         },
         "data": {
-          "checksum": "sha256-GvSViXbvUD0BdV2A+IzVJni2DjLvyM+j14hM29DcsYg=",
-          "range": "bytes=1109-268391"
+          "checksum": "sha256-KoaUrlV3QZ4ATGvKgOmZ1C8Rb/tHK3zEiCTGDrxxc/I=",
+          "range": "bytes=1102-272818"
         },
         "name": "ld-linux",
         "signature": {
-          "checksum": "sha1-nRIFect8o/LOUIEvN17AsrI07dg=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-DBrLE0fWPMyB5/0kAtNlIK6viCU=",
+          "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1/A0wNjkLqqBhe0jFr2D9SKcDNq8=",
+        "checksum": "Q10iHLABsXtuH2JyExQ2IIxH1NUCI=",
         "control": {
-          "checksum": "sha1-/A0wNjkLqqBhe0jFr2D9SKcDNq8=",
-          "range": "bytes=696-1054"
+          "checksum": "sha1-0iHLABsXtuH2JyExQ2IIxH1NUCI=",
+          "range": "bytes=698-1041"
         },
         "data": {
-          "checksum": "sha256-GT22MF6hR+Tj4el5xk2QEwNWig5JRoOrZ60Lecz+lok=",
-          "range": "bytes=1055-408851"
+          "checksum": "sha256-A3RF8XLSIePkapCnvEridXa2N7nheKNT1kTKDqZlGdI=",
+          "range": "bytes=1042-408849"
         },
         "name": "glibc-locale-posix",
         "signature": {
-          "checksum": "sha1-9uPIvcOCeZbPiR7+MLDB4tkJlHo=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-QqrJFnJmyPeT66hUk3O7NxaWY8I=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1YLxq+Z9/+aFnCwvgV7acVLT4QFA=",
+        "checksum": "Q1JYf1zI1zVi/S9sMI32guk6ptuRQ=",
         "control": {
-          "checksum": "sha1-YLxq+Z9/+aFnCwvgV7acVLT4QFA=",
-          "range": "bytes=701-1330"
+          "checksum": "sha1-JYf1zI1zVi/S9sMI32guk6ptuRQ=",
+          "range": "bytes=701-1308"
         },
         "data": {
-          "checksum": "sha256-9s5RNfAJ3GVt7a/fFUaew5MfYYUkvL/6FMvsEfD95jY=",
-          "range": "bytes=1331-5862057"
+          "checksum": "sha256-ioC8korS2nJpJvoS6He+mKkDsgVLcMxiEuYLsAB9M7U=",
+          "range": "bytes=1309-5959239"
         },
         "name": "glibc",
         "signature": {
-          "checksum": "sha1-Kvfb+I/1PCfiBTjoaU4ezZa0b+8=",
+          "checksum": "sha1-3TP2+cHjCEBrIFluCdTmr2oJA1s=",
           "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Q/Zy5ovYSu2p/vVLr6DgVA1e8AQ=",
+        "checksum": "Q1a5wJzZI7k9o4F8hHFpfuqAUIH5Q=",
         "control": {
-          "checksum": "sha1-Q/Zy5ovYSu2p/vVLr6DgVA1e8AQ=",
-          "range": "bytes=699-1062"
+          "checksum": "sha1-a5wJzZI7k9o4F8hHFpfuqAUIH5Q=",
+          "range": "bytes=710-1075"
         },
         "data": {
-          "checksum": "sha256-H3jxsw8ytOeCIR4vq17voSVhdNokXk8C1g075txH6Bs=",
-          "range": "bytes=1063-5903754"
+          "checksum": "sha256-2p1UC4F4Odfxup/J/nyzujYRGaxGVjBOBWoc0aajClI=",
+          "range": "bytes=1076-5903889"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-NIl2f5OI/wSZByI8Ds1ZUfbFWyw=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-SOFoklqXtH38i1PcI3G/cPdRFtY=",
+          "range": "bytes=0-709"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.1-r3.apk",
-        "version": "3.3.1-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.1-r4.apk",
+        "version": "3.3.1-r4"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q13wGUXdZut9OOTdY5z2amUj9wXC0=",
+        "checksum": "Q1gb2VyLOsGV7xUiHBT0Ypt64rw6Y=",
         "control": {
-          "checksum": "sha1-3wGUXdZut9OOTdY5z2amUj9wXC0=",
-          "range": "bytes=698-1068"
+          "checksum": "sha1-gb2VyLOsGV7xUiHBT0Ypt64rw6Y=",
+          "range": "bytes=702-1071"
         },
         "data": {
-          "checksum": "sha256-mRda6+YGlOCczyIWKaHqXskTINoT1rgorHDHqAKAb7c=",
-          "range": "bytes=1069-1188955"
+          "checksum": "sha256-h2tz/aFB2n8SFdBFde5foQm1ru+8JUcGp+trUeA2ZlQ=",
+          "range": "bytes=1072-1188954"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-+UdRc4U3PKw4H9OiNurHKXa5BYk=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-w6U2Pb1Y90u1iBFc/sHg2xn6Qmo=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.1-r3.apk",
-        "version": "3.3.1-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.1-r4.apk",
+        "version": "3.3.1-r4"
       },
       {
         "architecture": "x86_64",
@@ -208,22 +208,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1+0xClEzF5nhyNPUeGFhC++ElQmg=",
+        "checksum": "Q1u+fF2xg98dT0poYklte5HHMg/Kk=",
         "control": {
-          "checksum": "sha1-+0xClEzF5nhyNPUeGFhC++ElQmg=",
-          "range": "bytes=701-1107"
+          "checksum": "sha1-u+fF2xg98dT0poYklte5HHMg/Kk=",
+          "range": "bytes=701-1090"
         },
         "data": {
-          "checksum": "sha256-81V5R7T08up/3BwfuAG25Rq7KkB1MvALVCaogCpW500=",
-          "range": "bytes=1108-22181"
+          "checksum": "sha256-9e+i7LwSg7oAUU33f0r7A4Mc2suaK95iNU5BKaTSXac=",
+          "range": "bytes=1091-22179"
         },
         "name": "libcrypt1",
         "signature": {
-          "checksum": "sha1-k+7JfhPi5KOQ+6Nqk3oAfTbtOVM=",
+          "checksum": "sha1-EWBUcJqCJTOYJq1H0/kkO+m6W3E=",
           "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",
@@ -246,22 +246,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1z4pvqJVOguss+9HLVO7PzJUlt8w=",
+        "checksum": "Q1dmeR0/KVMZ3ZLmYVZZpeOM5D0YA=",
         "control": {
-          "checksum": "sha1-z4pvqJVOguss+9HLVO7PzJUlt8w=",
-          "range": "bytes=702-1032"
+          "checksum": "sha1-dmeR0/KVMZ3ZLmYVZZpeOM5D0YA=",
+          "range": "bytes=698-1038"
         },
         "data": {
-          "checksum": "sha256-AY5hTobJ3oQxODeewjKtWT/O0I3WSJJfbdnebiFHi9A=",
-          "range": "bytes=1033-61050535"
+          "checksum": "sha256-h229QLrsW/27BQzxyKGOvkrvJPnwhRPjtIV3aVoLq0U=",
+          "range": "bytes=1039-61050533"
         },
         "name": "glibc-locale-en",
         "signature": {
-          "checksum": "sha1-EnGHd74XHlmb/a2fq+hVub5BQN4=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-p2ZxY4sG1cAKJ7uPvhMKBxKw+k4=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-en-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-en-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",
@@ -284,41 +284,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ibJSAAe0yAmeC3Sp9K+672q3eKg=",
+        "checksum": "Q15bwVoaq1Noe1m3R1UrRBlJGLGSM=",
         "control": {
-          "checksum": "sha1-ibJSAAe0yAmeC3Sp9K+672q3eKg=",
-          "range": "bytes=704-1060"
+          "checksum": "sha1-5bwVoaq1Noe1m3R1UrRBlJGLGSM=",
+          "range": "bytes=702-1043"
         },
         "data": {
-          "checksum": "sha256-Qdx821f7/tO71EyPPGGyuTZlK4If05eUDqMkGTNYzdw=",
-          "range": "bytes=1061-603623"
+          "checksum": "sha256-RUfH3pZt5PBG2RCxX2qGzc0JK+BWQ3BfabP8B3Zjkyo=",
+          "range": "bytes=1044-605796"
         },
         "name": "ncurses-terminfo-base",
         "signature": {
-          "checksum": "sha1-hFLJnjW3MeXzjutUUaMVz+pq774=",
-          "range": "bytes=0-703"
+          "checksum": "sha1-qOe+XIaqWDBfRGrODGmvZj+PGs8=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ncurses-terminfo-base-6.4_p20231125-r3.apk",
-        "version": "6.4_p20231125-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/ncurses-terminfo-base-6.5_p20240629-r0.apk",
+        "version": "6.5_p20240629-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ggdVedzys8c0/DPbL/8uVM0IeHM=",
+        "checksum": "Q1UbEaadDhtuSAInuPjntJMZefM4U=",
         "control": {
-          "checksum": "sha1-ggdVedzys8c0/DPbL/8uVM0IeHM=",
-          "range": "bytes=697-1165"
+          "checksum": "sha1-UbEaadDhtuSAInuPjntJMZefM4U=",
+          "range": "bytes=698-1152"
         },
         "data": {
-          "checksum": "sha256-7NLgBuaKCCXSTXXEZ48mE9pTOgyoOY6yHLR2cW0LdGM=",
-          "range": "bytes=1166-1048223"
+          "checksum": "sha256-gkm/MRL/YRxHkRROZEW/TSWGC7r+ZAqogwd0Umio3LU=",
+          "range": "bytes=1153-1065345"
         },
         "name": "ncurses",
         "signature": {
-          "checksum": "sha1-50wXsiR3GgiiLwsWICdXEagYHRE=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-NLFv0xzWR8uGe+4SFVz9mAZDn/k=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ncurses-6.4_p20231125-r3.apk",
-        "version": "6.4_p20231125-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/ncurses-6.5_p20240629-r0.apk",
+        "version": "6.5_p20240629-r0"
       },
       {
         "architecture": "x86_64",
@@ -512,60 +512,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1KMg8c3QSJ+NeZPDKFMGmQlLUYME=",
+        "checksum": "Q1Kxll+QLZYaw52yo1UtG1Ye4o9fY=",
         "control": {
-          "checksum": "sha1-KMg8c3QSJ+NeZPDKFMGmQlLUYME=",
-          "range": "bytes=704-1057"
+          "checksum": "sha1-Kxll+QLZYaw52yo1UtG1Ye4o9fY=",
+          "range": "bytes=696-1033"
         },
         "data": {
-          "checksum": "sha256-ZJacULEBjzPdr68uYOi2nDpaNMQrwwBlTo+ZKAqts78=",
-          "range": "bytes=1058-2990798"
+          "checksum": "sha256-XT6dT973EmVtXZHhuW5+F2vKai202F4xyyTnPFJnGgs=",
+          "range": "bytes=1034-3018563"
         },
         "name": "ncurses-terminfo",
         "signature": {
-          "checksum": "sha1-fecXgZrXf427D4qg9ZlAuTz43W0=",
-          "range": "bytes=0-703"
+          "checksum": "sha1-IqOOoESnyj6ytmw0/kxqeP5t+aU=",
+          "range": "bytes=0-695"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ncurses-terminfo-6.4_p20231125-r3.apk",
-        "version": "6.4_p20231125-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/ncurses-terminfo-6.5_p20240629-r0.apk",
+        "version": "6.5_p20240629-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q13r+1JUdz32rNPARV9THvg4bpllM=",
+        "checksum": "Q1QOvPG8Drs+6hUX0hvQt4EOfmjXM=",
         "control": {
-          "checksum": "sha1-3r+1JUdz32rNPARV9THvg4bpllM=",
-          "range": "bytes=698-1061"
+          "checksum": "sha1-QOvPG8Drs+6hUX0hvQt4EOfmjXM=",
+          "range": "bytes=697-1060"
         },
         "data": {
-          "checksum": "sha256-apnA3TGfV7N2B1Xp5R/yjglx9HRGqoqHYVPGfGhCXo8=",
-          "range": "bytes=1062-178451"
+          "checksum": "sha256-07/awHiPtitUFLaoOdu6PW5qHX4yl2n5goRdLEfPxUk=",
+          "range": "bytes=1061-178450"
         },
         "name": "openssl-provider-legacy",
         "signature": {
-          "checksum": "sha1-oLy1zTY/WbDdrqnIe3/rrpxj0VU=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-n38XlIA18QC4lxXyKdNcioCCRqk=",
+          "range": "bytes=0-696"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/openssl-provider-legacy-3.3.1-r3.apk",
-        "version": "3.3.1-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/openssl-provider-legacy-3.3.1-r4.apk",
+        "version": "3.3.1-r4"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1/eKBTceqDR6fZQVoeOdWfx1SXRo=",
+        "checksum": "Q1BTkFvS1Ufg9rUbxWKMv2TTWt25g=",
         "control": {
-          "checksum": "sha1-/eKBTceqDR6fZQVoeOdWfx1SXRo=",
-          "range": "bytes=705-1115"
+          "checksum": "sha1-BTkFvS1Ufg9rUbxWKMv2TTWt25g=",
+          "range": "bytes=704-1116"
         },
         "data": {
-          "checksum": "sha256-H1aqjZjk79mgvrhp5QLK7ew5xYqT8P9VG5m8KXk3PJU=",
-          "range": "bytes=1116-1242637"
+          "checksum": "sha256-qGyumfoWLjsWyFcc2jNzyUks8eeJlWkSey+GgqgAM34=",
+          "range": "bytes=1117-1242652"
         },
         "name": "openssl",
         "signature": {
-          "checksum": "sha1-xYyQE6nodg8z47TyfnvFe7auA0M=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-KYCyUcw6HHqBQEjXydFvx2Icxf8=",
+          "range": "bytes=0-703"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/openssl-3.3.1-r3.apk",
-        "version": "3.3.1-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/openssl-3.3.1-r4.apk",
+        "version": "3.3.1-r4"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/jaeger-agent.lock.json
+++ b/wolfi-images/jaeger-agent.lock.json
@@ -14,117 +14,117 @@
     "packages": [
       {
         "architecture": "x86_64",
-        "checksum": "Q1Ai8jWuxKZR2M2XhOpOGAoTEwnnk=",
+        "checksum": "Q1WR9MGKU+cJh6dJFEXnr3zU1qsMM=",
         "control": {
-          "checksum": "sha1-Ai8jWuxKZR2M2XhOpOGAoTEwnnk=",
-          "range": "bytes=705-1037"
+          "checksum": "sha1-WR9MGKU+cJh6dJFEXnr3zU1qsMM=",
+          "range": "bytes=705-1034"
         },
         "data": {
-          "checksum": "sha256-e4UardkBVyaC49aSyrVmXNi8sSKqQl4eKYd0LxGRLA0=",
-          "range": "bytes=1038-255695"
+          "checksum": "sha256-EkOhtSivoLErXsK2J9ri39thkwb2kJGYHVou4n6dMKA=",
+          "range": "bytes=1035-254654"
         },
         "name": "ca-certificates-bundle",
         "signature": {
-          "checksum": "sha1-loRuyYQLm+atp+YteiQoj++EWIM=",
+          "checksum": "sha1-WL9vKv1nPIeaUQI4O0DiY9RdSHE=",
           "range": "bytes=0-704"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20240315-r4.apk",
-        "version": "20240315-r4"
+        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20240705-r0.apk",
+        "version": "20240705-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1+GH6qRN4iy1IDt0cT0x0tin7YfI=",
+        "checksum": "Q1KmG1L67f+/TnVGcnIcLfWRF/K2g=",
         "control": {
-          "checksum": "sha1-+GH6qRN4iy1IDt0cT0x0tin7YfI=",
-          "range": "bytes=703-1051"
+          "checksum": "sha1-KmG1L67f+/TnVGcnIcLfWRF/K2g=",
+          "range": "bytes=702-1051"
         },
         "data": {
-          "checksum": "sha256-rO0P9z2V49BSrz1A5Ap69tEappVrg5MMBjzW00rOpZc=",
-          "range": "bytes=1052-122464"
+          "checksum": "sha256-2YIxYc/Quit+Kri2qS8p6XvL7taAmOYJU/1Z8RNQ+88=",
+          "range": "bytes=1052-122509"
         },
         "name": "wolfi-baselayout",
         "signature": {
-          "checksum": "sha1-Ntb6VuMzDfM+frpCjKEIpDzl53I=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-VVyPrknEtqCPym5lfhVEuIhfkKg=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r12.apk",
-        "version": "20230201-r12"
+        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r13.apk",
+        "version": "20230201-r13"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q17rD4cKGW3uVSJw02PFiYR719t/Y=",
+        "checksum": "Q1ASyaCJL2Zyz4uAKpPPlx1Sd40yo=",
         "control": {
-          "checksum": "sha1-7rD4cKGW3uVSJw02PFiYR719t/Y=",
-          "range": "bytes=697-1108"
+          "checksum": "sha1-ASyaCJL2Zyz4uAKpPPlx1Sd40yo=",
+          "range": "bytes=706-1101"
         },
         "data": {
-          "checksum": "sha256-GvSViXbvUD0BdV2A+IzVJni2DjLvyM+j14hM29DcsYg=",
-          "range": "bytes=1109-268391"
+          "checksum": "sha256-KoaUrlV3QZ4ATGvKgOmZ1C8Rb/tHK3zEiCTGDrxxc/I=",
+          "range": "bytes=1102-272818"
         },
         "name": "ld-linux",
         "signature": {
-          "checksum": "sha1-nRIFect8o/LOUIEvN17AsrI07dg=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-DBrLE0fWPMyB5/0kAtNlIK6viCU=",
+          "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1/A0wNjkLqqBhe0jFr2D9SKcDNq8=",
+        "checksum": "Q10iHLABsXtuH2JyExQ2IIxH1NUCI=",
         "control": {
-          "checksum": "sha1-/A0wNjkLqqBhe0jFr2D9SKcDNq8=",
-          "range": "bytes=696-1054"
+          "checksum": "sha1-0iHLABsXtuH2JyExQ2IIxH1NUCI=",
+          "range": "bytes=698-1041"
         },
         "data": {
-          "checksum": "sha256-GT22MF6hR+Tj4el5xk2QEwNWig5JRoOrZ60Lecz+lok=",
-          "range": "bytes=1055-408851"
+          "checksum": "sha256-A3RF8XLSIePkapCnvEridXa2N7nheKNT1kTKDqZlGdI=",
+          "range": "bytes=1042-408849"
         },
         "name": "glibc-locale-posix",
         "signature": {
-          "checksum": "sha1-9uPIvcOCeZbPiR7+MLDB4tkJlHo=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-QqrJFnJmyPeT66hUk3O7NxaWY8I=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1YLxq+Z9/+aFnCwvgV7acVLT4QFA=",
+        "checksum": "Q1JYf1zI1zVi/S9sMI32guk6ptuRQ=",
         "control": {
-          "checksum": "sha1-YLxq+Z9/+aFnCwvgV7acVLT4QFA=",
-          "range": "bytes=701-1330"
+          "checksum": "sha1-JYf1zI1zVi/S9sMI32guk6ptuRQ=",
+          "range": "bytes=701-1308"
         },
         "data": {
-          "checksum": "sha256-9s5RNfAJ3GVt7a/fFUaew5MfYYUkvL/6FMvsEfD95jY=",
-          "range": "bytes=1331-5862057"
+          "checksum": "sha256-ioC8korS2nJpJvoS6He+mKkDsgVLcMxiEuYLsAB9M7U=",
+          "range": "bytes=1309-5959239"
         },
         "name": "glibc",
         "signature": {
-          "checksum": "sha1-Kvfb+I/1PCfiBTjoaU4ezZa0b+8=",
+          "checksum": "sha1-3TP2+cHjCEBrIFluCdTmr2oJA1s=",
           "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Zi0e8Bq6WCd/6uXXjVhb8YwMD1U=",
+        "checksum": "Q1WAlPh7UNBV+RHfBixVB5P9F9Mp8=",
         "control": {
-          "checksum": "sha1-Zi0e8Bq6WCd/6uXXjVhb8YwMD1U=",
-          "range": "bytes=700-1073"
+          "checksum": "sha1-WAlPh7UNBV+RHfBixVB5P9F9Mp8=",
+          "range": "bytes=700-1074"
         },
         "data": {
-          "checksum": "sha256-jMhtfqVjnhuuBO7wtNZ6RS/72sZWoKt/Moage2amlks=",
-          "range": "bytes=1074-81594"
+          "checksum": "sha256-i6uEFvUEbJ4YzgNSV58aObIdU608mjbCVPwyF57ZeQQ=",
+          "range": "bytes=1075-81593"
         },
         "name": "protobuf-c",
         "signature": {
-          "checksum": "sha1-kATwMKztK7nk7qbYCJPkCFp6IXc=",
+          "checksum": "sha1-47zwDXmhcWiVtTYCjq4sFld8wHQ=",
           "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r5.apk",
-        "version": "1.5.0-r5"
+        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r6.apk",
+        "version": "1.5.0-r6"
       },
       {
         "architecture": "x86_64",
@@ -204,41 +204,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Q/Zy5ovYSu2p/vVLr6DgVA1e8AQ=",
+        "checksum": "Q1a5wJzZI7k9o4F8hHFpfuqAUIH5Q=",
         "control": {
-          "checksum": "sha1-Q/Zy5ovYSu2p/vVLr6DgVA1e8AQ=",
-          "range": "bytes=699-1062"
+          "checksum": "sha1-a5wJzZI7k9o4F8hHFpfuqAUIH5Q=",
+          "range": "bytes=710-1075"
         },
         "data": {
-          "checksum": "sha256-H3jxsw8ytOeCIR4vq17voSVhdNokXk8C1g075txH6Bs=",
-          "range": "bytes=1063-5903754"
+          "checksum": "sha256-2p1UC4F4Odfxup/J/nyzujYRGaxGVjBOBWoc0aajClI=",
+          "range": "bytes=1076-5903889"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-NIl2f5OI/wSZByI8Ds1ZUfbFWyw=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-SOFoklqXtH38i1PcI3G/cPdRFtY=",
+          "range": "bytes=0-709"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.1-r3.apk",
-        "version": "3.3.1-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.1-r4.apk",
+        "version": "3.3.1-r4"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q13wGUXdZut9OOTdY5z2amUj9wXC0=",
+        "checksum": "Q1gb2VyLOsGV7xUiHBT0Ypt64rw6Y=",
         "control": {
-          "checksum": "sha1-3wGUXdZut9OOTdY5z2amUj9wXC0=",
-          "range": "bytes=698-1068"
+          "checksum": "sha1-gb2VyLOsGV7xUiHBT0Ypt64rw6Y=",
+          "range": "bytes=702-1071"
         },
         "data": {
-          "checksum": "sha256-mRda6+YGlOCczyIWKaHqXskTINoT1rgorHDHqAKAb7c=",
-          "range": "bytes=1069-1188955"
+          "checksum": "sha256-h2tz/aFB2n8SFdBFde5foQm1ru+8JUcGp+trUeA2ZlQ=",
+          "range": "bytes=1072-1188954"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-+UdRc4U3PKw4H9OiNurHKXa5BYk=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-w6U2Pb1Y90u1iBFc/sHg2xn6Qmo=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.1-r3.apk",
-        "version": "3.3.1-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.1-r4.apk",
+        "version": "3.3.1-r4"
       },
       {
         "architecture": "x86_64",
@@ -356,60 +356,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1gfqHM/7r3rXX1HqC163slTPP46o=",
+        "checksum": "Q1DLAp18ebMscosnQ4TfTivIzgtCY=",
         "control": {
-          "checksum": "sha1-gfqHM/7r3rXX1HqC163slTPP46o=",
-          "range": "bytes=704-1101"
+          "checksum": "sha1-DLAp18ebMscosnQ4TfTivIzgtCY=",
+          "range": "bytes=698-1079"
         },
         "data": {
-          "checksum": "sha256-OR7ikvfUYp78EsP0I2kuwqqAcy05jw9tr7JVQ6jTnGQ=",
-          "range": "bytes=1102-185433"
+          "checksum": "sha256-eiBdqqECWnULWGe/Gnd6iv/7h56A4xR2qw+5toY5Gaw=",
+          "range": "bytes=1080-185559"
         },
         "name": "libgcc",
         "signature": {
-          "checksum": "sha1-Il4pyVzI6eqNd/f4bsKeakpB5DI=",
-          "range": "bytes=0-703"
+          "checksum": "sha1-qVj9laNeBIwRxP+8ehB+fXftJrw=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.2.0-r7.apk",
-        "version": "13.2.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r0.apk",
+        "version": "13.3.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1c+lykdx+yHoqsrQmQLHMV7waR1Q=",
+        "checksum": "Q1p9aaHhpB2Ud0URrcIrVRAujMw+o=",
         "control": {
-          "checksum": "sha1-c+lykdx+yHoqsrQmQLHMV7waR1Q=",
-          "range": "bytes=701-1119"
+          "checksum": "sha1-p9aaHhpB2Ud0URrcIrVRAujMw+o=",
+          "range": "bytes=696-1097"
         },
         "data": {
-          "checksum": "sha256-CuZi2C5g0vUnz4PNH8jIWV+EBdVMvHr+sNKFYTSnQZk=",
-          "range": "bytes=1120-3155369"
+          "checksum": "sha256-rGMnyLiGEDCEVgqA1oXMf28QHuWHAaPzYrLeDzQ3WOU=",
+          "range": "bytes=1098-3155519"
         },
         "name": "libstdc++",
         "signature": {
-          "checksum": "sha1-7l8MLj8aCcdqta/0sR+0PscBsD4=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-lge2XoAsgvp8U6ZBgT52N2xNQAw=",
+          "range": "bytes=0-695"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.2.0-r7.apk",
-        "version": "13.2.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r0.apk",
+        "version": "13.3.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1R8OxpY0fGwVaIwft4wJeswF5D54=",
+        "checksum": "Q1DUpLMidX5HbXUAFV8y3Imyt+Ank=",
         "control": {
-          "checksum": "sha1-R8OxpY0fGwVaIwft4wJeswF5D54=",
-          "range": "bytes=695-1059"
+          "checksum": "sha1-DUpLMidX5HbXUAFV8y3Imyt+Ank=",
+          "range": "bytes=698-1063"
         },
         "data": {
-          "checksum": "sha256-wNc8/SBJrGHfwywAtzCsAqeUOt0IaAhqNtlbv8OiHBE=",
-          "range": "bytes=1060-242151"
+          "checksum": "sha256-ZUDWWOBnxl5xi3b5HQCHaiYqKDSrnVpJQgavWpn1duc=",
+          "range": "bytes=1064-255810"
         },
         "name": "c-ares",
         "signature": {
-          "checksum": "sha1-55/PTlEHXI3o0hx9dSVdNwQeSMg=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-0AXk7b/B1baNADDg/NSocbW//pw=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.31.0-r0.apk",
-        "version": "1.31.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.32.1-r0.apk",
+        "version": "1.32.1-r0"
       },
       {
         "architecture": "x86_64",
@@ -470,22 +470,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q10AaU1ocIM4PYYNvwbml8TmpNvEA=",
+        "checksum": "Q1ORn/60iAvLcAgApXYoZzM6o0XSs=",
         "control": {
-          "checksum": "sha1-0AaU1ocIM4PYYNvwbml8TmpNvEA=",
-          "range": "bytes=706-1085"
+          "checksum": "sha1-ORn/60iAvLcAgApXYoZzM6o0XSs=",
+          "range": "bytes=703-1081"
         },
         "data": {
-          "checksum": "sha256-1YQNYASFjlP3kXX58ec8du75ij/U6O4DPAKzJAPkln0=",
-          "range": "bytes=1086-4272589"
+          "checksum": "sha256-Ya2Dn1VNYB21ZBD/jBCSx3SxZuJloJET5xkjX0s3Vt8=",
+          "range": "bytes=1082-4272708"
         },
         "name": "libxml2",
         "signature": {
-          "checksum": "sha1-QFjdplzGn/MiNFxMykgafr6/w6U=",
-          "range": "bytes=0-705"
+          "checksum": "sha1-s5jaTwJdla4k4KK0KEk7AYbgdqs=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.1-r1.apk",
-        "version": "2.13.1-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.2-r0.apk",
+        "version": "2.13.2-r0"
       },
       {
         "architecture": "x86_64",
@@ -546,22 +546,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1+0xClEzF5nhyNPUeGFhC++ElQmg=",
+        "checksum": "Q1u+fF2xg98dT0poYklte5HHMg/Kk=",
         "control": {
-          "checksum": "sha1-+0xClEzF5nhyNPUeGFhC++ElQmg=",
-          "range": "bytes=701-1107"
+          "checksum": "sha1-u+fF2xg98dT0poYklte5HHMg/Kk=",
+          "range": "bytes=701-1090"
         },
         "data": {
-          "checksum": "sha256-81V5R7T08up/3BwfuAG25Rq7KkB1MvALVCaogCpW500=",
-          "range": "bytes=1108-22181"
+          "checksum": "sha256-9e+i7LwSg7oAUU33f0r7A4Mc2suaK95iNU5BKaTSXac=",
+          "range": "bytes=1091-22179"
         },
         "name": "libcrypt1",
         "signature": {
-          "checksum": "sha1-k+7JfhPi5KOQ+6Nqk3oAfTbtOVM=",
+          "checksum": "sha1-EWBUcJqCJTOYJq1H0/kkO+m6W3E=",
           "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/jaeger-all-in-one.lock.json
+++ b/wolfi-images/jaeger-all-in-one.lock.json
@@ -14,117 +14,117 @@
     "packages": [
       {
         "architecture": "x86_64",
-        "checksum": "Q1Ai8jWuxKZR2M2XhOpOGAoTEwnnk=",
+        "checksum": "Q1WR9MGKU+cJh6dJFEXnr3zU1qsMM=",
         "control": {
-          "checksum": "sha1-Ai8jWuxKZR2M2XhOpOGAoTEwnnk=",
-          "range": "bytes=705-1037"
+          "checksum": "sha1-WR9MGKU+cJh6dJFEXnr3zU1qsMM=",
+          "range": "bytes=705-1034"
         },
         "data": {
-          "checksum": "sha256-e4UardkBVyaC49aSyrVmXNi8sSKqQl4eKYd0LxGRLA0=",
-          "range": "bytes=1038-255695"
+          "checksum": "sha256-EkOhtSivoLErXsK2J9ri39thkwb2kJGYHVou4n6dMKA=",
+          "range": "bytes=1035-254654"
         },
         "name": "ca-certificates-bundle",
         "signature": {
-          "checksum": "sha1-loRuyYQLm+atp+YteiQoj++EWIM=",
+          "checksum": "sha1-WL9vKv1nPIeaUQI4O0DiY9RdSHE=",
           "range": "bytes=0-704"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20240315-r4.apk",
-        "version": "20240315-r4"
+        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20240705-r0.apk",
+        "version": "20240705-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1+GH6qRN4iy1IDt0cT0x0tin7YfI=",
+        "checksum": "Q1KmG1L67f+/TnVGcnIcLfWRF/K2g=",
         "control": {
-          "checksum": "sha1-+GH6qRN4iy1IDt0cT0x0tin7YfI=",
-          "range": "bytes=703-1051"
+          "checksum": "sha1-KmG1L67f+/TnVGcnIcLfWRF/K2g=",
+          "range": "bytes=702-1051"
         },
         "data": {
-          "checksum": "sha256-rO0P9z2V49BSrz1A5Ap69tEappVrg5MMBjzW00rOpZc=",
-          "range": "bytes=1052-122464"
+          "checksum": "sha256-2YIxYc/Quit+Kri2qS8p6XvL7taAmOYJU/1Z8RNQ+88=",
+          "range": "bytes=1052-122509"
         },
         "name": "wolfi-baselayout",
         "signature": {
-          "checksum": "sha1-Ntb6VuMzDfM+frpCjKEIpDzl53I=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-VVyPrknEtqCPym5lfhVEuIhfkKg=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r12.apk",
-        "version": "20230201-r12"
+        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r13.apk",
+        "version": "20230201-r13"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q17rD4cKGW3uVSJw02PFiYR719t/Y=",
+        "checksum": "Q1ASyaCJL2Zyz4uAKpPPlx1Sd40yo=",
         "control": {
-          "checksum": "sha1-7rD4cKGW3uVSJw02PFiYR719t/Y=",
-          "range": "bytes=697-1108"
+          "checksum": "sha1-ASyaCJL2Zyz4uAKpPPlx1Sd40yo=",
+          "range": "bytes=706-1101"
         },
         "data": {
-          "checksum": "sha256-GvSViXbvUD0BdV2A+IzVJni2DjLvyM+j14hM29DcsYg=",
-          "range": "bytes=1109-268391"
+          "checksum": "sha256-KoaUrlV3QZ4ATGvKgOmZ1C8Rb/tHK3zEiCTGDrxxc/I=",
+          "range": "bytes=1102-272818"
         },
         "name": "ld-linux",
         "signature": {
-          "checksum": "sha1-nRIFect8o/LOUIEvN17AsrI07dg=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-DBrLE0fWPMyB5/0kAtNlIK6viCU=",
+          "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1/A0wNjkLqqBhe0jFr2D9SKcDNq8=",
+        "checksum": "Q10iHLABsXtuH2JyExQ2IIxH1NUCI=",
         "control": {
-          "checksum": "sha1-/A0wNjkLqqBhe0jFr2D9SKcDNq8=",
-          "range": "bytes=696-1054"
+          "checksum": "sha1-0iHLABsXtuH2JyExQ2IIxH1NUCI=",
+          "range": "bytes=698-1041"
         },
         "data": {
-          "checksum": "sha256-GT22MF6hR+Tj4el5xk2QEwNWig5JRoOrZ60Lecz+lok=",
-          "range": "bytes=1055-408851"
+          "checksum": "sha256-A3RF8XLSIePkapCnvEridXa2N7nheKNT1kTKDqZlGdI=",
+          "range": "bytes=1042-408849"
         },
         "name": "glibc-locale-posix",
         "signature": {
-          "checksum": "sha1-9uPIvcOCeZbPiR7+MLDB4tkJlHo=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-QqrJFnJmyPeT66hUk3O7NxaWY8I=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1YLxq+Z9/+aFnCwvgV7acVLT4QFA=",
+        "checksum": "Q1JYf1zI1zVi/S9sMI32guk6ptuRQ=",
         "control": {
-          "checksum": "sha1-YLxq+Z9/+aFnCwvgV7acVLT4QFA=",
-          "range": "bytes=701-1330"
+          "checksum": "sha1-JYf1zI1zVi/S9sMI32guk6ptuRQ=",
+          "range": "bytes=701-1308"
         },
         "data": {
-          "checksum": "sha256-9s5RNfAJ3GVt7a/fFUaew5MfYYUkvL/6FMvsEfD95jY=",
-          "range": "bytes=1331-5862057"
+          "checksum": "sha256-ioC8korS2nJpJvoS6He+mKkDsgVLcMxiEuYLsAB9M7U=",
+          "range": "bytes=1309-5959239"
         },
         "name": "glibc",
         "signature": {
-          "checksum": "sha1-Kvfb+I/1PCfiBTjoaU4ezZa0b+8=",
+          "checksum": "sha1-3TP2+cHjCEBrIFluCdTmr2oJA1s=",
           "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Zi0e8Bq6WCd/6uXXjVhb8YwMD1U=",
+        "checksum": "Q1WAlPh7UNBV+RHfBixVB5P9F9Mp8=",
         "control": {
-          "checksum": "sha1-Zi0e8Bq6WCd/6uXXjVhb8YwMD1U=",
-          "range": "bytes=700-1073"
+          "checksum": "sha1-WAlPh7UNBV+RHfBixVB5P9F9Mp8=",
+          "range": "bytes=700-1074"
         },
         "data": {
-          "checksum": "sha256-jMhtfqVjnhuuBO7wtNZ6RS/72sZWoKt/Moage2amlks=",
-          "range": "bytes=1074-81594"
+          "checksum": "sha256-i6uEFvUEbJ4YzgNSV58aObIdU608mjbCVPwyF57ZeQQ=",
+          "range": "bytes=1075-81593"
         },
         "name": "protobuf-c",
         "signature": {
-          "checksum": "sha1-kATwMKztK7nk7qbYCJPkCFp6IXc=",
+          "checksum": "sha1-47zwDXmhcWiVtTYCjq4sFld8wHQ=",
           "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r5.apk",
-        "version": "1.5.0-r5"
+        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r6.apk",
+        "version": "1.5.0-r6"
       },
       {
         "architecture": "x86_64",
@@ -204,41 +204,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Q/Zy5ovYSu2p/vVLr6DgVA1e8AQ=",
+        "checksum": "Q1a5wJzZI7k9o4F8hHFpfuqAUIH5Q=",
         "control": {
-          "checksum": "sha1-Q/Zy5ovYSu2p/vVLr6DgVA1e8AQ=",
-          "range": "bytes=699-1062"
+          "checksum": "sha1-a5wJzZI7k9o4F8hHFpfuqAUIH5Q=",
+          "range": "bytes=710-1075"
         },
         "data": {
-          "checksum": "sha256-H3jxsw8ytOeCIR4vq17voSVhdNokXk8C1g075txH6Bs=",
-          "range": "bytes=1063-5903754"
+          "checksum": "sha256-2p1UC4F4Odfxup/J/nyzujYRGaxGVjBOBWoc0aajClI=",
+          "range": "bytes=1076-5903889"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-NIl2f5OI/wSZByI8Ds1ZUfbFWyw=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-SOFoklqXtH38i1PcI3G/cPdRFtY=",
+          "range": "bytes=0-709"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.1-r3.apk",
-        "version": "3.3.1-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.1-r4.apk",
+        "version": "3.3.1-r4"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q13wGUXdZut9OOTdY5z2amUj9wXC0=",
+        "checksum": "Q1gb2VyLOsGV7xUiHBT0Ypt64rw6Y=",
         "control": {
-          "checksum": "sha1-3wGUXdZut9OOTdY5z2amUj9wXC0=",
-          "range": "bytes=698-1068"
+          "checksum": "sha1-gb2VyLOsGV7xUiHBT0Ypt64rw6Y=",
+          "range": "bytes=702-1071"
         },
         "data": {
-          "checksum": "sha256-mRda6+YGlOCczyIWKaHqXskTINoT1rgorHDHqAKAb7c=",
-          "range": "bytes=1069-1188955"
+          "checksum": "sha256-h2tz/aFB2n8SFdBFde5foQm1ru+8JUcGp+trUeA2ZlQ=",
+          "range": "bytes=1072-1188954"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-+UdRc4U3PKw4H9OiNurHKXa5BYk=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-w6U2Pb1Y90u1iBFc/sHg2xn6Qmo=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.1-r3.apk",
-        "version": "3.3.1-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.1-r4.apk",
+        "version": "3.3.1-r4"
       },
       {
         "architecture": "x86_64",
@@ -356,60 +356,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1gfqHM/7r3rXX1HqC163slTPP46o=",
+        "checksum": "Q1DLAp18ebMscosnQ4TfTivIzgtCY=",
         "control": {
-          "checksum": "sha1-gfqHM/7r3rXX1HqC163slTPP46o=",
-          "range": "bytes=704-1101"
+          "checksum": "sha1-DLAp18ebMscosnQ4TfTivIzgtCY=",
+          "range": "bytes=698-1079"
         },
         "data": {
-          "checksum": "sha256-OR7ikvfUYp78EsP0I2kuwqqAcy05jw9tr7JVQ6jTnGQ=",
-          "range": "bytes=1102-185433"
+          "checksum": "sha256-eiBdqqECWnULWGe/Gnd6iv/7h56A4xR2qw+5toY5Gaw=",
+          "range": "bytes=1080-185559"
         },
         "name": "libgcc",
         "signature": {
-          "checksum": "sha1-Il4pyVzI6eqNd/f4bsKeakpB5DI=",
-          "range": "bytes=0-703"
+          "checksum": "sha1-qVj9laNeBIwRxP+8ehB+fXftJrw=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.2.0-r7.apk",
-        "version": "13.2.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r0.apk",
+        "version": "13.3.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1c+lykdx+yHoqsrQmQLHMV7waR1Q=",
+        "checksum": "Q1p9aaHhpB2Ud0URrcIrVRAujMw+o=",
         "control": {
-          "checksum": "sha1-c+lykdx+yHoqsrQmQLHMV7waR1Q=",
-          "range": "bytes=701-1119"
+          "checksum": "sha1-p9aaHhpB2Ud0URrcIrVRAujMw+o=",
+          "range": "bytes=696-1097"
         },
         "data": {
-          "checksum": "sha256-CuZi2C5g0vUnz4PNH8jIWV+EBdVMvHr+sNKFYTSnQZk=",
-          "range": "bytes=1120-3155369"
+          "checksum": "sha256-rGMnyLiGEDCEVgqA1oXMf28QHuWHAaPzYrLeDzQ3WOU=",
+          "range": "bytes=1098-3155519"
         },
         "name": "libstdc++",
         "signature": {
-          "checksum": "sha1-7l8MLj8aCcdqta/0sR+0PscBsD4=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-lge2XoAsgvp8U6ZBgT52N2xNQAw=",
+          "range": "bytes=0-695"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.2.0-r7.apk",
-        "version": "13.2.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r0.apk",
+        "version": "13.3.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1R8OxpY0fGwVaIwft4wJeswF5D54=",
+        "checksum": "Q1DUpLMidX5HbXUAFV8y3Imyt+Ank=",
         "control": {
-          "checksum": "sha1-R8OxpY0fGwVaIwft4wJeswF5D54=",
-          "range": "bytes=695-1059"
+          "checksum": "sha1-DUpLMidX5HbXUAFV8y3Imyt+Ank=",
+          "range": "bytes=698-1063"
         },
         "data": {
-          "checksum": "sha256-wNc8/SBJrGHfwywAtzCsAqeUOt0IaAhqNtlbv8OiHBE=",
-          "range": "bytes=1060-242151"
+          "checksum": "sha256-ZUDWWOBnxl5xi3b5HQCHaiYqKDSrnVpJQgavWpn1duc=",
+          "range": "bytes=1064-255810"
         },
         "name": "c-ares",
         "signature": {
-          "checksum": "sha1-55/PTlEHXI3o0hx9dSVdNwQeSMg=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-0AXk7b/B1baNADDg/NSocbW//pw=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.31.0-r0.apk",
-        "version": "1.31.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.32.1-r0.apk",
+        "version": "1.32.1-r0"
       },
       {
         "architecture": "x86_64",
@@ -470,22 +470,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q10AaU1ocIM4PYYNvwbml8TmpNvEA=",
+        "checksum": "Q1ORn/60iAvLcAgApXYoZzM6o0XSs=",
         "control": {
-          "checksum": "sha1-0AaU1ocIM4PYYNvwbml8TmpNvEA=",
-          "range": "bytes=706-1085"
+          "checksum": "sha1-ORn/60iAvLcAgApXYoZzM6o0XSs=",
+          "range": "bytes=703-1081"
         },
         "data": {
-          "checksum": "sha256-1YQNYASFjlP3kXX58ec8du75ij/U6O4DPAKzJAPkln0=",
-          "range": "bytes=1086-4272589"
+          "checksum": "sha256-Ya2Dn1VNYB21ZBD/jBCSx3SxZuJloJET5xkjX0s3Vt8=",
+          "range": "bytes=1082-4272708"
         },
         "name": "libxml2",
         "signature": {
-          "checksum": "sha1-QFjdplzGn/MiNFxMykgafr6/w6U=",
-          "range": "bytes=0-705"
+          "checksum": "sha1-s5jaTwJdla4k4KK0KEk7AYbgdqs=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.1-r1.apk",
-        "version": "2.13.1-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.2-r0.apk",
+        "version": "2.13.2-r0"
       },
       {
         "architecture": "x86_64",
@@ -546,22 +546,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1+0xClEzF5nhyNPUeGFhC++ElQmg=",
+        "checksum": "Q1u+fF2xg98dT0poYklte5HHMg/Kk=",
         "control": {
-          "checksum": "sha1-+0xClEzF5nhyNPUeGFhC++ElQmg=",
-          "range": "bytes=701-1107"
+          "checksum": "sha1-u+fF2xg98dT0poYklte5HHMg/Kk=",
+          "range": "bytes=701-1090"
         },
         "data": {
-          "checksum": "sha256-81V5R7T08up/3BwfuAG25Rq7KkB1MvALVCaogCpW500=",
-          "range": "bytes=1108-22181"
+          "checksum": "sha256-9e+i7LwSg7oAUU33f0r7A4Mc2suaK95iNU5BKaTSXac=",
+          "range": "bytes=1091-22179"
         },
         "name": "libcrypt1",
         "signature": {
-          "checksum": "sha1-k+7JfhPi5KOQ+6Nqk3oAfTbtOVM=",
+          "checksum": "sha1-EWBUcJqCJTOYJq1H0/kkO+m6W3E=",
           "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/node-exporter.lock.json
+++ b/wolfi-images/node-exporter.lock.json
@@ -14,117 +14,117 @@
     "packages": [
       {
         "architecture": "x86_64",
-        "checksum": "Q1Ai8jWuxKZR2M2XhOpOGAoTEwnnk=",
+        "checksum": "Q1WR9MGKU+cJh6dJFEXnr3zU1qsMM=",
         "control": {
-          "checksum": "sha1-Ai8jWuxKZR2M2XhOpOGAoTEwnnk=",
-          "range": "bytes=705-1037"
+          "checksum": "sha1-WR9MGKU+cJh6dJFEXnr3zU1qsMM=",
+          "range": "bytes=705-1034"
         },
         "data": {
-          "checksum": "sha256-e4UardkBVyaC49aSyrVmXNi8sSKqQl4eKYd0LxGRLA0=",
-          "range": "bytes=1038-255695"
+          "checksum": "sha256-EkOhtSivoLErXsK2J9ri39thkwb2kJGYHVou4n6dMKA=",
+          "range": "bytes=1035-254654"
         },
         "name": "ca-certificates-bundle",
         "signature": {
-          "checksum": "sha1-loRuyYQLm+atp+YteiQoj++EWIM=",
+          "checksum": "sha1-WL9vKv1nPIeaUQI4O0DiY9RdSHE=",
           "range": "bytes=0-704"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20240315-r4.apk",
-        "version": "20240315-r4"
+        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20240705-r0.apk",
+        "version": "20240705-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1+GH6qRN4iy1IDt0cT0x0tin7YfI=",
+        "checksum": "Q1KmG1L67f+/TnVGcnIcLfWRF/K2g=",
         "control": {
-          "checksum": "sha1-+GH6qRN4iy1IDt0cT0x0tin7YfI=",
-          "range": "bytes=703-1051"
+          "checksum": "sha1-KmG1L67f+/TnVGcnIcLfWRF/K2g=",
+          "range": "bytes=702-1051"
         },
         "data": {
-          "checksum": "sha256-rO0P9z2V49BSrz1A5Ap69tEappVrg5MMBjzW00rOpZc=",
-          "range": "bytes=1052-122464"
+          "checksum": "sha256-2YIxYc/Quit+Kri2qS8p6XvL7taAmOYJU/1Z8RNQ+88=",
+          "range": "bytes=1052-122509"
         },
         "name": "wolfi-baselayout",
         "signature": {
-          "checksum": "sha1-Ntb6VuMzDfM+frpCjKEIpDzl53I=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-VVyPrknEtqCPym5lfhVEuIhfkKg=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r12.apk",
-        "version": "20230201-r12"
+        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r13.apk",
+        "version": "20230201-r13"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q17rD4cKGW3uVSJw02PFiYR719t/Y=",
+        "checksum": "Q1ASyaCJL2Zyz4uAKpPPlx1Sd40yo=",
         "control": {
-          "checksum": "sha1-7rD4cKGW3uVSJw02PFiYR719t/Y=",
-          "range": "bytes=697-1108"
+          "checksum": "sha1-ASyaCJL2Zyz4uAKpPPlx1Sd40yo=",
+          "range": "bytes=706-1101"
         },
         "data": {
-          "checksum": "sha256-GvSViXbvUD0BdV2A+IzVJni2DjLvyM+j14hM29DcsYg=",
-          "range": "bytes=1109-268391"
+          "checksum": "sha256-KoaUrlV3QZ4ATGvKgOmZ1C8Rb/tHK3zEiCTGDrxxc/I=",
+          "range": "bytes=1102-272818"
         },
         "name": "ld-linux",
         "signature": {
-          "checksum": "sha1-nRIFect8o/LOUIEvN17AsrI07dg=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-DBrLE0fWPMyB5/0kAtNlIK6viCU=",
+          "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1/A0wNjkLqqBhe0jFr2D9SKcDNq8=",
+        "checksum": "Q10iHLABsXtuH2JyExQ2IIxH1NUCI=",
         "control": {
-          "checksum": "sha1-/A0wNjkLqqBhe0jFr2D9SKcDNq8=",
-          "range": "bytes=696-1054"
+          "checksum": "sha1-0iHLABsXtuH2JyExQ2IIxH1NUCI=",
+          "range": "bytes=698-1041"
         },
         "data": {
-          "checksum": "sha256-GT22MF6hR+Tj4el5xk2QEwNWig5JRoOrZ60Lecz+lok=",
-          "range": "bytes=1055-408851"
+          "checksum": "sha256-A3RF8XLSIePkapCnvEridXa2N7nheKNT1kTKDqZlGdI=",
+          "range": "bytes=1042-408849"
         },
         "name": "glibc-locale-posix",
         "signature": {
-          "checksum": "sha1-9uPIvcOCeZbPiR7+MLDB4tkJlHo=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-QqrJFnJmyPeT66hUk3O7NxaWY8I=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1YLxq+Z9/+aFnCwvgV7acVLT4QFA=",
+        "checksum": "Q1JYf1zI1zVi/S9sMI32guk6ptuRQ=",
         "control": {
-          "checksum": "sha1-YLxq+Z9/+aFnCwvgV7acVLT4QFA=",
-          "range": "bytes=701-1330"
+          "checksum": "sha1-JYf1zI1zVi/S9sMI32guk6ptuRQ=",
+          "range": "bytes=701-1308"
         },
         "data": {
-          "checksum": "sha256-9s5RNfAJ3GVt7a/fFUaew5MfYYUkvL/6FMvsEfD95jY=",
-          "range": "bytes=1331-5862057"
+          "checksum": "sha256-ioC8korS2nJpJvoS6He+mKkDsgVLcMxiEuYLsAB9M7U=",
+          "range": "bytes=1309-5959239"
         },
         "name": "glibc",
         "signature": {
-          "checksum": "sha1-Kvfb+I/1PCfiBTjoaU4ezZa0b+8=",
+          "checksum": "sha1-3TP2+cHjCEBrIFluCdTmr2oJA1s=",
           "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Zi0e8Bq6WCd/6uXXjVhb8YwMD1U=",
+        "checksum": "Q1WAlPh7UNBV+RHfBixVB5P9F9Mp8=",
         "control": {
-          "checksum": "sha1-Zi0e8Bq6WCd/6uXXjVhb8YwMD1U=",
-          "range": "bytes=700-1073"
+          "checksum": "sha1-WAlPh7UNBV+RHfBixVB5P9F9Mp8=",
+          "range": "bytes=700-1074"
         },
         "data": {
-          "checksum": "sha256-jMhtfqVjnhuuBO7wtNZ6RS/72sZWoKt/Moage2amlks=",
-          "range": "bytes=1074-81594"
+          "checksum": "sha256-i6uEFvUEbJ4YzgNSV58aObIdU608mjbCVPwyF57ZeQQ=",
+          "range": "bytes=1075-81593"
         },
         "name": "protobuf-c",
         "signature": {
-          "checksum": "sha1-kATwMKztK7nk7qbYCJPkCFp6IXc=",
+          "checksum": "sha1-47zwDXmhcWiVtTYCjq4sFld8wHQ=",
           "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r5.apk",
-        "version": "1.5.0-r5"
+        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r6.apk",
+        "version": "1.5.0-r6"
       },
       {
         "architecture": "x86_64",
@@ -204,41 +204,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Q/Zy5ovYSu2p/vVLr6DgVA1e8AQ=",
+        "checksum": "Q1a5wJzZI7k9o4F8hHFpfuqAUIH5Q=",
         "control": {
-          "checksum": "sha1-Q/Zy5ovYSu2p/vVLr6DgVA1e8AQ=",
-          "range": "bytes=699-1062"
+          "checksum": "sha1-a5wJzZI7k9o4F8hHFpfuqAUIH5Q=",
+          "range": "bytes=710-1075"
         },
         "data": {
-          "checksum": "sha256-H3jxsw8ytOeCIR4vq17voSVhdNokXk8C1g075txH6Bs=",
-          "range": "bytes=1063-5903754"
+          "checksum": "sha256-2p1UC4F4Odfxup/J/nyzujYRGaxGVjBOBWoc0aajClI=",
+          "range": "bytes=1076-5903889"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-NIl2f5OI/wSZByI8Ds1ZUfbFWyw=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-SOFoklqXtH38i1PcI3G/cPdRFtY=",
+          "range": "bytes=0-709"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.1-r3.apk",
-        "version": "3.3.1-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.1-r4.apk",
+        "version": "3.3.1-r4"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q13wGUXdZut9OOTdY5z2amUj9wXC0=",
+        "checksum": "Q1gb2VyLOsGV7xUiHBT0Ypt64rw6Y=",
         "control": {
-          "checksum": "sha1-3wGUXdZut9OOTdY5z2amUj9wXC0=",
-          "range": "bytes=698-1068"
+          "checksum": "sha1-gb2VyLOsGV7xUiHBT0Ypt64rw6Y=",
+          "range": "bytes=702-1071"
         },
         "data": {
-          "checksum": "sha256-mRda6+YGlOCczyIWKaHqXskTINoT1rgorHDHqAKAb7c=",
-          "range": "bytes=1069-1188955"
+          "checksum": "sha256-h2tz/aFB2n8SFdBFde5foQm1ru+8JUcGp+trUeA2ZlQ=",
+          "range": "bytes=1072-1188954"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-+UdRc4U3PKw4H9OiNurHKXa5BYk=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-w6U2Pb1Y90u1iBFc/sHg2xn6Qmo=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.1-r3.apk",
-        "version": "3.3.1-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.1-r4.apk",
+        "version": "3.3.1-r4"
       },
       {
         "architecture": "x86_64",
@@ -356,60 +356,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1gfqHM/7r3rXX1HqC163slTPP46o=",
+        "checksum": "Q1DLAp18ebMscosnQ4TfTivIzgtCY=",
         "control": {
-          "checksum": "sha1-gfqHM/7r3rXX1HqC163slTPP46o=",
-          "range": "bytes=704-1101"
+          "checksum": "sha1-DLAp18ebMscosnQ4TfTivIzgtCY=",
+          "range": "bytes=698-1079"
         },
         "data": {
-          "checksum": "sha256-OR7ikvfUYp78EsP0I2kuwqqAcy05jw9tr7JVQ6jTnGQ=",
-          "range": "bytes=1102-185433"
+          "checksum": "sha256-eiBdqqECWnULWGe/Gnd6iv/7h56A4xR2qw+5toY5Gaw=",
+          "range": "bytes=1080-185559"
         },
         "name": "libgcc",
         "signature": {
-          "checksum": "sha1-Il4pyVzI6eqNd/f4bsKeakpB5DI=",
-          "range": "bytes=0-703"
+          "checksum": "sha1-qVj9laNeBIwRxP+8ehB+fXftJrw=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.2.0-r7.apk",
-        "version": "13.2.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r0.apk",
+        "version": "13.3.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1c+lykdx+yHoqsrQmQLHMV7waR1Q=",
+        "checksum": "Q1p9aaHhpB2Ud0URrcIrVRAujMw+o=",
         "control": {
-          "checksum": "sha1-c+lykdx+yHoqsrQmQLHMV7waR1Q=",
-          "range": "bytes=701-1119"
+          "checksum": "sha1-p9aaHhpB2Ud0URrcIrVRAujMw+o=",
+          "range": "bytes=696-1097"
         },
         "data": {
-          "checksum": "sha256-CuZi2C5g0vUnz4PNH8jIWV+EBdVMvHr+sNKFYTSnQZk=",
-          "range": "bytes=1120-3155369"
+          "checksum": "sha256-rGMnyLiGEDCEVgqA1oXMf28QHuWHAaPzYrLeDzQ3WOU=",
+          "range": "bytes=1098-3155519"
         },
         "name": "libstdc++",
         "signature": {
-          "checksum": "sha1-7l8MLj8aCcdqta/0sR+0PscBsD4=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-lge2XoAsgvp8U6ZBgT52N2xNQAw=",
+          "range": "bytes=0-695"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.2.0-r7.apk",
-        "version": "13.2.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r0.apk",
+        "version": "13.3.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1R8OxpY0fGwVaIwft4wJeswF5D54=",
+        "checksum": "Q1DUpLMidX5HbXUAFV8y3Imyt+Ank=",
         "control": {
-          "checksum": "sha1-R8OxpY0fGwVaIwft4wJeswF5D54=",
-          "range": "bytes=695-1059"
+          "checksum": "sha1-DUpLMidX5HbXUAFV8y3Imyt+Ank=",
+          "range": "bytes=698-1063"
         },
         "data": {
-          "checksum": "sha256-wNc8/SBJrGHfwywAtzCsAqeUOt0IaAhqNtlbv8OiHBE=",
-          "range": "bytes=1060-242151"
+          "checksum": "sha256-ZUDWWOBnxl5xi3b5HQCHaiYqKDSrnVpJQgavWpn1duc=",
+          "range": "bytes=1064-255810"
         },
         "name": "c-ares",
         "signature": {
-          "checksum": "sha1-55/PTlEHXI3o0hx9dSVdNwQeSMg=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-0AXk7b/B1baNADDg/NSocbW//pw=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.31.0-r0.apk",
-        "version": "1.31.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.32.1-r0.apk",
+        "version": "1.32.1-r0"
       },
       {
         "architecture": "x86_64",
@@ -470,22 +470,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q10AaU1ocIM4PYYNvwbml8TmpNvEA=",
+        "checksum": "Q1ORn/60iAvLcAgApXYoZzM6o0XSs=",
         "control": {
-          "checksum": "sha1-0AaU1ocIM4PYYNvwbml8TmpNvEA=",
-          "range": "bytes=706-1085"
+          "checksum": "sha1-ORn/60iAvLcAgApXYoZzM6o0XSs=",
+          "range": "bytes=703-1081"
         },
         "data": {
-          "checksum": "sha256-1YQNYASFjlP3kXX58ec8du75ij/U6O4DPAKzJAPkln0=",
-          "range": "bytes=1086-4272589"
+          "checksum": "sha256-Ya2Dn1VNYB21ZBD/jBCSx3SxZuJloJET5xkjX0s3Vt8=",
+          "range": "bytes=1082-4272708"
         },
         "name": "libxml2",
         "signature": {
-          "checksum": "sha1-QFjdplzGn/MiNFxMykgafr6/w6U=",
-          "range": "bytes=0-705"
+          "checksum": "sha1-s5jaTwJdla4k4KK0KEk7AYbgdqs=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.1-r1.apk",
-        "version": "2.13.1-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.2-r0.apk",
+        "version": "2.13.2-r0"
       },
       {
         "architecture": "x86_64",
@@ -546,22 +546,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1+0xClEzF5nhyNPUeGFhC++ElQmg=",
+        "checksum": "Q1u+fF2xg98dT0poYklte5HHMg/Kk=",
         "control": {
-          "checksum": "sha1-+0xClEzF5nhyNPUeGFhC++ElQmg=",
-          "range": "bytes=701-1107"
+          "checksum": "sha1-u+fF2xg98dT0poYklte5HHMg/Kk=",
+          "range": "bytes=701-1090"
         },
         "data": {
-          "checksum": "sha256-81V5R7T08up/3BwfuAG25Rq7KkB1MvALVCaogCpW500=",
-          "range": "bytes=1108-22181"
+          "checksum": "sha256-9e+i7LwSg7oAUU33f0r7A4Mc2suaK95iNU5BKaTSXac=",
+          "range": "bytes=1091-22179"
         },
         "name": "libcrypt1",
         "signature": {
-          "checksum": "sha1-k+7JfhPi5KOQ+6Nqk3oAfTbtOVM=",
+          "checksum": "sha1-EWBUcJqCJTOYJq1H0/kkO+m6W3E=",
           "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",
@@ -717,22 +717,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q11MjyY75dy19jhUUc+pJ77bBmkiA=",
+        "checksum": "Q1/ttsPaLiaYQzm24eiYfuvGCA0qI=",
         "control": {
-          "checksum": "sha1-1MjyY75dy19jhUUc+pJ77bBmkiA=",
-          "range": "bytes=704-1086"
+          "checksum": "sha1-/ttsPaLiaYQzm24eiYfuvGCA0qI=",
+          "range": "bytes=707-1074"
         },
         "data": {
-          "checksum": "sha256-VzE/ZAEOrO6lBW21IJ6Kx4BCAaWIjuygSPZCYGwGKuk=",
-          "range": "bytes=1087-15542357"
+          "checksum": "sha256-Ezr5AYHlo085vIUfTKqHRYaKeqIycfbyhkhHDn8OsYA=",
+          "range": "bytes=1075-15542512"
         },
         "name": "prometheus-node-exporter",
         "signature": {
-          "checksum": "sha1-m6+CIL3VlmtVXNtxUmEDLVgOC9o=",
-          "range": "bytes=0-703"
+          "checksum": "sha1-hX2jHqoXcie63DKqIo2ZnJNZq9E=",
+          "range": "bytes=0-706"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/prometheus-node-exporter-1.8.1-r1.apk",
-        "version": "1.8.1-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/prometheus-node-exporter-1.8.1-r2.apk",
+        "version": "1.8.1-r2"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/opentelemetry-collector.lock.json
+++ b/wolfi-images/opentelemetry-collector.lock.json
@@ -14,117 +14,117 @@
     "packages": [
       {
         "architecture": "x86_64",
-        "checksum": "Q1Ai8jWuxKZR2M2XhOpOGAoTEwnnk=",
+        "checksum": "Q1WR9MGKU+cJh6dJFEXnr3zU1qsMM=",
         "control": {
-          "checksum": "sha1-Ai8jWuxKZR2M2XhOpOGAoTEwnnk=",
-          "range": "bytes=705-1037"
+          "checksum": "sha1-WR9MGKU+cJh6dJFEXnr3zU1qsMM=",
+          "range": "bytes=705-1034"
         },
         "data": {
-          "checksum": "sha256-e4UardkBVyaC49aSyrVmXNi8sSKqQl4eKYd0LxGRLA0=",
-          "range": "bytes=1038-255695"
+          "checksum": "sha256-EkOhtSivoLErXsK2J9ri39thkwb2kJGYHVou4n6dMKA=",
+          "range": "bytes=1035-254654"
         },
         "name": "ca-certificates-bundle",
         "signature": {
-          "checksum": "sha1-loRuyYQLm+atp+YteiQoj++EWIM=",
+          "checksum": "sha1-WL9vKv1nPIeaUQI4O0DiY9RdSHE=",
           "range": "bytes=0-704"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20240315-r4.apk",
-        "version": "20240315-r4"
+        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20240705-r0.apk",
+        "version": "20240705-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1+GH6qRN4iy1IDt0cT0x0tin7YfI=",
+        "checksum": "Q1KmG1L67f+/TnVGcnIcLfWRF/K2g=",
         "control": {
-          "checksum": "sha1-+GH6qRN4iy1IDt0cT0x0tin7YfI=",
-          "range": "bytes=703-1051"
+          "checksum": "sha1-KmG1L67f+/TnVGcnIcLfWRF/K2g=",
+          "range": "bytes=702-1051"
         },
         "data": {
-          "checksum": "sha256-rO0P9z2V49BSrz1A5Ap69tEappVrg5MMBjzW00rOpZc=",
-          "range": "bytes=1052-122464"
+          "checksum": "sha256-2YIxYc/Quit+Kri2qS8p6XvL7taAmOYJU/1Z8RNQ+88=",
+          "range": "bytes=1052-122509"
         },
         "name": "wolfi-baselayout",
         "signature": {
-          "checksum": "sha1-Ntb6VuMzDfM+frpCjKEIpDzl53I=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-VVyPrknEtqCPym5lfhVEuIhfkKg=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r12.apk",
-        "version": "20230201-r12"
+        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r13.apk",
+        "version": "20230201-r13"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q17rD4cKGW3uVSJw02PFiYR719t/Y=",
+        "checksum": "Q1ASyaCJL2Zyz4uAKpPPlx1Sd40yo=",
         "control": {
-          "checksum": "sha1-7rD4cKGW3uVSJw02PFiYR719t/Y=",
-          "range": "bytes=697-1108"
+          "checksum": "sha1-ASyaCJL2Zyz4uAKpPPlx1Sd40yo=",
+          "range": "bytes=706-1101"
         },
         "data": {
-          "checksum": "sha256-GvSViXbvUD0BdV2A+IzVJni2DjLvyM+j14hM29DcsYg=",
-          "range": "bytes=1109-268391"
+          "checksum": "sha256-KoaUrlV3QZ4ATGvKgOmZ1C8Rb/tHK3zEiCTGDrxxc/I=",
+          "range": "bytes=1102-272818"
         },
         "name": "ld-linux",
         "signature": {
-          "checksum": "sha1-nRIFect8o/LOUIEvN17AsrI07dg=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-DBrLE0fWPMyB5/0kAtNlIK6viCU=",
+          "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1/A0wNjkLqqBhe0jFr2D9SKcDNq8=",
+        "checksum": "Q10iHLABsXtuH2JyExQ2IIxH1NUCI=",
         "control": {
-          "checksum": "sha1-/A0wNjkLqqBhe0jFr2D9SKcDNq8=",
-          "range": "bytes=696-1054"
+          "checksum": "sha1-0iHLABsXtuH2JyExQ2IIxH1NUCI=",
+          "range": "bytes=698-1041"
         },
         "data": {
-          "checksum": "sha256-GT22MF6hR+Tj4el5xk2QEwNWig5JRoOrZ60Lecz+lok=",
-          "range": "bytes=1055-408851"
+          "checksum": "sha256-A3RF8XLSIePkapCnvEridXa2N7nheKNT1kTKDqZlGdI=",
+          "range": "bytes=1042-408849"
         },
         "name": "glibc-locale-posix",
         "signature": {
-          "checksum": "sha1-9uPIvcOCeZbPiR7+MLDB4tkJlHo=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-QqrJFnJmyPeT66hUk3O7NxaWY8I=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1YLxq+Z9/+aFnCwvgV7acVLT4QFA=",
+        "checksum": "Q1JYf1zI1zVi/S9sMI32guk6ptuRQ=",
         "control": {
-          "checksum": "sha1-YLxq+Z9/+aFnCwvgV7acVLT4QFA=",
-          "range": "bytes=701-1330"
+          "checksum": "sha1-JYf1zI1zVi/S9sMI32guk6ptuRQ=",
+          "range": "bytes=701-1308"
         },
         "data": {
-          "checksum": "sha256-9s5RNfAJ3GVt7a/fFUaew5MfYYUkvL/6FMvsEfD95jY=",
-          "range": "bytes=1331-5862057"
+          "checksum": "sha256-ioC8korS2nJpJvoS6He+mKkDsgVLcMxiEuYLsAB9M7U=",
+          "range": "bytes=1309-5959239"
         },
         "name": "glibc",
         "signature": {
-          "checksum": "sha1-Kvfb+I/1PCfiBTjoaU4ezZa0b+8=",
+          "checksum": "sha1-3TP2+cHjCEBrIFluCdTmr2oJA1s=",
           "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Zi0e8Bq6WCd/6uXXjVhb8YwMD1U=",
+        "checksum": "Q1WAlPh7UNBV+RHfBixVB5P9F9Mp8=",
         "control": {
-          "checksum": "sha1-Zi0e8Bq6WCd/6uXXjVhb8YwMD1U=",
-          "range": "bytes=700-1073"
+          "checksum": "sha1-WAlPh7UNBV+RHfBixVB5P9F9Mp8=",
+          "range": "bytes=700-1074"
         },
         "data": {
-          "checksum": "sha256-jMhtfqVjnhuuBO7wtNZ6RS/72sZWoKt/Moage2amlks=",
-          "range": "bytes=1074-81594"
+          "checksum": "sha256-i6uEFvUEbJ4YzgNSV58aObIdU608mjbCVPwyF57ZeQQ=",
+          "range": "bytes=1075-81593"
         },
         "name": "protobuf-c",
         "signature": {
-          "checksum": "sha1-kATwMKztK7nk7qbYCJPkCFp6IXc=",
+          "checksum": "sha1-47zwDXmhcWiVtTYCjq4sFld8wHQ=",
           "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r5.apk",
-        "version": "1.5.0-r5"
+        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r6.apk",
+        "version": "1.5.0-r6"
       },
       {
         "architecture": "x86_64",
@@ -204,41 +204,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Q/Zy5ovYSu2p/vVLr6DgVA1e8AQ=",
+        "checksum": "Q1a5wJzZI7k9o4F8hHFpfuqAUIH5Q=",
         "control": {
-          "checksum": "sha1-Q/Zy5ovYSu2p/vVLr6DgVA1e8AQ=",
-          "range": "bytes=699-1062"
+          "checksum": "sha1-a5wJzZI7k9o4F8hHFpfuqAUIH5Q=",
+          "range": "bytes=710-1075"
         },
         "data": {
-          "checksum": "sha256-H3jxsw8ytOeCIR4vq17voSVhdNokXk8C1g075txH6Bs=",
-          "range": "bytes=1063-5903754"
+          "checksum": "sha256-2p1UC4F4Odfxup/J/nyzujYRGaxGVjBOBWoc0aajClI=",
+          "range": "bytes=1076-5903889"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-NIl2f5OI/wSZByI8Ds1ZUfbFWyw=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-SOFoklqXtH38i1PcI3G/cPdRFtY=",
+          "range": "bytes=0-709"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.1-r3.apk",
-        "version": "3.3.1-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.1-r4.apk",
+        "version": "3.3.1-r4"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q13wGUXdZut9OOTdY5z2amUj9wXC0=",
+        "checksum": "Q1gb2VyLOsGV7xUiHBT0Ypt64rw6Y=",
         "control": {
-          "checksum": "sha1-3wGUXdZut9OOTdY5z2amUj9wXC0=",
-          "range": "bytes=698-1068"
+          "checksum": "sha1-gb2VyLOsGV7xUiHBT0Ypt64rw6Y=",
+          "range": "bytes=702-1071"
         },
         "data": {
-          "checksum": "sha256-mRda6+YGlOCczyIWKaHqXskTINoT1rgorHDHqAKAb7c=",
-          "range": "bytes=1069-1188955"
+          "checksum": "sha256-h2tz/aFB2n8SFdBFde5foQm1ru+8JUcGp+trUeA2ZlQ=",
+          "range": "bytes=1072-1188954"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-+UdRc4U3PKw4H9OiNurHKXa5BYk=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-w6U2Pb1Y90u1iBFc/sHg2xn6Qmo=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.1-r3.apk",
-        "version": "3.3.1-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.1-r4.apk",
+        "version": "3.3.1-r4"
       },
       {
         "architecture": "x86_64",
@@ -356,60 +356,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1gfqHM/7r3rXX1HqC163slTPP46o=",
+        "checksum": "Q1DLAp18ebMscosnQ4TfTivIzgtCY=",
         "control": {
-          "checksum": "sha1-gfqHM/7r3rXX1HqC163slTPP46o=",
-          "range": "bytes=704-1101"
+          "checksum": "sha1-DLAp18ebMscosnQ4TfTivIzgtCY=",
+          "range": "bytes=698-1079"
         },
         "data": {
-          "checksum": "sha256-OR7ikvfUYp78EsP0I2kuwqqAcy05jw9tr7JVQ6jTnGQ=",
-          "range": "bytes=1102-185433"
+          "checksum": "sha256-eiBdqqECWnULWGe/Gnd6iv/7h56A4xR2qw+5toY5Gaw=",
+          "range": "bytes=1080-185559"
         },
         "name": "libgcc",
         "signature": {
-          "checksum": "sha1-Il4pyVzI6eqNd/f4bsKeakpB5DI=",
-          "range": "bytes=0-703"
+          "checksum": "sha1-qVj9laNeBIwRxP+8ehB+fXftJrw=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.2.0-r7.apk",
-        "version": "13.2.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r0.apk",
+        "version": "13.3.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1c+lykdx+yHoqsrQmQLHMV7waR1Q=",
+        "checksum": "Q1p9aaHhpB2Ud0URrcIrVRAujMw+o=",
         "control": {
-          "checksum": "sha1-c+lykdx+yHoqsrQmQLHMV7waR1Q=",
-          "range": "bytes=701-1119"
+          "checksum": "sha1-p9aaHhpB2Ud0URrcIrVRAujMw+o=",
+          "range": "bytes=696-1097"
         },
         "data": {
-          "checksum": "sha256-CuZi2C5g0vUnz4PNH8jIWV+EBdVMvHr+sNKFYTSnQZk=",
-          "range": "bytes=1120-3155369"
+          "checksum": "sha256-rGMnyLiGEDCEVgqA1oXMf28QHuWHAaPzYrLeDzQ3WOU=",
+          "range": "bytes=1098-3155519"
         },
         "name": "libstdc++",
         "signature": {
-          "checksum": "sha1-7l8MLj8aCcdqta/0sR+0PscBsD4=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-lge2XoAsgvp8U6ZBgT52N2xNQAw=",
+          "range": "bytes=0-695"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.2.0-r7.apk",
-        "version": "13.2.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r0.apk",
+        "version": "13.3.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1R8OxpY0fGwVaIwft4wJeswF5D54=",
+        "checksum": "Q1DUpLMidX5HbXUAFV8y3Imyt+Ank=",
         "control": {
-          "checksum": "sha1-R8OxpY0fGwVaIwft4wJeswF5D54=",
-          "range": "bytes=695-1059"
+          "checksum": "sha1-DUpLMidX5HbXUAFV8y3Imyt+Ank=",
+          "range": "bytes=698-1063"
         },
         "data": {
-          "checksum": "sha256-wNc8/SBJrGHfwywAtzCsAqeUOt0IaAhqNtlbv8OiHBE=",
-          "range": "bytes=1060-242151"
+          "checksum": "sha256-ZUDWWOBnxl5xi3b5HQCHaiYqKDSrnVpJQgavWpn1duc=",
+          "range": "bytes=1064-255810"
         },
         "name": "c-ares",
         "signature": {
-          "checksum": "sha1-55/PTlEHXI3o0hx9dSVdNwQeSMg=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-0AXk7b/B1baNADDg/NSocbW//pw=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.31.0-r0.apk",
-        "version": "1.31.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.32.1-r0.apk",
+        "version": "1.32.1-r0"
       },
       {
         "architecture": "x86_64",
@@ -470,22 +470,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q10AaU1ocIM4PYYNvwbml8TmpNvEA=",
+        "checksum": "Q1ORn/60iAvLcAgApXYoZzM6o0XSs=",
         "control": {
-          "checksum": "sha1-0AaU1ocIM4PYYNvwbml8TmpNvEA=",
-          "range": "bytes=706-1085"
+          "checksum": "sha1-ORn/60iAvLcAgApXYoZzM6o0XSs=",
+          "range": "bytes=703-1081"
         },
         "data": {
-          "checksum": "sha256-1YQNYASFjlP3kXX58ec8du75ij/U6O4DPAKzJAPkln0=",
-          "range": "bytes=1086-4272589"
+          "checksum": "sha256-Ya2Dn1VNYB21ZBD/jBCSx3SxZuJloJET5xkjX0s3Vt8=",
+          "range": "bytes=1082-4272708"
         },
         "name": "libxml2",
         "signature": {
-          "checksum": "sha1-QFjdplzGn/MiNFxMykgafr6/w6U=",
-          "range": "bytes=0-705"
+          "checksum": "sha1-s5jaTwJdla4k4KK0KEk7AYbgdqs=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.1-r1.apk",
-        "version": "2.13.1-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.2-r0.apk",
+        "version": "2.13.2-r0"
       },
       {
         "architecture": "x86_64",
@@ -546,22 +546,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1+0xClEzF5nhyNPUeGFhC++ElQmg=",
+        "checksum": "Q1u+fF2xg98dT0poYklte5HHMg/Kk=",
         "control": {
-          "checksum": "sha1-+0xClEzF5nhyNPUeGFhC++ElQmg=",
-          "range": "bytes=701-1107"
+          "checksum": "sha1-u+fF2xg98dT0poYklte5HHMg/Kk=",
+          "range": "bytes=701-1090"
         },
         "data": {
-          "checksum": "sha256-81V5R7T08up/3BwfuAG25Rq7KkB1MvALVCaogCpW500=",
-          "range": "bytes=1108-22181"
+          "checksum": "sha256-9e+i7LwSg7oAUU33f0r7A4Mc2suaK95iNU5BKaTSXac=",
+          "range": "bytes=1091-22179"
         },
         "name": "libcrypt1",
         "signature": {
-          "checksum": "sha1-k+7JfhPi5KOQ+6Nqk3oAfTbtOVM=",
+          "checksum": "sha1-EWBUcJqCJTOYJq1H0/kkO+m6W3E=",
           "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/postgres-exporter.lock.json
+++ b/wolfi-images/postgres-exporter.lock.json
@@ -14,117 +14,117 @@
     "packages": [
       {
         "architecture": "x86_64",
-        "checksum": "Q1Ai8jWuxKZR2M2XhOpOGAoTEwnnk=",
+        "checksum": "Q1WR9MGKU+cJh6dJFEXnr3zU1qsMM=",
         "control": {
-          "checksum": "sha1-Ai8jWuxKZR2M2XhOpOGAoTEwnnk=",
-          "range": "bytes=705-1037"
+          "checksum": "sha1-WR9MGKU+cJh6dJFEXnr3zU1qsMM=",
+          "range": "bytes=705-1034"
         },
         "data": {
-          "checksum": "sha256-e4UardkBVyaC49aSyrVmXNi8sSKqQl4eKYd0LxGRLA0=",
-          "range": "bytes=1038-255695"
+          "checksum": "sha256-EkOhtSivoLErXsK2J9ri39thkwb2kJGYHVou4n6dMKA=",
+          "range": "bytes=1035-254654"
         },
         "name": "ca-certificates-bundle",
         "signature": {
-          "checksum": "sha1-loRuyYQLm+atp+YteiQoj++EWIM=",
+          "checksum": "sha1-WL9vKv1nPIeaUQI4O0DiY9RdSHE=",
           "range": "bytes=0-704"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20240315-r4.apk",
-        "version": "20240315-r4"
+        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20240705-r0.apk",
+        "version": "20240705-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1+GH6qRN4iy1IDt0cT0x0tin7YfI=",
+        "checksum": "Q1KmG1L67f+/TnVGcnIcLfWRF/K2g=",
         "control": {
-          "checksum": "sha1-+GH6qRN4iy1IDt0cT0x0tin7YfI=",
-          "range": "bytes=703-1051"
+          "checksum": "sha1-KmG1L67f+/TnVGcnIcLfWRF/K2g=",
+          "range": "bytes=702-1051"
         },
         "data": {
-          "checksum": "sha256-rO0P9z2V49BSrz1A5Ap69tEappVrg5MMBjzW00rOpZc=",
-          "range": "bytes=1052-122464"
+          "checksum": "sha256-2YIxYc/Quit+Kri2qS8p6XvL7taAmOYJU/1Z8RNQ+88=",
+          "range": "bytes=1052-122509"
         },
         "name": "wolfi-baselayout",
         "signature": {
-          "checksum": "sha1-Ntb6VuMzDfM+frpCjKEIpDzl53I=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-VVyPrknEtqCPym5lfhVEuIhfkKg=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r12.apk",
-        "version": "20230201-r12"
+        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r13.apk",
+        "version": "20230201-r13"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q17rD4cKGW3uVSJw02PFiYR719t/Y=",
+        "checksum": "Q1ASyaCJL2Zyz4uAKpPPlx1Sd40yo=",
         "control": {
-          "checksum": "sha1-7rD4cKGW3uVSJw02PFiYR719t/Y=",
-          "range": "bytes=697-1108"
+          "checksum": "sha1-ASyaCJL2Zyz4uAKpPPlx1Sd40yo=",
+          "range": "bytes=706-1101"
         },
         "data": {
-          "checksum": "sha256-GvSViXbvUD0BdV2A+IzVJni2DjLvyM+j14hM29DcsYg=",
-          "range": "bytes=1109-268391"
+          "checksum": "sha256-KoaUrlV3QZ4ATGvKgOmZ1C8Rb/tHK3zEiCTGDrxxc/I=",
+          "range": "bytes=1102-272818"
         },
         "name": "ld-linux",
         "signature": {
-          "checksum": "sha1-nRIFect8o/LOUIEvN17AsrI07dg=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-DBrLE0fWPMyB5/0kAtNlIK6viCU=",
+          "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1/A0wNjkLqqBhe0jFr2D9SKcDNq8=",
+        "checksum": "Q10iHLABsXtuH2JyExQ2IIxH1NUCI=",
         "control": {
-          "checksum": "sha1-/A0wNjkLqqBhe0jFr2D9SKcDNq8=",
-          "range": "bytes=696-1054"
+          "checksum": "sha1-0iHLABsXtuH2JyExQ2IIxH1NUCI=",
+          "range": "bytes=698-1041"
         },
         "data": {
-          "checksum": "sha256-GT22MF6hR+Tj4el5xk2QEwNWig5JRoOrZ60Lecz+lok=",
-          "range": "bytes=1055-408851"
+          "checksum": "sha256-A3RF8XLSIePkapCnvEridXa2N7nheKNT1kTKDqZlGdI=",
+          "range": "bytes=1042-408849"
         },
         "name": "glibc-locale-posix",
         "signature": {
-          "checksum": "sha1-9uPIvcOCeZbPiR7+MLDB4tkJlHo=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-QqrJFnJmyPeT66hUk3O7NxaWY8I=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1YLxq+Z9/+aFnCwvgV7acVLT4QFA=",
+        "checksum": "Q1JYf1zI1zVi/S9sMI32guk6ptuRQ=",
         "control": {
-          "checksum": "sha1-YLxq+Z9/+aFnCwvgV7acVLT4QFA=",
-          "range": "bytes=701-1330"
+          "checksum": "sha1-JYf1zI1zVi/S9sMI32guk6ptuRQ=",
+          "range": "bytes=701-1308"
         },
         "data": {
-          "checksum": "sha256-9s5RNfAJ3GVt7a/fFUaew5MfYYUkvL/6FMvsEfD95jY=",
-          "range": "bytes=1331-5862057"
+          "checksum": "sha256-ioC8korS2nJpJvoS6He+mKkDsgVLcMxiEuYLsAB9M7U=",
+          "range": "bytes=1309-5959239"
         },
         "name": "glibc",
         "signature": {
-          "checksum": "sha1-Kvfb+I/1PCfiBTjoaU4ezZa0b+8=",
+          "checksum": "sha1-3TP2+cHjCEBrIFluCdTmr2oJA1s=",
           "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Zi0e8Bq6WCd/6uXXjVhb8YwMD1U=",
+        "checksum": "Q1WAlPh7UNBV+RHfBixVB5P9F9Mp8=",
         "control": {
-          "checksum": "sha1-Zi0e8Bq6WCd/6uXXjVhb8YwMD1U=",
-          "range": "bytes=700-1073"
+          "checksum": "sha1-WAlPh7UNBV+RHfBixVB5P9F9Mp8=",
+          "range": "bytes=700-1074"
         },
         "data": {
-          "checksum": "sha256-jMhtfqVjnhuuBO7wtNZ6RS/72sZWoKt/Moage2amlks=",
-          "range": "bytes=1074-81594"
+          "checksum": "sha256-i6uEFvUEbJ4YzgNSV58aObIdU608mjbCVPwyF57ZeQQ=",
+          "range": "bytes=1075-81593"
         },
         "name": "protobuf-c",
         "signature": {
-          "checksum": "sha1-kATwMKztK7nk7qbYCJPkCFp6IXc=",
+          "checksum": "sha1-47zwDXmhcWiVtTYCjq4sFld8wHQ=",
           "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r5.apk",
-        "version": "1.5.0-r5"
+        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r6.apk",
+        "version": "1.5.0-r6"
       },
       {
         "architecture": "x86_64",
@@ -204,41 +204,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Q/Zy5ovYSu2p/vVLr6DgVA1e8AQ=",
+        "checksum": "Q1a5wJzZI7k9o4F8hHFpfuqAUIH5Q=",
         "control": {
-          "checksum": "sha1-Q/Zy5ovYSu2p/vVLr6DgVA1e8AQ=",
-          "range": "bytes=699-1062"
+          "checksum": "sha1-a5wJzZI7k9o4F8hHFpfuqAUIH5Q=",
+          "range": "bytes=710-1075"
         },
         "data": {
-          "checksum": "sha256-H3jxsw8ytOeCIR4vq17voSVhdNokXk8C1g075txH6Bs=",
-          "range": "bytes=1063-5903754"
+          "checksum": "sha256-2p1UC4F4Odfxup/J/nyzujYRGaxGVjBOBWoc0aajClI=",
+          "range": "bytes=1076-5903889"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-NIl2f5OI/wSZByI8Ds1ZUfbFWyw=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-SOFoklqXtH38i1PcI3G/cPdRFtY=",
+          "range": "bytes=0-709"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.1-r3.apk",
-        "version": "3.3.1-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.1-r4.apk",
+        "version": "3.3.1-r4"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q13wGUXdZut9OOTdY5z2amUj9wXC0=",
+        "checksum": "Q1gb2VyLOsGV7xUiHBT0Ypt64rw6Y=",
         "control": {
-          "checksum": "sha1-3wGUXdZut9OOTdY5z2amUj9wXC0=",
-          "range": "bytes=698-1068"
+          "checksum": "sha1-gb2VyLOsGV7xUiHBT0Ypt64rw6Y=",
+          "range": "bytes=702-1071"
         },
         "data": {
-          "checksum": "sha256-mRda6+YGlOCczyIWKaHqXskTINoT1rgorHDHqAKAb7c=",
-          "range": "bytes=1069-1188955"
+          "checksum": "sha256-h2tz/aFB2n8SFdBFde5foQm1ru+8JUcGp+trUeA2ZlQ=",
+          "range": "bytes=1072-1188954"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-+UdRc4U3PKw4H9OiNurHKXa5BYk=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-w6U2Pb1Y90u1iBFc/sHg2xn6Qmo=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.1-r3.apk",
-        "version": "3.3.1-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.1-r4.apk",
+        "version": "3.3.1-r4"
       },
       {
         "architecture": "x86_64",
@@ -356,60 +356,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1gfqHM/7r3rXX1HqC163slTPP46o=",
+        "checksum": "Q1DLAp18ebMscosnQ4TfTivIzgtCY=",
         "control": {
-          "checksum": "sha1-gfqHM/7r3rXX1HqC163slTPP46o=",
-          "range": "bytes=704-1101"
+          "checksum": "sha1-DLAp18ebMscosnQ4TfTivIzgtCY=",
+          "range": "bytes=698-1079"
         },
         "data": {
-          "checksum": "sha256-OR7ikvfUYp78EsP0I2kuwqqAcy05jw9tr7JVQ6jTnGQ=",
-          "range": "bytes=1102-185433"
+          "checksum": "sha256-eiBdqqECWnULWGe/Gnd6iv/7h56A4xR2qw+5toY5Gaw=",
+          "range": "bytes=1080-185559"
         },
         "name": "libgcc",
         "signature": {
-          "checksum": "sha1-Il4pyVzI6eqNd/f4bsKeakpB5DI=",
-          "range": "bytes=0-703"
+          "checksum": "sha1-qVj9laNeBIwRxP+8ehB+fXftJrw=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.2.0-r7.apk",
-        "version": "13.2.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r0.apk",
+        "version": "13.3.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1c+lykdx+yHoqsrQmQLHMV7waR1Q=",
+        "checksum": "Q1p9aaHhpB2Ud0URrcIrVRAujMw+o=",
         "control": {
-          "checksum": "sha1-c+lykdx+yHoqsrQmQLHMV7waR1Q=",
-          "range": "bytes=701-1119"
+          "checksum": "sha1-p9aaHhpB2Ud0URrcIrVRAujMw+o=",
+          "range": "bytes=696-1097"
         },
         "data": {
-          "checksum": "sha256-CuZi2C5g0vUnz4PNH8jIWV+EBdVMvHr+sNKFYTSnQZk=",
-          "range": "bytes=1120-3155369"
+          "checksum": "sha256-rGMnyLiGEDCEVgqA1oXMf28QHuWHAaPzYrLeDzQ3WOU=",
+          "range": "bytes=1098-3155519"
         },
         "name": "libstdc++",
         "signature": {
-          "checksum": "sha1-7l8MLj8aCcdqta/0sR+0PscBsD4=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-lge2XoAsgvp8U6ZBgT52N2xNQAw=",
+          "range": "bytes=0-695"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.2.0-r7.apk",
-        "version": "13.2.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r0.apk",
+        "version": "13.3.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1R8OxpY0fGwVaIwft4wJeswF5D54=",
+        "checksum": "Q1DUpLMidX5HbXUAFV8y3Imyt+Ank=",
         "control": {
-          "checksum": "sha1-R8OxpY0fGwVaIwft4wJeswF5D54=",
-          "range": "bytes=695-1059"
+          "checksum": "sha1-DUpLMidX5HbXUAFV8y3Imyt+Ank=",
+          "range": "bytes=698-1063"
         },
         "data": {
-          "checksum": "sha256-wNc8/SBJrGHfwywAtzCsAqeUOt0IaAhqNtlbv8OiHBE=",
-          "range": "bytes=1060-242151"
+          "checksum": "sha256-ZUDWWOBnxl5xi3b5HQCHaiYqKDSrnVpJQgavWpn1duc=",
+          "range": "bytes=1064-255810"
         },
         "name": "c-ares",
         "signature": {
-          "checksum": "sha1-55/PTlEHXI3o0hx9dSVdNwQeSMg=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-0AXk7b/B1baNADDg/NSocbW//pw=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.31.0-r0.apk",
-        "version": "1.31.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.32.1-r0.apk",
+        "version": "1.32.1-r0"
       },
       {
         "architecture": "x86_64",
@@ -470,22 +470,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q10AaU1ocIM4PYYNvwbml8TmpNvEA=",
+        "checksum": "Q1ORn/60iAvLcAgApXYoZzM6o0XSs=",
         "control": {
-          "checksum": "sha1-0AaU1ocIM4PYYNvwbml8TmpNvEA=",
-          "range": "bytes=706-1085"
+          "checksum": "sha1-ORn/60iAvLcAgApXYoZzM6o0XSs=",
+          "range": "bytes=703-1081"
         },
         "data": {
-          "checksum": "sha256-1YQNYASFjlP3kXX58ec8du75ij/U6O4DPAKzJAPkln0=",
-          "range": "bytes=1086-4272589"
+          "checksum": "sha256-Ya2Dn1VNYB21ZBD/jBCSx3SxZuJloJET5xkjX0s3Vt8=",
+          "range": "bytes=1082-4272708"
         },
         "name": "libxml2",
         "signature": {
-          "checksum": "sha1-QFjdplzGn/MiNFxMykgafr6/w6U=",
-          "range": "bytes=0-705"
+          "checksum": "sha1-s5jaTwJdla4k4KK0KEk7AYbgdqs=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.1-r1.apk",
-        "version": "2.13.1-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.2-r0.apk",
+        "version": "2.13.2-r0"
       },
       {
         "architecture": "x86_64",
@@ -546,22 +546,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1+0xClEzF5nhyNPUeGFhC++ElQmg=",
+        "checksum": "Q1u+fF2xg98dT0poYklte5HHMg/Kk=",
         "control": {
-          "checksum": "sha1-+0xClEzF5nhyNPUeGFhC++ElQmg=",
-          "range": "bytes=701-1107"
+          "checksum": "sha1-u+fF2xg98dT0poYklte5HHMg/Kk=",
+          "range": "bytes=701-1090"
         },
         "data": {
-          "checksum": "sha256-81V5R7T08up/3BwfuAG25Rq7KkB1MvALVCaogCpW500=",
-          "range": "bytes=1108-22181"
+          "checksum": "sha256-9e+i7LwSg7oAUU33f0r7A4Mc2suaK95iNU5BKaTSXac=",
+          "range": "bytes=1091-22179"
         },
         "name": "libcrypt1",
         "signature": {
-          "checksum": "sha1-k+7JfhPi5KOQ+6Nqk3oAfTbtOVM=",
+          "checksum": "sha1-EWBUcJqCJTOYJq1H0/kkO+m6W3E=",
           "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",
@@ -717,22 +717,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ZSA3uYHgOuEdsXqsjTZQOc7JGFM=",
+        "checksum": "Q1EoboUze7gNAngM1gmLzM1nPdaZQ=",
         "control": {
-          "checksum": "sha1-ZSA3uYHgOuEdsXqsjTZQOc7JGFM=",
-          "range": "bytes=697-1083"
+          "checksum": "sha1-EoboUze7gNAngM1gmLzM1nPdaZQ=",
+          "range": "bytes=702-1076"
         },
         "data": {
-          "checksum": "sha256-U6V84QUUZHttnP8E4tXIiGqLDrqo6l+b3pSK4J2U5oI=",
-          "range": "bytes=1084-13097660"
+          "checksum": "sha256-UgsCGyX15jOfLeHg74FRjndH8cYn03mDcRCkK73o3xA=",
+          "range": "bytes=1077-13097807"
         },
         "name": "prometheus-postgres-exporter",
         "signature": {
-          "checksum": "sha1-tYMJlKBEQpyVJBRdhmv1c/+AQfQ=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-sYyoMsyNe/5Ovl0/lVnAwIQbx0w=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/prometheus-postgres-exporter-0.15.0-r10.apk",
-        "version": "0.15.0-r10"
+        "url": "https://packages.wolfi.dev/os/x86_64/prometheus-postgres-exporter-0.15.0-r11.apk",
+        "version": "0.15.0-r11"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/postgresql-12-codeinsights.lock.json
+++ b/wolfi-images/postgresql-12-codeinsights.lock.json
@@ -14,117 +14,117 @@
     "packages": [
       {
         "architecture": "x86_64",
-        "checksum": "Q1Ai8jWuxKZR2M2XhOpOGAoTEwnnk=",
+        "checksum": "Q1WR9MGKU+cJh6dJFEXnr3zU1qsMM=",
         "control": {
-          "checksum": "sha1-Ai8jWuxKZR2M2XhOpOGAoTEwnnk=",
-          "range": "bytes=705-1037"
+          "checksum": "sha1-WR9MGKU+cJh6dJFEXnr3zU1qsMM=",
+          "range": "bytes=705-1034"
         },
         "data": {
-          "checksum": "sha256-e4UardkBVyaC49aSyrVmXNi8sSKqQl4eKYd0LxGRLA0=",
-          "range": "bytes=1038-255695"
+          "checksum": "sha256-EkOhtSivoLErXsK2J9ri39thkwb2kJGYHVou4n6dMKA=",
+          "range": "bytes=1035-254654"
         },
         "name": "ca-certificates-bundle",
         "signature": {
-          "checksum": "sha1-loRuyYQLm+atp+YteiQoj++EWIM=",
+          "checksum": "sha1-WL9vKv1nPIeaUQI4O0DiY9RdSHE=",
           "range": "bytes=0-704"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20240315-r4.apk",
-        "version": "20240315-r4"
+        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20240705-r0.apk",
+        "version": "20240705-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1+GH6qRN4iy1IDt0cT0x0tin7YfI=",
+        "checksum": "Q1KmG1L67f+/TnVGcnIcLfWRF/K2g=",
         "control": {
-          "checksum": "sha1-+GH6qRN4iy1IDt0cT0x0tin7YfI=",
-          "range": "bytes=703-1051"
+          "checksum": "sha1-KmG1L67f+/TnVGcnIcLfWRF/K2g=",
+          "range": "bytes=702-1051"
         },
         "data": {
-          "checksum": "sha256-rO0P9z2V49BSrz1A5Ap69tEappVrg5MMBjzW00rOpZc=",
-          "range": "bytes=1052-122464"
+          "checksum": "sha256-2YIxYc/Quit+Kri2qS8p6XvL7taAmOYJU/1Z8RNQ+88=",
+          "range": "bytes=1052-122509"
         },
         "name": "wolfi-baselayout",
         "signature": {
-          "checksum": "sha1-Ntb6VuMzDfM+frpCjKEIpDzl53I=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-VVyPrknEtqCPym5lfhVEuIhfkKg=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r12.apk",
-        "version": "20230201-r12"
+        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r13.apk",
+        "version": "20230201-r13"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q17rD4cKGW3uVSJw02PFiYR719t/Y=",
+        "checksum": "Q1ASyaCJL2Zyz4uAKpPPlx1Sd40yo=",
         "control": {
-          "checksum": "sha1-7rD4cKGW3uVSJw02PFiYR719t/Y=",
-          "range": "bytes=697-1108"
+          "checksum": "sha1-ASyaCJL2Zyz4uAKpPPlx1Sd40yo=",
+          "range": "bytes=706-1101"
         },
         "data": {
-          "checksum": "sha256-GvSViXbvUD0BdV2A+IzVJni2DjLvyM+j14hM29DcsYg=",
-          "range": "bytes=1109-268391"
+          "checksum": "sha256-KoaUrlV3QZ4ATGvKgOmZ1C8Rb/tHK3zEiCTGDrxxc/I=",
+          "range": "bytes=1102-272818"
         },
         "name": "ld-linux",
         "signature": {
-          "checksum": "sha1-nRIFect8o/LOUIEvN17AsrI07dg=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-DBrLE0fWPMyB5/0kAtNlIK6viCU=",
+          "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1/A0wNjkLqqBhe0jFr2D9SKcDNq8=",
+        "checksum": "Q10iHLABsXtuH2JyExQ2IIxH1NUCI=",
         "control": {
-          "checksum": "sha1-/A0wNjkLqqBhe0jFr2D9SKcDNq8=",
-          "range": "bytes=696-1054"
+          "checksum": "sha1-0iHLABsXtuH2JyExQ2IIxH1NUCI=",
+          "range": "bytes=698-1041"
         },
         "data": {
-          "checksum": "sha256-GT22MF6hR+Tj4el5xk2QEwNWig5JRoOrZ60Lecz+lok=",
-          "range": "bytes=1055-408851"
+          "checksum": "sha256-A3RF8XLSIePkapCnvEridXa2N7nheKNT1kTKDqZlGdI=",
+          "range": "bytes=1042-408849"
         },
         "name": "glibc-locale-posix",
         "signature": {
-          "checksum": "sha1-9uPIvcOCeZbPiR7+MLDB4tkJlHo=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-QqrJFnJmyPeT66hUk3O7NxaWY8I=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1YLxq+Z9/+aFnCwvgV7acVLT4QFA=",
+        "checksum": "Q1JYf1zI1zVi/S9sMI32guk6ptuRQ=",
         "control": {
-          "checksum": "sha1-YLxq+Z9/+aFnCwvgV7acVLT4QFA=",
-          "range": "bytes=701-1330"
+          "checksum": "sha1-JYf1zI1zVi/S9sMI32guk6ptuRQ=",
+          "range": "bytes=701-1308"
         },
         "data": {
-          "checksum": "sha256-9s5RNfAJ3GVt7a/fFUaew5MfYYUkvL/6FMvsEfD95jY=",
-          "range": "bytes=1331-5862057"
+          "checksum": "sha256-ioC8korS2nJpJvoS6He+mKkDsgVLcMxiEuYLsAB9M7U=",
+          "range": "bytes=1309-5959239"
         },
         "name": "glibc",
         "signature": {
-          "checksum": "sha1-Kvfb+I/1PCfiBTjoaU4ezZa0b+8=",
+          "checksum": "sha1-3TP2+cHjCEBrIFluCdTmr2oJA1s=",
           "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Zi0e8Bq6WCd/6uXXjVhb8YwMD1U=",
+        "checksum": "Q1WAlPh7UNBV+RHfBixVB5P9F9Mp8=",
         "control": {
-          "checksum": "sha1-Zi0e8Bq6WCd/6uXXjVhb8YwMD1U=",
-          "range": "bytes=700-1073"
+          "checksum": "sha1-WAlPh7UNBV+RHfBixVB5P9F9Mp8=",
+          "range": "bytes=700-1074"
         },
         "data": {
-          "checksum": "sha256-jMhtfqVjnhuuBO7wtNZ6RS/72sZWoKt/Moage2amlks=",
-          "range": "bytes=1074-81594"
+          "checksum": "sha256-i6uEFvUEbJ4YzgNSV58aObIdU608mjbCVPwyF57ZeQQ=",
+          "range": "bytes=1075-81593"
         },
         "name": "protobuf-c",
         "signature": {
-          "checksum": "sha1-kATwMKztK7nk7qbYCJPkCFp6IXc=",
+          "checksum": "sha1-47zwDXmhcWiVtTYCjq4sFld8wHQ=",
           "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r5.apk",
-        "version": "1.5.0-r5"
+        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r6.apk",
+        "version": "1.5.0-r6"
       },
       {
         "architecture": "x86_64",
@@ -204,41 +204,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Q/Zy5ovYSu2p/vVLr6DgVA1e8AQ=",
+        "checksum": "Q1a5wJzZI7k9o4F8hHFpfuqAUIH5Q=",
         "control": {
-          "checksum": "sha1-Q/Zy5ovYSu2p/vVLr6DgVA1e8AQ=",
-          "range": "bytes=699-1062"
+          "checksum": "sha1-a5wJzZI7k9o4F8hHFpfuqAUIH5Q=",
+          "range": "bytes=710-1075"
         },
         "data": {
-          "checksum": "sha256-H3jxsw8ytOeCIR4vq17voSVhdNokXk8C1g075txH6Bs=",
-          "range": "bytes=1063-5903754"
+          "checksum": "sha256-2p1UC4F4Odfxup/J/nyzujYRGaxGVjBOBWoc0aajClI=",
+          "range": "bytes=1076-5903889"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-NIl2f5OI/wSZByI8Ds1ZUfbFWyw=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-SOFoklqXtH38i1PcI3G/cPdRFtY=",
+          "range": "bytes=0-709"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.1-r3.apk",
-        "version": "3.3.1-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.1-r4.apk",
+        "version": "3.3.1-r4"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q13wGUXdZut9OOTdY5z2amUj9wXC0=",
+        "checksum": "Q1gb2VyLOsGV7xUiHBT0Ypt64rw6Y=",
         "control": {
-          "checksum": "sha1-3wGUXdZut9OOTdY5z2amUj9wXC0=",
-          "range": "bytes=698-1068"
+          "checksum": "sha1-gb2VyLOsGV7xUiHBT0Ypt64rw6Y=",
+          "range": "bytes=702-1071"
         },
         "data": {
-          "checksum": "sha256-mRda6+YGlOCczyIWKaHqXskTINoT1rgorHDHqAKAb7c=",
-          "range": "bytes=1069-1188955"
+          "checksum": "sha256-h2tz/aFB2n8SFdBFde5foQm1ru+8JUcGp+trUeA2ZlQ=",
+          "range": "bytes=1072-1188954"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-+UdRc4U3PKw4H9OiNurHKXa5BYk=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-w6U2Pb1Y90u1iBFc/sHg2xn6Qmo=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.1-r3.apk",
-        "version": "3.3.1-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.1-r4.apk",
+        "version": "3.3.1-r4"
       },
       {
         "architecture": "x86_64",
@@ -356,60 +356,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1gfqHM/7r3rXX1HqC163slTPP46o=",
+        "checksum": "Q1DLAp18ebMscosnQ4TfTivIzgtCY=",
         "control": {
-          "checksum": "sha1-gfqHM/7r3rXX1HqC163slTPP46o=",
-          "range": "bytes=704-1101"
+          "checksum": "sha1-DLAp18ebMscosnQ4TfTivIzgtCY=",
+          "range": "bytes=698-1079"
         },
         "data": {
-          "checksum": "sha256-OR7ikvfUYp78EsP0I2kuwqqAcy05jw9tr7JVQ6jTnGQ=",
-          "range": "bytes=1102-185433"
+          "checksum": "sha256-eiBdqqECWnULWGe/Gnd6iv/7h56A4xR2qw+5toY5Gaw=",
+          "range": "bytes=1080-185559"
         },
         "name": "libgcc",
         "signature": {
-          "checksum": "sha1-Il4pyVzI6eqNd/f4bsKeakpB5DI=",
-          "range": "bytes=0-703"
+          "checksum": "sha1-qVj9laNeBIwRxP+8ehB+fXftJrw=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.2.0-r7.apk",
-        "version": "13.2.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r0.apk",
+        "version": "13.3.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1c+lykdx+yHoqsrQmQLHMV7waR1Q=",
+        "checksum": "Q1p9aaHhpB2Ud0URrcIrVRAujMw+o=",
         "control": {
-          "checksum": "sha1-c+lykdx+yHoqsrQmQLHMV7waR1Q=",
-          "range": "bytes=701-1119"
+          "checksum": "sha1-p9aaHhpB2Ud0URrcIrVRAujMw+o=",
+          "range": "bytes=696-1097"
         },
         "data": {
-          "checksum": "sha256-CuZi2C5g0vUnz4PNH8jIWV+EBdVMvHr+sNKFYTSnQZk=",
-          "range": "bytes=1120-3155369"
+          "checksum": "sha256-rGMnyLiGEDCEVgqA1oXMf28QHuWHAaPzYrLeDzQ3WOU=",
+          "range": "bytes=1098-3155519"
         },
         "name": "libstdc++",
         "signature": {
-          "checksum": "sha1-7l8MLj8aCcdqta/0sR+0PscBsD4=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-lge2XoAsgvp8U6ZBgT52N2xNQAw=",
+          "range": "bytes=0-695"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.2.0-r7.apk",
-        "version": "13.2.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r0.apk",
+        "version": "13.3.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1R8OxpY0fGwVaIwft4wJeswF5D54=",
+        "checksum": "Q1DUpLMidX5HbXUAFV8y3Imyt+Ank=",
         "control": {
-          "checksum": "sha1-R8OxpY0fGwVaIwft4wJeswF5D54=",
-          "range": "bytes=695-1059"
+          "checksum": "sha1-DUpLMidX5HbXUAFV8y3Imyt+Ank=",
+          "range": "bytes=698-1063"
         },
         "data": {
-          "checksum": "sha256-wNc8/SBJrGHfwywAtzCsAqeUOt0IaAhqNtlbv8OiHBE=",
-          "range": "bytes=1060-242151"
+          "checksum": "sha256-ZUDWWOBnxl5xi3b5HQCHaiYqKDSrnVpJQgavWpn1duc=",
+          "range": "bytes=1064-255810"
         },
         "name": "c-ares",
         "signature": {
-          "checksum": "sha1-55/PTlEHXI3o0hx9dSVdNwQeSMg=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-0AXk7b/B1baNADDg/NSocbW//pw=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.31.0-r0.apk",
-        "version": "1.31.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.32.1-r0.apk",
+        "version": "1.32.1-r0"
       },
       {
         "architecture": "x86_64",
@@ -470,22 +470,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q10AaU1ocIM4PYYNvwbml8TmpNvEA=",
+        "checksum": "Q1ORn/60iAvLcAgApXYoZzM6o0XSs=",
         "control": {
-          "checksum": "sha1-0AaU1ocIM4PYYNvwbml8TmpNvEA=",
-          "range": "bytes=706-1085"
+          "checksum": "sha1-ORn/60iAvLcAgApXYoZzM6o0XSs=",
+          "range": "bytes=703-1081"
         },
         "data": {
-          "checksum": "sha256-1YQNYASFjlP3kXX58ec8du75ij/U6O4DPAKzJAPkln0=",
-          "range": "bytes=1086-4272589"
+          "checksum": "sha256-Ya2Dn1VNYB21ZBD/jBCSx3SxZuJloJET5xkjX0s3Vt8=",
+          "range": "bytes=1082-4272708"
         },
         "name": "libxml2",
         "signature": {
-          "checksum": "sha1-QFjdplzGn/MiNFxMykgafr6/w6U=",
-          "range": "bytes=0-705"
+          "checksum": "sha1-s5jaTwJdla4k4KK0KEk7AYbgdqs=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.1-r1.apk",
-        "version": "2.13.1-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.2-r0.apk",
+        "version": "2.13.2-r0"
       },
       {
         "architecture": "x86_64",
@@ -546,22 +546,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1+0xClEzF5nhyNPUeGFhC++ElQmg=",
+        "checksum": "Q1u+fF2xg98dT0poYklte5HHMg/Kk=",
         "control": {
-          "checksum": "sha1-+0xClEzF5nhyNPUeGFhC++ElQmg=",
-          "range": "bytes=701-1107"
+          "checksum": "sha1-u+fF2xg98dT0poYklte5HHMg/Kk=",
+          "range": "bytes=701-1090"
         },
         "data": {
-          "checksum": "sha256-81V5R7T08up/3BwfuAG25Rq7KkB1MvALVCaogCpW500=",
-          "range": "bytes=1108-22181"
+          "checksum": "sha256-9e+i7LwSg7oAUU33f0r7A4Mc2suaK95iNU5BKaTSXac=",
+          "range": "bytes=1091-22179"
         },
         "name": "libcrypt1",
         "signature": {
-          "checksum": "sha1-k+7JfhPi5KOQ+6Nqk3oAfTbtOVM=",
+          "checksum": "sha1-EWBUcJqCJTOYJq1H0/kkO+m6W3E=",
           "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",
@@ -717,22 +717,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1z4pvqJVOguss+9HLVO7PzJUlt8w=",
+        "checksum": "Q1dmeR0/KVMZ3ZLmYVZZpeOM5D0YA=",
         "control": {
-          "checksum": "sha1-z4pvqJVOguss+9HLVO7PzJUlt8w=",
-          "range": "bytes=702-1032"
+          "checksum": "sha1-dmeR0/KVMZ3ZLmYVZZpeOM5D0YA=",
+          "range": "bytes=698-1038"
         },
         "data": {
-          "checksum": "sha256-AY5hTobJ3oQxODeewjKtWT/O0I3WSJJfbdnebiFHi9A=",
-          "range": "bytes=1033-61050535"
+          "checksum": "sha256-h229QLrsW/27BQzxyKGOvkrvJPnwhRPjtIV3aVoLq0U=",
+          "range": "bytes=1039-61050533"
         },
         "name": "glibc-locale-en",
         "signature": {
-          "checksum": "sha1-EnGHd74XHlmb/a2fq+hVub5BQN4=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-p2ZxY4sG1cAKJ7uPvhMKBxKw+k4=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-en-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-en-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",
@@ -774,41 +774,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ibJSAAe0yAmeC3Sp9K+672q3eKg=",
+        "checksum": "Q15bwVoaq1Noe1m3R1UrRBlJGLGSM=",
         "control": {
-          "checksum": "sha1-ibJSAAe0yAmeC3Sp9K+672q3eKg=",
-          "range": "bytes=704-1060"
+          "checksum": "sha1-5bwVoaq1Noe1m3R1UrRBlJGLGSM=",
+          "range": "bytes=702-1043"
         },
         "data": {
-          "checksum": "sha256-Qdx821f7/tO71EyPPGGyuTZlK4If05eUDqMkGTNYzdw=",
-          "range": "bytes=1061-603623"
+          "checksum": "sha256-RUfH3pZt5PBG2RCxX2qGzc0JK+BWQ3BfabP8B3Zjkyo=",
+          "range": "bytes=1044-605796"
         },
         "name": "ncurses-terminfo-base",
         "signature": {
-          "checksum": "sha1-hFLJnjW3MeXzjutUUaMVz+pq774=",
-          "range": "bytes=0-703"
+          "checksum": "sha1-qOe+XIaqWDBfRGrODGmvZj+PGs8=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ncurses-terminfo-base-6.4_p20231125-r3.apk",
-        "version": "6.4_p20231125-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/ncurses-terminfo-base-6.5_p20240629-r0.apk",
+        "version": "6.5_p20240629-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ggdVedzys8c0/DPbL/8uVM0IeHM=",
+        "checksum": "Q1UbEaadDhtuSAInuPjntJMZefM4U=",
         "control": {
-          "checksum": "sha1-ggdVedzys8c0/DPbL/8uVM0IeHM=",
-          "range": "bytes=697-1165"
+          "checksum": "sha1-UbEaadDhtuSAInuPjntJMZefM4U=",
+          "range": "bytes=698-1152"
         },
         "data": {
-          "checksum": "sha256-7NLgBuaKCCXSTXXEZ48mE9pTOgyoOY6yHLR2cW0LdGM=",
-          "range": "bytes=1166-1048223"
+          "checksum": "sha256-gkm/MRL/YRxHkRROZEW/TSWGC7r+ZAqogwd0Umio3LU=",
+          "range": "bytes=1153-1065345"
         },
         "name": "ncurses",
         "signature": {
-          "checksum": "sha1-50wXsiR3GgiiLwsWICdXEagYHRE=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-NLFv0xzWR8uGe+4SFVz9mAZDn/k=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ncurses-6.4_p20231125-r3.apk",
-        "version": "6.4_p20231125-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/ncurses-6.5_p20240629-r0.apk",
+        "version": "6.5_p20240629-r0"
       },
       {
         "architecture": "x86_64",
@@ -850,22 +850,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1pFBna33iXNWoxlANBI0dibfvT94=",
+        "checksum": "Q1a6BZwHKJFZb3kLvCVJI8xP+VrT0=",
         "control": {
-          "checksum": "sha1-pFBna33iXNWoxlANBI0dibfvT94=",
-          "range": "bytes=706-1129"
+          "checksum": "sha1-a6BZwHKJFZb3kLvCVJI8xP+VrT0=",
+          "range": "bytes=704-1169"
         },
         "data": {
-          "checksum": "sha256-jsPjzi/shXYlr0zayGvJ82SSPVs4ew/DIy3L1hiuqdE=",
-          "range": "bytes=1130-66950"
+          "checksum": "sha256-FUKvi4Kg95WQig8Pig9G03JlHr70P4eGn/NNVkKZpSM=",
+          "range": "bytes=1170-71535"
         },
         "name": "libuuid",
         "signature": {
-          "checksum": "sha1-nVANm2v8k7qILW+g+xjNgr7yqQY=",
-          "range": "bytes=0-705"
+          "checksum": "sha1-Z4+F/Rm3twEs19SMey98+aXHXwo=",
+          "range": "bytes=0-703"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libuuid-2.40.1-r1.apk",
-        "version": "2.40.1-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libuuid-2.40.2-r0.apk",
+        "version": "2.40.2-r0"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/postgresql-12.lock.json
+++ b/wolfi-images/postgresql-12.lock.json
@@ -14,117 +14,117 @@
     "packages": [
       {
         "architecture": "x86_64",
-        "checksum": "Q1Ai8jWuxKZR2M2XhOpOGAoTEwnnk=",
+        "checksum": "Q1WR9MGKU+cJh6dJFEXnr3zU1qsMM=",
         "control": {
-          "checksum": "sha1-Ai8jWuxKZR2M2XhOpOGAoTEwnnk=",
-          "range": "bytes=705-1037"
+          "checksum": "sha1-WR9MGKU+cJh6dJFEXnr3zU1qsMM=",
+          "range": "bytes=705-1034"
         },
         "data": {
-          "checksum": "sha256-e4UardkBVyaC49aSyrVmXNi8sSKqQl4eKYd0LxGRLA0=",
-          "range": "bytes=1038-255695"
+          "checksum": "sha256-EkOhtSivoLErXsK2J9ri39thkwb2kJGYHVou4n6dMKA=",
+          "range": "bytes=1035-254654"
         },
         "name": "ca-certificates-bundle",
         "signature": {
-          "checksum": "sha1-loRuyYQLm+atp+YteiQoj++EWIM=",
+          "checksum": "sha1-WL9vKv1nPIeaUQI4O0DiY9RdSHE=",
           "range": "bytes=0-704"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20240315-r4.apk",
-        "version": "20240315-r4"
+        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20240705-r0.apk",
+        "version": "20240705-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1+GH6qRN4iy1IDt0cT0x0tin7YfI=",
+        "checksum": "Q1KmG1L67f+/TnVGcnIcLfWRF/K2g=",
         "control": {
-          "checksum": "sha1-+GH6qRN4iy1IDt0cT0x0tin7YfI=",
-          "range": "bytes=703-1051"
+          "checksum": "sha1-KmG1L67f+/TnVGcnIcLfWRF/K2g=",
+          "range": "bytes=702-1051"
         },
         "data": {
-          "checksum": "sha256-rO0P9z2V49BSrz1A5Ap69tEappVrg5MMBjzW00rOpZc=",
-          "range": "bytes=1052-122464"
+          "checksum": "sha256-2YIxYc/Quit+Kri2qS8p6XvL7taAmOYJU/1Z8RNQ+88=",
+          "range": "bytes=1052-122509"
         },
         "name": "wolfi-baselayout",
         "signature": {
-          "checksum": "sha1-Ntb6VuMzDfM+frpCjKEIpDzl53I=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-VVyPrknEtqCPym5lfhVEuIhfkKg=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r12.apk",
-        "version": "20230201-r12"
+        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r13.apk",
+        "version": "20230201-r13"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q17rD4cKGW3uVSJw02PFiYR719t/Y=",
+        "checksum": "Q1ASyaCJL2Zyz4uAKpPPlx1Sd40yo=",
         "control": {
-          "checksum": "sha1-7rD4cKGW3uVSJw02PFiYR719t/Y=",
-          "range": "bytes=697-1108"
+          "checksum": "sha1-ASyaCJL2Zyz4uAKpPPlx1Sd40yo=",
+          "range": "bytes=706-1101"
         },
         "data": {
-          "checksum": "sha256-GvSViXbvUD0BdV2A+IzVJni2DjLvyM+j14hM29DcsYg=",
-          "range": "bytes=1109-268391"
+          "checksum": "sha256-KoaUrlV3QZ4ATGvKgOmZ1C8Rb/tHK3zEiCTGDrxxc/I=",
+          "range": "bytes=1102-272818"
         },
         "name": "ld-linux",
         "signature": {
-          "checksum": "sha1-nRIFect8o/LOUIEvN17AsrI07dg=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-DBrLE0fWPMyB5/0kAtNlIK6viCU=",
+          "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1/A0wNjkLqqBhe0jFr2D9SKcDNq8=",
+        "checksum": "Q10iHLABsXtuH2JyExQ2IIxH1NUCI=",
         "control": {
-          "checksum": "sha1-/A0wNjkLqqBhe0jFr2D9SKcDNq8=",
-          "range": "bytes=696-1054"
+          "checksum": "sha1-0iHLABsXtuH2JyExQ2IIxH1NUCI=",
+          "range": "bytes=698-1041"
         },
         "data": {
-          "checksum": "sha256-GT22MF6hR+Tj4el5xk2QEwNWig5JRoOrZ60Lecz+lok=",
-          "range": "bytes=1055-408851"
+          "checksum": "sha256-A3RF8XLSIePkapCnvEridXa2N7nheKNT1kTKDqZlGdI=",
+          "range": "bytes=1042-408849"
         },
         "name": "glibc-locale-posix",
         "signature": {
-          "checksum": "sha1-9uPIvcOCeZbPiR7+MLDB4tkJlHo=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-QqrJFnJmyPeT66hUk3O7NxaWY8I=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1YLxq+Z9/+aFnCwvgV7acVLT4QFA=",
+        "checksum": "Q1JYf1zI1zVi/S9sMI32guk6ptuRQ=",
         "control": {
-          "checksum": "sha1-YLxq+Z9/+aFnCwvgV7acVLT4QFA=",
-          "range": "bytes=701-1330"
+          "checksum": "sha1-JYf1zI1zVi/S9sMI32guk6ptuRQ=",
+          "range": "bytes=701-1308"
         },
         "data": {
-          "checksum": "sha256-9s5RNfAJ3GVt7a/fFUaew5MfYYUkvL/6FMvsEfD95jY=",
-          "range": "bytes=1331-5862057"
+          "checksum": "sha256-ioC8korS2nJpJvoS6He+mKkDsgVLcMxiEuYLsAB9M7U=",
+          "range": "bytes=1309-5959239"
         },
         "name": "glibc",
         "signature": {
-          "checksum": "sha1-Kvfb+I/1PCfiBTjoaU4ezZa0b+8=",
+          "checksum": "sha1-3TP2+cHjCEBrIFluCdTmr2oJA1s=",
           "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Zi0e8Bq6WCd/6uXXjVhb8YwMD1U=",
+        "checksum": "Q1WAlPh7UNBV+RHfBixVB5P9F9Mp8=",
         "control": {
-          "checksum": "sha1-Zi0e8Bq6WCd/6uXXjVhb8YwMD1U=",
-          "range": "bytes=700-1073"
+          "checksum": "sha1-WAlPh7UNBV+RHfBixVB5P9F9Mp8=",
+          "range": "bytes=700-1074"
         },
         "data": {
-          "checksum": "sha256-jMhtfqVjnhuuBO7wtNZ6RS/72sZWoKt/Moage2amlks=",
-          "range": "bytes=1074-81594"
+          "checksum": "sha256-i6uEFvUEbJ4YzgNSV58aObIdU608mjbCVPwyF57ZeQQ=",
+          "range": "bytes=1075-81593"
         },
         "name": "protobuf-c",
         "signature": {
-          "checksum": "sha1-kATwMKztK7nk7qbYCJPkCFp6IXc=",
+          "checksum": "sha1-47zwDXmhcWiVtTYCjq4sFld8wHQ=",
           "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r5.apk",
-        "version": "1.5.0-r5"
+        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r6.apk",
+        "version": "1.5.0-r6"
       },
       {
         "architecture": "x86_64",
@@ -204,41 +204,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Q/Zy5ovYSu2p/vVLr6DgVA1e8AQ=",
+        "checksum": "Q1a5wJzZI7k9o4F8hHFpfuqAUIH5Q=",
         "control": {
-          "checksum": "sha1-Q/Zy5ovYSu2p/vVLr6DgVA1e8AQ=",
-          "range": "bytes=699-1062"
+          "checksum": "sha1-a5wJzZI7k9o4F8hHFpfuqAUIH5Q=",
+          "range": "bytes=710-1075"
         },
         "data": {
-          "checksum": "sha256-H3jxsw8ytOeCIR4vq17voSVhdNokXk8C1g075txH6Bs=",
-          "range": "bytes=1063-5903754"
+          "checksum": "sha256-2p1UC4F4Odfxup/J/nyzujYRGaxGVjBOBWoc0aajClI=",
+          "range": "bytes=1076-5903889"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-NIl2f5OI/wSZByI8Ds1ZUfbFWyw=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-SOFoklqXtH38i1PcI3G/cPdRFtY=",
+          "range": "bytes=0-709"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.1-r3.apk",
-        "version": "3.3.1-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.1-r4.apk",
+        "version": "3.3.1-r4"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q13wGUXdZut9OOTdY5z2amUj9wXC0=",
+        "checksum": "Q1gb2VyLOsGV7xUiHBT0Ypt64rw6Y=",
         "control": {
-          "checksum": "sha1-3wGUXdZut9OOTdY5z2amUj9wXC0=",
-          "range": "bytes=698-1068"
+          "checksum": "sha1-gb2VyLOsGV7xUiHBT0Ypt64rw6Y=",
+          "range": "bytes=702-1071"
         },
         "data": {
-          "checksum": "sha256-mRda6+YGlOCczyIWKaHqXskTINoT1rgorHDHqAKAb7c=",
-          "range": "bytes=1069-1188955"
+          "checksum": "sha256-h2tz/aFB2n8SFdBFde5foQm1ru+8JUcGp+trUeA2ZlQ=",
+          "range": "bytes=1072-1188954"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-+UdRc4U3PKw4H9OiNurHKXa5BYk=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-w6U2Pb1Y90u1iBFc/sHg2xn6Qmo=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.1-r3.apk",
-        "version": "3.3.1-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.1-r4.apk",
+        "version": "3.3.1-r4"
       },
       {
         "architecture": "x86_64",
@@ -356,60 +356,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1gfqHM/7r3rXX1HqC163slTPP46o=",
+        "checksum": "Q1DLAp18ebMscosnQ4TfTivIzgtCY=",
         "control": {
-          "checksum": "sha1-gfqHM/7r3rXX1HqC163slTPP46o=",
-          "range": "bytes=704-1101"
+          "checksum": "sha1-DLAp18ebMscosnQ4TfTivIzgtCY=",
+          "range": "bytes=698-1079"
         },
         "data": {
-          "checksum": "sha256-OR7ikvfUYp78EsP0I2kuwqqAcy05jw9tr7JVQ6jTnGQ=",
-          "range": "bytes=1102-185433"
+          "checksum": "sha256-eiBdqqECWnULWGe/Gnd6iv/7h56A4xR2qw+5toY5Gaw=",
+          "range": "bytes=1080-185559"
         },
         "name": "libgcc",
         "signature": {
-          "checksum": "sha1-Il4pyVzI6eqNd/f4bsKeakpB5DI=",
-          "range": "bytes=0-703"
+          "checksum": "sha1-qVj9laNeBIwRxP+8ehB+fXftJrw=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.2.0-r7.apk",
-        "version": "13.2.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r0.apk",
+        "version": "13.3.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1c+lykdx+yHoqsrQmQLHMV7waR1Q=",
+        "checksum": "Q1p9aaHhpB2Ud0URrcIrVRAujMw+o=",
         "control": {
-          "checksum": "sha1-c+lykdx+yHoqsrQmQLHMV7waR1Q=",
-          "range": "bytes=701-1119"
+          "checksum": "sha1-p9aaHhpB2Ud0URrcIrVRAujMw+o=",
+          "range": "bytes=696-1097"
         },
         "data": {
-          "checksum": "sha256-CuZi2C5g0vUnz4PNH8jIWV+EBdVMvHr+sNKFYTSnQZk=",
-          "range": "bytes=1120-3155369"
+          "checksum": "sha256-rGMnyLiGEDCEVgqA1oXMf28QHuWHAaPzYrLeDzQ3WOU=",
+          "range": "bytes=1098-3155519"
         },
         "name": "libstdc++",
         "signature": {
-          "checksum": "sha1-7l8MLj8aCcdqta/0sR+0PscBsD4=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-lge2XoAsgvp8U6ZBgT52N2xNQAw=",
+          "range": "bytes=0-695"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.2.0-r7.apk",
-        "version": "13.2.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r0.apk",
+        "version": "13.3.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1R8OxpY0fGwVaIwft4wJeswF5D54=",
+        "checksum": "Q1DUpLMidX5HbXUAFV8y3Imyt+Ank=",
         "control": {
-          "checksum": "sha1-R8OxpY0fGwVaIwft4wJeswF5D54=",
-          "range": "bytes=695-1059"
+          "checksum": "sha1-DUpLMidX5HbXUAFV8y3Imyt+Ank=",
+          "range": "bytes=698-1063"
         },
         "data": {
-          "checksum": "sha256-wNc8/SBJrGHfwywAtzCsAqeUOt0IaAhqNtlbv8OiHBE=",
-          "range": "bytes=1060-242151"
+          "checksum": "sha256-ZUDWWOBnxl5xi3b5HQCHaiYqKDSrnVpJQgavWpn1duc=",
+          "range": "bytes=1064-255810"
         },
         "name": "c-ares",
         "signature": {
-          "checksum": "sha1-55/PTlEHXI3o0hx9dSVdNwQeSMg=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-0AXk7b/B1baNADDg/NSocbW//pw=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.31.0-r0.apk",
-        "version": "1.31.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.32.1-r0.apk",
+        "version": "1.32.1-r0"
       },
       {
         "architecture": "x86_64",
@@ -470,22 +470,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q10AaU1ocIM4PYYNvwbml8TmpNvEA=",
+        "checksum": "Q1ORn/60iAvLcAgApXYoZzM6o0XSs=",
         "control": {
-          "checksum": "sha1-0AaU1ocIM4PYYNvwbml8TmpNvEA=",
-          "range": "bytes=706-1085"
+          "checksum": "sha1-ORn/60iAvLcAgApXYoZzM6o0XSs=",
+          "range": "bytes=703-1081"
         },
         "data": {
-          "checksum": "sha256-1YQNYASFjlP3kXX58ec8du75ij/U6O4DPAKzJAPkln0=",
-          "range": "bytes=1086-4272589"
+          "checksum": "sha256-Ya2Dn1VNYB21ZBD/jBCSx3SxZuJloJET5xkjX0s3Vt8=",
+          "range": "bytes=1082-4272708"
         },
         "name": "libxml2",
         "signature": {
-          "checksum": "sha1-QFjdplzGn/MiNFxMykgafr6/w6U=",
-          "range": "bytes=0-705"
+          "checksum": "sha1-s5jaTwJdla4k4KK0KEk7AYbgdqs=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.1-r1.apk",
-        "version": "2.13.1-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.2-r0.apk",
+        "version": "2.13.2-r0"
       },
       {
         "architecture": "x86_64",
@@ -546,22 +546,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1+0xClEzF5nhyNPUeGFhC++ElQmg=",
+        "checksum": "Q1u+fF2xg98dT0poYklte5HHMg/Kk=",
         "control": {
-          "checksum": "sha1-+0xClEzF5nhyNPUeGFhC++ElQmg=",
-          "range": "bytes=701-1107"
+          "checksum": "sha1-u+fF2xg98dT0poYklte5HHMg/Kk=",
+          "range": "bytes=701-1090"
         },
         "data": {
-          "checksum": "sha256-81V5R7T08up/3BwfuAG25Rq7KkB1MvALVCaogCpW500=",
-          "range": "bytes=1108-22181"
+          "checksum": "sha256-9e+i7LwSg7oAUU33f0r7A4Mc2suaK95iNU5BKaTSXac=",
+          "range": "bytes=1091-22179"
         },
         "name": "libcrypt1",
         "signature": {
-          "checksum": "sha1-k+7JfhPi5KOQ+6Nqk3oAfTbtOVM=",
+          "checksum": "sha1-EWBUcJqCJTOYJq1H0/kkO+m6W3E=",
           "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",
@@ -717,22 +717,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1z4pvqJVOguss+9HLVO7PzJUlt8w=",
+        "checksum": "Q1dmeR0/KVMZ3ZLmYVZZpeOM5D0YA=",
         "control": {
-          "checksum": "sha1-z4pvqJVOguss+9HLVO7PzJUlt8w=",
-          "range": "bytes=702-1032"
+          "checksum": "sha1-dmeR0/KVMZ3ZLmYVZZpeOM5D0YA=",
+          "range": "bytes=698-1038"
         },
         "data": {
-          "checksum": "sha256-AY5hTobJ3oQxODeewjKtWT/O0I3WSJJfbdnebiFHi9A=",
-          "range": "bytes=1033-61050535"
+          "checksum": "sha256-h229QLrsW/27BQzxyKGOvkrvJPnwhRPjtIV3aVoLq0U=",
+          "range": "bytes=1039-61050533"
         },
         "name": "glibc-locale-en",
         "signature": {
-          "checksum": "sha1-EnGHd74XHlmb/a2fq+hVub5BQN4=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-p2ZxY4sG1cAKJ7uPvhMKBxKw+k4=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-en-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-en-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",
@@ -774,41 +774,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ibJSAAe0yAmeC3Sp9K+672q3eKg=",
+        "checksum": "Q15bwVoaq1Noe1m3R1UrRBlJGLGSM=",
         "control": {
-          "checksum": "sha1-ibJSAAe0yAmeC3Sp9K+672q3eKg=",
-          "range": "bytes=704-1060"
+          "checksum": "sha1-5bwVoaq1Noe1m3R1UrRBlJGLGSM=",
+          "range": "bytes=702-1043"
         },
         "data": {
-          "checksum": "sha256-Qdx821f7/tO71EyPPGGyuTZlK4If05eUDqMkGTNYzdw=",
-          "range": "bytes=1061-603623"
+          "checksum": "sha256-RUfH3pZt5PBG2RCxX2qGzc0JK+BWQ3BfabP8B3Zjkyo=",
+          "range": "bytes=1044-605796"
         },
         "name": "ncurses-terminfo-base",
         "signature": {
-          "checksum": "sha1-hFLJnjW3MeXzjutUUaMVz+pq774=",
-          "range": "bytes=0-703"
+          "checksum": "sha1-qOe+XIaqWDBfRGrODGmvZj+PGs8=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ncurses-terminfo-base-6.4_p20231125-r3.apk",
-        "version": "6.4_p20231125-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/ncurses-terminfo-base-6.5_p20240629-r0.apk",
+        "version": "6.5_p20240629-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ggdVedzys8c0/DPbL/8uVM0IeHM=",
+        "checksum": "Q1UbEaadDhtuSAInuPjntJMZefM4U=",
         "control": {
-          "checksum": "sha1-ggdVedzys8c0/DPbL/8uVM0IeHM=",
-          "range": "bytes=697-1165"
+          "checksum": "sha1-UbEaadDhtuSAInuPjntJMZefM4U=",
+          "range": "bytes=698-1152"
         },
         "data": {
-          "checksum": "sha256-7NLgBuaKCCXSTXXEZ48mE9pTOgyoOY6yHLR2cW0LdGM=",
-          "range": "bytes=1166-1048223"
+          "checksum": "sha256-gkm/MRL/YRxHkRROZEW/TSWGC7r+ZAqogwd0Umio3LU=",
+          "range": "bytes=1153-1065345"
         },
         "name": "ncurses",
         "signature": {
-          "checksum": "sha1-50wXsiR3GgiiLwsWICdXEagYHRE=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-NLFv0xzWR8uGe+4SFVz9mAZDn/k=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ncurses-6.4_p20231125-r3.apk",
-        "version": "6.4_p20231125-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/ncurses-6.5_p20240629-r0.apk",
+        "version": "6.5_p20240629-r0"
       },
       {
         "architecture": "x86_64",
@@ -850,22 +850,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1pFBna33iXNWoxlANBI0dibfvT94=",
+        "checksum": "Q1a6BZwHKJFZb3kLvCVJI8xP+VrT0=",
         "control": {
-          "checksum": "sha1-pFBna33iXNWoxlANBI0dibfvT94=",
-          "range": "bytes=706-1129"
+          "checksum": "sha1-a6BZwHKJFZb3kLvCVJI8xP+VrT0=",
+          "range": "bytes=704-1169"
         },
         "data": {
-          "checksum": "sha256-jsPjzi/shXYlr0zayGvJ82SSPVs4ew/DIy3L1hiuqdE=",
-          "range": "bytes=1130-66950"
+          "checksum": "sha256-FUKvi4Kg95WQig8Pig9G03JlHr70P4eGn/NNVkKZpSM=",
+          "range": "bytes=1170-71535"
         },
         "name": "libuuid",
         "signature": {
-          "checksum": "sha1-nVANm2v8k7qILW+g+xjNgr7yqQY=",
-          "range": "bytes=0-705"
+          "checksum": "sha1-Z4+F/Rm3twEs19SMey98+aXHXwo=",
+          "range": "bytes=0-703"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libuuid-2.40.1-r1.apk",
-        "version": "2.40.1-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libuuid-2.40.2-r0.apk",
+        "version": "2.40.2-r0"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/prometheus.lock.json
+++ b/wolfi-images/prometheus.lock.json
@@ -14,117 +14,117 @@
     "packages": [
       {
         "architecture": "x86_64",
-        "checksum": "Q1Ai8jWuxKZR2M2XhOpOGAoTEwnnk=",
+        "checksum": "Q1WR9MGKU+cJh6dJFEXnr3zU1qsMM=",
         "control": {
-          "checksum": "sha1-Ai8jWuxKZR2M2XhOpOGAoTEwnnk=",
-          "range": "bytes=705-1037"
+          "checksum": "sha1-WR9MGKU+cJh6dJFEXnr3zU1qsMM=",
+          "range": "bytes=705-1034"
         },
         "data": {
-          "checksum": "sha256-e4UardkBVyaC49aSyrVmXNi8sSKqQl4eKYd0LxGRLA0=",
-          "range": "bytes=1038-255695"
+          "checksum": "sha256-EkOhtSivoLErXsK2J9ri39thkwb2kJGYHVou4n6dMKA=",
+          "range": "bytes=1035-254654"
         },
         "name": "ca-certificates-bundle",
         "signature": {
-          "checksum": "sha1-loRuyYQLm+atp+YteiQoj++EWIM=",
+          "checksum": "sha1-WL9vKv1nPIeaUQI4O0DiY9RdSHE=",
           "range": "bytes=0-704"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20240315-r4.apk",
-        "version": "20240315-r4"
+        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20240705-r0.apk",
+        "version": "20240705-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1+GH6qRN4iy1IDt0cT0x0tin7YfI=",
+        "checksum": "Q1KmG1L67f+/TnVGcnIcLfWRF/K2g=",
         "control": {
-          "checksum": "sha1-+GH6qRN4iy1IDt0cT0x0tin7YfI=",
-          "range": "bytes=703-1051"
+          "checksum": "sha1-KmG1L67f+/TnVGcnIcLfWRF/K2g=",
+          "range": "bytes=702-1051"
         },
         "data": {
-          "checksum": "sha256-rO0P9z2V49BSrz1A5Ap69tEappVrg5MMBjzW00rOpZc=",
-          "range": "bytes=1052-122464"
+          "checksum": "sha256-2YIxYc/Quit+Kri2qS8p6XvL7taAmOYJU/1Z8RNQ+88=",
+          "range": "bytes=1052-122509"
         },
         "name": "wolfi-baselayout",
         "signature": {
-          "checksum": "sha1-Ntb6VuMzDfM+frpCjKEIpDzl53I=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-VVyPrknEtqCPym5lfhVEuIhfkKg=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r12.apk",
-        "version": "20230201-r12"
+        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r13.apk",
+        "version": "20230201-r13"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q17rD4cKGW3uVSJw02PFiYR719t/Y=",
+        "checksum": "Q1ASyaCJL2Zyz4uAKpPPlx1Sd40yo=",
         "control": {
-          "checksum": "sha1-7rD4cKGW3uVSJw02PFiYR719t/Y=",
-          "range": "bytes=697-1108"
+          "checksum": "sha1-ASyaCJL2Zyz4uAKpPPlx1Sd40yo=",
+          "range": "bytes=706-1101"
         },
         "data": {
-          "checksum": "sha256-GvSViXbvUD0BdV2A+IzVJni2DjLvyM+j14hM29DcsYg=",
-          "range": "bytes=1109-268391"
+          "checksum": "sha256-KoaUrlV3QZ4ATGvKgOmZ1C8Rb/tHK3zEiCTGDrxxc/I=",
+          "range": "bytes=1102-272818"
         },
         "name": "ld-linux",
         "signature": {
-          "checksum": "sha1-nRIFect8o/LOUIEvN17AsrI07dg=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-DBrLE0fWPMyB5/0kAtNlIK6viCU=",
+          "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1/A0wNjkLqqBhe0jFr2D9SKcDNq8=",
+        "checksum": "Q10iHLABsXtuH2JyExQ2IIxH1NUCI=",
         "control": {
-          "checksum": "sha1-/A0wNjkLqqBhe0jFr2D9SKcDNq8=",
-          "range": "bytes=696-1054"
+          "checksum": "sha1-0iHLABsXtuH2JyExQ2IIxH1NUCI=",
+          "range": "bytes=698-1041"
         },
         "data": {
-          "checksum": "sha256-GT22MF6hR+Tj4el5xk2QEwNWig5JRoOrZ60Lecz+lok=",
-          "range": "bytes=1055-408851"
+          "checksum": "sha256-A3RF8XLSIePkapCnvEridXa2N7nheKNT1kTKDqZlGdI=",
+          "range": "bytes=1042-408849"
         },
         "name": "glibc-locale-posix",
         "signature": {
-          "checksum": "sha1-9uPIvcOCeZbPiR7+MLDB4tkJlHo=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-QqrJFnJmyPeT66hUk3O7NxaWY8I=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1YLxq+Z9/+aFnCwvgV7acVLT4QFA=",
+        "checksum": "Q1JYf1zI1zVi/S9sMI32guk6ptuRQ=",
         "control": {
-          "checksum": "sha1-YLxq+Z9/+aFnCwvgV7acVLT4QFA=",
-          "range": "bytes=701-1330"
+          "checksum": "sha1-JYf1zI1zVi/S9sMI32guk6ptuRQ=",
+          "range": "bytes=701-1308"
         },
         "data": {
-          "checksum": "sha256-9s5RNfAJ3GVt7a/fFUaew5MfYYUkvL/6FMvsEfD95jY=",
-          "range": "bytes=1331-5862057"
+          "checksum": "sha256-ioC8korS2nJpJvoS6He+mKkDsgVLcMxiEuYLsAB9M7U=",
+          "range": "bytes=1309-5959239"
         },
         "name": "glibc",
         "signature": {
-          "checksum": "sha1-Kvfb+I/1PCfiBTjoaU4ezZa0b+8=",
+          "checksum": "sha1-3TP2+cHjCEBrIFluCdTmr2oJA1s=",
           "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Zi0e8Bq6WCd/6uXXjVhb8YwMD1U=",
+        "checksum": "Q1WAlPh7UNBV+RHfBixVB5P9F9Mp8=",
         "control": {
-          "checksum": "sha1-Zi0e8Bq6WCd/6uXXjVhb8YwMD1U=",
-          "range": "bytes=700-1073"
+          "checksum": "sha1-WAlPh7UNBV+RHfBixVB5P9F9Mp8=",
+          "range": "bytes=700-1074"
         },
         "data": {
-          "checksum": "sha256-jMhtfqVjnhuuBO7wtNZ6RS/72sZWoKt/Moage2amlks=",
-          "range": "bytes=1074-81594"
+          "checksum": "sha256-i6uEFvUEbJ4YzgNSV58aObIdU608mjbCVPwyF57ZeQQ=",
+          "range": "bytes=1075-81593"
         },
         "name": "protobuf-c",
         "signature": {
-          "checksum": "sha1-kATwMKztK7nk7qbYCJPkCFp6IXc=",
+          "checksum": "sha1-47zwDXmhcWiVtTYCjq4sFld8wHQ=",
           "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r5.apk",
-        "version": "1.5.0-r5"
+        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r6.apk",
+        "version": "1.5.0-r6"
       },
       {
         "architecture": "x86_64",
@@ -204,41 +204,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Q/Zy5ovYSu2p/vVLr6DgVA1e8AQ=",
+        "checksum": "Q1a5wJzZI7k9o4F8hHFpfuqAUIH5Q=",
         "control": {
-          "checksum": "sha1-Q/Zy5ovYSu2p/vVLr6DgVA1e8AQ=",
-          "range": "bytes=699-1062"
+          "checksum": "sha1-a5wJzZI7k9o4F8hHFpfuqAUIH5Q=",
+          "range": "bytes=710-1075"
         },
         "data": {
-          "checksum": "sha256-H3jxsw8ytOeCIR4vq17voSVhdNokXk8C1g075txH6Bs=",
-          "range": "bytes=1063-5903754"
+          "checksum": "sha256-2p1UC4F4Odfxup/J/nyzujYRGaxGVjBOBWoc0aajClI=",
+          "range": "bytes=1076-5903889"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-NIl2f5OI/wSZByI8Ds1ZUfbFWyw=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-SOFoklqXtH38i1PcI3G/cPdRFtY=",
+          "range": "bytes=0-709"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.1-r3.apk",
-        "version": "3.3.1-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.1-r4.apk",
+        "version": "3.3.1-r4"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q13wGUXdZut9OOTdY5z2amUj9wXC0=",
+        "checksum": "Q1gb2VyLOsGV7xUiHBT0Ypt64rw6Y=",
         "control": {
-          "checksum": "sha1-3wGUXdZut9OOTdY5z2amUj9wXC0=",
-          "range": "bytes=698-1068"
+          "checksum": "sha1-gb2VyLOsGV7xUiHBT0Ypt64rw6Y=",
+          "range": "bytes=702-1071"
         },
         "data": {
-          "checksum": "sha256-mRda6+YGlOCczyIWKaHqXskTINoT1rgorHDHqAKAb7c=",
-          "range": "bytes=1069-1188955"
+          "checksum": "sha256-h2tz/aFB2n8SFdBFde5foQm1ru+8JUcGp+trUeA2ZlQ=",
+          "range": "bytes=1072-1188954"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-+UdRc4U3PKw4H9OiNurHKXa5BYk=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-w6U2Pb1Y90u1iBFc/sHg2xn6Qmo=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.1-r3.apk",
-        "version": "3.3.1-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.1-r4.apk",
+        "version": "3.3.1-r4"
       },
       {
         "architecture": "x86_64",
@@ -356,60 +356,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1gfqHM/7r3rXX1HqC163slTPP46o=",
+        "checksum": "Q1DLAp18ebMscosnQ4TfTivIzgtCY=",
         "control": {
-          "checksum": "sha1-gfqHM/7r3rXX1HqC163slTPP46o=",
-          "range": "bytes=704-1101"
+          "checksum": "sha1-DLAp18ebMscosnQ4TfTivIzgtCY=",
+          "range": "bytes=698-1079"
         },
         "data": {
-          "checksum": "sha256-OR7ikvfUYp78EsP0I2kuwqqAcy05jw9tr7JVQ6jTnGQ=",
-          "range": "bytes=1102-185433"
+          "checksum": "sha256-eiBdqqECWnULWGe/Gnd6iv/7h56A4xR2qw+5toY5Gaw=",
+          "range": "bytes=1080-185559"
         },
         "name": "libgcc",
         "signature": {
-          "checksum": "sha1-Il4pyVzI6eqNd/f4bsKeakpB5DI=",
-          "range": "bytes=0-703"
+          "checksum": "sha1-qVj9laNeBIwRxP+8ehB+fXftJrw=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.2.0-r7.apk",
-        "version": "13.2.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r0.apk",
+        "version": "13.3.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1c+lykdx+yHoqsrQmQLHMV7waR1Q=",
+        "checksum": "Q1p9aaHhpB2Ud0URrcIrVRAujMw+o=",
         "control": {
-          "checksum": "sha1-c+lykdx+yHoqsrQmQLHMV7waR1Q=",
-          "range": "bytes=701-1119"
+          "checksum": "sha1-p9aaHhpB2Ud0URrcIrVRAujMw+o=",
+          "range": "bytes=696-1097"
         },
         "data": {
-          "checksum": "sha256-CuZi2C5g0vUnz4PNH8jIWV+EBdVMvHr+sNKFYTSnQZk=",
-          "range": "bytes=1120-3155369"
+          "checksum": "sha256-rGMnyLiGEDCEVgqA1oXMf28QHuWHAaPzYrLeDzQ3WOU=",
+          "range": "bytes=1098-3155519"
         },
         "name": "libstdc++",
         "signature": {
-          "checksum": "sha1-7l8MLj8aCcdqta/0sR+0PscBsD4=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-lge2XoAsgvp8U6ZBgT52N2xNQAw=",
+          "range": "bytes=0-695"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.2.0-r7.apk",
-        "version": "13.2.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r0.apk",
+        "version": "13.3.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1R8OxpY0fGwVaIwft4wJeswF5D54=",
+        "checksum": "Q1DUpLMidX5HbXUAFV8y3Imyt+Ank=",
         "control": {
-          "checksum": "sha1-R8OxpY0fGwVaIwft4wJeswF5D54=",
-          "range": "bytes=695-1059"
+          "checksum": "sha1-DUpLMidX5HbXUAFV8y3Imyt+Ank=",
+          "range": "bytes=698-1063"
         },
         "data": {
-          "checksum": "sha256-wNc8/SBJrGHfwywAtzCsAqeUOt0IaAhqNtlbv8OiHBE=",
-          "range": "bytes=1060-242151"
+          "checksum": "sha256-ZUDWWOBnxl5xi3b5HQCHaiYqKDSrnVpJQgavWpn1duc=",
+          "range": "bytes=1064-255810"
         },
         "name": "c-ares",
         "signature": {
-          "checksum": "sha1-55/PTlEHXI3o0hx9dSVdNwQeSMg=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-0AXk7b/B1baNADDg/NSocbW//pw=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.31.0-r0.apk",
-        "version": "1.31.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.32.1-r0.apk",
+        "version": "1.32.1-r0"
       },
       {
         "architecture": "x86_64",
@@ -470,22 +470,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q10AaU1ocIM4PYYNvwbml8TmpNvEA=",
+        "checksum": "Q1ORn/60iAvLcAgApXYoZzM6o0XSs=",
         "control": {
-          "checksum": "sha1-0AaU1ocIM4PYYNvwbml8TmpNvEA=",
-          "range": "bytes=706-1085"
+          "checksum": "sha1-ORn/60iAvLcAgApXYoZzM6o0XSs=",
+          "range": "bytes=703-1081"
         },
         "data": {
-          "checksum": "sha256-1YQNYASFjlP3kXX58ec8du75ij/U6O4DPAKzJAPkln0=",
-          "range": "bytes=1086-4272589"
+          "checksum": "sha256-Ya2Dn1VNYB21ZBD/jBCSx3SxZuJloJET5xkjX0s3Vt8=",
+          "range": "bytes=1082-4272708"
         },
         "name": "libxml2",
         "signature": {
-          "checksum": "sha1-QFjdplzGn/MiNFxMykgafr6/w6U=",
-          "range": "bytes=0-705"
+          "checksum": "sha1-s5jaTwJdla4k4KK0KEk7AYbgdqs=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.1-r1.apk",
-        "version": "2.13.1-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.2-r0.apk",
+        "version": "2.13.2-r0"
       },
       {
         "architecture": "x86_64",
@@ -546,22 +546,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1+0xClEzF5nhyNPUeGFhC++ElQmg=",
+        "checksum": "Q1u+fF2xg98dT0poYklte5HHMg/Kk=",
         "control": {
-          "checksum": "sha1-+0xClEzF5nhyNPUeGFhC++ElQmg=",
-          "range": "bytes=701-1107"
+          "checksum": "sha1-u+fF2xg98dT0poYklte5HHMg/Kk=",
+          "range": "bytes=701-1090"
         },
         "data": {
-          "checksum": "sha256-81V5R7T08up/3BwfuAG25Rq7KkB1MvALVCaogCpW500=",
-          "range": "bytes=1108-22181"
+          "checksum": "sha256-9e+i7LwSg7oAUU33f0r7A4Mc2suaK95iNU5BKaTSXac=",
+          "range": "bytes=1091-22179"
         },
         "name": "libcrypt1",
         "signature": {
-          "checksum": "sha1-k+7JfhPi5KOQ+6Nqk3oAfTbtOVM=",
+          "checksum": "sha1-EWBUcJqCJTOYJq1H0/kkO+m6W3E=",
           "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",
@@ -736,41 +736,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1K7zkV+ytg2NfGl9Sq0L07g7m3t8=",
+        "checksum": "Q1b6lPwgirLFi4Au4nZA9U9ZbCW5U=",
         "control": {
-          "checksum": "sha1-K7zkV+ytg2NfGl9Sq0L07g7m3t8=",
-          "range": "bytes=703-1134"
+          "checksum": "sha1-b6lPwgirLFi4Au4nZA9U9ZbCW5U=",
+          "range": "bytes=692-1123"
         },
         "data": {
-          "checksum": "sha256-R8lBnMUORssXrz1Ph1NoBz+/StjHKbjVjNDDtSvb0Zs=",
-          "range": "bytes=1135-191882402"
+          "checksum": "sha256-wrUoVRHdcMxgoAyTZ/GAOn6i5DgC0aEwuTEPZDnqPi0=",
+          "range": "bytes=1124-191882678"
         },
         "name": "prometheus-2.53",
         "signature": {
-          "checksum": "sha1-LHetuVjR91DCOcHkyTC91kBA3vY=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-7VHQ9SJ4f6NLkX9mNbPzXbD90Vc=",
+          "range": "bytes=0-691"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/prometheus-2.53-2.53.0-r2.apk",
-        "version": "2.53.0-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/prometheus-2.53-2.53.0-r3.apk",
+        "version": "2.53.0-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1mKnd8VT1t/VpToT3N7SPrMi9G7M=",
+        "checksum": "Q1N9RV3bK23FszTjVJ375f9J8Mi+k=",
         "control": {
-          "checksum": "sha1-mKnd8VT1t/VpToT3N7SPrMi9G7M=",
-          "range": "bytes=704-1076"
+          "checksum": "sha1-N9RV3bK23FszTjVJ375f9J8Mi+k=",
+          "range": "bytes=700-1058"
         },
         "data": {
-          "checksum": "sha256-jQj6AJ1g/WJ9eLrczILo23fWFXkgfa9KdKtaFQoqSUc=",
-          "range": "bytes=1077-57321007"
+          "checksum": "sha256-xrebQam/kpgL9sbps9vNd8FouIgpe48ni6MdRWH666E=",
+          "range": "bytes=1059-57325397"
         },
         "name": "prometheus-alertmanager",
         "signature": {
-          "checksum": "sha1-ZOVjf8UJGM8EYWnakAYVMzPXaoE=",
-          "range": "bytes=0-703"
+          "checksum": "sha1-kJ1AacHBEFxPE6MpRVaNeyLNi4w=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/prometheus-alertmanager-0.27.0-r6.apk",
-        "version": "0.27.0-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/prometheus-alertmanager-0.27.0-r8.apk",
+        "version": "0.27.0-r8"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/redis-exporter.lock.json
+++ b/wolfi-images/redis-exporter.lock.json
@@ -14,117 +14,117 @@
     "packages": [
       {
         "architecture": "x86_64",
-        "checksum": "Q1Ai8jWuxKZR2M2XhOpOGAoTEwnnk=",
+        "checksum": "Q1WR9MGKU+cJh6dJFEXnr3zU1qsMM=",
         "control": {
-          "checksum": "sha1-Ai8jWuxKZR2M2XhOpOGAoTEwnnk=",
-          "range": "bytes=705-1037"
+          "checksum": "sha1-WR9MGKU+cJh6dJFEXnr3zU1qsMM=",
+          "range": "bytes=705-1034"
         },
         "data": {
-          "checksum": "sha256-e4UardkBVyaC49aSyrVmXNi8sSKqQl4eKYd0LxGRLA0=",
-          "range": "bytes=1038-255695"
+          "checksum": "sha256-EkOhtSivoLErXsK2J9ri39thkwb2kJGYHVou4n6dMKA=",
+          "range": "bytes=1035-254654"
         },
         "name": "ca-certificates-bundle",
         "signature": {
-          "checksum": "sha1-loRuyYQLm+atp+YteiQoj++EWIM=",
+          "checksum": "sha1-WL9vKv1nPIeaUQI4O0DiY9RdSHE=",
           "range": "bytes=0-704"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20240315-r4.apk",
-        "version": "20240315-r4"
+        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20240705-r0.apk",
+        "version": "20240705-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1+GH6qRN4iy1IDt0cT0x0tin7YfI=",
+        "checksum": "Q1KmG1L67f+/TnVGcnIcLfWRF/K2g=",
         "control": {
-          "checksum": "sha1-+GH6qRN4iy1IDt0cT0x0tin7YfI=",
-          "range": "bytes=703-1051"
+          "checksum": "sha1-KmG1L67f+/TnVGcnIcLfWRF/K2g=",
+          "range": "bytes=702-1051"
         },
         "data": {
-          "checksum": "sha256-rO0P9z2V49BSrz1A5Ap69tEappVrg5MMBjzW00rOpZc=",
-          "range": "bytes=1052-122464"
+          "checksum": "sha256-2YIxYc/Quit+Kri2qS8p6XvL7taAmOYJU/1Z8RNQ+88=",
+          "range": "bytes=1052-122509"
         },
         "name": "wolfi-baselayout",
         "signature": {
-          "checksum": "sha1-Ntb6VuMzDfM+frpCjKEIpDzl53I=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-VVyPrknEtqCPym5lfhVEuIhfkKg=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r12.apk",
-        "version": "20230201-r12"
+        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r13.apk",
+        "version": "20230201-r13"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q17rD4cKGW3uVSJw02PFiYR719t/Y=",
+        "checksum": "Q1ASyaCJL2Zyz4uAKpPPlx1Sd40yo=",
         "control": {
-          "checksum": "sha1-7rD4cKGW3uVSJw02PFiYR719t/Y=",
-          "range": "bytes=697-1108"
+          "checksum": "sha1-ASyaCJL2Zyz4uAKpPPlx1Sd40yo=",
+          "range": "bytes=706-1101"
         },
         "data": {
-          "checksum": "sha256-GvSViXbvUD0BdV2A+IzVJni2DjLvyM+j14hM29DcsYg=",
-          "range": "bytes=1109-268391"
+          "checksum": "sha256-KoaUrlV3QZ4ATGvKgOmZ1C8Rb/tHK3zEiCTGDrxxc/I=",
+          "range": "bytes=1102-272818"
         },
         "name": "ld-linux",
         "signature": {
-          "checksum": "sha1-nRIFect8o/LOUIEvN17AsrI07dg=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-DBrLE0fWPMyB5/0kAtNlIK6viCU=",
+          "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1/A0wNjkLqqBhe0jFr2D9SKcDNq8=",
+        "checksum": "Q10iHLABsXtuH2JyExQ2IIxH1NUCI=",
         "control": {
-          "checksum": "sha1-/A0wNjkLqqBhe0jFr2D9SKcDNq8=",
-          "range": "bytes=696-1054"
+          "checksum": "sha1-0iHLABsXtuH2JyExQ2IIxH1NUCI=",
+          "range": "bytes=698-1041"
         },
         "data": {
-          "checksum": "sha256-GT22MF6hR+Tj4el5xk2QEwNWig5JRoOrZ60Lecz+lok=",
-          "range": "bytes=1055-408851"
+          "checksum": "sha256-A3RF8XLSIePkapCnvEridXa2N7nheKNT1kTKDqZlGdI=",
+          "range": "bytes=1042-408849"
         },
         "name": "glibc-locale-posix",
         "signature": {
-          "checksum": "sha1-9uPIvcOCeZbPiR7+MLDB4tkJlHo=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-QqrJFnJmyPeT66hUk3O7NxaWY8I=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1YLxq+Z9/+aFnCwvgV7acVLT4QFA=",
+        "checksum": "Q1JYf1zI1zVi/S9sMI32guk6ptuRQ=",
         "control": {
-          "checksum": "sha1-YLxq+Z9/+aFnCwvgV7acVLT4QFA=",
-          "range": "bytes=701-1330"
+          "checksum": "sha1-JYf1zI1zVi/S9sMI32guk6ptuRQ=",
+          "range": "bytes=701-1308"
         },
         "data": {
-          "checksum": "sha256-9s5RNfAJ3GVt7a/fFUaew5MfYYUkvL/6FMvsEfD95jY=",
-          "range": "bytes=1331-5862057"
+          "checksum": "sha256-ioC8korS2nJpJvoS6He+mKkDsgVLcMxiEuYLsAB9M7U=",
+          "range": "bytes=1309-5959239"
         },
         "name": "glibc",
         "signature": {
-          "checksum": "sha1-Kvfb+I/1PCfiBTjoaU4ezZa0b+8=",
+          "checksum": "sha1-3TP2+cHjCEBrIFluCdTmr2oJA1s=",
           "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Zi0e8Bq6WCd/6uXXjVhb8YwMD1U=",
+        "checksum": "Q1WAlPh7UNBV+RHfBixVB5P9F9Mp8=",
         "control": {
-          "checksum": "sha1-Zi0e8Bq6WCd/6uXXjVhb8YwMD1U=",
-          "range": "bytes=700-1073"
+          "checksum": "sha1-WAlPh7UNBV+RHfBixVB5P9F9Mp8=",
+          "range": "bytes=700-1074"
         },
         "data": {
-          "checksum": "sha256-jMhtfqVjnhuuBO7wtNZ6RS/72sZWoKt/Moage2amlks=",
-          "range": "bytes=1074-81594"
+          "checksum": "sha256-i6uEFvUEbJ4YzgNSV58aObIdU608mjbCVPwyF57ZeQQ=",
+          "range": "bytes=1075-81593"
         },
         "name": "protobuf-c",
         "signature": {
-          "checksum": "sha1-kATwMKztK7nk7qbYCJPkCFp6IXc=",
+          "checksum": "sha1-47zwDXmhcWiVtTYCjq4sFld8wHQ=",
           "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r5.apk",
-        "version": "1.5.0-r5"
+        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r6.apk",
+        "version": "1.5.0-r6"
       },
       {
         "architecture": "x86_64",
@@ -204,41 +204,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Q/Zy5ovYSu2p/vVLr6DgVA1e8AQ=",
+        "checksum": "Q1a5wJzZI7k9o4F8hHFpfuqAUIH5Q=",
         "control": {
-          "checksum": "sha1-Q/Zy5ovYSu2p/vVLr6DgVA1e8AQ=",
-          "range": "bytes=699-1062"
+          "checksum": "sha1-a5wJzZI7k9o4F8hHFpfuqAUIH5Q=",
+          "range": "bytes=710-1075"
         },
         "data": {
-          "checksum": "sha256-H3jxsw8ytOeCIR4vq17voSVhdNokXk8C1g075txH6Bs=",
-          "range": "bytes=1063-5903754"
+          "checksum": "sha256-2p1UC4F4Odfxup/J/nyzujYRGaxGVjBOBWoc0aajClI=",
+          "range": "bytes=1076-5903889"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-NIl2f5OI/wSZByI8Ds1ZUfbFWyw=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-SOFoklqXtH38i1PcI3G/cPdRFtY=",
+          "range": "bytes=0-709"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.1-r3.apk",
-        "version": "3.3.1-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.1-r4.apk",
+        "version": "3.3.1-r4"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q13wGUXdZut9OOTdY5z2amUj9wXC0=",
+        "checksum": "Q1gb2VyLOsGV7xUiHBT0Ypt64rw6Y=",
         "control": {
-          "checksum": "sha1-3wGUXdZut9OOTdY5z2amUj9wXC0=",
-          "range": "bytes=698-1068"
+          "checksum": "sha1-gb2VyLOsGV7xUiHBT0Ypt64rw6Y=",
+          "range": "bytes=702-1071"
         },
         "data": {
-          "checksum": "sha256-mRda6+YGlOCczyIWKaHqXskTINoT1rgorHDHqAKAb7c=",
-          "range": "bytes=1069-1188955"
+          "checksum": "sha256-h2tz/aFB2n8SFdBFde5foQm1ru+8JUcGp+trUeA2ZlQ=",
+          "range": "bytes=1072-1188954"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-+UdRc4U3PKw4H9OiNurHKXa5BYk=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-w6U2Pb1Y90u1iBFc/sHg2xn6Qmo=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.1-r3.apk",
-        "version": "3.3.1-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.1-r4.apk",
+        "version": "3.3.1-r4"
       },
       {
         "architecture": "x86_64",
@@ -356,60 +356,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1gfqHM/7r3rXX1HqC163slTPP46o=",
+        "checksum": "Q1DLAp18ebMscosnQ4TfTivIzgtCY=",
         "control": {
-          "checksum": "sha1-gfqHM/7r3rXX1HqC163slTPP46o=",
-          "range": "bytes=704-1101"
+          "checksum": "sha1-DLAp18ebMscosnQ4TfTivIzgtCY=",
+          "range": "bytes=698-1079"
         },
         "data": {
-          "checksum": "sha256-OR7ikvfUYp78EsP0I2kuwqqAcy05jw9tr7JVQ6jTnGQ=",
-          "range": "bytes=1102-185433"
+          "checksum": "sha256-eiBdqqECWnULWGe/Gnd6iv/7h56A4xR2qw+5toY5Gaw=",
+          "range": "bytes=1080-185559"
         },
         "name": "libgcc",
         "signature": {
-          "checksum": "sha1-Il4pyVzI6eqNd/f4bsKeakpB5DI=",
-          "range": "bytes=0-703"
+          "checksum": "sha1-qVj9laNeBIwRxP+8ehB+fXftJrw=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.2.0-r7.apk",
-        "version": "13.2.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r0.apk",
+        "version": "13.3.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1c+lykdx+yHoqsrQmQLHMV7waR1Q=",
+        "checksum": "Q1p9aaHhpB2Ud0URrcIrVRAujMw+o=",
         "control": {
-          "checksum": "sha1-c+lykdx+yHoqsrQmQLHMV7waR1Q=",
-          "range": "bytes=701-1119"
+          "checksum": "sha1-p9aaHhpB2Ud0URrcIrVRAujMw+o=",
+          "range": "bytes=696-1097"
         },
         "data": {
-          "checksum": "sha256-CuZi2C5g0vUnz4PNH8jIWV+EBdVMvHr+sNKFYTSnQZk=",
-          "range": "bytes=1120-3155369"
+          "checksum": "sha256-rGMnyLiGEDCEVgqA1oXMf28QHuWHAaPzYrLeDzQ3WOU=",
+          "range": "bytes=1098-3155519"
         },
         "name": "libstdc++",
         "signature": {
-          "checksum": "sha1-7l8MLj8aCcdqta/0sR+0PscBsD4=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-lge2XoAsgvp8U6ZBgT52N2xNQAw=",
+          "range": "bytes=0-695"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.2.0-r7.apk",
-        "version": "13.2.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r0.apk",
+        "version": "13.3.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1R8OxpY0fGwVaIwft4wJeswF5D54=",
+        "checksum": "Q1DUpLMidX5HbXUAFV8y3Imyt+Ank=",
         "control": {
-          "checksum": "sha1-R8OxpY0fGwVaIwft4wJeswF5D54=",
-          "range": "bytes=695-1059"
+          "checksum": "sha1-DUpLMidX5HbXUAFV8y3Imyt+Ank=",
+          "range": "bytes=698-1063"
         },
         "data": {
-          "checksum": "sha256-wNc8/SBJrGHfwywAtzCsAqeUOt0IaAhqNtlbv8OiHBE=",
-          "range": "bytes=1060-242151"
+          "checksum": "sha256-ZUDWWOBnxl5xi3b5HQCHaiYqKDSrnVpJQgavWpn1duc=",
+          "range": "bytes=1064-255810"
         },
         "name": "c-ares",
         "signature": {
-          "checksum": "sha1-55/PTlEHXI3o0hx9dSVdNwQeSMg=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-0AXk7b/B1baNADDg/NSocbW//pw=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.31.0-r0.apk",
-        "version": "1.31.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.32.1-r0.apk",
+        "version": "1.32.1-r0"
       },
       {
         "architecture": "x86_64",
@@ -470,22 +470,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q10AaU1ocIM4PYYNvwbml8TmpNvEA=",
+        "checksum": "Q1ORn/60iAvLcAgApXYoZzM6o0XSs=",
         "control": {
-          "checksum": "sha1-0AaU1ocIM4PYYNvwbml8TmpNvEA=",
-          "range": "bytes=706-1085"
+          "checksum": "sha1-ORn/60iAvLcAgApXYoZzM6o0XSs=",
+          "range": "bytes=703-1081"
         },
         "data": {
-          "checksum": "sha256-1YQNYASFjlP3kXX58ec8du75ij/U6O4DPAKzJAPkln0=",
-          "range": "bytes=1086-4272589"
+          "checksum": "sha256-Ya2Dn1VNYB21ZBD/jBCSx3SxZuJloJET5xkjX0s3Vt8=",
+          "range": "bytes=1082-4272708"
         },
         "name": "libxml2",
         "signature": {
-          "checksum": "sha1-QFjdplzGn/MiNFxMykgafr6/w6U=",
-          "range": "bytes=0-705"
+          "checksum": "sha1-s5jaTwJdla4k4KK0KEk7AYbgdqs=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.1-r1.apk",
-        "version": "2.13.1-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.2-r0.apk",
+        "version": "2.13.2-r0"
       },
       {
         "architecture": "x86_64",
@@ -546,22 +546,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1+0xClEzF5nhyNPUeGFhC++ElQmg=",
+        "checksum": "Q1u+fF2xg98dT0poYklte5HHMg/Kk=",
         "control": {
-          "checksum": "sha1-+0xClEzF5nhyNPUeGFhC++ElQmg=",
-          "range": "bytes=701-1107"
+          "checksum": "sha1-u+fF2xg98dT0poYklte5HHMg/Kk=",
+          "range": "bytes=701-1090"
         },
         "data": {
-          "checksum": "sha256-81V5R7T08up/3BwfuAG25Rq7KkB1MvALVCaogCpW500=",
-          "range": "bytes=1108-22181"
+          "checksum": "sha256-9e+i7LwSg7oAUU33f0r7A4Mc2suaK95iNU5BKaTSXac=",
+          "range": "bytes=1091-22179"
         },
         "name": "libcrypt1",
         "signature": {
-          "checksum": "sha1-k+7JfhPi5KOQ+6Nqk3oAfTbtOVM=",
+          "checksum": "sha1-EWBUcJqCJTOYJq1H0/kkO+m6W3E=",
           "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/redis.lock.json
+++ b/wolfi-images/redis.lock.json
@@ -14,117 +14,117 @@
     "packages": [
       {
         "architecture": "x86_64",
-        "checksum": "Q1Ai8jWuxKZR2M2XhOpOGAoTEwnnk=",
+        "checksum": "Q1WR9MGKU+cJh6dJFEXnr3zU1qsMM=",
         "control": {
-          "checksum": "sha1-Ai8jWuxKZR2M2XhOpOGAoTEwnnk=",
-          "range": "bytes=705-1037"
+          "checksum": "sha1-WR9MGKU+cJh6dJFEXnr3zU1qsMM=",
+          "range": "bytes=705-1034"
         },
         "data": {
-          "checksum": "sha256-e4UardkBVyaC49aSyrVmXNi8sSKqQl4eKYd0LxGRLA0=",
-          "range": "bytes=1038-255695"
+          "checksum": "sha256-EkOhtSivoLErXsK2J9ri39thkwb2kJGYHVou4n6dMKA=",
+          "range": "bytes=1035-254654"
         },
         "name": "ca-certificates-bundle",
         "signature": {
-          "checksum": "sha1-loRuyYQLm+atp+YteiQoj++EWIM=",
+          "checksum": "sha1-WL9vKv1nPIeaUQI4O0DiY9RdSHE=",
           "range": "bytes=0-704"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20240315-r4.apk",
-        "version": "20240315-r4"
+        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20240705-r0.apk",
+        "version": "20240705-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1+GH6qRN4iy1IDt0cT0x0tin7YfI=",
+        "checksum": "Q1KmG1L67f+/TnVGcnIcLfWRF/K2g=",
         "control": {
-          "checksum": "sha1-+GH6qRN4iy1IDt0cT0x0tin7YfI=",
-          "range": "bytes=703-1051"
+          "checksum": "sha1-KmG1L67f+/TnVGcnIcLfWRF/K2g=",
+          "range": "bytes=702-1051"
         },
         "data": {
-          "checksum": "sha256-rO0P9z2V49BSrz1A5Ap69tEappVrg5MMBjzW00rOpZc=",
-          "range": "bytes=1052-122464"
+          "checksum": "sha256-2YIxYc/Quit+Kri2qS8p6XvL7taAmOYJU/1Z8RNQ+88=",
+          "range": "bytes=1052-122509"
         },
         "name": "wolfi-baselayout",
         "signature": {
-          "checksum": "sha1-Ntb6VuMzDfM+frpCjKEIpDzl53I=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-VVyPrknEtqCPym5lfhVEuIhfkKg=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r12.apk",
-        "version": "20230201-r12"
+        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r13.apk",
+        "version": "20230201-r13"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q17rD4cKGW3uVSJw02PFiYR719t/Y=",
+        "checksum": "Q1ASyaCJL2Zyz4uAKpPPlx1Sd40yo=",
         "control": {
-          "checksum": "sha1-7rD4cKGW3uVSJw02PFiYR719t/Y=",
-          "range": "bytes=697-1108"
+          "checksum": "sha1-ASyaCJL2Zyz4uAKpPPlx1Sd40yo=",
+          "range": "bytes=706-1101"
         },
         "data": {
-          "checksum": "sha256-GvSViXbvUD0BdV2A+IzVJni2DjLvyM+j14hM29DcsYg=",
-          "range": "bytes=1109-268391"
+          "checksum": "sha256-KoaUrlV3QZ4ATGvKgOmZ1C8Rb/tHK3zEiCTGDrxxc/I=",
+          "range": "bytes=1102-272818"
         },
         "name": "ld-linux",
         "signature": {
-          "checksum": "sha1-nRIFect8o/LOUIEvN17AsrI07dg=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-DBrLE0fWPMyB5/0kAtNlIK6viCU=",
+          "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1/A0wNjkLqqBhe0jFr2D9SKcDNq8=",
+        "checksum": "Q10iHLABsXtuH2JyExQ2IIxH1NUCI=",
         "control": {
-          "checksum": "sha1-/A0wNjkLqqBhe0jFr2D9SKcDNq8=",
-          "range": "bytes=696-1054"
+          "checksum": "sha1-0iHLABsXtuH2JyExQ2IIxH1NUCI=",
+          "range": "bytes=698-1041"
         },
         "data": {
-          "checksum": "sha256-GT22MF6hR+Tj4el5xk2QEwNWig5JRoOrZ60Lecz+lok=",
-          "range": "bytes=1055-408851"
+          "checksum": "sha256-A3RF8XLSIePkapCnvEridXa2N7nheKNT1kTKDqZlGdI=",
+          "range": "bytes=1042-408849"
         },
         "name": "glibc-locale-posix",
         "signature": {
-          "checksum": "sha1-9uPIvcOCeZbPiR7+MLDB4tkJlHo=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-QqrJFnJmyPeT66hUk3O7NxaWY8I=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1YLxq+Z9/+aFnCwvgV7acVLT4QFA=",
+        "checksum": "Q1JYf1zI1zVi/S9sMI32guk6ptuRQ=",
         "control": {
-          "checksum": "sha1-YLxq+Z9/+aFnCwvgV7acVLT4QFA=",
-          "range": "bytes=701-1330"
+          "checksum": "sha1-JYf1zI1zVi/S9sMI32guk6ptuRQ=",
+          "range": "bytes=701-1308"
         },
         "data": {
-          "checksum": "sha256-9s5RNfAJ3GVt7a/fFUaew5MfYYUkvL/6FMvsEfD95jY=",
-          "range": "bytes=1331-5862057"
+          "checksum": "sha256-ioC8korS2nJpJvoS6He+mKkDsgVLcMxiEuYLsAB9M7U=",
+          "range": "bytes=1309-5959239"
         },
         "name": "glibc",
         "signature": {
-          "checksum": "sha1-Kvfb+I/1PCfiBTjoaU4ezZa0b+8=",
+          "checksum": "sha1-3TP2+cHjCEBrIFluCdTmr2oJA1s=",
           "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Zi0e8Bq6WCd/6uXXjVhb8YwMD1U=",
+        "checksum": "Q1WAlPh7UNBV+RHfBixVB5P9F9Mp8=",
         "control": {
-          "checksum": "sha1-Zi0e8Bq6WCd/6uXXjVhb8YwMD1U=",
-          "range": "bytes=700-1073"
+          "checksum": "sha1-WAlPh7UNBV+RHfBixVB5P9F9Mp8=",
+          "range": "bytes=700-1074"
         },
         "data": {
-          "checksum": "sha256-jMhtfqVjnhuuBO7wtNZ6RS/72sZWoKt/Moage2amlks=",
-          "range": "bytes=1074-81594"
+          "checksum": "sha256-i6uEFvUEbJ4YzgNSV58aObIdU608mjbCVPwyF57ZeQQ=",
+          "range": "bytes=1075-81593"
         },
         "name": "protobuf-c",
         "signature": {
-          "checksum": "sha1-kATwMKztK7nk7qbYCJPkCFp6IXc=",
+          "checksum": "sha1-47zwDXmhcWiVtTYCjq4sFld8wHQ=",
           "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r5.apk",
-        "version": "1.5.0-r5"
+        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r6.apk",
+        "version": "1.5.0-r6"
       },
       {
         "architecture": "x86_64",
@@ -204,41 +204,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Q/Zy5ovYSu2p/vVLr6DgVA1e8AQ=",
+        "checksum": "Q1a5wJzZI7k9o4F8hHFpfuqAUIH5Q=",
         "control": {
-          "checksum": "sha1-Q/Zy5ovYSu2p/vVLr6DgVA1e8AQ=",
-          "range": "bytes=699-1062"
+          "checksum": "sha1-a5wJzZI7k9o4F8hHFpfuqAUIH5Q=",
+          "range": "bytes=710-1075"
         },
         "data": {
-          "checksum": "sha256-H3jxsw8ytOeCIR4vq17voSVhdNokXk8C1g075txH6Bs=",
-          "range": "bytes=1063-5903754"
+          "checksum": "sha256-2p1UC4F4Odfxup/J/nyzujYRGaxGVjBOBWoc0aajClI=",
+          "range": "bytes=1076-5903889"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-NIl2f5OI/wSZByI8Ds1ZUfbFWyw=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-SOFoklqXtH38i1PcI3G/cPdRFtY=",
+          "range": "bytes=0-709"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.1-r3.apk",
-        "version": "3.3.1-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.1-r4.apk",
+        "version": "3.3.1-r4"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q13wGUXdZut9OOTdY5z2amUj9wXC0=",
+        "checksum": "Q1gb2VyLOsGV7xUiHBT0Ypt64rw6Y=",
         "control": {
-          "checksum": "sha1-3wGUXdZut9OOTdY5z2amUj9wXC0=",
-          "range": "bytes=698-1068"
+          "checksum": "sha1-gb2VyLOsGV7xUiHBT0Ypt64rw6Y=",
+          "range": "bytes=702-1071"
         },
         "data": {
-          "checksum": "sha256-mRda6+YGlOCczyIWKaHqXskTINoT1rgorHDHqAKAb7c=",
-          "range": "bytes=1069-1188955"
+          "checksum": "sha256-h2tz/aFB2n8SFdBFde5foQm1ru+8JUcGp+trUeA2ZlQ=",
+          "range": "bytes=1072-1188954"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-+UdRc4U3PKw4H9OiNurHKXa5BYk=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-w6U2Pb1Y90u1iBFc/sHg2xn6Qmo=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.1-r3.apk",
-        "version": "3.3.1-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.1-r4.apk",
+        "version": "3.3.1-r4"
       },
       {
         "architecture": "x86_64",
@@ -356,60 +356,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1gfqHM/7r3rXX1HqC163slTPP46o=",
+        "checksum": "Q1DLAp18ebMscosnQ4TfTivIzgtCY=",
         "control": {
-          "checksum": "sha1-gfqHM/7r3rXX1HqC163slTPP46o=",
-          "range": "bytes=704-1101"
+          "checksum": "sha1-DLAp18ebMscosnQ4TfTivIzgtCY=",
+          "range": "bytes=698-1079"
         },
         "data": {
-          "checksum": "sha256-OR7ikvfUYp78EsP0I2kuwqqAcy05jw9tr7JVQ6jTnGQ=",
-          "range": "bytes=1102-185433"
+          "checksum": "sha256-eiBdqqECWnULWGe/Gnd6iv/7h56A4xR2qw+5toY5Gaw=",
+          "range": "bytes=1080-185559"
         },
         "name": "libgcc",
         "signature": {
-          "checksum": "sha1-Il4pyVzI6eqNd/f4bsKeakpB5DI=",
-          "range": "bytes=0-703"
+          "checksum": "sha1-qVj9laNeBIwRxP+8ehB+fXftJrw=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.2.0-r7.apk",
-        "version": "13.2.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r0.apk",
+        "version": "13.3.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1c+lykdx+yHoqsrQmQLHMV7waR1Q=",
+        "checksum": "Q1p9aaHhpB2Ud0URrcIrVRAujMw+o=",
         "control": {
-          "checksum": "sha1-c+lykdx+yHoqsrQmQLHMV7waR1Q=",
-          "range": "bytes=701-1119"
+          "checksum": "sha1-p9aaHhpB2Ud0URrcIrVRAujMw+o=",
+          "range": "bytes=696-1097"
         },
         "data": {
-          "checksum": "sha256-CuZi2C5g0vUnz4PNH8jIWV+EBdVMvHr+sNKFYTSnQZk=",
-          "range": "bytes=1120-3155369"
+          "checksum": "sha256-rGMnyLiGEDCEVgqA1oXMf28QHuWHAaPzYrLeDzQ3WOU=",
+          "range": "bytes=1098-3155519"
         },
         "name": "libstdc++",
         "signature": {
-          "checksum": "sha1-7l8MLj8aCcdqta/0sR+0PscBsD4=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-lge2XoAsgvp8U6ZBgT52N2xNQAw=",
+          "range": "bytes=0-695"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.2.0-r7.apk",
-        "version": "13.2.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r0.apk",
+        "version": "13.3.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1R8OxpY0fGwVaIwft4wJeswF5D54=",
+        "checksum": "Q1DUpLMidX5HbXUAFV8y3Imyt+Ank=",
         "control": {
-          "checksum": "sha1-R8OxpY0fGwVaIwft4wJeswF5D54=",
-          "range": "bytes=695-1059"
+          "checksum": "sha1-DUpLMidX5HbXUAFV8y3Imyt+Ank=",
+          "range": "bytes=698-1063"
         },
         "data": {
-          "checksum": "sha256-wNc8/SBJrGHfwywAtzCsAqeUOt0IaAhqNtlbv8OiHBE=",
-          "range": "bytes=1060-242151"
+          "checksum": "sha256-ZUDWWOBnxl5xi3b5HQCHaiYqKDSrnVpJQgavWpn1duc=",
+          "range": "bytes=1064-255810"
         },
         "name": "c-ares",
         "signature": {
-          "checksum": "sha1-55/PTlEHXI3o0hx9dSVdNwQeSMg=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-0AXk7b/B1baNADDg/NSocbW//pw=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.31.0-r0.apk",
-        "version": "1.31.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.32.1-r0.apk",
+        "version": "1.32.1-r0"
       },
       {
         "architecture": "x86_64",
@@ -470,22 +470,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q10AaU1ocIM4PYYNvwbml8TmpNvEA=",
+        "checksum": "Q1ORn/60iAvLcAgApXYoZzM6o0XSs=",
         "control": {
-          "checksum": "sha1-0AaU1ocIM4PYYNvwbml8TmpNvEA=",
-          "range": "bytes=706-1085"
+          "checksum": "sha1-ORn/60iAvLcAgApXYoZzM6o0XSs=",
+          "range": "bytes=703-1081"
         },
         "data": {
-          "checksum": "sha256-1YQNYASFjlP3kXX58ec8du75ij/U6O4DPAKzJAPkln0=",
-          "range": "bytes=1086-4272589"
+          "checksum": "sha256-Ya2Dn1VNYB21ZBD/jBCSx3SxZuJloJET5xkjX0s3Vt8=",
+          "range": "bytes=1082-4272708"
         },
         "name": "libxml2",
         "signature": {
-          "checksum": "sha1-QFjdplzGn/MiNFxMykgafr6/w6U=",
-          "range": "bytes=0-705"
+          "checksum": "sha1-s5jaTwJdla4k4KK0KEk7AYbgdqs=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.1-r1.apk",
-        "version": "2.13.1-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.2-r0.apk",
+        "version": "2.13.2-r0"
       },
       {
         "architecture": "x86_64",
@@ -546,22 +546,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1+0xClEzF5nhyNPUeGFhC++ElQmg=",
+        "checksum": "Q1u+fF2xg98dT0poYklte5HHMg/Kk=",
         "control": {
-          "checksum": "sha1-+0xClEzF5nhyNPUeGFhC++ElQmg=",
-          "range": "bytes=701-1107"
+          "checksum": "sha1-u+fF2xg98dT0poYklte5HHMg/Kk=",
+          "range": "bytes=701-1090"
         },
         "data": {
-          "checksum": "sha256-81V5R7T08up/3BwfuAG25Rq7KkB1MvALVCaogCpW500=",
-          "range": "bytes=1108-22181"
+          "checksum": "sha256-9e+i7LwSg7oAUU33f0r7A4Mc2suaK95iNU5BKaTSXac=",
+          "range": "bytes=1091-22179"
         },
         "name": "libcrypt1",
         "signature": {
-          "checksum": "sha1-k+7JfhPi5KOQ+6Nqk3oAfTbtOVM=",
+          "checksum": "sha1-EWBUcJqCJTOYJq1H0/kkO+m6W3E=",
           "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",
@@ -736,41 +736,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ibJSAAe0yAmeC3Sp9K+672q3eKg=",
+        "checksum": "Q15bwVoaq1Noe1m3R1UrRBlJGLGSM=",
         "control": {
-          "checksum": "sha1-ibJSAAe0yAmeC3Sp9K+672q3eKg=",
-          "range": "bytes=704-1060"
+          "checksum": "sha1-5bwVoaq1Noe1m3R1UrRBlJGLGSM=",
+          "range": "bytes=702-1043"
         },
         "data": {
-          "checksum": "sha256-Qdx821f7/tO71EyPPGGyuTZlK4If05eUDqMkGTNYzdw=",
-          "range": "bytes=1061-603623"
+          "checksum": "sha256-RUfH3pZt5PBG2RCxX2qGzc0JK+BWQ3BfabP8B3Zjkyo=",
+          "range": "bytes=1044-605796"
         },
         "name": "ncurses-terminfo-base",
         "signature": {
-          "checksum": "sha1-hFLJnjW3MeXzjutUUaMVz+pq774=",
-          "range": "bytes=0-703"
+          "checksum": "sha1-qOe+XIaqWDBfRGrODGmvZj+PGs8=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ncurses-terminfo-base-6.4_p20231125-r3.apk",
-        "version": "6.4_p20231125-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/ncurses-terminfo-base-6.5_p20240629-r0.apk",
+        "version": "6.5_p20240629-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ggdVedzys8c0/DPbL/8uVM0IeHM=",
+        "checksum": "Q1UbEaadDhtuSAInuPjntJMZefM4U=",
         "control": {
-          "checksum": "sha1-ggdVedzys8c0/DPbL/8uVM0IeHM=",
-          "range": "bytes=697-1165"
+          "checksum": "sha1-UbEaadDhtuSAInuPjntJMZefM4U=",
+          "range": "bytes=698-1152"
         },
         "data": {
-          "checksum": "sha256-7NLgBuaKCCXSTXXEZ48mE9pTOgyoOY6yHLR2cW0LdGM=",
-          "range": "bytes=1166-1048223"
+          "checksum": "sha256-gkm/MRL/YRxHkRROZEW/TSWGC7r+ZAqogwd0Umio3LU=",
+          "range": "bytes=1153-1065345"
         },
         "name": "ncurses",
         "signature": {
-          "checksum": "sha1-50wXsiR3GgiiLwsWICdXEagYHRE=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-NLFv0xzWR8uGe+4SFVz9mAZDn/k=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ncurses-6.4_p20231125-r3.apk",
-        "version": "6.4_p20231125-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/ncurses-6.5_p20240629-r0.apk",
+        "version": "6.5_p20240629-r0"
       },
       {
         "architecture": "x86_64",
@@ -793,22 +793,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q13tqxuiWMSp7zTXeDFyDNiIuwasI=",
+        "checksum": "Q10yqVNi88v61b9c2xWRzAF6OoxeM=",
         "control": {
-          "checksum": "sha1-3tqxuiWMSp7zTXeDFyDNiIuwasI=",
-          "range": "bytes=698-1167"
+          "checksum": "sha1-0yqVNi88v61b9c2xWRzAF6OoxeM=",
+          "range": "bytes=699-1153"
         },
         "data": {
-          "checksum": "sha256-TlLDfGn1XfcyAiZNOMHsOowLojJDFuauAce+WX9vEqA=",
-          "range": "bytes=1168-374527"
+          "checksum": "sha256-FuIB0FDd12TzYrIIHppD7p0xLNxtYmzWy7JILhdl014=",
+          "range": "bytes=1154-380130"
         },
         "name": "posix-libc-utils",
         "signature": {
-          "checksum": "sha1-MWRG5AeczFgrA81A+fuBipNYroc=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-x/BW5hmnekS+QwbYanJLRVu5/TU=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/posix-libc-utils-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/posix-libc-utils-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/repo-updater.lock.json
+++ b/wolfi-images/repo-updater.lock.json
@@ -14,117 +14,117 @@
     "packages": [
       {
         "architecture": "x86_64",
-        "checksum": "Q1Ai8jWuxKZR2M2XhOpOGAoTEwnnk=",
+        "checksum": "Q1WR9MGKU+cJh6dJFEXnr3zU1qsMM=",
         "control": {
-          "checksum": "sha1-Ai8jWuxKZR2M2XhOpOGAoTEwnnk=",
-          "range": "bytes=705-1037"
+          "checksum": "sha1-WR9MGKU+cJh6dJFEXnr3zU1qsMM=",
+          "range": "bytes=705-1034"
         },
         "data": {
-          "checksum": "sha256-e4UardkBVyaC49aSyrVmXNi8sSKqQl4eKYd0LxGRLA0=",
-          "range": "bytes=1038-255695"
+          "checksum": "sha256-EkOhtSivoLErXsK2J9ri39thkwb2kJGYHVou4n6dMKA=",
+          "range": "bytes=1035-254654"
         },
         "name": "ca-certificates-bundle",
         "signature": {
-          "checksum": "sha1-loRuyYQLm+atp+YteiQoj++EWIM=",
+          "checksum": "sha1-WL9vKv1nPIeaUQI4O0DiY9RdSHE=",
           "range": "bytes=0-704"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20240315-r4.apk",
-        "version": "20240315-r4"
+        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20240705-r0.apk",
+        "version": "20240705-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1+GH6qRN4iy1IDt0cT0x0tin7YfI=",
+        "checksum": "Q1KmG1L67f+/TnVGcnIcLfWRF/K2g=",
         "control": {
-          "checksum": "sha1-+GH6qRN4iy1IDt0cT0x0tin7YfI=",
-          "range": "bytes=703-1051"
+          "checksum": "sha1-KmG1L67f+/TnVGcnIcLfWRF/K2g=",
+          "range": "bytes=702-1051"
         },
         "data": {
-          "checksum": "sha256-rO0P9z2V49BSrz1A5Ap69tEappVrg5MMBjzW00rOpZc=",
-          "range": "bytes=1052-122464"
+          "checksum": "sha256-2YIxYc/Quit+Kri2qS8p6XvL7taAmOYJU/1Z8RNQ+88=",
+          "range": "bytes=1052-122509"
         },
         "name": "wolfi-baselayout",
         "signature": {
-          "checksum": "sha1-Ntb6VuMzDfM+frpCjKEIpDzl53I=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-VVyPrknEtqCPym5lfhVEuIhfkKg=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r12.apk",
-        "version": "20230201-r12"
+        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r13.apk",
+        "version": "20230201-r13"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q17rD4cKGW3uVSJw02PFiYR719t/Y=",
+        "checksum": "Q1ASyaCJL2Zyz4uAKpPPlx1Sd40yo=",
         "control": {
-          "checksum": "sha1-7rD4cKGW3uVSJw02PFiYR719t/Y=",
-          "range": "bytes=697-1108"
+          "checksum": "sha1-ASyaCJL2Zyz4uAKpPPlx1Sd40yo=",
+          "range": "bytes=706-1101"
         },
         "data": {
-          "checksum": "sha256-GvSViXbvUD0BdV2A+IzVJni2DjLvyM+j14hM29DcsYg=",
-          "range": "bytes=1109-268391"
+          "checksum": "sha256-KoaUrlV3QZ4ATGvKgOmZ1C8Rb/tHK3zEiCTGDrxxc/I=",
+          "range": "bytes=1102-272818"
         },
         "name": "ld-linux",
         "signature": {
-          "checksum": "sha1-nRIFect8o/LOUIEvN17AsrI07dg=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-DBrLE0fWPMyB5/0kAtNlIK6viCU=",
+          "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1/A0wNjkLqqBhe0jFr2D9SKcDNq8=",
+        "checksum": "Q10iHLABsXtuH2JyExQ2IIxH1NUCI=",
         "control": {
-          "checksum": "sha1-/A0wNjkLqqBhe0jFr2D9SKcDNq8=",
-          "range": "bytes=696-1054"
+          "checksum": "sha1-0iHLABsXtuH2JyExQ2IIxH1NUCI=",
+          "range": "bytes=698-1041"
         },
         "data": {
-          "checksum": "sha256-GT22MF6hR+Tj4el5xk2QEwNWig5JRoOrZ60Lecz+lok=",
-          "range": "bytes=1055-408851"
+          "checksum": "sha256-A3RF8XLSIePkapCnvEridXa2N7nheKNT1kTKDqZlGdI=",
+          "range": "bytes=1042-408849"
         },
         "name": "glibc-locale-posix",
         "signature": {
-          "checksum": "sha1-9uPIvcOCeZbPiR7+MLDB4tkJlHo=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-QqrJFnJmyPeT66hUk3O7NxaWY8I=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1YLxq+Z9/+aFnCwvgV7acVLT4QFA=",
+        "checksum": "Q1JYf1zI1zVi/S9sMI32guk6ptuRQ=",
         "control": {
-          "checksum": "sha1-YLxq+Z9/+aFnCwvgV7acVLT4QFA=",
-          "range": "bytes=701-1330"
+          "checksum": "sha1-JYf1zI1zVi/S9sMI32guk6ptuRQ=",
+          "range": "bytes=701-1308"
         },
         "data": {
-          "checksum": "sha256-9s5RNfAJ3GVt7a/fFUaew5MfYYUkvL/6FMvsEfD95jY=",
-          "range": "bytes=1331-5862057"
+          "checksum": "sha256-ioC8korS2nJpJvoS6He+mKkDsgVLcMxiEuYLsAB9M7U=",
+          "range": "bytes=1309-5959239"
         },
         "name": "glibc",
         "signature": {
-          "checksum": "sha1-Kvfb+I/1PCfiBTjoaU4ezZa0b+8=",
+          "checksum": "sha1-3TP2+cHjCEBrIFluCdTmr2oJA1s=",
           "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Zi0e8Bq6WCd/6uXXjVhb8YwMD1U=",
+        "checksum": "Q1WAlPh7UNBV+RHfBixVB5P9F9Mp8=",
         "control": {
-          "checksum": "sha1-Zi0e8Bq6WCd/6uXXjVhb8YwMD1U=",
-          "range": "bytes=700-1073"
+          "checksum": "sha1-WAlPh7UNBV+RHfBixVB5P9F9Mp8=",
+          "range": "bytes=700-1074"
         },
         "data": {
-          "checksum": "sha256-jMhtfqVjnhuuBO7wtNZ6RS/72sZWoKt/Moage2amlks=",
-          "range": "bytes=1074-81594"
+          "checksum": "sha256-i6uEFvUEbJ4YzgNSV58aObIdU608mjbCVPwyF57ZeQQ=",
+          "range": "bytes=1075-81593"
         },
         "name": "protobuf-c",
         "signature": {
-          "checksum": "sha1-kATwMKztK7nk7qbYCJPkCFp6IXc=",
+          "checksum": "sha1-47zwDXmhcWiVtTYCjq4sFld8wHQ=",
           "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r5.apk",
-        "version": "1.5.0-r5"
+        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r6.apk",
+        "version": "1.5.0-r6"
       },
       {
         "architecture": "x86_64",
@@ -204,41 +204,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Q/Zy5ovYSu2p/vVLr6DgVA1e8AQ=",
+        "checksum": "Q1a5wJzZI7k9o4F8hHFpfuqAUIH5Q=",
         "control": {
-          "checksum": "sha1-Q/Zy5ovYSu2p/vVLr6DgVA1e8AQ=",
-          "range": "bytes=699-1062"
+          "checksum": "sha1-a5wJzZI7k9o4F8hHFpfuqAUIH5Q=",
+          "range": "bytes=710-1075"
         },
         "data": {
-          "checksum": "sha256-H3jxsw8ytOeCIR4vq17voSVhdNokXk8C1g075txH6Bs=",
-          "range": "bytes=1063-5903754"
+          "checksum": "sha256-2p1UC4F4Odfxup/J/nyzujYRGaxGVjBOBWoc0aajClI=",
+          "range": "bytes=1076-5903889"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-NIl2f5OI/wSZByI8Ds1ZUfbFWyw=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-SOFoklqXtH38i1PcI3G/cPdRFtY=",
+          "range": "bytes=0-709"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.1-r3.apk",
-        "version": "3.3.1-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.1-r4.apk",
+        "version": "3.3.1-r4"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q13wGUXdZut9OOTdY5z2amUj9wXC0=",
+        "checksum": "Q1gb2VyLOsGV7xUiHBT0Ypt64rw6Y=",
         "control": {
-          "checksum": "sha1-3wGUXdZut9OOTdY5z2amUj9wXC0=",
-          "range": "bytes=698-1068"
+          "checksum": "sha1-gb2VyLOsGV7xUiHBT0Ypt64rw6Y=",
+          "range": "bytes=702-1071"
         },
         "data": {
-          "checksum": "sha256-mRda6+YGlOCczyIWKaHqXskTINoT1rgorHDHqAKAb7c=",
-          "range": "bytes=1069-1188955"
+          "checksum": "sha256-h2tz/aFB2n8SFdBFde5foQm1ru+8JUcGp+trUeA2ZlQ=",
+          "range": "bytes=1072-1188954"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-+UdRc4U3PKw4H9OiNurHKXa5BYk=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-w6U2Pb1Y90u1iBFc/sHg2xn6Qmo=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.1-r3.apk",
-        "version": "3.3.1-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.1-r4.apk",
+        "version": "3.3.1-r4"
       },
       {
         "architecture": "x86_64",
@@ -356,60 +356,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1gfqHM/7r3rXX1HqC163slTPP46o=",
+        "checksum": "Q1DLAp18ebMscosnQ4TfTivIzgtCY=",
         "control": {
-          "checksum": "sha1-gfqHM/7r3rXX1HqC163slTPP46o=",
-          "range": "bytes=704-1101"
+          "checksum": "sha1-DLAp18ebMscosnQ4TfTivIzgtCY=",
+          "range": "bytes=698-1079"
         },
         "data": {
-          "checksum": "sha256-OR7ikvfUYp78EsP0I2kuwqqAcy05jw9tr7JVQ6jTnGQ=",
-          "range": "bytes=1102-185433"
+          "checksum": "sha256-eiBdqqECWnULWGe/Gnd6iv/7h56A4xR2qw+5toY5Gaw=",
+          "range": "bytes=1080-185559"
         },
         "name": "libgcc",
         "signature": {
-          "checksum": "sha1-Il4pyVzI6eqNd/f4bsKeakpB5DI=",
-          "range": "bytes=0-703"
+          "checksum": "sha1-qVj9laNeBIwRxP+8ehB+fXftJrw=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.2.0-r7.apk",
-        "version": "13.2.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r0.apk",
+        "version": "13.3.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1c+lykdx+yHoqsrQmQLHMV7waR1Q=",
+        "checksum": "Q1p9aaHhpB2Ud0URrcIrVRAujMw+o=",
         "control": {
-          "checksum": "sha1-c+lykdx+yHoqsrQmQLHMV7waR1Q=",
-          "range": "bytes=701-1119"
+          "checksum": "sha1-p9aaHhpB2Ud0URrcIrVRAujMw+o=",
+          "range": "bytes=696-1097"
         },
         "data": {
-          "checksum": "sha256-CuZi2C5g0vUnz4PNH8jIWV+EBdVMvHr+sNKFYTSnQZk=",
-          "range": "bytes=1120-3155369"
+          "checksum": "sha256-rGMnyLiGEDCEVgqA1oXMf28QHuWHAaPzYrLeDzQ3WOU=",
+          "range": "bytes=1098-3155519"
         },
         "name": "libstdc++",
         "signature": {
-          "checksum": "sha1-7l8MLj8aCcdqta/0sR+0PscBsD4=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-lge2XoAsgvp8U6ZBgT52N2xNQAw=",
+          "range": "bytes=0-695"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.2.0-r7.apk",
-        "version": "13.2.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r0.apk",
+        "version": "13.3.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1R8OxpY0fGwVaIwft4wJeswF5D54=",
+        "checksum": "Q1DUpLMidX5HbXUAFV8y3Imyt+Ank=",
         "control": {
-          "checksum": "sha1-R8OxpY0fGwVaIwft4wJeswF5D54=",
-          "range": "bytes=695-1059"
+          "checksum": "sha1-DUpLMidX5HbXUAFV8y3Imyt+Ank=",
+          "range": "bytes=698-1063"
         },
         "data": {
-          "checksum": "sha256-wNc8/SBJrGHfwywAtzCsAqeUOt0IaAhqNtlbv8OiHBE=",
-          "range": "bytes=1060-242151"
+          "checksum": "sha256-ZUDWWOBnxl5xi3b5HQCHaiYqKDSrnVpJQgavWpn1duc=",
+          "range": "bytes=1064-255810"
         },
         "name": "c-ares",
         "signature": {
-          "checksum": "sha1-55/PTlEHXI3o0hx9dSVdNwQeSMg=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-0AXk7b/B1baNADDg/NSocbW//pw=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.31.0-r0.apk",
-        "version": "1.31.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.32.1-r0.apk",
+        "version": "1.32.1-r0"
       },
       {
         "architecture": "x86_64",
@@ -470,22 +470,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q10AaU1ocIM4PYYNvwbml8TmpNvEA=",
+        "checksum": "Q1ORn/60iAvLcAgApXYoZzM6o0XSs=",
         "control": {
-          "checksum": "sha1-0AaU1ocIM4PYYNvwbml8TmpNvEA=",
-          "range": "bytes=706-1085"
+          "checksum": "sha1-ORn/60iAvLcAgApXYoZzM6o0XSs=",
+          "range": "bytes=703-1081"
         },
         "data": {
-          "checksum": "sha256-1YQNYASFjlP3kXX58ec8du75ij/U6O4DPAKzJAPkln0=",
-          "range": "bytes=1086-4272589"
+          "checksum": "sha256-Ya2Dn1VNYB21ZBD/jBCSx3SxZuJloJET5xkjX0s3Vt8=",
+          "range": "bytes=1082-4272708"
         },
         "name": "libxml2",
         "signature": {
-          "checksum": "sha1-QFjdplzGn/MiNFxMykgafr6/w6U=",
-          "range": "bytes=0-705"
+          "checksum": "sha1-s5jaTwJdla4k4KK0KEk7AYbgdqs=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.1-r1.apk",
-        "version": "2.13.1-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.2-r0.apk",
+        "version": "2.13.2-r0"
       },
       {
         "architecture": "x86_64",
@@ -546,22 +546,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1+0xClEzF5nhyNPUeGFhC++ElQmg=",
+        "checksum": "Q1u+fF2xg98dT0poYklte5HHMg/Kk=",
         "control": {
-          "checksum": "sha1-+0xClEzF5nhyNPUeGFhC++ElQmg=",
-          "range": "bytes=701-1107"
+          "checksum": "sha1-u+fF2xg98dT0poYklte5HHMg/Kk=",
+          "range": "bytes=701-1090"
         },
         "data": {
-          "checksum": "sha256-81V5R7T08up/3BwfuAG25Rq7KkB1MvALVCaogCpW500=",
-          "range": "bytes=1108-22181"
+          "checksum": "sha256-9e+i7LwSg7oAUU33f0r7A4Mc2suaK95iNU5BKaTSXac=",
+          "range": "bytes=1091-22179"
         },
         "name": "libcrypt1",
         "signature": {
-          "checksum": "sha1-k+7JfhPi5KOQ+6Nqk3oAfTbtOVM=",
+          "checksum": "sha1-EWBUcJqCJTOYJq1H0/kkO+m6W3E=",
           "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/search-indexer.lock.json
+++ b/wolfi-images/search-indexer.lock.json
@@ -14,117 +14,117 @@
     "packages": [
       {
         "architecture": "x86_64",
-        "checksum": "Q1Ai8jWuxKZR2M2XhOpOGAoTEwnnk=",
+        "checksum": "Q1WR9MGKU+cJh6dJFEXnr3zU1qsMM=",
         "control": {
-          "checksum": "sha1-Ai8jWuxKZR2M2XhOpOGAoTEwnnk=",
-          "range": "bytes=705-1037"
+          "checksum": "sha1-WR9MGKU+cJh6dJFEXnr3zU1qsMM=",
+          "range": "bytes=705-1034"
         },
         "data": {
-          "checksum": "sha256-e4UardkBVyaC49aSyrVmXNi8sSKqQl4eKYd0LxGRLA0=",
-          "range": "bytes=1038-255695"
+          "checksum": "sha256-EkOhtSivoLErXsK2J9ri39thkwb2kJGYHVou4n6dMKA=",
+          "range": "bytes=1035-254654"
         },
         "name": "ca-certificates-bundle",
         "signature": {
-          "checksum": "sha1-loRuyYQLm+atp+YteiQoj++EWIM=",
+          "checksum": "sha1-WL9vKv1nPIeaUQI4O0DiY9RdSHE=",
           "range": "bytes=0-704"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20240315-r4.apk",
-        "version": "20240315-r4"
+        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20240705-r0.apk",
+        "version": "20240705-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1+GH6qRN4iy1IDt0cT0x0tin7YfI=",
+        "checksum": "Q1KmG1L67f+/TnVGcnIcLfWRF/K2g=",
         "control": {
-          "checksum": "sha1-+GH6qRN4iy1IDt0cT0x0tin7YfI=",
-          "range": "bytes=703-1051"
+          "checksum": "sha1-KmG1L67f+/TnVGcnIcLfWRF/K2g=",
+          "range": "bytes=702-1051"
         },
         "data": {
-          "checksum": "sha256-rO0P9z2V49BSrz1A5Ap69tEappVrg5MMBjzW00rOpZc=",
-          "range": "bytes=1052-122464"
+          "checksum": "sha256-2YIxYc/Quit+Kri2qS8p6XvL7taAmOYJU/1Z8RNQ+88=",
+          "range": "bytes=1052-122509"
         },
         "name": "wolfi-baselayout",
         "signature": {
-          "checksum": "sha1-Ntb6VuMzDfM+frpCjKEIpDzl53I=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-VVyPrknEtqCPym5lfhVEuIhfkKg=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r12.apk",
-        "version": "20230201-r12"
+        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r13.apk",
+        "version": "20230201-r13"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q17rD4cKGW3uVSJw02PFiYR719t/Y=",
+        "checksum": "Q1ASyaCJL2Zyz4uAKpPPlx1Sd40yo=",
         "control": {
-          "checksum": "sha1-7rD4cKGW3uVSJw02PFiYR719t/Y=",
-          "range": "bytes=697-1108"
+          "checksum": "sha1-ASyaCJL2Zyz4uAKpPPlx1Sd40yo=",
+          "range": "bytes=706-1101"
         },
         "data": {
-          "checksum": "sha256-GvSViXbvUD0BdV2A+IzVJni2DjLvyM+j14hM29DcsYg=",
-          "range": "bytes=1109-268391"
+          "checksum": "sha256-KoaUrlV3QZ4ATGvKgOmZ1C8Rb/tHK3zEiCTGDrxxc/I=",
+          "range": "bytes=1102-272818"
         },
         "name": "ld-linux",
         "signature": {
-          "checksum": "sha1-nRIFect8o/LOUIEvN17AsrI07dg=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-DBrLE0fWPMyB5/0kAtNlIK6viCU=",
+          "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1/A0wNjkLqqBhe0jFr2D9SKcDNq8=",
+        "checksum": "Q10iHLABsXtuH2JyExQ2IIxH1NUCI=",
         "control": {
-          "checksum": "sha1-/A0wNjkLqqBhe0jFr2D9SKcDNq8=",
-          "range": "bytes=696-1054"
+          "checksum": "sha1-0iHLABsXtuH2JyExQ2IIxH1NUCI=",
+          "range": "bytes=698-1041"
         },
         "data": {
-          "checksum": "sha256-GT22MF6hR+Tj4el5xk2QEwNWig5JRoOrZ60Lecz+lok=",
-          "range": "bytes=1055-408851"
+          "checksum": "sha256-A3RF8XLSIePkapCnvEridXa2N7nheKNT1kTKDqZlGdI=",
+          "range": "bytes=1042-408849"
         },
         "name": "glibc-locale-posix",
         "signature": {
-          "checksum": "sha1-9uPIvcOCeZbPiR7+MLDB4tkJlHo=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-QqrJFnJmyPeT66hUk3O7NxaWY8I=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1YLxq+Z9/+aFnCwvgV7acVLT4QFA=",
+        "checksum": "Q1JYf1zI1zVi/S9sMI32guk6ptuRQ=",
         "control": {
-          "checksum": "sha1-YLxq+Z9/+aFnCwvgV7acVLT4QFA=",
-          "range": "bytes=701-1330"
+          "checksum": "sha1-JYf1zI1zVi/S9sMI32guk6ptuRQ=",
+          "range": "bytes=701-1308"
         },
         "data": {
-          "checksum": "sha256-9s5RNfAJ3GVt7a/fFUaew5MfYYUkvL/6FMvsEfD95jY=",
-          "range": "bytes=1331-5862057"
+          "checksum": "sha256-ioC8korS2nJpJvoS6He+mKkDsgVLcMxiEuYLsAB9M7U=",
+          "range": "bytes=1309-5959239"
         },
         "name": "glibc",
         "signature": {
-          "checksum": "sha1-Kvfb+I/1PCfiBTjoaU4ezZa0b+8=",
+          "checksum": "sha1-3TP2+cHjCEBrIFluCdTmr2oJA1s=",
           "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Zi0e8Bq6WCd/6uXXjVhb8YwMD1U=",
+        "checksum": "Q1WAlPh7UNBV+RHfBixVB5P9F9Mp8=",
         "control": {
-          "checksum": "sha1-Zi0e8Bq6WCd/6uXXjVhb8YwMD1U=",
-          "range": "bytes=700-1073"
+          "checksum": "sha1-WAlPh7UNBV+RHfBixVB5P9F9Mp8=",
+          "range": "bytes=700-1074"
         },
         "data": {
-          "checksum": "sha256-jMhtfqVjnhuuBO7wtNZ6RS/72sZWoKt/Moage2amlks=",
-          "range": "bytes=1074-81594"
+          "checksum": "sha256-i6uEFvUEbJ4YzgNSV58aObIdU608mjbCVPwyF57ZeQQ=",
+          "range": "bytes=1075-81593"
         },
         "name": "protobuf-c",
         "signature": {
-          "checksum": "sha1-kATwMKztK7nk7qbYCJPkCFp6IXc=",
+          "checksum": "sha1-47zwDXmhcWiVtTYCjq4sFld8wHQ=",
           "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r5.apk",
-        "version": "1.5.0-r5"
+        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r6.apk",
+        "version": "1.5.0-r6"
       },
       {
         "architecture": "x86_64",
@@ -204,41 +204,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Q/Zy5ovYSu2p/vVLr6DgVA1e8AQ=",
+        "checksum": "Q1a5wJzZI7k9o4F8hHFpfuqAUIH5Q=",
         "control": {
-          "checksum": "sha1-Q/Zy5ovYSu2p/vVLr6DgVA1e8AQ=",
-          "range": "bytes=699-1062"
+          "checksum": "sha1-a5wJzZI7k9o4F8hHFpfuqAUIH5Q=",
+          "range": "bytes=710-1075"
         },
         "data": {
-          "checksum": "sha256-H3jxsw8ytOeCIR4vq17voSVhdNokXk8C1g075txH6Bs=",
-          "range": "bytes=1063-5903754"
+          "checksum": "sha256-2p1UC4F4Odfxup/J/nyzujYRGaxGVjBOBWoc0aajClI=",
+          "range": "bytes=1076-5903889"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-NIl2f5OI/wSZByI8Ds1ZUfbFWyw=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-SOFoklqXtH38i1PcI3G/cPdRFtY=",
+          "range": "bytes=0-709"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.1-r3.apk",
-        "version": "3.3.1-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.1-r4.apk",
+        "version": "3.3.1-r4"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q13wGUXdZut9OOTdY5z2amUj9wXC0=",
+        "checksum": "Q1gb2VyLOsGV7xUiHBT0Ypt64rw6Y=",
         "control": {
-          "checksum": "sha1-3wGUXdZut9OOTdY5z2amUj9wXC0=",
-          "range": "bytes=698-1068"
+          "checksum": "sha1-gb2VyLOsGV7xUiHBT0Ypt64rw6Y=",
+          "range": "bytes=702-1071"
         },
         "data": {
-          "checksum": "sha256-mRda6+YGlOCczyIWKaHqXskTINoT1rgorHDHqAKAb7c=",
-          "range": "bytes=1069-1188955"
+          "checksum": "sha256-h2tz/aFB2n8SFdBFde5foQm1ru+8JUcGp+trUeA2ZlQ=",
+          "range": "bytes=1072-1188954"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-+UdRc4U3PKw4H9OiNurHKXa5BYk=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-w6U2Pb1Y90u1iBFc/sHg2xn6Qmo=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.1-r3.apk",
-        "version": "3.3.1-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.1-r4.apk",
+        "version": "3.3.1-r4"
       },
       {
         "architecture": "x86_64",
@@ -356,60 +356,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1gfqHM/7r3rXX1HqC163slTPP46o=",
+        "checksum": "Q1DLAp18ebMscosnQ4TfTivIzgtCY=",
         "control": {
-          "checksum": "sha1-gfqHM/7r3rXX1HqC163slTPP46o=",
-          "range": "bytes=704-1101"
+          "checksum": "sha1-DLAp18ebMscosnQ4TfTivIzgtCY=",
+          "range": "bytes=698-1079"
         },
         "data": {
-          "checksum": "sha256-OR7ikvfUYp78EsP0I2kuwqqAcy05jw9tr7JVQ6jTnGQ=",
-          "range": "bytes=1102-185433"
+          "checksum": "sha256-eiBdqqECWnULWGe/Gnd6iv/7h56A4xR2qw+5toY5Gaw=",
+          "range": "bytes=1080-185559"
         },
         "name": "libgcc",
         "signature": {
-          "checksum": "sha1-Il4pyVzI6eqNd/f4bsKeakpB5DI=",
-          "range": "bytes=0-703"
+          "checksum": "sha1-qVj9laNeBIwRxP+8ehB+fXftJrw=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.2.0-r7.apk",
-        "version": "13.2.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r0.apk",
+        "version": "13.3.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1c+lykdx+yHoqsrQmQLHMV7waR1Q=",
+        "checksum": "Q1p9aaHhpB2Ud0URrcIrVRAujMw+o=",
         "control": {
-          "checksum": "sha1-c+lykdx+yHoqsrQmQLHMV7waR1Q=",
-          "range": "bytes=701-1119"
+          "checksum": "sha1-p9aaHhpB2Ud0URrcIrVRAujMw+o=",
+          "range": "bytes=696-1097"
         },
         "data": {
-          "checksum": "sha256-CuZi2C5g0vUnz4PNH8jIWV+EBdVMvHr+sNKFYTSnQZk=",
-          "range": "bytes=1120-3155369"
+          "checksum": "sha256-rGMnyLiGEDCEVgqA1oXMf28QHuWHAaPzYrLeDzQ3WOU=",
+          "range": "bytes=1098-3155519"
         },
         "name": "libstdc++",
         "signature": {
-          "checksum": "sha1-7l8MLj8aCcdqta/0sR+0PscBsD4=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-lge2XoAsgvp8U6ZBgT52N2xNQAw=",
+          "range": "bytes=0-695"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.2.0-r7.apk",
-        "version": "13.2.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r0.apk",
+        "version": "13.3.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1R8OxpY0fGwVaIwft4wJeswF5D54=",
+        "checksum": "Q1DUpLMidX5HbXUAFV8y3Imyt+Ank=",
         "control": {
-          "checksum": "sha1-R8OxpY0fGwVaIwft4wJeswF5D54=",
-          "range": "bytes=695-1059"
+          "checksum": "sha1-DUpLMidX5HbXUAFV8y3Imyt+Ank=",
+          "range": "bytes=698-1063"
         },
         "data": {
-          "checksum": "sha256-wNc8/SBJrGHfwywAtzCsAqeUOt0IaAhqNtlbv8OiHBE=",
-          "range": "bytes=1060-242151"
+          "checksum": "sha256-ZUDWWOBnxl5xi3b5HQCHaiYqKDSrnVpJQgavWpn1duc=",
+          "range": "bytes=1064-255810"
         },
         "name": "c-ares",
         "signature": {
-          "checksum": "sha1-55/PTlEHXI3o0hx9dSVdNwQeSMg=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-0AXk7b/B1baNADDg/NSocbW//pw=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.31.0-r0.apk",
-        "version": "1.31.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.32.1-r0.apk",
+        "version": "1.32.1-r0"
       },
       {
         "architecture": "x86_64",
@@ -470,22 +470,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q10AaU1ocIM4PYYNvwbml8TmpNvEA=",
+        "checksum": "Q1ORn/60iAvLcAgApXYoZzM6o0XSs=",
         "control": {
-          "checksum": "sha1-0AaU1ocIM4PYYNvwbml8TmpNvEA=",
-          "range": "bytes=706-1085"
+          "checksum": "sha1-ORn/60iAvLcAgApXYoZzM6o0XSs=",
+          "range": "bytes=703-1081"
         },
         "data": {
-          "checksum": "sha256-1YQNYASFjlP3kXX58ec8du75ij/U6O4DPAKzJAPkln0=",
-          "range": "bytes=1086-4272589"
+          "checksum": "sha256-Ya2Dn1VNYB21ZBD/jBCSx3SxZuJloJET5xkjX0s3Vt8=",
+          "range": "bytes=1082-4272708"
         },
         "name": "libxml2",
         "signature": {
-          "checksum": "sha1-QFjdplzGn/MiNFxMykgafr6/w6U=",
-          "range": "bytes=0-705"
+          "checksum": "sha1-s5jaTwJdla4k4KK0KEk7AYbgdqs=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.1-r1.apk",
-        "version": "2.13.1-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.2-r0.apk",
+        "version": "2.13.2-r0"
       },
       {
         "architecture": "x86_64",
@@ -546,22 +546,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1+0xClEzF5nhyNPUeGFhC++ElQmg=",
+        "checksum": "Q1u+fF2xg98dT0poYklte5HHMg/Kk=",
         "control": {
-          "checksum": "sha1-+0xClEzF5nhyNPUeGFhC++ElQmg=",
-          "range": "bytes=701-1107"
+          "checksum": "sha1-u+fF2xg98dT0poYklte5HHMg/Kk=",
+          "range": "bytes=701-1090"
         },
         "data": {
-          "checksum": "sha256-81V5R7T08up/3BwfuAG25Rq7KkB1MvALVCaogCpW500=",
-          "range": "bytes=1108-22181"
+          "checksum": "sha256-9e+i7LwSg7oAUU33f0r7A4Mc2suaK95iNU5BKaTSXac=",
+          "range": "bytes=1091-22179"
         },
         "name": "libcrypt1",
         "signature": {
-          "checksum": "sha1-k+7JfhPi5KOQ+6Nqk3oAfTbtOVM=",
+          "checksum": "sha1-EWBUcJqCJTOYJq1H0/kkO+m6W3E=",
           "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/searcher.lock.json
+++ b/wolfi-images/searcher.lock.json
@@ -14,117 +14,117 @@
     "packages": [
       {
         "architecture": "x86_64",
-        "checksum": "Q1Ai8jWuxKZR2M2XhOpOGAoTEwnnk=",
+        "checksum": "Q1WR9MGKU+cJh6dJFEXnr3zU1qsMM=",
         "control": {
-          "checksum": "sha1-Ai8jWuxKZR2M2XhOpOGAoTEwnnk=",
-          "range": "bytes=705-1037"
+          "checksum": "sha1-WR9MGKU+cJh6dJFEXnr3zU1qsMM=",
+          "range": "bytes=705-1034"
         },
         "data": {
-          "checksum": "sha256-e4UardkBVyaC49aSyrVmXNi8sSKqQl4eKYd0LxGRLA0=",
-          "range": "bytes=1038-255695"
+          "checksum": "sha256-EkOhtSivoLErXsK2J9ri39thkwb2kJGYHVou4n6dMKA=",
+          "range": "bytes=1035-254654"
         },
         "name": "ca-certificates-bundle",
         "signature": {
-          "checksum": "sha1-loRuyYQLm+atp+YteiQoj++EWIM=",
+          "checksum": "sha1-WL9vKv1nPIeaUQI4O0DiY9RdSHE=",
           "range": "bytes=0-704"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20240315-r4.apk",
-        "version": "20240315-r4"
+        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20240705-r0.apk",
+        "version": "20240705-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1+GH6qRN4iy1IDt0cT0x0tin7YfI=",
+        "checksum": "Q1KmG1L67f+/TnVGcnIcLfWRF/K2g=",
         "control": {
-          "checksum": "sha1-+GH6qRN4iy1IDt0cT0x0tin7YfI=",
-          "range": "bytes=703-1051"
+          "checksum": "sha1-KmG1L67f+/TnVGcnIcLfWRF/K2g=",
+          "range": "bytes=702-1051"
         },
         "data": {
-          "checksum": "sha256-rO0P9z2V49BSrz1A5Ap69tEappVrg5MMBjzW00rOpZc=",
-          "range": "bytes=1052-122464"
+          "checksum": "sha256-2YIxYc/Quit+Kri2qS8p6XvL7taAmOYJU/1Z8RNQ+88=",
+          "range": "bytes=1052-122509"
         },
         "name": "wolfi-baselayout",
         "signature": {
-          "checksum": "sha1-Ntb6VuMzDfM+frpCjKEIpDzl53I=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-VVyPrknEtqCPym5lfhVEuIhfkKg=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r12.apk",
-        "version": "20230201-r12"
+        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r13.apk",
+        "version": "20230201-r13"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q17rD4cKGW3uVSJw02PFiYR719t/Y=",
+        "checksum": "Q1ASyaCJL2Zyz4uAKpPPlx1Sd40yo=",
         "control": {
-          "checksum": "sha1-7rD4cKGW3uVSJw02PFiYR719t/Y=",
-          "range": "bytes=697-1108"
+          "checksum": "sha1-ASyaCJL2Zyz4uAKpPPlx1Sd40yo=",
+          "range": "bytes=706-1101"
         },
         "data": {
-          "checksum": "sha256-GvSViXbvUD0BdV2A+IzVJni2DjLvyM+j14hM29DcsYg=",
-          "range": "bytes=1109-268391"
+          "checksum": "sha256-KoaUrlV3QZ4ATGvKgOmZ1C8Rb/tHK3zEiCTGDrxxc/I=",
+          "range": "bytes=1102-272818"
         },
         "name": "ld-linux",
         "signature": {
-          "checksum": "sha1-nRIFect8o/LOUIEvN17AsrI07dg=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-DBrLE0fWPMyB5/0kAtNlIK6viCU=",
+          "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1/A0wNjkLqqBhe0jFr2D9SKcDNq8=",
+        "checksum": "Q10iHLABsXtuH2JyExQ2IIxH1NUCI=",
         "control": {
-          "checksum": "sha1-/A0wNjkLqqBhe0jFr2D9SKcDNq8=",
-          "range": "bytes=696-1054"
+          "checksum": "sha1-0iHLABsXtuH2JyExQ2IIxH1NUCI=",
+          "range": "bytes=698-1041"
         },
         "data": {
-          "checksum": "sha256-GT22MF6hR+Tj4el5xk2QEwNWig5JRoOrZ60Lecz+lok=",
-          "range": "bytes=1055-408851"
+          "checksum": "sha256-A3RF8XLSIePkapCnvEridXa2N7nheKNT1kTKDqZlGdI=",
+          "range": "bytes=1042-408849"
         },
         "name": "glibc-locale-posix",
         "signature": {
-          "checksum": "sha1-9uPIvcOCeZbPiR7+MLDB4tkJlHo=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-QqrJFnJmyPeT66hUk3O7NxaWY8I=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1YLxq+Z9/+aFnCwvgV7acVLT4QFA=",
+        "checksum": "Q1JYf1zI1zVi/S9sMI32guk6ptuRQ=",
         "control": {
-          "checksum": "sha1-YLxq+Z9/+aFnCwvgV7acVLT4QFA=",
-          "range": "bytes=701-1330"
+          "checksum": "sha1-JYf1zI1zVi/S9sMI32guk6ptuRQ=",
+          "range": "bytes=701-1308"
         },
         "data": {
-          "checksum": "sha256-9s5RNfAJ3GVt7a/fFUaew5MfYYUkvL/6FMvsEfD95jY=",
-          "range": "bytes=1331-5862057"
+          "checksum": "sha256-ioC8korS2nJpJvoS6He+mKkDsgVLcMxiEuYLsAB9M7U=",
+          "range": "bytes=1309-5959239"
         },
         "name": "glibc",
         "signature": {
-          "checksum": "sha1-Kvfb+I/1PCfiBTjoaU4ezZa0b+8=",
+          "checksum": "sha1-3TP2+cHjCEBrIFluCdTmr2oJA1s=",
           "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Zi0e8Bq6WCd/6uXXjVhb8YwMD1U=",
+        "checksum": "Q1WAlPh7UNBV+RHfBixVB5P9F9Mp8=",
         "control": {
-          "checksum": "sha1-Zi0e8Bq6WCd/6uXXjVhb8YwMD1U=",
-          "range": "bytes=700-1073"
+          "checksum": "sha1-WAlPh7UNBV+RHfBixVB5P9F9Mp8=",
+          "range": "bytes=700-1074"
         },
         "data": {
-          "checksum": "sha256-jMhtfqVjnhuuBO7wtNZ6RS/72sZWoKt/Moage2amlks=",
-          "range": "bytes=1074-81594"
+          "checksum": "sha256-i6uEFvUEbJ4YzgNSV58aObIdU608mjbCVPwyF57ZeQQ=",
+          "range": "bytes=1075-81593"
         },
         "name": "protobuf-c",
         "signature": {
-          "checksum": "sha1-kATwMKztK7nk7qbYCJPkCFp6IXc=",
+          "checksum": "sha1-47zwDXmhcWiVtTYCjq4sFld8wHQ=",
           "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r5.apk",
-        "version": "1.5.0-r5"
+        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r6.apk",
+        "version": "1.5.0-r6"
       },
       {
         "architecture": "x86_64",
@@ -204,41 +204,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Q/Zy5ovYSu2p/vVLr6DgVA1e8AQ=",
+        "checksum": "Q1a5wJzZI7k9o4F8hHFpfuqAUIH5Q=",
         "control": {
-          "checksum": "sha1-Q/Zy5ovYSu2p/vVLr6DgVA1e8AQ=",
-          "range": "bytes=699-1062"
+          "checksum": "sha1-a5wJzZI7k9o4F8hHFpfuqAUIH5Q=",
+          "range": "bytes=710-1075"
         },
         "data": {
-          "checksum": "sha256-H3jxsw8ytOeCIR4vq17voSVhdNokXk8C1g075txH6Bs=",
-          "range": "bytes=1063-5903754"
+          "checksum": "sha256-2p1UC4F4Odfxup/J/nyzujYRGaxGVjBOBWoc0aajClI=",
+          "range": "bytes=1076-5903889"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-NIl2f5OI/wSZByI8Ds1ZUfbFWyw=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-SOFoklqXtH38i1PcI3G/cPdRFtY=",
+          "range": "bytes=0-709"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.1-r3.apk",
-        "version": "3.3.1-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.1-r4.apk",
+        "version": "3.3.1-r4"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q13wGUXdZut9OOTdY5z2amUj9wXC0=",
+        "checksum": "Q1gb2VyLOsGV7xUiHBT0Ypt64rw6Y=",
         "control": {
-          "checksum": "sha1-3wGUXdZut9OOTdY5z2amUj9wXC0=",
-          "range": "bytes=698-1068"
+          "checksum": "sha1-gb2VyLOsGV7xUiHBT0Ypt64rw6Y=",
+          "range": "bytes=702-1071"
         },
         "data": {
-          "checksum": "sha256-mRda6+YGlOCczyIWKaHqXskTINoT1rgorHDHqAKAb7c=",
-          "range": "bytes=1069-1188955"
+          "checksum": "sha256-h2tz/aFB2n8SFdBFde5foQm1ru+8JUcGp+trUeA2ZlQ=",
+          "range": "bytes=1072-1188954"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-+UdRc4U3PKw4H9OiNurHKXa5BYk=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-w6U2Pb1Y90u1iBFc/sHg2xn6Qmo=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.1-r3.apk",
-        "version": "3.3.1-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.1-r4.apk",
+        "version": "3.3.1-r4"
       },
       {
         "architecture": "x86_64",
@@ -356,60 +356,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1gfqHM/7r3rXX1HqC163slTPP46o=",
+        "checksum": "Q1DLAp18ebMscosnQ4TfTivIzgtCY=",
         "control": {
-          "checksum": "sha1-gfqHM/7r3rXX1HqC163slTPP46o=",
-          "range": "bytes=704-1101"
+          "checksum": "sha1-DLAp18ebMscosnQ4TfTivIzgtCY=",
+          "range": "bytes=698-1079"
         },
         "data": {
-          "checksum": "sha256-OR7ikvfUYp78EsP0I2kuwqqAcy05jw9tr7JVQ6jTnGQ=",
-          "range": "bytes=1102-185433"
+          "checksum": "sha256-eiBdqqECWnULWGe/Gnd6iv/7h56A4xR2qw+5toY5Gaw=",
+          "range": "bytes=1080-185559"
         },
         "name": "libgcc",
         "signature": {
-          "checksum": "sha1-Il4pyVzI6eqNd/f4bsKeakpB5DI=",
-          "range": "bytes=0-703"
+          "checksum": "sha1-qVj9laNeBIwRxP+8ehB+fXftJrw=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.2.0-r7.apk",
-        "version": "13.2.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r0.apk",
+        "version": "13.3.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1c+lykdx+yHoqsrQmQLHMV7waR1Q=",
+        "checksum": "Q1p9aaHhpB2Ud0URrcIrVRAujMw+o=",
         "control": {
-          "checksum": "sha1-c+lykdx+yHoqsrQmQLHMV7waR1Q=",
-          "range": "bytes=701-1119"
+          "checksum": "sha1-p9aaHhpB2Ud0URrcIrVRAujMw+o=",
+          "range": "bytes=696-1097"
         },
         "data": {
-          "checksum": "sha256-CuZi2C5g0vUnz4PNH8jIWV+EBdVMvHr+sNKFYTSnQZk=",
-          "range": "bytes=1120-3155369"
+          "checksum": "sha256-rGMnyLiGEDCEVgqA1oXMf28QHuWHAaPzYrLeDzQ3WOU=",
+          "range": "bytes=1098-3155519"
         },
         "name": "libstdc++",
         "signature": {
-          "checksum": "sha1-7l8MLj8aCcdqta/0sR+0PscBsD4=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-lge2XoAsgvp8U6ZBgT52N2xNQAw=",
+          "range": "bytes=0-695"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.2.0-r7.apk",
-        "version": "13.2.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r0.apk",
+        "version": "13.3.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1R8OxpY0fGwVaIwft4wJeswF5D54=",
+        "checksum": "Q1DUpLMidX5HbXUAFV8y3Imyt+Ank=",
         "control": {
-          "checksum": "sha1-R8OxpY0fGwVaIwft4wJeswF5D54=",
-          "range": "bytes=695-1059"
+          "checksum": "sha1-DUpLMidX5HbXUAFV8y3Imyt+Ank=",
+          "range": "bytes=698-1063"
         },
         "data": {
-          "checksum": "sha256-wNc8/SBJrGHfwywAtzCsAqeUOt0IaAhqNtlbv8OiHBE=",
-          "range": "bytes=1060-242151"
+          "checksum": "sha256-ZUDWWOBnxl5xi3b5HQCHaiYqKDSrnVpJQgavWpn1duc=",
+          "range": "bytes=1064-255810"
         },
         "name": "c-ares",
         "signature": {
-          "checksum": "sha1-55/PTlEHXI3o0hx9dSVdNwQeSMg=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-0AXk7b/B1baNADDg/NSocbW//pw=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.31.0-r0.apk",
-        "version": "1.31.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.32.1-r0.apk",
+        "version": "1.32.1-r0"
       },
       {
         "architecture": "x86_64",
@@ -470,22 +470,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q10AaU1ocIM4PYYNvwbml8TmpNvEA=",
+        "checksum": "Q1ORn/60iAvLcAgApXYoZzM6o0XSs=",
         "control": {
-          "checksum": "sha1-0AaU1ocIM4PYYNvwbml8TmpNvEA=",
-          "range": "bytes=706-1085"
+          "checksum": "sha1-ORn/60iAvLcAgApXYoZzM6o0XSs=",
+          "range": "bytes=703-1081"
         },
         "data": {
-          "checksum": "sha256-1YQNYASFjlP3kXX58ec8du75ij/U6O4DPAKzJAPkln0=",
-          "range": "bytes=1086-4272589"
+          "checksum": "sha256-Ya2Dn1VNYB21ZBD/jBCSx3SxZuJloJET5xkjX0s3Vt8=",
+          "range": "bytes=1082-4272708"
         },
         "name": "libxml2",
         "signature": {
-          "checksum": "sha1-QFjdplzGn/MiNFxMykgafr6/w6U=",
-          "range": "bytes=0-705"
+          "checksum": "sha1-s5jaTwJdla4k4KK0KEk7AYbgdqs=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.1-r1.apk",
-        "version": "2.13.1-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.2-r0.apk",
+        "version": "2.13.2-r0"
       },
       {
         "architecture": "x86_64",
@@ -546,22 +546,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1+0xClEzF5nhyNPUeGFhC++ElQmg=",
+        "checksum": "Q1u+fF2xg98dT0poYklte5HHMg/Kk=",
         "control": {
-          "checksum": "sha1-+0xClEzF5nhyNPUeGFhC++ElQmg=",
-          "range": "bytes=701-1107"
+          "checksum": "sha1-u+fF2xg98dT0poYklte5HHMg/Kk=",
+          "range": "bytes=701-1090"
         },
         "data": {
-          "checksum": "sha256-81V5R7T08up/3BwfuAG25Rq7KkB1MvALVCaogCpW500=",
-          "range": "bytes=1108-22181"
+          "checksum": "sha256-9e+i7LwSg7oAUU33f0r7A4Mc2suaK95iNU5BKaTSXac=",
+          "range": "bytes=1091-22179"
         },
         "name": "libcrypt1",
         "signature": {
-          "checksum": "sha1-k+7JfhPi5KOQ+6Nqk3oAfTbtOVM=",
+          "checksum": "sha1-EWBUcJqCJTOYJq1H0/kkO+m6W3E=",
           "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/server.lock.json
+++ b/wolfi-images/server.lock.json
@@ -18,136 +18,136 @@
     "packages": [
       {
         "architecture": "x86_64",
-        "checksum": "Q1ibJSAAe0yAmeC3Sp9K+672q3eKg=",
+        "checksum": "Q15bwVoaq1Noe1m3R1UrRBlJGLGSM=",
         "control": {
-          "checksum": "sha1-ibJSAAe0yAmeC3Sp9K+672q3eKg=",
-          "range": "bytes=704-1060"
+          "checksum": "sha1-5bwVoaq1Noe1m3R1UrRBlJGLGSM=",
+          "range": "bytes=702-1043"
         },
         "data": {
-          "checksum": "sha256-Qdx821f7/tO71EyPPGGyuTZlK4If05eUDqMkGTNYzdw=",
-          "range": "bytes=1061-603623"
+          "checksum": "sha256-RUfH3pZt5PBG2RCxX2qGzc0JK+BWQ3BfabP8B3Zjkyo=",
+          "range": "bytes=1044-605796"
         },
         "name": "ncurses-terminfo-base",
         "signature": {
-          "checksum": "sha1-hFLJnjW3MeXzjutUUaMVz+pq774=",
-          "range": "bytes=0-703"
+          "checksum": "sha1-qOe+XIaqWDBfRGrODGmvZj+PGs8=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ncurses-terminfo-base-6.4_p20231125-r3.apk",
-        "version": "6.4_p20231125-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/ncurses-terminfo-base-6.5_p20240629-r0.apk",
+        "version": "6.5_p20240629-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Ai8jWuxKZR2M2XhOpOGAoTEwnnk=",
+        "checksum": "Q1WR9MGKU+cJh6dJFEXnr3zU1qsMM=",
         "control": {
-          "checksum": "sha1-Ai8jWuxKZR2M2XhOpOGAoTEwnnk=",
-          "range": "bytes=705-1037"
+          "checksum": "sha1-WR9MGKU+cJh6dJFEXnr3zU1qsMM=",
+          "range": "bytes=705-1034"
         },
         "data": {
-          "checksum": "sha256-e4UardkBVyaC49aSyrVmXNi8sSKqQl4eKYd0LxGRLA0=",
-          "range": "bytes=1038-255695"
+          "checksum": "sha256-EkOhtSivoLErXsK2J9ri39thkwb2kJGYHVou4n6dMKA=",
+          "range": "bytes=1035-254654"
         },
         "name": "ca-certificates-bundle",
         "signature": {
-          "checksum": "sha1-loRuyYQLm+atp+YteiQoj++EWIM=",
+          "checksum": "sha1-WL9vKv1nPIeaUQI4O0DiY9RdSHE=",
           "range": "bytes=0-704"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20240315-r4.apk",
-        "version": "20240315-r4"
+        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20240705-r0.apk",
+        "version": "20240705-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1+GH6qRN4iy1IDt0cT0x0tin7YfI=",
+        "checksum": "Q1KmG1L67f+/TnVGcnIcLfWRF/K2g=",
         "control": {
-          "checksum": "sha1-+GH6qRN4iy1IDt0cT0x0tin7YfI=",
-          "range": "bytes=703-1051"
+          "checksum": "sha1-KmG1L67f+/TnVGcnIcLfWRF/K2g=",
+          "range": "bytes=702-1051"
         },
         "data": {
-          "checksum": "sha256-rO0P9z2V49BSrz1A5Ap69tEappVrg5MMBjzW00rOpZc=",
-          "range": "bytes=1052-122464"
+          "checksum": "sha256-2YIxYc/Quit+Kri2qS8p6XvL7taAmOYJU/1Z8RNQ+88=",
+          "range": "bytes=1052-122509"
         },
         "name": "wolfi-baselayout",
         "signature": {
-          "checksum": "sha1-Ntb6VuMzDfM+frpCjKEIpDzl53I=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-VVyPrknEtqCPym5lfhVEuIhfkKg=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r12.apk",
-        "version": "20230201-r12"
+        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r13.apk",
+        "version": "20230201-r13"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q17rD4cKGW3uVSJw02PFiYR719t/Y=",
+        "checksum": "Q1ASyaCJL2Zyz4uAKpPPlx1Sd40yo=",
         "control": {
-          "checksum": "sha1-7rD4cKGW3uVSJw02PFiYR719t/Y=",
-          "range": "bytes=697-1108"
+          "checksum": "sha1-ASyaCJL2Zyz4uAKpPPlx1Sd40yo=",
+          "range": "bytes=706-1101"
         },
         "data": {
-          "checksum": "sha256-GvSViXbvUD0BdV2A+IzVJni2DjLvyM+j14hM29DcsYg=",
-          "range": "bytes=1109-268391"
+          "checksum": "sha256-KoaUrlV3QZ4ATGvKgOmZ1C8Rb/tHK3zEiCTGDrxxc/I=",
+          "range": "bytes=1102-272818"
         },
         "name": "ld-linux",
         "signature": {
-          "checksum": "sha1-nRIFect8o/LOUIEvN17AsrI07dg=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-DBrLE0fWPMyB5/0kAtNlIK6viCU=",
+          "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1/A0wNjkLqqBhe0jFr2D9SKcDNq8=",
+        "checksum": "Q10iHLABsXtuH2JyExQ2IIxH1NUCI=",
         "control": {
-          "checksum": "sha1-/A0wNjkLqqBhe0jFr2D9SKcDNq8=",
-          "range": "bytes=696-1054"
+          "checksum": "sha1-0iHLABsXtuH2JyExQ2IIxH1NUCI=",
+          "range": "bytes=698-1041"
         },
         "data": {
-          "checksum": "sha256-GT22MF6hR+Tj4el5xk2QEwNWig5JRoOrZ60Lecz+lok=",
-          "range": "bytes=1055-408851"
+          "checksum": "sha256-A3RF8XLSIePkapCnvEridXa2N7nheKNT1kTKDqZlGdI=",
+          "range": "bytes=1042-408849"
         },
         "name": "glibc-locale-posix",
         "signature": {
-          "checksum": "sha1-9uPIvcOCeZbPiR7+MLDB4tkJlHo=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-QqrJFnJmyPeT66hUk3O7NxaWY8I=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1YLxq+Z9/+aFnCwvgV7acVLT4QFA=",
+        "checksum": "Q1JYf1zI1zVi/S9sMI32guk6ptuRQ=",
         "control": {
-          "checksum": "sha1-YLxq+Z9/+aFnCwvgV7acVLT4QFA=",
-          "range": "bytes=701-1330"
+          "checksum": "sha1-JYf1zI1zVi/S9sMI32guk6ptuRQ=",
+          "range": "bytes=701-1308"
         },
         "data": {
-          "checksum": "sha256-9s5RNfAJ3GVt7a/fFUaew5MfYYUkvL/6FMvsEfD95jY=",
-          "range": "bytes=1331-5862057"
+          "checksum": "sha256-ioC8korS2nJpJvoS6He+mKkDsgVLcMxiEuYLsAB9M7U=",
+          "range": "bytes=1309-5959239"
         },
         "name": "glibc",
         "signature": {
-          "checksum": "sha1-Kvfb+I/1PCfiBTjoaU4ezZa0b+8=",
+          "checksum": "sha1-3TP2+cHjCEBrIFluCdTmr2oJA1s=",
           "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ggdVedzys8c0/DPbL/8uVM0IeHM=",
+        "checksum": "Q1UbEaadDhtuSAInuPjntJMZefM4U=",
         "control": {
-          "checksum": "sha1-ggdVedzys8c0/DPbL/8uVM0IeHM=",
-          "range": "bytes=697-1165"
+          "checksum": "sha1-UbEaadDhtuSAInuPjntJMZefM4U=",
+          "range": "bytes=698-1152"
         },
         "data": {
-          "checksum": "sha256-7NLgBuaKCCXSTXXEZ48mE9pTOgyoOY6yHLR2cW0LdGM=",
-          "range": "bytes=1166-1048223"
+          "checksum": "sha256-gkm/MRL/YRxHkRROZEW/TSWGC7r+ZAqogwd0Umio3LU=",
+          "range": "bytes=1153-1065345"
         },
         "name": "ncurses",
         "signature": {
-          "checksum": "sha1-50wXsiR3GgiiLwsWICdXEagYHRE=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-NLFv0xzWR8uGe+4SFVz9mAZDn/k=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ncurses-6.4_p20231125-r3.apk",
-        "version": "6.4_p20231125-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/ncurses-6.5_p20240629-r0.apk",
+        "version": "6.5_p20240629-r0"
       },
       {
         "architecture": "x86_64",
@@ -170,22 +170,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Zi0e8Bq6WCd/6uXXjVhb8YwMD1U=",
+        "checksum": "Q1WAlPh7UNBV+RHfBixVB5P9F9Mp8=",
         "control": {
-          "checksum": "sha1-Zi0e8Bq6WCd/6uXXjVhb8YwMD1U=",
-          "range": "bytes=700-1073"
+          "checksum": "sha1-WAlPh7UNBV+RHfBixVB5P9F9Mp8=",
+          "range": "bytes=700-1074"
         },
         "data": {
-          "checksum": "sha256-jMhtfqVjnhuuBO7wtNZ6RS/72sZWoKt/Moage2amlks=",
-          "range": "bytes=1074-81594"
+          "checksum": "sha256-i6uEFvUEbJ4YzgNSV58aObIdU608mjbCVPwyF57ZeQQ=",
+          "range": "bytes=1075-81593"
         },
         "name": "protobuf-c",
         "signature": {
-          "checksum": "sha1-kATwMKztK7nk7qbYCJPkCFp6IXc=",
+          "checksum": "sha1-47zwDXmhcWiVtTYCjq4sFld8wHQ=",
           "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r5.apk",
-        "version": "1.5.0-r5"
+        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r6.apk",
+        "version": "1.5.0-r6"
       },
       {
         "architecture": "x86_64",
@@ -265,41 +265,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Q/Zy5ovYSu2p/vVLr6DgVA1e8AQ=",
+        "checksum": "Q1a5wJzZI7k9o4F8hHFpfuqAUIH5Q=",
         "control": {
-          "checksum": "sha1-Q/Zy5ovYSu2p/vVLr6DgVA1e8AQ=",
-          "range": "bytes=699-1062"
+          "checksum": "sha1-a5wJzZI7k9o4F8hHFpfuqAUIH5Q=",
+          "range": "bytes=710-1075"
         },
         "data": {
-          "checksum": "sha256-H3jxsw8ytOeCIR4vq17voSVhdNokXk8C1g075txH6Bs=",
-          "range": "bytes=1063-5903754"
+          "checksum": "sha256-2p1UC4F4Odfxup/J/nyzujYRGaxGVjBOBWoc0aajClI=",
+          "range": "bytes=1076-5903889"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-NIl2f5OI/wSZByI8Ds1ZUfbFWyw=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-SOFoklqXtH38i1PcI3G/cPdRFtY=",
+          "range": "bytes=0-709"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.1-r3.apk",
-        "version": "3.3.1-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.1-r4.apk",
+        "version": "3.3.1-r4"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q13wGUXdZut9OOTdY5z2amUj9wXC0=",
+        "checksum": "Q1gb2VyLOsGV7xUiHBT0Ypt64rw6Y=",
         "control": {
-          "checksum": "sha1-3wGUXdZut9OOTdY5z2amUj9wXC0=",
-          "range": "bytes=698-1068"
+          "checksum": "sha1-gb2VyLOsGV7xUiHBT0Ypt64rw6Y=",
+          "range": "bytes=702-1071"
         },
         "data": {
-          "checksum": "sha256-mRda6+YGlOCczyIWKaHqXskTINoT1rgorHDHqAKAb7c=",
-          "range": "bytes=1069-1188955"
+          "checksum": "sha256-h2tz/aFB2n8SFdBFde5foQm1ru+8JUcGp+trUeA2ZlQ=",
+          "range": "bytes=1072-1188954"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-+UdRc4U3PKw4H9OiNurHKXa5BYk=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-w6U2Pb1Y90u1iBFc/sHg2xn6Qmo=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.1-r3.apk",
-        "version": "3.3.1-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.1-r4.apk",
+        "version": "3.3.1-r4"
       },
       {
         "architecture": "x86_64",
@@ -417,60 +417,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1gfqHM/7r3rXX1HqC163slTPP46o=",
+        "checksum": "Q1DLAp18ebMscosnQ4TfTivIzgtCY=",
         "control": {
-          "checksum": "sha1-gfqHM/7r3rXX1HqC163slTPP46o=",
-          "range": "bytes=704-1101"
+          "checksum": "sha1-DLAp18ebMscosnQ4TfTivIzgtCY=",
+          "range": "bytes=698-1079"
         },
         "data": {
-          "checksum": "sha256-OR7ikvfUYp78EsP0I2kuwqqAcy05jw9tr7JVQ6jTnGQ=",
-          "range": "bytes=1102-185433"
+          "checksum": "sha256-eiBdqqECWnULWGe/Gnd6iv/7h56A4xR2qw+5toY5Gaw=",
+          "range": "bytes=1080-185559"
         },
         "name": "libgcc",
         "signature": {
-          "checksum": "sha1-Il4pyVzI6eqNd/f4bsKeakpB5DI=",
-          "range": "bytes=0-703"
+          "checksum": "sha1-qVj9laNeBIwRxP+8ehB+fXftJrw=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.2.0-r7.apk",
-        "version": "13.2.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r0.apk",
+        "version": "13.3.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1c+lykdx+yHoqsrQmQLHMV7waR1Q=",
+        "checksum": "Q1p9aaHhpB2Ud0URrcIrVRAujMw+o=",
         "control": {
-          "checksum": "sha1-c+lykdx+yHoqsrQmQLHMV7waR1Q=",
-          "range": "bytes=701-1119"
+          "checksum": "sha1-p9aaHhpB2Ud0URrcIrVRAujMw+o=",
+          "range": "bytes=696-1097"
         },
         "data": {
-          "checksum": "sha256-CuZi2C5g0vUnz4PNH8jIWV+EBdVMvHr+sNKFYTSnQZk=",
-          "range": "bytes=1120-3155369"
+          "checksum": "sha256-rGMnyLiGEDCEVgqA1oXMf28QHuWHAaPzYrLeDzQ3WOU=",
+          "range": "bytes=1098-3155519"
         },
         "name": "libstdc++",
         "signature": {
-          "checksum": "sha1-7l8MLj8aCcdqta/0sR+0PscBsD4=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-lge2XoAsgvp8U6ZBgT52N2xNQAw=",
+          "range": "bytes=0-695"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.2.0-r7.apk",
-        "version": "13.2.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r0.apk",
+        "version": "13.3.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1R8OxpY0fGwVaIwft4wJeswF5D54=",
+        "checksum": "Q1DUpLMidX5HbXUAFV8y3Imyt+Ank=",
         "control": {
-          "checksum": "sha1-R8OxpY0fGwVaIwft4wJeswF5D54=",
-          "range": "bytes=695-1059"
+          "checksum": "sha1-DUpLMidX5HbXUAFV8y3Imyt+Ank=",
+          "range": "bytes=698-1063"
         },
         "data": {
-          "checksum": "sha256-wNc8/SBJrGHfwywAtzCsAqeUOt0IaAhqNtlbv8OiHBE=",
-          "range": "bytes=1060-242151"
+          "checksum": "sha256-ZUDWWOBnxl5xi3b5HQCHaiYqKDSrnVpJQgavWpn1duc=",
+          "range": "bytes=1064-255810"
         },
         "name": "c-ares",
         "signature": {
-          "checksum": "sha1-55/PTlEHXI3o0hx9dSVdNwQeSMg=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-0AXk7b/B1baNADDg/NSocbW//pw=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.31.0-r0.apk",
-        "version": "1.31.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.32.1-r0.apk",
+        "version": "1.32.1-r0"
       },
       {
         "architecture": "x86_64",
@@ -531,22 +531,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q10AaU1ocIM4PYYNvwbml8TmpNvEA=",
+        "checksum": "Q1ORn/60iAvLcAgApXYoZzM6o0XSs=",
         "control": {
-          "checksum": "sha1-0AaU1ocIM4PYYNvwbml8TmpNvEA=",
-          "range": "bytes=706-1085"
+          "checksum": "sha1-ORn/60iAvLcAgApXYoZzM6o0XSs=",
+          "range": "bytes=703-1081"
         },
         "data": {
-          "checksum": "sha256-1YQNYASFjlP3kXX58ec8du75ij/U6O4DPAKzJAPkln0=",
-          "range": "bytes=1086-4272589"
+          "checksum": "sha256-Ya2Dn1VNYB21ZBD/jBCSx3SxZuJloJET5xkjX0s3Vt8=",
+          "range": "bytes=1082-4272708"
         },
         "name": "libxml2",
         "signature": {
-          "checksum": "sha1-QFjdplzGn/MiNFxMykgafr6/w6U=",
-          "range": "bytes=0-705"
+          "checksum": "sha1-s5jaTwJdla4k4KK0KEk7AYbgdqs=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.1-r1.apk",
-        "version": "2.13.1-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.2-r0.apk",
+        "version": "2.13.2-r0"
       },
       {
         "architecture": "x86_64",
@@ -607,22 +607,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1+0xClEzF5nhyNPUeGFhC++ElQmg=",
+        "checksum": "Q1u+fF2xg98dT0poYklte5HHMg/Kk=",
         "control": {
-          "checksum": "sha1-+0xClEzF5nhyNPUeGFhC++ElQmg=",
-          "range": "bytes=701-1107"
+          "checksum": "sha1-u+fF2xg98dT0poYklte5HHMg/Kk=",
+          "range": "bytes=701-1090"
         },
         "data": {
-          "checksum": "sha256-81V5R7T08up/3BwfuAG25Rq7KkB1MvALVCaogCpW500=",
-          "range": "bytes=1108-22181"
+          "checksum": "sha256-9e+i7LwSg7oAUU33f0r7A4Mc2suaK95iNU5BKaTSXac=",
+          "range": "bytes=1091-22179"
         },
         "name": "libcrypt1",
         "signature": {
-          "checksum": "sha1-k+7JfhPi5KOQ+6Nqk3oAfTbtOVM=",
+          "checksum": "sha1-EWBUcJqCJTOYJq1H0/kkO+m6W3E=",
           "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",
@@ -645,22 +645,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1fnaWc3899x9dK4z4iTFNOeM6MI0=",
+        "checksum": "Q1yStY7gve/r3+nnaV+ul/l4zmwpU=",
         "control": {
-          "checksum": "sha1-fnaWc3899x9dK4z4iTFNOeM6MI0=",
-          "range": "bytes=702-1132"
+          "checksum": "sha1-yStY7gve/r3+nnaV+ul/l4zmwpU=",
+          "range": "bytes=699-1128"
         },
         "data": {
-          "checksum": "sha256-rhtsl8eIgOKIHSa3VsedIEj1sA3xRi83jc3fhTjIQLw=",
-          "range": "bytes=1133-377535"
+          "checksum": "sha256-1d/7CyMhSR2oDbLJtN12D1pYniEuQIptX78kAs2ZI14=",
+          "range": "bytes=1129-376508"
         },
         "name": "ca-certificates",
         "signature": {
-          "checksum": "sha1-I1wWFlIzyXu0g5mcgMo/iyW3Mhw=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-EIHhUeKgg6x/sc6JooVgTCBIgOg=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-20240315-r4.apk",
-        "version": "20240315-r4"
+        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-20240705-r0.apk",
+        "version": "20240705-r0"
       },
       {
         "architecture": "x86_64",
@@ -968,22 +968,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1KXXN9Hu7PZ0iPK7gAnYRUDcDzZs=",
+        "checksum": "Q1VJwVzi86yWcTj5PHY01vdoetpZQ=",
         "control": {
-          "checksum": "sha1-KXXN9Hu7PZ0iPK7gAnYRUDcDzZs=",
-          "range": "bytes=700-1063"
+          "checksum": "sha1-VJwVzi86yWcTj5PHY01vdoetpZQ=",
+          "range": "bytes=710-1058"
         },
         "data": {
-          "checksum": "sha256-F61XBj+QV78wXrinzeVQestiQeJtCAVPWwbLWf8c98Y=",
-          "range": "bytes=1064-12733161"
+          "checksum": "sha256-kBMNCuqgebDS1M9EjrUO3wqJ2laPKu/oE0YI/4szp4M=",
+          "range": "bytes=1059-12733185"
         },
         "name": "git-lfs",
         "signature": {
-          "checksum": "sha1-U6NrIIwbHHzX/fgtB3PoNVQZOJU=",
-          "range": "bytes=0-699"
+          "checksum": "sha1-RgfxUCV6GAC4fDsAvBAZ6AWoGFM=",
+          "range": "bytes=0-709"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/git-lfs-3.5.1-r6.apk",
-        "version": "3.5.1-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/git-lfs-3.5.1-r7.apk",
+        "version": "3.5.1-r7"
       },
       {
         "architecture": "x86_64",
@@ -1025,22 +1025,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1z4pvqJVOguss+9HLVO7PzJUlt8w=",
+        "checksum": "Q1dmeR0/KVMZ3ZLmYVZZpeOM5D0YA=",
         "control": {
-          "checksum": "sha1-z4pvqJVOguss+9HLVO7PzJUlt8w=",
-          "range": "bytes=702-1032"
+          "checksum": "sha1-dmeR0/KVMZ3ZLmYVZZpeOM5D0YA=",
+          "range": "bytes=698-1038"
         },
         "data": {
-          "checksum": "sha256-AY5hTobJ3oQxODeewjKtWT/O0I3WSJJfbdnebiFHi9A=",
-          "range": "bytes=1033-61050535"
+          "checksum": "sha256-h229QLrsW/27BQzxyKGOvkrvJPnwhRPjtIV3aVoLq0U=",
+          "range": "bytes=1039-61050533"
         },
         "name": "glibc-locale-en",
         "signature": {
-          "checksum": "sha1-EnGHd74XHlmb/a2fq+hVub5BQN4=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-p2ZxY4sG1cAKJ7uPvhMKBxKw+k4=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-en-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-en-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",
@@ -1253,41 +1253,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q159N4eiyaOIItDmaNcUwCEzopOQ0=",
+        "checksum": "Q1Xe6Mab0L6pI1cl1KoyHFFh22EnM=",
         "control": {
-          "checksum": "sha1-59N4eiyaOIItDmaNcUwCEzopOQ0=",
-          "range": "bytes=697-1137"
+          "checksum": "sha1-Xe6Mab0L6pI1cl1KoyHFFh22EnM=",
+          "range": "bytes=699-1127"
         },
         "data": {
-          "checksum": "sha256-YAYeT4S1TlekdgUVFi3Bqt8NUj3sBV1IIKCFkSzDQEM=",
-          "range": "bytes=1138-2550161"
+          "checksum": "sha256-xDHa35D2QjyjAX61JkPzSjbxYP8j+jVdZUolSCqc4Hw=",
+          "range": "bytes=1128-2571512"
         },
         "name": "p11-kit",
         "signature": {
-          "checksum": "sha1-u73VVE8Z2YCPfvy/7dGl9L5WE58=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-xeLkdL2Y2geUmjgmxvBrzYQPJ+A=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/p11-kit-0.25.3-r3.apk",
-        "version": "0.25.3-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/p11-kit-0.25.5-r0.apk",
+        "version": "0.25.5-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1u0Mde9gv6i/Mh7HcW3LtIyfIz2g=",
+        "checksum": "Q1Z6A8qRFoM2Og4D2fJ4qE2pugYo8=",
         "control": {
-          "checksum": "sha1-u0Mde9gv6i/Mh7HcW3LtIyfIz2g=",
-          "range": "bytes=705-1125"
+          "checksum": "sha1-Z6A8qRFoM2Og4D2fJ4qE2pugYo8=",
+          "range": "bytes=704-1108"
         },
         "data": {
-          "checksum": "sha256-cH7wwh2J0IPekB/ODuWjSHpU3pyarrG/XhTdTd3GZ2U=",
-          "range": "bytes=1126-575277"
+          "checksum": "sha256-JYA0kZGsjcz+sYUzzEM2mwcb1T3v/HJNfWMcVMCJE2k=",
+          "range": "bytes=1109-575276"
         },
         "name": "p11-kit-trust",
         "signature": {
-          "checksum": "sha1-BkatHr3xbv9kp95kv5bigMa8HrA=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-R4wCRm0VpFbrL0LTd4MQDOUQy7c=",
+          "range": "bytes=0-703"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/p11-kit-trust-0.25.3-r3.apk",
-        "version": "0.25.3-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/p11-kit-trust-0.25.5-r0.apk",
+        "version": "0.25.5-r0"
       },
       {
         "architecture": "x86_64",
@@ -1462,22 +1462,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q13tqxuiWMSp7zTXeDFyDNiIuwasI=",
+        "checksum": "Q10yqVNi88v61b9c2xWRzAF6OoxeM=",
         "control": {
-          "checksum": "sha1-3tqxuiWMSp7zTXeDFyDNiIuwasI=",
-          "range": "bytes=698-1167"
+          "checksum": "sha1-0yqVNi88v61b9c2xWRzAF6OoxeM=",
+          "range": "bytes=699-1153"
         },
         "data": {
-          "checksum": "sha256-TlLDfGn1XfcyAiZNOMHsOowLojJDFuauAce+WX9vEqA=",
-          "range": "bytes=1168-374527"
+          "checksum": "sha256-FuIB0FDd12TzYrIIHppD7p0xLNxtYmzWy7JILhdl014=",
+          "range": "bytes=1154-380130"
         },
         "name": "posix-libc-utils",
         "signature": {
-          "checksum": "sha1-MWRG5AeczFgrA81A+fuBipNYroc=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-x/BW5hmnekS+QwbYanJLRVu5/TU=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/posix-libc-utils-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/posix-libc-utils-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",
@@ -1538,22 +1538,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1pFBna33iXNWoxlANBI0dibfvT94=",
+        "checksum": "Q1a6BZwHKJFZb3kLvCVJI8xP+VrT0=",
         "control": {
-          "checksum": "sha1-pFBna33iXNWoxlANBI0dibfvT94=",
-          "range": "bytes=706-1129"
+          "checksum": "sha1-a6BZwHKJFZb3kLvCVJI8xP+VrT0=",
+          "range": "bytes=704-1169"
         },
         "data": {
-          "checksum": "sha256-jsPjzi/shXYlr0zayGvJ82SSPVs4ew/DIy3L1hiuqdE=",
-          "range": "bytes=1130-66950"
+          "checksum": "sha256-FUKvi4Kg95WQig8Pig9G03JlHr70P4eGn/NNVkKZpSM=",
+          "range": "bytes=1170-71535"
         },
         "name": "libuuid",
         "signature": {
-          "checksum": "sha1-nVANm2v8k7qILW+g+xjNgr7yqQY=",
-          "range": "bytes=0-705"
+          "checksum": "sha1-Z4+F/Rm3twEs19SMey98+aXHXwo=",
+          "range": "bytes=0-703"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libuuid-2.40.1-r1.apk",
-        "version": "2.40.1-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libuuid-2.40.2-r0.apk",
+        "version": "2.40.2-r0"
       },
       {
         "architecture": "x86_64",
@@ -1576,60 +1576,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1K7zkV+ytg2NfGl9Sq0L07g7m3t8=",
+        "checksum": "Q1b6lPwgirLFi4Au4nZA9U9ZbCW5U=",
         "control": {
-          "checksum": "sha1-K7zkV+ytg2NfGl9Sq0L07g7m3t8=",
-          "range": "bytes=703-1134"
+          "checksum": "sha1-b6lPwgirLFi4Au4nZA9U9ZbCW5U=",
+          "range": "bytes=692-1123"
         },
         "data": {
-          "checksum": "sha256-R8lBnMUORssXrz1Ph1NoBz+/StjHKbjVjNDDtSvb0Zs=",
-          "range": "bytes=1135-191882402"
+          "checksum": "sha256-wrUoVRHdcMxgoAyTZ/GAOn6i5DgC0aEwuTEPZDnqPi0=",
+          "range": "bytes=1124-191882678"
         },
         "name": "prometheus-2.53",
         "signature": {
-          "checksum": "sha1-LHetuVjR91DCOcHkyTC91kBA3vY=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-7VHQ9SJ4f6NLkX9mNbPzXbD90Vc=",
+          "range": "bytes=0-691"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/prometheus-2.53-2.53.0-r2.apk",
-        "version": "2.53.0-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/prometheus-2.53-2.53.0-r3.apk",
+        "version": "2.53.0-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1mKnd8VT1t/VpToT3N7SPrMi9G7M=",
+        "checksum": "Q1N9RV3bK23FszTjVJ375f9J8Mi+k=",
         "control": {
-          "checksum": "sha1-mKnd8VT1t/VpToT3N7SPrMi9G7M=",
-          "range": "bytes=704-1076"
+          "checksum": "sha1-N9RV3bK23FszTjVJ375f9J8Mi+k=",
+          "range": "bytes=700-1058"
         },
         "data": {
-          "checksum": "sha256-jQj6AJ1g/WJ9eLrczILo23fWFXkgfa9KdKtaFQoqSUc=",
-          "range": "bytes=1077-57321007"
+          "checksum": "sha256-xrebQam/kpgL9sbps9vNd8FouIgpe48ni6MdRWH666E=",
+          "range": "bytes=1059-57325397"
         },
         "name": "prometheus-alertmanager",
         "signature": {
-          "checksum": "sha1-ZOVjf8UJGM8EYWnakAYVMzPXaoE=",
-          "range": "bytes=0-703"
+          "checksum": "sha1-kJ1AacHBEFxPE6MpRVaNeyLNi4w=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/prometheus-alertmanager-0.27.0-r6.apk",
-        "version": "0.27.0-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/prometheus-alertmanager-0.27.0-r8.apk",
+        "version": "0.27.0-r8"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ZSA3uYHgOuEdsXqsjTZQOc7JGFM=",
+        "checksum": "Q1EoboUze7gNAngM1gmLzM1nPdaZQ=",
         "control": {
-          "checksum": "sha1-ZSA3uYHgOuEdsXqsjTZQOc7JGFM=",
-          "range": "bytes=697-1083"
+          "checksum": "sha1-EoboUze7gNAngM1gmLzM1nPdaZQ=",
+          "range": "bytes=702-1076"
         },
         "data": {
-          "checksum": "sha256-U6V84QUUZHttnP8E4tXIiGqLDrqo6l+b3pSK4J2U5oI=",
-          "range": "bytes=1084-13097660"
+          "checksum": "sha256-UgsCGyX15jOfLeHg74FRjndH8cYn03mDcRCkK73o3xA=",
+          "range": "bytes=1077-13097807"
         },
         "name": "prometheus-postgres-exporter",
         "signature": {
-          "checksum": "sha1-tYMJlKBEQpyVJBRdhmv1c/+AQfQ=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-sYyoMsyNe/5Ovl0/lVnAwIQbx0w=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/prometheus-postgres-exporter-0.15.0-r10.apk",
-        "version": "0.15.0-r10"
+        "url": "https://packages.wolfi.dev/os/x86_64/prometheus-postgres-exporter-0.15.0-r11.apk",
+        "version": "0.15.0-r11"
       },
       {
         "architecture": "x86_64",
@@ -1652,22 +1652,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q19lUpYPaVnv70kshfW0v/13XTNXc=",
+        "checksum": "Q1PHgnhvSy0SxqgLQc4V4dtaQ6sUo=",
         "control": {
-          "checksum": "sha1-9lUpYPaVnv70kshfW0v/13XTNXc=",
-          "range": "bytes=697-1146"
+          "checksum": "sha1-PHgnhvSy0SxqgLQc4V4dtaQ6sUo=",
+          "range": "bytes=699-1133"
         },
         "data": {
-          "checksum": "sha256-9Gn07toI1MChIgfXnxaTJQ6cH9BEG2bHmq2cYNSO9cU=",
-          "range": "bytes=1147-996427"
+          "checksum": "sha256-azs/Gn4jbpFwPIosLxAIQK9cuIRi/a4HWD9kOzi2whE=",
+          "range": "bytes=1134-1124576"
         },
         "name": "gdbm",
         "signature": {
-          "checksum": "sha1-iBmI2lW1dZcunxPMZXI29oayzBQ=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-62Pf1vhZGGdtLkZwFXpTAb7xiG0=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/gdbm-1.23-r6.apk",
-        "version": "1.23-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/gdbm-1.24-r0.apk",
+        "version": "1.24-r0"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/sourcegraph-base.lock.json
+++ b/wolfi-images/sourcegraph-base.lock.json
@@ -14,117 +14,117 @@
     "packages": [
       {
         "architecture": "x86_64",
-        "checksum": "Q1Ai8jWuxKZR2M2XhOpOGAoTEwnnk=",
+        "checksum": "Q1WR9MGKU+cJh6dJFEXnr3zU1qsMM=",
         "control": {
-          "checksum": "sha1-Ai8jWuxKZR2M2XhOpOGAoTEwnnk=",
-          "range": "bytes=705-1037"
+          "checksum": "sha1-WR9MGKU+cJh6dJFEXnr3zU1qsMM=",
+          "range": "bytes=705-1034"
         },
         "data": {
-          "checksum": "sha256-e4UardkBVyaC49aSyrVmXNi8sSKqQl4eKYd0LxGRLA0=",
-          "range": "bytes=1038-255695"
+          "checksum": "sha256-EkOhtSivoLErXsK2J9ri39thkwb2kJGYHVou4n6dMKA=",
+          "range": "bytes=1035-254654"
         },
         "name": "ca-certificates-bundle",
         "signature": {
-          "checksum": "sha1-loRuyYQLm+atp+YteiQoj++EWIM=",
+          "checksum": "sha1-WL9vKv1nPIeaUQI4O0DiY9RdSHE=",
           "range": "bytes=0-704"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20240315-r4.apk",
-        "version": "20240315-r4"
+        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20240705-r0.apk",
+        "version": "20240705-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1+GH6qRN4iy1IDt0cT0x0tin7YfI=",
+        "checksum": "Q1KmG1L67f+/TnVGcnIcLfWRF/K2g=",
         "control": {
-          "checksum": "sha1-+GH6qRN4iy1IDt0cT0x0tin7YfI=",
-          "range": "bytes=703-1051"
+          "checksum": "sha1-KmG1L67f+/TnVGcnIcLfWRF/K2g=",
+          "range": "bytes=702-1051"
         },
         "data": {
-          "checksum": "sha256-rO0P9z2V49BSrz1A5Ap69tEappVrg5MMBjzW00rOpZc=",
-          "range": "bytes=1052-122464"
+          "checksum": "sha256-2YIxYc/Quit+Kri2qS8p6XvL7taAmOYJU/1Z8RNQ+88=",
+          "range": "bytes=1052-122509"
         },
         "name": "wolfi-baselayout",
         "signature": {
-          "checksum": "sha1-Ntb6VuMzDfM+frpCjKEIpDzl53I=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-VVyPrknEtqCPym5lfhVEuIhfkKg=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r12.apk",
-        "version": "20230201-r12"
+        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r13.apk",
+        "version": "20230201-r13"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q17rD4cKGW3uVSJw02PFiYR719t/Y=",
+        "checksum": "Q1ASyaCJL2Zyz4uAKpPPlx1Sd40yo=",
         "control": {
-          "checksum": "sha1-7rD4cKGW3uVSJw02PFiYR719t/Y=",
-          "range": "bytes=697-1108"
+          "checksum": "sha1-ASyaCJL2Zyz4uAKpPPlx1Sd40yo=",
+          "range": "bytes=706-1101"
         },
         "data": {
-          "checksum": "sha256-GvSViXbvUD0BdV2A+IzVJni2DjLvyM+j14hM29DcsYg=",
-          "range": "bytes=1109-268391"
+          "checksum": "sha256-KoaUrlV3QZ4ATGvKgOmZ1C8Rb/tHK3zEiCTGDrxxc/I=",
+          "range": "bytes=1102-272818"
         },
         "name": "ld-linux",
         "signature": {
-          "checksum": "sha1-nRIFect8o/LOUIEvN17AsrI07dg=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-DBrLE0fWPMyB5/0kAtNlIK6viCU=",
+          "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1/A0wNjkLqqBhe0jFr2D9SKcDNq8=",
+        "checksum": "Q10iHLABsXtuH2JyExQ2IIxH1NUCI=",
         "control": {
-          "checksum": "sha1-/A0wNjkLqqBhe0jFr2D9SKcDNq8=",
-          "range": "bytes=696-1054"
+          "checksum": "sha1-0iHLABsXtuH2JyExQ2IIxH1NUCI=",
+          "range": "bytes=698-1041"
         },
         "data": {
-          "checksum": "sha256-GT22MF6hR+Tj4el5xk2QEwNWig5JRoOrZ60Lecz+lok=",
-          "range": "bytes=1055-408851"
+          "checksum": "sha256-A3RF8XLSIePkapCnvEridXa2N7nheKNT1kTKDqZlGdI=",
+          "range": "bytes=1042-408849"
         },
         "name": "glibc-locale-posix",
         "signature": {
-          "checksum": "sha1-9uPIvcOCeZbPiR7+MLDB4tkJlHo=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-QqrJFnJmyPeT66hUk3O7NxaWY8I=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1YLxq+Z9/+aFnCwvgV7acVLT4QFA=",
+        "checksum": "Q1JYf1zI1zVi/S9sMI32guk6ptuRQ=",
         "control": {
-          "checksum": "sha1-YLxq+Z9/+aFnCwvgV7acVLT4QFA=",
-          "range": "bytes=701-1330"
+          "checksum": "sha1-JYf1zI1zVi/S9sMI32guk6ptuRQ=",
+          "range": "bytes=701-1308"
         },
         "data": {
-          "checksum": "sha256-9s5RNfAJ3GVt7a/fFUaew5MfYYUkvL/6FMvsEfD95jY=",
-          "range": "bytes=1331-5862057"
+          "checksum": "sha256-ioC8korS2nJpJvoS6He+mKkDsgVLcMxiEuYLsAB9M7U=",
+          "range": "bytes=1309-5959239"
         },
         "name": "glibc",
         "signature": {
-          "checksum": "sha1-Kvfb+I/1PCfiBTjoaU4ezZa0b+8=",
+          "checksum": "sha1-3TP2+cHjCEBrIFluCdTmr2oJA1s=",
           "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Zi0e8Bq6WCd/6uXXjVhb8YwMD1U=",
+        "checksum": "Q1WAlPh7UNBV+RHfBixVB5P9F9Mp8=",
         "control": {
-          "checksum": "sha1-Zi0e8Bq6WCd/6uXXjVhb8YwMD1U=",
-          "range": "bytes=700-1073"
+          "checksum": "sha1-WAlPh7UNBV+RHfBixVB5P9F9Mp8=",
+          "range": "bytes=700-1074"
         },
         "data": {
-          "checksum": "sha256-jMhtfqVjnhuuBO7wtNZ6RS/72sZWoKt/Moage2amlks=",
-          "range": "bytes=1074-81594"
+          "checksum": "sha256-i6uEFvUEbJ4YzgNSV58aObIdU608mjbCVPwyF57ZeQQ=",
+          "range": "bytes=1075-81593"
         },
         "name": "protobuf-c",
         "signature": {
-          "checksum": "sha1-kATwMKztK7nk7qbYCJPkCFp6IXc=",
+          "checksum": "sha1-47zwDXmhcWiVtTYCjq4sFld8wHQ=",
           "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r5.apk",
-        "version": "1.5.0-r5"
+        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r6.apk",
+        "version": "1.5.0-r6"
       },
       {
         "architecture": "x86_64",
@@ -204,41 +204,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Q/Zy5ovYSu2p/vVLr6DgVA1e8AQ=",
+        "checksum": "Q1a5wJzZI7k9o4F8hHFpfuqAUIH5Q=",
         "control": {
-          "checksum": "sha1-Q/Zy5ovYSu2p/vVLr6DgVA1e8AQ=",
-          "range": "bytes=699-1062"
+          "checksum": "sha1-a5wJzZI7k9o4F8hHFpfuqAUIH5Q=",
+          "range": "bytes=710-1075"
         },
         "data": {
-          "checksum": "sha256-H3jxsw8ytOeCIR4vq17voSVhdNokXk8C1g075txH6Bs=",
-          "range": "bytes=1063-5903754"
+          "checksum": "sha256-2p1UC4F4Odfxup/J/nyzujYRGaxGVjBOBWoc0aajClI=",
+          "range": "bytes=1076-5903889"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-NIl2f5OI/wSZByI8Ds1ZUfbFWyw=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-SOFoklqXtH38i1PcI3G/cPdRFtY=",
+          "range": "bytes=0-709"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.1-r3.apk",
-        "version": "3.3.1-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.1-r4.apk",
+        "version": "3.3.1-r4"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q13wGUXdZut9OOTdY5z2amUj9wXC0=",
+        "checksum": "Q1gb2VyLOsGV7xUiHBT0Ypt64rw6Y=",
         "control": {
-          "checksum": "sha1-3wGUXdZut9OOTdY5z2amUj9wXC0=",
-          "range": "bytes=698-1068"
+          "checksum": "sha1-gb2VyLOsGV7xUiHBT0Ypt64rw6Y=",
+          "range": "bytes=702-1071"
         },
         "data": {
-          "checksum": "sha256-mRda6+YGlOCczyIWKaHqXskTINoT1rgorHDHqAKAb7c=",
-          "range": "bytes=1069-1188955"
+          "checksum": "sha256-h2tz/aFB2n8SFdBFde5foQm1ru+8JUcGp+trUeA2ZlQ=",
+          "range": "bytes=1072-1188954"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-+UdRc4U3PKw4H9OiNurHKXa5BYk=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-w6U2Pb1Y90u1iBFc/sHg2xn6Qmo=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.1-r3.apk",
-        "version": "3.3.1-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.1-r4.apk",
+        "version": "3.3.1-r4"
       },
       {
         "architecture": "x86_64",
@@ -356,60 +356,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1gfqHM/7r3rXX1HqC163slTPP46o=",
+        "checksum": "Q1DLAp18ebMscosnQ4TfTivIzgtCY=",
         "control": {
-          "checksum": "sha1-gfqHM/7r3rXX1HqC163slTPP46o=",
-          "range": "bytes=704-1101"
+          "checksum": "sha1-DLAp18ebMscosnQ4TfTivIzgtCY=",
+          "range": "bytes=698-1079"
         },
         "data": {
-          "checksum": "sha256-OR7ikvfUYp78EsP0I2kuwqqAcy05jw9tr7JVQ6jTnGQ=",
-          "range": "bytes=1102-185433"
+          "checksum": "sha256-eiBdqqECWnULWGe/Gnd6iv/7h56A4xR2qw+5toY5Gaw=",
+          "range": "bytes=1080-185559"
         },
         "name": "libgcc",
         "signature": {
-          "checksum": "sha1-Il4pyVzI6eqNd/f4bsKeakpB5DI=",
-          "range": "bytes=0-703"
+          "checksum": "sha1-qVj9laNeBIwRxP+8ehB+fXftJrw=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.2.0-r7.apk",
-        "version": "13.2.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r0.apk",
+        "version": "13.3.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1c+lykdx+yHoqsrQmQLHMV7waR1Q=",
+        "checksum": "Q1p9aaHhpB2Ud0URrcIrVRAujMw+o=",
         "control": {
-          "checksum": "sha1-c+lykdx+yHoqsrQmQLHMV7waR1Q=",
-          "range": "bytes=701-1119"
+          "checksum": "sha1-p9aaHhpB2Ud0URrcIrVRAujMw+o=",
+          "range": "bytes=696-1097"
         },
         "data": {
-          "checksum": "sha256-CuZi2C5g0vUnz4PNH8jIWV+EBdVMvHr+sNKFYTSnQZk=",
-          "range": "bytes=1120-3155369"
+          "checksum": "sha256-rGMnyLiGEDCEVgqA1oXMf28QHuWHAaPzYrLeDzQ3WOU=",
+          "range": "bytes=1098-3155519"
         },
         "name": "libstdc++",
         "signature": {
-          "checksum": "sha1-7l8MLj8aCcdqta/0sR+0PscBsD4=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-lge2XoAsgvp8U6ZBgT52N2xNQAw=",
+          "range": "bytes=0-695"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.2.0-r7.apk",
-        "version": "13.2.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r0.apk",
+        "version": "13.3.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1R8OxpY0fGwVaIwft4wJeswF5D54=",
+        "checksum": "Q1DUpLMidX5HbXUAFV8y3Imyt+Ank=",
         "control": {
-          "checksum": "sha1-R8OxpY0fGwVaIwft4wJeswF5D54=",
-          "range": "bytes=695-1059"
+          "checksum": "sha1-DUpLMidX5HbXUAFV8y3Imyt+Ank=",
+          "range": "bytes=698-1063"
         },
         "data": {
-          "checksum": "sha256-wNc8/SBJrGHfwywAtzCsAqeUOt0IaAhqNtlbv8OiHBE=",
-          "range": "bytes=1060-242151"
+          "checksum": "sha256-ZUDWWOBnxl5xi3b5HQCHaiYqKDSrnVpJQgavWpn1duc=",
+          "range": "bytes=1064-255810"
         },
         "name": "c-ares",
         "signature": {
-          "checksum": "sha1-55/PTlEHXI3o0hx9dSVdNwQeSMg=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-0AXk7b/B1baNADDg/NSocbW//pw=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.31.0-r0.apk",
-        "version": "1.31.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.32.1-r0.apk",
+        "version": "1.32.1-r0"
       },
       {
         "architecture": "x86_64",
@@ -470,22 +470,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q10AaU1ocIM4PYYNvwbml8TmpNvEA=",
+        "checksum": "Q1ORn/60iAvLcAgApXYoZzM6o0XSs=",
         "control": {
-          "checksum": "sha1-0AaU1ocIM4PYYNvwbml8TmpNvEA=",
-          "range": "bytes=706-1085"
+          "checksum": "sha1-ORn/60iAvLcAgApXYoZzM6o0XSs=",
+          "range": "bytes=703-1081"
         },
         "data": {
-          "checksum": "sha256-1YQNYASFjlP3kXX58ec8du75ij/U6O4DPAKzJAPkln0=",
-          "range": "bytes=1086-4272589"
+          "checksum": "sha256-Ya2Dn1VNYB21ZBD/jBCSx3SxZuJloJET5xkjX0s3Vt8=",
+          "range": "bytes=1082-4272708"
         },
         "name": "libxml2",
         "signature": {
-          "checksum": "sha1-QFjdplzGn/MiNFxMykgafr6/w6U=",
-          "range": "bytes=0-705"
+          "checksum": "sha1-s5jaTwJdla4k4KK0KEk7AYbgdqs=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.1-r1.apk",
-        "version": "2.13.1-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.2-r0.apk",
+        "version": "2.13.2-r0"
       },
       {
         "architecture": "x86_64",
@@ -546,22 +546,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1+0xClEzF5nhyNPUeGFhC++ElQmg=",
+        "checksum": "Q1u+fF2xg98dT0poYklte5HHMg/Kk=",
         "control": {
-          "checksum": "sha1-+0xClEzF5nhyNPUeGFhC++ElQmg=",
-          "range": "bytes=701-1107"
+          "checksum": "sha1-u+fF2xg98dT0poYklte5HHMg/Kk=",
+          "range": "bytes=701-1090"
         },
         "data": {
-          "checksum": "sha256-81V5R7T08up/3BwfuAG25Rq7KkB1MvALVCaogCpW500=",
-          "range": "bytes=1108-22181"
+          "checksum": "sha256-9e+i7LwSg7oAUU33f0r7A4Mc2suaK95iNU5BKaTSXac=",
+          "range": "bytes=1091-22179"
         },
         "name": "libcrypt1",
         "signature": {
-          "checksum": "sha1-k+7JfhPi5KOQ+6Nqk3oAfTbtOVM=",
+          "checksum": "sha1-EWBUcJqCJTOYJq1H0/kkO+m6W3E=",
           "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/sourcegraph-dev.lock.json
+++ b/wolfi-images/sourcegraph-dev.lock.json
@@ -14,98 +14,98 @@
     "packages": [
       {
         "architecture": "x86_64",
-        "checksum": "Q1Ai8jWuxKZR2M2XhOpOGAoTEwnnk=",
+        "checksum": "Q1WR9MGKU+cJh6dJFEXnr3zU1qsMM=",
         "control": {
-          "checksum": "sha1-Ai8jWuxKZR2M2XhOpOGAoTEwnnk=",
-          "range": "bytes=705-1037"
+          "checksum": "sha1-WR9MGKU+cJh6dJFEXnr3zU1qsMM=",
+          "range": "bytes=705-1034"
         },
         "data": {
-          "checksum": "sha256-e4UardkBVyaC49aSyrVmXNi8sSKqQl4eKYd0LxGRLA0=",
-          "range": "bytes=1038-255695"
+          "checksum": "sha256-EkOhtSivoLErXsK2J9ri39thkwb2kJGYHVou4n6dMKA=",
+          "range": "bytes=1035-254654"
         },
         "name": "ca-certificates-bundle",
         "signature": {
-          "checksum": "sha1-loRuyYQLm+atp+YteiQoj++EWIM=",
+          "checksum": "sha1-WL9vKv1nPIeaUQI4O0DiY9RdSHE=",
           "range": "bytes=0-704"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20240315-r4.apk",
-        "version": "20240315-r4"
+        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20240705-r0.apk",
+        "version": "20240705-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1+GH6qRN4iy1IDt0cT0x0tin7YfI=",
+        "checksum": "Q1KmG1L67f+/TnVGcnIcLfWRF/K2g=",
         "control": {
-          "checksum": "sha1-+GH6qRN4iy1IDt0cT0x0tin7YfI=",
-          "range": "bytes=703-1051"
+          "checksum": "sha1-KmG1L67f+/TnVGcnIcLfWRF/K2g=",
+          "range": "bytes=702-1051"
         },
         "data": {
-          "checksum": "sha256-rO0P9z2V49BSrz1A5Ap69tEappVrg5MMBjzW00rOpZc=",
-          "range": "bytes=1052-122464"
+          "checksum": "sha256-2YIxYc/Quit+Kri2qS8p6XvL7taAmOYJU/1Z8RNQ+88=",
+          "range": "bytes=1052-122509"
         },
         "name": "wolfi-baselayout",
         "signature": {
-          "checksum": "sha1-Ntb6VuMzDfM+frpCjKEIpDzl53I=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-VVyPrknEtqCPym5lfhVEuIhfkKg=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r12.apk",
-        "version": "20230201-r12"
+        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r13.apk",
+        "version": "20230201-r13"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q17rD4cKGW3uVSJw02PFiYR719t/Y=",
+        "checksum": "Q1ASyaCJL2Zyz4uAKpPPlx1Sd40yo=",
         "control": {
-          "checksum": "sha1-7rD4cKGW3uVSJw02PFiYR719t/Y=",
-          "range": "bytes=697-1108"
+          "checksum": "sha1-ASyaCJL2Zyz4uAKpPPlx1Sd40yo=",
+          "range": "bytes=706-1101"
         },
         "data": {
-          "checksum": "sha256-GvSViXbvUD0BdV2A+IzVJni2DjLvyM+j14hM29DcsYg=",
-          "range": "bytes=1109-268391"
+          "checksum": "sha256-KoaUrlV3QZ4ATGvKgOmZ1C8Rb/tHK3zEiCTGDrxxc/I=",
+          "range": "bytes=1102-272818"
         },
         "name": "ld-linux",
         "signature": {
-          "checksum": "sha1-nRIFect8o/LOUIEvN17AsrI07dg=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-DBrLE0fWPMyB5/0kAtNlIK6viCU=",
+          "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1/A0wNjkLqqBhe0jFr2D9SKcDNq8=",
+        "checksum": "Q10iHLABsXtuH2JyExQ2IIxH1NUCI=",
         "control": {
-          "checksum": "sha1-/A0wNjkLqqBhe0jFr2D9SKcDNq8=",
-          "range": "bytes=696-1054"
+          "checksum": "sha1-0iHLABsXtuH2JyExQ2IIxH1NUCI=",
+          "range": "bytes=698-1041"
         },
         "data": {
-          "checksum": "sha256-GT22MF6hR+Tj4el5xk2QEwNWig5JRoOrZ60Lecz+lok=",
-          "range": "bytes=1055-408851"
+          "checksum": "sha256-A3RF8XLSIePkapCnvEridXa2N7nheKNT1kTKDqZlGdI=",
+          "range": "bytes=1042-408849"
         },
         "name": "glibc-locale-posix",
         "signature": {
-          "checksum": "sha1-9uPIvcOCeZbPiR7+MLDB4tkJlHo=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-QqrJFnJmyPeT66hUk3O7NxaWY8I=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1YLxq+Z9/+aFnCwvgV7acVLT4QFA=",
+        "checksum": "Q1JYf1zI1zVi/S9sMI32guk6ptuRQ=",
         "control": {
-          "checksum": "sha1-YLxq+Z9/+aFnCwvgV7acVLT4QFA=",
-          "range": "bytes=701-1330"
+          "checksum": "sha1-JYf1zI1zVi/S9sMI32guk6ptuRQ=",
+          "range": "bytes=701-1308"
         },
         "data": {
-          "checksum": "sha256-9s5RNfAJ3GVt7a/fFUaew5MfYYUkvL/6FMvsEfD95jY=",
-          "range": "bytes=1331-5862057"
+          "checksum": "sha256-ioC8korS2nJpJvoS6He+mKkDsgVLcMxiEuYLsAB9M7U=",
+          "range": "bytes=1309-5959239"
         },
         "name": "glibc",
         "signature": {
-          "checksum": "sha1-Kvfb+I/1PCfiBTjoaU4ezZa0b+8=",
+          "checksum": "sha1-3TP2+cHjCEBrIFluCdTmr2oJA1s=",
           "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",
@@ -128,41 +128,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Q/Zy5ovYSu2p/vVLr6DgVA1e8AQ=",
+        "checksum": "Q1a5wJzZI7k9o4F8hHFpfuqAUIH5Q=",
         "control": {
-          "checksum": "sha1-Q/Zy5ovYSu2p/vVLr6DgVA1e8AQ=",
-          "range": "bytes=699-1062"
+          "checksum": "sha1-a5wJzZI7k9o4F8hHFpfuqAUIH5Q=",
+          "range": "bytes=710-1075"
         },
         "data": {
-          "checksum": "sha256-H3jxsw8ytOeCIR4vq17voSVhdNokXk8C1g075txH6Bs=",
-          "range": "bytes=1063-5903754"
+          "checksum": "sha256-2p1UC4F4Odfxup/J/nyzujYRGaxGVjBOBWoc0aajClI=",
+          "range": "bytes=1076-5903889"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-NIl2f5OI/wSZByI8Ds1ZUfbFWyw=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-SOFoklqXtH38i1PcI3G/cPdRFtY=",
+          "range": "bytes=0-709"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.1-r3.apk",
-        "version": "3.3.1-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.1-r4.apk",
+        "version": "3.3.1-r4"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q13wGUXdZut9OOTdY5z2amUj9wXC0=",
+        "checksum": "Q1gb2VyLOsGV7xUiHBT0Ypt64rw6Y=",
         "control": {
-          "checksum": "sha1-3wGUXdZut9OOTdY5z2amUj9wXC0=",
-          "range": "bytes=698-1068"
+          "checksum": "sha1-gb2VyLOsGV7xUiHBT0Ypt64rw6Y=",
+          "range": "bytes=702-1071"
         },
         "data": {
-          "checksum": "sha256-mRda6+YGlOCczyIWKaHqXskTINoT1rgorHDHqAKAb7c=",
-          "range": "bytes=1069-1188955"
+          "checksum": "sha256-h2tz/aFB2n8SFdBFde5foQm1ru+8JUcGp+trUeA2ZlQ=",
+          "range": "bytes=1072-1188954"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-+UdRc4U3PKw4H9OiNurHKXa5BYk=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-w6U2Pb1Y90u1iBFc/sHg2xn6Qmo=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.1-r3.apk",
-        "version": "3.3.1-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.1-r4.apk",
+        "version": "3.3.1-r4"
       },
       {
         "architecture": "x86_64",
@@ -185,22 +185,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Zi0e8Bq6WCd/6uXXjVhb8YwMD1U=",
+        "checksum": "Q1WAlPh7UNBV+RHfBixVB5P9F9Mp8=",
         "control": {
-          "checksum": "sha1-Zi0e8Bq6WCd/6uXXjVhb8YwMD1U=",
-          "range": "bytes=700-1073"
+          "checksum": "sha1-WAlPh7UNBV+RHfBixVB5P9F9Mp8=",
+          "range": "bytes=700-1074"
         },
         "data": {
-          "checksum": "sha256-jMhtfqVjnhuuBO7wtNZ6RS/72sZWoKt/Moage2amlks=",
-          "range": "bytes=1074-81594"
+          "checksum": "sha256-i6uEFvUEbJ4YzgNSV58aObIdU608mjbCVPwyF57ZeQQ=",
+          "range": "bytes=1075-81593"
         },
         "name": "protobuf-c",
         "signature": {
-          "checksum": "sha1-kATwMKztK7nk7qbYCJPkCFp6IXc=",
+          "checksum": "sha1-47zwDXmhcWiVtTYCjq4sFld8wHQ=",
           "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r5.apk",
-        "version": "1.5.0-r5"
+        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r6.apk",
+        "version": "1.5.0-r6"
       },
       {
         "architecture": "x86_64",
@@ -375,60 +375,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1gfqHM/7r3rXX1HqC163slTPP46o=",
+        "checksum": "Q1DLAp18ebMscosnQ4TfTivIzgtCY=",
         "control": {
-          "checksum": "sha1-gfqHM/7r3rXX1HqC163slTPP46o=",
-          "range": "bytes=704-1101"
+          "checksum": "sha1-DLAp18ebMscosnQ4TfTivIzgtCY=",
+          "range": "bytes=698-1079"
         },
         "data": {
-          "checksum": "sha256-OR7ikvfUYp78EsP0I2kuwqqAcy05jw9tr7JVQ6jTnGQ=",
-          "range": "bytes=1102-185433"
+          "checksum": "sha256-eiBdqqECWnULWGe/Gnd6iv/7h56A4xR2qw+5toY5Gaw=",
+          "range": "bytes=1080-185559"
         },
         "name": "libgcc",
         "signature": {
-          "checksum": "sha1-Il4pyVzI6eqNd/f4bsKeakpB5DI=",
-          "range": "bytes=0-703"
+          "checksum": "sha1-qVj9laNeBIwRxP+8ehB+fXftJrw=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.2.0-r7.apk",
-        "version": "13.2.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r0.apk",
+        "version": "13.3.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1c+lykdx+yHoqsrQmQLHMV7waR1Q=",
+        "checksum": "Q1p9aaHhpB2Ud0URrcIrVRAujMw+o=",
         "control": {
-          "checksum": "sha1-c+lykdx+yHoqsrQmQLHMV7waR1Q=",
-          "range": "bytes=701-1119"
+          "checksum": "sha1-p9aaHhpB2Ud0URrcIrVRAujMw+o=",
+          "range": "bytes=696-1097"
         },
         "data": {
-          "checksum": "sha256-CuZi2C5g0vUnz4PNH8jIWV+EBdVMvHr+sNKFYTSnQZk=",
-          "range": "bytes=1120-3155369"
+          "checksum": "sha256-rGMnyLiGEDCEVgqA1oXMf28QHuWHAaPzYrLeDzQ3WOU=",
+          "range": "bytes=1098-3155519"
         },
         "name": "libstdc++",
         "signature": {
-          "checksum": "sha1-7l8MLj8aCcdqta/0sR+0PscBsD4=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-lge2XoAsgvp8U6ZBgT52N2xNQAw=",
+          "range": "bytes=0-695"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.2.0-r7.apk",
-        "version": "13.2.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r0.apk",
+        "version": "13.3.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1R8OxpY0fGwVaIwft4wJeswF5D54=",
+        "checksum": "Q1DUpLMidX5HbXUAFV8y3Imyt+Ank=",
         "control": {
-          "checksum": "sha1-R8OxpY0fGwVaIwft4wJeswF5D54=",
-          "range": "bytes=695-1059"
+          "checksum": "sha1-DUpLMidX5HbXUAFV8y3Imyt+Ank=",
+          "range": "bytes=698-1063"
         },
         "data": {
-          "checksum": "sha256-wNc8/SBJrGHfwywAtzCsAqeUOt0IaAhqNtlbv8OiHBE=",
-          "range": "bytes=1060-242151"
+          "checksum": "sha256-ZUDWWOBnxl5xi3b5HQCHaiYqKDSrnVpJQgavWpn1duc=",
+          "range": "bytes=1064-255810"
         },
         "name": "c-ares",
         "signature": {
-          "checksum": "sha1-55/PTlEHXI3o0hx9dSVdNwQeSMg=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-0AXk7b/B1baNADDg/NSocbW//pw=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.31.0-r0.apk",
-        "version": "1.31.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.32.1-r0.apk",
+        "version": "1.32.1-r0"
       },
       {
         "architecture": "x86_64",
@@ -489,22 +489,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q10AaU1ocIM4PYYNvwbml8TmpNvEA=",
+        "checksum": "Q1ORn/60iAvLcAgApXYoZzM6o0XSs=",
         "control": {
-          "checksum": "sha1-0AaU1ocIM4PYYNvwbml8TmpNvEA=",
-          "range": "bytes=706-1085"
+          "checksum": "sha1-ORn/60iAvLcAgApXYoZzM6o0XSs=",
+          "range": "bytes=703-1081"
         },
         "data": {
-          "checksum": "sha256-1YQNYASFjlP3kXX58ec8du75ij/U6O4DPAKzJAPkln0=",
-          "range": "bytes=1086-4272589"
+          "checksum": "sha256-Ya2Dn1VNYB21ZBD/jBCSx3SxZuJloJET5xkjX0s3Vt8=",
+          "range": "bytes=1082-4272708"
         },
         "name": "libxml2",
         "signature": {
-          "checksum": "sha1-QFjdplzGn/MiNFxMykgafr6/w6U=",
-          "range": "bytes=0-705"
+          "checksum": "sha1-s5jaTwJdla4k4KK0KEk7AYbgdqs=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.1-r1.apk",
-        "version": "2.13.1-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.2-r0.apk",
+        "version": "2.13.2-r0"
       },
       {
         "architecture": "x86_64",
@@ -565,22 +565,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1+0xClEzF5nhyNPUeGFhC++ElQmg=",
+        "checksum": "Q1u+fF2xg98dT0poYklte5HHMg/Kk=",
         "control": {
-          "checksum": "sha1-+0xClEzF5nhyNPUeGFhC++ElQmg=",
-          "range": "bytes=701-1107"
+          "checksum": "sha1-u+fF2xg98dT0poYklte5HHMg/Kk=",
+          "range": "bytes=701-1090"
         },
         "data": {
-          "checksum": "sha256-81V5R7T08up/3BwfuAG25Rq7KkB1MvALVCaogCpW500=",
-          "range": "bytes=1108-22181"
+          "checksum": "sha256-9e+i7LwSg7oAUU33f0r7A4Mc2suaK95iNU5BKaTSXac=",
+          "range": "bytes=1091-22179"
         },
         "name": "libcrypt1",
         "signature": {
-          "checksum": "sha1-k+7JfhPi5KOQ+6Nqk3oAfTbtOVM=",
+          "checksum": "sha1-EWBUcJqCJTOYJq1H0/kkO+m6W3E=",
           "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/sourcegraph-template.lock.json
+++ b/wolfi-images/sourcegraph-template.lock.json
@@ -14,117 +14,117 @@
     "packages": [
       {
         "architecture": "x86_64",
-        "checksum": "Q1Ai8jWuxKZR2M2XhOpOGAoTEwnnk=",
+        "checksum": "Q1WR9MGKU+cJh6dJFEXnr3zU1qsMM=",
         "control": {
-          "checksum": "sha1-Ai8jWuxKZR2M2XhOpOGAoTEwnnk=",
-          "range": "bytes=705-1037"
+          "checksum": "sha1-WR9MGKU+cJh6dJFEXnr3zU1qsMM=",
+          "range": "bytes=705-1034"
         },
         "data": {
-          "checksum": "sha256-e4UardkBVyaC49aSyrVmXNi8sSKqQl4eKYd0LxGRLA0=",
-          "range": "bytes=1038-255695"
+          "checksum": "sha256-EkOhtSivoLErXsK2J9ri39thkwb2kJGYHVou4n6dMKA=",
+          "range": "bytes=1035-254654"
         },
         "name": "ca-certificates-bundle",
         "signature": {
-          "checksum": "sha1-loRuyYQLm+atp+YteiQoj++EWIM=",
+          "checksum": "sha1-WL9vKv1nPIeaUQI4O0DiY9RdSHE=",
           "range": "bytes=0-704"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20240315-r4.apk",
-        "version": "20240315-r4"
+        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20240705-r0.apk",
+        "version": "20240705-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1+GH6qRN4iy1IDt0cT0x0tin7YfI=",
+        "checksum": "Q1KmG1L67f+/TnVGcnIcLfWRF/K2g=",
         "control": {
-          "checksum": "sha1-+GH6qRN4iy1IDt0cT0x0tin7YfI=",
-          "range": "bytes=703-1051"
+          "checksum": "sha1-KmG1L67f+/TnVGcnIcLfWRF/K2g=",
+          "range": "bytes=702-1051"
         },
         "data": {
-          "checksum": "sha256-rO0P9z2V49BSrz1A5Ap69tEappVrg5MMBjzW00rOpZc=",
-          "range": "bytes=1052-122464"
+          "checksum": "sha256-2YIxYc/Quit+Kri2qS8p6XvL7taAmOYJU/1Z8RNQ+88=",
+          "range": "bytes=1052-122509"
         },
         "name": "wolfi-baselayout",
         "signature": {
-          "checksum": "sha1-Ntb6VuMzDfM+frpCjKEIpDzl53I=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-VVyPrknEtqCPym5lfhVEuIhfkKg=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r12.apk",
-        "version": "20230201-r12"
+        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r13.apk",
+        "version": "20230201-r13"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q17rD4cKGW3uVSJw02PFiYR719t/Y=",
+        "checksum": "Q1ASyaCJL2Zyz4uAKpPPlx1Sd40yo=",
         "control": {
-          "checksum": "sha1-7rD4cKGW3uVSJw02PFiYR719t/Y=",
-          "range": "bytes=697-1108"
+          "checksum": "sha1-ASyaCJL2Zyz4uAKpPPlx1Sd40yo=",
+          "range": "bytes=706-1101"
         },
         "data": {
-          "checksum": "sha256-GvSViXbvUD0BdV2A+IzVJni2DjLvyM+j14hM29DcsYg=",
-          "range": "bytes=1109-268391"
+          "checksum": "sha256-KoaUrlV3QZ4ATGvKgOmZ1C8Rb/tHK3zEiCTGDrxxc/I=",
+          "range": "bytes=1102-272818"
         },
         "name": "ld-linux",
         "signature": {
-          "checksum": "sha1-nRIFect8o/LOUIEvN17AsrI07dg=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-DBrLE0fWPMyB5/0kAtNlIK6viCU=",
+          "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1/A0wNjkLqqBhe0jFr2D9SKcDNq8=",
+        "checksum": "Q10iHLABsXtuH2JyExQ2IIxH1NUCI=",
         "control": {
-          "checksum": "sha1-/A0wNjkLqqBhe0jFr2D9SKcDNq8=",
-          "range": "bytes=696-1054"
+          "checksum": "sha1-0iHLABsXtuH2JyExQ2IIxH1NUCI=",
+          "range": "bytes=698-1041"
         },
         "data": {
-          "checksum": "sha256-GT22MF6hR+Tj4el5xk2QEwNWig5JRoOrZ60Lecz+lok=",
-          "range": "bytes=1055-408851"
+          "checksum": "sha256-A3RF8XLSIePkapCnvEridXa2N7nheKNT1kTKDqZlGdI=",
+          "range": "bytes=1042-408849"
         },
         "name": "glibc-locale-posix",
         "signature": {
-          "checksum": "sha1-9uPIvcOCeZbPiR7+MLDB4tkJlHo=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-QqrJFnJmyPeT66hUk3O7NxaWY8I=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1YLxq+Z9/+aFnCwvgV7acVLT4QFA=",
+        "checksum": "Q1JYf1zI1zVi/S9sMI32guk6ptuRQ=",
         "control": {
-          "checksum": "sha1-YLxq+Z9/+aFnCwvgV7acVLT4QFA=",
-          "range": "bytes=701-1330"
+          "checksum": "sha1-JYf1zI1zVi/S9sMI32guk6ptuRQ=",
+          "range": "bytes=701-1308"
         },
         "data": {
-          "checksum": "sha256-9s5RNfAJ3GVt7a/fFUaew5MfYYUkvL/6FMvsEfD95jY=",
-          "range": "bytes=1331-5862057"
+          "checksum": "sha256-ioC8korS2nJpJvoS6He+mKkDsgVLcMxiEuYLsAB9M7U=",
+          "range": "bytes=1309-5959239"
         },
         "name": "glibc",
         "signature": {
-          "checksum": "sha1-Kvfb+I/1PCfiBTjoaU4ezZa0b+8=",
+          "checksum": "sha1-3TP2+cHjCEBrIFluCdTmr2oJA1s=",
           "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Zi0e8Bq6WCd/6uXXjVhb8YwMD1U=",
+        "checksum": "Q1WAlPh7UNBV+RHfBixVB5P9F9Mp8=",
         "control": {
-          "checksum": "sha1-Zi0e8Bq6WCd/6uXXjVhb8YwMD1U=",
-          "range": "bytes=700-1073"
+          "checksum": "sha1-WAlPh7UNBV+RHfBixVB5P9F9Mp8=",
+          "range": "bytes=700-1074"
         },
         "data": {
-          "checksum": "sha256-jMhtfqVjnhuuBO7wtNZ6RS/72sZWoKt/Moage2amlks=",
-          "range": "bytes=1074-81594"
+          "checksum": "sha256-i6uEFvUEbJ4YzgNSV58aObIdU608mjbCVPwyF57ZeQQ=",
+          "range": "bytes=1075-81593"
         },
         "name": "protobuf-c",
         "signature": {
-          "checksum": "sha1-kATwMKztK7nk7qbYCJPkCFp6IXc=",
+          "checksum": "sha1-47zwDXmhcWiVtTYCjq4sFld8wHQ=",
           "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r5.apk",
-        "version": "1.5.0-r5"
+        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r6.apk",
+        "version": "1.5.0-r6"
       },
       {
         "architecture": "x86_64",
@@ -204,41 +204,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Q/Zy5ovYSu2p/vVLr6DgVA1e8AQ=",
+        "checksum": "Q1a5wJzZI7k9o4F8hHFpfuqAUIH5Q=",
         "control": {
-          "checksum": "sha1-Q/Zy5ovYSu2p/vVLr6DgVA1e8AQ=",
-          "range": "bytes=699-1062"
+          "checksum": "sha1-a5wJzZI7k9o4F8hHFpfuqAUIH5Q=",
+          "range": "bytes=710-1075"
         },
         "data": {
-          "checksum": "sha256-H3jxsw8ytOeCIR4vq17voSVhdNokXk8C1g075txH6Bs=",
-          "range": "bytes=1063-5903754"
+          "checksum": "sha256-2p1UC4F4Odfxup/J/nyzujYRGaxGVjBOBWoc0aajClI=",
+          "range": "bytes=1076-5903889"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-NIl2f5OI/wSZByI8Ds1ZUfbFWyw=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-SOFoklqXtH38i1PcI3G/cPdRFtY=",
+          "range": "bytes=0-709"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.1-r3.apk",
-        "version": "3.3.1-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.1-r4.apk",
+        "version": "3.3.1-r4"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q13wGUXdZut9OOTdY5z2amUj9wXC0=",
+        "checksum": "Q1gb2VyLOsGV7xUiHBT0Ypt64rw6Y=",
         "control": {
-          "checksum": "sha1-3wGUXdZut9OOTdY5z2amUj9wXC0=",
-          "range": "bytes=698-1068"
+          "checksum": "sha1-gb2VyLOsGV7xUiHBT0Ypt64rw6Y=",
+          "range": "bytes=702-1071"
         },
         "data": {
-          "checksum": "sha256-mRda6+YGlOCczyIWKaHqXskTINoT1rgorHDHqAKAb7c=",
-          "range": "bytes=1069-1188955"
+          "checksum": "sha256-h2tz/aFB2n8SFdBFde5foQm1ru+8JUcGp+trUeA2ZlQ=",
+          "range": "bytes=1072-1188954"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-+UdRc4U3PKw4H9OiNurHKXa5BYk=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-w6U2Pb1Y90u1iBFc/sHg2xn6Qmo=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.1-r3.apk",
-        "version": "3.3.1-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.1-r4.apk",
+        "version": "3.3.1-r4"
       },
       {
         "architecture": "x86_64",
@@ -356,60 +356,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1gfqHM/7r3rXX1HqC163slTPP46o=",
+        "checksum": "Q1DLAp18ebMscosnQ4TfTivIzgtCY=",
         "control": {
-          "checksum": "sha1-gfqHM/7r3rXX1HqC163slTPP46o=",
-          "range": "bytes=704-1101"
+          "checksum": "sha1-DLAp18ebMscosnQ4TfTivIzgtCY=",
+          "range": "bytes=698-1079"
         },
         "data": {
-          "checksum": "sha256-OR7ikvfUYp78EsP0I2kuwqqAcy05jw9tr7JVQ6jTnGQ=",
-          "range": "bytes=1102-185433"
+          "checksum": "sha256-eiBdqqECWnULWGe/Gnd6iv/7h56A4xR2qw+5toY5Gaw=",
+          "range": "bytes=1080-185559"
         },
         "name": "libgcc",
         "signature": {
-          "checksum": "sha1-Il4pyVzI6eqNd/f4bsKeakpB5DI=",
-          "range": "bytes=0-703"
+          "checksum": "sha1-qVj9laNeBIwRxP+8ehB+fXftJrw=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.2.0-r7.apk",
-        "version": "13.2.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r0.apk",
+        "version": "13.3.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1c+lykdx+yHoqsrQmQLHMV7waR1Q=",
+        "checksum": "Q1p9aaHhpB2Ud0URrcIrVRAujMw+o=",
         "control": {
-          "checksum": "sha1-c+lykdx+yHoqsrQmQLHMV7waR1Q=",
-          "range": "bytes=701-1119"
+          "checksum": "sha1-p9aaHhpB2Ud0URrcIrVRAujMw+o=",
+          "range": "bytes=696-1097"
         },
         "data": {
-          "checksum": "sha256-CuZi2C5g0vUnz4PNH8jIWV+EBdVMvHr+sNKFYTSnQZk=",
-          "range": "bytes=1120-3155369"
+          "checksum": "sha256-rGMnyLiGEDCEVgqA1oXMf28QHuWHAaPzYrLeDzQ3WOU=",
+          "range": "bytes=1098-3155519"
         },
         "name": "libstdc++",
         "signature": {
-          "checksum": "sha1-7l8MLj8aCcdqta/0sR+0PscBsD4=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-lge2XoAsgvp8U6ZBgT52N2xNQAw=",
+          "range": "bytes=0-695"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.2.0-r7.apk",
-        "version": "13.2.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r0.apk",
+        "version": "13.3.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1R8OxpY0fGwVaIwft4wJeswF5D54=",
+        "checksum": "Q1DUpLMidX5HbXUAFV8y3Imyt+Ank=",
         "control": {
-          "checksum": "sha1-R8OxpY0fGwVaIwft4wJeswF5D54=",
-          "range": "bytes=695-1059"
+          "checksum": "sha1-DUpLMidX5HbXUAFV8y3Imyt+Ank=",
+          "range": "bytes=698-1063"
         },
         "data": {
-          "checksum": "sha256-wNc8/SBJrGHfwywAtzCsAqeUOt0IaAhqNtlbv8OiHBE=",
-          "range": "bytes=1060-242151"
+          "checksum": "sha256-ZUDWWOBnxl5xi3b5HQCHaiYqKDSrnVpJQgavWpn1duc=",
+          "range": "bytes=1064-255810"
         },
         "name": "c-ares",
         "signature": {
-          "checksum": "sha1-55/PTlEHXI3o0hx9dSVdNwQeSMg=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-0AXk7b/B1baNADDg/NSocbW//pw=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.31.0-r0.apk",
-        "version": "1.31.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.32.1-r0.apk",
+        "version": "1.32.1-r0"
       },
       {
         "architecture": "x86_64",
@@ -470,22 +470,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q10AaU1ocIM4PYYNvwbml8TmpNvEA=",
+        "checksum": "Q1ORn/60iAvLcAgApXYoZzM6o0XSs=",
         "control": {
-          "checksum": "sha1-0AaU1ocIM4PYYNvwbml8TmpNvEA=",
-          "range": "bytes=706-1085"
+          "checksum": "sha1-ORn/60iAvLcAgApXYoZzM6o0XSs=",
+          "range": "bytes=703-1081"
         },
         "data": {
-          "checksum": "sha256-1YQNYASFjlP3kXX58ec8du75ij/U6O4DPAKzJAPkln0=",
-          "range": "bytes=1086-4272589"
+          "checksum": "sha256-Ya2Dn1VNYB21ZBD/jBCSx3SxZuJloJET5xkjX0s3Vt8=",
+          "range": "bytes=1082-4272708"
         },
         "name": "libxml2",
         "signature": {
-          "checksum": "sha1-QFjdplzGn/MiNFxMykgafr6/w6U=",
-          "range": "bytes=0-705"
+          "checksum": "sha1-s5jaTwJdla4k4KK0KEk7AYbgdqs=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.1-r1.apk",
-        "version": "2.13.1-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.2-r0.apk",
+        "version": "2.13.2-r0"
       },
       {
         "architecture": "x86_64",
@@ -546,22 +546,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1+0xClEzF5nhyNPUeGFhC++ElQmg=",
+        "checksum": "Q1u+fF2xg98dT0poYklte5HHMg/Kk=",
         "control": {
-          "checksum": "sha1-+0xClEzF5nhyNPUeGFhC++ElQmg=",
-          "range": "bytes=701-1107"
+          "checksum": "sha1-u+fF2xg98dT0poYklte5HHMg/Kk=",
+          "range": "bytes=701-1090"
         },
         "data": {
-          "checksum": "sha256-81V5R7T08up/3BwfuAG25Rq7KkB1MvALVCaogCpW500=",
-          "range": "bytes=1108-22181"
+          "checksum": "sha256-9e+i7LwSg7oAUU33f0r7A4Mc2suaK95iNU5BKaTSXac=",
+          "range": "bytes=1091-22179"
         },
         "name": "libcrypt1",
         "signature": {
-          "checksum": "sha1-k+7JfhPi5KOQ+6Nqk3oAfTbtOVM=",
+          "checksum": "sha1-EWBUcJqCJTOYJq1H0/kkO+m6W3E=",
           "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/symbols.lock.json
+++ b/wolfi-images/symbols.lock.json
@@ -14,117 +14,117 @@
     "packages": [
       {
         "architecture": "x86_64",
-        "checksum": "Q1Ai8jWuxKZR2M2XhOpOGAoTEwnnk=",
+        "checksum": "Q1WR9MGKU+cJh6dJFEXnr3zU1qsMM=",
         "control": {
-          "checksum": "sha1-Ai8jWuxKZR2M2XhOpOGAoTEwnnk=",
-          "range": "bytes=705-1037"
+          "checksum": "sha1-WR9MGKU+cJh6dJFEXnr3zU1qsMM=",
+          "range": "bytes=705-1034"
         },
         "data": {
-          "checksum": "sha256-e4UardkBVyaC49aSyrVmXNi8sSKqQl4eKYd0LxGRLA0=",
-          "range": "bytes=1038-255695"
+          "checksum": "sha256-EkOhtSivoLErXsK2J9ri39thkwb2kJGYHVou4n6dMKA=",
+          "range": "bytes=1035-254654"
         },
         "name": "ca-certificates-bundle",
         "signature": {
-          "checksum": "sha1-loRuyYQLm+atp+YteiQoj++EWIM=",
+          "checksum": "sha1-WL9vKv1nPIeaUQI4O0DiY9RdSHE=",
           "range": "bytes=0-704"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20240315-r4.apk",
-        "version": "20240315-r4"
+        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20240705-r0.apk",
+        "version": "20240705-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1+GH6qRN4iy1IDt0cT0x0tin7YfI=",
+        "checksum": "Q1KmG1L67f+/TnVGcnIcLfWRF/K2g=",
         "control": {
-          "checksum": "sha1-+GH6qRN4iy1IDt0cT0x0tin7YfI=",
-          "range": "bytes=703-1051"
+          "checksum": "sha1-KmG1L67f+/TnVGcnIcLfWRF/K2g=",
+          "range": "bytes=702-1051"
         },
         "data": {
-          "checksum": "sha256-rO0P9z2V49BSrz1A5Ap69tEappVrg5MMBjzW00rOpZc=",
-          "range": "bytes=1052-122464"
+          "checksum": "sha256-2YIxYc/Quit+Kri2qS8p6XvL7taAmOYJU/1Z8RNQ+88=",
+          "range": "bytes=1052-122509"
         },
         "name": "wolfi-baselayout",
         "signature": {
-          "checksum": "sha1-Ntb6VuMzDfM+frpCjKEIpDzl53I=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-VVyPrknEtqCPym5lfhVEuIhfkKg=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r12.apk",
-        "version": "20230201-r12"
+        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r13.apk",
+        "version": "20230201-r13"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q17rD4cKGW3uVSJw02PFiYR719t/Y=",
+        "checksum": "Q1ASyaCJL2Zyz4uAKpPPlx1Sd40yo=",
         "control": {
-          "checksum": "sha1-7rD4cKGW3uVSJw02PFiYR719t/Y=",
-          "range": "bytes=697-1108"
+          "checksum": "sha1-ASyaCJL2Zyz4uAKpPPlx1Sd40yo=",
+          "range": "bytes=706-1101"
         },
         "data": {
-          "checksum": "sha256-GvSViXbvUD0BdV2A+IzVJni2DjLvyM+j14hM29DcsYg=",
-          "range": "bytes=1109-268391"
+          "checksum": "sha256-KoaUrlV3QZ4ATGvKgOmZ1C8Rb/tHK3zEiCTGDrxxc/I=",
+          "range": "bytes=1102-272818"
         },
         "name": "ld-linux",
         "signature": {
-          "checksum": "sha1-nRIFect8o/LOUIEvN17AsrI07dg=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-DBrLE0fWPMyB5/0kAtNlIK6viCU=",
+          "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1/A0wNjkLqqBhe0jFr2D9SKcDNq8=",
+        "checksum": "Q10iHLABsXtuH2JyExQ2IIxH1NUCI=",
         "control": {
-          "checksum": "sha1-/A0wNjkLqqBhe0jFr2D9SKcDNq8=",
-          "range": "bytes=696-1054"
+          "checksum": "sha1-0iHLABsXtuH2JyExQ2IIxH1NUCI=",
+          "range": "bytes=698-1041"
         },
         "data": {
-          "checksum": "sha256-GT22MF6hR+Tj4el5xk2QEwNWig5JRoOrZ60Lecz+lok=",
-          "range": "bytes=1055-408851"
+          "checksum": "sha256-A3RF8XLSIePkapCnvEridXa2N7nheKNT1kTKDqZlGdI=",
+          "range": "bytes=1042-408849"
         },
         "name": "glibc-locale-posix",
         "signature": {
-          "checksum": "sha1-9uPIvcOCeZbPiR7+MLDB4tkJlHo=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-QqrJFnJmyPeT66hUk3O7NxaWY8I=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1YLxq+Z9/+aFnCwvgV7acVLT4QFA=",
+        "checksum": "Q1JYf1zI1zVi/S9sMI32guk6ptuRQ=",
         "control": {
-          "checksum": "sha1-YLxq+Z9/+aFnCwvgV7acVLT4QFA=",
-          "range": "bytes=701-1330"
+          "checksum": "sha1-JYf1zI1zVi/S9sMI32guk6ptuRQ=",
+          "range": "bytes=701-1308"
         },
         "data": {
-          "checksum": "sha256-9s5RNfAJ3GVt7a/fFUaew5MfYYUkvL/6FMvsEfD95jY=",
-          "range": "bytes=1331-5862057"
+          "checksum": "sha256-ioC8korS2nJpJvoS6He+mKkDsgVLcMxiEuYLsAB9M7U=",
+          "range": "bytes=1309-5959239"
         },
         "name": "glibc",
         "signature": {
-          "checksum": "sha1-Kvfb+I/1PCfiBTjoaU4ezZa0b+8=",
+          "checksum": "sha1-3TP2+cHjCEBrIFluCdTmr2oJA1s=",
           "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Zi0e8Bq6WCd/6uXXjVhb8YwMD1U=",
+        "checksum": "Q1WAlPh7UNBV+RHfBixVB5P9F9Mp8=",
         "control": {
-          "checksum": "sha1-Zi0e8Bq6WCd/6uXXjVhb8YwMD1U=",
-          "range": "bytes=700-1073"
+          "checksum": "sha1-WAlPh7UNBV+RHfBixVB5P9F9Mp8=",
+          "range": "bytes=700-1074"
         },
         "data": {
-          "checksum": "sha256-jMhtfqVjnhuuBO7wtNZ6RS/72sZWoKt/Moage2amlks=",
-          "range": "bytes=1074-81594"
+          "checksum": "sha256-i6uEFvUEbJ4YzgNSV58aObIdU608mjbCVPwyF57ZeQQ=",
+          "range": "bytes=1075-81593"
         },
         "name": "protobuf-c",
         "signature": {
-          "checksum": "sha1-kATwMKztK7nk7qbYCJPkCFp6IXc=",
+          "checksum": "sha1-47zwDXmhcWiVtTYCjq4sFld8wHQ=",
           "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r5.apk",
-        "version": "1.5.0-r5"
+        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r6.apk",
+        "version": "1.5.0-r6"
       },
       {
         "architecture": "x86_64",
@@ -204,41 +204,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Q/Zy5ovYSu2p/vVLr6DgVA1e8AQ=",
+        "checksum": "Q1a5wJzZI7k9o4F8hHFpfuqAUIH5Q=",
         "control": {
-          "checksum": "sha1-Q/Zy5ovYSu2p/vVLr6DgVA1e8AQ=",
-          "range": "bytes=699-1062"
+          "checksum": "sha1-a5wJzZI7k9o4F8hHFpfuqAUIH5Q=",
+          "range": "bytes=710-1075"
         },
         "data": {
-          "checksum": "sha256-H3jxsw8ytOeCIR4vq17voSVhdNokXk8C1g075txH6Bs=",
-          "range": "bytes=1063-5903754"
+          "checksum": "sha256-2p1UC4F4Odfxup/J/nyzujYRGaxGVjBOBWoc0aajClI=",
+          "range": "bytes=1076-5903889"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-NIl2f5OI/wSZByI8Ds1ZUfbFWyw=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-SOFoklqXtH38i1PcI3G/cPdRFtY=",
+          "range": "bytes=0-709"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.1-r3.apk",
-        "version": "3.3.1-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.1-r4.apk",
+        "version": "3.3.1-r4"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q13wGUXdZut9OOTdY5z2amUj9wXC0=",
+        "checksum": "Q1gb2VyLOsGV7xUiHBT0Ypt64rw6Y=",
         "control": {
-          "checksum": "sha1-3wGUXdZut9OOTdY5z2amUj9wXC0=",
-          "range": "bytes=698-1068"
+          "checksum": "sha1-gb2VyLOsGV7xUiHBT0Ypt64rw6Y=",
+          "range": "bytes=702-1071"
         },
         "data": {
-          "checksum": "sha256-mRda6+YGlOCczyIWKaHqXskTINoT1rgorHDHqAKAb7c=",
-          "range": "bytes=1069-1188955"
+          "checksum": "sha256-h2tz/aFB2n8SFdBFde5foQm1ru+8JUcGp+trUeA2ZlQ=",
+          "range": "bytes=1072-1188954"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-+UdRc4U3PKw4H9OiNurHKXa5BYk=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-w6U2Pb1Y90u1iBFc/sHg2xn6Qmo=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.1-r3.apk",
-        "version": "3.3.1-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.1-r4.apk",
+        "version": "3.3.1-r4"
       },
       {
         "architecture": "x86_64",
@@ -337,41 +337,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1gfqHM/7r3rXX1HqC163slTPP46o=",
+        "checksum": "Q1DLAp18ebMscosnQ4TfTivIzgtCY=",
         "control": {
-          "checksum": "sha1-gfqHM/7r3rXX1HqC163slTPP46o=",
-          "range": "bytes=704-1101"
+          "checksum": "sha1-DLAp18ebMscosnQ4TfTivIzgtCY=",
+          "range": "bytes=698-1079"
         },
         "data": {
-          "checksum": "sha256-OR7ikvfUYp78EsP0I2kuwqqAcy05jw9tr7JVQ6jTnGQ=",
-          "range": "bytes=1102-185433"
+          "checksum": "sha256-eiBdqqECWnULWGe/Gnd6iv/7h56A4xR2qw+5toY5Gaw=",
+          "range": "bytes=1080-185559"
         },
         "name": "libgcc",
         "signature": {
-          "checksum": "sha1-Il4pyVzI6eqNd/f4bsKeakpB5DI=",
-          "range": "bytes=0-703"
+          "checksum": "sha1-qVj9laNeBIwRxP+8ehB+fXftJrw=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.2.0-r7.apk",
-        "version": "13.2.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r0.apk",
+        "version": "13.3.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1c+lykdx+yHoqsrQmQLHMV7waR1Q=",
+        "checksum": "Q1p9aaHhpB2Ud0URrcIrVRAujMw+o=",
         "control": {
-          "checksum": "sha1-c+lykdx+yHoqsrQmQLHMV7waR1Q=",
-          "range": "bytes=701-1119"
+          "checksum": "sha1-p9aaHhpB2Ud0URrcIrVRAujMw+o=",
+          "range": "bytes=696-1097"
         },
         "data": {
-          "checksum": "sha256-CuZi2C5g0vUnz4PNH8jIWV+EBdVMvHr+sNKFYTSnQZk=",
-          "range": "bytes=1120-3155369"
+          "checksum": "sha256-rGMnyLiGEDCEVgqA1oXMf28QHuWHAaPzYrLeDzQ3WOU=",
+          "range": "bytes=1098-3155519"
         },
         "name": "libstdc++",
         "signature": {
-          "checksum": "sha1-7l8MLj8aCcdqta/0sR+0PscBsD4=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-lge2XoAsgvp8U6ZBgT52N2xNQAw=",
+          "range": "bytes=0-695"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.2.0-r7.apk",
-        "version": "13.2.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r0.apk",
+        "version": "13.3.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -394,22 +394,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1R8OxpY0fGwVaIwft4wJeswF5D54=",
+        "checksum": "Q1DUpLMidX5HbXUAFV8y3Imyt+Ank=",
         "control": {
-          "checksum": "sha1-R8OxpY0fGwVaIwft4wJeswF5D54=",
-          "range": "bytes=695-1059"
+          "checksum": "sha1-DUpLMidX5HbXUAFV8y3Imyt+Ank=",
+          "range": "bytes=698-1063"
         },
         "data": {
-          "checksum": "sha256-wNc8/SBJrGHfwywAtzCsAqeUOt0IaAhqNtlbv8OiHBE=",
-          "range": "bytes=1060-242151"
+          "checksum": "sha256-ZUDWWOBnxl5xi3b5HQCHaiYqKDSrnVpJQgavWpn1duc=",
+          "range": "bytes=1064-255810"
         },
         "name": "c-ares",
         "signature": {
-          "checksum": "sha1-55/PTlEHXI3o0hx9dSVdNwQeSMg=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-0AXk7b/B1baNADDg/NSocbW//pw=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.31.0-r0.apk",
-        "version": "1.31.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.32.1-r0.apk",
+        "version": "1.32.1-r0"
       },
       {
         "architecture": "x86_64",
@@ -470,22 +470,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q10AaU1ocIM4PYYNvwbml8TmpNvEA=",
+        "checksum": "Q1ORn/60iAvLcAgApXYoZzM6o0XSs=",
         "control": {
-          "checksum": "sha1-0AaU1ocIM4PYYNvwbml8TmpNvEA=",
-          "range": "bytes=706-1085"
+          "checksum": "sha1-ORn/60iAvLcAgApXYoZzM6o0XSs=",
+          "range": "bytes=703-1081"
         },
         "data": {
-          "checksum": "sha256-1YQNYASFjlP3kXX58ec8du75ij/U6O4DPAKzJAPkln0=",
-          "range": "bytes=1086-4272589"
+          "checksum": "sha256-Ya2Dn1VNYB21ZBD/jBCSx3SxZuJloJET5xkjX0s3Vt8=",
+          "range": "bytes=1082-4272708"
         },
         "name": "libxml2",
         "signature": {
-          "checksum": "sha1-QFjdplzGn/MiNFxMykgafr6/w6U=",
-          "range": "bytes=0-705"
+          "checksum": "sha1-s5jaTwJdla4k4KK0KEk7AYbgdqs=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.1-r1.apk",
-        "version": "2.13.1-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.2-r0.apk",
+        "version": "2.13.2-r0"
       },
       {
         "architecture": "x86_64",
@@ -546,22 +546,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1+0xClEzF5nhyNPUeGFhC++ElQmg=",
+        "checksum": "Q1u+fF2xg98dT0poYklte5HHMg/Kk=",
         "control": {
-          "checksum": "sha1-+0xClEzF5nhyNPUeGFhC++ElQmg=",
-          "range": "bytes=701-1107"
+          "checksum": "sha1-u+fF2xg98dT0poYklte5HHMg/Kk=",
+          "range": "bytes=701-1090"
         },
         "data": {
-          "checksum": "sha256-81V5R7T08up/3BwfuAG25Rq7KkB1MvALVCaogCpW500=",
-          "range": "bytes=1108-22181"
+          "checksum": "sha256-9e+i7LwSg7oAUU33f0r7A4Mc2suaK95iNU5BKaTSXac=",
+          "range": "bytes=1091-22179"
         },
         "name": "libcrypt1",
         "signature": {
-          "checksum": "sha1-k+7JfhPi5KOQ+6Nqk3oAfTbtOVM=",
+          "checksum": "sha1-EWBUcJqCJTOYJq1H0/kkO+m6W3E=",
           "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",
@@ -584,22 +584,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1fnaWc3899x9dK4z4iTFNOeM6MI0=",
+        "checksum": "Q1yStY7gve/r3+nnaV+ul/l4zmwpU=",
         "control": {
-          "checksum": "sha1-fnaWc3899x9dK4z4iTFNOeM6MI0=",
-          "range": "bytes=702-1132"
+          "checksum": "sha1-yStY7gve/r3+nnaV+ul/l4zmwpU=",
+          "range": "bytes=699-1128"
         },
         "data": {
-          "checksum": "sha256-rhtsl8eIgOKIHSa3VsedIEj1sA3xRi83jc3fhTjIQLw=",
-          "range": "bytes=1133-377535"
+          "checksum": "sha256-1d/7CyMhSR2oDbLJtN12D1pYniEuQIptX78kAs2ZI14=",
+          "range": "bytes=1129-376508"
         },
         "name": "ca-certificates",
         "signature": {
-          "checksum": "sha1-I1wWFlIzyXu0g5mcgMo/iyW3Mhw=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-EIHhUeKgg6x/sc6JooVgTCBIgOg=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-20240315-r4.apk",
-        "version": "20240315-r4"
+        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-20240705-r0.apk",
+        "version": "20240705-r0"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/syntax-highlighter.lock.json
+++ b/wolfi-images/syntax-highlighter.lock.json
@@ -14,117 +14,117 @@
     "packages": [
       {
         "architecture": "x86_64",
-        "checksum": "Q1Ai8jWuxKZR2M2XhOpOGAoTEwnnk=",
+        "checksum": "Q1WR9MGKU+cJh6dJFEXnr3zU1qsMM=",
         "control": {
-          "checksum": "sha1-Ai8jWuxKZR2M2XhOpOGAoTEwnnk=",
-          "range": "bytes=705-1037"
+          "checksum": "sha1-WR9MGKU+cJh6dJFEXnr3zU1qsMM=",
+          "range": "bytes=705-1034"
         },
         "data": {
-          "checksum": "sha256-e4UardkBVyaC49aSyrVmXNi8sSKqQl4eKYd0LxGRLA0=",
-          "range": "bytes=1038-255695"
+          "checksum": "sha256-EkOhtSivoLErXsK2J9ri39thkwb2kJGYHVou4n6dMKA=",
+          "range": "bytes=1035-254654"
         },
         "name": "ca-certificates-bundle",
         "signature": {
-          "checksum": "sha1-loRuyYQLm+atp+YteiQoj++EWIM=",
+          "checksum": "sha1-WL9vKv1nPIeaUQI4O0DiY9RdSHE=",
           "range": "bytes=0-704"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20240315-r4.apk",
-        "version": "20240315-r4"
+        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20240705-r0.apk",
+        "version": "20240705-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1+GH6qRN4iy1IDt0cT0x0tin7YfI=",
+        "checksum": "Q1KmG1L67f+/TnVGcnIcLfWRF/K2g=",
         "control": {
-          "checksum": "sha1-+GH6qRN4iy1IDt0cT0x0tin7YfI=",
-          "range": "bytes=703-1051"
+          "checksum": "sha1-KmG1L67f+/TnVGcnIcLfWRF/K2g=",
+          "range": "bytes=702-1051"
         },
         "data": {
-          "checksum": "sha256-rO0P9z2V49BSrz1A5Ap69tEappVrg5MMBjzW00rOpZc=",
-          "range": "bytes=1052-122464"
+          "checksum": "sha256-2YIxYc/Quit+Kri2qS8p6XvL7taAmOYJU/1Z8RNQ+88=",
+          "range": "bytes=1052-122509"
         },
         "name": "wolfi-baselayout",
         "signature": {
-          "checksum": "sha1-Ntb6VuMzDfM+frpCjKEIpDzl53I=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-VVyPrknEtqCPym5lfhVEuIhfkKg=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r12.apk",
-        "version": "20230201-r12"
+        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r13.apk",
+        "version": "20230201-r13"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q17rD4cKGW3uVSJw02PFiYR719t/Y=",
+        "checksum": "Q1ASyaCJL2Zyz4uAKpPPlx1Sd40yo=",
         "control": {
-          "checksum": "sha1-7rD4cKGW3uVSJw02PFiYR719t/Y=",
-          "range": "bytes=697-1108"
+          "checksum": "sha1-ASyaCJL2Zyz4uAKpPPlx1Sd40yo=",
+          "range": "bytes=706-1101"
         },
         "data": {
-          "checksum": "sha256-GvSViXbvUD0BdV2A+IzVJni2DjLvyM+j14hM29DcsYg=",
-          "range": "bytes=1109-268391"
+          "checksum": "sha256-KoaUrlV3QZ4ATGvKgOmZ1C8Rb/tHK3zEiCTGDrxxc/I=",
+          "range": "bytes=1102-272818"
         },
         "name": "ld-linux",
         "signature": {
-          "checksum": "sha1-nRIFect8o/LOUIEvN17AsrI07dg=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-DBrLE0fWPMyB5/0kAtNlIK6viCU=",
+          "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1/A0wNjkLqqBhe0jFr2D9SKcDNq8=",
+        "checksum": "Q10iHLABsXtuH2JyExQ2IIxH1NUCI=",
         "control": {
-          "checksum": "sha1-/A0wNjkLqqBhe0jFr2D9SKcDNq8=",
-          "range": "bytes=696-1054"
+          "checksum": "sha1-0iHLABsXtuH2JyExQ2IIxH1NUCI=",
+          "range": "bytes=698-1041"
         },
         "data": {
-          "checksum": "sha256-GT22MF6hR+Tj4el5xk2QEwNWig5JRoOrZ60Lecz+lok=",
-          "range": "bytes=1055-408851"
+          "checksum": "sha256-A3RF8XLSIePkapCnvEridXa2N7nheKNT1kTKDqZlGdI=",
+          "range": "bytes=1042-408849"
         },
         "name": "glibc-locale-posix",
         "signature": {
-          "checksum": "sha1-9uPIvcOCeZbPiR7+MLDB4tkJlHo=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-QqrJFnJmyPeT66hUk3O7NxaWY8I=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1YLxq+Z9/+aFnCwvgV7acVLT4QFA=",
+        "checksum": "Q1JYf1zI1zVi/S9sMI32guk6ptuRQ=",
         "control": {
-          "checksum": "sha1-YLxq+Z9/+aFnCwvgV7acVLT4QFA=",
-          "range": "bytes=701-1330"
+          "checksum": "sha1-JYf1zI1zVi/S9sMI32guk6ptuRQ=",
+          "range": "bytes=701-1308"
         },
         "data": {
-          "checksum": "sha256-9s5RNfAJ3GVt7a/fFUaew5MfYYUkvL/6FMvsEfD95jY=",
-          "range": "bytes=1331-5862057"
+          "checksum": "sha256-ioC8korS2nJpJvoS6He+mKkDsgVLcMxiEuYLsAB9M7U=",
+          "range": "bytes=1309-5959239"
         },
         "name": "glibc",
         "signature": {
-          "checksum": "sha1-Kvfb+I/1PCfiBTjoaU4ezZa0b+8=",
+          "checksum": "sha1-3TP2+cHjCEBrIFluCdTmr2oJA1s=",
           "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Zi0e8Bq6WCd/6uXXjVhb8YwMD1U=",
+        "checksum": "Q1WAlPh7UNBV+RHfBixVB5P9F9Mp8=",
         "control": {
-          "checksum": "sha1-Zi0e8Bq6WCd/6uXXjVhb8YwMD1U=",
-          "range": "bytes=700-1073"
+          "checksum": "sha1-WAlPh7UNBV+RHfBixVB5P9F9Mp8=",
+          "range": "bytes=700-1074"
         },
         "data": {
-          "checksum": "sha256-jMhtfqVjnhuuBO7wtNZ6RS/72sZWoKt/Moage2amlks=",
-          "range": "bytes=1074-81594"
+          "checksum": "sha256-i6uEFvUEbJ4YzgNSV58aObIdU608mjbCVPwyF57ZeQQ=",
+          "range": "bytes=1075-81593"
         },
         "name": "protobuf-c",
         "signature": {
-          "checksum": "sha1-kATwMKztK7nk7qbYCJPkCFp6IXc=",
+          "checksum": "sha1-47zwDXmhcWiVtTYCjq4sFld8wHQ=",
           "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r5.apk",
-        "version": "1.5.0-r5"
+        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r6.apk",
+        "version": "1.5.0-r6"
       },
       {
         "architecture": "x86_64",
@@ -204,41 +204,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Q/Zy5ovYSu2p/vVLr6DgVA1e8AQ=",
+        "checksum": "Q1a5wJzZI7k9o4F8hHFpfuqAUIH5Q=",
         "control": {
-          "checksum": "sha1-Q/Zy5ovYSu2p/vVLr6DgVA1e8AQ=",
-          "range": "bytes=699-1062"
+          "checksum": "sha1-a5wJzZI7k9o4F8hHFpfuqAUIH5Q=",
+          "range": "bytes=710-1075"
         },
         "data": {
-          "checksum": "sha256-H3jxsw8ytOeCIR4vq17voSVhdNokXk8C1g075txH6Bs=",
-          "range": "bytes=1063-5903754"
+          "checksum": "sha256-2p1UC4F4Odfxup/J/nyzujYRGaxGVjBOBWoc0aajClI=",
+          "range": "bytes=1076-5903889"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-NIl2f5OI/wSZByI8Ds1ZUfbFWyw=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-SOFoklqXtH38i1PcI3G/cPdRFtY=",
+          "range": "bytes=0-709"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.1-r3.apk",
-        "version": "3.3.1-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.1-r4.apk",
+        "version": "3.3.1-r4"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q13wGUXdZut9OOTdY5z2amUj9wXC0=",
+        "checksum": "Q1gb2VyLOsGV7xUiHBT0Ypt64rw6Y=",
         "control": {
-          "checksum": "sha1-3wGUXdZut9OOTdY5z2amUj9wXC0=",
-          "range": "bytes=698-1068"
+          "checksum": "sha1-gb2VyLOsGV7xUiHBT0Ypt64rw6Y=",
+          "range": "bytes=702-1071"
         },
         "data": {
-          "checksum": "sha256-mRda6+YGlOCczyIWKaHqXskTINoT1rgorHDHqAKAb7c=",
-          "range": "bytes=1069-1188955"
+          "checksum": "sha256-h2tz/aFB2n8SFdBFde5foQm1ru+8JUcGp+trUeA2ZlQ=",
+          "range": "bytes=1072-1188954"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-+UdRc4U3PKw4H9OiNurHKXa5BYk=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-w6U2Pb1Y90u1iBFc/sHg2xn6Qmo=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.1-r3.apk",
-        "version": "3.3.1-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.1-r4.apk",
+        "version": "3.3.1-r4"
       },
       {
         "architecture": "x86_64",
@@ -337,41 +337,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1gfqHM/7r3rXX1HqC163slTPP46o=",
+        "checksum": "Q1DLAp18ebMscosnQ4TfTivIzgtCY=",
         "control": {
-          "checksum": "sha1-gfqHM/7r3rXX1HqC163slTPP46o=",
-          "range": "bytes=704-1101"
+          "checksum": "sha1-DLAp18ebMscosnQ4TfTivIzgtCY=",
+          "range": "bytes=698-1079"
         },
         "data": {
-          "checksum": "sha256-OR7ikvfUYp78EsP0I2kuwqqAcy05jw9tr7JVQ6jTnGQ=",
-          "range": "bytes=1102-185433"
+          "checksum": "sha256-eiBdqqECWnULWGe/Gnd6iv/7h56A4xR2qw+5toY5Gaw=",
+          "range": "bytes=1080-185559"
         },
         "name": "libgcc",
         "signature": {
-          "checksum": "sha1-Il4pyVzI6eqNd/f4bsKeakpB5DI=",
-          "range": "bytes=0-703"
+          "checksum": "sha1-qVj9laNeBIwRxP+8ehB+fXftJrw=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.2.0-r7.apk",
-        "version": "13.2.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r0.apk",
+        "version": "13.3.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1c+lykdx+yHoqsrQmQLHMV7waR1Q=",
+        "checksum": "Q1p9aaHhpB2Ud0URrcIrVRAujMw+o=",
         "control": {
-          "checksum": "sha1-c+lykdx+yHoqsrQmQLHMV7waR1Q=",
-          "range": "bytes=701-1119"
+          "checksum": "sha1-p9aaHhpB2Ud0URrcIrVRAujMw+o=",
+          "range": "bytes=696-1097"
         },
         "data": {
-          "checksum": "sha256-CuZi2C5g0vUnz4PNH8jIWV+EBdVMvHr+sNKFYTSnQZk=",
-          "range": "bytes=1120-3155369"
+          "checksum": "sha256-rGMnyLiGEDCEVgqA1oXMf28QHuWHAaPzYrLeDzQ3WOU=",
+          "range": "bytes=1098-3155519"
         },
         "name": "libstdc++",
         "signature": {
-          "checksum": "sha1-7l8MLj8aCcdqta/0sR+0PscBsD4=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-lge2XoAsgvp8U6ZBgT52N2xNQAw=",
+          "range": "bytes=0-695"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.2.0-r7.apk",
-        "version": "13.2.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r0.apk",
+        "version": "13.3.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -394,22 +394,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1R8OxpY0fGwVaIwft4wJeswF5D54=",
+        "checksum": "Q1DUpLMidX5HbXUAFV8y3Imyt+Ank=",
         "control": {
-          "checksum": "sha1-R8OxpY0fGwVaIwft4wJeswF5D54=",
-          "range": "bytes=695-1059"
+          "checksum": "sha1-DUpLMidX5HbXUAFV8y3Imyt+Ank=",
+          "range": "bytes=698-1063"
         },
         "data": {
-          "checksum": "sha256-wNc8/SBJrGHfwywAtzCsAqeUOt0IaAhqNtlbv8OiHBE=",
-          "range": "bytes=1060-242151"
+          "checksum": "sha256-ZUDWWOBnxl5xi3b5HQCHaiYqKDSrnVpJQgavWpn1duc=",
+          "range": "bytes=1064-255810"
         },
         "name": "c-ares",
         "signature": {
-          "checksum": "sha1-55/PTlEHXI3o0hx9dSVdNwQeSMg=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-0AXk7b/B1baNADDg/NSocbW//pw=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.31.0-r0.apk",
-        "version": "1.31.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.32.1-r0.apk",
+        "version": "1.32.1-r0"
       },
       {
         "architecture": "x86_64",
@@ -470,22 +470,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q10AaU1ocIM4PYYNvwbml8TmpNvEA=",
+        "checksum": "Q1ORn/60iAvLcAgApXYoZzM6o0XSs=",
         "control": {
-          "checksum": "sha1-0AaU1ocIM4PYYNvwbml8TmpNvEA=",
-          "range": "bytes=706-1085"
+          "checksum": "sha1-ORn/60iAvLcAgApXYoZzM6o0XSs=",
+          "range": "bytes=703-1081"
         },
         "data": {
-          "checksum": "sha256-1YQNYASFjlP3kXX58ec8du75ij/U6O4DPAKzJAPkln0=",
-          "range": "bytes=1086-4272589"
+          "checksum": "sha256-Ya2Dn1VNYB21ZBD/jBCSx3SxZuJloJET5xkjX0s3Vt8=",
+          "range": "bytes=1082-4272708"
         },
         "name": "libxml2",
         "signature": {
-          "checksum": "sha1-QFjdplzGn/MiNFxMykgafr6/w6U=",
-          "range": "bytes=0-705"
+          "checksum": "sha1-s5jaTwJdla4k4KK0KEk7AYbgdqs=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.1-r1.apk",
-        "version": "2.13.1-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.2-r0.apk",
+        "version": "2.13.2-r0"
       },
       {
         "architecture": "x86_64",
@@ -546,22 +546,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1+0xClEzF5nhyNPUeGFhC++ElQmg=",
+        "checksum": "Q1u+fF2xg98dT0poYklte5HHMg/Kk=",
         "control": {
-          "checksum": "sha1-+0xClEzF5nhyNPUeGFhC++ElQmg=",
-          "range": "bytes=701-1107"
+          "checksum": "sha1-u+fF2xg98dT0poYklte5HHMg/Kk=",
+          "range": "bytes=701-1090"
         },
         "data": {
-          "checksum": "sha256-81V5R7T08up/3BwfuAG25Rq7KkB1MvALVCaogCpW500=",
-          "range": "bytes=1108-22181"
+          "checksum": "sha256-9e+i7LwSg7oAUU33f0r7A4Mc2suaK95iNU5BKaTSXac=",
+          "range": "bytes=1091-22179"
         },
         "name": "libcrypt1",
         "signature": {
-          "checksum": "sha1-k+7JfhPi5KOQ+6Nqk3oAfTbtOVM=",
+          "checksum": "sha1-EWBUcJqCJTOYJq1H0/kkO+m6W3E=",
           "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",


### PR DESCRIPTION
Automatically generated PR to update package lockfiles for Sourcegraph base images.

Built from Buildkite run [#281769](https://buildkite.com/sourcegraph/sourcegraph/builds/281769).
## Test Plan
- CI build verifies image functionality