### PR TITLE
refactor(github): Have a dedicated PublicRepository type

### DIFF
--- a/internal/repos/github.go
+++ b/internal/repos/github.go
@@ -712,7 +712,7 @@ func (s *GitHubSource) listRepos(ctx context.Context, repos []string, results ch
 	}
 }
 
-func batchRepos(repos []*github.Repository, batchSize int) (batches [][]*github.Repository) {
+func batchPublicRepos(repos []*github.PublicRepository, batchSize int) (batches [][]*github.PublicRepository) {
 	for i := 0; i < len(repos); i += batchSize {
 		end := i + batchSize
 		if end > len(repos) {
@@ -753,7 +753,7 @@ func (s *GitHubSource) listPublic(ctx context.Context, results chan *githubResul
 		// The ListPublicRepositories endpoint returns incomplete information,
 		// so we make additional calls to get the full information of each repo.
 
-		batchedRepos := batchRepos(repos, 30)
+		batchedRepos := batchPublicRepos(repos, 30)
 		for _, batch := range batchedRepos {
 			namesWithOwners := make([]string, 0, len(batch))
 


### PR DESCRIPTION
The repositories returned from [GitHub's public repositories endpoint](https://docs.github.com/en/rest/repos/repos?apiVersion=2022-11-28#list-public-repositories) has a reduced set of fields and has led to bugs in the past.

This PR introduces a dedicated PublicRepository type that prevents us from relying on fields that don't exist.

<!-- PR description tips: https://www.notion.so/sourcegraph/Write-a-good-pull-request-description-610a7fd3e613496eb76f450db5a49b6e -->

## Test plan

This is used only in 1 place so tests should still pass.

<!-- REQUIRED; info at https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles -->

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
