### PR TITLE
remove autocomplete limit from Cody dashboard page

### DIFF
--- a/client/web/src/cody/management/SubscriptionStats.tsx
+++ b/client/web/src/cody/management/SubscriptionStats.tsx
@@ -33,10 +33,8 @@ export const SubscriptionStats: React.FunctionComponent<SubscriptionStatsProps> 
     const stats = usageData?.currentUser
     const codyCurrentPeriodChatLimit = stats?.codyCurrentPeriodChatLimit || 0
     const codyCurrentPeriodChatUsage = stats?.codyCurrentPeriodChatUsage || 0
-    const codyCurrentPeriodCodeLimit = stats?.codyCurrentPeriodCodeLimit || 0
     const codyCurrentPeriodCodeUsage = stats?.codyCurrentPeriodCodeUsage || 0
 
-    const codeLimitReached = codyCurrentPeriodCodeUsage >= codyCurrentPeriodCodeLimit && codyCurrentPeriodCodeLimit > 0
     const chatLimitReached = codyCurrentPeriodChatUsage >= codyCurrentPeriodChatLimit && codyCurrentPeriodChatLimit > 0
     const isUserOnProTier = subscription.plan === CodySubscriptionPlan.PRO
 
@@ -84,40 +82,19 @@ export const SubscriptionStats: React.FunctionComponent<SubscriptionStatsProps> 
             <div className="d-flex flex-column align-items-center justify-content-center p-3">
                 <AutocompletesIcon />
                 <div className="my-2">
-                    {subscription.applyProRateLimits ? (
-                        <Text weight="bold" className={classNames('d-inline mb-0')}>
-                            Unlimited
-                        </Text>
-                    ) : usageData?.currentUser ? (
+                    {usageData?.currentUser ? (
                         <>
-                            <Text
-                                className={classNames('d-inline mb-0', codeLimitReached ? 'text-danger' : 'text-muted')}
-                            >
-                                {Math.min(codyCurrentPeriodCodeUsage, codyCurrentPeriodCodeLimit)} /
-                            </Text>{' '}
-                            <Text
-                                className={classNames('d-inline b-0', codeLimitReached ? 'text-danger' : 'text-muted')}
-                            >
-                                {codyCurrentPeriodCodeLimit}
-                            </Text>
+                            <Text className="d-inline mb-0 text-muted">{codyCurrentPeriodCodeUsage} /</Text>{' '}
+                            <Text className="d-inline b-0 text-muted">unlimited</Text>
                         </>
                     ) : (
                         <LoadingSpinner />
                     )}
                 </div>
-                <H4 className={classNames('mb-0', codeLimitReached ? 'text-danger' : 'text-muted')}>
-                    Autocomplete suggestions
-                </H4>
-                {!subscription.applyProRateLimits &&
-                    (codeLimitReached ? (
-                        <Text className="text-danger mb-0" size="small">
-                            Renews in <Timestamp date={usageRefreshTime} />
-                        </Text>
-                    ) : (
-                        <Text className="text-muted mb-0" size="small">
-                            this month
-                        </Text>
-                    ))}
+                <H4 className="mb-0 text-muted">Autocomplete suggestions</H4>
+                <Text className="text-muted mb-0" size="small">
+                    this month
+                </Text>
             </div>
             <div className="d-flex flex-column align-items-center justify-content-center p-3">
                 <ChatMessagesIcon />

--- a/client/web/src/cody/subscription/queries.tsx
+++ b/client/web/src/cody/subscription/queries.tsx
@@ -23,7 +23,6 @@ export const USER_CODY_USAGE = gql`
             codyCurrentPeriodChatUsage
             codyCurrentPeriodCodeUsage
             codyCurrentPeriodChatLimit
-            codyCurrentPeriodCodeLimit
             codySubscription {
                 status
                 plan

--- a/cmd/frontend/graphqlbackend/user.go
+++ b/cmd/frontend/graphqlbackend/user.go
@@ -279,6 +279,8 @@ func (r *UserResolver) CodyCurrentPeriodCodeLimit(ctx context.Context) (int32, e
 		return 0, errors.New("this feature is only available on sourcegraph.com")
 	}
 
+	// TODO(sqs): This is not enforced anymore as the intent is to give free unlimited autocomplete.
+
 	subscription, err := r.fetchCodySubscription(ctx)
 	if err != nil {
 		return 0, err


### PR DESCRIPTION
We [announced unlimited autocomplete for Cody Free](https://sourcegraph.com/blog/making-cody-free-10x-better), but we still have a very high limit technically that we think virtually nobody will hit outside of abuse. It does not make sense to show a limit, though.

Now it always shows "N / unlimited" to all users. For Cody Free users, it no longer shows a limit. For Cody Pro users, it now shows the actual number of autocompletes they've done this month.

![image](https://github.com/sourcegraph/sourcegraph/assets/1976/5047b5a6-a804-437a-8eb0-9155bc67fc38)


## Test plan

View page and ensure it shows correctly.