### PR TITLE
vsce: patch release v2.2.17

### DIFF
--- a/client/vscode/CHANGELOG.md
+++ b/client/vscode/CHANGELOG.md
@@ -7,6 +7,12 @@ The Sourcegraph extension uses major.EVEN_NUMBER.patch (eg. 2.0.1) for release v
 
 ### Changes
 
+### Fixes
+
+## 2.2.17
+
+### Changes
+
 - Change the extension name from "Sourcegraph" to "Search by
   Sourcegraph" [#51790](https://github.com/sourcegraph/sourcegraph/pull/51790)
 - Remove the URL and Access Token settings because authentication is managed in the extension now. [#63559](https://github.com/sourcegraph/sourcegraph/pull/63559)

--- a/client/vscode/package.json
+++ b/client/vscode/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "@sourcegraph/vscode",
   "displayName": "Search by Sourcegraph",
-  "version": "2.2.15",
+  "version": "2.2.17",
   "description": "Search all of your repositories across all branches and all code hosts",
   "publisher": "sourcegraph",
   "sideEffects": true,


### PR DESCRIPTION
Releasing the Sourcegraph Search VSCode extension

## Test plan

N/A: release
