### PR TITLE
Add SourcegraphModelConfig.AccessToken

### DIFF
--- a/cmd/frontend/internal/modelconfig/siteconfig_completions_test.go
+++ b/cmd/frontend/internal/modelconfig/siteconfig_completions_test.go
@@ -303,7 +303,7 @@ func TestConvertCompletionsConfig(t *testing.T) {
 	})
 
 	t.Run("MaxTokens", func(t *testing.T) {
-		t.Run("Alising", func(t *testing.T) {
+		t.Run("Aliasing", func(t *testing.T) {
 			compConfig := loadCompletionsConfig(schema.Completions{
 				Provider: "sourcegraph",
 

--- a/internal/modelconfig/types/site_config.go
+++ b/internal/modelconfig/types/site_config.go
@@ -20,14 +20,24 @@ type ModelFilters struct {
 // SourcegraphModelConfig is how we represent the configuration of Sourcegraph-supplied
 // LLM models to the Sourcegraph instance.
 type SourcegraphModelConfig struct {
+	// Endpoint is the Cody Gateway URL. This is used for two things: (1) Sending API requests
+	// if the Provider is configured to use the `SourcegraphProviderConfig`. (That is, the
+	// provider will use Cody Gateway for serving LLM requests.) And (2) if `PollingInterval`
+	// is set, this endpoint will be used to automatically pick up new LLM models from Cody
+	// Gateway as they get released.
+	Endpoint *string `json:"endpoint"`
+
+	// AccessToken is the access token this Sourcegraph instance should use when contacting
+	// Cody Gateway. If not set, a token will be generated automatically based on the site
+	// configuration's license key.
+	//
+	// See `conf/computed.go`'s `getSourcegraphProviderAccessToken`.
+	AccessToken *string `json:"accessToken"`
 
 	// PollingInterval is the frequency by which this instance should poll Cody Gateway
 	// for an updated list of LLM models. e.g. "6h" or "1d". Or "never" to disable this
 	// capability entirely.
 	PollingInterval *string `json:"pollingInterval"`
-	// Endpoint is the Cody Gateway URL that will be polled in order to pick up new
-	// LLM models as they are released..
-	Endpoint *string `json:"endpoint"`
 
 	// ModelFilters provide a way for the Sourcegraph admin to constrain the set of
 	// LLM models made available, e.g. to only "stable" models. Or those from


### PR DESCRIPTION
Fixes a small design oversight when creating the `SourcegraphModelConfig`.

The `SourcegraphModelConfig` type contains all the configuration knobs for a Sourcegraph admin to control how the "Sourcegraph-supplied LLM models" should be used. For example:

- If set to `null`, then Sourcegraph will not provide any LLM models for the instance. And only the admin-supplied providers and models will be used.
- It can be configured to poll Cody Gateway to automatically include "new models" so they can be made available to users of the instance as soon as they are served from Cody Gateway.

However, there's something that is lost in translation between "site admin configuring how LLM models get picked up" and "generating the `types.ModelConfiguration` data structure needed at runtime".

In order to actually _use_ Cody Gateway at runtime, the Completions Provider needs to know the URL endpoint and access token for Cody Gateway. This is made available via the `types.Provider.ServerSideConfig.SourcegraphProvider` field. (So when creating the "google" completions provider, that's how we know to send the request to Cody Gateway, etc.)

But with the data type we have right now, this data is missing.

With the current way you can configure Cody Enterprise, the `accessToken` field is optional. Because when we load the configuration, the Sourcegraph instance will automatically create a new access token based on the license key.

But as we transition to the new-style configuration data, we will no longer be able to rely on `CompletionsConfig.AccessToken`.

So specifically:

1. We need to add this field to the `types.SourcegraphModelConfig` config data type, so that when we are building the `types.ModelConfiguration` we know how to create the provider information to contact Cody Gateway as needed.
2. We can make this optional or remove it completely in how the Sourcegraph admin "enters/encodes" the `types.SourcegraphModelConfig` in their Site configuration data.  (And continue to just generate a token based on the license key.)

```go
// conf/computed.go
func getSourcegraphProviderAccessToken(accessToken string, config schema.SiteConfiguration) string {
	// If an access token is configured, use it.
	if accessToken != "" {
		return accessToken
	}

	// Otherwise, use the current license key to compute an access token.
	if config.LicenseKey == "" {
		return ""
	}

	return license.GenerateLicenseKeyBasedAccessToken(config.LicenseKey)
}
```

## Test plan

NA

## Changelog

NA