### PR TITLE
Pick up CompletionsConfig.User for the AzureOpenAI API Provider

### DIFF
--- a/cmd/frontend/internal/modelconfig/siteconfig_completions.go
+++ b/cmd/frontend/internal/modelconfig/siteconfig_completions.go
@@ -149,6 +149,7 @@ func getProviderConfiguration(siteConfig *conftypes.CompletionsConfig) *types.Se
 			AccessToken: siteConfig.AccessToken,
 			Endpoint:    siteConfig.Endpoint,
 
+			User:                        siteConfig.User,
 			UseDeprecatedCompletionsAPI: siteConfig.AzureUseDeprecatedCompletionsAPIForOldModels,
 		}
 	case conftypes.CompletionsProviderNameSourcegraph:

--- a/cmd/frontend/internal/modelconfig/siteconfig_completions_test.go
+++ b/cmd/frontend/internal/modelconfig/siteconfig_completions_test.go
@@ -245,6 +245,7 @@ func TestConvertCompletionsConfig(t *testing.T) {
 				AzureChatModel:       "gpt-3.5",
 				AzureCompletionModel: "gpt-4o",
 
+				User: "steve holt",
 				AzureUseDeprecatedCompletionsAPIForOldModels: true,
 			})
 			require.NotNil(t, compConfig)
@@ -268,6 +269,7 @@ func TestConvertCompletionsConfig(t *testing.T) {
 			require.NotNil(t, azureProviderConfig)
 			assert.Equal(t, "https://azure-openai.azure.com", azureProviderConfig.Endpoint)
 			assert.Equal(t, "azure-portal-api-key", azureProviderConfig.AccessToken)
+			assert.Equal(t, "steve holt", azureProviderConfig.User)
 			assert.True(t, azureProviderConfig.UseDeprecatedCompletionsAPI)
 
 			// ModelOverrides

--- a/internal/modelconfig/types/configuration.go
+++ b/internal/modelconfig/types/configuration.go
@@ -37,6 +37,8 @@ type AzureOpenAIProviderConfig struct {
 	// From the Azure OpenAI Service portal.
 	Endpoint string `json:"endpoint"`
 
+	// The user field passed along to OpenAI-provided models.
+	User string
 	// Enables the use of the older completions API for select Azure OpenAI models. This is just an escape hatch
 	// for backwards compatibility, because not all Azure OpenAI models are available on the "newer" completions API.
 	//

--- a/internal/modelconfig/types/configuration.go
+++ b/internal/modelconfig/types/configuration.go
@@ -38,12 +38,12 @@ type AzureOpenAIProviderConfig struct {
 	Endpoint string `json:"endpoint"`
 
 	// The user field passed along to OpenAI-provided models.
-	User string
+	User string `json:"user"`
 	// Enables the use of the older completions API for select Azure OpenAI models. This is just an escape hatch
 	// for backwards compatibility, because not all Azure OpenAI models are available on the "newer" completions API.
 	//
 	// Moving forward, this information should be encoded in the ModelRef's APIVersionID instead.
-	UseDeprecatedCompletionsAPI bool
+	UseDeprecatedCompletionsAPI bool `json:"useDeprecatedCompletionsApi"`
 }
 
 // GenericProvider is the generic format that older Sourcegraph instances used.


### PR DESCRIPTION
This PR fixes a small oversight when we convert the site config's "completions" configuration data into the `modelconfig/types.SiteModelConfig` object.

PR https://github.com/sourcegraph/sourcegraph/commit/8e37fcac2632692e430f6b53722a99528df6902a#diff-3c40fc45ac5714fdcbcfb874321044afe3ef449134adcf519d4fba5b966cf18fR71 added a new `User` field to the site configuration, which is used by the Azure OpenAI API provider.

So this piece of data needs to be put into the `internal/modelconfig/types.AzureOpenAIProviderConfig` field so it can available when we refactor the `internal/completions/client/azureopenai` package.
Since rather than pulling this information from the `internal/completions.CompletionRequestParameters::User` we will instead pass the `internal/modelconfig/types.AzureOpenAIProviderConfig` object, which will have all the Azure OpenAI-specific server-side configuration.

## Test plan

NA

## Changelog

NA