### PR TITLE
Svelte: use newly-baseline popover API for tooltips

### DIFF
--- a/client/web-sveltekit/src/lib/Tooltip.svelte
+++ b/client/web-sveltekit/src/lib/Tooltip.svelte
@@ -5,7 +5,7 @@
 </script>
 
 <script lang="ts">
-    import { popover, portal, uniqueID } from './dom'
+    import { popover, uniqueID } from './dom'
 
     /**
      * The content of the tooltip.
@@ -23,16 +23,16 @@
 
     const id = uniqueID('tooltip')
 
-    let visible = false
     let wrapper: HTMLElement | null
     let target: Element | null
+    let popoverElement: HTMLElement | null
 
     function show() {
-        visible = true
+        popoverElement?.showPopover()
     }
 
     function hide() {
-        visible = false
+        popoverElement?.hidePopover()
     }
 
     $: options = {
@@ -67,7 +67,6 @@
     svelte-ignore a11y-no-static-element-interactions
 -->
 <div
-    class="wrapper"
     bind:this={wrapper}
     on:mouseenter={show}
     on:mouseleave={hide}
@@ -77,19 +76,25 @@
 >
     <slot />
 </div>
-{#if (alwaysVisible || visible) && target && tooltip}
-    <div role="tooltip" {id} use:popover={{ reference: target, options }} use:portal>
+{#if target && tooltip}
+    <div
+        class:always-visible={alwaysVisible}
+        bind:this={popoverElement}
+        popover="manual"
+        {id}
+        use:popover={{ reference: target, options }}
+    >
         <div class="content">{tooltip}</div>
         <div data-arrow />
     </div>
 {/if}
 
 <style lang="scss">
-    .wrapper {
+    [data-tooltip-root] {
         display: contents;
     }
 
-    [role='tooltip'] {
+    [popover] {
         --tooltip-font-size: 0.75rem; // 12px
         --tooltip-line-height: 1.02rem; // 16.32px / 16px, per Figma
         --tooltip-max-width: 256px;
@@ -103,9 +108,11 @@
         --tooltip-arrow-main: 8px solid var(--tooltip-bg);
 
         all: initial;
+        &:not(:popover-open):not(.always-visible) {
+            display: none;
+        }
         position: absolute;
         isolation: isolate;
-        z-index: 1;
         font-family: inherit;
         font-size: var(--tooltip-font-size);
         font-style: normal;


### PR DESCRIPTION
The [popover API](https://developer.mozilla.org/en-US/docs/Web/API/Popover_API) is newly a part of basline 2024, meaning it's now widely supported across all major browsers. Comments inline for what this gives us.

## Test plan

<!-- REQUIRED; info at https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles -->

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
