### PR TITLE
Fix annoying consistency

### DIFF
--- a/internal/completions/client/azureopenai/openai.go
+++ b/internal/completions/client/azureopenai/openai.go
@@ -111,10 +111,10 @@ func getCredentialOptions() (*azidentity.DefaultAzureCredentialOptions, error) {
 
 }
 
-type GetCompletionsAPIClientFunc func(accessToken, endpoint string) (CompletionsClient, error)
+type GetCompletionsAPIClientFunc func(endpoint, accessToken string) (CompletionsClient, error)
 
-func NewClient(getClient GetCompletionsAPIClientFunc, accessToken, endpoint string, tokenizer tokenusage.Manager) (types.CompletionsClient, error) {
-	client, err := getClient(accessToken, endpoint)
+func NewClient(getClient GetCompletionsAPIClientFunc, endpoint, accessToken string, tokenizer tokenusage.Manager) (types.CompletionsClient, error) {
+	client, err := getClient(endpoint, accessToken)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/completions/client/client.go
+++ b/internal/completions/client/client.go
@@ -42,7 +42,7 @@ func getBasic(endpoint string, provider conftypes.CompletionsProviderName, acces
 	case conftypes.CompletionsProviderNameAzureOpenAI:
 		return azureopenai.NewClient(azureopenai.GetAPIClient, endpoint, accessToken, *tokenManager)
 	case conftypes.CompletionsProviderNameGoogle:
-		return google.NewClient(httpcli.UncachedExternalDoer, endpoint, accessToken, false)
+		return google.NewClient(httpcli.UncachedExternalDoer, endpoint, accessToken, false /* via gateway */)
 	case conftypes.CompletionsProviderNameSourcegraph:
 		return codygateway.NewClient(httpcli.CodyGatewayDoer, endpoint, accessToken, *tokenManager)
 	case conftypes.CompletionsProviderNameFireworks:


### PR DESCRIPTION
Fix an annoying inconsistency. There isn't a functional change here, but it's confusing and error prone enough that we need to make this fix.

`internal/completions/client/azureopenai/openai.go` exposes this function:

https://github.com/sourcegraph/sourcegraph/blob/da5968ba1ef1be0307a88b78ccb621a4ff1bef9f/internal/completions/client/azureopenai/openai.go#L116

Note the order of the parameters: `accessToken` and then `endpoint`.

This is where it is called. Notice the order of parameters `endpoint` and then `accessToken`.

https://github.com/sourcegraph/sourcegraph/blob/da5968ba1ef1be0307a88b78ccb621a4ff1bef9f/internal/completions/client/client.go#L40-L41

⚠️ So this is a bug, right?!? Due to some copy and paste error we're passing an access token to the parameter slot that should be an endpoint.

But there is another layer of indirection, the `type GetCompletionsAPIClientFunc func(accessToken, endpoint string) (CompletionsClient, error)`. But this too has the parameters as `accessToken` and then `endpoint`.

But if you go to the actual implementation of that function `azureopenai.GetAPIClient`, defined here:
https://github.com/sourcegraph/sourcegraph/blob/da5968ba1ef1be0307a88b78ccb621a4ff1bef9f/internal/completions/client/azureopenai/openai.go#L57

You see that the first parameter is actually `endpoint` and then `accessToken`.

... and that's why things are totally working just fine. The reality is that the first parameter should-be-and-is `endpoint` and the second parameter should-be-and-is `accessToken`. But within `func NewClient` and `type GetCompletionsAPIClientFunc` these are mislabeled.

## Test plan

NA

## Changelog

NA