### PR TITLE
Add GenericProviderConfig.ServiceName

### DIFF
--- a/cmd/frontend/internal/modelconfig/siteconfig_completions.go
+++ b/cmd/frontend/internal/modelconfig/siteconfig_completions.go
@@ -163,6 +163,7 @@ func getProviderConfiguration(siteConfig *conftypes.CompletionsConfig) *types.Se
 		// We'll add those when needed, when we expose the newer style configuration in the site-config.
 	default:
 		serverSideConfig.GenericProvider = &types.GenericProviderConfig{
+			ServiceName: types.GenericServiceProvider(siteConfig.Provider),
 			AccessToken: siteConfig.AccessToken,
 			Endpoint:    siteConfig.Endpoint,
 		}

--- a/internal/modelconfig/types/configuration.go
+++ b/internal/modelconfig/types/configuration.go
@@ -43,17 +43,31 @@ type AzureOpenAIProviderConfig struct {
 	// for backwards compatibility, because not all Azure OpenAI models are available on the "newer" completions API.
 	//
 	// Moving forward, this information should be encoded in the ModelRef's APIVersionID instead.
-	UseDeprecatedCompletionsAPI bool `json:"useDeprecatedCompletionsApi"`
+	UseDeprecatedCompletionsAPI bool
 }
 
-// GenericProvider is the generic format that older Sourcegraph instances used.
+// GenericServiceProvider is an enum for describing the API provider to use
+// for a GenericProviderConfig. These should generally be a subset of what
+// is available via site config, `conftypes.CompletionsProviderName`.
+type GenericServiceProvider string
+
+const (
+	GenericServiceProviderAnthropic GenericServiceProvider = "anthropic"
+	GenericServiceProviderFireworks GenericServiceProvider = "fireworks"
+	GenericServiceProviderGoogle    GenericServiceProvider = "google"
+	GenericServiceProviderOpenAI    GenericServiceProvider = "openai"
+)
+
+// GenericProvider just bundles the bare-bones information needed to describe a 3rd party API.
 //
-// Try to avoid using this where possible, and instead rely on the more specific
-// types like `AzureOpenAIProviderConfig`. Even if they only contain the same fields.
-// This allows us to more gracefully migrate customers forward as the API providers
-// and associated API clients evolve. e.g. giving us the possibility of providing
-// defaults for any missing configuration settings that get added later.
+// You should NEVER add new fields to this. Instead, if we wish to expose some provider-specific
+// configuration knob please introduce a new data type specific to that provider. (Rather than
+// adding a field to GenericProviderConfig that will not be applicable or ignored in some cases.)
 type GenericProviderConfig struct {
+	// ServiceName is the name of the LLM model provider or service that this generic provider
+	// config applies to.
+	ServiceName GenericServiceProvider `json:"serviceName"`
+
 	AccessToken string `json:"accessToken"`
 	Endpoint    string `json:"endpoint"`
 }

--- a/internal/modelconfig/validation.go
+++ b/internal/modelconfig/validation.go
@@ -41,6 +41,18 @@ func validateProvider(p types.Provider) error {
 	// data here, as it isn't clear if that is even a good idea
 	// in the first place. (e.g. we may not know the exact format
 	// of some 3rd party provider's configuration knob.)
+
+	// But there are some cases which are just too error prone to let slide...
+	if ssCfg := p.ServerSideConfig; ssCfg != nil {
+		// If using the "GenericProvider", we need to know the actual shape of the HTTP request
+		// to send!
+		if genCfg := ssCfg.GenericProvider; genCfg != nil {
+			if genCfg.ServiceName == "" {
+				return errors.New("no service name set for generic provider")
+			}
+		}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
While trying to use the `types.ModelConfiguration` data to configure completion providers, it became clear I missed something.

We expose the `types.GenericProviderConfig` as a bare-bones way to express LLM provider configuration, and it does great. But just knowing the (endpoint, access token) isn't enough to actually serve requests.

We need to know the _shape_ of API requests. e.g. if we should pass that endpoint/access to an OpenAI-compatible, Fireworks-compatible, or Google-compatible API provider.

> NOTE: An alternative approach would be to not add this field to `GenericProviderConfig` entirely, and instead add `AnthropicProvider *GenericProviderConfig`, `GoogleProvider *GenericProviderConfig`, etc. to the `ServerSideProviderConfig`. And essentially have the "service name" be implicit based on which field of `ServerSideProviderConfig` you found the object.
>
> There are advantages to that approach, but this seemed a bit cleaner IMHO. WDYT?

## Test plan

Added new unit tests

## Changelog

NA