### PR TITLE
Add more descriptive logging for autocompletion failures

### DIFF
--- a/internal/completions/client/fireworks/fireworks.go
+++ b/internal/completions/client/fireworks/fireworks.go
@@ -190,7 +190,11 @@ func (c *fireworksClient) makeRequest(ctx context.Context, feature types.Complet
 		// in the first and only message
 		prompt, promptErr := getPrompt(requestParams.Messages)
 		if promptErr != nil {
-			return nil, promptErr
+			requestParamsJSON, jsonErr := json.Marshal(requestParams)
+			if jsonErr != nil {
+				return nil, errors.Wrap(jsonErr, "failed to marshal requestParams to JSON")
+			}
+			return nil, errors.Wrapf(promptErr, "failed to get prompt. requestParams: %s", string(requestParamsJSON))
 		}
 
 		payload := fireworksRequest{

--- a/internal/completions/client/fireworks/prompt.go
+++ b/internal/completions/client/fireworks/prompt.go
@@ -7,7 +7,7 @@ import (
 
 func getPrompt(messages []types.Message) (string, error) {
 	if len(messages) != 1 {
-		return "", errors.New("Expected to receive exactly one message with the prompt")
+		return "", errors.Errorf("expected to receive exactly one message with the prompt (got %d)", len(messages))
 	}
 
 	prompt := messages[0].Text


### PR DESCRIPTION
# UPDATE: Nevermind, bug source was found - I'd still like to know if there is a current testing procedure though, please let me know!

## Description

Gather info for [this cody issue](https://github.com/sourcegraph/cody/issues/4639).

Error message traced to either azureopenai getPrompt() or fireworks getPrompt(). The method fails due to malformed request, hoping to gather for info as there could be many reasons why.

## Testing

THIS IS UNTESTED! Please point me to the current testing procedure/expectations if there is one, thanks!


- I attempted to utilize the sg dev tool, it was not found with the documented curl

- Also attempted to run local tests as described [here](https://docs-legacy.sourcegraph.com/dev/contributing/frontend_contribution), but that seemed to be out of date as well.