### PR TITLE
Documents that usages are first bucketed by provenance

### DIFF
--- a/cmd/frontend/graphqlbackend/codeintel.codenav.graphql
+++ b/cmd/frontend/graphqlbackend/codeintel.codenav.graphql
@@ -452,8 +452,9 @@ extend type Query {
     by a source range.
     Ordering and uniqueness guarantees:
     1. The usages returned will already be de-duplicated.
-    2. Results for a single file are contiguous.
+    2. Results are first grouped by provenance in the order precise, syntactic, then search-based.
     3. Results for a single repository are contiguous.
+    4. Results for a single file are contiguous.
     Related: See `codeGraphData` on GitBlob.
 
     EXPERIMENTAL: This API may make backwards-incompatible changes in the future.


### PR DESCRIPTION
Tried to structure the ordering guarantees as the cascade they form
1. Provenance
2. Repository
3. File

(Or would we group by repository first and then provenance?)

## Test plan

N/A