### PR TITLE
fix(batches): display failure alert depending on github app kind

### DIFF
--- a/client/web/src/enterprise/batches/settings/CommitSigningIntegrations.tsx
+++ b/client/web/src/enterprise/batches/settings/CommitSigningIntegrations.tsx
@@ -16,11 +16,12 @@ import {
     SummaryContainer,
 } from '../../../components/FilteredConnection/ui'
 import { GitHubAppFailureAlert } from '../../../components/gitHubApps/GitHubAppFailureAlert'
-import type {
-    BatchChangesCodeHostFields,
-    GlobalBatchChangesCodeHostsResult,
-    Scalars,
-    UserBatchChangesCodeHostsResult,
+import {
+    type BatchChangesCodeHostFields,
+    GitHubAppKind,
+    type GlobalBatchChangesCodeHostsResult,
+    type Scalars,
+    type UserBatchChangesCodeHostsResult,
 } from '../../../graphql-operations'
 
 import { useGlobalBatchChangesCodeHostConnection, useUserBatchChangesCodeHostConnection } from './backend'
@@ -54,9 +55,12 @@ export const CommitSigningIntegrations: React.FunctionComponent<
     const { loading, hasNextPage, fetchMore, connection, error, refetchAll } = connectionResult
 
     const location = useLocation()
-    const success = new URLSearchParams(location.search).get('success') === 'true'
-    const appName = new URLSearchParams(location.search).get('app_name')
-    const setupError = new URLSearchParams(location.search).get('error')
+    const searchParams = new URLSearchParams(location.search)
+    const kind = searchParams.get('kind')
+    const success = searchParams.get('success') === 'true'
+    const appName = searchParams.get('app_name')
+    const setupError = searchParams.get('error')
+    const shouldShowError = !success && setupError && !readOnly && kind === GitHubAppKind.COMMIT_SIGNING
     return (
         <Container>
             <H3>
@@ -85,7 +89,7 @@ export const CommitSigningIntegrations: React.FunctionComponent<
                         GitHub App {appName?.length ? `"${appName}" ` : ''}successfully connected.
                     </DismissibleAlert>
                 )}
-                {!success && setupError && !readOnly && <GitHubAppFailureAlert error={setupError} />}
+                {shouldShowError && <GitHubAppFailureAlert error={setupError} />}
                 <ConnectionList as="ul" className="list-group" aria-label="commit signing integrations">
                     {connection?.nodes?.map(node =>
                         node.supportsCommitSigning ? (


### PR DESCRIPTION
The Github failure alert shows up for non-commit signing failures, it should only show up when the kind is `COMMIT_SIGNING`

## Test plan

<!-- REQUIRED; info at https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles -->

Manual testing.

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
