### PR TITLE
Fix the scheduling interval for syntactic indexing

### DIFF
--- a/cmd/worker/shared/BUILD.bazel
+++ b/cmd/worker/shared/BUILD.bazel
@@ -43,6 +43,7 @@ go_library(
         "//internal/authz",
         "//internal/authz/providers",
         "//internal/authz/subrepoperms",
+        "//internal/codeintel/syntactic_indexing",
         "//internal/conf",
         "//internal/database",
         "//internal/debugserver",

--- a/cmd/worker/shared/main.go
+++ b/cmd/worker/shared/main.go
@@ -43,6 +43,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/authz/providers"
 	srp "github.com/sourcegraph/sourcegraph/internal/authz/subrepoperms"
+	"github.com/sourcegraph/sourcegraph/internal/codeintel/syntactic_indexing"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/encryption/keyring"
@@ -117,7 +118,7 @@ func LoadConfig(registerEnterpriseMigrators oobmigration.RegisterMigratorsFunc) 
 		"codeintel-uploadstore-expirer":               codeintel.NewPreciseCodeIntelUploadExpirer(),
 		"codeintel-package-filter-applicator":         codeintel.NewPackagesFilterApplicatorJob(),
 
-		//"codeintel-syntactic-indexing-scheduler": syntactic_indexing.NewSyntacticindexingSchedulerJob(),
+		"codeintel-syntactic-indexing-scheduler": syntactic_indexing.NewSyntacticindexingSchedulerJob(),
 
 		"auth-sourcegraph-operator-cleaner": auth.NewSourcegraphOperatorCleaner(),
 

--- a/internal/codeintel/syntactic_indexing/scheduler_config.go
+++ b/internal/codeintel/syntactic_indexing/scheduler_config.go
@@ -21,8 +21,11 @@ func (c *SchedulerConfig) Load() {
 	repositoryBatchSizeName := env.ChooseFallbackVariableName("CODEINTEL_SYNTACTIC_INDEXING_SCHEDULER_REPOSITORY_BATCH_SIZE")
 	policyBatchSizeName := env.ChooseFallbackVariableName("CODEINTEL_SYNTACTIC_INDEXING_SCHEDULER_POLICY_BATCH_SIZE")
 
-	c.SchedulerInterval = c.GetInterval(intervalName, "2m", "How frequently to run the auto-indexing scheduling routine.")
-	c.RepositoryProcessDelay = c.GetInterval(repositoryProcessDelayName, "24h", "The minimum frequency that the same repository can be considered for auto-index scheduling.")
-	c.RepositoryBatchSize = c.GetInt(repositoryBatchSizeName, "2500", "The number of repositories to consider for auto-indexing scheduling at a time.")
-	c.PolicyBatchSize = c.GetInt(policyBatchSizeName, "100", "The number of policies to consider for auto-indexing scheduling at a time.")
+	c.SchedulerInterval = c.GetInterval(intervalName, "2m", "How frequently to run syntactic indexing scheduling routine.")
+	c.RepositoryProcessDelay = c.GetInterval(repositoryProcessDelayName, "24h",
+		"The minimum frequency that the same repository can be considered for syntactic index scheduling.")
+	c.RepositoryBatchSize = c.GetInt(repositoryBatchSizeName, "2500",
+		"The number of repositories to consider for syntactic indexing scheduling at a time.")
+	c.PolicyBatchSize = c.GetInt(policyBatchSizeName, "100",
+		"The number of policies to consider for syntactic indexing scheduling at a time.")
 }

--- a/internal/codeintel/syntactic_indexing/scheduler_job.go
+++ b/internal/codeintel/syntactic_indexing/scheduler_job.go
@@ -26,7 +26,7 @@ func NewSyntacticindexingSchedulerJob() job.Job {
 }
 
 func (job *syntacticIndexingSchedulerJob) Description() string {
-	return ""
+	return "Scheduler job for codeintel syntactic indexing"
 }
 
 func (job *syntacticIndexingSchedulerJob) Config() []env.Config {

--- a/internal/codeintel/syntactic_indexing/scheduler_job.go
+++ b/internal/codeintel/syntactic_indexing/scheduler_job.go
@@ -84,13 +84,12 @@ func newSchedulerJob(
 			if config != nil && config.CodeintelSyntacticIndexingEnabled {
 				return scheduler.Schedule(observationCtx, ctx, time.Now())
 			} else {
-				observationCtx.Logger.Info("Syntactic indexing is disabled")
 				return nil
 			}
 		}),
 		goroutine.WithName("codeintel.syntactic-indexing-background-scheduler"),
 		goroutine.WithDescription("schedule syntactic indexing jobs in the background"),
-		goroutine.WithInterval(time.Second*5),
+		goroutine.WithInterval(schedulerConfig.SchedulerInterval),
 		goroutine.WithOperation(observationCtx.Operation(observation.Op{
 			Name:              "codeintel.syntactic_indexing.HandleIndexSchedule",
 			MetricLabelValues: []string{"HandleIndexSchedule"},


### PR DESCRIPTION
Fixes GRAPH-648 (hopefully)

The scheduler interval for syntactic indexing job was incorrect. 
I'm only assuming this will help – Robert suggested deploying this and testing, as from the cursory glance at the code it shouldn't produce _any_ metrics apart from the invocation count, because the feature is disabled on dotcom

<!-- PR description tips: https://www.notion.so/sourcegraph/Write-a-good-pull-request-description-610a7fd3e613496eb76f450db5a49b6e -->

## Test plan

- N/A
- We test in production 😎 

<!-- REQUIRED; info at https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles -->

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
