### PR TITLE
Add ModelRef.APIVersionID()

### DIFF
--- a/internal/modelconfig/types/refs.go
+++ b/internal/modelconfig/types/refs.go
@@ -33,3 +33,13 @@ func (mref ModelRef) ProviderID() ProviderID {
 	}
 	return ProviderID(string(mref)[:firstSep])
 }
+
+// Assuming the ModelRef is valid, returns the APIVersionID.
+// Will return junk data if the ModelRef is invalid.
+func (mref ModelRef) APIVersionID() APIVersionID {
+	parts := strings.Split(string(mref), "::")
+	if len(parts) != 3 {
+		return "error-invalid-modelref"
+	}
+	return APIVersionID(parts[1])
+}

--- a/internal/modelconfig/types/refs_test.go
+++ b/internal/modelconfig/types/refs_test.go
@@ -10,6 +10,7 @@ func TestModelRef(t *testing.T) {
 	t.Run("WellFormed", func(t *testing.T) {
 		testMRef := ModelRef("foo::bar::baz")
 		assert.EqualValues(t, "foo", testMRef.ProviderID())
+		assert.EqualValues(t, "bar", testMRef.APIVersionID())
 		assert.EqualValues(t, "baz", testMRef.ModelID())
 	})
 
@@ -19,6 +20,7 @@ func TestModelRef(t *testing.T) {
 	t.Run("Malformed", func(t *testing.T) {
 		oldStyleMRef := ModelRef("foo/baz")
 		assert.EqualValues(t, "error-invalid-modelref", oldStyleMRef.ProviderID())
+		assert.EqualValues(t, "error-invalid-modelref", oldStyleMRef.APIVersionID())
 		assert.EqualValues(t, "error-invalid-modelref", oldStyleMRef.ModelID())
 	})
 }

--- a/internal/modelconfig/validation.go
+++ b/internal/modelconfig/validation.go
@@ -53,6 +53,14 @@ func validateProvider(p types.Provider) error {
 		}
 	}
 
+	// BUG: We should verify the at the provider contains _some_
+	// server-side config. Since otherwise the provider cannot actually
+	// be used. However, we don't expect the Provider data exposed from
+	// the embedded binary or Cody Gateway to actually contain that
+	// server-side config because it doesn't make sense. So part of the
+	// rendering of data needs to fall back to using the Sourcegraph
+	// instance and its access token, etc.
+
 	return nil
 }
 


### PR DESCRIPTION
The `ModelRef` encodes three pieces of information to represent the unique identity of the model. So far, we've only needed to pull out the `ProviderID` and `ModelID`. But now that I'm working on reading this data for the completion APIs, it's time to add the `APIVersionID` function too.

Note that these functions should really return an `(string, error)` since it's possible the `ModelRef` they are operating on is invalid. But as-is things will explode loudly enough it won't be too difficult to detect, and leaving the function return type as `string` makes it _much_ easier to use.

I also added a comment about something I'll address when I get to adding support for fetching new models dynamically from Cody Gateway. Right now there is a validation check that probably should exist but doesn't, and we cannot add it just yet.

## Test plan

Added unit tests.

## Changelog

NA