### PR TITLE
chore: Make return type more obvious

### DIFF
--- a/internal/database/sub_repo_perms_store.go
+++ b/internal/database/sub_repo_perms_store.go
@@ -18,19 +18,6 @@ import (
 // and exclude patterns.
 const SubRepoPermsVersion = 1
 
-var (
-	SubRepoSupportedCodeHostTypes = []string{extsvc.TypePerforce}
-	supportedTypesQuery           = make([]*sqlf.Query, len(SubRepoSupportedCodeHostTypes))
-)
-
-func init() {
-	// Build this up at startup, so we don't need to rebuild it every time
-	// RepoSupported is called
-	for i, hostType := range SubRepoSupportedCodeHostTypes {
-		supportedTypesQuery[i] = sqlf.Sprintf("%s", hostType)
-	}
-}
-
 type SubRepoPermsStore interface {
 	basestore.ShareableStore
 	With(other basestore.ShareableStore) SubRepoPermsStore
@@ -471,9 +458,9 @@ SELECT
 FROM repo
 WHERE id = %s
 AND private = TRUE
-AND external_service_type IN (%s)
+AND external_service_type = %s
 )
-`, repoID, sqlf.Join(supportedTypesQuery, ","))
+`, repoID, extsvc.TypePerforce)
 
 	exists, _, err := basestore.ScanFirstBool(s.Query(ctx, q))
 	if err != nil {
@@ -491,9 +478,9 @@ SELECT
 FROM repo
 WHERE name = %s
 AND private = TRUE
-AND external_service_type IN (%s)
+AND external_service_type = %s
 )
-`, repo, sqlf.Join(supportedTypesQuery, ","))
+`, repo, extsvc.TypePerforce)
 
 	exists, _, err := basestore.ScanFirstBool(s.Query(ctx, q))
 	if err != nil {

--- a/internal/diskcache/cache.go
+++ b/internal/diskcache/cache.go
@@ -80,15 +80,15 @@ func NewStore(dir, component string, opts ...StoreOpt) Store {
 
 type StoreOpt func(*store)
 
-func WithBackgroundTimeout(t time.Duration) func(*store) {
+func WithBackgroundTimeout(t time.Duration) StoreOpt {
 	return func(s *store) { s.backgroundTimeout = t }
 }
 
-func WithBeforeEvict(f func(string, observation.TraceLogger)) func(*store) {
+func WithBeforeEvict(f func(string, observation.TraceLogger)) StoreOpt {
 	return func(s *store) { s.beforeEvict = f }
 }
 
-func WithobservationCtx(ctx *observation.Context) func(*store) {
+func WithobservationCtx(ctx *observation.Context) StoreOpt {
 	return func(s *store) { s.observe = newOperations(ctx, s.component) }
 }
 


### PR DESCRIPTION
These functions return StoreOpts, but that wasn't immediately clear, so adding this small tweak here.

Test plan: Ci passes.