### PR TITLE
add new "modelConfiguration" schema to site config

### DIFF
--- a/internal/modelconfig/types/configuration.go
+++ b/internal/modelconfig/types/configuration.go
@@ -43,7 +43,7 @@ type AzureOpenAIProviderConfig struct {
 	// for backwards compatibility, because not all Azure OpenAI models are available on the "newer" completions API.
 	//
 	// Moving forward, this information should be encoded in the ModelRef's APIVersionID instead.
-	UseDeprecatedCompletionsAPI bool
+	UseDeprecatedCompletionsAPI bool `json:"useDeprecatedCompletionsAPI"`
 }
 
 // GenericServiceProvider is an enum for describing the API provider to use

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -594,8 +594,12 @@ type ChangesetTemplate struct {
 	// Title description: The title of the changeset.
 	Title string `json:"title"`
 }
+
+// ClientSideModelConfig description: No client-side model configuration is currently available.
 type ClientSideModelConfig struct {
 }
+
+// ClientSideProviderConfig description: No client-side provider configuration is currently available.
 type ClientSideProviderConfig struct {
 }
 
@@ -764,7 +768,6 @@ type DefaultModelConfig struct {
 	ContextWindow    ContextWindow          `json:"contextWindow"`
 	ServerSideConfig *ServerSideModelConfig `json:"serverSideConfig,omitempty"`
 	Status           string                 `json:"status"`
-	Tier             string                 `json:"tier,omitempty"`
 }
 type DefaultModels struct {
 	// Chat description: The qualified name of the model to use for chat, in '${ProviderID}::${APIVersionID}::${ModelID}' format
@@ -1699,7 +1702,7 @@ type ModelFilters struct {
 	Allow []string `json:"allow,omitempty"`
 	// Deny description: Any models in this deny list will not be allowed. Wildcards may be used here, but not regexp.
 	Deny []string `json:"deny,omitempty"`
-	// StatusFilter description: Constrain models to just those in this list
+	// StatusFilter description: Constrain models to just those matching one of the supplied statuses
 	StatusFilter []string `json:"statusFilter,omitempty"`
 }
 type ModelOverride struct {
@@ -1710,13 +1713,12 @@ type ModelOverride struct {
 	ContextWindow    ContextWindow          `json:"contextWindow"`
 	// DisplayName description: display name
 	DisplayName string `json:"displayName"`
-	// ModelName description: model name
+	// ModelName description: model name used when sending requests to the LLM provider's backend API.
 	ModelName string `json:"modelName"`
 	// ModelRef description: The qualified name of the model in '${ProviderID}::${APIVersionID}::${ModelID}' format
 	ModelRef         string                 `json:"modelRef"`
 	ServerSideConfig *ServerSideModelConfig `json:"serverSideConfig,omitempty"`
 	Status           string                 `json:"status"`
-	Tier             string                 `json:"tier,omitempty"`
 }
 type Mount struct {
 	// Mountpoint description: The path in the container to mount the path on the local machine to.
@@ -3401,11 +3403,11 @@ type SiteModelConfiguration struct {
 	Sourcegraph       *SourcegraphModelConfig `json:"sourcegraph,omitempty"`
 }
 
-// SourcegraphModelConfig description: If null, Cody will not use Sourcegraph's servers for model discovery or LLM requests.
+// SourcegraphModelConfig description: If null, Cody will not use Sourcegraph's servers for model discovery.
 type SourcegraphModelConfig struct {
 	// AccessToken description: The Cody gateway access token to use. If null, an access token will be automatically generated based on the product license.
 	AccessToken *string `json:"accessToken,omitempty"`
-	// Endpoint description: The Cody gateway URL to use for making LLM requests and discovering new LLM models. If null, a good default URL will be used.
+	// Endpoint description: The Cody gateway URL to use for making LLM requests and discovering new LLM models. If null, the production URL for Cody gateway will be used.
 	Endpoint     *string       `json:"endpoint,omitempty"`
 	ModelFilters *ModelFilters `json:"modelFilters,omitempty"`
 	// PollingInterval description: The frequency at which Cody will poll Sourcegraph's servers for an updated list of models. e.g. '6h', '1d', or 'never'

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -594,6 +594,10 @@ type ChangesetTemplate struct {
 	// Title description: The title of the changeset.
 	Title string `json:"title"`
 }
+type ClientSideModelConfig struct {
+}
+type ClientSideProviderConfig struct {
+}
 
 // CloneURLToRepositoryName description: Describes a mapping from clone URL to repository name. The `from` field contains a regular expression with named capturing groups. The `to` field contains a template string that references capturing group names. For instance, if `from` is "^../(?P<name>\w+)$" and `to` is "github.com/user/{name}", the clone URL "../myRepository" would be mapped to the repository name "github.com/user/myRepository".
 type CloneURLToRepositoryName struct {
@@ -731,6 +735,12 @@ type ConfigFeatures struct {
 	Commands bool `json:"commands,omitempty"`
 }
 
+// ContextWindow description: Context window for the model
+type ContextWindow struct {
+	MaxInputTokens  int `json:"maxInputTokens"`
+	MaxOutputTokens int `json:"maxOutputTokens"`
+}
+
 // CustomGitFetchMapping description: Mapping from Git clone URl domain/path to git fetch command. The `domainPath` field contains the Git clone URL domain/path part. The `fetch` field contains the custom git fetch command.
 type CustomGitFetchMapping struct {
 	// DomainPath description: Git clone URL domain/path
@@ -745,12 +755,37 @@ type DebugLog struct {
 	ExtsvcGitlab bool `json:"extsvc.gitlab,omitempty"`
 }
 
+// DefaultModelConfig description: The model configuration that is applied to every model for a given provider.
+type DefaultModelConfig struct {
+	// Capabilities description: Whether the model can be used for chat, just autocomplete, etc.
+	Capabilities     []string               `json:"capabilities"`
+	Category         string                 `json:"category"`
+	ClientSideConfig *ClientSideModelConfig `json:"clientSideConfig,omitempty"`
+	ContextWindow    ContextWindow          `json:"contextWindow"`
+	ServerSideConfig *ServerSideModelConfig `json:"serverSideConfig,omitempty"`
+	Status           string                 `json:"status"`
+	Tier             string                 `json:"tier,omitempty"`
+}
+type DefaultModels struct {
+	// Chat description: The qualified name of the model to use for chat, in '${ProviderID}::${APIVersionID}::${ModelID}' format
+	Chat string `json:"chat,omitempty"`
+	// CodeCompletion description: The qualified name of the model to use for code completion, in '${ProviderID}::${APIVersionID}::${ModelID}' format
+	CodeCompletion string `json:"codeCompletion,omitempty"`
+	// FastChat description: The qualified name of the model to use for fast chat, in '${ProviderID}::${APIVersionID}::${ModelID}' format
+	FastChat string `json:"fastChat,omitempty"`
+}
+
 // DequeueCacheConfig description: The configuration for the dequeue cache of multiqueue executors. Each queue defines a limit of dequeues in the expiration window as well as a weight, indicating how frequently a queue is picked at random. For example, a weight of 4 for batches and 1 for codeintel means out of 5 dequeues, statistically batches will be picked 4 times and codeintel 1 time (unless one of those queues is at its limit).
 type DequeueCacheConfig struct {
 	// Batches description: The configuration for the batches queue.
 	Batches *Batches `json:"batches,omitempty"`
 	// Codeintel description: The configuration for the codeintel queue.
 	Codeintel *Codeintel `json:"codeintel,omitempty"`
+}
+type DoNotUsePhonyDiscriminantType struct {
+	// DoNotUseThisProperty description: Do not use/set this property, it is useless. go-jsonschema has an issue where it does not support writing a tagged union unless it can find a field each of the union types do NOT have in common; this type merely exists to provide a field that is not in common with all other oneOf types. https://sourcegraph.com/github.com/sourcegraph/go-jsonschema/-/blob/compiler/generator_tagged_union_type.go?L47-49
+	DoNotUseThisProperty string `json:"doNotUseThisProperty,omitempty"`
+	Type                 string `json:"type"`
 }
 
 // Dotcom description: Configuration options for Sourcegraph.com only.
@@ -1657,6 +1692,32 @@ type MavenRateLimit struct {
 	// RequestsPerHour description: Requests per hour permitted. This is an average, calculated per second. Internally, the burst limit is set to 100, which implies that for a requests per hour limit as low as 1, users will continue to be able to send a maximum of 100 requests immediately, provided that the complexity cost of each request is 1.
 	RequestsPerHour float64 `json:"requestsPerHour"`
 }
+
+// ModelFilters description: Filters that allow you to constrain which models are available to users.
+type ModelFilters struct {
+	// Allow description: Constrain models to only those in this allow list. Wildcards may be used here, but not regexp.
+	Allow []string `json:"allow,omitempty"`
+	// Deny description: Any models in this deny list will not be allowed. Wildcards may be used here, but not regexp.
+	Deny []string `json:"deny,omitempty"`
+	// StatusFilter description: Constrain models to just those in this list
+	StatusFilter []string `json:"statusFilter,omitempty"`
+}
+type ModelOverride struct {
+	// Capabilities description: Whether the model can be used for chat, just autocomplete, etc.
+	Capabilities     []string               `json:"capabilities"`
+	Category         string                 `json:"category"`
+	ClientSideConfig *ClientSideModelConfig `json:"clientSideConfig,omitempty"`
+	ContextWindow    ContextWindow          `json:"contextWindow"`
+	// DisplayName description: display name
+	DisplayName string `json:"displayName"`
+	// ModelName description: model name
+	ModelName string `json:"modelName"`
+	// ModelRef description: The qualified name of the model in '${ProviderID}::${APIVersionID}::${ModelID}' format
+	ModelRef         string                 `json:"modelRef"`
+	ServerSideConfig *ServerSideModelConfig `json:"serverSideConfig,omitempty"`
+	Status           string                 `json:"status"`
+	Tier             string                 `json:"tier,omitempty"`
+}
 type Mount struct {
 	// Mountpoint description: The path in the container to mount the path on the local machine to.
 	Mountpoint string `json:"mountpoint"`
@@ -2106,6 +2167,15 @@ type PhabricatorConnection struct {
 	// Url description: URL of a Phabricator instance, such as https://phabricator.example.com
 	Url string `json:"url,omitempty"`
 }
+type ProviderOverride struct {
+	ClientSideConfig   *ClientSideProviderConfig `json:"clientSideConfig,omitempty"`
+	DefaultModelConfig *DefaultModelConfig       `json:"defaultModelConfig,omitempty"`
+	// DisplayName description: display name
+	DisplayName string `json:"displayName"`
+	// Id description: provider ID
+	Id               string                    `json:"id"`
+	ServerSideConfig *ServerSideProviderConfig `json:"serverSideConfig,omitempty"`
+}
 
 // PythonPackagesConnection description: Configuration for a connection to Python simple repository APIs compatible with PEP 503
 type PythonPackagesConnection struct {
@@ -2383,6 +2453,152 @@ type Sentry struct {
 	CodeIntelDSN string `json:"codeIntelDSN,omitempty"`
 	// Dsn description: Sentry Data Source Name (DSN). Per the Sentry docs (https://docs.sentry.io/quickstart/#about-the-dsn), it should match the following pattern: '{PROTOCOL}://{PUBLIC_KEY}@{HOST}/{PATH}{PROJECT_ID}'.
 	Dsn string `json:"dsn,omitempty"`
+}
+type ServerSideModelConfig struct {
+	AwsBedrockProvisionedThroughput *ServerSideModelConfigAwsBedrockProvisionedThroughput
+	Unused                          *DoNotUsePhonyDiscriminantType
+}
+
+func (v ServerSideModelConfig) MarshalJSON() ([]byte, error) {
+	if v.AwsBedrockProvisionedThroughput != nil {
+		return json.Marshal(v.AwsBedrockProvisionedThroughput)
+	}
+	if v.Unused != nil {
+		return json.Marshal(v.Unused)
+	}
+	return nil, errors.New("tagged union type must have exactly 1 non-nil field value")
+}
+func (v *ServerSideModelConfig) UnmarshalJSON(data []byte) error {
+	var d struct {
+		DiscriminantProperty string `json:"type"`
+	}
+	if err := json.Unmarshal(data, &d); err != nil {
+		return err
+	}
+	switch d.DiscriminantProperty {
+	case "awsBedrockProvisionedThroughput":
+		return json.Unmarshal(data, &v.AwsBedrockProvisionedThroughput)
+	case "unused":
+		return json.Unmarshal(data, &v.Unused)
+	}
+	return fmt.Errorf("tagged union type must have a %q property whose value is one of %s", "type", []string{"awsBedrockProvisionedThroughput", "unused"})
+}
+
+type ServerSideModelConfigAwsBedrockProvisionedThroughput struct {
+	// Arn description: The 'provisioned throughput ARN' to use when sending requests to AWS Bedrock
+	Arn  string `json:"arn"`
+	Type string `json:"type"`
+}
+type ServerSideProviderConfig struct {
+	AwsBedrock  *ServerSideProviderConfigAWSBedrock
+	AzureOpenAI *ServerSideProviderConfigAzureOpenAI
+	Anthropic   *ServerSideProviderConfigAnthropicProvider
+	Fireworks   *ServerSideProviderConfigFireworksProvider
+	Google      *ServerSideProviderConfigGoogleProvider
+	Openai      *ServerSideProviderConfigOpenAIProvider
+	Sourcegraph *ServerSideProviderConfigSourcegraphProvider
+	Unused      *DoNotUsePhonyDiscriminantType
+}
+
+func (v ServerSideProviderConfig) MarshalJSON() ([]byte, error) {
+	if v.AwsBedrock != nil {
+		return json.Marshal(v.AwsBedrock)
+	}
+	if v.AzureOpenAI != nil {
+		return json.Marshal(v.AzureOpenAI)
+	}
+	if v.Anthropic != nil {
+		return json.Marshal(v.Anthropic)
+	}
+	if v.Fireworks != nil {
+		return json.Marshal(v.Fireworks)
+	}
+	if v.Google != nil {
+		return json.Marshal(v.Google)
+	}
+	if v.Openai != nil {
+		return json.Marshal(v.Openai)
+	}
+	if v.Sourcegraph != nil {
+		return json.Marshal(v.Sourcegraph)
+	}
+	if v.Unused != nil {
+		return json.Marshal(v.Unused)
+	}
+	return nil, errors.New("tagged union type must have exactly 1 non-nil field value")
+}
+func (v *ServerSideProviderConfig) UnmarshalJSON(data []byte) error {
+	var d struct {
+		DiscriminantProperty string `json:"type"`
+	}
+	if err := json.Unmarshal(data, &d); err != nil {
+		return err
+	}
+	switch d.DiscriminantProperty {
+	case "anthropic":
+		return json.Unmarshal(data, &v.Anthropic)
+	case "awsBedrock":
+		return json.Unmarshal(data, &v.AwsBedrock)
+	case "azureOpenAI":
+		return json.Unmarshal(data, &v.AzureOpenAI)
+	case "fireworks":
+		return json.Unmarshal(data, &v.Fireworks)
+	case "google":
+		return json.Unmarshal(data, &v.Google)
+	case "openai":
+		return json.Unmarshal(data, &v.Openai)
+	case "sourcegraph":
+		return json.Unmarshal(data, &v.Sourcegraph)
+	case "unused":
+		return json.Unmarshal(data, &v.Unused)
+	}
+	return fmt.Errorf("tagged union type must have a %q property whose value is one of %s", "type", []string{"awsBedrock", "azureOpenAI", "anthropic", "fireworks", "google", "openai", "sourcegraph", "unused"})
+}
+
+type ServerSideProviderConfigAWSBedrock struct {
+	// AccessToken description: Leave empty to rely on instance role bindings or other AWS configurations in frontend service. <ACCESS_KEY_ID>:<SECRET_ACCESS_KEY> if directly configuring the credentials, or <ACCESS_KEY_ID>:<SECRET_ACCESS_KEY>:<SESSION_TOKEN> if a session token is also required.
+	AccessToken string `json:"accessToken"`
+	// Endpoint description: For Pay-as-you-go, set it to an AWS region code (e.g., us-west-2) when using a public Amazon Bedrock endpoint; For Provisioned Throughput, set it to the provisioned VPC endpoint for the bedrock-runtime API (e.g., 'https://vpce-0a10b2345cd67e89f-abc0defg.bedrock-runtime.us-west-2.vpce.amazonaws.com')
+	Endpoint string `json:"endpoint"`
+	// Region description: Region to use when configuring API clients. (Since the 'frontend' binary's container won't be able to pick this up from the host OS's environment variables.)
+	Region string `json:"region"`
+	Type   string `json:"type"`
+}
+type ServerSideProviderConfigAnthropicProvider struct {
+	AccessToken string `json:"accessToken"`
+	Endpoint    string `json:"endpoint"`
+	Type        string `json:"type"`
+}
+type ServerSideProviderConfigAzureOpenAI struct {
+	// AccessToken description: As of 5.2.4 the access token can be left empty and it will rely on Environmental, Workload Identity or Managed Identity credentials configured for the frontend and worker services; Set it to <API_KEY> if directly configuring the credentials using the API key specified in the Azure portal
+	AccessToken string `json:"accessToken"`
+	// Endpoint description: Endpoint from the Azure OpenAI Service portal
+	Endpoint string `json:"endpoint"`
+	Type     string `json:"type"`
+	// UseDeprecatedCompletionsAPI description: Enables the use of the older completions API for select Azure OpenAI models. This is just an escape hatch, for backwards compatibility, because not all Azure OpenAI models are available on the 'newer' completions API.
+	UseDeprecatedCompletionsAPI bool `json:"useDeprecatedCompletionsAPI"`
+	// User description: The user field passed along to OpenAI-provided models.
+	User string `json:"user"`
+}
+type ServerSideProviderConfigFireworksProvider struct {
+	AccessToken string `json:"accessToken"`
+	Endpoint    string `json:"endpoint"`
+	Type        string `json:"type"`
+}
+type ServerSideProviderConfigGoogleProvider struct {
+	AccessToken string `json:"accessToken"`
+	Endpoint    string `json:"endpoint"`
+	Type        string `json:"type"`
+}
+type ServerSideProviderConfigOpenAIProvider struct {
+	AccessToken string `json:"accessToken"`
+	Endpoint    string `json:"endpoint"`
+	Type        string `json:"type"`
+}
+type ServerSideProviderConfigSourcegraphProvider struct {
+	AccessToken string `json:"accessToken"`
+	Endpoint    string `json:"endpoint"`
+	Type        string `json:"type"`
 }
 
 // Settings description: Configuration settings for users and organizations on Sourcegraph.
@@ -2909,7 +3125,8 @@ type SiteConfiguration struct {
 	// LsifEnforceAuth description: Whether or not LSIF uploads will be blocked unless a valid LSIF upload token is provided.
 	LsifEnforceAuth bool `json:"lsifEnforceAuth,omitempty"`
 	// MaxReposToSearch description: DEPRECATED: Configure maxRepos in search.limits. The maximum number of repositories to search across. The user is prompted to narrow their query if exceeded. Any value less than or equal to zero means unlimited.
-	MaxReposToSearch int `json:"maxReposToSearch,omitempty"`
+	MaxReposToSearch   int                     `json:"maxReposToSearch,omitempty"`
+	ModelConfiguration *SiteModelConfiguration `json:"modelConfiguration,omitempty"`
 	// Notifications description: Notifications recieved from Sourcegraph.com to display in Sourcegraph.
 	Notifications []*Notifications `json:"notifications,omitempty"`
 	// ObservabilityAlerts description: Configure notifications for Sourcegraph's built-in alerts.
@@ -3123,6 +3340,7 @@ func (v *SiteConfiguration) UnmarshalJSON(data []byte) error {
 	delete(m, "log")
 	delete(m, "lsifEnforceAuth")
 	delete(m, "maxReposToSearch")
+	delete(m, "modelConfiguration")
 	delete(m, "notifications")
 	delete(m, "observability.alerts")
 	delete(m, "observability.captureSlowGraphQLRequestsLimit")
@@ -3171,6 +3389,27 @@ func (v *SiteConfiguration) UnmarshalJSON(data []byte) error {
 		v.Additional[k] = vv
 	}
 	return nil
+}
+
+// SiteModelConfiguration description: BETA FEATURE, only enable if you know what you are doing. If set, Cody will use the new model configuration system and ignore the old 'completions' site configuration entirely.
+type SiteModelConfiguration struct {
+	DefaultModels *DefaultModels `json:"defaultModels,omitempty"`
+	// ModelOverrides description: Override, or add to, the list of models Cody is aware of and how they are configured to work
+	ModelOverrides []*ModelOverride `json:"modelOverrides,omitempty"`
+	// ProviderOverrides description: Configures model providers. Here you can override how Cody connects to model providers and e.g. bring your own API keys or self-hosted models.
+	ProviderOverrides []*ProviderOverride     `json:"providerOverrides,omitempty"`
+	Sourcegraph       *SourcegraphModelConfig `json:"sourcegraph,omitempty"`
+}
+
+// SourcegraphModelConfig description: If null, Cody will not use Sourcegraph's servers for model discovery or LLM requests.
+type SourcegraphModelConfig struct {
+	// AccessToken description: The Cody gateway access token to use. If null, an access token will be automatically generated based on the product license.
+	AccessToken *string `json:"accessToken,omitempty"`
+	// Endpoint description: The Cody gateway URL to use for making LLM requests and discovering new LLM models. If null, a good default URL will be used.
+	Endpoint     *string       `json:"endpoint,omitempty"`
+	ModelFilters *ModelFilters `json:"modelFilters,omitempty"`
+	// PollingInterval description: The frequency at which Cody will poll Sourcegraph's servers for an updated list of models. e.g. '6h', '1d', or 'never'
+	PollingInterval *string `json:"pollingInterval,omitempty"`
 }
 
 // SrcCliVersionCache description: Configuration related to the src-cli version cache. This should only be used on sourcegraph.com.

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -3241,11 +3241,6 @@
           "enum": ["experimental", "beta", "stable", "deprecated"],
           "examples": [["stable"]]
         },
-        "tier": {
-          "type": "string",
-          "enum": ["free", "pro", "enterprise"],
-          "default": ["free"]
-        },
         "contextWindow": {
           "$ref": "#/definitions/ContextWindow"
         },
@@ -3323,11 +3318,6 @@
           "type": "string",
           "enum": ["experimental", "beta", "stable", "deprecated"],
           "examples": [["stable"]]
-        },
-        "tier": {
-          "type": "string",
-          "enum": ["free", "pro", "enterprise"],
-          "default": ["free"]
         },
         "contextWindow": {
           "$ref": "#/definitions/ContextWindow"

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -3155,7 +3155,7 @@
             "type": "string",
             "enum": ["experimental", "beta", "stable", "deprecated"]
           },
-          "examples": [["beta"]],
+          "examples": [["beta", "stable"],
           "default": ["stable"]
         },
         "allow": {

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -3149,7 +3149,7 @@
       "default": null,
       "properties": {
         "statusFilter": {
-          "description": "Constrain models to just those in this list",
+          "description": "Constrain models to just those matching one of the supplied statuses",
           "type": "array",
           "items": {
             "type": "string",

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -3067,9 +3067,515 @@
       "!go": {
         "pointer": true
       }
+    },
+    "modelConfiguration": {
+      "$ref": "#/definitions/SiteModelConfiguration"
     }
   },
   "definitions": {
+    "SiteModelConfiguration": {
+      "type": "object",
+      "description": "BETA FEATURE, only enable if you know what you are doing. If set, Cody will use the new model configuration system and ignore the old 'completions' site configuration entirely.",
+      "properties": {
+        "sourcegraph": {
+          "$ref": "#/definitions/SourcegraphModelConfig"
+        },
+        "providerOverrides": {
+          "description": "Configures model providers. Here you can override how Cody connects to model providers and e.g. bring your own API keys or self-hosted models.",
+          "type": "array",
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/ProviderOverride"
+          }
+        },
+        "modelOverrides": {
+          "description": "Override, or add to, the list of models Cody is aware of and how they are configured to work",
+          "type": "array",
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/ModelOverride"
+          }
+        },
+        "defaultModels": {
+          "$ref": "#/definitions/DefaultModels"
+        }
+      }
+    },
+    "SourcegraphModelConfig": {
+      "description": "If null, Cody will not use Sourcegraph's servers for model discovery or LLM requests.",
+      "type": "object",
+      "!go": {
+        "pointer": true
+      },
+      "default": {
+        "pollingInterval": "6h"
+      },
+      "properties": {
+        "endpoint": {
+          "description": "The Cody gateway URL to use for making LLM requests and discovering new LLM models. If null, a good default URL will be used.",
+          "type": "string",
+          "!go": {
+            "pointer": true
+          },
+          "default": null
+        },
+        "accessToken": {
+          "description": "The Cody gateway access token to use. If null, an access token will be automatically generated based on the product license.",
+          "type": "string",
+          "!go": {
+            "pointer": true
+          },
+          "default": null
+        },
+        "pollingInterval": {
+          "description": "The frequency at which Cody will poll Sourcegraph's servers for an updated list of models. e.g. '6h', '1d', or 'never'",
+          "type": "string",
+          "!go": {
+            "pointer": true
+          },
+          "default": "6h"
+        },
+        "modelFilters": {
+          "$ref": "#/definitions/ModelFilters"
+        }
+      }
+    },
+    "ModelFilters": {
+      "description": "Filters that allow you to constrain which models are available to users.",
+      "type": "object",
+      "!go": {
+        "pointer": true
+      },
+      "default": null,
+      "properties": {
+        "statusFilter": {
+          "description": "Constrain models to just those in this list",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": ["experimental", "beta", "stable", "deprecated"]
+          },
+          "examples": [["beta"]],
+          "default": ["stable"]
+        },
+        "allow": {
+          "description": "Constrain models to only those in this allow list. Wildcards may be used here, but not regexp.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "examples": [[ "anthropic::*", "openai::2024-02-01::*" ]],
+          "default": ["*"]
+        },
+        "deny": {
+          "description": "Any models in this deny list will not be allowed. Wildcards may be used here, but not regexp.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "examples": [[ "*gpt*" ]],
+          "default": []
+        }
+      }
+    },
+    "ProviderOverride": {
+      "type": "object",
+      "required": ["id", "displayName"],
+      "properties": {
+        "id": {
+          "description": "provider ID",
+          "type": "string",
+          "examples": [["anthropic", "google", "acme-corp-custom"]]
+        },
+        "displayName": {
+          "description": "display name",
+          "type": "string",
+          "examples": [["Anthropic", "Google", "ACME Corp Custom"]]
+        },
+        "clientSideConfig": {
+          "$ref": "#/definitions/ClientSideProviderConfig"
+        },
+        "serverSideConfig": {
+          "$ref": "#/definitions/ServerSideProviderConfig"
+        },
+        "defaultModelConfig": {
+          "$ref": "#/definitions/DefaultModelConfig"
+        }
+      }
+    },
+    "ModelOverride": {
+      "type": "object",
+      "required": ["modelRef", "displayName", "modelName", "capabilities", "category", "status", "contextWindow"],
+      "properties": {
+        "modelRef": {
+          "description": "The qualified name of the model in '${ProviderID}::${APIVersionID}::${ModelID}' format",
+          "type": "string",
+          "examples": [["anthropic::2023-06-01::claude-3-sonnet", "openai::2024-02-01::gpt-4-turbo"]]
+        },
+        "displayName": {
+          "description": "display name",
+          "type": "string",
+          "examples": [["Claude 3 Sonnet", "GPT-4 Turbo"]]
+        },
+        "modelName": {
+          "description": "model name",
+          "type": "string",
+          "examples": [["claude-3-sonnet-20240229", "gpt-4-turbo"]]
+        },
+        "capabilities": {
+          "description": "Whether the model can be used for chat, just autocomplete, etc.",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": ["autocomplete", "chat"]
+          },
+          "examples": [["chat", "autocomplete"]]
+        },
+        "category": {
+          "type": "string",
+          "enum": ["accuracy", "balanced", "speed"],
+          "examples": [["balanced"]]
+        },
+        "status": {
+          "type": "string",
+          "enum": ["experimental", "beta", "stable", "deprecated"],
+          "examples": [["stable"]]
+        },
+        "tier": {
+          "type": "string",
+          "enum": ["free", "pro", "enterprise"],
+          "default": ["free"]
+        },
+        "contextWindow": {
+          "$ref": "#/definitions/ContextWindow"
+        },
+        "clientSideConfig": {
+          "$ref": "#/definitions/ClientSideModelConfig"
+        },
+        "serverSideConfig": {
+          "$ref": "#/definitions/ServerSideModelConfig"
+        }
+      }
+    },
+    "ContextWindow": {
+      "description": "Context window for the model",
+      "type": "object",
+      "examples": [{
+        "maxInputTokens": 7000,
+        "maxOutputTokens": 4000
+      }],
+      "required": ["maxInputTokens", "maxOutputTokens"],
+      "properties": {
+        "maxInputTokens": {
+          "type": "integer",
+          "examples": [7000]
+        },
+        "maxOutputTokens": {
+          "type": "integer",
+          "examples": [4000]
+        }
+      }
+    },
+    "DefaultModels": {
+      "type": "object",
+      "!go": {
+        "pointer": true
+      },
+      "default": null,
+      "properties": {
+        "chat": {
+          "description": "The qualified name of the model to use for chat, in '${ProviderID}::${APIVersionID}::${ModelID}' format",
+          "type": "string",
+          "examples": [["anthropic::2023-06-01::claude-3-sonnet", "openai::2024-02-01::gpt-4-turbo"]]
+        },
+        "fastChat": {
+          "description": "The qualified name of the model to use for fast chat, in '${ProviderID}::${APIVersionID}::${ModelID}' format",
+          "type": "string",
+          "examples": [["anthropic::2023-06-01::claude-3-sonnet", "openai::2024-02-01::gpt-4-turbo"]]
+        },
+        "codeCompletion": {
+          "description": "The qualified name of the model to use for code completion, in '${ProviderID}::${APIVersionID}::${ModelID}' format",
+          "type": "string",
+          "examples": [["anthropic::2023-06-01::claude-3-sonnet", "openai::2024-02-01::gpt-4-turbo"]]
+        }
+      }
+    },
+    "DefaultModelConfig": {
+      "description": "The model configuration that is applied to every model for a given provider.",
+      "type": "object",
+      "required": ["capabilities", "category", "status", "contextWindow"],
+      "properties": {
+        "capabilities": {
+          "description": "Whether the model can be used for chat, just autocomplete, etc.",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": ["autocomplete", "chat"]
+          },
+          "examples": [["chat", "autocomplete"]]
+        },
+        "category": {
+          "type": "string",
+          "enum": ["accuracy", "balanced", "speed"],
+          "examples": [["balanced"]]
+        },
+        "status": {
+          "type": "string",
+          "enum": ["experimental", "beta", "stable", "deprecated"],
+          "examples": [["stable"]]
+        },
+        "tier": {
+          "type": "string",
+          "enum": ["free", "pro", "enterprise"],
+          "default": ["free"]
+        },
+        "contextWindow": {
+          "$ref": "#/definitions/ContextWindow"
+        },
+        "clientSideConfig": {
+          "$ref": "#/definitions/ClientSideModelConfig"
+        },
+        "serverSideConfig": {
+          "$ref": "#/definitions/ServerSideModelConfig"
+        }
+      }
+    },
+    "ClientSideProviderConfig": {
+      "type": "object",
+      "!go": {
+        "pointer": true
+      },
+      "default": null,
+      "properties": {}
+    },
+    "ServerSideProviderConfig": {
+      "type": "object",
+      "!go": {
+        "pointer": true,
+        "taggedUnionType": true
+      },
+      "default": null,
+      "required": ["type"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["awsBedrock", "azureOpenAI", "anthropic", "fireworks", "google", "openai", "sourcegraph"]
+        }
+      },
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ServerSideProviderConfigAWSBedrock"
+        },
+        {
+          "$ref": "#/definitions/ServerSideProviderConfigAzureOpenAI"
+        },
+        {
+          "$ref": "#/definitions/ServerSideProviderConfigAnthropicProvider"
+        },
+        {
+          "$ref": "#/definitions/ServerSideProviderConfigFireworksProvider"
+        },
+        {
+          "$ref": "#/definitions/ServerSideProviderConfigGoogleProvider"
+        },
+        {
+          "$ref": "#/definitions/ServerSideProviderConfigOpenAIProvider"
+        },
+        {
+          "$ref": "#/definitions/ServerSideProviderConfigSourcegraphProvider"
+        },
+        {
+          "$ref": "#/definitions/DoNotUsePhonyDiscriminantType"
+        }
+      ]
+    },
+    "ServerSideProviderConfigAWSBedrock": {
+      "type": "object",
+      "required": ["type", "accessToken", "endpoint", "region"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "awsBedrock"
+        },
+        "accessToken": {
+          "description": "Leave empty to rely on instance role bindings or other AWS configurations in frontend service. <ACCESS_KEY_ID>:<SECRET_ACCESS_KEY> if directly configuring the credentials, or <ACCESS_KEY_ID>:<SECRET_ACCESS_KEY>:<SESSION_TOKEN> if a session token is also required.",
+          "type": "string"
+        },
+        "endpoint": {
+          "description": "For Pay-as-you-go, set it to an AWS region code (e.g., us-west-2) when using a public Amazon Bedrock endpoint; For Provisioned Throughput, set it to the provisioned VPC endpoint for the bedrock-runtime API (e.g., 'https://vpce-0a10b2345cd67e89f-abc0defg.bedrock-runtime.us-west-2.vpce.amazonaws.com')",
+          "type": "string"
+        },
+        "region": {
+          "description": "Region to use when configuring API clients. (Since the 'frontend' binary's container won't be able to pick this up from the host OS's environment variables.)",
+          "type": "string"
+        }
+      }
+    },
+    "ServerSideProviderConfigAzureOpenAI": {
+      "type": "object",
+      "required": ["type", "accessToken", "endpoint", "user", "useDeprecatedCompletionsAPI"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "azureOpenAI"
+        },
+        "accessToken": {
+          "description": "As of 5.2.4 the access token can be left empty and it will rely on Environmental, Workload Identity or Managed Identity credentials configured for the frontend and worker services; Set it to <API_KEY> if directly configuring the credentials using the API key specified in the Azure portal",
+          "type": "string"
+        },
+        "endpoint": {
+          "description": "Endpoint from the Azure OpenAI Service portal",
+          "type": "string"
+        },
+        "user": {
+          "description": "The user field passed along to OpenAI-provided models.",
+          "type": "string"
+        },
+        "useDeprecatedCompletionsAPI": {
+          "description": "Enables the use of the older completions API for select Azure OpenAI models. This is just an escape hatch, for backwards compatibility, because not all Azure OpenAI models are available on the 'newer' completions API.",
+          "type": "boolean"
+        }
+      }
+    },
+    "ServerSideProviderConfigAnthropicProvider": {
+      "type": "object",
+      "required": ["type", "accessToken", "endpoint"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "anthropic"
+        },
+        "accessToken": {
+          "type": "string"
+        },
+        "endpoint": {
+          "type": "string"
+        }
+      }
+    },
+    "ServerSideProviderConfigFireworksProvider": {
+      "type": "object",
+      "required": ["type", "accessToken", "endpoint"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "fireworks"
+        },
+        "accessToken": {
+          "type": "string"
+        },
+        "endpoint": {
+          "type": "string"
+        }
+      }
+    },
+    "ServerSideProviderConfigGoogleProvider": {
+      "type": "object",
+      "required": ["type", "accessToken", "endpoint"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "google"
+        },
+        "accessToken": {
+          "type": "string"
+        },
+        "endpoint": {
+          "type": "string"
+        }
+      }
+    },
+    "ServerSideProviderConfigOpenAIProvider": {
+      "type": "object",
+      "required": ["type", "accessToken", "endpoint"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "openai"
+        },
+        "accessToken": {
+          "type": "string"
+        },
+        "endpoint": {
+          "type": "string"
+        }
+      }
+    },
+    "ServerSideProviderConfigSourcegraphProvider": {
+      "type": "object",
+      "required": ["type", "accessToken", "endpoint"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "sourcegraph"
+        },
+        "accessToken": {
+          "type": "string"
+        },
+        "endpoint": {
+          "type": "string"
+        }
+      }
+    },
+    "ClientSideModelConfig": {
+      "type": "object",
+      "!go": {
+        "pointer": true
+      },
+      "default": null,
+      "properties": {}
+    },
+    "ServerSideModelConfig": {
+      "type": "object",
+      "!go": {
+        "pointer": true,
+        "taggedUnionType": true
+      },
+      "default": null,
+      "required": ["type"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["awsBedrockProvisionedThroughput"]
+        }
+      },
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ServerSideModelConfigAwsBedrockProvisionedThroughput"
+        },
+        {
+          "$ref": "#/definitions/DoNotUsePhonyDiscriminantType"
+        }
+      ]
+    },
+    "ServerSideModelConfigAwsBedrockProvisionedThroughput": {
+      "type": "object",
+      "required": ["type", "arn"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "awsBedrockProvisionedThroughput"
+        },
+        "arn": {
+          "description": "The 'provisioned throughput ARN' to use when sending requests to AWS Bedrock",
+          "type": "string"
+        }
+      }
+    },
+    "DoNotUsePhonyDiscriminantType": {
+      "type": "object",
+      "required": ["type"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "unused"
+        },
+        "doNotUseThisProperty": {
+          "description": "Do not use/set this property, it is useless. go-jsonschema has an issue where it does not support writing a tagged union unless it can find a field each of the union types do NOT have in common; this type merely exists to provide a field that is not in common with all other oneOf types. https://sourcegraph.com/github.com/sourcegraph/go-jsonschema/-/blob/compiler/generator_tagged_union_type.go?L47-49",
+          "type": "string"
+        }
+      }
+    },
     "BrandAssets": {
       "type": "object",
       "properties": {

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -3155,7 +3155,7 @@
             "type": "string",
             "enum": ["experimental", "beta", "stable", "deprecated"]
           },
-          "examples": [["beta", "stable"],
+          "examples": [["beta", "stable"]],
           "default": ["stable"]
         },
         "allow": {

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -3218,7 +3218,7 @@
           "examples": [["Claude 3 Sonnet", "GPT-4 Turbo"]]
         },
         "modelName": {
-          "description": "model name",
+          "description": "model name used when sending requests to the LLM provider's backend API.",
           "type": "string",
           "examples": [["claude-3-sonnet-20240229", "gpt-4-turbo"]]
         },

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -3102,7 +3102,7 @@
       }
     },
     "SourcegraphModelConfig": {
-      "description": "If null, Cody will not use Sourcegraph's servers for model discovery or LLM requests.",
+      "description": "If null, Cody will not use Sourcegraph's servers for model discovery.",
       "type": "object",
       "!go": {
         "pointer": true

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -3112,7 +3112,7 @@
       },
       "properties": {
         "endpoint": {
-          "description": "The Cody gateway URL to use for making LLM requests and discovering new LLM models. If null, a good default URL will be used.",
+          "description": "The Cody gateway URL to use for making LLM requests and discovering new LLM models. If null, the production URL for Cody gateway will be used.",
           "type": "string",
           "!go": {
             "pointer": true

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -3336,6 +3336,7 @@
         "pointer": true
       },
       "default": null,
+      "description": "No client-side provider configuration is currently available.",
       "properties": {}
     },
     "ServerSideProviderConfig": {
@@ -3513,6 +3514,7 @@
         "pointer": true
       },
       "default": null,
+      "description": "No client-side model configuration is currently available.",
       "properties": {}
     },
     "ServerSideModelConfig": {

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -3164,7 +3164,7 @@
           "items": {
             "type": "string"
           },
-          "examples": [[ "anthropic::*", "openai::2024-02-01::*" ]],
+          "examples": [["anthropic::*", "openai::2024-02-01::*"]],
           "default": ["*"]
         },
         "deny": {
@@ -3173,7 +3173,7 @@
           "items": {
             "type": "string"
           },
-          "examples": [[ "*gpt*" ]],
+          "examples": [["*gpt*"]],
           "default": []
         }
       }
@@ -3255,10 +3255,12 @@
     "ContextWindow": {
       "description": "Context window for the model",
       "type": "object",
-      "examples": [{
-        "maxInputTokens": 7000,
-        "maxOutputTokens": 4000
-      }],
+      "examples": [
+        {
+          "maxInputTokens": 7000,
+          "maxOutputTokens": 4000
+        }
+      ],
       "required": ["maxInputTokens", "maxOutputTokens"],
       "properties": {
         "maxInputTokens": {


### PR DESCRIPTION
## User-facing impacts

This PR adds a new top-level field to the site configuration `"modelConfiguration"`
which is intended to replace the old `"completions"` field. For now, this is 100%
opt-in (beta feature) and customers should only use this new field if they have
talked with us to confirm it should work in their case.

Today, this configuration is unused, but in future PRs it will actually be used (planned for the 5.5.0 release.)

Additionally, `"modelConfiguration"` acts as a feature-flag. If it is set
and not `null`, then Cody will enable this whole new model configuration system
end-to-end which involves many new components:

* Clients will make use of a new `/.api/modelconfig/supported-models.json` endpoint to query which models the server has available.
* Cody will respect this new site configuration, discovering new models from Sourcegraph's servers without an upgrade by default, etc.
* Clients will enable the "select an LLM model" dropdown menu for enterprise customers.
* The old `"completions"` configuration, if present, will be ignored if `"modelConfiguration"` is set.

## Implementation notes

This schema mirrors [the new model configuration schema](https://github.com/sourcegraph/sourcegraph/tree/main/internal/modelconfig/types)
that Chris and myself have been working on tirelessly to enable a myriad
of use-cases in the near future, including enabling customers to get
support for new models without upgrading Sourcegraph, enabling multiple
models / dropdown model selector in enterprise, improved self-hosted model
support, and more.

The translation is pretty much 1:1, with a few notable aspects:

* I broke out [`GenericProviderConfig`](https://github.com/sourcegraph/sourcegraph/blob/main/internal/modelconfig/types/configuration.go#L49-L73) into distinct types for each provider.
* I represent `ClientSideProviderConfig` and `ClientSideModelConfig` _objects_ (specify multiple fields)
* I represent `ServerSideProviderConfig` and `ServerSideModelConfig` as _tagged unions_ / _discriminated unions_, i.e. where you must write a `{"type": "foo"}` field as part of the object.

My next PR will be to handle conversion from the site config types to the `modelconfig/types`.

## Test plan

No impact to product behavior yet, nothing to test.

## Changelog

Changelog entry will come later with proper docs link, when we are ready for customers to use this.
