### PR TITLE
dotcom: Remove dotcom on-by-default Cloudflare trust mode

### DIFF
--- a/internal/requestclient/BUILD.bazel
+++ b/internal/requestclient/BUILD.bazel
@@ -11,7 +11,6 @@ go_library(
     importpath = "github.com/sourcegraph/sourcegraph/internal/requestclient",
     visibility = ["//:__subpackages__"],
     deps = [
-        "//internal/dotcom",
         "//internal/env",
         "//internal/grpc/propagator",
         "//internal/requestclient/geolocation",

--- a/internal/requestclient/http.go
+++ b/internal/requestclient/http.go
@@ -4,12 +4,10 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/sourcegraph/sourcegraph/internal/dotcom"
 	"github.com/sourcegraph/sourcegraph/internal/env"
 )
 
-var useCloudflareHeaders = env.MustGetBool("SRC_USE_CLOUDFLARE_HEADERS",
-	dotcom.SourcegraphDotComMode(), "Use Cloudflare headers for request metadata")
+var useCloudflareHeaders = env.MustGetBool("SRC_USE_CLOUDFLARE_HEADERS", false, "Use Cloudflare headers for request metadata")
 
 const (
 	// Sourcegraph-specific client IP header key


### PR DESCRIPTION
https://github.com/sourcegraph/deploy-sourcegraph-cloud/pull/18673 configures this env var explicitly. This feels cleaner than having yet-another-dependence-on-this-env-var.

Test plan: Check in after rollout.