### PR TITLE
notebooks: set default pattern type to keyword

### DIFF
--- a/internal/database/migration/shared/data/stitched-migration-graph.json
+++ b/internal/database/migration/shared/data/stitched-migration-graph.json
@@ -11303,8 +11303,8 @@
 			{
 				"ID": 1720165387,
 				"Name": "notebooks default to keyword search",
-				"UpQuery": "ALTER TABLE notebooks ALTER COLUMN pattern_type SET DEFAULT 'keyword';",
-				"DownQuery": "ALTER TABLE notebooks ALTER COLUMN pattern_type SET DEFAULT 'standard';",
+				"UpQuery": "ALTER TABLE IF EXISTS notebooks ALTER COLUMN pattern_type SET DEFAULT 'keyword';",
+				"DownQuery": "ALTER TABLE IF EXISTS notebooks ALTER COLUMN pattern_type SET DEFAULT 'standard';",
 				"Privileged": false,
 				"NonIdempotent": false,
 				"Parents": [

--- a/internal/database/migration/shared/data/stitched-migration-graph.json
+++ b/internal/database/migration/shared/data/stitched-migration-graph.json
@@ -11299,6 +11299,20 @@
 				],
 				"IsCreateIndexConcurrently": false,
 				"IndexMetadata": null
+			},
+			{
+				"ID": 1720165387,
+				"Name": "notebooks default to keyword search",
+				"UpQuery": "ALTER TABLE notebooks ALTER COLUMN pattern_type SET DEFAULT 'keyword';",
+				"DownQuery": "ALTER TABLE notebooks ALTER COLUMN pattern_type SET DEFAULT 'standard';",
+				"Privileged": false,
+				"NonIdempotent": false,
+				"Parents": [
+					1719214941,
+					1719498128
+				],
+				"IsCreateIndexConcurrently": false,
+				"IndexMetadata": null
 			}
 		],
 		"BoundsByRev": {
@@ -11559,8 +11573,7 @@
 			"v5.4.0": {
 				"RootID": 1648051770,
 				"LeafIDs": [
-					1719214941,
-					1719498128
+					1720165387
 				],
 				"PreCreation": false
 			}

--- a/internal/database/schema.json
+++ b/internal/database/schema.json
@@ -19142,7 +19142,7 @@
           "Index": 12,
           "TypeName": "pattern_type",
           "IsNullable": false,
-          "Default": "'standard'::pattern_type",
+          "Default": "'keyword'::pattern_type",
           "CharacterMaximumLength": 0,
           "IsIdentity": false,
           "IdentityGeneration": "",

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -2806,7 +2806,7 @@ Foreign-key constraints:
  namespace_user_id | integer                  |           |          | 
  namespace_org_id  | integer                  |           |          | 
  updater_user_id   | integer                  |           |          | 
- pattern_type      | pattern_type             |           | not null | 'standard'::pattern_type
+ pattern_type      | pattern_type             |           | not null | 'keyword'::pattern_type
 Indexes:
     "notebooks_pkey" PRIMARY KEY, btree (id)
     "notebooks_blocks_tsvector_idx" gin (blocks_tsvector)

--- a/migrations/frontend/1720165387_notebooks_default_to_keyword_search/down.sql
+++ b/migrations/frontend/1720165387_notebooks_default_to_keyword_search/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE notebooks ALTER COLUMN pattern_type SET DEFAULT 'standard';

--- a/migrations/frontend/1720165387_notebooks_default_to_keyword_search/down.sql
+++ b/migrations/frontend/1720165387_notebooks_default_to_keyword_search/down.sql
@@ -1,1 +1,1 @@
-ALTER TABLE notebooks ALTER COLUMN pattern_type SET DEFAULT 'standard';
+ALTER TABLE IF EXISTS notebooks ALTER COLUMN pattern_type SET DEFAULT 'standard';

--- a/migrations/frontend/1720165387_notebooks_default_to_keyword_search/metadata.yaml
+++ b/migrations/frontend/1720165387_notebooks_default_to_keyword_search/metadata.yaml
@@ -1,0 +1,2 @@
+name: notebooks default to keyword search
+parents: [1719214941, 1719498128]

--- a/migrations/frontend/1720165387_notebooks_default_to_keyword_search/up.sql
+++ b/migrations/frontend/1720165387_notebooks_default_to_keyword_search/up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE notebooks ALTER COLUMN pattern_type SET DEFAULT 'keyword';

--- a/migrations/frontend/1720165387_notebooks_default_to_keyword_search/up.sql
+++ b/migrations/frontend/1720165387_notebooks_default_to_keyword_search/up.sql
@@ -1,1 +1,1 @@
-ALTER TABLE notebooks ALTER COLUMN pattern_type SET DEFAULT 'keyword';
+ALTER TABLE IF EXISTS notebooks ALTER COLUMN pattern_type SET DEFAULT 'keyword';

--- a/migrations/frontend/squashed.sql
+++ b/migrations/frontend/squashed.sql
@@ -3571,7 +3571,7 @@ CREATE TABLE notebooks (
     namespace_user_id integer,
     namespace_org_id integer,
     updater_user_id integer,
-    pattern_type pattern_type DEFAULT 'standard'::pattern_type NOT NULL,
+    pattern_type pattern_type DEFAULT 'keyword'::pattern_type NOT NULL,
     CONSTRAINT blocks_is_array CHECK ((jsonb_typeof(blocks) = 'array'::text)),
     CONSTRAINT notebooks_has_max_1_namespace CHECK ((((namespace_user_id IS NULL) AND (namespace_org_id IS NULL)) OR ((namespace_user_id IS NULL) <> (namespace_org_id IS NULL))))
 );


### PR DESCRIPTION
Relates to https://github.com/sourcegraph/sourcegraph/pull/63472

This changes the default patternType of Notebooks from "standard" to "keyword". As a consequence, all new notebooks will default to keyword search. Existing notebooks will keep using standard search.

Test plan:
- I ran the migration locally and verified that new notebooks use "keyword" as default.