### PR TITLE
chore(local): simplify sg teammate

### DIFF
--- a/dev/sg/BUILD.bazel
+++ b/dev/sg/BUILD.bazel
@@ -67,7 +67,6 @@ go_library(
         "//dev/sg/internal/generate/proto",
         "//dev/sg/internal/images",
         "//dev/sg/internal/migration",
-        "//dev/sg/internal/open",
         "//dev/sg/internal/release",
         "//dev/sg/internal/repo",
         "//dev/sg/internal/rfc",

--- a/dev/sg/sg_teammate.go
+++ b/dev/sg/sg_teammate.go
@@ -11,7 +11,6 @@ import (
 	"github.com/urfave/cli/v2"
 
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/category"
-	"github.com/sourcegraph/sourcegraph/dev/sg/internal/open"
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/slack"
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/std"
 	"github.com/sourcegraph/sourcegraph/dev/team"
@@ -27,101 +26,46 @@ func getTeamResolver(ctx context.Context) (team.TeammateResolver, error) {
 	return team.NewTeammateResolver(githubClient, slackClient), nil
 }
 
-var (
-	teammateCommand = &cli.Command{
-		Name:        "teammate",
-		Usage:       "Get information about Sourcegraph teammates",
-		Description: `For example, you can check a teammate's current time and find their handbook bio!`,
-		UsageText: `
-# Get the current time of a team mate based on their slack handle (case insensitive).
-sg teammate time @dax
-sg teammate time dax
-# or their full name (case insensitive)
-sg teammate time thorsten ball
-
-# Open their handbook bio
-sg teammate handbook asdine
-`,
-		Category: category.Company,
-		Subcommands: []*cli.Command{{
-			Name:      "time",
-			ArgsUsage: "<nickname>",
-			Usage:     "Get the current time of a Sourcegraph teammate",
-			Action: func(ctx *cli.Context) error {
-				args := ctx.Args().Slice()
-				if len(args) == 0 {
-					return errors.New("no nickname provided")
-				}
-				resolver, err := getTeamResolver(ctx.Context)
-				if err != nil {
-					return err
-				}
-
-				teammate, err := resolver.ResolveByName(ctx.Context, strings.Join(args, " "))
-				if err != nil {
-					return err
-				}
-				std.Out.Writef("%s's current time is %s",
-					teammate.Name, timeAtLocation(teammate.SlackTimezone))
-				return nil
-			},
-		}, {
-			Name:      "handbook",
-			ArgsUsage: "<nickname>",
-			Usage:     "Open the handbook page of a Sourcegraph teammate",
-			Action: func(ctx *cli.Context) error {
-				args := ctx.Args().Slice()
-				if len(args) == 0 {
-					return errors.New("no nickname provided")
-				}
-				resolver, err := getTeamResolver(ctx.Context)
-				if err != nil {
-					return err
-				}
-				teammate, err := resolver.ResolveByName(ctx.Context, strings.Join(args, " "))
-				if err != nil {
-					return err
-				}
-				std.Out.Writef("Opening handbook link for %s: %s", teammate.Name, teammate.HandbookLink)
-				return open.URL(teammate.HandbookLink)
-			},
-		},
-			{
-				Name:      "details",
-				ArgsUsage: "<nickname>",
-				Usage:     "print the details of a Sourcegraph",
-				Action: func(ctx *cli.Context) error {
-					args := ctx.Args().Slice()
-					if len(args) == 0 {
-						return errors.New("no nickname provided")
-					}
-					handle := strings.Join(args, " ")
-					resolver, err := getTeamResolver(ctx.Context)
-					if err != nil {
-						return err
-					}
-					teammate, err := resolver.ResolveByName(ctx.Context, handle)
-					if err != nil {
-						return err
-					}
-					markdownFmt := `**Name**       : %s
+var markdownFmt = `**Name**       : %s
+**Local Time** : %s
 **Slack**      : %s
 **Email**      : %s
 **GitHub**     : %s
 **Location**   : %s
 **Role**       : %s
 **Description**: %s`
-					markdown := fmt.Sprintf(markdownFmt,
-						teammate.Name,
-						teammate.SlackName,
-						teammate.Email,
-						fmt.Sprintf("[%s](https://github.com/%s)", teammate.GitHub, teammate.GitHub),
-						teammate.Location,
-						teammate.Role,
-						teammate.Description)
-					return std.Out.WriteMarkdown(markdown)
-				},
-			},
+
+var (
+	teammateCommand = &cli.Command{
+		Name:     "teammate",
+		Usage:    "Get information about Sourcegraph teammates",
+		Category: category.Company,
+		Action: func(ctx *cli.Context) error {
+			args := ctx.Args().Slice()
+			if len(args) == 0 {
+				return errors.New("no nickname provided")
+			}
+			handle := strings.Join(args, " ")
+			resolver, err := getTeamResolver(ctx.Context)
+			if err != nil {
+				return err
+			}
+			teammate, err := resolver.ResolveByName(ctx.Context, handle)
+			if err != nil {
+				return err
+			}
+
+			markdown := fmt.Sprintf(markdownFmt,
+				teammate.Name,
+				timeAtLocation(teammate.SlackTimezone),
+				teammate.SlackName,
+				teammate.Email,
+				fmt.Sprintf("[%s](https://github.com/%s)", teammate.GitHub, teammate.GitHub),
+				teammate.Location,
+				teammate.Role,
+				teammate.Description,
+			)
+			return std.Out.WriteMarkdown(markdown)
 		},
 	}
 )
@@ -130,5 +74,5 @@ func timeAtLocation(loc *time.Location) string {
 	t := time.Now().In(loc)
 	t2 := time.Date(t.Year(), t.Month(), t.Day(), t.Hour(), t.Minute(), t.Second(), t.Nanosecond(), time.Local)
 	diff := t2.Sub(t) / time.Hour
-	return fmt.Sprintf("%s (%dh from your local time)", t.Format(time.RFC822), diff)
+	return fmt.Sprintf("%s (%dh from you)", t.Format(time.RFC822), diff)
 }


### PR DESCRIPTION
Drive by fix, dropped a few names who left the company and simplified commands. 

See DINF-106 

Before: `sg teammate time|details olaf` 
After: `sg teammate olaf` (shows both of the above) 

## Test plan

Locally tested + CI. 

