### PR TITLE
chore(appliance): use Helm's namespace features

### DIFF
--- a/internal/appliance/maintenance/helm/templates/NOTES.txt
+++ b/internal/appliance/maintenance/helm/templates/NOTES.txt
@@ -25,14 +25,14 @@ available at:
   $ echo -n 'http://' \
     && kubectl get service operator-ui \
           -o jsonpath='{.status.loadBalancer.ingress[0].ip}' \
-          --namespace {{ .Values.namespace }} && echo
+          --namespace {{ .Release.Namespace }} && echo
 
 If the result is simply `http://`, then it means the service
 is not fully provisioned yet. Either wait or monitor the
 output of this command:
 
   $ kubectl get service operator-ui \
-        --namespace {{ .Values.namespace }}
+        --namespace {{ .Release.Namespace }}
 
 The `EXTERNAL-IP` field will be either `<pending>` or an IP
 address.
@@ -45,7 +45,7 @@ password:
   $ echo -n 'Password: ' \
       && kubectl get secret operator-api \
              -o jsonpath='{.data.MAINTENANCE_PASSWORD}' \
-             --namespace {{ .Values.namespace }} \
+             --namespace {{ .Release.Namespace }} \
       | base64 -d && echo
 
 --------------------------------------------------------------

--- a/internal/appliance/maintenance/helm/templates/api-deploy.yaml
+++ b/internal/appliance/maintenance/helm/templates/api-deploy.yaml
@@ -3,7 +3,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: operator-api
-  namespace: {{ .Values.namespace }}
   labels:
     app: operator-api
 spec:
@@ -22,8 +21,8 @@ spec:
           ports:
             - containerPort: 80
           env:
-            - - name: API_ENDPOINT
-                value: 'maintenance.{{ .Values.namespace }}.svc.cluster.local'
+            - name: API_ENDPOINT
+              value: 'maintenance.{{ .Release.Namespace }}.svc.cluster.local'
             - name: MAINTENANCE_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/internal/appliance/maintenance/helm/templates/api-secret.yaml
+++ b/internal/appliance/maintenance/helm/templates/api-secret.yaml
@@ -2,9 +2,8 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: operator-api
-  namespace: {{ .Values.namespace }}
 data:
-  {{- $secretObj := (lookup "v1" "Secret" .Values.namespace "operator-api") | default dict }}
+  {{- $secretObj := (lookup "v1" "Secret" .Release.Namespace "operator-api") | default dict }}
   {{- $secretData := (get $secretObj "data") | default dict }}
   {{- $secret := (get $secretData "MAINTENANCE_PASSWORD") | default (randAlphaNum 15 | b64enc) }}
   MAINTENANCE_PASSWORD: {{ $secret | quote }}

--- a/internal/appliance/maintenance/helm/templates/api-service.yaml
+++ b/internal/appliance/maintenance/helm/templates/api-service.yaml
@@ -3,7 +3,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: operator-api
-  namespace: {{ .Values.namespace }}
 spec:
   selector:
     app: operator-api

--- a/internal/appliance/maintenance/helm/templates/namespace.yaml
+++ b/internal/appliance/maintenance/helm/templates/namespace.yaml
@@ -1,4 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: {{ .Values.namespace }}

--- a/internal/appliance/maintenance/helm/templates/ui-deploy.yaml
+++ b/internal/appliance/maintenance/helm/templates/ui-deploy.yaml
@@ -3,7 +3,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: operator-ui
-  namespace: {{ .Values.namespace }}
   labels:
     app: operator-ui
 spec:
@@ -23,4 +22,4 @@ spec:
             - containerPort: 80
           env:
             - name: API_ENDPOINT
-              value: 'http://operator-api.{{ .Values.namespace }}.svc.cluster.local'
+              value: 'http://operator-api.{{ .Release.Namespace }}.svc.cluster.local'

--- a/internal/appliance/maintenance/helm/templates/ui-service.yaml
+++ b/internal/appliance/maintenance/helm/templates/ui-service.yaml
@@ -3,7 +3,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: operator-ui
-  namespace: {{ .Values.namespace }}
 spec:
   selector:
     app: operator-ui


### PR DESCRIPTION
Helm supports a `--namespace` flag, which overrides `metadata.namespace`
for all resources. It appears more idiomatic to use this Helm feature,
putting direct control in the hands of admins (or anyone else using
Helm). It also supports a `--create-namespace` flag, which avoids us
having to create the actual namespace resource (especially since we
weren't making use of other metadata on it such as labels).

Helm exposes the namespace as `.Release.Namespace`.

Also - fix an array element's formatting in one appliance Helm template.

<!-- PR description tips: https://www.notion.so/sourcegraph/Write-a-good-pull-request-description-610a7fd3e613496eb76f450db5a49b6e -->

## Test plan

Manually tested by deploying the helm chart to a test namespace:

```
helm --namespace test install --create-namespace operator ./helm
```

<!-- REQUIRED; info at https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles -->

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
