### PR TITLE
chore(batches): simplify Sourcer interface

### DIFF
--- a/cmd/frontend/internal/batches/resolvers/changeset_counts_test.go
+++ b/cmd/frontend/internal/batches/resolvers/changeset_counts_test.go
@@ -189,7 +189,9 @@ func TestChangesetCountsOverTimeIntegration(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		src, err := sourcer.ForChangeset(ctx, bstore, c, sources.AuthenticationStrategyUserCredential, githubRepo, "")
+		src, err := sourcer.ForChangeset(ctx, bstore, c, githubRepo, sources.SourcerOpts{
+			AuthenticationStrategy: sources.AuthenticationStrategyUserCredential,
+		})
 		if err != nil {
 			t.Fatalf("failed to build source for repo: %s", err)
 		}

--- a/cmd/frontend/internal/batches/webhooks/bitbucketserver_test.go
+++ b/cmd/frontend/internal/batches/webhooks/bitbucketserver_test.go
@@ -166,7 +166,9 @@ func testBitbucketServerWebhook(db database.DB, userID int32) func(*testing.T) {
 			if err := s.CreateChangeset(ctx, ch); err != nil {
 				t.Fatal(err)
 			}
-			src, err := sourcer.ForChangeset(ctx, s, ch, sources.AuthenticationStrategyUserCredential, bitbucketRepo, "")
+			src, err := sourcer.ForChangeset(ctx, s, ch, bitbucketRepo, sources.SourcerOpts{
+				AuthenticationStrategy: sources.AuthenticationStrategyUserCredential,
+			})
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/cmd/frontend/internal/batches/webhooks/github_test.go
+++ b/cmd/frontend/internal/batches/webhooks/github_test.go
@@ -155,7 +155,9 @@ func testGitHubWebhook(db database.DB, userID int32) func(*testing.T) {
 			VCS:  protocol.VCSInfo{URL: "https://example.com/repo/"},
 		})
 
-		src, err := sourcer.ForChangeset(ctx, s, changeset, sources.AuthenticationStrategyUserCredential, githubRepo, "")
+		src, err := sourcer.ForChangeset(ctx, s, changeset, githubRepo, sources.SourcerOpts{
+			AuthenticationStrategy: sources.AuthenticationStrategyUserCredential,
+		})
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/batches/reconciler/executor.go
+++ b/internal/batches/reconciler/executor.go
@@ -9,8 +9,6 @@ import (
 	"text/template"
 	"time"
 
-	ghtypes "github.com/sourcegraph/sourcegraph/internal/github_apps/types"
-
 	"github.com/inconshreveable/log15" //nolint:logging // TODO move all logging to sourcegraph/log
 	"github.com/sourcegraph/log"
 
@@ -23,6 +21,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
+	ghtypes "github.com/sourcegraph/sourcegraph/internal/github_apps/types"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/repos"
@@ -657,7 +656,8 @@ func (e *executor) runAfterCommit(ctx context.Context, css sources.ChangesetSour
 		// Attempt to get a ChangesetSource authenticated with a GitHub App.
 		css, err = e.sourcer.ForChangeset(ctx, e.tx, e.ch, e.remote, sources.SourcerOpts{
 			AuthenticationStrategy: sources.AuthenticationStrategyGitHubApp,
-			GitHubAppKind:          ghtypes.SiteCredentialGitHubAppKind,
+			GitHubAppKind:          ghtypes.CommitSigningGitHubAppKind,
+			AsNonCredential:        true,
 		})
 		if err != nil {
 			switch err {

--- a/internal/batches/reconciler/executor_test.go
+++ b/internal/batches/reconciler/executor_test.go
@@ -14,9 +14,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/sourcegraph/sourcegraph/internal/gitserver"
-	"github.com/sourcegraph/sourcegraph/internal/httpcli"
-
 	"github.com/sourcegraph/log/logtest"
 
 	"github.com/sourcegraph/sourcegraph/internal/actor"
@@ -32,8 +29,10 @@ import (
 	et "github.com/sourcegraph/sourcegraph/internal/encryption/testing"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/auth"
+	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 	gitprotocol "github.com/sourcegraph/sourcegraph/internal/gitserver/protocol"
+	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/repos"
 

--- a/internal/batches/service/service.go
+++ b/internal/batches/service/service.go
@@ -1315,7 +1315,10 @@ func (s *Service) ValidateAuthenticator(ctx context.Context, a extsvcauth.Authen
 		GitHubAppAccount:       pointers.Deref(args.Username, ""),
 		GitHubAppKind:          args.GitHubAppKind,
 		AuthenticationStrategy: as,
-		AsGitHubApp:            true,
+
+		// This is set to true because we want to validate the authenticator, not
+		// actually use it to create changesets.
+		AsNonCredential: true,
 	})
 	if err != nil {
 		return err

--- a/internal/batches/service/service.go
+++ b/internal/batches/service/service.go
@@ -1125,7 +1125,7 @@ func (s *Service) EnqueueChangesetSync(ctx context.Context, id int64) (err error
 	ctx, _, endObservation := s.operations.enqueueChangesetSync.With(ctx, &err, observation.Args{})
 	defer endObservation(1, observation.Args{})
 
-	// Check for existence of changeset so we don't swallow that error.
+	// Check for existence of changeset, so we don't swallow that error.
 	changeset, err := s.store.GetChangeset(ctx, store.GetChangesetOpts{ID: id})
 	if err != nil {
 		return err
@@ -1222,10 +1222,10 @@ func (s *Service) ReenqueueChangeset(ctx context.Context, id int64) (changeset *
 
 // CheckNamespaceAccess checks whether the current user in the ctx has access
 // to either the user ID or the org ID as a namespace.
-// If the userID is non-zero that will be checked. Otherwise the org ID will be
+// If the userID is non-zero that will be checked. Otherwise, the org ID will be
 // checked.
 // If the current user is an admin, true will be returned.
-// Otherwise it checks whether the current user _is_ the namespace user or has
+// Otherwise, it checks whether the current user _is_ the namespace user or has
 // access to the namespace org.
 // If both values are zero, an error is returned.
 func (s *Service) CheckNamespaceAccess(ctx context.Context, namespaceUserID, namespaceOrgID int32) (err error) {
@@ -1248,7 +1248,7 @@ var ErrNoNamespace = errors.New("no namespace given")
 // FetchUsernameForBitbucketServerToken fetches the username associated with a
 // Bitbucket server token.
 //
-// We need the username in order to use the token as the password in a HTTP
+// We need the username in order to use the token as the password in an HTTP
 // BasicAuth username/password pair used by gitserver to push commits.
 //
 // In order to not require from users to type in their BitbucketServer username
@@ -1262,10 +1262,11 @@ func (s *Service) FetchUsernameForBitbucketServerToken(ctx context.Context, exte
 	defer endObservation(1, observation.Args{})
 
 	// Get a changeset source for the external service and use the given authenticator.
-	css, err := s.sourcer.ForExternalService(ctx, s.store, &extsvcauth.OAuthBearerToken{Token: token}, sources.ForExternalServiceOpts{
-		ExternalServiceType: externalServiceType,
-		ExternalServiceID:   externalServiceID,
-	}, sources.AuthenticationStrategyUserCredential)
+	css, err := s.sourcer.ForExternalService(ctx, s.store, &extsvcauth.OAuthBearerToken{Token: token}, sources.SourcerOpts{
+		ExternalServiceType:    externalServiceType,
+		AuthenticationStrategy: sources.AuthenticationStrategyUserCredential,
+		ExternalServiceID:      externalServiceID,
+	})
 	if err != nil {
 		return "", err
 	}
@@ -1308,12 +1309,14 @@ func (s *Service) ValidateAuthenticator(ctx context.Context, a extsvcauth.Authen
 	}
 
 	// Get a changeset source for the external service and use the given authenticator.
-	css, err := s.sourcer.ForExternalService(ctx, s.store, a, sources.ForExternalServiceOpts{
-		ExternalServiceType: args.ExternalServiceType,
-		ExternalServiceID:   args.ExternalServiceID,
-		GitHubAppAccount:    pointers.Deref(args.Username, ""),
-		GitHubAppKind:       args.GitHubAppKind,
-	}, as)
+	css, err := s.sourcer.ForExternalService(ctx, s.store, a, sources.SourcerOpts{
+		ExternalServiceType:    args.ExternalServiceType,
+		ExternalServiceID:      args.ExternalServiceID,
+		GitHubAppAccount:       pointers.Deref(args.Username, ""),
+		GitHubAppKind:          args.GitHubAppKind,
+		AuthenticationStrategy: as,
+		AsGitHubApp:            true,
+	})
 	if err != nil {
 		return err
 	}
@@ -1960,7 +1963,7 @@ func (s *Service) generateAuthenticatorForCredential(ctx context.Context, args g
 		}
 		a = auther
 	} else if args.externalServiceType == extsvc.TypeBitbucketServer {
-		// We need to fetch the username for the token, as just an OAuth token isn't enough for some reason..
+		// We need to fetch the username for the token, as just an OAuth token isn't enough for some reason.
 		username, err := s.FetchUsernameForBitbucketServerToken(ctx, args.externalServiceURL, args.externalServiceType, args.credential)
 		if err != nil {
 			if bitbucketserver.IsUnauthorized(err) {

--- a/internal/batches/sources/sources.go
+++ b/internal/batches/sources/sources.go
@@ -95,7 +95,10 @@ type SourcerOpts struct {
 	GitHubAppKind          ghtypes.GitHubAppKind
 	AuthenticationStrategy AuthenticationStrategy
 
-	AsGitHubApp bool
+	// We sometimes create a sourcer for a changeset that without the use of a credential.
+	// An example is when we want to create a GitHubSource for a changeset that is to
+	// be signed by a GitHub app.
+	AsNonCredential bool
 }
 
 // Sourcer exposes methods to get a ChangesetSource based on a changeset, repo or
@@ -169,7 +172,7 @@ func (s *sourcer) ForChangeset(ctx context.Context, tx SourcerStore, ch *btypes.
 		return nil, err
 	}
 
-	if opts.AsGitHubApp {
+	if opts.AsNonCredential {
 		return s.createChangesetSourceForGHApp(ctx, tx, css, extSvc, ch, targetRepo, repo, opts)
 	}
 
@@ -299,7 +302,7 @@ func (s *sourcer) ForExternalService(ctx context.Context, tx SourcerStore, au au
 		return nil, err
 	}
 
-	if opts.AsGitHubApp {
+	if opts.AsNonCredential {
 		return s.createChangesetSourceForGHApp(ctx, tx, css, extSvc, nil, nil, nil, opts)
 	}
 	return css.WithAuthenticator(au)

--- a/internal/batches/sources/sources.go
+++ b/internal/batches/sources/sources.go
@@ -170,7 +170,7 @@ func (s *sourcer) ForChangeset(ctx context.Context, tx SourcerStore, ch *btypes.
 	}
 
 	if opts.AsGitHubApp {
-		return s.createChangesetSourceForCommitSigning(ctx, tx, css, extSvc, ch, targetRepo, repo, opts)
+		return s.createChangesetSourceForGHApp(ctx, tx, css, extSvc, ch, targetRepo, repo, opts)
 	}
 
 	if ch.OwnedByBatchChangeID != 0 {
@@ -185,9 +185,8 @@ func (s *sourcer) ForChangeset(ctx context.Context, tx SourcerStore, ch *btypes.
 	return withSiteAuthenticator(ctx, tx, css, repo)
 }
 
-// createChangesetSourceForCommitSigning creates a changeset source that is authenticated with the commit signing module.
-// Currently, we only support the use of GitHub apps for commit signing,
-func (s *sourcer) createChangesetSourceForCommitSigning(
+// createChangesetSourceForGHApp creates a changeset source that is authenticated with a GitHub app.
+func (s *sourcer) createChangesetSourceForGHApp(
 	ctx context.Context,
 	tx SourcerStore,
 	css ChangesetSource,
@@ -301,7 +300,7 @@ func (s *sourcer) ForExternalService(ctx context.Context, tx SourcerStore, au au
 	}
 
 	if opts.AsGitHubApp {
-		return s.createChangesetSourceForCommitSigning(ctx, tx, css, extSvc, nil, nil, nil, opts)
+		return s.createChangesetSourceForGHApp(ctx, tx, css, extSvc, nil, nil, nil, opts)
 	}
 	return css.WithAuthenticator(au)
 }

--- a/internal/batches/sources/sources_test.go
+++ b/internal/batches/sources/sources_test.go
@@ -542,6 +542,7 @@ func TestSourcer_ForChangeset(t *testing.T) {
 			have, err := newMockSourcer(css).ForChangeset(ctx, tx, ch, repo, SourcerOpts{
 				AuthenticationStrategy: AuthenticationStrategyGitHubApp,
 				GitHubAppKind:          ghatypes.SiteCredentialGitHubAppKind,
+				AsNonCredential:        true,
 			})
 			assert.NoError(t, err)
 			assert.Same(t, want, have)
@@ -608,6 +609,7 @@ func TestSourcer_ForChangeset(t *testing.T) {
 			have, err := newMockSourcer(css).ForChangeset(ctx, tx, ch, targetRepo, SourcerOpts{
 				AuthenticationStrategy: AuthenticationStrategyGitHubApp,
 				GitHubAppKind:          ghatypes.SiteCredentialGitHubAppKind,
+				AsNonCredential:        true,
 			})
 			assert.NoError(t, err)
 			assert.Same(t, want, have)

--- a/internal/batches/sources/sources_test.go
+++ b/internal/batches/sources/sources_test.go
@@ -411,7 +411,9 @@ func TestSourcer_ForChangeset(t *testing.T) {
 				return want, nil
 			})
 
-			have, err := newMockSourcer(css).ForChangeset(ctx, tx, ch, AuthenticationStrategyUserCredential, repo, "")
+			have, err := newMockSourcer(css).ForChangeset(ctx, tx, ch, repo, SourcerOpts{
+				AuthenticationStrategy: AuthenticationStrategyUserCredential,
+			})
 			assert.NoError(t, err)
 			assert.Same(t, want, have)
 		})
@@ -452,7 +454,7 @@ func TestSourcer_ForChangeset(t *testing.T) {
 				return want, nil
 			})
 
-			have, err := newMockSourcer(css).ForChangeset(ctx, tx, ch, AuthenticationStrategyUserCredential, repo, "")
+			have, err := newMockSourcer(css).ForChangeset(ctx, tx, ch, repo, SourcerOpts{AuthenticationStrategy: AuthenticationStrategyUserCredential})
 			assert.NoError(t, err)
 			assert.Same(t, want, have)
 		})
@@ -487,7 +489,7 @@ func TestSourcer_ForChangeset(t *testing.T) {
 			tx.ExternalServicesFunc.SetDefaultReturn(extsvcStore)
 
 			css := NewMockChangesetSource()
-			_, err := newMockSourcer(css).ForChangeset(ctx, tx, ch, AuthenticationStrategyUserCredential, repo, "")
+			_, err := newMockSourcer(css).ForChangeset(ctx, tx, ch, repo, SourcerOpts{AuthenticationStrategy: AuthenticationStrategyUserCredential})
 			assert.Error(t, err)
 		})
 
@@ -537,7 +539,10 @@ func TestSourcer_ForChangeset(t *testing.T) {
 				return want, nil
 			})
 
-			have, err := newMockSourcer(css).ForChangeset(ctx, tx, ch, AuthenticationStrategyGitHubApp, repo, ghatypes.SiteCredentialGitHubAppKind)
+			have, err := newMockSourcer(css).ForChangeset(ctx, tx, ch, repo, SourcerOpts{
+				AuthenticationStrategy: AuthenticationStrategyGitHubApp,
+				GitHubAppKind:          ghatypes.SiteCredentialGitHubAppKind,
+			})
 			assert.NoError(t, err)
 			assert.Same(t, want, have)
 		})
@@ -600,7 +605,10 @@ func TestSourcer_ForChangeset(t *testing.T) {
 				},
 			}
 
-			have, err := newMockSourcer(css).ForChangeset(ctx, tx, ch, AuthenticationStrategyGitHubApp, targetRepo, ghatypes.SiteCredentialGitHubAppKind)
+			have, err := newMockSourcer(css).ForChangeset(ctx, tx, ch, targetRepo, SourcerOpts{
+				AuthenticationStrategy: AuthenticationStrategyGitHubApp,
+				GitHubAppKind:          ghatypes.SiteCredentialGitHubAppKind,
+			})
 			assert.NoError(t, err)
 			assert.Same(t, want, have)
 		})
@@ -633,7 +641,7 @@ func TestSourcer_ForChangeset(t *testing.T) {
 				return want, nil
 			})
 
-			have, err := newMockSourcer(css).ForChangeset(ctx, tx, ch, AuthenticationStrategyUserCredential, repo, "")
+			have, err := newMockSourcer(css).ForChangeset(ctx, tx, ch, repo, SourcerOpts{AuthenticationStrategy: AuthenticationStrategyUserCredential})
 			assert.NoError(t, err)
 			assert.Same(t, want, have)
 		})
@@ -659,7 +667,7 @@ func TestSourcer_ForChangeset(t *testing.T) {
 			want := errors.New("validator was called")
 			css.ValidateAuthenticatorFunc.SetDefaultReturn(want)
 
-			_, err := newMockSourcer(css).ForChangeset(ctx, tx, ch, AuthenticationStrategyUserCredential, repo, "")
+			_, err := newMockSourcer(css).ForChangeset(ctx, tx, ch, repo, SourcerOpts{AuthenticationStrategy: AuthenticationStrategyUserCredential})
 			assert.Error(t, err)
 		})
 	})

--- a/internal/batches/sources/testing/BUILD.bazel
+++ b/internal/batches/sources/testing/BUILD.bazel
@@ -10,7 +10,6 @@ go_library(
         "//internal/batches/sources",
         "//internal/batches/types",
         "//internal/extsvc/auth",
-        "//internal/github_apps/types",
         "//internal/gitserver/protocol",
         "//internal/types",
         "//lib/errors",

--- a/internal/batches/sources/testing/fake.go
+++ b/internal/batches/sources/testing/fake.go
@@ -2,7 +2,6 @@ package testing
 
 import (
 	"context"
-	ghtypes "github.com/sourcegraph/sourcegraph/internal/github_apps/types"
 
 	"github.com/sourcegraph/sourcegraph/internal/batches/sources"
 	btypes "github.com/sourcegraph/sourcegraph/internal/batches/types"
@@ -25,7 +24,7 @@ type fakeSourcer struct {
 	source sources.ChangesetSource
 }
 
-func (s *fakeSourcer) ForChangeset(ctx context.Context, tx sources.SourcerStore, ch *btypes.Changeset, as sources.AuthenticationStrategy, repo *types.Repo, gitHubAppKind ghtypes.GitHubAppKind) (sources.ChangesetSource, error) {
+func (s *fakeSourcer) ForChangeset(_ context.Context, _ sources.SourcerStore, _ *btypes.Changeset, _ *types.Repo, _ sources.SourcerOpts) (sources.ChangesetSource, error) {
 	return s.source, s.err
 }
 
@@ -33,7 +32,7 @@ func (s *fakeSourcer) ForUser(ctx context.Context, tx sources.SourcerStore, uid 
 	return s.source, s.err
 }
 
-func (s *fakeSourcer) ForExternalService(ctx context.Context, tx sources.SourcerStore, au auth.Authenticator, opts sources.ForExternalServiceOpts, as sources.AuthenticationStrategy) (sources.ChangesetSource, error) {
+func (s *fakeSourcer) ForExternalService(_ context.Context, _ sources.SourcerStore, _ auth.Authenticator, _ sources.SourcerOpts) (sources.ChangesetSource, error) {
 	return s.source, s.err
 }
 

--- a/internal/batches/syncer/syncer.go
+++ b/internal/batches/syncer/syncer.go
@@ -497,7 +497,9 @@ func (s *changesetSyncer) SyncChangeset(ctx context.Context, id int64) error {
 	}
 
 	srcer := sources.NewSourcer(s.httpFactory)
-	source, err := srcer.ForChangeset(ctx, s.syncStore, cs, sources.AuthenticationStrategyUserCredential, repo, "")
+	source, err := srcer.ForChangeset(ctx, s.syncStore, cs, repo, sources.SourcerOpts{
+		AuthenticationStrategy: sources.AuthenticationStrategyUserCredential,
+	})
 	if err != nil {
 		if errors.Is(err, store.ErrDeletedNamespace) {
 			syncLogger.Debug("SyncChangeset skipping changeset: namespace deleted")


### PR DESCRIPTION
<!-- PR description tips: https://www.notion.so/sourcegraph/Write-a-good-pull-request-description-610a7fd3e613496eb76f450db5a49b6e -->
This PR simplifies the Sourcer interface.

We added a couple of args and the `ForChangeset` and `ForExternalService` methods were looking a bit cumbersome to understand.

## Test plan

<!-- REQUIRED; info at https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles -->
Existing tests should be passing.

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
