### PR TITLE
Bump code-web-experimental version to 0.2.0

### DIFF
--- a/client/web/bundlesize.config.js
+++ b/client/web/bundlesize.config.js
@@ -22,7 +22,7 @@ const config = {
     },
     {
       path: path.join(STATIC_ASSETS_PATH, 'chunks/chunk-*.js'),
-      maxSize: '6.45MB', // Cody web chunk is very big
+      maxSize: '7MB', // Cody web chunk is very big
     },
     /**
      * Our main entry CSS bundle, contains core styles that are loaded on every page.

--- a/client/web/src/cody/chat/new-chat/NewCodyChatPage.tsx
+++ b/client/web/src/cody/chat/new-chat/NewCodyChatPage.tsx
@@ -1,6 +1,6 @@
 import type { FC } from 'react'
 
-import { ChatHistory, CodyWebChatProvider } from 'cody-web-experimental'
+import { CodyWebHistory, CodyWebChatProvider } from 'cody-web-experimental'
 import { Navigate } from 'react-router-dom'
 
 import { Badge, ButtonLink, PageHeader, Text } from '@sourcegraph/wildcard'
@@ -31,12 +31,8 @@ export const NewCodyChatPage: FC<NewCodyChatPageProps> = props => {
             <CodyPageHeader isSourcegraphDotCom={isSourcegraphDotCom} className={styles.pageHeader} />
 
             <div className={styles.chatContainer}>
-                <CodyWebChatProvider
-                    accessToken=""
-                    serverEndpoint={window.location.origin}
-                    initialContext={{ repositories: [] }}
-                >
-                    <ChatHistory>
+                <CodyWebChatProvider accessToken="" serverEndpoint={window.location.origin}>
+                    <CodyWebHistory>
                         {history => (
                             <div className={styles.chatHistory}>
                                 {history.loading && (
@@ -59,7 +55,7 @@ export const NewCodyChatPage: FC<NewCodyChatPageProps> = props => {
                                 )}
                             </div>
                         )}
-                    </ChatHistory>
+                    </CodyWebHistory>
                     <ChatUi className={styles.chat} />
                 </CodyWebChatProvider>
             </div>

--- a/client/web/src/cody/chat/new-chat/components/chat-history-list/ChatHistoryList.module.scss
+++ b/client/web/src/cody/chat/new-chat/components/chat-history-list/ChatHistoryList.module.scss
@@ -42,6 +42,15 @@
         color: var(--icon-color);
         visibility: hidden;
     }
+
+    &-title {
+        overflow: hidden;
+        display: -webkit-box;
+        line-clamp: 2;
+        -webkit-line-clamp: 3;
+        -webkit-box-orient: vertical;
+        margin-bottom: 0;
+    }
 }
 
 .footer {

--- a/client/web/src/cody/chat/new-chat/components/chat-history-list/ChatHistoryList.module.scss
+++ b/client/web/src/cody/chat/new-chat/components/chat-history-list/ChatHistoryList.module.scss
@@ -45,6 +45,8 @@
 
     &-title {
         overflow: hidden;
+        // Truncation for multiple lines
+        // stylelint-disable-next-line value-no-vendor-prefix
         display: -webkit-box;
         line-clamp: 2;
         -webkit-line-clamp: 3;

--- a/client/web/src/cody/chat/new-chat/components/chat-history-list/ChatHistoryList.tsx
+++ b/client/web/src/cody/chat/new-chat/components/chat-history-list/ChatHistoryList.tsx
@@ -1,9 +1,9 @@
 import type { FC } from 'react'
-import { MouseEvent, useMemo } from 'react'
+import { type MouseEvent, useMemo } from 'react'
 
 import { mdiDelete, mdiPlus } from '@mdi/js'
 import classNames from 'classnames'
-import { type ChatExportResult, getChatTitle } from 'cody-web-experimental'
+import type { ChatExportResult } from 'cody-web-experimental'
 
 import { Timestamp } from '@sourcegraph/branded/src/components/Timestamp'
 import { Icon, Text, Tooltip, Button } from '@sourcegraph/wildcard'
@@ -16,7 +16,7 @@ interface ChatHistoryListProps {
     className?: string
     onChatSelect: (chat: ChatExportResult) => void
     onChatDelete: (chat: ChatExportResult) => void
-    onChatCreate: () => void
+    onChatCreate: (force?: boolean) => void
 }
 
 export const ChatHistoryList: FC<ChatHistoryListProps> = props => {
@@ -24,11 +24,19 @@ export const ChatHistoryList: FC<ChatHistoryListProps> = props => {
 
     const sortedChats = useMemo(() => {
         try {
-            return [...chats].sort(
+            const sortedChats = [...chats].sort(
                 (chatA, chatB) =>
                     +safeTimestampToDate(chatB.transcript.lastInteractionTimestamp) -
                     +safeTimestampToDate(chatA.transcript.lastInteractionTimestamp)
             )
+
+            const mostRecentEmptyChat = sortedChats.find(chat => chat.transcript.interactions.length === 0)
+
+            if (mostRecentEmptyChat) {
+                return [mostRecentEmptyChat, ...sortedChats.filter(chat => chat.transcript.interactions.length > 0)]
+            }
+
+            return sortedChats
         } catch {
             return chats
         }
@@ -46,7 +54,7 @@ export const ChatHistoryList: FC<ChatHistoryListProps> = props => {
                 />
             ))}
             <footer className={styles.footer}>
-                <Button variant="primary" onClick={onChatCreate} className="w-100">
+                <Button variant="primary" onClick={() => onChatCreate()} className="w-100">
                     Start new chat
                     <Icon aria-label="Add chat" svgPath={mdiPlus} />
                 </Button>
@@ -87,13 +95,13 @@ const ChatHistoryItem: FC<ChatHistoryItemProps> = props => {
                         <Icon
                             aria-label="Delete chat"
                             svgPath={mdiDelete}
-                            // eslint-disable-next-line jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions
+
                             onClick={handleDelete}
                             className={styles.deleteButton}
                         />
                     </Tooltip>
                 </div>
-                <Text className="mb-0 truncate text-body">{title}</Text>
+                <Text className={styles.historyItemTitle}>{title}</Text>
             </button>
         </li>
     )
@@ -105,4 +113,18 @@ function safeTimestampToDate(timestamp: string = ''): Date {
     }
 
     return new Date(timestamp)
+}
+
+export function getChatTitle(chat: ChatExportResult): string {
+    if (chat.transcript.chatTitle) {
+        return chat.transcript.chatTitle
+    }
+
+    if (chat.transcript.interactions.length > 0) {
+        const firstQuestion = chat.transcript.interactions.find(interaction => interaction.humanMessage.text)
+
+        return firstQuestion?.humanMessage.text ?? ''
+    }
+
+    return 'New Cody Chat'
 }

--- a/client/web/src/cody/chat/new-chat/components/chat-history-list/ChatHistoryList.tsx
+++ b/client/web/src/cody/chat/new-chat/components/chat-history-list/ChatHistoryList.tsx
@@ -95,7 +95,6 @@ const ChatHistoryItem: FC<ChatHistoryItemProps> = props => {
                         <Icon
                             aria-label="Delete chat"
                             svgPath={mdiDelete}
-
                             onClick={handleDelete}
                             className={styles.deleteButton}
                         />

--- a/client/web/src/cody/chat/new-chat/components/chat-history-list/ChatHistoryList.tsx
+++ b/client/web/src/cody/chat/new-chat/components/chat-history-list/ChatHistoryList.tsx
@@ -15,7 +15,10 @@ export interface ChatExportResult {
         id: string
         chatModel?: string
         chatTitle?: string
-        interactions: unknown[]
+        interactions: {
+            humanMessage: { text: string }
+        }[]
+        lastInteractionTimestamp: string
     }
 }
 

--- a/client/web/src/cody/chat/new-chat/components/chat-history-list/ChatHistoryList.tsx
+++ b/client/web/src/cody/chat/new-chat/components/chat-history-list/ChatHistoryList.tsx
@@ -3,12 +3,21 @@ import { type MouseEvent, useMemo } from 'react'
 
 import { mdiDelete, mdiPlus } from '@mdi/js'
 import classNames from 'classnames'
-import type { ChatExportResult } from 'cody-web-experimental'
 
 import { Timestamp } from '@sourcegraph/branded/src/components/Timestamp'
 import { Icon, Text, Tooltip, Button } from '@sourcegraph/wildcard'
 
 import styles from './ChatHistoryList.module.scss'
+
+export interface ChatExportResult {
+    chatID: string
+    transcript: {
+        id: string
+        chatModel?: string
+        chatTitle?: string
+        interactions: unknown[]
+    }
+}
 
 interface ChatHistoryListProps {
     chats: ChatExportResult[]

--- a/client/web/src/cody/chat/new-chat/components/chat-ui/ChatUI.module.scss
+++ b/client/web/src/cody/chat/new-chat/components/chat-ui/ChatUI.module.scss
@@ -37,8 +37,9 @@
     }
 
     code {
+        // stylelint-disable-next-line declaration-property-unit-allowed-list
         padding: 1px 3px;
-        border-radius: 4px;
+        border-radius: 0.25rem;
         font-family: var(--monaco-monospace-font);
         color: var(--vscode-textPreformat-foreground);
         background-color: var(--vscode-textPreformat-background);

--- a/client/web/src/cody/chat/new-chat/components/chat-ui/ChatUI.module.scss
+++ b/client/web/src/cody/chat/new-chat/components/chat-ui/ChatUI.module.scss
@@ -1,5 +1,11 @@
 // stylelint-disable custom-property-pattern
 
+:root {
+    // Turn off background color for picker popover element
+    // Which causes glitch effect in Cody Web
+    --vscode-sideBar-background: transparent;
+}
+
 .chat {
     --vscode-editor-background: var(--body-bg);
     --vscode-editor-foreground: var(--body-color);

--- a/client/web/src/cody/chat/new-chat/components/chat-ui/ChatUI.module.scss
+++ b/client/web/src/cody/chat/new-chat/components/chat-ui/ChatUI.module.scss
@@ -10,7 +10,12 @@
     --vscode-inputOption-activeBackground: var(--search-input-token-filter);
     --vscode-inputOption-activeForeground: var(--body-color);
     --vscode-loading-dot-color: var(--body-color);
+    --vscode-textPreformat-foreground: var(--body-color);
+    --vscode-textPreformat-background: var(--secondary);
+    --vscode-sideBarSectionHeader-border: var(--border-color);
     --mention-color-opacity: 100%;
+
+    line-height: 1.55;
 
     h3 {
         font-size: inherit;
@@ -23,6 +28,27 @@
 
     a {
         color: var(--link-color) !important;
+    }
+
+    code {
+        padding: 1px 3px;
+        border-radius: 4px;
+        font-family: var(--monaco-monospace-font);
+        color: var(--vscode-textPreformat-foreground);
+        background-color: var(--vscode-textPreformat-background);
+    }
+
+    pre code {
+        padding: 0;
+    }
+
+    // Sourcegraph styles already add [hidden] display none
+    // and this breaks chat animation since there is no starting point
+    // with display:none element. Override this logic back to visibility: hidden;
+    // so chat animation would work again.
+    [hidden] {
+        visibility: hidden;
+        display: block !important;
     }
 }
 

--- a/package.json
+++ b/package.json
@@ -333,7 +333,7 @@
     "bloomfilter": "^0.0.18",
     "buffer": "^6.0.3",
     "classnames": "^2.2.6",
-    "cody-web-experimental": "^0.1.4",
+    "cody-web-experimental": "^0.2.0",
     "comlink": "^4.3.0",
     "copy-to-clipboard": "^3.3.1",
     "core-js": "^3.8.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -206,8 +206,8 @@ importers:
         specifier: ^2.2.6
         version: 2.3.2
       cody-web-experimental:
-        specifier: ^0.1.4
-        version: 0.1.4
+        specifier: ^0.2.0
+        version: 0.2.0
       comlink:
         specifier: ^4.3.0
         version: 4.3.0
@@ -14541,6 +14541,10 @@ packages:
 
   /cody-web-experimental@0.1.4:
     resolution: {integrity: sha512-5WE+ZWfbNhXJxvJeCFfyJPHNaPZKEdJAGoFa7sSXoxdeUEN62YGIs5DmpCOEmSCzX0cQm+35GWRWoV28HI/0jg==}
+    dev: false
+
+  /cody-web-experimental@0.2.0:
+    resolution: {integrity: sha512-fBuYER4PDN89y82J5eyBtmsIJUIFDECgYatCEp9+8ZnaaECviIGSfp49nnb6wUeqo9n7pVT/xdHIQ/sBPh/zjg==}
     dev: false
 
   /color-convert@1.9.3:


### PR DESCRIPTION
This PR bumps `cody-web-experimental` package to 0.2.0 which includes
- Fixes for UI flashes
- Support openCTX mention providers
- Fixes for cursor jumping
- Fixes for style leaking 

Here as well I included a few minor UI fixes for the chat which close 
- [CODY-2721 ](https://linear.app/sourcegraph/issue/CODY-2721/investigate-a-lot-of-empty-chats-being-added-each-time-you-view-a)
- [SRCH-671](https://linear.app/sourcegraph/issue/SRCH-671/truncate-chat-message-in-history-pane-and-show-new-message-instead-of)
- [SRCH-674](https://linear.app/sourcegraph/issue/SRCH-674/dont-show-empty-chats-generated-by-cody-blob-ui-view)
- [SRCH-647](https://linear.app/sourcegraph/issue/SRCH-647/glitches-in-rounded-corners-of-mention-menu)

I will update the package for the Svelte version as a follow-up early next week.

## Test plan
- Install the most recent deps
- Run sg start web-standalone
- Check chat UI on the standalone chat page and in blob UI 
