### PR TITLE
feat(batches): allow use of github app token for gitserver push

### DIFF
--- a/internal/batches/reconciler/executor.go
+++ b/internal/batches/reconciler/executor.go
@@ -4,11 +4,12 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	ghtypes "github.com/sourcegraph/sourcegraph/internal/github_apps/types"
 	"strings"
 	"sync"
 	"text/template"
 	"time"
+
+	ghtypes "github.com/sourcegraph/sourcegraph/internal/github_apps/types"
 
 	"github.com/inconshreveable/log15" //nolint:logging // TODO move all logging to sourcegraph/log
 	"github.com/sourcegraph/log"
@@ -198,7 +199,7 @@ func (e *executor) pushChangesetPatch(ctx context.Context, triggerUpdateWebhook 
 		return afterDone, errCannotPushToArchivedRepo
 	}
 
-	pushConf, err := css.GitserverPushConfig(remoteRepo)
+	pushConf, err := css.GitserverPushConfig(ctx, remoteRepo)
 	if err != nil {
 		return afterDone, err
 	}

--- a/internal/batches/reconciler/executor.go
+++ b/internal/batches/reconciler/executor.go
@@ -9,8 +9,6 @@ import (
 	"text/template"
 	"time"
 
-	ghtypes "github.com/sourcegraph/sourcegraph/internal/github_apps/types"
-
 	"github.com/inconshreveable/log15" //nolint:logging // TODO move all logging to sourcegraph/log
 	"github.com/sourcegraph/log"
 
@@ -23,6 +21,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
+	ghtypes "github.com/sourcegraph/sourcegraph/internal/github_apps/types"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/repos"

--- a/internal/batches/sources/azuredevops.go
+++ b/internal/batches/sources/azuredevops.go
@@ -57,8 +57,8 @@ func NewAzureDevOpsSource(ctx context.Context, svc *types.ExternalService, cf *h
 
 // GitserverPushConfig returns an authenticated push config used for pushing
 // commits to the code host.
-func (s AzureDevOpsSource) GitserverPushConfig(repo *types.Repo) (*protocol.PushConfig, error) {
-	return GitserverPushConfig(repo, s.client.Authenticator())
+func (s AzureDevOpsSource) GitserverPushConfig(ctx context.Context, repo *types.Repo) (*protocol.PushConfig, error) {
+	return GitserverPushConfig(ctx, repo, s.client.Authenticator())
 }
 
 // WithAuthenticator returns a copy of the original Source configured to use the

--- a/internal/batches/sources/azuredevops_test.go
+++ b/internal/batches/sources/azuredevops_test.go
@@ -62,7 +62,8 @@ func TestAzureDevOpsSource_GitserverPushConfig(t *testing.T) {
 		},
 	}
 
-	pushConfig, err := s.GitserverPushConfig(repo)
+	ctx := context.Background()
+	pushConfig, err := s.GitserverPushConfig(ctx, repo)
 	assert.Nil(t, err)
 	assert.NotNil(t, pushConfig)
 	assert.Equal(t, "https://user:pass@dev.azure.com/testorg/testproject/_git/testrepo", pushConfig.RemoteURL)

--- a/internal/batches/sources/bitbucketcloud.go
+++ b/internal/batches/sources/bitbucketcloud.go
@@ -56,8 +56,8 @@ func NewBitbucketCloudSource(ctx context.Context, svc *types.ExternalService, cf
 
 // GitserverPushConfig returns an authenticated push config used for pushing
 // commits to the code host.
-func (s BitbucketCloudSource) GitserverPushConfig(repo *types.Repo) (*protocol.PushConfig, error) {
-	return GitserverPushConfig(repo, s.client.Authenticator())
+func (s BitbucketCloudSource) GitserverPushConfig(ctx context.Context, repo *types.Repo) (*protocol.PushConfig, error) {
+	return GitserverPushConfig(ctx, repo, s.client.Authenticator())
 }
 
 // WithAuthenticator returns a copy of the original Source configured to use the

--- a/internal/batches/sources/bitbucketcloud_test.go
+++ b/internal/batches/sources/bitbucketcloud_test.go
@@ -84,7 +84,8 @@ func TestBitbucketCloudSource_GitserverPushConfig(t *testing.T) {
 		},
 	}
 
-	pushConfig, err := s.GitserverPushConfig(repo)
+	ctx := context.Background()
+	pushConfig, err := s.GitserverPushConfig(ctx, repo)
 	assert.Nil(t, err)
 	assert.NotNil(t, pushConfig)
 	assert.Equal(t, "https://user:pass@bitbucket.org/clone/link", pushConfig.RemoteURL)

--- a/internal/batches/sources/bitbucketserver.go
+++ b/internal/batches/sources/bitbucketserver.go
@@ -61,8 +61,8 @@ func NewBitbucketServerSource(ctx context.Context, svc *types.ExternalService, c
 	}, nil
 }
 
-func (s BitbucketServerSource) GitserverPushConfig(repo *types.Repo) (*protocol.PushConfig, error) {
-	return GitserverPushConfig(repo, s.au)
+func (s BitbucketServerSource) GitserverPushConfig(ctx context.Context, repo *types.Repo) (*protocol.PushConfig, error) {
+	return GitserverPushConfig(ctx, repo, s.au)
 }
 
 func (s BitbucketServerSource) WithAuthenticator(a auth.Authenticator) (ChangesetSource, error) {

--- a/internal/batches/sources/common.go
+++ b/internal/batches/sources/common.go
@@ -64,7 +64,7 @@ type ForkableChangesetSource interface {
 type ChangesetSource interface {
 	// GitserverPushConfig returns an authenticated push config used for pushing
 	// commits to the code host.
-	GitserverPushConfig(*types.Repo) (*protocol.PushConfig, error)
+	GitserverPushConfig(context.Context, *types.Repo) (*protocol.PushConfig, error)
 	// WithAuthenticator returns a copy of the original Source configured to use
 	// the given authenticator, provided that authenticator type is supported by
 	// the code host.

--- a/internal/batches/sources/gerrit.go
+++ b/internal/batches/sources/gerrit.go
@@ -62,8 +62,8 @@ func NewGerritSource(ctx context.Context, svc *types.ExternalService, cf *httpcl
 
 // GitserverPushConfig returns an authenticated push config used for pushing
 // commits to the code host.
-func (s GerritSource) GitserverPushConfig(repo *types.Repo) (*protocol.PushConfig, error) {
-	return GitserverPushConfig(repo, s.client.Authenticator())
+func (s GerritSource) GitserverPushConfig(ctx context.Context, repo *types.Repo) (*protocol.PushConfig, error) {
+	return GitserverPushConfig(ctx, repo, s.client.Authenticator())
 }
 
 // WithAuthenticator returns a copy of the original Source configured to use the

--- a/internal/batches/sources/gerrit_test.go
+++ b/internal/batches/sources/gerrit_test.go
@@ -55,7 +55,8 @@ func TestGerritSource_GitserverPushConfig(t *testing.T) {
 		},
 	}
 
-	pushConfig, err := s.GitserverPushConfig(repo)
+	ctx := context.Background()
+	pushConfig, err := s.GitserverPushConfig(ctx, repo)
 	assert.Nil(t, err)
 	assert.NotNil(t, pushConfig)
 	assert.Equal(t, "https://user:pass@gerrit.sgdev.org/testrepo", pushConfig.RemoteURL)

--- a/internal/batches/sources/github.go
+++ b/internal/batches/sources/github.go
@@ -78,8 +78,8 @@ func newGitHubSource(ctx context.Context, db database.DB, urn string, c *schema.
 	}, nil
 }
 
-func (s GitHubSource) GitserverPushConfig(repo *types.Repo) (*protocol.PushConfig, error) {
-	return GitserverPushConfig(repo, s.au)
+func (s GitHubSource) GitserverPushConfig(ctx context.Context, repo *types.Repo) (*protocol.PushConfig, error) {
+	return GitserverPushConfig(ctx, repo, s.au)
 }
 
 func (s GitHubSource) WithAuthenticator(a auth.Authenticator) (ChangesetSource, error) {

--- a/internal/batches/sources/gitlab.go
+++ b/internal/batches/sources/gitlab.go
@@ -82,8 +82,8 @@ func newGitLabSource(urn string, c *schema.GitLabConnection, cf *httpcli.Factory
 	}, nil
 }
 
-func (s GitLabSource) GitserverPushConfig(repo *types.Repo) (*protocol.PushConfig, error) {
-	return GitserverPushConfig(repo, s.au)
+func (s GitLabSource) GitserverPushConfig(ctx context.Context, repo *types.Repo) (*protocol.PushConfig, error) {
+	return GitserverPushConfig(ctx, repo, s.au)
 }
 
 func (s GitLabSource) WithAuthenticator(a auth.Authenticator) (ChangesetSource, error) {

--- a/internal/batches/sources/mocks_test.go
+++ b/internal/batches/sources/mocks_test.go
@@ -97,7 +97,7 @@ func NewMockChangesetSource() *MockChangesetSource {
 			},
 		},
 		GitserverPushConfigFunc: &ChangesetSourceGitserverPushConfigFunc{
-			defaultHook: func(*types.Repo) (r0 *protocol.PushConfig, r1 error) {
+			defaultHook: func(context.Context, *types.Repo) (r0 *protocol.PushConfig, r1 error) {
 				return
 			},
 		},
@@ -159,7 +159,7 @@ func NewStrictMockChangesetSource() *MockChangesetSource {
 			},
 		},
 		GitserverPushConfigFunc: &ChangesetSourceGitserverPushConfigFunc{
-			defaultHook: func(*types.Repo) (*protocol.PushConfig, error) {
+			defaultHook: func(context.Context, *types.Repo) (*protocol.PushConfig, error) {
 				panic("unexpected invocation of MockChangesetSource.GitserverPushConfig")
 			},
 		},
@@ -680,24 +680,24 @@ func (c ChangesetSourceCreateCommentFuncCall) Results() []interface{} {
 // GitserverPushConfig method of the parent MockChangesetSource instance is
 // invoked.
 type ChangesetSourceGitserverPushConfigFunc struct {
-	defaultHook func(*types.Repo) (*protocol.PushConfig, error)
-	hooks       []func(*types.Repo) (*protocol.PushConfig, error)
+	defaultHook func(context.Context, *types.Repo) (*protocol.PushConfig, error)
+	hooks       []func(context.Context, *types.Repo) (*protocol.PushConfig, error)
 	history     []ChangesetSourceGitserverPushConfigFuncCall
 	mutex       sync.Mutex
 }
 
 // GitserverPushConfig delegates to the next hook function in the queue and
 // stores the parameter and result values of this invocation.
-func (m *MockChangesetSource) GitserverPushConfig(v0 *types.Repo) (*protocol.PushConfig, error) {
-	r0, r1 := m.GitserverPushConfigFunc.nextHook()(v0)
-	m.GitserverPushConfigFunc.appendCall(ChangesetSourceGitserverPushConfigFuncCall{v0, r0, r1})
+func (m *MockChangesetSource) GitserverPushConfig(v0 context.Context, v1 *types.Repo) (*protocol.PushConfig, error) {
+	r0, r1 := m.GitserverPushConfigFunc.nextHook()(v0, v1)
+	m.GitserverPushConfigFunc.appendCall(ChangesetSourceGitserverPushConfigFuncCall{v0, v1, r0, r1})
 	return r0, r1
 }
 
 // SetDefaultHook sets function that is called when the GitserverPushConfig
 // method of the parent MockChangesetSource instance is invoked and the hook
 // queue is empty.
-func (f *ChangesetSourceGitserverPushConfigFunc) SetDefaultHook(hook func(*types.Repo) (*protocol.PushConfig, error)) {
+func (f *ChangesetSourceGitserverPushConfigFunc) SetDefaultHook(hook func(context.Context, *types.Repo) (*protocol.PushConfig, error)) {
 	f.defaultHook = hook
 }
 
@@ -706,7 +706,7 @@ func (f *ChangesetSourceGitserverPushConfigFunc) SetDefaultHook(hook func(*types
 // invokes the hook at the front of the queue and discards it. After the
 // queue is empty, the default hook function is invoked for any future
 // action.
-func (f *ChangesetSourceGitserverPushConfigFunc) PushHook(hook func(*types.Repo) (*protocol.PushConfig, error)) {
+func (f *ChangesetSourceGitserverPushConfigFunc) PushHook(hook func(context.Context, *types.Repo) (*protocol.PushConfig, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -715,19 +715,19 @@ func (f *ChangesetSourceGitserverPushConfigFunc) PushHook(hook func(*types.Repo)
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
 func (f *ChangesetSourceGitserverPushConfigFunc) SetDefaultReturn(r0 *protocol.PushConfig, r1 error) {
-	f.SetDefaultHook(func(*types.Repo) (*protocol.PushConfig, error) {
+	f.SetDefaultHook(func(context.Context, *types.Repo) (*protocol.PushConfig, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
 func (f *ChangesetSourceGitserverPushConfigFunc) PushReturn(r0 *protocol.PushConfig, r1 error) {
-	f.PushHook(func(*types.Repo) (*protocol.PushConfig, error) {
+	f.PushHook(func(context.Context, *types.Repo) (*protocol.PushConfig, error) {
 		return r0, r1
 	})
 }
 
-func (f *ChangesetSourceGitserverPushConfigFunc) nextHook() func(*types.Repo) (*protocol.PushConfig, error) {
+func (f *ChangesetSourceGitserverPushConfigFunc) nextHook() func(context.Context, *types.Repo) (*protocol.PushConfig, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -763,7 +763,10 @@ func (f *ChangesetSourceGitserverPushConfigFunc) History() []ChangesetSourceGits
 type ChangesetSourceGitserverPushConfigFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
-	Arg0 *types.Repo
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 *types.Repo
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 *protocol.PushConfig
@@ -775,7 +778,7 @@ type ChangesetSourceGitserverPushConfigFuncCall struct {
 // Args returns an interface slice containing the arguments of this
 // invocation.
 func (c ChangesetSourceGitserverPushConfigFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0}
+	return []interface{}{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
@@ -1502,7 +1505,7 @@ func NewMockForkableChangesetSource() *MockForkableChangesetSource {
 			},
 		},
 		GitserverPushConfigFunc: &ForkableChangesetSourceGitserverPushConfigFunc{
-			defaultHook: func(*types.Repo) (r0 *protocol.PushConfig, r1 error) {
+			defaultHook: func(context.Context, *types.Repo) (r0 *protocol.PushConfig, r1 error) {
 				return
 			},
 		},
@@ -1570,7 +1573,7 @@ func NewStrictMockForkableChangesetSource() *MockForkableChangesetSource {
 			},
 		},
 		GitserverPushConfigFunc: &ForkableChangesetSourceGitserverPushConfigFunc{
-			defaultHook: func(*types.Repo) (*protocol.PushConfig, error) {
+			defaultHook: func(context.Context, *types.Repo) (*protocol.PushConfig, error) {
 				panic("unexpected invocation of MockForkableChangesetSource.GitserverPushConfig")
 			},
 		},
@@ -2219,24 +2222,24 @@ func (c ForkableChangesetSourceGetForkFuncCall) Results() []interface{} {
 // when the GitserverPushConfig method of the parent
 // MockForkableChangesetSource instance is invoked.
 type ForkableChangesetSourceGitserverPushConfigFunc struct {
-	defaultHook func(*types.Repo) (*protocol.PushConfig, error)
-	hooks       []func(*types.Repo) (*protocol.PushConfig, error)
+	defaultHook func(context.Context, *types.Repo) (*protocol.PushConfig, error)
+	hooks       []func(context.Context, *types.Repo) (*protocol.PushConfig, error)
 	history     []ForkableChangesetSourceGitserverPushConfigFuncCall
 	mutex       sync.Mutex
 }
 
 // GitserverPushConfig delegates to the next hook function in the queue and
 // stores the parameter and result values of this invocation.
-func (m *MockForkableChangesetSource) GitserverPushConfig(v0 *types.Repo) (*protocol.PushConfig, error) {
-	r0, r1 := m.GitserverPushConfigFunc.nextHook()(v0)
-	m.GitserverPushConfigFunc.appendCall(ForkableChangesetSourceGitserverPushConfigFuncCall{v0, r0, r1})
+func (m *MockForkableChangesetSource) GitserverPushConfig(v0 context.Context, v1 *types.Repo) (*protocol.PushConfig, error) {
+	r0, r1 := m.GitserverPushConfigFunc.nextHook()(v0, v1)
+	m.GitserverPushConfigFunc.appendCall(ForkableChangesetSourceGitserverPushConfigFuncCall{v0, v1, r0, r1})
 	return r0, r1
 }
 
 // SetDefaultHook sets function that is called when the GitserverPushConfig
 // method of the parent MockForkableChangesetSource instance is invoked and
 // the hook queue is empty.
-func (f *ForkableChangesetSourceGitserverPushConfigFunc) SetDefaultHook(hook func(*types.Repo) (*protocol.PushConfig, error)) {
+func (f *ForkableChangesetSourceGitserverPushConfigFunc) SetDefaultHook(hook func(context.Context, *types.Repo) (*protocol.PushConfig, error)) {
 	f.defaultHook = hook
 }
 
@@ -2245,7 +2248,7 @@ func (f *ForkableChangesetSourceGitserverPushConfigFunc) SetDefaultHook(hook fun
 // instance invokes the hook at the front of the queue and discards it.
 // After the queue is empty, the default hook function is invoked for any
 // future action.
-func (f *ForkableChangesetSourceGitserverPushConfigFunc) PushHook(hook func(*types.Repo) (*protocol.PushConfig, error)) {
+func (f *ForkableChangesetSourceGitserverPushConfigFunc) PushHook(hook func(context.Context, *types.Repo) (*protocol.PushConfig, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -2254,19 +2257,19 @@ func (f *ForkableChangesetSourceGitserverPushConfigFunc) PushHook(hook func(*typ
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
 func (f *ForkableChangesetSourceGitserverPushConfigFunc) SetDefaultReturn(r0 *protocol.PushConfig, r1 error) {
-	f.SetDefaultHook(func(*types.Repo) (*protocol.PushConfig, error) {
+	f.SetDefaultHook(func(context.Context, *types.Repo) (*protocol.PushConfig, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
 func (f *ForkableChangesetSourceGitserverPushConfigFunc) PushReturn(r0 *protocol.PushConfig, r1 error) {
-	f.PushHook(func(*types.Repo) (*protocol.PushConfig, error) {
+	f.PushHook(func(context.Context, *types.Repo) (*protocol.PushConfig, error) {
 		return r0, r1
 	})
 }
 
-func (f *ForkableChangesetSourceGitserverPushConfigFunc) nextHook() func(*types.Repo) (*protocol.PushConfig, error) {
+func (f *ForkableChangesetSourceGitserverPushConfigFunc) nextHook() func(context.Context, *types.Repo) (*protocol.PushConfig, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -2303,7 +2306,10 @@ func (f *ForkableChangesetSourceGitserverPushConfigFunc) History() []ForkableCha
 type ForkableChangesetSourceGitserverPushConfigFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
-	Arg0 *types.Repo
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 *types.Repo
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 *protocol.PushConfig
@@ -2315,7 +2321,7 @@ type ForkableChangesetSourceGitserverPushConfigFuncCall struct {
 // Args returns an interface slice containing the arguments of this
 // invocation.
 func (c ForkableChangesetSourceGitserverPushConfigFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0}
+	return []interface{}{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this

--- a/internal/batches/sources/perforce.go
+++ b/internal/batches/sources/perforce.go
@@ -40,7 +40,7 @@ func NewPerforceSource(ctx context.Context, gitserverClient gitserver.Client, sv
 }
 
 // GitserverPushConfig returns an authenticated push config used for pushing commits to the code host.
-func (s PerforceSource) GitserverPushConfig(repo *types.Repo) (*protocol.PushConfig, error) {
+func (s PerforceSource) GitserverPushConfig(_ context.Context, repo *types.Repo) (*protocol.PushConfig, error) {
 	if s.perforceCreds == nil {
 		return nil, errors.New("no credentials set for Perforce Source")
 	}

--- a/internal/batches/sources/sources.go
+++ b/internal/batches/sources/sources.go
@@ -3,7 +3,6 @@ package sources
 import (
 	"context"
 	"fmt"
-	ghtypes "github.com/sourcegraph/sourcegraph/internal/github_apps/types"
 	"net/url"
 	"sort"
 	"strings"
@@ -21,6 +20,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/github"
 	ghaauth "github.com/sourcegraph/sourcegraph/internal/github_apps/auth"
 	ghastore "github.com/sourcegraph/sourcegraph/internal/github_apps/store"
+	ghtypes "github.com/sourcegraph/sourcegraph/internal/github_apps/types"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
@@ -281,7 +281,7 @@ func loadBatchesSource(ctx context.Context, tx SourcerStore, cf *httpcli.Factory
 // GitserverPushConfig creates a push configuration given a repo and an
 // authenticator. This function is only public for testing purposes, and should
 // not be used otherwise.
-func GitserverPushConfig(repo *types.Repo, au auth.Authenticator) (*protocol.PushConfig, error) {
+func GitserverPushConfig(ctx context.Context, repo *types.Repo, au auth.Authenticator) (*protocol.PushConfig, error) {
 	// Empty authenticators are not allowed.
 	if au == nil {
 		return nil, ErrNoPushCredentials{}
@@ -323,6 +323,16 @@ func GitserverPushConfig(repo *types.Repo, au auth.Authenticator) (*protocol.Pus
 		}
 	case *auth.BasicAuth:
 		if err := setBasicAuth(cloneURL, extSvcType, av.Username, av.Password); err != nil {
+			return nil, err
+		}
+	case *ghaauth.InstallationAuthenticator:
+		if av.NeedsRefresh() {
+			if err := av.Refresh(ctx, httpcli.ExternalClient); err != nil {
+				return nil, err
+			}
+		}
+		t := av.GetToken()
+		if err := setGitHubAppInstallationToken(cloneURL, extSvcType, t.Token); err != nil {
 			return nil, err
 		}
 	default:
@@ -564,7 +574,7 @@ func setOAuthTokenAuth(u *vcs.URL, extSvcType, token string) error {
 		return errors.New("require username/token to push commits to BitbucketServer")
 
 	default:
-		panic(fmt.Sprintf("setOAuthTokenAuth: invalid external service type %q", extSvcType))
+		return errors.Newf("setOAuthTokenAuth: invalid external service type %q", extSvcType)
 	}
 	return nil
 }
@@ -580,6 +590,16 @@ func setBasicAuth(u *vcs.URL, extSvcType, username, password string) error {
 
 	default:
 		panic(fmt.Sprintf("setBasicAuth: invalid external service type %q", extSvcType))
+	}
+	return nil
+}
+
+func setGitHubAppInstallationToken(u *vcs.URL, extSvcType, token string) error {
+	switch extSvcType {
+	case extsvc.TypeGitHub:
+		u.User = url.UserPassword("x-access-token", token)
+	default:
+		return errors.Newf("setGitHubAppInstallationToken: invalid external service type %q", extSvcType)
 	}
 	return nil
 }

--- a/internal/batches/sources/sources_test.go
+++ b/internal/batches/sources/sources_test.go
@@ -305,6 +305,7 @@ func TestGitserverPushConfig(t *testing.T) {
 			wantErr:             ErrNoPushCredentials{CredentialsType: "*auth.OAuthClient"},
 		},
 	}
+	ctx := context.Background()
 	for _, tt := range tcs {
 		t.Run(tt.name, func(t *testing.T) {
 			sources := map[string]*types.SourceInfo{}
@@ -323,7 +324,7 @@ func TestGitserverPushConfig(t *testing.T) {
 				},
 			}
 
-			havePushConfig, haveErr := GitserverPushConfig(repo, tt.authenticator)
+			havePushConfig, haveErr := GitserverPushConfig(ctx, repo, tt.authenticator)
 			if haveErr != tt.wantErr {
 				t.Fatalf("invalid error returned, want=%v have=%v", tt.wantErr, haveErr)
 			}

--- a/internal/batches/sources/testing/fake.go
+++ b/internal/batches/sources/testing/fake.go
@@ -283,8 +283,8 @@ func (s *FakeChangesetSource) CreateComment(ctx context.Context, c *sources.Chan
 	return s.Err
 }
 
-func (s *FakeChangesetSource) GitserverPushConfig(repo *types.Repo) (*protocol.PushConfig, error) {
-	return sources.GitserverPushConfig(repo, s.CurrentAuthenticator)
+func (s *FakeChangesetSource) GitserverPushConfig(ctx context.Context, repo *types.Repo) (*protocol.PushConfig, error) {
+	return sources.GitserverPushConfig(ctx, repo, s.CurrentAuthenticator)
 }
 
 func (s *FakeChangesetSource) WithAuthenticator(a auth.Authenticator) (sources.ChangesetSource, error) {


### PR DESCRIPTION
This PR allows the use of GitHub app installation token for Gitserver push to a codehost.

## Test plan

<!-- REQUIRED; info at https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles -->
* Manual testing
* Unit tests should be passing

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
