### PR TITLE
fix(svelte): Fixes excessive 'the hotkey ... has already been registered' messages

### DIFF
--- a/client/web-sveltekit/src/lib/Popover.svelte
+++ b/client/web-sveltekit/src/lib/Popover.svelte
@@ -2,7 +2,7 @@
     import type { OffsetOptions, Placement } from '@floating-ui/dom'
     import type { Action } from 'svelte/action'
 
-    import { registerHotkey } from '$lib/Hotkey'
+    import { createHotkey } from '$lib/Hotkey'
 
     import { popover, onClickOutside, portal } from './dom'
 
@@ -22,20 +22,25 @@
     let popoverContainer: HTMLElement | null
     let delayTimer: ReturnType<typeof setTimeout>
 
-    if (closeOnEsc) {
-        registerHotkey({
-            keys: { key: 'Esc' },
-            ignoreInputFields: false,
-            handler: event => {
-                event.preventDefault()
-                close()
-                return false
-            },
-        })
-    }
+    const escHotkey = closeOnEsc
+        ? createHotkey({
+              keys: { key: 'Esc' },
+              ignoreInputFields: false,
+              handler: event => {
+                  event.preventDefault()
+                  close()
+                  return false
+              },
+          })
+        : null
 
     function toggle(open?: boolean): void {
         isOpen = open === undefined ? !isOpen : open
+        if (isOpen) {
+            escHotkey?.enable()
+        } else {
+            escHotkey?.disable()
+        }
     }
 
     function close(): void {


### PR DESCRIPTION
Fixes srch-697

This commit makes two important changes:

- The popover component will now only register the ESC key handler when it is open (und unregister when it closes). This was done by exposing a new function that creates a hotkey without registering it. The existing `registerHotkey` function simply wraps the new function so that existing callsites are not affected by this change.
- The error message was turned into a warning and will now only be triggered in dev builds.

## Test plan

Existing unit test, manual testing.

Before this change: 
![2024-07-06_20-48](https://github.com/sourcegraph/sourcegraph/assets/179026/ee54245f-71eb-4819-bb46-aaf2c76b9958)

After this change: No messages.