### PR TITLE
scheduler: Simplify query for uncloned repos

### DIFF
--- a/cmd/repo-updater/shared/main.go
+++ b/cmd/repo-updater/shared/main.go
@@ -328,8 +328,6 @@ func watchSyncer(
 
 // newUnclonedReposManager creates a background routine that will periodically list
 // the uncloned repositories on gitserver and update the scheduler with the list.
-// It also ensures that if any of our indexable repos are missing from the cloned
-// list they will be added for cloning ASAP.
 func newUnclonedReposManager(ctx context.Context, logger log.Logger, sched *scheduler.UpdateScheduler, store repos.Store) goroutine.BackgroundRoutine {
 	return goroutine.NewPeriodicGoroutine(
 		actor.WithInternalActor(ctx),
@@ -341,15 +339,7 @@ func newUnclonedReposManager(ctx context.Context, logger log.Logger, sched *sche
 
 			baseRepoStore := database.ReposWith(logger, store)
 
-			// Move any repos managed by the scheduler that are uncloned to the front
-			// of the queue.
-			managed := sched.ListRepoIDs()
-
-			if len(managed) == 0 {
-				return nil
-			}
-
-			uncloned, err := baseRepoStore.ListMinimalRepos(ctx, database.ReposListOptions{IDs: managed, NoCloned: true})
+			uncloned, err := baseRepoStore.ListMinimalRepos(ctx, database.ReposListOptions{NoCloned: true})
 			if err != nil {
 				return errors.Wrap(err, "failed to fetch list of uncloned repositories")
 			}


### PR DESCRIPTION
Since we removed on-demand cloning, the scheduler is now expected to always contain all repositories. Thus, we no longer need to constrain the set of uncloned repos to a ginormous ID list.

Test plan:

CI still passes.