### PR TITLE
phabricator: Move syncer to worker

### DIFF
--- a/cmd/repo-updater/shared/BUILD.bazel
+++ b/cmd/repo-updater/shared/BUILD.bazel
@@ -15,7 +15,6 @@ go_library(
     deps = [
         "//cmd/frontend/globals",
         "//cmd/repo-updater/internal/gitserver",
-        "//cmd/repo-updater/internal/phabricator",
         "//cmd/repo-updater/internal/purge",
         "//cmd/repo-updater/internal/repoupdater",
         "//cmd/repo-updater/internal/scheduler",

--- a/cmd/repo-updater/shared/main.go
+++ b/cmd/repo-updater/shared/main.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/globals"
 	repogitserver "github.com/sourcegraph/sourcegraph/cmd/repo-updater/internal/gitserver"
-	"github.com/sourcegraph/sourcegraph/cmd/repo-updater/internal/phabricator"
 	"github.com/sourcegraph/sourcegraph/cmd/repo-updater/internal/purge"
 	"github.com/sourcegraph/sourcegraph/cmd/repo-updater/internal/repoupdater"
 	"github.com/sourcegraph/sourcegraph/cmd/repo-updater/internal/scheduler"
@@ -131,7 +130,6 @@ func Main(ctx context.Context, observationCtx *observation.Context, ready servic
 	routines := []goroutine.BackgroundRoutine{
 		makeGRPCServer(logger, server),
 		newUnclonedReposManager(ctx, logger, updateScheduler, store),
-		phabricator.NewRepositorySyncWorker(ctx, db, log.Scoped("PhabricatorRepositorySyncWorker"), store),
 		// Run git fetches scheduler
 		updateScheduler,
 	}

--- a/cmd/worker/internal/phabricator/BUILD.bazel
+++ b/cmd/worker/internal/phabricator/BUILD.bazel
@@ -2,18 +2,24 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "phabricator",
-    srcs = ["phabricator.go"],
-    importpath = "github.com/sourcegraph/sourcegraph/cmd/repo-updater/internal/phabricator",
-    tags = [TAG_PLATFORM_SOURCE],
-    visibility = ["//cmd/repo-updater:__subpackages__"],
+    srcs = [
+        "job.go",
+        "phabricator.go",
+    ],
+    importpath = "github.com/sourcegraph/sourcegraph/cmd/worker/internal/phabricator",
+    visibility = ["//cmd/worker:__subpackages__"],
     deps = [
+        "//cmd/worker/job",
+        "//cmd/worker/shared/init/db",
         "//internal/actor",
         "//internal/conf",
         "//internal/database",
+        "//internal/env",
         "//internal/extsvc",
         "//internal/extsvc/phabricator",
         "//internal/goroutine",
         "//internal/httpcli",
+        "//internal/observation",
         "//internal/repos",
         "//internal/types",
         "//lib/errors",

--- a/cmd/worker/internal/phabricator/job.go
+++ b/cmd/worker/internal/phabricator/job.go
@@ -1,0 +1,39 @@
+package phabricator
+
+import (
+	"context"
+
+	"github.com/sourcegraph/sourcegraph/cmd/worker/job"
+	workerdb "github.com/sourcegraph/sourcegraph/cmd/worker/shared/init/db"
+	"github.com/sourcegraph/sourcegraph/internal/env"
+	"github.com/sourcegraph/sourcegraph/internal/goroutine"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
+	"github.com/sourcegraph/sourcegraph/internal/repos"
+)
+
+type phabricatorRepoSyncerJob struct{}
+
+func NewPhabricatorRepoSyncerJob() job.Job {
+	return &phabricatorRepoSyncerJob{}
+}
+
+func (o *phabricatorRepoSyncerJob) Description() string {
+	return "Periodically syncs repositories from Phabricator to Sourcegraph"
+}
+
+func (o *phabricatorRepoSyncerJob) Config() []env.Config {
+	return nil
+}
+
+func (o *phabricatorRepoSyncerJob) Routines(startupCtx context.Context, observationCtx *observation.Context) ([]goroutine.BackgroundRoutine, error) {
+	db, err := workerdb.InitDB(observationCtx)
+	if err != nil {
+		return nil, err
+	}
+
+	store := repos.NewStore(observationCtx.Logger.Scoped("store"), db)
+
+	return []goroutine.BackgroundRoutine{
+		NewRepositorySyncWorker(context.Background(), db, observationCtx.Logger, store),
+	}, nil
+}

--- a/cmd/worker/internal/phabricator/phabricator.go
+++ b/cmd/worker/internal/phabricator/phabricator.go
@@ -27,7 +27,7 @@ const (
 
 var (
 	phabricatorUpdateTime = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "src_repoupdater_time_last_phabricator_sync",
+		Name: "src_phabricator_last_time_sync",
 		Help: "The last time a comprehensive Phabricator sync finished",
 	}, []string{tagID})
 )


### PR DESCRIPTION
This syncer doesn't depend on anything in repo updater, so we're moving it to worker instead, where it can selectively be disabled and is properly monitored.

Test plan:

CI passes, code review.