### PR TITLE
feat(svelte): Add cody button to repo home page

### DIFF
--- a/client/web-sveltekit/src/lib/cody/CodySidebar.svelte
+++ b/client/web-sveltekit/src/lib/cody/CodySidebar.svelte
@@ -71,6 +71,7 @@
         background-color: var(--input-bg);
         border-bottom: 1px solid var(--border-color-2);
         padding: 0.25rem 1rem;
+        height: var(--repo-header-height);
 
         // Shows the cody icon in color
         --icon-color: initial;

--- a/client/web-sveltekit/src/lib/repo/FileHeader.svelte
+++ b/client/web-sveltekit/src/lib/repo/FileHeader.svelte
@@ -131,6 +131,7 @@
         border-bottom: 1px solid var(--border-color);
         z-index: 1;
         gap: 1rem;
+        height: var(--repo-header-height);
     }
 
     h2 {

--- a/client/web-sveltekit/src/lib/repo/OpenCodyAction.svelte
+++ b/client/web-sveltekit/src/lib/repo/OpenCodyAction.svelte
@@ -9,12 +9,14 @@
     }
 </script>
 
-<Tooltip tooltip="Open Cody chat">
-    <button on:click={handleClick} aria-controls={CODY_SIDEBAR_ID} aria-expanded={$rightPanelOpen}>
-        <Icon icon={ISgCody} />
-        <span data-action-label>Cody</span>
-    </button>
-</Tooltip>
+{#if !$rightPanelOpen}
+    <Tooltip tooltip="Open Cody chat">
+        <button on:click={handleClick} aria-controls={CODY_SIDEBAR_ID} aria-expanded={$rightPanelOpen}>
+            <Icon icon={ISgCody} />
+            <span data-action-label>Cody</span>
+        </button>
+    </Tooltip>
+{/if}
 
 <style lang="scss">
     button {

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/+page.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/+page.svelte
@@ -8,11 +8,13 @@
 
     import type { PageData } from './$types'
     import type { RepoPage_Readme } from './page.gql'
+    import OpenCodyAction from '$lib/repo/OpenCodyAction.svelte'
 
     export let data: PageData
 
     const readme = createPromiseStore<RepoPage_Readme | null>()
     $: readme.set(data.readme)
+    $: isCodyAvailable = data.isCodyAvailable
 
     onMount(() => {
         TELEMETRY_RECORDER.recordEvent('repo', 'view')
@@ -23,13 +25,20 @@
     <title>{data.displayRepoName} - Sourcegraph</title>
 </svelte:head>
 
-<h3 class="header">
-    {#if $readme.value}
-        {$readme.value.name}
-    {:else if !$readme.pending}
-        Description
-    {/if}
-</h3>
+<div class="header">
+    <h3>
+        {#if $readme.value}
+            {$readme.value.name}
+        {:else if !$readme.pending}
+            Description
+        {/if}
+    </h3>
+    <div class="actions">
+        {#if $isCodyAvailable}
+            <OpenCodyAction />
+        {/if}
+    </div>
+</div>
 <div class="content">
     <div class="inner">
         {#if $readme.value}
@@ -50,9 +59,12 @@
         top: 0;
         padding: 0.5rem;
         border-bottom: 1px solid var(--border-color);
+        background-color: var(--color-bg-1);
+        height: var(--repo-header-height);
+
         display: flex;
         align-items: center;
-        background-color: var(--color-bg-1);
+        justify-content: space-between;
     }
 
     .content {

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/+layout.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/+layout.svelte
@@ -185,6 +185,10 @@
 <slot />
 
 <style lang="scss">
+    :root {
+        --repo-header-height: 2rem;
+    }
+
     .search-header {
         width: 100%;
         z-index: 1;


### PR DESCRIPTION
Based on #63677 

Closes srch-691
Closes srch-695

This adds the cody button to the repo "home page" so that cody can be opened from there.
This commit also makes it so that the cody button is hidden when the sidebar opens (like in the React app) and it adds a fixed height to the various headers so that they align well with the sidebar header and don't change size when the cody button is hidden when the sidebar is open.

<!-- PR description tips: https://www.notion.so/sourcegraph/Write-a-good-pull-request-description-610a7fd3e613496eb76f450db5a49b6e -->

## Test plan

Manual testing.

![2024-07-08_11-41_1](https://github.com/sourcegraph/sourcegraph/assets/179026/79831bfd-017f-4904-82a3-ab1310f80c6a)
![2024-07-08_11-41](https://github.com/sourcegraph/sourcegraph/assets/179026/14c62ed4-5b7c-4e9d-85b7-4ac7e78b8581)
