### PR TITLE
fix(batches): fix broken `ghauth` import

### DIFF
--- a/internal/batches/sources/sources.go
+++ b/internal/batches/sources/sources.go
@@ -363,7 +363,7 @@ func GitserverPushConfig(ctx context.Context, repo *types.Repo, au auth.Authenti
 		if err := setBasicAuth(cloneURL, extSvcType, av.Username, av.Password); err != nil {
 			return nil, err
 		}
-	case *ghaauth.InstallationAuthenticator:
+	case *ghauth.InstallationAuthenticator:
 		if av.NeedsRefresh() {
 			if err := av.Refresh(ctx, httpcli.ExternalClient); err != nil {
 				return nil, err


### PR DESCRIPTION
An earlier merge of my PR caused `main` to be broken due to an import change .

## Test plan

<!-- REQUIRED; info at https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles -->
Manually built main to ensure there are no other broken imports and bazel is passing.

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
