### PR TITLE
React app: bump cody web to 0.2.1

### DIFF
--- a/client/web/src/cody/chat/new-chat/components/chat-ui/ChatUI.module.scss
+++ b/client/web/src/cody/chat/new-chat/components/chat-ui/ChatUI.module.scss
@@ -57,6 +57,13 @@
         visibility: hidden;
         display: block !important;
     }
+
+    // Target all possible animated elements (radix accordions)
+    // and disable animation since there are flashes with exit
+    // animations.
+    :global(.tw-transition-all) {
+        animation: none !important;
+    }
 }
 
 [data-floating-ui-portal] {

--- a/package.json
+++ b/package.json
@@ -333,7 +333,7 @@
     "bloomfilter": "^0.0.18",
     "buffer": "^6.0.3",
     "classnames": "^2.2.6",
-    "cody-web-experimental": "^0.2.0",
+    "cody-web-experimental": "^0.2.1",
     "comlink": "^4.3.0",
     "copy-to-clipboard": "^3.3.1",
     "core-js": "^3.8.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -206,8 +206,8 @@ importers:
         specifier: ^2.2.6
         version: 2.3.2
       cody-web-experimental:
-        specifier: ^0.2.0
-        version: 0.2.0
+        specifier: ^0.2.1
+        version: 0.2.1
       comlink:
         specifier: ^4.3.0
         version: 4.3.0
@@ -14543,8 +14543,8 @@ packages:
     resolution: {integrity: sha512-5WE+ZWfbNhXJxvJeCFfyJPHNaPZKEdJAGoFa7sSXoxdeUEN62YGIs5DmpCOEmSCzX0cQm+35GWRWoV28HI/0jg==}
     dev: false
 
-  /cody-web-experimental@0.2.0:
-    resolution: {integrity: sha512-fBuYER4PDN89y82J5eyBtmsIJUIFDECgYatCEp9+8ZnaaECviIGSfp49nnb6wUeqo9n7pVT/xdHIQ/sBPh/zjg==}
+  /cody-web-experimental@0.2.1:
+    resolution: {integrity: sha512-ci7wRIOaxpD+xZ5ecR0IYeJhxAai4meIUNVGXzjUATYiRx3+755kWtrWRbvPGhmE+2jF1KB2DKKd+pyGKmfbdg==}
     dev: false
 
   /color-convert@1.9.3:


### PR DESCRIPTION
Bumps cody web experimental package to 0.2.1 which includes fixes for https://linear.app/sourcegraph/issue/SRCH-633/links-in-the-prompt-has-incorrect-url-in-cody-web

## Test plan
- Manual testing
- Check that links in cody web context lists work properly 

<!-- REQUIRED; info at https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles -->

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
