### PR TITLE
Svelte: encode path components in file header

### DIFF
--- a/client/web-sveltekit/src/lib/repo/FileHeader.svelte
+++ b/client/web-sveltekit/src/lib/repo/FileHeader.svelte
@@ -2,6 +2,7 @@
     import { writable } from 'svelte/store'
 
     import { resolveRoute } from '$app/paths'
+    import { encodeURIPathComponent } from '$lib/common'
     import { sizeToFit } from '$lib/dom'
     import Icon from '$lib/Icon.svelte'
     import { DropdownMenu, MenuLink } from '$lib/wildcard'
@@ -23,7 +24,7 @@
             index < all.length - 1 || type === 'tree' ? TREE_ROUTE_ID : BLOB_ROUTE_ID,
             {
                 repo: revision ? `${repoName}@${revision}` : repoName,
-                path: all.slice(0, index + 1).join('/'),
+                path: encodeURIPathComponent(all.slice(0, index + 1).join('/')),
             }
         ),
     ])


### PR DESCRIPTION
While adding a [file with a bunch of special characters in its name](https://sourcegraph.sourcegraph.com/github.com/sgtest/weird/-/blob/filenames/special-characters-~!%40%23%24%25%5E%26*()_+%3D-%60%7B%7D%5B%5D%5C%7C%22'%3F.%2C%3C%3E) to sgtest/weird, I noticed that clicking a link to the file is broken. 

This URI-encodes the path components so following the link does not yield a 404.

## Test plan

Quick manual test that I can click the file name in the header and it goes to the right place. 