### PR TITLE
feat/enterpriseportal: database layer for subscriptions upsert

### DIFF
--- a/cmd/enterprise-portal/internal/database/internal/upsert/BUILD.bazel
+++ b/cmd/enterprise-portal/internal/database/internal/upsert/BUILD.bazel
@@ -1,0 +1,26 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("//dev:go_defs.bzl", "go_test")
+
+go_library(
+    name = "upsert",
+    srcs = ["upsert.go"],
+    importpath = "github.com/sourcegraph/sourcegraph/cmd/enterprise-portal/internal/database/internal/upsert",
+    visibility = ["//cmd/enterprise-portal:__subpackages__"],
+    deps = [
+        "@com_github_jackc_pgx_v5//:pgx",
+        "@com_github_jackc_pgx_v5//pgxpool",
+    ],
+)
+
+go_test(
+    name = "upsert_test",
+    srcs = ["upsert_test.go"],
+    embed = [":upsert"],
+    deps = [
+        "//lib/pointers",
+        "@com_github_hexops_autogold_v2//:autogold",
+        "@com_github_hexops_valast//:valast",
+        "@com_github_jackc_pgx_v5//:pgx",
+        "@com_github_stretchr_testify//assert",
+    ],
+)

--- a/cmd/enterprise-portal/internal/database/internal/upsert/upsert.go
+++ b/cmd/enterprise-portal/internal/database/internal/upsert/upsert.go
@@ -1,0 +1,138 @@
+package upsert
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// Trick to avoid user-provided string values - outside this package, this type
+// can only be fulfilled by a constant string value.
+type constString string
+
+type Builder struct {
+	table      constString
+	primaryKey constString
+
+	insertColumns []string
+	args          pgx.NamedArgs
+	updateColumns []string
+
+	forceUpdate bool
+}
+
+// New instantiates an upsert.Builder that can be used with `upsert.Field(b, ...)`
+// to implement the database layer for the upsert pattern common in gRPC 'update',
+// methods, per the AIP: https://google.aip.dev/134
+func New(table, primaryKey constString, forceUpdate bool) *Builder {
+	return &Builder{
+		table:       table,
+		primaryKey:  primaryKey,
+		forceUpdate: forceUpdate,
+		args:        pgx.NamedArgs{},
+	}
+}
+
+type fieldOptions struct {
+	useColumnDefault    bool
+	ignoreOnForceUpdate bool
+}
+
+type fieldOptionFn func(*fieldOptions)
+
+func (fn fieldOptionFn) apply(opt *fieldOptions) { fn(opt) }
+
+type FieldOption interface {
+	apply(*fieldOptions)
+}
+
+// WithColumnDefault indicates that the field should not be included in an upsert
+// if the field has a zero value, which allows the column default to be used.
+//
+// It does NOT apply in a force update.
+func WithColumnDefault() FieldOption {
+	return fieldOptionFn(func(opt *fieldOptions) { opt.useColumnDefault = true })
+}
+
+// WithIgnoreOnForceUpdate indicates that the field should not be updated when
+// performing a force update.
+func WithIgnoreOnForceUpdate() FieldOption {
+	return fieldOptionFn(func(opt *fieldOptions) { opt.ignoreOnForceUpdate = true })
+}
+
+// Field registers a field that can be set in the upsert to value T. If T is
+// a zero value, the field is not set on an update, UNLESS the `forceUpdate`
+// parameter was provided as `true` to upsert.New(...).
+func Field[T comparable](b *Builder, column constString, value T, opts ...FieldOption) {
+	opt := fieldOptions{}
+	for _, o := range opts {
+		o.apply(&opt)
+	}
+	var zero T
+
+	// If upsert has a zero value, and we would prefer to use the column default,
+	// do nothing, unless we are performing a force-update across all fields.
+	if !b.forceUpdate && (zero == value && opt.useColumnDefault) {
+		return
+	}
+
+	// If we are force-updating, and the field is marked to be ignored, do nothing.
+	if b.forceUpdate && opt.ignoreOnForceUpdate {
+		return
+	}
+
+	b.insertColumns = append(b.insertColumns, string(column))
+	b.args[string(column)] = value
+
+	// If we are force-updating, or value is not zero, update the column in
+	// existing rows (on conflict).
+	if b.forceUpdate || value != zero {
+		b.updateColumns = append(b.updateColumns, string(column))
+	}
+}
+
+func (b *Builder) buildQuery() (string, bool) {
+	if len(b.updateColumns) == 0 {
+		return "", false
+	}
+
+	onConflictSets := make([]string, len(b.updateColumns))
+	for i, c := range b.updateColumns {
+		onConflictSets[i] = fmt.Sprintf("%[1]s = EXCLUDED.%[1]s", c)
+	}
+
+	insertArgNames := make([]string, len(b.insertColumns))
+	for i, c := range b.insertColumns {
+		insertArgNames[i] = fmt.Sprintf("@%s", c)
+	}
+
+	return fmt.Sprintf(`
+INSERT INTO %[1]s
+	(%[2]s)
+VALUES
+	(%[3]s)
+ON CONFLICT
+	(%[4]s)
+DO UPDATE SET
+	%[5]s`,
+		b.table,                             // %[1]s
+		strings.Join(b.insertColumns, ", "), // %[2]s
+		strings.Join(insertArgNames, ", "),  // %[3]s
+		b.primaryKey,                        // %[4]s
+		strings.Join(onConflictSets, ",\n"), // %[5]s
+	), true
+}
+
+func (b *Builder) Exec(ctx context.Context, db *pgxpool.Pool) error {
+	q, ok := b.buildQuery()
+	if !ok {
+		return nil
+	}
+	if _, err := db.Exec(ctx, q, b.args); err != nil {
+		return err
+	}
+	return nil
+}

--- a/cmd/enterprise-portal/internal/database/internal/upsert/upsert_test.go
+++ b/cmd/enterprise-portal/internal/database/internal/upsert/upsert_test.go
@@ -1,0 +1,113 @@
+package upsert
+
+import (
+	"testing"
+	"time"
+
+	"github.com/hexops/autogold/v2"
+	"github.com/hexops/valast"
+	"github.com/jackc/pgx/v5"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/sourcegraph/sourcegraph/lib/pointers"
+)
+
+func TestBuilder(t *testing.T) {
+	mockTime := time.Date(2024, 7, 8, 16, 39, 16, 4277000, time.Local)
+	for _, tc := range []struct {
+		name string
+
+		forceUpdate  bool
+		upsertFields func(b *Builder)
+
+		wantQuery autogold.Value
+		wantArgs  autogold.Value
+	}{
+		{
+			name:        "not force-update",
+			forceUpdate: false,
+			upsertFields: func(b *Builder) {
+				Field[*string](b, "col1", nil)
+
+				// WithIgnoreOnForceUpdate() does nothing because the we are not
+				// in a force-update.
+				Field(b, "col2", pointers.Ptr("value2"), WithIgnoreOnForceUpdate())
+
+				// WithColumnDefault() does nothing because the time is not zero
+				Field(b, "time", mockTime, WithColumnDefault())
+
+				// Do not set, it should use the default value.
+				Field(b, "should_be_ignored", "", WithColumnDefault())
+			},
+			wantQuery: autogold.Expect(`
+INSERT INTO table
+(col1, col2, time)
+VALUES
+(@col1, @col2, @time)
+ON CONFLICT
+(id)
+DO UPDATE SET
+col2 = EXCLUDED.col2,
+time = EXCLUDED.time`),
+			wantArgs: autogold.Expect(pgx.NamedArgs{
+				"col1": nil, "col2": valast.Ptr("value2"),
+				"time": time.Date(2024,
+					7,
+					8,
+					16,
+					39,
+					16,
+					4277000,
+					time.Local),
+			}),
+		},
+		{
+			name:        "force-update",
+			forceUpdate: true,
+			upsertFields: func(b *Builder) {
+				Field[*string](b, "col1", nil)
+				Field(b, "col2", pointers.Ptr("value2"))
+				Field(b, "time", mockTime)
+
+				// Do not set, it cannot be updated in a force-update.
+				Field(b, "should_be_ignored", "", WithIgnoreOnForceUpdate())
+			},
+			wantQuery: autogold.Expect(`
+INSERT INTO table
+(col1, col2, time)
+VALUES
+(@col1, @col2, @time)
+ON CONFLICT
+(id)
+DO UPDATE SET
+col1 = EXCLUDED.col1,
+col2 = EXCLUDED.col2,
+time = EXCLUDED.time`),
+			wantArgs: autogold.Expect(pgx.NamedArgs{
+				"col1": nil, "col2": valast.Ptr("value2"),
+				"time": time.Date(2024,
+					7,
+					8,
+					16,
+					39,
+					16,
+					4277000,
+					time.Local),
+			}),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			b := New("table", "id", tc.forceUpdate)
+			tc.upsertFields(b)
+
+			q, ok := b.buildQuery()
+			if tc.wantQuery == nil && tc.wantArgs == nil {
+				assert.False(t, ok)
+			} else {
+				assert.True(t, ok)
+				tc.wantQuery.Equal(t, q)
+				tc.wantArgs.Equal(t, b.args)
+			}
+		})
+	}
+}

--- a/cmd/enterprise-portal/internal/database/subscriptions/BUILD.bazel
+++ b/cmd/enterprise-portal/internal/database/subscriptions/BUILD.bazel
@@ -13,7 +13,9 @@ go_library(
     tags = [TAG_INFRA_CORESERVICES],
     visibility = ["//cmd/enterprise-portal:__subpackages__"],
     deps = [
+        "//cmd/enterprise-portal/internal/database/internal/upsert",
         "//lib/errors",
+        "//lib/pointers",
         "@com_github_jackc_pgtype//:pgtype",
         "@com_github_jackc_pgx_v5//:pgx",
         "@com_github_jackc_pgx_v5//pgxpool",
@@ -31,6 +33,7 @@ go_test(
         ":subscriptions",
         "//cmd/enterprise-portal/internal/database/databasetest",
         "//cmd/enterprise-portal/internal/database/internal/tables",
+        "//lib/pointers",
         "@com_github_google_uuid//:uuid",
         "@com_github_jackc_pgx_v5//:pgx",
         "@com_github_stretchr_testify//assert",

--- a/cmd/enterprise-portal/internal/database/subscriptions/subscriptions_test.go
+++ b/cmd/enterprise-portal/internal/database/subscriptions/subscriptions_test.go
@@ -123,7 +123,7 @@ func SubscriptionsStoreUpsert(t *testing.T, ctx context.Context, s *subscription
 	require.NoError(t, err)
 	assert.Equal(t, currentSubscription.ID, got.ID)
 	assert.Equal(t, currentSubscription.InstanceDomain, got.InstanceDomain)
-	assert.Equal(t, subscriptions.DefaultSubscriptionDisplayName, got.DisplayName)
+	assert.Empty(t, got.DisplayName)
 	assert.NotZero(t, got.CreatedAt)
 	assert.NotZero(t, got.UpdatedAt)
 	assert.Nil(t, got.ArchivedAt) // not archived yet
@@ -195,7 +195,7 @@ func SubscriptionsStoreUpsert(t *testing.T, ctx context.Context, s *subscription
 		})
 		require.NoError(t, err)
 		assert.Empty(t, got.InstanceDomain)
-		assert.Equal(t, subscriptions.DefaultSubscriptionDisplayName, got.DisplayName)
+		assert.Empty(t, got.DisplayName)
 		assert.Nil(t, got.ArchivedAt)
 
 		// Some fields cannot be updated in a force-update.

--- a/cmd/enterprise-portal/internal/database/subscriptions/subscriptions_test.go
+++ b/cmd/enterprise-portal/internal/database/subscriptions/subscriptions_test.go
@@ -168,7 +168,8 @@ func SubscriptionsStoreUpsert(t *testing.T, ctx context.Context, s *subscription
 		require.NoError(t, err)
 		assert.Equal(t, currentSubscription.InstanceDomain, got.InstanceDomain)
 		assert.Equal(t, currentSubscription.DisplayName, got.DisplayName)
-		assert.Equal(t, yesterday.UTC(), got.CreatedAt)
+		// Round times to allow for some precision drift in CI
+		assert.Equal(t, yesterday.Round(time.Second).UTC(), got.CreatedAt.Round(time.Second))
 	})
 
 	t.Run("update only archived at", func(t *testing.T) {
@@ -182,7 +183,8 @@ func SubscriptionsStoreUpsert(t *testing.T, ctx context.Context, s *subscription
 		assert.Equal(t, currentSubscription.InstanceDomain, got.InstanceDomain)
 		assert.Equal(t, currentSubscription.DisplayName, got.DisplayName)
 		assert.Equal(t, currentSubscription.CreatedAt, got.CreatedAt)
-		assert.Equal(t, yesterday.UTC(), *got.ArchivedAt)
+		// Round times to allow for some precision drift in CI
+		assert.Equal(t, yesterday.Round(time.Second).UTC(), got.ArchivedAt.Round(time.Second))
 	})
 
 	t.Run("force update to zero values", func(t *testing.T) {

--- a/cmd/enterprise-portal/internal/database/subscriptions/subscriptions_test.go
+++ b/cmd/enterprise-portal/internal/database/subscriptions/subscriptions_test.go
@@ -3,6 +3,7 @@ package subscriptions_test
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
@@ -12,6 +13,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/enterprise-portal/internal/database/databasetest"
 	"github.com/sourcegraph/sourcegraph/cmd/enterprise-portal/internal/database/internal/tables"
 	"github.com/sourcegraph/sourcegraph/cmd/enterprise-portal/internal/database/subscriptions"
+	"github.com/sourcegraph/sourcegraph/lib/pointers"
 )
 
 func TestSubscriptionsStore(t *testing.T) {
@@ -107,35 +109,96 @@ func SubscriptionsStoreList(t *testing.T, ctx context.Context, s *subscriptions.
 }
 
 func SubscriptionsStoreUpsert(t *testing.T, ctx context.Context, s *subscriptions.Store) {
-	// Create initial test record.
-	s1, err := s.Upsert(
+	// Create initial test record. The currentSubscription should be reassigned
+	// throughout various test cases to represent the current state of the test
+	// record, as the subtests are run in sequence.
+	currentSubscription, err := s.Upsert(
 		ctx,
 		uuid.New().String(),
 		subscriptions.UpsertSubscriptionOptions{InstanceDomain: "s1.sourcegraph.com"},
 	)
 	require.NoError(t, err)
 
-	got, err := s.Get(ctx, s1.ID)
+	got, err := s.Get(ctx, currentSubscription.ID)
 	require.NoError(t, err)
-	assert.Equal(t, s1.ID, got.ID)
-	assert.Equal(t, s1.InstanceDomain, got.InstanceDomain)
+	assert.Equal(t, currentSubscription.ID, got.ID)
+	assert.Equal(t, currentSubscription.InstanceDomain, got.InstanceDomain)
+	assert.Equal(t, subscriptions.DefaultSubscriptionDisplayName, got.DisplayName)
+	assert.NotZero(t, got.CreatedAt)
+	assert.NotZero(t, got.UpdatedAt)
+	assert.Nil(t, got.ArchivedAt) // not archived yet
 
 	t.Run("noop", func(t *testing.T) {
-		got, err = s.Upsert(ctx, s1.ID, subscriptions.UpsertSubscriptionOptions{})
+		t.Cleanup(func() { currentSubscription = got })
+
+		got, err = s.Upsert(ctx, currentSubscription.ID, subscriptions.UpsertSubscriptionOptions{})
 		require.NoError(t, err)
-		assert.Equal(t, s1.InstanceDomain, got.InstanceDomain)
+		assert.Equal(t, currentSubscription.InstanceDomain, got.InstanceDomain)
 	})
 
-	t.Run("update", func(t *testing.T) {
-		got, err = s.Upsert(ctx, s1.ID, subscriptions.UpsertSubscriptionOptions{InstanceDomain: "s1-new.sourcegraph.com"})
+	t.Run("update only domain", func(t *testing.T) {
+		t.Cleanup(func() { currentSubscription = got })
+
+		got, err = s.Upsert(ctx, currentSubscription.ID, subscriptions.UpsertSubscriptionOptions{
+			InstanceDomain: "s1-new.sourcegraph.com",
+		})
 		require.NoError(t, err)
 		assert.Equal(t, "s1-new.sourcegraph.com", got.InstanceDomain)
+		assert.Equal(t, currentSubscription.DisplayName, got.DisplayName)
 	})
 
-	t.Run("force update", func(t *testing.T) {
-		got, err = s.Upsert(ctx, s1.ID, subscriptions.UpsertSubscriptionOptions{ForceUpdate: true})
+	t.Run("update only display name", func(t *testing.T) {
+		t.Cleanup(func() { currentSubscription = got })
+
+		got, err = s.Upsert(ctx, currentSubscription.ID, subscriptions.UpsertSubscriptionOptions{
+			DisplayName: "My New Display Name",
+		})
+		require.NoError(t, err)
+		assert.Equal(t, currentSubscription.InstanceDomain, got.InstanceDomain)
+		assert.Equal(t, "My New Display Name", got.DisplayName)
+	})
+
+	t.Run("update only created at", func(t *testing.T) {
+		t.Cleanup(func() { currentSubscription = got })
+
+		yesterday := time.Now().Add(-24 * time.Hour)
+		got, err = s.Upsert(ctx, currentSubscription.ID, subscriptions.UpsertSubscriptionOptions{
+			CreatedAt: yesterday,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, currentSubscription.InstanceDomain, got.InstanceDomain)
+		assert.Equal(t, currentSubscription.DisplayName, got.DisplayName)
+		assert.Equal(t, yesterday.UTC(), got.CreatedAt)
+	})
+
+	t.Run("update only archived at", func(t *testing.T) {
+		t.Cleanup(func() { currentSubscription = got })
+
+		yesterday := time.Now().Add(-24 * time.Hour)
+		got, err = s.Upsert(ctx, currentSubscription.ID, subscriptions.UpsertSubscriptionOptions{
+			ArchivedAt: pointers.Ptr(yesterday),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, currentSubscription.InstanceDomain, got.InstanceDomain)
+		assert.Equal(t, currentSubscription.DisplayName, got.DisplayName)
+		assert.Equal(t, currentSubscription.CreatedAt, got.CreatedAt)
+		assert.Equal(t, yesterday.UTC(), *got.ArchivedAt)
+	})
+
+	t.Run("force update to zero values", func(t *testing.T) {
+		t.Cleanup(func() { currentSubscription = got })
+
+		got, err = s.Upsert(ctx, currentSubscription.ID, subscriptions.UpsertSubscriptionOptions{
+			ForceUpdate: true,
+		})
 		require.NoError(t, err)
 		assert.Empty(t, got.InstanceDomain)
+		assert.Equal(t, subscriptions.DefaultSubscriptionDisplayName, got.DisplayName)
+		assert.Nil(t, got.ArchivedAt)
+
+		// Some fields cannot be updated in a force-update.
+		assert.Equal(t, currentSubscription.ID, got.ID)
+		assert.Equal(t, currentSubscription.CreatedAt, got.CreatedAt)
 	})
 }
 

--- a/cmd/enterprise-portal/internal/subscriptionsservice/adapters.go
+++ b/cmd/enterprise-portal/internal/subscriptionsservice/adapters.go
@@ -65,11 +65,11 @@ func convertSubscriptionToProto(subscription *subscriptions.Subscription, attrs 
 			LastTransitionTime: timestamppb.New(*attrs.ArchivedAt),
 		})
 	}
-
 	return &subscriptionsv1.EnterpriseSubscription{
 		Id:             subscriptionsv1.EnterpriseSubscriptionIDPrefix + attrs.ID,
 		Conditions:     conds,
 		InstanceDomain: subscription.InstanceDomain,
+		DisplayName:    subscription.DisplayName,
 	}
 }
 

--- a/cmd/enterprise-portal/internal/subscriptionsservice/v1.go
+++ b/cmd/enterprise-portal/internal/subscriptionsservice/v1.go
@@ -311,7 +311,8 @@ func (s *handlerV1) UpdateEnterpriseSubscription(ctx context.Context, req *conne
 		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("subscription.id is required"))
 	}
 
-	// Double check with the dotcom DB that the subscription ID is valid.
+	// TEMPORARY: Double check with the dotcom DB that the subscription ID is valid.
+	// This currently ensures we never actually create new subscriptions.
 	subscriptionAttrs, err := s.store.ListDotcomEnterpriseSubscriptions(ctx, dotcomdb.ListEnterpriseSubscriptionsOptions{
 		SubscriptionIDs: []string{subscriptionID},
 	})
@@ -329,11 +330,16 @@ func (s *handlerV1) UpdateEnterpriseSubscription(ctx context.Context, req *conne
 		if v := req.Msg.GetSubscription().GetInstanceDomain(); v != "" {
 			opts.InstanceDomain = v
 		}
+		if v := req.Msg.GetSubscription().GetDisplayName(); v != "" {
+			opts.DisplayName = v
+		}
 	} else {
 		for _, p := range fieldPaths {
 			switch p {
 			case "instance_domain":
 				opts.InstanceDomain = req.Msg.GetSubscription().GetInstanceDomain()
+			case "display_name":
+				opts.DisplayName = req.Msg.GetSubscription().GetDisplayName()
 			case "*":
 				opts.ForceUpdate = true
 				opts.InstanceDomain = req.Msg.GetSubscription().GetInstanceDomain()

--- a/cmd/enterprise-portal/internal/subscriptionsservice/v1_test.go
+++ b/cmd/enterprise-portal/internal/subscriptionsservice/v1_test.go
@@ -243,6 +243,7 @@ func TestHandlerV1_UpdateEnterpriseSubscription(t *testing.T) {
 			Subscription: &subscriptionsv1.EnterpriseSubscription{
 				Id:             "80ca12e2-54b4-448c-a61a-390b1a9c1224",
 				InstanceDomain: "s1.sourcegraph.com",
+				DisplayName:    "My Test Subscription",
 			},
 			UpdateMask: nil,
 		})
@@ -252,6 +253,7 @@ func TestHandlerV1_UpdateEnterpriseSubscription(t *testing.T) {
 		h.mockStore.ListDotcomEnterpriseSubscriptionsFunc.SetDefaultReturn([]*dotcomdb.SubscriptionAttributes{{ID: "80ca12e2-54b4-448c-a61a-390b1a9c1224"}}, nil)
 		h.mockStore.UpsertEnterpriseSubscriptionFunc.SetDefaultHook(func(_ context.Context, _ string, opts subscriptions.UpsertSubscriptionOptions) (*subscriptions.Subscription, error) {
 			assert.NotEmpty(t, opts.InstanceDomain)
+			assert.NotEmpty(t, opts.DisplayName)
 			assert.False(t, opts.ForceUpdate)
 			return &subscriptions.Subscription{}, nil
 		})
@@ -265,6 +267,7 @@ func TestHandlerV1_UpdateEnterpriseSubscription(t *testing.T) {
 			Subscription: &subscriptionsv1.EnterpriseSubscription{
 				Id:             "80ca12e2-54b4-448c-a61a-390b1a9c1224",
 				InstanceDomain: "s1.sourcegraph.com",
+				DisplayName:    "My Test Subscription", // should not be included
 			},
 			UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"instance_domain"}},
 		})
@@ -274,6 +277,7 @@ func TestHandlerV1_UpdateEnterpriseSubscription(t *testing.T) {
 		h.mockStore.ListDotcomEnterpriseSubscriptionsFunc.SetDefaultReturn([]*dotcomdb.SubscriptionAttributes{{ID: "80ca12e2-54b4-448c-a61a-390b1a9c1224"}}, nil)
 		h.mockStore.UpsertEnterpriseSubscriptionFunc.SetDefaultHook(func(_ context.Context, _ string, opts subscriptions.UpsertSubscriptionOptions) (*subscriptions.Subscription, error) {
 			assert.NotEmpty(t, opts.InstanceDomain)
+			assert.Empty(t, opts.DisplayName)
 			assert.False(t, opts.ForceUpdate)
 			return &subscriptions.Subscription{}, nil
 		})

--- a/lib/enterpriseportal/subscriptions/v1/subscriptions.pb.go
+++ b/lib/enterpriseportal/subscriptions/v1/subscriptions.pb.go
@@ -1538,6 +1538,7 @@ type UpdateEnterpriseSubscriptionRequest struct {
 	// The list of fields to update, fields are specified relative to the EnterpriseSubscription.
 	// Updatable fields are:
 	//   - instance_domain
+	//   - display_name
 	UpdateMask *fieldmaskpb.FieldMask `protobuf:"bytes,2,opt,name=update_mask,json=updateMask,proto3" json:"update_mask,omitempty"`
 }
 

--- a/lib/enterpriseportal/subscriptions/v1/subscriptions.proto
+++ b/lib/enterpriseportal/subscriptions/v1/subscriptions.proto
@@ -327,6 +327,7 @@ message UpdateEnterpriseSubscriptionRequest {
   // The list of fields to update, fields are specified relative to the EnterpriseSubscription.
   // Updatable fields are:
   //  - instance_domain
+  //  - display_name
   google.protobuf.FieldMask update_mask = 2;
 }
 


### PR DESCRIPTION
Implements upsert for all the subscriptions fields in the DB client. As part of this I generalized the logic for building upsert DB interactions into a new `upsert` package, because this pattern is a common one we'll need to implement to maintain various AIP-update-compliant endpoints, which specifies various upsert behaviours: https://google.aip.dev/134

Part of CORE-216
Part of CORE-156

## Test plan

Integration tests against DB