### PR TITLE
feat(batches): sign commits created using a GitHub app credential

### DIFF
--- a/cmd/frontend/internal/batches/resolvers/BUILD.bazel
+++ b/cmd/frontend/internal/batches/resolvers/BUILD.bazel
@@ -53,7 +53,6 @@ go_library(
         "//internal/batches/rewirer",
         "//internal/batches/search",
         "//internal/batches/service",
-        "//internal/batches/sources",
         "//internal/batches/state",
         "//internal/batches/store",
         "//internal/batches/syncer",

--- a/cmd/frontend/internal/batches/resolvers/changeset_counts_test.go
+++ b/cmd/frontend/internal/batches/resolvers/changeset_counts_test.go
@@ -190,7 +190,7 @@ func TestChangesetCountsOverTimeIntegration(t *testing.T) {
 		}
 
 		src, err := sourcer.ForChangeset(ctx, bstore, c, githubRepo, sources.SourcerOpts{
-			AuthenticationStrategy: sources.AuthenticationStrategyUserCredential,
+			AuthenticationStrategy: types.SourceAuthenticationStrategyUserCredential,
 		})
 		if err != nil {
 			t.Fatalf("failed to build source for repo: %s", err)

--- a/cmd/frontend/internal/batches/resolvers/resolver.go
+++ b/cmd/frontend/internal/batches/resolvers/resolver.go
@@ -21,7 +21,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/auth"
 	"github.com/sourcegraph/sourcegraph/internal/batches/search"
 	"github.com/sourcegraph/sourcegraph/internal/batches/service"
-	"github.com/sourcegraph/sourcegraph/internal/batches/sources"
 	"github.com/sourcegraph/sourcegraph/internal/batches/store"
 	btypes "github.com/sourcegraph/sourcegraph/internal/batches/types"
 	"github.com/sourcegraph/sourcegraph/internal/database"

--- a/cmd/frontend/internal/batches/resolvers/resolver.go
+++ b/cmd/frontend/internal/batches/resolvers/resolver.go
@@ -1126,7 +1126,7 @@ func (r *Resolver) CreateBatchChangesCredential(ctx context.Context, args *graph
 	svc := service.New(r.store)
 
 	if userID != 0 {
-		cred, err := svc.CreateBatchChangesUserCredential(ctx, sources.AuthenticationStrategyUserCredential, service.CreateBatchChangesUserCredentialArgs{
+		cred, err := svc.CreateBatchChangesUserCredential(ctx, types.SourceAuthenticationStrategyUserCredential, service.CreateBatchChangesUserCredentialArgs{
 			ExternalServiceURL:  args.ExternalServiceURL,
 			ExternalServiceType: extsvc.KindToType(kind),
 			UserID:              userID,
@@ -1139,7 +1139,7 @@ func (r *Resolver) CreateBatchChangesCredential(ctx context.Context, args *graph
 		return &batchChangesUserCredentialResolver{credential: cred, ghStore: r.db.GitHubApps(), db: r.db, logger: r.logger}, nil
 	}
 
-	cred, err := svc.CreateBatchChangesSiteCredential(ctx, sources.AuthenticationStrategyUserCredential, service.CreateBatchChangesSiteCredentialArgs{
+	cred, err := svc.CreateBatchChangesSiteCredential(ctx, types.SourceAuthenticationStrategyUserCredential, service.CreateBatchChangesSiteCredentialArgs{
 		ExternalServiceURL:  args.ExternalServiceURL,
 		ExternalServiceType: extsvc.KindToType(kind),
 		Credential:          args.Credential,
@@ -1950,9 +1950,9 @@ func (r *Resolver) CheckBatchChangesCredential(ctx context.Context, args *graphq
 		ExternalServiceID:   cred.ExternalServiceURL(),
 		ExternalServiceType: extsvc.KindToType(cred.ExternalServiceKind()),
 	}
-	as := sources.AuthenticationStrategyUserCredential
+	as := types.SourceAuthenticationStrategyUserCredential
 	if cred.IsGitHubApp() {
-		as = sources.AuthenticationStrategyGitHubApp
+		as = types.SourceAuthenticationStrategyGitHubApp
 
 		ghApp, err := r.db.GitHubApps().GetByID(ctx, cred.GitHubAppID())
 		if err != nil {

--- a/cmd/frontend/internal/batches/webhooks/bitbucketserver_test.go
+++ b/cmd/frontend/internal/batches/webhooks/bitbucketserver_test.go
@@ -167,7 +167,7 @@ func testBitbucketServerWebhook(db database.DB, userID int32) func(*testing.T) {
 				t.Fatal(err)
 			}
 			src, err := sourcer.ForChangeset(ctx, s, ch, bitbucketRepo, sources.SourcerOpts{
-				AuthenticationStrategy: sources.AuthenticationStrategyUserCredential,
+				AuthenticationStrategy: types.SourceAuthenticationStrategyUserCredential,
 			})
 			if err != nil {
 				t.Fatal(err)

--- a/cmd/frontend/internal/batches/webhooks/github_test.go
+++ b/cmd/frontend/internal/batches/webhooks/github_test.go
@@ -156,7 +156,7 @@ func testGitHubWebhook(db database.DB, userID int32) func(*testing.T) {
 		})
 
 		src, err := sourcer.ForChangeset(ctx, s, changeset, githubRepo, sources.SourcerOpts{
-			AuthenticationStrategy: sources.AuthenticationStrategyUserCredential,
+			AuthenticationStrategy: types.SourceAuthenticationStrategyUserCredential,
 		})
 		if err != nil {
 			t.Fatal(err)

--- a/cmd/frontend/internal/githubapp/BUILD.bazel
+++ b/cmd/frontend/internal/githubapp/BUILD.bazel
@@ -19,7 +19,6 @@ go_library(
         "//cmd/frontend/internal/repos/webhooks/resolvers",
         "//internal/auth",
         "//internal/batches/service",
-        "//internal/batches/sources",
         "//internal/batches/store",
         "//internal/codeintel",
         "//internal/conf/conftypes",

--- a/cmd/frontend/internal/githubapp/httpapi.go
+++ b/cmd/frontend/internal/githubapp/httpapi.go
@@ -507,7 +507,7 @@ func handleCredentialCreation(ctx context.Context, db database.DB, stateDetails 
 	if *kind == ghtypes.UserCredentialGitHubAppKind {
 		if _, err = svc.CreateBatchChangesUserCredential(
 			ctx,
-			sources.AuthenticationStrategyGitHubApp,
+			types.SourceAuthenticationStrategyGitHubApp,
 			service.CreateBatchChangesUserCredentialArgs{
 				ExternalServiceURL:  esu,
 				ExternalServiceType: extsvc.VariantGitHub.AsType(),
@@ -521,7 +521,7 @@ func handleCredentialCreation(ctx context.Context, db database.DB, stateDetails 
 	} else {
 		if _, err := svc.CreateBatchChangesSiteCredential(
 			ctx,
-			sources.AuthenticationStrategyGitHubApp,
+			types.SourceAuthenticationStrategyGitHubApp,
 			service.CreateBatchChangesSiteCredentialArgs{
 				ExternalServiceURL:  esu,
 				ExternalServiceType: extsvc.VariantGitHub.AsType(),

--- a/cmd/frontend/internal/githubapp/httpapi.go
+++ b/cmd/frontend/internal/githubapp/httpapi.go
@@ -22,7 +22,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	authcheck "github.com/sourcegraph/sourcegraph/internal/auth"
 	"github.com/sourcegraph/sourcegraph/internal/batches/service"
-	"github.com/sourcegraph/sourcegraph/internal/batches/sources"
 	"github.com/sourcegraph/sourcegraph/internal/batches/store"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/encryption"
@@ -48,7 +47,7 @@ type gitHubAppServer struct {
 
 func (srv *gitHubAppServer) siteAdminMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// 🚨 SECURITY: only site admins can create github apps
+		// 🚨 SECURITY: only site admins can create GitHub apps
 		if err := authcheck.CheckCurrentUserIsSiteAdmin(r.Context(), srv.db); err != nil {
 			if errors.Is(err, authcheck.ErrMustBeSiteAdmin) {
 				http.Error(w, "User must be site admin", http.StatusForbidden)
@@ -371,7 +370,7 @@ func (srv *gitHubAppServer) setupHandler(w http.ResponseWriter, r *http.Request)
 	state := query.Get("state")
 	instID := query.Get("installation_id")
 	if state == "" || instID == "" {
-		// If neither state or installation ID is set, we redirect to the GitHub Apps page.
+		// If neither state nor installation ID is set, we redirect to the GitHub Apps page.
 		// This can happen when someone installs the App directly from GitHub, instead of
 		// following the link from within Sourcegraph.
 		http.Redirect(w, r, "/site-admin/github-apps", http.StatusFound)
@@ -555,7 +554,7 @@ func generateRedirectURL(stateDetails gitHubAppStateDetails, installationID *int
 
 	kind, err := parseKind(&stateDetails.Kind)
 	if err != nil {
-		return fmt.Sprintf("/site-admin/github-apps?success=false&kind=%s&error=%s", stateDetails.Kind, url.QueryEscape(creationErr.Error()))
+		return fmt.Sprintf("/site-admin/github-apps?success=false&kind=%s&error=%s", stateDetails.Kind, url.QueryEscape(err.Error()))
 	}
 
 	if kind == nil {

--- a/internal/batches/service/service_test.go
+++ b/internal/batches/service/service_test.go
@@ -1187,7 +1187,7 @@ index e5af166..d44c3fc 100644
 			if err := svc.ValidateAuthenticator(
 				ctx,
 				&extsvcauth.OAuthBearerToken{Token: "test123"},
-				sources.AuthenticationStrategyUserCredential,
+				types.SourceAuthenticationStrategyUserCredential,
 				validateArgs,
 			); err != nil {
 				t.Fatal(err)
@@ -1206,7 +1206,7 @@ index e5af166..d44c3fc 100644
 			if err := svc.ValidateAuthenticator(
 				ctx,
 				&extsvcauth.OAuthBearerToken{Token: "test123"},
-				sources.AuthenticationStrategyUserCredential,
+				types.SourceAuthenticationStrategyUserCredential,
 				validateArgs,
 			); err == nil {
 				t.Fatal("unexpected nil-error returned from ValidateAuthenticator")

--- a/internal/batches/sources/sources_test.go
+++ b/internal/batches/sources/sources_test.go
@@ -413,7 +413,7 @@ func TestSourcer_ForChangeset(t *testing.T) {
 			})
 
 			have, err := newMockSourcer(css).ForChangeset(ctx, tx, ch, repo, SourcerOpts{
-				AuthenticationStrategy: AuthenticationStrategyUserCredential,
+				AuthenticationStrategy: types.SourceAuthenticationStrategyUserCredential,
 			})
 			assert.NoError(t, err)
 			assert.Same(t, want, have)
@@ -455,7 +455,7 @@ func TestSourcer_ForChangeset(t *testing.T) {
 				return want, nil
 			})
 
-			have, err := newMockSourcer(css).ForChangeset(ctx, tx, ch, repo, SourcerOpts{AuthenticationStrategy: AuthenticationStrategyUserCredential})
+			have, err := newMockSourcer(css).ForChangeset(ctx, tx, ch, repo, SourcerOpts{AuthenticationStrategy: types.SourceAuthenticationStrategyUserCredential})
 			assert.NoError(t, err)
 			assert.Same(t, want, have)
 		})
@@ -490,7 +490,7 @@ func TestSourcer_ForChangeset(t *testing.T) {
 			tx.ExternalServicesFunc.SetDefaultReturn(extsvcStore)
 
 			css := NewMockChangesetSource()
-			_, err := newMockSourcer(css).ForChangeset(ctx, tx, ch, repo, SourcerOpts{AuthenticationStrategy: AuthenticationStrategyUserCredential})
+			_, err := newMockSourcer(css).ForChangeset(ctx, tx, ch, repo, SourcerOpts{AuthenticationStrategy: types.SourceAuthenticationStrategyUserCredential})
 			assert.Error(t, err)
 		})
 
@@ -541,7 +541,7 @@ func TestSourcer_ForChangeset(t *testing.T) {
 			})
 
 			have, err := newMockSourcer(css).ForChangeset(ctx, tx, ch, repo, SourcerOpts{
-				AuthenticationStrategy: AuthenticationStrategyGitHubApp,
+				AuthenticationStrategy: types.SourceAuthenticationStrategyGitHubApp,
 				GitHubAppKind:          ghatypes.SiteCredentialGitHubAppKind,
 				AsNonCredential:        true,
 			})
@@ -608,7 +608,7 @@ func TestSourcer_ForChangeset(t *testing.T) {
 			}
 
 			have, err := newMockSourcer(css).ForChangeset(ctx, tx, ch, targetRepo, SourcerOpts{
-				AuthenticationStrategy: AuthenticationStrategyGitHubApp,
+				AuthenticationStrategy: types.SourceAuthenticationStrategyGitHubApp,
 				GitHubAppKind:          ghatypes.SiteCredentialGitHubAppKind,
 				AsNonCredential:        true,
 			})
@@ -644,7 +644,7 @@ func TestSourcer_ForChangeset(t *testing.T) {
 				return want, nil
 			})
 
-			have, err := newMockSourcer(css).ForChangeset(ctx, tx, ch, repo, SourcerOpts{AuthenticationStrategy: AuthenticationStrategyUserCredential})
+			have, err := newMockSourcer(css).ForChangeset(ctx, tx, ch, repo, SourcerOpts{AuthenticationStrategy: types.SourceAuthenticationStrategyUserCredential})
 			assert.NoError(t, err)
 			assert.Same(t, want, have)
 		})
@@ -670,7 +670,7 @@ func TestSourcer_ForChangeset(t *testing.T) {
 			want := errors.New("validator was called")
 			css.ValidateAuthenticatorFunc.SetDefaultReturn(want)
 
-			_, err := newMockSourcer(css).ForChangeset(ctx, tx, ch, repo, SourcerOpts{AuthenticationStrategy: AuthenticationStrategyUserCredential})
+			_, err := newMockSourcer(css).ForChangeset(ctx, tx, ch, repo, SourcerOpts{AuthenticationStrategy: types.SourceAuthenticationStrategyUserCredential})
 			assert.Error(t, err)
 		})
 	})

--- a/internal/batches/syncer/syncer.go
+++ b/internal/batches/syncer/syncer.go
@@ -498,7 +498,7 @@ func (s *changesetSyncer) SyncChangeset(ctx context.Context, id int64) error {
 
 	srcer := sources.NewSourcer(s.httpFactory)
 	source, err := srcer.ForChangeset(ctx, s.syncStore, cs, repo, sources.SourcerOpts{
-		AuthenticationStrategy: sources.AuthenticationStrategyUserCredential,
+		AuthenticationStrategy: types.SourceAuthenticationStrategyUserCredential,
 	})
 	if err != nil {
 		if errors.Is(err, store.ErrDeletedNamespace) {

--- a/internal/gitserver/protocol/BUILD.bazel
+++ b/internal/gitserver/protocol/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "//internal/gitserver/gitdomain",
         "//internal/gitserver/v1:gitserver",
         "//internal/search/result",
+        "//internal/types",
         "//lib/errors",
         "@org_golang_google_protobuf//types/known/timestamppb",
     ],

--- a/internal/gitserver/protocol/gitserver.go
+++ b/internal/gitserver/protocol/gitserver.go
@@ -10,6 +10,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 	proto "github.com/sourcegraph/sourcegraph/internal/gitserver/v1"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
+	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
@@ -385,6 +386,10 @@ type PushConfig struct {
 	// Passphrase is the passphrase to decrypt the private key. It is required
 	// when passing PrivateKey.
 	Passphrase string
+
+	// AuthenticationStrategy is the authentication strategy used to generate the
+	// credential for the push operation
+	AuthenticationStrategy types.SourceAuthenticationStrategy
 }
 
 func (p *PushConfig) ToProto() *proto.PushConfig {

--- a/internal/types/BUILD.bazel
+++ b/internal/types/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "outbound_webhooks.go",
         "saved_searches.go",
         "secret.go",
+        "sources.go",
         "types.go",
         "webhook_logs.go",
     ],

--- a/internal/types/sources.go
+++ b/internal/types/sources.go
@@ -1,0 +1,15 @@
+package types
+
+// SourceAuthenticationStrategy defines the possible types of authentication strategy that can
+// be used to authenticate a ChangesetSource for a changeset.
+type SourceAuthenticationStrategy string
+
+const (
+	// SourceAuthenticationStrategyUserCredential is used to authenticate using a traditional PAT configured by
+	//the user or site admin. This should be used for all code host interactions unless another authentication
+	// strategy is explicitly required.
+	SourceAuthenticationStrategyUserCredential SourceAuthenticationStrategy = "USER_CREDENTIAL"
+
+	// SourceAuthenticationStrategyGitHubApp is used to authenticate using a GitHub App.
+	SourceAuthenticationStrategyGitHubApp SourceAuthenticationStrategy = "GITHUB_APP"
+)


### PR DESCRIPTION
Closes SRCH-685

When a GitHub app credential is used to push a commit, the commits aren't signed. 
With this PR, we re-use the `DuplicateCommit` method to create a signed commit so users who don't have a standalone Commit Signing app installed still get a signed commit when the commit is created with a GitHub app.

![image](https://github.com/sourcegraph/sourcegraph/assets/25608335/3058d05c-c20d-495d-abdf-49d525ec1f43)

To avoid cyclic imports, I had to move the `AuthenticationStrategy` const to the `internal/types` package and rename it to `SourceAuthenticationStrategy` so it's clear.

## Test plan

Add a GitHub app as a credential, then create a changeset targeting the repo that the GitHub app is installed on.
The final commit should be signed.

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
