### PR TITLE
feat(batches): Add "check" action to validate Github apps connection

### DIFF
--- a/client/web/src/enterprise/batches/settings/CodeHostConnectionNode.tsx
+++ b/client/web/src/enterprise/batches/settings/CodeHostConnectionNode.tsx
@@ -156,6 +156,7 @@ export const CodeHostConnectionNode: React.FunctionComponent<React.PropsWithChil
                                     config={gitHubApp}
                                     refetch={refetchAll}
                                     gitHubAppKind={gitHubAppKind}
+                                    credentialID={node.credential?.id}
                                 />
                             ) : (
                                 <>

--- a/client/web/src/enterprise/batches/settings/GitHubAppControls.tsx
+++ b/client/web/src/enterprise/batches/settings/GitHubAppControls.tsx
@@ -136,14 +136,12 @@ export const GitHubAppControls: React.FunctionComponent<GitHubAppControlsProps> 
             {error && <NodeAlert variant="danger">{error.message}</NodeAlert>}
             {!loading && data && (
                 <NodeAlert variant="success">
-                    Installations for <span className="font-weight-bold">"{config.name}"</span> successfully
-                    refreshed.
+                    Installations for <span className="font-weight-bold">"{config.name}"</span> successfully refreshed.
                 </NodeAlert>
             )}
             {!checkCredLoading && (checkCredResult || checkCredErr) && (
                 <NodeAlert variant={checkCredErr ? 'danger' : 'success'}>
-                    <span className="font-weight-bold">"{config.name}"</span> is {checkCredErr ? 'not' : ''}{' '}
-                    accessible.
+                    <span className="font-weight-bold">"{config.name}"</span> is {checkCredErr ? 'not' : ''} accessible.
                 </NodeAlert>
             )}
         </>


### PR DESCRIPTION
Closes SRCH-702

![CleanShot 2024-07-09 at 03 28 15@2x](https://github.com/sourcegraph/sourcegraph/assets/25608335/b6011864-fc4e-429c-b320-51c5a0c7b9e1)

This button adds a check button to the `GitHubApps` control that enables users to check if their GitHub app connection is accessible.

## Test plan

Manual testing.

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
