### PR TITLE
modelconfig: handle converting site config JSON -> internal data types

### DIFF
--- a/cmd/frontend/internal/modelconfig/BUILD.bazel
+++ b/cmd/frontend/internal/modelconfig/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
         "httpapi.go",
         "init.go",
         "service.go",
+        "siteconfig.go",
         "siteconfig_completions.go",
         "util.go",
     ],
@@ -27,6 +28,7 @@ go_library(
         "//internal/modelconfig/types",
         "//internal/observation",
         "//lib/errors",
+        "//schema",
         "@com_github_sourcegraph_log//:log",
     ],
 )

--- a/cmd/frontend/internal/modelconfig/init.go
+++ b/cmd/frontend/internal/modelconfig/init.go
@@ -49,7 +49,7 @@ func Init(
 		return errors.New("embedded model data is missing or corrupt")
 	}
 
-	siteModelConfig, err := getSiteModelConfigurationOrNil(logger, initialSiteConfig)
+	siteModelConfig, err := maybeGetSiteModelConfiguration(logger, initialSiteConfig)
 	if err != nil {
 		logger.Error("error loading LLM model configuration data via site config", log.Error(err))
 		return errors.Wrap(err, "loading LLM configuration info")
@@ -78,9 +78,7 @@ func Init(
 
 		latestSiteConfig := conf.Get().SiteConfiguration
 
-		// TODO(chrsmith): Load the newer form of LLM model configuration data. For now, we just
-		// load the older-stype completions configuration data if available.
-		latestSiteModelConfiguration, err := getSiteModelConfigurationOrNil(logger, latestSiteConfig)
+		latestSiteModelConfiguration, err := maybeGetSiteModelConfiguration(logger, latestSiteConfig)
 		if err != nil {
 			// BUG: If the site configuration data is somehow bad, we silently ignore
 			// the changes. This is bad, because there is no signal to the Sourcegraph

--- a/cmd/frontend/internal/modelconfig/init.go
+++ b/cmd/frontend/internal/modelconfig/init.go
@@ -13,7 +13,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/modelconfig/embedded"
-	"github.com/sourcegraph/sourcegraph/internal/modelconfig/types"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
@@ -50,18 +49,10 @@ func Init(
 		return errors.New("embedded model data is missing or corrupt")
 	}
 
-	// TODO(chrsmith): Load the newer form of LLM model configuration data. For now, we just
-	// load the older-stype completions configuration data if available.
-	var siteModelConfig *types.SiteModelConfiguration
-	if compConfig := conf.GetCompletionsConfig(initialSiteConfig); compConfig == nil {
-		logger.Info("ignoring site modelconfig data, completions config not set")
-	} else {
-		logger.Info("converting completions configuration data", log.String("apiProvider", string(compConfig.Provider)))
-		siteModelConfig, err = convertCompletionsConfig(compConfig)
-		if err != nil {
-			logger.Error("error loading LLM model configuration data via site config", log.Error(err))
-			return errors.Wrap(err, "converting completions config")
-		}
+	siteModelConfig, err := getSiteModelConfigurationOrNil(logger, initialSiteConfig)
+	if err != nil {
+		logger.Error("error loading LLM model configuration data via site config", log.Error(err))
+		return errors.Wrap(err, "converting completions config")
 	}
 
 	// Now build the initial view of the Sourcegraph instance's model configuration using this data.
@@ -89,18 +80,15 @@ func Init(
 
 		// TODO(chrsmith): Load the newer form of LLM model configuration data. For now, we just
 		// load the older-stype completions configuration data if available.
-		var latestSiteModelConfiguration *types.SiteModelConfiguration
-		if compConfig := conf.GetCompletionsConfig(latestSiteConfig); compConfig != nil {
-			latestSiteModelConfiguration, err = convertCompletionsConfig(compConfig)
-			if err != nil {
-				// BUG: If the site configuration data is somehow bad, we silently ignore
-				// the changes. This is bad, because there is no signal to the Sourcegraph
-				// admin that their configuration is invalid. Hopefully we can put the necessary
-				// validation logic inside the site configuration validation checks, so
-				// that they will be prevented from saving invalid config data.
-				logger.Error("errror loading updated site configuration", log.Error(err))
-				latestSiteModelConfiguration = nil
-			}
+		latestSiteModelConfiguration, err := getSiteModelConfigurationOrNil(logger, latestSiteConfig)
+		if err != nil {
+			// BUG: If the site configuration data is somehow bad, we silently ignore
+			// the changes. This is bad, because there is no signal to the Sourcegraph
+			// admin that their configuration is invalid. Hopefully we can put the necessary
+			// validation logic inside the site configuration validation checks, so
+			// that they will be prevented from saving invalid config data.
+			logger.Error("error loading updated site configuration", log.Error(err))
+			latestSiteModelConfiguration = nil
 		}
 
 		// Update and rebuild the LLM model configuration.

--- a/cmd/frontend/internal/modelconfig/init.go
+++ b/cmd/frontend/internal/modelconfig/init.go
@@ -52,7 +52,7 @@ func Init(
 	siteModelConfig, err := getSiteModelConfigurationOrNil(logger, initialSiteConfig)
 	if err != nil {
 		logger.Error("error loading LLM model configuration data via site config", log.Error(err))
-		return errors.Wrap(err, "converting completions config")
+		return errors.Wrap(err, "loading LLM configuration info")
 	}
 
 	// Now build the initial view of the Sourcegraph instance's model configuration using this data.

--- a/cmd/frontend/internal/modelconfig/siteconfig.go
+++ b/cmd/frontend/internal/modelconfig/siteconfig.go
@@ -10,11 +10,11 @@ import (
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
-// getSiteModelConfigurationOrNil returns the SiteModelConfiguration, or nil if there is none.
+// maybeGetSiteModelConfiguration returns the SiteModelConfiguration, or nil if there is none.
 //
 // This function is responsible for converting the schema.SiteConfiguration that admins write
 // into our internal data type.
-func getSiteModelConfigurationOrNil(logger log.Logger, siteConfig schema.SiteConfiguration) (*types.SiteModelConfiguration, error) {
+func maybeGetSiteModelConfiguration(logger log.Logger, siteConfig schema.SiteConfiguration) (*types.SiteModelConfiguration, error) {
 	// If "modelConfiguration" is specified, then we respect that and only that. If it is not specified,
 	// then we respect the older "completions" configuration.
 	modelConfig := siteConfig.ModelConfiguration

--- a/cmd/frontend/internal/modelconfig/siteconfig.go
+++ b/cmd/frontend/internal/modelconfig/siteconfig.go
@@ -1,0 +1,312 @@
+package modelconfig
+
+import (
+	"fmt"
+
+	"github.com/sourcegraph/log"
+
+	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/internal/modelconfig/types"
+	"github.com/sourcegraph/sourcegraph/schema"
+)
+
+// getSiteModelConfigurationOrNil returns the SiteModelConfiguration, or nil if there is none.
+//
+// This function is responsible for converting the schema.SiteConfiguration that admins write
+// into our internal data type.
+func getSiteModelConfigurationOrNil(logger log.Logger, siteConfig schema.SiteConfiguration) (*types.SiteModelConfiguration, error) {
+	// If "modelConfiguration" is specified, then we respect that and only that. If it is not specified,
+	// then we respect the older "completions" configuration.
+	modelConfig := siteConfig.ModelConfiguration
+	if modelConfig == nil {
+		if compConfig := conf.GetCompletionsConfig(siteConfig); compConfig != nil {
+			logger.Info("converting completions configuration data", log.String("apiProvider", string(compConfig.Provider)))
+			return convertCompletionsConfig(compConfig)
+		}
+		return nil, nil
+	}
+	return convertModelConfiguration(modelConfig), nil
+
+}
+
+// Performs no validation, assumes the config is valid.
+func convertModelConfiguration(v *schema.SiteModelConfiguration) *types.SiteModelConfiguration {
+	return &types.SiteModelConfiguration{
+		SourcegraphModelConfig: convertSourcegraphModelConfig(v.Sourcegraph),
+		ProviderOverrides:      convertProviderOverrides(v.ProviderOverrides),
+		ModelOverrides:         convertModelOverrides(v),
+		DefaultModels:          convertDefaultModels(v.DefaultModels),
+	}
+}
+
+func convertSourcegraphModelConfig(v *schema.SourcegraphModelConfig) *types.SourcegraphModelConfig {
+	if v == nil {
+		return nil
+	}
+	return &types.SourcegraphModelConfig{
+		Endpoint:        v.Endpoint,
+		AccessToken:     v.AccessToken,
+		PollingInterval: v.PollingInterval,
+		ModelFilters:    convertModelFilters(v.ModelFilters),
+	}
+}
+
+func convertProviderOverrides(overrides []*schema.ProviderOverride) []types.ProviderOverride {
+	var converted []types.ProviderOverride
+	for _, v := range overrides {
+		converted = append(converted, types.ProviderOverride{
+			ID:                 types.ProviderID(v.Id),
+			DisplayName:        v.DisplayName,
+			ClientSideConfig:   convertClientSideProviderConfig(v.ClientSideConfig),
+			ServerSideConfig:   convertServerSideProviderConfig(v.ServerSideConfig),
+			DefaultModelConfig: convertDefaultModelConfig(v.DefaultModelConfig),
+		})
+	}
+	return converted
+}
+
+func convertModelOverrides(modelConfig *schema.SiteModelConfiguration) []types.ModelOverride {
+	var converted []types.ModelOverride
+	for _, v := range modelConfig.ModelOverrides {
+		converted = append(converted, types.ModelOverride{
+			ModelRef:         types.ModelRef(v.ModelRef),
+			DisplayName:      v.DisplayName,
+			ModelName:        v.ModelName,
+			Capabilities:     convertModelCapabilities(v.Capabilities),
+			Category:         types.ModelCategory(v.Category),
+			Status:           types.ModelStatus(v.Status),
+			Tier:             types.ModelTierEnterprise, // Note: we always default to enterprise as the model tier for admin-defined models.
+			ContextWindow:    convertContextWindow(v.ContextWindow),
+			ClientSideConfig: convertClientSideModelConfig(v.ClientSideConfig),
+			ServerSideConfig: convertServerSideModelConfig(v.ServerSideConfig),
+		})
+	}
+	for _, modelRef := range modelConfig.ModelOverridesRecommendedSettings {
+		if recommended, ok := recommendedSettings[types.ModelRef(modelRef)]; ok {
+			converted = append(converted, recommended)
+		}
+	}
+	return converted
+}
+
+func convertDefaultModels(v *schema.DefaultModels) *types.DefaultModels {
+	if v == nil {
+		return nil
+	}
+	return &types.DefaultModels{
+		Chat:           types.ModelRef(v.Chat),
+		FastChat:       types.ModelRef(v.FastChat),
+		CodeCompletion: types.ModelRef(v.CodeCompletion),
+	}
+}
+
+func convertModelFilters(v *schema.ModelFilters) *types.ModelFilters {
+	if v == nil {
+		return nil
+	}
+	return &types.ModelFilters{
+		StatusFilter: v.StatusFilter,
+		Allow:        v.Allow,
+		Deny:         v.Deny,
+	}
+}
+
+func convertClientSideProviderConfig(v *schema.ClientSideProviderConfig) *types.ClientSideProviderConfig {
+	if v == nil {
+		return nil
+	}
+	return &types.ClientSideProviderConfig{
+		// We currently do not have any known client-side provider configuration.
+	}
+}
+
+func convertServerSideProviderConfig(cfg *schema.ServerSideProviderConfig) *types.ServerSideProviderConfig {
+	if cfg == nil {
+		return nil
+	}
+	if v := cfg.AwsBedrock; v != nil {
+		return &types.ServerSideProviderConfig{
+			AWSBedrock: &types.AWSBedrockProviderConfig{
+				AccessToken: v.AccessToken,
+				Endpoint:    v.Endpoint,
+				Region:      v.Region,
+			},
+		}
+	} else if v := cfg.AzureOpenAI; v != nil {
+		return &types.ServerSideProviderConfig{
+			AzureOpenAI: &types.AzureOpenAIProviderConfig{
+				AccessToken:                 v.AccessToken,
+				Endpoint:                    v.Endpoint,
+				User:                        v.User,
+				UseDeprecatedCompletionsAPI: v.UseDeprecatedCompletionsAPI,
+			},
+		}
+	} else if v := cfg.Anthropic; v != nil {
+		return &types.ServerSideProviderConfig{
+			GenericProvider: &types.GenericProviderConfig{
+				ServiceName: types.GenericServiceProviderAnthropic,
+				AccessToken: v.AccessToken,
+				Endpoint:    v.Endpoint,
+			},
+		}
+	} else if v := cfg.Fireworks; v != nil {
+		return &types.ServerSideProviderConfig{
+			GenericProvider: &types.GenericProviderConfig{
+				ServiceName: types.GenericServiceProviderFireworks,
+				AccessToken: v.AccessToken,
+				Endpoint:    v.Endpoint,
+			},
+		}
+	} else if v := cfg.Google; v != nil {
+		return &types.ServerSideProviderConfig{
+			GenericProvider: &types.GenericProviderConfig{
+				ServiceName: types.GenericServiceProviderGoogle,
+				AccessToken: v.AccessToken,
+				Endpoint:    v.Endpoint,
+			},
+		}
+	} else if v := cfg.Openai; v != nil {
+		return &types.ServerSideProviderConfig{
+			GenericProvider: &types.GenericProviderConfig{
+				ServiceName: types.GenericServiceProviderOpenAI,
+				AccessToken: v.AccessToken,
+				Endpoint:    v.Endpoint,
+			},
+		}
+	} else if v := cfg.Openaicompatible; v != nil {
+		// TODO(slimsag): self-hosted-llm: map this to OpenAICompatibleProviderConfig in the future
+		return &types.ServerSideProviderConfig{
+			GenericProvider: &types.GenericProviderConfig{
+				ServiceName: types.GenericServiceProviderOpenAI,
+				AccessToken: v.AccessToken,
+				Endpoint:    v.Endpoint,
+			},
+		}
+	} else if v := cfg.Sourcegraph; v != nil {
+		return &types.ServerSideProviderConfig{
+			SourcegraphProvider: &types.SourcegraphProviderConfig{
+				AccessToken: v.AccessToken,
+				Endpoint:    v.Endpoint,
+			},
+		}
+	} else {
+		panic(fmt.Sprintf("illegal state: %+v", v))
+	}
+}
+
+func convertClientSideModelConfig(v *schema.ClientSideModelConfig) *types.ClientSideModelConfig {
+	if v == nil {
+		return nil
+	}
+	return &types.ClientSideModelConfig{
+		// We currently do not have any known client-side model configuration.
+	}
+}
+
+func convertServerSideModelConfig(cfg *schema.ServerSideModelConfig) *types.ServerSideModelConfig {
+	if cfg == nil {
+		return nil
+	}
+	if v := cfg.AwsBedrockProvisionedThroughput; v != nil {
+		return &types.ServerSideModelConfig{
+			AWSBedrockProvisionedThroughput: &types.AWSBedrockProvisionedThroughput{
+				ARN: v.Arn,
+			},
+		}
+	} else {
+		panic(fmt.Sprintf("illegal state: %+v", v))
+	}
+}
+
+func convertDefaultModelConfig(v *schema.DefaultModelConfig) *types.DefaultModelConfig {
+	if v == nil {
+		return nil
+	}
+	return &types.DefaultModelConfig{
+		Capabilities:     convertModelCapabilities(v.Capabilities),
+		Category:         types.ModelCategory(v.Category),
+		Status:           types.ModelStatus(v.Status),
+		Tier:             types.ModelTierEnterprise, // Note: we always default to enterprise as the model tier for admin-defined models.
+		ContextWindow:    convertContextWindow(v.ContextWindow),
+		ClientSideConfig: convertClientSideModelConfig(v.ClientSideConfig),
+		ServerSideConfig: convertServerSideModelConfig(v.ServerSideConfig),
+	}
+}
+
+func convertContextWindow(v schema.ContextWindow) types.ContextWindow {
+	return types.ContextWindow{
+		MaxInputTokens:  v.MaxInputTokens,
+		MaxOutputTokens: v.MaxOutputTokens,
+	}
+}
+
+func convertModelCapabilities(capabilities []string) []types.ModelCapability {
+	var converted []types.ModelCapability
+	for _, v := range capabilities {
+		converted = append(converted, types.ModelCapability(v))
+	}
+	return converted
+}
+
+// These are the default values where if someone writes in their site config that they want to
+// use blessed Self-Hosted Model configurations, e.g.:
+//
+// ```
+// "modelOverridesRecommendedSettings": [
+//
+//	"bigcode::v1::starcoder2-7b",
+//	"mistral::v1::mixtral-8x7b-instruct"
+//
+// ],
+// ```
+//
+// It would specify these equivalent options for them under `modelOverrides`:
+var recommendedSettings = map[types.ModelRef]types.ModelOverride{
+	"bigcode::v1::starcoder2-3b":          recommendedSettingsStarcoder2("bigcode::v1::starcoder2-3b", "Starcoder2 3B", "starcoder2-3b"),
+	"bigcode::v1::starcoder2-7b":          recommendedSettingsStarcoder2("bigcode::v1::starcoder2-7b", "Starcoder2 7B", "starcoder2-7b"),
+	"bigcode::v1::starcoder2-15b":         recommendedSettingsStarcoder2("bigcode::v1::starcoder2-15b", "Starcoder2 15B", "starcoder2-15b"),
+	"mistral::v1::mistral-7b":             recommendedSettingsMistral("mistral::v1::mistral-7b", "Mistral 7B", "mistral-7b"),
+	"mistral::v1::mistral-7b-instruct":    recommendedSettingsMistral("mistral::v1::mistral-7b-instruct", "Mistral 7B Instruct", "mistral-7b-instruct"),
+	"mistral::v1::mixtral-8x7b":           recommendedSettingsMistral("mistral::v1::mixtral-8x7b", "Mixtral 8x7B", "mixtral-8x7b"),
+	"mistral::v1::mixtral-8x22b":          recommendedSettingsMistral("mistral::v1::mixtral-8x22b", "Mixtral 8x22B", "mixtral-8x22b"),
+	"mistral::v1::mixtral-8x7b-instruct":  recommendedSettingsMistral("mistral::v1::mixtral-8x7b-instruct", "Mixtral 8x7B Instruct", "mixtral-8x7b-instruct"),
+	"mistral::v1::mixtral-8x22b-instruct": recommendedSettingsMistral("mistral::v1::mixtral-8x22b", "Mixtral 8x22B", "mixtral-8x22b-instruct"),
+}
+
+func recommendedSettingsStarcoder2(modelRef, displayName, modelName string) types.ModelOverride {
+	// TODO(slimsag): self-hosted-llm: tune these further based on testing
+	return types.ModelOverride{
+		ModelRef:     types.ModelRef(modelRef),
+		DisplayName:  displayName,
+		ModelName:    modelName,
+		Capabilities: []types.ModelCapability{types.ModelCapabilityAutocomplete},
+		Category:     types.ModelCategoryBalanced,
+		Status:       types.ModelStatusStable,
+		Tier:         types.ModelTierEnterprise,
+		ContextWindow: types.ContextWindow{
+			MaxInputTokens:  8192,
+			MaxOutputTokens: 4000,
+		},
+		ClientSideConfig: nil,
+		ServerSideConfig: nil,
+	}
+}
+
+func recommendedSettingsMistral(modelRef, displayName, modelName string) types.ModelOverride {
+	// TODO(slimsag): self-hosted-llm: tune these further based on testing
+	return types.ModelOverride{
+		ModelRef:     types.ModelRef(modelRef),
+		DisplayName:  displayName,
+		ModelName:    modelName,
+		Capabilities: []types.ModelCapability{types.ModelCapabilityChat, types.ModelCapabilityAutocomplete},
+		Category:     types.ModelCategoryBalanced,
+		Status:       types.ModelStatusStable,
+		Tier:         types.ModelTierEnterprise,
+		ContextWindow: types.ContextWindow{
+			MaxInputTokens:  8192,
+			MaxOutputTokens: 4000,
+		},
+		ClientSideConfig: nil,
+		ServerSideConfig: nil,
+	}
+}

--- a/cmd/frontend/internal/modelconfig/siteconfig.go
+++ b/cmd/frontend/internal/modelconfig/siteconfig.go
@@ -15,18 +15,18 @@ import (
 // This function is responsible for converting the schema.SiteConfiguration that admins write
 // into our internal data type.
 func maybeGetSiteModelConfiguration(logger log.Logger, siteConfig schema.SiteConfiguration) (*types.SiteModelConfiguration, error) {
-	// If "modelConfiguration" is specified, then we respect that and only that. If it is not specified,
-	// then we respect the older "completions" configuration.
+	// If "modelConfiguration" is specified, then we respect that and only that.
 	modelConfig := siteConfig.ModelConfiguration
-	if modelConfig == nil {
-		if compConfig := conf.GetCompletionsConfig(siteConfig); compConfig != nil {
-			logger.Info("converting completions configuration data", log.String("apiProvider", string(compConfig.Provider)))
-			return convertCompletionsConfig(compConfig)
-		}
-		return nil, nil
+	if modelConfig != nil {
+		return convertModelConfiguration(modelConfig), nil
 	}
-	return convertModelConfiguration(modelConfig), nil
 
+	// Otherwise we fallback to legacy "completions" config
+	if compConfig := conf.GetCompletionsConfig(siteConfig); compConfig != nil {
+		logger.Info("converting completions configuration data", log.String("apiProvider", string(compConfig.Provider)))
+		return convertCompletionsConfig(compConfig)
+	}
+	return nil, nil
 }
 
 // Performs no validation, assumes the config is valid.


### PR DESCRIPTION
This causes the `modelconfig` package to actually begin converting the new `"modelConfiguration"` site config which was introduced in #63654 into the internal data types we use for model configuration.

This is all pretty straightforward / lame type conversion code, but carefully written to preserve all the semantics we care about.

## Test plan

Written very carefully, and confirmed that this query:

```
curl -H "Authorization: token $(cat ~/local-token)" https://sourcegraph.test:3443/.api/modelconfig/supported-models.json
```

returns what I would expect with this site configuration:

<details>
<summary>site config</summary>

```
  // Setting this field means we are opting into the new Cody model configuration system which is in beta.
  "modelConfiguration": {
    // Disable use of Sourcegraph's servers for model discovery
    "sourcegraph": null,

    // Configure the OpenAI-compatible API endpoints that Cody should use to provide
    // mistral and bigcode (starcoder) models.
    "providerOverrides": [
      {
        "displayName": "Mistral",
        "id": "mistral",
        "serverSideConfig": {
          "type": "openaicompatible",
          "endpoint": "...",
          "accessToken": "...",
        },
      },
      {
        "displayName": "Bigcode",
        "id": "bigcode",
        "serverSideConfig": {
          "type": "openaicompatible",
          "endpoint": "...",
          "accessToken": "...",
        },
      },
    ],

    // Configure which exact mistral and starcoder models we want available
    "modelOverridesRecommendedSettings": [
      "bigcode::v1::starcoder2-7b",
      "mistral::v1::mixtral-8x7b-instruct"
    ],

    // Configure which models Cody will use by default
    "defaultModels": {
      "chat": "mistral::v1::mixtral-8x7b-instruct",
      "fastChat": "mistral::v1::mixtral-8x7b-instruct",
      "codeCompletion": "bigcode::v1::starcoder2-7b",
    }
  }
```

</details>

We could certainly use more unit tests here to prevent potential future regressions, I can add those in a future PR.

## Changelog

Has no effect on users unless they opt into the early-access `"modelConfiguration"` site config feature.
