### PR TITLE
chore: drop isGitHubApp field from batch changes credentials

### DIFF
--- a/client/web/src/enterprise/batches/settings/BatchChangesSettingsArea.story.tsx
+++ b/client/web/src/enterprise/batches/settings/BatchChangesSettingsArea.story.tsx
@@ -47,7 +47,6 @@ const sshCredential = (isSiteCredential: boolean): BatchChangesCredentialFields 
     isSiteCredential,
     sshPublicKey:
         'rsa-ssh randorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorando',
-    isGitHubApp: false,
     gitHubApp: null,
 })
 

--- a/client/web/src/enterprise/batches/settings/BatchChangesSiteConfigSettingsPage.story.tsx
+++ b/client/web/src/enterprise/batches/settings/BatchChangesSiteConfigSettingsPage.story.tsx
@@ -156,7 +156,6 @@ export const ConfigAdded: StoryFn = () => (
                                     isSiteCredential: true,
                                     sshPublicKey:
                                         'rsa-ssh randorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorando',
-                                    isGitHubApp: false,
                                     gitHubApp: null,
                                 },
                                 externalServiceKind: ExternalServiceKind.GITHUB,
@@ -181,8 +180,6 @@ export const ConfigAdded: StoryFn = () => (
                                     isSiteCredential: true,
                                     sshPublicKey:
                                         'rsa-ssh randorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorando',
-                                    isGitHubApp: false,
-
                                     gitHubApp: null,
                                 },
                                 externalServiceKind: ExternalServiceKind.GITLAB,
@@ -199,7 +196,6 @@ export const ConfigAdded: StoryFn = () => (
                                     isSiteCredential: true,
                                     sshPublicKey:
                                         'rsa-ssh randorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorando',
-                                    isGitHubApp: false,
                                     gitHubApp: null,
                                 },
                                 externalServiceKind: ExternalServiceKind.BITBUCKETSERVER,
@@ -216,7 +212,6 @@ export const ConfigAdded: StoryFn = () => (
                                     isSiteCredential: true,
                                     sshPublicKey:
                                         'rsa-ssh randorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorando',
-                                    isGitHubApp: false,
                                     gitHubApp: null,
                                 },
                                 externalServiceKind: ExternalServiceKind.BITBUCKETCLOUD,

--- a/client/web/src/enterprise/batches/settings/CodeHostConnectionNode.story.tsx
+++ b/client/web/src/enterprise/batches/settings/CodeHostConnectionNode.story.tsx
@@ -35,7 +35,6 @@ const sshCredential = (isSiteCredential: boolean): BatchChangesCredentialFields 
     isSiteCredential,
     sshPublicKey:
         'rsa-ssh randorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorando',
-    isGitHubApp: false,
     gitHubApp: null,
 })
 

--- a/client/web/src/enterprise/batches/settings/CodeHostConnectionNode.tsx
+++ b/client/web/src/enterprise/batches/settings/CodeHostConnectionNode.tsx
@@ -98,7 +98,7 @@ export const CodeHostConnectionNode: React.FunctionComponent<React.PropsWithChil
     const gitHubApp: Pick<GitHubAppByIDFields, 'id' | 'name' | 'appURL' | 'logo' | 'appID'> | null =
         gitHubAppKind === GitHubAppKind.COMMIT_SIGNING
             ? node.commitSigningConfiguration
-            : (node.credential?.gitHubApp ?? null);
+            : node.credential?.gitHubApp ?? null
 
     return (
         <>

--- a/client/web/src/enterprise/batches/settings/CodeHostConnectionNode.tsx
+++ b/client/web/src/enterprise/batches/settings/CodeHostConnectionNode.tsx
@@ -98,9 +98,7 @@ export const CodeHostConnectionNode: React.FunctionComponent<React.PropsWithChil
     const gitHubApp: Pick<GitHubAppByIDFields, 'id' | 'name' | 'appURL' | 'logo' | 'appID'> | null =
         gitHubAppKind === GitHubAppKind.COMMIT_SIGNING
             ? node.commitSigningConfiguration
-            : node.credential?.isGitHubApp
-            ? node.credential.gitHubApp
-            : null
+            : (node.credential?.gitHubApp ?? null);
 
     return (
         <>

--- a/client/web/src/enterprise/batches/settings/RemoveCredentialModal.story.tsx
+++ b/client/web/src/enterprise/batches/settings/RemoveCredentialModal.story.tsx
@@ -27,7 +27,6 @@ const credential = {
     isSiteCredential: false,
     sshPublicKey:
         'ssh-rsa randorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorando',
-    isGitHubApp: false,
     gitHubApp: null,
 }
 

--- a/client/web/src/enterprise/batches/settings/ViewCredentialModal.story.tsx
+++ b/client/web/src/enterprise/batches/settings/ViewCredentialModal.story.tsx
@@ -20,7 +20,6 @@ const credential: BatchChangesCredentialFields = {
     isSiteCredential: false,
     sshPublicKey:
         'ssh-rsa randorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorando',
-    isGitHubApp: false,
     gitHubApp: null,
 }
 

--- a/client/web/src/enterprise/batches/settings/backend.ts
+++ b/client/web/src/enterprise/batches/settings/backend.ts
@@ -26,7 +26,6 @@ export const CREDENTIAL_FIELDS_FRAGMENT = gql`
         id
         sshPublicKey
         isSiteCredential
-        isGitHubApp
         gitHubApp {
             id
             appID

--- a/cmd/frontend/graphqlbackend/batches.go
+++ b/cmd/frontend/graphqlbackend/batches.go
@@ -566,7 +566,6 @@ type BatchChangesCredentialResolver interface {
 	ID() graphql.ID
 	ExternalServiceKind() string
 	ExternalServiceURL() string
-	IsGitHubApp() bool
 	GitHubAppID() int
 	SSHPublicKey(ctx context.Context) (*string, error)
 	CreatedAt() gqlutil.DateTime

--- a/cmd/frontend/graphqlbackend/batches.graphql
+++ b/cmd/frontend/graphqlbackend/batches.graphql
@@ -3559,12 +3559,7 @@ type BatchChangesCredential implements Node {
     isSiteCredential: Boolean!
 
     """
-    Whether the credential is tied to a GitHub App installation.
-    """
-    isGitHubApp: Boolean!
-
-    """
-    If the field isGitHubApp is true, this field contains the details of the GitHubApp.
+    If the credential is a gitHubApp, this field contains the details of the GitHubApp.
     """
     gitHubApp: GitHubApp
 }

--- a/cmd/frontend/graphqlbackend/batches.graphql
+++ b/cmd/frontend/graphqlbackend/batches.graphql
@@ -3559,7 +3559,7 @@ type BatchChangesCredential implements Node {
     isSiteCredential: Boolean!
 
     """
-    If the credential is a gitHubApp, this field contains the details of the GitHubApp.
+    If the credential is a GitHub app, this field contains the details of the GitHubApp.
     """
     gitHubApp: GitHubApp
 }

--- a/cmd/frontend/internal/batches/resolvers/resolver.go
+++ b/cmd/frontend/internal/batches/resolvers/resolver.go
@@ -1951,7 +1951,11 @@ func (r *Resolver) CheckBatchChangesCredential(ctx context.Context, args *graphq
 		ExternalServiceType: extsvc.KindToType(cred.ExternalServiceKind()),
 	}
 	as := sources.AuthenticationStrategyUserCredential
-	if cred.IsGitHubApp() {
+	ghApp, err := cred.GitHubApp(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if ghApp != nil {
 		as = sources.AuthenticationStrategyGitHubApp
 
 		ghApp, err := r.db.GitHubApps().GetByID(ctx, cred.GitHubAppID())

--- a/cmd/frontend/internal/batches/resolvers/resolver.go
+++ b/cmd/frontend/internal/batches/resolvers/resolver.go
@@ -1951,11 +1951,7 @@ func (r *Resolver) CheckBatchChangesCredential(ctx context.Context, args *graphq
 		ExternalServiceType: extsvc.KindToType(cred.ExternalServiceKind()),
 	}
 	as := sources.AuthenticationStrategyUserCredential
-	ghApp, err := cred.GitHubApp(ctx)
-	if err != nil {
-		return nil, err
-	}
-	if ghApp != nil {
+	if cred.GitHubAppID() > 0 {
 		as = sources.AuthenticationStrategyGitHubApp
 
 		ghApp, err := r.db.GitHubApps().GetByID(ctx, cred.GitHubAppID())


### PR DESCRIPTION
We now have the `gitHubApp` field that can be used instead. `isGitHubApp` was only introduced as part of the batch changes integration with github app, and is therefore not released yet.

Closes SRCH-704

## Test plan

Manual testing

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
