### PR TITLE
chore(batches): rename use of tokens to credentials

### DIFF
--- a/client/web/src/enterprise/batches/settings/CodeHostConnections.tsx
+++ b/client/web/src/enterprise/batches/settings/CodeHostConnections.tsx
@@ -80,7 +80,7 @@ const CodeHostConnections: React.FunctionComponent<React.PropsWithChildren<CodeH
     const shouldShowError = !success && setupError && gitHubAppKind !== GitHubAppKind.COMMIT_SIGNING
     return (
         <Container className="mb-3">
-            <H3>Code host tokens</H3>
+            <H3>Code host credentials</H3>
             {headerLine}
             <ConnectionContainer className="mb-3">
                 {error && <ConnectionError errors={[error.message]} />}


### PR DESCRIPTION
![image](https://github.com/sourcegraph/sourcegraph/assets/25608335/750c445f-63fe-46b3-b3c3-4e6d13a8a6a2)

The word token is stale now considering we now support the use of GitHub apps as a means of authentication for Code hosts and Batch Changes. 

## Test plan

UI update. Confirm this works as expected.

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
