### PR TITLE
fix: better alignemnt of github credentials and check success notice

### DIFF
--- a/client/web/src/enterprise/batches/settings/CodeHostConnectionNode.tsx
+++ b/client/web/src/enterprise/batches/settings/CodeHostConnectionNode.tsx
@@ -146,7 +146,7 @@ export const CodeHostConnectionNode: React.FunctionComponent<React.PropsWithChil
                             </Badge>
                         )}
                     </H3>
-                    <div className="mb-0 d-flex justify-content-end flex-grow-1 align-items-baseline">
+                    <div className="mb-0 d-flex justify-content-end flex-grow-1 align-items-baseline flex-wrap">
                         {isEnabled ? (
                             gitHubApp ? (
                                 <GitHubAppControls

--- a/client/web/src/enterprise/batches/settings/GitHubAppControls.tsx
+++ b/client/web/src/enterprise/batches/settings/GitHubAppControls.tsx
@@ -141,9 +141,10 @@ export const GitHubAppControls: React.FunctionComponent<GitHubAppControlsProps> 
             )}
             {!checkCredLoading && (checkCredResult || checkCredErr) && (
                 <>
-                    <br/>
+                    <br />
                     <NodeAlert variant={checkCredErr ? 'danger' : 'success'}>
-                        <span className="font-weight-bold">{config.name}</span> is {checkCredErr ? 'not' : ''} accessible.
+                        <span className="font-weight-bold">{config.name}</span> is {checkCredErr ? 'not' : ''}{' '}
+                        accessible.
                     </NodeAlert>
                 </>
             )}

--- a/client/web/src/enterprise/batches/settings/GitHubAppControls.tsx
+++ b/client/web/src/enterprise/batches/settings/GitHubAppControls.tsx
@@ -66,7 +66,7 @@ export const GitHubAppControls: React.FunctionComponent<GitHubAppControlsProps> 
     >(CHECK_BATCH_CHANGES_CREDENTIAL, {})
 
     return config ? (
-        <>
+        <div>
             {removeModalOpen && (
                 <RemoveGitHubAppModal onCancel={() => setRemoveModalOpen(false)} afterDelete={refetch} app={config} />
             )}
@@ -140,11 +140,14 @@ export const GitHubAppControls: React.FunctionComponent<GitHubAppControlsProps> 
                 </NodeAlert>
             )}
             {!checkCredLoading && (checkCredResult || checkCredErr) && (
-                <NodeAlert variant={checkCredErr ? 'danger' : 'success'}>
-                    <span className="font-weight-bold">"{config.name}"</span> is {checkCredErr ? 'not' : ''} accessible.
-                </NodeAlert>
+                <>
+                    <br/>
+                    <NodeAlert variant={checkCredErr ? 'danger' : 'success'}>
+                        <span className="font-weight-bold">{config.name}</span> is {checkCredErr ? 'not' : ''} accessible.
+                    </NodeAlert>
+                </>
             )}
-        </>
+        </div>
     ) : (
         <ButtonLink to={createURL} className="ml-auto text-nowrap" variant="success" as={Link} size="sm">
             Create GitHub App


### PR DESCRIPTION
Closes SRCH-701

Ideally we would use a DismissibleAlert one level up the React component chain, but that's turning out too tricky for the time we have left: https://sourcegraph.slack.com/archives/C07A21XEP0T/p1720486350310899

## Test plan

Manual testing

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
