### PR TITLE
chore(redis): set max active redis connections to 1000

### DIFF
--- a/internal/redispool/redispool.go
+++ b/internal/redispool/redispool.go
@@ -81,6 +81,7 @@ func dialRedis(rawEndpoint string) (redis.Conn, error) {
 var Cache = NewKeyValue(addresses.Cache, &redis.Pool{
 	MaxIdle:     3,
 	IdleTimeout: 240 * time.Second,
+	MaxActive:   1000,
 })
 
 // Store is a redis configured for persisting data. Do not abuse this pool,
@@ -90,4 +91,5 @@ var Cache = NewKeyValue(addresses.Cache, &redis.Pool{
 var Store = NewKeyValue(addresses.Store, &redis.Pool{
 	MaxIdle:     10,
 	IdleTimeout: 240 * time.Second,
+	MaxActive:   1000,
 })


### PR DESCRIPTION
When active client is 0, there is no limit to the amount of active clients which can lead to Redis quickly reaching it's MaxClient (10000 by default)

For more context see [this slack thread](https://sourcegraph.slack.com/archives/C05EMJM2SLR/p1720448507809479)

## Test plan
CI


## Changelog
* redis-pool: set max active clients to 1000
<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
