### PR TITLE
feat(svelte): Add 'y' shortcut to navigate to permalink 

### DIFF
--- a/client/web-sveltekit/src/lib/repo/Permalink.svelte
+++ b/client/web-sveltekit/src/lib/repo/Permalink.svelte
@@ -3,14 +3,36 @@
     Renders a permalink to the current page with the given Git commit ID.
 -->
 <script lang="ts">
+    import { goto } from '$app/navigation'
     import { page } from '$app/stores'
+    import { createHotkey } from '$lib/Hotkey'
     import Icon from '$lib/Icon.svelte'
     import { replaceRevisionInURL } from '$lib/shared'
     import Tooltip from '$lib/Tooltip.svelte'
+    import { parseBrowserRepoURL } from '$lib/web'
 
     export let commitID: string
 
+    const hotkey = createHotkey({
+        keys: { key: 'y' },
+        ignoreInputFields: true,
+        handler: () => {
+            const {revision} = parseBrowserRepoURL($page.url.pathname)
+            // Only navigate if necessary. We don't want to add unnecessary history entries.
+            if (revision !== commitID) {
+                goto(href, { noScroll: true, keepFocus: true }).catch(() => {
+                    // TODO: log error with Sentry
+                })
+            }
+        },
+    })
+
     $: href = commitID ? replaceRevisionInURL($page.url.toString(), commitID) : ''
+    $: if (href) {
+        hotkey.enable()
+    } else {
+        hotkey.disable()
+    }
 </script>
 
 {#if href}

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/+layout.ts
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/+layout.ts
@@ -41,11 +41,15 @@ export const load: LayoutLoad = async ({ parent, params }) => {
         filePath,
         parentPath,
         isCodyAvailable: createCodyAvailableStore(client, repoName),
-        lastCommit: client.query(LastCommitQuery, {
-            repoName,
-            revspec: revision,
-            filePath,
-        }),
+        lastCommit: resolvedRevision
+            .then(revspec =>
+                client.query(LastCommitQuery, {
+                    repoName,
+                    revspec,
+                    filePath,
+                })
+            )
+            .then(result => result.data?.repository?.lastCommit?.ancestors.nodes[0]),
         // Fetches the most recent commits for current blob, tree or repo root
         commitHistory: infinityQuery({
             client,


### PR DESCRIPTION
Fixes srch-589

This implements the 'y' shortcut to navigate to the permalink page, just
like we have in the React app.

According to aria guidelines it should be possible to disable single
character shortcuts but this actually never worked for the 'y' shortcut
because it was implemented differently. So adding it without the option
to turn it off is at least not a regression.

For reference this the code handling the shortcut in the React app: https://sourcegraph.sourcegraph.com/github.com/sourcegraph/sourcegraph@d9dff1191a3bad812aa5b50315b8e77ee0e40e55/-/blob/client/web/src/repo/actions/CopyPermalinkAction.tsx?L64-77

When initially implementing this I noticed that there is a slight delay between pressing 'y' and the URL/UI updating. That's because SvelteKit has to wait for `ResolveRepoRevision` call to resolve before updating the page. A new request is made because the URL changes which triggers the data loader. But we already know that such a request will return the same data, so the request is unnecessary. To avoid the second call I added another caching layer (see code and video).


https://github.com/sourcegraph/sourcegraph/assets/179026/40433dae-811e-41b6-a2fd-3ba1e2d9a25f

I also noticed that the last commit info would be reloaded which is unnecessary. I changed the implementation to use the resolved revision instead of the revision from the URL. Now the request will be properly cached on the commit ID and the implementation is also much simpler.

## Test plan

Manual testing.