### PR TITLE
keyword search: remove beta badge

### DIFF
--- a/client/web/src/storm/pages/SearchPage/KeywordSearchCtaSection.tsx
+++ b/client/web/src/storm/pages/SearchPage/KeywordSearchCtaSection.tsx
@@ -28,10 +28,7 @@ export const KeywordSearchCtaSection: React.FC<KeywordSearchCtaSection> = ({ cla
             contentClassName={classNames('flex-grow-1 d-flex justify-content-between p-4', styles.card)}
         >
             <div>
-                <H2 className="d-flex align-items-center">
-                    New keyword search
-                    <ProductStatusBadge status="beta" className="ml-2" />
-                </H2>
+                <H2 className="d-flex align-items-center">New keyword search</H2>
                 <div className="d-flex d-flex-column">
                     <div>
                         <KeywordSearchStarsIcon aria-hidden={true} />

--- a/client/web/src/storm/pages/SearchPage/KeywordSearchCtaSection.tsx
+++ b/client/web/src/storm/pages/SearchPage/KeywordSearchCtaSection.tsx
@@ -4,7 +4,7 @@ import { mdiClose } from '@mdi/js'
 import classNames from 'classnames'
 
 import { useTemporarySetting } from '@sourcegraph/shared/src/settings/temporary'
-import { Code, H2, Icon, Link, ProductStatusBadge, Text } from '@sourcegraph/wildcard'
+import { Code, H2, Icon, Link, Text } from '@sourcegraph/wildcard'
 
 import { MarketingBlock } from '../../../components/MarketingBlock'
 


### PR DESCRIPTION
This removes the beta badge from the CTA on the main page.

Closes SPLF-131

Test plan:
- inspected page visually
