### PR TITLE
fix: show success notice in the correct area

### DIFF
--- a/client/web/src/enterprise/batches/settings/CodeHostConnections.tsx
+++ b/client/web/src/enterprise/batches/settings/CodeHostConnections.tsx
@@ -77,6 +77,7 @@ const CodeHostConnections: React.FunctionComponent<React.PropsWithChildren<CodeH
     const success = new URLSearchParams(location.search).get('success') === 'true'
     const appName = new URLSearchParams(location.search).get('app_name')
     const setupError = new URLSearchParams(location.search).get('error')
+    const gitHubAppKindFromUrl = new URLSearchParams(location.search).get('kind')
     const shouldShowError = !success && setupError && gitHubAppKind !== GitHubAppKind.COMMIT_SIGNING
     return (
         <Container className="mb-3">
@@ -85,13 +86,13 @@ const CodeHostConnections: React.FunctionComponent<React.PropsWithChildren<CodeH
             <ConnectionContainer className="mb-3">
                 {error && <ConnectionError errors={[error.message]} />}
                 {loading && !connection && <ConnectionLoading />}
-                {success && (
+                {success && gitHubAppKindFromUrl !== GitHubAppKind.COMMIT_SIGNING && (
                     <DismissibleAlert
                         className="mb-3"
                         variant="success"
-                        partialStorageKey="batch-changes-github-app-integration-success"
+                        partialStorageKey={`batch-changes-github-app-integration-success-${appName}`}
                     >
-                        GitHub App {appName?.length ? `"${appName}" ` : ''}successfully connected.
+                        GitHub App {appName?.length ? `"${appName}" ` : ''} successfully connected.
                     </DismissibleAlert>
                 )}
                 {shouldShowError && <GitHubAppFailureAlert error={setupError} />}

--- a/client/web/src/enterprise/batches/settings/CommitSigningIntegrations.tsx
+++ b/client/web/src/enterprise/batches/settings/CommitSigningIntegrations.tsx
@@ -60,6 +60,7 @@ export const CommitSigningIntegrations: React.FunctionComponent<
     const success = searchParams.get('success') === 'true'
     const appName = searchParams.get('app_name')
     const setupError = searchParams.get('error')
+    const gitHubAppKind = searchParams.get('kind')
     const shouldShowError = !success && setupError && !readOnly && kind === GitHubAppKind.COMMIT_SIGNING
     return (
         <Container>
@@ -80,11 +81,11 @@ export const CommitSigningIntegrations: React.FunctionComponent<
             <ConnectionContainer className="mb-3">
                 {error && <ConnectionError errors={[error.message]} />}
                 {loading && !connection && <ConnectionLoading />}
-                {success && !readOnly && (
+                {success && !readOnly && gitHubAppKind === GitHubAppKind.COMMIT_SIGNING && (
                     <DismissibleAlert
                         className="mb-3"
                         variant="success"
-                        partialStorageKey="batch-changes-commit-signing-integration-success"
+                        partialStorageKey={`batch-changes-commit-signing-integration-success-${appName}`}
                     >
                         GitHub App {appName?.length ? `"${appName}" ` : ''}successfully connected.
                     </DismissibleAlert>


### PR DESCRIPTION
Previously the success notice would appear in the commit signing area of the site admin, even if we create a github app for regular code host stuff. This PR fixes it.

It also udpates the partial storage key of the notice, so that it will reappear if we create more apps.

## Test plan

Manual testing

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
