### PR TITLE
chore(local): sg analytics use the proper open wrapper

### DIFF
--- a/dev/sg/internal/analytics/BUILD.bazel
+++ b/dev/sg/internal/analytics/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
     visibility = ["//dev/sg:__subpackages__"],
     deps = [
         "//dev/sg/internal/background",
+        "//dev/sg/internal/open",
         "//dev/sg/internal/secrets",
         "//dev/sg/internal/std",
         "//dev/sg/root",

--- a/dev/sg/internal/analytics/oauth.go
+++ b/dev/sg/internal/analytics/oauth.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"os/exec"
 	"path"
 	"strconv"
 
@@ -18,6 +17,7 @@ import (
 
 	"github.com/sourcegraph/log"
 
+	"github.com/sourcegraph/sourcegraph/dev/sg/internal/open"
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/secrets"
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/std"
 	"github.com/sourcegraph/sourcegraph/dev/sg/root"
@@ -137,7 +137,7 @@ func (th *tokenHandlerImpl) Exchange(ctx context.Context, code string, opts ...o
 }
 
 func (th *tokenHandlerImpl) OpenURL(url string) error {
-	return exec.Command("open", url).Start()
+	return open.URL(url)
 }
 
 func handleAuthResponse() (*url.URL, chan string, chan error, error) {


### PR DESCRIPTION
We missed during the review that we are not using the `open` helper that wraps using the right method depending on the OS, which means that `sg analytics` doesn't work on Linux as is.

## Test plan

Locally tested. 
