### PR TITLE
Cody Web: bump cody web to 0.2.3

### DIFF
--- a/client/web/src/cody/chat/new-chat/components/chat-ui/ChatUI.module.scss
+++ b/client/web/src/cody/chat/new-chat/components/chat-ui/ChatUI.module.scss
@@ -21,6 +21,12 @@
     --vscode-sideBarSectionHeader-border: var(--border-color);
     --mention-color-opacity: 100%;
 
+    // LLM picker tokens
+    --vscode-quickInput-background: var(--dropdown-bg);
+    --vscode-dropdown-border: var(--border-color);
+    --vscode-dropdown-foreground: var(--body-color);
+    --vscode-foreground: var(--body-color);
+
     line-height: 1.55;
 
     h3 {

--- a/package.json
+++ b/package.json
@@ -333,7 +333,7 @@
     "bloomfilter": "^0.0.18",
     "buffer": "^6.0.3",
     "classnames": "^2.2.6",
-    "cody-web-experimental": "^0.2.1",
+    "cody-web-experimental": "^0.2.2",
     "comlink": "^4.3.0",
     "copy-to-clipboard": "^3.3.1",
     "core-js": "^3.8.2",

--- a/package.json
+++ b/package.json
@@ -333,7 +333,7 @@
     "bloomfilter": "^0.0.18",
     "buffer": "^6.0.3",
     "classnames": "^2.2.6",
-    "cody-web-experimental": "^0.2.2",
+    "cody-web-experimental": "^0.2.3",
     "comlink": "^4.3.0",
     "copy-to-clipboard": "^3.3.1",
     "core-js": "^3.8.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -206,8 +206,8 @@ importers:
         specifier: ^2.2.6
         version: 2.3.2
       cody-web-experimental:
-        specifier: ^0.2.1
-        version: 0.2.1
+        specifier: ^0.2.2
+        version: 0.2.2
       comlink:
         specifier: ^4.3.0
         version: 4.3.0
@@ -14547,6 +14547,10 @@ packages:
 
   /cody-web-experimental@0.2.1:
     resolution: {integrity: sha512-ci7wRIOaxpD+xZ5ecR0IYeJhxAai4meIUNVGXzjUATYiRx3+755kWtrWRbvPGhmE+2jF1KB2DKKd+pyGKmfbdg==}
+    dev: false
+
+  /cody-web-experimental@0.2.2:
+    resolution: {integrity: sha512-4fC3B992Onq1FScyvlNasVv1l3dHA4H7QjhrtNF1NYSE2dADAbxXCQcDff8+jSk/6Vvy3Rq6QmT2C0w5br7SgA==}
     dev: false
 
   /color-convert@1.9.3:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -206,8 +206,8 @@ importers:
         specifier: ^2.2.6
         version: 2.3.2
       cody-web-experimental:
-        specifier: ^0.2.2
-        version: 0.2.2
+        specifier: ^0.2.3
+        version: 0.2.3
       comlink:
         specifier: ^4.3.0
         version: 4.3.0
@@ -14549,8 +14549,8 @@ packages:
     resolution: {integrity: sha512-ci7wRIOaxpD+xZ5ecR0IYeJhxAai4meIUNVGXzjUATYiRx3+755kWtrWRbvPGhmE+2jF1KB2DKKd+pyGKmfbdg==}
     dev: false
 
-  /cody-web-experimental@0.2.2:
-    resolution: {integrity: sha512-4fC3B992Onq1FScyvlNasVv1l3dHA4H7QjhrtNF1NYSE2dADAbxXCQcDff8+jSk/6Vvy3Rq6QmT2C0w5br7SgA==}
+  /cody-web-experimental@0.2.3:
+    resolution: {integrity: sha512-Wymn3jVlnZMC/ww16x8RtCuoFwVfkk3A43Bzb16xIszZpDGS1DUBsyuqw+gHkO96w1GxfH+phP3EZpZrTm3X3w==}
     dev: false
 
   /color-convert@1.9.3:


### PR DESCRIPTION
Updating the `cody-web-experimental` package to the latest version which 
- Fixed problems with telemetry (now we send agent level of telemetry events with `Web.Cody` client name)
- Fixed remote repository context as you switch between chats 
- Added support for cody context filters in file and symbols mentions 
- Improved link rendering for remote files (no more "remote-file://" protocol prefixes.

Also, this PR adds some missing CSS token overrides for the LLM picker on dotcom.

Note: I, by accident, pushed the `0.2.2` version with the same build as I have published already in `0.2.1`. NPM doesn't allow to override the build with the same version, so I had to publish 0.2.3 to make it through to the Sourcegraph repo. This is why we jump from 0.2.1 to 0.2.3

## Test plan
-General manual checks for Cody Web 

