### PR TITLE
chore(security): Updated dind image to 27-0-3

### DIFF
--- a/dev/oci_deps.bzl
+++ b/dev/oci_deps.bzl
@@ -37,6 +37,7 @@ def oci_deps():
         name = "upstream_dind_base",
         digest = "sha256:2632da0d24924b179adf1c2e6f4ea6fb866747e84baea6b2ffaa8bff982ce102",
         image = "index.docker.io/library/docker",
+        platforms = ["linux/amd64"],
     )
 
     oci_pull(

--- a/dev/oci_deps.bzl
+++ b/dev/oci_deps.bzl
@@ -35,9 +35,8 @@ def oci_deps():
     # Tag: docker:27.0.3-dind
     oci_pull(
         name = "upstream_dind_base",
-        digest = "sha256:2632da0d24924b179adf1c2e6f4ea6fb866747e84baea6b2ffaa8bff982ce102",
+        digest = "sha256:4e52dcbcf86f5222648bc411cb32287f7b8480c97558eab0fee7b8b5a9376ab5",
         image = "index.docker.io/library/docker",
-        platforms = ["linux/amd64"],
     )
 
     oci_pull(

--- a/dev/oci_deps.bzl
+++ b/dev/oci_deps.bzl
@@ -32,10 +32,10 @@ def oci_deps():
     )
 
     # https://hub.docker.com/_/docker/tags?name=dind
-    # Tag: docker:26.1.3-dind
+    # Tag: docker:27.0.3-dind
     oci_pull(
         name = "upstream_dind_base",
-        digest = "sha256:ca2dd9db425230285567123ce06dbd3c2aed0eae23d58a1dd5787523a4329eea",
+        digest = "sha256:2632da0d24924b179adf1c2e6f4ea6fb866747e84baea6b2ffaa8bff982ce102",
         image = "index.docker.io/library/docker",
     )
 


### PR DESCRIPTION
<!-- PR description tips: https://www.notion.so/sourcegraph/Write-a-good-pull-request-description-610a7fd3e613496eb76f450db5a49b6e -->

Patches CVE-2024-24790 by upgrading to 27-0-3 tag. However, the patched version has CVE-2024-24791 😟  and it doesnt have patch.

## Test plan

<!-- REQUIRED; info at https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles -->
Build and test image locally.

### Instruction to build and test locally

- Go to `dev/oci_deps.bzl`
- Find the current tag example `docker:26.1.3-dind`
- Go to docker registry and search for updated tag and grab one example: `docker:27.0.3-dind`
- docker pull --platform linux/amd64 docker:27.0.3-dind
- Add `platforms = ["linux/amd64"],` to the oci_pull for building and testing locally
```bzl
  oci_pull(
        name = "upstream_dind_base",
        digest = "sha256:2632da0d24924b179adf1c2e6f4ea6fb866747e84baea6b2ffaa8bff982ce102",
        platforms = ["linux/amd64"],
    )
```
- Run `sg images build dind`
- For testing, run `docker run --rm -it --entrypoint /bin/sh -v /var/run/docker.sock:/var/run/docker.sock dind:candidate`
- Test docker commands and pull and run image for testing

## Changelog

- Upgraded dind to 27.0.3 to patch CVE-2024-24790 vulnerability

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
