### PR TITLE
squirrel: Correctly use request context

### DIFF
--- a/cmd/symbols/squirrel/util.go
+++ b/cmd/symbols/squirrel/util.go
@@ -260,7 +260,7 @@ func (s *SquirrelService) parse(ctx context.Context, repoCommitPath types.RepoCo
 }
 
 func (s *SquirrelService) getSymbols(ctx context.Context, repoCommitPath types.RepoCommitPath) (result.Symbols, error) { //nolint:unparam
-	root, err := s.parse(context.Background(), repoCommitPath)
+	root, err := s.parse(ctx, repoCommitPath)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The ctx parameter was unused, and I noticed that the parser is called without the request context. Fixing that here.

Test plan:

Code review and CI.