### PR TITLE
chore(svelte): Use MDI icons for seach input pattern type toggles

### DIFF
--- a/client/web-sveltekit/BUILD.bazel
+++ b/client/web-sveltekit/BUILD.bazel
@@ -92,6 +92,7 @@ BUILD_DEPS = [
     ":node_modules/@iconify-json/devicon-plain",
     ":node_modules/@iconify-json/file-icons",
     ":node_modules/@iconify-json/lucide",
+    ":node_modules/@iconify-json/mdi",
     ":node_modules/@iconify-json/ph",
     ":node_modules/@iconify-json/simple-icons",
     ":node_modules/@melt-ui/svelte",

--- a/client/web-sveltekit/package.json
+++ b/client/web-sveltekit/package.json
@@ -34,6 +34,7 @@
     "@iconify-json/devicon-plain": "^1.1.42",
     "@iconify-json/file-icons": "^1.1.8",
     "@iconify-json/lucide": "^1.1.188",
+    "@iconify-json/mdi": "^1.1.67",
     "@iconify-json/ph": "^1.1.13",
     "@iconify-json/simple-icons": "^1.1.104",
     "@playwright/test": "1.42.1",

--- a/client/web-sveltekit/src/auto-imports.d.ts
+++ b/client/web-sveltekit/src/auto-imports.d.ts
@@ -88,6 +88,8 @@ declare global {
   const ILucideWrapText: typeof import('~icons/lucide/wrap-text')['default']
   const ILucideX: typeof import('~icons/lucide/x')['default']
   const ILucidehevronLeft: typeof import('~icons/lucide/hevron-left')['default']
+  const IMdiFormatLetterCase: typeof import('~icons/mdi/format-letter-case')['default']
+  const IMdiRegex: typeof import('~icons/mdi/regex')['default']
   const IPhFileJpgLight: typeof import('~icons/ph/file-jpg-light')['default']
   const IPhFilePngLight: typeof import('~icons/ph/file-png-light')['default']
   const IPhGifFill: typeof import('~icons/ph/gif-fill')['default']

--- a/client/web-sveltekit/src/lib/search/input/SearchInput.svelte
+++ b/client/web-sveltekit/src/lib/search/input/SearchInput.svelte
@@ -272,7 +272,7 @@
                     class:active={$queryState.caseSensitive}
                     on:click={() => queryState.setCaseSensitive(caseSensitive => !caseSensitive)}
                 >
-                    <Icon icon={ILucideCaseSensitive} inline aria-hidden />
+                    <Icon icon={IMdiFormatLetterCase} inline aria-hidden />
                 </button>
             </Tooltip>
             <Tooltip tooltip="{regularExpressionEnabled ? 'Disable' : 'Enable'} regular expression">
@@ -282,7 +282,7 @@
                     class:active={regularExpressionEnabled}
                     on:click={() => setOrUnsetPatternType(SearchPatternType.regexp)}
                 >
-                    <Icon icon={ILucideRegex} inline aria-hidden />
+                    <Icon icon={IMdiRegex} inline aria-hidden />
                 </button>
             </Tooltip>
             {#if structuralEnabled}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1660,6 +1660,9 @@ importers:
       '@iconify-json/lucide':
         specifier: ^1.1.188
         version: 1.1.188
+      '@iconify-json/mdi':
+        specifier: ^1.1.67
+        version: 1.1.67
       '@iconify-json/ph':
         specifier: ^1.1.13
         version: 1.1.13
@@ -5552,6 +5555,12 @@ packages:
 
   /@iconify-json/lucide@1.1.188:
     resolution: {integrity: sha512-yJNoU7vX11OvdeSKBiAvmbk/etAq2HPCZQkZX1U687NZhn8dTfx1PfyNhPxtJilrd288XGDKK+NQgygcZ+Ho4g==}
+    dependencies:
+      '@iconify/types': 2.0.0
+    dev: true
+
+  /@iconify-json/mdi@1.1.67:
+    resolution: {integrity: sha512-00nllHES8hyACwIfgySlQgAE6MKgpr2wsKfpifMiZWZ9aXC5l4Jb0lR3lJSWwXgOW6kzAOdzC3T+2VOfBBZ13A==}
     dependencies:
       '@iconify/types': 2.0.0
     dev: true


### PR DESCRIPTION
We don't like the style/alignment of the Lucide case sensitivity and regex icons (the structural search icon seems fine). This commit switches them back to the MDI icons that we used before.

Solution or temporary workaround (tbd) for srch-544


## Test plan

Manual testing.