### PR TITLE
feat/enterpriseportal: db layer for cody gateway access

### DIFF
--- a/cmd/enterprise-portal/internal/database/codyaccess/BUILD.bazel
+++ b/cmd/enterprise-portal/internal/database/codyaccess/BUILD.bazel
@@ -1,3 +1,4 @@
+load("//dev:go_defs.bzl", "go_test")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
@@ -5,5 +6,31 @@ go_library(
     srcs = ["codygateway.go"],
     importpath = "github.com/sourcegraph/sourcegraph/cmd/enterprise-portal/internal/database/codyaccess",
     visibility = ["//cmd/enterprise-portal:__subpackages__"],
-    deps = ["//cmd/enterprise-portal/internal/database/subscriptions"],
+    deps = [
+        "//cmd/enterprise-portal/internal/database/internal/pgxerrors",
+        "//cmd/enterprise-portal/internal/database/internal/upsert",
+        "//cmd/enterprise-portal/internal/database/subscriptions",
+        "//internal/license",
+        "//lib/errors",
+        "@com_github_jackc_pgx_v5//:pgx",
+        "@com_github_jackc_pgx_v5//pgxpool",
+    ],
+)
+
+go_test(
+    name = "codyaccess_test",
+    srcs = ["codygateway_test.go"],
+    deps = [
+        ":codyaccess",
+        "//cmd/enterprise-portal/internal/database",
+        "//cmd/enterprise-portal/internal/database/databasetest",
+        "//cmd/enterprise-portal/internal/database/internal/tables",
+        "//cmd/enterprise-portal/internal/database/internal/utctime",
+        "//cmd/enterprise-portal/internal/database/subscriptions",
+        "//internal/license",
+        "//lib/pointers",
+        "@com_github_google_uuid//:uuid",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+    ],
 )

--- a/cmd/enterprise-portal/internal/database/codyaccess/BUILD.bazel
+++ b/cmd/enterprise-portal/internal/database/codyaccess/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "//lib/errors",
         "@com_github_jackc_pgx_v5//:pgx",
         "@com_github_jackc_pgx_v5//pgxpool",
+        "@io_gorm_gorm//:gorm",
     ],
 )
 

--- a/cmd/enterprise-portal/internal/database/codyaccess/BUILD.bazel
+++ b/cmd/enterprise-portal/internal/database/codyaccess/BUILD.bazel
@@ -20,6 +20,10 @@ go_library(
 go_test(
     name = "codyaccess_test",
     srcs = ["codygateway_test.go"],
+    tags = [
+        TAG_INFRA_CORESERVICES,
+        "requires-network",
+    ],
     deps = [
         ":codyaccess",
         "//cmd/enterprise-portal/internal/database",

--- a/cmd/enterprise-portal/internal/database/codyaccess/codygateway.go
+++ b/cmd/enterprise-portal/internal/database/codyaccess/codygateway.go
@@ -1,11 +1,31 @@
 package codyaccess
 
-import "github.com/sourcegraph/sourcegraph/cmd/enterprise-portal/internal/database/subscriptions"
+import (
+	"context"
+	"fmt"
+	"strings"
 
-type CodyGatewayAccess struct {
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/sourcegraph/sourcegraph/cmd/enterprise-portal/internal/database/internal/pgxerrors"
+	"github.com/sourcegraph/sourcegraph/cmd/enterprise-portal/internal/database/internal/upsert"
+	"github.com/sourcegraph/sourcegraph/cmd/enterprise-portal/internal/database/subscriptions"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+type TableCodyGatewayAccess struct {
 	// ⚠️ DO NOT USE: This field is only used for creating foreign key constraint.
 	Subscription *subscriptions.TableSubscription `gorm:"foreignKey:SubscriptionID"`
 
+	CodyGatewayAccess
+}
+
+func (s *TableCodyGatewayAccess) TableName() string {
+	return "enterprise_portal_cody_gateway_access"
+}
+
+type CodyGatewayAccess struct {
 	// SubscriptionID is the internal unprefixed UUID of the related subscription.
 	SubscriptionID string `gorm:"type:uuid;not null;unique"`
 
@@ -13,18 +33,199 @@ type CodyGatewayAccess struct {
 	Enabled bool `gorm:"not null"`
 
 	// chat_completions_rate_limit
-	ChatCompletionsRateLimit                int64 `gorm:"type:bigint;not null"`
-	ChatCompletionsRateLimitIntervalSeconds int   `gorm:"not null"`
+	ChatCompletionsRateLimit                *int64 `gorm:"type:bigint"`
+	ChatCompletionsRateLimitIntervalSeconds *int
 
 	// code_completions_rate_limit
-	CodeCompletionsRateLimit                int64 `gorm:"type:bigint;not null"`
-	CodeCompletionsRateLimitIntervalSeconds int   `gorm:"not null"`
+	CodeCompletionsRateLimit                *int64 `gorm:"type:bigint"`
+	CodeCompletionsRateLimitIntervalSeconds *int
 
 	// embeddings_rate_limit
-	EmbeddingsRateLimit                int64 `gorm:"type:bigint;not null"`
-	EmbeddingsRateLimitIntervalSeconds int   `gorm:"not null"`
+	EmbeddingsRateLimit                *int64 `gorm:"type:bigint"`
+	EmbeddingsRateLimitIntervalSeconds *int
 }
 
-func (s *CodyGatewayAccess) TableName() string {
-	return "enterprise_portal_cody_gateway_access"
+// codyGatewayAccessTableColumns must match scanCodyGatewayAccess() values.
+// Requires:
+//
+//	RIGHT JOIN
+//		enterprise_portal_subscriptions AS subscription
+//		ON subscription_id = subscription.id
+//
+// As this uses subscription fields.
+func codyGatewayAccessTableColumns() []string {
+	return []string{
+		"subscription.id",
+		"enabled",
+		"chat_completions_rate_limit",
+		"chat_completions_rate_limit_interval_seconds",
+		"code_completions_rate_limit",
+		"code_completions_rate_limit_interval_seconds",
+		"embeddings_rate_limit",
+		"embeddings_rate_limit_interval_seconds",
+		"subscription.display_name",
+	}
+}
+
+// scanCodyGatewayAccess matches s.columns() values.
+func scanCodyGatewayAccess(row pgx.Row) (*CodyGatewayAccessWithSubscriptionDetails, error) {
+	var a CodyGatewayAccessWithSubscriptionDetails
+	// RIGHT JOIN may surface null in enterprise_portal_cody_gateway_access if
+	// an active subscription exists, but explicit access is not configured. In
+	// this case we still need to return a valid CodyGatewayAccessWithSubscriptionDetails,
+	// just with empty fields.
+	var maybeEnabled *bool
+	err := row.Scan(
+		&a.SubscriptionID,
+		&maybeEnabled,
+		&a.ChatCompletionsRateLimit,
+		&a.ChatCompletionsRateLimitIntervalSeconds,
+		&a.CodeCompletionsRateLimit,
+		&a.CodeCompletionsRateLimitIntervalSeconds,
+		&a.EmbeddingsRateLimit,
+		&a.EmbeddingsRateLimitIntervalSeconds,
+		// Subscriptions fields
+		&a.DisplayName,
+	)
+	if err != nil {
+		return nil, err
+	}
+	if maybeEnabled != nil {
+		a.Enabled = *maybeEnabled
+	}
+	return &a, nil
+}
+
+// Store is the storage layer for Cody Gateway access.
+type CodyGatewayStore struct {
+	db *pgxpool.Pool
+}
+
+func NewCodyGatewayStore(db *pgxpool.Pool) *CodyGatewayStore {
+	return &CodyGatewayStore{db: db}
+}
+
+// CodyGatewayAccessWithSubscriptionDetails extends CodyGatewayAccess with metadata from
+// other tables used in the codyaccess API.
+type CodyGatewayAccessWithSubscriptionDetails struct {
+	CodyGatewayAccess
+
+	// DisplayName is the display name of the related subscription.
+	DisplayName string
+}
+
+var ErrSubscriptionDoesNotExist = errors.New("subscription does not exist")
+
+// Get returns the Cody Gateway access for the given subscription.
+func (s *CodyGatewayStore) Get(ctx context.Context, subscriptionID string) (*CodyGatewayAccessWithSubscriptionDetails, error) {
+	query := fmt.Sprintf(`SELECT
+	%s
+FROM
+	enterprise_portal_cody_gateway_access
+RIGHT JOIN
+	enterprise_portal_subscriptions AS subscription
+	ON subscription_id = subscription.id
+WHERE
+	subscription.id = @subscriptionID
+	AND subscription.archived_at IS NULL`,
+		strings.Join(codyGatewayAccessTableColumns(), ", "))
+
+	sub, err := scanCodyGatewayAccess(s.db.QueryRow(ctx, query, pgx.NamedArgs{
+		"subscriptionID": subscriptionID,
+	}))
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			// RIGHT JOIN in query ensures that if we find no result, it's
+			// because the subscription does not exist or is archived.
+			return nil, errors.WithSafeDetails(
+				errors.WithStack(ErrSubscriptionDoesNotExist),
+				err.Error())
+		}
+		return nil, err
+	}
+	return sub, nil
+}
+
+func (s *CodyGatewayStore) List(ctx context.Context) ([]*CodyGatewayAccessWithSubscriptionDetails, error) {
+	query := fmt.Sprintf(`SELECT
+	%s
+FROM
+	enterprise_portal_cody_gateway_access
+RIGHT JOIN
+	enterprise_portal_subscriptions AS subscription
+	ON subscription_id = subscription.id
+WHERE
+	subscription.archived_at IS NULL`,
+		strings.Join(codyGatewayAccessTableColumns(), ", "))
+
+	rows, err := s.db.Query(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var accs []*CodyGatewayAccessWithSubscriptionDetails
+	for rows.Next() {
+		sub, err := scanCodyGatewayAccess(rows)
+		if err != nil {
+			return nil, err
+		}
+		accs = append(accs, sub)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return accs, nil
+}
+
+type UpsertCodyGatewayAccessOptions struct {
+	// Whether or not a subscription has Cody Gateway access enabled.
+	Enabled bool
+
+	// chat_completions_rate_limit
+	ChatCompletionsRateLimit                *int64
+	ChatCompletionsRateLimitIntervalSeconds *int
+
+	// code_completions_rate_limit
+	CodeCompletionsRateLimit                *int64
+	CodeCompletionsRateLimitIntervalSeconds *int
+
+	// embeddings_rate_limit
+	EmbeddingsRateLimit                *int64
+	EmbeddingsRateLimitIntervalSeconds *int
+
+	// ForceUpdate indicates whether to force update all fields of the subscription
+	// record.
+	ForceUpdate bool
+}
+
+// toQuery returns the query based on the options. It returns an empty query if
+// nothing to update.
+func (opts UpsertCodyGatewayAccessOptions) Exec(ctx context.Context, db *pgxpool.Pool, subscriptionID string) error {
+	b := upsert.New("enterprise_portal_cody_gateway_access", "subscription_id", opts.ForceUpdate)
+	upsert.Field(b, "subscription_id", subscriptionID)
+	upsert.Field(b, "enabled", opts.Enabled)
+	upsert.Field(b, "chat_completions_rate_limit", opts.ChatCompletionsRateLimit)
+	upsert.Field(b, "chat_completions_rate_limit_interval_seconds", opts.ChatCompletionsRateLimitIntervalSeconds)
+	upsert.Field(b, "code_completions_rate_limit", opts.CodeCompletionsRateLimit)
+	upsert.Field(b, "code_completions_rate_limit_interval_seconds", opts.CodeCompletionsRateLimitIntervalSeconds)
+	upsert.Field(b, "embeddings_rate_limit", opts.EmbeddingsRateLimit)
+	upsert.Field(b, "embeddings_rate_limit_interval_seconds", opts.EmbeddingsRateLimitIntervalSeconds)
+	return b.Exec(ctx, db)
+}
+
+// Upsert upserts a Cody Gatweway access record based on the given options.
+// The caller should check that the subscription is not archived.
+//
+// If the subscription does not exist, then ErrSubscriptionDoesNotExist is
+// returned.
+func (s *CodyGatewayStore) Upsert(ctx context.Context, subscriptionID string, opts UpsertCodyGatewayAccessOptions) (*CodyGatewayAccessWithSubscriptionDetails, error) {
+	if err := opts.Exec(ctx, s.db, subscriptionID); err != nil {
+		if pgxerrors.IsContraintError(err, "fk_enterprise_portal_cody_gateway_access_subscription") {
+			return nil, errors.WithSafeDetails(
+				errors.WithStack(ErrSubscriptionDoesNotExist),
+				err.Error())
+		}
+		return nil, errors.Wrap(err, "exec")
+	}
+	return s.Get(ctx, subscriptionID)
 }

--- a/cmd/enterprise-portal/internal/database/codyaccess/codygateway.go
+++ b/cmd/enterprise-portal/internal/database/codyaccess/codygateway.go
@@ -272,7 +272,7 @@ func (s *CodyGatewayStore) Upsert(ctx context.Context, subscriptionID string, op
 				errors.WithStack(ErrSubscriptionDoesNotExist),
 				err.Error())
 		}
-		return nil, errors.Wrap(err, "exec")
+		return nil, err
 	}
 	return s.Get(ctx, subscriptionID)
 }

--- a/cmd/enterprise-portal/internal/database/codyaccess/codygateway.go
+++ b/cmd/enterprise-portal/internal/database/codyaccess/codygateway.go
@@ -53,7 +53,7 @@ type CodyGatewayAccess struct {
 	SubscriptionID string `gorm:"type:uuid;not null;unique"`
 
 	// Whether or not a subscription has Cody Gateway access enabled.
-	Enabled bool `gorm:"not null"`
+	Enabled bool `gorm:"not null;default:false"`
 
 	// chat_completions_rate_limit
 	ChatCompletionsRateLimit                sql.NullInt64
@@ -247,7 +247,7 @@ WHERE
 
 type UpsertCodyGatewayAccessOptions struct {
 	// Whether or not a subscription has Cody Gateway access enabled.
-	Enabled bool
+	Enabled *bool
 
 	// chat_completions_rate_limit
 	ChatCompletionsRateLimit                *int64
@@ -271,7 +271,9 @@ type UpsertCodyGatewayAccessOptions struct {
 func (opts UpsertCodyGatewayAccessOptions) Exec(ctx context.Context, db *pgxpool.Pool, subscriptionID string) error {
 	b := upsert.New("enterprise_portal_cody_gateway_access", "subscription_id", opts.ForceUpdate)
 	upsert.Field(b, "subscription_id", subscriptionID)
-	upsert.Field(b, "enabled", opts.Enabled)
+	upsert.Field(b, "enabled", opts.Enabled,
+		upsert.WithColumnDefault(),
+		upsert.WithValueOnForceUpdate(false))
 	upsert.Field(b, "chat_completions_rate_limit", opts.ChatCompletionsRateLimit)
 	upsert.Field(b, "chat_completions_rate_limit_interval_seconds", opts.ChatCompletionsRateLimitIntervalSeconds)
 	upsert.Field(b, "code_completions_rate_limit", opts.CodeCompletionsRateLimit)

--- a/cmd/enterprise-portal/internal/database/codyaccess/codygateway_test.go
+++ b/cmd/enterprise-portal/internal/database/codyaccess/codygateway_test.go
@@ -1,0 +1,250 @@
+package codyaccess_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sourcegraph/sourcegraph/cmd/enterprise-portal/internal/database/codyaccess"
+	"github.com/sourcegraph/sourcegraph/cmd/enterprise-portal/internal/database/databasetest"
+	"github.com/sourcegraph/sourcegraph/cmd/enterprise-portal/internal/database/internal/tables"
+	"github.com/sourcegraph/sourcegraph/cmd/enterprise-portal/internal/database/subscriptions"
+	"github.com/sourcegraph/sourcegraph/lib/pointers"
+)
+
+func mockSubscriptionDisplayName(idx int) string {
+	return fmt.Sprintf("Subscription %d", idx)
+}
+
+func TestCodyGatewayStore(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	db := databasetest.NewTestDB(t, "enterprise-portal", "CodyGatewayStore", tables.All()...)
+
+	// Create a test subscription as a parent.
+	subscriptionIDs := make([]string, 10)
+	for idx := range subscriptionIDs {
+		subscriptionID := uuid.NewString()
+		_, err := subscriptions.NewStore(db).Upsert(ctx, subscriptionID, subscriptions.UpsertSubscriptionOptions{
+			DisplayName:    mockSubscriptionDisplayName(idx),
+			InstanceDomain: fmt.Sprintf("s%d.sourcegraph.com", idx),
+		})
+		require.NoError(t, err)
+		subscriptionIDs[idx] = subscriptionID
+	}
+	databasetest.ClearTablesAfterTest(t, db, tables.All()...)
+
+	for _, tc := range []struct {
+		name string
+		test func(t *testing.T, ctx context.Context, subscriptionIDs []string, s *codyaccess.CodyGatewayStore)
+	}{
+		{"ListAndGet", CodyGatewayStoreListAndGet},
+		{"Upsert", CodyGatewayStoreUpsert},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// Only clear the CodyGatewayAccess table between tests.
+			databasetest.ClearTablesAfterTest(t, db, &codyaccess.TableCodyGatewayAccess{})
+
+			tc.test(t, ctx, subscriptionIDs, codyaccess.NewCodyGatewayStore(db))
+		})
+		if t.Failed() {
+			break
+		}
+	}
+
+	t.Run("archived subscriptions", func(t *testing.T) {
+		t.Run("already archived", func(t *testing.T) {
+			subscriptionID := uuid.NewString()
+			_, err := subscriptions.NewStore(db).Upsert(ctx, subscriptionID, subscriptions.UpsertSubscriptionOptions{
+				DisplayName:    "Archived subscription",
+				InstanceDomain: "archived.sourcegraph.com",
+				ArchivedAt:     pointers.Ptr(time.Now()),
+			})
+			require.NoError(t, err)
+
+			_, err = codyaccess.NewCodyGatewayStore(db).Upsert(ctx, subscriptionID, codyaccess.UpsertCodyGatewayAccessOptions{
+				Enabled: true,
+			})
+			assert.ErrorIs(t, err, codyaccess.ErrSubscriptionDoesNotExist)
+		})
+
+		t.Run("set then archive", func(t *testing.T) {
+			subscriptionID := uuid.NewString()
+			_, err := subscriptions.NewStore(db).Upsert(ctx, subscriptionID, subscriptions.UpsertSubscriptionOptions{
+				DisplayName:    "Soon-to-be-archived subscription",
+				InstanceDomain: "not-yet-archived.sourcegraph.com",
+			})
+			require.NoError(t, err)
+
+			_, err = codyaccess.NewCodyGatewayStore(db).Upsert(ctx, subscriptionID, codyaccess.UpsertCodyGatewayAccessOptions{
+				Enabled: true,
+			})
+			require.NoError(t, err)
+
+			_, err = subscriptions.NewStore(db).Upsert(ctx, subscriptionID, subscriptions.UpsertSubscriptionOptions{
+				ArchivedAt: pointers.Ptr(time.Now()),
+			})
+			require.NoError(t, err)
+
+			_, err = codyaccess.NewCodyGatewayStore(db).Get(ctx, subscriptionID)
+			assert.ErrorIs(t, err, codyaccess.ErrSubscriptionDoesNotExist)
+		})
+	})
+}
+
+func CodyGatewayStoreListAndGet(t *testing.T, ctx context.Context, subscriptionIDs []string, s *codyaccess.CodyGatewayStore) {
+	// Create explicit access for all but the last subscription. The last
+	// subscription still be able to get zero-value Cody Access.
+	for idx, sub := range subscriptionIDs[:len(subscriptionIDs)-1] {
+		_, err := s.Upsert(ctx, sub, codyaccess.UpsertCodyGatewayAccessOptions{
+			Enabled:                                 idx%2 == 0, // even
+			ChatCompletionsRateLimit:                pointers.Ptr(int64(idx)),
+			ChatCompletionsRateLimitIntervalSeconds: pointers.Ptr(int(idx)),
+			CodeCompletionsRateLimit:                pointers.Ptr(int64(idx)),
+			CodeCompletionsRateLimitIntervalSeconds: pointers.Ptr(int(idx)),
+			EmbeddingsRateLimit:                     pointers.Ptr(int64(idx)),
+			EmbeddingsRateLimitIntervalSeconds:      pointers.Ptr(int(idx)),
+		})
+		require.NoError(t, err)
+	}
+	assertAccess := func(idx int, got *codyaccess.CodyGatewayAccessWithSubscriptionDetails) {
+		assert.Equal(t, subscriptionIDs[idx], got.SubscriptionID)
+		assert.Equal(t, mockSubscriptionDisplayName(idx), got.DisplayName)
+
+		// Last subscription has no explicit access, only has default values.
+		if idx == len(subscriptionIDs)-1 {
+			assert.Equal(t,
+				codyaccess.CodyGatewayAccess{
+					SubscriptionID: subscriptionIDs[idx],
+					Enabled:        false,
+				},
+				got.CodyGatewayAccess)
+			return
+		}
+
+		assert.Equal(t, idx%2 == 0, got.Enabled)
+		assert.Equal(t, int64(idx), pointers.DerefZero(got.ChatCompletionsRateLimit))
+		assert.Equal(t, idx, pointers.DerefZero(got.ChatCompletionsRateLimitIntervalSeconds))
+		assert.Equal(t, int64(idx), pointers.DerefZero(got.CodeCompletionsRateLimit))
+		assert.Equal(t, idx, pointers.DerefZero(got.CodeCompletionsRateLimitIntervalSeconds))
+		assert.Equal(t, int64(idx), pointers.DerefZero(got.EmbeddingsRateLimit))
+		assert.Equal(t, idx, pointers.DerefZero(got.EmbeddingsRateLimitIntervalSeconds))
+	}
+
+	t.Run("List", func(t *testing.T) {
+		accs, err := s.List(ctx)
+		require.NoError(t, err)
+		require.Len(t, accs, len(subscriptionIDs))
+
+		for idx, got := range accs {
+			assertAccess(idx, got)
+		}
+	})
+
+	t.Run("Get", func(t *testing.T) {
+		for idx, sub := range subscriptionIDs {
+			t.Run(fmt.Sprintf("idx=%d", idx), func(t *testing.T) {
+				got, err := s.Get(ctx, sub)
+				require.NoError(t, err)
+
+				assertAccess(idx, got)
+			})
+		}
+
+		t.Run("ErrSubscriptionDoesNotExist", func(t *testing.T) {
+			_, err := s.Get(ctx, uuid.NewString())
+			assert.ErrorIs(t, err, codyaccess.ErrSubscriptionDoesNotExist)
+		})
+	})
+}
+
+func CodyGatewayStoreUpsert(t *testing.T, ctx context.Context, subscriptionIDs []string, s *codyaccess.CodyGatewayStore) {
+	// Create initial test record. The currentAccess should be reassigned
+	// throughout various test cases to represent the current state of the test
+	// record, as the subtests are run in sequence.
+	currentAccess, err := s.Upsert(
+		ctx,
+		subscriptionIDs[0],
+		codyaccess.UpsertCodyGatewayAccessOptions{
+			Enabled: false,
+		},
+	)
+	require.NoError(t, err)
+
+	got, err := s.Get(ctx, currentAccess.SubscriptionID)
+	require.NoError(t, err)
+	assert.False(t, got.Enabled)
+	assert.Equal(t, currentAccess.SubscriptionID, got.SubscriptionID)
+	assert.Equal(t, mockSubscriptionDisplayName(0), got.DisplayName)
+	assert.Nil(t, got.ChatCompletionsRateLimit)
+	assert.Nil(t, got.ChatCompletionsRateLimitIntervalSeconds)
+	assert.Nil(t, got.CodeCompletionsRateLimit)
+	assert.Nil(t, got.CodeCompletionsRateLimitIntervalSeconds)
+	assert.Nil(t, got.EmbeddingsRateLimit)
+	assert.Nil(t, got.EmbeddingsRateLimitIntervalSeconds)
+
+	t.Run("noop", func(t *testing.T) {
+		t.Cleanup(func() { currentAccess = got })
+
+		got, err = s.Upsert(ctx, currentAccess.SubscriptionID, codyaccess.UpsertCodyGatewayAccessOptions{})
+		require.NoError(t, err)
+		assert.Equal(t, currentAccess, got)
+	})
+
+	t.Run("subscription does not exist", func(t *testing.T) {
+		subscriptionID := uuid.NewString()
+		_, err = s.Upsert(ctx, subscriptionID, codyaccess.UpsertCodyGatewayAccessOptions{
+			Enabled: true,
+		})
+		assert.ErrorIs(t, err, codyaccess.ErrSubscriptionDoesNotExist)
+	})
+
+	t.Run("update only chat completions", func(t *testing.T) {
+		t.Cleanup(func() { currentAccess = got })
+
+		got, err = s.Upsert(ctx, currentAccess.SubscriptionID, codyaccess.UpsertCodyGatewayAccessOptions{
+			ChatCompletionsRateLimit: pointers.Ptr(int64(1234)),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, currentAccess.Enabled, got.Enabled)
+		assert.Equal(t, currentAccess.DisplayName, got.DisplayName)
+		assert.Equal(t, currentAccess.CodeCompletionsRateLimit, got.CodeCompletionsRateLimit)
+		assert.EqualValues(t, 1234, *got.ChatCompletionsRateLimit)
+	})
+
+	t.Run("update only enabled", func(t *testing.T) {
+		t.Cleanup(func() { currentAccess = got })
+
+		got, err = s.Upsert(ctx, currentAccess.SubscriptionID, codyaccess.UpsertCodyGatewayAccessOptions{
+			Enabled: true,
+		})
+		require.NoError(t, err)
+		assert.True(t, got.Enabled)
+		assert.Equal(t, currentAccess.DisplayName, got.DisplayName)
+		assert.Equal(t, currentAccess.CodeCompletionsRateLimit, got.CodeCompletionsRateLimit)
+		assert.EqualValues(t, 1234, *got.ChatCompletionsRateLimit)
+	})
+
+	t.Run("force update to zero values", func(t *testing.T) {
+		t.Cleanup(func() { currentAccess = got })
+
+		got, err = s.Upsert(ctx, currentAccess.SubscriptionID, codyaccess.UpsertCodyGatewayAccessOptions{
+			ForceUpdate: true,
+		})
+		require.NoError(t, err)
+
+		// Only fields that cannot be changed are not reset to zero values
+		assert.Equal(t, codyaccess.CodyGatewayAccessWithSubscriptionDetails{
+			CodyGatewayAccess: codyaccess.CodyGatewayAccess{
+				SubscriptionID: currentAccess.SubscriptionID,
+			},
+			DisplayName: currentAccess.DisplayName,
+		}, *got)
+	})
+}

--- a/cmd/enterprise-portal/internal/database/codyaccess/codygateway_test.go
+++ b/cmd/enterprise-portal/internal/database/codyaccess/codygateway_test.go
@@ -186,12 +186,12 @@ func CodyGatewayStoreListAndGet(t *testing.T, ctx context.Context, subscriptionI
 		}
 
 		assert.Equal(t, idx%2 == 0, got.Enabled)
-		assert.Equal(t, int64(idx), pointers.DerefZero(got.ChatCompletionsRateLimit))
-		assert.Equal(t, idx, pointers.DerefZero(got.ChatCompletionsRateLimitIntervalSeconds))
-		assert.Equal(t, int64(idx), pointers.DerefZero(got.CodeCompletionsRateLimit))
-		assert.Equal(t, idx, pointers.DerefZero(got.CodeCompletionsRateLimitIntervalSeconds))
-		assert.Equal(t, int64(idx), pointers.DerefZero(got.EmbeddingsRateLimit))
-		assert.Equal(t, idx, pointers.DerefZero(got.EmbeddingsRateLimitIntervalSeconds))
+		assert.Equal(t, int64(idx), got.ChatCompletionsRateLimit.Int64)
+		assert.Equal(t, int32(idx), got.ChatCompletionsRateLimitIntervalSeconds.Int32)
+		assert.Equal(t, int64(idx), got.CodeCompletionsRateLimit.Int64)
+		assert.Equal(t, int32(idx), got.CodeCompletionsRateLimitIntervalSeconds.Int32)
+		assert.Equal(t, int64(idx), got.EmbeddingsRateLimit.Int64)
+		assert.Equal(t, int32(idx), got.EmbeddingsRateLimitIntervalSeconds.Int32)
 
 		assert.Equal(t, []string{strconv.Itoa(idx), "activeLicense"}, got.ActiveLicenseInfo.Tags)
 		assert.Equal(t, uint(idx), got.ActiveLicenseInfo.UserCount)
@@ -246,12 +246,12 @@ func CodyGatewayStoreUpsert(t *testing.T, ctx context.Context, subscriptionIDs [
 	assert.False(t, got.Enabled)
 	assert.Equal(t, currentAccess.SubscriptionID, got.SubscriptionID)
 	assert.Equal(t, mockSubscriptionDisplayName(0), got.DisplayName)
-	assert.Nil(t, got.ChatCompletionsRateLimit)
-	assert.Nil(t, got.ChatCompletionsRateLimitIntervalSeconds)
-	assert.Nil(t, got.CodeCompletionsRateLimit)
-	assert.Nil(t, got.CodeCompletionsRateLimitIntervalSeconds)
-	assert.Nil(t, got.EmbeddingsRateLimit)
-	assert.Nil(t, got.EmbeddingsRateLimitIntervalSeconds)
+	assert.False(t, got.ChatCompletionsRateLimit.Valid)
+	assert.False(t, got.ChatCompletionsRateLimitIntervalSeconds.Valid)
+	assert.False(t, got.CodeCompletionsRateLimit.Valid)
+	assert.False(t, got.CodeCompletionsRateLimitIntervalSeconds.Valid)
+	assert.False(t, got.EmbeddingsRateLimit.Valid)
+	assert.False(t, got.EmbeddingsRateLimitIntervalSeconds.Valid)
 
 	t.Run("noop", func(t *testing.T) {
 		t.Cleanup(func() { currentAccess = got })
@@ -279,7 +279,7 @@ func CodyGatewayStoreUpsert(t *testing.T, ctx context.Context, subscriptionIDs [
 		assert.Equal(t, currentAccess.Enabled, got.Enabled)
 		assert.Equal(t, currentAccess.DisplayName, got.DisplayName)
 		assert.Equal(t, currentAccess.CodeCompletionsRateLimit, got.CodeCompletionsRateLimit)
-		assert.EqualValues(t, 1234, *got.ChatCompletionsRateLimit)
+		assert.EqualValues(t, 1234, got.ChatCompletionsRateLimit.Int64)
 	})
 
 	t.Run("update only enabled", func(t *testing.T) {
@@ -292,7 +292,7 @@ func CodyGatewayStoreUpsert(t *testing.T, ctx context.Context, subscriptionIDs [
 		assert.True(t, got.Enabled)
 		assert.Equal(t, currentAccess.DisplayName, got.DisplayName)
 		assert.Equal(t, currentAccess.CodeCompletionsRateLimit, got.CodeCompletionsRateLimit)
-		assert.EqualValues(t, 1234, *got.ChatCompletionsRateLimit)
+		assert.EqualValues(t, 1234, got.ChatCompletionsRateLimit.Int64)
 	})
 
 	t.Run("force update to zero values", func(t *testing.T) {

--- a/cmd/enterprise-portal/internal/database/databasetest/databasetest.go
+++ b/cmd/enterprise-portal/internal/database/databasetest/databasetest.go
@@ -57,6 +57,8 @@ func NewTestDB(t testing.TB, system, suite string, tables ...schema.Tabler) *pgx
 		},
 	)
 	require.NoError(t, err)
+	// Initialize extensions.
+	require.NoError(t, db.Exec(`CREATE EXTENSION IF NOT EXISTS pgcrypto;`).Error)
 	for _, table := range tables {
 		err = db.AutoMigrate(table)
 		require.NoError(t, err)

--- a/cmd/enterprise-portal/internal/database/internal/pgxerrors/BUILD.bazel
+++ b/cmd/enterprise-portal/internal/database/internal/pgxerrors/BUILD.bazel
@@ -1,0 +1,9 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "pgxerrors",
+    srcs = ["pgxerrors.go"],
+    importpath = "github.com/sourcegraph/sourcegraph/cmd/enterprise-portal/internal/database/internal/pgxerrors",
+    visibility = ["//cmd/enterprise-portal:__subpackages__"],
+    deps = ["@com_github_jackc_pgx_v5//pgconn"],
+)

--- a/cmd/enterprise-portal/internal/database/internal/pgxerrors/BUILD.bazel
+++ b/cmd/enterprise-portal/internal/database/internal/pgxerrors/BUILD.bazel
@@ -5,5 +5,8 @@ go_library(
     srcs = ["pgxerrors.go"],
     importpath = "github.com/sourcegraph/sourcegraph/cmd/enterprise-portal/internal/database/internal/pgxerrors",
     visibility = ["//cmd/enterprise-portal:__subpackages__"],
-    deps = ["@com_github_jackc_pgx_v5//pgconn"],
+    deps = [
+        "//lib/errors",
+        "@com_github_jackc_pgx_v5//pgconn",
+    ],
 )

--- a/cmd/enterprise-portal/internal/database/internal/pgxerrors/pgxerrors.go
+++ b/cmd/enterprise-portal/internal/database/internal/pgxerrors/pgxerrors.go
@@ -1,0 +1,17 @@
+package pgxerrors
+
+import (
+	"errors"
+
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+func IsContraintError(err error, constraint string) bool {
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) {
+		if pgErr.ConstraintName == constraint {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/enterprise-portal/internal/database/internal/pgxerrors/pgxerrors.go
+++ b/cmd/enterprise-portal/internal/database/internal/pgxerrors/pgxerrors.go
@@ -1,7 +1,7 @@
 package pgxerrors
 
 import (
-	"errors"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 
 	"github.com/jackc/pgx/v5/pgconn"
 )

--- a/cmd/enterprise-portal/internal/database/internal/tables/tables.go
+++ b/cmd/enterprise-portal/internal/database/internal/tables/tables.go
@@ -17,6 +17,6 @@ func All() []schema.Tabler {
 		&subscriptions.TableSubscriptionLicense{},
 		&subscriptions.SubscriptionLicenseCondition{},
 
-		&codyaccess.CodyGatewayAccess{},
+		&codyaccess.TableCodyGatewayAccess{},
 	}
 }

--- a/cmd/enterprise-portal/internal/database/migrate.go
+++ b/cmd/enterprise-portal/internal/database/migrate.go
@@ -111,6 +111,10 @@ func maybeMigrate(ctx context.Context, logger log.Logger, contract runtime.Contr
 				Context: ctx,
 				Logger:  gormlogger.Default.LogMode(gormlogger.Warn),
 			})
+			// Initialize extensions.
+			if err := conn.Exec(`CREATE EXTENSION IF NOT EXISTS pgcrypto;`).Error; err != nil {
+				return errors.Wrap(err, "install pgcrypto extension")
+			}
 			// Auto-migrate database table definitions.
 			for _, table := range tables.All() {
 				span.AddEvent(fmt.Sprintf("automigrate.%s", table.TableName()))

--- a/cmd/enterprise-portal/internal/database/subscriptions/subscriptions.go
+++ b/cmd/enterprise-portal/internal/database/subscriptions/subscriptions.go
@@ -210,7 +210,7 @@ func (opts UpsertSubscriptionOptions) Exec(ctx context.Context, db *pgxpool.Pool
 // Upsert upserts a subscription record based on the given options.
 func (s *Store) Upsert(ctx context.Context, subscriptionID string, opts UpsertSubscriptionOptions) (*Subscription, error) {
 	if err := opts.Exec(ctx, s.db, subscriptionID); err != nil {
-		return nil, errors.Wrap(err, "exec")
+		return nil, err
 	}
 	return s.Get(ctx, subscriptionID)
 }


### PR DESCRIPTION
Implements Cody Gateway access in Enterprise Portal DB, such that it replicates the behaviour it has today, retrieving:

- Quota overrides
- Subscription display name
- Active license info
- Non-revoked, non-expired license keys as hashes
   - Revocation + non-expiry replaces the existing mechanism of flagging licenses as `access_token_enabled`. Since we ended up doing zero-config for Cody Gateway, the only license hashes that are valid for Cody Gateway are non-expired licenses - once your license expires you should be switching to a new license key anyway.

It's fairly similar to the `dotcomdb` shim we built before, but for our new tables. See https://github.com/sourcegraph/sourcegraph/pull/63792 for the licenses tables.

None of this is going live yet.

Part of https://linear.app/sourcegraph/issue/CORE-100
Part of https://linear.app/sourcegraph/issue/CORE-160

## Test plan

DB integration tests

`sg run enterprise-portal` does the migrations without a hitch