### PR TITLE
pass ModelConfigInfo down to client.Get() for self-hosted-models

### DIFF
--- a/cmd/frontend/internal/clientconfig/clientconfig.go
+++ b/cmd/frontend/internal/clientconfig/clientconfig.go
@@ -17,7 +17,7 @@ func GetForActor(ctx context.Context, logger log.Logger, db database.DB, actor *
 		// If the site config has "modelConfiguration" specified / non-null, then the site admin
 		// has opted into the new model configuration system, wants to use the new /.api/supported-llms
 		// endpoint for models, etc.
-		ModelsAPIEnabled: conf.Get().SiteConfig().ModelConfiguration != nil,
+		ModelsAPIEnabled: conf.UseExperimentalModelConfiguration(),
 	}
 
 	// 🚨 SECURITY: This code lets site admins restrict who has access to Cody at all via RBAC.

--- a/cmd/frontend/internal/completions/resolvers/BUILD.bazel
+++ b/cmd/frontend/internal/completions/resolvers/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
         "//cmd/frontend/graphqlbackend",
         "//cmd/frontend/internal/cody",
         "//cmd/frontend/internal/httpapi/completions",
+        "//cmd/frontend/internal/modelconfig",
         "//internal/completions/client",
         "//internal/completions/types",
         "//internal/conf",

--- a/cmd/frontend/internal/completions/resolvers/resolver.go
+++ b/cmd/frontend/internal/completions/resolvers/resolver.go
@@ -55,7 +55,7 @@ func (c *completionsResolver) Completions(ctx context.Context, args graphqlbacke
 	}
 
 	var modelConfigInfo *types.ModelConfigInfo
-	if conf.Get().SiteConfig().ModelConfiguration != nil {
+	if conf.UseExperimentalModelConfiguration() {
 		// TODO(slimsag): self-hosted-models: this logic only handles Cody Enterprise with Self-hosted models
 		modelConfig, err := modelconfig.Get().Get()
 		if err != nil {

--- a/cmd/frontend/internal/httpapi/completions/BUILD.bazel
+++ b/cmd/frontend/internal/httpapi/completions/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
     visibility = ["//cmd/frontend:__subpackages__"],
     deps = [
         "//cmd/frontend/internal/cody",
+        "//cmd/frontend/internal/modelconfig",
         "//internal/accesstoken",
         "//internal/actor",
         "//internal/auth",
@@ -34,6 +35,8 @@ go_library(
         "//internal/hashutil",
         "//internal/honey",
         "//internal/metrics",
+        "//internal/modelconfig",
+        "//internal/modelconfig/types",
         "//internal/redispool",
         "//internal/requestclient",
         "//internal/search/streaming/http",

--- a/cmd/frontend/internal/httpapi/completions/get_model.go
+++ b/cmd/frontend/internal/httpapi/completions/get_model.go
@@ -9,7 +9,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/dotcom"
 	"github.com/sourcegraph/sourcegraph/internal/modelconfig"
-	modelconfigtypes "github.com/sourcegraph/sourcegraph/internal/modelconfig/types"
+	modelconfigSDK "github.com/sourcegraph/sourcegraph/internal/modelconfig/types"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 
 	"github.com/sourcegraph/sourcegraph/internal/completions/client/anthropic"
@@ -30,7 +30,7 @@ func getCodeCompletionModelFn() getModelFn {
 		if modelConfig := conf.Get().SiteConfig().ModelConfiguration; modelConfig != nil {
 			// Using new "modelConfiguration" site config.
 			// TODO(slimsag): self-hosted-models: currently this logic only handles Cody Enterprise with Self-hosted models
-			if err := modelconfig.ValidateModelRef(modelconfigtypes.ModelRef(requestParams.Model)); err != nil {
+			if err := modelconfig.ValidateModelRef(modelconfigSDK.ModelRef(requestParams.Model)); err != nil {
 				_ = err // TODO(slimsag): self-hosted-models: log the error
 				// We don't have a valid modelRef, so use whatever model we have instead.
 				modelConfig, err := frontendmodelconfig.Get().Get()
@@ -64,7 +64,7 @@ func getChatModelFn(db database.DB) getModelFn {
 		if modelConfig := conf.Get().SiteConfig().ModelConfiguration; modelConfig != nil {
 			// Using new "modelConfiguration" site config.
 			// TODO(slimsag): self-hosted-models: currently this logic only handles Cody Enterprise with Self-hosted models
-			if err := modelconfig.ValidateModelRef(modelconfigtypes.ModelRef(requestParams.Model)); err != nil {
+			if err := modelconfig.ValidateModelRef(modelconfigSDK.ModelRef(requestParams.Model)); err != nil {
 				_ = err // TODO(slimsag): self-hosted-models: log the error
 				// We don't have a valid modelRef, so use whatever model we have instead.
 				modelConfig, err := frontendmodelconfig.Get().Get()

--- a/cmd/frontend/internal/httpapi/completions/get_model.go
+++ b/cmd/frontend/internal/httpapi/completions/get_model.go
@@ -4,8 +4,12 @@ import (
 	"context"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/cody"
+	frontendmodelconfig "github.com/sourcegraph/sourcegraph/cmd/frontend/internal/modelconfig"
 	sgactor "github.com/sourcegraph/sourcegraph/internal/actor"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/dotcom"
+	"github.com/sourcegraph/sourcegraph/internal/modelconfig"
+	modelconfigtypes "github.com/sourcegraph/sourcegraph/internal/modelconfig/types"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 
 	"github.com/sourcegraph/sourcegraph/internal/completions/client/anthropic"
@@ -23,6 +27,21 @@ type getModelFn func(ctx context.Context, requestParams types.CodyCompletionRequ
 
 func getCodeCompletionModelFn() getModelFn {
 	return func(_ context.Context, requestParams types.CodyCompletionRequestParameters, c *conftypes.CompletionsConfig) (string, error) {
+		if modelConfig := conf.Get().SiteConfig().ModelConfiguration; modelConfig != nil {
+			// Using new "modelConfiguration" site config.
+			// TODO(slimsag): self-hosted-models: currently this logic only handles Cody Enterprise with Self-hosted models
+			if err := modelconfig.ValidateModelRef(modelconfigtypes.ModelRef(requestParams.Model)); err != nil {
+				_ = err // TODO(slimsag): self-hosted-models: log the error
+				// We don't have a valid modelRef, so use whatever model we have instead.
+				modelConfig, err := frontendmodelconfig.Get().Get()
+				if err != nil {
+					return "", err
+				}
+				return string(modelConfig.DefaultModels.CodeCompletion), nil
+			}
+			return requestParams.Model, nil // valid ModelRef
+		}
+
 		// For code completions, we only allow certain models to be used.
 		// (Regardless of if the user is on Cody Free, Pro, or Enterprise.)
 		if requestParams.Model != "" {
@@ -42,6 +61,24 @@ func getCodeCompletionModelFn() getModelFn {
 
 func getChatModelFn(db database.DB) getModelFn {
 	return func(ctx context.Context, requestParams types.CodyCompletionRequestParameters, c *conftypes.CompletionsConfig) (string, error) {
+		if modelConfig := conf.Get().SiteConfig().ModelConfiguration; modelConfig != nil {
+			// Using new "modelConfiguration" site config.
+			// TODO(slimsag): self-hosted-models: currently this logic only handles Cody Enterprise with Self-hosted models
+			if err := modelconfig.ValidateModelRef(modelconfigtypes.ModelRef(requestParams.Model)); err != nil {
+				_ = err // TODO(slimsag): self-hosted-models: log the error
+				// We don't have a valid modelRef, so use whatever model we have instead.
+				modelConfig, err := frontendmodelconfig.Get().Get()
+				if err != nil {
+					return "", err
+				}
+				if requestParams.Fast {
+					return string(modelConfig.DefaultModels.FastChat), nil
+				}
+				return string(modelConfig.DefaultModels.Chat), nil
+			}
+			return requestParams.Model, nil // valid ModelRef
+		}
+
 		// If running on dotcom, i.e. using Cody Free/Cody Pro, then a number
 		// of models are available depending on the caller's subscription status.
 		if dotcom.SourcegraphDotComMode() {

--- a/cmd/frontend/internal/httpapi/completions/get_model.go
+++ b/cmd/frontend/internal/httpapi/completions/get_model.go
@@ -27,7 +27,7 @@ type getModelFn func(ctx context.Context, requestParams types.CodyCompletionRequ
 
 func getCodeCompletionModelFn() getModelFn {
 	return func(_ context.Context, requestParams types.CodyCompletionRequestParameters, c *conftypes.CompletionsConfig) (string, error) {
-		if modelConfig := conf.Get().SiteConfig().ModelConfiguration; modelConfig != nil {
+		if conf.UseExperimentalModelConfiguration() {
 			// Using new "modelConfiguration" site config.
 			// TODO(slimsag): self-hosted-models: currently this logic only handles Cody Enterprise with Self-hosted models
 			if err := modelconfig.ValidateModelRef(modelconfigSDK.ModelRef(requestParams.Model)); err != nil {
@@ -61,7 +61,7 @@ func getCodeCompletionModelFn() getModelFn {
 
 func getChatModelFn(db database.DB) getModelFn {
 	return func(ctx context.Context, requestParams types.CodyCompletionRequestParameters, c *conftypes.CompletionsConfig) (string, error) {
-		if modelConfig := conf.Get().SiteConfig().ModelConfiguration; modelConfig != nil {
+		if conf.UseExperimentalModelConfiguration() {
 			// Using new "modelConfiguration" site config.
 			// TODO(slimsag): self-hosted-models: currently this logic only handles Cody Enterprise with Self-hosted models
 			if err := modelconfig.ValidateModelRef(modelconfigSDK.ModelRef(requestParams.Model)); err != nil {

--- a/cmd/frontend/internal/httpapi/completions/handler.go
+++ b/cmd/frontend/internal/httpapi/completions/handler.go
@@ -18,6 +18,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/featureflag"
 	"github.com/sourcegraph/sourcegraph/internal/guardrails"
 	"github.com/sourcegraph/sourcegraph/internal/metrics"
+	modelconfigtypes "github.com/sourcegraph/sourcegraph/internal/modelconfig/types"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 
 	"github.com/sourcegraph/sourcegraph/internal/accesstoken"
@@ -29,6 +30,7 @@ import (
 	"github.com/sourcegraph/log"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/cody"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/modelconfig"
 	"github.com/sourcegraph/sourcegraph/internal/completions/client"
 	"github.com/sourcegraph/sourcegraph/internal/completions/types"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
@@ -141,7 +143,9 @@ func newCompletionsHandler(
 
 		// Use the user's access token for Cody Gateway on dotcom if PLG is enabled.
 		accessToken := completionsConfig.AccessToken
-		isProviderCodyGateway := completionsConfig.Provider == conftypes.CompletionsProviderNameSourcegraph
+		// TODO(slimsag): self-hosted-models: Note we are disabling Cody Gateway if "modelConfiguration" is in use currently.
+		// this logic only handles Cody Enterprise with Self-hosted models
+		isProviderCodyGateway := conf.Get().SiteConfig().ModelConfiguration == nil && completionsConfig.Provider == conftypes.CompletionsProviderNameSourcegraph
 		if isDotcom && isProviderCodyGateway {
 			// Note: if we have no Authorization header, that's fine too, this will return an error
 			apiToken, _, err := authz.ParseAuthorizationHeader(r.Header.Get("Authorization"))
@@ -176,12 +180,29 @@ func newCompletionsHandler(
 			}
 		}
 
+		var modelConfigInfo *types.ModelConfigInfo
+		if conf.Get().SiteConfig().ModelConfiguration != nil {
+			// TODO(slimsag): self-hosted-models: this logic only handles Cody Enterprise with Self-hosted models
+			modelConfig, err := modelconfig.Get().Get()
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+			requestModelRef := modelconfigtypes.ModelRef(requestParams.Model) // a verified modelref at this point
+			modelConfigInfo, err = types.NewModelConfigInfo(modelConfig, requestModelRef)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+		}
+
 		completionClient, err := client.Get(
 			logger,
 			events,
 			completionsConfig.Endpoint,
 			completionsConfig.Provider,
 			accessToken,
+			modelConfigInfo,
 		)
 		l := trace.Logger(ctx, logger)
 		if err != nil {

--- a/cmd/frontend/internal/httpapi/completions/handler.go
+++ b/cmd/frontend/internal/httpapi/completions/handler.go
@@ -18,7 +18,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/featureflag"
 	"github.com/sourcegraph/sourcegraph/internal/guardrails"
 	"github.com/sourcegraph/sourcegraph/internal/metrics"
-	modelconfigtypes "github.com/sourcegraph/sourcegraph/internal/modelconfig/types"
+	modelconfigSDK "github.com/sourcegraph/sourcegraph/internal/modelconfig/types"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 
 	"github.com/sourcegraph/sourcegraph/internal/accesstoken"
@@ -188,7 +188,7 @@ func newCompletionsHandler(
 				http.Error(w, err.Error(), http.StatusInternalServerError)
 				return
 			}
-			requestModelRef := modelconfigtypes.ModelRef(requestParams.Model) // a verified modelref at this point
+			requestModelRef := modelconfigSDK.ModelRef(requestParams.Model) // a verified modelref at this point
 			modelConfigInfo, err = types.NewModelConfigInfo(modelConfig, requestModelRef)
 			if err != nil {
 				http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/cmd/frontend/internal/httpapi/completions/handler.go
+++ b/cmd/frontend/internal/httpapi/completions/handler.go
@@ -145,7 +145,7 @@ func newCompletionsHandler(
 		accessToken := completionsConfig.AccessToken
 		// TODO(slimsag): self-hosted-models: Note we are disabling Cody Gateway if "modelConfiguration" is in use currently.
 		// this logic only handles Cody Enterprise with Self-hosted models
-		isProviderCodyGateway := conf.Get().SiteConfig().ModelConfiguration == nil && completionsConfig.Provider == conftypes.CompletionsProviderNameSourcegraph
+		isProviderCodyGateway := !conf.UseExperimentalModelConfiguration() && completionsConfig.Provider == conftypes.CompletionsProviderNameSourcegraph
 		if isDotcom && isProviderCodyGateway {
 			// Note: if we have no Authorization header, that's fine too, this will return an error
 			apiToken, _, err := authz.ParseAuthorizationHeader(r.Header.Get("Authorization"))
@@ -181,7 +181,7 @@ func newCompletionsHandler(
 		}
 
 		var modelConfigInfo *types.ModelConfigInfo
-		if conf.Get().SiteConfig().ModelConfiguration != nil {
+		if conf.UseExperimentalModelConfiguration() {
 			// TODO(slimsag): self-hosted-models: this logic only handles Cody Enterprise with Self-hosted models
 			modelConfig, err := modelconfig.Get().Get()
 			if err != nil {

--- a/cmd/frontend/internal/httpapi/completions/handler.go
+++ b/cmd/frontend/internal/httpapi/completions/handler.go
@@ -185,12 +185,14 @@ func newCompletionsHandler(
 			// TODO(slimsag): self-hosted-models: this logic only handles Cody Enterprise with Self-hosted models
 			modelConfig, err := modelconfig.Get().Get()
 			if err != nil {
+				trace.Logger(ctx, logger).Info("UseExperimentalModelConfiguration - failed to load model configuration", log.Error(err))
 				http.Error(w, err.Error(), http.StatusInternalServerError)
 				return
 			}
 			requestModelRef := modelconfigSDK.ModelRef(requestParams.Model) // a verified modelref at this point
 			modelConfigInfo, err = types.NewModelConfigInfo(modelConfig, requestModelRef)
 			if err != nil {
+				trace.Logger(ctx, logger).Info("UseExperimentalModelConfiguration - failed to create model config info", log.Error(err))
 				http.Error(w, err.Error(), http.StatusInternalServerError)
 				return
 			}

--- a/cmd/frontend/internal/modelconfig/siteconfig.go
+++ b/cmd/frontend/internal/modelconfig/siteconfig.go
@@ -174,7 +174,7 @@ func convertServerSideProviderConfig(cfg *schema.ServerSideProviderConfig) *type
 			},
 		}
 	} else if v := cfg.Openaicompatible; v != nil {
-		// TODO(slimsag): self-hosted-llm: map this to OpenAICompatibleProviderConfig in the future
+		// TODO(slimsag): self-hosted-models: map this to OpenAICompatibleProviderConfig in the future
 		return &types.ServerSideProviderConfig{
 			GenericProvider: &types.GenericProviderConfig{
 				ServiceName: types.GenericServiceProviderOpenAI,
@@ -274,7 +274,7 @@ var recommendedSettings = map[types.ModelRef]types.ModelOverride{
 }
 
 func recommendedSettingsStarcoder2(modelRef, displayName, modelName string) types.ModelOverride {
-	// TODO(slimsag): self-hosted-llm: tune these further based on testing
+	// TODO(slimsag): self-hosted-models: tune these further based on testing
 	return types.ModelOverride{
 		ModelRef:     types.ModelRef(modelRef),
 		DisplayName:  displayName,
@@ -293,7 +293,7 @@ func recommendedSettingsStarcoder2(modelRef, displayName, modelName string) type
 }
 
 func recommendedSettingsMistral(modelRef, displayName, modelName string) types.ModelOverride {
-	// TODO(slimsag): self-hosted-llm: tune these further based on testing
+	// TODO(slimsag): self-hosted-models: tune these further based on testing
 	return types.ModelOverride{
 		ModelRef:     types.ModelRef(modelRef),
 		DisplayName:  displayName,

--- a/internal/completions/client/BUILD.bazel
+++ b/internal/completions/client/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
         "//internal/completions/client/openai",
         "//internal/completions/tokenusage",
         "//internal/completions/types",
+        "//internal/conf",
         "//internal/conf/conftypes",
         "//internal/httpcli",
         "//internal/metrics",

--- a/internal/completions/client/client.go
+++ b/internal/completions/client/client.go
@@ -12,6 +12,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/completions/client/openai"
 	"github.com/sourcegraph/sourcegraph/internal/completions/tokenusage"
 	"github.com/sourcegraph/sourcegraph/internal/completions/types"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/internal/telemetry"
@@ -24,16 +25,25 @@ func Get(
 	endpoint string,
 	provider conftypes.CompletionsProviderName,
 	accessToken string,
+	modelConfigInfo *types.ModelConfigInfo,
 ) (types.CompletionsClient, error) {
-	client, err := getBasic(endpoint, provider, accessToken)
+	client, err := getBasic(endpoint, provider, accessToken, modelConfigInfo)
 	if err != nil {
 		return nil, err
 	}
 	return newObservedClient(logger, events, client), nil
 }
 
-func getBasic(endpoint string, provider conftypes.CompletionsProviderName, accessToken string) (types.CompletionsClient, error) {
+func getBasic(endpoint string, provider conftypes.CompletionsProviderName, accessToken string, modelConfigInfo *types.ModelConfigInfo) (types.CompletionsClient, error) {
 	tokenManager := tokenusage.NewManager()
+
+	if conf.Get().SiteConfig().ModelConfiguration != nil {
+		// Using the new "modelConfiguration" site config
+		// TODO(slimsag): self-hosted-models: this logic only handles Cody Enterprise with Self-hosted models
+		// Only in this case do we have modelConfigInfo != nil
+		return nil, errors.Newf("TODO: implement self-hosted-models")
+	}
+
 	switch provider {
 	case conftypes.CompletionsProviderNameAnthropic:
 		return anthropic.NewClient(httpcli.UncachedExternalDoer, endpoint, accessToken, false, *tokenManager), nil

--- a/internal/completions/client/client.go
+++ b/internal/completions/client/client.go
@@ -41,6 +41,7 @@ func getBasic(endpoint string, provider conftypes.CompletionsProviderName, acces
 		// Using the new "modelConfiguration" site config
 		// TODO(slimsag): self-hosted-models: this logic only handles Cody Enterprise with Self-hosted models
 		// Only in this case do we have modelConfigInfo != nil
+		_ = modelConfigInfo
 		return nil, errors.Newf("TODO: implement self-hosted-models")
 	}
 

--- a/internal/completions/client/client.go
+++ b/internal/completions/client/client.go
@@ -37,7 +37,7 @@ func Get(
 func getBasic(endpoint string, provider conftypes.CompletionsProviderName, accessToken string, modelConfigInfo *types.ModelConfigInfo) (types.CompletionsClient, error) {
 	tokenManager := tokenusage.NewManager()
 
-	if conf.Get().SiteConfig().ModelConfiguration != nil {
+	if conf.UseExperimentalModelConfiguration() {
 		// Using the new "modelConfiguration" site config
 		// TODO(slimsag): self-hosted-models: this logic only handles Cody Enterprise with Self-hosted models
 		// Only in this case do we have modelConfigInfo != nil

--- a/internal/completions/types/BUILD.bazel
+++ b/internal/completions/types/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     tags = [TAG_CODY_CORE],
     visibility = ["//:__subpackages__"],
     deps = [
+        "//internal/modelconfig/types",
         "//lib/errors",
         "@com_github_sourcegraph_log//:log",
         "@io_opentelemetry_go_otel//attribute",

--- a/internal/completions/types/types.go
+++ b/internal/completions/types/types.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/sourcegraph/log"
 
-	modelconfigtypes "github.com/sourcegraph/sourcegraph/internal/modelconfig/types"
+	modelconfigSDK "github.com/sourcegraph/sourcegraph/internal/modelconfig/types"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
@@ -55,16 +55,16 @@ type CodyCompletionRequestParameters struct {
 // ModelConfigInfo is all the configuration information about the LLM Model and
 // the Provider we are using to resolve the request.
 type ModelConfigInfo struct {
-	Provider modelconfigtypes.Provider
-	Model    modelconfigtypes.Model
+	Provider modelconfigSDK.Provider
+	Model    modelconfigSDK.Model
 }
 
 // Builds ModelConfigInfo for a given modelRef by looking up information in the provided modelConfig.
 func NewModelConfigInfo(
-	modelConfig *modelconfigtypes.ModelConfiguration,
-	modelRef modelconfigtypes.ModelRef,
+	modelConfig *modelconfigSDK.ModelConfiguration,
+	modelRef modelconfigSDK.ModelRef,
 ) (*ModelConfigInfo, error) {
-	var model *modelconfigtypes.Model
+	var model *modelconfigSDK.Model
 	for _, m := range modelConfig.Models {
 		if m.ModelRef == modelRef {
 			model = &m
@@ -76,7 +76,7 @@ func NewModelConfigInfo(
 	}
 
 	wantProviderID := modelRef.ProviderID()
-	var provider *modelconfigtypes.Provider
+	var provider *modelconfigSDK.Provider
 	for _, p := range modelConfig.Providers {
 		if p.ID == wantProviderID {
 			provider = &p

--- a/internal/completions/types/types.go
+++ b/internal/completions/types/types.go
@@ -72,7 +72,7 @@ func NewModelConfigInfo(
 		}
 	}
 	if model == nil {
-		return nil, fmt.Errorf("model %q not found in model configuration", modelRef)
+		return nil, errors.Newf("model %q not found in model configuration", modelRef)
 	}
 
 	wantProviderID := modelRef.ProviderID()
@@ -84,7 +84,7 @@ func NewModelConfigInfo(
 		}
 	}
 	if provider == nil {
-		return nil, fmt.Errorf("model provider %q not found in model configuration", wantProviderID)
+		return nil, errors.Newf("model provider %q not found in model configuration", wantProviderID)
 	}
 	return &ModelConfigInfo{
 		Provider: *provider,

--- a/internal/completions/types/types.go
+++ b/internal/completions/types/types.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/sourcegraph/log"
 
+	modelconfigtypes "github.com/sourcegraph/sourcegraph/internal/modelconfig/types"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
@@ -49,6 +50,46 @@ type CodyCompletionRequestParameters struct {
 	// When Fast is true, then it is used as a hint to prefer a model
 	// that is faster (but probably "dumber").
 	Fast bool
+}
+
+// ModelConfigInfo is all the configuration information about the LLM Model and
+// the Provider we are using to resolve the request.
+type ModelConfigInfo struct {
+	Provider modelconfigtypes.Provider
+	Model    modelconfigtypes.Model
+}
+
+// Builds ModelConfigInfo for a given modelRef by looking up information in the provided modelConfig.
+func NewModelConfigInfo(
+	modelConfig *modelconfigtypes.ModelConfiguration,
+	modelRef modelconfigtypes.ModelRef,
+) (*ModelConfigInfo, error) {
+	var model *modelconfigtypes.Model
+	for _, m := range modelConfig.Models {
+		if m.ModelRef == modelRef {
+			model = &m
+			break
+		}
+	}
+	if model == nil {
+		return nil, fmt.Errorf("model %q not found in model configuration", modelRef)
+	}
+
+	wantProviderID := modelRef.ProviderID()
+	var provider *modelconfigtypes.Provider
+	for _, p := range modelConfig.Providers {
+		if p.ID == wantProviderID {
+			provider = &p
+			break
+		}
+	}
+	if provider == nil {
+		return nil, fmt.Errorf("model provider %q not found in model configuration", wantProviderID)
+	}
+	return &ModelConfigInfo{
+		Provider: *provider,
+		Model:    *model,
+	}, nil
 }
 
 type CompletionRequestParameters struct {

--- a/internal/conf/computed.go
+++ b/internal/conf/computed.go
@@ -674,6 +674,12 @@ func HashedLicenseKeyWithPrefix(licenseKey string, prefix string) string {
 	return hex.EncodeToString(hashutil.ToSHA256Bytes([]byte(prefix + licenseKey)))
 }
 
+// UseExperimentalModelConfiguration tells whether or not "modelConfiguration" has been specified
+// in the site configuration
+func UseExperimentalModelConfiguration() bool {
+	return Get().SiteConfig().ModelConfiguration != nil
+}
+
 // GetCompletionsConfig evaluates a complete completions configuration based on
 // site configuration. The configuration may be nil if completions is disabled.
 func GetCompletionsConfig(siteConfig schema.SiteConfiguration) (c *conftypes.CompletionsConfig) {


### PR DESCRIPTION
This PR has a single goal: pass a new `ModelConfigInfo` type, which has the `Provider` and `Model` we should use to serve a completions request, down into `client.Get()`

This PR explicitly only handles the case we care about for Self-hosted models, and all pieces of logic that I expect will be replaced/superseded by your work @chrsmith are annotated with `// TODO(slimsag): self-hosted-models:` comments so we can easily find and remove them when your work is ready.

Every location I have modified has been carefully wrapped in an if statement like `if conf.Get().SiteConfig().ModelConfiguration != nil` to ensure that this change _only_ affects people who set the new `"modelConfiguration"` site config property.

## Test plan

1. Configured `"modelConfiguration"` and removed `"completions"` in my dev instances' site config.
2. Used VS Code chat to confirm I see this codepath is connected end-to-end and I get a `TODO` error back:

<img width="679" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/3173176/d3c07ffe-7ec2-4ad9-9251-2272ce36d44b">

## Changelog

N/A