### PR TITLE
fix(svelte): Prefill search home page query input with (default) context filter

### DIFF
--- a/client/branded/src/search-ui/input/experimental/CodeMirrorQueryInputWrapper.tsx
+++ b/client/branded/src/search-ui/input/experimental/CodeMirrorQueryInputWrapper.tsx
@@ -254,7 +254,11 @@ export const CodeMirrorQueryInputWrapper = forwardRef<Editor, PropsWithChildren<
                     setSuggestionsState(getSuggestionsState(update.state))
                     // Show suggestions after the user interacted with the input, either by
                     // moving the cursor (via keyboard or mouse) or by entering text.
-                    if (update.transactions.some(tr => tr.isUserEvent('select') || tr.isUserEvent('input'))) {
+                    if (
+                        update.transactions.some(
+                            tr => tr.isUserEvent('select') || tr.isUserEvent('input') || tr.isUserEvent('delete')
+                        )
+                    ) {
                         setShowSuggestions(true)
                     }
                 }),

--- a/client/web-sveltekit/src/lib/search/BaseQueryInput.svelte
+++ b/client/web-sveltekit/src/lib/search/BaseQueryInput.svelte
@@ -98,8 +98,10 @@
     }))
 
     function createEditor(container: HTMLDivElement, doc: string, extensions: Extension): EditorView {
+        // Moves the cursor to the end of the document by default
+        const selection = { anchor: doc.length }
         const view = new EditorView({
-            state: EditorState.create({ doc, extensions }),
+            state: EditorState.create({ doc, extensions, selection }),
             parent: container,
         })
         return view

--- a/client/web-sveltekit/src/lib/search/input/SearchInput.svelte
+++ b/client/web-sveltekit/src/lib/search/input/SearchInput.svelte
@@ -137,7 +137,7 @@
     let userHasInteracted = !autoFocus
     const hasInteractedExtension = EditorView.updateListener.of(update => {
         if (!userHasInteracted) {
-            if (update.transactions.some(tr => tr.isUserEvent('select') || tr.isUserEvent('input'))) {
+            if (update.transactions.some(tr => tr.isUserEvent('select') || tr.isUserEvent('input') || tr.isUserEvent('delete'))) {
                 userHasInteracted = true
             }
         }

--- a/client/web-sveltekit/src/lib/search/results.ts
+++ b/client/web-sveltekit/src/lib/search/results.ts
@@ -2,7 +2,6 @@ import { sortBy } from 'lodash'
 
 import {
     appendFilter,
-    buildSearchURLQuery,
     FilterKind,
     findFilter,
     getMatchUrl,
@@ -53,27 +52,15 @@ export function getRepositoryBadges(
 }
 
 function buildSearchURLQueryForTopic(queryState: QueryState, topic: string): string {
-    const query = appendFilter(queryState.query, 'repo', `has.topic(${topic})`)
-
-    return buildSearchURLQuery(
-        query,
-        queryState.patternType,
-        queryState.caseSensitive,
-        queryState.searchContext,
-        queryState.searchMode
-    )
+    return queryState
+        .setQuery(appendFilter(queryState.query, 'repo', `has.topic(${topic})`))
+        .toSearchURLQueryParamaters()
 }
 
 function buildSearchURLQueryForMeta(queryState: QueryState, key: string, value?: string): string {
-    const query = appendFilter(queryState.query, 'repo', value ? `has.meta(${key}:${value})` : `has.meta(${key})`)
-
-    return buildSearchURLQuery(
-        query,
-        queryState.patternType,
-        queryState.caseSensitive,
-        queryState.searchContext,
-        queryState.searchMode
-    )
+    return queryState
+        .setQuery(appendFilter(queryState.query, 'repo', value ? `has.meta(${key}:${value})` : `has.meta(${key})`))
+        .toSearchURLQueryParamaters()
 }
 
 export function getOwnerDisplayName(result: OwnerMatch): string {
@@ -106,14 +93,7 @@ export function buildSearchURLQueryForOwner(queryState: QueryState, result: Owne
         query = omitFilter(query, selectFilter)
     }
     query = appendFilter(query, 'file', `has.owner(${handle})`)
-
-    return buildSearchURLQuery(
-        query,
-        queryState.patternType,
-        queryState.caseSensitive,
-        queryState.searchContext,
-        queryState.searchMode
-    )
+    return queryState.setQuery(query).toSearchURLQueryParamaters()
 }
 
 function sumHighlightRanges(count: number, item: MatchGroup): number {

--- a/client/web-sveltekit/src/routes/search/+page.ts
+++ b/client/web-sveltekit/src/routes/search/+page.ts
@@ -3,6 +3,7 @@ import { get } from 'svelte/store'
 
 import { browser } from '$app/environment'
 import { navigating } from '$app/stores'
+import { getGraphQLClient } from '$lib/graphql'
 import { SearchPatternType } from '$lib/graphql-operations'
 import { parseExtendedSearchURL, type ExtendedParsedSearchURL } from '$lib/search'
 import { SearchCachePolicy, getCachePolicyFromURL } from '$lib/search/state'
@@ -14,12 +15,12 @@ import {
     filterExists,
     FilterType,
     getGlobalSearchContextFilter,
-    omitFilter,
     emptyAggregateResults,
 } from '$lib/shared'
 
 import type { PageLoad } from './$types'
 import DotcomFooterLinks from './DotcomFooterLinks.svelte'
+import { DefaultSearchContext } from './page.gql'
 
 type SearchStreamCacheEntry = Observable<AggregateStreamingSearchResults>
 
@@ -101,15 +102,6 @@ export const load: PageLoad = async ({ parent, url, depends }) => {
         } = parsedQuery
         depends(`search:${url}`)
 
-        let searchContext = 'global'
-        if (filterExists(query, FilterType.context)) {
-            // TODO: Validate search context
-            const globalSearchContext = getGlobalSearchContextFilter(query)
-            if (globalSearchContext?.spec) {
-                searchContext = globalSearchContext.spec
-            }
-        }
-
         const options: StreamSearchOptions = {
             version: LATEST_VERSION,
             patternType,
@@ -148,28 +140,24 @@ export const load: PageLoad = async ({ parent, url, depends }) => {
             queryFilters,
             queryFromURL: query,
             queryOptions: {
-                query: withoutGlobalContext(query),
+                query,
                 caseSensitive,
                 patternType,
                 searchMode,
-                searchContext,
             },
         }
     }
+
+    const defaultSearchContext = await getGraphQLClient()
+        .query(DefaultSearchContext, {})
+        .toPromise()
+        .then(result => result.data?.defaultSearchContext?.spec ?? 'global')
+        .catch(() => 'global')
     return {
         codyHref,
         footer: window.context.sourcegraphDotComMode ? DotcomFooterLinks : null,
         queryOptions: {
-            query: '',
+            query: `context:${defaultSearchContext} `,
         },
     }
-}
-
-function withoutGlobalContext(query: string): string {
-    // TODO: Validate search context
-    const globalSearchContext = getGlobalSearchContextFilter(query)
-    if (globalSearchContext?.spec) {
-        return omitFilter(query, globalSearchContext.filter)
-    }
-    return query
 }

--- a/client/web-sveltekit/src/routes/search/+page.ts
+++ b/client/web-sveltekit/src/routes/search/+page.ts
@@ -12,9 +12,6 @@ import {
     LATEST_VERSION,
     type AggregateStreamingSearchResults,
     type StreamSearchOptions,
-    filterExists,
-    FilterType,
-    getGlobalSearchContextFilter,
     emptyAggregateResults,
 } from '$lib/shared'
 

--- a/client/web-sveltekit/src/routes/search/page.gql
+++ b/client/web-sveltekit/src/routes/search/page.gql
@@ -1,0 +1,5 @@
+query DefaultSearchContext {
+    defaultSearchContext {
+        spec
+    }
+}

--- a/client/web-sveltekit/vite.config.ts
+++ b/client/web-sveltekit/vite.config.ts
@@ -81,7 +81,7 @@ export default defineConfig(({ mode }) => {
             proxy: {
                 // Proxy requests to specific endpoints to a real Sourcegraph
                 // instance.
-                '^(/sign-(in|out)|/.assets|/-|/.api|/.auth|/search/stream|/users|/notebooks|/insights|/batch-changes)|/-/(raw|compare|own|code-graph|batch-changes|settings)(/|$)':
+                '^(/sign-(in|out)|/.assets|/-|/.api|/.auth|/search/stream|/users|/notebooks|/insights|/batch-changes|/contexts)|/-/(raw|compare|own|code-graph|batch-changes|settings)(/|$)':
                     {
                         target: process.env.SOURCEGRAPH_API_URL || 'https://sourcegraph.sourcegraph.com',
                         changeOrigin: true,


### PR DESCRIPTION
Closes srch-103

Currently we don't show the global context filter on the search home page or the search results page (global context is the default context).

This commit does two things:

- It prefills the search input on the search homepage with the user's default context (like the React app)
- It the logic that pre-processed the search query and removed the context filter if it was global.

In other words we simplify the query logic by showing/submitting the search query as is. Notably this doesn't affect how the search input works on repo pages.


## Test plan

- Opening the search home page pre-fills the query input with the default search context
- Submitting a query without a `context:` filter does not add a `context:` filter to the URL or the search input
- If a query contains `context:global` that filter is preserved in the query input (it wasn't before)