### PR TITLE
Bump cody-web-experimental to 0.2.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -333,7 +333,7 @@
     "bloomfilter": "^0.0.18",
     "buffer": "^6.0.3",
     "classnames": "^2.2.6",
-    "cody-web-experimental": "^0.2.3",
+    "cody-web-experimental": "^0.2.4",
     "comlink": "^4.3.0",
     "copy-to-clipboard": "^3.3.1",
     "core-js": "^3.8.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -206,8 +206,8 @@ importers:
         specifier: ^2.2.6
         version: 2.3.2
       cody-web-experimental:
-        specifier: ^0.2.3
-        version: 0.2.3
+        specifier: ^0.2.4
+        version: 0.2.4
       comlink:
         specifier: ^4.3.0
         version: 4.3.0
@@ -14556,6 +14556,10 @@ packages:
 
   /cody-web-experimental@0.2.3:
     resolution: {integrity: sha512-Wymn3jVlnZMC/ww16x8RtCuoFwVfkk3A43Bzb16xIszZpDGS1DUBsyuqw+gHkO96w1GxfH+phP3EZpZrTm3X3w==}
+    dev: false
+
+  /cody-web-experimental@0.2.4:
+    resolution: {integrity: sha512-92MNNTlZTndHN+kNUa4ojrZMIxgl78o+wswOhdzmIQm/FJFi977rnuQPSg/bV5jm8S3y3pdwUM7SUTqCKlwSHw==}
     dev: false
 
   /color-convert@1.9.3:


### PR DESCRIPTION
Follow up for https://github.com/sourcegraph/cody/pull/4826

In the latest release, 0.2.4, we fixed the problem that @fkling found about links [here](https://linear.app/sourcegraph/issue/SRCH-633/links-in-the-prompt-has-incorrect-url-in-cody-web#comment-b9427c46); cody assistance can render links in its response via markdown, and in 0.2.3, these links had deep link vscode command, which didn't work properly in cody web. Now it renders plain links when it's rendered for Cody Web.

## Test plan
- Check that links that Cody assistance provides work properly and don't have any deep links command 

<!-- REQUIRED; info at https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles -->

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
