### PR TITLE
fix: remove watch path that's gone

### DIFF
--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -255,7 +255,6 @@ commands:
       - lib
       - internal
       - cmd/symbols
-      - internal/rockskip
 
   embeddings:
     cmd: |


### PR DESCRIPTION
https://github.com/sourcegraph/sourcegraph/pull/63736 removed rockskip files, which lead to `sg start` failing because it was still watching those. This PR removes the watch and lets `sg start` succeed again.

## Test plan

Existing CI, manual test of `sg start`

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
