### PR TITLE
chore(svelte): Update cody web version

### DIFF
--- a/client/web-sveltekit/package.json
+++ b/client/web-sveltekit/package.json
@@ -93,7 +93,7 @@
     "@sourcegraph/wildcard": "workspace:*",
     "@storybook/test": "^8.0.5",
     "@urql/core": "^4.2.3",
-    "cody-web-experimental": "^0.2.3",
+    "cody-web-experimental": "^0.2.4",
     "copy-to-clipboard": "^3.3.1",
     "fzf": "^0.5.2",
     "highlight.js": "^10.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1594,8 +1594,8 @@ importers:
         specifier: ^4.2.3
         version: 4.2.3(graphql@15.4.0)
       cody-web-experimental:
-        specifier: ^0.2.3
-        version: 0.2.3
+        specifier: ^0.2.4
+        version: 0.2.4
       copy-to-clipboard:
         specifier: ^3.3.1
         version: 3.3.1
@@ -14552,10 +14552,6 @@ packages:
 
   /codemirror@5.65.9:
     resolution: {integrity: sha512-19Jox5sAKpusTDgqgKB5dawPpQcY+ipQK7xoEI+MVucEF9qqFaXpeqY1KaoyGBso/wHQoDa4HMMxMjdsS3Zzzw==}
-    dev: false
-
-  /cody-web-experimental@0.2.3:
-    resolution: {integrity: sha512-Wymn3jVlnZMC/ww16x8RtCuoFwVfkk3A43Bzb16xIszZpDGS1DUBsyuqw+gHkO96w1GxfH+phP3EZpZrTm3X3w==}
     dev: false
 
   /cody-web-experimental@0.2.4:


### PR DESCRIPTION
Similar to https://github.com/sourcegraph/sourcegraph/pull/63742 this updates to the latest cody web version in the new web app.

## Test plan

Manual testing
