### PR TITLE
fix(batches): enable check for creating source as non credential

### DIFF
--- a/internal/batches/reconciler/executor.go
+++ b/internal/batches/reconciler/executor.go
@@ -659,7 +659,7 @@ func (e *executor) runAfterCommit(ctx context.Context, css sources.ChangesetSour
 
 			// If the authentication strategy for the original Push is not GitHub App, we want to make use
 			// of a commit signing GitHub app to sign the commit.
-			AsNonCredential: css.AuthenticationStrategy() == sources.AuthenticationStrategyGitHubApp,
+			AsNonCredential: css.AuthenticationStrategy() != sources.AuthenticationStrategyGitHubApp,
 			GitHubAppKind:   ghtypes.CommitSigningGitHubAppKind,
 		})
 		if err != nil {
@@ -670,6 +670,7 @@ func (e *executor) runAfterCommit(ctx context.Context, css sources.ChangesetSour
 				}
 				// If we didn't find any GitHub Apps configured for this code host, it's a
 				// noop; commit signing is not set up for this code host.
+				e.logger.Warn("no Github App configured to sign commit, commit will not be verified")
 			default:
 				if rejectUnverifiedCommit {
 					return errors.Wrap(err, "failed to get GitHub App for commit verification")


### PR DESCRIPTION
This check was wrong as we create a non-credential source only when the ChangesetSource strategy isn't `GitHubApp`

## Test plan

<!-- REQUIRED; info at https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles -->
Manual testing

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
