### PR TITLE
Update comment and decode bytes instead

### DIFF
--- a/cmd/gitserver/internal/perforce/protects.go
+++ b/cmd/gitserver/internal/perforce/protects.go
@@ -165,7 +165,7 @@ func parseP4BrokerProtects(brokerProtects []byte) ([]*p4types.Protect, error) {
 	var protectsJson []byte
 	_, err := base64.StdEncoding.Decode(protectsJson, parsedBrokerResponse.Data)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to unescape protects response")
+		return nil, errors.Wrap(err, "failed to decode protects response")
 	}
 
 	return parseP4Protects(protectsJson)

--- a/cmd/gitserver/internal/perforce/protects.go
+++ b/cmd/gitserver/internal/perforce/protects.go
@@ -142,7 +142,7 @@ type perforceJSONProtect struct {
 }
 
 type perforceBrokerJSONProtect struct {
-	Data string `json:"data"` // URL encoded JSON
+	Data []byte `json:"data"` // base64 encoded JSON
 }
 
 // parseP4BrokerProtects decodes a `p4 protects` message returned from a
@@ -158,16 +158,17 @@ func parseP4BrokerProtects(brokerProtects []byte) ([]*p4types.Protect, error) {
 		return nil, errors.Wrap(err, "failed to unmarshal protect line")
 	}
 
-	if parsedBrokerResponse.Data == "" {
+	if len(parsedBrokerResponse.Data) == 0 {
 		return nil, errors.New("not a valid protects response")
 	}
 
-	protectsJson, err := base64.StdEncoding.DecodeString(parsedBrokerResponse.Data)
+	var protectsJson []byte
+	_, err := base64.StdEncoding.Decode(protectsJson, parsedBrokerResponse.Data)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to unescape protects response")
 	}
 
-	return parseP4Protects([]byte(protectsJson))
+	return parseP4Protects(protectsJson)
 }
 
 // parseP4Protects expects output from a `p4 protects` command called with

--- a/cmd/gitserver/internal/perforce/protects.go
+++ b/cmd/gitserver/internal/perforce/protects.go
@@ -3,7 +3,6 @@ package perforce
 import (
 	"bytes"
 	"context"
-	"encoding/base64"
 	"encoding/json"
 	"os"
 
@@ -142,7 +141,7 @@ type perforceJSONProtect struct {
 }
 
 type perforceBrokerJSONProtect struct {
-	Data string `json:"data"` // base64 encoded JSON
+	Data []byte `json:"data"` // base64 encoded JSON
 }
 
 // parseP4BrokerProtects decodes a `p4 protects` message returned from a
@@ -162,12 +161,7 @@ func parseP4BrokerProtects(brokerProtects []byte) ([]*p4types.Protect, error) {
 		return nil, errors.New("not a valid protects response")
 	}
 
-	protectsJson, err := base64.StdEncoding.DecodeString(parsedBrokerResponse.Data)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to decode protects response")
-	}
-
-	return parseP4Protects([]byte(protectsJson))
+	return parseP4Protects(parsedBrokerResponse.Data)
 }
 
 // parseP4Protects expects output from a `p4 protects` command called with

--- a/cmd/gitserver/internal/perforce/protects.go
+++ b/cmd/gitserver/internal/perforce/protects.go
@@ -142,7 +142,7 @@ type perforceJSONProtect struct {
 }
 
 type perforceBrokerJSONProtect struct {
-	Data []byte `json:"data"` // base64 encoded JSON
+	Data string `json:"data"` // base64 encoded JSON
 }
 
 // parseP4BrokerProtects decodes a `p4 protects` message returned from a
@@ -162,13 +162,12 @@ func parseP4BrokerProtects(brokerProtects []byte) ([]*p4types.Protect, error) {
 		return nil, errors.New("not a valid protects response")
 	}
 
-	var protectsJson []byte
-	_, err := base64.StdEncoding.Decode(protectsJson, parsedBrokerResponse.Data)
+	protectsJson, err := base64.StdEncoding.DecodeString(parsedBrokerResponse.Data)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to decode protects response")
 	}
 
-	return parseP4Protects(protectsJson)
+	return parseP4Protects([]byte(protectsJson))
 }
 
 // parseP4Protects expects output from a `p4 protects` command called with


### PR DESCRIPTION
Minor adjustment to decode the base64 encoded JSON directly to bytes instead of a string, and update the associated coment.

## Test plan

Existing test should still pass

<!-- REQUIRED; info at https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles -->

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
