### PR TITLE
fix(build): update wolfi image lock for otel

### DIFF
--- a/wolfi-images/opentelemetry-collector.lock.json
+++ b/wolfi-images/opentelemetry-collector.lock.json
@@ -755,22 +755,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ZrMuP718My90TnZrml7ylUmXGlo=",
+        "checksum": "Q1KgJAD0RtQUCakAdBGVnjppfBRD8=",
         "control": {
-          "checksum": "sha1-ZrMuP718My90TnZrml7ylUmXGlo=",
-          "range": "bytes=702-1093"
+          "checksum": "sha1-KgJAD0RtQUCakAdBGVnjppfBRD8=",
+          "range": "bytes=698-1074"
         },
         "data": {
-          "checksum": "sha256-+ZTF5s9bHKtoArLvOvIL/2seV4pE0ElEj9MlAscAdso=",
-          "range": "bytes=1094-53513"
+          "checksum": "sha256-OYnWS0GkjAi6HQutIcfq3EIqw/RWu9VjJv0MHhJj17s=",
+          "range": "bytes=1075-54087"
         },
         "name": "tini",
         "signature": {
-          "checksum": "sha1-OK9J/Z8qnRssJzNCu9hER8FuzSk=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-LVT2LB/h8Oe3c/9pai1JbjXyR44=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/tini-0.19.0-r4.apk",
-        "version": "0.19.0-r4"
+        "url": "https://packages.wolfi.dev/os/x86_64/tini-0.19.0-r5.apk",
+        "version": "0.19.0-r5"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/opentelemetry-collector.lock.json
+++ b/wolfi-images/opentelemetry-collector.lock.json
@@ -14,136 +14,117 @@
     "packages": [
       {
         "architecture": "x86_64",
-        "checksum": "Q1ge3SLQsJ9v2RnvIHHAP1yFyjrEU=",
+        "checksum": "Q1WR9MGKU+cJh6dJFEXnr3zU1qsMM=",
         "control": {
-          "checksum": "sha1-ge3SLQsJ9v2RnvIHHAP1yFyjrEU=",
-          "range": "bytes=693-1040"
+          "checksum": "sha1-WR9MGKU+cJh6dJFEXnr3zU1qsMM=",
+          "range": "bytes=705-1034"
         },
         "data": {
-          "checksum": "sha256-I0AdTdfGf4P/jwzTrLXm73l5/RNSlymEof/YZfev3xY=",
-          "range": "bytes=1041-255811"
+          "checksum": "sha256-EkOhtSivoLErXsK2J9ri39thkwb2kJGYHVou4n6dMKA=",
+          "range": "bytes=1035-254654"
         },
         "name": "ca-certificates-bundle",
         "signature": {
-          "checksum": "sha1-ge1eJBiQmFWAn9GapFkQpO+Rn/Y=",
-          "range": "bytes=0-692"
+          "checksum": "sha1-WL9vKv1nPIeaUQI4O0DiY9RdSHE=",
+          "range": "bytes=0-704"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20240315-r3.apk",
-        "version": "20240315-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20240705-r0.apk",
+        "version": "20240705-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1bgay5kOzpmDBgqJCg7dSlawyJg0=",
+        "checksum": "Q1KmG1L67f+/TnVGcnIcLfWRF/K2g=",
         "control": {
-          "checksum": "sha1-bgay5kOzpmDBgqJCg7dSlawyJg0=",
-          "range": "bytes=703-1067"
+          "checksum": "sha1-KmG1L67f+/TnVGcnIcLfWRF/K2g=",
+          "range": "bytes=702-1051"
         },
         "data": {
-          "checksum": "sha256-f83HfRE7r2ZniH7PyPmRqcoU5NTpF+Uk4FH80QbjvBM=",
-          "range": "bytes=1068-118370"
+          "checksum": "sha256-2YIxYc/Quit+Kri2qS8p6XvL7taAmOYJU/1Z8RNQ+88=",
+          "range": "bytes=1052-122509"
         },
         "name": "wolfi-baselayout",
         "signature": {
-          "checksum": "sha1-2hlCvYH1D7u25HkJGA75jjs/sQY=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-VVyPrknEtqCPym5lfhVEuIhfkKg=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r11.apk",
-        "version": "20230201-r11"
+        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r13.apk",
+        "version": "20230201-r13"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q17rD4cKGW3uVSJw02PFiYR719t/Y=",
+        "checksum": "Q1ASyaCJL2Zyz4uAKpPPlx1Sd40yo=",
         "control": {
-          "checksum": "sha1-7rD4cKGW3uVSJw02PFiYR719t/Y=",
-          "range": "bytes=697-1108"
+          "checksum": "sha1-ASyaCJL2Zyz4uAKpPPlx1Sd40yo=",
+          "range": "bytes=706-1101"
         },
         "data": {
-          "checksum": "sha256-GvSViXbvUD0BdV2A+IzVJni2DjLvyM+j14hM29DcsYg=",
-          "range": "bytes=1109-268391"
+          "checksum": "sha256-KoaUrlV3QZ4ATGvKgOmZ1C8Rb/tHK3zEiCTGDrxxc/I=",
+          "range": "bytes=1102-272818"
         },
         "name": "ld-linux",
         "signature": {
-          "checksum": "sha1-nRIFect8o/LOUIEvN17AsrI07dg=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-DBrLE0fWPMyB5/0kAtNlIK6viCU=",
+          "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1/A0wNjkLqqBhe0jFr2D9SKcDNq8=",
+        "checksum": "Q10iHLABsXtuH2JyExQ2IIxH1NUCI=",
         "control": {
-          "checksum": "sha1-/A0wNjkLqqBhe0jFr2D9SKcDNq8=",
-          "range": "bytes=696-1054"
+          "checksum": "sha1-0iHLABsXtuH2JyExQ2IIxH1NUCI=",
+          "range": "bytes=698-1041"
         },
         "data": {
-          "checksum": "sha256-GT22MF6hR+Tj4el5xk2QEwNWig5JRoOrZ60Lecz+lok=",
-          "range": "bytes=1055-408851"
+          "checksum": "sha256-A3RF8XLSIePkapCnvEridXa2N7nheKNT1kTKDqZlGdI=",
+          "range": "bytes=1042-408849"
         },
         "name": "glibc-locale-posix",
         "signature": {
-          "checksum": "sha1-9uPIvcOCeZbPiR7+MLDB4tkJlHo=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-QqrJFnJmyPeT66hUk3O7NxaWY8I=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1YLxq+Z9/+aFnCwvgV7acVLT4QFA=",
+        "checksum": "Q1JYf1zI1zVi/S9sMI32guk6ptuRQ=",
         "control": {
-          "checksum": "sha1-YLxq+Z9/+aFnCwvgV7acVLT4QFA=",
-          "range": "bytes=701-1330"
+          "checksum": "sha1-JYf1zI1zVi/S9sMI32guk6ptuRQ=",
+          "range": "bytes=701-1308"
         },
         "data": {
-          "checksum": "sha256-9s5RNfAJ3GVt7a/fFUaew5MfYYUkvL/6FMvsEfD95jY=",
-          "range": "bytes=1331-5862057"
+          "checksum": "sha256-ioC8korS2nJpJvoS6He+mKkDsgVLcMxiEuYLsAB9M7U=",
+          "range": "bytes=1309-5959239"
         },
         "name": "glibc",
         "signature": {
-          "checksum": "sha1-Kvfb+I/1PCfiBTjoaU4ezZa0b+8=",
+          "checksum": "sha1-3TP2+cHjCEBrIFluCdTmr2oJA1s=",
           "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Zjfs1uR/mYiortANP+EFcejW+vo=",
+        "checksum": "Q1WAlPh7UNBV+RHfBixVB5P9F9Mp8=",
         "control": {
-          "checksum": "sha1-Zjfs1uR/mYiortANP+EFcejW+vo=",
-          "range": "bytes=698-1085"
+          "checksum": "sha1-WAlPh7UNBV+RHfBixVB5P9F9Mp8=",
+          "range": "bytes=700-1074"
         },
         "data": {
-          "checksum": "sha256-BMd7TzffjbrFwdbopDPVYsX0X9XnusIMNbIf33/8kwc=",
-          "range": "bytes=1086-76881"
+          "checksum": "sha256-i6uEFvUEbJ4YzgNSV58aObIdU608mjbCVPwyF57ZeQQ=",
+          "range": "bytes=1075-81593"
         },
         "name": "protobuf-c",
         "signature": {
-          "checksum": "sha1-efGiXyYWsJ5P2uTkB6aXEZ3kl3o=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-47zwDXmhcWiVtTYCjq4sFld8wHQ=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r4.apk",
-        "version": "1.5.0-r4"
-      },
-      {
-        "architecture": "x86_64",
-        "checksum": "Q1Xf5v5uXumBgIR4d4ZxMRxdpyWlM=",
-        "control": {
-          "checksum": "sha1-Xf5v5uXumBgIR4d4ZxMRxdpyWlM=",
-          "range": "bytes=698-1078"
-        },
-        "data": {
-          "checksum": "sha256-eD7HqFCWNUBQiLq9PcWE/zPeZwkiv8hBrytI4qmfQ/8=",
-          "range": "bytes=1079-57055"
-        },
-        "name": "keyutils-libs",
-        "signature": {
-          "checksum": "sha1-V0HVgZLP7P5kNACfus3abCLCS20=",
-          "range": "bytes=0-697"
-        },
-        "url": "https://packages.wolfi.dev/os/x86_64/keyutils-libs-1.6.3-r2.apk",
-        "version": "1.6.3-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/protobuf-c-1.5.0-r6.apk",
+        "version": "1.5.0-r6"
       },
       {
         "architecture": "x86_64",
@@ -166,22 +147,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1wRzOx+L6MeRFtTcq2y/6ot7Cj54=",
+        "checksum": "Q1v0A2vQM5k8rQY/GpIq6xI4T0YmA=",
         "control": {
-          "checksum": "sha1-wRzOx+L6MeRFtTcq2y/6ot7Cj54=",
-          "range": "bytes=699-1069"
+          "checksum": "sha1-v0A2vQM5k8rQY/GpIq6xI4T0YmA=",
+          "range": "bytes=701-1064"
         },
         "data": {
-          "checksum": "sha256-gNRjwZ4XQatCYWediSVb+j8lS54CggvMC5Dn3qT84So=",
-          "range": "bytes=1070-61490"
+          "checksum": "sha256-uAOrkGDDc/yqt6VjIrlTEALBJG4BCI4njqZw5jQqF0o=",
+          "range": "bytes=1065-56984"
+        },
+        "name": "keyutils-libs",
+        "signature": {
+          "checksum": "sha1-32uYMH/zGBr9Jo3hiqnThlcqBcE=",
+          "range": "bytes=0-700"
+        },
+        "url": "https://packages.wolfi.dev/os/x86_64/keyutils-libs-1.6.3-r3.apk",
+        "version": "1.6.3-r3"
+      },
+      {
+        "architecture": "x86_64",
+        "checksum": "Q1Onuac6Y+IWA7a4b8FvqX1erWDDw=",
+        "control": {
+          "checksum": "sha1-Onuac6Y+IWA7a4b8FvqX1erWDDw=",
+          "range": "bytes=693-1048"
+        },
+        "data": {
+          "checksum": "sha256-KLtDAs3iU0oyZ/FysePG/J+1H1ofDxHXIY7xvtZhtMc=",
+          "range": "bytes=1049-61503"
         },
         "name": "libverto",
         "signature": {
-          "checksum": "sha1-kuPwakYdy5EM6sd5Ba0K0Ta8x4w=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-/IXL9S1O+MwaW7KsSzz1ywEqKFQ=",
+          "range": "bytes=0-692"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libverto-0.3.2-r3.apk",
-        "version": "0.3.2-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/libverto-0.3.2-r4.apk",
+        "version": "0.3.2-r4"
       },
       {
         "architecture": "x86_64",
@@ -204,60 +204,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1gTZGkWP+QO3mUqLVJth8vrDEzzU=",
+        "checksum": "Q1a5wJzZI7k9o4F8hHFpfuqAUIH5Q=",
         "control": {
-          "checksum": "sha1-gTZGkWP+QO3mUqLVJth8vrDEzzU=",
-          "range": "bytes=699-1076"
+          "checksum": "sha1-a5wJzZI7k9o4F8hHFpfuqAUIH5Q=",
+          "range": "bytes=710-1075"
         },
         "data": {
-          "checksum": "sha256-/IFXqeKvU0GODNsz1yPIEMcFHgABT+8rbZpSlTLo4e4=",
-          "range": "bytes=1077-5915704"
+          "checksum": "sha256-2p1UC4F4Odfxup/J/nyzujYRGaxGVjBOBWoc0aajClI=",
+          "range": "bytes=1076-5903889"
         },
         "name": "libcrypto3",
         "signature": {
-          "checksum": "sha1-l1o5ixkyWWqqJE3FOfR0QUemJUA=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-SOFoklqXtH38i1PcI3G/cPdRFtY=",
+          "range": "bytes=0-709"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.0-r9.apk",
-        "version": "3.3.0-r9"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.3.1-r4.apk",
+        "version": "3.3.1-r4"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1jhAhggAuZnU7FFHnebGA26mq+jI=",
+        "checksum": "Q1gb2VyLOsGV7xUiHBT0Ypt64rw6Y=",
         "control": {
-          "checksum": "sha1-jhAhggAuZnU7FFHnebGA26mq+jI=",
-          "range": "bytes=695-1079"
+          "checksum": "sha1-gb2VyLOsGV7xUiHBT0Ypt64rw6Y=",
+          "range": "bytes=702-1071"
         },
         "data": {
-          "checksum": "sha256-XTCQYnhGSm7SkGwqV/TQMFqGajVJVYhKAidKfLb2D3Y=",
-          "range": "bytes=1080-1197081"
+          "checksum": "sha256-h2tz/aFB2n8SFdBFde5foQm1ru+8JUcGp+trUeA2ZlQ=",
+          "range": "bytes=1072-1188954"
         },
         "name": "libssl3",
         "signature": {
-          "checksum": "sha1-qVrfDVxubkrb5Yrd2mFTv2A0G7k=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-w6U2Pb1Y90u1iBFc/sHg2xn6Qmo=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.0-r9.apk",
-        "version": "3.3.0-r9"
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.3.1-r4.apk",
+        "version": "3.3.1-r4"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1BQEXaeya6QB39QLeKcB99qBNF2o=",
+        "checksum": "Q1p04MrHQPrXOzuV/uF290zjnltqI=",
         "control": {
-          "checksum": "sha1-BQEXaeya6QB39QLeKcB99qBNF2o=",
-          "range": "bytes=699-1229"
+          "checksum": "sha1-p04MrHQPrXOzuV/uF290zjnltqI=",
+          "range": "bytes=704-1219"
         },
         "data": {
-          "checksum": "sha256-ugj/qGEBzhvdX17S22Anry+biy3lcqywhGMSHLIBCvo=",
-          "range": "bytes=1230-2551676"
+          "checksum": "sha256-TsXeqhUGykAhjQUEAlMUSzDQBcWDkkDvReoeHCL1F6c=",
+          "range": "bytes=1220-2555814"
         },
         "name": "krb5-libs",
         "signature": {
-          "checksum": "sha1-oqDPmNM4EngXAGayd/BZOqJAIao=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-cPyzS38QHuNlOCQb8IPlsl2PLHQ=",
+          "range": "bytes=0-703"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/krb5-libs-1.21.2-r2.apk",
-        "version": "1.21.2-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/krb5-libs-1.21.3-r0.apk",
+        "version": "1.21.3-r0"
       },
       {
         "architecture": "x86_64",
@@ -280,60 +280,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1wzZwtLauOQfLQC7YUvZdfKxtlwQ=",
+        "checksum": "Q17uprcuQ2VFudMcWAwtP7miJmLYs=",
         "control": {
-          "checksum": "sha1-wzZwtLauOQfLQC7YUvZdfKxtlwQ=",
-          "range": "bytes=698-1085"
+          "checksum": "sha1-7uprcuQ2VFudMcWAwtP7miJmLYs=",
+          "range": "bytes=695-1067"
         },
         "data": {
-          "checksum": "sha256-TO8CAULO44s/LphhtcaFOGJB7aFldk13v1cV9ceZHww=",
-          "range": "bytes=1086-276837"
+          "checksum": "sha256-unKdPbvO2VHZ5w1t1l8mOpQuNdUGwLhofEO4weN2Mig=",
+          "range": "bytes=1068-280973"
         },
         "name": "libuv",
         "signature": {
-          "checksum": "sha1-LRiyeKmjexy8CJizLxjd6ikon1w=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-4lKldnTO71WHMZ4tbANz6i2/Ed0=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libuv-1.48.0-r2.apk",
-        "version": "1.48.0-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libuv-1.48.0-r3.apk",
+        "version": "1.48.0-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q14S6biy8fc5OGbGEJoLBM+tJOGyo=",
+        "checksum": "Q1CN6zJbOPznWUfTrb/41KT7E6dm8=",
         "control": {
-          "checksum": "sha1-4S6biy8fc5OGbGEJoLBM+tJOGyo=",
-          "range": "bytes=703-1102"
+          "checksum": "sha1-CN6zJbOPznWUfTrb/41KT7E6dm8=",
+          "range": "bytes=699-1083"
         },
         "data": {
-          "checksum": "sha256-hwjdLQYfuMAGQeONmFVo0lZKKQK1S+3PBhrI3upm5W4=",
-          "range": "bytes=1103-155304"
+          "checksum": "sha256-ybzFzoQh1yNTcd3cjt54nYsPlAxAcMUcVMxEv1JRnpQ=",
+          "range": "bytes=1084-155375"
         },
         "name": "zlib",
         "signature": {
-          "checksum": "sha1-ZuLd7kE+AGhn27o8ZqDGM5eundc=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-CPXJcCjinAXP+H8Z5tkko8ayG6E=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/zlib-1.3.1-r2.apk",
-        "version": "1.3.1-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/zlib-1.3.1-r3.apk",
+        "version": "1.3.1-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ykDkP+AmDi2VcZZ1c4q4sez/DxI=",
+        "checksum": "Q1rgbci8SRSjW7EB0NSh6ZUPJLndM=",
         "control": {
-          "checksum": "sha1-ykDkP+AmDi2VcZZ1c4q4sez/DxI=",
-          "range": "bytes=705-1079"
+          "checksum": "sha1-rgbci8SRSjW7EB0NSh6ZUPJLndM=",
+          "range": "bytes=702-1060"
         },
         "data": {
-          "checksum": "sha256-t3BrH7lWfY3to3Fu3EKAMZx29v9Hnl5seyXJzLmZ9/4=",
-          "range": "bytes=1080-251884"
+          "checksum": "sha256-tf4xbo+NP+ssiaZtC1kOKehffAZ3+d17bhgfU3/30+g=",
+          "range": "bytes=1061-256582"
         },
         "name": "libnghttp2-14",
         "signature": {
-          "checksum": "sha1-CotSXRaPLKQCBRHrgzrDOD+4w20=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-KrsJYTyUsll+EUhHekbkdZFzeig=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.62.1-r0.apk",
-        "version": "1.62.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.62.1-r1.apk",
+        "version": "1.62.1-r1"
       },
       {
         "architecture": "x86_64",
@@ -356,174 +356,174 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1gfqHM/7r3rXX1HqC163slTPP46o=",
+        "checksum": "Q1DLAp18ebMscosnQ4TfTivIzgtCY=",
         "control": {
-          "checksum": "sha1-gfqHM/7r3rXX1HqC163slTPP46o=",
-          "range": "bytes=704-1101"
+          "checksum": "sha1-DLAp18ebMscosnQ4TfTivIzgtCY=",
+          "range": "bytes=698-1079"
         },
         "data": {
-          "checksum": "sha256-OR7ikvfUYp78EsP0I2kuwqqAcy05jw9tr7JVQ6jTnGQ=",
-          "range": "bytes=1102-185433"
+          "checksum": "sha256-eiBdqqECWnULWGe/Gnd6iv/7h56A4xR2qw+5toY5Gaw=",
+          "range": "bytes=1080-185559"
         },
         "name": "libgcc",
         "signature": {
-          "checksum": "sha1-Il4pyVzI6eqNd/f4bsKeakpB5DI=",
-          "range": "bytes=0-703"
+          "checksum": "sha1-qVj9laNeBIwRxP+8ehB+fXftJrw=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.2.0-r7.apk",
-        "version": "13.2.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r0.apk",
+        "version": "13.3.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1c+lykdx+yHoqsrQmQLHMV7waR1Q=",
+        "checksum": "Q1p9aaHhpB2Ud0URrcIrVRAujMw+o=",
         "control": {
-          "checksum": "sha1-c+lykdx+yHoqsrQmQLHMV7waR1Q=",
-          "range": "bytes=701-1119"
+          "checksum": "sha1-p9aaHhpB2Ud0URrcIrVRAujMw+o=",
+          "range": "bytes=696-1097"
         },
         "data": {
-          "checksum": "sha256-CuZi2C5g0vUnz4PNH8jIWV+EBdVMvHr+sNKFYTSnQZk=",
-          "range": "bytes=1120-3155369"
+          "checksum": "sha256-rGMnyLiGEDCEVgqA1oXMf28QHuWHAaPzYrLeDzQ3WOU=",
+          "range": "bytes=1098-3155519"
         },
         "name": "libstdc++",
         "signature": {
-          "checksum": "sha1-7l8MLj8aCcdqta/0sR+0PscBsD4=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-lge2XoAsgvp8U6ZBgT52N2xNQAw=",
+          "range": "bytes=0-695"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.2.0-r7.apk",
-        "version": "13.2.0-r7"
+        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r0.apk",
+        "version": "13.3.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1DE49kWSnmqVKJdjHFYC1bLkvyb0=",
+        "checksum": "Q1DUpLMidX5HbXUAFV8y3Imyt+Ank=",
         "control": {
-          "checksum": "sha1-DE49kWSnmqVKJdjHFYC1bLkvyb0=",
-          "range": "bytes=697-1078"
+          "checksum": "sha1-DUpLMidX5HbXUAFV8y3Imyt+Ank=",
+          "range": "bytes=698-1063"
         },
         "data": {
-          "checksum": "sha256-uDg8Qc6Rnro/68Vb5ufFSkqFLGrEsbvPb0pMJNvT1zw=",
-          "range": "bytes=1079-242085"
+          "checksum": "sha256-ZUDWWOBnxl5xi3b5HQCHaiYqKDSrnVpJQgavWpn1duc=",
+          "range": "bytes=1064-255810"
         },
         "name": "c-ares",
         "signature": {
-          "checksum": "sha1-iYEm6EWQKzxkeoDm+QsRfhw8pDg=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-0AXk7b/B1baNADDg/NSocbW//pw=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.29.0-r0.apk",
-        "version": "1.29.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.32.1-r0.apk",
+        "version": "1.32.1-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q12eWmn2tCkXxwncU6gagKM3Wd9Sk=",
+        "checksum": "Q1g2RQKAvNjlRPxWjinIRveaq7IlY=",
         "control": {
-          "checksum": "sha1-2eWmn2tCkXxwncU6gagKM3Wd9Sk=",
-          "range": "bytes=696-1169"
+          "checksum": "sha1-g2RQKAvNjlRPxWjinIRveaq7IlY=",
+          "range": "bytes=695-1154"
         },
         "data": {
-          "checksum": "sha256-IFKNdojOhml3DbWPryQuHUiV3tgTWHyqOYD1JNe9IJ4=",
-          "range": "bytes=1170-2582015"
+          "checksum": "sha256-UsQFfOTXCZBan0mxDvR+ts0NKcbv1lNijxnRxjsmZhA=",
+          "range": "bytes=1155-2566233"
         },
         "name": "nghttp2",
         "signature": {
-          "checksum": "sha1-2/9n7KbRuOkrvhYqCFR5Mblx+z8=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-SUvMhz1cc5Or5Qh4fUEvPCp0NAw=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.62.1-r0.apk",
-        "version": "1.62.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-1.62.1-r1.apk",
+        "version": "1.62.1-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ialksjwPWvvZW+O2ABMbbBV/KTg=",
+        "checksum": "Q1sTMGOgdbZyDKxlRAByisPMHTbpY=",
         "control": {
-          "checksum": "sha1-ialksjwPWvvZW+O2ABMbbBV/KTg=",
-          "range": "bytes=702-1074"
+          "checksum": "sha1-sTMGOgdbZyDKxlRAByisPMHTbpY=",
+          "range": "bytes=703-1060"
         },
         "data": {
-          "checksum": "sha256-+ctDr3AO9mTXovGRPWk6h2ZgfY99Toy6esjBNHtJPY4=",
-          "range": "bytes=1075-631903"
+          "checksum": "sha256-bUy0h/zxpq7iP6vrQRMftZ9nevkHTB87hSX17wz4lmM=",
+          "range": "bytes=1061-631449"
         },
         "name": "nghttp2-dev",
         "signature": {
-          "checksum": "sha1-wZGQRluFd6DL1USzeak75o5/BTc=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-fQ6aDq3Io/gdJ5s5t3M+FwED1Y0=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.62.1-r0.apk",
-        "version": "1.62.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp2-dev-1.62.1-r1.apk",
+        "version": "1.62.1-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1MlpRL1nBMU3RgNdSZVB42/vlGME=",
+        "checksum": "Q1rD3dEbbN8s5QAIQK1I8uF1O+oSo=",
         "control": {
-          "checksum": "sha1-MlpRL1nBMU3RgNdSZVB42/vlGME=",
-          "range": "bytes=697-1164"
+          "checksum": "sha1-rD3dEbbN8s5QAIQK1I8uF1O+oSo=",
+          "range": "bytes=701-1154"
         },
         "data": {
-          "checksum": "sha256-RiEPDasBVtnThSxGqTCDvb4J7WXM9YRpJwfYZJ3JLbs=",
-          "range": "bytes=1165-2274746"
+          "checksum": "sha256-41W2IRSRALQijYojLaqAiSSN1uO7twatGn8jqEuCZUg=",
+          "range": "bytes=1155-1439872"
         },
         "name": "xz",
         "signature": {
-          "checksum": "sha1-3wMPFIUEVfkAs7QSENemZsnTLyE=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-lozWkVrKvSrd1SoM7Zv08YYG2pA=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/xz-5.4.6-r2.apk",
-        "version": "5.4.6-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/xz-5.6.2-r0.apk",
+        "version": "5.6.2-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1TS707T+cPGL7TYVHQBCJoWwHZ0E=",
+        "checksum": "Q1ORn/60iAvLcAgApXYoZzM6o0XSs=",
         "control": {
-          "checksum": "sha1-TS707T+cPGL7TYVHQBCJoWwHZ0E=",
-          "range": "bytes=706-1098"
+          "checksum": "sha1-ORn/60iAvLcAgApXYoZzM6o0XSs=",
+          "range": "bytes=703-1081"
         },
         "data": {
-          "checksum": "sha256-x18L706Vug5qDzq13SXuN/vGdVgzrqB06dW2DdgHGR4=",
-          "range": "bytes=1099-4541967"
+          "checksum": "sha256-Ya2Dn1VNYB21ZBD/jBCSx3SxZuJloJET5xkjX0s3Vt8=",
+          "range": "bytes=1082-4272708"
         },
         "name": "libxml2",
         "signature": {
-          "checksum": "sha1-BYhOxDos48sN8df8LMsSpROv2aw=",
-          "range": "bytes=0-705"
+          "checksum": "sha1-s5jaTwJdla4k4KK0KEk7AYbgdqs=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.12.7-r0.apk",
-        "version": "2.12.7-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.2-r0.apk",
+        "version": "2.13.2-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1wJPtj5XZtnPiVWGM5dsT+nyfWXc=",
+        "checksum": "Q1wbnfumlWEiJnVUsJBRcQjFD3U6I=",
         "control": {
-          "checksum": "sha1-wJPtj5XZtnPiVWGM5dsT+nyfWXc=",
-          "range": "bytes=705-1234"
+          "checksum": "sha1-wbnfumlWEiJnVUsJBRcQjFD3U6I=",
+          "range": "bytes=699-1222"
         },
         "data": {
-          "checksum": "sha256-sw+CjlpsjO01q6lqzXgHnniiJKn7bqOSNO6vNqdGc7I=",
-          "range": "bytes=1235-3873775"
+          "checksum": "sha256-IXMNbJjj3kTjkWVBIHVRfG3zJQY2r5Eslgh/3TpMSsE=",
+          "range": "bytes=1223-3886778"
         },
         "name": "bind-libs",
         "signature": {
-          "checksum": "sha1-9zDzmHAeu7mWpidXAatqrLZVzUs=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-JNN15IPpJ2hMsO6hFVpDYPvvX5g=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bind-libs-9.18.26-r0.apk",
-        "version": "9.18.26-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/bind-libs-9.18.27-r1.apk",
+        "version": "9.18.27-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1AxEQdi8fVcYtGc3zHTCW3OZdY2Q=",
+        "checksum": "Q1kXUOoNa2KXixxAASo1W/im1qZ7s=",
         "control": {
-          "checksum": "sha1-AxEQdi8fVcYtGc3zHTCW3OZdY2Q=",
-          "range": "bytes=694-1208"
+          "checksum": "sha1-kXUOoNa2KXixxAASo1W/im1qZ7s=",
+          "range": "bytes=702-1215"
         },
         "data": {
-          "checksum": "sha256-/dt3qJw5D9iSJ/mKkRQkhWD8R52selhpcwXyw7KLMhg=",
-          "range": "bytes=1209-879444"
+          "checksum": "sha256-HRADvfRXfYsgEjUMGM4Hd7prpIv+YWILVfovbGOkEME=",
+          "range": "bytes=1216-879975"
         },
         "name": "bind-tools",
         "signature": {
-          "checksum": "sha1-VTb0YdUzPMk8Po0p4nj0y5Jey6k=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-8WUTMUaJTaX0T9FS/c+GddL7ttY=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bind-tools-9.18.26-r0.apk",
-        "version": "9.18.26-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/bind-tools-9.18.27-r1.apk",
+        "version": "9.18.27-r1"
       },
       {
         "architecture": "x86_64",
@@ -546,22 +546,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1+0xClEzF5nhyNPUeGFhC++ElQmg=",
+        "checksum": "Q1u+fF2xg98dT0poYklte5HHMg/Kk=",
         "control": {
-          "checksum": "sha1-+0xClEzF5nhyNPUeGFhC++ElQmg=",
-          "range": "bytes=701-1107"
+          "checksum": "sha1-u+fF2xg98dT0poYklte5HHMg/Kk=",
+          "range": "bytes=701-1090"
         },
         "data": {
-          "checksum": "sha256-81V5R7T08up/3BwfuAG25Rq7KkB1MvALVCaogCpW500=",
-          "range": "bytes=1108-22181"
+          "checksum": "sha256-9e+i7LwSg7oAUU33f0r7A4Mc2suaK95iNU5BKaTSXac=",
+          "range": "bytes=1091-22179"
         },
         "name": "libcrypt1",
         "signature": {
-          "checksum": "sha1-k+7JfhPi5KOQ+6Nqk3oAfTbtOVM=",
+          "checksum": "sha1-EWBUcJqCJTOYJq1H0/kkO+m6W3E=",
           "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r6.apk",
-        "version": "2.39-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.39-r7.apk",
+        "version": "2.39-r7"
       },
       {
         "architecture": "x86_64",
@@ -622,60 +622,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1fr0OtiVaD3c5nw8fy5m74hDe9PU=",
+        "checksum": "Q1BRGmQ9LZTeZqbxQ1ls69T6efViw=",
         "control": {
-          "checksum": "sha1-fr0OtiVaD3c5nw8fy5m74hDe9PU=",
-          "range": "bytes=697-1092"
+          "checksum": "sha1-BRGmQ9LZTeZqbxQ1ls69T6efViw=",
+          "range": "bytes=698-1080"
         },
         "data": {
-          "checksum": "sha256-lukjMYpGmuhBNDUbbTJMIrUWaR4rNikEnW4BgiTaLj8=",
-          "range": "bytes=1093-113872"
+          "checksum": "sha256-vtJ4WJ5M+31ZKSBYBedbrl/FrbAw8hGpPRrHC7kasOk=",
+          "range": "bytes=1081-113895"
         },
         "name": "libpsl",
         "signature": {
-          "checksum": "sha1-Lrrudgn1i1a0JhjdzeXG+exnjQA=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-DuAoiykwhu8vu1qxdEDK5oyAmf8=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libpsl-0.21.5-r2.apk",
-        "version": "0.21.5-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libpsl-0.21.5-r3.apk",
+        "version": "0.21.5-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1oauHQa0YcFcEHSQWdfohfNEN4sY=",
+        "checksum": "Q11DZVpe2UYyDr/dG6BDysZhE3L48=",
         "control": {
-          "checksum": "sha1-oauHQa0YcFcEHSQWdfohfNEN4sY=",
-          "range": "bytes=698-1057"
+          "checksum": "sha1-1DZVpe2UYyDr/dG6BDysZhE3L48=",
+          "range": "bytes=707-1049"
         },
         "data": {
-          "checksum": "sha256-d95c9lpjQrpuZ1CcQ8ZZ89LAGGKcessd+hxrOQpP4LU=",
-          "range": "bytes=1058-173549"
+          "checksum": "sha256-aECfsy7giZsLNxZM0HMeF4OS2gu+ycX4DUTJXsiZRQs=",
+          "range": "bytes=1050-173585"
         },
         "name": "libbrotlicommon1",
         "signature": {
-          "checksum": "sha1-g3ufBq/tyiNP6AaOoqwItVvh7uk=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-7LXD38QwFhklZCEqyW4qIncfZV0=",
+          "range": "bytes=0-706"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlicommon1-1.1.0-r2.apk",
-        "version": "1.1.0-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlicommon1-1.1.0-r3.apk",
+        "version": "1.1.0-r3"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q18Otq7NLoYnNMebI/1Rr/s0zdLVw=",
+        "checksum": "Q1Cgr886A8Ryzynz9pxRKsNybVuK0=",
         "control": {
-          "checksum": "sha1-8Otq7NLoYnNMebI/1Rr/s0zdLVw=",
-          "range": "bytes=705-1072"
+          "checksum": "sha1-Cgr886A8Ryzynz9pxRKsNybVuK0=",
+          "range": "bytes=694-1043"
         },
         "data": {
-          "checksum": "sha256-sR3QidR/e46PJ/3S2fxAjN/hRSSA3Ar32Nw7VshTHWg=",
-          "range": "bytes=1073-81475"
+          "checksum": "sha256-mH+MTbqpLiqgydlgE+tSDEt0Sh1/zqMvAqspV4lr+Ks=",
+          "range": "bytes=1044-81511"
         },
         "name": "libbrotlidec1",
         "signature": {
-          "checksum": "sha1-6GpZI5cBUXOvjCYG81aZZR53lMI=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-Yp4Bde9oHQCec8HM2qn6hVKgtko=",
+          "range": "bytes=0-693"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlidec1-1.1.0-r2.apk",
-        "version": "1.1.0-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlidec1-1.1.0-r3.apk",
+        "version": "1.1.0-r3"
       },
       {
         "architecture": "x86_64",
@@ -736,22 +736,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1rbqSkkmmv1u0qIlXaMJlECAL++8=",
+        "checksum": "Q1RWU8dFiWCX33/o5LdX/jng/cB+I=",
         "control": {
-          "checksum": "sha1-rbqSkkmmv1u0qIlXaMJlECAL++8=",
-          "range": "bytes=662-1056"
+          "checksum": "sha1-RWU8dFiWCX33/o5LdX/jng/cB+I=",
+          "range": "bytes=663-1060"
         },
         "data": {
-          "checksum": "sha256-JExtSd5jJ++EltuXBoPUSVrpPHvTzLW0EDtiqQSCU8c=",
-          "range": "bytes=1057-102062736"
+          "checksum": "sha256-ad8M+THg/r8RODDz2gI0lWe6vJdt/mKTWijOEH4iI0E=",
+          "range": "bytes=1061-106162840"
         },
         "name": "opentelemetry-collector",
         "signature": {
-          "checksum": "sha1-JHLXe7uu3KaUeeqxCaRx8ob8Zgk=",
-          "range": "bytes=0-661"
+          "checksum": "sha1-om9BmmNl44S5Z8fIkaiDLKMLThw=",
+          "range": "bytes=0-662"
         },
-        "url": "https://packages.sgdev.org/main/x86_64/opentelemetry-collector-0.92.0-r7.apk",
-        "version": "0.92.0-r7"
+        "url": "https://packages.sgdev.org/main/x86_64/opentelemetry-collector-0.103.0-r9.apk",
+        "version": "0.103.0-r9"
       },
       {
         "architecture": "x86_64",
@@ -774,22 +774,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q19f/3419Xa/xv9jgQ0mMYs011fBk=",
+        "checksum": "Q1mTmy64gKYi4THBqewuvYL2uUyHc=",
         "control": {
-          "checksum": "sha1-9f/3419Xa/xv9jgQ0mMYs011fBk=",
-          "range": "bytes=696-1041"
+          "checksum": "sha1-mTmy64gKYi4THBqewuvYL2uUyHc=",
+          "range": "bytes=700-1031"
         },
         "data": {
-          "checksum": "sha256-iqHASiMgiu6rIjbWGwBmmq1Zthae8BkE4QZkiVPH7Ek=",
-          "range": "bytes=1042-1888945"
+          "checksum": "sha256-p0qua2luH33oAgOcLkU9f7k+I8WnykFszVMwNahujDA=",
+          "range": "bytes=1032-1889523"
         },
         "name": "tzdata",
         "signature": {
-          "checksum": "sha1-PCC3jiXlTwrimRMXH/4RyNvccOM=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-sBf5jVLVpWj4DiXaAd/mjo0pTfk=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/tzdata-2024a-r2.apk",
-        "version": "2024a-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/tzdata-2024a-r3.apk",
+        "version": "2024a-r3"
       },
       {
         "architecture": "x86_64",


### PR DESCRIPTION
<!-- PR description tips: https://www.notion.so/sourcegraph/Write-a-good-pull-request-description-610a7fd3e613496eb76f450db5a49b6e -->
We need to update the wolfi lock image for https://github.com/sourcegraph/sourcegraph/pull/63171 in order for `sg run` to work

We've made all the changes to the deployment repos for this to be pushed out in the release today. 

## Test plan

<!-- REQUIRED; info at https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles -->
Manually tested

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
- fix(build): update wolfi lock for otel-collector
