### PR TITLE
Add more Completions handler tests

### DIFF
--- a/cmd/frontend/internal/httpapi/completions/BUILD.bazel
+++ b/cmd/frontend/internal/httpapi/completions/BUILD.bazel
@@ -56,6 +56,7 @@ go_test(
     name = "completions_test",
     srcs = [
         "entconfig_anthropic_test.go",
+        "entconfig_awsbedrock_test.go",
         "entconfig_azureopenai_test.go",
         "entconfig_base_test.go",
         "get_model_test.go",

--- a/cmd/frontend/internal/httpapi/completions/BUILD.bazel
+++ b/cmd/frontend/internal/httpapi/completions/BUILD.bazel
@@ -56,6 +56,7 @@ go_test(
     name = "completions_test",
     srcs = [
         "entconfig_anthropic_test.go",
+        "entconfig_azureopenai_test.go",
         "entconfig_base_test.go",
         "get_model_test.go",
         "handler_test.go",
@@ -69,9 +70,11 @@ go_test(
     deps = [
         "//cmd/frontend/internal/modelconfig",
         "//internal/actor",
+        "//internal/completions/client/azureopenai",
         "//internal/completions/types",
         "//internal/conf",
         "//internal/conf/conftypes",
+        "//internal/database",
         "//internal/database/dbmocks",
         "//internal/featureflag",
         "//internal/httpcli",

--- a/cmd/frontend/internal/httpapi/completions/entconfig_awsbedrock_test.go
+++ b/cmd/frontend/internal/httpapi/completions/entconfig_awsbedrock_test.go
@@ -1,0 +1,154 @@
+package completions
+
+import (
+	"testing"
+
+	"github.com/sourcegraph/sourcegraph/internal/completions/types"
+	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
+	"github.com/sourcegraph/sourcegraph/lib/pointers"
+	"github.com/sourcegraph/sourcegraph/schema"
+)
+
+func testAPIProviderAWSBedrock(t *testing.T, infra *apiProviderTestInfra) {
+
+	// getValidTestData returns a valid test scenario for the AWS Bedrock LLM provider.
+	getValidTestData := func() completionsRequestTestData {
+		initialSiteConfig := schema.SiteConfiguration{
+			CodyEnabled:                  pointers.Ptr(true),
+			CodyPermissions:              pointers.Ptr(false),
+			CodyRestrictUsersFeatureFlag: pointers.Ptr(false),
+
+			// Use a config WITHOUT Provisioned Throughput.
+			Completions: &schema.Completions{
+				Provider: string(conftypes.CompletionsProviderNameAWSBedrock),
+
+				AccessToken: "<ACCESS_KEY_ID>:<SECRET_ACCESS_KEY>:<SESSION_TOKEN>",
+				Endpoint:    "us-west-2",
+
+				ChatModel:       "anthropic.claude-3-opus-20240229-v1:0",
+				CompletionModel: "anthropic.claude-instant-v1",
+				FastChatModel:   "anthropic.claude-3-opus-20240229-v1_FAST:0",
+			},
+		}
+
+		// Request from the end user.
+		userCompletionRequest := types.CodyCompletionRequestParameters{
+			CompletionRequestParameters: types.CompletionRequestParameters{
+				Messages: []types.Message{
+					{
+						Speaker: "human",
+						Text:    "please make this code better",
+					},
+				},
+				Stream: pointers.Ptr(false),
+			},
+		}
+
+		// The request made to AWS Bedrock. The LLM model to use isn't included in the payload,
+		// instead it is embedded in the request URL.
+		wantRequestToBedrock := map[string]any{
+			"anthropic_version": "bedrock-2023-05-31",
+			// This is hard-coded in our Bedrock client, as the default if
+			// requestParams.MaxTokensToSample is unset.
+			"max_tokens": 300,
+			"messages": []map[string]any{
+				{
+					"role": "user",
+					"content": []map[string]any{
+						{
+							"type": "text",
+							"text": "please make this code better",
+						},
+					},
+				},
+			},
+		}
+		const wantRequestToBedrockPath = "/model/anthropic.claude-3-opus-20240229-v1:0/invoke"
+
+		responseFromBedrock := map[string]any{
+			"content": []map[string]string{
+				{
+					"speak": "user",
+					"text":  "A rewrite in Rust is the only option.",
+				},
+			},
+			"usage": map[string]int{
+				"input_token":   100,
+				"output_tokens": 200,
+			},
+			"stop_reason": "max_tokens",
+		}
+
+		wantCompletionsResponse := types.CompletionResponse{
+			Completion: "A rewrite in Rust is the only option.",
+			StopReason: "max_tokens",
+			Logprobs:   nil,
+		}
+
+		return completionsRequestTestData{
+			SiteConfig:                   initialSiteConfig,
+			UserCompletionRequest:        userCompletionRequest,
+			WantRequestToLLMProvider:     wantRequestToBedrock,
+			WantRequestToLLMProviderPath: wantRequestToBedrockPath,
+			ResponseFromLLMProvider:      responseFromBedrock,
+			WantCompletionResponse:       wantCompletionsResponse,
+		}
+	}
+
+	t.Run("TestDataIsValid", func(t *testing.T) {
+		// Just confirm that the stock test data works as expected,
+		// without any test-specific modifications.
+		data := getValidTestData()
+		runCompletionsTest(t, infra, data)
+	})
+
+	t.Run("ProvisionedThroughput", func(t *testing.T) {
+		const (
+			priovisionedThroughputARN = "arn:aws:bedrock:us-west-2:012345678901:provisioned-model/abcdefghijkl"
+			// The chat model encodes the model name and provisioned throughput ARN.
+			chatModelInConfig = "anthropic.claude-3-haiku-20240307-v1:0-100k/" + priovisionedThroughputARN
+			// Just a regular model name.
+			fastChatModelInConfig = "anthropic.claude-v2-fastchat"
+
+			accessTokenInConfig = "<ACCESS_KEY_ID>:<SECRET_ACCESS_KEY>:<SESSION_TOKEN>"
+			endpointInConfig    = "https://vpce-0a10b2345cd67e89f-abc0defg.bedrock-runtime.us-west-2.vpce.amazonaws.com"
+		)
+
+		getProvisionedThroughputSiteConfig := func() *schema.Completions {
+
+			return &schema.Completions{
+				Provider:    string(conftypes.CompletionsProviderNameAWSBedrock),
+				AccessToken: accessTokenInConfig,
+				Endpoint:    endpointInConfig,
+
+				ChatModel:       chatModelInConfig,
+				CompletionModel: "unused",
+				FastChatModel:   fastChatModelInConfig,
+			}
+		}
+
+		t.Run("Chat", func(t *testing.T) {
+			data := getValidTestData()
+			data.SiteConfig.Completions = getProvisionedThroughputSiteConfig()
+
+			// The chat model is using provisioned throughput, so the
+			// URLs are different.
+			data.WantRequestToLLMProviderPath = "/model/arn:aws:bedrock:us-west-2:012345678901:provisioned-model/abcdefghijkl/invoke"
+
+			runCompletionsTest(t, infra, data)
+		})
+
+		t.Run("FastChat", func(t *testing.T) {
+			data := getValidTestData()
+			data.SiteConfig.Completions = getProvisionedThroughputSiteConfig()
+
+			data.UserCompletionRequest.Fast = true
+
+			// The fast chat model does not have provisioned throughput, and
+			// so the request path to bedrock just has the model's name. (No ARN.)
+			data.WantRequestToLLMProviderPath = "/model/anthropic.claude-v2-fastchat/invoke"
+
+			runCompletionsTest(t, infra, data)
+		})
+	})
+}

--- a/cmd/frontend/internal/httpapi/completions/entconfig_azureopenai_test.go
+++ b/cmd/frontend/internal/httpapi/completions/entconfig_azureopenai_test.go
@@ -1,0 +1,127 @@
+package completions
+
+import (
+	"testing"
+
+	"github.com/sourcegraph/sourcegraph/internal/completions/types"
+	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
+	"github.com/sourcegraph/sourcegraph/lib/pointers"
+	"github.com/sourcegraph/sourcegraph/schema"
+)
+
+func testAPIProviderAzureOpenAI(t *testing.T, infra *apiProviderTestInfra) {
+
+	// getValidTestData returns a valid test scenario for the AzureOpenAI LLM provider.
+	getValidTestData := func() completionsRequestTestData {
+		initialSiteConfig := schema.SiteConfiguration{
+			CodyEnabled:                  pointers.Ptr(true),
+			CodyPermissions:              pointers.Ptr(false),
+			CodyRestrictUsersFeatureFlag: pointers.Ptr(false),
+
+			Completions: &schema.Completions{
+				Provider: string(conftypes.CompletionsProviderNameAzureOpenAI),
+
+				AccessToken: "horse-battery-staple",
+				Endpoint:    "https://endpoint-from-config.example.com",
+
+				ChatModel:       "deployment-id-1_chat",
+				CompletionModel: "deployment-id-2_completion",
+				FastChatModel:   "deployment-id-3_fastchat",
+
+				// Configure hooks to provide a friendly name for the opaque model names.
+				AzureChatModel:       "gpt-35-turbo_chat",
+				AzureCompletionModel: "gpt-35-turbo_completion",
+				// BUG: There is no way to express the FastChat model used.
+				User: "azure-user-string",
+			},
+		}
+
+		// Request from the end user.
+		userCompletionRequest := types.CodyCompletionRequestParameters{
+			CompletionRequestParameters: types.CompletionRequestParameters{
+				Messages: []types.Message{
+					{
+						Speaker: "human",
+						Text:    "please make this code better",
+					},
+				},
+				Stream: pointers.Ptr(false),
+			},
+		}
+
+		// azopenai.ChatCompletionsOptions. Although the actual JSON format is burried
+		// deep in the Azure SDK code.
+		wantRequestToAzureOpenAI := map[string]any{
+			"max_tokens": 0,
+			"messages": []map[string]any{
+				map[string]any{
+					"content": "please make this code better",
+					"role":    "user",
+				},
+			},
+			"model":       "deployment-id-1_chat",
+			"n":           1,
+			"temperature": 0,
+			"top_p":       0,
+			"user":        "azure-user-string",
+		}
+		const wantRequestToAzureOpenAIPath = "/openai/deployments/deployment-id-1_chat/chat/completions"
+
+		// azopenai.GetChatCompletionsResponse. Note that the way the SDK
+		// parses the HTTP response, the outermost "ChatCompletions" field
+		// is omitted. And all the field names are remapped to snake_case.
+		responseFromAzureOpenAI := map[string]any{
+			"id": "azure-id",
+			"choices": []map[string]any{
+				map[string]any{
+					"finish_reason": "stop", // CompletionsFinishReasonStop
+					"index":         100,
+					"log_probs":     nil,
+					"delta": map[string]any{
+						"content": "A rewrite in Rust is the only option.",
+					},
+				},
+			},
+			"usage": map[string]any{
+				"completion_tokens": 1,
+				"prompt_tokens":     2,
+				"total_tokens":      3,
+			},
+		}
+
+		wantCompletionsResponse := types.CompletionResponse{
+			Completion: "A rewrite in Rust is the only option.",
+			StopReason: "stop",
+			Logprobs:   nil,
+		}
+
+		return completionsRequestTestData{
+			SiteConfig:                   initialSiteConfig,
+			UserCompletionRequest:        userCompletionRequest,
+			WantRequestToLLMProvider:     wantRequestToAzureOpenAI,
+			WantRequestToLLMProviderPath: wantRequestToAzureOpenAIPath,
+			ResponseFromLLMProvider:      responseFromAzureOpenAI,
+			WantCompletionResponse:       wantCompletionsResponse,
+		}
+	}
+
+	t.Run("TestDataIsValid", func(t *testing.T) {
+		// Just confirm that the stock test data works as expected,
+		// without any test-specific modifications.
+		data := getValidTestData()
+		runCompletionsTest(t, infra, data)
+	})
+
+	t.Run("AzureSpecificConfigFlags", func(t *testing.T) {
+		// Customize the site configuration data and verify
+		// that the Azure-specific values are actually used.
+		data := getValidTestData()
+
+		compConfig := data.SiteConfig.Completions
+		compConfig.User = "some-other-azure-user"
+
+		data.WantRequestToLLMProvider["user"] = "some-other-azure-user"
+
+		runCompletionsTest(t, infra, data)
+	})
+}

--- a/cmd/frontend/internal/httpapi/completions/entconfig_base_test.go
+++ b/cmd/frontend/internal/httpapi/completions/entconfig_base_test.go
@@ -285,6 +285,7 @@ func TestAPIProviders(t *testing.T) {
 	}{
 		{"BasicConfigChecks", testBasicConfiguration},
 		{"APIProvider-Anthropic", testAPIProviderAnthropic},
+		{"APIProvider-AWSBedrock", testAPIProviderAWSBedrock},
 		{"APIProvider-AzureOpenAI", testAPIProviderAzureOpenAI},
 	}
 	for _, testSuite := range testSuites {

--- a/cmd/frontend/internal/httpapi/completions/entconfig_base_test.go
+++ b/cmd/frontend/internal/httpapi/completions/entconfig_base_test.go
@@ -15,8 +15,10 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/modelconfig"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
+	"github.com/sourcegraph/sourcegraph/internal/completions/client/azureopenai"
 	"github.com/sourcegraph/sourcegraph/internal/completions/types"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbmocks"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/internal/licensing"
@@ -47,6 +49,7 @@ func (c *mockDoer) Do(r *http.Request) (*http.Response, error) {
 // running an API provider test.
 type apiProviderTestInfra struct {
 	// Don't use these directly. Tests should just use the exported fields and functions.
+	mockDB                database.DB
 	chatCompletionHandler http.Handler
 	codeCompletionHandler http.Handler
 	mockGetModelFn        *mockGetModelFn
@@ -110,7 +113,16 @@ func (ti *apiProviderTestInfra) AssertCompletionsResponse(t *testing.T, rawRespo
 
 	var gotResponse types.CompletionResponse
 	err := json.Unmarshal([]byte(rawResponseJSON), &gotResponse)
-	require.NoError(t, err, "error unmarshalling JSON, full response:\n%s", rawResponseJSON)
+	if err != nil {
+		if strings.Contains(rawResponseJSON, "dial tcp: lookup") {
+			// If you see this error, it is because a "real" HTTP client was used. And not one which
+			// mas mocked out. So double check which HTTP client the LLM API Provider is using, and
+			// that the apiProviderTestInfra mocked it out correctly. (e.g. as part of the
+			// `AssertCodyGatewayReceivesRequestWithResponse` function.)
+			t.Log("HINT: It looks like the HTTP request wasn't mocked out. Did you mock out the right httpcli.Doer?")
+		}
+		t.Errorf("error unmarshalling JSON\nError: %s\nFull response body:\n%s", err.Error(), rawResponseJSON)
+	}
 
 	assert.Equal(t, wantResponse, gotResponse)
 }
@@ -149,9 +161,7 @@ func (ti *apiProviderTestInfra) AssertCodyGatewayReceivesRequestWithResponse(
 func (ti *apiProviderTestInfra) AssertGenericExternalAPIRequestWithResponse(
 	t *testing.T, opts assertLLMRequestOptions) {
 	initialDoer := httpcli.UncachedExternalDoer
-	t.Logf("Saving initialDoer which was %v", initialDoer)
 	t.Cleanup(func() {
-		t.Logf("Resetting initialDoer for generic external %v", initialDoer)
 		httpcli.UncachedExternalDoer = initialDoer
 	})
 	httpcli.UncachedExternalDoer = &mockDoer{
@@ -159,7 +169,6 @@ func (ti *apiProviderTestInfra) AssertGenericExternalAPIRequestWithResponse(
 			return ti.assertDoerReceivesRequestAndSendResponse(t, r, opts)
 		},
 	}
-	t.Logf("Replaced initialDoer for generic external to %v", httpcli.UncachedExternalDoer)
 }
 
 // assertDoerReceivesRequestAndSendResponse is an http.HandlerFunc that we hook into
@@ -201,7 +210,7 @@ func (ti *apiProviderTestInfra) assertDoerReceivesRequestAndSendResponse(
 
 	// Compare the incomming HTTP request matches what we expect.
 	assert.EqualValues(t, wantReqPayload, gotReqPayload,
-		"Comparing the raw vs. expected payloads:\nWant: %s\nGot : %s",
+		"Difference from the expected HTTP request body sent to 3rd party LLM provider:\nWant: %s\nGot : %s",
 		string(reqObjJSON), string(reqBodyJSON))
 
 	respObjJSON, err := json.Marshal(opts.OutResponseObj)
@@ -265,6 +274,7 @@ func TestAPIProviders(t *testing.T) {
 	testInfra := apiProviderTestInfra{
 		chatCompletionHandler: chatCompletionHandler,
 		codeCompletionHandler: codeCompletionHandler,
+		mockDB:                mockDB,
 		mockGetModelFn:        &mockGetModelFn,
 	}
 
@@ -274,7 +284,8 @@ func TestAPIProviders(t *testing.T) {
 		TestFn func(t *testing.T, infra *apiProviderTestInfra)
 	}{
 		{"BasicConfigChecks", testBasicConfiguration},
-		{"APIProviderAnthropic", testAPIProviderAnthropic},
+		{"APIProvider-Anthropic", testAPIProviderAnthropic},
+		{"APIProvider-AzureOpenAI", testAPIProviderAzureOpenAI},
 	}
 	for _, testSuite := range testSuites {
 		t.Run(testSuite.Name, func(t *testing.T) {
@@ -418,4 +429,89 @@ func testBasicConfiguration(t *testing.T, infra *apiProviderTestInfra) {
 			})
 		})
 	})
+}
+
+// completionsRequestTestData bundles the test data we wish to validate when exercising one of our
+// completion APIs. Tests are of the form:
+//
+// 1. Configure the local Sourcegraph instance to reflect the provided `SiteConfig`.
+// 2. Invoke the UserCompletionRequest, with the `GetModelFn` returning the supplied string.
+// 3. Verify that the outbound `WantRequestToLLMProvider` matches what is provided.
+// 4. Simulate `ResponseFromLLMProvider` being returned.
+// 5. Verify the completions handler returned the `WantCompletionsResponse` payload.
+type completionsRequestTestData struct {
+	// SiteConfig of the Sourcegraph instance.
+	SiteConfig schema.SiteConfiguration
+
+	// HTTP request the user sent to invoke the completions endpoint.
+	UserCompletionRequest types.CodyCompletionRequestParameters
+
+	// RequestToLLMProvider is the HTTP request that Sourcegraph will send to the
+	// 3rd party LLM Provider. e.g. AWS Bedrock, Fireworks, or even Cody Gateway.
+	//
+	// BUG: We describe this as a map[string]any instead of a generic type because in
+	// many cases the actual type isn't exported from the `internal/completions/client/...`
+	// package. But if we were to actually export types, this would be much easier to maintain.
+	WantRequestToLLMProvider map[string]any
+	// URL path we expect the request to be sent to, e.g. "/v1/chat/completions"
+	WantRequestToLLMProviderPath string
+	// ResponseFromLLMProvider is the HTTP response sent from the 3rd party LLM Provider.
+	ResponseFromLLMProvider map[string]any
+
+	// WantCompletionsResponse is the result we expect the Sourcegraph Completions API to
+	// return.
+	WantCompletionResponse types.CompletionResponse
+}
+
+func runCompletionsTest(t *testing.T, infra *apiProviderTestInfra, data completionsRequestTestData) {
+	ctx := context.Background()
+
+	// Set the site config.
+	infra.SetSiteConfig(t, data.SiteConfig)
+	compConfig := conf.GetCompletionsConfig(data.SiteConfig)
+
+	// When we make the completion request, the mocked getModelFn will be called.
+	// Assuming the test request is a chat completion, we just use the "real" function
+	// here.
+	{
+		realChatModelFn := getChatModelFn(infra.mockDB)
+		getModelResult, getModelErr := realChatModelFn(ctx, data.UserCompletionRequest, compConfig)
+		infra.PushGetModelResult(getModelResult, getModelErr)
+	}
+
+	// Register our hook to verify that the expected LLM request was sent out.
+	// The HTTP Client Doer we mock out is dependent on the API provider used.
+	//
+	// Since the mocked Doers are all cleaned up at the end of the testcase,
+	// we just register every possible one so things (hopefully) just work.
+	{
+		require.NotEmpty(t, data.WantRequestToLLMProviderPath)
+
+		infra.AssertCodyGatewayReceivesRequestWithResponse(
+			t, assertLLMRequestOptions{
+				WantRequestPath: data.WantRequestToLLMProviderPath,
+				WantRequestObj:  &data.WantRequestToLLMProvider,
+				OutResponseObj:  &data.ResponseFromLLMProvider,
+			})
+		infra.AssertGenericExternalAPIRequestWithResponse(
+			t, assertLLMRequestOptions{
+				WantRequestPath: data.WantRequestToLLMProviderPath,
+				WantRequestObj:  &data.WantRequestToLLMProvider,
+				OutResponseObj:  &data.ResponseFromLLMProvider,
+			})
+
+		// The Azure OpenAI SDK is a bit tricky to use. But we
+		// hook into the AzureAPI client that gets created and
+		// set it to the `UncachedExternalDoer` which was replaced
+		// with our mock in the earlier call.
+		azureopenai.MockAzureAPIClientTransport = httpcli.UncachedExternalDoer
+		t.Cleanup(func() {
+			azureopenai.MockAzureAPIClientTransport = nil
+		})
+	}
+
+	// With all of our mocks in-place, we now simulate making the HTTP request.
+	status, responseBody := infra.CallChatCompletionAPI(t, data.UserCompletionRequest)
+	assert.Equal(t, http.StatusOK, status)
+	infra.AssertCompletionsResponse(t, responseBody, data.WantCompletionResponse)
 }

--- a/internal/completions/client/azureopenai/BUILD.bazel
+++ b/internal/completions/client/azureopenai/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
         "//internal/completions/tokenizer",
         "//internal/completions/tokenusage",
         "//internal/completions/types",
+        "//internal/httpcli",
         "//lib/errors",
         "@com_github_azure_azure_sdk_for_go_sdk_ai_azopenai//:azopenai",
         "@com_github_azure_azure_sdk_for_go_sdk_azcore//:azcore",

--- a/internal/conf/computed_test.go
+++ b/internal/conf/computed_test.go
@@ -303,6 +303,23 @@ func TestCodyEnabled(t *testing.T) {
 			sc:   schema.SiteConfiguration{Completions: &schema.Completions{Enabled: pointers.Ptr(true), Model: "foobar"}},
 			want: true,
 		},
+		{
+			// Having the ModelConfiguration explicitly set will not be sufficient. The
+			// cody.enabled setting is still required.
+			name: "cody.enabled not set, modelconfig supplied",
+			sc: schema.SiteConfiguration{
+				ModelConfiguration: &schema.SiteModelConfiguration{},
+			},
+			want: false,
+		},
+		{
+			name: "cody.enabled not set, modelconfig supplied",
+			sc: schema.SiteConfiguration{
+				CodyEnabled:        pointers.Ptr(true),
+				ModelConfiguration: &schema.SiteModelConfiguration{},
+			},
+			want: true,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
This PR adds more unit tests for the "Chat Completions" HTTP endpoint. The goal is to have unit tests for more of the one-off quirks that we support today, so that we can catch any regressions when refactoring this code.

This PR adds _another layer_ of test infrastructure to use to streamline writing completion tests. (Since they are kinda involved, and are mocking out multiple interactions, it's kinda necessary.)

It introduces a new data type `completionsRequestTestData` which contains all of the "inputs" to the test case, as well as some of the things we want to validate.

```go
type completionsRequestTestData struct {
	SiteConfig schema.SiteConfiguration
	UserCompletionRequest types.CodyCompletionRequestParameters
	WantRequestToLLMProvider map[string]any
	WantRequestToLLMProviderPath string
	ResponseFromLLMProvider map[string]any
	WantCompletionResponse types.CompletionResponse
}
```

Then to run one of these tests, you just call the new function:

```go
func runCompletionsTest(t *testing.T, infra *apiProviderTestInfra, data completionsRequestTestData) {
```

With this, the new pattern for completion tests is of the form:

```go
func TestProviderX(t *testing.T) {
    // Return a valid site configuration, and the expected API request body
    // we will send to the LLM API provider X.
    getValidTestData := func() completionsRequestTestData {
        ...
    }

    t.Run("TestDataIsValid", func(t *testing.T) {
        // Just confirm that the stock test data works as expected,
        // without any test-specific modifications.
        data := getValidTestData()
        runCompletionsTest(t, infra, data)
    })
}
```

And then, for more sophisticated tests, we would just overwrite whatever subset of fields are necessary from the stock test data.

For example, testing the way AWS Bedrock provisioned throughput ARNs get reflected in the completions API can be done by creating a function to return the specific site configuration data, and then:

```go
	t.Run("Chat", func(t *testing.T) {
			data := getValidTestData()
			data.SiteConfig.Completions = getProvisionedThroughputSiteConfig()

			// The chat model is using provisioned throughput, so the
			// URLs are different.
			data.WantRequestToLLMProviderPath = "/model/arn:aws:bedrock:us-west-2:012345678901:provisioned-model/abcdefghijkl/invoke"

			runCompletionsTest(t, infra, data)
		})

		t.Run("FastChat", func(t *testing.T) {
			data := getValidTestData()
			data.SiteConfig.Completions = getProvisionedThroughputSiteConfig()

			data.UserCompletionRequest.Fast = true

			// The fast chat model does not have provisioned throughput, and
			// so the request path to bedrock just has the model's name. (No ARN.)
			data.WantRequestToLLMProviderPath = "/model/anthropic.claude-v2-fastchat/invoke"

			runCompletionsTest(t, infra, data)
		})
```


## Test plan

Added more unit tests.

## Changelog

NA