### PR TITLE
Search: make 'exclude tests' more general

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -221,10 +221,11 @@ func TestSearchResolver_DynamicFilters(t *testing.T) {
 				fileMatch("assets/javascripts/bootstrap.min.js"),
 			},
 			expectedDynamicFilterStrsRegexp: map[string]int{
-				`repo:^testRepo$`:             3,
-				`-file:\.min\.js$|\.js\.map$`: 3,
-				`lang:javascript`:             1,
-				`type:path`:                   3,
+				`repo:^testRepo$`:  3,
+				`-file:\.min\.js$`: 1,
+				`-file:\.js\.map$`: 2,
+				`lang:javascript`:  1,
+				`type:path`:        3,
 			},
 		},
 

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -194,10 +194,10 @@ func TestSearchResolver_DynamicFilters(t *testing.T) {
 				fileMatch("/foo.go"),
 			},
 			expectedDynamicFilterStrsRegexp: map[string]int{
-				`repo:^testRepo$`:  2,
-				`-file:_test\.go$`: 1,
-				`lang:go`:          2,
-				`type:path`:        2,
+				`repo:^testRepo$`:   2,
+				`-file:_test\.\w+$`: 1,
+				`lang:go`:           2,
+				`type:path`:         2,
 			},
 		},
 
@@ -221,11 +221,10 @@ func TestSearchResolver_DynamicFilters(t *testing.T) {
 				fileMatch("assets/javascripts/bootstrap.min.js"),
 			},
 			expectedDynamicFilterStrsRegexp: map[string]int{
-				`repo:^testRepo$`:  3,
-				`-file:\.min\.js$`: 1,
-				`-file:\.js\.map$`: 2,
-				`lang:javascript`:  1,
-				`type:path`:        3,
+				`repo:^testRepo$`:             3,
+				`-file:\.min\.js$|\.js\.map$`: 3,
+				`lang:javascript`:             1,
+				`type:path`:                   3,
 			},
 		},
 

--- a/internal/search/streaming/search_filters.go
+++ b/internal/search/streaming/search_filters.go
@@ -38,12 +38,12 @@ var commonFileFilters = []struct {
 	regexFilter string
 }{
 	{
-		label:       "Exclude _test.xx",
+		label:       "Exclude _test.*",
 		regexp:      lazyregexp.New(`_tests?\.\w+$`),
 		regexFilter: `-file:_test\.\w+$`,
 	},
 	{
-		label:       "Exclude .test.xx",
+		label:       "Exclude .test.*",
 		regexp:      lazyregexp.New(`\.tests?\.\w+$`),
 		regexFilter: `-file:\.test\.\w+$`,
 	},
@@ -69,8 +69,13 @@ var commonFileFilters = []struct {
 	},
 	{
 		label:       "Exclude minified JavaScript",
-		regexp:      lazyregexp.New(`\.min\.js$|\.js\.map$`),
-		regexFilter: `-file:\.min\.js$|\.js\.map$`,
+		regexp:      lazyregexp.New(`\.min\.js$`),
+		regexFilter: `-file:\.min\.js$`,
+	},
+	{
+		label:       "Exclude JavaScript maps",
+		regexp:      lazyregexp.New(`\.js\.map$`),
+		regexFilter: `-file:\.js\.map$`,
 	},
 }
 

--- a/internal/search/streaming/search_filters.go
+++ b/internal/search/streaming/search_filters.go
@@ -10,6 +10,7 @@ import (
 	"golang.org/x/text/language"
 
 	"github.com/grafana/regexp"
+
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
@@ -35,37 +36,41 @@ var commonFileFilters = []struct {
 	label       string
 	regexp      *lazyregexp.Regexp
 	regexFilter string
-	globFilter  string
 }{
 	{
-		label:       "Exclude Go tests",
-		regexp:      lazyregexp.New(`_test\.go$`),
-		regexFilter: `-file:_test\.go$`,
-		globFilter:  `-file:**_test.go`,
+		label:       "Exclude _test.xx",
+		regexp:      lazyregexp.New(`_tests?\.\w+$`),
+		regexFilter: `-file:_test\.\w+$`,
 	},
 	{
-		label:       "Exclude Go vendor",
+		label:       "Exclude .test.xx",
+		regexp:      lazyregexp.New(`\.tests?\.\w+$`),
+		regexFilter: `-file:\.test\.\w+$`,
+	},
+	{
+		label:       "Exclude Ruby tests",
+		regexp:      lazyregexp.New(`_spec\.rb$`),
+		regexFilter: `-file:_spec\.rb$`,
+	},
+	{
+		label:       "Exclude vendor",
 		regexp:      lazyregexp.New(`(^|/)vendor/`),
 		regexFilter: `-file:(^|/)vendor/`,
-		globFilter:  `-file:vendor/** -file:**/vendor/**`,
+	},
+	{
+		label:       "Exclude third party",
+		regexp:      lazyregexp.New(`(^|/)third[_\-]?party/`),
+		regexFilter: `-file:(^|/)third[_\-]?party/`,
 	},
 	{
 		label:       "Exclude node_modules",
 		regexp:      lazyregexp.New(`(^|/)node_modules/`),
 		regexFilter: `-file:(^|/)node_modules/`,
-		globFilter:  `-file:node_modules/** -file:**/node_modules/**`,
 	},
 	{
 		label:       "Exclude minified JavaScript",
-		regexp:      lazyregexp.New(`\.min\.js$`),
-		regexFilter: `-file:\.min\.js$`,
-		globFilter:  `-file:**.min.js`,
-	},
-	{
-		label:       "Exclude JavaScript maps",
-		regexp:      lazyregexp.New(`\.js\.map$`),
-		regexFilter: `-file:\.js\.map$`,
-		globFilter:  `-file:**.js.map`,
+		regexp:      lazyregexp.New(`\.min\.js$|\.js\.map$`),
+		regexFilter: `-file:\.min\.js$|\.js\.map$`,
 	},
 }
 

--- a/internal/search/streaming/search_filters_test.go
+++ b/internal/search/streaming/search_filters_test.go
@@ -112,6 +112,32 @@ func TestSearchFiltersUpdate(t *testing.T) {
 			wantFilterCount: 2,
 		},
 		{
+			name: "FileMatch, test files",
+			events: []SearchEvent{
+				{
+					Results: []result.Match{
+						&result.FileMatch{
+							File: result.File{
+								Repo: repo,
+								Path: "agent_test.py",
+							},
+							PathMatches: make(result.Ranges, 1),
+						},
+						&result.FileMatch{
+							File: result.File{
+								Repo: repo,
+								Path: "agent.py",
+							},
+							PathMatches: make(result.Ranges, 1),
+						},
+					},
+				},
+			},
+			wantFilterValue: "-file:_test\\.\\w+$",
+			wantFilterKind:  "file",
+			wantFilterCount: 1,
+		},
+		{
 			name: "SymbolMatch",
 			events: []SearchEvent{
 				{


### PR DESCRIPTION
The "Exclude" options in the filter panels are very useful, but many are specific to Go. This change generalizes them so they apply in many more cases:
* All files with suffix `_test` plus extension (covers Go, Python, some Ruby, C++, C, more)
* All files with suffix `.test` plus extension (covers Javascript, some Ruby)
* Ruby specs
* Third party folders (common general naming pattern)

Relates to SPLF-70

## Test plan

Added new unit test. Tested manually.

<img width="1165" alt="Screenshot 2024-07-10 at 12 46 53 PM" src="https://github.com/sourcegraph/sourcegraph/assets/7461306/3a99cb20-37d8-4301-a63d-7d144802c019">
