### PR TITLE
Svelte: add more general shrinkable path

### DIFF
--- a/client/common/src/util/highlightNode.ts
+++ b/client/common/src/util/highlightNode.ts
@@ -150,7 +150,9 @@ function highlightNodeHelper(
                 }
 
                 let newNode: Node
-                if (newNodes.length === 1) {
+                if (newNodes.length === 0) {
+                    newNode = document.createTextNode('')
+                } else if (newNodes.length === 1) {
                     // If we only have one new node, no need to wrap it in a containing span
                     newNode = newNodes[0]
                 } else {

--- a/client/web-sveltekit/BUILD.bazel
+++ b/client/web-sveltekit/BUILD.bazel
@@ -198,7 +198,7 @@ copy_to_directory(
 
 playwright_test_bin.playwright_test(
     name = "e2e_test",
-    timeout = "short",
+    timeout = "long",
     args = [
         "test",
         "--config $(location playwright.config.ts)",

--- a/client/web-sveltekit/prettier.config.cjs
+++ b/client/web-sveltekit/prettier.config.cjs
@@ -2,5 +2,5 @@ const baseConfig = require('../../prettier.config.js')
 module.exports = {
     ...baseConfig,
     plugins: [...(baseConfig.plugins || []), 'prettier-plugin-svelte'],
-    overrides: [...(baseConfig.overrides || []), { files: '*.svelte', options: { parser: 'svelte' } }],
+    overrides: [...(baseConfig.overrides || []), { files: '*.svelte', options: { parser: 'svelte', htmlWhitespaceSensitivity: 'strict' } }],
 }

--- a/client/web-sveltekit/src/lib/Tooltip.svelte
+++ b/client/web-sveltekit/src/lib/Tooltip.svelte
@@ -73,12 +73,16 @@
     on:mouseleave={hide}
     on:focusin={show}
     on:focusout={hide}
-    data-tooltip-root
->
-    <slot />
-</div>
-{#if (alwaysVisible || visible) && target && tooltip}
-    <div role="tooltip" {id} use:popover={{ reference: target, options }} use:portal>
+    data-tooltip-root><!--
+--><slot /><!--
+--></div
+><!--
+-->{#if (alwaysVisible || visible) && target && tooltip}<div
+        role="tooltip"
+        {id}
+        use:popover={{ reference: target, options }}
+        use:portal
+    >
         <div class="content">{tooltip}</div>
         <div data-arrow />
     </div>

--- a/client/web-sveltekit/src/lib/dom.ts
+++ b/client/web-sveltekit/src/lib/dom.ts
@@ -341,58 +341,58 @@ export const portal: Action<HTMLElement, { container?: HTMLElement | null } | un
 /**
  * An action that resizes an element with the provided grow and shrink callbacks until the target element no longer overflows.
  *
- * @param grow A callback to increase the size of the contained contents. Returns a boolean indicating more growth is possible.
- * @param shrink A callback to reduce the size of the contained contents. Returns a boolean indicating more shrinking is possible.
+ * @param grow A callback to increase the size of the contained contents. Returns a boolean indicating whether growing was successful.
+ * @param shrink A callback to reduce the size of the contained contents. Returns a boolean indicating whether shrinking was successful.
  * @returns An action that updates the overflow state of the element.
  */
 export const sizeToFit: Action<HTMLElement, { grow: () => boolean; shrink: () => boolean }> = (
     target,
     { grow, shrink }
 ) => {
-    async function resize(): Promise<void> {
-        if (target.scrollWidth > target.clientWidth) {
-            // Shrink until we fit
-            while (target.scrollWidth > target.clientWidth) {
-                if (!shrink()) {
-                    return
-                }
-                await tick()
-            }
-        } else {
-            // Grow until we overflow, then shrink once
-            while (target.scrollWidth <= target.clientWidth && grow()) {
-                await tick()
-            }
-            await tick()
-            if (target.scrollWidth > target.clientWidth) {
-                shrink()
-                await tick()
-            }
-        }
-    }
-
-    // Resizing can (and probably will) trigger mutations, so do not trigger a
-    // new resize if there is a resize in progress.
     let resizing = false
-    function resizeOnce() {
+    async function resize(): Promise<void> {
         if (resizing) {
+            // Growing and shrinking can cause child nodes to be added
+            // or removed, triggering resize observer during resizing.
+            // If we're already resizing, we can safely ignore those events.
             return
         }
         resizing = true
-        resize().then(() => {
-            resizing = false
-        })
+        // Grow until we overflow
+        while (target.scrollWidth <= target.clientWidth && grow()) {
+            await tick()
+        }
+        await tick()
+        // Then shrink until we fit
+        while (target.scrollWidth > target.clientWidth && shrink()) {
+            await tick()
+        }
+        await tick()
+        resizing = false
     }
 
-    const resizeObserver = new ResizeObserver(resizeOnce)
+    const resizeObserver = new ResizeObserver(resize)
     resizeObserver.observe(target)
-    const mutationObserver = new MutationObserver(resizeOnce)
-    mutationObserver.observe(target, { attributes: true, childList: true, characterData: true, subtree: true })
+
+    function isElement(node: Node): node is Element {
+        return node.nodeType === Node.ELEMENT_NODE
+    }
+
+    // If any children change size, that could trigger an overflow, so check the size again
+    target.childNodes.forEach(child => isElement(child) && resizeObserver.observe(child))
+    const mutationObserver = new MutationObserver(mutationList => {
+        for (const mutation of mutationList) {
+            mutation.addedNodes.forEach(node => isElement(node) && resizeObserver.observe(node))
+            mutation.removedNodes.forEach(node => isElement(node) && resizeObserver.unobserve(node))
+        }
+    })
+    mutationObserver.observe(target, { childList: true })
+
     return {
         update(params) {
             grow = params.grow
             shrink = params.shrink
-            resizeOnce()
+            resize()
         },
         destroy() {
             resizeObserver.disconnect()

--- a/client/web-sveltekit/src/lib/path/DisplayPath.stories.svelte
+++ b/client/web-sveltekit/src/lib/path/DisplayPath.stories.svelte
@@ -1,0 +1,40 @@
+<script lang="ts" context="module">
+    import { Story } from '@storybook/addon-svelte-csf'
+
+    import Icon from '$lib/Icon.svelte'
+
+    import { pathHrefFactory } from '.'
+    import DisplayPath from './DisplayPath.svelte'
+
+    export const meta = {
+        component: DisplayPath,
+    }
+</script>
+
+<Story name="Default">
+    <DisplayPath path="my/displayed/path" />
+</Story>
+
+<Story name="Copy button">
+    <DisplayPath path="my/displayed/path" showCopyButton />
+</Story>
+
+<Story name="File Icon">
+    <DisplayPath path="my/displayed/path">
+        <Icon slot="file-icon" icon={ILucideEye} inline />
+    </DisplayPath>
+</Story>
+
+<Story name="Linkified">
+    <DisplayPath
+        path="my/displayed/path"
+        pathHref={pathHrefFactory({
+            repoName: 'myrepo',
+            revision: 'main',
+            fullPath: 'my/displayed/path',
+            fullPathType: 'blob',
+        })}
+    >
+        <Icon icon={ILucideEye} inline />
+    </DisplayPath>
+</Story>

--- a/client/web-sveltekit/src/lib/path/DisplayPath.svelte
+++ b/client/web-sveltekit/src/lib/path/DisplayPath.svelte
@@ -69,7 +69,8 @@
             ><!--
         -->{/if}<!--
     -->{/each}<!--
-    We include the copy button in this component because
+    We include the copy button in this component because we want it to wrap along with the path
+    elements. Otherwise, an invisible button might wrap to its own line, which looks weird.
     -->{#if showCopyButton}<!--
         --><span
             data-copy-button

--- a/client/web-sveltekit/src/lib/path/DisplayPath.svelte
+++ b/client/web-sveltekit/src/lib/path/DisplayPath.svelte
@@ -1,0 +1,91 @@
+<script lang="ts">
+    import CopyButton from '$lib/wildcard/CopyButton.svelte'
+
+    export let path: string
+    export let showCopyButton = false
+    export let pathHref: ((path: string) => string) | undefined = undefined
+    $: parts = path.split('/').map((part, index, allParts) => ({ part, path: allParts.slice(0, index + 1).join('/') }))
+</script>
+
+<!--
+    NOTE: all the weird comments in here are being very careful to not
+    introduce any additional whitespace in the path container since that would
+    make the path invalid when copied from a selection
+-->
+<span data-path-container>
+    <slot name="prefix" /><!--
+    -->{#each parts as { part, path }, index}<!--
+        -->{@const last =
+            index === parts.length - 1}<!--
+        -->{#if index > 0}<!--
+            --><span data-slash>/</span
+            ><!--
+        -->{/if}<!--
+        Wrap the anchor element with a span because otherwise it adds
+        spaces around it when copied
+        --><span
+            class:last
+            data-path-item
+            >{#if pathHref}<a href={pathHref(path)}>{part}</a>{:else}{part}{/if}<!--component
+            --></span
+        ><!--
+        -->{#if last}<!--
+            --><span data-file-icon aria-hidden="true"
+                ><slot name="file-icon" /></span
+            ><!--
+        -->{/if}<!--
+    -->{/each}<!--
+    -->{#if showCopyButton}<!--
+        --><span data-copy-button
+            ><CopyButton value={path} label="Copy path to clipboard" /></span
+        ><!--
+    -->{/if}
+</span>
+
+<style lang="scss">
+    [data-path-container] {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.125em;
+
+        font-weight: 400;
+        font-size: var(--code-font-size);
+        font-family: var(--code-font-family);
+    }
+
+    // Global so a data-slash can be slotted in in the prefix
+    [data-slash] {
+        color: var(--text-disabled);
+        display: inline;
+    }
+
+    [data-path-item] {
+        display: inline;
+        white-space: nowrap;
+        color: var(--text-body);
+        & > a {
+            color: inherit;
+        }
+
+        // HACK: The file icon is placed after the file name
+        // in the DOM so it doesn't add any spaces in the file
+        // path when copied. This visually reorders the last
+        // path element after the file icon.
+        &.last {
+            order: 1;
+        }
+    }
+
+    [data-file-icon] {
+        user-select: none; // Avoids a trailing space on select + copy
+        &:empty {
+            display: none;
+        }
+    }
+
+    [data-copy-button] {
+        margin-left: 0.5rem;
+        user-select: none; // Avoids a trailing space on select + copy
+        order: 1;
+    }
+</style>

--- a/client/web-sveltekit/src/lib/path/ShrinkablePath.stories.svelte
+++ b/client/web-sveltekit/src/lib/path/ShrinkablePath.stories.svelte
@@ -1,0 +1,49 @@
+<script lang="ts" context="module">
+    import { Story } from '@storybook/addon-svelte-csf'
+
+    import { sizeToFit } from '$lib/dom'
+    import Icon from '$lib/Icon.svelte'
+
+    import { pathHrefFactory } from '.'
+    import ShrinkablePath from './ShrinkablePath.svelte'
+
+    export const meta = {
+        component: ShrinkablePath,
+    }
+
+    const path = 'very/very/very/long/displayed/path'
+
+    let shrinkableDefault: ShrinkablePath
+    let shrinkableLinkified: ShrinkablePath
+</script>
+
+<Story name="Default">
+    <div use:sizeToFit={{ grow: () => shrinkableDefault.grow(), shrink: () => shrinkableDefault.shrink() }}>
+        <ShrinkablePath bind:this={shrinkableDefault} {path} />
+    </div>
+</Story>
+
+<Story name="Linkified">
+    <div use:sizeToFit={{ grow: () => shrinkableLinkified.grow(), shrink: () => shrinkableLinkified.shrink() }}>
+        <ShrinkablePath
+            bind:this={shrinkableLinkified}
+            {path}
+            pathHref={pathHrefFactory({
+                repoName: 'myrepo',
+                revision: 'main',
+                fullPath: path,
+                fullPathType: 'blob',
+            })}
+        >
+            <Icon icon={ILucideEye} inline />
+        </ShrinkablePath>
+    </div>
+</Story>
+
+<style lang="scss">
+    div {
+        width: 200px;
+        overflow: hidden;
+        resize: horizontal;
+    }
+</style>

--- a/client/web-sveltekit/src/lib/path/ShrinkablePath.svelte
+++ b/client/web-sveltekit/src/lib/path/ShrinkablePath.svelte
@@ -1,3 +1,9 @@
+<!--
+    @component
+    ShrinkablePath is a DisplayPath that can collapse its path items
+    into a dropdown menu to save space. It does not do this automatically,
+    and is usually used alongside a helper like `sizeToFit`.
+-->
 <script lang="ts">
     import { writable } from 'svelte/store'
 
@@ -33,6 +39,7 @@
         return false
     }
 
+    // Returns whether growing was successful
     export function grow(): boolean {
         if (collapsedPartCount > 0) {
             collapsedPartCount--

--- a/client/web-sveltekit/src/lib/path/ShrinkablePath.svelte
+++ b/client/web-sveltekit/src/lib/path/ShrinkablePath.svelte
@@ -1,0 +1,70 @@
+<script lang="ts">
+    import { writable } from 'svelte/store'
+
+    import { getButtonClassName } from '$lib/wildcard/Button'
+    import DropdownMenu from '$lib/wildcard/menu/DropdownMenu.svelte'
+    import MenuLink from '$lib/wildcard/menu/MenuLink.svelte'
+    import MenuText from '$lib/wildcard/menu/MenuText.svelte'
+
+    import Icon from '../Icon.svelte'
+
+    import DisplayPath from './DisplayPath.svelte'
+
+    export let path: string
+    export let showCopyButton = false
+    export let pathHref: ((path: string) => string) | undefined = undefined
+
+    $: parts = path.split('/').map((part, _, allParts) => ({ part, path: allParts.join('/') }))
+    let collapsedPartCount = 0
+    $: collapsedParts = parts.slice(0, collapsedPartCount)
+    $: visibleParts = parts.slice(collapsedPartCount)
+
+    $: scopedPathHref = pathHref
+        ? (path: string) => pathHref(collapsedParts.map(({ part }) => part).join('/') + path)
+        : undefined
+
+    // Returns whether shrinking was successful
+    export function shrink(): boolean {
+        // Never collapse the last element of the path
+        if (collapsedPartCount < parts.length - 1) {
+            collapsedPartCount++
+            return true
+        }
+        return false
+    }
+
+    export function grow(): boolean {
+        if (collapsedPartCount > 0) {
+            collapsedPartCount--
+            return true
+        }
+        return false
+    }
+
+    const breadcrumbMenuOpen = writable(false)
+</script>
+
+<DisplayPath path={visibleParts.map(({ part }) => part).join('/')} {showCopyButton} pathHref={scopedPathHref}>
+    <svelte:fragment slot="prefix">
+        {#if collapsedParts.length > 0}
+            <DropdownMenu
+                open={breadcrumbMenuOpen}
+                triggerButtonClass={getButtonClassName({ variant: 'icon', outline: true, size: 'sm' })}
+                aria-label="{$breadcrumbMenuOpen ? 'Close' : 'Open'} collapsed path elements"
+            >
+                <Icon slot="trigger" inline icon={ILucideEllipsis} aria-label="Collapsed path elements" />
+                {#each collapsedParts as { part, path }}
+                    <svelte:component
+                        this={pathHref ? MenuLink : MenuText}
+                        href={pathHref ? pathHref(path) : undefined}
+                    >
+                        <Icon inline icon={ILucideFolder} aria-hidden="true" />
+                        {part}
+                    </svelte:component>
+                {/each}
+            </DropdownMenu>
+            <span data-slash>/</span>
+        {/if}
+    </svelte:fragment>
+    <slot name="file-icon" slot="file-icon" />
+</DisplayPath>

--- a/client/web-sveltekit/src/lib/path/ShrinkablePath.svelte
+++ b/client/web-sveltekit/src/lib/path/ShrinkablePath.svelte
@@ -20,7 +20,7 @@
     export let showCopyButton = false
     export let pathHref: ((path: string) => string) | undefined = undefined
 
-    $: parts = path.split('/').map((part, _, allParts) => ({ part, path: allParts.join('/') }))
+    $: parts = path.split('/').map((part, index, allParts) => ({ part, path: allParts.slice(0, index + 1).join('/') }))
     let collapsedPartCount = 0
     $: collapsedParts = parts.slice(0, collapsedPartCount)
     $: visibleParts = parts.slice(collapsedPartCount)

--- a/client/web-sveltekit/src/lib/path/index.ts
+++ b/client/web-sveltekit/src/lib/path/index.ts
@@ -1,0 +1,28 @@
+import { resolveRoute } from '$app/paths'
+import { encodeURIPathComponent } from '$lib/common'
+
+const TREE_ROUTE_ID = '/[...repo=reporev]/(validrev)/(code)/-/tree/[...path]'
+const BLOB_ROUTE_ID = '/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]'
+
+export function pathHrefFactory({
+    repoName,
+    revision,
+    fullPath,
+    fullPathType,
+}: {
+    repoName: string
+    revision: string | undefined
+    fullPath: string
+    fullPathType: 'blob' | 'tree'
+}): (targetPath: string) => string {
+    return (targetPath: string) =>
+        resolveRoute(
+            // If we are targeting the last item in the path, respect the passed-in type.
+            // Otherwise, we know we are targeting a tree higher up in the path.
+            fullPath === targetPath && fullPathType === 'blob' ? BLOB_ROUTE_ID : TREE_ROUTE_ID,
+            {
+                repo: revision ? `${repoName}@${revision}` : repoName,
+                path: encodeURIPathComponent(targetPath),
+            }
+        )
+}

--- a/client/web-sveltekit/src/lib/repo/FileHeader.svelte
+++ b/client/web-sveltekit/src/lib/repo/FileHeader.svelte
@@ -36,7 +36,12 @@
 
 <header use:sizeToFit={{ grow, shrink }}>
     <h2 data-testid="file-header-path">
-        <ShrinkablePath bind:this={shrinkablePath} {path} showCopyButton>
+        <ShrinkablePath
+            bind:this={shrinkablePath}
+            {path}
+            pathHref={pathHrefFactory({ repoName, revision, fullPath: path, fullPathType: type })}
+            showCopyButton
+        >
             <slot name="file-icon" slot="file-icon" />
         </ShrinkablePath>
     </h2>

--- a/client/web-sveltekit/src/lib/repo/FileHeader.svelte
+++ b/client/web-sveltekit/src/lib/repo/FileHeader.svelte
@@ -36,12 +36,7 @@
 
 <header use:sizeToFit={{ grow, shrink }}>
     <h2 data-testid="file-header-path">
-        <ShrinkablePath
-            bind:this={shrinkablePath}
-            {path}
-            pathHref={pathHrefFactory({ repoName, revision, fullPath: path, fullPathType: type })}
-            showCopyButton
-        >
+        <ShrinkablePath bind:this={shrinkablePath} {path} showCopyButton>
             <slot name="file-icon" slot="file-icon" />
         </ShrinkablePath>
     </h2>

--- a/client/web-sveltekit/src/lib/repo/FileHeader.svelte
+++ b/client/web-sveltekit/src/lib/repo/FileHeader.svelte
@@ -1,105 +1,49 @@
 <script lang="ts">
-    import { writable } from 'svelte/store'
-
-    import { resolveRoute } from '$app/paths'
-    import { encodeURIPathComponent } from '$lib/common'
     import { sizeToFit } from '$lib/dom'
     import Icon from '$lib/Icon.svelte'
-    import { DropdownMenu, MenuLink } from '$lib/wildcard'
+    import { pathHrefFactory } from '$lib/path'
+    import ShrinkablePath from '$lib/path/ShrinkablePath.svelte'
+    import { DropdownMenu } from '$lib/wildcard'
     import { getButtonClassName } from '$lib/wildcard/Button'
-    import CopyButton from '$lib/wildcard/CopyButton.svelte'
-
-    const TREE_ROUTE_ID = '/[...repo=reporev]/(validrev)/(code)/-/tree/[...path]'
-    const BLOB_ROUTE_ID = '/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]'
 
     export let repoName: string
     export let revision: string | undefined
     export let path: string
     export let type: 'blob' | 'tree'
 
-    $: breadcrumbs = path.split('/').map((part, index, all): [string, string] => [
-        part,
-        resolveRoute(
-            // Only the last element in a path can be a blob
-            index < all.length - 1 || type === 'tree' ? TREE_ROUTE_ID : BLOB_ROUTE_ID,
-            {
-                repo: revision ? `${repoName}@${revision}` : repoName,
-                path: encodeURIPathComponent(all.slice(0, index + 1).join('/')),
-            }
-        ),
-    ])
-
-    // HACK: we use a flexbox for the path and an inline icon, but we still want the copied path to be usable.
-    // This event handler removes the newlines surrounding slashes from the copied text.
-    function stripSpaces(event: ClipboardEvent) {
-        const selection = document.getSelection() ?? ''
-        event.clipboardData?.setData('text/plain', selection.toString().replaceAll(/\n?\/\n?/g, '/'))
-        event.preventDefault()
-    }
-
-    const breadcrumbMenuOpen = writable(false)
-    $: compact = false
-    $: visibleBreadcrumbCount = breadcrumbs.length
-    $: collapsedBreadcrumbCount = breadcrumbs.length - visibleBreadcrumbCount
+    let compact = false
+    let shrinkablePath: ShrinkablePath
     function grow(): boolean {
         // Expand the breadcrumbs first, then the actions
-        if (visibleBreadcrumbCount < breadcrumbs.length) {
-            visibleBreadcrumbCount += 1
+        if (shrinkablePath.grow()) {
             return true
         }
-        compact = false
+        if (compact) {
+            compact = false
+            return true
+        }
         return false
     }
     function shrink(): boolean {
         // Collapse the actions first, then the breadcrumbs
         if (!compact) {
             compact = true
-            return visibleBreadcrumbCount > 1
+            return true
         }
-        if (visibleBreadcrumbCount > 1) {
-            visibleBreadcrumbCount -= 1
-        }
-        return visibleBreadcrumbCount > 1
+        return shrinkablePath.shrink()
     }
 </script>
 
-<div class="header" use:sizeToFit={{ grow, shrink }}>
-    <h2 on:copy={stripSpaces} data-testid="file-header-path">
-        {#if collapsedBreadcrumbCount > 0}
-            <DropdownMenu
-                open={breadcrumbMenuOpen}
-                triggerButtonClass={getButtonClassName({ variant: 'icon', outline: true, size: 'sm' })}
-                aria-label="{$breadcrumbMenuOpen ? 'Close' : 'Open'} collapsed path elements"
-            >
-                <svelte:fragment slot="trigger">
-                    <Icon inline icon={ILucideEllipsis} aria-label="Collapsed path elements" />
-                </svelte:fragment>
-                {#each breadcrumbs.slice(0, collapsedBreadcrumbCount) as [name, path]}
-                    <MenuLink href={path}>
-                        <Icon inline icon={ILucideFolder} aria-label="Collapsed path elements" />
-                        {name}
-                    </MenuLink>
-                {/each}
-            </DropdownMenu>
-            <span class="slash">/</span>
-        {/if}
-        {#each breadcrumbs.slice(collapsedBreadcrumbCount) as [name, path], index}
-            {@const last = index === breadcrumbs.length - collapsedBreadcrumbCount - 1}
-            <span class:last>
-                {#if index > 0}
-                    <span class="slash">/</span>
-                {/if}
-                {#if last}
-                    <slot name="icon" />
-                {/if}
-                {#if path}
-                    <a href={path}>{name}</a>
-                {:else}
-                    {name}
-                {/if}
-            </span>
-        {/each}
-        <span class="copy-button"><CopyButton value={path} label="Copy path to clipboard" /></span>
+<header use:sizeToFit={{ grow, shrink }}>
+    <h2 data-testid="file-header-path">
+        <ShrinkablePath
+            bind:this={shrinkablePath}
+            {path}
+            pathHref={pathHrefFactory({ repoName, revision, fullPath: path, fullPathType: type })}
+            showCopyButton
+        >
+            <slot name="file-icon" slot="file-icon" />
+        </ShrinkablePath>
     </h2>
     <div class="actions" class:compact>
         <slot name="actions" />
@@ -118,10 +62,10 @@
             </div>
         {/if}
     </div>
-</div>
+</header>
 
 <style lang="scss">
-    .header {
+    header {
         display: flex;
         flex-wrap: nowrap;
         justify-content: space-between;
@@ -135,47 +79,31 @@
     }
 
     h2 {
-        flex: 1;
-
         display: flex;
         flex-wrap: nowrap;
-        gap: 0.375em;
-        span {
-            display: flex;
-            gap: inherit;
-            white-space: nowrap;
-        }
-
-        font-weight: 400;
-        font-size: var(--code-font-size);
-        font-family: var(--code-font-family);
+        gap: 0.5rem;
+        align-items: center;
         margin: 0;
 
-        a {
-            color: var(--text-body);
-
-            &:hover {
-                color: var(--text-title);
-            }
+        :global([data-path-container]) {
+            gap: 0.375em !important;
         }
 
-        .slash {
-            color: var(--text-disabled);
-        }
+        // Grow to fill the rest of the header so the hoverable area for
+        // showing the copy button is large.
+        flex: 1;
 
-        .last {
-            color: var(--text-title);
+        :global([data-copy-button]) {
+            opacity: 0;
+            transition: opacity 0.2s;
         }
-
-        .copy-button {
-            visibility: hidden;
-        }
-        &:hover .copy-button {
-            visibility: visible;
+        &:is(:hover, :focus-within) :global([data-copy-button]) {
+            opacity: 1;
         }
     }
 
     .actions {
+        margin-left: auto;
         display: flex;
         justify-content: space-evenly;
         gap: 1rem;

--- a/client/web-sveltekit/src/lib/repo/Permalink.svelte
+++ b/client/web-sveltekit/src/lib/repo/Permalink.svelte
@@ -17,7 +17,7 @@
         keys: { key: 'y' },
         ignoreInputFields: true,
         handler: () => {
-            const {revision} = parseBrowserRepoURL($page.url.pathname)
+            const { revision } = parseBrowserRepoURL($page.url.pathname)
             // Only navigate if necessary. We don't want to add unnecessary history entries.
             if (revision !== commitID) {
                 goto(href, { noScroll: true, keepFocus: true }).catch(() => {

--- a/client/web-sveltekit/src/lib/repo/filePopover/FilePopover.svelte
+++ b/client/web-sveltekit/src/lib/repo/filePopover/FilePopover.svelte
@@ -50,16 +50,12 @@
     $: lastCommit = entry.history.nodes[0].commit
 </script>
 
-<div class="root section muted">
-    <div class="repo-and-path section">
-        <DisplayPath path={displayRepoName(repoName)} />
-        {#if dirName}
-            <span>·</span>
-            <DisplayPath
-                path={dirName}
-                pathHref={pathHrefFactory({ repoName, revision, fullPath: dirName, fullPathType: 'tree' })}
-            />
-        {/if}
+<div class="root">
+    <div class="path section">
+        <DisplayPath
+            path={dirName}
+            pathHref={pathHrefFactory({ repoName, revision, fullPath: dirName, fullPathType: 'tree' })}
+        />
     </div>
 
     <div class="lang-and-file section">
@@ -114,12 +110,6 @@
 
         .section {
             padding: 0.5rem 1rem;
-        }
-
-        .repo-and-path {
-            display: flex;
-            flex-wrap: wrap;
-            gap: 0.375em;
             border-bottom: 1px solid var(--border-color);
         }
 
@@ -180,10 +170,6 @@
 
     .title {
         color: var(--text-title);
-    }
-
-    .muted {
-        color: var(--text-muted);
     }
 
     .body {

--- a/client/web-sveltekit/src/lib/repo/filePopover/FilePopover.svelte
+++ b/client/web-sveltekit/src/lib/repo/filePopover/FilePopover.svelte
@@ -28,7 +28,6 @@
     import Icon from '$lib/Icon.svelte'
     import { pathHrefFactory } from '$lib/path'
     import DisplayPath from '$lib/path/DisplayPath.svelte'
-    import { displayRepoName } from '$lib/shared'
     import Timestamp from '$lib/Timestamp.svelte'
     import { formatBytes } from '$lib/utils'
     import Badge from '$lib/wildcard/Badge.svelte'

--- a/client/web-sveltekit/src/lib/shared.ts
+++ b/client/web-sveltekit/src/lib/shared.ts
@@ -25,6 +25,7 @@ export { TemporarySettingsStorage } from '@sourcegraph/shared/src/settings/tempo
 export {
     LATEST_VERSION,
     TELEMETRY_FILTER_TYPES,
+    getRevision,
     aggregateStreamingSearch,
     emptyAggregateResults,
     getFileMatchUrl,

--- a/client/web-sveltekit/src/lib/wildcard/CopyButton.svelte
+++ b/client/web-sveltekit/src/lib/wildcard/CopyButton.svelte
@@ -21,14 +21,14 @@
 </script>
 
 <span class="copy-button">
-    <Tooltip {tooltip} placement="bottom">
-        <slot name="custom" {handleCopy}>
-            <Button on:click={handleCopy} variant="icon" size="sm" aria-label={label}>
-                <Icon inline icon={ILucideCopy} aria-hidden />
-            </Button>
-        </slot>
-    </Tooltip>
-</span>
+    <Tooltip {tooltip} placement="bottom"
+        ><slot name="custom" {handleCopy}
+            ><Button on:click={handleCopy} variant="icon" size="sm" aria-label={label}
+                ><Icon inline icon={ILucideCopy} aria-hidden /></Button
+            ></slot
+        ></Tooltip
+    ></span
+>
 
 <style lang="scss">
     .copy-button {

--- a/client/web-sveltekit/src/lib/wildcard/CopyButton.svelte
+++ b/client/web-sveltekit/src/lib/wildcard/CopyButton.svelte
@@ -33,10 +33,8 @@
 <style lang="scss">
     .copy-button {
         display: contents;
-        color: var(--text-muted);
-
         &:hover {
-            color: var(--body-color);
+            --icon-color: var(--body-color);
         }
     }
 </style>

--- a/client/web-sveltekit/src/lib/wildcard/menu/MenuText.svelte
+++ b/client/web-sveltekit/src/lib/wildcard/menu/MenuText.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+    import type { HTMLAttributes } from 'svelte/elements'
+
+    import { getContext } from './DropdownMenu.svelte'
+
+    type $$Props = HTMLAttributes<HTMLDivElement>
+
+    const { item } = getContext()
+</script>
+
+<div {...$$restProps} {...$item} use:item>
+    <slot />
+</div>
+
+<!-- styles are defined in Menu.svelte -->

--- a/client/web-sveltekit/src/lib/wildcard/menu/MenuText.svelte
+++ b/client/web-sveltekit/src/lib/wildcard/menu/MenuText.svelte
@@ -12,4 +12,15 @@
     <slot />
 </div>
 
-<!-- styles are defined in Menu.svelte -->
+<!-- styles are mostly defined in Menu.svelte. Unsets default styles for non-interactive menu item -->
+<style lang="scss">
+    div[role='menuitem'] {
+        cursor: unset;
+        &:hover,
+        &:focus {
+            background-color: unset;
+            color: unset;
+            text-decoration: none;
+        }
+    }
+</style>

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/DiffView.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/DiffView.svelte
@@ -19,11 +19,9 @@
 </script>
 
 <FileHeader type="blob" repoName={data.repoName} revision={data.revision} path={data.filePath}>
-    <svelte:fragment slot="icon">
-        {#if $commit.value?.blob}
-            <FileIcon file={$commit.value.blob} inline />
-        {/if}
-    </svelte:fragment>
+    {#if $commit.value?.blob}
+        <FileIcon slot="file-icon" file={$commit.value.blob} inline />
+    {/if}
 </FileHeader>
 
 <div class="info">

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/DiffView.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/DiffView.svelte
@@ -19,9 +19,11 @@
 </script>
 
 <FileHeader type="blob" repoName={data.repoName} revision={data.revision} path={data.filePath}>
-    {#if $commit.value?.blob}
-        <FileIcon slot="file-icon" file={$commit.value.blob} inline />
-    {/if}
+    <svelte:fragment slot="file-icon">
+        {#if $commit.value?.blob}
+            <FileIcon file={$commit.value.blob} inline />
+        {/if}
+    </svelte:fragment>
 </FileHeader>
 
 <div class="info">

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/FileView.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/FileView.svelte
@@ -22,6 +22,7 @@
     import FileIcon from '$lib/repo/FileIcon.svelte'
     import { renderMermaid } from '$lib/repo/mermaid'
     import OpenInEditor from '$lib/repo/open-in-editor/OpenInEditor.svelte'
+    import OpenCodyAction from '$lib/repo/OpenCodyAction.svelte'
     import Permalink from '$lib/repo/Permalink.svelte'
     import { createCodeIntelAPI, replaceRevisionInURL } from '$lib/shared'
     import { isLightTheme, settings } from '$lib/stores'
@@ -36,7 +37,6 @@
     import { FileViewGitBlob, FileViewHighlightedFile } from './FileView.gql'
     import FileViewModeSwitcher from './FileViewModeSwitcher.svelte'
     import OpenInCodeHostAction from './OpenInCodeHostAction.svelte'
-    import OpenCodyAction from '$lib/repo/OpenCodyAction.svelte'
     import { CodeViewMode, toCodeViewMode } from './util'
 
     export let data: Extract<PageData, { type: 'FileView' }>
@@ -166,14 +166,12 @@
 
 {#if embedded}
     <FileHeader type="blob" repoName={data.repoName} path={data.filePath} {revision}>
-        <FileIcon slot="icon" file={blob} inline />
-        <svelte:fragment slot="actions">
-            <slot name="actions" />
-        </svelte:fragment>
+        <FileIcon slot="file-icon" file={blob} inline />
+        <slot name="actions" slot="actions" />
     </FileHeader>
 {:else}
     <FileHeader type="blob" repoName={data.repoName} path={data.filePath} {revision}>
-        <FileIcon slot="icon" file={blob} inline />
+        <FileIcon slot="file-icon" file={blob} inline />
         <svelte:fragment slot="actions">
             {#if !revisionOverride}
                 {#await data.externalServiceType then externalServiceType}

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/page.spec.ts
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/page.spec.ts
@@ -404,7 +404,7 @@ test.describe('scroll behavior', () => {
 
 test('non-existent file', async ({ page, sg }) => {
     sg.mockOperations({
-        BlobFileViewBlobQuery: ({ }) => ({
+        BlobFileViewBlobQuery: ({}) => ({
             repository: {
                 commit: {
                     blob: null,
@@ -419,7 +419,7 @@ test('non-existent file', async ({ page, sg }) => {
 
 test('error loading file data', async ({ page, sg }) => {
     sg.mockOperations({
-        BlobFileViewBlobQuery: ({ }) => {
+        BlobFileViewBlobQuery: ({}) => {
             throw new Error('Blob error')
         },
     })
@@ -430,7 +430,7 @@ test('error loading file data', async ({ page, sg }) => {
 
 test.skip('error loading highlights data', async ({ page, sg }) => {
     sg.mockOperations({
-        BlobFileViewHighlightedFileQuery: ({ }) => {
+        BlobFileViewHighlightedFileQuery: ({}) => {
             throw new Error('Highlights error')
         },
     })

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/page.spec.ts
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/page.spec.ts
@@ -248,6 +248,9 @@ test.describe('file header', () => {
         test('textContent is exactly the path', async ({ page, context }) => {
             await context.grantPermissions(['clipboard-read', 'clipboard-write'])
             await page.goto(url)
+            // We specifically check the textContent here because this is what is
+            // used to apply highlights. It must exactly equal the path (no additional
+            // whitespace) or the highlights will be incorrectly offset.
             const pathContainer = await page
                 .locator('css=[data-path-container]')
                 .first()

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/page.spec.ts
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/page.spec.ts
@@ -245,14 +245,14 @@ test.describe('file header', () => {
             await expect(page.getByRole('link', { name: 'src' })).toBeVisible()
         })
 
-        test('select and copy file path', async ({ page, context }) => {
+        test('textContent is exactly the path', async ({ page, context }) => {
             await context.grantPermissions(['clipboard-read', 'clipboard-write'])
             await page.goto(url)
-            await page.getByTestId('file-header-path').selectText()
-            await page.keyboard.press(`Meta+KeyC`)
-            await page.keyboard.press(`Control+KeyC`)
-            const clipboardText = await page.evaluate('navigator.clipboard.readText()')
-            expect(clipboardText, 'path should be copied to clipboard and not contain spaces').toBe('src/readme.md')
+            const pathContainer = await page
+                .locator('css=[data-path-container]')
+                .first()
+                .evaluateHandle(elem => elem.textContent)
+            expect(await pathContainer.jsonValue()).toEqual('src/readme.md')
         })
 
         test('copy path button', async ({ page, context }) => {

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/page.spec.ts
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/page.spec.ts
@@ -251,11 +251,8 @@ test.describe('file header', () => {
             // We specifically check the textContent here because this is what is
             // used to apply highlights. It must exactly equal the path (no additional
             // whitespace) or the highlights will be incorrectly offset.
-            const pathContainer = await page
-                .locator('css=[data-path-container]')
-                .first()
-                .evaluateHandle(elem => elem.textContent)
-            expect(await pathContainer.jsonValue()).toEqual('src/readme.md')
+            const pathContainer = page.locator('css=[data-path-container]').first()
+            await expect(pathContainer).toHaveText(/^src\/readme.md$/)
         })
 
         test('copy path button', async ({ page, context }) => {
@@ -407,7 +404,7 @@ test.describe('scroll behavior', () => {
 
 test('non-existent file', async ({ page, sg }) => {
     sg.mockOperations({
-        BlobFileViewBlobQuery: ({}) => ({
+        BlobFileViewBlobQuery: ({ }) => ({
             repository: {
                 commit: {
                     blob: null,
@@ -422,7 +419,7 @@ test('non-existent file', async ({ page, sg }) => {
 
 test('error loading file data', async ({ page, sg }) => {
     sg.mockOperations({
-        BlobFileViewBlobQuery: ({}) => {
+        BlobFileViewBlobQuery: ({ }) => {
             throw new Error('Blob error')
         },
     })
@@ -433,7 +430,7 @@ test('error loading file data', async ({ page, sg }) => {
 
 test.skip('error loading highlights data', async ({ page, sg }) => {
     sg.mockOperations({
-        BlobFileViewHighlightedFileQuery: ({}) => {
+        BlobFileViewHighlightedFileQuery: ({ }) => {
             throw new Error('Highlights error')
         },
     })

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/page.spec.ts
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/page.spec.ts
@@ -309,7 +309,11 @@ test('file popover', async ({ page, sg }, testInfo) => {
     await expect(page.getByText('Last Changed')).toBeVisible()
 
     // Click the parent dir in the popover and expect to navigate to that page
-    await page.locator('span').filter({ hasText: /^src$/ }).getByRole('link').click()
+    await page
+        .locator('div')
+        .filter({ hasText: /^sourcegraph\/sourcegraph · src$/ })
+        .getByRole('link')
+        .click()
     await page.waitForURL(/src$/)
 })
 

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/page.spec.ts
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/page.spec.ts
@@ -250,7 +250,7 @@ test('history panel', async ({ page, sg }) => {
 
 test('file popover', async ({ page, sg }, testInfo) => {
     // Test needs more time to teardown
-    test.setTimeout(testInfo.timeout * 3000)
+    test.setTimeout(testInfo.timeout * 4)
 
     await page.goto(`/${repoName}`)
 
@@ -309,11 +309,7 @@ test('file popover', async ({ page, sg }, testInfo) => {
     await expect(page.getByText('Last Changed')).toBeVisible()
 
     // Click the parent dir in the popover and expect to navigate to that page
-    await page
-        .locator('div')
-        .filter({ hasText: /^sourcegraph\/sourcegraph · src$/ })
-        .getByRole('link')
-        .click()
+    await page.locator('div').filter({ hasText: /^src$/ }).getByRole('link').click()
     await page.waitForURL(/src$/)
 })
 

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/+layout.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/+layout.svelte
@@ -87,6 +87,21 @@
         entry => entry.visibility === 'user' || (entry.visibility === 'admin' && data.user?.siteAdmin)
     )
     $: visibleNavEntryCount = viewableNavEntries.length
+    function grow(): boolean {
+        if (visibleNavEntryCount < viewableNavEntries.length) {
+            visibleNavEntryCount++
+            return true
+        }
+        return false
+    }
+    function shrink(): boolean {
+        if (visibleNavEntryCount > 0) {
+            visibleNavEntryCount--
+            return true
+        }
+        return false
+    }
+
     $: navEntriesToShow = viewableNavEntries.slice(0, visibleNavEntryCount)
     $: overflowNavEntries = viewableNavEntries.slice(visibleNavEntryCount)
     $: allMenuEntries = [...overflowNavEntries, ...menuEntries]
@@ -135,19 +150,7 @@
     </div>
 </GlobalHeaderPortal>
 
-<nav
-    aria-label="repository"
-    use:sizeToFit={{
-        grow() {
-            visibleNavEntryCount = Math.min(visibleNavEntryCount + 1, viewableNavEntries.length)
-            return visibleNavEntryCount < viewableNavEntries.length
-        },
-        shrink() {
-            visibleNavEntryCount = Math.max(visibleNavEntryCount - 1, 0)
-            return visibleNavEntryCount > 0
-        },
-    }}
->
+<nav aria-label="repository" use:sizeToFit={{ grow, shrink }}>
     <RepoMenu
         repoName={data.repoName}
         displayRepoName={data.displayRepoName}

--- a/client/web-sveltekit/src/routes/search/FileSearchResultHeader.svelte
+++ b/client/web-sveltekit/src/routes/search/FileSearchResultHeader.svelte
@@ -1,13 +1,13 @@
 <script lang="ts">
     import { highlightRanges } from '$lib/dom'
-    import { getFileMatchUrl, type ContentMatch, type PathMatch, type SymbolMatch } from '$lib/shared'
-    import CopyButton from '$lib/wildcard/CopyButton.svelte'
+    import DisplayPath from '$lib/path/DisplayPath.svelte'
+    import { pathHrefFactory } from '$lib/path/index'
+    import { getRevision, type ContentMatch, type PathMatch, type SymbolMatch } from '$lib/shared'
 
     import RepoRev from './RepoRev.svelte'
 
     export let result: ContentMatch | PathMatch | SymbolMatch
 
-    $: fileURL = getFileMatchUrl(result)
     $: rev = result.branches?.[0]
 
     $: matches =
@@ -16,34 +16,37 @@
             : []
 </script>
 
-<RepoRev repoName={result.repository} {rev} />
-<span class="interpunct">·</span>
-<span class="root">
-    {#key result}
-        <a class="path" href={fileURL} use:highlightRanges={{ ranges: matches }}>
-            {result.path}
-        </a>
-    {/key}
-    <span data-visible-on-focus><CopyButton value={result.path} label="Copy path to clipboard" /></span>
-</span>
+<div class="root">
+    <RepoRev repoName={result.repository} {rev} />
+    <span class="interpunct">·</span>
+    <!-- Wrap the path and the copy button in a span so they wrap together  -->
+    <span use:highlightRanges={{ ranges: matches }}>
+        <DisplayPath
+            path={result.path}
+            pathHref={pathHrefFactory({
+                repoName: result.repository,
+                revision: getRevision(result.branches, result.commit),
+                fullPath: result.path,
+                fullPathType: 'blob',
+            })}
+            showCopyButton
+        />
+    </span>
+</div>
 
 <style lang="scss">
     .root {
-        font-family: var(--code-font-family);
-        font-size: var(--code-font-size);
+        display: inline-flex;
+        flex-wrap: wrap;
+        align-items: center;
+        gap: 0.5rem;
 
-        a,
-        span {
-            vertical-align: middle;
+        :global([data-path-container]) {
+            flex-flow: wrap;
         }
     }
 
     .interpunct {
-        margin: 0 0.5rem;
         color: var(--text-disabled);
-    }
-
-    .path {
-        color: var(--text-body);
     }
 </style>

--- a/client/web-sveltekit/src/routes/search/FileSearchResultHeader.svelte
+++ b/client/web-sveltekit/src/routes/search/FileSearchResultHeader.svelte
@@ -19,7 +19,7 @@
 <div class="root">
     <RepoRev repoName={result.repository} {rev} />
     <span class="interpunct">·</span>
-    <span use:highlightRanges={{ ranges: matches }}>
+    <span class="path" use:highlightRanges={{ ranges: matches }}>
         <DisplayPath
             path={result.path}
             pathHref={pathHrefFactory({
@@ -43,6 +43,10 @@
         :global([data-path-container]) {
             flex-flow: wrap;
         }
+    }
+
+    .path {
+        display: contents;
     }
 
     .interpunct {

--- a/client/web-sveltekit/src/routes/search/FileSearchResultHeader.svelte
+++ b/client/web-sveltekit/src/routes/search/FileSearchResultHeader.svelte
@@ -19,7 +19,6 @@
 <div class="root">
     <RepoRev repoName={result.repository} {rev} />
     <span class="interpunct">·</span>
-    <!-- Wrap the path and the copy button in a span so they wrap together  -->
     <span use:highlightRanges={{ ranges: matches }}>
         <DisplayPath
             path={result.path}

--- a/client/web-sveltekit/src/routes/search/SearchResult.svelte
+++ b/client/web-sveltekit/src/routes/search/SearchResult.svelte
@@ -1,4 +1,4 @@
-<article data-testid="search-result">
+<article data-show-copy-target data-testid="search-result">
     <div class="header">
         <div class="title">
             <slot name="title" />
@@ -18,15 +18,12 @@
 
 <style lang="scss">
     article {
-        :global([data-visible-on-focus]) {
-            visibility: hidden;
+        :global([data-copy-button]) {
+            opacity: 0;
+            transition: opacity 0.2s;
         }
-
-        &:hover,
-        &:focus-within {
-            :global([data-visible-on-focus]) {
-                visibility: visible;
-            }
+        &:is(:hover, :focus-within) :global([data-copy-button]) {
+            opacity: 1;
         }
     }
 

--- a/client/web-sveltekit/src/routes/search/page.spec.ts
+++ b/client/web-sveltekit/src/routes/search/page.spec.ts
@@ -131,11 +131,13 @@ test('copy path button appears and copies path', async ({ page, sg }) => {
     )
     await stream.close()
 
-    const copyPathButton = page.getByRole('button', { name: 'Copy path to clipboard' })
-
     for (const match of [contentMatch, pathMatch, symbolMatch]) {
-        await page.getByRole('link', { name: match.path }).hover()
-        expect(copyPathButton).toBeVisible()
+        await page.getByText(match.path).hover()
+        const copyPathButton = page
+            .locator('article')
+            .filter({ hasText: match.path })
+            .getByLabel('Copy path to clipboard')
+        await expect(copyPathButton).toBeVisible()
         await copyPathButton.click()
         const clipboardText = await page.evaluate('navigator.clipboard.readText()')
         expect(clipboardText).toBe(match.path)

--- a/client/web-sveltekit/src/testing/search-testdata.ts
+++ b/client/web-sveltekit/src/testing/search-testdata.ts
@@ -104,7 +104,7 @@ function createUnifiedDiff(): string {
 
 export function createContentMatch(): ContentMatch {
     const repository = createRepoName()
-    const path = faker.system.filePath()
+    const path = faker.system.filePath().slice(1)
 
     return {
         type: 'content',
@@ -160,7 +160,7 @@ export function createTeamMatch(): TeamMatch {
 }
 
 export function createPathMatch(): PathMatch {
-    const path = faker.system.filePath()
+    const path = faker.system.filePath().slice(1)
     return {
         type: 'path',
         repository: createRepoName(),
@@ -172,7 +172,7 @@ export function createPathMatch(): PathMatch {
     }
 }
 export function createSymbolMatch(): SymbolMatch {
-    const path = faker.system.filePath()
+    const path = faker.system.filePath().slice(1)
     return {
         type: 'symbol',
         repository: createRepoName(),


### PR DESCRIPTION
This adds two new components for the common situation of needing to display a styled path. 

- `DisplayPath` handles splitting, coloring, spacing, slotting in a file icon, adding a copy button, and ensuring that no spaces get introduced when copying the path manually
- `ShrinkablePath` is built on top of `DisplayPath` and adds the ability to collapse path elements into a dropdown menu

These are used in three places:
- The file header. There should be no change in behavior except maybe a simplified DOM. This makes use of the "Shrinkable" version of the component.
- The file search result header. This required carefully ensuring that the text content of the node is exactly equal to the path so that the character offsets are correct.
- The file popover, where it is used for both the repo name (unlinkified version) and the file name (linkified version).

Fixes SRCH-718
Fixes SRCH-690

[Video walkthrough](https://share.cleanshot.com/VwfMYGwq)

## Test plan

Existing tests that I wrote previously cover most of this. I updated them where necessary. Added storybook pages for most of the variants. Lots of manual and visual testing. Interestingly, playwright seems to have simulated copy/paste behavior that does not match real browsers, so I could not rely on that for testing.
