### PR TITLE
feature/db/sub_repo_perms: add IPs column to sub repo perms

### DIFF
--- a/internal/database/schema.json
+++ b/internal/database/schema.json
@@ -26150,6 +26150,19 @@
       "Comment": "Responsible for storing permissions at a finer granularity than repo",
       "Columns": [
         {
+          "Name": "ips",
+          "Index": 8,
+          "TypeName": "text[]",
+          "IsNullable": true,
+          "Default": "",
+          "CharacterMaximumLength": 0,
+          "IsIdentity": false,
+          "IdentityGeneration": "",
+          "IsGenerated": "NEVER",
+          "GenerationExpression": "",
+          "Comment": "IP addresses corresponding to each path. IP in slot 0 in the array corresponds to path the in slot 0 of the path array, etc. NULL if not yet migrated, empty array for no IP restrictions."
+        },
+        {
           "Name": "paths",
           "Index": 7,
           "TypeName": "text[]",
@@ -26238,6 +26251,13 @@
         }
       ],
       "Constraints": [
+        {
+          "Name": "ips_paths_length_check",
+          "ConstraintType": "c",
+          "RefTableName": "",
+          "IsDeferrable": false,
+          "ConstraintDefinition": "CHECK (ips IS NULL OR array_length(ips, 1) = array_length(paths, 1) AND NOT (''::text = ANY (ips)))"
+        },
         {
           "Name": "sub_repo_permissions_repo_id_fk",
           "ConstraintType": "f",

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -3989,9 +3989,12 @@ Foreign-key constraints:
  version    | integer                  |           | not null | 1
  updated_at | timestamp with time zone |           | not null | now()
  paths      | text[]                   |           |          | 
+ ips        | text[]                   |           |          | 
 Indexes:
     "sub_repo_permissions_repo_id_user_id_version_uindex" UNIQUE, btree (repo_id, user_id, version)
     "sub_repo_perms_user_id" btree (user_id)
+Check constraints:
+    "ips_paths_length_check" CHECK (ips IS NULL OR array_length(ips, 1) = array_length(paths, 1) AND NOT (''::text = ANY (ips)))
 Foreign-key constraints:
     "sub_repo_permissions_repo_id_fk" FOREIGN KEY (repo_id) REFERENCES repo(id) ON DELETE CASCADE
     "sub_repo_permissions_users_id_fk" FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
@@ -3999,6 +4002,8 @@ Foreign-key constraints:
 ```
 
 Responsible for storing permissions at a finer granularity than repo
+
+**ips**: IP addresses corresponding to each path. IP in slot 0 in the array corresponds to path the in slot 0 of the path array, etc. NULL if not yet migrated, empty array for no IP restrictions.
 
 **paths**: Paths that begin with a minus sign (-) are exclusion paths.
 

--- a/migrations/frontend/1720651147_add_ips_to_sub_repo_perms_table/down.sql
+++ b/migrations/frontend/1720651147_add_ips_to_sub_repo_perms_table/down.sql
@@ -1,5 +1,3 @@
--- Undo the changes made in the up migration
-
 -- Remove the check constraint to ensure ips is either NULL or has the same length as paths
 ALTER TABLE IF EXISTS ONLY sub_repo_permissions
     DROP CONSTRAINT IF EXISTS ips_paths_length_check;

--- a/migrations/frontend/1720651147_add_ips_to_sub_repo_perms_table/down.sql
+++ b/migrations/frontend/1720651147_add_ips_to_sub_repo_perms_table/down.sql
@@ -1,0 +1,9 @@
+-- Undo the changes made in the up migration
+
+-- Remove the check constraint to ensure ips is either NULL or has the same length as paths
+ALTER TABLE IF EXISTS ONLY sub_repo_permissions
+    DROP CONSTRAINT IF EXISTS ips_paths_length_check;
+
+-- Remove the new 'ips' column from the sub_repo_permissions table
+ALTER TABLE IF EXISTS ONLY sub_repo_permissions
+    DROP COLUMN IF EXISTS ips;

--- a/migrations/frontend/1720651147_add_ips_to_sub_repo_perms_table/metadata.yaml
+++ b/migrations/frontend/1720651147_add_ips_to_sub_repo_perms_table/metadata.yaml
@@ -1,0 +1,2 @@
+name: add ips to sub_repo_perms_table
+parents: [1720165387]

--- a/migrations/frontend/1720651147_add_ips_to_sub_repo_perms_table/up.sql
+++ b/migrations/frontend/1720651147_add_ips_to_sub_repo_perms_table/up.sql
@@ -1,0 +1,33 @@
+-- Perform migration here.
+--
+-- See /migrations/README.md. Highlights:
+--  * Make migrations idempotent (use IF EXISTS)
+--  * Make migrations backwards-compatible (old readers/writers must continue to work)
+--  * If you are using CREATE INDEX CONCURRENTLY, then make sure that only one statement
+--    is defined per file, and that each such statement is NOT wrapped in a transaction.
+--    Each such migration must also declare "createIndexConcurrently: true" in their
+--    associated metadata.yaml file.
+--  * If you are modifying Postgres extensions, you must also declare "privileged: true"
+--    in the associated metadata.yaml file.
+
+-- Add the new 'ips' column to the sub_repo_permissions table
+ALTER TABLE IF EXISTS ONLY sub_repo_permissions
+    ADD COLUMN IF NOT EXISTS ips text[];
+
+-- Remove the check constraint to ensure ips is either NULL or has the same length as paths
+ALTER TABLE IF EXISTS ONLY sub_repo_permissions
+    DROP CONSTRAINT IF EXISTS ips_paths_length_check;
+
+-- Add a check constraint to ensure ips is either NULL or has the same length as paths
+ALTER TABLE IF EXISTS ONLY sub_repo_permissions
+    ADD CONSTRAINT ips_paths_length_check
+        CHECK (
+            ips IS NULL
+                OR (
+                    array_length(ips, 1) = array_length(paths, 1)
+                    AND NOT '' = ANY(ips) -- Don't allow empty strings
+                )
+            );
+
+-- Add a comment explaining the new column
+COMMENT ON COLUMN sub_repo_permissions.ips IS 'IP addresses corresponding to each path. IP in slot 0 in the array corresponds to path the in slot 0 of the path array, etc. NULL if not yet migrated, empty array for no IP restrictions.';

--- a/migrations/frontend/1720651147_add_ips_to_sub_repo_perms_table/up.sql
+++ b/migrations/frontend/1720651147_add_ips_to_sub_repo_perms_table/up.sql
@@ -1,15 +1,3 @@
--- Perform migration here.
---
--- See /migrations/README.md. Highlights:
---  * Make migrations idempotent (use IF EXISTS)
---  * Make migrations backwards-compatible (old readers/writers must continue to work)
---  * If you are using CREATE INDEX CONCURRENTLY, then make sure that only one statement
---    is defined per file, and that each such statement is NOT wrapped in a transaction.
---    Each such migration must also declare "createIndexConcurrently: true" in their
---    associated metadata.yaml file.
---  * If you are modifying Postgres extensions, you must also declare "privileged: true"
---    in the associated metadata.yaml file.
-
 -- Add the new 'ips' column to the sub_repo_permissions table
 ALTER TABLE IF EXISTS ONLY sub_repo_permissions
     ADD COLUMN IF NOT EXISTS ips text[];

--- a/migrations/frontend/squashed.sql
+++ b/migrations/frontend/squashed.sql
@@ -4618,12 +4618,16 @@ CREATE TABLE sub_repo_permissions (
     user_id integer NOT NULL,
     version integer DEFAULT 1 NOT NULL,
     updated_at timestamp with time zone DEFAULT now() NOT NULL,
-    paths text[]
+    paths text[],
+    ips text[],
+    CONSTRAINT ips_paths_length_check CHECK (((ips IS NULL) OR ((array_length(ips, 1) = array_length(paths, 1)) AND (NOT (''::text = ANY (ips))))))
 );
 
 COMMENT ON TABLE sub_repo_permissions IS 'Responsible for storing permissions at a finer granularity than repo';
 
 COMMENT ON COLUMN sub_repo_permissions.paths IS 'Paths that begin with a minus sign (-) are exclusion paths.';
+
+COMMENT ON COLUMN sub_repo_permissions.ips IS 'IP addresses corresponding to each path. IP in slot 0 in the array corresponds to path the in slot 0 of the path array, etc. NULL if not yet migrated, empty array for no IP restrictions.';
 
 CREATE TABLE survey_responses (
     id bigint NOT NULL,


### PR DESCRIPTION
This PR modifies the sub_repo_permissions database to store the ip addresses associated with each Perforce path rule, as part of the IP based sub repo permissions work. 

The new IP column is implemetned as a []text similar to the path column. The IP address associated with `paths[0]` is stored in the ips column in `ips[0]`. 

For example, the follownig proections table 

```
Protections:
    read     user     emily   *                    //depot/elm_proj/...
    write    group    devgrp  *                    //...
    write    user     *       192.168.41.0/24     -//...
    write    user     *       [2001:db8:1:2::]/64 -//...
    write    user     joe     *                   -//...
    write    user     lisag   *                   -//depot/...
    write    user     lisag   *                    //depot/doc/...
    super    user     edk     *                    //...
```

turns into the following rows in the sub_repo_permissions table

| repo_id | user_id | version | updated_at | paths | ips |
|---------|---------|---------|------------|-------|-----|
| 1 | 1 | 1 | 2023-07-01 10:00:00 | {`"//depot/elm_proj/..."`} | {`"*"`} |
| 1 | 2 | 1 | 2023-07-01 10:00:00 | {`"//..."`} | {`"*"`} |
| 1 | 3 | 1 | 2023-07-01 10:00:00 | {`"-//..."`} | {`"192.168.41.0/24"`} |
| 1 | 4 | 1 | 2023-07-01 10:00:00 | {`"-//..."`} | {`"2001:db8:1:2::]/64"`} |
| 1 | 5 | 1 | 2023-07-01 10:00:00 | {`"-//..."`} | {`"*"`} |
| 1 | 6 | 1 | 2023-07-01 10:00:00 | {`"-//depot/..."`, `"//depot/doc/..."`} | {`"*"`, `"*"`} |
| 1 | 7 | 1 | 2023-07-01 10:00:00 | {`"//..."`} | {`"*"`} |

## Test plan

The unit test for the sub_repository_permissions store PR that is built on this PR: https://app.graphite.dev/github/pr/sourcegraph/sourcegraph/63811/internal-database-sub_repo_permissions-modify-store-to-be-able-to-insert-ip-based-permissions

## Changelog

- The sub_repo_permissions table now has an ips column to store the associated IP address associated with each path rule.
