### PR TITLE
Context: return lines around symbol match

### DIFF
--- a/cmd/frontend/internal/codycontext/context.go
+++ b/cmd/frontend/internal/codycontext/context.go
@@ -351,22 +351,17 @@ func addLimitsAndFilter(plan *search.Inputs, filter fileMatcher, args GetContext
 }
 
 func fileMatchToContextMatch(fm *result.FileMatch) FileChunkContext {
-	if len(fm.ChunkMatches) == 0 {
+	var startLine int
+	if len(fm.Symbols) != 0 {
+		startLine = max(0, fm.Symbols[0].Symbol.Line-5) // 5 lines of leading context, clamped to zero
+	} else if len(fm.ChunkMatches) != 0 {
+		// To provide some context variety, we just use the top-ranked
+		// chunk (the first chunk) from each file match.
+		startLine = max(0, fm.ChunkMatches[0].ContentStart.Line-5) // 5 lines of leading context, clamped to zero
+	} else {
 		// If this is a filename-only match, return a single chunk at the start of the file
-		return FileChunkContext{
-			RepoName:  fm.Repo.Name,
-			RepoID:    fm.Repo.ID,
-			CommitID:  fm.CommitID,
-			Path:      fm.Path,
-			StartLine: 0,
-		}
+		startLine = 0
 	}
-
-	// To provide some context variety, we just use the top-ranked
-	// chunk (the first chunk) from each file
-
-	// 5 lines of leading context, clamped to zero
-	startLine := max(0, fm.ChunkMatches[0].ContentStart.Line-5)
 
 	return FileChunkContext{
 		RepoName:  fm.Repo.Name,

--- a/cmd/frontend/internal/codycontext/context_test.go
+++ b/cmd/frontend/internal/codycontext/context_test.go
@@ -64,6 +64,40 @@ func TestFileMatchToContextMatches(t *testing.T) {
 				StartLine: 85,
 			},
 		},
+		{
+			// With symbol match returns context around first symbol
+			fileMatch: &result.FileMatch{
+				File: result.File{
+					Path:     "main.go",
+					CommitID: "abc123",
+					Repo: types.MinimalRepo{
+						Name: "repo",
+						ID:   1,
+					},
+				},
+				Symbols: []*result.SymbolMatch{
+					{
+						Symbol: result.Symbol{
+							Line: 23,
+							Name: "symbol",
+						},
+					},
+					{
+						Symbol: result.Symbol{
+							Line: 37,
+							Name: "symbol",
+						},
+					},
+				},
+			},
+			want: FileChunkContext{
+				RepoName:  "repo",
+				RepoID:    1,
+				CommitID:  "abc123",
+				Path:      "main.go",
+				StartLine: 18,
+			},
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
This PR fixes an important bug in #62976, where we didn't properly map the
symbol line match to the return type. Instead, we accidentally treated symbol
matches like file matches and returned the start of the file.

## Test plan

Add new unit test for symbol match conversion. Extensive manual testing.