### PR TITLE
chore: Replace 'dumps' terminology in comments

### DIFF
--- a/internal/codeintel/uploads/internal/background/commitgraph/job_commitgraph.go
+++ b/internal/codeintel/uploads/internal/background/commitgraph/job_commitgraph.go
@@ -90,7 +90,7 @@ func (s *commitGraphUpdater) lockAndUpdateUploadsVisibleToCommits(ctx context.Co
 
 	// The following process pulls the commit graph for the given repository from gitserver, pulls the set of LSIF
 	// upload objects for the given repository from Postgres, and correlates them into a visibility
-	// graph. This graph is then upserted back into Postgres for use by find closest dumps queries.
+	// graph. This graph is then upserted back into Postgres for use by find closest completd uploads queries.
 	//
 	// The user should supply a dirty token that is associated with the given repository so that
 	// the repository can be unmarked as long as the repository is not marked as dirty again before

--- a/internal/codeintel/uploads/internal/store/commitgraph.go
+++ b/internal/codeintel/uploads/internal/store/commitgraph.go
@@ -63,7 +63,7 @@ var scanDirtyRepositories = basestore.NewSliceScanner(func(s dbutil.Scanner) (dr
 
 // UpdateUploadsVisibleToCommits uses the given commit graph and the tip of non-stale branches and tags to determine the
 // set of LSIF uploads that are visible for each commit, and the set of uploads which are visible at the tip of a
-// non-stale branch or tag. The decorated commit graph is serialized to Postgres for use by find closest dumps
+// non-stale branch or tag. The decorated commit graph is serialized to Postgres for use by find closest completed uploads
 // queries.
 //
 // If dirtyToken is supplied, the repository will be unmarked when the supplied token does matches the most recent
@@ -278,7 +278,7 @@ LIMIT %s
 // optional indexer.
 //
 // This method should be used when the commit is known to exist in the lsif_nearest_uploads table. If it doesn't, then this method
-// will return no dumps (as the input commit is not reachable from anything with an upload). The nearest uploads table must be
+// will return no completed uploads (as the input commit is not reachable from anything with an upload). The nearest uploads table must be
 // refreshed before calling this method when the commit is unknown.
 //
 // Because refreshing the commit graph can be very expensive, we also provide FindClosestCompletedUploadsFromGraphFragment. That method should
@@ -291,9 +291,9 @@ LIMIT %s
 // by depth (e.g. if the graph contains an ancestor at depth d, then the graph also contains all other ancestors up to depth d), then
 // we get the ideal behavior. Only if we contain a partial row of ancestors will we return partial results.
 //
-// It is possible for some dumps to overlap theoretically, e.g. if someone uploads one dump covering the repository root and then later
-// splits the repository into multiple dumps. For this reason, the returned dumps are always sorted in most-recently-finished order to
-// prevent returning data from stale dumps.
+// It is possible for some indexes to overlap theoretically, e.g. if someone uploads one index covering the repository root and then later
+// splits the repository into multiple indexes. For this reason, the returned indexes are always sorted in most-recently-finished order to
+// prevent returning data from stale indexes.
 func (s *store) FindClosestCompletedUploads(ctx context.Context, opts shared.UploadMatchingOptions) (_ []shared.CompletedUpload, err error) {
 	ctx, trace, endObservation := s.operations.findClosestCompletedUploads.With(ctx, &err, observation.Args{Attrs: opts.Attrs()})
 	defer endObservation(1, observation.Args{})

--- a/internal/codeintel/uploads/internal/store/observability.go
+++ b/internal/codeintel/uploads/internal/store/observability.go
@@ -61,7 +61,7 @@ type operations struct {
 	markFailed                           *observation.Operation
 	deleteUploads                        *observation.Operation
 
-	// Dumps
+	// Completed uploads
 	findClosestCompletedUploads                   *observation.Operation
 	findClosestCompletedUploadsFromGraphFragment  *observation.Operation
 	getCompletedUploadsWithDefinitionsForMonikers *observation.Operation
@@ -168,7 +168,7 @@ func newOperations(observationCtx *observation.Context) *operations {
 		persistNearestUploadsLinks: op("persistNearestUploadsLinks"),
 		persistUploadsVisibleAtTip: op("persistUploadsVisibleAtTip"),
 
-		// Dumps
+		// Completed uploads
 		findClosestCompletedUploads:                   op("FindClosestCompletedUploads"),
 		findClosestCompletedUploadsFromGraphFragment:  op("FindClosestCompletedUploadsFromGraphFragment"),
 		getCompletedUploadsWithDefinitionsForMonikers: op("GetUploadsWithDefinitionsForMonikers"),

--- a/internal/codeintel/uploads/internal/store/uploads_test.go
+++ b/internal/codeintel/uploads/internal/store/uploads_test.go
@@ -358,7 +358,7 @@ func TestGetCompletedUploadsByIDs(t *testing.T) {
 	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(observation.TestContextTB(t), db)
 
-	// Dumps do not exist initially
+	// Indexes do not exist initially
 	if uploads, err := store.GetCompletedUploadsByIDs(context.Background(), []int{1, 2}); err != nil {
 		t.Fatalf("unexpected error getting dump: %s", err)
 	} else if len(uploads) > 0 {

--- a/internal/codeintel/uploads/service.go
+++ b/internal/codeintel/uploads/service.go
@@ -112,10 +112,10 @@ func (s *Service) InferClosestUploads(ctx context.Context, opts shared.UploadMat
 		return nil, err
 	}
 
-	// The parameters exactPath and rootMustEnclosePath align here: if we're looking for dumps
-	// that can answer queries for a directory (e.g. diagnostics), we want any dump that happens
-	// to intersect the target directory. If we're looking for dumps that can answer queries for
-	// a single file, then we need a dump with a root that properly encloses that file.
+	// The parameters exactPath and rootMustEnclosePath align here: if we're looking for completed uploads
+	// that can answer queries for a directory (e.g. diagnostics), we want any completed upload that happens
+	// to intersect the target directory. If we're looking for completed uploads that can answer queries for
+	// a single file, then we need a completed upload with a root that properly encloses that file.
 	if uploads, err := s.store.FindClosestCompletedUploads(ctx, opts); err != nil {
 		return nil, errors.Wrap(err, "store.FindClosestCompletedUploads")
 	} else if len(uploads) != 0 {
@@ -129,7 +129,7 @@ func (s *Service) InferClosestUploads(ctx context.Context, opts shared.UploadMat
 		return nil, nil
 	}
 
-	// Commit is known and the empty dumps list explicitly means nothing is visible
+	// Commit is known and the empty completed uploads list explicitly means nothing is visible
 	if commitExists, err := s.store.HasCommit(ctx, opts.RepositoryID, opts.Commit); err != nil {
 		return nil, errors.Wrap(err, "dbstore.HasCommit")
 	} else if commitExists {


### PR DESCRIPTION
Missed some places during https://github.com/sourcegraph/sourcegraph/pull/61131

## Test plan

n/a, updating comments only

## Changelog