### PR TITLE
refactor(codeintel): Extracts a MappedIndex abstraction over uploads

### DIFF
--- a/internal/codeintel/codenav/BUILD.bazel
+++ b/internal/codeintel/codenav/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "gittree_translator.go",
         "iface.go",
         "init.go",
+        "mapped_index.go",
         "mocks_temp.go",
         "observability.go",
         "request_state.go",
@@ -60,6 +61,7 @@ go_test(
     timeout = "short",
     srcs = [
         "gittree_translator_test.go",
+        "mapped_index_test.go",
         "scip_utils_test.go",
         "service_closest_uploads_test.go",
         "service_definitions_test.go",
@@ -80,6 +82,7 @@ go_test(
         "//internal/actor",
         "//internal/api",
         "//internal/authz",
+        "//internal/codeintel/codenav/internal/lsifstore",
         "//internal/codeintel/codenav/shared",
         "//internal/codeintel/core",
         "//internal/codeintel/uploads/shared",

--- a/internal/codeintel/codenav/BUILD.bazel
+++ b/internal/codeintel/codenav/BUILD.bazel
@@ -53,6 +53,7 @@ go_library(
         "@com_github_sourcegraph_scip//bindings/go/scip",
         "@com_github_wk8_go_ordered_map_v2//:go-ordered-map",
         "@io_opentelemetry_go_otel//attribute",
+        "@org_golang_google_protobuf//proto",
     ],
 )
 

--- a/internal/codeintel/codenav/internal/lsifstore/lsifstore_documents.go
+++ b/internal/codeintel/codenav/internal/lsifstore/lsifstore_documents.go
@@ -41,11 +41,8 @@ func (s *store) SCIPDocument(ctx context.Context, uploadID int, path core.Upload
 		return &document, nil
 	})
 	doc, ok, err := scanner(s.db.Query(ctx, sqlf.Sprintf(fetchSCIPDocumentQuery, uploadID, path.RawValue())))
-	if err != nil {
+	if err != nil || !ok {
 		return core.None[*scip.Document](), err
-	}
-	if !ok {
-		return core.None[*scip.Document](), nil
 	}
 	return core.Some(doc), nil
 }

--- a/internal/codeintel/codenav/internal/lsifstore/lsifstore_documents.go
+++ b/internal/codeintel/codenav/internal/lsifstore/lsifstore_documents.go
@@ -16,7 +16,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 )
 
-func (s *store) SCIPDocument(ctx context.Context, uploadID int, path core.UploadRelPath) (_ *scip.Document, err error) {
+func (s *store) SCIPDocument(ctx context.Context, uploadID int, path core.UploadRelPath) (_ *scip.Document, found bool, err error) {
 	ctx, _, endObservation := s.operations.scipDocument.With(ctx, &err, observation.Args{Attrs: []attribute.KeyValue{
 		attribute.String("path", path.RawValue()),
 		attribute.Int("uploadID", uploadID),
@@ -40,8 +40,7 @@ func (s *store) SCIPDocument(ctx context.Context, uploadID int, path core.Upload
 		}
 		return &document, nil
 	})
-	doc, _, err := scanner(s.db.Query(ctx, sqlf.Sprintf(fetchSCIPDocumentQuery, uploadID, path.RawValue())))
-	return doc, err
+	return scanner(s.db.Query(ctx, sqlf.Sprintf(fetchSCIPDocumentQuery, uploadID, path.RawValue())))
 }
 
 const fetchSCIPDocumentQuery = `

--- a/internal/codeintel/codenav/internal/lsifstore/store.go
+++ b/internal/codeintel/codenav/internal/lsifstore/store.go
@@ -24,7 +24,7 @@ type LsifStore interface {
 	// Whole-document data
 	GetStencil(ctx context.Context, bundleID int, path core.UploadRelPath) ([]shared.Range, error)
 	GetRanges(ctx context.Context, bundleID int, path core.UploadRelPath, startLine, endLine int) ([]shared.CodeIntelligenceRange, error)
-	SCIPDocument(ctx context.Context, uploadID int, path core.UploadRelPath) (_ *scip.Document, found bool, err error)
+	SCIPDocument(ctx context.Context, uploadID int, path core.UploadRelPath) (core.Option[*scip.Document], error)
 
 	// Fetch symbol names by position
 	GetMonikersByPosition(ctx context.Context, uploadID int, path core.UploadRelPath, line, character int) ([][]precise.MonikerData, error)

--- a/internal/codeintel/codenav/internal/lsifstore/store.go
+++ b/internal/codeintel/codenav/internal/lsifstore/store.go
@@ -24,7 +24,7 @@ type LsifStore interface {
 	// Whole-document data
 	GetStencil(ctx context.Context, bundleID int, path core.UploadRelPath) ([]shared.Range, error)
 	GetRanges(ctx context.Context, bundleID int, path core.UploadRelPath, startLine, endLine int) ([]shared.CodeIntelligenceRange, error)
-	SCIPDocument(ctx context.Context, uploadID int, path core.UploadRelPath) (_ *scip.Document, err error)
+	SCIPDocument(ctx context.Context, uploadID int, path core.UploadRelPath) (_ *scip.Document, found bool, err error)
 
 	// Fetch symbol names by position
 	GetMonikersByPosition(ctx context.Context, uploadID int, path core.UploadRelPath, line, character int) ([][]precise.MonikerData, error)

--- a/internal/codeintel/codenav/mapped_index.go
+++ b/internal/codeintel/codenav/mapped_index.go
@@ -11,8 +11,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/codenav/internal/lsifstore"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/codenav/shared"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/core"
-	"github.com/sourcegraph/sourcegraph/internal/gitserver"
-	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
 type MappedIndex interface {
@@ -35,32 +33,6 @@ type MappedDocument interface {
 }
 
 var _ MappedDocument = &mappedDocument{}
-
-// NewMappedIndex creates a MappedIndex for an uploaded index and a targetCommit
-func NewMappedIndex(
-	lsifStore lsifstore.LsifStore,
-	repo *types.Repo,
-	gitserverClient gitserver.Client,
-	upload core.UploadLike,
-	targetCommit api.CommitID,
-) (MappedIndex, error) {
-	// NOTE(issue: GRAPH-742): No idea if 100 is a reasonable number here (the resolver wide one has a default of 1000),
-	// This will go away once the linked issue is fixed.
-	hunkCache, err := NewHunkCache(100)
-	if err != nil {
-		return nil, err
-	}
-	gitTreeTranslator := NewGitTreeTranslator(gitserverClient, &TranslationBase{
-		Repo:   repo,
-		Commit: targetCommit,
-	}, hunkCache)
-	return mappedIndex{
-		lsifStore:         lsifStore,
-		gitTreeTranslator: gitTreeTranslator,
-		upload:            upload,
-		targetCommit:      targetCommit,
-	}, nil
-}
 
 // NewMappedIndexFromTranslator creates a MappedIndex using the given GitTreeTranslator.
 // The translators SourceCommit has to be the targetCommit, which will be mapped to upload.GetCommit()

--- a/internal/codeintel/codenav/mapped_index.go
+++ b/internal/codeintel/codenav/mapped_index.go
@@ -50,8 +50,8 @@ func NewMappedIndex(
 	upload core.UploadLike,
 	targetCommit api.CommitID,
 ) (MappedIndex, error) {
-	// NOTE: No idea if 100 is a reasonable number here (the resolver wide one has a default of 1000),
-	// I'll get rid of the LRU cache once I get the unified diff command output from gitserver
+	// NOTE(issue: GRAPH-742): No idea if 100 is a reasonable number here (the resolver wide one has a default of 1000),
+	// This will go away once the linked issue is fixed.
 	hunkCache, err := NewHunkCache(100)
 	if err != nil {
 		return nil, err

--- a/internal/codeintel/codenav/mapped_index.go
+++ b/internal/codeintel/codenav/mapped_index.go
@@ -1,0 +1,202 @@
+package codenav
+
+import (
+	"context"
+	"sync"
+
+	genslices "github.com/life4/genesis/slices"
+	"github.com/sourcegraph/scip/bindings/go/scip"
+
+	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/codeintel/codenav/internal/lsifstore"
+	"github.com/sourcegraph/sourcegraph/internal/codeintel/codenav/shared"
+	"github.com/sourcegraph/sourcegraph/internal/codeintel/core"
+	"github.com/sourcegraph/sourcegraph/internal/gitserver"
+	"github.com/sourcegraph/sourcegraph/internal/types"
+)
+
+type Mapped interface {
+	IndexCommit() api.CommitID
+	TargetCommit() api.CommitID
+}
+
+// MappedIndex wraps an uploaded SCIP index and a target commit and creates MappedDocument instances,
+// which automatically map occurrence ranges across the target and index commit.
+type MappedIndex interface {
+	GetDocument(context.Context, core.RepoRelPath) (core.Option[MappedDocument], error)
+	GetUploadSummary() core.UploadSummary
+	// TODO: Should there be a bulk-API for getting multiple documents?
+	Mapped
+}
+
+var _ MappedIndex = mappedIndex{}
+
+// MappedDocument wraps a SCIP document from an uploaded index.
+// All methods accept and return ranges in the context of the target commit.
+type MappedDocument interface {
+	GetOccurrences(context.Context) ([]*scip.Occurrence, error)
+	GetOccurrencesAtRange(context.Context, scip.Range) ([]*scip.Occurrence, error)
+	Mapped
+}
+
+var _ MappedDocument = &mappedDocument{}
+
+// NewMappedIndex creates a MappedIndex for an uploaded index and a targetCommit
+func NewMappedIndex(
+	lsifStore lsifstore.LsifStore,
+	repo *types.Repo,
+	gitserverClient gitserver.Client,
+	upload core.UploadLike,
+	targetCommit api.CommitID,
+) (MappedIndex, error) {
+	// NOTE: No idea if 100 is a reasonable number here (the resolver wide one has a default of 1000),
+	// I'll get rid of the LRU cache once I get the unified diff command output from gitserver
+	hunkCache, err := NewHunkCache(100)
+	if err != nil {
+		return nil, err
+	}
+	gitTreeTranslator := NewGitTreeTranslator(gitserverClient, &TranslationBase{
+		Repo:   repo,
+		Commit: targetCommit,
+	}, hunkCache)
+	return mappedIndex{
+		lsifStore:         lsifStore,
+		gitTreeTranslator: gitTreeTranslator,
+		upload:            upload,
+		targetCommit:      targetCommit,
+	}, nil
+}
+
+// NewMappedIndexFromTranslator creates a MappedIndex using the given GitTreeTranslator.
+// The translators SourceCommit has to be the targetCommit, which will be mapped to upload.GetCommit()
+func NewMappedIndexFromTranslator(
+	lsifStore lsifstore.LsifStore,
+	gitTreeTranslator GitTreeTranslator,
+	upload core.UploadLike,
+) MappedIndex {
+	return mappedIndex{
+		lsifStore:         lsifStore,
+		gitTreeTranslator: gitTreeTranslator,
+		upload:            upload,
+		targetCommit:      gitTreeTranslator.GetSourceCommit(),
+	}
+}
+
+type mappedIndex struct {
+	lsifStore         lsifstore.LsifStore
+	gitTreeTranslator GitTreeTranslator
+	upload            core.UploadLike
+	targetCommit      api.CommitID
+}
+
+func (i mappedIndex) IndexCommit() api.CommitID {
+	return i.upload.GetCommit()
+}
+
+func (i mappedIndex) TargetCommit() api.CommitID {
+	return i.targetCommit
+}
+
+func (i mappedIndex) GetUploadSummary() core.UploadSummary {
+	return core.UploadSummary{
+		ID:     i.upload.GetID(),
+		Root:   i.upload.GetRoot(),
+		Commit: i.upload.GetCommit(),
+	}
+}
+
+func (i mappedIndex) GetDocument(ctx context.Context, path core.RepoRelPath) (core.Option[MappedDocument], error) {
+	document, found, err := i.lsifStore.SCIPDocument(ctx, i.upload.GetID(), core.NewUploadRelPath(i.upload, path))
+	if err != nil {
+		return core.None[MappedDocument](), err
+	}
+	if !found {
+		return core.None[MappedDocument](), nil
+	}
+	// TODO: Should we cache the mapped document? The current usages don't request the same document twice
+	// so we'd just be increasing resident memory
+	return core.Some[MappedDocument](&mappedDocument{
+		gitTreeTranslator: i.gitTreeTranslator,
+		indexCommit:       i.upload.GetCommit(),
+		targetCommit:      i.targetCommit,
+		path:              path,
+		document:          document,
+	}), nil
+}
+
+type mappedDocument struct {
+	gitTreeTranslator GitTreeTranslator
+	indexCommit       api.CommitID
+	targetCommit      api.CommitID
+	path              core.RepoRelPath
+	document          *scip.Document
+
+	isMappedLock sync.Mutex
+	isMapped     bool
+}
+
+func (d *mappedDocument) IndexCommit() api.CommitID {
+	return d.indexCommit
+}
+
+func (d *mappedDocument) TargetCommit() api.CommitID {
+	return d.targetCommit
+}
+
+func (d *mappedDocument) GetOccurrences(ctx context.Context) ([]*scip.Occurrence, error) {
+	if d.isMapped {
+		return d.document.Occurrences, nil
+	}
+
+	d.isMappedLock.Lock()
+	defer d.isMappedLock.Unlock()
+
+	for _, occ := range d.document.Occurrences {
+		scipRange := scip.NewRangeUnchecked(occ.Range)
+		sharedRange := shared.TranslateRange(scipRange)
+		mappedRange, ok, err := d.gitTreeTranslator.GetTargetCommitRangeFromSourceRange(ctx, string(d.indexCommit), d.path.RawValue(), sharedRange, true)
+		if err != nil {
+			return nil, err
+		}
+		if !ok {
+			continue
+		}
+		occ.Range = mappedRange.ToSCIPRange().SCIPRange()
+	}
+	d.isMapped = true
+	return d.document.Occurrences, nil
+}
+
+func (d *mappedDocument) GetOccurrencesAtRange(ctx context.Context, rg scip.Range) ([]*scip.Occurrence, error) {
+	if d.isMapped {
+		return FindOccurrencesWithEqualRange(d.document.Occurrences, rg), nil
+
+	}
+	d.isMappedLock.Lock()
+	defer d.isMappedLock.Unlock()
+
+	mappedRg, ok, err := d.gitTreeTranslator.GetTargetCommitRangeFromSourceRange(
+		ctx, string(d.indexCommit), d.path.RawValue(), shared.TranslateRange(rg), false,
+	)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		// The range was changed/removed in the target commit, so return no occurrences
+		return nil, nil
+	}
+	pastOccurrences := FindOccurrencesWithEqualRange(d.document.Occurrences, mappedRg.ToSCIPRange())
+	Range := rg.SCIPRange()
+	return genslices.Map(pastOccurrences, func(occ *scip.Occurrence) *scip.Occurrence {
+		return &scip.Occurrence{
+			// Return the range in the target commit, instead of the index commit
+			Range:                 Range,
+			Symbol:                occ.Symbol,
+			SymbolRoles:           occ.SymbolRoles,
+			OverrideDocumentation: occ.OverrideDocumentation,
+			SyntaxKind:            occ.SyntaxKind,
+			Diagnostics:           occ.Diagnostics,
+			EnclosingRange:        occ.EnclosingRange,
+		}
+	}), nil
+}

--- a/internal/codeintel/codenav/mapped_index_test.go
+++ b/internal/codeintel/codenav/mapped_index_test.go
@@ -195,6 +195,8 @@ func TestMappedIndex_GetDocumentNoTranslation(t *testing.T) {
 
 func TestMappedIndex_GetDocumentWithTranslation(t *testing.T) {
 	targetCommit, upload, lsifStore := setupSimpleUpload()
+	// The translator passed to NewMappedIndex uses the targetCommit as its base.
+	// This -2 thus means going from index -> target shifts by +2 lines.
 	translator := shiftAllTranslator(targetCommit, -2)
 	mappedIndex := NewMappedIndexFromTranslator(lsifStore, translator, upload)
 

--- a/internal/codeintel/codenav/mapped_index_test.go
+++ b/internal/codeintel/codenav/mapped_index_test.go
@@ -72,19 +72,19 @@ func doc(path string, occurrences ...fakeOccurrence) fakeDocument {
 func setupUpload(commit api.CommitID, root string, documents ...fakeDocument) (uploadsshared.CompletedUpload, lsifstore.LsifStore) {
 	id := newUploadID()
 	lsifStore := NewMockLsifStore()
-	lsifStore.SCIPDocumentFunc.SetDefaultHook(func(ctx context.Context, uploadId int, path core.UploadRelPath) (*scip.Document, bool, error) {
+	lsifStore.SCIPDocumentFunc.SetDefaultHook(func(ctx context.Context, uploadId int, path core.UploadRelPath) (core.Option[*scip.Document], error) {
 		if id != uploadId {
-			return nil, false, errors.New("unknown upload id")
+			return core.None[*scip.Document](), errors.New("unknown upload id")
 		}
 		for _, document := range documents {
 			if document.path.Equal(path) {
-				return &scip.Document{
+				return core.Some(&scip.Document{
 					RelativePath: document.path.RawValue(),
 					Occurrences:  document.Occurrences(),
-				}, true, nil
+				}), nil
 			}
 		}
-		return nil, false, nil
+		return core.None[*scip.Document](), nil
 	})
 
 	return uploadsshared.CompletedUpload{

--- a/internal/codeintel/codenav/mapped_index_test.go
+++ b/internal/codeintel/codenav/mapped_index_test.go
@@ -1,0 +1,240 @@
+package codenav
+
+import (
+	"context"
+	"errors"
+	"slices"
+	"testing"
+
+	"github.com/sourcegraph/scip/bindings/go/scip"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/codeintel/codenav/internal/lsifstore"
+	"github.com/sourcegraph/sourcegraph/internal/codeintel/codenav/shared"
+	"github.com/sourcegraph/sourcegraph/internal/codeintel/core"
+	uploadsshared "github.com/sourcegraph/sourcegraph/internal/codeintel/uploads/shared"
+)
+
+var uploadIDSupply = 0
+
+func newUploadID() int {
+	uploadIDSupply += 1
+	return uploadIDSupply
+}
+
+func testRange(r int) scip.Range {
+	return scip.NewRangeUnchecked([]int32{int32(r), int32(r), int32(r)})
+}
+
+type fakeOccurrence struct {
+	symbol       string
+	isDefinition bool
+	rg           scip.Range
+}
+
+type fakeDocument struct {
+	path        core.UploadRelPath
+	occurrences []fakeOccurrence
+}
+
+func (d fakeDocument) Occurrences() []*scip.Occurrence {
+	occs := make([]*scip.Occurrence, 0, len(d.occurrences))
+	for _, occ := range d.occurrences {
+		var symbolRoles scip.SymbolRole = 0
+		if occ.isDefinition {
+			symbolRoles = scip.SymbolRole_Definition
+		}
+		occs = append(occs, &scip.Occurrence{
+			Range:       occ.rg.SCIPRange(),
+			Symbol:      occ.symbol,
+			SymbolRoles: int32(symbolRoles),
+		})
+	}
+	return occs
+}
+
+func ref(symbol string, rg int) fakeOccurrence {
+	return fakeOccurrence{
+		symbol:       symbol,
+		isDefinition: false,
+		rg:           testRange(rg),
+	}
+}
+
+func doc(path string, occurrences ...fakeOccurrence) fakeDocument {
+	return fakeDocument{
+		path:        core.NewUploadRelPathUnchecked(path),
+		occurrences: occurrences,
+	}
+}
+
+// Set up uploads + lsifstore
+func setupUpload(commit api.CommitID, root string, documents ...fakeDocument) (uploadsshared.CompletedUpload, lsifstore.LsifStore) {
+	id := newUploadID()
+	lsifStore := NewMockLsifStore()
+	lsifStore.SCIPDocumentFunc.SetDefaultHook(func(ctx context.Context, uploadId int, path core.UploadRelPath) (*scip.Document, bool, error) {
+		if id != uploadId {
+			return nil, false, errors.New("unknown upload id")
+		}
+		for _, document := range documents {
+			if document.path.Equal(path) {
+				return &scip.Document{
+					RelativePath: document.path.RawValue(),
+					Occurrences:  document.Occurrences(),
+				}, true, nil
+			}
+		}
+		return nil, false, nil
+	})
+
+	return uploadsshared.CompletedUpload{
+		ID:     id,
+		Commit: string(commit),
+		Root:   root,
+	}, lsifStore
+}
+
+func shiftSCIPRange(r scip.Range, numLines int) scip.Range {
+	return scip.NewRangeUnchecked([]int32{
+		r.Start.Line + int32(numLines),
+		r.Start.Character,
+		r.End.Line + int32(numLines),
+		r.End.Character,
+	})
+}
+
+func shiftPos(pos shared.Position, numLines int) shared.Position {
+	return shared.Position{
+		Line:      pos.Line + numLines,
+		Character: pos.Character,
+	}
+}
+
+// A GitTreeTranslator that returns positions and ranges shifted by numLines
+// and returns failed translations for paths in failingFiles
+func fakeTranslator(targetCommit api.CommitID, numLines int, failingFiles ...string) GitTreeTranslator {
+	translator := NewMockGitTreeTranslator()
+	translator.GetSourceCommitFunc.SetDefaultReturn(targetCommit)
+	translator.GetTargetCommitPositionFromSourcePositionFunc.SetDefaultHook(func(ctx context.Context, commit string, path string, pos shared.Position, reverse bool) (shared.Position, bool, error) {
+		numLines := numLines
+		if reverse {
+			numLines = -numLines
+		}
+		if slices.Contains(failingFiles, path) {
+			return shared.Position{}, false, nil
+		}
+		return shiftPos(pos, numLines), true, nil
+	})
+	translator.GetTargetCommitRangeFromSourceRangeFunc.SetDefaultHook(func(ctx context.Context, commit string, path string, rg shared.Range, reverse bool) (shared.Range, bool, error) {
+		numLines := numLines
+		if reverse {
+			numLines = -numLines
+		}
+		if slices.Contains(failingFiles, path) {
+			return shared.Range{}, false, nil
+		}
+		return shared.Range{Start: shiftPos(rg.Start, numLines), End: shiftPos(rg.End, numLines)}, true, nil
+	})
+	return translator
+}
+
+// A GitTreeTranslator that returns all positions and ranges shifted by numLines.
+func shiftAllTranslator(targetCommit api.CommitID, numLines int) GitTreeTranslator {
+	return fakeTranslator(targetCommit, numLines)
+}
+
+// A GitTreeTranslator that returns all positions and ranges unchanged
+func noopTranslator(targetCommit api.CommitID) GitTreeTranslator {
+	return shiftAllTranslator(targetCommit, 0)
+}
+
+func setupSimpleUpload() (api.CommitID, uploadsshared.CompletedUpload, lsifstore.LsifStore) {
+	indexCommit := api.CommitID("deadbeef")
+	targetCommit := api.CommitID("beefdead")
+	upload, lsifStore := setupUpload(indexCommit, "indexRoot/",
+		doc("a.go",
+			ref("a", 1),
+			ref("b", 2),
+			ref("c", 3)),
+		doc("b.go",
+			ref("a", 2)))
+	return targetCommit, upload, lsifStore
+}
+
+func TestNewMappedIndex(t *testing.T) {
+	indexCommit := api.CommitID("deadbeef")
+	targetCommit := api.CommitID("beefdead")
+	upload, lsifStore := setupUpload(indexCommit, "")
+	mappedIndex, err := NewMappedIndex(lsifStore, nil, nil, upload, targetCommit)
+	require.NoError(t, err)
+	require.Equal(t, indexCommit, mappedIndex.IndexCommit())
+	require.Equal(t, targetCommit, mappedIndex.TargetCommit())
+}
+
+func TestMappedIndex_GetDocumentNoTranslation(t *testing.T) {
+	targetCommit, upload, lsifStore := setupSimpleUpload()
+	translator := noopTranslator(targetCommit)
+	mappedIndex := NewMappedIndexFromTranslator(lsifStore, translator, upload)
+
+	ctx := context.Background()
+	unknownDoc, err := mappedIndex.GetDocument(ctx, core.NewRepoRelPathUnchecked("indexRoot/unknown.go"))
+	require.NoError(t, err)
+	require.True(t, unknownDoc.IsNone())
+
+	mappedDocumentResult, err := mappedIndex.GetDocument(ctx, core.NewRepoRelPathUnchecked("indexRoot/a.go"))
+	require.NoError(t, err)
+	mappedDocument := mappedDocumentResult.Unwrap()
+
+	occurrences, err := mappedDocument.GetOccurrencesAtRange(ctx, testRange(1))
+	require.NoError(t, err)
+	require.Len(t, occurrences, 1)
+	require.Equal(t, scip.NewRangeUnchecked(occurrences[0].GetRange()).Start.Line, int32(1))
+
+	noOccurrences, err := mappedDocument.GetOccurrencesAtRange(ctx, testRange(4))
+	require.NoError(t, err)
+	require.Len(t, noOccurrences, 0)
+
+	allOccurrences, err := mappedDocument.GetOccurrences(ctx)
+	require.NoError(t, err)
+	require.Len(t, allOccurrences, 3)
+}
+
+func TestMappedIndex_GetDocumentWithTranslation(t *testing.T) {
+	targetCommit, upload, lsifStore := setupSimpleUpload()
+	translator := shiftAllTranslator(targetCommit, -2)
+	mappedIndex := NewMappedIndexFromTranslator(lsifStore, translator, upload)
+
+	ctx := context.Background()
+	mappedDocumentOption, err := mappedIndex.GetDocument(ctx, core.NewRepoRelPathUnchecked("indexRoot/a.go"))
+	require.NoError(t, err)
+	mappedDocument := mappedDocumentOption.Unwrap()
+
+	noOccurrences, err := mappedDocument.GetOccurrencesAtRange(ctx, testRange(1))
+	require.NoError(t, err)
+	require.Len(t, noOccurrences, 0)
+
+	occurrences, err := mappedDocument.GetOccurrencesAtRange(ctx, shiftSCIPRange(testRange(1), 2))
+	require.NoError(t, err)
+	require.Len(t, occurrences, 1)
+	require.Equal(t, scip.NewRangeUnchecked(occurrences[0].GetRange()).Start.Line, int32(3))
+
+	allOccurrences, err := mappedDocument.GetOccurrences(ctx)
+	require.NoError(t, err)
+	require.Len(t, allOccurrences, 3)
+}
+
+func TestMappedIndex_GetDocumentFailedTranslation(t *testing.T) {
+	targetCommit, upload, lsifStore := setupSimpleUpload()
+	translator := fakeTranslator(targetCommit, 0, "indexRoot/b.go")
+	mappedIndex := NewMappedIndexFromTranslator(lsifStore, translator, upload)
+
+	ctx := context.Background()
+	mappedDocumentOption, err := mappedIndex.GetDocument(ctx, core.NewRepoRelPathUnchecked("indexRoot/b.go"))
+	require.NoError(t, err)
+	mappedDocument := mappedDocumentOption.Unwrap()
+
+	occurrences, err := mappedDocument.GetOccurrencesAtRange(ctx, testRange(2))
+	require.NoError(t, err)
+	require.Len(t, occurrences, 0)
+}

--- a/internal/codeintel/codenav/mapped_index_test.go
+++ b/internal/codeintel/codenav/mapped_index_test.go
@@ -165,16 +165,6 @@ func setupSimpleUpload() (api.CommitID, uploadsshared.CompletedUpload, lsifstore
 	return targetCommit, upload, lsifStore
 }
 
-func TestNewMappedIndex(t *testing.T) {
-	indexCommit := api.CommitID("deadbeef")
-	targetCommit := api.CommitID("beefdead")
-	upload, lsifStore := setupUpload(indexCommit, "")
-	mappedIndex, err := NewMappedIndex(lsifStore, nil, nil, upload, targetCommit)
-	require.NoError(t, err)
-	require.Equal(t, indexCommit, mappedIndex.IndexCommit())
-	require.Equal(t, targetCommit, mappedIndex.TargetCommit())
-}
-
 func TestMappedIndex_GetDocumentNoTranslation(t *testing.T) {
 	targetCommit, upload, lsifStore := setupSimpleUpload()
 	translator := noopTranslator(targetCommit)

--- a/internal/codeintel/codenav/mocks_temp.go
+++ b/internal/codeintel/codenav/mocks_temp.go
@@ -143,7 +143,7 @@ func NewMockLsifStore() *MockLsifStore {
 			},
 		},
 		SCIPDocumentFunc: &LsifStoreSCIPDocumentFunc{
-			defaultHook: func(context.Context, int, core.UploadRelPath) (r0 *scip.Document, r1 bool, r2 error) {
+			defaultHook: func(context.Context, int, core.UploadRelPath) (r0 core.Option[*scip.Document], r1 error) {
 				return
 			},
 		},
@@ -220,7 +220,7 @@ func NewStrictMockLsifStore() *MockLsifStore {
 			},
 		},
 		SCIPDocumentFunc: &LsifStoreSCIPDocumentFunc{
-			defaultHook: func(context.Context, int, core.UploadRelPath) (*scip.Document, bool, error) {
+			defaultHook: func(context.Context, int, core.UploadRelPath) (core.Option[*scip.Document], error) {
 				panic("unexpected invocation of MockLsifStore.SCIPDocument")
 			},
 		},
@@ -1811,24 +1811,24 @@ func (c LsifStoreGetStencilFuncCall) Results() []interface{} {
 // LsifStoreSCIPDocumentFunc describes the behavior when the SCIPDocument
 // method of the parent MockLsifStore instance is invoked.
 type LsifStoreSCIPDocumentFunc struct {
-	defaultHook func(context.Context, int, core.UploadRelPath) (*scip.Document, bool, error)
-	hooks       []func(context.Context, int, core.UploadRelPath) (*scip.Document, bool, error)
+	defaultHook func(context.Context, int, core.UploadRelPath) (core.Option[*scip.Document], error)
+	hooks       []func(context.Context, int, core.UploadRelPath) (core.Option[*scip.Document], error)
 	history     []LsifStoreSCIPDocumentFuncCall
 	mutex       sync.Mutex
 }
 
 // SCIPDocument delegates to the next hook function in the queue and stores
 // the parameter and result values of this invocation.
-func (m *MockLsifStore) SCIPDocument(v0 context.Context, v1 int, v2 core.UploadRelPath) (*scip.Document, bool, error) {
-	r0, r1, r2 := m.SCIPDocumentFunc.nextHook()(v0, v1, v2)
-	m.SCIPDocumentFunc.appendCall(LsifStoreSCIPDocumentFuncCall{v0, v1, v2, r0, r1, r2})
-	return r0, r1, r2
+func (m *MockLsifStore) SCIPDocument(v0 context.Context, v1 int, v2 core.UploadRelPath) (core.Option[*scip.Document], error) {
+	r0, r1 := m.SCIPDocumentFunc.nextHook()(v0, v1, v2)
+	m.SCIPDocumentFunc.appendCall(LsifStoreSCIPDocumentFuncCall{v0, v1, v2, r0, r1})
+	return r0, r1
 }
 
 // SetDefaultHook sets function that is called when the SCIPDocument method
 // of the parent MockLsifStore instance is invoked and the hook queue is
 // empty.
-func (f *LsifStoreSCIPDocumentFunc) SetDefaultHook(hook func(context.Context, int, core.UploadRelPath) (*scip.Document, bool, error)) {
+func (f *LsifStoreSCIPDocumentFunc) SetDefaultHook(hook func(context.Context, int, core.UploadRelPath) (core.Option[*scip.Document], error)) {
 	f.defaultHook = hook
 }
 
@@ -1836,7 +1836,7 @@ func (f *LsifStoreSCIPDocumentFunc) SetDefaultHook(hook func(context.Context, in
 // SCIPDocument method of the parent MockLsifStore instance invokes the hook
 // at the front of the queue and discards it. After the queue is empty, the
 // default hook function is invoked for any future action.
-func (f *LsifStoreSCIPDocumentFunc) PushHook(hook func(context.Context, int, core.UploadRelPath) (*scip.Document, bool, error)) {
+func (f *LsifStoreSCIPDocumentFunc) PushHook(hook func(context.Context, int, core.UploadRelPath) (core.Option[*scip.Document], error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -1844,20 +1844,20 @@ func (f *LsifStoreSCIPDocumentFunc) PushHook(hook func(context.Context, int, cor
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *LsifStoreSCIPDocumentFunc) SetDefaultReturn(r0 *scip.Document, r1 bool, r2 error) {
-	f.SetDefaultHook(func(context.Context, int, core.UploadRelPath) (*scip.Document, bool, error) {
-		return r0, r1, r2
+func (f *LsifStoreSCIPDocumentFunc) SetDefaultReturn(r0 core.Option[*scip.Document], r1 error) {
+	f.SetDefaultHook(func(context.Context, int, core.UploadRelPath) (core.Option[*scip.Document], error) {
+		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *LsifStoreSCIPDocumentFunc) PushReturn(r0 *scip.Document, r1 bool, r2 error) {
-	f.PushHook(func(context.Context, int, core.UploadRelPath) (*scip.Document, bool, error) {
-		return r0, r1, r2
+func (f *LsifStoreSCIPDocumentFunc) PushReturn(r0 core.Option[*scip.Document], r1 error) {
+	f.PushHook(func(context.Context, int, core.UploadRelPath) (core.Option[*scip.Document], error) {
+		return r0, r1
 	})
 }
 
-func (f *LsifStoreSCIPDocumentFunc) nextHook() func(context.Context, int, core.UploadRelPath) (*scip.Document, bool, error) {
+func (f *LsifStoreSCIPDocumentFunc) nextHook() func(context.Context, int, core.UploadRelPath) (core.Option[*scip.Document], error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -1901,13 +1901,10 @@ type LsifStoreSCIPDocumentFuncCall struct {
 	Arg2 core.UploadRelPath
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 *scip.Document
+	Result0 core.Option[*scip.Document]
 	// Result1 is the value of the 2nd result returned from this method
 	// invocation.
-	Result1 bool
-	// Result2 is the value of the 3rd result returned from this method
-	// invocation.
-	Result2 error
+	Result1 error
 }
 
 // Args returns an interface slice containing the arguments of this
@@ -1919,7 +1916,7 @@ func (c LsifStoreSCIPDocumentFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c LsifStoreSCIPDocumentFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1, c.Result2}
+	return []interface{}{c.Result0, c.Result1}
 }
 
 // MockGitTreeTranslator is a mock implementation of the GitTreeTranslator

--- a/internal/codeintel/codenav/scip_utils.go
+++ b/internal/codeintel/codenav/scip_utils.go
@@ -2,6 +2,7 @@ package codenav
 
 import (
 	"github.com/sourcegraph/scip/bindings/go/scip"
+
 	"github.com/sourcegraph/sourcegraph/internal/collections"
 )
 
@@ -9,7 +10,7 @@ type IOccurrence interface {
 	GetRange() []int32
 }
 
-func findOccurrencesWithEqualRange[Occurrence IOccurrence](occurrences []Occurrence, search scip.Range) []Occurrence {
+func FindOccurrencesWithEqualRange[Occurrence IOccurrence](occurrences []Occurrence, search scip.Range) []Occurrence {
 	interval := collections.BinarySearchRangeFunc(occurrences, search, func(occ Occurrence, r scip.Range) int {
 		occRange := scip.NewRangeUnchecked(occ.GetRange())
 		return occRange.CompareStrict(r)

--- a/internal/codeintel/codenav/scip_utils_test.go
+++ b/internal/codeintel/codenav/scip_utils_test.go
@@ -82,7 +82,7 @@ func Test_findOccurrencesWithEqualRange(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := findOccurrencesWithEqualRange(tt.args.occurrences, tt.args.search)
+			got := FindOccurrencesWithEqualRange(tt.args.occurrences, tt.args.search)
 			if diff := cmp.Diff(got, tt.want); diff != "" {
 				t.Errorf("unexpected ranges (-want +got):\n%s", diff)
 			}

--- a/internal/codeintel/codenav/service.go
+++ b/internal/codeintel/codenav/service.go
@@ -864,8 +864,8 @@ func (s *Service) SnapshotForDocument(ctx context.Context, repositoryID api.Repo
 
 	upload := uploads[0]
 
-	document, err := s.lsifstore.SCIPDocument(ctx, upload.ID, core.NewUploadRelPath(upload, path))
-	if err != nil || document == nil {
+	document, found, err := s.lsifstore.SCIPDocument(ctx, upload.ID, core.NewUploadRelPath(upload, path))
+	if err != nil || !found {
 		return nil, err
 	}
 
@@ -994,8 +994,8 @@ func (s *Service) SnapshotForDocument(ctx context.Context, repositoryID api.Repo
 }
 
 func (s *Service) SCIPDocument(ctx context.Context, gitTreeTranslator GitTreeTranslator, upload core.UploadLike, path core.RepoRelPath) (*scip.Document, error) {
-	rawDocument, err := s.lsifstore.SCIPDocument(ctx, upload.GetID(), core.NewUploadRelPath(upload, path))
-	if err != nil {
+	rawDocument, found, err := s.lsifstore.SCIPDocument(ctx, upload.GetID(), core.NewUploadRelPath(upload, path))
+	if err != nil || !found {
 		return nil, err
 	}
 	// The caller shouldn't need to care whether the document was uploaded

--- a/internal/codeintel/codenav/service.go
+++ b/internal/codeintel/codenav/service.go
@@ -1141,7 +1141,7 @@ func (s *Service) SyntacticUsages(
 	if err != nil {
 		return SyntacticUsagesResult{}, PreviousSyntacticSearch{}, err
 	}
-	index := mappedIndex{s.lsifstore, gitTreeTranslator, upload, args.Commit}
+	index := NewMappedIndexFromTranslator(s.lsifstore, gitTreeTranslator, upload)
 	return syntacticUsagesImpl(ctx, trace, s.searchClient, index, args)
 }
 
@@ -1227,7 +1227,7 @@ func (s *Service) SearchBasedUsages(
 		if uploadErr != nil {
 			trace.Info("no syntactic upload found, return all search-based results", log.Error(err))
 		} else {
-			syntacticIndex = core.Some[MappedIndex](mappedIndex{s.lsifstore, gitTreeTranslator, upload, args.Commit})
+			syntacticIndex = core.Some[MappedIndex](NewMappedIndexFromTranslator(s.lsifstore, gitTreeTranslator, upload))
 		}
 	}
 

--- a/internal/codeintel/codenav/service.go
+++ b/internal/codeintel/codenav/service.go
@@ -1089,152 +1089,6 @@ func (s *Service) getSyntacticUpload(ctx context.Context, trace observation.Trac
 	return uploads[0], nil
 }
 
-// getSyntacticSymbolsAtRange tries to look up the symbols at the given coordinates
-// in a syntactic upload. If this function returns an error you should most likely
-// log and handle it instead of rethrowing, as this could fail for a myriad of reasons
-// (some broken invariant internally, network issue etc.)
-// If this function doesn't error, the returned slice is guaranteed to be non-empty
-//
-// NOTE(id: single-syntactic-upload): This function returns the uploadID because we're
-// making the assumption that there'll only be a single syntactic upload at the root
-// directory for a particular commit.
-func (s *Service) getSyntacticSymbolsAtRange(
-	ctx context.Context,
-	trace observation.TraceLogger,
-	gitTreeTranslator GitTreeTranslator,
-	args UsagesForSymbolArgs,
-) (symbols []*scip.Symbol, upload uploadsshared.CompletedUpload, err *SyntacticUsagesError) {
-	upload, err = s.getSyntacticUpload(ctx, trace, args)
-	if err != nil {
-		return nil, upload, err
-	}
-
-	doc, docErr := s.lsifstore.SCIPDocument(ctx, upload.ID, core.NewUploadRelPath(upload, args.Path))
-	if docErr != nil {
-		return nil, upload, &SyntacticUsagesError{
-			Code:            SU_NoSyntacticIndex,
-			UnderlyingError: docErr,
-		}
-	}
-
-	trace = trace.WithFields(log.String("sourceCommit", string(gitTreeTranslator.GetSourceCommit())),
-		log.String("targetCommit", upload.Commit),
-		log.String("sourceRange", args.SymbolRange.String()))
-	targetRange, err := translateLookupRangeToCommit(ctx, gitTreeTranslator, api.CommitID(upload.Commit), args.Path, args.SymbolRange)
-	if err != nil {
-		trace.Info("range translation failed", log.Error(err))
-		return nil, upload, err
-	}
-	trace = trace.WithFields(log.String("targetRange", targetRange.String()))
-
-	symbols = []*scip.Symbol{}
-	var parseFail *scip.Occurrence = nil
-
-	// FIXME(issue: GRAPH-674): Properly handle different text encodings here.
-	for _, occurrence := range findOccurrencesWithEqualRange(doc.Occurrences, targetRange) {
-		parsedSymbol, err := scip.ParseSymbol(occurrence.Symbol)
-		if err != nil {
-			parseFail = occurrence
-			continue
-		}
-		symbols = append(symbols, parsedSymbol)
-	}
-
-	if parseFail != nil {
-		trace.Warn("getSyntacticSymbolsAtRange: Failed to parse symbol", log.String("symbol", parseFail.Symbol))
-	}
-
-	if len(symbols) == 0 {
-		trace.Warn("getSyntacticSymbolsAtRange: No symbols found at requested range")
-		return nil, upload, &SyntacticUsagesError{
-			Code:            SU_NoSymbolAtRequestedRange,
-			UnderlyingError: nil,
-		}
-	}
-
-	return symbols, upload, nil
-}
-
-func translateLookupRangeToCommit(
-	ctx context.Context,
-	gitTreeTranslator GitTreeTranslator,
-	uploadCommit api.CommitID,
-	path core.RepoRelPath,
-	sourceRange scip.Range,
-) (scip.Range, *SyntacticUsagesError) {
-	if gitTreeTranslator.GetSourceCommit() == uploadCommit {
-		return sourceRange, nil
-	}
-	targetRange, translated, gitErr := gitTreeTranslator.GetTargetCommitRangeFromSourceRange(
-		ctx, string(uploadCommit), path.RawValue(), shared.TranslateRange(sourceRange), false)
-	if gitErr != nil {
-		return sourceRange, &SyntacticUsagesError{
-			Code:            SU_FailedToAdjustRange,
-			UnderlyingError: gitErr,
-		}
-	}
-	if !translated {
-		return sourceRange, &SyntacticUsagesError{SU_FailedToAdjustRange, nil}
-	}
-	return targetRange.ToSCIPRange(), nil
-}
-
-func (s *Service) findSyntacticMatchesForCandidateFile(
-	ctx context.Context,
-	trace observation.TraceLogger,
-	gitTreeTranslator GitTreeTranslator,
-	upload core.UploadLike,
-	filePath core.RepoRelPath,
-	candidateFile candidateFile,
-) ([]SyntacticMatch, []SearchBasedMatch, *SyntacticUsagesError) {
-	document, docErr := s.lsifstore.SCIPDocument(ctx, upload.GetID(), core.NewUploadRelPath(upload, filePath))
-	if docErr != nil {
-		return nil, nil, &SyntacticUsagesError{
-			Code:            SU_NoSyntacticIndex,
-			UnderlyingError: docErr,
-		}
-	}
-
-	syntacticMatches := []SyntacticMatch{}
-	searchBasedMatches := []SearchBasedMatch{}
-	// TODO: We can optimize this further by continuously slicing the occurrences array
-	// as both these arrays are sorted
-	failedTranslationCount := 0
-	for _, sourceCandidateRange := range candidateFile.matches {
-		// See TODO(id: add-bulk-translation-api); once that is fixed, use that here.
-		targetCandidateRange, err := translateLookupRangeToCommit(ctx, gitTreeTranslator, upload.GetCommit(), filePath, sourceCandidateRange)
-		if err != nil {
-			failedTranslationCount++
-			continue
-		}
-
-		foundSyntacticMatch := false
-		for _, occ := range findOccurrencesWithEqualRange(document.Occurrences, targetCandidateRange) {
-			if !scip.IsLocalSymbol(occ.Symbol) {
-				foundSyntacticMatch = true
-				// Return results at the commit the match was found at, not at the commit
-				// where the syntactic upload was found.
-				syntacticMatches = append(syntacticMatches, SyntacticMatch{
-					Path:         filePath,
-					Range:        sourceCandidateRange,
-					Symbol:       occ.Symbol,
-					IsDefinition: scip.SymbolRole_Definition.Matches(occ),
-				})
-			}
-		}
-		if !foundSyntacticMatch {
-			searchBasedMatches = append(searchBasedMatches, SearchBasedMatch{
-				Path:  filePath,
-				Range: sourceCandidateRange,
-			})
-		}
-	}
-	if failedTranslationCount != 0 {
-		trace.Info("findSyntacticMatchesForCandidateFile", log.Int("failedTranslationCount", failedTranslationCount))
-	}
-	return syntacticMatches, searchBasedMatches, nil
-}
-
 type SearchBasedMatch struct {
 	Path         core.RepoRelPath
 	Range        scip.Range
@@ -1273,63 +1127,12 @@ func (s *Service) SyntacticUsages(
 	}})
 	defer endObservation(1, observation.Args{})
 
-	symbolsAtRange, upload, err := s.getSyntacticSymbolsAtRange(ctx, trace, gitTreeTranslator, args)
+	upload, err := s.getSyntacticUpload(ctx, trace, args)
 	if err != nil {
 		return SyntacticUsagesResult{}, PreviousSyntacticSearch{}, err
 	}
-
-	// Overlapping symbolsAtRange should lead to the same display name, but be scored separately.
-	// (Meaning we just need a single Searcher/Zoekt search)
-	searchSymbol := symbolsAtRange[0]
-	language, langErr := languageFromFilepath(trace, args.Path)
-	if langErr != nil {
-		return SyntacticUsagesResult{}, PreviousSyntacticSearch{}, &SyntacticUsagesError{
-			Code:            SU_FailedToSearch,
-			UnderlyingError: langErr,
-		}
-	}
-
-	symbolName, ok := nameFromGlobalSymbol(searchSymbol)
-	if !ok {
-		return SyntacticUsagesResult{}, PreviousSyntacticSearch{}, &SyntacticUsagesError{
-			Code:            SU_FailedToSearch,
-			UnderlyingError: errors.New("can't find syntactic occurrences for locals via search"),
-		}
-	}
-	searchCoords := searchArgs{
-		repo:       args.Repo.Name,
-		commit:     args.Commit,
-		identifier: symbolName,
-		language:   language,
-	}
-	candidateMatches, searchErr := findCandidateOccurrencesViaSearch(ctx, trace, s.searchClient, searchCoords)
-	if searchErr != nil {
-		return SyntacticUsagesResult{}, PreviousSyntacticSearch{}, &SyntacticUsagesError{
-			Code:            SU_FailedToSearch,
-			UnderlyingError: searchErr,
-		}
-	}
-
-	results := [][]SyntacticMatch{}
-
-	for pair := candidateMatches.Oldest(); pair != nil; pair = pair.Next() {
-		// We're assuming the upload we found earlier contains the relevant SCIP document
-		// see NOTE(id: single-syntactic-upload)
-		syntacticMatches, _, err := s.findSyntacticMatchesForCandidateFile(ctx, trace, gitTreeTranslator, upload, pair.Key, pair.Value)
-		if err != nil {
-			// TODO: Errors that are not "no index found in the DB" should be reported
-			// TODO: Track metrics about how often this happens (GRAPH-693)
-			continue
-		}
-		results = append(results, syntacticMatches)
-	}
-	return SyntacticUsagesResult{
-			Matches: slices.Concat(results...),
-		}, PreviousSyntacticSearch{
-			UploadSummary: core.UploadSummary{upload.ID, upload.Root, api.CommitID(upload.Commit)},
-			SymbolName:    symbolName,
-			Language:      language,
-		}, nil
+	index := mappedIndex{s.lsifstore, gitTreeTranslator, upload, args.Commit}
+	return syntacticUsagesImpl(ctx, trace, s.searchClient, index, args)
 }
 
 const MAX_FILE_SIZE_FOR_SYMBOL_DETECTION_BYTES = 10_000_000
@@ -1360,9 +1163,9 @@ func (s *Service) symbolNameFromGit(ctx context.Context, args UsagesForSymbolArg
 // we've already collected during syntactic usages during
 // search-based usages.
 type PreviousSyntacticSearch struct {
-	core.UploadSummary
-	SymbolName string
-	Language   string
+	MappedIndex MappedIndex
+	SymbolName  string
+	Language    string
 }
 
 func languageFromFilepath(trace observation.TraceLogger, path core.RepoRelPath) (string, error) {
@@ -1392,12 +1195,12 @@ func (s *Service) SearchBasedUsages(
 
 	var language string
 	var symbolName string
-	var syntacticUpload core.Option[core.UploadLike]
+	var syntacticIndex core.Option[MappedIndex]
 
 	if prev, ok := previousSyntacticSearch.Get(); ok {
 		language = prev.Language
 		symbolName = prev.SymbolName
-		syntacticUpload = core.Some[core.UploadLike](&prev.UploadSummary)
+		syntacticIndex = core.Some[MappedIndex](prev.MappedIndex)
 	} else {
 		language, err = languageFromFilepath(trace, args.Path)
 		if err != nil {
@@ -1414,11 +1217,11 @@ func (s *Service) SearchBasedUsages(
 		if uploadErr != nil {
 			trace.Info("no syntactic upload found, return all search-based results", log.Error(err))
 		} else {
-			syntacticUpload = core.Some[core.UploadLike](upload)
+			syntacticIndex = core.Some[MappedIndex](mappedIndex{s.lsifstore, gitTreeTranslator, upload, args.Commit})
 		}
 	}
 
-	return s.searchBasedUsagesInner(ctx, trace, gitTreeTranslator, args, symbolName, language, syntacticUpload)
+	return s.searchBasedUsagesInner(ctx, trace, args, symbolName, language, syntacticIndex)
 }
 
 // searchBasedUsagesInner is extracted from SearchBasedUsages to allow
@@ -1426,11 +1229,10 @@ func (s *Service) SearchBasedUsages(
 func (s *Service) searchBasedUsagesInner(
 	ctx context.Context,
 	trace observation.TraceLogger,
-	gitTreeTranslator GitTreeTranslator,
 	args UsagesForSymbolArgs,
 	symbolName string,
 	language string,
-	syntacticUpload core.Option[core.UploadLike],
+	syntacticIndex core.Option[MappedIndex],
 ) (matches []SearchBasedMatch, err error) {
 	searchCoords := searchArgs{
 		repo:       args.Repo.Name,
@@ -1449,8 +1251,8 @@ func (s *Service) searchBasedUsagesInner(
 
 	results := [][]SearchBasedMatch{}
 	for pair := candidateMatches.Oldest(); pair != nil; pair = pair.Next() {
-		if upload, ok := syntacticUpload.Get(); ok {
-			_, searchBasedMatches, err := s.findSyntacticMatchesForCandidateFile(ctx, trace, gitTreeTranslator, upload, pair.Key, pair.Value)
+		if index, ok := syntacticIndex.Get(); ok {
+			_, searchBasedMatches, err := findSyntacticMatchesForCandidateFile(ctx, trace, index, pair.Key, pair.Value)
 			if err == nil {
 				results = append(results, searchBasedMatches)
 				continue

--- a/internal/codeintel/codenav/service_snapshot_test.go
+++ b/internal/codeintel/codenav/service_snapshot_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/sourcegraph/log"
 	"github.com/sourcegraph/scip/bindings/go/scip"
 
+	"github.com/sourcegraph/sourcegraph/internal/codeintel/core"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/uploads/shared"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
@@ -36,7 +37,7 @@ func TestSnapshotForDocument(t *testing.T) {
 	mockUploadSvc.GetCompletedUploadsByIDsFunc.SetDefaultReturn([]shared.CompletedUpload{{}}, nil)
 	mockRepoStore.GetFunc.SetDefaultReturn(&types.Repo{}, nil)
 	mockGitserverClient.NewFileReaderFunc.SetDefaultReturn(io.NopCloser(bytes.NewReader([]byte(sampleFile1))), nil)
-	mockLsifStore.SCIPDocumentFunc.SetDefaultReturn(&scip.Document{
+	mockLsifStore.SCIPDocumentFunc.SetDefaultReturn(core.Some(&scip.Document{
 		RelativePath: "burger.go",
 		Occurrences: []*scip.Occurrence{{
 			Range:       []int32{2, 4, 9},
@@ -50,7 +51,7 @@ func TestSnapshotForDocument(t *testing.T) {
 				IsImplementation: true,
 			}},
 		}},
-	}, true, nil)
+	}), nil)
 
 	data, err := svc.SnapshotForDocument(context.Background(), 0, "deadbeef", repoRelPath("burger.go"), 0)
 	if err != nil {

--- a/internal/codeintel/codenav/service_snapshot_test.go
+++ b/internal/codeintel/codenav/service_snapshot_test.go
@@ -50,7 +50,7 @@ func TestSnapshotForDocument(t *testing.T) {
 				IsImplementation: true,
 			}},
 		}},
-	}, nil)
+	}, true, nil)
 
 	data, err := svc.SnapshotForDocument(context.Background(), 0, "deadbeef", repoRelPath("burger.go"), 0)
 	if err != nil {

--- a/internal/codeintel/codenav/service_syntactic_usages_test.go
+++ b/internal/codeintel/codenav/service_syntactic_usages_test.go
@@ -66,8 +66,8 @@ func TestSearchBasedUsages_ResultWithoutSymbols(t *testing.T) {
 	)
 
 	usages, searchErr := svc.searchBasedUsagesInner(
-		context.Background(), observation.TestTraceLogger(log.NoOp()), NewMockGitTreeTranslator(), UsagesForSymbolArgs{},
-		"symbol", "Java", core.None[core.UploadLike](),
+		context.Background(), observation.TestTraceLogger(log.NoOp()), UsagesForSymbolArgs{},
+		"symbol", "Java", core.None[MappedIndex](),
 	)
 	require.NoError(t, searchErr)
 	expectSearchRanges(t, usages, refRange, refRange2)
@@ -90,8 +90,8 @@ func TestSearchBasedUsages_ResultWithSymbol(t *testing.T) {
 	)
 
 	usages, searchErr := svc.searchBasedUsagesInner(
-		context.Background(), observation.TestTraceLogger(log.NoOp()), NewMockGitTreeTranslator(), UsagesForSymbolArgs{},
-		"symbol", "Java", core.None[core.UploadLike](),
+		context.Background(), observation.TestTraceLogger(log.NoOp()), UsagesForSymbolArgs{},
+		"symbol", "Java", core.None[MappedIndex](),
 	)
 	require.NoError(t, searchErr)
 	expectSearchRanges(t, usages, refRange, refRange2, defRange)

--- a/internal/codeintel/codenav/service_syntactic_usages_test.go
+++ b/internal/codeintel/codenav/service_syntactic_usages_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/core"
-	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 )
 
@@ -59,15 +58,9 @@ func TestSearchBasedUsages_ResultWithoutSymbols(t *testing.T) {
 		WithFile("path.java", refRange, refRange2).
 		Build()
 
-	svc := newService(
-		observation.TestContextTB(t), defaultMockRepoStore(),
-		NewMockLsifStore(), NewMockUploadService(), gitserver.NewMockClient(),
-		mockSearchClient, log.NoOp(),
-	)
-
-	usages, searchErr := svc.searchBasedUsagesInner(
-		context.Background(), observation.TestTraceLogger(log.NoOp()), UsagesForSymbolArgs{},
-		"symbol", "Java", core.None[MappedIndex](),
+	usages, searchErr := searchBasedUsagesImpl(
+		context.Background(), observation.TestTraceLogger(log.NoOp()), mockSearchClient,
+		UsagesForSymbolArgs{}, "symbol", "Java", core.None[MappedIndex](),
 	)
 	require.NoError(t, searchErr)
 	expectSearchRanges(t, usages, refRange, refRange2)
@@ -83,15 +76,9 @@ func TestSearchBasedUsages_ResultWithSymbol(t *testing.T) {
 		WithSymbols("path.java", defRange).
 		Build()
 
-	svc := newService(
-		observation.TestContextTB(t), defaultMockRepoStore(),
-		NewMockLsifStore(), NewMockUploadService(), gitserver.NewMockClient(),
-		mockSearchClient, log.NoOp(),
-	)
-
-	usages, searchErr := svc.searchBasedUsagesInner(
-		context.Background(), observation.TestTraceLogger(log.NoOp()), UsagesForSymbolArgs{},
-		"symbol", "Java", core.None[MappedIndex](),
+	usages, searchErr := searchBasedUsagesImpl(
+		context.Background(), observation.TestTraceLogger(log.NoOp()), mockSearchClient,
+		UsagesForSymbolArgs{}, "symbol", "Java", core.None[MappedIndex](),
 	)
 	require.NoError(t, searchErr)
 	expectSearchRanges(t, usages, refRange, refRange2, defRange)

--- a/internal/codeintel/codenav/syntactic.go
+++ b/internal/codeintel/codenav/syntactic.go
@@ -250,3 +250,152 @@ func scipFromResultRange(resultRange result.Range) (scip.Range, error) {
 		int32(resultRange.End.Column),
 	})
 }
+
+// symbolAtRange tries to look up the symbols at the given coordinates
+// in a syntactic upload. If this function returns an error you should most likely
+// log and handle it instead of rethrowing, as this could fail for a myriad of reasons
+// (some broken invariant internally, network issue etc.)
+// If this function doesn't error, the returned slice is guaranteed to be non-empty
+func symbolAtRange(
+	ctx context.Context,
+	mappedIndex MappedIndex,
+	args UsagesForSymbolArgs,
+) (*scip.Symbol, error) {
+	docOpt, err := mappedIndex.GetDocument(ctx, args.Path)
+	if err != nil {
+		return nil, err
+	}
+	doc, isSome := docOpt.Get()
+	if !isSome {
+		return nil, errors.New("no document found")
+	}
+	occs, err := doc.GetOccurrencesAtRange(ctx, args.SymbolRange)
+	if err != nil {
+		return nil, err
+	}
+	if len(occs) == 0 {
+		return nil, errors.New("no occurrences found")
+	}
+	sym, err := scip.ParseSymbol(occs[0].Symbol)
+	if err != nil {
+		return nil, err
+	}
+	return sym, nil
+}
+
+func findSyntacticMatchesForCandidateFile(
+	ctx context.Context,
+	trace observation.TraceLogger,
+	mappedIndex MappedIndex,
+	filePath core.RepoRelPath,
+	candidateFile candidateFile,
+) ([]SyntacticMatch, []SearchBasedMatch, *SyntacticUsagesError) {
+	documentOpt, docErr := mappedIndex.GetDocument(ctx, filePath)
+	if docErr != nil {
+		return nil, nil, &SyntacticUsagesError{
+			Code:            SU_Fatal,
+			UnderlyingError: docErr,
+		}
+	}
+	document, isSome := documentOpt.Get()
+	if !isSome {
+		return nil, nil, &SyntacticUsagesError{
+			Code: SU_NoSyntacticIndex,
+		}
+	}
+	syntacticMatches := []SyntacticMatch{}
+	searchBasedMatches := []SearchBasedMatch{}
+
+	failedTranslationCount := 0
+	for _, sourceCandidateRange := range candidateFile.matches {
+		foundSyntacticMatch := false
+		occurrences, occErr := document.GetOccurrencesAtRange(ctx, sourceCandidateRange)
+		if occErr != nil {
+			failedTranslationCount += 1
+			continue
+		}
+		for _, occ := range occurrences {
+			if !scip.IsLocalSymbol(occ.Symbol) {
+				foundSyntacticMatch = true
+				syntacticMatches = append(syntacticMatches, SyntacticMatch{
+					Path:         filePath,
+					Range:        sourceCandidateRange,
+					Symbol:       occ.Symbol,
+					IsDefinition: scip.SymbolRole_Definition.Matches(occ),
+				})
+			}
+		}
+		if !foundSyntacticMatch {
+			searchBasedMatches = append(searchBasedMatches, SearchBasedMatch{
+				Path:  filePath,
+				Range: sourceCandidateRange,
+			})
+		}
+	}
+	if failedTranslationCount != 0 {
+		trace.Info("findSyntacticMatchesForCandidateFile", log.Int("failedTranslationCount", failedTranslationCount))
+	}
+	return syntacticMatches, searchBasedMatches, nil
+}
+
+func syntacticUsagesImpl(
+	ctx context.Context,
+	trace observation.TraceLogger,
+	searchClient searchclient.SearchClient,
+	mappedIndex MappedIndex,
+	args UsagesForSymbolArgs,
+) (SyntacticUsagesResult, PreviousSyntacticSearch, *SyntacticUsagesError) {
+	searchSymbol, symErr := symbolAtRange(ctx, mappedIndex, args)
+	if symErr != nil {
+		return SyntacticUsagesResult{}, PreviousSyntacticSearch{}, &SyntacticUsagesError{
+			Code:            SU_NoSymbolAtRequestedRange,
+			UnderlyingError: symErr,
+		}
+	}
+	language, langErr := languageFromFilepath(trace, args.Path)
+	if langErr != nil {
+		return SyntacticUsagesResult{}, PreviousSyntacticSearch{}, &SyntacticUsagesError{
+			Code:            SU_FailedToSearch,
+			UnderlyingError: langErr,
+		}
+	}
+	symbolName, ok := nameFromGlobalSymbol(searchSymbol)
+	if !ok {
+		return SyntacticUsagesResult{}, PreviousSyntacticSearch{}, &SyntacticUsagesError{
+			Code:            SU_FailedToSearch,
+			UnderlyingError: errors.New("can't find syntactic occurrences for locals via search"),
+		}
+	}
+	searchCoords := searchArgs{
+		repo:       args.Repo.Name,
+		commit:     args.Commit,
+		identifier: symbolName,
+		language:   language,
+	}
+	candidateMatches, searchErr := findCandidateOccurrencesViaSearch(ctx, trace, searchClient, searchCoords)
+	if searchErr != nil {
+		return SyntacticUsagesResult{}, PreviousSyntacticSearch{}, &SyntacticUsagesError{
+			Code:            SU_FailedToSearch,
+			UnderlyingError: searchErr,
+		}
+	}
+
+	results := [][]SyntacticMatch{}
+
+	for pair := candidateMatches.Oldest(); pair != nil; pair = pair.Next() {
+		// We're assuming the upload we found earlier contains the relevant SCIP document
+		// see NOTE(id: single-syntactic-upload)
+		syntacticMatches, _, err := findSyntacticMatchesForCandidateFile(ctx, trace, mappedIndex, pair.Key, pair.Value)
+		if err != nil {
+			// TODO: Errors that are not "no index found in the DB" should be reported
+			// TODO: Track metrics about how often this happens (GRAPH-693)
+			continue
+		}
+		results = append(results, syntacticMatches)
+	}
+	return SyntacticUsagesResult{Matches: slices.Concat(results...)}, PreviousSyntacticSearch{
+		MappedIndex: mappedIndex,
+		SymbolName:  symbolName,
+		Language:    language,
+	}, nil
+}


### PR DESCRIPTION
Precursor for https://linear.app/sourcegraph/issue/GRAPH-735/test-syntactic-usages

This PR introduces the `MappedIndex` abstraction, which wraps up an upload with a target commit. Its APIs then take care of mapping upload relative paths and repo relative paths, and ranges across commits.

My main motivation for making this change is that I can now test this logic in isolation (which this PR does), and also have an interface that is easy to fake and use to test syntactic usages.

## Test plan

Added unit tests for the `MappedIndex` component, manual testing of the GraphQL APIs show no changes in the syntactic usages output between this PR and master.