### PR TITLE
chore(search): update search API call sites to set the version explicitly

### DIFF
--- a/client/shared/src/codeintel/legacy-extensions/util/api.ts
+++ b/client/shared/src/codeintel/legacy-extensions/util/api.ts
@@ -2,6 +2,7 @@ import gql from 'tagged-template-noop'
 
 import { isErrorLike } from '@sourcegraph/common'
 
+import { SearchVersion } from '../../../graphql-operations'
 import type * as sourcegraph from '../api'
 import { cache } from '../util'
 
@@ -251,6 +252,7 @@ export class API {
 
         const data = await queryGraphQL<Response>(buildSearchQuery(fileLocal), {
             query,
+            version: SearchVersion.V3,
         })
         return data.search.results.results.filter(isDefined)
     }
@@ -322,8 +324,8 @@ function buildSearchQuery(fileLocal: boolean): string {
 
     if (fileLocal) {
         return gql`
-            query LegacyCodeIntelSearch2($query: String!) {
-                search(query: $query) {
+            query LegacyCodeIntelSearch2($query: String!, $version: SearchVersion!) {
+                search(query: $query, version: $version) {
                     ...SearchResults
                     ...FileLocal
                 }
@@ -334,8 +336,8 @@ function buildSearchQuery(fileLocal: boolean): string {
     }
 
     return gql`
-        query LegacyCodeIntelSearch3($query: String!) {
-            search(query: $query) {
+        query LegacyCodeIntelSearch3($query: String!, $version: SearchVersion!) {
+            search(query: $query, version: $version) {
                 ...SearchResults
             }
         }

--- a/client/web/src/codeintel/ReferencesPanelQueries.ts
+++ b/client/web/src/codeintel/ReferencesPanelQueries.ts
@@ -241,8 +241,8 @@ export const FETCH_HIGHLIGHTED_BLOB = gql`
 `
 
 export const CODE_INTEL_SEARCH_QUERY = gql`
-    query CodeIntelSearch2($query: String!) {
-        search(query: $query) {
+    query CodeIntelSearch2($query: String!, $version: SearchVersion!) {
+        search(query: $query, version: $version) {
             __typename
             results {
                 __typename

--- a/client/web/src/enterprise/codeintel/useSearchBasedCodeIntel.ts
+++ b/client/web/src/enterprise/codeintel/useSearchBasedCodeIntel.ts
@@ -16,6 +16,7 @@ import { CODE_INTEL_SEARCH_QUERY, LOCAL_CODE_INTEL_QUERY } from '../../codeintel
 import type { SettingsGetter } from '../../codeintel/settings'
 import { isDefined } from '../../codeintel/util/helpers'
 import type { CodeIntelSearch2Variables } from '../../graphql-operations'
+import { SearchVersion } from '../../graphql-operations'
 import { syntaxHighlight } from '../../repo/blob/codemirror/highlight'
 import { getBlobEditView } from '../../repo/blob/use-blob-store'
 
@@ -367,6 +368,7 @@ async function executeSearchQuery(terms: string[]): Promise<SearchResult[]> {
         query: getDocumentNode(CODE_INTEL_SEARCH_QUERY),
         variables: {
             query: terms.join(' '),
+            version: SearchVersion.V3,
         },
     })
 

--- a/client/web/src/enterprise/insights/core/hooks/live-preview-insight/use-live-preview-lang-stats-insight.ts
+++ b/client/web/src/enterprise/insights/core/hooks/live-preview-insight/use-live-preview-lang-stats-insight.ts
@@ -14,6 +14,7 @@ import {
     type LangStatsInsightContentResult,
     type LangStatsInsightContentVariables,
     SearchPatternType,
+    SearchVersion,
 } from '../../../../../graphql-operations'
 import type { CategoricalChartContent } from '../../backend/code-insights-backend-types'
 
@@ -162,8 +163,8 @@ function quoteIfNeeded(value: string): string {
 }
 
 export const GET_LANG_STATS_GQL = gql`
-    query LangStatsInsightContent($query: String!) {
-        search(query: $query) {
+    query LangStatsInsightContent($query: String!, $version: SearchVersion!) {
+        search(query: $query, version: $version) {
             results {
                 limitHit
             }
@@ -180,6 +181,7 @@ export const GET_LANG_STATS_GQL = gql`
 function fetchLangStatsInsight(query: string): Observable<LangStatsInsightContentResult> {
     return requestGraphQL<LangStatsInsightContentResult, LangStatsInsightContentVariables>(GET_LANG_STATS_GQL, {
         query,
+        version: SearchVersion.V3,
     }).pipe(map(dataOrThrowErrors))
 }
 

--- a/client/web/src/enterprise/insights/pages/insights/creation/lang-stats/LangStatsInsightCreationPage.story.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/lang-stats/LangStatsInsightCreationPage.story.tsx
@@ -10,6 +10,7 @@ import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
 
 import { WebStory } from '../../../../../../components/WebStory'
 import type { LangStatsInsightContentResult } from '../../../../../../graphql-operations'
+import { SearchVersion } from '../../../../../../graphql-operations'
 import { GET_LANG_STATS_GQL } from '../../../../core/hooks/live-preview-insight'
 import { useCodeInsightsLicenseState } from '../../../../stores'
 
@@ -31,7 +32,7 @@ export default defaultStory
 const LANG_STATS_MOCK: MockedResponse<LangStatsInsightContentResult> = {
     request: {
         query: getDocumentNode(GET_LANG_STATS_GQL),
-        variables: {},
+        variables: { version: SearchVersion.V3 },
     },
     result: {
         data: {

--- a/client/web/src/search/backend.tsx
+++ b/client/web/src/search/backend.tsx
@@ -1,7 +1,6 @@
 import { type Observable, of } from 'rxjs'
 import { map } from 'rxjs/operators'
 
-import { createAggregateError } from '@sourcegraph/common'
 import { dataOrThrowErrors, gql } from '@sourcegraph/http-client'
 
 import { queryGraphQL, requestGraphQL } from '../backend/graphql'
@@ -16,34 +15,8 @@ import type {
     UpdateSavedSearchVariables,
     Scalars,
     SavedSearchFields,
-    ReposByQueryResult,
     SavedSearchResult,
 } from '../graphql-operations'
-
-export function fetchReposByQuery(query: string): Observable<{ name: string; url: string }[]> {
-    return queryGraphQL<ReposByQueryResult>(
-        gql`
-            query ReposByQuery($query: String!) {
-                search(query: $query) {
-                    results {
-                        repositories {
-                            name
-                            url
-                        }
-                    }
-                }
-            }
-        `,
-        { query }
-    ).pipe(
-        map(({ data, errors }) => {
-            if (!data?.search?.results?.repositories) {
-                throw createAggregateError(errors)
-            }
-            return data.search.results.repositories
-        })
-    )
-}
 
 const savedSearchFragment = gql`
     fragment SavedSearchFields on SavedSearch {

--- a/client/web/src/search/results/StreamingSearchResults.test.tsx
+++ b/client/web/src/search/results/StreamingSearchResults.test.tsx
@@ -12,6 +12,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { GitRefType, SearchPatternType } from '@sourcegraph/shared/src/graphql-operations'
 import { SearchMode, SearchQueryStateStoreProvider } from '@sourcegraph/shared/src/search'
 import type { AggregateStreamingSearchResults, Skipped } from '@sourcegraph/shared/src/search/stream'
+import { LATEST_VERSION } from '@sourcegraph/shared/src/search/stream'
 import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
@@ -109,7 +110,7 @@ describe('StreamingSearchResults', () => {
 
         expect(receivedQuery).toEqual('r:golang/oauth2 test f:travis')
         expect(receivedOptions).toEqual({
-            version: 'V3',
+            version: LATEST_VERSION,
             patternType: SearchPatternType.regexp,
             caseSensitive: true,
             searchMode: SearchMode.SmartSearch,

--- a/client/web/src/search/results/components/search-results-info-bar/SearchResultsInfoBar.test.tsx
+++ b/client/web/src/search/results/components/search-results-info-bar/SearchResultsInfoBar.test.tsx
@@ -1,6 +1,7 @@
 import { noop } from 'lodash'
 import { describe, expect, test } from 'vitest'
 
+import { LATEST_VERSION } from '@sourcegraph/shared/src/search/stream'
 import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
@@ -32,7 +33,7 @@ const COMMON_PROPS: Omit<SearchResultsInfoBarProps, 'enableCodeMonitoring'> = {
     sidebarCollapsed: false,
     isSourcegraphDotCom: true,
     options: {
-        version: 'V3',
+        version: LATEST_VERSION,
         patternType: SearchPatternType.standard,
         caseSensitive: false,
         trace: undefined,

--- a/cmd/frontend/backend/go_importers.go
+++ b/cmd/frontend/backend/go_importers.go
@@ -64,7 +64,8 @@ func CountGoImporters(ctx context.Context, cli httpcli.Doer, repo api.RepoName) 
 
 	q.Query = countGoImportersGraphQLQuery
 	q.Variables = map[string]any{
-		"query": countGoImportersSearchQuery(repo),
+		"query":   countGoImportersSearchQuery(repo),
+		"version": "V3",
 	}
 
 	body, err := json.Marshal(q)
@@ -144,6 +145,6 @@ func countGoImportersSearchQuery(repo api.RepoName) string {
 }
 
 const countGoImportersGraphQLQuery = `
-query CountGoImporters($query: String!) {
-  search(query: $query) { results { matchCount } }
+query CountGoImporters($query: String!, $version: SearchVersion!) {
+  search(query: $query, version: $version) { results { matchCount } }
 }`

--- a/cmd/frontend/internal/compute/resolvers/resolvers.go
+++ b/cmd/frontend/internal/compute/resolvers/resolvers.go
@@ -232,7 +232,7 @@ func NewBatchComputeImplementer(ctx context.Context, logger log.Logger, db datab
 	log15.Debug("compute", "search", searchQuery)
 
 	patternType := "regexp"
-	job, err := gql.NewBatchSearchImplementer(ctx, logger, db, &gql.SearchArgs{Query: searchQuery, PatternType: &patternType})
+	job, err := gql.NewBatchSearchImplementer(ctx, logger, db, &gql.SearchArgs{Query: searchQuery, PatternType: &patternType, Version: "V3"})
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/internal/compute/streaming/compute.go
+++ b/cmd/frontend/internal/compute/streaming/compute.go
@@ -73,7 +73,7 @@ func NewComputeStream(ctx context.Context, logger log.Logger, db database.DB, se
 	searchClient := client.New(logger, db, gitserver.NewClient("http.compute.search"))
 	inputs, err := searchClient.Plan(
 		ctx,
-		"",
+		"V3",
 		&patternType,
 		searchQuery,
 		search.Precise,

--- a/internal/cmd/search-blitz/client.go
+++ b/internal/cmd/search-blitz/client.go
@@ -45,7 +45,7 @@ func (s *client) search(ctx context.Context, query, queryName string) (*metrics,
 	return s.doGraphQL(ctx, graphQLRequest{
 		QueryName:        queryName,
 		GraphQLQuery:     graphQLSearchQuery,
-		GraphQLVariables: map[string]string{"query": query},
+		GraphQLVariables: map[string]string{"query": query, "version": "V3"},
 		MetricsFromBody: func(body io.Reader) (*metrics, error) {
 			var respDec struct {
 				Data struct {

--- a/internal/cmd/search-blitz/search.graphql
+++ b/internal/cmd/search-blitz/search.graphql
@@ -86,8 +86,8 @@ fragment SearchResultsAlertFields on SearchResults {
     }
 }
 
-query ($query: String!) {
-    search(query: $query) {
+query ($query: String!, $version: SearchVersion!) {
+    search(query: $query, version: $version) {
         results {
             results {
                 __typename

--- a/internal/insights/query/streaming/search_client.go
+++ b/internal/insights/query/streaming/search_client.go
@@ -33,7 +33,7 @@ type insightsSearchClient struct {
 func (r *insightsSearchClient) Search(ctx context.Context, query string, patternType *string, sender streaming.Sender) (*search.Alert, error) {
 	inputs, err := r.searchClient.Plan(
 		ctx,
-		"",
+		"V3",
 		patternType,
 		query,
 		search.Precise,

--- a/internal/search/streaming/http/client.go
+++ b/internal/search/streaming/http/client.go
@@ -15,13 +15,11 @@ import (
 
 const maxPayloadSize = 10 * 1024 * 1024 // 10mb
 
-// TODO(stefan): Remove NewRequest in favor of NewRequestWithVersion.
-
-// NewRequest returns an http.Request against the streaming API for query.
+// NewRequest returns an http.Request against the Stream API. Use
+// NewRequestWithVersion if you want to specify the version of the search syntax
+// or the default patternType.
 func NewRequest(baseURL string, query string) (*http.Request, error) {
-	// We don't set version or pattern type and rely on the defaults of the route
-	// handler.
-	return NewRequestWithVersion(baseURL, query, "", nil)
+	return NewRequestWithVersion(baseURL, query, "V3", nil)
 }
 
 // NewRequestWithVersion returns an http.Request against the streaming API for


### PR DESCRIPTION
I went through all call sites of the 3 search APIs (Stream API, GQL API, SearchClient (internal)) and made sure that the query syntax version is set to "V3".

Why?

Without this change, a new default search syntax version might have caused a change in behavior for some of the call sites.

## Test plan
- No functional change, so relying mostly on CI
- The codeintel GQL queries set the patternType explicitly, so this change is a NOP.

I tested manually
- search based code intel sends GQL requests with version "V3"
- repo badge still works
- compute GQL returns results
