### PR TITLE
chore(config): clarify env var already registered panic

### DIFF
--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -97,7 +97,7 @@ func Get(name, defaultValue, description string) string {
 
 	e := envflag{description: description, value: value}
 	if existing, ok := env[name]; ok && existing != e {
-		panic(fmt.Sprintf("env var %q already registered with a different description or value", name))
+		panic(fmt.Sprintf("env var %q already registered with a different description or value\n\tBefore: %q\n\tAfter: %q", name, existing, e))
 	}
 	env[name] = e
 


### PR DESCRIPTION
When `internal/env/env.Get` detects a difference in between already registered descriptions, it panics (good). But the error message doesn't tell you what's the difference and you're left out to put a few prints for yourself in the code to try to understand what's wrong. 

See also: https://github.com/sourcegraph/sourcegraph/pull/63786

Before:

<img width="1109" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/10151/56b2d65c-ef87-4134-bfc0-67248aa48350">

After: 

![CleanShot 2024-07-11 at 15 26 13@2x](https://github.com/sourcegraph/sourcegraph/assets/10151/406bca90-2b87-481d-aad3-6550afaca29f)


## Test plan

CI + local run 

## Changelog

- When conflicting env var are detected, print the two to ease debugging.
