### PR TITLE
chore(svelte): Commit/diff style and behavior tweaks

### DIFF
--- a/client/web-sveltekit/src/auto-imports.d.ts
+++ b/client/web-sveltekit/src/auto-imports.d.ts
@@ -11,6 +11,7 @@ declare global {
   const ILucideArchive: typeof import('~icons/lucide/archive')['default']
   const ILucideArrowDownFromLine: typeof import('~icons/lucide/arrow-down-from-line')['default']
   const ILucideArrowLeftFromLine: typeof import('~icons/lucide/arrow-left-from-line')['default']
+  const ILucideArrowRight: typeof import('~icons/lucide/arrow-right')['default']
   const ILucideArrowRightFromLine: typeof import('~icons/lucide/arrow-right-from-line')['default']
   const ILucideBarChartBig: typeof import('~icons/lucide/bar-chart-big')['default']
   const ILucideBookOpen: typeof import('~icons/lucide/book-open')['default']

--- a/client/web-sveltekit/src/lib/CodeMirrorBlob.svelte
+++ b/client/web-sveltekit/src/lib/CodeMirrorBlob.svelte
@@ -71,7 +71,7 @@
             padding: '0 1.5ex',
         },
         '.cm-line': {
-            lineHeight: '1.54',
+            lineHeight: 'var(--code-line-height)',
             padding: '0',
         },
         '.selected-line': {

--- a/client/web-sveltekit/src/lib/repo/FileDiff.gql
+++ b/client/web-sveltekit/src/lib/repo/FileDiff.gql
@@ -1,12 +1,17 @@
 fragment FileDiff_Diff on FileDiff {
-    newPath
-    oldPath
     mostRelevantFile {
         canonicalURL # key field
         url
+        path
     }
     newFile {
         canonicalURL # key field
+        path
+        binary
+    }
+    oldFile {
+        canonicalURL # key field
+        path
         binary
     }
     stat {

--- a/client/web-sveltekit/src/lib/repo/FileDiff.svelte
+++ b/client/web-sveltekit/src/lib/repo/FileDiff.svelte
@@ -13,17 +13,17 @@
     import FileDiffHunks from './FileDiffHunks.svelte'
 
     export let fileDiff: FileDiff_Diff
-    export let expanded = !!fileDiff.newPath
+    export let expanded = !!fileDiff.newFile?.path && fileDiff.hunks.length > 0
 
     const dispatch = createEventDispatcher<{ toggle: { expanded: boolean } }>()
 
-    $: isBinary = fileDiff.newFile?.binary
-    $: isNew = !fileDiff.oldPath
-    $: isDeleted = !fileDiff.newPath
-    $: isRenamed = fileDiff.newPath && fileDiff.oldPath && fileDiff.newPath !== fileDiff.oldPath
-    $: isMoved = isRenamed && dirname(fileDiff.newPath!) !== dirname(fileDiff.oldPath!)
-    $: path = isRenamed ? `${fileDiff.oldPath} -> ${fileDiff.newPath}` : isDeleted ? fileDiff.oldPath : fileDiff.newPath
-    $: stat = fileDiff.stat
+    $: ({ oldFile, newFile, stat } = fileDiff)
+
+    $: isBinary = (newFile && newFile.binary) || !!oldFile?.binary
+    $: isNew = !oldFile
+    $: isDeleted = !newFile
+    $: isRenamed = oldFile?.path !== newFile?.path
+    $: isMoved = isRenamed && oldFile && newFile && dirname(newFile.path) !== dirname(oldFile.path)
     $: linkFile = fileDiff.mostRelevantFile.__typename === 'GitBlob'
 
     function toggle() {
@@ -44,20 +44,37 @@
         <Badge variant="warning">{isMoved ? 'Moved' : 'Renamed'}</Badge>
     {/if}
     {#if stat}
-        <small class="added">+{numberWithCommas(stat.added)}</small>
-        <small class="deleted">-{numberWithCommas(stat.deleted)}</small>
+        <small class="added">+{numberWithCommas(stat.added)}<span class="visually-hidden">lines added</span></small>
+        <small class="deleted"
+            >-{numberWithCommas(stat.deleted)}<span class="visually-hidden">lines removed</span></small
+        >
         <DiffSquares added={stat.added} deleted={stat.deleted} />
     {/if}
     {#if linkFile}
-        <a href={fileDiff.mostRelevantFile.url}><span title={path}>{path}</span></a>
+        {#if oldFile && newFile && isRenamed}
+            <span>
+                <a href={oldFile.canonicalURL}>{oldFile.path}</a>
+                <Icon icon={ILucideArrowRight} inline aria-hidden />
+                <span class="visually-hidden">{isMoved ? 'moved' : 'renamed'} to</span>
+                <a href={newFile.canonicalURL}>{newFile.path}</a>
+            </span>
+        {:else}
+            <a href={fileDiff.mostRelevantFile.url}>{fileDiff.mostRelevantFile.path}</a>
+        {/if}
     {:else}
-        <span title={path}>{path}</span>
+        {newFile?.path || oldFile?.path}
     {/if}
 </div>
-{#if !isBinary && expanded}
-    <div class="hunks">
-        <FileDiffHunks hunks={fileDiff.hunks} />
-    </div>
+{#if expanded}
+    {#if isBinary}
+        <small class="info">(binary file not rendered)</small>
+    {:else if fileDiff.hunks.length === 0}
+        <small>(no changes)</small>
+    {:else}
+        <div class="hunks">
+            <FileDiffHunks hunks={fileDiff.hunks} />
+        </div>
+    {/if}
 {/if}
 
 <style lang="scss">
@@ -73,8 +90,10 @@
     }
 
     .hunks {
-        border-radius: var(--border-radius);
         border: 1px solid var(--border-color);
+        border-radius: var(--border-radius);
+        // This prevents the inner element from leaking over the rounded border
+        overflow: hidden;
     }
 
     .added {
@@ -83,5 +102,9 @@
 
     .deleted {
         color: var(--danger);
+    }
+
+    small {
+        color: var(--text-muted);
     }
 </style>

--- a/client/web-sveltekit/src/lib/repo/FileDiffHunks.svelte
+++ b/client/web-sveltekit/src/lib/repo/FileDiffHunks.svelte
@@ -45,50 +45,45 @@
     }
 </script>
 
-{#if hunks.length === 0}
-    <div class="text-muted mr-2">No changes</div>
-{:else}
-    <table>
-        <colgroup>
-            <col width="40" />
-            <col width="40" />
-            <col />
-        </colgroup>
-        <tbody>
-            {#each hunks as hunk (hunk.oldRange.startLine)}
-                {@const oldStartLine = hunk.oldRange.startLine}
-                {@const newStartLine = hunk.newRange.startLine}
-                <tr>
-                    <td class="header" colspan="3">
-                        @@ -{hunk.oldRange.startLine},{hunk.oldRange.lines} +{hunk.newRange.startLine},{hunk.newRange
-                            .lines}
-                        {#if hunk.section}
-                            @@ {hunk.section}
-                        {/if}
-                    </td>
+<table>
+    <colgroup>
+        <col width="40" />
+        <col width="40" />
+        <col />
+    </colgroup>
+    <tbody>
+        {#each hunks as hunk (hunk.oldRange.startLine)}
+            {@const oldStartLine = hunk.oldRange.startLine}
+            {@const newStartLine = hunk.newRange.startLine}
+            <tr>
+                <td class="header" colspan="3">
+                    @@ -{hunk.oldRange.startLine},{hunk.oldRange.lines} +{hunk.newRange.startLine},{hunk.newRange.lines}
+                    {#if hunk.section}
+                        @@ {hunk.section}
+                    {/if}
+                </td>
+            </tr>
+            {#each linesToDiffInformation(hunk.highlight.lines) as { marker, added, deleted, newLineOffset, oldLineOffset, html }}
+                <tr class:added class:deleted>
+                    <td class="num"
+                        >{#if !added}{oldStartLine + oldLineOffset}{/if}</td
+                    >
+                    <td class="num"
+                        >{#if !deleted}{newStartLine + newLineOffset}{/if}</td
+                    >
+                    <td class="content" data-diff-marker={marker}>{@html html}</td>
                 </tr>
-                {#each linesToDiffInformation(hunk.highlight.lines) as { marker, added, deleted, newLineOffset, oldLineOffset, html }}
-                    <tr class:added class:deleted>
-                        <td class="num"
-                            >{#if !added}{oldStartLine + oldLineOffset}{/if}</td
-                        >
-                        <td class="num"
-                            >{#if !deleted}{newStartLine + newLineOffset}{/if}</td
-                        >
-                        <td class="content" data-diff-marker={marker}>{@html html}</td>
-                    </tr>
-                {/each}
             {/each}
-        </tbody>
-    </table>
-{/if}
+        {/each}
+    </tbody>
+</table>
 
 <style lang="scss">
     table {
         width: 100%;
         border-collapse: collapse;
         font-family: var(--code-font-family);
-        font-size: 0.75rem;
+        font-size: var(--code-font-size);
     }
 
     tr.added {
@@ -101,24 +96,28 @@
 
     td {
         background-color: var(--code-bg);
-
-        &.num {
-            min-width: 2.5rem;
-            line-height: 1.6666666667;
-            white-space: nowrap;
-            text-align: right;
-            -webkit-user-select: none;
-            user-select: none;
-            vertical-align: top;
-            padding: 0 0.5rem;
-            color: var(--text-muted);
-        }
+        line-height: var(--code-line-height);
 
         &.header {
             white-space: pre-wrap;
             background-color: var(--color-bg-2);
             color: var(--body-color);
             padding: 0.25rem 1rem;
+        }
+
+        &.num {
+            color: var(--text-muted);
+            min-width: 2.5rem;
+            // The alignment between the line numbers and the marker/content seems to be a bit off, due to,
+            // apparently, specifying `vertical-align: top`. Hover this declaration is necessary so that the
+            // line number is aligned with the first line when the content wraps around.
+            // Adding a top padding makes it look better.
+            padding-top: 2px;
+            padding-inline: 0.5rem;
+            text-align: right;
+            user-select: none;
+            vertical-align: top;
+            white-space: nowrap;
         }
 
         &.content {

--- a/client/web-sveltekit/src/lib/repo/Permalink.svelte
+++ b/client/web-sveltekit/src/lib/repo/Permalink.svelte
@@ -17,7 +17,7 @@
         keys: { key: 'y' },
         ignoreInputFields: true,
         handler: () => {
-            const {revision} = parseBrowserRepoURL($page.url.pathname)
+            const { revision } = parseBrowserRepoURL($page.url.pathname)
             // Only navigate if necessary. We don't want to add unnecessary history entries.
             if (revision !== commitID) {
                 goto(href, { noScroll: true, keepFocus: true }).catch(() => {

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/-/commit/[...revspec]/page.spec.ts
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/-/commit/[...revspec]/page.spec.ts
@@ -72,8 +72,9 @@ test('shows previous diffs when error occurs', async ({ page, sg }) => {
                             nodes: [
                                 {
                                     __typename: 'FileDiff',
-                                    oldPath: null,
-                                    newPath: '<new path>',
+                                    newFile: {
+                                        path: '<new path>',
+                                    },
                                 },
                             ],
                             pageInfo: {

--- a/client/web-sveltekit/src/routes/styles.scss
+++ b/client/web-sveltekit/src/routes/styles.scss
@@ -45,10 +45,12 @@ input:focus-visible {
 
 // Taken from https://www.a11yproject.com/posts/how-to-hide-content/
 .visually-hidden {
-    clip-path: inset(50%);
+    // stylelint-disable-next-line declaration-property-unit-allowed-list
     height: 1px;
+    // stylelint-disable-next-line declaration-property-unit-allowed-list
+    width: 1px;
+    clip-path: inset(50%);
     overflow: hidden;
     position: absolute;
     white-space: nowrap;
-    width: 1px;
 }

--- a/client/web-sveltekit/src/routes/styles.scss
+++ b/client/web-sveltekit/src/routes/styles.scss
@@ -42,3 +42,13 @@ button:focus-visible {
 input:focus-visible {
     box-shadow: 0 0 0 2px var(--primary-2);
 }
+
+// Taken from https://www.a11yproject.com/posts/how-to-hide-content/
+.visually-hidden {
+    clip-path: inset(50%);
+    height: 1px;
+    overflow: hidden;
+    position: absolute;
+    white-space: nowrap;
+    width: 1px;
+}

--- a/client/web-sveltekit/src/routes/svelte-overrides.scss
+++ b/client/web-sveltekit/src/routes/svelte-overrides.scss
@@ -14,6 +14,7 @@ body {
     --font-family-base: 'Inter Variable', sans-serif;
     --monospace-font-family: 'Roboto Mono Variable', monospace;
     --code-font-family: var(--monospace-font-family);
+    --code-line-height: 1.54;
     --font-size-base: 0.9375rem;
     --font-size-small: 0.875rem;
     --font-size-extra-small: 0.6875rem;


### PR DESCRIPTION
A couple of tweaks to the commit / diff view:

- Linking both file paths in the header for renamed files
- Collapse renamed file diffs without changes by default
- Move "no changes" out of `FileDiffHunks` to not render a border around the test.
- Add description for binary files
- Adjust line height and font size to match what we use in the file view
- Added the `visibly-hidden` utility class to render content for a11y purposes (I didn't  test the changes I made with a screenreader though)

Contributes to SRCH-523


## Test plan

Manual testing

| Before | After |
|--------|--------|
| ![2024-07-11_15-25](https://github.com/sourcegraph/sourcegraph/assets/179026/b4b6444f-5aae-4cd4-acfd-7287df042a88) | ![2024-07-11_15-25_1](https://github.com/sourcegraph/sourcegraph/assets/179026/124b486f-0c73-447b-9879-81aac1e9f0aa) | 