### PR TITLE
fix(config): homogeneize desc for REDIS_ENDPOINT

### DIFF
--- a/cmd/cody-gateway/shared/config/config.go
+++ b/cmd/cody-gateway/shared/config/config.go
@@ -388,7 +388,7 @@ func (c *Config) Load() {
 
 	c.Environment = c.Get("CODY_GATEWAY_ENVIRONMENT", "dev", "Environment name.")
 
-	c.RedisEndpoint = c.Get("REDIS_ENDPOINT", "", "Redis endpoint to connect to for storing KV data.")
+	c.RedisEndpoint = c.Get("REDIS_ENDPOINT", "", "Redis endpoint. Used as fallback if neither REDIS_CACHE_ENDPOINT or REDIS_STORE_ENDPOINT are not specified.")
 }
 
 // loadFlaggingConfig loads the common set of flagging-related environment variables for

--- a/internal/redispool/redispool.go
+++ b/internal/redispool/redispool.go
@@ -28,7 +28,7 @@ var addresses = func() struct {
 		Store string
 	}{}
 
-	fallback := env.Get("REDIS_ENDPOINT", "", "redis endpoint. Used as fallback if REDIS_CACHE_ENDPOINT or REDIS_STORE_ENDPOINT is not specified.")
+	fallback := env.Get("REDIS_ENDPOINT", "", "Redis endpoint. Used as fallback if neither REDIS_CACHE_ENDPOINT or REDIS_STORE_ENDPOINT are not specified.")
 
 	for _, addr := range []string{
 		env.Get("REDIS_CACHE_ENDPOINT", "", "redis used for cache data. Default redis-cache:6379"),


### PR DESCRIPTION
PR #63625 introduced an explicit REDIS_ENDPOINT setting for the Cody Gateway, whose description differ from the default in redispool.

internal/env.Get detects that and panics, which this commit fixes.

Ideally, we shouldn't read env var from internal packages, will submit a ticket for that (and it should be caught by CI as well, when descs are drifting).

See also: https://github.com/sourcegraph/sourcegraph/pull/63784

## Test plan

`sg start dotcom` doesn't panic on the REDIS_ENDPOINT having two different descriptions. 

## Changelog

- Prevent a panic introduced by explicitly listing REDIS_ENDPOINT in CodyGateway with a different description from the default one in the redispool package. 
