### PR TITLE
gateway: Don't panic because of duplicate env var registration

### DIFF
--- a/internal/redispool/redispool.go
+++ b/internal/redispool/redispool.go
@@ -37,7 +37,7 @@ var addresses = func() struct {
 	}
 
 	redis.Cache = env.Get("REDIS_CACHE_ENDPOINT", fallback("redis-cache:6379"), "redis used for cache data. if not set, REDIS_ENDPOINT will be considered")
-	redis.Cache = env.Get("REDIS_STORE_ENDPOINT", fallback("redis-store:6379"), "redis used for persistent stores (eg HTTP sessions). if not set, REDIS_ENDPOINT will be considered")
+	redis.Store = env.Get("REDIS_STORE_ENDPOINT", fallback("redis-store:6379"), "redis used for persistent stores (eg HTTP sessions). if not set, REDIS_ENDPOINT will be considered")
 
 	return redis
 }()

--- a/internal/redispool/redispool.go
+++ b/internal/redispool/redispool.go
@@ -2,6 +2,7 @@
 package redispool
 
 import (
+	"os"
 	"strings"
 	"time"
 
@@ -28,30 +29,15 @@ var addresses = func() struct {
 		Store string
 	}{}
 
-	fallback := env.Get("REDIS_ENDPOINT", "", "redis endpoint. Used as fallback if REDIS_CACHE_ENDPOINT or REDIS_STORE_ENDPOINT is not specified.")
-
-	for _, addr := range []string{
-		env.Get("REDIS_CACHE_ENDPOINT", "", "redis used for cache data. Default redis-cache:6379"),
-		fallback,
-		"redis-cache:6379",
-	} {
-		if addr != "" {
-			redis.Cache = addr
-			break
+	fallback := func(d string) string {
+		if os.Getenv("REDIS_ENDPOINT") != "" {
+			return os.Getenv("REDIS_ENDPOINT")
 		}
+		return d
 	}
 
-	// addrStore
-	for _, addr := range []string{
-		env.Get("REDIS_STORE_ENDPOINT", "", "redis used for persistent stores (eg HTTP sessions). Default redis-store:6379"),
-		fallback,
-		"redis-store:6379",
-	} {
-		if addr != "" {
-			redis.Store = addr
-			break
-		}
-	}
+	redis.Cache = env.Get("REDIS_CACHE_ENDPOINT", fallback("redis-cache:6379"), "redis used for cache data. if not set, REDIS_ENDPOINT will be considered")
+	redis.Cache = env.Get("REDIS_STORE_ENDPOINT", fallback("redis-store:6379"), "redis used for persistent stores (eg HTTP sessions). if not set, REDIS_ENDPOINT will be considered")
 
 	return redis
 }()


### PR DESCRIPTION
`REDIS_ENDPOINT` is now registered by gateway, but it is also registered in `internal/redispool` as the fallback for when the other values are not set.

The real fix would be to not have env vars in that package, and instead each service creates one instance of each of those two in their `cmd/`, but that's a lot of work so short-term fixing it by reading the fallback using os.Getenv.

Test plan:

`sg run cody-gateway` doesn't panic.