### PR TITLE
release/feature: update `sg release cut` to automate stitch graph gen and release branch creation

### DIFF
--- a/dev/sg/internal/release/cut.go
+++ b/dev/sg/internal/release/cut.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"fmt"
 	"os/exec"
+	"regexp"
 	"strings"
 
-	"github.com/Masterminds/semver"
 	"github.com/urfave/cli/v2"
 
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/std"
@@ -19,30 +19,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/repo"
 )
 
-func genMigrationGraph(ctx context.Context, newVersion string) error {
-	err := run.Cmd(ctx, "comby", "-in-place", "\"const maxVersionString = :[1]\"", fmt.Sprintf("\"const maxVersionString = \"%d\"\"", newVersion), "internal/database/migration/shared/data/cmd/generator/consts.go").Run().Wait()
-	if err != nil {
-		return errors.Wrap(err, "Could not run comby to change maxVersionString")
-	}
-	err = run.Cmd(ctx, "git", "add", "./internal/database/migration/shared/data/cmd/generator/consts.go").Run().Wait()
-	if err != nil {
-		return errors.Wrap(err, "Could not git add file")
-	}
-	err = run.Cmd(ctx, "git", "commit", "-m", "Update maxVersionString").Run().Wait()
-	if err != nil {
-		return errors.Wrap(err, "Could not git commit file")
-	}
-	err = run.Cmd(ctx, "git", "archive", "--format=tar.gz", "HEAD", "migrations", ">", fmt.Sprintf("migrations-v%d.tar.gz", newVersion)).Run().Wait()
-	if err != nil {
-		return errors.Wrap(err, "Could not create git archive")
-	}
-	err = run.Cmd(ctx, "CLOUDSDK_CORE_PROJECT=\"sourcegraph-ci\"", "gsutil", "cp", fmt.Sprintf("migrations-v%d", newVersion), "gs://schemas-migrations/migrations/").Run().Wait()
-	if err != nil {
-		return errors.Wrap(err, "Could not push git archive to GCS")
-	}
-	return nil
-}
-
 func cutReleaseBranch(cctx *cli.Context) error {
 	p := std.Out.Pending(output.Styled(output.StylePending, "Checking for GitHub CLI..."))
 	ghPath, err := exec.LookPath("gh")
@@ -52,68 +28,19 @@ func cutReleaseBranch(cctx *cli.Context) error {
 	}
 	p.Complete(output.Linef(output.EmojiSuccess, output.StyleSuccess, "Using GitHub CLI at %q", ghPath))
 
-	var version string
-	if cctx.String("version") == "auto" {
-		var err error
-		version, err = determineNextReleaseVersion(cctx.Context)
-		if err != nil {
-			return err
-		}
-	} else {
-		// Normalize the version string, to prevent issues where this was given with the wrong convention
-		// which requires a full rebuild.
-		version = fmt.Sprintf("v%s", strings.TrimPrefix(cctx.String("version"), "v"))
-	}
-	v, err := semver.NewVersion(version)
-	if err != nil {
-		return errors.Newf("invalid version %q, must be semver", version)
-	}
-
-	releaseBranch := v.String()
+	// Check that main has been pulled to the local branch
 	defaultBranch := cctx.String("branch")
-
-	ctx := cctx.Context
-	releaseGitRepoBranch := repo.NewGitRepo(releaseBranch, releaseBranch)
 	defaultGitRepoBranch := repo.NewGitRepo(defaultBranch, defaultBranch)
-
-	if ok, err := defaultGitRepoBranch.IsDirty(ctx); err != nil {
-		return errors.Wrap(err, "check if current branch is dirty")
-	} else if ok {
-		return errors.Newf("current branch is dirty. please commit your unstaged changes")
-	}
-
-	p = std.Out.Pending(output.Styled(output.StylePending, "Checking if the release branch exists locally ..."))
-	if ok, err := releaseGitRepoBranch.HasLocalBranch(ctx); err != nil {
-		p.Destroy()
-		return errors.Wrapf(err, "checking if %q branch exists localy", releaseBranch)
-	} else if ok {
-		p.Destroy()
-		return errors.Newf("branch %q exists locally", releaseBranch)
-	}
-	p.Complete(output.Linef(output.EmojiSuccess, output.StyleSuccess, "Release branch %q does not exist locally", releaseBranch))
-
-	p = std.Out.Pending(output.Styled(output.StylePending, "Checking if the release branch exists in remote ..."))
-	if ok, err := releaseGitRepoBranch.HasRemoteBranch(ctx); err != nil {
-		p.Destroy()
-		return errors.Wrapf(err, "checking if %q branch exists in remote repo", releaseBranch)
-	} else if ok {
-		p.Destroy()
-		return errors.Newf("release branch %q exists in remote repo", releaseBranch)
-	}
-	p.Complete(output.Linef(output.EmojiSuccess, output.StyleSuccess, "Release branch %q does not exist in remote", releaseBranch))
-
-	p = std.Out.Pending(output.Styled(output.StylePending, "Checking if the default branch is up to date with remote ..."))
-	if _, err := defaultGitRepoBranch.FetchOrigin(ctx); err != nil {
-		p.Destroy()
-		return errors.Wrapf(err, "fetching origin for %q", defaultBranch)
-	}
-
-	if err := defaultGitRepoBranch.Checkout(ctx); err != nil {
+	if err := defaultGitRepoBranch.Checkout(cctx.Context); err != nil {
 		p.Destroy()
 		return errors.Wrapf(err, "checking out %q", defaultBranch)
 	}
-
-	if ok, err := defaultGitRepoBranch.IsOutOfSync(ctx); err != nil {
+	p = std.Out.Pending(output.Styled(output.StylePending, "Checking if the default branch is up to date with remote ..."))
+	if _, err := defaultGitRepoBranch.FetchOrigin(cctx.Context); err != nil {
+		p.Destroy()
+		return errors.Wrapf(err, "fetching origin for %q", defaultBranch)
+	}
+	if ok, err := defaultGitRepoBranch.IsOutOfSync(cctx.Context); err != nil {
 		p.Destroy()
 		return errors.Wrapf(err, "checking if %q branch is up to date with remote", defaultBranch)
 	} else if ok {
@@ -122,23 +49,77 @@ func cutReleaseBranch(cctx *cli.Context) error {
 	}
 	p.Complete(output.Linef(output.EmojiSuccess, output.StyleSuccess, "Local branch is up to date with remote"))
 
-	p = std.Out.Pending(output.Styled(output.StylePending, "Creating release branch..."))
-	if err := releaseGitRepoBranch.CheckoutNewBranch(ctx); err != nil {
-		p.Destroy()
-		return errors.Wrap(err, "failed to create release branch")
+	// Normalize the version string, to prevent issues where this was given with the wrong convention
+	// which requires a full rebuild.
+	version := fmt.Sprintf("v%s", strings.TrimPrefix(cctx.String("version"), "v"))
+	if !regexp.MustCompile("\\d+\\.\\d+\\.0)$").MatchString(version) {
+		return errors.Newf("invalid version input %q, must be of the form X.Y.0", version)
 	}
-	p.Complete(output.Linef(output.EmojiSuccess, output.StyleSuccess, "Release branch %q created", releaseBranch))
+	releaseBranch := strings.Replace(version, ".0", ".x", 1)
 
-	p = std.Out.Pending(output.Styled(output.StylePending, "Pushing release branch..."))
-	if _, err := releaseGitRepoBranch.Push(ctx); err != nil {
-		p.Destroy()
-		return errors.Wrap(err, "failed to push release branch")
+	// Ensure release branch conforms to release process policy
+	if !regexp.MustCompile("\\d+\\.\\d+\\.x)$").MatchString(releaseBranch) {
+		return errors.Newf("invalid branch name %q, must be of the form X.Y.x", releaseBranch)
 	}
-	p.Complete(output.Linef(output.EmojiSuccess, output.StyleSuccess, "Release branch %q pushed", releaseBranch))
 
+	// Check that the branch doesn't exist locally
+	releaseGitRepoBranch := repo.NewGitRepo(releaseBranch, releaseBranch)
+	p = std.Out.Pending(output.Styled(output.StylePending, "Checking if the release branch exists locally ..."))
+	if ok, err := releaseGitRepoBranch.HasLocalBranch(cctx.Context); err != nil {
+		p.Destroy()
+		return errors.Wrapf(err, "checking if %q branch exists localy", releaseBranch)
+	} else if ok {
+		p.Destroy()
+		return errors.Newf("branch %q exists locally", releaseBranch)
+	}
+	p.Complete(output.Linef(output.EmojiSuccess, output.StyleSuccess, "Release branch %q does not exist locally", releaseBranch))
+
+	// Check the remote doesn't have the new release branch already
+	p = std.Out.Pending(output.Styled(output.StylePending, "Checking if the release branch exists in remote ..."))
+	if ok, err := releaseGitRepoBranch.HasRemoteBranch(cctx.Context); err != nil {
+		p.Destroy()
+		return errors.Wrapf(err, "checking if %q branch exists in remote repo", releaseBranch)
+	} else if ok {
+		p.Destroy()
+		return errors.Newf("release branch %q exists in remote repo", releaseBranch)
+	}
+	p.Complete(output.Linef(output.EmojiSuccess, output.StyleSuccess, "Release branch %q does not exist in remote", releaseBranch))
+
+	// Checkout and push release branch
+	releaseGitRepoBranch.CheckoutNewBranch(cctx.Context)
+	_, err = releaseGitRepoBranch.Push(cctx.Context)
+	if err != nil {
+		return errors.Wrapf(err, "could not push release branch %q", releaseBranch)
+	}
+
+	// generate and commit max string const and migration graph archive
+	err = replaceMaxVersion(cctx.Context, version)
+	if err != nil {
+		return err
+	}
+	_, err = releaseGitRepoBranch.Add(cctx.Context, "internal/database/migration/shared/data/cmd/generator/consts.go")
+	if err != nil {
+		return errors.Wrap(err, "could not add consts.go to staged changes")
+	}
+	_, err = releaseGitRepoBranch.Commit(cctx.Context, "chore: update max version")
+	if err != nil {
+		return errors.Wrap(err, "could not commit staged changes")
+	}
+	_, err = releaseGitRepoBranch.Push(cctx.Context)
+	if err != nil {
+		return errors.Wrap(err, "could not push staged changes")
+	}
+
+	// generate new stitched migration archive
+	err = genStitchMigrationArchive(cctx.Context, version)
+	if err != nil {
+		return err
+	}
+
+	// Create backport label
 	p = std.Out.Pending(output.Styled(output.StylePending, "Creating backport label..."))
 	if _, err := execute.GH(
-		ctx,
+		cctx.Context,
 		"label",
 		"create",
 		fmt.Sprintf("backport %s", releaseBranch),
@@ -150,5 +131,34 @@ func cutReleaseBranch(cctx *cli.Context) error {
 	}
 	p.Complete(output.Linef(output.EmojiSuccess, output.StyleSuccess, "Backport label created"))
 
+	return nil
+}
+
+func replaceMaxVersion(ctx context.Context, newVersion string) error {
+	p := std.Out.Pending(output.Styled(output.StylePending, "Checking for comby CLI..."))
+	combyPath, err := exec.LookPath("comby")
+	if err != nil {
+		p.Destroy()
+		return errors.Wrap(err, "Comby (https://comby.dev/) is required for installation")
+	}
+	p.Complete(output.Linef(output.EmojiSuccess, output.StyleSuccess, "Using Comby at %q", combyPath))
+
+	err = run.Cmd(ctx, "comby", "-in-place", "\"const maxVersionString = :[1]\"", fmt.Sprintf("\"const maxVersionString = \"%d\"\"", newVersion), "internal/database/migration/shared/data/cmd/generator/consts.go").Run().Wait()
+	if err != nil {
+		return errors.Wrap(err, "Could not run comby to change maxVersionString")
+	}
+	return nil
+}
+
+// TODO set timestamp during archive generation for cache
+func genStitchMigrationArchive(ctx context.Context, newVersion string) error {
+	err := run.Cmd(ctx, "git", "archive", "--format=tar.gz", "HEAD", "migrations", ">", fmt.Sprintf("migrations-v%s.tar.gz", newVersion)).Run().Wait()
+	if err != nil {
+		return errors.Wrap(err, "Could not create git archive")
+	}
+	err = run.Cmd(ctx, "CLOUDSDK_CORE_PROJECT=\"sourcegraph-ci\"", "gsutil", "cp", fmt.Sprintf("migrations-v%s", newVersion), "gs://schemas-migrations/migrations/").Run().Wait()
+	if err != nil {
+		return errors.Wrap(err, "Could not push git archive to GCS")
+	}
 	return nil
 }

--- a/dev/sg/internal/release/release.go
+++ b/dev/sg/internal/release/release.go
@@ -199,7 +199,7 @@ var Command = &cli.Command{
 		},
 		{
 			Name:      "cut",
-			Usage:     "Cut a release",
+			Usage:     "Cut a minor release branch",
 			Category:  category.Util,
 			UsageText: "sg release cut",
 			Action:    cutReleaseBranch,

--- a/dev/sg/internal/repo/git_repo.go
+++ b/dev/sg/internal/repo/git_repo.go
@@ -110,6 +110,16 @@ func (g *GitRepo) IsDirty(ctx context.Context) (bool, error) {
 	return len(files) > 0, nil
 }
 
+// Add a file to staged changes
+func (g *GitRepo) Add(ctx context.Context, file string) (string, error) {
+	return run.Cmd(ctx, "git", "add", file).Run().String()
+}
+
+// Commit commits the staged changes with the given message
+func (g *GitRepo) Commit(ctx context.Context, message string) (string, error) {
+	return run.Cmd(ctx, "git", "commit", "-m", message).Run().String()
+}
+
 // Push pushes the current branch to origin using the specific push options
 func (g *GitRepo) Push(ctx context.Context, opts ...pushOpt) (string, error) {
 	cmd := []string{"git", "push", "origin", g.Branch}


### PR DESCRIPTION
<!-- PR description tips: https://www.notion.so/sourcegraph/Write-a-good-pull-request-description-610a7fd3e613496eb76f450db5a49b6e -->

Resolve: [https://linear.app/sourcegraph/issue/REL-253/bug-automate-the-stitched-migration-graph-bazel-archive-generation](https://linear.app/sourcegraph/issue/REL-253/bug-automate-the-stitched-migration-graph-bazel-archive-generation)

## Test plan

<!-- REQUIRED; info at https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles -->

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
