### PR TITLE
fix(svelte): respect default pattern type in toggles

### DIFF
--- a/client/web-sveltekit/src/lib/search/input/SearchInput.svelte
+++ b/client/web-sveltekit/src/lib/search/input/SearchInput.svelte
@@ -33,6 +33,7 @@
     import { createSuggestionsSource } from '$lib/web'
 
     import { type QueryStateStore, getQueryURL, QueryState } from '../state'
+    import { settings } from '$lib/stores'
 
     import { createRecentSearchesStore } from './recentSearches'
     import Suggestions from './Suggestions.svelte'
@@ -192,8 +193,15 @@
 
     function setOrUnsetPatternType(patternType: SearchPatternType): void {
         queryState.setPatternType(currentPatternType =>
-            currentPatternType === patternType ? SearchPatternType.keyword : patternType
+            currentPatternType === patternType ? getUnselectedPatternType() : patternType
         )
+    }
+
+    // When a toggle is unset, we revert back to the default pattern type. However, if the default pattern type
+    // is regexp, we should revert to keyword instead (otherwise it's not possible to disable the toggle).
+    function getUnselectedPatternType(): SearchPatternType {
+        const defaultPatternType = ($settings?.['search.defaultPatternType'] as SearchPatternType) ?? SearchPatternType.keyword
+        return defaultPatternType === SearchPatternType.regexp ? SearchPatternType.keyword : defaultPatternType
     }
 
     async function submitQuery(state: QueryState): Promise<void> {


### PR DESCRIPTION
In Sveltekit, we respect the setting `search.defaultPatternType` for the initial search, but if you set then unset the regexp toggle, it always reverts to `keyword`. Now we revert back to the default when a toggle is unset.

This is important because some customers have disabled keyword search, and we've directed them to use `search.defaultPatternType`.

## Test plan

Manually tested search + toggles with following config:
* No settings
* `search.defaultPatternType: standard`, `keyword`, and `regexp`