### PR TITLE
Svelte: Minor styling updates to tabs and search result filters

### DIFF
--- a/client/web-sveltekit/src/lib/TabsHeader.svelte
+++ b/client/web-sveltekit/src/lib/TabsHeader.svelte
@@ -76,7 +76,7 @@
         align-items: center;
         min-height: 2rem;
         padding: 0.25rem 0.75rem;
-        color: var(--text-muted);
+        color: var(--text-body);
         display: inline-flex;
         flex-flow: row nowrap;
         justify-content: center;

--- a/client/web-sveltekit/src/lib/search/dynamicFilters/SectionItem.svelte
+++ b/client/web-sveltekit/src/lib/search/dynamicFilters/SectionItem.svelte
@@ -32,7 +32,7 @@
 
 <style lang="scss">
     a {
-        --icon-color: currentColor;
+        --icon-color: var(--header-icon-color);
 
         display: flex;
         width: 100%;


### PR DESCRIPTION
## Before
<img width="791" alt="CleanShot 2024-07-12 at 08 01 16@2x" src="https://github.com/user-attachments/assets/c1263eb8-159d-43a5-9115-eb568d4ec372">

<img width="375" alt="CleanShot 2024-07-12 at 08 01 31@2x" src="https://github.com/user-attachments/assets/4e05a26e-6c04-4862-aac9-01d9a217b4f1">

## After
<img width="705" alt="CleanShot 2024-07-12 at 08 00 27@2x" src="https://github.com/user-attachments/assets/c3c528b3-593f-4fd7-aec7-a1075548f1a3">

<img width="375" alt="CleanShot 2024-07-12 at 08 00 45@2x" src="https://github.com/user-attachments/assets/1f083180-9428-42ac-a41a-ba3d5dbb7160">

## Test Plan
Tested locally, manually.