### PR TITLE
fix(sg): do not try to publish analytics when it is disabled

### DIFF
--- a/dev/sg/main.go
+++ b/dev/sg/main.go
@@ -196,6 +196,13 @@ var sg = &cli.App{
 		} else {
 			cmd.Context = secrets.WithContext(cmd.Context, secretsStore)
 		}
+		// Initialize context
+		cmd.Context, err = usershell.Context(cmd.Context)
+		if err != nil {
+			std.Out.WriteWarningf("Unable to infer user shell context: %s", err)
+		}
+		cmd.Context = background.Context(cmd.Context, verbose)
+		interrupt.Register(func() { background.Wait(cmd.Context, std.Out) })
 
 		// Set up analytics and hooks for each command - do this as the first context
 		// setup
@@ -228,19 +235,10 @@ var sg = &cli.App{
 
 			// Add analytics to each command
 			addAnalyticsHooks([]string{"sg"}, cmd.App.Commands)
+			// Start the analytics publisher
+			analytics.BackgroundEventPublisher(cmd.Context)
+			interrupt.Register(analytics.StopBackgroundEventPublisher)
 		}
-
-		// Initialize context after analytics are set up
-		cmd.Context, err = usershell.Context(cmd.Context)
-		if err != nil {
-			std.Out.WriteWarningf("Unable to infer user shell context: %s", err)
-		}
-		cmd.Context = background.Context(cmd.Context, verbose)
-		interrupt.Register(func() { background.Wait(cmd.Context, std.Out) })
-
-		// start the analytics publisher
-		analytics.BackgroundEventPublisher(cmd.Context)
-		interrupt.Register(analytics.StopBackgroundEventPublisher)
 
 		// Configure logger, for commands that use components that use loggers
 		if _, set := os.LookupEnv(log.EnvDevelopment); !set {

--- a/dev/sg/main.go
+++ b/dev/sg/main.go
@@ -213,7 +213,7 @@ var sg = &cli.App{
 					msg = "The problem occured while trying to get a secret via Google. Below is the error:\n"
 					msg += fmt.Sprintf("\n```%v```\n", err)
 					msg += "\nPossible fixes:\n"
-					msg += "- You should be in the `gcp-engineers@sourcegraph.com` group. Ask #ask-it-tech-ops or #discuss-dev-infra to check that\n"
+					msg += "- You should be in the `gcp-engineering@sourcegraph.com` group. Ask #ask-it-tech-ops or #discuss-dev-infra to check that\n"
 					msg += "- Ensure you're currently authenticated with your sourcegraph.com account by running `gcloud auth list`\n"
 					msg += "- Ensure you're authenticated with gcloud by running `gcloud auth application-default login`\n"
 				} else {

--- a/dev/sg/main.go
+++ b/dev/sg/main.go
@@ -202,6 +202,10 @@ var sg = &cli.App{
 			std.Out.WriteWarningf("Unable to infer user shell context: %s", err)
 		}
 		cmd.Context = background.Context(cmd.Context, verbose)
+
+		// We need to register the wait in the interrupt handlers, because if interrupted
+		// the .After on cli.App won't run. This makes sure that both the happy and sad paths
+		// are waiting for background tasks to finish.
 		interrupt.Register(func() { background.Wait(cmd.Context, std.Out) })
 
 		// Set up analytics and hooks for each command - do this as the first context


### PR DESCRIPTION
The background publisher was started regardless if analytics was disabled or not. This PR makes it so that we only publish analytics if it is enabled.

To make it work and not duplicate the disabled analytics check, I moved the usershell + background context creation to happen earlier.

## Test plan
CI and tested locally

## Changelog
* sg - only start the analytics background publisher when analytics are enabled
