### PR TITLE
chore: Bump autoindexing image SHAs

### DIFF
--- a/internal/codeintel/autoindexing/internal/inference/libs/indexes.go
+++ b/internal/codeintel/autoindexing/internal/inference/libs/indexes.go
@@ -27,12 +27,12 @@ var defaultIndexers = map[string]string{
 
 // To update, run `DOCKER_USER=... DOCKER_PASS=... ./update-shas.sh`
 var defaultIndexerSHAs = map[string]string{
-	"sourcegraph/scip-go":         "sha256:56414010d8917d6952c051dd5fcc0901fdf5c12031d352cc0b26778f040dddcc",
+	"sourcegraph/scip-go":         "sha256:bf89e619382fed5efa21a51806d7c6f22d19b6dea458a58554c0af89120f4ca3",
 	"sourcegraph/scip-rust":       "sha256:adf0047fc3050ba4f7be71302b42c74b49901f38fb40916d94ac5fc9181ac078",
-	"sourcegraph/scip-java":       "sha256:a2b3828145cd38758a43363f06d786f9e620c97979a9291463c6544f7f17c68f",
+	"sourcegraph/scip-java":       "sha256:02b5dd2a14b3d0cd776b561ba68660676b4172677fd1fff59cb5d9a0b5351cea",
 	"sourcegraph/scip-python":     "sha256:e3c13f0cadca78098439c541d19a72c21672a3263e22aa706760d941581e068d",
 	"sourcegraph/scip-typescript": "sha256:3df8b36a2ad4e073415bfbeaedf38b3cfff3e697614c8f578299f470d140c2c8",
-	"sourcegraph/scip-ruby":       "sha256:ef53e5f1450330ddb4a3edce963b7e10d900d44ff1e7de4960680289ac25f319",
+	"sourcegraph/scip-ruby":       "sha256:75a54c6032c977ae4960c5651f6095bb017bf55b7a4b86e608c6235443c38cbb",
 	"sourcegraph/scip-dotnet":     "sha256:1d8a590edfb3834020fceedacac6608811dd31fcba9092426140093876d8d52e",
 }
 

--- a/internal/codeintel/autoindexing/internal/inference/testdata/JVM_project_with_Gradle.yaml
+++ b/internal/codeintel/autoindexing/internal/inference/testdata/JVM_project_with_Gradle.yaml
@@ -1,7 +1,7 @@
 - steps: []
   local_steps: []
   root: ""
-  indexer: sourcegraph/scip-java@sha256:a2b3828145cd38758a43363f06d786f9e620c97979a9291463c6544f7f17c68f
+  indexer: sourcegraph/scip-java@sha256:02b5dd2a14b3d0cd776b561ba68660676b4172677fd1fff59cb5d9a0b5351cea
   indexer_args:
     - scip-java
     - index

--- a/internal/codeintel/autoindexing/internal/inference/testdata/JVM_project_with_Maven.yaml
+++ b/internal/codeintel/autoindexing/internal/inference/testdata/JVM_project_with_Maven.yaml
@@ -1,7 +1,7 @@
 - steps: []
   local_steps: []
   root: ""
-  indexer: sourcegraph/scip-java@sha256:a2b3828145cd38758a43363f06d786f9e620c97979a9291463c6544f7f17c68f
+  indexer: sourcegraph/scip-java@sha256:02b5dd2a14b3d0cd776b561ba68660676b4172677fd1fff59cb5d9a0b5351cea
   indexer_args:
     - scip-java
     - index

--- a/internal/codeintel/autoindexing/internal/inference/testdata/JVM_project_with_SBT.yaml
+++ b/internal/codeintel/autoindexing/internal/inference/testdata/JVM_project_with_SBT.yaml
@@ -1,7 +1,7 @@
 - steps: []
   local_steps: []
   root: ""
-  indexer: sourcegraph/scip-java@sha256:a2b3828145cd38758a43363f06d786f9e620c97979a9291463c6544f7f17c68f
+  indexer: sourcegraph/scip-java@sha256:02b5dd2a14b3d0cd776b561ba68660676b4172677fd1fff59cb5d9a0b5351cea
   indexer_args:
     - scip-java
     - index

--- a/internal/codeintel/autoindexing/internal/inference/testdata/JVM_project_with_lsif-java.json.yaml
+++ b/internal/codeintel/autoindexing/internal/inference/testdata/JVM_project_with_lsif-java.json.yaml
@@ -1,7 +1,7 @@
 - steps: []
   local_steps: []
   root: ""
-  indexer: sourcegraph/scip-java@sha256:a2b3828145cd38758a43363f06d786f9e620c97979a9291463c6544f7f17c68f
+  indexer: sourcegraph/scip-java@sha256:02b5dd2a14b3d0cd776b561ba68660676b4172677fd1fff59cb5d9a0b5351cea
   indexer_args:
     - scip-java
     - index

--- a/internal/codeintel/autoindexing/internal/inference/testdata/Nested_JVM_project_WITHOUT_top-level_build_file.yaml
+++ b/internal/codeintel/autoindexing/internal/inference/testdata/Nested_JVM_project_WITHOUT_top-level_build_file.yaml
@@ -1,7 +1,7 @@
 - steps: []
   local_steps: []
   root: my-module
-  indexer: sourcegraph/scip-java@sha256:a2b3828145cd38758a43363f06d786f9e620c97979a9291463c6544f7f17c68f
+  indexer: sourcegraph/scip-java@sha256:02b5dd2a14b3d0cd776b561ba68660676b4172677fd1fff59cb5d9a0b5351cea
   indexer_args:
     - scip-java
     - index
@@ -11,7 +11,7 @@
 - steps: []
   local_steps: []
   root: our-module
-  indexer: sourcegraph/scip-java@sha256:a2b3828145cd38758a43363f06d786f9e620c97979a9291463c6544f7f17c68f
+  indexer: sourcegraph/scip-java@sha256:02b5dd2a14b3d0cd776b561ba68660676b4172677fd1fff59cb5d9a0b5351cea
   indexer_args:
     - scip-java
     - index

--- a/internal/codeintel/autoindexing/internal/inference/testdata/Nested_JVM_project_with_top-level_build_file.yaml
+++ b/internal/codeintel/autoindexing/internal/inference/testdata/Nested_JVM_project_with_top-level_build_file.yaml
@@ -1,7 +1,7 @@
 - steps: []
   local_steps: []
   root: ""
-  indexer: sourcegraph/scip-java@sha256:a2b3828145cd38758a43363f06d786f9e620c97979a9291463c6544f7f17c68f
+  indexer: sourcegraph/scip-java@sha256:02b5dd2a14b3d0cd776b561ba68660676b4172677fd1fff59cb5d9a0b5351cea
   indexer_args:
     - scip-java
     - index

--- a/internal/codeintel/autoindexing/internal/inference/testdata/go_files_in_root.yaml
+++ b/internal/codeintel/autoindexing/internal/inference/testdata/go_files_in_root.yaml
@@ -8,7 +8,7 @@
         echo "No netrc config set, continuing"
       fi
   root: ""
-  indexer: sourcegraph/scip-go@sha256:56414010d8917d6952c051dd5fcc0901fdf5c12031d352cc0b26778f040dddcc
+  indexer: sourcegraph/scip-go@sha256:bf89e619382fed5efa21a51806d7c6f22d19b6dea458a58554c0af89120f4ca3
   indexer_args:
     - GO111MODULE=off
     - scip-go

--- a/internal/codeintel/autoindexing/internal/inference/testdata/go_modules.yaml
+++ b/internal/codeintel/autoindexing/internal/inference/testdata/go_modules.yaml
@@ -1,6 +1,6 @@
 - steps:
     - root: foo/bar
-      image: sourcegraph/scip-go@sha256:56414010d8917d6952c051dd5fcc0901fdf5c12031d352cc0b26778f040dddcc
+      image: sourcegraph/scip-go@sha256:bf89e619382fed5efa21a51806d7c6f22d19b6dea458a58554c0af89120f4ca3
       commands:
         - |
           if [ "$NETRC_DATA" ]; then
@@ -19,7 +19,7 @@
         echo "No netrc config set, continuing"
       fi
   root: foo/bar
-  indexer: sourcegraph/scip-go@sha256:56414010d8917d6952c051dd5fcc0901fdf5c12031d352cc0b26778f040dddcc
+  indexer: sourcegraph/scip-go@sha256:bf89e619382fed5efa21a51806d7c6f22d19b6dea458a58554c0af89120f4ca3
   indexer_args:
     - scip-go
     - --no-animation
@@ -33,7 +33,7 @@
     - NETRC_DATA
 - steps:
     - root: foo/baz
-      image: sourcegraph/scip-go@sha256:56414010d8917d6952c051dd5fcc0901fdf5c12031d352cc0b26778f040dddcc
+      image: sourcegraph/scip-go@sha256:bf89e619382fed5efa21a51806d7c6f22d19b6dea458a58554c0af89120f4ca3
       commands:
         - |
           if [ "$NETRC_DATA" ]; then
@@ -52,7 +52,7 @@
         echo "No netrc config set, continuing"
       fi
   root: foo/baz
-  indexer: sourcegraph/scip-go@sha256:56414010d8917d6952c051dd5fcc0901fdf5c12031d352cc0b26778f040dddcc
+  indexer: sourcegraph/scip-go@sha256:bf89e619382fed5efa21a51806d7c6f22d19b6dea458a58554c0af89120f4ca3
   indexer_args:
     - scip-go
     - --no-animation

--- a/internal/codeintel/autoindexing/internal/inference/testdata/scip-ruby.yaml
+++ b/internal/codeintel/autoindexing/internal/inference/testdata/scip-ruby.yaml
@@ -1,7 +1,7 @@
 - steps: []
   local_steps: []
   root: a
-  indexer: sourcegraph/scip-ruby@sha256:ef53e5f1450330ddb4a3edce963b7e10d900d44ff1e7de4960680289ac25f319
+  indexer: sourcegraph/scip-ruby@sha256:75a54c6032c977ae4960c5651f6095bb017bf55b7a4b86e608c6235443c38cbb
   indexer_args:
     - scip-ruby-autoindex
   outfile: index.scip
@@ -9,7 +9,7 @@
 - steps: []
   local_steps: []
   root: b
-  indexer: sourcegraph/scip-ruby@sha256:ef53e5f1450330ddb4a3edce963b7e10d900d44ff1e7de4960680289ac25f319
+  indexer: sourcegraph/scip-ruby@sha256:75a54c6032c977ae4960c5651f6095bb017bf55b7a4b86e608c6235443c38cbb
   indexer_args:
     - scip-ruby-autoindex
   outfile: index.scip
@@ -17,7 +17,7 @@
 - steps: []
   local_steps: []
   root: c
-  indexer: sourcegraph/scip-ruby@sha256:ef53e5f1450330ddb4a3edce963b7e10d900d44ff1e7de4960680289ac25f319
+  indexer: sourcegraph/scip-ruby@sha256:75a54c6032c977ae4960c5651f6095bb017bf55b7a4b86e608c6235443c38cbb
   indexer_args:
     - scip-ruby-autoindex
   outfile: index.scip
@@ -25,7 +25,7 @@
 - steps: []
   local_steps: []
   root: d
-  indexer: sourcegraph/scip-ruby@sha256:ef53e5f1450330ddb4a3edce963b7e10d900d44ff1e7de4960680289ac25f319
+  indexer: sourcegraph/scip-ruby@sha256:75a54c6032c977ae4960c5651f6095bb017bf55b7a4b86e608c6235443c38cbb
   indexer_args:
     - scip-ruby-autoindex
   outfile: index.scip
@@ -33,7 +33,7 @@
 - steps: []
   local_steps: []
   root: e
-  indexer: sourcegraph/scip-ruby@sha256:ef53e5f1450330ddb4a3edce963b7e10d900d44ff1e7de4960680289ac25f319
+  indexer: sourcegraph/scip-ruby@sha256:75a54c6032c977ae4960c5651f6095bb017bf55b7a4b86e608c6235443c38cbb
   indexer_args:
     - scip-ruby-autoindex
   outfile: index.scip


### PR DESCRIPTION
Picks up latest versions of SCIP indexers for auto-indexing.

## Test plan

Updated snapshot tests
