### PR TITLE
fix(batches): the baseURL for github instance is now updated when creating a GitHub app

### DIFF
--- a/client/web/src/enterprise/batches/settings/AddCredentialModal.tsx
+++ b/client/web/src/enterprise/batches/settings/AddCredentialModal.tsx
@@ -383,6 +383,7 @@ const AddToken: FC<AddTokenProps> = ({
                         authenticatedUser={user as unknown as AuthenticatedUser}
                         minimizedMode={true}
                         kind={kind}
+                        externalServiceURL={externalServiceURL}
                     />
                 )}
             </>

--- a/client/web/src/enterprise/batches/settings/BatchChangesCreateGitHubAppPage.tsx
+++ b/client/web/src/enterprise/batches/settings/BatchChangesCreateGitHubAppPage.tsx
@@ -23,16 +23,18 @@ interface BatchChangesCreateGitHubAppPageProps {
     authenticatedUser: AuthenticatedUser
     minimizedMode?: boolean
     kind: GitHubAppKind
+    externalServiceURL?: string
 }
 
 export const BatchChangesCreateGitHubAppPage: FC<BatchChangesCreateGitHubAppPageProps> = ({
     minimizedMode,
     kind,
     authenticatedUser,
+    externalServiceURL,
 }) => {
     const location = useLocation()
     const searchParams = new URLSearchParams(location.search)
-    const baseURL = searchParams.get('baseURL')
+    const baseURL = externalServiceURL || searchParams.get('baseURL')
 
     const isGitHubAppKindCredential = kind === GitHubAppKind.USER_CREDENTIAL || kind === GitHubAppKind.SITE_CREDENTIAL
 


### PR DESCRIPTION
Closes SRCH-723

The baseURL for  GitHub apps defaults to `https://github.com` when no `externalServiceURL`, we somehow missed this during our testing.

![CleanShot 2024-07-12 at 11 57 00@2x](https://github.com/user-attachments/assets/99b68a11-de38-4a2d-8c4c-3219f0c9abf7)


## Test plan

<!-- REQUIRED; info at https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles -->

Manual testing with the GHE instance.

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
