### PR TITLE
fix(svelte): Ctrl+backspace in fuzzy finder

### DIFF
--- a/client/web-sveltekit/src/routes/[...repo=reporev]/+layout.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/+layout.svelte
@@ -122,7 +122,10 @@
             key: 'ctrl+backspace',
             mac: 'cmd+backspace',
         },
-        ignoreInputFields: false,
+        // Ctrl/cmd+Backspace is used to delete whole words in inputs
+        // This would interfere e.g. with the fuzzy finder (but not the search input because
+        // CodeMirror handles this itself)
+        ignoreInputFields: true,
         handler: () => {
             goto(data.repoURL)
         },


### PR DESCRIPTION
We register ctrl+backspace to go to the repository root, but that should not trigger when an input field, such as the fuzzy finder, is focused.

Fixes srch-681

## Test plan

Manual testing.
