### PR TITLE
[Backport-5.5.x]: Move Cody Web to beta (#63806)

### DIFF
--- a/client/web/src/cody/chat/new-chat/NewCodyChatPage.tsx
+++ b/client/web/src/cody/chat/new-chat/NewCodyChatPage.tsx
@@ -3,7 +3,7 @@ import type { FC } from 'react'
 import { CodyWebHistory, CodyWebChatProvider } from 'cody-web-experimental'
 import { Navigate } from 'react-router-dom'
 
-import { Badge, ButtonLink, PageHeader, Text } from '@sourcegraph/wildcard'
+import { ButtonLink, PageHeader, ProductStatusBadge, Text } from '@sourcegraph/wildcard'
 
 import { Page } from '../../../components/Page'
 import { PageTitle } from '../../../components/PageTitle'
@@ -95,9 +95,7 @@ const CodyPageHeader: FC<CodyPageHeaderProps> = props => {
                 <PageHeader.Breadcrumb icon={CodyColorIcon}>
                     <div className="d-inline-flex align-items-center">
                         Cody Chat
-                        <Badge variant="info" className="ml-2">
-                            Experimental
-                        </Badge>
+                        <ProductStatusBadge status="beta" className="ml-2" />
                     </div>
                 </PageHeader.Breadcrumb>
             </PageHeader.Heading>

--- a/client/web/src/cody/sidebar/new-cody-sidebar/NewCodySidebar.tsx
+++ b/client/web/src/cody/sidebar/new-cody-sidebar/NewCodySidebar.tsx
@@ -4,7 +4,7 @@ import { mdiClose } from '@mdi/js'
 
 import { CodyLogo } from '@sourcegraph/cody-ui'
 import { lazyComponent } from '@sourcegraph/shared/src/util/lazyComponent'
-import { Alert, Badge, Button, H4, Icon, LoadingSpinner } from '@sourcegraph/wildcard'
+import { Alert, Button, H4, Icon, LoadingSpinner, ProductStatusBadge } from '@sourcegraph/wildcard'
 
 import styles from './NewCodySidebar.module.scss'
 
@@ -32,7 +32,7 @@ export const NewCodySidebar: FC<NewCodySidebarProps> = props => {
                     <CodyLogo />
                     Cody
                     <div className="ml-2">
-                        <Badge variant="info">Experimental</Badge>
+                        <ProductStatusBadge status="beta" />
                     </div>
                 </div>
                 <Button variant="icon" aria-label="Close" onClick={onClose}>


### PR DESCRIPTION
Closes
https://linear.app/sourcegraph/issue/CODY-2847/change-experimental-labels-to-beta

## Test plan
- Check that the cody web page and cody web side panel have beta badges

(cherry-picked from commit fbb0a1fec167050a6312ae9ab76f00c1facf952d)

## Test plan
- Check that the side-panel Cody and Cody Chat page have beta product status badges 
