### PR TITLE
change model identifier for finetuned deepseek model

### DIFF
--- a/cmd/cody-gateway/internal/httpapi/completions/fireworks.go
+++ b/cmd/cody-gateway/internal/httpapi/completions/fireworks.go
@@ -262,12 +262,14 @@ func pickFineTunedModel(model string, language string) string {
 	case fireworks.FineTunedFIMLangDeepSeekLogsTrained:
 		{
 			switch language {
-			case "typescript", "typescriptreact":
+			case "typescript":
 				return fireworks.FineTunedDeepseekLogsTrainedTypescript
-			case "javascript", "javascriptreact":
+			case "javascript":
 				return fireworks.FineTunedDeepseekLogsTrainedJavascript
 			case "python":
 				return fireworks.FineTunedDeepseekLogsTrainedPython
+			case "typescriptreact", "javascriptreact":
+				return fireworks.FineTunedDeepseekLogsTrainedReact
 			default:
 				return fireworks.DeepseekCoder7b
 			}

--- a/internal/completions/client/fireworks/fireworks.go
+++ b/internal/completions/client/fireworks/fireworks.go
@@ -61,17 +61,18 @@ const FineTunedLlamaAll = "accounts/sourcegraph/models/finetuned-fim-lang-all-mo
 
 var FineTunedLlamaModelVariants = []string{FineTunedLlamaTypescript, FineTunedLlamaJavascript, FineTunedLlamaPhp, FineTunedLlamaPython, FineTunedLlamaAll}
 
-const FineTunedDeepseekStackTrainedTypescript = "accounts/sourcegraph/models/finetuned-fim-lang-ts-model-deepseek-7b-stack-trained-v1"
-const FineTunedDeepseekStackTrainedPython = "accounts/sourcegraph/models/finetuned-fim-lang-py-model-deepseek-7b-stack-trained-v1"
+const FineTunedDeepseekStackTrainedTypescript = "accounts/sourcegraph/models/finetuned-fim-lang-ts-like-model-deepseek-7b-stack-v2"
+const FineTunedDeepseekStackTrainedPython = "accounts/sourcegraph/models/finetuned-fim-lang-py-model-deepseek-7b-stack-v2"
 const FineTunedFIMLangDeepSeekStackTrained = "fim-lang-specific-model-deepseek-stack-trained"
 
-const FineTunedDeepseekLogsTrainedTypescript = "accounts/sourcegraph/models/finetuned-fim-lang-ts-model-deepseek-7b-logs-trained-v1"
-const FineTunedDeepseekLogsTrainedJavascript = "accounts/sourcegraph/models/finetuned-fim-lang-js-model-deepseek-7b-logs-trained-v1"
-const FineTunedDeepseekLogsTrainedPython = "accounts/sourcegraph/models/finetuned-fim-lang-py-model-deepseek-7b-logs-trained-v1"
+const FineTunedDeepseekLogsTrainedTypescript = "accounts/sourcegraph/models/finetuned-fim-lang-ts-model-deepseek-7b-logs-v2"
+const FineTunedDeepseekLogsTrainedJavascript = "accounts/sourcegraph/models/finetuned-fim-lang-js-model-deepseek-7b-logs-v2"
+const FineTunedDeepseekLogsTrainedPython = "accounts/sourcegraph/models/finetuned-fim-lang-py-model-deepseek-7b-logs-v2"
+const FineTunedDeepseekLogsTrainedReact = "accounts/sourcegraph/models/finetuned-fim-lang-tsx-jsx-model-deepseek-7b-logs-v2"
 const FineTunedFIMLangDeepSeekLogsTrained = "fim-lang-specific-model-deepseek-logs-trained"
 
 var FineTunedDeepseekStackTrainedModelVariants = []string{FineTunedDeepseekStackTrainedTypescript, FineTunedDeepseekStackTrainedPython, FineTunedFIMLangDeepSeekStackTrained}
-var FineTunedDeepseekLogsTrainedModelVariants = []string{FineTunedDeepseekLogsTrainedTypescript, FineTunedDeepseekLogsTrainedJavascript, FineTunedDeepseekLogsTrainedPython, FineTunedFIMLangDeepSeekLogsTrained}
+var FineTunedDeepseekLogsTrainedModelVariants = []string{FineTunedDeepseekLogsTrainedTypescript, FineTunedDeepseekLogsTrainedJavascript, FineTunedDeepseekLogsTrainedPython, FineTunedDeepseekLogsTrainedReact, FineTunedFIMLangDeepSeekLogsTrained}
 
 func NewClient(cli httpcli.Doer, endpoint, accessToken string) types.CompletionsClient {
 	return &fireworksClient{


### PR DESCRIPTION
## Context
1. Change model identifier for deepseek-coder-v2 model for fine-tuned models.

## Test plan
```
curl -vS -X POST http://localhost:9992/v1/completions/fireworks -H 'Authorization: bearer <SGD_TOKEN>' -d '{"stream":false,"max_tokens":50, "model": "fim-lang-specific-model-deepseek-stack-trained", "stop_sequences": ["\n\n"], "prompt": "const value = ", "stream":false, "languageId": "python"}' -H 'X-sourcegraph-feature: code_completions'
```

```
curl -vS -X POST http://localhost:9992/v1/completions/fireworks -H 'Authorization: bearer <SGD_TOKEN>' -d '{"stream":false,"max_tokens":50, "model": "fim-lang-specific-model-deepseek-logs-trained", "stop_sequences": ["\n\n"], "prompt": "const value = ", "stream":false, "languageId": "python"}' -H 'X-sourcegraph-feature: code_completions'
```

