### PR TITLE
chore(search_jobs): remove label "admin" from contact card

### DIFF
--- a/client/web/src/enterprise/search-jobs/UsersPicker.tsx
+++ b/client/web/src/enterprise/search-jobs/UsersPicker.tsx
@@ -125,8 +125,6 @@ export const UsersPicker: FC<UsersPickerProps> = props => {
                                     <span className={styles.itemUsername}>
                                         <MultiComboboxOptionText />
                                     </span>
-                                    {user.siteAdmin && <span className={styles.itemRole}>Admin</span>}
-
                                     <span className={styles.itemEmail}>
                                         {user.primaryEmail?.email ?? 'No email set'}
                                     </span>


### PR DESCRIPTION
This removes the label "admin" next to the user's name and email address. The label has no relevance for Search Jobs.

Test plan:
manual testing

**before**
<img width="1177" alt="Screenshot 2024-07-15 at 12 06 05" src="https://github.com/user-attachments/assets/df1581b1-837a-4aaa-bc36-b5fa45e59d1a">

**after**
<img width="1185" alt="Screenshot 2024-07-15 at 12 00 11" src="https://github.com/user-attachments/assets/fb3222dd-5dd6-429d-a6fe-519812755cd4">
