### PR TITLE
chore(svelte): Refactor infinity query implementation

### DIFF
--- a/client/web-sveltekit/prettier.config.cjs
+++ b/client/web-sveltekit/prettier.config.cjs
@@ -2,5 +2,8 @@ const baseConfig = require('../../prettier.config.js')
 module.exports = {
     ...baseConfig,
     plugins: [...(baseConfig.plugins || []), 'prettier-plugin-svelte'],
-    overrides: [...(baseConfig.overrides || []), { files: '*.svelte', options: { parser: 'svelte', htmlWhitespaceSensitivity: 'strict' } }],
+    overrides: [
+        ...(baseConfig.overrides || []),
+        { files: '*.svelte', options: { parser: 'svelte', htmlWhitespaceSensitivity: 'strict' } },
+    ],
 }

--- a/client/web-sveltekit/src/lib/graphql/urql.test.ts
+++ b/client/web-sveltekit/src/lib/graphql/urql.test.ts
@@ -1,215 +1,191 @@
 import { type AnyVariables, Client, type OperationResult, CombinedError, cacheExchange } from '@urql/core'
-import { test, expect, vi, beforeEach } from 'vitest'
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest'
 import { pipe, filter, map, merge } from 'wonka'
 
-import { infinityQuery } from './urql'
+import { IncrementalRestoreStrategy, infinityQuery } from './urql'
 
-function getMockClient(responses: Partial<OperationResult<any, AnyVariables>>[]): Client {
-    return new Client({
-        url: '#testingonly',
-        exchanges: [
-            cacheExchange, // This is required because infiniteQuery expects that a cache exchange is present
-            ({ forward }) =>
-                operations$ => {
-                    const mockResults$ = pipe(
-                        operations$,
-                        filter(operation => {
-                            switch (operation.kind) {
-                                case 'query':
-                                case 'mutation':
-                                    return true
-                                default:
-                                    return false
-                            }
-                        }),
-                        map((operation): OperationResult<any, AnyVariables> => {
-                            const response = responses.shift()
-                            if (!response) {
+describe('infinityQuery', () => {
+    function getMockClient(responses: Partial<OperationResult<any, AnyVariables>>[]): Client {
+        return new Client({
+            url: '#testingonly',
+            exchanges: [
+                cacheExchange, // This is required because infiniteQuery expects that a cache exchange is present
+                ({ forward }) =>
+                    operations$ => {
+                        const mockResults$ = pipe(
+                            operations$,
+                            filter(operation => {
+                                switch (operation.kind) {
+                                    case 'query':
+                                    case 'mutation':
+                                        return true
+                                    default:
+                                        return false
+                                }
+                            }),
+                            map((operation): OperationResult<any, AnyVariables> => {
+                                const response = responses.shift()
+                                if (!response) {
+                                    return {
+                                        operation,
+                                        error: new CombinedError({
+                                            networkError: new Error('No more responses'),
+                                        }),
+                                        stale: false,
+                                        hasNext: false,
+                                    }
+                                }
                                 return {
+                                    ...response,
                                     operation,
-                                    error: new CombinedError({
-                                        networkError: new Error('No more responses'),
-                                    }),
+                                    data: response.data ?? undefined,
+                                    error: response.error ?? undefined,
                                     stale: false,
                                     hasNext: false,
                                 }
-                            }
-                            return {
-                                ...response,
-                                operation,
-                                data: response.data ?? undefined,
-                                error: response.error ?? undefined,
-                                stale: false,
-                                hasNext: false,
-                            }
-                        })
-                    )
+                            })
+                        )
 
-                    const forward$ = pipe(
-                        operations$,
-                        filter(operation => {
-                            switch (operation.kind) {
-                                case 'query':
-                                case 'mutation':
-                                    return false
-                                default:
-                                    return true
-                            }
-                        }),
-                        forward
-                    )
+                        const forward$ = pipe(
+                            operations$,
+                            filter(operation => {
+                                switch (operation.kind) {
+                                    case 'query':
+                                    case 'mutation':
+                                        return false
+                                    default:
+                                        return true
+                                }
+                            }),
+                            forward
+                        )
 
-                    return merge([mockResults$, forward$])
-                },
-        ],
-    })
-}
+                        return merge([mockResults$, forward$])
+                    },
+            ],
+        })
+    }
 
-function getQuery(client: Client) {
-    return infinityQuery({
-        client,
-        query: 'query { list { nodes { id } } pageInfo { hasNextPage, endCursor } } }',
-        variables: {
-            first: 2,
-            afterCursor: null as string | null,
-        },
-        nextVariables: previousResult => {
-            if (previousResult?.data?.list?.pageInfo?.hasNextPage) {
+    function getQuery(client: Client) {
+        return infinityQuery({
+            client,
+            query: 'query { list { nodes { id } } pageInfo { hasNextPage, endCursor } } }',
+            variables: {
+                first: 2,
+                afterCursor: null as string | null,
+            },
+            mapResult: (result, previousResult) => {
+                const list = result.data?.list
                 return {
-                    afterCursor: previousResult.data.list.pageInfo.endCursor,
+                    nextVariables: list?.pageInfo.hasNextPage ? { afterCursor: list.pageInfo.endCursor } : undefined,
+                    data: (previousResult.data ?? []).concat(list?.nodes ?? []),
+                    error: result.error,
                 }
-            }
-            return undefined
-        },
-        combine: (previousResult, nextResult) => {
-            if (!nextResult.data?.list) {
-                return nextResult
-            }
-            const previousNodes = previousResult.data?.list?.nodes ?? []
-            const nextNodes = nextResult.data.list?.nodes ?? []
-            return {
-                ...nextResult,
+            },
+            createRestoreStrategy: api =>
+                new IncrementalRestoreStrategy(
+                    api,
+                    n => n.length,
+                    n => ({ first: n.length })
+                ),
+        })
+    }
+
+    let query: ReturnType<typeof getQuery>
+
+    beforeEach(() => {
+        vi.useFakeTimers()
+
+        const client = getMockClient([
+            {
                 data: {
                     list: {
-                        ...nextResult.data.list,
-                        nodes: [...previousNodes, ...nextNodes],
-                    },
-                },
-            }
-        },
-    })
-}
-
-let query: ReturnType<typeof infinityQuery>
-
-beforeEach(() => {
-    vi.useFakeTimers()
-
-    const client = getMockClient([
-        {
-            data: {
-                list: {
-                    nodes: [{ id: 1 }, { id: 2 }],
-                    pageInfo: {
-                        hasNextPage: true,
-                        endCursor: '2',
+                        nodes: [{ id: 1 }, { id: 2 }],
+                        pageInfo: {
+                            hasNextPage: true,
+                            endCursor: '2',
+                        },
                     },
                 },
             },
-        },
-        {
-            data: {
-                list: {
-                    nodes: [{ id: 3 }, { id: 4 }],
-                    pageInfo: {
-                        hasNextPage: true,
-                        endCursor: '4',
+            {
+                data: {
+                    list: {
+                        nodes: [{ id: 3 }, { id: 4 }],
+                        pageInfo: {
+                            hasNextPage: true,
+                            endCursor: '4',
+                        },
                     },
                 },
             },
-        },
-        {
-            data: {
-                list: {
-                    nodes: [{ id: 5 }, { id: 6 }],
-                    pageInfo: {
-                        hasNextPage: false,
+            {
+                data: {
+                    list: {
+                        nodes: [{ id: 5 }, { id: 6 }],
+                        pageInfo: {
+                            hasNextPage: false,
+                        },
                     },
                 },
             },
-        },
-    ])
-    query = getQuery(client)
-})
-
-test('fetch more', async () => {
-    const subscribe = vi.fn()
-    query.subscribe(subscribe)
-
-    await vi.runAllTimersAsync()
-
-    // 1. call: fetching -> true
-    // 2. call: result
-    expect(subscribe).toHaveBeenCalledTimes(2)
-    expect(subscribe.mock.calls[0][0]).toMatchObject({
-        fetching: true,
+        ])
+        query = getQuery(client)
     })
-    expect(subscribe.mock.calls[1][0]).toMatchObject({
-        fetching: false,
-        data: {
-            list: {
-                nodes: [{ id: 1 }, { id: 2 }],
-                pageInfo: {
-                    hasNextPage: true,
-                    endCursor: '2',
-                },
+
+    afterEach(() => {
+        vi.useRealTimers()
+    })
+
+    test('fetch more', async () => {
+        const subscribe = vi.fn()
+        query.subscribe(subscribe)
+
+        await vi.runAllTimersAsync()
+
+        // 1. call: fetching -> true
+        // 2. call: result
+        expect(subscribe).toHaveBeenCalledTimes(2)
+        expect(subscribe.mock.calls[0][0]).toMatchObject({
+            fetching: true,
+        })
+        expect(subscribe.mock.calls[1][0]).toMatchObject({
+            fetching: false,
+            data: [{ id: 1 }, { id: 2 }],
+            nextVariables: {
+                afterCursor: '2',
             },
-        },
-    })
+        })
 
-    // Fetch more data
-    query.fetchMore()
-    await vi.runAllTimersAsync()
+        // Fetch more data
+        query.fetchMore()
+        await vi.runAllTimersAsync()
 
-    // 3. call: fetching -> true
-    // 4. call: result
-    expect(subscribe).toHaveBeenCalledTimes(4)
-    expect(subscribe.mock.calls[2][0]).toMatchObject({
-        fetching: true,
-    })
-    expect(subscribe.mock.calls[3][0]).toMatchObject({
-        fetching: false,
-        data: {
-            list: {
-                nodes: [{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }],
-                pageInfo: {
-                    hasNextPage: true,
-                    endCursor: '4',
-                },
+        // 3. call: fetching -> true
+        // 4. call: result
+        expect(subscribe).toHaveBeenCalledTimes(4)
+        expect(subscribe.mock.calls[2][0]).toMatchObject({
+            fetching: true,
+        })
+        expect(subscribe.mock.calls[3][0]).toMatchObject({
+            fetching: false,
+            data: [{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }],
+            nextVariables: {
+                afterCursor: '4',
             },
-        },
+        })
     })
-})
 
-test('restoring state', async () => {
-    const subscribe = vi.fn()
-    query.subscribe(subscribe)
-    await vi.runAllTimersAsync()
-    await query.restore(result => (result.data as any).list.nodes.length < 5)
+    test('restoring state', async () => {
+        const subscribe = vi.fn()
+        query.subscribe(subscribe)
+        const snapshot = query.capture()
+        query.restore({ ...snapshot!, count: 6 })
+        await vi.runAllTimersAsync()
 
-    expect(subscribe).toHaveBeenCalledTimes(6)
-    expect(subscribe.mock.calls[4][0]).toMatchObject({
-        restoring: true,
-    })
-    expect(subscribe.mock.calls[5][0]).toMatchObject({
-        restoring: false,
-        data: {
-            list: {
-                nodes: [{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }, { id: 5 }, { id: 6 }],
-                pageInfo: {
-                    hasNextPage: false,
-                },
-            },
-        },
+        expect(subscribe.mock.calls[3][0]).toMatchObject({
+            fetching: false,
+            data: [{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }, { id: 5 }, { id: 6 }],
+        })
     })
 })

--- a/client/web-sveltekit/src/lib/graphql/urql.test.ts
+++ b/client/web-sveltekit/src/lib/graphql/urql.test.ts
@@ -74,14 +74,15 @@ describe('infinityQuery', () => {
                 first: 2,
                 afterCursor: null as string | null,
             },
-            mapResult: (result, previousResult) => {
+            map: result => {
                 const list = result.data?.list
                 return {
                     nextVariables: list?.pageInfo.hasNextPage ? { afterCursor: list.pageInfo.endCursor } : undefined,
-                    data: (previousResult.data ?? []).concat(list?.nodes ?? []),
+                    data: list?.nodes,
                     error: result.error,
                 }
             },
+            merge: (prev, next) => [...(prev ?? []), ...(next ?? [])],
             createRestoreStrategy: api =>
                 new IncrementalRestoreStrategy(
                     api,

--- a/client/web-sveltekit/src/lib/graphql/urql.ts
+++ b/client/web-sveltekit/src/lib/graphql/urql.ts
@@ -87,15 +87,13 @@ interface InfinityQueryArgs<TData, TPayload = any, TVariables extends AnyVariabl
      * @param previousResult - The previous result of the query.
      * @returns The new/combined result state.
      */
-    map: (
-        result: OperationResult<TPayload, TVariables>,
-    ) => InfinityStoreResult<TData, TVariables>
+    map: (result: OperationResult<TPayload, TVariables>) => InfinityStoreResult<TData, TVariables>
 
     /**
      * Optional callback to merge the data from the previous result with the new data.
      * If not provided the new data will replace the old data.
      */
-    merge?: (previousData: TData|undefined, newData: TData|undefined) => TData
+    merge?: (previousData: TData | undefined, newData: TData | undefined) => TData
 
     /**
      * Returns a strategy for restoring the data when navigating back to a page.
@@ -211,9 +209,11 @@ export function infinityQuery<
         variables: Partial<TVariables>,
         previousResult: InfinityStoreResult<TData, TVariables>
     ): Promise<InfinityStoreResult<TData, TVariables>> {
-        const result = args.map(await initialVariables.then(initialVariables =>
-            args.client.query(args.query, { ...initialVariables, ...variables })
-        ))
+        const result = args.map(
+            await initialVariables.then(initialVariables =>
+                args.client.query(args.query, { ...initialVariables, ...variables })
+            )
+        )
         if (args.merge) {
             result.data = args.merge(previousResult.data, result.data)
         }

--- a/client/web-sveltekit/src/lib/graphql/urql.ts
+++ b/client/web-sveltekit/src/lib/graphql/urql.ts
@@ -298,7 +298,8 @@ interface RestoreStrategy<TSnapshot, TData> {
     restore(snapshot: TSnapshot): Promise<void>
 }
 
-interface IncrementalRestoreStrategySnapshot<TVariables extends AnyVariables> {
+// This needs to be exported so that TS type inference can work in SvelteKit generated files.
+export interface IncrementalRestoreStrategySnapshot<TVariables extends AnyVariables> {
     count: number
     variables?: Partial<TVariables>
     nonce: string

--- a/client/web-sveltekit/src/lib/graphql/urql.ts
+++ b/client/web-sveltekit/src/lib/graphql/urql.ts
@@ -63,7 +63,7 @@ export function query<TData = any, TVariables extends AnyVariables = AnyVariable
     return getGraphQLClient().query<TData, TVariables>(query, variables).toPromise()
 }
 
-interface InfinityQueryArgs<TData, TPayload = any, TVariables extends AnyVariables = AnyVariables, TSnapshot = void> {
+interface InfinityQueryArgs<TData, TPayload = any, TVariables extends AnyVariables = AnyVariables, TSnapshot = any> {
     /**
      * The {@link Client} instance to use for the query.
      */
@@ -149,7 +149,7 @@ interface InfinityStoreResultState<TData = any, TVariables extends AnyVariables 
 }
 
 // This needs to be exported so that TS type inference can work in SvelteKit generated files.
-export interface InfinityQueryStore<TData = any, TVariables extends AnyVariables = AnyVariables, TSnapshot = void>
+export interface InfinityQueryStore<TData = any, TVariables extends AnyVariables = AnyVariables, TSnapshot = any>
     extends Readable<InfinityStoreResultState<TData, TVariables>> {
     /**
      * Reruns the query with the next set of query variables.

--- a/client/web-sveltekit/src/lib/repo/HistoryPanel.stories.svelte
+++ b/client/web-sveltekit/src/lib/repo/HistoryPanel.stories.svelte
@@ -2,12 +2,15 @@
     import { createHistoryResults } from '$testing/testdata'
     import { Story } from '@storybook/addon-svelte-csf'
     import HistoryPanel from './HistoryPanel.svelte'
+    import { readable } from 'svelte/store'
     export const meta = {
         component: HistoryPanel,
         parameters: {
             sveltekit_experimental: {
                 stores: {
-                    page: {},
+                    page: {
+                        url: new URL(window.location.href),
+                    },
                 },
             },
         },
@@ -17,12 +20,19 @@
 <script lang="ts">
     let commitCount = 5
     $: [initial] = createHistoryResults(1, commitCount)
+    $: store = {
+        ...readable({ data: initial.nodes, fetching: false }),
+        fetchMore: () => {},
+        fetchWhile: () => Promise.resolve(),
+        capture: () => undefined,
+        restore: () => Promise.resolve(),
+    }
 </script>
 
 <Story name="Default">
     <p>Commits to show: <input type="number" bind:value={commitCount} min="1" max="100" /></p>
     <hr />
     {#key commitCount}
-        <HistoryPanel history={initial} enableInlineDiffs={false} fetchMore={() => {}} />
+        <HistoryPanel history={store} enableInlineDiff={false} />
     {/key}
 </Story>

--- a/client/web-sveltekit/src/lib/search/input/SearchInput.svelte
+++ b/client/web-sveltekit/src/lib/search/input/SearchInput.svelte
@@ -200,7 +200,8 @@
     // When a toggle is unset, we revert back to the default pattern type. However, if the default pattern type
     // is regexp, we should revert to keyword instead (otherwise it's not possible to disable the toggle).
     function getUnselectedPatternType(): SearchPatternType {
-        const defaultPatternType = ($settings?.['search.defaultPatternType'] as SearchPatternType) ?? SearchPatternType.keyword
+        const defaultPatternType =
+            ($settings?.['search.defaultPatternType'] as SearchPatternType) ?? SearchPatternType.keyword
         return defaultPatternType === SearchPatternType.regexp ? SearchPatternType.keyword : defaultPatternType
     }
 

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/+layout.ts
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/+layout.ts
@@ -1,11 +1,10 @@
 import { dirname } from 'path'
 
-import { from } from 'rxjs'
 import { readable, derived, type Readable } from 'svelte/store'
 
 import { CodyContextFiltersSchema, getFiltersFromCodyContextFilters } from '$lib/cody/config'
 import type { LineOrPositionOrRange } from '$lib/common'
-import { getGraphQLClient, infinityQuery, type GraphQLClient } from '$lib/graphql'
+import { getGraphQLClient, infinityQuery, type GraphQLClient, IncrementalRestoreStrategy } from '$lib/graphql'
 import { ROOT_PATH, fetchSidebarFileTree } from '$lib/repo/api/tree'
 import { resolveRevision } from '$lib/repo/utils'
 import { parseRepoRevision } from '$lib/shared'
@@ -54,45 +53,29 @@ export const load: LayoutLoad = async ({ parent, params }) => {
         commitHistory: infinityQuery({
             client,
             query: GitHistoryQuery,
-            variables: from(
-                resolvedRevision.then(revspec => ({
-                    repoName,
-                    revspec,
-                    filePath,
-                    first: HISTORY_COMMITS_PER_PAGE,
-                    afterCursor: null as string | null,
-                }))
-            ),
-            nextVariables: previousResult => {
-                if (previousResult?.data?.repository?.commit?.ancestors?.pageInfo?.hasNextPage) {
-                    return {
-                        afterCursor: previousResult.data.repository.commit.ancestors.pageInfo.endCursor,
-                    }
-                }
-                return undefined
-            },
-            combine: (previousResult, nextResult) => {
-                if (!nextResult.data?.repository?.commit) {
-                    return nextResult
-                }
-                const previousNodes = previousResult.data?.repository?.commit?.ancestors?.nodes ?? []
-                const nextNodes = nextResult.data.repository?.commit?.ancestors.nodes ?? []
+            variables: resolvedRevision.then(revspec => ({
+                repoName,
+                revspec,
+                filePath,
+                first: HISTORY_COMMITS_PER_PAGE,
+                afterCursor: null as string | null,
+            })),
+            mapResult: (result, previousResult) => {
+                const anestors = result.data?.repository?.commit?.ancestors
                 return {
-                    ...nextResult,
-                    data: {
-                        repository: {
-                            ...nextResult.data.repository,
-                            commit: {
-                                ...nextResult.data.repository.commit,
-                                ancestors: {
-                                    ...nextResult.data.repository.commit.ancestors,
-                                    nodes: [...previousNodes, ...nextNodes],
-                                },
-                            },
-                        },
-                    },
+                    nextVariables: anestors?.pageInfo.hasNextPage
+                        ? { afterCursor: anestors.pageInfo.endCursor }
+                        : undefined,
+                    data: (previousResult.data ?? []).concat(anestors?.nodes ?? []),
+                    error: result.error,
                 }
             },
+            createRestoreStrategy: api =>
+                new IncrementalRestoreStrategy(
+                    api,
+                    n => n.length,
+                    n => ({ first: n.length })
+                ),
         }),
 
         // We are not extracting the selected position from the URL because that creates a dependency
@@ -101,54 +84,24 @@ export const load: LayoutLoad = async ({ parent, params }) => {
             infinityQuery({
                 client,
                 query: RepoPage_PreciseCodeIntel,
-                variables: from(
-                    resolvedRevision.then(revspec => ({
-                        repoName,
-                        revspec,
-                        filePath,
-                        first: REFERENCES_PER_PAGE,
-                        // Line and character are 1-indexed, but the API expects 0-indexed
-                        line: lineOrPosition.line - 1,
-                        character: lineOrPosition.character! - 1,
-                        afterCursor: null as string | null,
-                    }))
-                ),
-                nextVariables: previousResult => {
-                    if (previousResult?.data?.repository?.commit?.blob?.lsif?.references.pageInfo.hasNextPage) {
-                        return {
-                            afterCursor: previousResult.data.repository.commit.blob.lsif.references.pageInfo.endCursor,
-                        }
-                    }
-                    return undefined
-                },
-                combine: (previousResult, nextResult) => {
-                    if (!nextResult.data?.repository?.commit?.blob?.lsif) {
-                        return nextResult
-                    }
-
-                    const previousNodes = previousResult.data?.repository?.commit?.blob?.lsif?.references?.nodes ?? []
-                    const nextNodes = nextResult.data?.repository?.commit?.blob?.lsif?.references?.nodes ?? []
-
+                variables: resolvedRevision.then(revspec => ({
+                    repoName,
+                    revspec,
+                    filePath,
+                    first: REFERENCES_PER_PAGE,
+                    // Line and character are 1-indexed, but the API expects 0-indexed
+                    line: lineOrPosition.line - 1,
+                    character: lineOrPosition.character! - 1,
+                    afterCursor: null as string | null,
+                })),
+                mapResult: (result, previousResult) => {
+                    const references = result.data?.repository?.commit?.blob?.lsif?.references
                     return {
-                        ...nextResult,
-                        data: {
-                            repository: {
-                                ...nextResult.data.repository,
-                                commit: {
-                                    ...nextResult.data.repository.commit,
-                                    blob: {
-                                        ...nextResult.data.repository.commit.blob,
-                                        lsif: {
-                                            ...nextResult.data.repository.commit.blob.lsif,
-                                            references: {
-                                                ...nextResult.data.repository.commit.blob.lsif.references,
-                                                nodes: [...previousNodes, ...nextNodes],
-                                            },
-                                        },
-                                    },
-                                },
-                            },
-                        },
+                        nextVariables: references?.pageInfo.hasNextPage
+                            ? { afterCursor: references.pageInfo.endCursor }
+                            : undefined,
+                        data: (previousResult.data ?? []).concat(references?.nodes ?? []),
+                        error: result.error,
                     }
                 },
             }),

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/+layout.ts
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/+layout.ts
@@ -60,16 +60,17 @@ export const load: LayoutLoad = async ({ parent, params }) => {
                 first: HISTORY_COMMITS_PER_PAGE,
                 afterCursor: null as string | null,
             })),
-            mapResult: (result, previousResult) => {
+            map: result => {
                 const anestors = result.data?.repository?.commit?.ancestors
                 return {
                     nextVariables: anestors?.pageInfo.hasNextPage
                         ? { afterCursor: anestors.pageInfo.endCursor }
                         : undefined,
-                    data: (previousResult.data ?? []).concat(anestors?.nodes ?? []),
+                    data: anestors?.nodes,
                     error: result.error,
                 }
             },
+            merge: (previous, next) => (previous ?? []).concat(next ?? []),
             createRestoreStrategy: api =>
                 new IncrementalRestoreStrategy(
                     api,
@@ -94,16 +95,17 @@ export const load: LayoutLoad = async ({ parent, params }) => {
                     character: lineOrPosition.character! - 1,
                     afterCursor: null as string | null,
                 })),
-                mapResult: (result, previousResult) => {
+                map: result => {
                     const references = result.data?.repository?.commit?.blob?.lsif?.references
                     return {
                         nextVariables: references?.pageInfo.hasNextPage
                             ? { afterCursor: references.pageInfo.endCursor }
                             : undefined,
-                        data: (previousResult.data ?? []).concat(references?.nodes ?? []),
+                        data: references?.nodes,
                         error: result.error,
                     }
                 },
+                merge: (previous, next) => (previous ?? []).concat(next ?? []),
             }),
     }
 }

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/-/commits/[...path]/+page.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/-/commits/[...path]/+page.svelte
@@ -13,26 +13,25 @@
     import RepositoryRevPicker from '../../../RepositoryRevPicker.svelte'
 
     import type { PageData, Snapshot } from './$types'
-    import type { CommitsPage_GitCommitConnection } from './page.gql'
 
     export let data: PageData
 
     // This tracks the number of commits that have been loaded and the current scroll
     // position, so both can be restored when the user refreshes the page or navigates
     // back to it.
-    export const snapshot: Snapshot<{ commitCount: number; scroller: ScrollerCapture }> = {
+    export const snapshot: Snapshot<{
+        commits: ReturnType<typeof data.commitsQuery.capture>
+        scroller: ScrollerCapture
+    }> = {
         capture() {
             return {
-                commitCount: commits?.nodes.length ?? 0,
+                commits: commitsQuery.capture(),
                 scroller: scroller.capture(),
             }
         },
         async restore(snapshot) {
-            if (snapshot?.commitCount !== undefined && get(navigating)?.type === 'popstate') {
-                await commitsQuery?.restore(result => {
-                    const count = result.data?.repository?.commit?.ancestors.nodes?.length
-                    return !!count && count < snapshot.commitCount
-                })
+            if (get(navigating)?.type === 'popstate') {
+                await commitsQuery?.restore(snapshot.commits)
             }
             scroller.restore(snapshot.scroller)
         },
@@ -43,14 +42,9 @@
     }
 
     let scroller: Scroller
-    let commits: CommitsPage_GitCommitConnection | null = null
 
     $: commitsQuery = data.commitsQuery
-    // We conditionally check for the ancestors field to be able to show
-    // previously loaded commits when an error occurs while fetching more commits.
-    $: if ($commitsQuery?.data?.repository?.commit?.ancestors) {
-        commits = $commitsQuery.data.repository.commit.ancestors
-    }
+    $: commits = $commitsQuery.data
     $: pageTitle = (() => {
         const parts = ['Commits']
         if (data.path) {
@@ -86,9 +80,9 @@
 </header>
 <section>
     <Scroller bind:this={scroller} margin={600} on:more={fetchMore}>
-        {#if !$commitsQuery.restoring && commits}
+        {#if commits}
             <ul class="commits">
-                {#each commits.nodes as commit (commit.canonicalURL)}
+                {#each commits as commit (commit.canonicalURL)}
                     <li>
                         <div class="commit">
                             <Commit {commit} />
@@ -122,7 +116,7 @@
                 {/each}
             </ul>
         {/if}
-        {#if $commitsQuery.fetching || $commitsQuery.restoring}
+        {#if $commitsQuery.fetching}
             <div class="footer">
                 <LoadingSpinner />
             </div>

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/-/commits/[...path]/+page.ts
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/-/commits/[...path]/+page.ts
@@ -1,6 +1,4 @@
-import { from } from 'rxjs'
-
-import { getGraphQLClient, infinityQuery } from '$lib/graphql'
+import { IncrementalRestoreStrategy, getGraphQLClient, infinityQuery } from '$lib/graphql'
 import { resolveRevision } from '$lib/repo/utils'
 import { parseRepoRevision } from '$lib/shared'
 
@@ -18,45 +16,30 @@ export const load: PageLoad = ({ parent, params }) => {
     const commitsQuery = infinityQuery({
         client,
         query: CommitsPage_CommitsQuery,
-        variables: from(
-            resolvedRevision.then(revision => ({
-                repoName,
-                revision,
-                first: PAGE_SIZE,
-                path,
-                afterCursor: null as string | null,
-            }))
-        ),
-        nextVariables: previousResult => {
-            if (previousResult?.data?.repository?.commit?.ancestors?.pageInfo?.hasNextPage) {
-                return {
-                    afterCursor: previousResult.data.repository.commit.ancestors.pageInfo.endCursor,
-                }
-            }
-            return undefined
-        },
-        combine: (previousResult, nextResult) => {
-            if (!nextResult.data?.repository?.commit) {
-                return nextResult
-            }
-            const previousNodes = previousResult.data?.repository?.commit?.ancestors?.nodes ?? []
-            const nextNodes = nextResult.data.repository?.commit?.ancestors.nodes ?? []
+        variables: resolvedRevision.then(revision => ({
+            repoName,
+            revision,
+            first: PAGE_SIZE,
+            path,
+            afterCursor: null as string | null,
+        })),
+        mapResult(result, previousResult) {
+            const ancestors = result.data?.repository?.commit?.ancestors
             return {
-                ...nextResult,
-                data: {
-                    repository: {
-                        ...nextResult.data.repository,
-                        commit: {
-                            ...nextResult.data.repository.commit,
-                            ancestors: {
-                                ...nextResult.data.repository.commit.ancestors,
-                                nodes: [...previousNodes, ...nextNodes],
-                            },
-                        },
-                    },
-                },
+                nextVariables:
+                    ancestors?.pageInfo?.endCursor && ancestors.pageInfo.hasNextPage
+                        ? { afterCursor: ancestors.pageInfo.endCursor }
+                        : undefined,
+                data: (previousResult.data ?? []).concat(ancestors?.nodes ?? []),
+                error: result.error,
             }
         },
+        createRestoreStrategy: api =>
+            new IncrementalRestoreStrategy(
+                api,
+                n => n.length,
+                n => ({ first: n.length })
+            ),
     })
 
     return {

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/-/commits/[...path]/+page.ts
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/-/commits/[...path]/+page.ts
@@ -23,17 +23,18 @@ export const load: PageLoad = ({ parent, params }) => {
             path,
             afterCursor: null as string | null,
         })),
-        mapResult(result, previousResult) {
+        map: result => {
             const ancestors = result.data?.repository?.commit?.ancestors
             return {
                 nextVariables:
                     ancestors?.pageInfo?.endCursor && ancestors.pageInfo.hasNextPage
                         ? { afterCursor: ancestors.pageInfo.endCursor }
                         : undefined,
-                data: (previousResult.data ?? []).concat(ancestors?.nodes ?? []),
+                data: ancestors?.nodes,
                 error: result.error,
             }
         },
+        merge: (previous, next) => (previous ?? []).concat(next ?? []),
         createRestoreStrategy: api =>
             new IncrementalRestoreStrategy(
                 api,

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/-/branches/all/+page.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/-/branches/all/+page.svelte
@@ -8,39 +8,34 @@
     import GitReference from '$lib/repo/GitReference.svelte'
     import Scroller, { type Capture as ScrollerCapture } from '$lib/Scroller.svelte'
     import { Alert, Button, Input } from '$lib/wildcard'
-    import type { GitBranchesConnection } from '$testing/graphql-type-mocks'
 
     import type { PageData, Snapshot } from './$types'
 
     export let data: PageData
 
-    export const snapshot: Snapshot<{ count: number; scroller: ScrollerCapture }> = {
+    export const snapshot: Snapshot<{
+        branches: ReturnType<typeof data.branchesQuery.capture>
+        scroller: ScrollerCapture
+    }> = {
         capture() {
             return {
-                count: branchesConnection?.nodes.length ?? 0,
+                branches: data.branchesQuery.capture(),
                 scroller: scroller.capture(),
             }
         },
         async restore(snapshot) {
-            if (snapshot?.count && get(navigating)?.type === 'popstate') {
-                await branchesQuery?.restore(result => {
-                    const count = result.data?.repository?.branches?.nodes?.length
-                    return !!count && count < snapshot.count
-                })
+            if (get(navigating)?.type === 'popstate') {
+                await data.branchesQuery?.restore(snapshot.branches)
             }
             scroller.restore(snapshot.scroller)
         },
     }
 
     let scroller: Scroller
-    let branchesConnection: GitBranchesConnection | undefined
 
     $: query = data.query
     $: branchesQuery = data.branchesQuery
-    $: branchesConnection = $branchesQuery.data?.repository?.branches ?? branchesConnection
-    $: if (branchesQuery) {
-        branchesConnection = undefined
-    }
+    $: branches = $branchesQuery.data
 </script>
 
 <svelte:head>
@@ -53,15 +48,15 @@
         <Button variant="primary" type="submit">Search</Button>
     </form>
     <Scroller bind:this={scroller} margin={600} on:more={branchesQuery.fetchMore}>
-        {#if !$branchesQuery.restoring && branchesConnection}
+        {#if branches}
             <table>
                 <tbody>
-                    {#each branchesConnection.nodes as tag (tag)}
-                        <GitReference ref={tag} />
+                    {#each branches.nodes as branch (branch)}
+                        <GitReference ref={branch} />
                     {:else}
                         <tr>
                             <td colspan="2">
-                                <Alert variant="info">No tags found</Alert>
+                                <Alert variant="info">No branches found</Alert>
                             </td>
                         </tr>
                     {/each}
@@ -69,7 +64,7 @@
             </table>
         {/if}
         <div>
-            {#if $branchesQuery.fetching || $branchesQuery.restoring}
+            {#if $branchesQuery.fetching}
                 <LoadingSpinner />
             {:else if $branchesQuery.error}
                 <Alert variant="danger">
@@ -78,12 +73,12 @@
             {/if}
         </div>
     </Scroller>
-    {#if branchesConnection && branchesConnection.nodes.length > 0}
+    {#if branches && branches.nodes.length > 0}
         <div class="footer">
-            {branchesConnection.totalCount}
-            {pluralize('branch', branchesConnection.totalCount)} total
-            {#if branchesConnection.totalCount > branchesConnection.nodes.length}
-                (showing {branchesConnection.nodes.length})
+            {branches.totalCount}
+            {pluralize('branch', branches.totalCount)} total
+            {#if branches.totalCount > branches.nodes.length}
+                (showing {branches.nodes.length})
             {/if}
         </div>
     {/if}

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/-/branches/all/+page.ts
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/-/branches/all/+page.ts
@@ -22,7 +22,7 @@ export const load: PageLoad = ({ params, url }) => {
                 withBehindAhead: true,
                 query,
             },
-            mapResult: result => {
+            map: result => {
                 const branches = result.data?.repository?.branches
                 return {
                     nextVariables: branches?.pageInfo.hasNextPage

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/-/branches/all/+page.ts
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/-/branches/all/+page.ts
@@ -1,4 +1,4 @@
-import { getGraphQLClient, infinityQuery } from '$lib/graphql'
+import { getGraphQLClient, infinityQuery, OverwriteRestoreStrategy } from '$lib/graphql'
 import { parseRepoRevision } from '$lib/shared'
 
 import type { PageLoad } from './$types'
@@ -22,17 +22,22 @@ export const load: PageLoad = ({ params, url }) => {
                 withBehindAhead: true,
                 query,
             },
-            nextVariables: previousResult => {
-                if (previousResult?.data?.repository?.branches?.pageInfo?.hasNextPage) {
-                    return {
-                        first: previousResult.data.repository.branches.nodes.length + PAGE_SIZE,
-                    }
+            mapResult: result => {
+                const branches = result.data?.repository?.branches
+                return {
+                    nextVariables: branches?.pageInfo.hasNextPage
+                        ? { first: branches.nodes.length + PAGE_SIZE }
+                        : undefined,
+                    data: branches
+                        ? {
+                              nodes: branches.nodes,
+                              totalCount: branches.totalCount,
+                          }
+                        : undefined,
+                    error: result.error,
                 }
-                return undefined
             },
-            combine: (_previousResult, nextResult) => {
-                return nextResult
-            },
+            createRestoreStrategy: api => new OverwriteRestoreStrategy(api, data => ({ first: data.nodes.length })),
         }),
     }
 }

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/-/commit/[...revspec]/+page.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/-/commit/[...revspec]/+page.svelte
@@ -62,7 +62,7 @@
 
 <section>
     {#if data.commit}
-        <Scroller bind:this={scroller} margin={600} on:more={data.diff?.fetchMore}>
+        <Scroller bind:this={scroller} margin={600} on:more={diffQuery?.fetchMore}>
             <div class="header">
                 <div class="info"><Commit commit={data.commit} alwaysExpanded /></div>
                 <div class="parents">

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/-/commit/[...revspec]/+page.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/-/commit/[...revspec]/+page.svelte
@@ -21,7 +21,7 @@
 
     interface Capture {
         scroll: ScrollerCapture
-        diffCount: number
+        diffs?: ReturnType<NonNullable<typeof data.diff>['capture']>
         expandedDiffs: Array<[number, boolean]>
     }
 
@@ -30,16 +30,13 @@
     export const snapshot: Snapshot<Capture> = {
         capture: () => ({
             scroll: scroller.capture(),
-            diffCount: diffs?.nodes.length ?? 0,
+            diffs: diffQuery?.capture(),
             expandedDiffs: Array.from(expandedDiffs.entries()),
         }),
         restore: async capture => {
             expandedDiffs = new Map(capture.expandedDiffs)
-            if (capture?.diffCount !== undefined && get(navigating)?.type === 'popstate') {
-                await data.diff?.restore(result => {
-                    const count = result.data?.repository?.comparison.fileDiffs.nodes.length
-                    return !!count && count < capture.diffCount
-                })
+            if (get(navigating)?.type === 'popstate') {
+                await data.diff?.restore(capture.diffs)
             }
             scroller.restore(capture.scroll)
         },
@@ -50,7 +47,6 @@
     let expandedDiffs = new Map<number, boolean>()
 
     $: diffQuery = data.diff
-    $: diffs = $diffQuery?.data?.repository?.comparison.fileDiffs ?? null
 
     afterNavigate(() => {
         repositoryContext.set({ revision: data.commit.abbreviatedOID })
@@ -104,9 +100,9 @@
                 </div>
             </div>
             <hr />
-            {#if !$diffQuery?.restoring && diffs}
+            {#if $diffQuery?.data}
                 <ul class="diffs">
-                    {#each diffs.nodes as node, index}
+                    {#each $diffQuery.data as node, index}
                         <li>
                             <FileDiff
                                 fileDiff={node}
@@ -117,7 +113,7 @@
                     {/each}
                 </ul>
             {/if}
-            {#if $diffQuery?.fetching || $diffQuery?.restoring}
+            {#if $diffQuery?.fetching}
                 <LoadingSpinner />
             {:else if $diffQuery?.error}
                 <div class="error">

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/-/commit/[...revspec]/+page.ts
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/-/commit/[...revspec]/+page.ts
@@ -41,7 +41,7 @@ export const load: PageLoad = async ({ params }) => {
                   mapResult: (result, previousResult) => {
                       const pageInfo = result.data?.repository?.comparison.fileDiffs.pageInfo
                       return {
-                          pageInfo: pageInfo?.hasNextPage ? { after: pageInfo.endCursor } : undefined,
+                          nextVariables: pageInfo?.hasNextPage ? { after: pageInfo.endCursor } : undefined,
                           data: (previousResult.data ?? []).concat(
                               result.data?.repository?.comparison.fileDiffs.nodes ?? []
                           ),

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/-/commit/[...revspec]/+page.ts
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/-/commit/[...revspec]/+page.ts
@@ -38,16 +38,15 @@ export const load: PageLoad = async ({ params }) => {
                       first: PAGE_SIZE,
                       after: null as string | null,
                   },
-                  mapResult: (result, previousResult) => {
-                      const pageInfo = result.data?.repository?.comparison.fileDiffs.pageInfo
+                  map: result => {
+                      const diffs = result.data?.repository?.comparison.fileDiffs
                       return {
-                          nextVariables: pageInfo?.hasNextPage ? { after: pageInfo.endCursor } : undefined,
-                          data: (previousResult.data ?? []).concat(
-                              result.data?.repository?.comparison.fileDiffs.nodes ?? []
-                          ),
+                          nextVariables: diffs?.pageInfo.hasNextPage ? { after: diffs?.pageInfo.endCursor } : undefined,
+                          data: diffs?.nodes,
                           error: result.error,
                       }
                   },
+                  merge: (previous, next) => (previous ?? []).concat(next ?? []),
                   createRestoreStrategy: api =>
                       new IncrementalRestoreStrategy(
                           api,

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/-/tags/+page.ts
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/-/tags/+page.ts
@@ -22,7 +22,7 @@ export const load: PageLoad = ({ params, url }) => {
                 withBehindAhead: false,
                 query,
             },
-            mapResult: result => {
+            map: result => {
                 const gitRefs = result.data?.repository?.gitRefs
                 return {
                     nextVariables: gitRefs?.pageInfo.hasNextPage


### PR DESCRIPTION
In preparation for other work, this commit substantially refactors the "infinity query" store implementation. The internals have been changed completely which allows us to simplify its public API.

- Simpler configuration. Query responses and next variables are now processed and merged in a single function.
- Restoration support. So far pages/components had to implement restoring the state of an infinity store on their own. Now the restoration strategy is part of the configuration. Pages/components only have to get an opaque snapshot via `store.capture()` and restore it via `store.restore(snapshot)`.
- More predictable state. It wasn't always obvious if the store content stale data e.g. during restoring data. Now `data` will only be set when the data is 'fresh'.
- Smarter 'incremental restoration' strategy. This strategy makes multiple requests to restore the previous state. It makes multiple requests because normally requests are cached and there this is fast. When the data is not cached though there is a noticable delay due to waterfall requests. Now we use a simple heuristic to determine whether or not GraqhQL data might be cached. If not we make a single request to restore the state.

For review I suggest to turn whitespace changes off.

## Test plan

Manual testing, unit tests.