### PR TITLE
fix(appliance): do not delete unowned resources

### DIFF
--- a/internal/appliance/reconciler/frontend.go
+++ b/internal/appliance/reconciler/frontend.go
@@ -230,7 +230,7 @@ func (r *Reconciler) reconcileFrontendIngress(ctx context.Context, sg *config.So
 	cfg := sg.Spec.Frontend
 	ingress := ingress.NewIngress(name, sg.Namespace)
 	if cfg.Ingress == nil {
-		return r.ensureObjectDeleted(ctx, &ingress)
+		return ensureObjectDeleted(ctx, r, owner, &ingress)
 	}
 
 	ingress.SetAnnotations(cfg.Ingress.Annotations)


### PR DESCRIPTION
The appliance checks owner references, and only deletes (or updates) resources whose owner references matches the configmap being reconciled.

The current user interface to external databases, is for the admin to create secrets with a well-known name out of band (e.g. "pgsql-auth") and then disable the relevant backing services (e.g. pgsql). This commit fixes a bug in which the appliance would have deleted such secrets, leaving the admin unable to use external databases.

Discovered while investigating
https://linear.app/sourcegraph/issue/REL-14/ensure-pods-roll-when-referenced-secret-changes, but does not close it.

<!-- PR description tips: https://www.notion.so/sourcegraph/Write-a-good-pull-request-description-610a7fd3e613496eb76f450db5a49b6e -->

## Test plan

Test against a real k8s API server (envtest) included. Tests that exercise deletion, e.g. `TestApplianceTestSuite/TestResourcesDeletedWhenDisabled`, still pass.

<!-- REQUIRED; info at https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles -->

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
