### PR TITLE
fix(esbuild): add chunk cleaner plugin

### DIFF
--- a/client/web/dev/BUILD.bazel
+++ b/client/web/dev/BUILD.bazel
@@ -20,6 +20,7 @@ ts_project(
     name = "dev",
     srcs = [
         "esbuild/build.ts",
+        "esbuild/chunkCleaner.ts",
         "esbuild/config.ts",
         "esbuild/manifestPlugin.ts",
         "esbuild/server.ts",

--- a/client/web/dev/esbuild/chunkCleaner.ts
+++ b/client/web/dev/esbuild/chunkCleaner.ts
@@ -1,0 +1,36 @@
+import * as esbuild from 'esbuild'
+import fs from 'fs'
+import path from 'path'
+
+/**
+ * chunkCleaner is a small plugin that removes the 'chunks' directory when the build starts from the configured `outDir` if it exists
+ *
+ * NOTE: This is a bandage, long term solution: https://linear.app/sourcegraph/issue/DINF-115
+**/
+const chunkCleaner: esbuild.Plugin = {
+    name: "chunkCleaner",
+    setup(build: esbuild.PluginBuild) {
+        build.onStart(() => {
+            const outDir = build.initialOptions.outdir
+            if (!outDir) {
+                // nothing to clean if no outdir is defined
+                return
+            }
+
+            const chunkDir = path.join(outDir, "chunks")
+
+
+            console.debug(`[chunk cleaner] removing '${chunkDir}'`)
+            fs.rm(chunkDir, { recursive: true, force: true }, (err) => {
+                if (err) {
+                    console.warn(`[chunk cleaner] failed to remove ${chunkDir} - it might not exist: ${err}`)
+                } else {
+                    console.log(`[chunk cleaner] removed '${chunkDir}'`)
+                }
+            })
+
+        })
+    }
+}
+
+export default chunkCleaner

--- a/client/web/dev/esbuild/chunkCleaner.ts
+++ b/client/web/dev/esbuild/chunkCleaner.ts
@@ -1,14 +1,15 @@
-import * as esbuild from 'esbuild'
 import fs from 'fs'
 import path from 'path'
+
+import * as esbuild from 'esbuild'
 
 /**
  * chunkCleaner is a small plugin that removes the 'chunks' directory when the build starts from the configured `outDir` if it exists
  *
  * NOTE: This is a bandage, long term solution: https://linear.app/sourcegraph/issue/DINF-115
-**/
+ **/
 const chunkCleaner: esbuild.Plugin = {
-    name: "chunkCleaner",
+    name: 'chunkCleaner',
     setup(build: esbuild.PluginBuild) {
         build.onStart(() => {
             const outDir = build.initialOptions.outdir
@@ -17,20 +18,18 @@ const chunkCleaner: esbuild.Plugin = {
                 return
             }
 
-            const chunkDir = path.join(outDir, "chunks")
-
+            const chunkDir = path.join(outDir, 'chunks')
 
             console.debug(`[chunk cleaner] removing '${chunkDir}'`)
-            fs.rm(chunkDir, { recursive: true, force: true }, (err) => {
+            fs.rm(chunkDir, { recursive: true, force: true }, err => {
                 if (err) {
                     console.warn(`[chunk cleaner] failed to remove ${chunkDir} - it might not exist: ${err}`)
                 } else {
                     console.log(`[chunk cleaner] removed '${chunkDir}'`)
                 }
             })
-
         })
-    }
+    },
 }
 
 export default chunkCleaner

--- a/client/web/dev/esbuild/config.ts
+++ b/client/web/dev/esbuild/config.ts
@@ -16,6 +16,8 @@ import { MONACO_LANGUAGES_AND_FEATURES } from '@sourcegraph/build-config/src/mon
 import type { EnvironmentConfig } from '../utils'
 
 import { manifestPlugin } from './manifestPlugin'
+
+import chunkCleaner from './chunkCleaner'
 import { WEB_BUILD_MANIFEST_FILENAME, webManifestBuilder } from './webmanifest'
 
 /**
@@ -40,6 +42,7 @@ export function esbuildBuildOptions(ENVIRONMENT_CONFIG: EnvironmentConfig): esbu
         entryNames: '[name]-[hash]',
         outdir: STATIC_ASSETS_PATH,
         plugins: [
+            chunkCleaner,
             stylePlugin,
             manifestPlugin({
                 manifestFilename: WEB_BUILD_MANIFEST_FILENAME,
@@ -56,34 +59,34 @@ export function esbuildBuildOptions(ENVIRONMENT_CONFIG: EnvironmentConfig): esbu
                 'react-dom/client': path.join(ROOT_PATH, 'node_modules/react-dom/client'),
                 ...(ENVIRONMENT_CONFIG.DEV_WEB_BUILDER_OMIT_SLOW_DEPS
                     ? {
-                          // Monaco
-                          '@sourcegraph/shared/src/components/MonacoEditor':
-                              '@sourcegraph/shared/src/components/NoMonacoEditor',
-                          'monaco-editor': '/dev/null',
-                          'monaco-editor/esm/vs/editor/editor.api': '/dev/null',
-                          'monaco-yaml': '/dev/null',
+                        // Monaco
+                        '@sourcegraph/shared/src/components/MonacoEditor':
+                            '@sourcegraph/shared/src/components/NoMonacoEditor',
+                        'monaco-editor': '/dev/null',
+                        'monaco-editor/esm/vs/editor/editor.api': '/dev/null',
+                        'monaco-yaml': '/dev/null',
 
-                          // GraphiQL
-                          './api/ApiConsole': path.join(ROOT_PATH, 'client/web/src/api/NoApiConsole.tsx'),
-                          '@graphiql/react': '/dev/null',
-                          graphiql: '/dev/null',
+                        // GraphiQL
+                        './api/ApiConsole': path.join(ROOT_PATH, 'client/web/src/api/NoApiConsole.tsx'),
+                        '@graphiql/react': '/dev/null',
+                        graphiql: '/dev/null',
 
-                          // Misc.
-                          recharts: '/dev/null',
-                      }
+                        // Misc.
+                        recharts: '/dev/null',
+                    }
                     : null),
             }),
             ENVIRONMENT_CONFIG.DEV_WEB_BUILDER_OMIT_SLOW_DEPS ? null : monacoPlugin(MONACO_LANGUAGES_AND_FEATURES),
             buildTimerPlugin,
             ENVIRONMENT_CONFIG.SENTRY_UPLOAD_SOURCE_MAPS
                 ? sentryEsbuildPlugin({
-                      org: ENVIRONMENT_CONFIG.SENTRY_ORGANIZATION,
-                      project: ENVIRONMENT_CONFIG.SENTRY_PROJECT,
-                      authToken: ENVIRONMENT_CONFIG.SENTRY_DOT_COM_AUTH_TOKEN,
-                      silent: true,
-                      release: { name: `frontend@${ENVIRONMENT_CONFIG.VERSION}` },
-                      sourcemaps: { assets: [path.join('dist', '*.map'), path.join('dist', 'chunks', '*.map')] },
-                  })
+                    org: ENVIRONMENT_CONFIG.SENTRY_ORGANIZATION,
+                    project: ENVIRONMENT_CONFIG.SENTRY_PROJECT,
+                    authToken: ENVIRONMENT_CONFIG.SENTRY_DOT_COM_AUTH_TOKEN,
+                    silent: true,
+                    release: { name: `frontend@${ENVIRONMENT_CONFIG.VERSION}` },
+                    sourcemaps: { assets: [path.join('dist', '*.map'), path.join('dist', 'chunks', '*.map')] },
+                })
                 : null,
         ].filter((plugin): plugin is esbuild.Plugin => plugin !== null),
         define: {

--- a/client/web/dev/esbuild/config.ts
+++ b/client/web/dev/esbuild/config.ts
@@ -15,9 +15,8 @@ import { MONACO_LANGUAGES_AND_FEATURES } from '@sourcegraph/build-config/src/mon
 
 import type { EnvironmentConfig } from '../utils'
 
-import { manifestPlugin } from './manifestPlugin'
-
 import chunkCleaner from './chunkCleaner'
+import { manifestPlugin } from './manifestPlugin'
 import { WEB_BUILD_MANIFEST_FILENAME, webManifestBuilder } from './webmanifest'
 
 /**
@@ -59,34 +58,34 @@ export function esbuildBuildOptions(ENVIRONMENT_CONFIG: EnvironmentConfig): esbu
                 'react-dom/client': path.join(ROOT_PATH, 'node_modules/react-dom/client'),
                 ...(ENVIRONMENT_CONFIG.DEV_WEB_BUILDER_OMIT_SLOW_DEPS
                     ? {
-                        // Monaco
-                        '@sourcegraph/shared/src/components/MonacoEditor':
-                            '@sourcegraph/shared/src/components/NoMonacoEditor',
-                        'monaco-editor': '/dev/null',
-                        'monaco-editor/esm/vs/editor/editor.api': '/dev/null',
-                        'monaco-yaml': '/dev/null',
+                          // Monaco
+                          '@sourcegraph/shared/src/components/MonacoEditor':
+                              '@sourcegraph/shared/src/components/NoMonacoEditor',
+                          'monaco-editor': '/dev/null',
+                          'monaco-editor/esm/vs/editor/editor.api': '/dev/null',
+                          'monaco-yaml': '/dev/null',
 
-                        // GraphiQL
-                        './api/ApiConsole': path.join(ROOT_PATH, 'client/web/src/api/NoApiConsole.tsx'),
-                        '@graphiql/react': '/dev/null',
-                        graphiql: '/dev/null',
+                          // GraphiQL
+                          './api/ApiConsole': path.join(ROOT_PATH, 'client/web/src/api/NoApiConsole.tsx'),
+                          '@graphiql/react': '/dev/null',
+                          graphiql: '/dev/null',
 
-                        // Misc.
-                        recharts: '/dev/null',
-                    }
+                          // Misc.
+                          recharts: '/dev/null',
+                      }
                     : null),
             }),
             ENVIRONMENT_CONFIG.DEV_WEB_BUILDER_OMIT_SLOW_DEPS ? null : monacoPlugin(MONACO_LANGUAGES_AND_FEATURES),
             buildTimerPlugin,
             ENVIRONMENT_CONFIG.SENTRY_UPLOAD_SOURCE_MAPS
                 ? sentryEsbuildPlugin({
-                    org: ENVIRONMENT_CONFIG.SENTRY_ORGANIZATION,
-                    project: ENVIRONMENT_CONFIG.SENTRY_PROJECT,
-                    authToken: ENVIRONMENT_CONFIG.SENTRY_DOT_COM_AUTH_TOKEN,
-                    silent: true,
-                    release: { name: `frontend@${ENVIRONMENT_CONFIG.VERSION}` },
-                    sourcemaps: { assets: [path.join('dist', '*.map'), path.join('dist', 'chunks', '*.map')] },
-                })
+                      org: ENVIRONMENT_CONFIG.SENTRY_ORGANIZATION,
+                      project: ENVIRONMENT_CONFIG.SENTRY_PROJECT,
+                      authToken: ENVIRONMENT_CONFIG.SENTRY_DOT_COM_AUTH_TOKEN,
+                      silent: true,
+                      release: { name: `frontend@${ENVIRONMENT_CONFIG.VERSION}` },
+                      sourcemaps: { assets: [path.join('dist', '*.map'), path.join('dist', 'chunks', '*.map')] },
+                  })
                 : null,
         ].filter((plugin): plugin is esbuild.Plugin => plugin !== null),
         define: {

--- a/client/web/package.json
+++ b/client/web/package.json
@@ -21,7 +21,7 @@
     "generate": "pnpm -w run generate",
     "dev": "ts-node -T dev/esbuild/server.ts",
     "build": "pnpm run generate && pnpm run clean && ts-node -T dev/esbuild/build.ts",
-    "clean": "rm -r dist/chunks dist/main-* dist/embedMain-*",
+    "clean": "rm -rf dist/chunks dist/main-* dist/embedMain-*",
     "watch": "WATCH=1 pnpm run --silent build",
     "lint": "pnpm lint:js && pnpm:lint:css",
     "lint:js": "NODE_OPTIONS=\"--max_old_space_size=16192\" eslint --cache '**/*.[tj]s?(x)'",

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -516,16 +516,6 @@ commands:
     description: Enterprise version of the web app
     cmd: pnpm --filter @sourcegraph/web dev
     install: |
-      # ❗ This is a bandage, long term solution: https://linear.app/sourcegraph/issue/DINF-115
-      dir_path=client/web/dist/chunks
-      dir_size=$(du -k "$dir_path" | cut -f1)
-      size_limit=$((300 * 1024)) # If above 300mb, just nuke it
-
-      if [ "$dir_size" -gt "$size_limit" ]; then
-          rm -Rf "$dir_path/"*
-          touch "${dir_path}/.gitkeep"
-      fi
-
       pnpm install
       pnpm run generate
     env:


### PR DESCRIPTION
when running esbuild in dev mode it continuoysly rebuilds and each time
it produces a bunch of chunk files in client/web/dist/chunks. Which
could lead to a very large chunk directory if the dev server is left
long enough.

Chunk-cleaner removes the dist/chunks directory upon esbuild start up.
**This introduces a ~500ms cost per esbuild.**

## Test plan
Tested locally + CI

## Changelog
