### PR TITLE
chore(svelte): Refactor repo loaders

### DIFF
--- a/client/web-sveltekit/prettier.config.cjs
+++ b/client/web-sveltekit/prettier.config.cjs
@@ -2,5 +2,8 @@ const baseConfig = require('../../prettier.config.js')
 module.exports = {
     ...baseConfig,
     plugins: [...(baseConfig.plugins || []), 'prettier-plugin-svelte'],
-    overrides: [...(baseConfig.overrides || []), { files: '*.svelte', options: { parser: 'svelte', htmlWhitespaceSensitivity: 'strict' } }],
+    overrides: [
+        ...(baseConfig.overrides || []),
+        { files: '*.svelte', options: { parser: 'svelte', htmlWhitespaceSensitivity: 'strict' } },
+    ],
 }

--- a/client/web-sveltekit/src/lib/repo/utils.ts
+++ b/client/web-sveltekit/src/lib/repo/utils.ts
@@ -1,4 +1,10 @@
-import type { ResolvedRevision } from '../../routes/[...repo=reporev]/+layout'
+import type { ResolvedRepository } from '../../routes/[...repo=reporev]/layout.gql'
+
+export interface ResolvedRevision {
+    repo: ResolvedRepository
+    defaultBranch: string
+    commitID: string
+}
 
 export function getRevisionLabel(
     urlRevision: string | undefined,

--- a/client/web-sveltekit/src/lib/search/input/SearchInput.svelte
+++ b/client/web-sveltekit/src/lib/search/input/SearchInput.svelte
@@ -200,7 +200,8 @@
     // When a toggle is unset, we revert back to the default pattern type. However, if the default pattern type
     // is regexp, we should revert to keyword instead (otherwise it's not possible to disable the toggle).
     function getUnselectedPatternType(): SearchPatternType {
-        const defaultPatternType = ($settings?.['search.defaultPatternType'] as SearchPatternType) ?? SearchPatternType.keyword
+        const defaultPatternType =
+            ($settings?.['search.defaultPatternType'] as SearchPatternType) ?? SearchPatternType.keyword
         return defaultPatternType === SearchPatternType.regexp ? SearchPatternType.keyword : defaultPatternType
     }
 

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/page.spec.ts
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/page.spec.ts
@@ -379,6 +379,9 @@ test.describe('cody sidebar', () => {
         })
 
         test('disabled when disabled on instance', async ({ page, sg }) => {
+            // These tests seem to take longer than the default timeout
+            test.setTimeout(10000)
+
             sg.setWindowContext({
                 codyEnabledOnInstance: false,
             })
@@ -388,6 +391,9 @@ test.describe('cody sidebar', () => {
         })
 
         test('disabled when disabled for user', async ({ page, sg }) => {
+            // These tests seem to take longer than the default timeout
+            test.setTimeout(10000)
+
             sg.setWindowContext({
                 codyEnabledOnInstance: true,
                 codyEnabledForCurrentUser: false,

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/RepositoryRevPicker.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/RepositoryRevPicker.svelte
@@ -32,6 +32,7 @@
     import { goto } from '$app/navigation'
     import Icon from '$lib/Icon.svelte'
     import Popover from '$lib/Popover.svelte'
+    import type { ResolvedRevision } from '$lib/repo/utils'
     import { replaceRevisionInURL } from '$lib/shared'
     import TabPanel from '$lib/TabPanel.svelte'
     import Tabs from '$lib/Tabs.svelte'
@@ -40,8 +41,6 @@
     import { getButtonClassName } from '$lib/wildcard/Button'
     import ButtonGroup from '$lib/wildcard/ButtonGroup.svelte'
     import CopyButton from '$lib/wildcard/CopyButton.svelte'
-
-    import type { ResolvedRevision } from '../+layout'
 
     import Picker from './Picker.svelte'
     import RepositoryRevPickerItem from './RepositoryRevPickerItem.svelte'

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/+layout.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/+layout.svelte
@@ -158,8 +158,8 @@
         repoName={data.repoName}
         displayRepoName={data.displayRepoName}
         repoURL={data.repoURL}
-        externalURL={data.resolvedRevision?.repo?.externalURLs?.[0].url}
-        externalServiceKind={data.resolvedRevision?.repo?.externalURLs?.[0].serviceKind ?? undefined}
+        externalURL={data.resolvedRepository.externalURLs[0]?.url}
+        externalServiceKind={data.resolvedRepository.externalURLs[0]?.serviceKind ?? undefined}
     />
 
     <TabsHeader id="repoheader" {tabs} selected={selectedTab} />

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/+layout.ts
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/+layout.ts
@@ -7,7 +7,7 @@ import { CloneInProgressError, RepoNotFoundError, displayRepoName, parseRepoRevi
 import type { LayoutLoad } from './$types'
 import { ResolveRepoRevision, ResolvedRepository, type ResolveRepoRevisionResult } from './layout.gql'
 
-export const load: LayoutLoad = async ({ params, url, depends, untrack }) => {
+export const load: LayoutLoad = async ({ params, url, depends }) => {
     const client = getGraphQLClient()
 
     // This allows other places to reload all repo related data by calling
@@ -24,7 +24,7 @@ export const load: LayoutLoad = async ({ params, url, depends, untrack }) => {
         client,
         repoName,
         revspec: revision,
-        url: untrack(() => new URL(url)),
+        url,
     })
 
     return {

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/+layout.ts
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/+layout.ts
@@ -1,28 +1,13 @@
-import { redirect, error } from '@sveltejs/kit'
+import { error, redirect } from '@sveltejs/kit'
 
-import { asError, loadMarkdownSyntaxHighlighting, type ErrorLike } from '$lib/common'
+import { loadMarkdownSyntaxHighlighting } from '$lib/common'
 import { getGraphQLClient, type GraphQLClient } from '$lib/graphql'
-import {
-    CloneInProgressError,
-    RepoNotFoundError,
-    RepoSeeOtherError,
-    RevisionNotFoundError,
-    displayRepoName,
-    isRepoSeeOtherErrorLike,
-    isRevisionNotFoundErrorLike,
-    parseRepoRevision,
-} from '$lib/shared'
+import { CloneInProgressError, RepoNotFoundError, displayRepoName, parseRepoRevision } from '$lib/shared'
 
 import type { LayoutLoad } from './$types'
 import { ResolveRepoRevision, ResolvedRepository, type ResolveRepoRevisionResult } from './layout.gql'
 
-export interface ResolvedRevision {
-    repo: ResolvedRepository & NonNullable<{ commit: ResolvedRepository['commit'] }>
-    commitID: string
-    defaultBranch: string
-}
-
-export const load: LayoutLoad = async ({ params, url, depends }) => {
+export const load: LayoutLoad = async ({ params, url, depends, untrack }) => {
     const client = getGraphQLClient()
 
     // This allows other places to reload all repo related data by calling
@@ -35,29 +20,12 @@ export const load: LayoutLoad = async ({ params, url, depends }) => {
 
     // An empty revision means we are at the default branch
     const { repoName, revision = '' } = parseRepoRevision(params.repo)
-
-    let resolvedRevisionOrError: ResolvedRevision | ErrorLike
-    let resolvedRevision: ResolvedRevision | undefined
-
-    try {
-        resolvedRevisionOrError = await resolveRepoRevision({ client, repoName, revspec: revision })
-        resolvedRevision = resolvedRevisionOrError
-    } catch (repoError: unknown) {
-        const redirect = isRepoSeeOtherErrorLike(repoError)
-
-        if (redirect) {
-            redirectToExternalHost(redirect, url)
-        }
-
-        // TODO: use different error codes for different types of errors
-        // Let revision errors be handled by the nested layout so that we can
-        // still render the main repo navigation and header
-        if (!isRevisionNotFoundErrorLike(repoError)) {
-            error(400, asError(repoError))
-        }
-
-        resolvedRevisionOrError = asError(repoError)
-    }
+    const resolvedRepository = await resolveRepoRevision({
+        client,
+        repoName,
+        revspec: revision,
+        url: untrack(() => new URL(url)),
+    })
 
     return {
         repoURL: '/' + params.repo,
@@ -74,9 +42,9 @@ export const load: LayoutLoad = async ({ params, url, depends }) => {
          * - an abbreviated commit SHA
          * - a symbolic revision (e.g. a branch or tag name)
          */
-        displayRevision: displayRevision(revision, resolvedRevision),
-        resolvedRevisionOrError,
-        resolvedRevision,
+        displayRevision: displayRevision(revision, resolvedRepository),
+        defaultBranch: resolvedRepository.defaultBranch?.abbrevName || 'HEAD',
+        resolvedRepository: resolvedRepository,
     }
 }
 
@@ -88,25 +56,16 @@ export const load: LayoutLoad = async ({ params, url, depends }) => {
  * @param resolvedRevision The resolved revision
  * @returns A human readable revision string
  */
-function displayRevision(revision: string, resolvedRevision: ResolvedRevision | undefined): string {
+function displayRevision(revision: string, resolvedRevision: ResolvedRepository | undefined): string {
     if (!resolvedRevision) {
         return revision
     }
 
-    if (revision && resolvedRevision.commitID.startsWith(revision)) {
-        return resolvedRevision.commitID.slice(0, 7)
+    if (revision && resolvedRevision.commit?.oid.startsWith(revision)) {
+        return resolvedRevision.commit.oid?.slice(0, 7)
     }
 
     return revision
-}
-
-function redirectToExternalHost(externalRedirectURL: string, currentURL: URL): never {
-    const externalHostURL = new URL(externalRedirectURL)
-    const redirectURL = new URL(currentURL)
-    // Preserve the path of the current URL and redirect to the repo on the external host.
-    redirectURL.host = externalHostURL.host
-    redirectURL.protocol = externalHostURL.protocol
-    redirect(303, redirectURL.toString())
 }
 
 // This is a cache for resolved repository information to help in the following case:
@@ -120,15 +79,28 @@ function redirectToExternalHost(externalRedirectURL: string, currentURL: URL): n
 // have previously seen in a response.
 const resolvedRepoRevision = new Map<string, ResolveRepoRevisionResult>()
 
+/**
+ * This function takes the repository name and revision from the URL and fetches the corresponding
+ * repository information.
+ * One of three things can happen:
+ * - If the repository has a server side redirect configured, the user is redirected to the new URL
+ * - If the repository was not found, is currently being cloned or is scheduled for cloning, an error is thrown
+ * - Otherwise the resolved repository information is returned
+ *
+ * Note that it's possible that the provided revision does not exist in the repository. In that case
+ * the repository information is still returned, but the commit information will be missing.
+ */
 async function resolveRepoRevision({
     client,
     repoName,
     revspec = '',
+    url,
 }: {
     client: GraphQLClient
     repoName: string
     revspec?: string
-}): Promise<ResolvedRevision> {
+    url: URL
+}): Promise<ResolvedRepository> {
     const cacheKey = `${repoName}@${revspec}`
 
     let data: ResolveRepoRevisionResult | undefined
@@ -153,42 +125,33 @@ async function resolveRepoRevision({
     }
 
     if (!data?.repositoryRedirect) {
-        throw new RepoNotFoundError(repoName)
+        error(404, new RepoNotFoundError(repoName))
     }
 
     if (data.repositoryRedirect.__typename === 'Redirect') {
-        throw new RepoSeeOtherError(data.repositoryRedirect.url)
+        const redirectURL = new URL(url)
+        const externalURL = new URL(data.repositoryRedirect.url)
+        // Preserve the path of the current URL and redirect to the repo on the external host.
+        redirectURL.host = externalURL.host
+        redirectURL.protocol = externalURL.protocol
+        redirect(303, redirectURL)
     }
     if (data.repositoryRedirect.mirrorInfo.cloneInProgress) {
-        throw new CloneInProgressError(repoName, data.repositoryRedirect.mirrorInfo.cloneProgress || undefined)
+        error(503, new CloneInProgressError(repoName, data.repositoryRedirect.mirrorInfo.cloneProgress || undefined))
     }
     if (!data.repositoryRedirect.mirrorInfo.cloned) {
-        throw new CloneInProgressError(repoName, 'queued for cloning')
+        error(503, new CloneInProgressError(repoName, 'queued for cloning'))
     }
 
     // The "revision" we queried for could be a commit or a changelist.
     const commit = data.repositoryRedirect.commit || data.repositoryRedirect.changelist?.commit
-    if (!commit) {
-        throw new RevisionNotFoundError(revspec)
-    }
-
-    const defaultBranch = data.repositoryRedirect.defaultBranch?.abbrevName || 'HEAD'
-
-    /*
-     * TODO: What exactly is this check for?
-    if (!commit.tree) {
-        throw new RevisionNotFoundError(defaultBranch)
-    }
-    */
 
     // Cache the resolved repository information
-    resolvedRepoRevision.set(`${repoName}@${commit.oid}`, data)
-
-    return {
-        repo: data.repositoryRedirect,
-        commitID: commit.oid,
-        defaultBranch,
+    if (commit) {
+        resolvedRepoRevision.set(`${repoName}@${commit.oid}`, data)
     }
+
+    return data.repositoryRedirect
 }
 
 /**


### PR DESCRIPTION
This commit is in preparation for other work. It refactors how we work with resolved repository and resolved revision information.

The idea was that the top level repo loader should try to resolve the repository information and error if that wasn't possible. Not being able to resolve the revision was accepted, hence this check:

```js
// still render the main repo navigation and header
if (!isRevisionNotFoundErrorLike(repoError)) {
  error(400, asError(repoError))
}
```

However the way it was implemented meant that we wouldn't pass any resolved repository information to the sub-pages/layouts when the revision couldn't be resolved, which seems wrong.

With these changes, the top level repo loader now provides a `resolvedRepository` object (where `commit`/`changelist` might be unset) and the `(validrev)` loader creates the `resolvedRevision` object, just how its sub-pages/layouts expect.

And instead of returning error objects from `resolveRepoRevision` and checking them in the loader we throw errors/redirects directly in that function. IMO that makes the whole flow easier to understand.

## Test plan

Manual testing, CI integration tests
