### PR TITLE
refactor: upgrade to rules_oci 2.0 (2nd attempt)

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -106,9 +106,9 @@ http_archive(
 # Container rules
 http_archive(
     name = "rules_oci",
-    sha256 = "647f4c6fd092dc7a86a7f79892d4b1b7f1de288bdb4829ca38f74fd430fcd2fe",
-    strip_prefix = "rules_oci-1.7.6",
-    url = "https://github.com/bazel-contrib/rules_oci/releases/download/v1.7.6/rules_oci-v1.7.6.tar.gz",
+    sha256 = "f70f07f9d0d6c275d7ec7d3c7f236d9b552ba3205e8f37df9c1125031cf967cc",
+    strip_prefix = "rules_oci-2.0.0-beta1",
+    url = "https://github.com/bazel-contrib/rules_oci/releases/download/v2.0.0-beta1/rules_oci-v2.0.0-beta1.tar.gz",
 )
 
 http_archive(
@@ -407,15 +407,9 @@ load("@rules_oci//oci:dependencies.bzl", "rules_oci_dependencies")
 
 rules_oci_dependencies()
 
-load("@rules_oci//oci:repositories.bzl", "LATEST_CRANE_VERSION", "oci_register_toolchains")
+load("@rules_oci//oci:repositories.bzl", "oci_register_toolchains")
 
-oci_register_toolchains(
-    name = "oci",
-    crane_version = LATEST_CRANE_VERSION,
-    # Uncommenting the zot toolchain will cause it to be used instead of crane for some tasks.
-    # Note that it does not support docker-format images.
-    # zot_version = LATEST_ZOT_VERSION,
-)
+oci_register_toolchains(name = "oci")
 
 # Optional, for oci_tarball rule
 load("@rules_pkg//:deps.bzl", "rules_pkg_dependencies")

--- a/cmd/appliance/BUILD.bazel
+++ b/cmd/appliance/BUILD.bazel
@@ -1,6 +1,6 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 load("//dev:oci_defs.bzl", "image_repository", "oci_image", "oci_push", "oci_tarball")
-load("@rules_pkg//:pkg.bzl", "pkg_tar")
+load("//dev:oci_defs.bzl", "pkg_tar")
 load("@container_structure_test//:defs.bzl", "container_structure_test")
 load("//wolfi-images:defs.bzl", "wolfi_base")
 

--- a/cmd/batcheshelper/BUILD.bazel
+++ b/cmd/batcheshelper/BUILD.bazel
@@ -1,7 +1,6 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
-load("@rules_pkg//:pkg.bzl", "pkg_tar")
 load("@container_structure_test//:defs.bzl", "container_structure_test")
-load("//dev:oci_defs.bzl", "image_repository", "oci_image", "oci_push", "oci_tarball")
+load("//dev:oci_defs.bzl", "image_repository", "oci_image", "oci_push", "oci_tarball", "pkg_tar")
 load("//dev:go_defs.bzl", "go_test")
 load("//wolfi-images:defs.bzl", "wolfi_base")
 

--- a/cmd/blobstore/BUILD.bazel
+++ b/cmd/blobstore/BUILD.bazel
@@ -1,7 +1,7 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 load("@container_structure_test//:defs.bzl", "container_structure_test")
 load("//dev:oci_defs.bzl", "oci_image", "oci_tarball")
-load("@rules_pkg//:pkg.bzl", "pkg_tar")
+load("//dev:oci_defs.bzl", "pkg_tar")
 
 go_library(
     name = "blobstore_lib",

--- a/cmd/bundled-executor/BUILD.bazel
+++ b/cmd/bundled-executor/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_pkg//:pkg.bzl", "pkg_tar")
+load("//dev:oci_defs.bzl", "pkg_tar")
 load("@container_structure_test//:defs.bzl", "container_structure_test")
 load("//dev:oci_defs.bzl", "image_repository", "oci_image", "oci_push", "oci_tarball")
 load("//cmd/server:macro.bzl", "container_dependencies", "dependencies_tars")

--- a/cmd/cody-gateway/BUILD.bazel
+++ b/cmd/cody-gateway/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
-load("@rules_pkg//:pkg.bzl", "pkg_tar")
+load("//dev:oci_defs.bzl", "pkg_tar")
 load("@container_structure_test//:defs.bzl", "container_structure_test")
 load("//dev:oci_defs.bzl", "image_repository", "oci_image", "oci_push", "oci_tarball")
 

--- a/cmd/customer-2315/BUILD.bazel
+++ b/cmd/customer-2315/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
-load("@rules_pkg//:pkg.bzl", "pkg_tar")
+load("//dev:oci_defs.bzl", "pkg_tar")
 load("@container_structure_test//:defs.bzl", "container_structure_test")
 load("//dev:oci_defs.bzl", "image_repository", "oci_image", "oci_push", "oci_tarball")
 

--- a/cmd/customer-4512/BUILD.bazel
+++ b/cmd/customer-4512/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
-load("@rules_pkg//:pkg.bzl", "pkg_tar")
+load("//dev:oci_defs.bzl", "pkg_tar")
 load("@container_structure_test//:defs.bzl", "container_structure_test")
 load("//dev:oci_defs.bzl", "image_repository", "oci_image", "oci_push", "oci_tarball")
 

--- a/cmd/embeddings/BUILD.bazel
+++ b/cmd/embeddings/BUILD.bazel
@@ -1,6 +1,6 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 load("//dev:oci_defs.bzl", "image_repository", "oci_image", "oci_push", "oci_tarball")
-load("@rules_pkg//:pkg.bzl", "pkg_tar")
+load("//dev:oci_defs.bzl", "pkg_tar")
 load("@container_structure_test//:defs.bzl", "container_structure_test")
 
 go_library(

--- a/cmd/enterprise-portal/BUILD.bazel
+++ b/cmd/enterprise-portal/BUILD.bazel
@@ -1,6 +1,6 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 load("//dev:oci_defs.bzl", "image_repository", "oci_image", "oci_push", "oci_tarball")
-load("@rules_pkg//:pkg.bzl", "pkg_tar")
+load("//dev:oci_defs.bzl", "pkg_tar")
 load("@container_structure_test//:defs.bzl", "container_structure_test")
 load("//dev:msp_delivery.bzl", "msp_delivery")
 

--- a/cmd/executor-kubernetes/BUILD.bazel
+++ b/cmd/executor-kubernetes/BUILD.bazel
@@ -1,5 +1,5 @@
 load("//dev:oci_defs.bzl", "image_repository", "oci_image", "oci_push", "oci_tarball")
-load("@rules_pkg//:pkg.bzl", "pkg_tar")
+load("//dev:oci_defs.bzl", "pkg_tar")
 load("@container_structure_test//:defs.bzl", "container_structure_test")
 load("//cmd/server:macro.bzl", "container_dependencies", "dependencies_tars")
 load("//wolfi-images:defs.bzl", "wolfi_base")

--- a/cmd/executor/BUILD.bazel
+++ b/cmd/executor/BUILD.bazel
@@ -1,7 +1,7 @@
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 load("//dev:oci_defs.bzl", "image_repository", "oci_image", "oci_push", "oci_tarball")
-load("@rules_pkg//:pkg.bzl", "pkg_tar")
+load("//dev:oci_defs.bzl", "pkg_tar")
 load("@container_structure_test//:defs.bzl", "container_structure_test")
 load("//wolfi-images:defs.bzl", "wolfi_base")
 

--- a/cmd/executor/vm-image/BUILD.bazel
+++ b/cmd/executor/vm-image/BUILD.bazel
@@ -28,6 +28,7 @@ sh_binary(
     env = {
         "SRC_CLI_VERSION": SRC_CLI_VERSION,
     },
+    deps = ["@bazel_tools//tools/bash/runfiles"],
 )
 
 sh_binary(

--- a/cmd/executor/vm-image/_ami.build.sh
+++ b/cmd/executor/vm-image/_ami.build.sh
@@ -1,6 +1,19 @@
 #!/usr/bin/env bash
 
 set -eu
+
+# --- begin runfiles.bash initialization v3 ---
+# Copy-pasted from the Bazel Bash runfiles library v3.
+set -uo pipefail; set +e; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+# shellcheck disable=SC1090
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$0.runfiles/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
+# --- end runfiles.bash initialization v3 ---
+
 ## Setting up inputs/data
 gcloud="$(pwd)/$1" # used in workdir folder, so need an absolute path
 packer="$(pwd)/$2"

--- a/cmd/frontend/BUILD.bazel
+++ b/cmd/frontend/BUILD.bazel
@@ -1,6 +1,6 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 load("//dev:oci_defs.bzl", "image_repository", "oci_image", "oci_push", "oci_tarball")
-load("@rules_pkg//:pkg.bzl", "pkg_tar")
+load("//dev:oci_defs.bzl", "pkg_tar")
 load("@container_structure_test//:defs.bzl", "container_structure_test")
 
 go_library(

--- a/cmd/gitserver/BUILD.bazel
+++ b/cmd/gitserver/BUILD.bazel
@@ -1,6 +1,6 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 load("//dev:oci_defs.bzl", "image_repository", "oci_image", "oci_push", "oci_tarball")
-load("@rules_pkg//:pkg.bzl", "pkg_tar")
+load("//dev:oci_defs.bzl", "pkg_tar")
 load("@container_structure_test//:defs.bzl", "container_structure_test")
 load("//wolfi-images:defs.bzl", "wolfi_base")
 

--- a/cmd/loadtest/BUILD.bazel
+++ b/cmd/loadtest/BUILD.bazel
@@ -1,6 +1,6 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 load("//dev:oci_defs.bzl", "image_repository", "oci_image", "oci_push", "oci_tarball")
-load("@rules_pkg//:pkg.bzl", "pkg_tar")
+load("//dev:oci_defs.bzl", "pkg_tar")
 load("@container_structure_test//:defs.bzl", "container_structure_test")
 
 go_library(

--- a/cmd/migrator/BUILD.bazel
+++ b/cmd/migrator/BUILD.bazel
@@ -1,6 +1,6 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 load("//dev:oci_defs.bzl", "image_repository", "oci_image", "oci_push", "oci_tarball")
-load("@rules_pkg//:pkg.bzl", "pkg_tar")
+load("//dev:oci_defs.bzl", "pkg_tar")
 load("@container_structure_test//:defs.bzl", "container_structure_test")
 
 go_library(

--- a/cmd/msp-example/BUILD.bazel
+++ b/cmd/msp-example/BUILD.bazel
@@ -1,6 +1,6 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 load("//dev:oci_defs.bzl", "image_repository", "oci_image", "oci_push", "oci_tarball")
-load("@rules_pkg//:pkg.bzl", "pkg_tar")
+load("//dev:oci_defs.bzl", "pkg_tar")
 load("@container_structure_test//:defs.bzl", "container_structure_test")
 load("//dev:msp_delivery.bzl", "msp_delivery")
 

--- a/cmd/pings/BUILD.bazel
+++ b/cmd/pings/BUILD.bazel
@@ -1,6 +1,6 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 load("//dev:oci_defs.bzl", "image_repository", "oci_image", "oci_push", "oci_tarball")
-load("@rules_pkg//:pkg.bzl", "pkg_tar")
+load("//dev:oci_defs.bzl", "pkg_tar")
 load("@container_structure_test//:defs.bzl", "container_structure_test")
 load("//dev:msp_delivery.bzl", "msp_delivery")
 

--- a/cmd/precise-code-intel-worker/BUILD.bazel
+++ b/cmd/precise-code-intel-worker/BUILD.bazel
@@ -1,6 +1,6 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 load("//dev:oci_defs.bzl", "image_repository", "oci_image", "oci_push", "oci_tarball")
-load("@rules_pkg//:pkg.bzl", "pkg_tar")
+load("//dev:oci_defs.bzl", "pkg_tar")
 load("@container_structure_test//:defs.bzl", "container_structure_test")
 
 go_library(

--- a/cmd/repo-updater/BUILD.bazel
+++ b/cmd/repo-updater/BUILD.bazel
@@ -1,6 +1,6 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 load("//dev:oci_defs.bzl", "image_repository", "oci_image", "oci_push", "oci_tarball")
-load("@rules_pkg//:pkg.bzl", "pkg_tar")
+load("//dev:oci_defs.bzl", "pkg_tar")
 load("@container_structure_test//:defs.bzl", "container_structure_test")
 load("//wolfi-images:defs.bzl", "wolfi_base")
 

--- a/cmd/searcher/BUILD.bazel
+++ b/cmd/searcher/BUILD.bazel
@@ -1,6 +1,6 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 load("//dev:oci_defs.bzl", "image_repository", "oci_image", "oci_push", "oci_tarball")
-load("@rules_pkg//:pkg.bzl", "pkg_tar")
+load("//dev:oci_defs.bzl", "pkg_tar")
 load("@container_structure_test//:defs.bzl", "container_structure_test")
 load("//wolfi-images:defs.bzl", "wolfi_base")
 

--- a/cmd/server/BUILD.bazel
+++ b/cmd/server/BUILD.bazel
@@ -1,7 +1,7 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 load("//dev:oci_defs.bzl", "image_repository", "oci_image", "oci_push", "oci_tarball")
 load("@container_structure_test//:defs.bzl", "container_structure_test")
-load("@rules_pkg//:pkg.bzl", "pkg_tar")
+load("//dev:oci_defs.bzl", "pkg_tar")
 load("macro.bzl", "container_dependencies", "dependencies_tars")
 load("//wolfi-images:defs.bzl", "wolfi_base")
 

--- a/cmd/server/macro.bzl
+++ b/cmd/server/macro.bzl
@@ -2,7 +2,7 @@
 Various helpers to help with server image building
 """
 
-load("@rules_pkg//:pkg.bzl", "pkg_tar")
+load("//dev:oci_defs.bzl", "pkg_tar")
 
 def get_last_segment(path):
     """

--- a/cmd/symbols/BUILD.bazel
+++ b/cmd/symbols/BUILD.bazel
@@ -1,6 +1,6 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 load("//dev:oci_defs.bzl", "image_repository", "oci_image", "oci_push", "oci_tarball")
-load("@rules_pkg//:pkg.bzl", "pkg_tar")
+load("//dev:oci_defs.bzl", "pkg_tar")
 load("@container_structure_test//:defs.bzl", "container_structure_test")
 load("//wolfi-images:defs.bzl", "wolfi_base")
 

--- a/cmd/syntactic-code-intel-worker/BUILD.bazel
+++ b/cmd/syntactic-code-intel-worker/BUILD.bazel
@@ -1,6 +1,6 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 load("//dev:oci_defs.bzl", "image_repository", "oci_image", "oci_push", "oci_tarball")
-load("@rules_pkg//:pkg.bzl", "pkg_tar")
+load("//dev:oci_defs.bzl", "pkg_tar")
 load("@container_structure_test//:defs.bzl", "container_structure_test")
 
 go_library(

--- a/cmd/telemetry-gateway/BUILD.bazel
+++ b/cmd/telemetry-gateway/BUILD.bazel
@@ -1,6 +1,6 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 load("//dev:oci_defs.bzl", "image_repository", "oci_image", "oci_push", "oci_tarball")
-load("@rules_pkg//:pkg.bzl", "pkg_tar")
+load("//dev:oci_defs.bzl", "pkg_tar")
 load("@container_structure_test//:defs.bzl", "container_structure_test")
 load("//dev:msp_delivery.bzl", "msp_delivery")
 

--- a/cmd/worker/BUILD.bazel
+++ b/cmd/worker/BUILD.bazel
@@ -1,7 +1,7 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 load("@container_structure_test//:defs.bzl", "container_structure_test")
 load("//dev:oci_defs.bzl", "image_repository", "oci_image", "oci_push", "oci_tarball")
-load("@rules_pkg//:pkg.bzl", "pkg_tar")
+load("//dev:oci_defs.bzl", "pkg_tar")
 
 go_library(
     name = "worker_lib",

--- a/dev/build-tracker/BUILD.bazel
+++ b/dev/build-tracker/BUILD.bazel
@@ -2,7 +2,7 @@ load("//dev:go_mockgen.bzl", "go_mockgen")
 load("//dev:go_defs.bzl", "go_test")
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 load("//dev:oci_defs.bzl", "image_repository", "oci_image", "oci_push", "oci_tarball")
-load("@rules_pkg//:pkg.bzl", "pkg_tar")
+load("//dev:oci_defs.bzl", "pkg_tar")
 load("@container_structure_test//:defs.bzl", "container_structure_test")
 load("//dev:msp_delivery.bzl", "msp_delivery")
 

--- a/dev/ci/push_all.sh
+++ b/dev/ci/push_all.sh
@@ -186,6 +186,7 @@ bazel "${bazelrc[@]}" build \
   --build_event_binary_file_path_conversion=false \
   --build_event_binary_file_upload_mode=wait_for_upload_complete \
   --build_event_publish_all_actions=true \
+  --remote_download_outputs=toplevel \
   ${images}
 
 echo "--- :bash: Generating jobfile - started"

--- a/dev/linearhooks/BUILD.bazel
+++ b/dev/linearhooks/BUILD.bazel
@@ -1,6 +1,6 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 load("//dev:oci_defs.bzl", "image_repository", "oci_image", "oci_push", "oci_tarball")
-load("@rules_pkg//:pkg.bzl", "pkg_tar")
+load("//dev:oci_defs.bzl", "pkg_tar")
 load("@container_structure_test//:defs.bzl", "container_structure_test")
 load("//dev:msp_delivery.bzl", "msp_delivery")
 

--- a/dev/oci_defs.bzl
+++ b/dev/oci_defs.bzl
@@ -1,6 +1,6 @@
 """OCI bazel defs"""
 
-load("@rules_oci//oci:defs.bzl", _oci_image = "oci_image", _oci_push = "oci_push", _oci_tarball = "oci_tarball")
+load("@rules_oci//oci:defs.bzl", _oci_image = "oci_image", _oci_load = "oci_load", _oci_push = "oci_push")
 
 REGISTRY_REPOSITORY_PREFIX = "europe-west1-docker.pkg.dev/sourcegraph-security-logging/rules-oci-test/{}"
 # REGISTRY_REPOSITORY_PREFIX = "us.gcr.io/sourcegraph-dev/{}"
@@ -12,7 +12,7 @@ def image_repository(image):
     return REGISTRY_REPOSITORY_PREFIX.format(image)
 
 def oci_tarball(name, **kwargs):
-    _oci_tarball(
+    _oci_load(
         name = name,
         # Don't build this by default with bazel build //... since most oci_tarball
         # targets do not need to be built on CI. This prevents the remote cache from

--- a/dev/oci_defs.bzl
+++ b/dev/oci_defs.bzl
@@ -1,6 +1,7 @@
 """OCI bazel defs"""
 
 load("@rules_oci//oci:defs.bzl", _oci_image = "oci_image", _oci_load = "oci_load", _oci_push = "oci_push")
+load("@rules_pkg//:pkg.bzl", _pkg_tar = "pkg_tar")
 
 REGISTRY_REPOSITORY_PREFIX = "europe-west1-docker.pkg.dev/sourcegraph-security-logging/rules-oci-test/{}"
 # REGISTRY_REPOSITORY_PREFIX = "us.gcr.io/sourcegraph-dev/{}"
@@ -57,3 +58,10 @@ oci_image_cross = rule(
         ),
     },
 )
+
+def pkg_tar(name, **kwargs):
+    _pkg_tar(
+        name = name,
+        extension = "tar.gz",
+        **kwargs
+    )

--- a/doc/dev/background-information/bazel/containers.md
+++ b/doc/dev/background-information/bazel/containers.md
@@ -154,11 +154,8 @@ We can now build this image _locally_ and run those tests as well.
 Example:
 
 ```
-# Create a tarball that can be loaded in Docker of the worker service:
-bazel build //cmd/worker:image_tarball
-
-# Load the image in Docker:
-docker load --input $(bazel cquery //cmd/worker:image_tarball  --output=files)
+# Create and load a tarball that can be loaded in Docker of the worker service:
+bazel run //cmd/worker:image_tarball
 
 # Run the container structure tests
 bazel test //cmd/worker:image_test

--- a/doc/dev/background-information/bazel/faq.md
+++ b/doc/dev/background-information/bazel/faq.md
@@ -55,11 +55,8 @@ Our containers are only built for `linux/amd64`, therefore we need to cross-comp
 Example:
 
 ```
-# Create a tarball that can be loaded in Docker of the worker service:
-bazel build //cmd/worker:image_tarball
-
-# Load the image in Docker:
-docker load --input $(bazel cquery //cmd/worker:image_tarball  --output=files)
+# Create and load a tarball that can be loaded in Docker of the worker service:
+bazel run //cmd/worker:image_tarball
 ```
 
 You can also use the same configuration flag to run the container tests on MacOS:

--- a/doc/dev/background-information/sg/index.md
+++ b/doc/dev/background-information/sg/index.md
@@ -186,8 +186,7 @@ env:
 commands:
   gitserver:
     install: |
-      bazel build //cmd/gitserver:image_tarball && \
-      docker load --input $(bazel cquery //cmd/gitserver:image_tarball --output=files)
+      bazel run //cmd/gitserver:image_tarball
   gitserver-0:
     cmd: |
       docker inspect gitserver-${GITSERVER_INDEX} >/dev/null 2>&1 && docker stop gitserver-${GITSERVER_INDEX}

--- a/docker-images/appliance-frontend/BUILD.bazel
+++ b/docker-images/appliance-frontend/BUILD.bazel
@@ -1,5 +1,5 @@
 load("//dev:oci_defs.bzl", "image_repository", "oci_image", "oci_push", "oci_tarball")
-load("@rules_pkg//:pkg.bzl", "pkg_tar")
+load("//dev:oci_defs.bzl", "pkg_tar")
 load("@container_structure_test//:defs.bzl", "container_structure_test")
 load("//wolfi-images:defs.bzl", "wolfi_base")
 

--- a/docker-images/cadvisor/BUILD.bazel
+++ b/docker-images/cadvisor/BUILD.bazel
@@ -1,6 +1,6 @@
 load("//dev:oci_defs.bzl", "image_repository", "oci_image", "oci_push", "oci_tarball")
 load("@container_structure_test//:defs.bzl", "container_structure_test")
-load("@rules_pkg//:pkg.bzl", "pkg_tar")
+load("//dev:oci_defs.bzl", "pkg_tar")
 load("//wolfi-images:defs.bzl", "wolfi_base")
 
 filegroup(

--- a/docker-images/codeinsights-db/BUILD.bazel
+++ b/docker-images/codeinsights-db/BUILD.bazel
@@ -1,6 +1,6 @@
 load("@container_structure_test//:defs.bzl", "container_structure_test")
 load("@rules_pkg//:mappings.bzl", "pkg_attributes", "pkg_files")
-load("@rules_pkg//:pkg.bzl", "pkg_tar")
+load("//dev:oci_defs.bzl", "pkg_tar")
 load("//dev:oci_defs.bzl", "image_repository", "oci_image", "oci_push", "oci_tarball")
 load("//wolfi-images:defs.bzl", "wolfi_base")
 

--- a/docker-images/dind/BUILD.bazel
+++ b/docker-images/dind/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@aspect_bazel_lib//lib:expand_template.bzl", "expand_template")
-load("@rules_pkg//:pkg.bzl", "pkg_tar")
+load("//dev:oci_defs.bzl", "pkg_tar")
 load("//dev:oci_defs.bzl", "image_repository", "oci_image", "oci_push", "oci_tarball")
 
 expand_template(

--- a/docker-images/executor-vm/BUILD.bazel
+++ b/docker-images/executor-vm/BUILD.bazel
@@ -1,5 +1,5 @@
 load("//dev:oci_defs.bzl", "image_repository", "oci_image", "oci_push", "oci_tarball")
-load("@rules_pkg//:pkg.bzl", "pkg_tar")
+load("//dev:oci_defs.bzl", "pkg_tar")
 
 pkg_tar(
     name = "src-cli",

--- a/docker-images/grafana/BUILD.bazel
+++ b/docker-images/grafana/BUILD.bazel
@@ -1,5 +1,5 @@
 load("//dev:oci_defs.bzl", "image_repository", "oci_image", "oci_push", "oci_tarball")
-load("@rules_pkg//:pkg.bzl", "pkg_tar")
+load("//dev:oci_defs.bzl", "pkg_tar")
 load("@container_structure_test//:defs.bzl", "container_structure_test")
 load("//wolfi-images:defs.bzl", "wolfi_base")
 

--- a/docker-images/indexed-searcher/BUILD.bazel
+++ b/docker-images/indexed-searcher/BUILD.bazel
@@ -1,6 +1,6 @@
 load("//dev:oci_defs.bzl", "image_repository", "oci_image", "oci_push", "oci_tarball")
 load("//cmd/server:macro.bzl", "container_dependencies", "dependencies_tars")
-load("@rules_pkg//:pkg.bzl", "pkg_tar")
+load("//dev:oci_defs.bzl", "pkg_tar")
 load("@container_structure_test//:defs.bzl", "container_structure_test")
 
 DEPS = ["@com_github_sourcegraph_zoekt//cmd/zoekt-webserver"]

--- a/docker-images/jaeger-all-in-one/BUILD.bazel
+++ b/docker-images/jaeger-all-in-one/BUILD.bazel
@@ -1,5 +1,5 @@
 load("//dev:oci_defs.bzl", "image_repository", "oci_image", "oci_push", "oci_tarball")
-load("@rules_pkg//:pkg.bzl", "pkg_tar")
+load("//dev:oci_defs.bzl", "pkg_tar")
 load("@container_structure_test//:defs.bzl", "container_structure_test")
 load("//wolfi-images:defs.bzl", "wolfi_base")
 

--- a/docker-images/opentelemetry-collector/BUILD.bazel
+++ b/docker-images/opentelemetry-collector/BUILD.bazel
@@ -1,5 +1,5 @@
 load("//dev:oci_defs.bzl", "image_repository", "oci_image", "oci_push", "oci_tarball")
-load("@rules_pkg//:pkg.bzl", "pkg_tar")
+load("//dev:oci_defs.bzl", "pkg_tar")
 load("@container_structure_test//:defs.bzl", "container_structure_test")
 load("//wolfi-images:defs.bzl", "wolfi_base")
 

--- a/docker-images/postgres-12-alpine/BUILD.bazel
+++ b/docker-images/postgres-12-alpine/BUILD.bazel
@@ -1,6 +1,6 @@
 load("@container_structure_test//:defs.bzl", "container_structure_test")
 load("@rules_pkg//:mappings.bzl", "pkg_attributes", "pkg_files")
-load("@rules_pkg//:pkg.bzl", "pkg_tar")
+load("//dev:oci_defs.bzl", "pkg_tar")
 load("//dev:oci_defs.bzl", "image_repository", "oci_image", "oci_push", "oci_tarball")
 load("//wolfi-images:defs.bzl", "wolfi_base")
 

--- a/docker-images/postgres_exporter/BUILD.bazel
+++ b/docker-images/postgres_exporter/BUILD.bazel
@@ -1,5 +1,5 @@
 load("//dev:oci_defs.bzl", "image_repository", "oci_image", "oci_push", "oci_tarball")
-load("@rules_pkg//:pkg.bzl", "pkg_tar")
+load("//dev:oci_defs.bzl", "pkg_tar")
 load("@container_structure_test//:defs.bzl", "container_structure_test")
 load("//wolfi-images:defs.bzl", "wolfi_base")
 

--- a/docker-images/prometheus/BUILD.bazel
+++ b/docker-images/prometheus/BUILD.bazel
@@ -1,5 +1,5 @@
 load("//dev:oci_defs.bzl", "image_repository", "oci_image", "oci_push", "oci_tarball")
-load("@rules_pkg//:pkg.bzl", "pkg_tar")
+load("//dev:oci_defs.bzl", "pkg_tar")
 load("@container_structure_test//:defs.bzl", "container_structure_test")
 load("//wolfi-images:defs.bzl", "wolfi_base")
 

--- a/docker-images/redis-cache/BUILD.bazel
+++ b/docker-images/redis-cache/BUILD.bazel
@@ -1,5 +1,5 @@
 load("//dev:oci_defs.bzl", "image_repository", "oci_image", "oci_push", "oci_tarball")
-load("@rules_pkg//:pkg.bzl", "pkg_tar")
+load("//dev:oci_defs.bzl", "pkg_tar")
 load("@container_structure_test//:defs.bzl", "container_structure_test")
 load("//wolfi-images:defs.bzl", "wolfi_base")
 

--- a/docker-images/redis-store/BUILD.bazel
+++ b/docker-images/redis-store/BUILD.bazel
@@ -1,5 +1,5 @@
 load("//dev:oci_defs.bzl", "image_repository", "oci_image", "oci_push", "oci_tarball")
-load("@rules_pkg//:pkg.bzl", "pkg_tar")
+load("//dev:oci_defs.bzl", "pkg_tar")
 load("@container_structure_test//:defs.bzl", "container_structure_test")
 load("//wolfi-images:defs.bzl", "wolfi_base")
 

--- a/docker-images/search-indexer/BUILD.bazel
+++ b/docker-images/search-indexer/BUILD.bazel
@@ -1,6 +1,6 @@
 load("//dev:oci_defs.bzl", "image_repository", "oci_image", "oci_push", "oci_tarball")
 load("//cmd/server:macro.bzl", "container_dependencies", "dependencies_tars")
-load("@rules_pkg//:pkg.bzl", "pkg_tar")
+load("//dev:oci_defs.bzl", "pkg_tar")
 load("@container_structure_test//:defs.bzl", "container_structure_test")
 load("//wolfi-images:defs.bzl", "wolfi_base")
 

--- a/docker-images/sg/BUILD.bazel
+++ b/docker-images/sg/BUILD.bazel
@@ -1,5 +1,5 @@
 load("//dev:oci_defs.bzl", "image_repository", "oci_image", "oci_push", "oci_tarball")
-load("@rules_pkg//:pkg.bzl", "pkg_tar")
+load("//dev:oci_defs.bzl", "pkg_tar")
 load("@container_structure_test//:defs.bzl", "container_structure_test")
 
 pkg_tar(

--- a/docker-images/syntax-highlighter/BUILD.bazel
+++ b/docker-images/syntax-highlighter/BUILD.bazel
@@ -1,6 +1,6 @@
 load("@container_structure_test//:defs.bzl", "container_structure_test")
 load("@crate_index//:defs.bzl", "aliases", "all_crate_deps")
-load("@rules_pkg//:pkg.bzl", "pkg_tar")
+load("//dev:oci_defs.bzl", "pkg_tar")
 load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_library", "rust_test")
 load("//dev:oci_defs.bzl", "image_repository", "oci_image", "oci_push", "oci_tarball")
 load("//wolfi-images:defs.bzl", "wolfi_base")

--- a/docker-images/syntax-highlighter/crates/scip-syntax/BUILD.bazel
+++ b/docker-images/syntax-highlighter/crates/scip-syntax/BUILD.bazel
@@ -113,22 +113,31 @@ oci_image(
     base = "@scip-java",
 )
 
+# TODO: this is expensive as whole has to be uploaded to the remote cache
+# Instead call the executable script created by oci_tarball to load the image
+# to daemon.
 oci_tarball(
     name = "scip_java_image_tarball",
     image = ":scip_java_image",
     repo_tags = ["scip-java:tmp"],
 )
 
+filegroup(
+    name = "scip_java_image_tarball_tar",
+    srcs = [":scip_java_image_tarball"],
+    output_group = "tarball",
+)
+
 genrule(
     name = "java_groundtruth_scip",
     srcs = [
         "testdata/scip-index.sh",
-        ":scip_java_image_tarball",
+        ":scip_java_image_tarball_tar",
     ] + glob(["testdata/java/**"]),
     outs = ["index-java.scip"],
     cmd = """\
     $(location testdata/scip-index.sh) \
-        $(location :scip_java_image_tarball) \
+        $(location :scip_java_image_tarball_tar) \
         scip-java:tmp \
         $(location testdata/java/build.gradle) \
         'scip-java index' \

--- a/internal/appliance/frontend/maintenance/BUILD.bazel
+++ b/internal/appliance/frontend/maintenance/BUILD.bazel
@@ -3,7 +3,7 @@ load("@aspect_rules_ts//ts:defs.bzl", "ts_config")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@npm//internal/appliance/frontend/maintenance:tsconfig-to-swcconfig/package_json.bzl", tsconfig_to_swcconfig = "bin")
 load("@npm//internal/appliance/frontend/maintenance:vite/package_json.bzl", vite_bin = "bin")
-load("@rules_pkg//:pkg.bzl", "pkg_tar")
+load("//dev:oci_defs.bzl", "pkg_tar")
 load("//wolfi-images:defs.bzl", "wolfi_base")
 load("@container_structure_test//:defs.bzl", "container_structure_test")
 

--- a/internal/version/BUILD.bazel
+++ b/internal/version/BUILD.bazel
@@ -1,6 +1,6 @@
 load("@aspect_bazel_lib//lib:expand_template.bzl", "expand_template")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
-load("@rules_pkg//:pkg.bzl", "pkg_tar")
+load("//dev:oci_defs.bzl", "pkg_tar")
 load("//dev:go_defs.bzl", "go_test")
 
 go_library(

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -822,8 +822,7 @@ commands:
     # Nothing to run for this, we just want to re-run the install script every time.
     cmd: exit 0
     install: |
-      bazel build //cmd/batcheshelper:image_tarball
-      docker load --input $(bazel cquery //cmd/batcheshelper:image_tarball --output=files)
+      bazel run //cmd/batcheshelper:image_tarball
     env:
       IMAGE: batcheshelper:candidate
       # TODO: This is required but should only be set on M1 Macs.
@@ -920,8 +919,7 @@ commands:
       mkdir -p "${GRAFANA_DISK}"
       mkdir -p "$(dirname ${GRAFANA_LOG_FILE})"
       docker inspect $CONTAINER >/dev/null 2>&1 && docker rm -f $CONTAINER
-      bazel build //docker-images/grafana:image_tarball
-      docker load --input $(bazel cquery //docker-images/grafana:image_tarball --output=files)
+      bazel run //docker-images/grafana:image_tarball
     env:
       GRAFANA_DISK: $HOME/.sourcegraph-dev/data/grafana
       # Log file location: since we log outside of the Docker container, we should
@@ -978,8 +976,7 @@ commands:
 
       cp ${PROM_TARGETS} "${CONFIG_DIR}"/prometheus_targets.yml
 
-      bazel build //docker-images/prometheus:image_tarball
-      docker load --input $(bazel cquery //docker-images/prometheus:image_tarball --output=files)
+      bazel run //docker-images/prometheus:image_tarball
     env:
       PROMETHEUS_DISK: $HOME/.sourcegraph-dev/data/prometheus
       # See comment above for `grafana`
@@ -1035,8 +1032,7 @@ commands:
         "${IMAGE}"
     install: |
       docker inspect $CONTAINER >/dev/null 2>&1 && docker rm -f $CONTAINER
-      bazel build //docker-images/postgres_exporter:image_tarball
-      docker load --input $(bazel cquery //docker-images/postgres_exporter:image_tarball --output=files)
+      bazel run //docker-images/postgres_exporter:image_tarball
     env:
       IMAGE: postgres-exporter:candidate
       CONTAINER: postgres_exporter
@@ -1050,8 +1046,7 @@ commands:
 
   otel-collector:
     install: |
-      bazel build //docker-images/opentelemetry-collector:image_tarball
-      docker load --input $(bazel cquery //docker-images/opentelemetry-collector:image_tarball --output=files)
+      bazel run //docker-images/opentelemetry-collector:image_tarball
     description: OpenTelemetry collector
     cmd: |
       JAEGER_HOST='host.docker.internal'


### PR DESCRIPTION
2nd attempt of #63111, a follow up https://github.com/sourcegraph/sourcegraph/pull/63085

rules_oci 2.0 brings a lot of performance improvement around oci_image and oci_pull, which will benefit Sourcegraph. It will also make RBE faster and have less load on remote cache.

However, 2.0 makes some breaking changes like

- oci_tarball's default output is no longer a tarball
- oci_image no longer compresses layers that are uncompressed, somebody
has to make sure all `pkg_tar` targets have a `compression` attribute
set to compress it beforehand.
- there is no curl fallback, but this is fine for sourcegraph as it
already uses bazel 7.1.

I checked all targets that use oci_tarball as much as i could to make sure nothing depends on the default tarball output of oci_tarball. there was one target  which used the default output which i put a TODO for somebody else (somebody who is more on top of the repo) to tackle **later**.

## Test plan

CI. Also run delivery on this PR (don't land those changes)
