### PR TITLE
updated error messaging for blocked requests due to abuse

### DIFF
--- a/cmd/cody-gateway/internal/httpapi/completions/flagging.go
+++ b/cmd/cody-gateway/internal/httpapi/completions/flagging.go
@@ -161,7 +161,7 @@ func containsAny(prompt string, patterns []string) (bool, string) {
 // requestBlockedError returns an error indicating that the request was blocked, including the trace ID.
 func requestBlockedError(ctx context.Context) error {
 	traceID := trace.FromContext(ctx).SpanContext().TraceID().String()
-	return errors.Errorf("request blocked - if you think this is a mistake, please contact support@sourcegraph.com and reference this ID: %s", traceID)
+	return errors.Errorf("We blocked your request because we detected your prompt to be against our Acceptable Use Policy (https://sourcegraph.com/terms/aup). If you think this is a mistake, please contact support@sourcegraph.com and reference this ID: %s", traceID)
 }
 
 // PromptRecorder implementations should save select completions prompts for

--- a/cmd/cody-gateway/internal/httpapi/completions/flagging.go
+++ b/cmd/cody-gateway/internal/httpapi/completions/flagging.go
@@ -161,7 +161,7 @@ func containsAny(prompt string, patterns []string) (bool, string) {
 // requestBlockedError returns an error indicating that the request was blocked, including the trace ID.
 func requestBlockedError(ctx context.Context) error {
 	traceID := trace.FromContext(ctx).SpanContext().TraceID().String()
-	return errors.Errorf("We blocked your request because we detected your prompt to be against our Acceptable Use Policy (https://sourcegraph.com/terms/aup). If you think this is a mistake, please contact support@sourcegraph.com and reference this ID: %s", traceID)
+	return errors.Errorf("We blocked your request because we detected your prompt to be against our Acceptable Use Policy (https://sourcegraph.com/terms/aup). Try again by removing any phrases that may violate our AUP. If you think this is a mistake, please contact support@sourcegraph.com and reference this ID: %s", traceID)
 }
 
 // PromptRecorder implementations should save select completions prompts for


### PR DESCRIPTION
Requirements:

- Updating the error message to be more descriptive, since the current one is very vague and results in a lot of customer support requests. Example below:
<img width="440" alt="Screenshot 2024-07-15 at 2 53 08 PM" src="https://github.com/user-attachments/assets/3edf2791-a8bf-441f-ac9f-f1d68539ef1e">

- Updated message says:
  - We blocked your request because we detected your prompt to be against our Acceptable Use Policy (https://sourcegraph.com/terms/aup). If you think this is a mistake, please contact support@sourcegraph.com and reference this ID: %s", traceID

<!-- PR description tips: https://www.notion.so/sourcegraph/Write-a-good-pull-request-description-610a7fd3e613496eb76f450db5a49b6e -->

## Test plan

manual testing
<!-- REQUIRED; info at https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles -->

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
