### PR TITLE
fix(sg): resolve overwrite `env` ordering in sg

### DIFF
--- a/dev/sg/internal/run/BUILD.bazel
+++ b/dev/sg/internal/run/BUILD.bazel
@@ -43,6 +43,7 @@ go_test(
     srcs = [
         "docker_command_test.go",
         "logger_test.go",
+        "run_test.go",
     ],
     embed = [":run"],
     tags = [TAG_INFRA_DEVINFRA],

--- a/dev/sg/internal/run/command.go
+++ b/dev/sg/internal/run/command.go
@@ -279,8 +279,11 @@ func startSgCmd(ctx context.Context, cmd SGConfigCommand, parentEnv map[string]s
 	}
 
 	opts := commandOptions{
-		name:   conf.Name,
-		exec:   exec,
+		name: conf.Name,
+		exec: exec,
+		// The ordering here is quite important because we want to allow the `parentEnv` and `secretsEnv`
+		// to override the config values for a command. This ensures env vars in the sg overwrite file
+		// are always the final authority.
 		env:    makeEnv(conf.Env, parentEnv, secretsEnv),
 		dir:    conf.RepositoryRoot,
 		stdout: outputOptions{ignore: conf.IgnoreStdout},

--- a/dev/sg/internal/run/command.go
+++ b/dev/sg/internal/run/command.go
@@ -281,7 +281,7 @@ func startSgCmd(ctx context.Context, cmd SGConfigCommand, parentEnv map[string]s
 	opts := commandOptions{
 		name:   conf.Name,
 		exec:   exec,
-		env:    makeEnv(parentEnv, secretsEnv, conf.Env),
+		env:    makeEnv(conf.Env, parentEnv, secretsEnv),
 		dir:    conf.RepositoryRoot,
 		stdout: outputOptions{ignore: conf.IgnoreStdout},
 		stderr: outputOptions{ignore: conf.IgnoreStderr},

--- a/dev/sg/internal/run/command.go
+++ b/dev/sg/internal/run/command.go
@@ -265,7 +265,7 @@ type outputOptions struct {
 }
 
 func startSgCmd(ctx context.Context, cmd SGConfigCommand, parentEnv map[string]string) (*startedCmd, error) {
-	exec, err := cmd.GetExecCmd(ctx)
+	ex, err := cmd.GetExecCmd(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -280,7 +280,7 @@ func startSgCmd(ctx context.Context, cmd SGConfigCommand, parentEnv map[string]s
 
 	opts := commandOptions{
 		name: conf.Name,
-		exec: exec,
+		exec: ex,
 		// The ordering here is quite important because we want to allow the `parentEnv` and `secretsEnv`
 		// to override the config values for a command. This ensures env vars in the sg overwrite file
 		// are always the final authority.

--- a/dev/sg/internal/run/run_test.go
+++ b/dev/sg/internal/run/run_test.go
@@ -1,0 +1,56 @@
+package run
+
+import (
+	"os"
+	"testing"
+)
+
+func TestMakeEnvMap(t *testing.T) {
+	env1 := map[string]string{
+		"SRC_TEST_ENV_NAME": "SRC_TEST_ENV_VALUE",
+	}
+	env2 := map[string]string{
+		"SRC_TEST_ENV_NAME": "SRC_TEST_ENV_VALUE2",
+	}
+	env3 := map[string]string{
+		"SRC_TEST_ENV_NAME": "SRC_TEST_ENV_VALUE3",
+	}
+
+	testcases := []struct {
+		envs []map[string]string
+		want string
+	}{
+		{
+			envs: []map[string]string{env1},
+			want: "SRC_TEST_ENV_VALUE",
+		},
+		{
+			envs: []map[string]string{env1, env2},
+			want: "SRC_TEST_ENV_VALUE2",
+		},
+		{
+			envs: []map[string]string{env1, env2, env3},
+			want: "SRC_TEST_ENV_VALUE3",
+		},
+	}
+
+	t.Run("rightmost value takes precedence", func(t *testing.T) {
+		for _, tc := range testcases {
+			if got := makeEnvMap(tc.envs...); got["SRC_TEST_ENV_NAME"] != tc.want {
+				t.Errorf("makeEnvMap(%v) = %v, want %v", tc.envs, got, tc.want)
+			}
+		}
+	})
+
+	t.Run("os.Environ() is included and not overwritten", func(t *testing.T) {
+		if err := os.Setenv("SRC_TEST_ENV_NAME", "PROCESS_ENV_VALUE"); err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() {
+			os.Unsetenv("SRC_TEST_ENV_NAME")
+		})
+		if got := makeEnvMap(env1); got["SRC_TEST_ENV_NAME"] != "PROCESS_ENV_VALUE" {
+			t.Errorf("makeEnvMap(%v) = %v, want %v", env1, got, "PROCESS_ENV_VALUE")
+		}
+	})
+}


### PR DESCRIPTION
Closes [DINF-58](https://linear.app/sourcegraph/issue/DINF-58/overwrite-ordering-in-sg)

https://github.com/user-attachments/assets/d8e59a5f-9390-47f7-a6a7-9ccbf97423f8

## Test plan

- Add a `commandset` to the `sg.config.overwrite.yaml`
- This commandset should depend on an existing command in the `sg.config.yaml` file.
- The commandset should also include an `env var` that should override what's set in the `command` contained in the `sg.config.yaml` file.
- Running `sg start <commandset name>` should allow the env ordering matrix shown below

```
Priority: overwrite.command.env > overwrite.commandset.env > command.env > commandset.env.
```

## Changelog

N/A