### PR TITLE
Upgrade cody web experimental package to 0.2.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -333,7 +333,7 @@
     "bloomfilter": "^0.0.18",
     "buffer": "^6.0.3",
     "classnames": "^2.2.6",
-    "cody-web-experimental": "^0.2.4",
+    "cody-web-experimental": "^0.2.5",
     "comlink": "^4.3.0",
     "copy-to-clipboard": "^3.3.1",
     "core-js": "^3.8.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -218,8 +218,8 @@ importers:
         specifier: ^2.2.6
         version: 2.3.2
       cody-web-experimental:
-        specifier: ^0.2.4
-        version: 0.2.4
+        specifier: ^0.2.5
+        version: 0.2.5
       comlink:
         specifier: ^4.3.0
         version: 4.3.0
@@ -15177,6 +15177,10 @@ packages:
 
   /cody-web-experimental@0.2.4:
     resolution: {integrity: sha512-92MNNTlZTndHN+kNUa4ojrZMIxgl78o+wswOhdzmIQm/FJFi977rnuQPSg/bV5jm8S3y3pdwUM7SUTqCKlwSHw==}
+    dev: false
+
+  /cody-web-experimental@0.2.5:
+    resolution: {integrity: sha512-dQ9QmE1AUHTV3POH3XLgHFOFFy99Xl8L9x4CRnsB5z4a4y6Ki8uCxUewhTGjX9FbgBePqhBsTtsXzMcrZ5YpCA==}
     dev: false
 
   /color-convert@1.9.3:


### PR DESCRIPTION

This PR upgrades the cody web experimental package to 0.2.5, in the new version we fixed
- Telemetry problem with init extension-related events (we don't send install extension events anymore)
- Most recent updates on LLM availability for enterprise instances 
 
## Test plan
- CI is green
- Manual check on basic Cody Web functionality (highly recommended) 