### PR TITLE
misc saved searches followups

### DIFF
--- a/client/web/src/components/FilteredConnection/utils.ts
+++ b/client/web/src/components/FilteredConnection/utils.ts
@@ -41,8 +41,12 @@ export function getFilterFromURL<K extends string>(
                 continue
             }
         }
+
         // couldn't find a value, add default
-        values[filter.id] = filter.options[0].value
+        const defaultOption = filter.options.at(0)
+        if (defaultOption !== undefined) {
+            values[filter.id] = defaultOption.value
+        }
     }
     return values
 }
@@ -117,8 +121,8 @@ export function urlSearchParamsForFilteredConnection({
     if (filterValues && filters) {
         for (const filter of filters) {
             const value = filterValues[filter.id]
-            const defaultValue = filter.options[0].value
-            if (value !== undefined && value !== null && value !== defaultValue) {
+            const defaultOption = filter.options.at(0)
+            if (value !== undefined && value !== null && (!defaultOption || value !== defaultOption.value)) {
                 params.set(filter.id, value)
             } else {
                 params.delete(filter.id)

--- a/client/web/src/nav/GlobalNavbar.tsx
+++ b/client/web/src/nav/GlobalNavbar.tsx
@@ -304,7 +304,9 @@ export const InlineNavigationPanel: FC<InlineNavigationPanelProps> = props => {
 
     const toolsItems = useMemo(() => {
         const items: (NavDropdownItem | false)[] = [
-            props.authenticatedUser
+            // Don't show "Saved Searches" on dotcom yet because it results in a Tools menu with
+            // only 1 item, which looks weird. Users can still find it in their user menu.
+            props.authenticatedUser && !isSourcegraphDotCom
                 ? {
                       path: PageRoutes.SavedSearches,
                       content: 'Saved Searches',
@@ -321,7 +323,14 @@ export const InlineNavigationPanel: FC<InlineNavigationPanelProps> = props => {
             },
         ]
         return items.filter<NavDropdownItem>((item): item is NavDropdownItem => !!item)
-    }, [showSearchContext, showSearchJobs, showCodeMonitoring, showSearchNotebook, props.authenticatedUser])
+    }, [
+        props.authenticatedUser,
+        isSourcegraphDotCom,
+        showSearchContext,
+        showSearchNotebook,
+        showCodeMonitoring,
+        showSearchJobs,
+    ])
     const toolsItem = toolsItems.length > 0 && (
         <NavDropdown
             key="tools"

--- a/client/web/src/savedSearches/graphql.mocks.ts
+++ b/client/web/src/savedSearches/graphql.mocks.ts
@@ -52,6 +52,7 @@ const savedSearchesMock: MockedResponse<SavedSearchesResult, SavedSearchesVariab
         variables: {
             query: '',
             owner: '1',
+            viewerIsAffiliated: true,
             after: null,
             before: null,
             first: 100,

--- a/client/web/src/savedSearches/graphql.ts
+++ b/client/web/src/savedSearches/graphql.ts
@@ -24,6 +24,7 @@ export const savedSearchesQuery = gql`
     query SavedSearches(
         $query: String
         $owner: ID
+        $viewerIsAffiliated: Boolean
         $first: Int
         $last: Int
         $after: String
@@ -33,6 +34,7 @@ export const savedSearchesQuery = gql`
         savedSearches(
             query: $query
             owner: $owner
+            viewerIsAffiliated: $viewerIsAffiliated
             first: $first
             last: $last
             after: $after

--- a/cmd/frontend/internal/savedsearches/resolvers/resolvers.go
+++ b/cmd/frontend/internal/savedsearches/resolvers/resolvers.go
@@ -236,7 +236,7 @@ func (r *Resolver) UpdateSavedSearch(ctx context.Context, args *graphqlbackend.U
 		ID:          id,
 		Description: args.Input.Description,
 		Query:       args.Input.Query,
-		Owner:       old.Owner,
+		Owner:       old.Owner, // use transferSavedSearchOwnership to update the owner
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
- Don't show the Tools menu on dotcom for now, since there is only 1 item. Users can still access saved searches in their user menu.
- Fix an issue where non-site admins on dotcom would see an error at `/saved-searches` until they changed the Owner filter.
- Other minor code cleanups.

## Test plan

Try being a non-site admin and ensure that `/saved-searches` works.