### PR TITLE
chore(svelte): Disable tests which time out

### DIFF
--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/page.spec.ts
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/page.spec.ts
@@ -378,7 +378,7 @@ test.describe('cody sidebar', () => {
             })
         })
 
-        test('disabled when disabled on instance', async ({ page, sg }) => {
+        test.fixme('disabled when disabled on instance', async ({ page, sg }) => {
             // These tests seem to take longer than the default timeout
             test.setTimeout(10000)
 
@@ -390,7 +390,7 @@ test.describe('cody sidebar', () => {
             await doesNotHaveCody(page)
         })
 
-        test('disabled when disabled for user', async ({ page, sg }) => {
+        test.fixme('disabled when disabled for user', async ({ page, sg }) => {
             // These tests seem to take longer than the default timeout
             test.setTimeout(10000)
 


### PR DESCRIPTION
These two tests seem to time out regularly (e.g.
https://buildkite.com/sourcegraph/sourcegraph/builds/282453#0190b9e2-2f71-4876-a84f-c40783e906c8)


## Test plan

CI