### PR TITLE
feat(appliance): roll frontend deployment when pgsql secret changes

### DIFF
--- a/internal/appliance/reconciler/frontend_test.go
+++ b/internal/appliance/reconciler/frontend_test.go
@@ -1,5 +1,10 @@
 package reconciler
 
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
 func (suite *ApplianceTestSuite) TestDeployFrontend() {
 	for _, tc := range []struct {
 		name string
@@ -15,4 +20,38 @@ func (suite *ApplianceTestSuite) TestDeployFrontend() {
 			suite.makeGoldenAssertions(namespace, tc.name)
 		})
 	}
+}
+
+func (suite *ApplianceTestSuite) TestFrontendDeploymentRollsWhenPGSecretChanges() {
+	// Create the frontend before the PGSQL secret exists. In general, this
+	// might happen, depending on the order of the reconcile loop. If we
+	// introducce concurrency to this, we'll have little control over what
+	// happens first.
+	namespace := suite.createConfigMapAndAwaitReconciliation("frontend/default")
+
+	// Create the PGSQL secret.
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: pgsqlSecretName,
+		},
+		StringData: map[string]string{
+			"host":     "example.com",
+			"port":     "5432",
+			"user":     "alice",
+			"password": "letmein",
+			"database": "sg",
+		},
+	}
+	_, err := suite.k8sClient.CoreV1().Secrets(namespace).Create(suite.ctx, secret, metav1.CreateOptions{})
+	suite.Require().NoError(err)
+
+	// We have to make a config change to trigger the reconcile loop
+	suite.awaitReconciliation(namespace, func() {
+		cfgMap := suite.newConfigMap(namespace, "frontend/default")
+		cfgMap.GetAnnotations()["force-reconcile"] = "1"
+		_, err := suite.k8sClient.CoreV1().ConfigMaps(namespace).Update(suite.ctx, cfgMap, metav1.UpdateOptions{})
+		suite.Require().NoError(err)
+	})
+
+	suite.makeGoldenAssertions(namespace, "frontend/after-create-pg-secret")
 }

--- a/internal/appliance/reconciler/testdata/golden-fixtures/frontend/after-create-pg-secret.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/frontend/after-create-pg-secret.yaml
@@ -1,0 +1,562 @@
+resources:
+  - apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      annotations:
+        appliance.sourcegraph.com/configHash: e32d95c60ed3e814ce53f11507d1c894ae3b417b653a9f307379b9252d6d5785
+      creationTimestamp: "2024-04-19T00:00:00Z"
+      generation: 2
+      labels:
+        app.kubernetes.io/component: sourcegraph-frontend
+        app.kubernetes.io/name: sourcegraph
+        app.kubernetes.io/version: 5.3.9104
+        deploy: sourcegraph
+      name: sourcegraph-frontend
+      namespace: NORMALIZED_FOR_TESTING
+      ownerReferences:
+        - apiVersion: v1
+          blockOwnerDeletion: true
+          controller: true
+          kind: ConfigMap
+          name: sg
+          uid: NORMALIZED_FOR_TESTING
+      resourceVersion: NORMALIZED_FOR_TESTING
+      uid: NORMALIZED_FOR_TESTING
+    spec:
+      minReadySeconds: 10
+      progressDeadlineSeconds: 600
+      replicas: 2
+      revisionHistoryLimit: 10
+      selector:
+        matchLabels:
+          app: sourcegraph-frontend
+      strategy:
+        rollingUpdate:
+          maxSurge: 2
+          maxUnavailable: 0
+        type: RollingUpdate
+      template:
+        metadata:
+          annotations:
+            checksum/auth: 4e19711e205ab5b68efbd2490090e332c5309e36c925c97ca8d103722e3125a9
+            kubectl.kubernetes.io/default-container: sourcegraph-frontend
+          creationTimestamp: null
+          labels:
+            app: sourcegraph-frontend
+            deploy: sourcegraph
+          name: sourcegraph-frontend
+        spec:
+          containers:
+            - args:
+                - serve
+              env:
+                - name: DEPLOY_TYPE
+                  value: appliance
+                - name: PGDATABASE
+                  valueFrom:
+                    secretKeyRef:
+                      key: database
+                      name: pgsql-auth
+                - name: PGHOST
+                  valueFrom:
+                    secretKeyRef:
+                      key: host
+                      name: pgsql-auth
+                - name: PGPASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      key: password
+                      name: pgsql-auth
+                - name: PGPORT
+                  valueFrom:
+                    secretKeyRef:
+                      key: port
+                      name: pgsql-auth
+                - name: PGUSER
+                  valueFrom:
+                    secretKeyRef:
+                      key: user
+                      name: pgsql-auth
+                - name: CODEINTEL_PGDATABASE
+                  valueFrom:
+                    secretKeyRef:
+                      key: database
+                      name: codeintel-db-auth
+                - name: CODEINTEL_PGHOST
+                  valueFrom:
+                    secretKeyRef:
+                      key: host
+                      name: codeintel-db-auth
+                - name: CODEINTEL_PGPASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      key: password
+                      name: codeintel-db-auth
+                - name: CODEINTEL_PGPORT
+                  valueFrom:
+                    secretKeyRef:
+                      key: port
+                      name: codeintel-db-auth
+                - name: CODEINTEL_PGUSER
+                  valueFrom:
+                    secretKeyRef:
+                      key: user
+                      name: codeintel-db-auth
+                - name: CODEINSIGHTS_PGDATABASE
+                  valueFrom:
+                    secretKeyRef:
+                      key: database
+                      name: codeinsights-db-auth
+                - name: CODEINSIGHTS_PGHOST
+                  valueFrom:
+                    secretKeyRef:
+                      key: host
+                      name: codeinsights-db-auth
+                - name: CODEINSIGHTS_PGPASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      key: password
+                      name: codeinsights-db-auth
+                - name: CODEINSIGHTS_PGPORT
+                  valueFrom:
+                    secretKeyRef:
+                      key: port
+                      name: codeinsights-db-auth
+                - name: CODEINSIGHTS_PGUSER
+                  valueFrom:
+                    secretKeyRef:
+                      key: user
+                      name: codeinsights-db-auth
+                - name: REDIS_CACHE_ENDPOINT
+                  valueFrom:
+                    secretKeyRef:
+                      key: endpoint
+                      name: redis-cache
+                - name: REDIS_STORE_ENDPOINT
+                  valueFrom:
+                    secretKeyRef:
+                      key: endpoint
+                      name: redis-store
+                - name: OTEL_AGENT_HOST
+                  valueFrom:
+                    fieldRef:
+                      apiVersion: v1
+                      fieldPath: status.hostIP
+                - name: OTEL_EXPORTER_OTLP_ENDPOINT
+                  value: http://$(OTEL_AGENT_HOST):4317
+              image: index.docker.io/sourcegraph/frontend:5.3.9104
+              imagePullPolicy: IfNotPresent
+              livenessProbe:
+                failureThreshold: 3
+                httpGet:
+                  path: /healthz
+                  port: debug
+                  scheme: HTTP
+                initialDelaySeconds: 300
+                periodSeconds: 10
+                successThreshold: 1
+                timeoutSeconds: 5
+              name: frontend
+              ports:
+                - containerPort: 3080
+                  name: http
+                  protocol: TCP
+                - containerPort: 3090
+                  name: http-internal
+                  protocol: TCP
+                - containerPort: 6060
+                  name: debug
+                  protocol: TCP
+              readinessProbe:
+                failureThreshold: 3
+                httpGet:
+                  path: /ready
+                  port: debug
+                  scheme: HTTP
+                periodSeconds: 5
+                successThreshold: 1
+                timeoutSeconds: 5
+              resources:
+                limits:
+                  cpu: "2"
+                  ephemeral-storage: 8Gi
+                  memory: 4G
+                requests:
+                  cpu: "2"
+                  ephemeral-storage: 4Gi
+                  memory: 2G
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                runAsGroup: 101
+                runAsUser: 100
+              terminationMessagePath: /dev/termination-log
+              terminationMessagePolicy: FallbackToLogsOnError
+              volumeMounts:
+                - mountPath: /home/sourcegraph
+                  name: home-dir
+          dnsPolicy: ClusterFirst
+          initContainers:
+            - args:
+                - up
+              env:
+                - name: DEPLOY_TYPE
+                  value: appliance
+                - name: PGDATABASE
+                  valueFrom:
+                    secretKeyRef:
+                      key: database
+                      name: pgsql-auth
+                - name: PGHOST
+                  valueFrom:
+                    secretKeyRef:
+                      key: host
+                      name: pgsql-auth
+                - name: PGPASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      key: password
+                      name: pgsql-auth
+                - name: PGPORT
+                  valueFrom:
+                    secretKeyRef:
+                      key: port
+                      name: pgsql-auth
+                - name: PGUSER
+                  valueFrom:
+                    secretKeyRef:
+                      key: user
+                      name: pgsql-auth
+                - name: CODEINTEL_PGDATABASE
+                  valueFrom:
+                    secretKeyRef:
+                      key: database
+                      name: codeintel-db-auth
+                - name: CODEINTEL_PGHOST
+                  valueFrom:
+                    secretKeyRef:
+                      key: host
+                      name: codeintel-db-auth
+                - name: CODEINTEL_PGPASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      key: password
+                      name: codeintel-db-auth
+                - name: CODEINTEL_PGPORT
+                  valueFrom:
+                    secretKeyRef:
+                      key: port
+                      name: codeintel-db-auth
+                - name: CODEINTEL_PGUSER
+                  valueFrom:
+                    secretKeyRef:
+                      key: user
+                      name: codeintel-db-auth
+                - name: CODEINSIGHTS_PGDATABASE
+                  valueFrom:
+                    secretKeyRef:
+                      key: database
+                      name: codeinsights-db-auth
+                - name: CODEINSIGHTS_PGHOST
+                  valueFrom:
+                    secretKeyRef:
+                      key: host
+                      name: codeinsights-db-auth
+                - name: CODEINSIGHTS_PGPASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      key: password
+                      name: codeinsights-db-auth
+                - name: CODEINSIGHTS_PGPORT
+                  valueFrom:
+                    secretKeyRef:
+                      key: port
+                      name: codeinsights-db-auth
+                - name: CODEINSIGHTS_PGUSER
+                  valueFrom:
+                    secretKeyRef:
+                      key: user
+                      name: codeinsights-db-auth
+              image: index.docker.io/sourcegraph/migrator:5.3.9104
+              imagePullPolicy: IfNotPresent
+              name: migrator
+              resources:
+                limits:
+                  cpu: 500m
+                  memory: 100M
+                requests:
+                  cpu: 100m
+                  memory: 50M
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                runAsGroup: 101
+                runAsUser: 100
+              terminationMessagePath: /dev/termination-log
+              terminationMessagePolicy: FallbackToLogsOnError
+          restartPolicy: Always
+          schedulerName: default-scheduler
+          securityContext:
+            fsGroup: 101
+            fsGroupChangePolicy: OnRootMismatch
+            runAsGroup: 101
+            runAsUser: 100
+          serviceAccount: sourcegraph-frontend
+          serviceAccountName: sourcegraph-frontend
+          terminationGracePeriodSeconds: 30
+          volumes:
+            - emptyDir: {}
+              name: home-dir
+    status: {}
+  - apiVersion: v1
+    data:
+      spec: |
+        spec:
+          requestedVersion: "5.3.9104"
+
+          blobstore:
+            disabled: true
+
+          codeInsights:
+            disabled: true
+
+          codeIntel:
+            disabled: true
+
+          frontend: {}
+
+          grafana:
+            disabled: true
+
+          gitServer:
+            disabled: true
+
+          indexedSearch:
+            disabled: true
+
+          openTelemetry:
+            disabled: true
+
+          pgsql:
+            disabled: true
+
+          postgresExporter:
+            disabled: true
+
+          preciseCodeIntel:
+            disabled: true
+
+          redisCache:
+            disabled: true
+
+          redisStore:
+            disabled: true
+
+          repoUpdater:
+            disabled: true
+
+          searcher:
+            disabled: true
+
+          symbols:
+            disabled: true
+
+          syntectServer:
+            disabled: true
+
+          worker:
+            disabled: true
+
+          prometheus:
+            disabled: true
+    kind: ConfigMap
+    metadata:
+      annotations:
+        appliance.sourcegraph.com/currentVersion: 5.3.9104
+        appliance.sourcegraph.com/managed: "true"
+        force-reconcile: "1"
+      creationTimestamp: "2024-04-19T00:00:00Z"
+      name: sg
+      namespace: NORMALIZED_FOR_TESTING
+      resourceVersion: NORMALIZED_FOR_TESTING
+      uid: NORMALIZED_FOR_TESTING
+  - apiVersion: rbac.authorization.k8s.io/v1
+    kind: Role
+    metadata:
+      annotations:
+        appliance.sourcegraph.com/configHash: b5dce290e22d1afb4c9102ac4c245490ab01dd3be13653de391536cfe0e323b0
+      creationTimestamp: "2024-04-19T00:00:00Z"
+      labels:
+        deploy: sourcegraph
+      name: sourcegraph-frontend
+      namespace: NORMALIZED_FOR_TESTING
+      ownerReferences:
+        - apiVersion: v1
+          blockOwnerDeletion: true
+          controller: true
+          kind: ConfigMap
+          name: sg
+          uid: NORMALIZED_FOR_TESTING
+      resourceVersion: NORMALIZED_FOR_TESTING
+      uid: NORMALIZED_FOR_TESTING
+    rules:
+      - apiGroups:
+          - ""
+        resources:
+          - endpoints
+          - services
+        verbs:
+          - get
+          - list
+          - watch
+      - apiGroups:
+          - apps
+        resources:
+          - statefulsets
+        verbs:
+          - get
+          - list
+          - watch
+  - apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      annotations:
+        appliance.sourcegraph.com/configHash: b5dce290e22d1afb4c9102ac4c245490ab01dd3be13653de391536cfe0e323b0
+      creationTimestamp: "2024-04-19T00:00:00Z"
+      labels:
+        deploy: sourcegraph
+      name: sourcegraph-frontend
+      namespace: NORMALIZED_FOR_TESTING
+      ownerReferences:
+        - apiVersion: v1
+          blockOwnerDeletion: true
+          controller: true
+          kind: ConfigMap
+          name: sg
+          uid: NORMALIZED_FOR_TESTING
+      resourceVersion: NORMALIZED_FOR_TESTING
+      uid: NORMALIZED_FOR_TESTING
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: Role
+      name: sourcegraph-frontend
+    subjects:
+      - kind: ServiceAccount
+        name: sourcegraph-frontend
+        namespace: NORMALIZED_FOR_TESTING
+  - apiVersion: v1
+    data:
+      database: c2c=
+      host: ZXhhbXBsZS5jb20=
+      password: bGV0bWVpbg==
+      port: NTQzMg==
+      user: YWxpY2U=
+    kind: Secret
+    metadata:
+      creationTimestamp: "2024-04-19T00:00:00Z"
+      name: pgsql-auth
+      namespace: NORMALIZED_FOR_TESTING
+      resourceVersion: NORMALIZED_FOR_TESTING
+      uid: NORMALIZED_FOR_TESTING
+    type: Opaque
+  - apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      annotations:
+        appliance.sourcegraph.com/configHash: b5dce290e22d1afb4c9102ac4c245490ab01dd3be13653de391536cfe0e323b0
+      creationTimestamp: "2024-04-19T00:00:00Z"
+      labels:
+        deploy: sourcegraph
+      name: sourcegraph-frontend
+      namespace: NORMALIZED_FOR_TESTING
+      ownerReferences:
+        - apiVersion: v1
+          blockOwnerDeletion: true
+          controller: true
+          kind: ConfigMap
+          name: sg
+          uid: NORMALIZED_FOR_TESTING
+      resourceVersion: NORMALIZED_FOR_TESTING
+      uid: NORMALIZED_FOR_TESTING
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      annotations:
+        appliance.sourcegraph.com/configHash: b5dce290e22d1afb4c9102ac4c245490ab01dd3be13653de391536cfe0e323b0
+        prometheus.io/port: "6060"
+        sourcegraph.prometheus/scrape: "true"
+      creationTimestamp: "2024-04-19T00:00:00Z"
+      labels:
+        app: sourcegraph-frontend
+        app.kubernetes.io/component: sourcegraph-frontend
+        deploy: sourcegraph
+      name: sourcegraph-frontend
+      namespace: NORMALIZED_FOR_TESTING
+      ownerReferences:
+        - apiVersion: v1
+          blockOwnerDeletion: true
+          controller: true
+          kind: ConfigMap
+          name: sg
+          uid: NORMALIZED_FOR_TESTING
+      resourceVersion: NORMALIZED_FOR_TESTING
+      uid: NORMALIZED_FOR_TESTING
+    spec:
+      clusterIP: NORMALIZED_FOR_TESTING
+      clusterIPs:
+        - NORMALIZED_FOR_TESTING
+      internalTrafficPolicy: Cluster
+      ipFamilies:
+        - IPv4
+      ipFamilyPolicy: SingleStack
+      ports:
+        - name: http
+          port: 30080
+          protocol: TCP
+          targetPort: http
+      selector:
+        app: sourcegraph-frontend
+      sessionAffinity: None
+      type: ClusterIP
+    status:
+      loadBalancer: {}
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      annotations:
+        appliance.sourcegraph.com/configHash: b5dce290e22d1afb4c9102ac4c245490ab01dd3be13653de391536cfe0e323b0
+      creationTimestamp: "2024-04-19T00:00:00Z"
+      labels:
+        app: sourcegraph-frontend-internal
+        app.kubernetes.io/component: sourcegraph-frontend-internal
+        deploy: sourcegraph
+      name: sourcegraph-frontend-internal
+      namespace: NORMALIZED_FOR_TESTING
+      ownerReferences:
+        - apiVersion: v1
+          blockOwnerDeletion: true
+          controller: true
+          kind: ConfigMap
+          name: sg
+          uid: NORMALIZED_FOR_TESTING
+      resourceVersion: NORMALIZED_FOR_TESTING
+      uid: NORMALIZED_FOR_TESTING
+    spec:
+      clusterIP: NORMALIZED_FOR_TESTING
+      clusterIPs:
+        - NORMALIZED_FOR_TESTING
+      internalTrafficPolicy: Cluster
+      ipFamilies:
+        - IPv4
+      ipFamilyPolicy: SingleStack
+      ports:
+        - name: http-internal
+          port: 80
+          protocol: TCP
+          targetPort: http-internal
+      selector:
+        app: sourcegraph-frontend
+      sessionAffinity: None
+      type: ClusterIP
+    status:
+      loadBalancer: {}


### PR DESCRIPTION
Idea for https://linear.app/sourcegraph/issue/REL-14/ensure-pods-roll-when-referenced-secret-changes, does not close it though. Please see that issue for more context and alternative approaches considered.

This PR is designed to illustrate the idea more clearly than typing a description of it - do feel free to push back, just because it's already PR'ed doesn't mean it's "too late!". If the general approach is 👍, I can make similar PRs for the other services and their dependencies (basically everything that depends on codeintel/codeinsights DBs and Redis) to close this.

This approach is a bit of a departure from how our helm chart works. That hashes hashes values blocks to determine these annotations. The issue is, that these values blocks often contain references to secrets, and therefore don't change when the _content_ of the secret changes. Example:

https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/84ea4b213d8c08390f3b3335c3f226016a0408b5/charts/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml#L32 - this annotation, when changed, causes pods to roll on deployment.

https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/84ea4b213d8c08390f3b3335c3f226016a0408b5/charts/sourcegraph/templates/_helpers.tpl#L259-L264 - the template helper hashes some values blocks

https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/84ea4b213d8c08390f3b3335c3f226016a0408b5/charts/sourcegraph/values.yaml#L722-L736 - if the auth block references an existing secret instead of being set directly, this won't change when the secret content changes.

This PR takes a more general approach of looking for that secret, which must always eventually exist - whether admin-provisioned or provisioned by the pgsql service definition - and hashes that.

Draft because I'm looking for approach review, ~also because this depends on an unmerged branch. This can be reviewed independently, but that bug fix (https://github.com/sourcegraph/sourcegraph/pull/63826) is also necessary for this to actually work, otherwise the admin-provisioned secret is blown away by the reconcile loop.~

## Test plan

envtest tests included.

<!-- REQUIRED; info at https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles -->

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
