### PR TITLE
pr-auditor: use pr-auditor from devx-service

### DIFF
--- a/.github/workflows/pr-auditor.yml
+++ b/.github/workflows/pr-auditor.yml
@@ -1,21 +1,21 @@
-# See https://docs.sourcegraph.com/dev/background-information/ci#pr-auditor
 name: pr-auditor
 on:
   pull_request_target:
     types: [ closed, edited, opened, synchronize, ready_for_review ]
-  workflow_dispatch:
+
 
 jobs:
   check-pr:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
-          repository: 'sourcegraph/pr-auditor'
+          repository: 'sourcegraph/devx-service'
+          token: ${{ secrets.PR_AUDITOR_TOKEN }}
       - uses: actions/setup-go@v4
         with: { go-version: '1.22' }
 
-      - run: './check-pr.sh'
+      - run: 'go run ./cmd/pr-auditor'
         env:
           GITHUB_EVENT_PATH: ${{ env.GITHUB_EVENT_PATH }}
           GITHUB_TOKEN: ${{ secrets.PR_AUDITOR_TOKEN }}


### PR DESCRIPTION
Updates PR-auditor to use the PR-auditor from the devx-service

## Test plan
Once merged, this [PR](https://github.com/sourcegraph/sourcegraph/pull/63846) should fail

